### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Ray): remove a defeq abuse

### DIFF
--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -50,18 +50,18 @@ set_option linter.unusedVariables false in
 def RayVector (R M : Type*) [Zero M] :=
   { v : M // v ≠ 0 }
 
-/-- Create a `RayVector` from a nonzero vector -/
-def RayVector.mk (R : Type*) {M : Type*} [Zero M] (v : M) (h : v ≠ 0) : RayVector R M := ⟨v, h⟩
+def RayVector.equiv (R : Type*) {M : Type*} [Zero M] : RayVector R M ≃ { v : M // v ≠ 0 } :=
+  Equiv.refl _
 
 instance RayVector.coe {R M : Type*} [Zero M] : CoeOut (RayVector R M) M where
-  coe := Subtype.val
+  coe x := (equiv R x).val
 
 @[simp]
-theorem RayVector.coe_mk {R M : Type*} [Zero M] {v : M} (h : v ≠ 0) :
-    RayVector.mk R v h = v := rfl
+theorem RayVector.coe_equiv_symm {R M : Type*} [Zero M] {v : M} (h : v ≠ 0) :
+    (RayVector.equiv R).symm ⟨v, h⟩ = v := rfl
 
 @[ext]
-theorem RayVector.ext {R M : Type*} [Zero M] {x y : RayVector R M} (h : x.val = y.val) :
+theorem RayVector.ext {R M : Type*} [Zero M] {x y : RayVector R M} (h : (x : M) = (y : M)) :
     x = y := Subtype.ext h
 
 instance {R M : Type*} [Zero M] [Nontrivial M] : Nonempty (RayVector R M) :=
@@ -236,7 +236,7 @@ variable (R)
 
 /-- The ray given by a nonzero vector. -/
 def rayOfNeZero (v : M) (h : v ≠ 0) : Module.Ray R M :=
-  ⟦.mk R v h⟧
+  ⟦(RayVector.equiv R).symm ⟨v, h⟩⟧
 
 /-- An induction principle for `Module.Ray`, used as `induction x using Module.Ray.ind`. -/
 theorem Module.Ray.ind {C : Module.Ray R M → Prop} (h : ∀ (v) (hv : v ≠ 0), C (rayOfNeZero R v hv))
@@ -382,7 +382,7 @@ namespace RayVector
 
 /-- Negating a nonzero vector. -/
 instance {R : Type*} : Neg (RayVector R M) :=
-  ⟨fun v => .mk R (-v) (neg_ne_zero.2 v.prop)⟩
+  ⟨fun v => (equiv R).symm ⟨-v, neg_ne_zero.2 v.prop⟩⟩
 
 /-- Negating a nonzero vector commutes with coercion to the underlying module. -/
 @[simp, norm_cast]

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -51,15 +51,15 @@ def RayVector (R M : Type*) [Zero M] :=
   { v : M // v ≠ 0 }
 
 /-- Equivalence between `RayVector` and non-zero vectors. -/
-def RayVector.equiv (R : Type*) {M : Type*} [Zero M] : RayVector R M ≃ { v : M // v ≠ 0 } :=
+def RayVector.equiv (R M : Type*) [Zero M] : RayVector R M ≃ { v : M // v ≠ 0 } :=
   Equiv.refl _
 
 instance RayVector.coe {R M : Type*} [Zero M] : CoeOut (RayVector R M) M where
-  coe x := (equiv R x).val
+  coe x := (equiv R M x).val
 
 @[simp]
 theorem RayVector.coe_equiv_symm {R M : Type*} [Zero M] {v : M} (h : v ≠ 0) :
-    (RayVector.equiv R).symm ⟨v, h⟩ = v := rfl
+    (RayVector.equiv R M).symm ⟨v, h⟩ = v := rfl
 
 @[ext]
 theorem RayVector.ext {R M : Type*} [Zero M] {x y : RayVector R M} (h : (x : M) = (y : M)) :
@@ -237,7 +237,7 @@ variable (R)
 
 /-- The ray given by a nonzero vector. -/
 def rayOfNeZero (v : M) (h : v ≠ 0) : Module.Ray R M :=
-  ⟦(RayVector.equiv R).symm ⟨v, h⟩⟧
+  ⟦(RayVector.equiv R M).symm ⟨v, h⟩⟧
 
 /-- An induction principle for `Module.Ray`, used as `induction x using Module.Ray.ind`. -/
 theorem Module.Ray.ind {C : Module.Ray R M → Prop} (h : ∀ (v) (hv : v ≠ 0), C (rayOfNeZero R v hv))
@@ -383,7 +383,7 @@ namespace RayVector
 
 /-- Negating a nonzero vector. -/
 instance {R : Type*} : Neg (RayVector R M) :=
-  ⟨fun v => (equiv R).symm ⟨-v, neg_ne_zero.2 v.prop⟩⟩
+  ⟨fun v => (equiv R M).symm ⟨-v, neg_ne_zero.2 v.prop⟩⟩
 
 /-- Negating a nonzero vector commutes with coercion to the underlying module. -/
 @[simp, norm_cast]

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -50,6 +50,7 @@ set_option linter.unusedVariables false in
 def RayVector (R M : Type*) [Zero M] :=
   { v : M // v ≠ 0 }
 
+/-- Equivalence between `RayVector` and non-zero vectors. -/
 def RayVector.equiv (R : Type*) {M : Type*} [Zero M] : RayVector R M ≃ { v : M // v ≠ 0 } :=
   Equiv.refl _
 

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -50,8 +50,19 @@ set_option linter.unusedVariables false in
 def RayVector (R M : Type*) [Zero M] :=
   { v : M // v ≠ 0 }
 
+/-- Create a `RayVector` from a nonzero vector -/
+def RayVector.mk (R : Type*) {M : Type*} [Zero M] (v : M) (h : v ≠ 0) : RayVector R M := ⟨v, h⟩
+
 instance RayVector.coe {R M : Type*} [Zero M] : CoeOut (RayVector R M) M where
   coe := Subtype.val
+
+@[simp]
+theorem RayVector.coe_mk {R M : Type*} [Zero M] {v : M} (h : v ≠ 0) :
+    RayVector.mk R v h = v := rfl
+
+@[ext]
+theorem RayVector.ext {R M : Type*} [Zero M] {x y : RayVector R M} (h : x.val = y.val) :
+    x = y := Subtype.ext h
 
 instance {R M : Type*} [Zero M] [Nontrivial M] : Nonempty (RayVector R M) :=
   ⟨Classical.indefiniteDescription _ <| exists_ne (0 : M)⟩
@@ -225,7 +236,7 @@ variable (R)
 
 /-- The ray given by a nonzero vector. -/
 def rayOfNeZero (v : M) (h : v ≠ 0) : Module.Ray R M :=
-  ⟦⟨v, h⟩⟧
+  ⟦.mk R v h⟧
 
 /-- An induction principle for `Module.Ray`, used as `induction x using Module.Ray.ind`. -/
 theorem Module.Ray.ind {C : Module.Ray R M → Prop} (h : ∀ (v) (hv : v ≠ 0), C (rayOfNeZero R v hv))
@@ -371,17 +382,16 @@ namespace RayVector
 
 /-- Negating a nonzero vector. -/
 instance {R : Type*} : Neg (RayVector R M) :=
-  ⟨fun v => ⟨-v, neg_ne_zero.2 v.prop⟩⟩
+  ⟨fun v => .mk R (-v) (neg_ne_zero.2 v.prop)⟩
 
 /-- Negating a nonzero vector commutes with coercion to the underlying module. -/
 @[simp, norm_cast]
 theorem coe_neg {R : Type*} (v : RayVector R M) : ↑(-v) = -(v : M) :=
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Negating a nonzero vector twice produces the original vector. -/
 instance {R : Type*} : InvolutiveNeg (RayVector R M) where
-  neg_neg v := by rw [Subtype.ext_iff, coe_neg, coe_neg, neg_neg]
+  neg_neg v := by rw [RayVector.ext_iff, coe_neg, coe_neg, neg_neg]
 
 /-- If two nonzero vectors are equivalent, so are their negations. -/
 @[simp]


### PR DESCRIPTION
Previously, the code uses Subtype constructor to construct RayVector, and the instance cannot see through this. As a common practice, RayVector declares its own constructor to resolve this


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
