### PR TITLE
[Merged by Bors] - feat(Order/InititalSeg): `PrincipalSeg` is trichotomous for well orders

### DIFF
--- a/Mathlib/Order/InitialSeg.lean
+++ b/Mathlib/Order/InitialSeg.lean
@@ -568,8 +568,8 @@ noncomputable def InitialSeg.total (r s) [IsWellOrder α r] [IsWellOrder β s] :
 noncomputable def PrincipalSeg.trichotomy (r s) [IsWellOrder α r] [IsWellOrder β s] :
     (r ≺i s) ⊕ (r ≃r s) ⊕ (s ≺i r) :=
   match InitialSeg.total r s with
-  | .inl f => (f.principalSumRelIso).elim .inl (.inr ∘ .inl)
-  | .inr g => (g.principalSumRelIso).elim (.inr ∘ .inr) (.inr ∘ .inl ∘ .symm)
+  | .inl f => f.principalSumRelIso.elim .inl (.inr ∘ .inl)
+  | .inr g => g.principalSumRelIso.elim (.inr ∘ .inr) (.inr ∘ .inl ∘ .symm)
 
 /-! ### Initial or principal segments with `<` -/
 

--- a/Mathlib/Order/InitialSeg.lean
+++ b/Mathlib/Order/InitialSeg.lean
@@ -564,6 +564,13 @@ noncomputable def InitialSeg.total (r s) [IsWellOrder α r] [IsWellOrder β s] :
       · exact ⟨Sum.inr <| (g.codRestrict {x | Sum.Lex r s x f.top}
           (fun a => _root_.trans (g.lt_top a) h) h).transRelIso f.subrelIso⟩
 
+/-- For any two well orders, one is a principal segment of the other, or they are isomorphic. -/
+noncomputable def PrincipalSeg.trichotomy (r s) [IsWellOrder α r] [IsWellOrder β s] :
+    (r ≺i s) ⊕ (r ≃r s) ⊕ (s ≺i r) :=
+  match InitialSeg.total r s with
+  | .inl f => (f.principalSumRelIso).elim .inl (.inr ∘ .inl)
+  | .inr g => (g.principalSumRelIso).elim (.inr ∘ .inr) (.inr ∘ .inl ∘ .symm)
+
 /-! ### Initial or principal segments with `<` -/
 
 namespace InitialSeg


### PR DESCRIPTION
For any two well orders, one is a principal segment of the other, or they are isomorphic.

Suggested by @vihdzp in the review of #39545
https://github.com/leanprover-community/mathlib4/pull/39545#discussion_r3262466782. It may slightly simplify the proof of `infinite_iff_nonempty_relEmbedding_of_isWellOrder`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
