### PR TITLE
chore: deduplicate `Relation.CutExpand`

### DIFF
--- a/Mathlib/Data/Multiset/DershowitzManna.lean
+++ b/Mathlib/Data/Multiset/DershowitzManna.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Algebra.Order.Sub.Unbundled.Basic
 public import Mathlib.Data.Multiset.OrderedMonoid
 
+import Mathlib.Logic.Hydra
+
 /-!
 # Dershowitz-Manna ordering
 
@@ -71,101 +73,47 @@ lemma IsDershowitzMannaLT.trans :
   · obtain ⟨z, hz, hyz⟩ := hYZ₂ y <| mem_of_le (Multiset.sub_le_self ..) hy
     exact ⟨z, .inl hz, hyz⟩
 
-/-- A special case of `IsDershowitzMannaLT`. The transitive closure of it is used to define
-an equivalent (proved later) version of the ordering. -/
-private def OneStep (M N : Multiset α) : Prop :=
-  ∃ X Y a,
-      M = X + Y
-    ∧ N = X + {a}
-    ∧ ∀ y ∈ Y, y < a
-
-private lemma isDershowitzMannaLT_of_oneStep : OneStep M N → IsDershowitzMannaLT M N := by
-  rintro ⟨X, Y, a, M_def, N_def, ys_lt_a⟩
-  use X, Y, {a}, by simp, M_def, N_def
-  · simpa
-
-private lemma isDershowitzMannaLT_singleton_insert (h : OneStep N (a ::ₘ M)) :
-    ∃ M', N = a ::ₘ M' ∧ OneStep M' M ∨ N = M + M' ∧ ∀ x ∈ M', x < a := by
-  classical
-  obtain ⟨X, Y, b, rfl, h0, h2⟩ := h
-  obtain rfl | hab := eq_or_ne a b
-  · refine ⟨Y, .inr ⟨?_, h2⟩⟩
-    simpa [add_comm _ {a}, singleton_add, eq_comm] using h0
-  refine ⟨Y + (M - {b}), .inl ⟨?_, M - {b}, Y, b, add_comm .., ?_, h2⟩⟩
-  · rw [← singleton_add, add_comm] at h0
-    rw [tsub_eq_tsub_of_add_eq_add h0, add_comm Y, ← singleton_add, ← add_assoc,
-      add_tsub_cancel_of_le]
-    have : a ∈ X + {b} := by simp [← h0]
-    simpa [hab] using this
-  · rw [tsub_add_cancel_of_le]
-    have : b ∈ a ::ₘ M := by simp [h0]
-    simpa [hab.symm] using this
-
-private lemma acc_oneStep_cons_of_acc_lt (ha : Acc LT.lt a) :
-    ∀ {M}, Acc OneStep M → Acc OneStep (a ::ₘ M) := by
-  induction ha with | _ a _ ha
-  rintro M hM
-  induction hM with | _ M hM ihM
-  refine .intro _ fun N hNM ↦ ?_
-  obtain ⟨N, ⟨rfl, hNM'⟩ | ⟨rfl, hN⟩⟩ := isDershowitzMannaLT_singleton_insert hNM
-  · exact ihM _ hNM'
-  clear hNM
-  induction N using Multiset.induction with
-  | empty =>
-    simpa using .intro _ hM
-  | @cons b N ihN =>
-    simp only [mem_cons, forall_eq_or_imp, add_cons] at hN ⊢
-    obtain ⟨hba, hN⟩ := hN
-    exact ha _ hba <| ihN hN
-
-/-- If all elements of a multiset `M` are accessible with `<`, then the multiset `M` is
-accessible given the `OneStep` relation. -/
-private lemma acc_oneStep_of_acc_lt (hM : ∀ x ∈ M, Acc LT.lt x) : Acc OneStep M := by
-  induction M using Multiset.induction_on with
-  | empty =>
-    constructor
-    simp [OneStep, eq_comm (b := _ + _)]
-  | cons a M ih =>
-    exact acc_oneStep_cons_of_acc_lt (hM _ <| mem_cons_self ..) <| ih fun x hx ↦
-      hM _ <| mem_cons_of_mem hx
-
-/-- Over a well-founded order, `OneStep` is well-founded. -/
-private lemma isDershowitzMannaLT_singleton_wf [WellFoundedLT α] :
-    WellFounded (OneStep : Multiset α → Multiset α → Prop) :=
-  ⟨fun _M ↦ acc_oneStep_of_acc_lt fun a _ ↦ WellFoundedLT.apply a⟩
-
-private lemma transGen_oneStep_of_isDershowitzMannaLT :
-    IsDershowitzMannaLT M N → TransGen OneStep M N := by
+private lemma transGen_cutExpand_of_isDershowitzMannaLT :
+    IsDershowitzMannaLT M N → TransGen (CutExpand (· < ·)) M N := by
   classical
   rintro ⟨X, Y, Z, hZ, hM, hN, hYZ⟩
   induction Z using Multiset.induction_on generalizing X Y M N with
   | empty => simp at hZ
   | cons z Z ih => ?_
   obtain rfl | hZ := eq_or_ne Z 0
