### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Matrix/Charpoly/Eigs): generalize to `CommRing`s

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Eigs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Eigs.lean
@@ -63,32 +63,35 @@ open scoped Matrix
 
 namespace Matrix
 
-/-- The roots of the characteristic polynomial are in the spectrum of the matrix. -/
-theorem mem_spectrum_of_isRoot_charpoly [Nontrivial R]
-    {r : R} (hr : IsRoot B.charpoly r) : r ∈ spectrum R B := by
-  simp_all [eval_charpoly, spectrum.mem_iff, isUnit_iff_isUnit_det, algebraMap_eq_diagonal,
+theorem mem_spectrum_iff_not_isUnit_eval_charpoly {r : R} :
+    r ∈ spectrum R B ↔ ¬IsUnit (B.charpoly.eval r) := by
+  simp [eval_charpoly, spectrum.mem_iff, isUnit_iff_isUnit_det, algebraMap_eq_diagonal,
     Pi.algebraMap_def]
+
+/-- The roots of the characteristic polynomial are in the spectrum of the matrix. -/
+theorem mem_spectrum_of_isRoot_charpoly [Nontrivial R] {r : R} (hr : IsRoot B.charpoly r) :
+    r ∈ spectrum R B := by
+  simp [mem_spectrum_iff_not_isUnit_eval_charpoly, hr.eq_zero]
 
 /--
 In fields, the roots of the characteristic polynomial are exactly the spectrum of the matrix.
 The weaker direction is true in nontrivial rings (see `Matrix.mem_spectrum_of_isRoot_charpoly`).
 -/
 theorem mem_spectrum_iff_isRoot_charpoly {r : K} : r ∈ spectrum K A ↔ IsRoot A.charpoly r := by
-  simp [eval_charpoly, spectrum.mem_iff, isUnit_iff_isUnit_det, algebraMap_eq_diagonal,
-    Pi.algebraMap_def]
+  simp [mem_spectrum_iff_not_isUnit_eval_charpoly]
 
-theorem det_eq_prod_roots_charpoly_of_splits (hAps : A.charpoly.Splits) :
-    A.det = (Matrix.charpoly A).roots.prod := by
-  rw [det_eq_sign_charpoly_coeff, ← charpoly_natDegree_eq_dim A,
-    hAps.coeff_zero_eq_prod_roots_of_monic A.charpoly_monic, ← mul_assoc,
+theorem det_eq_prod_roots_charpoly_of_splits [IsDomain R] (hAps : B.charpoly.Splits) :
+    B.det = (Matrix.charpoly B).roots.prod := by
+  rw [det_eq_sign_charpoly_coeff, ← charpoly_natDegree_eq_dim B,
+    hAps.coeff_zero_eq_prod_roots_of_monic B.charpoly_monic, ← mul_assoc,
     ← pow_two, pow_right_comm, neg_one_sq, one_pow, one_mul]
 
-theorem trace_eq_sum_roots_charpoly_of_splits (hAps : A.charpoly.Splits) :
-    A.trace = (Matrix.charpoly A).roots.sum := by
+theorem trace_eq_sum_roots_charpoly_of_splits [IsDomain R] (hAps : B.charpoly.Splits) :
+    B.trace = (Matrix.charpoly B).roots.sum := by
   rcases isEmpty_or_nonempty n with h | _
   · simp
   · rw [trace_eq_neg_charpoly_nextCoeff, neg_eq_iff_eq_neg,
-      ← hAps.nextCoeff_eq_neg_sum_roots_of_monic A.charpoly_monic]
+      ← hAps.nextCoeff_eq_neg_sum_roots_of_monic B.charpoly_monic]
 
 variable (A)
 


### PR DESCRIPTION
Also adds `r ∈ spectrum R B ↔ ¬IsUnit (B.charpoly.eval r)` which is the ring version of `r ∈ spectrum K A ↔ A.charpoly.IsRoot r`.

---
The `variable`s above define `A` over a `Field` and `B` over a `CommRing`, switching `A` to `B` generalizes.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
