### PR TITLE
feat(Data/ZMod/Basic): isUnit characterisation in prime power moduli

### DIFF
--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -848,8 +848,8 @@ lemma isUnit_iff_not_prime_dvd_val {p n : ℕ} (hp : p.Prime) (hn : 0 < n)
 /-- In `ZMod (p ^ n)` for a prime `p` and `n > 0`, an element fails to be a unit
 iff its canonical lift to `ℕ` is divisible by `p`. -/
 lemma not_isUnit_iff_prime_dvd_val {p n : ℕ} (hp : p.Prime) (hn : 0 < n)
-    (x : ZMod (p ^ n)) : ¬ IsUnit x ↔ p ∣ x.val := by
-  rw [isUnit_iff_not_prime_dvd_val hp hn, Classical.not_not]
+    (x : ZMod (p ^ n)) : ¬ IsUnit x ↔ p ∣ x.val :=
+  (isUnit_iff_not_prime_dvd_val hp hn x).not_left
 
 @[simp]
 theorem inv_coe_unit {n : ℕ} (u : (ZMod n)ˣ) : (u : ZMod n)⁻¹ = (u⁻¹ : (ZMod n)ˣ) := by

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -836,6 +836,21 @@ theorem prime_natCast_not_isUnit_pow {p d : ℕ} (hp : p.Prime) (hd : 0 < d) :
   simp [isUnit_prime_iff_not_dvd hp]
   lia
 
+/-- In `ZMod (p ^ n)` for a prime `p` and `n > 0`, an element is a unit
+iff its canonical lift to `ℕ` is not divisible by `p`. -/
+lemma isUnit_iff_not_prime_dvd_val {p n : ℕ} (hp : p.Prime) (hn : 0 < n)
+    (x : ZMod (p ^ n)) : IsUnit x ↔ ¬ p ∣ x.val := by
+  have h_ne : NeZero (p ^ n) := ⟨pow_ne_zero _ hp.pos.ne'⟩
+  conv_lhs => rw [show x = ((x.val : ℕ) : ZMod (p ^ n)) from (natCast_zmod_val x).symm]
+  rw [isUnit_iff_coprime, Nat.coprime_pow_right_iff hn,
+      Nat.coprime_comm, hp.coprime_iff_not_dvd]
+
+/-- In `ZMod (p ^ n)` for a prime `p` and `n > 0`, an element fails to be a unit
+iff its canonical lift to `ℕ` is divisible by `p`. -/
+lemma not_isUnit_iff_prime_dvd_val {p n : ℕ} (hp : p.Prime) (hn : 0 < n)
+    (x : ZMod (p ^ n)) : ¬ IsUnit x ↔ p ∣ x.val := by
+  rw [isUnit_iff_not_prime_dvd_val hp hn, Classical.not_not]
+
 @[simp]
 theorem inv_coe_unit {n : ℕ} (u : (ZMod n)ˣ) : (u : ZMod n)⁻¹ = (u⁻¹ : (ZMod n)ˣ) := by
   have := congr_arg ((↑) : ℕ → ZMod n) (val_coe_unit_coprime u)


### PR DESCRIPTION
Add two lemmas characterising units in ZMod (p^n) via divisibility of the canonical lift:

  isUnit_iff_not_prime_dvd_val: for prime p and n > 0,
    IsUnit x ↔ ¬ p ∣ x.val.

  not_isUnit_iff_prime_dvd_val: for prime p and n > 0,
    ¬ IsUnit x ↔ p ∣ x.val.

These specialise the existing isUnit_iff_coprime to prime power moduli, where the coprimality condition reduces to a simple divisibility check on the unique prime factor.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
