### PR TITLE
[Merged by Bors] - feat(GroupTheory/Sylow): the order of a group divides the product of all the element orders

### DIFF
--- a/Mathlib/GroupTheory/PGroup.lean
+++ b/Mathlib/GroupTheory/PGroup.lean
@@ -37,6 +37,12 @@ theorem iff_orderOf [hp : Fact p.Prime] : IsPGroup p G ↔ ∀ g : G, ∃ k : �
         ((Nat.dvd_prime_pow hp.out).mp (orderOf_dvd_of_pow_eq_one hk)),
       Exists.imp fun k hk => by rw [← hk, pow_orderOf_eq_one]⟩
 
+theorem dvd_orderOf [Fact p.Prime] (hG : IsPGroup p G) {g : G} (hg : g ≠ 1) : p ∣ orderOf g := by
+  have ⟨k, hk⟩ := IsPGroup.iff_orderOf.mp hG g
+  rw [hk]
+  refine dvd_pow_self _ fun hk0 ↦ hg ?_
+  rw [← orderOf_eq_one_iff, hk, hk0, pow_zero]
+
 theorem of_card {n : ℕ} (hG : Nat.card G = p ^ n) : IsPGroup p G := fun g =>
   ⟨n, by rw [← hG, pow_card_eq_one']⟩
 

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -737,6 +737,33 @@ theorem card_eq_multiplicity [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow
   rw [heq, ← hp.out.pow_dvd_iff_dvd_ordProj (show Nat.card G ≠ 0 from Nat.card_pos.ne'), ← heq]
   exact P.1.card_subgroup_dvd_card
 
+variable (G) in
+theorem _root_.Group.natCard_dvd_univ_prod_orderOf [Fintype G] :
+    Nat.card G ∣ ∏ g : G, orderOf g := by
+  refine Nat.factorization_prime_le_iff_dvd Nat.card_pos.ne' ?_ |>.mp fun p hp ↦ ?_
+  · exact prod_ne_zero_iff.mpr fun g _ ↦ orderOf_ne_zero_iff.mpr <| isOfFinOrder_of_finite g
+  have H := Classical.arbitrary <| Sylow p G
+  rw [Nat.factorization_prod_apply fun g _ ↦ orderOf_ne_zero_iff.mpr <| isOfFinOrder_of_finite g]
+  suffices Nat.card H - 1 ≤ ∑ g : G, (orderOf g).factorization p by
+    grw [← this, H.card_eq_multiplicity (hp := ⟨hp⟩),
+      ← Nat.le_sub_one_of_lt <| Nat.lt_pow_self hp.one_lt]
+  have := Fintype.ofFinite
+  grw [← sum_le_sum_of_subset (H \ {1} : Set G).toFinset.subset_univ,
+    ← card_nsmul_le_sum _ _ 1 fun g hg ↦ ?_]
+  · simp [← SetLike.coe_sort_coe]
+  simp_rw [Set.mem_toFinset, Set.mem_diff, Set.mem_singleton_iff] at hg
+  have ⟨k, hk⟩ := IsPGroup.iff_orderOf (hp := ⟨hp⟩).mp H.isPGroup' ⟨g, hg.left⟩
+  have : k ≠ 0 := by rintro rfl; simp_all
+  simp [← orderOf_mk g hg.left, hk, hp.factorization_self, Nat.one_le_iff_ne_zero.mpr this]
+
+variable (G) in
+theorem _root_.Group.natCard_dvd_exponent_pow [Finite G] :
+    Nat.card G ∣ Monoid.exponent G ^ Nat.card G := by
+  have := Fintype.ofFinite G
+  apply dvd_trans <| Group.natCard_dvd_univ_prod_orderOf G
+  rw [Nat.card_eq_fintype_card, ← card_univ, ← Finset.prod_const]
+  exact Finset.prod_dvd_prod_of_dvd _ _ fun g _ ↦ Monoid.order_dvd_exponent g
+
 /-- If `G` has a normal Sylow `p`-subgroup, then it is the only Sylow `p`-subgroup. -/
 @[implicit_reducible]
 noncomputable def unique_of_normal {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -738,7 +738,7 @@ theorem card_eq_multiplicity [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow
   exact P.1.card_subgroup_dvd_card
 
 variable (G) in
-theorem _root_.Group.natCard_dvd_univ_prod_orderOf [Fintype G] :
+theorem _root_.Group.card_dvd_prod_orderOf [Fintype G] :
     Nat.card G ∣ ∏ g : G, orderOf g := by
   refine Nat.factorization_prime_le_iff_dvd Nat.card_pos.ne' ?_ |>.mp fun p hp ↦ ?_
   · exact prod_ne_zero_iff.mpr fun g _ ↦ orderOf_ne_zero_iff.mpr <| isOfFinOrder_of_finite g

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -756,14 +756,6 @@ theorem _root_.Group.natCard_dvd_univ_prod_orderOf [Fintype G] :
   have : k ≠ 0 := by rintro rfl; simp_all
   simp [← orderOf_mk g hg.left, hk, hp.factorization_self, Nat.one_le_iff_ne_zero.mpr this]
 
-variable (G) in
-theorem _root_.Group.natCard_dvd_exponent_pow [Finite G] :
-    Nat.card G ∣ Monoid.exponent G ^ Nat.card G := by
-  have := Fintype.ofFinite G
-  apply dvd_trans <| Group.natCard_dvd_univ_prod_orderOf G
-  rw [Nat.card_eq_fintype_card, ← card_univ, ← Finset.prod_const]
-  exact Finset.prod_dvd_prod_of_dvd _ _ fun g _ ↦ Monoid.order_dvd_exponent g
-
 /-- If `G` has a normal Sylow `p`-subgroup, then it is the only Sylow `p`-subgroup. -/
 @[implicit_reducible]
 noncomputable def unique_of_normal {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -738,23 +738,17 @@ theorem card_eq_multiplicity [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow
   exact P.1.card_subgroup_dvd_card
 
 variable (G) in
-theorem _root_.Group.card_dvd_prod_orderOf [Fintype G] :
-    Nat.card G ∣ ∏ g : G, orderOf g := by
-  refine Nat.factorization_prime_le_iff_dvd Nat.card_pos.ne' ?_ |>.mp fun p hp ↦ ?_
-  · exact prod_ne_zero_iff.mpr fun g _ ↦ orderOf_ne_zero_iff.mpr <| isOfFinOrder_of_finite g
-  have H := Classical.arbitrary <| Sylow p G
-  rw [Nat.factorization_prod_apply fun g _ ↦ orderOf_ne_zero_iff.mpr <| isOfFinOrder_of_finite g]
-  suffices Nat.card H - 1 ≤ ∑ g : G, (orderOf g).factorization p by
-    grw [← this, H.card_eq_multiplicity (hp := ⟨hp⟩),
-      ← Nat.le_sub_one_of_lt <| Nat.lt_pow_self hp.one_lt]
-  have := Fintype.ofFinite
-  grw [← sum_le_sum_of_subset (H \ {1} : Set G).toFinset.subset_univ,
-    ← card_nsmul_le_sum _ _ 1 fun g hg ↦ ?_]
-  · simp [← SetLike.coe_sort_coe]
-  simp_rw [Set.mem_toFinset, Set.mem_diff, Set.mem_singleton_iff] at hg
-  have ⟨k, hk⟩ := IsPGroup.iff_orderOf (hp := ⟨hp⟩).mp H.isPGroup' ⟨g, hg.left⟩
-  have : k ≠ 0 := by rintro rfl; simp_all
-  simp [← orderOf_mk g hg.left, hk, hp.factorization_self, Nat.one_le_iff_ne_zero.mpr this]
+theorem _root_.Group.card_dvd_prod_orderOf [Fintype G] : Nat.card G ∣ ∏ g : G, orderOf g := by
+  classical
+  refine Nat.dvd_iff_prime_pow_dvd_dvd .. |>.mpr fun p k hp h ↦ ?_
+  have := Fact.mk hp
+  have ⟨H, hH⟩ := exists_subgroup_card_pow_prime p h
+  have (g : G) (hg : g ∈ (H \ {1} : Set G).toFinset) : p ∣ orderOf g := by
+    have ⟨hg, hg1⟩ : g ∈ H ∧ g ≠ 1 := by simpa using hg
+    simpa using IsPGroup.of_card hH |>.dvd_orderOf (g := ⟨g, hg⟩) <| by simpa
+  grw [← prod_dvd_prod_of_subset _ _ _ (H \ {1} : Set G).toFinset.subset_univ,
+    ← prod_dvd_prod_of_dvd _ _ this, prod_const, k.le_sub_one_of_lt <| k.lt_pow_self hp.one_lt]
+  simp [Finset.card_sdiff, ← Nat.card_eq_fintype_card, hH]
 
 /-- If `G` has a normal Sylow `p`-subgroup, then it is the only Sylow `p`-subgroup. -/
 @[implicit_reducible]


### PR DESCRIPTION
In finite groups, `Nat.card G ∣ ∏ g, orderOf g`.

The proof takes prime `p` and a Sylow subgroup of order `p^k` and argues that the multiplicity of `p` in the product of the orders is at least `p^k - 1` (excluding the identity element), which is at least `k`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
