### PR TITLE
feat(AlgebraicTopology/Quasicategory): functor quasi-categories

### DIFF
--- a/Mathlib/AlgebraicTopology/Quasicategory/InternalHom.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/InternalHom.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 Jack McKoen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jack McKoen
+-/
+module
+
+public import Mathlib.AlgebraicTopology.SimplicialSet.AnodyneExtensions.Inner.Basic
+public import Mathlib.AlgebraicTopology.SimplicialSet.Monomorphisms
+public import Mathlib.AlgebraicTopology.SimplicialSet.Skeleton
+public import Mathlib.CategoryTheory.LiftingProperties.PushoutProduct
+public import Mathlib.CategoryTheory.Monoidal.Closed.InternalCurrying
+public import Mathlib.CategoryTheory.MorphismProperty.Comma
+
+/-!
+# Functor Quasi-categories
+
+-/
+
+public section
+
+open CategoryTheory Simplicial MorphismProperty MonoidalCategory Arrow
+
+universe v u
+
+namespace SSet
+
+open modelCategoryQuillen
+
+abbrev BdryHornPushouts :=
+  (I.{u}.arrowObj.map (pushoutProduct.obj Λ[2, 1].ι)).arrowMorphism
+
+open CartesianMonoidalCategory in
+local instance {C : Type u} [Category.{v} C] [CartesianMonoidalCategory C] (X : C) :
+    (tensorLeft X).PreservesMonomorphisms where
+  preserves f hf := {
+    right_cancellation _ _ w := by
+      apply CartesianMonoidalCategory.hom_ext
+      · simpa using w =≫ fst _ _
+      · simpa [cancel_mono_assoc_iff] using w =≫ snd _ _}
+
+lemma BdryTensorS_le_monomorphisms (S : SSet) : I.{u}.map (tensorLeft S) ≤ monomorphisms SSet := by
+  intro X Y f ⟨_, _, ⟨_, ⟨hg⟩, ⟨e⟩⟩⟩
+  rw [← arrow_mk_iso_iff (monomorphisms SSet) e]
+  infer_instance
+
+lemma innerAnodyneExtensions_eq_retracts_transfiniteCompositions' :
+    innerAnodyneExtensions = (transfiniteCompositions.{u}
+      (coproducts.{u} BdryHornPushouts.{u}).pushouts).retracts := by
+  sorry
+
+section ULift
+
+-- From topcat-model-category
+
+variable (α : Type u)
+
+def orderIsoULift [Preorder α] : α ≃o ULift.{v} α where
+  toEquiv := Equiv.ulift.symm
+  map_rel_iff' := by rfl
+
+instance [Preorder α] [SuccOrder α] : SuccOrder (ULift.{v} α) :=
+  SuccOrder.ofOrderIso (orderIsoULift α)
+
+instance [Preorder α] [WellFoundedLT α] : WellFoundedLT (ULift.{v} α) where
+  wf := (orderIsoULift.{v} α).symm.toRelIsoLT.toRelEmbedding.isWellFounded.wf
+
+end ULift
+
+section Mono
+
+-- From topcat-model-category
+
+noncomputable def transfiniteCompositionOfMono {X Y : SSet.{u}} (i : X ⟶ Y) [Mono i] :
+    (coproducts.{u} I).pushouts.TransfiniteCompositionOfShape ℕ i where
+  toTransfiniteCompositionOfShape :=
+    (relativeCellComplexOfMono i).toTransfiniteCompositionOfShape
+  map_mem d hd := by
+    apply pushouts_monotone _ _
+      ((relativeCellComplexOfMono i).attachCells d hd).pushouts_coproducts
+    apply coproducts_monotone
+    rintro _ _ _ ⟨⟩
+    exact boundary_ι_mem_I d
+
+lemma transfiniteCompositions_pushouts_coproducts :
+    transfiniteCompositions.{u} (coproducts.{u} I).pushouts = monomorphisms SSet.{u} := by
+  apply le_antisymm
+  · rw [transfiniteCompositions_le_iff, pushouts_le_iff, coproducts_le_iff]
+    exact I_le_monomorphisms
+  · intro _ _ i (_ : Mono i)
+    apply transfiniteCompositionsOfShape_le_transfiniteCompositions _ (ULift ℕ)
+    exact ⟨(transfiniteCompositionOfMono i).ofOrderIso (orderIsoULift.{u} ℕ).symm⟩
+
+end Mono
+
+instance ihom_isQuasicategory {S T : SSet.{u}} [hT : Quasicategory T] :
+    Quasicategory ((ihom S).obj T) := by
+  rw [quasicategory_iff_from_innerFibration _ stdSimplex.isTerminalObj₀, innerFibration_iff,
+    ← innerFibrations.single_le_iff, innerFibrations, ← MorphismProperty.le_llp_iff_le_rlp,
+    ← coproducts_le_iff.{u}, ← pushouts_le_iff, ← transfiniteCompositions_le_iff.{u},
+    ← retracts_le_iff, ← innerAnodyneExtensions_eq_retracts_transfiniteCompositions,
+    innerAnodyneExtensions_eq_retracts_transfiniteCompositions', retracts_le_iff,
+    transfiniteCompositions_le_iff, pushouts_le_iff, coproducts_le_iff] at hT ⊢
+  ---
+  have h₁ : I ≤ (single ((MonoidalClosed.pre Λ[2, 1].ι).app T)).llp := by
+    · intro _ _ f ⟨n⟩
+      rw [single, llp_ofHoms_iff_hasLiftingProperty,
+        ← PushoutProduct.hasLiftingProperty_mk_isTerminal_iff (X := T) stdSimplex.isTerminalObj₀]
+      apply hT
+      · exact ⟨Arrow.mk ∂Δ[n].ι, boundary_ι_mem_I n, ⟨Iso.refl _⟩⟩
+      · exact prop_single (stdSimplex.isTerminalObj₀.from T)
+  ---
+  rw [← coproducts_le_iff.{u}, ← pushouts_le_iff, ← transfiniteCompositions_le_iff.{u},
+    transfiniteCompositions_pushouts_coproducts] at h₁
+  ---
+  have h₄ : I ≤
+      (single ((ihom S).map ((MonoidalClosed.pre Λ[2, 1].ι).app T))).llp := by
+    intro _ _ _ ⟨n⟩
+    rw [single, llp_ofHoms_iff_hasLiftingProperty, ← (ihom.adjunction S).hasLiftingProperty_iff]
+    apply (BdryTensorS_le_monomorphisms S).trans h₁
+    · refine ⟨_, _, ⟨∂Δ[n].ι, ⟨boundary_ι_mem_I n, ⟨Iso.refl _⟩⟩⟩⟩
+    · exact prop_single ((MonoidalClosed.pre Λ[2, 1].ι).app T)
+  ---
+  suffices I ≤ (single ((MonoidalClosed.pre Λ[2, 1].ι).app ((ihom S).obj T))).llp by
+    intro _ _ f ⟨⟨_, _, _⟩, ⟨n⟩, ⟨e⟩⟩
+    have := this ∂Δ[n].ι (boundary_ι_mem_I n)
+    rw [llp_ofHoms_iff_hasLiftingProperty] at this ⊢
+    rw [← PushoutProduct.hasLiftingProperty_mk_isTerminal_iff
+      (X := (ihom S).obj T) stdSimplex.isTerminalObj₀] at this
+    rwa [← HasLiftingProperty.iff_of_arrow_iso_left e]
+  ---
+  intro _ _ _ ⟨n⟩
+  have := h₄ ∂Δ[n].ι (boundary_ι_mem_I n)
+  rw [llp_ofHoms_iff_hasLiftingProperty] at this ⊢
+  ---
+  refine (HasLiftingProperty.iff_of_arrow_iso_right _ ?_).1 this
+  refine Arrow.isoMk' _ _ ?_ ?_ ?_
+  · refine (MonoidalClosed.ihomCurryIso Δ[2] S T).symm ≪≫ ?_ ≪≫
+      (MonoidalClosed.ihomCurryIso S Δ[2] T)
+    refine Iso.app ?_ T
+    exact asIso ((conjugateEquiv (ihom.adjunction _) (ihom.adjunction _))
+      ((curriedTensor _).map (β_ _ _).hom))
+  · refine (MonoidalClosed.ihomCurryIso Λ[2, 1].toSSet S T).symm ≪≫ ?_ ≪≫
+      (MonoidalClosed.ihomCurryIso S Λ[2, 1].toSSet T)
+    refine Iso.app ?_ T
+    exact asIso ((conjugateEquiv (ihom.adjunction _) (ihom.adjunction _))
+      ((curriedTensor _).map (β_ _ _).hom))
+  · rfl
+
+end SSet

