### PR TITLE
feat: tactic `apply_rulesets`

### DIFF
--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -8,6 +8,12 @@ public import Mathlib.Tactic.Algebraize
 public import Mathlib.Tactic.ApplyAt
 public import Mathlib.Tactic.ApplyCongr
 public import Mathlib.Tactic.ApplyFun
+public import Mathlib.Tactic.ApplyRuleSets
+public import Mathlib.Tactic.ApplyRuleSets.Attr
+public import Mathlib.Tactic.ApplyRuleSets.Core
+public import Mathlib.Tactic.ApplyRuleSets.Elab
+public import Mathlib.Tactic.ApplyRuleSets.RuleProc
+public import Mathlib.Tactic.ApplyRuleSets.Types
 public import Mathlib.Tactic.ApplyWith
 public import Mathlib.Tactic.ArithMult
 public import Mathlib.Tactic.ArithMult.Init

--- a/Mathlib/Tactic/ApplyRuleSets.lean
+++ b/Mathlib/Tactic/ApplyRuleSets.lean
@@ -1,0 +1,3 @@
+module
+
+public import Mathlib.Tactic.ApplyRuleSets.Elab

--- a/Mathlib/Tactic/ApplyRuleSets/Attr.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Attr.lean
@@ -22,9 +22,10 @@ initialize ruleSetsExt : SimpleScopedEnvExtension RuleSetExtEntry RuleSets ←
     addEntry := fun s e =>
       let rule := { e.rule with order := s.nextOrder }
       let rs := s.ruleSets.getD e.ruleSetName {}
-      let tree := e.keys.foldl (fun t (key, lazyEntry) =>
-        RefinedDiscrTree.insert t key (lazyEntry, rule)) rs.tree
-      let rs := { entries := rs.entries.push rule, tree := tree }
+      let refinedTree := e.refinedKeys.foldl (fun t (key, lazyEntry) =>
+        RefinedDiscrTree.insert t key (lazyEntry, rule)) rs.refinedTree
+      let discrTree := rs.discrTree.insertKeyValue e.discrPath rule
+      let rs := { entries := rs.entries.push rule, refinedTree, discrTree }
       { ruleSets := s.ruleSets.insert e.ruleSetName rs, nextOrder := s.nextOrder + 1 }
   }
 
@@ -42,7 +43,8 @@ def addTheoremRule (ruleSetName declName : Name) (kind : AttributeKind)
   let info ← getConstInfo declName
   let pattern := info.type
   let (_, _, conclusion) ← forallMetaTelescope pattern
-  let keys ← keysForPattern conclusion
+  let refinedKeys ← keysForPattern conclusion
+  let discrPath ← discrPathForPattern conclusion
   let value := mkConst declName (info.levelParams.map Level.param)
   let rule : Rule := {
     origin := .decl declName
@@ -53,7 +55,7 @@ def addTheoremRule (ruleSetName declName : Name) (kind : AttributeKind)
   }
   if rule.hasExprMVar then
     throwError "invalid theorem rule `{.ofConstName declName}` contains expression metavariables"
-  ruleSetsExt.add { ruleSetName, rule, keys } kind
+  ruleSetsExt.add { ruleSetName, rule, refinedKeys, discrPath } kind
   trace[Meta.Tactic.apply_rulesets.attr] "added theorem rule {declName} to {ruleSetName}"
 
 /-- Register a ruleproc in a ruleset. -/
@@ -73,7 +75,11 @@ def addProcRule (ruleSetName declName : Name) (kind : AttributeKind)
   }
   if rule.hasExprMVar then
     throwError "invalid ruleproc rule `{.ofConstName declName}` contains expression metavariables"
-  ruleSetsExt.add { ruleSetName, rule, keys := decl.keys } kind
+  ruleSetsExt.add {
+    ruleSetName := ruleSetName
+    rule := rule
+    refinedKeys := decl.refinedKeys
+    discrPath := decl.discrPath } kind
   trace[Meta.Tactic.apply_rulesets.attr] "added ruleproc {declName} to {ruleSetName}"
 
 /-- Register the theorem and proc attributes for a ruleset. -/

--- a/Mathlib/Tactic/ApplyRuleSets/Attr.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Attr.lean
@@ -1,0 +1,3 @@
+module
+
+public import Mathlib.Tactic.ApplyRuleSets.Elab

--- a/Mathlib/Tactic/ApplyRuleSets/Attr.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Attr.lean
@@ -1,3 +1,99 @@
+/-
+Copyright (c) 2026 Tomáš Skřivan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomáš Skřivan
+-/
 module
 
-public import Mathlib.Tactic.ApplyRuleSets.Elab
+public import Mathlib.Tactic.ApplyRuleSets.RuleProc
+
+public meta section
+
+namespace Mathlib
+namespace Tactic.ApplyRuleSets
+
+open Lean Meta Elab
+open Lean.Meta.RefinedDiscrTree
+
+initialize ruleSetsExt : SimpleScopedEnvExtension RuleSetExtEntry RuleSets ←
+  registerSimpleScopedEnvExtension {
+    name := by exact decl_name%
+    initial := {}
+    addEntry := fun s e =>
+      let rule := { e.rule with order := s.nextOrder }
+      let rs := s.ruleSets.getD e.ruleSetName {}
+      let tree := e.keys.foldl (fun t (key, lazyEntry) =>
+        RefinedDiscrTree.insert t key (lazyEntry, rule)) rs.tree
+      let rs := { entries := rs.entries.push rule, tree := tree }
+      { ruleSets := s.ruleSets.insert e.ruleSetName rs, nextOrder := s.nextOrder + 1 }
+  }
+
+/-- Return true if `name` is a registered ruleset. -/
+def isRuleSetName (name : Name) : CoreM Bool := do
+  return (ruleSetsExt.getState (← getEnv)).ruleSets.contains name
+
+/-- Get a registered ruleset. -/
+def getRuleSet (name : Name) : CoreM RuleSet := do
+  return (ruleSetsExt.getState (← getEnv)).ruleSets.getD name {}
+
+/-- Add a theorem to a ruleset. -/
+def addTheoremRule (ruleSetName declName : Name) (kind : AttributeKind)
+    (prio : Nat := eval_prio default) : MetaM Unit := do
+  let info ← getConstInfo declName
+  let pattern := info.type
+  let (_, _, conclusion) ← forallMetaTelescope pattern
+  let keys ← keysForPattern conclusion
+  let value := mkConst declName (info.levelParams.map Level.param)
+  let rule : Rule := {
+    origin := .decl declName
+    type := .expr value
+    pattern := pattern
+    levelParams := info.levelParams.toArray
+    priority := prio
+  }
+  ruleSetsExt.add { ruleSetName, rule, keys } kind
+  trace[Meta.Tactic.apply_rulesets.attr] "added theorem rule {declName} to {ruleSetName}"
+
+/-- Register a ruleproc in a ruleset. -/
+def addProcRule (ruleSetName declName : Name) (kind : AttributeKind)
+    (prio : Nat := eval_prio default) : MetaM Unit := do
+  let some decl ← getRuleProcDecl? declName
+    | throwError "invalid ruleproc attribute: `{.ofConstName declName}` has no registered pattern"
+  let some proc := decl.defaultProc?
+    | throwError "invalid ruleproc attribute: `{.ofConstName declName}` does not elaborate as a `RuleProc`; \
+      provide defaults for all ruleproc parameters before the comma"
+  let rule : Rule := {
+    origin := .decl declName
+    type := .proc proc
+    pattern := decl.pattern
+    levelParams := decl.levelParams
+    priority := prio
+  }
+  ruleSetsExt.add { ruleSetName, rule, keys := decl.keys } kind
+  trace[Meta.Tactic.apply_rulesets.attr] "added ruleproc {declName} to {ruleSetName}"
+
+/-- Register the theorem and proc attributes for a ruleset. -/
+def registerRuleSetAttr (ruleSetName : Name) (descr : String) : IO Unit := do
+  registerBuiltinAttribute {
+    name := ruleSetName
+    descr := descr
+    applicationTime := AttributeApplicationTime.afterCompilation
+    add := fun decl stx kind => discard <| MetaM.run do
+      let prio ← getAttrParamOptPrio stx[1]
+      if (← getRuleProcDecl? decl).isSome then
+        addProcRule ruleSetName decl kind prio
+      else
+        addTheoremRule ruleSetName decl kind prio
+    erase := fun _ => throwError "can't remove ruleset attributes"
+  }
+
+/-- Register a new ruleset and its associated attributes. -/
+macro (name := registerRulesetCmd) doc:(docComment)? "register_ruleset " id:ident : command => do
+  let str := id.getId.toString
+  let idParser := mkIdentFrom id (`Parser.Attr ++ id.getId)
+  let descr := quote ((doc.map (·.getDocString) |>.getD s!"ruleset {id.getId}").removeLeadingSpaces)
+  `($[$doc:docComment]? public meta initialize registerRuleSetAttr $(quote id.getId) $descr
+    $[$doc:docComment]? syntax (name := $idParser:ident) $(quote str):str (prio)? : attr)
+
+end Tactic.ApplyRuleSets
+end Mathlib

--- a/Mathlib/Tactic/ApplyRuleSets/Attr.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Attr.lean
@@ -62,8 +62,8 @@ def addProcRule (ruleSetName declName : Name) (kind : AttributeKind)
   let some decl ← getRuleProcDecl? declName
     | throwError "invalid ruleproc attribute: `{.ofConstName declName}` has no registered pattern"
   let some proc := decl.defaultProc?
-    | throwError "invalid ruleproc attribute: `{.ofConstName declName}` does not elaborate as a `RuleProc`; \
-      provide defaults for all ruleproc parameters before the comma"
+    | throwError "invalid ruleproc attribute: `{.ofConstName declName}` does not elaborate as a \
+      `RuleProc`; provide defaults for all ruleproc parameters before the comma"
   let rule : Rule := {
     origin := .decl declName
     type := .proc proc

--- a/Mathlib/Tactic/ApplyRuleSets/Attr.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Attr.lean
@@ -51,6 +51,8 @@ def addTheoremRule (ruleSetName declName : Name) (kind : AttributeKind)
     levelParams := info.levelParams.toArray
     priority := prio
   }
+  if rule.hasExprMVar then
+    throwError "invalid theorem rule `{.ofConstName declName}` contains expression metavariables"
   ruleSetsExt.add { ruleSetName, rule, keys } kind
   trace[Meta.Tactic.apply_rulesets.attr] "added theorem rule {declName} to {ruleSetName}"
 
@@ -69,6 +71,8 @@ def addProcRule (ruleSetName declName : Name) (kind : AttributeKind)
     levelParams := decl.levelParams
     priority := prio
   }
+  if rule.hasExprMVar then
+    throwError "invalid ruleproc rule `{.ofConstName declName}` contains expression metavariables"
   ruleSetsExt.add { ruleSetName, rule, keys := decl.keys } kind
   trace[Meta.Tactic.apply_rulesets.attr] "added ruleproc {declName} to {ruleSetName}"
 

--- a/Mathlib/Tactic/ApplyRuleSets/Core.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Core.lean
@@ -210,7 +210,7 @@ def successCacheIndex (goal : Goal) (proof : Expr) : ApplyRuleSetsM Nat := do
   return caches.size - 1
 
 def cacheSuccess (goal : Goal) (proof : Expr) : ApplyRuleSetsM Unit := do
-  let proof ← instantiateMVars proof
+  let proof ← withProfile `instantiateMVars <| instantiateMVars proof
   unless proof.hasExprMVar do
     let i ← successCacheIndex goal proof
     modifyGoalCacheAt i fun cache =>
@@ -255,20 +255,32 @@ def runAutoParam? (goalType : Expr) : ApplyRuleSetsM (Option Expr) :=
 /-- Query selected rulesets for candidates matching `goalType`. -/
 def takeRuleSetTree (rsName : Name) : ApplyRuleSetsM (RefinedDiscrTree Rule) := do
   let tree? ← modifyGet fun s =>
-    (s.ruleSetTrees.get? rsName,
-      { s with ruleSetTrees := s.ruleSetTrees.alter rsName fun _ => none })
-  return tree?.getD (← getRuleSet rsName).tree
+    (s.refinedRuleSetTrees.get? rsName,
+      { s with refinedRuleSetTrees := s.refinedRuleSetTrees.alter rsName fun _ => none })
+  return tree?.getD (← getRuleSet rsName).refinedTree
+
+def queryRuleSetRefined (goalType : Expr) (rsName : Name) : ApplyRuleSetsM (Array Rule) := do
+  let tree ← takeRuleSetTree rsName
+  let (result, tree) ← withProfile `refinedDiscrTree.getMatch <|
+    withConfig (fun cfg => { cfg with iota := false, zeta := false }) <|
+      tree.getMatch goalType true true
+  modify fun s =>
+    { s with refinedRuleSetTrees := s.refinedRuleSetTrees.alter rsName fun _ => some tree }
+  return result.toArray
+
+def queryRuleSetPlain (goalType : Expr) (rsName : Name) : ApplyRuleSetsM (Array Rule) := do
+  withProfile `discrTree.getMatch do
+    return ← (← getRuleSet rsName).discrTree.getMatch goalType
 
 def queryRuleSets (goalType : Expr) (rulesets : Array Name) : ApplyRuleSetsM (Array Rule) := do
   let mut out := #[]
   for rsName in rulesets do
-    let tree ← takeRuleSetTree rsName
-    let (result, tree) ← withProfile `discrTree.getMatch <|
-      withConfig (fun cfg => { cfg with iota := false, zeta := false }) <|
-        tree.getMatch goalType true true
-    modify fun s =>
-      { s with ruleSetTrees := s.ruleSetTrees.alter rsName fun _ => some tree }
-    out := out ++ result.toArray
+    let result ←
+      if (← read).config.useRefinedDiscrTree then
+        queryRuleSetRefined goalType rsName
+      else
+        queryRuleSetPlain goalType rsName
+    out := out ++ result
   return out
 
 /-- Sort candidates by priority, explicitness, and insertion order. -/
@@ -289,8 +301,8 @@ def Rule.instantiate (rule : Rule) : MetaM (RuleType × Expr) := do
   return (type, pattern)
 
 def matchRuleConclusion (_rule : Rule) (conclusion goal : Expr) : ApplyRuleSetsM Bool := do
-  let conclusion ← instantiateMVars conclusion
-  let goal ← instantiateMVars goal
+  let conclusion ← withProfile `instantiateMVars <| instantiateMVars conclusion
+  let goal ← withProfile `instantiateMVars <| instantiateMVars goal
   withProfile `isDefEq <|
     withTransparency (← read).config.transparency <| isDefEq conclusion goal
 
@@ -300,6 +312,7 @@ mutual
 partial def assumption? (origin : ArgOrigin) (goalType : Expr) : ApplyRuleSetsM (Option Expr) := do
   unless ← withProfile `isProp <| isProp goalType do
     return none
+  withProfile `assumption do
   for localDecl in ← getLCtx do
     unless localDecl.isAuxDecl do
       if ← withProfile `isProp <| isProp localDecl.type then
@@ -312,7 +325,7 @@ partial def assumption? (origin : ArgOrigin) (goalType : Expr) : ApplyRuleSetsM 
             type := .expr (.fvar localDecl.fvarId)
           }
           let goal ← withProfile `goal.mk <| mkGoal goalType
-          if let some r ← tryRule? origin goal rule then
+          if let some r ← withoutChargingCurrentTimer <| tryRule? origin goal rule then
             return r
   return none
 
@@ -491,18 +504,18 @@ partial def tryRule? (origin : ArgOrigin) (goal : Goal) (rule : Rule) :
   | .expr expr =>
     unless ← synthesizeArgs rule.name args do
       return none
-    let proof ← withProfile `mkApp <| instantiateMVars (mkAppN expr args)
+    let proof ← withProfile `instantiateMVars <| instantiateMVars (mkAppN expr args)
     return some proof
   | .proc procExpr =>
     unless ← synthesizeArgs rule.name args (allowPostponed := true) do
       trace[Meta.Tactic.apply_rulesets]
         "failed to synthesize ruleproc arguments for {rule.name}"
       return none
-    let args ← args.mapM instantiateMVars
+    let args ← withProfile `instantiateMVars <| args.mapM instantiateMVars
     let proc ← withProfile `ruleproc.eval <| evalRuleProc procExpr
     let some proof ← withProfile `ruleproc.run <| proc args origin goalType
       | trace[Meta.Tactic.apply_rulesets] "ruleproc {rule.name} returned none"; return none
-    let proofType ← inferType proof
+    let proofType ← withProfile `inferType <| inferType proof
     let ok ← withProfile `isDefEq <|
       withTransparency (← read).config.transparency <| isDefEq proofType goalType
     unless ok do

--- a/Mathlib/Tactic/ApplyRuleSets/Core.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Core.lean
@@ -54,14 +54,21 @@ def currentGoalCache? : ApplyRuleSetsM (Option GoalCache) := do
   let caches := (← get).goalCaches
   return caches.back?
 
-def cacheCurrentFailure (goal : Goal) : ApplyRuleSetsM Unit := do
+def modifyGoalCacheAt (i : Nat) (f : GoalCache → GoalCache) : ApplyRuleSetsM Unit := do
   modify fun s =>
-    let i := s.goalCaches.size - 1
     if h : i < s.goalCaches.size then
-      let cache := { s.goalCaches[i] with failures := s.goalCaches[i].failures.insert goal }
-      { s with goalCaches := s.goalCaches.set i cache }
+      { s with goalCaches := s.goalCaches.set i (f s.goalCaches[i]) }
     else
       s
+
+def modifyCurrentGoalCache (f : GoalCache → GoalCache) : ApplyRuleSetsM Unit := do
+  let caches := (← get).goalCaches
+  unless caches.isEmpty do
+    modifyGoalCacheAt (caches.size - 1) f
+
+def cacheCurrentFailure (goal : Goal) : ApplyRuleSetsM Unit := do
+  modifyCurrentGoalCache fun cache =>
+    { cache with failures := cache.failures.insert goal }
 
 def containsCurrentFailure (goal : Goal) : ApplyRuleSetsM Bool := do
   return (← currentGoalCache?).any (·.failures.contains goal)
@@ -84,6 +91,8 @@ def maxLocalIndex? (es : Array Expr) : MetaM (Option Nat) := do
 def successCacheIndex (goal : Goal) (proof : Expr) : ApplyRuleSetsM Nat := do
   let maxIdx? ← maxLocalIndex? #[goal.expr, proof]
   let caches := (← get).goalCaches
+  if caches.isEmpty then
+    return 0
   let some maxIdx := maxIdx? | return 0
   for h : i in [:caches.size] do
     if maxIdx < caches[i].minLctxIndex then
@@ -94,12 +103,8 @@ def cacheSuccess (goal : Goal) (proof : Expr) : ApplyRuleSetsM Unit := do
   let proof ← instantiateMVars proof
   unless proof.hasExprMVar do
     let i ← successCacheIndex goal proof
-    modify fun s =>
-      if h : i < s.goalCaches.size then
-        let cache := { s.goalCaches[i] with successes := s.goalCaches[i].successes.insert goal proof }
-        { s with goalCaches := s.goalCaches.set i cache }
-      else
-        s
+    modifyGoalCacheAt i fun cache =>
+      { cache with successes := cache.successes.insert goal proof }
 
 def mkGoal (e : Expr) : MetaM Goal := do
   let r ← abstractMVars (← instantiateMVars e)
@@ -200,7 +205,7 @@ partial def assumption? (origin : ArgOrigin) (goalType : Expr) : ApplyRuleSetsM 
 partial def applyRuleSets (origin : ArgOrigin) (goalType : Expr) :
     ApplyRuleSetsM (Option Expr) := do
   if let some r ← applyRuleSetsGoal origin (← mkGoal goalType) then
-    if ← isDefEq goalType (← inferType r) then
+    if ← withTransparency (← read).config.transparency <| isDefEq goalType (← inferType r) then
       return r
     else
       return none
@@ -266,6 +271,54 @@ partial def applyRuleSetsGoalCore (origin : ArgOrigin) (goal : Goal) (goalType :
   trace[Meta.Tactic.apply_rulesets] "no rule matched"
   return none
 
+partial def synthesizeInstanceArg? (ruleName : Name) (arg type : Expr) : ApplyRuleSetsM Bool := do
+  unless (← isClass? type).isSome do
+    return false
+  if let .some inst ← trySynthInstance type then
+    if ← isDefEq arg inst then
+      return true
+    trace[Meta.Tactic.apply_rulesets]
+      "{ruleName}, failed to assign instance{indentExpr type}\
+      \nsynthesized value{indentExpr inst}\nis not definitionally equal to{indentExpr arg}"
+  else
+    trace[Meta.Tactic.apply_rulesets]
+      "{ruleName}, failed to synthesize instance{indentExpr type}"
+  return false
+
+partial def synthesizeProofArg? (ruleName : Name) (argIndex : Nat) (arg type : Expr) :
+    ApplyRuleSetsM Bool := do
+  unless ← isProp type do
+    return false
+  let argName := (← getMCtx).getDecl arg.mvarId! |>.userName
+  let origin := { ruleName, argIndex := some argIndex, argName := some argName }
+  if let some proof ← withIncreasedSearchDepth <| applyRuleSets origin type then
+    if ← isDefEq arg proof then
+      return true
+    trace[Meta.Tactic.apply_rulesets]
+      "{ruleName}, failed to assign proof{indentExpr type}"
+  let ctx ← read
+  if let some proof ← ctx.disch origin type then
+    if ← isDefEq arg proof then
+      return true
+    trace[Meta.Tactic.apply_rulesets]
+      "{ruleName}, failed to assign discharger proof{indentExpr type}"
+  trace[Meta.Tactic.apply_rulesets]
+    "{ruleName}, failed to discharge hypothesis{indentExpr type}"
+  addFailedSubgoal arg
+  return true
+
+partial def checkPostponedArgs (ruleName : Name) (args : Array Expr) (allowPostponed : Bool) :
+    ApplyRuleSetsM Bool := do
+  let mut success := true
+  for arg in args do
+    if (← instantiateMVars arg).isMVar then
+      if allowPostponed then
+        continue
+      trace[Meta.Tactic.apply_rulesets]
+        "{ruleName}, failed to infer `({← ppExpr arg} : {← ppExpr (← inferType arg)})`"
+      success := false
+  return success
+
 /-- Synthesize arguments created by theorem or ruleproc application. -/
 partial def synthesizeArgs (ruleName : Name) (args : Array Expr)
     (allowPostponed := false) : ApplyRuleSetsM Bool := do
@@ -275,49 +328,16 @@ partial def synthesizeArgs (ruleName : Name) (args : Array Expr)
     let arg := args[i]
     if (← instantiateMVars arg).isMVar then
       let type ← inferType arg
-      if (← isClass? type).isSome then
-        if let .some inst ← trySynthInstance type then
-          if (← isDefEq arg inst) then
-            continue
-          else
-            trace[Meta.Tactic.apply_rulesets]
-              "{ruleName}, failed to assign instance{indentExpr type}\
-              \nsynthesized value{indentExpr inst}\nis not definitionally equal to{indentExpr arg}"
-        else
-          trace[Meta.Tactic.apply_rulesets]
-            "{ruleName}, failed to synthesize instance{indentExpr type}"
-      if (← isProp type) then
-        let argName := (← getMCtx).getDecl arg.mvarId! |>.userName
-        let origin := { ruleName, argIndex := some i, argName := some argName }
-        if let some proof ← withIncreasedSearchDepth <| applyRuleSets origin type then
-          if (← isDefEq arg proof) then
-            continue
-          else
-            trace[Meta.Tactic.apply_rulesets]
-              "{ruleName}, failed to assign proof{indentExpr type}"
-        let ctx ← read
-        if let some proof ← ctx.disch origin type then
-          if (← isDefEq arg proof) then
-            continue
-          else
-            trace[Meta.Tactic.apply_rulesets]
-              "{ruleName}, failed to assign discharger proof{indentExpr type}"
-        trace[Meta.Tactic.apply_rulesets]
-          "{ruleName}, failed to discharge hypothesis{indentExpr type}"
-        addFailedSubgoal arg
-        success := false
+      if ← synthesizeInstanceArg? ruleName arg type then
         continue
-      else
-        postponed := postponed.push arg
-  for arg in postponed do
-    if (← instantiateMVars arg).isMVar then
-      if allowPostponed then
+      if ← isProp type then
+        unless ← synthesizeProofArg? ruleName i arg type do
+          postponed := postponed.push arg
+        if (← instantiateMVars arg).isMVar then
+          success := false
         continue
-      trace[Meta.Tactic.apply_rulesets]
-        "{ruleName}, failed to infer `({← ppExpr arg} : {← ppExpr (← inferType arg)})`"
-      success := false
-      continue
-  return success
+      postponed := postponed.push arg
+  return success && (← checkPostponedArgs ruleName postponed allowPostponed)
 
 partial def tryRule? (origin : ArgOrigin) (goal : Goal) (rule : Rule) :
     ApplyRuleSetsM (Option Expr) := do

--- a/Mathlib/Tactic/ApplyRuleSets/Core.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Core.lean
@@ -1,0 +1,3 @@
+module
+
+public import Mathlib.Tactic.ApplyRuleSets.Elab

--- a/Mathlib/Tactic/ApplyRuleSets/Core.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Core.lean
@@ -72,6 +72,28 @@ def withProfile {α} (op : Name) (x : ApplyRuleSetsM α) : ApplyRuleSetsM α := 
     profileExit
     throw e
 
+/-- Run `x` without charging its elapsed time to the currently active profile timer.
+
+Nested `withProfile` calls inside `x` are still recorded. This is used at public recursive-search
+entry points so callers such as ruleprocs are not charged for delegated `apply_rulesets` search. -/
+def withoutChargingCurrentTimer {α} (x : ApplyRuleSetsM α) : ApplyRuleSetsM α := do
+  let profile := (← get).profile
+  unless profile.enabled && !profile.stack.isEmpty do
+    return ← x
+  let now ← IO.monoNanosNow
+  profileChargeCurrent now
+  let oldStack := profile.stack
+  modify fun s => { s with profile := { s.profile with stack := [], lastNanos := now } }
+  try
+    let a ← x
+    let finish ← IO.monoNanosNow
+    modify fun s => { s with profile := { s.profile with stack := oldStack, lastNanos := finish } }
+    return a
+  catch e =>
+    let finish ← IO.monoNanosNow
+    modify fun s => { s with profile := { s.profile with stack := oldStack, lastNanos := finish } }
+    throw e
+
 def initProfileState : MetaM ProfileState := do
   let now ← IO.monoNanosNow
   return { enabled := true, startNanos := now, lastNanos := now }
@@ -295,6 +317,10 @@ partial def assumption? (origin : ArgOrigin) (goalType : Expr) : ApplyRuleSetsM 
   return none
 
 partial def applyRuleSets (origin : ArgOrigin) (goalType : Expr) :
+    ApplyRuleSetsM (Option Expr) :=
+  withoutChargingCurrentTimer <| applyRuleSetsCoreSearch origin goalType
+
+partial def applyRuleSetsCoreSearch (origin : ArgOrigin) (goalType : Expr) :
     ApplyRuleSetsM (Option Expr) := do
   let goal ← withProfile `goal.mk <| mkGoal goalType
   if let some r ← applyRuleSetsGoal origin goal then
@@ -349,7 +375,7 @@ partial def applyRuleSetsGoalCore (origin : ArgOrigin) (goal : Goal) (goalType :
         return none
       trace[Meta.Tactic.apply_rulesets] "introducing {xs.size} binder(s)"
       let some proof ← withIncreasedSearchDepth <| withIncreasedCacheDepth <|
-        applyRuleSets origin body | return none
+        applyRuleSetsCoreSearch origin body | return none
       return some (← withProfile `mkLambdaFVars <| mkLambdaFVars xs proof)
       | pure ()
     return some proof
@@ -387,7 +413,7 @@ partial def synthesizeProofArg? (ruleName : Name) (argIndex : Nat) (arg type : E
     return false
   let argName := (← getMCtx).getDecl arg.mvarId! |>.userName
   let origin := { ruleName, argIndex := some argIndex, argName := some argName }
-  if let some proof ← withIncreasedSearchDepth <| applyRuleSets origin type then
+  if let some proof ← withIncreasedSearchDepth <| applyRuleSetsCoreSearch origin type then
     if ← withProfile `isDefEq <| isDefEq arg proof then
       return true
     trace[Meta.Tactic.apply_rulesets]
@@ -474,7 +500,7 @@ partial def tryRule? (origin : ArgOrigin) (goal : Goal) (rule : Rule) :
       return none
     let args ← args.mapM instantiateMVars
     let proc ← withProfile `ruleproc.eval <| evalRuleProc procExpr
-    let some proof ← proc args origin goalType
+    let some proof ← withProfile `ruleproc.run <| proc args origin goalType
       | trace[Meta.Tactic.apply_rulesets] "ruleproc {rule.name} returned none"; return none
     let proofType ← inferType proof
     let ok ← withProfile `isDefEq <|

--- a/Mathlib/Tactic/ApplyRuleSets/Core.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Core.lean
@@ -37,17 +37,78 @@ def withIncreasedSearchDepth {α} (x : ApplyRuleSetsM α) : ApplyRuleSetsM α :=
     modify fun s => { s with depth := depth }
     throw e
 
-/-- Roll back metavariable assignments if `x` returns `none` or throws. -/
-def observingWithRollback? {α} (x : ApplyRuleSetsM (Option α)) : ApplyRuleSetsM (Option α) := do
-  let mctx ← getMCtx
+def withIncreasedCacheDepth {α} (x : ApplyRuleSetsM α) : ApplyRuleSetsM α := do
+  let oldSize := (← get).goalCaches.size
+  let minLctxIndex := (← getLCtx).numIndices
+  modify fun s =>
+    { s with goalCaches := s.goalCaches.push { minLctxIndex } }
   try
-    match ← x with
-    | some a => return some a
-    | none => setMCtx mctx; return none
+    let a ← x
+    modify fun s => { s with goalCaches := s.goalCaches.extract 0 oldSize }
+    return a
   catch e =>
-    trace[Meta.Tactic.apply_rulesets] "candidate failed: {e.toMessageData}"
-    setMCtx mctx
-    return none
+    modify fun s => { s with goalCaches := s.goalCaches.extract 0 oldSize }
+    throw e
+
+def currentGoalCache? : ApplyRuleSetsM (Option GoalCache) := do
+  let caches := (← get).goalCaches
+  return caches.back?
+
+def cacheCurrentFailure (goal : Goal) : ApplyRuleSetsM Unit := do
+  modify fun s =>
+    let i := s.goalCaches.size - 1
+    if h : i < s.goalCaches.size then
+      let cache := { s.goalCaches[i] with failures := s.goalCaches[i].failures.insert goal }
+      { s with goalCaches := s.goalCaches.set i cache }
+    else
+      s
+
+def containsCurrentFailure (goal : Goal) : ApplyRuleSetsM Bool := do
+  return (← currentGoalCache?).any (·.failures.contains goal)
+
+def findCachedSuccess? (goal : Goal) : ApplyRuleSetsM (Option Expr) := do
+  for cache in (← get).goalCaches.reverse do
+    if let some proof := cache.successes.get? goal then
+      return some proof
+  return none
+
+def maxLocalIndex? (es : Array Expr) : MetaM (Option Nat) := do
+  let lctx ← getLCtx
+  let mut max? := none
+  for e in es do
+    for fvarId in (Lean.collectFVars {} e).fvarIds do
+      if let some decl := lctx.find? fvarId then
+        max? := some <| max (max?.getD 0) decl.index
+  return max?
+
+def successCacheIndex (goal : Goal) (proof : Expr) : ApplyRuleSetsM Nat := do
+  let maxIdx? ← maxLocalIndex? #[goal.expr, proof]
+  let caches := (← get).goalCaches
+  let some maxIdx := maxIdx? | return 0
+  for h : i in [:caches.size] do
+    if maxIdx < caches[i].minLctxIndex then
+      return i
+  return caches.size - 1
+
+def cacheSuccess (goal : Goal) (proof : Expr) : ApplyRuleSetsM Unit := do
+  let proof ← instantiateMVars proof
+  unless proof.hasExprMVar do
+    let i ← successCacheIndex goal proof
+    modify fun s =>
+      if h : i < s.goalCaches.size then
+        let cache := { s.goalCaches[i] with successes := s.goalCaches[i].successes.insert goal proof }
+        { s with goalCaches := s.goalCaches.set i cache }
+      else
+        s
+
+def mkGoal (e : Expr) : MetaM Goal := do
+  let r ← abstractMVars (← instantiateMVars e)
+  let expr ← lambdaTelescope r.expr fun xs body => mkForallFVars xs body
+  return { expr, numOutputs := r.numMVars }
+
+def Goal.open {α} (goal : Goal) (k : Array Expr → Expr → MetaM α) : MetaM α := do
+  let (outputs, _, body) ← forallMetaTelescopeReducing goal.expr (some goal.numOutputs)
+  k outputs body
 
 /-- Run the tactic embedded in an `autoParam` goal. -/
 def runAutoParam? (goalType : Expr) : MetaM (Option Expr) := do
@@ -132,15 +193,41 @@ partial def assumption? (origin : ArgOrigin) (goalType : Expr) : ApplyRuleSetsM 
             pattern := localDecl.type
             type := .expr (.fvar localDecl.fvarId)
           }
