### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Submonoid/Units): units in `MonoidHom.eqLocusM`

### DIFF
--- a/Mathlib/Algebra/Group/Submonoid/Units.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Units.lean
@@ -350,3 +350,6 @@ theorem MonoidHom.isUnit_eqLocusM_mk_iff {N : Type*} [Monoid N] (f g : M →* N)
   refine ⟨s, hs.left, ?_, hs.right⟩
   rw [← mul_one (f s), ← map_one g, ← hs.left, map_mul, ← mul_assoc, ← hr, ← map_mul,
     hs.right, map_one, one_mul]
+
+instance {N : Type*} [Monoid N] (f g : M →* N) : IsLocalHom (f.eqLocusM g).subtype where
+  map_nonunit r := f.isUnit_eqLocusM_mk_iff g r.prop |>.2

--- a/Mathlib/Algebra/Group/Submonoid/Units.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Units.lean
@@ -341,8 +341,8 @@ def unitsEquivSelf (H : Subgroup G) : H.units ≃* H :=
 end Subgroup
 
 @[to_additive]
-theorem MonoidHom.isUnit_eqLocusM_mk_iff {M N : Type*} [Monoid M] [Monoid N]
-    (f g : M →* N) {r : M} (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocusM g) ↔ IsUnit r := by
+theorem MonoidHom.isUnit_eqLocusM_mk_iff {N : Type*} [Monoid N] (f g : M →* N) {r : M}
+    (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocusM g) ↔ IsUnit r := by
   refine ⟨fun h ↦ h.map (SubmonoidClass.subtype _), fun h ↦ ?_⟩
   obtain ⟨s, hs⟩ := isUnit_iff_exists.mp h
   suffices ∃ a, r * a = 1 ∧ f a = g a ∧ a * r = 1 by

--- a/Mathlib/Algebra/Group/Submonoid/Units.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Units.lean
@@ -339,3 +339,14 @@ def unitsEquivSelf (H : Subgroup G) : H.units ≃* H :=
   H.unitsEquivUnitsType.trans (toUnits (G := H)).symm
 
 end Subgroup
+
+@[to_additive]
+theorem MonoidHom.isUnit_eqLocusM_mk_iff {M N : Type*} [Monoid M] [Monoid N]
+    (f g : M →* N) {r : M} (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocusM g) ↔ IsUnit r := by
+  refine ⟨fun h ↦ h.map (SubmonoidClass.subtype _), fun h ↦ ?_⟩
+  obtain ⟨s, hs⟩ := isUnit_iff_exists.mp h
+  suffices ∃ a, r * a = 1 ∧ f a = g a ∧ a * r = 1 by
+    simpa [isUnit_iff_exists, ← Subtype.val_inj]
+  refine ⟨s, hs.left, ?_, hs.right⟩
+  rw [← mul_one (f s), ← map_one g, ← hs.left, map_mul, ← mul_assoc, ← hr, ← map_mul,
+    hs.right, map_one, one_mul]

