### PR TITLE
[Merged by Bors] - feat: a random variable whose law is a dirac is ae constant

### DIFF
--- a/Mathlib/Probability/HasLaw.lean
+++ b/Mathlib/Probability/HasLaw.lean
@@ -183,20 +183,37 @@ lemma HasPDF.hasLaw [h : HasPDF X P μ] : HasLaw X (μ.withDensity (pdf X P μ))
   aemeasurable := h.aemeasurable
   map_eq := map_eq_withDensity_pdf X P μ
 
-lemma HasLaw.ae_eq_of_dirac [MeasurableSingletonClass 𝓧] {x : 𝓧}
-    (hX : HasLaw X (.dirac x) P) : X =ᵐ[P] (fun _ ↦ x) := by
+lemma HasLaw.ae_eq_of_smul_dirac {c : ℝ≥0∞} [MeasurableSingletonClass 𝓧] {x : 𝓧}
+    (hX : HasLaw X (c • .dirac x) P) :
+    X =ᵐ[P] (fun _ ↦ x) := by
   apply ae_of_ae_map (p := fun y ↦ y = x) hX.aemeasurable
-  rw [hX.map_eq, ae_dirac_iff]
-  simp
+  rw [hX.map_eq]
+  apply Measure.ae_smul_measure (by simp)
+
+lemma HasLaw.ae_eq_of_dirac [MeasurableSingletonClass 𝓧] {x : 𝓧} (hX : HasLaw X (.dirac x) P) :
+    X =ᵐ[P] (fun _ ↦ x) :=
+  HasLaw.ae_eq_of_smul_dirac (c := 1) (by simpa)
+
+lemma hasLaw_smul_dirac_of_ae_eq {x : 𝓧} (hX : X =ᵐ[P] fun _ ↦ x) :
+    HasLaw X ((P Set.univ) • .dirac x) P where
+  aemeasurable := aemeasurable_const.congr hX.symm
+  map_eq := by
+    rw [map_congr hX]
+    simp
+
+lemma hasLaw_dirac_of_ae_eq [IsProbabilityMeasure P] {x : 𝓧} (hX : X =ᵐ[P] fun _ ↦ x) :
+    HasLaw X (.dirac x) P := by
+  simpa using hasLaw_smul_dirac_of_ae_eq hX
+
+lemma hasLaw_smul_dirac_iff [MeasurableSingletonClass 𝓧] {x : 𝓧} :
+    HasLaw X ((P Set.univ) • .dirac x) P ↔ X =ᵐ[P] (fun _ ↦ x) where
+  mp := HasLaw.ae_eq_of_smul_dirac
+  mpr := hasLaw_smul_dirac_of_ae_eq
 
 lemma hasLaw_dirac_iff [IsProbabilityMeasure P] [MeasurableSingletonClass 𝓧] {x : 𝓧} :
     HasLaw X (.dirac x) P ↔ X =ᵐ[P] (fun _ ↦ x) where
   mp := HasLaw.ae_eq_of_dirac
-  mpr h :=
-    { aemeasurable := aemeasurable_const.congr h.symm
-      map_eq := by
-        rw [map_congr h]
-        simp }
+  mpr := hasLaw_dirac_of_ae_eq
 
 lemma indepFun_iff_hasLaw_prodMk_prod [IsFiniteMeasure P] {𝓨 : Type*} {m𝓨 : MeasurableSpace 𝓨}
     {ν : Measure 𝓨} {Y : Ω → 𝓨} (hX : HasLaw X μ P) (hY : HasLaw Y ν P) :

--- a/Mathlib/Probability/HasLaw.lean
+++ b/Mathlib/Probability/HasLaw.lean
@@ -183,6 +183,21 @@ lemma HasPDF.hasLaw [h : HasPDF X P μ] : HasLaw X (μ.withDensity (pdf X P μ))
   aemeasurable := h.aemeasurable
   map_eq := map_eq_withDensity_pdf X P μ
 
+lemma HasLaw.ae_eq_of_dirac [MeasurableSingletonClass 𝓧] {x : 𝓧}
+    (hX : HasLaw X (.dirac x) P) : X =ᵐ[P] (fun _ ↦ x) := by
+  apply ae_of_ae_map (p := fun y ↦ y = x) hX.aemeasurable
+  rw [hX.map_eq, ae_dirac_iff]
+  simp
+
+lemma hasLaw_dirac_iff [IsProbabilityMeasure P] [MeasurableSingletonClass 𝓧] {x : 𝓧} :
+    HasLaw X (.dirac x) P ↔ X =ᵐ[P] (fun _ ↦ x) where
+  mp := HasLaw.ae_eq_of_dirac
+  mpr h :=
+    { aemeasurable := aemeasurable_const.congr h.symm
+      map_eq := by
+        rw [map_congr h]
+        simp }
+
 lemma indepFun_iff_hasLaw_prodMk_prod [IsFiniteMeasure P] {𝓨 : Type*} {m𝓨 : MeasurableSpace 𝓨}
     {ν : Measure 𝓨} {Y : Ω → 𝓨} (hX : HasLaw X μ P) (hY : HasLaw Y ν P) :
     X ⟂ᵢ[P] Y ↔ HasLaw (fun ω ↦ (X ω, Y ω)) (μ.prod ν) P where


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
