### PR TITLE
[Merged by Bors] - refactor(RingTheory/Coalgebra): make the indexing type of `Repr` an argument

### DIFF
--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -89,6 +89,9 @@ namespace Coalgebra
 variable {R : Type u} {A : Type v} {ι : Type*} {κ Λ : ι → Type*}
 variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A] {a : A}
 
+@[deprecated "The indexing type is now unbundled" (since := "2026-05-31")]
+protected abbrev Repr.ι (repr : Repr R a ι) : Type _ := ι
+
 @[simp]
 theorem coassoc_apply (a : A) :
     TensorProduct.assoc R A A A (comul.rTensor A (comul a)) = comul.lTensor A (comul a) :=

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -90,8 +90,8 @@ variable {R : Type u} {A : Type v} {ι : Type*} {κ Λ : ι → Type*}
 variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A] {a : A}
 
 /-- The indexing type of a representation of `comul a` -/
-@[nolint unusedArgs, deprecated "The indexing type is now unbundled" (since := "2026-05-31")]
-protected abbrev Repr.ι (repr : Repr R a ι) : Type _ := ι
+@[nolint unusedArguments, deprecated "The indexing type is now unbundled" (since := "2026-05-31")]
+protected abbrev Repr.ι (_repr : Repr R a ι) : Type _ := ι
 
 @[simp]
 theorem coassoc_apply (a : A) :

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -48,9 +48,7 @@ A representation of an element `a` of a coalgebra `A` is a finite sum of pure te
 that is equal to `comul a`.
 -/
 structure Coalgebra.Repr (R : Type u) {A : Type v}
-    [CommSemiring R] [AddCommMonoid A] [Module R A] [CoalgebraStruct R A] (a : A) where
-  /-- the indexing type of a representation of `comul a` -/
-  {ι : Type*}
+    [CommSemiring R] [AddCommMonoid A] [Module R A] [CoalgebraStruct R A] (a : A) (ι : Type*) where
   /-- the finite indexing set of a representation of `comul a` -/
   (index : Finset ι)
   /-- the first coordinate of a representation of `comul a` -/
@@ -63,7 +61,7 @@ structure Coalgebra.Repr (R : Type u) {A : Type v}
 /-- An arbitrarily chosen representation. -/
 noncomputable def Coalgebra.Repr.arbitrary (R : Type u) {A : Type v}
     [CommSemiring R] [AddCommMonoid A] [Module R A] [CoalgebraStruct R A] (a : A) :
-    Coalgebra.Repr R a where
+    Coalgebra.Repr R a (A × A) where
   left := Prod.fst
   right := Prod.snd
   index := TensorProduct.exists_finset (R := R) (CoalgebraStruct.comul a) |>.choose
@@ -88,7 +86,7 @@ class Coalgebra (R : Type u) (A : Type v)
   lTensor_counit_comp_comul : counit.lTensor A ∘ₗ comul = (TensorProduct.mk R _ _).flip 1
 
 namespace Coalgebra
-variable {R : Type u} {A : Type v}
+variable {R : Type u} {A : Type v} {ι : Type*} {κ Λ : ι → Type*}
 variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A] {a : A}
 
 @[simp]
@@ -116,18 +114,18 @@ theorem lTensor_counit_comul (a : A) : counit.lTensor A (comul a) = a ⊗ₜ[R] 
   LinearMap.congr_fun lTensor_counit_comp_comul a
 
 @[simp]
-lemma sum_counit_tmul_eq {a : A} (repr : Coalgebra.Repr R a) :
+lemma sum_counit_tmul_eq (repr : Repr R a ι) :
     ∑ i ∈ repr.index, counit (R := R) (repr.left i) ⊗ₜ (repr.right i) = 1 ⊗ₜ[R] a := by
   simpa [← repr.eq, map_sum] using congr($(rTensor_counit_comp_comul (R := R) (A := A)) a)
 
 @[simp]
-lemma sum_tmul_counit_eq {a : A} (repr : Coalgebra.Repr R a) :
+lemma sum_tmul_counit_eq (repr : Repr R a ι) :
     ∑ i ∈ repr.index, (repr.left i) ⊗ₜ counit (R := R) (repr.right i) = a ⊗ₜ[R] 1 := by
   simpa [← repr.eq, map_sum] using congr($(lTensor_counit_comp_comul (R := R) (A := A)) a)
 
 -- Cannot be @[simp] because `a₂` cannot be inferred by `simp`.
-lemma sum_tmul_tmul_eq {a : A} (repr : Repr R a)
-    (a₁ : (i : repr.ι) → Repr R (repr.left i)) (a₂ : (i : repr.ι) → Repr R (repr.right i)) :
+lemma sum_tmul_tmul_eq (repr : Repr R a ι)
+    (a₁ : (i : ι) → Repr R (repr.left i) (κ i)) (a₂ : (i : ι) → Repr R (repr.right i) (Λ i)) :
     ∑ i ∈ repr.index, ∑ j ∈ (a₁ i).index,
       (a₁ i).left j ⊗ₜ[R] ((a₁ i).right j ⊗ₜ[R] repr.right i)
       = ∑ i ∈ repr.index, ∑ j ∈ (a₂ i).index,
