### PR TITLE
[Merged by Bors] - feat: continuity of posLog

### DIFF
--- a/Mathlib/Analysis/Complex/ValueDistribution/Proximity/Basic.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/Proximity/Basic.lean
@@ -152,6 +152,14 @@ theorem proximity_nonneg {a : WithTop E} :
     proximity (fun _ ↦ c) ⊤ r = log⁺ ‖c‖ := by
   simp [proximity, circleAverage_const]
 
+/--
+If `f` is continuous, then so is its proximitiy function at `⊤`.
+-/
+@[fun_prop] theorem continuous_proximity_top (hf : Continuous f) :
+    Continuous (proximity f ⊤) := by
+  simp only [proximity, reduceDIte]
+  fun_prop
+
 /-!
 ## Behaviour under Arithmetic Operations
 -/

--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -118,6 +118,18 @@ lemma posLog_le_posLog (hx : 0 ≤ x) (hxy : x ≤ y) : log⁺ x ≤ log⁺ y :=
   have : 1 ≤ |x ^ n| := by simp_all [one_le_pow₀, hx.le]
   simp [posLog_eq_log this, posLog_eq_log hx.le]
 
+/-- The function `log⁺` is continuous. -/
+@[fun_prop] theorem continuous_posLog : Continuous log⁺ := by
+  rw [continuous_iff_continuousAt]
+  intro x
+  by_cases hx : x = 0
+  · apply ContinuousAt.congr (f := fun _ ↦ 0) (by fun_prop)
+    filter_upwards [Metric.ball_mem_nhds _ zero_lt_one] with y hy
+    rw [eq_comm, posLog_eq_zero_iff y]
+    simp_all [le_of_lt]
+  unfold posLog
+  fun_prop
+
 /-!
 ## Estimates for Products
 -/

--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -39,7 +39,10 @@ noncomputable def posLog : ℝ → ℝ := fun r ↦ max 0 (log r)
 scoped notation "log⁺" => posLog
 
 /-- Definition of the positive part of the logarithm, formulated as a theorem. -/
-theorem posLog_def : log⁺ x = max 0 (log x) := rfl
+theorem posLog_apply : log⁺ x = max 0 (log x) := rfl
+
+/-- Definition of the positive part of the logarithm, formulated as a theorem. -/
+theorem posLog_def : log⁺ = max 0 (log ·) := rfl
 
 /-!
 ## Elementary Properties
@@ -47,7 +50,7 @@ theorem posLog_def : log⁺ x = max 0 (log x) := rfl
 
 /-- Presentation of `log` in terms of its positive part. -/
 theorem posLog_sub_posLog_inv : log⁺ x - log⁺ x⁻¹ = log x := by
-  rw [posLog_def, posLog_def, log_inv]
+  rw [posLog_apply, posLog_apply, log_inv]
   by_cases! h : 0 ≤ log x
   · simp [h]
   · simp [neg_nonneg.1 (Left.nonneg_neg_iff.2 h.le)]
@@ -91,7 +94,7 @@ theorem log_of_nat_eq_posLog {n : ℕ} : log⁺ n = log n := by
 
 /-- The function `log⁺` equals `log (max 1 _)` for non-negative real numbers. -/
 theorem posLog_eq_log_max_one (hx : 0 ≤ x) : log⁺ x = log (max 1 x) := by
-  grind [le_abs, posLog_eq_log, log_one, max_eq_left, log_nonpos, posLog_def]
+  grind [le_abs, posLog_eq_log, log_one, max_eq_left, log_nonpos, posLog_apply]
 
 /-- The function `log⁺` is monotone on the positive axis. -/
 theorem monotoneOn_posLog : MonotoneOn log⁺ (Set.Ici 0) := by
@@ -127,7 +130,7 @@ lemma posLog_le_posLog (hx : 0 ≤ x) (hxy : x ≤ y) : log⁺ x ≤ log⁺ y :=
     filter_upwards [Metric.ball_mem_nhds _ zero_lt_one] with y hy
     rw [eq_comm, posLog_eq_zero_iff y]
     simp_all [le_of_lt]
-  unfold posLog
+  rw [posLog_def]
   fun_prop
 
 /-!


### PR DESCRIPTION
Establish continuity of posLog. As a trivial corollary, establish continuity of the proximitiy function.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
