### PR TITLE
fix: add BatteriesRecycling to the Mathlib cache allowlist

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -29,6 +29,7 @@ TODO: write a better predicate. -/
 def isPartOfMathlibCache (mod : Name) : Bool := #[
   `Mathlib,
   `Batteries,
+  `BatteriesRecycling,
   `Aesop,
   `Cli,
   `ImportGraph,


### PR DESCRIPTION
This PR adds the `BatteriesRecycling` module root to `isPartOfMathlibCache` in `Cache/IO.lean`, so that `lake exe cache` hashes, stores, and retrieves its oleans.

The batteries "recycling" refactor introduced a new top-level `BatteriesRecycling` library: [leanprover-community/batteries#1792 "chore: deprecate `Batteries.RBMap` declarations"](https://github.com/leanprover-community/batteries/pull/1792) created it (declaring the Lake library in `lakefile.toml` and moving the `RBTree` implementation there), and [leanprover-community/batteries#1793 "chore: deprecate the SatisfiesM / MonadSatisfying API"](https://github.com/leanprover-community/batteries/pull/1793) added the `MonadSatisfying` implementation. `Batteries.Data.RBMap.Basic` and `Batteries.Classes.SatisfiesM` re-import these, so Mathlib depends on them transitively. Because `isPartOfMathlibCache` keys on `mod.getRoot`, the new `BatteriesRecycling.*` modules fall outside the cache, so `lake build --no-build --rehash Mathlib` reports `BatteriesRecycling.MonadSatisfying.Basic` and `BatteriesRecycling.RBTree.Basic` as out-of-date in CI's cache-verification step.

Master does not yet observe this (it still pins batteries `v4.31.0-rc1`, which predates the refactor), but `nightly-testing` does, and master will too once it updates batteries onto a recycling-era release.

🤖 Prepared with Claude Code