--- a/Mathlib/AlgebraicTopology/Quasicategory/InternalHom.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/InternalHom.lean
@@ -27,8 +27,23 @@ namespace SSet
 
 open modelCategoryQuillen
 
-abbrev BdryHornPushouts :=
-  (I.{u}.arrowObj.map (pushoutProduct.obj Λ[2, 1].ι)).arrowMorphism
+abbrev bdryHornPushouts := I.{u}.strictMapArrow (pushoutProduct.obj Λ[2, 1].ι)
+
+lemma temp {A B : SSet.{u}} (f : A ⟶ B) (X : SSet.{u}) {T : SSet.{u}} (t : Limits.IsTerminal T) :
+    I.{u} ≤
+      (single ((MonoidalClosed.pre f).app X)).llp ↔
+    I.{u}.strictMapArrow (pushoutProduct.obj f) ≤
+      (single (t.from X)).llp := by
+  simp only [le_llp_iff_le_rlp, single_le_iff]
+  constructor
+  · rintro h _ _ g ⟨⟨_, _, _⟩, ⟨n⟩⟩
+    erw [PushoutProduct.hasLiftingProperty_mk_isTerminal_iff t]
+    exact h _ (boundary_ι_mem_I n)
+  · intro h _ _ _ ⟨n⟩
+    rw [← PushoutProduct.hasLiftingProperty_mk_isTerminal_iff t]
+    apply h (Arrow.mk f □ ∂Δ[n].ι).hom
+    constructor
+    exact boundary_ι_mem_I n
 
 open CartesianMonoidalCategory in
 local instance {C : Type u} [Category.{v} C] [CartesianMonoidalCategory C] (X : C) :
