### PR TITLE
[Merged by Bors] - feat(NumberTheory/MulChar): add ringHomCompHom, ringHomComp_zpow, zpow_apply_coe

### DIFF
--- a/Mathlib/NumberTheory/MulChar/Basic.lean
+++ b/Mathlib/NumberTheory/MulChar/Basic.lean
@@ -446,6 +446,25 @@ lemma ringHomComp_pow (χ : MulChar R R') (f : R' →+* R'') (n : ℕ) :
   | zero => simp only [pow_zero, ringHomComp_one]
   | succ n ih => simp only [pow_succ, ih, ringHomComp_mul]
 
+/-- Bundled version of `MulChar.ringHomComp` as a `MonoidHom`. -/
+@[simps]
+def ringHomCompHom (f : R' →+* R'') : MulChar R R' →* MulChar R R'' where
+  toFun χ := χ.ringHomComp f
+  map_one' := ringHomComp_one f
+  map_mul' _ _ := ringHomComp_mul _ _ f
+
+lemma ringHomComp_zpow (χ : MulChar R R') (f : R' →+* R'') (n : ℤ) :
+    χ.ringHomComp f ^ n = (χ ^ n).ringHomComp f :=
+  ((ringHomCompHom f).map_zpow χ n).symm
+
+/-- If `a` is a unit and `n : ℤ`, then `(χ ^ n) a = χ (a ^ n)`. -/
+theorem zpow_apply_coe {R : Type*} [CommGroupWithZero R] {R' : Type*} [CommRing R']
+    (χ : MulChar R R') (n : ℤ) (a : Rˣ) : (χ ^ n) a = χ (a ^ n : Rˣ) := by
+  obtain ⟨m, rfl | rfl⟩ := Int.eq_nat_or_neg n
+  · simp [pow_apply_coe]
+  · rw [zpow_neg, zpow_natCast, inv_apply', ← Units.val_inv_eq_inv_val, pow_apply_coe,
+      ← inv_zpow', zpow_natCast, Units.val_pow_eq_pow_val, map_pow]
+
 lemma injective_ringHomComp {f : R' →+* R''} (hf : Function.Injective f) :
     Function.Injective (ringHomComp (R := R) · f) := by
   simpa

--- a/Mathlib/NumberTheory/MulChar/Basic.lean
+++ b/Mathlib/NumberTheory/MulChar/Basic.lean
@@ -462,8 +462,7 @@ theorem zpow_apply_coe {R : Type*} [CommGroupWithZero R] {R' : Type*} [CommRing 
     (χ : MulChar R R') (n : ℤ) (a : Rˣ) : (χ ^ n) a = χ (a ^ n : Rˣ) := by
   obtain ⟨m, rfl | rfl⟩ := Int.eq_nat_or_neg n
   · simp [pow_apply_coe]
-  · rw [zpow_neg, zpow_natCast, inv_apply', ← Units.val_inv_eq_inv_val, pow_apply_coe,
-      ← inv_zpow', zpow_natCast, Units.val_pow_eq_pow_val, map_pow]
+  · simp [pow_apply_coe, inv_apply', ← inv_pow]
 
 lemma injective_ringHomComp {f : R' →+* R''} (hf : Function.Injective f) :
     Function.Injective (ringHomComp (R := R) · f) := by


### PR DESCRIPTION
Adds three lemmas to `Mathlib.NumberTheory.MulChar.Basic`:

- `MulChar.ringHomCompHom`: the bundled `MonoidHom` `MulChar R R' →* MulChar R R''` induced by post-composition with `f : R' →+* R''`. 
- `MulChar.ringHomComp_zpow`: extends the existing `ringHomComp_pow` (for `ℕ`) to integer powers. 
- `MulChar.zpow_apply_coe`: integer-power analogue of the existing `pow_apply_coe`. 

:robot: This PR was extracted from the [SKW project](https://github.com/xroblot/SKW) by Claude.