### PR TITLE
feat(Analysis/Calculus/ParametricIntegral): one-sided differentiation under the integral

### DIFF
--- a/Mathlib/Analysis/Calculus/ParametricIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntegral.lean
@@ -51,6 +51,10 @@ assume `H = ℝ` or `H = ℂ` and use the high-school derivative `deriv` instead
 
 We also provide versions of these theorems for set integrals.
 
+`hasDerivWithinAt_Ici_integral_of_dominated_loc_of_deriv_le` is a one-sided (right) variant of
+`hasDerivAt_integral_of_dominated_loc_of_deriv_le`, whose hypotheses are required only on a
+right-neighborhood `s ∈ 𝓝[≥] x₀` of `x₀`.
+
 ## Tags
 integral, derivative
 -/
@@ -306,3 +310,104 @@ theorem hasDerivAt_integral_of_dominated_loc_of_deriv_le (hs : s ∈ 𝓝 x₀)
     hF'_meas this bound_integrable diff_x₀
 
 end
+
+section OneSided
+
+open Set
+
+variable {F F' : ℝ → α → E} {x₀ : ℝ} {bound : α → ℝ}
+
+/-- Derivative of the affine map `y ↦ c + (y − p) • v`. -/
+private theorem hasDerivAt_affine_aux (p : ℝ) (c v : E) (x : ℝ) :
+    HasDerivAt (fun y : ℝ ↦ c + (y - p) • v) v x := by
+  simpa using (((hasDerivAt_id x).sub_const p).smul_const v).const_add c
+
+/-- Core of `hasDerivWithinAt_Ici_integral_of_dominated_loc_of_deriv_le`, with the hypotheses on the
+explicit set `Ici x₀ ∩ ball x₀ ε`. Proved by extending `F` across `x₀` by its affine
+first-order part below `x₀` (two-sided dominated) and invoking the two-sided
+`hasDerivAt_integral_of_dominated_loc_of_deriv_le`. -/
+private theorem hasDerivWithinAt_Ici_integral_aux {ε : ℝ} (ε_pos : 0 < ε)
+    (hF_meas : ∀ x ∈ Ici x₀ ∩ ball x₀ ε, AEStronglyMeasurable (F x) μ)
+    (hF_int : Integrable (F x₀) μ) (hF'_meas : AEStronglyMeasurable (F' x₀) μ)
+    (h_bound : ∀ᵐ a ∂μ, ∀ x ∈ Ici x₀ ∩ ball x₀ ε, ‖F' x a‖ ≤ bound a)
+    (bound_integrable : Integrable bound μ)
+    (h_diff : ∀ᵐ a ∂μ, ∀ x ∈ Ici x₀ ∩ ball x₀ ε, HasDerivWithinAt (F · a) (F' x a) (Ici x₀) x) :
+    Integrable (F' x₀) μ ∧
+      HasDerivWithinAt (fun x ↦ ∫ a, F x a ∂μ) (∫ a, F' x₀ a ∂μ) (Ici x₀) x₀ := by
+  classical
+  set G : ℝ → α → E := fun x a ↦ if x₀ ≤ x then F x a else F x₀ a + (x - x₀) • F' x₀ a with hGdef
+  set G' : ℝ → α → E := fun x a ↦ if x₀ ≤ x then F' x a else F' x₀ a with hG'def
+  have hx₀mem : x₀ ∈ Ici x₀ ∩ ball x₀ ε := ⟨mem_Ici.mpr le_rfl, mem_ball_self ε_pos⟩
+  have hG_ge : ∀ x a, x₀ ≤ x → G x a = F x a := fun x a h ↦ by simp [hGdef, h]
+  have hG_lt : ∀ x a, ¬ x₀ ≤ x → G x a = F x₀ a + (x - x₀) • F' x₀ a :=
+    fun x a h ↦ by simp [hGdef, h]
+  have hG'_ge : ∀ x a, x₀ ≤ x → G' x a = F' x a := fun x a h ↦ by simp [hG'def, h]
+  have hG'_lt : ∀ x a, ¬ x₀ ≤ x → G' x a = F' x₀ a := fun x a h ↦ by simp [hG'def, h]
+  have hGx₀ : G x₀ = F x₀ := by funext a; exact hG_ge x₀ a le_rfl
+  have hG'x₀ : G' x₀ = F' x₀ := by funext a; exact hG'_ge x₀ a le_rfl
+  have hG_meas : ∀ᶠ x in 𝓝 x₀, AEStronglyMeasurable (G x) μ := by
+    filter_upwards [ball_mem_nhds x₀ ε_pos] with x hx
+    by_cases hle : x₀ ≤ x
+    · simpa only [show G x = F x from funext fun a ↦ hG_ge x a hle] using hF_meas x ⟨hle, hx⟩
+    · have : G x = fun a ↦ F x₀ a + (x - x₀) • F' x₀ a := funext fun a ↦ hG_lt x a hle
+      rw [this]; exact hF_int.aestronglyMeasurable.add (hF'_meas.const_smul _)
+  have hG_bound : ∀ᵐ a ∂μ, ∀ x ∈ ball x₀ ε, ‖G' x a‖ ≤ bound a := by
+    filter_upwards [h_bound] with a ha x hx
+    by_cases hle : x₀ ≤ x
+    · rw [hG'_ge x a hle]; exact ha x ⟨hle, hx⟩
+    · rw [hG'_lt x a hle]; exact ha x₀ hx₀mem
+  have hG_diff : ∀ᵐ a ∂μ, ∀ x ∈ ball x₀ ε, HasDerivAt (G · a) (G' x a) x := by
+    filter_upwards [h_diff] with a ha x hx
+    rcases lt_trichotomy x₀ x with hlt | heq | hlt
+    · have hIci : Ici x₀ ∈ 𝓝 x := Ici_mem_nhds hlt
+      have hFx : HasDerivAt (F · a) (F' x a) x := (ha x ⟨le_of_lt hlt, hx⟩).hasDerivAt hIci
+      rw [hG'_ge x a (le_of_lt hlt)]
+      refine hFx.congr_of_eventuallyEq ?_
+      filter_upwards [hIci] with y hy using hG_ge y a hy
+    · subst heq
+      have hR : HasDerivWithinAt (G · a) (F' x₀ a) (Ici x₀) x₀ :=
+        (ha x₀ hx₀mem).congr (fun y hy ↦ hG_ge y a hy) (hG_ge x₀ a le_rfl)
+      have haff : HasDerivAt (fun y : ℝ ↦ F x₀ a + (y - x₀) • F' x₀ a) (F' x₀ a) x₀ :=
+        hasDerivAt_affine_aux x₀ (F x₀ a) (F' x₀ a) x₀
+      have hL : HasDerivWithinAt (G · a) (F' x₀ a) (Iic x₀) x₀ := by
+        refine haff.hasDerivWithinAt.congr (fun y hy ↦ ?_) ?_
+        · by_cases hxy : x₀ ≤ y
+          · rw [hG_ge y a hxy, le_antisymm (mem_Iic.mp hy) hxy]; simp
+          · exact hG_lt y a hxy
+        · rw [hG_ge x₀ a le_rfl]; simp
+      rw [hG'_ge x₀ a le_rfl]
+      have := hR.union hL
+      rwa [Ici_union_Iic, hasDerivWithinAt_univ] at this
+    · rw [hG'_lt x a (not_le.mpr hlt)]
+      refine (hasDerivAt_affine_aux x₀ (F x₀ a) (F' x₀ a) x).congr_of_eventuallyEq ?_
+      filter_upwards [Iio_mem_nhds hlt] with y hy using hG_lt y a (not_le.mpr hy)
+  obtain ⟨hF'_int, key⟩ := hasDerivAt_integral_of_dominated_loc_of_deriv_le (s := ball x₀ ε)
+    (ball_mem_nhds x₀ ε_pos) hG_meas (hGx₀ ▸ hF_int) (hG'x₀ ▸ hF'_meas) hG_bound
+    bound_integrable hG_diff
+  rw [hG'x₀] at hF'_int key
+  refine ⟨hF'_int, key.hasDerivWithinAt.congr (fun x hx ↦ ?_) ?_⟩
+  · exact integral_congr_ae (Eventually.of_forall fun a ↦ (hG_ge x a hx).symm)
+  · exact integral_congr_ae (Eventually.of_forall fun a ↦ (hG_ge x₀ a le_rfl).symm)
+
+/-- **Right-derivative under the integral sign.** A one-sided analogue of
+`hasDerivAt_integral_of_dominated_loc_of_deriv_le`: if `x ↦ F x a` is differentiable within `Ici x₀`
+with derivative `F' x a` bounded for ae `a` by an integrable `bound a` on a right-neighborhood
+`s` of `x₀`, then `F' x₀` is integrable and `x ↦ ∫ a, F x a ∂μ` has derivative `∫ a, F' x₀ a ∂μ`
+within `Ici x₀` at `x₀`.
+
+The domination is required only on `s ∈ 𝓝[≥] x₀`, so this applies when `F x a` is not
+defined/integrable for `x < x₀` — e.g. Gibbs families `g ↦ ∫ A e ^ (-g • V)` with `V` bounded below
+but not above, where the two-sided theorem fails. -/
+theorem hasDerivWithinAt_Ici_integral_of_dominated_loc_of_deriv_le {s : Set ℝ} (hs : s ∈ 𝓝[≥] x₀)
+    (hF_meas : ∀ᶠ x in 𝓝[≥] x₀, AEStronglyMeasurable (F x) μ) (hF_int : Integrable (F x₀) μ)
+    (hF'_meas : AEStronglyMeasurable (F' x₀) μ)
+    (h_bound : ∀ᵐ a ∂μ, ∀ x ∈ s, ‖F' x a‖ ≤ bound a) (bound_integrable : Integrable bound μ)
+    (h_diff : ∀ᵐ a ∂μ, ∀ x ∈ s, HasDerivWithinAt (F · a) (F' x a) (Ici x₀) x) :
+    Integrable (F' x₀) μ ∧
+      HasDerivWithinAt (fun x ↦ ∫ a, F x a ∂μ) (∫ a, F' x₀ a ∂μ) (Ici x₀) x₀ := by
+  obtain ⟨ε, ε_pos, hε⟩ := Metric.mem_nhdsWithin_iff.1 (hF_meas.and hs)
+  exact hasDerivWithinAt_Ici_integral_aux ε_pos (fun x hx ↦ (hε ⟨hx.2, hx.1⟩).1) hF_int hF'_meas
+    (h_bound.mono fun a ha x hx ↦ ha x (hε ⟨hx.2, hx.1⟩).2) bound_integrable
+    (h_diff.mono fun a ha x hx ↦ ha x (hε ⟨hx.2, hx.1⟩).2)
+
+end OneSided


### PR DESCRIPTION
Adds `hasDerivWithinAt_Ici_integral_of_dominated_loc_of_deriv_le`, the within-`Ici x₀` (right) analogue of `hasDerivAt_integral_of_dominated_loc_of_deriv_le`: differentiation under the integral sign where the derivative bound is required only on a **right**-neighborhood `s ∈ 𝓝[≥] x₀`, concluding `HasDerivWithinAt (fun x ↦ ∫ a, F x a ∂μ) (∫ a, F' x₀ a ∂μ) (Ici x₀) x₀`.

### Motivation

The existing two-sided theorem needs the domination on a full neighborhood of `x₀`. That fails for parametric integrals dominated only on one side — e.g. Gibbs / partition-function families `g ↦ ∫ A e ^ (-g • V)` where `V` is bounded below but not above, so the weight is integrable only for `g ≥ 0` (the Dyson-instability situation in constructive QFT). One still wants the one-sided derivative at the boundary.

### Proof

Rather than re-running the dominated-convergence argument, `F` is extended across `x₀` by its affine first-order part below `x₀`,
`G x a = if x₀ ≤ x then F x a else F x₀ a + (x - x₀) • F' x₀ a`,
which is two-sided dominated (the affine part has constant derivative `F' x₀ a`, bounded by `bound a`). The existing two-sided theorem applies to `G`, and since `G = F` on `Ici x₀`, the conclusion restricts to the desired `HasDerivWithinAt`.

I'm happy to adjust naming, or to generalize to an arbitrary set `t` (`𝓝[t] x₀`) if reviewers prefer — that would need the direct dominated-convergence proof rather than the extension trick.
