### PR TITLE
add linter for name capitalization

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -482,7 +482,11 @@ initialize addLinter longLineLinter
 end Style.longLine
 
 /-- The `nameCheck` linter emits a warning on declarations whose name is non-standard style.
-(Currently, this only includes declarations whose name includes a double underscore.)
+Currently, this checks:
+- Declarations whose name includes a double underscore.
+- (When `linter.style.nameCheck.capitalization` is enabled) declarations whose case does not match
+  the mathlib naming conventions: `theorem`/`lemma` should be `snake_case`,
+  `structure`/`class`/`inductive` should be `UpperCamelCase`.
 
 **Why is this bad?** Double underscores in theorem names can be considered non-standard style and
 probably have been introduced by accident.
@@ -492,6 +496,31 @@ conventions.
 public register_option linter.style.nameCheck : Bool := {
   defValue := true
   descr := "enable the `nameCheck` linter"
+}
+
+/--
+The `nameCheck.capitalization` linter checks that declaration names follow the mathlib
+capitalization conventions described at
+<https://leanprover-community.github.io/contribute/naming.html#capitalization>:
+
+- `theorem` and `lemma` names should be `snake_case`: the last name component, and each
+  underscore-separated chunk thereof, should not start with an uppercase letter.
+- `structure`, `class`, `inductive` and `class inductive` names should be `UpperCamelCase`:
+  the last name component should start with an uppercase letter and contain no underscores.
+
+`def`, `abbrev`, `instance` and `opaque` are not checked because the appropriate convention
+depends on whether the elaborated declaration is a `Prop`, a `Type`, or another term — which
+cannot be determined from syntax alone.
+
+**Why is this bad?** Consistent capitalization makes names easier to read and search for.
+
+**How to fix this?** Rename the declaration to follow the convention above. Rare exceptions
+exist (e.g. `Ne`, `outParam`, interval notation like `Set.Icc`); locally disable the linter
+with `set_option linter.style.nameCheck.capitalization false in` for those.
+-/
+public register_option linter.style.nameCheck.capitalization : Bool := {
+  defValue := false
+  descr := "enable capitalization checks (snake_case vs UpperCamelCase) in the `nameCheck` linter"
 }
 
 namespace Style.nameCheck
@@ -517,6 +546,136 @@ def doubleUnderscore : Linter where run := withSetOptionIn fun stx => do
               conventions. Consider using single underscores instead."
 
 initialize addLinter doubleUnderscore
