### PR TITLE
[Merged by Bors] - perf: lower priority for `IsSimpleRing.instNontrivial` and `UnitalShelf.toOne`

### DIFF
--- a/Mathlib/Algebra/Quandle.lean
+++ b/Mathlib/Algebra/Quandle.lean
@@ -108,6 +108,8 @@ class UnitalShelf (α : Type u) extends Shelf α, One α where
   one_act : ∀ a : α, act 1 a = a
   act_one : ∀ a : α, act a 1 = a
 
+attribute [instance 100] UnitalShelf.toOne
+
 /-- The type of homomorphisms between shelves.
 This is also the notion of rack and quandle homomorphisms.
 -/

--- a/Mathlib/RingTheory/SimpleRing/Basic.lean
+++ b/Mathlib/RingTheory/SimpleRing/Basic.lean
@@ -15,7 +15,7 @@ A ring `R` is **simple** if it has only two two-sided ideals, namely `⊥` and `
 
 ## Main results
 
-- `IsSimpleRing.nontrivial`: simple rings are non-trivial.
+- `IsSimpleRing.instNontrivial`: simple rings are non-trivial.
 - `DivisionRing.isSimpleRing`: division rings are simple.
 - `RingHom.injective`: every ring homomorphism from a simple ring to a nontrivial ring is injective.
 - `IsSimpleRing.iff_injective_ringHom`: a ring is simple iff every ring homomorphism to a nontrivial
@@ -34,6 +34,8 @@ variable {R}
 instance [IsSimpleRing R] : Nontrivial R := by
   obtain ⟨x, _, hx⟩ := SetLike.exists_of_lt (bot_lt_top : (⊥ : TwoSidedIdeal R) < ⊤)
   use x, 0, hx
+
+attribute [instance 200] IsSimpleRing.instNontrivial
 
 lemma one_mem_of_ne_bot {A : Type*} [NonAssocRing A] [IsSimpleRing A] (I : TwoSidedIdeal A)
     (hI : I ≠ ⊥) : (1 : A) ∈ I :=


### PR DESCRIPTION
These instances have very weak keys `([Nontrivial, *])` resp. `([One, *])`, hence are always applied. Let's lower their priority a bit.

---

Found using an updated version of this code: https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2322780.20scoping.20a.20few.20instances.20with.20weak.20keys/with/504683279

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
