### PR TITLE
[Merged by Bors] - feat(GroupTheory): subgroup-valued lower central series

### DIFF
--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -612,6 +612,13 @@ theorem lowerCentralSeries_mono (n : ℕ) :
   | zero => intro S T h; simpa
   | succ d hd => intro S T h; simp only [lowerCentralSeries_succ]; exact commutator_mono (hd h) h
 
+@[to_additive]
+instance lowerCentralSeries_normal (S : Subgroup G) [S.Normal] (n : ℕ) :
+    (S.lowerCentralSeries n).Normal := by
+  induction n with
+  | zero => simpa using ‹S.Normal›
+  | succ n _ => simp only [lowerCentralSeries_succ]; infer_instance
+
 /-- The lower central series commutes with images under a group homomorphism. -/
 @[to_additive]
 theorem map_lowerCentralSeries {H : Type*} [Group H] (f : G →* H) (S : Subgroup G) (n : ℕ) :
@@ -635,8 +642,8 @@ theorem top_subtype_lowerCentralSeries (H : Subgroup G) (n : ℕ) :
   congr 1
   ext; simp
 
-/-- A subgroup `H` of `G`'s lower central series (viewed in `G`) coincides with the lower
-central series of `H` as its own group, mapped back to `G`. -/
+/-- The lower central series of `H : Subgroup G`, computed in `G`, coincides with the lower
+central series of `H` viewed as its own group, mapped back to `G`. -/
 @[to_additive]
 theorem lowerCentralSeries_eq_map (H : Subgroup G) (n : ℕ) :
     H.lowerCentralSeries n = ((⊤ : Subgroup H).lowerCentralSeries n).map H.subtype :=
@@ -663,6 +670,28 @@ theorem nilpotencyClass_le (H : Subgroup G) [hG : IsNilpotent G] :
   rw [← Subgroup.map_injective H.subtype_injective |>.eq_iff' (Subgroup.map_bot H.subtype),
     top_subtype_lowerCentralSeries]
   exact le_bot_iff.mp <| (H.lowerCentralSeries_mono n le_top).trans_eq hG
+
+/-- A subgroup is nilpotent iff its lower central series (computed in the ambient group) eventually
+vanishes. -/
+@[to_additive /-- An additive subgroup is nilpotent iff its lower central series eventually
+vanishes. -/]
+theorem isNilpotent_iff_lowerCentralSeries (S : Subgroup G) :
+    Group.IsNilpotent S ↔ ∃ n, S.lowerCentralSeries n = ⊥ := by
+  rw [nilpotent_iff_lowerCentralSeries]
+  refine exists_congr fun n => ?_
+  rw [← Subgroup.map_injective S.subtype_injective |>.eq_iff' (Subgroup.map_bot S.subtype),
+    top_subtype_lowerCentralSeries]
+
+@[to_additive]
+theorem isNilpotent_of_lowerCentralSeries_eq_bot {S : Subgroup G} {n : ℕ}
+    (h : S.lowerCentralSeries n = ⊥) : Group.IsNilpotent S :=
+  (isNilpotent_iff_lowerCentralSeries S).mpr ⟨n, h⟩
+
+@[to_additive]
+theorem lowerCentralSeries_eq_bot_of_nilpotencyClass_le {S : Subgroup G}
+    [Group.IsNilpotent S] {n : ℕ} (hn : Group.nilpotencyClass S ≤ n) :
+    S.lowerCentralSeries n = ⊥ := by
+  rw [lowerCentralSeries_eq_map, lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr hn, map_bot]
 
 @[to_additive]
 instance (priority := 100) _root_.Group.isNilpotent_of_subsingleton [Subsingleton G] :

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -644,6 +644,13 @@ theorem lowerCentralSeries_map_subtype_le (H : Subgroup G) (n : ℕ) :
   rw [top_subtype_lowerCentralSeries]
   exact lowerCentralSeries_mono n le_top
 
+@[to_additive (attr := deprecated "Use `map_lowerCentralSeries` and \
+  `lowerCentralSeries_mono` instead." (since := "2026-05-28"))]
+theorem lowerCentralSeries.map {K : Type*} [Group K] (f : G →* K) (n : ℕ) :
+    ((⊤ : Subgroup G).lowerCentralSeries n).map f ≤ (⊤ : Subgroup K).lowerCentralSeries n := by
+  rw [map_lowerCentralSeries]
+  exact lowerCentralSeries_mono n le_top
+
 @[to_additive]
 instance lowerCentralSeries_normal (S : Subgroup G) [S.Normal] (n : ℕ) :
     (S.lowerCentralSeries n).Normal := by
@@ -997,14 +1004,7 @@ theorem Subgroup.lowerCentralSeries_prod (S₁ : Subgroup G₁) (S₂ : Subgroup
       (S₁.lowerCentralSeries n).prod (S₂.lowerCentralSeries n) := by
   induction n with
   | zero => simp
-  | succ n ih =>
-    calc
-      (S₁.prod S₂).lowerCentralSeries n.succ
-          = ⁅(S₁.prod S₂).lowerCentralSeries n, S₁.prod S₂⁆ := rfl
-      _ = ⁅(S₁.lowerCentralSeries n).prod (S₂.lowerCentralSeries n), S₁.prod S₂⁆ := by rw [ih]
-      _ = ⁅S₁.lowerCentralSeries n, S₁⁆.prod ⁅S₂.lowerCentralSeries n, S₂⁆ :=
-        commutator_prod_prod _ _ _ _
-      _ = (S₁.lowerCentralSeries n.succ).prod (S₂.lowerCentralSeries n.succ) := rfl
+  | succ n ih => simp_rw [lowerCentralSeries_succ, ih, commutator_prod_prod]
 
 /-- The ⊤-specialization of `lowerCentralSeries_prod`. -/
 @[to_additive]
@@ -1043,18 +1043,11 @@ variable {η : Type*} {Gs : η → Type*} [∀ i, Group (Gs i)]
 theorem Subgroup.lowerCentralSeries_pi_le (Ss : ∀ i, Subgroup (Gs i)) (n : ℕ) :
     (Subgroup.pi Set.univ Ss).lowerCentralSeries n ≤ Subgroup.pi Set.univ
       fun i => (Ss i).lowerCentralSeries n := by
-  let pi := fun f : ∀ i, Subgroup (Gs i) => Subgroup.pi Set.univ f
   induction n with
   | zero => simp
   | succ n ih =>
-    calc
-      (Subgroup.pi Set.univ Ss).lowerCentralSeries n.succ
-          = ⁅(Subgroup.pi Set.univ Ss).lowerCentralSeries n, pi Ss⁆ := rfl
-      _ ≤ ⁅pi fun i => (Ss i).lowerCentralSeries n, pi Ss⁆ :=
-        commutator_mono ih (le_refl _)
-      _ ≤ pi fun i => ⁅(Ss i).lowerCentralSeries n, Ss i⁆ :=
-        commutator_pi_pi_le _ _
-      _ = pi fun i => (Ss i).lowerCentralSeries n.succ := rfl
+    simp_rw [lowerCentralSeries_succ]
+    grw [commutator_mono ih le_rfl, commutator_pi_pi_le]
 
 /-- The ⊤-specialization of `lowerCentralSeries_pi_le`. -/
 @[to_additive]
@@ -1085,17 +1078,9 @@ variable {η : Type*} {Gs : η → Type*} [∀ i, Group (Gs i)]
 theorem Subgroup.lowerCentralSeries_pi_of_finite [Finite η] (Ss : ∀ i, Subgroup (Gs i)) (n : ℕ) :
     (Subgroup.pi Set.univ Ss).lowerCentralSeries n = Subgroup.pi Set.univ
       fun i => (Ss i).lowerCentralSeries n := by
-  let pi := fun f : ∀ i, Subgroup (Gs i) => Subgroup.pi Set.univ f
   induction n with
   | zero => simp
-  | succ n ih =>
-    calc
-      (Subgroup.pi Set.univ Ss).lowerCentralSeries n.succ
-          = ⁅(Subgroup.pi Set.univ Ss).lowerCentralSeries n, pi Ss⁆ := rfl
-      _ = ⁅pi fun i => (Ss i).lowerCentralSeries n, pi Ss⁆ := by rw [ih]
-      _ = pi fun i => ⁅(Ss i).lowerCentralSeries n, Ss i⁆ :=
-        commutator_pi_pi_of_finite _ _
-      _ = pi fun i => (Ss i).lowerCentralSeries n.succ := rfl
+  | succ n ih => simp_rw [lowerCentralSeries_succ, ih, commutator_pi_pi_of_finite]
 
 /-- The ⊤-specialization of `lowerCentralSeries_pi_of_finite`. -/
 @[to_additive]
@@ -1290,7 +1275,6 @@ alias least_descending_central_series_length_eq_nilpotencyClass :=
 @[deprecated (since := "2026-03-25")] alias lowerCentralSeries_eq_bot_iff_nilpotencyClass_le :=
   lowerCentralSeries_eq_bot_iff_nilpotencyClass_le
 @[deprecated (since := "2026-03-25")] alias upperCentralSeries.map := upperCentralSeries.map
-@[deprecated (since := "2026-05-25")] alias lowerCentralSeries.map := map_lowerCentralSeries
 @[deprecated (since := "2026-03-25")] alias isNilpotent_of_ker_le_center :=
   isNilpotent_of_ker_le_center
 @[deprecated (since := "2026-03-25")] alias nilpotencyClass_le_of_ker_le_center :=
@@ -1328,10 +1312,8 @@ alias least_descending_central_series_length_eq_nilpotencyClass :=
 @[deprecated (since := "2026-03-25")]
 alias upperCentralSeries.card_image_eq_of_le_nilpotencyClass :=
   upperCentralSeries.card_image_eq_of_le_nilpotencyClass
--- `Subgroup.lowerCentralSeries_prod` is now generalized; no deprecation needed.
 @[deprecated (since := "2026-03-25")] alias isNilpotent_prod := isNilpotent_prod
 @[deprecated (since := "2026-03-25")] alias nilpotencyClass_prod := nilpotencyClass_prod
--- `Subgroup.lowerCentralSeries_pi_le` and `_pi_of_finite` are now generalized.
 @[deprecated (since := "2026-03-25")] alias isNilpotent_pi_of_bounded_class :=
   isNilpotent_pi_of_bounded_class
 @[deprecated (since := "2026-03-25")] alias isNilpotent_pi := isNilpotent_pi

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -26,9 +26,10 @@ subgroup `G` of `G`, and `⊥` denotes the trivial subgroup `{1}`.
 * `upperCentralSeries G : ℕ → Subgroup G` : the upper central series of a group `G`.
      This is an increasing sequence of characteristic subgroups `H n` of `G` with `H 0 = ⊥` and
      `H (n + 1) / H n` is the centre of `G / H n`.
-* `lowerCentralSeries G : ℕ → Subgroup G` : the lower central series of a group `G`.
-     This is a decreasing sequence of characteristic subgroups `H n` of `G` with `H 0 = ⊤` and
-     `H (n + 1) = ⁅H n, G⁆`.
+* `Subgroup.lowerCentralSeries (S : Subgroup G) : ℕ → Subgroup G` : the lower central series of `S`,
+     computed in the ambient group `G`. This is the iterated commutator
+     `S, ⁅S, S⁆, ⁅⁅S, S⁆, S⁆, …`. The classical lower central series of `G` is the case
+     `S = ⊤`, also accessible as `lowerCentralSeries G`.
 * `IsNilpotent` : A group G is nilpotent if its upper central series reaches `⊤`, or
     equivalently if its lower central series reaches `⊥`.
 * `Group.nilpotencyClass` : the length of the upper central series of a nilpotent group.
@@ -69,7 +70,7 @@ subgroup `G` of `G`, and `⊥` denotes the trivial subgroup `{1}`.
 A "central series" is usually defined to be a finite sequence of normal subgroups going
 from `⊥` to `⊤` with the property that each subquotient is contained within the centre of
 the associated quotient of `G`. This means that if `G` is not nilpotent, then
-none of what we have called `upperCentralSeries G`, `lowerCentralSeries G` or
+none of what we have called `upperCentralSeries G`, `(⊤ : Subgroup G).lowerCentralSeries` or
 the sequences satisfying `IsAscendingCentralSeries` or `IsDescendingCentralSeries`
 are actually central series. Note that the fact that the upper and lower central series
 are not central series if `G` is not nilpotent is a standard abuse of notation.
@@ -83,19 +84,19 @@ open commutatorElement Subgroup
 
 section WithGroup
 
-variable {G : Type*} [Group G] (H : Subgroup G) [Normal H]
+variable {G : Type*} [Group G] (N : Subgroup G) [Normal N]
 
 namespace Subgroup
 
-/-- If `H` is a normal subgroup of `G`, then the set `{x : G | ∀ y : G, x*y*x⁻¹*y⁻¹ ∈ H}`
+/-- If `N` is a normal subgroup of `G`, then the set `{x : G | ∀ y : G, x*y*x⁻¹*y⁻¹ ∈ N}`
 is a subgroup of `G` (because it is the preimage in `G` of the centre of the
-quotient group `G/H`.)
+quotient group `G/N`.)
 -/
