### PR TITLE
[Merged by Bors] - feat: more API for the variation of vector measures

### DIFF
--- a/Mathlib/MeasureTheory/Measure/PreVariation.lean
+++ b/Mathlib/MeasureTheory/Measure/PreVariation.lean
@@ -109,7 +109,7 @@ lemma exists_Finpartition_sum_gt {s : Set X} (hs : MeasurableSet s) {a : ℝ≥0
   simp_all [preVariationFun, lt_iSup_iff]
 
 lemma exists_Finpartition_sum_ge {s : Set X} (hs : MeasurableSet s) {ε : ℝ≥0} (hε : 0 < ε)
-    (h : preVariationFun f s ≠ ⊤) :
+    (h : preVariationFun f s ≠ ∞) :
     ∃ P : Finpartition (⟨s, hs⟩ : Subtype MeasurableSet),
     preVariationFun f s ≤ ∑ p ∈ P.parts, f p + ε := by
   let ε' := min ε (preVariationFun f s).toNNReal
@@ -129,6 +129,16 @@ lemma exists_Finpartition_sum_ge {s : Set X} (hs : MeasurableSet s) {ε : ℝ≥
         exact (ENNReal.add_le_add_iff_right coe_ne_top).mpr (le_of_lt hP)
       _ ≤ ∑ p ∈ P.parts, f p + ε := by gcongr
   · simp [*]
+
+lemma exists_Finpartition_sum_ge' {s : Set X} (hs : MeasurableSet s) {ε : ℝ≥0∞} (hε : 0 < ε)
+    (h : preVariationFun f s ≠ ∞) :
+    ∃ P : Finpartition (⟨s, hs⟩ : Subtype MeasurableSet),
+    preVariationFun f s ≤ ∑ p ∈ P.parts, f p + ε := by
+  rcases eq_top_or_lt_top ε with rfl | h'ε
+  · obtain ⟨P⟩ : Nonempty (Finpartition (⟨s, hs⟩ : Subtype MeasurableSet)) := inferInstance
+    exact ⟨P, by simp⟩
+  · lift ε to NNReal using h'ε.ne
+    exact exists_Finpartition_sum_ge _ hs (by simpa using hε) h
 
 lemma sum_le_preVariationFun_iUnion' {s : ℕ → Set X} (hs : ∀ i, MeasurableSet (s i))
     (hs' : Pairwise (Disjoint on s))

--- a/Mathlib/MeasureTheory/Measure/PreVariation.lean
+++ b/Mathlib/MeasureTheory/Measure/PreVariation.lean
@@ -135,10 +135,9 @@ lemma exists_Finpartition_sum_ge' {s : Set X} (hs : MeasurableSet s) {ε : ℝ�
     ∃ P : Finpartition (⟨s, hs⟩ : Subtype MeasurableSet),
     preVariationFun f s ≤ ∑ p ∈ P.parts, f p + ε := by
   rcases eq_top_or_lt_top ε with rfl | h'ε
-  · obtain ⟨P⟩ : Nonempty (Finpartition (⟨s, hs⟩ : Subtype MeasurableSet)) := inferInstance
-    exact ⟨P, by simp⟩
-  · lift ε to NNReal using h'ε.ne
-    exact exists_Finpartition_sum_ge _ hs (by simpa using hε) h
+  · simp
+  lift ε to NNReal using h'ε.ne
+  exact exists_Finpartition_sum_ge _ hs (by simpa using hε) h
 
 lemma sum_le_preVariationFun_iUnion' {s : ℕ → Set X} (hs : ∀ i, MeasurableSet (s i))
     (hs' : Pairwise (Disjoint on s))

--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -566,7 +566,7 @@ end
 
 section
 
-variable [MeasurableSpace α] [MeasurableSpace β]
+variable {mα : MeasurableSpace α} [MeasurableSpace β]
 variable {M : Type*} [AddCommMonoid M] [TopologicalSpace M]
 variable (v : VectorMeasure α M)
 
@@ -642,7 +642,8 @@ theorem mapRange_add {v w : VectorMeasure α M} {f : M →+ N} (hf : Continuous 
 
 /-- Given a continuous `AddMonoidHom` `f : M → N`, `mapRangeHom` is the `AddMonoidHom` mapping the
 vector measure `v` on `M` to the vector measure `f ∘ v` on `N`. -/
-def mapRangeHom (f : M →+ N) (hf : Continuous f) : VectorMeasure α M →+ VectorMeasure α N where
+def mapRangeHom {α : Type*} [MeasurableSpace α] (f : M →+ N) (hf : Continuous f) :
+    VectorMeasure α M →+ VectorMeasure α N where
   toFun v := v.mapRange f hf
   map_zero' := mapRange_zero hf
   map_add' _ _ := mapRange_add hf
@@ -664,7 +665,8 @@ variable [ContinuousAdd M] [ContinuousAdd N]
 
 /-- Given a continuous linear map `f : M → N`, `mapRangeₗ` is the linear map mapping the
 vector measure `v` on `M` to the vector measure `f ∘ v` on `N`. -/
-def mapRangeₗ (f : M →ₗ[R] N) (hf : Continuous f) : VectorMeasure α M →ₗ[R] VectorMeasure α N where
+def mapRangeₗ {α : Type*} [MeasurableSpace α] (f : M →ₗ[R] N) (hf : Continuous f) :
+    VectorMeasure α M →ₗ[R] VectorMeasure α N where
   toFun v := v.mapRange f.toAddMonoidHom hf
   map_add' _ _ := mapRange_add hf
   map_smul' _ _ := mapRange_smul hf
@@ -750,6 +752,18 @@ theorem restrict_restrict {s t : Set α} (hs : MeasurableSet s) (ht : Measurable
   ext u hu
   simp [restrict_apply, hs, hu, ht, Set.inter_assoc]
 
+theorem restrict_map {f : α → β} (hf : Measurable f) {s : Set β} (hs : MeasurableSet s) :
+    (v.map f).restrict s = (v.restrict (f ⁻¹' s)).map f := by
+  ext t ht
+  simp [map_apply, hs, hf hs, restrict_apply, ht, hf, hf ht]
+
+theorem restrict_toSignedMeasure {μ : Measure α} [IsFiniteMeasure μ]
+    {s : Set α} (hs : MeasurableSet s) :
+    μ.toSignedMeasure.restrict s = (μ.restrict s).toSignedMeasure := by
+  ext t ht
+  rw [restrict_apply _ hs ht, Measure.toSignedMeasure_apply_measurable (ht.inter hs),
+    Measure.toSignedMeasure_apply_measurable ht, measureReal_restrict_apply ht]
+
 section ContinuousAdd
 
 variable [ContinuousAdd M]
@@ -762,7 +776,7 @@ theorem map_add (v w : VectorMeasure α M) (f : α → β) : (v + w).map f = v.m
 
 /-- `VectorMeasure.map` as an additive monoid homomorphism. -/
 @[simps]
-def mapGm (f : α → β) : VectorMeasure α M →+ VectorMeasure β M where
+def mapGm {α : Type*} [MeasurableSpace α] (f : α → β) : VectorMeasure α M →+ VectorMeasure β M where
   toFun v := v.map f
   map_zero' := map_zero f
   map_add' _ _ := map_add _ _ f
@@ -777,7 +791,8 @@ theorem restrict_add (v w : VectorMeasure α M) (i : Set α) :
 
 /-- `VectorMeasure.restrict` as an additive monoid homomorphism. -/
 @[simps]
-def restrictGm (i : Set α) : VectorMeasure α M →+ VectorMeasure α M where
+def restrictGm {α : Type*} [MeasurableSpace α] (i : Set α) :
+    VectorMeasure α M →+ VectorMeasure α M where
   toFun v := v.restrict i
   map_zero' := restrict_zero
   map_add' _ _ := restrict_add _ _ i

--- a/Mathlib/MeasureTheory/VectorMeasure/Variation/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Variation/Basic.lean
@@ -84,7 +84,7 @@ lemma exists_variation_le_add' (μ : VectorMeasure X V) {s : Set X} (hs : Measur
     at hμ ⊢
   obtain ⟨P, hP⟩ : ∃ P : Finpartition (⟨s, hs⟩ : Subtype MeasurableSet),
       preVariationFun (fun x ↦ ‖μ x‖ₑ) s ≤ ∑ p ∈ P.parts, (fun x ↦ ‖μ x‖ₑ) ↑p + ε :=
-    preVariation.exists_Finpartition_sum_ge'  (‖μ ·‖ₑ) hs hε hμ
+    preVariation.exists_Finpartition_sum_ge' (‖μ ·‖ₑ) hs hε hμ
   refine ⟨P.parts.map (Function.Embedding.subtype _), ?_, ?_, ?_, ?_⟩
   · simp only [mem_map, Function.Embedding.subtype_apply, Subtype.exists, exists_and_right,
       exists_eq_right, forall_exists_index]
@@ -98,8 +98,7 @@ lemma exists_variation_le_add' (μ : VectorMeasure X V) {s : Set X} (hs : Measur
     exact (disjoint_subtype_iff (fun _ _ hs ht ↦ hs.inter ht) _).1
       (P.disjoint i_mem j_mem (by simpa using hij))
   · simp +contextual
-  · rw [Finset.sum_map]
-    exact hP.trans_eq rfl
+  · rwa [Finset.sum_map]
 
 /-- Measure version of `preVariation.exists_Finpartition_sum_ge`. -/
 lemma exists_variation_le_add (μ : VectorMeasure X V) {s : Set X} (hs : MeasurableSet s)
@@ -308,7 +307,7 @@ instance {x : X} {v : V} : IsFiniteMeasure (VectorMeasure.dirac x v).variation :
   infer_instance
 
 @[simp] lemma variation_toSignedMeasure {μ : Measure X} [IsFiniteMeasure μ] :
-    variation μ.toSignedMeasure = μ := by
+    μ.toSignedMeasure.variation = μ := by
   apply le_antisymm
   · apply variation_le_of_forall_enorm_le (fun s hs ↦ ?_)
     simp [Measure.toSignedMeasure_apply, hs, Measure.real, Real.enorm_eq_ofReal]

--- a/Mathlib/MeasureTheory/VectorMeasure/Variation/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Variation/Basic.lean
@@ -33,7 +33,7 @@ such vector-valued measures.
 public section
 
 open Finset Set
-open scoped ENNReal
+open scoped ENNReal NNReal
 
 namespace MeasureTheory.VectorMeasure
 
@@ -74,6 +74,39 @@ lemma le_variation (μ : VectorMeasure X V) {s : Set X} (hs : MeasurableSet s) {
       · simp_all
       simp only [sup_set_eq_biUnion, id_eq]
       exact hs.diff <| .biUnion (Finset.countable_toSet _) (by simp)
+
+/-- Measure version of `preVariation.exists_Finpartition_sum_ge'`. -/
+lemma exists_variation_le_add' (μ : VectorMeasure X V) {s : Set X} (hs : MeasurableSet s)
+    {ε : ℝ≥0∞} (hε : 0 < ε) (hμ : μ.variation s ≠ ∞) :
+    ∃ (P : Finset (Set X)), (∀ t ∈ P, t ⊆ s) ∧ ((P : Set (Set X)).PairwiseDisjoint id) ∧
+      (∀ t ∈ P, MeasurableSet t) ∧ μ.variation s ≤ ∑ p ∈ P, ‖μ p‖ₑ + ε := by
+  simp only [variation_apply, preVariation, ennrealToMeasure_apply hs, ennrealPreVariation_apply]
+    at hμ ⊢
+  obtain ⟨P, hP⟩ : ∃ P : Finpartition (⟨s, hs⟩ : Subtype MeasurableSet),
+      preVariationFun (fun x ↦ ‖μ x‖ₑ) s ≤ ∑ p ∈ P.parts, (fun x ↦ ‖μ x‖ₑ) ↑p + ε :=
+    preVariation.exists_Finpartition_sum_ge'  (‖μ ·‖ₑ) hs hε hμ
+  refine ⟨P.parts.map (Function.Embedding.subtype _), ?_, ?_, ?_, ?_⟩
+  · simp only [mem_map, Function.Embedding.subtype_apply, Subtype.exists, exists_and_right,
+      exists_eq_right, forall_exists_index]
+    intro t ht h't
+    exact P.le h't
+  · intro i hi  j hj hij
+    simp only [coe_map, Function.Embedding.subtype_apply, Set.mem_image, SetLike.mem_coe,
+      Subtype.exists, exists_and_right, exists_eq_right] at hi hj
+    rcases hi with ⟨h'i, i_mem⟩
+    rcases hj with ⟨h'j, j_mem⟩
+    exact (disjoint_subtype_iff (fun _ _ hs ht ↦ hs.inter ht) _).1
+      (P.disjoint i_mem j_mem (by simpa using hij))
+  · simp +contextual
+  · rw [Finset.sum_map]
+    exact hP.trans_eq rfl
+
+/-- Measure version of `preVariation.exists_Finpartition_sum_ge`. -/
+lemma exists_variation_le_add (μ : VectorMeasure X V) {s : Set X} (hs : MeasurableSet s)
+    {ε : ℝ≥0} (hε : 0 < ε) (hμ : μ.variation s ≠ ∞) :
+    ∃ (P : Finset (Set X)), (∀ t ∈ P, t ⊆ s) ∧ ((P : Set (Set X)).PairwiseDisjoint id) ∧
+      (∀ t ∈ P, MeasurableSet t) ∧ μ.variation s ≤ ∑ p ∈ P, ‖μ p‖ₑ + ε :=
+  exists_variation_le_add' μ hs (mod_cast hε) hμ
 
 theorem enorm_measure_le_variation (μ : VectorMeasure X V) (E : Set X) :
     ‖μ E‖ₑ ≤ variation μ E := by
@@ -273,6 +306,15 @@ instance [Finite X] : IsFiniteMeasure μ.variation where
 instance {x : X} {v : V} : IsFiniteMeasure (VectorMeasure.dirac x v).variation := by
   simp only [variation_dirac, enorm_eq_nnnorm, Measure.coe_nnreal_smul]
   infer_instance
+
+@[simp] lemma variation_toSignedMeasure {μ : Measure X} [IsFiniteMeasure μ] :
+    variation μ.toSignedMeasure = μ := by
+  apply le_antisymm
+  · apply variation_le_of_forall_enorm_le (fun s hs ↦ ?_)
+    simp [Measure.toSignedMeasure_apply, hs, Measure.real, Real.enorm_eq_ofReal]
+  · apply Measure.le_iff.2 (fun s hs ↦ ?_)
+    apply le_trans ?_ (enorm_measure_le_variation _ _)
+    simp [Measure.toSignedMeasure_apply, hs, Measure.real, Real.enorm_eq_ofReal]
 
 end NormedAddCommGroup
 

--- a/Mathlib/MeasureTheory/VectorMeasure/Variation/Defs.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Variation/Defs.lean
@@ -32,7 +32,7 @@ not less than this function. It turns out that this function is a measure.
 
 @[expose] public section
 
-variable {X : Type*} [MeasurableSpace X]
+variable {X : Type*} {mX : MeasurableSpace X}
 
 open scoped ENNReal
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
