### PR TITLE
doc(Probability/HasLaw): mention `MeasurePreserving` in the docstring

### DIFF
--- a/Mathlib/Probability/HasLaw.lean
+++ b/Mathlib/Probability/HasLaw.lean
@@ -17,6 +17,13 @@ measurable. Indeed, if `X` is not almost-everywhere measurable then `P.map X` is
 so that `HasLaw X 0 P` would be true. The measurability hypothesis ensures nice interactions with
 operations on the codomain of `X`.
 See for instance `HasLaw.comp`, `IndepFun.hasLaw_mul` and `IndepFun.hasLaw_add`.
+
+Note the existence of the analog concept `MeasureTheory.MeasurePreserving` which requires
+measurability instead of a.e.-measurability. This is too strong in probability theory where
+we often use almost-everywhere equality and only need a.e.-measurability hypotheses.
+However, if one wants to state `HasLaw f μ P` for a certain explicit function `f` that is not
+only `AEMeasurable` but `Measurable`, then one should state `MeasureTheory.MeasurePreserving f P μ`
+instead and rely on lemmas in this file that link the two notions.
 -/
 
 public section
@@ -34,7 +41,14 @@ variable (X μ) in
 /-- The predicate `HasLaw X μ P` registers the fact that the random variable `X` has law `μ` under
 the measure `P`, in other words that `P.map X = μ`. We also require `X` to be `AEMeasurable`,
 to allow for nice interactions with operations on the codomain of `X`. See for instance
-`HasLaw.comp`, `IndepFun.hasLaw_mul` and `IndepFun.hasLaw_add`. -/
+`HasLaw.comp`, `IndepFun.hasLaw_mul` and `IndepFun.hasLaw_add`.
+
+Note the existence of the analog concept `MeasureTheory.MeasurePreserving` which requires
+measurability instead of a.e.-measurability. This is too strong in probability theory where
+we often use almost-everywhere equality and only need a.e.-measurability hypotheses.
+However, if one wants to state `HasLaw f μ P` for a certain explicit function `f` that is not
+only `AEMeasurable` but `Measurable`, then one should state `MeasureTheory.MeasurePreserving f P μ`
+instead and rely on lemmas in this file that link the two notions. -/
 @[fun_prop]
 structure HasLaw (P : Measure Ω := by volume_tac) : Prop where
   protected aemeasurable : AEMeasurable X P := by fun_prop


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
