### PR TITLE
[Merged by Bors] - feat(Module/Projective): direct sum of projective modules is projective

### DIFF
--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -213,6 +213,14 @@ theorem component.of [DecidableEq ι] (i j : ι) (b : M j) :
     component R ι M i ((lof R ι M j) b) = if h : j = i then Eq.recOn h b else 0 :=
   DFinsupp.single_apply
 
+lemma component_comp_lof [DecidableEq ι] (i j : ι) :
+    component R ι M i ∘ₗ lof R ι M j = if h : j = i then h ▸ .id else 0 := by
+  aesop (add simp component.of)
+
+@[simp]
+lemma component_comp_lof_same [DecidableEq ι] (i : ι) : component R ι M i ∘ₗ lof R ι M i = .id := by
+  simp [component_comp_lof]
+
 section map
 
 variable {R} {N : ι → Type*}

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -291,8 +291,8 @@ end OfLiftingProperty
 
 section DirectSum
 
-variable {R : Type u} [Semiring R] {ι : Type v} {M : ι → Type w} [(i : ι) → AddCommMonoid (M i)]
-    [(i : ι) → Module R (M i)]
+variable {R : Type u} [Semiring R]
+variable {ι : Type v} {M : ι → Type w} [(i : ι) → AddCommMonoid (M i)] [(i : ι) → Module R (M i)]
 
 theorem Projective.directSum_iff : Projective R (⨁ i, M i) ↔ ∀ (i : ι), Projective R (M i) := by
   classical

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Module.Shrink
 public import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import Mathlib.Logic.UnivLE
+public import Mathlib.LinearAlgebra.DirectSum.Basis
 
 /-!
 
@@ -59,6 +60,7 @@ projective module
 universe w v u
 
 open LinearMap hiding id
+open DirectSum hiding id id_apply
 open Finsupp
 
 /- The actual implementation we choose: `P` is projective if the natural surjection
