### PR TITLE
experiment: have `LinearMap` extend `DistribMulActionHom`

### DIFF
--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -374,7 +374,7 @@ The `R`-linear equivalence between additive morphisms `A →+ B` and `ℕ`-linea
 def addMonoidHomLequivNat {A B : Type*} (R : Type*) [Semiring R] [AddCommMonoid A]
     [AddCommMonoid B] [Module R B] : (A →+ B) ≃ₗ[R] A →ₗ[ℕ] B where
   toFun := AddMonoidHom.toNatLinearMap
-  invFun := LinearMap.toAddMonoidHom
+  invFun f := f.toAddMonoidHom
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 
@@ -385,7 +385,7 @@ The `R`-linear equivalence between additive morphisms `A →+ B` and `ℤ`-linea
 def addMonoidHomLequivInt {A B : Type*} (R : Type*) [Semiring R] [AddCommGroup A] [AddCommGroup B]
     [Module R B] : (A →+ B) ≃ₗ[R] A →ₗ[ℤ] B where
   toFun := AddMonoidHom.toIntLinearMap
-  invFun := LinearMap.toAddMonoidHom
+  invFun f := f.toAddMonoidHom
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 

--- a/Mathlib/Algebra/Module/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Module/Equiv/Defs.lean
@@ -138,15 +138,12 @@ variable [RingHomInvPair σ σ'] [RingHomInvPair σ' σ]
 instance : Coe (M ≃ₛₗ[σ] M₂) (M →ₛₗ[σ] M₂) :=
   ⟨toLinearMap⟩
 
--- This exists for compatibility, previously `≃ₗ[R]` extended `≃` instead of `≃+`.
-/-- The equivalence of types underlying a linear equivalence. -/
-def toEquiv (e : M ≃ₛₗ[σ] M₂) : M ≃ M₂ := e.toAddEquiv.toEquiv
-
 theorem toEquiv_injective :
-    (toEquiv (modM := modM) (modM₂ := modM₂) : (M ≃ₛₗ[σ] M₂) → M ≃ M₂).Injective :=
-  fun ⟨⟨⟨_, _⟩, _⟩, _, _, _⟩ ⟨⟨⟨_, _⟩, _⟩, _, _, _⟩ h ↦
-    (LinearEquiv.mk.injEq _ _ _ _ _ _ _ _).mpr
-      ⟨LinearMap.ext (congr_fun (Equiv.mk.inj h).1), (Equiv.mk.inj h).2⟩
+    (fun f : (M ≃ₛₗ[σ] M₂) => f.toEquiv).Injective := by
+  intro f g hfg
+  cases f
+  cases g
+  simpa using hfg
 
 @[simp]
 theorem toEquiv_inj {e₁ e₂ : M ≃ₛₗ[σ] M₂} : e₁.toEquiv = e₂.toEquiv ↔ e₁ = e₂ :=
