### PR TITLE
feat(Tactic): `nonempty` attribute

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7252,6 +7252,7 @@ public import Mathlib.Tactic.Monotonicity.Basic
 public import Mathlib.Tactic.Monotonicity.Lemmas
 public import Mathlib.Tactic.MoveAdd
 public import Mathlib.Tactic.NoncommRing
+public import Mathlib.Tactic.NonemptyAttr
 public import Mathlib.Tactic.Nontriviality
 public import Mathlib.Tactic.Nontriviality.Core
 public import Mathlib.Tactic.NormNum

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -202,6 +202,7 @@ public import Mathlib.Tactic.Monotonicity.Basic
 public import Mathlib.Tactic.Monotonicity.Lemmas
 public import Mathlib.Tactic.MoveAdd
 public import Mathlib.Tactic.NoncommRing
+public import Mathlib.Tactic.NonemptyAttr
 public import Mathlib.Tactic.Nontriviality
 public import Mathlib.Tactic.Nontriviality.Core
 public import Mathlib.Tactic.NormNum

--- a/Mathlib/Tactic/NonemptyAttr.lean
+++ b/Mathlib/Tactic/NonemptyAttr.lean
@@ -7,6 +7,40 @@ module
 
 public meta import Mathlib.Util.AddRelatedDecl
 
+/-! The `nonempty` attribute
+
+When adding the `[nonempty]` attribute to a definition of type `α`,
+a declaration of type `Nonempty α` is automatically generated and is
+registered as an instance.
+
+This can be used to make available to the typeclass system facts that
+derive from the mere existence of an object of type `α` without making
+`α` a class.
+
+For instance, given a functor `F : C ⥤ D` between categories,
+the data of some fully faithful structure `ffStruct : F.FullyFaithful` on `F`
+allows one to derive `F.Full` and `F.Faithful`. However, this fact
+cannot be directly made available to typeclass synthesis, as the
+`FullyFaithful` structure is not a class (to avoid potential diamonds with
+such data-carrying classes).
+To avoid following every `FullyFaithful` declaration by two instance declarations,
+one can tag such declaration with `@[nonempty]` so that, when combined with
+instances of the form
+```
+instance {C D : Type*} [Category* C] [Category* D] (F : C ⥤ D) [Nonempty F.FullyFaithful] :
+    F.Full := …
+
+instance {C D : Type*} [Category* C] [Category* D] (F : C ⥤ D) [Nonempty F.FullyFaithful] :
+    F.Faithful := …
+```
+instances can be synthesized for `F.Full` and `F.Faithful`.
+
+- `@[nonempty (name := foo)]` names the resulting instance `foo`.
+- `@[nonempty (priority := 123)]` gives the resulting instance a priority of `123`.
+- `@[nonempty -inst]` does not register the instance.
+- If the attribute is made local or scoped, the same modifier is applied to the resulting instance.
+-/
+
 public meta section
 
 open Lean Meta Elab Tactic
@@ -26,7 +60,7 @@ structure Config where
   /-- If true, register the generated `Nonempty _` declaration as an instance. -/
   inst : Bool := true
 
-/-- Function elaborating `Push.Config`. -/
+/-- Function elaborating `NonemptyAttr.Config`. -/
 declare_command_config_elab elabNonemptyConfig Config
 
 /-- Syntax for optional instance priority argument in the `nonempty` attribute -/
@@ -35,13 +69,42 @@ syntax optPrio := atomic("(" &"priority" ":=" prio ")")?
 /-- Syntax for optional instance name argument in the `nonempty` attribute -/
 syntax optName := atomic("(" &"name" ":=" ident ")")?
 
