### PR TITLE
[Merged by Bors] - feat(Tactic): introduce `bdsimp` as a backward compatible version of `bdsimp`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7093,6 +7093,7 @@ public import Mathlib.Tactic.ArithMult
 public import Mathlib.Tactic.ArithMult.Init
 public import Mathlib.Tactic.Attr.Core
 public import Mathlib.Tactic.Attr.Register
+public import Mathlib.Tactic.BDSimp
 public import Mathlib.Tactic.Basic
 public import Mathlib.Tactic.Bound
 public import Mathlib.Tactic.Bound.Attribute

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -13,6 +13,7 @@ public import Mathlib.Tactic.ArithMult
 public import Mathlib.Tactic.ArithMult.Init
 public import Mathlib.Tactic.Attr.Core
 public import Mathlib.Tactic.Attr.Register
+public import Mathlib.Tactic.BDSimp
 public import Mathlib.Tactic.Basic
 public import Mathlib.Tactic.Bound
 public import Mathlib.Tactic.Bound.Attribute

--- a/Mathlib/Tactic/BDSimp.lean
+++ b/Mathlib/Tactic/BDSimp.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+module
+
+import Mathlib.Init
+
+/-!
+# `bdsimp` tactic
+
+`bdsimp` is a backward compatibility macro for `dsimp` that allows dependent rewrites inside
+depended-on positions.
+-/
+
+public meta section
+
+open Lean.Parser.Tactic
+
+/-- `bdsimp` definitionally simplifies the goal. This is a backward compatibility macro for `dsimp`.
+Like `dsimp`, it applies only theorems that hold by reflexivity, and the result is guaranteed to be
+definitionally equal to the input. The difference is that `bdsimp` allows any theorem whose proof is
+reflexivity, while `dsimp` requires the proof to hold at `.instances` transparency level.
+
+This tactic is a temporary workaround.
+`bdsimp` also rewrites in depended-on positions, which means the result can fail to typecheck at
+the expected `.instances` transparency level. For example:
+```lean
+@[expose] def two := 2
+@[defeq] lemma two_eq : two = 2 := by rfl
+instance : NeZero two := inferInstanceAs (NeZero 2)
+
+example (x : Fin two) : x * 0 = 0 := by
+  bdsimp only [two_eq]
+  fail_if_success rw [Fin.mul_zero] -- Fails: `x : Fin two` but `· * · : Fin 2 → Fin 2 → Fin 2`
+```
+
+This tactic supports all options supported by `dsimp`.
+-/
+syntax (name := bdsimp) "bdsimp" optConfig (discharger)? (&" only")?
+  (" [" withoutPosition((simpErase <|> simpLemma),*,?) "]")? (location)? : tactic
+
+macro_rules
+| `(tactic|bdsimp $cfg $[$disch]? $[only%$only]? $[[$lemmas]]? $[$loc]?) =>
+    `(tactic|set_option backward.defeqAttrib.useBackward true in
+      dsimp $cfg $[$disch]? $[only%$only]? $[[$lemmas]]? $[$loc]?)


### PR DESCRIPTION
This PR adds a tactic `bdsimp` which behaves like `dsimp` from before Lean v4.30.0. This is a temporary workaround until we can get a more principled (reducible-defeq respecting) version working.

Zulip thread: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.40.5Bsimps.5D.20fails.20to.20declare.20some.20lemmas.20as.20defeq/near/599343452

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
