### PR TITLE
feat: add instances of MetricSpace, NormedAddGroup, and NormedAddCommGroup for DirectLimit

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2117,6 +2117,7 @@ public import Mathlib.Analysis.Normed.Group.Constructions
 public import Mathlib.Analysis.Normed.Group.Continuity
 public import Mathlib.Analysis.Normed.Group.ControlledClosure
 public import Mathlib.Analysis.Normed.Group.Defs
+public import Mathlib.Analysis.Normed.Group.DirectLimit
 public import Mathlib.Analysis.Normed.Group.FunctionSeries
 public import Mathlib.Analysis.Normed.Group.Hom
 public import Mathlib.Analysis.Normed.Group.HomCompletion
@@ -7817,6 +7818,7 @@ public import Mathlib.Topology.MetricSpace.CoveringNumbers
 public import Mathlib.Topology.MetricSpace.Defs
 public import Mathlib.Topology.MetricSpace.Dilation
 public import Mathlib.Topology.MetricSpace.DilationEquiv
+public import Mathlib.Topology.MetricSpace.DirectLimit
 public import Mathlib.Topology.MetricSpace.Equicontinuity
 public import Mathlib.Topology.MetricSpace.Gluing
 public import Mathlib.Topology.MetricSpace.GromovHausdorff

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2212,6 +2212,7 @@ public import Mathlib.Analysis.Normed.Order.Hom.Ultra
 public import Mathlib.Analysis.Normed.Order.Lattice
 public import Mathlib.Analysis.Normed.Order.UpperLower
 public import Mathlib.Analysis.Normed.Ring.Basic
+public import Mathlib.Analysis.Normed.Ring.DirectLimit
 public import Mathlib.Analysis.Normed.Ring.Finite
 public import Mathlib.Analysis.Normed.Ring.InfiniteProd
 public import Mathlib.Analysis.Normed.Ring.InfiniteSum

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -68,6 +68,19 @@ noncomputable instance : NormedGroup (DirectLimit G f) where
 
 end NormedGroup
 