---TODO: more doc
-/-- The `nonempty` attribute. -/
+/-- When adding the `[nonempty]` attribute to a definition of type `α`,
+a declaration of type `Nonempty α` is automatically generated and is
+registered as an instance.
+
+This can be used to make available to the typeclass system facts that
+derive from the mere existence of an object of type `α` without making
+`α` a class.
+
+For instance, given a functor `F : C ⥤ D` between categories,
+the data of some fully faithful structure `ffStruct : F.FullyFaithful` on `F`
+allows one to obtain `F.Full` and `F.Faithful`. However, this fact
+cannot be directly made available to typeclass synthesis, as the
+`FullyFaithful` structure is not a class (to avoid potential diamonds with
+such data-carrying classes).
+To avoid following every single `FullyFaithful` declaration by two instance declarations,
+one can tag such declarations with `@[nonempty]` so that, when combined with
+instances of the form
+```
+instance {C D : Type*} [Category* C] [Category* D] (F : C ⥤ D) [Nonempty F.FullyFaithful] :
+    F.Full := …
+
+instance {C D : Type*} [Category* C] [Category* D] (F : C ⥤ D) [Nonempty F.FullyFaithful] :
+    F.Faithful := …
+```
+instances can be synthesized for `F.Full` and `F.Faithful`.
+
+- `@[nonempty (name := foo)]` names the resulting instance `foo`.
+- `@[nonempty (priority := 123)]` gives the resulting instance a priority of `123`.
+- `@[nonempty -inst]` does not register the instance.
+- If the attribute is made local or scoped, the same modifier is applied to the resulting instance.
+-/
 syntax (name := nonempty) "nonempty" optPrio optName Parser.Tactic.optConfig : attr
 
 initialize registerBuiltinAttribute {
   name := `nonempty
-  descr := "Adds a declaration of type `Nonempty α` when tagging a declaration of type `α`"
+  descr := "Add an instance of type `Nonempty α` when tagging a declaration of type `α`"
   applicationTime := .afterCompilation
   add := fun src ref kind => match ref with
   | `(attr| nonempty $[(priority := $n:num)]? $[(name := $q:ident)]? $c:optConfig) => do

--- a/Mathlib/Tactic/NonemptyAttr.lean
+++ b/Mathlib/Tactic/NonemptyAttr.lean
@@ -21,15 +21,37 @@ def toNonempty (e : Expr) : MetaM Expr := do
       let e2 ← mkAppM ``Nonempty.intro #[e]
       return e2) e
 
