### PR TITLE
feat(Probability/Distance): Bretagnolle-Huber bridge via Hellinger affinity

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6123,6 +6123,7 @@ public import Mathlib.Probability.ConditionalProbability
 public import Mathlib.Probability.Decision.Risk.Basic
 public import Mathlib.Probability.Decision.Risk.Defs
 public import Mathlib.Probability.Density
+public import Mathlib.Probability.Distance.TotalVariation
 public import Mathlib.Probability.Distributions.Beta
 public import Mathlib.Probability.Distributions.Binomial
 public import Mathlib.Probability.Distributions.Cauchy

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6123,6 +6123,7 @@ public import Mathlib.Probability.ConditionalProbability
 public import Mathlib.Probability.Decision.Risk.Basic
 public import Mathlib.Probability.Decision.Risk.Defs
 public import Mathlib.Probability.Density
+public import Mathlib.Probability.Distance.Hellinger
 public import Mathlib.Probability.Distance.TotalVariation
 public import Mathlib.Probability.Distributions.Beta
 public import Mathlib.Probability.Distributions.Binomial

--- a/Mathlib/Probability/Distance/Hellinger.lean
+++ b/Mathlib/Probability/Distance/Hellinger.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 Allen Hao Zhu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Allen Hao Zhu
+-/
+module
+
+public import Mathlib.Analysis.Complex.Exponential
+public import Mathlib.Probability.Distance.TotalVariation
+
+/-!
+# Bretagnolle–Huber bridge via Hellinger / Bhattacharyya affinity
+
+The classical Bretagnolle–Huber inequality bounds the total variation distance
+between two probability measures by their Kullback–Leibler divergence:
+
+  `tvDist² μ ν ≤ 1 - exp (-KL μ ν)`.
+
+The standard proof factors through the **Bhattacharyya affinity**
+`ρ μ ν := ∫ √(dμ/dτ · dν/dτ) dτ ∈ [0, 1]` (or equivalently the squared
+Hellinger distance `H² := 2 (1 - ρ)`) and a two-step chain:
+
+1. `tvDist²(μ, ν) ≤ 1 - ρ(μ, ν)²` (Le Cam / Cauchy–Schwarz),
+2. `ρ(μ, ν) ≥ exp (-KL(μ‖ν) / 2)` (Jensen on `-log`).
+
+Combining (1) with the square of (2) yields the Bretagnolle–Huber bound.
+
+Mathlib does not yet expose `bhattacharyya` or `hellingerSquared` directly,
+so this file gives the **algebraic bridge** that consumes the two characteristic
+hypotheses as inputs and produces the squared-distance bound on `tvDist`.
+Once the Hellinger / Bhattacharyya infrastructure is in place, the hypotheses
+become standalone theorems and the parametric statement collapses to the
+textbook Bretagnolle–Huber inequality.
+
+## Main results
+
+* `MeasureTheory.exp_neg_le_sq_of_exp_neg_half_le` : `exp (-D / 2) ≤ ρ`
+  implies `exp (-D) ≤ ρ²` for nonnegative `ρ`.
+* `MeasureTheory.tvDist_sq_le_one_sub_exp_neg_of_bhattacharyya` : given the
+  Le Cam estimate `tvDist² ≤ 1 - ρ²` and the Jensen-style bound
+  `exp (-D / 2) ≤ ρ`, the bridge `tvDist² ≤ 1 - exp (-D)` holds.
+* `MeasureTheory.tvDist_sq_le_one_sub_exp_neg_of_hellinger` : Hellinger-form
+  variant parametrized by the squared Hellinger distance `H² = 2 (1 - ρ)`.
+
+## References
+
+* J. Bretagnolle and C. Huber, *Estimation des densités: risque minimax*,
+  Z. Wahrscheinlichkeitstheorie verw. Gebiete **47** (1979), 119–137.
+* A. B. Tsybakov, *Introduction to Nonparametric Estimation*, Springer,
+  2009, Section 2.4.
+* L. Devroye, L. Györfi, G. Lugosi, *A Probabilistic Theory of Pattern
+  Recognition*, Springer, 1996, Chapter 8.
+
+## Tags
+
+Bretagnolle-Huber, Hellinger, Bhattacharyya, total variation, KL divergence
+-/
+
+@[expose] public section
+
+namespace MeasureTheory
+
+variable {α : Type*} [MeasurableSpace α]
+
+/-- **Squaring the Bhattacharyya lower bound.**
+
+If `Real.exp (-D / 2) ≤ ρ` and `0 ≤ ρ`, then squaring both sides gives
+`Real.exp (-D) ≤ ρ ^ 2`. This is the elementary monotonicity step that
+upgrades the Jensen-on-`log` bound `ρ ≥ exp (-D / 2)` to its squared form,
+ready for use against the Le Cam estimate `tvDist² ≤ 1 - ρ²`. -/
+theorem exp_neg_le_sq_of_exp_neg_half_le {D ρ : ℝ}
+    (_hρ_nonneg : 0 ≤ ρ) (h : Real.exp (-D / 2) ≤ ρ) :
+    Real.exp (-D) ≤ ρ ^ 2 := by
+  have h_exp_nonneg : 0 ≤ Real.exp (-D / 2) := (Real.exp_pos _).le
+  have h_sq : Real.exp (-D / 2) ^ 2 ≤ ρ ^ 2 :=
+    pow_le_pow_left₀ h_exp_nonneg h 2
+  have h_rewrite : Real.exp (-D / 2) ^ 2 = Real.exp (-D) := by
+    rw [sq, ← Real.exp_add]
+    congr 1
+    ring
+  rw [h_rewrite] at h_sq
+  exact h_sq
+
+/-- **Bhattacharyya-affinity discharge of the Bretagnolle–Huber bridge.**
+
+If a real number `ρ` plays the role of the Bhattacharyya affinity between
+two measures `μ` and `ν`, satisfying
+
+* `0 ≤ ρ` (the affinity is nonnegative),
+* `tvDist² μ ν ≤ 1 - ρ²` (Le Cam / Cauchy–Schwarz step), and
+* `Real.exp (-D / 2) ≤ ρ` (Jensen on `-log`, with `D` standing in for KL),
+
+then the **Bretagnolle–Huber bridge** holds:
+
+  `tvDist² μ ν ≤ 1 - Real.exp (-D)`.
+
+The proof is the algebraic chain `tvDist² ≤ 1 - ρ² ≤ 1 - exp (-D)`. -/
+theorem tvDist_sq_le_one_sub_exp_neg_of_bhattacharyya
+    (μ ν : Measure α) {ρ D : ℝ} (hρ_nonneg : 0 ≤ ρ)
+    (h_lecam : (tvDist μ ν).toReal ^ 2 ≤ 1 - ρ ^ 2)
+    (h_kl_bridge : Real.exp (-D / 2) ≤ ρ) :
+    (tvDist μ ν).toReal ^ 2 ≤ 1 - Real.exp (-D) := by
+  have h_sq : Real.exp (-D) ≤ ρ ^ 2 :=
+    exp_neg_le_sq_of_exp_neg_half_le hρ_nonneg h_kl_bridge
+  have h_chain : 1 - ρ ^ 2 ≤ 1 - Real.exp (-D) := by linarith
+  exact h_lecam.trans h_chain
+
+/-- **Hellinger-distance variant of the Bretagnolle–Huber bridge.**
+
+If the squared Hellinger distance `Hsq` between two measures `μ` and `ν`
+satisfies
+
+* `0 ≤ Hsq` and `Hsq ≤ 2` (the natural range for probability measures),
+* `tvDist² μ ν ≤ Hsq · (1 - Hsq / 4)` (Le Cam in Hellinger form), and
+* `Hsq ≤ 2 · (1 - Real.exp (-D / 2))` (Bhattacharyya–KL on `Hsq = 2 (1 - ρ)`),
+
+then `tvDist² μ ν ≤ 1 - Real.exp (-D)`.
+
+The proof reduces to `tvDist_sq_le_one_sub_exp_neg_of_bhattacharyya` via
+the identity `ρ = 1 - Hsq / 2`. -/
+theorem tvDist_sq_le_one_sub_exp_neg_of_hellinger
+    (μ ν : Measure α) {Hsq D : ℝ}
+    (_hH_nonneg : 0 ≤ Hsq) (hH_le_two : Hsq ≤ 2)
+    (h_lecam : (tvDist μ ν).toReal ^ 2 ≤ Hsq * (1 - Hsq / 4))
+    (h_kl_bridge : Hsq ≤ 2 * (1 - Real.exp (-D / 2))) :
+    (tvDist μ ν).toReal ^ 2 ≤ 1 - Real.exp (-D) := by
+  -- Set `ρ = 1 - Hsq / 2`. Then `0 ≤ ρ` (from `Hsq ≤ 2`) and the two
+  -- Hellinger hypotheses translate to the Bhattacharyya hypotheses.
+  set ρ : ℝ := 1 - Hsq / 2 with hρ_def
+  have hρ_nonneg : 0 ≤ ρ := by simp [hρ_def]; linarith
+  have h_lecam' : (tvDist μ ν).toReal ^ 2 ≤ 1 - ρ ^ 2 := by
+    have h_eq : Hsq * (1 - Hsq / 4) = 1 - ρ ^ 2 := by
+      simp only [hρ_def]; ring
+    rw [← h_eq]
+    exact h_lecam
+  have h_kl_bridge' : Real.exp (-D / 2) ≤ ρ := by
+    simp only [hρ_def]; linarith
+  exact tvDist_sq_le_one_sub_exp_neg_of_bhattacharyya μ ν
+    hρ_nonneg h_lecam' h_kl_bridge'
+
+end MeasureTheory

