### PR TITLE
[Merged by Bors] - chore(Tactic/ComputeAsymptotics/Multiseries): deduplicate `Basis` definition

### DIFF
--- a/Mathlib/Tactic/ComputeAsymptotics/Multiseries/Basis.lean
+++ b/Mathlib/Tactic/ComputeAsymptotics/Multiseries/Basis.lean
@@ -7,7 +7,7 @@ module
 public import Mathlib.Analysis.Complex.Exponential
 public import Mathlib.Analysis.Asymptotics.AsymptoticEquivalent
 public import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
-public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Majorized
+public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Defs
 
 /-!
 # Well-formed bases
@@ -25,9 +25,6 @@ public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Majorized
 namespace Tactic.ComputeAsymptotics
 
 open Asymptotics Filter
-
-/-- List of functions used to construct monomials in multiseries. -/
-abbrev Basis := List (ℝ → ℝ)
 
 /-- `WellFormedBasis basis` means that all functions from `basis` tend to `atTop`, and
 `basis` is sorted such that if

--- a/Mathlib/Tactic/ComputeAsymptotics/Multiseries/Defs.lean
+++ b/Mathlib/Tactic/ComputeAsymptotics/Multiseries/Defs.lean
@@ -42,7 +42,7 @@ in the basis `[b₂, ..., bₙ]` (`basis_tl`).
 
 namespace Tactic.ComputeAsymptotics
 
-open Filter Topology Stream'
+open Filter Stream'
 
 /-- List of functions used to construct monomials in multiseries. -/
 abbrev Basis := List (ℝ → ℝ)

--- a/Mathlib/Tactic/ComputeAsymptotics/Multiseries/Defs.lean
+++ b/Mathlib/Tactic/ComputeAsymptotics/Multiseries/Defs.lean
@@ -40,7 +40,7 @@ in the basis `[b₂, ..., bₙ]` (`basis_tl`).
 
 @[expose] public section
 
-namespace ComputeAsymptotics
+namespace Tactic.ComputeAsymptotics
 
 open Filter Topology Stream'
 
@@ -609,8 +609,6 @@ end Sorted
 
 section Approximates
 
-open Tactic.ComputeAsymptotics
-
 /-- Coinductive predicate stating that `ms` approximates its attached function on `basis`.
 * If `basis = []`, i.e. `ms` is just a real number, `Approximates` holds unconditionally.
 * If `basis = basis_hd :: basis_tl` and `ms = nil`, then `f =ᶠ[atTop] 0`.
@@ -686,7 +684,7 @@ theorem elim_cons {exp : ℝ}
   cases h <;> simp at h_ms; grind
 
 /-- One can replace `f` in `Approximates` with the funcion that eventually equals `f`. -/
-theorem replaceFun_Approximates {ms : MultiseriesExpansion (basis_hd :: basis_tl)} {f : ℝ → ℝ}
+theorem replaceFun {ms : MultiseriesExpansion (basis_hd :: basis_tl)} {f : ℝ → ℝ}
     (h_equiv : ms.toFun =ᶠ[atTop] f) (h_approx : ms.Approximates) :
     (ms.replaceFun f).Approximates := by
   let motive (ms : MultiseriesExpansion (basis_hd :: basis_tl)) : Prop :=
@@ -724,4 +722,4 @@ end Approximates
 
 end MultiseriesExpansion
 
-end ComputeAsymptotics
+end Tactic.ComputeAsymptotics


### PR DESCRIPTION
1. Fix namespace in `Defs.lean`: `ComputeAsymptotics` -> `Tactic.ComputeAsymptotics`
2. Import `Defs` in `Basis` and remove the duplicate `Basis` definition in the latter
3. Rename `Approximates.replaceFun_Approximates` to `Approximates.replaceFun`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This is a part of the `compute_asymptotics` tactic (#28291).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)