### PR TITLE
[Merged by Bors] - chore(CI): fix merge conflict resolution for nightly-testing

### DIFF
--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -1,4 +1,4 @@
-# This job merges every commit to `master` into `nightly-testing`, resolving merge conflicts in favor of `nightly-testing`.
+# This job merges every commit to `master` into `nightly-testing`, resolving merge conflicts in favor of `master`.
 
 name: Merge master to nightly
 
@@ -49,15 +49,17 @@ jobs:
           git config user.name "mathlib-nightly-testing[bot]"
           git config user.email "mathlib-nightly-testing[bot]@users.noreply.github.com"
 
-      - name: Merge master to nightly favoring nightly changes
+      - name: Merge master to nightly favoring master changes
         run: |
           cd nightly-testing
           git remote add upstream https://github.com/leanprover-community/mathlib4.git
           git fetch upstream master
-          # Merge master into nightly-testing, resolving conflicts in favor of nightly-testing
+          # Merge master into nightly-testing, resolving conflicts in favor of master.
+          # In the past, we've silently dropped changes made on master because
+          # conflicts were resolved in favor of nightly-testing, which is bad.
           # If the merge goes badly, we proceed anyway via '|| true'.
           # CI will report failures on the 'nightly-testing' branch direct to Zulip.
-          git merge upstream/master --strategy-option ours --no-commit --allow-unrelated-histories || true
+          git merge upstream/master --strategy-option theirs --no-commit --allow-unrelated-histories || true
           # We aggressively run `lake update`, to avoid having to do this by hand.
           # When Batteries changes break Mathlib, this will likely show up on nightly-testing first.
           lake update -v


### PR DESCRIPTION
Resolving merge conflicts in favor of `nightly-testing` when merging `master` may be convenient for nightly maintainers, but it can lead to changes made on `master` accidentally being dropped again later in the bump PR. For an example case, see #40189 (see [#PR reviews > #39443 &#96;nonempty_preimage_iff&#96; @ 💬](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2339443.20.60nonempty_preimage_iff.60/near/599885755) for an explanation of what happened).

Resolving conflicts in favor of `master` means that `nightly-testing` will rather break than silently undoing changes made on `master`.