### PR TITLE
[Merged by Bors] - refactor(Analysis): golf `Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction`

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
@@ -121,13 +121,9 @@ lemma σ_im_ne_zero {g z} : (σ g z).im ≠ 0 ↔ z.im ≠ 0 := by
   split_ifs <;> simp
 
 lemma σ_mul (g g' : GL (Fin 2) ℝ) (z : ℂ) : σ (g * g') z = σ g (σ g' z) := by
-  simp only [σ, map_mul, Units.val_mul]
-  rcases g.det_ne_zero.lt_or_gt with (h | h) <;>
-  rcases g'.det_ne_zero.lt_or_gt with (h' | h')
-  · simp [mul_pos_of_neg_of_neg h h', h.not_gt, h'.not_gt]
-  · simp [(mul_neg_of_neg_of_pos h h').not_gt, h.not_gt, h']
-  · simp [(mul_neg_of_pos_of_neg h h').not_gt, h, h'.not_gt]
-  · simp [mul_pos h h', h, h']
+  simp only [σ, map_mul, Units.val_mul, mul_pos_iff]
+  rcases g.det_ne_zero.lt_or_gt with h | h <;> rcases g'.det_ne_zero.lt_or_gt with h' | h' <;>
+    simp [h, h', h.not_gt, h'.not_gt]
 
 lemma σ_mul_comm (g h : GL (Fin 2) ℝ) (z : ℂ) : σ g (σ h z) = σ h (σ g z) := by
   simp only [σ]
@@ -156,13 +152,7 @@ def smulAux (g : GL (Fin 2) ℝ) (z : ℍ) : ℍ :=
 
 lemma denom_cocycle' (g h : GL (Fin 2) ℝ) (z : ℍ) :
     denom (g * h) z = σ h (denom g (smulAux h z)) * denom h z := by
-  simp only [smulAux, smulAux', coe_mk, map_div₀, σ_num, σ_denom, σ_sq]
-  change _ = (_ * (_ / _) + _) * _
-  field_simp [denom_ne_zero h z]
-  simp only [denom, Units.val_mul, mul_apply, Fin.sum_univ_succ, Finset.univ_unique,
-    Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one, Complex.ofReal_add,
-    Complex.ofReal_mul, num]
-  ring
+  simpa [smulAux, smulAux', denom, σ_sq] using denom_cocycle g h z.im_ne_zero
 
 theorem mul_smul' (g h : GL (Fin 2) ℝ) (z : ℍ) :
     smulAux (g * h) z = smulAux g (smulAux h z) := by

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
@@ -121,9 +121,13 @@ lemma σ_im_ne_zero {g z} : (σ g z).im ≠ 0 ↔ z.im ≠ 0 := by
   split_ifs <;> simp
 
 lemma σ_mul (g g' : GL (Fin 2) ℝ) (z : ℂ) : σ (g * g') z = σ g (σ g' z) := by
-  simp only [σ, map_mul, Units.val_mul, mul_pos_iff]
-  rcases g.det_ne_zero.lt_or_gt with h | h <;> rcases g'.det_ne_zero.lt_or_gt with h' | h' <;>
-    simp [h, h', h.not_gt, h'.not_gt]
+  simp only [σ, map_mul, Units.val_mul]
+  rcases g.det_ne_zero.lt_or_gt with (h | h) <;>
+  rcases g'.det_ne_zero.lt_or_gt with (h' | h')
+  · simp [mul_pos_of_neg_of_neg h h', h.not_gt, h'.not_gt]
+  · simp [(mul_neg_of_neg_of_pos h h').not_gt, h.not_gt, h']
+  · simp [(mul_neg_of_pos_of_neg h h').not_gt, h, h'.not_gt]
+  · simp [mul_pos h h', h, h']
 
 lemma σ_mul_comm (g h : GL (Fin 2) ℝ) (z : ℂ) : σ g (σ h z) = σ h (σ g z) := by
   simp only [σ]


### PR DESCRIPTION
- refactors `σ_mul` by simplifying the determinant sign split with `mul_pos_iff`
- rewrites `denom_cocycle'` as a direct consequence of `denom_cocycle`

Extracted from #37968

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)