### PR TITLE
feat(Algebra/Module/ZLattice): Quotient by `IsZLattice` is group isomorphic to `UnitAddTorus`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -836,6 +836,7 @@ public import Mathlib.Algebra.Module.ULift
 public import Mathlib.Algebra.Module.ZLattice.Basic
 public import Mathlib.Algebra.Module.ZLattice.Covolume
 public import Mathlib.Algebra.Module.ZLattice.Summable
+public import Mathlib.Algebra.Module.ZLattice.Torus
 public import Mathlib.Algebra.Module.ZMod
 public import Mathlib.Algebra.MonoidAlgebra.Basic
 public import Mathlib.Algebra.MonoidAlgebra.Cardinal

--- a/Mathlib/Algebra/Module/ZLattice/Torus.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Torus.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 Jack McCarthy. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jack McCarthy
+-/
+module
+
+public import Mathlib.Algebra.Module.ZLattice.Basic
+public import Mathlib.LinearAlgebra.Quotient.Pi
+public import Mathlib.Topology.Instances.AddCircle.Real
+
+/-!
+# Quotients by `IsZLattice`s are tori
+
+The quotient of a finite-dimensional real normed space `E` by an `IsZLattice ℝ L` is
+isomorphic, as an additive group, to the unit additive torus `UnitAddTorus ι = ι → ℝ ⧸ ℤ`,
+where `ι` indexes a `ℤ`-basis of `L`.
+
+## Main definitions
+
+* `IsZLattice.quotientAddEquivUnitAddTorus`: the additive equivalence
+  `E ⧸ L ≃+ UnitAddTorus ι`, given a `ℤ`-basis of `L`.
+
+## Future work
+
+Promoting to a `ContinuousAddEquiv` requires continuous versions of
+`Submodule.Quotient.equiv` and `Submodule.quotientPi` not yet in Mathlib.
+-/
+
+@[expose] public section
+
+namespace IsZLattice
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {L : Submodule ℤ E} [DiscreteTopology L] [IsZLattice ℝ L]
+  {ι : Type*} [Finite ι] (b : Module.Basis ι ℤ L)
+
+/-- The image of `L` under the basis-induced equivalence `E ≃ₗ[ℝ] ι → ℝ` is the standard
+integer lattice in `ι → ℝ`. -/
+theorem map_basis_equivFun_eq :
+    Submodule.map ((b.ofZLatticeBasis ℝ).equivFun.toLinearMap.restrictScalars ℤ : E →ₗ[ℤ] ι → ℝ) L =
+      Submodule.pi (Set.univ : Set ι) (fun _ : ι ↦ ℤ ∙ (1 : ℝ)) := by
+  classical
+  haveI : Fintype ι := Fintype.ofFinite ι
+  set b' := b.ofZLatticeBasis ℝ
+  rw [show L = Submodule.span ℤ (Set.range b') from (b.ofZLatticeBasis_span ℝ).symm]
+  simp [Submodule.map_span, Submodule.span_range_eq_iSup, ← Submodule.iSup_map_single,
+    Finsupp.single_eq_pi_single]
+
+/-- The additive equivalence between `E ⧸ L` and the unit additive torus `UnitAddTorus ι`,
+given a `ℤ`-basis of `L`. -/
+noncomputable def quotientAddEquivUnitAddTorus [Fintype ι] [DecidableEq ι] :
+    (E ⧸ L) ≃+ UnitAddTorus ι :=
+  (Submodule.Quotient.equiv L _ ((b.ofZLatticeBasis ℝ).equivFun.restrictScalars ℤ)
+      (map_basis_equivFun_eq b)).trans (Submodule.quotientPi _) |>.toAddEquiv.trans <|
+    .piCongrRight fun _ ↦ QuotientAddGroup.quotientAddEquivOfEq <|
+      Submodule.span_singleton_toAddSubgroup_eq_zmultiples (1 : ℝ)
+
+end IsZLattice

--- a/Mathlib/Algebra/Module/ZLattice/Torus.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Torus.lean
@@ -13,13 +13,13 @@ public import Mathlib.Topology.Instances.AddCircle.Real
 # Quotients by `IsZLattice`s are tori
 
 The quotient of a finite-dimensional real normed space `E` by an `IsZLattice ℝ L` is
-isomorphic, as an additive group, to the unit additive torus `UnitAddTorus ι = ι → ℝ ⧸ ℤ`,
-where `ι` indexes a `ℤ`-basis of `L`.
+isomorphic, as an additive group, to a unit additive torus, with index type given by
+`Module.Free.ChooseBasisIndex ℤ L`.
 
 ## Main definitions
 
 * `IsZLattice.quotientAddEquivUnitAddTorus`: the additive equivalence
-  `E ⧸ L ≃+ UnitAddTorus ι`, given a `ℤ`-basis of `L`.
+  `E ⧸ L ≃+ UnitAddTorus (Module.Free.ChooseBasisIndex ℤ L)`.
 
 ## Future work
 
@@ -47,13 +47,14 @@ theorem map_basis_equivFun_eq :
   simp [Submodule.map_span, Submodule.span_range_eq_iSup, ← Submodule.iSup_map_single,
     Finsupp.single_eq_pi_single]
 
-/-- The additive equivalence between `E ⧸ L` and the unit additive torus `UnitAddTorus ι`,
-given a `ℤ`-basis of `L`. -/
-noncomputable def quotientAddEquivUnitAddTorus [Fintype ι] [DecidableEq ι] :
-    (E ⧸ L) ≃+ UnitAddTorus ι :=
-  (Submodule.Quotient.equiv L _ ((b.ofZLatticeBasis ℝ).equivFun.restrictScalars ℤ)
-      (map_basis_equivFun_eq b)).trans (Submodule.quotientPi _) |>.toAddEquiv.trans <|
-    .piCongrRight fun _ ↦ QuotientAddGroup.quotientAddEquivOfEq <|
-      Submodule.span_singleton_toAddSubgroup_eq_zmultiples (1 : ℝ)
+/-- The additive equivalence between `E ⧸ L` and the unit additive torus, using the canonical
+choice of `ℤ`-basis of `L` from `Module.Free.chooseBasis`. -/
+noncomputable def quotientAddEquivUnitAddTorus :
+    (E ⧸ L) ≃+ UnitAddTorus (Module.Free.ChooseBasisIndex ℤ L) := by
+  let b := Module.Free.chooseBasis ℤ L
+  exact (Submodule.Quotient.equiv L _ ((b.ofZLatticeBasis ℝ).equivFun.restrictScalars ℤ)
+        (map_basis_equivFun_eq b)).trans (Submodule.quotientPi _) |>.toAddEquiv.trans <|
+      .piCongrRight fun _ ↦ QuotientAddGroup.quotientAddEquivOfEq <|
+        Submodule.span_singleton_toAddSubgroup_eq_zmultiples (1 : ℝ)
 
 end IsZLattice

--- a/Mathlib/Analysis/Fourier/AddCircleMulti.lean
+++ b/Mathlib/Analysis/Fourier/AddCircleMulti.lean
@@ -37,9 +37,6 @@ local instance : Measure.IsAddHaarMeasure (volume : Measure UnitAddCircle) :=
 local instance : IsProbabilityMeasure (volume : Measure UnitAddCircle) :=
   inferInstanceAs (IsProbabilityMeasure AddCircle.haarAddCircle)
 
-/-- The product of finitely many copies of the unit circle, indexed by `d`. -/
-abbrev UnitAddTorus (d : Type*) := d → UnitAddCircle
-
 namespace UnitAddTorus
 
 variable {d : Type*} [Fintype d]

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -48,10 +48,10 @@ lemma coe_span_smul {R' M' : Type*} [CommSemiring R'] [AddCommMonoid M'] [Module
           exact mem_set_smul_of_mem_mem (hc hi) <| Submodule.smul_mem _ _ hn) <|
     set_smul_mono_left _ Submodule.subset_span
 
-lemma span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
-    (span ℤ {a}).toAddSubgroup = AddSubgroup.zmultiples a := by
+lemma span_singleton_toAddSubgroup_eq_zmultiples {M : Type*} [AddCommGroup M] (a : M) :
+    (span ℤ ({a} : Set M)).toAddSubgroup = AddSubgroup.zmultiples a := by
   ext i
-  simp [Ideal.mem_span_singleton', AddSubgroup.mem_zmultiples_iff]
+  simp [Submodule.mem_span_singleton, AddSubgroup.mem_zmultiples_iff]
 
 @[simp] lemma _root_.Ideal.span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
     (Ideal.span {a}).toAddSubgroup = AddSubgroup.zmultiples a :=

--- a/Mathlib/Topology/Instances/AddCircle/Real.lean
+++ b/Mathlib/Topology/Instances/AddCircle/Real.lean
@@ -48,6 +48,9 @@ section UnitAddCircle
 abbrev UnitAddCircle :=
   AddCircle (1 : ℝ)
 
+/-- The product of finitely many copies of the unit circle, indexed by `d`. -/
+abbrev UnitAddTorus (d : Type*) := d → UnitAddCircle
+
 end UnitAddCircle
 
 namespace ZMod


### PR DESCRIPTION
The main result `quotientAddEquivUnitAddTorus` constructs an isomorphism `(E ⧸ L) ≃+ UnitAddTorus ι` for any `IsZLattice ℝ L`.

Currently left as a draft for educational purpose. See the Zulip thread [#mathlib4 > What Is A Torus?](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/What.20Is.20A.20Torus.3F/with/595553420) for more discussion.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #39452 
- [x] depends on: #39453

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
