### PR TITLE
[Merged by Bors] - chore(FieldTheory/KrullTopology): move lemmas to earlier file

### DIFF
--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -639,8 +639,9 @@ noncomputable def restrictRestrictAlgEquivMapHom (F K L E : Type*) [Field F] [Fi
     Gal(E/L) →* Gal(K/F) :=
   (AlgEquiv.restrictNormalHom K).comp (MulSemiringAction.toAlgAut Gal(E/L) F E)
 
-section
-variable {F E : Type*} [Field F] [Field E] [Algebra F E] (K L : IntermediateField F E) [Normal F K]
+variable {F E : Type*} (E' : Type*) [Field F] [Field E] [Field E']
+  [Algebra F E] [Algebra F E'] [Algebra E E'] [IsScalarTower F E E']
+  (K L : IntermediateField F E) [Normal F K]
 
 @[simp]
 theorem restrictRestrictAlgEquivMapHom_apply (φ : Gal(E/L)) (x : K) :
@@ -670,45 +671,39 @@ theorem restrictRestrictAlgEquivMapHom_surjective [FiniteDimensional F K] [Finit
   obtain ⟨z, rfl⟩ : y ∈ (⊥ : IntermediateField F E) := h ▸ mem_inf.mpr ⟨hx₁, hy⟩
   exact mem_bot.mp ⟨z, rfl⟩
 
-end
-
-section
-variable {F E : Type*} (K : Type*) [Field F] [Field E] [Field K]
-  [Algebra F E] [Algebra F K] [Algebra E K] [IsScalarTower F E K] (L : IntermediateField F E)
-
 /-- If `K / E / k` is a field extension tower with `E / k` normal,
 `L` is an intermediate field of `E / k`, then the fixing subgroup of `L` viewed as an
 intermediate field of `K / k` is equal to the preimage of the fixing subgroup of `L` viewed as an
 intermediate field of `E / k` under the natural map `Aut(K / k) → Aut(E / k)`
 (`AlgEquiv.restrictNormalHom`). -/
 theorem map_fixingSubgroup [Normal F E] :
-    (L.map (IsScalarTower.toAlgHom F E K)).fixingSubgroup =
-      L.fixingSubgroup.comap (AlgEquiv.restrictNormalHom (F := F) (K₁ := K) E) := by
+    (L.map (IsScalarTower.toAlgHom F E E')).fixingSubgroup =
+      L.fixingSubgroup.comap (AlgEquiv.restrictNormalHom (F := F) (K₁ := E') E) := by
   ext f
   simp only [Subgroup.mem_comap, mem_fixingSubgroup_iff]
   constructor
   · rintro h x hx
     change f.restrictNormal E x = x
-    apply_fun _ using (algebraMap E K).injective
+    apply_fun _ using (algebraMap E E').injective
     rw [AlgEquiv.restrictNormal_commutes]
     exact h _ ⟨x, hx, rfl⟩
   · rintro h _ ⟨x, hx, rfl⟩
-    replace h := congr(algebraMap E K $(show f.restrictNormal E x = x from h x hx))
+    replace h := congr(algebraMap E E' $(show f.restrictNormal E x = x from h x hx))
     rwa [AlgEquiv.restrictNormal_commutes] at h
 
 /-- If `K / E / k` is a field extension tower with `E / k` and `K / k` normal,
 `L` is an intermediate field of `E / k`, then the index of the fixing subgroup of `L` viewed as an
 intermediate field of `K / k` is equal to the index of the fixing subgroup of `L` viewed as an
 intermediate field of `E / k`. -/
-theorem map_fixingSubgroup_index [Normal F E] [Normal F K] :
-    (L.map (IsScalarTower.toAlgHom F E K)).fixingSubgroup.index = L.fixingSubgroup.index := by
-  rw [L.map_fixingSubgroup K, L.fixingSubgroup.index_comap_of_surjective
+theorem map_fixingSubgroup_index [Normal F E] [Normal F E'] :
+    (L.map (IsScalarTower.toAlgHom F E E')).fixingSubgroup.index = L.fixingSubgroup.index := by
+  rw [L.map_fixingSubgroup E', L.fixingSubgroup.index_comap_of_surjective
     (AlgEquiv.restrictNormalHom_surjective _)]
 
 variable {K} in
 /-- If `K / k` is a Galois extension, `L` is an intermediate field of `K / k`, then `[L : k]`
 as a natural number is equal to the index of the fixing subgroup of `L`. -/
-theorem finrank_eq_fixingSubgroup_index (L : IntermediateField F K) [IsGalois F K] :
+theorem finrank_eq_fixingSubgroup_index (L : IntermediateField F E') [IsGalois F E'] :
     Module.finrank F L = L.fixingSubgroup.index := by
   wlog hnfd : FiniteDimensional F L generalizing L
   · rw [Module.finrank_of_infinite_dimensional hnfd]
@@ -721,18 +716,16 @@ theorem finrank_eq_fixingSubgroup_index (L : IntermediateField F K) [IsGalois F 
     rw [i.finrank_eq, this _ hfd] at hL'
     exact (Subgroup.index_antitone <| fixingSubgroup_le <|
       IntermediateField.lift_le L').not_gt hL'
-  let E := normalClosure F L K
+  let E := normalClosure F L E'
   have hle : L ≤ E := by simpa only [fieldRange_val] using L.val.fieldRange_le_normalClosure
   let L' := restrict hle
   have h := Module.finrank_mul_finrank F ↥L' ↥E
   classical
   rw [← IsGalois.card_fixingSubgroup_eq_finrank L', ← IsGalois.card_aut_eq_finrank F E] at h
   rw [← L'.fixingSubgroup.index_mul_card, Nat.mul_left_inj Finite.card_pos.ne'] at h
-  rw [(restrict_algEquiv hle).toLinearEquiv.finrank_eq, h, ← L'.map_fixingSubgroup_index K]
+  rw [(restrict_algEquiv hle).toLinearEquiv.finrank_eq, h, ← L'.map_fixingSubgroup_index E']
   congr 2
   exact lift_restrict hle
-
-end
 
 end IntermediateField
 

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -736,7 +736,6 @@ end
 
 end IntermediateField
 
-
 end restrictRestrictAlgEquivMapHom
 
 namespace Algebra

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -639,6 +639,7 @@ noncomputable def restrictRestrictAlgEquivMapHom (F K L E : Type*) [Field F] [Fi
     Gal(E/L) →* Gal(K/F) :=
   (AlgEquiv.restrictNormalHom K).comp (MulSemiringAction.toAlgAut Gal(E/L) F E)
 
+section
 variable {F E : Type*} [Field F] [Field E] [Algebra F E] (K L : IntermediateField F E) [Normal F K]
 
 @[simp]
@@ -669,7 +670,72 @@ theorem restrictRestrictAlgEquivMapHom_surjective [FiniteDimensional F K] [Finit
   obtain ⟨z, rfl⟩ : y ∈ (⊥ : IntermediateField F E) := h ▸ mem_inf.mpr ⟨hx₁, hy⟩
   exact mem_bot.mp ⟨z, rfl⟩
 
+end
+
+section
+variable {F E : Type*} (K : Type*) [Field F] [Field E] [Field K]
+  [Algebra F E] [Algebra F K] [Algebra E K] [IsScalarTower F E K] (L : IntermediateField F E)
+
+/-- If `K / E / k` is a field extension tower with `E / k` normal,
+`L` is an intermediate field of `E / k`, then the fixing subgroup of `L` viewed as an
+intermediate field of `K / k` is equal to the preimage of the fixing subgroup of `L` viewed as an
+intermediate field of `E / k` under the natural map `Aut(K / k) → Aut(E / k)`
+(`AlgEquiv.restrictNormalHom`). -/
+theorem map_fixingSubgroup [Normal F E] :
+    (L.map (IsScalarTower.toAlgHom F E K)).fixingSubgroup =
+      L.fixingSubgroup.comap (AlgEquiv.restrictNormalHom (F := F) (K₁ := K) E) := by
+  ext f
+  simp only [Subgroup.mem_comap, mem_fixingSubgroup_iff]
+  constructor
+  · rintro h x hx
+    change f.restrictNormal E x = x
+    apply_fun _ using (algebraMap E K).injective
+    rw [AlgEquiv.restrictNormal_commutes]
+    exact h _ ⟨x, hx, rfl⟩
+  · rintro h _ ⟨x, hx, rfl⟩
+    replace h := congr(algebraMap E K $(show f.restrictNormal E x = x from h x hx))
+    rwa [AlgEquiv.restrictNormal_commutes] at h
+
+/-- If `K / E / k` is a field extension tower with `E / k` and `K / k` normal,
+`L` is an intermediate field of `E / k`, then the index of the fixing subgroup of `L` viewed as an
+intermediate field of `K / k` is equal to the index of the fixing subgroup of `L` viewed as an
+intermediate field of `E / k`. -/
+theorem map_fixingSubgroup_index [Normal F E] [Normal F K] :
+    (L.map (IsScalarTower.toAlgHom F E K)).fixingSubgroup.index = L.fixingSubgroup.index := by
+  rw [L.map_fixingSubgroup K, L.fixingSubgroup.index_comap_of_surjective
+    (AlgEquiv.restrictNormalHom_surjective _)]
+
+variable {K} in
+/-- If `K / k` is a Galois extension, `L` is an intermediate field of `K / k`, then `[L : k]`
+as a natural number is equal to the index of the fixing subgroup of `L`. -/
+theorem finrank_eq_fixingSubgroup_index (L : IntermediateField F K) [IsGalois F K] :
+    Module.finrank F L = L.fixingSubgroup.index := by
+  wlog hnfd : FiniteDimensional F L generalizing L
+  · rw [Module.finrank_of_infinite_dimensional hnfd]
+    by_contra! h
+    replace h : L.fixingSubgroup.FiniteIndex := ⟨h.symm⟩
+    obtain ⟨L', hfd, hL'⟩ :=
+      exists_lt_finrank_of_infinite_dimensional hnfd L.fixingSubgroup.index
+    let i := (liftAlgEquiv L').toLinearEquiv
+    replace hfd := i.finiteDimensional
+    rw [i.finrank_eq, this _ hfd] at hL'
+    exact (Subgroup.index_antitone <| fixingSubgroup_le <|
+      IntermediateField.lift_le L').not_gt hL'
+  let E := normalClosure F L K
+  have hle : L ≤ E := by simpa only [fieldRange_val] using L.val.fieldRange_le_normalClosure
+  let L' := restrict hle
+  have h := Module.finrank_mul_finrank F ↥L' ↥E
+  classical
+  rw [← IsGalois.card_fixingSubgroup_eq_finrank L', ← IsGalois.card_aut_eq_finrank F E] at h
+  rw [← L'.fixingSubgroup.index_mul_card, Nat.mul_left_inj Finite.card_pos.ne'] at h
+  rw [(restrict_algEquiv hle).toLinearEquiv.finrank_eq, h, ← L'.map_fixingSubgroup_index K]
+  congr 2
+  exact lift_restrict hle
+
+end
+
 end IntermediateField
+
 
 end restrictRestrictAlgEquivMapHom
 

--- a/Mathlib/FieldTheory/KrullTopology.lean
+++ b/Mathlib/FieldTheory/KrullTopology.lean
@@ -44,10 +44,6 @@ all intermediate fields `E` with `E/K` finite dimensional.
 - `stabilizer_isOpen_of_isIntegral`: For an integral field extension `L/K`, the stabilizer
   in `Gal(L/K)` of any element in `L` is open for the Krull topology.
 
-- `IntermediateField.finrank_eq_fixingSubgroup_index`: given a Galois extension `K/k` and an
-  intermediate field `L`, the `[L : k]` as a natural number is equal to the index of the
-  fixing subgroup of `L`.
-
 ## Notation
 
 - In docstrings, we will write `Gal(L/E)` to denote the fixing subgroup of an intermediate field
@@ -271,66 +267,3 @@ theorem stabilizer_isOpen_of_isIntegral [Algebra.IsIntegral K L] (x : L) :
   simpa using (forall_mem_adjoin_smul_eq_self_iff K (S := {x}) g).symm
 
 end MulAction
-
-namespace IntermediateField
-
-variable {k E : Type*} (K : Type*) [Field k] [Field E] [Field K]
-  [Algebra k E] [Algebra k K] [Algebra E K] [IsScalarTower k E K] (L : IntermediateField k E)
-
-/-- If `K / E / k` is a field extension tower with `E / k` normal,
-`L` is an intermediate field of `E / k`, then the fixing subgroup of `L` viewed as an
-intermediate field of `K / k` is equal to the preimage of the fixing subgroup of `L` viewed as an
-intermediate field of `E / k` under the natural map `Aut(K / k) → Aut(E / k)`
-(`AlgEquiv.restrictNormalHom`). -/
-theorem map_fixingSubgroup [Normal k E] :
-    (L.map (IsScalarTower.toAlgHom k E K)).fixingSubgroup =
-      L.fixingSubgroup.comap (AlgEquiv.restrictNormalHom (F := k) (K₁ := K) E) := by
-  ext f
-  simp only [Subgroup.mem_comap, mem_fixingSubgroup_iff]
-  constructor
-  · rintro h x hx
-    change f.restrictNormal E x = x
-    apply_fun _ using (algebraMap E K).injective
-    rw [AlgEquiv.restrictNormal_commutes]
-    exact h _ ⟨x, hx, rfl⟩
-  · rintro h _ ⟨x, hx, rfl⟩
-    replace h := congr(algebraMap E K $(show f.restrictNormal E x = x from h x hx))
-    rwa [AlgEquiv.restrictNormal_commutes] at h
-
-/-- If `K / E / k` is a field extension tower with `E / k` and `K / k` normal,
-`L` is an intermediate field of `E / k`, then the index of the fixing subgroup of `L` viewed as an
-intermediate field of `K / k` is equal to the index of the fixing subgroup of `L` viewed as an
-intermediate field of `E / k`. -/
-theorem map_fixingSubgroup_index [Normal k E] [Normal k K] :
-    (L.map (IsScalarTower.toAlgHom k E K)).fixingSubgroup.index = L.fixingSubgroup.index := by
-  rw [L.map_fixingSubgroup K, L.fixingSubgroup.index_comap_of_surjective
-    (AlgEquiv.restrictNormalHom_surjective _)]
-
-variable {K} in
-/-- If `K / k` is a Galois extension, `L` is an intermediate field of `K / k`, then `[L : k]`
-as a natural number is equal to the index of the fixing subgroup of `L`. -/
-theorem finrank_eq_fixingSubgroup_index (L : IntermediateField k K) [IsGalois k K] :
-    Module.finrank k L = L.fixingSubgroup.index := by
-  wlog hnfd : FiniteDimensional k L generalizing L
-  · rw [Module.finrank_of_infinite_dimensional hnfd]
-    by_contra! h
-    replace h : L.fixingSubgroup.FiniteIndex := ⟨h.symm⟩
-    obtain ⟨L', hfd, hL'⟩ :=
-      exists_lt_finrank_of_infinite_dimensional hnfd L.fixingSubgroup.index
-    let i := (liftAlgEquiv L').toLinearEquiv
-    replace hfd := i.finiteDimensional
-    rw [i.finrank_eq, this _ hfd] at hL'
-    exact (Subgroup.index_antitone <| fixingSubgroup_le <|
-      IntermediateField.lift_le L').not_gt hL'
-  let E := normalClosure k L K
-  have hle : L ≤ E := by simpa only [fieldRange_val] using L.val.fieldRange_le_normalClosure
-  let L' := restrict hle
-  have h := Module.finrank_mul_finrank k ↥L' ↥E
-  classical
-  rw [← IsGalois.card_fixingSubgroup_eq_finrank L', ← IsGalois.card_aut_eq_finrank k E] at h
-  rw [← L'.fixingSubgroup.index_mul_card, Nat.mul_left_inj Finite.card_pos.ne'] at h
-  rw [(restrict_algEquiv hle).toLinearEquiv.finrank_eq, h, ← L'.map_fixingSubgroup_index K]
-  congr 2
-  exact lift_restrict hle
-
-end IntermediateField


### PR DESCRIPTION
We move some lemmas unrelated to the Krull topology out of the `KrullTopology` file. They are placed in the earlier file `FieldTheory/IsGalois/Basic` instead.

---

In #23693 it is said that
> The proof of it uses some results in this file, so it can't be put into earlier files.

This is no longer true, so we want move it out of the `KrullTopology` file because the theorems have nothing to do with the Krull topology. I found that they can go in `FieldTheory/IsGalois/Basic` without modifying the proofs. They cannot go any earlier because the statement of the theorems contains `IsGalois`, which is defined in this file.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
