### PR TITLE
feat(PerronFrobenius): Perron–Frobenius for column-stochastic matrices

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5077,6 +5077,7 @@ public import Mathlib.LinearAlgebra.Matrix.Notation
 public import Mathlib.LinearAlgebra.Matrix.Orthogonal
 public import Mathlib.LinearAlgebra.Matrix.Permanent
 public import Mathlib.LinearAlgebra.Matrix.Permutation
+public import Mathlib.LinearAlgebra.Matrix.PerronFrobenius.Stochastic
 public import Mathlib.LinearAlgebra.Matrix.Polynomial
 public import Mathlib.LinearAlgebra.Matrix.PosDef
 public import Mathlib.LinearAlgebra.Matrix.ProjectiveSpecialLinearGroup

--- a/Mathlib/LinearAlgebra/Matrix/PerronFrobenius/Stochastic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PerronFrobenius/Stochastic.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2025 Matteo Cipollina. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matteo Cipollina, Michail Karatarakis
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.PerronFrobenius.Dominance
+
+/-!
+# Column-stochastic matrices
+
+Perron–Frobenius consequences for irreducible column-stochastic matrices.
+
+## Main results
+
+* `exists_positive_eigenvector_of_irreducible_stochastic`: an irreducible column-stochastic
+  matrix has a unique stationary distribution in the standard simplex.
+
+## References
+
+* [E. Seneta, *Non-negative Matrices and Markov Chains*][seneta2006]
+
+## Tags
+
+stochastic matrix, stationary distribution, Perron–Frobenius theorem
+-/
+
+@[expose] public section
+
+namespace Matrix
+
+open CollatzWielandt
+
+variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+
+/-- An irreducible column-stochastic matrix has a unique stationary vector in the simplex. -/
+theorem exists_positive_eigenvector_of_irreducible_stochastic
+    {A : Matrix n n ℝ} (hA_irred : A.IsIrreducible) (h_col_stoch : ∀ j, ∑ i, A i j = 1) :
+    ∃! v : stdSimplex ℝ n, A *ᵥ v.val = v.val := by
+  have hA_nonneg := hA_irred.1
+  have h_eig_T : Aᵀ *ᵥ (fun _ ↦ 1) = (1 : ℝ) • (fun _ ↦ 1) := by
+    ext i; simp [mulVec_apply, h_col_stoch]
+  have r_A_eq_one : perronRoot_alt A = 1 := by
+    rw [perronRoot_transpose_eq A hA_irred]
+    exact (eigenvalue_is_perron_root_of_positive_eigenvector hA_irred.transpose
+      (fun i j ↦ hA_nonneg j i) zero_lt_one (fun _ ↦ zero_lt_one) h_eig_T).symm
+  obtain ⟨v, ⟨r, hr_pos, h_eig⟩, _⟩ := pft_irreducible hA_irred
+  have v_pos_raw := eigenvector_is_positive_of_irreducible hA_irred h_eig v.property.1
+    (ne_zero_of_mem_stdSimplex v.property)
+  have h_eig_one : A *ᵥ v.val = v.val := by
+    simpa [
+      eigenvalue_is_perron_root_of_positive_eigenvector hA_irred hA_nonneg hr_pos v_pos_raw h_eig,
+      r_A_eq_one] using h_eig
+  refine ⟨v, h_eig_one, fun w hw_eig ↦ Subtype.ext ?_⟩
+  have hv_eig' : A *ᵥ v.val = (1 : ℝ) • v.val := by simpa using h_eig_one
+  have hw_eig' : A *ᵥ w.val = (1 : ℝ) • w.val := by simpa using hw_eig
+  have v_pos := eigenvector_is_positive_of_irreducible hA_irred hv_eig' v.property.1
+    (ne_zero_of_mem_stdSimplex v.property)
+  have w_pos := eigenvector_is_positive_of_irreducible hA_irred hw_eig' w.property.1
+    (ne_zero_of_mem_stdSimplex w.property)
+  obtain ⟨c, _, hc_eq⟩ :=
+    uniqueness_of_positive_eigenvector_gen hA_irred zero_lt_one v_pos w_pos hv_eig' hw_eig'
+  have hc_one : c = 1 := by
+    calc c = c * ∑ i, w.val i := by simp [w.property.2]
+      _ = ∑ i, v.val i := by simp [hc_eq, smul_eq_mul, ← Finset.mul_sum]
+      _ = 1 := v.property.2
+  simp [hc_eq, hc_one]
+
+end Matrix


### PR DESCRIPTION
Add `Mathlib/LinearAlgebra/Matrix/PerronFrobenius/Stochastic.lean`: Perron–Frobenius theorem for column-stochastic matrices.

Part of the Perron–Frobenius formalization (with @or4nge19).

---

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [ ] depends on: #39923

cc @or4nge19 for review