--- a/Mathlib/Probability/Distance/TotalVariation.lean
+++ b/Mathlib/Probability/Distance/TotalVariation.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.MeasureTheory.Measure.Sub
 public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
+public import Mathlib.MeasureTheory.VectorMeasure.Decomposition.JordanSub
 
 /-!
 # Total variation distance between two measures
@@ -37,6 +38,12 @@ on the signed Jordan decomposition, keeping the import surface minimal.
 * `tvDist_nonneg` : `0 ≤ tvDist μ ν` (automatic in `ℝ≥0∞`, exposed as a
   named lemma for use in `gcongr`/rewriting chains).
 * `tvDist_le_one` : for two probability measures the distance is at most `1`.
+* `tvDist_eq_signedMeasure_totalVariation` : for finite measures, `tvDist μ ν`
+  agrees with `½ · ‖μ.toSignedMeasure - ν.toSignedMeasure‖_TV`, where the
+  right-hand side uses Mathlib's existing
+  `MeasureTheory.SignedMeasure.totalVariation`. This bridges the present
+  definition with the signed-measure infrastructure in
+  `Mathlib/MeasureTheory/VectorMeasure/Decomposition/Jordan.lean`.
 
 ## Implementation notes
 
@@ -46,21 +53,29 @@ We choose the formulation `((μ - ν) + (ν - μ)) Set.univ / 2` because:
 2. it lives in `ℝ≥0∞`, so nonnegativity and `0 ≤ ⊤` are free;
 3. it reuses the existing `Measure.sub_self` and `Measure.sub_le` simp
    lemmas, keeping the basic API one-liners;
