### PR TITLE
[Merged by Bors] -  feat(Order/WellFoundedSet): minimal element of a nonempty set exists if `<` is well founded on the set

### DIFF
--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -82,19 +82,6 @@ instance (r : β → β → Prop) (f : α → β) [IsWellFounded β r] :
     IsWellFounded α (r.onFun f) where
   wf := IsWellFounded.wf.onFun
 
-theorem subtype_iff {p : α → Prop} :
-    WellFounded (α := Subtype p) (Function.onFun r Subtype.val) ↔
-      WellFounded (fun a b ↦ r a b ∧ p a ∧ p b) := by
-  simp_rw [wellFounded_iff_isEmpty_descending_chain, ← not_iff_not (a := IsEmpty _),
-    not_isEmpty_iff, nonempty_subtype]
-  refine ⟨fun ⟨f, ha⟩ ↦ ⟨(f ·), ?_⟩, fun ⟨f, ha⟩ ↦ ⟨(⟨f ·, ?_⟩), ?_⟩⟩ <;> grind
-
-theorem subtype_iff' {p : α → Prop} {r : Subtype p → Subtype p → Prop} :
-    WellFounded r ↔ WellFounded (fun a b ↦ ∃ ha : p a, ∃ hb : p b, r ⟨a, ha⟩ ⟨b, hb⟩) := by
-  simp_rw [wellFounded_iff_isEmpty_descending_chain, ← not_iff_not (a := IsEmpty _),
-    not_isEmpty_iff, nonempty_subtype]
-  refine ⟨fun ⟨f, ha⟩ ↦ ⟨(f ·), ?_⟩, fun ⟨f, ha⟩ ↦ ⟨(⟨f ·, (ha _).snd.fst⟩), ?_⟩⟩ <;> grind
-
 theorem _root_.Function.Injective.isWellOrder (r : β → β → Prop) {f : α → β} (hf : f.Injective)
     [IsWellOrder β r] : IsWellOrder α (r.onFun f) where
   __ := hf.trichotomous_onFun r

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -82,6 +82,19 @@ instance (r : β → β → Prop) (f : α → β) [IsWellFounded β r] :
     IsWellFounded α (r.onFun f) where
   wf := IsWellFounded.wf.onFun
 
+theorem subtype_iff {p : α → Prop} :
+    WellFounded (α := Subtype p) (Function.onFun r Subtype.val) ↔
+      WellFounded (fun a b ↦ r a b ∧ p a ∧ p b) := by
+  simp_rw [wellFounded_iff_isEmpty_descending_chain, ← not_iff_not (a := IsEmpty _),
+    not_isEmpty_iff, nonempty_subtype]
+  refine ⟨fun ⟨f, ha⟩ ↦ ⟨(f ·), ?_⟩, fun ⟨f, ha⟩ ↦ ⟨(⟨f ·, ?_⟩), ?_⟩⟩ <;> grind
+
+theorem subtype_iff' {p : α → Prop} {r : Subtype p → Subtype p → Prop} :
+    WellFounded r ↔ WellFounded (fun a b ↦ ∃ ha : p a, ∃ hb : p b, r ⟨a, ha⟩ ⟨b, hb⟩) := by
+  simp_rw [wellFounded_iff_isEmpty_descending_chain, ← not_iff_not (a := IsEmpty _),
+    not_isEmpty_iff, nonempty_subtype]
+  refine ⟨fun ⟨f, ha⟩ ↦ ⟨(f ·), ?_⟩, fun ⟨f, ha⟩ ↦ ⟨(⟨f ·, (ha _).snd.fst⟩), ?_⟩⟩ <;> grind
+
 theorem _root_.Function.Injective.isWellOrder (r : β → β → Prop) {f : α → β} (hf : f.Injective)
     [IsWellOrder β r] : IsWellOrder α (r.onFun f) where
   __ := hf.trichotomous_onFun r

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -561,11 +561,9 @@ lemma WellFoundedOn.mapsTo {α β : Type*} {r : α → α → Prop} (f : β → 
 
 @[to_dual]
 theorem WellFoundedOn.exists_minimal {α : Type*} [Preorder α] {s : Set α}
-    (h : s.WellFoundedOn (· < ·)) (nonempty : s.Nonempty) : ∃ a, Minimal (· ∈ s) a := by
-  rw [wellFoundedOn_iff, ← WellFounded.subtype_iff] at h
-  convert WellFoundedLT.exists_minimal ⟨h⟩ Set.univ (@Set.univ_nonempty _ (by simpa))
-  refine ⟨fun ⟨a, ha⟩ ↦ ⟨⟨a, ha.prop⟩, ?_⟩, fun ⟨a, this⟩ ↦ ⟨a, ?_⟩⟩
-  <;> simpa only [mem_univ, minimal_true_subtype]
+    (h : s.WellFoundedOn (· < ·)) (nonempty : s.Nonempty) : ∃ a, Minimal (· ∈ s) a :=
+  have ⟨m, hm⟩ := WellFoundedLT.exists_minimal ⟨h⟩ univ <| nonempty.elim (⟨⟨·, ·⟩, trivial⟩)
+  ⟨m, m.property, fun y hy ↦ hm.right (y := ⟨y, hy⟩) trivial⟩
 
 end WellFoundedOn
 

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -559,6 +559,14 @@ lemma WellFoundedOn.mapsTo {α β : Type*} {r : α → α → Prop} (f : β → 
     t.WellFoundedOn (r on f) := by
   exact InvImage.wf (fun x : t ↦ ⟨f x, h x.prop⟩) hw
 
+@[to_dual]
+theorem WellFoundedOn.exists_minimal {α : Type*} [Preorder α] {s : Set α}
+    (h : s.WellFoundedOn (· < ·)) (nonempty : s.Nonempty) : ∃ a, Minimal (· ∈ s) a := by
+  rw [wellFoundedOn_iff, ← WellFounded.subtype_iff] at h
+  convert WellFoundedLT.exists_minimal ⟨h⟩ Set.univ (@Set.univ_nonempty _ (by simpa))
+  refine ⟨fun ⟨a, ha⟩ ↦ ⟨⟨a, ha.prop⟩, ?_⟩, fun ⟨a, this⟩ ↦ ⟨a, ?_⟩⟩
+  <;> simpa only [mem_univ, minimal_true_subtype]
+
 end WellFoundedOn
 
 section LinearOrder


### PR DESCRIPTION
There exists a inimal element in a nonempty set if `<` is well founded on the set.

---
It was a lemmas for #39781, which has been closed since there would be a better proof.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
