### PR TITLE
[Merged by Bors] - feat(FieldTheory/IntermediateField): add PowerBasis.ofAdjoinSimpleEqTop

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -581,6 +581,24 @@ theorem finiteDimensional_adjoin {S : Set L} [Finite S] (hS : ∀ x ∈ S, IsInt
   haveI (x : S) := adjoin.finiteDimensional (hS x.1 x.2)
   exact finiteDimensional_iSup_of_finite
 
+/-- If `x` generates `L` over `K` (i.e., `K⟮x⟯ = ⊤`) and is integral over `K`, then `x`
+defines a `PowerBasis` for `L` over `K`. See `PowerBasis.ofAdjoinEqTop` for a version with
+`Algebra.adjoin`. -/
+noncomputable def _root_.PowerBasis.ofAdjoinSimpleEqTop {x : L} (h : IsIntegral K x)
+    (hgen : K⟮x⟯ = ⊤) : PowerBasis K L :=
+  (adjoin.powerBasis h).map ((IntermediateField.equivOfEq hgen).trans IntermediateField.topEquiv)
+
+@[simp]
+lemma _root_.PowerBasis.ofAdjoinSimpleEqTop_gen {x : L} (h : IsIntegral K x)
+    (hgen : K⟮x⟯ = ⊤) : (PowerBasis.ofAdjoinSimpleEqTop h hgen).gen = x := by
+  simp [PowerBasis.ofAdjoinSimpleEqTop]
+
+@[simp]
+lemma _root_.PowerBasis.ofAdjoinSimpleEqTop_dim {x : L} (h : IsIntegral K x)
+    (hgen : K⟮x⟯ = ⊤) :
+    (PowerBasis.ofAdjoinSimpleEqTop h hgen).dim = (minpoly K x).natDegree := by
+  simp [PowerBasis.ofAdjoinSimpleEqTop]
+
 end PowerBasis
 
 /-- Algebra homomorphism `F⟮α⟯ →ₐ[F] K` are in bijection with the set of roots


### PR DESCRIPTION
Adds `PowerBasis.ofAdjoinSimpleEqTop`, the `IntermediateField.adjoin` analogue of the
existing `PowerBasis.ofAdjoinEqTop` (which uses `Algebra.adjoin`): if `α` generates `L`
over `K` (i.e. `K⟮α⟯ = ⊤`) and is integral over `K`, then `α` defines a `PowerBasis`
for `L` over `K`.


---


The declaration is placed in `Mathlib.FieldTheory.IntermediateField.Adjoin.Basic`
(alongside `adjoin.powerBasis` and `adjoin.finrank`) rather than `Adjoin.Algebra`,
since its proof uses `adjoin.powerBasis` and `PowerBasis.map`.

:robot: This PR was extracted from the [SKW project](https://github.com/xroblot/SKW) by Claude.