### PR TITLE
[Merged by Bors] - feat(ZetaAsymp): derivative of RiemannZeta at 0

### DIFF
--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -473,5 +473,5 @@ theorem deriv_riemannZeta_zero :
   convert! h₄ using 1
   rw [completedRiemannZeta₀_zero, hasDerivAt_Gamma_one.deriv, show 4 * (π : ℂ) = 2 * 2 * π by ring]
   open ComplexOrder in
-  repeat rw [log_mul (by positivity) (by positivity) (by simp [Complex.arg]; grind [Real.pi_pos])]
+  repeat rw [log_mul (by positivity) (by positivity) (by simp [arg, LT.lt.le, Real.pi_pos])]
   ring

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -9,7 +9,7 @@ public import Mathlib.NumberTheory.LSeries.RiemannZeta
 public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 
 /-!
-# Asymptotics of `ζ s` as `s → 1` and `deriv ζ s` as `s → 0`
+# Asymptotics of `ζ s` as `s → 1` or `s → 0`
 
 The goal of this file is to evaluate the limit of `ζ s - 1 / (s - 1)` as `s → 1`.
 

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -19,6 +19,7 @@ The goal of this file is to evaluate the limit of `ζ s - 1 / (s - 1)` as `s →
   neighbourhoods of 1 in `ℂ`, exists and is equal to the Euler-Mascheroni constant `γ`.
 * `riemannZeta_one_ne_zero`: with our definition of `ζ 1` (which is characterised as the limit of
   `ζ s - 1 / (s - 1) / Gammaℝ s` as `s → 1`), we have `ζ 1 ≠ 0`.
+* `deriv_riemannZeta_zero`: `ζ'(0) = -log(2π) / 2`, which derives from the above.
 
 ### Outline of arguments
 
@@ -33,12 +34,15 @@ we obtain the limit along punctured neighbourhoods of 1 in `ℂ`.
 
 @[expose] public section
 
-open Real Set MeasureTheory Filter Topology
+open Set MeasureTheory Filter Topology
 
-@[inherit_doc] local notation "γ" => eulerMascheroniConstant
+@[inherit_doc] local notation "γ" => Real.eulerMascheroniConstant
 
 namespace ZetaAsymptotics
+
 -- since the intermediate lemmas are of little interest in themselves we put them in a namespace
+
+open Real
 
 /-!
 ## Definitions
@@ -392,18 +396,25 @@ lemma tendsto_riemannZeta_sub_one_div_Gammaℝ :
   convert! this using 2
   ring_nf
 
+end val_at_one
+
+end ZetaAsymptotics
+
+open scoped Real
+open Complex
+
 /-- Formula for `ζ 1`. Note that mathematically `ζ 1` is undefined, but our construction ascribes
 this particular value to it. -/
-lemma _root_.riemannZeta_one : riemannZeta 1 = (γ - Complex.log (4 * ↑π)) / 2 := by
+lemma riemannZeta_one : riemannZeta 1 = (γ - log (4 * π)) / 2 := by
   have := (HurwitzZeta.tendsto_hurwitzZetaEven_sub_one_div_nhds_one 0).mono_left
     <| nhdsWithin_le_nhds (s := {1}ᶜ)
   simp only [HurwitzZeta.hurwitzZetaEven_zero, div_right_comm _ _ (Gammaℝ _)] at this
-  exact tendsto_nhds_unique this tendsto_riemannZeta_sub_one_div_Gammaℝ
+  exact tendsto_nhds_unique this ZetaAsymptotics.tendsto_riemannZeta_sub_one_div_Gammaℝ
 
 /-- Formula for `Λ 1`. Note that mathematically `Λ 1` is undefined, but our construction ascribes
 this particular value to it. -/
-lemma _root_.completedRiemannZeta_one :
-    completedRiemannZeta 1 = (γ - Complex.log (4 * ↑π)) / 2 :=
+lemma completedRiemannZeta_one :
+    completedRiemannZeta 1 = (γ - Complex.log (4 * π)) / 2 :=
   (riemannZeta_one ▸ div_one (_ : ℂ) ▸ Gammaℝ_one ▸ riemannZeta_def_of_ne_zero one_ne_zero).symm
 
 /-- Formula for `Λ₀ 1`, where `Λ₀` is the entire function satisfying
@@ -412,28 +423,56 @@ lemma _root_.completedRiemannZeta_one :
 Note that `s = 1` is _not_ a pole of `Λ₀`, so this statement (unlike `riemannZeta_one`) is
 a mathematically meaningful statement and is not dependent on Mathlib's particular conventions for
 division by zero. -/
