### PR TITLE
[Merged by Bors] - feat: measurability of positive and negative parts

### DIFF
--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
@@ -396,6 +396,18 @@ protected theorem inf [SemilatticeInf β] [ContinuousInf β] (hf : AEStronglyMea
   ⟨hf.mk f ⊓ hg.mk g, hf.stronglyMeasurable_mk.inf hg.stronglyMeasurable_mk,
     hf.ae_eq_mk.inf hg.ae_eq_mk⟩
 
+@[to_additive (attr := fun_prop)]
+protected theorem oneLePart [Group β] [Lattice β] [ContinuousSup β]
+    (hf : AEStronglyMeasurable f μ) :
+    AEStronglyMeasurable (fun x ↦ oneLePart (f x)) μ :=
+  hf.sup aestronglyMeasurable_const
+
+@[to_additive (attr := fun_prop)]
+protected theorem leOnePart [Group β] [Lattice β] [ContinuousSup β] [ContinuousInv β]
+    (hf : AEStronglyMeasurable f μ) :
+    AEStronglyMeasurable (fun x ↦ leOnePart (f x)) μ :=
+  hf.inv.sup aestronglyMeasurable_const
+
 end Order
 
 /-!

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -578,6 +578,17 @@ protected theorem inf [Min β] [ContinuousInf β] (hf : StronglyMeasurable f)
   ⟨fun n => hf.approx n ⊓ hg.approx n, fun x =>
     (hf.tendsto_approx x).inf_nhds (hg.tendsto_approx x)⟩
 
+@[to_additive (attr := fun_prop)]
+protected theorem oneLePart [Group β] [Lattice β] [ContinuousSup β] (hf : StronglyMeasurable f) :
+    StronglyMeasurable fun x ↦ oneLePart (f x) :=
+  hf.sup stronglyMeasurable_const
+
+@[to_additive (attr := fun_prop)]
+protected theorem leOnePart [Group β] [Lattice β] [ContinuousSup β] [ContinuousInv β]
+    (hf : StronglyMeasurable f) :
+    StronglyMeasurable fun x ↦ leOnePart (f x) :=
+  hf.inv.sup stronglyMeasurable_const
+
 end Order
 
 /-!

--- a/Mathlib/MeasureTheory/Order/Group/Lattice.lean
+++ b/Mathlib/MeasureTheory/Order/Group/Lattice.lean
@@ -31,6 +31,12 @@ protected theorem Measurable.oneLePart [MeasurableSup α] (hf : Measurable f) :
     Measurable fun x ↦ oneLePart (f x) :=
   measurable_oneLePart.comp hf
 
+@[to_additive (attr := fun_prop)]
+protected theorem AEMeasurable.oneLePart {μ : MeasureTheory.Measure β} [MeasurableSup α]
+    (hf : AEMeasurable f μ) :
+    AEMeasurable (fun x ↦ oneLePart (f x)) μ :=
+  hf.sup_const 1
+
 variable [MeasurableInv α]
 
 @[to_additive]
@@ -41,6 +47,12 @@ theorem measurable_leOnePart [MeasurableSup α] : Measurable (leOnePart : α →
 protected theorem Measurable.leOnePart [MeasurableSup α] (hf : Measurable f) :
     Measurable fun x ↦ leOnePart (f x) :=
   measurable_leOnePart.comp hf
+
+@[to_additive (attr := fun_prop)]
+protected theorem AEMeasurable.leOnePart {μ : MeasureTheory.Measure β} [MeasurableSup α]
+    (hf : AEMeasurable f μ) :
+    AEMeasurable (fun x ↦ leOnePart (f x)) μ :=
+  hf.inv.sup_const 1
 
 variable [MeasurableSup₂ α]
 


### PR DESCRIPTION
Provide `fun_prop` lemmas for the measurability of positive and negative parts.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
