### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Sites): a cover preserving functor that preserves pullbacks preserves `1`-hypercovers

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Continuous.lean
+++ b/Mathlib/CategoryTheory/Sites/Continuous.lean
@@ -85,6 +85,58 @@ then `(E.map F).multifork P` is a limit iff `E.multifork (F.op ⋙ P)` is a limi
 def isLimitMapMultiforkEquiv {A : Type u} [Category.{t} A] (P : Dᵒᵖ ⥤ A) :
     IsLimit ((E.map F).multifork P) ≃ IsLimit (E.multifork (F.op ⋙ P)) := by rfl
 
+section
+
+variable {E} {W : C} {i₁ i₂ : E.I₀} (p₁ : W ⟶ E.X i₁) (p₂ : W ⟶ E.X i₂)
+
+lemma functorPushforward_sieve₁_map_le :
+    Sieve.functorPushforward F (E.sieve₁ p₁ p₂) ≤ (E.map F).sieve₁ (F.map p₁) (F.map p₂) := by
+  rw [Sieve.functorPushforward_le_iff_le_functorPullback]
+  intro Y f ⟨k, u, hf₁, hf₂⟩
+  exact ⟨k, F.map u, by simp [← Functor.map_comp, hf₁], by simp [← Functor.map_comp, hf₂]⟩
+
+variable (i₁ i₂) in
+set_option backward.isDefEq.respectTransparency false in
+lemma functorPushforward_sieve₁'_of_preservesLimit [HasPullback (E.f i₁) (E.f i₂)]
+    [PreservesLimit (cospan (E.f i₁) (E.f i₂)) F] :
+    Sieve.functorPushforward F (E.sieve₁' i₁ i₂) =
+      (E.map F).sieve₁ (F.map <| pullback.fst _ _) (F.map <| pullback.snd _ _) := by
+  have : HasPullback ((E.map F).f i₁) ((E.map F).f i₂) :=
+    hasPullback_of_preservesPullback F (E.f i₁) (E.f i₂)
+  refine le_antisymm ?_ ?_
+  · rw [PreOneHypercover.sieve₁'_eq_sieve₁]
+    apply PreOneHypercover.functorPushforward_sieve₁_map_le
+  · rw [PreOneHypercover.sieve₁_eq_pullback_sieve₁' _ _ _
+      (by simp [← Functor.map_comp, pullback.condition])]
+    rintro W f ⟨Z, u, v, ⟨k⟩, h⟩
+    refine ⟨E.Y k, pullback.lift (E.p₁ k) (E.p₂ k) (E.w _), u, ?_, ?_⟩
+    · use E.Y k, 𝟙 _, pullback.lift (E.p₁ k) (E.p₂ k) (E.w _), ⟨k⟩
+      simp
+    · simp only [pullback.hom_ext_iff, Category.assoc, limit.lift_π, PullbackCone.mk_π_app] at h
+      apply IsPullback.hom_ext (IsPullback.map _ (.of_hasPullback _ _)) <;>
+        simp [← h.left, ← h.right, ← Functor.map_comp]
+
+set_option backward.isDefEq.respectTransparency false in
+lemma functorPushforward_sieve₁_of_preservesLimitsOfShape (h : p₁ ≫ E.f _ = p₂ ≫ E.f _)
+    [HasPullbacks C] [PreservesLimitsOfShape WalkingCospan F] :
+    Sieve.functorPushforward F (E.sieve₁ p₁ p₂) = (E.map F).sieve₁ (F.map p₁) (F.map p₂) := by
+  refine le_antisymm (PreOneHypercover.functorPushforward_sieve₁_map_le _ _ _) ?_
+  have : HasPullback ((E.map F).f i₁) ((E.map F).f i₂) :=
+    hasPullback_of_preservesPullback F (E.f i₁) (E.f i₂)
+  rintro T f ⟨k, u, hf₁, hf₂⟩
+  let l : W ⟶ pullback (E.f i₁) (E.f i₂) := pullback.lift p₁ p₂ h
+  have hl₁ : l ≫ pullback.fst _ _ = p₁ := by simp [l]
+  have hl₂ : l ≫ pullback.snd _ _ = p₂ := by simp [l]
+  let r : E.Y k ⟶ pullback (E.f i₁) (E.f i₂) := pullback.lift (E.p₁ _) (E.p₂ _) (E.w _)
+  refine ⟨pullback l r, pullback.fst _ _, IsPullback.lift
+    (IsPullback.map _ (.of_hasPullback _ _)) f u ?_, ?_, ?_⟩
+  · apply (IsPullback.map _ (.of_hasPullback _ _)).hom_ext <;>
+      simp [l, r, ← Functor.map_comp, hf₁, hf₂]
+  · refine ⟨k, pullback.snd _ _, ?_, ?_⟩ <;> simp [← hl₁, ← hl₂, pullback.condition_assoc, r]
+  · simp
+
+end
+
 end PreOneHypercover
 
 namespace GrothendieckTopology

--- a/Mathlib/CategoryTheory/Sites/Continuous.lean
+++ b/Mathlib/CategoryTheory/Sites/Continuous.lean
@@ -117,7 +117,7 @@ lemma functorPushforward_sieve₁'_of_preservesLimit [HasPullback (E.f i₁) (E.
         simp [← h.left, ← h.right, ← Functor.map_comp]
 
 set_option backward.isDefEq.respectTransparency false in
-lemma functorPushforward_sieve₁_of_preservesLimitsOfShape (h : p₁ ≫ E.f _ = p₂ ≫ E.f _)
+lemma functorPushforward_sieve₁_of_preservesPullbacks (h : p₁ ≫ E.f _ = p₂ ≫ E.f _)
     [HasPullbacks C] [PreservesLimitsOfShape WalkingCospan F] :
     Sieve.functorPushforward F (E.sieve₁ p₁ p₂) = (E.map F).sieve₁ (F.map p₁) (F.map p₂) := by
   refine le_antisymm (PreOneHypercover.functorPushforward_sieve₁_map_le _ _ _) ?_

--- a/Mathlib/CategoryTheory/Sites/CoverPreserving.lean
+++ b/Mathlib/CategoryTheory/Sites/CoverPreserving.lean
@@ -179,10 +179,10 @@ lemma Functor.PreservesOneHypercovers.of_coverPreserving [HasPullbacks C]
     have : HasPullback ((E.toPreOneHypercover.map F).f i₁) ((E.toPreOneHypercover.map F).f i₂) :=
       hasPullback_of_preservesPullback F (E.f i₁) (E.f i₂)
     have := H.cover_preserve (E.mem₁ i₁ i₂ (pullback.fst (E.f i₁) (E.f i₂)) _ pullback.condition)
-    rw [PreOneHypercover.functorPushforward_sieve₁_of_preservesLimitsOfShape] at this
-    · refine K.superset_covering ?_
-        (K.pullback_stable (IsPullback.lift (.map _ (.of_hasPullback _ _)) p₁ p₂ h) this)
-      simp [PreOneHypercover.pullback_sieve₁]
-    · exact pullback.condition
+    rw [PreOneHypercover.functorPushforward_sieve₁_of_preservesLimitsOfShape _ _ _
+      pullback.condition] at this
+    refine K.superset_covering ?_
+      (K.pullback_stable (IsPullback.lift (.map _ (.of_hasPullback _ _)) p₁ p₂ h) this)
+    simp [PreOneHypercover.pullback_sieve₁]
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/CoverPreserving.lean
+++ b/Mathlib/CategoryTheory/Sites/CoverPreserving.lean
@@ -179,7 +179,7 @@ lemma Functor.PreservesOneHypercovers.of_coverPreserving [HasPullbacks C]
     have : HasPullback ((E.toPreOneHypercover.map F).f i₁) ((E.toPreOneHypercover.map F).f i₂) :=
       hasPullback_of_preservesPullback F (E.f i₁) (E.f i₂)
     have := H.cover_preserve (E.mem₁ i₁ i₂ (pullback.fst (E.f i₁) (E.f i₂)) _ pullback.condition)
-    rw [PreOneHypercover.functorPushforward_sieve₁_of_preservesLimitsOfShape _ _ _
+    rw [PreOneHypercover.functorPushforward_sieve₁_of_preservesPullbacks _ _ _
       pullback.condition] at this
     refine K.superset_covering ?_
       (K.pullback_stable (IsPullback.lift (.map _ (.of_hasPullback _ _)) p₁ p₂ h) this)

--- a/Mathlib/CategoryTheory/Sites/CoverPreserving.lean
+++ b/Mathlib/CategoryTheory/Sites/CoverPreserving.lean
@@ -168,4 +168,21 @@ lemma Functor.isContinuous_of_coverPreserving (hF₁ : CompatiblePreserving.{max
       rintro Y _ ⟨Z, g, h, hg, rfl⟩
       simpa using congrArg _ ((hy₁ g hg).trans (hy₂ g hg).symm)
 
+/-- If `C` has pullbacks and `F : C ⥤ D` preserves pullbacks, any cover preserving
+functor preserves all `1`-hypercovers. -/
+lemma Functor.PreservesOneHypercovers.of_coverPreserving [HasPullbacks C]
+    [PreservesLimitsOfShape WalkingCospan F] (H : CoverPreserving J K F) :
+    Functor.PreservesOneHypercovers.{w} F J K := by
+  refine fun {U} E ↦ ⟨?_, fun i₁ i₂ W p₁ p₂ h ↦ ?_⟩
+  · simp [PreZeroHypercover.sieve₀_map, H.cover_preserve E.mem₀]
+  · let P : C := pullback (E.f i₁) (E.f i₂)
+    have : HasPullback ((E.toPreOneHypercover.map F).f i₁) ((E.toPreOneHypercover.map F).f i₂) :=
+      hasPullback_of_preservesPullback F (E.f i₁) (E.f i₂)
+    have := H.cover_preserve (E.mem₁ i₁ i₂ (pullback.fst (E.f i₁) (E.f i₂)) _ pullback.condition)
+    rw [PreOneHypercover.functorPushforward_sieve₁_of_preservesLimitsOfShape] at this
+    · refine K.superset_covering ?_
+        (K.pullback_stable (IsPullback.lift (.map _ (.of_hasPullback _ _)) p₁ p₂ h) this)
+      simp [PreOneHypercover.pullback_sieve₁]
+    · exact pullback.condition
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Hypercover/One.lean
+++ b/Mathlib/CategoryTheory/Sites/Hypercover/One.lean
@@ -76,8 +76,7 @@ lemma pullback_sieve₁ {i₁ i₂ : E.I₀} {W : C} (p₁ : W ⟶ E.X i₁) (p�
     Sieve.pullback f (E.sieve₁ p₁ p₂) = E.sieve₁ (f ≫ p₁) (f ≫ p₂) := by
   refine le_antisymm ?_ ?_ <;>
   · intro Z g ⟨k, u, hu₁, hu₂⟩
-    use k, u
-    simp_all
+    cat_disch
 
 section
 

--- a/Mathlib/CategoryTheory/Sites/Hypercover/One.lean
+++ b/Mathlib/CategoryTheory/Sites/Hypercover/One.lean
@@ -71,6 +71,14 @@ def sieve₁ {i₁ i₂ : E.I₀} {W : C} (p₁ : W ⟶ E.X i₁) (p₂ : W ⟶ 
     rintro Z Z' g ⟨j, h, fac₁, fac₂⟩ φ
     exact ⟨j, φ ≫ h, by simpa using φ ≫= fac₁, by simpa using φ ≫= fac₂⟩
 
+lemma pullback_sieve₁ {i₁ i₂ : E.I₀} {W : C} (p₁ : W ⟶ E.X i₁) (p₂ : W ⟶ E.X i₂)
+    {T : C} (f : T ⟶ W) :
+    Sieve.pullback f (E.sieve₁ p₁ p₂) = E.sieve₁ (f ≫ p₁) (f ≫ p₂) := by
+  refine le_antisymm ?_ ?_ <;>
+  · intro Z g ⟨k, u, hu₁, hu₂⟩
+    use k, u
+    simp_all
+
 section
 
 variable {i₁ i₂ : E.I₀} [HasPullback (E.f i₁) (E.f i₂)]
@@ -78,6 +86,14 @@ variable {i₁ i₂ : E.I₀} [HasPullback (E.f i₁) (E.f i₂)]
 /-- The obvious morphism `E.Y j ⟶ pullback (E.f i₁) (E.f i₂)` given by `E : PreOneHypercover S`. -/
 noncomputable abbrev toPullback (j : E.I₁ i₁ i₂) : E.Y j ⟶ pullback (E.f i₁) (E.f i₂) :=
   pullback.lift (E.p₁ j) (E.p₂ j) (E.w j)
+
+@[reassoc (attr := simp)]
+lemma toPullback_fst (k : E.I₁ i₁ i₂) : E.toPullback k ≫ pullback.fst _ _ = E.p₁ k := by
+  rw [pullback.lift_fst]
+
+@[reassoc (attr := simp)]
+lemma toPullback_snd (k : E.I₁ i₁ i₂) : E.toPullback k ≫ pullback.snd _ _ = E.p₂ k := by
+  rw [pullback.lift_snd]
 
 variable (i₁ i₂) in
 /-- The sieve of `pullback (E.f i₁) (E.f i₂)` given by `E : PreOneHypercover S`. -/


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
