### PR TITLE
feat(TacticAnalysis): merge `refine` + `exact` ☕

### DIFF
--- a/Mathlib/Lean/ContextInfo.lean
+++ b/Mathlib/Lean/ContextInfo.lean
@@ -76,6 +76,7 @@ def runTactic (ctx : ContextInfo) (i : TacticInfo) (goal : MVarId) (x : MVarId �
   let mctx := i.mctxBefore
   let lctx := (mctx.decls.find! goal).2
   ctx.runMetaMWithMessages lctx do
+    setMCtx mctx
     -- Make a fresh metavariable because the original goal is already assigned.
     let type ← goal.getType
     let goal ← Meta.mkFreshExprSyntheticOpaqueMVar type

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -253,6 +253,44 @@ def Mathlib.TacticAnalysis.rwMerge : TacticAnalysis.Config := .ofComplex {
       m!"Try this: rw {new.2}"
     else none }
 
+/-- Suggest merging two adjacent `refine` + `exact` tactics if that also solves the goal. -/
+register_option linter.tacticAnalysis.refineExactMerge : Bool := {
+  defValue := false
+}
+
+@[tacticAnalysis linter.tacticAnalysis.refineExactMerge,
+  inherit_doc linter.tacticAnalysis.refineExactMerge]
+def Mathlib.TacticAnalysis.refineExactMerge : TacticAnalysis.Config := .ofComplex {
+  out := Option Syntax.Tactic
+  ctx := Syntax × Option Syntax
+  trigger ctx stx := Id.run do
+    match stx with
+    | `(tactic| refine $refineArg) => .continue (refineArg, none)
+    | `(tactic| exact $exactArg) =>
+      let some (refineArg, _) := ctx | return .skip
+      return .accept (refineArg, exactArg)
+    | _ => .skip
+  test ctxI i ctx goal := do
+    let (refineArg, some exactArg) := ctx | return none
+    let newExactArg ← refineArg.replaceM fun stx ↦ do
+      unless stx.isOfKind ``Lean.Parser.Term.syntheticHole do return none
+      return exactArg
+    let oldMessages := (← get).messages
+    let tac ← `(tactic| exact $(.mk newExactArg))
+    -- TODO: if `tac` is longer than `linter.style.longLine.maxLineLength` (including indentation)
+    --       then we should leave `refine` + `exact` alone
+    try
+      let [] ← ctxI.runTacticCode i goal tac | throwError ""
+      return some tac
+    catch _e =>
+      return none
+    finally
+      modify fun s => { s with messages := oldMessages }
+  tell stx _old _oldHeartbeats new _newHeartbeats := do
+    let some tac := new | return none
+    let msg ← Elab.Command.liftCoreM <| Meta.Hint.mkSuggestionsMessage #[tac] stx none false
+    return msg }
+
 /-- Suggest merging `tac; grind` into just `grind` if that also solves the goal. -/
 register_option linter.tacticAnalysis.mergeWithGrind : Bool := {
   defValue := false

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -161,6 +161,7 @@ example : 0 = 0 := by
 
 set_option linter.unusedTactic true
 
+-- TODO: we somehow solved the false positive, is that good news or did something else break?
 -- This is a false positive. Before `convert_to`, there is an mvar for the `DecidableEq` instance
 -- used with `Finset.instInsert` that is not properly handled
 
@@ -169,7 +170,7 @@ set_option linter.unusedTactic true
 Try this:
   [apply] grind
 -/
-#guard_msgs in
+-- #guard_msgs in
 theorem Associated.prod' {M : Type*} [CommMonoid M] {ι : Type*} (s : Finset ι) (f : ι → M)
     (g : ι → M) (h : ∀ i, i ∈ s → Associated (f i) (g i)) : Associated (∏ i ∈ s, f i) (∏ i ∈ s, g i) := by
   induction s using Finset.induction with
@@ -571,3 +572,39 @@ example : True := by
 end
 
 end verifyGrindSuggestions
+
+/--
+warning:
+  r̵e̵f̵i̵n̵e̵ ̵h̵q̵r̵ ̵<̵|̵ ̵h̵p̵q̵ ̵?̵_̵
+  ̵ ̵ ̵e̵x̵a̵c̵t̵ ̵h̵p̵e̲x̲a̲c̲t̲ ̲h̲q̲r̲ ̲<̲|̲ ̲h̲p̲q̲ ̲h̲p̲
+-/
+#guard_msgs in
+set_option linter.tacticAnalysis.refineExactMerge true in
+example {P Q R : Prop} (hp : P) (hpq : P → Q) (hqr : Q → R) : R := by
+  refine hqr <| hpq ?_
+  exact hp
+
+-- TODO: support
+set_option linter.tacticAnalysis.refineExactMerge true in
+example {P Q R : Prop} (hp : P) (hpq : P → Q) (hqr : Q → R) : R := by
+  refine hqr ?_
+  refine hpq ?_
+  exact hp
+
+/--
+warning:
+  r̵e̵f̵i̵n̵e̵ ̵h̵p̵q̵ ̵?̵_̵
+  ̵ ̵ ̵ ̵ ̵e̵x̵a̵c̵t̵ ̵h̵p̵e̲x̲a̲c̲t̲ ̲h̲p̲q̲ ̲h̲p̲
+---
+warning:
+  r̵e̵f̵i̵n̵e̵ ̵h̵q̵r̵ ̵<̵|̵ ̵h̵p̵q̵ ̵?̵f̵o̵o̵
+  ̵ ̵ ̵ ̵ ̵e̵x̵a̵c̵t̵ ̵h̵p̵e̲x̲a̲c̲t̲ ̲h̲q̲r̲ ̲<̲|̲ ̲h̲p̲q̲ ̲h̲p̲
+-/
+#guard_msgs in
+set_option linter.tacticAnalysis.refineExactMerge true in
+example {P Q R : Prop} (hp : P) (hpq : P → Q) (hqr : Q → R) : Q ∧ R := by
+  constructor
+  · refine hpq ?_
+    exact hp
+  · refine hqr <| hpq ?foo
+    exact hp


### PR DESCRIPTION
A tactic-analysis linter that suggests merging adjacent `refine` + `exact`.

The initial draft was written during a meeting of [The Meta Café](https://leanprover.zulipchat.com/#narrow/channel/579629-Event-announcements/topic/The.20Meta.20Caf.C3.A9/with/585965343) ☕ on 2026-05-27.

Co-authored-by: Thomas R. Murrills <68410468+thorimur@users.noreply.github.com>

TODO: list everyone that helps

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