+/-- The configuration options for the `nonempty` attribute. -/
+structure Config where
+  /-- If true, register the generated `Nonempty _` declaration as an instance. -/
+  inst : Bool := true
+
+/-- Function elaborating `Push.Config`. -/
+declare_command_config_elab elabNonemptyConfig Config
+
+/-- Syntax for optional instance priority argument in the `nonempty` attribute -/
+syntax optPrio := atomic("(" &"priority" ":=" prio ")")?
+
+/-- Syntax for optional instance name argument in the `nonempty` attribute -/
+syntax optName := atomic("(" &"name" ":=" ident ")")?
+
+--TODO: more doc
+/-- The `nonempty` attribute. -/
+syntax (name := nonempty) "nonempty" optPrio optName Parser.Tactic.optConfig : attr
+
 initialize registerBuiltinAttribute {
   name := `nonempty
   descr := "Adds a declaration of type `Nonempty α` when tagging a declaration of type `α`"
   applicationTime := .afterCompilation
   add := fun src ref kind => match ref with
-  | `(attr| nonempty) => MetaM.run' do
-    if (kind != AttributeKind.global) then
-      throwError "nonempty failed"
-    addRelatedInst src ref (hoverInfo := true)
+  | `(attr| nonempty $[(priority := $n:num)]? $[(name := $q:ident)]? $c:optConfig) => do
+    let prio : Option Nat := n.map (·.getNat)
+    let name : Option Name := q.map (·.getId)
+    let cfg ← liftCommandElabM <| elabNonemptyConfig c
+    MetaM.run' do
+    addRelatedInst src ref (prio := prio.getD (eval_prio default))
+      (name? := name) (inst := cfg.inst)
+      (kind := kind) (hoverInfo := true)
       fun value levels => do
         let newValue ← (toNonempty value)
         pure (newValue, levels)
@@ -38,4 +60,3 @@ initialize registerBuiltinAttribute {
 end Mathlib.Tactic.NonemptyAttr
 
 end
-

--- a/Mathlib/Tactic/NonemptyAttr.lean
+++ b/Mathlib/Tactic/NonemptyAttr.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+module
+
+public meta import Mathlib.Util.AddRelatedDecl
+
+public meta section
+
+open Lean Meta Elab Tactic
+
+namespace Mathlib.Tactic.NonemptyAttr
+
+/-- Given an expression assumed of type `α`, returns an expression for of type `Nonempty α`. -/
+def toNonempty (e : Expr) : MetaM Expr := do
+  mapForallTelescope
+    (fun e' => do
+      let e ← instantiateMVars e'
+      let e2 ← mkAppM ``Nonempty.intro #[e]
+      return e2) e
+
+initialize registerBuiltinAttribute {
+  name := `nonempty
+  descr := "Adds a declaration of type `Nonempty α` when tagging a declaration of type `α`"
+  applicationTime := .afterCompilation
+  add := fun src ref kind => match ref with
+  | `(attr| nonempty) => MetaM.run' do
+    if (kind != AttributeKind.global) then
+      throwError "nonempty failed"
+    addRelatedInst src ref (hoverInfo := true)
+      fun value levels => do
+        let newValue ← (toNonempty value)
+        pure (newValue, levels)
+  | _ => throwUnsupportedSyntax }
+
+end Mathlib.Tactic.NonemptyAttr
+
+end
+

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -94,10 +94,13 @@ in the environment. -/
 private partial def mkUnusedBaseName (baseName : Name) : MetaM Name := do
   let currNamespace ← getCurrNamespace
   let env ← getEnv
-  if (env.contains (currNamespace ++ baseName)) then
+  -- We don’t use directly env.contains as extra care is needed to correctly handle private names.
+  let hasDeclName env declName :=
+    env.contains (mkPrivateName env declName) || env.contains (privateToUserName declName)
+  if hasDeclName env (currNamespace ++ baseName) then
     let rec loop (idx : Nat) := do
       let name := baseName.appendIndexAfter idx
-      if env.contains (currNamespace ++ name) then
+      if hasDeclName env (currNamespace ++ name) then
         loop (idx+1)
       else
         return name
@@ -107,8 +110,8 @@ private partial def mkUnusedBaseName (baseName : Name) : MetaM Name := do
 
 /-- A helper function for constructing a related `Prop`-class instance declaration
 from an existing declaration.
-Due to the slightly different logic for handling name and making the declaration
-an instance, this is kept separate from `addRelatedDecl`
+This is kept separate from `addRelatedDecl` due to the slightly different logic needed
+for handling name generation, visibility, and making the declaration an instance.
 
 This is currently used by the attribute `nonempty`.
 
@@ -128,6 +131,7 @@ Arguments:
   instances names from their type.
 * `inst`: register the instance, defaults to true.
 * `prio`: set priority of the instance, defaults to the default instance priority, i.e., 1000.
+* `kind`: mark the added instance as scoped/global/local. Defaults to global.
 * When `hoverInfo := true`, the generated constant will be shown as the hover information on `ref`.
   Warning: As a result, the original doc-string of `ref` will not be visible,
   and go-to-def on `ref` will not go to the definition of `ref`.
@@ -136,17 +140,23 @@ def addRelatedInst (src : Name) (ref : Syntax)
     (construct : Expr → List Name → MetaM (Expr × List Name))
     (docstringPrefix? : Option String := none)
     (name? : Option Name := none)
-    (inst : Bool := true)
-    (prio := eval_prio default)
-    (hoverInfo : Bool := false) :
+    (inst : Bool := true) (prio : Nat := eval_prio default)
+    (hoverInfo : Bool := false) (kind : AttributeKind := .global) :
     MetaM Unit := do
+  let priv := isPrivateName src
   let info ← withoutExporting <| getConstInfo src
   let value := .const src (info.levelParams.map mkLevelParam)
   let (newValue, newLevels) ← construct value info.levelParams
   let newValue ← instantiateMVars newValue
   let newType ← instantiateMVars (← inferType newValue)
-  let tgt := if let some name := name? then name else
-    ← mkUnusedBaseName <| ← Command.NameGen.mkBaseNameWithSuffix "inst" newType
+  -- Some special support needs to be added for private instance
+  let modifyNameIfPrivate : Name → MetaM Name := fun x ↦ do
+    if priv then return mkPrivateName (← getEnv) x else return x
+  let tgt : Name ← do
+    if let some name := name? then (modifyNameIfPrivate name)
+    else
+      modifyNameIfPrivate
+        (← mkUnusedBaseName <| ← Command.NameGen.mkBaseNameWithSuffix "inst" newType)
   addDeclarationRangesFromSyntax tgt (← getRef) ref
   unless ← isProp newType do throwError "Related instance is not a proposition: {newType}"
   addDecl <| ← mkThmOrUnsafeDef
@@ -155,7 +165,7 @@ def addRelatedInst (src : Name) (ref : Syntax)
   | none, none => pure ()
   | some doc, none | none, some doc => addDocStringCore tgt doc
   | some docPre, some docPost => addDocStringCore tgt s!"{docPre}\n\n---\n\n{docPost}"
-  if inst then addInstance tgt .global prio
+  if inst then addInstance tgt kind prio
   if hoverInfo then
      Term.TermElabM.run' do Term.addTermInfo' ref (← mkConstWithLevelParams tgt) (isBinder := true)
 

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -87,4 +87,76 @@ def addRelatedDecl (src tgt : Name) (ref : Syntax)
     if hoverInfo then
       Term.addTermInfo' ref (← mkConstWithLevelParams tgt) (isBinder := true)
 
+/-- This is an adaptation of `Lean.Elab.Util.mkUnusedBaseName` but
+doing everything in `MetaM` instead of `MacroM`.
+It returns the base name suffixed by a numerical index if the name already exists
+in the environment. -/
+private partial def mkUnusedBaseName (baseName : Name) : MetaM Name := do
+  let currNamespace ← getCurrNamespace
+  let env ← getEnv
+  if (env.contains (currNamespace ++ baseName)) then
+    let rec loop (idx : Nat) := do
+      let name := baseName.appendIndexAfter idx
+      if env.contains (currNamespace ++ name) then
+        loop (idx+1)
+      else
+        return name
+    loop 1
+  else
+    return baseName
+
+/-- A helper function for constructing a related `Prop`-class instance declaration
+from an existing declaration.
+Due to the slightly different logic for handling name and making the declaration
+an instance, this is kept separate from `addRelatedDecl`
+
+This is currently used by the attribute `nonempty`.
+
+This helper calls `addDeclarationRangesFromSyntax`, so jump-to-definition works.
+
+Arguments:
+* `src : Name` is the existing declaration that we are modifying.
+* `ref : Syntax` is the syntax where the user requested the related declaration.
+* `construct value levels : MetaM (Expr × List Name)`
+  given an `Expr.const` referring to the original declaration, and its universe variables,
+  should construct the value of the new declaration,
+  along with the names of its universe variables.
+* `docstringPrefix?` is prepended to the doc-string of `src` to form the doc-string of `tgt`.
+  If it is `none`, only the doc-string of `src` is used.
+* `name?`: optional name for the new declaration. This default to `none`,
+  in which case the name will be generated with the same heuristic that autogenerates
+  instances names from their type.
+* `inst`: register the instance, defaults to true.
+* `prio`: set priority of the instance, defaults to the default instance priority, i.e., 1000.
+* When `hoverInfo := true`, the generated constant will be shown as the hover information on `ref`.
+  Warning: As a result, the original doc-string of `ref` will not be visible,
+  and go-to-def on `ref` will not go to the definition of `ref`.
+-/
+def addRelatedInst (src : Name) (ref : Syntax)
+    (construct : Expr → List Name → MetaM (Expr × List Name))
+    (docstringPrefix? : Option String := none)
+    (name? : Option Name := none)
+    (inst : Bool := true)
+    (prio := eval_prio default)
+    (hoverInfo : Bool := false) :
+    MetaM Unit := do
+  let info ← withoutExporting <| getConstInfo src
+  let value := .const src (info.levelParams.map mkLevelParam)
+  let (newValue, newLevels) ← construct value info.levelParams
+  let newValue ← instantiateMVars newValue
+  let newType ← instantiateMVars (← inferType newValue)
+  let tgt := if let some name := name? then name else
+    ← mkUnusedBaseName <| ← Command.NameGen.mkBaseNameWithSuffix "inst" newType
+  addDeclarationRangesFromSyntax tgt (← getRef) ref
+  unless ← isProp newType do throwError "Related instance is not a proposition: {newType}"
+  addDecl <| ← mkThmOrUnsafeDef
+    { levelParams := newLevels, type := newType, name := tgt, value := newValue }
+  match docstringPrefix?, ← findDocString? (← getEnv) src with
+  | none, none => pure ()
+  | some doc, none | none, some doc => addDocStringCore tgt doc
+  | some docPre, some docPost => addDocStringCore tgt s!"{docPre}\n\n---\n\n{docPost}"
+  if inst then addInstance tgt .global prio
+  if hoverInfo then
+     Term.TermElabM.run' do Term.addTermInfo' ref (← mkConstWithLevelParams tgt) (isBinder := true)
+
 end Mathlib.Tactic

--- a/MathlibTest/NonemptyAttr.lean
+++ b/MathlibTest/NonemptyAttr.lean
@@ -6,50 +6,106 @@ Authors: Robin Carlier
 module
 
 public import Mathlib.Tactic.NonemptyAttr
-public import Mathlib.CategoryTheory.Functor.FullyFaithful
+public import Mathlib.Logic.Nonempty
 
-open CategoryTheory
+/-! Tests for the behavior of the `nonempty` attribute. -/
 
 @[expose] public section
 
-variable (C : Type*) [Category* C]
-def F : C ⥤ C where
-  obj x := x
-  map x := x
+def Foo := Unit
 
-@[nonempty]
-def Ff : (F C).FullyFaithful :=
-  sorry
+@[nonempty] def F : Foo := .unit
 
-@[nonempty]
-def Ff' : (F C).FullyFaithful :=
-  sorry
+/-- info: instNonemptyFoo : Nonempty Foo -/
+#guard_msgs in #check instNonemptyFoo
 
-instance (C : Type*) [Category* C] : Nonempty (F C).FullyFaithful := sorry
-instance (C : Type*) [Category* C] : Nonempty (F C).FullyFaithful := sorry
-instance (C : Type*) [Category* C] : Nonempty (F C).FullyFaithful := sorry
+/-- info: instNonemptyFoo -/
+#guard_msgs in #synth Nonempty Foo
 
--- @[nonempty]
--- def Ff' : ∀ (C : Type*) [Category* C], (F C).FullyFaithful :=
---   sorry
+#guard_msgs in @[nonempty] def G : Foo := .unit
 
-section
+/-! testing if repeated application add suffixes -/
 
-#check Ff
--- #check instFullF
--- #check instFaithfulF
+/-- info: instNonemptyFoo_1 : Nonempty Foo -/
+#guard_msgs in #check instNonemptyFoo_1
 
-set_option trace.Meta.synthInstance true in
-#synth Nonempty (F C).FullyFaithful
-#synth (F C).Full
-#synth (F C).Faithful
+def Bar := Unit
+
+#guard_msgs in @[nonempty -inst] def H : Bar := .unit
+
+/--
+error: failed to synthesize
+  Nonempty Bar
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+-/
+#guard_msgs in #synth Nonempty Bar
+
+#guard_msgs in @[nonempty (priority := 100) -inst] def K : Bar := .unit
+
+/-! Testing if named priority work -/
+
+#guard_msgs in @[nonempty (priority := mid) -inst] def U : Bar := .unit
+
+/-! Testing if manual name works -/
+
+#guard_msgs in @[nonempty (priority := mid) (name := hello) -inst] def V : Bar := .unit
+
+/-- info: hello : Nonempty Bar -/
+#guard_msgs in #check hello
+
+/-! Check that `scoped nonempty` correctly adds a scoped instance -/
+section «scoped»
+
+def Boz := Unit
+
+namespace Boz
+
+@[scoped nonempty] def foo : Boz := .unit
+
+/-- info: instNonempty -/
+#guard_msgs in #synth Nonempty Boz
+
+end Boz
+
+/--
+error: failed to synthesize
+  Nonempty Boz
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+-/
+#guard_msgs in #synth Nonempty Boz
+
+/-- info: instNonempty -/
+#guard_msgs in open scoped Boz in #synth Nonempty Boz
+
+end «scoped»
 
 end
 
-example : (F C).Full := inferInstance
-example : (F C).Faithful := inferInstance
+/-! Check interaction of nonempty with private/public. -/
 
-@[nonempty]
-def Ff'' : Nat := sorry
+section
+
+@[expose] public def Faa := Unit
+
+@[nonempty] def faaAux : Faa := .unit
+
+-- Should be private:
+
+/--
+info: private theorem instNonemptyFaa : Nonempty Faa :=
+Nonempty.intro faaAux
+-/
+#guard_msgs in
+#print instNonemptyFaa
+
+@[nonempty (name := bar)] def faaAux' : Faa := .unit
+
+/--
+info: private theorem bar : Nonempty Faa :=
+Nonempty.intro faaAux'
+-/
+#guard_msgs in #print bar
 
 end

--- a/MathlibTest/NonemptyAttr.lean
+++ b/MathlibTest/NonemptyAttr.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+module
+
+public import Mathlib.Tactic.NonemptyAttr
+public import Mathlib.CategoryTheory.Functor.FullyFaithful
+
+open CategoryTheory
+
+@[expose] public section
+
+variable (C : Type*) [Category* C]
+def F : C ⥤ C where
+  obj x := x
+  map x := x
+
+@[nonempty]
+def Ff : (F C).FullyFaithful :=
+  sorry
+
+@[nonempty]
+def Ff' : (F C).FullyFaithful :=
+  sorry
+
+instance (C : Type*) [Category* C] : Nonempty (F C).FullyFaithful := sorry
+instance (C : Type*) [Category* C] : Nonempty (F C).FullyFaithful := sorry
+instance (C : Type*) [Category* C] : Nonempty (F C).FullyFaithful := sorry
+
+-- @[nonempty]
+-- def Ff' : ∀ (C : Type*) [Category* C], (F C).FullyFaithful :=
+--   sorry
+
+section
+
+#check Ff
+-- #check instFullF
+-- #check instFaithfulF
+
+set_option trace.Meta.synthInstance true in
+#synth Nonempty (F C).FullyFaithful
+#synth (F C).Full
+#synth (F C).Faithful
+
+end
+
+example : (F C).Full := inferInstance
+example : (F C).Faithful := inferInstance
+
+@[nonempty]
+def Ff'' : Nat := sorry
+
+end


### PR DESCRIPTION
This PR adds a `nonempty` attribute. When tagging a definition of type `α` with `[nonempty]`, an instance of type `Nonempty α` is automatically generated and registered using the definition.

Such an attribute is useful in the following scenario: certain structures are not classes (e.g., to avoid data-carrying classes potentially creating diamonds), but mere existence of terms of such structures allows to derive instances about the parameters of the structure. Using `[nonempty]` lets one auto-generate the instances derived instance (provided they correctly follow from `[Nonempty _]`).

Such is the case for the `CategoryTheory.Functor.FullyFaithful` structure, which allows to derive the `Prop`-classes `CategoryTheory.Functor.Full` and `CategoryTheory.Functor.Faithful`. Currently in mathlib, most definitions of type `CategoryTheory.Functor.FullyFaithful` are immediately followed by the corresponding `Full` and `Faithful` instances, adding "boilerplate" and increasing the surface for potential mistakes (like forgetting one or both of the instances.)

The attribute uses a variation of `addRelatedDecl` called `addRelatedInstance`, which handles automatic name generation and registration of instances from a given declaration and a "constructor" of type `Expr → List Name → MetaM (Expr × List Name)`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I believe abstracting `addRelatedInst` might have other possible usages: for instance, given an adjunction `adj: L ⊣ R`, it would be nice to have an attribute that one can tag on such adjunctions that automatically registers `L.IsLeftAdjoint` and `R.IsRightAdjoint`. The `nonempty` attribute here can’t really do this because `R` can’t be inferred from a goal of type `L.IsLeftAdjoint`, but the situation is quite similar, and `addRelatedInst` could also help writing this kind of attribute.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
