### PR TITLE
feat(Analysis): add Commute.exp_smul_right and symmetric variants

### DIFF
--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -240,6 +240,18 @@ theorem _root_.Commute.exp [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) :
     Commute (exp x) (exp y) :=
   h.exp_left.exp_right
 
+theorem _root_.Commute.exp_smul_right [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) (r : 𝕂) :
+    Commute x (exp (r • y)) :=
+  (h.smul_right r).exp_right
+
+theorem _root_.Commute.exp_smul_left [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) (r : 𝕂) :
+    Commute (exp (r • x)) y :=
+  (h.smul_left r).exp_left
+
+theorem _root_.Commute.exp_smul [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) (r s : 𝕂) :
+    Commute (exp (r • x)) (exp (s • y)) :=
+  ((h.smul_left r).smul_right s).exp
+
 end TopologicalAlgebra
 
 section TopologicalDivisionAlgebra


### PR DESCRIPTION
## Summary

Adds `Commute.exp_smul_right`, `Commute.exp_smul_left`, and `Commute.exp_smul`
to `Mathlib/Analysis/Normed/Algebra/Exponential.lean`, immediately after
`Commute.exp`. One-line compositions of `Commute.smul_*` with `Commute.exp_*`.
Same typeclass scope as `Commute.exp_right`; no new hypotheses.

## Context

`Commute.exp_right` / `Commute.exp_left` / `Commute.exp` handle the
`Commute x (exp y)` shape; `Commute.smul_right` / `Commute.smul_left` handle
`Commute x (r • y)`. The natural composition `Commute x (exp (r • y))` —
the canonical shape in one-parameter semigroups `t ↦ exp (t • Q)` — is absent
and currently requires inline chaining.

## Notes

- One-line proofs; same typeclass scope as `Commute.exp_right`.
- No `@[simp]` / no `@[to_additive]` — matches the existing `Commute.exp_*` choices.
- API minimal — `exp_smul_self`, `exp_nsmul_*` can follow separately if needed.

## Where this can be used

**Existing Mathlib — concrete simplifications.**
`Mathlib/Analysis/SpecialFunctions/Exponential.lean:292, 313` write the chain
explicitly: `(((Commute.refl x).smul_left t').smul_right t).exp_right` would
compress to `((Commute.refl x).smul_left t').exp_smul_right t`.

`Mathlib/Analysis/CStarAlgebra/Fuglede.lean:76` uses
`grind [exp_add_of_commute, Commute.smul_right, Commute.neg_right]` to discharge
a commutation goal in the Fuglede–Putnam–Rosenblum proof; these lemmas would be
natural additions to that hint set.

**Areas where this composition recurs.**
The composition `[P, Q] = 0 ⟹ [P, exp(t · Q)] = 0` appears in:

| Area | Where the composition appears |
|---|---|
| **Strongly continuous semigroups** (Hille–Yosida) | `P` commutes with the infinitesimal generator `Q` ⟹ `P` commutes with `e^{tQ}`. |
| **Stone's theorem** | One-parameter unitary groups `U(t) = exp(itA)`; commuting observables commute with the full evolution. |
| **Markov semigroups** | `M_t = exp(tQ)` for `Q` a Q-matrix; symmetries of `Q` lift to symmetries of `M_t`. |
| **Lie group exponential** | `X`, `Y` commuting in the Lie algebra ⟹ `exp(tX)`, `exp(sY)` commute. |
| **Functional calculus** | `f(A)g(A) = g(A)f(A)` for commuting operators, with the exp specialisation at each step. |
| **PDE flows** | Heat / Schrödinger evolution: conservation laws are commutation with `exp(t·Δ)` / `exp(-itH)`. |
| **Tomita–Takesaki** | The modular automorphism group `σ^φ_t = Ad(Δ^{it})` on a von Neumann algebra. |