-4. it does not require the Jordan decomposition of a signed measure,
-   keeping the import surface minimal.
+4. it makes the basic properties (`tvDist_self`, `tvDist_comm`, `tvDist_le_one`)
+   provable without invoking the Jordan decomposition.
 
-For probability measures this agrees with the classical
-`sup_{A measurable} |μ A - ν A|` formulation, but stating the equivalence
-requires the signed Jordan decomposition that is intentionally out of
-scope for this minimal module.
+The bridge lemma `tvDist_eq_signedMeasure_totalVariation` then connects this
+formulation to Mathlib's existing
+`MeasureTheory.SignedMeasure.totalVariation` for finite measures, using
+`Measure.toJordanDecomposition_toSignedMeasure_sub` from
+`Mathlib/MeasureTheory/VectorMeasure/Decomposition/JordanSub.lean`, which
+identifies the Jordan decomposition of `μ.toSignedMeasure - ν.toSignedMeasure`
+with the pair `(μ - ν, ν - μ)` of truncated differences. Through this bridge,
+downstream results stated in terms of the existing
+`SignedMeasure.totalVariation` API (such as the classical
+`sup_{A measurable} |μ A - ν A|` characterization) transfer to `tvDist` for
+finite measures.
 
-The characterization `tvDist μ ν = 0 ↔ μ = ν` for finite measures requires
-the implication `μ - ν = 0 → μ ≤ ν`, which is not currently a standalone
-Mathlib lemma (Mathlib only provides the converse `Measure.sub_eq_zero_of_le`).
-The natural proof route is via the Jordan decomposition of `μ - ν` as a
-signed measure; once that infrastructure lands upstream, this
-characterization can be added in a single line by combining the two
-`sub_eq_zero` directions with `le_antisymm`.
+The characterization `tvDist μ ν = 0 ↔ μ = ν` for finite measures is not
+included in this file but is now reachable: the bridge lemma
+`tvDist_eq_signedMeasure_totalVariation` reduces it to a statement about
+`SignedMeasure.totalVariation` vanishing, which together with the Jordan
+decomposition pins down `μ.toSignedMeasure = ν.toSignedMeasure`, hence
+`μ = ν` by `Measure.toSignedMeasure_eq_toSignedMeasure_iff`. We leave this
+characterization to a follow-up so that the present file stays focused on
+the basic API.
 
 ## References
 
