### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits): some API for binary (co)products

### DIFF
--- a/Mathlib/CategoryTheory/Adhesive/Basic.lean
+++ b/Mathlib/CategoryTheory/Adhesive/Basic.lean
@@ -183,7 +183,8 @@ theorem is_coprod_iff_isPushout {X E Y YE : C} (c : BinaryCofan X E) (hc : IsCol
     refine ⟨H, ⟨Limits.PushoutCocone.isColimitAux' _ ?_⟩⟩
     intro s
     dsimp
-    refine ⟨h.desc (BinaryCofan.mk (c.inr ≫ s.inr) s.inl), h.fac _ ⟨WalkingPair.right⟩, ?_, ?_⟩
+    refine ⟨BinaryCofan.IsColimit.desc h (c.inr ≫ s.inr) s.inl,
+        BinaryCofan.IsColimit.inr_desc h _ _, ?_, ?_⟩
     · apply BinaryCofan.IsColimit.hom_ext hc
       · rw [← H.w_assoc]; erw [h.fac _ ⟨WalkingPair.right⟩]; exact s.condition
       · rw [← Category.assoc]; exact h.fac _ ⟨WalkingPair.left⟩

--- a/Mathlib/CategoryTheory/Limits/Constructions/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/BinaryProducts.lean
@@ -64,9 +64,9 @@ def isPullbackOfIsTerminalIsProduct {W X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) (h
     IsLimit (PullbackCone.mk _ _ (show h ≫ f = k ≫ g from H₁.hom_ext _ _)) := by
   apply PullbackCone.isLimitAux'
   intro s
-  use H₂.lift (BinaryFan.mk s.fst s.snd)
-  use H₂.fac (BinaryFan.mk s.fst s.snd) ⟨WalkingPair.left⟩
-  use H₂.fac (BinaryFan.mk s.fst s.snd) ⟨WalkingPair.right⟩
+  use BinaryFan.IsLimit.lift H₂ s.fst s.snd
+  use BinaryFan.IsLimit.lift_fst _ _ _
+  use BinaryFan.IsLimit.lift_snd _ _ _
   intro m h₁ h₂
   apply H₂.hom_ext
   rintro ⟨⟨⟩⟩
@@ -171,9 +171,9 @@ def isPushoutOfIsInitialIsCoproduct {W X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) (h
     IsColimit (PushoutCocone.mk _ _ (show h ≫ f = k ≫ g from H₁.hom_ext _ _)) := by
   apply PushoutCocone.isColimitAux'
   intro s
-  use H₂.desc (BinaryCofan.mk s.inl s.inr)
-  use H₂.fac (BinaryCofan.mk s.inl s.inr) ⟨WalkingPair.left⟩
-  use H₂.fac (BinaryCofan.mk s.inl s.inr) ⟨WalkingPair.right⟩
+  use BinaryCofan.IsColimit.desc H₂ s.inl s.inr
+  use BinaryCofan.IsColimit.inl_desc H₂ _ _
+  use BinaryCofan.IsColimit.inr_desc H₂ _ _
   intro m h₁ h₂
   apply H₂.hom_ext
   rintro ⟨⟨⟩⟩

--- a/Mathlib/CategoryTheory/Limits/MonoCoprod.lean
+++ b/Mathlib/CategoryTheory/Limits/MonoCoprod.lean
@@ -55,7 +55,7 @@ variable {C}
 instance (priority := 100) monoCoprodOfHasZeroMorphisms [HasZeroMorphisms C] : MonoCoprod C :=
   ⟨fun A B c hc => by
     haveI : IsSplitMono c.inl :=
-      IsSplitMono.mk' (SplitMono.mk (hc.desc (BinaryCofan.mk (𝟙 A) 0)) (IsColimit.fac _ _ _))
+      IsSplitMono.mk' (SplitMono.mk (BinaryCofan.IsColimit.desc hc (𝟙 A) 0) (IsColimit.fac _ _ _))
     infer_instance⟩
 
 namespace MonoCoprod
@@ -64,7 +64,8 @@ set_option backward.isDefEq.respectTransparency false in
 theorem binaryCofan_inr {A B : C} [MonoCoprod C] (c : BinaryCofan A B) (hc : IsColimit c) :
     Mono c.inr := by
   haveI hc' : IsColimit (BinaryCofan.mk c.inr c.inl) :=
-    BinaryCofan.IsColimit.mk _ (fun f₁ f₂ => hc.desc (BinaryCofan.mk f₂ f₁))
+    BinaryCofan.IsColimit.mk _
+      (fun f₁ f₂ => BinaryCofan.IsColimit.desc (s := c) hc f₂ f₁)
       (by simp) (by simp)
       (fun f₁ f₂ m h₁ h₂ => BinaryCofan.IsColimit.hom_ext hc (by cat_disch) (by cat_disch))
   exact binaryCofan_inl _ hc'

--- a/Mathlib/CategoryTheory/Limits/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preorder.lean
@@ -152,7 +152,7 @@ def semilatticeInfOfIsLimitBinaryFan
   inf X Y := (c X Y).pt
   inf_le_left X Y := leOfHom (c X Y).fst
   inf_le_right X Y := leOfHom (c X Y).snd
-  le_inf _ _ _ le_fst le_snd := leOfHom <| (h _ _).lift (BinaryFan.mk le_fst.hom le_snd.hom)
+  le_inf _ _ _ le_fst le_snd := leOfHom <| BinaryFan.IsLimit.lift (h _ _) le_fst.hom le_snd.hom
 
 variable (C) in
 /-- If a partial order has binary products, then it is an inf-semilattice -/
@@ -170,7 +170,7 @@ def semilatticeSupOfIsColimitBinaryCofan
   sup X Y := (c X Y).pt
   le_sup_left X Y := leOfHom (c X Y).inl
   le_sup_right X Y := leOfHom (c X Y).inr
-  sup_le _ _ _ le_inl le_inr := leOfHom <| (h _ _).desc (BinaryCofan.mk le_inl.hom le_inr.hom)
+  sup_le _ _ _ le_inl le_inr := leOfHom <| BinaryCofan.IsColimit.desc (h _ _) le_inl.hom le_inr.hom
 
 variable (C) in
 /-- If a partial order has binary coproducts, then it is a sup-semilattice -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryBiproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryBiproducts.lean
@@ -533,12 +533,12 @@ theorem biprod.inr_snd {X Y : C} [HasBinaryBiproduct X Y] :
 /-- Given a pair of maps into the summands of a binary biproduct,
 we obtain a map into the binary biproduct. -/
 abbrev biprod.lift {W X Y : C} [HasBinaryBiproduct X Y] (f : W ⟶ X) (g : W ⟶ Y) : W ⟶ X ⊞ Y :=
-  (BinaryBiproduct.isLimit X Y).lift (BinaryFan.mk f g)
+  BinaryFan.IsLimit.lift (BinaryBiproduct.isLimit X Y) f g
 
 /-- Given a pair of maps out of the summands of a binary biproduct,
 we obtain a map out of the binary biproduct. -/
 abbrev biprod.desc {W X Y : C} [HasBinaryBiproduct X Y] (f : X ⟶ W) (g : Y ⟶ W) : X ⊞ Y ⟶ W :=
-  (BinaryBiproduct.isColimit X Y).desc (BinaryCofan.mk f g)
+  BinaryCofan.IsColimit.desc (BinaryBiproduct.isColimit X Y) f g
 
 @[reassoc (attr := simp)]
 theorem biprod.lift_fst {W X Y : C} [HasBinaryBiproduct X Y] (f : W ⟶ X) (g : W ⟶ Y) :

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -361,12 +361,51 @@ def BinaryCofan.isColimitMk {W : C} {inl : X ⟶ W} {inr : Y ⟶ W}
 /-- If `s` is a limit binary fan over `X` and `Y`, then every pair of morphisms `f : W ⟶ X` and
 `g : W ⟶ Y` induces a morphism `l : W ⟶ s.pt` satisfying `l ≫ s.fst = f` and `l ≫ s.snd = g`.
 -/
+def BinaryFan.IsLimit.lift {W : C} {s : BinaryFan X Y} (h : IsLimit s) (f : W ⟶ X) (g : W ⟶ Y) :
+    W ⟶ s.pt :=
+  h.lift (BinaryFan.mk f g)
+
+@[reassoc (attr := simp)]
+lemma BinaryFan.IsLimit.lift_fst {W : C} {s : BinaryFan X Y} (h : IsLimit s)
+    (f : W ⟶ X) (g : W ⟶ Y) :
+    lift h f g ≫ s.fst = f :=
+  h.fac (BinaryFan.mk f g) _
+
+@[reassoc (attr := simp)]
+lemma BinaryFan.IsLimit.lift_snd {W : C} {s : BinaryFan X Y} (h : IsLimit s)
+    (f : W ⟶ X) (g : W ⟶ Y) :
+    lift h f g ≫ s.snd = g :=
+  h.fac (BinaryFan.mk f g) _
+
+/-- If `s` is a limit binary fan over `X` and `Y`, then every pair of morphisms `f : W ⟶ X` and
+`g : W ⟶ Y` induces a morphism `l : W ⟶ s.pt` satisfying `l ≫ s.fst = f` and `l ≫ s.snd = g`.
+-/
 @[simps]
 def BinaryFan.IsLimit.lift' {W X Y : C} {s : BinaryFan X Y} (h : IsLimit s) (f : W ⟶ X)
     (g : W ⟶ Y) : { l : W ⟶ s.pt // l ≫ s.fst = f ∧ l ≫ s.snd = g } :=
   ⟨h.lift <| BinaryFan.mk f g, h.fac _ _, h.fac _ _⟩
 
-/-- If `s` is a colimit binary cofan over `X` and `Y`,, then every pair of morphisms `f : X ⟶ W` and
+/-- If `s` is a colimit binary cofan over `X` and `Y`, then every pair of morphisms `f : X ⟶ W` and
+`g : Y ⟶ W` induces a morphism `l : s.pt ⟶ W` satisfying `s.inl ≫ l = f` and `s.inr ≫ l = g`.
+-/
+def BinaryCofan.IsColimit.desc {W : C} {s : BinaryCofan X Y} (h : IsColimit s)
+    (f : X ⟶ W) (g : Y ⟶ W) :
+    s.pt ⟶ W :=
+  h.desc (BinaryCofan.mk f g)
+
+@[reassoc (attr := simp)]
+lemma BinaryCofan.IsColimit.desc_fst {W : C} {s : BinaryCofan X Y} (h : IsColimit s)
+    (f : X ⟶ W) (g : Y ⟶ W) :
+    s.inl ≫ desc h f g = f :=
+  h.fac (BinaryCofan.mk f g) _
+
+@[reassoc (attr := simp)]
+lemma BinaryCofan.IsColimit.desc_snd {W : C} {s : BinaryCofan X Y} (h : IsColimit s)
+    (f : X ⟶ W) (g : Y ⟶ W) :
+    s.inr ≫ desc h f g = g :=
+  h.fac (BinaryCofan.mk f g) _
+
+/-- If `s` is a colimit binary cofan over `X` and `Y`, then every pair of morphisms `f : X ⟶ W` and
 `g : Y ⟶ W` induces a morphism `l : s.pt ⟶ W` satisfying `s.inl ≫ l = f` and `s.inr ≫ l = g`.
 -/
 @[simps]
@@ -1070,6 +1109,24 @@ def coprod.functorLeftComp (X Y : C) :
   NatIso.ofComponents (coprod.associator _ _)
 
 end CoprodFunctor
+
+section
+
+variable {C} {D : Type*} [Category* D] {F : C ⥤ D}
+
+/-- `F.mapCone s` being limiting is the same as the induced binary fan being limiting. -/
+def BinaryFan.isLimitMapConeEquiv {X Y : C} {s : BinaryFan X Y} :
+    IsLimit (F.mapCone s) ≃ IsLimit (BinaryFan.mk (F.map s.fst) (F.map s.snd)) :=
+  IsLimit.equivOfNatIsoOfIso (diagramIsoPair _) _ _ <| BinaryFan.ext (Iso.refl _)
+    (by simp [BinaryFan.fst]) (by simp [BinaryFan.snd])
+
+/-- `F.mapCocone s` being colimiting is the same as the induced binary cofan being colimiting. -/
+def BinaryCofan.isColimitMapConeEquiv {X Y : C} {s : BinaryCofan X Y} :
+    IsColimit (F.mapCocone s) ≃ IsColimit (BinaryCofan.mk (F.map s.inl) (F.map s.inr)) :=
+  IsColimit.equivOfNatIsoOfIso (diagramIsoPair _) _ _ <| BinaryCofan.ext (Iso.refl _)
+    (by simp [BinaryCofan.inl]) (by simp [BinaryCofan.inr])
+
+end
 
 noncomputable section ProdComparison
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -1114,17 +1114,39 @@ section
 
 variable {C} {D : Type*} [Category* D] {F : C ⥤ D}
 
+variable (F) in
+/-- The image of a binary fan by a functor. -/
+abbrev BinaryFan.map {X Y : C} (s : BinaryFan X Y) : BinaryFan (F.obj X) (F.obj Y) :=
+  mk (F.map s.fst) (F.map s.snd)
+
+@[simp]
+lemma BinaryFan.map_fst {X Y : C} (s : BinaryFan X Y) : (s.map F).fst = F.map s.fst := rfl
+
+@[simp]
+lemma BinaryFan.map_snd {X Y : C} (s : BinaryFan X Y) : (s.map F).snd = F.map s.snd := rfl
+
+variable (F) in
+/-- The image of a binary cofan by a functor. -/
+abbrev BinaryCofan.map {X Y : C} (s : BinaryCofan X Y) : BinaryCofan (F.obj X) (F.obj Y) :=
+  mk (F.map s.inl) (F.map s.inr)
+
+@[simp]
+lemma BinaryCofan.map_inl {X Y : C} (s : BinaryCofan X Y) : (s.map F).inl = F.map s.inl := rfl
+
+@[simp]
+lemma BinaryCofan.map_inr {X Y : C} (s : BinaryCofan X Y) : (s.map F).inr = F.map s.inr := rfl
+
 /-- `F.mapCone s` being limiting is the same as the induced binary fan being limiting. -/
 def BinaryFan.isLimitMapConeEquiv {X Y : C} {s : BinaryFan X Y} :
-    IsLimit (F.mapCone s) ≃ IsLimit (BinaryFan.mk (F.map s.fst) (F.map s.snd)) :=
-  IsLimit.equivOfNatIsoOfIso (diagramIsoPair _) _ _ <| BinaryFan.ext (Iso.refl _)
-    (by simp [BinaryFan.fst]) (by simp [BinaryFan.snd])
+    IsLimit (F.mapCone s) ≃ IsLimit (s.map F) :=
+  IsLimit.equivOfNatIsoOfIso (diagramIsoPair _) _ _ <| ext (Iso.refl _)
+    (by simp [fst]) (by simp [snd])
 
 /-- `F.mapCocone s` being colimiting is the same as the induced binary cofan being colimiting. -/
 def BinaryCofan.isColimitMapConeEquiv {X Y : C} {s : BinaryCofan X Y} :
-    IsColimit (F.mapCocone s) ≃ IsColimit (BinaryCofan.mk (F.map s.inl) (F.map s.inr)) :=
-  IsColimit.equivOfNatIsoOfIso (diagramIsoPair _) _ _ <| BinaryCofan.ext (Iso.refl _)
-    (by simp [BinaryCofan.inl]) (by simp [BinaryCofan.inr])
+    IsColimit (F.mapCocone s) ≃ IsColimit (s.map F) :=
+  IsColimit.equivOfNatIsoOfIso (diagramIsoPair _) _ _ <| ext (Iso.refl _)
+    (by simp [inl]) (by simp [inr])
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -394,13 +394,13 @@ def BinaryCofan.IsColimit.desc {W : C} {s : BinaryCofan X Y} (h : IsColimit s)
   h.desc (BinaryCofan.mk f g)
 
 @[reassoc (attr := simp)]
-lemma BinaryCofan.IsColimit.desc_fst {W : C} {s : BinaryCofan X Y} (h : IsColimit s)
+lemma BinaryCofan.IsColimit.inl_desc {W : C} {s : BinaryCofan X Y} (h : IsColimit s)
     (f : X ⟶ W) (g : Y ⟶ W) :
     s.inl ≫ desc h f g = f :=
   h.fac (BinaryCofan.mk f g) _
 
 @[reassoc (attr := simp)]
-lemma BinaryCofan.IsColimit.desc_snd {W : C} {s : BinaryCofan X Y} (h : IsColimit s)
+lemma BinaryCofan.IsColimit.inr_desc {W : C} {s : BinaryCofan X Y} (h : IsColimit s)
     (f : X ⟶ W) (g : Y ⟶ W) :
     s.inr ≫ desc h f g = g :=
   h.fac (BinaryCofan.mk f g) _
@@ -416,7 +416,7 @@ def BinaryCofan.IsColimit.desc' {W X Y : C} {s : BinaryCofan X Y} (h : IsColimit
 /-- Binary products are symmetric. -/
 def BinaryFan.isLimitFlip {X Y : C} {c : BinaryFan X Y} (hc : IsLimit c) :
     IsLimit (BinaryFan.mk c.snd c.fst) :=
-  BinaryFan.isLimitMk (fun s => hc.lift (BinaryFan.mk s.snd s.fst)) (fun _ => hc.fac _ _)
+  BinaryFan.isLimitMk (fun s => IsLimit.lift hc s.snd s.fst) (fun _ => hc.fac _ _)
     (fun _ => hc.fac _ _) fun s _ e₁ e₂ =>
     BinaryFan.IsLimit.hom_ext hc
       (e₂.trans (hc.fac (BinaryFan.mk s.snd s.fst) ⟨WalkingPair.left⟩).symm)
@@ -450,7 +450,7 @@ set_option backward.isDefEq.respectTransparency false in
 noncomputable def BinaryFan.isLimitCompLeftIso {X Y X' : C} (c : BinaryFan X Y) (f : X ⟶ X')
     [IsIso f] (h : IsLimit c) : IsLimit (BinaryFan.mk (c.fst ≫ f) c.snd) := by
   fapply BinaryFan.isLimitMk
-  · exact fun s => h.lift (BinaryFan.mk (s.fst ≫ inv f) s.snd)
+  · exact fun s => IsLimit.lift h (s.fst ≫ inv f) s.snd
   · simp
   · simp
   · intro s m e₁ e₂
@@ -466,7 +466,7 @@ noncomputable def BinaryFan.isLimitCompRightIso {X Y Y' : C} (c : BinaryFan X Y)
 /-- Binary coproducts are symmetric. -/
 def BinaryCofan.isColimitFlip {X Y : C} {c : BinaryCofan X Y} (hc : IsColimit c) :
     IsColimit (BinaryCofan.mk c.inr c.inl) :=
-  BinaryCofan.isColimitMk (fun s => hc.desc (BinaryCofan.mk s.inr s.inl)) (fun _ => hc.fac _ _)
+  BinaryCofan.isColimitMk (fun s => IsColimit.desc hc s.inr s.inl) (fun _ => hc.fac _ _)
     (fun _ => hc.fac _ _) fun s _ e₁ e₂ =>
     BinaryCofan.IsColimit.hom_ext hc
       (e₂.trans (hc.fac (BinaryCofan.mk s.inr s.inl) ⟨WalkingPair.left⟩).symm)
@@ -500,7 +500,7 @@ set_option backward.isDefEq.respectTransparency false in
 noncomputable def BinaryCofan.isColimitCompLeftIso {X Y X' : C} (c : BinaryCofan X Y) (f : X' ⟶ X)
     [IsIso f] (h : IsColimit c) : IsColimit (BinaryCofan.mk (f ≫ c.inl) c.inr) := by
   fapply BinaryCofan.isColimitMk
-  · exact fun s => h.desc (BinaryCofan.mk (inv f ≫ s.inl) s.inr)
+  · exact fun s => BinaryCofan.IsColimit.desc h (inv f ≫ s.inl) s.inr
   · simp
   · simp
   · intro s m e₁ e₂
@@ -1503,11 +1503,11 @@ if `sYZ` is a limit cone we can construct a binary fan over `sXY.X Z`.
 
 This is an ingredient of building the associator for a Cartesian category. -/
 def BinaryFan.assocInv (P : IsLimit sXY) (s : BinaryFan X sYZ.pt) : BinaryFan sXY.pt Z :=
-  BinaryFan.mk (P.lift (BinaryFan.mk s.fst (s.snd ≫ sYZ.fst))) (s.snd ≫ sYZ.snd)
+  BinaryFan.mk (IsLimit.lift P s.fst (s.snd ≫ sYZ.fst)) (s.snd ≫ sYZ.snd)
 
 @[simp]
 lemma BinaryFan.assocInv_fst (P : IsLimit sXY) (s : BinaryFan X sYZ.pt) :
-    (assocInv P s).fst = P.lift (mk s.fst (s.snd ≫ sYZ.fst)) := rfl
+    (assocInv P s).fst = IsLimit.lift P s.fst (s.snd ≫ sYZ.fst) := rfl
 
 @[simp]
 lemma BinaryFan.assocInv_snd (P : IsLimit sXY) (s : BinaryFan X sYZ.pt) :
@@ -1531,10 +1531,10 @@ protected def IsLimit.assoc (P : IsLimit sXY) (Q : IsLimit sYZ) {s : BinaryFan s
     · apply P.hom_ext
       rintro ⟨⟨⟩⟩
       · simpa using w ⟨.left⟩
-      · replace w : m ≫ Q.lift (BinaryFan.mk (s.fst ≫ sXY.snd) s.snd) = t.π.app ⟨.right⟩ := by
+      · replace w : m ≫ BinaryFan.IsLimit.lift Q (s.fst ≫ sXY.snd) s.snd = t.π.app ⟨.right⟩ := by
           simpa using w ⟨.right⟩
         simp [← w]
-    · replace w : m ≫ Q.lift (BinaryFan.mk (s.fst ≫ sXY.snd) s.snd) = t.π.app ⟨.right⟩ := by
+    · replace w : m ≫ BinaryFan.IsLimit.lift Q (s.fst ≫ sXY.snd) s.snd = t.π.app ⟨.right⟩ := by
         simpa using w ⟨.right⟩
       simp [← w]
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/IsPullback/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/IsPullback/Basic.lean
@@ -356,15 +356,8 @@ lemma of_isLimit_binaryFan_of_isTerminal
     {T : C} (hT : IsTerminal T) :
     IsPullback c.fst c.snd (hT.from _) (hT.from _) where
   isLimit' := ⟨PullbackCone.IsLimit.mk _
-    (fun s ↦ hc.lift (BinaryFan.mk s.fst s.snd))
-    (fun s ↦ hc.fac (BinaryFan.mk s.fst s.snd) ⟨.left⟩)
-    (fun s ↦ hc.fac (BinaryFan.mk s.fst s.snd) ⟨.right⟩)
-    (fun s m h₁ h₂ ↦ by
-      apply BinaryFan.IsLimit.hom_ext hc
-      · rw [h₁, hc.fac (BinaryFan.mk s.fst s.snd) ⟨.left⟩]
-        rfl
-      · rw [h₂, hc.fac (BinaryFan.mk s.fst s.snd) ⟨.right⟩]
-        rfl)⟩
+    (fun s ↦ BinaryFan.IsLimit.lift hc s.fst s.snd) (by simp) (by simp)
+    (fun s m h₁ h₂ ↦ by apply BinaryFan.IsLimit.hom_ext hc <;> cat_disch)⟩
 end
 
 lemma mk' {P X Y Z : C} {fst : P ⟶ X} {snd : P ⟶ Y} {f : X ⟶ Z} {g : Y ⟶ Z}
@@ -744,15 +737,8 @@ lemma of_isColimit_binaryCofan_of_isInitial
     IsPushout (hI.to _) (hI.to _) c.inr c.inl where
   w := hI.hom_ext _ _
   isColimit' := ⟨PushoutCocone.IsColimit.mk _
-    (fun s ↦ hc.desc (BinaryCofan.mk s.inr s.inl))
-    (fun s ↦ hc.fac (BinaryCofan.mk s.inr s.inl) ⟨.right⟩)
-    (fun s ↦ hc.fac (BinaryCofan.mk s.inr s.inl) ⟨.left⟩)
-    (fun s m h₁ h₂ ↦ by
-      apply BinaryCofan.IsColimit.hom_ext hc
-      · rw [h₂, hc.fac (BinaryCofan.mk s.inr s.inl) ⟨.left⟩]
-        rfl
-      · rw [h₁, hc.fac (BinaryCofan.mk s.inr s.inl) ⟨.right⟩]
-        rfl)⟩
+    (fun s ↦ BinaryCofan.IsColimit.desc hc s.inr s.inl) (by simp) (by simp)
+    (fun s m h₁ h₂ ↦ by apply BinaryCofan.IsColimit.hom_ext hc <;> cat_disch)⟩
 
 lemma mk' {Z X Y P : C} {f : Z ⟶ X} {g : Z ⟶ Y} {inl : X ⟶ P} {inr : Y ⟶ P}
     (w : f ≫ inl = g ≫ inr)

--- a/Mathlib/CategoryTheory/Limits/Types/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Products.lean
@@ -163,8 +163,7 @@ def binaryProductFunctor : Type u ⥤ Type u ⥤ Type u where
         (BinaryFan.mk (↾_root_.Prod.fst) (↾_root_.Prod.snd ≫ f)) }
   map {X₁ X₂} f :=
     { app := fun Y =>
-      (binaryProductLimit X₂ Y).lift (BinaryFan.mk (↾_root_.Prod.fst ≫ f)
-      (↾_root_.Prod.snd)) }
+      BinaryFan.IsLimit.lift (binaryProductLimit X₂ Y) (↾_root_.Prod.fst ≫ f) (↾_root_.Prod.snd) }
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The product functor given by the instance `HasBinaryProducts (Type u)` is isomorphic to the

--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -347,15 +347,15 @@ def BinaryBicone.ofLimitCone {X Y : C} {t : Cone (pair X Y)} (ht : IsLimit t) :
   pt := t.pt
   fst := t.π.app ⟨WalkingPair.left⟩
   snd := t.π.app ⟨WalkingPair.right⟩
-  inl := ht.lift (BinaryFan.mk (𝟙 X) 0)
-  inr := ht.lift (BinaryFan.mk 0 (𝟙 Y))
+  inl := BinaryFan.IsLimit.lift ht (𝟙 X) 0
+  inr := BinaryFan.IsLimit.lift ht 0 (𝟙 Y)
 
 theorem inl_of_isLimit {X Y : C} {t : BinaryBicone X Y} (ht : IsLimit t.toCone) :
-    t.inl = ht.lift (BinaryFan.mk (𝟙 X) 0) := by
+    t.inl = BinaryFan.IsLimit.lift ht (𝟙 X) 0 := by
   apply ht.uniq (BinaryFan.mk (𝟙 X) 0); rintro ⟨⟨⟩⟩ <;> simp
 
 theorem inr_of_isLimit {X Y : C} {t : BinaryBicone X Y} (ht : IsLimit t.toCone) :
-    t.inr = ht.lift (BinaryFan.mk 0 (𝟙 Y)) := by
+    t.inr = BinaryFan.IsLimit.lift ht 0 (𝟙 Y) := by
   apply ht.uniq (BinaryFan.mk 0 (𝟙 Y)); rintro ⟨⟨⟩⟩ <;> simp
 
 /-- In a preadditive category, any binary bicone which is a limit cone is in fact a bilimit
@@ -388,18 +388,18 @@ set_option backward.isDefEq.respectTransparency false in
 def BinaryBicone.ofColimitCocone {X Y : C} {t : Cocone (pair X Y)} (ht : IsColimit t) :
     BinaryBicone X Y where
   pt := t.pt
-  fst := ht.desc (BinaryCofan.mk (𝟙 X) 0)
-  snd := ht.desc (BinaryCofan.mk 0 (𝟙 Y))
+  fst := BinaryCofan.IsColimit.desc ht (𝟙 X) 0
+  snd := BinaryCofan.IsColimit.desc ht 0 (𝟙 Y)
   inl := t.ι.app ⟨WalkingPair.left⟩
   inr := t.ι.app ⟨WalkingPair.right⟩
 
 theorem fst_of_isColimit {X Y : C} {t : BinaryBicone X Y} (ht : IsColimit t.toCocone) :
-    t.fst = ht.desc (BinaryCofan.mk (𝟙 X) 0) := by
+    t.fst = BinaryCofan.IsColimit.desc ht (𝟙 X) 0 := by
   apply ht.uniq (BinaryCofan.mk (𝟙 X) 0)
   rintro ⟨⟨⟩⟩ <;> simp
 
 theorem snd_of_isColimit {X Y : C} {t : BinaryBicone X Y} (ht : IsColimit t.toCocone) :
-    t.snd = ht.desc (BinaryCofan.mk 0 (𝟙 Y)) := by
+    t.snd = BinaryCofan.IsColimit.desc ht 0 (𝟙 Y) := by
   apply ht.uniq (BinaryCofan.mk 0 (𝟙 Y))
   rintro ⟨⟨⟩⟩ <;> simp
 


### PR DESCRIPTION
We add `BinaryFan.IsLimit.lift` as the analogue to `Fan.IsLimit.lift` and `BinaryFan.isLimitMapConeEquiv` as the analogue to `Fan.isLimitMapConeEquiv`. We also add the dual versions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
