### PR TITLE
[Merged by Bors] - chore: expire delegations if later pushes touch sensitive files

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -7,4 +7,37 @@ update_base_for_deletes = true
 cut_body_after = "\n---"
 max_batch_size = 16
 [delegation]
-default_expiry_sec = 1209600
+default_expiry_sec = 1209600 # 2 weeks
+# Entries below are Erlang `:glob` patterns (NOT gitignore): `*` matches across `/`,
+# `?` is one char, and patterns are anchored -- so a directory and its
+# top-level aggregator file are listed separately (e.g. `Mathlib/**` does not
+# cover `Mathlib.lean`).
+#
+# Allow-list: a delegation covers only new author work within these paths.
+restrict_to_paths = [
+  "Archive/**",
+  "Counterexamples/**",
+  "docs/**",
+  "DownstreamTest/**",
+  "Mathlib/**",
+  "MathlibTest/**",
+  "widget/**",
+  "Archive.lean",
+  "Counterexamples.lean",
+  "docs.lean",
+  "Mathlib.lean",
+]
+# Deny-list: always revoke delegation when these are touched, even if a path
+# also matches the allow-list.
+# Redundant with the allow-list today (these are already excluded by omission),
+# but kept as a reference so the protection survives any future widening of
+# `restrict_to_paths`.
+# invalidate_on_paths = [
+#   ".github/**",
+#   "scripts/**",
+#   "Cache/**",
+#   "lakefile.lean",
+#   "lake-manifest.json",
+#   "lean-toolchain",
+#   "bors.toml",
+# ]


### PR DESCRIPTION
This PR adds a `restrict_to_paths` setting per https://github.com/leanprover-community/bors-ng/pull/50 so that delegated PRs will have their delegations expire immediately if the author pushes changes to any files outside the following locations:
- "Archive/**",
- "Counterexamples/**",
- "docs/**",
- "DownstreamTest/**",
- "Mathlib/**",
- "MathlibTest/**",
- "widget/**",
- "Archive.lean",
- "Counterexamples.lean",
- "docs.lean",
- "Mathlib.lean",

As a consequence, changes outside these directories after delegation must be re-approved by a maintainer.

(bors will do its best to distinguish from changes to the code coming from the `master` branch so except in cases of PRs that touch a large number of files, merging `master` should be safe, even if there are changes outside the above directories.)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
