### PR TITLE
[Merged by Bors] - doc: add library note about scoping simp lemmas with weak keys

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7313,6 +7313,7 @@ public import Mathlib.Tactic.Set
 public import Mathlib.Tactic.SetLike
 public import Mathlib.Tactic.SetNotationForOrder
 public import Mathlib.Tactic.SimpIntro
+public import Mathlib.Tactic.SimpLibraryNote
 public import Mathlib.Tactic.SimpRw
 public import Mathlib.Tactic.Simproc.Divisors
 public import Mathlib.Tactic.Simproc.ExistsAndEq

--- a/Mathlib/Algebra/AddConstMap/Basic.lean
+++ b/Mathlib/Algebra/AddConstMap/Basic.lean
@@ -76,11 +76,13 @@ protected theorem semiconj [Add G] [Add H] [AddConstMapClass F G H a b] (f : F) 
     Semiconj f (· + a) (· + b) :=
   map_add_const f
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_add_nsmul [AddMonoid G] [AddMonoid H] [AddConstMapClass F G H a b]
     (f : F) (x : G) (n : ℕ) : f (x + n • a) = f x + n • b := by
   simpa using (AddConstMapClass.semiconj f).iterate_right n x
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_add_nat' [AddMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℕ) : f (x + n) = f x + n • b := by simp [← map_add_nsmul]
@@ -88,6 +90,7 @@ theorem map_add_nat' [AddMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 
 theorem map_add_one [AddMonoidWithOne G] [Add H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) : f (x + 1) = f x + b := map_add_const f x
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_add_ofNat' [AddMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℕ) [n.AtLeastTwo] :
@@ -101,6 +104,7 @@ theorem map_add_ofNat [AddMonoidWithOne G] [AddMonoidWithOne H] [AddConstMapClas
     (f : F) (x : G) (n : ℕ) [n.AtLeastTwo] :
     f (x + ofNat(n)) = f x + ofNat(n) := map_add_nat f x n
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_const [AddZeroClass G] [Add H] [AddConstMapClass F G H a b] (f : F) :
     f a = f 0 + b := by
@@ -110,11 +114,13 @@ theorem map_one [AddZeroClass G] [One G] [Add H] [AddConstMapClass F G H 1 b] (f
     f 1 = f 0 + b :=
   map_const f
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_nsmul_const [AddMonoid G] [AddMonoid H] [AddConstMapClass F G H a b]
     (f : F) (n : ℕ) : f (n • a) = f 0 + n • b := by
   simpa using map_add_nsmul f 0 n
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_nat' [AddMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
     (f : F) (n : ℕ) : f n = f 0 + n • b := by
@@ -132,6 +138,7 @@ theorem map_ofNat [AddMonoidWithOne G] [AddMonoidWithOne H] [AddConstMapClass F 
     (f : F) (n : ℕ) [n.AtLeastTwo] :
     f ofNat(n) = f 0 + ofNat(n) := map_nat f n
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_const_add [AddCommMagma G] [Add H] [AddConstMapClass F G H a b]
     (f : F) (x : G) : f (a + x) = f x + b := by
@@ -140,11 +147,13 @@ theorem map_const_add [AddCommMagma G] [Add H] [AddConstMapClass F G H a b]
 theorem map_one_add [AddCommMonoidWithOne G] [Add H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) : f (1 + x) = f x + b := map_const_add f x
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_nsmul_add [AddCommMonoid G] [AddMonoid H] [AddConstMapClass F G H a b]
     (f : F) (n : ℕ) (x : G) : f (n • a + x) = f x + n • b := by
   rw [add_comm, map_add_nsmul]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_nat_add' [AddCommMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
     (f : F) (n : ℕ) (x : G) : f (↑n + x) = f x + n • b := by
@@ -163,11 +172,13 @@ theorem map_ofNat_add [AddCommMonoidWithOne G] [AddMonoidWithOne H] [AddConstMap
     f (ofNat(n) + x) = f x + ofNat(n) :=
   map_nat_add f n x
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_sub_nsmul [AddGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (x : G) (n : ℕ) : f (x - n • a) = f x - n • b := by
   conv_rhs => rw [← sub_add_cancel x (n • a), map_add_nsmul, add_sub_cancel_right]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_sub_const [AddGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (x : G) : f (x - a) = f x - b := by
@@ -177,28 +188,33 @@ theorem map_sub_one [AddGroup G] [One G] [AddGroup H] [AddConstMapClass F G H 1 
     (f : F) (x : G) : f (x - 1) = f x - b :=
   map_sub_const f x
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_sub_nat' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℕ) : f (x - n) = f x - n • b := by
   simpa using map_sub_nsmul f x n
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_sub_ofNat' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℕ) [n.AtLeastTwo] :
     f (x - ofNat(n)) = f x - ofNat(n) • b :=
   map_sub_nat' f x n
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_add_zsmul [AddGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (x : G) : ∀ n : ℤ, f (x + n • a) = f x + n • b
   | (n : ℕ) => by simp
   | .negSucc n => by simp [← sub_eq_add_neg]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_zsmul_const [AddGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (n : ℤ) : f (n • a) = f 0 + n • b := by
   simpa using map_add_zsmul f 0 n
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_add_int' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℤ) : f (x + n) = f x + n • b := by
@@ -207,11 +223,13 @@ theorem map_add_int' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 
 theorem map_add_int [AddGroupWithOne G] [AddGroupWithOne H] [AddConstMapClass F G H 1 1]
     (f : F) (x : G) (n : ℤ) : f (x + n) = f x + n := by simp
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_sub_zsmul [AddGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (x : G) (n : ℤ) : f (x - n • a) = f x - n • b := by
   simpa [sub_eq_add_neg] using map_add_zsmul f x (-n)
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_sub_int' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℤ) : f (x - n) = f x - n • b := by
@@ -220,11 +238,13 @@ theorem map_sub_int' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 
 theorem map_sub_int [AddGroupWithOne G] [AddGroupWithOne H] [AddConstMapClass F G H 1 1]
     (f : F) (x : G) (n : ℤ) : f (x - n) = f x - n := by simp
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_zsmul_add [AddCommGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (n : ℤ) (x : G) : f (n • a + x) = f x + n • b := by
   rw [add_comm, map_add_zsmul]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem map_int_add' [AddCommGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
     (f : F) (n : ℤ) (x : G) : f (↑n + x) = f x + n • b := by

--- a/Mathlib/Algebra/CharP/Two.lean
+++ b/Mathlib/Algebra/CharP/Two.lean
@@ -44,6 +44,7 @@ theorem of_one_ne_zero_of_two_eq_zero (h₁ : (1 : R) ≠ 0) (h₂ : (2 : R) = 0
 
 variable [CharP R 2]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem two_eq_zero : (2 : R) = 0 := by
   rw [← Nat.cast_two, CharP.cast_eq_zero]
@@ -64,6 +65,7 @@ theorem natCast_cases (n : ℕ) : (n : R) = 0 ∨ (n : R) = 1 :=
 theorem natCast_eq_mod (n : ℕ) : (n : R) = (n % 2 : ℕ) := by
   simp [natCast_eq_ite, Nat.even_iff]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem ofNat_eq_mod (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : R) = (ofNat(n) % 2 : ℕ) :=
   natCast_eq_mod n
@@ -80,13 +82,16 @@ variable [Semiring R] [CharP R 2]
 @[scoped simp]
 theorem add_self_eq_zero (x : R) : x + x = 0 := by rw [← two_mul x, two_eq_zero, zero_mul]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 protected theorem two_nsmul (x : R) : 2 • x = 0 := by rw [two_nsmul, add_self_eq_zero]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 protected theorem add_cancel_left (a b : R) : a + (a + b) = b := by
   rw [← add_assoc, add_self_eq_zero, zero_add]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 protected theorem add_cancel_right (a b : R) : a + b + b = a := by
   rw [add_assoc, add_self_eq_zero, add_zero]
@@ -115,6 +120,7 @@ theorem add_eq_iff_eq_add {a b c : R} : a + b = c ↔ a = c + b := by
 theorem eq_add_iff_add_eq {a b c : R} : a = b + c ↔ a + c = b := by
   rw [← eq_sub_iff_add_eq, sub_eq_add]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 protected theorem two_zsmul (x : R) : (2 : ℤ) • x = 0 := by
   rw [two_zsmul, add_self_eq_zero]
@@ -184,6 +190,7 @@ theorem sq_injective : Function.Injective fun x : R ↦ x ^ 2 := by
   intro x y h
   rwa [← CharTwo.add_eq_zero, ← add_sq, pow_eq_zero_iff two_ne_zero, CharTwo.add_eq_zero] at h
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem sq_inj {x y : R} : x ^ 2 = y ^ 2 ↔ x = y :=
   sq_injective.eq_iff

--- a/Mathlib/Algebra/CharP/Two.lean
+++ b/Mathlib/Algebra/CharP/Two.lean
@@ -76,6 +76,7 @@ section Semiring
 
 variable [Semiring R] [CharP R 2]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem add_self_eq_zero (x : R) : x + x = 0 := by rw [← two_mul x, two_eq_zero, zero_mul]
 
@@ -96,6 +97,7 @@ section Ring
 
 variable [Ring R] [CharP R 2]
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem neg_eq (x : R) : -x = x := by
   rw [neg_eq_iff_add_eq_zero, add_self_eq_zero]
@@ -103,6 +105,7 @@ theorem neg_eq (x : R) : -x = x := by
 theorem neg_eq' : Neg.neg = (id : R → R) :=
   funext neg_eq
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem sub_eq_add (x y : R) : x - y = x + y := by rw [sub_eq_add_neg, neg_eq]
 

--- a/Mathlib/Algebra/GradedMonoid.lean
+++ b/Mathlib/Algebra/GradedMonoid.lean
@@ -307,6 +307,7 @@ variable {A}
 theorem mk_zero_smul {i} (a : A 0) (b : A i) : mk _ (a • b) = mk _ a * mk _ b :=
   Sigma.ext (zero_add _).symm <| eqRec_heq _ _
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem GradeZero.smul_eq_mul (a b : A 0) : a • b = a * b :=
   rfl

--- a/Mathlib/Algebra/Ring/BooleanRing.lean
+++ b/Mathlib/Algebra/Ring/BooleanRing.lean
@@ -57,12 +57,14 @@ namespace BooleanRing
 
 variable [BooleanRing α] (a b : α)
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 lemma mul_self : a * a = a := IsIdempotentElem.eq (isIdempotentElem a)
 
 instance : Std.IdempotentOp (α := α) (· * ·) :=
   ⟨BooleanRing.mul_self⟩
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem add_self : a + a = 0 := by
   have : a + a = a + a + (a + a) :=
@@ -72,6 +74,7 @@ theorem add_self : a + a = 0 := by
       _ = a + a + (a + a) := by rw [mul_self]
   rwa [right_eq_add] at this
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem neg_eq : -a = a :=
   calc
@@ -94,6 +97,7 @@ theorem mul_add_mul : a * b + b * a = 0 := by
       _ = a + b + (a * b + b * a) := by abel
   rwa [left_eq_add] at this
 
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
 @[scoped simp]
 theorem sub_eq_add : a - b = a + b := by rw [sub_eq_add_neg, add_right_inj, neg_eq]
 

--- a/Mathlib/Algebra/Ring/CharZero.lean
+++ b/Mathlib/Algebra/Ring/CharZero.lean
@@ -88,12 +88,14 @@ end Semiring
 section NonAssocRing
 variable [NonAssocRing R] [NoZeroDivisors R] [CharZero R]
 
--- `scoped` attribute here and below because the `simp` keys are weak
--- (see https://github.com/leanprover-community/mathlib4/pull/15631)
-@[scoped simp] theorem CharZero.neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
+@[scoped simp]
+theorem CharZero.neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
   neg_eq_iff_add_eq_zero.trans add_self_eq_zero
 
-@[scoped simp] theorem CharZero.eq_neg_self_iff {a : R} : a = -a ↔ a = 0 :=
+-- For the use of `scoped` rather than `simp`, see library note [Simp lemmas with weak keys]
+@[scoped simp]
+theorem CharZero.eq_neg_self_iff {a : R} : a = -a ↔ a = 0 :=
   eq_neg_iff_add_eq_zero.trans add_self_eq_zero
 
 theorem nat_mul_inj {n : ℕ} {a b : R} (h : (n : R) * a = (n : R) * b) : n = 0 ∨ a = b := by

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -281,6 +281,7 @@ public import Mathlib.Tactic.Set
 public import Mathlib.Tactic.SetLike
 public import Mathlib.Tactic.SetNotationForOrder
 public import Mathlib.Tactic.SimpIntro
+public import Mathlib.Tactic.SimpLibraryNote
 public import Mathlib.Tactic.SimpRw
 public import Mathlib.Tactic.Simproc.Divisors
 public import Mathlib.Tactic.Simproc.ExistsAndEq

--- a/Mathlib/Tactic/SimpLibraryNote.lean
+++ b/Mathlib/Tactic/SimpLibraryNote.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2026 Paul Lezeau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Lezeau
+-/
+
+module
+
+public import Batteries.Util.LibraryNote
+
+library_note «Simp lemmas with weak keys» /--
+Certain theorems shouldn't be tagged with the `simp` attribute as they have "weak keys", i.e. they
+match on certain patterns that occur much more often than the lemmas are actually applicable.
+This is harmful as it affects the performance of the `simp` tactic.
+As a replacement, one can use `scoped simp` with an appropriate namespace.
+See also the following PRs:
+- https://github.com/leanprover-community/mathlib4/pull/15620
+- https://github.com/leanprover-community/mathlib4/pull/15631
+-/

--- a/Mathlib/Tactic/SimpLibraryNote.lean
+++ b/Mathlib/Tactic/SimpLibraryNote.lean
@@ -7,6 +7,15 @@ Authors: Paul Lezeau
 module
 
 public import Batteries.Util.LibraryNote
+public import Mathlib.Init
+
+/-! # Simp Lemmas With Weak Keys Library Note
+
+This file contains a library note explaining how to handle `simp` lemmas that have "weak keys".
+
+-/
+
+@[expose] public section
 
 library_note «Simp lemmas with weak keys» /--
 Certain theorems shouldn't be tagged with the `simp` attribute as they have "weak keys", i.e. they


### PR DESCRIPTION
In PR #39262 I noticed that some `simp` lemmas were scoped for a reason that is not immediately obvious, so I figured that adding a library note would be nice in case anyone else runs into this in the future (this pattern is quite common in Mathlib!)

In case it's helpful for review, here are links to a few of the PRs that added this scoping initially:
- #14233
- #15620
- #15631

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