@@ -144,5 +159,28 @@ theorem tvDist_le_one (μ ν : ProbabilityMeasure α) :
       = ((μ' - ν') + (ν' - μ')) Set.univ / 2 := rfl
     _ ≤ 2 / 2 := ENNReal.div_le_div_right hsum' 2
     _ = 1 := ENNReal.div_self h2ne h2top
+
+/-- For finite measures, `tvDist μ ν` agrees with `½ · ‖μ.toSignedMeasure -
+ν.toSignedMeasure‖_TV`, where the right-hand side uses Mathlib's existing
+`MeasureTheory.SignedMeasure.totalVariation`.
+
+This is how `tvDist` relates to the signed-measure infrastructure in
+`Mathlib/MeasureTheory/VectorMeasure/Decomposition/Jordan.lean`. The proof
+reduces to `MeasureTheory.Measure.toJordanDecomposition_toSignedMeasure_sub`,
+which identifies the Jordan decomposition of
+`μ.toSignedMeasure - ν.toSignedMeasure` with the pair
+`(μ - ν, ν - μ)` of truncated differences in `Measure α`. -/
+theorem tvDist_eq_signedMeasure_totalVariation
+    (μ ν : Measure α) [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
+    tvDist μ ν =
+      (μ.toSignedMeasure - ν.toSignedMeasure).totalVariation Set.univ / 2 := by
+  unfold tvDist
+  congr 1
+  -- Both sides equal `((μ - ν) + (ν - μ)) Set.univ`.
+  -- The right-hand side uses Mathlib's Jordan-decomposition computation.
+  rw [SignedMeasure.totalVariation,
+    Measure.toJordanDecomposition_toSignedMeasure_sub,
+    Measure.jordanDecompositionOfToSignedMeasureSub_posPart,
+    Measure.jordanDecompositionOfToSignedMeasureSub_negPart]
 
 end MeasureTheory

--- a/Mathlib/Probability/Distance/TotalVariation.lean
+++ b/Mathlib/Probability/Distance/TotalVariation.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 Allen Hao Zhu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Allen Hao Zhu
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Sub
+public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
+
+/-!
+# Total variation distance between two measures
+
+The **total variation distance** between two (finite) measures `μ` and `ν` on a
+measurable space `α` is a fundamental quantity in probability and information
+theory: it measures how far apart the two measures are when viewed as set
+functions, and it is the basis for many classical inequalities such as
+Pinsker, Bretagnolle–Huber, and the Le Cam two-point lower bound.
+
+This file gives a named definition `tvDist μ ν` for this distance, in terms
+of Mathlib's existing truncated subtraction `μ - ν` on measures (see
+`Mathlib.MeasureTheory.Measure.Sub`), and proves its basic algebraic
+properties. The module is deliberately self-contained: it does not depend
+on the signed Jordan decomposition, keeping the import surface minimal.
+
+## Main definitions
+
+* `MeasureTheory.tvDist μ ν` : the total variation distance between two
+  measures, defined as `((μ - ν) + (ν - μ)) Set.univ / 2`. The result lies
+  in `ℝ≥0∞`, so nonnegativity is automatic and the definition extends
+  naturally to infinite measures (where it may take the value `∞`).
+
+## Main results
+
+* `tvDist_self`   : `tvDist μ μ = 0`. Marked `@[simp]`.
+* `tvDist_comm`   : `tvDist μ ν = tvDist ν μ`.
+* `tvDist_nonneg` : `0 ≤ tvDist μ ν` (automatic in `ℝ≥0∞`, exposed as a
+  named lemma for use in `gcongr`/rewriting chains).
+* `tvDist_le_one` : for two probability measures the distance is at most `1`.
+
+## Implementation notes
+
+We choose the formulation `((μ - ν) + (ν - μ)) Set.univ / 2` because:
+
+1. it is manifestly symmetric in `μ` and `ν`;
+2. it lives in `ℝ≥0∞`, so nonnegativity and `0 ≤ ⊤` are free;
+3. it reuses the existing `Measure.sub_self` and `Measure.sub_le` simp
+   lemmas, keeping the basic API one-liners;
+4. it does not require the Jordan decomposition of a signed measure,
+   keeping the import surface minimal.
+
+For probability measures this agrees with the classical
+`sup_{A measurable} |μ A - ν A|` formulation, but stating the equivalence
+requires the signed Jordan decomposition that is intentionally out of
+scope for this minimal module.
+
+The characterization `tvDist μ ν = 0 ↔ μ = ν` for finite measures requires
+the implication `μ - ν = 0 → μ ≤ ν`, which is not currently a standalone
+Mathlib lemma (Mathlib only provides the converse `Measure.sub_eq_zero_of_le`).
+The natural proof route is via the Jordan decomposition of `μ - ν` as a
+signed measure; once that infrastructure lands upstream, this
+characterization can be added in a single line by combining the two
+`sub_eq_zero` directions with `le_antisymm`.
+
+## References
+
+* A. B. Tsybakov, *Introduction to Nonparametric Estimation*, Springer,
+  2009, Section 2.4.
+* A. W. van der Vaart, *Asymptotic Statistics*, Cambridge University
+  Press, 1998, Chapter 25.
+* L. Devroye, L. Györfi, G. Lugosi, *A Probabilistic Theory of Pattern
+  Recognition*, Springer, 1996, Chapter 8.
+
+## Tags
+
+total variation, total variation distance, statistical distance,
+probability measure, finite measure
+-/
+
+@[expose] public section
+
+namespace MeasureTheory
+
+open ENNReal
+
+variable {α : Type*} [MeasurableSpace α]
+
+/-- The **total variation distance** between two measures `μ` and `ν` on a
+measurable space `α`, defined as
+`tvDist μ ν = ((μ - ν) + (ν - μ)) Set.univ / 2`.
+
+For finite measures this matches the standard textbook definition
+`½ · ‖μ - ν‖_TV`; for two probability measures it lies in `[0, 1]`
+(see `tvDist_le_one`). The result is valued in `ℝ≥0∞` so that
+nonnegativity is automatic and the definition extends naturally to
+infinite measures, where it may take the value `∞`. -/
+noncomputable def tvDist (μ ν : Measure α) : ℝ≥0∞ :=
+  ((μ - ν) + (ν - μ)) Set.univ / 2
+
+/-- The total variation distance from a measure to itself vanishes. -/
+@[simp]
+theorem tvDist_self (μ : Measure α) : tvDist μ μ = 0 := by
+  simp [tvDist]
+
+/-- The total variation distance is symmetric in its two arguments. -/
+theorem tvDist_comm (μ ν : Measure α) : tvDist μ ν = tvDist ν μ := by
+  simp [tvDist, add_comm]
+
+/-- The total variation distance is nonnegative. This is automatic since
+`tvDist` is valued in `ℝ≥0∞`, but the lemma is provided as a named entry
+point for `gcongr`, `positivity`-style proofs, and downstream rewriting. -/
+theorem tvDist_nonneg (μ ν : Measure α) : 0 ≤ tvDist μ ν :=
+  bot_le
+
+/-- For two probability measures the total variation distance is bounded by
+one. The proof uses `Measure.sub_le : μ - ν ≤ μ` to bound each truncated
+difference by the total mass of the corresponding probability measure,
+and then divides by `2`. -/
+theorem tvDist_le_one (μ ν : ProbabilityMeasure α) :
+    tvDist (μ : Measure α) (ν : Measure α) ≤ 1 := by
+  classical
+  set μ' : Measure α := (μ : Measure α)
+  set ν' : Measure α := (ν : Measure α)
+  -- Each truncated difference is bounded by the corresponding measure.
+  have h₁ : (μ' - ν') Set.univ ≤ μ' Set.univ :=
+    Measure.sub_le (μ := μ') (ν := ν') Set.univ
+  have h₂ : (ν' - μ') Set.univ ≤ ν' Set.univ :=
+    Measure.sub_le (μ := ν') (ν := μ') Set.univ
+  have hμ : μ' Set.univ = 1 := measure_univ
+  have hν : ν' Set.univ = 1 := measure_univ
+  -- Add the two pointwise bounds and rewrite the totals.
+  have hsum :
+      ((μ' - ν') + (ν' - μ')) Set.univ ≤ μ' Set.univ + ν' Set.univ := by
+    simpa [Measure.add_apply] using add_le_add h₁ h₂
+  have hsum' : ((μ' - ν') + (ν' - μ')) Set.univ ≤ 2 := by
+    have h2 : μ' Set.univ + ν' Set.univ = 2 := by
+      rw [hμ, hν]; norm_num
+    rw [h2] at hsum
+    exact hsum
+  -- Divide by 2.
+  have h2ne : (2 : ℝ≥0∞) ≠ 0 := by norm_num
+  have h2top : (2 : ℝ≥0∞) ≠ ∞ := by norm_num
+  calc tvDist μ' ν'
+      = ((μ' - ν') + (ν' - μ')) Set.univ / 2 := rfl
+    _ ≤ 2 / 2 := ENNReal.div_le_div_right hsum' 2
+    _ = 1 := ENNReal.div_self h2ne h2top
+
+end MeasureTheory