@@ -137,7 +135,7 @@ lemma sum_tmul_tmul_eq {a : A} (repr : Repr R a)
 
 @[simp]
 theorem sum_counit_tmul_map_eq {B : Type*} [AddCommMonoid B] [Module R B]
-    {F : Type*} [FunLike F A B] [LinearMapClass F R A B] (f : F) (a : A) {repr : Repr R a} :
+    {F : Type*} [FunLike F A B] [LinearMapClass F R A B] (f : F) (a : A) {repr : Repr R a ι} :
     ∑ i ∈ repr.index, counit (R := R) (repr.left i) ⊗ₜ f (repr.right i) = 1 ⊗ₜ[R] f a := by
   have := sum_counit_tmul_eq repr
   apply_fun LinearMap.lTensor R (f : A →ₗ[R] B) at this
@@ -145,7 +143,7 @@ theorem sum_counit_tmul_map_eq {B : Type*} [AddCommMonoid B] [Module R B]
 
 @[simp]
 theorem sum_map_tmul_counit_eq {B : Type*} [AddCommMonoid B] [Module R B]
-    {F : Type*} [FunLike F A B] [LinearMapClass F R A B] (f : F) (a : A) {repr : Repr R a} :
+    {F : Type*} [FunLike F A B] [LinearMapClass F R A B] (f : F) (a : A) {repr : Repr R a ι} :
     ∑ i ∈ repr.index, f (repr.left i) ⊗ₜ counit (R := R) (repr.right i) = f a ⊗ₜ[R] 1 := by
   have := sum_tmul_counit_eq repr
   apply_fun LinearMap.rTensor R (f : A →ₗ[R] B) at this
@@ -153,8 +151,8 @@ theorem sum_map_tmul_counit_eq {B : Type*} [AddCommMonoid B] [Module R B]
 
 -- Cannot be @[simp] because `a₁` cannot be inferred by `simp`.
 theorem sum_map_tmul_tmul_eq {B : Type*} [AddCommMonoid B] [Module R B]
-    {F : Type*} [FunLike F A B] [LinearMapClass F R A B] (f g h : F) (a : A) {repr : Repr R a}
-    {a₁ : (i : repr.ι) → Repr R (repr.left i)} {a₂ : (i : repr.ι) → Repr R (repr.right i)} :
+    {F : Type*} [FunLike F A B] [LinearMapClass F R A B] (f g h : F) (a : A) {repr : Repr R a ι}
+    {a₁ : (i : ι) → Repr R (repr.left i) (κ i)} {a₂ : (i : ι) → Repr R (repr.right i) (Λ i)} :
     ∑ i ∈ repr.index, ∑ j ∈ (a₂ i).index,
       f (repr.left i) ⊗ₜ (g ((a₂ i).left j) ⊗ₜ h ((a₂ i).right j)) =
     ∑ i ∈ repr.index, ∑ j ∈ (a₁ i).index,
@@ -164,7 +162,7 @@ theorem sum_map_tmul_tmul_eq {B : Type*} [AddCommMonoid B] [Module R B]
     (TensorProduct.map (g : A →ₗ[R] B) (h : A →ₗ[R] B)) at this
   simp_all only [map_sum, TensorProduct.map_tmul, LinearMap.coe_coe]
 
-lemma sum_counit_smul (𝓡 : Repr R a) :
+lemma sum_counit_smul (𝓡 : Repr R a ι) :
     ∑ x ∈ 𝓡.index, counit (R := R) (𝓡.left x) • 𝓡.right x = a := by
   simpa only [map_sum, TensorProduct.lift.tmul, LinearMap.lsmul_apply, one_smul]
     using congr(TensorProduct.lift (LinearMap.lsmul R A) $(sum_counit_tmul_eq (R := R) 𝓡))

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -89,8 +89,9 @@ namespace Coalgebra
 variable {R : Type u} {A : Type v} {ι : Type*} {κ Λ : ι → Type*}
 variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A] {a : A}
 
-@[deprecated "The indexing type is now unbundled" (since := "2026-05-31")]
-protected abbrev Repr.ι (_repr : Repr R a ι) : Type _ := ι
+/-- The indexing type of a representation of `comul a` -/
+@[nolint unusedArgs, deprecated "The indexing type is now unbundled" (since := "2026-05-31")]
+protected abbrev Repr.ι (repr : Repr R a ι) : Type _ := ι
 
 @[simp]
 theorem coassoc_apply (a : A) :

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -90,7 +90,7 @@ variable {R : Type u} {A : Type v} {ι : Type*} {κ Λ : ι → Type*}
 variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A] {a : A}
 
 @[deprecated "The indexing type is now unbundled" (since := "2026-05-31")]
-protected abbrev Repr.ι (repr : Repr R a ι) : Type _ := ι
+protected abbrev Repr.ι (_repr : Repr R a ι) : Type _ := ι
 
 @[simp]
 theorem coassoc_apply (a : A) :

