### PR TITLE
[Merged by Bors] - feat: a bounded variation function is the difference of two monotone functions that add up to the variation

### DIFF
--- a/Mathlib/Analysis/BoundedVariation.lean
+++ b/Mathlib/Analysis/BoundedVariation.lean
@@ -14,7 +14,7 @@ public import Mathlib.Topology.EMetricSpace.BoundedVariation
 # Almost everywhere differentiability of functions with locally bounded variation
 
 In this file we show that a bounded variation function is differentiable almost everywhere.
-This implies that Lipschitz functions from the real line into finite-dimensional vector space
+This implies that Lipschitz functions from the real line into finite-dimensional vector spaces
 are also differentiable almost everywhere.
 
 ## Main definitions and results

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -1090,7 +1090,7 @@ end variationOnFromTo
 /-- If a real-valued function has bounded variation on a set, then it is a difference of monotone
 functions there. Moreover, one can make sure that the two monotone functions add up to the
 variation of `f`. -/
-theorem LocallyBoundedVariationOn.exists_monotoneOn_sub_monotoneOn {f : α → ℝ} {s : Set α}
+theorem LocallyBoundedVariationOn.exists_monotoneOn_sub_monotoneOn' {f : α → ℝ} {s : Set α}
     (h : LocallyBoundedVariationOn f s) :
     ∃ p q : α → ℝ, MonotoneOn p s ∧ MonotoneOn q s ∧ f = p - q ∧
       ∀ x ∈ s, ∀ y ∈ s, (p y - p x) + (q y - q x) = variationOnFromTo f s x y := by
