### PR TITLE
[Merged by Bors] - fix: decls with a non-consecutive duplicate namespace

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/JointEigenspace.lean
+++ b/Mathlib/Analysis/InnerProductSpace/JointEigenspace.lean
@@ -140,6 +140,10 @@ theorem directSum_isInternal_of_pairwise_commute [DecidableEq (n → 𝕜)]
   · rw [iSup_iInf_eq_top_of_commute hT hC, top_orthogonal_eq_bot]
   · exact orthogonalFamily_iInf_eigenspaces hT
 
+@[deprecated (since := "2026-05-24")]
+alias LinearMap.IsSymmetric.directSum_isInternal_of_pairwise_commute :=
+  directSum_isInternal_of_pairwise_commute
+
 end RCLike
 
 end IsSymmetric

--- a/Mathlib/CategoryTheory/Groupoid/VertexGroup.lean
+++ b/Mathlib/CategoryTheory/Groupoid/VertexGroup.lean
@@ -77,11 +77,17 @@ def vertexGroupIsomOfPath {c d : C} (p : Quiver.Path c d) : (c ⟶ c) ≃* (d �
 
 /-- A functor defines a morphism of vertex groups. -/
 @[simps]
-def CategoryTheory.Functor.mapVertexGroup {D : Type v} [Groupoid D] (φ : C ⥤ D) (c : C) :
+def _root_.CategoryTheory.Functor.mapVertexGroup {D : Type v} [Groupoid D] (φ : C ⥤ D) (c : C) :
     (c ⟶ c) →* (φ.obj c ⟶ φ.obj c) where
   toFun := φ.map
   map_one' := φ.map_id c
   map_mul' := φ.map_comp
+
+@[deprecated (since := "2026-05-24")]
+alias CategoryTheory.Functor.mapVertexGroup := CategoryTheory.Functor.mapVertexGroup
+
+@[deprecated (since := "2026-05-24")]
+alias CategoryTheory.Functor.mapVertexGroup_apply := CategoryTheory.Functor.mapVertexGroup_apply
 
 end Groupoid
 

--- a/Mathlib/CategoryTheory/Subobject/Classifier/Defs.lean
+++ b/Mathlib/CategoryTheory/Subobject/Classifier/Defs.lean
@@ -393,6 +393,8 @@ def Ω₀ : Subobject Ω := h.homEquiv (𝟙 Ω)
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.Ω₀ := Ω₀
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.Ω₀ := Ω₀
 
 /-- `h.homEquiv` acts like an "object comprehension" operator: it maps any characteristic map
 `f : X ⟶ Ω` to the associated subobject of `X`, obtained by pulling back `h.Ω₀` along `f`. -/
@@ -402,6 +404,8 @@ lemma homEquiv_eq {X : C} (f : X ⟶ Ω) :
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.homEquiv_eq := homEquiv_eq
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.homEquiv_eq := homEquiv_eq
 
 /-- For any subobject `x`, the pullback of `h.Ω₀` along the characteristic map of `x`
 given by `h.homEquiv` is `x` itself. -/
@@ -411,6 +415,9 @@ lemma pullback_homEquiv_symm_obj_Ω₀ {X : C} (x : Subobject X) :
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.pullback_homEquiv_symm_obj_Ω₀ :=
+  pullback_homEquiv_symm_obj_Ω₀
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.pullback_homEquiv_symm_obj_Ω₀ :=
   pullback_homEquiv_symm_obj_Ω₀
 
 section
@@ -422,6 +429,8 @@ def χ : X ⟶ Ω := h.homEquiv.symm (Subobject.mk m)
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.χ := χ
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.χ := χ
 
 /-- `h.iso m` is the isomorphism between `m` and the pullback of `Ω₀`
     along the characteristic map of `m`. -/
@@ -432,6 +441,8 @@ noncomputable def iso : MonoOver.mk m ≅
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.iso := iso
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.iso := iso
 
 /-- `h.π m` is the first projection in the following pullback square:
 
@@ -449,6 +460,8 @@ noncomputable def π : U ⟶ Subobject.underlying.obj h.Ω₀ :=
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.π := π
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.π := π
 
 set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp)]
