### PR TITLE
feat: experimental hack to allow by finiteness auto-params

### DIFF
--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.Order.Ring.WithTop
 public import Mathlib.Algebra.Order.Sub.WithTop
 public import Mathlib.Data.NNReal.Defs
 public import Mathlib.Order.Interval.Set.WithBotTop
+import Mathlib.Tactic.Finiteness
 
 /-!
 # Extended non-negative reals
@@ -236,8 +237,12 @@ theorem coe_comp_toNNReal_comp {ι : Type*} {f : ι → ℝ≥0∞} (hf : ∀ x,
   ext x
   simp [coe_toNNReal (hf x)]
 
+/-- Mark a proposition as ... `finiteness` tactic as autoparam. -/
+def autofinite (p : Prop) : Prop := p
+
 @[simp]
-theorem ofReal_toReal {a : ℝ≥0∞} (h : a ≠ ∞) : ENNReal.ofReal a.toReal = a := by
+theorem ofReal_toReal {a : ℝ≥0∞} (h : autofinite (a ≠ ∞)) : ENNReal.ofReal a.toReal = a := by
+  simp [autofinite] at h -- XXX
   simp [ENNReal.toReal, ENNReal.ofReal, h]
 
 @[simp]
@@ -290,8 +295,50 @@ theorem ofNNReal_toNNReal (x : ℝ) : (Real.toNNReal x : ℝ≥0∞) = ENNReal.o
 
 @[simp] theorem ofReal_one : ENNReal.ofReal (1 : ℝ) = (1 : ℝ≥0∞) := by simp [ENNReal.ofReal]
 
+-- write a simproc that fires on autofinite and dispatches to the finiteness tactic
+-- should make ofReal_toReal work in simp the way I want to
+
+-- greedy version: define a simproc firing on every goal of the shape a ≠ ∞ ... might be too strong!
+
+open Lean Meta Elab in
+simproc_decl autofinite' (autofinite _) := fun e ↦ do
+  trace[Meta.debug] m!"entering simproc autofinite' on expression `{e}`"
+  -- p is the argument passed to autofinite, i.e. the goal to prove
+  let goal := e.appArg!
+  trace[Meta.debug] m!"goal is {goal}"
+  -- Note: finiteness is a macro for macro
+  let tacticCode ← `(by finiteness)
+  -- This is cargo-culted from XXX.
+  let disch : Simp.Discharge := fun e => do
+    let mvar ← mkFreshExprSyntheticOpaqueMVar e `simp.discharger
+    trace[Meta.debug] m!"mvar is {mvar}"
+    let runTac? : TermElabM (Option Expr) :=
+      try
+        Term.withoutModifyingElabMetaStateWithInfo do
+          Term.withSynthesize (postpone := .no) do
+            Term.runTactic (report := false) mvar.mvarId! tacticCode .term
+          let result ← instantiateMVars mvar
+          if result.hasExprMVar then
+            trace[Meta.debug] "foobar"
+            return none
+          else
+            return some result
+      catch msg =>
+        trace[Meta.debug] "in the catch case: {msg.toMessageData}"
+        return none
+    let (result?, _) ← liftM (m := MetaM) <| Term.TermElabM.run runTac?
+    return result?
+  match (← disch goal) with
+  | some pf => return Simp.Step.done {
+      expr := mkConst ``True, proof? := mkApp2 (mkConst ``eq_true) goal pf }
+  | none =>
+    trace[Meta.debug] m!"discharging failed"
+    return Simp.Step.continue
+
+attribute [simp] autofinite'
+
 theorem ofReal_toReal_le {a : ℝ≥0∞} : ENNReal.ofReal a.toReal ≤ a :=
-  if ha : a = ∞ then ha.symm ▸ le_top else le_of_eq (ofReal_toReal ha)
+  if ha : a = ∞ then ha.symm ▸ le_top else (by simp)
 
 theorem forall_ennreal {p : ℝ≥0∞ → Prop} : (∀ a, p a) ↔ (∀ r : ℝ≥0, p r) ∧ p ∞ :=
   WithTop.forall.trans and_comm
@@ -345,7 +392,9 @@ theorem ofReal_ne_top {r : ℝ} : ENNReal.ofReal r ≠ ∞ := coe_ne_top
 theorem ofReal_toReal_eq_iff : ENNReal.ofReal a.toReal = a ↔ a ≠ ⊤ :=
   ⟨fun h => by
     rw [← h]
-    exact ofReal_ne_top, ofReal_toReal⟩
+    exact ofReal_ne_top, by intro; simp⟩
+    -- +contextual adds hypotheses of implications as additional simp lemmas, not local hypotheses,
+    -- so doesn't work here!
 
 @[simp]
 theorem toReal_ofReal_eq_iff {a : ℝ} : (ENNReal.ofReal a).toReal = a ↔ 0 ≤ a :=


### PR DESCRIPTION
This provides a way to apply `by finiteness` auto-parameters in simp lemmas.

(Making simp run dischargers natively requires unfortunate hacks... so is not easily doable.)

Another alternative: make a simproc to run auto-params in general. This might be even better.

Written at the Mathlib Initiative Retreat. Thanks to Joachim Breitner and Henrik Böving for the help writing this!

---

The hack is calling `runTactic`: if `finiteness` (and, hence, `aesop`) could be called from an appropriate meta function instead, we could make the implementation more robust.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