-@[to_additive /-- If `H` is a normal additive subgroup of `G`, then the set
-`{x : G | ∀ y : G, x + y -x - y ∈ H}` is an additive subgroup of `G`
-(because it is the preimage in `G` of the centre of the additive quotient group `G/H`.) -/]
+@[to_additive /-- If `N` is a normal additive subgroup of `G`, then the set
+`{x : G | ∀ y : G, x + y -x - y ∈ N}` is an additive subgroup of `G`
+(because it is the preimage in `G` of the centre of the additive quotient group `G/N`.) -/]
 def upperCentralSeriesStep : Subgroup G where
-  carrier := { x : G | ∀ y : G, ⁅x, y⁆ ∈ H }
+  carrier := { x : G | ∀ y : G, ⁅x, y⁆ ∈ N }
   one_mem' y := by simp
   mul_mem' {a b} ha hb y := by
     convert! Subgroup.mul_mem _ (ha (b * y * b⁻¹)) (hb y) using 1
@@ -107,16 +108,16 @@ def upperCentralSeriesStep : Subgroup G where
 
 @[to_additive]
 theorem mem_upperCentralSeriesStep (x : G) :
-    x ∈ upperCentralSeriesStep H ↔ ∀ y, ⁅x, y⁆ ∈ H := Iff.rfl
+    x ∈ upperCentralSeriesStep N ↔ ∀ y, ⁅x, y⁆ ∈ N := Iff.rfl
 
 open QuotientGroup
 
-/-- The proof that `upperCentralSeriesStep H` is the preimage of the centre of `G/H` under
+/-- The proof that `upperCentralSeriesStep N` is the preimage of the centre of `G/N` under
 the canonical surjection. -/
