### PR TITLE
chore(MeasureTheory): remove all `erw` in `MeasureTheory`

### DIFF
--- a/Mathlib/Data/ENNReal/Operations.lean
+++ b/Mathlib/Data/ENNReal/Operations.lean
@@ -656,6 +656,16 @@ lemma add_biSup {ι : Type*} {s : Set ι} (hs : s.Nonempty) (f : ι → ℝ≥0�
 lemma biSup_add {ι : Type*} {s : Set ι} (hs : s.Nonempty) (f : ι → ℝ≥0∞) :
     (⨆ i ∈ s, f i) + a = ⨆ i ∈ s, f i + a := biSup_add' hs _
 
+lemma biSup_biSup_add {ι : Type*} {s : Set ι} {P : ι → Prop} (h : ∃ i ∈ s, P i) (f : ι → ℝ≥0∞) :
+    (⨆ i ∈ s, ⨆ (_ : P i), f i) + a = ⨆ i ∈ s, ⨆ (_ : P i), f i + a := by
+  obtain ⟨j, js, hj⟩ := h
+  rw [← iSup_subtype'', ← iSup_subtype'']
+  exact ENNReal.biSup_add ⟨⟨j, js⟩, hj⟩ _
+
+lemma biSup_univ_biSup_add {ι : Type*} {P : ι → Prop} (h : ∃ i, P i) (f : ι → ℝ≥0∞) :
+    (⨆ i, ⨆ (_ : P i), f i) + a = ⨆ i, ⨆ (_ : P i), f i + a :=
+  ENNReal.biSup_add h f
+
 lemma add_sSup (hs : s.Nonempty) : a + sSup s = ⨆ b ∈ s, a + b := by
   rw [sSup_eq_iSup, add_biSup hs]
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -454,6 +454,17 @@ theorem ext_of_Ico_finite {α : Type*} [TopologicalSpace α] {m : MeasurableSpac
   rintro - ⟨a, b, hlt, rfl⟩
   exact h hlt
 
+theorem ext_of_Ioc_finite' {α : Type*} [LinearOrder α] (a : αᵒᵈ) :
+    OrderDual.toDual (α := α) a = a := rfl
+
+theorem ext_of_Ioc_finite'' {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
+    ⇑OrderDual.ofDual ⁻¹' Ioc (α := α) (↑b : α) a = Ico a b := by
+  nth_rw 2 [← ext_of_Ioc_finite' a, ← ext_of_Ioc_finite' b]
+  rw [Ico_toDual (α := α)]
+
+theorem ext_of_Ioc_finite''' {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
+    ⇑OrderDual.ofDual ⁻¹' Ioc a b = Ioc a b := rfl
+
 set_option backward.isDefEq.respectTransparency false in
 /-- Two finite measures on a Borel space are equal if they agree on all open-closed intervals.  If
 `α` is a conditionally complete linear order with no top element,
@@ -464,8 +475,7 @@ theorem ext_of_Ioc_finite {α : Type*} [TopologicalSpace α] {m : MeasurableSpac
     [IsFiniteMeasure μ] (hμν : μ univ = ν univ) (h : ∀ ⦃a b⦄, a < b → μ (Ioc a b) = ν (Ioc a b)) :
     μ = ν := by
   refine @ext_of_Ico_finite αᵒᵈ _ _ _ _ _ ‹_› μ ν _ hμν fun a b hab => ?_
-  erw [Ico_toDual (α := α)]
-  exact h hab
+  convert! h hab using 1 <;> rw [← ext_of_Ioc_finite''] <;> rfl
 
 /-- Two measures which are finite on closed-open intervals are equal if they agree on all
 closed-open intervals. -/

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -53,14 +53,6 @@ section OrderTopology
 variable (α)
 variable [TopologicalSpace α] [SecondCountableTopology α] [LinearOrder α] [OrderTopology α]
 
-theorem ext_of_Ioc_finite' {α : Type*} [LinearOrder α] (a : αᵒᵈ) :
-    OrderDual.toDual (α := α) a = a := rfl
-
-theorem ext_of_Ioc_finite'' {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
-    ⇑OrderDual.ofDual ⁻¹' Ioc (α := α) (↑b : α) a = Ico a b := by
-  nth_rw 2 [← ext_of_Ioc_finite' a, ← ext_of_Ioc_finite' b]
-  rw [Ico_toDual (α := α)]
-
 theorem borel_eq_generateFrom_Iio : borel α = .generateFrom (range Iio) := by
   refine le_antisymm ?_ (generateFrom_le ?_)
   · rw [borel_eq_generateFrom_of_subbasis (@OrderTopology.topology_eq_generate_intervals α _ _ _)]

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -411,7 +411,7 @@ theorem Dense.borel_eq_generateFrom_Ioc_mem_aux {α : Type*} [TopologicalSpace �
     constructor <;> rintro ⟨l, hl, u, hu, hlt, rfl⟩
     exacts [⟨u, hu, l, hl, hlt, Ico_toDual⟩, ⟨u, hu, l, hl, hlt, Ioc_toDual⟩]
   · calc
-      _ = OrderDual.ofDual '' (Ioo x y) := by --TODO: extract this as separate lemma
+      _ = OrderDual.ofDual '' (Ioo x y) := by
         ext
         simp only [mem_Ioo, mem_image_equiv, OrderDual.ofDual_symm_eq]
         tauto
@@ -506,7 +506,7 @@ theorem ext_of_Ioc' {α : Type*} [TopologicalSpace α] {m : MeasurableSpace α}
   refine @ext_of_Ico' αᵒᵈ _ _ _ _ _ ‹_› _ μ ν ?_ ?_
   all_goals
     intro a b hab
-    rw [← ext_of_Ioc_finite' a, ← ext_of_Ioc_finite' b,
+    rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b,
       Ico_toDual (α := α)]
   exacts [hμ hab, h hab]
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -53,6 +53,14 @@ section OrderTopology
 variable (α)
 variable [TopologicalSpace α] [SecondCountableTopology α] [LinearOrder α] [OrderTopology α]
 
+theorem ext_of_Ioc_finite' {α : Type*} [LinearOrder α] (a : αᵒᵈ) :
+    OrderDual.toDual (α := α) a = a := rfl
+
+theorem ext_of_Ioc_finite'' {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
+    ⇑OrderDual.ofDual ⁻¹' Ioc (α := α) (↑b : α) a = Ico a b := by
+  nth_rw 2 [← ext_of_Ioc_finite' a, ← ext_of_Ioc_finite' b]
+  rw [Ico_toDual (α := α)]
+
 theorem borel_eq_generateFrom_Iio : borel α = .generateFrom (range Iio) := by
   refine le_antisymm ?_ (generateFrom_le ?_)
   · rw [borel_eq_generateFrom_of_subbasis (@OrderTopology.topology_eq_generate_intervals α _ _ _)]
@@ -410,8 +418,12 @@ theorem Dense.borel_eq_generateFrom_Ioc_mem_aux {α : Type*} [TopologicalSpace �
   · ext s
     constructor <;> rintro ⟨l, hl, u, hu, hlt, rfl⟩
     exacts [⟨u, hu, l, hl, hlt, Ico_toDual⟩, ⟨u, hu, l, hl, hlt, Ioc_toDual⟩]
-  · erw [Ioo_toDual]
-    exact he
+  · calc
+      _ = OrderDual.ofDual '' (Ioo x y) := by --TODO: extract this as separate lemma
+        ext
+        simp only [mem_Ioo, mem_image_equiv, OrderDual.ofDual_symm_eq]
+        tauto
+      _ = _ := by rw [he, image_empty]
 
 theorem Dense.borel_eq_generateFrom_Ioc_mem {α : Type*} [TopologicalSpace α] [LinearOrder α]
     [OrderTopology α] [SecondCountableTopology α] [DenselyOrdered α] [NoMaxOrder α] {s : Set α}
@@ -454,18 +466,6 @@ theorem ext_of_Ico_finite {α : Type*} [TopologicalSpace α] {m : MeasurableSpac
   rintro - ⟨a, b, hlt, rfl⟩
   exact h hlt
 
-theorem ext_of_Ioc_finite' {α : Type*} [LinearOrder α] (a : αᵒᵈ) :
-    OrderDual.toDual (α := α) a = a := rfl
-
-theorem ext_of_Ioc_finite'' {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
-    ⇑OrderDual.ofDual ⁻¹' Ioc (α := α) (↑b : α) a = Ico a b := by
-  nth_rw 2 [← ext_of_Ioc_finite' a, ← ext_of_Ioc_finite' b]
-  rw [Ico_toDual (α := α)]
-
-theorem ext_of_Ioc_finite''' {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
-    ⇑OrderDual.ofDual ⁻¹' Ioc a b = Ioc a b := rfl
-
-set_option backward.isDefEq.respectTransparency false in
 /-- Two finite measures on a Borel space are equal if they agree on all open-closed intervals.  If
 `α` is a conditionally complete linear order with no top element,
 `MeasureTheory.Measure.ext_of_Ioc` is an extensionality lemma with weaker assumptions on `μ` and
@@ -474,8 +474,11 @@ theorem ext_of_Ioc_finite {α : Type*} [TopologicalSpace α] {m : MeasurableSpac
     [SecondCountableTopology α] [LinearOrder α] [OrderTopology α] [BorelSpace α] (μ ν : Measure α)
     [IsFiniteMeasure μ] (hμν : μ univ = ν univ) (h : ∀ ⦃a b⦄, a < b → μ (Ioc a b) = ν (Ioc a b)) :
     μ = ν := by
-  refine @ext_of_Ico_finite αᵒᵈ _ _ _ _ _ ‹_› μ ν _ hμν fun a b hab => ?_
-  convert! h hab using 1 <;> rw [← ext_of_Ioc_finite''] <;> rfl
+  refine
+    ext_of_generate_finite _ (BorelSpace.measurable_eq.trans (borel_eq_generateFrom_Ioc α))
+      (isPiSystem_Ioc (id : α → α) id) ?_ hμν
+  rintro - ⟨a, b, hlt, rfl⟩
+  exact h hlt
 
 /-- Two measures which are finite on closed-open intervals are equal if they agree on all
 closed-open intervals. -/
@@ -508,7 +511,11 @@ theorem ext_of_Ioc' {α : Type*} [TopologicalSpace α] {m : MeasurableSpace α}
     [SecondCountableTopology α] [LinearOrder α] [OrderTopology α] [BorelSpace α] [NoMinOrder α]
     (μ ν : Measure α) (hμ : ∀ ⦃a b⦄, a < b → μ (Ioc a b) ≠ ∞)
     (h : ∀ ⦃a b⦄, a < b → μ (Ioc a b) = ν (Ioc a b)) : μ = ν := by
-  refine @ext_of_Ico' αᵒᵈ _ _ _ _ _ ‹_› _ μ ν ?_ ?_ <;> intro a b hab <;> erw [Ico_toDual (α := α)]
+  refine @ext_of_Ico' αᵒᵈ _ _ _ _ _ ‹_› _ μ ν ?_ ?_
+  all_goals
+    intro a b hab
+    rw [← ext_of_Ioc_finite' a, ← ext_of_Ioc_finite' b,
+      Ico_toDual (α := α)]
   exacts [hμ hab, h hab]
 
 /-- Two measures which are finite on closed-open intervals are equal if they agree on all

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -413,8 +413,8 @@ theorem Dense.borel_eq_generateFrom_Ioc_mem_aux {α : Type*} [TopologicalSpace �
   · calc
       _ = OrderDual.ofDual '' (Ioo x y) := by
         ext
-        simp only [mem_Ioo, mem_image_equiv, OrderDual.ofDual_symm_eq]
-        tauto
+        simp only [mem_Ioo, mem_image_equiv, OrderDual.ofDual_symm_eq, OrderDual.toDual_of_op]
+        exact And.comm
       _ = _ := by rw [he, image_empty]
 
 theorem Dense.borel_eq_generateFrom_Ioc_mem {α : Type*} [TopologicalSpace α] [LinearOrder α]
@@ -506,8 +506,7 @@ theorem ext_of_Ioc' {α : Type*} [TopologicalSpace α] {m : MeasurableSpace α}
   refine @ext_of_Ico' αᵒᵈ _ _ _ _ _ ‹_› _ μ ν ?_ ?_
   all_goals
     intro a b hab
-    rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b,
-      Ico_toDual (α := α)]
+    rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b, Ico_toDual]
   exacts [hμ hab, h hab]
 
 /-- Two measures which are finite on closed-open intervals are equal if they agree on all

--- a/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
+++ b/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
@@ -106,7 +106,9 @@ theorem exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure [NormedAddC
   -- it follows that `s` contains a nonzero point of `L`.
   have h_zero : 0 ∈ K := K.zero_mem_of_symmetric h_symm
   suffices Set.Nonempty (⋂ n, Z n) by
-    erw [← Set.iInter_inter, K.iInter_smul_eq_self h_zero] at this
+    simp_rw [Z, S, ConvexBody.coe_smul', NNReal.smul_def, ← Set.iInter_inter, NNReal.coe_add,
+      NNReal.coe_one] at this
+    rw [K.iInter_smul_eq_self h_zero] at this
     · obtain ⟨x, hx⟩ := this
       exact ⟨⟨x, by simp_all⟩, by aesop⟩
     · exact (exists_seq_strictAnti_tendsto (0 : ℝ≥0)).choose_spec.2.2

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -122,8 +122,8 @@ theorem volume_closedBall {x : AddCircle T} (ε : ℝ) :
 
 instance : IsUnifLocDoublingMeasure (volume : Measure (AddCircle T)) := by
   refine ⟨⟨Real.toNNReal 2, Filter.Eventually.of_forall fun ε x => ?_⟩⟩
-  simp only [volume_closedBall]
-  erw [← ENNReal.ofReal_mul zero_le_two]
+  rw [volume_closedBall, volume_closedBall, ENNReal.ofNNReal_toNNReal 2,
+    ← ENNReal.ofReal_mul zero_le_two]
   apply ENNReal.ofReal_le_ofReal
   rw [mul_min_of_nonneg _ _ (zero_le_two : (0 : ℝ) ≤ 2)]
   exact min_le_min (by linarith [hT.out]) (le_refl _)

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -194,31 +194,6 @@ theorem exists_simpleFunc_forall_lintegral_sub_lt_of_pos {f : α → ℝ≥0∞}
   simp only [add_apply, sub_apply, add_tsub_eq_max]
   rfl
 
-theorem eexists_simpleFunc_forall_lintegral_sub_lt_of_pos {f : α → ℝ≥0∞} (h : ∫⁻ x, f x ∂μ ≠ ∞)
-    {ε : ℝ≥0∞} (hε : ε ≠ 0) :
-    ∃ φ : α →ₛ ℝ≥0,
-      (∀ x, ↑(φ x) ≤ f x) ∧
-        ∀ ψ : α →ₛ ℝ≥0, (∀ x, ↑(ψ x) ≤ f x) → (map (↑) (ψ - φ)).lintegral μ < ε := by
-  rw [lintegral_eq_nnreal] at h
-  have : ⨆ φ, ⨆ (_ : ∀ (x : α), ↑(φ x) ≤ f x), (SimpleFunc.map ofNNReal φ).lintegral μ
-      < ⨆ i, (⨆ (_ : ∀ (x : α), ↑(i x) ≤ f x), (SimpleFunc.map ofNNReal i).lintegral μ + ε) := by
-    convert! ENNReal.lt_add_right h hε
-    conv_rhs => rw [← iSup_univ, ENNReal.biSup_add univ_nonempty]
-    simp only [mem_univ, iSup_pos]
-    congr! 1
-    ext x
-    rw [iSup_pos (by sorry)]
-    simp_rw [biSup_addÄ]
-    simp
-  simp_rw [lt_iSup_iff, iSup_lt_iff, iSup_le_iff] at this
-  rcases this with ⟨φ, hle : ∀ x, ↑(φ x) ≤ f x, b, hbφ, hb⟩
-  refine ⟨φ, hle, fun ψ hψ => ?_⟩
-  have : (map (↑) φ).lintegral μ ≠ ∞ := ne_top_of_le_ne_top h (by exact le_iSup₂ (α := ℝ≥0∞) φ hle)
-  rw [← ENNReal.add_lt_add_iff_left this, ← add_lintegral, ← SimpleFunc.map_add @ENNReal.coe_add]
-  refine (hb _ fun x => le_trans ?_ (max_le (hle x) (hψ x))).trans_lt hbφ
-  simp only [add_apply, sub_apply, add_tsub_eq_max]
-  rfl
-
 theorem iSup_lintegral_le {ι : Sort*} (f : ι → α → ℝ≥0∞) :
     ⨆ i, ∫⁻ a, f i a ∂μ ≤ ∫⁻ a, ⨆ i, f i a ∂μ := by
   simp only [← iSup_apply]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -184,7 +184,32 @@ theorem exists_simpleFunc_forall_lintegral_sub_lt_of_pos {f : α → ℝ≥0∞}
         ∀ ψ : α →ₛ ℝ≥0, (∀ x, ↑(ψ x) ≤ f x) → (map (↑) (ψ - φ)).lintegral μ < ε := by
   rw [lintegral_eq_nnreal] at h
   have := ENNReal.lt_add_right h hε
-  erw [ENNReal.biSup_add] at this <;> [skip; exact ⟨0, fun x => zero_le⟩]
+  rw [ENNReal.biSup_univ_biSup_add (h := by exact ⟨0, fun x => zero_le⟩)] at this
+  simp_rw [lt_iSup_iff, iSup_lt_iff, iSup_le_iff] at this
+  rcases this with ⟨φ, hle : ∀ x, ↑(φ x) ≤ f x, b, hbφ, hb⟩
+  refine ⟨φ, hle, fun ψ hψ => ?_⟩
+  have : (map (↑) φ).lintegral μ ≠ ∞ := ne_top_of_le_ne_top h (by exact le_iSup₂ (α := ℝ≥0∞) φ hle)
+  rw [← ENNReal.add_lt_add_iff_left this, ← add_lintegral, ← SimpleFunc.map_add @ENNReal.coe_add]
+  refine (hb _ fun x => le_trans ?_ (max_le (hle x) (hψ x))).trans_lt hbφ
+  simp only [add_apply, sub_apply, add_tsub_eq_max]
+  rfl
+
+theorem eexists_simpleFunc_forall_lintegral_sub_lt_of_pos {f : α → ℝ≥0∞} (h : ∫⁻ x, f x ∂μ ≠ ∞)
+    {ε : ℝ≥0∞} (hε : ε ≠ 0) :
+    ∃ φ : α →ₛ ℝ≥0,
+      (∀ x, ↑(φ x) ≤ f x) ∧
+        ∀ ψ : α →ₛ ℝ≥0, (∀ x, ↑(ψ x) ≤ f x) → (map (↑) (ψ - φ)).lintegral μ < ε := by
+  rw [lintegral_eq_nnreal] at h
+  have : ⨆ φ, ⨆ (_ : ∀ (x : α), ↑(φ x) ≤ f x), (SimpleFunc.map ofNNReal φ).lintegral μ
+      < ⨆ i, (⨆ (_ : ∀ (x : α), ↑(i x) ≤ f x), (SimpleFunc.map ofNNReal i).lintegral μ + ε) := by
+    convert! ENNReal.lt_add_right h hε
+    conv_rhs => rw [← iSup_univ, ENNReal.biSup_add univ_nonempty]
+    simp only [mem_univ, iSup_pos]
+    congr! 1
+    ext x
+    rw [iSup_pos (by sorry)]
+    simp_rw [biSup_addÄ]
+    simp
   simp_rw [lt_iSup_iff, iSup_lt_iff, iSup_le_iff] at this
   rcases this with ⟨φ, hle : ∀ x, ↑(φ x) ≤ f x, b, hbφ, hb⟩
   refine ⟨φ, hle, fun ψ hψ => ?_⟩

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Countable.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Countable.lean
@@ -238,7 +238,9 @@ theorem exists_pos_lintegral_lt_of_sigmaFinite (μ : Measure α) [SigmaFinite μ
   have hN_meas : Measurable N := measurableSet_spanningSetsIndex μ
   have hNs : ∀ n, N ⁻¹' {n} = s n := preimage_spanningSetsIndex_singleton μ
   refine ⟨δ ∘ N, fun x => δpos _, measurable_from_nat.comp hN_meas, ?_⟩
-  erw [lintegral_comp measurable_from_nat.coe_nnreal_ennreal hN_meas]
+  have := Function.comp_assoc (fun (x : ℝ≥0) ↦ (↑x : ℝ≥0∞)) δ N
+  change ∫⁻ (x : α), ↑(((fun (n : ℕ) ↦ (↑(δ n) : ℝ≥0∞)) ∘ N) x) ∂μ < ε
+  rw [lintegral_comp measurable_from_nat.coe_nnreal_ennreal hN_meas]
   simpa [N, hNs, lintegral_countable', measurableSet_spanningSetsIndex, mul_comm] using δsum
 
 omit [MeasurableSpace α]

--- a/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/NNReal.lean
+++ b/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/NNReal.lean
@@ -77,8 +77,9 @@ theorem _root_.MeasureTheory.Measure.ext_of_integral_eq_on_compactlySupported_nn
   apply Measure.ext_of_integral_eq_on_compactlySupported
   intro f
   repeat rw [integral_eq_integral_pos_part_sub_integral_neg_part f.integrable]
-  erw [hμν f.nnrealPart, hμν (-f).nnrealPart]
-  rfl
+  have := hμν f.nnrealPart
+  have := hμν (-f).nnrealPart
+  simp_all
 
 /-- If two regular measures induce the same linear functional on `C_c(X, ℝ≥0)`, then they are
 equal. -/

--- a/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
@@ -104,9 +104,11 @@ noncomputable def OrthonormalBasis.measurableEquiv (b : OrthonormalBasis ι ℝ 
 theorem OrthonormalBasis.measurePreserving_measurableEquiv (b : OrthonormalBasis ι ℝ F) :
     MeasurePreserving b.measurableEquiv volume volume := by
   convert! (b.measurableEquiv.symm.measurable.measurePreserving _).symm
-  rw [← (EuclideanSpace.basisFun ι ℝ).addHaar_eq_volume]
-  erw [MeasurableEquiv.coe_toEquiv_symm, Basis.map_addHaar _ b.repr.symm.toContinuousLinearEquiv]
-  exact b.addHaar_eq_volume.symm
+  convert! b.addHaar_eq_volume.symm
+  have : (EuclideanSpace.basisFun ι ℝ).toBasis.map ↑↑b.repr.symm = b.toBasis := rfl
+  rw [← this, ← Basis.map_addHaar _ b.repr.symm.toContinuousLinearEquiv,
+    ← MeasurableEquiv.coe_toEquiv_symm, (EuclideanSpace.basisFun ι ℝ).addHaar_eq_volume]
+  rfl
 
 theorem OrthonormalBasis.measurePreserving_repr (b : OrthonormalBasis ι ℝ F) :
     MeasurePreserving b.repr volume volume := b.measurePreserving_measurableEquiv

--- a/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
@@ -154,9 +154,8 @@ theorem measurePreserving (f : E ≃ₗᵢ[ℝ] F) :
     MeasurePreserving f := by
   refine ⟨f.continuous.measurable, ?_⟩
   rcases exists_orthonormalBasis ℝ E with ⟨w, b, _hw⟩
-  erw [← OrthonormalBasis.addHaar_eq_volume b, ← OrthonormalBasis.addHaar_eq_volume (b.map f),
-    Basis.map_addHaar _ f.toContinuousLinearEquiv]
-  congr
+  rw [← OrthonormalBasis.addHaar_eq_volume b, ← OrthonormalBasis.addHaar_eq_volume (b.map f)]
+  exact Basis.map_addHaar _ f.toContinuousLinearEquiv
 
 end LinearIsometryEquiv
 

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -99,8 +99,10 @@ theorem map_addHaar {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E] [Normed
     (b : Basis ι ℝ E) (f : E ≃L[ℝ] F) :
     map f b.addHaar = (b.map f.toLinearEquiv).addHaar := by
   rw [eq_comm, Basis.addHaar_eq_iff, Measure.map_apply f.continuous.measurable
-    (PositiveCompacts.isCompact _).measurableSet, Basis.coe_parallelepiped, Basis.coe_map]
-  erw [← image_parallelepiped, f.toEquiv.preimage_image, addHaar_self]
+    (PositiveCompacts.isCompact _).measurableSet, Basis.coe_parallelepiped, Basis.coe_map,
+    ← addHaar_self b, ← f.toEquiv.preimage_image (_root_.parallelepiped ⇑b)]
+  congr 2
+  exact (image_parallelepiped f.toLinearMap (⇑b : ι → E)).symm
 
 end Module.Basis
 

--- a/Mathlib/MeasureTheory/Measure/Prod.lean
+++ b/Mathlib/MeasureTheory/Measure/Prod.lean
@@ -131,12 +131,14 @@ theorem Measurable.lintegral_prod_right' [SFinite ν] :
     exact (measurable_measure_prodMk_left hs).const_mul _
   · rintro f g - hf - h2f h2g
     simp only [Pi.add_apply]
-    conv => enter [1, x]; erw [lintegral_add_left (hf.comp m)]
+    conv =>
+      enter [1, x]
+      rw [lintegral_add_left (by exact hf.comp m) (fun a ↦ g (x, a))]
     exact h2f.add h2g
   · intro f hf h2f h3f
     have : ∀ x, Monotone fun n y => f n (x, y) := fun x i j hij y => h2f hij (x, y)
-    conv => enter [1, x]; erw [lintegral_iSup (fun n => (hf n).comp m) (this x)]
-    exact .iSup h3f
+    convert! Measurable.iSup h3f with x
+    exact lintegral_iSup (fun n => (hf n).comp m) (this x)
 
 /-- The Lebesgue integral is measurable. This shows that the integrand of (the right-hand-side of)
   Tonelli's theorem is measurable.

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -145,10 +145,16 @@ theorem Ico_ofDual {x y : αᵒᵈ} : Ico (ofDual y) (ofDual x) = toDual ⁻¹' 
 theorem Ioo_ofDual {x y : αᵒᵈ} : Ioo (ofDual y) (ofDual x) = toDual ⁻¹' Ioo x y :=
   Set.ext fun _ => and_comm
 
-theorem ext_of_Ioc_finite'' {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
-    ⇑OrderDual.ofDual ⁻¹' Ioc (α := α) (↑b : α) a = Ico a b := by
-  nth_rw 2 [← toDual_of_op a, ← toDual_of_op b]
+@[to_dual]
+theorem OrderDual.ofDual_Ioc_preimage_Ioc {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
+    Ico a b = ⇑OrderDual.ofDual ⁻¹' Ioc (α := α) (↑b : α) a := by
+  conv_lhs => rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b]
   rw [Ico_toDual (α := α)]
+
+theorem OrderDual.ofDual_Ioo_preimage_Ioo {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
+    Ioo a b = ⇑OrderDual.ofDual ⁻¹' Ioo (α := α) (↑b : α) a := by
+  conv_lhs => rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b]
+  rw [Ioo_toDual (α := α)]
 
 @[to_dual (attr := simp)]
 theorem nonempty_Iio [NoMinOrder α] : (Iio a).Nonempty :=

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -149,7 +149,7 @@ theorem Ioo_ofDual {x y : αᵒᵈ} : Ioo (ofDual y) (ofDual x) = toDual ⁻¹' 
 theorem OrderDual.ofDual_Ioc_preimage_Ioc (a b : αᵒᵈ) :
     Ico a b = ⇑OrderDual.ofDual ⁻¹' Ioc (α := α) (↑b : α) a := by
   conv_lhs => rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b]
-  rw [Ico_toDual (α := α)]
+  exact Ico_toDual
 
 theorem OrderDual.ofDual_Ioo_preimage_Ioo (a b : αᵒᵈ) :
     Ioo a b = ⇑OrderDual.ofDual ⁻¹' Ioo (α := α) (↑b : α) a := by

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -145,6 +145,11 @@ theorem Ico_ofDual {x y : αᵒᵈ} : Ico (ofDual y) (ofDual x) = toDual ⁻¹' 
 theorem Ioo_ofDual {x y : αᵒᵈ} : Ioo (ofDual y) (ofDual x) = toDual ⁻¹' Ioo x y :=
   Set.ext fun _ => and_comm
 
+theorem ext_of_Ioc_finite'' {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
+    ⇑OrderDual.ofDual ⁻¹' Ioc (α := α) (↑b : α) a = Ico a b := by
+  nth_rw 2 [← toDual_of_op a, ← toDual_of_op b]
+  rw [Ico_toDual (α := α)]
+
 @[to_dual (attr := simp)]
 theorem nonempty_Iio [NoMinOrder α] : (Iio a).Nonempty :=
   exists_lt a

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -146,12 +146,12 @@ theorem Ioo_ofDual {x y : αᵒᵈ} : Ioo (ofDual y) (ofDual x) = toDual ⁻¹' 
   Set.ext fun _ => and_comm
 
 @[to_dual]
-theorem OrderDual.ofDual_Ioc_preimage_Ioc {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
+theorem OrderDual.ofDual_Ioc_preimage_Ioc (a b : αᵒᵈ) :
     Ico a b = ⇑OrderDual.ofDual ⁻¹' Ioc (α := α) (↑b : α) a := by
   conv_lhs => rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b]
   rw [Ico_toDual (α := α)]
 
-theorem OrderDual.ofDual_Ioo_preimage_Ioo {α : Type*} [LinearOrder α] (a b : αᵒᵈ) :
+theorem OrderDual.ofDual_Ioo_preimage_Ioo (a b : αᵒᵈ) :
     Ioo a b = ⇑OrderDual.ofDual ⁻¹' Ioo (α := α) (↑b : α) a := by
   conv_lhs => rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b]
   rw [Ioo_toDual (α := α)]

--- a/Mathlib/Order/OrderDual.lean
+++ b/Mathlib/Order/OrderDual.lean
@@ -141,8 +141,7 @@ def ofDual : αᵒᵈ ≃ α :=
 @[simp] theorem toDual_comp_ofDual : (toDual (α := α)) ∘ ofDual = id := rfl
 @[simp] theorem ofDual_comp_toDual : (ofDual (α := α)) ∘ toDual = id := rfl
 
-theorem toDual_of_op (a : αᵒᵈ) :
-    OrderDual.toDual (α := α) a = a := rfl
+theorem toDual_of_op (a : αᵒᵈ) : OrderDual.toDual (α := α) a = a := rfl
 
 theorem toDual_inj {a b : α} : toDual a = toDual b ↔ a = b := by simp
 theorem ofDual_inj {a b : αᵒᵈ} : ofDual a = ofDual b ↔ a = b := by simp

--- a/Mathlib/Order/OrderDual.lean
+++ b/Mathlib/Order/OrderDual.lean
@@ -141,6 +141,9 @@ def ofDual : αᵒᵈ ≃ α :=
 @[simp] theorem toDual_comp_ofDual : (toDual (α := α)) ∘ ofDual = id := rfl
 @[simp] theorem ofDual_comp_toDual : (ofDual (α := α)) ∘ toDual = id := rfl
 
+theorem toDual_of_op (a : αᵒᵈ) :
+    OrderDual.toDual (α := α) a = a := rfl
+
 theorem toDual_inj {a b : α} : toDual a = toDual b ↔ a = b := by simp
 theorem ofDual_inj {a b : αᵒᵈ} : ofDual a = ofDual b ↔ a = b := by simp
 


### PR DESCRIPTION
12 `erw`'s in total; some slved more elegantally than other.
If needed, I can split this up

- [ ] depends on: #40392
- [ ] depends on: #40394
- [x] depends on: #40350
- [ ] depends on: #40402
- [ ] depends on: #40404
- [ ] depends on: #40405
- [x] depends on: #40407
- [x] depends on: #40408
- [ ] depends on: #40409

