### PR TITLE
[Merged by Bors] - fix: label parsing in the check_title workflow

### DIFF
--- a/scripts/check_title_labels.lean
+++ b/scripts/check_title_labels.lean
@@ -21,8 +21,11 @@ open Cli in
 The exit code is the number of violations found. -/
 def checkTitleLabelsCLI (args : Parsed) : IO UInt32 := do
   let title := (args.positionalArg! "title").value
-  let labels : Array String := args.variableArgsAs! String
-  -- We not validate titles of WIP PRs.
+  let labels : List String := match args.flag? "labels" with
+  | some f => (f.as! String).splitOn "\n"
+  | none => []
+  IO.println s!"labels are {labels}"
+  -- We do not validate titles of WIP PRs.
   if labels.contains "WIP" then return 0
 
   let mut numberErrors := 0
@@ -45,7 +48,7 @@ def checkTitleLabels : Cmd := `[Cli|
   If the inpupt title does not pass validation, output a list of errors."
 
   FLAGS:
-    "labels" : Array String; "list of label names of this PR\
+    "labels" : String; "newline-separated list of label names of this PR\
       These are optional; we merely use a WIP label to skip any checks of the PR title"
 
   ARGS:


### PR DESCRIPTION
The workflow step returns all labels as one string, separated by newlines. Since GitHub labels are allowed to contain spaces, it's safest to make the script expect a newline-separated (and not e.g. space-separated) label names.

The old logic never fired, as the labels are a flag, not a variable argument.

Spotted in #40181; thanks `@kim-em` for the report and suggesting an initial fix.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
