### PR TITLE
feat: fix universes of `Cardinal.lift_mk_eq`

### DIFF
--- a/Mathlib/Algebra/FreeAlgebra/Cardinality.lean
+++ b/Mathlib/Algebra/FreeAlgebra/Cardinality.lean
@@ -36,7 +36,7 @@ theorem cardinalMk_eq_max_lift [Nonempty X] [Nontrivial R] :
 
 @[simp]
 theorem cardinalMk_eq_lift [IsEmpty X] : #(FreeAlgebra R X) = Cardinal.lift.{v} #R := by
-  have := lift_mk_eq'.2 ⟨show (FreeMonoid X →₀ R) ≃ R from Finsupp.uniqueEquiv 1⟩
+  have := lift_mk_eq.2 ⟨show (FreeMonoid X →₀ R) ≃ R from Finsupp.uniqueEquiv 1⟩
   rw [lift_id'.{u, v}, lift_umax] at this
   rwa [equivMonoidAlgebraFreeMonoid.toEquiv.cardinal_eq, MonoidAlgebra]
 

--- a/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
@@ -161,14 +161,14 @@ theorem ringEquiv_of_equiv_of_charZero [CharZero K] [CharZero L] (hK : ℵ₀ < 
   obtain ⟨s, hs⟩ := exists_isTranscendenceBasis ℤ K
   obtain ⟨t, ht⟩ := exists_isTranscendenceBasis ℤ L
   have hL : ℵ₀ < #L := by
-    rwa [← aleph0_lt_lift.{v, u}, ← lift_mk_eq'.2 hKL, aleph0_lt_lift]
+    rwa [← aleph0_lt_lift.{v, u}, ← lift_mk_eq.2 hKL, aleph0_lt_lift]
   have : Cardinal.lift.{v} #s = Cardinal.lift.{u} #t := by
     rw [← lift_injective (cardinal_eq_cardinal_transcendence_basis_of_aleph0_lt _
         hs (le_of_eq mk_int) hK),
       ← lift_injective (cardinal_eq_cardinal_transcendence_basis_of_aleph0_lt _
         ht (le_of_eq mk_int) hL)]
-    exact Cardinal.lift_mk_eq'.2 hKL
-  obtain ⟨e⟩ := Cardinal.lift_mk_eq'.1 this
+    exact Cardinal.lift_mk_eq.2 hKL
+  obtain ⟨e⟩ := Cardinal.lift_mk_eq.1 this
   exact ⟨equivOfTranscendenceBasis _ _ e hs ht⟩
 
 private theorem ringEquiv_of_Cardinal_eq_of_charP (p : ℕ) [Fact p.Prime] [CharP K p] [CharP L p]
@@ -178,14 +178,14 @@ private theorem ringEquiv_of_Cardinal_eq_of_charP (p : ℕ) [Fact p.Prime] [Char
   obtain ⟨s, hs⟩ := exists_isTranscendenceBasis (ZMod p) K
   obtain ⟨t, ht⟩ := exists_isTranscendenceBasis (ZMod p) L
   have hL : ℵ₀ < #L := by
-    rwa [← aleph0_lt_lift.{v, u}, ← lift_mk_eq'.2 hKL, aleph0_lt_lift]
+    rwa [← aleph0_lt_lift.{v, u}, ← lift_mk_eq.2 hKL, aleph0_lt_lift]
   have : Cardinal.lift.{v} #s = Cardinal.lift.{u} #t := by
     rw [← lift_injective (cardinal_eq_cardinal_transcendence_basis_of_aleph0_lt _
         hs (le_of_lt (lt_aleph0_of_finite _)) hK),
       ← lift_injective (cardinal_eq_cardinal_transcendence_basis_of_aleph0_lt _
         ht (le_of_lt (lt_aleph0_of_finite _)) hL)]
-    exact Cardinal.lift_mk_eq'.2 hKL
-  obtain ⟨e⟩ := Cardinal.lift_mk_eq'.1 this
+    exact Cardinal.lift_mk_eq.2 hKL
+  obtain ⟨e⟩ := Cardinal.lift_mk_eq.1 this
   exact ⟨equivOfTranscendenceBasis _ _ e hs ht⟩
 
 /-- Two uncountable algebraically closed fields are isomorphic

--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -382,7 +382,7 @@ theorem lift_rank_range_le (f : M →ₗ[R] M') : Cardinal.lift.{v}
     refine le_ciSup Cardinal.bddAbove_of_small ⟨rangeSplitting f '' s, ?_⟩
     apply LinearIndependent.of_comp f.rangeRestrict
     convert! li.comp (Equiv.Set.rangeSplittingImageEquiv f s) (Equiv.injective _) using 1
-  · exact (Cardinal.lift_mk_eq'.mpr ⟨Equiv.Set.rangeSplittingImageEquiv f s⟩).ge
+  · exact (Cardinal.lift_mk_eq.mpr ⟨Equiv.Set.rangeSplittingImageEquiv f s⟩).ge
 
 theorem rank_range_le (f : M →ₗ[R] M₁) : Module.rank R (LinearMap.range f) ≤ Module.rank R M := by
   simpa using lift_rank_range_le f

--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -132,7 +132,7 @@ whenever `#R < #M`. -/
 lemma rank_eq_mk_of_infinite_lt [Infinite R] (h_lt : lift.{v} #R < lift.{u} #M) :
     Module.rank R M = #M := by
   have : Infinite M := infinite_iff.mpr <| lift_le.mp <| le_trans (by simp) h_lt.le
-  have h : lift #M = lift #(ChooseBasisIndex R M →₀ R) := lift_mk_eq'.mpr ⟨(chooseBasis R M).repr⟩
+  have h : lift #M = lift #(ChooseBasisIndex R M →₀ R) := lift_mk_eq.mpr ⟨(chooseBasis R M).repr⟩
   simp only [mk_finsupp_lift_of_infinite', ← rank_eq_card_chooseBasisIndex, lift_max,
     lift_lift] at h
   refine lift_inj.mp ((max_eq_iff.mp h.symm).resolve_right <| not_and_of_not_left _ ?_).left

--- a/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
@@ -216,7 +216,7 @@ theorem lift_cardinalMk_eq_lift_cardinalMk_field_pow_lift_rank [Module.Free K V]
   haveI : Finite s := by
     obtain ⟨t, ht⟩ := ‹Module.Finite K V›
     exact basis_finite_of_finite_spans t.finite_toSet ht hs
-  have := lift_mk_eq'.2 ⟨hs.repr.toEquiv⟩
+  have := lift_mk_eq.2 ⟨hs.repr.toEquiv⟩
   rwa [Finsupp.equivFunOnFinite.cardinal_eq, mk_arrow, hs.mk_eq_rank'', lift_power, lift_lift,
     lift_lift, lift_umax] at this
 

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -95,7 +95,7 @@ theorem mk_eq_mk_of_basis (v : Basis ι R M) (v' : Basis ι' R M) :
 /-- Given two bases indexed by `ι` and `ι'` of an `R`-module, where `R` satisfies the invariant
 basis number property, an equiv `ι ≃ ι'`. -/
 def Module.Basis.indexEquiv (v : Basis ι R M) (v' : Basis ι' R M) : ι ≃ ι' :=
-  (Cardinal.lift_mk_eq'.1 <| mk_eq_mk_of_basis v v').some
+  (Cardinal.lift_mk_eq.1 <| mk_eq_mk_of_basis v v').some
 
 theorem mk_eq_mk_of_basis' {ι' : Type w} (v : Basis ι R M) (v' : Basis ι' R M) : #ι = #ι' :=
   Cardinal.lift_inj.1 <| mk_eq_mk_of_basis v v'

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -786,7 +786,7 @@ theorem empty.nonempty_embedding_iff :
 theorem empty.nonempty_equiv_iff :
     Nonempty (M ≃[Language.empty] N) ↔ Cardinal.lift.{w'} #M = Cardinal.lift.{w} #N :=
   _root_.trans ⟨Nonempty.map fun f => f.toEquiv, Nonempty.map fun f => { toEquiv := f }⟩
-    Cardinal.lift_mk_eq'.symm
+    Cardinal.lift_mk_eq.symm
 
 /-- Makes a `Language.empty.Hom` out of any function.
 This is only needed because there is no instance of `FunLike (M → N) M N`, and thus no instance of

--- a/Mathlib/RingTheory/AlgebraicIndependent/Basic.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/Basic.lean
@@ -323,7 +323,7 @@ open Cardinal
 
 theorem AlgebraicIndependent.lift_cardinalMk_le_trdeg [Nontrivial R]
     (hx : AlgebraicIndependent R x) : lift.{v} #ι ≤ lift.{u} (trdeg R A) := by
-  rw [lift_mk_eq'.mpr ⟨.ofInjective _ hx.injective⟩, lift_le]
+  rw [lift_mk_eq.mpr ⟨.ofInjective _ hx.injective⟩, lift_le]
   exact le_ciSup_of_le bddAbove_of_small ⟨_, hx.to_subtype_range⟩ le_rfl
 
 theorem AlgebraicIndependent.cardinalMk_le_trdeg [Nontrivial R] {ι : Type v} {x : ι → A}

--- a/Mathlib/RingTheory/AlgebraicIndependent/RankAndCardinality.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/RankAndCardinality.lean
@@ -43,7 +43,7 @@ theorem IsTranscendenceBasis.lift_cardinalMk_eq_max_lift
     {ι : Type w} {x : ι → E} [Nonempty ι] (hx : IsTranscendenceBasis F x) :
     lift.{max u w} #E = lift.{max v w} #F ⊔ lift.{max u v} #ι ⊔ ℵ₀ := by
   let K := Algebra.adjoin F (Set.range x)
-  suffices #E = #K by simp [K, this, ← lift_mk_eq'.2 ⟨hx.1.aevalEquiv.toEquiv⟩]
+  suffices #E = #K by simp [K, this, ← lift_mk_eq.2 ⟨hx.1.aevalEquiv.toEquiv⟩]
   haveI : Algebra.IsAlgebraic K E := hx.isAlgebraic
   refine le_antisymm ?_ (mk_le_of_injective Subtype.val_injective)
   haveI : Infinite K := hx.1.aevalEquiv.infinite_iff.1 inferInstance
@@ -59,7 +59,7 @@ theorem IsTranscendenceBasis.lift_rank_eq_max_lift
     MvRatFunc.rank_eq_max_lift, lift_max, lift_max, lift_lift, lift_lift, lift_aleph0]
   refine mul_eq_left le_sup_right ((lift_le.2 ((rank_le_card K E).trans
     (Algebra.IsAlgebraic.cardinalMk_le_max K E))).trans_eq ?_) (by simp [rank_pos.ne'])
-  simp [K, ← lift_mk_eq'.2 ⟨hx.1.aevalEquivField.toEquiv⟩]
+  simp [K, ← lift_mk_eq.2 ⟨hx.1.aevalEquivField.toEquiv⟩]
 
 theorem Algebra.Transcendental.rank_eq_cardinalMk
     (F : Type u) (E : Type v) [Field F] [Field E] [Algebra F E] [Algebra.Transcendental F E] :

--- a/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
@@ -419,7 +419,7 @@ theorem lift_cardinalMk_eq_trdeg (hx : IsTranscendenceBasis R x) :
     lift.{w} #ι = lift.{u} (trdeg R A) := by
   have := (faithfulSMul_iff_algebraMap_injective R A).mpr hx.1.algebraMap_injective
   rw [← matroid_cRank_eq, ← (matroid_isBase_iff.mpr hx.to_subtype_range).cardinalMk_eq_cRank,
-    lift_mk_eq'.mpr ⟨.ofInjective _ hx.1.injective⟩]
+    lift_mk_eq.mpr ⟨.ofInjective _ hx.1.injective⟩]
 
 theorem cardinalMk_eq_trdeg {ι : Type w} {x : ι → A} (hx : IsTranscendenceBasis R x) :
     #ι = trdeg R A := by

--- a/Mathlib/RingTheory/Localization/Cardinality.lean
+++ b/Mathlib/RingTheory/Localization/Cardinality.lean
@@ -41,7 +41,7 @@ namespace IsLocalization
 theorem lift_cardinalMk_le (S : Submonoid R) [IsLocalization S L] :
     Cardinal.lift.{u} #L ≤ Cardinal.lift.{v} #R := by
   have := Localization.cardinalMk_le S
-  rwa [← lift_le.{v}, lift_mk_eq'.2 ⟨(Localization.algEquiv S L).toEquiv⟩] at this
+  rwa [← lift_le.{v}, lift_mk_eq.2 ⟨(Localization.algEquiv S L).toEquiv⟩] at this
 
 /-- A localization always has cardinality less than or equal to the base ring. -/
 theorem cardinalMk_le {L : Type u} [CommSemiring L] [Algebra R L]
@@ -71,7 +71,7 @@ variable (L)
 theorem lift_cardinalMk (S : Submonoid R) [IsLocalization S L] (hS : S ≤ R⁰) :
     Cardinal.lift.{u} #L = Cardinal.lift.{v} #R := by
   have := Localization.cardinalMk hS
-  rwa [← lift_inj.{u, v}, lift_mk_eq'.2 ⟨(Localization.algEquiv S L).toEquiv⟩] at this
+  rwa [← lift_inj.{u, v}, lift_mk_eq.2 ⟨(Localization.algEquiv S L).toEquiv⟩] at this
 
 /-- If you do not localize at any zero-divisors, localization preserves cardinality. -/
 theorem cardinalMk (L : Type u) [CommRing L] [Algebra R L]

--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -617,7 +617,7 @@ section Function
 variable {α β : Type u} {β' : Type v}
 
 theorem mk_equiv_eq_zero_iff_lift_ne : #(α ≃ β') = 0 ↔ lift.{v} #α ≠ lift.{u} #β' := by
-  rw [mk_eq_zero_iff, ← not_nonempty_iff, ← lift_mk_eq']
+  rw [mk_eq_zero_iff, ← not_nonempty_iff, ← lift_mk_eq]
 
 theorem mk_equiv_eq_zero_iff_ne : #(α ≃ β) = 0 ↔ #α ≠ #β := by
   rw [mk_equiv_eq_zero_iff_lift_ne, lift_id, lift_id]
@@ -671,9 +671,9 @@ theorem mk_perm_eq_two_power : #(Equiv.Perm α) = 2 ^ #α := by
 
 theorem mk_equiv_eq_arrow_of_lift_eq (leq : lift.{v} #α = lift.{u} #β') :
     #(α ≃ β') = #(α → β') := by
-  obtain ⟨e⟩ := lift_mk_eq'.mp leq
-  have e₁ := lift_mk_eq'.mpr ⟨.equivCongr (.refl α) e⟩
-  have e₂ := lift_mk_eq'.mpr ⟨.arrowCongr (.refl α) e⟩
+  obtain ⟨e⟩ := lift_mk_eq.mp leq
+  have e₁ := lift_mk_eq.mpr ⟨.equivCongr (.refl α) e⟩
+  have e₂ := lift_mk_eq.mpr ⟨.arrowCongr (.refl α) e⟩
   rw [lift_id'.{u, v}] at e₁ e₂
   rw [← e₁, ← e₂, lift_inj, mk_perm_eq_self_power, power_def]
 
@@ -702,7 +702,7 @@ theorem mk_surjective_eq_arrow_of_lift_le (lle : lift.{u} #β' ≤ lift.{v} #α)
     #{f : α → β' | Surjective f} = #(α → β') :=
   (mk_set_le _).antisymm <|
     have ⟨e⟩ : Nonempty (α ≃ α ⊕ β') := by
-      simp_rw [← lift_mk_eq', mk_sum, lift_add, lift_lift]; rw [lift_umax.{u, v}, eq_comm]
+      simp_rw [← lift_mk_eq, mk_sum, lift_add, lift_lift]; rw [lift_umax.{u, v}, eq_comm]
       exact add_eq_left (aleph0_le_lift.mpr <| aleph0_le_mk α) lle
     ⟨⟨fun f ↦ ⟨fun a ↦ (e a).elim f id, fun b ↦ ⟨e.symm (.inr b), congr_arg _ (e.right_inv _)⟩⟩,
       fun f g h ↦ funext fun a ↦ by
@@ -840,7 +840,7 @@ theorem mk_compl_eq_mk_compl_finite_lift {α : Type u} {β : Type v} [Finite α]
     (h2 : lift.{v, u} #s = lift.{u, v} #t) :
     lift.{v} #(sᶜ : Set α) = lift.{u} #(tᶜ : Set β) := by
   cases nonempty_fintype α
-  rcases lift_mk_eq'.1 h1 with ⟨e⟩; letI : Fintype β := Fintype.ofEquiv α e
+  rcases lift_mk_eq.1 h1 with ⟨e⟩; letI : Fintype β := Fintype.ofEquiv α e
   replace h1 : Fintype.card α = Fintype.card β := (Fintype.ofEquiv_card _).symm
   classical
     lift s to Finset α using s.toFinite
@@ -876,8 +876,8 @@ theorem extend_function {α β : Type*} {s : Set α} (f : s ↪ β)
 theorem extend_function_finite {α : Type u} {β : Type v} [Finite α] {s : Set α} (f : s ↪ β)
     (h : Nonempty (α ≃ β)) : ∃ g : α ≃ β, ∀ x : s, g x = f x := by
   apply extend_function.{u, v} f
-  rw [← lift_mk_eq'] at h
-  rw [← lift_mk_eq', mk_compl_eq_mk_compl_finite_lift h]
+  rw [← lift_mk_eq] at h
+  rw [← lift_mk_eq, mk_compl_eq_mk_compl_finite_lift h]
   rw [mk_range_eq_of_injective]; exact f.2
 
 theorem extend_function_of_lt {α β : Type*} {s : Set α} (f : s ↪ β) (hs : #s < #α)
@@ -887,7 +887,7 @@ theorem extend_function_of_lt {α β : Type*} {s : Set α} (f : s ↪ β) (hs : 
   · apply extend_function f
     obtain ⟨g⟩ := id h
     haveI := Infinite.of_injective _ g.injective
-    rw [← lift_mk_eq'] at h ⊢
+    rw [← lift_mk_eq] at h ⊢
     rwa [mk_compl_of_infinite s hs, mk_compl_of_infinite]
     rwa [← lift_lt, mk_range_eq_of_injective f.injective, ← h, lift_lt]
 

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -418,7 +418,7 @@ theorem range_natCast : range ((↑) : ℕ → Cardinal) = Iio ℵ₀ :=
   ext fun x => by simp only [mem_Iio, mem_range, eq_comm, lt_aleph0]
 
 theorem mk_eq_nat_iff {α : Type u} {n : ℕ} : #α = n ↔ Nonempty (α ≃ Fin n) := by
-  rw [← lift_mk_fin, ← lift_uzero #α, lift_mk_eq']
+  rw [← lift_mk_fin, ← lift_uzero #α, lift_mk_eq]
 
 theorem lt_aleph0_iff_finite {α : Type u} : #α < ℵ₀ ↔ Finite α := by
   simp only [lt_aleph0, mk_eq_nat_iff, finite_iff_exists_equiv_fin]
@@ -699,7 +699,7 @@ theorem mk_range_eq (f : α → β) (h : Injective f) : #(range f) = #α :=
 
 theorem mk_range_eq_of_injective {α : Type u} {β : Type v} {f : α → β} (hf : Injective f) :
     lift.{u} #(range f) = lift.{v} #α :=
-  lift_mk_eq'.mpr ⟨(Equiv.ofInjective f hf).symm⟩
+  lift_mk_eq.mpr ⟨(Equiv.ofInjective f hf).symm⟩
 
 @[deprecated mk_range_eq_of_injective (since := "2026-01-06")]
 theorem mk_range_eq_lift {α : Type u} {β : Type v} {f : α → β} (hf : Injective f) :

--- a/Mathlib/SetTheory/Cardinal/Defs.lean
+++ b/Mathlib/SetTheory/Cardinal/Defs.lean
@@ -182,21 +182,23 @@ theorem out_lift_equiv (a : Cardinal.{u}) : Nonempty ((lift.{v} a).out ≃ a.out
   rw [← mk_out a, ← mk_uLift, mk_out]
   exact ⟨outMkEquiv.trans Equiv.ulift⟩
 
-theorem lift_mk_eq {α : Type u} {β : Type v} :
+-- TODO: remove the second prime once `lift_mk_eq'` is deprecated
+private theorem lift_mk_eq'' {α : Type u} {β : Type v} :
     lift.{max v w} #α = lift.{max u w} #β ↔ Nonempty (α ≃ β) :=
   Quotient.eq'.trans
     ⟨fun ⟨f⟩ => ⟨Equiv.ulift.symm.trans <| f.trans Equiv.ulift⟩, fun ⟨f⟩ =>
       ⟨Equiv.ulift.trans <| f.trans Equiv.ulift.symm⟩⟩
 
-/-- A variant of `Cardinal.lift_mk_eq` with specialized universes.
-Because Lean often cannot realize it should use this specialization itself,
-we provide this statement separately so you don't have to solve the specialization problem either.
--/
-theorem lift_mk_eq' {α : Type u} {β : Type v} : lift.{v} #α = lift.{u} #β ↔ Nonempty (α ≃ β) :=
-  lift_mk_eq.{u, v, 0}
+theorem lift_mk_eq {α : Type u} {β : Type v} : lift.{v} #α = lift.{u} #β ↔ Nonempty (α ≃ β) :=
+  lift_mk_eq''.{u, v, 0}
+
+@[deprecated lift_mk_eq (since := "2026-05-24")]
+theorem lift_mk_eq' {α : Type u} {β : Type v} :
+    lift.{max v w} #α = lift.{max u w} #β ↔ Nonempty (α ≃ β) :=
+  lift_mk_eq''
 
 theorem mk_congr_lift {α : Type u} {β : Type v} (e : α ≃ β) : lift.{v} #α = lift.{u} #β :=
-  lift_mk_eq'.2 ⟨e⟩
+  lift_mk_eq.2 ⟨e⟩
 
 alias _root_.Equiv.lift_cardinal_eq := mk_congr_lift
 
@@ -341,7 +343,7 @@ theorem mk_sigma {ι} (f : ι → Type*) : #(Σ i, f i) = sum fun i => #(f i) :=
 theorem mk_sigma_congr_lift {ι : Type v} {ι' : Type v'} {f : ι → Type w} {g : ι' → Type w'}
     (e : ι ≃ ι') (h : ∀ i, lift.{w'} #(f i) = lift.{w} #(g (e i))) :
     lift.{max v' w'} #(Σ i, f i) = lift.{max v w} #(Σ i, g i) :=
-  Cardinal.lift_mk_eq'.2 ⟨.sigmaCongr e fun i ↦ Classical.choice <| Cardinal.lift_mk_eq'.1 (h i)⟩
+  Cardinal.lift_mk_eq.2 ⟨.sigmaCongr e fun i ↦ Classical.choice <| Cardinal.lift_mk_eq.1 (h i)⟩
 
 theorem mk_sigma_congr {ι ι' : Type u} {f : ι → Type v} {g : ι' → Type v} (e : ι ≃ ι')
     (h : ∀ i, #(f i) = #(g (e i))) : #(Σ i, f i) = #(Σ i, g i) :=
@@ -383,11 +385,8 @@ theorem sum_const' (ι : Type u) (a : Cardinal.{u}) : (sum fun _ : ι => a) = #�
 @[simp]
 theorem lift_sum {ι : Type u} (f : ι → Cardinal.{v}) :
     Cardinal.lift.{w} (Cardinal.sum f) = Cardinal.sum fun i => Cardinal.lift.{w} (f i) :=
-  Equiv.cardinal_eq <|
-    Equiv.ulift.trans <|
-      Equiv.sigmaCongrRight fun a =>
-    -- Porting note: Inserted universe hint .{_,_,v} below
-        Nonempty.some <| by rw [← lift_mk_eq.{_, _, v}, mk_out, mk_out, lift_lift]
+  Equiv.cardinal_eq <| Equiv.ulift.trans <| .sigmaCongrRight fun a ↦
+    Nonempty.some <| by rw [← lift_mk_eq, mk_out, mk_out, lift_lift]
 
 theorem sum_nat_eq_add_sum_succ (f : ℕ → Cardinal.{u}) :
     Cardinal.sum f = f 0 + Cardinal.sum fun i => f (i + 1) := by
@@ -408,7 +407,7 @@ theorem mk_pi {ι : Type u} (α : ι → Type v) : #(Π i, α i) = prod fun i =>
 theorem mk_pi_congr_lift {ι : Type v} {ι' : Type v'} {f : ι → Type w} {g : ι' → Type w'}
     (e : ι ≃ ι') (h : ∀ i, lift.{w'} #(f i) = lift.{w} #(g (e i))) :
     lift.{max v' w'} #(Π i, f i) = lift.{max v w} #(Π i, g i) :=
-  Cardinal.lift_mk_eq'.2 ⟨.piCongr e fun i ↦ Classical.choice <| Cardinal.lift_mk_eq'.1 (h i)⟩
+  Cardinal.lift_mk_eq.2 ⟨.piCongr e fun i ↦ Classical.choice <| Cardinal.lift_mk_eq.1 (h i)⟩
 
 theorem mk_pi_congr {ι ι' : Type u} {f : ι → Type v} {g : ι' → Type v} (e : ι ≃ ι')
     (h : ∀ i, #(f i) = #(g (e i))) : #(Π i, f i) = #(Π i, g i) :=


### PR DESCRIPTION
The canonical way to write down a inequality between x : Cardinal.{u} and y : Cardinal.{v} is via lift.{v} x ≤ lift.{u} y. The extra universe w might make the lemma seem more general, but it ends up causing more trouble since Lean cannot infer it automatically.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
