### PR TITLE
[Merged by Bors] - feat(Projectivization/Independence): add lemma about independence

### DIFF
--- a/Mathlib/LinearAlgebra/Projectivization/Independence.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Independence.lean
@@ -113,7 +113,7 @@ theorem independent_pair_iff_ne (u v : ℙ K V) : Independent ![u, v] ↔ u ≠ 
   rw [independent_iff_not_dependent, dependent_pair_iff_eq u v]
 
 /-- Two points are independent if and only if their underlying vectors are linearly independent. -/
-lemma independent_mk_iff_linearIndep (u v : V) (hu : u ≠ 0) (hv : v ≠ 0) :
+lemma independent_mk_iff_linearIndep {u v : V} (hu : u ≠ 0) (hv : v ≠ 0) :
     Independent ![mk K u hu, mk K v hv] ↔ LinearIndependent K ![u, v] := by
   rw [independent_pair_iff_ne, ne_eq, mk_eq_mk_iff' K u v hu hv, linearIndependent_fin2]
   simp only [Matrix.cons_val_zero, Matrix.cons_val_one]

--- a/Mathlib/LinearAlgebra/Projectivization/Independence.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Independence.lean
@@ -113,7 +113,7 @@ theorem independent_pair_iff_ne (u v : ℙ K V) : Independent ![u, v] ↔ u ≠ 
   rw [independent_iff_not_dependent, dependent_pair_iff_eq u v]
 
 /-- Two points are independent if and only if their underlying vectors are linearly independent. -/
-lemma independent_mk_iff_linearIndep {u v : V} (hu : u ≠ 0) (hv : v ≠ 0) :
+lemma independent_mk_iff_LinearIndependent {u v : V} (hu : u ≠ 0) (hv : v ≠ 0) :
     Independent ![mk K u hu, mk K v hv] ↔ LinearIndependent K ![u, v] := by
   rw [independent_pair_iff_ne, ne_eq, mk_eq_mk_iff' K u v hu hv, linearIndependent_fin2]
   simp only [Matrix.cons_val_zero, Matrix.cons_val_one]

--- a/Mathlib/LinearAlgebra/Projectivization/Independence.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Independence.lean
@@ -112,4 +112,11 @@ theorem dependent_pair_iff_eq (u v : ℙ K V) : Dependent ![u, v] ↔ u = v := b
 theorem independent_pair_iff_ne (u v : ℙ K V) : Independent ![u, v] ↔ u ≠ v := by
   rw [independent_iff_not_dependent, dependent_pair_iff_eq u v]
 
+/-- Two points are independent if and only if their underlying vectors are linearly independent. -/
+lemma independent_mk_iff_linearIndep (u v : V) (hu : u ≠ 0) (hv : v ≠ 0) :
+    Independent ![mk K u hu, mk K v hv] ↔ LinearIndependent K ![u, v] := by
+  rw [independent_pair_iff_ne, ne_eq, mk_eq_mk_iff' K u v hu hv, linearIndependent_fin2]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
+  exact ⟨fun h ↦ ⟨hv, fun a ha ↦ h ⟨a, ha⟩⟩, fun ⟨_, h⟩ ⟨a, ha⟩ ↦ h a ha⟩
+
 end Projectivization


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
