### PR TITLE
[Merged by Bors] - feat(Probability/Independence/InfinitePi): rearrangement of infinite product measures

### DIFF
--- a/Mathlib/Probability/Independence/InfinitePi.lean
+++ b/Mathlib/Probability/Independence/InfinitePi.lean
@@ -114,7 +114,7 @@ lemma _root_.MeasureTheory.Measure.map_infinitePi_infinitePi_of_inj {α : Type*}
     (infinitePi P).map (fun ω i ↦ ω (f i)) = infinitePi (fun i ↦ P (f i)) := by
   rw [(iIndepFun_iff_map_fun_eq_infinitePi_map <| by fun_prop).mp ?_]
   · simp [infinitePi_map_eval]
-  exact iIndepFun.precomp hf <| iIndepFun_infinitePi (X := fun x ω ↦ ω) <| by fun_prop
+  exact .precomp hf <| iIndepFun_infinitePi (X := fun x ω ↦ ω) <| by fun_prop
 
 section curry
 

--- a/Mathlib/Probability/Independence/InfinitePi.lean
+++ b/Mathlib/Probability/Independence/InfinitePi.lean
@@ -108,9 +108,9 @@ lemma iIndepFun_infinitePi {Ω : ι → Type*} {mΩ : ∀ i, MeasurableSpace (Ω
   congrm infinitePi fun i ↦ ?_
   rw [← infinitePi_map_eval P i, map_map (mX i) (by fun_prop), Function.comp_def]
 
-lemma Measure.map_infinitePi_infinitePi_of_inj {Ω : ι → Type*} {mΩ : ∀ i, MeasurableSpace (Ω i)}
-    {P : (i : ι) → Measure (Ω i)} [∀ i, IsProbabilityMeasure (P i)] {f : ι → ι}
-    (hf : Function.Injective f) :
+lemma _root_.MeasureTheory.Measure.map_infinitePi_infinitePi_of_inj {α : Type*} {Ω : ι → Type*}
+    {mΩ : ∀ i, MeasurableSpace (Ω i)} {P : (i : ι) → Measure (Ω i)}
+    [∀ i, IsProbabilityMeasure (P i)] {f : α → ι} (hf : Function.Injective f) :
     (infinitePi P).map (fun ω i ↦ ω (f i)) = infinitePi (fun i ↦ P (f i)) := by
   have := iIndepFun.precomp hf <|
     iIndepFun_infinitePi (P := P) (X := fun x ω ↦ ω) (by measurability)

--- a/Mathlib/Probability/Independence/InfinitePi.lean
+++ b/Mathlib/Probability/Independence/InfinitePi.lean
@@ -109,7 +109,7 @@ lemma iIndepFun_infinitePi {Ω : ι → Type*} {mΩ : ∀ i, MeasurableSpace (Ω
   rw [← infinitePi_map_eval P i, map_map (mX i) (by fun_prop), Function.comp_def]
 
 lemma _root_.MeasureTheory.Measure.map_infinitePi_infinitePi_of_inj {α : Type*} {Ω : ι → Type*}
-    {mΩ : ∀ i, MeasurableSpace (Ω i)} {P : (i : ι) → Measure (Ω i)}
+    {mΩ : ∀ i, MeasurableSpace (Ω i)} {P : ∀ i, Measure (Ω i)}
     [∀ i, IsProbabilityMeasure (P i)] {f : α → ι} (hf : Function.Injective f) :
     (infinitePi P).map (fun ω i ↦ ω (f i)) = infinitePi (fun i ↦ P (f i)) := by
   rw [(iIndepFun_iff_map_fun_eq_infinitePi_map <| by fun_prop).mp ?_]

--- a/Mathlib/Probability/Independence/InfinitePi.lean
+++ b/Mathlib/Probability/Independence/InfinitePi.lean
@@ -112,10 +112,9 @@ lemma _root_.MeasureTheory.Measure.map_infinitePi_infinitePi_of_inj {α : Type*}
     {mΩ : ∀ i, MeasurableSpace (Ω i)} {P : (i : ι) → Measure (Ω i)}
     [∀ i, IsProbabilityMeasure (P i)] {f : α → ι} (hf : Function.Injective f) :
     (infinitePi P).map (fun ω i ↦ ω (f i)) = infinitePi (fun i ↦ P (f i)) := by
-  have := iIndepFun.precomp hf <|
-    iIndepFun_infinitePi (P := P) (X := fun x ω ↦ ω) (by measurability)
-  rw [iIndepFun_iff_map_fun_eq_infinitePi_map (by measurability)] at this
-  simpa [infinitePi_map_eval] using this
+  rw [(iIndepFun_iff_map_fun_eq_infinitePi_map <| by fun_prop).mp ?_]
+  · simp [infinitePi_map_eval]
+  exact iIndepFun.precomp hf <| iIndepFun_infinitePi (X := fun x ω ↦ ω) <| by fun_prop
 
 section curry
 

--- a/Mathlib/Probability/Independence/InfinitePi.lean
+++ b/Mathlib/Probability/Independence/InfinitePi.lean
@@ -108,7 +108,7 @@ lemma iIndepFun_infinitePi {Ω : ι → Type*} {mΩ : ∀ i, MeasurableSpace (Ω
   congrm infinitePi fun i ↦ ?_
   rw [← infinitePi_map_eval P i, map_map (mX i) (by fun_prop), Function.comp_def]
 
-lemma map_infinitePi_infinitePi_of_inj {Ω : ι → Type*} {mΩ : ∀ i, MeasurableSpace (Ω i)}
+lemma Measure.map_infinitePi_infinitePi_of_inj {Ω : ι → Type*} {mΩ : ∀ i, MeasurableSpace (Ω i)}
     {P : (i : ι) → Measure (Ω i)} [∀ i, IsProbabilityMeasure (P i)] {f : ι → ι}
     (hf : Function.Injective f) :
     (infinitePi P).map (fun ω i ↦ ω (f i)) = infinitePi (fun i ↦ P (f i)) := by

--- a/Mathlib/Probability/Independence/InfinitePi.lean
+++ b/Mathlib/Probability/Independence/InfinitePi.lean
@@ -108,6 +108,15 @@ lemma iIndepFun_infinitePi {Ω : ι → Type*} {mΩ : ∀ i, MeasurableSpace (Ω
   congrm infinitePi fun i ↦ ?_
   rw [← infinitePi_map_eval P i, map_map (mX i) (by fun_prop), Function.comp_def]
 
+lemma map_infinitePi_infinitePi_of_inj {Ω : ι → Type*} {mΩ : ∀ i, MeasurableSpace (Ω i)}
+    {P : (i : ι) → Measure (Ω i)} [∀ i, IsProbabilityMeasure (P i)] {f : ι → ι}
+    (hf : Function.Injective f) :
+    (infinitePi P).map (fun ω i ↦ ω (f i)) = infinitePi (fun i ↦ P (f i)) := by
+  have := iIndepFun.precomp hf <|
+    iIndepFun_infinitePi (P := P) (X := fun x ω ↦ ω) (by measurability)
+  rw [iIndepFun_iff_map_fun_eq_infinitePi_map (by measurability)] at this
+  simpa [infinitePi_map_eval] using this
+
 section curry
 
 omit [IsProbabilityMeasure P]

--- a/Mathlib/Probability/ProductMeasure.lean
+++ b/Mathlib/Probability/ProductMeasure.lean
@@ -5,7 +5,6 @@ Authors: Etienne Marion
 -/
 module
 
-public import Mathlib.Probability.HasLaw
 public import Mathlib.Probability.Kernel.Composition.MeasureComp
 public import Mathlib.Probability.Kernel.IonescuTulcea.Traj
 
@@ -479,10 +478,6 @@ lemma _root_.measurePreserving_eval_infinitePi (i : ι) :
 lemma infinitePi_map_eval (i : ι) :
     (infinitePi μ).map (fun x ↦ x i) = μ i :=
   (measurePreserving_eval_infinitePi μ i).map_eq
-
-lemma hasLaw_infinitePi_eval (i : ι) :
-    HasLaw (fun ω ↦ ω i) (μ i) (infinitePi (fun i ↦ μ i)) :=
-  .mk (Measurable.aemeasurable (by measurability)) (infinitePi_map_eval μ i)
 
 lemma infinitePi_map_pi {Y : ι → Type*} [∀ i, MeasurableSpace (Y i)] {f : (i : ι) → X i → Y i}
     (hf : ∀ i, Measurable (f i)) :

--- a/Mathlib/Probability/ProductMeasure.lean
+++ b/Mathlib/Probability/ProductMeasure.lean
@@ -5,6 +5,7 @@ Authors: Etienne Marion
 -/
 module
 
+public import Mathlib.Probability.HasLaw
 public import Mathlib.Probability.Kernel.Composition.MeasureComp
 public import Mathlib.Probability.Kernel.IonescuTulcea.Traj
 
@@ -478,6 +479,10 @@ lemma _root_.measurePreserving_eval_infinitePi (i : ι) :
 lemma infinitePi_map_eval (i : ι) :
     (infinitePi μ).map (fun x ↦ x i) = μ i :=
   (measurePreserving_eval_infinitePi μ i).map_eq
+
+lemma hasLaw_infinitePi_eval (i : ι) :
+    HasLaw (fun ω ↦ ω i) (μ i) (infinitePi (fun i ↦ μ i)) :=
+  .mk (Measurable.aemeasurable (by measurability)) (infinitePi_map_eval μ i)
 
 lemma infinitePi_map_pi {Y : ι → Type*} [∀ i, MeasurableSpace (Y i)] {f : (i : ι) → X i → Y i}
     (hf : ∀ i, Measurable (f i)) :


### PR DESCRIPTION
This PR introduces a lemma for coordinate transformations of `infinitePi` measures.

- `MeasureTheory.Measure.map_infinitePi_infinitePi_of_inj`: if `f : α → ι` is injective, then the pushforward of the coordinates rearranged according to `f` (i.e., the law of `fun ω i ↦ ω (f i)` is the same as the infinite product of the rearranged laws.

This lemma bears some resemblance to `infinitePi_map_piCongrLeft`, but does not require `f` to be a bijection and probably is easier to work with in practice.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
