### PR TITLE
feat(ci): cross-reference tag review via post-build dump + workflow_run shim

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -760,7 +760,10 @@ jobs:
         with:
           name: crossref-tags-baseline
           path: crossref-tags.tsv
-          retention-days: 5
+          # 30 days: PRs that sit idle for a week or two should still find a
+          # baseline at their merge-base SHA. The TSV is ~55 KB so the
+          # storage cost is trivial.
+          retention-days: 30
 
       - name: prepare crossref bridge outputs
         # The privileged crossref_review.yml workflow_run job only fires

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -748,8 +748,10 @@ jobs:
       - name: dump cross-reference tags to TSV
         # Walks Mathlib.CrossRef.tagExt and writes one TSV row per @[stacks ...] /
         # @[kerodon ...] / @[wikidata ...] tag for the privileged workflow_run
-        # job (crossref_review.yml) to consume. The script has no network access
-        # and enforces a 2 MB output cap.
+        # job (crossref_review.yml) to consume. No network, defence-in-depth
+        # size cap (the trusted bound is in mathlib-ci's post-comment.sh).
+        # Only useful when there's a PR to comment on, so skip on push runs.
+        if: github.event.pull_request.number != ''
         run: lake env lean --run scripts/dump_crossref_tags.lean crossref-tags.tsv
 
       - name: prepare crossref bridge outputs

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -745,17 +745,26 @@ jobs:
       - name: clean up the import graph file
         run: rm import_graph.dot
 
-      # PR-only: this only feeds crossref_review.yml's PR comment.
-      # See scripts/dump_crossref_tags.lean for the output format and the
-      # (defence-in-depth) size cap; the trusted bound is in mathlib-ci's
-      # post-comment.sh.
+      # Always-on: produce the TSV for every build (PR + push to master).
+      # Master pushes upload it as a plain artifact (`crossref-tags-baseline`)
+      # so that workflow_run jobs on PRs can subtract the merge-base baseline
+      # and only render tags this PR actually changed.
+      # PR runs additionally emit a privileged bridge artifact for
+      # `crossref_review.yml` to consume.
+      # See scripts/dump_crossref_tags.lean for the output format.
       - name: dump cross-reference tags to TSV
-        if: github.event.pull_request.number != ''
         run: lake env lean --run scripts/dump_crossref_tags.lean crossref-tags.tsv
 
+      - name: upload crossref-tags baseline artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: crossref-tags-baseline
+          path: crossref-tags.tsv
+          retention-days: 5
+
       - name: prepare crossref bridge outputs
-        # We only emit the crossref bridge artifact when this build is for a PR
-        # (the `crossref_review.yml` workflow_run job has nothing to post otherwise).
+        # The privileged crossref_review.yml workflow_run job only fires
+        # for PRs; non-PR builds don't need the bridge artifact.
         id: crossref_outputs
         env:
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -745,12 +745,11 @@ jobs:
       - name: clean up the import graph file
         run: rm import_graph.dot
 
+      # PR-only: this only feeds crossref_review.yml's PR comment.
+      # See scripts/dump_crossref_tags.lean for the output format and the
+      # (defence-in-depth) size cap; the trusted bound is in mathlib-ci's
+      # post-comment.sh.
       - name: dump cross-reference tags to TSV
-        # Walks Mathlib.CrossRef.tagExt and writes one TSV row per @[stacks ...] /
-        # @[kerodon ...] / @[wikidata ...] tag for the privileged workflow_run
-        # job (crossref_review.yml) to consume. No network, defence-in-depth
-        # size cap (the trusted bound is in mathlib-ci's post-comment.sh).
-        # Only useful when there's a PR to comment on, so skip on push runs.
         if: github.event.pull_request.number != ''
         run: lake env lean --run scripts/dump_crossref_tags.lean crossref-tags.tsv
 

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -745,6 +745,41 @@ jobs:
       - name: clean up the import graph file
         run: rm import_graph.dot
 