-@[to_additive /-- The proof that `upperCentralSeriesStep H` is the preimage of the centre of `G/H`\
+@[to_additive /-- The proof that `upperCentralSeriesStep N` is the preimage of the centre of `G/N`\
 under the canonical surjection. -/]
 theorem upperCentralSeriesStep_eq_comap_center :
-    upperCentralSeriesStep H = Subgroup.comap (mk' H) (center (G ⧸ H)) := by
+    upperCentralSeriesStep N = Subgroup.comap (mk' N) (center (G ⧸ N)) := by
   ext
   rw [mem_comap, mem_center_iff, forall_mk]
   refine forall_congr' fun y => ?_
@@ -125,8 +126,8 @@ theorem upperCentralSeriesStep_eq_comap_center :
   simp_rw [mul_assoc]
 
 @[to_additive]
-instance [H.Characteristic] : Characteristic (upperCentralSeriesStep H) :=
-  (upperCentralSeriesStep_eq_comap_center H) ▸ Characteristic.comap_quotient_mk centerCharacteristic
+instance [N.Characteristic] : Characteristic (upperCentralSeriesStep N) :=
+  (upperCentralSeriesStep_eq_comap_center N) ▸ Characteristic.comap_quotient_mk centerCharacteristic
 
 variable (G)
 
@@ -410,7 +411,7 @@ theorem _root_.AddSubgroup.top_lowerCentralSeries_one {G : Type*} [AddGroup G] :
     (⊤ : AddSubgroup G).lowerCentralSeries 1 = _root_.addCommutator G :=
   rfl
 
-attribute [to_additive existing (attr := simp) AddSubgroup.top_lowerCentralSeries_one]
+attribute [to_additive existing AddSubgroup.top_lowerCentralSeries_one]
   top_lowerCentralSeries_one
 
 @[to_additive]
@@ -422,8 +423,8 @@ theorem mem_lowerCentralSeries_succ_iff (S : Subgroup G) (n : ℕ) (q : G) :
 instance lowerCentralSeries_characteristic (S : Subgroup G) [S.Characteristic] (n : ℕ) :
     (S.lowerCentralSeries n).Characteristic := by
   induction n with
-  | zero => simpa using ‹S.Characteristic›
-  | succ d _ => simp only [lowerCentralSeries_succ]; infer_instance
+  | zero => simpa
+  | succ d _ => rw [lowerCentralSeries_succ]; infer_instance
 
 @[to_additive]
 theorem self_le_normalizer_lowerCentralSeries (S : Subgroup G) :
@@ -431,7 +432,7 @@ theorem self_le_normalizer_lowerCentralSeries (S : Subgroup G) :
   | 0 => Subgroup.le_normalizer
   | n + 1 => by
     rw [lowerCentralSeries_succ]
-    exact normalizer_commutator_ge_right _ _
+    apply normalizer_commutator_ge_right
 
 @[to_additive]
 theorem lowerCentralSeries_antitone (S : Subgroup G) : Antitone S.lowerCentralSeries := by
@@ -442,7 +443,7 @@ theorem lowerCentralSeries_antitone (S : Subgroup G) : Antitone S.lowerCentralSe
 /-- The lower central series of a group is a descending central series. -/
 @[to_additive /-- The lower central series of an additive group is a descending central series. -/]
 theorem lowerCentralSeries_isDescendingCentralSeries :
-    IsDescendingCentralSeries ((⊤ : Subgroup G).lowerCentralSeries) := by
+    IsDescendingCentralSeries (G := G) (lowerCentralSeries ⊤) := by
   constructor
   · rfl
   intro x n hxn g
@@ -452,7 +453,7 @@ theorem lowerCentralSeries_isDescendingCentralSeries :
 @[to_additive /-- Any descending central series for an additive group is bounded below by the lower
 central series. -/]
 theorem descending_central_series_ge_lower (H : ℕ → Subgroup G) (hH : IsDescendingCentralSeries H) :
-    ∀ n : ℕ, (⊤ : Subgroup G).lowerCentralSeries n ≤ H n
+    ∀ n : ℕ, lowerCentralSeries ⊤ n ≤ H n
   | 0 => hH.1.symm ▸ le_refl ⊤
   | n + 1 => commutator_le.mpr fun x hx q _ =>
       hH.2 x n (descending_central_series_ge_lower H hH n hx) q
@@ -470,10 +471,8 @@ theorem map_lowerCentralSeries {H : Type*} [Group H] (f : G →* H) (S : Subgrou
 the lower central series of `H` viewed as its own group, mapped back to `G`. -/
 @[to_additive (attr := simp)]
 theorem top_subtype_lowerCentralSeries (H : Subgroup G) (n : ℕ) :
-    ((⊤ : Subgroup H).lowerCentralSeries n).map H.subtype = H.lowerCentralSeries n := by
-  rw [map_lowerCentralSeries]
-  congr 1
-  ext; simp
+    (lowerCentralSeries ⊤ n).map H.subtype = H.lowerCentralSeries n := by
+  rw [map_lowerCentralSeries, ← MonoidHom.range_eq_map, subtype_range]
 
 /-- A subgroup is nilpotent iff its lower central series (computed in the ambient group) eventually
 vanishes. -/
@@ -489,17 +488,15 @@ theorem isNilpotent_iff_lowerCentralSeries (S : Subgroup G) :
     rw [hn, le_bot_iff] at h1
     rw [← top_subtype_lowerCentralSeries, h1, Subgroup.map_bot]
   · rintro ⟨n, hn⟩
-    refine ⟨n, (⊤ : Subgroup S).lowerCentralSeries,
-      lowerCentralSeries_isDescendingCentralSeries, ?_⟩
-    rwa [← Subgroup.map_injective S.subtype_injective |>.eq_iff' (Subgroup.map_bot S.subtype),
-      top_subtype_lowerCentralSeries]
+    refine ⟨n, lowerCentralSeries ⊤, lowerCentralSeries_isDescendingCentralSeries, ?_⟩
+    rwa [← map_subtype_inj, map_bot, top_subtype_lowerCentralSeries]
 
 /-- A group is nilpotent if and only if its lower central series eventually reaches
 the trivial subgroup. -/
 @[to_additive /-- An additive group is nilpotent if and only if its lower central series eventually
 reaches the trivial additive subgroup. -/]
 theorem nilpotent_iff_lowerCentralSeries :
-    IsNilpotent G ↔ ∃ n, (⊤ : Subgroup G).lowerCentralSeries n = ⊥ :=
+    IsNilpotent G ↔ ∃ n, lowerCentralSeries (⊤ : Subgroup G) n = ⊥ :=
   Group.isNilpotent_top.symm.trans (isNilpotent_iff_lowerCentralSeries ⊤)
 
 end Subgroup
@@ -599,19 +596,18 @@ theorem lowerCentralSeries_length_eq_nilpotencyClass :
     rw [← le_bot_iff, ← hn]
     exact descending_central_series_ge_lower H hH n
   · rintro n h
-    exact ⟨(⊤ : Subgroup G).lowerCentralSeries,
-      ⟨lowerCentralSeries_isDescendingCentralSeries, h⟩⟩
+    exact ⟨lowerCentralSeries ⊤, ⟨lowerCentralSeries_isDescendingCentralSeries, h⟩⟩
 
 @[to_additive (attr := simp)]
 theorem lowerCentralSeries_nilpotencyClass :
-    (⊤ : Subgroup G).lowerCentralSeries (Group.nilpotencyClass G) = ⊥ := by
+    lowerCentralSeries (⊤ : Subgroup G) (Group.nilpotencyClass G) = ⊥ := by
   classical
   rw [← lowerCentralSeries_length_eq_nilpotencyClass]
   exact Nat.find_spec (nilpotent_iff_lowerCentralSeries.mp hG)
 
 @[to_additive]
 theorem lowerCentralSeries_eq_bot_iff_nilpotencyClass_le {n : ℕ} :
-    (⊤ : Subgroup G).lowerCentralSeries n = ⊥ ↔ Group.nilpotencyClass G ≤ n := by
+    lowerCentralSeries (⊤ : Subgroup G) n = ⊥ ↔ Group.nilpotencyClass G ≤ n := by
   classical
   constructor
   · intro h
@@ -643,15 +639,17 @@ theorem lowerCentralSeries_mono (n : ℕ) :
 instance lowerCentralSeries_normal (S : Subgroup G) [S.Normal] (n : ℕ) :
     (S.lowerCentralSeries n).Normal := by
   induction n with
-  | zero => simpa using ‹S.Normal›
-  | succ n _ => simp only [lowerCentralSeries_succ]; infer_instance
+  | zero => simpa
+  | succ n _ => rw [lowerCentralSeries_succ]; infer_instance
 
 /-- A subgroup of a nilpotent group is nilpotent. -/
 @[to_additive /-- An additive subgroup of a nilpotent group is nilpotent. -/]
 instance isNilpotent (H : Subgroup G) [hG : IsNilpotent G] : IsNilpotent H := by
-  rw [isNilpotent_iff_lowerCentralSeries]
-  rcases nilpotent_iff_lowerCentralSeries.mp hG with ⟨n, hG⟩
-  exact ⟨n, le_bot_iff.mp <| (H.lowerCentralSeries_mono n le_top).trans_eq hG⟩
+  rw [nilpotent_iff_lowerCentralSeries] at *
+  rcases hG with ⟨n, hG⟩
+  refine ⟨n, ?_⟩
+  rw [← map_subtype_inj, map_bot, top_subtype_lowerCentralSeries, eq_bot_iff, ← hG]
+  exact H.lowerCentralSeries_mono n le_top
 
 /-- The nilpotency class of a subgroup is less or equal to the nilpotency class of the group. -/
 @[to_additive /-- The nilpotency class of an additive subgroup is less or equal to the nilpotency
@@ -661,9 +659,8 @@ theorem nilpotencyClass_le (H : Subgroup G) [hG : IsNilpotent G] :
   repeat rw [← lowerCentralSeries_length_eq_nilpotencyClass]
   classical apply Nat.find_mono
   intro n hG
-  rw [← Subgroup.map_injective H.subtype_injective |>.eq_iff' (Subgroup.map_bot H.subtype),
-    top_subtype_lowerCentralSeries]
-  exact le_bot_iff.mp <| (H.lowerCentralSeries_mono n le_top).trans_eq hG
+  rw [← map_subtype_inj, map_bot, top_subtype_lowerCentralSeries, eq_bot_iff, ← hG]
+  exact H.lowerCentralSeries_mono n le_top
 
 @[to_additive]
 theorem isNilpotent_of_lowerCentralSeries_eq_bot {S : Subgroup G} {n : ℕ}
@@ -694,8 +691,8 @@ theorem upperCentralSeries.map {H : Type*} [Group H] {f : G →* H} (h : Functio
 
 @[to_additive]
 theorem top_lowerCentralSeries_succ_eq_bot {n : ℕ}
-    (h : (⊤ : Subgroup G).lowerCentralSeries n ≤ center G) :
-    (⊤ : Subgroup G).lowerCentralSeries (n + 1) = ⊥ := by
+    (h : lowerCentralSeries (⊤ : Subgroup G) n ≤ center G) :
+    lowerCentralSeries (⊤ : Subgroup G) (n + 1) = ⊥ := by
   rw [lowerCentralSeries_succ, commutator_def, closure_eq_bot_iff, Set.subset_singleton_iff]
   rintro x ⟨y, hy1, z, ⟨⟩, rfl⟩
   rw [commutatorElement_def, mul_assoc, ← mul_inv_rev, mul_inv_eq_one, eq_comm]
@@ -890,7 +887,7 @@ end Group
 
 -- todo: namespace `derivedSeries` and to_additivize.
 theorem Subgroup.derived_le_lower_central (n : ℕ) :
-    derivedSeries G n ≤ (⊤ : Subgroup G).lowerCentralSeries n := by
+    derivedSeries G n ≤ lowerCentralSeries (⊤ : Subgroup G) n := by
   induction n with
   | zero => simp
   | succ i ih => apply commutator_mono ih; simp

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -637,6 +637,13 @@ theorem lowerCentralSeries_mono (n : ℕ) :
   | zero => intro S T h; simpa
   | succ d hd => intro S T h; simp only [lowerCentralSeries_succ]; exact commutator_mono (hd h) h
 
+@[to_additive (attr := deprecated "Use `top_subtype_lowerCentralSeries` and \
+  `lowerCentralSeries_mono` instead." (since := "2026-05-27"))]
+theorem lowerCentralSeries_map_subtype_le (H : Subgroup G) (n : ℕ) :
+    ((⊤ : Subgroup H).lowerCentralSeries n).map H.subtype ≤ lowerCentralSeries ⊤ n := by
+  rw [top_subtype_lowerCentralSeries]
+  exact lowerCentralSeries_mono n le_top
+
 @[to_additive]
 instance lowerCentralSeries_normal (S : Subgroup G) [S.Normal] (n : ℕ) :
     (S.lowerCentralSeries n).Normal := by

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -378,10 +378,12 @@ theorem nilpotent_iff_finite_descending_central_series :
     rw [tsub_self]
     exact hH.1
 
+variable {G}
+
 /-- The lower central series of a subgroup `S` of `G`, computed in the ambient group `G`.
 This is the iterated commutator `⁅⁅⋯⁅S, S⁆, S⁆⋯, S⁆`, a subgroup of `G`. The lower central series
 of `G` itself is the case `S = ⊤`. -/
-def lowerCentralSeries {G : Type*} [Group G] (S : Subgroup G) : ℕ → Subgroup G
+def lowerCentralSeries (S : Subgroup G) : ℕ → Subgroup G
   | 0 => S
   | n + 1 => ⁅lowerCentralSeries S n, S⁆
 
@@ -393,8 +395,6 @@ def _root_.AddSubgroup.lowerCentralSeries {G : Type*} [AddGroup G] (S : AddSubgr
   | n + 1 => ⁅lowerCentralSeries S n, S⁆
 
 attribute [to_additive existing] lowerCentralSeries
-
-variable {G}
 
 @[to_additive (attr := simp)]
 theorem lowerCentralSeries_zero (S : Subgroup G) : S.lowerCentralSeries 0 = S := rfl
@@ -419,10 +419,11 @@ theorem mem_lowerCentralSeries_succ_iff (S : Subgroup G) (n : ℕ) (q : G) :
     q ∈ closure { x | ∃ p ∈ S.lowerCentralSeries n, ∃ q ∈ S, ⁅p, q⁆ = x } := Iff.rfl
 
 @[to_additive]
-instance (n : ℕ) : Characteristic ((⊤ : Subgroup G).lowerCentralSeries n) := by
+instance lowerCentralSeries_characteristic (S : Subgroup G) [S.Characteristic] (n : ℕ) :
+    (S.lowerCentralSeries n).Characteristic := by
   induction n with
-  | zero => simp [topCharacteristic]
-  | succ d hd => simp only [lowerCentralSeries_succ]; infer_instance
+  | zero => simpa using ‹S.Characteristic›
+  | succ d _ => simp only [lowerCentralSeries_succ]; infer_instance
 
 @[to_additive]
 theorem self_le_normalizer_lowerCentralSeries (S : Subgroup G) :
@@ -456,21 +457,50 @@ theorem descending_central_series_ge_lower (H : ℕ → Subgroup G) (hH : IsDesc
   | n + 1 => commutator_le.mpr fun x hx q _ =>
       hH.2 x n (descending_central_series_ge_lower H hH n hx) q
 
+/-- The lower central series commutes with images under a group homomorphism. -/
+@[to_additive]
+theorem map_lowerCentralSeries {H : Type*} [Group H] (f : G →* H) (S : Subgroup G) (n : ℕ) :
+    (S.lowerCentralSeries n).map f = (S.map f).lowerCentralSeries n := by
+  induction n with
+  | zero => simp
+  | succ d hd =>
+    rw [lowerCentralSeries_succ, lowerCentralSeries_succ, Subgroup.map_commutator, hd]
+
+/-- The lower central series of `H : Subgroup G` computed in the ambient group `G` coincides with
+the lower central series of `H` viewed as its own group, mapped back to `G`. -/
+@[to_additive (attr := simp)]
+theorem top_subtype_lowerCentralSeries (H : Subgroup G) (n : ℕ) :
+    ((⊤ : Subgroup H).lowerCentralSeries n).map H.subtype = H.lowerCentralSeries n := by
+  rw [map_lowerCentralSeries]
+  congr 1
+  ext; simp
+
+/-- A subgroup is nilpotent iff its lower central series (computed in the ambient group) eventually
+vanishes. -/
+@[to_additive /-- An additive subgroup is nilpotent iff its lower central series eventually
+vanishes. -/]
+theorem isNilpotent_iff_lowerCentralSeries (S : Subgroup G) :
+    Group.IsNilpotent S ↔ ∃ n, S.lowerCentralSeries n = ⊥ := by
+  rw [nilpotent_iff_finite_descending_central_series]
+  refine ⟨?_, ?_⟩
+  · rintro ⟨n, H, hH, hn⟩
+    refine ⟨n, ?_⟩
+    have h1 := descending_central_series_ge_lower H hH n
+    rw [hn, le_bot_iff] at h1
+    rw [← top_subtype_lowerCentralSeries, h1, Subgroup.map_bot]
+  · rintro ⟨n, hn⟩
+    refine ⟨n, (⊤ : Subgroup S).lowerCentralSeries,
+      lowerCentralSeries_isDescendingCentralSeries, ?_⟩
+    rwa [← Subgroup.map_injective S.subtype_injective |>.eq_iff' (Subgroup.map_bot S.subtype),
+      top_subtype_lowerCentralSeries]
+
 /-- A group is nilpotent if and only if its lower central series eventually reaches
 the trivial subgroup. -/
 @[to_additive /-- An additive group is nilpotent if and only if its lower central series eventually
 reaches the trivial additive subgroup. -/]
 theorem nilpotent_iff_lowerCentralSeries :
-    IsNilpotent G ↔ ∃ n, (⊤ : Subgroup G).lowerCentralSeries n = ⊥ := by
-  rw [nilpotent_iff_finite_descending_central_series]
-  constructor
-  · rintro ⟨n, H, ⟨h0, hs⟩, hn⟩
-    use n
-    rw [eq_bot_iff, ← hn]
-    exact descending_central_series_ge_lower H ⟨h0, hs⟩ n
-  · rintro ⟨n, hn⟩
-    exact ⟨n, (⊤ : Subgroup G).lowerCentralSeries,
-      lowerCentralSeries_isDescendingCentralSeries, hn⟩
+    IsNilpotent G ↔ ∃ n, (⊤ : Subgroup G).lowerCentralSeries n = ⊥ :=
+  Group.isNilpotent_top.symm.trans (isNilpotent_iff_lowerCentralSeries ⊤)
 
 end Subgroup
 
@@ -600,10 +630,7 @@ namespace Subgroup
 @[to_additive]
 theorem lowerCentralSeries_le_self (S : Subgroup G) (n : ℕ) :
     S.lowerCentralSeries n ≤ S := by
-  induction n with
-  | zero => simp
-  | succ d hd =>
-    simpa using (commutator_le_sup _ _).trans (by simp [hd])
+  simpa using S.lowerCentralSeries_antitone (Nat.zero_le n)
 
 @[to_additive]
 theorem lowerCentralSeries_mono (n : ℕ) :
@@ -619,45 +646,12 @@ instance lowerCentralSeries_normal (S : Subgroup G) [S.Normal] (n : ℕ) :
   | zero => simpa using ‹S.Normal›
   | succ n _ => simp only [lowerCentralSeries_succ]; infer_instance
 
-/-- The lower central series commutes with images under a group homomorphism. -/
-@[to_additive]
-theorem map_lowerCentralSeries {H : Type*} [Group H] (f : G →* H) (S : Subgroup G) (n : ℕ) :
-    (S.lowerCentralSeries n).map f = (S.map f).lowerCentralSeries n := by
-  induction n with
-  | zero => simp
-  | succ d hd =>
-    rw [lowerCentralSeries_succ, lowerCentralSeries_succ, Subgroup.map_commutator, hd]
-
-/-- For `K ≤ H ≤ G`, the lower central series of `K` computed inside `H` and mapped to `G`
-coincides with the lower central series of `K.map H.subtype` computed directly in `G`. -/
-@[to_additive]
-theorem subtype_lowerCentralSeries (H : Subgroup G) (K : Subgroup H) (n : ℕ) :
-    (K.lowerCentralSeries n).map H.subtype = (K.map H.subtype).lowerCentralSeries n :=
-  map_lowerCentralSeries H.subtype K n
-
-@[to_additive (attr := simp)]
-theorem top_subtype_lowerCentralSeries (H : Subgroup G) (n : ℕ) :
-    ((⊤ : Subgroup H).lowerCentralSeries n).map H.subtype = H.lowerCentralSeries n := by
-  rw [subtype_lowerCentralSeries]
-  congr 1
-  ext; simp
-
-/-- The lower central series of `H : Subgroup G`, computed in `G`, coincides with the lower
-central series of `H` viewed as its own group, mapped back to `G`. -/
-@[to_additive]
-theorem lowerCentralSeries_eq_map (H : Subgroup G) (n : ℕ) :
-    H.lowerCentralSeries n = ((⊤ : Subgroup H).lowerCentralSeries n).map H.subtype :=
-  (top_subtype_lowerCentralSeries H n).symm
-
 /-- A subgroup of a nilpotent group is nilpotent. -/
 @[to_additive /-- An additive subgroup of a nilpotent group is nilpotent. -/]
 instance isNilpotent (H : Subgroup G) [hG : IsNilpotent G] : IsNilpotent H := by
-  rw [nilpotent_iff_lowerCentralSeries] at *
-  rcases hG with ⟨n, hG⟩
-  refine ⟨n, ?_⟩
-  rw [← Subgroup.map_injective H.subtype_injective |>.eq_iff' (Subgroup.map_bot H.subtype),
-    top_subtype_lowerCentralSeries]
-  exact le_bot_iff.mp <| (H.lowerCentralSeries_mono n le_top).trans_eq hG
+  rw [isNilpotent_iff_lowerCentralSeries]
+  rcases nilpotent_iff_lowerCentralSeries.mp hG with ⟨n, hG⟩
+  exact ⟨n, le_bot_iff.mp <| (H.lowerCentralSeries_mono n le_top).trans_eq hG⟩
 
 /-- The nilpotency class of a subgroup is less or equal to the nilpotency class of the group. -/
 @[to_additive /-- The nilpotency class of an additive subgroup is less or equal to the nilpotency
@@ -671,17 +665,6 @@ theorem nilpotencyClass_le (H : Subgroup G) [hG : IsNilpotent G] :
     top_subtype_lowerCentralSeries]
   exact le_bot_iff.mp <| (H.lowerCentralSeries_mono n le_top).trans_eq hG
 
-/-- A subgroup is nilpotent iff its lower central series (computed in the ambient group) eventually
-vanishes. -/
-@[to_additive /-- An additive subgroup is nilpotent iff its lower central series eventually
-vanishes. -/]
-theorem isNilpotent_iff_lowerCentralSeries (S : Subgroup G) :
-    Group.IsNilpotent S ↔ ∃ n, S.lowerCentralSeries n = ⊥ := by
-  rw [nilpotent_iff_lowerCentralSeries]
-  refine exists_congr fun n => ?_
-  rw [← Subgroup.map_injective S.subtype_injective |>.eq_iff' (Subgroup.map_bot S.subtype),
-    top_subtype_lowerCentralSeries]
-
 @[to_additive]
 theorem isNilpotent_of_lowerCentralSeries_eq_bot {S : Subgroup G} {n : ℕ}
     (h : S.lowerCentralSeries n = ⊥) : Group.IsNilpotent S :=
@@ -691,7 +674,8 @@ theorem isNilpotent_of_lowerCentralSeries_eq_bot {S : Subgroup G} {n : ℕ}
 theorem lowerCentralSeries_eq_bot_of_nilpotencyClass_le {S : Subgroup G}
     [Group.IsNilpotent S] {n : ℕ} (hn : Group.nilpotencyClass S ≤ n) :
     S.lowerCentralSeries n = ⊥ := by
-  rw [lowerCentralSeries_eq_map, lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr hn, map_bot]
+  rw [← top_subtype_lowerCentralSeries,
+    lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr hn, map_bot]
 
 @[to_additive]
 instance (priority := 100) _root_.Group.isNilpotent_of_subsingleton [Subsingleton G] :

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -23,13 +23,13 @@ Recall that if `H K : Subgroup G` then `⁅H, K⁆ : Subgroup G` is the subgroup
 by the commutators `hkh⁻¹k⁻¹`. Recall also Lean's conventions that `⊤` denotes the
 subgroup `G` of `G`, and `⊥` denotes the trivial subgroup `{1}`.
 
-* `upperCentralSeries G : ℕ → Subgroup G` : the upper central series of a group `G`.
+* `Subgroup.upperCentralSeries G : ℕ → Subgroup G` : the upper central series of a group `G`.
      This is an increasing sequence of characteristic subgroups `H n` of `G` with `H 0 = ⊥` and
      `H (n + 1) / H n` is the centre of `G / H n`.
 * `Subgroup.lowerCentralSeries (S : Subgroup G) : ℕ → Subgroup G` : the lower central series of `S`,
      computed in the ambient group `G`. This is the iterated commutator
      `S, ⁅S, S⁆, ⁅⁅S, S⁆, S⁆, …`. The classical lower central series of `G` is the case
-     `S = ⊤`, also accessible as `lowerCentralSeries G`.
+     `S = ⊤`.
 * `IsNilpotent` : A group G is nilpotent if its upper central series reaches `⊤`, or
     equivalently if its lower central series reaches `⊥`.
 * `Group.nilpotencyClass` : the length of the upper central series of a nilpotent group.
@@ -397,11 +397,13 @@ def _root_.AddSubgroup.lowerCentralSeries {G : Type*} [AddGroup G] (S : AddSubgr
 
 attribute [to_additive existing] lowerCentralSeries
 
-@[to_additive (attr := simp)]
-theorem lowerCentralSeries_zero (S : Subgroup G) : S.lowerCentralSeries 0 = S := rfl
+variable (S : Subgroup G)
 
 @[to_additive (attr := simp)]
-theorem lowerCentralSeries_succ (S : Subgroup G) (n : ℕ) :
+theorem lowerCentralSeries_zero : S.lowerCentralSeries 0 = S := rfl
+
+@[to_additive (attr := simp)]
+theorem lowerCentralSeries_succ (n : ℕ) :
     S.lowerCentralSeries (n + 1) = ⁅S.lowerCentralSeries n, S⁆ := rfl
 
 theorem top_lowerCentralSeries_one : (⊤ : Subgroup G).lowerCentralSeries 1 = _root_.commutator G :=
@@ -415,19 +417,19 @@ attribute [to_additive existing AddSubgroup.top_lowerCentralSeries_one]
   top_lowerCentralSeries_one
 
 @[to_additive]
-theorem mem_lowerCentralSeries_succ_iff (S : Subgroup G) (n : ℕ) (q : G) :
+theorem mem_lowerCentralSeries_succ_iff (n : ℕ) (q : G) :
     q ∈ S.lowerCentralSeries (n + 1) ↔
     q ∈ closure { x | ∃ p ∈ S.lowerCentralSeries n, ∃ q ∈ S, ⁅p, q⁆ = x } := Iff.rfl
 
 @[to_additive]
-instance lowerCentralSeries_characteristic (S : Subgroup G) [S.Characteristic] (n : ℕ) :
+instance lowerCentralSeries_characteristic [S.Characteristic] (n : ℕ) :
     (S.lowerCentralSeries n).Characteristic := by
   induction n with
   | zero => simpa
   | succ d _ => rw [lowerCentralSeries_succ]; infer_instance
 
 @[to_additive]
-theorem self_le_normalizer_lowerCentralSeries (S : Subgroup G) :
+theorem self_le_normalizer_lowerCentralSeries :
     ∀ n, S ≤ Subgroup.normalizer (S.lowerCentralSeries n : Set G)
   | 0 => Subgroup.le_normalizer
   | n + 1 => by
@@ -435,7 +437,7 @@ theorem self_le_normalizer_lowerCentralSeries (S : Subgroup G) :
     apply normalizer_commutator_ge_right
 
 @[to_additive]
-theorem lowerCentralSeries_antitone (S : Subgroup G) : Antitone S.lowerCentralSeries := by
+theorem lowerCentralSeries_antitone : Antitone S.lowerCentralSeries := by
   refine antitone_nat_of_succ_le fun n => ?_
   rw [lowerCentralSeries_succ, ← le_normalizer_iff_commutator_le_left]
   exact S.self_le_normalizer_lowerCentralSeries n
@@ -460,7 +462,7 @@ theorem descending_central_series_ge_lower (H : ℕ → Subgroup G) (hH : IsDesc
 
 /-- The lower central series commutes with images under a group homomorphism. -/
 @[to_additive]
-theorem map_lowerCentralSeries {H : Type*} [Group H] (f : G →* H) (S : Subgroup G) (n : ℕ) :
+theorem map_lowerCentralSeries {K : Type*} [Group K] (f : G →* K) (n : ℕ) :
     (S.lowerCentralSeries n).map f = (S.map f).lowerCentralSeries n := by
   induction n with
   | zero => simp
@@ -478,7 +480,7 @@ theorem top_subtype_lowerCentralSeries (H : Subgroup G) (n : ℕ) :
 vanishes. -/
 @[to_additive /-- An additive subgroup is nilpotent iff its lower central series eventually
 vanishes. -/]
-theorem isNilpotent_iff_lowerCentralSeries (S : Subgroup G) :
+theorem isNilpotent_iff_lowerCentralSeries :
     Group.IsNilpotent S ↔ ∃ n, S.lowerCentralSeries n = ⊥ := by
   rw [nilpotent_iff_finite_descending_central_series]
   refine ⟨?_, ?_⟩
@@ -690,11 +692,11 @@ theorem upperCentralSeries.map {H : Type*} [Group H] {f : G →* H} (h : Functio
     simpa using hd (mem_map_of_mem f (hx y))
 
 @[to_additive]
-theorem top_lowerCentralSeries_succ_eq_bot {n : ℕ}
-    (h : lowerCentralSeries (⊤ : Subgroup G) n ≤ center G) :
-    lowerCentralSeries (⊤ : Subgroup G) (n + 1) = ⊥ := by
+theorem lowerCentralSeries_succ_eq_bot (S : Subgroup G) {n : ℕ}
+    (h : S.lowerCentralSeries n ≤ center G) :
+    S.lowerCentralSeries (n + 1) = ⊥ := by
   rw [lowerCentralSeries_succ, commutator_def, closure_eq_bot_iff, Set.subset_singleton_iff]
-  rintro x ⟨y, hy1, z, ⟨⟩, rfl⟩
+  rintro x ⟨y, hy1, z, _, rfl⟩
   rw [commutatorElement_def, mul_assoc, ← mul_inv_rev, mul_inv_eq_one, eq_comm]
   exact mem_center_iff.mp (h hy1) z
 
@@ -706,7 +708,7 @@ theorem isNilpotent_of_ker_le_center {H : Type*} [Group H] (f : G →* H) (hf1 :
     [IsNilpotent H] : IsNilpotent G := by
   rw [nilpotent_iff_lowerCentralSeries]
   rcases nilpotent_iff_lowerCentralSeries.mp ‹_› with ⟨n, hn⟩
-  refine ⟨n + 1, top_lowerCentralSeries_succ_eq_bot
+  refine ⟨n + 1, lowerCentralSeries_succ_eq_bot ⊤
     (le_trans ((Subgroup.map_eq_bot_iff _).mp ?_) hf1)⟩
   rw [map_lowerCentralSeries, ← le_bot_iff]
   exact hn ▸ Subgroup.lowerCentralSeries_mono n le_top
@@ -722,7 +724,7 @@ theorem nilpotencyClass_le_of_ker_le_center {H : Type*} [Group H] (f : G →* H)
   have : IsNilpotent G := isNilpotent_of_ker_le_center f hf1
   rw [← lowerCentralSeries_length_eq_nilpotencyClass]
   classical apply Nat.find_min'
-  refine top_lowerCentralSeries_succ_eq_bot
+  refine lowerCentralSeries_succ_eq_bot ⊤
     (le_trans ((Subgroup.map_eq_bot_iff _).mp ?_) hf1)
   rw [map_lowerCentralSeries, ← le_bot_iff,
     ← lowerCentralSeries_nilpotencyClass (G := H)]
@@ -887,7 +889,7 @@ end Group
 
 -- todo: namespace `derivedSeries` and to_additivize.
 theorem Subgroup.derived_le_lower_central (n : ℕ) :
-    derivedSeries G n ≤ lowerCentralSeries (⊤ : Subgroup G) n := by
+    derivedSeries G n ≤ lowerCentralSeries ⊤ n := by
   induction n with
   | zero => simp
   | succ i ih => apply commutator_mono ih; simp
@@ -1282,8 +1284,6 @@ alias least_descending_central_series_length_eq_nilpotencyClass :=
   lowerCentralSeries_eq_bot_iff_nilpotencyClass_le
 @[deprecated (since := "2026-03-25")] alias upperCentralSeries.map := upperCentralSeries.map
 @[deprecated (since := "2026-05-25")] alias lowerCentralSeries.map := map_lowerCentralSeries
-@[deprecated (since := "2026-05-25")] alias lowerCentralSeries_succ_eq_bot :=
-  top_lowerCentralSeries_succ_eq_bot
 @[deprecated (since := "2026-03-25")] alias isNilpotent_of_ker_le_center :=
   isNilpotent_of_ker_le_center
 @[deprecated (since := "2026-03-25")] alias nilpotencyClass_le_of_ker_le_center :=

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -1098,8 +1098,8 @@ end FinitePi
 instance (priority := 100) IsNilpotent.to_isSolvable [h : IsNilpotent G] : IsSolvable G := by
   obtain ⟨n, hn⟩ := nilpotent_iff_lowerCentralSeries.1 h
   use n
-  rw [eq_bot_iff, ← hn]
-  exact derived_le_lower_central n
+  rw [eq_bot_iff, ← hn, ← Subgroup.top_derivedSeries_eq]
+  exact Subgroup.derivedSeries_le_lowerCentralSeries _ n
 
 instance [IsSimpleGroup G] [IsNilpotent G] : CommGroup G :=
   ⟨IsSimpleGroup.comm_iff_isSolvable.mpr inferInstance⟩

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -378,67 +378,70 @@ theorem nilpotent_iff_finite_descending_central_series :
     rw [tsub_self]
     exact hH.1
 
-/-- The lower central series of a group `G` is a sequence `H n` of subgroups of `G`, defined
-by `H 0` is all of `G` and for `n≥1`, `H (n + 1) = ⁅H n, G⁆` -/
-def lowerCentralSeries (G : Type*) [Group G] : ℕ → Subgroup G
-  | 0 => ⊤
-  | n + 1 => ⁅lowerCentralSeries G n, ⊤⁆
+/-- The lower central series of a subgroup `S` of `G`, computed in the ambient group `G`.
+This is the iterated commutator `⁅⁅⋯⁅S, S⁆, S⁆⋯, S⁆`, a subgroup of `G`. The lower central series
+of `G` itself is the case `S = ⊤`. -/
+def lowerCentralSeries {G : Type*} [Group G] (S : Subgroup G) : ℕ → Subgroup G
+  | 0 => S
+  | n + 1 => ⁅lowerCentralSeries S n, S⁆
 
-/-- The lower central series of an additive group `G` is a sequence `H n` of additive
-subgroups of `G`, defined by `H 0` is all of `G` and for `n≥1`, `H (n + 1) = ⁅H n, G⁆` -/
-def _root_.AddSubgroup.lowerCentralSeries (G : Type*) [AddGroup G] : ℕ → AddSubgroup G
-  | 0 => ⊤
-  | n + 1 => ⁅lowerCentralSeries G n, ⊤⁆
+/-- The lower central series of an additive subgroup `S` of `G`, computed in the ambient additive
+group `G`. -/
+def _root_.AddSubgroup.lowerCentralSeries {G : Type*} [AddGroup G] (S : AddSubgroup G) :
+    ℕ → AddSubgroup G
+  | 0 => S
+  | n + 1 => ⁅lowerCentralSeries S n, S⁆
 
 attribute [to_additive existing] lowerCentralSeries
 
 variable {G}
 
 @[to_additive (attr := simp)]
-theorem lowerCentralSeries_zero : lowerCentralSeries G 0 = ⊤ := rfl
+theorem lowerCentralSeries_zero (S : Subgroup G) : S.lowerCentralSeries 0 = S := rfl
 
-theorem lowerCentralSeries_one : lowerCentralSeries G 1 = _root_.commutator G := rfl
+@[to_additive (attr := simp)]
+theorem lowerCentralSeries_succ (S : Subgroup G) (n : ℕ) :
+    S.lowerCentralSeries (n + 1) = ⁅S.lowerCentralSeries n, S⁆ := rfl
 
-theorem _root_.AddSubgroup.lowerCentralSeries_one {G : Type*} [AddGroup G] :
-    AddSubgroup.lowerCentralSeries G 1 = _root_.addCommutator G :=
+theorem top_lowerCentralSeries_one : (⊤ : Subgroup G).lowerCentralSeries 1 = _root_.commutator G :=
   rfl
 
-attribute [to_additive existing (attr := simp) AddSubgroup.lowerCentralSeries_one]
-  lowerCentralSeries_one
-
-@[to_additive]
-theorem mem_lowerCentralSeries_succ_iff (n : ℕ) (q : G) :
-    q ∈ lowerCentralSeries G (n + 1) ↔
-    q ∈ closure { x | ∃ p ∈ lowerCentralSeries G n,
-                        ∃ q ∈ (⊤ : Subgroup G), ⁅p, q⁆ = x } := Iff.rfl
-
-@[to_additive]
-theorem lowerCentralSeries_succ (n : ℕ) :
-    lowerCentralSeries G (n + 1) =
-      closure { x | ∃ p ∈ lowerCentralSeries G n, ∃ q ∈ (⊤ : Subgroup G), ⁅p, q⁆ = x } :=
+theorem _root_.AddSubgroup.top_lowerCentralSeries_one {G : Type*} [AddGroup G] :
+    (⊤ : AddSubgroup G).lowerCentralSeries 1 = _root_.addCommutator G :=
   rfl
 
+attribute [to_additive existing (attr := simp) AddSubgroup.top_lowerCentralSeries_one]
+  top_lowerCentralSeries_one
+
 @[to_additive]
-instance (n : ℕ) : Characteristic (lowerCentralSeries G n) := by
+theorem mem_lowerCentralSeries_succ_iff (S : Subgroup G) (n : ℕ) (q : G) :
+    q ∈ S.lowerCentralSeries (n + 1) ↔
+    q ∈ closure { x | ∃ p ∈ S.lowerCentralSeries n, ∃ q ∈ S, ⁅p, q⁆ = x } := Iff.rfl
+
+@[to_additive]
+instance (n : ℕ) : Characteristic ((⊤ : Subgroup G).lowerCentralSeries n) := by
   induction n with
   | zero => simp [topCharacteristic]
-  | succ d hd => unfold lowerCentralSeries; infer_instance
+  | succ d hd => simp only [lowerCentralSeries_succ]; infer_instance
 
 @[to_additive]
-theorem lowerCentralSeries_antitone : Antitone (lowerCentralSeries G) := by
-  refine antitone_nat_of_succ_le fun n x hx => ?_
-  simp only [mem_lowerCentralSeries_succ_iff, mem_top,
-    true_and] at hx
-  refine
-    closure_induction ?_ (Subgroup.one_mem _) (fun _ _ _ _ ↦ mul_mem) (fun _ _ ↦ inv_mem) hx
-  rintro y ⟨z, hz, a, ha⟩
-  rw [← ha, commutatorElement_def, mul_assoc, mul_assoc, ← mul_assoc a z⁻¹ a⁻¹]
-  exact mul_mem hz (Normal.conj_mem inferInstance z⁻¹ (inv_mem hz) a)
+theorem self_le_normalizer_lowerCentralSeries (S : Subgroup G) :
+    ∀ n, S ≤ Subgroup.normalizer (S.lowerCentralSeries n : Set G)
+  | 0 => Subgroup.le_normalizer
+  | n + 1 => by
+    rw [lowerCentralSeries_succ]
+    exact normalizer_commutator_ge_right _ _
+
+@[to_additive]
+theorem lowerCentralSeries_antitone (S : Subgroup G) : Antitone S.lowerCentralSeries := by
+  refine antitone_nat_of_succ_le fun n => ?_
+  rw [lowerCentralSeries_succ, ← le_normalizer_iff_commutator_le_left]
+  exact S.self_le_normalizer_lowerCentralSeries n
 
 /-- The lower central series of a group is a descending central series. -/
 @[to_additive /-- The lower central series of an additive group is a descending central series. -/]
 theorem lowerCentralSeries_isDescendingCentralSeries :
-    IsDescendingCentralSeries (lowerCentralSeries G) := by
+    IsDescendingCentralSeries ((⊤ : Subgroup G).lowerCentralSeries) := by
   constructor
   · rfl
   intro x n hxn g
@@ -448,7 +451,7 @@ theorem lowerCentralSeries_isDescendingCentralSeries :
 @[to_additive /-- Any descending central series for an additive group is bounded below by the lower
 central series. -/]
 theorem descending_central_series_ge_lower (H : ℕ → Subgroup G) (hH : IsDescendingCentralSeries H) :
-    ∀ n : ℕ, lowerCentralSeries G n ≤ H n
+    ∀ n : ℕ, (⊤ : Subgroup G).lowerCentralSeries n ≤ H n
   | 0 => hH.1.symm ▸ le_refl ⊤
   | n + 1 => commutator_le.mpr fun x hx q _ =>
       hH.2 x n (descending_central_series_ge_lower H hH n hx) q
@@ -457,7 +460,8 @@ theorem descending_central_series_ge_lower (H : ℕ → Subgroup G) (hH : IsDesc
 the trivial subgroup. -/
 @[to_additive /-- An additive group is nilpotent if and only if its lower central series eventually
 reaches the trivial additive subgroup. -/]
-theorem nilpotent_iff_lowerCentralSeries : IsNilpotent G ↔ ∃ n, lowerCentralSeries G n = ⊥ := by
+theorem nilpotent_iff_lowerCentralSeries :
+    IsNilpotent G ↔ ∃ n, (⊤ : Subgroup G).lowerCentralSeries n = ⊥ := by
   rw [nilpotent_iff_finite_descending_central_series]
   constructor
   · rintro ⟨n, H, ⟨h0, hs⟩, hn⟩
@@ -465,7 +469,8 @@ theorem nilpotent_iff_lowerCentralSeries : IsNilpotent G ↔ ∃ n, lowerCentral
     rw [eq_bot_iff, ← hn]
     exact descending_central_series_ge_lower H ⟨h0, hs⟩ n
   · rintro ⟨n, hn⟩
-    exact ⟨n, lowerCentralSeries G, lowerCentralSeries_isDescendingCentralSeries, hn⟩
+    exact ⟨n, (⊤ : Subgroup G).lowerCentralSeries,
+      lowerCentralSeries_isDescendingCentralSeries, hn⟩
 
 end Subgroup
 
@@ -564,18 +569,19 @@ theorem lowerCentralSeries_length_eq_nilpotencyClass :
     rw [← le_bot_iff, ← hn]
     exact descending_central_series_ge_lower H hH n
   · rintro n h
-    exact ⟨lowerCentralSeries G, ⟨lowerCentralSeries_isDescendingCentralSeries, h⟩⟩
+    exact ⟨(⊤ : Subgroup G).lowerCentralSeries,
+      ⟨lowerCentralSeries_isDescendingCentralSeries, h⟩⟩
 
 @[to_additive (attr := simp)]
 theorem lowerCentralSeries_nilpotencyClass :
-    lowerCentralSeries G (Group.nilpotencyClass G) = ⊥ := by
+    (⊤ : Subgroup G).lowerCentralSeries (Group.nilpotencyClass G) = ⊥ := by
   classical
   rw [← lowerCentralSeries_length_eq_nilpotencyClass]
   exact Nat.find_spec (nilpotent_iff_lowerCentralSeries.mp hG)
 
 @[to_additive]
 theorem lowerCentralSeries_eq_bot_iff_nilpotencyClass_le {n : ℕ} :
-    lowerCentralSeries G n = ⊥ ↔ Group.nilpotencyClass G ≤ n := by
+    (⊤ : Subgroup G).lowerCentralSeries n = ⊥ ↔ Group.nilpotencyClass G ≤ n := by
   classical
   constructor
   · intro h
@@ -583,7 +589,7 @@ theorem lowerCentralSeries_eq_bot_iff_nilpotencyClass_le {n : ℕ} :
     exact Nat.find_le h
   · intro h
     rw [eq_bot_iff, ← lowerCentralSeries_nilpotencyClass]
-    exact lowerCentralSeries_antitone h
+    exact lowerCentralSeries_antitone _ h
 
 end Subgroup
 
@@ -592,25 +598,46 @@ end Classical
 namespace Subgroup
 
 @[to_additive]
-theorem lowerCentralSeries_map_subtype_le (H : Subgroup G) (n : ℕ) :
-    (lowerCentralSeries H n).map H.subtype ≤ lowerCentralSeries G n := by
+theorem lowerCentralSeries_le_self (S : Subgroup G) (n : ℕ) :
+    S.lowerCentralSeries n ≤ S := by
   induction n with
   | zero => simp
   | succ d hd =>
-    rw [lowerCentralSeries_succ, lowerCentralSeries_succ, MonoidHom.map_closure]
-    apply Subgroup.closure_mono
-    rintro x1 ⟨x2, ⟨x3, hx3, x4, _hx4, rfl⟩, rfl⟩
-    exact ⟨x3, hd (mem_map.mpr ⟨x3, hx3, rfl⟩), x4, by simp⟩
+    simpa using (commutator_le_sup _ _).trans (by simp [hd])
+
+@[to_additive]
+theorem lowerCentralSeries_mono (n : ℕ) :
+    Monotone (fun S : Subgroup G => S.lowerCentralSeries n) := by
+  induction n with
+  | zero => intro S T h; simpa
+  | succ d hd => intro S T h; simp only [lowerCentralSeries_succ]; exact commutator_mono (hd h) h
+
+@[to_additive (attr := simp)]
+theorem top_subtype_lowerCentralSeries (H : Subgroup G) (n : ℕ) :
+    ((⊤ : Subgroup H).lowerCentralSeries n).map H.subtype = H.lowerCentralSeries n := by
+  induction n with
+  | zero => ext; simp
+  | succ d hd =>
+    simp only [lowerCentralSeries_succ, Subgroup.map_commutator, hd]
+    congr 1
+    ext; simp
+
+/-- A subgroup `H` of `G`'s lower central series (viewed in `G`) coincides with the lower
+central series of `H` as its own group, mapped back to `G`. -/
+@[to_additive]
+theorem lowerCentralSeries_eq_map (H : Subgroup G) (n : ℕ) :
+    H.lowerCentralSeries n = ((⊤ : Subgroup H).lowerCentralSeries n).map H.subtype :=
+  (top_subtype_lowerCentralSeries H n).symm
 
 /-- A subgroup of a nilpotent group is nilpotent. -/
 @[to_additive /-- An additive subgroup of a nilpotent group is nilpotent. -/]
 instance isNilpotent (H : Subgroup G) [hG : IsNilpotent G] : IsNilpotent H := by
   rw [nilpotent_iff_lowerCentralSeries] at *
   rcases hG with ⟨n, hG⟩
-  use n
-  have := lowerCentralSeries_map_subtype_le H n
-  simp only [hG, SetLike.le_def, mem_map, exists_imp] at this
-  exact eq_bot_iff.mpr fun x hx => Subtype.ext (this x ⟨hx, rfl⟩)
+  refine ⟨n, ?_⟩
+  rw [← Subgroup.map_injective H.subtype_injective |>.eq_iff' (Subgroup.map_bot H.subtype),
+    top_subtype_lowerCentralSeries]
+  exact le_bot_iff.mp <| (H.lowerCentralSeries_mono n le_top).trans_eq hG
 
 /-- The nilpotency class of a subgroup is less or equal to the nilpotency class of the group. -/
 @[to_additive /-- The nilpotency class of an additive subgroup is less or equal to the nilpotency
@@ -620,9 +647,9 @@ theorem nilpotencyClass_le (H : Subgroup G) [hG : IsNilpotent G] :
   repeat rw [← lowerCentralSeries_length_eq_nilpotencyClass]
   classical apply Nat.find_mono
   intro n hG
-  have := lowerCentralSeries_map_subtype_le H n
-  simp only [hG, SetLike.le_def, mem_map, exists_imp] at this
-  exact eq_bot_iff.mpr fun x hx => Subtype.ext (this x ⟨hx, rfl⟩)
+  rw [← Subgroup.map_injective H.subtype_injective |>.eq_iff' (Subgroup.map_bot H.subtype),
+    top_subtype_lowerCentralSeries]
+  exact le_bot_iff.mp <| (H.lowerCentralSeries_mono n le_top).trans_eq hG
 
 @[to_additive]
 instance (priority := 100) _root_.Group.isNilpotent_of_subsingleton [Subsingleton G] :
@@ -640,23 +667,18 @@ theorem upperCentralSeries.map {H : Type*} [Group H] {f : G →* H} (h : Functio
     simpa using hd (mem_map_of_mem f (hx y))
 
 @[to_additive]
-theorem lowerCentralSeries.map {H : Type*} [Group H] (f : G →* H) (n : ℕ) :
-    Subgroup.map f (lowerCentralSeries G n) ≤ lowerCentralSeries H n := by
+theorem map_lowerCentralSeries {H : Type*} [Group H] (f : G →* H) (S : Subgroup G) (n : ℕ) :
+    (S.lowerCentralSeries n).map f = (S.map f).lowerCentralSeries n := by
   induction n with
   | zero => simp
   | succ d hd =>
-    rintro a ⟨x, hx : x ∈ lowerCentralSeries G d.succ, rfl⟩
-    refine closure_induction (hx := hx) ?_ (by simp [f.map_one, Subgroup.one_mem _])
-      (fun y z _ _ hy hz => by simp [map_mul, Subgroup.mul_mem _ hy hz]) (fun y _ hy => by
-        rw [f.map_inv]; exact Subgroup.inv_mem _ hy)
-    rintro a ⟨y, hy, z, ⟨-, rfl⟩⟩
-    apply mem_closure.mpr
-    exact fun K hK => hK ⟨f y, hd (mem_map_of_mem f hy), by simp [commutatorElement_def]⟩
+    rw [lowerCentralSeries_succ, lowerCentralSeries_succ, Subgroup.map_commutator, hd]
 
 @[to_additive]
-theorem lowerCentralSeries_succ_eq_bot {n : ℕ} (h : lowerCentralSeries G n ≤ center G) :
-    lowerCentralSeries G (n + 1) = ⊥ := by
-  rw [lowerCentralSeries_succ, closure_eq_bot_iff, Set.subset_singleton_iff]
+theorem top_lowerCentralSeries_succ_eq_bot {n : ℕ}
+    (h : (⊤ : Subgroup G).lowerCentralSeries n ≤ center G) :
+    (⊤ : Subgroup G).lowerCentralSeries (n + 1) = ⊥ := by
+  rw [lowerCentralSeries_succ, commutator_def, closure_eq_bot_iff, Set.subset_singleton_iff]
   rintro x ⟨y, hy1, z, ⟨⟩, rfl⟩
   rw [commutatorElement_def, mul_assoc, ← mul_inv_rev, mul_inv_eq_one, eq_comm]
   exact mem_center_iff.mp (h hy1) z
@@ -669,9 +691,10 @@ theorem isNilpotent_of_ker_le_center {H : Type*} [Group H] (f : G →* H) (hf1 :
     [IsNilpotent H] : IsNilpotent G := by
   rw [nilpotent_iff_lowerCentralSeries]
   rcases nilpotent_iff_lowerCentralSeries.mp ‹_› with ⟨n, hn⟩
-  use n + 1
-  refine lowerCentralSeries_succ_eq_bot (le_trans ((Subgroup.map_eq_bot_iff _).mp ?_) hf1)
-  exact eq_bot_iff.mpr (hn ▸ lowerCentralSeries.map f n)
+  refine ⟨n + 1, top_lowerCentralSeries_succ_eq_bot
+    (le_trans ((Subgroup.map_eq_bot_iff _).mp ?_) hf1)⟩
+  rw [map_lowerCentralSeries, ← le_bot_iff]
+  exact hn ▸ Subgroup.lowerCentralSeries_mono n le_top
 
 end Subgroup
 
@@ -684,10 +707,11 @@ theorem nilpotencyClass_le_of_ker_le_center {H : Type*} [Group H] (f : G →* H)
   have : IsNilpotent G := isNilpotent_of_ker_le_center f hf1
   rw [← lowerCentralSeries_length_eq_nilpotencyClass]
   classical apply Nat.find_min'
-  refine lowerCentralSeries_succ_eq_bot (le_trans ((Subgroup.map_eq_bot_iff _).mp ?_) hf1)
-  rw [eq_bot_iff]
-  apply le_trans (lowerCentralSeries.map f _)
-  simp only [lowerCentralSeries_nilpotencyClass, le_bot_iff]
+  refine top_lowerCentralSeries_succ_eq_bot
+    (le_trans ((Subgroup.map_eq_bot_iff _).mp ?_) hf1)
+  rw [map_lowerCentralSeries, ← le_bot_iff,
+    ← lowerCentralSeries_nilpotencyClass (G := H)]
+  exact Subgroup.lowerCentralSeries_mono _ le_top
 
 /-- The range of a surjective homomorphism from a nilpotent group is nilpotent. -/
 @[to_additive /-- The range of a surjective homomorphism from a nilpotent additive group is
@@ -846,11 +870,19 @@ theorem nilpotent_center_quotient_ind {P : ∀ (G) [Group G] [IsNilpotent G], Pr
 
 end Group
 
--- todo: namespace `derivedSeries` and to_additivize.
-theorem Subgroup.derived_le_lower_central (n : ℕ) : derivedSeries G n ≤ lowerCentralSeries G n := by
+-- todo: to_additivize.
+theorem Subgroup.derivedSeries_le_lowerCentralSeries (S : Subgroup G) (n : ℕ) :
+    S.derivedSeries n ≤ S.lowerCentralSeries n := by
   induction n with
   | zero => simp
-  | succ i ih => apply commutator_mono ih; simp
+  | succ i ih =>
+    apply (Subgroup.commutator_mono ih (S.derivedSeries_le_self i)).trans
+    simp
+
+@[deprecated Subgroup.derivedSeries_le_lowerCentralSeries (since := "2026-05-25")]
+theorem Subgroup.derived_le_lower_central (n : ℕ) :
+    _root_.derivedSeries G n ≤ (⊤ : Subgroup G).lowerCentralSeries n := by
+  simpa using (⊤ : Subgroup G).derivedSeries_le_lowerCentralSeries n
 
 /-- Abelian groups are nilpotent. -/
 @[to_additive /-- Abelian groups are nilpotent. -/]
@@ -943,26 +975,26 @@ section Prod
 variable {G₁ G₂ : Type*} [Group G₁] [Group G₂]
 
 @[to_additive]
-theorem Subgroup.lowerCentralSeries_prod (n : ℕ) :
-    lowerCentralSeries (G₁ × G₂) n = (lowerCentralSeries G₁ n).prod (lowerCentralSeries G₂ n) := by
+theorem Subgroup.lowerCentralSeries_prod (S₁ : Subgroup G₁) (S₂ : Subgroup G₂) (n : ℕ) :
+    (S₁.prod S₂).lowerCentralSeries n =
+      (S₁.lowerCentralSeries n).prod (S₂.lowerCentralSeries n) := by
   induction n with
   | zero => simp
   | succ n ih =>
     calc
-      lowerCentralSeries (G₁ × G₂) n.succ = ⁅lowerCentralSeries (G₁ × G₂) n, ⊤⁆ := rfl
-      _ = ⁅(lowerCentralSeries G₁ n).prod (lowerCentralSeries G₂ n), ⊤⁆ := by rw [ih]
-      _ = ⁅(lowerCentralSeries G₁ n).prod (lowerCentralSeries G₂ n), (⊤ : Subgroup G₁).prod ⊤⁆ := by
-        simp
-      _ = ⁅lowerCentralSeries G₁ n, (⊤ : Subgroup G₁)⁆.prod ⁅lowerCentralSeries G₂ n, ⊤⁆ :=
-        (commutator_prod_prod _ _ _ _)
-      _ = (lowerCentralSeries G₁ n.succ).prod (lowerCentralSeries G₂ n.succ) := rfl
+      (S₁.prod S₂).lowerCentralSeries n.succ
+          = ⁅(S₁.prod S₂).lowerCentralSeries n, S₁.prod S₂⁆ := rfl
+      _ = ⁅(S₁.lowerCentralSeries n).prod (S₂.lowerCentralSeries n), S₁.prod S₂⁆ := by rw [ih]
+      _ = ⁅S₁.lowerCentralSeries n, S₁⁆.prod ⁅S₂.lowerCentralSeries n, S₂⁆ :=
+        commutator_prod_prod _ _ _ _
+      _ = (S₁.lowerCentralSeries n.succ).prod (S₂.lowerCentralSeries n.succ) := rfl
 
 /-- Products of nilpotent groups are nilpotent. -/
 @[to_additive /-- Products of nilpotent groups are nilpotent. -/]
 instance Group.isNilpotent_prod [IsNilpotent G₁] [IsNilpotent G₂] : IsNilpotent (G₁ × G₂) := by
   rw [nilpotent_iff_lowerCentralSeries]
   refine ⟨max (Group.nilpotencyClass G₁) (Group.nilpotencyClass G₂), ?_⟩
-  rw [lowerCentralSeries_prod,
+  rw [← top_prod_top (G := G₁) (N := G₂), lowerCentralSeries_prod,
     lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr (le_max_left _ _),
     lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr (le_max_right _ _), bot_prod_bot]
 
@@ -973,8 +1005,10 @@ theorem Group.nilpotencyClass_prod [IsNilpotent G₁] [IsNilpotent G₂] :
     Group.nilpotencyClass (G₁ × G₂) =
     max (Group.nilpotencyClass G₁) (Group.nilpotencyClass G₂) := by
   refine eq_of_forall_ge_iff fun k => ?_
-  simp only [max_le_iff, ← lowerCentralSeries_eq_bot_iff_nilpotencyClass_le,
-    lowerCentralSeries_prod, prod_eq_bot_iff]
+  rw [max_le_iff, ← lowerCentralSeries_eq_bot_iff_nilpotencyClass_le,
+    ← lowerCentralSeries_eq_bot_iff_nilpotencyClass_le,
+    ← lowerCentralSeries_eq_bot_iff_nilpotencyClass_le,
+    ← top_prod_top (G := G₁) (N := G₂), lowerCentralSeries_prod, prod_eq_bot_iff]
 
 end Prod
 
@@ -984,19 +1018,21 @@ section BoundedPi
 variable {η : Type*} {Gs : η → Type*} [∀ i, Group (Gs i)]
 
 @[to_additive]
-theorem Subgroup.lowerCentralSeries_pi_le (n : ℕ) :
-    lowerCentralSeries (∀ i, Gs i) n ≤ Subgroup.pi Set.univ
-      fun i => lowerCentralSeries (Gs i) n := by
+theorem Subgroup.lowerCentralSeries_pi_le (Ss : ∀ i, Subgroup (Gs i)) (n : ℕ) :
+    (Subgroup.pi Set.univ Ss).lowerCentralSeries n ≤ Subgroup.pi Set.univ
+      fun i => (Ss i).lowerCentralSeries n := by
   let pi := fun f : ∀ i, Subgroup (Gs i) => Subgroup.pi Set.univ f
   induction n with
-  | zero => simp [pi_top]
+  | zero => simp
   | succ n ih =>
     calc
-      lowerCentralSeries (∀ i, Gs i) n.succ = ⁅lowerCentralSeries (∀ i, Gs i) n, ⊤⁆ := rfl
-      _ ≤ ⁅pi fun i => lowerCentralSeries (Gs i) n, ⊤⁆ := commutator_mono ih (le_refl _)
-      _ = ⁅pi fun i => lowerCentralSeries (Gs i) n, pi fun i => ⊤⁆ := by simp [pi, pi_top]
-      _ ≤ pi fun i => ⁅lowerCentralSeries (Gs i) n, ⊤⁆ := commutator_pi_pi_le _ _
-      _ = pi fun i => lowerCentralSeries (Gs i) n.succ := rfl
+      (Subgroup.pi Set.univ Ss).lowerCentralSeries n.succ
+          = ⁅(Subgroup.pi Set.univ Ss).lowerCentralSeries n, pi Ss⁆ := rfl
+      _ ≤ ⁅pi fun i => (Ss i).lowerCentralSeries n, pi Ss⁆ :=
+        commutator_mono ih (le_refl _)
+      _ ≤ pi fun i => ⁅(Ss i).lowerCentralSeries n, Ss i⁆ :=
+        commutator_pi_pi_le _ _
+      _ = pi fun i => (Ss i).lowerCentralSeries n.succ := rfl
 
 /-- Products of nilpotent groups are nilpotent if their nilpotency class is bounded. -/
 @[to_additive /-- Products of nilpotent additive groups are nilpotent if their nilpotency class is
@@ -1005,8 +1041,8 @@ theorem Group.isNilpotent_pi_of_bounded_class [∀ i, IsNilpotent (Gs i)] (n : �
     (h : ∀ i, Group.nilpotencyClass (Gs i) ≤ n) : IsNilpotent (∀ i, Gs i) := by
   rw [nilpotent_iff_lowerCentralSeries]
   refine ⟨n, ?_⟩
-  rw [eq_bot_iff]
-  apply le_trans (lowerCentralSeries_pi_le _)
+  rw [eq_bot_iff, ← pi_top (I := Set.univ)]
+  apply le_trans (lowerCentralSeries_pi_le _ _)
   rw [← eq_bot_iff, pi_eq_bot_iff]
   intro i
   apply lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr (h i)
@@ -1019,19 +1055,20 @@ section FinitePi
 variable {η : Type*} {Gs : η → Type*} [∀ i, Group (Gs i)]
 
 @[to_additive]
-theorem Subgroup.lowerCentralSeries_pi_of_finite [Finite η] (n : ℕ) :
-    lowerCentralSeries (∀ i, Gs i) n = Subgroup.pi Set.univ
-      fun i => lowerCentralSeries (Gs i) n := by
+theorem Subgroup.lowerCentralSeries_pi_of_finite [Finite η] (Ss : ∀ i, Subgroup (Gs i)) (n : ℕ) :
+    (Subgroup.pi Set.univ Ss).lowerCentralSeries n = Subgroup.pi Set.univ
+      fun i => (Ss i).lowerCentralSeries n := by
   let pi := fun f : ∀ i, Subgroup (Gs i) => Subgroup.pi Set.univ f
   induction n with
-  | zero => simp [pi_top]
+  | zero => simp
   | succ n ih =>
     calc
-      lowerCentralSeries (∀ i, Gs i) n.succ = ⁅lowerCentralSeries (∀ i, Gs i) n, ⊤⁆ := rfl
-      _ = ⁅pi fun i => lowerCentralSeries (Gs i) n, ⊤⁆ := by rw [ih]
-      _ = ⁅pi fun i => lowerCentralSeries (Gs i) n, pi fun i => ⊤⁆ := by simp [pi, pi_top]
-      _ = pi fun i => ⁅lowerCentralSeries (Gs i) n, ⊤⁆ := commutator_pi_pi_of_finite _ _
-      _ = pi fun i => lowerCentralSeries (Gs i) n.succ := rfl
+      (Subgroup.pi Set.univ Ss).lowerCentralSeries n.succ
+          = ⁅(Subgroup.pi Set.univ Ss).lowerCentralSeries n, pi Ss⁆ := rfl
+      _ = ⁅pi fun i => (Ss i).lowerCentralSeries n, pi Ss⁆ := by rw [ih]
+      _ = pi fun i => ⁅(Ss i).lowerCentralSeries n, Ss i⁆ :=
+        commutator_pi_pi_of_finite _ _
+      _ = pi fun i => (Ss i).lowerCentralSeries n.succ := rfl
 
 /-- n-ary products of nilpotent groups are nilpotent. -/
 @[to_additive /-- n-ary products of nilpotent groups are nilpotent. -/]
@@ -1039,7 +1076,7 @@ instance Group.isNilpotent_pi [Finite η] [∀ i, IsNilpotent (Gs i)] : IsNilpot
   cases nonempty_fintype η
   rw [nilpotent_iff_lowerCentralSeries]
   refine ⟨Finset.univ.sup fun i => Group.nilpotencyClass (Gs i), ?_⟩
-  rw [lowerCentralSeries_pi_of_finite, pi_eq_bot_iff]
+  rw [← pi_top (I := Set.univ), lowerCentralSeries_pi_of_finite, pi_eq_bot_iff]
   intro i
   rw [lowerCentralSeries_eq_bot_iff_nilpotencyClass_le]
   exact Finset.le_sup (f := fun i => Group.nilpotencyClass (Gs i)) (Finset.mem_univ i)
@@ -1052,7 +1089,8 @@ theorem Group.nilpotencyClass_pi [Fintype η] [∀ i, IsNilpotent (Gs i)] :
   apply eq_of_forall_ge_iff
   intro k
   simp only [Finset.sup_le_iff, ← lowerCentralSeries_eq_bot_iff_nilpotencyClass_le,
-    lowerCentralSeries_pi_of_finite, pi_eq_bot_iff, Finset.mem_univ, true_imp_iff]
+    ← pi_top (I := Set.univ), lowerCentralSeries_pi_of_finite, pi_eq_bot_iff, Finset.mem_univ,
+    true_imp_iff]
 
 end FinitePi
 
@@ -1190,7 +1228,7 @@ open Group
   nilpotent_iff_finite_descending_central_series
 @[deprecated (since := "2026-03-25")] alias lowerCentralSeries := lowerCentralSeries
 @[deprecated (since := "2026-03-25")] alias lowerCentralSeries_zero := lowerCentralSeries_zero
-@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_one := lowerCentralSeries_one
+@[deprecated (since := "2026-05-25")] alias lowerCentralSeries_one := top_lowerCentralSeries_one
 @[deprecated (since := "2026-03-25")] alias mem_lowerCentralSeries_succ_iff :=
   mem_lowerCentralSeries_succ_iff
 @[deprecated (since := "2026-03-25")] alias lowerCentralSeries_succ := lowerCentralSeries_succ
@@ -1218,12 +1256,10 @@ alias least_descending_central_series_length_eq_nilpotencyClass :=
   lowerCentralSeries_nilpotencyClass
 @[deprecated (since := "2026-03-25")] alias lowerCentralSeries_eq_bot_iff_nilpotencyClass_le :=
   lowerCentralSeries_eq_bot_iff_nilpotencyClass_le
-@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_map_subtype_le :=
-  lowerCentralSeries_map_subtype_le
 @[deprecated (since := "2026-03-25")] alias upperCentralSeries.map := upperCentralSeries.map
-@[deprecated (since := "2026-03-25")] alias lowerCentralSeries.map := lowerCentralSeries.map
-@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_succ_eq_bot :=
-  lowerCentralSeries_succ_eq_bot
+@[deprecated (since := "2026-05-25")] alias lowerCentralSeries.map := map_lowerCentralSeries
+@[deprecated (since := "2026-05-25")] alias lowerCentralSeries_succ_eq_bot :=
+  top_lowerCentralSeries_succ_eq_bot
 @[deprecated (since := "2026-03-25")] alias isNilpotent_of_ker_le_center :=
   isNilpotent_of_ker_le_center
 @[deprecated (since := "2026-03-25")] alias nilpotencyClass_le_of_ker_le_center :=
@@ -1261,14 +1297,12 @@ alias least_descending_central_series_length_eq_nilpotencyClass :=
 @[deprecated (since := "2026-03-25")]
 alias upperCentralSeries.card_image_eq_of_le_nilpotencyClass :=
   upperCentralSeries.card_image_eq_of_le_nilpotencyClass
-@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_prod := lowerCentralSeries_prod
+-- `Subgroup.lowerCentralSeries_prod` is now generalized; no deprecation needed.
 @[deprecated (since := "2026-03-25")] alias isNilpotent_prod := isNilpotent_prod
 @[deprecated (since := "2026-03-25")] alias nilpotencyClass_prod := nilpotencyClass_prod
-@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_pi_le := lowerCentralSeries_pi_le
+-- `Subgroup.lowerCentralSeries_pi_le` and `_pi_of_finite` are now generalized.
 @[deprecated (since := "2026-03-25")] alias isNilpotent_pi_of_bounded_class :=
   isNilpotent_pi_of_bounded_class
-@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_pi_of_finite :=
-  lowerCentralSeries_pi_of_finite
 @[deprecated (since := "2026-03-25")] alias isNilpotent_pi := isNilpotent_pi
 @[deprecated (since := "2026-03-25")] alias nilpotencyClass_pi := nilpotencyClass_pi
 @[deprecated (since := "2026-03-25")] alias nilpotencyClass_le_one_of_isSimple_of_isNilpotent :=

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -612,15 +612,28 @@ theorem lowerCentralSeries_mono (n : ℕ) :
   | zero => intro S T h; simpa
   | succ d hd => intro S T h; simp only [lowerCentralSeries_succ]; exact commutator_mono (hd h) h
 
+/-- The lower central series commutes with images under a group homomorphism. -/
+@[to_additive]
+theorem map_lowerCentralSeries {H : Type*} [Group H] (f : G →* H) (S : Subgroup G) (n : ℕ) :
+    (S.lowerCentralSeries n).map f = (S.map f).lowerCentralSeries n := by
+  induction n with
+  | zero => simp
+  | succ d hd =>
+    rw [lowerCentralSeries_succ, lowerCentralSeries_succ, Subgroup.map_commutator, hd]
+
+/-- For `K ≤ H ≤ G`, the lower central series of `K` computed inside `H` and mapped to `G`
+coincides with the lower central series of `K.map H.subtype` computed directly in `G`. -/
+@[to_additive]
+theorem subtype_lowerCentralSeries (H : Subgroup G) (K : Subgroup H) (n : ℕ) :
+    (K.lowerCentralSeries n).map H.subtype = (K.map H.subtype).lowerCentralSeries n :=
+  map_lowerCentralSeries H.subtype K n
+
 @[to_additive (attr := simp)]
 theorem top_subtype_lowerCentralSeries (H : Subgroup G) (n : ℕ) :
     ((⊤ : Subgroup H).lowerCentralSeries n).map H.subtype = H.lowerCentralSeries n := by
-  induction n with
-  | zero => ext; simp
-  | succ d hd =>
-    simp only [lowerCentralSeries_succ, Subgroup.map_commutator, hd]
-    congr 1
-    ext; simp
+  rw [subtype_lowerCentralSeries]
+  congr 1
+  ext; simp
 
 /-- A subgroup `H` of `G`'s lower central series (viewed in `G`) coincides with the lower
 central series of `H` as its own group, mapped back to `G`. -/
@@ -665,14 +678,6 @@ theorem upperCentralSeries.map {H : Type*} [Group H] {f : G →* H} (h : Functio
     rintro _ ⟨x, hx : x ∈ upperCentralSeries G d.succ, rfl⟩ y'
     rcases h y' with ⟨y, rfl⟩
     simpa using hd (mem_map_of_mem f (hx y))
-
-@[to_additive]
-theorem map_lowerCentralSeries {H : Type*} [Group H] (f : G →* H) (S : Subgroup G) (n : ℕ) :
-    (S.lowerCentralSeries n).map f = (S.map f).lowerCentralSeries n := by
-  induction n with
-  | zero => simp
-  | succ d hd =>
-    rw [lowerCentralSeries_succ, lowerCentralSeries_succ, Subgroup.map_commutator, hd]
 
 @[to_additive]
 theorem top_lowerCentralSeries_succ_eq_bot {n : ℕ}
@@ -870,19 +875,12 @@ theorem nilpotent_center_quotient_ind {P : ∀ (G) [Group G] [IsNilpotent G], Pr
 
 end Group
 
--- todo: to_additivize.
-theorem Subgroup.derivedSeries_le_lowerCentralSeries (S : Subgroup G) (n : ℕ) :
-    S.derivedSeries n ≤ S.lowerCentralSeries n := by
+-- todo: namespace `derivedSeries` and to_additivize.
+theorem Subgroup.derived_le_lower_central (n : ℕ) :
+    derivedSeries G n ≤ (⊤ : Subgroup G).lowerCentralSeries n := by
   induction n with
   | zero => simp
-  | succ i ih =>
-    apply (Subgroup.commutator_mono ih (S.derivedSeries_le_self i)).trans
-    simp
-
-@[deprecated Subgroup.derivedSeries_le_lowerCentralSeries (since := "2026-05-25")]
-theorem Subgroup.derived_le_lower_central (n : ℕ) :
-    _root_.derivedSeries G n ≤ (⊤ : Subgroup G).lowerCentralSeries n := by
-  simpa using (⊤ : Subgroup G).derivedSeries_le_lowerCentralSeries n
+  | succ i ih => apply commutator_mono ih; simp
 
 /-- Abelian groups are nilpotent. -/
 @[to_additive /-- Abelian groups are nilpotent. -/]
@@ -989,12 +987,19 @@ theorem Subgroup.lowerCentralSeries_prod (S₁ : Subgroup G₁) (S₂ : Subgroup
         commutator_prod_prod _ _ _ _
       _ = (S₁.lowerCentralSeries n.succ).prod (S₂.lowerCentralSeries n.succ) := rfl
 
+/-- The ⊤-specialization of `lowerCentralSeries_prod`. -/
+@[to_additive]
+theorem Subgroup.top_lowerCentralSeries_prod (n : ℕ) :
+    (⊤ : Subgroup (G₁ × G₂)).lowerCentralSeries n =
+      ((⊤ : Subgroup G₁).lowerCentralSeries n).prod ((⊤ : Subgroup G₂).lowerCentralSeries n) := by
+  rw [← lowerCentralSeries_prod, top_prod_top]
+
 /-- Products of nilpotent groups are nilpotent. -/
 @[to_additive /-- Products of nilpotent groups are nilpotent. -/]
 instance Group.isNilpotent_prod [IsNilpotent G₁] [IsNilpotent G₂] : IsNilpotent (G₁ × G₂) := by
   rw [nilpotent_iff_lowerCentralSeries]
   refine ⟨max (Group.nilpotencyClass G₁) (Group.nilpotencyClass G₂), ?_⟩
-  rw [← top_prod_top (G := G₁) (N := G₂), lowerCentralSeries_prod,
+  rw [top_lowerCentralSeries_prod,
     lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr (le_max_left _ _),
     lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr (le_max_right _ _), bot_prod_bot]
 
@@ -1005,10 +1010,8 @@ theorem Group.nilpotencyClass_prod [IsNilpotent G₁] [IsNilpotent G₂] :
     Group.nilpotencyClass (G₁ × G₂) =
     max (Group.nilpotencyClass G₁) (Group.nilpotencyClass G₂) := by
   refine eq_of_forall_ge_iff fun k => ?_
-  rw [max_le_iff, ← lowerCentralSeries_eq_bot_iff_nilpotencyClass_le,
-    ← lowerCentralSeries_eq_bot_iff_nilpotencyClass_le,
-    ← lowerCentralSeries_eq_bot_iff_nilpotencyClass_le,
-    ← top_prod_top (G := G₁) (N := G₂), lowerCentralSeries_prod, prod_eq_bot_iff]
+  simp only [max_le_iff, ← lowerCentralSeries_eq_bot_iff_nilpotencyClass_le,
+    top_lowerCentralSeries_prod, prod_eq_bot_iff]
 
 end Prod
 
@@ -1034,18 +1037,23 @@ theorem Subgroup.lowerCentralSeries_pi_le (Ss : ∀ i, Subgroup (Gs i)) (n : ℕ
         commutator_pi_pi_le _ _
       _ = pi fun i => (Ss i).lowerCentralSeries n.succ := rfl
 
+/-- The ⊤-specialization of `lowerCentralSeries_pi_le`. -/
+@[to_additive]
+theorem Subgroup.top_lowerCentralSeries_pi_le (n : ℕ) :
+    (⊤ : Subgroup (∀ i, Gs i)).lowerCentralSeries n ≤ Subgroup.pi Set.univ
+      fun i => (⊤ : Subgroup (Gs i)).lowerCentralSeries n := by
+  rw [← pi_top (I := Set.univ)]
+  exact lowerCentralSeries_pi_le _ _
+
 /-- Products of nilpotent groups are nilpotent if their nilpotency class is bounded. -/
 @[to_additive /-- Products of nilpotent additive groups are nilpotent if their nilpotency class is
 bounded. -/]
 theorem Group.isNilpotent_pi_of_bounded_class [∀ i, IsNilpotent (Gs i)] (n : ℕ)
     (h : ∀ i, Group.nilpotencyClass (Gs i) ≤ n) : IsNilpotent (∀ i, Gs i) := by
   rw [nilpotent_iff_lowerCentralSeries]
-  refine ⟨n, ?_⟩
-  rw [eq_bot_iff, ← pi_top (I := Set.univ)]
-  apply le_trans (lowerCentralSeries_pi_le _ _)
-  rw [← eq_bot_iff, pi_eq_bot_iff]
-  intro i
-  apply lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr (h i)
+  refine ⟨n, eq_bot_iff.mpr <| (top_lowerCentralSeries_pi_le _).trans ?_⟩
+  rw [le_bot_iff, pi_eq_bot_iff]
+  exact fun i => lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr (h i)
 
 end BoundedPi
 
@@ -1070,13 +1078,20 @@ theorem Subgroup.lowerCentralSeries_pi_of_finite [Finite η] (Ss : ∀ i, Subgro
         commutator_pi_pi_of_finite _ _
       _ = pi fun i => (Ss i).lowerCentralSeries n.succ := rfl
 
+/-- The ⊤-specialization of `lowerCentralSeries_pi_of_finite`. -/
+@[to_additive]
+theorem Subgroup.top_lowerCentralSeries_pi_of_finite [Finite η] (n : ℕ) :
+    (⊤ : Subgroup (∀ i, Gs i)).lowerCentralSeries n = Subgroup.pi Set.univ
+      fun i => (⊤ : Subgroup (Gs i)).lowerCentralSeries n := by
+  rw [← pi_top (I := Set.univ), lowerCentralSeries_pi_of_finite]
+
 /-- n-ary products of nilpotent groups are nilpotent. -/
 @[to_additive /-- n-ary products of nilpotent groups are nilpotent. -/]
 instance Group.isNilpotent_pi [Finite η] [∀ i, IsNilpotent (Gs i)] : IsNilpotent (∀ i, Gs i) := by
   cases nonempty_fintype η
   rw [nilpotent_iff_lowerCentralSeries]
   refine ⟨Finset.univ.sup fun i => Group.nilpotencyClass (Gs i), ?_⟩
-  rw [← pi_top (I := Set.univ), lowerCentralSeries_pi_of_finite, pi_eq_bot_iff]
+  rw [top_lowerCentralSeries_pi_of_finite, pi_eq_bot_iff]
   intro i
   rw [lowerCentralSeries_eq_bot_iff_nilpotencyClass_le]
   exact Finset.le_sup (f := fun i => Group.nilpotencyClass (Gs i)) (Finset.mem_univ i)
@@ -1089,8 +1104,7 @@ theorem Group.nilpotencyClass_pi [Fintype η] [∀ i, IsNilpotent (Gs i)] :
   apply eq_of_forall_ge_iff
   intro k
   simp only [Finset.sup_le_iff, ← lowerCentralSeries_eq_bot_iff_nilpotencyClass_le,
-    ← pi_top (I := Set.univ), lowerCentralSeries_pi_of_finite, pi_eq_bot_iff, Finset.mem_univ,
-    true_imp_iff]
+    top_lowerCentralSeries_pi_of_finite, pi_eq_bot_iff, Finset.mem_univ, true_imp_iff]
 
 end FinitePi
 
@@ -1098,8 +1112,8 @@ end FinitePi
 instance (priority := 100) IsNilpotent.to_isSolvable [h : IsNilpotent G] : IsSolvable G := by
   obtain ⟨n, hn⟩ := nilpotent_iff_lowerCentralSeries.1 h
   use n
-  rw [eq_bot_iff, ← hn, ← Subgroup.top_derivedSeries_eq]
-  exact Subgroup.derivedSeries_le_lowerCentralSeries _ n
+  rw [eq_bot_iff, ← hn]
+  exact derived_le_lower_central n
 
 instance [IsSimpleGroup G] [IsNilpotent G] : CommGroup G :=
   ⟨IsSimpleGroup.comm_iff_isSolvable.mpr inferInstance⟩

--- a/Mathlib/GroupTheory/Solvable.lean
+++ b/Mathlib/GroupTheory/Solvable.lean
@@ -71,69 +71,6 @@ instance derivedSeries_characteristic (n : ℕ) : (derivedSeries G n).Characteri
 
 end derivedSeries
 
-section SubgroupDerivedSeries
-
-/-- The derived series of a subgroup `S` of `G`, computed in the ambient group `G`. This is the
-sequence `S, ⁅S, S⁆, ⁅⁅S, S⁆, ⁅S, S⁆⁆, …` of subgroups of `G`. The classical `derivedSeries G` is
-the case `S = ⊤`. -/
-def Subgroup.derivedSeries (S : Subgroup G) : ℕ → Subgroup G
-  | 0 => S
-  | n + 1 => ⁅Subgroup.derivedSeries S n, Subgroup.derivedSeries S n⁆
-
-namespace Subgroup
-
-@[simp]
-theorem derivedSeries_zero (S : Subgroup G) : S.derivedSeries 0 = S := rfl
-
-@[simp]
-theorem derivedSeries_succ (S : Subgroup G) (n : ℕ) :
-    S.derivedSeries (n + 1) = ⁅S.derivedSeries n, S.derivedSeries n⁆ := rfl
-
-theorem derivedSeries_le_self (S : Subgroup G) (n : ℕ) : S.derivedSeries n ≤ S := by
-  induction n with
-  | zero => simp
-  | succ d hd =>
-    simpa using (Subgroup.commutator_le_sup _ _).trans (by simp [hd])
-
-theorem derivedSeries_antitone (S : Subgroup G) : Antitone S.derivedSeries := by
-  refine antitone_nat_of_succ_le fun n => ?_
-  simpa using (Subgroup.commutator_le_sup _ _).trans (by simp)
-
-theorem map_derivedSeries {H : Type*} [Group H] (f : G →* H) (S : Subgroup G) (n : ℕ) :
-    (S.derivedSeries n).map f = (S.map f).derivedSeries n := by
-  induction n with
-  | zero => simp
-  | succ d hd => rw [derivedSeries_succ, derivedSeries_succ, Subgroup.map_commutator, hd]
-
-theorem derivedSeries_mono (n : ℕ) :
-    Monotone (fun S : Subgroup G => S.derivedSeries n) := by
-  induction n with
-  | zero => intro S T h; simpa
-  | succ d hd =>
-    intro S T h; simp only [derivedSeries_succ]; exact Subgroup.commutator_mono (hd h) (hd h)
-
-@[simp]
-theorem top_derivedSeries_eq (n : ℕ) :
-    (⊤ : Subgroup G).derivedSeries n = _root_.derivedSeries G n := by
-  induction n with
-  | zero => simp
-  | succ d hd => rw [derivedSeries_succ, _root_.derivedSeries_succ, hd]
-
-theorem top_subtype_derivedSeries (H : Subgroup G) (n : ℕ) :
-    ((⊤ : Subgroup H).derivedSeries n).map H.subtype = H.derivedSeries n := by
-  induction n with
-  | zero => ext; simp
-  | succ d hd =>
-    simp only [derivedSeries_succ, Subgroup.map_commutator, hd]
-
-theorem derivedSeries_eq_map (H : Subgroup G) (n : ℕ) :
-    H.derivedSeries n = ((⊤ : Subgroup H).derivedSeries n).map H.subtype :=
-  (top_subtype_derivedSeries H n).symm
-
-end Subgroup
-
-end SubgroupDerivedSeries
-
 section CommutatorMap
 
 section DerivedSeriesMap

--- a/Mathlib/GroupTheory/Solvable.lean
+++ b/Mathlib/GroupTheory/Solvable.lean
@@ -71,6 +71,69 @@ instance derivedSeries_characteristic (n : ℕ) : (derivedSeries G n).Characteri
 
 end derivedSeries
 
+section SubgroupDerivedSeries
+
+/-- The derived series of a subgroup `S` of `G`, computed in the ambient group `G`. This is the
+sequence `S, ⁅S, S⁆, ⁅⁅S, S⁆, ⁅S, S⁆⁆, …` of subgroups of `G`. The classical `derivedSeries G` is
+the case `S = ⊤`. -/
+def Subgroup.derivedSeries (S : Subgroup G) : ℕ → Subgroup G
+  | 0 => S
+  | n + 1 => ⁅Subgroup.derivedSeries S n, Subgroup.derivedSeries S n⁆
+
+namespace Subgroup
+
+@[simp]
+theorem derivedSeries_zero (S : Subgroup G) : S.derivedSeries 0 = S := rfl
+
+@[simp]
+theorem derivedSeries_succ (S : Subgroup G) (n : ℕ) :
+    S.derivedSeries (n + 1) = ⁅S.derivedSeries n, S.derivedSeries n⁆ := rfl
+
+theorem derivedSeries_le_self (S : Subgroup G) (n : ℕ) : S.derivedSeries n ≤ S := by
+  induction n with
+  | zero => simp
+  | succ d hd =>
+    simpa using (Subgroup.commutator_le_sup _ _).trans (by simp [hd])
+
+theorem derivedSeries_antitone (S : Subgroup G) : Antitone S.derivedSeries := by
+  refine antitone_nat_of_succ_le fun n => ?_
+  simpa using (Subgroup.commutator_le_sup _ _).trans (by simp)
+
+theorem map_derivedSeries {H : Type*} [Group H] (f : G →* H) (S : Subgroup G) (n : ℕ) :
+    (S.derivedSeries n).map f = (S.map f).derivedSeries n := by
+  induction n with
+  | zero => simp
+  | succ d hd => rw [derivedSeries_succ, derivedSeries_succ, Subgroup.map_commutator, hd]
+
+theorem derivedSeries_mono (n : ℕ) :
+    Monotone (fun S : Subgroup G => S.derivedSeries n) := by
+  induction n with
+  | zero => intro S T h; simpa
+  | succ d hd =>
+    intro S T h; simp only [derivedSeries_succ]; exact Subgroup.commutator_mono (hd h) (hd h)
+
+@[simp]
+theorem top_derivedSeries_eq (n : ℕ) :
+    (⊤ : Subgroup G).derivedSeries n = _root_.derivedSeries G n := by
+  induction n with
+  | zero => simp
+  | succ d hd => rw [derivedSeries_succ, _root_.derivedSeries_succ, hd]
+
+theorem top_subtype_derivedSeries (H : Subgroup G) (n : ℕ) :
+    ((⊤ : Subgroup H).derivedSeries n).map H.subtype = H.derivedSeries n := by
+  induction n with
+  | zero => ext; simp
+  | succ d hd =>
+    simp only [derivedSeries_succ, Subgroup.map_commutator, hd]
+
+theorem derivedSeries_eq_map (H : Subgroup G) (n : ℕ) :
+    H.derivedSeries n = ((⊤ : Subgroup H).derivedSeries n).map H.subtype :=
+  (top_subtype_derivedSeries H n).symm
+
+end Subgroup
+
+end SubgroupDerivedSeries
+
 section CommutatorMap
 
 section DerivedSeriesMap


### PR DESCRIPTION
This PR replaces `Subgroup.lowerCentralSeries (G : Type*)` with the more general `Subgroup.lowerCentralSeries (S : Subgroup G)`, the iterated commutator `⁅⁅⋯⁅S, S⁆, S⁆⋯, S⁆` of `S` with itself viewed in the ambient group `G`. The classical lower central series of `G` becomes the case `S = ⊤`; most of the existing API (`_zero`, `_succ`, `_antitone`, `_le_self`, `_mono`, `map_*`, the prod and pi versions) generalizes to arbitrary subgroups, and the proofs of `Subgroup.isNilpotent` and `Subgroup.nilpotencyClass_le` shed the `.map S.subtype` plumbing.

Motivation: requested on [#mathlib4 > Subgroup.lowerCentralSeries](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Subgroup.2ElowerCentralSeries/near/597532296); needed to clean up the Fitting's theorem PR (#39813).

🤖 Prepared with Claude Code