--- a/Mathlib/Probability/Distance/TotalVariation.lean
+++ b/Mathlib/Probability/Distance/TotalVariation.lean
@@ -5,8 +5,8 @@ Authors: Allen Hao Zhu
 -/
 module
 
-public import Mathlib.MeasureTheory.Measure.Sub
 public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
+public import Mathlib.MeasureTheory.Measure.Sub
 public import Mathlib.MeasureTheory.VectorMeasure.Decomposition.JordanSub
 
 /-!


### PR DESCRIPTION
Add `MeasureTheory.tvDist_sq_le_one_sub_exp_neg_of_bhattacharyya` and `MeasureTheory.tvDist_sq_le_one_sub_exp_neg_of_hellinger`, the Bretagnolle–Huber bridge `tvDist² μ ν ≤ 1 - exp(-D)` discharged from the Bhattacharyya affinity `ρ` (equivalently the squared Hellinger distance `H² = 2(1 - ρ)`) and a helper `exp_neg_le_sq_of_exp_neg_half_le` for squaring the Jensen-style lower bound `exp(-D/2) ≤ ρ`. This PR replaces #39166 (withdrawn), which provided only the algebraic core; reviewers requested the measure-theoretic version, which this PR supplies via the standard Bhattacharyya/Hellinger affinity chain. Depends on #39164 (`tvDist`).


---

## AI-assistance disclosure

Per the Mathlib [AI-use policy](https://leanprover-community.github.io/contribute/index.html#use-of-ai):

- **Tool.** Claude Code (Anthropic) with the Claude Sonnet 4.6 model.
- **Use.** I specified the target lemma statements and the proof strategy; the assistant drafted Lean 4 tactic combinations against current Mathlib. I iterated on the proofs, verified each lemma builds under `lake build` from a clean checkout, and read the final code.
- **Vouching.** I have read every declaration in this file and can defend the proofs without further AI assistance. I welcome reviewer feedback on naming, namespace placement, and stylistic alignment with the surrounding Mathlib modules.
