### PR TITLE
feat(Mathlib/Data/Finite/Option): option type is finite iff type is finite

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3820,6 +3820,7 @@ public import Mathlib.Data.FinEnum
 public import Mathlib.Data.FinEnum.Option
 public import Mathlib.Data.Finite.Card
 public import Mathlib.Data.Finite.Defs
+public import Mathlib.Data.Finite.Option
 public import Mathlib.Data.Finite.Perm
 public import Mathlib.Data.Finite.Prod
 public import Mathlib.Data.Finite.Set

--- a/Mathlib/Data/Finite/Option.lean
+++ b/Mathlib/Data/Finite/Option.lean
@@ -16,6 +16,3 @@ theorem Option.finite_iff {α : Type*} : Finite (Option α) ↔ Finite α where
   mp
   | @Finite.intro _ 0 e => (e none).elim0
   | @Finite.intro _ (n + 1) e => ⟨(e.trans (finSuccEquiv n)).removeNone⟩
-
-
-#min_imports

--- a/Mathlib/Data/Finite/Option.lean
+++ b/Mathlib/Data/Finite/Option.lean
@@ -5,7 +5,8 @@ Authors: Alex Brodbelt, Eric Wieser
 -/
 module
 
-public import Mathlib.Data.Fintype.Option
+public import Mathlib.Data.Finite.Defs
+import Mathlib.Data.Fintype.Option
 import Mathlib.Logic.Equiv.Fin.Basic
 
 /-!

--- a/Mathlib/Data/Finite/Option.lean
+++ b/Mathlib/Data/Finite/Option.lean
@@ -6,17 +6,18 @@ Authors: Alex Brodbelt, Eric Wieser
 module
 
 public import Mathlib.Data.Fintype.Option
-public import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Logic.Equiv.Fin.Basic
 
 /-!
 # Finiteness conditions for `Option` types
 -/
 
-@[expose] public section
-/-- The `Option` type on a type is finite if and only if the underlying type is finite -/
+public section
+
+/-- The `Option` type on a type is finite if and only if the underlying type is finite. -/
 @[simp]
 theorem Option.finite_iff {α : Type*} : Finite (Option α) ↔ Finite α where
-  mpr _ := instFiniteOption
+  mpr _ := inferInstance
   mp
   | @Finite.intro _ 0 e => (e none).elim0
   | @Finite.intro _ (n + 1) e => ⟨(e.trans (finSuccEquiv n)).removeNone⟩

--- a/Mathlib/Data/Finite/Option.lean
+++ b/Mathlib/Data/Finite/Option.lean
@@ -1,15 +1,19 @@
 /-
 Copyright (c) 2026 Alex Brodbelt. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alex Brodbelt and Eric Wieser
+Authors: Alex Brodbelt, Eric Wieser
 -/
 module
 
 public import Mathlib.Data.Fintype.Option
 public import Mathlib.Logic.Equiv.Fin.Basic
 
-@[expose] public section
+/-!
+# Finiteness conditions for `Option` types
+-/
 
+@[expose] public section
+/-- The `Option` type on a type is finite if and only if the underlying type is finite -/
 @[simp]
 theorem Option.finite_iff {α : Type*} : Finite (Option α) ↔ Finite α where
   mpr _ := instFiniteOption

--- a/Mathlib/Data/Finite/Option.lean
+++ b/Mathlib/Data/Finite/Option.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Alex Brodbelt. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Brodbelt and Eric Wieser
+-/
 module
 
 public import Mathlib.Data.Fintype.Option

--- a/Mathlib/Data/Finite/Option.lean
+++ b/Mathlib/Data/Finite/Option.lean
@@ -1,0 +1,16 @@
+module
+
+public import Mathlib.Data.Fintype.Option
+public import Mathlib.Logic.Equiv.Fin.Basic
+
+@[expose] public section
+
+@[simp]
+theorem Option.finite_iff {α : Type*} : Finite (Option α) ↔ Finite α where
+  mpr _ := instFiniteOption
+  mp
+  | @Finite.intro _ 0 e => (e none).elim0
+  | @Finite.intro _ (n + 1) e => ⟨(e.trans (finSuccEquiv n)).removeNone⟩
+
+
+#min_imports


### PR DESCRIPTION
Option type is finite if and only if the type is finite.

This is an intermediate result to proving that if the `GroupWithZero` is (in)finite then the `Units` are (in)finite.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
