### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Sites): make auxiliary declarations for `OneHypercoverDenseData.isSheaf_iff` private

### DIFF
--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/OneHypercoverDense.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/OneHypercoverDense.lean
@@ -321,7 +321,7 @@ section
 variable {S} (s : Multifork (S.index G))
 
 /-- Auxiliary definition for `lift`. -/
-noncomputable def liftAux (i : (data X).I₀) : s.pt ⟶ G.obj (op (F.obj ((data X).X i))) :=
+private noncomputable def liftAux (i : (data X).I₀) : s.pt ⟶ G.obj (op (F.obj ((data X).X i))) :=
   hG₀.amalgamate ⟨_, cover_lift F J₀ _ (J.pullback_stable ((data X).f i) S.2)⟩
     (fun ⟨W₀, a, ha⟩ ↦ s.ι ⟨_, F.map a ≫ (data X).f i, ha⟩) (by
       rintro ⟨W₀, a, ha⟩ ⟨Z₀, b, hb⟩ ⟨U₀, p₁, p₂, fac⟩
@@ -331,13 +331,13 @@ noncomputable def liftAux (i : (data X).I₀) : s.pt ⟶ G.obj (op (F.obj ((data
           r := ⟨_, F.map p₁, F.map p₂, by
               simp only [← Functor.map_comp_assoc, fac]⟩ })
 
-lemma liftAux_fac {i : (data X).I₀} {W₀ : C₀} (a : W₀ ⟶ (data X).X i)
+private lemma liftAux_fac {i : (data X).I₀} {W₀ : C₀} (a : W₀ ⟶ (data X).X i)
     (ha : S (F.map a ≫ (data X).f i)) :
     liftAux hG₀ s i ≫ G.map (F.map a).op = s.ι ⟨_, F.map a ≫ (data X).f i, ha⟩ :=
   hG₀.amalgamate_map _ _ _ ⟨W₀, a, ha⟩
 
 /-- Auxiliary definition for the lemma `OneHypercoverDenseData.isSheaf_iff`. -/
-noncomputable def lift : s.pt ⟶ G.obj (op X) :=
+private noncomputable def lift : s.pt ⟶ G.obj (op X) :=
   Multifork.IsLimit.lift (hG X) (fun i ↦ liftAux hG₀ s i) (by
     rintro ⟨⟨i₁, i₂⟩, j⟩
     dsimp at i₁ i₂ j ⊢
@@ -355,13 +355,13 @@ noncomputable def lift : s.pt ⟶ G.obj (op X) :=
     rw [map_comp_assoc, map_comp_assoc, (data X).w j])
 
 @[reassoc]
-lemma lift_map (i : (data X).I₀) :
+private lemma lift_map (i : (data X).I₀) :
     lift hG₀ hG s ≫ G.map ((data X).f i).op = liftAux hG₀ s i :=
   Multifork.IsLimit.fac _ _ _ _
 
 set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
-lemma fac (a : S.Arrow) :
+private lemma fac (a : S.Arrow) :
     lift hG₀ hG s ≫ G.map a.f.op = s.ι a :=
   Multifork.IsLimit.hom_ext (hG _) (fun i ↦
     Presheaf.IsSheaf.hom_ext hG₀
@@ -388,7 +388,7 @@ lemma fac (a : S.Arrow) :
 set_option backward.isDefEq.respectTransparency false in
 variable {s} in
 include hG hG₀ in
-lemma hom_ext {f₁ f₂ : s.pt ⟶ G.obj (op X)}
+private lemma hom_ext {f₁ f₂ : s.pt ⟶ G.obj (op X)}
     (h : ∀ (a : S.Arrow), f₁ ≫ G.map a.f.op = f₂ ≫ G.map a.f.op) : f₁ = f₂ :=
   Multifork.IsLimit.hom_ext (hG X) (fun i ↦ by
     refine Presheaf.IsSheaf.hom_ext hG₀
@@ -401,7 +401,7 @@ lemma hom_ext {f₁ f₂ : s.pt ⟶ G.obj (op X)}
 end
 
 /-- Auxiliary definition for the lemma `OneHypercoverDenseData.isSheaf_iff`. -/
-noncomputable def isLimit : IsLimit (S.multifork G) :=
+private noncomputable def isLimit : IsLimit (S.multifork G) :=
   Multifork.IsLimit.mk _
     (lift hG₀ hG) (fac hG₀ hG) (fun s _ hm ↦
       hom_ext hG₀ hG (fun a ↦ (hm a).trans (fac hG₀ hG s a).symm))


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
