### PR TITLE
feat: fix universes of `Ordinal.lift_type_le`

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -684,7 +684,7 @@ theorem lift_id : ∀ a, lift.{u, u} a = a :=
 theorem lift_uzero (a : Ordinal.{u}) : lift.{0} a = a :=
   lift_id' a
 
-theorem lift_type_le {α : Type u} {β : Type v} {r s} [IsWellOrder α r] [IsWellOrder β s] :
+private theorem lift_type_le' {α : Type u} {β : Type v} {r s} [IsWellOrder α r] [IsWellOrder β s] :
     lift.{max v w} (type r) ≤ lift.{max u w} (type s) ↔ Nonempty (r ≼i s) := by
   constructor <;> refine fun ⟨f⟩ ↦ ⟨?_⟩
   · exact (RelIso.preimage Equiv.ulift r).symm.toInitialSeg.trans
@@ -692,14 +692,18 @@ theorem lift_type_le {α : Type u} {β : Type v} {r s} [IsWellOrder α r] [IsWel
   · exact (RelIso.preimage Equiv.ulift r).toInitialSeg.trans
       (f.trans (RelIso.preimage Equiv.ulift s).symm.toInitialSeg)
 
+theorem lift_type_le {α : Type u} {β : Type v} {r s} [IsWellOrder α r] [IsWellOrder β s] :
+    lift.{v} (type r) ≤ lift.{u} (type s) ↔ Nonempty (r ≼i s) :=
+  lift_type_le'.{u, v, 0}
+
 theorem lift_type_eq {α : Type u} {β : Type v} {r s} [IsWellOrder α r] [IsWellOrder β s] :
-    lift.{max v w} (type r) = lift.{max u w} (type s) ↔ Nonempty (r ≃r s) := by
+    lift.{v} (type r) = lift.{u} (type s) ↔ Nonempty (r ≃r s) := by
   refine Quotient.eq'.trans ⟨?_, ?_⟩ <;> refine fun ⟨f⟩ ↦ ⟨?_⟩
   · exact (RelIso.preimage Equiv.ulift r).symm.trans <| f.trans (RelIso.preimage Equiv.ulift s)
   · exact (RelIso.preimage Equiv.ulift r).trans <| f.trans (RelIso.preimage Equiv.ulift s).symm
 
 theorem lift_type_lt {α : Type u} {β : Type v} {r s} [IsWellOrder α r] [IsWellOrder β s] :
-    lift.{max v w} (type r) < lift.{max u w} (type s) ↔ Nonempty (r ≺i s) := by
+    lift.{v} (type r) < lift.{u} (type s) ↔ Nonempty (r ≺i s) := by
   constructor <;> refine fun ⟨f⟩ ↦ ⟨?_⟩
   · exact (f.relIsoTrans (RelIso.preimage Equiv.ulift r).symm).transInitial
       (RelIso.preimage Equiv.ulift s).toInitialSeg
@@ -710,7 +714,7 @@ theorem lift_type_lt {α : Type u} {β : Type v} {r s} [IsWellOrder α r] [IsWel
 theorem lift_le {a b : Ordinal} : lift.{u, v} a ≤ lift.{u, v} b ↔ a ≤ b :=
   inductionOn₂ a b fun α r _ β s _ => by
     rw [← lift_umax]
-    exact lift_type_le.{_, _, u}
+    exact lift_type_le'.{_, _, u}
 
 @[simp]
 theorem lift_inj {a b : Ordinal} : lift.{u, v} a = lift.{u, v} b ↔ a = b := by
@@ -737,8 +741,7 @@ theorem type_lt_Iio (o : Ordinal.{u}) : typeLT (Iio o) = lift.{u + 1} o := by si
 def liftInitialSeg : Ordinal.{v} ≤i Ordinal.{max u v} := by
   refine ⟨RelEmbedding.ofMonotone lift.{u} (by simp),
     fun a b ↦ Ordinal.inductionOn₂ a b fun α r _ β s _ h ↦ ?_⟩
-  rw [RelEmbedding.ofMonotone_coe, ← lift_id'.{max u v} (type s),
-    ← lift_umax.{v, u}, lift_type_lt] at h
+  rw [RelEmbedding.ofMonotone_coe, ← lift_umax, ← lift_id'.{v} (type s), lift_type_lt] at h
   obtain ⟨f⟩ := h
   use typein r f.top
   rw [RelEmbedding.ofMonotone_coe, ← lift_umax, lift_typein_top, lift_id']


### PR DESCRIPTION
The canonical way to write down a inequality between `x : Ordinal.{u}` and `y : Ordinal.{v}` is via `lift.{v} x ≤ lift.{u} y`. The extra universe `w` might make the lemma seem more general, but it ends up causing more trouble since Lean cannot infer it automatically.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
