### PR TITLE
[Merged by Bors] - ci: labels_from_comment anchor label match to whole line

### DIFF
--- a/.github/workflows/labels_from_comment.yml
+++ b/.github/workflows/labels_from_comment.yml
@@ -45,8 +45,13 @@ jobs:
           inComment=""
           label="${labelArray[$i]}"
           printf $'\nProcessing label \'%s\'\n' "${label}"
-          # extract the last line that, up to leading/trailing whitespace, matches the current label
-          inComment="$(printf '%s' "${COMMENT}" | grep "[-]\?${label}$" | tail -1)"
+          # extract the last line whose *entire* content (up to leading/trailing
+          # whitespace, already stripped above) is the label, optionally preceded
+          # by `-`. Anchoring both ends (not just `$`) is what stops bot directives
+          # such as `!downstream-check FLT` — and the downstream-reports automation
+          # comments — from being mistaken for a label request just because the line
+          # happens to end in a label name.
+          inComment="$(printf '%s' "${COMMENT}" | grep "^[-]\?${label}$" | tail -1)"
           if [ -n "${inComment}" ]
           then
             printf $'Found \'%s\'\n' "${inComment}"


### PR DESCRIPTION
The label-from-comment matcher only anchored the end of the line (`[-]\?<label>$`), so any line ending in a label name was treated as a label request. 

This anchors the start of the line as well (`^[-]\?<label>$`), so only a line whose entire content is the label name (optionally preceded by `-`) matches. This is what the workflow's own header comment already documents:

> The script reacts to lines in the comment whose entire content is, up to whitespace, the label name, optionally preceded by `-`.