### PR TITLE
feat(Analysis): `StdSimplex` is a `MetricSpace`

### DIFF
--- a/Mathlib/Analysis/Convex/MetricSpace.lean
+++ b/Mathlib/Analysis/Convex/MetricSpace.lean
@@ -7,15 +7,14 @@ module
 
 public import Mathlib.Analysis.Convex.Combination
 public import Mathlib.Analysis.Normed.Group.AddTorsor
+public import Mathlib.Analysis.Normed.Lp.Finsupp
 public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.Geometry.Convex.ConvexSpace.AffineSpace
 public import Mathlib.Geometry.Convex.ConvexSpace.Module
-public import Mathlib.Topology.MetricSpace.Finsupp
 
 import Mathlib.Tactic.Positivity.Finset
 
 /-!
-
 # Convex spaces with compatible metric structure
 
 A convex space has a compatible metric structure if `dist(∑ tᵢ xᵢ, ∑ tᵢ yᵢ) ≤ ∑ tᵢ dist(xᵢ, yᵢ)`.
@@ -47,6 +46,7 @@ public section
 namespace Convexity
 
 open ConvexSpace
+open scoped NNReal
 
 variable {I X : Type*}
 
@@ -292,26 +292,33 @@ instance IsConvexDist.submodule {F M : Type*} [AddCommGroup M] [MetricSpace M]
 namespace StdSimplex
 variable {R : Type*} [PartialOrder R] [Semiring R]
 
-noncomputable instance [PseudoEMetricSpace R] : PseudoEMetricSpace (StdSimplex R I) :=
-  .induced weights inferInstance
+noncomputable instance instPseudoEMetricSpace [PseudoEMetricSpace R] :
+    PseudoEMetricSpace (StdSimplex R I) :=
+  .induced (WithLp.toLp (1 : ℝ≥0) ∘ weights) <|
+    have : Fact ((1 : ℝ≥0) ≤ 1) := ⟨le_rfl⟩; inferInstance
 
 lemma edist_def [PseudoEMetricSpace R] (w₁ w₂ : StdSimplex R I) :
-    edist w₁ w₂ = (w₁.weights.zipWith edist (edist_self _) w₂.weights).sum fun _i r ↦ r := rfl
+    edist w₁ w₂ = (w₁.weights.zipWith edist (edist_self _) w₂.weights).sum fun _i r ↦ r := by
+  simp [edist]
 
-noncomputable instance [EMetricSpace R] : EMetricSpace (StdSimplex R I) :=
-  .induced weights weights_injective inferInstance
+noncomputable instance instEMetricSpace [EMetricSpace R] : EMetricSpace (StdSimplex R I) :=
+  .induced (WithLp.toLp (1 : ℝ≥0) ∘ weights) ((WithLp.toLp_injective _).comp weights_injective) <|
+    have : Fact ((1 : ℝ≥0) ≤ 1) := ⟨le_rfl⟩; inferInstance
 
 noncomputable instance [PseudoMetricSpace R] : PseudoMetricSpace (StdSimplex R I) :=
-  .induced weights inferInstance
+  .induced (WithLp.toLp (1 : ℝ≥0) ∘ weights) <|
+    have : Fact ((1 : ℝ≥0) ≤ 1) := ⟨le_rfl⟩; inferInstance
 
 lemma dist_def [PseudoMetricSpace R] (w₁ w₂ : StdSimplex R I) :
-    dist w₁ w₂ = (w₁.weights.zipWith dist (dist_self _) w₂.weights).sum fun _i r ↦ r := rfl
+    dist w₁ w₂ = (w₁.weights.zipWith dist (dist_self _) w₂.weights).sum fun _i r ↦ r := by
+  simp [dist]
 
 lemma nndist_def [PseudoMetricSpace R] (w₁ w₂ : StdSimplex R I) :
-    nndist w₁ w₂ = (w₁.weights.zipWith nndist (nndist_self _) w₂.weights).sum fun _i r ↦ r :=
-  Finsupp.nndist_def ..
+    nndist w₁ w₂ = (w₁.weights.zipWith nndist (nndist_self _) w₂.weights).sum fun _i r ↦ r := by
+  have : Fact ((1 : ℝ≥0) ≤ 1) := ⟨le_rfl⟩; rw [nndist_induced, Finsupp.nndist_def]; simp
 
 noncomputable instance [MetricSpace R] : MetricSpace (StdSimplex R I) :=
