### PR TITLE
[Merged by Bors] - feat: if an L^p space is complete, so is its target space unless the measure is zero

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5335,6 +5335,7 @@ public import Mathlib.MeasureTheory.Function.LpSeminorm.TriangleInequality
 public import Mathlib.MeasureTheory.Function.LpSeminorm.Trim
 public import Mathlib.MeasureTheory.Function.LpSpace.Basic
 public import Mathlib.MeasureTheory.Function.LpSpace.Complete
+public import Mathlib.MeasureTheory.Function.LpSpace.CompleteOfCompleteLp
 public import Mathlib.MeasureTheory.Function.LpSpace.ContinuousCompMeasurePreserving
 public import Mathlib.MeasureTheory.Function.LpSpace.ContinuousFunctions
 public import Mathlib.MeasureTheory.Function.LpSpace.DomAct.Basic

--- a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
@@ -5,6 +5,7 @@ Authors: Rémy Degenne, Sébastien Gouëzel
 -/
 module
 
+public import Mathlib.Analysis.Normed.Operator.Bilinear
 public import Mathlib.Analysis.Normed.Operator.NNNorm
 public import Mathlib.MeasureTheory.Function.LpSeminorm.ChebyshevMarkov
 public import Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
@@ -774,7 +775,7 @@ theorem norm_compLp_le (L : E →SL[σ] F) (f : Lp E p μ) : ‖L.compLp f‖ �
 variable (μ p)
 
 /-- Composing `f : Lp E p μ` with `L : E →L[𝕜] F`, seen as a `𝕜`-linear map on `Lp E p μ`. -/
-def compLpₗ (L : E →SL[σ] F) : Lp E p μ →ₛₗ[σ] Lp F p μ where
+@[simps] def compLpₗ (L : E →SL[σ] F) : Lp E p μ →ₛₗ[σ] Lp F p μ where
   toFun f := L.compLp f
   map_add' f g := by
     ext1
