### PR TITLE
chore: try reverting

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -3,6 +3,7 @@ module  -- shake: keep-all, shake: keep-downstream
 public import Lean.Linter.Sets -- for the definition of linter sets
 public import Lean.LibrarySuggestions.Default -- for `+suggestions` modes in tactics
 public import Mathlib.Lean.Linter -- linter utilities; will be transitively imported in #31134
+public import Mathlib.Lean.InstancePrio -- Wraps the command elaborator to change instance priorities.
 public import Mathlib.Tactic.AdaptationNote -- make #adaptation_note available everywhere
 public import Mathlib.Tactic.Lemma
 public import Mathlib.Tactic.Linter.AuxLemma

--- a/Mathlib/Lean/InstancePrio.lean
+++ b/Mathlib/Lean/InstancePrio.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+module
+
+public meta import Lean.Elab.Declaration
+
+/-!
+# Override for the `instance` command that sets priorities automatically.
+-/
+
+public meta section
+
+namespace Lean.Elab.Command
+
+open Lean Meta Parser Command
+
+/-- Default priority used for specific instances. -/
+def specificInstancePrio := 2000
+
+/-- Wrap the declaration elaborator so more specific instances get declared with a high priority.
+
+An instance counts as unspecific if it has a trivial discrimination tree key
+(looking like `[ClassName, *, ..., *]`).
+-/
+@[command_elab declaration, incremental]
+def elabInstanceWithPrio : CommandElab := fun stx => do
+  let oldEnv := (← get).env
+  -- TODO: this is a bit fragile, what if someone else wants to wrap `elabDeclaration` themselves?
+  -- We might like to have some sort of hook instead, which can run one after another,
+  -- instead of overriding each other.
+  elabDeclaration stx
+  let newEnv := (← get).env
+  for (name, info) in newEnv.constants do
+    -- Check that `name` is an instance in `newEnv` but was not before.
+    -- This covers two cases:
+    -- * `name` is a new declaration (and so it is not in `oldEnv`, nor in `oldEnv`'s instances)
+    -- * `name` is an existing declaration (so it is in `oldEnv`), but it isn't in `oldEnv`'s instances
+    -- The first case handles `instance` and `@[instance] def`, but also `class Bar extends Foo`.
+    -- I expect the second case does not occur, but it would be useful to cover it anyway.
+    let some instEntry :=
+        instanceExtension.getState newEnv |>.instanceNames.find? name
+      | continue
+    if !isInstanceCore oldEnv name &&
+        -- Only update the priority if it has not been set already.
+        -- TODO: this check is a bit too coarse: `instance (priority := 1000) ...` should count as
+        -- a manual override, but we update it anyway.
+        instEntry.priority == 1000 then
+      -- This is adapted from `mkKey` in the implementation of `#discr_tree_key`.
+      let key ← liftTermElabM do
+        let (_, _, type) ← withReducible <| forallMetaTelescopeReducing info.type
+        let type ← whnfR type
+        DiscrTree.mkPath type
+      -- If the key doesn't look like `[ClassName, *, ..., *]`, raise the priority.
+      if key[1:].any (· != .star) then
+        instanceExtension.add
+          { instEntry with priority := specificInstancePrio }
+          (← liftCoreM <| getInstanceAttrKind? name).get!
+
+end Lean.Elab.Command

--- a/Mathlib/Lean/InstancePrio.lean
+++ b/Mathlib/Lean/InstancePrio.lean
@@ -18,7 +18,7 @@ namespace Lean.Elab.Command
 open Lean Meta Parser Command
 
 /-- Default priority used for specific instances. -/
-def specificInstancePrio := 2000
+def specificInstancePrio := 1000
 
 /-- Wrap the declaration elaborator so more specific instances get declared with a high priority.
 

--- a/MathlibTest/InstancePrio.lean
+++ b/MathlibTest/InstancePrio.lean
@@ -1,0 +1,26 @@
+import Mathlib.Init
+
+class Foo (a : Type)
+
+-- A specific instance gets a high priority.
+instance instFooNat : Foo Nat where
+/-- info: some (2000) -/
+#guard_msgs in
+#eval do Lean.logInfo m!"{← Lean.Meta.getInstancePriority? ``instFooNat}"
+
+-- While instances coming from inheritance or otherwise unspecific ones get a low priority.
+class Bar (a : Type) extends Foo a
+/-- info: some (1000) -/
+#guard_msgs in
+#eval do Lean.logInfo m!"{← Lean.Meta.getInstancePriority? ``Bar.toFoo}"
+
+instance Bar.toFoo2 [Bar a] : Foo a where
+/-- info: some (1000) -/
+#guard_msgs in
+#eval do Lean.logInfo m!"{← Lean.Meta.getInstancePriority? ``Bar.toFoo2}"
+
+-- Also make sure a specific instance that doesn't come from an `instance` command gets higher priority.
+class Baz (a : Type) extends Foo Nat
+/-- info: some (2000) -/
+#guard_msgs in
+#eval do Lean.logInfo m!"{← Lean.Meta.getInstancePriority? ``Baz.toFoo}"


### PR DESCRIPTION
Try the env extension in #40114, but without modifying the initial priorities, to see if the wild increase in build time is due to the extension or the priority tweaking.

The current PR also takes a very long time to build while the priorities should be the same as in Mathlib master, so the issue is probably with the extension.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
