### PR TITLE
[Merged by Bors] - feat(ci): publish prebuilt CI tools from master as an artifact

### DIFF
--- a/.github/workflows/publish_tools.yml
+++ b/.github/workflows/publish_tools.yml
@@ -97,6 +97,6 @@ jobs:
           name: tools-bin
           path: tools-bin.tar.gz
           # Master is pushed frequently, so a short retention keeps storage bounded
-          # while always leaving a recent artifact available, even over a quiet weekend.
+          # while still leaving a recent artifact available.
           retention-days: 7
           if-no-files-found: error

--- a/.github/workflows/publish_tools.yml
+++ b/.github/workflows/publish_tools.yml
@@ -72,6 +72,20 @@ jobs:
           # Tarball (rather than a plain directory artifact) so that executable bits
           # and the hidden `.lake` directory survive upload/download without relying
           # on `include-hidden-files` or post-download `chmod`.
+          #
+          # We bundle exactly what `build_template.yml` invokes from `tools-branch/`:
+          #   - .lake/build:                    holds the `cache` binary that the build
+          #                                     job runs by path (.lake/build/bin/cache).
+          #                                     We include the whole build dir, not just
+          #                                     the binary, so any shared libraries it
+          #                                     resolves via rpath sit beside it.
+          #   - scripts/lake-build-with-retry.sh: builds Mathlib/Archive/Counterexamples
+          #                                     with retries.
+          #   - scripts/lake-build-wrapper.py:  wraps the `lake test` step.
+          #   - lean-toolchain:                 the toolchain the binary was linked
+          #                                     against; the consumer `elan toolchain
+          #                                     install`s it so the prebuilt binary has a
+          #                                     matching runtime even on a bump PR.
           tar -czf "${GITHUB_WORKSPACE}/tools-bin.tar.gz" \
             .lake/build \
             scripts/lake-build-with-retry.sh \

--- a/.github/workflows/publish_tools.yml
+++ b/.github/workflows/publish_tools.yml
@@ -1,0 +1,90 @@
+# Builds the trusted CI tooling (`cache` binary + the `lake-build-*` helper scripts)
+# from `master` and publishes them as a small artifact (`tools-bin`).
+#
+# `build_template.yml` normally checks out `master` and builds these tools from
+# source on *every* CI run (the "build tools-branch tools" step, ~30s + a full
+# checkout). Instead, regular CI runs download the artifact produced here via the
+# `get-tools` composite action, and only fall back to building from source when no
+# artifact is available or a non-`master` tools branch is requested (bors, ci_dev,
+# nightly-testing).
+#
+# Trust model: this workflow is triggered *only* by pushes to `master` on the
+# canonical repository, so every artifact it emits is provably built from trusted
+# `master` code. The consumer pins its download to this workflow's `push` runs on
+# `master`, preserving the same guarantee that the previous `master` checkout gave.
+name: publish CI tools
+
+on:
+  push:
+    branches:
+      - master
+  # Allow manual rebuilds (e.g. after fixing a broken tools build).
+  workflow_dispatch:
+
+concurrency:
+  # Only keep the latest publish run; superseded master pushes are cancelled.
+  group: publish-tools-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish tools
+    # Only publish from the canonical repository. nightly-testing has no `master`
+    # branch and builds its tools from `nightly-testing-green` on demand instead.
+    if: github.repository == 'leanprover-community/mathlib4'
+    # Must run on the same runner class as the consumers (build_template's `pr`
+    # runners) so the produced binary is ABI/toolchain/path compatible.
+    runs-on: pr
+    steps:
+      # Build in `tools-branch/` so the on-disk layout (and absolute paths baked
+      # into any rpaths) matches exactly what `build_template.yml` reconstructs.
+      - name: Checkout master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          path: tools-branch
+
+      - name: install elan
+        shell: bash
+        run: |
+          set -o pipefail
+          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
+          chmod +x elan-init.sh
+          ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      - name: build tools
+        shell: bash
+        run: |
+          cd tools-branch
+          # `check-yaml` and `graph` are built as a smoke test that master's tools
+          # still compile; only `cache` is bundled (the only one consumed by path).
+          lake build cache check-yaml graph
+          ls .lake/build/bin/cache
+
+      - name: bundle tools
+        shell: bash
+        run: |
+          cd tools-branch
+          # Tarball (rather than a plain directory artifact) so that executable bits
+          # and the hidden `.lake` directory survive upload/download without relying
+          # on `include-hidden-files` or post-download `chmod`.
+          tar -czf "${GITHUB_WORKSPACE}/tools-bin.tar.gz" \
+            .lake/build \
+            scripts/lake-build-with-retry.sh \
+            scripts/lake-build-wrapper.py \
+            lean-toolchain
+          ls -l "${GITHUB_WORKSPACE}/tools-bin.tar.gz"
+
+      - name: upload tools artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tools-bin
+          path: tools-bin.tar.gz
+          # Master is pushed frequently, so a short retention keeps storage bounded
+          # while always leaving a recent artifact available, even over a quiet weekend.
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/publish_tools.yml
+++ b/.github/workflows/publish_tools.yml
@@ -35,12 +35,12 @@ jobs:
     # Only publish from the canonical repository. nightly-testing has no `master`
     # branch and builds its tools from `nightly-testing-green` on demand instead.
     if: github.repository == 'leanprover-community/mathlib4'
