### PR TITLE
chore(Order/Partition/Finpartition): deprecate `ofPairwiseDisjoint`

### DIFF
--- a/Mathlib/MeasureTheory/VectorMeasure/Variation/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Variation/Basic.lean
@@ -56,12 +56,12 @@ lemma le_variation (μ : VectorMeasure X V) {s : Set X} (hs : MeasurableSet s) {
     (hP₁ : ∀ t ∈ P, t ⊆ s) (hP₂ : (P : Set (Set X)).PairwiseDisjoint id) :
     ∑ p ∈ P, ‖μ p‖ₑ ≤ μ.variation s := by
   classical
-  set Q := Finpartition.ofPairwiseDisjoint P hP₂ with defQ
+  set Q := Finpartition.ofErase P hP₂.supIndep rfl with defQ
   set Q' := Q.ofSubset (filter_subset MeasurableSet Q.parts) rfl with defQ'
   have hQ' : ∀ t ∈ Q'.parts, t ⊆ s := by simp [Q', Q]; grind
   calc
     ∑ p ∈ P, ‖μ p‖ₑ = ∑ p ∈ Q.parts, ‖μ p‖ₑ :=
-      (Finpartition.sum_ofPairwiseDisjoint_eq_sum hP₂ (by simp)).symm
+      (P.sum_erase (by simp)).symm
     _ = ∑ p ∈ Q'.parts, ‖μ p‖ₑ := (Q.sum_ofSubset_eq_sum _ _ _ (by simp_all)).symm
     _ ≤ ∑ p ∈ (Q'.extendOfLE (Finset.sup_le hQ')).parts, ‖μ p‖ₑ :=
       sum_le_sum_of_subset (Q'.parts_subset_extendOfLE (Finset.sup_le hQ'))

--- a/Mathlib/Order/Partition/Finpartition.lean
+++ b/Mathlib/Order/Partition/Finpartition.lean
@@ -450,25 +450,17 @@ lemma sum_restrict (P : Finpartition a) (hb : b ≤ a) {M : Type*} [AddCommMonoi
 
 /-- A `Finpartition` constructor of `parts.sup id` from a finset `parts` of pairwise disjoint
 elements. Any `⊥` elements in `parts` are erased. -/
-@[simps]
+@[deprecated ofErase (since := "2026-06-05"), simps! parts]
 def ofPairwiseDisjoint (parts : Finset α) (hdisjoint : (parts : Set α).PairwiseDisjoint id) :
-    Finpartition (parts.sup id) where
-  parts := parts.erase ⊥
-  supIndep := Finset.supIndep_iff_pairwiseDisjoint.mpr fun _ ha _ hb hab =>
-    hdisjoint (Finset.erase_subset _ _ ha) (Finset.erase_subset _ _ hb) hab
-  sup_parts := Finset.sup_erase_bot parts
-  bot_notMem := Finset.notMem_erase _ _
+    Finpartition (parts.sup id) :=
+  ofErase parts hdisjoint.supIndep rfl
 
+@[deprecated Finset.sum_erase (since := "2026-06-05")]
 lemma sum_ofPairwiseDisjoint_eq_sum {parts : Finset α}
     (hdisjoint : (parts : Set α).PairwiseDisjoint id)
     {X : Type*} [AddCommMonoid X] {f : α → X} (hf : f ⊥ = 0) :
-    ∑ p ∈ (ofPairwiseDisjoint parts hdisjoint).parts, f p = ∑ p ∈ parts, f p := by
-  by_cases hbot : ⊥ ∈ parts
-  · simp only [Finpartition.ofPairwiseDisjoint]
-    rw [← erase_union_eq ⊥ parts hbot, union_comm, sum_union_eq_right]
-    · simp
-    grind
-  · simp_all
+    ∑ p ∈ (ofPairwiseDisjoint parts hdisjoint).parts, f p = ∑ p ∈ parts, f p :=
+  parts.sum_erase hf
 
 end DistribLattice
 


### PR DESCRIPTION
This is a duplicate of `Finpartition.ofErase`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