@@ -521,7 +518,7 @@ theorem symm_bijective [Module R M] [Module S M₂] [RingHomInvPair σ' σ] [Rin
 
 @[simp]
 theorem mk_coe' (f h₁ h₂ h₃ h₄) :
-    (LinearEquiv.mk ⟨⟨f, h₁⟩, h₂⟩ (⇑e) h₃ h₄ : M₂ ≃ₛₗ[σ'] M) = e.symm :=
+    (LinearEquiv.mk (LinearMap.mk f h₁ h₂) (⇑e) h₃ h₄ : M₂ ≃ₛₗ[σ'] M) = e.symm :=
   symm_bijective.injective <| ext fun _ ↦ rfl
 
 @[simp]
@@ -534,8 +531,8 @@ theorem symm_mk (toLinearMap invFun h₁ h₂) : dsimp%
 
 /-- For a more powerful version, see `coe_symm_mk'`. -/
 theorem coe_symm_mk [Module R M] [Module R M₂]
-    {to_fun inv_fun map_add map_smul left_inv right_inv} :
-    ⇑(⟨⟨⟨to_fun, map_add⟩, map_smul⟩, inv_fun, left_inv, right_inv⟩ : M ≃ₗ[R] M₂).symm = inv_fun :=
+    {f g h₁ h₂ h₃ h₄} :
+    ⇑(LinearEquiv.mk (LinearMap.mk f h₁ h₂) g h₃ h₄ : M ≃ₗ[R] M₂).symm = g :=
   rfl
 
 @[simp]

--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -84,13 +84,10 @@ is semilinear if it satisfies the two properties `f (x + y) = f x + f y` and
 maps is available with the predicate `IsLinearMap`, but it should be avoided most of the time. -/
 structure LinearMap {R S : Type*} [Semiring R] [Semiring S] (σ : R →+* S) (M : Type*)
     (M₂ : Type*) [AddCommMonoid M] [AddCommMonoid M₂] [Module R M] [Module S M₂] extends
-    AddHom M M₂, MulActionHom σ M M₂
-
-/-- The `MulActionHom` underlying a `LinearMap`. -/
-add_decl_doc LinearMap.toMulActionHom
-
-/-- The `AddHom` underlying a `LinearMap`. -/
-add_decl_doc LinearMap.toAddHom
+    MulActionHom σ M M₂, DistribMulActionHom σ.toMonoidHom M M₂ where
+  map_zero' := calc
+    toFun 0 = toFun ((0 : R) • 0) := by rw [zero_smul]
+    _ = 0 := by rw [map_smul']; simp
 
 /-- `M →ₛₗ[σ] N` is the type of `σ`-semilinear maps from `M` to `N`. -/
 notation:25 M " →ₛₗ[" σ:25 "] " M₂:0 => LinearMap σ M M₂
@@ -205,16 +202,12 @@ instance instFunLike : FunLike (M →ₛₗ[σ] M₃) M M₃ where
 
 instance semilinearMapClass : SemilinearMapClass (M →ₛₗ[σ] M₃) σ M M₃ where
   map_add f := f.map_add'
-  map_smulₛₗ := LinearMap.map_smul'
+  map_smulₛₗ f := f.map_smul'
 
 @[simp, norm_cast]
 lemma coe_coe {F : Type*} [FunLike F M M₃] [SemilinearMapClass F σ M M₃] {f : F} :
     ⇑(f : M →ₛₗ[σ] M₃) = f :=
   rfl
-
-/-- The `DistribMulActionHom` underlying a `LinearMap`. -/
-def toDistribMulActionHom (f : M →ₛₗ[σ] M₃) : DistribMulActionHom σ.toMonoidHom M M₃ :=
-  { f with map_zero' := show f 0 = 0 from map_zero f }
 
 @[simp]
 theorem coe_toAddHom (f : M →ₛₗ[σ] M₃) : ⇑f.toAddHom = f := rfl
@@ -243,13 +236,8 @@ theorem copy_eq (f : M →ₛₗ[σ] M₃) (f' : M → M₃) (h : f' = ⇑f) : f
 initialize_simps_projections LinearMap (toFun → apply)
 
 @[simp]
-theorem coe_mk {σ : R →+* S} (f : AddHom M M₃) (h) :
-    ((LinearMap.mk f h : M →ₛₗ[σ] M₃) : M → M₃) = f :=
-  rfl
-
-@[simp]
-theorem coe_addHom_mk {σ : R →+* S} (f : AddHom M M₃) (h) :
-    ((LinearMap.mk f h : M →ₛₗ[σ] M₃) : AddHom M M₃) = f :=
+theorem coe_mk {σ : R →+* S} (f : M →ₑ[⇑σ] M₃) (h0) (ha) :
+    ((LinearMap.mk f h0 ha : M →ₛₗ[σ] M₃) : M → M₃) = f :=
   rfl
 
 theorem coe_semilinearMap {F : Type*} [FunLike F M M₃] [SemilinearMapClass F σ M M₃] (f : F) :
@@ -314,8 +302,8 @@ protected theorem congr_arg {x x' : M} : x = x' → f x = f x' :=
 protected theorem congr_fun (h : f = g) (x : M) : f x = g x :=
   DFunLike.congr_fun h x
 
-@[simp] lemma mk_coe (f : M →ₛₗ[σ] M₃) (h) : (mk f h : M →ₛₗ[σ] M₃) = f := rfl
-@[simp] lemma mk_coe' (f : M →ₛₗ[σ] M₃) (h) : (mk f.toAddHom h : M →ₛₗ[σ] M₃) = f := rfl
+@[simp] lemma mk_coe (f : M →ₛₗ[σ] M₃) :
+    (mk f.toMulActionHom f.map_zero' f.map_add' : M →ₛₗ[σ] M₃) = f := rfl
 
 variable (fₗ f g)
 
@@ -399,14 +387,6 @@ theorem isLinearMap_of_compatibleSMul [Module S M] [Module S M₂] [CompatibleSM
   map_add := map_add f
   map_smul := map_smul_of_tower f
 
-/-- Convert a linear map to an additive monoid hom. -/
--- See note [implicit instance arguments]
-def toAddMonoidHom {modM₁ : Module R M₁} {modM₂ : Module S M₂} {σ : R →+* S} (f : M₁ →ₛₗ[σ] M₂) :
-    M₁ →+ M₂ where
-  toFun := f
-  map_zero' := f.map_zero
-  map_add' := f.map_add
-
 omit [Module R M₂] in
 @[simp]
 lemma toAddMonoidHom_coe {modM₁ : Module R M₁} {modM₂ : Module S M₂} {σ : R →+* S}
@@ -456,7 +436,7 @@ lemma restrictScalars_id [CompatibleSMul M M R S] :
 end RestrictScalars
 
 theorem toAddMonoidHom_injective :
-    Function.Injective (toAddMonoidHom : (M →ₛₗ[σ] M₃) → M →+ M₃) := fun fₗ gₗ h ↦
+    Function.Injective (fun f : (M →ₛₗ[σ] M₃) => f.toAddMonoidHom) := fun fₗ gₗ h ↦
   ext <| (DFunLike.congr_fun h : ∀ x, fₗ.toAddMonoidHom x = gₗ.toAddMonoidHom x)
 
 /-- If two `σ`-linear maps from `R` are equal on `1`, then they are equal. -/
@@ -486,9 +466,9 @@ variable {σ₁₂ : R₁ →+* R₂} {σ₂₃ : R₂ →+* R₃} {σ₁₃ : R
 def comp [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃] (f : M₂ →ₛₗ[σ₂₃] M₃) (g : M₁ →ₛₗ[σ₁₂] M₂) :
     M₁ →ₛₗ[σ₁₃] M₃ where
   toFun x := f (g x)
-  map_add' := by simp only [map_add, forall_const]
+  map_add' := by simp
   -- Note that https://github.com/leanprover-community/mathlib4/pull/8386 changed `map_smulₛₗ` to `map_smulₛₗ _`
-  map_smul' r x := by simp only [map_smulₛₗ _, RingHomCompTriple.comp_apply]
+  map_smul' := by simp
 
 variable [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
 variable (f : M₂ →ₛₗ[σ₂₃] M₃) (g : M₁ →ₛₗ[σ₁₂] M₂)
@@ -559,14 +539,10 @@ variable [Module R M] [Module S M₂] {σ : R →+* S} {σ' : S →+* R} [RingHo
 
 /-- If a function `g` is a left and right inverse of a linear map `f`, then `g` is linear itself. -/
 def inverse (f : M →ₛₗ[σ] M₂) (g : M₂ → M) (h₁ : LeftInverse g f) (h₂ : RightInverse g f) :
-    M₂ →ₛₗ[σ'] M := by
-  dsimp [LeftInverse, Function.RightInverse] at h₁ h₂
-  exact
-    { toFun := g
-      map_add' := fun x y ↦ by rw [← h₁ (g (x + y)), ← h₁ (g x + g y)]; simp [h₂]
-      map_smul' := fun a b ↦ by
-        rw [← h₁ (g (a • b)), ← h₁ (σ' a • g b)]
-        simp [h₂] }
+    M₂ →ₛₗ[σ'] M where
+  toFun := g
+  map_add' x y := by rw [← h₁.eq (g (x + y)), ← h₁.eq (g x + g y)]; simp [h₂.eq]
+  map_smul' a b := by rw [← h₁.eq (g (a • b)), ← h₁.eq (σ' a • g b)]; simp [h₂.eq]
 
 variable (f : M →ₛₗ[σ] M₂) (g : M₂ →ₛₗ[σ'] M) (h : g.comp f = .id)
 
@@ -905,9 +881,9 @@ def evalAddMonoidHom (a : M) : (M →ₛₗ[σ₁₂] M₂) →+ M₂ where
 /-- `LinearMap.toAddMonoidHom` promoted to an `AddMonoidHom`. -/
 @[simps]
 def toAddMonoidHom' : (M →ₛₗ[σ₁₂] M₂) →+ M →+ M₂ where
-  toFun := toAddMonoidHom
+  toFun f := f.toAddMonoidHom
   map_zero' := by ext; rfl
-  map_add' := by intros; ext; rfl
+  map_add' _ _ := by ext; rfl
 
 /-- If `M` is the zero module, then the identity map of `M` is the zero map. -/
 @[simp]

--- a/Mathlib/Algebra/Module/Submodule/Equiv.lean
+++ b/Mathlib/Algebra/Module/Submodule/Equiv.lean
@@ -282,12 +282,20 @@ noncomputable def codRestrict₂ :
     M₁ →ₗ[R] M₂ →ₗ[R] M₃ :=
   let e : LinearMap.range i ≃ₗ[R] M₃ := (LinearEquiv.ofInjective i hi).symm
   { toFun := fun x ↦ e.comp <| (f x).codRestrict (p := LinearMap.range i) (hf x)
-    map_add' := by intro x₁ x₂; ext y; simp [f.map_add, ← e.map_add, codRestrict]
-    map_smul' := by intro t x; ext y; simp [f.map_smul, ← e.map_smul, codRestrict] }
+    map_add' x₁ x₂ := by
+      ext y
+      simp only [← map_add, comp_apply, LinearEquiv.coe_coe, add_apply, e.injective.eq_iff]
+      ext
+      simp
+    map_smul' t x := by
+      ext y
+      simp only [← map_smul, comp_apply, LinearEquiv.coe_coe, smul_apply, e.injective.eq_iff]
+      ext
+      simp }
 
 @[simp]
 lemma codRestrict₂_apply (x : M₁) (y : M₂) :
-    i (codRestrict₂ f i hi hf x y) = f x y := by
-  simp [codRestrict₂]
+    i (codRestrict₂ f i hi hf x y) = f x y :=
+  LinearEquiv.ofInjective_symm_apply i (h := hi) ⟨f x y, hf x y⟩
 
 end LinearMap

--- a/Mathlib/Data/Complex/BigOperators.lean
+++ b/Mathlib/Data/Complex/BigOperators.lean
@@ -46,7 +46,7 @@ theorem re_sum (f : α → ℂ) : (∑ i ∈ s, f i).re = ∑ i ∈ s, (f i).re 
 
 @[simp]
 lemma re_expect (f : α → ℂ) : (𝔼 i ∈ s, f i).re = 𝔼 i ∈ s, (f i).re :=
-  map_expect (LinearMap.mk reAddGroupHom.toAddHom (by simp)) f s
+  map_expect { reAddGroupHom with map_smul' := by simp : ℂ →ₗ[ℚ≥0] ℝ} f s
 
 @[simp]
 lemma re_balance [Fintype α] (f : α → ℂ) (a : α) : re (balance f a) = balance (re ∘ f) a := by
@@ -61,7 +61,7 @@ theorem im_sum (f : α → ℂ) : (∑ i ∈ s, f i).im = ∑ i ∈ s, (f i).im 
 
 @[simp]
 lemma im_expect (f : α → ℂ) : (𝔼 i ∈ s, f i).im = 𝔼 i ∈ s, (f i).im :=
-  map_expect (LinearMap.mk imAddGroupHom.toAddHom (by simp)) f s
+  map_expect { imAddGroupHom with map_smul' := by simp : ℂ →ₗ[ℚ≥0] ℝ } f s
 
 @[simp]
 lemma im_balance [Fintype α] (f : α → ℂ) (a : α) : im (balance f a) = balance (im ∘ f) a := by


### PR DESCRIPTION
This lets up remove some definitions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