@@ -46,8 +61,26 @@ lemma BdryTensorS_le_monomorphisms (S : SSet) : I.{u}.map (tensorLeft S) ≤ mon
 
 lemma innerAnodyneExtensions_eq_retracts_transfiniteCompositions' :
     innerAnodyneExtensions = (transfiniteCompositions.{u}
-      (coproducts.{u} BdryHornPushouts.{u}).pushouts).retracts := by
-  sorry
+      (coproducts.{u} bdryHornPushouts.{u}).pushouts).retracts := by
+  apply le_antisymm
+  ·
+    rw [innerAnodyneExtensions_eq_retracts_transfiniteCompositions]
+    /-
+    rw [retracts_le_iff, transfiniteCompositions_le_iff, pushouts_le_iff, coproducts_le_iff,
+      innerAnodyneExtensions_eq_llp_rlp]
+    refine le_trans ?_ (retracts_le_llp_rlp _)
+    -/
+
+    let : (transfiniteCompositions.{u, u}
+        (coproducts.{u} bdryHornPushouts).pushouts).retracts.IsStableUnderRetracts := by
+      sorry
+    rw [retracts_le_iff]
+    --rw [← llp_rlp_of_hasSmallObjectArgument]
+
+    sorry
+  ·
+
+    sorry
 
 section ULift
 
@@ -93,44 +126,32 @@ lemma transfiniteCompositions_pushouts_coproducts :
 
 end Mono
 