+      - name: dump cross-reference tags to TSV
+        # Walks Mathlib.CrossRef.tagExt and writes one TSV row per @[stacks ...] /
+        # @[kerodon ...] / @[wikidata ...] tag for the privileged workflow_run
+        # job (crossref_review.yml) to consume. The script has no network access
+        # and enforces a 2 MB output cap.
+        run: lake env lean --run scripts/dump_crossref_tags.lean crossref-tags.tsv
+
+      - name: prepare crossref bridge outputs
+        # We only emit the crossref bridge artifact when this build is for a PR
+        # (the `crossref_review.yml` workflow_run job has nothing to post otherwise).
+        id: crossref_outputs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ inputs.pr_branch_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request_target" ] && [ -n "$PR_NUMBER" ]; then
+            jq -n --arg n "$PR_NUMBER" --arg s "$HEAD_SHA" \
+              '{ pr_number: $n, head_sha: $s }' > crossref-bridge-outputs.json
+            echo "emit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "emit=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: emit crossref bridge artifact
+        if: steps.crossref_outputs.outputs.emit == 'true'
+        uses: leanprover-community/privilege-escalation-bridge/emit@f5dfe313a79647c07315b451b2dc2a81a161a50d # v1.2.0
+        with:
+          artifact: crossref-tags-bridge
+          outputs_file: crossref-bridge-outputs.json
+          include_event: minimal
+          files: |
+            crossref-tags.tsv
+          retention_days: 5
+
       - name: check all scripts build successfully
         run: |
           lake env lean scripts/create_deprecated_modules.lean

--- a/.github/workflows/crossref_review.yml
+++ b/.github/workflows/crossref_review.yml
@@ -1,0 +1,62 @@
+# Cross-reference tag review (workflow_run)
+#
+# Privileged companion to the `dump cross-reference tags to TSV` step in
+# `build_template.yml`. Downloads the bridge artifact emitted by the build,
+# hands off to mathlib-ci's orchestrator, which in turn invokes the
+# pinned `leanprover-community/external-tags` tool to fetch snippets and
+# produce the PR comment body, then posts/updates the comment.
+#
+# The privileged job runs with `pull-requests: write`, but it executes only
+# code from mathlib-ci (which executes only code from external-tags at a
+# pinned SHA). Nothing from the build artifact is interpreted as code; the
+# TSV is parsed as untrusted data.
+name: cross-reference review (workflow_run)
+
+on:
+  workflow_run:
+    workflows:
+      - continuous integration
+      - continuous integration (mathlib forks)
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: Post cross-reference review comment
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'leanprover-community/mathlib4' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Consume bridge artifact
+        id: bridge
+        uses: leanprover-community/privilege-escalation-bridge/consume@f5dfe313a79647c07315b451b2dc2a81a161a50d # v1.2.0
+        with:
+          token: ${{ github.token }}
+          artifact: crossref-tags-bridge
+          # Pushes (non-PR builds) intentionally skip the emit step, so a
+          # missing artifact is the common case for non-PR runs.
+          fail_on_missing: false
+          extract: |
+            pr_number=outputs.pr_number
+            head_sha=outputs.head_sha
+
+      - name: Checkout mathlib-ci
+        if: steps.bridge.outputs.pr_number != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: leanprover-community/mathlib-ci
+          ref: master
+          path: mathlib-ci
+
+      - name: Run cross-reference review
+        if: steps.bridge.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.bridge.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.bridge.outputs.head_sha }}
+          TSV_PATH: ${{ github.workspace }}/.bridge/crossref-tags.tsv
+        run: bash mathlib-ci/scripts/crossref_review/post-comment.sh

--- a/.github/workflows/crossref_review.yml
+++ b/.github/workflows/crossref_review.yml
@@ -60,6 +60,52 @@ jobs:
         if: steps.bridge.outputs.pr_number != ''
         uses: ./workflow-actions/.github/actions/get-mathlib-ci
 
