### PR TITLE
[Merged by Bors] - feat(Data/Nat/Choose/Bounds): add ascFactorial and choose bounds by power of left index

### DIFF
--- a/Mathlib/Data/Nat/Choose/Bounds.lean
+++ b/Mathlib/Data/Nat/Choose/Bounds.lean
@@ -57,6 +57,17 @@ lemma choose_le_pow (n k : ℕ) : n.choose k ≤ n ^ k :=
 lemma choose_lt_pow (hn : n ≠ 0) (hk : 2 ≤ k) : n.choose k < n ^ k :=
   (choose_le_descFactorial n k).trans_lt (descFactorial_lt_pow hn hk)
 
+theorem choose_add_le_add_one_pow (n k : ℕ) : (n + k).choose k ≤ (n + 1) ^ k := by
+  rw [choose_eq_asc_factorial_div_factorial]
+  exact Nat.div_le_of_le_mul (ascFactorial_le_factorial_mul_pow _ _)
+
+theorem choose_le_sub_pow (n k : ℕ) : n.choose k ≤ (n + 1 - k) ^ k := by
+  rcases le_or_gt k n with h | h
+  · obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le h
+    rw [Nat.add_comm k m, Nat.add_right_comm, Nat.add_sub_cancel]
+    exact choose_add_le_add_one_pow m k
+  · simp [choose_eq_zero_of_lt h]
+
 -- horrific casting is due to ℕ-subtraction
 theorem pow_le_choose (r n : ℕ) : ((n + 1 - r : ℕ) ^ r : α) / r ! ≤ n.choose r := by
   rw [div_le_iff₀']

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -289,6 +289,19 @@ theorem ascFactorial_le_pow_add (n : ℕ) : ∀ k : ℕ, (n + 1).ascFactorial k 
     exact Nat.mul_le_mul_right _
       (Nat.le_trans (ascFactorial_le_pow_add _ k) (Nat.pow_le_pow_left (le_succ _) _))
 
+theorem ascFactorial_le_factorial_mul_pow (n k : ℕ) : n.ascFactorial k ≤ k ! * n ^ k :=
+  match k with
+  | 0 => by simp
+  | j + 1 => by
+    rcases n.eq_zero_or_pos with rfl | hn
+    · simp [zero_ascFactorial]
+    rw [ascFactorial_succ, factorial_succ, pow_succ',
+      Nat.mul_assoc (j + 1), Nat.mul_left_comm j !, ← Nat.mul_assoc (j + 1)]
+    refine Nat.mul_le_mul ?_ (ascFactorial_le_factorial_mul_pow n j)
+    rw [add_one_mul, Nat.add_comm]
+    have : j ≤ j * n := Nat.le_mul_of_pos_right j hn
+    lia
+
 theorem ascFactorial_lt_pow_add (n : ℕ) : ∀ {k : ℕ}, 2 ≤ k → (n + 1).ascFactorial k < (n + k) ^ k
   | 0 => by rintro ⟨⟩
   | 1 => by intro; contradiction

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -298,9 +298,8 @@ theorem ascFactorial_le_factorial_mul_pow (n k : ℕ) : n.ascFactorial k ≤ k !
     rw [ascFactorial_succ, factorial_succ, pow_succ',
       Nat.mul_assoc (j + 1), Nat.mul_left_comm j !, ← Nat.mul_assoc (j + 1)]
     refine Nat.mul_le_mul ?_ (ascFactorial_le_factorial_mul_pow n j)
-    rw [add_one_mul, Nat.add_comm]
-    have : j ≤ j * n := Nat.le_mul_of_pos_right j hn
-    lia
+    rw [add_one_mul, Nat.add_comm, Nat.add_le_add_iff_right]
+    exact Nat.le_mul_of_pos_right j hn
 
 theorem ascFactorial_lt_pow_add (n : ℕ) : ∀ {k : ℕ}, 2 ≤ k → (n + 1).ascFactorial k < (n + k) ^ k
   | 0 => by rintro ⟨⟩


### PR DESCRIPTION
From exponential-ramsey. These bounds are slightly stronger than what's already there. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
