### PR TITLE
feat: add option `deprecated.module.exclude_root`

### DIFF
--- a/Mathlib/Tactic/Linter/DeprecatedModule.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedModule.lean
@@ -46,6 +46,19 @@ public register_option linter.deprecated.module : Bool := {
 }
 
 /--
+The `deprecated.module.exclude_root` controls whether the `deprecated.module` linter will run
+on root modules. The default value is `false`; this option has no effect if the `deprecated.module`
+linter is disabled.
+
+Some root modules (e.g. `Mathlib`) are designed to import every module regardless of deprecation
+status. This option allows to exclude deprecated import checking in such cases.
+-/
+public register_option linter.deprecated.module.exclude_root : Bool := {
+  defValue := false
+  descr := "disable the `deprecated.module` linter on project roots"
+}
+
+/--
 Defines the `deprecatedModuleExt` extension for adding a `HashSet` of triples of
 * a module `Name` that has been deprecated and
 * an array of `Name`s of modules that should be imported instead
@@ -135,9 +148,9 @@ def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx ↦ do
     return
   if (← get).messages.hasErrors then
     return
-  -- Exempt Mathlib.lean since it's auto-generated and imports all modules
-  -- for backwards compatibility
-  if (← getFileName).endsWith "Mathlib.lean" then
+  -- Exempt root module?
+  if (← getBoolOption `linter.deprecated.module.exempt_root)
+      && (← getMainModule).getNumParts == 1 then
     return
   let laterCommand ← IsLaterCommand.get
   -- If `laterCommand` is `true`, then the linter already did what it was supposed to do.


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
