### PR TITLE
chore(AlgebraicTopology): refactor proofs where `grind?` fails

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplexCategory/DeltaZeroIter.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/DeltaZeroIter.lean
@@ -119,7 +119,7 @@ def σ₀Iter (i : ℕ) {n m : ℕ} (hi : n + i = m := by lia) : ⦋m⦌ ⟶ ⦋
   Hom.mk
     { toFun j :=
         if j.val < i then 0 else ⟨j.val - i, by lia⟩
-      monotone' _ _ _ := by grind [Fin.zero_le] }
+      monotone' a _ _ := by grind [Fin.zero_le] }
 
 lemma σ₀Iter_coe_eq_of_lt (i : ℕ) {n m : ℕ}
     (j : Fin (m + 1)) (hi : n + i = m := by lia) (hj : j.val < i := by grind) :

--- a/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/NormalForms.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/NormalForms.lean
@@ -163,7 +163,6 @@ lemma simplicialInsert_length (a : ℕ) (L : List ℕ) :
     (simplicialInsert a L).length = L.length + 1 := by
   induction L generalizing a <;> grind
 
-set_option linter.tacticAnalysis.verifyGrindOnly true in
 /-- `simplicialInsert` preserves admissibility -/
 theorem simplicialInsert_isAdmissible (L : List ℕ) (hL : IsAdmissible (m + 1) L) (j : ℕ)
     (hj : j ≤ m) :

--- a/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/NormalForms.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/NormalForms.lean
@@ -163,13 +163,17 @@ lemma simplicialInsert_length (a : ℕ) (L : List ℕ) :
     (simplicialInsert a L).length = L.length + 1 := by
   induction L generalizing a <;> grind
 
+set_option linter.tacticAnalysis.verifyGrindOnly true in
 /-- `simplicialInsert` preserves admissibility -/
 theorem simplicialInsert_isAdmissible (L : List ℕ) (hL : IsAdmissible (m + 1) L) (j : ℕ)
     (hj : j ≤ m) :
     IsAdmissible m <| simplicialInsert j L := by
   induction L generalizing j m with
   | nil => exact IsAdmissible.singleton hj
-  | cons a L h_rec => cases L <;> grind
+  | cons a L h_rec =>
+    cases L
+    · grind
+    · grind only [simplicialInsert, = isAdmissible_cons_cons_iff]
 
 end AdmissibleLists
 
@@ -226,8 +230,9 @@ def simplicialEvalσ (L : List ℕ) : ℕ → ℕ :=
 lemma simplicialEvalσ_of_le_mem (j : ℕ) (hj : ∀ k ∈ L, j ≤ k) : simplicialEvalσ L j = j := by
   induction L with | nil => grind | cons _ _ _ => simp only [List.forall_mem_cons] at hj; grind
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 lemma simplicialEvalσ_monotone (L : List ℕ) : Monotone (simplicialEvalσ L) := by
-  induction L <;> grind [Monotone]
+  induction L <;> grind only [Monotone, simplicialEvalσ]
 
 variable {m}
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NonDegenerateSimplices.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NonDegenerateSimplices.lean
@@ -67,9 +67,10 @@ lemma induction_mk {motive : X.N → Sort*}
     (mk : ∀ (n : ℕ) (x : X.nonDegenerate n), motive (mk x.1 x.2)) {n : ℕ} (s : X.nonDegenerate n) :
   induction (motive := motive) mk (N.mk s.val s.property) = mk n s := rfl
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 lemma ext_iff (x y : X.N) :
     x = y ↔ x.toS = y.toS := by
-  grind [cases SSet.N]
+  grind only [cases SSet.N]
 
 instance : Preorder X.N := Preorder.lift toS
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NonDegenerateSimplicesSubcomplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NonDegenerateSimplicesSubcomplex.lean
@@ -53,9 +53,10 @@ lemma mk_surjective (s : A.N) :
       (hx' : x ∉ A.obj _), s = mk x hx hx' :=
   ⟨s.dim, s.simplex, s.nonDegenerate, s.notMem, rfl⟩
 
+set_option linter.tacticAnalysis.verifyGrindOnly false in
 lemma ext_iff (x y : A.N) :
     x = y ↔ x.toN = y.toN := by
-  grind [cases SSet.Subcomplex.N]
+  grind only [cases SSet.Subcomplex.N]
 
 variable (A) in
 @[elab_as_elim]


### PR DESCRIPTION
These are sources of technical debt as now reported in the [weekly linting report](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Weekly.20linting.20log/with/544658968). The idea is that a successful grind proof can fail to report the theorems it used via grind?, which means that if these proofs break across toolchains that it becomes significantly harder to repair.

---

- [ ] depends on: #39808

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
