### PR TITLE
chore(Algebra/Field/Defs): add `Ring K` as direct extends arm of `Field`

### DIFF
--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -179,6 +179,15 @@ If the field has positive characteristic `p`, our division by zero convention fo
 @[stacks 09FD "first part"]
 class Field (K : Type u) extends CommRing K, DivisionRing K, Ring K
 
+/-- `Ring K` is listed as a direct parent of `Field K` (in addition to `CommRing K`
+and `DivisionRing K`, which both already imply it) so that `Field.toRing` is an
+auto-generated one-step fused projection. Without this redundancy, code that
+needs `Ring K` from a `Field K` has to go via `Field.toCommRing.toRing` or
+`Field.toDivisionRing.toRing` — a composition of two parent rebuilds — which is
+measurably more expensive in `isDefEq` checks that compare `Ring`-valued data
+obtained through the two paths. -/
+add_decl_doc Field.toRing
+
 -- see Note [lower instance priority]
 instance (priority := 100) Field.toSemifield [Field K] : Semifield K := { ‹Field K› with }
 

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -179,8 +179,8 @@ If the field has positive characteristic `p`, our division by zero convention fo
 @[stacks 09FD "first part"]
 class Field (K : Type u) extends CommRing K, DivisionRing K, Ring K
 
-/-- Every field is a ring. -/
-add_decl_doc Field.toRing
+attribute [implicit_reducible] Field.toRing
+attribute [instance] Field.toRing
 
 -- see Note [lower instance priority]
 instance (priority := 100) Field.toSemifield [Field K] : Semifield K := { ‹Field K› with }

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -177,7 +177,7 @@ See also note [forgetful inheritance].
 If the field has positive characteristic `p`, our division by zero convention forces
 `ratCast (1 / p) = 1 / 0 = 0`. -/
 @[stacks 09FD "first part"]
-class Field (K : Type u) extends CommRing K, DivisionRing K
+class Field (K : Type u) extends CommRing K, DivisionRing K, Ring K
 
 -- see Note [lower instance priority]
 instance (priority := 100) Field.toSemifield [Field K] : Semifield K := { ‹Field K› with }

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -179,13 +179,7 @@ If the field has positive characteristic `p`, our division by zero convention fo
 @[stacks 09FD "first part"]
 class Field (K : Type u) extends CommRing K, DivisionRing K, Ring K
 
-/-- `Ring K` is listed as a direct parent of `Field K` (in addition to `CommRing K`
-and `DivisionRing K`, which both already imply it) so that `Field.toRing` is an
-auto-generated one-step fused projection. Without this redundancy, code that
-needs `Ring K` from a `Field K` has to go via `Field.toCommRing.toRing` or
-`Field.toDivisionRing.toRing` — a composition of two parent rebuilds — which is
-measurably more expensive in `isDefEq` checks that compare `Ring`-valued data
-obtained through the two paths. -/
+/-- Every field is a ring. -/
 add_decl_doc Field.toRing
 
 -- see Note [lower instance priority]


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

(potentially ridiculous Claude idea)