### PR TITLE
perf(Algebra/Ring/Defs): unfold the new `Semiring` instances

### DIFF
--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -147,9 +147,21 @@ class Semiring (α : Type u) extends AddCommMonoid α, MonoidWithZero α, NonUni
 class Ring (R : Type u) extends Semiring R, AddCommGroup R, AddGroupWithOne R
 
 -- Add some short-cut instances to avoid going through the less used ring type classes.
-instance [Semiring α] : Distrib α := inferInstance
-instance [Semiring α] : MulZeroClass α := inferInstance
-instance [Semiring α] : MulZeroOneClass α := inferInstance
+instance [i : Semiring α] : Distrib α where
+  left_distrib := i.toDistrib.left_distrib
+  right_distrib := i.toDistrib.right_distrib
+
+instance [i : Semiring α] : MulZeroClass α where
+  zero_mul := i.toMonoidWithZero.zero_mul
+  mul_zero := i.toMonoidWithZero.mul_zero
+
+instance [i : Semiring α] : MulZeroOneClass α where
+  toMulOneClass := {
+    one_mul := i.toMulOneClass.one_mul
+    mul_one := i.toMulOneClass.mul_one }
+  zero_mul := i.toMonoidWithZero.zero_mul
+  mul_zero := i.toMonoidWithZero.mul_zero
+
 attribute [instance] Semiring.toMonoid
 
 /-!


### PR DESCRIPTION
I really hope that this ugly thing does not give a speedup.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
