### PR TITLE
feat: GraphLike typeclass

### DIFF
--- a/Mathlib/Combinatorics/GraphLike/Basic.lean
+++ b/Mathlib/Combinatorics/GraphLike/Basic.lean
@@ -228,11 +228,11 @@ end HyperGraphLike
 
 open HyperGraphLike
 
-class GraphLike (V I O E : outParam Type*) (Gr : Type*) extends
-    HyperGraphLike V I O E Gr where
-  exists_isLink_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃ x y, IsLink G e x y
-  eq_or_eq_of_isLink_of_isLink : ∀ ⦃G e x y x' y'⦄, IsLink (Gr := Gr) G e x y → IsLink G e x' y' →
-    x = x' ∧ y = y' ∨ x = y' ∧ y = x'
+-- class UndirGraphLike (V I O E : outParam Type*) (Gr : Type*) extends
+--     HyperGraphLike V I O E Gr where
+--   exists_isLink_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃ x y, IsLink G e x y
+--   eq_or_eq_of_isLink_of_isLink : ∀ ⦃G e x y x' y'⦄, IsLink (Gr := Gr) G e x y → IsLink G e x' y' →
+--     x = x' ∧ y = y' ∨ x = y' ∧ y = x'
 
 class DigraphLike (V I O E : outParam Type*) (Gr : Type*) extends
     HyperGraphLike V I O E Gr where
@@ -320,28 +320,28 @@ def ofSourceTarget (verts : Gr → Set V) (edges : Gr → Set E) (src : Gr → E
 
 variable [DigraphLike V I O E Gr] {G : Gr}
 
-instance instGraphLike : GraphLike V I O E Gr where
-  exists_isLink_of_mem_edges G e he := by
-    obtain ⟨i, ⟨hi, heq⟩, _⟩ := exists_unique_mem_edgeIn_of_mem_edges he
-    obtain ⟨o, ⟨ho, heq'⟩, _⟩ := exists_unique_mem_edgeOut_of_mem_edges he
-    use (source G i).get hi, (target G o).get ho
-    refine ⟨⟨i, hi, ?_⟩, o, ho, ?_⟩
-      <;> grind [input_eq_source_edgeIn, output_eq_target_edgeOut]
-  eq_or_eq_of_isLink_of_isLink G e x y x' y' h h' := by
-    left
-    simp only [IsLink, IsEdgeSource, IsEdgeTarget] at h h'
-    obtain ⟨_, he⟩ := ran_input_subset h.1
-    obtain ⟨⟨i, hi, hxeq⟩, o, ho, hyeq⟩ := h
-    obtain ⟨⟨i', hi', hxeq'⟩, o', ho', hyeq'⟩ := h'
-    rw [←input_eq_source_edgeIn] at hxeq hxeq'
-    rw [←output_eq_target_edgeOut] at hyeq hyeq'
-    suffices i = i' ∧ o = o' by grind
-    refine ⟨ExistsUnique.unique (exists_unique_mem_edgeIn_of_mem_edges he) ?_ ?_,
-      ExistsUnique.unique (exists_unique_mem_edgeOut_of_mem_edges he) ?_ ?_⟩
-    all_goals
-      rw [Part.mem_eq]
-      use (by assumption)
-      grind
+-- instance instGraphLike : GraphLike V I O E Gr where
+--   exists_isLink_of_mem_edges G e he := by
+--     obtain ⟨i, ⟨hi, heq⟩, _⟩ := exists_unique_mem_edgeIn_of_mem_edges he
+--     obtain ⟨o, ⟨ho, heq'⟩, _⟩ := exists_unique_mem_edgeOut_of_mem_edges he
+--     use (source G i).get hi, (target G o).get ho
+--     refine ⟨⟨i, hi, ?_⟩, o, ho, ?_⟩
+--       <;> grind [input_eq_source_edgeIn, output_eq_target_edgeOut]
+--   eq_or_eq_of_isLink_of_isLink G e x y x' y' h h' := by
+--     left
+--     simp only [IsLink, IsEdgeSource, IsEdgeTarget] at h h'
+--     obtain ⟨_, he⟩ := ran_input_subset h.1
+--     obtain ⟨⟨i, hi, hxeq⟩, o, ho, hyeq⟩ := h
+--     obtain ⟨⟨i', hi', hxeq'⟩, o', ho', hyeq'⟩ := h'
+--     rw [←input_eq_source_edgeIn] at hxeq hxeq'
+--     rw [←output_eq_target_edgeOut] at hyeq hyeq'
+--     suffices i = i' ∧ o = o' by grind
+--     refine ⟨ExistsUnique.unique (exists_unique_mem_edgeIn_of_mem_edges he) ?_ ?_,
+--       ExistsUnique.unique (exists_unique_mem_edgeOut_of_mem_edges he) ?_ ?_⟩
+--     all_goals
+--       rw [Part.mem_eq]
+--       use (by assumption)
+--       grind
 
 noncomputable def edgeInFlag {G : Gr} {e : E} (he : e ∈ edges G) : I :=
   Classical.choose (exists_unique_mem_edgeIn_of_mem_edges he)
@@ -357,18 +357,22 @@ lemma mem_edgeOut_iff (e : E) (o : O) : e ∈ edgeOut G o ↔ ∃ h : e ∈ edge
   simp_rw [edgeOutFlag, ExistsUnique.choose_eq_iff]
   exact ⟨fun h => ⟨mem_edges_of_mem_edgeOut h, h⟩, fun ⟨_, h⟩ => h⟩
 
-end DigraphLike
-
-open GraphLike DigraphLike
-
-class SimpleGraphLike (V I O E : outParam Type*) (Gr : Type*) extends GraphLike V I O E Gr where
+protected class Simple (V I O E : outParam Type*) (Gr : Type*) [DigraphLike V I O E Gr] where
   eq_of_isLink_of_isLink : ∀ ⦃G e e' x y⦄, IsLink (Gr := Gr) G e x y → IsLink G e' x y → e = e'
 
-class IrreflHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends
+end DigraphLike
+
+open DigraphLike
+
+-- class SimpleGraphLike (V I O E : outParam Type*) (Gr : Type*) extends
+--     HyperGraphLike V I O E Gr where
+--   eq_of_isLink_of_isLink : ∀ ⦃G e e' x y⦄, IsLink (Gr := Gr) G e x y → IsLink G e' x y → e = e'
+
+class IrreflHyperGraphLike (V I O E : outParam Type*) (Gr : Type*) extends
     HyperGraphLike V I O E Gr where
   not_isSource_isTarget : ∀ ⦃G e x⦄, ¬ (IsEdgeSource (Gr := Gr) G e x ∧ IsEdgeTarget G e x)
 
-class SymmHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends
+class SymmHyperGraphLike (V I O E : outParam Type*) (Gr : Type*) extends
     HyperGraphLike V I O E Gr where
   swapIO : Gr → I →. O
   swapOI : Gr → O →. I
@@ -385,14 +389,13 @@ instance : DigraphLike V (V × V × V) (V × V × V) (V × V) (Digraph V) :=
   (src := fun _ => Prod.fst) (tgt := fun _ => Prod.snd)
   (mem_verts_src := fun _ _ _ => trivial) (mem_verts_tgt := fun _ _ _ => trivial)
 
-instance : SimpleGraphLike V (V × V × V) (V × V × V) (V × V) (Digraph V) where
-  eq_of_isLink_of_isLink G := by
-    intro ⟨x, y⟩ ⟨x', y'⟩ x'' y'' h h'
+instance : DigraphLike.Simple V (V × V × V) (V × V × V) (V × V) (Digraph V) where
+  eq_of_isLink_of_isLink G e e' x y h h' := by
     simp [IsLink, IsEdgeSource, input, IsEdgeTarget, output, PFun.ran] at h h'
     grind
 
 -- this is not quite right, bc `G.IsLink e x y` gives you `IsLink G e x x`
-instance : GraphLike V (V × E) (V × E) E (Graph V E) where
+instance : HyperGraphLike V (V × E) (V × E) E (Graph V E) where
   verts := Graph.vertexSet
   edges := Graph.edgeSet
   input G d := ⟨∃ y, G.IsLink d.2 d.1 y, fun _ => d⟩
@@ -411,19 +414,19 @@ instance : GraphLike V (V × E) (V × E) E (Graph V E) where
   eq_of_mem_output_of_mem_output G := by
     intro ⟨x, e⟩ ⟨x', e'⟩ z f ⟨⟨y, hlink⟩, heq⟩ ⟨⟨y', hlink'⟩, heq'⟩
     simp_all
-  exists_isLink_of_mem_edges G e he := by
-    obtain ⟨x, y, hlink⟩ := G.edge_mem_iff_exists_isLink e |>.mp he
-    refine ⟨x, y, ?_, ?_⟩
-    · use ⟨x, e⟩, ⟨y, hlink⟩
-      rfl
-    · use ⟨y, e⟩, ⟨x, hlink⟩
-      rfl
-  eq_or_eq_of_isLink_of_isLink G e x y x' y' h h' := by
-    obtain ⟨⟨i, ⟨a, halink⟩, hi⟩, o, ⟨b, hblink⟩, ho⟩ := h
-    obtain ⟨⟨i', ⟨a', halink'⟩, hi'⟩, o', ⟨b', hblink'⟩, ho'⟩ := h'
-    subst_vars
-    simp_all only
-    sorry
+  -- exists_isLink_of_mem_edges G e he := by
+  --   obtain ⟨x, y, hlink⟩ := G.edge_mem_iff_exists_isLink e |>.mp he
+  --   refine ⟨x, y, ?_, ?_⟩
+  --   · use ⟨x, e⟩, ⟨y, hlink⟩
+  --     rfl
+  --   · use ⟨y, e⟩, ⟨x, hlink⟩
+  --     rfl
+  -- eq_or_eq_of_isLink_of_isLink G e x y x' y' h h' := by
+  --   obtain ⟨⟨i, ⟨a, halink⟩, hi⟩, o, ⟨b, hblink⟩, ho⟩ := h
+  --   obtain ⟨⟨i', ⟨a', halink'⟩, hi'⟩, o', ⟨b', hblink'⟩, ho'⟩ := h'
+  --   subst_vars
+  --   simp_all only
+  --   sorry
     -- obtain (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩) := halink.eq_and_eq_or_eq_and_eq halink'
     -- · obtain (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩) := hblink.eq_and_eq_or_eq_and_eq hblink'
     --   · left; exact ⟨rfl, rfl⟩
@@ -455,38 +458,86 @@ instance : GraphLike V (V × E) (V × E) E (Graph V E) where
     --   <;> simp_all only
 
 
--- -- instance : SymmHyperGraphLike V (E × V × V) (Graph V E) where
--- --   inv G := fun ⟨e, x, y⟩ => ⟨e, y, x⟩
--- --   inv_inv_eq G := by simp
--- --   isSource_iff_isTarget_inv G := by
--- --     rintro ⟨e, x, y⟩ x'
--- --     simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
--- --       and_congr_right_iff]
--- --     rintro rfl
--- --     exact G.isLink_comm
+instance : SymmHyperGraphLike V (V × E) (V × E) E (Graph V E) where
+  swapIO G d := ⟨(input G d).Dom, fun _ => d⟩
+  swapOI G d := ⟨(output G d).Dom, fun _ => d⟩
+  dom_swapIO_eq G := rfl
+  dom_swapOI_eq G := rfl
+  inFlag_mem_comp G := by
+    intro ⟨x, e⟩ ⟨y, hlink⟩
+    simp only [PFun.comp_apply, Part.mem_bind_iff, Part.mem_mk_iff, exists_prop,
+      exists_eq_right_right, and_true]
+    exact ⟨⟨y, hlink⟩, ⟨y, hlink.symm⟩⟩
+  outFlag_mem_comp G := by
+    intro ⟨x, e⟩ ⟨y, hlink⟩
+    simp only [PFun.comp_apply, Part.mem_bind_iff, Part.mem_mk_iff, exists_prop,
+      exists_eq_right_right, and_true]
+    exact ⟨⟨y, hlink⟩, ⟨y, hlink.symm⟩⟩
+  edgeIn_eq_edgeOut_swapIO G := by
+    ext ⟨x, e⟩ e'
+    simp only [edgeIn, input, Part.mem_mk_iff, Function.comp_apply, exists_prop, PFun.comp_apply,
+      Part.mem_bind_iff, edgeOut, output, Prod.exists, mk.injEq, exists_eq_right_right,
+      ↓existsAndEq, true_and, iff_self_and, and_imp, forall_exists_index]
+    rintro y h rfl
+    use y, h.symm
+  edgeOut_eq_edgeIn_swapOI G := by
+    ext ⟨x, e⟩ e'
+    simp only [edgeOut, output, Part.mem_mk_iff, Function.comp_apply, exists_prop, PFun.comp_apply,
+      Part.mem_bind_iff, edgeIn, input, Prod.exists, mk.injEq, exists_eq_right_right, ↓existsAndEq,
+      true_and, iff_self_and, and_imp, forall_exists_index]
+    intro y h rfl
+    use y, h.symm
 
--- -- instance : GraphLike V (V × V) (SimpleGraph V) := by
--- --   refine ofIsLink (fun G => Set.univ) (fun G => {p | G.Adj p.1 p.2})
--- --     (fun G e x y => e.1 = x ∧ e.2 = y ∧ G.Adj x y) ?_ ?_ ?_ ?uniq
--- --   case uniq =>
--- --     rintro G ⟨x, y⟩ _ _ _ _ ⟨rfl, rfl, h⟩ ⟨rfl, rfl, h'⟩
--- --     exact ⟨rfl, rfl⟩
--- --   all_goals simp
+instance : HyperGraphLike V (V × V) (V × V) (Sym2 V) (SimpleGraph V) where
+  verts _ := Set.univ
+  edges G := G.edgeSet
+  input G d := ⟨G.Adj d.1 d.2, fun _ => (d.1, .mk d.1 d.2)⟩
+  output G d := ⟨G.Adj d.1 d.2, fun _ => (d.1, .mk d.1 d.2)⟩
+  ran_input_subset G := by
+    intro ⟨x, e⟩ ⟨⟨a, b⟩, hdom, h⟩
+    simp_all only [mk.injEq, mem_prod, mem_univ, true_and]
+    rw [←h.2, G.mem_edgeSet]
+    exact hdom
+  ran_output_subset G := by
+    intro ⟨x, e⟩ ⟨⟨a, b⟩, hdom, h⟩
+    simp_all only [mk.injEq, mem_prod, mem_univ, true_and]
+    rw [←h.2, G.mem_edgeSet]
+    exact hdom
+  eq_of_mem_input_of_mem_input G := by
+    intro ⟨x, y⟩ ⟨x', y'⟩ z e ⟨hdom, h⟩ ⟨hdom', h'⟩
+    simp_all
+    grind
+  eq_of_mem_output_of_mem_output G := by
+    intro ⟨x, y⟩ ⟨x', y'⟩ z e ⟨hdom, h⟩ ⟨hdom', h'⟩
+    simp_all
+    grind
 
--- -- instance : SymmHyperGraphLike V (V × V) (SimpleGraph V) where
--- --   inv G := fun ⟨x, y⟩ => ⟨y, x⟩
--- --   inv_inv_eq G := by simp
--- --   isSource_iff_isTarget_inv G := by
--- --     intro ⟨x, y⟩ _
--- --     simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
--- --       and_congr_right_iff]
--- --     rintro rfl
--- --     exact G.adj_comm ..
+instance : SymmHyperGraphLike V (V × V) (V × V) (Sym2 V) (SimpleGraph V) where
+  swapIO G d := ⟨G.Adj d.1 d.2, fun _ => d.swap⟩
+  swapOI G d := ⟨G.Adj d.1 d.2, fun _ => d.swap⟩
+  dom_swapIO_eq G := rfl
+  dom_swapOI_eq G := rfl
+  inFlag_mem_comp G := by
+    intro ⟨x, y⟩ (h : G.Adj x y)
+    simp [h, h.symm]
+  outFlag_mem_comp G := by
+    intro ⟨x, y⟩ (h : G.Adj x y)
+    simp [h, h.symm]
+  edgeIn_eq_edgeOut_swapIO G := by
+    ext ⟨x, y⟩ e
+    simp [edgeIn, input, edgeOut, output]
+    grind [G.adj_comm]
+  edgeOut_eq_edgeIn_swapOI G := by
+    ext ⟨x, y⟩ e
+    simp [edgeIn, input, edgeOut, output]
+    grind [G.adj_comm]
 
--- -- instance : IrreflHyperGraphLike V (V × V) (SimpleGraph V) where
--- --   not_isSource_isTarget G := by
--- --     intro ⟨x, y⟩ _
--- --     simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
--- --       not_and, and_imp]
--- --     rintro rfl h rfl
--- --     exact G.irrefl
+-- instance : IrreflHyperGraphLike V (V × V) (V × V) (Sym2 V) (SimpleGraph V) where
+--   not_isSource_isTarget G := by
+--     intro e x
+--     simp [IsEdgeSource, input]
+
+    -- simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
+    --   not_and, and_imp]
+    -- rintro rfl h rfl
+    -- exact G.irrefl

--- a/Mathlib/Combinatorics/GraphLike/Basic.lean
+++ b/Mathlib/Combinatorics/GraphLike/Basic.lean
@@ -16,209 +16,93 @@ public section
 
 open Prod Set
 
-variable {V H I O E Gr : Type*}
+variable {V E Gr : Type*} {G : Gr} {e : E} {x y : V}
 
-class HyperGraphLike (V I O E : outParam Type*) (Gr : Type*) where
+class HyperGraphLike (V E : outParam Type*) (Gr : Type*) where
   verts : Gr → Set V
   edges : Gr → Set E
-  input : Gr → I →. V × E
-  output : Gr → O →. V × E
-  ran_input_subset : ∀ ⦃G⦄, (input G).ran ⊆ verts G ×ˢ edges G
-  ran_output_subset : ∀ ⦃G⦄, (output G).ran ⊆ verts G ×ˢ edges G
-  eq_of_mem_input_of_mem_input : ∀ ⦃G i i' x e⦄,
-      (x, e) ∈ input G i → (x, e) ∈ input G i' → i = i'
-  eq_of_mem_output_of_mem_output : ∀ ⦃G o o' x e⦄,
-      (x, e) ∈ output G o → (x, e) ∈ output G o' → o = o'
+  IsSource : Gr → E → V → Prop
+  IsTarget : Gr → E → V → Prop
+  IsLink : Gr → E → V → V → Prop
+  mem_edges_of_isSource : ∀ ⦃G e x⦄, IsSource G e x → e ∈ edges G
+  mem_edges_of_isTarget : ∀ ⦃G e x⦄, IsTarget G e x → e ∈ edges G
+  mem_verts_of_isSource : ∀ ⦃G e x⦄, IsSource G e x → x ∈ verts G
+  mem_verts_of_isTarget : ∀ ⦃G e x⦄, IsTarget G e x → x ∈ verts G
+  isSource_left_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → IsSource G e x
+  isTarget_right_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → IsTarget G e y
 
 namespace HyperGraphLike
 
-variable [HyperGraphLike V I O E Gr] {G : Gr}
-
-@[expose]
-def inFlags (G : Gr) : Set I := (input G).Dom
-
-@[expose]
-def outFlags (G : Gr) : Set O := (output G).Dom
-
-@[expose]
-def source (G : Gr) : I →. V := fun i => ⟨(input G i).Dom, fst ∘ (input G i).get⟩
-
-@[expose]
-def target (G : Gr) : O →. V := fun i => ⟨(output G i).Dom, fst ∘ (output G i).get⟩
-
-@[expose]
-def edgeIn (G : Gr) : I →. E := fun i => ⟨(input G i).Dom, snd ∘ (input G i).get⟩
-
-@[expose]
-def edgeOut (G : Gr) : O →. E := fun i => ⟨(output G i).Dom, snd ∘ (output G i).get⟩
-
-lemma input_eq_source_edgeIn {G : Gr} {i : I} (hi : i ∈ inFlags G) :
-    ⟨source G i |>.get hi, edgeIn G i |>.get hi⟩ = (input G i).get hi := by
-  simp [source, edgeIn]
-
-lemma output_eq_target_edgeOut {G : Gr} {o : O} (ho : o ∈ outFlags G) :
-    ⟨target G o |>.get ho, edgeOut G o |>.get ho⟩ = (output G o).get ho := by
-  simp [target, edgeOut]
-
-lemma mem_verts_of_mem_source {v : V} {i : I} (h : v ∈ source G i) : v ∈ verts G := by
-  obtain ⟨hi, h⟩ := h
-  simp only [source, Function.comp_apply] at h
-  exact h ▸ (ran_input_subset ⟨i, hi, rfl⟩).1
-
-lemma mem_verts_of_mem_target {v : V} {o : O} (h : v ∈ target G o) : v ∈ verts G := by
-  obtain ⟨ho, h⟩ := h
-  simp only [target, Function.comp_apply] at h
-  exact h ▸ (ran_output_subset ⟨o, ho, rfl⟩).1
-
-lemma mem_edges_of_mem_edgeIn {e : E} {i : I} (h : e ∈ edgeIn G i) : e ∈ edges G := by
-  obtain ⟨hi, h⟩ := h
-  simp only [edgeIn, Function.comp_apply] at h
-  exact h ▸ (ran_input_subset ⟨i, hi, rfl⟩).2
-
-lemma mem_edges_of_mem_edgeOut {e : E} {o : O} (h : e ∈ edgeOut G o) : e ∈ edges G := by
-  obtain ⟨ho, h⟩ := h
-  simp only [edgeOut, Function.comp_apply] at h
-  exact h ▸ (ran_output_subset ⟨o, ho, rfl⟩).2
-
-def IsEdgeSource (G : Gr) (e : E) (v : V) : Prop := ⟨v, e⟩ ∈ (input G).ran
-
-def IsEdgeTarget (G : Gr) (e : E) (v : V) : Prop := ⟨v, e⟩ ∈ (output G).ran
-
-def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsEdgeSource G e x ∧ IsEdgeTarget G e y
+variable [instHGL : HyperGraphLike V E Gr]
 
 @[implicit_reducible]
 def ofIsSourceIsTarget (verts : Gr → Set V) (edges : Gr → Set E)
-    (IsEdgeSource : Gr → E → V → Prop) (IsEdgeTarget : Gr → E → V → Prop)
-    (mem_verts_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → v ∈ verts G)
-    (mem_edges_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → e ∈ edges G)
-    (mem_verts_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → v ∈ verts G)
-    (mem_edges_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → e ∈ edges G)
-    : HyperGraphLike V (V × E) (V × E) E Gr where
+    (IsSource : Gr → E → V → Prop) (IsTarget : Gr → E → V → Prop)
+    (mem_edges_of_isSource : ∀ ⦃G e v⦄, IsSource G e v → e ∈ edges G)
+    (mem_edges_of_isTarget : ∀ ⦃G e v⦄, IsTarget G e v → e ∈ edges G)
+    (mem_verts_of_isSource : ∀ ⦃G e v⦄, IsSource G e v → v ∈ verts G)
+    (mem_verts_of_isTarget : ∀ ⦃G e v⦄, IsTarget G e v → v ∈ verts G)
+    : HyperGraphLike V E Gr where
   verts := verts
   edges := edges
-  input G d := ⟨IsEdgeSource G d.2 d.1, fun _ => d⟩
-  output G d := ⟨IsEdgeTarget G d.2 d.1, fun _ => d⟩
-  ran_input_subset _ := by
-    rintro ⟨v, e⟩ ⟨⟨v', e'⟩, hdom, rfl, _⟩
-    exact ⟨mem_verts_of_isEdgeSource hdom, mem_edges_of_isEdgeSource hdom⟩
-  ran_output_subset _ := by
-    rintro ⟨v, e⟩ ⟨⟨v', e'⟩, hdom, rfl, _⟩
-    exact ⟨mem_verts_of_isEdgeTarget hdom, mem_edges_of_isEdgeTarget hdom⟩
-  eq_of_mem_input_of_mem_input := by simp_all
-  eq_of_mem_output_of_mem_output := by simp_all
+  IsSource := IsSource
+  IsTarget := IsTarget
+  IsLink G e x y := IsSource G e x ∧ IsTarget G e y
+  mem_edges_of_isSource := mem_edges_of_isSource
+  mem_edges_of_isTarget := mem_edges_of_isTarget
+  mem_verts_of_isSource := mem_verts_of_isSource
+  mem_verts_of_isTarget := mem_verts_of_isTarget
+  isSource_left_of_isLink _ _ _ _ h := h.1
+  isTarget_right_of_isLink _ _ _ _ h := h.2
 
-def Adj (G : Gr) (x y : V) : Prop := ∃ e, IsEdgeSource G e x ∧ IsEdgeTarget G e y
+lemma IsSource.mem_verts (h : IsSource G e x) : x ∈ verts G := mem_verts_of_isSource h
 
-def FlagInc (G : Gr) (i : I) (o : O) : Prop := ∃ e, e ∈ edgeIn G i ∧ e ∈ edgeOut G o
+lemma IsTarget.mem_verts (h : IsTarget G e x) : x ∈ verts G := mem_verts_of_isTarget h
 
-lemma Adj.iff_exists_inFlags_outFlags {G : Gr} {x y : V} :
-    Adj G x y ↔ ∃ i o, FlagInc G i o ∧ x ∈ source G i ∧ y ∈ target G o := by
-  simp_rw [Adj, IsEdgeSource, IsEdgeTarget, FlagInc]
-  constructor
-  -- · intro ⟨e, o, ⟨i, hin, hxe⟩, ⟨o, hout, hye⟩⟩
-  · intro ⟨e, ⟨i, hin, he⟩, ⟨o, hout, ho⟩⟩
-    simp only [edgeIn, Part.mem_mk_iff, Function.comp_apply, edgeOut, exists_exists_eq_and, source,
-      target]
-    use! i, o, hin, hout, (by grind), hin, (by grind), (by grind)
-  · rintro ⟨i, o, ⟨e, ⟨hin, rfl⟩, ⟨hout, heout⟩⟩, ⟨hin', rfl⟩, ⟨hout', rfl⟩⟩
-    use (edgeIn G i).get hin
-    constructor
-    · use i, hin
-      exact input_eq_source_edgeIn hin
-    · use o, hout
-      rw [←heout]
-      exact (output_eq_target_edgeOut hout).symm
+lemma IsSource.mem_edges (h : IsSource G e x) : e ∈ edges G := mem_edges_of_isSource h
 
-lemma FlagInc.mem_inFlags_left {i : I} {o : O} (h : FlagInc G i o) : i ∈ inFlags G := by
-  obtain ⟨e, ⟨h, _⟩, _⟩ := h
-  exact h
+lemma IsTarget.mem_edges (h : IsTarget G e x) : e ∈ edges G := mem_edges_of_isTarget h
 
-lemma FlagInc.mem_outFlags_right {i : I} {o : O} (h : FlagInc G i o) : o ∈ outFlags G := by
-  obtain ⟨e, _, h, _⟩ := h
-  exact h
+lemma IsLink.isSource_left (h : IsLink G e x y) : IsSource G e x := isSource_left_of_isLink h
 
-lemma FlagInc.mem_edgeIn_iff_mem_edgeOut {i : I} {o : O} (h : FlagInc G i o) (e : E) :
-    e ∈ edgeIn G i ↔ e ∈ edgeOut G o := by
-  obtain ⟨e', hei, heo⟩ := h
-  refine ⟨fun he => ?_, fun he => ?_⟩
-  · rwa [Part.mem_unique he hei]
-  · rwa [Part.mem_unique he heo]
+lemma IsLink.isTarget_right (h : IsLink G e x y) : IsTarget G e y := isTarget_right_of_isLink h
 
