### PR TITLE
[Merged by Bors] - chore(ci): harden untrusted-PR-checkout workflows

### DIFF
--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -22,6 +22,8 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
         path: pr-branch
+        # Untrusted (potentially fork) checkout: don't persist the GITHUB_TOKEN into its .git/config.
+        persist-credentials: false
 
     - name: Checkout local actions
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/add_label_from_diff.yaml
+++ b/.github/workflows/add_label_from_diff.yaml
@@ -43,6 +43,8 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         fetch-depth: 0
         path: pr-branch
+        # Untrusted (potentially fork) checkout: don't persist the GITHUB_TOKEN into its .git/config.
+        persist-credentials: false
     - name: Run autolabel
       working-directory: pr-branch
       run: |

--- a/.github/workflows/bot_fix_style.yaml
+++ b/.github/workflows/bot_fix_style.yaml
@@ -12,6 +12,14 @@ on:
     # triggers on a review comment
     types: [created, edited]
 
+# `lint-style-action` in `fix` mode pushes a style-fix commit and reacts/comments
+# on the PR. Grant exactly those scopes rather than inheriting the default token
+# permissions; all other scopes are implicitly 'none'.
+permissions:
+  contents: write       # push the style-fix commit to the PR branch
+  pull-requests: write  # add the bot's reaction/comment
+  issues: write         # PR comment reactions go through the issues API
+
 jobs:
   fix_style:
     # we set some variables. The ones of the form `${{ X }}${{ Y }}` are typically not

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -127,6 +127,9 @@ jobs:
           ref: ${{ inputs.pr_branch_ref }}
           fetch-depth: 2 # we may fetch cache from the commit before this one (or earlier)
           path: pr-branch
+          # This is an untrusted (potentially fork) checkout whose code we build.
+          # Don't leave the GITHUB_TOKEN in pr-branch/.git/config, where that code could read it.
+          persist-credentials: false
 
       - name: Prepare DownstreamTest directory
         shell: bash
@@ -689,6 +692,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pr_branch_ref }}
+          # Untrusted (potentially fork) checkout: don't persist the GITHUB_TOKEN into its .git/config.
+          persist-credentials: false
 
       - name: Configure Lean
         uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -13,6 +13,13 @@ on:
   pull_request_review_comment:
     types: [created]
 
+# This job only parses the triggering comment and emits an artifact for the
+# privileged `maintainer_bors_wf_run` workflow to consume; it never uses the
+# token to mutate the repo. Keep it read-only rather than inheriting the
+# default token permissions.
+permissions:
+  contents: read
+
 jobs:
   add_ready_to_merge_label:
     # we set some variables. The ones of the form `${{ X }}${{ Y }}` are typically not

--- a/.github/workflows/olean_report.yaml
+++ b/.github/workflows/olean_report.yaml
@@ -88,6 +88,8 @@ jobs:
           ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 0
           path: pr-branch
+          # Untrusted (potentially fork) checkout: don't persist the GITHUB_TOKEN into its .git/config.
+          persist-credentials: false
 
       # Check out master into tools-branch.  We build the `cache` binary from
       # here so that a single binary can fetch oleans for both checkouts.


### PR DESCRIPTION
Preemptive hardening of our PR-triggered workflows. None of these currently give attack surface, but they are typical 'smells' that could be flagged by a security scan, so let's just address them.

- `persist-credentials: false` on every checkout of untrusted (potentially fork) PR-head content. Today this is harmless: the data-only checkouts never run PR code, and the one job that builds PR code runs under landrun with no network. This just stops the `GITHUB_TOKEN` from being written into the checked-out tree's `.git/config` regardless.
- Explicit least-privilege `permissions:` on two comment-triggered workflows that were inheriting the default token.

No behavioral changes: all affected git operations are unauthenticated reads on a public repo, and none of these jobs push from the untrusted checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)