### PR TITLE
feat(Topology/Separation/Hausdorff): add `Filter.limUnder_congr`

### DIFF
--- a/Mathlib/Order/Filter/AtTopBot/Archimedean.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Archimedean.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.Order.Archimedean.Basic
 public import Mathlib.Order.Filter.AtTopBot.Group
 public import Mathlib.Order.Filter.CountablyGenerated
 public import Mathlib.Tactic.GCongr
+public import Mathlib.Topology.Separation.Hausdorff
 import Mathlib.Algebra.Order.Group.Basic
 
 /-!
@@ -40,6 +41,15 @@ theorem tendsto_natCast_atTop_iff [Semiring R] [PartialOrder R] [IsStrictOrdered
 theorem PNat.tendsto_comp_val_iff {β : Type*} {f : ℕ → β} {l : Filter β} :
     Tendsto (fun x : ℕ+ => f x) atTop l ↔ Tendsto f atTop l := by
   exact tendsto_comp_val_Ioi_atTop
+
+theorem PNat.limUnder_eq {β : Type*} [TopologicalSpace β] [Nonempty β] [T2Space β] {f : ℕ → β} :
+    atTop.limUnder (fun x : ℕ+ => f x) = atTop.limUnder f :=
+  limUnder_congr fun _ => tendsto_comp_val_iff
+
+theorem PNat.limUnder_eq_limUnder_succ {β : Type*} [TopologicalSpace β] [Nonempty β] [T2Space β]
+    {f : ℕ → β} :
+    atTop.limUnder (fun x : ℕ+ => f x) = atTop.limUnder (fun x => f (x + 1)) := by
+  rw [limUnder_eq, limUnder_add_eq_limUnder_nat]
 
 theorem tendsto_natCast_atTop_atTop [Semiring R] [PartialOrder R] [IsOrderedRing R]
     [Archimedean R] :

--- a/Mathlib/Topology/Separation/Hausdorff.lean
+++ b/Mathlib/Topology/Separation/Hausdorff.lean
@@ -73,7 +73,7 @@ open Function Set Filter Topology TopologicalSpace
 
 universe u v
 
-variable {X : Type*} {Y : Type*} [TopologicalSpace X]
+variable {X : Type*} {Y : Type*} {Z : Type*} [TopologicalSpace X]
 
 section Separation
 
@@ -295,6 +295,19 @@ theorem Filter.Tendsto.limUnder_eq {x : X} {f : Filter Y} [NeBot f] {g : Y → X
 theorem Filter.limUnder_eq_iff {f : Filter Y} [NeBot f] {g : Y → X} (h : ∃ x, Tendsto g f (𝓝 x))
     {x} : @limUnder _ _ _ ⟨x⟩ f g = x ↔ Tendsto g f (𝓝 x) :=
   ⟨fun c => c ▸ tendsto_nhds_limUnder h, Filter.Tendsto.limUnder_eq⟩
+
+theorem Filter.limUnder_congr
+    [Nonempty X] {l₁ : Filter Y} {l₂ : Filter Z} [NeBot l₁] [NeBot l₂]
+    {f : Y -> X} {g : Z -> X} (h : ∀ x, Tendsto f l₁ (𝓝 x) ↔ Tendsto g l₂ (𝓝 x)) :
+    l₁.limUnder f = l₂.limUnder g := by
+  rcases em <| ∃ x, Tendsto f l₁ (𝓝 x) with ⟨x, hx⟩ | h'
+  · rw [hx.limUnder_eq, h x |>.mp hx |>.limUnder_eq]
+  · rw [limUnder_of_not_tendsto h', limUnder_of_not_tendsto <|
+      mt (fun ⟨x, hx⟩ => ⟨x, h x |>.mpr hx⟩) h']
+
+theorem limUnder_add_eq_limUnder_nat {α : Type*} [TopologicalSpace α] [Nonempty α] [T2Space α]
+    {f : ℕ -> α} (k : ℕ) : atTop.limUnder (fun n => f (n + k)) = atTop.limUnder f :=
+  Filter.limUnder_congr fun _ => tendsto_add_atTop_iff_nat k
 
 theorem Continuous.limUnder_eq [TopologicalSpace Y] {f : Y → X} (h : Continuous f) (y : Y) :
     @limUnder _ _ _ ⟨f y⟩ (𝓝 y) f = f y :=


### PR DESCRIPTION
This PR adds `Filter.limUnder_congr` and some lemmas about `limUnder`.

`Filter.limUnder_congr` allows rewriting `limUnder` expressions using equivalences of convergence behavior, without proving the filters actually converge, allowing convergence proofs to be carried out on more convenient expressions latter.