### PR TITLE
[Merged by Bors] - feat(FieldTheory/IntermediateField): add AlgHom.equivFieldRange

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -546,6 +546,16 @@ variable {f}
 theorem mem_fieldRange {y : L'} : y ∈ f.fieldRange ↔ ∃ x, f x = y :=
   Iff.rfl
 
+/-- An algebra homomorphism between fields restricts to an algebra equivalence onto its range. -/
+noncomputable def equivFieldRange : L ≃ₐ[K] f.fieldRange :=
+  AlgEquiv.ofBijective
+    (f.codRestrict f.range fun x ↦ mem_fieldRange.mpr ⟨x, rfl⟩)
+    ⟨fun _ _ h ↦ f.injective (congr_arg Subtype.val h),
+     fun ⟨_, hy⟩ ↦ (mem_fieldRange.mp hy).imp fun _ hx => Subtype.ext hx⟩
+
+@[simp]
+theorem equivFieldRange_apply (x : L) : f.equivFieldRange x = f x := rfl
+
 end AlgHom
 
 namespace IntermediateField


### PR DESCRIPTION
Add `AlgHom.equivFieldRange : L ≃ₐ[K] f.fieldRange`, which constructs an algebra equivalence from a field algebra homomorphism `f : L →ₐ[K] L'` onto its range.

:robot: This PR was extracted from the [SKW project](https://github.com/xroblot/SKW) by Claude.