+
+/-- The capitalization convention expected for a declaration's last name component. -/
+private inductive ExpectedCase
+  /-- `snake_case`: each underscore-separated chunk starts with a non-uppercase character. -/
+  | snakeCase
+  /-- `UpperCamelCase`: the component starts with an uppercase letter and has no underscores. -/
+  | upperCamelCase
+  /-- `lowerCamelCase`: the component starts with a lowercase letter and has no underscores. -/
+  | lowerCamelCase
+
+/-- The classification of a declaration for the capitalization linter. For most kinds the expected
+case is fixed by the keyword; for `def`/`abbrev`/`opaque`/`instance` it depends on the
+elaborated return type. -/
+private inductive DeclClass
+  /-- The expected case is fixed by the keyword. -/
+  | byKeyword (case : ExpectedCase) (kindStr : String)
+  /-- The expected case depends on the elaborated return type. -/
+  | byType (kindStr : String)
+
+/-- Given a top-level declaration `Syntax`, classify it for the capitalization linter, or return
+`none` if this linter does not check the kind. -/
+private def classifyDecl (stx : Syntax) : Option DeclClass :=
+  -- `lemma` is registered as a separate top-level command (later expanded to `theorem`).
+  if stx.getKind == `Mathlib.Tactic.lemma || stx.getKind == `lemma then
+    some (.byKeyword .snakeCase "lemma")
+  else if stx.isOfKind ``Lean.Parser.Command.declaration then
+    let inner := stx[1]
+    if inner.isOfKind ``Lean.Parser.Command.theorem then
+      some (.byKeyword .snakeCase "theorem")
+    else if inner.isOfKind ``Lean.Parser.Command.structure then
+      -- `structure` and `class` share this kind; both require `UpperCamelCase`.
+      some (.byKeyword .upperCamelCase "structure or class")
+    else if inner.isOfKind ``Lean.Parser.Command.inductive then
+      some (.byKeyword .upperCamelCase "inductive type")
+    else if inner.isOfKind ``Lean.Parser.Command.classInductive then
+      some (.byKeyword .upperCamelCase "class inductive")
+    else if inner.isOfKind ``Lean.Parser.Command.definition then
+      some (.byType "def")
+    else if inner.isOfKind ``Lean.Parser.Command.abbrev then
+      some (.byType "abbrev")
+    else if inner.isOfKind ``Lean.Parser.Command.opaque then
+      some (.byType "opaque")
+    else if inner.isOfKind ``Lean.Parser.Command.instance then
+      some (.byType "instance")
+    else
+      none
+  else
+    none
+
+/-- A `String` is considered to start with an uppercase letter for the purposes of these checks. -/
+private def startsUpper (s : String) : Bool :=
+  !s.isEmpty && s.front.isUpper
+
+/-- A `String` contains only "ordinary" identifier characters: ASCII letters, digits and `_`.
+Names with other characters are likely intentional (e.g. notation, `«…»`-quoted names) and are
+skipped to avoid false positives. -/
+private def isOrdinaryIdent (s : String) : Bool :=
+  s.all fun c => c.isAlphanum || c == '_'
+
+/-- Given the type of a `def`/`abbrev`/`opaque`/`instance`, determine the expected case based on
+the ultimate return type (stripping all `Π` binders).
+
+- If the return type is itself a sort (`Prop`, `Type _`), the declaration introduces a `Prop`
+  or `Type`, so the name should be `UpperCamelCase` (rule 2).
+- Otherwise, if the return type *has* type `Prop`, the declaration produces a proof, so the
+  name should be `snake_case` (rule 1).
+- Otherwise, the declaration produces a term of some `Type`, so the name should be
+  `lowerCamelCase` (rule 4). -/
+private def caseFromType (typ : Expr) : MetaM ExpectedCase :=
+  Meta.forallTelescopeReducing typ fun _ ret => do
+    if ret.isSort then
+      return .upperCamelCase
+    else if (← Meta.isProp ret) then
+      return .snakeCase
+    else
+      return .lowerCamelCase
+
+@[inherit_doc linter.style.nameCheck.capitalization]
+def capitalization : Linter where run := withSetOptionIn fun stx => do
+    unless getLinterValue linter.style.nameCheck.capitalization (← getLinterOptions) do
+      return
+    if (← get).messages.hasErrors then
+      return
+    let some declClass := classifyDecl stx | return
+    let some declIdStx := stx.find? (·.isOfKind ``declId) | return
+    let id := declIdStx[0]
+    if id.getPos? == some default then return
+    if id.getKind != `ident then return
+    let parsedName := id.getId
+    if parsedName.hasMacroScopes then return
+    -- Resolve `_root_.foo` to `foo`, and otherwise prepend the current namespace.
+    let fullName : Name :=
+      if let `_root_ :: rest := parsedName.components then
+        rest.foldl (· ++ ·) default
+      else (← getCurrNamespace) ++ parsedName
+    -- Only check the last component of the name (the part after the final namespace `.`).
+    let last := fullName.getString!
+    -- Skip names that include underscored prefixes or non-letter characters; these are usually
+    -- auto-generated (e.g. `_aux_…`) or intentionally quoted with `«…»`.
+    if last.startsWith "_" then return
+    unless isOrdinaryIdent last do return
+    let (expected, kindStr) ← match declClass with
+      | .byKeyword case kind => pure (case, kind)
+      | .byType kind =>
+        let some info := (← getEnv).find? fullName | return
+        let case ← try liftTermElabM <| caseFromType info.type catch _ => return
+        pure (case, kind)
+    match expected with
+    | .snakeCase =>
+      if last.splitOn "_" |>.any startsUpper then
+        Linter.logLint linter.style.nameCheck.capitalization id m!"\
+          The {kindStr} name '{last}' does not follow the mathlib snake_case convention. \
+          Each underscore-separated chunk should start with a lowercase letter.\n\
+          See https://leanprover-community.github.io/contribute/naming.html#capitalization."
+    | .upperCamelCase =>
+      if !startsUpper last || last.contains '_' then
+        Linter.logLint linter.style.nameCheck.capitalization id m!"\
+          The {kindStr} name '{last}' does not follow the mathlib UpperCamelCase convention. \
+          Names of types, structures, classes and inductives should start with an uppercase \
+          letter and contain no underscores.\n\
+          See https://leanprover-community.github.io/contribute/naming.html#capitalization."
+    | .lowerCamelCase =>
+      if startsUpper last || last.contains '_' then
+        Linter.logLint linter.style.nameCheck.capitalization id m!"\
+          The {kindStr} name '{last}' does not follow the mathlib lowerCamelCase convention. \
+          Definitions whose return value is a term of a `Type` should start with a lowercase \
+          letter and contain no underscores.\n\
+          See https://leanprover-community.github.io/contribute/naming.html#capitalization."
+
+initialize addLinter capitalization
 
 end Style.nameCheck
 

