### PR TITLE
[Merged by Bors] - fix(RingTheory): correct misnamed theorem

### DIFF
--- a/Mathlib/RingTheory/Flat/EquationalCriterion.lean
+++ b/Mathlib/RingTheory/Flat/EquationalCriterion.lean
@@ -44,7 +44,7 @@ that $x = y \circ a$ and $a \circ f = 0$. We recover the usual equational criter
 $K = R$ and $N = R^l$. This is used in the proof of Lazard's theorem.
 
 We conclude that every linear map from a finitely presented module to a flat module factors
-through a finite free module (`Module.Flat.exists_factorization_of_isFinitelyPresented`), and
+through a finite free module (`Module.Flat.exists_factorization_of_finitePresentation`), and
 every finitely presented flat module is projective (`Module.Flat.projective_of_finitePresentation`).
 
 ## References
@@ -268,9 +268,9 @@ theorem exists_factorization_of_comp_eq_zero_of_free [Flat R M] {K N : Type*} [A
 /-- Every homomorphism from a finitely presented module to a flat module factors through a finite
 free module. -/
 @[stacks 058E "only if"]
-theorem exists_factorization_of_isFinitelyPresented [Flat R M] {P : Type*} [AddCommGroup P]
+theorem exists_factorization_of_finitePresentation [Flat R M] {P : Type*} [AddCommGroup P]
     [Module R P] [FinitePresentation R P] (h₁ : P →ₗ[R] M) :
-      ∃ (k : ℕ) (h₂ : P →ₗ[R] (Fin k →₀ R)) (h₃ : (Fin k →₀ R) →ₗ[R] M), h₁ = h₃ ∘ₗ h₂ := by
+    ∃ (k : ℕ) (h₂ : P →ₗ[R] (Fin k →₀ R)) (h₃ : (Fin k →₀ R) →ₗ[R] M), h₁ = h₃ ∘ₗ h₂ := by
   have ⟨_, K, ϕ, hK⟩ := FinitePresentation.exists_fin R P
   haveI : Module.Finite R K := .of_fg hK
   have : (h₁ ∘ₗ ϕ.symm ∘ₗ K.mkQ) ∘ₗ K.subtype = 0 := by
@@ -281,9 +281,13 @@ theorem exists_factorization_of_isFinitelyPresented [Flat R M] {P : Type*} [AddC
   apply (cancel_right K.mkQ_surjective).mp
   simpa [comp_assoc]
 
+@[deprecated (since := "2026-05-23")]
+alias Module.Flat.exists_factorization_of_isFinitelyPresented :=
+  exists_factorization_of_finitePresentation
+
 @[stacks 00NX "(1) → (2)"]
 theorem projective_of_finitePresentation [Flat R M] [FinitePresentation R M] : Projective R M :=
-  have ⟨_, f, g, eq⟩ := exists_factorization_of_isFinitelyPresented (.id (R := R) (M := M))
+  have ⟨_, f, g, eq⟩ := exists_factorization_of_finitePresentation (.id (R := R) (M := M))
   .of_split f g eq.symm
 
 end Module.Flat

--- a/Mathlib/RingTheory/Flat/EquationalCriterion.lean
+++ b/Mathlib/RingTheory/Flat/EquationalCriterion.lean
@@ -282,8 +282,7 @@ theorem exists_factorization_of_finitePresentation [Flat R M] {P : Type*} [AddCo
   simpa [comp_assoc]
 
 @[deprecated (since := "2026-05-23")]
-alias Module.Flat.exists_factorization_of_isFinitelyPresented :=
-  exists_factorization_of_finitePresentation
+alias exists_factorization_of_isFinitelyPresented := exists_factorization_of_finitePresentation
 
 @[stacks 00NX "(1) → (2)"]
 theorem projective_of_finitePresentation [Flat R M] [FinitePresentation R M] : Projective R M :=


### PR DESCRIPTION
Update `isFinitelyPresented` to `finitePresentation` to match the typeclass `Module.FinitePresentation`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
