### PR TITLE
feat(LinearAlgebra/Matrix): nonsingular inverse commutes with any monoid hom of matrix rings

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -488,6 +488,23 @@ theorem inv_inj (h : A⁻¹ = B⁻¹) (h' : IsUnit A.det) : A = B := by
 
 end InvEqInv
 
+section Map
+
+variable {R S F : Type*} [CommRing R] [CommRing S]
+  [FunLike F (Matrix n n R) (Matrix n n S)]
+  [MonoidHomClass F (Matrix n n R) (Matrix n n S)]
+
+/-- Any monoid homomorphism `f : Matrix n n R →* Matrix n n S` between matrix rings
+sends the nonsingular inverse of an invertible matrix to the nonsingular inverse of its image.
+In particular this applies to `RingHom`, `RingEquiv`, `AlgHom`, `AlgEquiv`, and `StarAlgEquiv`
+between matrix rings, since each of these provides a `MonoidHomClass` instance. -/
+theorem map_nonsing_inv (f : F) {A : Matrix n n R} (hA : IsUnit A.det) :
+    (f A)⁻¹ = f A⁻¹ := by
+  apply Matrix.inv_eq_right_inv
+  rw [← map_mul, Matrix.mul_nonsing_inv A hA, map_one]
+
+end Map
+
 variable (A)
 
 set_option backward.isDefEq.respectTransparency false in


### PR DESCRIPTION
Adds `Matrix.map_nonsing_inv`: for any `MonoidHomClass` morphism `f : Matrix n n R →* Matrix n n S` between matrix rings over commutative rings, and any `A : Matrix n n R` with `IsUnit A.det`,

```
(f A)⁻¹ = f A⁻¹
```

The proof is short: `Matrix.inv_eq_right_inv` plus the fact that `f` preserves `*` and `1`:

```lean
theorem map_nonsing_inv (f : F) {A : Matrix n n R} (hA : IsUnit A.det) :
    (f A)⁻¹ = f A⁻¹ := by
  apply Matrix.inv_eq_right_inv
  rw [← map_mul, Matrix.mul_nonsing_inv A hA, map_one]
```

Since `RingHom`, `RingEquiv`, `AlgHom`, `AlgEquiv`, and `StarAlgEquiv` between matrix rings all provide `MonoidHomClass` instances, the lemma applies uniformly to all of them — in particular to `Unitary.conjStarAlgAut`-style conjugations by a unitary matrix, which is the original motivating use case.

This came up in a downstream project (mechanical formalization of Bach's *Learning Theory from First Principles*), where it underpins a spectral-identity proof: `(U * X * star U)⁻¹ = U * X⁻¹ * star U` for unitary `U` and invertible `X`. Rather than special-case the unitary-conjugation version, I generalized to any `MonoidHomClass` since the proof works mechanically.

### Why not just `map_inv`?

The generic `map_inv` discharges `⁻¹` through a `MonoidHom` between groups, but `Matrix n n R` is not a group under multiplication — `⁻¹` here is `Matrix.nonsing_inv` (adjugate / det), which is only a two-sided inverse on the submonoid of nonsingular matrices. So `map_inv` doesn't apply directly; we need the `IsUnit A.det` hypothesis and a custom proof routed through `Matrix.inv_eq_right_inv`.

### Tests

- `lake build Mathlib.LinearAlgebra.Matrix.NonsingularInverse` — green
- `lake build Mathlib.Analysis.Matrix.Spectrum Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs` — green (downstream smoke check, no regressions)
- Verified usability against both `RingEquiv` and `StarAlgEquiv` instances via local smoke tests

### Notes on AI assistance

Per the Mathlib [AI-use policy](https://leanprover-community.github.io/contribute/index.html#use-of-ai):

- **Tool.** Claude Code (Anthropic), Claude Opus 4.7 model.
- **Use.** I specified the target statement (originally `ℝ`-specific to a unitary conjugation) and the scope of generalization. The assistant drafted the more general `MonoidHomClass` version, chose the file home, verified the proof builds under `lake build`, and tested downstream files for regressions. I reviewed the proof, naming, and file placement.
- **Vouching.** I have read the declaration and can defend the proof without further AI assistance. Happy to take reviewer feedback on naming (`map_nonsing_inv` vs alternatives), namespace placement, or whether the typeclass bound should be relaxed further (e.g. to `MulHomClass` if we can avoid `map_one` — though `map_mul` + `mul_nonsing_inv = 1` + applying `f` to `1` seems to genuinely require `OneHomClass` too).