-  .induced weights weights_injective inferInstance
+  .induced (WithLp.toLp (1 : ℝ≥0) ∘ weights) ((WithLp.toLp_injective _).comp weights_injective) <|
+    have : Fact ((1 : ℝ≥0) ≤ 1) := ⟨le_rfl⟩; inferInstance
 
 end Convexity.StdSimplex

--- a/Mathlib/Analysis/Convex/MetricSpace.lean
+++ b/Mathlib/Analysis/Convex/MetricSpace.lean
@@ -10,6 +10,9 @@ public import Mathlib.Analysis.Normed.Group.AddTorsor
 public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.Geometry.Convex.ConvexSpace.AffineSpace
 public import Mathlib.Geometry.Convex.ConvexSpace.Module
+public import Mathlib.Topology.MetricSpace.Finsupp
+
+import Mathlib.Tactic.Positivity.Finset
 
 /-!
 
@@ -286,4 +289,29 @@ instance IsConvexDist.submodule {F M : Type*} [AddCommGroup M] [MetricSpace M]
     [SetLike F M] [AddSubmonoidClass F M] [SMulMemClass F ℝ M] {S : F} :
     IsConvexDist S := .subtype _ _
 
-end Convexity
+namespace StdSimplex
+variable {R : Type*} [PartialOrder R] [Semiring R]
+
+noncomputable instance [PseudoEMetricSpace R] : PseudoEMetricSpace (StdSimplex R I) :=
+  .induced weights inferInstance
+
+lemma edist_def [PseudoEMetricSpace R] (w₁ w₂ : StdSimplex R I) :
+    edist w₁ w₂ = (w₁.weights.zipWith edist (edist_self _) w₂.weights).sum fun _i r ↦ r := rfl
+
+noncomputable instance [EMetricSpace R] : EMetricSpace (StdSimplex R I) :=
+  .induced weights weights_injective inferInstance
+
+noncomputable instance [PseudoMetricSpace R] : PseudoMetricSpace (StdSimplex R I) :=
+  .induced weights inferInstance
+
+lemma dist_def [PseudoMetricSpace R] (w₁ w₂ : StdSimplex R I) :
+    dist w₁ w₂ = (w₁.weights.zipWith dist (dist_self _) w₂.weights).sum fun _i r ↦ r := rfl
+
+lemma nndist_def [PseudoMetricSpace R] (w₁ w₂ : StdSimplex R I) :
+    nndist w₁ w₂ = (w₁.weights.zipWith nndist (nndist_self _) w₂.weights).sum fun _i r ↦ r :=
+  Finsupp.nndist_def ..
+
+noncomputable instance [MetricSpace R] : MetricSpace (StdSimplex R I) :=
+  .induced weights weights_injective inferInstance
+
+end Convexity.StdSimplex

--- a/Mathlib/Analysis/Normed/Lp/Finsupp.lean
+++ b/Mathlib/Analysis/Normed/Lp/Finsupp.lean
@@ -36,7 +36,8 @@ namespace Finsupp
 variable {ι X : Type*} [Zero X] {p : ℝ≥0} [Fact (1 ≤ p)]
 
 /-- The L^1 extended metric on `ι`-many copies of a metric space `X` -/
-noncomputable instance [PseudoEMetricSpace X] : PseudoEMetricSpace (WithLp p <| ι →₀ X) where
+noncomputable instance instPseudoEMetricSpace [PseudoEMetricSpace X] :
+    PseudoEMetricSpace (WithLp p <| ι →₀ X) where
   edist f g :=
   ((f.ofLp.zipWith edist (edist_self _) g.ofLp).sum fun i r ↦ r ^ (p : ℝ)) ^ (p⁻¹ : ℝ)
   edist_self f := by
@@ -65,11 +66,12 @@ lemma edist_def [PseudoEMetricSpace X] {p : ℝ≥0} [Fact (1 ≤ p)]
       ((f.ofLp.zipWith edist (edist_self _) g.ofLp).sum fun _i r ↦ r ^ (p : ℝ)) ^ (p⁻¹ : ℝ) := rfl
 
 /-- The L^1 extended metric on `ι`-many copies of a metric space `X` -/
-noncomputable instance [EMetricSpace X] : EMetricSpace (WithLp p <| ι →₀ X) where
+noncomputable instance instEMetricSpace [EMetricSpace X] : EMetricSpace (WithLp p <| ι →₀ X) where
   eq_of_edist_eq_zero {f g} hfg := by simp_all [edist_def, sum, WithLp.ext_iff, DFunLike.ext_iff]
 
 /-- The L^1 metric on `ι`-many copies of a metric space `X` -/