-lemma _root_.completedRiemannZeta₀_one :
-    completedRiemannZeta₀ 1 = (γ - Complex.log (4 * ↑π)) / 2 + 1 := by
+lemma completedRiemannZeta₀_one : completedRiemannZeta₀ 1 = (γ - log (4 * ↑π)) / 2 + 1 := by
   have := completedRiemannZeta_eq 1
   rw [sub_self, div_zero, div_one, sub_zero, eq_sub_iff_add_eq] at this
   rw [← this, completedRiemannZeta_one]
 
 /-- With Mathlib's particular conventions, we have `ζ 1 ≠ 0`. -/
-lemma _root_.riemannZeta_one_ne_zero : riemannZeta 1 ≠ 0 := by
+lemma riemannZeta_one_ne_zero : riemannZeta 1 ≠ 0 := by
   -- This one's for you, Kevin.
-  suffices (γ - (4 * π).log) / 2 ≠ 0 by
+  suffices (γ - Real.log (4 * π)) / 2 ≠ 0 by
     simpa only [riemannZeta_one, ← ofReal_ne_zero, ofReal_log (by positivity : 0 ≤ 4 * π),
       push_cast]
   refine div_ne_zero (sub_lt_zero.mpr (lt_trans ?_ ?_ (b := 1))).ne two_ne_zero
   · exact Real.eulerMascheroniConstant_lt_two_thirds.trans (by norm_num)
-  · rw [lt_log_iff_exp_lt (by positivity)]
+  · rw [Real.lt_log_iff_exp_lt (by positivity)]
     exact (lt_trans Real.exp_one_lt_d9 (by norm_num)).trans_le
-      <| mul_le_mul_of_nonneg_left two_le_pi (by simp)
+      <| mul_le_mul_of_nonneg_left Real.two_le_pi (by simp)
 
-lemma _root_.riemannZeta_eventually_ne_zero_nhds_one : ∀ᶠ s in 𝓝 1, riemannZeta s ≠ 0 := by
+lemma riemannZeta_eventually_ne_zero_nhds_one : ∀ᶠ s in 𝓝 1, riemannZeta s ≠ 0 := by
   filter_upwards [eventually_nhdsWithin_iff.1 <| riemannZeta_residue_one.eventually_ne one_ne_zero]
   grind [riemannZeta_one_ne_zero]
 
-end val_at_one
+lemma completedRiemannZeta₀_zero : completedRiemannZeta₀ 0 = (γ - Complex.log (4 * π)) / 2 + 1 := by
+  rw [← completedRiemannZeta₀_one_sub]
+  simp [completedRiemannZeta₀_one]
 
-end ZetaAsymptotics
+/-- The derivative of `riemannZeta` at `s = 0` equals `-log(2π) / 2`. -/
+theorem deriv_riemannZeta_zero :
+    deriv riemannZeta 0 = -log (2 * π) / 2 := by
+  rw [funext riemannZeta_eq_mul_completedRiemannZeta₀]
+  apply HasDerivAt.deriv
+  have h₁ : HasDerivAt ((id * completedRiemannZeta₀ - 1) - id / (1 - id)) _ 0 :=
+    .sub
+      (.sub (.mul (hasDerivAt_id 0) differentiable_completedZeta₀.differentiableAt.hasDerivAt)
+        (hasDerivAt_const 0 1))
+      (.div (hasDerivAt_id 0) (.sub (hasDerivAt_const 0 1) (hasDerivAt_id 0)) (by simp))
+  have h₂ : HasDerivAt ((fun x : ℂ => 2) * fun (x : ℂ) => (π : ℂ) ^ (-x / 2)) _ 0 :=
+    .mul (hasDerivAt_const 0 2) <|
+    .cpow (hasDerivAt_const 0 _) (.div_const (.neg <| hasDerivAt_id 0) 2) (by simp; positivity)
+  have h₃ : HasDerivAt (Gamma ∘ fun x => x / 2 + 1) (deriv Gamma (0 / 2 + 1) * (1 / 2 + 0)) 0 := by
+    refine (differentiableAt_Gamma _ ?_).hasDerivAt.comp 0 ?_
+    · simp only [zero_div]
+      norm_cast
+      simp
+    · exact ((hasDerivAt_id 0).div_const 2).add (hasDerivAt_const 0 1)
+  have h₄ := h₁.mul ((h₂.mul h₃).inv (by simp))
+  simp only [one_mul, id_eq, zero_mul, add_zero, sub_zero, Pi.sub_apply, mul_one,
+    neg_zero, one_pow, Pi.inv_apply, Pi.mul_apply, zero_div, cpow_zero, mul_zero,
+    Function.comp_apply, zero_add, Pi.one_apply, Gamma_one, Pi.div_apply, div_one] at h₄
+  convert! h₄ using 1
+  rw [completedRiemannZeta₀_zero, hasDerivAt_Gamma_one.deriv, show 4 * (π : ℂ) = 2 * 2 * π by ring]
+  open ComplexOrder in
+  repeat rw [log_mul (by positivity) (by positivity) (by simp [Complex.arg]; grind [Real.pi_pos])]
+  ring

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -9,7 +9,7 @@ public import Mathlib.NumberTheory.LSeries.RiemannZeta
 public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 
 /-!
