### PR TITLE
[Merged by Bors] - chore(Data/Finsupp/Order): add `Finsupp.support_add_eq'` for canonically ordered `Finsupp`s

### DIFF
--- a/Mathlib/Algebra/Group/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Finsupp.lean
@@ -59,7 +59,7 @@ lemma support_add [DecidableEq ι] : (g₁ + g₂).support ⊆ g₁.support ∪ 
 
 /-- The support of a sum is the union of the supports when the supports are disjoint.
 
-In the case where the coefficients lie in `CanonicallyOrderedAdd`, there is also
+In the case where the coefficients satisfy `CanonicallyOrderedAdd`, there is also
 `Finsupp.support_add_eq_union`, which holds without any disjointness assumption. -/
 lemma support_add_eq [DecidableEq ι] (h : Disjoint g₁.support g₂.support) :
     (g₁ + g₂).support = g₁.support ∪ g₂.support :=

--- a/Mathlib/Algebra/Group/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Finsupp.lean
@@ -57,6 +57,10 @@ lemma add_apply (g₁ g₂ : ι →₀ M) (a : ι) : (g₁ + g₂) a = g₁ a + 
 
 lemma support_add [DecidableEq ι] : (g₁ + g₂).support ⊆ g₁.support ∪ g₂.support := support_zipWith
 
+/-- The support of a sum is the union of the supports when the supports are disjoint.
+
+In the case where the coefficients lie in `CanonicallyOrderedAdd`, there is also
+`Finsupp.support_add_eq_union`, which holds without any disjointness assumption. -/
 lemma support_add_eq [DecidableEq ι] (h : Disjoint g₁.support g₂.support) :
     (g₁ + g₂).support = g₁.support ∪ g₂.support :=
   le_antisymm support_zipWith fun a ha => by

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -300,6 +300,12 @@ lemma embDomain_tsub (f : ι ↪ κ) (f1 f2 : ι →₀ α) :
     (f1 - f2).embDomain f = f1.embDomain f - f2.embDomain f := by
   simp_rw [embDomain_eq_mapDomain, mapDomain_tsub f.injective]
 
+lemma support_add_eq' {f1 f2 : ι →₀ α} [DecidableEq ι] :
+    (f1 + f2).support = (f1.support ∪ f2.support : Finset ι) := by
+  refine le_antisymm support_add (Finset.le_iff_subset.2 (Finset.union_subset ?_ ?_))
+  · exact support_mono le_self_add
+  · exact support_mono <| CanonicallyOrderedAdd.le_add_self ..
+
 end PartialOrder
 
 section LinearOrder

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -300,8 +300,7 @@ lemma embDomain_tsub (f : ι ↪ κ) (f1 f2 : ι →₀ α) :
     (f1 - f2).embDomain f = f1.embDomain f - f2.embDomain f := by
   simp_rw [embDomain_eq_mapDomain, mapDomain_tsub f.injective]
 
-/-- The support of a sum is the union of the supports, when the coefficients lie in
-`CanonicallyOrderedAdd`.
+/-- The support of a sum is the union of the supports, when the coefficients satisfy `CanonicallyOrderedAdd`.
 
 In the case where the supports are disjoint, there is also `Finsupp.support_add_eq`, which holds
 in any `AddZeroClass`. -/

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -301,7 +301,7 @@ lemma embDomain_tsub (f : ι ↪ κ) (f1 f2 : ι →₀ α) :
   simp_rw [embDomain_eq_mapDomain, mapDomain_tsub f.injective]
 
 lemma support_add_eq' {f1 f2 : ι →₀ α} [DecidableEq ι] :
-    (f1 + f2).support = (f1.support ∪ f2.support : Finset ι) :=
+    (f1 + f2).support = f1.support ∪ f2.support :=
   le_antisymm support_add <| Finset.union_subset
     (support_mono le_self_add) (support_mono le_add_self)
 

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -304,7 +304,7 @@ lemma support_add_eq' {f1 f2 : ι →₀ α} [DecidableEq ι] :
     (f1 + f2).support = (f1.support ∪ f2.support : Finset ι) := by
   refine le_antisymm support_add (Finset.le_iff_subset.2 (Finset.union_subset ?_ ?_))
   · exact support_mono le_self_add