-          if let some r ← tryRule? origin goalType rule then
+          if let some r ← tryRule? origin (← mkGoal goalType) rule then
             return r
   return none
 
 partial def applyRuleSets (origin : ArgOrigin) (goalType : Expr) :
     ApplyRuleSetsM (Option Expr) := do
-  let goalType ← instantiateMVars goalType
+  if let some r ← applyRuleSetsGoal origin (← mkGoal goalType) then
+    if ← isDefEq goalType (← inferType r) then
+      return r
+    else
+      return none
+  else
+    return none
+
+partial def applyRuleSetsGoal (origin : ArgOrigin) (goal : Goal) :
+    ApplyRuleSetsM (Option Expr) := do
+  let goalType ← goal.open fun _ goalType => pure goalType
   withTraceNode `Meta.Tactic.apply_rulesets
     (fun _ => return s!"{← ppExpr goalType}") do
+  if ← containsCurrentFailure goal then
+    trace[Meta.Tactic.apply_rulesets] "failed goal cache hit"
+    return none
+  if let some proof ← findCachedSuccess? goal then
+    trace[Meta.Tactic.apply_rulesets] "successful goal cache hit"
+    return some proof
+  match ← applyRuleSetsGoalCore origin goal goalType with
+  | some proof =>
+    cacheSuccess goal proof
+    return some proof
+  | none =>
+    cacheCurrentFailure goal
+    return none
+
+partial def applyRuleSetsGoalCore (origin : ArgOrigin) (goal : Goal) (goalType : Expr) :
+    ApplyRuleSetsM (Option Expr) := do
   checkStep
   let depth := (← get).depth
   let maxDepth := (← read).config.maxDepth
@@ -149,19 +236,20 @@ partial def applyRuleSets (origin : ArgOrigin) (goalType : Expr) :
     return none
   let cfg := (← read).config
   if cfg.autoParam then
-    if let some proof ← observingWithRollback? <| runAutoParam? goalType then
+    if let some proof ← runAutoParam? goalType then
       trace[Meta.Tactic.apply_rulesets] "solved by autoParam tactic"
       return some proof
   if cfg.assumption then
-    if let some proof ← observingWithRollback? <| assumption? origin goalType then
+    if let some proof ← assumption? origin goalType then
       trace[Meta.Tactic.apply_rulesets] "solved by local assumption"
       return some proof
   if cfg.intro then
-    let some proof ← observingWithRollback? <| forallTelescopeReducing goalType fun xs body => do
+    let some proof ← forallTelescopeReducing goalType fun xs body => do
       if xs.isEmpty then
         return none
       trace[Meta.Tactic.apply_rulesets] "introducing {xs.size} binder(s)"
-      let some proof ← withIncreasedSearchDepth <| applyRuleSets origin body | return none
+      let some proof ← withIncreasedSearchDepth <| withIncreasedCacheDepth <|
+        applyRuleSets origin body | return none
       return some (← mkLambdaFVars xs proof)
       | pure ()
     return some proof
@@ -169,11 +257,11 @@ partial def applyRuleSets (origin : ArgOrigin) (goalType : Expr) :
   trace[Meta.Tactic.apply_rulesets]
     "candidate rules: {rules.map fun rule => rule.name}"
   for rule in (← read).explicitRules do
-    if let some proof ← observingWithRollback? <| tryRule? origin goalType rule then
+    if let some proof ← tryRule? origin goal rule then
       return some proof
   for rule in rules do
     unless (← read).erased.contains rule.name do
-      if let some proof ← observingWithRollback? <| tryRule? origin goalType rule then
+      if let some proof ← tryRule? origin goal rule then
         return some proof
   trace[Meta.Tactic.apply_rulesets] "no rule matched"
   return none
@@ -231,7 +319,7 @@ partial def synthesizeArgs (ruleName : Name) (args : Array Expr)
       continue
   return success
 
-partial def tryRule? (origin : ArgOrigin) (goalType : Expr) (rule : Rule) :
+partial def tryRule? (origin : ArgOrigin) (goal : Goal) (rule : Rule) :
     ApplyRuleSetsM (Option Expr) := do
   let action := match rule.origin with
     | .decl .. =>
@@ -246,6 +334,10 @@ partial def tryRule? (origin : ArgOrigin) (goalType : Expr) (rule : Rule) :
   if (← read).erased.contains rule.name then
     trace[Meta.Tactic.apply_rulesets] "rule is erased"
     return none
+  if rule.hasExprMVar then
+    trace[Meta.Tactic.apply_rulesets] "rule contains expression metavariables"
+    return none
+  let goalType ← goal.open fun _ goalType => pure goalType
   let (ruleType, pattern) ← rule.instantiate
   let (args, _, conclusion) ← forallMetaTelescope pattern
   let ok ← matchRuleConclusion rule conclusion goalType
@@ -277,9 +369,6 @@ partial def tryRule? (origin : ArgOrigin) (goalType : Expr) (rule : Rule) :
     return some proof
 
 end
-
-/-- Backward-search using the active rule sets. Alias for `applyRuleSets`. -/
-abbrev appluRuleSets := applyRuleSets
 
 end Tactic.ApplyRuleSets
 end Mathlib

--- a/Mathlib/Tactic/ApplyRuleSets/Core.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Core.lean
@@ -1,3 +1,285 @@
+/-
+Copyright (c) 2026 Tomáš Skřivan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomáš Skřivan
+-/
 module
 
-public import Mathlib.Tactic.ApplyRuleSets.Elab
+public meta import Mathlib.Lean.Meta.RefinedDiscrTree.Lookup
+public import Lean.Elab.Tactic.ElabTerm
+public import Lean.Meta.Tactic.ExposeNames
+public import Mathlib.Tactic.ApplyRuleSets.Attr
+
+public meta section
+
+namespace Mathlib
+namespace Tactic.ApplyRuleSets
+
+open Lean Meta Elab Tactic
+
+/-- Increase and check step count. -/
+def checkStep : ApplyRuleSetsM Unit := do
+  let n := (← get).numSteps
+  let maxSteps := (← read).config.maxSteps
+  if n ≥ maxSteps then
+    throwError "apply_rulesets failed, maximum number of steps ({maxSteps}) exceeded"
+  modify fun s => { s with numSteps := s.numSteps + 1 }
+
+/-- Increase the logical search depth without introducing a new metavariable depth. -/
+def withIncreasedSearchDepth {α} (x : ApplyRuleSetsM α) : ApplyRuleSetsM α := do
+  let depth := (← get).depth
+  modify fun s => { s with depth := depth + 1 }
+  try
+    let a ← x
+    modify fun s => { s with depth := depth }
+    return a
+  catch e =>
+    modify fun s => { s with depth := depth }
+    throw e
+
+/-- Roll back metavariable assignments if `x` returns `none` or throws. -/
+def observingWithRollback? {α} (x : ApplyRuleSetsM (Option α)) : ApplyRuleSetsM (Option α) := do
+  let mctx ← getMCtx
+  try
+    match ← x with
+    | some a => return some a
+    | none => setMCtx mctx; return none
+  catch e =>
+    trace[Meta.Tactic.apply_rulesets] "candidate failed: {e.toMessageData}"
+    setMCtx mctx
+    return none
+
+/-- Run the tactic embedded in an `autoParam` goal. -/
+def runAutoParam? (goalType : Expr) : MetaM (Option Expr) := do
+  let some (.const tacticDecl _) := goalType.getAutoParamTactic?
+    | return none
+  let goalType := goalType.appFn!.appArg!
+  let .ok tacticSyntax := evalSyntaxConstant (← getEnv) (← getOptions) tacticDecl
+    | return none
+  let tacticSeq : TSyntax `Lean.Parser.Tactic.tacticSeq := ⟨tacticSyntax⟩
+  let tacticCode ← `(tactic| try ($tacticSeq:tacticSeq))
+  let mvar ← mkFreshExprSyntheticOpaqueMVar goalType `apply_rulesets.autoParam
+  let runTac? : TermElabM (Option Expr) := do
+    try
+      Term.withoutModifyingElabMetaStateWithInfo do
+        Term.withSynthesize (postpone := .no) do
+          discard <| Tactic.run mvar.mvarId! <|
+            Tactic.evalTactic tacticCode *> Tactic.pruneSolvedGoals
+        let result ← instantiateMVars mvar
+        if result.hasExprMVar then
+          return none
+        else
+          return some result
+    catch _ =>
+      return none
+  let (result?, _) ← runTac?.run {} {}
+  return result?
+
+/-- Query selected rulesets for candidates matching `goalType`. -/
+def takeRuleSetTree (rsName : Name) : ApplyRuleSetsM (RefinedDiscrTree Rule) := do
+  let tree? ← modifyGet fun s =>
+    (s.ruleSetTrees.get? rsName,
+      { s with ruleSetTrees := s.ruleSetTrees.alter rsName fun _ => none })
+  return tree?.getD (← getRuleSet rsName).tree
+
+def queryRuleSets (goalType : Expr) (rulesets : Array Name) : ApplyRuleSetsM (Array Rule) := do
+  let mut out := #[]
+  for rsName in rulesets do
+    let tree ← takeRuleSetTree rsName
+    let (result, tree) ← withConfig (fun cfg => { cfg with iota := false, zeta := false }) <|
+      tree.getMatch goalType true true
+    modify fun s =>
+      { s with ruleSetTrees := s.ruleSetTrees.alter rsName fun _ => some tree }
+    out := out ++ result.toArray
+  return out
+
+/-- Sort candidates by priority, explicitness, and insertion order. -/
+def sortRules (rules : Array Rule) : Array Rule :=
+  rules.qsort fun a b =>
+    if a.priority != b.priority then
+      a.priority > b.priority
+    else
+      a.order < b.order
+
+def Rule.instantiate (rule : Rule) : MetaM (RuleType × Expr) := do
+  let levelParams := rule.allLevelParams
+  let us ← levelParams.mapM fun _ => mkFreshLevelMVar
+  let pattern := rule.pattern.instantiateLevelParamsArray levelParams us
+  let type := match rule.type with
+    | .expr proof => .expr (proof.instantiateLevelParamsArray levelParams us)
+    | .proc proc => .proc (proc.instantiateLevelParamsArray levelParams us)
+  return (type, pattern)
+
+def matchRuleConclusion (_rule : Rule) (conclusion goal : Expr) : ApplyRuleSetsM Bool := do
+  let conclusion ← instantiateMVars conclusion
+  let goal ← instantiateMVars goal
+  withTransparency (← read).config.transparency <| isDefEq conclusion goal
+
+mutual
+
+/-- Try to solve a proposition goal by a local hypothesis. -/
+partial def assumption? (origin : ArgOrigin) (goalType : Expr) : ApplyRuleSetsM (Option Expr) := do
+  unless ← isProp goalType do
+    return none
+  for localDecl in ← getLCtx do
+    unless localDecl.isAuxDecl do
+      if ← isProp localDecl.type then
+        if ← isDefEq localDecl.type goalType then
+          return some (mkFVar localDecl.fvarId)
+        if localDecl.type.isForall then
+          let rule : Rule := {
+            origin := .fvar localDecl.fvarId
+            pattern := localDecl.type
+            type := .expr (.fvar localDecl.fvarId)
+          }
+          if let some r ← tryRule? origin goalType rule then
+            return r
+  return none
+
+partial def applyRuleSets (origin : ArgOrigin) (goalType : Expr) :
+    ApplyRuleSetsM (Option Expr) := do
+  let goalType ← instantiateMVars goalType
+  withTraceNode `Meta.Tactic.apply_rulesets
+    (fun _ => return s!"{← ppExpr goalType}") do
+  checkStep
+  let depth := (← get).depth
+  let maxDepth := (← read).config.maxDepth
+  if depth > maxDepth then
+    trace[Meta.Tactic.apply_rulesets] "maximum recursion depth ({maxDepth}) exceeded"
+    return none
+  let cfg := (← read).config
+  if cfg.autoParam then
+    if let some proof ← observingWithRollback? <| runAutoParam? goalType then
+      trace[Meta.Tactic.apply_rulesets] "solved by autoParam tactic"
+      return some proof
+  if cfg.assumption then
+    if let some proof ← observingWithRollback? <| assumption? origin goalType then
+      trace[Meta.Tactic.apply_rulesets] "solved by local assumption"
+      return some proof
+  if cfg.intro then
+    let some proof ← observingWithRollback? <| forallTelescopeReducing goalType fun xs body => do
+      if xs.isEmpty then
+        return none
+      trace[Meta.Tactic.apply_rulesets] "introducing {xs.size} binder(s)"
+      let some proof ← withIncreasedSearchDepth <| applyRuleSets origin body | return none
+      return some (← mkLambdaFVars xs proof)
+      | pure ()
+    return some proof
+  let rules := sortRules (← queryRuleSets goalType (← read).rulesets)
+  trace[Meta.Tactic.apply_rulesets]
+    "candidate rules: {rules.map fun rule => rule.name}"
+  for rule in (← read).explicitRules do
+    if let some proof ← observingWithRollback? <| tryRule? origin goalType rule then
+      return some proof
+  for rule in rules do
+    unless (← read).erased.contains rule.name do
+      if let some proof ← observingWithRollback? <| tryRule? origin goalType rule then
+        return some proof
+  trace[Meta.Tactic.apply_rulesets] "no rule matched"
+  return none
+
+/-- Synthesize arguments created by theorem or ruleproc application. -/
+partial def synthesizeArgs (ruleName : Name) (args : Array Expr)
+    (allowPostponed := false) : ApplyRuleSetsM Bool := do
+  let mut success := true
+  let mut postponed := #[]
+  for h : i in [:args.size] do
+    let arg := args[i]
+    if (← instantiateMVars arg).isMVar then
+      let type ← inferType arg
+      if (← isClass? type).isSome then
+        if let .some inst ← trySynthInstance type then
+          if (← isDefEq arg inst) then
+            continue
+          else
+            trace[Meta.Tactic.apply_rulesets]
+              "{ruleName}, failed to assign instance{indentExpr type}\
+              \nsynthesized value{indentExpr inst}\nis not definitionally equal to{indentExpr arg}"
+        else
+          trace[Meta.Tactic.apply_rulesets]
+            "{ruleName}, failed to synthesize instance{indentExpr type}"
+      if (← isProp type) then
+        let argName := (← getMCtx).getDecl arg.mvarId! |>.userName
+        let origin := { ruleName, argIndex := some i, argName := some argName }
+        if let some proof ← withIncreasedSearchDepth <| applyRuleSets origin type then
+          if (← isDefEq arg proof) then
+            continue
+          else
+            trace[Meta.Tactic.apply_rulesets]
+              "{ruleName}, failed to assign proof{indentExpr type}"
+        let ctx ← read
+        if let some proof ← ctx.disch origin type then
+          if (← isDefEq arg proof) then
+            continue
+          else
+            trace[Meta.Tactic.apply_rulesets]
+              "{ruleName}, failed to assign discharger proof{indentExpr type}"
+        trace[Meta.Tactic.apply_rulesets]
+          "{ruleName}, failed to discharge hypothesis{indentExpr type}"
+        addFailedSubgoal arg
+        success := false
+        continue
+      else
+        postponed := postponed.push arg
+  for arg in postponed do
+    if (← instantiateMVars arg).isMVar then
+      if allowPostponed then
+        continue
+      trace[Meta.Tactic.apply_rulesets]
+        "{ruleName}, failed to infer `({← ppExpr arg} : {← ppExpr (← inferType arg)})`"
+      success := false
+      continue
+  return success
+
+partial def tryRule? (origin : ArgOrigin) (goalType : Expr) (rule : Rule) :
+    ApplyRuleSetsM (Option Expr) := do
+  let action := match rule.origin with
+    | .decl .. =>
+      match rule.type with
+      | .proc _ => "applying ruleproc"
+      | .expr _ => "applying theorem"
+    | .fvar .. | .stx .. | .other .. => match rule.type with
+      | .proc _ => "applying explicit ruleproc"
+      | .expr _ => "applying explicit rule"
+  withTraceNode `Meta.Tactic.apply_rulesets
+    (fun _ => return s!"{action}: {rule.name}") do
+  if (← read).erased.contains rule.name then
+    trace[Meta.Tactic.apply_rulesets] "rule is erased"
+    return none
+  let (ruleType, pattern) ← rule.instantiate
+  let (args, _, conclusion) ← forallMetaTelescope pattern
+  let ok ← matchRuleConclusion rule conclusion goalType
+  unless ok do
+    trace[Meta.Tactic.apply_rulesets]
+      "failed to unify rule pattern{indentExpr conclusion}\nwith{indentExpr goalType}"
+    return none
+  match ruleType with
+  | .expr expr =>
+    unless ← synthesizeArgs rule.name args do
+      return none
+    return some (← instantiateMVars (mkAppN expr args))
+  | .proc procExpr =>
+    unless ← synthesizeArgs rule.name args (allowPostponed := true) do
+      trace[Meta.Tactic.apply_rulesets]
+        "failed to synthesize ruleproc arguments for {rule.name}"
+      return none
+    let args ← args.mapM instantiateMVars
+    let proc ← evalRuleProc procExpr
+    let some proof ← proc args origin goalType
+      | trace[Meta.Tactic.apply_rulesets] "ruleproc {rule.name} returned none"; return none
+    let proofType ← inferType proof
+    let ok ← withTransparency (← read).config.transparency <| isDefEq proofType goalType
+    unless ok do
+      trace[Meta.Tactic.apply_rulesets]
+        "ruleproc {rule.name} returned proof of wrong type{indentExpr proofType}\
+        \nfor{indentExpr goalType}"
+      return none
+    return some proof
+
+end
+
+/-- Backward-search using the active rule sets. Alias for `applyRuleSets`. -/
+abbrev appluRuleSets := applyRuleSets
+
+end Tactic.ApplyRuleSets
+end Mathlib

--- a/Mathlib/Tactic/ApplyRuleSets/Core.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Core.lean
@@ -17,6 +17,94 @@ namespace Tactic.ApplyRuleSets
 
 open Lean Meta Elab Tactic
 
+def ProfileEntry.addNanos (entry : ProfileEntry) (nanos : Nat) : ProfileEntry :=
+  { entry with nanos := entry.nanos + nanos }
+
+def ProfileEntry.incCount (entry : ProfileEntry) : ProfileEntry :=
+  { entry with count := entry.count + 1 }
+
+def profileChargeCurrent (now : Nat) : ApplyRuleSetsM Unit := do
+  let profile := (← get).profile
+  unless profile.enabled do
+    return ()
+  let some op := profile.stack.head? | return ()
+  let elapsed := now - profile.lastNanos
+  let entry := (profile.times.get? op).getD {}
+  modify fun s =>
+    { s with profile :=
+      { s.profile with
+        lastNanos := now
+        times := s.profile.times.insert op (entry.addNanos elapsed) } }
+
+def profileEnter (op : Name) : ApplyRuleSetsM Unit := do
+  unless (← get).profile.enabled do
+    return ()
+  let now ← IO.monoNanosNow
+  profileChargeCurrent now
+  let entry := ((← get).profile.times.get? op).getD {}
+  modify fun s =>
+    { s with profile :=
+      { s.profile with
+        lastNanos := now
+        stack := op :: s.profile.stack
+        times := s.profile.times.insert op entry.incCount } }
+
+def profileExit : ApplyRuleSetsM Unit := do
+  unless (← get).profile.enabled do
+    return ()
+  let now ← IO.monoNanosNow
+  profileChargeCurrent now
+  modify fun s =>
+    { s with profile :=
+      { s.profile with
+        lastNanos := now
+        stack := s.profile.stack.tail } }
+
+def withProfile {α} (op : Name) (x : ApplyRuleSetsM α) : ApplyRuleSetsM α := do
+  unless (← get).profile.enabled do
+    return ← x
+  profileEnter op
+  try
+    let a ← x
+    profileExit
+    return a
+  catch e =>
+    profileExit
+    throw e
+
+def initProfileState : MetaM ProfileState := do
+  let now ← IO.monoNanosNow
+  return { enabled := true, startNanos := now, lastNanos := now }
+
+def formatProfileNanos (nanos : Nat) : String :=
+  let ms := nanos / 1_000_000
+  let frac := (nanos % 1_000_000) / 1_000
+  s!"{ms}.{frac / 100}{(frac / 10) % 10}{frac % 10}ms"
+
+def formatProfilePct (nanos total : Nat) : String :=
+  if total == 0 then
+    "0.0%"
+  else
+    let tenths := (nanos * 1000) / total
+    s!"{tenths / 10}.{tenths % 10}%"
+
+def finishProfileReport (profile : ProfileState) : MetaM MessageData := do
+  let finish ← IO.monoNanosNow
+  let total := finish - profile.startNanos
+  let entries := profile.times.toArray.qsort fun a b => a.2.nanos > b.2.nanos
+  let mut categorized := 0
+  let mut lines : Array MessageData :=
+    #[m!"apply_rulesets profile: total {formatProfileNanos total}"]
+  for (op, entry) in entries do
+    categorized := categorized + entry.nanos
+    lines := lines.push <| m!"  {op}: {formatProfileNanos entry.nanos} \
+      ({formatProfilePct entry.nanos total}), {entry.count} call(s)"
+  let uncategorized := total - categorized
+  if uncategorized > 0 then
+    lines := lines.push <| m!"  uncategorized: {formatProfileNanos uncategorized} \
+      ({formatProfilePct uncategorized total})"
+  return MessageData.joinSep lines.toList "\n"
+
 /-- Increase and check step count. -/
 def checkStep : ApplyRuleSetsM Unit := do
   let n := (← get).numSteps
@@ -116,30 +204,31 @@ def Goal.open {α} (goal : Goal) (k : Array Expr → Expr → MetaM α) : MetaM 
   k outputs body
 
 /-- Run the tactic embedded in an `autoParam` goal. -/
-def runAutoParam? (goalType : Expr) : MetaM (Option Expr) := do
-  let some (.const tacticDecl _) := goalType.getAutoParamTactic?
-    | return none
-  let goalType := goalType.appFn!.appArg!
-  let .ok tacticSyntax := evalSyntaxConstant (← getEnv) (← getOptions) tacticDecl
-    | return none
-  let tacticSeq : TSyntax `Lean.Parser.Tactic.tacticSeq := ⟨tacticSyntax⟩
-  let tacticCode ← `(tactic| try ($tacticSeq:tacticSeq))
-  let mvar ← mkFreshExprSyntheticOpaqueMVar goalType `apply_rulesets.autoParam
-  let runTac? : TermElabM (Option Expr) := do
-    try
-      Term.withoutModifyingElabMetaStateWithInfo do
-        Term.withSynthesize (postpone := .no) do
-          discard <| Tactic.run mvar.mvarId! <|
-            Tactic.evalTactic tacticCode *> Tactic.pruneSolvedGoals
-        let result ← instantiateMVars mvar
-        if result.hasExprMVar then
-          return none
-        else
-          return some result
-    catch _ =>
-      return none
-  let (result?, _) ← runTac?.run {} {}
-  return result?
+def runAutoParam? (goalType : Expr) : ApplyRuleSetsM (Option Expr) :=
+  withProfile `autoParam do
+    let some (.const tacticDecl _) := goalType.getAutoParamTactic?
+      | return none
+    let goalType := goalType.appFn!.appArg!
+    let .ok tacticSyntax := evalSyntaxConstant (← getEnv) (← getOptions) tacticDecl
+      | return none
+    let tacticSeq : TSyntax `Lean.Parser.Tactic.tacticSeq := ⟨tacticSyntax⟩
+    let tacticCode ← `(tactic| try ($tacticSeq:tacticSeq))
+    let mvar ← mkFreshExprSyntheticOpaqueMVar goalType `apply_rulesets.autoParam
+    let runTac? : TermElabM (Option Expr) := do
+      try
+        Term.withoutModifyingElabMetaStateWithInfo do
+          Term.withSynthesize (postpone := .no) do
+            discard <| Tactic.run mvar.mvarId! <|
+              Tactic.evalTactic tacticCode *> Tactic.pruneSolvedGoals
+          let result ← instantiateMVars mvar
+          if result.hasExprMVar then
+            return none
+          else
+            return some result
+      catch _ =>
+        return none
+    let (result?, _) ← runTac?.run {} {}
+    return result?
 
 /-- Query selected rulesets for candidates matching `goalType`. -/
 def takeRuleSetTree (rsName : Name) : ApplyRuleSetsM (RefinedDiscrTree Rule) := do
@@ -152,8 +241,9 @@ def queryRuleSets (goalType : Expr) (rulesets : Array Name) : ApplyRuleSetsM (Ar
   let mut out := #[]
   for rsName in rulesets do
     let tree ← takeRuleSetTree rsName
-    let (result, tree) ← withConfig (fun cfg => { cfg with iota := false, zeta := false }) <|
-      tree.getMatch goalType true true
+    let (result, tree) ← withProfile `discrTree.getMatch <|
+      withConfig (fun cfg => { cfg with iota := false, zeta := false }) <|
+        tree.getMatch goalType true true
     modify fun s =>
       { s with ruleSetTrees := s.ruleSetTrees.alter rsName fun _ => some tree }
     out := out ++ result.toArray
@@ -179,18 +269,19 @@ def Rule.instantiate (rule : Rule) : MetaM (RuleType × Expr) := do
 def matchRuleConclusion (_rule : Rule) (conclusion goal : Expr) : ApplyRuleSetsM Bool := do
   let conclusion ← instantiateMVars conclusion
   let goal ← instantiateMVars goal
-  withTransparency (← read).config.transparency <| isDefEq conclusion goal
+  withProfile `isDefEq <|
+    withTransparency (← read).config.transparency <| isDefEq conclusion goal
 
 mutual
 
 /-- Try to solve a proposition goal by a local hypothesis. -/
 partial def assumption? (origin : ArgOrigin) (goalType : Expr) : ApplyRuleSetsM (Option Expr) := do
-  unless ← isProp goalType do
+  unless ← withProfile `isProp <| isProp goalType do
     return none
   for localDecl in ← getLCtx do
     unless localDecl.isAuxDecl do
-      if ← isProp localDecl.type then
-        if ← isDefEq localDecl.type goalType then
+      if ← withProfile `isProp <| isProp localDecl.type then
+        if ← withProfile `isDefEq <| isDefEq localDecl.type goalType then
           return some (mkFVar localDecl.fvarId)
         if localDecl.type.isForall then
           let rule : Rule := {
@@ -198,14 +289,17 @@ partial def assumption? (origin : ArgOrigin) (goalType : Expr) : ApplyRuleSetsM 
             pattern := localDecl.type
             type := .expr (.fvar localDecl.fvarId)
           }
-          if let some r ← tryRule? origin (← mkGoal goalType) rule then
+          let goal ← withProfile `goal.mk <| mkGoal goalType
+          if let some r ← tryRule? origin goal rule then
             return r
   return none
 
 partial def applyRuleSets (origin : ArgOrigin) (goalType : Expr) :
     ApplyRuleSetsM (Option Expr) := do
-  if let some r ← applyRuleSetsGoal origin (← mkGoal goalType) then
-    if ← withTransparency (← read).config.transparency <| isDefEq goalType (← inferType r) then
+  let goal ← withProfile `goal.mk <| mkGoal goalType
+  if let some r ← applyRuleSetsGoal origin goal then
+    if ← withProfile `isDefEq <|
+        withTransparency (← read).config.transparency <| isDefEq goalType (← inferType r) then
       return r
     else
       return none
@@ -214,21 +308,21 @@ partial def applyRuleSets (origin : ArgOrigin) (goalType : Expr) :
 
 partial def applyRuleSetsGoal (origin : ArgOrigin) (goal : Goal) :
     ApplyRuleSetsM (Option Expr) := do
-  let goalType ← goal.open fun _ goalType => pure goalType
+  let goalType ← withProfile `goal.open <| goal.open fun _ goalType => pure goalType
   withTraceNode `Meta.Tactic.apply_rulesets
     (fun _ => return s!"{← ppExpr goalType}") do
-  if ← containsCurrentFailure goal then
+  if ← withProfile `cache.lookup <| containsCurrentFailure goal then
     trace[Meta.Tactic.apply_rulesets] "failed goal cache hit"
     return none
