### PR TITLE
[Merged by Bors] - feat: the identity function is a.e.-strongly measurable w.r.t. the map by an a.e.-strongly measurable function

### DIFF
--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
@@ -400,7 +400,8 @@ section Monoid
 
 variable {M : Type*} [Monoid M] [TopologicalSpace M] [ContinuousMul M]
 
-@[to_additive (attr := fun_prop, measurability)]
+-- TODO: `fun_prop` cannot use lemmas with a condition quantifying over the function
+@[to_additive (attr := fun_prop)]
 theorem _root_.List.aestronglyMeasurable_prod (l : List (α → M))
     (hl : ∀ f ∈ l, AEStronglyMeasurable f μ) : AEStronglyMeasurable l.prod μ := by
   induction l with
@@ -410,7 +411,7 @@ theorem _root_.List.aestronglyMeasurable_prod (l : List (α → M))
     rw [List.prod_cons]
     exact hl.1.mul (ihl hl.2)
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem _root_.List.aestronglyMeasurable_fun_prod
     (l : List (α → M)) (hl : ∀ f ∈ l, AEStronglyMeasurable f μ) :
     AEStronglyMeasurable (fun x => (l.map fun f : α → M => f x).prod) μ := by
@@ -422,26 +423,26 @@ section CommMonoid
 
 variable {M : Type*} [CommMonoid M] [TopologicalSpace M] [ContinuousMul M]
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem _root_.Multiset.aestronglyMeasurable_prod (l : Multiset (α → M))
     (hl : ∀ f ∈ l, AEStronglyMeasurable f μ) : AEStronglyMeasurable l.prod μ := by
   rcases l with ⟨l⟩
   simpa using l.aestronglyMeasurable_prod (by simpa using hl)
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem _root_.Multiset.aestronglyMeasurable_fun_prod (s : Multiset (α → M))
     (hs : ∀ f ∈ s, AEStronglyMeasurable f μ) :
     AEStronglyMeasurable (fun x => (s.map fun f : α → M => f x).prod) μ := by
   simpa only [← Pi.multiset_prod_apply] using s.aestronglyMeasurable_prod hs
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem _root_.Finset.aestronglyMeasurable_prod {ι : Type*} {f : ι → α → M} (s : Finset ι)
     (hf : ∀ i ∈ s, AEStronglyMeasurable (f i) μ) : AEStronglyMeasurable (∏ i ∈ s, f i) μ :=
   Multiset.aestronglyMeasurable_prod _ fun _g hg =>
     let ⟨_i, hi, hg⟩ := Multiset.mem_map.1 hg
     hg ▸ hf _ hi
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem _root_.Finset.aestronglyMeasurable_fun_prod {ι : Type*} {f : ι → α → M} (s : Finset ι)
     (hf : ∀ i ∈ s, AEStronglyMeasurable (f i) μ) :
     AEStronglyMeasurable (fun a => ∏ i ∈ s, f i a) μ := by
