### PR TITLE
feat(Algebra/Group/Submonoid): type class to indicate that supremum in a SubmonoidClass agrees with supremum of submonoids

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -470,6 +470,7 @@ public import Mathlib.Algebra.Group.Submonoid.Operations
 public import Mathlib.Algebra.Group.Submonoid.Pointwise
 public import Mathlib.Algebra.Group.Submonoid.Saturation
 public import Mathlib.Algebra.Group.Submonoid.Support
+public import Mathlib.Algebra.Group.Submonoid.SSup
 public import Mathlib.Algebra.Group.Submonoid.Units
 public import Mathlib.Algebra.Group.Subsemigroup.Basic
 public import Mathlib.Algebra.Group.Subsemigroup.Defs

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -468,9 +468,9 @@ public import Mathlib.Algebra.Group.Submonoid.MulAction
 public import Mathlib.Algebra.Group.Submonoid.MulOpposite
 public import Mathlib.Algebra.Group.Submonoid.Operations
 public import Mathlib.Algebra.Group.Submonoid.Pointwise
+public import Mathlib.Algebra.Group.Submonoid.SSup
 public import Mathlib.Algebra.Group.Submonoid.Saturation
 public import Mathlib.Algebra.Group.Submonoid.Support
-public import Mathlib.Algebra.Group.Submonoid.SSup
 public import Mathlib.Algebra.Group.Submonoid.Units
 public import Mathlib.Algebra.Group.Subsemigroup.Basic
 public import Mathlib.Algebra.Group.Subsemigroup.Defs

--- a/Mathlib/Algebra/Group/Submonoid/SSup.lean
+++ b/Mathlib/Algebra/Group/Submonoid/SSup.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2024 Joe Cool. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Marcus Zibrowius
+-/
+module
+
+public import Mathlib.Algebra.Group.Submonoid.Basic
+
+/-! # Suprema in a SubmonoidClass -/
+
+public section
+
+open Submonoid in
+/-- A class to indicate that the canonical map `.ofClass` from a class `S` of submonoids
+    of `M` to `Submonoid M` preserves suprema. -/
+class SubmonoidClass.IsConcreteSSup (S : Type*) (M : outParam Type*) [Monoid M] [SetLike S M]
+    [SubmonoidClass S M] [SupSet S] : Prop where
+  sSup_toSubmonoid (S : Set S) : ofClass (sSup S) = sSup (ofClass '' S)
+
+open AddSubmonoid in
+/-- A class to indicate that the canonical map `.ofClass` from a class `S` of additive submonoids
+    of `M` to `AddSubmonoid M` preserves suprema. -/
+class AddSubmonoidClass.IsConcreteSSup (S : Type*) (M : outParam Type*) [AddMonoid M] [SetLike S M]
+    [AddSubmonoidClass S M] [SupSet S] : Prop where
+  sSup_toAddSubmonoid (S : Set S) : ofClass (sSup S) = sSup (ofClass '' S)
+
+attribute [to_additive existing] SubmonoidClass.IsConcreteSSup
+
+namespace SubmonoidClass
+
+open Submonoid
+
+@[to_additive]
+theorem iSup_toSubmonoid {S : Type*} {M : Type*} [SetLike S M] [Monoid M] [SubmonoidClass S M]
+    [SupSet S] [IsConcreteSSup S M]
+    {ι : Sort*} (ℳ : ι → S) :
+    ofClass (⨆ i, ℳ i) = ⨆ i, ofClass (ℳ i) := by
+  rw [iSup,IsConcreteSSup.sSup_toSubmonoid,←Set.range_comp]
+  rfl
+
+@[to_additive, simp]
+theorem mem_iSup_iff_mem_iSup_Submonoid {S : Type*} {M : Type*} [SetLike S M] [Monoid M]
+    [SubmonoidClass S M] [SupSet S] [IsConcreteSSup S M] {ι : Sort*} (ℳ : ι → S) (m : M) :
+    m ∈ (⨆ i, ℳ i : S) ↔ m ∈ (⨆ i, ofClass (ℳ i)) := by
+  rw [← iSup_toSubmonoid ℳ]
+  rfl
+
+@[to_additive]
+instance (M : Type*) [Monoid M] : IsConcreteSSup (Submonoid M) M where
+  sSup_toSubmonoid S := by
+    have : ofClass (sSup S) = sSup S := by rfl
+    rw [this, Set.EqOn.image_eq_self (f := ofClass) (fun _ ↦ congrFun rfl)]
+
+end SubmonoidClass

--- a/Mathlib/Algebra/Group/Submonoid/SSup.lean
+++ b/Mathlib/Algebra/Group/Submonoid/SSup.lean
@@ -31,7 +31,7 @@ namespace SubmonoidClass
 
 open Submonoid
 
-@[to_additive]
+@[to_additive, simp]
 theorem iSup_toSubmonoid {S : Type*} {M : Type*} [SetLike S M] [Monoid M] [SubmonoidClass S M]
     [SupSet S] [IsConcreteSSup S M]
     {ι : Sort*} (ℳ : ι → S) :
@@ -39,7 +39,7 @@ theorem iSup_toSubmonoid {S : Type*} {M : Type*} [SetLike S M] [Monoid M] [Submo
   rw [iSup,IsConcreteSSup.sSup_toSubmonoid,←Set.range_comp]
   rfl
 
-@[to_additive, simp]
+@[to_additive]
 theorem mem_iSup_iff_mem_iSup_Submonoid {S : Type*} {M : Type*} [SetLike S M] [Monoid M]
     [SubmonoidClass S M] [SupSet S] [IsConcreteSSup S M] {ι : Sort*} (ℳ : ι → S) (m : M) :
     m ∈ (⨆ i, ℳ i : S) ↔ m ∈ (⨆ i, ofClass (ℳ i)) := by


### PR DESCRIPTION
Add a type class `SubmonoidClass.IsConcreteSSup` to indicate that the canonical map `.ofClass` from a class `S` of submonoids of `M` to `Submonoid M` preserves suprema.

---

This PR implements the minimal type class assumption needed to make „pushfoward of gradings along maps of indexing sets“ – see draft PR #39356 – work in some `SetLike` generality.

Given `{S M : Type*} [SetLike S M] [Monoid M] [SubmonoidClass S M]`, we have canonical maps
```
   S → Submonoid M → Set M
```
The first is `Submonoid.ofClass`, the second and the composition are `coe` maps coming from the `SetLike` structures.  Depending on `S`, these maps may or may not satisfy various properties with respect the lattice structures on `Submonoid M` and `Set M`.  Mathlib so far includes the type class `[IsConcreteLE S M]`, which asserts that the composition `S → Set M` is order-preserving and order-reflecting.  The type class defined here asserts that the first map, `S → Submonoid M`, preserves suprema.

In examples such as `S = Subgroup M`, `S = Submodule R M`, much more is true – in these cases, `S` is a complete sublattice of `Submonoid M`.  But there are also examples where only the weaker property defined here holds, e.g. `S = OpenSubgroup M` for a topological group `M`.

[Zulip discussion thead about this PR](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/type.20class.20to.20indicate.20that.20supremum.20in.20a.20SubmonoidClass.20agr/with/626031731)

Note on `outParam`:  I did *not* write `(M : outParam Type*)` in the assumptions of `SubmonoidClass.IsConcreteSSup` in accordance with the [DocString of `Setlike`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/SetLike/Basic.html#SetLike). However, we do have `(B : outParam Type*)` in the definition of `IsConcreteLE`, so perhaps I'm misinterpreting the DocString.


<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
