### PR TITLE
[Merged by Bors] - chore(Topology/Instances/Complex): remove an erw

### DIFF
--- a/Mathlib/Topology/Instances/Complex.lean
+++ b/Mathlib/Topology/Instances/Complex.lean
@@ -69,23 +69,17 @@ theorem Complex.uniformContinuous_ringHom_eq_id_or_conj (K : Subfield ℂ) {ψ :
       let j := RingEquiv.subfieldCongr h
       -- ψ₁ is the continuous ring hom `ℝ →+* ℂ` constructed from `j : closure (K) ≃+* ℝ`
       -- and `extψ : closure (K) →+* ℂ`
-      let ψ₁ := RingHom.comp extψ (RingHom.comp j.symm.toRingHom ofRealHom.rangeRestrict)
+      let ψ₁ := RingHom.comp extψ (RingHom.comp j.symm.toRingHom ofRealHom.rangeRestrictField)
       -- Porting note: was `by continuity!` and was used inline
       have hψ₁ : Continuous ψ₁ := by
         simpa only [RingHom.coe_comp] using! hψ.comp ((continuous_algebraMap ℝ ℂ).subtype_mk _)
       ext1 x
-      rsuffices ⟨r, hr⟩ : ∃ r : ℝ, ofRealHom.rangeRestrict r = j (ι x)
-      · have :=
-          RingHom.congr_fun (ringHom_eq_ofReal_of_continuous hψ₁) r
-        rw [RingHom.comp_apply, RingHom.comp_apply] at this
-        -- In `this`, the `DFunLike.coe` thinks it is applying a `(ℝ →+* ↥ofRealHom.fieldRange)`,
-        -- while in `hr`, we have a `(ℝ →+* ↥ofRealHom.range)`.
-        -- We could add a `@[simp]` lemma fixing this, but it breaks later steps of the proof.
-        erw [hr] at this
-        rw [RingEquiv.toRingHom_eq_coe] at this
+      rsuffices ⟨r, hr⟩ : ∃ r : ℝ, ofRealHom.rangeRestrictField r = j (ι x)
+      · have := RingHom.congr_fun (ringHom_eq_ofReal_of_continuous hψ₁) r
+        rw [RingHom.comp_apply, RingHom.comp_apply, hr, RingEquiv.toRingHom_eq_coe] at this
         convert! this using 1
         · exact (IsDenseInducing.extend_eq di hc.continuous _).symm
-        · rw [← ofRealHom.coe_rangeRestrict, hr]
+        · rw [← ofRealHom.coe_rangeRestrictField, hr]
           rfl
       obtain ⟨r, hr⟩ := SetLike.coe_mem (j (ι x))
       exact ⟨r, Subtype.ext hr⟩


### PR DESCRIPTION
- rewrites the real subfield branch to use `ofRealHom.rangeRestrictField`, allowing the `hr` rewrite to be handled by `rw`

Extracted from #40147