-lemma FlagInc.edgeIn_eq_edgeOut {i : I} {o : O} (h : FlagInc G i o) : edgeIn G i = edgeOut G o :=
-    Part.ext h.mem_edgeIn_iff_mem_edgeOut
+lemma IsLink.mem_verts_left (h : IsLink G e x y) : x ∈ verts G := h.isSource_left.mem_verts
+
+lemma IsLink.mem_verts_right (h : IsLink G e x y) : y ∈ verts G := h.isTarget_right.mem_verts
+
+lemma IsLink.mem_edges (h : IsLink G e x y) : e ∈ edges G := h.isSource_left.mem_edges
+
+def Adj (G : Gr) (x y : V) : Prop := ∃ e, IsLink G e x y
+
+lemma Adj.mem_verts_left (h : Adj G x y) : x ∈ verts G :=
+  have ⟨_, h⟩ := h
+  h.mem_verts_left
+
+lemma Adj.mem_verts_right (h : Adj G x y) : y ∈ verts G :=
+  have ⟨_, h⟩ := h
+  h.mem_verts_right
 
 structure Dart (G : Gr) where
-  i : I
-  o : O
-  inc : FlagInc G i o
+  src : V
+  tgt : V
+  edge : E
+  h : IsLink G edge src tgt
 
 namespace Dart
 
 @[ext]