-noncomputable instance [PseudoMetricSpace X] : PseudoMetricSpace (WithLp p <| ι →₀ X) :=
+noncomputable instance instPseudoMetricSpace [PseudoMetricSpace X] :
+    PseudoMetricSpace (WithLp p <| ι →₀ X) :=
   PseudoEMetricSpace.toPseudoMetricSpaceOfDist
     (fun f g ↦ ((f.ofLp.zipWith dist (dist_self _) g.ofLp).sum fun i r ↦ r ^ (p : ℝ)) ^ (p⁻¹ : ℝ))
     (fun f g ↦ by dsimp [sum]; positivity) fun f g ↦ by
@@ -94,7 +96,7 @@ lemma nndist_def [PseudoMetricSpace X] (f g : WithLp p <| ι →₀ X) :
   simp [← coe_nndist]
 
 /-- The L^1 metric on `ι`-many copies of a metric space `X` -/
-noncomputable instance [MetricSpace X] : MetricSpace (WithLp p <| ι →₀ X) :=
+noncomputable instance instMetricSpace [MetricSpace X] : MetricSpace (WithLp p <| ι →₀ X) :=
   EMetricSpace.toMetricSpaceOfDist
     (fun f g ↦ ((f.ofLp.zipWith dist (dist_self _) g.ofLp).sum fun i r ↦ r ^ (p : ℝ)) ^ (p⁻¹ : ℝ))
     (fun f g ↦ by dsimp [sum]; positivity) fun f g ↦ by rw [edist_dist, dist_def]

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -346,8 +346,8 @@ theorem mapDomain_finsetSum {f : α → β} {s : Finset ι} {v : ι → α →�
 
 @[deprecated (since := "2026-04-08")] alias mapDomain_finset_sum := mapDomain_finsetSum
 
-theorem mapDomain_sum [Zero N] {f : α → β} {s : α →₀ N} {v : α → N → α →₀ M} :
-    mapDomain f (s.sum v) = s.sum fun a b => mapDomain f (v a b) :=
+theorem mapDomain_sum [Zero N] {f : α → β} {s : ι →₀ N} {v : ι → N → α →₀ M} :
+    mapDomain f (s.sum v) = s.sum fun i n ↦ mapDomain f (v i n) :=
   map_finsuppSum (mapDomain.addMonoidHom f : (α →₀ M) →+ β →₀ M) _ _
 
 theorem mapDomain_support [DecidableEq β] {f : α → β} {s : α →₀ M} :

--- a/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
@@ -76,8 +76,10 @@ lemma support_weights_nonempty [Nontrivial R] (w : StdSimplex R M) :
 lemma nonempty [Nontrivial R] (w : StdSimplex R M) : Nonempty M :=
   w.support_weights_nonempty.to_type
 
-@[simp] lemma weights_inj {f g : StdSimplex R M} : f.weights = g.weights ↔ f = g := by
-  cases f; cases g; simp
+lemma weights_injective : (weights : StdSimplex R M → M →₀ R).Injective := by rintro ⟨f⟩ ⟨g⟩; simp
+
+@[simp] lemma weights_inj {f g : StdSimplex R M} : f.weights = g.weights ↔ f = g :=
+  weights_injective.eq_iff
 
 @[ext] alias ⟨ext, _⟩ := weights_inj
 

--- a/Mathlib/Topology/MetricSpace/Pseudo/Constructions.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Constructions.lean
@@ -37,6 +37,11 @@ abbrev PseudoMetricSpace.induced {α β} (f : α → β) (m : PseudoMetricSpace 
   cobounded_sets := Set.ext fun s => mem_comap_iff_compl.trans <| by
     simp only [← isBounded_def, isBounded_iff, forall_mem_image, mem_setOf]
 
+omit [PseudoMetricSpace α] in
+lemma nndist_induced (f : α → β) (m : PseudoMetricSpace β) (x y : α) :
+    haveI := m.induced f
+    nndist x y = nndist (f x) (f y) := rfl
+
 /-- Pull back a pseudometric space structure by an inducing map. This is a version of
 `PseudoMetricSpace.induced` useful in case if the domain already has a `TopologicalSpace`
 structure. -/


### PR DESCRIPTION
Endow the standard simplex over a metric space with the L^1 metric.

---
- [x] depends on: #40212

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
