### PR TITLE
[Merged by Bors] - chore: move dominated convergence to general versions for setToFun

### DIFF
--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -86,7 +86,6 @@ theorem hasSum_integral_of_dominated_convergence {ι} [Countable ι] {F : ι →
   exact hasSum_setToFun_of_dominated_convergence _ bound hF_meas h_bound bound_summable
     bound_integrable h_lim
 
-set_option backward.defeqAttrib.useBackward true in
 theorem integral_tsum {ι} [Countable ι] {f : ι → α → G} (hf : ∀ i, AEStronglyMeasurable (f i) μ)
     (hf' : ∑' i, ∫⁻ a : α, ‖f i a‖ₑ ∂μ ≠ ∞) :
     ∫ a, ∑' i, f i a ∂μ = ∑' i, ∫ a, f i a ∂μ := by

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -82,55 +82,18 @@ theorem hasSum_integral_of_dominated_convergence {ι} [Countable ι] {F : ι →
     (bound_integrable : Integrable (fun a => ∑' n, bound n a) μ)
     (h_lim : ∀ᵐ a ∂μ, HasSum (fun n => F n a) (f a)) :
     HasSum (fun n => ∫ a, F n a ∂μ) (∫ a, f a ∂μ) := by
-  have hb_nonneg : ∀ᵐ a ∂μ, ∀ n, 0 ≤ bound n a :=
-    eventually_countable_forall.2 fun n => (h_bound n).mono fun a => (norm_nonneg _).trans
-  have hb_le_tsum : ∀ n, bound n ≤ᵐ[μ] fun a => ∑' n, bound n a := by
-    intro n
-    filter_upwards [hb_nonneg, bound_summable]
-      with _ ha0 ha_sum using ha_sum.le_tsum _ fun i _ => ha0 i
-  have hF_integrable : ∀ n, Integrable (F n) μ := by
-    refine fun n => bound_integrable.mono' (hF_meas n) ?_
-    exact EventuallyLE.trans (h_bound n) (hb_le_tsum n)
-  simp only [HasSum, ← integral_finsetSum _ fun n _ => hF_integrable n]
-  refine tendsto_integral_filter_of_dominated_convergence
-      (fun a => ∑' n, bound n a) ?_ ?_ bound_integrable h_lim
-  · exact Eventually.of_forall fun s => s.aestronglyMeasurable_fun_sum fun n _ => hF_meas n
-  · filter_upwards with s
-    filter_upwards [eventually_countable_forall.2 h_bound, hb_nonneg, bound_summable]
-      with a hFa ha0 has
-    calc
-      ‖∑ n ∈ s, F n a‖ ≤ ∑ n ∈ s, bound n a := norm_sum_le_of_le _ fun n _ => hFa n
-      _ ≤ ∑' n, bound n a := has.sum_le_tsum _ (fun n _ => ha0 n)
+  simp only [integral_eq_setToFun]
+  exact hasSum_setToFun_of_dominated_convergence _ bound hF_meas h_bound bound_summable
+    bound_integrable h_lim
 
 set_option backward.defeqAttrib.useBackward true in
 theorem integral_tsum {ι} [Countable ι] {f : ι → α → G} (hf : ∀ i, AEStronglyMeasurable (f i) μ)
     (hf' : ∑' i, ∫⁻ a : α, ‖f i a‖ₑ ∂μ ≠ ∞) :
-    ∫ a : α, ∑' i, f i a ∂μ = ∑' i, ∫ a : α, f i a ∂μ := by
+    ∫ a, ∑' i, f i a ∂μ = ∑' i, ∫ a, f i a ∂μ := by
   by_cases hG : CompleteSpace G; swap
   · simp [integral, hG]
-  have hf'' i : AEMeasurable (‖f i ·‖ₑ) μ := (hf i).enorm
-  have hhh : ∀ᵐ a : α ∂μ, Summable fun n => (‖f n a‖₊ : ℝ) := by
-    rw [← lintegral_tsum hf''] at hf'
-    refine (ae_lt_top' (AEMeasurable.tsum hf'') hf').mono ?_
-    intro x hx
-    rw [← ENNReal.tsum_coe_ne_top_iff_summable_coe]
-    exact hx.ne
-  convert!
-    (MeasureTheory.hasSum_integral_of_dominated_convergence (fun i a => ‖f i a‖₊) hf _ hhh ⟨_, _⟩
-        _).tsum_eq.symm
-  · intro n
-    filter_upwards with x
-    rfl
-  · fun_prop
-  · dsimp [HasFiniteIntegral]
-    have : ∫⁻ a, ∑' n, ‖f n a‖ₑ ∂μ < ⊤ := by rwa [lintegral_tsum hf'', lt_top_iff_ne_top]
-    convert! this using 1
-    apply lintegral_congr_ae
-    simp_rw [← coe_nnnorm, ← NNReal.coe_tsum, enorm_eq_nnnorm, NNReal.nnnorm_eq]
-    filter_upwards [hhh] with a ha
-    exact ENNReal.coe_tsum (NNReal.summable_coe.mp ha)
-  · filter_upwards [hhh] with x hx
-    exact hx.of_norm.hasSum
+  simp only [integral_eq_setToFun]
+  exact setToFun_tsum _ hf hf'
 
 lemma hasSum_integral_of_summable_integral_norm {ι} [Countable ι] {F : ι → α → E}
     (hF_int : ∀ i : ι, Integrable (F i) μ) (hF_sum : Summable fun i ↦ ∫ a, ‖F i a‖ ∂μ) :
@@ -162,10 +125,8 @@ theorem tendsto_integral_filter_of_norm_le_const {ι} {l : Filter ι} [l.IsCount
     (h_bound : ∃ C, ∀ᶠ n in l, (∀ᵐ ω ∂μ, ‖F n ω‖ ≤ C))
     (h_lim : ∀ᵐ ω ∂μ, Tendsto (fun n => F n ω) l (𝓝 (f ω))) :
     Tendsto (fun n => ∫ ω, F n ω ∂μ) l (nhds (∫ ω, f ω ∂μ)) := by
-  obtain ⟨c, h_boundc⟩ := h_bound
-  let C : α → ℝ := (fun _ => c)
-  exact tendsto_integral_filter_of_dominated_convergence
-    C h_meas h_boundc (integrable_const c) h_lim
+  simp only [integral_eq_setToFun]
+  exact tendsto_setToFun_filter_of_norm_le_const _ h_meas h_bound h_lim
 
 end MeasureTheory
 

--- a/Mathlib/MeasureTheory/Integral/SetToL1.lean
+++ b/Mathlib/MeasureTheory/Integral/SetToL1.lean
@@ -5,6 +5,7 @@ Authors: Zhouhang Zhou, Yury Kudryashov, Sébastien Gouëzel, Rémy Degenne
 -/
 module
 
+public import Mathlib.MeasureTheory.Constructions.Polish.StronglyMeasurable
 public import Mathlib.MeasureTheory.Integral.FinMeasAdditive
 public import Mathlib.Analysis.Normed.Operator.Extend
 
@@ -714,9 +715,7 @@ theorem setToFun_smul_left' (hT : DominatedFinMeasAdditive μ T C)
 theorem setToFun_zero (hT : DominatedFinMeasAdditive μ T C) : setToFun μ T hT (0 : α → E) = 0 := by
   by_cases hF : CompleteSpace F; swap
   · simp [setToFun, hF]
-  rw [Pi.zero_def, setToFun_eq hT (integrable_zero _ _ _)]
-  simp only [← Pi.zero_def]
-  rw [Integrable.toL1_zero, map_zero]
+  rw [setToFun_eq hT (integrable_zero _ _ _), Integrable.toL1_zero, map_zero]
 
 @[simp]
 theorem setToFun_zero_left {hT : DominatedFinMeasAdditive μ (0 : Set α → E →L[ℝ] F) C} :
@@ -1309,6 +1308,81 @@ theorem tendsto_setToFun_filter_of_dominated_convergence (hT : DominatedFinMeasA
   · filter_upwards [h_lim]
     refine fun a h_lin => @Tendsto.comp _ _ _ (fun n => x (n + k)) (fun n => fs n a) _ _ _ h_lin ?_
     rwa [tendsto_add_atTop_iff_nat]
+
+/-- Lebesgue dominated convergence theorem for series. -/
+theorem hasSum_setToFun_of_dominated_convergence (hT : DominatedFinMeasAdditive μ T C)
+    {ι} [Countable ι] {F : ι → α → E} {f : α → E}
+    (bound : ι → α → ℝ) (hF_meas : ∀ n, AEStronglyMeasurable (F n) μ)
+    (h_bound : ∀ n, ∀ᵐ a ∂μ, ‖F n a‖ ≤ bound n a)
+    (bound_summable : ∀ᵐ a ∂μ, Summable fun n => bound n a)
+    (bound_integrable : Integrable (fun a => ∑' n, bound n a) μ)
+    (h_lim : ∀ᵐ a ∂μ, HasSum (fun n => F n a) (f a)) :
+    HasSum (fun n => setToFun μ T hT (F n)) (setToFun μ T hT f) := by
+  have hb_nonneg : ∀ᵐ a ∂μ, ∀ n, 0 ≤ bound n a :=
+    eventually_countable_forall.2 fun n => (h_bound n).mono fun a => (norm_nonneg _).trans
+  have hb_le_tsum : ∀ n, bound n ≤ᵐ[μ] fun a => ∑' n, bound n a := by
+    intro n
+    filter_upwards [hb_nonneg, bound_summable]
+      with _ ha0 ha_sum using ha_sum.le_tsum _ fun i _ => ha0 i
+  have hF_integrable : ∀ n, Integrable (F n) μ := by
+    refine fun n => bound_integrable.mono' (hF_meas n) ?_
+    exact EventuallyLE.trans (h_bound n) (hb_le_tsum n)
+  simp only [HasSum, ← setToFun_finsetSum _ _ fun n _ => hF_integrable n]
+  refine tendsto_setToFun_filter_of_dominated_convergence _
+      (fun a => ∑' n, bound n a) ?_ ?_ bound_integrable h_lim
+  · exact Eventually.of_forall fun s => s.aestronglyMeasurable_fun_sum fun n _ => hF_meas n
+  · filter_upwards with s
+    filter_upwards [eventually_countable_forall.2 h_bound, hb_nonneg, bound_summable]
+      with a hFa ha0 has
+    calc
+      ‖∑ n ∈ s, F n a‖ ≤ ∑ n ∈ s, bound n a := norm_sum_le_of_le _ fun n _ => hFa n
+      _ ≤ ∑' n, bound n a := has.sum_le_tsum _ (fun n _ => ha0 n)
+
+theorem setToFun_tsum [CompleteSpace E] (hT : DominatedFinMeasAdditive μ T C)
+    {ι} [Countable ι] {f : ι → α → E} (hf : ∀ i, AEStronglyMeasurable (f i) μ)
+    (hf' : ∑' i, ∫⁻ a : α, ‖f i a‖ₑ ∂μ ≠ ∞) :
+    setToFun μ T hT (fun a ↦ ∑' i, f i a) = ∑' i, setToFun μ T hT (f i) := by
+  by_cases hF : CompleteSpace F; swap
+  · simp [setToFun, hF]
+  have hf'' i : AEMeasurable (‖f i ·‖ₑ) μ := (hf i).enorm
+  have hhh : ∀ᵐ a : α ∂μ, Summable fun n => (‖f n a‖₊ : ℝ) := by
+    rw [← lintegral_tsum hf''] at hf'
+    refine (ae_lt_top' (AEMeasurable.tsum hf'') hf').mono ?_
+    intro x hx
+    rw [← ENNReal.tsum_coe_ne_top_iff_summable_coe]
+    exact hx.ne
+  convert!
+    (MeasureTheory.hasSum_setToFun_of_dominated_convergence hT (fun i a => ‖f i a‖₊) hf _ hhh ⟨_, _⟩
+        _).tsum_eq.symm
+  · intro n
+    filter_upwards with x
+    rfl
+  · fun_prop
+  · dsimp [HasFiniteIntegral]
+    have : ∫⁻ a, ∑' n, ‖f n a‖ₑ ∂μ < ⊤ := by rwa [lintegral_tsum hf'', lt_top_iff_ne_top]
+    convert! this using 1
+    apply lintegral_congr_ae
+    simp_rw [← coe_nnnorm, ← NNReal.coe_tsum, enorm_eq_nnnorm, NNReal.nnnorm_eq]
+    filter_upwards [hhh] with a ha
+    exact ENNReal.coe_tsum (NNReal.summable_coe.mp ha)
+  · filter_upwards [hhh] with x hx
+    exact hx.of_norm.hasSum
+
+/-- Corollary of the Lebesgue dominated convergence theorem: If a sequence of functions `F n` is
+(eventually) uniformly bounded by a constant and converges (eventually) pointwise to a
+function `f`, then the integrals of `F n` with respect to a finite measure `μ` converge
+to the integral of `f`. -/
+theorem tendsto_setToFun_filter_of_norm_le_const (hT : DominatedFinMeasAdditive μ T C)
+    {ι} {l : Filter ι} [l.IsCountablyGenerated]
+    {F : ι → α → E} [IsFiniteMeasure μ] {f : α → E}
+    (h_meas : ∀ᶠ n in l, AEStronglyMeasurable (F n) μ)
+    (h_bound : ∃ C, ∀ᶠ n in l, ∀ᵐ ω ∂μ, ‖F n ω‖ ≤ C)
+    (h_lim : ∀ᵐ ω ∂μ, Tendsto (fun n => F n ω) l (𝓝 (f ω))) :
+    Tendsto (fun n => setToFun μ T hT (F n)) l (𝓝 (setToFun μ T hT f)) := by
+  obtain ⟨c, h_boundc⟩ := h_bound
+  let C : α → ℝ := (fun _ => c)
+  exact tendsto_setToFun_filter_of_dominated_convergence hT
+    C h_meas h_boundc (integrable_const c) h_lim
 
 variable {X : Type*} [TopologicalSpace X] [FirstCountableTopology X]
 

--- a/Mathlib/MeasureTheory/Integral/SetToL1.lean
+++ b/Mathlib/MeasureTheory/Integral/SetToL1.lean
@@ -715,7 +715,9 @@ theorem setToFun_smul_left' (hT : DominatedFinMeasAdditive μ T C)
 theorem setToFun_zero (hT : DominatedFinMeasAdditive μ T C) : setToFun μ T hT (0 : α → E) = 0 := by
   by_cases hF : CompleteSpace F; swap
   · simp [setToFun, hF]
-  rw [setToFun_eq hT (integrable_zero _ _ _), Integrable.toL1_zero, map_zero]
+  rw [Pi.zero_def, setToFun_eq hT (integrable_zero _ _ _)]
+  simp only [← Pi.zero_def]
+  rw [Integrable.toL1_zero, map_zero]
 
 @[simp]
 theorem setToFun_zero_left {hT : DominatedFinMeasAdditive μ (0 : Set α → E →L[ℝ] F) C} :


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