@@ -286,5 +288,38 @@ theorem Projective.of_lifting_property {R : Type u} [Ring R] {P : Type v} [AddCo
   exact ⟨e.toLinearMap ∘ₗ g, hg⟩
 
 end OfLiftingProperty
+
+section DirectSum
+
+variable {R : Type u} [Semiring R] {ι : Type v} {M : ι → Type w} [(i : ι) → AddCommMonoid (M i)]
+    [(i : ι) → Module R (M i)]
+
+theorem directSum_iff : Module.Projective R (⨁ i, M i) ↔ ∀ (i : ι), Module.Projective R (M i) := by
+  classical
+  constructor
+  · intro H i
+    refine Projective.iff_split'.{max u v w} |>.mpr ?_
+    obtain ⟨T, I₁, I₂, I₃, f, g, hfg⟩ := Projective.iff_split.mp H
+    refine ⟨T, I₁, I₂, I₃, f.comp (DirectSum.lof ..), (DirectSum.component ..).comp g, ?_⟩
+    rw [LinearMap.ext_iff] at hfg
+    ext
+    simp at hfg
+    simp [hfg]
+  · intro H
+    refine Projective.iff_split.mpr ?_
+    have := fun i ↦ Projective.iff_split'.{max u v w}.mp (H i)
+    choose T I₁ I₂ I₃ f g hfg using this
+    refine ⟨⨁ i, T i, inferInstance, inferInstance, inferInstance, ?_⟩
+    use DirectSum.toModule _ _ _ fun i ↦ (DirectSum.lof ..).comp (f i)
+    use DirectSum.toModule _ _ _ fun i ↦ (DirectSum.lof ..).comp (g i)
+    ext x
+    have := LinearMap.ext_iff.mp (hfg x)
+    simp at this
+    simp [this]
+
+instance Projective.directSum [∀ (i : ι), Module.Projective R (M i)] :
+    Module.Projective R (⨁ i, M i) := directSum_iff.mpr ‹_›
+
+end DirectSum
 
 end Module

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -6,9 +6,9 @@ Authors: Kevin Buzzard, Antoine Labelle
 module
 
 public import Mathlib.Algebra.Module.Shrink
+public import Mathlib.LinearAlgebra.DirectSum.Basis
 public import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import Mathlib.Logic.UnivLE
-public import Mathlib.LinearAlgebra.DirectSum.Basis
 
 /-!
 

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -60,7 +60,7 @@ projective module
 universe w v u
 
 open LinearMap hiding id
-open DirectSum hiding id id_apply
+open DirectSum hiding id_apply
 open Finsupp
 
 /- The actual implementation we choose: `P` is projective if the natural surjection
@@ -297,19 +297,9 @@ variable {ι : Type v} {M : ι → Type w} [(i : ι) → AddCommMonoid (M i)] [(
 theorem Projective.directSum_iff : Projective R (⨁ i, M i) ↔ ∀ (i : ι), Projective R (M i) := by
   classical
   refine ⟨fun H i ↦ ?_, fun H ↦ ?_⟩
-  · refine iff_split'.{max u v w} |>.mpr ?_
-    obtain ⟨T, I₁, I₂, I₃, f, g, hfg⟩ := iff_split.mp H
-    refine ⟨T, I₁, I₂, I₃, f.comp (DirectSum.lof ..), (DirectSum.component ..).comp g, ?_⟩
-    simp [← comp_assoc _ f, comp_assoc _ g, hfg]
-  · refine iff_split.mpr ?_
-    have := fun i ↦ iff_split'.{max u v w}.mp (H i)
-    choose T I₁ I₂ I₃ f g hfg using this
-    refine ⟨⨁ i, T i, inferInstance, inferInstance, inferInstance, ?_⟩
-    use DirectSum.toModule _ _ _ fun i ↦ (DirectSum.lof ..).comp (f i)
-    use DirectSum.toModule _ _ _ fun i ↦ (DirectSum.lof ..).comp (g i)
-    ext x
-    have := by simpa using LinearMap.ext_iff.mp (hfg x)
-    simp [this]
+  · exact .of_split (DirectSum.lof ..) (DirectSum.component ..) (by simp)
+  · let e : (⨁ i, M i) ≃ₗ[R] Π₀ i, M i := .refl ..
+    exact Projective.of_equiv' e.symm
 
 instance Projective.directSum [∀ (i : ι), Projective R (M i)] : Projective R (⨁ i, M i) :=
   directSum_iff.mpr ‹_›

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -6,7 +6,6 @@ Authors: Kevin Buzzard, Antoine Labelle
 module
 
 public import Mathlib.Algebra.Module.Shrink
-public import Mathlib.LinearAlgebra.DirectSum.Basis
 public import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import Mathlib.Logic.UnivLE
 

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -294,31 +294,25 @@ section DirectSum
 variable {R : Type u} [Semiring R] {ι : Type v} {M : ι → Type w} [(i : ι) → AddCommMonoid (M i)]
     [(i : ι) → Module R (M i)]
 
-theorem directSum_iff : Module.Projective R (⨁ i, M i) ↔ ∀ (i : ι), Module.Projective R (M i) := by
+theorem Projective.directSum_iff : Projective R (⨁ i, M i) ↔ ∀ (i : ι), Projective R (M i) := by
   classical
-  constructor
-  · intro H i
-    refine Projective.iff_split'.{max u v w} |>.mpr ?_
-    obtain ⟨T, I₁, I₂, I₃, f, g, hfg⟩ := Projective.iff_split.mp H
+  refine ⟨fun H i ↦ ?_, fun H ↦ ?_⟩
+  · refine iff_split'.{max u v w} |>.mpr ?_
+    obtain ⟨T, I₁, I₂, I₃, f, g, hfg⟩ := iff_split.mp H
     refine ⟨T, I₁, I₂, I₃, f.comp (DirectSum.lof ..), (DirectSum.component ..).comp g, ?_⟩
-    rw [LinearMap.ext_iff] at hfg
-    ext
-    simp at hfg
-    simp [hfg]
-  · intro H
-    refine Projective.iff_split.mpr ?_
-    have := fun i ↦ Projective.iff_split'.{max u v w}.mp (H i)
+    simp [← comp_assoc _ f, comp_assoc _ g, hfg]
+  · refine iff_split.mpr ?_
+    have := fun i ↦ iff_split'.{max u v w}.mp (H i)
     choose T I₁ I₂ I₃ f g hfg using this
     refine ⟨⨁ i, T i, inferInstance, inferInstance, inferInstance, ?_⟩
     use DirectSum.toModule _ _ _ fun i ↦ (DirectSum.lof ..).comp (f i)
     use DirectSum.toModule _ _ _ fun i ↦ (DirectSum.lof ..).comp (g i)
     ext x
-    have := LinearMap.ext_iff.mp (hfg x)
-    simp at this
+    have := by simpa using LinearMap.ext_iff.mp (hfg x)
     simp [this]
 
-instance Projective.directSum [∀ (i : ι), Module.Projective R (M i)] :
-    Module.Projective R (⨁ i, M i) := directSum_iff.mpr ‹_›
+instance Projective.directSum [∀ (i : ι), Projective R (M i)] : Projective R (⨁ i, M i) :=
+  directSum_iff.mpr ‹_›
 
 end DirectSum
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
