### PR TITLE
feat(Order/OrderIsoNat): some lemmas about `((· < ·) : ℕ → ℕ → Prop) ↪r r`

### DIFF
--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -80,6 +80,7 @@ theorem not_wellFounded (f : ((· > ·) : ℕ → ℕ → Prop) ↪r r) : ¬Well
 section LinearOrder
 
 variable {α : Type*} {r : α → α → Prop}
+
 theorem infinite_iff_nonempty_relEmbedding_of_isWellOrder [IsWellOrder α r] :
     Infinite α ↔ Nonempty (((· < ·) : ℕ → ℕ → Prop) ↪r r) := by
   refine ⟨fun _ ↦ ?_, (·.elim (Infinite.of_injective _ ·.injective))⟩
@@ -100,19 +101,18 @@ theorem finite_iff_empty_relEmbedding_of_isWellOrder [IsWellOrder α r] :
   rw [← not_iff_not, not_finite_iff_infinite, not_isEmpty_iff,
     infinite_iff_nonempty_relEmbedding_of_isWellOrder (r := r)]
 
-theorem _root_.IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap {α : Type*} (r : α → α → Prop)
+theorem _root_.IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap
     [IsWellOrder α r] [IsWellFounded α (Function.swap r)] : Finite α := by
   rw [finite_iff_empty_relEmbedding_of_isWellOrder (r := r)]
   have : WellFounded (Function.swap r) := IsWellFounded.wf
   rw [wellFounded_iff_isEmpty] at this
   exact Function.isEmpty RelEmbedding.swap
 
-instance (priority := low) _root_.instFiniteOfWellFoundedLTOfWellFoundedGT {α : Type*}
+instance (priority := low) _root_.instFiniteOfWellFoundedLTOfWellFoundedGT
     [LinearOrder α] [WellFoundedLT α] [WellFoundedGT α] : Finite α :=
-  IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap LT.lt
+  IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap (r := LT.lt)
 
-theorem infinite_iff_nonempty_relEmbedding_lt_or_nonempty_relEmbedding_gt
-    [IsStrictTotalOrder α r] :
+theorem infinite_iff_nonempty_relEmbedding_lt_or_nonempty_relEmbedding_gt [IsStrictTotalOrder α r] :
     Infinite α ↔
       Nonempty (((· < ·) : ℕ → ℕ → Prop) ↪r r) ∨
       Nonempty (((· > ·) : ℕ → ℕ → Prop) ↪r r) := by
@@ -122,10 +122,9 @@ theorem infinite_iff_nonempty_relEmbedding_lt_or_nonempty_relEmbedding_gt
   apply (@Function.isEmpty _ _ · RelEmbedding.swap) at h_lt
   rw [← wellFounded_iff_isEmpty, ← isWellFounded_iff] at h_gt h_lt
   have : IsWellOrder α r := ⟨⟩
-  exact IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap r
+  exact IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap (r := r)
 
-theorem finite_iff_isEmpty_relEmbedding_lt_and_isEmpty_relEmbedding_gt
-    [IsStrictTotalOrder α r] :
+theorem finite_iff_isEmpty_relEmbedding_lt_and_isEmpty_relEmbedding_gt [IsStrictTotalOrder α r] :
     Finite α ↔
       IsEmpty (((· < ·) : ℕ → ℕ → Prop) ↪r r) ∧
       IsEmpty (((· > ·) : ℕ → ℕ → Prop) ↪r r) := by

--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -76,6 +76,95 @@ theorem not_wellFounded (f : ((· > ·) : ℕ → ℕ → Prop) ↪r r) : ¬Well
   rw [wellFounded_iff_isEmpty, not_isEmpty_iff]
   exact ⟨f⟩
 