--- a/Mathlib/RingTheory/Coalgebra/Convolution.lean
+++ b/Mathlib/RingTheory/Coalgebra/Convolution.lean
@@ -43,7 +43,7 @@ suppress_compilation
 open Coalgebra TensorProduct WithConv
 open scoped RingTheory.LinearMap
 
-variable {R A B C : Type*} [CommSemiring R]
+variable {R A B C ι : Type*} [CommSemiring R]
 
 namespace LinearMap
 section NonUnitalNonAssocSemiring
@@ -62,7 +62,7 @@ lemma convMul_def (f g : WithConv (C →ₗ[R] A)) :
 lemma convMul_apply (f g : WithConv (C →ₗ[R] A)) (c : C) :
     (f * g) c = mul' R A (.map f.ofConv g.ofConv (comul c)) := rfl
 
-lemma _root_.Coalgebra.Repr.convMul_apply {a : C} (𝓡 : Coalgebra.Repr R a)
+lemma _root_.Coalgebra.Repr.convMul_apply {a : C} (𝓡 : Coalgebra.Repr R a ι)
     (f g : WithConv (C →ₗ[R] A)) : (f * g) a = ∑ i ∈ 𝓡.index, f (𝓡.left i) * g (𝓡.right i) := by
   simp [convMul_def, ← 𝓡.eq]
 

--- a/Mathlib/RingTheory/Coalgebra/Hom.lean
+++ b/Mathlib/RingTheory/Coalgebra/Hom.lean
@@ -264,7 +264,7 @@ end CoalgHom
 
 namespace Coalgebra
 
-variable (R : Type u) (A : Type v) (B : Type w)
+variable (R : Type u) (A : Type v) (B : Type w) {ι : Type*}
 
 variable [CommSemiring R] [AddCommMonoid A] [AddCommMonoid B] [Module R A] [Module R B]
 variable [Coalgebra R A] [Coalgebra R B]
@@ -302,9 +302,9 @@ variable {A B}
 If `φ : A → B` is a coalgebra map and `a = ∑ xᵢ ⊗ yᵢ`, then `φ a = ∑ φ xᵢ ⊗ φ yᵢ`
 -/
 @[simps]
-def Repr.induced {a : A} (repr : Repr R a)
+def Repr.induced {a : A} (repr : Repr R a ι)
     {F : Type*} [FunLike F A B] [CoalgHomClass F R A B]
-    (φ : F) : Repr R (φ a) where
+    (φ : F) : Repr R (φ a) ι where
   index := repr.index
   left := φ ∘ repr.left
   right := φ ∘ repr.right

--- a/Mathlib/RingTheory/HopfAlgebra/Basic.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/Basic.lean
@@ -75,7 +75,8 @@ namespace HopfAlgebra
 
 export HopfAlgebraStruct (antipode)
 
-variable {R : Type u} {A : Type v} [CommSemiring R] [Semiring A] [HopfAlgebra R A] {a : A}
+variable {R : Type u} {A : Type v} {ι : Type*} [CommSemiring R] [Semiring A] [HopfAlgebra R A]
+  {a : A}
 
 @[simp]
 theorem mul_antipode_rTensor_comul_apply (a : A) :
@@ -96,22 +97,22 @@ theorem antipode_one :
 
 open Coalgebra
 
-lemma sum_antipode_mul_eq_algebraMap_counit (repr : Repr R a) :
+lemma sum_antipode_mul_eq_algebraMap_counit (repr : Repr R a ι) :
     ∑ i ∈ repr.index, antipode R (repr.left i) * repr.right i =
       algebraMap R A (counit a) := by
   simpa [← repr.eq, map_sum] using congr($(mul_antipode_rTensor_comul (R := R)) a)
 
-lemma sum_mul_antipode_eq_algebraMap_counit (repr : Repr R a) :
+lemma sum_mul_antipode_eq_algebraMap_counit (repr : Repr R a ι) :
     ∑ i ∈ repr.index, repr.left i * antipode R (repr.right i) =
       algebraMap R A (counit a) := by
   simpa [← repr.eq, map_sum] using congr($(mul_antipode_lTensor_comul (R := R)) a)
 
-lemma sum_antipode_mul_eq_smul (repr : Repr R a) :
+lemma sum_antipode_mul_eq_smul (repr : Repr R a ι) :
     ∑ i ∈ repr.index, antipode R (repr.left i) * repr.right i =
       counit (R := R) a • 1 := by
   rw [sum_antipode_mul_eq_algebraMap_counit, Algebra.smul_def, mul_one]
 
-lemma sum_mul_antipode_eq_smul (repr : Repr R a) :
+lemma sum_mul_antipode_eq_smul (repr : Repr R a ι) :
     ∑ i ∈ repr.index, repr.left i * antipode R (repr.right i) =
       counit (R := R) a • 1 := by
   rw [sum_mul_antipode_eq_algebraMap_counit, Algebra.smul_def, mul_one]


### PR DESCRIPTION
... rather than a field.

Since fields are semireducible, having a type as a field is incompatible with the new stringence of tactics to rewrite only up to defeq.

For `Repr`, this issue shows up as soon as the indexing type isn't arbitrary anymore, usually because it is derived from one or more existing indexing types.

From Toric


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
