### PR TITLE
[Merged by Bors] - chore(CI): bind cache-upload job to GitHub environments

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -30,6 +30,10 @@ jobs:
       # Use the MASTER cache key only when merging into mathlib4 (staging branch);
       # 'bors try' runs (trying branch) and nightly-testing use NON_MASTER
       cache_application_id: ${{ github.ref_name == 'staging' && github.repository == 'leanprover-community/mathlib4' && vars.CACHE_MASTER_WRITER_AZURE_APP_ID || vars.CACHE_NON_MASTER_WRITER_AZURE_APP_ID }}
+      # Track the cache_application_id choice above; the environment fixes the OIDC subject the Azure app trusts.
+      # nightly-testing is intentionally left without an environment ('') so it keeps its existing ref-based trust.
+      # TODO: give mathlib4-nightly-testing its own cache-upload environment + federated credential.
+      cache_environment: ${{ github.repository == 'leanprover-community/mathlib4' && (github.ref_name == 'staging' && 'cache-upload-master' || 'cache-upload-forks') || '' }}
       # bors runs should build the tools from their commit-under-test: after all, we are trying to
       # test 'what would happen if this was merged', so we need to use the 'would-be-post-merge' tools
       tools_branch_ref: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,5 +37,9 @@ jobs:
       pr_branch_ref: ${{ github.sha }}
       # Use the MASTER cache key only on mathlib4/master; nightly-testing and other branches use NON_MASTER
       cache_application_id: ${{ github.repository == 'leanprover-community/mathlib4' && github.ref == 'refs/heads/master' && vars.CACHE_MASTER_WRITER_AZURE_APP_ID || vars.CACHE_NON_MASTER_WRITER_AZURE_APP_ID }}
+      # Track the cache_application_id choice above; the environment fixes the OIDC subject the Azure app trusts.
+      # nightly-testing is intentionally left without an environment ('') so it keeps its existing ref-based trust.
+      # TODO: give mathlib4-nightly-testing its own cache-upload environment + federated credential.
+      cache_environment: ${{ github.repository == 'leanprover-community/mathlib4' && (github.ref == 'refs/heads/master' && 'cache-upload-master' || 'cache-upload-forks') || '' }}
       runs_on: pr
     secrets: inherit

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -37,5 +37,6 @@ jobs:
       concurrency_group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       pr_branch_ref: ${{ github.event.pull_request.head.sha }}
       cache_application_id: ${{ vars.CACHE_NON_MASTER_WRITER_AZURE_APP_ID }}
+      cache_environment: cache-upload-forks
       runs_on: pr
     secrets: inherit

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -27,6 +27,12 @@ on:
       cache_application_id:
         type: string
         required: true
+      cache_environment:
+        # GitHub environment for the `upload_cache` job. Its only role is to fix the
+        # OIDC `sub` claim to `...:environment:<name>`, which the Azure cache app's
+        # federated credential is scoped to; it must match the writer `cache_application_id`.
+        type: string
+        required: true
 
 env:
   # Disable Lake's automatic fetching of cloud builds.
@@ -608,6 +614,10 @@ jobs:
     name: Upload to cache
     needs: [build]
     runs-on: ubuntu-latest # These steps run on a GitHub runner; no landrun sandboxing is needed.
+    # Pins the OIDC `sub` claim to `...:environment:<cache_environment>`, which the Azure cache
+    # app's federated credential is scoped to. A token minted by any job without this environment
+    # (e.g. the untrusted build/post_steps/style_lint jobs) cannot satisfy that trust.
+    environment: ${{ inputs.cache_environment }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -46,5 +46,6 @@ jobs:
       run_post_ci: ${{ inputs.run_post_ci }}
       mathlib_ci_ref: ${{ inputs.mathlib_ci_ref }}
       cache_application_id: ${{ vars.CACHE_NON_MASTER_WRITER_AZURE_APP_ID }}
+      cache_environment: cache-upload-forks
       runs_on: pr
     secrets: inherit


### PR DESCRIPTION
Pin the `upload_cache` job to a GitHub environment so its OIDC `sub` claim is `repo:.../...:environment:<name>`. The Azure cache app's federated credential is scoped to that subject, so a token minted by any job *without* the environment (e.g. the untrusted build / post_steps / style_lint jobs) cannot satisfy the trust, regardless of token exposure.