### PR TITLE
[Merged by Bors] - fix(CategoryTheory/Adjunction): make the left and right triangle identities type-correct

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -269,11 +269,15 @@ theorem homEquiv_naturality_right_square_iff (f : X' ⟶ X) (g : X ⟶ G.obj Y')
     homEquiv_naturality_right_square adj f g h k⟩
 
 @[simp]
-theorem left_triangle : whiskerRight adj.unit F ≫ whiskerLeft F adj.counit = 𝟙 _ := by
+theorem left_triangle :
+    whiskerRight adj.unit F ≫ (Functor.associator ..).hom ≫ whiskerLeft F adj.counit =
+    F.leftUnitor.hom ≫ F.rightUnitor.inv := by
   ext; simp
 
 @[simp]
-theorem right_triangle : whiskerLeft G adj.unit ≫ whiskerRight adj.counit G = 𝟙 _ := by
+theorem right_triangle :
+    whiskerLeft G adj.unit ≫ (Functor.associator ..).inv ≫ whiskerRight adj.counit G =
+    G.rightUnitor.hom ≫ G.leftUnitor.inv := by
   ext; simp
 
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -171,8 +171,9 @@ noncomputable def fullyFaithfulROfIsIsoCounit [IsIso h.counit] : R.FullyFaithful
 set_option backward.isDefEq.respectTransparency false in
 instance whiskerLeft_counit_iso_of_L_fully_faithful [L.Full] [L.Faithful] :
     IsIso (whiskerLeft L h.counit) := by
-  have := h.left_triangle
-  rw [← IsIso.eq_inv_comp] at this
+  have := ((Functor.associator ..).inv ≫ whiskerRight (inv h.unit) L) ≫= h.left_triangle
+  simp only [assoc, ← whiskerRight_comp_assoc, IsIso.inv_hom_id, whiskerRight_id', id_comp,
+    Iso.inv_hom_id_assoc] at this
   rw [this]
   infer_instance
 
@@ -180,11 +181,10 @@ set_option backward.isDefEq.respectTransparency false in
 instance whiskerRight_counit_iso_of_L_fully_faithful [L.Full] [L.Faithful] :
     IsIso (whiskerRight h.counit R) := by
   have := h.right_triangle
-  rw [← IsIso.eq_inv_comp] at this
+  rw [← IsIso.eq_inv_comp, Iso.inv_comp_eq] at this
   rw [this]
   infer_instance
 
-set_option backward.isDefEq.respectTransparency false in
 instance whiskerLeft_unit_iso_of_R_fully_faithful [R.Full] [R.Faithful] :
     IsIso (whiskerLeft R h.unit) := by
   have := h.right_triangle
@@ -192,7 +192,6 @@ instance whiskerLeft_unit_iso_of_R_fully_faithful [R.Full] [R.Faithful] :
   rw [this]
   infer_instance
 
-set_option backward.isDefEq.respectTransparency false in
 instance whiskerRight_unit_iso_of_R_fully_faithful [R.Full] [R.Faithful] :
     IsIso (whiskerRight h.unit L) := by
   have := h.left_triangle

--- a/Mathlib/CategoryTheory/Localization/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Localization/Adjunction.lean
@@ -95,8 +95,7 @@ noncomputable def localization : G' ⊣ F' :=
       left_triangle := by
         apply natTrans_ext L₁ W₁
         intro X₁
-        have eq := congr_app adj.left_triangle X₁
-        dsimp at eq
+        have eq := adj.left_triangle_components X₁
         rw [NatTrans.comp_app, NatTrans.comp_app, whiskerRight_app, Localization.ε_app,
           Functor.associator_hom_app, id_comp, whiskerLeft_app, G'.map_comp, G'.map_comp,
           assoc, assoc]
@@ -108,8 +107,7 @@ noncomputable def localization : G' ⊣ F' :=
       right_triangle := by
         apply natTrans_ext L₂ W₂
         intro X₂
-        have eq := congr_app adj.right_triangle X₂
-        dsimp at eq
+        have eq := adj.right_triangle_components X₂
         rw [NatTrans.comp_app, NatTrans.comp_app, whiskerLeft_app, whiskerRight_app,
           Localization.η_app, Functor.associator_inv_app, id_comp, F'.map_comp, F'.map_comp]
         erw [← (Localization.ε _ _ _ _ _ _).naturality_assoc, Localization.ε_app,

--- a/Mathlib/CategoryTheory/Sites/Sheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheafification.lean
@@ -149,9 +149,7 @@ variable {D}
 set_option backward.defeqAttrib.useBackward true in
 theorem isIso_toSheafify {P : Cᵒᵖ ⥤ D} (hP : Presheaf.IsSheaf J P) : IsIso (toSheafify J P) := by
   refine ⟨(sheafificationAdjunction J D |>.counit.app ⟨P, hP⟩).hom, ?_, ?_⟩
-  · change _ = (𝟙 (sheafToPresheaf J D ⋙ 𝟭 (Cᵒᵖ ⥤ D)) :).app ⟨P, hP⟩
-    rw [← sheafificationAdjunction J D |>.right_triangle]
-    rfl
+  · exact sheafificationAdjunction J D |>.right_triangle_components ⟨P, hP⟩
   · change (sheafToPresheaf _ _).map _ ≫ _ = _
     change _ ≫ (sheafificationAdjunction J D).unit.app ((sheafToPresheaf J D).obj ⟨P, hP⟩) = _
     rw [← (sheafificationAdjunction J D).inv_counit_map (X := ⟨P, hP⟩)]


### PR DESCRIPTION
The current lemmas `CategoryTheory.Adjunction.left_triangle` and `CategoryTheory.Adjunction.right_triangle` abuse strict associativity and unitality of functor compositions and are missing associators and unitors. Their expressions are changed to be correct and proofs relying on this are reworked.

This came up in #39867.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
