### PR TITLE
chore(Algebra/Star/Module): remove an erw

### DIFF
--- a/Mathlib/Algebra/Star/Module.lean
+++ b/Mathlib/Algebra/Star/Module.lean
@@ -223,7 +223,8 @@ def StarModule.decomposeProdAdjoint : A ≃ₗ[R] selfAdjoint A × skewAdjoint A
   refine LinearEquiv.ofLinear ((selfAdjointPart R).prod (skewAdjointPart R))
     (LinearMap.coprod ((selfAdjoint.submodule R A).subtype) (skewAdjoint.submodule R A).subtype)
     ?_ (LinearMap.ext <| StarModule.selfAdjointPart_add_skewAdjointPart R)
-  ext x <;> dsimp only [Submodule.subtype, selfAdjoint.submodule, skewAdjoint.submodule] <;> simp
+  dsimp [Submodule.subtype, selfAdjoint.submodule, skewAdjoint.submodule]
+  ext x <;> simp
 
 end SelfSkewAdjoint
 

--- a/Mathlib/Algebra/Star/Module.lean
+++ b/Mathlib/Algebra/Star/Module.lean
@@ -223,8 +223,7 @@ def StarModule.decomposeProdAdjoint : A ≃ₗ[R] selfAdjoint A × skewAdjoint A
   refine LinearEquiv.ofLinear ((selfAdjointPart R).prod (skewAdjointPart R))
     (LinearMap.coprod ((selfAdjoint.submodule R A).subtype) (skewAdjoint.submodule R A).subtype)
     ?_ (LinearMap.ext <| StarModule.selfAdjointPart_add_skewAdjointPart R)
-  -- Note: with https://github.com/leanprover-community/mathlib4/pull/6965 `Submodule.coe_subtype` doesn't fire in `dsimp` or `simp`
-  ext x <;> dsimp <;> erw [Submodule.coe_subtype, Submodule.coe_subtype] <;> simp
+  ext x <;> dsimp only [Submodule.subtype, selfAdjoint.submodule, skewAdjoint.submodule] <;> simp
 
 end SelfSkewAdjoint
 


### PR DESCRIPTION
- rewrites `StarModule.decomposeProdAdjoint` by making the subtype definitions explicit in `dsimp only` before `simp`

Extracted from #40147