+      # mathlib-ci's post-comment.sh hardcodes the pinned external-tags
+      # SHA. We grep it out so the cache key tracks the same source of
+      # truth. Bumping the pin is a one-line PR to mathlib-ci.
+      - name: Resolve pinned external-tags SHA
+        if: steps.bridge.outputs.pr_number != ''
+        id: pin
+        run: |
+          sha=$(grep -E '^EXTERNAL_TAGS_SHA=' "${CI_SCRIPTS_DIR}/crossref_review/post-comment.sh" | head -1 | cut -d'"' -f2)
+          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not parse EXTERNAL_TAGS_SHA from post-comment.sh; got: '$sha'" >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "external-tags pinned at $sha"
+
+      # Restore (and on miss, eventually populate) a single cache that
+      # covers both the Lean toolchain (~/.elan) and the built
+      # external-tags lake project. The key changes whenever the pinned
+      # external-tags ref changes; a stale toolchain across pin bumps
+      # costs us one rebuild and that's acceptable.
+      - name: Restore external-tags build cache
+        if: steps.bridge.outputs.pr_number != ''
+        id: cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.elan
+            external-tags
+          key: crossref-render-${{ steps.pin.outputs.sha }}-${{ runner.os }}
+
+      - name: Install elan
+        if: steps.bridge.outputs.pr_number != '' && steps.cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          curl -sSfL https://elan.lean-lang.org/elan-init.sh \
+            | bash -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Clone and build external-tags
+        if: steps.bridge.outputs.pr_number != '' && steps.cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          git clone --quiet https://github.com/leanprover-community/external-tags external-tags
+          ( cd external-tags && git checkout --quiet "${{ steps.pin.outputs.sha }}" )
+          ( cd external-tags && lake build crossref-render )
+
       - name: Run cross-reference review
         if: steps.bridge.outputs.pr_number != ''
         env:
@@ -67,4 +113,9 @@ jobs:
           PR_NUMBER: ${{ steps.bridge.outputs.pr_number }}
           HEAD_SHA: ${{ steps.bridge.outputs.head_sha }}
           TSV_PATH: ${{ github.workspace }}/.bridge/crossref-tags.tsv
-        run: bash "${CI_SCRIPTS_DIR}/crossref_review/post-comment.sh"
+          CROSSREF_RENDER_BIN: ${{ github.workspace }}/external-tags/.lake/build/bin/crossref-render
+        run: |
+          # elan is needed on PATH so the lake-built binary can find its
+          # toolchain shared libs (rpath points into ~/.elan/toolchains/).
+          [[ -d "$HOME/.elan/bin" ]] && export PATH="$HOME/.elan/bin:$PATH"
+          bash "${CI_SCRIPTS_DIR}/crossref_review/post-comment.sh"

--- a/.github/workflows/crossref_review.yml
+++ b/.github/workflows/crossref_review.yml
@@ -44,13 +44,21 @@ jobs:
             pr_number=outputs.pr_number
             head_sha=outputs.head_sha
 
-      - name: Checkout mathlib-ci
+      # Use the local composite action so the pinned mathlib-ci ref is the
+      # single source of truth (matches olean_report.yaml, etc.). The
+      # validate-ci-scripts-paths lint requires this.
+      - name: Checkout local actions
         if: steps.bridge.outputs.pr_number != ''
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: leanprover-community/mathlib-ci
-          ref: master
-          path: mathlib-ci
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          sparse-checkout: .github/actions
+          path: workflow-actions
+
+      - name: Get mathlib-ci
+        if: steps.bridge.outputs.pr_number != ''
+        uses: ./workflow-actions/.github/actions/get-mathlib-ci
 
       - name: Run cross-reference review
         if: steps.bridge.outputs.pr_number != ''
@@ -59,4 +67,4 @@ jobs:
           PR_NUMBER: ${{ steps.bridge.outputs.pr_number }}
           HEAD_SHA: ${{ steps.bridge.outputs.head_sha }}
           TSV_PATH: ${{ github.workspace }}/.bridge/crossref-tags.tsv
-        run: bash mathlib-ci/scripts/crossref_review/post-comment.sh
+        run: bash "${CI_SCRIPTS_DIR}/crossref_review/post-comment.sh"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -210,6 +210,14 @@ to module `Foo.Bar` (no `srcDir` indirection).
   you can convert `pick abc # x scripts/auto_commit.sh cmd` to `x scripts/auto_commit.sh cmd`
   (by deleting the "pick abc # " prefix), and git will re-run the command via exec.
   Example: `scripts/auto_commit.sh lake exe mk_all`
