### PR TITLE
[Merged by Bors] - feat(RiemannZeta): zeta in terms of completedRiemannZeta₀

### DIFF
--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -160,8 +160,8 @@ lemma riemannZeta_eq_completedRiemannZeta₀_div :
   ext1 s
   rcases eq_or_ne s 0 with rfl | hs
   · simp [riemannZeta_zero]
-  have : s / 2 ≠ 0 := by grind
-  grind [Gamma_add_one, Gammaℝ, completedRiemannZeta_eq, riemannZeta_def_of_ne_zero]
+  rw [riemannZeta_def_of_ne_zero hs, completedRiemannZeta_eq, Gammaℝ, Gamma_add_one _ (by grind)]
+  field
 
 /-- The trivial zeroes of the zeta function. -/
 theorem riemannZeta_neg_two_mul_nat_add_one (n : ℕ) : riemannZeta (-2 * (n + 1)) = 0 :=

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -154,8 +154,8 @@ lemma riemannZeta_def_of_ne_zero {s : ℂ} (hs : s ≠ 0) :
   rw [riemannZeta, hurwitzZetaEven, Function.update_of_ne hs, completedHurwitzZetaEven_zero]
 
 /-- Definition of the zeta function in terms of `completedRiemannZeta₀`. -/
-lemma riemannZeta_eq_completedRiemannZeta₀ {s : ℂ} (hs : s ≠ 0) :
-    riemannZeta s = (completedRiemannZeta₀ s - 1 / s - 1 / (1 - s)) / (π ^ (-s / 2) * Gamma (s / 2)) := by
+lemma riemannZeta_eq_completedRiemannZeta₀ {s : ℂ} (hs : s ≠ 0) : riemannZeta s =
+    (completedRiemannZeta₀ s - 1 / s - 1 / (1 - s)) / (π ^ (-s / 2) * Gamma (s / 2)) := by
   rw [riemannZeta_def_of_ne_zero hs, completedRiemannZeta_eq, Gammaℝ]
 
 /-- Version of `completedRiemannZeta₀` that avoids `s ≠ 0` -/

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -154,14 +154,18 @@ lemma riemannZeta_def_of_ne_zero {s : ℂ} (hs : s ≠ 0) :
   rw [riemannZeta, hurwitzZetaEven, Function.update_of_ne hs, completedHurwitzZetaEven_zero]
 
 /-- Definition of the zeta function in terms of `completedRiemannZeta₀`. -/
-lemma riemannZeta_eq_completedRiemannZeta₀_div :
-    riemannZeta = fun s ↦ (s * completedRiemannZeta₀ s - 1 - s / (1 - s)) /
+lemma riemannZeta_eq_completedRiemannZeta₀ {s : ℂ} (hs : s ≠ 0) :
+    riemannZeta s = (completedRiemannZeta₀ s - 1 / s - 1 / (1 - s)) / (π ^ (-s / 2) * Gamma (s / 2)) := by
+  rw [riemannZeta_def_of_ne_zero hs, completedRiemannZeta_eq, Gammaℝ]
+
+/-- Version of `completedRiemannZeta₀` that avoids `s ≠ 0` -/
+lemma riemannZeta_eq_mul_completedRiemannZeta₀ (s : ℂ) :
+    riemannZeta s = (s * completedRiemannZeta₀ s - 1 - s / (1 - s)) /
       (2 * π ^ (-s / 2) * Gamma (s / 2 + 1)) := by
-  ext1 s
   rcases eq_or_ne s 0 with rfl | hs
   · simp [riemannZeta_zero]
-  rw [riemannZeta_def_of_ne_zero hs, completedRiemannZeta_eq, Gammaℝ, Gamma_add_one _ (by grind)]
-  field
+  · rw [riemannZeta_eq_completedRiemannZeta₀ hs, Gamma_add_one (s / 2) (by grind)]
+    field
 
 /-- The trivial zeroes of the zeta function. -/
 theorem riemannZeta_neg_two_mul_nat_add_one (n : ℕ) : riemannZeta (-2 * (n + 1)) = 0 :=

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -153,6 +153,16 @@ lemma riemannZeta_def_of_ne_zero {s : ℂ} (hs : s ≠ 0) :
     riemannZeta s = completedRiemannZeta s / Gammaℝ s := by
   rw [riemannZeta, hurwitzZetaEven, Function.update_of_ne hs, completedHurwitzZetaEven_zero]
 
+/-- Definition of the zeta function in terms of `completedRiemannZeta₀`. -/
+lemma riemannZeta_eq_completedRiemannZeta₀_div :
+    riemannZeta = fun s ↦ (s * completedRiemannZeta₀ s - 1 - s / (1 - s)) /
+      (2 * π ^ (-s / 2) * Gamma (s / 2 + 1)) := by
+  ext1 s
+  rcases eq_or_ne s 0 with rfl | hs
+  · simp [riemannZeta_zero]
+  have : s / 2 ≠ 0 := by grind
+  grind [Gamma_add_one, Gammaℝ, completedRiemannZeta_eq, riemannZeta_def_of_ne_zero]
+
 /-- The trivial zeroes of the zeta function. -/
 theorem riemannZeta_neg_two_mul_nat_add_one (n : ℕ) : riemannZeta (-2 * (n + 1)) = 0 :=
   hurwitzZetaEven_neg_two_mul_nat_add_one 0 n


### PR DESCRIPTION
Gives riemannZeta directly in terms of completedRiemannZeta₀, which is useful for some computations.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