--- a/MathlibTest/NameCheckCapitalization.lean
+++ b/MathlibTest/NameCheckCapitalization.lean
@@ -1,0 +1,192 @@
+import Mathlib.Tactic.Linter.Style
+import Mathlib.Tactic.Lemma
+
+set_option linter.style.nameCheck.capitalization true
+
+/-! ## Positive examples (no warnings expected) -/
+
+theorem good_snake_case : True := trivial
+
+theorem good_with_camelCase_chunk : True := trivial
+
+lemma good_lemma_name : True := trivial
+
+structure GoodStruct where
+  x : Nat
+
+class GoodClass where
+  y : Nat
+
+inductive GoodInductive where
+  | bar
+  | baz
+
+class inductive GoodClassInductive where
+  | bar
+
+-- A `def` whose return value is a term of a `Type` should be `lowerCamelCase`.
+def goodValueDef : Nat := 0
+
+-- A `def` whose return value is a `Type` should be `UpperCamelCase`.
+def GoodTypeDef : Type := Nat
+
+-- A `def` whose return value is a `Prop` (a "predicate") should also be `UpperCamelCase`.
+def GoodPredicate (n : Nat) : Prop := n = 0
+
+-- A `def` that ultimately produces a proof should be `snake_case`.
+def good_proof_def : ∀ n : Nat, n = n := fun _ => rfl
+
+-- `abbrev` follows the same rules as `def`.
+abbrev goodValueAbbrev : Nat := 0
+abbrev GoodTypeAbbrev : Type := Nat
+
+-- `opaque` follows the same rules. The return type is `Nat`, so lowerCamelCase.
+opaque goodValueOpaque : Nat
+
+-- An `instance` returns an instance of a class (a term of a `Type`), so lowerCamelCase.
+instance goodInstance : Inhabited Nat := ⟨0⟩
+
+/-! ## Negative examples (warnings expected) -/
+
+/--
+warning: The theorem name 'BadTheoremName' does not follow the mathlib snake_case convention. Each underscore-separated chunk should start with a lowercase letter.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+theorem BadTheoremName : True := trivial
+
+/--
+warning: The theorem name 'foo_Bar_baz' does not follow the mathlib snake_case convention. Each underscore-separated chunk should start with a lowercase letter.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+theorem foo_Bar_baz : True := trivial
+
+/--
+warning: The lemma name 'BadLemma' does not follow the mathlib snake_case convention. Each underscore-separated chunk should start with a lowercase letter.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+lemma BadLemma : True := trivial
+
+/--
+warning: The structure or class name 'bad_struct' does not follow the mathlib UpperCamelCase convention. Names of types, structures, classes and inductives should start with an uppercase letter and contain no underscores.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+structure bad_struct where
+  x : Nat
+
+/--
+warning: The structure or class name 'badClass' does not follow the mathlib UpperCamelCase convention. Names of types, structures, classes and inductives should start with an uppercase letter and contain no underscores.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+class badClass where
+  y : Nat
+
+/--
+warning: The inductive type name 'bad_inductive' does not follow the mathlib UpperCamelCase convention. Names of types, structures, classes and inductives should start with an uppercase letter and contain no underscores.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+inductive bad_inductive where
+  | bar
+
+/--
+warning: The class inductive name 'bad_class_inductive' does not follow the mathlib UpperCamelCase convention. Names of types, structures, classes and inductives should start with an uppercase letter and contain no underscores.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+class inductive bad_class_inductive where
+  | bar
+
+-- A `def` whose return value is a term of a `Type` should be `lowerCamelCase`, not
+-- `UpperCamelCase`.
+/--
+warning: The def name 'BadValueDef' does not follow the mathlib lowerCamelCase convention. Definitions whose return value is a term of a `Type` should start with a lowercase letter and contain no underscores.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+def BadValueDef : Nat := 0
+
+-- A `def` whose return value is a term of a `Type` should be `lowerCamelCase`, not `snake_case`.
+/--
+warning: The def name 'bad_value_def' does not follow the mathlib lowerCamelCase convention. Definitions whose return value is a term of a `Type` should start with a lowercase letter and contain no underscores.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+def bad_value_def : Nat := 0
+
+-- A `def` whose return value is a `Type` should be `UpperCamelCase`.
+/--
+warning: The def name 'badTypeDef' does not follow the mathlib UpperCamelCase convention. Names of types, structures, classes and inductives should start with an uppercase letter and contain no underscores.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+def badTypeDef : Type := Nat
+
+-- A `def` whose return value is a `Prop` (a predicate) should be `UpperCamelCase`.
+/--
+warning: The def name 'badPredicate' does not follow the mathlib UpperCamelCase convention. Names of types, structures, classes and inductives should start with an uppercase letter and contain no underscores.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+def badPredicate (n : Nat) : Prop := n = 0
+
+-- A `def` whose return value is a proof should be `snake_case`.
+/--
+warning: The def name 'BadProofDef' does not follow the mathlib snake_case convention. Each underscore-separated chunk should start with a lowercase letter.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+def BadProofDef : ∀ n : Nat, n = n := fun _ => rfl
+
+-- `abbrev` follows the same rules.
+/--
+warning: The abbrev name 'BadValueAbbrev' does not follow the mathlib lowerCamelCase convention. Definitions whose return value is a term of a `Type` should start with a lowercase letter and contain no underscores.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+abbrev BadValueAbbrev : Nat := 0
+
+-- `instance` should be `lowerCamelCase`.
+/--
+warning: The instance name 'BadInstance' does not follow the mathlib lowerCamelCase convention. Definitions whose return value is a term of a `Type` should start with a lowercase letter and contain no underscores.
+See https://leanprover-community.github.io/contribute/naming.html#capitalization.
+
+Note: This linter can be disabled with `set_option linter.style.nameCheck.capitalization false`
+-/
+#guard_msgs in
+instance BadInstance : Inhabited Nat := ⟨0⟩
+
+/-! ## Default off: when the option is not set, nothing is flagged. -/
+
+set_option linter.style.nameCheck.capitalization false in
+theorem Silenced_When_Off : True := trivial


### PR DESCRIPTION
This PR adds a `nameCheck.capitalization` linter to try and capture the guidelines in [this section](https://leanprover-community.github.io/contribute/naming.html#capitalization) of the conventions page.

Some potentially relevant Zulip threads:

- [#lean4 > automatic spelling generation &amp; comparison](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/automatic.20spelling.20generation.20.26.20comparison/with/505760384)
- [#mathlib4 > naming convention linter](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/naming.20convention.20linter/with/564571875)
- [#mathlib4 > Naming convention](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Naming.20convention/with/535123036)

These changes were made entirely with Claude Code and have not currently been audited.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