-  if let some proof ← findCachedSuccess? goal then
+  if let some proof ← withProfile `cache.lookup <| findCachedSuccess? goal then
     trace[Meta.Tactic.apply_rulesets] "successful goal cache hit"
     return some proof
   match ← applyRuleSetsGoalCore origin goal goalType with
   | some proof =>
-    cacheSuccess goal proof
+    withProfile `cache.insertSuccess <| cacheSuccess goal proof
     return some proof
   | none =>
-    cacheCurrentFailure goal
+    withProfile `cache.insertFailure <| cacheCurrentFailure goal
     return none
 
 partial def applyRuleSetsGoalCore (origin : ArgOrigin) (goal : Goal) (goalType : Expr) :
@@ -249,16 +343,18 @@ partial def applyRuleSetsGoalCore (origin : ArgOrigin) (goal : Goal) (goalType :
       trace[Meta.Tactic.apply_rulesets] "solved by local assumption"
       return some proof
   if cfg.intro then
-    let some proof ← forallTelescopeReducing goalType fun xs body => do
+    let some proof ← withProfile `forallMetaTelescope <|
+      forallTelescopeReducing goalType fun xs body => do
       if xs.isEmpty then
         return none
       trace[Meta.Tactic.apply_rulesets] "introducing {xs.size} binder(s)"
       let some proof ← withIncreasedSearchDepth <| withIncreasedCacheDepth <|
         applyRuleSets origin body | return none
-      return some (← mkLambdaFVars xs proof)
+      return some (← withProfile `mkLambdaFVars <| mkLambdaFVars xs proof)
       | pure ()
     return some proof
-  let rules := sortRules (← queryRuleSets goalType (← read).rulesets)
+  let rules ← withProfile `rules.querySort do
+    return sortRules (← queryRuleSets goalType (← read).rulesets)
   trace[Meta.Tactic.apply_rulesets]
     "candidate rules: {rules.map fun rule => rule.name}"
   for rule in (← read).explicitRules do
@@ -274,8 +370,8 @@ partial def applyRuleSetsGoalCore (origin : ArgOrigin) (goal : Goal) (goalType :
 partial def synthesizeInstanceArg? (ruleName : Name) (arg type : Expr) : ApplyRuleSetsM Bool := do
   unless (← isClass? type).isSome do
     return false
-  if let .some inst ← trySynthInstance type then
-    if ← isDefEq arg inst then
+  if let .some inst ← withProfile `synthInstance <| trySynthInstance type then
+    if ← withProfile `isDefEq <| isDefEq arg inst then
       return true
     trace[Meta.Tactic.apply_rulesets]
       "{ruleName}, failed to assign instance{indentExpr type}\
@@ -292,13 +388,13 @@ partial def synthesizeProofArg? (ruleName : Name) (argIndex : Nat) (arg type : E
   let argName := (← getMCtx).getDecl arg.mvarId! |>.userName
   let origin := { ruleName, argIndex := some argIndex, argName := some argName }
   if let some proof ← withIncreasedSearchDepth <| applyRuleSets origin type then
-    if ← isDefEq arg proof then
+    if ← withProfile `isDefEq <| isDefEq arg proof then
       return true
     trace[Meta.Tactic.apply_rulesets]
       "{ruleName}, failed to assign proof{indentExpr type}"
   let ctx ← read
-  if let some proof ← ctx.disch origin type then
-    if ← isDefEq arg proof then
+  if let some proof ← withProfile `discharger <| ctx.disch origin type then
+    if ← withProfile `isDefEq <| isDefEq arg proof then
       return true
     trace[Meta.Tactic.apply_rulesets]
       "{ruleName}, failed to assign discharger proof{indentExpr type}"
@@ -311,7 +407,7 @@ partial def checkPostponedArgs (ruleName : Name) (args : Array Expr) (allowPostp
     ApplyRuleSetsM Bool := do
   let mut success := true
   for arg in args do
-    if (← instantiateMVars arg).isMVar then
+    if (← withProfile `instantiateMVars <| instantiateMVars arg).isMVar then
       if allowPostponed then
         continue
       trace[Meta.Tactic.apply_rulesets]
@@ -326,14 +422,14 @@ partial def synthesizeArgs (ruleName : Name) (args : Array Expr)
   let mut postponed := #[]
   for h : i in [:args.size] do
     let arg := args[i]
-    if (← instantiateMVars arg).isMVar then
-      let type ← inferType arg
+    if (← withProfile `instantiateMVars <| instantiateMVars arg).isMVar then
+      let type ← withProfile `inferType <| inferType arg
       if ← synthesizeInstanceArg? ruleName arg type then
         continue
-      if ← isProp type then
+      if ← withProfile `isProp <| isProp type then
         unless ← synthesizeProofArg? ruleName i arg type do
           postponed := postponed.push arg
-        if (← instantiateMVars arg).isMVar then
+        if (← withProfile `instantiateMVars <| instantiateMVars arg).isMVar then
           success := false
         continue
       postponed := postponed.push arg
@@ -357,9 +453,9 @@ partial def tryRule? (origin : ArgOrigin) (goal : Goal) (rule : Rule) :
   if rule.hasExprMVar then
     trace[Meta.Tactic.apply_rulesets] "rule contains expression metavariables"
     return none
-  let goalType ← goal.open fun _ goalType => pure goalType
-  let (ruleType, pattern) ← rule.instantiate
-  let (args, _, conclusion) ← forallMetaTelescope pattern
+  let goalType ← withProfile `goal.open <| goal.open fun _ goalType => pure goalType
+  let (ruleType, pattern) ← withProfile `rule.instantiate <| rule.instantiate
+  let (args, _, conclusion) ← withProfile `forallMetaTelescope <| forallMetaTelescope pattern
   let ok ← matchRuleConclusion rule conclusion goalType
   unless ok do
     trace[Meta.Tactic.apply_rulesets]
@@ -369,18 +465,20 @@ partial def tryRule? (origin : ArgOrigin) (goal : Goal) (rule : Rule) :
   | .expr expr =>
     unless ← synthesizeArgs rule.name args do
       return none
-    return some (← instantiateMVars (mkAppN expr args))
+    let proof ← withProfile `mkApp <| instantiateMVars (mkAppN expr args)
+    return some proof
   | .proc procExpr =>
     unless ← synthesizeArgs rule.name args (allowPostponed := true) do
       trace[Meta.Tactic.apply_rulesets]
         "failed to synthesize ruleproc arguments for {rule.name}"
       return none
     let args ← args.mapM instantiateMVars
-    let proc ← evalRuleProc procExpr
+    let proc ← withProfile `ruleproc.eval <| evalRuleProc procExpr
     let some proof ← proc args origin goalType
       | trace[Meta.Tactic.apply_rulesets] "ruleproc {rule.name} returned none"; return none
     let proofType ← inferType proof
-    let ok ← withTransparency (← read).config.transparency <| isDefEq proofType goalType
+    let ok ← withProfile `isDefEq <|
+      withTransparency (← read).config.transparency <| isDefEq proofType goalType
     unless ok do
       trace[Meta.Tactic.apply_rulesets]
         "ruleproc {rule.name} returned proof of wrong type{indentExpr proofType}\

--- a/Mathlib/Tactic/ApplyRuleSets/Elab.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Elab.lean
@@ -151,6 +151,8 @@ private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
             pattern := type
             order := i
           }
+          if rule.hasExprMVar then
+            throwErrorAt explicitTerms[i] "explicit rule contains expression metavariables"
           explicitRules := explicitRules.push rule
         else
           let e ← abstractMVars e
@@ -162,6 +164,8 @@ private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
             levelParams := e.paramNames
             order := i
           }
+          if rule.hasExprMVar then
+            throwErrorAt explicitTerms[i] "explicit rule contains expression metavariables"
           explicitRules := explicitRules.push rule
     Term.synthesizeSyntheticMVarsNoPostponing
     let ctx : Context :=
@@ -171,7 +175,7 @@ private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
         erased := erased,
         disch := disch
         lctxInitIndices := (← getLCtx).numIndices }