-    # Must run on the same runner class as the consumers (build_template's `pr`
-    # runners) so the produced binary is ABI/toolchain/path compatible.
+    # Must run on the same kind of runner as the consumers (build_template's `pr`
+    # runners), so the binary we build here will run on the machines that use it.
     runs-on: pr
     steps:
-      # Build in `tools-branch/` so the on-disk layout (and absolute paths baked
-      # into any rpaths) matches exactly what `build_template.yml` reconstructs.
+      # Build under `tools-branch/`, the same directory `build_template.yml` unpacks
+      # the tools into, in case the build bakes its own location into the binary.
       - name: Checkout master
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -76,16 +76,16 @@ jobs:
           # We bundle exactly what `build_template.yml` invokes from `tools-branch/`:
           #   - .lake/build:                    holds the `cache` binary that the build
           #                                     job runs by path (.lake/build/bin/cache).
-          #                                     We include the whole build dir, not just
-          #                                     the binary, so any shared libraries it
-          #                                     resolves via rpath sit beside it.
+          #                                     We ship the whole build dir, not just the
+          #                                     binary, in case it needs other files there
+          #                                     to run.
           #   - scripts/lake-build-with-retry.sh: builds Mathlib/Archive/Counterexamples
           #                                     with retries.
           #   - scripts/lake-build-wrapper.py:  wraps the `lake test` step.
-          #   - lean-toolchain:                 the toolchain the binary was linked
-          #                                     against; the consumer `elan toolchain
-          #                                     install`s it so the prebuilt binary has a
-          #                                     matching runtime even on a bump PR.
+          #   - lean-toolchain:                 the toolchain this binary was built with;
+          #                                     the consumer installs it (via elan) so the
+          #                                     binary has a matching Lean to run against,
+          #                                     even when the PR uses a newer toolchain.
           tar -czf "${GITHUB_WORKSPACE}/tools-bin.tar.gz" \
             .lake/build \
             scripts/lake-build-with-retry.sh \

--- a/.github/workflows/publish_tools.yml
+++ b/.github/workflows/publish_tools.yml
@@ -1,17 +1,15 @@
 # Builds the trusted CI tooling (`cache` binary + the `lake-build-*` helper scripts)
 # from `master` and publishes them as a small artifact (`tools-bin`).
 #
-# `build_template.yml` normally checks out `master` and builds these tools from
-# source on *every* CI run (the "build tools-branch tools" step, ~30s + a full
-# checkout). Instead, regular CI runs download the artifact produced here via the
-# `get-tools` composite action, and only fall back to building from source when no
-# artifact is available or a non-`master` tools branch is requested (bors, ci_dev,
-# nightly-testing).
+# CI runs (build_template.yml, via the `get-tools` composite action) download this
+# artifact and use the tools directly, saving a full `master` checkout plus a ~30s
+# build on every run. They build the tools from source only when no artifact is
+# available or a non-`master` tools branch is requested (bors, ci_dev, nightly-testing).
 #
 # Trust model: this workflow is triggered *only* by pushes to `master` on the
-# canonical repository, so every artifact it emits is provably built from trusted
-# `master` code. The consumer pins its download to this workflow's `push` runs on
-# `master`, preserving the same guarantee that the previous `master` checkout gave.
+# canonical repository, so every artifact it emits is built from trusted `master`
+# code, and the consumer pins its download to this workflow's `master` `push` runs.
+# The tools a CI run executes are therefore always built from trusted `master` code.
 name: publish CI tools
 
 on:


### PR DESCRIPTION
Add a workflow that, on every push to master, builds the trusted CI tooling (the `cache` binary + the `lake-build-*` helper scripts) and publishes them as a small `tools-bin` tarball artifact. CI runs can then download this instead of rebuilding the tools from a master checkout on every run