### PR TITLE
[Merged by Bors] - feat(Valued/WithVal): missing rfl lemmas for field operations

### DIFF
--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -127,9 +127,9 @@ lemma toVal_bijective : Function.Bijective (toVal v) :=
 
 @[simp] lemma ofVal_intCast (z : ℤ) : ofVal (z : WithVal v) = z := rfl
 
-@[simp] lemma toVal_ofNat (n : ℕ) : toVal v ofNat(n) = ofNat(n) := rfl
+@[simp] lemma toVal_ofNat (n : ℕ) [n.AtLeastTwo] : toVal v ofNat(n) = ofNat(n) := rfl
 
-@[simp] lemma ofVal_ofNat (n : ℕ) : ofVal (ofNat(n) : WithVal v) = ofNat(n) := rfl
+@[simp] lemma ofVal_ofNat (n : ℕ) [n.AtLeastTwo] : ofVal (ofNat(n) : WithVal v) = ofNat(n) := rfl
 
 @[simp] lemma toVal_eq_zero (x : R) : toVal v x = 0 ↔ x = 0 := (toVal_injective v).eq_iff
 

--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -119,6 +119,18 @@ lemma toVal_bijective : Function.Bijective (toVal v) :=
 
 @[simp] lemma ofVal_pow (x : WithVal v) (n : ℕ) : ofVal (x ^ n) = (ofVal x) ^ n := rfl
 
+@[simp] lemma toVal_natCast (n : ℕ) : toVal v n = n := rfl
+
+@[simp] lemma ofVal_natCast (n : ℕ) : ofVal (n : WithVal v) = n := rfl
+
+@[simp] lemma toVal_intCast (z : ℤ) : toVal v z = z := rfl
+
+@[simp] lemma ofVal_intCast (z : ℤ) : ofVal (z : WithVal v) = z := rfl
+
+@[simp] lemma toVal_ofNat (n : ℕ) : toVal v ofNat(n) = ofNat(n) := rfl
+
+@[simp] lemma ofVal_ofNat (n : ℕ) : ofVal (ofNat(n) : WithVal v) = ofNat(n) := rfl
+
 @[simp] lemma toVal_eq_zero (x : R) : toVal v x = 0 ↔ x = 0 := (toVal_injective v).eq_iff
 
 @[simp] lemma ofVal_eq_zero (x : WithVal v) : ofVal x = 0 ↔ x = 0 := (ofVal_injective v).eq_iff
@@ -326,6 +338,18 @@ instance [NumberField R] : NumberField (WithVal v) where
 @[simp] lemma toVal_inv (x : R) : toVal v x⁻¹ = (toVal v x)⁻¹ := rfl
 
 @[simp] lemma ofVal_inv (x : WithVal v) : ofVal (x⁻¹) = (ofVal x)⁻¹ := rfl
+
+@[simp] lemma toVal_zpow (x : R) (z : ℤ) : toVal v (x ^ z) = (toVal v x) ^ z := rfl
+
+@[simp] lemma ofVal_zpow (x : WithVal v) (z : ℤ) : ofVal (x ^ z) = (ofVal x) ^ z := rfl
+
+@[simp] lemma toVal_nnratCast (q : ℚ≥0) : toVal v q = q := rfl
+
+@[simp] lemma ofVal_nnratCast (q : ℚ≥0) : ofVal (q : WithVal v) = q := rfl
+
+@[simp] lemma toVal_ratCast (q : ℚ) : toVal v q = q := rfl
+
+@[simp] lemma ofVal_ratCast (q : ℚ) : ofVal (q : WithVal v) = q := rfl
 
 end Field
 


### PR DESCRIPTION
This adds the missing lemmas for `(nat|int|nnrat|rat)Cast`, `zpow`, and `ofNat`.

These were found while attempting a refactor to use `Function.Injective.field` in #39562.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
