### PR TITLE
feat(Geometry/Manifold/VectorBundle/CovariantDerivative/Riemannian): koszul formula

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4651,6 +4651,7 @@ public import Mathlib.Geometry.Manifold.VectorBundle.Basic
 public import Mathlib.Geometry.Manifold.VectorBundle.ContMDiffSection
 public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Basic
 public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Torsion
+public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Riemannian
 public import Mathlib.Geometry.Manifold.VectorBundle.FiberwiseLinear
 public import Mathlib.Geometry.Manifold.VectorBundle.Hom
 public import Mathlib.Geometry.Manifold.VectorBundle.LocalFrame

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4650,8 +4650,8 @@ public import Mathlib.Geometry.Manifold.StructureGroupoid
 public import Mathlib.Geometry.Manifold.VectorBundle.Basic
 public import Mathlib.Geometry.Manifold.VectorBundle.ContMDiffSection
 public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Basic
-public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Torsion
 public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Riemannian
+public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Torsion
 public import Mathlib.Geometry.Manifold.VectorBundle.FiberwiseLinear
 public import Mathlib.Geometry.Manifold.VectorBundle.Hom
 public import Mathlib.Geometry.Manifold.VectorBundle.LocalFrame

--- a/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Riemannian.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Riemannian.lean
@@ -18,11 +18,6 @@ determined by the metric and Lie brackets via
 
 This is the **Koszul formula** — the explicit identity that *forces*
 uniqueness of the Levi-Civita connection.
-
-mathlib has the covariant-derivative / Riemannian-bundle / Lie-bracket
-machinery but no metric-compatibility predicate and no Koszul formula
-(`grep -ri Koszul`: no relevant hits). One helper definition
-(`IsMetricCompatible`, ~½ page) is added here.
 -/
 
 @[expose] public section

--- a/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Riemannian.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Riemannian.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Seed Prover, Kim Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seed Prover, Kim Morrison
+-/
 module
 
 public import Mathlib.Geometry.Manifold.VectorBundle.Riemannian
@@ -6,23 +11,21 @@ public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Torsion
 /-!
 # Koszul formula
 
-§38 of Oliver Knill's *Some Fundamental Theorems in Mathematics* (an
-additional statement of the section on Riemannian geometry; the boxed
-main theorem is the Levi-Civita fundamental theorem). For any smooth
-torsion-free metric-compatible covariant derivative `cov` on the tangent
-bundle of a Riemannian manifold, the inner product `⟨∇_X Y, Z⟩` is
-determined by the metric and Lie brackets via
+This file proves the Koszul formula for a smooth torsion-free metric-compatible
+covariant derivative on the tangent bundle of a Riemannian manifold.
+
+For such a covariant derivative `cov`, the inner product `⟨∇_X Y, Z⟩` is determined
+by the metric and Lie brackets via
 
 `2 ⟨∇_X Y, Z⟩ = X·⟨Y, Z⟩ + Y·⟨X, Z⟩ − Z·⟨X, Y⟩`
 `               − ⟨X, [Y, Z]⟩ − ⟨Y, [X, Z]⟩ + ⟨Z, [X, Y]⟩`.
 
-This is the **Koszul formula** — the explicit identity that *forces*
-uniqueness of the Levi-Civita connection.
+This formula implies the uniqueness of the Levi-Civita connection.
 -/
 
 @[expose] public section
 
-namespace Geometry.KoszulFormula
+namespace CovariantDerivative
 
 open scoped Manifold Topology
 open Bundle ContDiff VectorField CovariantDerivative
@@ -44,9 +47,10 @@ def IsMetricCompatible : Prop :=
     ∀ (x : M) (v : TangentSpace I x),
       mvfderiv I (fun y ↦ ⟪Y y, Z y⟫) x v = ⟪cov Y x v, Z x⟫ + ⟪Y x, cov Z x v⟫
 
+/-- The Koszul formula for a smooth torsion-free metric-compatible covariant derivative. -/
 theorem koszul_formula
-    [ContMDiffCovariantDerivative cov ∞]
-    (_htor : cov.torsion = 0) (_hmet : IsMetricCompatible cov)
+    [cov.ContMDiffCovariantDerivative ∞]
+    (_htor : cov.torsion = 0) (_hmet : cov.IsMetricCompatible)
     (X Y Z : Π x : M, TangentSpace I x)
     (_hX : CMDiff ∞ (T% X)) (_hY : CMDiff ∞ (T% Y)) (_hZ : CMDiff ∞ (T% Z))
     (x : M) :
@@ -68,6 +72,6 @@ theorem koszul_formula
     inner_sub_right, real_inner_comm (Z x), real_inner_comm (Z x), real_inner_comm (Y x)]
   ring
 
-end Geometry.KoszulFormula
+end CovariantDerivative
 
 end

