### PR TITLE
[Merged by Bors] - refactor(CategoryTheory): redefine `MorphismProperty.IsLocalAtTarget` in terms of presieves

### DIFF
--- a/Mathlib/AlgebraicGeometry/Cover/Open.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Open.lean
@@ -62,19 +62,19 @@ def affineCover (X : Scheme.{u}) : OpenCover X := by
 instance : Inhabited X.OpenCover :=
   ⟨X.affineCover⟩
 
-theorem OpenCover.iSup_opensRange {X : Scheme.{u}} (𝒰 : X.OpenCover) :
+theorem OpenCover.iSup_opensRange {X : Scheme.{u}} (𝒰 : Scheme.OpenCover.{v} X) :
     ⨆ i, (𝒰.f i).opensRange = ⊤ :=
   Opens.ext <| by rw [Opens.coe_iSup]; exact 𝒰.iUnion_range
 
 /-- The ranges of the maps in a scheme-theoretic open cover are a topological open cover. -/
-lemma OpenCover.isOpenCover_opensRange {X : Scheme.{u}} (𝒰 : X.OpenCover) :
+lemma OpenCover.isOpenCover_opensRange {X : Scheme.{u}} (𝒰 : OpenCover.{v} X) :
     IsOpenCover fun i ↦ (𝒰.f i).opensRange :=
   .mk 𝒰.iSup_opensRange
 
 /-- Every open cover of a quasi-compact scheme can be refined into a finite subcover.
 -/
 @[simps! X f]
-def OpenCover.finiteSubcover {X : Scheme.{u}} (𝒰 : OpenCover X) [H : CompactSpace X] :
+def OpenCover.finiteSubcover {X : Scheme.{u}} (𝒰 : OpenCover.{v} X) [H : CompactSpace X] :
     OpenCover X := by
   have :=
     @CompactSpace.elim_nhds_subcover _ _ H (fun x : X => Set.range (𝒰.f (𝒰.idx x)))

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -125,11 +125,12 @@ protected lemma mk' {P : MorphismProperty Scheme} [P.RespectsIso]
     (of_sSup_eq_top :
       ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) {ι : Type u} (U : ι → Y.Opens), iSup U = ⊤ →
         (∀ i, P (f ∣_ U i)) → P f) :
-    IsZariskiLocalAtTarget P where
-  pullbackSnd 𝒰 i hf := (P.arrow_mk_iso_iff (morphismRestrictOpensRange _ _)).mp (restrict _ _ hf)
-  of_zeroHypercover {X Y f} 𝒰 h := by
-    refine of_sSup_eq_top f _ (Scheme.OpenCover.iSup_opensRange 𝒰) ?_
-    exact fun i ↦ (P.arrow_mk_iso_iff (morphismRestrictOpensRange f _)).mpr (h i)
+    IsZariskiLocalAtTarget P := by
+  refine .mk_of_iff_of_zeroHypercover fun {X Y} f 𝒰 ↦ ?_
+  refine ⟨fun hf i ↦ (P.arrow_mk_iso_iff (morphismRestrictOpensRange _ _)).mp (restrict _ _ hf),
+    fun h ↦ ?_⟩
+  refine of_sSup_eq_top f _ (Scheme.OpenCover.iSup_opensRange <| .ulift 𝒰) ?_
+  exact fun i ↦ (P.arrow_mk_iso_iff (morphismRestrictOpensRange f _)).mpr (h _)
 
 variable {P : MorphismProperty Scheme.{u}} [IsZariskiLocalAtTarget P]
   {X Y : Scheme.{u}} {f : X ⟶ Y} (𝒰 : Y.OpenCover)
@@ -233,18 +234,18 @@ protected lemma mk' {P : MorphismProperty Scheme} [P.RespectsIso]
     (of_sSup_eq_top :
       ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) {ι : Type u} (U : ι → X.Opens), iSup U = ⊤ →
         (∀ i, P ((U i).ι ≫ f)) → P f) :