@@ -461,6 +474,8 @@ lemma iso_inv_left_π :
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.iso_inv_left_π := iso_inv_left_π
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.iso_inv_left_π := iso_inv_left_π
 
 @[reassoc (attr := simp)]
 lemma iso_inv_hom_left_comp :
@@ -470,6 +485,9 @@ lemma iso_inv_hom_left_comp :
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.iso_inv_hom_left_comp :=
+  iso_inv_hom_left_comp
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.iso_inv_hom_left_comp :=
   iso_inv_hom_left_comp
 
 @[deprecated (since := "2025-12-18")]
@@ -486,6 +504,8 @@ lemma isPullback {U X : C} (m : U ⟶ X) [Mono m] :
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.isPullback := isPullback
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.isPullback := isPullback
 
 variable {m}
 lemma uniq {χ' : X ⟶ Ω} {π : U ⟶ h.Ω₀}
@@ -496,6 +516,8 @@ lemma uniq {χ' : X ⟶ Ω} {π : U ⟶ h.Ω₀}
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.uniq := uniq
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.uniq := uniq
 
 end
 
@@ -511,18 +533,24 @@ noncomputable def isTerminalΩ₀ : IsTerminal (h.Ω₀ : C) :=
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.isTerminalΩ₀ := isTerminalΩ₀
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.isTerminalΩ₀ := isTerminalΩ₀
 
 /-- The unique map to the terminal object. -/
 noncomputable def χ₀ (U : C) : U ⟶ h.Ω₀ := h.isTerminalΩ₀.from U
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.χ₀ := χ₀
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.χ₀ := χ₀
 
 include h in
 lemma hasTerminal : HasTerminal C := h.isTerminalΩ₀.hasTerminal
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.hasTerminal := hasTerminal
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.hasTerminal := hasTerminal
 
 variable [HasTerminal C]
 
@@ -532,6 +560,8 @@ noncomputable def isoΩ₀ : (h.Ω₀ : C) ≅ ⊤_ C :=
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.isoΩ₀ := isoΩ₀
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.isoΩ₀ := isoΩ₀
 
 /-- Any representation `Ω` of `Subobject.presheaf C` gives a subobject classifier with truth values
 object `Ω`. -/
@@ -553,6 +583,8 @@ noncomputable def classifier : Subobject.Classifier C where
 
 @[deprecated (since := "2026-03-06")]
 alias _root.CategoryTheory.Classifier.SubobjectRepresentableBy.classifier := classifier
+@[deprecated (since := "2026-03-06")]
+alias _root_.CategoryTheory.Classifier.SubobjectRepresentableBy.classifier := classifier
 
 end SubobjectRepresentableBy
 end FromRepresentation

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -74,11 +74,14 @@ noncomputable def _root_.Set.Countable.finiteExhaustion {s : Set α} (hs : s.Cou
   · refine ⟨fun _ ↦ ∅, by simp [Finite.to_subtype], fun n ↦ by simp, ?_⟩
     simp [Set.not_nonempty_iff_eq_empty'.mp h]
 
-lemma Set.nonempty_finiteExhaustion_iff {s : Set α} :
+lemma _root_.Set.nonempty_finiteExhaustion_iff {s : Set α} :
     Nonempty s.FiniteExhaustion ↔ s.Countable := by
   refine ⟨fun ⟨K⟩ ↦ ?_, fun h ↦ ⟨h.finiteExhaustion⟩⟩
   rw [← K.iUnion_eq]
   exact countable_iUnion <| fun i ↦ (K.finite i).countable
+
+@[deprecated (since := "2026-05-24")]
+alias Set.nonempty_finiteExhaustion_iff := Set.nonempty_finiteExhaustion_iff
 
 section prod
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -317,10 +317,12 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   (Z : M → Type*) [TopologicalSpace (TotalSpace F Z)] [∀ b, TopologicalSpace (Z b)]
   [FiberBundle F Z] [∀ b, AddCommMonoid (Z b)] [∀ b, Module 𝕜 (Z b)] [VectorBundle 𝕜 F Z]
 
-theorem Bundle.Trivialization.mdifferentiable [ContMDiffVectorBundle 1 F Z I]
+theorem mdifferentiable [ContMDiffVectorBundle 1 F Z I]
     (e : Trivialization F (π F Z)) [MemTrivializationAtlas e] :
     e.MDifferentiable (I.prod 𝓘(𝕜, F)) (I.prod 𝓘(𝕜, F)) :=
   ⟨e.contMDiffOn.mdifferentiableOn one_ne_zero, e.contMDiffOn_symm.mdifferentiableOn one_ne_zero⟩
+
+@[deprecated (since := "2026-05-24")] alias Bundle.Trivialization.mdifferentiable := mdifferentiable
 
 end
 

--- a/Mathlib/GroupTheory/Submonoid/Inverses.lean
+++ b/Mathlib/GroupTheory/Submonoid/Inverses.lean
@@ -50,9 +50,14 @@ noncomputable instance [CommMonoid M] : CommGroup (IsUnit.submonoid M) :=
     mul_comm := fun a b ↦ by convert! mul_comm a b }
 
 @[to_additive]
-theorem IsUnit.Submonoid.coe_inv [Monoid M] (x : IsUnit.submonoid M) :
+theorem _root_.IsUnit.submonoid.coe_inv [Monoid M] (x : IsUnit.submonoid M) :
     ↑x⁻¹ = (↑x.prop.unit⁻¹ : M) :=
   rfl
+
+@[deprecated (since := "2026-05-24")]
+alias _root_.AddSubmonoid.IsUnit.Submonoid.coe_neg := IsAddUnit.addSubmonoid.coe_neg
+@[to_additive existing, deprecated (since := "2026-05-24")]
+alias IsUnit.Submonoid.coe_inv := IsUnit.submonoid.coe_inv
 
 section Monoid
 

--- a/Mathlib/Logic/Equiv/Set.lean
+++ b/Mathlib/Logic/Equiv/Set.lean
@@ -246,8 +246,10 @@ protected def singleton {α} (a : α) : ({a} : Set α) ≃ PUnit.{u} :=
     subst x
     rfl, fun ⟨⟩ => rfl⟩
 
-lemma Equiv.strictMono_setCongr {α : Type*} [Preorder α] {S T : Set α} (h : S = T) :
+lemma _root_.Equiv.strictMono_setCongr {α : Type*} [Preorder α] {S T : Set α} (h : S = T) :
     StrictMono (setCongr h) := fun _ _ ↦ id
+
+@[deprecated (since := "2026-05-24")] alias Equiv.strictMono_setCongr := Equiv.strictMono_setCongr
 
 /-- If `a ∉ s`, then `insert a s` is equivalent to `s ⊕ PUnit`. -/
 protected def insert {α} {s : Set.{u} α} [DecidablePred (· ∈ s)] {a : α} (H : a ∉ s) :

--- a/Mathlib/NumberTheory/NumberField/CMField.lean
+++ b/Mathlib/NumberTheory/NumberField/CMField.lean
@@ -554,9 +554,6 @@ instance of_isAbelianGalois [IsAbelianGalois ℚ K] :
     exact hσ₁.comp _
   exact IsCMField.of_forall_isConj K hσ₂
 
-@[deprecated (since := "2025-11-19")] alias NumberField.CMExtension.of_isMulCommutative :=
-  NumberField.IsCMField.of_isAbelianGalois
-
 end NumberField.IsCMField
 namespace IsCyclotomicExtension.Rat
 

--- a/Mathlib/NumberTheory/NumberField/Completion/FinitePlace.lean
+++ b/Mathlib/NumberTheory/NumberField/Completion/FinitePlace.lean
@@ -177,30 +177,60 @@ theorem adicAbv_intCast_le_one (n : ℤ) : adicAbv K v n ≤ 1 :=
 @[deprecated (since := "2026-03-11")]
 alias NumberField.RingOfIntegers.HeightOneSpectrum.one_lt_absNorm := one_lt_absNorm
 @[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.RingOfIntegers.HeightOneSpectrum.one_lt_absNorm := one_lt_absNorm
+@[deprecated (since := "2026-03-11")]
 alias NumberField.RingOfIntegers.HeightOneSpectrum.one_lt_absNorm_nnreal := one_lt_absNorm_nnreal
+@[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.RingOfIntegers.HeightOneSpectrum.one_lt_absNorm_nnreal :=
+  one_lt_absNorm_nnreal
 @[deprecated (since := "2026-03-11")]
 alias NumberField.RingOfIntegers.HeightOneSpectrum.absNorm_ne_zero := absNorm_ne_zero
 @[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.RingOfIntegers.HeightOneSpectrum.absNorm_ne_zero := absNorm_ne_zero
+@[deprecated (since := "2026-03-11")]
 alias NumberField.RingOfIntegers.HeightOneSpectrum.adicAbv := adicAbv
 @[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.RingOfIntegers.HeightOneSpectrum.adicAbv := adicAbv
+@[deprecated (since := "2026-03-11")]
 alias NumberField.RingOfIntegers.HeightOneSpectrum.adicAbv_def := adicAbv_def
+@[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.RingOfIntegers.HeightOneSpectrum.adicAbv_def := adicAbv_def
 @[deprecated (since := "2026-03-11")]
 alias NumberField.RingOfIntegers.HeightOneSpectrum.isNonarchimedean_adicAbv :=
   isNonarchimedean_adicAbv
 @[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.RingOfIntegers.HeightOneSpectrum.isNonarchimedean_adicAbv :=
+  isNonarchimedean_adicAbv
+@[deprecated (since := "2026-03-11")]
 alias NumberField.instRankOneAdicCompletion := instRankOneAdicCompletion
+@[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.instRankOneAdicCompletion := instRankOneAdicCompletion
 @[deprecated (since := "2026-03-11")]
 alias NumberField.instNormedFieldValuedAdicCompletion := instNormedFieldValuedAdicCompletion
 @[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.instNormedFieldValuedAdicCompletion := instNormedFieldValuedAdicCompletion
+@[deprecated (since := "2026-03-11")]
 alias NumberField.rankOne_hom'_def := rankOne_hom'_def
+@[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.rankOne_hom'_def := rankOne_hom'_def
 @[deprecated (since := "2026-03-11")]
 alias NumberField.toNNReal_valued_eq_adicAbv := toNNReal_valued_eq_adicAbv
 @[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.toNNReal_valued_eq_adicAbv := toNNReal_valued_eq_adicAbv
+@[deprecated (since := "2026-03-11")]
 alias NumberField.RingOfIntegers.HeightOneSpectrum.adicAbv_add_le_max := adicAbv_add_le_max
+@[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.RingOfIntegers.HeightOneSpectrum.adicAbv_add_le_max := adicAbv_add_le_max
 @[deprecated (since := "2026-03-11")]
 alias NumberField.RingOfIntegers.HeightOneSpectrum.adicAbv_natCast_le_one := adicAbv_natCast_le_one
 @[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.RingOfIntegers.HeightOneSpectrum.adicAbv_natCast_le_one :=
+  adicAbv_natCast_le_one
+@[deprecated (since := "2026-03-11")]
 alias NumberField.RingOfIntegers.HeightOneSpectrum.adicAbv_intCast_le_one := adicAbv_intCast_le_one
+@[deprecated (since := "2026-03-11")]
+alias _root_.NumberField.RingOfIntegers.HeightOneSpectrum.adicAbv_intCast_le_one :=
+  adicAbv_intCast_le_one
 
 end HeightOneSpectrum
 
@@ -210,7 +240,7 @@ open HeightOneSpectrum Valuation.IsRankOneDiscrete
 for the equality involving `‖embedding v x‖` on the LHS. -/
 theorem FinitePlace.norm_def (x : v.adicCompletion K) :
     ‖x‖ = toNNReal (absNorm_ne_zero v) (Valued.v x) := by
-  simp [Valued.toNormedField.norm_def, Valuation.RankOne.hom, rankOne_hom'_def,
+  simp [Valued.toNormedField.norm_def, Valuation.RankOne.hom, HeightOneSpectrum.rankOne_hom'_def,
     valueGroup₀_equiv_withZeroMulInt_restrict_apply_of_surjective
       (valuedAdicCompletion_surjective K v)]
 

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Basic.lean
@@ -306,8 +306,11 @@ theorem card_filter_mk_eq [NumberField K] (w : InfinitePlace K) : #{φ | mk φ =
     rwa [Ne, eq_comm, ← ComplexEmbedding.isReal_iff, ← isReal_iff]
 
 open scoped Classical in
-noncomputable instance NumberField.InfinitePlace.fintype [NumberField K] :
+protected noncomputable instance fintype [NumberField K] :
     Fintype (InfinitePlace K) := Set.fintypeRange _
+
+@[deprecated (since := "2026-05-24")]
+alias NumberField.InfinitePlace.fintype := InfinitePlace.fintype
 
 open scoped Classical in
 @[to_additive]

--- a/Mathlib/Order/Filter/Germ/Basic.lean
+++ b/Mathlib/Order/Filter/Germ/Basic.lean
@@ -252,9 +252,11 @@ theorem compTendsto'_coe (f : Germ l β) {lc : Filter γ} {g : γ → α} (hg : 
     f.compTendsto' _ hg.germ_tendsto = f.compTendsto g hg :=
   rfl
 
-theorem Filter.Tendsto.congr_germ {f g : β → γ} {l : Filter α} {l' : Filter β} (h : f =ᶠ[l'] g)
-    {φ : α → β} (hφ : Tendsto φ l l') : (f ∘ φ : Germ l γ) = g ∘ φ :=
+theorem _root_.Filter.Tendsto.congr_germ {f g : β → γ} {l : Filter α} {l' : Filter β}
+    (h : f =ᶠ[l'] g) {φ : α → β} (hφ : Tendsto φ l l') : (f ∘ φ : Germ l γ) = g ∘ φ :=
   EventuallyEq.germ_eq (h.comp_tendsto hφ)
+
+@[deprecated (since := "2026-05-24")] alias Filter.Tendsto.congr_germ := Filter.Tendsto.congr_germ
 
 lemma isConstant_comp_tendsto {lc : Filter γ} {g : γ → α}
     (hf : (f : Germ l β).IsConstant) (hg : Tendsto g lc l) : IsConstant (f ∘ g : Germ lc β) := by

--- a/Mathlib/RingTheory/TensorProduct/Maps.lean
+++ b/Mathlib/RingTheory/TensorProduct/Maps.lean
@@ -410,8 +410,11 @@ lemma commRight_tmul (s : S) (a : A) : commRight R S A (s ⊗ₜ a) = a ⊗ₜ s
 variable {S A} in
 attribute [local instance] Algebra.TensorProduct.rightAlgebra in
 @[simp]
-lemma Algebra.TensorProduct.commRight_symm_tmul (s : S) (a : A) :
+lemma commRight_symm_tmul (s : S) (a : A) :
     (commRight R S A).symm (a ⊗ₜ[R] s) = s ⊗ₜ a := rfl
+
+@[deprecated (since := "2026-05-24")]
+alias Algebra.TensorProduct.commRight_symm_tmul := commRight_symm_tmul
 
 end
 


### PR DESCRIPTION
The `dupNamespace` linter only lints against duplicate namespaces which are consecutive, and changing it to lint against any duplication reveals some mistakes.
We prefix decls with `_root_` when appropriate or just delete the explicit namespace when we're already inside it, and fix related mistakes.

---

- `Analysis/InnerProductSpace/JointEigenspace`: Add a deprecation for [#39784](/leanprover-community/mathlib4/pull/39784)
- `CategoryTheory/Subobject/Classifier/Defs`: [#36060](/leanprover-community/mathlib4/pull/36060) added deprecations with a typo, `_root` instead of `_root_`. We add the correct deprecations while preserving their `since` date.
- `NumberTheory/NumberField/Completion/FinitePlace`: [#36492](/leanprover-community/mathlib4/pull/36492) added deprecations without a `_root_` prefix. We add the correct deprecations while preserving their `since` date.
- `NumberTheory/NumberField/CMField`: [#31811](/leanprover-community/mathlib4/pull/31811) added a deprecation which is missing a `_root_`, but 6 months have passed so we just delete it.
- `GroupTheory/Submonoid/Inverses`: The "submonoid" in `IsUnit.Submonoid.coe_inv` was accidentally capitalized during the port, but it's about `IsUnit.submonoid`.

There's only one place with duplication which I haven't fixed: [`CategoryTheory.Bicategory.Adj.Bicategory.associator`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Bicategory/Adjunction/Adj.html#CategoryTheory.Bicategory.Adj.Bicategory.associator) and the 4 defs below it. I think they are intentional.
IMO these mistakes are a motivation to lint against any namespace duplication, even if we have to disable the linter in a few places where a namespace is intentionally duplicated. Linter in #39793.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
