### PR TITLE
chore: omega to lia replacements that require unfolding min/max

### DIFF
--- a/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
+++ b/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
@@ -50,7 +50,7 @@ lemma of_abv_le (n : ℕ) (hm : ∀ m, n ≤ m → abv (f m) ≤ a m) :
     simp only [Nat.succ_add, Nat.succ_eq_add_one, Finset.sum_range_succ_comm]
     simp only [add_assoc, sub_eq_add_neg]
     simp only [sub_eq_add_neg] at hi
-    grw [abv_add abv, hm _ (by omega), hi]
+    grw [abv_add abv, hm _ (by simp [max_def]; lia), hi]
 
 lemma of_abv (hf : IsCauSeq abs fun m ↦ ∑ n ∈ range m, abv (f n)) :
     IsCauSeq abv fun m ↦ ∑ n ∈ range m, f n :=

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -324,7 +324,8 @@ lemma spine_map_vertex (Δ : X _⦋n⦌) {m : ℕ}
     (X.spine m (X.map φ.op Δ)).vertex i =
       (X.spine n Δ).vertex (φ.toOrderHom i) :=
   truncation (max m n + 1) |>.obj X
-    |>.spine_map_vertex n (by omega) Δ m (by omega) (InducedCategory.homMk φ) i
+    |>.spine_map_vertex n (by rw [max_def]; lia) Δ m (by rw [max_def]; lia)
+    (InducedCategory.homMk φ) i
 
 lemma spine_map_subinterval (j l : ℕ) (h : j + l ≤ n) (Δ : X _⦋n⦌) :
     X.spine l (X.map (subinterval j l h).op Δ) = (X.spine n Δ).interval j l h :=

--- a/Mathlib/Analysis/Normed/Module/Bases.lean
+++ b/Mathlib/Analysis/Normed/Module/Bases.lean
@@ -304,9 +304,9 @@ theorem tendsto_proj (x : X) : Tendsto (fun n ↦ b.proj n x) atTop (𝓝 x) := 
 theorem proj_comp (n m : ℕ) (x : X) : b.proj n (b.proj m x) = b.proj (min n m) x := by
   simp only [proj, GeneralSchauderBasis.proj_comp]
   congr 2
-  ext _
-  simp only [Finset.mem_inter, Finset.mem_range]
-  omega
+  ext
+  simp [min_def]
+  lia
 
 /-- The projections are uniformly bounded. -/
 theorem exists_norm_proj_le [CompleteSpace X] : ∃ C : ℝ, ∀ n : ℕ, ‖b.proj n‖ ≤ C := by

--- a/Mathlib/Combinatorics/Enumerative/DyckWord.lean
+++ b/Mathlib/Combinatorics/Enumerative/DyckWord.lean
@@ -155,7 +155,7 @@ def drop (i : ℕ) (hi : (p.toList.take i).count U = (p.toList.take i).count D) 
     rw [← take_append_drop i p.toList, count_append, count_append] at this
     lia
   count_D_le_count_U k := by
-    rw [show i = min i (i + k) by omega, ← take_take] at hi
+    rw [show i = min i (i + k) by simp, ← take_take] at hi
     rw [take_drop, ← add_le_add_iff_left (((p.toList.take (i + k)).take i).count U),
       ← count_append, hi, ← count_append, take_append_drop]
     exact p.count_D_le_count_U _