-    IsZariskiLocalAtSource P where
-  comp 𝒰 i H := by
-    rw [← IsOpenImmersion.isoOfRangeEq_hom_fac (𝒰.f i) (Scheme.Opens.ι _)
+    IsZariskiLocalAtSource P := by
+  refine .mk_of_iff_of_zeroHypercover fun {X Y} f 𝒰 ↦ ⟨fun hf i ↦ ?_, fun hf ↦ ?_⟩
+  · rw [← IsOpenImmersion.isoOfRangeEq_hom_fac (𝒰.f i) (Scheme.Opens.ι _)
       (congr_arg Opens.carrier (𝒰.f i).opensRange.opensRange_ι.symm), Category.assoc,
       P.cancel_left_of_respectsIso]
-    exact restrict _ _ H
-  of_zeroHypercover {X Y} f 𝒰 h := by
-    refine of_sSup_eq_top f _ (Scheme.OpenCover.iSup_opensRange 𝒰) fun i ↦ ?_
-    rw [← IsOpenImmersion.isoOfRangeEq_inv_fac (𝒰.f i) (Scheme.Opens.ι _)
-      (congr_arg Opens.carrier (𝒰.f i).opensRange.opensRange_ι.symm), Category.assoc,
+    exact restrict _ _ hf
+  · refine of_sSup_eq_top f _ (Scheme.OpenCover.iSup_opensRange <| .ulift 𝒰) fun i ↦ ?_
+    dsimp
+    rw [← IsOpenImmersion.isoOfRangeEq_inv_fac (𝒰.f _) (Scheme.Opens.ι _)
+      (congr_arg Opens.carrier (𝒰.f _).opensRange.opensRange_ι.symm), Category.assoc,
       P.cancel_left_of_respectsIso]
-    exact h _
+    exact hf _
 
 variable {P : MorphismProperty Scheme.{u}} [IsZariskiLocalAtSource P]
 variable {X Y : Scheme.{u}} {f : X ⟶ Y} (𝒰 : X.OpenCover)
@@ -286,13 +287,12 @@ lemma of_isOpenImmersion [P.ContainsIdentities] [IsOpenImmersion f] : P f :=
 
 lemma isZariskiLocalAtTarget [P.IsMultiplicative]
     (hP : ∀ {X Y Z : Scheme.{u}} (f : X ⟶ Y) (g : Y ⟶ Z) [IsOpenImmersion g], P (f ≫ g) → P f) :
-    IsZariskiLocalAtTarget P where
-  pullbackSnd {X Y} f 𝒰 i hf := by
-    apply hP _ (𝒰.f i)
+    IsZariskiLocalAtTarget P := by
+  refine .mk_of_iff_of_zeroHypercover fun {X Y} f 𝒰 ↦ ⟨fun hf i ↦ ?_, fun h ↦ ?_⟩
+  · apply hP _ (𝒰.f i)
     rw [← pullback.condition]
     exact IsZariskiLocalAtSource.comp hf _
-  of_zeroHypercover {X Y} f 𝒰 h := by
-    rw [P.iff_of_zeroHypercover_source (𝒰.pullback₁ f)]
+  · rw [P.iff_of_zeroHypercover_source (𝒰.pullback₁ f)]
     intro i
     rw [← Scheme.Cover.pullbackHom_map]
     exact P.comp_mem _ _ (h i) (of_isOpenImmersion _)
@@ -646,13 +646,18 @@ theorem isStableUnderBaseChange (hP' : Q.IsStableUnderBaseChange) :
 lemma isZariskiLocalAtSource
     (H : ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffine Y] (𝒰 : Scheme.OpenCover.{u} X),
         Q f ↔ ∀ i, Q (𝒰.f i ≫ f)) : IsZariskiLocalAtSource P := by
-  refine .mk_of_iff ?_
-  intro X Y f 𝒰
-  simp_rw [IsZariskiLocalAtTarget.iff_of_iSup_eq_top _ (iSup_affineOpens_eq_top Y)]
-  rw [forall_comm]
-  refine forall_congr' fun U ↦ ?_
-  simp_rw [HasAffineProperty.iff_of_isAffine, morphismRestrict_comp]
-  exact @H _ _ (f ∣_ U.1) U.2 (Scheme.OpenCover.restrict 𝒰 (f ⁻¹ᵁ U.1))
+  refine .mk_of_small ?_ ?_
+  all_goals
+    intro X Y f 𝒰 hf
+    simp_rw [IsZariskiLocalAtTarget.iff_of_iSup_eq_top _ (iSup_affineOpens_eq_top Y),
+      HasAffineProperty.iff_of_isAffine, morphismRestrict_comp] at hf ⊢
+  · intro i U
+    let 𝒰' : X.OpenCover := (Scheme.Cover.ulift 𝒰).add (𝒰.f i)
+    exact (H (f ∣_ U.1) (𝒰'.restrict _)).mp (hf _) none
+  · intro U
+    rw [H (f ∣_ U.1) (Scheme.OpenCover.restrict 𝒰 _)]
+    intro i
+    exact hf _ _
 
 end HasAffineProperty
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -646,10 +646,8 @@ theorem isStableUnderBaseChange (hP' : Q.IsStableUnderBaseChange) :
 lemma isZariskiLocalAtSource
     (H : ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffine Y] (𝒰 : Scheme.OpenCover.{u} X),
         Q f ↔ ∀ i, Q (𝒰.f i ≫ f)) : IsZariskiLocalAtSource P := by
-  refine .mk_of_small ?_ ?_
-  all_goals
-    intro X Y f 𝒰 hf
-    simp_rw [IsZariskiLocalAtTarget.iff_of_iSup_eq_top _ (iSup_affineOpens_eq_top Y),
+  refine .mk_of_small (fun {X Y f} 𝒰 hf ↦ ?_) (fun {X Y f} 𝒰 hf ↦ ?_) <;>
+  simp_rw [IsZariskiLocalAtTarget.iff_of_iSup_eq_top _ (iSup_affineOpens_eq_top Y),
       HasAffineProperty.iff_of_isAffine, morphismRestrict_comp] at hf ⊢
   · intro i U
     let 𝒰' : X.OpenCover := (Scheme.Cover.ulift 𝒰).add (𝒰.f i)

--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -225,7 +225,7 @@ theorem universally_isZariskiLocalAtTarget (P : MorphismProperty Scheme)
 
 lemma universally_isZariskiLocalAtSource (P : MorphismProperty Scheme)
     [IsZariskiLocalAtSource P] : IsZariskiLocalAtSource P.universally := by
-  refine .mk_of_iff ?_
+  refine .mk_of_iff_of_zeroHypercover ?_
   intro X Y f 𝒰
   refine ⟨fun hf i ↦ ?_, fun hf ↦ ?_⟩
   · apply MorphismProperty.universally_mk'

--- a/Mathlib/AlgebraicGeometry/Morphisms/LocalClosure.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/LocalClosure.lean
@@ -73,12 +73,12 @@ instance [P.RespectsIso] : (sourceLocalClosure W P).RespectsIso where
 
 instance [P.RespectsIso] [P.RespectsLeft @IsOpenImmersion] :
     IsZariskiLocalAtSource (sourceLocalClosure IsOpenImmersion P) := by
-  refine .mk_of_iff fun f 𝒰 ↦ ?_
+  refine .mk_of_iff_of_zeroHypercover fun f 𝒰 ↦ ?_
   refine ⟨fun ⟨𝒱, h⟩ ↦ fun i ↦ ⟨𝒱.pullback₁ (𝒰.f i), fun j ↦ ?_⟩, fun h ↦ ?_⟩
   · simpa [pullback.condition_assoc] using
       RespectsLeft.precomp (Q := @IsOpenImmersion) _ inferInstance _ (h j)
   · choose 𝒱 h𝒱 using h
-    exact ⟨𝒰.bind 𝒱, fun i ↦ h𝒱 _ _⟩
+    exact ⟨(Scheme.Cover.ulift 𝒰).bind (fun i ↦ Scheme.Cover.ulift (𝒱 _)), fun i ↦ h𝒱 _ _⟩
 
 instance [P.IsStableUnderBaseChange] : (sourceLocalClosure W P).IsStableUnderBaseChange := by
   refine .mk' fun X Y S f g _ ⟨𝒰, hg⟩ ↦ ⟨𝒰.pullback₁ (pullback.snd f g), fun i ↦ ?_⟩

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -854,7 +854,7 @@ set_option backward.isDefEq.respectTransparency false in
 /-- The restriction of an open cover to an open subset. -/
 @[simps! I₀ X f]
 noncomputable
-def Scheme.OpenCover.restrict {X : Scheme.{u}} (𝒰 : X.OpenCover) (U : Opens X) :
+def Scheme.OpenCover.restrict {X : Scheme.{u}} (𝒰 : Scheme.OpenCover.{v} X) (U : Opens X) :
     U.toScheme.OpenCover := by
   refine Cover.copy (𝒰.pullback₁ U.ι) 𝒰.I₀ _ (𝒰.f · ∣_ U) (Equiv.refl _)
     (fun i ↦ IsOpenImmersion.isoOfRangeEq (Opens.ι _) (pullback.snd _ _) ?_) ?_

--- a/Mathlib/CategoryTheory/MorphismProperty/Local.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Local.lean
@@ -23,10 +23,6 @@ We say that
 - `P` is local at the source if for every `f : X ⟶ Y`, `P` holds for `f` if and only if it holds
   for the restrictions of `f` to `Uᵢ` for a `K`-cover `{Uᵢ}` of `X`.
 
-## Implementation details
-
-The covers appearing in the definitions have index type in the morphism universe of `C`.
-
 ## TODOs
 
 - Define source and target local closure of a morphism property.
@@ -51,72 +47,95 @@ A property of morphisms `P` in `C` is local at the target with respect to the pr
 it respects isomorphisms, and:
 `P` holds for `f : X ⟶ Y` if and only if it holds for the restrictions of `f` to `Uᵢ` for a
 `0`-hypercover `{Uᵢ}` of `Y` in the precoverage `K`.
-
-For a version of `of_zeroHypercover` that takes a `v`-small `0`-hypercover in an arbitrary
-universe, use `CategoryTheory.MorphismProperty.of_zeroHypercover_target`.
 -/
-class IsLocalAtTarget (P : MorphismProperty C) (K : Precoverage C) [K.HasPullbacks]
-    extends RespectsIso P where
+class IsLocalAtTarget (P : MorphismProperty C) (K : Precoverage C) extends RespectsIso P where
   /-- If `P` holds for `f : X ⟶ Y`, it also holds for `f` restricted to `Uᵢ` for any
-  `K`-cover `𝒰` of `Y`. -/
-  pullbackSnd {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K Y)
-    (i : 𝒰.I₀) (hf : P f) : P (pullback.snd f (𝒰.f i))
+  `K`-cover `R` of `Y`. -/
+  pullbackSnd {X Y : C} {f : Y ⟶ X} {R : Presieve X} {U : C} {g : U ⟶ X} (hR : R ∈ K X)
+    (hg : R g) (hf : P f) [HasPullback f g] :
+    P (pullback.snd f g)
   /-- If `P` holds for `f` restricted to `Uᵢ` for all `i`, it also holds for `f : X ⟶ Y` for any
-  `K`-cover `𝒰` of `Y`. -/
-  of_zeroHypercover {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K Y)
-    (h : ∀ i, P (pullback.snd f (𝒰.f i))) : P f
+  `K`-cover `R` of `Y`. -/
+  of_forall_pullbackSnd {X Y : C} {f : Y ⟶ X} {R : Presieve X} (hR : R ∈ K X)
+    (h : ∀ {U : C} {g : U ⟶ X} [HasPullback f g], R g → P (pullback.snd f g)) :
+    P f
 
 namespace IsLocalAtTarget
 
-variable {P : MorphismProperty C} {K L : Precoverage C} [K.HasPullbacks]
+variable {P : MorphismProperty C} {K L : Precoverage C}
 
 lemma mk_of_iff [P.RespectsIso]
-    (H : ∀ {X Y : C} (f : X ⟶ Y) (𝒰 : Precoverage.ZeroHypercover.{v} K Y),
+    (H : ∀ ⦃X Y : C⦄ ⦃f : X ⟶ Y⦄ ⦃R : Presieve Y⦄, R ∈ K Y →
+      (P f ↔ ∀ {U : C} (g : U ⟶ Y) [HasPullback f g], R g → P (pullback.snd f g))) :
+    P.IsLocalAtTarget K where
+  pullbackSnd := by grind
+  of_forall_pullbackSnd := by grind
+
+lemma iff_of_forall_pullbackSnd [P.IsLocalAtTarget K] {X Y : C} {R : Presieve Y} (hR : R ∈ K Y)
+    {f : X ⟶ Y} :
+    P f ↔ ∀ {U : C} (g : U ⟶ Y) [HasPullback f g], R g → P (pullback.snd f g) := by
+  grind [IsLocalAtTarget]
+
+lemma mk_of_iff_of_zeroHypercover [K.HasPullbacks] [P.RespectsIso]
+    (H : ∀ {X Y : C} (f : X ⟶ Y) (𝒰 : Precoverage.ZeroHypercover.{max u v} K Y),
       P f ↔ ∀ i, P (pullback.snd f (𝒰.f i))) :
-    P.IsLocalAtTarget K where
-  pullbackSnd 𝒰 i h := (H _ 𝒰).mp h i
-  of_zeroHypercover 𝒰 h := (H _ 𝒰).mpr h
+    P.IsLocalAtTarget K := by
+  refine mk_of_iff fun X Y f R hR ↦ ?_
+  obtain ⟨𝒰, rfl⟩ := R.exists_eq_preZeroHypercover
+  rw [H _ ⟨𝒰, hR⟩]
+  have _ (i) : HasPullback (𝒰.f i) f := (Precoverage.hasPullbacks_of_mem _ hR).hasPullback ⟨i⟩
+  refine ⟨fun h U g hfg ↦ ?_, fun h i ↦ h _ ⟨i⟩⟩
+  rintro ⟨i⟩
+  exact h i
 
-lemma mk_of_isStableUnderBaseChange [P.IsStableUnderBaseChange]
-    (H : ∀ {X Y : C} (f : X ⟶ Y) (𝒰 : Precoverage.ZeroHypercover.{v} K Y),
-      (∀ i, P (pullback.snd f (𝒰.f i))) → P f) :
-    P.IsLocalAtTarget K where
-  pullbackSnd _ _ hf := P.pullback_snd _ _ hf
-  of_zeroHypercover _ := H _ _
+lemma mk_of_small [K.HasPullbacks] [P.RespectsIso] [Precoverage.Small.{w} K]
+    (h₁ : ∀ {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{max u v} K Y),
+        P f → ∀ i, P (pullback.snd f (𝒰.f i)))
+    (h₂ : ∀ {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{w} K Y),
+        (∀ i, P (pullback.snd f (𝒰.f i))) → P f) :
+    P.IsLocalAtTarget K :=
+  .mk_of_iff_of_zeroHypercover fun _ 𝒰 ↦ ⟨fun hf _ ↦ h₁ 𝒰 hf _,
+    fun h ↦ h₂ 𝒰.restrictIndexOfSmall fun _ ↦ h _⟩
 
-lemma of_le [L.HasPullbacks] [IsLocalAtTarget P L] (hle : K ≤ L) : IsLocalAtTarget P K where
-  pullbackSnd 𝒰 i hf := pullbackSnd (𝒰.weaken hle) i hf
-  of_zeroHypercover 𝒰 := of_zeroHypercover (𝒰.weaken hle)
+lemma mk_of_isStableUnderBaseChange [K.HasPullbacks] [P.IsStableUnderBaseChange]
+    (H : ∀ {X Y : C} (f : X ⟶ Y) (𝒰 : Precoverage.ZeroHypercover.{max u v} K Y),
+      (∀ (i : 𝒰.I₀), P (pullback.snd f (𝒰.f i))) → P f) :
+    P.IsLocalAtTarget K :=
+  .mk_of_iff_of_zeroHypercover fun _ 𝒰 ↦ ⟨fun hf _ ↦ P.pullback_snd _ _ hf, fun h ↦ H _ 𝒰 h⟩
+
+lemma of_le [IsLocalAtTarget P L] (hle : K ≤ L) : IsLocalAtTarget P K where
+  pullbackSnd h i hf := pullbackSnd (hle _ h) i hf
+  of_forall_pullbackSnd hR h := of_forall_pullbackSnd (hle _ hR) h
 
 instance top : IsLocalAtTarget (⊤ : MorphismProperty C) K where
   pullbackSnd := by simp
-  of_zeroHypercover := by simp
+  of_forall_pullbackSnd := by simp
 
-variable [IsLocalAtTarget P K] {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K Y)
+variable [IsLocalAtTarget P K] {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{w} K Y)
 
 lemma of_isPullback {X' : C} (i : 𝒰.I₀) {fst : X' ⟶ X} {snd : X' ⟶ 𝒰.X i}
     (h : IsPullback fst snd f (𝒰.f i)) (hf : P f) :
     P snd := by
+  have : HasPullback f (𝒰.f i) := h.hasPullback
   rw [← P.cancel_left_of_respectsIso h.isoPullback.inv, h.isoPullback_inv_snd]
-  exact pullbackSnd _ _ hf
+  exact pullbackSnd 𝒰.mem₀ ⟨i⟩ hf
 
-lemma iff_of_zeroHypercover : P f ↔ ∀ i, P (pullback.snd f (𝒰.f i)) :=
-  ⟨fun hf _ ↦ pullbackSnd _ _ hf, fun h ↦ of_zeroHypercover _ h⟩
+lemma of_zeroHypercover [K.HasPullbacks] (h : ∀ (i : 𝒰.I₀), P (pullback.snd f (𝒰.f i))) :
+    P f :=
+  of_forall_pullbackSnd 𝒰.mem₀ (by rintro _ _ _ ⟨i⟩; exact h _)
+
+lemma iff_of_zeroHypercover [K.HasPullbacks] : P f ↔ ∀ i, P (pullback.snd f (𝒰.f i)) :=
+  ⟨fun hf _ ↦ pullbackSnd 𝒰.mem₀ ⟨_⟩ hf, fun h ↦ of_zeroHypercover _ h⟩
 
 instance inf (P Q : MorphismProperty C) [IsLocalAtTarget P K] [IsLocalAtTarget Q K] :
     IsLocalAtTarget (P ⊓ Q) K where
-  pullbackSnd _ i h := ⟨pullbackSnd _ i h.1, pullbackSnd _ i h.2⟩
-  of_zeroHypercover _ h :=
-    ⟨of_zeroHypercover _ fun i ↦ (h i).1, of_zeroHypercover _ fun i ↦ (h i).2⟩
+  pullbackSnd hR i h := ⟨pullbackSnd hR i h.1, pullbackSnd hR i h.2⟩
+  of_forall_pullbackSnd hR h :=
+    ⟨of_forall_pullbackSnd hR fun i ↦ (h i).1, of_forall_pullbackSnd hR fun i ↦ (h i).2⟩
 
 end IsLocalAtTarget
 
-lemma of_zeroHypercover_target {P : MorphismProperty C} {K : Precoverage C} [K.HasPullbacks]
-    [P.IsLocalAtTarget K] {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{w} K Y)
-    [Precoverage.ZeroHypercover.Small.{v} 𝒰] (h : ∀ i, P (pullback.snd f (𝒰.f i))) :
-    P f := by
-  rw [IsLocalAtTarget.iff_of_zeroHypercover (P := P) 𝒰.restrictIndexOfSmall]
-  simp [h]
+alias of_zeroHypercover_target := IsLocalAtTarget.of_zeroHypercover
 
 alias iff_of_zeroHypercover_target := IsLocalAtTarget.iff_of_zeroHypercover
 
@@ -125,57 +144,74 @@ A property of morphisms `P` in `C` is local at the source with respect to the pr
 it respects isomorphisms, and:
 `P` holds for `f : X ⟶ Y` if and only if it holds for the restrictions of `f` to `Uᵢ` for a
 `0`-hypercover `{Uᵢ}` of `X` in the precoverage `K`.
-
-For a version of `of_zeroHypercover` that takes a `v`-small `0`-hypercover in an arbitrary
-universe, use `CategoryTheory.MorphismProperty.of_zeroHypercover_source`.
 -/
 class IsLocalAtSource (P : MorphismProperty C) (K : Precoverage C) extends RespectsIso P where
-  /-- If `P` holds for `f : X ⟶ Y`, it also holds for `𝒰.f i ≫ f` for any `K`-cover `𝒰` of `X`. -/
-  comp {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K X) (i : 𝒰.I₀)
-    (hf : P f) : P (𝒰.f i ≫ f)
+  /-- If `P` holds for `f : X ⟶ Y`, it also holds for `𝒰.f i ≫ f` for any `K`-cover `R` of `X`. -/
+  comp {X Y : C} {f : X ⟶ Y} {R : Presieve X} (hR : R ∈ K X) {U : C} (g : U ⟶ X) (hg : R g)
+    (hf : P f) : P (g ≫ f)
   /-- If `P` holds for `𝒰.f i ≫ f` for all `i`, it holds for `f : X ⟶ Y` for any `K`-cover
-  `𝒰` of X. -/
-  of_zeroHypercover {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K X) :
-    (∀ i, P (𝒰.f i ≫ f)) → P f
+  `R` of X. -/
+  of_forall_comp {X Y : C} {f : X ⟶ Y} {R : Presieve X} (hR : R ∈ K X) :
+    (∀ ⦃U : C⦄ ⦃g : U ⟶ X⦄, R g → P (g ≫ f)) → P f
 
 namespace IsLocalAtSource
 
 variable {P : MorphismProperty C} {K L : Precoverage C}
 
 lemma mk_of_iff [P.RespectsIso]
-    (H : ∀ {X Y : C} (f : X ⟶ Y) (𝒰 : Precoverage.ZeroHypercover.{v} K X),
-      P f ↔ ∀ i, P (𝒰.f i ≫ f)) :
+    (H : ∀ {X Y : C} {f : X ⟶ Y} {R : Presieve X}, R ∈ K X →
+      (P f ↔ ∀ ⦃U : C⦄ ⦃g : U ⟶ X⦄, R g → P (g ≫ f))) :
     P.IsLocalAtSource K where
-  comp 𝒰 i h := (H _ 𝒰).mp h i
-  of_zeroHypercover 𝒰 h := (H _ 𝒰).mpr h
+  comp hR _ _ hg hf := by grind
+  of_forall_comp hR h := by grind
+
+lemma mk_of_iff_of_zeroHypercover [P.RespectsIso]
+    (H : ∀ {X Y : C} (f : X ⟶ Y) (𝒰 : Precoverage.ZeroHypercover.{max u v} K X),
+        P f ↔ ∀ i, P (𝒰.f i ≫ f)) :
+    P.IsLocalAtSource K := by
+  refine .mk_of_iff fun {X Y} f R hR ↦ ?_
+  rw [Precoverage.mem_iff_exists_zeroHypercover] at hR
+  obtain ⟨𝒰, rfl⟩ := hR
+  rw [H _ 𝒰]
+  refine ⟨fun h U g ↦ ?_, fun h i ↦ h ⟨i⟩⟩
+  rintro ⟨i⟩
+  apply h
+
+lemma mk_of_small [P.RespectsIso] [Precoverage.Small.{w} K]
+    (h₁ : ∀ {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{max u v} K X),
+        P f → ∀ i, P (𝒰.f i ≫ f))
+    (h₂ : ∀ {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{w} K X),
+        (∀ i, P (𝒰.f i ≫ f)) → P f) :
+    P.IsLocalAtSource K :=
+  .mk_of_iff_of_zeroHypercover fun _ 𝒰 ↦ ⟨fun hf _ ↦ h₁ 𝒰 hf _,
+    fun h ↦ h₂ 𝒰.restrictIndexOfSmall fun _ ↦ h _⟩
 
 lemma of_le [IsLocalAtSource P L] (hle : K ≤ L) : IsLocalAtSource P K where
-  comp 𝒰 i hf := comp (𝒰.weaken hle) i hf
-  of_zeroHypercover 𝒰 h := of_zeroHypercover (𝒰.weaken hle) h
+  comp hR _ _ := comp (hle _ hR) _
+  of_forall_comp hR h := of_forall_comp (hle _ hR) h
 
 instance top : IsLocalAtSource (⊤ : MorphismProperty C) K where
   comp := by simp
-  of_zeroHypercover := by simp
+  of_forall_comp := by simp
 
-variable [IsLocalAtSource P K] {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K X)
+variable [IsLocalAtSource P K] {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{w} K X)
+
+lemma of_zeroHypercover (h : ∀ i, P (𝒰.f i ≫ f)) : P f :=
+  of_forall_comp 𝒰.mem₀ fun U g ↦ by rintro ⟨i⟩; exact h _
 
 lemma iff_of_zeroHypercover : P f ↔ ∀ i, P (𝒰.f i ≫ f) :=
-  ⟨fun hf i ↦ comp _ i hf, fun h ↦ of_zeroHypercover _ h⟩
+  ⟨fun hf i ↦ comp 𝒰.mem₀ _ ⟨i⟩ hf,
+    fun h ↦ of_forall_comp 𝒰.mem₀ fun U g ↦ by rintro ⟨i⟩; exact h _⟩
 
 instance inf (P Q : MorphismProperty C) [IsLocalAtSource P K] [IsLocalAtSource Q K] :
     IsLocalAtSource (P ⊓ Q) K where
-  comp 𝒰 i hf := ⟨comp 𝒰 i hf.1, comp 𝒰 i hf.2⟩
-  of_zeroHypercover _ h :=
-    ⟨of_zeroHypercover _ fun i ↦ (h i).1, of_zeroHypercover _ fun i ↦ (h i).2⟩
+  comp hR _ _ hg hf := ⟨comp hR _ hg hf.left, comp hR _ hg hf.right⟩
+  of_forall_comp hR h :=
+    ⟨of_forall_comp hR fun _ _ hg ↦ (h hg).1, of_forall_comp hR fun _ _ hg ↦ (h hg).2⟩
 
 end IsLocalAtSource
 
-lemma of_zeroHypercover_source {P : MorphismProperty C} {K : Precoverage C}
-    [P.IsLocalAtSource K] {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{w} K X)
-    [Precoverage.ZeroHypercover.Small.{v} 𝒰] (h : ∀ i, P (𝒰.f i ≫ f)) :
-    P f := by
-  rw [IsLocalAtSource.iff_of_zeroHypercover (P := P) 𝒰.restrictIndexOfSmall]
-  simp [h]
+alias of_zeroHypercover_source := IsLocalAtSource.of_zeroHypercover
 
 alias iff_of_zeroHypercover_source := IsLocalAtSource.iff_of_zeroHypercover
 
@@ -188,7 +224,7 @@ If for all `i`, the maps `X ×[S] Uᵢ ⟶ Y ×[S] Uᵢ` are equal, then
 `f` and `g` are equal. -/
 lemma eq_of_zeroHypercover_target [HasEqualizers C] [HasPullbacks C] {X Y S : C} {f g : X ⟶ Y}
     {s : X ⟶ S} {t : Y ⟶ S} (hf : f ≫ t = s) (hg : g ≫ t = s) {J : Precoverage C}
-    (𝒰 : Precoverage.ZeroHypercover.{v} J S) [J.IsStableUnderBaseChange]
+    (𝒰 : Precoverage.ZeroHypercover.{w} J S) [J.IsStableUnderBaseChange]
     [(MorphismProperty.isomorphisms C).IsLocalAtTarget J]
     (H : ∀ i,
       pullback.map s (𝒰.f i) t (𝒰.f i) f (𝟙 (𝒰.X i)) (𝟙 S) (by simp [hf]) (by simp) =


### PR DESCRIPTION
This changes the definition slightly: The condition is now required for covers indexed in `Type max u v`, while before this PR it was only required for index types in `Type v`.

Requested in review of #32046.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
