### PR TITLE
perf(Linter/DeprecatedModule): avoid running check multiple times in parallel

### DIFF
--- a/Mathlib/Tactic/Linter/DeprecatedModule.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedModule.lean
@@ -8,6 +8,7 @@ module
 public meta import Std.Time.Format
 public import Mathlib.Init
 public import Std.Time.Date
+public meta import Std.Sync.Mutex
 
 /-!
 # The `deprecated.module` linter
@@ -116,18 +117,14 @@ elab "#show_deprecated_modules" : command => do
 namespace DeprecatedModule
 
 /--
-`IsLaterCommand` is an `IO.Ref` that starts out being `false`.
+`IsLaterCommand` is a `Std.Mutex` that starts out being `false`.
 As soon as a (non-import) command in a file is processed, the `deprecated.module` linter
 sets it to `true`.
 If it is `false`, then the `deprecated.module` linter will check for deprecated modules.
 
 This is used to ensure that the linter performs the deprecation checks only once per file.
-There are possible concurrency issues, but they should not be particularly worrying:
-* the linter check should be relatively quick;
-* the only way in which the linter could change what it reports is if the imports are changed
-  and a change in imports triggers a rebuild of the whole file anyway, resetting the `IO.Ref`.
 -/
-initialize IsLaterCommand : IO.Ref Bool ← IO.mkRef false
+initialize IsLaterCommand : Std.Mutex Bool ← Std.Mutex.new false
 
 @[inherit_doc Mathlib.Linter.linter.deprecated.module]
 def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx ↦ do
@@ -139,13 +136,15 @@ def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx ↦ do
   -- for backwards compatibility
   if (← getFileName).endsWith "Mathlib.lean" then
     return
-  let laterCommand ← IsLaterCommand.get
+  let laterCommand ← IsLaterCommand.atomically do
+    let curr ← get
+    set true
+    return curr
   -- If `laterCommand` is `true`, then the linter already did what it was supposed to do.
   -- If `laterCommand` is `false` at the end of file, the file is an import-only file and
   -- the linter should not do anything.
   if laterCommand || (Parser.isTerminalCommand stx && !laterCommand) then
     return
-  IsLaterCommand.set true
   let deprecations := deprecatedModuleExt.getState (← getEnv)
   if deprecations.isEmpty then
     return


### PR DESCRIPTION
Use a mutex to ensure we only run the linter check once:
this removes instruction jitter and might provide a small speed-up.
(It will also enable generalising this linter to downstream projects without a big performance loss, by moving the
check for being the root module under the mutex.)

Analogous to https://github.com/leanprover-community/mathlib4/pull/39957; let's see if this makes any difference.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