+- `dump_crossref_tags.lean` walks `Mathlib.CrossRef.tagExt` in a fully built Mathlib environment
+  and writes one TSV row per `@[stacks ...]` / `@[kerodon ...]` / `@[wikidata ...]` tag with
+  columns `(database, tag, declName, module, comment)`. Used by the `cross-reference review`
+  workflow_run job (`.github/workflows/crossref_review.yml`) to hand off to the orchestrator in
+  [leanprover-community/external-tags](https://github.com/leanprover-community/external-tags).
+  The output is capped at 2 MB and TSV fields are sanitised so user-controlled comments cannot
+  break the framing.
+  Usage: `lake env lean --run scripts/dump_crossref_tags.lean <out.tsv>`.
 - `parse_shake_output.py` parses the captured output of `lake shake` and reports the number of
   files changed and imports added/removed. Used by the `shake` workflow to populate the PR body
   and Zulip notification. Counts are printed to stdout and, if a second argument is given

--- a/scripts/dump_crossref_tags.lean
+++ b/scripts/dump_crossref_tags.lean
@@ -30,15 +30,18 @@ Implementation: we use `importModules (loadExts := true)` rather than the
 `withImportModules` wrapper, because the latter passes `loadExts := false`
 and would leave `tagExt` empty for imported modules.
 
-Safety: fields are normalised (tabs / newlines in comments become single
-spaces) and the whole file is capped at `maxBytes` to bound what a malicious
-PR could emit.
+Hygiene: fields are normalised (tabs / newlines in comments become single
+spaces) so they can't break the TSV framing, and the whole file is capped
+at `maxBytes`. This script lives in `scripts/` and runs with the PR's
+permissions, so the cap is defence-in-depth — the trusted consumer
+(mathlib-ci's `post-comment.sh`) enforces its own cap on the artifact
+before parsing.
 -/
 
 open Lean Mathlib.CrossRef
 
-/-- Hard cap on the output. The current population is ~55 KB (539 tags); we
-allow ~50× headroom and refuse to emit anything larger. -/
+/-- Hard cap on the output. The current population is ~55 KB (491 tags);
+2 MB is ample headroom. -/
 def maxBytes : Nat := 2 * 1024 * 1024
 
 /-- Replace tabs, newlines, and carriage returns with single spaces so a

--- a/scripts/dump_crossref_tags.lean
+++ b/scripts/dump_crossref_tags.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Lean
+import Mathlib.Tactic.CrossRefAttribute
+
+/-!
+# Dump every cross-reference tag in Mathlib to TSV
+
+```sh
+lake env lean --run scripts/dump_crossref_tags.lean <out.tsv>
+```
+
+Loads the elaborated Mathlib environment, walks `Mathlib.CrossRef.tagExt`,
+and writes one TSV record per tag:
+
+```
+<database>\t<tag>\t<declName>\t<module>\t<comment>
+```
+
+This is the only piece of cross-reference review machinery that has to live
+in mathlib4: the rest (snippet fetching, filtering by PR diff, Markdown
+rendering, comment posting) is in `leanprover-community/external-tags`
+and `leanprover-community/mathlib-ci`. The TSV emitted here is treated as
+untrusted data by the privileged workflow_run consumer.
+
+Implementation: we use `importModules (loadExts := true)` rather than the
+`withImportModules` wrapper, because the latter passes `loadExts := false`
+and would leave `tagExt` empty for imported modules.
+
+Safety: fields are normalised (tabs / newlines in comments become single
+spaces) and the whole file is capped at `maxBytes` to bound what a malicious
+PR could emit.
+-/
+
+open Lean Mathlib.CrossRef
+
+/-- Hard cap on the output. The current population is ~55 KB (539 tags); we
+allow ~50× headroom and refuse to emit anything larger. -/
+def maxBytes : Nat := 2 * 1024 * 1024
+
+/-- Replace tabs, newlines, and carriage returns with single spaces so a
+field can't break the TSV framing. -/
+def sanitiseField (s : String) : String :=
+  s.replace "\t" " " |>.replace "\r\n" " " |>.replace "\n" " " |>.replace "\r" " "
+
+/-- Convert a module name like `` `Mathlib.Algebra.Foo `` to its source path
+(e.g. `"Mathlib/Algebra/Foo.lean"`). -/
+def moduleToFilePath (m : Name) : String :=
+  m.toString.replace "." "/" ++ ".lean"
+
+unsafe def run (outPath : System.FilePath) : IO UInt32 := do
+  initSearchPath (← findSysroot)
+  enableInitializersExecution
+  let env ← importModules (loadExts := true) #[`Mathlib] {} 1024
+  let tagsPair : List Tag × Array (Array Tag) :=
+    PersistentEnvExtension.getState tagExt env
+  let allTags := tagsPair.2.flatten.appendList tagsPair.1
+  let mut rows : Array String := #[]
+  for tag in allTags do
+    let some mod := env.getModuleFor? tag.declName | continue
+    let file := moduleToFilePath mod
+    let dbName : String := match tag.database with
+      | .kerodon  => "kerodon"
+      | .stacks   => "stacks"
+      | .wikidata => "wikidata"
+    rows := rows.push s!"{dbName}\t{sanitiseField tag.tag}\t{tag.declName}\t\
+      {sanitiseField file}\t{sanitiseField tag.comment}"
+  let body := String.intercalate "\n" rows.toList ++ if rows.isEmpty then "" else "\n"
+  if body.utf8ByteSize > maxBytes then
+    throw <| .userError s!"dump exceeds {maxBytes} bytes (got {body.utf8ByteSize})"
+  IO.FS.writeFile outPath body
+  IO.eprintln s!"Wrote {rows.size} cross-reference tag(s) to {outPath} \
+    ({body.utf8ByteSize} bytes)."
+  return 0
+
+unsafe def main (args : List String) : IO UInt32 := do
+  match args with
+  | [out] => run out
+  | _ =>
+    IO.eprintln "Usage: lake env lean --run scripts/dump_crossref_tags.lean <out.tsv>"
+    return 64

--- a/scripts/dump_crossref_tags.lean
+++ b/scripts/dump_crossref_tags.lean
@@ -69,7 +69,8 @@ unsafe def run (outPath : System.FilePath) : IO UInt32 := do
       | .kerodon  => "kerodon"
       | .stacks   => "stacks"
       | .wikidata => "wikidata"
-    rows := rows.push s!"{dbName}\t{sanitiseField tag.tag}\t{tag.declName}\t\
+    rows := rows.push s!"{dbName}\t{sanitiseField tag.tag}\t\
+      {sanitiseField tag.declName.toString}\t\
       {sanitiseField file}\t{sanitiseField tag.comment}"
   let body := String.intercalate "\n" rows.toList ++ if rows.isEmpty then "" else "\n"
   if body.utf8ByteSize > maxBytes then


### PR DESCRIPTION
This PR adds the cross-reference tag review pipeline on the mathlib4 side. Three new steps in `post_steps` of [build_template.yml](.github/workflows/build_template.yml) run `scripts/dump_crossref_tags.lean`, upload its TSV unconditionally as a plain `crossref-tags-baseline` artifact (30-day retention), and on PR builds also emit a privileged `crossref-tags-bridge` via [`privilege-escalation-bridge`](https://github.com/leanprover-community/privilege-escalation-bridge). A new [crossref_review.yml](.github/workflows/crossref_review.yml) workflow_run listener consumes the bridge, caches and pre-builds `crossref-render` from a pinned [external-tags](https://github.com/leanprover-community/external-tags) ref, and invokes the orchestrator in [mathlib-ci #44](https://github.com/leanprover-community/mathlib-ci/pull/44).

Trust model: the privileged job runs only code from `mathlib-ci@<pinned SHA>` (which in turn only runs `external-tags@<pinned SHA>`). The TSV is parsed as untrusted data; user-controllable fields are escaped before going into the bot comment.

- [ ] depends on: #39876

🤖 Prepared with [Claude Code](https://claude.com/claude-code)