+section LinearOrder
+
+variable {α : Type*} {r : α → α → Prop}
+
+-- This is for the proof of `infinite_iff_nonempty_relEmbedding_of_isWellOrder` without importing
+-- module `Mathlib.SetTheory.Ordinal.Arithmetic`.
+variable (α) in
+private noncomputable def omegaInitialSeqAux [Infinite α] [LinearOrder α] [wf : WellFoundedLT α] :
+    Nat → { a : α // (Set.Iic a).Finite }
+| 0 => letI OrderBot := wf.toOrderBot; ⟨⊥, by simp⟩
+| n' + 1 => by
+  letI pred := omegaInitialSeqAux n'
+  haveI hmin := wf.exists_minimal (Set.Iic pred.val)ᶜ pred.prop.infinite_compl.nonempty
+  refine ⟨hmin.choose, ?_⟩
+  suffices Set.Iic hmin.choose = insert hmin.choose (Set.Iic pred.val) from
+    this ▸ pred.prop.insert hmin.choose
+  grind [Minimal]
+
+variable (α) in
+private noncomputable abbrev omegaInitialSeq [Infinite α] [LinearOrder α] [WellFoundedLT α]
+    (n : Nat) : α := omegaInitialSeqAux α n
+
+variable (α) in
+private lemma omegaInitialSeq_lt_omegaInitialSeq_succ [Infinite α] [LinearOrder α]
+    [wf : WellFoundedLT α] (n : Nat) : omegaInitialSeq α n < omegaInitialSeq α (n + 1) := by
+  match n with
+  | 0 =>
+    unfold omegaInitialSeq omegaInitialSeqAux
+    generalize_proofs _ _ hmin
+    simpa [omegaInitialSeqAux, bot_lt_iff_ne_bot] using hmin.choose_spec.prop
+  | n' + 1 =>
+    simp only [Subtype.coe_lt_coe, omegaInitialSeqAux, Set.compl_Iic, Set.mem_Ioi, Subtype.mk_lt_mk]
+    generalize_proofs hmin hmin'
+    exact hmin'.choose_spec.prop
+
+theorem infinite_iff_nonempty_relEmbedding_of_isWellOrder [IsWellOrder α r] :
+    Infinite α ↔ Nonempty (((· < ·) : ℕ → ℕ → Prop) ↪r r) := by
+  refine ⟨fun _ ↦ ?_, (·.elim (Infinite.of_injective _ ·.injective))⟩
+  /- Auxiliary definition and lemmas `*omegaInitialSeq*` can be avoided with the following proof
+  with ordinal, which however requires to import module `Mathlib.SetTheory.Ordinal.Arithmetic`:
+  ```
+  rw [← (RelIso.relEmbeddingCongr (.refl _) (Ordinal.enum r)).nonempty_congr,
+    ← (RelIso.relEmbeddingCongr ULift.orderIso.toRelIsoLT (.refl _)).nonempty_congr,
+    ← Ordinal.type_le_iff']
+  simp [← Ordinal.aleph0_le_card, ← Ordinal.lift_card]
+  ``` -/
+  let : LinearOrder α := IsWellOrder.linearOrder r
+  exact ⟨natLT (omegaInitialSeq α) (omegaInitialSeq_lt_omegaInitialSeq_succ α)⟩
+
+theorem finite_iff_empty_relEmbedding_of_isWellOrder [IsWellOrder α r] :
+    Finite α ↔ IsEmpty (((· < ·) : ℕ → ℕ → Prop) ↪r r) := by
+  rw [← not_iff_not, not_finite_iff_infinite, not_isEmpty_iff,
+    infinite_iff_nonempty_relEmbedding_of_isWellOrder (r := r)]
+
+theorem _root_.IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap {α : Type*} (r : α → α → Prop)
+    [IsWellOrder α r] [IsWellFounded α (Function.swap r)] : Finite α := by
+  rw [finite_iff_empty_relEmbedding_of_isWellOrder (r := r)]
+  have : WellFounded (Function.swap r) := IsWellFounded.wf
+  rw [wellFounded_iff_isEmpty] at this
+  exact Function.isEmpty RelEmbedding.swap
+
+instance (priority := low) _root_.instFiniteOfWellFoundedLTOfWellFoundedGT {α : Type*}
+    [LinearOrder α] [WellFoundedLT α] [WellFoundedGT α] : Finite α :=
+  IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap LT.lt
+
+theorem infinite_iff_nonempty_relEmbedding_lt_or_nonempty_relEmbedding_gt
+    [Std.Trichotomous r] [IsStrictOrder α r] :
+    Infinite α ↔
+      Nonempty (((· < ·) : ℕ → ℕ → Prop) ↪r r) ∨
+      Nonempty (((· > ·) : ℕ → ℕ → Prop) ↪r r) := by
+  refine ⟨fun inf ↦ ?_, by rintro (h | h) <;> exact h.elim (Infinite.of_injective _ ·.injective)⟩
+  contrapose! inf with h
+  obtain ⟨h_lt, h_gt⟩ := h
+  apply (@Function.isEmpty _ _ · RelEmbedding.swap) at h_lt
+  rw [← wellFounded_iff_isEmpty, ← isWellFounded_iff] at h_gt h_lt
+  have : IsWellOrder α r := ⟨⟩
+  exact IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap r
+
+theorem finite_iff_isEmpty_relEmbedding_lt_and_isEmpty_relEmbedding_gt
+    [Std.Trichotomous r] [IsStrictOrder α r] :
+    Finite α ↔
+      IsEmpty (((· < ·) : ℕ → ℕ → Prop) ↪r r) ∧
+      IsEmpty (((· > ·) : ℕ → ℕ → Prop) ↪r r) := by
+  rw [← not_iff_not, Classical.not_and_iff_not_or_not, not_finite_iff_infinite,
+    not_isEmpty_iff, not_isEmpty_iff,
+    infinite_iff_nonempty_relEmbedding_lt_or_nonempty_relEmbedding_gt (r := r)]
+
+end LinearOrder
+
 end RelEmbedding
 
 theorem not_strictAnti_of_wellFoundedLT [Preorder α] [WellFoundedLT α] (f : ℕ → α) :

--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -142,7 +142,7 @@ instance (priority := low) _root_.instFiniteOfWellFoundedLTOfWellFoundedGT {α :
   IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap LT.lt
 
 theorem infinite_iff_nonempty_relEmbedding_lt_or_nonempty_relEmbedding_gt
-    [Std.Trichotomous r] [IsStrictOrder α r] :
+    [IsStrictTotalOrder α r] :
     Infinite α ↔
       Nonempty (((· < ·) : ℕ → ℕ → Prop) ↪r r) ∨
       Nonempty (((· > ·) : ℕ → ℕ → Prop) ↪r r) := by
@@ -155,7 +155,7 @@ theorem infinite_iff_nonempty_relEmbedding_lt_or_nonempty_relEmbedding_gt
   exact IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap r
 
 theorem finite_iff_isEmpty_relEmbedding_lt_and_isEmpty_relEmbedding_gt
-    [Std.Trichotomous r] [IsStrictOrder α r] :
+    [IsStrictTotalOrder α r] :
     Finite α ↔
       IsEmpty (((· < ·) : ℕ → ℕ → Prop) ↪r r) ∧
       IsEmpty (((· > ·) : ℕ → ℕ → Prop) ↪r r) := by

--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -10,6 +10,7 @@ public import Mathlib.Logic.Denumerable
 public import Mathlib.Logic.Function.Iterate
 public import Mathlib.Order.Hom.Basic
 public import Mathlib.Data.Set.Subsingleton
+public import Mathlib.Order.InitialSeg
 
 /-!
 # Relation embeddings from the naturals
@@ -79,51 +80,20 @@ theorem not_wellFounded (f : ((· > ·) : ℕ → ℕ → Prop) ↪r r) : ¬Well
 section LinearOrder
 
 variable {α : Type*} {r : α → α → Prop}
-
--- This is for the proof of `infinite_iff_nonempty_relEmbedding_of_isWellOrder` without importing
--- module `Mathlib.SetTheory.Ordinal.Arithmetic`.
-variable (α) in
-private noncomputable def omegaInitialSeqAux [Infinite α] [LinearOrder α] [wf : WellFoundedLT α] :
-    Nat → { a : α // (Set.Iic a).Finite }
-| 0 => letI OrderBot := wf.toOrderBot; ⟨⊥, by simp⟩
-| n' + 1 => by
-  letI pred := omegaInitialSeqAux n'
-  haveI hmin := wf.exists_minimal (Set.Iic pred.val)ᶜ pred.prop.infinite_compl.nonempty
-  refine ⟨hmin.choose, ?_⟩
-  suffices Set.Iic hmin.choose = insert hmin.choose (Set.Iic pred.val) from
-    this ▸ pred.prop.insert hmin.choose
-  grind [Minimal]
-
-variable (α) in
-private noncomputable abbrev omegaInitialSeq [Infinite α] [LinearOrder α] [WellFoundedLT α]
-    (n : Nat) : α := omegaInitialSeqAux α n
-
-variable (α) in
-private lemma omegaInitialSeq_lt_omegaInitialSeq_succ [Infinite α] [LinearOrder α]
-    [wf : WellFoundedLT α] (n : Nat) : omegaInitialSeq α n < omegaInitialSeq α (n + 1) := by
-  match n with
-  | 0 =>
-    unfold omegaInitialSeq omegaInitialSeqAux
-    generalize_proofs _ _ hmin
-    simpa [omegaInitialSeqAux, bot_lt_iff_ne_bot] using hmin.choose_spec.prop
-  | n' + 1 =>
-    simp only [Subtype.coe_lt_coe, omegaInitialSeqAux, Set.compl_Iic, Set.mem_Ioi, Subtype.mk_lt_mk]
-    generalize_proofs hmin hmin'
-    exact hmin'.choose_spec.prop
-
 theorem infinite_iff_nonempty_relEmbedding_of_isWellOrder [IsWellOrder α r] :
     Infinite α ↔ Nonempty (((· < ·) : ℕ → ℕ → Prop) ↪r r) := by
   refine ⟨fun _ ↦ ?_, (·.elim (Infinite.of_injective _ ·.injective))⟩
-  /- Auxiliary definition and lemmas `*omegaInitialSeq*` can be avoided with the following proof
-  with ordinal, which however requires to import module `Mathlib.SetTheory.Ordinal.Arithmetic`:
-  ```
-  rw [← (RelIso.relEmbeddingCongr (.refl _) (Ordinal.enum r)).nonempty_congr,
-    ← (RelIso.relEmbeddingCongr ULift.orderIso.toRelIsoLT (.refl _)).nonempty_congr,
-    ← Ordinal.type_le_iff']
-  simp [← Ordinal.aleph0_le_card, ← Ordinal.lift_card]
-  ``` -/
-  let : LinearOrder α := IsWellOrder.linearOrder r
-  exact ⟨natLT (omegaInitialSeq α) (omegaInitialSeq_lt_omegaInitialSeq_succ α)⟩
+  match InitialSeg.total ((· < ·) : ℕ → ℕ → Prop) r with
+  | .inl f => exact ⟨f.toRelEmbedding⟩
+  | .inr g =>
+    match g.principalSumRelIso with
+    | .inr g => exact ⟨g.symm⟩
+    | .inl g =>
+      absurd (‹_› : Infinite α)
+      rw [not_infinite_iff_finite, finite_iff_nonempty_fintype,
+        ← Set.univ_finite_iff_nonempty_fintype]
+      refine Set.Finite.of_finite_image ?_ g.injective.injOn
+      simp [g.range_eq, Set.finite_lt_nat]
 
 theorem finite_iff_empty_relEmbedding_of_isWellOrder [IsWellOrder α r] :
     Finite α ↔ IsEmpty (((· < ·) : ℕ → ℕ → Prop) ↪r r) := by


### PR DESCRIPTION
This PR contains several lemmas about relation embedding from `<` in `Nat`, well order, and (in)finiteness.

- `RelEmbedding.infinite_iff_nonempty_relEmbedding_of_isWellOrder`: a type with a well order relation is infinite iff there is such a relation embedding.
- `RelEmbedding.finite_iff_empty_relEmbedding_of_isWellOrder`: a finite variant of `infinite_iff_nonempty_relEmbedding_of_isWellOrder`
- `IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap`: a type with a linear order relation well founded on both directions is finite.
- `instFiniteOfWellFoundedLTOfWellFoundedGT`: an instance variant of `IsWellOrder.finite_of_isWellOrder_of_isWellOrder_swap` on `WellFounded{LT,GT}`.
- `RelEmbedding.infinite_iff_nonempty_relEmbedding_lt_or_nonempty_relEmbedding_gt`: a type with a linear order relation is infinite iff there are both relation embedding between `<` in `Nat` and this relation, and between `>` in `Nat` and this relation.
- `RelEmbedding.finite_iff_isEmpty_relEmbedding_lt_and_isEmpty_relEmbedding_gt`: a finite variant of `infinite_iff_nonempty_relEmbedding_lt_or_nonempty_relEmbedding_gt`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

<details>

<summary> Edit: remove the description on the original motivation since `WellQuasiOrdered` instead of theorems in this PR can be used for that goal. </summary>

`RelEmbedding.finite_iff_empty_relEmbedding_of_isWellOrder` might be used for proof of
```lean
example {α β γ} [LinearOrder α] [LinearOrder β] [WellFoundedLT α] [WellFoundedLT β] [LinearOrder γ]
    {f : α × β ≃ γ} (mono : Monotone f) : WellFoundedLT γ := sorry
```
The latter will be used for
```lean
example {α β γ} [Finite α] [LinearOrder β] [WellFoundedLT β] [LinearOrder γ]
    {f : (α → β) ≃ γ} (mono : Monotone f) : WellFoundedLT γ := sorry
```
And the finial goal is the well-foundedness of monomial order when the index type `σ` is finite (under the definition in #39214).