### PR TITLE
[Merged by Bors] - chore(CategoryTheory): dualise preservation of multicoequalizers

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Multiequalizer.lean
@@ -32,6 +32,61 @@ variable {C D : Type*} [Category* C] [Category* D]
 
 namespace Limits
 
+section Multifork
+
+variable {J : MulticospanShape.{w, w'}} (d : MulticospanIndex J C)
+  (c : Multifork d) (F : C ⥤ D)
+
+/-- The multicospan index obtained by applying a functor. -/
+@[simps]
+def MulticospanIndex.map : MulticospanIndex J D where
+  left i := F.obj (d.left i)
+  right i := F.obj (d.right i)
+  fst i := F.map (d.fst i)
+  snd i := F.map (d.snd i)
+
+set_option backward.defeqAttrib.useBackward true in
+/-- If `d : MulticospanIndex J C` and `F : C ⥤ D`, this is the obvious isomorphism
+`(d.map F).multicospan ≅ d.multicospan ⋙ F`. -/
+@[simps!]
+def MulticospanIndex.multicospanMapIso : (d.map F).multicospan ≅ d.multicospan ⋙ F :=
+  NatIso.ofComponents
+    (fun i ↦ match i with
+      | .left _ => Iso.refl _
+      | .right _ => Iso.refl _)
+    (by rintro a b (_ | _) <;> simp)
+
+variable {d}
+
+set_option backward.defeqAttrib.useBackward true in
+/-- If `d : MulticospanIndex J C`, `c : Multifork d` and `F : C ⥤ D`,
+this is the induced multifork of `d.map F`. -/
+@[simps!]
+def Multifork.map : Multifork (d.map F) :=
+  Multifork.ofι _ (F.obj c.pt) (fun i ↦ F.map (c.ι i)) (fun j ↦ by
+    dsimp
+    rw [← F.map_comp, ← F.map_comp, condition])
+
+set_option backward.defeqAttrib.useBackward true in
+/-- If `d : MulticospanIndex J C`, `c : Multifork d` and `F : C ⥤ D`,
+the cone `F.mapCone c` is limiting iff the multifork `c.map F` is. -/
+def Multifork.isLimitMapEquiv :
+    IsLimit (F.mapCone c) ≃ IsLimit (c.map F) :=
+  Equiv.trans (IsLimit.postcomposeInvEquiv (d.multicospanMapIso F) (F.mapCone c)).symm
+    (IsLimit.equivIsoLimit
+      (Multifork.ext (Iso.refl _) (fun i ↦ by dsimp only [Multifork.ι]; simp)))
+
+/-- If `d : MulticospanIndex J C`, `c : Multifork d` is a limit multifork,
+and `F : C ⥤ D` is a functor which preserves the limit of `d.multicospan`,
+then the multifork `c.map F` is limiting. -/
+noncomputable def Multifork.isLimitMapOfPreserves
+    [PreservesLimit d.multicospan F] (hc : IsLimit c) : IsLimit (c.map F) :=
+  (isLimitMapEquiv c F) (isLimitOfPreserves F hc)
+
+end Multifork
+
+section Multicofork
+
 variable {J : MultispanShape.{w, w'}} (d : MultispanIndex J C)
   (c : Multicofork d) (F : C ⥤ D)
 
@@ -80,6 +135,8 @@ then the multicofork `c.map F` is colimit. -/
 noncomputable def Multicofork.isColimitMapOfPreserves
     [PreservesColimit d.multispan F] (hc : IsColimit c) : IsColimit (c.map F) :=
   (isColimitMapEquiv c F) (isColimitOfPreserves F hc)
+
+end Multicofork
 
 end Limits
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -329,7 +329,6 @@ variable {C : Type u} [Category.{v} C] {J : MulticospanShape.{w, w'}}
   (I : MulticospanIndex J C)
 
 /-- The multicospan associated to `I : MulticospanIndex`. -/
-@[simps]
 def multicospan : WalkingMulticospan J ⥤ C where
   obj x :=
     match x with
@@ -344,6 +343,22 @@ def multicospan : WalkingMulticospan J ⥤ C where
     rintro (_ | _) <;> rfl
   map_comp := by
     rintro (_ | _) (_ | _) (_ | _) (_ | _ | _) (_ | _ | _) <;> cat_disch
+
+@[simp]
+theorem multicospan_obj_left (a) : I.multicospan.obj (WalkingMulticospan.left a) = I.left a :=
+  rfl
+
+@[simp]
+theorem multicospan_obj_right (b) : I.multicospan.obj (WalkingMulticospan.right b) = I.right b :=
+  rfl
+
+@[simp]
+theorem multicospan_map_fst (a) : I.multicospan.map (WalkingMulticospan.Hom.fst a) = I.fst a :=
+  rfl
+
+@[simp]
+theorem multicospan_map_snd (a) : I.multicospan.map (WalkingMulticospan.Hom.snd a) = I.snd a :=
+  rfl
 
 /-- The induced map `∏ᶜ I.left ⟶ ∏ᶜ I.right` via `I.fst` for limiting fans. -/
 def fstPiMapOfIsLimit (c : Fan I.left) {d : Fan I.right} (hd : IsLimit d) : c.pt ⟶ d.pt :=

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -329,6 +329,7 @@ variable {C : Type u} [Category.{v} C] {J : MulticospanShape.{w, w'}}
   (I : MulticospanIndex J C)
 
 /-- The multicospan associated to `I : MulticospanIndex`. -/
+@[simps]
 def multicospan : WalkingMulticospan J ⥤ C where
   obj x :=
     match x with
@@ -419,6 +420,7 @@ variable {C : Type u} [Category.{v} C] {J : MultispanShape.{w, w'}}
     (I : MultispanIndex J C)
 
 /-- The multispan associated to `I : MultispanIndex`. -/
+@[simps]
 def multispan : WalkingMultispan J ⥤ C where
   obj x :=
     match x with

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -420,7 +420,6 @@ variable {C : Type u} [Category.{v} C] {J : MultispanShape.{w, w'}}
     (I : MultispanIndex J C)
 
 /-- The multispan associated to `I : MultispanIndex`. -/
-@[simps]
 def multispan : WalkingMultispan J ⥤ C where
   obj x :=
     match x with

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -329,7 +329,6 @@ variable {C : Type u} [Category.{v} C] {J : MulticospanShape.{w, w'}}
   (I : MulticospanIndex J C)
 
 /-- The multicospan associated to `I : MulticospanIndex`. -/
-@[simps]
 def multicospan : WalkingMulticospan J ⥤ C where
   obj x :=
     match x with

--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/OneHypercoverDense.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/OneHypercoverDense.lean
@@ -801,7 +801,7 @@ lemma isSheaf : Presheaf.IsSheaf J (presheaf data G₀) := by
           (fun _ ↦ (compPresheafIso _ _).hom.naturality _)) _).1
       (IsLimit.ofIsoLimit (presheafObjIsLimit data G₀ X)
         (Multifork.ext (Iso.refl _) (fun i ↦ ?_)))⟩
-    simp [Multifork.ι, PreOneHypercover.multifork]
+    simp [Multifork.ι, PreOneHypercover.multifork, MulticospanIndex.multicospan]
 
 /-- Let `F : C₀ ⥤ C` be a dense subsite and `data : ∀ X, F.OneHypercoverDenseData J₀ J X`
 be a family of structures. Let `G₀` be a sheaf on `C₀`. This is a sheaf on `C` which

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -119,20 +119,8 @@ def multicospanComp : (S.index (P ⋙ F)).multicospan ≅ (S.index P).multicospa
       | WalkingMulticospan.left _ => Iso.refl _
       | WalkingMulticospan.right _ => Iso.refl _)
     (by
-      #adaptation_note /-- Proof repaired after leanprover/lean4#13363.
-      The body of this `by` block was previously
-      ```
       rintro (a | b) (a | b) (f | f | f)
-      all_goals cat_disch
-      ```
-      The replacement proof is a short-term fix, and we request that the authors/maintainers of
-      this file review the proof, and either approve it by removing this note,
-      revise the proof or the prerequisites appropriately, or minimize a problem in lean4 that
-      still needs addressing. -/
-      rintro (a | b) (a | b) (f | f | f) <;>
-        simp only [WalkingMulticospan.Hom.id_eq_id, Iso.refl_hom, Category.id_comp,
-          Category.comp_id, Functor.map_id] <;>
-        dsimp [CategoryStruct.comp] <;> simp)
+      all_goals cat_disch)
 
 set_option backward.defeqAttrib.useBackward true in
 /-- Mapping the multifork associated to a cover `S : J.Cover X` and a presheaf `P` with


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
