### PR TITLE
chore: avoid throwError or trace[...] with s! syntax

### DIFF
--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -106,7 +106,7 @@ def synthesizeArgs (thmId : Origin) (xs : Array Expr)
       when applying theorem `{← ppOrigin' thmId}`."
 
       trace[Meta.Tactic.fun_prop]
-        "{← ppOrigin thmId}, failed to infer `({← ppExpr x} : {← ppExpr (← inferType x)})`"
+        "{← ppOrigin thmId}, failed to infer `({x} : {← inferType x})`"
       return false
 
   return true
@@ -141,13 +141,13 @@ def tryTheoremWithHint? (e : Expr) (thmOrigin : Origin)
     let type ← instantiateMVars <| ← inferType thmProof
     let (xs, _, type) ← forallMetaTelescope type
 
-    for (i,x) in hint do
+    for (i, x) in hint do
       try
-        for (id,v) in hint do
+        for (id, v) in hint do
           xs[id]!.mvarId!.assignIfDefEq v
       catch _ =>
         trace[Debug.Meta.Tactic.fun_prop]
-          "failed to use hint {i} `{← ppExpr x} when applying theorem {← ppOrigin thmOrigin}"
+          "failed to use hint {i} `{x}` when applying theorem {← ppOrigin thmOrigin}"
 
     tryTheoremCore xs thmProof type e thmOrigin funProp
 
@@ -185,9 +185,8 @@ def applyIdRule (funPropDecl : FunPropDecl) (e : Expr)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
   let thms ← getLambdaTheorems funPropDecl.funPropName .id
   if thms.size = 0 then
-    let msg := s!"missing identity rule to prove `{← ppExpr e}`"
-    logError msg
-    trace[Meta.Tactic.fun_prop] msg
+    logError s!"missing identity rule to prove `{← ppExpr e}`"
+    trace[Meta.Tactic.fun_prop] "missing identity rule to prove `{e}`"
     return none
 
   for thm in thms do
@@ -205,9 +204,8 @@ def applyConstRule (funPropDecl : FunPropDecl) (e : Expr)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
   let thms ← getLambdaTheorems funPropDecl.funPropName .const
   if thms.size = 0 then
-    let msg := s!"missing constant rule to prove `{← ppExpr e}`"
-    logError msg
-    trace[Meta.Tactic.fun_prop] msg
+    logError s!"missing constant rule to prove `{← ppExpr e}`"
+    trace[Meta.Tactic.fun_prop] "missing constant rule to prove `{e}`"
     return none
   for thm in thms do
     let .const := thm.thmArgs | return none
@@ -242,9 +240,8 @@ def applyCompRule (funPropDecl : FunPropDecl) (e f g : Expr)
 
   let thms ← getLambdaTheorems funPropDecl.funPropName .comp
   if thms.size = 0 then
-    let msg := s!"missing composition rule to prove `{← ppExpr e}`"
-    logError msg
-    trace[Meta.Tactic.fun_prop] msg
+    logError s!"missing composition rule to prove `{← ppExpr e}`"
+    trace[Meta.Tactic.fun_prop] "missing composition rule to prove `{e}`"
     return none
 
   for thm in thms do
@@ -265,9 +262,8 @@ def applyPiRule (funPropDecl : FunPropDecl) (e : Expr)
 
   let thms ← getLambdaTheorems funPropDecl.funPropName .pi
   if thms.size = 0 then
-    let msg := s!"missing pi rule to prove `{← ppExpr e}`"
-    logError msg
-    trace[Meta.Tactic.fun_prop] msg
+    logError s!"missing pi rule to prove `{← ppExpr e}`"
+    trace[Meta.Tactic.fun_prop] "missing pi rule to prove `{e}`"
     return none
 
   for thm in thms do
@@ -298,7 +294,7 @@ def letCase (funPropDecl : FunPropDecl) (e : Expr) (f : Expr)
     -- Usually this is caused by the usage of `FunLike`
     let yType := yType.headBeta
     if (yType.hasLooseBVar 0) then
-      throwError "dependent type encountered {← ppExpr (Expr.forallE xName xType yType default)}"
+      throwError "dependent type encountered `{(Expr.forallE xName xType yType default)}`"
 
     -- let binding can be pulled out of the lambda function
     if ¬(yValue.hasLooseBVar 0) then
