### PR TITLE
[Merged by Bors] - perf(ValuativeRel/ValuativeTopology): local instance for `isUniformAddGroup`

### DIFF
--- a/Mathlib/NumberTheory/RamificationInertia/Valuation.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Valuation.lean
@@ -61,8 +61,6 @@ theorem valuation_liesOver (x : K) :
 
 variable (K)
 
--- TODO: Can remove the `attribute [-instance] ValuativeRel.isUniformAddGroup` after #36769
--- attribute [-instance] ValuativeRel.isUniformAddGroup in
 theorem uniformContinuous_algebraMap_liesOver :
     UniformContinuous (algebraMap (WithVal (v.valuation K)) (WithVal (w.valuation L))) := by
   refine uniformContinuous_of_continuousAt_zero _ ?_

--- a/Mathlib/NumberTheory/RamificationInertia/Valuation.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Valuation.lean
@@ -62,7 +62,7 @@ theorem valuation_liesOver (x : K) :
 variable (K)
 
 -- TODO: Can remove the `attribute [-instance] ValuativeRel.isUniformAddGroup` after #36769
-attribute [-instance] ValuativeRel.isUniformAddGroup in
+-- attribute [-instance] ValuativeRel.isUniformAddGroup in
 theorem uniformContinuous_algebraMap_liesOver :
     UniformContinuous (algebraMap (WithVal (v.valuation K)) (WithVal (w.valuation L))) := by
   refine uniformContinuous_of_continuousAt_zero _ ?_

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -152,7 +152,7 @@ section Units
 variable {R K}
 
 -- TODO: Can remove the `attribute [-instance] ValuativeRel.isUniformAddGroup` after #36769
-attribute [-instance] ValuativeRel.isUniformAddGroup in
+-- attribute [-instance] ValuativeRel.isUniformAddGroup in
 set_option backward.isDefEq.respectTransparency false in
 theorem isUnit_iff {a : FiniteAdeleRing R K} :
     IsUnit a ↔ (∀ v, a v ≠ 0) ∧ ∀ᶠ v in Filter.cofinite, Valued.v (a v) = 1 := by

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -151,8 +151,6 @@ section Units
 
 variable {R K}
 
--- TODO: Can remove the `attribute [-instance] ValuativeRel.isUniformAddGroup` after #36769
--- attribute [-instance] ValuativeRel.isUniformAddGroup in
 set_option backward.isDefEq.respectTransparency false in
 theorem isUnit_iff {a : FiniteAdeleRing R K} :
     IsUnit a ↔ (∀ v, a v ≠ 0) ∧ ∀ᶠ v in Filter.cofinite, Valued.v (a v) = 1 := by

--- a/Mathlib/Topology/Algebra/ValuativeRel/ValuativeTopology.lean
+++ b/Mathlib/Topology/Algebra/ValuativeRel/ValuativeTopology.lean
@@ -80,7 +80,7 @@ valuative and nonarchimedean, and the addition is uniformly continuous,
 can be automatically inferred. -/
 local instance uniformSpace : UniformSpace R := IsTopologicalAddGroup.rightUniformSpace R
 
-instance isUniformAddGroup : IsUniformAddGroup R := isUniformAddGroup_of_addCommGroup
+local instance isUniformAddGroup : IsUniformAddGroup R := isUniformAddGroup_of_addCommGroup
 
 end ValuativeRel
 

--- a/Mathlib/Topology/Algebra/ValuativeRel/ValuativeTopology.lean
+++ b/Mathlib/Topology/Algebra/ValuativeRel/ValuativeTopology.lean
@@ -80,6 +80,7 @@ valuative and nonarchimedean, and the addition is uniformly continuous,
 can be automatically inferred. -/
 local instance uniformSpace : UniformSpace R := IsTopologicalAddGroup.rightUniformSpace R
 
+/-- This is not made into a global instance to avoid diamonds. -/
 local instance isUniformAddGroup : IsUniformAddGroup R := isUniformAddGroup_of_addCommGroup
 
 end ValuativeRel

--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -518,7 +518,7 @@ theorem IsEquiv.orderRingIso_symm_apply (h : v.IsEquiv w) (x : WithVal w) :
 open MonoidWithZeroHom MonoidWithZeroHom.ValueGroup₀
 
 -- TODO: Can remove the `attribute [-instance] ValuativeRel.isUniformAddGroup` after #36769