-  · exact .single ⟨X, Y, z, hM, hN, by simpa using hYZ⟩
+  · subst hM hN
+    apply TransGen.single
+    rw [cutExpand_add_left]
+    exact cutExpand_singleton <| by simpa using hYZ
   let Y' : Multiset α := Y.filter (· < z)
-  refine .tail (b := X + Y' + Z) (ih (X + Y') (Y - Y') hZ ?_ rfl fun y hy ↦ ?_) <|
-    ⟨X + Z, Y', z, add_right_comm .., by simp [hN, add_comm (_ + _)], by simp [Y']⟩
+  refine .tail (b := X + Y' + Z) (ih (X + Y') (Y - Y') hZ ?_ rfl fun y hy ↦ ?_) ?_
+    -- ⟨X + Z, Y', z, add_right_comm .., by simp [hN, add_comm (_ + _)], by simp [Y']⟩
   · rw [add_add_tsub_cancel (filter_le ..), hM]
   · simp only [sub_filter_eq_filter_not, mem_filter, Y'] at hy
     simpa [hy.2] using hYZ y (by simp_all)
+  · subst hN
+    rw [add_assoc, cutExpand_add_left, ← singleton_add, cutExpand_add_right]
+    exact cutExpand_singleton <| by simp [Y']
 
-private lemma isDershowitzMannaLT_of_transGen_oneStep (hMN : TransGen OneStep M N) :
-    IsDershowitzMannaLT M N :=
-  hMN.trans_induction_on (by rintro _ _ ⟨X, Y, a, rfl, rfl, hYa⟩; exact ⟨X, Y, {a}, by simpa⟩)
-    fun _ _ ↦ .trans
+private lemma isDershowitzMannaLT_of_transGen_cutExpand (hMN : TransGen (CutExpand (· < ·)) M N) :
+    IsDershowitzMannaLT M N := by
+  refine hMN.trans_induction_on (fun {a b} hab => ?_) fun _ _ ↦ .trans
+  classical
+  obtain ⟨s, x, hsx, hxb, hab⟩ := cutExpand_iff.1 hab
+  exact ⟨b.erase x, s, {x}, singleton_ne_zero x, hab,
+    (add_singleton_eq_iff.2 ⟨hxb, rfl⟩).symm, fun y hy => ⟨x, mem_singleton_self x, hsx y hy⟩⟩
 
-/-- `TransGen OneStep` and `IsDershowitzMannaLT` are equivalent. -/
-private lemma transGen_oneStep_eq_isDershowitzMannaLT :
-    (TransGen OneStep : Multiset α → Multiset α → Prop) = IsDershowitzMannaLT := by
+/-- `TransGen (CutExpand (· < ·))` and `IsDershowitzMannaLT` are equivalent. -/
+private lemma transGen_cutExpand_eq_isDershowitzMannaLT :
+    (TransGen (CutExpand (· < ·)) : Multiset α → Multiset α → Prop) = IsDershowitzMannaLT := by
   ext M N
-  exact ⟨isDershowitzMannaLT_of_transGen_oneStep, transGen_oneStep_of_isDershowitzMannaLT⟩
+  exact ⟨isDershowitzMannaLT_of_transGen_cutExpand, transGen_cutExpand_of_isDershowitzMannaLT⟩
 
 /-- Over a well-founded order, the Dershowitz-Manna order on multisets is well-founded. -/
 theorem wellFounded_isDershowitzMannaLT [WellFoundedLT α] :
     WellFounded (IsDershowitzMannaLT : Multiset α → Multiset α → Prop) := by
-  rw [← transGen_oneStep_eq_isDershowitzMannaLT]
-  exact isDershowitzMannaLT_singleton_wf.transGen
+  rw [← transGen_cutExpand_eq_isDershowitzMannaLT]
+  exact wellFounded_lt.cutExpand.transGen
 
 instance instWellFoundedIsDershowitzMannaLT [WellFoundedLT α] : WellFoundedRelation (Multiset α) :=
     ⟨IsDershowitzMannaLT, wellFounded_isDershowitzMannaLT⟩

--- a/Mathlib/Data/Multiset/DershowitzManna.lean
+++ b/Mathlib/Data/Multiset/DershowitzManna.lean
@@ -87,7 +87,6 @@ private lemma transGen_cutExpand_of_isDershowitzMannaLT :
     exact cutExpand_singleton <| by simpa using hYZ
   let Y' : Multiset α := Y.filter (· < z)
   refine .tail (b := X + Y' + Z) (ih (X + Y') (Y - Y') hZ ?_ rfl fun y hy ↦ ?_) ?_
-    -- ⟨X + Z, Y', z, add_right_comm .., by simp [hN, add_comm (_ + _)], by simp [Y']⟩
   · rw [add_add_tsub_cancel (filter_le ..), hM]
   · simp only [sub_filter_eq_filter_not, mem_filter, Y'] at hy
     simpa [hy.2] using hYZ y (by simp_all)


### PR DESCRIPTION
The file `Mathlib/Data/Multiset/DershowitzManna` has a private definition called `Multiset.OneStep` which is the same as `Relation.CutExpand (· < ·)` and a bunch of private theorems proving `WellFounded.cutExpand`. This PR replaces all this with the existing theorems about `Relation.CutExpand` to reduce duplication.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