@@ -329,7 +325,7 @@ def letCase (funPropDecl : FunPropDecl) (e : Expr) (f : Expr)
 /-- Prove function property of using *morphism theorems*. -/
 def applyMorRules (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
-  trace[Debug.Meta.Tactic.fun_prop] "applying morphism theorems to {← ppExpr e}"
+  trace[Debug.Meta.Tactic.fun_prop] "applying morphism theorems to `{e}`"
 
   -- get theorems
   let candidates ← getMorphismTheorems e
@@ -343,7 +339,7 @@ def applyMorRules (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 
   -- if all failed try to add/remove arguments
   match ← fData.isMorApplication with
-  | .none => throwError "fun_prop bug: invalid use of mor rules on {← ppExpr e}"
+  | .none => throwError "fun_prop bug: invalid use of mor rules on `{e}`"
   | .underApplied =>
     applyPiRule funPropDecl e funProp
   | .overApplied =>
@@ -384,7 +380,7 @@ def removeArgRule (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     FunPropM (Option Result) := do
 
   match h : fData.args.size with
-  | 0 => throwError "fun_prop bug: invalid use of remove arg case {←ppExpr e}"
+  | 0 => throwError "fun_prop bug: invalid use of remove arg case `{e}`"
   | n + 1 =>
     let arg := fData.args[n]
 
@@ -544,7 +540,7 @@ def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     let .fvar id := fData.fn | throwError "fun_prop bug: invalid use of fvar app case"
     let thms ← getLocalTheorems funPropDecl (.fvar id) fData.mainArgs fData.args.size
     trace[Meta.Tactic.fun_prop]
-      "candidate local theorems for {← ppExpr (.fvar id)} \
+      "candidate local theorems for {Expr.fvar id} \
          {← thms.mapM fun thm => ppOrigin thm.thmOrigin}"
 
     if let some r ← tryTheorems funPropDecl e fData thms funProp then
@@ -608,7 +604,7 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
       return r
   else
     trace[Meta.Tactic.fun_prop]
-      s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
+      "failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
          now trying to prove `{funPropDecl.funPropName}` from another function property"
 
     if let some r ← applyTransitionRules e funProp then
@@ -641,7 +637,8 @@ mutual
       trace[Meta.Tactic.fun_prop] "reusing previously found proof for `{e}`"
       return some { proof := proof }
     else if (← get).failureCache.contains e then
-      trace[Meta.Tactic.fun_prop] "skipping proof search, proving `{e}` was tried already and failed"
+      trace[Meta.Tactic.fun_prop]
+        "skipping proof search, proving `{e}` was tried already and failed"
       return none
     else
       -- take care of forall and let binders and run main
@@ -706,7 +703,7 @@ mutual
       | .const .. | .proj .. => do
         constAppCase funPropDecl e fData funProp
       | _ =>
-        trace[Debug.Meta.Tactic.fun_prop] "unknown case, ctor: {f.ctorName}\n{e}"
+        trace[Debug.Meta.Tactic.fun_prop] "unknown case, ctor: `{f.ctorName}`\n`{e}`"
         return none
 
 end

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -35,8 +35,8 @@ def synthesizeInstance (thmId : Origin) (x type : Expr) : MetaM Bool := do
       return true
     else
       trace[Meta.Tactic.fun_prop]
-"{← ppOrigin thmId}, failed to assign instance{indentExpr type}
-synthesized value{indentExpr val}\nis not definitionally equal to{indentExpr x}"
+        "{← ppOrigin thmId}, failed to assign instance{indentExpr type}
+      synthesized value{indentExpr val}\nis not definitionally equal to{indentExpr x}"
       return false
   | _ =>
     trace[Meta.Tactic.fun_prop]
@@ -491,16 +491,16 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 
   for thm in thms do
 
-    trace[Debug.Meta.Tactic.fun_prop] "trying theorem {thm.thmOrigin}"
+    trace[Debug.Meta.Tactic.fun_prop] "trying theorem {← ppOrigin thm.thmOrigin}"
 
     match compare thm.appliedArgs fData.args.size with
     | .lt =>
-      trace[Meta.Tactic.fun_prop] "removing argument to later use {thm.thmOrigin}"
+      trace[Meta.Tactic.fun_prop] "removing argument to later use {← ppOrigin thm.thmOrigin}"
       if let some r ← removeArgRule funPropDecl e fData funProp then
         return r
       continue
     | .gt =>
-      trace[Meta.Tactic.fun_prop] "adding argument to later use {thm.thmOrigin}"
+      trace[Meta.Tactic.fun_prop] "adding argument to later use {← ppOrigin thm.thmOrigin}"
       if let some r ← applyPiRule funPropDecl e funProp then
         return r
       continue
@@ -516,8 +516,8 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
           match dec? with
           | some (.comp f g) =>
             trace[Meta.Tactic.fun_prop]
-              s!"decomposing to later use {←ppOrigin' thm.thmOrigin} as:
-                   ({← ppExpr f}) ∘ ({← ppExpr g})"
+              "decomposing to later use {← ppOrigin thm.thmOrigin} as:
+                   ({f}) ∘ ({g})"
             if let some r ← applyCompRule funPropDecl e f g funProp then
               return r
           | some _ =>
@@ -527,8 +527,7 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
         else
           let some (f, g) ← fData.decompositionOverArgs thm.mainArgs | continue
           trace[Meta.Tactic.fun_prop]
-            s!"decomposing to later use {←ppOrigin' thm.thmOrigin} as:
-                 ({← ppExpr f}) ∘ ({← ppExpr g})"
+            "decomposing to later use {← ppOrigin thm.thmOrigin} as: ({f}) ∘ ({g})"
           if let some r ← applyCompRule funPropDecl e f g funProp then
             return r
       -- todo: decompose if uncurried and arguments do not match exactly
@@ -545,8 +544,8 @@ def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     let .fvar id := fData.fn | throwError "fun_prop bug: invalid use of fvar app case"
     let thms ← getLocalTheorems funPropDecl (.fvar id) fData.mainArgs fData.args.size
     trace[Meta.Tactic.fun_prop]
-      s!"candidate local theorems for {←ppExpr (.fvar id)} \
-         {← thms.mapM fun thm => ppOrigin' thm.thmOrigin}"
+      "candidate local theorems for {← ppExpr (.fvar id)} \
+         {← thms.mapM fun thm => ppOrigin thm.thmOrigin}"
 
     if let some r ← tryTheorems funPropDecl e fData thms funProp then
       return r
@@ -578,7 +577,7 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
   let globalThms ← getDeclTheorems funPropDecl funName fData.mainArgs fData.args.size
 
   trace[Meta.Tactic.fun_prop]
-    s!"candidate theorems for {funName} {← globalThms.mapM fun thm => ppOrigin' thm.thmOrigin}"
+    "candidate theorems for {funName} {← globalThms.mapM fun thm => ppOrigin thm.thmOrigin}"
 
   if let some r ← tryTheorems funPropDecl e fData globalThms funProp then
     return r
@@ -587,14 +586,14 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
   let localThms ← getLocalTheorems funPropDecl (.decl funName) fData.mainArgs fData.args.size
   if localThms.size ≠ 0 then
     trace[Meta.Tactic.fun_prop]
-      s!"candidate local theorems for {funName} \
-        {← localThms.mapM fun thm => ppOrigin' thm.thmOrigin}"
+      "candidate local theorems for {funName} \
+        {← localThms.mapM fun thm => ppOrigin thm.thmOrigin}"
   if let some r ← tryTheorems funPropDecl e fData localThms funProp then
     return r
 
   -- log error if no global or local theorems were found
   if globalThms.size = 0 && localThms.size = 0 then
-     logError s!"No theorems found for `{funName}` in order to prove `{← ppExpr e}`"
+     logError s!"No theorems found for `{funName}` in order to prove `{e}`"
 
   if (← fData.isMorApplication) != .none then
     if let some r ← applyMorRules funPropDecl e fData funProp then
@@ -602,8 +601,8 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 
   if let .comp f g ← fData.decomposition then
     trace[Meta.Tactic.fun_prop]
-      s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
-         trying again after decomposing function as: `({← ppExpr f}) ∘ ({← ppExpr g})`"
+      "failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
+         trying again after decomposing function as: `({f}) ∘ ({g})`"
 
     if let some r ← applyCompRule funPropDecl e f g funProp then
       return r
@@ -635,15 +634,14 @@ mutual
 
     let e ← instantiateMVars e
 
-    withTraceNode `Meta.Tactic.fun_prop
-      (fun _ => do pure s!"{← ppExpr e}") do
+    withTraceNode `Meta.Tactic.fun_prop (fun _ => do pure m!"{e}") do
 
     -- check cache for successful goals
     if let some { expr := _, proof? := some proof, .. } := (← get).cache.find? e then
-      trace[Meta.Tactic.fun_prop] "reusing previously found proof for {e}"
+      trace[Meta.Tactic.fun_prop] "reusing previously found proof for `{e}`"
       return some { proof := proof }
     else if (← get).failureCache.contains e then
-      trace[Meta.Tactic.fun_prop] "skipping proof search, proving {e} was tried already and failed"
+      trace[Meta.Tactic.fun_prop] "skipping proof search, proving `{e}` was tried already and failed"
       return none
     else
       -- take care of forall and let binders and run main
@@ -681,11 +679,11 @@ mutual
 
     match ← getFunctionData? f (← unfoldNamePred) with
     | .letE f =>
-      trace[Debug.Meta.Tactic.fun_prop] "let case on {← ppExpr f}"
+      trace[Debug.Meta.Tactic.fun_prop] "let case on `{f}`"
       let e := e.setArg funPropDecl.funArgId f -- update e with reduced f
       letCase funPropDecl e f funProp
     | .lam f =>
-      trace[Debug.Meta.Tactic.fun_prop] "pi case on {← ppExpr f}"
+      trace[Debug.Meta.Tactic.fun_prop] "pi case on `{f}`"
       let e := e.setArg funPropDecl.funArgId f -- update e with reduced f
       applyPiRule funPropDecl e funProp
     | .data fData =>

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -491,16 +491,16 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 
   for thm in thms do
 
-    trace[Debug.Meta.Tactic.fun_prop] "trying theorem {← ppOrigin' thm.thmOrigin}"
+    trace[Debug.Meta.Tactic.fun_prop] "trying theorem {thm.thmOrigin}"
 
     match compare thm.appliedArgs fData.args.size with
     | .lt =>
-      trace[Meta.Tactic.fun_prop] "removing argument to later use {← ppOrigin' thm.thmOrigin}"
+      trace[Meta.Tactic.fun_prop] "removing argument to later use {thm.thmOrigin}"
       if let some r ← removeArgRule funPropDecl e fData funProp then
         return r
       continue
     | .gt =>
-      trace[Meta.Tactic.fun_prop] "adding argument to later use {← ppOrigin' thm.thmOrigin}"
+      trace[Meta.Tactic.fun_prop] "adding argument to later use {thm.thmOrigin}"
       if let some r ← applyPiRule funPropDecl e funProp then
         return r
       continue

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -491,16 +491,16 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 
   for thm in thms do
 
-    trace[Debug.Meta.Tactic.fun_prop] s!"trying theorem {← ppOrigin' thm.thmOrigin}"
+    trace[Debug.Meta.Tactic.fun_prop] "trying theorem {← ppOrigin' thm.thmOrigin}"
 
     match compare thm.appliedArgs fData.args.size with
     | .lt =>
-      trace[Meta.Tactic.fun_prop] s!"removing argument to later use {← ppOrigin' thm.thmOrigin}"
+      trace[Meta.Tactic.fun_prop] "removing argument to later use {← ppOrigin' thm.thmOrigin}"
       if let some r ← removeArgRule funPropDecl e fData funProp then
         return r
       continue
     | .gt =>
-      trace[Meta.Tactic.fun_prop] s!"adding argument to later use {← ppOrigin' thm.thmOrigin}"
+      trace[Meta.Tactic.fun_prop] "adding argument to later use {← ppOrigin' thm.thmOrigin}"
       if let some r ← applyPiRule funPropDecl e funProp then
         return r
       continue

--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -99,7 +99,7 @@ def getFunProp? (e : Expr) : MetaM (Option (FunPropDecl × Expr)) := do
     return none
   else
     if decls.size > 1 then
-      throwError "fun_prop bug: expression {← ppExpr e} matches multiple function properties\n\
+      throwError "fun_prop bug: expression `{e}` matches multiple function properties\n\
         {decls.map (fun d => d.funPropName)}"
 
     let decl := decls[0]
@@ -134,7 +134,7 @@ open Elab Term in
 /-- Turn tactic syntax into a discharger function. -/
 def tacticToDischarge (tacticCode : TSyntax `tactic) : Expr → MetaM (Option Expr) := fun e =>
   withTraceNode `Meta.Tactic.fun_prop
-    (fun _ => do pure s!"discharging: {← ppExpr e}") do
+    (fun _ => do pure s!"discharging: `{← ppExpr e}`") do
     let mvar ← mkFreshExprSyntheticOpaqueMVar e `funProp.discharger
     let runTac? : TermElabM (Option Expr) :=
       try

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -80,7 +80,7 @@ def funPropTac : Tactic
             if let some n := type.getAppFn.constName?
             then s!" Consider marking `{n}` with `@[fun_prop]`."
             else ""
-          throwError "`{← ppExpr type}` is not a `fun_prop` goal!{hint}"
+          throwError "`{type}` is not a `fun_prop` goal!{hint}"
 
       let cfg ← elabFunPropConfig cfg
 

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -324,7 +324,7 @@ def getTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : Me
   let info ← getConstInfo declName
   forallTelescope info.type fun xs b => do
     let some (decl,f) ← getFunProp? b
-      | throwError "unrecognized function property `{← ppExpr b}`"
+      | throwError "unrecognized function property `{b}`"
     let funPropName := decl.funPropName
     let fData? ←
       withConfig (fun cfg => { cfg with zeta := false}) <| getFunctionData? f defaultUnfoldPred
@@ -374,7 +374,7 @@ def getTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : Me
 
         throwError "Not a valid `fun_prop` theorem!"
     | _ =>
-      throwError "unrecognized theoremType `{← ppExpr b}`"
+      throwError "unrecognized theoremType `{b}`"
 
 
 /-- Register theorem `declName` with `fun_prop`. -/

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -336,7 +336,7 @@ def getTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : Me
       }
 
     let .data fData := fData?
-      | throwError "function in invalid form {← ppExpr f}"
+      | throwError "function in invalid form {f}"
 
     match fData.fn with
     | .const funName _ =>

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -336,7 +336,7 @@ def getTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : Me
       }
 
     let .data fData := fData?
-      | throwError s!"function in invalid form {← ppExpr f}"
+      | throwError "function in invalid form {← ppExpr f}"
 
     match fData.fn with
     | .const funName _ =>

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -160,7 +160,7 @@ def increaseSteps : FunPropM Unit := do
   let numSteps := (← get).numSteps
   let maxSteps := (← read).config.maxSteps
   if numSteps > maxSteps then
-     throwError s!"fun_prop failed, maximum number({maxSteps}) of steps exceeded"
+     throwError "fun_prop failed, maximum number({maxSteps}) of steps exceeded"
   modify (fun s => {s with numSteps := s.numSteps + 1})
 
 /-- Increase transition depth. Return `none` if maximum transition depth has been reached. -/

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -160,7 +160,7 @@ def increaseSteps : FunPropM Unit := do
   let numSteps := (← get).numSteps
   let maxSteps := (← read).config.maxSteps
   if numSteps > maxSteps then
-     throwError "fun_prop failed, maximum number({maxSteps}) of steps exceeded"
+     throwError "`fun_prop` failed, maximum number ({maxSteps}) of steps exceeded"
   modify (fun s => {s with numSteps := s.numSteps + 1})
 
 /-- Increase transition depth. Return `none` if maximum transition depth has been reached. -/

--- a/Mathlib/Tactic/HigherOrder.lean
+++ b/Mathlib/Tactic/HigherOrder.lean
@@ -64,7 +64,7 @@ partial def mkHigherOrderType (e : Expr) : MetaM Expr := do
       let exp ← mkHigherOrderType body
       mkForallFVars #[fvar] exp (binderInfoForMVars := e.binderInfo)
     else
-      let some (_, lhs, rhs) ← matchEq? body | throwError "not an equality {← ppExpr body}"
+      let some (_, lhs, rhs) ← matchEq? body | throwError "not an equality `{body}`"
       mkEq (← mkComp fvar lhs) (← mkComp fvar rhs)
 
 /-- A user attribute that applies to lemmas of the shape `∀ x, f (g x) = h x`.

--- a/Mathlib/Tactic/Order.lean
+++ b/Mathlib/Tactic/Order.lean
@@ -244,7 +244,7 @@ def orderCoreImp (only? : Bool) (hyps : Array Expr) (negGoal : Expr) (g : MVarId
     trace[order] "Collected atoms:\n{atomsMsg}"
     for (type, facts) in TypeToFacts do
       let some orderType ← findBestOrderInstance type | continue
-      trace[order] "Working on type {← ppExpr type} ({orderType})"
+      trace[order] "Working on type {type} ({orderType})"
       let factsMsg := String.intercalate "\n" (facts.map toString).toList
       trace[order] "Collected facts:\n{factsMsg}"
       let facts ← replaceBotTop facts


### PR DESCRIPTION
This is not necessary (these methods take in MessageData arguments automatically, so arguments are already formatted) and can be actively harmful: with s!, expressions can get printed as _uniq.NNNN instead of the corresponding local variable.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
