### PR TITLE
[Merged by Bors] - chore(Algebra/CategoryTheory/ModuleCat): generalize universe parameter in `LocalGeneratorsData`

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Generators.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Generators.lean
@@ -29,7 +29,7 @@ define sheaves of modules of finite type.
 
 @[expose] public section
 
-universe u v' u'
+universe w u v' u'
 
 open CategoryTheory Limits
 
@@ -112,12 +112,24 @@ variable [∀ (X : C), HasWeakSheafify (J.over X) AddCommGrpCat.{u}]
 over a covering of the terminal object. -/
 structure LocalGeneratorsData where
   /-- the index type of the covering -/
-  I : Type u'
+  I : Type w
   /-- a family of objects which cover the terminal object -/
   X : I → C
   coversTop : J.CoversTop X
   /-- the data of sections of `M` over `X i` which generate `M.over (X i)` -/
   generators (i : I) : (M.over (X i)).GeneratingSections
+
+/-- Shrink the indexing type of `LocalGeneratorsData` into the universe of the site. -/
+noncomputable
+def shrink {M : SheafOfModules.{u} R} (q : M.LocalGeneratorsData) :
+    LocalGeneratorsData.{u'} M where
+  I := Set.range q.X
+  X i := q.X i.2.choose
+  coversTop X := by
+    refine J.superset_covering (fun Y hY H ↦ ?_) (q.coversTop X)
+    obtain ⟨i, ⟨hi⟩⟩ := (Sieve.mem_ofObjects_iff ..).mp H
+    exact ⟨⟨_, i, rfl⟩, ⟨hi ≫ eqToHom (by grind)⟩⟩
+  generators i := q.generators i.2.choose
 
 variable {M} in
 /-- The data of local generators of a sheaf of modules is finite type if
@@ -129,7 +141,7 @@ class LocalGeneratorsData.IsFiniteType (p : M.LocalGeneratorsData) : Prop where
 many sections. -/
 class IsFiniteType (M : SheafOfModules.{u} R) : Prop where
   exists_localGeneratorsData (M) :
-    ∃ (σ : M.LocalGeneratorsData), σ.IsFiniteType
+    ∃ (σ : (LocalGeneratorsData.{u'} M)), σ.IsFiniteType
 
 /-- A choice of local generators when `M` is a sheaf of modules of finite type. -/
 @[deprecated "Use the lemma `IsFiniteType.exists_localGeneratorsData` instead."

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Generators.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Generators.lean
@@ -121,7 +121,7 @@ structure LocalGeneratorsData where
 
 /-- Shrink the indexing type of `LocalGeneratorsData` into the universe of the site. -/
 noncomputable
-def shrink {M : SheafOfModules.{u} R} (q : M.LocalGeneratorsData) :
+def LocalGeneratorsData.shrink {M : SheafOfModules.{u} R} (q : M.LocalGeneratorsData) :
     LocalGeneratorsData.{u'} M where
   I := Set.range q.X
   X i := q.X i.2.choose


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