@@ -1113,6 +1113,14 @@ theorem LocallyBoundedVariationOn.exists_monotoneOn_sub_monotoneOn {f : α → �
   · intro x hx y hy
     rw [← variationOnFromTo.add h hx cs hy, variationOnFromTo.eq_neg_swap]
     ring
+
+/-- If a real-valued function has bounded variation on a set, then it is a difference of monotone
+functions there. -/
+theorem LocallyBoundedVariationOn.exists_monotoneOn_sub_monotoneOn {f : α → ℝ} {s : Set α}
+    (h : LocallyBoundedVariationOn f s) :
+    ∃ p q : α → ℝ, MonotoneOn p s ∧ MonotoneOn q s ∧ f = p - q := by
+  rcases h.exists_monotoneOn_sub_monotoneOn' with ⟨p, q, hp, hq, h'f, -⟩
+  exact ⟨p, q, hp, hq, h'f⟩
 
 /-! ### Lipschitz functions and bounded variation -/
 

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -1024,20 +1024,33 @@ protected theorem antitoneOn (hf : LocallyBoundedVariationOn f s) {b : α} (bs :
   rw [← variationOnFromTo.add hf as cs bs]
   exact le_add_of_nonneg_left (variationOnFromTo.nonneg_of_le f s ac)
 
+lemma abs_sub_le_sub_of_le {f : α → ℝ} {s : Set α} (hf : LocallyBoundedVariationOn f s)
+    {a b c : α} (as : a ∈ s) (bs : b ∈ s) (cs : c ∈ s) (bc : b ≤ c) :
+    |f c - f b| ≤ variationOnFromTo f s a c - variationOnFromTo f s a b := calc
+  _ = dist (f b) (f c) := by rw [dist_comm, Real.dist_eq]
+  _ ≤ variationOnFromTo f s b c := by
+    rw [variationOnFromTo.eq_of_le f s bc, dist_edist]
+    apply ENNReal.toReal_mono (hf b c bs cs)
+    apply eVariationOn.edist_le f
+    exacts [⟨bs, le_rfl, bc⟩, ⟨cs, bc, le_rfl⟩]
+  _ = variationOnFromTo f s a c - variationOnFromTo f s a b := by
+    rw [← variationOnFromTo.add hf as bs cs, add_sub_cancel_left]
+
+protected theorem add_self_monotoneOn {f : α → ℝ} {s : Set α} (hf : LocallyBoundedVariationOn f s)
+    {a : α} (as : a ∈ s) : MonotoneOn (variationOnFromTo f s a + f) s := by
+  rintro b bs c cs bc
+  suffices f b - f c ≤ variationOnFromTo f s a c - variationOnFromTo f s a b by simp; linarith
+  calc
+    f b - f c ≤ |f c - f b| := by grw [le_abs_self (f b - f c), abs_sub_comm (f b) (f c)]
+    _ ≤ variationOnFromTo f s a c - variationOnFromTo f s a b := abs_sub_le_sub_of_le hf as bs cs bc
+
 protected theorem sub_self_monotoneOn {f : α → ℝ} {s : Set α} (hf : LocallyBoundedVariationOn f s)
     {a : α} (as : a ∈ s) : MonotoneOn (variationOnFromTo f s a - f) s := by
   rintro b bs c cs bc
   rw [Pi.sub_apply, Pi.sub_apply, le_sub_iff_add_le, add_comm_sub, ← le_sub_iff_add_le']
   calc
     f c - f b ≤ |f c - f b| := le_abs_self _
-    _ = dist (f b) (f c) := by rw [dist_comm, Real.dist_eq]
-    _ ≤ variationOnFromTo f s b c := by
-      rw [variationOnFromTo.eq_of_le f s bc, dist_edist]
-      apply ENNReal.toReal_mono (hf b c bs cs)
-      apply eVariationOn.edist_le f
-      exacts [⟨bs, le_rfl, bc⟩, ⟨cs, bc, le_rfl⟩]
-    _ = variationOnFromTo f s a c - variationOnFromTo f s a b := by
-      rw [← variationOnFromTo.add hf as bs cs, add_sub_cancel_left]
+    _ ≤ variationOnFromTo f s a c - variationOnFromTo f s a b := abs_sub_le_sub_of_le hf as bs cs bc
 
 protected theorem comp_eq_of_monotoneOn {β : Type*} [LinearOrder β] (f : α → E) {t : Set β}
     (φ : β → α) (hφ : MonotoneOn φ t) {x y : β} (hx : x ∈ t) (hy : y ∈ t) :
@@ -1075,15 +1088,31 @@ theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_rightLim_
 end variationOnFromTo
 
 /-- If a real-valued function has bounded variation on a set, then it is a difference of monotone
-functions there. -/
+functions there. Moreover, one can make sure that the two monotone functions add up to the
+variation of `f`. -/
 theorem LocallyBoundedVariationOn.exists_monotoneOn_sub_monotoneOn {f : α → ℝ} {s : Set α}
     (h : LocallyBoundedVariationOn f s) :
-    ∃ p q : α → ℝ, MonotoneOn p s ∧ MonotoneOn q s ∧ f = p - q := by
+    ∃ p q : α → ℝ, MonotoneOn p s ∧ MonotoneOn q s ∧ f = p - q ∧
+      ∀ x ∈ s, ∀ y ∈ s, (p y - p x) + (q y - q x) = variationOnFromTo f s x y := by
   rcases eq_empty_or_nonempty s with (rfl | ⟨c, cs⟩)
-  · exact ⟨f, 0, subsingleton_empty.monotoneOn _, subsingleton_empty.monotoneOn _,
-      (sub_zero f).symm⟩
-  · exact ⟨_, _, variationOnFromTo.monotoneOn h cs, variationOnFromTo.sub_self_monotoneOn h cs,
-      (sub_sub_cancel _ _).symm⟩
+  · refine ⟨f, 0, subsingleton_empty.monotoneOn _, subsingleton_empty.monotoneOn _,
+      (sub_zero f).symm, fun x hx y hy ↦ by simp at hx⟩
+  refine ⟨fun x ↦ (variationOnFromTo f s c x + f x) / 2,
+    fun x ↦ (variationOnFromTo f s c x - f x) / 2, ?_, ?_, ?_, ?_⟩
+  · intro x hx y hy hxy
+    dsimp
+    gcongr 1
+    simpa using variationOnFromTo.add_self_monotoneOn h cs hx hy hxy
+  · intro x hx y hy hxy
+    dsimp
+    gcongr 1
+    simpa using variationOnFromTo.sub_self_monotoneOn h cs hx hy hxy
+  · ext
+    simp
+    ring
+  · intro x hx y hy
+    rw [← variationOnFromTo.add h hx cs hy, variationOnFromTo.eq_neg_swap]
+    ring
 
 /-! ### Lipschitz functions and bounded variation -/
 


### PR DESCRIPTION
We already have this lemma, but without the information that the monotone functions add up to the variation. And the construction needs to be a little bit more clever to get this.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
