### PR TITLE
[Merged by Bors] - chore: remove many `set_option linter.deprecated false`

### DIFF
--- a/Mathlib/Algebra/Group/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Finsupp.lean
@@ -86,7 +86,6 @@ noncomputable def uniqueAddEquiv (i : ι) [Subsingleton ι] : (ι →₀ M) ≃+
 @[simp↓ high] lemma uniqueAddEquiv_symm_apply_apply (i : ι) [Subsingleton ι] (m : M) (j : ι) :
     (uniqueAddEquiv i).symm m j = m := by simp [Subsingleton.elim j i]
 
-set_option linter.deprecated false in
 /-- If `M` is the trivial monoid, then the monoid of finitely supported functions `ι →₀ M` is
 is isomorphic to `M`. -/
 @[simps!, deprecated uniqueAddEquiv (since := "2026-05-06")]
@@ -173,7 +172,6 @@ lemma support_single_add_single_subset [DecidableEq ι] {f₁ f₂ : ι} {g₁ g
   refine subset_trans Finsupp.support_add <| union_subset_iff.mpr ⟨?_, ?_⟩ <;>
   exact subset_trans Finsupp.support_single_subset (by simp)
 
-set_option linter.deprecated false in
 @[deprecated uniqueAddEquiv_symm_apply (since := "2026-05-06")]
 lemma _root_.AddEquiv.finsuppUnique_symm {M : Type*} [AddZeroClass M] (d : M) :
     AddEquiv.finsuppUnique.symm d = single () d := by ext; simp [AddEquiv.finsuppUnique]

--- a/Mathlib/Algebra/MvPolynomial/Equiv.lean
+++ b/Mathlib/Algebra/MvPolynomial/Equiv.lean
@@ -123,14 +123,12 @@ polynomials over the ground ring. -/
 @[deprecated uniqueAlgEquiv (since := "2026-04-15")]
 abbrev pUnitAlgEquiv := uniqueAlgEquiv (R := R) PUnit
 
-set_option linter.deprecated false in
 @[deprecated uniqueAlgEquiv_monomial (since := "2026-04-15")]
 theorem pUnitAlgEquiv_monomial {d : PUnit →₀ ℕ} {r : R} :
     MvPolynomial.pUnitAlgEquiv R (MvPolynomial.monomial d r)
       = Polynomial.monomial (d ()) r :=
   uniqueAlgEquiv_monomial _
 
-set_option linter.deprecated false in
 @[deprecated uniqueAlgEquiv_symm_monomial (since := "2026-04-15")]
 theorem pUnitAlgEquiv_symm_monomial {d : PUnit →₀ ℕ} {r : R} :
     (MvPolynomial.pUnitAlgEquiv R).symm (Polynomial.monomial (d ()) r)
@@ -230,27 +228,23 @@ theorem eval₂_const_uniqueAlgEquiv [Unique σ] {f : MvPolynomial σ R}
       f.eval₂ φ (fun _ ↦ a) := by
   rw [← eval₂_uniqueAlgEquiv]
 
-set_option linter.deprecated false in
 @[deprecated eval₂_uniqueAlgEquiv_symm (since := "2026-04-15")]
 theorem eval₂_pUnitAlgEquiv_symm {f : Polynomial R} {φ : R →+* S} {a : Unit → S} :
     ((MvPolynomial.pUnitAlgEquiv R).symm f : MvPolynomial Unit R).eval₂ φ a =
       f.eval₂ φ (a ()) :=
   eval₂_uniqueAlgEquiv_symm
 
-set_option linter.deprecated false in
 @[deprecated eval₂_const_uniqueAlgEquiv_symm (since := "2026-04-15")]
 theorem eval₂_const_pUnitAlgEquiv_symm {f : Polynomial R} {φ : R →+* S} {a : S} :
     ((MvPolynomial.pUnitAlgEquiv R).symm f : MvPolynomial Unit R).eval₂ φ (fun _ ↦ a) =
       f.eval₂ φ a :=
   eval₂_const_uniqueAlgEquiv_symm
 
-set_option linter.deprecated false in
 @[deprecated eval₂_uniqueAlgEquiv (since := "2026-04-15")]
 theorem eval₂_pUnitAlgEquiv {f : MvPolynomial PUnit R} {φ : R →+* S} {a : PUnit → S} :
     ((MvPolynomial.pUnitAlgEquiv R) f : Polynomial R).eval₂ φ (a default) = f.eval₂ φ a :=
   eval₂_uniqueAlgEquiv
 
-set_option linter.deprecated false in
 @[deprecated eval₂_const_uniqueAlgEquiv (since := "2026-04-15")]
 theorem eval₂_const_pUnitAlgEquiv {f : MvPolynomial PUnit R} {φ : R →+* S} {a : S} :
     ((MvPolynomial.pUnitAlgEquiv R) f : Polynomial R).eval₂ φ a = f.eval₂ φ (fun _ ↦ a) :=

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
@@ -413,7 +413,6 @@ section ModularScalarTowers
 @[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
 def coe (g : SL(2, ℤ)) : GL(2, ℝ)⁺ := ((g : SL(2, ℝ)) : GL(2, ℝ)⁺)
 
-set_option linter.deprecated false in
 @[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
 lemma coe_inj (a b : SL(2, ℤ)) : coe a = coe b ↔ a = b := by
   refine ⟨fun h ↦ a.ext b fun i j ↦ ?_, congr_arg _⟩
@@ -424,22 +423,18 @@ lemma coe_inj (a b : SL(2, ℤ)) : coe a = coe b ↔ a = b := by
 @[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
 def coeHom : SL(2, ℤ) →* GL(2, ℝ)⁺ := toGLPos.comp <| map <| Int.castRingHom _
 
-set_option linter.deprecated false in
 @[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
 lemma coeHom_apply (g : SL(2, ℤ)) : coeHom g = coe g := rfl
 
-set_option linter.deprecated false in
 @[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
 theorem coe_apply_complex {g : SL(2, ℤ)} {i j : Fin 2} :
     (Units.val <| Subtype.val <| coe g) i j = (Subtype.val g i j : ℂ) :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
 theorem det_coe {g : SL(2, ℤ)} : det (Units.val <| Subtype.val <| coe g) = 1 := by
   simp only [SpecialLinearGroup.coe_GLPos_coe_GL_coe_matrix, SpecialLinearGroup.det_coe, coe]
 
-set_option linter.deprecated false in
 @[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
 lemma coe_one : coe 1 = 1 := by
   simp only [coe, map_one]
@@ -456,7 +451,6 @@ theorem SLOnGLPos_smul_apply (s : SL(2, ℤ)) (g : GL(2, ℝ)⁺) (z : ℍ) :
     (s • g) • z = ((s : GL(2, ℝ)⁺) * g) • z :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
 lemma SL_to_GL_tower : IsScalarTower SL(2, ℤ) GL(2, ℝ)⁺ ℍ where
   smul_assoc s g z := by

--- a/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
+++ b/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
@@ -132,13 +132,11 @@ theorem decompLinearIsometryEquiv_symm_contLinear (p : W × (V →L[𝕜] W)) :
   inherit_doc decompLinearIsometryEquiv]
 abbrev toConstProdContinuousLinearMap := decompLinearIsometryEquiv 𝕜 𝕜 V W
 
-set_option linter.deprecated false in
 @[deprecated fst_decompLinearIsometryEquiv (since := "2026-03-03")]
 theorem toConstProdContinuousLinearMap_fst (f : V →ᴬ[𝕜] W) :
     (toConstProdContinuousLinearMap 𝕜 V W f).fst = f 0 :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated snd_decompLinearIsometryEquiv (since := "2026-03-03")]
 theorem toConstProdContinuousLinearMap_snd (f : V →ᴬ[𝕜] W) :
     (toConstProdContinuousLinearMap 𝕜 V W f).snd = f.contLinear :=

--- a/Mathlib/Analysis/Real/Hyperreal.lean
+++ b/Mathlib/Analysis/Real/Hyperreal.lean
@@ -317,14 +317,12 @@ theorem lt_of_tendsto_zero_of_pos {f : ℕ → ℝ} (hf : Tendsto f atTop (𝓝 
     ∀ {r : ℝ}, 0 < r → ofSeq f < (r : ℝ*) := fun hr ↦
   ofSeq_lt_ofSeq.2 <| (hf.eventually <| gt_mem_nhds hr).filter_mono Nat.hyperfilter_le_atTop
 
-set_option linter.deprecated false in
 @[deprecated archimedeanClassMk_pos_of_tendsto (since := "2026-01-05")]
 theorem neg_lt_of_tendsto_zero_of_pos {f : ℕ → ℝ} (hf : Tendsto f atTop (𝓝 0)) :
     ∀ {r : ℝ}, 0 < r → (-r : ℝ*) < ofSeq f := fun hr =>
   have hg := hf.neg
   neg_lt_of_neg_lt (by rw [neg_zero] at hg; exact lt_of_tendsto_zero_of_pos hg hr)
 
-set_option linter.deprecated false in
 @[deprecated archimedeanClassMk_pos_of_tendsto (since := "2026-01-05")]
 theorem gt_of_tendsto_zero_of_neg {f : ℕ → ℝ} (hf : Tendsto f atTop (𝓝 0)) :
     ∀ {r : ℝ}, r < 0 → (r : ℝ*) < ofSeq f := fun {r} hr => by
@@ -373,7 +371,6 @@ theorem tendsto_atBot_iff {x : ℝ*} : x.Tendsto atBot ↔ x < 0 ∧ mk x < 0 wh
 def IsSt (x : ℝ*) (r : ℝ) :=
   ∀ δ : ℝ, 0 < δ → (r - δ : ℝ*) < x ∧ x < r + δ
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem isSt_iff {x r} : IsSt x r ↔ 0 ≤ mk x ∧ stdPart x = r where
   mp h := by
@@ -388,13 +385,11 @@ theorem isSt_iff {x r} : IsSt x r ↔ 0 ≤ mk x ∧ stdPart x = r where
     · apply lt_of_lt_stdPart coeRingHom h; simpa
     · apply lt_of_stdPart_lt coeRingHom h; simpa
 
-set_option linter.deprecated false in
 open scoped Classical in
 /-- Standard part function: like a "round" to ℝ instead of ℤ -/
 @[deprecated stdPart (since := "2026-01-05")]
 noncomputable def st : ℝ* → ℝ := fun x => if h : ∃ r, IsSt x r then Classical.choose h else 0
 
-set_option linter.deprecated false in
 @[deprecated "`st` is deprecated" (since := "2026-01-05")]
 theorem st_eq (x : ℝ*) : st x = stdPart x := by
   rw [st]
@@ -407,14 +402,12 @@ theorem st_eq (x : ℝ*) : st x = stdPart x := by
     by_contra! hx
     exact h _ hx rfl
 
-set_option linter.deprecated false in
 /-- A hyperreal number is infinitesimal if its standard part is 0.
 **Do not use.** Write `0 < ArchimedeanClass.mk x` instead. -/
 @[deprecated ArchimedeanClass.mk (since := "2026-01-05")]
 def Infinitesimal (x : ℝ*) :=
   IsSt x 0
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_iff {x : ℝ*} : Infinitesimal x ↔ 0 < mk x := by
   rw [Infinitesimal, isSt_iff, stdPart_eq_zero, lt_iff_le_and_ne']
@@ -425,7 +418,6 @@ theorem infinitesimal_iff {x : ℝ*} : Infinitesimal x ↔ 0 < mk x := by
 def InfinitePos (x : ℝ*) :=
   ∀ r : ℝ, ↑r < x
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_iff {x : ℝ*} : InfinitePos x ↔ 0 < x ∧ mk x < 0 := by
   refine ⟨fun h ↦ ?_, fun ⟨hx, hx'⟩ r ↦ ?_⟩
@@ -440,7 +432,6 @@ theorem infinitePos_iff {x : ℝ*} : InfinitePos x ↔ 0 < x ∧ mk x < 0 := by
 def InfiniteNeg (x : ℝ*) :=
   ∀ r : ℝ, x < r
 
-set_option linter.deprecated false in
 @[deprecated "`InfiniteNeg` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_iff {x : ℝ*} : InfiniteNeg x ↔ x < 0 ∧ mk x < 0 := by
   refine ⟨fun h ↦ ?_, fun ⟨hx, hx'⟩ r ↦ ?_⟩
@@ -449,38 +440,32 @@ theorem infiniteNeg_iff {x : ℝ*} : InfiniteNeg x ↔ x < 0 ∧ mk x < 0 := by
     simpa [abs_of_neg hx, lt_neg] using! h (-n)
   · exact lt_of_mk_lt_mk_of_nonpos (hx'.trans_le <| mk_map_nonneg_of_archimedean coeRingHom _) hx.le
 
-set_option linter.deprecated false in
 /-- A hyperreal number is infinite if it is infinite positive or infinite negative.
 **Do not use.** Write `ArchimedeanClass.mk x < 0` instead. -/
 @[deprecated ArchimedeanClass.mk (since := "2026-01-05")]
 def Infinite (x : ℝ*) :=
   InfinitePos x ∨ InfiniteNeg x
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infinite_iff {x : ℝ*} : Infinite x ↔ mk x < 0 := by
   rw [Infinite, infinitePos_iff, infiniteNeg_iff]
   aesop
 
-set_option linter.deprecated false in
 @[deprecated tendsto_iff_forall (since := "2026-01-05")]
 theorem isSt_ofSeq_iff_tendsto {f : ℕ → ℝ} {r : ℝ} :
     IsSt (ofSeq f) r ↔ Tendsto f (hyperfilter ℕ) (𝓝 r) :=
   Iff.trans (forall₂_congr fun _ _ ↦ (ofSeq_lt_ofSeq.and ofSeq_lt_ofSeq).trans eventually_and.symm)
     (nhds_basis_Ioo_pos _).tendsto_right_iff.symm
 
-set_option linter.deprecated false in
 @[deprecated tendsto_iff_forall (since := "2026-01-05")]
 theorem isSt_iff_tendsto {x : ℝ*} {r : ℝ} : IsSt x r ↔ x.Tendsto (𝓝 r) := by
   rcases ofSeq_surjective x with ⟨f, rfl⟩
   exact isSt_ofSeq_iff_tendsto
 
-set_option linter.deprecated false in
 @[deprecated stdPart_of_tendsto (since := "2026-01-05")]
 theorem isSt_of_tendsto {f : ℕ → ℝ} {r : ℝ} (hf : Tendsto f atTop (𝓝 r)) : IsSt (ofSeq f) r :=
   isSt_ofSeq_iff_tendsto.2 <| hf.mono_left Nat.hyperfilter_le_atTop
 
-set_option linter.deprecated false in
 @[deprecated "Use `stdPart_monotoneOn` and `MonotoneOn.reflect_lt`" (since := "2026-01-05")]
 protected theorem IsSt.lt {x y : ℝ*} {r s : ℝ} (hxr : IsSt x r) (hys : IsSt y s) (hrs : r < s) :
     x < y := by
@@ -489,130 +474,106 @@ protected theorem IsSt.lt {x y : ℝ*} {r s : ℝ} (hxr : IsSt x r) (hys : IsSt 
   rw [isSt_ofSeq_iff_tendsto] at hxr hys
   exact ofSeq_lt_ofSeq.2 <| hxr.eventually_lt hys hrs
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem IsSt.unique {x : ℝ*} {r s : ℝ} (hr : IsSt x r) (hs : IsSt x s) : r = s := by
   rcases ofSeq_surjective x with ⟨f, rfl⟩
   rw [isSt_ofSeq_iff_tendsto] at hr hs
   exact tendsto_nhds_unique hr hs
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem IsSt.st_eq {x : ℝ*} {r : ℝ} (hxr : IsSt x r) : st x = r := by
   have h : ∃ r, IsSt x r := ⟨r, hxr⟩
   rw [st, dif_pos h]
   exact (Classical.choose_spec h).unique hxr
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem IsSt.not_infinite {x : ℝ*} {r : ℝ} (h : IsSt x r) : ¬Infinite x := fun hi ↦
   hi.elim (fun hp ↦ lt_asymm (h 1 one_pos).2 (hp (r + 1))) fun hn ↦
     lt_asymm (h 1 one_pos).1 (hn (r - 1))
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem not_infinite_of_exists_st {x : ℝ*} : (∃ r : ℝ, IsSt x r) → ¬Infinite x := fun ⟨_r, hr⟩ =>
   hr.not_infinite
 
-set_option linter.deprecated false in
 @[deprecated stdPart_eq_zero (since := "2026-01-05")]
 theorem Infinite.st_eq {x : ℝ*} (hi : Infinite x) : st x = 0 :=
   dif_neg fun ⟨_r, hr⟩ ↦ hr.not_infinite hi
 
-set_option linter.deprecated false in
 @[deprecated stdPart_eq_sSup (since := "2026-01-05")]
 theorem isSt_sSup {x : ℝ*} (hni : ¬Infinite x) : IsSt x (sSup { y : ℝ | (y : ℝ*) < x }) := by
   rw [infinite_iff, not_lt] at hni
   rw [isSt_iff]
   exact ⟨hni, stdPart_eq_sSup coeRingHom x⟩
 
-set_option linter.deprecated false in
 @[deprecated stdPart_eq_sSup (since := "2026-01-05")]
 theorem exists_st_of_not_infinite {x : ℝ*} (hni : ¬Infinite x) : ∃ r : ℝ, IsSt x r :=
   ⟨sSup { y : ℝ | (y : ℝ*) < x }, isSt_sSup hni⟩
 
-set_option linter.deprecated false in
 @[deprecated stdPart_eq_sSup (since := "2026-01-05")]
 theorem st_eq_sSup {x : ℝ*} : st x = sSup { y : ℝ | (y : ℝ*) < x } := by
   rw [st_eq]
   exact stdPart_eq_sSup coeRingHom x
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem exists_st_iff_not_infinite {x : ℝ*} : (∃ r : ℝ, IsSt x r) ↔ ¬Infinite x :=
   ⟨not_infinite_of_exists_st, exists_st_of_not_infinite⟩
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem infinite_iff_not_exists_st {x : ℝ*} : Infinite x ↔ ¬∃ r : ℝ, IsSt x r :=
   iff_not_comm.mp exists_st_iff_not_infinite
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem IsSt.isSt_st {x : ℝ*} {r : ℝ} (hxr : IsSt x r) : IsSt x (st x) := by
   rwa [hxr.st_eq]
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem isSt_st_of_exists_st {x : ℝ*} (hx : ∃ r : ℝ, IsSt x r) : IsSt x (st x) :=
   let ⟨_r, hr⟩ := hx; hr.isSt_st
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem isSt_st' {x : ℝ*} (hx : ¬Infinite x) : IsSt x (st x) :=
   (isSt_sSup hx).isSt_st
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem isSt_st {x : ℝ*} (hx : st x ≠ 0) : IsSt x (st x) :=
   isSt_st' <| mt Infinite.st_eq hx
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem isSt_refl_real (r : ℝ) : IsSt r r := isSt_ofSeq_iff_tendsto.2 tendsto_const_nhds
 
-set_option linter.deprecated false in
 @[deprecated stdPart_coe (since := "2026-01-05")]
 theorem st_id_real (r : ℝ) : st r = r := (isSt_refl_real r).st_eq
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem eq_of_isSt_real {r s : ℝ} : IsSt r s → r = s :=
   (isSt_refl_real r).unique
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem isSt_real_iff_eq {r s : ℝ} : IsSt r s ↔ r = s :=
   ⟨eq_of_isSt_real, fun hrs => hrs ▸ isSt_refl_real r⟩
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem isSt_symm_real {r s : ℝ} : IsSt r s ↔ IsSt s r := by
   rw [isSt_real_iff_eq, isSt_real_iff_eq, eq_comm]
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem isSt_trans_real {r s t : ℝ} : IsSt r s → IsSt s t → IsSt r t := by
   rw [isSt_real_iff_eq, isSt_real_iff_eq, isSt_real_iff_eq]; exact Eq.trans
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem isSt_inj_real {r₁ r₂ s : ℝ} (h1 : IsSt r₁ s) (h2 : IsSt r₂ s) : r₁ = r₂ :=
   Eq.trans (eq_of_isSt_real h1) (eq_of_isSt_real h2).symm
 
-set_option linter.deprecated false in
 @[deprecated "`IsSt` is deprecated" (since := "2026-01-05")]
 theorem isSt_iff_abs_sub_lt_delta {x : ℝ*} {r : ℝ} : IsSt x r ↔ ∀ δ : ℝ, 0 < δ → |x - ↑r| < δ := by
   simp only [abs_sub_lt_iff, sub_lt_iff_lt_add, IsSt, and_comm, add_comm]
 
-set_option linter.deprecated false in
 @[deprecated stdPart_map (since := "2026-01-05")]
 theorem IsSt.map {x : ℝ*} {r : ℝ} (hxr : IsSt x r) {f : ℝ → ℝ} (hf : ContinuousAt f r) :
     IsSt (x.map f) (f r) := by
   rcases ofSeq_surjective x with ⟨g, rfl⟩
   exact isSt_ofSeq_iff_tendsto.2 <| hf.tendsto.comp (isSt_ofSeq_iff_tendsto.1 hxr)
 
-set_option linter.deprecated false in
 @[deprecated stdPart_map₂ (since := "2026-01-05")]
 theorem IsSt.map₂ {x y : ℝ*} {r s : ℝ} (hxr : IsSt x r) (hys : IsSt y s) {f : ℝ → ℝ → ℝ}
     (hf : ContinuousAt (Function.uncurry f) (r, s)) : IsSt (x.map₂ f y) (f r s) := by
@@ -621,165 +582,132 @@ theorem IsSt.map₂ {x y : ℝ*} {r s : ℝ} (hxr : IsSt x r) (hys : IsSt y s) {
   rw [isSt_ofSeq_iff_tendsto] at hxr hys
   exact isSt_ofSeq_iff_tendsto.2 <| hf.tendsto.comp (hxr.prodMk_nhds hys)
 
-set_option linter.deprecated false in
 @[deprecated stdPart_add (since := "2026-01-05")]
 theorem IsSt.add {x y : ℝ*} {r s : ℝ} (hxr : IsSt x r) (hys : IsSt y s) :
     IsSt (x + y) (r + s) := hxr.map₂ hys continuous_add.continuousAt
 
-set_option linter.deprecated false in
 @[deprecated stdPart_neg (since := "2026-01-05")]
 theorem IsSt.neg {x : ℝ*} {r : ℝ} (hxr : IsSt x r) : IsSt (-x) (-r) :=
   hxr.map continuous_neg.continuousAt
 
-set_option linter.deprecated false in
 @[deprecated stdPart_sub (since := "2026-01-05")]
 theorem IsSt.sub {x y : ℝ*} {r s : ℝ} (hxr : IsSt x r) (hys : IsSt y s) : IsSt (x - y) (r - s) :=
   hxr.map₂ hys continuous_sub.continuousAt
 
-set_option linter.deprecated false in
 @[deprecated stdPart_monotoneOn (since := "2026-01-05")]
 theorem IsSt.le {x y : ℝ*} {r s : ℝ} (hrx : IsSt x r) (hsy : IsSt y s) (hxy : x ≤ y) : r ≤ s :=
   not_lt.1 fun h ↦ hxy.not_gt <| hsy.lt hrx h
 
-set_option linter.deprecated false in
 @[deprecated stdPart_monotoneOn (since := "2026-01-05")]
 theorem st_le_of_le {x y : ℝ*} (hix : ¬Infinite x) (hiy : ¬Infinite y) : x ≤ y → st x ≤ st y :=
   (isSt_st' hix).le (isSt_st' hiy)
 
-set_option linter.deprecated false in
 @[deprecated stdPart_monotoneOn (since := "2026-01-05")]
 theorem lt_of_st_lt {x y : ℝ*} (hix : ¬Infinite x) (hiy : ¬Infinite y) : st x < st y → x < y :=
   (isSt_st' hix).lt (isSt_st' hiy)
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_def {x : ℝ*} : InfinitePos x ↔ ∀ r : ℝ, ↑r < x := Iff.rfl
 
-set_option linter.deprecated false in
 @[deprecated "`InfiniteNeg` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_def {x : ℝ*} : InfiniteNeg x ↔ ∀ r : ℝ, x < r := Iff.rfl
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` is deprecated" (since := "2026-01-05")]
 theorem InfinitePos.pos {x : ℝ*} (hip : InfinitePos x) : 0 < x := hip 0
 
-set_option linter.deprecated false in
 @[deprecated "`InfiniteNeg` is deprecated" (since := "2026-01-05")]
 theorem InfiniteNeg.lt_zero {x : ℝ*} : InfiniteNeg x → x < 0 := fun hin => hin 0
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem Infinite.ne_zero {x : ℝ*} (hI : Infinite x) : x ≠ 0 :=
   hI.elim (fun hip => hip.pos.ne') fun hin => hin.lt_zero.ne
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem not_infinite_zero : ¬Infinite 0 := fun hI => hI.ne_zero rfl
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem InfiniteNeg.not_infinitePos {x : ℝ*} : InfiniteNeg x → ¬InfinitePos x := fun hn hp =>
   (hn 0).not_gt (hp 0)
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem InfinitePos.not_infiniteNeg {x : ℝ*} (hp : InfinitePos x) : ¬InfiniteNeg x := fun hn ↦
   hn.not_infinitePos hp
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem InfinitePos.neg {x : ℝ*} : InfinitePos x → InfiniteNeg (-x) := fun hp r =>
   neg_lt.mp (hp (-r))
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem InfiniteNeg.neg {x : ℝ*} : InfiniteNeg x → InfinitePos (-x) := fun hp r =>
   lt_neg.mp (hp (-r))
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_neg {x : ℝ*} : InfiniteNeg (-x) ↔ InfinitePos x :=
   ⟨fun hin => neg_neg x ▸ hin.neg, InfinitePos.neg⟩
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem infinitePos_neg {x : ℝ*} : InfinitePos (-x) ↔ InfiniteNeg x :=
   ⟨fun hin => neg_neg x ▸ hin.neg, InfiniteNeg.neg⟩
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infinite_neg {x : ℝ*} : Infinite (-x) ↔ Infinite x :=
   or_comm.trans <| infiniteNeg_neg.or infinitePos_neg
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 nonrec theorem Infinitesimal.not_infinite {x : ℝ*} (h : Infinitesimal x) : ¬Infinite x :=
   h.not_infinite
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem Infinite.not_infinitesimal {x : ℝ*} (h : Infinite x) : ¬Infinitesimal x := fun h' ↦
   h'.not_infinite h
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem InfinitePos.not_infinitesimal {x : ℝ*} (h : InfinitePos x) : ¬Infinitesimal x :=
   Infinite.not_infinitesimal (Or.inl h)
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem InfiniteNeg.not_infinitesimal {x : ℝ*} (h : InfiniteNeg x) : ¬Infinitesimal x :=
   Infinite.not_infinitesimal (Or.inr h)
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_iff_infinite_and_pos {x : ℝ*} : InfinitePos x ↔ Infinite x ∧ 0 < x :=
   ⟨fun hip => ⟨Or.inl hip, hip 0⟩, fun ⟨hi, hp⟩ =>
     hi.casesOn id fun hin => False.elim (not_lt_of_gt hp (hin 0))⟩
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_iff_infinite_and_neg {x : ℝ*} : InfiniteNeg x ↔ Infinite x ∧ x < 0 :=
   ⟨fun hip => ⟨Or.inr hip, hip 0⟩, fun ⟨hi, hp⟩ =>
     hi.casesOn (fun hin => False.elim (not_lt_of_gt hp (hin 0))) fun hip => hip⟩
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_iff_infinite_of_nonneg {x : ℝ*} (hp : 0 ≤ x) : InfinitePos x ↔ Infinite x :=
   .symm <| or_iff_left fun h ↦ h.lt_zero.not_ge hp
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_iff_infinite_of_pos {x : ℝ*} (hp : 0 < x) : InfinitePos x ↔ Infinite x :=
   infinitePos_iff_infinite_of_nonneg hp.le
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_iff_infinite_of_neg {x : ℝ*} (hn : x < 0) : InfiniteNeg x ↔ Infinite x :=
   .symm <| or_iff_right fun h ↦ h.pos.not_gt hn
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_abs_iff_infinite_abs {x : ℝ*} : InfinitePos |x| ↔ Infinite |x| :=
   infinitePos_iff_infinite_of_nonneg (abs_nonneg _)
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infinite_abs_iff {x : ℝ*} : Infinite |x| ↔ Infinite x := by
   cases le_total 0 x <;> simp [*, abs_of_nonneg, abs_of_nonpos, infinite_neg]
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_abs_iff_infinite {x : ℝ*} : InfinitePos |x| ↔ Infinite x :=
   infinitePos_abs_iff_infinite_abs.trans infinite_abs_iff
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infinite_iff_abs_lt_abs {x : ℝ*} : Infinite x ↔ ∀ r : ℝ, (|r| : ℝ*) < |x| :=
   infinitePos_abs_iff_infinite.symm.trans ⟨fun hI r => coe_abs r ▸ hI |r|, fun hR r =>
     (le_abs_self _).trans_lt (hR r)⟩
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem infinitePos_add_not_infiniteNeg {x y : ℝ*} :
     InfinitePos x → ¬InfiniteNeg y → InfinitePos (x + y) := by
@@ -788,50 +716,42 @@ theorem infinitePos_add_not_infiniteNeg {x y : ℝ*} :
   convert! add_lt_add_of_lt_of_le (hip (r + -r₂)) (not_lt.mp hr₂) using 1
   simp
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem not_infiniteNeg_add_infinitePos {x y : ℝ*} :
     ¬InfiniteNeg x → InfinitePos y → InfinitePos (x + y) := fun hx hy =>
   add_comm y x ▸ infinitePos_add_not_infiniteNeg hy hx
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_add_not_infinitePos {x y : ℝ*} :
     InfiniteNeg x → ¬InfinitePos y → InfiniteNeg (x + y) := by
   rw [← infinitePos_neg, ← infinitePos_neg, ← @infiniteNeg_neg y, neg_add]
   exact infinitePos_add_not_infiniteNeg
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem not_infinitePos_add_infiniteNeg {x y : ℝ*} :
     ¬InfinitePos x → InfiniteNeg y → InfiniteNeg (x + y) := fun hx hy =>
   add_comm y x ▸ infiniteNeg_add_not_infinitePos hy hx
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem infinitePos_add_infinitePos {x y : ℝ*} :
     InfinitePos x → InfinitePos y → InfinitePos (x + y) := fun hx hy =>
   infinitePos_add_not_infiniteNeg hx hy.not_infiniteNeg
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` and `InfiniteNeg` are deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_add_infiniteNeg {x y : ℝ*} :
     InfiniteNeg x → InfiniteNeg y → InfiniteNeg (x + y) := fun hx hy =>
   infiniteNeg_add_not_infinitePos hx hy.not_infinitePos
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_add_not_infinite {x y : ℝ*} :
     InfinitePos x → ¬Infinite y → InfinitePos (x + y) := fun hx hy =>
   infinitePos_add_not_infiniteNeg hx (not_or.mp hy).2
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_add_not_infinite {x y : ℝ*} :
     InfiniteNeg x → ¬Infinite y → InfiniteNeg (x + y) := fun hx hy =>
   infiniteNeg_add_not_infinitePos hx (not_or.mp hy).1
 
-set_option linter.deprecated false in
 @[deprecated "`InfinitePos` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_of_tendsto_top {f : ℕ → ℝ} (hf : Tendsto f atTop atTop) :
     InfinitePos (ofSeq f) := by
@@ -839,7 +759,6 @@ theorem infinitePos_of_tendsto_top {f : ℕ → ℝ} (hf : Tendsto f atTop atTop
   rw [infinitePos_iff]
   exact ⟨lt_of_tendsto_atTop 0 hf, archimedeanClassMk_neg_of_tendsto_atTop hf⟩
 
-set_option linter.deprecated false in
 @[deprecated "`InfiniteNeg` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_of_tendsto_bot {f : ℕ → ℝ} (hf : Tendsto f atTop atBot) :
     InfiniteNeg (ofSeq f) := by
@@ -847,30 +766,25 @@ theorem infiniteNeg_of_tendsto_bot {f : ℕ → ℝ} (hf : Tendsto f atTop atBot
   rw [infiniteNeg_iff]
   exact ⟨lt_of_tendsto_atBot 0 hf, archimedeanClassMk_neg_of_tendsto_atBot hf⟩
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem not_infinite_neg {x : ℝ*} : ¬Infinite x → ¬Infinite (-x) := mt infinite_neg.mp
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem not_infinite_add {x y : ℝ*} (hx : ¬Infinite x) (hy : ¬Infinite y) : ¬Infinite (x + y) :=
   have ⟨r, hr⟩ := exists_st_of_not_infinite hx
   have ⟨s, hs⟩ := exists_st_of_not_infinite hy
   not_infinite_of_exists_st <| ⟨r + s, hr.add hs⟩
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem not_infinite_iff_exist_lt_gt {x : ℝ*} : ¬Infinite x ↔ ∃ r s : ℝ, (r : ℝ*) < x ∧ x < s :=
   ⟨fun hni ↦ let ⟨r, hr⟩ := exists_st_of_not_infinite hni; ⟨r - 1, r + 1, hr 1 one_pos⟩,
     fun ⟨r, s, hr, hs⟩ hi ↦ hi.elim (fun hp ↦ (hp s).not_gt hs) (fun hn ↦ (hn r).not_gt hr)⟩
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem not_infinite_real (r : ℝ) : ¬Infinite r := by
   rw [not_infinite_iff_exist_lt_gt]
   exact ⟨r - 1, r + 1, coe_lt_coe.2 <| sub_one_lt r, coe_lt_coe.2 <| lt_add_one r⟩
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem Infinite.ne_real {x : ℝ*} : Infinite x → ∀ r : ℝ, x ≠ r := fun hi r hr =>
   not_infinite_real r <| @Eq.subst _ Infinite _ _ hr hi
@@ -879,24 +793,20 @@ theorem Infinite.ne_real {x : ℝ*} : Infinite x → ∀ r : ℝ, x ≠ r := fun
 ### Facts about `st` that require some infinite machinery
 -/
 
-set_option linter.deprecated false in
 @[deprecated stdPart_mul (since := "2026-01-05")]
 theorem IsSt.mul {x y : ℝ*} {r s : ℝ} (hxr : IsSt x r) (hys : IsSt y s) : IsSt (x * y) (r * s) :=
   hxr.map₂ hys continuous_mul.continuousAt
 
-set_option linter.deprecated false in
 @[deprecated mk_mul (since := "2026-01-05")]
 theorem not_infinite_mul {x y : ℝ*} (hx : ¬Infinite x) (hy : ¬Infinite y) : ¬Infinite (x * y) :=
   have ⟨_r, hr⟩ := exists_st_of_not_infinite hx
   have ⟨_s, hs⟩ := exists_st_of_not_infinite hy
   (hr.mul hs).not_infinite
 
-set_option linter.deprecated false in
 @[deprecated stdPart_add (since := "2026-01-05")]
 theorem st_add {x y : ℝ*} (hx : ¬Infinite x) (hy : ¬Infinite y) : st (x + y) = st x + st y :=
   (isSt_st' (not_infinite_add hx hy)).unique ((isSt_st' hx).add (isSt_st' hy))
 
-set_option linter.deprecated false in
 @[deprecated stdPart_neg (since := "2026-01-05")]
 theorem st_neg (x : ℝ*) : st (-x) = -st x := by
   classical
@@ -904,7 +814,6 @@ theorem st_neg (x : ℝ*) : st (-x) = -st x := by
   · rw [h.st_eq, (infinite_neg.2 h).st_eq, neg_zero]
   · exact (isSt_st' (not_infinite_neg h)).unique (isSt_st' h).neg
 
-set_option linter.deprecated false in
 @[deprecated stdPart_mul (since := "2026-01-05")]
 theorem st_mul {x y : ℝ*} (hx : ¬Infinite x) (hy : ¬Infinite y) : st (x * y) = st x * st y :=
   have hx' := isSt_st' hx
@@ -916,112 +825,91 @@ theorem st_mul {x y : ℝ*} (hx : ¬Infinite x) (hy : ¬Infinite y) : st (x * y)
 ### Basic lemmas about infinitesimal
 -/
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_def {x : ℝ*} : Infinitesimal x ↔ ∀ r : ℝ, 0 < r → -(r : ℝ*) < x ∧ x < r := by
   simp [Infinitesimal, IsSt]
 
-set_option linter.deprecated false in
 @[deprecated lt_of_pos_of_archimedean (since := "2026-01-05")]
 theorem lt_of_pos_of_infinitesimal {x : ℝ*} : Infinitesimal x → ∀ r : ℝ, 0 < r → x < r :=
   fun hi r hr => ((infinitesimal_def.mp hi) r hr).2
 
-set_option linter.deprecated false in
 @[deprecated lt_of_neg_of_archimedean (since := "2026-01-05")]
 theorem lt_neg_of_pos_of_infinitesimal {x : ℝ*} : Infinitesimal x → ∀ r : ℝ, 0 < r → -↑r < x :=
   fun hi r hr => ((infinitesimal_def.mp hi) r hr).1
 
-set_option linter.deprecated false in
 @[deprecated lt_of_neg_of_archimedean (since := "2026-01-05")]
 theorem gt_of_neg_of_infinitesimal {x : ℝ*} (hi : Infinitesimal x) (r : ℝ) (hr : r < 0) : ↑r < x :=
   neg_neg r ▸ (infinitesimal_def.1 hi (-r) (neg_pos.2 hr)).1
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem abs_lt_real_iff_infinitesimal {x : ℝ*} : Infinitesimal x ↔ ∀ r : ℝ, r ≠ 0 → |x| < |↑r| :=
   ⟨fun hi r hr ↦ abs_lt.mpr (coe_abs r ▸ infinitesimal_def.mp hi |r| (abs_pos.2 hr)), fun hR ↦
     infinitesimal_def.mpr fun r hr => abs_lt.mp <| (abs_of_pos <| coe_pos.2 hr) ▸ hR r <| hr.ne'⟩
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_zero : Infinitesimal 0 := isSt_refl_real 0
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem Infinitesimal.eq_zero {r : ℝ} : Infinitesimal r → r = 0 := eq_of_isSt_real
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_real_iff {r : ℝ} : Infinitesimal r ↔ r = 0 :=
   isSt_real_iff_eq
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 nonrec theorem Infinitesimal.add {x y : ℝ*} (hx : Infinitesimal x) (hy : Infinitesimal y) :
     Infinitesimal (x + y) := by simpa only [add_zero] using! hx.add hy
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 nonrec theorem Infinitesimal.neg {x : ℝ*} (hx : Infinitesimal x) : Infinitesimal (-x) := by
   simpa only [neg_zero] using! hx.neg
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_neg {x : ℝ*} : Infinitesimal (-x) ↔ Infinitesimal x :=
   ⟨fun h => neg_neg x ▸ h.neg, Infinitesimal.neg⟩
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 nonrec theorem Infinitesimal.mul {x y : ℝ*} (hx : Infinitesimal x) (hy : Infinitesimal y) :
     Infinitesimal (x * y) := by simpa only [mul_zero] using! hx.mul hy
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_of_tendsto_zero {f : ℕ → ℝ} (h : Tendsto f atTop (𝓝 0)) :
     Infinitesimal (ofSeq f) :=
   isSt_of_tendsto h
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_epsilon : Infinitesimal ε :=
   infinitesimal_of_tendsto_zero tendsto_inv_atTop_nhds_zero_nat
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem not_real_of_infinitesimal_ne_zero (x : ℝ*) : Infinitesimal x → x ≠ 0 → ∀ r : ℝ, x ≠ r :=
   fun hi hx r hr =>
   hx <| hr.trans <| coe_eq_zero.2 <| IsSt.unique (hr.symm ▸ isSt_refl_real r : IsSt x r) hi
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem IsSt.infinitesimal_sub {x : ℝ*} {r : ℝ} (hxr : IsSt x r) : Infinitesimal (x - ↑r) := by
   simpa only [sub_self] using! hxr.sub (isSt_refl_real r)
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_sub_st {x : ℝ*} (hx : ¬Infinite x) : Infinitesimal (x - ↑(st x)) :=
   (isSt_st' hx).infinitesimal_sub
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_iff_infinitesimal_inv_pos {x : ℝ*} :
     InfinitePos x ↔ Infinitesimal x⁻¹ ∧ 0 < x⁻¹ := by
   rw [infinitePos_iff, infinitesimal_iff]
   aesop
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_iff_infinitesimal_inv_neg {x : ℝ*} :
     InfiniteNeg x ↔ Infinitesimal x⁻¹ ∧ x⁻¹ < 0 := by
   rw [← infinitePos_neg, infinitePos_iff_infinitesimal_inv_pos, inv_neg, neg_pos, infinitesimal_neg]
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_inv_of_infinite {x : ℝ*} : Infinite x → Infinitesimal x⁻¹ := fun hi =>
   Or.casesOn hi (fun hip => (infinitePos_iff_infinitesimal_inv_pos.mp hip).1) fun hin =>
     (infiniteNeg_iff_infinitesimal_inv_neg.mp hin).1
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinite_of_infinitesimal_inv {x : ℝ*} (h0 : x ≠ 0) (hi : Infinitesimal x⁻¹) :
     Infinite x := by
@@ -1029,49 +917,40 @@ theorem infinite_of_infinitesimal_inv {x : ℝ*} (h0 : x ≠ 0) (hi : Infinitesi
   · exact Or.inr (infiniteNeg_iff_infinitesimal_inv_neg.mpr ⟨hi, inv_lt_zero.mpr hn⟩)
   · exact Or.inl (infinitePos_iff_infinitesimal_inv_pos.mpr ⟨hi, inv_pos.mpr hp⟩)
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinite_iff_infinitesimal_inv {x : ℝ*} (h0 : x ≠ 0) : Infinite x ↔ Infinitesimal x⁻¹ :=
   ⟨infinitesimal_inv_of_infinite, infinite_of_infinitesimal_inv h0⟩
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_pos_iff_infinitePos_inv {x : ℝ*} :
     InfinitePos x⁻¹ ↔ Infinitesimal x ∧ 0 < x :=
   infinitePos_iff_infinitesimal_inv_pos.trans <| by rw [inv_inv]
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_neg_iff_infiniteNeg_inv {x : ℝ*} :
     InfiniteNeg x⁻¹ ↔ Infinitesimal x ∧ x < 0 :=
   infiniteNeg_iff_infinitesimal_inv_neg.trans <| by rw [inv_inv]
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitesimal_iff_infinite_inv {x : ℝ*} (h : x ≠ 0) : Infinitesimal x ↔ Infinite x⁻¹ :=
   Iff.trans (by rw [inv_inv]) (infinite_iff_infinitesimal_inv (inv_ne_zero h)).symm
 
-set_option linter.deprecated false in
 @[deprecated stdPart_inv (since := "2026-01-05")]
 theorem IsSt.inv {x : ℝ*} {r : ℝ} (hi : ¬Infinitesimal x) (hr : IsSt x r) : IsSt x⁻¹ r⁻¹ :=
   hr.map <| continuousAt_inv₀ <| by rintro rfl; exact hi hr
 
-set_option linter.deprecated false in
 @[deprecated stdPart_inv (since := "2026-01-05")]
 theorem st_inv (x : ℝ*) : st x⁻¹ = (st x)⁻¹ := by
   simp [st_eq]
 
-set_option linter.deprecated false in
 @[deprecated archimedeanClassMk_omega_neg (since := "2026-01-05")]
 theorem infinitePos_omega : InfinitePos ω :=
   infinitePos_iff_infinitesimal_inv_pos.mpr ⟨infinitesimal_epsilon, epsilon_pos⟩
 
-set_option linter.deprecated false in
 @[deprecated archimedeanClassMk_omega_neg (since := "2026-01-05")]
 theorem infinite_omega : Infinite ω :=
   (infinite_iff_infinitesimal_inv omega_ne_zero).mpr infinitesimal_epsilon
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_mul_of_infinitePos_not_infinitesimal_pos {x y : ℝ*} :
     InfinitePos x → ¬Infinitesimal y → 0 < y → InfinitePos (x * y) := fun hx hy₁ hy₂ r => by
@@ -1082,76 +961,64 @@ theorem infinitePos_mul_of_infinitePos_not_infinitesimal_pos {x y : ℝ*} :
   rw [← div_mul_cancel₀ r (ne_of_gt hyr.1), coe_mul]
   exact mul_lt_mul (hx (r / r₁)) hyr.2 (coe_lt_coe.2 hyr.1) (le_of_lt (hx 0))
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_mul_of_not_infinitesimal_pos_infinitePos {x y : ℝ*} :
     ¬Infinitesimal x → 0 < x → InfinitePos y → InfinitePos (x * y) := fun hx hp hy =>
   mul_comm y x ▸ infinitePos_mul_of_infinitePos_not_infinitesimal_pos hy hx hp
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_mul_of_infiniteNeg_not_infinitesimal_neg {x y : ℝ*} :
     InfiniteNeg x → ¬Infinitesimal y → y < 0 → InfinitePos (x * y) := by
   rw [← infinitePos_neg, ← neg_pos, ← neg_mul_neg, ← infinitesimal_neg]
   exact infinitePos_mul_of_infinitePos_not_infinitesimal_pos
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_mul_of_not_infinitesimal_neg_infiniteNeg {x y : ℝ*} :
     ¬Infinitesimal x → x < 0 → InfiniteNeg y → InfinitePos (x * y) := fun hx hp hy =>
   mul_comm y x ▸ infinitePos_mul_of_infiniteNeg_not_infinitesimal_neg hy hx hp
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_mul_of_infinitePos_not_infinitesimal_neg {x y : ℝ*} :
     InfinitePos x → ¬Infinitesimal y → y < 0 → InfiniteNeg (x * y) := by
   rw [← infinitePos_neg, ← neg_pos, neg_mul_eq_mul_neg, ← infinitesimal_neg]
   exact infinitePos_mul_of_infinitePos_not_infinitesimal_pos
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_mul_of_not_infinitesimal_neg_infinitePos {x y : ℝ*} :
     ¬Infinitesimal x → x < 0 → InfinitePos y → InfiniteNeg (x * y) := fun hx hp hy =>
   mul_comm y x ▸ infiniteNeg_mul_of_infinitePos_not_infinitesimal_neg hy hx hp
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_mul_of_infiniteNeg_not_infinitesimal_pos {x y : ℝ*} :
     InfiniteNeg x → ¬Infinitesimal y → 0 < y → InfiniteNeg (x * y) := by
   rw [← infinitePos_neg, ← infinitePos_neg, neg_mul_eq_neg_mul]
   exact infinitePos_mul_of_infinitePos_not_infinitesimal_pos
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_mul_of_not_infinitesimal_pos_infiniteNeg {x y : ℝ*} :
     ¬Infinitesimal x → 0 < x → InfiniteNeg y → InfiniteNeg (x * y) := fun hx hp hy => by
   rw [mul_comm]; exact infiniteNeg_mul_of_infiniteNeg_not_infinitesimal_pos hy hx hp
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_mul_infinitePos {x y : ℝ*} :
     InfinitePos x → InfinitePos y → InfinitePos (x * y) := fun hx hy =>
   infinitePos_mul_of_infinitePos_not_infinitesimal_pos hx hy.not_infinitesimal (hy 0)
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_mul_infiniteNeg {x y : ℝ*} :
     InfiniteNeg x → InfiniteNeg y → InfinitePos (x * y) := fun hx hy =>
   infinitePos_mul_of_infiniteNeg_not_infinitesimal_neg hx hy.not_infinitesimal (hy 0)
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_mul_infiniteNeg {x y : ℝ*} :
     InfinitePos x → InfiniteNeg y → InfiniteNeg (x * y) := fun hx hy =>
   infiniteNeg_mul_of_infinitePos_not_infinitesimal_neg hx hy.not_infinitesimal (hy 0)
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infiniteNeg_mul_infinitePos {x y : ℝ*} :
     InfiniteNeg x → InfinitePos y → InfiniteNeg (x * y) := fun hx hy =>
   infiniteNeg_mul_of_infiniteNeg_not_infinitesimal_pos hx hy.not_infinitesimal (hy 0)
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinite_mul_of_infinite_not_infinitesimal {x y : ℝ*} :
     Infinite x → ¬Infinitesimal y → Infinite (x * y) := fun hx hy =>
@@ -1164,13 +1031,11 @@ theorem infinite_mul_of_infinite_not_infinitesimal {x y : ℝ*} :
       (fun H0 Hx => Or.inl (infinitePos_mul_of_infiniteNeg_not_infinitesimal_neg Hx hy H0))
       fun H0 Hx => Or.inr (infiniteNeg_mul_of_infiniteNeg_not_infinitesimal_pos Hx hy H0))
 
-set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinite_mul_of_not_infinitesimal_infinite {x y : ℝ*} :
     ¬Infinitesimal x → Infinite y → Infinite (x * y) := fun hx hy => by
   rw [mul_comm]; exact infinite_mul_of_infinite_not_infinitesimal hy hx
 
-set_option linter.deprecated false in
 @[deprecated "`Infinite` is deprecated" (since := "2026-01-05")]
 theorem Infinite.mul {x y : ℝ*} : Infinite x → Infinite y → Infinite (x * y) := fun hx hy =>
   infinite_mul_of_infinite_not_infinitesimal hx hy.not_infinitesimal

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -89,7 +89,6 @@ def leftAdjointsCoyonedaEquiv {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) (a
     NatIso.ofComponents fun Y =>
       ((adj1.homEquiv X.unop Y).trans (adj2.homEquiv X.unop Y).symm).toIso
 
-set_option linter.deprecated false in
 /-- Deprecated: prefer `(Adjunction.conjugateIsoEquiv adj1 adj2).symm`. -/
 @[deprecated "Use `(Adjunction.conjugateIsoEquiv adj1 adj2).symm` \
   (requires `import Mathlib.CategoryTheory.Adjunction.Mates`)." (since := "2026-01-31")]
@@ -98,7 +97,6 @@ def natIsoOfRightAdjointNatIso {F F' : C ⥤ D} {G G' : D ⥤ C}
   NatIso.removeOp ((Coyoneda.fullyFaithful.whiskeringRight _).isoEquiv.symm
     (leftAdjointsCoyonedaEquiv adj2 (adj1.ofNatIsoRight r)))
 
-set_option linter.deprecated false in
 /-- Deprecated: prefer `Adjunction.conjugateIsoEquiv adj1 adj2`. -/
 @[deprecated "Use `Adjunction.conjugateIsoEquiv adj1 adj2` \
   (requires `import Mathlib.CategoryTheory.Adjunction.Mates`)." (since := "2026-01-31")]

--- a/Mathlib/CategoryTheory/Monoidal/OfHasFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Monoidal/OfHasFiniteProducts.lean
@@ -181,7 +181,6 @@ variable [PreservesLimit (Functor.empty.{0} C) F]
   [PreservesLimitsOfShape (Discrete WalkingPair) F]
 
 set_option backward.defeqAttrib.useBackward true in
-set_option linter.deprecated false in
 @[deprecated inferInstance (since := "2025-10-19")]
 instance :
     have : HasFiniteProducts C := hasFiniteProducts_of_has_binary_and_terminal
@@ -191,7 +190,6 @@ instance :
     IsIso (η F) := by dsimp [η_eq]; apply instIsIsoTerminalComparison
 
 set_option backward.defeqAttrib.useBackward true in
-set_option linter.deprecated false in
 @[deprecated inferInstance (since := "2025-10-19")]
 instance (X Y : C) :
     have : HasFiniteProducts C := hasFiniteProducts_of_has_binary_and_terminal

--- a/Mathlib/Computability/Primrec/Basic.lean
+++ b/Mathlib/Computability/Primrec/Basic.lean
@@ -573,7 +573,6 @@ theorem option_getD : Primrec₂ (@Option.getD α) :=
 theorem option_getD_default [Inhabited α] : Primrec (fun o : Option α => o.getD default) :=
   option_getD.comp .id (const default)
 
-set_option linter.deprecated false in
 @[deprecated option_getD_default (since := "2026-01-05")]
 theorem option_iget [Inhabited α] : Primrec (@Option.iget α _) :=
   option_getD_default

--- a/Mathlib/Data/Nat/Bits.lean
+++ b/Mathlib/Data/Nat/Bits.lean
@@ -178,7 +178,6 @@ lemma testBit_bit_succ (m b n) : testBit (bit b n) (succ m) = testBit n m := by
 
 /-! ### `boddDiv2_eq` and `bodd` -/
 
-set_option linter.deprecated false in
 @[deprecated "`Nat.boddDiv2` has been deprecated" (since := "2026-03-22")]
 theorem boddDiv2_eq (n : ℕ) : boddDiv2 n = (bodd n, div2 n) := by
   induction n with

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -150,17 +150,14 @@ end pmap
 theorem seq_some {α β} {a : α} {f : α → β} : some f <*> some a = some (f a) :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "Use `Option.get` with proof of `isSome`." (since := "2026-01-05")]
 theorem iget_mem [Inhabited α] : ∀ {o : Option α}, isSome o → o.iget ∈ o
   | some _, _ => rfl
 
-set_option linter.deprecated false in
 @[deprecated "Use `Option.getD`." (since := "2026-01-05")]
 theorem iget_of_mem [Inhabited α] {a : α} : ∀ {o : Option α}, a ∈ o → o.iget = a
   | _, rfl => rfl
 
-set_option linter.deprecated false in
 @[deprecated "Use `Option.getD` directly." (since := "2026-01-05")]
 theorem getD_default_eq_iget [Inhabited α] (o : Option α) :
     o.getD default = o.iget := by cases o <;> rfl

--- a/Mathlib/Data/Option/Defs.lean
+++ b/Mathlib/Data/Option/Defs.lean
@@ -52,7 +52,6 @@ abbrev iget [Inhabited α] : Option α → α
   | some x => x
   | none => default
 
-set_option linter.deprecated false in
 @[deprecated "Use `Option.getD`." (since := "2026-01-05")]
 theorem iget_some [Inhabited α] {a : α} : (some a).iget = a :=
   rfl

--- a/Mathlib/Data/String/Basic.lean
+++ b/Mathlib/Data/String/Basic.lean
@@ -133,7 +133,6 @@ instance decidableLE : DecidableLE String := by
 theorem le_iff_toList_le {s₁ s₂ : String} : s₁ ≤ s₂ ↔ s₁.toList ≤ s₂.toList :=
   (not_congr lt_iff_toList_lt).trans not_lt
 
-set_option linter.deprecated false in
 @[deprecated "Use the new String API" (since := "2026-04-01")]
 theorem toList_nonempty :
     ∀ {s : String}, s ≠ "" → s.toList = String.Legacy.front s :: (String.Legacy.drop s 1).toList

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -539,7 +539,6 @@ theorem mem_diagSet_iff_isDiag (z : Sym2 α) : z ∈ diagSet ↔ z.IsDiag := .rf
 
 theorem diagSet_eq_setOf_isDiag : diagSet = {z : Sym2 α | z.IsDiag} := rfl
 
-set_option linter.deprecated false in
 @[deprecated Set.compl_setOf (since := "2025-12-10")]
 theorem diagSet_compl_eq_setOf_not_isDiag : diagSetᶜ = {z : Sym2 α | ¬z.IsDiag} :=
   congrArg _ diagSet_eq_setOf_isDiag

--- a/Mathlib/Geometry/Convex/Cone/Basic.lean
+++ b/Mathlib/Geometry/Convex/Cone/Basic.lean
@@ -417,7 +417,6 @@ See `IsReproducing.isGenerating` and `IsGenerating.isReproducing` for details. -
 def IsGenerating (C : ConvexCone R M) : Prop :=
   Submodule.span R (C : Set M) = ⊤
 
-set_option linter.deprecated false in
 /-- A sufficient criteria for a convex cone `C` to be generating is that top is less than or equal
 to the linear span of `C`. -/
 @[deprecated "no replacement" (since := "2026-03-30")]
@@ -425,40 +424,34 @@ theorem IsGenerating.of_top_le_span {C : ConvexCone R M} (h : ⊤ ≤ Submodule.
     C.IsGenerating :=
   eq_top_iff.mpr h
 
-set_option linter.deprecated false in
 /-- The linear span of a generating convex cone equals top. -/
 @[deprecated "no replacement" (since := "2026-03-30")]
 lemma IsGenerating.span_eq_top {C : ConvexCone R M} (hC : C.IsGenerating) :
     Submodule.span R (C : Set M) = ⊤ :=
   hC
 
-set_option linter.deprecated false in
 /-- Top is less than or equal to the linear span of a generating convex cone. -/
 @[deprecated "no replacement" (since := "2026-03-30")]
 lemma IsGenerating.top_le_span {C : ConvexCone R M} (hC : C.IsGenerating) :
     ⊤ ≤ Submodule.span R (C : Set M) :=
   hC.span_eq_top.ge
 
-set_option linter.deprecated false in
 /-- The whole `R`-module `M` (viewed as the top convex cone) is generating. -/
 @[deprecated "no replacement" (since := "2026-03-30")]
 theorem isGenerating_top : (⊤ : ConvexCone R M).IsGenerating := by
   simp
 
-set_option linter.deprecated false in
 /-- The empty convex cone is generating iff the module is a subsingleton. -/
 @[deprecated "no replacement" (since := "2026-03-30")]
 theorem isGenerating_bot_iff : (⊥ : ConvexCone R M).IsGenerating ↔ Subsingleton M := by
   simpa only [IsGenerating, coe_bot, Submodule.span_empty, ← Submodule.subsingleton_iff R] using
     subsingleton_iff_bot_eq_top
 
-set_option linter.deprecated false in
 /-- In a subsingleton module, the empty convex cone is generating. -/
 @[deprecated "no replacement" (since := "2026-03-30")]
 theorem isGenerating_bot [Subsingleton M] : (⊥ : ConvexCone R M).IsGenerating :=
   isGenerating_bot_iff.mpr inferInstance
 
-set_option linter.deprecated false in
 /-- A convex cone containing a generating cone is also a generating cone. -/
 @[gcongr, deprecated "no replacement" (since := "2026-03-30")]
 theorem IsGenerating.mono {C₁ C₂ : ConvexCone R M} (h : C₁ ≤ C₂) (hgen : C₁.IsGenerating) :
@@ -702,12 +695,10 @@ def toCone (s : Set M) (hs : Convex 𝕜 s) : ConvexCone 𝕜 M := by
 
 variable {s : Set M} (hs : Convex 𝕜 s) {x : M}
 
-set_option linter.deprecated false in
 @[deprecated ConvexCone.mem_hull_of_convex (since := "2026-03-30")]
 theorem mem_toCone : x ∈ hs.toCone s ↔ ∃ c : 𝕜, 0 < c ∧ ∃ y ∈ s, c • y = x := by
   simp only [toCone, ConvexCone.mem_mk, mem_iUnion, mem_smul_set, eq_comm, exists_prop]
 
-set_option linter.deprecated false in
 @[deprecated ConvexCone.mem_hull_of_convex (since := "2026-03-30")]
 theorem mem_toCone' : x ∈ hs.toCone s ↔ ∃ c : 𝕜, 0 < c ∧ c • x ∈ s := by
   refine hs.mem_toCone.trans ⟨?_, ?_⟩
@@ -716,12 +707,10 @@ theorem mem_toCone' : x ∈ hs.toCone s ↔ ∃ c : 𝕜, 0 < c ∧ c • x ∈ 
   · rintro ⟨c, hc, hcx⟩
     exact ⟨c⁻¹, inv_pos.2 hc, _, hcx, by rw [smul_smul, inv_mul_cancel₀ hc.ne', one_smul]⟩
 
-set_option linter.deprecated false in
 @[deprecated ConvexCone.subset_hull (since := "2026-03-30")]
 theorem subset_toCone : s ⊆ hs.toCone s := fun x hx =>
   hs.mem_toCone'.2 ⟨1, zero_lt_one, by rwa [one_smul]⟩
 
-set_option linter.deprecated false in
 /-- `hs.toCone s` is the least cone that includes `s`. -/
 @[deprecated "`ConvexCone.gi.gc.isLeast_l`" (since := "2026-03-30")]
 theorem toCone_isLeast : IsLeast { t : ConvexCone 𝕜 M | s ⊆ t } (hs.toCone s) := by
@@ -729,14 +718,12 @@ theorem toCone_isLeast : IsLeast { t : ConvexCone 𝕜 M | s ⊆ t } (hs.toCone 
   rcases hs.mem_toCone.1 hx with ⟨c, hc, y, hy, rfl⟩
   exact t.smul_mem hc (ht hy)
 
-set_option linter.deprecated false in
 @[deprecated "`ConvexCone.gi.gc.isLUB_u.sSup_eq`" (since := "2026-03-30")]
 theorem toCone_eq_sInf : hs.toCone s = sInf { t : ConvexCone 𝕜 M | s ⊆ t } :=
   hs.toCone_isLeast.isGLB.sInf_eq.symm
 
 end Convex
 
-set_option linter.deprecated false in
 @[deprecated "no replacement" (since := "2026-03-30")]
 theorem convexHull_toCone_isLeast (s : Set M) :
     IsLeast { t : ConvexCone 𝕜 M | s ⊆ t } ((convex_convexHull 𝕜 s).toCone _) := by
@@ -744,7 +731,6 @@ theorem convexHull_toCone_isLeast (s : Set M) :
   ext t
   exact ⟨fun h => convexHull_min h t.convex, (subset_convexHull 𝕜 s).trans⟩
 
-set_option linter.deprecated false in
 @[deprecated "no replacement" (since := "2026-03-30")]
 theorem convexHull_toCone_eq_sInf (s : Set M) :
     (convex_convexHull 𝕜 s).toCone _ = sInf { t : ConvexCone 𝕜 M | s ⊆ t } :=

--- a/Mathlib/GroupTheory/Coxeter/Length.lean
+++ b/Mathlib/GroupTheory/Coxeter/Length.lean
@@ -136,7 +136,6 @@ theorem length_mul_ge_length_sub_length (w₁ w₂ : W) : ℓ w₁ - ℓ w₂ �
 theorem length_mul_ge_length_sub_length' (w₁ w₂ : W) : ℓ w₂ - ℓ w₁ ≤ ℓ (w₁ * w₂) := by
   rw [Nat.sub_le_iff_le_add]; exact length_le_length_mul_add_left ..
 
-set_option linter.deprecated false in
 @[deprecated "use `length_le_length_mul_add_left` and `length_le_length_mul_add_right"
 (since := "2026-03-25")]
 theorem length_mul_ge_max (w₁ w₂ : W) : max (ℓ w₁ - ℓ w₂) (ℓ w₂ - ℓ w₁) ≤ ℓ (w₁ * w₂) :=

--- a/Mathlib/Lean/MessageData/Trace.lean
+++ b/Mathlib/Lean/MessageData/Trace.lean
@@ -41,7 +41,6 @@ def traceResultOf (headerStr : String) : Option TraceResult :=
   else if headerStr.startsWith "💥️" then some .error
   else none
 
-set_option linter.deprecated false in
 /-- Strip the leading status emoji and space from a trace header string,
 leaving just the semantic content for comparison across trace runs.
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -608,17 +608,14 @@ variable (k)
 def affineCombinationSingleWeights [DecidableEq ι] (i : ι) : ι → k :=
   Pi.single i 1
 
-set_option linter.deprecated false in
 @[deprecated Pi.single_eq_same (since := "2026-04-16")]
 theorem affineCombinationSingleWeights_apply_self [DecidableEq ι] (i : ι) :
     affineCombinationSingleWeights k i i = 1 := Pi.single_eq_same _ _
 
-set_option linter.deprecated false in
 @[deprecated Pi.single_eq_of_ne (since := "2026-04-16")]
 theorem affineCombinationSingleWeights_apply_of_ne [DecidableEq ι] {i j : ι} (h : j ≠ i) :
     affineCombinationSingleWeights k i j = 0 := Pi.single_eq_of_ne h _
 
-set_option linter.deprecated false in
 @[deprecated Finset.sum_pi_single' (since := "2026-04-16")]
 theorem sum_affineCombinationSingleWeights [DecidableEq ι] {i : ι} (h : i ∈ s) :
     ∑ j ∈ s, affineCombinationSingleWeights k i j = 1 := by
@@ -692,7 +689,6 @@ theorem affineCombination_piSingle [DecidableEq ι] (p : ι → P) {i : ι}
   rintro j - hj
   simp [hj]
 
-set_option linter.deprecated false in
 /-- An affine combination with `affineCombinationSingleWeights` gives the specified point. -/
 @[deprecated affineCombination_piSingle (since := "2026-04-16")]
 theorem affineCombination_affineCombinationSingleWeights [DecidableEq ι] (p : ι → P) {i : ι}

--- a/Mathlib/LinearAlgebra/Dual/Defs.lean
+++ b/Mathlib/LinearAlgebra/Dual/Defs.lean
@@ -66,7 +66,6 @@ def dualPairing (R M) [CommSemiring R] [AddCommMonoid M] [Module R M] :
     Module.Dual R M →ₗ[R] M →ₗ[R] R :=
   LinearMap.id
 
-set_option linter.deprecated false in
 @[deprecated "`Module.dualPairing` has been deprecated" (since := "2026-04-02")]
 theorem dualPairing_apply (v x) : dualPairing R M v x = v x := rfl
 

--- a/Mathlib/LinearAlgebra/Finsupp/Pi.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Pi.lean
@@ -57,13 +57,11 @@ noncomputable def LinearEquiv.finsuppUnique (α : Type*) [Unique α] : (α →�
 
 variable {R M}
 
-set_option linter.deprecated false in
 @[deprecated uniqueLinearEquiv_apply (since := "2026-05-06")]
 theorem LinearEquiv.finsuppUnique_apply (α : Type*) [Unique α] (f : α →₀ M) :
     LinearEquiv.finsuppUnique R M α f = f default :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated uniqueLinearEquiv_symm_apply (since := "2026-05-06")]
 theorem LinearEquiv.finsuppUnique_symm_apply (α : Type*) [Unique α] (m : M) :
     (LinearEquiv.finsuppUnique R M α).symm m = Finsupp.single default m := by

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
@@ -356,7 +356,6 @@ theorem Measurable.ennreal_tsum {ι} [Countable ι] {f : ι → α → ℝ≥0�
   simp_rw [ENNReal.tsum_eq_iSup_sum]
   exact .iSup fun s ↦ s.measurable_fun_sum fun i _ => h i
 
-set_option linter.deprecated false in
 @[fun_prop, deprecated
   "Use `Measurable.tsum'` from `Mathlib.MeasureTheory.Constructions.Polish.Basic` instead"
   (since := "2026-04-30")]
@@ -365,7 +364,6 @@ theorem Measurable.ennreal_tsum' {ι} [Countable ι] {f : ι → α → ℝ≥0�
   convert! Measurable.ennreal_tsum h with x
   exact tsum_apply (Pi.summable.2 fun _ => ENNReal.summable)
 
-set_option linter.deprecated false in
 @[fun_prop, deprecated
   "Use `Measurable.tsum` from `Mathlib.MeasureTheory.Constructions.Polish.Basic` instead"
   (since := "2026-04-30")]
@@ -382,7 +380,6 @@ theorem AEMeasurable.ennreal_tsum {ι} [Countable ι] {f : ι → α → ℝ≥0
   simp_rw [ENNReal.tsum_eq_iSup_sum]
   exact .iSup fun s ↦ Finset.aemeasurable_fun_sum s fun i _ => h i
 
-set_option linter.deprecated false in
 @[fun_prop, deprecated
   "Use `AEMeasurable.tsum` from `Mathlib.MeasureTheory.Constructions.Polish.Basic` instead"
   (since := "2026-04-30")]

--- a/Mathlib/NumberTheory/ModularForms/LevelOne/DimensionFormula.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne/DimensionFormula.lean
@@ -94,7 +94,6 @@ lemma discriminantEquiv_apply (f : CuspForm 𝒮ℒ k) (z : ℍ) :
 @[deprecated discriminantEquiv (since := "2026-05-18")]
 def divDiscriminant (f : CuspForm 𝒮ℒ k) : ModularForm 𝒮ℒ (k - 12) := discriminantEquiv f
 
-set_option linter.deprecated false in
 @[deprecated discriminantEquiv_apply (since := "2026-05-18")]
 lemma divDiscriminant_apply (f : CuspForm 𝒮ℒ k) (z : ℍ) :
     (divDiscriminant f) z = f z / Δ z := rfl

--- a/Mathlib/Order/Comparable.lean
+++ b/Mathlib/Order/Comparable.lean
@@ -52,66 +52,53 @@ variable {r : α → α → Prop}
 def CompRel (r : α → α → Prop) (a b : α) : Prop :=
   r a b ∨ r b a
 
-set_option linter.deprecated false in
 @[deprecated SymmGen.of_rel (since := "2026-01-25")]
 theorem CompRel.of_rel (h : r a b) : CompRel r a b :=
   SymmGen.of_rel h
 
-set_option linter.deprecated false in
 @[deprecated SymmGen.of_rel_symm (since := "2026-01-25")]
 theorem CompRel.of_rel_symm (h : r b a) : CompRel r a b :=
   SymmGen.of_rel_symm h
 
-set_option linter.deprecated false in
 @[deprecated symmGen_swap (since := "2026-01-25")]
 theorem compRel_swap (r : α → α → Prop) : CompRel (swap r) = CompRel r :=
   symmGen_swap r
 
-set_option linter.deprecated false in
 @[deprecated symmGen_swap_apply (since := "2026-01-25")]
 theorem compRel_swap_apply (r : α → α → Prop) : CompRel (swap r) a b ↔ CompRel r a b :=
   symmGen_swap_apply r
 
-set_option linter.deprecated false in
 @[simp, refl, deprecated SymmGen.refl (since := "2026-01-25")]
 theorem CompRel.refl (r : α → α → Prop) [Std.Refl r] (a : α) : CompRel r a a :=
   SymmGen.refl r a
 
-set_option linter.deprecated false in
 @[deprecated SymmGen.rfl (since := "2026-01-25")]
 theorem CompRel.rfl [Std.Refl r] : CompRel r a a := SymmGen.rfl
 
-set_option linter.deprecated false in
 @[deprecated SymmGen.instRefl (since := "2026-01-25")]
 instance [Std.Refl r] : Std.Refl (CompRel r) :=
   SymmGen.instRefl
 
-set_option linter.deprecated false in
 @[symm, deprecated SymmGen.symm (since := "2026-01-25")]
 theorem CompRel.symm : CompRel r a b → CompRel r b a :=
   SymmGen.symm
 
-set_option linter.deprecated false in
 @[deprecated SymmGen.instSymm (since := "2026-01-25")]
 instance : Std.Symm (CompRel r) :=
   SymmGen.instSymm
 
-set_option linter.deprecated false in
 @[deprecated symmGen_comm (since := "2026-01-25")]
 theorem compRel_comm {a b : α} : CompRel r a b ↔ CompRel r b a :=
   symmGen_comm
 
-set_option linter.deprecated false in
 @[deprecated SymmGen.decidableRel (since := "2026-01-25")]
 instance CompRel.decidableRel [DecidableRel r] : DecidableRel (CompRel r) :=
   SymmGen.decidableRel
 
-set_option linter.deprecated false in
 @[deprecated AntisymmRel.symmGen (since := "2026-01-25")]
 theorem AntisymmRel.compRel (h : AntisymmRel r a b) : CompRel r a b :=
   AntisymmRel.symmGen h
 
-set_option linter.deprecated false in
 @[simp, deprecated symmGen_of_total (since := "2026-01-25")]
 theorem compRel_of_total [Std.Total r] (a b : α) : CompRel r a b :=
   symmGen_of_total a b
@@ -124,11 +111,9 @@ section LE
 
 variable [LE α]
 
-set_option linter.deprecated false in
 @[deprecated SymmGen.of_le (since := "2026-01-25")]
 theorem CompRel.of_le (h : a ≤ b) : CompRel (· ≤ ·) a b := SymmGen.of_le h
 
-set_option linter.deprecated false in
 @[deprecated SymmGen.of_ge (since := "2026-01-25")]
 theorem CompRel.of_ge (h : b ≤ a) : CompRel (· ≤ ·) a b := SymmGen.of_ge h
 
@@ -141,18 +126,15 @@ section Preorder
 
 variable [Preorder α]
 
-set_option linter.deprecated false in
 @[deprecated SymmGen.of_lt (since := "2026-01-25")]
 theorem CompRel.of_lt (h : a < b) : CompRel (· ≤ ·) a b := SymmGen.of_lt h
 
-set_option linter.deprecated false in
 @[deprecated SymmGen.of_gt (since := "2026-01-25")]
 theorem CompRel.of_gt (h : b < a) : CompRel (· ≤ ·) a b := SymmGen.of_gt h
 
 alias LT.lt.compRel := CompRel.of_lt
 alias LT.lt.compRel_symm := CompRel.of_gt
 
-set_option linter.deprecated false in
 @[trans, deprecated SymmGen.of_symmGen_of_antisymmRel (since := "2026-01-25")]
 theorem CompRel.of_compRel_of_antisymmRel
     (h₁ : CompRel (· ≤ ·) a b) (h₂ : AntisymmRel (· ≤ ·) b c) : CompRel (· ≤ ·) a c :=
@@ -160,37 +142,30 @@ theorem CompRel.of_compRel_of_antisymmRel
 
 alias CompRel.trans_antisymmRel := CompRel.of_compRel_of_antisymmRel
 
-set_option linter.deprecated false in
 @[deprecated instTransSymmGenLeAntisymmRel (since := "2026-01-25")]
 instance : @Trans α α α (CompRel (· ≤ ·)) (AntisymmRel (· ≤ ·)) (CompRel (· ≤ ·)) :=
   instTransSymmGenLeAntisymmRel
 
-set_option linter.deprecated false in
 @[trans, deprecated SymmGen.of_antisymmRel_of_symmGen (since := "2026-01-25")]
 theorem CompRel.of_antisymmRel_of_compRel
     (h₁ : AntisymmRel (· ≤ ·) a b) (h₂ : CompRel (· ≤ ·) b c) : CompRel (· ≤ ·) a c :=
   SymmGen.of_antisymmRel_of_symmGen h₁ h₂
 
 alias AntisymmRel.trans_compRel := CompRel.of_antisymmRel_of_compRel
-
-set_option linter.deprecated false in
 @[deprecated instTransAntisymmRelLeSymmGen (since := "2026-01-25")]
 instance : @Trans α α α (AntisymmRel (· ≤ ·)) (CompRel (· ≤ ·)) (CompRel (· ≤ ·)) :=
   instTransAntisymmRelLeSymmGen
 
-set_option linter.deprecated false in
 @[deprecated AntisymmRel.symmGen_congr (since := "2026-01-25")]
 theorem AntisymmRel.compRel_congr (h₁ : AntisymmRel (· ≤ ·) a b) (h₂ : AntisymmRel (· ≤ ·) c d) :
     CompRel (· ≤ ·) a c ↔ CompRel (· ≤ ·) b d :=
   AntisymmRel.symmGen_congr h₁ h₂
 
-set_option linter.deprecated false in
 @[deprecated AntisymmRel.symmGen_congr_left (since := "2026-01-25")]
 theorem AntisymmRel.compRel_congr_left (h : AntisymmRel (· ≤ ·) a b) :
     CompRel (· ≤ ·) a c ↔ CompRel (· ≤ ·) b c :=
   AntisymmRel.symmGen_congr_left h
 
-set_option linter.deprecated false in
 @[deprecated AntisymmRel.symmGen_congr_right (since := "2026-01-25")]
 theorem AntisymmRel.compRel_congr_right (h : AntisymmRel (· ≤ ·) b c) :
     CompRel (· ≤ ·) a b ↔ CompRel (· ≤ ·) a c :=
@@ -208,7 +183,6 @@ def Relation.linearOrderOfSymmGen [PartialOrder α]
   toDecidableEq := decEq
   toDecidableLT := decLT
 
-set_option linter.deprecated false in
 /-- A partial order where any two elements are comparable is a linear order. -/
 @[deprecated linearOrderOfSymmGen (since := "2026-01-25"), implicit_reducible]
 def linearOrderOfComprel [PartialOrder α]
@@ -280,7 +254,6 @@ theorem AntisymmRel.not_incompRel (h : AntisymmRel r a b) : ¬ IncompRel r a b :
 theorem not_symmGen_iff : ¬ Relation.SymmGen r a b ↔ IncompRel r a b := by
   simp [Relation.SymmGen, IncompRel]
 
-set_option linter.deprecated false in
 @[deprecated not_symmGen_iff (since := "2026-01-25")]
 theorem not_compRel_iff : ¬ CompRel r a b ↔ IncompRel r a b :=
   not_symmGen_iff
@@ -288,7 +261,6 @@ theorem not_compRel_iff : ¬ CompRel r a b ↔ IncompRel r a b :=
 theorem not_incompRel_iff_symmGen : ¬ IncompRel r a b ↔ Relation.SymmGen r a b := by
   rw [← not_symmGen_iff, not_not]
 
-set_option linter.deprecated false in
 @[deprecated not_incompRel_iff_symmGen (since := "2026-01-25")]
 theorem not_incompRel_iff : ¬ IncompRel r a b ↔ CompRel r a b :=
   not_incompRel_iff_symmGen

--- a/Mathlib/Order/Defs/Unbundled.lean
+++ b/Mathlib/Order/Defs/Unbundled.lean
@@ -454,7 +454,6 @@ theorem trans_trichotomous_right [IsTrans α r] [Std.Trichotomous r] {a b c : α
   · exact h₁
   · exact absurd h₃ h₂
 
-set_option linter.deprecated false in
 @[deprecated IsTrans.trans (since := "2026-02-20")]
 theorem transitive_of_trans (r : α → α → Prop) [IsTrans α r] : Transitive r := IsTrans.trans
 

--- a/Mathlib/Order/Interval/Finset/Nat.lean
+++ b/Mathlib/Order/Interval/Finset/Nat.lean
@@ -141,7 +141,6 @@ theorem Ico_succ_right_eq_insert_Ico (h : a ≤ b) : Ico a b.succ = insert b (Ic
   simp_rw [mem_insert, mem_Ico]
   lia
 
-set_option linter.deprecated false in
 theorem mod_injOn_Ico (n a : ℕ) : Set.InjOn (· % a) (Finset.Ico n (n + a)) := by
   induction n with
   | zero =>

--- a/Mathlib/Probability/Distributions/Geometric.lean
+++ b/Mathlib/Probability/Distributions/Geometric.lean
@@ -151,7 +151,6 @@ variable {p : ℝ}
 noncomputable
 def geometricPMFReal (p : ℝ) (n : ℕ) : ℝ := (1 - p) ^ n * p
 
-set_option linter.deprecated false in
 @[deprecated hasSum_one_geometricMeasure (since := "2026-03-08")]
 lemma geometricPMFRealSum (hp_pos : 0 < p) (hp_le_one : p ≤ 1) :
     HasSum (fun n ↦ geometricPMFReal p n) 1 := by
@@ -162,21 +161,18 @@ lemma geometricPMFRealSum (hp_pos : 0 < p) (hp_le_one : p ≤ 1) :
   rw [inv_mul_eq_div, div_self hp_pos.ne'] at this
   exact this
 
-set_option linter.deprecated false in
 @[deprecated geometricMeasure_real_singleton_pos (since := "2026-03-08")]
 lemma geometricPMFReal_pos {n : ℕ} (hp_pos : 0 < p) (hp_lt_one : p < 1) :
     0 < geometricPMFReal p n := by
   rw [geometricPMFReal]
   positivity [sub_pos.mpr hp_lt_one]
 
-set_option linter.deprecated false in
 @[deprecated measureReal_nonneg (since := "2026-03-08")]
 lemma geometricPMFReal_nonneg {n : ℕ} (hp_pos : 0 < p) (hp_le_one : p ≤ 1) :
     0 ≤ geometricPMFReal p n := by
   rw [geometricPMFReal]
   positivity [sub_nonneg.mpr hp_le_one]
 
-set_option linter.deprecated false in
 /-- Geometric distribution with success probability `p`. -/
 @[deprecated geometricMeasure (since := "2026-03-08")]
 noncomputable
@@ -187,12 +183,10 @@ def geometricPMF (hp_pos : 0 < p) (hp_le_one : p ≤ 1) : PMF ℕ :=
     exact (geometricPMFRealSum hp_pos hp_le_one).toNNReal
       (fun n ↦ geometricPMFReal_nonneg hp_pos hp_le_one)⟩
 
-set_option linter.deprecated false in
 @[deprecated Measurable.of_discrete (since := "2026-03-08")]
 lemma measurable_geometricPMFReal : Measurable (geometricPMFReal p) := by
   fun_prop
 
-set_option linter.deprecated false in
 @[deprecated StronglyMeasurable.of_discrete (since := "2026-03-08")]
 lemma stronglyMeasurable_geometricPMFReal : StronglyMeasurable (geometricPMFReal p) :=
   stronglyMeasurable_iff_measurable.mpr measurable_geometricPMFReal

--- a/Mathlib/Probability/Distributions/Poisson/Basic.lean
+++ b/Mathlib/Probability/Distributions/Poisson/Basic.lean
@@ -214,19 +214,16 @@ def poissonPMFReal (r : ℝ≥0) (n : ℕ) : ℝ := exp (-r) * r ^ n / (n)!
 @[deprecated (since := "2026-03-08")]
 alias poissonPMFRealSum := hasSum_one_poissonMeasure
 
-set_option linter.deprecated false in
 @[deprecated poissonMeasure_real_singleton_pos (since := "2026-03-08")]
 lemma poissonPMFReal_pos {r : ℝ≥0} {n : ℕ} (hr : 0 < r) : 0 < poissonPMFReal r n := by
   rw [poissonPMFReal]
   positivity
 
-set_option linter.deprecated false in
 @[deprecated measureReal_nonneg (since := "2026-03-08")]
 lemma poissonPMFReal_nonneg {r : ℝ≥0} {n : ℕ} : 0 ≤ poissonPMFReal r n := by
   unfold poissonPMFReal
   positivity
 
-set_option linter.deprecated false in
 /-- The pmf of the Poisson distribution depending on its rate, as a PMF. -/
 @[deprecated poissonMeasure (since := "2026-03-08")]
 noncomputable
@@ -236,17 +233,14 @@ def poissonPMF (r : ℝ≥0) : PMF ℕ := by
   rw [← toNNReal_one]
   exact (poissonPMFRealSum r).toNNReal (fun n ↦ poissonPMFReal_nonneg)
 
-set_option linter.deprecated false in
 @[deprecated poissonMeasure (since := "2026-03-08")]
 lemma poissonPMFReal_ofReal_eq_poissonPMF (r : ℝ≥0) (n : ℕ) :
     ENNReal.ofReal (poissonPMFReal r n) = poissonPMF r n := by
   simpa only [poissonPMF] using by rfl
 
-set_option linter.deprecated false in
 @[deprecated Measurable.of_discrete (since := "2026-03-08")]
 lemma measurable_poissonPMFReal (r : ℝ≥0) : Measurable (poissonPMFReal r) := by fun_prop
 
-set_option linter.deprecated false in
 @[deprecated StronglyMeasurable.of_discrete (since := "2026-03-08")]
 lemma stronglyMeasurable_poissonPMFReal (r : ℝ≥0) : StronglyMeasurable (poissonPMFReal r) :=
   stronglyMeasurable_iff_measurable.mpr (measurable_poissonPMFReal r)

--- a/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
@@ -301,7 +301,6 @@ def bernoulli (p : ℝ≥0) (h : p ≤ 1) : PMF Bool :=
 
 variable {p : ℝ≥0} (h : p ≤ 1) (b : Bool)
 
-set_option linter.deprecated false in
 @[deprecated ProbabilityTheory.bernoulliMeasure_apply (since := "2026-04-07")]
 theorem bernoulli_apply : bernoulli p h b = cond b p (1 - p) := by
   simp only [bernoulli, ofFintype_apply]

--- a/Mathlib/Probability/ProbabilityMassFunction/Integrals.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Integrals.lean
@@ -54,7 +54,6 @@ theorem integral_eq_sum [Fintype α] (p : PMF α) (f : α → E) :
 
 end General
 
-set_option linter.deprecated false in
 @[deprecated ProbabilityTheory.integral_bernoulliMeasure (since := "2026-04-07")]
 theorem bernoulli_expectation {p : ℝ≥0} (h : p ≤ 1) :
     ∫ b, cond b 1 0 ∂((bernoulli p h).toMeasure) = p.toReal := by

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -589,7 +589,6 @@ theorem ofSuppBddBelow_eq_zero {f : Γ → R} {hf} : ofSuppBddBelow f hf = 0 ↔
 theorem coeff_ofSuppBddBelow {f : Γ → R} {hf} : (ofSuppBddBelow f hf).coeff = f :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated le_order_iff_forall (since := "2026-01-02")]
 theorem order_ofForallLtEqZero [Zero Γ] (f : Γ → R) (hf : f ≠ 0) (n : Γ)
     (hn : ∀ (m : Γ), m < n → f m = 0) :

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -64,14 +64,12 @@ theorem integerNormalization_support (p : S[X]) :
 noncomputable def coeffIntegerNormalization (p : S[X]) (i : ℕ) : R :=
   (integerNormalization M p).coeff i
 
-set_option linter.deprecated false in
 @[deprecated integerNormalization_support (since := "2026-02-05")]
 theorem coeffIntegerNormalization_of_coeff_zero (p : S[X]) (i : ℕ) (h : coeff p i = 0) :
     coeffIntegerNormalization M p i = 0 :=
   notMem_support_iff.mp <| Finset.not_mem_subset (integerNormalization_support M p) <|
     notMem_support_iff.mpr h
 
-set_option linter.deprecated false in
 @[deprecated integerNormalization_support (since := "2026-02-05")]
 theorem coeffIntegerNormalization_mem_support (p : S[X]) (i : ℕ)
     (h : coeffIntegerNormalization M p i ≠ 0) : i ∈ p.support := by
@@ -79,7 +77,6 @@ theorem coeffIntegerNormalization_mem_support (p : S[X]) (i : ℕ)
   simp only [mem_support_iff, ne_eq, not_not] at h
   exact coeffIntegerNormalization_of_coeff_zero M p i h
 
-set_option linter.deprecated false in
 @[deprecated integerNormalization_spec (since := "2026-02-05")]
 theorem integerNormalization_coeff (p : S[X]) (i : ℕ) :
     (integerNormalization M p).coeff i = coeffIntegerNormalization M p i :=

--- a/Mathlib/SetTheory/Cardinal/Cofinality/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality/Ordinal.lean
@@ -321,7 +321,6 @@ theorem _root_.Cardinal.iSup_lt_of_lt_cof_ord {f : α → Cardinal.{u}} {a : Car
   rw [← ord_lt_ord, iSup_ord]
   apply Ordinal.iSup_lt_of_lt_cof <;> simpa
 
-set_option linter.deprecated false in
 /-- The set in the `lsub` characterization of `cof` is nonempty. -/
 @[deprecated "to build an increasing function with limit o, use the fundamental sequence API."
 (since := "2026-03-27")]
@@ -329,7 +328,6 @@ theorem cof_lsub_def_nonempty (o) :
     { a : Cardinal | ∃ (ι : _) (f : ι → Ordinal), lsub.{u, u} f = o ∧ #ι = a }.Nonempty :=
   ⟨_, ⟨_, _, lsub_typein o, mk_toType o⟩⟩
 
-set_option linter.deprecated false in
 @[deprecated "to build an increasing function with limit o, use the fundamental sequence API."
 (since := "2026-03-27")]
 theorem cof_eq_sInf_lsub (o : Ordinal.{u}) : cof o =
@@ -347,7 +345,6 @@ theorem cof_eq_sInf_lsub (o : Ordinal.{u}) : cof o =
     rw [← not_lt, ← typein_le_typein, typein_enum] at hb'
     exact hb'.trans_lt (lt_lsub.{u, u} f ⟨b, hb⟩)
 
-set_option linter.deprecated false in
 @[deprecated "to build an increasing function with limit o, use the fundamental sequence API."
 (since := "2026-03-27")]
 theorem exists_lsub_cof (o : Ordinal) :
@@ -355,19 +352,16 @@ theorem exists_lsub_cof (o : Ordinal) :
   rw [cof_eq_sInf_lsub]
   exact csInf_mem (cof_lsub_def_nonempty o)
 
-set_option linter.deprecated false in
 @[deprecated cof_iSup_add_one_le (since := "2026-03-22")]
 theorem cof_lsub_le {ι} (f : ι → Ordinal) : cof (lsub.{u, u} f) ≤ #ι :=
   cof_iSup_add_one_le f
 
-set_option linter.deprecated false in
 @[deprecated cof_lift_iSup_add_one_le (since := "2026-03-22")]
 theorem cof_lsub_le_lift {ι} (f : ι → Ordinal) :
     cof (lsub.{u, v} f) ≤ Cardinal.lift.{v, u} #ι := by
   rw [← lift_id'.{u} (lsub f), ← Cardinal.lift_umax.{u, v}]
   exact cof_lift_iSup_add_one_le _
 
-set_option linter.deprecated false in
 @[deprecated le_cof_iff (since := "2026-03-21")]
 theorem le_cof_iff_lsub {o : Ordinal} {a : Cardinal} :
     a ≤ cof o ↔ ∀ {ι} (f : ι → Ordinal), lsub.{u, u} f = o → a ≤ #ι := by
@@ -378,7 +372,6 @@ theorem le_cof_iff_lsub {o : Ordinal} {a : Cardinal} :
         rw [← hb]
         exact H _ hf⟩
 
-set_option linter.deprecated false in
 @[deprecated lift_iSup_add_one_lt_of_lt_cof (since := "2026-03-22")]
 theorem lsub_lt_ord_lift {ι} {f : ι → Ordinal} {c : Ordinal}
     (hι : Cardinal.lift.{v, u} #ι < c.cof)
@@ -386,7 +379,6 @@ theorem lsub_lt_ord_lift {ι} {f : ι → Ordinal} {c : Ordinal}
   apply lift_iSup_add_one_lt_of_lt_cof _ hf
   rwa [Cardinal.lift_umax, c.lift_id']
 
-set_option linter.deprecated false in
 @[deprecated iSup_add_one_lt_of_lt_cof (since := "2026-03-22")]
 theorem lsub_lt_ord {ι} {f : ι → Ordinal} {c : Ordinal} (hι : #ι < c.cof) :
     (∀ i, f i < c) → lsub.{u, u} f < c :=
@@ -444,7 +436,6 @@ theorem nfp_lt_ord {f : Ordinal → Ordinal} {c} (hc : ℵ₀ < cof c) (hf : ∀
     a < c → nfp f a < c :=
   nfpFamily_lt_ord_lift hc (by simpa using Cardinal.one_lt_aleph0.trans hc) fun _ => hf
 
-set_option linter.deprecated false in
 @[deprecated exists_lsub_cof (since := "2026-03-21")]
 theorem exists_blsub_cof (o : Ordinal) :
     ∃ f : ∀ a < (cof o).ord, Ordinal, blsub.{u, u} _ f = o := by
@@ -454,7 +445,6 @@ theorem exists_blsub_cof (o : Ordinal) :
   rw [← hι, hι']
   exact ⟨_, hf⟩
 
-set_option linter.deprecated false in
 @[deprecated le_cof_iff (since := "2026-03-21")]
 theorem le_cof_iff_blsub {b : Ordinal} {a : Cardinal} :
     a ≤ cof b ↔ ∀ {o} (f : ∀ a < o, Ordinal), blsub.{u, u} o f = b → a ≤ o.card :=
@@ -464,33 +454,28 @@ theorem le_cof_iff_blsub {b : Ordinal} {a : Cardinal} :
       rw [← @blsub_eq_lsub' ι r hr] at hf
       simpa using H _ hf⟩
 
-set_option linter.deprecated false in
 @[deprecated cof_lift_iSup_add_one_le (since := "2026-03-22")]
 theorem cof_blsub_le_lift {o} (f : ∀ a < o, Ordinal) :
     cof (blsub.{u, v} o f) ≤ Cardinal.lift.{v, u} o.card := by
   rw [← mk_toType o]
   exact cof_lsub_le_lift _
 
-set_option linter.deprecated false in
 @[deprecated cof_iSup_add_one_le (since := "2026-03-22")]
 theorem cof_blsub_le {o} (f : ∀ a < o, Ordinal) : cof (blsub.{u, u} o f) ≤ o.card := by
   rw [← o.card.lift_id]
   exact cof_blsub_le_lift f
 
-set_option linter.deprecated false in
 @[deprecated lift_iSup_add_one_lt_of_lt_cof (since := "2026-03-22")]
 theorem blsub_lt_ord_lift {o : Ordinal.{u}} {f : ∀ a < o, Ordinal} {c : Ordinal}
     (ho : Cardinal.lift.{v, u} o.card < c.cof) (hf : ∀ i hi, f i hi < c) : blsub.{u, v} o f < c :=
   lt_of_le_of_ne (blsub_le hf) fun h =>
     ho.not_ge (by simpa [← iSup_ord, hf, h] using cof_blsub_le_lift.{u, v} f)
 
-set_option linter.deprecated false in
 @[deprecated iSup_add_one_lt_of_lt_cof (since := "2026-03-22")]
 theorem blsub_lt_ord {o : Ordinal} {f : ∀ a < o, Ordinal} {c : Ordinal} (ho : o.card < c.cof)
     (hf : ∀ i hi, f i hi < c) : blsub.{u, u} o f < c :=
   blsub_lt_ord_lift (by rwa [o.card.lift_id]) hf
 
-set_option linter.deprecated false in
 @[deprecated lift_iSup_lt_of_lt_cof (since := "2026-03-22")]
 theorem cof_bsup_le_lift {o : Ordinal} {f : ∀ a < o, Ordinal} (H : ∀ i h, f i h < bsup.{u, v} o f) :
     cof (bsup.{u, v} o f) ≤ Cardinal.lift.{v, u} o.card := by
@@ -498,20 +483,17 @@ theorem cof_bsup_le_lift {o : Ordinal} {f : ∀ a < o, Ordinal} (H : ∀ i h, f 
   rw [H]
   exact cof_blsub_le_lift.{u, v} f
 
-set_option linter.deprecated false in
 @[deprecated iSup_lt_of_lt_cof (since := "2026-03-22")]
 theorem cof_bsup_le {o : Ordinal} {f : ∀ a < o, Ordinal} :
     (∀ i h, f i h < bsup.{u, u} o f) → cof (bsup.{u, u} o f) ≤ o.card := by
   rw [← o.card.lift_id]
   exact cof_bsup_le_lift
 
-set_option linter.deprecated false in
 @[deprecated lift_iSup_lt_of_lt_cof (since := "2026-03-22")]
 theorem bsup_lt_ord_lift {o : Ordinal} {f : ∀ a < o, Ordinal} {c : Ordinal}
     (ho : Cardinal.lift.{v, u} o.card < c.cof) (hf : ∀ i hi, f i hi < c) : bsup.{u, v} o f < c :=
   (bsup_le_blsub f).trans_lt (blsub_lt_ord_lift ho hf)
 
-set_option linter.deprecated false in
 @[deprecated iSup_lt_of_lt_cof (since := "2026-03-22")]
 theorem bsup_lt_ord {o : Ordinal} {f : ∀ a < o, Ordinal} {c : Ordinal} (ho : o.card < c.cof) :
     (∀ i hi, f i hi < c) → bsup.{u, u} o f < c :=

--- a/Mathlib/SetTheory/Cardinal/Regular.lean
+++ b/Mathlib/SetTheory/Cardinal/Regular.lean
@@ -143,14 +143,12 @@ lemma isRegular_lift_iff {κ : Cardinal.{v}} :
     (Cardinal.lift.{u} κ).IsRegular ↔ κ.IsRegular :=
   ⟨fun ⟨h₁, h₂⟩ ↦ ⟨by simpa using h₁, by simpa [← lift_le.{u, v}]⟩, fun h ↦ h.lift⟩
 
-set_option linter.deprecated false in
 @[deprecated lift_iSup_add_one_lt_of_lt_cof (since := "2026-03-22")]
 theorem lsub_lt_ord_lift_of_isRegular {ι} {f : ι → Ordinal} {c} (hc : IsRegular c)
     (hι : Cardinal.lift.{v, u} #ι < c) (hf : ∀ i, f i < c.ord) : Ordinal.lsub.{u, v} f < c.ord := by
   apply lift_iSup_add_one_lt_of_lt_cof _ hf
   rwa [lift_umax, c.ord.lift_id', hc.cof_ord]
 
-set_option linter.deprecated false in
 @[deprecated iSup_add_one_lt_of_lt_cof (since := "2026-03-22")]
 theorem lsub_lt_ord_of_isRegular {ι} {f : ι → Ordinal} {c} (hc : IsRegular c) (hι : #ι < c) :
     (∀ i, f i < c.ord) → Ordinal.lsub f < c.ord :=
@@ -167,27 +165,23 @@ theorem iSup_lt_ord_of_isRegular {ι} {f : ι → Ordinal} {c} (hc : IsRegular c
     (∀ i, f i < c.ord) → iSup f < c.ord :=
   Ordinal.iSup_lt_of_lt_cof (by rwa [hc.cof_ord])
 
-set_option linter.deprecated false in
 @[deprecated lift_iSup_add_one_lt_of_lt_cof (since := "2026-03-22")]
 theorem blsub_lt_ord_lift_of_isRegular {o : Ordinal} {f : ∀ a < o, Ordinal} {c} (hc : IsRegular c)
     (ho : Cardinal.lift.{v, u} o.card < c) :
     (∀ i hi, f i hi < c.ord) → Ordinal.blsub.{u, v} o f < c.ord :=
   blsub_lt_ord_lift (by rwa [hc.cof_ord])
 
-set_option linter.deprecated false in
 @[deprecated lift_iSup_add_one_lt_of_lt_cof (since := "2026-03-22")]
 theorem blsub_lt_ord_of_isRegular {o : Ordinal} {f : ∀ a < o, Ordinal} {c} (hc : IsRegular c)
     (ho : o.card < c) : (∀ i hi, f i hi < c.ord) → Ordinal.blsub o f < c.ord :=
   blsub_lt_ord (by rwa [hc.cof_ord])
 
-set_option linter.deprecated false in
 @[deprecated iSup_lt_ord_lift_of_isRegular (since := "2026-03-22")]
 theorem bsup_lt_ord_lift_of_isRegular {o : Ordinal} {f : ∀ a < o, Ordinal} {c} (hc : IsRegular c)
     (hι : Cardinal.lift.{v, u} o.card < c) :
     (∀ i hi, f i hi < c.ord) → Ordinal.bsup.{u, v} o f < c.ord :=
   bsup_lt_ord_lift (by rwa [hc.cof_ord])
 
-set_option linter.deprecated false in
 @[deprecated lift_iSup_lt_of_lt_cof (since := "2026-03-22")]
 theorem bsup_lt_ord_of_isRegular {o : Ordinal} {f : ∀ a < o, Ordinal} {c} (hc : IsRegular c)
     (hι : o.card < c) : (∀ i hi, f i hi < c.ord) → Ordinal.bsup o f < c.ord :=

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -194,7 +194,6 @@ def boundedLimitRecOn {l : Ordinal} (lLim : IsSuccLimit l) {motive : Iio l → S
     exact succ ⟨o, ho'⟩ (IH ho')
   | limit o ho' IH => exact limit _ ho' fun a ha ↦ IH a.1 ha (ha.trans (c := l) ho)
 
-set_option linter.deprecated false in
 @[deprecated limitRecOn_zero (since := "2025-12-26")]
 theorem boundedLimitRec_zero {l} (lLim : IsSuccLimit l) {motive} (H₁ H₂ H₃) :
     @boundedLimitRecOn l lLim motive ⟨0, lLim.bot_lt⟩ H₁ H₂ H₃ = H₁ := by
@@ -202,7 +201,6 @@ theorem boundedLimitRec_zero {l} (lLim : IsSuccLimit l) {motive} (H₁ H₂ H₃
   dsimp
   rw [limitRecOn_zero]
 
-set_option linter.deprecated false in
 @[deprecated limitRecOn_succ (since := "2025-12-26")]
 theorem boundedLimitRec_succ {l} (lLim : IsSuccLimit l) {motive} (o H₁ H₂ H₃) :
     @boundedLimitRecOn l lLim motive ⟨succ o.1, lLim.succ_lt o.2⟩ H₁ H₂ H₃ = H₂ o
@@ -212,7 +210,6 @@ theorem boundedLimitRec_succ {l} (lLim : IsSuccLimit l) {motive} (o H₁ H₂ H�
   rw [limitRecOn_succ]
   rfl
 
-set_option linter.deprecated false in
 @[deprecated limitRecOn_limit (since := "2025-12-26")]
 theorem boundedLimitRec_limit {l} (lLim : IsSuccLimit l) {motive} (o H₁ H₂ H₃ oLim) :
     @boundedLimitRecOn l lLim motive o H₁ H₂ H₃ = H₃ o oLim (fun x _ ↦
@@ -237,7 +234,6 @@ theorem has_succ_of_type_succ_lt {α} {r : α → α → Prop} [wo : IsWellOrder
   · rw [enum_typein]
   · rw [Subtype.mk_lt_mk, lt_succ_iff]
 
-set_option linter.deprecated false in
 @[deprecated isSuccPrelimit_type_lt_iff (since := "2026-04-12")]
 theorem toType_noMax_of_succ_lt {o : Ordinal} (ho : ∀ a < o, succ a < o) : NoMaxOrder o.ToType :=
   ⟨has_succ_of_type_succ_lt (type_toType _ ▸ ho)⟩
@@ -325,65 +321,53 @@ theorem lift_pred (o : Ordinal.{v}) : lift.{u} (pred o) = pred (lift.{u} o) := b
 protected def IsNormal (f : Ordinal → Ordinal) : Prop :=
   Order.IsNormal f
 
-set_option linter.deprecated false in
 @[deprecated IsNormal.le_iff_forall_le (since := "2025-12-25")]
 theorem IsNormal.limit_le {f} (H : Ordinal.IsNormal f) :
     ∀ {o}, IsSuccLimit o → ∀ {a}, f o ≤ a ↔ ∀ b < o, f b ≤ a :=
   H.le_iff_forall_le
 
-set_option linter.deprecated false in
 @[deprecated IsNormal.lt_iff_exists_lt (since := "2025-12-25")]
 theorem IsNormal.limit_lt {f} (H : Ordinal.IsNormal f) {o} (h : IsSuccLimit o) {a} :
     a < f o ↔ ∃ b < o, a < f b :=
   H.lt_iff_exists_lt h
 
-set_option linter.deprecated false in
 @[deprecated Order.IsNormal.strictMono (since := "2025-12-25")]
 theorem IsNormal.strictMono {f} (H : Ordinal.IsNormal f) : StrictMono f :=
   Order.IsNormal.strictMono H
 
-set_option linter.deprecated false in
 @[deprecated Order.IsNormal.strictMono (since := "2025-12-25")]
 theorem IsNormal.monotone {f} (H : Ordinal.IsNormal f) : Monotone f :=
   H.strictMono.monotone
 
-set_option linter.deprecated false in
 @[deprecated isNormal_iff (since := "2025-12-25")]
 theorem isNormal_iff_strictMono_limit (f : Ordinal → Ordinal) :
     Ordinal.IsNormal f ↔ StrictMono f ∧ ∀ o, IsSuccLimit o → ∀ a, (∀ b < o, f b ≤ a) → f o ≤ a :=
   isNormal_iff
 
-set_option linter.deprecated false in
 @[deprecated StrictMono.lt_iff_lt (since := "2025-12-25")]
 theorem IsNormal.lt_iff {f} (H : Ordinal.IsNormal f) {a b} : f a < f b ↔ a < b :=
   H.strictMono.lt_iff_lt
 
-set_option linter.deprecated false in
 @[deprecated StrictMono.le_iff_le (since := "2025-12-25")]
 theorem IsNormal.le_iff {f} (H : Ordinal.IsNormal f) {a b} : f a ≤ f b ↔ a ≤ b :=
   H.strictMono.le_iff_le
 
-set_option linter.deprecated false in
 @[deprecated Injective.eq_iff (since := "2025-12-25")]
 theorem IsNormal.inj {f} (H : Ordinal.IsNormal f) {a b} : f a = f b ↔ a = b :=
   H.strictMono.injective.eq_iff
 
-set_option linter.deprecated false in
 @[deprecated StrictMono.id_le (since := "2025-12-25")]
 theorem IsNormal.id_le {f} (H : Ordinal.IsNormal f) : id ≤ f :=
   H.strictMono.id_le
 
-set_option linter.deprecated false in
 @[deprecated StrictMono.le_apply (since := "2025-12-25")]
 theorem IsNormal.le_apply {f} (H : Ordinal.IsNormal f) {a} : a ≤ f a :=
   H.strictMono.le_apply
 
-set_option linter.deprecated false in
 @[deprecated StrictMono.le_apply (since := "2025-12-25")]
 theorem IsNormal.le_iff_eq {f} (H : Ordinal.IsNormal f) {a} : f a ≤ a ↔ f a = a :=
   H.le_apply.ge_iff_eq'
 
-set_option linter.deprecated false in
 @[deprecated IsNormal.map_isLUB (since := "2025-12-25")]
 theorem IsNormal.le_set {f o} (H : Ordinal.IsNormal f) (p : Set Ordinal) (p0 : p.Nonempty) (b)
     (H₂ : ∀ o, b ≤ o ↔ ∀ a ∈ p, a ≤ o) : f b ≤ o ↔ ∀ a ∈ p, f a ≤ o := by
@@ -391,25 +375,21 @@ theorem IsNormal.le_set {f o} (H : Ordinal.IsNormal f) (p : Set Ordinal) (p0 : p
   refine ⟨fun hb a ha ↦ (hp.1 (mem_image_of_mem _ ha)).trans hb, fun H ↦ hp.2 ?_⟩
   simpa [mem_upperBounds]
 
-set_option linter.deprecated false in
 @[deprecated IsNormal.map_isLUB (since := "2025-12-25")]
 theorem IsNormal.le_set' {f o} (H : Ordinal.IsNormal f) (p : Set α) (p0 : p.Nonempty)
     (g : α → Ordinal) (b) (H₂ : ∀ o, b ≤ o ↔ ∀ a ∈ p, g a ≤ o) :
     f b ≤ o ↔ ∀ a ∈ p, f (g a) ≤ o := by
   simpa [H₂] using H.le_set (g '' p) (p0.image g) b
 
-set_option linter.deprecated false in
 @[deprecated IsNormal.id (since := "2025-12-25")]
 theorem IsNormal.refl : Ordinal.IsNormal id :=
   .id
 
-set_option linter.deprecated false in
 @[deprecated IsNormal.comp (since := "2025-12-25")]
 theorem IsNormal.trans {f g} (H₁ : Ordinal.IsNormal f) (H₂ : Ordinal.IsNormal g) :
     IsNormal (f ∘ g) :=
   H₁.comp H₂
 
-set_option linter.deprecated false in
 @[deprecated IsNormal.map_isSuccLimit (since := "2025-12-25")]
 theorem IsNormal.isSuccLimit {f} (H : Ordinal.IsNormal f) {o} (ho : IsSuccLimit o) :
     IsSuccLimit (f o) :=

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -565,7 +565,6 @@ def toTypeOrderBot {o : Ordinal} (ho : o ≠ 0) : OrderBot o.ToType where
   bot := (enum (· < ·)) ⟨0, _⟩
   bot_le := enum_zero_le' (bot_lt_iff_ne_bot.2 ho)
 
-set_option linter.deprecated false in
 @[deprecated "use `WellFoundedLT.toOrderBot` if you need an `OrderBot` instance"
 (since := "2026-04-12")]
 theorem enum_zero_eq_bot {o : Ordinal} (ho : 0 < o) :
@@ -1211,7 +1210,6 @@ theorem mk_Iio_toType_ord_lt {c : Cardinal} (i : c.ord.ToType) : #(Iio i) < c :=
 
 @[deprecated (since := "2026-03-20")] alias mk_Iio_ord_toType := mk_Iio_toType_ord_lt
 
-set_option linter.deprecated false in
 @[deprecated mk_Iio_lt (since := "2026-03-20")]
 theorem card_typein_toType_lt (c : Cardinal) (x : c.ord.ToType) :
     card (typein (α := c.ord.ToType) (· < ·) x) < c :=
@@ -1256,7 +1254,6 @@ theorem ord_eq_omega0 {a : Cardinal} : a.ord = ω ↔ a = ℵ₀ :=
 def ord.orderEmbedding : Cardinal ↪o Ordinal :=
   OrderEmbedding.ofStrictMono _ fun _ _ ↦ Cardinal.ord_lt_ord.2
 
-set_option linter.deprecated false in
 @[deprecated ord (since := "2026-02-27")]
 theorem ord.orderEmbedding_coe : (ord.orderEmbedding : Cardinal → Ordinal) = ord :=
   rfl

--- a/Mathlib/SetTheory/Ordinal/Family.lean
+++ b/Mathlib/SetTheory/Ordinal/Family.lean
@@ -33,7 +33,6 @@ well-ordering. -/
 def bfamilyOfFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → α) :
     ∀ a < type r, α := fun a ha => f (enum r ⟨a, ha⟩)
 
-set_option linter.deprecated false in
 /-- Converts a family indexed by a `Type u` to one indexed by an `Ordinal.{u}` using a well-ordering
 given by the axiom of choice. -/
 @[deprecated enum (since := "2026-04-06")]
@@ -50,33 +49,28 @@ def familyOfBFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {
       rw [← ho]
       exact typein_lt_type r i)
 
-set_option linter.deprecated false in
 /-- Converts a family indexed by an `Ordinal.{u}` to one indexed by a `Type u` using a well-ordering
 given by the axiom of choice. -/
 @[deprecated typein (since := "2026-04-06")]
 def familyOfBFamily (o : Ordinal) (f : ∀ a < o, α) : o.ToType → α :=
   familyOfBFamily' (· < ·) (type_toType o) f
 
-set_option linter.deprecated false in
 @[deprecated "bfamilyOfFamily is deprecated" (since := "2026-04-06")]
 theorem bfamilyOfFamily'_typein {ι} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → α) (i) :
     bfamilyOfFamily' r f (typein r i) (typein_lt_type r i) = f i := by
   simp only [bfamilyOfFamily', enum_typein]
 
-set_option linter.deprecated false in
 @[deprecated "bfamilyOfFamily is deprecated" (since := "2026-04-06")]
 theorem bfamilyOfFamily_typein {ι} (f : ι → α) (i) :
     bfamilyOfFamily f (typein _ i) (typein_lt_type _ i) = f i :=
   bfamilyOfFamily'_typein _ f i
 
-set_option linter.deprecated false in
 @[deprecated "familyOfBFamily is deprecated" (since := "2026-04-06")]
 theorem familyOfBFamily'_enum {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {o}
     (ho : type r = o) (f : ∀ a < o, α) (i hi) :
     familyOfBFamily' r ho f (enum r ⟨i, by rwa [ho]⟩) = f i hi := by
   simp only [familyOfBFamily', typein_enum]
 
-set_option linter.deprecated false in
 @[deprecated "familyOfBFamily is deprecated" (since := "2026-04-06")]
 theorem familyOfBFamily_enum (o : Ordinal) (f : ∀ a < o, α) (i hi) :
     familyOfBFamily o f (enum (α := o.ToType) (· < ·) ⟨i, hi.trans_eq (type_toType _).symm⟩)
@@ -88,17 +82,14 @@ theorem familyOfBFamily_enum (o : Ordinal) (f : ∀ a < o, α) (i hi) :
 def brange (o : Ordinal) (f : ∀ a < o, α) : Set α :=
   { a | ∃ i hi, f i hi = a }
 
-set_option linter.deprecated false in
 @[deprecated mem_range (since := "2026-04-06")]
 theorem mem_brange {o : Ordinal} {f : ∀ a < o, α} {a} : a ∈ brange o f ↔ ∃ i hi, f i hi = a :=
   Iff.rfl
 
-set_option linter.deprecated false in
 @[deprecated mem_range_self (since := "2026-04-06")]
 theorem mem_brange_self {o} (f : ∀ a < o, α) (i hi) : f i hi ∈ brange o f :=
   ⟨i, hi, rfl⟩
 
-set_option linter.deprecated false in
 @[deprecated "familyOfBFamily is deprecated" (since := "2026-04-06")]
 theorem range_familyOfBFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {o}
     (ho : type r = o) (f : ∀ a < o, α) : range (familyOfBFamily' r ho f) = brange o f := by
@@ -108,12 +99,10 @@ theorem range_familyOfBFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrd
   · rintro ⟨i, hi, rfl⟩
     exact ⟨_, familyOfBFamily'_enum _ _ _ _ _⟩
 
-set_option linter.deprecated false in
 @[deprecated "familyOfBFamily is deprecated" (since := "2026-04-06")]
 theorem range_familyOfBFamily {o} (f : ∀ a < o, α) : range (familyOfBFamily o f) = brange o f :=
   range_familyOfBFamily' _ _ f
 
-set_option linter.deprecated false in
 @[deprecated "bfamilyOfFamily is deprecated" (since := "2026-04-06")]
 theorem brange_bfamilyOfFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → α) :
     brange _ (bfamilyOfFamily' r f) = range f := by
@@ -123,37 +112,31 @@ theorem brange_bfamilyOfFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOr
   · rintro ⟨b, rfl⟩
     exact ⟨_, _, bfamilyOfFamily'_typein _ _ _⟩
 
-set_option linter.deprecated false in
 @[deprecated "bfamilyOfFamily is deprecated" (since := "2026-04-06")]
 theorem brange_bfamilyOfFamily {ι : Type u} (f : ι → α) : brange _ (bfamilyOfFamily f) = range f :=
   brange_bfamilyOfFamily' _ _
 
-set_option linter.deprecated false in
 @[deprecated "brange is deprecated" (since := "2026-04-06")]
 theorem brange_const {o : Ordinal} (ho : o ≠ 0) {c : α} : (brange o fun _ _ => c) = {c} := by
   rw [← range_familyOfBFamily]
   exact @Set.range_const _ o.ToType (nonempty_toType_iff.2 ho) c
 
-set_option linter.deprecated false in
 @[deprecated "bfamilyOfFamily is deprecated" (since := "2026-04-06")]
 theorem comp_bfamilyOfFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → α)
     (g : α → β) : (fun i hi => g (bfamilyOfFamily' r f i hi)) = bfamilyOfFamily' r (g ∘ f) :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "bfamilyOfFamily is deprecated" (since := "2026-04-06")]
 theorem comp_bfamilyOfFamily {ι : Type u} (f : ι → α) (g : α → β) :
     (fun i hi => g (bfamilyOfFamily f i hi)) = bfamilyOfFamily (g ∘ f) :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "familyOfBFamily is deprecated" (since := "2026-04-06")]
 theorem comp_familyOfBFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {o}
     (ho : type r = o) (f : ∀ a < o, α) (g : α → β) :
     g ∘ familyOfBFamily' r ho f = familyOfBFamily' r ho fun i hi => g (f i hi) :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "familyOfBFamily is deprecated" (since := "2026-04-06")]
 theorem comp_familyOfBFamily {o} (f : ∀ a < o, α) (g : α → β) :
     g ∘ familyOfBFamily o f = familyOfBFamily o fun i hi => g (f i hi) :=
@@ -259,33 +242,28 @@ theorem unbounded_range_of_le_iSup {α β : Type u} (r : α → α → Prop) [Is
       (Ordinal.iSup_le fun y => ((typein_lt_typein r).2 <| hx _ <| mem_range_self y).le)
       (typein_lt_type r x)
 
-set_option linter.deprecated false in
 @[deprecated Order.IsNormal.map_iSup (since := "2025-12-25")]
 theorem IsNormal.map_iSup_of_bddAbove {f : Ordinal.{u} → Ordinal.{v}} (H : Ordinal.IsNormal f)
     {ι : Type*} (g : ι → Ordinal.{u}) (hg : BddAbove (range g))
     [Nonempty ι] : f (⨆ i, g i) = ⨆ i, f (g i) :=
   Order.IsNormal.map_iSup H hg
 
-set_option linter.deprecated false in
 @[deprecated Order.IsNormal.map_iSup (since := "2025-12-25")]
 theorem IsNormal.map_iSup {f : Ordinal.{u} → Ordinal.{v}} (H : Ordinal.IsNormal f)
     {ι : Type w} (g : ι → Ordinal.{u}) [Small.{u} ι] [Nonempty ι] :
     f (⨆ i, g i) = ⨆ i, f (g i) :=
   Order.IsNormal.map_iSup H bddAbove_of_small
 
-set_option linter.deprecated false in
 @[deprecated Order.IsNormal.map_sSup (since := "2025-12-25")]
 theorem IsNormal.map_sSup_of_bddAbove {f : Ordinal.{u} → Ordinal.{v}} (H : Ordinal.IsNormal f)
     {s : Set Ordinal.{u}} (hs : BddAbove s) (hn : s.Nonempty) : f (sSup s) = sSup (f '' s) :=
   Order.IsNormal.map_sSup H hn hs
 
-set_option linter.deprecated false in
 @[deprecated Order.IsNormal.map_sSup (since := "2025-12-25")]
 theorem IsNormal.map_sSup {f : Ordinal.{u} → Ordinal.{v}} (H : IsNormal f)
     {s : Set Ordinal.{u}} (hn : s.Nonempty) [Small.{u} s] : f (sSup s) = sSup (f '' s) :=
   Order.IsNormal.map_sSup H hn bddAbove_of_small
 
-set_option linter.deprecated false in
 @[deprecated Order.IsNormal.apply_of_isSuccLimit (since := "2025-12-25")]
 theorem IsNormal.apply_of_isSuccLimit {f : Ordinal.{u} → Ordinal.{v}} (H : Ordinal.IsNormal f)
     {o : Ordinal} (ho : IsSuccLimit o) : f o = ⨆ a : Iio o, f a :=
@@ -372,14 +350,12 @@ theorem iSup_Iio_add_one {a : Ordinal.{u}} {f : Iio a → Ordinal.{u}}
 
 section bsup
 
-set_option linter.deprecated false in
 @[deprecated "familyOfBFamily is deprecated" (since := "2026-04-06")]
 theorem iSup_eq_iSup {ι ι' : Type u} (r : ι → ι → Prop) (r' : ι' → ι' → Prop) [IsWellOrder ι r]
     [IsWellOrder ι' r'] {o : Ordinal} (ho : type r = o) (ho' : type r' = o) (f : ∀ a < o, Ordinal) :
     iSup (familyOfBFamily' r ho f) = iSup (familyOfBFamily' r' ho' f) :=
   congrArg sSup (by simp_rw [range_familyOfBFamily'])
 
-set_option linter.deprecated false in
 /-- The supremum of a family of ordinals indexed by the set of ordinals less than some
 `o : Ordinal.{u}`. This is a special case of `iSup` over the family provided by
 `familyOfBFamily`. -/
@@ -387,50 +363,42 @@ set_option linter.deprecated false in
 def bsup (o : Ordinal.{u}) (f : ∀ a < o, Ordinal.{max u v}) : Ordinal.{max u v} :=
   iSup (familyOfBFamily o f)
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem iSup_eq_bsup {o : Ordinal} (f : ∀ a < o, Ordinal) :
     iSup (familyOfBFamily o f) = bsup o f :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem iSup'_eq_bsup {o : Ordinal} {ι} (r : ι → ι → Prop) [IsWellOrder ι r] (ho : type r = o)
     (f : ∀ a < o, Ordinal) : iSup (familyOfBFamily' r ho f) = bsup o f :=
   iSup_eq_iSup r _ ho _ f
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem sSup_eq_bsup {o : Ordinal} (f : ∀ a < o, Ordinal) : sSup (brange o f) = bsup o f := by
   congr
   rw [range_familyOfBFamily]
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup'_eq_iSup {ι} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → Ordinal) :
     bsup _ (bfamilyOfFamily' r f) = iSup f := by
   simp +unfoldPartialApp only [← iSup'_eq_bsup r, enum_typein, familyOfBFamily', bfamilyOfFamily']
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_eq_iSup {ι} (f : ι → Ordinal) : bsup _ (bfamilyOfFamily f) = iSup f :=
   bsup'_eq_iSup _ f
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_eq_bsup {ι : Type u} (r r' : ι → ι → Prop) [IsWellOrder ι r] [IsWellOrder ι r']
     (f : ι → Ordinal.{max u v}) :
     bsup.{_, v} _ (bfamilyOfFamily' r f) = bsup.{_, v} _ (bfamilyOfFamily' r' f) := by
   rw [bsup'_eq_iSup, bsup'_eq_iSup]
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_congr {o₁ o₂ : Ordinal.{u}} (f : ∀ a < o₁, Ordinal.{max u v}) (ho : o₁ = o₂) :
     bsup.{_, v} o₁ f = bsup.{_, v} o₂ fun a h => f a (h.trans_eq ho.symm) := by
   subst ho
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_le_iff {o f a} : bsup.{u, v} o f ≤ a ↔ ∀ i h, f i h ≤ a :=
   Ordinal.iSup_le_iff.trans
@@ -438,24 +406,20 @@ theorem bsup_le_iff {o f a} : bsup.{u, v} o f ≤ a ↔ ∀ i h, f i h ≤ a :=
       rw [← familyOfBFamily_enum o f]
       exact h _, fun h _ => h _ _⟩
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_le {o : Ordinal} {f : ∀ b < o, Ordinal} {a} :
     (∀ i h, f i h ≤ a) → bsup.{u, v} o f ≤ a :=
   bsup_le_iff.2
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem le_bsup {o} (f : ∀ a < o, Ordinal) (i h) : f i h ≤ bsup o f :=
   bsup_le_iff.1 le_rfl _ _
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem lt_bsup {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) {a} :
     a < bsup.{_, v} o f ↔ ∃ i hi, a < f i hi := by
   simpa only [not_forall, not_le] using not_congr (@bsup_le_iff.{_, v} _ f a)
 
-set_option linter.deprecated false in
 @[deprecated IsNormal.map_iSup (since := "2026-04-05")]
 theorem IsNormal.bsup {f : Ordinal → Ordinal} (H : IsNormal f) {o : Ordinal} :
     ∀ (g : ∀ a < o, Ordinal), o ≠ 0 → f (bsup o g) = bsup o fun a h => f (g a h) :=
@@ -464,13 +428,11 @@ theorem IsNormal.bsup {f : Ordinal → Ordinal} (H : IsNormal f) {o : Ordinal} :
     rw [← iSup'_eq_bsup r, Order.IsNormal.map_iSup H bddAbove_of_small, ← iSup'_eq_bsup r] <;>
       rfl
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem lt_bsup_of_ne_bsup {o : Ordinal.{u}} {f : ∀ a < o, Ordinal.{max u v}} :
     (∀ i h, f i h ≠ bsup.{_, v} o f) ↔ ∀ i h, f i h < bsup.{_, v} o f :=
   ⟨fun hf _ _ => lt_of_le_of_ne (le_bsup _ _ _) (hf _ _), fun hf _ _ => ne_of_lt (hf _ _)⟩
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_not_succ_of_ne_bsup {o : Ordinal.{u}} {f : ∀ a < o, Ordinal.{max u v}}
     (hf : ∀ {i : Ordinal} (h : i < o), f i h ≠ bsup.{_, v} o f) (a) :
@@ -478,7 +440,6 @@ theorem bsup_not_succ_of_ne_bsup {o : Ordinal.{u}} {f : ∀ a < o, Ordinal.{max 
   rw [← iSup_eq_bsup] at *
   exact succ_lt_iSup_of_ne_iSup fun i => hf _
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_eq_zero_iff {o} {f : ∀ a < o, Ordinal} : bsup o f = 0 ↔ ∀ i hi, f i hi = 0 := by
   refine
@@ -487,36 +448,30 @@ theorem bsup_eq_zero_iff {o} {f : ∀ a < o, Ordinal} : bsup o f = 0 ↔ ∀ i h
   rw [← nonpos_iff_eq_zero, ← h]
   exact le_bsup f i hi
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem lt_bsup_of_limit {o : Ordinal} {f : ∀ a < o, Ordinal}
     (hf : ∀ {a a'} (ha : a < o) (ha' : a' < o), a < a' → f a ha < f a' ha')
     (ho : ∀ a < o, succ a < o) (i h) : f i h < bsup o f :=
   (hf _ _ <| lt_succ i).trans_le (le_bsup f (succ i) <| ho _ h)
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_succ_of_mono {o : Ordinal} {f : ∀ a < succ o, Ordinal}
     (hf : ∀ {i j} (hi hj), i ≤ j → f i hi ≤ f j hj) : bsup _ f = f o (lt_succ o) :=
   le_antisymm (bsup_le fun _i hi => hf _ _ <| le_of_lt_succ hi) (le_bsup _ _ _)
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_zero (f : ∀ a < (0 : Ordinal), Ordinal) : bsup 0 f = 0 :=
   bsup_eq_zero_iff.2 fun _i hi => (not_lt_zero hi).elim
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_const {o : Ordinal.{u}} (ho : o ≠ 0) (a : Ordinal.{max u v}) :
     (bsup.{_, v} o fun _ _ => a) = a :=
   le_antisymm (bsup_le fun _ _ => le_rfl) (le_bsup _ 0 (pos_iff_ne_zero.2 ho))
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_one (f : ∀ a < (1 : Ordinal), Ordinal) : bsup 1 f = f 0 zero_lt_one := by
   simp_rw [← iSup_eq_bsup, ciSup_unique, familyOfBFamily, familyOfBFamily', typein_one_toType]
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_le_of_brange_subset {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o', Ordinal}
     (h : brange o f ⊆ brange o' g) : bsup.{u, max v w} o f ≤ bsup.{v, max u w} o' g :=
@@ -525,13 +480,11 @@ theorem bsup_le_of_brange_subset {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o'
     rw [← hj']
     apply le_bsup
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem bsup_eq_of_brange_eq {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o', Ordinal}
     (h : brange o f = brange o' g) : bsup.{u, max v w} o f = bsup.{v, max u w} o' g :=
   (bsup_le_of_brange_subset.{u, v, w} h.le).antisymm (bsup_le_of_brange_subset.{v, u, w} h.ge)
 
-set_option linter.deprecated false in
 @[deprecated "bsup is deprecated" (since := "2026-04-05")]
 theorem iSup_Iio_eq_bsup {o} {f : ∀ a < o, Ordinal} : ⨆ a : Iio o, f a.1 a.2 = bsup o f := by
   simp_rw [Iio, bsup, iSup, range_familyOfBFamily, brange, range, Subtype.exists, mem_setOf]
@@ -545,42 +498,34 @@ section lsub
 def lsub {ι : Type u} (f : ι → Ordinal.{max u v}) : Ordinal :=
   iSup (succ ∘ f)
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem iSup_eq_lsub {ι} (f : ι → Ordinal) : iSup (succ ∘ f) = lsub f :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_le_iff {ι} {f : ι → Ordinal} {a} : lsub f ≤ a ↔ ∀ i, f i < a :=
   Ordinal.iSup_add_one_le_iff
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_le {ι} {f : ι → Ordinal} {a} : (∀ i, f i < a) → lsub f ≤ a :=
   lsub_le_iff.2
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lt_lsub {ι} (f : ι → Ordinal) (i) : f i < lsub f :=
   Ordinal.lt_iSup_add_one f i
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lt_lsub_iff {ι} {f : ι → Ordinal} {a} : a < lsub f ↔ ∃ i, a ≤ f i := by
   simpa only [not_forall, not_lt, not_le] using not_congr lsub_le_iff
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem iSup_le_lsub {ι} (f : ι → Ordinal) : iSup f ≤ lsub f :=
   Ordinal.iSup_le fun i => (lt_lsub f i).le
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_le_succ_iSup {ι} (f : ι → Ordinal) : lsub f ≤ succ (iSup f) :=
   lsub_le fun i => lt_succ_iff.2 (Ordinal.le_iSup f i)
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem iSup_eq_lsub_or_succ_iSup_eq_lsub {ι} (f : ι → Ordinal) :
     iSup f = lsub f ∨ succ (iSup f) = lsub f := by
@@ -588,7 +533,6 @@ theorem iSup_eq_lsub_or_succ_iSup_eq_lsub {ι} (f : ι → Ordinal) :
   · exact Or.inl h
   · exact Or.inr ((succ_le_of_lt h).antisymm (lsub_le_succ_iSup f))
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem succ_iSup_le_lsub_iff {ι} (f : ι → Ordinal) :
     succ (iSup f) ≤ lsub f ↔ ∃ i, f i = iSup f := by
@@ -600,13 +544,11 @@ theorem succ_iSup_le_lsub_iff {ι} (f : ι → Ordinal) :
   rw [succ_le_iff, ← hf]
   exact lt_lsub _ _
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem succ_iSup_eq_lsub_iff {ι} (f : ι → Ordinal) :
     succ (iSup f) = lsub f ↔ ∃ i, f i = iSup f :=
   (lsub_le_succ_iSup f).ge_iff_eq'.symm.trans (succ_iSup_le_lsub_iff f)
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem iSup_eq_lsub_iff {ι} (f : ι → Ordinal) :
     iSup f = lsub f ↔ ∀ a < lsub f, succ a < lsub f := by
@@ -623,7 +565,6 @@ theorem iSup_eq_lsub_iff {ι} (f : ι → Ordinal) :
   rw [heq] at this
   exact this.false
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem iSup_eq_lsub_iff_lt_iSup {ι} (f : ι → Ordinal) :
     iSup f = lsub f ↔ ∀ i, f i < iSup f :=
@@ -631,18 +572,15 @@ theorem iSup_eq_lsub_iff_lt_iSup {ι} (f : ι → Ordinal) :
     rw [h]
     apply lt_lsub, fun h => le_antisymm (iSup_le_lsub f) (lsub_le h)⟩
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_empty {ι} [h : IsEmpty ι] (f : ι → Ordinal) : lsub f = 0 := by
   rw [← nonpos_iff_eq_zero, lsub_le_iff]
   exact h.elim
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_pos {ι} [h : Nonempty ι] (f : ι → Ordinal) : 0 < lsub f :=
   h.elim fun i => (lt_lsub f i).pos
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_eq_zero_iff {ι} (f : ι → Ordinal) :
     lsub.{_, v} f = 0 ↔ IsEmpty ι := by
@@ -651,47 +589,39 @@ theorem lsub_eq_zero_iff {ι} (f : ι → Ordinal) :
   rw [h] at this
   exact this.false
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_const {ι} [Nonempty ι] (o : Ordinal) : (lsub fun _ : ι => o) = succ o :=
   ciSup_const
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_unique {ι} [Unique ι] (f : ι → Ordinal) : lsub f = succ (f default) :=
   ciSup_unique
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_le_of_range_subset {ι ι'} {f : ι → Ordinal} {g : ι' → Ordinal}
     (h : Set.range f ⊆ Set.range g) : lsub.{u, max v w} f ≤ lsub.{v, max u w} g :=
   csSup_le_csSup' bddAbove_of_small (by convert! Set.image_mono h <;> apply Set.range_comp)
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_eq_of_range_eq {ι ι'} {f : ι → Ordinal} {g : ι' → Ordinal}
     (h : Set.range f = Set.range g) : lsub.{u, max v w} f = lsub.{v, max u w} g :=
   (lsub_le_of_range_subset.{u, v, w} h.le).antisymm (lsub_le_of_range_subset.{v, u, w} h.ge)
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_sum {α : Type u} {β : Type v} (f : α ⊕ β → Ordinal) :
     lsub.{max u v, w} f =
       max (lsub.{u, max v w} fun a => f (Sum.inl a)) (lsub.{v, max u w} fun b => f (Sum.inr b)) :=
   iSup_sum _
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_notMem_range {ι} (f : ι → Ordinal) :
     lsub f ∉ Set.range f := fun ⟨i, h⟩ =>
   h.not_lt (lt_lsub f i)
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem nonempty_compl_range {ι : Type u} (f : ι → Ordinal.{max u v}) : (Set.range f)ᶜ.Nonempty :=
   ⟨_, lsub_notMem_range f⟩
 
-set_option linter.deprecated false in
 @[deprecated "lsub is deprecated" (since := "2026-03-27")]
 theorem lsub_typein (o : Ordinal) : lsub.{u, u} (typein (α := o.ToType) (· < ·)) = o :=
   (lsub_le.{u, u} typein_lt_self).antisymm
@@ -700,7 +630,6 @@ theorem lsub_typein (o : Ordinal) : lsub.{u, u} (typein (α := o.ToType) (· < �
       have h := h.trans_eq (type_toType o).symm
       simpa [typein_enum] using lt_lsub.{u, u} (typein (· < ·)) (enum (· < ·) ⟨_, h⟩))
 
-set_option linter.deprecated false in
 @[deprecated IsSuccPrelimit.sSup_Iio (since := "2026-03-27")]
 theorem iSup_typein_limit {o : Ordinal.{u}} (ho : ∀ a, a < o → succ a < o) :
     iSup (typein ((· < ·) : o.ToType → o.ToType → Prop)) = o := by
@@ -719,26 +648,22 @@ end lsub
 
 section blsub
 
-set_option linter.deprecated false in
 /-- The least strict upper bound of a family of ordinals indexed by the set of ordinals less than
 some `o : Ordinal.{u}`. -/
 @[deprecated "write `⨆ i : Iio o, f i + 1` instead." (since := "2026-03-23")]
 def blsub (o : Ordinal.{u}) (f : ∀ a < o, Ordinal.{max u v}) : Ordinal.{max u v} :=
   bsup.{_, v} o fun a ha => succ (f a ha)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem bsup_eq_blsub (o : Ordinal.{u}) (f : ∀ a < o, Ordinal.{max u v}) :
     (bsup.{_, v} o fun a ha => succ (f a ha)) = blsub.{_, v} o f :=
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem lsub_eq_blsub' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {o} (ho : type r = o)
     (f : ∀ a < o, Ordinal) : lsub (familyOfBFamily' r ho f) = blsub o f :=
   iSup'_eq_bsup r ho fun a ha => succ (f a ha)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem lsub_eq_lsub {ι ι' : Type u} (r : ι → ι → Prop) (r' : ι' → ι' → Prop) [IsWellOrder ι r]
     [IsWellOrder ι' r'] {o} (ho : type r = o) (ho' : type r' = o)
@@ -746,81 +671,68 @@ theorem lsub_eq_lsub {ι ι' : Type u} (r : ι → ι → Prop) (r' : ι' → ι
     lsub.{_, v} (familyOfBFamily' r ho f) = lsub.{_, v} (familyOfBFamily' r' ho' f) := by
   rw [lsub_eq_blsub', lsub_eq_blsub']
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem lsub_eq_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     lsub.{_, v} (familyOfBFamily o f) = blsub.{_, v} o f :=
   lsub_eq_blsub' _ _ _
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_eq_lsub' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r]
     (f : ι → Ordinal.{max u v}) : blsub.{_, v} _ (bfamilyOfFamily' r f) = lsub.{_, v} f :=
   bsup'_eq_iSup r (succ ∘ f)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_eq_blsub {ι : Type u} (r r' : ι → ι → Prop) [IsWellOrder ι r] [IsWellOrder ι r']
     (f : ι → Ordinal.{max u v}) :
     blsub.{_, v} _ (bfamilyOfFamily' r f) = blsub.{_, v} _ (bfamilyOfFamily' r' f) := by
   rw [blsub_eq_lsub', blsub_eq_lsub']
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_eq_lsub {ι : Type u} (f : ι → Ordinal.{max u v}) :
     blsub.{_, v} _ (bfamilyOfFamily f) = lsub.{_, v} f :=
   blsub_eq_lsub' _ _
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_congr {o₁ o₂ : Ordinal.{u}} (f : ∀ a < o₁, Ordinal.{max u v}) (ho : o₁ = o₂) :
     blsub.{_, v} o₁ f = blsub.{_, v} o₂ fun a h => f a (h.trans_eq ho.symm) := by
   subst ho
   rfl
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_le_iff {o : Ordinal.{u}} {f : ∀ a < o, Ordinal.{max u v}} {a} :
     blsub.{_, v} o f ≤ a ↔ ∀ i h, f i h < a := by
   convert! bsup_le_iff.{_, v} (f := fun a ha => succ (f a ha)) (a := a) using 2
   simp_rw [succ_le_iff]
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_le {o : Ordinal} {f : ∀ b < o, Ordinal} {a} : (∀ i h, f i h < a) → blsub o f ≤ a :=
   blsub_le_iff.2
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem lt_blsub {o} (f : ∀ a < o, Ordinal) (i h) : f i h < blsub o f :=
   blsub_le_iff.1 le_rfl _ _
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem lt_blsub_iff {o : Ordinal.{u}} {f : ∀ b < o, Ordinal.{max u v}} {a} :
     a < blsub.{_, v} o f ↔ ∃ i hi, a ≤ f i hi := by
   simpa only [not_forall, not_lt, not_le] using not_congr (@blsub_le_iff.{_, v} _ f a)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem bsup_le_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     bsup.{_, v} o f ≤ blsub.{_, v} o f :=
   bsup_le fun i h => (lt_blsub f i h).le
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_le_bsup_succ {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     blsub.{_, v} o f ≤ succ (bsup.{_, v} o f) :=
   blsub_le fun i h => lt_succ_iff.2 (le_bsup f i h)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem bsup_eq_blsub_or_succ_bsup_eq_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     bsup.{_, v} o f = blsub.{_, v} o f ∨ succ (bsup.{_, v} o f) = blsub.{_, v} o f := by
   rw [← iSup_eq_bsup, ← lsub_eq_blsub]
   exact iSup_eq_lsub_or_succ_iSup_eq_lsub _
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem bsup_succ_le_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     succ (bsup.{_, v} o f) ≤ blsub.{_, v} o f ↔ ∃ i hi, f i hi = bsup.{_, v} o f := by
@@ -833,20 +745,17 @@ theorem bsup_succ_le_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) 
   rw [succ_le_iff, ← hf]
   exact lt_blsub _ _ _
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem bsup_succ_eq_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     succ (bsup.{_, v} o f) = blsub.{_, v} o f ↔ ∃ i hi, f i hi = bsup.{_, v} o f :=
   (blsub_le_bsup_succ f).ge_iff_eq'.symm.trans (bsup_succ_le_blsub f)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem bsup_eq_blsub_iff_succ {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     bsup.{_, v} o f = blsub.{_, v} o f ↔ ∀ a < blsub.{_, v} o f, succ a < blsub.{_, v} o f := by
   rw [← iSup_eq_bsup, ← lsub_eq_blsub]
   apply iSup_eq_lsub_iff
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem bsup_eq_blsub_iff_lt_bsup {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     bsup.{_, v} o f = blsub.{_, v} o f ↔ ∀ i hi, f i hi < bsup.{_, v} o f :=
@@ -854,7 +763,6 @@ theorem bsup_eq_blsub_iff_lt_bsup {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max
     rw [h]
     apply lt_blsub, fun h => le_antisymm (bsup_le_blsub f) (blsub_le h)⟩
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem bsup_eq_blsub_of_lt_succ_limit {o : Ordinal.{u}} (ho : IsSuccLimit o)
     {f : ∀ a < o, Ordinal.{max u v}} (hf : ∀ a ha, f a ha < f (succ a) (ho.succ_lt ha)) :
@@ -862,28 +770,23 @@ theorem bsup_eq_blsub_of_lt_succ_limit {o : Ordinal.{u}} (ho : IsSuccLimit o)
   rw [bsup_eq_blsub_iff_lt_bsup]
   exact fun i hi => (hf i hi).trans_le (le_bsup f _ _)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_succ_of_mono {o : Ordinal.{u}} {f : ∀ a < succ o, Ordinal.{max u v}}
     (hf : ∀ {i j} (hi hj), i ≤ j → f i hi ≤ f j hj) : blsub.{_, v} _ f = succ (f o (lt_succ o)) :=
   bsup_succ_of_mono fun {_ _} hi hj h => succ_le_succ (hf hi hj h)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_eq_zero_iff {o} {f : ∀ a < o, Ordinal} : blsub o f = 0 ↔ o = 0 := by
   rw [← lsub_eq_blsub, lsub_eq_zero_iff]
   exact isEmpty_toType_iff
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_zero (f : ∀ a < (0 : Ordinal), Ordinal) : blsub 0 f = 0 := by rw [blsub_eq_zero_iff]
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_pos {o : Ordinal} (ho : 0 < o) (f : ∀ a < o, Ordinal) : 0 < blsub o f :=
   (lt_blsub f 0 ho).pos
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_type {α : Type u} (r : α → α → Prop) [IsWellOrder α r]
     (f : ∀ a < type r, Ordinal.{max u v}) :
@@ -892,38 +795,31 @@ theorem blsub_type {α : Type u} (r : α → α → Prop) [IsWellOrder α r]
     rw [blsub_le_iff, lsub_le_iff]
     exact ⟨fun H b => H _ _, fun H i h => by simpa only [typein_enum] using H (enum r ⟨i, h⟩)⟩
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_const {o : Ordinal} (ho : o ≠ 0) (a : Ordinal) :
     (blsub.{u, v} o fun _ _ => a) = succ a :=
   bsup_const.{u, v} ho (succ a)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_one (f : ∀ a < (1 : Ordinal), Ordinal) : blsub 1 f = succ (f 0 zero_lt_one) :=
   bsup_one _
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_id : ∀ o, (blsub.{u, u} o fun x _ => x) = o :=
   lsub_typein
 
-set_option linter.deprecated false in
 @[deprecated IsSuccPrelimit.sSup_Iio (since := "2026-03-23")]
 theorem bsup_id_limit {o : Ordinal} : (∀ a < o, succ a < o) → (bsup.{u, u} o fun x _ => x) = o :=
   iSup_typein_limit
 
-set_option linter.deprecated false in
 @[deprecated csSup_Iic (since := "2026-03-23")]
 theorem bsup_id_add_one (o) : (bsup.{u, u} (o + 1) fun x _ => x) = o :=
   iSup_typein_succ
 
-set_option linter.deprecated false in
 @[deprecated csSup_Iic (since := "2026-03-23")]
 theorem bsup_id_succ (o) : (bsup.{u, u} (succ o) fun x _ => x) = o :=
   iSup_typein_succ
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_le_of_brange_subset {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o', Ordinal}
     (h : brange o f ⊆ brange o' g) : blsub.{u, max v w} o f ≤ blsub.{v, max u w} o' g :=
@@ -932,14 +828,12 @@ theorem blsub_le_of_brange_subset {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o
     simp_rw [← hc'] at hb'
     exact ⟨c, hc, hb'⟩
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_eq_of_brange_eq {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o', Ordinal}
     (h : { o | ∃ i hi, f i hi = o } = { o | ∃ i hi, g i hi = o }) :
     blsub.{u, max v w} o f = blsub.{v, max u w} o' g :=
   (blsub_le_of_brange_subset.{u, v, w} h.le).antisymm (blsub_le_of_brange_subset.{v, u, w} h.ge)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem bsup_comp {o o' : Ordinal.{max u v}} {f : ∀ a < o, Ordinal.{max u v w}}
     (hf : ∀ {i j} (hi) (hj), i ≤ j → f i hi ≤ f j hj) {g : ∀ a < o', Ordinal.{max u v}}
@@ -951,7 +845,6 @@ theorem bsup_comp {o o' : Ordinal.{max u v}} {f : ∀ a < o, Ordinal.{max u v w}
     rcases hi with ⟨j, hj, hj'⟩
     exact (hf _ _ hj').trans (le_bsup _ _ _)
 
-set_option linter.deprecated false in
 @[deprecated "blsub is deprecated" (since := "2026-03-23")]
 theorem blsub_comp {o o' : Ordinal.{max u v}} {f : ∀ a < o, Ordinal.{max u v w}}
     (hf : ∀ {i j} (hi) (hj), i ≤ j → f i hi ≤ f j hj) {g : ∀ a < o', Ordinal.{max u v}}
@@ -960,20 +853,17 @@ theorem blsub_comp {o o' : Ordinal.{max u v}} {f : ∀ a < o, Ordinal.{max u v w
   @bsup_comp.{u, v, w} o _ (fun a ha => succ (f a ha))
     (fun {_ _} _ _ h => succ_le_succ_iff.2 (hf _ _ h)) g hg
 
-set_option linter.deprecated false in
 @[deprecated IsNormal.apply_of_isSuccLimit (since := "2026-03-23")]
 theorem IsNormal.bsup_eq {f : Ordinal.{u} → Ordinal.{max u v}} (H : IsNormal f) {o : Ordinal.{u}}
     (h : IsSuccLimit o) : (Ordinal.bsup.{_, v} o fun x _ => f x) = f o := by
   rw [← IsNormal.bsup.{u, u, v} H (fun x _ => x) h.ne_bot, bsup_id_limit fun _ ↦ h.succ_lt]
 
-set_option linter.deprecated false in
 @[deprecated IsNormal.apply_of_isSuccLimit (since := "2026-03-23")]
 theorem IsNormal.blsub_eq {f : Ordinal.{u} → Ordinal.{max u v}} (H : IsNormal f) {o : Ordinal.{u}}
     (h : IsSuccLimit o) : (blsub.{_, v} o fun x _ => f x) = f o := by
   rw [← IsNormal.bsup_eq.{u, v} H h, bsup_eq_blsub_of_lt_succ_limit h]
   exact fun a _ => H.strictMono (lt_succ a)
 
-set_option linter.deprecated false in
 @[deprecated isNormal_iff (since := "2026-03-23")]
 theorem isNormal_iff_lt_succ_and_bsup_eq {f : Ordinal.{u} → Ordinal.{max u v}} :
     IsNormal f ↔ (∀ a, f a < f (succ a)) ∧
@@ -983,7 +873,6 @@ theorem isNormal_iff_lt_succ_and_bsup_eq {f : Ordinal.{u} → Ordinal.{max u v}}
       rw [← h₂ _ ho]
       simpa [IsLUB, upperBounds, lowerBounds, IsLeast, bsup_le_iff] using le_bsup _⟩
 
-set_option linter.deprecated false in
 @[deprecated isNormal_iff (since := "2026-03-23")]
 theorem isNormal_iff_lt_succ_and_blsub_eq {f : Ordinal.{u} → Ordinal.{max u v}} :
     IsNormal f ↔ (∀ a, f a < f (succ a)) ∧

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -392,18 +392,15 @@ theorem nfp_zero_left (a) : nfp 0 a = a := by
   · rw [Function.iterate_succ']
     simp
 
-set_option linter.deprecated false in
 @[deprecated "do not depend on the junk values of `nfp`" (since := "2026-05-13")]
 theorem nfp_zero : nfp 0 = id := by
   ext
   exact nfp_zero_left _
 
-set_option linter.deprecated false in
 @[deprecated "do not depend on the junk values of `deriv`" (since := "2026-05-13")]
 theorem deriv_zero : deriv 0 = id :=
   deriv_eq_id_of_nfp_eq_id nfp_zero
 
-set_option linter.deprecated false in
 @[deprecated "do not depend on the junk values of `deriv`" (since := "2026-05-13")]
 theorem deriv_zero_left (a) : deriv 0 a = a := by
   rw [deriv_zero, id_eq]

--- a/Mathlib/SetTheory/Ordinal/FundamentalSequence.lean
+++ b/Mathlib/SetTheory/Ordinal/FundamentalSequence.lean
@@ -121,7 +121,6 @@ theorem exists_isFundamentalSeq (ha : o.cof.ord = a) : ∃ f : Iio a → Iio o, 
 
 /-! ### Deprecated material -/
 
-set_option linter.deprecated false in
 /-- A fundamental sequence for `a` is an increasing sequence of length `o = cof a` that converges at
     `a`. We provide `o` explicitly in order to avoid type rewrites. -/
 @[deprecated IsFundamentalSeq (since := "2026-03-23")]
@@ -132,25 +131,21 @@ namespace IsFundamentalSequence
 
 variable {a o : Ordinal.{u}} {f : ∀ b < o, Ordinal.{u}}
 
-set_option linter.deprecated false in
 @[deprecated IsFundamentalSeq.ord_cof (since := "2026-03-23")]
 protected theorem cof_eq (hf : IsFundamentalSequence a o f) : a.cof.ord = o :=
   hf.1.antisymm' <| by
     rw [← hf.2.2]
     exact (ord_le_ord.2 (cof_blsub_le f)).trans (ord_card_le o)
 
-set_option linter.deprecated false in
 @[deprecated IsFundamentalSeq.strictMono (since := "2026-03-23")]
 protected theorem strict_mono (hf : IsFundamentalSequence a o f) {i j} :
     ∀ hi hj, i < j → f i hi < f j hj :=
   hf.2.1
 
-set_option linter.deprecated false in
 @[deprecated IsFundamentalSeq.iSup_add_one_eq (since := "2026-03-23")]
 theorem blsub_eq (hf : IsFundamentalSequence a o f) : blsub.{u, u} o f = a :=
   hf.2.2
 
-set_option linter.deprecated false in
 @[deprecated IsFundamentalSeq (since := "2026-03-23")]
 theorem ord_cof (hf : IsFundamentalSequence a o f) :
     IsFundamentalSequence a a.cof.ord fun i hi => f i (hi.trans_le (by rw [hf.cof_eq])) := by
@@ -158,17 +153,14 @@ theorem ord_cof (hf : IsFundamentalSequence a o f) :
   subst H
   exact hf
 
-set_option linter.deprecated false in
 @[deprecated IsFundamentalSeq.id (since := "2026-03-23")]
 theorem id_of_le_cof (h : o ≤ o.cof.ord) : IsFundamentalSequence o o fun a _ => a :=
   ⟨h, @fun _ _ _ _ => id, blsub_id o⟩
 
-set_option linter.deprecated false in
 @[deprecated IsFundamentalSeq.zero (since := "2026-03-23")]
 protected theorem zero {f : ∀ b < (0 : Ordinal), Ordinal} : IsFundamentalSequence 0 0 f :=
   ⟨by rw [cof_zero, ord_zero], @fun i _ hi => (not_lt_zero hi).elim, blsub_zero f⟩
 
-set_option linter.deprecated false in
 @[deprecated IsFundamentalSeq.add_one (since := "2026-03-23")]
 protected theorem succ : IsFundamentalSequence (succ o) 1 fun _ _ => o := by
   refine ⟨?_, @fun i j hi hj h => ?_, blsub_const Ordinal.one_ne_zero o⟩
@@ -177,7 +169,6 @@ protected theorem succ : IsFundamentalSequence (succ o) 1 fun _ _ => o := by
     rw [hi, hj] at h
     exact h.false.elim
 
-set_option linter.deprecated false in
 @[deprecated IsFundamentalSeq.strictMono (since := "2026-03-23")]
 protected theorem monotone (hf : IsFundamentalSequence a o f) {i j : Ordinal} (hi : i < o)
     (hj : j < o) (hij : i ≤ j) : f i hi ≤ f j hj := by
@@ -185,7 +176,6 @@ protected theorem monotone (hf : IsFundamentalSequence a o f) {i j : Ordinal} (h
   · exact (hf.2.1 hi hj hij).le
   · rfl
 
-set_option linter.deprecated false in
 @[deprecated IsFundamentalSeq.comp (since := "2026-03-23")]
 theorem trans {a o o' : Ordinal.{u}} {f : ∀ b < o, Ordinal.{u}} (hf : IsFundamentalSequence a o f)
     {g : ∀ b < o', Ordinal.{u}} (hg : IsFundamentalSequence o o' g) :
@@ -198,7 +188,6 @@ theorem trans {a o o' : Ordinal.{u}} {f : ∀ b < o, Ordinal.{u}} (hf : IsFundam
     · exact hf.2.2
     · exact hg.2.2
 
-set_option linter.deprecated false in
 @[deprecated IsFundamentalSeq (since := "2026-03-23")]
 protected theorem lt {a o : Ordinal} {s : Π p < o, Ordinal}
     (h : IsFundamentalSequence a o s) {p : Ordinal} (hp : p < o) : s p hp < a :=
@@ -206,7 +195,6 @@ protected theorem lt {a o : Ordinal} {s : Π p < o, Ordinal}
 
 end IsFundamentalSequence
 
-set_option linter.deprecated false in
 /-- Every ordinal has a fundamental sequence. -/
 @[deprecated exists_isFundamentalSeq (since := "2026-03-23")]
 theorem exists_fundamental_sequence (a : Ordinal.{u}) :

--- a/Mathlib/SetTheory/Ordinal/Topology.lean
+++ b/Mathlib/SetTheory/Ordinal/Topology.lean
@@ -97,7 +97,6 @@ theorem mem_iff_iSup_of_isClosed (hs : IsClosed s) :
       (∀ i, f i ∈ s) ∧ ⨆ i, f i = a := by
   rw [← mem_closure_iff_iSup, hs.closure_eq]
 
-set_option linter.deprecated false in
 @[deprecated mem_closure_iff_iSup (since := "2026-04-05")]
 theorem mem_closure_iff_bsup :
     a ∈ closure s ↔
@@ -110,7 +109,6 @@ theorem mem_closure_iff_bsup :
   · rintro ⟨o, ho, f, hf, rfl⟩
     exact ⟨_, by simpa, familyOfBFamily _ f, fun i ↦ hf .., iSup_eq_bsup f⟩
 
-set_option linter.deprecated false in
 @[deprecated mem_closure_iff_iSup (since := "2026-04-05")]
 theorem mem_closed_iff_bsup (hs : IsClosed s) :
     a ∈ s ↔
@@ -127,7 +125,6 @@ theorem isClosed_iff_iSup :
   rcases mem_closure_iff_iSup.1 hx with ⟨ι, hι, f, hf, rfl⟩
   exact h hι f hf
 
-set_option linter.deprecated false in
 @[deprecated isClosed_iff_iSup (since := "2026-04-05")]
 theorem isClosed_iff_bsup :
     IsClosed s ↔

--- a/Mathlib/Topology/Category/TopCat/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Basic.lean
@@ -161,7 +161,6 @@ def Hom.equivContinuousMap (X Y : TopCat.{u}) : (X ⟶ Y) ≃ C(X, Y) where
   toFun f := f.hom
   invFun f := ofHom f
 
-set_option linter.deprecated false in
 /--
 Replace a function coercion for a morphism `TopCat.of X ⟶ TopCat.of Y` with the definitionally
 equal function coercion for a continuous map `C(X, Y)`.

--- a/Mathlib/Topology/Compactification/OnePoint/ProjectiveLine.lean
+++ b/Mathlib/Topology/Compactification/OnePoint/ProjectiveLine.lean
@@ -65,7 +65,6 @@ lemma Matrix.fin_two_smul_prod (g : Matrix (Fin 2) (Fin 2) R) (v : R × R) :
     g • v = (g 0 0 * v.1 + g 0 1 * v.2, g 1 0 * v.1 + g 1 1 * v.2) := by
   simp [Equiv.smul_def, smul_eq_mulVec, Matrix.mulVec_eq_sum]
 
-set_option linter.deprecated false in
 @[deprecated Matrix.GeneralLinearGroup.fin_two_smul (since := "2026-04-19")]
 lemma Matrix.GeneralLinearGroup.fin_two_smul_prod {R : Type*} [CommRing R]
     (g : GL (Fin 2) R) (v : R × R) :

--- a/Mathlib/Util/MemoFix.lean
+++ b/Mathlib/Util/MemoFix.lean
@@ -18,7 +18,6 @@ variable {α β : Type}
 @[noinline, deprecated "deprecated without replacement" (since := "2026-01-24")]
 def injectIntoBaseIO {α : Type} (a : α) : BaseIO α := pure a
 
-set_option linter.deprecated false in
 @[deprecated "deprecated without replacement" (since := "2026-01-24")]
 unsafe def memoFixImpl [Nonempty β] (f : (α → β) → (α → β)) : α → β := unsafeBaseIO do
   let cache : IO.Ref (Lean.PtrMap α β) ← ST.mkRef Lean.mkPtrMap


### PR DESCRIPTION
Since v4.31.rc0, the "deprecated declaration" linter warning is automatically silenced when a deprecated declaration is used _inside another one_. Hence most of the 400 manual disablements of this linter in mathlib can be removed.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