-attribute [-instance] ValuativeRel.isUniformAddGroup in
+-- attribute [-instance] ValuativeRel.isUniformAddGroup in
 set_option backward.isDefEq.respectTransparency false in
 theorem IsEquiv.uniformContinuous_equiv [hval : Valued R Γ₀'] (hv : Valued.v = w)
     (h : v.IsEquiv w) : UniformContinuous (WithVal.equiv v) := by
@@ -543,7 +543,7 @@ theorem IsEquiv.uniformContinuous_equiv [hval : Valued R Γ₀'] (hv : Valued.v 
   simpa [lt_div_iff₀ hs0', ← map_mul] using hx
 
 -- TODO: Can remove the `attribute [-instance] ValuativeRel.isUniformAddGroup` after #36769
-attribute [-instance] ValuativeRel.isUniformAddGroup in
+-- attribute [-instance] ValuativeRel.isUniformAddGroup in
 set_option backward.isDefEq.respectTransparency false in
 theorem IsEquiv.uniformContinuous_equiv_symm [hval : Valued R Γ₀'] (hv : Valued.v = w)
     (h : w.IsEquiv v) : UniformContinuous (WithVal.equiv v).symm := by
@@ -641,7 +641,7 @@ theorem restrict_exists_div_eq {K : Type*} [Field K] {Γ₀ : Type*}
       embedding_strictMono.lt_iff_lt, map_zero]
     refine WithZero.pos_iff_ne_zero.mpr (Units.ne_zero γ)⟩
 
-attribute [-instance] ValuativeRel.isUniformAddGroup in
+-- attribute [-instance] ValuativeRel.isUniformAddGroup in
 set_option backward.isDefEq.respectTransparency false in
 open UniformSpace.Completion in
 theorem IsEquiv.valuedCompletion_le_one_iff {K : Type*} [Field K] {v : Valuation K Γ₀}

--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -517,8 +517,6 @@ theorem IsEquiv.orderRingIso_symm_apply (h : v.IsEquiv w) (x : WithVal w) :
 
 open MonoidWithZeroHom MonoidWithZeroHom.ValueGroup₀
 
--- TODO: Can remove the `attribute [-instance] ValuativeRel.isUniformAddGroup` after #36769
--- attribute [-instance] ValuativeRel.isUniformAddGroup in
 set_option backward.isDefEq.respectTransparency false in
 theorem IsEquiv.uniformContinuous_equiv [hval : Valued R Γ₀'] (hv : Valued.v = w)
     (h : v.IsEquiv w) : UniformContinuous (WithVal.equiv v) := by
@@ -542,8 +540,6 @@ theorem IsEquiv.uniformContinuous_equiv [hval : Valued R Γ₀'] (hv : Valued.v 
     ← hy, ← toVal_mul, ← h'.orderRingIso_apply, ← h'.orderRingIso.lt_symm_apply, lt_def]
   simpa [lt_div_iff₀ hs0', ← map_mul] using hx
 
--- TODO: Can remove the `attribute [-instance] ValuativeRel.isUniformAddGroup` after #36769
--- attribute [-instance] ValuativeRel.isUniformAddGroup in
 set_option backward.isDefEq.respectTransparency false in
 theorem IsEquiv.uniformContinuous_equiv_symm [hval : Valued R Γ₀'] (hv : Valued.v = w)
     (h : w.IsEquiv v) : UniformContinuous (WithVal.equiv v).symm := by
@@ -641,7 +637,6 @@ theorem restrict_exists_div_eq {K : Type*} [Field K] {Γ₀ : Type*}
       embedding_strictMono.lt_iff_lt, map_zero]
     refine WithZero.pos_iff_ne_zero.mpr (Units.ne_zero γ)⟩
 
--- attribute [-instance] ValuativeRel.isUniformAddGroup in
 set_option backward.isDefEq.respectTransparency false in
 open UniformSpace.Completion in
 theorem IsEquiv.valuedCompletion_le_one_iff {K : Type*} [Field K] {v : Valuation K Γ₀}


### PR DESCRIPTION
Make `ValuativeRel.isUniformAddGroup` a `local instance`. This is done to avoid diamonds similar to `ValuativeRel.uniformSpace`. It also reverts most of the performance degradation of #34045

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