-    let s : State := {}
+    let s : State := { goalCaches := #[{ minLctxIndex := (← getLCtx).numIndices }] }
     let (proof?, s) ← (applyRuleSets { ruleName := Name.anonymous } goalType).run ctx |>.run s
     match proof? with
     | some proof => goal.assign proof; replaceMainGoal []

--- a/Mathlib/Tactic/ApplyRuleSets/Elab.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Elab.lean
@@ -14,6 +14,32 @@ import Qq
 
 This file defines tactic elaboration for a configurable backward-search tactic using named rulesets.
 Rulesets contain theorem rules and procedural rules (`ruleproc`s) in one ordered database.
+
+The tactic searches backwards from the current goal using local hypotheses, optional introductions,
+explicit rules supplied in the tactic call, and rules from named rulesets. For example:
+
+```lean
+apply_rulesets [my_rules, some_theorem, localHyp]
+```
+
+Entries in the bracket list can be:
+* a ruleset name, such as `my_rules`,
+* a theorem, local hypothesis, or proof term to use as an explicit rule,
+* an erased declaration name, written `-Some.rule`, or
+* a tactic discharger, written `by tac`.
+
+Dischargers are tried in the order they appear:
+
+```lean
+apply_rulesets [my_rules, by assumption, by omega, by grind]
+apply_rulesets [my_rules, by first | assumption | omega | grind]
+```
+
+The old syntax `apply_rulesets (disch := tac) [...]` is still accepted for discoverability, but
+emits a warning recommending `apply_rulesets [..., by tac]`.
+
+`apply_rulesets?` is the same tactic with failed-subgoal collection enabled. If search fails, it
+offers code actions of the form `have : <subgoal> := sorry` for side goals it could not solve.
 -/
 
 public meta section
@@ -26,7 +52,8 @@ open Lean.Parser.Tactic
 
 open Parser.Tactic in
 syntax applyRuleSetErase := "-" term:max
-syntax applyRuleSetArg := applyRuleSetErase <|> term
+syntax applyRuleSetDischarger := "by " tacticSeq
+syntax applyRuleSetArg := applyRuleSetErase <|> applyRuleSetDischarger <|> term
 syntax applyRuleSetArgs := "[" applyRuleSetArg,* "]"
 
 /-- Config elaborator for `apply_rulesets`. -/
@@ -44,17 +71,33 @@ private def parseApplyRuleSetArgs (args : TSyntax ``applyRuleSetArgs) :
   | `(applyRuleSetArgs| [$xs,*]) => xs.getElems
   | _ => #[]
 
+abbrev Discharger := ArgOrigin → Expr → MetaM (Option Expr)
+
+private def firstDischarger (dischargers : Array Discharger) : Discharger := fun origin goal => do
+  for disch in dischargers do
+    if let some proof ← disch origin goal then
+      return some proof
+  return none
+
 open Mathlib.Meta.FunProp in
-private def tacticDischarger (d? : Option (TSyntax ``Parser.Tactic.discharger)) :
-    TacticM (ArgOrigin → Expr → MetaM (Option Expr)) := do
+private def deprecatedDischarger? (d? : Option (TSyntax ``Parser.Tactic.discharger)) :
+    TacticM (Option Discharger) := do
   match d? with
-  | none => return fun _ _ => pure none
+  | none => return none
   | some d =>
+    logWarningAt d "`apply_rulesets (disch := tac)` is deprecated; prefer \
+      `apply_rulesets [by tac]`"
     match d with
     | `(discharger| (discharger := $tac)) =>
       let disch := Mathlib.Meta.FunProp.tacticToDischarge (← `(tactic| ($tac)))
-      return fun _ e => disch e
-    | _ => return fun _ _ => pure none
+      return some fun _ e => disch e
+    | _ => return none
+
+open Mathlib.Meta.FunProp in
+private def tacticSeqDischarger (seq : TSyntax ``Lean.Parser.Tactic.tacticSeq) :
+    TacticM Discharger := do
+  let disch := Mathlib.Meta.FunProp.tacticToDischarge (← `(tactic| ($seq:tacticSeq)))
+  return fun _ e => disch e
 
 open Lean Meta in
 private partial def leadingIndent (source : String) (pos : String.Pos.Raw) : String :=
@@ -126,7 +169,9 @@ private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
       { cfg with collectFailedSubgoals := true }
     else
       cfg
-  let disch ← tacticDischarger d?
+  let mut dischargers := #[]
+  if let some disch ← deprecatedDischarger? d? then
+    dischargers := dischargers.push disch
   let args := argsStx?.map parseApplyRuleSetArgs |>.getD #[]
   let mut rulesets := #[]
   let mut explicitTerms : Array Term := #[]
@@ -137,6 +182,8 @@ private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
       match t.raw with
       | .ident .. => erased := erased.insert (← realizeGlobalConstNoOverload t.raw)
       | _ => throwErrorAt t "apply_rulesets only supports removals by name"
+    | `(applyRuleSetArg| by $seq:tacticSeq) =>
+      dischargers := dischargers.push (← tacticSeqDischarger seq)
     | `(applyRuleSetArg| $t:term) =>
       match t.raw with
       | .ident _ _ val _ =>
@@ -159,6 +206,7 @@ private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
         explicitRules := explicitRules.push { rule with order := i }
       else
         explicitRules := explicitRules.push (← mkExplicitExprRule origin i explicitTerms[i] e)
+    let disch := firstDischarger dischargers
     Term.synthesizeSyntheticMVarsNoPostponing
     let ctx : Context :=
       { config := cfg,

--- a/Mathlib/Tactic/ApplyRuleSets/Elab.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Elab.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Tactic.ApplyRuleSets.Core
 public import Mathlib.Tactic.FunProp.Decl
+import Qq
 
 /-!
 # The `apply_rulesets` tactic
@@ -82,9 +83,10 @@ def addHaveSuggestions (ref : Syntax) (goals : Array Expr) : TacticM Unit := do
   for goal in goals do
     if !collected.contains goal then
       collected := collected.insert goal
+      let code := s!"have : {← ppExpr goal} := sorry"
       let suggestion : Suggestion := {
-        suggestion := .string s!"{indent}have : {← ppExpr goal} := sorry\n"
-        toCodeActionTitle? := some fun _ => "Insert `have` for current goal"
+        suggestion := .string s!"{indent}{code}\n"
+        toCodeActionTitle? := some fun _ => code
       }
       suggestions := suggestions.push suggestion
   addSuggestions ref suggestions (origSpan? := some (Syntax.ofRange insertionRange))
@@ -100,6 +102,19 @@ private def explicitOrigin (order : Nat) (ref : Syntax) (expr : Expr) : Origin :
     match expr.constName? with
     | some declName => .decl declName
     | none => .stx (explicitRuleId order) ref
+
+private def mkExplicitExprRule (origin : Origin) (order : Nat) (ref : Term) (e : Expr) :
+    TacticM Rule := do
+  let (e, pattern, levelParams) ←
+    if e.isLambda then
+      pure (e, ← inferType e, #[])
+    else
+      let e ← abstractMVars e
+      pure (e.expr, ← inferType e.expr, e.paramNames)
+  let rule : Rule := { origin, type := .expr e, pattern, levelParams, order }
+  if rule.hasExprMVar then
+    throwErrorAt ref "explicit rule contains expression metavariables"
+  return rule
 
 private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
     (d? : Option (TSyntax ``Parser.Tactic.discharger))
@@ -143,30 +158,7 @@ private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
       if let some rule ← explicitRuleProcRule? origin e then
         explicitRules := explicitRules.push { rule with order := i }
       else
-        if e.isLambda then
-          let type ← inferType e
-          let rule : Rule := {
-            origin := origin
-            type := .expr e
-            pattern := type
-            order := i
-          }
-          if rule.hasExprMVar then
-            throwErrorAt explicitTerms[i] "explicit rule contains expression metavariables"
-          explicitRules := explicitRules.push rule
-        else
-          let e ← abstractMVars e
-          let type ← inferType e.expr
-          let rule : Rule := {
-            origin := origin
-            type := .expr e.expr
-            pattern := type
-            levelParams := e.paramNames
-            order := i
-          }
-          if rule.hasExprMVar then
-            throwErrorAt explicitTerms[i] "explicit rule contains expression metavariables"
-          explicitRules := explicitRules.push rule
+        explicitRules := explicitRules.push (← mkExplicitExprRule origin i explicitTerms[i] e)
     Term.synthesizeSyntheticMVarsNoPostponing
     let ctx : Context :=
       { config := cfg,

--- a/Mathlib/Tactic/ApplyRuleSets/Elab.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Elab.lean
@@ -1,0 +1,600 @@
+/-
+Copyright (c) 2026 Tomáš Skřivan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomáš Skřivan
+-/
+module
+
+public meta import Mathlib.Lean.Meta.RefinedDiscrTree.Initialize
+public meta import Mathlib.Lean.Meta.RefinedDiscrTree.Lookup
+public import Lean.Elab.Tactic.Config
+public import Lean.Elab.Tactic.ElabTerm
+public import Lean.Meta.Tactic.SolveByElim
+public import Mathlib.Tactic.FunProp.Decl
+
+/-!
+# The `apply_rulesets` tactic
+
+This file defines a first version of a configurable backward-search tactic using named rulesets.
+Rulesets contain theorem rules and procedural rules (`ruleproc`s) in one ordered database.
+-/
+
+public meta section
+
+namespace Mathlib
+namespace Tactic.ApplyRuleSets
+
+open Lean Meta Elab Tactic Term
+open Lean.Parser.Tactic
+open Lean.Meta.RefinedDiscrTree
+
+initialize registerTraceClass `Meta.Tactic.apply_rulesets
+initialize registerTraceClass `Meta.Tactic.apply_rulesets.attr
+
+/-- Configuration for `apply_rulesets`. -/
+structure Config extends ApplyConfig where
+  /-- Maximum recursive depth. -/
+  maxDepth : Nat := 50
+  /-- Maximum number of candidate attempts. -/
+  maxSteps : Nat := 10000
+  /-- Transparency used by unification. -/
+  transparency : TransparencyMode := .default
+  /-- Use local hypotheses to solve proposition goals. -/
+  assumption : Bool := true
+  /-- Introduce leading binders and continue recursively. -/
+  intro : Bool := true
+  /-- Run the tactic embedded in `autoParam` goals. -/
+  autoParam : Bool := true
+
+instance : Inhabited Config := ⟨{}⟩
+
+/-- Information about a goal passed to a rule or discharger. -/
+structure ArgOrigin where
+  /-- The theorem or term rule that generated the goal, or `anonymous` for the root goal. -/
+  ruleName : Name
+  /-- Argument index in the theorem telescope, or `none` for the root goal. -/
+  argIndex : Option Nat := none
+  /-- Argument binder name in the theorem telescope, or `none` for the root goal. -/
+  argName : Option Name := none
+deriving Inhabited, BEq
+
+/-- Explicit tactic-call theorem or term. -/
+structure ExplicitRule where
+  order : Nat
+  expr : Expr
+deriving Inhabited
+
+def ExplicitRule.name (r : ExplicitRule) : Name :=
+  r.expr.constName?.getD (`apply_rulesets.explicit ++ Name.num Name.anonymous r.order)
+
+/-- Search context. -/
+structure Context where
+  config : Config := {}
+  rulesets : Array Name := #[]
+  explicitRules : Array ExplicitRule := #[]
+  /-- Side-condition discharger for proposition arguments. -/
+  disch : ArgOrigin → Expr → MetaM (Option Expr) := fun _ _ => pure none
+
+/-- Search state. -/
+structure State where
+  numSteps : Nat := 0
+  messages : List String := []
+
+/-- Monad used by `apply_rulesets`. -/
+abbrev ApplyRuleSetsM := ReaderT Context <| StateT State MetaM
+
+/-- A procedural rule. The array contains the synthesized arguments from the ruleproc pattern. -/
+abbrev RuleProc := Array Expr → ArgOrigin → Expr → ApplyRuleSetsM (Option Expr)
+
+/-- Common metadata for theorem rules and ruleprocs. -/
+structure RuleHeader where
+  name : Name
+  priority : Nat := eval_prio default
+  order : Nat := 0
+  explicit : Bool := false
+deriving Inhabited, BEq
+
+/-- A theorem rule stored in a ruleset. -/
+structure TheoremRule where
+  header : RuleHeader
+deriving Inhabited, BEq
+
+/-- A procedural rule stored in a ruleset. -/
+structure ProcRule where
+  header : RuleHeader
+  pattern : Expr
+deriving Inhabited, BEq
+
+/-- A rule entry. -/
+inductive RuleEntry where
+  | theorem (rule : TheoremRule)
+  | proc (rule : ProcRule)
+deriving Inhabited, BEq
+
+def RuleEntry.header : RuleEntry → RuleHeader
+  | .theorem r => r.header
+  | .proc r => r.header
+
+/-- Ruleset data kept in the environment. -/
+structure RuleSet where
+  entries : Array RuleEntry := #[]
+  tree : RefinedDiscrTree RuleEntry := {}
+deriving Inhabited
+
+/-- All registered rulesets. -/
+structure RuleSets where
+  ruleSets : Std.HashMap Name RuleSet := {}
+  nextOrder : Nat := 0
+deriving Inhabited
+
+/-- Entry added to the global ruleset extension. -/
+structure RuleSetExtEntry where
+  ruleSetName : Name
+  entry : RuleEntry
+  keys : List (Key × LazyEntry)
+deriving Inhabited
+
+initialize ruleSetsExt : SimpleScopedEnvExtension RuleSetExtEntry RuleSets ←
+  registerSimpleScopedEnvExtension {
+    name := by exact decl_name%
+    initial := {}
+    addEntry := fun s e =>
+      let header := e.entry.header
+      let header := { header with order := s.nextOrder, explicit := false }
+      let entry := match e.entry with
+        | .theorem r => .theorem { r with header := header }
+        | .proc r => .proc { r with header := header }
+      let rs := s.ruleSets.getD e.ruleSetName {}
+      let tree := e.keys.foldl (fun t (key, lazyEntry) =>
+        RefinedDiscrTree.insert t key (lazyEntry, entry)) rs.tree
+      let rs := { entries := rs.entries.push entry, tree := tree }
+      { ruleSets := s.ruleSets.insert e.ruleSetName rs, nextOrder := s.nextOrder + 1 }
+  }
+
+/-- Return true if `name` is a registered ruleset. -/
+def isRuleSetName (name : Name) : CoreM Bool := do
+  return (ruleSetsExt.getState (← getEnv)).ruleSets.contains name
+
+/-- Get a registered ruleset. -/
+def getRuleSet (name : Name) : CoreM RuleSet := do
+  return (ruleSetsExt.getState (← getEnv)).ruleSets.getD name {}
+
+/-- Compute indexing keys for a theorem conclusion or ruleproc pattern. -/
+def keysForPattern (pattern : Expr) : MetaM (List (Key × LazyEntry)) := do
+  RefinedDiscrTree.initializeLazyEntryWithEta pattern
+
+/-- Add a theorem to a ruleset. -/
+def addTheoremRule (ruleSetName declName : Name) (kind : AttributeKind)
+    (prio : Nat := eval_prio default) : MetaM Unit := do
+  let info ← getConstInfo declName
+  let (_, _, conclusion) ← forallMetaTelescope info.type
+  let keys ← keysForPattern conclusion
+  let entry : RuleEntry := .theorem { header := { name := declName, priority := prio } }
+  ruleSetsExt.add { ruleSetName, entry, keys } kind
+  trace[Meta.Tactic.apply_rulesets.attr] "added theorem rule {declName} to {ruleSetName}"
+
+/-- Persistent information about a declared ruleproc pattern. -/
+structure RuleProcDecl where
+  declName : Name
+  pattern : Expr
+  keys : List (Key × LazyEntry)
+deriving Inhabited
+
+initialize ruleProcDeclExt : SimpleScopedEnvExtension RuleProcDecl (Std.HashMap Name RuleProcDecl) ←
+  registerSimpleScopedEnvExtension {
+    name := by exact decl_name%
+    initial := {}
+    addEntry := fun s e => s.insert e.declName e
+  }
+
+/-- Register the pattern for a ruleproc declaration. -/
+def registerRuleProcPattern (declName : Name) (pattern : Expr) : MetaM Unit := do
+  let (_, _, conclusion) ← forallMetaTelescope pattern
+  let keys ← keysForPattern conclusion
+  modifyEnv fun env => ruleProcDeclExt.addEntry env { declName, pattern, keys }
+
+/-- Return registered pattern information for a ruleproc declaration. -/
+def getRuleProcDecl? (declName : Name) : CoreM (Option RuleProcDecl) := do
+  return (ruleProcDeclExt.getState (← getEnv)).get? declName
+
+/-- Register a ruleproc in a ruleset. -/
+def addProcRule (ruleSetName declName : Name) (kind : AttributeKind)
+    (prio : Nat := eval_prio default) : MetaM Unit := do
+  let some decl ← getRuleProcDecl? declName
+    | throwError "invalid ruleproc attribute: `{.ofConstName declName}` has no registered pattern"
+  let info ← getConstInfo declName
+  unless (← isDefEq info.type (mkConst ``RuleProc)) do
+    throwError "invalid ruleproc: `{.ofConstName declName}` has type{indentExpr info.type}\
+      \nexpected `RuleProc`"
+  let header := { name := declName, priority := prio }
+  let entry : RuleEntry := .proc { header, pattern := decl.pattern }
+  ruleSetsExt.add { ruleSetName, entry, keys := decl.keys } kind
+  trace[Meta.Tactic.apply_rulesets.attr] "added ruleproc {declName} to {ruleSetName}"
+
+/-- Evaluate a ruleproc declaration. -/
+unsafe def getRuleProcFromDeclImpl (declName : Name) : MetaM RuleProc := do
+  let env ← getEnv
+  let opts ← getOptions
+  match env.evalConst RuleProc opts declName with
+  | .ok proc => return proc
+  | .error err => throwError err
+
+@[implemented_by getRuleProcFromDeclImpl]
+opaque getRuleProcFromDecl (declName : Name) : MetaM RuleProc
+
+/-- Declaration command used internally by `ruleproc_decl`. -/
+elab "ruleproc_pattern% " pat:term " => " proc:ident : command => do
+  Command.liftTermElabM do
+    let procName ← realizeGlobalConstNoOverload proc
+    let pattern ← Term.elabType pat
+    Term.synthesizeSyntheticMVars
+    let pattern ← Term.levelMVarToParam (← instantiateMVars pattern)
+    registerRuleProcPattern procName pattern
+
+private def binderNames (binders : Array Syntax) : Array Name := Id.run do
+  let mut names := #[]
+  let mut instIdx := 0
+  for binder in binders do
+    match binder.getKind with
+    | `Lean.Parser.Term.explicitBinder | `Lean.Parser.Term.implicitBinder =>
+      for arg in binder[1].getArgs do
+        if arg.isIdent then
+          let name := arg.getId
+          unless name == `_ do
+            names := names.push name
+    | `Lean.Parser.Term.instBinder =>
+      let explicitNames := binder[1].getArgs.filter Syntax.isIdent |>.map Syntax.getId
+      if explicitNames.isEmpty then
+        names := names.push (.mkSimple s!"_inst{instIdx}")
+        instIdx := instIdx + 1
+      else
+        for name in explicitNames do
+          names := names.push name
+    | _ => pure ()
+  return names
+
+private def mkRuleProcBody (xs : Ident) (names : Array Name) (body : Term) : MacroM Term := do
+  let mut result := body
+  for i in [0:names.size] do
+    let i := names.size - 1 - i
+    let id := mkIdent names[i]!
+    let idx := quote i
+    result ← `(let $id:ident : Lean.Expr := $xs[$idx]!; $result)
+  return result
+
+/-- Syntax for a ruleproc declaration. -/
+syntax (docComment)? "ruleproc_decl " ident (ppSpace bracketedBinder)* " : " term " := "
+  term : command
+
+macro_rules
+  | `($[$doc?:docComment]? ruleproc_decl $n:ident $bs* : $pat:term := $body:term) => do
+    let xs := mkIdent `xs
+    let body ← mkRuleProcBody xs (binderNames bs) body
+    `($[$doc?:docComment]? meta def $n : Mathlib.Tactic.ApplyRuleSets.RuleProc :=
+        fun $xs:ident => $body
+      ruleproc_pattern% (∀ $bs*, $pat) => $n)
+
+/-- Syntax for a ruleproc declaration immediately attached to rulesets. -/
+syntax (docComment)? attrKind "ruleproc " "[" ident,* "]" ident
+  (ppSpace bracketedBinder)* " : " term " := " term : command
+
+macro_rules
+  | `($[$doc?:docComment]? $kind:attrKind ruleproc [$attrs,*] $n:ident $bs* :
+      $pat:term := $body:term) => do
+    let attrs := attrs.getElems
+    let mut cmds : Array Syntax :=
+      #[← `($[$doc?:docComment]? ruleproc_decl $n $bs* : $pat := $body)]
+    for attr in attrs do
+      let attrName := attr.getId
+      let attrParser := mkIdentFrom attr (`Parser.Attr ++ attrName)
+      let attrStx : TSyntax `attr := ⟨mkNode attrParser.getId #[mkAtom attrName.toString]⟩
+      cmds := cmds.push (← `(attribute [$kind $attrStx:attr] $n))
+    return mkNullNode cmds
+
+/-- Register the theorem and proc attributes for a ruleset. -/
+def registerRuleSetAttr (ruleSetName : Name) (descr : String) : IO Unit := do
+  registerBuiltinAttribute {
+    name := ruleSetName
+    descr := descr
+    applicationTime := AttributeApplicationTime.afterCompilation
+    add := fun decl stx kind => discard <| MetaM.run do
+      let prio ← getAttrParamOptPrio stx[1]
+      if (← getRuleProcDecl? decl).isSome then
+        addProcRule ruleSetName decl kind prio
+      else
+        addTheoremRule ruleSetName decl kind prio
+    erase := fun _ => throwError "can't remove ruleset attributes"
+  }
+
+/-- Register a new ruleset and its associated attributes. -/
+macro (name := registerRulesetCmd) doc:(docComment)? "register_ruleset " id:ident : command => do
+  let str := id.getId.toString
+  let idParser := mkIdentFrom id (`Parser.Attr ++ id.getId)
+  let descr := quote ((doc.map (·.getDocString) |>.getD s!"ruleset {id.getId}").removeLeadingSpaces)
+  `($[$doc:docComment]? public meta initialize registerRuleSetAttr $(quote id.getId) $descr
+    $[$doc:docComment]? syntax (name := $idParser:ident) $(quote str):str (prio)? : attr)
+
+/-- Increase and check step count. -/
+def checkStep : ApplyRuleSetsM Unit := do
+  let n := (← get).numSteps
+  let maxSteps := (← read).config.maxSteps
+  if n ≥ maxSteps then
+    throwError "apply_rulesets failed, maximum number of steps ({maxSteps}) exceeded"
+  modify fun s => { s with numSteps := s.numSteps + 1 }
+
+/-- Roll back metavariable assignments if `x` returns `none` or throws. -/
+def observingWithRollback? {α} (x : ApplyRuleSetsM (Option α)) : ApplyRuleSetsM (Option α) := do
+  let mctx ← getMCtx
+  try
+    match ← x with
+    | some a => return some a
+    | none => setMCtx mctx; return none
+  catch e =>
+    trace[Meta.Tactic.apply_rulesets] "candidate failed: {e.toMessageData}"
+    setMCtx mctx
+    return none
+
+/-- Try to solve a proposition goal by a local hypothesis. -/
+def assumption? (goalType : Expr) : MetaM (Option Expr) := do
+  unless ← isProp goalType do
+    return none
+  for localDecl in ← getLCtx do
+    unless localDecl.isAuxDecl do
+      if ← isProp localDecl.type then
+        if ← isDefEq localDecl.type goalType then
+          return some (mkFVar localDecl.fvarId)
+  return none
+
+/-- Run the tactic embedded in an `autoParam` goal. -/
+def runAutoParam? (goalType : Expr) : MetaM (Option Expr) := do
+  let some (.const tacticDecl _) := goalType.getAutoParamTactic?
+    | return none
+  let goalType := goalType.appFn!.appArg!
+  let .ok tacticSyntax := evalSyntaxConstant (← getEnv) (← getOptions) tacticDecl
+    | return none
+  let tacticSeq : TSyntax `Lean.Parser.Tactic.tacticSeq := ⟨tacticSyntax⟩
+  let tacticCode ← `(tactic| try ($tacticSeq:tacticSeq))
+  let mvar ← mkFreshExprSyntheticOpaqueMVar goalType `apply_rulesets.autoParam
+  let runTac? : TermElabM (Option Expr) := do
+    try
+      Term.withoutModifyingElabMetaStateWithInfo do
+        Term.withSynthesize (postpone := .no) do
+          discard <| Tactic.run mvar.mvarId! <|
+            Tactic.evalTactic tacticCode *> Tactic.pruneSolvedGoals
+        let result ← instantiateMVars mvar
+        if result.hasExprMVar then
+          return none
+        else
+          return some result
+    catch _ =>
+      return none
+  let (result?, _) ← runTac?.run {} {}
+  return result?
+
+/-- Query selected rulesets for candidates matching `goalType`. -/
+def queryRuleSets (goalType : Expr) (rulesets : Array Name) : MetaM (Array RuleEntry) := do
+  let mut out := #[]
+  for rsName in rulesets do
+    let rs ← getRuleSet rsName
+    let (result, _) ← withConfig (fun cfg => { cfg with iota := false, zeta := false }) <|
+      rs.tree.getMatch goalType true true
+    out := out ++ result.toArray
+  return out
+
+/-- Sort candidates by priority, explicitness, and insertion order. -/
+def sortEntries (entries : Array RuleEntry) : Array RuleEntry :=
+  entries.qsort fun a b =>
+    let ah := a.header
+    let bh := b.header
+    if ah.priority != bh.priority then
+      ah.priority > bh.priority
+    else if ah.explicit != bh.explicit then
+      ah.explicit && !bh.explicit
+    else
+      ah.order < bh.order
+
+mutual
+
+partial def prove? (origin : ArgOrigin) (goalType : Expr) (entries : Array RuleEntry)
+    (erased : Std.HashSet Name) (depth : Nat) : ApplyRuleSetsM (Option Expr) := do
+  checkStep
+  let maxDepth := (← read).config.maxDepth
+  if depth > maxDepth then
+    return none
+  let cfg := (← read).config
+  if cfg.autoParam then
+    if let some proof ← observingWithRollback? <| runAutoParam? goalType then
+      return some proof
+  if cfg.assumption then
+    if let some proof ← observingWithRollback? <| assumption? goalType then
+      return some proof
+  if cfg.intro then
+    let some proof ← observingWithRollback? <| forallTelescopeReducing goalType fun xs body => do
+      if xs.isEmpty then
+        return none
+      let some proof ← prove? origin body entries erased (depth + 1) | return none
+      return some (← mkLambdaFVars xs proof)
+      | pure ()
+    return some proof
+  let entries := sortEntries (← queryRuleSets goalType (← read).rulesets)
+  for rule in (← read).explicitRules do
+    if let some proof ←
+        observingWithRollback? <| tryExplicit? origin goalType entries erased depth rule then
+      return some proof
+  for entry in entries do
+    unless erased.contains entry.header.name do
+      if let some proof ←
+          observingWithRollback? <| tryEntry? origin goalType entries erased depth entry then
+        return some proof
+  return none
+
+/-- Synthesize arguments created by theorem application. -/
+partial def synthesizeArgs (ruleName : Name) (args : Array Expr) (entries : Array RuleEntry)
+    (erased : Std.HashSet Name) (depth : Nat) : ApplyRuleSetsM Bool := do
+  let mut postponed := #[]
+  for h : i in [:args.size] do
+    let arg := args[i]
+    if (← instantiateMVars arg).isMVar then
+      let type ← inferType arg
+      if (← isClass? type).isSome then
+        if let .some inst ← trySynthInstance type then
+          if (← isDefEq arg inst) then
+            continue
+      if (← isProp type) then
+        let argName := (← getMCtx).getDecl arg.mvarId! |>.userName
+        let origin := { ruleName, argIndex := some i, argName := some argName }
+        if let some proof ← prove? origin type entries erased (depth + 1) then
+          if (← isDefEq arg proof) then
+            continue
+        let ctx ← read
+        if let some proof ← ctx.disch origin type then
+          if (← isDefEq arg proof) then
+            continue
+        return false
+      else
+        postponed := postponed.push arg
+  for arg in postponed do
+    if (← instantiateMVars arg).isMVar then
+      return false
+  return true
+
+/-- Try an explicit theorem or term provided in the tactic call. -/
+partial def tryExplicit? (_origin : ArgOrigin) (goalType : Expr) (entries : Array RuleEntry)
+    (erased : Std.HashSet Name) (depth : Nat) (r : ExplicitRule) :
+    ApplyRuleSetsM (Option Expr) := do
+  let name := r.name
+  if erased.contains name then
+    return none
+  let type ← inferType r.expr
+  let (args, _, conclusion) ← forallMetaTelescope type
+  let ok ← withTransparency (← read).config.transparency <| isDefEq conclusion goalType
+  unless ok do return none
+  unless ← synthesizeArgs name args entries erased depth do return none
+  return some (← instantiateMVars (mkAppN r.expr args))
+
+/-- Try a theorem rule. -/
+partial def tryTheorem? (_origin : ArgOrigin) (goalType : Expr) (entries : Array RuleEntry)
+    (erased : Std.HashSet Name) (depth : Nat) (rule : TheoremRule) :
+    ApplyRuleSetsM (Option Expr) := do
+  let val ← mkConstWithFreshMVarLevels rule.header.name
+  let type ← inferType val
+  let (args, _, conclusion) ← forallMetaTelescope type
+  let ok ← withTransparency (← read).config.transparency <| isDefEq conclusion goalType
+  unless ok do
+    return none
+  unless ← synthesizeArgs rule.header.name args entries erased depth do
+    return none
+  return some (← instantiateMVars (mkAppN val args))
+
+/-- Try a ruleproc. -/
+partial def tryProc? (origin : ArgOrigin) (goalType : Expr) (entries : Array RuleEntry)
+    (erased : Std.HashSet Name) (depth : Nat) (rule : ProcRule) :
+    ApplyRuleSetsM (Option Expr) := do
+  let (args, _, conclusion) ← forallMetaTelescope rule.pattern
+  let ok ← withTransparency (← read).config.transparency <| isDefEq conclusion goalType
+  unless ok do
+    trace[Meta.Tactic.apply_rulesets] "ruleproc {rule.header.name} did not match {goalType}"
+    return none
+  unless ← synthesizeArgs rule.header.name args entries erased depth do
+    trace[Meta.Tactic.apply_rulesets]
+      "failed to synthesize ruleproc arguments for {rule.header.name}"
+    return none
+  let args ← args.mapM instantiateMVars
+  let proc ← getRuleProcFromDecl rule.header.name
+  let some proof ← proc args origin goalType
+    | trace[Meta.Tactic.apply_rulesets] "ruleproc {rule.header.name} returned none"; return none
+  let proofType ← inferType proof
+  let ok ← withTransparency (← read).config.transparency <| isDefEq proofType goalType
+  unless ok do
+    trace[Meta.Tactic.apply_rulesets]
+      "ruleproc {rule.header.name} returned proof of wrong type {proofType} for {goalType}"
+    return none
+  return some proof
+
+/-- Try any rule entry. -/
+partial def tryEntry? (origin : ArgOrigin) (goalType : Expr) (entries : Array RuleEntry)
+    (erased : Std.HashSet Name) (depth : Nat) : RuleEntry → ApplyRuleSetsM (Option Expr)
+  | .theorem rule => tryTheorem? origin goalType entries erased depth rule
+  | .proc rule => tryProc? origin goalType entries erased depth rule
+
+end
+
+open Parser.Tactic in
+syntax applyRuleSetErase := "-" term:max
+syntax applyRuleSetArg := applyRuleSetErase <|> term
+syntax applyRuleSetArgs := "[" applyRuleSetArg,* "]"
+
+/-- Config elaborator for `apply_rulesets`. -/
+declare_config_elab elabApplyRuleSetsConfig Config
+
+syntax (name := applyRuleSetsTac) "apply_rulesets" optConfig (discharger)? ppSpace
+  applyRuleSetArgs : tactic
+
+open Parser.Tactic in
+private def parseApplyRuleSetArgs (args : TSyntax ``applyRuleSetArgs) :
+    Array (TSyntax ``applyRuleSetArg) :=
+  match args with
+  | `(applyRuleSetArgs| [$xs,*]) => xs.getElems
+  | _ => #[]
+
+open Mathlib.Meta.FunProp in
+private def tacticDischarger (d? : Option (TSyntax ``Parser.Tactic.discharger)) :
+    TacticM (ArgOrigin → Expr → MetaM (Option Expr)) := do
+  match d? with
+  | none => return fun _ _ => pure none
+  | some d =>
+    match d with
+    | `(discharger| (discharger := $tac)) =>
+      let disch := Mathlib.Meta.FunProp.tacticToDischarge (← `(tactic| ($tac)))
+      return fun _ e => disch e
+    | _ => return fun _ _ => pure none
+
+@[tactic applyRuleSetsTac]
+def evalApplyRuleSets : Tactic := fun stx => do
+  let `(tactic| apply_rulesets $cfgStx:optConfig $[$d?]? $argsStx:applyRuleSetArgs) := stx
+    | throwUnsupportedSyntax
+  let cfg ← elabApplyRuleSetsConfig cfgStx
+  let disch ← tacticDischarger d?
+  let args := parseApplyRuleSetArgs argsStx
+  let mut rulesets := #[]
+  let mut explicitTerms : Array Term := #[]
+  let mut erased : Std.HashSet Name := {}
+  let mut positives := 0
+  for arg in args do
+    match arg with
+    | `(applyRuleSetArg| - $t:term) =>
+      match t.raw with
+      | .ident _ _ val _ => erased := erased.insert val
+      | _ => throwErrorAt t "apply_rulesets only supports removals by name"
+    | `(applyRuleSetArg| $t:term) =>
+      positives := positives + 1
+      match t.raw with
+      | .ident _ _ val _ =>
+        if ← isRuleSetName val then
+          rulesets := rulesets.push val
+        else
+          explicitTerms := explicitTerms.push t
+      | _ => explicitTerms := explicitTerms.push t
+    | _ => throwUnsupportedSyntax
+  if positives == 0 then
+    throwError "apply_rulesets requires at least one positive ruleset, theorem, or term"
+  withMainContext do
+    let goal ← getMainGoal
+    let goalType ← goal.getType
+    let mut explicitRules := #[]
+    for h : i in [:explicitTerms.size] do
+      let e ← Term.elabTerm explicitTerms[i].raw none
+      explicitRules := explicitRules.push ({ order := i, expr := e } : ExplicitRule)
+    Term.synthesizeSyntheticMVarsNoPostponing
+    let allEntries := #[]
+    let ctx : Context :=
+      { config := cfg, rulesets := rulesets, explicitRules := explicitRules, disch := disch }
+    let s : State := {}
+    let (proof?, _) ←
+      (prove? { ruleName := Name.anonymous } goalType allEntries erased 0).run ctx |>.run s
+    match proof? with
+    | some proof => goal.assign proof; replaceMainGoal []
+    | none => throwError "apply_rulesets failed"
+
+end Tactic.ApplyRuleSets
+end Mathlib

--- a/Mathlib/Tactic/ApplyRuleSets/Elab.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Elab.lean
@@ -55,13 +55,15 @@ syntax applyRuleSetErase := "-" term:max
 syntax applyRuleSetDischarger := "by " tacticSeq
 syntax applyRuleSetArg := applyRuleSetErase <|> applyRuleSetDischarger <|> term
 syntax applyRuleSetArgs := "[" applyRuleSetArg,* "]"
+syntax applyRuleSetsProfile := "+profile"
 
 /-- Config elaborator for `apply_rulesets`. -/
 declare_config_elab elabApplyRuleSetsConfig Config
 
-syntax (name := applyRuleSetsTac) "apply_rulesets" optConfig (discharger)?
+syntax (name := applyRuleSetsTac) "apply_rulesets" optConfig (applyRuleSetsProfile)? (discharger)?
   (ppSpace applyRuleSetArgs)? : tactic
-syntax (name := applyRuleSetsQuestionTac) "apply_rulesets?" optConfig (discharger)?
+syntax (name := applyRuleSetsQuestionTac) "apply_rulesets?" optConfig (applyRuleSetsProfile)?
+  (discharger)?
   (ppSpace applyRuleSetArgs)? : tactic
 
 open Parser.Tactic in
@@ -160,15 +162,15 @@ private def mkExplicitExprRule (origin : Origin) (order : Nat) (ref : Term) (e :
   return rule
 
 private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
+    (profileStx? : Option (TSyntax ``applyRuleSetsProfile))
     (d? : Option (TSyntax ``Parser.Tactic.discharger))
     (argsStx? : Option (TSyntax ``applyRuleSetArgs)) (forceCollectFailedSubgoals : Bool) :
     TacticM Unit := do
   let cfg ← elabApplyRuleSetsConfig cfgStx
   let cfg :=
-    if forceCollectFailedSubgoals then
-      { cfg with collectFailedSubgoals := true }
-    else
-      cfg
+    { cfg with
+      collectFailedSubgoals := cfg.collectFailedSubgoals || forceCollectFailedSubgoals
+      profile := cfg.profile || profileStx?.isSome }
   let mut dischargers := #[]
   if let some disch ← deprecatedDischarger? d? then
     dischargers := dischargers.push disch
@@ -215,8 +217,11 @@ private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
         erased := erased,
         disch := disch
         lctxInitIndices := (← getLCtx).numIndices }
-    let s : State := { goalCaches := #[{ minLctxIndex := (← getLCtx).numIndices }] }
+    let profile ← if cfg.profile then initProfileState else pure {}
+    let s : State := { goalCaches := #[{ minLctxIndex := (← getLCtx).numIndices }], profile }
     let (proof?, s) ← (applyRuleSets { ruleName := Name.anonymous } goalType).run ctx |>.run s
+    if cfg.profile then
+      logInfo (← finishProfileReport s.profile)
     match proof? with
     | some proof => goal.assign proof; replaceMainGoal []
     | none =>
@@ -226,15 +231,19 @@ private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
 
 @[tactic applyRuleSetsTac]
 def evalApplyRuleSets : Tactic := fun stx => do
-  let `(tactic| apply_rulesets $cfgStx:optConfig $[$d?]? $[$argsStx?:applyRuleSetArgs]?) := stx
+  let `(tactic|
+      apply_rulesets $cfgStx:optConfig $[$profileStx?:applyRuleSetsProfile]?
+        $[$d?]? $[$argsStx?:applyRuleSetArgs]?) := stx
     | throwUnsupportedSyntax
-  evalApplyRuleSetsCore cfgStx d? argsStx? (forceCollectFailedSubgoals := false)
+  evalApplyRuleSetsCore cfgStx profileStx? d? argsStx? (forceCollectFailedSubgoals := false)
 
 @[tactic applyRuleSetsQuestionTac]
 def evalApplyRuleSetsQuestion : Tactic := fun stx => do
-  let `(tactic| apply_rulesets? $cfgStx:optConfig $[$d?]? $[$argsStx?:applyRuleSetArgs]?) := stx
+  let `(tactic|
+      apply_rulesets? $cfgStx:optConfig $[$profileStx?:applyRuleSetsProfile]?
+        $[$d?]? $[$argsStx?:applyRuleSetArgs]?) := stx
     | throwUnsupportedSyntax
-  evalApplyRuleSetsCore cfgStx d? argsStx? (forceCollectFailedSubgoals := true)
+  evalApplyRuleSetsCore cfgStx profileStx? d? argsStx? (forceCollectFailedSubgoals := true)
 
 
 end Tactic.ApplyRuleSets

--- a/Mathlib/Tactic/ApplyRuleSets/Elab.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Elab.lean
@@ -5,17 +5,13 @@ Authors: Tomáš Skřivan
 -/
 module
 
-public meta import Mathlib.Lean.Meta.RefinedDiscrTree.Initialize
-public meta import Mathlib.Lean.Meta.RefinedDiscrTree.Lookup
-public import Lean.Elab.Tactic.Config
-public import Lean.Elab.Tactic.ElabTerm
-public import Lean.Meta.Tactic.SolveByElim
+public import Mathlib.Tactic.ApplyRuleSets.Core
 public import Mathlib.Tactic.FunProp.Decl
 
 /-!
 # The `apply_rulesets` tactic
 
-This file defines a first version of a configurable backward-search tactic using named rulesets.
+This file defines tactic elaboration for a configurable backward-search tactic using named rulesets.
 Rulesets contain theorem rules and procedural rules (`ruleproc`s) in one ordered database.
 -/
 
@@ -26,627 +22,6 @@ namespace Tactic.ApplyRuleSets
 
 open Lean Meta Elab Tactic Term
 open Lean.Parser.Tactic
-open Lean.Meta.RefinedDiscrTree
-
-initialize registerTraceClass `Meta.Tactic.apply_rulesets
-initialize registerTraceClass `Meta.Tactic.apply_rulesets.attr
-
-/-- Configuration for `apply_rulesets`. -/
-structure Config extends ApplyConfig where
-  /-- Maximum recursive depth. -/
-  maxDepth : Nat := 50
-  /-- Maximum number of candidate attempts. -/
-  maxSteps : Nat := 10000
-  /-- Transparency used by unification. -/
-  transparency : TransparencyMode := .default
-  /-- Use local hypotheses to solve proposition goals. -/
-  assumption : Bool := true
-  /-- Introduce leading binders and continue recursively. -/
-  intro : Bool := true
-  /-- Run the tactic embedded in `autoParam` goals. -/
-  autoParam : Bool := true
-
-instance : Inhabited Config := ⟨{}⟩
-
-/-- Information about a goal passed to a rule or discharger. -/
-structure ArgOrigin where
-  /-- The theorem or term rule that generated the goal, or `anonymous` for the root goal. -/
-  ruleName : Name
-  /-- Argument index in the theorem telescope, or `none` for the root goal. -/
-  argIndex : Option Nat := none
-  /-- Argument binder name in the theorem telescope, or `none` for the root goal. -/
-  argName : Option Name := none
-deriving Inhabited, BEq
-
-/-- Explicit tactic-call theorem or term. -/
-structure ExplicitRule where
-  order : Nat
-  expr : Expr
-deriving Inhabited
-
-def ExplicitRule.name (r : ExplicitRule) : Name :=
-  r.expr.constName?.getD (`apply_rulesets.explicit ++ Name.num Name.anonymous r.order)
-
-/-- Search context. -/
-structure Context where
-  config : Config := {}
-  rulesets : Array Name := #[]
-  explicitRules : Array ExplicitRule := #[]
-  erased : Std.HashSet Name := {}
-  /-- Side-condition discharger for proposition arguments. -/
-  disch : ArgOrigin → Expr → MetaM (Option Expr) := fun _ _ => pure none
-
-/-- Search state. -/
-structure State where
-  numSteps : Nat := 0
-  depth : Nat := 0
-  messages : List String := []
-
-/-- Monad used by `apply_rulesets`. -/
-abbrev ApplyRuleSetsM := ReaderT Context <| StateT State MetaM
-
-/-- A procedural rule. The array contains the synthesized arguments from the ruleproc pattern. -/
-abbrev RuleProc := Array Expr → ArgOrigin → Expr → ApplyRuleSetsM (Option Expr)
-
-/-- Common metadata for theorem rules and ruleprocs. -/
-structure RuleHeader where
-  name : Name
-  priority : Nat := eval_prio default
-  order : Nat := 0
-  explicit : Bool := false
-deriving Inhabited, BEq
-
-/-- A theorem rule stored in a ruleset. -/
-structure TheoremRule where
-  header : RuleHeader
-deriving Inhabited, BEq
-
-/-- A procedural rule stored in a ruleset. -/
-structure ProcRule where
-  header : RuleHeader
-  pattern : Expr
-  levelParams : Array Name := #[]
-deriving Inhabited, BEq
-
-/-- A rule entry. -/
-inductive RuleEntry where
-  | theorem (rule : TheoremRule)
-  | proc (rule : ProcRule)
-deriving Inhabited, BEq
-
-def RuleEntry.header : RuleEntry → RuleHeader
-  | .theorem r => r.header
-  | .proc r => r.header
-
-/-- Ruleset data kept in the environment. -/
-structure RuleSet where
-  entries : Array RuleEntry := #[]
-  tree : RefinedDiscrTree RuleEntry := {}
-deriving Inhabited
-
-/-- All registered rulesets. -/
-structure RuleSets where
-  ruleSets : Std.HashMap Name RuleSet := {}
-  nextOrder : Nat := 0
-deriving Inhabited
-
-/-- Entry added to the global ruleset extension. -/
-structure RuleSetExtEntry where
-  ruleSetName : Name
-  entry : RuleEntry
-  keys : List (Key × LazyEntry)
-deriving Inhabited
-
-initialize ruleSetsExt : SimpleScopedEnvExtension RuleSetExtEntry RuleSets ←
-  registerSimpleScopedEnvExtension {
-    name := by exact decl_name%
-    initial := {}
-    addEntry := fun s e =>
-      let header := e.entry.header
-      let header := { header with order := s.nextOrder, explicit := false }
-      let entry := match e.entry with
-        | .theorem r => .theorem { r with header := header }
-        | .proc r => .proc { r with header := header }
-      let rs := s.ruleSets.getD e.ruleSetName {}
-      let tree := e.keys.foldl (fun t (key, lazyEntry) =>
-        RefinedDiscrTree.insert t key (lazyEntry, entry)) rs.tree
-      let rs := { entries := rs.entries.push entry, tree := tree }
-      { ruleSets := s.ruleSets.insert e.ruleSetName rs, nextOrder := s.nextOrder + 1 }
-  }
-
-/-- Return true if `name` is a registered ruleset. -/
-def isRuleSetName (name : Name) : CoreM Bool := do
-  return (ruleSetsExt.getState (← getEnv)).ruleSets.contains name
-
-/-- Get a registered ruleset. -/
-def getRuleSet (name : Name) : CoreM RuleSet := do
-  return (ruleSetsExt.getState (← getEnv)).ruleSets.getD name {}
-
-/-- Compute indexing keys for a theorem conclusion or ruleproc pattern. -/
-def keysForPattern (pattern : Expr) : MetaM (List (Key × LazyEntry)) := do
-  RefinedDiscrTree.initializeLazyEntryWithEta pattern
-
-/-- Add a theorem to a ruleset. -/
-def addTheoremRule (ruleSetName declName : Name) (kind : AttributeKind)
-    (prio : Nat := eval_prio default) : MetaM Unit := do
-  let info ← getConstInfo declName
-  let (_, _, conclusion) ← forallMetaTelescope info.type
-  let keys ← keysForPattern conclusion
-  let entry : RuleEntry := .theorem { header := { name := declName, priority := prio } }
-  ruleSetsExt.add { ruleSetName, entry, keys } kind
-  trace[Meta.Tactic.apply_rulesets.attr] "added theorem rule {declName} to {ruleSetName}"
-
-/-- Persistent information about a declared ruleproc pattern. -/
-structure RuleProcDecl where
-  declName : Name
-  pattern : Expr
-  levelParams : Array Name := #[]
-  keys : List (Key × LazyEntry)
-deriving Inhabited
-
-initialize ruleProcDeclExt : SimpleScopedEnvExtension RuleProcDecl (Std.HashMap Name RuleProcDecl) ←
-  registerSimpleScopedEnvExtension {
-    name := by exact decl_name%
-    initial := {}
-    addEntry := fun s e => s.insert e.declName e
-  }
-
-private partial def collectLevelParamsLevel (u : Level) (params : Std.HashSet Name) :
-    Std.HashSet Name :=
-  match u with
-  | .zero | .mvar _ => params
-  | .succ u => collectLevelParamsLevel u params
-  | .max u v | .imax u v => collectLevelParamsLevel v (collectLevelParamsLevel u params)
-  | .param n => params.insert n
-
-private partial def collectLevelParamsExpr (e : Expr) (params : Std.HashSet Name := {}) :
-    Std.HashSet Name :=
-  match e with
-  | .bvar _ | .fvar _ | .mvar _ | .sort _ | .lit _ => params
-  | .const _ us => us.foldl (fun params u => collectLevelParamsLevel u params) params
-  | .app f a => collectLevelParamsExpr a (collectLevelParamsExpr f params)
-  | .lam _ d b _ | .forallE _ d b _ =>
-      collectLevelParamsExpr b (collectLevelParamsExpr d params)
-  | .letE _ t v b _ =>
-      collectLevelParamsExpr b (collectLevelParamsExpr v (collectLevelParamsExpr t params))
-  | .mdata _ e | .proj _ _ e => collectLevelParamsExpr e params
-
-private def collectLevelParams (e : Expr) : Array Name :=
-  collectLevelParamsExpr e |>.toArray
-
-/-- Register the pattern for a ruleproc declaration. -/
-def registerRuleProcPattern (declName : Name) (pattern : Expr)
-    (levelParams : Array Name := #[]) : MetaM Unit := do
-  let levelParams := levelParams ++ (collectLevelParams pattern).filter (!levelParams.contains ·)
-  let (_, _, conclusion) ← forallMetaTelescope pattern
-  let keys ← keysForPattern conclusion
-  modifyEnv fun env => ruleProcDeclExt.addEntry env { declName, pattern, levelParams, keys }
-
-/-- Return registered pattern information for a ruleproc declaration. -/
-def getRuleProcDecl? (declName : Name) : CoreM (Option RuleProcDecl) := do
-  return (ruleProcDeclExt.getState (← getEnv)).get? declName
-
-/-- Register a ruleproc in a ruleset. -/
-def addProcRule (ruleSetName declName : Name) (kind : AttributeKind)
-    (prio : Nat := eval_prio default) : MetaM Unit := do
-  let some decl ← getRuleProcDecl? declName
-    | throwError "invalid ruleproc attribute: `{.ofConstName declName}` has no registered pattern"
-  let info ← getConstInfo declName
-  unless (← isDefEq info.type (mkConst ``RuleProc)) do
-    throwError "invalid ruleproc: `{.ofConstName declName}` has type{indentExpr info.type}\
-      \nexpected `RuleProc`"
-  let header := { name := declName, priority := prio }
-  let entry : RuleEntry :=
-    .proc { header, pattern := decl.pattern, levelParams := decl.levelParams }
-  ruleSetsExt.add { ruleSetName, entry, keys := decl.keys } kind
-  trace[Meta.Tactic.apply_rulesets.attr] "added ruleproc {declName} to {ruleSetName}"
-
-/-- Evaluate a ruleproc declaration. -/
-unsafe def getRuleProcFromDeclImpl (declName : Name) : MetaM RuleProc := do
-  let env ← getEnv
-  let opts ← getOptions
-  match env.evalConst RuleProc opts declName with
-  | .ok proc => return proc
-  | .error err => throwError err
-
-@[implemented_by getRuleProcFromDeclImpl]
-opaque getRuleProcFromDecl (declName : Name) : MetaM RuleProc
-
-/-- Declaration command used internally to register a ruleproc pattern. -/
-elab "ruleproc_pattern% " pat:term " => " proc:ident : command => do
-  Command.liftTermElabM do
-    let procName ← realizeGlobalConstNoOverload proc
-    let pattern ← Term.withAutoBoundImplicit <| Term.elabType pat
-    Term.synthesizeSyntheticMVars
-    let pattern ← abstractMVars (← instantiateMVars pattern)
-    let levelParams := pattern.paramNames
-    let pattern ← lambdaTelescope pattern.expr fun xs pattern => mkForallFVars xs pattern
-    registerRuleProcPattern procName pattern levelParams
-
-private def mkRuleProcBody (xs : Ident) (names : Array (Nat × Name)) (body : Term) :
-    MacroM Term := do
-  let mut result := body
-  for i in [0:names.size] do
-    let i := names.size - 1 - i
-    let (argIdx, name) := names[i]!
-    let id := mkIdentFrom body name
-    let idx := quote argIdx
-    result ← `(let $id:ident : Lean.Expr := $xs[$idx]!; $result)
-  return result
-
-private def removeUnusedForallBinders (e : Expr) : MetaM Expr := do
-  forallTelescope e fun xs body => do
-    let mut result := body
-    for _h : i in [:xs.size] do
-      let i := xs.size - 1 - i
-      let x := xs[i]!
-      if result.containsFVar x.fvarId! then
-        let decl ← x.fvarId!.getDecl
-        result := Expr.forallE decl.userName decl.type (result.abstract #[x]) decl.binderInfo
-    return result
-
-private def closeRuleProcPattern (pat : Term) :
-    TermElabM (Expr × Array Name × Array (Nat × Name)) := do
-  let pattern ← Term.withAutoBoundImplicit <| Term.elabType pat
-  Term.synthesizeSyntheticMVars
-  let pattern ← abstractMVars (← instantiateMVars pattern)
-  let levelParams := pattern.paramNames
-  let pattern ← lambdaTelescope pattern.expr fun xs pattern => mkForallFVars xs pattern
-  let pattern ← removeUnusedForallBinders pattern
-  let names ← forallTelescope pattern fun xs _ => do
-    let mut names := #[]
-    for h : i in [:xs.size] do
-      let name ← xs[i].fvarId!.getUserName
-      unless name.isAnonymous do
-        names := names.push (i, name)
-    return names
-  return (pattern, levelParams, names)
-
-private def attrInstancesOfAttributes (attrs : TSyntax ``Parser.Term.attributes) :
-    Array (TSyntax ``Parser.Term.attrInstance) :=
-  attrs.raw[1].getArgs.filterMap fun stx =>
-    if stx.isOfKind ``Parser.Term.attrInstance then
-      some ⟨stx⟩
-    else
-      none
-
-/-- Syntax for a ruleproc declaration. -/
-syntax (name := ruleprocCmd) (docComment)? (Parser.Term.attributes)? "ruleproc " ident
-  (ppSpace bracketedBinder)* " : " term " := "
-  term : command
-
-@[command_elab ruleprocCmd]
-def elabRuleProc : Command.CommandElab := fun stx => do
-  let `(command| $[$doc?:docComment]? $[$attrs?:attributes]? ruleproc $n:ident $bs* :
-      $pat:term := $body:term) := stx
-    | throwUnsupportedSyntax
-  let scope ← Command.getScope
-  let varDecls : TSyntaxArray ``Lean.Parser.Term.bracketedBinder :=
-    scope.varDecls.map (fun stx => ⟨stx⟩)
-  let allBinders := varDecls ++ bs
-  let pat ← `(∀ $allBinders*, $pat)
-  let (pattern, levelParams, names) ← Command.liftTermElabM <| closeRuleProcPattern pat
-  let xs := mkIdent `__ruleprocArgs
-  let body ← liftMacroM <| mkRuleProcBody xs names body
-  Command.elabCommand <| ← `($[$doc?:docComment]? meta def $n :
-    Mathlib.Tactic.ApplyRuleSets.RuleProc := fun $xs:ident => $body)
-  Command.liftTermElabM do
-    let procName ← realizeGlobalConstNoOverload n
-    registerRuleProcPattern procName pattern levelParams
-  if let some attrs := attrs? then
-    let attrInsts := attrInstancesOfAttributes attrs
-    Command.elabCommand <| ← `(command| attribute [$attrInsts,*] $n)
-
-/-- Register the theorem and proc attributes for a ruleset. -/
-def registerRuleSetAttr (ruleSetName : Name) (descr : String) : IO Unit := do
-  registerBuiltinAttribute {
-    name := ruleSetName
-    descr := descr
-    applicationTime := AttributeApplicationTime.afterCompilation
-    add := fun decl stx kind => discard <| MetaM.run do
-      let prio ← getAttrParamOptPrio stx[1]
-      if (← getRuleProcDecl? decl).isSome then
-        addProcRule ruleSetName decl kind prio
-      else
-        addTheoremRule ruleSetName decl kind prio
-    erase := fun _ => throwError "can't remove ruleset attributes"
-  }
-
-/-- Register a new ruleset and its associated attributes. -/
-macro (name := registerRulesetCmd) doc:(docComment)? "register_ruleset " id:ident : command => do
-  let str := id.getId.toString
-  let idParser := mkIdentFrom id (`Parser.Attr ++ id.getId)
-  let descr := quote ((doc.map (·.getDocString) |>.getD s!"ruleset {id.getId}").removeLeadingSpaces)
-  `($[$doc:docComment]? public meta initialize registerRuleSetAttr $(quote id.getId) $descr
-    $[$doc:docComment]? syntax (name := $idParser:ident) $(quote str):str (prio)? : attr)
-
-/-- Increase and check step count. -/
-def checkStep : ApplyRuleSetsM Unit := do
-  let n := (← get).numSteps
-  let maxSteps := (← read).config.maxSteps
-  if n ≥ maxSteps then
-    throwError "apply_rulesets failed, maximum number of steps ({maxSteps}) exceeded"
-  modify fun s => { s with numSteps := s.numSteps + 1 }
-
-/-- Increase the logical search depth without introducing a new metavariable depth. -/
-def withIncreasedSearchDepth {α} (x : ApplyRuleSetsM α) : ApplyRuleSetsM α := do
-  let depth := (← get).depth
-  modify fun s => { s with depth := depth + 1 }
-  try
-    let a ← x
-    modify fun s => { s with depth := depth }
-    return a
-  catch e =>
-    modify fun s => { s with depth := depth }
-    throw e
-
-/-- Roll back metavariable assignments if `x` returns `none` or throws. -/
-def observingWithRollback? {α} (x : ApplyRuleSetsM (Option α)) : ApplyRuleSetsM (Option α) := do
-  let mctx ← getMCtx
-  try
-    match ← x with
-    | some a => return some a
-    | none => setMCtx mctx; return none
-  catch e =>
-    trace[Meta.Tactic.apply_rulesets] "candidate failed: {e.toMessageData}"
-    setMCtx mctx
-    return none
-
-/-- Try to solve a proposition goal by a local hypothesis. -/
-def assumption? (goalType : Expr) : MetaM (Option Expr) := do
-  unless ← isProp goalType do
-    return none
-  for localDecl in ← getLCtx do
-    unless localDecl.isAuxDecl do
-      if ← isProp localDecl.type then
-        if ← isDefEq localDecl.type goalType then
-          return some (mkFVar localDecl.fvarId)
-  return none
-
-/-- Run the tactic embedded in an `autoParam` goal. -/
-def runAutoParam? (goalType : Expr) : MetaM (Option Expr) := do
-  let some (.const tacticDecl _) := goalType.getAutoParamTactic?
-    | return none
-  let goalType := goalType.appFn!.appArg!
-  let .ok tacticSyntax := evalSyntaxConstant (← getEnv) (← getOptions) tacticDecl
-    | return none
-  let tacticSeq : TSyntax `Lean.Parser.Tactic.tacticSeq := ⟨tacticSyntax⟩
-  let tacticCode ← `(tactic| try ($tacticSeq:tacticSeq))
-  let mvar ← mkFreshExprSyntheticOpaqueMVar goalType `apply_rulesets.autoParam
-  let runTac? : TermElabM (Option Expr) := do
-    try
-      Term.withoutModifyingElabMetaStateWithInfo do
-        Term.withSynthesize (postpone := .no) do
-          discard <| Tactic.run mvar.mvarId! <|
-            Tactic.evalTactic tacticCode *> Tactic.pruneSolvedGoals
-        let result ← instantiateMVars mvar
-        if result.hasExprMVar then
-          return none
-        else
-          return some result
-    catch _ =>
-      return none
-  let (result?, _) ← runTac?.run {} {}
-  return result?
-
-/-- Query selected rulesets for candidates matching `goalType`. -/
-def queryRuleSets (goalType : Expr) (rulesets : Array Name) : MetaM (Array RuleEntry) := do
-  let mut out := #[]
-  for rsName in rulesets do
-    let rs ← getRuleSet rsName
-    let (result, _) ← withConfig (fun cfg => { cfg with iota := false, zeta := false }) <|
-      rs.tree.getMatch goalType true true
-    out := out ++ result.toArray
-  return out
-
-/-- Sort candidates by priority, explicitness, and insertion order. -/
-def sortEntries (entries : Array RuleEntry) : Array RuleEntry :=
-  entries.qsort fun a b =>
-    let ah := a.header
-    let bh := b.header
-    if ah.priority != bh.priority then
-      ah.priority > bh.priority
-    else if ah.explicit != bh.explicit then
-      ah.explicit && !bh.explicit
-    else
-      ah.order < bh.order
-
-def matchRuleProcConclusion (pattern goal : Expr) : MetaM Bool := do
-  let pattern ← instantiateMVars pattern
-  let goal ← instantiateMVars goal
-  let patternFn := pattern.getAppFn
-  let goalFn := goal.getAppFn
-  if patternFn.constName? == goalFn.constName? && pattern.getAppNumArgs == goal.getAppNumArgs then
-    for patternArg in pattern.getAppArgs, goalArg in goal.getAppArgs do
-      let patternArg ← instantiateMVars patternArg
-      if patternArg.isMVar then
-        try
-          patternArg.mvarId!.assign goalArg
-        catch _ =>
-          unless ← withTransparency .none <| isDefEq patternArg goalArg do
-            return false
-      else
-        unless ← withTransparency .none <| isDefEq patternArg goalArg do
-          return false
-    return true
-  else
-    withTransparency .none <| isDefEq pattern goal
-
-def ProcRule.instantiatePattern (rule : ProcRule) : MetaM Expr := do
-  let us ← rule.levelParams.mapM fun _ => mkFreshLevelMVar
-  return rule.pattern.instantiateLevelParamsArray rule.levelParams us
-
-mutual
-
-partial def applyRuleSets (origin : ArgOrigin) (goalType : Expr) :
-    ApplyRuleSetsM (Option Expr) := do
-  let goalType ← instantiateMVars goalType
-  withTraceNode `Meta.Tactic.apply_rulesets
-    (fun _ => return s!"{← ppExpr goalType}") do
-  checkStep
-  let depth := (← get).depth
-  let maxDepth := (← read).config.maxDepth
-  if depth > maxDepth then
-    trace[Meta.Tactic.apply_rulesets] "maximum recursion depth ({maxDepth}) exceeded"
-    return none
-  let cfg := (← read).config
-  if cfg.autoParam then
-    if let some proof ← observingWithRollback? <| runAutoParam? goalType then
-      trace[Meta.Tactic.apply_rulesets] "solved by autoParam tactic"
-      return some proof
-  if cfg.assumption then
-    if let some proof ← observingWithRollback? <| assumption? goalType then
-      trace[Meta.Tactic.apply_rulesets] "solved by local assumption"
-      return some proof
-  if cfg.intro then
-    let some proof ← observingWithRollback? <| forallTelescopeReducing goalType fun xs body => do
-      if xs.isEmpty then
-        return none
-      trace[Meta.Tactic.apply_rulesets] "introducing {xs.size} binder(s)"
-      let some proof ← withIncreasedSearchDepth <| applyRuleSets origin body | return none
-      return some (← mkLambdaFVars xs proof)
-      | pure ()
-    return some proof
-  let entries := sortEntries (← queryRuleSets goalType (← read).rulesets)
-  trace[Meta.Tactic.apply_rulesets]
-    "candidate rules: {entries.map fun entry => entry.header.name}"
-  for rule in (← read).explicitRules do
-    if let some proof ←
-        observingWithRollback? <| tryExplicit? origin goalType rule then
-      return some proof
-  for entry in entries do
-    unless (← read).erased.contains entry.header.name do
-      if let some proof ←
-          observingWithRollback? <| tryEntry? origin goalType entry then
-        return some proof
-  trace[Meta.Tactic.apply_rulesets] "no rule matched"
-  return none
-
-/-- Synthesize arguments created by theorem or ruleproc application. -/
-partial def synthesizeArgs (ruleName : Name) (args : Array Expr)
-    (allowPostponed := false) : ApplyRuleSetsM Bool := do
-  let mut postponed := #[]
-  for h : i in [:args.size] do
-    let arg := args[i]
-    if (← instantiateMVars arg).isMVar then
-      let type ← inferType arg
-      if (← isClass? type).isSome then
-        if let .some inst ← trySynthInstance type then
-          if (← isDefEq arg inst) then
-            continue
-          else
-            trace[Meta.Tactic.apply_rulesets]
-              "{ruleName}, failed to assign instance{indentExpr type}\
-              \nsynthesized value{indentExpr inst}\nis not definitionally equal to{indentExpr arg}"
-        else
-          trace[Meta.Tactic.apply_rulesets]
-            "{ruleName}, failed to synthesize instance{indentExpr type}"
-      if (← isProp type) then
-        let argName := (← getMCtx).getDecl arg.mvarId! |>.userName
-        let origin := { ruleName, argIndex := some i, argName := some argName }
-        if let some proof ← withIncreasedSearchDepth <| applyRuleSets origin type then
-          if (← isDefEq arg proof) then
-            continue
-          else
-            trace[Meta.Tactic.apply_rulesets]
-              "{ruleName}, failed to assign proof{indentExpr type}"
-        let ctx ← read
-        if let some proof ← ctx.disch origin type then
-          if (← isDefEq arg proof) then
-            continue
-          else
-            trace[Meta.Tactic.apply_rulesets]
-              "{ruleName}, failed to assign discharger proof{indentExpr type}"
-        trace[Meta.Tactic.apply_rulesets]
-          "{ruleName}, failed to discharge hypothesis{indentExpr type}"
-        return false
-      else
-        postponed := postponed.push arg
-  for arg in postponed do
-    if (← instantiateMVars arg).isMVar then
-      if allowPostponed then
-        continue
-      trace[Meta.Tactic.apply_rulesets]
-        "{ruleName}, failed to infer `({← ppExpr arg} : {← ppExpr (← inferType arg)})`"
-      return false
-  return true
-
-/-- Try an explicit theorem or term provided in the tactic call. -/
-partial def tryExplicit? (_origin : ArgOrigin) (goalType : Expr) (r : ExplicitRule) :
-    ApplyRuleSetsM (Option Expr) := do
-  let name := r.name
-  withTraceNode `Meta.Tactic.apply_rulesets
-    (fun _ => return s!"applying explicit rule: {name}") do
-  if (← read).erased.contains name then
-    trace[Meta.Tactic.apply_rulesets] "rule is erased"
-    return none
-  let type ← inferType r.expr
-  let (args, _, conclusion) ← forallMetaTelescope type
-  let ok ← withTransparency (← read).config.transparency <| isDefEq conclusion goalType
-  unless ok do
-    trace[Meta.Tactic.apply_rulesets]
-      "failed to unify explicit rule conclusion{indentExpr conclusion}\nwith{indentExpr goalType}"
-    return none
-  unless ← synthesizeArgs name args do return none
-  return some (← instantiateMVars (mkAppN r.expr args))
-
-/-- Try a theorem rule. -/
-partial def tryTheorem? (_origin : ArgOrigin) (goalType : Expr) (rule : TheoremRule) :
-    ApplyRuleSetsM (Option Expr) := do
-  withTraceNode `Meta.Tactic.apply_rulesets
-    (fun _ => return s!"applying theorem: {rule.header.name}") do
-  let val ← mkConstWithFreshMVarLevels rule.header.name
-  let type ← inferType val
-  let (args, _, conclusion) ← forallMetaTelescope type
-  let ok ← withTransparency (← read).config.transparency <| isDefEq conclusion goalType
-  unless ok do
-    trace[Meta.Tactic.apply_rulesets]
-      "failed to unify {rule.header.name} conclusion{indentExpr conclusion}\
-      \nwith{indentExpr goalType}"
-    return none
-  unless ← synthesizeArgs rule.header.name args do
-    return none
-  return some (← instantiateMVars (mkAppN val args))
-
-/-- Try a ruleproc. -/
-partial def tryProc? (origin : ArgOrigin) (goalType : Expr) (rule : ProcRule) :
-    ApplyRuleSetsM (Option Expr) := do
-  withTraceNode `Meta.Tactic.apply_rulesets
-    (fun _ => return s!"applying ruleproc: {rule.header.name}") do
-  let pattern ← rule.instantiatePattern
-  let (args, _, conclusion) ← forallMetaTelescope pattern
-  let ok ← matchRuleProcConclusion conclusion goalType
-  unless ok do
-    trace[Meta.Tactic.apply_rulesets]
-      "failed to unify ruleproc pattern{indentExpr conclusion}\nwith{indentExpr goalType}"
-    return none
-  unless ← synthesizeArgs rule.header.name args (allowPostponed := true) do
-    trace[Meta.Tactic.apply_rulesets]
-      "failed to synthesize ruleproc arguments for {rule.header.name}"
-    return none
-  let args ← args.mapM instantiateMVars
-  let proc ← getRuleProcFromDecl rule.header.name
-  let some proof ← proc args origin goalType
-    | trace[Meta.Tactic.apply_rulesets] "ruleproc {rule.header.name} returned none"; return none
-  let proofType ← inferType proof
-  let ok ← withTransparency (← read).config.transparency <| isDefEq proofType goalType
-  unless ok do
-    trace[Meta.Tactic.apply_rulesets]
-      "ruleproc {rule.header.name} returned proof of wrong type{indentExpr proofType}\
-      \nfor{indentExpr goalType}"
-    return none
-  return some proof
-
-/-- Try any rule entry. -/
-partial def tryEntry? (origin : ArgOrigin) (goalType : Expr) :
-    RuleEntry → ApplyRuleSetsM (Option Expr)
-  | .theorem rule => tryTheorem? origin goalType rule
-  | .proc rule => tryProc? origin goalType rule
-
-end
-
-/-- Backward-search using the active rule sets. Alias for `applyRuleSets`. -/
-abbrev appluRuleSets := applyRuleSets
 
 open Parser.Tactic in
 syntax applyRuleSetErase := "-" term:max
@@ -656,8 +31,10 @@ syntax applyRuleSetArgs := "[" applyRuleSetArg,* "]"
 /-- Config elaborator for `apply_rulesets`. -/
 declare_config_elab elabApplyRuleSetsConfig Config
 
-syntax (name := applyRuleSetsTac) "apply_rulesets" optConfig (discharger)? ppSpace
-  applyRuleSetArgs : tactic
+syntax (name := applyRuleSetsTac) "apply_rulesets" optConfig (discharger)?
+  (ppSpace applyRuleSetArgs)? : tactic
+syntax (name := applyRuleSetsQuestionTac) "apply_rulesets?" optConfig (discharger)?
+  (ppSpace applyRuleSetArgs)? : tactic
 
 open Parser.Tactic in
 private def parseApplyRuleSetArgs (args : TSyntax ``applyRuleSetArgs) :
@@ -678,25 +55,74 @@ private def tacticDischarger (d? : Option (TSyntax ``Parser.Tactic.discharger)) 
       return fun _ e => disch e
     | _ => return fun _ _ => pure none
 
-@[tactic applyRuleSetsTac]
-def evalApplyRuleSets : Tactic := fun stx => do
-  let `(tactic| apply_rulesets $cfgStx:optConfig $[$d?]? $argsStx:applyRuleSetArgs) := stx
-    | throwUnsupportedSyntax
+open Lean Meta in
+private partial def leadingIndent (source : String) (pos : String.Pos.Raw) : String :=
+  let rec go (i : String.Pos.Raw) : String.Pos.Raw :=
+    if i.atEnd source then
+      i
+    else
+      let c := i.get source
+      if c == ' ' || c == '\t' then
+        go (i.next source)
+      else
+        i
+  String.Pos.Raw.extract source pos (go pos)
+
+open Lean.Meta.Tactic.TryThis in
+def addHaveSuggestions (ref : Syntax) (goals : Array Expr) : TacticM Unit := do
+  let some refRange := ref.getRange? | return
+  let fileMap ← getFileMap
+  let lineStart := fileMap.lineStart (fileMap.toPosition refRange.start).line
+  let source := fileMap.source
+  let insertionRange : Syntax.Range := ⟨lineStart, lineStart⟩
+
+  let indent := leadingIndent source lineStart
+  let mut collected : ExprSet := {}
+  let mut suggestions : Array Suggestion := #[]
+  for goal in goals do
+    if !collected.contains goal then
+      collected := collected.insert goal
+      let suggestion : Suggestion := {
+        suggestion := .string s!"{indent}have : {← ppExpr goal} := sorry\n"
+        toCodeActionTitle? := some fun _ => "Insert `have` for current goal"
+      }
+      suggestions := suggestions.push suggestion
+  addSuggestions ref suggestions (origSpan? := some (Syntax.ofRange insertionRange))
+    (header := "Code action:")
+
+private def explicitRuleId (order : Nat) : Name :=
+  `apply_rulesets.explicit ++ Name.num Name.anonymous order
+
+private def explicitOrigin (order : Nat) (ref : Syntax) (expr : Expr) : Origin :=
+  match expr with
+  | .fvar fvarId => .fvar fvarId
+  | _ =>
+    match expr.constName? with
+    | some declName => .decl declName
+    | none => .stx (explicitRuleId order) ref
+
+private def evalApplyRuleSetsCore (cfgStx : TSyntax ``Parser.Tactic.optConfig)
+    (d? : Option (TSyntax ``Parser.Tactic.discharger))
+    (argsStx? : Option (TSyntax ``applyRuleSetArgs)) (forceCollectFailedSubgoals : Bool) :
+    TacticM Unit := do
   let cfg ← elabApplyRuleSetsConfig cfgStx
+  let cfg :=
+    if forceCollectFailedSubgoals then
+      { cfg with collectFailedSubgoals := true }
+    else
+      cfg
   let disch ← tacticDischarger d?
-  let args := parseApplyRuleSetArgs argsStx
+  let args := argsStx?.map parseApplyRuleSetArgs |>.getD #[]
   let mut rulesets := #[]
   let mut explicitTerms : Array Term := #[]
   let mut erased : Std.HashSet Name := {}
-  let mut positives := 0
   for arg in args do
     match arg with
     | `(applyRuleSetArg| - $t:term) =>
       match t.raw with
-      | .ident _ _ val _ => erased := erased.insert val
+      | .ident .. => erased := erased.insert (← realizeGlobalConstNoOverload t.raw)
       | _ => throwErrorAt t "apply_rulesets only supports removals by name"
     | `(applyRuleSetArg| $t:term) =>
-      positives := positives + 1
       match t.raw with
       | .ident _ _ val _ =>
         if ← isRuleSetName val then
@@ -705,24 +131,67 @@ def evalApplyRuleSets : Tactic := fun stx => do
           explicitTerms := explicitTerms.push t
       | _ => explicitTerms := explicitTerms.push t
     | _ => throwUnsupportedSyntax
-  if positives == 0 then
-    throwError "apply_rulesets requires at least one positive ruleset, theorem, or term"
   withMainContext do
     let goal ← getMainGoal
     let goalType ← goal.getType
     let mut explicitRules := #[]
     for h : i in [:explicitTerms.size] do
       let e ← Term.elabTerm explicitTerms[i].raw none
-      explicitRules := explicitRules.push ({ order := i, expr := e } : ExplicitRule)
+      Term.synthesizeSyntheticMVarsNoPostponing
+      let e ← instantiateMVars e
+      let origin := explicitOrigin i explicitTerms[i].raw e
+      if let some rule ← explicitRuleProcRule? origin e then
+        explicitRules := explicitRules.push { rule with order := i }
+      else
+        if e.isLambda then
+          let type ← inferType e
+          let rule : Rule := {
+            origin := origin
+            type := .expr e
+            pattern := type
+            order := i
+          }
+          explicitRules := explicitRules.push rule
+        else
+          let e ← abstractMVars e
+          let type ← inferType e.expr
+          let rule : Rule := {
+            origin := origin
+            type := .expr e.expr
+            pattern := type
+            levelParams := e.paramNames
+            order := i
+          }
+          explicitRules := explicitRules.push rule
     Term.synthesizeSyntheticMVarsNoPostponing
     let ctx : Context :=
-      { config := cfg, rulesets := rulesets, explicitRules := explicitRules, erased := erased,
-        disch := disch }
+      { config := cfg,
+        rulesets := rulesets,
+        explicitRules := explicitRules,
+        erased := erased,
+        disch := disch
+        lctxInitIndices := (← getLCtx).numIndices }
     let s : State := {}
-    let (proof?, _) ← (applyRuleSets { ruleName := Name.anonymous } goalType).run ctx |>.run s
+    let (proof?, s) ← (applyRuleSets { ruleName := Name.anonymous } goalType).run ctx |>.run s
     match proof? with
     | some proof => goal.assign proof; replaceMainGoal []
-    | none => throwError "apply_rulesets failed"
+    | none =>
+      unless cfg.collectFailedSubgoals do
+        throwError "apply_rulesets failed"
+      addHaveSuggestions (← getRef) s.failedSubgoals
+
+@[tactic applyRuleSetsTac]
+def evalApplyRuleSets : Tactic := fun stx => do
+  let `(tactic| apply_rulesets $cfgStx:optConfig $[$d?]? $[$argsStx?:applyRuleSetArgs]?) := stx
+    | throwUnsupportedSyntax
+  evalApplyRuleSetsCore cfgStx d? argsStx? (forceCollectFailedSubgoals := false)
+
+@[tactic applyRuleSetsQuestionTac]
+def evalApplyRuleSetsQuestion : Tactic := fun stx => do
+  let `(tactic| apply_rulesets? $cfgStx:optConfig $[$d?]? $[$argsStx?:applyRuleSetArgs]?) := stx
+    | throwUnsupportedSyntax
+  evalApplyRuleSetsCore cfgStx d? argsStx? (forceCollectFailedSubgoals := true)
+
 
 end Tactic.ApplyRuleSets
 end Mathlib

--- a/Mathlib/Tactic/ApplyRuleSets/Elab.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Elab.lean
@@ -72,12 +72,14 @@ structure Context where
   config : Config := {}
   rulesets : Array Name := #[]
   explicitRules : Array ExplicitRule := #[]
+  erased : Std.HashSet Name := {}
   /-- Side-condition discharger for proposition arguments. -/
   disch : ArgOrigin → Expr → MetaM (Option Expr) := fun _ _ => pure none
 
 /-- Search state. -/
 structure State where
   numSteps : Nat := 0
+  depth : Nat := 0
   messages : List String := []
 
 /-- Monad used by `apply_rulesets`. -/
@@ -103,6 +105,7 @@ deriving Inhabited, BEq
 structure ProcRule where
   header : RuleHeader
   pattern : Expr
+  levelParams : Array Name := #[]
 deriving Inhabited, BEq
 
 /-- A rule entry. -/
@@ -177,6 +180,7 @@ def addTheoremRule (ruleSetName declName : Name) (kind : AttributeKind)
 structure RuleProcDecl where
   declName : Name
   pattern : Expr
+  levelParams : Array Name := #[]
   keys : List (Key × LazyEntry)
 deriving Inhabited
 
@@ -187,11 +191,36 @@ initialize ruleProcDeclExt : SimpleScopedEnvExtension RuleProcDecl (Std.HashMap 
     addEntry := fun s e => s.insert e.declName e
   }
 
+private partial def collectLevelParamsLevel (u : Level) (params : Std.HashSet Name) :
+    Std.HashSet Name :=
+  match u with
+  | .zero | .mvar _ => params
+  | .succ u => collectLevelParamsLevel u params
+  | .max u v | .imax u v => collectLevelParamsLevel v (collectLevelParamsLevel u params)
+  | .param n => params.insert n
+
+private partial def collectLevelParamsExpr (e : Expr) (params : Std.HashSet Name := {}) :
+    Std.HashSet Name :=
+  match e with
+  | .bvar _ | .fvar _ | .mvar _ | .sort _ | .lit _ => params
+  | .const _ us => us.foldl (fun params u => collectLevelParamsLevel u params) params
+  | .app f a => collectLevelParamsExpr a (collectLevelParamsExpr f params)
+  | .lam _ d b _ | .forallE _ d b _ =>
+      collectLevelParamsExpr b (collectLevelParamsExpr d params)
+  | .letE _ t v b _ =>
+      collectLevelParamsExpr b (collectLevelParamsExpr v (collectLevelParamsExpr t params))
+  | .mdata _ e | .proj _ _ e => collectLevelParamsExpr e params
+
+private def collectLevelParams (e : Expr) : Array Name :=
+  collectLevelParamsExpr e |>.toArray
+
 /-- Register the pattern for a ruleproc declaration. -/
-def registerRuleProcPattern (declName : Name) (pattern : Expr) : MetaM Unit := do
+def registerRuleProcPattern (declName : Name) (pattern : Expr)
+    (levelParams : Array Name := #[]) : MetaM Unit := do
+  let levelParams := levelParams ++ (collectLevelParams pattern).filter (!levelParams.contains ·)
   let (_, _, conclusion) ← forallMetaTelescope pattern
   let keys ← keysForPattern conclusion
-  modifyEnv fun env => ruleProcDeclExt.addEntry env { declName, pattern, keys }
+  modifyEnv fun env => ruleProcDeclExt.addEntry env { declName, pattern, levelParams, keys }
 
 /-- Return registered pattern information for a ruleproc declaration. -/
 def getRuleProcDecl? (declName : Name) : CoreM (Option RuleProcDecl) := do
@@ -207,7 +236,8 @@ def addProcRule (ruleSetName declName : Name) (kind : AttributeKind)
     throwError "invalid ruleproc: `{.ofConstName declName}` has type{indentExpr info.type}\
       \nexpected `RuleProc`"
   let header := { name := declName, priority := prio }
-  let entry : RuleEntry := .proc { header, pattern := decl.pattern }
+  let entry : RuleEntry :=
+    .proc { header, pattern := decl.pattern, levelParams := decl.levelParams }
   ruleSetsExt.add { ruleSetName, entry, keys := decl.keys } kind
   trace[Meta.Tactic.apply_rulesets.attr] "added ruleproc {declName} to {ruleSetName}"
 
@@ -222,74 +252,90 @@ unsafe def getRuleProcFromDeclImpl (declName : Name) : MetaM RuleProc := do
 @[implemented_by getRuleProcFromDeclImpl]
 opaque getRuleProcFromDecl (declName : Name) : MetaM RuleProc
 
-/-- Declaration command used internally by `ruleproc_decl`. -/
+/-- Declaration command used internally to register a ruleproc pattern. -/
 elab "ruleproc_pattern% " pat:term " => " proc:ident : command => do
   Command.liftTermElabM do
     let procName ← realizeGlobalConstNoOverload proc
-    let pattern ← Term.elabType pat
+    let pattern ← Term.withAutoBoundImplicit <| Term.elabType pat
     Term.synthesizeSyntheticMVars
-    let pattern ← Term.levelMVarToParam (← instantiateMVars pattern)
-    registerRuleProcPattern procName pattern
+    let pattern ← abstractMVars (← instantiateMVars pattern)
+    let levelParams := pattern.paramNames
+    let pattern ← lambdaTelescope pattern.expr fun xs pattern => mkForallFVars xs pattern
+    registerRuleProcPattern procName pattern levelParams
 
-private def binderNames (binders : Array Syntax) : Array Name := Id.run do
-  let mut names := #[]
-  let mut instIdx := 0
-  for binder in binders do
-    match binder.getKind with
-    | `Lean.Parser.Term.explicitBinder | `Lean.Parser.Term.implicitBinder =>
-      for arg in binder[1].getArgs do
-        if arg.isIdent then
-          let name := arg.getId
-          unless name == `_ do
-            names := names.push name
-    | `Lean.Parser.Term.instBinder =>
-      let explicitNames := binder[1].getArgs.filter Syntax.isIdent |>.map Syntax.getId
-      if explicitNames.isEmpty then
-        names := names.push (.mkSimple s!"_inst{instIdx}")
-        instIdx := instIdx + 1
-      else
-        for name in explicitNames do
-          names := names.push name
-    | _ => pure ()
-  return names
-
-private def mkRuleProcBody (xs : Ident) (names : Array Name) (body : Term) : MacroM Term := do
+private def mkRuleProcBody (xs : Ident) (names : Array (Nat × Name)) (body : Term) :
+    MacroM Term := do
   let mut result := body
   for i in [0:names.size] do
     let i := names.size - 1 - i
-    let id := mkIdent names[i]!
-    let idx := quote i
+    let (argIdx, name) := names[i]!
+    let id := mkIdentFrom body name
+    let idx := quote argIdx
     result ← `(let $id:ident : Lean.Expr := $xs[$idx]!; $result)
   return result
 
+private def removeUnusedForallBinders (e : Expr) : MetaM Expr := do
+  forallTelescope e fun xs body => do
+    let mut result := body
+    for _h : i in [:xs.size] do
+      let i := xs.size - 1 - i
+      let x := xs[i]!
+      if result.containsFVar x.fvarId! then
+        let decl ← x.fvarId!.getDecl
+        result := Expr.forallE decl.userName decl.type (result.abstract #[x]) decl.binderInfo
+    return result
+
+private def closeRuleProcPattern (pat : Term) :
+    TermElabM (Expr × Array Name × Array (Nat × Name)) := do
+  let pattern ← Term.withAutoBoundImplicit <| Term.elabType pat
+  Term.synthesizeSyntheticMVars
+  let pattern ← abstractMVars (← instantiateMVars pattern)
+  let levelParams := pattern.paramNames
+  let pattern ← lambdaTelescope pattern.expr fun xs pattern => mkForallFVars xs pattern
+  let pattern ← removeUnusedForallBinders pattern
+  let names ← forallTelescope pattern fun xs _ => do
+    let mut names := #[]
+    for h : i in [:xs.size] do
+      let name ← xs[i].fvarId!.getUserName
+      unless name.isAnonymous do
+        names := names.push (i, name)
+    return names
+  return (pattern, levelParams, names)
+
+private def attrInstancesOfAttributes (attrs : TSyntax ``Parser.Term.attributes) :
+    Array (TSyntax ``Parser.Term.attrInstance) :=
+  attrs.raw[1].getArgs.filterMap fun stx =>
+    if stx.isOfKind ``Parser.Term.attrInstance then
+      some ⟨stx⟩
+    else
+      none
+
 /-- Syntax for a ruleproc declaration. -/
-syntax (docComment)? "ruleproc_decl " ident (ppSpace bracketedBinder)* " : " term " := "
+syntax (name := ruleprocCmd) (docComment)? (Parser.Term.attributes)? "ruleproc " ident
+  (ppSpace bracketedBinder)* " : " term " := "
   term : command
 
-macro_rules
-  | `($[$doc?:docComment]? ruleproc_decl $n:ident $bs* : $pat:term := $body:term) => do
-    let xs := mkIdent `xs
-    let body ← mkRuleProcBody xs (binderNames bs) body
-    `($[$doc?:docComment]? meta def $n : Mathlib.Tactic.ApplyRuleSets.RuleProc :=
-        fun $xs:ident => $body
-      ruleproc_pattern% (∀ $bs*, $pat) => $n)
-
-/-- Syntax for a ruleproc declaration immediately attached to rulesets. -/
-syntax (docComment)? attrKind "ruleproc " "[" ident,* "]" ident
-  (ppSpace bracketedBinder)* " : " term " := " term : command
-
-macro_rules
-  | `($[$doc?:docComment]? $kind:attrKind ruleproc [$attrs,*] $n:ident $bs* :
-      $pat:term := $body:term) => do
-    let attrs := attrs.getElems
-    let mut cmds : Array Syntax :=
-      #[← `($[$doc?:docComment]? ruleproc_decl $n $bs* : $pat := $body)]
-    for attr in attrs do
-      let attrName := attr.getId
-      let attrParser := mkIdentFrom attr (`Parser.Attr ++ attrName)
-      let attrStx : TSyntax `attr := ⟨mkNode attrParser.getId #[mkAtom attrName.toString]⟩
-      cmds := cmds.push (← `(attribute [$kind $attrStx:attr] $n))
-    return mkNullNode cmds
+@[command_elab ruleprocCmd]
+def elabRuleProc : Command.CommandElab := fun stx => do
+  let `(command| $[$doc?:docComment]? $[$attrs?:attributes]? ruleproc $n:ident $bs* :
+      $pat:term := $body:term) := stx
+    | throwUnsupportedSyntax
+  let scope ← Command.getScope
+  let varDecls : TSyntaxArray ``Lean.Parser.Term.bracketedBinder :=
+    scope.varDecls.map (fun stx => ⟨stx⟩)
+  let allBinders := varDecls ++ bs
+  let pat ← `(∀ $allBinders*, $pat)
+  let (pattern, levelParams, names) ← Command.liftTermElabM <| closeRuleProcPattern pat
+  let xs := mkIdent `__ruleprocArgs
+  let body ← liftMacroM <| mkRuleProcBody xs names body
+  Command.elabCommand <| ← `($[$doc?:docComment]? meta def $n :
+    Mathlib.Tactic.ApplyRuleSets.RuleProc := fun $xs:ident => $body)
+  Command.liftTermElabM do
+    let procName ← realizeGlobalConstNoOverload n
+    registerRuleProcPattern procName pattern levelParams
+  if let some attrs := attrs? then
+    let attrInsts := attrInstancesOfAttributes attrs
+    Command.elabCommand <| ← `(command| attribute [$attrInsts,*] $n)
 
 /-- Register the theorem and proc attributes for a ruleset. -/
 def registerRuleSetAttr (ruleSetName : Name) (descr : String) : IO Unit := do
@@ -321,6 +367,18 @@ def checkStep : ApplyRuleSetsM Unit := do
   if n ≥ maxSteps then
     throwError "apply_rulesets failed, maximum number of steps ({maxSteps}) exceeded"
   modify fun s => { s with numSteps := s.numSteps + 1 }
+
+/-- Increase the logical search depth without introducing a new metavariable depth. -/
+def withIncreasedSearchDepth {α} (x : ApplyRuleSetsM α) : ApplyRuleSetsM α := do
+  let depth := (← get).depth
+  modify fun s => { s with depth := depth + 1 }
+  try
+    let a ← x
+    modify fun s => { s with depth := depth }
+    return a
+  catch e =>
+    modify fun s => { s with depth := depth }
+    throw e
 
 /-- Roll back metavariable assignments if `x` returns `none` or throws. -/
 def observingWithRollback? {α} (x : ApplyRuleSetsM (Option α)) : ApplyRuleSetsM (Option α) := do
@@ -393,44 +451,80 @@ def sortEntries (entries : Array RuleEntry) : Array RuleEntry :=
     else
       ah.order < bh.order
 
+def matchRuleProcConclusion (pattern goal : Expr) : MetaM Bool := do
+  let pattern ← instantiateMVars pattern
+  let goal ← instantiateMVars goal
+  let patternFn := pattern.getAppFn
+  let goalFn := goal.getAppFn
+  if patternFn.constName? == goalFn.constName? && pattern.getAppNumArgs == goal.getAppNumArgs then
+    for patternArg in pattern.getAppArgs, goalArg in goal.getAppArgs do
+      let patternArg ← instantiateMVars patternArg
+      if patternArg.isMVar then
+        try
+          patternArg.mvarId!.assign goalArg
+        catch _ =>
+          unless ← withTransparency .none <| isDefEq patternArg goalArg do
+            return false
+      else
+        unless ← withTransparency .none <| isDefEq patternArg goalArg do
+          return false
+    return true
+  else
+    withTransparency .none <| isDefEq pattern goal
+
+def ProcRule.instantiatePattern (rule : ProcRule) : MetaM Expr := do
+  let us ← rule.levelParams.mapM fun _ => mkFreshLevelMVar
+  return rule.pattern.instantiateLevelParamsArray rule.levelParams us
+
 mutual
 
-partial def prove? (origin : ArgOrigin) (goalType : Expr) (entries : Array RuleEntry)
-    (erased : Std.HashSet Name) (depth : Nat) : ApplyRuleSetsM (Option Expr) := do
+partial def applyRuleSets (origin : ArgOrigin) (goalType : Expr) :
+    ApplyRuleSetsM (Option Expr) := do
+  let goalType ← instantiateMVars goalType
+  withTraceNode `Meta.Tactic.apply_rulesets
+    (fun _ => return s!"{← ppExpr goalType}") do
   checkStep
+  let depth := (← get).depth
   let maxDepth := (← read).config.maxDepth
   if depth > maxDepth then
+    trace[Meta.Tactic.apply_rulesets] "maximum recursion depth ({maxDepth}) exceeded"
     return none
   let cfg := (← read).config
   if cfg.autoParam then
     if let some proof ← observingWithRollback? <| runAutoParam? goalType then
+      trace[Meta.Tactic.apply_rulesets] "solved by autoParam tactic"
       return some proof
   if cfg.assumption then
     if let some proof ← observingWithRollback? <| assumption? goalType then
+      trace[Meta.Tactic.apply_rulesets] "solved by local assumption"
       return some proof
   if cfg.intro then
     let some proof ← observingWithRollback? <| forallTelescopeReducing goalType fun xs body => do
       if xs.isEmpty then
         return none
-      let some proof ← prove? origin body entries erased (depth + 1) | return none
+      trace[Meta.Tactic.apply_rulesets] "introducing {xs.size} binder(s)"
+      let some proof ← withIncreasedSearchDepth <| applyRuleSets origin body | return none
       return some (← mkLambdaFVars xs proof)
       | pure ()
     return some proof
   let entries := sortEntries (← queryRuleSets goalType (← read).rulesets)
+  trace[Meta.Tactic.apply_rulesets]
+    "candidate rules: {entries.map fun entry => entry.header.name}"
   for rule in (← read).explicitRules do
     if let some proof ←
-        observingWithRollback? <| tryExplicit? origin goalType entries erased depth rule then
+        observingWithRollback? <| tryExplicit? origin goalType rule then
       return some proof
   for entry in entries do
-    unless erased.contains entry.header.name do
+    unless (← read).erased.contains entry.header.name do
       if let some proof ←
-          observingWithRollback? <| tryEntry? origin goalType entries erased depth entry then
+          observingWithRollback? <| tryEntry? origin goalType entry then
         return some proof
+  trace[Meta.Tactic.apply_rulesets] "no rule matched"
   return none
 
-/-- Synthesize arguments created by theorem application. -/
-partial def synthesizeArgs (ruleName : Name) (args : Array Expr) (entries : Array RuleEntry)
-    (erased : Std.HashSet Name) (depth : Nat) : ApplyRuleSetsM Bool := do
+/-- Synthesize arguments created by theorem or ruleproc application. -/
+partial def synthesizeArgs (ruleName : Name) (args : Array Expr)
+    (allowPostponed := false) : ApplyRuleSetsM Bool := do
   let mut postponed := #[]
   for h : i in [:args.size] do
     let arg := args[i]
@@ -440,62 +534,93 @@ partial def synthesizeArgs (ruleName : Name) (args : Array Expr) (entries : Arra
         if let .some inst ← trySynthInstance type then
           if (← isDefEq arg inst) then
             continue
+          else
+            trace[Meta.Tactic.apply_rulesets]
+              "{ruleName}, failed to assign instance{indentExpr type}\
+              \nsynthesized value{indentExpr inst}\nis not definitionally equal to{indentExpr arg}"
+        else
+          trace[Meta.Tactic.apply_rulesets]
+            "{ruleName}, failed to synthesize instance{indentExpr type}"
       if (← isProp type) then
         let argName := (← getMCtx).getDecl arg.mvarId! |>.userName
         let origin := { ruleName, argIndex := some i, argName := some argName }
-        if let some proof ← prove? origin type entries erased (depth + 1) then
+        if let some proof ← withIncreasedSearchDepth <| applyRuleSets origin type then
           if (← isDefEq arg proof) then
             continue
+          else
+            trace[Meta.Tactic.apply_rulesets]
+              "{ruleName}, failed to assign proof{indentExpr type}"
         let ctx ← read
         if let some proof ← ctx.disch origin type then
           if (← isDefEq arg proof) then
             continue
+          else
+            trace[Meta.Tactic.apply_rulesets]
+              "{ruleName}, failed to assign discharger proof{indentExpr type}"
+        trace[Meta.Tactic.apply_rulesets]
+          "{ruleName}, failed to discharge hypothesis{indentExpr type}"
         return false
       else
         postponed := postponed.push arg
   for arg in postponed do
     if (← instantiateMVars arg).isMVar then
+      if allowPostponed then
+        continue
+      trace[Meta.Tactic.apply_rulesets]
+        "{ruleName}, failed to infer `({← ppExpr arg} : {← ppExpr (← inferType arg)})`"
       return false
   return true
 
 /-- Try an explicit theorem or term provided in the tactic call. -/
-partial def tryExplicit? (_origin : ArgOrigin) (goalType : Expr) (entries : Array RuleEntry)
-    (erased : Std.HashSet Name) (depth : Nat) (r : ExplicitRule) :
+partial def tryExplicit? (_origin : ArgOrigin) (goalType : Expr) (r : ExplicitRule) :
     ApplyRuleSetsM (Option Expr) := do
   let name := r.name
-  if erased.contains name then
+  withTraceNode `Meta.Tactic.apply_rulesets
+    (fun _ => return s!"applying explicit rule: {name}") do
+  if (← read).erased.contains name then
+    trace[Meta.Tactic.apply_rulesets] "rule is erased"
     return none
   let type ← inferType r.expr
   let (args, _, conclusion) ← forallMetaTelescope type
   let ok ← withTransparency (← read).config.transparency <| isDefEq conclusion goalType
-  unless ok do return none
-  unless ← synthesizeArgs name args entries erased depth do return none
+  unless ok do
+    trace[Meta.Tactic.apply_rulesets]
+      "failed to unify explicit rule conclusion{indentExpr conclusion}\nwith{indentExpr goalType}"
+    return none
+  unless ← synthesizeArgs name args do return none
   return some (← instantiateMVars (mkAppN r.expr args))
 
 /-- Try a theorem rule. -/
-partial def tryTheorem? (_origin : ArgOrigin) (goalType : Expr) (entries : Array RuleEntry)
-    (erased : Std.HashSet Name) (depth : Nat) (rule : TheoremRule) :
+partial def tryTheorem? (_origin : ArgOrigin) (goalType : Expr) (rule : TheoremRule) :
     ApplyRuleSetsM (Option Expr) := do
+  withTraceNode `Meta.Tactic.apply_rulesets
+    (fun _ => return s!"applying theorem: {rule.header.name}") do
   let val ← mkConstWithFreshMVarLevels rule.header.name
   let type ← inferType val
   let (args, _, conclusion) ← forallMetaTelescope type
   let ok ← withTransparency (← read).config.transparency <| isDefEq conclusion goalType
   unless ok do
+    trace[Meta.Tactic.apply_rulesets]
+      "failed to unify {rule.header.name} conclusion{indentExpr conclusion}\
+      \nwith{indentExpr goalType}"
     return none
-  unless ← synthesizeArgs rule.header.name args entries erased depth do
+  unless ← synthesizeArgs rule.header.name args do
     return none
   return some (← instantiateMVars (mkAppN val args))
 
 /-- Try a ruleproc. -/
-partial def tryProc? (origin : ArgOrigin) (goalType : Expr) (entries : Array RuleEntry)
-    (erased : Std.HashSet Name) (depth : Nat) (rule : ProcRule) :
+partial def tryProc? (origin : ArgOrigin) (goalType : Expr) (rule : ProcRule) :
     ApplyRuleSetsM (Option Expr) := do
-  let (args, _, conclusion) ← forallMetaTelescope rule.pattern
-  let ok ← withTransparency (← read).config.transparency <| isDefEq conclusion goalType
+  withTraceNode `Meta.Tactic.apply_rulesets
+    (fun _ => return s!"applying ruleproc: {rule.header.name}") do
+  let pattern ← rule.instantiatePattern
+  let (args, _, conclusion) ← forallMetaTelescope pattern
+  let ok ← matchRuleProcConclusion conclusion goalType
   unless ok do
-    trace[Meta.Tactic.apply_rulesets] "ruleproc {rule.header.name} did not match {goalType}"
+    trace[Meta.Tactic.apply_rulesets]
+      "failed to unify ruleproc pattern{indentExpr conclusion}\nwith{indentExpr goalType}"
     return none
-  unless ← synthesizeArgs rule.header.name args entries erased depth do
+  unless ← synthesizeArgs rule.header.name args (allowPostponed := true) do
     trace[Meta.Tactic.apply_rulesets]
       "failed to synthesize ruleproc arguments for {rule.header.name}"
     return none
@@ -507,17 +632,21 @@ partial def tryProc? (origin : ArgOrigin) (goalType : Expr) (entries : Array Rul
   let ok ← withTransparency (← read).config.transparency <| isDefEq proofType goalType
   unless ok do
     trace[Meta.Tactic.apply_rulesets]
-      "ruleproc {rule.header.name} returned proof of wrong type {proofType} for {goalType}"
+      "ruleproc {rule.header.name} returned proof of wrong type{indentExpr proofType}\
+      \nfor{indentExpr goalType}"
     return none
   return some proof
 
 /-- Try any rule entry. -/
-partial def tryEntry? (origin : ArgOrigin) (goalType : Expr) (entries : Array RuleEntry)
-    (erased : Std.HashSet Name) (depth : Nat) : RuleEntry → ApplyRuleSetsM (Option Expr)
-  | .theorem rule => tryTheorem? origin goalType entries erased depth rule
-  | .proc rule => tryProc? origin goalType entries erased depth rule
+partial def tryEntry? (origin : ArgOrigin) (goalType : Expr) :
+    RuleEntry → ApplyRuleSetsM (Option Expr)
+  | .theorem rule => tryTheorem? origin goalType rule
+  | .proc rule => tryProc? origin goalType rule
 
 end
+
+/-- Backward-search using the active rule sets. Alias for `applyRuleSets`. -/
+abbrev appluRuleSets := applyRuleSets
 
 open Parser.Tactic in
 syntax applyRuleSetErase := "-" term:max
@@ -586,12 +715,11 @@ def evalApplyRuleSets : Tactic := fun stx => do
       let e ← Term.elabTerm explicitTerms[i].raw none
       explicitRules := explicitRules.push ({ order := i, expr := e } : ExplicitRule)
     Term.synthesizeSyntheticMVarsNoPostponing
-    let allEntries := #[]
     let ctx : Context :=
-      { config := cfg, rulesets := rulesets, explicitRules := explicitRules, disch := disch }
+      { config := cfg, rulesets := rulesets, explicitRules := explicitRules, erased := erased,
+        disch := disch }
     let s : State := {}
-    let (proof?, _) ←
-      (prove? { ruleName := Name.anonymous } goalType allEntries erased 0).run ctx |>.run s
+    let (proof?, _) ← (applyRuleSets { ruleName := Name.anonymous } goalType).run ctx |>.run s
     match proof? with
     | some proof => goal.assign proof; replaceMainGoal []
     | none => throwError "apply_rulesets failed"

--- a/Mathlib/Tactic/ApplyRuleSets/RuleProc.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/RuleProc.lean
@@ -25,12 +25,17 @@ abbrev RuleProc := Array Expr → ArgOrigin → Expr → ApplyRuleSetsM (Option 
 def keysForPattern (pattern : Expr) : MetaM (List (Key × LazyEntry)) := do
   RefinedDiscrTree.initializeLazyEntryWithEta pattern
 
+/-- Compute a plain discrimination-tree path for a theorem conclusion or ruleproc pattern. -/
+def discrPathForPattern (pattern : Expr) : MetaM (Array DiscrTree.Key) := do
+  DiscrTree.mkPath pattern
+
 /-- Persistent information about a declared ruleproc pattern. -/
 structure RuleProcDecl where
   declName : Name
   pattern : Expr
   levelParams : Array Name := #[]
-  keys : List (Key × LazyEntry)
+  refinedKeys : List (Key × LazyEntry)
+  discrPath : Array DiscrTree.Key
   /-- The declaration applied to default procedural parameters, if it has type `RuleProc`.
   This is used when registering a ruleproc in a ruleset with an attribute. Parameterized
   ruleprocs without defaults have no default proc and must be supplied explicitly, e.g.
@@ -53,9 +58,10 @@ def registerRuleProcPattern (declName : Name) (pattern : Expr) (levelParams : Ar
       metavariables"
   let levelParams := levelParams ++ (exprLevelParams pattern).filter (!levelParams.contains ·)
   let (_, _, conclusion) ← forallMetaTelescope pattern
-  let keys ← keysForPattern conclusion
+  let refinedKeys ← keysForPattern conclusion
+  let discrPath ← discrPathForPattern conclusion
   modifyEnv fun env => ruleProcDeclExt.addEntry env {
-    declName, pattern, levelParams, keys, defaultProc? }
+    declName, pattern, levelParams, refinedKeys, discrPath, defaultProc? }
 
 /-- Return registered pattern information for a ruleproc declaration. -/
 def getRuleProcDecl? (declName : Name) : CoreM (Option RuleProcDecl) := do

--- a/Mathlib/Tactic/ApplyRuleSets/RuleProc.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/RuleProc.lean
@@ -48,7 +48,8 @@ initialize ruleProcDeclExt : SimpleScopedEnvExtension RuleProcDecl (Std.HashMap 
 def registerRuleProcPattern (declName : Name) (pattern : Expr) (levelParams : Array Name := #[])
     (defaultProc? : Option Expr := none) : MetaM Unit := do
   if pattern.hasExprMVar then
-    throwError "invalid ruleproc pattern for `{.ofConstName declName}` contains expression metavariables"
+    throwError "invalid ruleproc pattern for `{.ofConstName declName}` contains expression \
+      metavariables"
   let levelParams := levelParams ++ (exprLevelParams pattern).filter (!levelParams.contains ·)
   let (_, _, conclusion) ← forallMetaTelescope pattern
   let keys ← keysForPattern conclusion
@@ -168,8 +169,8 @@ syntax (name := ruleprocCmd) (docComment)? (Lean.Parser.Term.attributes)? "rulep
 @[command_elab ruleprocCmd]
 def elabRuleProc : Command.CommandElab := fun stx => do
   let cmdStx := stx
-  let `(command| $[$doc?:docComment]? $[$attrs?:attributes]? ruleproc $n:ident $preBs* $[, $postBs*]? :
-      $pat:term := $body:term) := cmdStx
+  let `(command| $[$doc?:docComment]? $[$attrs?:attributes]? ruleproc $n:ident $preBs*
+      $[, $postBs*]? : $pat:term := $body:term) := cmdStx
     | throwUnsupportedSyntax
   let scope ← Command.getScope
   let varDecls : TSyntaxArray ``Lean.Parser.Term.bracketedBinder :=

--- a/Mathlib/Tactic/ApplyRuleSets/RuleProc.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/RuleProc.lean
@@ -8,6 +8,7 @@ module
 public meta import Mathlib.Lean.Meta.RefinedDiscrTree.Encode
 public import Lean.Elab.Tactic.ElabTerm
 public import Mathlib.Tactic.ApplyRuleSets.Types
+public import Mathlib.Tactic.FunProp.Decl
 
 public meta section
 
@@ -126,6 +127,12 @@ private def mkRuleProcBody (xs : Ident) (names : Array (Nat × Name)) (body : Te
     result ← `(let $id:ident : Lean.Expr := $xs[$idx]!; $result)
   return result
 
+private def mkRuleProcTacticBody (goal : Ident)
+    (seq : TSyntax ``Lean.Parser.Tactic.tacticSeq) : MacroM Term := do
+  `(do
+    withOptions (·.setBool `linter.unusedTactic false) <|
+      Mathlib.Meta.FunProp.tacticToDischarge (← `(tactic| ($seq:tacticSeq))) $goal)
+
 private def removeUnusedForallBinders (e : Expr) (keepPrefix : Nat := 0) : MetaM Expr := do
   forallTelescope e fun xs body => do
     let mut result := body
@@ -162,7 +169,56 @@ private def attrInstancesOfAttributes (attrs : TSyntax ``Lean.Parser.Term.attrib
     else
       none
 
-/-- Syntax for a ruleproc declaration. -/
+/-- Declares a procedural rule for `apply_rulesets`.
+
+A `ruleproc` has a pattern, written like a theorem conclusion, and produces a value of type
+`RuleProc`. During search, `apply_rulesets` first matches the pattern against the current goal. If
+the pattern matches, the ruleproc is run with the matched pattern arguments, origin information, and
+the current goal expression.
+
+The simplest form is a meta-code ruleproc:
+
+```lean
+ruleproc solveNeedFirst : NeedFirst := fun origin goal => do
+  return some (Lean.mkConst ``NeedFirst.intro)
+```
+
+Named binders in the pattern are exposed in the body as `Lean.Expr` values through the argument
+array. For example, in
+
+```lean
+ruleproc reflByProc {A : Type} (a : A) : a = a := fun _ _ => do
+  return some (← Lean.Meta.mkAppM ``Eq.refl #[a])
+```
+
+the name `a` in the body is a `Lean.Expr` corresponding to the matched pattern argument.
+
+Binders before a comma are procedural parameters, not part of the matching pattern:
+
+```lean
+ruleproc procWithParam (n : Nat), {A : Prop} : A := fun _ _ => do
+  logInfo m!"parameter: {n}"
+  return none
+```
+
+Such a ruleproc must be supplied explicitly with its parameter, for example
+`apply_rulesets [procWithParam 7]`, unless all procedural parameters have defaults and the
+declaration elaborates to `RuleProc` without extra arguments.
+
+Ruleprocs can also be written in tactic mode:
+
+```lean
+ruleproc run_tactic (a b : Int) : a < b := by
+  omega
+```
+
+In tactic mode, the binders are used only for pattern matching. They are not introduced as local
+terms in the tactic script; if the tactic needs to inspect matched expressions, use the meta-code
+form instead.
+
+Adding an attribute such as `@[my_rules]` registers the ruleproc in that ruleset. Attribute
+registration is only allowed when the declaration has a default executable `RuleProc`; parameterized
+ruleprocs without defaults should be passed explicitly in the tactic call. -/
 syntax (name := ruleprocCmd) (docComment)? (Lean.Parser.Term.attributes)? "ruleproc " ident
   (ppSpace bracketedBinder)* ("," (ppSpace bracketedBinder)*)? " : " term " := " term : command
 
@@ -183,9 +239,19 @@ def elabRuleProc : Command.CommandElab := fun stx => do
   let (pattern, levelParams, names) ← Command.liftTermElabM <|
     closeRuleProcPattern pat
   let xs := mkIdent `__ruleprocArgs
-  let body ← liftMacroM <| mkRuleProcBody xs names body
-  Command.elabCommand <| ← `($[$doc?:docComment]? meta def $n $procBs* :
-    Mathlib.Tactic.ApplyRuleSets.RuleProc := fun $xs:ident => $body)
+  let cmd ← match body with
+    | `(term| by $seq:tacticSeq) =>
+      let origin := mkIdent `__ruleprocOrigin
+      let goal := mkIdent `__ruleprocGoal
+      let body ← liftMacroM <| mkRuleProcTacticBody goal seq
+      `($[$doc?:docComment]? meta def $n $procBs* :
+        Mathlib.Tactic.ApplyRuleSets.RuleProc :=
+          fun $xs:ident $origin:ident $goal:ident => $body)
+    | _ =>
+      let body ← liftMacroM <| mkRuleProcBody xs names body
+      `($[$doc?:docComment]? meta def $n $procBs* :
+        Mathlib.Tactic.ApplyRuleSets.RuleProc := fun $xs:ident => $body)
+  Command.elabCommand cmd
   Command.liftTermElabM do
     let procName ← realizeGlobalConstNoOverload n
     let default? ← try

--- a/Mathlib/Tactic/ApplyRuleSets/RuleProc.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/RuleProc.lean
@@ -1,0 +1,200 @@
+/-
+Copyright (c) 2026 Tomáš Skřivan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomáš Skřivan
+-/
+module
+
+public meta import Mathlib.Lean.Meta.RefinedDiscrTree.Encode
+public import Lean.Elab.Tactic.ElabTerm
+public import Mathlib.Tactic.ApplyRuleSets.Types
+
+public meta section
+
+namespace Mathlib
+namespace Tactic.ApplyRuleSets
+
+open Lean Meta Elab Term
+open Lean.Meta.RefinedDiscrTree
+
+/-- A procedural rule. The array contains the synthesized arguments from the ruleproc pattern. -/
+abbrev RuleProc := Array Expr → ArgOrigin → Expr → ApplyRuleSetsM (Option Expr)
+
+/-- Compute indexing keys for a theorem conclusion or ruleproc pattern. -/
+def keysForPattern (pattern : Expr) : MetaM (List (Key × LazyEntry)) := do
+  RefinedDiscrTree.initializeLazyEntryWithEta pattern
+
+/-- Persistent information about a declared ruleproc pattern. -/
+structure RuleProcDecl where
+  declName : Name
+  pattern : Expr
+  levelParams : Array Name := #[]
+  keys : List (Key × LazyEntry)
+  /-- The declaration applied to default procedural parameters, if it has type `RuleProc`.
+  This is used when registering a ruleproc in a ruleset with an attribute. Parameterized
+  ruleprocs without defaults have no default proc and must be supplied explicitly, e.g.
+  `apply_rulesets [myProc 7]`. -/
+  defaultProc? : Option Expr := none
+deriving Inhabited
+
+initialize ruleProcDeclExt : SimpleScopedEnvExtension RuleProcDecl (Std.HashMap Name RuleProcDecl) ←
+  registerSimpleScopedEnvExtension {
+    name := by exact decl_name%
+    initial := {}
+    addEntry := fun s e => s.insert e.declName e
+  }
+
+/-- Register the pattern for a ruleproc declaration. -/
+def registerRuleProcPattern (declName : Name) (pattern : Expr) (levelParams : Array Name := #[])
+    (defaultProc? : Option Expr := none) : MetaM Unit := do
+  let levelParams := levelParams ++ (exprLevelParams pattern).filter (!levelParams.contains ·)
+  let (_, _, conclusion) ← forallMetaTelescope pattern
+  let keys ← keysForPattern conclusion
+  modifyEnv fun env => ruleProcDeclExt.addEntry env {
+    declName, pattern, levelParams, keys, defaultProc? }
+
+/-- Return registered pattern information for a ruleproc declaration. -/
+def getRuleProcDecl? (declName : Name) : CoreM (Option RuleProcDecl) := do
+  return (ruleProcDeclExt.getState (← getEnv)).get? declName
+
+/-- Evaluate a ruleproc declaration. -/
+unsafe def getRuleProcFromDeclImpl (declName : Name) : MetaM RuleProc := do
+  let env ← getEnv
+  let opts ← getOptions
+  match env.evalConst RuleProc opts declName with
+  | .ok proc => return proc
+  | .error err => throwError err
+
+@[implemented_by getRuleProcFromDeclImpl]
+opaque getRuleProcFromDecl (declName : Name) : MetaM RuleProc
+
+/-- Evaluate a ruleproc expression. -/
+unsafe def evalRuleProcImpl (proc : Expr) : MetaM RuleProc := do
+  Meta.evalExpr RuleProc (mkConst ``RuleProc) proc (safety := .unsafe)
+
+@[implemented_by evalRuleProcImpl]
+opaque evalRuleProc (proc : Expr) : MetaM RuleProc
+
+def instantiateRuleProcPattern (decl : RuleProcDecl) (proc : Expr) : MetaM (Expr × Array Name) := do
+  let some declName := proc.getAppFn.constName?
+    | throwError "ruleproc term is not headed by a declaration{indentExpr proc}"
+  unless declName == decl.declName do
+    throwError "ruleproc declaration mismatch: expected `{.ofConstName decl.declName}`, \
+      got `{declName}`"
+  let pattern := decl.pattern
+  let levelParams :=
+    decl.levelParams ++ (exprLevelParams pattern).filter (!decl.levelParams.contains ·)
+  return (pattern, levelParams)
+
+def explicitRuleProcRule? (origin : Origin) (proc : Expr) : MetaM (Option Rule) := do
+  let some declName := proc.getAppFn.constName?
+    | return none
+  unless (← getRuleProcDecl? declName).isSome do
+    return none
+  unless ← isDefEq (← inferType proc) (mkConst ``RuleProc) do
+    return none
+  let some decl ← getRuleProcDecl? declName
+    | throwError "explicit ruleproc `{.ofConstName declName}` has no registered pattern"
+  let (pattern, levelParams) ← instantiateRuleProcPattern decl proc
+  return some { origin, type := .proc proc, pattern, levelParams }
+
+/-- Declaration command used internally to register a ruleproc pattern. -/
+elab "ruleproc_pattern% " pat:term " => " proc:ident : command => do
+  Command.liftTermElabM do
+    let procName ← realizeGlobalConstNoOverload proc
+    let pattern ← Term.withAutoBoundImplicit <| Term.elabType pat
+    Term.synthesizeSyntheticMVars
+    let pattern ← abstractMVars (← instantiateMVars pattern)
+    let levelParams := pattern.paramNames
+    let pattern ← lambdaTelescope pattern.expr fun xs pattern => mkForallFVars xs pattern
+    registerRuleProcPattern procName pattern levelParams
+
+private def mkRuleProcBody (xs : Ident) (names : Array (Nat × Name)) (body : Term) :
+    MacroM Term := do
+  let mut result := body
+  for i in [0:names.size] do
+    let i := names.size - 1 - i
+    let (argIdx, name) := names[i]!
+    let id := mkIdentFrom body name
+    let idx := quote argIdx
+    result ← `(let $id:ident : Lean.Expr := $xs[$idx]!; $result)
+  return result
+
+private def removeUnusedForallBinders (e : Expr) (keepPrefix : Nat := 0) : MetaM Expr := do
+  forallTelescope e fun xs body => do
+    let mut result := body
+    for _h : i in [:xs.size] do
+      let i := xs.size - 1 - i
+      let x := xs[i]!
+      if i < keepPrefix || result.containsFVar x.fvarId! then
+        let decl ← x.fvarId!.getDecl
+        result := Expr.forallE decl.userName decl.type (result.abstract #[x]) decl.binderInfo
+    return result
+
+private def closeRuleProcPattern (pat : Term) :
+    TermElabM (Expr × Array Name × Array (Nat × Name)) := do
+  let pattern ← Term.withAutoBoundImplicit <| Term.elabType pat
+  Term.synthesizeSyntheticMVars
+  let pattern ← abstractMVars (← instantiateMVars pattern)
+  let levelParams := pattern.paramNames
+  let pattern ← lambdaTelescope pattern.expr fun xs pattern => mkForallFVars xs pattern
+  let pattern ← removeUnusedForallBinders pattern
+  let names ← forallTelescope pattern fun xs _ => do
+    let mut names := #[]
+    for h : i in [:xs.size] do
+      let name ← xs[i].fvarId!.getUserName
+      unless name.isAnonymous do
+        names := names.push (i, name)
+    return names
+  return (pattern, levelParams, names)
+
+private def attrInstancesOfAttributes (attrs : TSyntax ``Lean.Parser.Term.attributes) :
+    Array (TSyntax ``Lean.Parser.Term.attrInstance) :=
+  attrs.raw[1].getArgs.filterMap fun stx =>
+    if stx.isOfKind ``Lean.Parser.Term.attrInstance then
+      some ⟨stx⟩
+    else
+      none
+
+/-- Syntax for a ruleproc declaration. -/
+syntax (name := ruleprocCmd) (docComment)? (Lean.Parser.Term.attributes)? "ruleproc " ident
+  (ppSpace bracketedBinder)* ("," (ppSpace bracketedBinder)*)? " : " term " := " term : command
+
+@[command_elab ruleprocCmd]
+def elabRuleProc : Command.CommandElab := fun stx => do
+  let cmdStx := stx
+  let `(command| $[$doc?:docComment]? $[$attrs?:attributes]? ruleproc $n:ident $preBs* $[, $postBs*]? :
+      $pat:term := $body:term) := cmdStx
+    | throwUnsupportedSyntax
+  let scope ← Command.getScope
+  let varDecls : TSyntaxArray ``Lean.Parser.Term.bracketedBinder :=
+    scope.varDecls.map (fun stx => ⟨stx⟩)
+  let (procBs, patternBs) :=
+    match postBs with
+    | none => (#[], varDecls ++ preBs)
+    | some postBs => (preBs, varDecls ++ postBs)
+  let pat ← `(∀ $patternBs*, $pat)
+  let (pattern, levelParams, names) ← Command.liftTermElabM <|
+    closeRuleProcPattern pat
+  let xs := mkIdent `__ruleprocArgs
+  let body ← liftMacroM <| mkRuleProcBody xs names body
+  Command.elabCommand <| ← `($[$doc?:docComment]? meta def $n $procBs* :
+    Mathlib.Tactic.ApplyRuleSets.RuleProc := fun $xs:ident => $body)
+  Command.liftTermElabM do
+    let procName ← realizeGlobalConstNoOverload n
+    let default? ← try
+      let proc ← Term.elabTerm (mkIdentFrom n procName) (some (mkConst ``RuleProc))
+      Term.synthesizeSyntheticMVars
+      let proc ← instantiateMVars proc
+      if proc.hasExprMVar then
+        throwError "ruleproc has unsolved default parameter"
+      pure <| some proc
+    catch _ =>
+      pure none
+    registerRuleProcPattern procName pattern levelParams (defaultProc? := default?)
+  if let some attrs := attrs? then
+    let attrInsts := attrInstancesOfAttributes attrs
+    Command.elabCommand <| ← `(command| attribute [$attrInsts,*] $n)
+
+end Tactic.ApplyRuleSets
+end Mathlib

--- a/Mathlib/Tactic/ApplyRuleSets/RuleProc.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/RuleProc.lean
@@ -47,6 +47,8 @@ initialize ruleProcDeclExt : SimpleScopedEnvExtension RuleProcDecl (Std.HashMap 
 /-- Register the pattern for a ruleproc declaration. -/
 def registerRuleProcPattern (declName : Name) (pattern : Expr) (levelParams : Array Name := #[])
     (defaultProc? : Option Expr := none) : MetaM Unit := do
+  if pattern.hasExprMVar then
+    throwError "invalid ruleproc pattern for `{.ofConstName declName}` contains expression metavariables"
   let levelParams := levelParams ++ (exprLevelParams pattern).filter (!levelParams.contains ·)
   let (_, _, conclusion) ← forallMetaTelescope pattern
   let keys ← keysForPattern conclusion
@@ -96,7 +98,10 @@ def explicitRuleProcRule? (origin : Origin) (proc : Expr) : MetaM (Option Rule) 
   let some decl ← getRuleProcDecl? declName
     | throwError "explicit ruleproc `{.ofConstName declName}` has no registered pattern"
   let (pattern, levelParams) ← instantiateRuleProcPattern decl proc
-  return some { origin, type := .proc proc, pattern, levelParams }
+  let rule : Rule := { origin, type := .proc proc, pattern, levelParams }
+  if rule.hasExprMVar then
+    throwError "explicit ruleproc `{.ofConstName declName}` contains expression metavariables"
+  return some rule
 
 /-- Declaration command used internally to register a ruleproc pattern. -/
 elab "ruleproc_pattern% " pat:term " => " proc:ident : command => do

--- a/Mathlib/Tactic/ApplyRuleSets/Types.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Types.lean
@@ -6,6 +6,7 @@ Authors: Tomáš Skřivan
 module
 
 public meta import Mathlib.Lean.Meta.RefinedDiscrTree.Initialize
+public import Lean.Meta.DiscrTree
 public import Lean.Elab.Tactic.Config
 public import Lean.Meta.Tactic.SolveByElim
 
@@ -27,7 +28,7 @@ structure Config extends ApplyConfig where
   /-- Maximum number of candidate attempts. -/
   maxSteps : Nat := 10000
   /-- Transparency used by unification. -/
-  transparency : TransparencyMode := .default
+  transparency : TransparencyMode := .reducible
   /-- Use local hypotheses to solve proposition goals. -/
   assumption : Bool := true
   /-- Introduce leading binders and continue recursively. -/
@@ -39,6 +40,9 @@ structure Config extends ApplyConfig where
   collectFailedSubgoals : Bool := false
   /-- Print an exclusive timing profile for selected `apply_rulesets` operations. -/
   profile : Bool := false
+  /-- Use `RefinedDiscrTree` for ruleset lookup. If false, use Lean's plain `DiscrTree` instead.
+  This is intended for profiling and comparison; candidate sets may differ. -/
+  useRefinedDiscrTree : Bool := true
 
 instance : Inhabited Config := ⟨{}⟩
 
@@ -90,6 +94,11 @@ structure Rule where
   priority : Nat := eval_prio default
   order : Nat := 0
 deriving Inhabited
+
+instance : BEq Rule where
+  -- `DiscrTree` uses `BEq` only to deduplicate values. Rules are ordered explicitly, so keep every
+  -- registered entry even if two rule payloads are structurally identical.
+  beq _ _ := false
 
 /-- A canonicalized goal used by `apply_rulesets` internally.
 
@@ -153,7 +162,7 @@ structure State where
   failedSubgoals : Array Expr := #[]
   /-- Per-run ruleset trees. `RefinedDiscrTree` resolves lazy entries during lookup, so each
   `getMatch` result must be stored back here for subsequent queries in the same tactic run. -/
-  ruleSetTrees : Std.HashMap Name (RefinedDiscrTree Rule) := {}
+  refinedRuleSetTrees : Std.HashMap Name (RefinedDiscrTree Rule) := {}
   /-- Stack of goal caches, one for each local-context depth used by introduced binders. -/
   goalCaches : Array GoalCache := #[]
   profile : ProfileState := {}
@@ -174,7 +183,8 @@ abbrev ApplyRuleSetsM := ReaderT Context <| StateT State MetaM
 /-- Ruleset data kept in the environment. -/
 structure RuleSet where
   entries : Array Rule := #[]
-  tree : RefinedDiscrTree Rule := {}
+  refinedTree : RefinedDiscrTree Rule := {}
+  discrTree : DiscrTree Rule := {}
 deriving Inhabited
 
 /-- All registered rulesets. -/
@@ -187,7 +197,8 @@ deriving Inhabited
 structure RuleSetExtEntry where
   ruleSetName : Name
   rule : Rule
-  keys : List (Key × LazyEntry)
+  refinedKeys : List (Key × LazyEntry)
+  discrPath : Array DiscrTree.Key
 deriving Inhabited
 
 def addFailedSubgoal (e : Expr) : ApplyRuleSetsM Unit := do

--- a/Mathlib/Tactic/ApplyRuleSets/Types.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Types.lean
@@ -1,0 +1,3 @@
+module
+
+public import Mathlib.Tactic.ApplyRuleSets.Elab

--- a/Mathlib/Tactic/ApplyRuleSets/Types.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Types.lean
@@ -129,7 +129,6 @@ def Rule.allLevelParams (rule : Rule) : Array Name :=
 structure State where
   numSteps : Nat := 0
   depth : Nat := 0
-  messages : List String := []
   failedSubgoals : Array Expr := #[]
   /-- Per-run ruleset trees. `RefinedDiscrTree` resolves lazy entries during lookup, so each
   `getMatch` result must be stored back here for subsequent queries in the same tactic run. -/

--- a/Mathlib/Tactic/ApplyRuleSets/Types.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Types.lean
@@ -37,6 +37,8 @@ structure Config extends ApplyConfig where
   /-- Failed subgoals are collected during the search and code action adding
   `have : <subgoal> := sorry` is offered at the end. -/
   collectFailedSubgoals : Bool := false
+  /-- Print an exclusive timing profile for selected `apply_rulesets` operations. -/
+  profile : Bool := false
 
 instance : Inhabited Config := ⟨{}⟩
 
@@ -107,6 +109,25 @@ structure GoalCache where
   failures : Std.HashSet Goal := {}
 deriving Inhabited
 
+/-- Accumulated timing data for one profiling category. -/
+structure ProfileEntry where
+  nanos : Nat := 0
+  count : Nat := 0
+deriving Inhabited
+
+/-- Exclusive profiling state for `apply_rulesets`.
+
+The currently active operation is the head of `stack`. Whenever a new operation starts or ends, the
+elapsed time since `lastNanos` is charged to the previous stack head, so operation counters do not
+overlap. -/
+structure ProfileState where
+  enabled : Bool := false
+  startNanos : Nat := 0
+  lastNanos : Nat := 0
+  stack : List Name := []
+  times : Std.HashMap Name ProfileEntry := {}
+deriving Inhabited
+
 def Rule.name (rule : Rule) : Name :=
   rule.origin.name
 
@@ -135,6 +156,7 @@ structure State where
   ruleSetTrees : Std.HashMap Name (RefinedDiscrTree Rule) := {}
   /-- Stack of goal caches, one for each local-context depth used by introduced binders. -/
   goalCaches : Array GoalCache := #[]
+  profile : ProfileState := {}
 
 /-- Search context. -/
 structure Context where

--- a/Mathlib/Tactic/ApplyRuleSets/Types.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Types.lean
@@ -89,8 +89,32 @@ structure Rule where
   order : Nat := 0
 deriving Inhabited
 
+/-- A canonicalized goal used by `apply_rulesets` internally.
+
+The expression `expr` contains no expression metavariables from the original goal. If the original
+goal was `P a b ?c ?d`, then `expr` is `∀ c d, P a b c d`, and `numOutputs = 2` records how many
+leading binders should be reopened as fresh output metavariables for each attempt. -/
+structure Goal where
+  expr : Expr
+  numOutputs : Nat
+deriving Inhabited, BEq, Hashable
+
+/-- Per-local-context-depth cache for `apply_rulesets` goals. -/
+structure GoalCache where
+  /-- All local declarations with index strictly below this are in scope for this cache level. -/
+  minLctxIndex : Nat
+  successes : Std.HashMap Goal Expr := {}
+  failures : Std.HashSet Goal := {}
+deriving Inhabited
+
 def Rule.name (rule : Rule) : Name :=
   rule.origin.name
+
+def Rule.hasExprMVar (rule : Rule) : Bool :=
+  rule.pattern.hasExprMVar ||
+    match rule.type with
+    | .expr proof => proof.hasExprMVar
+    | .proc proc => proc.hasExprMVar
 
 def exprLevelParams (e : Expr) : Array Name :=
   (Lean.collectLevelParams {} e).params
@@ -110,6 +134,8 @@ structure State where
   /-- Per-run ruleset trees. `RefinedDiscrTree` resolves lazy entries during lookup, so each
   `getMatch` result must be stored back here for subsequent queries in the same tactic run. -/
   ruleSetTrees : Std.HashMap Name (RefinedDiscrTree Rule) := {}
+  /-- Stack of goal caches, one for each local-context depth used by introduced binders. -/
+  goalCaches : Array GoalCache := #[]
 
 /-- Search context. -/
 structure Context where

--- a/Mathlib/Tactic/ApplyRuleSets/Types.lean
+++ b/Mathlib/Tactic/ApplyRuleSets/Types.lean
@@ -1,3 +1,170 @@
+/-
+Copyright (c) 2026 Tomáš Skřivan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomáš Skřivan
+-/
 module
 
-public import Mathlib.Tactic.ApplyRuleSets.Elab
+public meta import Mathlib.Lean.Meta.RefinedDiscrTree.Initialize
+public import Lean.Elab.Tactic.Config
+public import Lean.Meta.Tactic.SolveByElim
+
+public meta section
+
+namespace Mathlib
+namespace Tactic.ApplyRuleSets
+
+open Lean Meta
+open Lean.Meta.RefinedDiscrTree
+
+initialize registerTraceClass `Meta.Tactic.apply_rulesets
+initialize registerTraceClass `Meta.Tactic.apply_rulesets.attr
+
+/-- Configuration for `apply_rulesets`. -/
+structure Config extends ApplyConfig where
+  /-- Maximum recursive depth. -/
+  maxDepth : Nat := 50
+  /-- Maximum number of candidate attempts. -/
+  maxSteps : Nat := 10000
+  /-- Transparency used by unification. -/
+  transparency : TransparencyMode := .default
+  /-- Use local hypotheses to solve proposition goals. -/
+  assumption : Bool := true
+  /-- Introduce leading binders and continue recursively. -/
+  intro : Bool := true
+  /-- Run the tactic embedded in `autoParam` goals. -/
+  autoParam : Bool := true
+  /-- Failed subgoals are collected during the search and code action adding
+  `have : <subgoal> := sorry` is offered at the end. -/
+  collectFailedSubgoals : Bool := false
+
+instance : Inhabited Config := ⟨{}⟩
+
+/-- Information about a goal passed to a rule or discharger. -/
+structure ArgOrigin where
+  /-- The theorem or term rule that generated the goal, or `anonymous` for the root goal. -/
+  ruleName : Name
+  /-- Argument index in the theorem telescope, or `none` for the root goal. -/
+  argIndex : Option Nat := none
+  /-- Argument binder name in the theorem telescope, or `none` for the root goal. -/
+  argName : Option Name := none
+deriving Inhabited, BEq
+
+/-- Where a rule came from. -/
+inductive Origin where
+  /-- A global declaration in the environment. -/
+  | decl (declName : Name)
+  /-- A local hypothesis. -/
+  | fvar (fvarId : FVarId)
+  /-- A proof term or proc provided directly to a tactic call. -/
+  | stx (id : Name) (ref : Syntax)
+  /-- Some other origin. -/
+  | other (name : Name)
+deriving Inhabited, Repr
+
+def Origin.name : Origin → Name
+  | .decl declName .. => declName
+  | .fvar fvarId => fvarId.name
+  | .stx id _ => id
+  | .other name => name
+
+/-- The implementation kind of a rule. -/
+inductive RuleType where
+  /-- Apply this expression to synthesized arguments. -/
+  | expr (proof : Expr)
+  /-- Run this procedural rule. -/
+  | proc (proc : Expr)
+deriving Inhabited
+
+/-- A theorem, explicit term, or procedural rule candidate.
+
+`pattern` is the (possibly dependent) type whose telescope conclusion is unified with the goal.
+For theorem rules this is the theorem type; for ruleprocs it is the declared ruleproc pattern. -/
+structure Rule where
+  origin : Origin
+  type : RuleType
+  pattern : Expr
+  levelParams : Array Name := #[]
+  priority : Nat := eval_prio default
+  order : Nat := 0
+deriving Inhabited
+
+def Rule.name (rule : Rule) : Name :=
+  rule.origin.name
+
+def exprLevelParams (e : Expr) : Array Name :=
+  (Lean.collectLevelParams {} e).params
+
+def Rule.allLevelParams (rule : Rule) : Array Name :=
+  let params := rule.levelParams ++ exprLevelParams rule.pattern
+  match rule.type with
+  | .expr proof => params ++ (exprLevelParams proof).filter (!params.contains ·)
+  | .proc proc => params ++ (exprLevelParams proc).filter (!params.contains ·)
+
+/-- Search state. -/
+structure State where
+  numSteps : Nat := 0
+  depth : Nat := 0
+  messages : List String := []
+  failedSubgoals : Array Expr := #[]
+  /-- Per-run ruleset trees. `RefinedDiscrTree` resolves lazy entries during lookup, so each
+  `getMatch` result must be stored back here for subsequent queries in the same tactic run. -/
+  ruleSetTrees : Std.HashMap Name (RefinedDiscrTree Rule) := {}
+
+/-- Search context. -/
+structure Context where
+  config : Config := {}
+  rulesets : Array Name := #[]
+  explicitRules : Array Rule := #[]
+  erased : Std.HashSet Name := {}
+  /-- Side-condition discharger for proposition arguments. -/
+  disch : ArgOrigin → Expr → MetaM (Option Expr) := fun _ _ => pure none
+  lctxInitIndices : Nat
+
+/-- Monad used by `apply_rulesets`. -/
+abbrev ApplyRuleSetsM := ReaderT Context <| StateT State MetaM
+
+/-- Ruleset data kept in the environment. -/
+structure RuleSet where
+  entries : Array Rule := #[]
+  tree : RefinedDiscrTree Rule := {}
+deriving Inhabited
+
+/-- All registered rulesets. -/
+structure RuleSets where
+  ruleSets : Std.HashMap Name RuleSet := {}
+  nextOrder : Nat := 0
+deriving Inhabited
+
+/-- Entry added to the global ruleset extension. -/
+structure RuleSetExtEntry where
+  ruleSetName : Name
+  rule : Rule
+  keys : List (Key × LazyEntry)
+deriving Inhabited
+
+def addFailedSubgoal (e : Expr) : ApplyRuleSetsM Unit := do
+  unless (← read).config.collectFailedSubgoals do
+    return ()
+
+  unless e.isMVar do
+    throwError m!"apply_ruleset bug! Trying to store unsolved goal that is not meta variable!"
+
+  let numIndices := (← read).lctxInitIndices
+
+  let type ← inferType e >>= instantiateMVars
+  let xs : Array Expr :=
+    -- collect all fvars that are in the goal and are not in the original context
+    (← getLCtx).foldl (init := #[]) (fun xs decl =>
+      if decl.index ≥ numIndices && type.containsFVar decl.fvarId then
+        xs.push (.fvar decl.fvarId)
+      else
+        xs)
+
+  let type ← mkForallFVars xs type
+
+  modify (fun s =>
+    { s with failedSubgoals := s.failedSubgoals.push type })
+
+end Tactic.ApplyRuleSets
+end Mathlib

--- a/MathlibTest/ApplyRuleSetsAttr.lean
+++ b/MathlibTest/ApplyRuleSetsAttr.lean
@@ -1,0 +1,64 @@
+module
+
+public import MathlibTest.ApplyRuleSetsRegister
+
+open Mathlib.Tactic.ApplyRuleSets
+
+public section
+
+attribute [test_rules] And.intro
+
+ruleproc_decl exactTrue : True := fun _ _ => do
+  return some (Lean.mkConst ``True.intro)
+
+attribute [test_rules] exactTrue
+
+inductive NeedFirst : Prop where
+  | intro
+
+inductive NeedOther : Prop where
+  | intro
+
+inductive FromFirst : Prop where
+  | intro (first : NeedFirst)
+
+theorem fromFirstRule (first : NeedFirst) : FromFirst :=
+  FromFirst.intro first
+
+attribute [test_rules] fromFirstRule
+
+ruleproc_decl solveNeedFirst : NeedFirst := fun origin _ => do
+  if origin.argName == some `first then
+    return some (Lean.mkConst ``NeedFirst.intro)
+  else
+    return none
+
+attribute [test_rules] solveNeedFirst
+
+ruleproc_decl solveNeedOther : NeedOther := fun _ _ => do
+  return some (Lean.mkConst ``NeedOther.intro)
+
+attribute [test_rules] solveNeedOther
+
+ruleproc_decl lowNat : Nat := fun _ _ => do
+  return some (Lean.mkNatLit 1)
+
+ruleproc_decl highNat : Nat := fun _ _ => do
+  return some (Lean.mkNatLit 2)
+
+attribute [test_rules 100] lowNat
+attribute [test_rules 200] highNat
+
+ruleproc_decl wrongPatternProc : NeedOther := fun _ _ => do
+  return some (Lean.mkConst ``True.intro)
+
+attribute [test_rules] wrongPatternProc
+
+def autoParamSource (h : True := by trivial) : True := h
+
+theorem autoParamRule (h : autoParam True autoParamSource._auto_1) : True := h
+
+ruleproc_decl reflByProc {A : Type} (a : A) : a = a := fun _ _ => do
+  return some (← Lean.Meta.mkAppM ``Eq.refl #[a])
+
+attribute [test_rules] reflByProc

--- a/MathlibTest/ApplyRuleSetsAttr.lean
+++ b/MathlibTest/ApplyRuleSetsAttr.lean
@@ -1,7 +1,7 @@
 module
 
 public import MathlibTest.ApplyRuleSetsRegister
-import Mathlib
+-- import Mathlib
 
 open Mathlib.Tactic.ApplyRuleSets
 
@@ -67,52 +67,3 @@ theorem autoParamRule (h : autoParam True autoParamSource._auto_1) : True := h
 @[test_rules]
 ruleproc reflByProc {A : Type} (a : A) : a = a := fun _ _ => do
   return some (← Lean.Meta.mkAppM ``Eq.refl #[a])
-
-
-
--- open Lean Meta Elab Term Command
--- elab "simproc_elab%" e:term : term => do
-
-
---   let simprocName := `_root_.my_simproc
---   let simprocId := mkIdent  simprocName
---   let stx ← `(command| simproc_decl $simprocId (_) := $e)
---   liftCommandElabM (elabCommand stx)
---   -- logInfo m!"defining new simproc {simprocName}"
---   -- logInfo m!"new simproc {Expr.const `my_simproc []} : {← inferType (Expr.const `my_simproc [])}"
---   let env ← getEnv
---   let s? := env.find? simprocName
---   logInfo m!"found new simproc: {s?.isSome}"
---   elabTerm simprocId none
-
-
--- meta def rewriteNat (n : Nat) : Simp.Simproc := fun e => do
---   if (← inferType e) != .const ``Nat [] then
---     return .continue
-
---   let nExpr := mkNatLit n
---   let prf ← mkSorry (← mkEq e nExpr) true
-
---   return .done { expr := nExpr, proof? := prf }
-
--- set_option Elab.async false
-
-
--- theorem fake_theorem : 1 + 2 = sorry := by
---   let a := simproc_elab% (rewriteNat 42)
---   conv_lhs => simp [my_simproc]
---   sorry
-
--- #check my_simproc
-
--- run_meta
---   logInfo m!"is simproc: {← Lean.Meta.Simp.isSimproc ``my_simproc}"
-
--- #exit
--- #check my_simproc
-
-
-
--- #check Lean.Meta.Simp.isSimproc
-
--- #conv (simp [simproc_elab% (rewriteNat 42)]) => 1 + 2

--- a/MathlibTest/ApplyRuleSetsAttr.lean
+++ b/MathlibTest/ApplyRuleSetsAttr.lean
@@ -1,6 +1,7 @@
 module
 
 public import MathlibTest.ApplyRuleSetsRegister
+import Mathlib
 
 open Mathlib.Tactic.ApplyRuleSets
 
@@ -8,10 +9,9 @@ public section
 
 attribute [test_rules] And.intro
 
-ruleproc_decl exactTrue : True := fun _ _ => do
+@[test_rules]
+ruleproc exactTrue : True := fun _ _ => do
   return some (Lean.mkConst ``True.intro)
-
-attribute [test_rules] exactTrue
 
 inductive NeedFirst : Prop where
   | intro
@@ -22,43 +22,97 @@ inductive NeedOther : Prop where
 inductive FromFirst : Prop where
   | intro (first : NeedFirst)
 
+inductive DelegatedFromFirst : Prop where
+  | intro (first : NeedFirst)
+
 theorem fromFirstRule (first : NeedFirst) : FromFirst :=
   FromFirst.intro first
 
 attribute [test_rules] fromFirstRule
 
-ruleproc_decl solveNeedFirst : NeedFirst := fun origin _ => do
+@[test_rules]
+ruleproc solveNeedFirst : NeedFirst := fun origin _ => do
   if origin.argName == some `first then
     return some (Lean.mkConst ``NeedFirst.intro)
   else
     return none
 
-attribute [test_rules] solveNeedFirst
-
-ruleproc_decl solveNeedOther : NeedOther := fun _ _ => do
+@[test_rules]
+ruleproc solveNeedOther : NeedOther := fun _ _ => do
   return some (Lean.mkConst ``NeedOther.intro)
 
-attribute [test_rules] solveNeedOther
+@[test_rules]
+ruleproc solveDelegatedFromFirst : DelegatedFromFirst := fun _ _ => do
+  let some first ← applyRuleSets
+      { ruleName := `solveDelegatedFromFirst, argName := some `first } (Lean.mkConst ``NeedFirst)
+    | return none
+  return some (Lean.mkApp (Lean.mkConst ``DelegatedFromFirst.intro) first)
 
-ruleproc_decl lowNat : Nat := fun _ _ => do
+@[test_rules 100]
+ruleproc lowNat : Nat := fun _ _ => do
   return some (Lean.mkNatLit 1)
 
-ruleproc_decl highNat : Nat := fun _ _ => do
+@[test_rules 200]
+ruleproc highNat : Nat := fun _ _ => do
   return some (Lean.mkNatLit 2)
 
-attribute [test_rules 100] lowNat
-attribute [test_rules 200] highNat
-
-ruleproc_decl wrongPatternProc : NeedOther := fun _ _ => do
+@[test_rules]
+ruleproc wrongPatternProc : NeedOther := fun _ _ => do
   return some (Lean.mkConst ``True.intro)
-
-attribute [test_rules] wrongPatternProc
 
 def autoParamSource (h : True := by trivial) : True := h
 
 theorem autoParamRule (h : autoParam True autoParamSource._auto_1) : True := h
 
-ruleproc_decl reflByProc {A : Type} (a : A) : a = a := fun _ _ => do
+@[test_rules]
+ruleproc reflByProc {A : Type} (a : A) : a = a := fun _ _ => do
   return some (← Lean.Meta.mkAppM ``Eq.refl #[a])
 
-attribute [test_rules] reflByProc
+
+
+-- open Lean Meta Elab Term Command
+-- elab "simproc_elab%" e:term : term => do
+
+
+--   let simprocName := `_root_.my_simproc
+--   let simprocId := mkIdent  simprocName
+--   let stx ← `(command| simproc_decl $simprocId (_) := $e)
+--   liftCommandElabM (elabCommand stx)
+--   -- logInfo m!"defining new simproc {simprocName}"
+--   -- logInfo m!"new simproc {Expr.const `my_simproc []} : {← inferType (Expr.const `my_simproc [])}"
+--   let env ← getEnv
+--   let s? := env.find? simprocName
+--   logInfo m!"found new simproc: {s?.isSome}"
+--   elabTerm simprocId none
+
+
+-- meta def rewriteNat (n : Nat) : Simp.Simproc := fun e => do
+--   if (← inferType e) != .const ``Nat [] then
+--     return .continue
+
+--   let nExpr := mkNatLit n
+--   let prf ← mkSorry (← mkEq e nExpr) true
+
+--   return .done { expr := nExpr, proof? := prf }
+
+-- set_option Elab.async false
+
+
+-- theorem fake_theorem : 1 + 2 = sorry := by
+--   let a := simproc_elab% (rewriteNat 42)
+--   conv_lhs => simp [my_simproc]
+--   sorry
+
+-- #check my_simproc
+
+-- run_meta
+--   logInfo m!"is simproc: {← Lean.Meta.Simp.isSimproc ``my_simproc}"
+
+-- #exit
+-- #check my_simproc
+
+
+
+-- #check Lean.Meta.Simp.isSimproc
+
+-- #conv (simp [simproc_elab% (rewriteNat 42)]) => 1 + 2

--- a/MathlibTest/ApplyRuleSetsRegister.lean
+++ b/MathlibTest/ApplyRuleSetsRegister.lean
@@ -1,0 +1,7 @@
+module
+
+public import Mathlib.Tactic.ApplyRuleSets
+
+open Mathlib.Tactic.ApplyRuleSets
+
+register_ruleset test_rules

--- a/MathlibTest/ApplyRuleSetsRegister.lean
+++ b/MathlibTest/ApplyRuleSetsRegister.lean
@@ -5,3 +5,4 @@ public import Mathlib.Tactic.ApplyRuleSets
 open Mathlib.Tactic.ApplyRuleSets
 
 register_ruleset test_rules
+register_ruleset parse_expr

--- a/MathlibTest/ApplyRuleSetsRegister.lean
+++ b/MathlibTest/ApplyRuleSetsRegister.lean
@@ -6,3 +6,4 @@ open Mathlib.Tactic.ApplyRuleSets
 
 register_ruleset test_rules
 register_ruleset parse_expr
+register_ruleset has_deriv

--- a/MathlibTest/ApplyRuleSetsRegister.lean
+++ b/MathlibTest/ApplyRuleSetsRegister.lean
@@ -7,3 +7,4 @@ open Mathlib.Tactic.ApplyRuleSets
 register_ruleset test_rules
 register_ruleset parse_expr
 register_ruleset has_deriv
+register_ruleset tc_rules

--- a/MathlibTest/ApplyRuleSetsRingExpr.lean
+++ b/MathlibTest/ApplyRuleSetsRingExpr.lean
@@ -1,0 +1,156 @@
+module
+
+public import MathlibTest.ApplyRuleSetsRegister
+
+open Mathlib.Tactic.ApplyRuleSets
+
+inductive RingExpr where
+  | var (n : Nat)
+  | neg (a : RingExpr)
+  | add (a b : RingExpr)
+  | sub (a b : RingExpr)
+  | mul (a b : RingExpr)
+
+variable {α : Type*} [Inhabited α] [Neg α] [Add α] [Sub α] [Mul α]
+
+def RingExpr.interpret (expr : RingExpr) (atoms : List α) : α :=
+  match expr with
+  | var i =>
+    if h : i < atoms.length then
+      atoms[i]
+    else
+      default
+  | neg a => - a.interpret atoms
+  | add a b => a.interpret atoms + b.interpret atoms
+  | sub a b => a.interpret atoms - b.interpret atoms
+  | mul a b => a.interpret atoms * b.interpret atoms
+
+def HasRingExpr (atoms : List α) (e : α) (expr : RingExpr) : Prop :=
+  expr.interpret atoms = e
+
+namespace HasRingExpr
+-- parse_expr
+
+theorem expr_congr {atoms : List α} {x : α} {expr expr' : RingExpr}
+    (h : HasRingExpr atoms x expr) (h' : expr = expr') : HasRingExpr atoms x expr' := by
+  subst h'
+  exact h
+
+@[parse_expr]
+theorem neg (atoms : List α) (x : α) (e : RingExpr) (h : HasRingExpr atoms x e) :
+    HasRingExpr atoms (-x) (.neg e) := by
+  simp [HasRingExpr, RingExpr.interpret] at h ⊢
+  exact congrArg Neg.neg h
+
+@[parse_expr]
+theorem add (atoms : List α) (x y : α) (ex ey : RingExpr)
+    (hx : HasRingExpr atoms x ex) (hy : HasRingExpr atoms y ey) :
+    HasRingExpr atoms (x + y) (.add ex ey) := by
+  simp [HasRingExpr, RingExpr.interpret] at hx hy ⊢
+  rw [hx, hy]
+
+@[parse_expr]
+theorem sub (atoms : List α) (x y : α) (ex ey : RingExpr)
+    (hx : HasRingExpr atoms x ex) (hy : HasRingExpr atoms y ey) :
+    HasRingExpr atoms (x - y) (.sub ex ey) := by
+  simp [HasRingExpr, RingExpr.interpret] at hx hy ⊢
+  rw [hx, hy]
+
+@[parse_expr]
+theorem mul (atoms : List α) (x y : α) (ex ey : RingExpr)
+    (hx : HasRingExpr atoms x ex) (hy : HasRingExpr atoms y ey) :
+    HasRingExpr atoms (x * y) (.mul ex ey) := by
+  simp [HasRingExpr, RingExpr.interpret] at hx hy ⊢
+  rw [hx, hy]
+
+
+open Lean Meta Mathlib.Tactic.ApplyRuleSets in
+@[parse_expr high]
+ruleproc collect_atoms (atoms : List α) (e : α) (expr : RingExpr) : HasRingExpr atoms e expr :=
+  fun argOrigin goal => do
+    let atoms ← instantiateMVars atoms
+    let e ← instantiateMVars e
+    let expr ← instantiateMVars expr
+
+    -- figure out atoms
+    if atoms.isMVar && ¬e.isMVar then
+      let fvars := (← (e.collectFVars.run {})).2.fvarIds
+
+      let mut xs ← mkAppOptM ``List.nil #[α]
+      for id in fvars do
+        let t ← id.getType
+        if ← isDefEq t α then
+          xs := ← mkAppM ``List.cons #[.fvar id, xs]
+
+      atoms.mvarId!.assign xs
+      return ← applyRuleSets argOrigin goal
+
+    -- figure out atom index
+    if ¬atoms.isMVar && e.isFVar && expr.isMVar then
+      let rec getAtoms (atoms : Expr) (atomsFVars : Array FVarId) : Option (Array FVarId) := do
+        match atoms with
+        | mkApp3 (.const ``List.cons _) _ (.fvar id) atoms' =>
+          getAtoms atoms' (atomsFVars.push id)
+        | Expr.app (Expr.const ``List.nil _) _  => some atomsFVars
+        | _ => none
+
+      let some atomsFVars := getAtoms atoms #[] | return none
+      let .fvar id := e | return none
+
+      let some i := atomsFVars.idxOf? id | return none
+
+      let exprVal ← mkAppM ``RingExpr.var #[mkNatLit i]
+      expr.mvarId!.assign exprVal
+
+      let prf ← mkFreshExprMVar goal
+      try
+        prf.mvarId!.refl
+        return prf
+      catch _ =>
+        pure ()
+    return none
+
+
+variable (x y : Int)
+
+example : HasRingExpr [x, y] x (.var 0) := by
+  apply HasRingExpr.expr_congr
+  apply_rulesets [parse_expr]
+  rfl
+
+example : HasRingExpr [x, y] y (.var 1) := by
+  apply HasRingExpr.expr_congr
+  apply_rulesets [parse_expr]
+  rfl
+
+example : HasRingExpr [x, y] (-x) (.neg (.var 0)) := by
+  apply HasRingExpr.expr_congr
+  apply_rulesets [parse_expr]
+  rfl
+
+example : HasRingExpr [x, y] (x + y) (.add (.var 0) (.var 1)) := by
+  apply HasRingExpr.expr_congr
+  apply_rulesets [parse_expr]
+  rfl
+
+example : HasRingExpr [x, y] (x - y) (.sub (.var 0) (.var 1)) := by
+  apply HasRingExpr.expr_congr
+  apply_rulesets [parse_expr]
+  rfl
+
+example : HasRingExpr [x, y] (x * y) (.mul (.var 0) (.var 1)) := by
+  apply HasRingExpr.expr_congr
+  apply_rulesets [parse_expr]
+  rfl
+
+example : HasRingExpr [x, y] ((x + y) * (-x - y))
+    (.mul (.add (.var 0) (.var 1)) (.sub (.neg (.var 0)) (.var 1))) := by
+  apply HasRingExpr.expr_congr
+  apply_rulesets [parse_expr]
+  rfl
+
+
+variable (x y z : Int)
+
+set_option pp.proofs false
+#check (by apply_rulesets [parse_expr] : HasRingExpr _ (x + y * z) _)

--- a/MathlibTest/apply_rulesets.lean
+++ b/MathlibTest/apply_rulesets.lean
@@ -41,8 +41,55 @@ def applyRuleSetsBigConj : Nat → (Nat → Prop) → Prop
 
 -- This is intentionally large enough to exercise repeated recursive rule application, local
 -- forall-hypothesis instantiation, and the success cache without relying on timing thresholds.
-example (p : Nat → Prop) (h : ∀ i, p i) : applyRuleSetsBigConj 64 p := by
-  apply_rulesets (config := { maxDepth := 200 }) +profile [And.intro, True.intro, h]
+-- set_option trace.profiler true in
+#time example (p : Nat → Prop) (h : ∀ i, p i) : applyRuleSetsBigConj 64 p := by
+  dsimp [applyRuleSetsBigConj]
+  apply_rulesets (config := { maxDepth := 200, transparency := .reducible }) +profile [And.intro, True.intro, h]
+
+#time example (p : Nat → Prop) (h : ∀ i, p i) : applyRuleSetsBigConj 64 p := by
+  dsimp [applyRuleSetsBigConj]
+  apply_rulesets (config := { maxDepth := 200 }) [And.intro, True.intro, h]
+
+inductive ApplyRuleSetsProfileClassGoal (α : Type) : Prop where
+  | intro [Inhabited α]
+
+theorem applyRuleSetsProfileClassRule {α : Type} [Inhabited α] :
+    ApplyRuleSetsProfileClassGoal α :=
+  .intro
+
+inductive ApplyRuleSetsProfileDischarged : Prop where
+  | intro
+
+theorem applyRuleSetsProfileDischargedRule (_ : (0 : Nat) ≤ 0) :
+    ApplyRuleSetsProfileDischarged :=
+  .intro
+
+def applyRuleSetsProfileStress : Nat → (Nat → Prop) → Prop
+  | 0, _ => True
+  | n + 1, p =>
+    (p n ∧ applyRuleSetsProfileStress n p) ∧
+      (p n → p n) ∧
+      ApplyRuleSetsProfileClassGoal Nat ∧
+      ApplyRuleSetsProfileClassGoal Nat ∧
+      ApplyRuleSetsProfileDischarged ∧
+      True
+
+-- This intentionally mixes explicit-rule failures and successes, ruleset lookup, repeated local
+-- forall-hypothesis instantiation, narrow introductions, typeclass synthesis, discharger fallback, and
+-- repeated identical goals that can hit the success cache.
+#time example (p : Nat → Prop) (h : ∀ i, p i) : applyRuleSetsProfileStress 16 p := by
+  dsimp [applyRuleSetsProfileStress]
+  apply_rulesets (config := { maxDepth := 300 }) +profile
+    [test_rules, @applyRuleSetsProfileClassRule Nat inferInstance,
+      applyRuleSetsProfileDischargedRule,
+      True.intro, h, by decide]
+
+#time example (p : Nat → Prop) (h : ∀ i, p i) : applyRuleSetsProfileStress 16 p := by
+  dsimp [applyRuleSetsProfileStress]
+  apply_rulesets (config := { maxDepth := 300, useRefinedDiscrTree := false }) +profile
+    [test_rules, @applyRuleSetsProfileClassRule Nat inferInstance,
+      applyRuleSetsProfileDischargedRule,
+      True.intro, h, by decide]
 
 example (p : Prop) (hp : p) : p := by
   apply_rulesets
@@ -202,10 +249,10 @@ example : HasDeriv (fun x : Nat => x / x) (fun xdx =>
   · simp -zeta []; rfl
 
 
--- example : HasDeriv (fun x : Nat => (x * x + x) / ((x + x)*(x + x))) sorry := by
---   apply congr_deriv
---   · apply_rulesets [has_deriv]
---   · sorry
+example : HasDeriv (fun x : Nat => (x * x + x) / ((x + x)*(x + x))) sorry := by
+  apply congr_deriv
+  · apply_rulesets [has_deriv]
+  · sorry
 
 end HasDeriv
 

--- a/MathlibTest/apply_rulesets.lean
+++ b/MathlibTest/apply_rulesets.lean
@@ -1,0 +1,87 @@
+module
+
+public import MathlibTest.ApplyRuleSetsAttr
+
+open Mathlib.Tactic.ApplyRuleSets
+
+example (p q : Prop) (hp : p) (hq : q) : p ∧ q := by
+  apply_rulesets [test_rules, hp, hq]
+
+example (p q : Prop) (hp : p) (hq : q) : p ∧ q := by
+  fail_if_success apply_rulesets [test_rules, -And.intro, hp, hq]
+  exact ⟨hp, hq⟩
+
+example : True := by
+  apply_rulesets [test_rules]
+
+example (p : Prop) (hp : p) : p := by
+  apply_rulesets [hp]
+
+example (p : Prop) (hp : p) : p := by
+  apply_rulesets [test_rules]
+
+example (p q : Prop) : p → q → p ∧ q := by
+  apply_rulesets [test_rules]
+
+example : True := by
+  apply_rulesets (disch := trivial) [id]
+
+-- Explicit theorem/term rules are tried directly.
+example (p q : Prop) (hp : p) (hq : q) : p ∧ q := by
+  apply_rulesets [fun hp hq => And.intro hp hq, hp, hq]
+
+-- Local hypotheses are used for proposition goals by default.
+example (p : Prop) (hp : p) : p := by
+  apply_rulesets [test_rules]
+
+-- The local-assumption step can be disabled.
+example (p : Prop) (hp : p) : p := by
+  fail_if_success apply_rulesets (config := { assumption := false }) [test_rules]
+  exact hp
+
+-- Leading binders are introduced by default.
+example (p q : Prop) : p → q → p ∧ q := by
+  apply_rulesets [test_rules]
+
+-- The intro step can be disabled.
+example (p q : Prop) : p → q → p ∧ q := by
+  fail_if_success apply_rulesets (config := { intro := false }) [test_rules]
+  intro hp hq
+  exact ⟨hp, hq⟩
+
+-- The tactic-level discharger is only needed after recursive search and assumption fail.
+example : True := by
+  apply_rulesets (disch := trivial) [id]
+
+-- `autoParam` arguments are solved by running their embedded tactic.
+example : True := by
+  apply_rulesets [autoParamRule]
+
+-- Ruleprocs are filtered by their pattern before being run.
+example : NeedOther := by
+  apply_rulesets [test_rules]
+
+-- Ruleprocs receive origin information for theorem side goals.
+example : FromFirst := by
+  apply_rulesets [test_rules]
+
+-- Ruleproc declaration binders are synthesized and exposed as local `Expr` aliases in the body.
+example : (3 : Nat) = 3 := by
+  apply_rulesets [test_rules]
+
+-- Ruleproc priority is respected.
+example : (by apply_rulesets [test_rules] : Nat) = 2 := by
+  rfl
+
+-- Removing a ruleproc by name excludes it from the active candidate set.
+example : Nat := by
+  apply_rulesets [test_rules, -highNat]
+
+example : (by apply_rulesets [test_rules, -highNat] : Nat) = 1 := by
+  rfl
+
+-- Maximum depth applies to recursive theorem-rule search.
+example (p q : Prop) : p → q → p ∧ q := by
+  fail_if_success apply_rulesets (config := { maxDepth := 0 }) [test_rules]
+  intro hp hq
+  exact ⟨hp, hq⟩

--- a/MathlibTest/apply_rulesets.lean
+++ b/MathlibTest/apply_rulesets.lean
@@ -1,6 +1,7 @@
 module
 
 public import MathlibTest.ApplyRuleSetsAttr
+import Qq
 
 open Mathlib.Tactic.ApplyRuleSets
 
@@ -184,3 +185,59 @@ example : HasDeriv (fun x : Nat => x / x) (fun xdx =>
   · simp -zeta []; rfl
 
 end HasDeriv
+
+namespace Addition
+open Lean Meta Qq
+
+-- turn all Add instances to `test_rules`
+run_meta
+  let [u] ← mkFreshLevelMVars 1 | unreachable!
+  let A ← mkFreshExprMVar (mkSort u)
+  let e := Expr.app (.const ``Add [u]) A
+
+  let globalInstances ← getGlobalInstancesIndex
+  let candidates ← globalInstances.getUnify e
+  for inst in candidates do
+    let some name := inst.globalName? | continue
+    addTheoremRule `test_rules name .global inst.priority
+
+-- implement addition on structures
+@[test_rules (low+1)]
+ruleproc structure_add {A : Type _} : Add A := fun _ _ => do
+  let .const fn _ := A.getAppFn' | return none
+  let env ← getEnv
+  unless isStructure env fn do return none
+
+  let ctor := getStructureCtor env fn
+  let parms := A.getAppArgs
+  let ctorVal ← mkAppOptM ctor.name (parms.map some)
+
+  let (xs, _, _) ← forallMetaTelescope (← inferType ctorVal)
+  let r ←
+    withLocalDeclD `a A fun a => do
+    withLocalDeclD `b A fun b => do
+      for x in xs, i in [0:xs.size] do
+        let X ← inferType x
+        let addCls ← mkAppM ``Add #[X]
+        let addInst ← applyRuleSets default addCls
+        let ci ← mkAppOptM ``Add.add #[X, addInst, a.proj fn i, b.proj fn i]
+        x.mvarId!.assign ci
+
+      mkLambdaFVars #[a,b] (mkAppN ctorVal xs)
+
+  return ← mkAppM ``Add.mk #[r]
+
+structure Vec3 (α : Type _) where
+  (x y z : α)
+
+example : Add (Vec3 (Vec3 Nat)) := by apply_rulesets [test_rules]
+
+-- run_meta
+--   let globalInstances ← getGlobalInstancesIndex
+--   for inst in globalInstances.elements do
+--     let some name := inst.globalName? | continue
+--     addTheoremRule `tc_rules name .global inst.priority
+
+-- #check (by apply_rulesets [tc_rules, structure_add] : Add (Vec3 (Vec3 Nat)))
+
+end Addition

--- a/MathlibTest/apply_rulesets.lean
+++ b/MathlibTest/apply_rulesets.lean
@@ -21,6 +21,12 @@ ruleproc proc3 (param : Nat), {A : Prop} : A := fun _ _ => do
   logInfo m!"calling `proc3` on {A} with param := {param}"
   return none
 
+set_option linter.unusedTactic false in
+ruleproc run_tactic (a b : Int) : a < b := by grind
+
+example : (1 : Int) < 2 := by
+  apply_rulesets [run_tactic]
+
 example (p q : Prop) : p → q → p ∧ q := by
   fail_if_success apply_rulesets [test_rules, -Add.intro]
   apply_rulesets [test_rules]
@@ -58,7 +64,10 @@ example (p q : Prop) : p → q → p ∧ q := by
   apply_rulesets [test_rules]
 
 example : True := by
-  apply_rulesets (disch := trivial) [id]
+  apply_rulesets [id, by trivial]
+
+example : True := by
+  apply_rulesets [id, by assumption, by trivial]
 
 -- Explicit theorem/term rules are tried directly.
 example (p q : Prop) (hp : p) (hq : q) : p ∧ q := by
@@ -85,7 +94,7 @@ example (p q : Prop) : p → q → p ∧ q := by
 
 -- The tactic-level discharger is only needed after recursive search and assumption fail.
 example : True := by
-  apply_rulesets (disch := trivial) [id]
+  apply_rulesets [id, by trivial]
 
 -- `autoParam` arguments are solved by running their embedded tactic.
 example : True := by

--- a/MathlibTest/apply_rulesets.lean
+++ b/MathlibTest/apply_rulesets.lean
@@ -62,7 +62,7 @@ example : True := by
 
 -- Explicit theorem/term rules are tried directly.
 example (p q : Prop) (hp : p) (hq : q) : p ∧ q := by
-  apply_rulesets [fun hp hq => And.intro hp hq, hp, hq]
+  apply_rulesets [fun (hp : p) (hq : q) => And.intro hp hq, hp, hq]
 
 -- Local hypotheses are used for proposition goals by default.
 example (p : Prop) (hp : p) : p := by
@@ -123,3 +123,55 @@ example (p q : Prop) : p → q → p ∧ q := by
   fail_if_success apply_rulesets (config := { maxDepth := 0 }) [test_rules]
   intro hp hq
   exact ⟨hp, hq⟩
+
+structure HasDeriv (f : α → β) (f' : α × α → β × β) : Prop where
+
+
+namespace HasDeriv
+
+theorem congr_deriv {f : α → β} {f' f''} (hf : HasDeriv f f') (hf : f' = f'')  :
+    HasDeriv f f'' := ⟨⟩
+
+@[has_deriv]
+theorem id : HasDeriv (fun x : α => x) (fun xdx => xdx) := ⟨⟩
+
+local instance [Add α] [Add β] : Add (α × β) := ⟨fun (x,y) (x',y') => (x+x', y+y')⟩
+
+@[has_deriv]
+theorem add [Add β] (f g : α → β) (hf : HasDeriv f f') (hg : HasDeriv g g') :
+    HasDeriv (fun x : α => f x + g x) (fun xdx => f' xdx + g' xdx) := ⟨⟩
+
+@[has_deriv high]
+theorem div_bad [Div β] (f g : α → β) (hf : HasDeriv f f') (hg : HasDeriv g g')
+    (bad : False) :
+    HasDeriv (fun x : α => f x / g x) (fun xdx => f' xdx) := ⟨⟩
+
+@[has_deriv]
+theorem div_good [Add β] [Sub β] [Mul β] [Div β] [One β] (f g : α → β)
+    (hf : HasDeriv f f') (hg : HasDeriv g g') :
+    HasDeriv (fun x : α => f x / g x) (fun xdx =>
+      let (y,dy) := f' xdx; let (z,dz) := g' xdx;
+      let y := y; let z := z;
+      let iz := 1/z
+      (y*iz, (iz*iz)*(dy * z - y * dz))) := ⟨⟩
+
+example : HasDeriv (fun x : Nat => x) (fun xdx => xdx) := by
+  apply congr_deriv
+  · apply_rulesets [has_deriv]
+  · rfl
+
+example : HasDeriv (fun x : Nat => x + x + x) (fun xdx => xdx + xdx + xdx) := by
+  apply congr_deriv
+  · apply_rulesets [has_deriv]
+  · rfl
+
+example : HasDeriv (fun x : Nat => x / x) (fun xdx =>
+      have y := xdx.fst;
+      have z := xdx.fst;
+      have iz := 1 / z;
+      (y * iz, iz * iz * (xdx.snd * z - y * xdx.snd))) := by
+  apply congr_deriv
+  · apply_rulesets [has_deriv]
+  · simp -zeta []; rfl
+
+end HasDeriv

--- a/MathlibTest/apply_rulesets.lean
+++ b/MathlibTest/apply_rulesets.lean
@@ -129,7 +129,7 @@ structure HasDeriv (f : α → β) (f' : α × α → β × β) : Prop where
 
 namespace HasDeriv
 
-theorem congr_deriv {f : α → β} {f' f''} (hf : HasDeriv f f') (hf : f' = f'')  :
+theorem congr_deriv {f : α → β} {f' f''} (_ : HasDeriv f f') (_ : f' = f'')  :
     HasDeriv f f'' := ⟨⟩
 
 @[has_deriv]
@@ -138,17 +138,17 @@ theorem id : HasDeriv (fun x : α => x) (fun xdx => xdx) := ⟨⟩
 local instance [Add α] [Add β] : Add (α × β) := ⟨fun (x,y) (x',y') => (x+x', y+y')⟩
 
 @[has_deriv]
-theorem add [Add β] (f g : α → β) (hf : HasDeriv f f') (hg : HasDeriv g g') :
+theorem add [Add β] (f g : α → β) (_ : HasDeriv f f') (_ : HasDeriv g g') :
     HasDeriv (fun x : α => f x + g x) (fun xdx => f' xdx + g' xdx) := ⟨⟩
 
 @[has_deriv high]
-theorem div_bad [Div β] (f g : α → β) (hf : HasDeriv f f') (hg : HasDeriv g g')
-    (bad : False) :
+theorem div_bad [Div β] (f g : α → β) (_ : HasDeriv f f') (_ : HasDeriv g g')
+    (_ : False) :
     HasDeriv (fun x : α => f x / g x) (fun xdx => f' xdx) := ⟨⟩
 
 @[has_deriv]
 theorem div_good [Add β] [Sub β] [Mul β] [Div β] [One β] (f g : α → β)
-    (hf : HasDeriv f f') (hg : HasDeriv g g') :
+    (_ : HasDeriv f f') (_ : HasDeriv g g') :
     HasDeriv (fun x : α => f x / g x) (fun xdx =>
       let (y,dy) := f' xdx; let (z,dz) := g' xdx;
       let y := y; let z := z;

--- a/MathlibTest/apply_rulesets.lean
+++ b/MathlibTest/apply_rulesets.lean
@@ -65,6 +65,10 @@ example : NeedOther := by
 example : FromFirst := by
   apply_rulesets [test_rules]
 
+-- Ruleprocs can recursively call `applyRuleSets`.
+example : DelegatedFromFirst := by
+  apply_rulesets [test_rules]
+
 -- Ruleproc declaration binders are synthesized and exposed as local `Expr` aliases in the body.
 example : (3 : Nat) = 3 := by
   apply_rulesets [test_rules]

--- a/MathlibTest/apply_rulesets.lean
+++ b/MathlibTest/apply_rulesets.lean
@@ -4,6 +4,40 @@ public import MathlibTest.ApplyRuleSetsAttr
 
 open Mathlib.Tactic.ApplyRuleSets
 
+open Lean
+ruleproc proc1 {A : Sort*} : A := fun _ _ => do
+  logInfo m!"calling `proc1` on {A}"
+  return none
+
+@[test_rules]
+ruleproc sortTrue {A : Sort*} : A := fun _ _ => do
+  return some (Lean.mkConst ``True.intro)
+
+ruleproc proc2 {A : Prop} : A := fun _ _ => do
+  logInfo m!"calling `proc2` on {A}"
+  return none
+
+ruleproc proc3 (param : Nat), {A : Prop} : A := fun _ _ => do
+  logInfo m!"calling `proc3` on {A} with param := {param}"
+  return none
+
+example (p q : Prop) : p → q → p ∧ q := by
+  fail_if_success apply_rulesets [test_rules, -Add.intro]
+  apply_rulesets [test_rules]
+
+example : True := by
+  apply_rulesets [sortTrue]
+
+example (p : Prop) (hp : p) : p := by
+  apply_rulesets
+
+example (p : Prop) (hp : p) : p := by
+  apply_rulesets []
+
+example : True := by
+  fail_if_success apply_rulesets [test_rules, -exactTrue, -sortTrue]
+  apply True.intro
+
 example (p q : Prop) (hp : p) (hq : q) : p ∧ q := by
   apply_rulesets [test_rules, hp, hq]
 

--- a/MathlibTest/apply_rulesets.lean
+++ b/MathlibTest/apply_rulesets.lean
@@ -35,6 +35,15 @@ example (p q : Prop) : p → q → p ∧ q := by
 example : True := by
   apply_rulesets [sortTrue]
 
+def applyRuleSetsBigConj : Nat → (Nat → Prop) → Prop
+  | 0, _ => True
+  | n + 1, p => p n ∧ applyRuleSetsBigConj n p
+
+-- This is intentionally large enough to exercise repeated recursive rule application, local
+-- forall-hypothesis instantiation, and the success cache without relying on timing thresholds.
+example (p : Nat → Prop) (h : ∀ i, p i) : applyRuleSetsBigConj 64 p := by
+  apply_rulesets (config := { maxDepth := 200 }) +profile [And.intro, True.intro, h]
+
 example (p : Prop) (hp : p) : p := by
   apply_rulesets
 
@@ -151,6 +160,14 @@ local instance [Add α] [Add β] : Add (α × β) := ⟨fun (x,y) (x',y') => (x+
 theorem add [Add β] (f g : α → β) (_ : HasDeriv f f') (_ : HasDeriv g g') :
     HasDeriv (fun x : α => f x + g x) (fun xdx => f' xdx + g' xdx) := ⟨⟩
 
+@[has_deriv]
+theorem mul [Add β] [Mul β] (f g : α → β) (_ : HasDeriv f f') (_ : HasDeriv g g') :
+    HasDeriv (fun x : α => f x * g x) (fun xdx =>
+      let (y,dy) := f' xdx
+      let (z,dz) := g' xdx
+      let y := y; let z := z
+      (y * z, dy * z + y * dz)) := ⟨⟩
+
 @[has_deriv high]
 theorem div_bad [Div β] (f g : α → β) (_ : HasDeriv f f') (_ : HasDeriv g g')
     (_ : False) :
@@ -183,6 +200,12 @@ example : HasDeriv (fun x : Nat => x / x) (fun xdx =>
   apply congr_deriv
   · apply_rulesets [has_deriv]
   · simp -zeta []; rfl
+
+
+-- example : HasDeriv (fun x : Nat => (x * x + x) / ((x + x)*(x + x))) sorry := by
+--   apply congr_deriv
+--   · apply_rulesets [has_deriv]
+--   · sorry
 
 end HasDeriv
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -77,10 +77,6 @@ lean_lib Archive where
 lean_lib Counterexamples where
   leanOptions := mathlibLeanOptions
 
-lean_lib ApplyRuleSets where
-  precompileModules := true
-  roots := #[`Mathlib.Tactic.ApplyRuleSets]
-
 /-- Additional documentation in the form of modules that only contain module docstrings. -/
 lean_lib docs where
   roots := #[`docs]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -77,6 +77,10 @@ lean_lib Archive where
 lean_lib Counterexamples where
   leanOptions := mathlibLeanOptions
 
+lean_lib ApplyRuleSets where
+  precompileModules := true
+  roots := #[`Mathlib.Tactic.ApplyRuleSets]
+
 /-- Additional documentation in the form of modules that only contain module docstrings. -/
 lean_lib docs where
   roots := #[`docs]


### PR DESCRIPTION
`apply_rulesets` is just like `apply_rules` but allows to create rule sets, ruleprocs (similar to simprocs), handles metavariables in the goal and couple of other nifty features

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
