### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/InfiniteSum): add hasProd_ite_eq' and tprod_ite_eq'

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -168,9 +168,15 @@ lemma hasProd_singleton (m : β) (f : β → α) : HasProd (({m} : Set β).restr
 
 @[to_additive]
 theorem hasProd_ite_eq (b : β) [DecidablePred (· = b)] (a : α) (L := unconditional β) [L.LeAtTop] :
-    HasProd (fun b' ↦ if b' = b then a else 1) a L := by
-  convert! hasProd_single b (hf := fun b' hb' ↦ if_neg hb') (L := L)
-  exact (if_pos rfl).symm
+    HasProd (fun b' ↦ if b' = b then a else 1) a L :=
+  suffices HasProd (fun b' ↦ if b' = b then a else 1) (if b = b then a else 1) L by simpa
+  hasProd_single b (hf := fun b' hb' ↦ if_neg hb') (L := L)
+
+@[to_additive]
+theorem hasProd_ite_eq' (b : β) [DecidablePred (b = ·)] (a : α) (L := unconditional β) [L.LeAtTop] :
+    HasProd (fun b' ↦ if b = b' then a else 1) a L :=
+  suffices HasProd (fun b' ↦ if b = b' then a else 1) (if b = b then a else 1) L by simpa
+  hasProd_single b (hf := fun b' hb' ↦ if_neg hb'.symm) (L := L)
 
 @[to_additive]
 theorem Equiv.hasProd_iff (e : γ ≃ β) : HasProd (f ∘ e) a ↔ HasProd f a :=
@@ -506,6 +512,14 @@ theorem tprod_ite_eq (b : β) [DecidablePred (· = b)] (a : β → α)
   rw [tprod_eq_mulSingle b]
   · simp
   · intro b' hb'; simp [hb']
+
+@[to_additive (attr := simp)]
+theorem tprod_ite_eq' (b : β) [DecidablePred (b = ·)] (a : β → α)
+    (L := unconditional β) [L.LeAtTop] :
+    ∏'[L] b', (if b = b' then a b' else 1) = a b := by
+  rw [tprod_eq_mulSingle b]
+  · simp
+  · intro b' hb'; simp [hb'.symm]
 
 @[to_additive]
 theorem Finset.tprod_subtype (s : Finset β) (f : β → α) :


### PR DESCRIPTION
Adds `eq'` variants that mirror those in `Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean` and `Mathlib/Algebra/BigOperators/Finsupp/Basic.lean`.

For proof of their usefulness, these summability lemmas about indicator functions are now straight-forward:

```lean
theorem hasSum_indicator_singleton_const [CommMonoid α] [TopologicalSpace α] [TopologicalSpace β] [AddCommMonoid β]
  {x : α} {f : α → β} (L := unconditional α) [L.LeAtTop]
  : HasSum (fun y => Set.indicator {y} f x) (f x) L
:= by
  classical
  exact hasSum_ite_eq' x (f x) L

theorem summable_indicator_singleton_const [CommMonoid α] [TopologicalSpace α] [TopologicalSpace β] [AddCommMonoid β]
  {x : α} {f : α → β} (L := unconditional α) [L.LeAtTop]
  : Summable (fun y => Set.indicator {y} f x) L
:= ⟨_, hasSum_indicator_singleton_const _⟩
```

We are also depending on these proofs in [Polya-lean](https://github.com/alma-n/polya-lean).

Update: changed `convert` to `convert!`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
