### PR TITLE
[Merged by Bors] - chore: respect naming conventions for defs in more meta code

### DIFF
--- a/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
@@ -114,7 +114,7 @@ def mkLiftMap₂LiftExpr (e : Expr) : TermElabM Expr := do
     none
 
 /-- Coherence tactic for bicategories. -/
-def bicategory_coherence (g : MVarId) : TermElabM Unit := g.withContext do
+def bicategoryCoherence (g : MVarId) : TermElabM Unit := g.withContext do
   withOptions (fun opts => synthInstance.maxSize.set opts
     (max 256 (synthInstance.maxSize.get opts))) do
   let thms := [``BicategoricalCoherence.iso, ``Iso.trans, ``Iso.symm, ``Iso.refl,

--- a/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
@@ -132,6 +132,8 @@ def bicategoryCoherence (g : MVarId) : TermElabM Unit := g.withContext do
   let [] ← g₂.applyConst ``Subsingleton.elim
     | exception g "This shouldn't happen; Subsingleton.elim does not create goals."
 
+@[deprecated (since := "2026-05-27")] alias bicategory_coherence := bicategoryCoherence
+
 open Lean.Parser.Tactic
 
 /--

--- a/Mathlib/Tactic/CategoryTheory/Coherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence.lean
@@ -124,7 +124,7 @@ def mkProjectMapExpr (e : Expr) : TermElabM Expr := do
     none
 
 /-- Coherence tactic for monoidal categories. -/
-def monoidal_coherence (g : MVarId) : TermElabM Unit := g.withContext do
+def monoidalCoherence (g : MVarId) : TermElabM Unit := g.withContext do
   withOptions (fun opts => synthInstance.maxSize.set opts
     (max 512 (synthInstance.maxSize.get opts))) do
   let thms := [``MonoidalCoherence.iso, ``Iso.trans, ``Iso.symm, ``Iso.refl,
@@ -173,12 +173,12 @@ elab (name := pure_coherence) "pure_coherence" : tactic => do
     They are given in `Mathlib.Tactic.CategoryTheory.Monoidal.Basic` and \
     `Mathlib.Tactic.CategoryTheory.Bicategory.Basic.lean` respectively."
   let g ← getMainGoal
-  monoidal_coherence g <|> bicategory_coherence g
+  monoidalCoherence g <|> bicategoryCoherence g
 
 /-- The same as `pure_coherence`, but used internally in `coherence` without the warning. -/
 elab (name := pure_coherence_internal) "pure_coherence_internal" : tactic => do
   let g ← getMainGoal
-  monoidal_coherence g <|> bicategory_coherence g
+  monoidalCoherence g <|> bicategoryCoherence g
 
 /--
 Auxiliary simp lemma for the `coherence` tactic:

--- a/Mathlib/Tactic/CategoryTheory/Coherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence.lean
@@ -142,6 +142,8 @@ def monoidalCoherence (g : MVarId) : TermElabM Unit := g.withContext do
   let [] ← g₂.applyConst ``Subsingleton.elim
     | exception g "This shouldn't happen; Subsingleton.elim does not create goals."
 
+@[deprecated (since := "2026-05-27")] alias monoidal_coherence := monoidalCoherence
+
 open Mathlib.Tactic.BicategoryCoherence
 
 /--

--- a/Mathlib/Tactic/CategoryTheory/Coherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence.lean
@@ -269,6 +269,8 @@ def coherenceLoop (maxSteps := 37) : TacticM Unit :=
       -- and whose second terms can be identified by recursively called `coherence`.
       coherenceLoop maxSteps'
 
+@[deprecated (since := "2026-05-27")] alias coherence_loop := coherenceLoop
+
 open Lean.Parser.Tactic
 
 /--

--- a/Mathlib/Tactic/CategoryTheory/Coherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence.lean
@@ -238,7 +238,7 @@ def insertTrailingIds (g : MVarId) : MetaM MVarId := do
 -- Porting note: this is an ugly port, using too many `evalTactic`s.
 -- We can refactor later into either a `macro` (but the flow control is awkward)
 -- or a `MetaM` tactic.
-def coherence_loop (maxSteps := 37) : TacticM Unit :=
+def coherenceLoop (maxSteps := 37) : TacticM Unit :=
   match maxSteps with
   | 0 => exception' "`coherence` tactic reached iteration limit"
   | maxSteps' + 1 => do
@@ -265,7 +265,7 @@ def coherence_loop (maxSteps := 37) : TacticM Unit :=
       evalTactic (← `(tactic| rfl)) <|>
         exception' "`coherence` tactic failed, non-structural morphisms don't match"
       -- and whose second terms can be identified by recursively called `coherence`.
-      coherence_loop maxSteps'
+      coherenceLoop maxSteps'
 
 open Lean.Parser.Tactic
 
@@ -317,7 +317,7 @@ elab_rules : tactic
     (simp -failIfUnchanged only [bicategoricalComp, monoidalComp]);
     whisker_simps -failIfUnchanged;
     monoidal_simps -failIfUnchanged))
-  coherence_loop
+  coherenceLoop
 
 end Coherence
 

--- a/Mathlib/Tactic/Choose.lean
+++ b/Mathlib/Tactic/Choose.lean
@@ -41,6 +41,8 @@ def mkSometimes (u : Level) (α nonemp p : Expr) :
       mkApp7 (Expr.const ``Function.sometimes_spec [u]) t α nonemp p val' e spec)
   else pure (val, spec)
 
+@[deprecated (since := "2026-05-27")] alias mk_sometimes := mkSometimes
+
 /-- Results of searching for nonempty instances,
 to eliminate dependencies on propositions (`choose!`).
 `success` means we found at least one instance;

--- a/Mathlib/Tactic/Choose.lean
+++ b/Mathlib/Tactic/Choose.lean
@@ -23,15 +23,15 @@ namespace Mathlib.Tactic.Choose
 
 /-- Given `α : Sort u`, `nonemp : Nonempty α`, `p : α → Prop`, a context of free variables
 `ctx`, and a pair of an element `val : α` and `spec : p val`,
-`mk_sometimes u α nonemp p ctx (val, spec)` produces another pair `val', spec'`
+`mkSometimes u α nonemp p ctx (val, spec)` produces another pair `val', spec'`
 such that `val'` does not have any free variables from elements of `ctx` whose types are
 propositions. This is done by applying `Function.sometimes` to abstract over all the propositional
 arguments. -/
-def mk_sometimes (u : Level) (α nonemp p : Expr) :
+def mkSometimes (u : Level) (α nonemp p : Expr) :
     List Expr → Expr × Expr → MetaM (Expr × Expr)
 | [], (val, spec) => pure (val, spec)
 | (e :: ctx), (val, spec) => do
-  let (val, spec) ← mk_sometimes u α nonemp p ctx (val, spec)
+  let (val, spec) ← mkSometimes u α nonemp p ctx (val, spec)
   let t ← inferType e
   let b ← isProp t
   if b then do
@@ -150,7 +150,7 @@ def choose1 (g : MVarId) (nondep : Bool) (h : Option Expr) (data : Name) :
         let mut dataVal := mkApp3 (.const ``Classical.choose [u]) α p (mkAppN h ctx)
         let mut specVal := mkApp3 (.const ``Classical.choose_spec [u]) α p (mkAppN h ctx)
         if let some nonemp := nonemp then
-          (dataVal, specVal) ← mk_sometimes u α nonemp p ctx.toList (dataVal, specVal)
+          (dataVal, specVal) ← mkSometimes u α nonemp p ctx.toList (dataVal, specVal)
         dataVal ← mkLambdaFVars ctx' dataVal
         specVal ← mkLambdaFVars ctx specVal
         let (fvar, g) ← withLocalDeclD .anonymous dataTy fun d ↦ do

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -366,7 +366,7 @@ def dispatchLemma
           π ``natDegree_smul_le_of_le ``degree_smul_le_of_le ``coeff_smul
         | _ => π ``le_rfl ``le_rfl ``rfl
 
-/-- `try_rfl mvs` takes as input a list of `MVarId`s, scans them partitioning them into two
+/-- `tryRfl mvs` takes as input a list of `MVarId`s, scans them partitioning them into two
 lists: the goals containing some metavariables and the goals not containing any metavariable.
 
 If a goal containing a metavariable has the form `?_ = x`, `x = ?_`, where `?_` is a metavariable
@@ -378,7 +378,7 @@ If a goal does not contain metavariables, it tries `rfl` on it.
 It returns the list of `MVarId`s, beginning with the ones that initially involved (`Expr`)
 metavariables followed by the rest.
 -/
-def try_rfl (mvs : List MVarId) : MetaM (List MVarId) := do
+def tryRfl (mvs : List MVarId) : MetaM (List MVarId) := do
   let (yesMV, noMV) := ← mvs.partitionM fun mv =>
                           return hasExprMVar (← instantiateMVars (← mv.getDecl).type)
   let tried_rfl := ← noMV.mapM fun g => g.applyConst ``rfl <|> return [g]
@@ -487,7 +487,7 @@ elab_rules : tactic | `(tactic| compute_degree $[!%$bang]?) => focus <| withMain
         f!"'compute_degree' first applies lemma '{lem.lastComponentAsString}'"
       let mut (gls, static) := (← goal.applyConst lem, [])
       while gls != [] do (gls, static) ← splitApply gls static
-      let rfled ← try_rfl static
+      let rfled ← tryRfl static
       setGoals rfled
       --  simplify the left-hand sides, since this is where the degree computations leave
       --  expressions such as `max (0 * 1) (max (1 + 0 + 3 * 4) (7 * 0))`

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -394,6 +394,8 @@ def tryRfl (mvs : List MVarId) : MetaM (List MVarId) := do
         return [g]
   return (assignable.flatten ++ tried_rfl.flatten)
 
+@[deprecated (since := "2026-05-27")] alias try_rfl := tryRfl
+
 /--
 `splitApply mvs static` takes two lists of `MVarId`s.  The first list, `mvs`,
 corresponds to goals that are potentially within the scope of `compute_degree`:

--- a/Mathlib/Tactic/Linarith/NNRealPreprocessor.lean
+++ b/Mathlib/Tactic/Linarith/NNRealPreprocessor.lean
@@ -37,6 +37,8 @@ def getNNRealtoRealArg? (e : Expr) : Option Expr :=
   | .app (.const ``NNReal.toReal _) n => some n
   | _ => none
 
+@[deprecated (since := "2026-05-27")] alias isNNRealtoReal := getNNRealtoRealArg?
+
 /--
 `getNNRealComparisons e` returns a list of all subexpressions of `e` of the form `(x : ℝ)`.
 -/
@@ -57,6 +59,8 @@ def mkToRealNonnegProof? (e : Expr) : MetaM (Option Expr) :=
   catch e => do
     trace[linarith] "Got exception when using `coe_nonneg` {e.toMessageData}"
     return none
+
+@[deprecated (since := "2026-05-27")] alias mk_toReal_nonneg_prf := mkToRealNonnegProof?
 
 initialize nnrealToRealTransform.set fun l => do
   let l ← l.mapM fun e => do

--- a/Mathlib/Tactic/Linarith/NNRealPreprocessor.lean
+++ b/Mathlib/Tactic/Linarith/NNRealPreprocessor.lean
@@ -32,7 +32,7 @@ partial def isNNRealProp (e : Expr) : MetaM Bool := succeeds do
   let (_, _, .const ``NNReal _, _, _) ← e.ineqOrNotIneq? | failure
 
 /-- If `e` is of the form `((x : ℝ≥0) : ℝ)`, `NNReal.toReal e` returns `x`. -/
-def isNNRealtoReal (e : Expr) : Option Expr :=
+def getNNRealtoRealArg? (e : Expr) : Option Expr :=
   match e with
   | .app (.const ``NNReal.toReal _) n => some n
   | _ => none
@@ -41,7 +41,7 @@ def isNNRealtoReal (e : Expr) : Option Expr :=
 `getNNRealComparisons e` returns a list of all subexpressions of `e` of the form `(x : ℝ)`.
 -/
 partial def getNNRealCoes (e : Expr) : List Expr :=
-  match isNNRealtoReal e with
+  match getNNRealtoRealArg? e with
   | some x => [x]
   | none => match e.getAppFnArgs with
     | (``HAdd.hAdd, #[_, _, _, _, a, b]) => getNNRealCoes a ++ getNNRealCoes b
@@ -52,7 +52,7 @@ partial def getNNRealCoes (e : Expr) : List Expr :=
     | _ => []
 
 /-- If `e : ℝ≥0`, returns a proof of `0 ≤ (e : ℝ)`. -/
-def mkToRealNonnegProof (e : Expr) : MetaM (Option Expr) :=
+def mkToRealNonnegProof? (e : Expr) : MetaM (Option Expr) :=
   try commitIfNoEx (mkAppM ``NNReal.coe_nonneg #[e])
   catch e => do
     trace[linarith] "Got exception when using `coe_nonneg` {e.toMessageData}"
@@ -71,7 +71,7 @@ initialize nnrealToRealTransform.set fun l => do
       discard <| (getNNRealCoes a).mapM AtomM.addAtom
       discard <| (getNNRealCoes b).mapM AtomM.addAtom
     return (← get).atoms.toList
-  let nonnegProofs : List Expr ← atoms.filterMapM mkToRealNonnegProof
+  let nonnegProofs : List Expr ← atoms.filterMapM mkToRealNonnegProof?
   return nonnegProofs ++ l
 
 end  Mathlib.Tactic.Linarith

--- a/Mathlib/Tactic/Linarith/NNRealPreprocessor.lean
+++ b/Mathlib/Tactic/Linarith/NNRealPreprocessor.lean
@@ -52,7 +52,7 @@ partial def getNNRealCoes (e : Expr) : List Expr :=
     | _ => []
 
 /-- If `e : ℝ≥0`, returns a proof of `0 ≤ (e : ℝ)`. -/
-def mk_toReal_nonneg_prf (e : Expr) : MetaM (Option Expr) :=
+def mkToRealNonnegProof (e : Expr) : MetaM (Option Expr) :=
   try commitIfNoEx (mkAppM ``NNReal.coe_nonneg #[e])
   catch e => do
     trace[linarith] "Got exception when using `coe_nonneg` {e.toMessageData}"
@@ -71,7 +71,7 @@ initialize nnrealToRealTransform.set fun l => do
       discard <| (getNNRealCoes a).mapM AtomM.addAtom
       discard <| (getNNRealCoes b).mapM AtomM.addAtom
     return (← get).atoms.toList
-  let nonneg_pfs : List Expr ← atoms.filterMapM mk_toReal_nonneg_prf
-  return nonneg_pfs ++ l
+  let nonnegProofs : List Expr ← atoms.filterMapM mkToRealNonnegProof
+  return nonnegProofs ++ l
 
 end  Mathlib.Tactic.Linarith

--- a/Mathlib/Tactic/Linarith/NNRealPreprocessor.lean
+++ b/Mathlib/Tactic/Linarith/NNRealPreprocessor.lean
@@ -32,18 +32,18 @@ partial def isNNRealProp (e : Expr) : MetaM Bool := succeeds do
   let (_, _, .const ``NNReal _, _, _) ← e.ineqOrNotIneq? | failure
 
 /-- If `e` is of the form `((x : ℝ≥0) : ℝ)`, `NNReal.toReal e` returns `x`. -/
-def getNNRealtoRealArg? (e : Expr) : Option Expr :=
+def getNNRealToRealArg? (e : Expr) : Option Expr :=
   match e with
   | .app (.const ``NNReal.toReal _) n => some n
   | _ => none
 
-@[deprecated (since := "2026-05-27")] alias isNNRealtoReal := getNNRealtoRealArg?
+@[deprecated (since := "2026-05-27")] alias isNNRealtoReal := getNNRealToRealArg?
 
 /--
 `getNNRealComparisons e` returns a list of all subexpressions of `e` of the form `(x : ℝ)`.
 -/
 partial def getNNRealCoes (e : Expr) : List Expr :=
-  match getNNRealtoRealArg? e with
+  match getNNRealToRealArg? e with
   | some x => [x]
   | none => match e.getAppFnArgs with
     | (``HAdd.hAdd, #[_, _, _, _, a, b]) => getNNRealCoes a ++ getNNRealCoes b

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -111,6 +111,8 @@ def mkNatCastNonnegProof? (p : Expr × Expr) : MetaM (Option Expr) :=
       trace[linarith] "Got exception when using cast {e.toMessageData}"
       return none
 
+@[deprecated (since := "2026-05-27")] alias mk_natCast_nonneg_prf := mkNatCastNonnegProof?
+
 /--
 If `h` is an equality or inequality between natural numbers,
 `natToInt` lifts this inequality to the integers.
@@ -168,6 +170,8 @@ def mkNonstrictIntProof? (pf : Expr) : MetaM (Option Expr) := do
       (← mkAppM ``lt_of_not_ge #[pf])
   | _ => return none
 
+@[deprecated (since := "2026-05-27")] alias mkNonstrictIntProof := mkNonstrictIntProof?
+
 /-- `strengthenStrictInt h` turns a proof `h` of a strict integer inequality `t1 < t2`
 into a proof of `t1 ≤ t2 + 1`. -/
 def strengthenStrictInt : Preprocessor where
@@ -187,6 +191,8 @@ partial def rearrangeComparison? (e : Expr) : MetaM (Option Expr) := do
   | (Ineq.le, _) => try? <| mkAppM ``Linarith.sub_nonpos_of_le #[e]
   | (Ineq.lt, _) => try? <| mkAppM ``Linarith.sub_neg_of_lt #[e]
   | (Ineq.eq, _) => try? <| mkAppM ``sub_eq_zero_of_eq #[e]
+
+@[deprecated (since := "2026-05-27")] alias rearrangeComparison := rearrangeComparison?
 
 /--
 `compWithZero h` takes a proof `h` of an equality, inequality, or negation thereof,

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -104,7 +104,7 @@ partial def getNatComparisons (e : Expr) : List (Expr × Expr) :=
     | _ => []
 
 /-- If `e : ℕ`, returns a proof of `0 ≤ (e : C)`. -/
-def mk_natCast_nonneg_prf (p : Expr × Expr) : MetaM (Option Expr) :=
+def mkNatCastNonnegProof? (p : Expr × Expr) : MetaM (Option Expr) :=
   match p with
   | ⟨e, target⟩ => try commitIfNoEx (mkAppM ``natCast_nonneg #[target, e])
     catch e => do
@@ -146,9 +146,9 @@ def natToInt : GlobalBranchingPreprocessor where
         pure <| (es.insertMany indices_a).insertMany indices_b
       catch _ => pure es
     let atoms : Array Expr := (← get).atoms
-    let nonneg_pfs : List Expr ← nonnegs.toList.filterMapM fun p => do
-      mk_natCast_nonneg_prf (atoms[p.1]!, atoms[p.2]!)
-    pure [(g, nonneg_pfs ++ l)]
+    let nonnegProofs : List Expr ← nonnegs.toList.filterMapM fun p => do
+      mkNatCastNonnegProof? (atoms[p.1]!, atoms[p.2]!)
+    pure [(g, nonnegProofs ++ l)]
 
 end natToInt
 
@@ -159,7 +159,7 @@ If `pf` is a proof of a strict inequality `(a : ℤ) < b`,
 `mkNonstrictIntProof pf` returns a proof of `a + 1 ≤ b`,
 and similarly if `pf` proves a negated weak inequality.
 -/
-def mkNonstrictIntProof (pf : Expr) : MetaM (Option Expr) := do
+def mkNonstrictIntProof? (pf : Expr) : MetaM (Option Expr) := do
   match ← (← inferType pf).ineqOrNotIneq? with
   | (true, Ineq.lt, .const ``Int [], a, b) =>
     return mkApp (← mkAppM ``Iff.mpr #[← mkAppOptM ``Int.add_one_le_iff #[a, b]]) pf
@@ -172,7 +172,7 @@ def mkNonstrictIntProof (pf : Expr) : MetaM (Option Expr) := do
 into a proof of `t1 ≤ t2 + 1`. -/
 def strengthenStrictInt : Preprocessor where
   description := "strengthen strict inequalities over int"
-  transform h := return [(← mkNonstrictIntProof h).getD h]
+  transform h := return [(← mkNonstrictIntProof? h).getD h]
 
 end strengthenStrictInt
 
@@ -182,7 +182,7 @@ section compWithZero
 `rearrangeComparison e` takes a proof `e` of an equality, inequality, or negation thereof,
 and turns it into a proof of a comparison `_ R 0`, where `R ∈ {=, ≤, <}`.
 -/
-partial def rearrangeComparison (e : Expr) : MetaM (Option Expr) := do
+partial def rearrangeComparison? (e : Expr) : MetaM (Option Expr) := do
   match ← (← inferType e).ineq? with
   | (Ineq.le, _) => try? <| mkAppM ``Linarith.sub_nonpos_of_le #[e]
   | (Ineq.lt, _) => try? <| mkAppM ``Linarith.sub_neg_of_lt #[e]
@@ -194,7 +194,7 @@ and turns it into a proof of a comparison `_ R 0`, where `R ∈ {=, ≤, <}`.
 -/
 def compWithZero : Preprocessor where
   description := "make comparisons with zero"
-  transform e := return (← rearrangeComparison e).toList
+  transform e := return (← rearrangeComparison? e).toList
 
 end compWithZero
 

--- a/Mathlib/Tactic/Ring/Compare.lean
+++ b/Mathlib/Tactic/Ring/Compare.lean
@@ -64,6 +64,10 @@ abbrev leOfPartialOrder (α : Type*) [PartialOrder α] : LE α := inferInstance
 /-- `PartialOrder` implies `LT`. -/
 abbrev ltOfPartialOrder (α : Type*) [PartialOrder α] : LT α := inferInstance
 
+@[deprecated (since := "2026-05-27")] alias amwo_of_cs := addMonoidWithOneOfCommSemiring
+@[deprecated (since := "2026-05-27")] alias le_of_po := leOfPartialOrder
+@[deprecated (since := "2026-05-27")] alias lt_of_po := ltOfPartialOrder
+
 end Typeclass
 
 /-! The lemmas like `add_le_add_right` in the root namespace are stated under minimal type classes,

--- a/Mathlib/Tactic/Ring/Compare.lean
+++ b/Mathlib/Tactic/Ring/Compare.lean
@@ -55,13 +55,14 @@ runtime is devoted to type class inference. -/
 section Typeclass
 
 /-- `CommSemiring` implies `AddMonoidWithOne`. -/
-abbrev amwo_of_cs (α : Type*) [CommSemiring α] : AddMonoidWithOne α := inferInstance
+abbrev addMonoidWithOneOfCommSemiring (α : Type*) [CommSemiring α] : AddMonoidWithOne α :=
+  inferInstance
 
 /-- `PartialOrder` implies `LE`. -/
-abbrev le_of_po (α : Type*) [PartialOrder α] : LE α := inferInstance
+abbrev leOfPartialOrder (α : Type*) [PartialOrder α] : LE α := inferInstance
 
 /-- `PartialOrder` implies `LT`. -/
-abbrev lt_of_po (α : Type*) [PartialOrder α] : LT α := inferInstance
+abbrev ltOfPartialOrder (α : Type*) [PartialOrder α] : LT α := inferInstance
 
 end Typeclass
 
@@ -124,11 +125,12 @@ def evalLE {v : Level} {α : Q(Type v)}
     (ics : Q(CommSemiring $α)) (_ : Q(PartialOrder $α)) (_ : Q(IsOrderedRing $α))
     {a b : Q($α)} (va : Ring.ExSum q($ics) a) (vb : Ring.ExSum q($ics) b) :
     MetaM (Except ExceptType Q($a ≤ $b)) := do
-  let lα : Q(LE $α) := q(le_of_po $α)
+  let lα : Q(LE $α) := q(leOfPartialOrder $α)
   assumeInstancesCommute
-  let ⟨_, pz⟩ ← NormNum.mkOfNat α q(amwo_of_cs $α) q(nat_lit 0)
+  let ⟨_, pz⟩ ← NormNum.mkOfNat α q(addMonoidWithOneOfCommSemiring $α) q(nat_lit 0)
   let rz : NormNum.Result q((0:$α)) :=
-    NormNum.Result.isNat q(amwo_of_cs $α) q(nat_lit 0) (q(NormNum.isNat_ofNat $α $pz):)
+    NormNum.Result.isNat q(addMonoidWithOneOfCommSemiring $α) q(nat_lit 0)
+      (q(NormNum.isNat_ofNat $α $pz):)
   match va, vb with
   /- `0 ≤ 0` -/
   | .zero, .zero => pure <| .ok (q(le_refl (0:$α)):)
@@ -162,11 +164,12 @@ def evalLT {v : Level} {α : Q(Type v)}
     (ics : Q(CommSemiring $α)) (_ : Q(PartialOrder $α)) (_ : Q(IsStrictOrderedRing $α))
     {a b : Q($α)} (va : Ring.ExSum q($ics) a) (vb : Ring.ExSum q($ics) b) :
     MetaM (Except ExceptType Q($a < $b)) := do
-  let lα : Q(LT $α) := q(lt_of_po $α)
+  let lα : Q(LT $α) := q(ltOfPartialOrder $α)
   assumeInstancesCommute
-  let ⟨_, pz⟩ ← NormNum.mkOfNat α q(amwo_of_cs $α) q(nat_lit 0)
+  let ⟨_, pz⟩ ← NormNum.mkOfNat α q(addMonoidWithOneOfCommSemiring $α) q(nat_lit 0)
   let rz : NormNum.Result q((0:$α)) :=
-    NormNum.Result.isNat q(amwo_of_cs $α) q(nat_lit 0) (q(NormNum.isNat_ofNat $α $pz):)
+    NormNum.Result.isNat q(addMonoidWithOneOfCommSemiring $α) q(nat_lit 0)
+      (q(NormNum.isNat_ofNat $α $pz):)
   match va, vb with
   /- `0 < 0` -/
   | .zero, .zero => return .error tooSmall


### PR DESCRIPTION
This PR removes underscores from various metaprogramming `defs` which were misnamed. 

Sometimes meta-level tactic API is named to reflect the tactic syntax, and sometimes expressions representing proofs are named with underscores; but both of these are ordinary parts of the API which should respect ordinary naming conventions for defs.

Note that this PR also renames a couple of definitions in `Mathlib.Tactic.Linarith.NNRealPreprocesser` and `Mathlib.Tactic.Linarith.Preprocessing` to more closely reflect their type (e.g. using `?` for `Option`, `get` instead of `is` for computing data; also `Proof` instead of `Prf` to avoid the unnecessary abbreviation).

These are exempted by the `defsWithUnderscore` linter due to living in `Mathlib.Tactic`. (A change to this is explored in #39890, which removes this heuristic.)


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