-protected lemma ext {d d' : Dart G} (hi : d.i = d'.i) (ho : d.o = d'.o) : d = d' := by
+protected lemma ext {d d' : Dart G} (hs : d.src = d'.src) (ht : d.tgt = d'.tgt)
+    (he : d.edge = d'.edge) : d = d' := by
   cases d; cases d'; congr
 
-lemma mem_inFlags (d : Dart G) : d.i ∈ inFlags G := d.inc.mem_inFlags_left
+lemma src_mem (d : Dart G) : d.src ∈ verts G := d.h.mem_verts_left
 
-lemma mem_outFlags (d : Dart G) : d.o ∈ outFlags G := d.inc.mem_outFlags_right
+lemma tgt_mem (d : Dart G) : d.tgt ∈ verts G := d.h.mem_verts_right
 
-def src (d : Dart G) : V := (source G d.i).get d.mem_inFlags
+lemma edge_mem (d : Dart G) : d.edge ∈ edges G := d.h.mem_edges
 
-lemma src_mem (d : Dart G) : d.src ∈ verts G :=
-  mem_verts_of_mem_source (Part.get_mem _)
-
--- def isSource (d : Dart G) : IsSource G d.edge d.source := d.isLink.1
-
-def tgt (d : Dart G) : V := (target G d.o).get d.mem_outFlags
-
-lemma tgt_mem (d : Dart G) : d.tgt ∈ verts G :=
-  mem_verts_of_mem_target (Part.get_mem _)
-
--- def isTarget (d : Dart G) : IsTarget G d.edge d.target := d.isLink.2
-
-def edge (d : Dart G) : E := (edgeIn G d.i).get d.mem_inFlags
-
-lemma edge_mem_edgeIn (d : Dart G) : d.edge ∈ edgeIn G d.i := Part.get_mem _
-
-lemma edge_mem_edgeOut (d : Dart G) : d.edge ∈ edgeOut G d.o :=
-  d.inc.mem_edgeIn_iff_mem_edgeOut _ |>.mp d.edge_mem_edgeIn
-
-lemma isEdgeSource (d : Dart G) : IsEdgeSource G d.edge d.src := by
-  refine ⟨d.i, d.mem_inFlags, ?_⟩
-  simp [src, edge, input_eq_source_edgeIn]
-
-lemma isEdgeTarget (d : Dart G) : IsEdgeTarget G d.edge d.tgt := by
-  refine ⟨d.o, d.mem_outFlags, ?_⟩
-  simp only [← output_eq_target_edgeOut, tgt, edge, d.inc.edgeIn_eq_edgeOut]
-
-noncomputable def ofEdge {e : E} {x y : V} (hsrc : IsEdgeSource G e x) (htgt : IsEdgeTarget G e y) :
-    Dart G where
-  i := Classical.choose hsrc
-  o := Classical.choose htgt
-  inc := by
-    have ⟨hin, hget⟩ := Classical.choose_spec hsrc
-    have ⟨hout, hget'⟩ := Classical.choose_spec htgt
-    refine ⟨e, ⟨hin, ?_⟩, ⟨hout, ?_⟩⟩
-    · simp [edgeIn, hget]
-    · simp [edgeOut, hget']
-
-lemma ext_edge {d d' : Dart G} (hsrc : d.src = d'.src) (htgt : d.tgt = d'.tgt)
-    (hedge : d.edge = d'.edge) : d = d' := by
-  ext
-  · apply eq_of_mem_input_of_mem_input (G := G) (x := d.src) (e := d.edge)
-    all_goals simp_rw [Part.mem_eq, ←input_eq_source_edgeIn]
-    · use d.mem_inFlags
-      simpa using ⟨rfl, rfl⟩
-    · use d'.mem_inFlags
-      simpa [hsrc, hedge] using ⟨rfl, rfl⟩
-  · apply eq_of_mem_output_of_mem_output (G := G) (x := d.tgt) (e := d.edge)
-    all_goals simp_rw [Part.mem_eq, ←output_eq_target_edgeOut]
-    · use d.mem_outFlags
-      simpa [←d.inc.edgeIn_eq_edgeOut] using ⟨rfl, rfl⟩
-    · use d'.mem_outFlags
-      simpa [htgt, hedge, ←d'.inc.edgeIn_eq_edgeOut] using ⟨rfl, rfl⟩
-
-lemma adj (d : Dart G) : Adj G d.src d.tgt := ⟨d.edge, d.isEdgeSource, d.isEdgeTarget⟩
+lemma adj (d : Dart G) : Adj G d.src d.tgt := ⟨d.edge, d.h⟩
 
 def AdjDart (d d' : Dart G) : Prop := d.tgt = d'.src
 
@@ -228,316 +112,277 @@ end HyperGraphLike
 
 open HyperGraphLike
 
--- class UndirGraphLike (V I O E : outParam Type*) (Gr : Type*) extends
---     HyperGraphLike V I O E Gr where
---   exists_isLink_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃ x y, IsLink G e x y
---   eq_or_eq_of_isLink_of_isLink : ∀ ⦃G e x y x' y'⦄, IsLink (Gr := Gr) G e x y → IsLink G e x' y' →
---     x = x' ∧ y = y' ∨ x = y' ∧ y = x'
+class HyperGraphLike.Symm (V E : outParam Type*) (Gr : Type*) extends HyperGraphLike V E Gr where
+  isSource_iff_isTarget : ∀ ⦃G e x⦄, IsSource G e x ↔ IsTarget G e x
+  isLink_symm : ∀ ⦃G e⦄, Symmetric (IsLink G e)
 
-class DigraphLike (V I O E : outParam Type*) (Gr : Type*) extends
-    HyperGraphLike V I O E Gr where
-  exists_unique_mem_edgeIn_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! i : I, e ∈ edgeIn G i
-  exists_unique_mem_edgeOut_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! o : O, e ∈ edgeOut G o
+namespace HyperGraphLike.Symm
+
+variable [HyperGraphLike.Symm V E Gr]
+
+lemma adj_symm : Symmetric (Adj G) := by
+  intro x y ⟨e, h⟩
+  exact ⟨e, isLink_symm h⟩
+
+-- -- etc API lemmas as for `Graph`
+
+end HyperGraphLike.Symm
+
+class GraphLike (V E : outParam Type*) (Gr : Type*) extends HyperGraphLike V E Gr where
+  mem_edges_iff_exists_isLink : ∀ ⦃G e⦄, e ∈ edges G ↔ ∃ x y, IsLink G e x y
+  isSource_iff_exists_isLink : ∀ ⦃G e x⦄, IsSource G e x ↔ ∃ y, IsLink G e x y
+  isTarget_iff_exists_isLink : ∀ ⦃G e y⦄, IsTarget G e y ↔ ∃ x, IsLink G e x y
+  eq_and_eq_or_eq_and_eq_of_isLink_of_isLink : ∀ ⦃G : Gr⦄ ⦃e x y x' y'⦄,
+      IsLink G e x y → IsLink G e x' y' → x = x' ∧ y = y' ∨ x = y' ∧ y = x'
+
+namespace GraphLike
+
+@[implicit_reducible]
+def ofIsLink (verts : Gr → Set V) (IsLink : Gr → E → V → V → Prop)
+    (mem_verts_left_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → x ∈ verts G)
+    (mem_verts_right_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → y ∈ verts G)
+    (eq_and_eq_or_eq_and_eq_of_isLink_of_isLink : ∀ ⦃G e x y x' y'⦄,
+      IsLink G e x y → IsLink G e x' y' → x = x' ∧ y = y' ∨ x = y' ∧ y = x') :
+    GraphLike V E Gr where
+  verts := verts
+  edges G := {e | ∃ x y, IsLink G e x y}
+  IsSource G e x := ∃ y, IsLink G e x y
+  IsTarget G e y := ∃ x, IsLink G e x y
+  IsLink := IsLink
+  mem_edges_of_isSource _ _ x h := ⟨x, h⟩
+  mem_edges_of_isTarget _ _ y := fun ⟨x, h⟩ => ⟨x, y, h⟩
+  mem_verts_of_isSource _ _ _ := fun ⟨_, h⟩ => mem_verts_left_of_isLink h
+  mem_verts_of_isTarget _ _ _ := fun ⟨_, h⟩ => mem_verts_right_of_isLink h
+  mem_edges_iff_exists_isLink _ _ := Iff.rfl
+  isSource_iff_exists_isLink _ _ _ := Iff.rfl
+  isTarget_iff_exists_isLink _ _ _ := Iff.rfl
+  eq_and_eq_or_eq_and_eq_of_isLink_of_isLink := eq_and_eq_or_eq_and_eq_of_isLink_of_isLink
+  isSource_left_of_isLink _ _ _ y h := ⟨y, h⟩
+  isTarget_right_of_isLink _ _ x _ h := ⟨x, h⟩
+
+class Simple (V E : outParam Type*) (Gr : Type*) extends GraphLike V E Gr where
+  eq_of_isLink_of_isLink : ∀ ⦃G e e' x y⦄, IsLink G e x y → IsLink G e' x y → e = e'
+
+class Directed (V E : outParam Type*) (Gr : Type*) extends GraphLike V E Gr where
+  existsUnique_isLink_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! x, ∃! y, IsLink G e x y
+
+variable [GraphLike V E Gr]
+
+noncomputable def endpoints (he : e ∈ edges G) : Sym2 V :=
+  s(Classical.choose (mem_edges_iff_exists_isLink.mp he),
+    Classical.choose <| Classical.choose_spec (mem_edges_iff_exists_isLink.mp he))
+
+lemma eq_endpoints_of_isLink (h : IsLink G e x y) : s(x, y) = endpoints h.mem_edges := by
+  simpa [endpoints] using eq_and_eq_or_eq_and_eq_of_isLink_of_isLink (G := G) (e := e) h <|
+    Classical.choose_spec <| Classical.choose_spec (mem_edges_iff_exists_isLink.mp h.mem_edges)
+
+end GraphLike
+
+open GraphLike
+
+class DigraphLike (V E : outParam Type*) (Gr : Type*) extends
+    GraphLike V E Gr where
+  eq_of_isSource_of_isSource : ∀ ⦃G e x x'⦄, IsSource G e x → IsSource G e x' → x = x'
+  eq_of_isTarget_of_isTarget : ∀ ⦃G e y y'⦄, IsTarget G e y → IsTarget G e y' → y = y'
 
 namespace DigraphLike
 
 @[implicit_reducible]
-def ofIsLink (verts : Gr → Set V) (edges : Gr → Set E)
-    (IsLink : Gr → E → V → V → Prop)
-    (mem_edges_iff_exists_isLink : ∀ ⦃G e⦄, e ∈ edges G ↔ ∃ x y, IsLink G e x y)
-    (mem_verts_left_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → x ∈ verts G)
-    (mem_verts_right_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → y ∈ verts G)
-    (eq_and_eq_of_isLink_of_isLink : ∀ ⦃G e x x' y y'⦄,
-      IsLink G e x y → IsLink G e x' y' → x = x' ∧ y = y') :
-     DigraphLike V (V × E) (V × E) E Gr
-    where
+def ofSourceTarget (verts : Gr → Set V) (edges : Gr → Set E) (src : Gr → E → V)
+    (tgt : Gr → E → V) (mem_verts_src : ∀ ⦃G e⦄, e ∈ edges G → src G e ∈ verts G)
+    (mem_verts_tgt : ∀ ⦃G e⦄, e ∈ edges G → tgt G e ∈ verts G) : DigraphLike V E Gr where
   verts := verts
   edges := edges
-  input G d := ⟨∃ y, IsLink G d.2 d.1 y, fun _ => d⟩
-  output G d := ⟨∃ x, IsLink G d.2 x d.1, fun _ => d⟩
-  ran_input_subset G := by
-    intro ⟨x, e⟩ ⟨⟨x', e'⟩, ⟨y, hlink⟩, heq⟩
-    obtain ⟨rfl, rfl⟩ : x' = x ∧ e' = e := by simpa using heq
-    exact ⟨mem_verts_left_of_isLink hlink, mem_edges_iff_exists_isLink.mpr ⟨x', y, hlink⟩⟩
-  ran_output_subset G := by
-    intro ⟨y, e⟩ ⟨⟨y', e'⟩, ⟨x, hlink⟩, heq⟩
-    obtain ⟨rfl, rfl⟩ : y' = y ∧ e' = e := by simpa using heq
-    exact ⟨mem_verts_right_of_isLink hlink, mem_edges_iff_exists_isLink.mpr ⟨x, y', hlink⟩⟩
-  eq_of_mem_input_of_mem_input G := by simp; grind
-  eq_of_mem_output_of_mem_output G := by simp; grind
-  exists_unique_mem_edgeIn_of_mem_edges G e he := by
-    obtain ⟨x, y, hlink⟩ := mem_edges_iff_exists_isLink.mp he
-    use ⟨x, e⟩
-    simp [edgeIn]
-    grind
-  exists_unique_mem_edgeOut_of_mem_edges G e he := by
-    obtain ⟨x, y, hlink⟩ := mem_edges_iff_exists_isLink.mp he
-    use ⟨y, e⟩
-    simp [edgeOut]
-    grind
+  IsSource G e x := e ∈ edges G ∧ src G e = x
+  IsTarget G e y := e ∈ edges G ∧ tgt G e = y
+  IsLink G e x y := e ∈ edges G ∧ src G e = x ∧ tgt G e = y
+  mem_edges_of_isSource _ _ _ h := h.1
+  mem_edges_of_isTarget _ _ _ h := h.1
+  mem_verts_of_isSource _ _ _ := fun ⟨he, hx⟩ => hx ▸ mem_verts_src he
+  mem_verts_of_isTarget _ _ _ := fun ⟨he, hy⟩ => hy ▸ mem_verts_tgt he
+  isSource_left_of_isLink _ _ _ _ := fun ⟨he, hx, _⟩ => ⟨he, hx⟩
+  isTarget_right_of_isLink _ _ _ _ := fun ⟨he, _, hy⟩ => ⟨he, hy⟩
+  mem_edges_iff_exists_isLink G e :=
+      ⟨fun he => ⟨src G e, tgt G e, he, rfl, rfl⟩, fun ⟨_, _, he, _, _⟩ => he⟩
+  isSource_iff_exists_isLink G e _ :=
+      ⟨fun ⟨he, hx⟩ => ⟨tgt G e, he, hx, rfl⟩, fun ⟨_, he, hx, _⟩ => ⟨he, hx⟩⟩
+  isTarget_iff_exists_isLink G e _ :=
+      ⟨fun ⟨he, hy⟩ => ⟨src G e, he, rfl, hy⟩, fun ⟨_, he, _, hy⟩ => ⟨he, hy⟩⟩
+  eq_and_eq_or_eq_and_eq_of_isLink_of_isLink _ _ _ _ _ _ :=
+      fun ⟨_, hx, hy⟩ ⟨_, hx', hy'⟩ => Or.inl ⟨hx.symm.trans hx', hy.symm.trans hy'⟩
+  eq_of_isSource_of_isSource _ _ _ _ := fun ⟨_, hx⟩ ⟨_, hx'⟩ => hx.symm.trans hx'
+  eq_of_isTarget_of_isTarget _ _ _ _ := fun ⟨_, hy⟩ ⟨_, hy'⟩ => hy.symm.trans hy'
 
-@[implicit_reducible]
-def ofSourceTarget (verts : Gr → Set V) (edges : Gr → Set E) (src : Gr → E → V) (tgt : Gr → E → V)
-    (mem_verts_src : ∀ ⦃G e⦄, e ∈ edges G → src G e ∈ verts G)
-    (mem_verts_tgt : ∀ ⦃G e⦄, e ∈ edges G → tgt G e ∈ verts G) :
-    DigraphLike V (V × E) (V × E) E Gr where
-  verts := verts
-  edges := edges
-  input G d := ⟨d.2 ∈ edges G ∧ src G d.2 = d.1, fun _ => d⟩
-  output G d := ⟨d.2 ∈ edges G ∧ tgt G d.2 = d.1, fun _ => d⟩
-  ran_input_subset G := by
-    rintro ⟨x, e⟩ ⟨⟨x', e'⟩, ⟨hmem, h⟩, ⟨rfl, rfl⟩⟩
-    exact ⟨h ▸ mem_verts_src hmem, hmem⟩
-  ran_output_subset G := by
-    rintro ⟨x, e⟩ ⟨⟨x', e'⟩, ⟨hmem, h⟩, ⟨rfl, rfl⟩⟩
-    exact ⟨h ▸ mem_verts_tgt hmem, hmem⟩
-  eq_of_mem_input_of_mem_input G := by
-    intro ⟨x, e⟩ ⟨x', e'⟩ z f
-    simp only [Part.mem_mk_iff, mk.injEq, exists_and_left, exists_prop, and_imp]
-    rintro rfl _ rfl rfl rfl _ _ rfl
-    exact ⟨rfl, rfl⟩
-  eq_of_mem_output_of_mem_output G := by
-    intro ⟨x, e⟩ ⟨x', e'⟩ z f
-    simp only [Part.mem_mk_iff, mk.injEq, exists_and_left, exists_prop, and_imp]
-    rintro rfl _ rfl rfl rfl _ _ rfl
-    exact ⟨rfl, rfl⟩
-  exists_unique_mem_edgeIn_of_mem_edges G := by
-    intro e he
-    apply existsUnique_of_exists_of_unique
-    · use ⟨src G e, e⟩
-      simpa [edgeIn]
-    · rintro ⟨x, f⟩ ⟨x', f'⟩ ⟨⟨_, hx⟩, rfl⟩ ⟨⟨_, hx'⟩, h⟩
-      simp_all [edgeIn]
-      grind
-  exists_unique_mem_edgeOut_of_mem_edges G := by
-    intro e he
-    apply existsUnique_of_exists_of_unique
-    · use ⟨tgt G e, e⟩
-      simpa [edgeOut]
-    · rintro ⟨x, f⟩ ⟨x', f'⟩ ⟨⟨_, hx⟩, rfl⟩ ⟨⟨_, hx'⟩, h⟩
-      simp_all [edgeOut]
-      grind
+variable [DigraphLike V E Gr]
 
-variable [DigraphLike V I O E Gr] {G : Gr}
+noncomputable def src (he : e ∈ edges G) : V :=
+    Classical.choose (mem_edges_iff_exists_isLink.mp he)
 
--- instance instGraphLike : GraphLike V I O E Gr where
---   exists_isLink_of_mem_edges G e he := by
---     obtain ⟨i, ⟨hi, heq⟩, _⟩ := exists_unique_mem_edgeIn_of_mem_edges he
---     obtain ⟨o, ⟨ho, heq'⟩, _⟩ := exists_unique_mem_edgeOut_of_mem_edges he
---     use (source G i).get hi, (target G o).get ho
---     refine ⟨⟨i, hi, ?_⟩, o, ho, ?_⟩
---       <;> grind [input_eq_source_edgeIn, output_eq_target_edgeOut]
---   eq_or_eq_of_isLink_of_isLink G e x y x' y' h h' := by
---     left
---     simp only [IsLink, IsEdgeSource, IsEdgeTarget] at h h'
---     obtain ⟨_, he⟩ := ran_input_subset h.1
---     obtain ⟨⟨i, hi, hxeq⟩, o, ho, hyeq⟩ := h
---     obtain ⟨⟨i', hi', hxeq'⟩, o', ho', hyeq'⟩ := h'
---     rw [←input_eq_source_edgeIn] at hxeq hxeq'
---     rw [←output_eq_target_edgeOut] at hyeq hyeq'
---     suffices i = i' ∧ o = o' by grind
---     refine ⟨ExistsUnique.unique (exists_unique_mem_edgeIn_of_mem_edges he) ?_ ?_,
---       ExistsUnique.unique (exists_unique_mem_edgeOut_of_mem_edges he) ?_ ?_⟩
---     all_goals
---       rw [Part.mem_eq]
---       use (by assumption)
---       grind
+noncomputable def tgt (he : e ∈ edges G) : V :=
+    Classical.choose <| Classical.choose_spec (mem_edges_iff_exists_isLink.mp he)
 
-noncomputable def edgeInFlag {G : Gr} {e : E} (he : e ∈ edges G) : I :=
-  Classical.choose (exists_unique_mem_edgeIn_of_mem_edges he)
+lemma isLink_src_tgt (he : e ∈ edges G) : IsLink G e (src he) (tgt he) :=
+    Classical.choose_spec <| Classical.choose_spec (mem_edges_iff_exists_isLink.mp he)
 
-lemma mem_edgeIn_iff (e : E) (i : I) : e ∈ edgeIn G i ↔ ∃ h : e ∈ edges G, edgeInFlag h = i := by
-  simp_rw [edgeInFlag, ExistsUnique.choose_eq_iff]
-  exact ⟨fun h => ⟨mem_edges_of_mem_edgeIn h, h⟩, fun ⟨_, h⟩ => h⟩
+lemma isSource_src (he : e ∈ edges G) : IsSource G e (src he) := isLink_src_tgt he |>.isSource_left
 
-noncomputable def edgeOutFlag {G : Gr} {e : E} (he : e ∈ edges G) : O :=
-  Classical.choose (exists_unique_mem_edgeOut_of_mem_edges he)
+lemma isTarget_tgt (he : e ∈ edges G) : IsTarget G e (tgt he) := isLink_src_tgt he |>.isTarget_right
 
-lemma mem_edgeOut_iff (e : E) (o : O) : e ∈ edgeOut G o ↔ ∃ h : e ∈ edges G, edgeOutFlag h = o := by
-  simp_rw [edgeOutFlag, ExistsUnique.choose_eq_iff]
-  exact ⟨fun h => ⟨mem_edges_of_mem_edgeOut h, h⟩, fun ⟨_, h⟩ => h⟩
+lemma eq_src_left_of_isLink (h : IsLink G e x y) : x = src h.mem_edges :=
+  eq_of_isSource_of_isSource h.isSource_left (isSource_src h.mem_edges)
 
-protected class Simple (V I O E : outParam Type*) (Gr : Type*) [DigraphLike V I O E Gr] where
-  eq_of_isLink_of_isLink : ∀ ⦃G e e' x y⦄, IsLink (Gr := Gr) G e x y → IsLink G e' x y → e = e'
+lemma eq_tgt_right_of_isLink (h : IsLink G e x y) : y = tgt h.mem_edges :=
+  eq_of_isTarget_of_isTarget h.isTarget_right (isTarget_tgt h.mem_edges)
+
+lemma isLink_iff_eq_src_eq_tgt (he : e ∈ edges G) (x y : V) :
+    IsLink G e x y ↔ x = src he ∧ y = tgt he :=
+  ⟨fun h => ⟨eq_src_left_of_isLink h, eq_tgt_right_of_isLink h⟩,
+    fun ⟨hx, hy⟩ => hx ▸ hy ▸ isLink_src_tgt he⟩
 
 end DigraphLike
 
 open DigraphLike
 
--- class SimpleGraphLike (V I O E : outParam Type*) (Gr : Type*) extends
---     HyperGraphLike V I O E Gr where
---   eq_of_isLink_of_isLink : ∀ ⦃G e e' x y⦄, IsLink (Gr := Gr) G e x y → IsLink G e' x y → e = e'
+class IrreflHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends
+    HyperGraphLike V E Gr where
+  not_isLink_self_self : ∀ ⦃G e x⦄, ¬ (IsLink G e x x)
 
-class IrreflHyperGraphLike (V I O E : outParam Type*) (Gr : Type*) extends
-    HyperGraphLike V I O E Gr where
-  not_isSource_isTarget : ∀ ⦃G e x⦄, ¬ (IsEdgeSource (Gr := Gr) G e x ∧ IsEdgeTarget G e x)
-
-class SymmHyperGraphLike (V I O E : outParam Type*) (Gr : Type*) extends
-    HyperGraphLike V I O E Gr where
-  swapIO : Gr → I →. O
-  swapOI : Gr → O →. I
-  dom_swapIO_eq : ∀ ⦃G⦄, (swapIO G).Dom = (input G).Dom
-  dom_swapOI_eq : ∀ ⦃G⦄, (swapOI G).Dom = (output G).Dom
-  inFlag_mem_comp : ∀ ⦃G i⦄, i ∈ (input G).Dom → i ∈ (swapOI G).comp (swapIO G) i
-  outFlag_mem_comp : ∀ ⦃G o⦄, o ∈ (output G).Dom → o ∈ (swapIO G).comp (swapOI G) o
-  edgeIn_eq_edgeOut_swapIO : ∀ ⦃G⦄, edgeIn G = (edgeOut G).comp (swapIO G)
-  edgeOut_eq_edgeIn_swapOI : ∀ ⦃G⦄, edgeOut G = (edgeIn G).comp (swapOI G)
-
-instance : DigraphLike V (V × V × V) (V × V × V) (V × V) (Digraph V) :=
+instance instDigraphLikeDigraph : DigraphLike V (V × V) (Digraph V) :=
   ofSourceTarget (Gr := Digraph V)
   (verts := fun _ => Set.univ) (edges := fun G => {p : V × V | G.Adj p.1 p.2})
   (src := fun _ => Prod.fst) (tgt := fun _ => Prod.snd)
   (mem_verts_src := fun _ _ _ => trivial) (mem_verts_tgt := fun _ _ _ => trivial)
 
-instance : DigraphLike.Simple V (V × V × V) (V × V × V) (V × V) (Digraph V) where
+instance : GraphLike.Simple V (V × V) (Digraph V) where
   eq_of_isLink_of_isLink G e e' x y h h' := by
-    simp [IsLink, IsEdgeSource, input, IsEdgeTarget, output, PFun.ran] at h h'
+    cases e; cases e'
+    simp_all [IsLink]
+
+instance : GraphLike V E (Graph V E) := by
+  refine ofIsLink Graph.vertexSet Graph.IsLink ?_ ?_ ?_
+  · intro G e x y h
+    exact h.left_mem
+  · intro G e x y h
+    exact h.right_mem
+  · intro G e x y x' y' h h'
+    exact h.eq_and_eq_or_eq_and_eq h'
+
+-- sanity check
+lemma Graph.edges_eq_edgeSet (G : Graph V E) : edges G = G.edgeSet := by
+  ext x
+  simp [edges, G.edge_mem_iff_exists_isLink]
+
+instance : HyperGraphLike.Symm V E (Graph V E) where
+  isSource_iff_isTarget G e x := by
+    simp [IsSource, IsTarget]
+    grind [Graph.isLink_comm]
+  isLink_symm G e := by
+    intro x y h
+    exact h.symm
+
+instance : GraphLike V (Sym2 V) (SimpleGraph V) := by
+  refine ofIsLink (fun _ => Set.univ) (fun (G : SimpleGraph V) e x y => G.Adj x y ∧ e = s(x, y))
+    ?_ ?_ ?_
+  · intro G e x y h; trivial
+  · intro G e x y h; trivial
+  · rintro G e x y x' y' ⟨_, rfl⟩ ⟨_, h⟩
     grind
 
--- this is not quite right, bc `G.IsLink e x y` gives you `IsLink G e x x`
-instance : HyperGraphLike V (V × E) (V × E) E (Graph V E) where
-  verts := Graph.vertexSet
-  edges := Graph.edgeSet
-  input G d := ⟨∃ y, G.IsLink d.2 d.1 y, fun _ => d⟩
-  output G d := ⟨∃ x, G.IsLink d.2 x d.1, fun _ => d⟩
-  ran_input_subset G := by
-    intro ⟨x, e⟩ ⟨⟨x', e'⟩, ⟨y, hlink⟩, heq⟩
-    rw [mk.injEq] at heq
-    exact ⟨heq.1 ▸ hlink.left_mem, heq.2 ▸ hlink.edge_mem⟩
-  ran_output_subset G := by
-    intro ⟨x, e⟩ ⟨⟨x', e'⟩, ⟨y, hlink⟩, heq⟩
-    rw [mk.injEq] at heq
-    exact ⟨heq.1 ▸ hlink.right_mem, heq.2 ▸ hlink.edge_mem⟩
-  eq_of_mem_input_of_mem_input G := by
-    intro ⟨x, e⟩ ⟨x', e'⟩ z f ⟨⟨y, hlink⟩, heq⟩ ⟨⟨y', hlink'⟩, heq'⟩
-    simp_all
-  eq_of_mem_output_of_mem_output G := by
-    intro ⟨x, e⟩ ⟨x', e'⟩ z f ⟨⟨y, hlink⟩, heq⟩ ⟨⟨y', hlink'⟩, heq'⟩
-    simp_all
-  -- exists_isLink_of_mem_edges G e he := by
-  --   obtain ⟨x, y, hlink⟩ := G.edge_mem_iff_exists_isLink e |>.mp he
-  --   refine ⟨x, y, ?_, ?_⟩
-  --   · use ⟨x, e⟩, ⟨y, hlink⟩
-  --     rfl
-  --   · use ⟨y, e⟩, ⟨x, hlink⟩
-  --     rfl
-  -- eq_or_eq_of_isLink_of_isLink G e x y x' y' h h' := by
-  --   obtain ⟨⟨i, ⟨a, halink⟩, hi⟩, o, ⟨b, hblink⟩, ho⟩ := h
-  --   obtain ⟨⟨i', ⟨a', halink'⟩, hi'⟩, o', ⟨b', hblink'⟩, ho'⟩ := h'
-  --   subst_vars
-  --   simp_all only
-  --   sorry
-    -- obtain (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩) := halink.eq_and_eq_or_eq_and_eq halink'
-    -- · obtain (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩) := hblink.eq_and_eq_or_eq_and_eq hblink'
-    --   · left; exact ⟨rfl, rfl⟩
-    --   · obtain (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩) := halink.eq_and_eq_or_eq_and_eq hblink
-    -- obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink hblink
-
-    -- <;>  obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink' hblink'
-    -- <;>  obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink hblink'
-    -- · left; exact ⟨rfl, hblink.right_unique hblink'⟩
-    -- · right; exact ⟨rfl, hblink.right_unique hblink'.symm⟩
-    -- · obtain rfl := halink.right_unique hblink
-    --   obtain rfl := hblink.right_unique hblink'
-    --   sorry
-    -- · sorry
-    -- simp_all
-    -- have h₁ := G.eq_or_eq_of_isLink_of_isLink halink' hblink
-    -- have h₂ := G.eq_or_eq_of_isLink_of_isLink halink hblink'
-    -- have h₃ := G.eq_or_eq_of_isLink_of_isLink halink' hblink'
-
-    -- simp_all only
-    -- obtain (rfl | rfl) := h₀
-    --   <;> obtain (rfl | rfl) := h₁
-    --   <;> obtain (rfl | rfl) := h₂
-    --   <;> cases h₃
-
-    -- obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink hblink
-    --   <;> obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink' hblink'
-    --   <;> obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink hblink'
-    --   <;> simp_all only
-
-
-instance : SymmHyperGraphLike V (V × E) (V × E) E (Graph V E) where
-  swapIO G d := ⟨(input G d).Dom, fun _ => d⟩
-  swapOI G d := ⟨(output G d).Dom, fun _ => d⟩
-  dom_swapIO_eq G := rfl
-  dom_swapOI_eq G := rfl
-  inFlag_mem_comp G := by
-    intro ⟨x, e⟩ ⟨y, hlink⟩
-    simp only [PFun.comp_apply, Part.mem_bind_iff, Part.mem_mk_iff, exists_prop,
-      exists_eq_right_right, and_true]
-    exact ⟨⟨y, hlink⟩, ⟨y, hlink.symm⟩⟩
-  outFlag_mem_comp G := by
-    intro ⟨x, e⟩ ⟨y, hlink⟩
-    simp only [PFun.comp_apply, Part.mem_bind_iff, Part.mem_mk_iff, exists_prop,
-      exists_eq_right_right, and_true]
-    exact ⟨⟨y, hlink⟩, ⟨y, hlink.symm⟩⟩
-  edgeIn_eq_edgeOut_swapIO G := by
-    ext ⟨x, e⟩ e'
-    simp only [edgeIn, input, Part.mem_mk_iff, Function.comp_apply, exists_prop, PFun.comp_apply,
-      Part.mem_bind_iff, edgeOut, output, Prod.exists, mk.injEq, exists_eq_right_right,
-      ↓existsAndEq, true_and, iff_self_and, and_imp, forall_exists_index]
-    rintro y h rfl
-    use y, h.symm
-  edgeOut_eq_edgeIn_swapOI G := by
-    ext ⟨x, e⟩ e'
-    simp only [edgeOut, output, Part.mem_mk_iff, Function.comp_apply, exists_prop, PFun.comp_apply,
-      Part.mem_bind_iff, edgeIn, input, Prod.exists, mk.injEq, exists_eq_right_right, ↓existsAndEq,
-      true_and, iff_self_and, and_imp, forall_exists_index]
-    intro y h rfl
-    use y, h.symm
-
-instance : HyperGraphLike V (V × V) (V × V) (Sym2 V) (SimpleGraph V) where
-  verts _ := Set.univ
-  edges G := G.edgeSet
-  input G d := ⟨G.Adj d.1 d.2, fun _ => (d.1, .mk d.1 d.2)⟩
-  output G d := ⟨G.Adj d.1 d.2, fun _ => (d.1, .mk d.1 d.2)⟩
-  ran_input_subset G := by
-    intro ⟨x, e⟩ ⟨⟨a, b⟩, hdom, h⟩
-    simp_all only [mk.injEq, mem_prod, mem_univ, true_and]
-    rw [←h.2, G.mem_edgeSet]
-    exact hdom
-  ran_output_subset G := by
-    intro ⟨x, e⟩ ⟨⟨a, b⟩, hdom, h⟩
-    simp_all only [mk.injEq, mem_prod, mem_univ, true_and]
-    rw [←h.2, G.mem_edgeSet]
-    exact hdom
-  eq_of_mem_input_of_mem_input G := by
-    intro ⟨x, y⟩ ⟨x', y'⟩ z e ⟨hdom, h⟩ ⟨hdom', h'⟩
-    simp_all
-    grind
-  eq_of_mem_output_of_mem_output G := by
-    intro ⟨x, y⟩ ⟨x', y'⟩ z e ⟨hdom, h⟩ ⟨hdom', h'⟩
-    simp_all
-    grind
-
-instance : SymmHyperGraphLike V (V × V) (V × V) (Sym2 V) (SimpleGraph V) where
-  swapIO G d := ⟨G.Adj d.1 d.2, fun _ => d.swap⟩
-  swapOI G d := ⟨G.Adj d.1 d.2, fun _ => d.swap⟩
-  dom_swapIO_eq G := rfl
-  dom_swapOI_eq G := rfl
-  inFlag_mem_comp G := by
-    intro ⟨x, y⟩ (h : G.Adj x y)
-    simp [h, h.symm]
-  outFlag_mem_comp G := by
-    intro ⟨x, y⟩ (h : G.Adj x y)
-    simp [h, h.symm]
-  edgeIn_eq_edgeOut_swapIO G := by
-    ext ⟨x, y⟩ e
-    simp [edgeIn, input, edgeOut, output]
+instance : HyperGraphLike.Symm V (Sym2 V) (SimpleGraph V) where
+  isSource_iff_isTarget G e x := by
+    simp [IsSource, IsTarget]
     grind [G.adj_comm]
-  edgeOut_eq_edgeIn_swapOI G := by
-    ext ⟨x, y⟩ e
-    simp [edgeIn, input, edgeOut, output]
+  isLink_symm G e h := by
+    simp [IsLink]
     grind [G.adj_comm]
 
--- instance : IrreflHyperGraphLike V (V × V) (V × V) (Sym2 V) (SimpleGraph V) where
---   not_isSource_isTarget G := by
---     intro e x
---     simp [IsEdgeSource, input]
+instance : IrreflHyperGraphLike V (Sym2 V) (SimpleGraph V) where
+  not_isLink_self_self G e x := by simp [IsLink]
 
-    -- simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
-    --   not_and, and_imp]
-    -- rintro rfl h rfl
-    -- exact G.irrefl
+section HalfEdge
+
+structure BondGraph (V E : Type*) where
+  verts : Set V
+  edges : Set E
+  endpoint : E → V
+  endpoint_mem_of_mem : ∀ ⦃e⦄, e ∈ edges → endpoint e ∈ verts
+  swap : E → E
+  swap_mem_of_mem : ∀ ⦃e⦄, e ∈ edges → swap e ∈ edges
+  swap_swap_eq_of_mem : ∀ ⦃e⦄, e ∈ edges → swap (swap e) = e
+
+instance : GraphLike V (Sym2 E) (BondGraph V E) where
+  verts G := G.verts
+  edges G := {s(e, G.swap e) | e ∈ G.edges}
+  IsSource G e x := ∃ f ∈ G.edges, G.endpoint f = x ∧ s(f, G.swap f) = e
+  IsTarget G e x := ∃ f ∈ G.edges, G.endpoint f = x ∧ s(f, G.swap f) = e
+  IsLink G e x y := ∃ f ∈ G.edges, G.endpoint f = x ∧ G.endpoint (G.swap f) = y ∧ s(f, G.swap f) = e
+  mem_edges_of_isSource G e x := by rintro ⟨f, hf, _, rfl⟩; use f
+  mem_edges_of_isTarget G e y := by rintro ⟨f, hf, _, rfl⟩; use f
+  mem_verts_of_isSource G e x := by rintro ⟨f, hf, rfl, _⟩; exact G.endpoint_mem_of_mem hf
+  mem_verts_of_isTarget G e x := by rintro ⟨f, hf, rfl, _⟩; exact G.endpoint_mem_of_mem hf
+  isSource_left_of_isLink G e x y := by rintro ⟨f, hf, rfl, rfl, rfl⟩; use f
+  isTarget_right_of_isLink G e x y := by
+    rintro ⟨f, hf, rfl, rfl, rfl⟩
+    use G.swap f, G.swap_mem_of_mem hf, rfl
+    rw [Sym2.eq_swap, G.swap_swap_eq_of_mem hf]
+  mem_edges_iff_exists_isLink G e := by simp
+  isSource_iff_exists_isLink G e x := by simp
+  isTarget_iff_exists_isLink G e y := by
+    constructor
+    · rintro ⟨f, hf, rfl, rfl⟩
+      use G.endpoint (G.swap f), G.swap f, G.swap_mem_of_mem hf, rfl
+      simp [G.swap_swap_eq_of_mem hf]
+    · rintro ⟨x, f, hf, rfl, rfl, rfl⟩
+      use G.swap f, G.swap_mem_of_mem hf, rfl
+      simp [G.swap_swap_eq_of_mem hf]
+  eq_and_eq_or_eq_and_eq_of_isLink_of_isLink G _ _ _ _ _ := by
+    simp only [forall_exists_index, and_imp]
+    rintro e he rfl rfl rfl f hf rfl rfl
+    simp only [Sym2.eq, Sym2.rel_iff', mk.injEq, swap_prod_mk]
+    rintro (⟨rfl, _⟩ | ⟨rfl, _⟩)
+    · simp
+    · simp [G.swap_swap_eq_of_mem he]
+
+structure IrreflBondGraph (V E : Type*) extends BondGraph V E where
+  endpoint_ne_endpoint_swap : ∀ ⦃e⦄, e ∈ edges → endpoint e ≠ endpoint (swap e)
+  -- ne_swap_self : ∀ ⦃e⦄, e ∈ edges → swap e ≠ e
+
+instance : GraphLike V (Sym2 E) (IrreflBondGraph V E) where
+  verts G := G.verts
+  edges G := {s(e, G.swap e) | e ∈ G.edges}
+  IsSource G e x := ∃ f ∈ G.edges, G.endpoint f = x ∧ s(f, G.swap f) = e
+  IsTarget G e x := ∃ f ∈ G.edges, G.endpoint f = x ∧ s(f, G.swap f) = e
+  IsLink G e x y := ∃ f ∈ G.edges, G.endpoint f = x ∧ G.endpoint (G.swap f) = y ∧ s(f, G.swap f) = e
+  mem_edges_of_isSource G e x := by rintro ⟨f, hf, _, rfl⟩; use f
+  mem_edges_of_isTarget G e y := by rintro ⟨f, hf, _, rfl⟩; use f
+  mem_verts_of_isSource G e x := by rintro ⟨f, hf, rfl, _⟩; exact G.endpoint_mem_of_mem hf
+  mem_verts_of_isTarget G e x := by rintro ⟨f, hf, rfl, _⟩; exact G.endpoint_mem_of_mem hf
+  isSource_left_of_isLink G e x y := by rintro ⟨f, hf, rfl, rfl, rfl⟩; use f
+  isTarget_right_of_isLink G e x y := by
+    rintro ⟨f, hf, rfl, rfl, rfl⟩
+    use G.swap f, G.swap_mem_of_mem hf, rfl
+    rw [Sym2.eq_swap, G.swap_swap_eq_of_mem hf]
+  mem_edges_iff_exists_isLink G e := by simp
+  isSource_iff_exists_isLink G e x := by simp
+  isTarget_iff_exists_isLink G e y := by
+    constructor
+    · rintro ⟨f, hf, rfl, rfl⟩
+      use G.endpoint (G.swap f), G.swap f, G.swap_mem_of_mem hf, rfl
+      simp [G.swap_swap_eq_of_mem hf]
+    · rintro ⟨x, f, hf, rfl, rfl, rfl⟩
+      use G.swap f, G.swap_mem_of_mem hf, rfl
+      simp [G.swap_swap_eq_of_mem hf]
+  eq_and_eq_or_eq_and_eq_of_isLink_of_isLink G _ _ _ _ _ := by
+    simp only [forall_exists_index, and_imp]
+    rintro e he rfl rfl rfl f hf rfl rfl
+    simp only [Sym2.eq, Sym2.rel_iff', mk.injEq, swap_prod_mk]
+    rintro (⟨rfl, _⟩ | ⟨rfl, _⟩)
+    · simp
+    · simp [G.swap_swap_eq_of_mem he]
+
+instance : IrreflHyperGraphLike V (Sym2 E) (IrreflBondGraph V E) where
+  not_isLink_self_self G e x := by
+    rintro ⟨f, hf, rfl, h, _⟩
+    exact G.endpoint_ne_endpoint_swap hf h.symm
+
+end HalfEdge

--- a/Mathlib/Combinatorics/GraphLike/Basic.lean
+++ b/Mathlib/Combinatorics/GraphLike/Basic.lean
@@ -6,7 +6,7 @@ Authors: Jun Kwon, Thomas Waring
 module
 
 public import Mathlib.Data.PFun
-public import Mathlib.Combinatorics.Graph.Basic
+public import Mathlib.Combinatorics.Graph.Subgraph
 public import Mathlib.Combinatorics.SimpleGraph.Dart
 public import Mathlib.Combinatorics.Digraph.Basic
 public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
@@ -28,7 +28,7 @@ variable {V E Gr : Type*} {G : Gr} {e : E} {x y : V}
 /-- The type `Gr` consists of graph-like objects on vertices `V` and edges `E`. Note that we
 *cannot* require the converse of `isSource_left_of_isLink` and `isTarget_right_of_isLink` taken
 together, as might be tempting: in an undirected graph we want, for instance `IsLink G e x y` and
-`IsLink G e y x` to both be true, and this converse would then imply `IsLink H e x x`, which we
+`IsLink G e y x` to both be true, and this converse would then imply `IsLink G e x x`, which we
 don't necessarily want. We also can't take `is{Source / Target}_{left / right}_of_isLink` as a
 definition, to account for edges which have inputs but no outputs. -/
 class HyperGraphLike (V E : outParam Type*) (Gr : Type*) where
@@ -131,6 +131,15 @@ def AdjDart (d d' : Dart G) : Prop := d.tgt = d'.src
 
 end Dart
 
+/-- This is weaker than requiring that the clauses listed *determine* the order relation,
+but it ought to be enough to define eg lifting walks from a subgraph. -/
+class HyperGraphLikeLE (Gr : Type*) [HyperGraphLike V E Gr] [LE Gr] where
+  verts_mono {H G : Gr} : H ≤ G → verts H ⊆ verts G
+  edges_mono {H G : Gr} : H ≤ G → edges H ⊆ edges G
+  isSource_mono {H G : Gr} : H ≤ G → ∀ ⦃e x⦄, IsSource H e x → IsSource G e x
+  isTarget_mono {H G : Gr} : H ≤ G → ∀ ⦃e y⦄, IsTarget H e y → IsTarget G e y
+  isLink_mono {H G : Gr} : H ≤ G → ∀ ⦃e x y⦄, IsLink H e x y → IsLink G e x y
+
 end HyperGraphLike
 
 open HyperGraphLike
@@ -149,7 +158,7 @@ lemma adj_symm : Symmetric (Adj G) := by
   intro x y ⟨e, h⟩
   exact ⟨e, isLink_symm h⟩
 
--- -- etc API lemmas as for `Graph`
+-- etc API lemmas as for `Graph`
 
 end HyperGraphLike.Symm
 
@@ -203,6 +212,18 @@ noncomputable def endpoints (he : e ∈ edges G) : Sym2 V :=
 lemma eq_endpoints_of_isLink (h : IsLink G e x y) : s(x, y) = endpoints h.mem_edges := by
   simpa [endpoints] using eq_and_eq_or_eq_and_eq_of_isLink_of_isLink (G := G) (e := e) h <|
     Classical.choose_spec <| Classical.choose_spec (mem_edges_iff_exists_isLink.mp h.mem_edges)
+
+/-- A convenient constructor for `HyperGraphLikeLE` in the case of graphlike types. -/
+@[implicit_reducible]
+def hyperGraphLikeLE [LE Gr] (hverts : ∀ {H G : Gr}, H ≤ G → verts H ⊆ verts G)
+    (hedges : ∀ {H G : Gr}, H ≤ G → edges H ⊆ edges G)
+    (hlink : ∀ {H G : Gr}, H ≤ G → ∀ ⦃e x y⦄, IsLink H e x y → IsLink G e x y) :
+    HyperGraphLikeLE Gr where
+  verts_mono := hverts
+  edges_mono := hedges
+  isSource_mono h e x := by grind [isSource_iff_exists_isLink]
+  isTarget_mono h e x := by grind [isTarget_iff_exists_isLink]
+  isLink_mono := hlink
 
 end GraphLike
 
@@ -295,7 +316,7 @@ instance : GraphLike.Simple V (V × V) (Digraph V) where
     cases e; cases e'
     simp_all [IsLink]
 
-/-- `Graph` is `GraphLike`. -/
+/-- `Graph` is `GraphLike` ... -/
 instance : GraphLike V E (Graph V E) := by
   refine ofIsLink Graph.vertexSet Graph.IsLink ?_ ?_ ?_
   · intro G e x y h
@@ -305,12 +326,7 @@ instance : GraphLike V E (Graph V E) := by
   · intro G e x y x' y' h h'
     exact h.eq_and_eq_or_eq_and_eq h'
 
--- sanity check
-lemma Graph.edges_eq_edgeSet (G : Graph V E) : edges G = G.edgeSet := by
-  ext x
-  simp [edges, G.edge_mem_iff_exists_isLink]
-
-/-- `Graph` is symmetric. -/
+/-- ... and symmetric. -/
 instance : HyperGraphLike.Symm V E (Graph V E) where
   isSource_iff_isTarget G e x := by
     simp [IsSource, IsTarget]
@@ -318,6 +334,17 @@ instance : HyperGraphLike.Symm V E (Graph V E) where
   isLink_symm G e := by
     intro x y h
     exact h.symm
+
+-- sanity check
+lemma Graph.edges_eq_edgeSet (G : Graph V E) : edges G = G.edgeSet := by
+  ext x
+  simp [edges, G.edge_mem_iff_exists_isLink]
+
+instance : HyperGraphLikeLE (Graph V E) := by
+  refine GraphLike.hyperGraphLikeLE ?_ ?_ ?_
+  · intro _ _ h; exact h.vertexSet_mono
+  · intro _ _ h; simpa [Graph.edges_eq_edgeSet] using h.edgeSet_mono
+  · intro _ _ h; exact h.isLink_mono
 
 /-- `SimpleGraph` is `Graphlike`, ... -/
 instance : GraphLike V (Sym2 V) (SimpleGraph V) := by

--- a/Mathlib/Combinatorics/GraphLike/Basic.lean
+++ b/Mathlib/Combinatorics/GraphLike/Basic.lean
@@ -19,7 +19,7 @@ public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
 no duplicated edges) no longer works, bc the same edge could be traversed both ways.
 -/
 
-public section
+@[expose] public section
 
 open Prod Set
 

--- a/Mathlib/Combinatorics/GraphLike/Basic.lean
+++ b/Mathlib/Combinatorics/GraphLike/Basic.lean
@@ -7,8 +7,9 @@ module
 
 public import Mathlib.Data.PFun
 public import Mathlib.Combinatorics.Graph.Basic
-public import Mathlib.Combinatorics.SimpleGraph.Basic
+public import Mathlib.Combinatorics.SimpleGraph.Dart
 public import Mathlib.Combinatorics.Digraph.Basic
+public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
 
 /-! # Typeclass for graph-like data
 
@@ -24,11 +25,22 @@ open Prod Set
 
 variable {V E Gr : Type*} {G : Gr} {e : E} {x y : V}
 
+/-- The type `Gr` consists of graph-like objects on vertices `V` and edges `E`. Note that we
+*cannot* require the converse of `isSource_left_of_isLink` and `isTarget_right_of_isLink` taken
+together, as might be tempting: in an undirected graph we want, for instance `IsLink G e x y` and
+`IsLink G e y x` to both be true, and this converse would then imply `IsLink H e x x`, which we
+don't necessarily want. We also can't take `is{Source / Target}_{left / right}_of_isLink` as a
+definition, to account for edges which have inputs but no outputs. -/
 class HyperGraphLike (V E : outParam Type*) (Gr : Type*) where
+  /-- The set of vertices of a graph. -/
   verts : Gr → Set V
+  /-- The set of edges of a graph. -/
   edges : Gr → Set E
+  /-- A vertex can acts as an input to an edge. -/
   IsSource : Gr → E → V → Prop
+  /-- A vertex can acts as an output from an edge. -/
   IsTarget : Gr → E → V → Prop
+  /-- An edges represents a walk of length one. -/
   IsLink : Gr → E → V → V → Prop
   mem_edges_of_isSource : ∀ ⦃G e x⦄, IsSource G e x → e ∈ edges G
   mem_edges_of_isTarget : ∀ ⦃G e x⦄, IsTarget G e x → e ∈ edges G
@@ -39,8 +51,10 @@ class HyperGraphLike (V E : outParam Type*) (Gr : Type*) where
 
 namespace HyperGraphLike
 
-variable [instHGL : HyperGraphLike V E Gr]
+variable [HyperGraphLike V E Gr]
 
+/-- Construct an instance based on source and target relations. `IsLink G e x y` is defined to be
+`IsSource G e x ∧ IsTarget G e y`. -/
 @[implicit_reducible]
 def ofIsSourceIsTarget (verts : Gr → Set V) (edges : Gr → Set E)
     (IsSource : Gr → E → V → Prop) (IsTarget : Gr → E → V → Prop)
@@ -79,6 +93,7 @@ lemma IsLink.mem_verts_right (h : IsLink G e x y) : y ∈ verts G := h.isTarget_
 
 lemma IsLink.mem_edges (h : IsLink G e x y) : e ∈ edges G := h.isSource_left.mem_edges
 
+/-- Notion of adjacency derived from `IsLink`. -/
 def Adj (G : Gr) (x y : V) : Prop := ∃ e, IsLink G e x y
 
 lemma Adj.mem_verts_left (h : Adj G x y) : x ∈ verts G :=
@@ -89,6 +104,7 @@ lemma Adj.mem_verts_right (h : Adj G x y) : y ∈ verts G :=
   have ⟨_, h⟩ := h
   h.mem_verts_right
 
+/-- A `Dart` is a walk of length one. -/
 structure Dart (G : Gr) where
   src : V
   tgt : V
@@ -110,6 +126,7 @@ lemma edge_mem (d : Dart G) : d.edge ∈ edges G := d.h.mem_edges
 
 lemma adj (d : Dart G) : Adj G d.src d.tgt := ⟨d.edge, d.h⟩
 
+/-- Darts are adjacent if they can appear as consecutive steps in a walk. -/
 def AdjDart (d d' : Dart G) : Prop := d.tgt = d'.src
 
 end Dart
@@ -118,6 +135,8 @@ end HyperGraphLike
 
 open HyperGraphLike
 
+/-- A class for hypergraphs with no orientation on edges, so that `IsSource` and `IsTarget` agree
+and `IsLink` is symmetric. -/
 class HyperGraphLike.Symm (V E : outParam Type*) (Gr : Type*) extends HyperGraphLike V E Gr where
   isSource_iff_isTarget : ∀ ⦃G e x⦄, IsSource G e x ↔ IsTarget G e x
   isLink_symm : ∀ ⦃G e⦄, Symmetric (IsLink G e)
@@ -134,6 +153,9 @@ lemma adj_symm : Symmetric (Adj G) := by
 
 end HyperGraphLike.Symm
 
+/-- A `GraphLike` type, where each edge connects a unique (not necessarily distinct) pair
+of vertices. For this class and those inheriting it, `IsSource` and `IsTarget` are inferred from
+`IsLink`. -/
 class GraphLike (V E : outParam Type*) (Gr : Type*) extends HyperGraphLike V E Gr where
   mem_edges_iff_exists_isLink : ∀ ⦃G e⦄, e ∈ edges G ↔ ∃ x y, IsLink G e x y
   isSource_iff_exists_isLink : ∀ ⦃G e x⦄, IsSource G e x ↔ ∃ y, IsLink G e x y
@@ -141,8 +163,10 @@ class GraphLike (V E : outParam Type*) (Gr : Type*) extends HyperGraphLike V E G
   eq_and_eq_or_eq_and_eq_of_isLink_of_isLink : ∀ ⦃G : Gr⦄ ⦃e x y x' y'⦄,
       IsLink G e x y → IsLink G e x' y' → x = x' ∧ y = y' ∨ x = y' ∧ y = x'
 
-namespace DirGraphLike
+namespace GraphLike
 
+/-- Construct a `GraphLike` instance directly from the `IsLink` relation. `IsSource` and `IsTarget`
+are given their only possible definitions. -/
 @[implicit_reducible]
 def ofIsLink (verts : Gr → Set V) (IsLink : Gr → E → V → V → Prop)
     (mem_verts_left_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → x ∈ verts G)
@@ -166,11 +190,9 @@ def ofIsLink (verts : Gr → Set V) (IsLink : Gr → E → V → V → Prop)
   isSource_left_of_isLink _ _ _ y h := ⟨y, h⟩
   isTarget_right_of_isLink _ _ x _ h := ⟨x, h⟩
 
+/-- A simple `GraphLike` type has at most one edge linking any two vertices. -/
 class Simple (V E : outParam Type*) (Gr : Type*) extends GraphLike V E Gr where
   eq_of_isLink_of_isLink : ∀ ⦃G e e' x y⦄, IsLink G e x y → IsLink G e' x y → e = e'
-
-class Directed (V E : outParam Type*) (Gr : Type*) extends GraphLike V E Gr where
-  existsUnique_isLink_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! x, ∃! y, IsLink G e x y
 
 variable [GraphLike V E Gr]
 
@@ -182,10 +204,11 @@ lemma eq_endpoints_of_isLink (h : IsLink G e x y) : s(x, y) = endpoints h.mem_ed
   simpa [endpoints] using eq_and_eq_or_eq_and_eq_of_isLink_of_isLink (G := G) (e := e) h <|
     Classical.choose_spec <| Classical.choose_spec (mem_edges_iff_exists_isLink.mp h.mem_edges)
 
-end DirGraphLike
+end GraphLike
 
-open DirGraphLike
+open GraphLike
 
+/-- In a `DigraphLike` type, each edge has a unique source and target. -/
 class DigraphLike (V E : outParam Type*) (Gr : Type*) extends
     GraphLike V E Gr where
   eq_of_isSource_of_isSource : ∀ ⦃G e x x'⦄, IsSource G e x → IsSource G e x' → x = x'
@@ -245,25 +268,34 @@ lemma isLink_iff_eq_src_eq_tgt (he : e ∈ edges G) (x y : V) :
   ⟨fun h => ⟨eq_src_left_of_isLink h, eq_tgt_right_of_isLink h⟩,
     fun ⟨hx, hy⟩ => hx ▸ hy ▸ isLink_src_tgt he⟩
 
+lemma eq_and_eq_of_isLink_of_isLink {e : E} {x y x' y' : V} (h : IsLink G e x y)
+    (h' : IsLink G e x' y') : x = x' ∧ y = y' :=
+  ⟨eq_of_isSource_of_isSource h.isSource_left h'.isSource_left,
+  eq_of_isTarget_of_isTarget h.isTarget_right h'.isTarget_right⟩
+
 end DigraphLike
 
 open DigraphLike
 
+/-- In an irreflexive hypergraph-like type, there is no length-one walk from a vertex to itself. -/
 class IrreflHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends
     HyperGraphLike V E Gr where
   not_isLink_self_self : ∀ ⦃G e x⦄, ¬ (IsLink G e x x)
 
+/-- `Digraph` is indeed `DigraphLike`... -/
 instance instDigraphLikeDigraph : DigraphLike V (V × V) (Digraph V) :=
   ofSourceTarget (Gr := Digraph V)
   (verts := fun _ => Set.univ) (edges := fun G => {p : V × V | G.Adj p.1 p.2})
   (src := fun _ => Prod.fst) (tgt := fun _ => Prod.snd)
   (mem_verts_src := fun _ _ _ => trivial) (mem_verts_tgt := fun _ _ _ => trivial)
 
+/-- ... and simple. -/
 instance : GraphLike.Simple V (V × V) (Digraph V) where
   eq_of_isLink_of_isLink G e e' x y h h' := by
     cases e; cases e'
     simp_all [IsLink]
 
+/-- `Graph` is `GraphLike`. -/
 instance : GraphLike V E (Graph V E) := by
   refine ofIsLink Graph.vertexSet Graph.IsLink ?_ ?_ ?_
   · intro G e x y h
@@ -278,6 +310,7 @@ lemma Graph.edges_eq_edgeSet (G : Graph V E) : edges G = G.edgeSet := by
   ext x
   simp [edges, G.edge_mem_iff_exists_isLink]
 
+/-- `Graph` is symmetric. -/
 instance : HyperGraphLike.Symm V E (Graph V E) where
   isSource_iff_isTarget G e x := by
     simp [IsSource, IsTarget]
@@ -286,6 +319,7 @@ instance : HyperGraphLike.Symm V E (Graph V E) where
     intro x y h
     exact h.symm
 
+/-- `SimpleGraph` is `Graphlike`, ... -/
 instance : GraphLike V (Sym2 V) (SimpleGraph V) := by
   refine ofIsLink (fun _ => Set.univ) (fun (G : SimpleGraph V) e x y => G.Adj x y ∧ e = s(x, y))
     ?_ ?_ ?_
@@ -294,6 +328,7 @@ instance : GraphLike V (Sym2 V) (SimpleGraph V) := by
   · rintro G e x y x' y' ⟨_, rfl⟩ ⟨_, h⟩
     grind
 
+/-- ... symmetric, ... -/
 instance : HyperGraphLike.Symm V (Sym2 V) (SimpleGraph V) where
   isSource_iff_isTarget G e x := by
     simp [IsSource, IsTarget]
@@ -302,10 +337,35 @@ instance : HyperGraphLike.Symm V (Sym2 V) (SimpleGraph V) where
     simp [IsLink]
     grind [G.adj_comm]
 
+/-- ... simple, ... -/
+instance : GraphLike.Simple V (Sym2 V) (SimpleGraph V) where
+  eq_of_isLink_of_isLink G e e' x y := by rintro ⟨h, rfl⟩ ⟨h', rfl⟩; rfl
+
+/-- ... and irreflexive. -/
 instance : IrreflHyperGraphLike V (Sym2 V) (SimpleGraph V) where
   not_isLink_self_self G e x := by simp [IsLink]
 
+-- sanity checks.
+lemma SimpleGraph.edges_eq_edgeSet (G : SimpleGraph V) : edges G = G.edgeSet := by
+  ext x
+  rcases x with ⟨x, y⟩
+  simp [edges]
+  grind [G.adj_comm]
+
+lemma SimpleGraph.adj_iff_adj (G : SimpleGraph V) (x y : V) :
+    G.Adj x y ↔ HyperGraphLike.Adj G x y := by
+  simp [HyperGraphLike.Adj, IsLink]
+
+def SimpleGraph.dart_equiv_dart (G : SimpleGraph V) :
+    G.Dart ≃ HyperGraphLike.Dart G where
+  toFun d := ⟨d.fst, d.snd, s(d.fst, d.snd), d.adj, rfl⟩
+  invFun d := ⟨⟨d.src, d.tgt⟩, (G.adj_iff_adj _ _).mpr d.adj⟩
+  right_inv d := by rcases d with ⟨x, y, e, h, rfl⟩; simp
+
 section HalfEdge
+
+/-! A rough definition and instance(s) to show that a graph-like type defined in terms of half-edges
+can be fit (faithfully imo) into this framework. -/
 
 structure BondGraph (V E : Type*) where
   verts : Set V
@@ -392,3 +452,9 @@ instance : IrreflHyperGraphLike V (Sym2 E) (IrreflBondGraph V E) where
     exact G.endpoint_ne_endpoint_swap hf h.symm
 
 end HalfEdge
+
+-- i don't think this is particularly interesting but it is at least possible
+instance : HyperGraphLike V (Finset V) (AbstractSimplicialComplex V) := by
+  refine ofIsSourceIsTarget (fun _ => Set.univ) (fun K => K.faces) (fun K e x => e ∈ K ∧ x ∈ e)
+      (fun K e x => e ∈ K ∧ x ∈ e) (fun _ _ _ h => h.1) (fun _ _ _ h => h.1)
+      (fun _ _ _ _ => trivial) (fun _ _ _ _ => trivial)

--- a/Mathlib/Combinatorics/GraphLike/Basic.lean
+++ b/Mathlib/Combinatorics/GraphLike/Basic.lean
@@ -5,7 +5,7 @@ Authors: Jun Kwon, Thomas Waring
 -/
 module
 
-public import Mathlib.Data.PFun
+public import Mathlib.Combinatorics.Quiver.Basic
 public import Mathlib.Combinatorics.Graph.Subgraph
 public import Mathlib.Combinatorics.SimpleGraph.Dart
 public import Mathlib.Combinatorics.Digraph.Basic
@@ -28,9 +28,11 @@ variable {V E Gr : Type*} {G : Gr} {e : E} {x y : V}
 /-- The type `Gr` consists of graph-like objects on vertices `V` and edges `E`. Note that we
 *cannot* require the converse of `isSource_left_of_isLink` and `isTarget_right_of_isLink` taken
 together, as might be tempting: in an undirected graph we want, for instance `IsLink G e x y` and
-`IsLink G e y x` to both be true, and this converse would then imply `IsLink G e x x`, which we
-don't necessarily want. We also can't take `is{Source / Target}_{left / right}_of_isLink` as a
-definition, to account for edges which have inputs but no outputs. -/
+`IsLink G e y x` to both be true (you can cross bridge `e` in both directions),
+and this converse would then imply `IsLink G e x x` (you can walk halfway across and turn back),
+which we don't necessarily want (it would in particular break the bridges of Königsberg problem).
+We also can't take `is{Source / Target}_{left / right}_of_isLink` as a definition, to account for
+edges which have inputs but no outputs. -/
 class HyperGraphLike (V E : outParam Type*) (Gr : Type*) where
   /-- The set of vertices of a graph. -/
   verts : Gr → Set V
@@ -485,3 +487,8 @@ instance : HyperGraphLike V (Finset V) (AbstractSimplicialComplex V) := by
   refine ofIsSourceIsTarget (fun _ => Set.univ) (fun K => K.faces) (fun K e x => e ∈ K ∧ x ∈ e)
       (fun K e x => e ∈ K ∧ x ∈ e) (fun _ _ _ h => h.1) (fun _ _ _ h => h.1)
       (fun _ _ _ _ => trivial) (fun _ _ _ _ => trivial)
+
+@[implicit_reducible]
+def instQuiver (Q : Type*) [Quiver Q] : GraphLike Q (Σ x y : Q, x ⟶ y) Unit := by
+  refine ofIsLink (fun _ => Set.univ) (fun _ ⟨x, y, f⟩ x' y' => x = x' ∧ y = y') ?_ ?_ ?_
+  all_goals grind

--- a/Mathlib/Combinatorics/GraphLike/Basic.lean
+++ b/Mathlib/Combinatorics/GraphLike/Basic.lean
@@ -9,7 +9,13 @@ public import Mathlib.Combinatorics.Graph.Basic
 public import Mathlib.Combinatorics.SimpleGraph.Basic
 public import Mathlib.Combinatorics.Digraph.Basic
 
-/-! # Typeclass for graph-like data -/
+/-! # Typeclass for graph-like data
+
+- packaging junk values problematic due to non-defeq instances for the same type, move to relations
+(more ergononmic than partially defined functions i think)
+- method of undirected graph = directed modulo involution means the definition of trail (walk with
+no duplicated edges) no longer works, bc the same edge could be traversed both ways.
+-/
 
 public section
 
@@ -17,92 +23,25 @@ variable {V H I O E Gr : Type*}
 
 class HyperGraphLike (V E : outParam Type*) (Gr : Type*) where
   verts : Gr → Set V
-  -- flags : Gr → Set H
   edges : Gr → Set E
-  -- IsEndpoint : Gr → H → V → Prop
-  -- IsInFlag : Gr → E → H → Prop
-  -- IsOutFlag : Gr → E → H → Prop
-  -- mem_flags_iff_exists_isEnpoint : ∀ ⦃G h⦄, h ∈ flags G ↔ ∃ x, IsEndpoint G h x
-  -- inFlags : Gr → Set I
-  -- outFlags : Gr → Set O
   IsSource : Gr → E → V → Prop
   IsTarget : Gr → E → V → Prop
-  -- source : Gr → I → V
-  -- target : Gr → O → V
-  -- edgeI : Gr → I → E
-  -- edgeO : Gr → O → E
-  -- IsSource : Gr → I → V → Prop
-  -- IsTarget : Gr → O → V → Prop
-  -- IsInPort : Gr → E → I → Prop
-  -- IsOutPort : Gr → E → O → Prop
-  -- mapsTo_source : ∀ ⦃G⦄, Set.MapsTo (source G) (inFlags G) (verts G)
-  -- mapsTo_target : ∀ ⦃G⦄, Set.MapsTo (target G) (outFlags G) (verts G)
-  -- mapsTo_edgeI : ∀ ⦃G⦄, Set.MapsTo (edgeI G) (inFlags G) (edges G)
-  -- mapsTo_edgeO : ∀ ⦃G⦄, Set.MapsTo (edgeO G) (outFlags G) (edges G)
-  -- eq_of_source_eq_of_edgeI_eq : ∀ ⦃G i i'⦄, i ∈ inFlags G → i' ∈ inFlags G →
-  --   source G i = source G i' → edgeI G i = edgeI G i' → i = i'
-  -- eq_of_target_eq_of_edgeO_eq : ∀ ⦃G o o'⦄, o ∈ outFlags G → o' ∈ outFlags G →
-  --   target G o = target G o' → edgeO G o = edgeO G o' → o = o'
   mem_verts_of_isSource : ∀ ⦃G e x⦄, IsSource G e x → x ∈ verts G
   mem_verts_of_isTarget : ∀ ⦃G e x⦄, IsTarget G e x → x ∈ verts G
   mem_edges_of_isSource : ∀ ⦃G e x⦄, IsSource G e x → e ∈ edges G
   mem_edges_of_isTarget : ∀ ⦃G e x⦄, IsTarget G e x → e ∈ edges G
-  -- mem_inFlags_iff : ∀ ⦃G i⦄, i ∈ inFlags G ↔
-  --     (∃! x ∈ verts G, IsSource G i x) ∧ (∃! e ∈ edges G, IsInPort G e i)
-  -- mem_outFlags_iff : ∀ ⦃G o⦄, o ∈ outFlags G ↔
-  --     (∃! x ∈ verts G, IsTarget G o x) ∧ (∃! e ∈ edges G, IsOutPort G e o)
 
 namespace HyperGraphLike
 
 variable [HyperGraphLike V E Gr] {G : Gr}
 
--- def IsEdgeSource (G : Gr) (e : E) (v : V) : Prop := ∃ i ∈ inFlags G, source G i = v ∧ edgeI G i = e
-
--- def IsEdgeTarget (G : Gr) (e : E) (v : V) : Prop := ∃ o ∈ outFlags G, target G o = v ∧ edgeO G o = e
-
--- def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsEdgeSource G e x ∧ IsEdgeTarget G e y
-
 def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsSource G e x ∧ IsTarget G e y
-
--- @[implicit_reducible]
--- def ofIsSourceIsTarget (verts : Gr → Set V) (edges : Gr → Set E)
---     (IsEdgeSource : Gr → E → V → Prop) (IsEdgeTarget : Gr → E → V → Prop)
---     (mem_verts_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → v ∈ verts G)
---     (mem_edges_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → e ∈ edges G)
---     (mem_verts_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → v ∈ verts G)
---     (mem_edges_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → e ∈ edges G)
---     : HyperGraphLike V (E × V) (E × V) E Gr where
---   verts := verts
---   inFlags G := {d | IsEdgeSource G d.1 d.2}
---   outFlags G := {d | IsEdgeTarget G d.1 d.2}
---   edges := edges
---   source _ d := d.2
---   target _ d := d.2
---   edgeI _ d := d.1
---   edgeO _ d := d.1
---   mapsTo_source G i hi := mem_verts_of_isEdgeSource hi
---   mapsTo_target G o ho := mem_verts_of_isEdgeTarget ho
---   mapsTo_edgeI G i hi := mem_edges_of_isEdgeSource hi
---   mapsTo_edgeO G o ho := mem_edges_of_isEdgeTarget ho
---   eq_of_source_eq_of_edgeI_eq G i i' _ _ h h' := by cases i; cases i'; congr
---   eq_of_target_eq_of_edgeO_eq G o o' _ _ h h' := by cases o; cases o'; congr
-
--- def Adj (G : Gr) (x y : V) : Prop := ∃ e ∈ edges G, IsEdgeSource G e x ∧ IsEdgeTarget G e y
 
 def Adj (G : Gr) (x y : V) : Prop := ∃ e, IsSource G e x ∧ IsTarget G e y
 
--- def FlagsInc (G : Gr) (i : I) (o : O) : Prop :=
---     edgeI G i = edgeO G o ∧ i ∈ inFlags G ∧ o ∈ outFlags G
+def sources (G : Gr) (e : E) : Set V := {x | IsSource G e x}
 
--- lemma Adj.iff_exists_inFlag_outFlag {G : Gr} {x y : V} :
---     Adj G x y ↔ ∃ i o, FlagsInc G i o ∧ source G i = x ∧ target G o = y := by
---   simp_rw [Adj, IsEdgeSource, IsEdgeTarget, FlagsInc]
---   constructor
---   · rintro ⟨_, he, ⟨i, hi, rfl, rfl⟩, o, ho, rfl, h⟩
---     use i, o
---     grind
---   · rintro ⟨i, o, ⟨he, hi, ho⟩, rfl, rfl⟩
---     exact ⟨edgeI G i, mapsTo_edgeI hi, ⟨i, hi, rfl, rfl⟩, o, ho, rfl, he.symm⟩
+def targets (G : Gr) (e : E) : Set V := {y | IsTarget G e y}
 
 structure Dart (G : Gr) where
   source : V
@@ -112,64 +51,20 @@ structure Dart (G : Gr) where
 
 namespace Dart
 
--- @[ext]
--- protected lemma ext {d d' : Dart G} (hi : d.i = d'.i) (ho : d.o = d'.o) : d = d' := by
---   cases d; cases d'; congr
-
--- lemma inFlag_mem (d : Dart G) : d.i ∈ inFlags G := d.inc.2.1
-
--- lemma outFlag_mem (d : Dart G) : d.o ∈ outFlags G := d.inc.2.2
-
--- def src (d : Dart G) : V := source G d.i
-
--- lemma src_mem (d : Dart G) : d.src ∈ verts G := mapsTo_source d.inFlag_mem
+@[ext]
+protected lemma ext {d d' : Dart G} (hs : d.source = d'.source) (ho : d.target = d'.target)
+    (he : d.edge = d'.edge) : d = d' := by
+  cases d; cases d'; congr
 
 def isSource (d : Dart G) : IsSource G d.edge d.source := d.isLink.1
 
 lemma source_mem (d : Dart G) : d.source ∈ verts G := mem_verts_of_isSource d.isSource
 
--- def tgt (d : Dart G) : V := target G d.o
-
--- lemma tgt_mem (d : Dart G) : d.tgt ∈ verts G := mapsTo_target d.outFlag_mem
-
 def isTarget (d : Dart G) : IsTarget G d.edge d.target := d.isLink.2
 
 lemma target_mem (d : Dart G) : d.target ∈ verts G := mem_verts_of_isTarget d.isLink.2
 
--- def edge (d : Dart G) : E := edgeI G d.i
-
--- lemma edge_eq_edgeI (d : Dart G) : d.edge = edgeI G d.i := by rfl
-
--- lemma edge_eq_edgeO (d : Dart G) : d.edge = edgeO G d.o := by rw [←d.inc.1]; rfl
-
--- lemma edge_mem (d : Dart G) : d.edge ∈ edges G := mapsTo_edgeI d.inFlag_mem
-
 lemma edge_mem (d : Dart G) : d.edge ∈ edges G := mem_edges_of_isSource d.isSource
-
--- lemma isEdgeSource (d : Dart G) : IsEdgeSource G d.edge d.src :=
---   ⟨d.i, d.inFlag_mem, rfl, d.edge_eq_edgeI⟩
-
--- lemma isEdgeTarget (d : Dart G) : IsEdgeTarget G d.edge d.tgt :=
---   ⟨d.o, d.outFlag_mem, rfl, d.edge_eq_edgeO.symm⟩
-
--- noncomputable def ofEdge {e : E} {x y : V} (hsrc : IsEdgeSource G e x) (htgt : IsEdgeTarget G e y) :
---     Dart G where
---   i := Classical.choose hsrc
---   o := Classical.choose htgt
---   inc :=
---     have ⟨hi, _, hei⟩ := Classical.choose_spec hsrc
---     have ⟨ho, _, heo⟩ := Classical.choose_spec htgt
---     ⟨hei.trans heo.symm, hi, ho⟩
-
--- lemma ext_edge {d d' : Dart G} (hsrc : d.src = d'.src) (htgt : d.tgt = d'.tgt)
---     (hedge : d.edge = d'.edge) : d = d' := by
---   ext
---   · exact eq_of_source_eq_of_edgeI_eq d.inFlag_mem d'.inFlag_mem hsrc hedge
---   · apply eq_of_target_eq_of_edgeO_eq d.outFlag_mem d'.outFlag_mem htgt
---     simp_rw [←edge_eq_edgeO]
---     assumption
-
--- lemma adj (d : Dart G) : Adj G d.src d.tgt := ⟨d.edge, d.edge_mem, d.isEdgeSource, d.isEdgeTarget⟩
 
 lemma adj (d : Dart G) : Adj G d.source d.target := ⟨d.edge, d.isSource, d.isTarget⟩
 
@@ -181,20 +76,12 @@ end HyperGraphLike
 
 open HyperGraphLike
 
-class GraphLike (V E : outParam Type*) (Gr : Type*) extends
+class DirGraphLike (V E : outParam Type*) (Gr : Type*) extends
     HyperGraphLike V E Gr where
-  -- injOn_edgeI : ∀ ⦃G⦄, Set.InjOn (edgeI G) (inFlags G)
-  -- injOn_edgeO : ∀ ⦃G⦄, Set.InjOn (edgeO G) (outFlags G)
   exists_unique_isSource_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! x, IsSource G e x
   exists_unique_isTarget_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! x, IsTarget G e x
-  -- flagI : Gr → E → I
-  -- flagO : Gr → E → O
-  -- mapsTo_flagI : ∀ ⦃G⦄, Set.MapsTo (flagI G) (edges G) (inFlags G)
-  -- invOn_flagI : ∀ ⦃G⦄, Set.InvOn (flagI G) (edgeI G) (inFlags G) (edges G)
-  -- mapsTo_flagO : ∀ ⦃G⦄, Set.MapsTo (flagO G) (edges G) (outFlags G)
-  -- invOn_flagO : ∀ ⦃G⦄, Set.InvOn (flagO G) (edgeO G) (outFlags G) (edges G)
 
-namespace GraphLike
+namespace DirGraphLike
 
 @[implicit_reducible]
 def ofIsLink (verts : Gr → Set V) (edges : Gr → Set E)
@@ -204,11 +91,9 @@ def ofIsLink (verts : Gr → Set V) (edges : Gr → Set E)
     (mem_verts_right_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → y ∈ verts G)
     (eq_and_eq_of_isLink_of_isLink : ∀ ⦃G e x x' y y'⦄,
       IsLink G e x y → IsLink G e x' y' → x = x' ∧ y = y') :
-    GraphLike V E Gr
+    DirGraphLike V E Gr
     where
   verts := verts
-  -- inFlags G := {d | ∃ y, IsLink G d.1 d.2 y}
-  -- outFlags G := {d | ∃ x, IsLink G d.1 x d.2}
   edges := edges
   IsSource G e x := ∃ y, IsLink G e x y
   IsTarget G e y := ∃ x, IsLink G e x y
@@ -226,54 +111,12 @@ def ofIsLink (verts : Gr → Set V) (edges : Gr → Set E)
       exact ⟨y, x, h⟩
     · intro y y' ⟨x, hx⟩ ⟨x', hx'⟩
       exact eq_and_eq_of_isLink_of_isLink hx hx' |>.2
-  -- target G d := d.2
-  -- source G d := d.2
-  -- edgeI G d := d.1
-  -- edgeO G d := d.1
-  -- mapsTo_source G d := fun ⟨_, hd⟩ => mem_verts_left_of_isLink hd
-  -- mapsTo_target G d := fun ⟨_, hd⟩ => mem_verts_right_of_isLink hd
-  -- mapsTo_edgeI G d := fun ⟨y, hd⟩ => mem_edges_iff_exists_isLink.mpr ⟨d.2, y, hd⟩
-  -- mapsTo_edgeO G d := fun ⟨x, hd⟩ => mem_edges_iff_exists_isLink.mpr ⟨x, d.2, hd⟩
-  -- eq_of_source_eq_of_edgeI_eq _ i i' _ _ _ _ := by cases i; cases i'; congr
-  -- eq_of_target_eq_of_edgeO_eq _ o o' _ _ _ _ := by cases o; cases o'; congr
-  -- flagI G e :=
-  --   have : Decidable (∃ x y, IsLink G e x y) := Classical.propDecidable _
-  --   if h : ∃ x y, IsLink G e x y then ⟨e, Classical.choose h⟩ else ⟨e, Classical.arbitrary V⟩
-  -- flagO G e :=
-  --   have : Decidable (∃ y x, IsLink G e x y) := Classical.propDecidable _
-  --   if h : ∃ y x, IsLink G e x y then ⟨e, Classical.choose h⟩ else ⟨e, Classical.arbitrary V⟩
-  -- mapsTo_flagI G e he := by
-  --   rw [mem_edges_iff_exists_isLink] at he
-  --   simp [he, Classical.choose_spec he]
-  -- invOn_flagI G := by
-  --   refine ⟨?_, ?_⟩
-  --   · intro ⟨e, x⟩ ⟨y, h⟩
-  --     have h' : ∃ x y, IsLink G e x y := ⟨x, y, h⟩
-  --     simp only [h', ↓reduceDIte, Prod.mk.injEq, true_and]
-  --     exact eq_and_eq_of_isLink_of_isLink (Classical.choose_spec <| Classical.choose_spec h') h |>.1
-  --   · intro e he
-  --     have h' : ∃ x y, IsLink G e x y := mem_edges_iff_exists_isLink.mp he
-  --     simp only [h', ↓reduceDIte]
-  -- mapsTo_flagO G e he := by
-  --   obtain ⟨x, y, he⟩ := by rwa [mem_edges_iff_exists_isLink] at he
-  --   replace he : ∃ y x, IsLink G e x y := ⟨y, x, he⟩
-  --   simp [he, Classical.choose_spec he]
-  -- invOn_flagO G := by
-  --   refine ⟨?_, ?_⟩
-  --   · intro ⟨e, y⟩ ⟨x, h⟩
-  --     have h' : ∃ y x, IsLink G e x y := ⟨y, x, h⟩
-  --     simp only [h', ↓reduceDIte, Prod.mk.injEq, true_and]
-  --     exact eq_and_eq_of_isLink_of_isLink (Classical.choose_spec <| Classical.choose_spec h') h |>.2
-  --   · intro e he
-  --     obtain ⟨x, y, h⟩ : ∃ x y, IsLink G e x y := mem_edges_iff_exists_isLink.mp he
-  --     have h' : ∃ y x, IsLink G e x y := ⟨y, x, h⟩
-  --     simp only [h', ↓reduceDIte]
 
 @[implicit_reducible]
 def ofSourceTarget (verts : Gr → Set V) (edges : Gr → Set E) (src : Gr → E → V) (tgt : Gr → E → V)
     (mem_verts_src : ∀ ⦃G e⦄, e ∈ edges G → src G e ∈ verts G)
     (mem_verts_tgt : ∀ ⦃G e⦄, e ∈ edges G → tgt G e ∈ verts G) :
-    GraphLike V E Gr where
+    DirGraphLike V E Gr where
   verts := verts
   edges := edges
   IsSource G e x := e ∈ edges G ∧ src G e = x
@@ -288,31 +131,8 @@ def ofSourceTarget (verts : Gr → Set V) (edges : Gr → Set E) (src : Gr → E
   exists_unique_isTarget_of_mem_edges G e he := by
     use tgt G e
     grind
-  -- inFlags := edges
-  -- outFlags := edges
-  -- source := src
-  -- target := tgt
-  -- edgeI _ := id
-  -- edgeO _ := id
-  -- mapsTo_source := mem_verts_src
-  -- mapsTo_target := mem_verts_tgt
-  -- mapsTo_edgeI _ _ := id
-  -- mapsTo_edgeO _ _ := id
-  -- eq_of_source_eq_of_edgeI_eq _ _ _ _ _ _ := id
-  -- eq_of_target_eq_of_edgeO_eq _ _ _ _ _ _ := id
-  -- injOn_edgeI _ := Set.injOn_id _
-  -- injOn_edgeO _ := Set.injOn_id _
 
-variable [GraphLike V E Gr] {G : Gr}
-
--- lemma invOn_edgeI : Set.InvOn (edgeI G) (flagI G) (edges G) (inFlags G) :=
---   (invOn_flagI (G := G)).symm
-
--- lemma bijOn_flagI : Set.BijOn (flagI G) (edges G) (inFlags G) :=
---   invOn_flagI.symm.bijOn (mapsTo_flagI (G := G)) (mapsTo_edgeI (G := G))
-
--- lemma bijOn_edgeI : Set.BijOn (edgeI G) (inFlags G) (edges G) :=
---   invOn_flagI.bijOn (mapsTo_edgeI (G := G)) (mapsTo_flagI (G := G))
+variable [DirGraphLike V E Gr] {G : Gr}
 
 noncomputable def edgeSource {G : Gr} {e : E} (he : e ∈ edges G) : V :=
   Classical.choose (exists_unique_isSource_of_mem_edges he)
@@ -320,39 +140,6 @@ noncomputable def edgeSource {G : Gr} {e : E} (he : e ∈ edges G) : V :=
 lemma isSource_iff (e : E) (x : V) : IsSource G e x ↔ ∃ h : e ∈ edges G, edgeSource h = x := by
   simp_rw [edgeSource, ExistsUnique.choose_eq_iff]
   exact ⟨fun h => ⟨mem_edges_of_isSource h, h⟩, fun ⟨_, h⟩ => h⟩
-  -- constructor
-  -- · intro h
-  --   use mem_edges_of_isSource h
-  --   rwa [edgeSource, ExistsUnique.choose_eq_iff]
-  -- · intro ⟨_, h⟩
-
-  -- rw [IsEdgeSource, edgeSource]
-  -- constructor
-  -- · intro ⟨i, hi, hx, he⟩
-  --   rw [←he, invOn_edgeI.2 hi]
-  --   exact ⟨mapsTo_edgeI hi, hx⟩
-  -- · rintro ⟨he, rfl⟩
-  --   use flagI G e, mapsTo_flagI he, rfl, invOn_edgeI.1 he
-
--- lemma invOn_edgeO : Set.InvOn (edgeO G) (flagO G) (edges G) (outFlags G) :=
---   (invOn_flagO (G := G)).symm
-
--- lemma bijOn_flagO : Set.BijOn (flagO G) (edges G) (outFlags G) :=
---   invOn_flagO.symm.bijOn (mapsTo_flagO (G := G)) (mapsTo_edgeO (G := G))
-
--- lemma bijOn_edgeO : Set.BijOn (edgeO G) (outFlags G) (edges G) :=
---   invOn_flagO.bijOn (mapsTo_edgeO (G := G)) (mapsTo_flagO (G := G))
-
--- def edgeTarget (G : Gr) (e : E) : V := target G <| flagO G e
-
--- lemma isEdgeTarget_iff (e : E) (x : V) : IsEdgeTarget G e x ↔ e ∈ edges G ∧ edgeTarget G e = x := by
---   rw [IsEdgeTarget, edgeTarget]
---   constructor
---   · intro ⟨o, ho, hx, he⟩
---     rw [←he, invOn_edgeO.2 ho]
---     exact ⟨mapsTo_edgeO ho, hx⟩
---   · rintro ⟨he, rfl⟩
---     use flagO G e, mapsTo_flagO he, rfl, invOn_flagO.2 he
 
 noncomputable def edgeTarget {G : Gr} {e : E} (he : e ∈ edges G) : V :=
   Classical.choose (exists_unique_isTarget_of_mem_edges he)
@@ -361,49 +148,33 @@ lemma isTarget_iff (e : E) (x : V) : IsTarget G e x ↔ ∃ h : e ∈ edges G, e
   simp_rw [edgeTarget, ExistsUnique.choose_eq_iff]
   exact ⟨fun h => ⟨mem_edges_of_isTarget h, h⟩, fun ⟨_, h⟩ => h⟩
 
-end GraphLike
+end DirGraphLike
 
-open GraphLike
+open DirGraphLike
 
-class SimpleGraphLike (V E : outParam Type*) (Gr : Type*) extends GraphLike V E Gr where
-  eq_of_isSource_isSource_isTarget_isTarget : ∀ ⦃G e e' x y⦄,
-    IsSource G e x → IsSource G e' x → IsTarget G e y → IsTarget G e' y → e = e'
-  -- eq_of_source_eq_of_target_eq : ∀ ⦃G e e'⦄, source G (flagI G e) = source G (flagI G e') →
-  --   target G (flagO G e) = target G (flagO G e') → e = e'
+class SimpleHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends HyperGraphLike V E Gr where
+  eq_of_isSource_eq_of_isTarget_eq : ∀ ⦃G e e'⦄, e ∈ edges G → e' ∈ edges G →
+      (∀ x, IsSource G e x ↔ IsSource G e' x) → (∀ y, IsTarget G e y ↔ IsTarget G e' y) → e = e'
 
 class IrreflHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends
     HyperGraphLike V E Gr where
   not_isSource_isTarget : ∀ ⦃G e x⦄, ¬ (IsSource G e x ∧ IsTarget G e x)
-  -- edgeI_ne_edgeO_of_source_eq_target : ∀ ⦃G i o⦄, source G i = target G o → edgeI G i ≠ edgeO G o
 
 class SymmHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends
     HyperGraphLike V E Gr where
-  inv : Gr → E → E -- this is non-canonical outside of `edges G`
-  inv_inv_eq : ∀ ⦃G e⦄, inv G (inv G e) = e
-  isSource_iff_isTarget_inv : ∀ ⦃G e x⦄, IsSource G e x ↔ IsTarget G (inv G e) x
-  -- swapIO : Gr → I → O
-  -- swapOI : Gr → O → I
-  -- edgeO_swapIO_eq : ∀ ⦃G i⦄, i ∈ inFlags G → edgeO G (swapIO G i) = edgeI G i
-  -- edgeI_swapOI_eq : ∀ ⦃G o⦄, o ∈ outFlags G → edgeI G (swapOI G o) = edgeO G o
-  -- mapsTo_swapIO : ∀ ⦃G⦄, Set.MapsTo (swapIO G) (inFlags G) (outFlags G)
-  -- mapsTo_swapOI : ∀ ⦃G⦄, Set.MapsTo (swapOI G) (outFlags G) (inFlags G)
-  -- invOn_swap : ∀ ⦃G⦄, Set.InvOn (swapOI G) (swapIO G) (inFlags G) (outFlags G)
+  isSource_iff_isTarget : ∀ ⦃G e x⦄, IsSource G e x ↔ IsTarget G e x
 
-instance : GraphLike V (V × V) (Digraph V) := ofSourceTarget (Gr := Digraph V)
+instance : DirGraphLike V (V × V) (Digraph V) := ofSourceTarget (Gr := Digraph V)
   (verts := fun _ => Set.univ) (edges := fun G => {p : V × V | G.Adj p.1 p.2})
   (src := fun _ => Prod.fst) (tgt := fun _ => Prod.snd)
   (mem_verts_src := fun _ _ _ => trivial) (mem_verts_tgt := fun _ _ _ => trivial)
 
-instance : SimpleGraphLike V (V × V) (Digraph V) where
-  eq_of_isSource_isSource_isTarget_isTarget G := by
-    intro ⟨x, y⟩ ⟨x', y'⟩ _ _ ⟨_, hx⟩ ⟨_, hx'⟩ ⟨_, hy⟩ ⟨_, hy'⟩
-    congr
-    · exact hx.trans hx'.symm
-    · exact hy.trans hy'.symm
-    -- cases
-    -- obtain ⟨_, _⟩ := hx
+instance : SimpleHyperGraphLike V (V × V) (Digraph V) where
+  eq_of_isSource_eq_of_isTarget_eq := by
+    intro G ⟨x, y⟩ ⟨x', y'⟩ h h' hx hy
+    simp_all [IsSource, IsTarget, edges]
 
-instance : GraphLike V (E × V × V) (Graph V E) := by
+instance : DirGraphLike V (E × V × V) (Graph V E) := by
   refine ofIsLink Graph.vertexSet (fun G => {p | G.IsLink p.1 p.2.1 p.2.2})
     (fun G e x y => e.2.1 = x ∧ e.2.2 = y ∧ G.IsLink e.1 x y) ?_ ?_ ?_ ?_
   · simp
@@ -413,23 +184,18 @@ instance : GraphLike V (E × V × V) (Graph V E) := by
     exact h.right_mem
   · rintro G ⟨e, z⟩ x x' y y' ⟨rfl, rfl, h⟩ ⟨rfl, rfl, h'⟩
     simp
-  --   exact ⟨rfl, h.right_unique h'⟩
-  -- · rintro G (e | e) x y h <;> exact G.left_mem_of_isLink h
-  -- · rintro G (e | e) x y h <;> exact h.right_mem
-  -- · rintro G (e | e) x x' y y' h h'
-    -- · simp at h
 
-instance : SymmHyperGraphLike V (E × V × V) (Graph V E) where
-  inv G := fun ⟨e, x, y⟩ => ⟨e, y, x⟩
-  inv_inv_eq G := by simp
-  isSource_iff_isTarget_inv G := by
-    rintro ⟨e, x, y⟩ x'
-    simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
-      and_congr_right_iff]
-    rintro rfl
-    exact G.isLink_comm
+-- instance : SymmHyperGraphLike V (E × V × V) (Graph V E) where
+--   inv G := fun ⟨e, x, y⟩ => ⟨e, y, x⟩
+--   inv_inv_eq G := by simp
+--   isSource_iff_isTarget_inv G := by
+--     rintro ⟨e, x, y⟩ x'
+--     simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
+--       and_congr_right_iff]
+--     rintro rfl
+--     exact G.isLink_comm
 
-instance : GraphLike V (V × V) (SimpleGraph V) := by
+instance : DirGraphLike V (V × V) (SimpleGraph V) := by
   refine ofIsLink (fun G => Set.univ) (fun G => {p | G.Adj p.1 p.2})
     (fun G e x y => e.1 = x ∧ e.2 = y ∧ G.Adj x y) ?_ ?_ ?_ ?uniq
   case uniq =>
@@ -437,15 +203,15 @@ instance : GraphLike V (V × V) (SimpleGraph V) := by
     exact ⟨rfl, rfl⟩
   all_goals simp
 
-instance : SymmHyperGraphLike V (V × V) (SimpleGraph V) where
-  inv G := fun ⟨x, y⟩ => ⟨y, x⟩
-  inv_inv_eq G := by simp
-  isSource_iff_isTarget_inv G := by
-    intro ⟨x, y⟩ _
-    simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
-      and_congr_right_iff]
-    rintro rfl
-    exact G.adj_comm ..
+-- instance : SymmHyperGraphLike V (V × V) (SimpleGraph V) where
+--   inv G := fun ⟨x, y⟩ => ⟨y, x⟩
+--   inv_inv_eq G := by simp
+--   isSource_iff_isTarget_inv G := by
+--     intro ⟨x, y⟩ _
+--     simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
+--       and_congr_right_iff]
+--     rintro rfl
+--     exact G.adj_comm ..
 
 instance : IrreflHyperGraphLike V (V × V) (SimpleGraph V) where
   not_isSource_isTarget G := by
@@ -454,36 +220,3 @@ instance : IrreflHyperGraphLike V (V × V) (SimpleGraph V) where
       not_and, and_imp]
     rintro rfl h rfl
     exact G.irrefl
-
--- class HyperGraphLike₂ (V E : outParam Type*) (Gr : Type*) where
---   verts : Gr → Set V
---   edges : Gr → Set E
---   IsSource : Gr → E → V → Prop
---   IsTarget : Gr → E → V → Prop
---   mem_verts_of_isSource : ∀ ⦃G e v⦄, e ∈ edges G → IsSource G e v → v ∈ verts G
---   mem_verts_of_isTarget : ∀ ⦃G e v⦄, e ∈ edges G → IsTarget G e v → v ∈ verts G
---   mem_edges_of_isSource : ∀ ⦃G e v⦄, e ∈ edges G → IsSource G e v → e ∈ edges G
---   mem_edges_of_isTarget : ∀ ⦃G e v⦄, e ∈ edges G → IsTarget G e v → e ∈ edges G
-
--- namespace HyperGraphLike₂
-
--- variable [HyperGraphLike₂ V E Gr]
-
--- def Adj (G : Gr) (x y : V) : Prop := ∃ e ∈ edges G, IsSource G e x ∧ IsTarget G e y
-
--- def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsSource G e x ∧ IsTarget G e y
-
--- structure Dart (G : Gr) where
---   s : V
---   t : V
---   e : E
---   isSource : IsSource G e s
---   isTarget : IsTarget G e t
-
--- end HyperGraphLike₂
-
--- class GraphLike₂ (V E : outParam Type*) (Gr : Type*) extends HyperGraphLike₂ V E Gr where
---   source : Gr → E → V
---   target : Gr → E → V
---   isSource_iff : ∀ ⦃G e v⦄, e ∈ edges G → (IsSource G e v ↔ v = source G e)
---   isTarget_iff : ∀ ⦃G e v⦄, e ∈ edges G → (IsTarget G e v ↔ v = target G e)

--- a/Mathlib/Combinatorics/GraphLike/Basic.lean
+++ b/Mathlib/Combinatorics/GraphLike/Basic.lean
@@ -14,45 +14,75 @@ public import Mathlib.Combinatorics.Digraph.Basic
 
 public section
 
+open Prod Set
+
 variable {V H I O E Gr : Type*}
 
 class HyperGraphLike (V I O E : outParam Type*) (Gr : Type*) where
   verts : Gr → Set V
   edges : Gr → Set E
-  source : Gr → I →. V
-  target : Gr → O →. V
-  edgeI : Gr → I →. E
-  edgeO : Gr → O →. E
-  dom_source_eq_dom_edgeI : ∀ ⦃G⦄, (source G).Dom = (edgeI G).Dom
-  dom_target_eq_dom_edgeO : ∀ ⦃G⦄, (target G).Dom = (edgeO G).Dom
-  ran_source_subset_verts : ∀ ⦃G⦄, (source G).ran ⊆ verts G
-  ran_target_subset_verts : ∀ ⦃G⦄, (target G).ran ⊆ verts G
-  ran_edgeI_subset_edges : ∀ ⦃G⦄, (edgeI G).ran ⊆ edges G
-  ran_edgeO_subset_edges : ∀ ⦃G⦄, (edgeO G).ran ⊆ edges G
+  input : Gr → I →. V × E
+  output : Gr → O →. V × E
+  ran_input_subset : ∀ ⦃G⦄, (input G).ran ⊆ verts G ×ˢ edges G
+  ran_output_subset : ∀ ⦃G⦄, (output G).ran ⊆ verts G ×ˢ edges G
+  eq_of_mem_input_of_mem_input : ∀ ⦃G i i' x e⦄,
+      (x, e) ∈ input G i → (x, e) ∈ input G i' → i = i'
+  eq_of_mem_output_of_mem_output : ∀ ⦃G o o' x e⦄,
+      (x, e) ∈ output G o → (x, e) ∈ output G o' → o = o'
 
 namespace HyperGraphLike
 
 variable [HyperGraphLike V I O E Gr] {G : Gr}
 
--- def inFlags (G : Gr) : Set I := (source G).Dom
+@[expose]
+def inFlags (G : Gr) : Set I := (input G).Dom
 
--- def outFlags (G : Gr) : Set O := (target G).Dom
+@[expose]
+def outFlags (G : Gr) : Set O := (output G).Dom
 
-def mem_verts_of_mem_source {v : V} {i : I} (h : v ∈ source G i) : v ∈ verts G :=
-  ran_source_subset_verts ⟨i, h⟩
+@[expose]
+def source (G : Gr) : I →. V := fun i => ⟨(input G i).Dom, fst ∘ (input G i).get⟩
 
-def mem_verts_of_mem_target {v : V} {o : O} (h : v ∈ target G o) : v ∈ verts G :=
-  ran_target_subset_verts ⟨o, h⟩
+@[expose]
+def target (G : Gr) : O →. V := fun i => ⟨(output G i).Dom, fst ∘ (output G i).get⟩
 
-def mem_edges_of_mem_edgeI {e : E} {i : I} (h : e ∈ edgeI G i) : e ∈ edges G :=
-  ran_edgeI_subset_edges ⟨i, h⟩
+@[expose]
+def edgeIn (G : Gr) : I →. E := fun i => ⟨(input G i).Dom, snd ∘ (input G i).get⟩
 
-def mem_edges_of_mem_edgeO {e : E} {o : O} (h : e ∈ edgeO G o) : e ∈ edges G :=
-  ran_edgeO_subset_edges ⟨o, h⟩
+@[expose]
+def edgeOut (G : Gr) : O →. E := fun i => ⟨(output G i).Dom, snd ∘ (output G i).get⟩
 
-def IsEdgeSource (G : Gr) (e : E) (v : V) : Prop := ∃ i, v ∈ source G i ∧ e ∈ edgeI G i
+lemma input_eq_source_edgeIn {G : Gr} {i : I} (hi : i ∈ inFlags G) :
+    ⟨source G i |>.get hi, edgeIn G i |>.get hi⟩ = (input G i).get hi := by
+  simp [source, edgeIn]
 
-def IsEdgeTarget (G : Gr) (e : E) (v : V) : Prop := ∃ o, v ∈ target G o ∧ e ∈ edgeO G o
+lemma output_eq_target_edgeOut {G : Gr} {o : O} (ho : o ∈ outFlags G) :
+    ⟨target G o |>.get ho, edgeOut G o |>.get ho⟩ = (output G o).get ho := by
+  simp [target, edgeOut]
+
+lemma mem_verts_of_mem_source {v : V} {i : I} (h : v ∈ source G i) : v ∈ verts G := by
+  obtain ⟨hi, h⟩ := h
+  simp only [source, Function.comp_apply] at h
+  exact h ▸ (ran_input_subset ⟨i, hi, rfl⟩).1
+
+lemma mem_verts_of_mem_target {v : V} {o : O} (h : v ∈ target G o) : v ∈ verts G := by
+  obtain ⟨ho, h⟩ := h
+  simp only [target, Function.comp_apply] at h
+  exact h ▸ (ran_output_subset ⟨o, ho, rfl⟩).1
+
+lemma mem_edges_of_mem_edgeIn {e : E} {i : I} (h : e ∈ edgeIn G i) : e ∈ edges G := by
+  obtain ⟨hi, h⟩ := h
+  simp only [edgeIn, Function.comp_apply] at h
+  exact h ▸ (ran_input_subset ⟨i, hi, rfl⟩).2
+
+lemma mem_edges_of_mem_edgeOut {e : E} {o : O} (h : e ∈ edgeOut G o) : e ∈ edges G := by
+  obtain ⟨ho, h⟩ := h
+  simp only [edgeOut, Function.comp_apply] at h
+  exact h ▸ (ran_output_subset ⟨o, ho, rfl⟩).2
+
+def IsEdgeSource (G : Gr) (e : E) (v : V) : Prop := ⟨v, e⟩ ∈ (input G).ran
+
+def IsEdgeTarget (G : Gr) (e : E) (v : V) : Prop := ⟨v, e⟩ ∈ (output G).ran
 
 def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsEdgeSource G e x ∧ IsEdgeTarget G e y
 
@@ -63,37 +93,64 @@ def ofIsSourceIsTarget (verts : Gr → Set V) (edges : Gr → Set E)
     (mem_edges_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → e ∈ edges G)
     (mem_verts_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → v ∈ verts G)
     (mem_edges_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → e ∈ edges G)
-    : HyperGraphLike V (E × V) (E × V) E Gr where
+    : HyperGraphLike V (V × E) (V × E) E Gr where
   verts := verts
   edges := edges
-  source G d := ⟨IsEdgeSource G d.1 d.2, fun _ => d.2⟩
-  target G d := ⟨IsEdgeTarget G d.1 d.2, fun _ => d.2⟩
-  edgeI G d := ⟨IsEdgeSource G d.1 d.2, fun _ => d.1⟩
-  edgeO G d := ⟨IsEdgeTarget G d.1 d.2, fun _ => d.1⟩
-  dom_source_eq_dom_edgeI _ := rfl
-  dom_target_eq_dom_edgeO _ := rfl
-  ran_source_subset_verts _ _ := fun ⟨_, h, h'⟩ => h' ▸ mem_verts_of_isEdgeSource h
-  ran_target_subset_verts _ _ := fun ⟨_, h, h'⟩ => h' ▸ mem_verts_of_isEdgeTarget h
-  ran_edgeI_subset_edges _ _ := fun ⟨_, h, h'⟩ => h' ▸ mem_edges_of_isEdgeSource h
-  ran_edgeO_subset_edges _ _ := fun ⟨_, h, h'⟩ => h' ▸ mem_edges_of_isEdgeTarget h
+  input G d := ⟨IsEdgeSource G d.2 d.1, fun _ => d⟩
+  output G d := ⟨IsEdgeTarget G d.2 d.1, fun _ => d⟩
+  ran_input_subset _ := by
+    rintro ⟨v, e⟩ ⟨⟨v', e'⟩, hdom, rfl, _⟩
+    exact ⟨mem_verts_of_isEdgeSource hdom, mem_edges_of_isEdgeSource hdom⟩
+  ran_output_subset _ := by
+    rintro ⟨v, e⟩ ⟨⟨v', e'⟩, hdom, rfl, _⟩
+    exact ⟨mem_verts_of_isEdgeTarget hdom, mem_edges_of_isEdgeTarget hdom⟩
+  eq_of_mem_input_of_mem_input := by simp_all
+  eq_of_mem_output_of_mem_output := by simp_all
 
-def Adj (G : Gr) (x y : V) : Prop := ∃ e ∈ edges G, IsEdgeSource G e x ∧ IsEdgeTarget G e y
+def Adj (G : Gr) (x y : V) : Prop := ∃ e, IsEdgeSource G e x ∧ IsEdgeTarget G e y
 
-def FlagsInc (G : Gr) (i : I) (o : O) : Prop := ∃ e, e ∈ edgeI G i ∧ e ∈ edgeO G o
+def FlagInc (G : Gr) (i : I) (o : O) : Prop := ∃ e, e ∈ edgeIn G i ∧ e ∈ edgeOut G o
 
-lemma Adj.iff_exists_inFlag_outFlag {G : Gr} {x y : V} :
-    Adj G x y ↔ ∃ i o, FlagsInc G i o ∧ x ∈ source G i ∧ y ∈ target G o := by
-  simp_rw [Adj, IsEdgeSource, IsEdgeTarget, FlagsInc]
+lemma Adj.iff_exists_inFlags_outFlags {G : Gr} {x y : V} :
+    Adj G x y ↔ ∃ i o, FlagInc G i o ∧ x ∈ source G i ∧ y ∈ target G o := by
+  simp_rw [Adj, IsEdgeSource, IsEdgeTarget, FlagInc]
   constructor
-  · grind
-  · rintro ⟨i, o, ⟨⟨e, he⟩, he'⟩⟩
-    use! e, mem_edges_of_mem_edgeI he.1
-    grind
+  -- · intro ⟨e, o, ⟨i, hin, hxe⟩, ⟨o, hout, hye⟩⟩
+  · intro ⟨e, ⟨i, hin, he⟩, ⟨o, hout, ho⟩⟩
+    simp only [edgeIn, Part.mem_mk_iff, Function.comp_apply, edgeOut, exists_exists_eq_and, source,
+      target]
+    use! i, o, hin, hout, (by grind), hin, (by grind), (by grind)
+  · rintro ⟨i, o, ⟨e, ⟨hin, rfl⟩, ⟨hout, heout⟩⟩, ⟨hin', rfl⟩, ⟨hout', rfl⟩⟩
+    use (edgeIn G i).get hin
+    constructor
+    · use i, hin
+      exact input_eq_source_edgeIn hin
+    · use o, hout
+      rw [←heout]
+      exact (output_eq_target_edgeOut hout).symm
+
+lemma FlagInc.mem_inFlags_left {i : I} {o : O} (h : FlagInc G i o) : i ∈ inFlags G := by
+  obtain ⟨e, ⟨h, _⟩, _⟩ := h
+  exact h
+
+lemma FlagInc.mem_outFlags_right {i : I} {o : O} (h : FlagInc G i o) : o ∈ outFlags G := by
+  obtain ⟨e, _, h, _⟩ := h
+  exact h
+
+lemma FlagInc.mem_edgeIn_iff_mem_edgeOut {i : I} {o : O} (h : FlagInc G i o) (e : E) :
+    e ∈ edgeIn G i ↔ e ∈ edgeOut G o := by
+  obtain ⟨e', hei, heo⟩ := h
+  refine ⟨fun he => ?_, fun he => ?_⟩
+  · rwa [Part.mem_unique he hei]
+  · rwa [Part.mem_unique he heo]
+
+lemma FlagInc.edgeIn_eq_edgeOut {i : I} {o : O} (h : FlagInc G i o) : edgeIn G i = edgeOut G o :=
+    Part.ext h.mem_edgeIn_iff_mem_edgeOut
 
 structure Dart (G : Gr) where
   i : I
   o : O
-  inc : FlagsInc G i o
+  inc : FlagInc G i o
 
 namespace Dart
 
@@ -101,64 +158,69 @@ namespace Dart
 protected lemma ext {d d' : Dart G} (hi : d.i = d'.i) (ho : d.o = d'.o) : d = d' := by
   cases d; cases d'; congr
 
--- lemma inFlag_mem (d : Dart G) : d.i ∈ inFlags G := d.inc.2.1
+lemma mem_inFlags (d : Dart G) : d.i ∈ inFlags G := d.inc.mem_inFlags_left
 
--- lemma outFlag_mem (d : Dart G) : d.o ∈ outFlags G := d.inc.2.2
+lemma mem_outFlags (d : Dart G) : d.o ∈ outFlags G := d.inc.mem_outFlags_right
 
--- def src (d : Dart G) : V := source G d.i
+def src (d : Dart G) : V := (source G d.i).get d.mem_inFlags
 
--- lemma src_mem (d : Dart G) : d.src ∈ verts G := mapsTo_source d.inFlag_mem
+lemma src_mem (d : Dart G) : d.src ∈ verts G :=
+  mem_verts_of_mem_source (Part.get_mem _)
 
-def isSource (d : Dart G) : IsSource G d.edge d.source := d.isLink.1
+-- def isSource (d : Dart G) : IsSource G d.edge d.source := d.isLink.1
 
-lemma source_mem (d : Dart G) : d.source ∈ verts G := mem_verts_of_isSource d.isSource
+def tgt (d : Dart G) : V := (target G d.o).get d.mem_outFlags
 
--- def tgt (d : Dart G) : V := target G d.o
+lemma tgt_mem (d : Dart G) : d.tgt ∈ verts G :=
+  mem_verts_of_mem_target (Part.get_mem _)
 
--- lemma tgt_mem (d : Dart G) : d.tgt ∈ verts G := mapsTo_target d.outFlag_mem
+-- def isTarget (d : Dart G) : IsTarget G d.edge d.target := d.isLink.2
 
-def isTarget (d : Dart G) : IsTarget G d.edge d.target := d.isLink.2
+def edge (d : Dart G) : E := (edgeIn G d.i).get d.mem_inFlags
 
-lemma target_mem (d : Dart G) : d.target ∈ verts G := mem_verts_of_isTarget d.isLink.2
+lemma edge_mem_edgeIn (d : Dart G) : d.edge ∈ edgeIn G d.i := Part.get_mem _
 
--- def edge (d : Dart G) : E := edgeI G d.i
+lemma edge_mem_edgeOut (d : Dart G) : d.edge ∈ edgeOut G d.o :=
+  d.inc.mem_edgeIn_iff_mem_edgeOut _ |>.mp d.edge_mem_edgeIn
 
--- lemma edge_eq_edgeI (d : Dart G) : d.edge = edgeI G d.i := by rfl
+lemma isEdgeSource (d : Dart G) : IsEdgeSource G d.edge d.src := by
+  refine ⟨d.i, d.mem_inFlags, ?_⟩
+  simp [src, edge, input_eq_source_edgeIn]
 
--- lemma edge_eq_edgeO (d : Dart G) : d.edge = edgeO G d.o := by rw [←d.inc.1]; rfl
+lemma isEdgeTarget (d : Dart G) : IsEdgeTarget G d.edge d.tgt := by
+  refine ⟨d.o, d.mem_outFlags, ?_⟩
+  simp only [← output_eq_target_edgeOut, tgt, edge, d.inc.edgeIn_eq_edgeOut]
 
--- lemma edge_mem (d : Dart G) : d.edge ∈ edges G := mapsTo_edgeI d.inFlag_mem
+noncomputable def ofEdge {e : E} {x y : V} (hsrc : IsEdgeSource G e x) (htgt : IsEdgeTarget G e y) :
+    Dart G where
+  i := Classical.choose hsrc
+  o := Classical.choose htgt
+  inc := by
+    have ⟨hin, hget⟩ := Classical.choose_spec hsrc
+    have ⟨hout, hget'⟩ := Classical.choose_spec htgt
+    refine ⟨e, ⟨hin, ?_⟩, ⟨hout, ?_⟩⟩
+    · simp [edgeIn, hget]
+    · simp [edgeOut, hget']
 
-lemma edge_mem (d : Dart G) : d.edge ∈ edges G := mem_edges_of_isSource d.isSource
+lemma ext_edge {d d' : Dart G} (hsrc : d.src = d'.src) (htgt : d.tgt = d'.tgt)
+    (hedge : d.edge = d'.edge) : d = d' := by
+  ext
+  · apply eq_of_mem_input_of_mem_input (G := G) (x := d.src) (e := d.edge)
+    all_goals simp_rw [Part.mem_eq, ←input_eq_source_edgeIn]
+    · use d.mem_inFlags
+      simpa using ⟨rfl, rfl⟩
+    · use d'.mem_inFlags
+      simpa [hsrc, hedge] using ⟨rfl, rfl⟩
+  · apply eq_of_mem_output_of_mem_output (G := G) (x := d.tgt) (e := d.edge)
+    all_goals simp_rw [Part.mem_eq, ←output_eq_target_edgeOut]
+    · use d.mem_outFlags
+      simpa [←d.inc.edgeIn_eq_edgeOut] using ⟨rfl, rfl⟩
+    · use d'.mem_outFlags
+      simpa [htgt, hedge, ←d'.inc.edgeIn_eq_edgeOut] using ⟨rfl, rfl⟩
 
--- lemma isEdgeSource (d : Dart G) : IsEdgeSource G d.edge d.src :=
---   ⟨d.i, d.inFlag_mem, rfl, d.edge_eq_edgeI⟩
+lemma adj (d : Dart G) : Adj G d.src d.tgt := ⟨d.edge, d.isEdgeSource, d.isEdgeTarget⟩
 
--- lemma isEdgeTarget (d : Dart G) : IsEdgeTarget G d.edge d.tgt :=
---   ⟨d.o, d.outFlag_mem, rfl, d.edge_eq_edgeO.symm⟩
-
--- noncomputable def ofEdge {e : E} {x y : V} (hsrc : IsEdgeSource G e x) (htgt : IsEdgeTarget G e y) :
---     Dart G where
---   i := Classical.choose hsrc
---   o := Classical.choose htgt
---   inc :=
---     have ⟨hi, _, hei⟩ := Classical.choose_spec hsrc
---     have ⟨ho, _, heo⟩ := Classical.choose_spec htgt
---     ⟨hei.trans heo.symm, hi, ho⟩
-
--- lemma ext_edge {d d' : Dart G} (hsrc : d.src = d'.src) (htgt : d.tgt = d'.tgt)
---     (hedge : d.edge = d'.edge) : d = d' := by
---   ext
---   · exact eq_of_source_eq_of_edgeI_eq d.inFlag_mem d'.inFlag_mem hsrc hedge
---   · apply eq_of_target_eq_of_edgeO_eq d.outFlag_mem d'.outFlag_mem htgt
---     simp_rw [←edge_eq_edgeO]
---     assumption
-
--- lemma adj (d : Dart G) : Adj G d.src d.tgt := ⟨d.edge, d.edge_mem, d.isEdgeSource, d.isEdgeTarget⟩
-
-lemma adj (d : Dart G) : Adj G d.source d.target := ⟨d.edge, d.isSource, d.isTarget⟩
-
-def AdjDart (d d' : Dart G) : Prop := d.target = d'.source
+def AdjDart (d d' : Dart G) : Prop := d.tgt = d'.src
 
 end Dart
 
@@ -166,20 +228,18 @@ end HyperGraphLike
 
 open HyperGraphLike
 
-class GraphLike (V E : outParam Type*) (Gr : Type*) extends
-    HyperGraphLike V E Gr where
-  -- injOn_edgeI : ∀ ⦃G⦄, Set.InjOn (edgeI G) (inFlags G)
-  -- injOn_edgeO : ∀ ⦃G⦄, Set.InjOn (edgeO G) (outFlags G)
-  exists_unique_isSource_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! x, IsSource G e x
-  exists_unique_isTarget_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! x, IsTarget G e x
-  -- flagI : Gr → E → I
-  -- flagO : Gr → E → O
-  -- mapsTo_flagI : ∀ ⦃G⦄, Set.MapsTo (flagI G) (edges G) (inFlags G)
-  -- invOn_flagI : ∀ ⦃G⦄, Set.InvOn (flagI G) (edgeI G) (inFlags G) (edges G)
-  -- mapsTo_flagO : ∀ ⦃G⦄, Set.MapsTo (flagO G) (edges G) (outFlags G)
-  -- invOn_flagO : ∀ ⦃G⦄, Set.InvOn (flagO G) (edgeO G) (outFlags G) (edges G)
+class GraphLike (V I O E : outParam Type*) (Gr : Type*) extends
+    HyperGraphLike V I O E Gr where
+  exists_isLink_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃ x y, IsLink G e x y
+  eq_or_eq_of_isLink_of_isLink : ∀ ⦃G e x y x' y'⦄, IsLink (Gr := Gr) G e x y → IsLink G e x' y' →
+    x = x' ∧ y = y' ∨ x = y' ∧ y = x'
 
-namespace GraphLike
+class DigraphLike (V I O E : outParam Type*) (Gr : Type*) extends
+    HyperGraphLike V I O E Gr where
+  exists_unique_mem_edgeIn_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! i : I, e ∈ edgeIn G i
+  exists_unique_mem_edgeOut_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! o : O, e ∈ edgeOut G o
+
+namespace DigraphLike
 
 @[implicit_reducible]
 def ofIsLink (verts : Gr → Set V) (edges : Gr → Set E)
@@ -189,286 +249,244 @@ def ofIsLink (verts : Gr → Set V) (edges : Gr → Set E)
     (mem_verts_right_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → y ∈ verts G)
     (eq_and_eq_of_isLink_of_isLink : ∀ ⦃G e x x' y y'⦄,
       IsLink G e x y → IsLink G e x' y' → x = x' ∧ y = y') :
-    GraphLike V E Gr
+     DigraphLike V (V × E) (V × E) E Gr
     where
   verts := verts
-  -- inFlags G := {d | ∃ y, IsLink G d.1 d.2 y}
-  -- outFlags G := {d | ∃ x, IsLink G d.1 x d.2}
   edges := edges
-  IsSource G e x := ∃ y, IsLink G e x y
-  IsTarget G e y := ∃ x, IsLink G e x y
-  mem_verts_of_isSource G e x := fun ⟨_, h⟩ => mem_verts_left_of_isLink h
-  mem_verts_of_isTarget G e y := fun ⟨_, h⟩ => mem_verts_right_of_isLink h
-  mem_edges_of_isSource G e x := fun ⟨y, h⟩ => mem_edges_iff_exists_isLink |>.mpr ⟨x, y, h⟩
-  mem_edges_of_isTarget G e y := fun ⟨x, h⟩ => mem_edges_iff_exists_isLink |>.mpr ⟨x, y, h⟩
-  exists_unique_isSource_of_mem_edges G e he := by
-    apply existsUnique_of_exists_of_unique (mem_edges_iff_exists_isLink.mp he)
-    intro x x' ⟨_, hy⟩ ⟨_, hy'⟩
-    exact eq_and_eq_of_isLink_of_isLink hy hy' |>.1
-  exists_unique_isTarget_of_mem_edges G e he := by
-    apply existsUnique_of_exists_of_unique
-    · obtain ⟨x, y, h⟩ := mem_edges_iff_exists_isLink.mp he
-      exact ⟨y, x, h⟩
-    · intro y y' ⟨x, hx⟩ ⟨x', hx'⟩
-      exact eq_and_eq_of_isLink_of_isLink hx hx' |>.2
-  -- target G d := d.2
-  -- source G d := d.2
-  -- edgeI G d := d.1
-  -- edgeO G d := d.1
-  -- mapsTo_source G d := fun ⟨_, hd⟩ => mem_verts_left_of_isLink hd
-  -- mapsTo_target G d := fun ⟨_, hd⟩ => mem_verts_right_of_isLink hd
-  -- mapsTo_edgeI G d := fun ⟨y, hd⟩ => mem_edges_iff_exists_isLink.mpr ⟨d.2, y, hd⟩
-  -- mapsTo_edgeO G d := fun ⟨x, hd⟩ => mem_edges_iff_exists_isLink.mpr ⟨x, d.2, hd⟩
-  -- eq_of_source_eq_of_edgeI_eq _ i i' _ _ _ _ := by cases i; cases i'; congr
-  -- eq_of_target_eq_of_edgeO_eq _ o o' _ _ _ _ := by cases o; cases o'; congr
-  -- flagI G e :=
-  --   have : Decidable (∃ x y, IsLink G e x y) := Classical.propDecidable _
-  --   if h : ∃ x y, IsLink G e x y then ⟨e, Classical.choose h⟩ else ⟨e, Classical.arbitrary V⟩
-  -- flagO G e :=
-  --   have : Decidable (∃ y x, IsLink G e x y) := Classical.propDecidable _
-  --   if h : ∃ y x, IsLink G e x y then ⟨e, Classical.choose h⟩ else ⟨e, Classical.arbitrary V⟩
-  -- mapsTo_flagI G e he := by
-  --   rw [mem_edges_iff_exists_isLink] at he
-  --   simp [he, Classical.choose_spec he]
-  -- invOn_flagI G := by
-  --   refine ⟨?_, ?_⟩
-  --   · intro ⟨e, x⟩ ⟨y, h⟩
-  --     have h' : ∃ x y, IsLink G e x y := ⟨x, y, h⟩
-  --     simp only [h', ↓reduceDIte, Prod.mk.injEq, true_and]
-  --     exact eq_and_eq_of_isLink_of_isLink (Classical.choose_spec <| Classical.choose_spec h') h |>.1
-  --   · intro e he
-  --     have h' : ∃ x y, IsLink G e x y := mem_edges_iff_exists_isLink.mp he
-  --     simp only [h', ↓reduceDIte]
-  -- mapsTo_flagO G e he := by
-  --   obtain ⟨x, y, he⟩ := by rwa [mem_edges_iff_exists_isLink] at he
-  --   replace he : ∃ y x, IsLink G e x y := ⟨y, x, he⟩
-  --   simp [he, Classical.choose_spec he]
-  -- invOn_flagO G := by
-  --   refine ⟨?_, ?_⟩
-  --   · intro ⟨e, y⟩ ⟨x, h⟩
-  --     have h' : ∃ y x, IsLink G e x y := ⟨y, x, h⟩
-  --     simp only [h', ↓reduceDIte, Prod.mk.injEq, true_and]
-  --     exact eq_and_eq_of_isLink_of_isLink (Classical.choose_spec <| Classical.choose_spec h') h |>.2
-  --   · intro e he
-  --     obtain ⟨x, y, h⟩ : ∃ x y, IsLink G e x y := mem_edges_iff_exists_isLink.mp he
-  --     have h' : ∃ y x, IsLink G e x y := ⟨y, x, h⟩
-  --     simp only [h', ↓reduceDIte]
+  input G d := ⟨∃ y, IsLink G d.2 d.1 y, fun _ => d⟩
+  output G d := ⟨∃ x, IsLink G d.2 x d.1, fun _ => d⟩
+  ran_input_subset G := by
+    intro ⟨x, e⟩ ⟨⟨x', e'⟩, ⟨y, hlink⟩, heq⟩
+    obtain ⟨rfl, rfl⟩ : x' = x ∧ e' = e := by simpa using heq
+    exact ⟨mem_verts_left_of_isLink hlink, mem_edges_iff_exists_isLink.mpr ⟨x', y, hlink⟩⟩
+  ran_output_subset G := by
+    intro ⟨y, e⟩ ⟨⟨y', e'⟩, ⟨x, hlink⟩, heq⟩
+    obtain ⟨rfl, rfl⟩ : y' = y ∧ e' = e := by simpa using heq
+    exact ⟨mem_verts_right_of_isLink hlink, mem_edges_iff_exists_isLink.mpr ⟨x, y', hlink⟩⟩
+  eq_of_mem_input_of_mem_input G := by simp; grind
+  eq_of_mem_output_of_mem_output G := by simp; grind
+  exists_unique_mem_edgeIn_of_mem_edges G e he := by
+    obtain ⟨x, y, hlink⟩ := mem_edges_iff_exists_isLink.mp he
+    use ⟨x, e⟩
+    simp [edgeIn]
+    grind
+  exists_unique_mem_edgeOut_of_mem_edges G e he := by
+    obtain ⟨x, y, hlink⟩ := mem_edges_iff_exists_isLink.mp he
+    use ⟨y, e⟩
+    simp [edgeOut]
+    grind
 
 @[implicit_reducible]
 def ofSourceTarget (verts : Gr → Set V) (edges : Gr → Set E) (src : Gr → E → V) (tgt : Gr → E → V)
     (mem_verts_src : ∀ ⦃G e⦄, e ∈ edges G → src G e ∈ verts G)
     (mem_verts_tgt : ∀ ⦃G e⦄, e ∈ edges G → tgt G e ∈ verts G) :
-    GraphLike V E Gr where
+    DigraphLike V (V × E) (V × E) E Gr where
   verts := verts
   edges := edges
-  IsSource G e x := e ∈ edges G ∧ src G e = x
-  IsTarget G e y := e ∈ edges G ∧ tgt G e = y
-  mem_verts_of_isSource G e x h := h.2 ▸ (mem_verts_src h.1)
-  mem_verts_of_isTarget G e x h := h.2 ▸ (mem_verts_tgt h.1)
-  mem_edges_of_isSource G e x h := h.1
-  mem_edges_of_isTarget G e x h := h.1
-  exists_unique_isSource_of_mem_edges G e he := by
-    use src G e
-    grind
-  exists_unique_isTarget_of_mem_edges G e he := by
-    use tgt G e
-    grind
-  -- inFlags := edges
-  -- outFlags := edges
-  -- source := src
-  -- target := tgt
-  -- edgeI _ := id
-  -- edgeO _ := id
-  -- mapsTo_source := mem_verts_src
-  -- mapsTo_target := mem_verts_tgt
-  -- mapsTo_edgeI _ _ := id
-  -- mapsTo_edgeO _ _ := id
-  -- eq_of_source_eq_of_edgeI_eq _ _ _ _ _ _ := id
-  -- eq_of_target_eq_of_edgeO_eq _ _ _ _ _ _ := id
-  -- injOn_edgeI _ := Set.injOn_id _
-  -- injOn_edgeO _ := Set.injOn_id _
+  input G d := ⟨d.2 ∈ edges G ∧ src G d.2 = d.1, fun _ => d⟩
+  output G d := ⟨d.2 ∈ edges G ∧ tgt G d.2 = d.1, fun _ => d⟩
+  ran_input_subset G := by
+    rintro ⟨x, e⟩ ⟨⟨x', e'⟩, ⟨hmem, h⟩, ⟨rfl, rfl⟩⟩
+    exact ⟨h ▸ mem_verts_src hmem, hmem⟩
+  ran_output_subset G := by
+    rintro ⟨x, e⟩ ⟨⟨x', e'⟩, ⟨hmem, h⟩, ⟨rfl, rfl⟩⟩
+    exact ⟨h ▸ mem_verts_tgt hmem, hmem⟩
+  eq_of_mem_input_of_mem_input G := by
+    intro ⟨x, e⟩ ⟨x', e'⟩ z f
+    simp only [Part.mem_mk_iff, mk.injEq, exists_and_left, exists_prop, and_imp]
+    rintro rfl _ rfl rfl rfl _ _ rfl
+    exact ⟨rfl, rfl⟩
+  eq_of_mem_output_of_mem_output G := by
+    intro ⟨x, e⟩ ⟨x', e'⟩ z f
+    simp only [Part.mem_mk_iff, mk.injEq, exists_and_left, exists_prop, and_imp]
+    rintro rfl _ rfl rfl rfl _ _ rfl
+    exact ⟨rfl, rfl⟩
+  exists_unique_mem_edgeIn_of_mem_edges G := by
+    intro e he
+    apply existsUnique_of_exists_of_unique
+    · use ⟨src G e, e⟩
+      simpa [edgeIn]
+    · rintro ⟨x, f⟩ ⟨x', f'⟩ ⟨⟨_, hx⟩, rfl⟩ ⟨⟨_, hx'⟩, h⟩
+      simp_all [edgeIn]
+      grind
+  exists_unique_mem_edgeOut_of_mem_edges G := by
+    intro e he
+    apply existsUnique_of_exists_of_unique
+    · use ⟨tgt G e, e⟩
+      simpa [edgeOut]
+    · rintro ⟨x, f⟩ ⟨x', f'⟩ ⟨⟨_, hx⟩, rfl⟩ ⟨⟨_, hx'⟩, h⟩
+      simp_all [edgeOut]
+      grind
 
-variable [GraphLike V E Gr] {G : Gr}
+variable [DigraphLike V I O E Gr] {G : Gr}
 
--- lemma invOn_edgeI : Set.InvOn (edgeI G) (flagI G) (edges G) (inFlags G) :=
---   (invOn_flagI (G := G)).symm
+instance instGraphLike : GraphLike V I O E Gr where
+  exists_isLink_of_mem_edges G e he := by
+    obtain ⟨i, ⟨hi, heq⟩, _⟩ := exists_unique_mem_edgeIn_of_mem_edges he
+    obtain ⟨o, ⟨ho, heq'⟩, _⟩ := exists_unique_mem_edgeOut_of_mem_edges he
+    use (source G i).get hi, (target G o).get ho
+    refine ⟨⟨i, hi, ?_⟩, o, ho, ?_⟩
+      <;> grind [input_eq_source_edgeIn, output_eq_target_edgeOut]
+  eq_or_eq_of_isLink_of_isLink G e x y x' y' h h' := by
+    left
+    simp only [IsLink, IsEdgeSource, IsEdgeTarget] at h h'
+    obtain ⟨_, he⟩ := ran_input_subset h.1
+    obtain ⟨⟨i, hi, hxeq⟩, o, ho, hyeq⟩ := h
+    obtain ⟨⟨i', hi', hxeq'⟩, o', ho', hyeq'⟩ := h'
+    rw [←input_eq_source_edgeIn] at hxeq hxeq'
+    rw [←output_eq_target_edgeOut] at hyeq hyeq'
+    suffices i = i' ∧ o = o' by grind
+    refine ⟨ExistsUnique.unique (exists_unique_mem_edgeIn_of_mem_edges he) ?_ ?_,
+      ExistsUnique.unique (exists_unique_mem_edgeOut_of_mem_edges he) ?_ ?_⟩
+    all_goals
+      rw [Part.mem_eq]
+      use (by assumption)
+      grind
 
--- lemma bijOn_flagI : Set.BijOn (flagI G) (edges G) (inFlags G) :=
---   invOn_flagI.symm.bijOn (mapsTo_flagI (G := G)) (mapsTo_edgeI (G := G))
+noncomputable def edgeInFlag {G : Gr} {e : E} (he : e ∈ edges G) : I :=
+  Classical.choose (exists_unique_mem_edgeIn_of_mem_edges he)
 
--- lemma bijOn_edgeI : Set.BijOn (edgeI G) (inFlags G) (edges G) :=
---   invOn_flagI.bijOn (mapsTo_edgeI (G := G)) (mapsTo_flagI (G := G))
+lemma mem_edgeIn_iff (e : E) (i : I) : e ∈ edgeIn G i ↔ ∃ h : e ∈ edges G, edgeInFlag h = i := by
+  simp_rw [edgeInFlag, ExistsUnique.choose_eq_iff]
+  exact ⟨fun h => ⟨mem_edges_of_mem_edgeIn h, h⟩, fun ⟨_, h⟩ => h⟩
 
-noncomputable def edgeSource {G : Gr} {e : E} (he : e ∈ edges G) : V :=
-  Classical.choose (exists_unique_isSource_of_mem_edges he)
+noncomputable def edgeOutFlag {G : Gr} {e : E} (he : e ∈ edges G) : O :=
+  Classical.choose (exists_unique_mem_edgeOut_of_mem_edges he)
 
-lemma isSource_iff (e : E) (x : V) : IsSource G e x ↔ ∃ h : e ∈ edges G, edgeSource h = x := by
-  simp_rw [edgeSource, ExistsUnique.choose_eq_iff]
-  exact ⟨fun h => ⟨mem_edges_of_isSource h, h⟩, fun ⟨_, h⟩ => h⟩
-  -- constructor
-  -- · intro h
-  --   use mem_edges_of_isSource h
-  --   rwa [edgeSource, ExistsUnique.choose_eq_iff]
-  -- · intro ⟨_, h⟩
+lemma mem_edgeOut_iff (e : E) (o : O) : e ∈ edgeOut G o ↔ ∃ h : e ∈ edges G, edgeOutFlag h = o := by
+  simp_rw [edgeOutFlag, ExistsUnique.choose_eq_iff]
+  exact ⟨fun h => ⟨mem_edges_of_mem_edgeOut h, h⟩, fun ⟨_, h⟩ => h⟩
 
-  -- rw [IsEdgeSource, edgeSource]
-  -- constructor
-  -- · intro ⟨i, hi, hx, he⟩
-  --   rw [←he, invOn_edgeI.2 hi]
-  --   exact ⟨mapsTo_edgeI hi, hx⟩
-  -- · rintro ⟨he, rfl⟩
-  --   use flagI G e, mapsTo_flagI he, rfl, invOn_edgeI.1 he
+end DigraphLike
 
--- lemma invOn_edgeO : Set.InvOn (edgeO G) (flagO G) (edges G) (outFlags G) :=
---   (invOn_flagO (G := G)).symm
+open GraphLike DigraphLike
 
--- lemma bijOn_flagO : Set.BijOn (flagO G) (edges G) (outFlags G) :=
---   invOn_flagO.symm.bijOn (mapsTo_flagO (G := G)) (mapsTo_edgeO (G := G))
-
--- lemma bijOn_edgeO : Set.BijOn (edgeO G) (outFlags G) (edges G) :=
---   invOn_flagO.bijOn (mapsTo_edgeO (G := G)) (mapsTo_flagO (G := G))
-
--- def edgeTarget (G : Gr) (e : E) : V := target G <| flagO G e
-
--- lemma isEdgeTarget_iff (e : E) (x : V) : IsEdgeTarget G e x ↔ e ∈ edges G ∧ edgeTarget G e = x := by
---   rw [IsEdgeTarget, edgeTarget]
---   constructor
---   · intro ⟨o, ho, hx, he⟩
---     rw [←he, invOn_edgeO.2 ho]
---     exact ⟨mapsTo_edgeO ho, hx⟩
---   · rintro ⟨he, rfl⟩
---     use flagO G e, mapsTo_flagO he, rfl, invOn_flagO.2 he
-
-noncomputable def edgeTarget {G : Gr} {e : E} (he : e ∈ edges G) : V :=
-  Classical.choose (exists_unique_isTarget_of_mem_edges he)
-
-lemma isTarget_iff (e : E) (x : V) : IsTarget G e x ↔ ∃ h : e ∈ edges G, edgeTarget h = x := by
-  simp_rw [edgeTarget, ExistsUnique.choose_eq_iff]
-  exact ⟨fun h => ⟨mem_edges_of_isTarget h, h⟩, fun ⟨_, h⟩ => h⟩
-
-end GraphLike
-
-open GraphLike
-
-class SimpleGraphLike (V E : outParam Type*) (Gr : Type*) extends GraphLike V E Gr where
-  eq_of_isSource_isSource_isTarget_isTarget : ∀ ⦃G e e' x y⦄,
-    IsSource G e x → IsSource G e' x → IsTarget G e y → IsTarget G e' y → e = e'
-  -- eq_of_source_eq_of_target_eq : ∀ ⦃G e e'⦄, source G (flagI G e) = source G (flagI G e') →
-  --   target G (flagO G e) = target G (flagO G e') → e = e'
+class SimpleGraphLike (V I O E : outParam Type*) (Gr : Type*) extends GraphLike V I O E Gr where
+  eq_of_isLink_of_isLink : ∀ ⦃G e e' x y⦄, IsLink (Gr := Gr) G e x y → IsLink G e' x y → e = e'
 
 class IrreflHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends
-    HyperGraphLike V E Gr where
-  not_isSource_isTarget : ∀ ⦃G e x⦄, ¬ (IsSource G e x ∧ IsTarget G e x)
-  -- edgeI_ne_edgeO_of_source_eq_target : ∀ ⦃G i o⦄, source G i = target G o → edgeI G i ≠ edgeO G o
+    HyperGraphLike V I O E Gr where
+  not_isSource_isTarget : ∀ ⦃G e x⦄, ¬ (IsEdgeSource (Gr := Gr) G e x ∧ IsEdgeTarget G e x)
 
 class SymmHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends
-    HyperGraphLike V E Gr where
-  inv : Gr → E → E -- this is non-canonical outside of `edges G`
-  inv_inv_eq : ∀ ⦃G e⦄, inv G (inv G e) = e
-  isSource_iff_isTarget_inv : ∀ ⦃G e x⦄, IsSource G e x ↔ IsTarget G (inv G e) x
-  -- swapIO : Gr → I → O
-  -- swapOI : Gr → O → I
-  -- edgeO_swapIO_eq : ∀ ⦃G i⦄, i ∈ inFlags G → edgeO G (swapIO G i) = edgeI G i
-  -- edgeI_swapOI_eq : ∀ ⦃G o⦄, o ∈ outFlags G → edgeI G (swapOI G o) = edgeO G o
-  -- mapsTo_swapIO : ∀ ⦃G⦄, Set.MapsTo (swapIO G) (inFlags G) (outFlags G)
-  -- mapsTo_swapOI : ∀ ⦃G⦄, Set.MapsTo (swapOI G) (outFlags G) (inFlags G)
-  -- invOn_swap : ∀ ⦃G⦄, Set.InvOn (swapOI G) (swapIO G) (inFlags G) (outFlags G)
+    HyperGraphLike V I O E Gr where
+  swapIO : Gr → I →. O
+  swapOI : Gr → O →. I
+  dom_swapIO_eq : ∀ ⦃G⦄, (swapIO G).Dom = (input G).Dom
+  dom_swapOI_eq : ∀ ⦃G⦄, (swapOI G).Dom = (output G).Dom
+  inFlag_mem_comp : ∀ ⦃G i⦄, i ∈ (input G).Dom → i ∈ (swapOI G).comp (swapIO G) i
+  outFlag_mem_comp : ∀ ⦃G o⦄, o ∈ (output G).Dom → o ∈ (swapIO G).comp (swapOI G) o
+  edgeIn_eq_edgeOut_swapIO : ∀ ⦃G⦄, edgeIn G = (edgeOut G).comp (swapIO G)
+  edgeOut_eq_edgeIn_swapOI : ∀ ⦃G⦄, edgeOut G = (edgeIn G).comp (swapOI G)
 
-instance : GraphLike V (V × V) (Digraph V) := ofSourceTarget (Gr := Digraph V)
+instance : DigraphLike V (V × V × V) (V × V × V) (V × V) (Digraph V) :=
+  ofSourceTarget (Gr := Digraph V)
   (verts := fun _ => Set.univ) (edges := fun G => {p : V × V | G.Adj p.1 p.2})
   (src := fun _ => Prod.fst) (tgt := fun _ => Prod.snd)
   (mem_verts_src := fun _ _ _ => trivial) (mem_verts_tgt := fun _ _ _ => trivial)
 
-instance : SimpleGraphLike V (V × V) (Digraph V) where
-  eq_of_isSource_isSource_isTarget_isTarget G := by
-    intro ⟨x, y⟩ ⟨x', y'⟩ _ _ ⟨_, hx⟩ ⟨_, hx'⟩ ⟨_, hy⟩ ⟨_, hy'⟩
-    congr
-    · exact hx.trans hx'.symm
-    · exact hy.trans hy'.symm
-    -- cases
-    -- obtain ⟨_, _⟩ := hx
+instance : SimpleGraphLike V (V × V × V) (V × V × V) (V × V) (Digraph V) where
+  eq_of_isLink_of_isLink G := by
+    intro ⟨x, y⟩ ⟨x', y'⟩ x'' y'' h h'
+    simp [IsLink, IsEdgeSource, input, IsEdgeTarget, output, PFun.ran] at h h'
+    grind
 
-instance : GraphLike V (E × V × V) (Graph V E) := by
-  refine ofIsLink Graph.vertexSet (fun G => {p | G.IsLink p.1 p.2.1 p.2.2})
-    (fun G e x y => e.2.1 = x ∧ e.2.2 = y ∧ G.IsLink e.1 x y) ?_ ?_ ?_ ?_
-  · simp
-  · intro G ⟨e, _⟩ x y ⟨_, _, h⟩
-    exact h.left_mem
-  · intro G ⟨e, _⟩ x y ⟨_, _, h⟩
-    exact h.right_mem
-  · rintro G ⟨e, z⟩ x x' y y' ⟨rfl, rfl, h⟩ ⟨rfl, rfl, h'⟩
-    simp
-  --   exact ⟨rfl, h.right_unique h'⟩
-  -- · rintro G (e | e) x y h <;> exact G.left_mem_of_isLink h
-  -- · rintro G (e | e) x y h <;> exact h.right_mem
-  -- · rintro G (e | e) x x' y y' h h'
-    -- · simp at h
+-- this is not quite right, bc `G.IsLink e x y` gives you `IsLink G e x x`
+instance : GraphLike V (V × E) (V × E) E (Graph V E) where
+  verts := Graph.vertexSet
+  edges := Graph.edgeSet
+  input G d := ⟨∃ y, G.IsLink d.2 d.1 y, fun _ => d⟩
+  output G d := ⟨∃ x, G.IsLink d.2 x d.1, fun _ => d⟩
+  ran_input_subset G := by
+    intro ⟨x, e⟩ ⟨⟨x', e'⟩, ⟨y, hlink⟩, heq⟩
+    rw [mk.injEq] at heq
+    exact ⟨heq.1 ▸ hlink.left_mem, heq.2 ▸ hlink.edge_mem⟩
+  ran_output_subset G := by
+    intro ⟨x, e⟩ ⟨⟨x', e'⟩, ⟨y, hlink⟩, heq⟩
+    rw [mk.injEq] at heq
+    exact ⟨heq.1 ▸ hlink.right_mem, heq.2 ▸ hlink.edge_mem⟩
+  eq_of_mem_input_of_mem_input G := by
+    intro ⟨x, e⟩ ⟨x', e'⟩ z f ⟨⟨y, hlink⟩, heq⟩ ⟨⟨y', hlink'⟩, heq'⟩
+    simp_all
+  eq_of_mem_output_of_mem_output G := by
+    intro ⟨x, e⟩ ⟨x', e'⟩ z f ⟨⟨y, hlink⟩, heq⟩ ⟨⟨y', hlink'⟩, heq'⟩
+    simp_all
+  exists_isLink_of_mem_edges G e he := by
+    obtain ⟨x, y, hlink⟩ := G.edge_mem_iff_exists_isLink e |>.mp he
+    refine ⟨x, y, ?_, ?_⟩
+    · use ⟨x, e⟩, ⟨y, hlink⟩
+      rfl
+    · use ⟨y, e⟩, ⟨x, hlink⟩
+      rfl
+  eq_or_eq_of_isLink_of_isLink G e x y x' y' h h' := by
+    obtain ⟨⟨i, ⟨a, halink⟩, hi⟩, o, ⟨b, hblink⟩, ho⟩ := h
+    obtain ⟨⟨i', ⟨a', halink'⟩, hi'⟩, o', ⟨b', hblink'⟩, ho'⟩ := h'
+    subst_vars
+    simp_all only
+    sorry
+    -- obtain (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩) := halink.eq_and_eq_or_eq_and_eq halink'
+    -- · obtain (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩) := hblink.eq_and_eq_or_eq_and_eq hblink'
+    --   · left; exact ⟨rfl, rfl⟩
+    --   · obtain (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩) := halink.eq_and_eq_or_eq_and_eq hblink
+    -- obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink hblink
 
-instance : SymmHyperGraphLike V (E × V × V) (Graph V E) where
-  inv G := fun ⟨e, x, y⟩ => ⟨e, y, x⟩
-  inv_inv_eq G := by simp
-  isSource_iff_isTarget_inv G := by
-    rintro ⟨e, x, y⟩ x'
-    simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
-      and_congr_right_iff]
-    rintro rfl
-    exact G.isLink_comm
+    -- <;>  obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink' hblink'
+    -- <;>  obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink hblink'
+    -- · left; exact ⟨rfl, hblink.right_unique hblink'⟩
+    -- · right; exact ⟨rfl, hblink.right_unique hblink'.symm⟩
+    -- · obtain rfl := halink.right_unique hblink
+    --   obtain rfl := hblink.right_unique hblink'
+    --   sorry
+    -- · sorry
+    -- simp_all
+    -- have h₁ := G.eq_or_eq_of_isLink_of_isLink halink' hblink
+    -- have h₂ := G.eq_or_eq_of_isLink_of_isLink halink hblink'
+    -- have h₃ := G.eq_or_eq_of_isLink_of_isLink halink' hblink'
 
-instance : GraphLike V (V × V) (SimpleGraph V) := by
-  refine ofIsLink (fun G => Set.univ) (fun G => {p | G.Adj p.1 p.2})
-    (fun G e x y => e.1 = x ∧ e.2 = y ∧ G.Adj x y) ?_ ?_ ?_ ?uniq
-  case uniq =>
-    rintro G ⟨x, y⟩ _ _ _ _ ⟨rfl, rfl, h⟩ ⟨rfl, rfl, h'⟩
-    exact ⟨rfl, rfl⟩
-  all_goals simp
+    -- simp_all only
+    -- obtain (rfl | rfl) := h₀
+    --   <;> obtain (rfl | rfl) := h₁
+    --   <;> obtain (rfl | rfl) := h₂
+    --   <;> cases h₃
 
-instance : SymmHyperGraphLike V (V × V) (SimpleGraph V) where
-  inv G := fun ⟨x, y⟩ => ⟨y, x⟩
-  inv_inv_eq G := by simp
-  isSource_iff_isTarget_inv G := by
-    intro ⟨x, y⟩ _
-    simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
-      and_congr_right_iff]
-    rintro rfl
-    exact G.adj_comm ..
+    -- obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink hblink
+    --   <;> obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink' hblink'
+    --   <;> obtain (rfl | rfl) := G.eq_or_eq_of_isLink_of_isLink halink hblink'
+    --   <;> simp_all only
 
-instance : IrreflHyperGraphLike V (V × V) (SimpleGraph V) where
-  not_isSource_isTarget G := by
-    intro ⟨x, y⟩ _
-    simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
-      not_and, and_imp]
-    rintro rfl h rfl
-    exact G.irrefl
 
--- class HyperGraphLike₂ (V E : outParam Type*) (Gr : Type*) where
---   verts : Gr → Set V
---   edges : Gr → Set E
---   IsSource : Gr → E → V → Prop
---   IsTarget : Gr → E → V → Prop
---   mem_verts_of_isSource : ∀ ⦃G e v⦄, e ∈ edges G → IsSource G e v → v ∈ verts G
---   mem_verts_of_isTarget : ∀ ⦃G e v⦄, e ∈ edges G → IsTarget G e v → v ∈ verts G
---   mem_edges_of_isSource : ∀ ⦃G e v⦄, e ∈ edges G → IsSource G e v → e ∈ edges G
---   mem_edges_of_isTarget : ∀ ⦃G e v⦄, e ∈ edges G → IsTarget G e v → e ∈ edges G
+-- -- instance : SymmHyperGraphLike V (E × V × V) (Graph V E) where
+-- --   inv G := fun ⟨e, x, y⟩ => ⟨e, y, x⟩
+-- --   inv_inv_eq G := by simp
+-- --   isSource_iff_isTarget_inv G := by
+-- --     rintro ⟨e, x, y⟩ x'
+-- --     simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
+-- --       and_congr_right_iff]
+-- --     rintro rfl
+-- --     exact G.isLink_comm
 
--- namespace HyperGraphLike₂
+-- -- instance : GraphLike V (V × V) (SimpleGraph V) := by
+-- --   refine ofIsLink (fun G => Set.univ) (fun G => {p | G.Adj p.1 p.2})
+-- --     (fun G e x y => e.1 = x ∧ e.2 = y ∧ G.Adj x y) ?_ ?_ ?_ ?uniq
+-- --   case uniq =>
+-- --     rintro G ⟨x, y⟩ _ _ _ _ ⟨rfl, rfl, h⟩ ⟨rfl, rfl, h'⟩
+-- --     exact ⟨rfl, rfl⟩
+-- --   all_goals simp
 
--- variable [HyperGraphLike₂ V E Gr]
+-- -- instance : SymmHyperGraphLike V (V × V) (SimpleGraph V) where
+-- --   inv G := fun ⟨x, y⟩ => ⟨y, x⟩
+-- --   inv_inv_eq G := by simp
+-- --   isSource_iff_isTarget_inv G := by
+-- --     intro ⟨x, y⟩ _
+-- --     simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
+-- --       and_congr_right_iff]
+-- --     rintro rfl
+-- --     exact G.adj_comm ..
 
--- def Adj (G : Gr) (x y : V) : Prop := ∃ e ∈ edges G, IsSource G e x ∧ IsTarget G e y
-
--- def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsSource G e x ∧ IsTarget G e y
-
--- structure Dart (G : Gr) where
---   s : V
---   t : V
---   e : E
---   isSource : IsSource G e s
---   isTarget : IsTarget G e t
-
--- end HyperGraphLike₂
-
--- class GraphLike₂ (V E : outParam Type*) (Gr : Type*) extends HyperGraphLike₂ V E Gr where
---   source : Gr → E → V
---   target : Gr → E → V
---   isSource_iff : ∀ ⦃G e v⦄, e ∈ edges G → (IsSource G e v ↔ v = source G e)
---   isTarget_iff : ∀ ⦃G e v⦄, e ∈ edges G → (IsTarget G e v ↔ v = target G e)
+-- -- instance : IrreflHyperGraphLike V (V × V) (SimpleGraph V) where
+-- --   not_isSource_isTarget G := by
+-- --     intro ⟨x, y⟩ _
+-- --     simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
+-- --       not_and, and_imp]
+-- --     rintro rfl h rfl
+-- --     exact G.irrefl

--- a/Mathlib/Combinatorics/GraphLike/Basic.lean
+++ b/Mathlib/Combinatorics/GraphLike/Basic.lean
@@ -1,0 +1,489 @@
+/-
+Copyright (c) 2026 Thomas Waring. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jun Kwon, Thomas Waring
+-/
+module
+
+public import Mathlib.Combinatorics.Graph.Basic
+public import Mathlib.Combinatorics.SimpleGraph.Basic
+public import Mathlib.Combinatorics.Digraph.Basic
+
+/-! # Typeclass for graph-like data -/
+
+public section
+
+variable {V H I O E Gr : Type*}
+
+class HyperGraphLike (V E : outParam Type*) (Gr : Type*) where
+  verts : Gr → Set V
+  -- flags : Gr → Set H
+  edges : Gr → Set E
+  -- IsEndpoint : Gr → H → V → Prop
+  -- IsInFlag : Gr → E → H → Prop
+  -- IsOutFlag : Gr → E → H → Prop
+  -- mem_flags_iff_exists_isEnpoint : ∀ ⦃G h⦄, h ∈ flags G ↔ ∃ x, IsEndpoint G h x
+  -- inFlags : Gr → Set I
+  -- outFlags : Gr → Set O
+  IsSource : Gr → E → V → Prop
+  IsTarget : Gr → E → V → Prop
+  -- source : Gr → I → V
+  -- target : Gr → O → V
+  -- edgeI : Gr → I → E
+  -- edgeO : Gr → O → E
+  -- IsSource : Gr → I → V → Prop
+  -- IsTarget : Gr → O → V → Prop
+  -- IsInPort : Gr → E → I → Prop
+  -- IsOutPort : Gr → E → O → Prop
+  -- mapsTo_source : ∀ ⦃G⦄, Set.MapsTo (source G) (inFlags G) (verts G)
+  -- mapsTo_target : ∀ ⦃G⦄, Set.MapsTo (target G) (outFlags G) (verts G)
+  -- mapsTo_edgeI : ∀ ⦃G⦄, Set.MapsTo (edgeI G) (inFlags G) (edges G)
+  -- mapsTo_edgeO : ∀ ⦃G⦄, Set.MapsTo (edgeO G) (outFlags G) (edges G)
+  -- eq_of_source_eq_of_edgeI_eq : ∀ ⦃G i i'⦄, i ∈ inFlags G → i' ∈ inFlags G →
+  --   source G i = source G i' → edgeI G i = edgeI G i' → i = i'
+  -- eq_of_target_eq_of_edgeO_eq : ∀ ⦃G o o'⦄, o ∈ outFlags G → o' ∈ outFlags G →
+  --   target G o = target G o' → edgeO G o = edgeO G o' → o = o'
+  mem_verts_of_isSource : ∀ ⦃G e x⦄, IsSource G e x → x ∈ verts G
+  mem_verts_of_isTarget : ∀ ⦃G e x⦄, IsTarget G e x → x ∈ verts G
+  mem_edges_of_isSource : ∀ ⦃G e x⦄, IsSource G e x → e ∈ edges G
+  mem_edges_of_isTarget : ∀ ⦃G e x⦄, IsTarget G e x → e ∈ edges G
+  -- mem_inFlags_iff : ∀ ⦃G i⦄, i ∈ inFlags G ↔
+  --     (∃! x ∈ verts G, IsSource G i x) ∧ (∃! e ∈ edges G, IsInPort G e i)
+  -- mem_outFlags_iff : ∀ ⦃G o⦄, o ∈ outFlags G ↔
+  --     (∃! x ∈ verts G, IsTarget G o x) ∧ (∃! e ∈ edges G, IsOutPort G e o)
+
+namespace HyperGraphLike
+
+variable [HyperGraphLike V E Gr] {G : Gr}
+
+-- def IsEdgeSource (G : Gr) (e : E) (v : V) : Prop := ∃ i ∈ inFlags G, source G i = v ∧ edgeI G i = e
+
+-- def IsEdgeTarget (G : Gr) (e : E) (v : V) : Prop := ∃ o ∈ outFlags G, target G o = v ∧ edgeO G o = e
+
+-- def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsEdgeSource G e x ∧ IsEdgeTarget G e y
+
+def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsSource G e x ∧ IsTarget G e y
+
+-- @[implicit_reducible]
+-- def ofIsSourceIsTarget (verts : Gr → Set V) (edges : Gr → Set E)
+--     (IsEdgeSource : Gr → E → V → Prop) (IsEdgeTarget : Gr → E → V → Prop)
+--     (mem_verts_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → v ∈ verts G)
+--     (mem_edges_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → e ∈ edges G)
+--     (mem_verts_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → v ∈ verts G)
+--     (mem_edges_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → e ∈ edges G)
+--     : HyperGraphLike V (E × V) (E × V) E Gr where
+--   verts := verts
+--   inFlags G := {d | IsEdgeSource G d.1 d.2}
+--   outFlags G := {d | IsEdgeTarget G d.1 d.2}
+--   edges := edges
+--   source _ d := d.2
+--   target _ d := d.2
+--   edgeI _ d := d.1
+--   edgeO _ d := d.1
+--   mapsTo_source G i hi := mem_verts_of_isEdgeSource hi
+--   mapsTo_target G o ho := mem_verts_of_isEdgeTarget ho
+--   mapsTo_edgeI G i hi := mem_edges_of_isEdgeSource hi
+--   mapsTo_edgeO G o ho := mem_edges_of_isEdgeTarget ho
+--   eq_of_source_eq_of_edgeI_eq G i i' _ _ h h' := by cases i; cases i'; congr
+--   eq_of_target_eq_of_edgeO_eq G o o' _ _ h h' := by cases o; cases o'; congr
+
+-- def Adj (G : Gr) (x y : V) : Prop := ∃ e ∈ edges G, IsEdgeSource G e x ∧ IsEdgeTarget G e y
+
+def Adj (G : Gr) (x y : V) : Prop := ∃ e, IsSource G e x ∧ IsTarget G e y
+
+-- def FlagsInc (G : Gr) (i : I) (o : O) : Prop :=
+--     edgeI G i = edgeO G o ∧ i ∈ inFlags G ∧ o ∈ outFlags G
+
+-- lemma Adj.iff_exists_inFlag_outFlag {G : Gr} {x y : V} :
+--     Adj G x y ↔ ∃ i o, FlagsInc G i o ∧ source G i = x ∧ target G o = y := by
+--   simp_rw [Adj, IsEdgeSource, IsEdgeTarget, FlagsInc]
+--   constructor
+--   · rintro ⟨_, he, ⟨i, hi, rfl, rfl⟩, o, ho, rfl, h⟩
+--     use i, o
+--     grind
+--   · rintro ⟨i, o, ⟨he, hi, ho⟩, rfl, rfl⟩
+--     exact ⟨edgeI G i, mapsTo_edgeI hi, ⟨i, hi, rfl, rfl⟩, o, ho, rfl, he.symm⟩
+
+structure Dart (G : Gr) where
+  source : V
+  target : V
+  edge : E
+  isLink : IsLink G edge source target
+
+namespace Dart
+
+-- @[ext]
+-- protected lemma ext {d d' : Dart G} (hi : d.i = d'.i) (ho : d.o = d'.o) : d = d' := by
+--   cases d; cases d'; congr
+
+-- lemma inFlag_mem (d : Dart G) : d.i ∈ inFlags G := d.inc.2.1
+
+-- lemma outFlag_mem (d : Dart G) : d.o ∈ outFlags G := d.inc.2.2
+
+-- def src (d : Dart G) : V := source G d.i
+
+-- lemma src_mem (d : Dart G) : d.src ∈ verts G := mapsTo_source d.inFlag_mem
+
+def isSource (d : Dart G) : IsSource G d.edge d.source := d.isLink.1
+
+lemma source_mem (d : Dart G) : d.source ∈ verts G := mem_verts_of_isSource d.isSource
+
+-- def tgt (d : Dart G) : V := target G d.o
+
+-- lemma tgt_mem (d : Dart G) : d.tgt ∈ verts G := mapsTo_target d.outFlag_mem
+
+def isTarget (d : Dart G) : IsTarget G d.edge d.target := d.isLink.2
+
+lemma target_mem (d : Dart G) : d.target ∈ verts G := mem_verts_of_isTarget d.isLink.2
+
+-- def edge (d : Dart G) : E := edgeI G d.i
+
+-- lemma edge_eq_edgeI (d : Dart G) : d.edge = edgeI G d.i := by rfl
+
+-- lemma edge_eq_edgeO (d : Dart G) : d.edge = edgeO G d.o := by rw [←d.inc.1]; rfl
+
+-- lemma edge_mem (d : Dart G) : d.edge ∈ edges G := mapsTo_edgeI d.inFlag_mem
+
+lemma edge_mem (d : Dart G) : d.edge ∈ edges G := mem_edges_of_isSource d.isSource
+
+-- lemma isEdgeSource (d : Dart G) : IsEdgeSource G d.edge d.src :=
+--   ⟨d.i, d.inFlag_mem, rfl, d.edge_eq_edgeI⟩
+
+-- lemma isEdgeTarget (d : Dart G) : IsEdgeTarget G d.edge d.tgt :=
+--   ⟨d.o, d.outFlag_mem, rfl, d.edge_eq_edgeO.symm⟩
+
+-- noncomputable def ofEdge {e : E} {x y : V} (hsrc : IsEdgeSource G e x) (htgt : IsEdgeTarget G e y) :
+--     Dart G where
+--   i := Classical.choose hsrc
+--   o := Classical.choose htgt
+--   inc :=
+--     have ⟨hi, _, hei⟩ := Classical.choose_spec hsrc
+--     have ⟨ho, _, heo⟩ := Classical.choose_spec htgt
+--     ⟨hei.trans heo.symm, hi, ho⟩
+
+-- lemma ext_edge {d d' : Dart G} (hsrc : d.src = d'.src) (htgt : d.tgt = d'.tgt)
+--     (hedge : d.edge = d'.edge) : d = d' := by
+--   ext
+--   · exact eq_of_source_eq_of_edgeI_eq d.inFlag_mem d'.inFlag_mem hsrc hedge
+--   · apply eq_of_target_eq_of_edgeO_eq d.outFlag_mem d'.outFlag_mem htgt
+--     simp_rw [←edge_eq_edgeO]
+--     assumption
+
+-- lemma adj (d : Dart G) : Adj G d.src d.tgt := ⟨d.edge, d.edge_mem, d.isEdgeSource, d.isEdgeTarget⟩
+
+lemma adj (d : Dart G) : Adj G d.source d.target := ⟨d.edge, d.isSource, d.isTarget⟩
+
+def AdjDart (d d' : Dart G) : Prop := d.target = d'.source
+
+end Dart
+
+end HyperGraphLike
+
+open HyperGraphLike
+
+class GraphLike (V E : outParam Type*) (Gr : Type*) extends
+    HyperGraphLike V E Gr where
+  -- injOn_edgeI : ∀ ⦃G⦄, Set.InjOn (edgeI G) (inFlags G)
+  -- injOn_edgeO : ∀ ⦃G⦄, Set.InjOn (edgeO G) (outFlags G)
+  exists_unique_isSource_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! x, IsSource G e x
+  exists_unique_isTarget_of_mem_edges : ∀ ⦃G e⦄, e ∈ edges G → ∃! x, IsTarget G e x
+  -- flagI : Gr → E → I
+  -- flagO : Gr → E → O
+  -- mapsTo_flagI : ∀ ⦃G⦄, Set.MapsTo (flagI G) (edges G) (inFlags G)
+  -- invOn_flagI : ∀ ⦃G⦄, Set.InvOn (flagI G) (edgeI G) (inFlags G) (edges G)
+  -- mapsTo_flagO : ∀ ⦃G⦄, Set.MapsTo (flagO G) (edges G) (outFlags G)
+  -- invOn_flagO : ∀ ⦃G⦄, Set.InvOn (flagO G) (edgeO G) (outFlags G) (edges G)
+
+namespace GraphLike
+
+@[implicit_reducible]
+def ofIsLink (verts : Gr → Set V) (edges : Gr → Set E)
+    (IsLink : Gr → E → V → V → Prop)
+    (mem_edges_iff_exists_isLink : ∀ ⦃G e⦄, e ∈ edges G ↔ ∃ x y, IsLink G e x y)
+    (mem_verts_left_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → x ∈ verts G)
+    (mem_verts_right_of_isLink : ∀ ⦃G e x y⦄, IsLink G e x y → y ∈ verts G)
+    (eq_and_eq_of_isLink_of_isLink : ∀ ⦃G e x x' y y'⦄,
+      IsLink G e x y → IsLink G e x' y' → x = x' ∧ y = y') :
+    GraphLike V E Gr
+    where
+  verts := verts
+  -- inFlags G := {d | ∃ y, IsLink G d.1 d.2 y}
+  -- outFlags G := {d | ∃ x, IsLink G d.1 x d.2}
+  edges := edges
+  IsSource G e x := ∃ y, IsLink G e x y
+  IsTarget G e y := ∃ x, IsLink G e x y
+  mem_verts_of_isSource G e x := fun ⟨_, h⟩ => mem_verts_left_of_isLink h
+  mem_verts_of_isTarget G e y := fun ⟨_, h⟩ => mem_verts_right_of_isLink h
+  mem_edges_of_isSource G e x := fun ⟨y, h⟩ => mem_edges_iff_exists_isLink |>.mpr ⟨x, y, h⟩
+  mem_edges_of_isTarget G e y := fun ⟨x, h⟩ => mem_edges_iff_exists_isLink |>.mpr ⟨x, y, h⟩
+  exists_unique_isSource_of_mem_edges G e he := by
+    apply existsUnique_of_exists_of_unique (mem_edges_iff_exists_isLink.mp he)
+    intro x x' ⟨_, hy⟩ ⟨_, hy'⟩
+    exact eq_and_eq_of_isLink_of_isLink hy hy' |>.1
+  exists_unique_isTarget_of_mem_edges G e he := by
+    apply existsUnique_of_exists_of_unique
+    · obtain ⟨x, y, h⟩ := mem_edges_iff_exists_isLink.mp he
+      exact ⟨y, x, h⟩
+    · intro y y' ⟨x, hx⟩ ⟨x', hx'⟩
+      exact eq_and_eq_of_isLink_of_isLink hx hx' |>.2
+  -- target G d := d.2
+  -- source G d := d.2
+  -- edgeI G d := d.1
+  -- edgeO G d := d.1
+  -- mapsTo_source G d := fun ⟨_, hd⟩ => mem_verts_left_of_isLink hd
+  -- mapsTo_target G d := fun ⟨_, hd⟩ => mem_verts_right_of_isLink hd
+  -- mapsTo_edgeI G d := fun ⟨y, hd⟩ => mem_edges_iff_exists_isLink.mpr ⟨d.2, y, hd⟩
+  -- mapsTo_edgeO G d := fun ⟨x, hd⟩ => mem_edges_iff_exists_isLink.mpr ⟨x, d.2, hd⟩
+  -- eq_of_source_eq_of_edgeI_eq _ i i' _ _ _ _ := by cases i; cases i'; congr
+  -- eq_of_target_eq_of_edgeO_eq _ o o' _ _ _ _ := by cases o; cases o'; congr
+  -- flagI G e :=
+  --   have : Decidable (∃ x y, IsLink G e x y) := Classical.propDecidable _
+  --   if h : ∃ x y, IsLink G e x y then ⟨e, Classical.choose h⟩ else ⟨e, Classical.arbitrary V⟩
+  -- flagO G e :=
+  --   have : Decidable (∃ y x, IsLink G e x y) := Classical.propDecidable _
+  --   if h : ∃ y x, IsLink G e x y then ⟨e, Classical.choose h⟩ else ⟨e, Classical.arbitrary V⟩
+  -- mapsTo_flagI G e he := by
+  --   rw [mem_edges_iff_exists_isLink] at he
+  --   simp [he, Classical.choose_spec he]
+  -- invOn_flagI G := by
+  --   refine ⟨?_, ?_⟩
+  --   · intro ⟨e, x⟩ ⟨y, h⟩
+  --     have h' : ∃ x y, IsLink G e x y := ⟨x, y, h⟩
+  --     simp only [h', ↓reduceDIte, Prod.mk.injEq, true_and]
+  --     exact eq_and_eq_of_isLink_of_isLink (Classical.choose_spec <| Classical.choose_spec h') h |>.1
+  --   · intro e he
+  --     have h' : ∃ x y, IsLink G e x y := mem_edges_iff_exists_isLink.mp he
+  --     simp only [h', ↓reduceDIte]
+  -- mapsTo_flagO G e he := by
+  --   obtain ⟨x, y, he⟩ := by rwa [mem_edges_iff_exists_isLink] at he
+  --   replace he : ∃ y x, IsLink G e x y := ⟨y, x, he⟩
+  --   simp [he, Classical.choose_spec he]
+  -- invOn_flagO G := by
+  --   refine ⟨?_, ?_⟩
+  --   · intro ⟨e, y⟩ ⟨x, h⟩
+  --     have h' : ∃ y x, IsLink G e x y := ⟨y, x, h⟩
+  --     simp only [h', ↓reduceDIte, Prod.mk.injEq, true_and]
+  --     exact eq_and_eq_of_isLink_of_isLink (Classical.choose_spec <| Classical.choose_spec h') h |>.2
+  --   · intro e he
+  --     obtain ⟨x, y, h⟩ : ∃ x y, IsLink G e x y := mem_edges_iff_exists_isLink.mp he
+  --     have h' : ∃ y x, IsLink G e x y := ⟨y, x, h⟩
+  --     simp only [h', ↓reduceDIte]
+
+@[implicit_reducible]
+def ofSourceTarget (verts : Gr → Set V) (edges : Gr → Set E) (src : Gr → E → V) (tgt : Gr → E → V)
+    (mem_verts_src : ∀ ⦃G e⦄, e ∈ edges G → src G e ∈ verts G)
+    (mem_verts_tgt : ∀ ⦃G e⦄, e ∈ edges G → tgt G e ∈ verts G) :
+    GraphLike V E Gr where
+  verts := verts
+  edges := edges
+  IsSource G e x := e ∈ edges G ∧ src G e = x
+  IsTarget G e y := e ∈ edges G ∧ tgt G e = y
+  mem_verts_of_isSource G e x h := h.2 ▸ (mem_verts_src h.1)
+  mem_verts_of_isTarget G e x h := h.2 ▸ (mem_verts_tgt h.1)
+  mem_edges_of_isSource G e x h := h.1
+  mem_edges_of_isTarget G e x h := h.1
+  exists_unique_isSource_of_mem_edges G e he := by
+    use src G e
+    grind
+  exists_unique_isTarget_of_mem_edges G e he := by
+    use tgt G e
+    grind
+  -- inFlags := edges
+  -- outFlags := edges
+  -- source := src
+  -- target := tgt
+  -- edgeI _ := id
+  -- edgeO _ := id
+  -- mapsTo_source := mem_verts_src
+  -- mapsTo_target := mem_verts_tgt
+  -- mapsTo_edgeI _ _ := id
+  -- mapsTo_edgeO _ _ := id
+  -- eq_of_source_eq_of_edgeI_eq _ _ _ _ _ _ := id
+  -- eq_of_target_eq_of_edgeO_eq _ _ _ _ _ _ := id
+  -- injOn_edgeI _ := Set.injOn_id _
+  -- injOn_edgeO _ := Set.injOn_id _
+
+variable [GraphLike V E Gr] {G : Gr}
+
+-- lemma invOn_edgeI : Set.InvOn (edgeI G) (flagI G) (edges G) (inFlags G) :=
+--   (invOn_flagI (G := G)).symm
+
+-- lemma bijOn_flagI : Set.BijOn (flagI G) (edges G) (inFlags G) :=
+--   invOn_flagI.symm.bijOn (mapsTo_flagI (G := G)) (mapsTo_edgeI (G := G))
+
+-- lemma bijOn_edgeI : Set.BijOn (edgeI G) (inFlags G) (edges G) :=
+--   invOn_flagI.bijOn (mapsTo_edgeI (G := G)) (mapsTo_flagI (G := G))
+
+noncomputable def edgeSource {G : Gr} {e : E} (he : e ∈ edges G) : V :=
+  Classical.choose (exists_unique_isSource_of_mem_edges he)
+
+lemma isSource_iff (e : E) (x : V) : IsSource G e x ↔ ∃ h : e ∈ edges G, edgeSource h = x := by
+  simp_rw [edgeSource, ExistsUnique.choose_eq_iff]
+  exact ⟨fun h => ⟨mem_edges_of_isSource h, h⟩, fun ⟨_, h⟩ => h⟩
+  -- constructor
+  -- · intro h
+  --   use mem_edges_of_isSource h
+  --   rwa [edgeSource, ExistsUnique.choose_eq_iff]
+  -- · intro ⟨_, h⟩
+
+  -- rw [IsEdgeSource, edgeSource]
+  -- constructor
+  -- · intro ⟨i, hi, hx, he⟩
+  --   rw [←he, invOn_edgeI.2 hi]
+  --   exact ⟨mapsTo_edgeI hi, hx⟩
+  -- · rintro ⟨he, rfl⟩
+  --   use flagI G e, mapsTo_flagI he, rfl, invOn_edgeI.1 he
+
+-- lemma invOn_edgeO : Set.InvOn (edgeO G) (flagO G) (edges G) (outFlags G) :=
+--   (invOn_flagO (G := G)).symm
+
+-- lemma bijOn_flagO : Set.BijOn (flagO G) (edges G) (outFlags G) :=
+--   invOn_flagO.symm.bijOn (mapsTo_flagO (G := G)) (mapsTo_edgeO (G := G))
+
+-- lemma bijOn_edgeO : Set.BijOn (edgeO G) (outFlags G) (edges G) :=
+--   invOn_flagO.bijOn (mapsTo_edgeO (G := G)) (mapsTo_flagO (G := G))
+
+-- def edgeTarget (G : Gr) (e : E) : V := target G <| flagO G e
+
+-- lemma isEdgeTarget_iff (e : E) (x : V) : IsEdgeTarget G e x ↔ e ∈ edges G ∧ edgeTarget G e = x := by
+--   rw [IsEdgeTarget, edgeTarget]
+--   constructor
+--   · intro ⟨o, ho, hx, he⟩
+--     rw [←he, invOn_edgeO.2 ho]
+--     exact ⟨mapsTo_edgeO ho, hx⟩
+--   · rintro ⟨he, rfl⟩
+--     use flagO G e, mapsTo_flagO he, rfl, invOn_flagO.2 he
+
+noncomputable def edgeTarget {G : Gr} {e : E} (he : e ∈ edges G) : V :=
+  Classical.choose (exists_unique_isTarget_of_mem_edges he)
+
+lemma isTarget_iff (e : E) (x : V) : IsTarget G e x ↔ ∃ h : e ∈ edges G, edgeTarget h = x := by
+  simp_rw [edgeTarget, ExistsUnique.choose_eq_iff]
+  exact ⟨fun h => ⟨mem_edges_of_isTarget h, h⟩, fun ⟨_, h⟩ => h⟩
+
+end GraphLike
+
+open GraphLike
+
+class SimpleGraphLike (V E : outParam Type*) (Gr : Type*) extends GraphLike V E Gr where
+  eq_of_isSource_isSource_isTarget_isTarget : ∀ ⦃G e e' x y⦄,
+    IsSource G e x → IsSource G e' x → IsTarget G e y → IsTarget G e' y → e = e'
+  -- eq_of_source_eq_of_target_eq : ∀ ⦃G e e'⦄, source G (flagI G e) = source G (flagI G e') →
+  --   target G (flagO G e) = target G (flagO G e') → e = e'
+
+class IrreflHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends
+    HyperGraphLike V E Gr where
+  not_isSource_isTarget : ∀ ⦃G e x⦄, ¬ (IsSource G e x ∧ IsTarget G e x)
+  -- edgeI_ne_edgeO_of_source_eq_target : ∀ ⦃G i o⦄, source G i = target G o → edgeI G i ≠ edgeO G o
+
+class SymmHyperGraphLike (V E : outParam Type*) (Gr : Type*) extends
+    HyperGraphLike V E Gr where
+  inv : Gr → E → E -- this is non-canonical outside of `edges G`
+  inv_inv_eq : ∀ ⦃G e⦄, inv G (inv G e) = e
+  isSource_iff_isTarget_inv : ∀ ⦃G e x⦄, IsSource G e x ↔ IsTarget G (inv G e) x
+  -- swapIO : Gr → I → O
+  -- swapOI : Gr → O → I
+  -- edgeO_swapIO_eq : ∀ ⦃G i⦄, i ∈ inFlags G → edgeO G (swapIO G i) = edgeI G i
+  -- edgeI_swapOI_eq : ∀ ⦃G o⦄, o ∈ outFlags G → edgeI G (swapOI G o) = edgeO G o
+  -- mapsTo_swapIO : ∀ ⦃G⦄, Set.MapsTo (swapIO G) (inFlags G) (outFlags G)
+  -- mapsTo_swapOI : ∀ ⦃G⦄, Set.MapsTo (swapOI G) (outFlags G) (inFlags G)
+  -- invOn_swap : ∀ ⦃G⦄, Set.InvOn (swapOI G) (swapIO G) (inFlags G) (outFlags G)
+
+instance : GraphLike V (V × V) (Digraph V) := ofSourceTarget (Gr := Digraph V)
+  (verts := fun _ => Set.univ) (edges := fun G => {p : V × V | G.Adj p.1 p.2})
+  (src := fun _ => Prod.fst) (tgt := fun _ => Prod.snd)
+  (mem_verts_src := fun _ _ _ => trivial) (mem_verts_tgt := fun _ _ _ => trivial)
+
+instance : SimpleGraphLike V (V × V) (Digraph V) where
+  eq_of_isSource_isSource_isTarget_isTarget G := by
+    intro ⟨x, y⟩ ⟨x', y'⟩ _ _ ⟨_, hx⟩ ⟨_, hx'⟩ ⟨_, hy⟩ ⟨_, hy'⟩
+    congr
+    · exact hx.trans hx'.symm
+    · exact hy.trans hy'.symm
+    -- cases
+    -- obtain ⟨_, _⟩ := hx
+
+instance : GraphLike V (E × V × V) (Graph V E) := by
+  refine ofIsLink Graph.vertexSet (fun G => {p | G.IsLink p.1 p.2.1 p.2.2})
+    (fun G e x y => e.2.1 = x ∧ e.2.2 = y ∧ G.IsLink e.1 x y) ?_ ?_ ?_ ?_
+  · simp
+  · intro G ⟨e, _⟩ x y ⟨_, _, h⟩
+    exact h.left_mem
+  · intro G ⟨e, _⟩ x y ⟨_, _, h⟩
+    exact h.right_mem
+  · rintro G ⟨e, z⟩ x x' y y' ⟨rfl, rfl, h⟩ ⟨rfl, rfl, h'⟩
+    simp
+  --   exact ⟨rfl, h.right_unique h'⟩
+  -- · rintro G (e | e) x y h <;> exact G.left_mem_of_isLink h
+  -- · rintro G (e | e) x y h <;> exact h.right_mem
+  -- · rintro G (e | e) x x' y y' h h'
+    -- · simp at h
+
+instance : SymmHyperGraphLike V (E × V × V) (Graph V E) where
+  inv G := fun ⟨e, x, y⟩ => ⟨e, y, x⟩
+  inv_inv_eq G := by simp
+  isSource_iff_isTarget_inv G := by
+    rintro ⟨e, x, y⟩ x'
+    simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
+      and_congr_right_iff]
+    rintro rfl
+    exact G.isLink_comm
+
+instance : GraphLike V (V × V) (SimpleGraph V) := by
+  refine ofIsLink (fun G => Set.univ) (fun G => {p | G.Adj p.1 p.2})
+    (fun G e x y => e.1 = x ∧ e.2 = y ∧ G.Adj x y) ?_ ?_ ?_ ?uniq
+  case uniq =>
+    rintro G ⟨x, y⟩ _ _ _ _ ⟨rfl, rfl, h⟩ ⟨rfl, rfl, h'⟩
+    exact ⟨rfl, rfl⟩
+  all_goals simp
+
+instance : SymmHyperGraphLike V (V × V) (SimpleGraph V) where
+  inv G := fun ⟨x, y⟩ => ⟨y, x⟩
+  inv_inv_eq G := by simp
+  isSource_iff_isTarget_inv G := by
+    intro ⟨x, y⟩ _
+    simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
+      and_congr_right_iff]
+    rintro rfl
+    exact G.adj_comm ..
+
+instance : IrreflHyperGraphLike V (V × V) (SimpleGraph V) where
+  not_isSource_isTarget G := by
+    intro ⟨x, y⟩ _
+    simp only [IsSource, exists_and_left, ↓existsAndEq, true_and, IsTarget, exists_eq_left',
+      not_and, and_imp]
+    rintro rfl h rfl
+    exact G.irrefl
+
+-- class HyperGraphLike₂ (V E : outParam Type*) (Gr : Type*) where
+--   verts : Gr → Set V
+--   edges : Gr → Set E
+--   IsSource : Gr → E → V → Prop
+--   IsTarget : Gr → E → V → Prop
+--   mem_verts_of_isSource : ∀ ⦃G e v⦄, e ∈ edges G → IsSource G e v → v ∈ verts G
+--   mem_verts_of_isTarget : ∀ ⦃G e v⦄, e ∈ edges G → IsTarget G e v → v ∈ verts G
+--   mem_edges_of_isSource : ∀ ⦃G e v⦄, e ∈ edges G → IsSource G e v → e ∈ edges G
+--   mem_edges_of_isTarget : ∀ ⦃G e v⦄, e ∈ edges G → IsTarget G e v → e ∈ edges G
+
+-- namespace HyperGraphLike₂
+
+-- variable [HyperGraphLike₂ V E Gr]
+
+-- def Adj (G : Gr) (x y : V) : Prop := ∃ e ∈ edges G, IsSource G e x ∧ IsTarget G e y
+
+-- def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsSource G e x ∧ IsTarget G e y
+
+-- structure Dart (G : Gr) where
+--   s : V
+--   t : V
+--   e : E
+--   isSource : IsSource G e s
+--   isTarget : IsTarget G e t
+
+-- end HyperGraphLike₂
+
+-- class GraphLike₂ (V E : outParam Type*) (Gr : Type*) extends HyperGraphLike₂ V E Gr where
+--   source : Gr → E → V
+--   target : Gr → E → V
+--   isSource_iff : ∀ ⦃G e v⦄, e ∈ edges G → (IsSource G e v ↔ v = source G e)
+--   isTarget_iff : ∀ ⦃G e v⦄, e ∈ edges G → (IsTarget G e v ↔ v = target G e)

--- a/Mathlib/Combinatorics/GraphLike/Basic.lean
+++ b/Mathlib/Combinatorics/GraphLike/Basic.lean
@@ -5,6 +5,7 @@ Authors: Jun Kwon, Thomas Waring
 -/
 module
 
+public import Mathlib.Data.PFun
 public import Mathlib.Combinatorics.Graph.Basic
 public import Mathlib.Combinatorics.SimpleGraph.Basic
 public import Mathlib.Combinatorics.Digraph.Basic
@@ -15,106 +16,90 @@ public section
 
 variable {V H I O E Gr : Type*}
 
-class HyperGraphLike (V E : outParam Type*) (Gr : Type*) where
+class HyperGraphLike (V I O E : outParam Type*) (Gr : Type*) where
   verts : Gr → Set V
-  -- flags : Gr → Set H
   edges : Gr → Set E
-  -- IsEndpoint : Gr → H → V → Prop
-  -- IsInFlag : Gr → E → H → Prop
-  -- IsOutFlag : Gr → E → H → Prop
-  -- mem_flags_iff_exists_isEnpoint : ∀ ⦃G h⦄, h ∈ flags G ↔ ∃ x, IsEndpoint G h x
-  -- inFlags : Gr → Set I
-  -- outFlags : Gr → Set O
-  IsSource : Gr → E → V → Prop
-  IsTarget : Gr → E → V → Prop
-  -- source : Gr → I → V
-  -- target : Gr → O → V
-  -- edgeI : Gr → I → E
-  -- edgeO : Gr → O → E
-  -- IsSource : Gr → I → V → Prop
-  -- IsTarget : Gr → O → V → Prop
-  -- IsInPort : Gr → E → I → Prop
-  -- IsOutPort : Gr → E → O → Prop
-  -- mapsTo_source : ∀ ⦃G⦄, Set.MapsTo (source G) (inFlags G) (verts G)
-  -- mapsTo_target : ∀ ⦃G⦄, Set.MapsTo (target G) (outFlags G) (verts G)
-  -- mapsTo_edgeI : ∀ ⦃G⦄, Set.MapsTo (edgeI G) (inFlags G) (edges G)
-  -- mapsTo_edgeO : ∀ ⦃G⦄, Set.MapsTo (edgeO G) (outFlags G) (edges G)
-  -- eq_of_source_eq_of_edgeI_eq : ∀ ⦃G i i'⦄, i ∈ inFlags G → i' ∈ inFlags G →
-  --   source G i = source G i' → edgeI G i = edgeI G i' → i = i'
-  -- eq_of_target_eq_of_edgeO_eq : ∀ ⦃G o o'⦄, o ∈ outFlags G → o' ∈ outFlags G →
-  --   target G o = target G o' → edgeO G o = edgeO G o' → o = o'
-  mem_verts_of_isSource : ∀ ⦃G e x⦄, IsSource G e x → x ∈ verts G
-  mem_verts_of_isTarget : ∀ ⦃G e x⦄, IsTarget G e x → x ∈ verts G
-  mem_edges_of_isSource : ∀ ⦃G e x⦄, IsSource G e x → e ∈ edges G
-  mem_edges_of_isTarget : ∀ ⦃G e x⦄, IsTarget G e x → e ∈ edges G
-  -- mem_inFlags_iff : ∀ ⦃G i⦄, i ∈ inFlags G ↔
-  --     (∃! x ∈ verts G, IsSource G i x) ∧ (∃! e ∈ edges G, IsInPort G e i)
-  -- mem_outFlags_iff : ∀ ⦃G o⦄, o ∈ outFlags G ↔
-  --     (∃! x ∈ verts G, IsTarget G o x) ∧ (∃! e ∈ edges G, IsOutPort G e o)
+  source : Gr → I →. V
+  target : Gr → O →. V
+  edgeI : Gr → I →. E
+  edgeO : Gr → O →. E
+  dom_source_eq_dom_edgeI : ∀ ⦃G⦄, (source G).Dom = (edgeI G).Dom
+  dom_target_eq_dom_edgeO : ∀ ⦃G⦄, (target G).Dom = (edgeO G).Dom
+  ran_source_subset_verts : ∀ ⦃G⦄, (source G).ran ⊆ verts G
+  ran_target_subset_verts : ∀ ⦃G⦄, (target G).ran ⊆ verts G
+  ran_edgeI_subset_edges : ∀ ⦃G⦄, (edgeI G).ran ⊆ edges G
+  ran_edgeO_subset_edges : ∀ ⦃G⦄, (edgeO G).ran ⊆ edges G
 
 namespace HyperGraphLike
 
-variable [HyperGraphLike V E Gr] {G : Gr}
+variable [HyperGraphLike V I O E Gr] {G : Gr}
 
--- def IsEdgeSource (G : Gr) (e : E) (v : V) : Prop := ∃ i ∈ inFlags G, source G i = v ∧ edgeI G i = e
+-- def inFlags (G : Gr) : Set I := (source G).Dom
 
--- def IsEdgeTarget (G : Gr) (e : E) (v : V) : Prop := ∃ o ∈ outFlags G, target G o = v ∧ edgeO G o = e
+-- def outFlags (G : Gr) : Set O := (target G).Dom
 
--- def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsEdgeSource G e x ∧ IsEdgeTarget G e y
+def mem_verts_of_mem_source {v : V} {i : I} (h : v ∈ source G i) : v ∈ verts G :=
+  ran_source_subset_verts ⟨i, h⟩
 
-def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsSource G e x ∧ IsTarget G e y
+def mem_verts_of_mem_target {v : V} {o : O} (h : v ∈ target G o) : v ∈ verts G :=
+  ran_target_subset_verts ⟨o, h⟩
 
--- @[implicit_reducible]
--- def ofIsSourceIsTarget (verts : Gr → Set V) (edges : Gr → Set E)
---     (IsEdgeSource : Gr → E → V → Prop) (IsEdgeTarget : Gr → E → V → Prop)
---     (mem_verts_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → v ∈ verts G)
---     (mem_edges_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → e ∈ edges G)
---     (mem_verts_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → v ∈ verts G)
---     (mem_edges_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → e ∈ edges G)
---     : HyperGraphLike V (E × V) (E × V) E Gr where
---   verts := verts
---   inFlags G := {d | IsEdgeSource G d.1 d.2}
---   outFlags G := {d | IsEdgeTarget G d.1 d.2}
---   edges := edges
---   source _ d := d.2
---   target _ d := d.2
---   edgeI _ d := d.1
---   edgeO _ d := d.1
---   mapsTo_source G i hi := mem_verts_of_isEdgeSource hi
---   mapsTo_target G o ho := mem_verts_of_isEdgeTarget ho
---   mapsTo_edgeI G i hi := mem_edges_of_isEdgeSource hi
---   mapsTo_edgeO G o ho := mem_edges_of_isEdgeTarget ho
---   eq_of_source_eq_of_edgeI_eq G i i' _ _ h h' := by cases i; cases i'; congr
---   eq_of_target_eq_of_edgeO_eq G o o' _ _ h h' := by cases o; cases o'; congr
+def mem_edges_of_mem_edgeI {e : E} {i : I} (h : e ∈ edgeI G i) : e ∈ edges G :=
+  ran_edgeI_subset_edges ⟨i, h⟩
 
--- def Adj (G : Gr) (x y : V) : Prop := ∃ e ∈ edges G, IsEdgeSource G e x ∧ IsEdgeTarget G e y
+def mem_edges_of_mem_edgeO {e : E} {o : O} (h : e ∈ edgeO G o) : e ∈ edges G :=
+  ran_edgeO_subset_edges ⟨o, h⟩
 
-def Adj (G : Gr) (x y : V) : Prop := ∃ e, IsSource G e x ∧ IsTarget G e y
+def IsEdgeSource (G : Gr) (e : E) (v : V) : Prop := ∃ i, v ∈ source G i ∧ e ∈ edgeI G i
 
--- def FlagsInc (G : Gr) (i : I) (o : O) : Prop :=
---     edgeI G i = edgeO G o ∧ i ∈ inFlags G ∧ o ∈ outFlags G
+def IsEdgeTarget (G : Gr) (e : E) (v : V) : Prop := ∃ o, v ∈ target G o ∧ e ∈ edgeO G o
 
--- lemma Adj.iff_exists_inFlag_outFlag {G : Gr} {x y : V} :
---     Adj G x y ↔ ∃ i o, FlagsInc G i o ∧ source G i = x ∧ target G o = y := by
---   simp_rw [Adj, IsEdgeSource, IsEdgeTarget, FlagsInc]
---   constructor
---   · rintro ⟨_, he, ⟨i, hi, rfl, rfl⟩, o, ho, rfl, h⟩
---     use i, o
---     grind
---   · rintro ⟨i, o, ⟨he, hi, ho⟩, rfl, rfl⟩
---     exact ⟨edgeI G i, mapsTo_edgeI hi, ⟨i, hi, rfl, rfl⟩, o, ho, rfl, he.symm⟩
+def IsLink (G : Gr) (e : E) (x y : V) : Prop := IsEdgeSource G e x ∧ IsEdgeTarget G e y
+
+@[implicit_reducible]
+def ofIsSourceIsTarget (verts : Gr → Set V) (edges : Gr → Set E)
+    (IsEdgeSource : Gr → E → V → Prop) (IsEdgeTarget : Gr → E → V → Prop)
+    (mem_verts_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → v ∈ verts G)
+    (mem_edges_of_isEdgeSource : ∀ ⦃G e v⦄, IsEdgeSource G e v → e ∈ edges G)
+    (mem_verts_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → v ∈ verts G)
+    (mem_edges_of_isEdgeTarget : ∀ ⦃G e v⦄, IsEdgeTarget G e v → e ∈ edges G)
+    : HyperGraphLike V (E × V) (E × V) E Gr where
+  verts := verts
+  edges := edges
+  source G d := ⟨IsEdgeSource G d.1 d.2, fun _ => d.2⟩
+  target G d := ⟨IsEdgeTarget G d.1 d.2, fun _ => d.2⟩
+  edgeI G d := ⟨IsEdgeSource G d.1 d.2, fun _ => d.1⟩
+  edgeO G d := ⟨IsEdgeTarget G d.1 d.2, fun _ => d.1⟩
+  dom_source_eq_dom_edgeI _ := rfl
+  dom_target_eq_dom_edgeO _ := rfl
+  ran_source_subset_verts _ _ := fun ⟨_, h, h'⟩ => h' ▸ mem_verts_of_isEdgeSource h
+  ran_target_subset_verts _ _ := fun ⟨_, h, h'⟩ => h' ▸ mem_verts_of_isEdgeTarget h
+  ran_edgeI_subset_edges _ _ := fun ⟨_, h, h'⟩ => h' ▸ mem_edges_of_isEdgeSource h
+  ran_edgeO_subset_edges _ _ := fun ⟨_, h, h'⟩ => h' ▸ mem_edges_of_isEdgeTarget h
+
+def Adj (G : Gr) (x y : V) : Prop := ∃ e ∈ edges G, IsEdgeSource G e x ∧ IsEdgeTarget G e y
+
+def FlagsInc (G : Gr) (i : I) (o : O) : Prop := ∃ e, e ∈ edgeI G i ∧ e ∈ edgeO G o
+
+lemma Adj.iff_exists_inFlag_outFlag {G : Gr} {x y : V} :
+    Adj G x y ↔ ∃ i o, FlagsInc G i o ∧ x ∈ source G i ∧ y ∈ target G o := by
+  simp_rw [Adj, IsEdgeSource, IsEdgeTarget, FlagsInc]
+  constructor
+  · grind
+  · rintro ⟨i, o, ⟨⟨e, he⟩, he'⟩⟩
+    use! e, mem_edges_of_mem_edgeI he.1
+    grind
 
 structure Dart (G : Gr) where
-  source : V
-  target : V
-  edge : E
-  isLink : IsLink G edge source target
+  i : I
+  o : O
+  inc : FlagsInc G i o
 
 namespace Dart
 
--- @[ext]
--- protected lemma ext {d d' : Dart G} (hi : d.i = d'.i) (ho : d.o = d'.o) : d = d' := by
---   cases d; cases d'; congr
+@[ext]
+protected lemma ext {d d' : Dart G} (hi : d.i = d'.i) (ho : d.o = d'.o) : d = d' := by
+  cases d; cases d'; congr
 
 -- lemma inFlag_mem (d : Dart G) : d.i ∈ inFlags G := d.inc.2.1
 

--- a/Mathlib/Combinatorics/GraphLike/Walk.lean
+++ b/Mathlib/Combinatorics/GraphLike/Walk.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 Thomas Waring. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jun Kwon, Thomas Waring
+-/
+module
+
+public import Mathlib.Combinatorics.GraphLike.Basic
+public import Mathlib.Combinatorics.SimpleGraph.Walk.Basic
+
+public section
+
+namespace HyperGraphLike
+
+variable {V E Gr : Type*} [HyperGraphLike V E Gr]
+
+inductive GLWalk (G : Gr) : V → V → Type _ where
+  | nil {x : V} (h : x ∈ verts G) : GLWalk G x x
+  | cons {x y z : V} {e : E} (h : IsLink G e x y) (p : GLWalk G y z) : GLWalk G x z
+
+end HyperGraphLike
+
+open HyperGraphLike SimpleGraph
+
+variable {V : Type*} {G : SimpleGraph V}
+
+def SimpleGraph.Walk.toGLWalk {x y : V} (p : G.Walk x y) : GLWalk G x y :=
+  match p with
+  | nil => GLWalk.nil trivial
+  | cons h p => GLWalk.cons ⟨h, rfl⟩ (p.toGLWalk)
+
+def HyperGraphLike.GLWalk.toSimpleGraphWalk {x y : V} (p : GLWalk G x y) : G.Walk x y :=
+  match p with
+  | nil _ => Walk.nil
+  | cons h p => Walk.cons h.1 p.toSimpleGraphWalk
+
+def walkEquivGLWalk {x y : V} : G.Walk x y ≃ GLWalk G x y where
+  toFun := SimpleGraph.Walk.toGLWalk
+  invFun := HyperGraphLike.GLWalk.toSimpleGraphWalk
+  left_inv p := by
+    induction p <;> simp_all [Walk.toGLWalk, GLWalk.toSimpleGraphWalk]
+  right_inv p := by
+    induction p with
+    | nil => simp [Walk.toGLWalk, GLWalk.toSimpleGraphWalk]
+    | cons h _ => simp_all [Walk.toGLWalk, GLWalk.toSimpleGraphWalk, h.2]


### PR DESCRIPTION
A proposal for a typeclass representing `GraphLike` objects. This is axiomatised in terms of a relations `IsSource` and `IsTarget` between edges and vertices, as well as `IsLink` to represent walks of length one.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