-instance ihom_isQuasicategory {S T : SSet.{u}} [hT : Quasicategory T] :
-    Quasicategory ((ihom S).obj T) := by
+lemma quasicategory_iff_trivialFibration (T : SSet.{u}) :
+    Quasicategory T ↔ I.rlp ((MonoidalClosed.pre Λ[2, 1].ι).app T) := by
   rw [quasicategory_iff_from_innerFibration _ stdSimplex.isTerminalObj₀, innerFibration_iff,
     ← innerFibrations.single_le_iff, innerFibrations, ← MorphismProperty.le_llp_iff_le_rlp,
     ← coproducts_le_iff.{u}, ← pushouts_le_iff, ← transfiniteCompositions_le_iff.{u},
     ← retracts_le_iff, ← innerAnodyneExtensions_eq_retracts_transfiniteCompositions,
     innerAnodyneExtensions_eq_retracts_transfiniteCompositions', retracts_le_iff,
-    transfiniteCompositions_le_iff, pushouts_le_iff, coproducts_le_iff] at hT ⊢
-  ---
-  have h₁ : I ≤ (single ((MonoidalClosed.pre Λ[2, 1].ι).app T)).llp := by
-    · intro _ _ f ⟨n⟩
-      rw [single, llp_ofHoms_iff_hasLiftingProperty,
-        ← PushoutProduct.hasLiftingProperty_mk_isTerminal_iff (X := T) stdSimplex.isTerminalObj₀]
-      apply hT
-      · exact ⟨Arrow.mk ∂Δ[n].ι, boundary_ι_mem_I n, ⟨Iso.refl _⟩⟩
-      · exact prop_single (stdSimplex.isTerminalObj₀.from T)
-  ---
+    transfiniteCompositions_le_iff, pushouts_le_iff, coproducts_le_iff, ← temp, le_llp_iff_le_rlp,
+    single_le_iff]
+
+instance ihom_isQuasicategory {S T : SSet.{u}} [hT : Quasicategory T] :
+    Quasicategory ((ihom S).obj T) := by
+  rw [quasicategory_iff_trivialFibration, ← I.rlp.single_le_iff, ← le_llp_iff_le_rlp] at hT ⊢
   rw [← coproducts_le_iff.{u}, ← pushouts_le_iff, ← transfiniteCompositions_le_iff.{u},
-    transfiniteCompositions_pushouts_coproducts] at h₁
+    transfiniteCompositions_pushouts_coproducts] at hT
   ---
-  have h₄ : I ≤
-      (single ((ihom S).map ((MonoidalClosed.pre Λ[2, 1].ι).app T))).llp := by
+  have h : I ≤ (single ((ihom S).map ((MonoidalClosed.pre Λ[2, 1].ι).app T))).llp := by
+    rw [le_llp_iff_le_rlp, single_le_iff]
     intro _ _ _ ⟨n⟩
-    rw [single, llp_ofHoms_iff_hasLiftingProperty, ← (ihom.adjunction S).hasLiftingProperty_iff]
-    apply (BdryTensorS_le_monomorphisms S).trans h₁
+    rw [← (ihom.adjunction S).hasLiftingProperty_iff]
+    apply (BdryTensorS_le_monomorphisms S).trans hT
     · refine ⟨_, _, ⟨∂Δ[n].ι, ⟨boundary_ι_mem_I n, ⟨Iso.refl _⟩⟩⟩⟩
-    · exact prop_single ((MonoidalClosed.pre Λ[2, 1].ι).app T)
-  ---
-  suffices I ≤ (single ((MonoidalClosed.pre Λ[2, 1].ι).app ((ihom S).obj T))).llp by
-    intro _ _ f ⟨⟨_, _, _⟩, ⟨n⟩, ⟨e⟩⟩
-    have := this ∂Δ[n].ι (boundary_ι_mem_I n)
-    rw [llp_ofHoms_iff_hasLiftingProperty] at this ⊢
-    rw [← PushoutProduct.hasLiftingProperty_mk_isTerminal_iff
-      (X := (ihom S).obj T) stdSimplex.isTerminalObj₀] at this
-    rwa [← HasLiftingProperty.iff_of_arrow_iso_left e]
+    · exact prop_single _
   ---
   intro _ _ _ ⟨n⟩
