### PR TITLE
chore(Data): refactor proofs where `grind?` fails

### DIFF
--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -195,15 +195,19 @@ theorem ofNat_le_ofNat {n m : Nat} (h : n ≤ m) : ofNat n ≤ ofNat m := by
 theorem toNat_le_toNat {b₀ b₁ : Bool} (h : b₀ ≤ b₁) : toNat b₀ ≤ toNat b₁ := by
   cases b₀ <;> cases b₁ <;> simp_all +decide
 
-theorem ofNat_toNat (b : Bool) : ofNat (toNat b) = b := by grind [cases Bool]
+set_option linter.tacticAnalysis.verifyGrindOnly false in
+theorem ofNat_toNat (b : Bool) : ofNat (toNat b) = b := by
+  grind only [cases Bool, = ofNat_zero, = toNat_true, = toNat_false, = ofNat_add_one]
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 @[simp]
 theorem injective_iff {α : Sort*} {f : Bool → α} : Function.Injective f ↔ f false ≠ f true :=
-  ⟨fun Hinj Heq ↦ false_ne_true (Hinj Heq), fun H x y ↦ by grind [cases Bool]⟩
+  ⟨fun Hinj Heq ↦ false_ne_true (Hinj Heq), fun H x y ↦ by grind only [cases Bool]⟩
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 /-- **Kaminski's Equation** -/
 theorem apply_apply_apply (f : Bool → Bool) (x : Bool) : f (f (f x)) = f x := by
-  cases h₁ : f true <;> cases h₂ : f false <;> grind [cases Bool]
+  cases h₁ : f true <;> cases h₂ : f false <;> grind only [cases Bool]
 
 /-- `xor3 x y c` is `((x XOR y) XOR c)`. -/
 protected def xor3 (x y c : Bool) :=

--- a/Mathlib/Data/Bool/Set.lean
+++ b/Mathlib/Data/Bool/Set.lean
@@ -23,10 +23,14 @@ namespace Bool
 @[simp]
 theorem univ_eq : (univ : Set Bool) = {false, true} := by grind
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 @[simp, grind =]
-theorem range_eq {α : Type*} (f : Bool → α) : range f = {f false, f true} := by grind [cases Bool]
+theorem range_eq {α : Type*} (f : Bool → α) : range f = {f false, f true} := by
+  grind only [cases Bool, = mem_insert_iff, = mem_range, = mem_singleton_iff]
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 @[simp, grind =]
-theorem compl_singleton (b : Bool) : ({b}ᶜ : Set Bool) = {!b} := by grind [cases Bool]
+theorem compl_singleton (b : Bool) : ({b}ᶜ : Set Bool) = {!b} := by
+  grind only [cases Bool, = mem_singleton_iff, = mem_compl_iff]
 
 end Bool

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -719,7 +719,7 @@ lemma mul_nonpos_iff {a b : EReal} : a * b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a �
 lemma mul_eq_top (a b : EReal) :
     a * b = ⊤ ↔ (a = ⊥ ∧ b < 0) ∨ (a < 0 ∧ b = ⊥) ∨ (a = ⊤ ∧ 0 < b) ∨ (0 < a ∧ b = ⊤) := by
   induction a, b using EReal.induction₂_symm with
-  | symm h => grind [EReal.mul_comm]
+  | symm h => rw [EReal.mul_comm]; grind
   | top_top => simp
   | top_pos _ hx => simp [EReal.top_mul_coe_of_pos hx, hx]
   | top_zero => simp

--- a/Mathlib/Data/Fin/Tuple/NatAntidiagonal.lean
+++ b/Mathlib/Data/Fin/Tuple/NatAntidiagonal.lean
@@ -154,9 +154,7 @@ theorem antidiagonalTuple_pairwise_pi_lex :
     | zero =>
       rw [antidiagonal_zero]
       exact List.pairwise_singleton _ _
