### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Sites): precoverages generating a Grothendieck topology

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3372,6 +3372,8 @@ public import Mathlib.CategoryTheory.Sites.Point.Over
 public import Mathlib.CategoryTheory.Sites.Point.Presheaf
 public import Mathlib.CategoryTheory.Sites.Point.Skyscraper
 public import Mathlib.CategoryTheory.Sites.Precoverage
+public import Mathlib.CategoryTheory.Sites.Precoverage.Generates
+public import Mathlib.CategoryTheory.Sites.Precoverage.Subsheaf
 public import Mathlib.CategoryTheory.Sites.PrecoverageToGrothendieck
 public import Mathlib.CategoryTheory.Sites.Preserves
 public import Mathlib.CategoryTheory.Sites.PreservesLimits

--- a/Mathlib/CategoryTheory/ShrinkYoneda.lean
+++ b/Mathlib/CategoryTheory/ShrinkYoneda.lean
@@ -60,6 +60,9 @@ def shrinkCompUliftFunctorIso (F : C ⥤ Type w') [FunctorToTypes.Small.{w} F]
   NatIso.ofComponents
     (fun X ↦ Equiv.toIso ((Equiv.ulift.trans (equivShrink _).symm).trans (equivShrink _)))
 
+unif_hint (F : C ⥤ Type w') [FunctorToTypes.Small.{w} F] (X : C) where ⊢
+  Shrink (F.obj X) ≟ (FunctorToTypes.shrink F).obj X
+
 end FunctorToTypes
 
 variable [LocallySmall.{w} C]

--- a/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
+++ b/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
@@ -5,6 +5,7 @@ Authors: Bhavik Mehta
 -/
 module
 
+public import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
 public import Mathlib.CategoryTheory.Sites.Sieves
 
 /-!
@@ -227,6 +228,13 @@ theorem restrict_extend {x : FamilyOfElements P R} (t : x.Compatible) :
   funext Y f hf
   exact extend_agrees t hf
 
+lemma FamilyOfElements.Compatible.of_mono (f : P ⟶ Q) [Mono f] {x : R.FamilyOfElements P}
+    (hx : (x.map f).Compatible) :
+    x.Compatible := by
+  intro Y Z W g₁ g₂ f₁ f₂ hf₁ hf₂ heq
+  refine injective_of_mono (f.app _) ?_
+  simpa using hx _ _ hf₁ hf₂ heq
+
 /--
 If the arrow set for a family of elements is actually a sieve (i.e. it is downward closed) then the
 consistency condition can be simplified.
@@ -406,6 +414,13 @@ lemma FamilyOfElements.isAmalgamation_singleton_iff {X Y : C} (f : X ⟶ Y)
   refine ⟨fun H ↦ H _ _, ?_⟩
   rintro H Y g ⟨rfl⟩
   exact H
+
+lemma FamilyOfElements.IsAmalgamation.of_mono (f : P ⟶ Q) [Mono f] {x : R.FamilyOfElements P}
+    {t : P.obj (.op X)} (ht : (x.map f).IsAmalgamation (f.app _ t)) :
+    x.IsAmalgamation t := by
+  intro Y u hu
+  refine injective_of_mono (f.app _) ?_
+  simpa [NatTrans.naturality_apply] using ht _ hu
 
 /-- A presheaf is separated for a presieve if there is at most one amalgamation. -/
 def IsSeparatedFor (P : Cᵒᵖ ⥤ Type w) (R : Presieve X) : Prop :=
@@ -726,6 +741,11 @@ theorem isSeparatedFor_iso {P' : Cᵒᵖ ⥤ Type w} (i : P ≅ P') (hP : IsSepa
     IsSeparatedFor P' R := by
   intro x t₁ t₂ ht₁ ht₂
   simpa using congrArg (i.hom.app _) <| hP (x.map i.inv) _ _ (ht₁.map i.inv) (ht₂.map i.inv)
+
+lemma IsSeparatedFor.of_mono (f : P ⟶ Q) [Mono f] (h : R.IsSeparatedFor Q) :
+    R.IsSeparatedFor P := by
+  intro x t₁ t₂ ht₁ ht₂
+  exact injective_of_mono _ <|  h (x.map f) _ _ (ht₁.map f) (ht₂.map f)
 
 /-- If a presieve `R` on `X` has a subsieve `S` such that:
 

--- a/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
+++ b/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
@@ -420,7 +420,7 @@ lemma FamilyOfElements.IsAmalgamation.of_mono (f : P ⟶ Q) [Mono f] {x : R.Fami
     x.IsAmalgamation t := by
   intro Y u hu
   refine injective_of_mono (f.app _) ?_
-  simpa [NatTrans.naturality_apply] using ht _ hu
+  simpa using ht _ hu
 
 /-- A presheaf is separated for a presieve if there is at most one amalgamation. -/
 def IsSeparatedFor (P : Cᵒᵖ ⥤ Type w) (R : Presieve X) : Prop :=

--- a/Mathlib/CategoryTheory/Sites/Precoverage/Generates.lean
+++ b/Mathlib/CategoryTheory/Sites/Precoverage/Generates.lean
@@ -86,8 +86,9 @@ lemma Generates.isSheaf_of_forall (h : K.Generates J) (F : Cᵒᵖ ⥤ Type w)
       fun Z g hg ↦ ⟨x g hg, .base <| .inl <| .inl ⟨⟨g, hg⟩, rfl⟩⟩
     have ht₁' : t₁ ∈ Q.obj (.op X) := .base (.inl <| .inr ⟨𝟙 _, by simp⟩)
     have ht₂' : t₂ ∈ Q.obj (.op X) := .base (.inr ⟨𝟙 _, by simp⟩)
-    exact congr($((hQ _ hS).isSeparatedFor x' ⟨_, ht₁'⟩ ⟨_, ht₂'⟩
-      (.of_mono Q.ι ht₁) (.of_mono Q.ι ht₂)).val)
+    have : (⟨t₁, ht₁'⟩ : Q.obj _) = ⟨t₂, ht₂'⟩ :=
+      (hQ _ hS).isSeparatedFor x' ⟨_, ht₁'⟩ ⟨_, ht₂'⟩ (.of_mono Q.ι ht₁) (.of_mono Q.ι ht₂)
+    simp_all
   · let 𝒮 (Z : C) := Set.range (fun (g : { g : Z ⟶ X | S.arrows g }) ↦ x _ g.2)
     let Q : Subfunctor F := K.subsheafify 𝒮
     have (Z : C) : _root_.Small.{max u v} (Q.toFunctor.obj (Opposite.op Z)) :=

--- a/Mathlib/CategoryTheory/Sites/Precoverage/Generates.lean
+++ b/Mathlib/CategoryTheory/Sites/Precoverage/Generates.lean
@@ -51,7 +51,6 @@ lemma Generates.generate_mem (H : K.Generates J) {X : C} {R : Presieve X} (h : R
     .generate R ∈ J X :=
   H.le_toPrecoverage _ h
 
-set_option backward.isDefEq.respectTransparency false in
 private lemma Generates.isSheaf_of_forall_aux (h : K.Generates J) (F : Cᵒᵖ ⥤ Type w)
     (H : ∀ ⦃X : C⦄, ∀ R ∈ K X, Presieve.IsSheafFor F R)
     [∀ (Z : C), _root_.Small.{max u v} (F.obj (.op Z))] :
@@ -67,12 +66,18 @@ private lemma Generates.isSheaf_of_forall_aux (h : K.Generates J) (F : Cᵒᵖ �
   rw [← Presieve.isSheafFor_iff_of_nat_equiv e he]
   exact H _ hR
 
+/-- If `K` generates `J`, then any presheaf `Cᵒᵖ ⥤ Type w` that satisfies the sheaf
+condition for all `K`-coverings, is a `J`-sheaf. -/
 lemma Generates.isSheaf_of_forall (h : K.Generates J) (F : Cᵒᵖ ⥤ Type w)
     (H : ∀ ⦃X : C⦄, ∀ R ∈ K X, Presieve.IsSheafFor F R) :
     Presieve.IsSheaf J F := by
+  /- By assumption, the statement holds for `w = max u v`. The idea of the proof is
+  to construct a suitable `Type max u v` valued subsheaf of `F` for each covering sieve `S` in
+  `J` and every family of sections over `S` to check the necessary conditions.
+  We explain existence below, uniqueness works similary. -/
   intro X S hS
   rw [← Presieve.isSeparatedFor_and_exists_isAmalgamation_iff_isSheafFor]
-  refine ⟨?_, fun x hx ↦ ?_⟩
+  refine ⟨?_, ?_⟩
   · intro x t₁ t₂ ht₁ ht₂
     let 𝒮 (Z : C) : Set (F.obj (.op Z)) :=
       .range (fun (g : { g : Z ⟶ X | S.arrows g }) ↦ x _ g.2) ∪
@@ -89,12 +94,19 @@ lemma Generates.isSheaf_of_forall (h : K.Generates J) (F : Cᵒᵖ ⥤ Type w)
     have : (⟨t₁, ht₁'⟩ : Q.obj _) = ⟨t₂, ht₂'⟩ :=
       (hQ _ hS).isSeparatedFor x' ⟨_, ht₁'⟩ ⟨_, ht₂'⟩ (.of_mono Q.ι ht₁) (.of_mono Q.ι ht₂)
     simp_all
-  · let 𝒮 (Z : C) := Set.range (fun (g : { g : Z ⟶ X | S.arrows g }) ↦ x _ g.2)
+  · -- Let `x` be a compatible family of elements over `S`. We need to show it glues.
+    intro x hx
+    -- Let `𝒮` be the family of subsets consisting of the family of elements `x`.
+    let 𝒮 (Z : C) := Set.range (fun (g : { g : Z ⟶ X | S.arrows g }) ↦ x _ g.2)
+    /- Let `Q` be the smallest `K`-subsheaf of `K` containing `𝒮`. This is `max u v`-small, because
+    `𝒮` is `max u v`-small. -/
     let Q : Subfunctor F := K.subsheafify 𝒮
     have (Z : C) : _root_.Small.{max u v} (Q.toFunctor.obj (Opposite.op Z)) :=
       small_subsheafify_of_small H _ inferInstance _
     have hQ : Presieve.IsSheaf J Q.toFunctor :=
       h.isSheaf_of_forall_aux _ fun X R hR ↦ isSheafFor_subsheafify _ hR (H _ hR)
+    /- By assumption, `Q` is a `J`-sheaf, so the family of sections `x` glues and gives rise
+    to an amalgamation of `x` in `F`. -/
     obtain ⟨t, ht, _⟩ := hQ _ hS (fun Z g hg ↦ ⟨x g hg, .base ⟨⟨g, hg⟩, rfl⟩⟩) (.of_mono Q.ι hx)
     exact ⟨t.val, ht.map Q.ι⟩
 

--- a/Mathlib/CategoryTheory/Sites/Precoverage/Generates.lean
+++ b/Mathlib/CategoryTheory/Sites/Precoverage/Generates.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+module
+
+public import Mathlib.CategoryTheory.Sites.Closed
+public import Mathlib.CategoryTheory.Sites.Coverage
+public import Mathlib.CategoryTheory.Sites.Precoverage.Subsheaf
+public import Mathlib.Logic.Small.Set
+
+/-!
+# Generators of a Grothendieck topology
+
+Let `K` be a precoverage and `J` a Grothendieck topology on a category `C`. We
+say `K` generates `J` if for every presheaf `F` on `C`, it is a sheaf for `J` if and only
+if it is a sheaf for every covering in `K`.
+
+If `K` generates `J`, then `J` is the smallest Grothendieck topology containing `K`. The converse
+only holds if `K` is a coverage or a pretopology.
+
+## Implementation details
+
+For `C : Type u` and `Category.{v} C`, the definition of `Precoverage.Generates` quantifies over
+presheafs `Cᵒᵖ ⥤ Type max u v`. We then show that this implies that the condition holds
+for all presheafs `Cᵒᵖ ⥤ Type w`.
+-/
+
+@[expose] public section
+
+universe t t' w v u
+
+namespace CategoryTheory
+
+variable {C : Type u} [Category.{v} C] {A : Type*} [Category* A]
+  {K : Precoverage C} {J : GrothendieckTopology C}
+
+namespace Precoverage
+
+/-- A precoverage `K` generates the topology `J` if a presheaf on `C` is a sheaf
+for `K` if and only if it is a sheaf for `J`. -/
+structure Generates (K : Precoverage C) (J : GrothendieckTopology C) : Prop where
+  le_toPrecoverage : K ≤ J.toPrecoverage
+  isSheaf_of_forall_max (F : Cᵒᵖ ⥤ Type (max u v)) (H : ∀ ⦃X : C⦄, ∀ R ∈ K X, R.IsSheafFor F) :
+    Presieve.IsSheaf J F
+
+variable {K : Precoverage C} {J : GrothendieckTopology C}
+
+lemma Generates.generate_mem (H : K.Generates J) {X : C} {R : Presieve X} (h : R ∈ K X) :
+    .generate R ∈ J X :=
+  H.le_toPrecoverage _ h
+
+set_option backward.isDefEq.respectTransparency false in
+private lemma Generates.isSheaf_of_forall_aux (h : K.Generates J) (F : Cᵒᵖ ⥤ Type w)
+    (H : ∀ ⦃X : C⦄, ∀ R ∈ K X, Presieve.IsSheafFor F R)
+    [∀ (Z : C), _root_.Small.{max u v} (F.obj (.op Z))] :
+    Presieve.IsSheaf J F := by
+  intro X S hS
+  let F' : Cᵒᵖ ⥤ Type max u v := FunctorToTypes.shrink F
+  let e (X : C) : F.obj (.op X) ≃ F'.obj (.op X) := equivShrink _
+  have he (X Y : C) (f : X ⟶ Y) (x : F.obj (.op Y)) :
+      (e X) (F.map f.op x) = F'.map f.op (e Y x) := by
+    simp [e, F']
+  rw [Presieve.isSheafFor_iff_of_nat_equiv e he] at ⊢
+  refine h.isSheaf_of_forall_max F' (fun X R hR ↦ ?_) _ hS
+  rw [← Presieve.isSheafFor_iff_of_nat_equiv e he]
+  exact H _ hR
+
+lemma Generates.isSheaf_of_forall (h : K.Generates J) (F : Cᵒᵖ ⥤ Type w)
+    (H : ∀ ⦃X : C⦄, ∀ R ∈ K X, Presieve.IsSheafFor F R) :
+    Presieve.IsSheaf J F := by
+  intro X S hS
+  rw [← Presieve.isSeparatedFor_and_exists_isAmalgamation_iff_isSheafFor]
+  refine ⟨?_, fun x hx ↦ ?_⟩
+  · intro x t₁ t₂ ht₁ ht₂
+    let 𝒮 (Z : C) : Set (F.obj (.op Z)) :=
+      .range (fun (g : { g : Z ⟶ X | S.arrows g }) ↦ x _ g.2) ∪
+      .range (fun (g : Z ⟶ X) ↦ F.map g.op t₁) ∪ .range (fun (g : Z ⟶ X) ↦ F.map g.op t₂)
+    let Q : Subfunctor F := K.subsheafify 𝒮
+    have (Z : C) : _root_.Small.{max u v} (Q.toFunctor.obj (Opposite.op Z)) :=
+      small_subsheafify_of_small H _ inferInstance _
+    have hQ : Presieve.IsSheaf J Q.toFunctor :=
+      h.isSheaf_of_forall_aux _ fun X R hR ↦ isSheafFor_subsheafify _ hR (H _ hR)
+    let x' : S.arrows.FamilyOfElements Q.toFunctor :=
+      fun Z g hg ↦ ⟨x g hg, .base <| .inl <| .inl ⟨⟨g, hg⟩, rfl⟩⟩
+    have ht₁' : t₁ ∈ Q.obj (.op X) := .base (.inl <| .inr ⟨𝟙 _, by simp⟩)
+    have ht₂' : t₂ ∈ Q.obj (.op X) := .base (.inr ⟨𝟙 _, by simp⟩)
+    exact congr($((hQ _ hS).isSeparatedFor x' ⟨_, ht₁'⟩ ⟨_, ht₂'⟩
+      (.of_mono Q.ι ht₁) (.of_mono Q.ι ht₂)).val)
+  · let 𝒮 (Z : C) := Set.range (fun (g : { g : Z ⟶ X | S.arrows g }) ↦ x _ g.2)
+    let Q : Subfunctor F := K.subsheafify 𝒮
+    have (Z : C) : _root_.Small.{max u v} (Q.toFunctor.obj (Opposite.op Z)) :=
+      small_subsheafify_of_small H _ inferInstance _
+    have hQ : Presieve.IsSheaf J Q.toFunctor :=
+      h.isSheaf_of_forall_aux _ fun X R hR ↦ isSheafFor_subsheafify _ hR (H _ hR)
+    obtain ⟨t, ht, _⟩ := hQ _ hS (fun Z g hg ↦ ⟨x g hg, .base ⟨⟨g, hg⟩, rfl⟩⟩) (.of_mono Q.ι hx)
+    refine ⟨t.val, ht.map Q.ι⟩
+
+/-- If `K` generates `J`, then any presheaf is a sheaf if and only if it is a sheaf
+for all `K`-covers. -/
+lemma Generates.isSheaf_type_iff (H : K.Generates J) {F : Cᵒᵖ ⥤ Type w} :
+    Presieve.IsSheaf J F ↔ ∀ ⦃X : C⦄, ∀ R ∈ K X, Presieve.IsSheafFor F R := by
+  refine ⟨fun h X R hR ↦ ?_, fun h ↦ H.isSheaf_of_forall _ h⟩
+  rw [Presieve.isSheafFor_iff_generate]
+  exact h _ (H.le_toPrecoverage _ hR)
+
+/--
+If `K` generates `J`, then `J` is equal to the smallest Grothendieck topology containing `K`.
+The converse is false, but holds if `K` is a coverage, see `CategoryTheory.Coverage.generates_iff`.
+-/
+lemma Generates.toGrothendieck_eq (H : K.Generates J) : K.toGrothendieck = J := by
+  refine le_antisymm ?_ ?_
+  · rw [toGrothendieck_le_iff_le_toPrecoverage]
+    exact H.le_toPrecoverage
+  · apply CategoryTheory.le_topology_of_closedSieves_isSheaf
+    rw [H.isSheaf_type_iff]
+    intro X R hR
+    rw [Presieve.isSheafFor_iff_generate]
+    exact classifier_isSheaf K.toGrothendieck _ (K.generate_mem_toGrothendieck hR)
+
+lemma Generates.isSheaf_iff (H : K.Generates J) {F : Cᵒᵖ ⥤ A} :
+    Presheaf.IsSheaf J F ↔ ∀ ⦃X : C⦄, ∀ R ∈ K X, ∀ (M : A),
+      Presieve.IsSheafFor (F ⋙ coyoneda.obj (.op M)) R := by
+  grind [Presheaf.IsSheaf, H.isSheaf_type_iff]
+
+end Precoverage
+
+/-- If `K` is a coverage, it generates the smallest Grothendieck topology containing `K`. -/
+lemma Coverage.generates_toGrothendieck (K : Coverage C) : K.Generates K.toGrothendieck where
+  le_toPrecoverage := by
+    rw [← Precoverage.toGrothendieck_le_iff_le_toPrecoverage, ← toGrothendieck_toPrecoverage]
+  isSheaf_of_forall_max F h := by rwa [Presieve.isSheaf_coverage]
+
+lemma Coverage.generates_iff {K : Coverage C} : K.Generates J ↔ K.toGrothendieck = J := by
+  refine ⟨fun h ↦ ?_, ?_⟩
+  · rw [← Coverage.toGrothendieck_toPrecoverage]
+    exact h.toGrothendieck_eq
+  · rintro rfl
+    exact Coverage.generates_toGrothendieck _
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Precoverage/Generates.lean
+++ b/Mathlib/CategoryTheory/Sites/Precoverage/Generates.lean
@@ -96,7 +96,7 @@ lemma Generates.isSheaf_of_forall (h : K.Generates J) (F : Cᵒᵖ ⥤ Type w)
     have hQ : Presieve.IsSheaf J Q.toFunctor :=
       h.isSheaf_of_forall_aux _ fun X R hR ↦ isSheafFor_subsheafify _ hR (H _ hR)
     obtain ⟨t, ht, _⟩ := hQ _ hS (fun Z g hg ↦ ⟨x g hg, .base ⟨⟨g, hg⟩, rfl⟩⟩) (.of_mono Q.ι hx)
-    refine ⟨t.val, ht.map Q.ι⟩
+    exact ⟨t.val, ht.map Q.ι⟩
 
 /-- If `K` generates `J`, then any presheaf is a sheaf if and only if it is a sheaf
 for all `K`-covers. -/

--- a/Mathlib/CategoryTheory/Sites/Precoverage/Subsheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Precoverage/Subsheaf.lean
@@ -57,7 +57,7 @@ inductive SubsheafClosure (K : Precoverage C) {F : Cᵒᵖ ⥤ Type w}
       {t : F.obj (.op Z)} (ht : y.IsAmalgamation t) : K.SubsheafClosure 𝒮 Z t
 
 variable (K) in
-/-- The `K`-sheafification of family of sets `𝒮` in `F`: If `F` is
+/-- The `K`-sheafification of a family of sets `𝒮` in `F`: If `F` is
 a sheaf for `K`, this is the smallest subsheaf of `F` containing `𝒮`. -/
 @[simps]
 def subsheafify (𝒮 : ∀ Z : C, Set (F.obj (.op Z))) : Subfunctor F where

--- a/Mathlib/CategoryTheory/Sites/Precoverage/Subsheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Precoverage/Subsheaf.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+module
+
+public import Mathlib.CategoryTheory.Sites.IsSheafFor
+public import Mathlib.CategoryTheory.Sites.Precoverage
+
+/-!
+# Sheafification of subpresheafs for precoverages
+
+Let `K` be a precoverage. In this file we define the `K`-sheafification of a subpresheaf.
+More generally, for a family of subsets `𝒮` of sections of a sheaf `F`, we construct
+the smallest subsheaf of `F` containing `𝒮`.
+
+## Main declarations
+
+- `CategoryTheory.Precoverage.subsheafify`: `K`-sheafification of family of sets `𝒮` in a presheaf
+  `F`. This is only a sheaf if `F` itself is a sheaf.
+- `CategoryTheory.Precoverage.small_subsheafify_of_small`: If all the sets in the family `𝒮`
+  are small, then the `K`-sheafification is again small.
+
+## TODOs
+
+- Relate `Precoverage.subsheafify K` with `Subfunctor.sheafify` for the Grothendieck topology
+  `Precoverage.toGrothendieck K`.
+-/
+
+@[expose] public section
+
+universe w v u
+
+namespace CategoryTheory
+
+variable {C : Type u} [Category.{v} C] {K : Precoverage C}
+
+namespace Precoverage
+
+variable {F : Cᵒᵖ ⥤ Type w}
+
+/-- Closure of a family of elements of a presheaf under restriction and gluing of
+sections over coverings in `K`. -/
+inductive SubsheafClosure (K : Precoverage C) {F : Cᵒᵖ ⥤ Type w}
+    (𝒮 : ∀ Z : C, Set (F.obj (.op Z))) :
+    ∀ Z : C, F.obj (.op Z) → Prop where
+  /-- Element of the initial family. -/
+  | base {Z : C} {a : F.obj (.op Z)} : a ∈ 𝒮 Z → K.SubsheafClosure 𝒮 Z a
+  /-- Restriction of an element in the closure along a morphism. -/
+  | restrict {Z W : C} (h : Z ⟶ W) {a : F.obj (.op W)} :
+      K.SubsheafClosure 𝒮 W a → K.SubsheafClosure 𝒮 Z (F.map h.op a)
+  /-- Gluing of sections in the closure. -/
+  | amalgamate {Z : C} {R : Presieve Z} (hR : R ∈ K Z)
+      {y : Presieve.FamilyOfElements F R} (hy : y.Compatible)
+      (hmem : ∀ ⦃W : C⦄ (r : W ⟶ Z) (hr : R r), K.SubsheafClosure 𝒮 W (y r hr))
+      {t : F.obj (.op Z)} (ht : y.IsAmalgamation t) : K.SubsheafClosure 𝒮 Z t
+
+variable (K) in
+/-- The `K`-sheafification of family of sets `𝒮` in `F`: If `F` is
+a sheaf for `K`, this is the smallest subsheaf of `F` containing `𝒮`. -/
+@[simps]
+def subsheafify (𝒮 : ∀ Z : C, Set (F.obj (.op Z))) : Subfunctor F where
+  obj U := { x | K.SubsheafClosure 𝒮 U.unop x }
+  map _ _ ht := .restrict _ ht
+
+variable (𝒮 : ∀ Z : C, Set (F.obj (.op Z)))
+
+/-- If `F` is a sheaf for `R` and `R ∈ K X`, then the `K`-sheafification of `𝒮` is a
+sheaf for `R`. -/
+lemma isSheafFor_subsheafify (𝒮 : ∀ Z : C, Set (F.obj (.op Z))) {X : C} {R : Presieve X}
+    (h : R ∈ K X) (h' : R.IsSheafFor F) :
+    R.IsSheafFor (K.subsheafify 𝒮).toFunctor := by
+  let G := K.subsheafify 𝒮
+  rw [← Presieve.isSeparatedFor_and_exists_isAmalgamation_iff_isSheafFor]
+  refine ⟨.of_mono G.ι h'.isSeparatedFor, fun x hx ↦ ?_⟩
+  obtain ⟨t, ht, uniq⟩ := h' (x.map G.ι) (hx.map G.ι)
+  exact ⟨⟨t, .amalgamate h (hx.map G.ι) (fun _ _ hr ↦ (x _ hr).property) ht⟩, .of_mono _ ht⟩
+
+namespace SmallConstruction
+
+variable (K) in
+/-- Upper bound for the sections of `Precoverage.subsheafify`: If for every `X : C`,
+the underlying type of `𝒮 X` embeds into `ι X`, the sections of `K.subsheafify 𝒮`
+on `X` embed into `Witness K ι X`. -/
+private inductive Witness (ι : C → Type w) : C → Type max w u v where
+  | base (X : C) : ι X → Witness ι X
+  | restrict {X Y : C} (f : X ⟶ Y) : Witness ι Y → Witness ι X
+  /-- Family of elements over a covering in `K`. Note that it is not necessarily compatible. -/
+  | amalgamate {X : C} {R : Presieve X} (hR : R ∈ K X)
+      (h : ∀ ⦃W⦄ (r : W ⟶ X), R r → Witness ι W) : Witness ι X
+
+/-- Realization of a term of `Witness K ι X` as a section of `F` over `X`. By
+construction, the sections will lie in the subsheaf `K.subsheafify 𝒮`.
+This takes values in `Option`, because not every term constructed from
+the `Witness.amalgamate` constructor corresponds to a compatible family. -/
+private noncomputable
+def Witness.eval (hF : ∀ ⦃X : C⦄ (R : Presieve X), R ∈ K X → Presieve.IsSheafFor F R)
+    (ι : C → Type max u v) (t : ∀ X, ι X → F.obj (.op X)) :
+    {X : C} → Witness K ι X → Option (F.obj (.op X))
+  | _, .base X i => t _ i
+  | _, .restrict f i => do F.map f.op (← eval hF _ t i)
+  | _, .amalgamate (R := R) hR h =>
+    open Classical in
+    let vals := fun W (r : W ⟶ _) (hr : R r) ↦ eval hF _ t (h r hr)
+    /- If all elements of the family are evaluatable and the resulting family is compatible, take
+    the glued section. Otherwise, return `none`. -/
+    if hall : ∀ (W : C) (r : W ⟶ _) (hr : R r), (vals W r hr).isSome then
+      let y : R.FamilyOfElements F := fun _ _ hr ↦ (vals _ _ _).get (hall _ _ hr)
+      if hy : y.Compatible then some (hF _ hR _ hy).choose else none
+    else none
+
+end SmallConstruction
+
+open SmallConstruction in
+/-- If `𝒮 Z` is `max u v`-small for every `Z`, then the subsheaf generated by `𝒮 Z` has
+`max u v`-small sections. -/
+lemma small_subsheafify_of_small
+    (hF : ∀ ⦃X : C⦄ (R : Presieve X), R ∈ K X → Presieve.IsSheafFor F R)
+    (𝒮 : ∀ Z : C, Set (F.obj (.op Z))) (h : ∀ Z, _root_.Small.{max u v} (𝒮 Z)) :
+    FunctorToTypes.Small.{max u v} (K.subsheafify 𝒮).toFunctor := by
+  rintro ⟨X⟩
+  let ι (X : C) := Shrink.{max u v} (𝒮 X)
+  let t (X : C) (i : ι X) : F.obj (Opposite.op X) := ((equivShrink _).symm i).val
+  have (x : F.obj (.op X)) (hx : K.SubsheafClosure 𝒮 X x) :
+      ∃ (i : Witness K ι X), Witness.eval hF _ t i = x := by
+    induction hx with
+    | base ha => exact ⟨.base _ (equivShrink _ ⟨_, ha⟩), by grind [Witness.eval]⟩
+    | restrict f ha ih =>
+      obtain ⟨i, hi⟩ := ih
+      use .restrict f i
+      grind [Witness.eval]
+    | amalgamate hR hy hmem ht ih =>
+      choose x hx using ih
+      exact ⟨.amalgamate hR x, by simp [Witness.eval, hx]; grind⟩
+  choose i hi using this
+  have : Function.Injective (fun x : { x // K.SubsheafClosure 𝒮 X x } ↦ i x x.prop) := by
+    intro x y hxy
+    ext
+    apply Option.some_injective
+    simp [← hi _ x.prop, ← hi _ y.prop, hxy]
+  exact small_of_injective this
+
+end Precoverage
+
+end CategoryTheory


### PR DESCRIPTION
For a category `C`, a precoverage `K` on `C` and a Grothendieck topology `J`, we add a predicate `Precoverage.Generates K J` saying that the sheaves for `J` are exactly the presheaves satisfying the sheaf-condition for all coverings in `K`. We show that if the universe of the presheaves in the definition are chosen large enough, the condition extends to all presheaves in an arbitrary universe.

If `K` generates `J` in the above sense, then `J` is the smallest Grothendieck topology containing `K`. In general the converse is false, but it holds if `K` is a coverage, i.e., satisfies some pullback stability condition. The motivation for introducing this additional notion is the study of the pro-étale topology: The precoverage given by all open covers and single morphism covers by faithfully flat, weakly-étale morphisms `Spec S ⟶ Spec R` is not a coverage, but it generates the pro-étale topology. This fact will be used to study the comparison of the étale and pro-étale topologies.

From Proetale.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

AI usage disclosure: The proof idea for the independence of the universe is by Gemini and Aristotle. All Lean code is written by myself.

I think the PR is easiest to review as a whole, but if someone prefers me to split it, I would be happy to do so.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