-  have := h₄ ∂Δ[n].ι (boundary_ι_mem_I n)
+  have := h ∂Δ[n].ι (boundary_ι_mem_I n)
   rw [llp_ofHoms_iff_hasLiftingProperty] at this ⊢
   ---
   refine (HasLiftingProperty.iff_of_arrow_iso_right _ ?_).1 this

--- a/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
@@ -153,6 +153,18 @@ lemma arrowMorphismObj_eq (W : MorphismProperty T) : W.arrowObj.arrowMorphism = 
 @[simp]
 lemma arrowObjMorphism_eq (W : ObjectProperty (Arrow T)) : W.arrowMorphism.arrowObj = W := rfl
 
+/-- The image (up to isomorphisms) of a `MorphismProperty A` by a functor `Arrow A ⥤ Arrow B` -/
+abbrev mapArrow (W : MorphismProperty A) (F : Arrow A ⥤ Arrow B) : MorphismProperty B :=
+  (W.arrowObj.map F).arrowMorphism
+
+/-- The image (up to isomorphisms) of a `MorphismProperty A` by a functor `Arrow A ⥤ Arrow B` -/
+abbrev strictMapArrow (W : MorphismProperty A) (F : Arrow A ⥤ Arrow B) : MorphismProperty B :=
+  (W.arrowObj.strictMap F).arrowMorphism
+
+/-- The inverse image of a `MorphismProperty B` by a functor `Arrow A ⥤ Arrow B` -/
+abbrev inverseImageArrow (W : MorphismProperty B) (F : Arrow A ⥤ Arrow B) : MorphismProperty A :=
+  (W.arrowObj.inverseImage F).arrowMorphism
+
 /-- The object property on `Under X` induced by a morphism property. -/
 def underObj (W : MorphismProperty T) {X : T} : ObjectProperty (Under X) := fun f ↦ W f.hom
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
@@ -124,6 +124,35 @@ def overObj (W : MorphismProperty T) {X : T} : ObjectProperty (Over X) := fun f 
 instance [W.RespectsIso] : (W.overObj (X := X)).IsClosedUnderIsomorphisms :=
   inferInstanceAs <| (W.commaObj _ _).IsClosedUnderIsomorphisms
 
+/-- The object property on `Arrow T` induced by a morphism property on `T`. -/
+def arrowObj (W : MorphismProperty T) : ObjectProperty (Arrow T) := fun f ↦ W f.hom
+
+@[simp] lemma arrowObj_iff (Y : Arrow T) : W.arrowObj Y ↔ W Y.hom := .rfl
+
+instance [W.RespectsIso] : (W.arrowObj (T := T)).IsClosedUnderIsomorphisms :=
+  inferInstanceAs <| (W.commaObj _ _).IsClosedUnderIsomorphisms
+
+/-- The morphism property on `T` induced by an object property on `Arrow T`. -/
+def _root_.CategoryTheory.ObjectProperty.arrowMorphism (W : ObjectProperty (Arrow T)) :
+    MorphismProperty T := fun _ _ f ↦ W f
+
+@[simp]
+lemma arrowMorphism_iff {W : ObjectProperty (Arrow T)} {X Y : T} (f : X ⟶ Y) :
+    W.arrowMorphism f ↔ W f := .rfl
+
+/-- There is an equivalence between morphism properties on `T` and object properties
+on `Arrow T`. -/
+@[simps]
+def arrowObjEquiv : MorphismProperty T ≃ ObjectProperty (Arrow T) where
+  toFun := arrowObj
+  invFun := ObjectProperty.arrowMorphism
+
+@[simp]
+lemma arrowMorphismObj_eq (W : MorphismProperty T) : W.arrowObj.arrowMorphism = W := rfl
+
+@[simp]
+lemma arrowObjMorphism_eq (W : ObjectProperty (Arrow T)) : W.arrowMorphism.arrowObj = W := rfl
+
 /-- The object property on `Under X` induced by a morphism property. -/
 def underObj (W : MorphismProperty T) {X : T} : ObjectProperty (Under X) := fun f ↦ W f.hom
 


### PR DESCRIPTION
WIP

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
