### PR TITLE
refactor(Analysis/Convex): use the new convexity concepts

### DIFF
--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -7,8 +7,9 @@ module
 
 public import Mathlib.Algebra.Ring.Action.Pointwise.Set
 public import Mathlib.Analysis.Convex.Star
-public import Mathlib.Tactic.Field
+public import Mathlib.Geometry.Convex.ConvexSpace.Module
 public import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Defs
+public import Mathlib.Tactic.Field
 public import Mathlib.Tactic.NoncommRing
 
 /-!
@@ -18,10 +19,6 @@ In a 𝕜-vector space, we define the following property:
 * `Convex 𝕜 s`: A set `s` is convex if for any two points `x y ∈ s` it includes `segment 𝕜 x y`.
 
 We provide various equivalent versions, and prove that some specific sets are convex.
-
-## TODO
-
-Generalize all this file to affine spaces.
 -/
 
 @[expose] public section
@@ -29,12 +26,634 @@ Generalize all this file to affine spaces.
 
 variable {𝕜 E F β : Type*}
 
-open LinearMap Set
+open Convexity LinearMap Set
 
 open scoped Convex Pointwise
 
-/-! ### Convexity of sets -/
 
+section OrderedSemiring
+
+variable [Semiring 𝕜] [PartialOrder 𝕜] [IsStrictOrderedRing 𝕜]
+
+section AddCommMonoid
+
+variable [AddCommMonoid E] [AddCommMonoid F]
+
+section SMul
+
+variable (𝕜) [SMul 𝕜 E] [SMul 𝕜 F] (s : Set E) {x : E}
+
+/-- Convexity of sets. -/
+@[deprecated IsConvexSet (since := "2026-06-04")]
+def Convex : Prop :=
+  ∀ ⦃x : E⦄, x ∈ s → StarConvex 𝕜 x s
+
+variable {𝕜 s}
+
+
+lemma IsConvexSet.starConvex (hs : IsConvexSet 𝕜 s) (hx : x ∈ s) : StarConvex 𝕜 x s :=
+  hs hx
+
+theorem IsConvexSet.starConvex (hs : IsConvexSet 𝕜 s) (hx : x ∈ s) : StarConvex 𝕜 x s :=
+  hs hx
+
+theorem isconvexset_iff_segment_subset : IsConvexSet 𝕜 s ↔ ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → [x -[𝕜] y] ⊆ s :=
+  forall₂_congr fun _ _ => starConvex_iff_segment_subset
+
+theorem IsConvexSet.segment_subset (h : IsConvexSet 𝕜 s) {x y : E} (hx : x ∈ s) (hy : y ∈ s) :
+    [x -[𝕜] y] ⊆ s :=
+  isconvexset_iff_segment_subset.1 h hx hy
+
+theorem IsConvexSet.openSegment_subset (h : IsConvexSet 𝕜 s) {x y : E} (hx : x ∈ s) (hy : y ∈ s) :
+    openSegment 𝕜 x y ⊆ s :=
+  (openSegment_subset_segment 𝕜 x y).trans (h.segment_subset hx hy)
+
+theorem isconvexset_iff_add_mem : IsConvexSet 𝕜 s ↔
+    ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 → a • x + b • y ∈ s := by
+  simp_rw [isconvexset_iff_segment_subset, segment_subset_iff]
+
+/-- Alternative definition of set isconvexsetity, in terms of pointwise set operations. -/
+theorem isconvexset_iff_pointwise_add_subset :
+    IsConvexSet 𝕜 s ↔ ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 → a • s + b • s ⊆ s :=
+  Iff.intro
+    (by
+      rintro hA a b ha hb hab w ⟨au, ⟨u, hu, rfl⟩, bv, ⟨v, hv, rfl⟩, rfl⟩
+      exact hA hu hv ha hb hab)
+    fun h _ hx _ hy _ _ ha hb hab => (h ha hb hab) (Set.add_mem_add ⟨_, hx, rfl⟩ ⟨_, hy, rfl⟩)
+
+alias ⟨IsConvexSet.set_combo_subset, _⟩ := isconvexset_iff_pointwise_add_subset
+
+theorem isconvexset_empty : IsConvexSet 𝕜 (∅ : Set E) := fun _ => False.elim
+
+theorem isconvexset_univ : IsConvexSet 𝕜 (Set.univ : Set E) := fun _ _ => starConvex_univ _
+
+theorem IsConvexSet.inter {t : Set E} (hs : IsConvexSet 𝕜 s) (ht : IsConvexSet 𝕜 t) : IsConvexSet 𝕜 (s ∩ t) :=
+  fun _ hx => (hs hx.1).inter (ht hx.2)
+
+theorem isconvexset_sInter {S : Set (Set E)} (h : ∀ s ∈ S, IsConvexSet 𝕜 s) : IsConvexSet 𝕜 (⋂₀ S) := fun _ hx =>
+  starConvex_sInter fun _ hs => h _ hs <| hx _ hs
+
+theorem isconvexset_iInter {ι : Sort*} {s : ι → Set E} (h : ∀ i, IsConvexSet 𝕜 (s i)) :
+    IsConvexSet 𝕜 (⋂ i, s i) :=
+  sInter_range s ▸ isconvexset_sInter <| forall_mem_range.2 h
+
+theorem isconvexset_iInter₂ {ι : Sort*} {κ : ι → Sort*} {s : (i : ι) → κ i → Set E}
+    (h : ∀ i j, IsConvexSet 𝕜 (s i j)) : IsConvexSet 𝕜 (⋂ (i) (j), s i j) :=
+  isconvexset_iInter fun i => isconvexset_iInter <| h i
+
+theorem IsConvexSet.prod {s : Set E} {t : Set F} (hs : IsConvexSet 𝕜 s) (ht : IsConvexSet 𝕜 t) :
+    IsConvexSet 𝕜 (s ×ˢ t) := fun _ hx => (hs hx.1).prod (ht hx.2)
+
+theorem isconvexset_pi {ι : Type*} {E : ι → Type*} [∀ i, AddCommMonoid (E i)] [∀ i, SMul 𝕜 (E i)]
+    {s : Set ι} {t : ∀ i, Set (E i)} (ht : ∀ ⦃i⦄, i ∈ s → IsConvexSet 𝕜 (t i)) : IsConvexSet 𝕜 (s.pi t) :=
+  fun _ hx => starConvex_pi fun _ hi => ht hi <| hx _ hi
+
+theorem Directed.isconvexset_iUnion {ι : Sort*} {s : ι → Set E} (hdir : Directed (· ⊆ ·) s)
+    (hc : ∀ ⦃i : ι⦄, IsConvexSet 𝕜 (s i)) : IsConvexSet 𝕜 (⋃ i, s i) := by
+  rintro x hx y hy a b ha hb hab
+  rw [mem_iUnion] at hx hy ⊢
+  obtain ⟨i, hx⟩ := hx
+  obtain ⟨j, hy⟩ := hy
+  obtain ⟨k, hik, hjk⟩ := hdir i j
+  exact ⟨k, hc (hik hx) (hjk hy) ha hb hab⟩
+
+theorem DirectedOn.isconvexset_sUnion {c : Set (Set E)} (hdir : DirectedOn (· ⊆ ·) c)
+    (hc : ∀ ⦃A : Set E⦄, A ∈ c → IsConvexSet 𝕜 A) : IsConvexSet 𝕜 (⋃₀ c) := by
+  rw [sUnion_eq_iUnion]
+  exact (directedOn_iff_directed.1 hdir).isconvexset_iUnion fun A => hc A.2
+
+theorem IsConvexSet.setOf_const_imp {P : Prop} (hs : IsConvexSet 𝕜 s) : IsConvexSet 𝕜 {x | P → x ∈ s} := by
+  by_cases hP : P <;> simp [hP, hs, isconvexset_univ]
+
+end SMul
+
+section Module
+
+variable [Module 𝕜 E] [Module 𝕜 F] {s : Set E} {x : E}
+
+theorem isconvexset_iff_openSegment_subset [ZeroLEOneClass 𝕜] :
+    IsConvexSet 𝕜 s ↔ ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → openSegment 𝕜 x y ⊆ s :=
+  forall₂_congr fun _ => starConvex_iff_openSegment_subset
+
+theorem isconvexset_iff_forall_pos :
+    IsConvexSet 𝕜 s ↔
+      ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 → a • x + b • y ∈ s :=
+  forall₂_congr fun _ => starConvex_iff_forall_pos
+
+theorem isconvexset_iff_pairwise_pos : IsConvexSet 𝕜 s ↔
+    s.Pairwise fun x y => ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 → a • x + b • y ∈ s := by
+  refine isconvexset_iff_forall_pos.trans ⟨fun h x hx y hy _ => h hx hy, ?_⟩
+  intro h x hx y hy a b ha hb hab
+  obtain rfl | hxy := eq_or_ne x y
+  · rwa [IsConvexSet.combo_self hab]
+  · exact h hx hy hxy ha hb hab
+
+theorem IsConvexSet.starConvex_iff [ZeroLEOneClass 𝕜] (hs : IsConvexSet 𝕜 s) (h : s.Nonempty) :
+    StarConvex 𝕜 x s ↔ x ∈ s :=
+  ⟨fun hxs => hxs.mem h, hs.starConvex⟩
+
+protected theorem Set.Subsingleton.isconvexset {s : Set E} (h : s.Subsingleton) : IsConvexSet 𝕜 s :=
+  isconvexset_iff_pairwise_pos.mpr (h.pairwise _)
+
+@[simp] theorem isconvexset_singleton (c : E) : IsConvexSet 𝕜 ({c} : Set E) :=
+  subsingleton_singleton.isconvexset
+
+theorem isconvexset_zero : IsConvexSet 𝕜 (0 : Set E) :=
+  isconvexset_singleton _
+
+theorem isconvexset_segment [IsOrderedRing 𝕜] (x y : E) : IsConvexSet 𝕜 [x -[𝕜] y] := by
+  rintro p ⟨ap, bp, hap, hbp, habp, rfl⟩ q ⟨aq, bq, haq, hbq, habq, rfl⟩ a b ha hb hab
+  refine
+    ⟨a * ap + b * aq, a * bp + b * bq, add_nonneg (mul_nonneg ha hap) (mul_nonneg hb haq),
+      add_nonneg (mul_nonneg ha hbp) (mul_nonneg hb hbq), ?_, ?_⟩
+  · rw [add_add_add_comm, ← mul_add, ← mul_add, habp, habq, mul_one, mul_one, hab]
+  · match_scalars <;> noncomm_ring
+
+/-- See `IsConvexSet.semilinear_image` for a version for semilinear maps, but requiring that `𝕜` be a
+  linear order, instead of just a partial order. -/
+theorem IsConvexSet.linear_image (hs : IsConvexSet 𝕜 s) (f : E →ₗ[𝕜] F) : IsConvexSet 𝕜 (f '' s) := by
+  rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩ a b ha hb hab
+  exact ⟨a • x + b • y, hs hx hy ha hb hab, by rw [f.map_add, f.map_smul, f.map_smul]⟩
+
+theorem IsConvexSet.is_linear_image (hs : IsConvexSet 𝕜 s) {f : E → F} (hf : IsLinearMap 𝕜 f) :
+    IsConvexSet 𝕜 (f '' s) :=
+  hs.linear_image <| hf.mk' f
+
+theorem IsConvexSet.linear_preimage {s : Set F} (hs : IsConvexSet 𝕜 s) (f : E →ₗ[𝕜] F) : IsConvexSet 𝕜 (f ⁻¹' s) :=
+  fun x hx y hy a b ha hb hab => by
+    rw [mem_preimage, f.map_add, LinearMap.map_smul_of_tower, LinearMap.map_smul_of_tower]
+    exact hs hx hy ha hb hab
+
+theorem IsConvexSet.is_linear_preimage {s : Set F} (hs : IsConvexSet 𝕜 s) {f : E → F} (hf : IsLinearMap 𝕜 f) :
+    IsConvexSet 𝕜 (f ⁻¹' s) := hs.linear_preimage <| hf.mk' f
+
+theorem IsConvexSet.add {t : Set E} (hs : IsConvexSet 𝕜 s) (ht : IsConvexSet 𝕜 t) : IsConvexSet 𝕜 (s + t) := by
+  rw [← add_image_prod]
+  exact (hs.prod ht).is_linear_image IsLinearMap.isLinearMap_add
+
+variable (𝕜 E)
+
+/-- The isconvexset sets form an additive submonoid under pointwise addition. -/
+noncomputable def isconvexsetAddSubmonoid : AddSubmonoid (Set E) where
+  carrier := {s : Set E | IsConvexSet 𝕜 s}
+  zero_mem' := isconvexset_zero
+  add_mem' := IsConvexSet.add
+
+@[simp, norm_cast]
+theorem coe_isconvexsetAddSubmonoid : ↑(isconvexsetAddSubmonoid 𝕜 E) = {s : Set E | IsConvexSet 𝕜 s} :=
+  rfl
+
+variable {𝕜 E}
+
+@[simp]
+theorem mem_isconvexsetAddSubmonoid {s : Set E} : s ∈ isconvexsetAddSubmonoid 𝕜 E ↔ IsConvexSet 𝕜 s :=
+  Iff.rfl
+
+theorem isconvexset_list_sum {l : List (Set E)} (h : ∀ i ∈ l, IsConvexSet 𝕜 i) : IsConvexSet 𝕜 l.sum :=
+  (isconvexsetAddSubmonoid 𝕜 E).list_sum_mem h
+
+theorem isconvexset_multiset_sum {s : Multiset (Set E)} (h : ∀ i ∈ s, IsConvexSet 𝕜 i) : IsConvexSet 𝕜 s.sum :=
+  (isconvexsetAddSubmonoid 𝕜 E).multiset_sum_mem _ h
+
+theorem isconvexset_sum {ι} {s : Finset ι} (t : ι → Set E) (h : ∀ i ∈ s, IsConvexSet 𝕜 (t i)) :
+    IsConvexSet 𝕜 (∑ i ∈ s, t i) :=
+  (isconvexsetAddSubmonoid 𝕜 E).sum_mem h
+
+theorem IsConvexSet.vadd (hs : IsConvexSet 𝕜 s) (z : E) : IsConvexSet 𝕜 (z +ᵥ s) := by
+  simp_rw [← image_vadd, vadd_eq_add, ← singleton_add]
+  exact (isconvexset_singleton _).add hs
+
+theorem IsConvexSet.translate (hs : IsConvexSet 𝕜 s) (z : E) : IsConvexSet 𝕜 ((fun x => z + x) '' s) :=
+  hs.vadd _
+
+/-- The translation of a isconvexset set is also isconvexset. -/
+theorem IsConvexSet.translate_preimage_right (hs : IsConvexSet 𝕜 s) (z : E) :
+    IsConvexSet 𝕜 ((fun x => z + x) ⁻¹' s) := by
+  intro x hx y hy a b ha hb hab
+  have h := hs hx hy ha hb hab
+  rwa [smul_add, smul_add, add_add_add_comm, ← add_smul, hab, one_smul] at h
+
+/-- The translation of a isconvexset set is also isconvexset. -/
+theorem IsConvexSet.translate_preimage_left (hs : IsConvexSet 𝕜 s) (z : E) :
+    IsConvexSet 𝕜 ((fun x => x + z) ⁻¹' s) := by
+  simpa only [add_comm] using hs.translate_preimage_right z
+
+section OrderedAddCommMonoid
+
+variable [AddCommMonoid β] [PartialOrder β] [IsOrderedAddMonoid β] [Module 𝕜 β] [PosSMulMono 𝕜 β]
+
+theorem isconvexset_Iic (r : β) : IsConvexSet 𝕜 (Iic r) := fun x hx y hy a b ha hb hab =>
+  calc
+    a • x + b • y ≤ a • r + b • r :=
+      add_le_add (smul_le_smul_of_nonneg_left hx ha) (smul_le_smul_of_nonneg_left hy hb)
+    _ = r := IsConvexSet.combo_self hab _
+
+theorem isconvexset_Ici (r : β) : IsConvexSet 𝕜 (Ici r) :=
+  isconvexset_Iic (β := βᵒᵈ) r
+
+theorem isconvexset_Icc (r s : β) : IsConvexSet 𝕜 (Icc r s) :=
+  Ici_inter_Iic.subst ((isconvexset_Ici r).inter <| isconvexset_Iic s)
+
+theorem isconvexset_halfSpace_le {f : E → β} (h : IsLinearMap 𝕜 f) (r : β) : IsConvexSet 𝕜 { w | f w ≤ r } :=
+  (isconvexset_Iic r).is_linear_preimage h
+theorem isconvexset_halfSpace_ge {f : E → β} (h : IsLinearMap 𝕜 f) (r : β) : IsConvexSet 𝕜 { w | r ≤ f w } :=
+  (isconvexset_Ici r).is_linear_preimage h
+theorem isconvexset_hyperplane {f : E → β} (h : IsLinearMap 𝕜 f) (r : β) : IsConvexSet 𝕜 { w | f w = r } := by
+  simp_rw [le_antisymm_iff]
+  exact (isconvexset_halfSpace_le h r).inter (isconvexset_halfSpace_ge h r)
+
+end OrderedAddCommMonoid
+
+section OrderedCancelAddCommMonoid
+
+variable [AddCommMonoid β] [PartialOrder β] [IsOrderedCancelAddMonoid β]
+  [Module 𝕜 β] [PosSMulStrictMono 𝕜 β]
+
+theorem isconvexset_Iio (r : β) : IsConvexSet 𝕜 (Iio r) := by
+  intro x hx y hy a b ha hb hab
+  obtain rfl | ha' := ha.eq_or_lt
+  · rw [zero_add] at hab
+    rwa [zero_smul, zero_add, hab, one_smul]
+  rw [mem_Iio] at hx hy
+  calc
+    a • x + b • y < a • r + b • r := add_lt_add_of_lt_of_le
+        (smul_lt_smul_of_pos_left hx ha') (smul_le_smul_of_nonneg_left hy.le hb)
+    _ = r := IsConvexSet.combo_self hab _
+
+theorem isconvexset_Ioi (r : β) : IsConvexSet 𝕜 (Ioi r) :=
+  isconvexset_Iio (β := βᵒᵈ) r
+
+theorem isconvexset_Ioo (r s : β) : IsConvexSet 𝕜 (Ioo r s) :=
+  Ioi_inter_Iio.subst ((isconvexset_Ioi r).inter <| isconvexset_Iio s)
+
+theorem isconvexset_Ico (r s : β) : IsConvexSet 𝕜 (Ico r s) :=
+  Ici_inter_Iio.subst ((isconvexset_Ici r).inter <| isconvexset_Iio s)
+
+theorem isconvexset_Ioc (r s : β) : IsConvexSet 𝕜 (Ioc r s) :=
+  Ioi_inter_Iic.subst ((isconvexset_Ioi r).inter <| isconvexset_Iic s)
+
+theorem isconvexset_halfSpace_lt {f : E → β} (h : IsLinearMap 𝕜 f) (r : β) : IsConvexSet 𝕜 { w | f w < r } :=
+  (isconvexset_Iio r).is_linear_preimage h
+theorem isconvexset_halfSpace_gt {f : E → β} (h : IsLinearMap 𝕜 f) (r : β) : IsConvexSet 𝕜 { w | r < f w } :=
+  (isconvexset_Ioi r).is_linear_preimage h
+end OrderedCancelAddCommMonoid
+
+section LinearOrderedAddCommMonoid
+
+variable [AddCommMonoid β] [LinearOrder β] [IsOrderedAddMonoid β] [Module 𝕜 β] [PosSMulMono 𝕜 β]
+
+theorem isconvexset_uIcc (r s : β) : IsConvexSet 𝕜 (uIcc r s) :=
+  isconvexset_Icc _ _
+
+end LinearOrderedAddCommMonoid
+
+end Module
+
+section IsScalarTower
+
+variable [ZeroLEOneClass 𝕜] [Module 𝕜 E]
+variable (R : Type*) [Semiring R] [PartialOrder R] [Module R E]
+variable [Module R 𝕜] [IsScalarTower R 𝕜 E]
+
+/-- Lift the isconvexsetity of a set up through a scalar tower. -/
+theorem IsConvexSet.lift [SMulPosMono R 𝕜] {s : Set E} (hs : IsConvexSet 𝕜 s) : IsConvexSet R s := by
+  intro x hx y hy a b ha hb hab
+  suffices (a • (1 : 𝕜)) • x + (b • (1 : 𝕜)) • y ∈ s by simpa using this
+  refine hs hx hy ?_ ?_ (by simpa [add_smul] using congr($(hab) • (1 : 𝕜)))
+  all_goals exact zero_smul R (1 : 𝕜) ▸ smul_le_smul_of_nonneg_right ‹_› zero_le_one
+
+end IsScalarTower
+
+end AddCommMonoid
+
+section LinearOrderedAddCommMonoid
+
+variable [AddCommMonoid E] [LinearOrder E] [IsOrderedAddMonoid E]
+  [PartialOrder β] [Module 𝕜 E] [PosSMulMono 𝕜 E]
+  {s : Set E} {f : E → β}
+
+theorem MonotoneOn.isconvexset_le (hf : MonotoneOn f s) (hs : IsConvexSet 𝕜 s) (r : β) :
+    IsConvexSet 𝕜 ({ x ∈ s | f x ≤ r }) := fun x hx y hy _ _ ha hb hab =>
+  ⟨hs hx.1 hy.1 ha hb hab,
+    (hf (hs hx.1 hy.1 ha hb hab) (max_rec' (· ∈ s) hx.1 hy.1)
+      (IsConvexSet.combo_le_max x y ha hb hab)).trans
+      (max_rec' (f · ≤ r) hx.2 hy.2)⟩
+
+theorem MonotoneOn.isconvexset_lt (hf : MonotoneOn f s) (hs : IsConvexSet 𝕜 s) (r : β) :
+    IsConvexSet 𝕜 ({ x ∈ s | f x < r }) := fun x hx y hy _ _ ha hb hab =>
+  ⟨hs hx.1 hy.1 ha hb hab,
+    (hf (hs hx.1 hy.1 ha hb hab) (max_rec' (· ∈ s) hx.1 hy.1)
+          (IsConvexSet.combo_le_max x y ha hb hab)).trans_lt
+      (max_rec' (f · < r) hx.2 hy.2)⟩
+
+theorem MonotoneOn.isconvexset_ge (hf : MonotoneOn f s) (hs : IsConvexSet 𝕜 s) (r : β) :
+    IsConvexSet 𝕜 ({ x ∈ s | r ≤ f x }) :=
+  MonotoneOn.isconvexset_le (E := Eᵒᵈ) (β := βᵒᵈ) hf.dual (by exact hs) r
+
+theorem MonotoneOn.isconvexset_gt (hf : MonotoneOn f s) (hs : IsConvexSet 𝕜 s) (r : β) :
+    IsConvexSet 𝕜 ({ x ∈ s | r < f x }) :=
+  MonotoneOn.isconvexset_lt (E := Eᵒᵈ) (β := βᵒᵈ) hf.dual (by exact hs) r
+
+theorem AntitoneOn.isconvexset_le (hf : AntitoneOn f s) (hs : IsConvexSet 𝕜 s) (r : β) :
+    IsConvexSet 𝕜 ({ x ∈ s | f x ≤ r }) :=
+  MonotoneOn.isconvexset_ge (β := βᵒᵈ) hf hs r
+
+theorem AntitoneOn.isconvexset_lt (hf : AntitoneOn f s) (hs : IsConvexSet 𝕜 s) (r : β) :
+    IsConvexSet 𝕜 ({ x ∈ s | f x < r }) :=
+  MonotoneOn.isconvexset_gt (β := βᵒᵈ) hf hs r
+
+theorem AntitoneOn.isconvexset_ge (hf : AntitoneOn f s) (hs : IsConvexSet 𝕜 s) (r : β) :
+    IsConvexSet 𝕜 ({ x ∈ s | r ≤ f x }) :=
+  MonotoneOn.isconvexset_le (β := βᵒᵈ) hf hs r
+
+theorem AntitoneOn.isconvexset_gt (hf : AntitoneOn f s) (hs : IsConvexSet 𝕜 s) (r : β) :
+    IsConvexSet 𝕜 ({ x ∈ s | r < f x }) :=
+  MonotoneOn.isconvexset_lt (β := βᵒᵈ) hf hs r
+
+theorem Monotone.isconvexset_le (hf : Monotone f) (r : β) : IsConvexSet 𝕜 { x | f x ≤ r } :=
+  Set.sep_univ.subst ((hf.monotoneOn univ).isconvexset_le isconvexset_univ r)
+
+theorem Monotone.isconvexset_lt (hf : Monotone f) (r : β) : IsConvexSet 𝕜 { x | f x ≤ r } :=
+  Set.sep_univ.subst ((hf.monotoneOn univ).isconvexset_le isconvexset_univ r)
+
+theorem Monotone.isconvexset_ge (hf : Monotone f) (r : β) : IsConvexSet 𝕜 { x | r ≤ f x } :=
+  Set.sep_univ.subst ((hf.monotoneOn univ).isconvexset_ge isconvexset_univ r)
+
+theorem Monotone.isconvexset_gt (hf : Monotone f) (r : β) : IsConvexSet 𝕜 { x | f x ≤ r } :=
+  Set.sep_univ.subst ((hf.monotoneOn univ).isconvexset_le isconvexset_univ r)
+
+theorem Antitone.isconvexset_le (hf : Antitone f) (r : β) : IsConvexSet 𝕜 { x | f x ≤ r } :=
+  Set.sep_univ.subst ((hf.antitoneOn univ).isconvexset_le isconvexset_univ r)
+
+theorem Antitone.isconvexset_lt (hf : Antitone f) (r : β) : IsConvexSet 𝕜 { x | f x < r } :=
+  Set.sep_univ.subst ((hf.antitoneOn univ).isconvexset_lt isconvexset_univ r)
+
+theorem Antitone.isconvexset_ge (hf : Antitone f) (r : β) : IsConvexSet 𝕜 { x | r ≤ f x } :=
+  Set.sep_univ.subst ((hf.antitoneOn univ).isconvexset_ge isconvexset_univ r)
+
+theorem Antitone.isconvexset_gt (hf : Antitone f) (r : β) : IsConvexSet 𝕜 { x | r < f x } :=
+  Set.sep_univ.subst ((hf.antitoneOn univ).isconvexset_gt isconvexset_univ r)
+
+end LinearOrderedAddCommMonoid
+
+end OrderedSemiring
+
+section OrderedCommSemiring
+
+variable [CommSemiring 𝕜] [PartialOrder 𝕜]
+
+section AddCommMonoid
+
+variable [AddCommMonoid E] [AddCommMonoid F] [Module 𝕜 E] [Module 𝕜 F] {s : Set E}
+
+theorem IsConvexSet.smul (hs : IsConvexSet 𝕜 s) (c : 𝕜) : IsConvexSet 𝕜 (c • s) :=
+  hs.linear_image (LinearMap.lsmul _ _ c)
+
+theorem IsConvexSet.smul_preimage (hs : IsConvexSet 𝕜 s) (c : 𝕜) : IsConvexSet 𝕜 ((fun z => c • z) ⁻¹' s) :=
+  hs.linear_preimage (LinearMap.lsmul _ _ c)
+
+theorem IsConvexSet.affinity (hs : IsConvexSet 𝕜 s) (z : E) (c : 𝕜) :
+    IsConvexSet 𝕜 ((fun x => z + c • x) '' s) := by
+  simpa only [← image_smul, ← image_vadd, image_image] using! (hs.smul c).vadd z
+
+end AddCommMonoid
+
+end OrderedCommSemiring
+
+section StrictOrderedCommSemiring
+
+variable [CommSemiring 𝕜] [PartialOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E]
+
+theorem isconvexset_openSegment (a b : E) : IsConvexSet 𝕜 (openSegment 𝕜 a b) := by
+  rw [isconvexset_iff_openSegment_subset]
+  rintro p ⟨ap, bp, hap, hbp, habp, rfl⟩ q ⟨aq, bq, haq, hbq, habq, rfl⟩ z ⟨a, b, ha, hb, hab, rfl⟩
+  refine ⟨a * ap + b * aq, a * bp + b * bq, by positivity, by positivity, ?_, ?_⟩
+  · linear_combination (norm := noncomm_ring) a * habp + b * habq + hab
+  · module
+
+end StrictOrderedCommSemiring
+
+section OrderedRing
+
+variable [Ring 𝕜] [PartialOrder 𝕜]
+
+section AddCommGroup
+
+variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F] {s t : Set E}
+
+@[simp]
+theorem isconvexset_vadd (a : E) : IsConvexSet 𝕜 (a +ᵥ s) ↔ IsConvexSet 𝕜 s :=
+  ⟨fun h ↦ by simpa using h.vadd (-a), fun h ↦ h.vadd _⟩
+
+/-- Affine subspaces are isconvexset. -/
+theorem AffineSubspace.isconvexset (Q : AffineSubspace 𝕜 E) : IsConvexSet 𝕜 (Q : Set E) :=
+  fun x hx y hy a b _ _ hab ↦ by simpa [IsConvexSet.combo_eq_smul_sub_add hab] using! Q.2 _ hy hx hx
+
+/-- The preimage of a isconvexset set under an affine map is isconvexset. -/
+theorem IsConvexSet.affine_preimage (f : E →ᵃ[𝕜] F) {s : Set F} (hs : IsConvexSet 𝕜 s) : IsConvexSet 𝕜 (f ⁻¹' s) :=
+  fun _ hx => (hs hx).affine_preimage _
+
+/-- The image of a isconvexset set under an affine map is isconvexset. -/
+theorem IsConvexSet.affine_image (f : E →ᵃ[𝕜] F) (hs : IsConvexSet 𝕜 s) : IsConvexSet 𝕜 (f '' s) := by
+  rintro _ ⟨x, hx, rfl⟩
+  exact (hs hx).affine_image _
+
+theorem IsConvexSet.neg (hs : IsConvexSet 𝕜 s) : IsConvexSet 𝕜 (-s) :=
+  hs.is_linear_preimage IsLinearMap.isLinearMap_neg
+
+theorem IsConvexSet.sub (hs : IsConvexSet 𝕜 s) (ht : IsConvexSet 𝕜 t) : IsConvexSet 𝕜 (s - t) := by
+  rw [sub_eq_add_neg]
+  exact hs.add ht.neg
+
+variable [AddRightMono 𝕜]
+
+theorem IsConvexSet.add_smul_mem (hs : IsConvexSet 𝕜 s) {x y : E} (hx : x ∈ s) (hy : x + y ∈ s) {t : 𝕜}
+    (ht : t ∈ Icc (0 : 𝕜) 1) : x + t • y ∈ s := by
+  have h : x + t • y = (1 - t) • x + t • (x + y) := by match_scalars <;> noncomm_ring
+  rw [h]
+  exact hs hx hy (sub_nonneg_of_le ht.2) ht.1 (sub_add_cancel _ _)
+
+theorem IsConvexSet.smul_mem_of_zero_mem (hs : IsConvexSet 𝕜 s) {x : E} (zero_mem : (0 : E) ∈ s) (hx : x ∈ s)
+    {t : 𝕜} (ht : t ∈ Icc (0 : 𝕜) 1) : t • x ∈ s := by
+  simpa using hs.add_smul_mem zero_mem (by simpa using hx) ht
+
+theorem IsConvexSet.mapsTo_lineMap (h : IsConvexSet 𝕜 s) {x y : E} (hx : x ∈ s) (hy : y ∈ s) :
+    MapsTo (AffineMap.lineMap x y) (Icc (0 : 𝕜) 1) s := by
+  simpa only [mapsTo_iff_image_subset, segment_eq_image_lineMap] using h.segment_subset hx hy
+
+theorem IsConvexSet.lineMap_mem (h : IsConvexSet 𝕜 s) {x y : E} (hx : x ∈ s) (hy : y ∈ s) {t : 𝕜}
+    (ht : t ∈ Icc 0 1) : AffineMap.lineMap x y t ∈ s :=
+  h.mapsTo_lineMap hx hy ht
+
+theorem IsConvexSet.add_smul_sub_mem (h : IsConvexSet 𝕜 s) {x y : E} (hx : x ∈ s) (hy : y ∈ s) {t : 𝕜}
+    (ht : t ∈ Icc (0 : 𝕜) 1) : x + t • (y - x) ∈ s := by
+  rw [add_comm]
+  exact h.lineMap_mem hx hy ht
+
+end AddCommGroup
+
+end OrderedRing
+
+section LinearOrder
+
+variable [Semiring 𝕜] [AddCommMonoid E]
+section SemilinearMap
+
+variable [PartialOrder 𝕜]
+variable {𝕜' : Type*} [Semiring 𝕜'] [PartialOrder 𝕜']
+variable {σ : 𝕜 →+* 𝕜'} [RingHomSurjective σ]
+variable {F' : Type*} [AddCommMonoid F'] [Module 𝕜' F'] [Module 𝕜 E]
+
+theorem IsConvexSet.semilinear_image {s : Set E} (hs : IsConvexSet 𝕜 s) (hσ : ∀ {s t}, σ s ≤ σ t ↔ s ≤ t)
+    (f : E →ₛₗ[σ] F') : IsConvexSet 𝕜' (f '' s) := by
+  rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩ a b ha hb hab
+  obtain ⟨r, rfl⟩ : ∃ r : 𝕜, σ r = a := RingHomSurjective.is_surjective ..
+  obtain ⟨t, rfl⟩ : ∃ t : 𝕜, σ t = b := RingHomSurjective.is_surjective ..
+  refine ⟨r • x + t • y, hs hx hy (by simp_all [(@hσ 0 r).mp]) (by simp_all [(@hσ 0 t).mp])
+    ?_, by simp⟩
+  apply_fun σ using Function.Injective.of_eq_imp_le (hσ.mp ·.le)
+  simpa
+
+end SemilinearMap
+
+variable [LinearOrder 𝕜] [IsOrderedRing 𝕜]
+
+theorem IsConvexSet_subadditive_le [SMul 𝕜 E] {f : E → 𝕜} (hf1 : ∀ x y, f (x + y) ≤ (f x) + (f y))
+    (hf2 : ∀ ⦃c⦄ x, 0 ≤ c → f (c • x) ≤ c * f x) (B : 𝕜) :
+    IsConvexSet 𝕜 { x | f x ≤ B } := by
+  rw [isconvexset_iff_segment_subset]
+  rintro x hx y hy z ⟨a, b, ha, hb, hs, rfl⟩
+  calc
+    _ ≤ a • (f x) + b • (f y) := le_trans (hf1 _ _) (add_le_add (hf2 x ha) (hf2 y hb))
+    _ ≤ a • B + b • B := by gcongr <;> assumption
+    _ ≤ B := by rw [← add_smul, hs, one_smul]
+
+end LinearOrder
+
+theorem IsConvexSet.midpoint_mem [Ring 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]
+    [AddCommGroup E] [Module 𝕜 E] [Invertible (2 : 𝕜)] {s : Set E} {x y : E}
+    (h : IsConvexSet 𝕜 s) (hx : x ∈ s) (hy : y ∈ s) : midpoint 𝕜 x y ∈ s :=
+  h.segment_subset hx hy <| midpoint_mem_segment x y
+
+section LinearOrderedField
+
+variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]
+
+section AddCommGroup
+
+variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F] {s : Set E}
+
+/-- Alternative definition of set isconvexsetity, using division. -/
+theorem isconvexset_iff_div :
+    IsConvexSet 𝕜 s ↔ ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s →
+      ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → 0 < a + b → (a / (a + b)) • x + (b / (a + b)) • y ∈ s :=
+  forall₂_congr fun _ _ => starConvex_iff_div
+
+theorem IsConvexSet.mem_smul_of_zero_mem (h : IsConvexSet 𝕜 s) {x : E} (zero_mem : (0 : E) ∈ s) (hx : x ∈ s)
+    {t : 𝕜} (ht : 1 ≤ t) : x ∈ t • s := by
+  rw [mem_smul_set_iff_inv_smul_mem₀ (zero_lt_one.trans_le ht).ne']
+  exact h.smul_mem_of_zero_mem zero_mem hx
+    ⟨inv_nonneg.2 (zero_le_one.trans ht), inv_le_one_of_one_le₀ ht⟩
+
+theorem IsConvexSet.exists_mem_add_smul_eq (h : IsConvexSet 𝕜 s) {x y : E} {p q : 𝕜} (hx : x ∈ s) (hy : y ∈ s)
+    (hp : 0 ≤ p) (hq : 0 ≤ q) : ∃ z ∈ s, (p + q) • z = p • x + q • y := by
+  rcases _root_.em (p = 0 ∧ q = 0) with (⟨rfl, rfl⟩ | hpq)
+  · use x, hx
+    simp
+  · replace hpq : 0 < p + q :=
+      (add_nonneg hp hq).lt_of_ne' (mt (add_eq_zero_iff_of_nonneg hp hq).1 hpq)
+    refine ⟨_, isconvexset_iff_div.1 h hx hy hp hq hpq, ?_⟩
+    match_scalars <;> field
+
+protected theorem IsConvexSet.add_smul (h_conv : IsConvexSet 𝕜 s) {p q : 𝕜} (hp : 0 ≤ p) (hq : 0 ≤ q) :
+    (p + q) • s = p • s + q • s := (add_smul_subset _ _ _).antisymm <| by
+  rintro _ ⟨_, ⟨v₁, h₁, rfl⟩, _, ⟨v₂, h₂, rfl⟩, rfl⟩
+  exact h_conv.exists_mem_add_smul_eq h₁ h₂ hp hq
+
+theorem IsConvexSet.add_half_self_eq_self (h_conv : IsConvexSet 𝕜 s) : (2 : 𝕜)⁻¹ • s + (2 : 𝕜)⁻¹ • s = s := by
+  rw [← h_conv.add_smul (by norm_num) (by norm_num)]
+  ring_nf
+  rw [one_smul]
+
+end AddCommGroup
+
+end LinearOrderedField
+
+/-!
+#### IsConvexSet sets in an ordered space
+Relates `IsConvexSet` and `OrdConnected`.
+-/
+
+
+section
+
+theorem Set.OrdConnected.isconvexset_of_chain [Semiring 𝕜] [PartialOrder 𝕜] [AddCommMonoid E]
+    [PartialOrder E] [IsOrderedAddMonoid E] [Module 𝕜 E] [PosSMulMono 𝕜 E] {s : Set E}
+    (hs : s.OrdConnected) (h : IsChain (· ≤ ·) s) : IsConvexSet 𝕜 s := by
+  refine isconvexset_iff_segment_subset.mpr fun x hx y hy => ?_
+  obtain hxy | hyx := h.total hx hy
+  · exact (segment_subset_Icc hxy).trans (hs.out hx hy)
+  · rw [segment_symm]
+    exact (segment_subset_Icc hyx).trans (hs.out hy hx)
+
+theorem Set.OrdConnected.isconvexset [Semiring 𝕜] [PartialOrder 𝕜] [AddCommMonoid E] [LinearOrder E]
+    [IsOrderedAddMonoid E] [Module 𝕜 E] [PosSMulMono 𝕜 E] {s : Set E} (hs : s.OrdConnected) :
+    IsConvexSet 𝕜 s :=
+  hs.isconvexset_of_chain <| isChain_of_trichotomous s
+
+theorem isconvexset_iff_ordConnected [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] {s : Set 𝕜} :
+    IsConvexSet 𝕜 s ↔ s.OrdConnected := by
+  simp_rw [isconvexset_iff_segment_subset, segment_eq_uIcc, ordConnected_iff_uIcc_subset]
+
+alias ⟨IsConvexSet.ordConnected, _⟩ := isconvexset_iff_ordConnected
+
+end
+
+/-! #### IsConvexSetity of submodules/subspaces -/
+
+
+namespace Submodule
+
+variable [Semiring 𝕜] [PartialOrder 𝕜] [AddCommMonoid E] [Module 𝕜 E]
+
+protected theorem isconvexset (K : Submodule 𝕜 E) : IsConvexSet 𝕜 (↑K : Set E) := by
+  repeat' intro
+  refine add_mem (smul_mem _ _ ?_) (smul_mem _ _ ?_) <;> assumption
+
+protected theorem starConvex (K : Submodule 𝕜 E) : StarConvex 𝕜 (0 : E) K :=
+  K.isconvexset K.zero_mem
+
+theorem IsConvexSet.semilinear_range {𝕜' : Type*} [Semiring 𝕜'] {σ : 𝕜' →+* 𝕜}
+    [RingHomSurjective σ] {F' : Type*} [AddCommMonoid F'] [Module 𝕜' F']
+    (f : F' →ₛₗ[σ] E) : IsConvexSet 𝕜 (LinearMap.range f : Set E) := Submodule.isconvexset ..
+
+end Submodule
+
+section CommSemiring
+
+variable {R : Type*} [CommSemiring R]
+variable (A : Type*) [Semiring A] [Algebra R A]
+variable {M : Type*} [AddCommMonoid M] [Module A M] [Module R M] [IsScalarTower R A M]
+variable [PartialOrder R] [PartialOrder A]
+
+lemma isconvexset_of_nonneg_surjective_algebraMap [FaithfulSMul R A] {s : Set M}
+    (halg : Set.Ici 0 ⊆ algebraMap R A '' Set.Ici 0) (hs : IsConvexSet R s) :
+    IsConvexSet A s := by
+  simp only [IsConvexSet, StarConvex] at hs ⊢
+  intro u hu v hv a b ha hb hab
+  obtain ⟨c, hc1, hc2⟩ := halg ha
+  obtain ⟨d, hd1, hd2⟩ := halg hb
+  convert! hs hu hv hc1 hd1 _ using 2
+  · rw [← hc2, algebraMap_smul]
+  · rw [← hd2, algebraMap_smul]
+  rw [← hc2, ← hd2, ← algebraMap.coe_add] at hab
+  exact (FaithfulSMul.algebraMap_eq_one_iff R A).mp hab
+
+end CommSemiring
+
+#exit
+
+/-! ### Deprecated -/
 
 section OrderedSemiring
 
@@ -49,10 +668,15 @@ section SMul
 variable (𝕜) [SMul 𝕜 E] [SMul 𝕜 F] (s : Set E) {x : E}
 
 /-- Convexity of sets. -/
+@[deprecated IsConvexSet (since := "2026-06-04")]
 def Convex : Prop :=
   ∀ ⦃x : E⦄, x ∈ s → StarConvex 𝕜 x s
 
 variable {𝕜 s}
+
+
+lemma IsConvexSet.starConvex (hs : IsConvexSet 𝕜 s) (hx : x ∈ s) : StarConvex 𝕜 x s :=
+  hs hx
 
 theorem Convex.starConvex (hs : Convex 𝕜 s) (hx : x ∈ s) : StarConvex 𝕜 x s :=
   hs hx

--- a/Mathlib/Analysis/Convex/Star.lean
+++ b/Mathlib/Analysis/Convex/Star.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
 public import Mathlib.Algebra.Module.LinearMap.Prod
 public import Mathlib.Algebra.Order.Module.Synonym
 public import Mathlib.Analysis.Convex.Segment
+public import Mathlib.Geometry.Convex.ConvexSpace.Module
 public import Mathlib.Tactic.GCongr
 public import Mathlib.Tactic.Module
 
@@ -48,12 +49,12 @@ Replace with `Convexity.IsStarConvexSet`.
 
 @[expose] public section
 
+open Convexity Set
+open scoped Convex Pointwise
 
-open Set
+variable {R 𝕜 E F : Type*}
 
-open Convex Pointwise
-
-variable {𝕜 E F : Type*}
+/-! ### Deprecated -/
 
 section OrderedSemiring
 
@@ -69,6 +70,7 @@ variable (𝕜) [SMul 𝕜 E] [SMul 𝕜 F] (x : E) (s : Set E)
 
 /-- Star-convexity of sets. `s` is star-convex at `x` if every segment from `x` to a point in `s` is
 contained in `s`. -/
+@[deprecated IsStarConvexSet (since := "2026-06-04")]
 def StarConvex (𝕜 : Type*) {E : Type*} [Semiring 𝕜] [PartialOrder 𝕜]
     [AddCommMonoid E] [SMul 𝕜 E] (x : E) (s : Set E) : Prop :=
   ∀ ⦃y : E⦄, y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 → a • x + b • y ∈ s
@@ -98,30 +100,38 @@ theorem starConvex_iff_pointwise_add_subset :
   rintro hA a b ha hb hab w ⟨au, ⟨u, rfl : u = x, rfl⟩, bv, ⟨v, hv, rfl⟩, rfl⟩
   exact hA hv ha hb hab
 
+@[deprecated IsStarConvexSet.empty (since := "2026-06-04")]
 theorem starConvex_empty (x : E) : StarConvex 𝕜 x ∅ := fun _ hy => hy.elim
 
+@[deprecated IsStarConvexSet.univ (since := "2026-06-04")]
 theorem starConvex_univ (x : E) : StarConvex 𝕜 x univ := fun _ _ _ _ _ _ _ => trivial
 
+@[deprecated IsStarConvexSet.inter (since := "2026-06-04")]
 theorem StarConvex.inter (hs : StarConvex 𝕜 x s) (ht : StarConvex 𝕜 x t) : StarConvex 𝕜 x (s ∩ t) :=
   fun _ hy _ _ ha hb hab => ⟨hs hy.left ha hb hab, ht hy.right ha hb hab⟩
 
+@[deprecated IsStarConvexSet.sInter (since := "2026-06-04")]
 theorem starConvex_sInter {S : Set (Set E)} (h : ∀ s ∈ S, StarConvex 𝕜 x s) :
     StarConvex 𝕜 x (⋂₀ S) := fun _ hy _ _ ha hb hab s hs => h s hs (hy s hs) ha hb hab
 
+@[deprecated IsStarConvexSet.iInter (since := "2026-06-04")]
 theorem starConvex_iInter {ι : Sort*} {s : ι → Set E} (h : ∀ i, StarConvex 𝕜 x (s i)) :
     StarConvex 𝕜 x (⋂ i, s i) :=
   sInter_range s ▸ starConvex_sInter <| forall_mem_range.2 h
 
+@[deprecated IsStarConvexSet.iInter₂ (since := "2026-06-04")]
 theorem starConvex_iInter₂ {ι : Sort*} {κ : ι → Sort*} {s : (i : ι) → κ i → Set E}
     (h : ∀ i j, StarConvex 𝕜 x (s i j)) : StarConvex 𝕜 x (⋂ (i) (j), s i j) :=
   starConvex_iInter fun i => starConvex_iInter (h i)
 
+@[deprecated IsStarConvexSet.union (since := "2026-06-04")]
 theorem StarConvex.union (hs : StarConvex 𝕜 x s) (ht : StarConvex 𝕜 x t) :
     StarConvex 𝕜 x (s ∪ t) := by
   rintro y (hy | hy) a b ha hb hab
   · exact Or.inl (hs hy ha hb hab)
   · exact Or.inr (ht hy ha hb hab)
 
+@[deprecated IsStarConvexSet.iUnion (since := "2026-06-04")]
 theorem starConvex_iUnion {ι : Sort*} {s : ι → Set E} (hs : ∀ i, StarConvex 𝕜 x (s i)) :
     StarConvex 𝕜 x (⋃ i, s i) := by
   rintro y hy a b ha hb hab
@@ -129,19 +139,23 @@ theorem starConvex_iUnion {ι : Sort*} {s : ι → Set E} (hs : ∀ i, StarConve
   obtain ⟨i, hy⟩ := hy
   exact ⟨i, hs i hy ha hb hab⟩
 
+@[deprecated IsStarConvexSet.iUnion₂ (since := "2026-06-04")]
 theorem starConvex_iUnion₂ {ι : Sort*} {κ : ι → Sort*} {s : (i : ι) → κ i → Set E}
     (h : ∀ i j, StarConvex 𝕜 x (s i j)) : StarConvex 𝕜 x (⋃ (i) (j), s i j) :=
   starConvex_iUnion fun i => starConvex_iUnion (h i)
 
+@[deprecated IsStarConvexSet.sUnion (since := "2026-06-04")]
 theorem starConvex_sUnion {S : Set (Set E)} (hS : ∀ s ∈ S, StarConvex 𝕜 x s) :
     StarConvex 𝕜 x (⋃₀ S) := by
   rw [sUnion_eq_iUnion]
   exact starConvex_iUnion fun s => hS _ s.2
 
+@[deprecated IsStarConvexSet.prod (since := "2026-06-04")]
 theorem StarConvex.prod {y : F} {s : Set E} {t : Set F} (hs : StarConvex 𝕜 x s)
     (ht : StarConvex 𝕜 y t) : StarConvex 𝕜 (x, y) (s ×ˢ t) := fun _ hy _ _ ha hb hab =>
   ⟨hs hy.1 ha hb hab, ht hy.2 ha hb hab⟩
 
+@[deprecated IsStarConvexSet.pi (since := "2026-06-04")]
 theorem starConvex_pi {ι : Type*} {E : ι → Type*} [∀ i, AddCommMonoid (E i)] [∀ i, SMul 𝕜 (E i)]
     {x : ∀ i, E i} {s : Set ι} {t : ∀ i, Set (E i)} (ht : ∀ ⦃i⦄, i ∈ s → StarConvex 𝕜 (x i) (t i)) :
     StarConvex 𝕜 x (s.pi t) := fun _ hy _ _ ha hb hab i hi => ht hi (hy i hi) ha hb hab
@@ -152,6 +166,7 @@ section Module
 
 variable [Module 𝕜 E] [Module 𝕜 F] {x y z : E} {s : Set E}
 
+@[deprecated IsStarConvexSet.mem (since := "2026-06-04")]
 theorem StarConvex.mem [ZeroLEOneClass 𝕜] (hs : StarConvex 𝕜 x s) (h : s.Nonempty) : x ∈ s := by
   obtain ⟨y, hy⟩ := h
   convert! hs hy zero_le_one le_rfl (add_zero 1)
@@ -189,29 +204,35 @@ theorem starConvex_iff_openSegment_subset [ZeroLEOneClass 𝕜] (hx : x ∈ s) :
   starConvex_iff_segment_subset.trans <|
     forall₂_congr fun _ hy => (openSegment_subset_iff_segment_subset hx hy).symm
 
+@[deprecated IsStarConvexSet.singleton (since := "2026-06-04")]
 theorem starConvex_singleton (x : E) : StarConvex 𝕜 x {x} := by
   rintro y (rfl : y = x) a b _ _ hab
   exact Convex.combo_self hab _
 
+@[deprecated IsStarConvexSet.image (since := "2026-06-04")]
 theorem StarConvex.linear_image (hs : StarConvex 𝕜 x s) (f : E →ₗ[𝕜] F) :
     StarConvex 𝕜 (f x) (f '' s) := by
   rintro _ ⟨y, hy, rfl⟩ a b ha hb hab
   exact ⟨a • x + b • y, hs hy ha hb hab, by rw [f.map_add, f.map_smul, f.map_smul]⟩
 
+@[deprecated IsStarConvexSet.image (since := "2026-06-04")]
 theorem StarConvex.is_linear_image (hs : StarConvex 𝕜 x s) {f : E → F} (hf : IsLinearMap 𝕜 f) :
     StarConvex 𝕜 (f x) (f '' s) :=
   hs.linear_image <| hf.mk' f
 
+@[deprecated IsStarConvexSet.preimage (since := "2026-06-04")]
 theorem StarConvex.linear_preimage {s : Set F} (f : E →ₗ[𝕜] F) (hs : StarConvex 𝕜 (f x) s) :
     StarConvex 𝕜 x (f ⁻¹' s) := by
   intro y hy a b ha hb hab
   rw [mem_preimage, f.map_add, f.map_smul, f.map_smul]
   exact hs hy ha hb hab
 
+@[deprecated IsStarConvexSet.preimage (since := "2026-06-04")]
 theorem StarConvex.is_linear_preimage {s : Set F} {f : E → F} (hs : StarConvex 𝕜 (f x) s)
     (hf : IsLinearMap 𝕜 f) : StarConvex 𝕜 x (preimage f s) :=
   hs.linear_preimage <| hf.mk' f
 
+@[deprecated IsStarConvexSet.add (since := "2026-06-04")]
 theorem StarConvex.add {t : Set E} (hs : StarConvex 𝕜 x s) (ht : StarConvex 𝕜 y t) :
     StarConvex 𝕜 (x + y) (s + t) := by
   rw [← add_image_prod]
@@ -347,10 +368,12 @@ theorem StarConvex.affine_image (f : E →ᵃ[𝕜] F) {s : Set E} (hs : StarCon
   refine ⟨a • x + b • y', ⟨hs hy' ha hb hab, ?_⟩⟩
   rw [Convex.combo_affine_apply hab, hy'f]
 
+@[deprecated IsStarConvexSet.neg (since := "2026-06-04")]
 theorem StarConvex.neg (hs : StarConvex 𝕜 x s) : StarConvex 𝕜 (-x) (-s) := by
   rw [← image_neg_eq_neg]
   exact hs.is_linear_image IsLinearMap.isLinearMap_neg
 
+@[deprecated IsStarConvexSet.sub (since := "2026-06-04")]
 theorem StarConvex.sub (hs : StarConvex 𝕜 x s) (ht : StarConvex 𝕜 y t) :
     StarConvex 𝕜 (x - y) (s - t) := by
   simp_rw [sub_eq_add_neg]


### PR DESCRIPTION
Deprecate all the `Module`-specific convexity concepts in favor of the more general `ConvexSpace` ones.

---
- [x] depends on: #40230

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
