### PR TITLE
[Merged by Bors] - fix(Tactic/Algebra): properly handle scalars that evaluate to zero

### DIFF
--- a/Mathlib/Tactic/Algebra/Basic.lean
+++ b/Mathlib/Tactic/Algebra/Basic.lean
@@ -195,9 +195,14 @@ def cast (cR : Algebra.Cache sR) (u' : Level) (R' : Q(Type u'))
   let ⟨r, pf_smul⟩ ← evalSMulCast q($sAlg) q($_smul) r'
   let ⟨_r'', vr, pr⟩ ←
     Common.eval rcℕ (Ring.ringCompute cR.toCache) cR.toCache q($r)
-  assumeInstancesCommute
-  return ⟨_, Common.ExSum.add (Common.ExProd.const (.mk _ vr)) .zero,
-    q(cast_smul_eq_mul $pr $pf_smul)⟩
+  match vr with
+  | .zero .. =>
+    assumeInstancesCommute
+    return ⟨_, .zero, q(cast_zero_smul_eq_zero_mul $pr $pf_smul)⟩
+  | vr =>
+    assumeInstancesCommute
+    return ⟨_, Common.ExSum.add (Common.ExProd.const (.mk _ vr)) .zero,
+      q(cast_smul_eq_mul $pr $pf_smul)⟩
 
 /-- Evaluate the product of two normalized expressions in `R` using `ring`. -/
 def neg (cR : Algebra.Cache sR) {a : Q($A)} (_rA : Q(CommRing $A)) (za : BaseType sAlg a) :

--- a/Mathlib/Tactic/Algebra/Lemmas.lean
+++ b/Mathlib/Tactic/Algebra/Lemmas.lean
@@ -191,6 +191,12 @@ theorem add_algebraMap_isNat_zero {r s : R} (h : r + s = 0) :
   exact ⟨by simp⟩
 
 /- RingCompute.cast -/
+theorem cast_zero_smul_eq_zero_mul {R' : Type*} [HSMul R' A A] {r' : R'} {r : R}
+    (hr : r = 0) (h_smul : ∀ (a : A), r • a = r' • a) (a : A) :
+    r' • a = (0 : A) * a := by
+  simp [← h_smul, hr]
+
+/- RingCompute.cast -/
 theorem cast_smul_eq_mul {R' : Type*} [HSMul R' A A] {r' : R'} {r r'' : R}
     (hr : r = r'') (h_smul : ∀ (a : A), r • a = r' • a) (a : A) :
     r' • a = (algebraMap R A r'' + 0) * a := by

--- a/MathlibTest/Algebra.lean
+++ b/MathlibTest/Algebra.lean
@@ -148,3 +148,7 @@ example {A R R' : Type*} [CommRing A] [CommRing R] [CommRing R'] [Algebra R A] [
 example {A R R' : Type*} [CommRing A] [CommRing R] [CommRing R'] [Algebra R A] [Algebra R' A] (r : R) (r' : R') (x : A) :
 (r : R) • x + (1 : ℕ) • x + (r' : R') • x = (r' : R') • x + (1 : ℕ) • x + (r : R) • x:= by
   algebra
+
+/- Ensure that terms are eliminated if the coefficient happens to evaluate to zero. -/
+example (x : ℚ) : 0 • x = 0 := by
+  algebra


### PR DESCRIPTION
When `algebra` encounters `0 • x` it gets normalized to `0 • x` instead of `0`, breaking the invariant that coefficients are not allowed to be zero. This PR fixes this issue and adds a corresponding test.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