--- a/Mathlib/Algebra/Ring/Subring/Units.lean
+++ b/Mathlib/Algebra/Ring/Subring/Units.lean
@@ -33,10 +33,22 @@ theorem Units.mem_posSubgroup {R : Type*} [Semiring R] [LinearOrder R] [IsStrict
     (u : Rˣ) : u ∈ Units.posSubgroup R ↔ (0 : R) < u :=
   Iff.rfl
 
-theorem RingHom.isUnit_eqLocusS_mk_iff {R T : Type*} [Semiring R] [Semiring T] (f g : R →+* T)
-    {r : R} (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocusS g) ↔ IsUnit r :=
+namespace RingHom
+
+variable {R T : Type*} [Semiring T]
+
+theorem isUnit_eqLocusS_mk_iff [Semiring R] (f g : R →+* T) {r : R} (hr : f r = g r) :
+    IsUnit (⟨r, hr⟩ : f.eqLocusS g) ↔ IsUnit r :=
   MonoidHom.isUnit_eqLocusM_mk_iff ..
 
-theorem RingHom.isUnit_eqLocus_mk_iff {R T : Type*} [Ring R] [Semiring T] (f g : R →+* T)
-    {r : R} (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocus g) ↔ IsUnit r :=
+theorem isUnit_eqLocus_mk_iff [Ring R] (f g : R →+* T) {r : R} (hr : f r = g r) :
+    IsUnit (⟨r, hr⟩ : f.eqLocus g) ↔ IsUnit r :=
   MonoidHom.isUnit_eqLocusM_mk_iff ..
+
+instance [Semiring R] (f g : R →+* T) : IsLocalHom (f.eqLocusS g).subtype where
+  map_nonunit r := f.isUnit_eqLocusS_mk_iff g r.prop |>.2
+
+instance [Ring R] (f g : R →+* T) : IsLocalHom (f.eqLocus g).subtype where
+  map_nonunit r := f.isUnit_eqLocus_mk_iff g r.prop |>.2
+
+end RingHom

--- a/Mathlib/Algebra/Ring/Subring/Units.lean
+++ b/Mathlib/Algebra/Ring/Subring/Units.lean
@@ -11,6 +11,8 @@ public import Mathlib.Algebra.Order.GroupWithZero.Submonoid
 public import Mathlib.Algebra.Order.Ring.Defs
 public import Mathlib.Algebra.Ring.Subring.Basic
 
+import Mathlib.Algebra.Group.Submonoid.Units
+
 /-!
 
 # Unit subgroups of a ring
@@ -32,17 +34,9 @@ theorem Units.mem_posSubgroup {R : Type*} [Semiring R] [LinearOrder R] [IsStrict
   Iff.rfl
 
 theorem RingHom.isUnit_eqLocusS_mk_iff {R T : Type*} [Semiring R] [Semiring T] (f g : R →+* T)
-    {r : R} (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocusS g) ↔ IsUnit r := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · simp [isUnit_iff_exists, ← Subtype.val_inj] at h ⊢
-    grind
-  obtain ⟨s, hs⟩ := isUnit_iff_exists.mp h
-  suffices ∃ a, r * a = 1 ∧ f a = g a ∧ a * r = 1 by
-    simpa [isUnit_iff_exists, ← Subtype.val_inj]
-  refine ⟨s, hs.left, ?_, hs.right⟩
-  rw [← mul_one (f s), ← map_one g, ← hs.left, map_mul, ← mul_assoc, ← hr, ← map_mul,
-    hs.right, map_one, one_mul]
+    {r : R} (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocusS g) ↔ IsUnit r :=
+  MonoidHom.isUnit_eqLocusM_mk_iff ..
 
 theorem RingHom.isUnit_eqLocus_mk_iff {R T : Type*} [Ring R] [Semiring T] (f g : R →+* T)
     {r : R} (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocus g) ↔ IsUnit r :=
-  RingHom.isUnit_eqLocusS_mk_iff ..
+  MonoidHom.isUnit_eqLocusM_mk_iff ..

--- a/Mathlib/Algebra/Ring/Subring/Units.lean
+++ b/Mathlib/Algebra/Ring/Subring/Units.lean
@@ -31,8 +31,8 @@ theorem Units.mem_posSubgroup {R : Type*} [Semiring R] [LinearOrder R] [IsStrict
     (u : Rˣ) : u ∈ Units.posSubgroup R ↔ (0 : R) < u :=
   Iff.rfl
 
-theorem RingHom.isUnit_eqLocus_mk_iff {R T : Type*} [Ring R] [Semiring T] (f g : R →+* T)
-    {r : R} (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocus g) ↔ IsUnit r := by
+theorem RingHom.isUnit_eqLocusS_mk_iff {R T : Type*} [Semiring R] [Semiring T] (f g : R →+* T)
+    {r : R} (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocusS g) ↔ IsUnit r := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · simp [isUnit_iff_exists, ← Subtype.val_inj] at h ⊢
     grind
@@ -42,3 +42,7 @@ theorem RingHom.isUnit_eqLocus_mk_iff {R T : Type*} [Ring R] [Semiring T] (f g :
   refine ⟨s, hs.left, ?_, hs.right⟩
   rw [← mul_one (f s), ← map_one g, ← hs.left, map_mul, ← mul_assoc, ← hr, ← map_mul,
     hs.right, map_one, one_mul]
+
+theorem RingHom.isUnit_eqLocus_mk_iff {R T : Type*} [Ring R] [Semiring T] (f g : R →+* T)
+    {r : R} (hr : f r = g r) : IsUnit (⟨r, hr⟩ : f.eqLocus g) ↔ IsUnit r :=
+  RingHom.isUnit_eqLocusS_mk_iff ..


### PR DESCRIPTION
This PR adds `MonoidHom.isUnit_eqLocusM_mk_iff`, which is the monoid version of `RingHom.isUnit_eqLocus_mk_iff`.
@eric-wieser 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