@@ -814,6 +815,46 @@ theorem smul_compLpL [Fact (1 ≤ p)] {𝕜''} [NormedRing 𝕜''] [Module 𝕜'
 
 theorem norm_compLpL_le [Fact (1 ≤ p)] (L : E →SL[σ] F) : ‖L.compLpL p μ‖ ≤ ‖L‖ :=
   LinearMap.mkContinuous_norm_le _ (norm_nonneg _) _
+
+section Bilinear
+
+variable {F G : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  [NormedAddCommGroup G] [NormedSpace 𝕜 G]
+
+variable (μ p) in
+/-- Given a continuous bilinear map `G → E → F`, construct the associated bilinear map
+`G → Lp E p μ → Lp F p μ`. -/
+@[simps] def compLpₗ₂ (B : G →L[𝕜] E →L[𝕜] F) : G →ₗ[𝕜] Lp E p μ →ₗ[𝕜] Lp F p μ where
+  toFun g := (B g).compLpₗ p μ
+  map_add' g h := by
+    ext f
+    filter_upwards [(B (g + h)).coeFn_compLp f, (B g).coeFn_compLp f, (B h).coeFn_compLp f,
+      Lp.coeFn_add ((B g).compLp f) ((B h).compLp f)] with x hx hg hh hadd
+    simp only [compLpₗ_apply, LinearMap.add_apply, hx, hadd]
+    simp only [map_add, add_apply, Pi.add_apply, hg, hh]
+  map_smul' c g := by
+    ext f
+    filter_upwards [(c • B g).coeFn_compLp f, (B g).coeFn_compLp f,
+      Lp.coeFn_smul c ((B g).compLp f)] with x hx hg hsmul
+    simp [hx, hsmul, hg]
+
+variable (μ p) in
+/-- Given a continuous bilinear map `G → E → F`, construct the associated continuous bilinear map
+`G → Lp E p μ → Lp F p μ`. -/
+def compLpL₂ [Fact (1 ≤ p)] (B : G →L[𝕜] E →L[𝕜] F) :
+    G →L[𝕜] Lp E p μ →L[𝕜] Lp F p μ :=
+  (B.compLpₗ₂ p μ).mkContinuous₂ ‖B‖ (fun c f ↦ by
+    simp only [compLpₗ₂_apply, compLpₗ_apply]
+    grw [norm_compLp_le, le_opNorm])
+
+@[simp] theorem compLpL₂_apply_apply [Fact (1 ≤ p)] (B : G →L[𝕜] E →L[𝕜] F) (g : G) (f : Lp E p μ) :
+    compLpL₂ p μ B g f = (B g).compLp f := rfl
+
+theorem norm_compLpL₂ [Fact (1 ≤ p)] (B : G →L[𝕜] E →L[𝕜] F) :
+    ‖B.compLpL₂ p μ‖ ≤ ‖B‖ :=
+  LinearMap.mkContinuous₂_norm_le _ (norm_nonneg _) _
+
+end Bilinear
 
 end ContinuousLinearMap
 

--- a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
@@ -850,7 +850,7 @@ def compLpL₂ [Fact (1 ≤ p)] (B : G →L[𝕜] E →L[𝕜] F) :
 @[simp] theorem compLpL₂_apply_apply [Fact (1 ≤ p)] (B : G →L[𝕜] E →L[𝕜] F) (g : G) (f : Lp E p μ) :
     compLpL₂ p μ B g f = (B g).compLp f := rfl
 
-theorem norm_compLpL₂ [Fact (1 ≤ p)] (B : G →L[𝕜] E →L[𝕜] F) :
+theorem norm_compLpL₂_le [Fact (1 ≤ p)] (B : G →L[𝕜] E →L[𝕜] F) :
     ‖B.compLpL₂ p μ‖ ≤ ‖B‖ :=
   LinearMap.mkContinuous₂_norm_le _ (norm_nonneg _) _
 

--- a/Mathlib/MeasureTheory/Function/LpSpace/CompleteOfCompleteLp.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/CompleteOfCompleteLp.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+module
+
+public import Mathlib.Analysis.Normed.Operator.Mul
+public import Mathlib.MeasureTheory.Function.ConvergenceInMeasure
+public import Mathlib.MeasureTheory.Function.LpSpace.Complete
+public import Mathlib.MeasureTheory.Function.StronglyMeasurable.Lp
+
+/-!
+# If an `Lp` space is complete, so is the target space
+-/
+
+@[expose] public section
+
+open scoped ENNReal Topology
+open Filter ContinuousLinearMap
+
+namespace MeasureTheory
+
+variable {α E : Type*} [NormedAddCommGroup E] [MeasurableSpace α] {p : ℝ≥0∞} {μ : Measure α}
+
+lemma FinStronglyMeasurable.exists_measurableSet_measure_pos_lt_top {f : α → E}
+    (hf : FinStronglyMeasurable f μ) (h'f : ¬(f =ᵐ[μ] 0)) :
+    ∃ s, MeasurableSet s ∧ 0 < μ s ∧ μ s < ∞ := by
+  contrapose! h'f
+  rcases hf with ⟨fn, hfn, hfn_lim⟩
+  have A n : μ (Function.support (fn n)) = 0 := by
+    by_contra!
+    have := h'f (Function.support (fn n)) (fn n).measurableSet_support (by positivity)
+    exact (lt_irrefl _ (this.trans_lt (hfn n))).elim
+  have B : ∀ᵐ x ∂μ, ∀ n, fn n x = 0 := ae_all_iff.mpr A
+  filter_upwards [B] with x hx
+  apply tendsto_nhds_unique (hfn_lim x)
+  simp [hx]
+
+lemma AEFinStronglyMeasurable.exists_measurableSet_measure_pos_lt_top {f : α → E}
+    (hf : AEFinStronglyMeasurable f μ) (h'f : ¬(f =ᵐ[μ] 0)) :
+    ∃ s, MeasurableSet s ∧ 0 < μ s ∧ μ s < ∞ := by
+  apply hf.finStronglyMeasurable_mk.exists_measurableSet_measure_pos_lt_top
+  contrapose! h'f
+  exact hf.ae_eq_mk.trans h'f
+
+variable (E p μ) in
+lemma nontrivial_Lp_real_of_nontrivial_Lp [Nontrivial (Lp E p μ)] : Nontrivial (Lp ℝ p μ) := by
+  obtain ⟨f, hf⟩ : ∃ f : Lp E p μ, f ≠ 0 := exists_ne 0
+  have hfne : ¬ (f =ᵐ[μ] 0) := by
+    contrapose! hf
+    ext
+    grw [hf, (Lp.coeFn_zero E p μ)]
+  rcases eq_top_or_lt_top p with rfl | h'p
+  · apply nontrivial_of_ne ((memLp_top_const (1 : ℝ)).toLp _) 0
+    contrapose! hfne
+    have := Lp.ext_iff.1 hfne
+    grw [Lp.coeFn_zero, MemLp.coeFn_toLp] at this
+    filter_upwards [this] with x hx using by simp at hx
+  rcases eq_or_ne p 0 with rfl | hp
+  · have : MemLp (fun (_ : α) ↦ (1 : ℝ)) 0 μ := by simpa using aestronglyMeasurable_const
+    apply nontrivial_of_ne (this.toLp _) 0
+    contrapose! hfne
+    have := Lp.ext_iff.1 hfne
+    grw [Lp.coeFn_zero, MemLp.coeFn_toLp] at this
+    filter_upwards [this] with x hx using by simp at hx
+  · have h'f : AEFinStronglyMeasurable f μ :=
+      MemLp.aefinStronglyMeasurable (Lp.memLp f) hp h'p.ne
+    obtain ⟨s, s_meas, s_pos, s_top⟩ : ∃ s, MeasurableSet s ∧ 0 < μ s ∧ μ s < ∞ :=
+      h'f.exists_measurableSet_measure_pos_lt_top hfne
+    apply nontrivial_of_ne (indicatorConstLp p s_meas s_top.ne 1) 0
+    intro hzero
+    have : ‖indicatorConstLp p s_meas s_top.ne (1 : ℝ)‖ = ‖(0 : Lp ℝ p μ)‖ := by rw [hzero]
+    simp only [norm_indicatorConstLp hp h'p.ne, norm_one, one_div, one_mul, Lp.norm_zero] at this
+    rw [Real.rpow_eq_zero (by positivity) (by simp [ENNReal.toReal_eq_zero_iff, hp, h'p.ne]),
+      measureReal_eq_zero_iff] at this
+    order
+
+variable [NormedSpace ℝ E]
+
+variable (E p μ) in
+/-- If an `L^p` space is complete and nontrivial, then the target space is complete. -/
+lemma completeSpace_of_completeSpace_Lp [hp : Fact (1 ≤ p)]
+    [CompleteSpace (Lp E p μ)] [Nontrivial (Lp E p μ)] : CompleteSpace E := by
+  /- Consider a nonzero function `f : α → ℝ` in `L^p`. Given a Cauchy sequence `uₙ` in `E`, form
+  the Cauchy sequence `f • uₙ` in `L^p E`. By completeness, it converges. Consider a subsequence
+  which converges almost everywhere. As `f` is nonzero, we get some `x` such that `f x • uₙ`
+  converges along this subsequence and `f x ≠ 0`. Then `uₙ` converges along this subsequence, and
+  therefore along all indices as it is Cauchy. -/
+  obtain ⟨f, hf⟩ : ∃ f : Lp ℝ p μ, f ≠ 0 := by
+    have : Nontrivial (Lp ℝ p μ) := nontrivial_Lp_real_of_nontrivial_Lp E p μ
+    exact exists_ne 0
+  let m : E →L[ℝ] Lp E p μ := ((ContinuousLinearMap.lsmul ℝ ℝ).flip.compLpL₂ p μ).flip f
+  apply Metric.complete_of_cauchySeq_tendsto (fun u hu ↦ ?_)
+  obtain ⟨g, hg⟩ : ∃ g, Tendsto (m ∘ u) atTop (𝓝 g) :=
+    cauchySeq_tendsto_of_complete (m.lipschitz.cauchySeq_comp hu)
+  let f' : ℕ → (α → E) := fun n ↦ (m ∘ u) n
+  obtain ⟨ns, hns, nslim⟩ : ∃ ns : ℕ → ℕ, StrictMono ns ∧
+      ∀ᵐ x ∂μ, Tendsto (fun i ↦ f' (ns i) x) atTop (𝓝 (g x)) :=
+    (tendstoInMeasure_of_tendsto_Lp hg).exists_seq_tendsto_ae
+  have : (ae (μ.restrict (Function.support f))).NeBot := by
+    apply ae_restrict_neBot.2
+    have : NeZero μ := by
+      contrapose! hf
+      simp [neZero_iff] at hf
+      ext
+      simp only [hf, ae_zero, ZeroMemClass.coe_zero]
+      trivial
+    contrapose! hf
+    ext
+    filter_upwards [compl_mem_ae_iff.2 hf] with y hy
+    simp at hy
+    simp [hy]
+  have A : ∀ᵐ x ∂(μ.restrict (Function.support f)),
+    Tendsto (fun i ↦ f' (ns i) x) atTop (𝓝 (g x)) := ae_restrict_of_ae nslim
+  have B : ∀ᵐ x ∂(μ.restrict (Function.support f)), x ∈ Function.support f :=
+    ae_restrict_mem (measurableSet_support (by fun_prop))
+  have C : ∀ᵐ x ∂(μ.restrict (Function.support f)), ∀ n, m (u n) x = (f x) • u n := by
+    apply ae_restrict_of_ae
+    apply ae_all_iff.2 (fun n ↦ ?_)
+    filter_upwards [(toSpanSingleton ℝ (u n)).coeFn_compLp f] with x hx using by simp [m, hx]
+  obtain ⟨x, xlim, hx, hmx⟩ : ∃ x, Tendsto (fun i ↦ f' (ns i) x) atTop (𝓝 (g x))
+    ∧ x ∈ Function.support f ∧ ∀ n, m (u n) x = (f x) • u n := (A.and (B.and C)).exists
+  simp only [Function.comp_apply, hmx, f'] at xlim
+  refine ⟨(f x)⁻¹ • g x, ?_⟩
+  apply tendsto_nhds_of_cauchySeq_of_subseq hu (StrictMono.tendsto_atTop hns)
+  convert Tendsto.const_smul xlim (f x)⁻¹ with n
+  rw [smul_smul, inv_mul_cancel₀, one_smul, Function.comp]
+  exact hx
+
+end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/LpSpace/CompleteOfCompleteLp.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/CompleteOfCompleteLp.lean
@@ -117,10 +117,9 @@ lemma completeSpace_of_completeSpace_Lp [hp : Fact (1 ≤ p)]
     ∧ x ∈ Function.support f ∧ ∀ n, m (u n) x = (f x) • u n := (A.and (B.and C)).exists
   simp only [Function.comp_apply, hmx, f'] at xlim
   refine ⟨(f x)⁻¹ • g x, ?_⟩
-  apply tendsto_nhds_of_cauchySeq_of_subseq hu (StrictMono.tendsto_atTop hns)
-  convert Tendsto.const_smul xlim (f x)⁻¹ with n
   apply tendsto_nhds_of_cauchySeq_of_subseq hu hns.tendsto_atTop
   convert xlim.const_smul (f x)⁻¹ with n
+  rw [smul_smul, inv_mul_cancel₀, one_smul, Function.comp]
   exact hx
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/LpSpace/CompleteOfCompleteLp.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/CompleteOfCompleteLp.lean
@@ -50,7 +50,7 @@ lemma nontrivial_Lp_real_of_nontrivial_Lp [Nontrivial (Lp E p μ)] : Nontrivial 
   have hfne : ¬ (f =ᵐ[μ] 0) := by
     contrapose! hf
     ext
-    grw [hf, (Lp.coeFn_zero E p μ)]
+    grw [hf, Lp.coeFn_zero E p μ]
   rcases eq_top_or_lt_top p with rfl | h'p
   · apply nontrivial_of_ne ((memLp_top_const (1 : ℝ)).toLp _) 0
     contrapose! hfne

--- a/Mathlib/MeasureTheory/Function/LpSpace/CompleteOfCompleteLp.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/CompleteOfCompleteLp.lean
@@ -21,7 +21,7 @@ open Filter ContinuousLinearMap
 
 namespace MeasureTheory
 
-variable {α E : Type*} [NormedAddCommGroup E] [MeasurableSpace α] {p : ℝ≥0∞} {μ : Measure α}
+variable {α E : Type*} [NormedAddCommGroup E] {mα : MeasurableSpace α} {p : ℝ≥0∞} {μ : Measure α}
 
 lemma FinStronglyMeasurable.exists_measurableSet_measure_pos_lt_top {f : α → E}
     (hf : FinStronglyMeasurable f μ) (h'f : ¬(f =ᵐ[μ] 0)) :
@@ -31,7 +31,7 @@ lemma FinStronglyMeasurable.exists_measurableSet_measure_pos_lt_top {f : α → 
   have A n : μ (Function.support (fn n)) = 0 := by
     by_contra!
     have := h'f (Function.support (fn n)) (fn n).measurableSet_support (by positivity)
-    exact (lt_irrefl _ (this.trans_lt (hfn n))).elim
+    grind
   have B : ∀ᵐ x ∂μ, ∀ n, fn n x = 0 := ae_all_iff.mpr A
   filter_upwards [B] with x hx
   apply tendsto_nhds_unique (hfn_lim x)
@@ -100,17 +100,11 @@ lemma completeSpace_of_completeSpace_Lp [hp : Fact (1 ≤ p)]
     (tendstoInMeasure_of_tendsto_Lp hg).exists_seq_tendsto_ae
   have : (ae (μ.restrict (Function.support f))).NeBot := by
     apply ae_restrict_neBot.2
-    have : NeZero μ := by
-      contrapose! hf
-      simp [neZero_iff] at hf
-      ext
-      simp only [hf, ae_zero, ZeroMemClass.coe_zero]
-      trivial
+    apply μ.measure_support_eq_zero_iff.not.2
     contrapose! hf
     ext
-    filter_upwards [compl_mem_ae_iff.2 hf] with y hy
-    simp at hy
-    simp [hy]
+    grw [Lp.coeFn_zero]
+    exact hf
   have A : ∀ᵐ x ∂(μ.restrict (Function.support f)),
     Tendsto (fun i ↦ f' (ns i) x) atTop (𝓝 (g x)) := ae_restrict_of_ae nslim
   have B : ∀ᵐ x ∂(μ.restrict (Function.support f)), x ∈ Function.support f :=
@@ -125,7 +119,8 @@ lemma completeSpace_of_completeSpace_Lp [hp : Fact (1 ≤ p)]
   refine ⟨(f x)⁻¹ • g x, ?_⟩
   apply tendsto_nhds_of_cauchySeq_of_subseq hu (StrictMono.tendsto_atTop hns)
   convert Tendsto.const_smul xlim (f x)⁻¹ with n
-  rw [smul_smul, inv_mul_cancel₀, one_smul, Function.comp]
+  apply tendsto_nhds_of_cauchySeq_of_subseq hu hns.tendsto_atTop
+  convert xlim.const_smul (f x)⁻¹ with n
   exact hx
 
 end MeasureTheory


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
