### PR TITLE
chore(MeasureTheory/SetSemiring): deprecate `disjointOfUnion`

### DIFF
--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -391,6 +391,7 @@ variable {j : Set α} {J : Finset (Set α)}
 
 open MeasureTheory Order
 
+@[deprecated "deprecated without replacement" (since := "2026-06-01")]
 theorem disjointOfUnion_props (hC : IsSetSemiring C) (h1 : ↑J ⊆ C) :
     ∃ K : Set α → Finset (Set α),
       PairwiseDisjoint J K
@@ -475,38 +476,47 @@ a `Finset (Set α)` such that `K j := hC.disjointOfUnion hJ` are disjoint
 and `⋃₀ K j ⊆ j`, for `j ∈ J`.
 Using these we write `⋃₀ J` as a disjoint union `⋃₀ J = ⋃₀ ⋃ x ∈ J, (K x)`.
 See `MeasureTheory.IsSetSemiring.disjointOfUnion_props`. -/
+@[deprecated "deprecated without replacement" (since := "2026-06-01")]
 noncomputable def disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (j : Set α) :=
   (hC.disjointOfUnion_props hJ).choose j
 
+@[deprecated "deprecated without replacement" (since := "2026-06-01")]
 lemma pairwiseDisjoint_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
     PairwiseDisjoint J (hC.disjointOfUnion hJ) :=
   (Exists.choose_spec (hC.disjointOfUnion_props hJ)).1
 
+@[deprecated "deprecated without replacement" (since := "2026-06-01")]
 lemma disjointOfUnion_subset (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
     (disjointOfUnion hC hJ j : Set (Set α)) ⊆ C :=
   (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.1 _ hj
 
+@[deprecated "deprecated without replacement" (since := "2026-06-01")]
 lemma pairwiseDisjoint_biUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
     PairwiseDisjoint (⋃ x ∈ J, (hC.disjointOfUnion hJ x : Set (Set α))) id :=
   (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.2.1
 
+@[deprecated "deprecated without replacement" (since := "2026-06-01")]
 lemma pairwiseDisjoint_disjointOfUnion_of_mem (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
     PairwiseDisjoint (hC.disjointOfUnion hJ j : Set (Set α)) id := by
   apply PairwiseDisjoint.subset (hC.pairwiseDisjoint_biUnion_disjointOfUnion hJ)
   exact subset_iUnion₂_of_subset j hj fun ⦃a⦄ a ↦ a
 
+@[deprecated "deprecated without replacement" (since := "2026-06-01")]
 lemma disjointOfUnion_subset_of_mem (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
     ⋃₀ hC.disjointOfUnion hJ j ⊆ j :=
   (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.2.2.1 j hj
 
+@[deprecated "deprecated without replacement" (since := "2026-06-01")]
 lemma subset_of_mem_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) {x : Set α}
     (hx : x ∈ (hC.disjointOfUnion hJ) j) : x ⊆ j :=
   sUnion_subset_iff.mp (hC.disjointOfUnion_subset_of_mem hJ hj) x hx
 
+@[deprecated "deprecated without replacement" (since := "2026-06-01")]
 lemma empty_notMem_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
     ∅ ∉ hC.disjointOfUnion hJ j :=
   (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.2.2.2.1 j hj
 
+@[deprecated "deprecated without replacement" (since := "2026-06-01")]
 lemma sUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
     ⋃₀ ⋃ x ∈ J, (hC.disjointOfUnion hJ x : Set (Set α)) = ⋃₀ J :=
   (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.2.2.2.2.symm


### PR DESCRIPTION
This definition was only used in the proof of `AddContent.addContent_sUnion_le_sum`. Since it is defined using choice with very specific properties, it is unlikely to be reusable elsewhere.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #40060 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
