### PR TITLE
[Merged by Bors] - feat(CategoryTheory/MorphismProperty): `HasPullbacksAgainst`

### DIFF
--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -978,6 +978,98 @@ instance {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [P.IsStableUnderCobaseChangeAlo
     IsStableUnderCobaseChangeAlong.of_isPushout (IsPushout.of_left' pb right.flip)
       (IsStableUnderCobaseChangeAlong.of_isPushout right.flip hp)
 
+/-- `P.IsStableUnderBaseChangeAgainst P'` states that for any morphism `f` satisfying `P` and
+any morphism `g` with the same codomain as `f` satisfying `P'`, any pullback of `f` along `g`
+also satisfies `P`. -/
+class IsStableUnderBaseChangeAgainst
+    (P P' : MorphismProperty C) : Prop where
+  isStableUnderBaseChangeAlong ⦃X Y : C ⦄ (f : X ⟶ Y) (hf : P' f) :
+    P.IsStableUnderBaseChangeAlong f
+
+instance (P : MorphismProperty C) [P.IsStableUnderBaseChange]
+    (P' : MorphismProperty C) :
+    P.IsStableUnderBaseChangeAgainst P' where
+  isStableUnderBaseChangeAlong := inferInstance
+
+lemma isStableUnderBaseChangeAgainst_top_iff
+    (P : MorphismProperty C) :
+    P.IsStableUnderBaseChangeAgainst ⊤ ↔ P.IsStableUnderBaseChange :=
+  ⟨ fun h ↦ ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
+      (h.isStableUnderBaseChangeAlong _ (by tauto)).of_isPullback h' h''⟩,
+    fun _ ↦ inferInstance ⟩
+
+/-- `P.HasPullbacksAgainst P'` states that for any morphism `f` satisfying `P'`,
+`P` has pullbacks along `f`. -/
+class HasPullbacksAgainst
+    (P P' : MorphismProperty C) : Prop where
+  hasPullbacksAlong ⦃X Y : C ⦄ (f : X ⟶ Y) (hf : P' f) :
+    P.HasPullbacksAlong f
+
+instance (P : MorphismProperty C) [P.HasPullbacks] (P' : MorphismProperty C) :
+    P.HasPullbacksAgainst P' where
+  hasPullbacksAlong := inferInstance
+
+lemma HasPullbacksAgainst_top_iff
+    (P : MorphismProperty C) :
+    P.IsStableUnderBaseChangeAgainst ⊤ ↔ P.IsStableUnderBaseChange :=
+  ⟨ fun h ↦ ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
+      (h.isStableUnderBaseChangeAlong _ (by tauto)).of_isPullback h' h''⟩,
+    fun _ ↦ inferInstance⟩
+
+lemma hasPullback_ofHasPullbacksAgainst
+    {P : MorphismProperty C} {P' : MorphismProperty C} {c c' c'' : C}
+    {f : c ⟶ c'} {g : c'' ⟶ c'} [P.HasPullbacksAgainst P'] (hf : P f) (hg : P' g) :
+    Limits.HasPullback f g :=
+  letI : P.HasPullbacksAlong g :=
+    MorphismProperty.HasPullbacksAgainst.hasPullbacksAlong g hg
+  MorphismProperty.HasPullbacksAlong.hasPullback f hf
+
+/-- `P.IsStableUnderCobaseChangeAgainst P'` states that for any morphism `f` satisfying `P` and
+any morphism `g` with the same codomain as `f` satisfying `P'`, any pullback of `f` along `g`
+also satisfies `P`. -/
+class IsStableUnderCobaseChangeAgainst
+    (P P' : MorphismProperty C) : Prop where
+  isStableUnderCobaseChangeAlong ⦃X Y : C ⦄ (f : X ⟶ Y) (hf : P' f) :
+    P.IsStableUnderCobaseChangeAlong f
+
+instance (P : MorphismProperty C) [P.IsStableUnderCobaseChange]
+    (P' : MorphismProperty C) :
+    P.IsStableUnderCobaseChangeAgainst P' where
+  isStableUnderCobaseChangeAlong := inferInstance
+
+lemma isStableUnderCobaseChangeAgainst_top_iff
+    (P : MorphismProperty C) :
+    P.IsStableUnderCobaseChangeAgainst ⊤ ↔ P.IsStableUnderCobaseChange :=
+  ⟨ fun h ↦ ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
+      (h.isStableUnderCobaseChangeAlong _ (by tauto)).of_isPushout h' h''⟩,
+    fun _ ↦ inferInstance ⟩
+
+/-- `P.HasPullbacksAgainst P'` states that for any morphism `f` satisfying `P'`,
+`P` has pullbacks along `f`. -/
+class HasPushoutsAgainst
+    (P P' : MorphismProperty C) : Prop where
+  hasPushoutsAlong ⦃X Y : C ⦄ (f : X ⟶ Y) (hf : P' f) :
+    P.HasPushoutsAlong f
+
+instance (P : MorphismProperty C) [P.HasPushouts] (P' : MorphismProperty C) :
+    P.HasPushoutsAgainst P' where
+  hasPushoutsAlong := inferInstance
+
+lemma HasPushoutsAgainst_top_iff
+    (P : MorphismProperty C) :
+    P.IsStableUnderCobaseChangeAgainst ⊤ ↔ P.IsStableUnderCobaseChange :=
+  ⟨ fun h ↦ ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
+      (h.isStableUnderCobaseChangeAlong _ (by tauto)).of_isPushout h' h''⟩,
+    fun _ ↦ inferInstance⟩
+
+lemma hasPullback_ofHasPushoutsAgainst
+    {P : MorphismProperty C} {P' : MorphismProperty C} {c c' c'' : C}
+    {f : c ⟶ c'} {g : c ⟶ c''} [P.HasPushoutsAgainst P'] (hf : P f) (hg : P' g) :
+    Limits.HasPushout f g :=
+  letI : P.HasPushoutsAlong g :=
+    MorphismProperty.HasPushoutsAgainst.hasPushoutsAlong g hg
+  MorphismProperty.HasPushoutsAlong.hasPushout f hf
+
 end MorphismProperty
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -983,7 +983,7 @@ any morphism `g` with the same codomain as `f` satisfying `P'`, any pullback of 
 also satisfies `P`. -/
 class IsStableUnderBaseChangeAgainst
     (P P' : MorphismProperty C) : Prop where
-  isStableUnderBaseChangeAlong ⦃X Y : C ⦄ (f : X ⟶ Y) (hf : P' f) :
+  isStableUnderBaseChangeAlong ⦃X Y : C⦄ (f : X ⟶ Y) (hf : P' f) :
     P.IsStableUnderBaseChangeAlong f
 
 instance (P : MorphismProperty C) [P.IsStableUnderBaseChange]
@@ -993,10 +993,11 @@ instance (P : MorphismProperty C) [P.IsStableUnderBaseChange]
 
 lemma isStableUnderBaseChangeAgainst_top_iff
     (P : MorphismProperty C) :
-    P.IsStableUnderBaseChangeAgainst ⊤ ↔ P.IsStableUnderBaseChange :=
-  ⟨ fun h ↦ ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
-      (h.isStableUnderBaseChangeAlong _ (by tauto)).of_isPullback h' h''⟩,
-    fun _ ↦ inferInstance ⟩
+    P.IsStableUnderBaseChangeAgainst ⊤ ↔ P.IsStableUnderBaseChange where
+  mp h :=
+    ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
+      (h.isStableUnderBaseChangeAlong _ (by tauto)).of_isPullback h' h''⟩
+  mpr _ := inferInstance
 
 /-- `P.HasPullbacksAgainst P'` states that for any morphism `f` satisfying `P'`,
 `P` has pullbacks along `f`. -/
@@ -1011,10 +1012,11 @@ instance (P : MorphismProperty C) [P.HasPullbacks] (P' : MorphismProperty C) :
 
 lemma HasPullbacksAgainst_top_iff
     (P : MorphismProperty C) :
-    P.IsStableUnderBaseChangeAgainst ⊤ ↔ P.IsStableUnderBaseChange :=
-  ⟨ fun h ↦ ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
-      (h.isStableUnderBaseChangeAlong _ (by tauto)).of_isPullback h' h''⟩,
-    fun _ ↦ inferInstance⟩
+    P.IsStableUnderBaseChangeAgainst ⊤ ↔ P.IsStableUnderBaseChange where
+  mp h :=
+    ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
+      (h.isStableUnderBaseChangeAlong _ (by tauto)).of_isPullback h' h''⟩
+  mpr _ := inferInstance
 
 lemma hasPullback_ofHasPullbacksAgainst
     {P : MorphismProperty C} {P' : MorphismProperty C} {c c' c'' : C}
@@ -1039,10 +1041,11 @@ instance (P : MorphismProperty C) [P.IsStableUnderCobaseChange]
 
 lemma isStableUnderCobaseChangeAgainst_top_iff
     (P : MorphismProperty C) :
-    P.IsStableUnderCobaseChangeAgainst ⊤ ↔ P.IsStableUnderCobaseChange :=
-  ⟨ fun h ↦ ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
-      (h.isStableUnderCobaseChangeAlong _ (by tauto)).of_isPushout h' h''⟩,
-    fun _ ↦ inferInstance ⟩
+    P.IsStableUnderCobaseChangeAgainst ⊤ ↔ P.IsStableUnderCobaseChange where
+  mp h :=
+    ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
+      (h.isStableUnderCobaseChangeAlong _ (by tauto)).of_isPushout h' h''⟩
+  mpr _ := inferInstance
 
 /-- `P.HasPullbacksAgainst P'` states that for any morphism `f` satisfying `P'`,
 `P` has pullbacks along `f`. -/
@@ -1057,10 +1060,11 @@ instance (P : MorphismProperty C) [P.HasPushouts] (P' : MorphismProperty C) :
 
 lemma HasPushoutsAgainst_top_iff
     (P : MorphismProperty C) :
-    P.IsStableUnderCobaseChangeAgainst ⊤ ↔ P.IsStableUnderCobaseChange :=
-  ⟨ fun h ↦ ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
-      (h.isStableUnderCobaseChangeAlong _ (by tauto)).of_isPushout h' h''⟩,
-    fun _ ↦ inferInstance⟩
+    P.IsStableUnderCobaseChangeAgainst ⊤ ↔ P.IsStableUnderCobaseChange where
+  mp h :=
+    ⟨fun {_ _ _ _} _ _ _ _ h' h'' ↦
+      (h.isStableUnderCobaseChangeAlong _ (by tauto)).of_isPushout h' h''⟩
+  mpr _ := inferInstance
 
 lemma hasPullback_ofHasPushoutsAgainst
     {P : MorphismProperty C} {P' : MorphismProperty C} {c c' c'' : C}

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -1048,7 +1048,7 @@ lemma isStableUnderCobaseChangeAgainst_top_iff
   mpr _ := inferInstance
 
 /-- `P.HasPullbacksAgainst P'` states that for any morphism `f` satisfying `P'`,
-`P` has pullbacks along `f`. -/
+`P` has pushouts along `f`. -/
 class HasPushoutsAgainst
     (P P' : MorphismProperty C) : Prop where
   hasPushoutsAlong ⦃X Y : C ⦄ (f : X ⟶ Y) (hf : P' f) :

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -1010,7 +1010,7 @@ instance (P : MorphismProperty C) [P.HasPullbacks] (P' : MorphismProperty C) :
     P.HasPullbacksAgainst P' where
   hasPullbacksAlong := inferInstance
 
-lemma HasPullbacksAgainst_top_iff
+lemma hasPullbacksAgainst_top_iff
     (P : MorphismProperty C) :
     P.IsStableUnderBaseChangeAgainst ⊤ ↔ P.IsStableUnderBaseChange where
   mp h :=
@@ -1018,7 +1018,7 @@ lemma HasPullbacksAgainst_top_iff
       (h.isStableUnderBaseChangeAlong _ (by tauto)).of_isPullback h' h''⟩
   mpr _ := inferInstance
 
-lemma hasPullback_ofHasPullbacksAgainst
+lemma _root_.CategoryTheory.Limits.hasPullback_ofHasPullbacksAgainst
     {P : MorphismProperty C} {P' : MorphismProperty C} {c c' c'' : C}
     {f : c ⟶ c'} {g : c'' ⟶ c'} [P.HasPullbacksAgainst P'] (hf : P f) (hg : P' g) :
     Limits.HasPullback f g :=
@@ -1058,7 +1058,7 @@ instance (P : MorphismProperty C) [P.HasPushouts] (P' : MorphismProperty C) :
     P.HasPushoutsAgainst P' where
   hasPushoutsAlong := inferInstance
 
-lemma HasPushoutsAgainst_top_iff
+lemma hasPushoutsAgainst_top_iff
     (P : MorphismProperty C) :
     P.IsStableUnderCobaseChangeAgainst ⊤ ↔ P.IsStableUnderCobaseChange where
   mp h :=
@@ -1066,7 +1066,7 @@ lemma HasPushoutsAgainst_top_iff
       (h.isStableUnderCobaseChangeAlong _ (by tauto)).of_isPushout h' h''⟩
   mpr _ := inferInstance
 
-lemma hasPullback_ofHasPushoutsAgainst
+lemma _root_.CategoryTheory.Limits.hasPushout_ofHasPushoutsAgainst
     {P : MorphismProperty C} {P' : MorphismProperty C} {c c' c'' : C}
     {f : c ⟶ c'} {g : c ⟶ c''} [P.HasPushoutsAgainst P'] (hf : P f) (hg : P' g) :
     Limits.HasPushout f g :=


### PR DESCRIPTION
Given `P P̀': MorphismProperty C`, we add a type class `HasPullbacksAgainst` expressing that any morphism satisfying `P` admits a pullback along any morphism satisfying `P'`. We also add a type-class expressing that pullbacks of morphisms of `P` along any morphism satisfying `P'` still satisfies `P`. 

This will be used to encode pairs of morphism properties for which suitable bicategories of spans exist.

From [SymmMonCoherence](https://github.com/robin-carlier/SymmMonCoherence)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I welcome any better name here! `HasPullacksAlong` and friends are already taken, hence I picked "against".

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