@@ -211,7 +211,7 @@ def denest (hn : p.IsNested) : DyckWord where
     rw [← drop_one, take_drop, dropLast_eq_take, take_take]
     have ub : min (1 + i) (p.toList.length - 1) < p.toList.length :=
       (min_le_right _ p.toList.length.pred).trans_lt (Nat.pred_lt ((length_pos_iff.mpr h).ne'))
-    have lb : 0 < min (1 + i) (p.toList.length - 1) := by omega
+    have lb : 0 < min (1 + i) (p.toList.length - 1) := by rw [min_def]; lia
     have eq := hn.2 lb ub
     set j := min (1 + i) (p.toList.length - 1)
     rw [← (p.toList.take j).take_append_drop 1, count_append, count_append, take_take,

--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -309,8 +309,8 @@ theorem exists_lt_ack_of_nat_primrec {f : ℕ → ℕ} (hf : Nat.Primrec f) :
         apply (hb _).trans ((ack_pair_lt _ _ _).trans_le _)
         -- If m is the maximum, we get a very weak inequality.
         rcases lt_or_ge _ m with h₁ | h₁
-        · rw [max_eq_left h₁.le]
-          gcongr <;> omega
+        · rw [max_eq_left h₁.le, max_def]
+          gcongr <;> lia
         rw [max_eq_right h₁]
         -- We get rid of the second `pair`.
         apply (ack_pair_lt _ _ _).le.trans

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -140,12 +140,11 @@ theorem evalFrom_split [Fintype σ] {x : List α} {s t : σ} (hlen : Fintype.car
     ⟨M.evalFrom s ((x.take m).take n), (x.take m).take n, (x.take m).drop n,
                     x.drop m, ?_, ?_, ?_, by rfl, ?_⟩
   · rw [List.take_append_drop, List.take_append_drop]
-  · simp only [List.length_drop, List.length_take]
-    omega
+  · simp [min_def]; lia
   · intro h
     have hlen' := congr_arg List.length h
-    simp only [List.length_drop, List.length, List.length_take] at hlen'
-    omega
+    simp [min_def] at hlen'
+    lia
   have hq : M.evalFrom (M.evalFrom s ((x.take m).take n)) ((x.take m).drop n) =
       M.evalFrom s ((x.take m).take n) := by
     rw [List.take_take, min_eq_left hle, ← evalFrom_of_append, heq, ← min_eq_left hle, ←

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -170,7 +170,7 @@ def permutationsAux.rec {C : List α → List α → Sort v} (H0 : ∀ is, C [] 
   | t :: ts, is =>
       H1 t ts is (permutationsAux.rec H0 H1 ts (t :: is)) (permutationsAux.rec H0 H1 is [])
   termination_by ts is => (length ts + length is, length ts)
-  decreasing_by all_goals (simp_wf; grind)
+  decreasing_by all_goals (simp [Prod.lex_def] <;> lia)
 
 /-- An auxiliary function for defining `permutations`. `permutationsAux ts is` is the set of all
 permutations of `is ++ ts` that do not fix `ts`. -/

--- a/Mathlib/Data/List/Infix.lean
+++ b/Mathlib/Data/List/Infix.lean
@@ -56,7 +56,7 @@ lemma isPrefix_append_of_length (h : l₁.length ≤ l₂.length) : l₁ <+: l�
    fun h ↦ h.trans <| l₂.prefix_append l₃⟩
 
 @[simp] lemma take_isPrefix_take {m n : ℕ} : l.take m <+: l.take n ↔ m ≤ n ∨ l.length ≤ n := by
-  simp [prefix_take_iff, take_prefix]; omega
+  simp [prefix_take_iff, take_prefix, min_def]; lia
 
 @[gcongr]
 protected theorem IsPrefix.flatten {l₁ l₂ : List (List α)} (h : l₁ <+: l₂) :
@@ -323,7 +323,7 @@ lemma map_tails {β : Type*} (g : α → β) : (l.map g).tails = l.tails.map (ma
   induction l using reverseRecOn <;> simp [*]
 
 lemma take_inits {n} : (l.take n).inits = l.inits.take (n + 1) := by
-  apply ext_getElem <;> (simp [take_take] <;> grind)
+  apply ext_getElem <;> (simp [take_take, min_def]; lia)
 
 end InitsTails
 

--- a/Mathlib/Data/Multiset/UnionInter.lean
+++ b/Mathlib/Data/Multiset/UnionInter.lean
@@ -244,7 +244,8 @@ theorem inter_add_sub_of_add_eq_add [DecidableEq α] {M N P Q : Multiset α} (h 
   have h0 : M.count x + N.count x = P.count x + Q.count x := by
     rw [Multiset.ext] at h
     simp_all only [Multiset.count_add]
-  omega
+  simp [min_def]
+  lia
 
 /-! ### Disjoint multisets -/
 

--- a/Mathlib/Data/Vector/Defs.lean
+++ b/Mathlib/Data/Vector/Defs.lean
@@ -192,7 +192,7 @@ def shiftLeftFill (v : Vector α n) (i : ℕ) (fill : α) : Vector α n :=
 /-- `shiftRightFill v i` is the vector obtained by right-shifting `v` `i` times and padding with the
     `fill` argument. If `v.length < i` then this will return `replicate n fill`. -/
 def shiftRightFill (v : Vector α n) (i : ℕ) (fill : α) : Vector α n :=
-  Vector.congr (by omega) (replicate (min n i) fill ++ take (n - i) v)
+  Vector.congr (by simp [Nat.min_def]; lia) (replicate (min n i) fill ++ take (n - i) v)
 
 end Shift
 

--- a/Mathlib/Data/ZMod/ValMinAbs.lean
+++ b/Mathlib/Data/ZMod/ValMinAbs.lean
@@ -163,9 +163,9 @@ variable {n a : ℕ}
 
 lemma valMinAbs_natAbs_eq_min [hpos : NeZero n] (a : ZMod n) :
     a.valMinAbs.natAbs = min a.val (n - a.val) := by
-  rw [valMinAbs_def_pos]
+  rw [valMinAbs_def_pos, min_def]
   have := a.val_lt
-  omega
+  lia
 
 set_option backward.isDefEq.respectTransparency false in
 lemma valMinAbs_natCast_of_le_half (ha : a ≤ n / 2) : (a : ZMod n).valMinAbs = a := by

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -313,7 +313,7 @@ theorem TendstoInMeasure.exists_seq_tendsto_ae (hfg : TendstoInMeasure μ f atTo
         mul_comm (_ ^ n), mul_assoc, ← ENNReal.inv_le_iff_le_mul, inv_inv, ← pow_add]
       · gcongr
         · simp
-        · omega
+        · simp [max_def] at hn_ge; lia
       all_goals simp
     exact le_trans hNx.le h_inv_n_le_k
   rw [ae_iff]

--- a/Mathlib/NumberTheory/LSeries/Deriv.lean
+++ b/Mathlib/NumberTheory/LSeries/Deriv.lean
@@ -109,7 +109,8 @@ lemma LSeries.abscissaOfAbsConv_logMul {f : ℕ → ℂ} :
   · refine (LSeriesSummable_of_abscissaOfAbsConv_lt_re <| by simp [hs])
       |>.norm.of_norm_bounded_eventually_nat (g := fun n ↦ ‖term (logMul f) s n‖) ?_
     filter_upwards [Filter.eventually_ge_atTop <| max 1 (Nat.ceil (Real.exp 1))] with n hn
-    simp only [term_of_ne_zero (show n ≠ 0 by omega), logMul, norm_mul, mul_div_assoc,
+    simp only [max_def] at hn
+    simp only [term_of_ne_zero (show n ≠ 0 by lia), logMul, norm_mul, mul_div_assoc,
       ← natCast_log, norm_real]
     refine le_mul_of_one_le_left (norm_nonneg _) (.trans ?_ <| Real.le_norm_self _)
     simpa using Real.log_le_log (Real.exp_pos 1) <| Nat.ceil_le.mp <| (le_max_right _ _).trans hn

--- a/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
@@ -315,9 +315,8 @@ lemma add_eq_min {q r : ℚ} (hqr : q + r ≠ 0) (hq : q ≠ 0) (hr : r ≠ 0)
   have h1 := min_le_padicValRat_add (p := p) hqr
   have h2 := min_le_padicValRat_add (p := p) (ne_of_eq_of_ne (add_neg_cancel_right q r) hq)
   have h3 := min_le_padicValRat_add (p := p) (ne_of_eq_of_ne (add_neg_cancel_right r q) hr)
-  rw [add_neg_cancel_right, padicValRat.neg] at h2 h3
-  rw [add_comm] at h3
-  omega
+  simp [min_def, add_comm] at h1 h2 h3 ⊢
+  lia
 
 lemma add_eq_of_lt {q r : ℚ} (hqr : q + r ≠ 0)
     (hq : q ≠ 0) (hr : r ≠ 0) (hval : padicValRat p q < padicValRat p r) :

--- a/Mathlib/Order/Interval/Finset/Box.lean
+++ b/Mathlib/Order/Interval/Finset/Box.lean
@@ -102,8 +102,8 @@ lemma card_box : ∀ {n}, n ≠ 0 → #(box n : Finset (ℤ × ℤ)) = 8 * n
 @[simp] lemma mem_box : ∀ {n}, x ∈ box n ↔ max x.1.natAbs x.2.natAbs = n
   | 0 => by simp [Prod.ext_iff]
   | n + 1 => by
-    simp [box_succ_eq_sdiff, Prod.le_def]
-    omega
+    simp [box_succ_eq_sdiff, Prod.le_def, max_def]
+    lia
 
 -- TODO: Can this be generalised to locally finite archimedean ordered rings?
 lemma existsUnique_mem_box (x : ℤ × ℤ) : ∃! n : ℕ, x ∈ box n := by

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -83,8 +83,9 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
   obtain ⟨n₁, hn₁⟩ := h₂
   obtain ⟨n₂, hn₂⟩ := h₃
   let N := n₁ ⊔ n₂
-  have h₄ : a ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₁
-  have h₅ : b ^ (N + 1) = 0 := pow_eq_zero_of_le (by omega) hn₂
+  have : N = if n₁ ≤ n₂ then n₂ else n₁ := by simp [N, max_def]
+  have h₄ : a ^ (N + 1) = 0 := pow_eq_zero_of_le (by lia) hn₁
+  have h₅ : b ^ (N + 1) = 0 := pow_eq_zero_of_le (by lia) hn₂
   rw [exp_eq_sum (k := 2 * N + 1)
     (Commute.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero h₁ h₄ h₅ (by lia)),
     exp_eq_sum h₄, exp_eq_sum h₅]
@@ -226,8 +227,9 @@ theorem commute_exp_left_of_commute
   obtain ⟨k, hfM⟩ := hfM
   obtain ⟨l, hfN⟩ := hfN
   let kl := max k l
-  replace hfM : fM ^ kl = 0 := pow_eq_zero_of_le (by omega) hfM
-  replace hfN : fN ^ kl = 0 := pow_eq_zero_of_le (by omega) hfN
+  have : kl = if k ≤ l then l else k := by simp [kl, max_def]
+  replace hfM : fM ^ kl = 0 := pow_eq_zero_of_le (by lia) hfM
+  replace hfN : fN ^ kl = 0 := pow_eq_zero_of_le (by lia) hfN
   have (i : ℕ) : (fN ^ i) (g m) = g ((fM ^ i) m) := by
     simpa using LinearMap.congr_fun (Module.End.commute_pow_left_of_commute h i) m
   simp [exp_eq_sum hfM, exp_eq_sum hfN, this, map_rat_smul]

--- a/Mathlib/RingTheory/PowerSeries/Restricted.lean
+++ b/Mathlib/RingTheory/PowerSeries/Restricted.lean
@@ -147,14 +147,18 @@ lemma mul {f g : PowerSeries R} (hf : IsRestricted c f) (hg : IsRestricted c g) 
   · calc _ < ε / max a b * b := by
           grw [gBound1 snd]
           gcongr
-          exact fBound2 fst (by omega)
+          apply fBound2 fst
+          simp [max_def] at *
+          lia
          _ ≤ ε := by
           rw [div_mul_comm, mul_le_iff_le_one_left ‹_›]
           bound
   · calc _ < a * (ε / max a b) := by
           grw [fBound1 fst]
           gcongr
-          exact gBound2 snd (by omega)
+          apply gBound2 snd
+          simp [max_def] at *
+          lia
          _ ≤ ε := by
           rw [mul_div_left_comm, mul_le_iff_le_one_right ‹_›]
           bound


### PR DESCRIPTION
This is a draft PR, as we may not want to actually take this approach. This is mostly to point out where this pattern applies.

#40015 was merged with some outstanding comments from @grunweg, asking about some replacements of `omega` with `grind` made in that PR. In general this is undesirable, as we would rather replace with `lia` for the purposes of more clearly communicating the intent of the proof and potential performance benefits.

I noted that in the couple of cases there, all that was required to use `lia` was some unfolding. I had a guess that this would be the case throughout Mathlib, and decided to check this against [#**nightly-testing-mathlib>nightly-testing regression log**](https://leanprover.zulipchat.com/#narrow/channel/595625-nightly-testing-mathlib/topic/nightly-testing.20regression.20log/with/600010631), which records all places that `omega` cannot be directly replaced with `lia`. There are only 44 places this happens, and about 75% of them amount to using `max_def`/`min_def` as shown in this PR.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