--- a/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Riemannian.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Riemannian.lean
@@ -1,0 +1,78 @@
+module
+
+public import Mathlib.Geometry.Manifold.VectorBundle.Riemannian
+public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Torsion
+
+/-!
+# Koszul formula
+
+§38 of Oliver Knill's *Some Fundamental Theorems in Mathematics* (an
+additional statement of the section on Riemannian geometry; the boxed
+main theorem is the Levi-Civita fundamental theorem). For any smooth
+torsion-free metric-compatible covariant derivative `cov` on the tangent
+bundle of a Riemannian manifold, the inner product `⟨∇_X Y, Z⟩` is
+determined by the metric and Lie brackets via
+
+`2 ⟨∇_X Y, Z⟩ = X·⟨Y, Z⟩ + Y·⟨X, Z⟩ − Z·⟨X, Y⟩`
+`               − ⟨X, [Y, Z]⟩ − ⟨Y, [X, Z]⟩ + ⟨Z, [X, Y]⟩`.
+
+This is the **Koszul formula** — the explicit identity that *forces*
+uniqueness of the Levi-Civita connection.
+
+mathlib has the covariant-derivative / Riemannian-bundle / Lie-bracket
+machinery but no metric-compatibility predicate and no Koszul formula
+(`grep -ri Koszul`: no relevant hits). One helper definition
+(`IsMetricCompatible`, ~½ page) is added here.
+-/
+
+@[expose] public section
+
+namespace Geometry.KoszulFormula
+
+open scoped Manifold Topology
+open Bundle ContDiff VectorField CovariantDerivative
+
+local notation "⟪" x ", " y "⟫" => inner ℝ x y
+
+variable {E H M : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  [FiniteDimensional ℝ E] [CompleteSpace E] [TopologicalSpace H]
+  {I : ModelWithCorners ℝ E H} [TopologicalSpace M] [ChartedSpace H M]
+  [IsManifold I ∞ M] [RiemannianBundle (fun (x : M) ↦ TangentSpace I x)]
+  (cov : CovariantDerivative I E (TangentSpace I (M := M)))
+
+/-- A covariant derivative `cov` on `TM` is **compatible with the
+Riemannian metric** if `v · ⟨Y, Z⟩ = ⟨∇_v Y, Z⟩ + ⟨Y, ∇_v Z⟩` for all
+smooth vector fields `Y, Z` and every point/direction `(x, v)`. -/
+def IsMetricCompatible : Prop :=
+  ∀ (Y Z : Π x : M, TangentSpace I x),
+    CMDiff ∞ (T% Y) → CMDiff ∞ (T% Z) →
+    ∀ (x : M) (v : TangentSpace I x),
+      mvfderiv I (fun y ↦ ⟪Y y, Z y⟫) x v = ⟪cov Y x v, Z x⟫ + ⟪Y x, cov Z x v⟫
+
+theorem koszul_formula
+    [ContMDiffCovariantDerivative cov ∞]
+    (_htor : cov.torsion = 0) (_hmet : IsMetricCompatible cov)
+    (X Y Z : Π x : M, TangentSpace I x)
+    (_hX : CMDiff ∞ (T% X)) (_hY : CMDiff ∞ (T% Y)) (_hZ : CMDiff ∞ (T% Z))
+    (x : M) :
+    2 * ⟪cov Y x (X x), Z x⟫ =
+      mvfderiv I (fun y ↦ ⟪Y y, Z y⟫) x (X x)
+      + mvfderiv I (fun y ↦ ⟪X y, Z y⟫) x (Y x)
+      - mvfderiv I (fun y ↦ ⟪X y, Y y⟫) x (Z x)
+      - ⟪X x, mlieBracket I Y Z x⟫
+      - ⟪Y x, mlieBracket I X Z x⟫
+      + ⟪Z x, mlieBracket I X Y x⟫ := by
+  have hXat : MDiffAt (T% X) x := _hX.contMDiffAt.mdifferentiableAt (by tauto)
+  have hYat : MDiffAt (T% Y) x := _hY.contMDiffAt.mdifferentiableAt (by tauto)
+  have hZat : MDiffAt (T% Z) x := _hZ.contMDiffAt.mdifferentiableAt (by tauto)
+  have h_tor : ∀ {X' Y' : Π x : M, TangentSpace I x}, MDiffAt (T% X') x → MDiffAt (T% Y') x →
+      cov Y' x (X' x) - cov X' x (Y' x) = mlieBracket I X' Y' x :=
+    cov.torsion_eq_zero_iff.1 _htor
+  rw [_hmet Y Z _hY _hZ .., _hmet X Z _hX _hZ .., _hmet X Y _hX _hY ..,
+    ← h_tor hYat hZat, ← h_tor hXat hZat, ← h_tor hXat hYat, inner_sub_right, inner_sub_right,
+    inner_sub_right, real_inner_comm (Z x), real_inner_comm (Z x), real_inner_comm (Y x)]
+  ring
+
+end Geometry.KoszulFormula
+
+end


### PR DESCRIPTION
Greetings! This PR proposes a proof of Koszul formula mentioned at [lean-eval](https://lean-lang.org/eval/problems/koszul_formula/). The formalization of statement is due to @kim-em.

The proof comes from Seed Prover (lean-eval) and was golfed by me.
Co-authored-by: @GanjinZero 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
