### PR TITLE
[Merged by Bors] - feat(Data/Finset/Powerset): add results about powersetCard

### DIFF
--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -337,7 +337,7 @@ lemma eq_of_powersetCard_eq {a b : Finset α} {r : ℕ}
 
 /-- For `1 ≤ r ≤ q`, the map `powersetCard r` is injective on the finsets of cardinality `q`. -/
 lemma powersetCard_injOn {q r : ℕ} (hr₀ : r ≠ 0) (hrq : r ≤ q) :
-    Set.InjOn (·.powersetCard r) {a : Finset α | #a = q}
+    Set.InjOn (fun a ↦ a.powersetCard r) {a : Finset α | #a = q}
   | _, rfl, _, hbq, h => eq_of_powersetCard_eq hbq.symm hr₀ hrq h
 
 theorem powersetCard_map {β : Type*} (f : α ↪ β) (n : ℕ) (s : Finset α) :

--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -329,13 +329,14 @@ lemma powersetCard_biUnion [DecidableEq α] {r : ℕ} (hr : r ≠ 0) (hrs : r �
 
 /-- If two finsets of equal cardinality have the same `r`-element subsets for some `1 ≤ r ≤ #a`,
 they are equal. -/
-lemma eq_of_powersetCard_eq [DecidableEq α] {a b : Finset α} {r : ℕ}
+lemma eq_of_powersetCard_eq {a b : Finset α} {r : ℕ}
     (hab : #a = #b) (hr₀ : r ≠ 0) (hra : r ≤ #a)
     (h : a.powersetCard r = b.powersetCard r) : a = b := by
+  classical
   simpa [powersetCard_biUnion hr₀, ← hab, hra] using congr(($h).biUnion id)
 
 /-- For `1 ≤ r ≤ q`, the map `powersetCard r` is injective on the finsets of cardinality `q`. -/
-lemma powersetCard_injOn [DecidableEq α] {q r : ℕ} (hr₀ : r ≠ 0) (hrq : r ≤ q) :
+lemma powersetCard_injOn {q r : ℕ} (hr₀ : r ≠ 0) (hrq : r ≤ q) :
     Set.InjOn (·.powersetCard r) {a : Finset α | #a = q}
   | _, rfl, _, hbq, h => eq_of_powersetCard_eq hbq.symm hr₀ hrq h
 

--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -320,6 +320,25 @@ theorem powersetCard_sup [DecidableEq α] (u : Finset α) (n : ℕ) (hn : n < u.
     rw [← insert_erase hx, powersetCard_succ_insert (notMem_erase _ _)]
     exact mem_union_right _ (mem_image_of_mem _ ht)
 
+/-- The union of all `r`-element subsets of `s` is `s`, provided `1 ≤ r ≤ #s`. -/
+lemma powersetCard_biUnion [DecidableEq α] {r : ℕ} (hr : r ≠ 0) (hrs : r ≤ #s) :
+    (s.powersetCard r).biUnion id = s := by
+  obtain ⟨r, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hr
+  rw [← sup_eq_biUnion]
+  exact powersetCard_sup _ _ hrs
+
+/-- If two finsets of equal cardinality have the same `r`-element subsets for some `1 ≤ r ≤ #a`,
+they are equal. -/
+lemma eq_of_powersetCard_eq [DecidableEq α] {a b : Finset α} {r : ℕ}
+    (hab : #a = #b) (hr₀ : r ≠ 0) (hra : r ≤ #a)
+    (h : a.powersetCard r = b.powersetCard r) : a = b := by
+  simpa [powersetCard_biUnion hr₀, ← hab, hra] using congr(($h).biUnion id)
+
+/-- For `1 ≤ r ≤ q`, the map `powersetCard r` is injective on the finsets of cardinality `q`. -/
+lemma powersetCard_injOn [DecidableEq α] {q r : ℕ} (hr₀ : r ≠ 0) (hrq : r ≤ q) :
+    Set.InjOn (·.powersetCard r) {a : Finset α | #a = q}
+  | _, rfl, _, hbq, h => eq_of_powersetCard_eq hbq.symm hr₀ hrq h
+
 theorem powersetCard_map {β : Type*} (f : α ↪ β) (n : ℕ) (s : Finset α) :
     powersetCard n (s.map f) = (powersetCard n s).map (mapEmbedding f).toEmbedding :=
   ext fun t => by


### PR DESCRIPTION
These are useful for set family combinatorics

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