-    | succ n n_ih =>
-      simp
-      grind
+    | succ => grind [antidiagonal_succ, List.pairwise_cons]
 
 end List.Nat
 

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -312,10 +312,10 @@ theorem image_congr (h : (s : Set α).EqOn f g) : Finset.image f s = Finset.imag
   simp_rw [mem_image, ← bex_def]
   exact exists₂_congr fun x hx => by rw [h hx]
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 theorem _root_.Function.Injective.mem_finset_image (hf : Injective f) :
     f a ∈ s.image f ↔ a ∈ s := by
-  grind
-
+  grind only [= mem_image]
 
 @[simp, norm_cast]
 theorem coe_image : ↑(s.image f) = f '' ↑s :=

--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -75,8 +75,9 @@ theorem powerset_eq_singleton_empty : s.powerset = {∅} ↔ s = ∅ := by
 
 theorem image_injOn_powerset_of_injOn {β : Type*} [DecidableEq β] {f : α → β} (H : Set.InjOn f s) :
     Set.InjOn (α := Finset α) (·.image f) s.powerset := by
-  have {z a} (_ : z ⊆ s) (_ : a ∈ s) : a ∈ z ↔ f a ∈ z.image f := by grind [H.eq_iff]
-  exact fun _ _ _ _ _ => by grind
+  have {z a} (h₁ : z ⊆ s) (h₂ : a ∈ s) : a ∈ z ↔ f a ∈ z.image f :=
+    ⟨mem_image_of_mem f, by grind [Set.InjOn]⟩
+  grind [Set.InjOn]
 
 /-- `s.biUnion id ⊆ t` iff every member of `s` is a subset of `t`, i.e. `s ⊆ t.powerset`. -/
 lemma biUnion_id_subset_iff_subset_powerset [DecidableEq α] {s : Finset (Finset α)} :

--- a/Mathlib/Data/Finset/Range.lean
+++ b/Mathlib/Data/Finset/Range.lean
@@ -110,7 +110,8 @@ protected alias ⟨_, Aesop.range_nonempty⟩ := nonempty_range_iff
 
 @[simp]
 theorem range_eq_empty_iff : range n = ∅ ↔ n = 0 := by
-  grind [nonempty_range_iff]
+  have := @nonempty_range_iff
+  grind
 
 @[aesop safe apply (rule_sets := [finsetNonempty])]
 theorem nonempty_range_add_one : (range <| n + 1).Nonempty :=

--- a/Mathlib/Data/Finset/SMulAntidiagonal.lean
+++ b/Mathlib/Data/Finset/SMulAntidiagonal.lean
@@ -93,6 +93,7 @@ theorem smulAntidiagonal_mono_right {s : Set G}
 theorem support_smulAntidiagonal_subset_smul {s : Set G}
     {t : Set P} (hst : ∀ a, (s.smulAntidiagonal t a).Finite) :
     { a | (SMulAntidiagonal a (hst a)).Nonempty } ⊆ (s • t) := by
+  rintro _ ⟨_, _⟩
   grind [mem_smul, mem_smulAntidiagonal]
 
 variable [PartialOrder G] [PartialOrder P] [IsOrderedCancelSMul G P] {s : Set G}

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -97,7 +97,7 @@ theorem exists_of_length_succ {n} : ∀ l : List α, l.length = n + 1 → ∃ h 
 
 theorem length_eq_succ_iff {n} {l : List α} :
     l.length = n + 1 ↔ ∃ h t, h :: t = l ∧ t.length = n := by
