### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology/SimplicialSet): more API for PairingCore

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/PairingCore.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/PairingCore.lean
@@ -166,6 +166,12 @@ lemma pairing_p_symm_equivI (x : h.ι) :
     DFunLike.coe (F := h.I ≃ h.II) h.pairing.p.symm (h.equivI x) = h.equivII x := by
   simp [pairing]
 
+lemma type₁_pairing (x : h.ι) :
+    h.type₁ x = h.pairing.p (h.equivII x) := by
+  dsimp +instances
+  rw [h.pairing_p_equivII x]
+  rfl
+
 /-- The condition that `h : A.PairingCore` is proper, i.e. for each `s : h.ι`,
 the type (II) simplex `h.type₂ s` is uniquely a `1`-codimensional
 face of the type (I) simplex `h.type₁ s`. -/
@@ -182,6 +188,11 @@ instance [h.IsProper] : h.pairing.IsProper where
   isUniquelyCodimOneFace x := by
     obtain ⟨s, rfl⟩ := h.equivII.surjective x
     simpa using h.isUniquelyCodimOneFace s
+
+lemma isProper_pairing_iff :
+    h.pairing.IsProper ↔ h.IsProper := by
+  refine ⟨fun _ ↦ ⟨fun s ↦ ?_⟩, fun _ ↦ inferInstance⟩
+  simpa [type₁_pairing] using h.pairing.isUniquelyCodimOneFace (h.equivII s)
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
@@ -233,6 +244,18 @@ instance [h.IsRegular] : h.pairing.IsRegular where
     rw [wellFounded_iff_isEmpty_descending_chain] at this ⊢
     exact ⟨fun ⟨f, hf⟩ ↦ this.false
       ⟨fun n ↦ h.equivII.symm (f n), fun n ↦ by simpa [ancestralRel_iff] using hf n⟩⟩
+
+lemma isRegular_pairing_iff (h : A.PairingCore) :
+    h.pairing.IsRegular ↔ h.IsRegular := by
+  refine ⟨fun _ ↦ ?_, fun _ ↦ inferInstance⟩
+  have : h.IsProper := by
+    rw [← isProper_pairing_iff]
+    infer_instance
+  constructor
+  have := h.pairing.wf
+  rw [wellFounded_iff_isEmpty_descending_chain] at this ⊢
+  exact ⟨fun ⟨f, hf⟩ ↦ this.false
+    ⟨fun n ↦ h.equivII (f n), fun n ↦ by simpa [ancestralRel_iff] using hf n⟩⟩
 
 end PairingCore
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/PairingCore.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/PairingCore.lean
@@ -168,9 +168,7 @@ lemma pairing_p_symm_equivI (x : h.ι) :
 
 lemma type₁_pairing (x : h.ι) :
     h.type₁ x = h.pairing.p (h.equivII x) := by
-  dsimp +instances
-  rw [h.pairing_p_equivII x]
-  rfl
+  simp +instances
 
 /-- The condition that `h : A.PairingCore` is proper, i.e. for each `s : h.ι`,
 the type (II) simplex `h.type₂ s` is uniquely a `1`-codimensional

--- a/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/Rank.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/Rank.lean
@@ -166,6 +166,16 @@ noncomputable def weakRankFunctionEquiv :
   left_inv _ := by simp
   right_inv _ := by simp
 
+variable {h α} [WellFoundedLT α]
+
+lemma RankFunction.isRegular [h.IsProper] (f : h.RankFunction α) : h.IsRegular := by
+  rw [← isRegular_pairing_iff]
+  exact (h.rankFunctionEquiv α f).isRegular
+
+lemma WeakRankFunction.isRegular [h.IsProper] (f : h.WeakRankFunction α) : h.IsRegular := by
+  rw [← isRegular_pairing_iff]
+  exact (h.weakRankFunctionEquiv α f).isRegular
+
 end PairingCore
 
 end SSet.Subcomplex

--- a/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/RankNat.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/RankNat.lean
@@ -23,9 +23,13 @@ universe u
 
 open Simplicial
 
-namespace SSet.Subcomplex.Pairing
+namespace SSet.Subcomplex
 
-variable {X : SSet.{u}} {A : X.Subcomplex} (P : A.Pairing)
+variable {X : SSet.{u}} {A : X.Subcomplex}
+
+namespace Pairing
+
+variable (P : A.Pairing)
 
 instance (y : P.II) : Finite { x // P.AncestralRel x y } := by
   let T := { x : P.II // P.AncestralRel x y }
@@ -94,4 +98,22 @@ lemma isRegular_iff_nonempty_weakRankFunction [P.IsProper] :
     P.IsRegular ↔ Nonempty (P.WeakRankFunction ℕ) :=
   ⟨fun _ ↦ inferInstance, fun ⟨h⟩ ↦ h.isRegular⟩
 
-end SSet.Subcomplex.Pairing
+end Pairing
+
+namespace PairingCore
+
+variable (P : A.PairingCore)
+
+lemma isRegular_iff_nonempty_rankFunction [P.IsProper] :
+    P.IsRegular ↔ Nonempty (P.RankFunction ℕ) := by
+  rw [← isRegular_pairing_iff, Pairing.isRegular_iff_nonempty_rankFunction]
+  exact (P.rankFunctionEquiv ℕ).symm.nonempty_congr
+
+lemma isRegular_iff_nonempty_weakRankFunction [P.IsProper] :
+    P.IsRegular ↔ Nonempty (P.WeakRankFunction ℕ) := by
+  rw [← isRegular_pairing_iff, Pairing.isRegular_iff_nonempty_weakRankFunction]
+  exact (P.weakRankFunctionEquiv ℕ).symm.nonempty_congr
+
+end PairingCore
+
+end SSet.Subcomplex


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