-  · exact support_mono <| CanonicallyOrderedAdd.le_add_self ..
+  · exact support_mono <| le_add_self ..
 
 end PartialOrder
 

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -300,7 +300,12 @@ lemma embDomain_tsub (f : ι ↪ κ) (f1 f2 : ι →₀ α) :
     (f1 - f2).embDomain f = f1.embDomain f - f2.embDomain f := by
   simp_rw [embDomain_eq_mapDomain, mapDomain_tsub f.injective]
 
-lemma support_add_eq' {f1 f2 : ι →₀ α} [DecidableEq ι] :
+/-- The support of a sum is the union of the supports, when the coefficients lie in
+`CanonicallyOrderedAdd`.
+
+In the case where the supports are disjoint, there is also `Finsupp.support_add_eq`, which holds
+in any `AddZeroClass`. -/
+lemma support_add_eq_union {f1 f2 : ι →₀ α} [DecidableEq ι] :
     (f1 + f2).support = f1.support ∪ f2.support :=
   le_antisymm support_add <| Finset.union_subset
     (support_mono le_self_add) (support_mono le_add_self)

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -301,10 +301,9 @@ lemma embDomain_tsub (f : ι ↪ κ) (f1 f2 : ι →₀ α) :
   simp_rw [embDomain_eq_mapDomain, mapDomain_tsub f.injective]
 
 lemma support_add_eq' {f1 f2 : ι →₀ α} [DecidableEq ι] :
-    (f1 + f2).support = (f1.support ∪ f2.support : Finset ι) := by
-  refine le_antisymm support_add (Finset.le_iff_subset.2 (Finset.union_subset ?_ ?_))
-  · exact support_mono le_self_add
-  · exact support_mono le_add_self
+    (f1 + f2).support = (f1.support ∪ f2.support : Finset ι) :=
+  le_antisymm support_add <| Finset.union_subset
+    (support_mono le_self_add) (support_mono le_add_self)
 
 end PartialOrder
 

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -300,10 +300,11 @@ lemma embDomain_tsub (f : ι ↪ κ) (f1 f2 : ι →₀ α) :
     (f1 - f2).embDomain f = f1.embDomain f - f2.embDomain f := by
   simp_rw [embDomain_eq_mapDomain, mapDomain_tsub f.injective]
 
-/-- The support of a sum is the union of the supports, when the coefficients satisfy `CanonicallyOrderedAdd`.
+/-- The support of a sum is the union of the supports, when the coefficients satisfy
+`CanonicallyOrderedAdd`.
 
-In the case where the supports are disjoint, there is also `Finsupp.support_add_eq`, which holds
-in any `AddZeroClass`. -/
+In the case where the supports are disjoint, there is also `Finsupp.support_add_eq`,
+which holds in any `AddZeroClass`. -/
 lemma support_add_eq_union {f1 f2 : ι →₀ α} [DecidableEq ι] :
     (f1 + f2).support = f1.support ∪ f2.support :=
   le_antisymm support_add <| Finset.union_subset

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -304,7 +304,7 @@ lemma support_add_eq' {f1 f2 : ι →₀ α} [DecidableEq ι] :
     (f1 + f2).support = (f1.support ∪ f2.support : Finset ι) := by
   refine le_antisymm support_add (Finset.le_iff_subset.2 (Finset.union_subset ?_ ?_))
   · exact support_mono le_self_add
-  · exact support_mono <| le_add_self ..
+  · exact support_mono le_add_self
 
 end PartialOrder
 


### PR DESCRIPTION
Greetings! This PR attempts to show that in a `CanonicallyOrderedAdd` setting, the support of `f1 + f2` is exactly the union of the supports of `f1` and `f2`. This result will be handy in combinatorics and when the coefficients are in natural number (for example [here](https://github.com/Yu-Misaka/YoungDiagram/blob/master/YoungDiagram/Chromosome/Basic.lean))

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