-# Asymptotics of `ζ s` as `s → 1`
+# Asymptotics of `ζ s` as `s → 1` and `deriv ζ s` as `s → 0`
 
 The goal of this file is to evaluate the limit of `ζ s - 1 / (s - 1)` as `s → 1`.
 
@@ -17,9 +17,9 @@ The goal of this file is to evaluate the limit of `ζ s - 1 / (s - 1)` as `s →
 
 * `tendsto_riemannZeta_sub_one_div`: the limit of `ζ s - 1 / (s - 1)`, at the filter of punctured
   neighbourhoods of 1 in `ℂ`, exists and is equal to the Euler-Mascheroni constant `γ`.
+* `deriv_riemannZeta_zero`: `ζ'(0) = -log(2π) / 2`, which derives from the above.
 * `riemannZeta_one_ne_zero`: with our definition of `ζ 1` (which is characterised as the limit of
   `ζ s - 1 / (s - 1) / Gammaℝ s` as `s → 1`), we have `ζ 1 ≠ 0`.
-* `deriv_riemannZeta_zero`: `ζ'(0) = -log(2π) / 2`, which derives from the above.
 
 ### Outline of arguments
 
@@ -466,12 +466,10 @@ theorem deriv_riemannZeta_zero :
       norm_cast
       simp
     · exact ((hasDerivAt_id 0).div_const 2).add (hasDerivAt_const 0 1)
-  have h₄ := h₁.mul ((h₂.mul h₃).inv (by simp))
-  simp only [one_mul, id_eq, zero_mul, add_zero, sub_zero, Pi.sub_apply, mul_one,
-    neg_zero, one_pow, Pi.inv_apply, Pi.mul_apply, zero_div, cpow_zero, mul_zero,
-    Function.comp_apply, zero_add, Pi.one_apply, Gamma_one, Pi.div_apply, div_one] at h₄
-  convert! h₄ using 1
-  rw [completedRiemannZeta₀_zero, hasDerivAt_Gamma_one.deriv, show 4 * (π : ℂ) = 2 * 2 * π by ring]
+  suffices h : -(log (2 * π) * 2) = γ - log (2 * 2 * π) + (-log π + -γ) by
+    norm_num only at h
+    convert! h₁.mul ((h₂.mul h₃).inv (by simp)) using 1
+    simpa [completedRiemannZeta₀_zero, hasDerivAt_Gamma_one.deriv, field]
   open ComplexOrder in
   repeat rw [log_mul (by positivity) (by positivity) (by simp [arg, LT.lt.le, Real.pi_pos])]
   ring

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -413,8 +413,7 @@ lemma riemannZeta_one : riemannZeta 1 = (γ - log (4 * π)) / 2 := by
 
 /-- Formula for `Λ 1`. Note that mathematically `Λ 1` is undefined, but our construction ascribes
 this particular value to it. -/
-lemma completedRiemannZeta_one :
-    completedRiemannZeta 1 = (γ - Complex.log (4 * π)) / 2 :=
+lemma completedRiemannZeta_one : completedRiemannZeta 1 = (γ - log (4 * π)) / 2 :=
   (riemannZeta_one ▸ div_one (_ : ℂ) ▸ Gammaℝ_one ▸ riemannZeta_def_of_ne_zero one_ne_zero).symm
 
 /-- Formula for `Λ₀ 1`, where `Λ₀` is the entire function satisfying

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -459,7 +459,7 @@ theorem deriv_riemannZeta_zero :
       (.div (hasDerivAt_id 0) (.sub (hasDerivAt_const 0 1) (hasDerivAt_id 0)) (by simp))
   have h₂ : HasDerivAt ((fun x : ℂ => 2) * fun (x : ℂ) => (π : ℂ) ^ (-x / 2)) _ 0 :=
     .mul (hasDerivAt_const 0 2) <|
-    .cpow (hasDerivAt_const 0 _) (.div_const (.neg <| hasDerivAt_id 0) 2) (by simp; positivity)
+    .cpow (hasDerivAt_const 0 _) (.div_const (.neg <| hasDerivAt_id 0) 2) (by simp [Real.pi_pos])
   have h₃ : HasDerivAt (Gamma ∘ fun x => x / 2 + 1) (deriv Gamma (0 / 2 + 1) * (1 / 2 + 0)) 0 := by
     refine (differentiableAt_Gamma _ ?_).hasDerivAt.comp 0 ?_
     · simp only [zero_div]


### PR DESCRIPTION
Adds `deriv_riemannZeta_zero`: `ζ'(0) = -log(2π) / 2`.


---

There's a bit of noise in the PR because I changed around a bit of the scoping just a little in the file.
I think it was for the better.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
