### PR TITLE
chore(Order/Preorder/Finite): use `to_dual` (closed since duplicated)

### DIFF
--- a/Mathlib/Order/Preorder/Finite.lean
+++ b/Mathlib/Order/Preorder/Finite.lean
@@ -23,6 +23,7 @@ namespace Finset
 section IsTrans
 variable [LE α] [IsTrans α LE.le] {s : Finset α} {a : α}
 
+@[to_dual]
 lemma exists_maximalFor (f : ι → α) (s : Finset ι) (hs : s.Nonempty) :
     ∃ i, MaximalFor (· ∈ s) f i := by
   induction hs using Finset.Nonempty.cons_induction with
@@ -35,25 +36,20 @@ lemma exists_maximalFor (f : ι → α) (s : Finset ι) (hs : s.Nonempty) :
       exact fun k hk hik ↦ _root_.trans (hj.2 hk <| _root_.trans hji hik) hji
     · exact ⟨j, mem_cons_of_mem hj.1, by simpa [hji] using hj.2⟩
 
-lemma exists_minimalFor (f : ι → α) (s : Finset ι) (hs : s.Nonempty) :
-    ∃ i, MinimalFor (· ∈ s) f i := exists_maximalFor (α := αᵒᵈ) f s hs
-
+@[to_dual]
 lemma exists_maximal (hs : s.Nonempty) : ∃ i, Maximal (· ∈ s) i := s.exists_maximalFor id hs
-lemma exists_minimal (hs : s.Nonempty) : ∃ i, Minimal (· ∈ s) i := s.exists_minimalFor id hs
 
 end IsTrans
 
 section Preorder
 variable [Preorder α] {s : Finset α} {a : α}
 
+@[to_dual]
 lemma exists_le_maximal (s : Finset α) (ha : a ∈ s) : ∃ b, a ≤ b ∧ Maximal (· ∈ s) b := by
   classical
   obtain ⟨b, hb, hab, hbmin⟩ : ∃ b ∈ s, a ≤ b ∧ _ := by
     simpa [Maximal, and_assoc] using {x ∈ s | a ≤ x}.exists_maximal ⟨a, mem_filter.2 ⟨ha, le_rfl⟩⟩
   exact ⟨b, hab, hb, fun c hc hbc ↦ hbmin hc (hab.trans hbc) hbc⟩
-
-lemma exists_le_minimal (s : Finset α) (ha : a ∈ s) : ∃ b ≤ a, Minimal (· ∈ s) b :=
-  exists_le_maximal (α := αᵒᵈ) s ha
 
 end Preorder
 end Finset
@@ -62,41 +58,32 @@ namespace Set
 section IsTrans
 variable [LE α] [IsTrans α LE.le] {s : Set α} {a : α}
 
+@[to_dual]
 lemma Finite.exists_maximalFor (f : ι → α) (s : Set ι) (h : s.Finite) (hs : s.Nonempty) :
     ∃ i, MaximalFor (· ∈ s) f i := by
   lift s to Finset ι using h; exact s.exists_maximalFor f hs
 
-lemma Finite.exists_minimalFor (f : ι → α) (s : Set ι) (h : s.Finite) (hs : s.Nonempty) :
-    ∃ i, MinimalFor (· ∈ s) f i := Finite.exists_maximalFor (α := αᵒᵈ) f s h hs
-
+@[to_dual]
 lemma Finite.exists_maximal (h : s.Finite) (hs : s.Nonempty) : ∃ i, Maximal (· ∈ s) i :=
   h.exists_maximalFor id _ hs
 
-lemma Finite.exists_minimal (h : s.Finite) (hs : s.Nonempty) : ∃ i, Minimal (· ∈ s) i :=
-  h.exists_minimalFor id _ hs
-
 /-- A version of `Finite.exists_maximalFor` with the (weaker) hypothesis that the image of `s`
 is finite rather than `s` itself. -/
+@[to_dual /- A version of `Finite.exists_minimalFor` with the (weaker) hypothesis that the image of
+`s` is finite rather than `s` itself.-/]
 lemma Finite.exists_maximalFor' (f : ι → α) (s : Set ι) (h : (f '' s).Finite) (hs : s.Nonempty) :
     ∃ i, MaximalFor (· ∈ s) f i := by
   obtain ⟨_, ⟨a, ha, rfl⟩, hmax⟩ := Finite.exists_maximalFor id (f '' s) h (hs.image f)
   exact ⟨a, ha, fun a' ha' hf ↦ hmax (mem_image_of_mem f ha') hf⟩
-
-/-- A version of `Finite.exists_minimalFor` with the (weaker) hypothesis that the image of `s`
-is finite rather than `s` itself. -/
-lemma Finite.exists_minimalFor' (f : ι → α) (s : Set ι) (h : (f '' s).Finite) (hs : s.Nonempty) :
-    ∃ i, MinimalFor (· ∈ s) f i := h.exists_maximalFor' (α := αᵒᵈ) f s hs
 
 end IsTrans
 
 section Preorder
 variable [Preorder α] {s : Set α} {a : α}
 
+@[to_dual]
 lemma Finite.exists_le_maximal (hs : s.Finite) (ha : a ∈ s) : ∃ b, a ≤ b ∧ Maximal (· ∈ s) b := by
   lift s to Finset α using hs; exact s.exists_le_maximal ha
-
-lemma Finite.exists_le_minimal (hs : s.Finite) (ha : a ∈ s) : ∃ b, b ≤ a ∧ Minimal (· ∈ s) b := by
-  lift s to Finset α using hs; exact s.exists_le_minimal ha
 
 variable [Nonempty α]
 
@@ -107,6 +94,7 @@ lemma infinite_of_forall_exists_gt (h : ∀ a, ∃ b ∈ s, a < b) : s.Infinite 
   exact infinite_of_injective_forall_mem
     (strictMono_nat_of_lt_succ fun n => (h _).choose_spec.2).injective hf
 
+@[to_dual existing infinite_of_forall_exists_gt]
 lemma infinite_of_forall_exists_lt (h : ∀ a, ∃ b ∈ s, b < a) : s.Infinite :=
   infinite_of_forall_exists_gt (α := αᵒᵈ) h
 
@@ -115,8 +103,8 @@ end Preorder
 section PartialOrder
 variable (α) [PartialOrder α]
 
+@[to_dual]
 lemma finite_isTop : {a : α | IsTop a}.Finite := (subsingleton_isTop α).finite
-lemma finite_isBot : {a : α | IsBot a}.Finite := (subsingleton_isBot α).finite
 
 end PartialOrder
 
@@ -152,10 +140,8 @@ end Set
 section Preorder
 variable [Preorder α] [Finite α] {p : α → Prop} {a : α}
 
+@[to_dual]
 lemma Finite.exists_le_maximal (h : p a) : ∃ b, a ≤ b ∧ Maximal p b :=
   {x | p x}.toFinite.exists_le_maximal h
-
-lemma Finite.exists_le_minimal (h : p a) : ∃ b ≤ a, Minimal p b :=
-  {x | p x}.toFinite.exists_le_minimal h
 
 end Preorder


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
