### PR TITLE
[Merged by Bors] - chore: define `Complex.UnitDisc` using `Subsemigroup.unitBall`

### DIFF
--- a/Mathlib/Analysis/Complex/UnitDisc/Basic.lean
+++ b/Mathlib/Analysis/Complex/UnitDisc/Basic.lean
@@ -27,7 +27,7 @@ namespace Complex
 
 /-- The complex unit disc, denoted as `𝔻` within the Complex namespace -/
 def UnitDisc : Type :=
-  ball (0 : ℂ) 1 deriving TopologicalSpace
+  Subsemigroup.unitBall ℂ deriving TopologicalSpace, CommSemigroup
 
 @[inherit_doc] scoped[Complex.UnitDisc] notation "𝔻" => Complex.UnitDisc
 open UnitDisc
@@ -36,8 +36,6 @@ namespace UnitDisc
 
 /-- Coercion to `ℂ`. -/
 @[coe] protected def coe : 𝔻 → ℂ := Subtype.val
-
-instance instCommSemigroup : CommSemigroup UnitDisc := inferInstanceAs <| CommSemigroup (ball _ _)
 
 instance instSemigroupWithZero : SemigroupWithZero UnitDisc :=
   inferInstanceAs <| SemigroupWithZero (ball _ _)

--- a/Mathlib/Analysis/Complex/UnitDisc/Basic.lean
+++ b/Mathlib/Analysis/Complex/UnitDisc/Basic.lean
@@ -27,7 +27,7 @@ namespace Complex
 
 /-- The complex unit disc, denoted as `𝔻` within the Complex namespace -/
 def UnitDisc : Type :=
-  Subsemigroup.unitBall ℂ deriving TopologicalSpace, CommSemigroup
+  Subsemigroup.unitBall ℂ deriving TopologicalSpace
 
 @[inherit_doc] scoped[Complex.UnitDisc] notation "𝔻" => Complex.UnitDisc
 open UnitDisc
@@ -36,6 +36,8 @@ namespace UnitDisc
 
 /-- Coercion to `ℂ`. -/
 @[coe] protected def coe : 𝔻 → ℂ := Subtype.val
+
+instance instCommSemigroup : CommSemigroup UnitDisc := inferInstanceAs <| CommSemigroup (ball _ _)
 
 instance instSemigroupWithZero : SemigroupWithZero UnitDisc :=
   inferInstanceAs <| SemigroupWithZero (ball _ _)

--- a/Mathlib/Analysis/Normed/Field/UnitBall.lean
+++ b/Mathlib/Analysis/Normed/Field/UnitBall.lean
@@ -35,6 +35,10 @@ def Subsemigroup.unitBall (𝕜 : Type*) [NonUnitalSeminormedRing 𝕜] : Subsem
     rw [mem_ball_zero_iff] at *
     exact (norm_mul_le _ _).trans_lt (mul_lt_one_of_nonneg_of_lt_one_left (norm_nonneg _) hx hy.le)
 
+@[simp] lemma Subsemigroup.mem_unitBall (𝕜 : Type*) [NonUnitalSeminormedRing 𝕜] {x : 𝕜} :
+    x ∈ Subsemigroup.unitBall 𝕜 ↔ ‖x‖ < 1 := by
+  simp [Subsemigroup.unitBall]
+
 instance Metric.unitBall.instSemigroup [NonUnitalSeminormedRing 𝕜] : Semigroup (ball (0 : 𝕜) 1) :=
   inferInstanceAs <| Semigroup (Subsemigroup.unitBall 𝕜)
 


### PR DESCRIPTION
The motivation is to have some local consistency between the definitions of `Circle` and `Complex.UnitDisc`. At the moment, there is a mild style inconsistency since `Circle` uses `Submonoid.unitSphere` whereas `Complex.UnitDisc` uses a raw `Metric.ball`.

The background is that we are about to add `Complex.closedUnitDisc` and so the question arose about which pattern to follow. I decided that we should follow `Circle` and bring `Complex.UnitDisc` in line.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