+section SeminormedCommGroup
+
+variable [∀ i, SeminormedCommGroup (G i)]
+variable [∀ i j h, MonoidHomClass (T h) (G i) (G j)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+@[to_additive]
+noncomputable instance : SeminormedCommGroup (DirectLimit G f) where
+  __ := (inferInstance : SeminormedGroup (DirectLimit G f))
+  __ := (inferInstance : CommGroup (DirectLimit G f))
+
+end SeminormedCommGroup
+
 section NormedCommGroup
 
 variable [∀ i, NormedCommGroup (G i)]

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -53,29 +53,12 @@ variable [∀ i, NormedGroup (G i)]
 variable [∀ i j h, MonoidHomClass (T h) (G i) (G j)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 
+@[to_additive]
 noncomputable instance : NormedGroup (DirectLimit G f) where
   __ := (inferInstance : SeminormedGroup (DirectLimit G f))
   __ := (inferInstance : MetricSpace (DirectLimit G f))
 
 end NormedGroup
-
-namespace NormedAddGroup
-
-variable [∀ i, NormedAddGroup (G i)]
-variable [∀ i j h, AddMonoidHomClass (T h) (G i) (G j)]
-variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
-
-noncomputable instance instNormedAddGroup : NormedAddGroup (DirectLimit G f) where
-  norm := DirectLimit.lift f (ih := fun i x ↦ ‖x‖) (fun i j h x ↦ by
-    simpa [NormedAddGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 0 x).symm)
-  dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
-    rw [dist_def, NormedAddGroup.dist_eq, neg_def, add_def, DirectLimit.lift_def])
-
-lemma norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖x‖ := by
-  change DirectLimit.lift f (ih := fun i x ↦ ‖x‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
-  apply DirectLimit.lift_def
-
-end NormedAddGroup
 
 namespace NormedAddCommGroup
 
@@ -84,7 +67,7 @@ variable [∀ i j h, AddMonoidHomClass (T h) (G i) (G j)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 
 noncomputable instance instNormedAddCommGroup : NormedAddCommGroup (DirectLimit G f) where
-  __ := NormedAddGroup.instNormedAddGroup
+  __ := (inferInstance : NormedAddGroup (DirectLimit G f))
   __ := (inferInstance : AddCommGroup (DirectLimit G f))
 
 end NormedAddCommGroup

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -55,9 +55,6 @@ noncomputable instance instNormedAddCommGroup : NormedAddCommGroup (DirectLimit 
   __ := NormedAddGroup.instNormedAddGroup
   __ := (inferInstance : AddCommGroup (DirectLimit G f))
 
-example (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖x‖ := by
-  apply DirectLimit.NormedAddGroup.norm_def
-
 end NormedAddCommGroup
 
 end DirectLimit

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -53,7 +53,7 @@ variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 
 noncomputable instance instNormedAddCommGroup : NormedAddCommGroup (DirectLimit G f) where
   __ := NormedAddGroup.instNormedAddGroup
-  __ : AddCommGroup (DirectLimit G f) := _
+  __ := (inferInstance : AddCommGroup (DirectLimit G f))
 
 example (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖(x : G i)‖ := by
   apply DirectLimit.NormedAddGroup.norm_def

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -33,8 +33,6 @@ variable [∀ i, SeminormedGroup (G i)]
 variable [∀ i j h, MonoidHomClass (T h) (G i) (G j)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 
-#synth ∀ i, PseudoMetricSpace (G i)
-
 @[to_additive]
 noncomputable instance : SeminormedGroup (DirectLimit G f) where
   norm := DirectLimit.lift f (ih := fun i x ↦ ‖x‖) (fun i j h x ↦ by
@@ -58,15 +56,6 @@ variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 noncomputable instance : NormedGroup (DirectLimit G f) where
   __ := (inferInstance : SeminormedGroup (DirectLimit G f))
   __ := (inferInstance : MetricSpace (DirectLimit G f))
-
-@[to_additive]
-noncomputable instance : NormedGroup (DirectLimit G f) where
-  norm := DirectLimit.lift f (ih := fun i x ↦ ‖x‖) (fun i j h x ↦ by
-    simpa [NormedGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 1 x).symm)
-  dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
-    rw [dist_def, NormedGroup.dist_eq, inv_def, mul_def, DirectLimit.lift_def])
-
-
 
 end NormedGroup
 

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -9,8 +9,6 @@ public import Mathlib.Analysis.Normed.Group.Defs
 public import Mathlib.Algebra.Colimit.DirectLimit
 public import Mathlib.Topology.MetricSpace.DirectLimit
 
-@[expose] public section
-
 /-!
 # Direct Limit of normed additive groups
 
@@ -18,6 +16,8 @@ We introduct instances of `NormedAddGroup` and `NormedAddCommGroup` on `DirectLi
 under the assumption that the types `T h` that the maps in the directed system come from,
 all have instances of `IsometryClass`.
 -/
+
+@[expose] public section
 
 namespace DirectLimit
 

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -14,7 +14,7 @@ public import Mathlib.Topology.MetricSpace.DirectLimit
 /-!
 # Direct Limit of normed additive groups
 
-We introduct instances on `DirectLimit` for `NormedAddGroup` and `NormedAddCommGroup`,
+We introduct instances of `NormedAddGroup` and `NormedAddCommGroup` on `DirectLimit`,
 under the assumption that the types `T h` that the maps in the directed system come from,
 all have instances of `IsometryClass`.
 -/

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -33,6 +33,9 @@ noncomputable instance instNormedAddGroup : NormedAddGroup (DirectLimit G f) whe
   dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
     rw [MetricSpace.dist_def, NormedAddGroup.dist_eq x y, neg_def, add_def, DirectLimit.lift_def])
 
+lemma norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖(x : G i)‖ := by
+  change DirectLimit.lift f (ih := fun i x => ‖ (x : G i)‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
+  apply DirectLimit.lift_def
 
 end NormedAddGroup
 

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -27,6 +27,49 @@ variable [∀ i j (h : i ≤ j), FunLike (T h) (G i) (G j)] [DirectedSystem G (f
 variable [IsDirectedOrder ι]
 variable [Nonempty ι]
 
+section SeminormedGroup
+
+variable [∀ i, SeminormedGroup (G i)]
+variable [∀ i j h, MonoidHomClass (T h) (G i) (G j)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+#synth ∀ i, PseudoMetricSpace (G i)
+
+@[to_additive]
+noncomputable instance : SeminormedGroup (DirectLimit G f) where
+  norm := DirectLimit.lift f (ih := fun i x ↦ ‖x‖) (fun i j h x ↦ by
+    simpa [SeminormedGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 1 x).symm)
+  dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
+    rw [dist_def, SeminormedGroup.dist_eq, inv_def, mul_def, DirectLimit.lift_def])
+
+@[to_additive norm_def]
+lemma mul_norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖x‖ := by
+  change DirectLimit.lift f (ih := fun i x ↦ ‖x‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
+  apply DirectLimit.lift_def
+
+end SeminormedGroup
+
+section NormedGroup
+
+variable [∀ i, NormedGroup (G i)]
+variable [∀ i j h, MonoidHomClass (T h) (G i) (G j)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+noncomputable instance : NormedGroup (DirectLimit G f) where
+  __ := (inferInstance : SeminormedGroup (DirectLimit G f))
+  __ := (inferInstance : MetricSpace (DirectLimit G f))
+
+@[to_additive]
+noncomputable instance : NormedGroup (DirectLimit G f) where
+  norm := DirectLimit.lift f (ih := fun i x ↦ ‖x‖) (fun i j h x ↦ by
+    simpa [NormedGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 1 x).symm)
+  dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
+    rw [dist_def, NormedGroup.dist_eq, inv_def, mul_def, DirectLimit.lift_def])
+
+
+
+end NormedGroup
+
 namespace NormedAddGroup
 
 variable [∀ i, NormedAddGroup (G i)]
@@ -37,7 +80,7 @@ noncomputable instance instNormedAddGroup : NormedAddGroup (DirectLimit G f) whe
   norm := DirectLimit.lift f (ih := fun i x ↦ ‖x‖) (fun i j h x ↦ by
     simpa [NormedAddGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 0 x).symm)
   dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
-    rw [MetricSpace.dist_def, NormedAddGroup.dist_eq, neg_def, add_def, DirectLimit.lift_def])
+    rw [dist_def, NormedAddGroup.dist_eq, neg_def, add_def, DirectLimit.lift_def])
 
 lemma norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖x‖ := by
   change DirectLimit.lift f (ih := fun i x ↦ ‖x‖) _ ⟦⟨i, x⟩⟧ = ‖x‖

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -60,16 +60,17 @@ noncomputable instance : NormedGroup (DirectLimit G f) where
 
 end NormedGroup
 
-namespace NormedAddCommGroup
+section NormedCommGroup
 
-variable [∀ i, NormedAddCommGroup (G i)]
-variable [∀ i j h, AddMonoidHomClass (T h) (G i) (G j)]
+variable [∀ i, NormedCommGroup (G i)]
+variable [∀ i j h, MonoidHomClass (T h) (G i) (G j)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 
-noncomputable instance instNormedAddCommGroup : NormedAddCommGroup (DirectLimit G f) where
-  __ := (inferInstance : NormedAddGroup (DirectLimit G f))
-  __ := (inferInstance : AddCommGroup (DirectLimit G f))
+@[to_additive]
+noncomputable instance : NormedCommGroup (DirectLimit G f) where
+  __ := (inferInstance : NormedGroup (DirectLimit G f))
+  __ := (inferInstance : CommGroup (DirectLimit G f))
 
-end NormedAddCommGroup
+end NormedCommGroup
 
 end DirectLimit

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -39,5 +39,21 @@ lemma norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ =
 
 end NormedAddGroup
 
+namespace NormedAddCommGroup
+
+variable [∀ i, NormedAddCommGroup (G i)]
+variable [∀ i j h, AddMonoidHomClass (T h) (G i) (G j)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+noncomputable instance instNormedAddCommGroup : NormedAddCommGroup (DirectLimit G f) where
+  norm := DirectLimit.lift f (ih := fun i x => ‖ (x : G i)‖) (fun i j h x ↦ by
+    simpa [NormedAddGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 0 x).symm)
+  dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
+    rw [MetricSpace.dist_def, NormedAddGroup.dist_eq x y, neg_def, add_def, DirectLimit.lift_def])
+
+example (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖(x : G i)‖ := by
+  apply DirectLimit.NormedAddGroup.norm_def
+
+end NormedAddCommGroup
 
 end DirectLimit

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -40,7 +40,7 @@ noncomputable instance instNormedAddGroup : NormedAddGroup (DirectLimit G f) whe
     rw [MetricSpace.dist_def, NormedAddGroup.dist_eq, neg_def, add_def, DirectLimit.lift_def])
 
 lemma norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖x‖ := by
-  change DirectLimit.lift f (ih := fun i x ↦ ‖(x : G i)‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
+  change DirectLimit.lift f (ih := fun i x ↦ ‖x‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
   apply DirectLimit.lift_def
 
 end NormedAddGroup
@@ -55,7 +55,7 @@ noncomputable instance instNormedAddCommGroup : NormedAddCommGroup (DirectLimit 
   __ := NormedAddGroup.instNormedAddGroup
   __ := (inferInstance : AddCommGroup (DirectLimit G f))
 
-example (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖(x : G i)‖ := by
+example (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖x‖ := by
   apply DirectLimit.NormedAddGroup.norm_def
 
 end NormedAddCommGroup

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -54,10 +54,8 @@ variable [∀ i j h, AddMonoidHomClass (T h) (G i) (G j)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 
 noncomputable instance instNormedAddCommGroup : NormedAddCommGroup (DirectLimit G f) where
-  norm := DirectLimit.lift f (ih := fun i x => ‖ (x : G i)‖) (fun i j h x ↦ by
-    simpa [NormedAddGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 0 x).symm)
-  dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
-    rw [MetricSpace.dist_def, NormedAddGroup.dist_eq x y, neg_def, add_def, DirectLimit.lift_def])
+  __ := NormedAddGroup.instNormedAddGroup
+  __ : AddCommGroup (DirectLimit G f) := _
 
 example (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖(x : G i)‖ := by
   apply DirectLimit.NormedAddGroup.norm_def

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -34,12 +34,12 @@ variable [∀ i j h, AddMonoidHomClass (T h) (G i) (G j)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 
 noncomputable instance instNormedAddGroup : NormedAddGroup (DirectLimit G f) where
-  norm := DirectLimit.lift f (ih := fun i x ↦ ‖(x : G i)‖) (fun i j h x ↦ by
+  norm := DirectLimit.lift f (ih := fun i x ↦ ‖x‖) (fun i j h x ↦ by
     simpa [NormedAddGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 0 x).symm)
   dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
-    rw [MetricSpace.dist_def, NormedAddGroup.dist_eq x y, neg_def, add_def, DirectLimit.lift_def])
+    rw [MetricSpace.dist_def, NormedAddGroup.dist_eq, neg_def, add_def, DirectLimit.lift_def])
 
-lemma norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖(x : G i)‖ := by
+lemma norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖x‖ := by
   change DirectLimit.lift f (ih := fun i x ↦ ‖(x : G i)‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
   apply DirectLimit.lift_def
 

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -5,7 +5,7 @@ Authors: Matthew Corbelli
 -/
 module
 
-public import Mathlib.Analysis.Normed.Group.Defs
+public import Mathlib.Analysis.Normed.Group.Basic
 public import Mathlib.Algebra.Colimit.DirectLimit
 public import Mathlib.Topology.MetricSpace.DirectLimit
 
@@ -44,6 +44,14 @@ noncomputable instance : SeminormedGroup (DirectLimit G f) where
 lemma mul_norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖x‖ := by
   change DirectLimit.lift f (ih := fun i x ↦ ‖x‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
   apply DirectLimit.lift_def
+
+@[to_additive nnnorm_def]
+lemma mul_nnnorm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖₊ = ‖x‖₊ := by
+  simp_rw [← @norm_toNNReal', mul_norm_def]
+
+@[to_additive enorm_def]
+lemma mul_enorm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ₑ = ‖x‖ₑ := by
+  rw [@enorm'_eq_iff_norm_eq,  mul_norm_def]
 
 end SeminormedGroup
 

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -34,13 +34,13 @@ variable [∀ i j h, AddMonoidHomClass (T h) (G i) (G j)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 
 noncomputable instance instNormedAddGroup : NormedAddGroup (DirectLimit G f) where
-  norm := DirectLimit.lift f (ih := fun i x => ‖(x : G i)‖) (fun i j h x ↦ by
+  norm := DirectLimit.lift f (ih := fun i x ↦ ‖(x : G i)‖) (fun i j h x ↦ by
     simpa [NormedAddGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 0 x).symm)
   dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
     rw [MetricSpace.dist_def, NormedAddGroup.dist_eq x y, neg_def, add_def, DirectLimit.lift_def])
 
 lemma norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖(x : G i)‖ := by
-  change DirectLimit.lift f (ih := fun i x => ‖(x : G i)‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
+  change DirectLimit.lift f (ih := fun i x ↦ ‖(x : G i)‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
   apply DirectLimit.lift_def
 
 end NormedAddGroup

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -11,6 +11,14 @@ public import Mathlib.Topology.MetricSpace.DirectLimit
 
 @[expose] public section
 
+/-!
+# Direct Limit of normed additive groups
+
+We introduct instances on `DirectLimit` for `NormedAddGroup` and `NormedAddCommGroup`,
+under the assumption that the types `T h` that the maps in the directed system come from,
+all have instances of `IsometryClass`.
+-/
+
 namespace DirectLimit
 
 variable {ι : Type*} [Preorder ι] {G : ι → Type*}

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2026 Matthew Corbelli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matthew Corbelli
+-/
+module
+
+public import Mathlib.Analysis.Normed.Group.Defs
+public import Mathlib.Algebra.Colimit.DirectLimit
+public import Mathlib.Topology.MetricSpace.DirectLimit
+
+@[expose] public section
+
+namespace DirectLimit
+
+variable {ι : Type*} [Preorder ι] {G : ι → Type*}
+variable {T : ∀ ⦃i j : ι⦄, i ≤ j → Type*} {f : ∀ _ _ h, T h}
+variable [∀ i j (h : i ≤ j), FunLike (T h) (G i) (G j)] [DirectedSystem G (f · · ·)]
+variable [IsDirectedOrder ι]
+variable [Nonempty ι]
+
+
+
+namespace NormedAddGroup
+
+variable [∀ i, NormedAddGroup (G i)]
+variable [∀ i j h, AddMonoidHomClass (T h) (G i) (G j)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+noncomputable instance instNormedAddGroup : NormedAddGroup (DirectLimit G f) where
+  norm := DirectLimit.lift f (ih := fun i x => ‖ (x : G i)‖) (fun i j h x ↦ by
+    simpa [NormedAddGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 0 x).symm)
+  dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
+    rw [MetricSpace.dist_def, NormedAddGroup.dist_eq x y, neg_def, add_def, DirectLimit.lift_def])
+
+
+end NormedAddGroup
+
+
+end DirectLimit

--- a/Mathlib/Analysis/Normed/Group/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Group/DirectLimit.lean
@@ -27,8 +27,6 @@ variable [∀ i j (h : i ≤ j), FunLike (T h) (G i) (G j)] [DirectedSystem G (f
 variable [IsDirectedOrder ι]
 variable [Nonempty ι]
 
-
-
 namespace NormedAddGroup
 
 variable [∀ i, NormedAddGroup (G i)]
@@ -36,13 +34,13 @@ variable [∀ i j h, AddMonoidHomClass (T h) (G i) (G j)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 
 noncomputable instance instNormedAddGroup : NormedAddGroup (DirectLimit G f) where
-  norm := DirectLimit.lift f (ih := fun i x => ‖ (x : G i)‖) (fun i j h x ↦ by
+  norm := DirectLimit.lift f (ih := fun i x => ‖(x : G i)‖) (fun i j h x ↦ by
     simpa [NormedAddGroup.dist_eq] using (IsometryClass.dist_eq (f i j h) 0 x).symm)
   dist_eq := DirectLimit.induction₂ f (fun i x y ↦ by
     rw [MetricSpace.dist_def, NormedAddGroup.dist_eq x y, neg_def, add_def, DirectLimit.lift_def])
 
 lemma norm_def (i : ι) (x : G i) : ‖(⟦⟨i, x⟩⟧ : DirectLimit G f)‖ = ‖(x : G i)‖ := by
-  change DirectLimit.lift f (ih := fun i x => ‖ (x : G i)‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
+  change DirectLimit.lift f (ih := fun i x => ‖(x : G i)‖) _ ⟦⟨i, x⟩⟧ = ‖x‖
   apply DirectLimit.lift_def
 
 end NormedAddGroup

--- a/Mathlib/Analysis/Normed/Ring/DirectLimit.lean
+++ b/Mathlib/Analysis/Normed/Ring/DirectLimit.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 Matthew Corbelli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matthew Corbelli
+-/
+module
+
+public import Mathlib.Analysis.Normed.Group.DirectLimit
+public import Mathlib.Analysis.Normed.Ring.Basic
+public import Mathlib.Algebra.Colimit.DirectLimit
+
+/-!
+# Direct Limit of normed rings
+
+We introduct instances of `NormedRing` and `NonUnitalNormedRing` on `DirectLimit`,
+under the assumption that the types `T h` that the maps in the directed system come from,
+all have instances of `IsometryClass`.
+-/
+
+@[expose] public section
+
+namespace DirectLimit
+
+variable {ι : Type*} [Preorder ι] {G : ι → Type*}
+variable {T : ∀ ⦃i j : ι⦄, i ≤ j → Type*} {f : ∀ _ _ h, T h}
+variable [∀ i j (h : i ≤ j), FunLike (T h) (G i) (G j)] [DirectedSystem G (f · · ·)]
+variable [IsDirectedOrder ι]
+variable [Nonempty ι]
+
+section NonUnitalNormedRing
+
+variable [∀ i, NonUnitalNormedRing (G i)]
+variable [∀ i j h, NonUnitalRingHomClass (T h) (G i) (G j)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+noncomputable instance : NonUnitalNormedRing (DirectLimit G f) where
+  __ := (inferInstance : NormedAddCommGroup (DirectLimit G f))
+  __ := (inferInstance : NonUnitalRing (DirectLimit G f))
+  norm_mul_le := DirectLimit.induction₂ f
+    fun i x y ↦ by simp_rw [mul_def, norm_def]; exact norm_mul_le x y
+
+end NonUnitalNormedRing
+
+section NormedRing
+
+variable [∀ i, NormedRing (G i)]
+variable [∀ i j h, RingHomClass (T h) (G i) (G j)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+noncomputable instance : NormedRing (DirectLimit G f) where
+  __ := (inferInstance : Ring (DirectLimit G f))
+  __ := (inferInstance : NonUnitalNormedRing (DirectLimit G f))
+
+end NormedRing
+
+
+end DirectLimit

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -49,8 +49,7 @@ noncomputable instance : MetricSpace (DirectLimit G f) where
     intro i x y
     rw [DirectLimit.lift₂_def]
     intro h
-    have h' := eq_of_dist_eq_zero h
-    rw [h']
+    simp [eq_of_dist_eq_zero h]
 
 lemma dist_def (i : ι) (x y : G i) :
     dist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = dist x y := by

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -8,8 +8,6 @@ module
 public import Mathlib.Order.DirectedInverseSystem
 public import Mathlib.Topology.MetricSpace.Isometry
 
-@[expose] public section
-
 /-!
 # Metrics on direct limits
 
@@ -19,6 +17,7 @@ system of metric spaces and the transition maps `f` are isometries (using `Isome
 See also `Metric.InductiveLimit` in `Mathlib/Topology/MetricSpace/Gluing.lean`, which
 handles sequential inductive limits of metric spaces.
 -/
+@[expose] public section
 
 namespace DirectLimit
 

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Matthew Corbelli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matthew Corbelli
+-/
+module
+
+public import Mathlib.Order.DirectedInverseSystem
+public import Mathlib.Topology.MetricSpace.Isometry
+
+@[expose] public section
+
+namespace DirectLimit
+
+variable {ι : Type*} [Preorder ι] {G : ι → Type*}
+variable {T : ∀ ⦃i j : ι⦄, i ≤ j → Type*} {f : ∀ _ _ h, T h}
+variable [∀ i j (h : i ≤ j), FunLike (T h) (G i) (G j)] [DirectedSystem G (f · · ·)]
+variable [IsDirectedOrder ι]
+
+namespace Metric
+
+variable [∀ i, MetricSpace (G i)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+noncomputable instance : MetricSpace (DirectLimit G f) where
+  dist := DirectLimit.lift₂ f f (fun i ↦ dist (α := G i))
+    (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm)
+  dist_self := by
+    apply DirectLimit.induction
+    intro i x
+    rw [← dist_self x]
+    apply DirectLimit.lift₂_def f f (fun i ↦ dist (α := G i) )
+      (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm) i x x
+  dist_comm := by
+    apply DirectLimit.induction₂
+    intro i x y
+    simp_rw [lift₂_def, dist_comm x y]
+  dist_triangle := by
+    apply DirectLimit.induction₃
+    intro i x y z
+    simp_rw [lift₂_def, dist_triangle]
+  eq_of_dist_eq_zero := by
+    apply DirectLimit.induction₂
+    intro i x y
+    rw [DirectLimit.lift₂_def]
+    intro h
+    have h' := eq_of_dist_eq_zero h
+    rw [h']
+
+lemma MetricSpace.dist_def (i : ι) (x y : G i) :
+    dist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = dist x y := by
+  change DirectLimit.lift₂ f f
+    (fun i ↦ dist (α := G i))
+    (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm)
+    ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧ = dist x y
+  rw [lift₂_def]
+
+end Metric
+
+end DirectLimit

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -33,9 +33,9 @@ noncomputable instance : MetricSpace (DirectLimit G f) where
   dist_self := DirectLimit.induction f (fun i x ↦ by rw [← dist_self x, lift₂_def])
   dist_comm := DirectLimit.induction₂ f (fun i x y ↦ by simp_rw [lift₂_def, dist_comm x y])
   dist_triangle := DirectLimit.induction₃ f (fun i x y z ↦ by simp_rw [lift₂_def, dist_triangle])
-  eq_of_dist_eq_zero {x' y'} h:= DirectLimit.induction₂ f (fun i x y h ↦ by
-    rw [lift₂_def] at h
-    simp [eq_of_dist_eq_zero h]) x' y' h
+  eq_of_dist_eq_zero {x y} h := DirectLimit.induction₂ f (fun i x' y' h' ↦ by
+    rw [lift₂_def] at h'
+    simp [eq_of_dist_eq_zero h']) x y h
 
 lemma dist_def (i : ι) (x y : G i) :
     dist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = dist x y := by

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -10,6 +10,11 @@ public import Mathlib.Topology.MetricSpace.Isometry
 
 @[expose] public section
 
+/-!
+Gives an instance of `MetricSpace` on the `DirectLimit` of a directed system of metric spaces,
+where all the maps in the directed system are from types satisfying the class `IsometryClass`.
+-/
+
 namespace DirectLimit
 
 variable {ι : Type*} [Preorder ι] {G : ι → Type*}

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -17,7 +17,7 @@ variable {T : ∀ ⦃i j : ι⦄, i ≤ j → Type*} {f : ∀ _ _ h, T h}
 variable [∀ i j (h : i ≤ j), FunLike (T h) (G i) (G j)] [DirectedSystem G (f · · ·)]
 variable [IsDirectedOrder ι]
 
-namespace Metric
+namespace MetricSpace
 
 variable [∀ i, MetricSpace (G i)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
@@ -47,7 +47,7 @@ noncomputable instance : MetricSpace (DirectLimit G f) where
     have h' := eq_of_dist_eq_zero h
     rw [h']
 
-lemma MetricSpace.dist_def (i : ι) (x y : G i) :
+lemma dist_def (i : ι) (x y : G i) :
     dist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = dist x y := by
   change DirectLimit.lift₂ f f
     (fun i ↦ dist (α := G i))
@@ -55,6 +55,6 @@ lemma MetricSpace.dist_def (i : ι) (x y : G i) :
     ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧ = dist x y
   rw [lift₂_def]
 
-end Metric
+end MetricSpace
 
 end DirectLimit

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -45,6 +45,14 @@ lemma dist_def (i : ι) (x y : G i) :
     ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧ = dist x y
   rw [lift₂_def]
 
+lemma nndist_def (i : ι) (x y : G i) :
+    nndist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = nndist x y := by
+  simp_rw [nndist_dist, dist_def]
+
+lemma edist_def (i : ι) (x y : G i) :
+    edist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = edist x y := by
+  simp_rw [edist_dist, dist_def]
+
 end PseudoMetricSpace
 
 namespace MetricSpace

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -26,6 +26,40 @@ variable {T : ∀ ⦃i j : ι⦄, i ≤ j → Type*} {f : ∀ _ _ h, T h}
 variable [∀ i j (h : i ≤ j), FunLike (T h) (G i) (G j)] [DirectedSystem G (f · · ·)]
 variable [IsDirectedOrder ι]
 
+section PseudoEMetricSpace
+
+variable [∀ i, PseudoEMetricSpace (G i)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+noncomputable instance : PseudoEMetricSpace (DirectLimit G f) where
+  edist := DirectLimit.lift₂ f f (fun i ↦ edist (α := G i))
+    (fun i j h x y ↦ (IsometryClass.edist_eq (f i j h) x y).symm)
+  edist_self := DirectLimit.induction f fun i x ↦ by rw [← edist_self x, lift₂_def]
+  edist_comm := DirectLimit.induction₂ f fun i x y ↦ by simp_rw [lift₂_def, edist_comm x y]
+  edist_triangle := DirectLimit.induction₃ f fun i x y z ↦ by simp_rw [lift₂_def, edist_triangle]
+
+lemma edist_def (i : ι) (x y : G i) :
+    edist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = edist x y := by
+  change DirectLimit.lift₂ f f _
+    (fun i j h x y ↦ (IsometryClass.edist_eq (f i j h) x y).symm)
+    ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧ = edist x y
+  rw [lift₂_def]
+
+end PseudoEMetricSpace
+
+section EMetricSpace
+
+variable [∀ i, EMetricSpace (G i)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+noncomputable instance : EMetricSpace (DirectLimit G f) where
+  __ := (inferInstance : PseudoEMetricSpace (DirectLimit G f))
+  eq_of_edist_eq_zero {x y} h := DirectLimit.induction₂ f (fun i x' y' h' ↦ by
+    rw [edist_def] at h'
+    simp [eq_of_edist_eq_zero h']) x y h
+
+end EMetricSpace
+
 section PseudoMetricSpace
 
 variable [∀ i, PseudoMetricSpace (G i)]
@@ -48,10 +82,6 @@ lemma dist_def (i : ι) (x y : G i) :
 lemma nndist_def (i : ι) (x y : G i) :
     nndist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = nndist x y := by
   simp_rw [nndist_dist, dist_def]
-
-lemma edist_def (i : ι) (x y : G i) :
-    edist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = edist x y := by
-  simp_rw [edist_dist, dist_def]
 
 end PseudoMetricSpace
 

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -30,20 +30,12 @@ variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 noncomputable instance : MetricSpace (DirectLimit G f) where
   dist := DirectLimit.lift₂ f f (fun i ↦ dist (α := G i))
     (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm)
-  dist_self := by
-    apply DirectLimit.induction
-    intro i x
-    rw [← dist_self x]
-    apply DirectLimit.lift₂_def f f (fun i ↦ dist (α := G i) )
-      (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm) i x x
+  dist_self := DirectLimit.induction f (fun i x ↦ by rw [← dist_self x, lift₂_def])
   dist_comm := DirectLimit.induction₂ f (fun i x y ↦ by simp_rw [lift₂_def, dist_comm x y])
   dist_triangle := DirectLimit.induction₃ f (fun i x y z ↦ by simp_rw [lift₂_def, dist_triangle])
-  eq_of_dist_eq_zero := by
-    apply DirectLimit.induction₂
-    intro i x y
-    rw [DirectLimit.lift₂_def]
-    intro h
-    simp [eq_of_dist_eq_zero h]
+  eq_of_dist_eq_zero {x' y'} h:= DirectLimit.induction₂ f (fun i x y h ↦ by
+    rw [lift₂_def] at h
+    simp [eq_of_dist_eq_zero h]) x' y' h
 
 lemma dist_def (i : ι) (x y : G i) :
     dist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = dist x y := by

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -26,7 +26,7 @@ variable {T : ∀ ⦃i j : ι⦄, i ≤ j → Type*} {f : ∀ _ _ h, T h}
 variable [∀ i j (h : i ≤ j), FunLike (T h) (G i) (G j)] [DirectedSystem G (f · · ·)]
 variable [IsDirectedOrder ι]
 
-namespace PseudoMetricSpace
+section PseudoMetricSpace
 
 variable [∀ i, PseudoMetricSpace (G i)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
@@ -55,7 +55,7 @@ lemma edist_def (i : ι) (x y : G i) :
 
 end PseudoMetricSpace
 
-namespace MetricSpace
+section MetricSpace
 
 variable [∀ i, MetricSpace (G i)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
@@ -67,10 +67,6 @@ noncomputable instance : MetricSpace (DirectLimit G f) where
   eq_of_dist_eq_zero {x y} h := DirectLimit.induction₂ f (fun i x' y' h' ↦ by
     rw [lift₂_def] at h'
     simp [eq_of_dist_eq_zero h']) x y h
-
-lemma dist_def (i : ι) (x y : G i) :
-    dist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = dist x y :=
-  DirectLimit.PseudoMetricSpace.dist_def i x y
 
 end MetricSpace
 

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -36,14 +36,8 @@ noncomputable instance : MetricSpace (DirectLimit G f) where
     rw [← dist_self x]
     apply DirectLimit.lift₂_def f f (fun i ↦ dist (α := G i) )
       (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm) i x x
-  dist_comm := by
-    apply DirectLimit.induction₂
-    intro i x y
-    simp_rw [lift₂_def, dist_comm x y]
-  dist_triangle := by
-    apply DirectLimit.induction₃
-    intro i x y z
-    simp_rw [lift₂_def, dist_triangle]
+  dist_comm := DirectLimit.induction₂ f (fun i x y ↦ by simp_rw [lift₂_def, dist_comm x y])
+  dist_triangle := DirectLimit.induction₃ f (fun i x y z ↦ by simp_rw [lift₂_def, dist_triangle])
   eq_of_dist_eq_zero := by
     apply DirectLimit.induction₂
     intro i x y

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -53,8 +53,7 @@ noncomputable instance : MetricSpace (DirectLimit G f) where
 
 lemma dist_def (i : ι) (x y : G i) :
     dist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = dist x y := by
-  change DirectLimit.lift₂ f f
-    (fun i ↦ dist (α := G i))
+  change DirectLimit.lift₂ f f _
     (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm)
     ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧ = dist x y
   rw [lift₂_def]

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -11,8 +11,13 @@ public import Mathlib.Topology.MetricSpace.Isometry
 @[expose] public section
 
 /-!
-Gives an instance of `MetricSpace` on the `DirectLimit` of a directed system of metric spaces,
-where all the maps in the directed system are from types satisfying the class `IsometryClass`.
+# Metrics on direct limits
+
+This file defines a `MetricSpace` instance on `DirectLimit G f` when `G` and `f` form a directed
+system of metric spaces and the transition maps `f` are isometries (using `IsometryClass`).
+
+See also `Metric.InductiveLimit` in `Mathlib/Topology/MetricSpace/Gluing.lean`, which
+handles sequential inductive limits of metric spaces.
 -/
 
 namespace DirectLimit

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -61,11 +61,9 @@ variable [∀ i, MetricSpace (G i)]
 variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 
 noncomputable instance : MetricSpace (DirectLimit G f) where
-  dist := DirectLimit.lift₂ f f (fun i ↦ dist (α := G i))
-    (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm)
   __ := (inferInstance : PseudoMetricSpace (DirectLimit G f))
   eq_of_dist_eq_zero {x y} h := DirectLimit.induction₂ f (fun i x' y' h' ↦ by
-    rw [lift₂_def] at h'
+    rw [dist_def] at h'
     simp [eq_of_dist_eq_zero h']) x y h
 
 end MetricSpace

--- a/Mathlib/Topology/MetricSpace/DirectLimit.lean
+++ b/Mathlib/Topology/MetricSpace/DirectLimit.lean
@@ -26,6 +26,27 @@ variable {T : ∀ ⦃i j : ι⦄, i ≤ j → Type*} {f : ∀ _ _ h, T h}
 variable [∀ i j (h : i ≤ j), FunLike (T h) (G i) (G j)] [DirectedSystem G (f · · ·)]
 variable [IsDirectedOrder ι]
 
+namespace PseudoMetricSpace
+
+variable [∀ i, PseudoMetricSpace (G i)]
+variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
+
+noncomputable instance : PseudoMetricSpace (DirectLimit G f) where
+  dist := DirectLimit.lift₂ f f (fun i ↦ dist (α := G i))
+    (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm)
+  dist_self := DirectLimit.induction f fun i x ↦ by rw [← dist_self x, lift₂_def]
+  dist_comm := DirectLimit.induction₂ f fun i x y ↦ by simp_rw [lift₂_def, dist_comm x y]
+  dist_triangle := DirectLimit.induction₃ f fun i x y z ↦ by simp_rw [lift₂_def, dist_triangle]
+
+lemma dist_def (i : ι) (x y : G i) :
+    dist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = dist x y := by
+  change DirectLimit.lift₂ f f _
+    (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm)
+    ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧ = dist x y
+  rw [lift₂_def]
+
+end PseudoMetricSpace
+
 namespace MetricSpace
 
 variable [∀ i, MetricSpace (G i)]
@@ -34,19 +55,14 @@ variable [∀ i j h, IsometryClass (T h) (G i) (G j)]
 noncomputable instance : MetricSpace (DirectLimit G f) where
   dist := DirectLimit.lift₂ f f (fun i ↦ dist (α := G i))
     (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm)
-  dist_self := DirectLimit.induction f (fun i x ↦ by rw [← dist_self x, lift₂_def])
-  dist_comm := DirectLimit.induction₂ f (fun i x y ↦ by simp_rw [lift₂_def, dist_comm x y])
-  dist_triangle := DirectLimit.induction₃ f (fun i x y z ↦ by simp_rw [lift₂_def, dist_triangle])
+  __ := (inferInstance : PseudoMetricSpace (DirectLimit G f))
   eq_of_dist_eq_zero {x y} h := DirectLimit.induction₂ f (fun i x' y' h' ↦ by
     rw [lift₂_def] at h'
     simp [eq_of_dist_eq_zero h']) x y h
 
 lemma dist_def (i : ι) (x y : G i) :
-    dist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = dist x y := by
-  change DirectLimit.lift₂ f f _
-    (fun i j h x y ↦ (IsometryClass.dist_eq (f i j h) x y).symm)
-    ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧ = dist x y
-  rw [lift₂_def]
+    dist (α := DirectLimit G f) ⟦⟨i,x⟩⟧ ⟦⟨i,y⟩⟧ = dist x y :=
+  DirectLimit.PseudoMetricSpace.dist_def i x y
 
 end MetricSpace
 


### PR DESCRIPTION
add files `Topology/MetricSpace/DirectLimit.lean` (with an instance of `MetricSpace` for a `DirectLimit` of a directed system of `MetricSpace`s with `IsometryClass` map types between them) and `Analysis/Normed/Group/DirectLimit.lean` (with instances of `NormedAddGroup` and `NormedAddCommGroup` on `DirectLimit`)
also lemmas `dist_def` and `norm_def` for these.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This PR is part of a project of adding support for direct limits of $C^*$-algebras (as I described [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Early.20feedback.20on.20approach.20towards.20formalizing.20UHF.20algebras.3F) ).
This PR uses `IsometryClass` to implement the requirement that the directed systems preserve the `Norm` on the `NormedAddGroup`s, following the advice I got [this Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Representing.20norm-preservation.20for.20directed.20systems.3F/with/595941824) .


Use of AI:
I again used ChatGPT a bit for some advice when writing this (for example, for ideas for simplifying parts of proofs that I suspected could be simpler/shorter, and for advice on which of a couple options would be more idiomatic).
I can personally vouch for all of these contributions, and that I understand this code.