-  grind [cases List]
+  cases l <;> grind
 
 @[simp] lemma length_injective_iff : Injective (List.length : List α → ℕ) ↔ Subsingleton α := by
   constructor

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -150,10 +150,14 @@ theorem isChain_cons_map_of_isChain_cons {S : β → β → Prop} (f : α → β
     {l : List α} (p : IsChain R (a :: l)) : IsChain S (f a :: map f l) :=
   (isChain_cons_map f).2 <| p.imp H
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 theorem isChain_pmap {S : β → β → Prop} {p : α → Prop} (f : ∀ a, p a → β) {l : List α}
     (hl : ∀ a ∈ l, p a) : IsChain S (pmap f l hl) ↔
     IsChain (fun a b => ∃ ha, ∃ hb, S (f a ha) (f b hb)) l := by
-  induction l using twoStepInduction <;> grind
+  induction l using twoStepInduction
+  · grind
+  · grind
+  · grind only [= isChain_cons_cons, = pmap_cons]
 
 theorem isChain_pmap_of_isChain {S : β → β → Prop} {p : α → Prop} {f : ∀ a, p a → β}
     (H : ∀ a b ha hb, R a b → S (f a ha) (f b hb)) {l : List α} (hl₁ : IsChain R l)
@@ -170,10 +174,11 @@ theorem isChain_cons_pmap {p : β → Prop} (f : ∀ b, p b → α) {l : List β
     IsChain (fun a b => ∃ ha, ∃ hb, R (f a ha) (f b hb)) (a :: l) :=
   isChain_pmap (l := a :: _) f (by grind)
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 theorem isChain_cons_pmap_of_isChain_cons {S : β → β → Prop} {p : α → Prop} {f : ∀ a, p a → β}
     (H : ∀ a b ha hb, R a b → S (f a ha) (f b hb)) {l : List α} {a} (ha)
     (hl₁ : IsChain R (a :: l)) (hl₂ : ∀ a ∈ l, p a) : IsChain S (f a ha :: pmap f l hl₂) :=
-    (isChain_cons_pmap f _ _).2 <| hl₁.imp_of_mem_imp (by grind)
+    (isChain_cons_pmap f _ _).2 <| hl₁.imp_of_mem_imp (by grind only [= mem_cons])
 
 theorem isChain_cons_of_isChain_cons_pmap {S : β → β → Prop} {p : α → Prop} (f : ∀ a, p a → β)
     {l : List α} (hl₁ : ∀ a ∈ l, p a) {a} (ha) (hl₂ : IsChain S (f a ha :: pmap f l hl₁))

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -38,7 +38,7 @@ theorem count_lt_length_iff {a : α} : l.count a < l.length ↔ ∃ b ∈ l, b �
 
 lemma countP_erase (p : α → Bool) (l : List α) (a : α) :
     countP p (l.erase a) = countP p l - if a ∈ l ∧ p a then 1 else 0 := by
-  grind [countP_eq_length_filter]
+  grind [= countP_eq_length_filter]
 
 lemma count_diff (a : α) (l₁ : List α) :
     ∀ l₂, count a (l₁.diff l₂) = count a l₁ - count a l₂

--- a/Mathlib/Data/List/Cycle.lean
+++ b/Mathlib/Data/List/Cycle.lean
@@ -286,7 +286,7 @@ theorem next_eq_getElem {l : List α} {a : α} (ha : a ∈ l) :
   by_cases ha' : a ∈ l.dropLast
   · simp [next, nextOr_eq_getElem_idxOf_succ_of_mem_dropLast ha',
       Nat.mod_eq_of_lt <| succ_idxOf_lt_length_of_mem_dropLast ha']
-  grind [dropLast_append_getLast, next_getLast_eq_head_of_notMem_dropLast, Nat.mod_self]
+  grind [dropLast_append_getLast hl, next_getLast_eq_head_of_notMem_dropLast, Nat.mod_self]
 
 theorem next_getElem (l : List α) (h : Nodup l) (i : Nat) (hi : i < l.length) :
     l.next l[i] (get_mem ..) = l[(i + 1) % l.length]'(Nat.mod_lt _ (i.zero_le.trans_lt hi)) := by

--- a/Mathlib/Data/List/Induction.lean
+++ b/Mathlib/Data/List/Induction.lean
@@ -38,7 +38,7 @@ theorem reverseRec_concat {motive : List α → Sort*} (x : α) (xs : List α) (
     (append_singleton : ∀ (l : List α) (a : α), motive l → motive (l ++ [a])) :
     (xs ++ [x]).reverseRec nil append_singleton =
     append_singleton xs x (xs.reverseRec nil append_singleton) := by
-  grind [reverseRec, cases List]
+  cases xs <;> grind [reverseRec]
 
 /-- Like `reverseRec`, but with the list parameter placed first. -/
 @[elab_as_elim]
@@ -92,7 +92,7 @@ theorem bidirectionalRec_cons_append {motive : List α → Sort*}
     (a : α) (l : List α) (b : α) :
     bidirectionalRec nil singleton cons_append (a :: (l ++ [b])) =
       cons_append a l b (bidirectionalRec nil singleton cons_append l) := by
-  grind [bidirectionalRec, cases List]
+  cases l <;> grind [bidirectionalRec]
 
 /-- Like `bidirectionalRec`, but with the list parameter placed first. -/
 @[elab_as_elim]

--- a/Mathlib/Data/List/ReduceOption.lean
+++ b/Mathlib/Data/List/ReduceOption.lean
@@ -118,9 +118,9 @@ theorem reduceOption_length_lt_iff {l : List (Option α)} :
     l.reduceOption.length < l.length ↔ none ∈ l := by
   rw [Nat.lt_iff_le_and_ne, and_iff_right (reduceOption_length_le l), Ne,
     reduceOption_length_eq_iff]
-  induction l
-  · simp
-  · grind [cases Option]
+  induction l with
+  | nil => grind
+  | cons hd => cases hd with grind
 
 theorem reduceOption_singleton (x : Option α) : [x].reduceOption = x.toList := by cases x <;> rfl
 

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -71,8 +71,8 @@ theorem exists_of_mem_keys {a} {l : List (Sigma β)} (h : a ∈ l.keys) :
 theorem mem_keys {a} {l : List (Sigma β)} : a ∈ l.keys ↔ ∃ b : β a, Sigma.mk a b ∈ l :=
   ⟨exists_of_mem_keys, fun ⟨_, h⟩ => mem_keys_of_mem h⟩
 
-theorem notMem_keys {a} {l : List (Sigma β)} : a ∉ l.keys ↔ ∀ b : β a, Sigma.mk a b ∉ l := by
-  grind
+theorem notMem_keys {a} {l : List (Sigma β)} : a ∉ l.keys ↔ ∀ b : β a, Sigma.mk a b ∉ l :=
+  ⟨by grind, by grind⟩
 
 theorem ne_key {a} {l : List (Sigma β)} : a ∉ l.keys ↔ ∀ s : Sigma β, s ∈ l → a ≠ s.1 := by
   grind

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -159,7 +159,7 @@ theorem Pairwise.insertionSort_eq {l : List α} : Pairwise r l → insertionSort
 /-- For a reflexive relation, insert then erasing is the identity. -/
 theorem erase_orderedInsert [DecidableEq α] [Std.Refl r] (x : α) (xs : List α) :
     (xs.orderedInsert r x).erase x = xs := by
-  induction xs with 
+  induction xs with
   | nil => grind
   | cons hd => grind [refl (r := r) hd]
 

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -152,12 +152,16 @@ variable {r}
 /-- If `l` is already `List.Pairwise` with respect to `r`, then `insertionSort` does not change
 it. -/
 theorem Pairwise.insertionSort_eq {l : List α} : Pairwise r l → insertionSort r l = l := by
-  induction l <;> grind [cases List]
+  induction l with
+  | nil => grind
+  | cons _ tl => cases tl <;> grind
 
 /-- For a reflexive relation, insert then erasing is the identity. -/
 theorem erase_orderedInsert [DecidableEq α] [Std.Refl r] (x : α) (xs : List α) :
     (xs.orderedInsert r x).erase x = xs := by
-  induction xs <;> grind [Std.Refl]
+  induction xs with 
+  | nil => grind
+  | cons hd => grind [refl (r := r) hd]
 
 /-- Inserting then erasing an element that is absent is the identity. -/
 theorem erase_orderedInsert_of_notMem [DecidableEq α]

--- a/Mathlib/Data/List/TakeDrop.lean
+++ b/Mathlib/Data/List/TakeDrop.lean
@@ -94,11 +94,12 @@ variable (l : List α) (n : ℕ)
 
 theorem tail_take_eq_take_tail : (l.take n).tail = l.tail.take (n - 1) := by
   ext
-  grind
+  grind only [= getElem?_neg, = getElem?_pos, = length_take, = length_tail, = Nat.min_def,
+    = getElem_tail, = getElem_take]
 
 theorem dropLast_take_eq_take_dropLast : (l.take n).dropLast = l.dropLast.take (n - 1) := by
   ext
-  grind
+  grind only [= getElem?_take, = getElem?_dropLast, = length_take, = Nat.min_def]
 
 theorem tail_drop_eq_drop_tail : (l.drop n).tail = l.tail.drop n := by
   ext

--- a/Mathlib/Data/List/Triplewise.lean
+++ b/Mathlib/Data/List/Triplewise.lean
@@ -36,7 +36,8 @@ variable {a b c : α} {l l₁ l₂ : List α} {p q : α → α → α → Prop} 
 
 @[grind =]
 lemma triplewise_cons : (a :: l).Triplewise p ↔ l.Pairwise (p a) ∧ l.Triplewise p := by
-  grind [triplewise_iff]
+  rw [triplewise_iff]
+  grind
 
 variable (a b p)
 

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -123,26 +123,26 @@ theorem mem_pmem {a : α} (h : ∀ a ∈ x, p a) (ha : a ∈ x) : f a (h a ha) �
 theorem pmap_bind {α β γ} {x : Option α} {g : α → Option β} {p : β → Prop} {f : ∀ b, p b → γ} (H)
     (H' : ∀ (a : α), ∀ b ∈ g a, b ∈ x >>= g) :
     pmap f (x >>= g) H = x >>= fun a ↦ pmap f (g a) fun _ h ↦ H _ (H' a _ h) := by
-  grind [cases Option]
+  cases x <;> grind
 
 theorem bind_pmap {α β γ} {p : α → Prop} (f : ∀ a, p a → β) (x : Option α) (g : β → Option γ) (H) :
     pmap f x H >>= g = x.pbind fun a h ↦ g (f a (H _ h)) := by
-  grind [cases Option, pmap]
+  cases x <;> grind
 
 variable {f x}
 
 theorem pbind_eq_none {f : ∀ a : α, a ∈ x → Option β}
     (h' : ∀ a (H : a ∈ x), f a H = none → x = none) : x.pbind f = none ↔ x = none := by
-  grind [cases Option]
+  cases x <;> grind
 
 theorem join_pmap_eq_pmap_join {f : ∀ a, p a → β} {x : Option (Option α)} (H) :
     (pmap (pmap f) x H).join = pmap f x.join fun a h ↦ H (some a) (mem_of_mem_join h) _ rfl := by
-  grind [cases Option]
+  cases x <;> grind
 
 theorem pmap_bind_id_eq_pmap_join {f : ∀ a, p a → β} {x : Option (Option α)} (H) :
     ((pmap (pmap f) x H).bind fun a ↦ a) =
       pmap f x.join fun a h ↦ H (some a) (mem_of_mem_join h) _ rfl := by
-  grind [cases Option]
+  cases x <;> grind
 
 end pmap
 

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -1290,6 +1290,7 @@ theorem ncard_sumEquiv_symm_apply {α : Type*} (s : Set α) :
 end ncard
 end Set
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 /-- A surjective function `f : α → β` decreases cardinality by at most one if and only if
 there is at most a collision between a unique pair of elements. -/
 theorem Function.Surjective.card_le_card_add_one_iff
@@ -1310,7 +1311,8 @@ theorem Function.Surjective.card_le_card_add_one_iff
     obtain ⟨x, hx⟩ := h
     simp only [Set.subset_def, Set.mem_compl_iff] at hx
     -- we show that the only possible collision is between `x` and `g (f x)`
-    suffices ∀ a b : α, f a = f b → a ≠ b → a = x ∨ a = g (f x) by grind
+    suffices ∀ a b : α, f a = f b → a ≠ b → a = x ∨ a = g (f x) by
+      grind only [= Set.mem_insert_iff, = Set.mem_singleton_iff]
     intro a b
     by_cases ha : a ∈ Set.range g <;> by_cases hb : b ∈ Set.range g <;> grind
   · -- we must show that any two elements `a` and `b` missed by `g` are equal

--- a/Mathlib/Data/Set/Disjoint.lean
+++ b/Mathlib/Data/Set/Disjoint.lean
@@ -56,7 +56,8 @@ alias ⟨_, Nonempty.not_disjoint⟩ := not_disjoint_iff_nonempty_inter
 lemma disjoint_or_nonempty_inter (s t : Set α) : Disjoint s t ∨ (s ∩ t).Nonempty :=
   (em _).imp_right not_disjoint_iff_nonempty_inter.1
 
-lemma disjoint_iff_forall_ne : Disjoint s t ↔ ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ t → a ≠ b := by grind
+lemma disjoint_iff_forall_ne : Disjoint s t ↔ ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ t → a ≠ b :=
+  ⟨by grind, by grind⟩
 
 alias ⟨_root_.Disjoint.ne_of_mem, _⟩ := disjoint_iff_forall_ne
 

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -1116,12 +1116,13 @@ lemma BijOn.symm {g : β → α} (h : InvOn f g t s) (hf : BijOn f s t) : BijOn 
 lemma bijOn_comm {g : β → α} (h : InvOn f g t s) : BijOn f s t ↔ BijOn g t s :=
   ⟨BijOn.symm h, BijOn.symm h.symm⟩
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 /-- If `t ⊆ f '' s`, there exists a preimage of `t` under `f` contained in `s` such that
 `f` restricted to `u` is injective. -/
 lemma SurjOn.exists_subset_injOn_image_eq (hfs : s.SurjOn f t) :
     ∃ u ⊆ s, u.InjOn f ∧ f '' u = t := by
   choose x hmem heq using hfs
-  exact ⟨range (fun a : t ↦ x a.2), by grind, fun _ ↦ by grind, by aesop⟩
+  refine ⟨range (fun a : t ↦ x a.2), by grind, fun _ ↦ by grind only [= mem_range], by aesop⟩
 
 end Set
 

--- a/Mathlib/Data/Set/Insert.lean
+++ b/Mathlib/Data/Set/Insert.lean
@@ -365,8 +365,9 @@ theorem pair_subset (ha : a ∈ s) (hb : b ∈ s) : {a, b} ⊆ s :=
 
 theorem subset_pair_iff : s ⊆ {a, b} ↔ ∀ x ∈ s, x = a ∨ x = b := by grind
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 theorem subset_pair_iff_eq {x y : α} : s ⊆ {x, y} ↔ s = ∅ ∨ s = {x} ∨ s = {y} ∨ s = {x, y} where
-  mp := by grind
+  mp := by grind only [subset_def, mem_insert_iff, mem_singleton_iff, mem_empty_iff_false]
   mpr := by grind
 
 theorem Nonempty.subset_pair_iff_eq (hs : s.Nonempty) :

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -97,7 +97,10 @@ instance [Std.Total r] [Std.Total s] : Std.Total (Lex r s) :=
     | inr a, inr b => (total_of s a b).imp Lex.inr Lex.inr⟩
 
 instance [Std.Trichotomous r] [Std.Trichotomous s] : Std.Trichotomous (Lex r s) := by
-  grind [Std.Trichotomous, Lex]
+  constructor
+  have := Std.Trichotomous.trichotomous (r := r)
+  have := Std.Trichotomous.trichotomous (r := s)
+  grind [Lex]
 
 instance [IsWellOrder α r] [IsWellOrder β s] :
     IsWellOrder (α ⊕ β) (Sum.Lex r s) where wf := Sum.lex_wf IsWellFounded.wf IsWellFounded.wf


### PR DESCRIPTION
These are sources of technical debt as now reported in the [weekly linting report](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Weekly.20linting.20log/with/544658968). The idea is that a successful `grind` proof can fail to report the theorems it used via `grind?`, which means that if these proofs break across toolchains that it becomes significantly harder to repair.

Most of these are fixed by squeezing the call to `grind` and unsetting `linter.tacticAnalysis.verifyGrindOnly` so they no longer appear in the weekly report. Unfortunately, this can't be on by default for performance reasons, but I highly encourage using this linter when adding any `grind` proofs.

---

https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/verifyGrindOnly.20PRs/with/601460139

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