@@ -770,13 +771,13 @@ theorem _root_.aestronglyMeasurable_add_measure_iff [PseudoMetrizableSpace β] {
   rw [← sum_cond, aestronglyMeasurable_sum_measure_iff, Bool.forall_bool, and_comm]
   rfl
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem add_measure [PseudoMetrizableSpace β] {ν : Measure α} {f : α → β}
     (hμ : AEStronglyMeasurable f μ) (hν : AEStronglyMeasurable f ν) :
     AEStronglyMeasurable f (μ + ν) :=
   aestronglyMeasurable_add_measure_iff.2 ⟨hμ, hν⟩
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem iUnion [PseudoMetrizableSpace β] {s : ι → Set α}
     (h : ∀ i, AEStronglyMeasurable f (μ.restrict (s i))) :
     AEStronglyMeasurable f (μ.restrict (⋃ i, s i)) :=
@@ -802,7 +803,7 @@ theorem aestronglyMeasurable_uIoc_iff [LinearOrder α] [PseudoMetrizableSpace β
         AEStronglyMeasurable f (μ.restrict <| Ioc b a) := by
   rw [uIoc_eq_union, aestronglyMeasurable_union_iff]
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem smul_measure {R : Type*} [SMul R ℝ≥0∞] [IsScalarTower R ℝ≥0∞ ℝ≥0∞]
     (h : AEStronglyMeasurable f μ) (c : R) : AEStronglyMeasurable f (c • μ) :=
   ⟨h.mk f, h.stronglyMeasurable_mk, ae_smul_measure h.ae_eq_mk c⟩

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
@@ -135,6 +135,27 @@ theorem aestronglyMeasurable_zero_measure (f : α → β) :
 theorem SimpleFunc.aestronglyMeasurable (f : α →ₛ β) : AEStronglyMeasurable f μ :=
   f.stronglyMeasurable.aestronglyMeasurable
 
+/-- In a pseudometrizable space, if a measure `μ` is supported on
+a separable set then the identity function is `AEStronglyMeasurable` with respect to `μ`. -/
+lemma aestronglyMeasurable_id_of_isSeparable [TopologicalSpace α]
+    [TopologicalSpace.PseudoMetrizableSpace α] [OpensMeasurableSpace α]
+    {s : Set α} (h1 : TopologicalSpace.IsSeparable s) (h2 : μ sᶜ = 0) (h3 : MeasurableSet s) :
+    AEStronglyMeasurable id μ := by
+  nontriviality α
+  obtain ⟨a, -⟩ := exists_pair_ne α
+  classical
+  refine ⟨s.piecewise id (fun _ ↦ a), ?_, Filter.mem_of_superset h2 (fun x hx ↦ by simp [hx])⟩
+  have h : StronglyMeasurable ((↑) : s → α) := by
+    have := h1.secondCountableTopology
+    exact continuous_subtype_val.stronglyMeasurable
+  have : s.piecewise id (fun _ ↦ a) = ((↑) : s → α).extend ((↑) : s → α) (fun _ ↦ a) := by
+    ext x
+    by_cases hx : x ∈ s
+    · simp [Function.extend_val_apply, hx]
+    · simp [hx]
+  rw [this]
+  exact (MeasurableEmbedding.subtype_coe h3).stronglyMeasurable_extend h stronglyMeasurable_const
+
 namespace AEStronglyMeasurable
 
 @[fun_prop]
@@ -379,8 +400,7 @@ section Monoid
 
 variable {M : Type*} [Monoid M] [TopologicalSpace M] [ContinuousMul M]
 
--- TODO: `fun_prop` cannot use lemmas with a condition quantifying over the function
-@[to_additive (attr := fun_prop)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem _root_.List.aestronglyMeasurable_prod (l : List (α → M))
     (hl : ∀ f ∈ l, AEStronglyMeasurable f μ) : AEStronglyMeasurable l.prod μ := by
   induction l with
@@ -390,7 +410,7 @@ theorem _root_.List.aestronglyMeasurable_prod (l : List (α → M))
     rw [List.prod_cons]
     exact hl.1.mul (ihl hl.2)
 
-@[to_additive (attr := fun_prop)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem _root_.List.aestronglyMeasurable_fun_prod
     (l : List (α → M)) (hl : ∀ f ∈ l, AEStronglyMeasurable f μ) :
     AEStronglyMeasurable (fun x => (l.map fun f : α → M => f x).prod) μ := by
@@ -402,26 +422,26 @@ section CommMonoid
 
 variable {M : Type*} [CommMonoid M] [TopologicalSpace M] [ContinuousMul M]
 
-@[to_additive (attr := fun_prop)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem _root_.Multiset.aestronglyMeasurable_prod (l : Multiset (α → M))
     (hl : ∀ f ∈ l, AEStronglyMeasurable f μ) : AEStronglyMeasurable l.prod μ := by
   rcases l with ⟨l⟩
   simpa using l.aestronglyMeasurable_prod (by simpa using hl)
 
-@[to_additive (attr := fun_prop)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem _root_.Multiset.aestronglyMeasurable_fun_prod (s : Multiset (α → M))
     (hs : ∀ f ∈ s, AEStronglyMeasurable f μ) :
     AEStronglyMeasurable (fun x => (s.map fun f : α → M => f x).prod) μ := by
   simpa only [← Pi.multiset_prod_apply] using s.aestronglyMeasurable_prod hs
 
-@[to_additive (attr := fun_prop)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem _root_.Finset.aestronglyMeasurable_prod {ι : Type*} {f : ι → α → M} (s : Finset ι)
     (hf : ∀ i ∈ s, AEStronglyMeasurable (f i) μ) : AEStronglyMeasurable (∏ i ∈ s, f i) μ :=
   Multiset.aestronglyMeasurable_prod _ fun _g hg =>
     let ⟨_i, hi, hg⟩ := Multiset.mem_map.1 hg
     hg ▸ hf _ hi
 
-@[to_additive (attr := fun_prop)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem _root_.Finset.aestronglyMeasurable_fun_prod {ι : Type*} {f : ι → α → M} (s : Finset ι)
     (hf : ∀ i ∈ s, AEStronglyMeasurable (f i) μ) :
     AEStronglyMeasurable (fun a => ∏ i ∈ s, f i a) μ := by
@@ -585,6 +605,17 @@ theorem isSeparable_ae_range (hf : AEStronglyMeasurable f μ) :
   filter_upwards [hf.ae_eq_mk] with x hx
   simp [hx]
 
+/-- If `μ : Measure α` and `f : α → β` is `AEStronglyMeasurable` where `β` is a pseudometrizable
+space and a Borel space, then the identity is a.e.-strongly measurable w.r.t. `μ.map f`. -/
+lemma aestronglyMeasurable_id_map {mβ : MeasurableSpace β}
+    [TopologicalSpace.PseudoMetrizableSpace β] [BorelSpace β]
+    {f : α → β} (hf : AEStronglyMeasurable f μ) :
+    AEStronglyMeasurable id (μ.map f) := by
+  obtain ⟨t, ht1, ht2⟩ := hf.isSeparable_ae_range
+  refine aestronglyMeasurable_id_of_isSeparable ht1.closure ?_ isClosed_closure.measurableSet
+  refine ae_map_iff hf.aemeasurable isClosed_closure.measurableSet |>.2 ?_
+  filter_upwards [ht2] with ω hω using subset_closure hω
+
 /-- A function is almost everywhere strongly measurable if and only if it is almost everywhere
 measurable, and up to a zero measure set its range is contained in a separable set. -/
 theorem _root_.aestronglyMeasurable_iff_aemeasurable_separable [PseudoMetrizableSpace β]
@@ -739,13 +770,13 @@ theorem _root_.aestronglyMeasurable_add_measure_iff [PseudoMetrizableSpace β] {
   rw [← sum_cond, aestronglyMeasurable_sum_measure_iff, Bool.forall_bool, and_comm]
   rfl
 
-@[fun_prop]
+@[fun_prop, measurability]
 theorem add_measure [PseudoMetrizableSpace β] {ν : Measure α} {f : α → β}
     (hμ : AEStronglyMeasurable f μ) (hν : AEStronglyMeasurable f ν) :
     AEStronglyMeasurable f (μ + ν) :=
   aestronglyMeasurable_add_measure_iff.2 ⟨hμ, hν⟩
 
-@[fun_prop]
+@[fun_prop, measurability]
 protected theorem iUnion [PseudoMetrizableSpace β] {s : ι → Set α}
     (h : ∀ i, AEStronglyMeasurable f (μ.restrict (s i))) :
     AEStronglyMeasurable f (μ.restrict (⋃ i, s i)) :=
@@ -771,7 +802,7 @@ theorem aestronglyMeasurable_uIoc_iff [LinearOrder α] [PseudoMetrizableSpace β
         AEStronglyMeasurable f (μ.restrict <| Ioc b a) := by
   rw [uIoc_eq_union, aestronglyMeasurable_union_iff]
 
-@[fun_prop]
+@[fun_prop, measurability]
 theorem smul_measure {R : Type*} [SMul R ℝ≥0∞] [IsScalarTower R ℝ≥0∞ ℝ≥0∞]
     (h : AEStronglyMeasurable f μ) (c : R) : AEStronglyMeasurable f (c • μ) :=
   ⟨h.mk f, h.stronglyMeasurable_mk, ae_smul_measure h.ae_eq_mk c⟩

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
@@ -139,22 +139,25 @@ theorem SimpleFunc.aestronglyMeasurable (f : α →ₛ β) : AEStronglyMeasurabl
 a separable set then the identity function is `AEStronglyMeasurable` with respect to `μ`. -/
 lemma aestronglyMeasurable_id_of_isSeparable [TopologicalSpace α]
     [TopologicalSpace.PseudoMetrizableSpace α] [OpensMeasurableSpace α]
-    {s : Set α} (h1 : TopologicalSpace.IsSeparable s) (h2 : μ sᶜ = 0) (h3 : MeasurableSet s) :
+    {s : Set α} (h1 : TopologicalSpace.IsSeparable s) (h2 : μ sᶜ = 0) :
     AEStronglyMeasurable id μ := by
   nontriviality α
   obtain ⟨a, -⟩ := exists_pair_ne α
   classical
-  refine ⟨s.piecewise id (fun _ ↦ a), ?_, Filter.mem_of_superset h2 (fun x hx ↦ by simp [hx])⟩
-  have h : StronglyMeasurable ((↑) : s → α) := by
-    have := h1.secondCountableTopology
+  refine ⟨(closure s).piecewise id (fun _ ↦ a), ?_,
+    Filter.mem_of_superset h2 (fun x hx ↦ by simp [subset_closure hx])⟩
+  have h : StronglyMeasurable ((↑) : closure s → α) := by
+    have := h1.closure.secondCountableTopology
     exact continuous_subtype_val.stronglyMeasurable
-  have : s.piecewise id (fun _ ↦ a) = ((↑) : s → α).extend ((↑) : s → α) (fun _ ↦ a) := by
+  have : (closure s).piecewise id (fun _ ↦ a) =
+      ((↑) : closure s → α).extend ((↑) : closure s → α) (fun _ ↦ a) := by
     ext x
-    by_cases hx : x ∈ s
+    by_cases hx : x ∈ closure s
     · simp [Function.extend_val_apply, hx]
     · simp [hx]
   rw [this]
-  exact (MeasurableEmbedding.subtype_coe h3).stronglyMeasurable_extend h stronglyMeasurable_const
+  exact (MeasurableEmbedding.subtype_coe isClosed_closure.measurableSet).stronglyMeasurable_extend
+    h stronglyMeasurable_const
 
 namespace AEStronglyMeasurable
 
@@ -613,7 +616,7 @@ lemma aestronglyMeasurable_id_map {mβ : MeasurableSpace β}
     {f : α → β} (hf : AEStronglyMeasurable f μ) :
     AEStronglyMeasurable id (μ.map f) := by
   obtain ⟨t, ht1, ht2⟩ := hf.isSeparable_ae_range
-  refine aestronglyMeasurable_id_of_isSeparable ht1.closure ?_ isClosed_closure.measurableSet
+  refine aestronglyMeasurable_id_of_isSeparable ht1.closure ?_
   refine ae_map_iff hf.aemeasurable isClosed_closure.measurableSet |>.2 ?_
   filter_upwards [ht2] with ω hω using subset_closure hω
 


### PR DESCRIPTION
If `AEStronglyMeasurable f µ` then `AEStronglyMeasurable id (µ.map f)`. Contrary to [aestronglyMeasurable_id](https://leanprover-community.github.io/mathlib4_docs/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.html#aestronglyMeasurable_id) this does not require the identity to be defined over a second-countable space as `f` has a.e.-separable range.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
