### PR TITLE
[Merged by Bors] - chore(MeasureTheory/Measure/AddContent): golf some proofs

### DIFF
--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -250,37 +250,14 @@ private lemma AddContent.supClosureFun_apply_of_mem (hC : IsSetSemiring C)
   toFun := m.supClosureFun
   empty' := by rw [m.supClosureFun_apply_of_mem hC hC.empty_mem, addContent_empty]
   sUnion' I hI h'I hh'I := by
-    classical
-    have A (s) (hs : s ∈ I) : ∃ (J : Finset (Set α)),
-        ↑J ⊆ C ∧ (PairwiseDisjoint (J : Set (Set α)) id) ∧ s = ⋃₀ ↑J := by
-      obtain ⟨P, PC⟩ : ∃ (P : Finpartition s), ↑P.parts ⊆ C := by
-        have := hI hs
-        rwa [hC.mem_supClosure_iff] at this
-      refine ⟨P.parts, PC, P.disjoint, ?_⟩
-      convert! P.sup_parts.symm
-      simp [sUnion_eq_biUnion]
-    choose! J hJC hJdisj hJs using A
-    have H {a i} (hi : i ∈ I) (ha : a ∈ J i) : a ⊆ i := by
-      rw [hJs i hi]
-      exact subset_sUnion_of_mem ha
-    let K : Finset (Set α) := Finset.biUnion I J
-    have : ⋃₀ ↑I = ⋃₀ (↑K : Set (Set α)) := by grind
-    rw [this, m.supClosureFun_apply hC (J := K) (by simpa [K] using hJC) _ rfl]; swap
-    · simp only [K, coe_biUnion]
-      refine (h'I.mono_on ?_).biUnion hJdisj
-      simp
-      grind
-    simp only [K]
-    rw [sum_biUnion_of_pairwise_eq_zero]; swap
-    · intro i hi j hj hij k hk
-      simp only [Finset.mem_inter] at hk
-      have : Disjoint k k := by
-        have : Disjoint i j := h'I hi hj hij
-        exact this.mono (H hi hk.1) (H hj hk.2)
-      simp only [disjoint_self, Set.bot_eq_empty] at this
-      simp [this]
-    apply Finset.sum_congr rfl (fun i hi ↦ Eq.symm ?_)
-    exact m.supClosureFun_apply hC (hJC i hi) (hJdisj i hi) (hJs i hi)
+    choose! J hJC using fun s (hs : s ∈ I) => hC.mem_supClosure_iff.mp (hI hs)
+    let K : Finpartition (I.sup id) := Finpartition.combine J h'I.supIndep
+    rw [← sSup_eq_sUnion, ← sup_id_eq_sSup, ← K.sup_parts, sup_id_eq_sSup, sSup_eq_sUnion,
+      m.supClosureFun_apply hC (by simpa [K] using hJC) K.supIndep.pairwiseDisjoint rfl,
+      Finpartition.sum_combine]
+    refine Finset.sum_congr rfl fun i hi ↦ Eq.symm <|
+      m.supClosureFun_apply hC (hJC i hi) (J i).supIndep.pairwiseDisjoint ?_
+    rw [← sSup_eq_sUnion, ← sup_id_eq_sSup, (J i).sup_parts]
 
 lemma AddContent.supClosure_apply (hC : IsSetSemiring C)
     (m : AddContent G C) {s : Set α} {J : Finset (Set α)}
@@ -322,50 +299,31 @@ lemma addContent_mono (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C)
   · simp only [coe_singleton, pairwiseDisjoint_singleton]
   · simp [hst]
 
-/-- An `addContent C` on a `SetSemiring C` is sub-additive. -/
-lemma addContent_sUnion_le_sum {m : AddContent G C} (hC : IsSetSemiring C)
-    (J : Finset (Set α)) (h_ss : ↑J ⊆ C) (h_mem : ⋃₀ ↑J ∈ C) :
-    m (⋃₀ ↑J) ≤ ∑ u ∈ J, m u := by
-  classical
-  have h1 : (disjiUnion J (hC.disjointOfUnion h_ss)
-      (hC.pairwiseDisjoint_disjointOfUnion h_ss) : Set (Set α)) ⊆ C := by
-    simp only [disjiUnion_eq_biUnion, coe_biUnion, mem_coe, iUnion_subset_iff]
-    exact fun _ x ↦ hC.disjointOfUnion_subset h_ss x
-  have h2 : PairwiseDisjoint (disjiUnion J (hC.disjointOfUnion h_ss)
-      ((hC.pairwiseDisjoint_disjointOfUnion h_ss)) : Set (Set α)) id := by
-    simp only [disjiUnion_eq_biUnion, coe_biUnion, mem_coe]
-    exact hC.pairwiseDisjoint_biUnion_disjointOfUnion h_ss
-  have h3 : ⋃₀ J = ⋃₀ ((disjiUnion J (hC.disjointOfUnion h_ss)
-      (hC.pairwiseDisjoint_disjointOfUnion h_ss)) : Set (Set α)) := by
-    simp only [disjiUnion_eq_biUnion, coe_biUnion, mem_coe]
-    exact (Exists.choose_spec (hC.disjointOfUnion_props h_ss)).2.2.2.2.2
-  rw [h3, addContent_sUnion h1 h2, sum_disjiUnion]
-  · gcongr with x hx
-    refine sum_addContent_le_of_subset hC (hC.disjointOfUnion_subset h_ss hx)
-      (hC.pairwiseDisjoint_disjointOfUnion_of_mem h_ss hx) (h_ss hx)
-      (fun _ s ↦ hC.subset_of_mem_disjointOfUnion h_ss hx s)
-  · simp only [disjiUnion_eq_biUnion, coe_biUnion, mem_coe] at *
-    exact h3.symm ▸ h_mem
-
 lemma addContent_le_sum_of_subset_sUnion {m : AddContent G C} (hC : IsSetSemiring C)
     {J : Finset (Set α)} (h_ss : ↑J ⊆ C) (ht : t ∈ C) (htJ : t ⊆ ⋃₀ ↑J) :
     m t ≤ ∑ u ∈ J, m u := by
-  -- we can't apply `addContent_mono` and `addContent_sUnion_le_sum` because `⋃₀ ↑J` might not
-  -- be in `C`
-  classical
-  let Jt := J.image (fun u ↦ t ∩ u)
-  have ht_eq : t = ⋃₀ Jt := by
-    rw [coe_image, sUnion_image, ← inter_iUnion₂, inter_eq_self_of_subset_left]
-    rwa [← sUnion_eq_biUnion]
-  rw [ht_eq]
-  refine (addContent_sUnion_le_sum hC Jt ?_ ?_).trans ?_
-  · intro s
-    simp only [Jt, coe_image, Set.mem_image, mem_coe, forall_exists_index, and_imp]
-    rintro u hu rfl
-    exact hC.inter_mem _ ht _ (h_ss hu)
-  · rwa [← ht_eq]
-  · refine (Finset.sum_image_le_of_nonneg fun _ _ ↦ zero_le).trans (sum_le_sum fun u hu ↦ ?_)
-    exact addContent_mono hC (hC.inter_mem _ ht _ (h_ss hu)) (h_ss hu) inter_subset_right
+  simp_rw +singlePass [← sSup_eq_sUnion, sSup_eq_iSup', SetLike.coe_sort_coe,
+    ← J.equivFin.symm.iSup_comp, iSup_eq_iUnion, ← iUnion_disjointed] at htJ
+  set f := disjointed fun j => (J.equivFin.symm j).1
+  have h1 : ∀ j, f j ∈ supClosure C :=
+    hC.isSetRing_supClosure.disjointed_mem fun j =>
+      subset_supClosure <| h_ss <| (J.equivFin.symm j).2
+  have h2 : Pairwise (Disjoint on f) := disjoint_disjointed _
+  have h3 : ⋃ i, f i ∈ supClosure C :=
+    supClosed_supClosure.iSup_mem (subset_supClosure hC.empty_mem) h1
+  grw [← m.supClosure_apply_of_mem hC ht,
+    addContent_mono hC.isSetRing_supClosure.isSetSemiring (subset_supClosure ht) h3 htJ,
+    addContent_iUnion h1 h2 h3, ← J.sum_attach, Finset.attach_eq_univ, ← J.equivFin.symm.sum_comp]
+  gcongr with j -
+  rw [← m.supClosure_apply_of_mem hC (h_ss (J.equivFin.symm _).2)]
+  exact addContent_mono hC.isSetRing_supClosure.isSetSemiring (h1 j)
+    (subset_supClosure (h_ss (J.equivFin.symm j).2)) (disjointed_subset _ j)
+
+/-- An `addContent C` on a `SetSemiring C` is sub-additive. -/
+lemma addContent_sUnion_le_sum {m : AddContent G C} (hC : IsSetSemiring C)
+    (J : Finset (Set α)) (h_ss : ↑J ⊆ C) (h_mem : ⋃₀ ↑J ∈ C) :
+    m (⋃₀ ↑J) ≤ ∑ u ∈ J, m u :=
+  addContent_le_sum_of_subset_sUnion hC h_ss h_mem subset_rfl
 
 /-- If an `AddContent` is σ-subadditive on a semi-ring of sets, then it is σ-additive. -/
 theorem addContent_iUnion_eq_tsum_of_disjoint_of_addContent_iUnion_le {m : AddContent ℝ≥0∞ C}


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
