### PR TITLE
refactor: make `IsAtom` not depend on `OrderBot`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Order.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Order.lean
@@ -46,7 +46,7 @@ variable {G : Type*} [Group G] (H : Subgroup G)
 /-- In a group that satisfies the normalizer condition, every maximal subgroup is normal -/
 theorem NormalizerCondition.normal_of_coatom (hnc : NormalizerCondition G) (hmax : IsCoatom H) :
     H.Normal :=
-  normalizer_eq_top_iff.mp (hmax.2 _ (hnc H (lt_top_iff_ne_top.mpr hmax.1)))
+  normalizer_eq_top_iff.mp (hmax.isMax_of_gt (hnc H hmax.lt_top)).eq_top
 
 @[simp]
 theorem isCoatom_comap {H : Type*} [Group H] (f : G ≃* H) {K : Subgroup H} :
@@ -61,13 +61,14 @@ theorem isCoatom_map (f : G ≃* H) {K : Subgroup G} :
 lemma isCoatom_comap_of_surjective
     {H : Type*} [Group H] {φ : G →* H} (hφ : Function.Surjective φ)
     {M : Subgroup H} (hM : IsCoatom M) : IsCoatom (M.comap φ) := by
-  refine And.imp (fun hM ↦ ?_) (fun hM ↦ ?_) hM
-  · rwa [← (comap_injective hφ).ne_iff, comap_top] at hM
-  · intro K hK
-    specialize hM (K.map φ)
-    rw [← comap_lt_comap_of_surjective hφ, ← (comap_injective hφ).eq_iff] at hM
-    rw [comap_map_eq_self ((M.ker_le_comap φ).trans hK.le), comap_top] at hM
-    exact hM hK
+  rw [← covBy_top_iff] at hM ⊢
+  refine ⟨?_, fun c hc hct => ?_⟩
+  · rw [← comap_top φ, comap_lt_comap_of_surjective hφ]
+    exact hM.lt
+  · rw [← comap_map_eq_self ((M.ker_le_comap φ).trans hc.le), ← comap_top φ,
+      comap_lt_comap_of_surjective hφ] at hct
+    rw [← comap_map_eq_self ((M.ker_le_comap φ).trans hc.le), comap_lt_comap_of_surjective hφ] at hc
+    exact hM.2 hc hct
 
 end Subgroup
 end Coatom

--- a/Mathlib/Algebra/Lie/InvariantForm.lean
+++ b/Mathlib/Algebra/Lie/InvariantForm.lean
@@ -102,7 +102,7 @@ lemma orthogonal_disjoint
   rw [disjoint_iff, ← hI.lt_iff, lt_iff_le_and_ne]
   suffices ¬I ≤ orthogonal Φ hΦ_inv I by simpa
   intro contra
-  apply hI.1
+  apply hI.ne_bot
   rw [eq_bot_iff, ← lie_eq_self_of_isAtom_of_nonabelian I hI (hL I hI),
       LieSubmodule.lieIdeal_oper_eq_span, LieSubmodule.lieSpan_le]
   rintro _ ⟨x, y, rfl⟩
@@ -181,7 +181,7 @@ decreasing_by
   apply finrank_lt_finrank_of_lt
   suffices ¬I ≤ J' by simpa
   intro hIJ'
-  apply hJ.1
+  apply hJ.ne_bot
   rw [eq_bot_iff]
   exact orthogonal_disjoint Φ hΦ_nondeg hΦ_inv hL J hJ le_rfl (hJI.trans hIJ')
 

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -80,7 +80,7 @@ instance instSemisimple [IsKilling K L] [Module.Finite K L] : IsSemisimple K L :
   · exact LieModule.traceForm_lieInvariant _ _ _
   · exact (LieModule.traceForm_isSymm K L L).isRefl
   · intro I h₁ h₂
-    exact h₁.1 <| IsKilling.ideal_eq_bot_of_isLieAbelian I
+    exact h₁.ne_bot <| IsKilling.ideal_eq_bot_of_isLieAbelian I
 
 /-- The converse of this is true in characteristic zero; it is
 `LieAlgebra.HasTrivialRadical.instIsKilling`. There are counterexamples

--- a/Mathlib/Algebra/Lie/Semisimple/Basic.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Basic.lean
@@ -174,7 +174,7 @@ lemma isSimple_of_isAtom (I : LieIdeal R L) (hI : IsAtom I) : IsSimple R I where
     -- We need to show that `J = ⊥`.
     -- Since `J` is an ideal of `L`, and `I` is an atom,
     -- it suffices to show that `J < I`.
-    apply hI.2
+    refine (hI.isMin_of_lt ?_).eq_bot
     rw [lt_iff_le_and_ne]
     constructor
     -- We know that `J ≤ I` since `J` is an ideal of `I`.

--- a/Mathlib/Data/Finset/Grade.lean
+++ b/Mathlib/Data/Finset/Grade.lean
@@ -137,7 +137,7 @@ lemma covBy_iff_exists_erase : s ⋖ t ↔ ∃ a ∈ t, t.erase a = s := by
 end DecidableEq
 
 @[simp] lemma isAtom_singleton (a : α) : IsAtom ({a} : Finset α) :=
-  ⟨singleton_ne_empty a, fun _ ↦ eq_empty_of_ssubset_singleton⟩
+  bot_covBy_iff.1 (by simp)
 
 protected lemma isAtom_iff : IsAtom s ↔ ∃ a, s = {a} := by
   simp [← bot_covBy_iff, covBy_iff_exists_cons, eq_comm]

--- a/Mathlib/GroupTheory/GroupAction/Jordan.lean
+++ b/Mathlib/GroupTheory/GroupAction/Jordan.lean
@@ -67,7 +67,7 @@ theorem normalClosure_of_stabilizer_eq_top (hsn' : 2 < ENat.card α)
   have hGa : IsCoatom (stabilizer G a) := by
     rw [isCoatom_stabilizer_iff_preprimitive]
     exact isPreprimitive_of_is_two_pretransitive hG'
-  apply hGa.right
+  refine (hGa.isMax_of_gt ?_).eq_top
   -- Remains to prove: (stabilizer G a) < Subgroup.normalClosure (stabilizer G a)
   constructor
   · apply le_normalClosure

--- a/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
@@ -348,7 +348,9 @@ theorem isCoatom_stabilizer_of_ncard_lt_ncard_compl
   have : Fintype α := Fintype.ofFinite α
   -- To prove that `stabilizer (Perm α) s` is maximal,
   -- we need to prove that it is `≠ ⊤`
-  refine ⟨stabilizer_ne_top_of_nonempty_of_nonempty_compl h0 h1, fun G hG ↦ ?_⟩
+  refine covBy_top_iff.1 ⟨lt_top_iff_ne_top.2
+    (stabilizer_ne_top_of_nonempty_of_nonempty_compl h0 h1), fun G hG => ?_⟩
+  rw [lt_top_iff_ne_top, not_ne_iff]
   have hG' : stabilizer (Perm α) sᶜ < G := by rwa [stabilizer_compl]
   -- … and that every strict over-subgroup `G` is equal to `⊤`
   -- We know that `G` contains a swap

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/MaximalSubgroups.lean
@@ -227,9 +227,9 @@ theorem isCoatom_stabilizer_of_ncard_lt_ncard_compl {s : Set α}
     grind
   -- To prove that `stabilizer (alternatingGroup α) s` is maximal,
   -- we need to prove that it is `≠ ⊤`
-  use stabilizer_ne_top h0.nonempty h1
+  refine covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 (stabilizer_ne_top h0.nonempty h1), fun G hG => ?_⟩
   -- … and that every strict over-subgroup `G` is equal to `⊤`
-  intro G hG
+  rw [lt_top_iff_ne_top, not_ne_iff]
   suffices IsPreprimitive G α from subgroup_eq_top_of_isPreprimitive hα G hG.le
   -- G acts transitively
   have := G.isPretransitive_of_stabilizer_lt hG

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -785,7 +785,7 @@ theorem normal_of_all_max_subgroups_normal [Finite G]
       · exact heq
       · haveI := hnc _ hK
         have hPK : P ≤ K := le_trans le_normalizer hNK
-        refine (hK.1 ?_).elim
+        refine (hK.ne_top ?_).elim
         rw [← sup_of_le_right hNK, P.normalizer_sup_eq_top' hPK])
 
 theorem normal_of_normalizerCondition (hnc : NormalizerCondition G) {p : ℕ} [Fact p.Prime]

--- a/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
@@ -210,8 +210,7 @@ submodules equal to the span of a nonzero element of the module. -/
 theorem atom_iff_nonzero_span (W : Submodule K V) :
     IsAtom W ↔ ∃ v ≠ 0, W = span K {v} := by
   refine ⟨fun h => ?_, fun h => ?_⟩
-  · --obtain ⟨hbot, h⟩ := h
-    rcases (Submodule.ne_bot_iff W).1 h.ne_bot with ⟨v, ⟨hW, hv⟩⟩
+  · rcases (Submodule.ne_bot_iff W).1 h.ne_bot with ⟨v, ⟨hW, hv⟩⟩
     refine ⟨v, ⟨hv, ?_⟩⟩
     by_contra! heq
     refine hv (span_singleton_eq_bot.1 (h.isMin_of_lt ?_).eq_bot)

--- a/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
@@ -195,32 +195,27 @@ variable {K V}
 /-- For a module over a division ring, the span of a nonzero element is an atom of the
 lattice of submodules. -/
 theorem nonzero_span_atom (v : V) (hv : v ≠ 0) : IsAtom (span K {v} : Submodule K V) := by
-  constructor
-  · rw [Submodule.ne_bot_iff]
-    exact ⟨v, ⟨mem_span_singleton_self v, hv⟩⟩
-  · intro T hT
-    by_contra h
-    apply hT.2
-    change span K {v} ≤ T
-    simp_rw [span_singleton_le_iff_mem, ← Ne.eq_def, Submodule.ne_bot_iff] at *
-    rcases h with ⟨s, ⟨hs, hz⟩⟩
-    rcases mem_span_singleton.1 (hT.1 hs) with ⟨a, rfl⟩
-    rcases eq_or_ne a 0 with rfl | h
-    · simp only [zero_smul, ne_eq, not_true] at hz
-    · rwa [T.smul_mem_iff h] at hs
+  rw [isAtom_iff_le_of_ge]
+  refine ⟨(Submodule.ne_bot_iff _).2 ⟨v, by simp [hv]⟩, fun T hTe hTv x hxv => ?_⟩
+  rw [Submodule.ne_bot_iff] at hTe
+  obtain ⟨c, hcT, hc0⟩ := hTe
+  obtain ⟨k₁, hk₁⟩ := mem_span_singleton.1 hxv
+  obtain ⟨k₂, hk₂⟩ := mem_span_singleton.1 (hTv hcT)
+  have hk0 : k₂ ≠ 0 := (smul_ne_zero_iff_left hv).1 (hk₂.trans_ne hc0)
+  rw [← hk₁, ← div_mul_cancel₀ k₁ hk0, mul_smul, hk₂]
+  exact smul_mem T (k₁ / k₂) hcT
 
 /-- The atoms of the lattice of submodules of a module over a division ring are the
 submodules equal to the span of a nonzero element of the module. -/
 theorem atom_iff_nonzero_span (W : Submodule K V) :
     IsAtom W ↔ ∃ v ≠ 0, W = span K {v} := by
   refine ⟨fun h => ?_, fun h => ?_⟩
-  · obtain ⟨hbot, h⟩ := h
-    rcases (Submodule.ne_bot_iff W).1 hbot with ⟨v, ⟨hW, hv⟩⟩
+  · --obtain ⟨hbot, h⟩ := h
+    rcases (Submodule.ne_bot_iff W).1 h.ne_bot with ⟨v, ⟨hW, hv⟩⟩
     refine ⟨v, ⟨hv, ?_⟩⟩
-    by_contra heq
-    specialize h (span K {v})
-    rw [span_singleton_eq_bot, lt_iff_le_and_ne] at h
-    exact hv (h ⟨(span_singleton_le_iff_mem v W).2 hW, Ne.symm heq⟩)
+    by_contra! heq
+    refine hv (span_singleton_eq_bot.1 (h.isMin_of_lt ?_).eq_bot)
+    exact lt_of_le_of_ne ((span_singleton_le_iff_mem _ _).2 hW) heq.symm
   · rcases h with ⟨v, ⟨hv, rfl⟩⟩
     exact nonzero_span_atom v hv
 

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -557,7 +557,7 @@ theorem finrank_span_singleton {v : V} (hv : v ≠ 0) : finrank K (K ∙ v) = 1 
 /-- A submodule over a division ring is an atom of the submodule lattice iff it has `finrank` 1. -/
 theorem Submodule.isAtom_iff_finrank_eq_one {S : Submodule K V} :
     IsAtom S ↔ finrank K S = 1 := by
-  refine ⟨fun hS ↦ ?_, fun hS ↦ ⟨by aesop, fun T hT ↦ ?_⟩⟩
+  refine ⟨fun hS ↦ ?_, fun hS ↦ isAtom_iff_le_of_ge.2 ⟨by aesop, fun T hb hT => ?_⟩⟩
   · obtain ⟨v : V, hv : v ∈ S, hv_ne : v ≠ 0⟩ := S.ne_bot_iff.mp hS.ne_bot
     suffices K ∙ v = S by rw [← this, finrank_span_singleton hv_ne]
     have : K ∙ v ≠ ⊥ := by
@@ -565,10 +565,9 @@ theorem Submodule.isAtom_iff_finrank_eq_one {S : Submodule K V} :
       exact ⟨v, mem_span_singleton_self v, hv_ne⟩
     rwa [← hS.le_iff_eq this, span_le, Set.singleton_subset_iff]
   · have : FiniteDimensional K S := .of_finrank_eq_succ hS
-    have : FiniteDimensional K T := .of_injective (inclusion hT.le) (inclusion_injective hT.le)
-    rw [← finrank_eq_zero (R := K)]
-    by_contra h
-    exact hT.ne <| eq_of_le_of_finrank_le hT.le <| by lia
+    have : FiniteDimensional K T := .of_injective (inclusion hT) (inclusion_injective hT)
+    rw [ne_eq, ← finrank_eq_zero (R := K)] at hb
+    exact (eq_of_le_of_finrank_le hT (by lia)).ge
 
 /-- In a one-dimensional space, any vector is a multiple of any nonzero vector -/
 lemma exists_smul_eq_of_finrank_eq_one

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -556,18 +556,17 @@ theorem comap_map_sup_of_comap_le {f : M →ₛₗ[τ₁₂] M₂} {p : Submodul
 
 theorem isCoatom_comap_or_eq_top (f : M →ₛₗ[τ₁₂] M₂) {p : Submodule R₂ M₂} (hp : IsCoatom p) :
     IsCoatom (comap f p) ∨ comap f p = ⊤ :=
-  or_iff_not_imp_right.mpr fun h ↦ ⟨h, fun q lt ↦ by
-    rw [← comap_map_sup_of_comap_le lt.le, hp.2 (map f q ⊔ p), comap_top]
+  or_iff_not_imp_right.mpr fun h ↦ covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 h, fun q lt ↦ by
+    rw [lt_top_iff_ne_top, not_ne_iff, ← comap_map_sup_of_comap_le lt.le, ← comap_top f]
+    refine congrArg (comap f) (hp.isMax_of_gt ?_).eq_top
     simpa only [right_lt_sup, map_le_iff_le_comap] using lt.not_ge⟩
 
 theorem isCoatom_comap_iff {f : M →ₛₗ[τ₁₂] M₂} (hf : Surjective f) {p : Submodule R₂ M₂} :
-    IsCoatom (comap f p) ↔ IsCoatom p := by
-  have := comap_injective_of_surjective hf
-  rw [IsCoatom, IsCoatom, ← comap_top f, this.ne_iff]
-  refine and_congr_right fun _ ↦
-    ⟨fun h m hm ↦ this (h _ <| comap_strictMono_of_surjective hf hm), fun h m hm ↦ ?_⟩
-  rw [← h _ (lt_map_of_comap_lt_of_surjective hf hm),
-    comap_map_eq_self ((comap_mono bot_le).trans hm.le)]
+    IsCoatom (comap f p) ↔ IsCoatom p :=
+  ⟨fun h => ((gc_map_comap f).toGaloisInsertion
+    (fun p => (map_comap_eq_of_surjective hf p).ge)).isCoatom_of_image h,
+    fun h => (isCoatom_comap_or_eq_top f h).resolve_right
+      (((comap_lt_comap_iff_of_surjective hf).2 h.lt_top).trans_eq (comap_top f)).ne⟩
 
 theorem isCoatom_map_of_ker_le {f : M →ₛₗ[τ₁₂] M₂} (hf : Surjective f) {p : Submodule R M}
     (le : LinearMap.ker f ≤ p) (hp : IsCoatom p) : IsCoatom (map f p) :=

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -67,40 +67,75 @@ section IsAtom
 
 section Preorder
 
-variable [Preorder α] [OrderBot α] {a b x : α}
+variable [Preorder α] {a b x : α}
 
-/-- An atom of an `OrderBot` is an element with no other element between it and `⊥`,
-  which is not `⊥`. -/
+/-- An atom is an element with only one element strictly less than it, up to order equivalence.
+When `α` has an `OrderBot`, this is equivalent to the standard definition of
+being a minimal non-bottom element. -/
+@[no_expose]
 def IsAtom (a : α) : Prop :=
-  a ≠ ⊥ ∧ ∀ b, b < a → b = ⊥
+  ∃ b, b ⋖ a ∧ ∀ c, c < a → b ≤ c
 
-theorem IsAtom.Iic (ha : IsAtom a) (hax : a ≤ x) : IsAtom (⟨a, hax⟩ : Set.Iic x) :=
-  ⟨fun con => ha.1 (Subtype.mk_eq_mk.1 con), fun ⟨b, _⟩ hba => Subtype.mk_eq_mk.2 (ha.2 b hba)⟩
+theorem IsAtom.not_isMin (ha : IsAtom a) : ¬IsMin a :=
+  ha.elim fun _ h1 h2 => h2.not_lt h1.1.lt
 
-theorem IsAtom.of_isAtom_coe_Iic {a : Set.Iic x} (ha : IsAtom a) : IsAtom (a : α) :=
-  ⟨fun con => ha.1 (Subtype.ext con), fun b hba =>
-    Subtype.mk_eq_mk.1 (ha.2 ⟨b, hba.le.trans a.prop⟩ hba)⟩
+theorem IsAtom.Iic (ha : IsAtom a) (hax : a ≤ x) : IsAtom (⟨a, hax⟩ : Set.Iic x) := by
+  rcases ha with ⟨b, hba, hbb⟩
+  refine ⟨⟨b, hba.le.trans hax⟩, ?_, fun c hc => hbb c hc⟩
+  rw [covBy_iff_Ioo_eq, Set.eq_empty_iff_forall_notMem] at hba ⊢
+  exact ⟨hba.1, fun c hc => hba.2 c hc⟩
 
-theorem isAtom_iff_le_of_ge : IsAtom a ↔ a ≠ ⊥ ∧ ∀ b ≠ ⊥, b ≤ a → a ≤ b :=
-  and_congr Iff.rfl <|
-    forall_congr' fun b => by
-      simp only [Ne, @not_imp_comm (b = ⊥), Classical.not_imp, lt_iff_le_not_ge]
+theorem IsAtom.of_isAtom_coe_Iic {a : Set.Iic x} (ha : IsAtom a) : IsAtom (a : α) := by
+  rcases ha with ⟨b, hba, hbb⟩
+  refine ⟨b, ?_, fun c hc => hbb ⟨c, hc.le.trans a.2⟩ hc⟩
+  rw [covBy_iff_Ioo_eq, Set.eq_empty_iff_forall_notMem] at hba ⊢
+  exact ⟨hba.1, fun c hc => hba.2 ⟨c, hc.2.le.trans a.2⟩ hc⟩
 
-lemma IsAtom.ne_bot (ha : IsAtom a) : a ≠ ⊥ := ha.1
+theorem IsAtom.isMin_of_lt (ha : IsAtom a) (hx : x < a) : IsMin x := by
+  rcases ha with ⟨b, hba, hbb⟩
+  intro c hc
+  exact (not_lt_iff_le_imp_ge.1 (fun h => hba.2 h hx) (hbb x hx)).trans (hbb c (hc.trans_lt hx))
+
+section OrderBot
+variable [OrderBot α]
+
+lemma IsAtom.bot_lt (ha : IsAtom a) : ⊥ < a :=
+  lt_of_le_not_ge bot_le fun h => ha.not_isMin (isMin_bot.mono h)
+
+lemma IsAtom.ne_bot (ha : IsAtom a) : a ≠ ⊥ :=
+  ha.bot_lt.ne'
+
+@[simp]
+theorem bot_covBy_iff : ⊥ ⋖ a ↔ IsAtom a := by
+  refine ⟨fun h => ⟨⊥, h, fun _ _ => bot_le⟩, fun h => ⟨h.bot_lt, fun x hxb hxa => ?_⟩⟩
+  obtain ⟨b, hba, hbb⟩ := h
+  exact hba.2 ((hbb ⊥ (hxb.trans hxa)).trans_lt hxb) hxa
+
+alias ⟨CovBy.isAtom, IsAtom.bot_covBy⟩ := bot_covBy_iff
+
+@[deprecated (since := "2026-06-06")]
+alias CovBy.is_atom := CovBy.isAtom
+
+end OrderBot
 
 end Preorder
 
 section PartialOrder
 
-variable [PartialOrder α] [OrderBot α] {a b x : α}
+variable [PartialOrder α] {a b x : α}
+
+section OrderBot
+variable [OrderBot α]
+
+theorem isAtom_iff_le_of_ge : IsAtom a ↔ a ≠ ⊥ ∧ ∀ b ≠ ⊥, b ≤ a → a ≤ b := by
+  rw [← bot_covBy_iff, covBy_iff_Ioo_eq, bot_lt_iff_ne_bot, Set.eq_empty_iff_forall_notMem]
+  refine and_congr_right fun ha => forall_congr' fun b => ?_
+  rw [Set.mem_Ioo, not_and, not_lt_iff_le_imp_ge, bot_lt_iff_ne_bot]
 
 theorem IsAtom.lt_iff (h : IsAtom a) : x < a ↔ x = ⊥ :=
-  ⟨h.2 x, fun hx => hx.symm ▸ h.1.bot_lt⟩
+  ⟨fun hx => (h.isMin_of_lt hx).eq_bot, fun hx => hx.symm ▸ h.bot_lt⟩
 
 theorem IsAtom.le_iff (h : IsAtom a) : x ≤ a ↔ x = ⊥ ∨ x = a := by rw [le_iff_lt_or_eq, h.lt_iff]
-
-lemma IsAtom.bot_lt (h : IsAtom a) : ⊥ < a :=
-  h.lt_iff.mpr rfl
 
 lemma IsAtom.le_iff_eq (ha : IsAtom a) (hb : b ≠ ⊥) : b ≤ a ↔ b = a :=
   ha.le_iff.trans <| or_iff_right hb
@@ -115,11 +150,7 @@ lemma IsAtom.ne_bot_iff_eq (ha : IsAtom a) (hba : b ≤ a) : b ≠ ⊥ ↔ b = a
 theorem IsAtom.Iic_eq (h : IsAtom a) : Set.Iic a = {⊥, a} :=
   Set.ext fun _ => h.le_iff
 
-@[simp]
-theorem bot_covBy_iff : ⊥ ⋖ a ↔ IsAtom a := by
-  simp only [CovBy, bot_lt_iff_ne_bot, IsAtom, not_imp_not]
-
-alias ⟨CovBy.is_atom, IsAtom.bot_covBy⟩ := bot_covBy_iff
+end OrderBot
 
 end PartialOrder
 
@@ -134,9 +165,8 @@ protected lemma IsAtom.le_iSup (ha : IsAtom a) : a ≤ iSup f ↔ ∃ i, a ≤ f
   have ha'' : Disjoint a (⨆ i, f i) :=
     disjoint_iSup_iff.2 fun i => fun x hxa hxf => le_bot_iff.2 <| of_not_not fun hx =>
       have hxa : x < a := (le_iff_eq_or_lt.1 hxa).resolve_left (by rintro rfl; exact ha' _ hxf)
-      hx (ha.2 _ hxa)
-  obtain rfl := le_bot_iff.1 (ha'' le_rfl h)
-  exact ha.1 rfl
+      hx (ha.lt_iff.1 hxa)
+  exact ha.ne_bot (le_bot_iff.1 (ha'' le_rfl h))
 
 protected lemma IsAtom.le_sSup (ha : IsAtom a) : a ≤ sSup s ↔ ∃ b ∈ s, a ≤ b := by
   simp [sSup_eq_iSup', ha.le_iSup]
@@ -150,52 +180,78 @@ section Preorder
 
 variable [Preorder α]
 
-/-- A coatom of an `OrderTop` is an element with no other element between it and `⊤`,
-  which is not `⊤`. -/
-def IsCoatom [OrderTop α] (a : α) : Prop :=
-  a ≠ ⊤ ∧ ∀ b, a < b → b = ⊤
+/-- A coatom is an element with only one element strictly greater than it, up to order equivalence.
+When `α` has an `OrderTop`, this is equivalent to the standard definition of
+being a maximal non-top element. -/
+@[no_expose]
+def IsCoatom (a : α) : Prop :=
+  ∃ b, a ⋖ b ∧ ∀ c, a < c → c ≤ b
 
 @[simp]
-theorem isCoatom_dual_iff_isAtom [OrderBot α] {a : α} :
-    IsCoatom (OrderDual.toDual a) ↔ IsAtom a :=
-  Iff.rfl
+theorem isCoatom_dual_iff_isAtom {a : α} :
+    IsCoatom (OrderDual.toDual a) ↔ IsAtom a := by
+  unfold IsAtom IsCoatom
+  simp
 
 @[simp]
-theorem isAtom_dual_iff_isCoatom [OrderTop α] {a : α} :
-    IsAtom (OrderDual.toDual a) ↔ IsCoatom a :=
-  Iff.rfl
+theorem isAtom_dual_iff_isCoatom {a : α} :
+    IsAtom (OrderDual.toDual a) ↔ IsCoatom a := by
+  unfold IsAtom IsCoatom
+  simp
 
 alias ⟨_, IsAtom.dual⟩ := isCoatom_dual_iff_isAtom
 
 alias ⟨_, IsCoatom.dual⟩ := isAtom_dual_iff_isCoatom
 
-variable [OrderTop α] {a x : α}
+variable {a b x : α}
+
+theorem IsCoatom.not_isMax (ha : IsCoatom a) : ¬IsMax a :=
+  ha.dual.not_isMin
 
 theorem IsCoatom.Ici (ha : IsCoatom a) (hax : x ≤ a) : IsCoatom (⟨a, hax⟩ : Set.Ici x) :=
-  ha.dual.Iic hax
+  (ha.dual.Iic hax).dual
 
 theorem IsCoatom.of_isCoatom_coe_Ici {a : Set.Ici x} (ha : IsCoatom a) : IsCoatom (a : α) :=
-  @IsAtom.of_isAtom_coe_Iic αᵒᵈ _ _ x a ha
+  (@IsAtom.of_isAtom_coe_Iic αᵒᵈ _ x a ha.dual).dual
 
-theorem isCoatom_iff_ge_of_le : IsCoatom a ↔ a ≠ ⊤ ∧ ∀ b ≠ ⊤, a ≤ b → b ≤ a :=
-  isAtom_iff_le_of_ge (α := αᵒᵈ)
+theorem IsCoatom.isMax_of_gt (ha : IsCoatom a) (hx : a < x) : IsMax x :=
+  ha.dual.isMin_of_lt hx
 
-lemma IsCoatom.ne_top (ha : IsCoatom a) : a ≠ ⊤ := ha.1
+section OrderTop
+variable [OrderTop α]
+
+lemma IsCoatom.lt_top (ha : IsCoatom a) : a < ⊤ :=
+  ha.dual.bot_lt
+
+lemma IsCoatom.ne_top (ha : IsCoatom a) : a ≠ ⊤ :=
+  ha.lt_top.ne
+
+@[simp]
+theorem covBy_top_iff : a ⋖ ⊤ ↔ IsCoatom a :=
+  (toDual_covBy_toDual_iff.symm.trans
+    (@bot_covBy_iff αᵒᵈ _ a _)).trans isAtom_dual_iff_isCoatom
+
+alias ⟨CovBy.isCoatom, IsCoatom.covBy_top⟩ := covBy_top_iff
+
+end OrderTop
 
 end Preorder
 
 section PartialOrder
 
-variable [PartialOrder α] [OrderTop α] {a b x : α}
+variable [PartialOrder α] {a b x : α}
+
+section OrderTop
+variable [OrderTop α]
+
+theorem isCoatom_iff_ge_of_le : IsCoatom a ↔ a ≠ ⊤ ∧ ∀ b ≠ ⊤, a ≤ b → b ≤ a :=
+  isAtom_dual_iff_isCoatom.symm.trans (isAtom_iff_le_of_ge (α := αᵒᵈ))
 
 theorem IsCoatom.lt_iff (h : IsCoatom a) : a < x ↔ x = ⊤ :=
   h.dual.lt_iff
 
 theorem IsCoatom.le_iff (h : IsCoatom a) : a ≤ x ↔ x = ⊤ ∨ x = a :=
   h.dual.le_iff
-
-lemma IsCoatom.lt_top (h : IsCoatom a) : a < ⊤ :=
-  h.lt_iff.mpr rfl
 
 lemma IsCoatom.le_iff_eq (ha : IsCoatom a) (hb : b ≠ ⊤) : a ≤ b ↔ b = a := ha.dual.le_iff_eq hb
 
@@ -209,11 +265,22 @@ lemma IsCoatom.ne_top_iff_eq (ha : IsCoatom a) (hab : a ≤ b) : b ≠ ⊤ ↔ b
 theorem IsCoatom.Ici_eq (h : IsCoatom a) : Set.Ici a = {⊤, a} :=
   h.dual.Iic_eq
 
-@[simp]
-theorem covBy_top_iff : a ⋖ ⊤ ↔ IsCoatom a :=
-  toDual_covBy_toDual_iff.symm.trans bot_covBy_iff
+end OrderTop
 
-alias ⟨CovBy.isCoatom, IsCoatom.covBy_top⟩ := covBy_top_iff
+end PartialOrder
+
+section Coframe
+variable [Coframe α] {f : ι → α} {s : Set α} {a : α}
+
+protected lemma IsCoatom.iInf_le (ha : IsCoatom a) : iInf f ≤ a ↔ ∃ i, f i ≤ a :=
+  IsAtom.le_iSup (α := αᵒᵈ) ha.dual
+
+protected lemma IsCoatom.sInf_le (ha : IsCoatom a) : sInf s ≤ a ↔ ∃ b ∈ s, b ≤ a := by
+  simp [sInf_eq_iInf', ha.iInf_le]
+
+end Coframe
+
+end IsCoatom
 
 namespace SetLike
 
@@ -221,13 +288,19 @@ variable {A B : Type*} [PartialOrder A] [SetLike A B] [IsConcreteLE A B]
 
 theorem isAtom_iff [OrderBot A] {K : A} :
     IsAtom K ↔ K ≠ ⊥ ∧ ∀ H g, H ≤ K → g ∉ H → g ∈ K → H = ⊥ := by
-  simp_rw [IsAtom, lt_iff_le_not_ge, SetLike.not_le_iff_exists,
-    and_comm (a := _ ≤ _), and_imp, exists_imp, ← and_imp, and_comm]
+  rw [← bot_covBy_iff, covBy_iff_Ioo_eq, bot_lt_iff_ne_bot, Set.eq_empty_iff_forall_notMem]
+  refine and_congr_right fun hK => forall_congr' fun x => ?_
+  rw [Set.mem_Ioo, and_comm, not_and, bot_lt_iff_ne_bot, not_ne_iff, SetLike.lt_iff_le_and_exists]
+  simp_rw [and_imp, exists_imp, and_imp]
+  exact ⟨fun h hxK g hgK hgx => h g hxK hgx hgK, fun h g hxK hgx hgK => h hxK g hgK hgx⟩
 
 theorem isCoatom_iff [OrderTop A] {K : A} :
     IsCoatom K ↔ K ≠ ⊤ ∧ ∀ H g, K ≤ H → g ∉ K → g ∈ H → H = ⊤ := by
-  simp_rw [IsCoatom, lt_iff_le_not_ge, SetLike.not_le_iff_exists,
-    and_comm (a := _ ≤ _), and_imp, exists_imp, ← and_imp, and_comm]
+  rw [← covBy_top_iff, covBy_iff_Ioo_eq, lt_top_iff_ne_top, Set.eq_empty_iff_forall_notMem]
+  refine and_congr_right fun hK => forall_congr' fun x => ?_
+  rw [Set.mem_Ioo, not_and, lt_top_iff_ne_top, not_ne_iff, SetLike.lt_iff_le_and_exists]
+  simp_rw [and_imp, exists_imp, and_imp]
+  exact ⟨fun h hxK g hgK hgx => h g hxK hgx hgK, fun h g hxK hgx hgK => h hxK g hgK hgx⟩
 
 theorem covBy_iff {K L : A} :
     K ⋖ L ↔ K < L ∧ ∀ H g, K ≤ H → H ≤ L → g ∉ K → g ∈ H → H = L := by
@@ -248,23 +321,9 @@ theorem covBy_iff' {K L : A} :
 
 end SetLike
 
-end PartialOrder
+section Preorder
 
-section Coframe
-variable [Coframe α] {f : ι → α} {s : Set α} {a : α}
-
-protected lemma IsCoatom.iInf_le (ha : IsCoatom a) : iInf f ≤ a ↔ ∃ i, f i ≤ a :=
-  IsAtom.le_iSup (α := αᵒᵈ) ha
-
-protected lemma IsCoatom.sInf_le (ha : IsCoatom a) : sInf s ≤ a ↔ ∃ b ∈ s, b ≤ a := by
-  simp [sInf_eq_iInf', ha.iInf_le]
-
-end Coframe
-end IsCoatom
-
-section PartialOrder
-
-variable [PartialOrder α] {a b : α}
+variable [Preorder α] {a b : α}
 
 @[simp]
 theorem Set.Ici.isAtom_iff {b : Set.Ici a} : IsAtom b ↔ a ⋖ b := by
@@ -282,13 +341,22 @@ theorem covBy_iff_atom_Ici (h : a ≤ b) : a ⋖ b ↔ IsAtom (⟨b, h⟩ : Set.
 
 theorem covBy_iff_coatom_Iic (h : a ≤ b) : a ⋖ b ↔ IsCoatom (⟨a, h⟩ : Set.Iic b) := by simp
 
-end PartialOrder
+end Preorder
 
-section SemilatticeInf
-variable [SemilatticeInf α] [OrderBot α] {a b : α}
+section PartialOrder
+variable [PartialOrder α] [OrderBot α] {a b : α}
 
 lemma IsAtom.not_disjoint_iff_le (ha : IsAtom a) : ¬ Disjoint a b ↔ a ≤ b := by
-  rw [disjoint_iff, ← inf_eq_left]; exact ha.ne_bot_iff_eq inf_le_left
+  refine ⟨fun h => ?_, fun h₁ h₂ => ?_⟩
+  · unfold Disjoint at h
+    push Not at h
+    obtain ⟨c, hca, hcb, hck⟩ := h
+    obtain rfl | rfl := ha.le_iff.1 hca
+    · simp at hck
+    · exact hcb
+  · apply ha.not_isMin
+    rw [h₂.eq_bot_of_le h₁]
+    exact isMin_bot
 
 lemma IsAtom.not_le_iff_disjoint (ha : IsAtom a) : ¬ a ≤ b ↔ Disjoint a b :=
   ha.not_disjoint_iff_le.not_right.symm
@@ -296,13 +364,22 @@ lemma IsAtom.not_le_iff_disjoint (ha : IsAtom a) : ¬ a ≤ b ↔ Disjoint a b :
 lemma IsAtom.disjoint_of_ne (ha : IsAtom a) (hb : IsAtom b) (hab : a ≠ b) : Disjoint a b := by
   simp [← ha.not_le_iff_disjoint, hb.le_iff, hab, ha.ne_bot]
 
-end SemilatticeInf
+end PartialOrder
 
-section SemilatticeSup
-variable [SemilatticeSup α] [OrderTop α] {a b : α}
+section PartialOrder
+variable [PartialOrder α] [OrderTop α] {a b : α}
 
 lemma IsCoatom.not_codisjoint_iff_le (ha : IsCoatom a) : ¬ Codisjoint a b ↔ b ≤ a := by
-  rw [codisjoint_iff, ← sup_eq_left]; exact ha.ne_top_iff_eq le_sup_left
+  refine ⟨fun h => ?_, fun h₁ h₂ => ?_⟩
+  · unfold Codisjoint at h
+    push Not at h
+    obtain ⟨c, hca, hcb, hck⟩ := h
+    obtain rfl | rfl := ha.le_iff.1 hca
+    · simp at hck
+    · exact hcb
+  · apply ha.not_isMax
+    rw [h₂.eq_top_of_le h₁]
+    exact isMax_top
 
 lemma IsCoatom.not_le_iff_codisjoint (ha : IsCoatom a) : ¬ b ≤ a ↔ Codisjoint a b :=
   ha.not_codisjoint_iff_le.not_right.symm
@@ -310,6 +387,11 @@ lemma IsCoatom.not_le_iff_codisjoint (ha : IsCoatom a) : ¬ b ≤ a ↔ Codisjoi
 lemma IsCoatom.codisjoint_of_ne (ha : IsCoatom a) (hb : IsCoatom b) (hab : a ≠ b) :
     Codisjoint a b := by
   simp [← ha.not_le_iff_codisjoint, hb.le_iff, hab, ha.ne_top]
+
+end PartialOrder
+
+section SemilatticeSup
+variable [SemilatticeSup α] [OrderTop α] {a b : α}
 
 theorem IsCoatom.sup_eq_top_of_ne (ha : IsCoatom a) (hb : IsCoatom b) (hab : a ≠ b) : a ⊔ b = ⊤ :=
   codisjoint_iff.1 <| ha.codisjoint_of_ne hb hab
@@ -352,13 +434,15 @@ variable {α}
 
 @[simp]
 theorem isCoatomic_dual_iff_isAtomic [OrderBot α] : IsCoatomic αᵒᵈ ↔ IsAtomic α :=
-  ⟨fun h => ⟨fun b => by apply h.eq_top_or_exists_le_coatom⟩, fun h =>
-    ⟨fun b => by apply h.eq_bot_or_exists_atom_le⟩⟩
+  ⟨fun h => ⟨fun b => (h.eq_top_or_exists_le_coatom (.toDual b)).imp (by simp) (by simp)⟩,
+    fun h => ⟨fun b => (h.eq_bot_or_exists_atom_le b.ofDual).imp (by simp)
+      (by simp [OrderDual.le_toDual])⟩⟩
 
 @[simp]
 theorem isAtomic_dual_iff_isCoatomic [OrderTop α] : IsAtomic αᵒᵈ ↔ IsCoatomic α :=
-  ⟨fun h => ⟨fun b => by apply h.eq_bot_or_exists_atom_le⟩, fun h =>
-    ⟨fun b => by apply h.eq_top_or_exists_le_coatom⟩⟩
+  ⟨fun h => ⟨fun b => (h.eq_bot_or_exists_atom_le (.toDual b)).imp (by simp) (by simp)⟩,
+    fun h => ⟨fun b => (h.eq_top_or_exists_le_coatom b.ofDual).imp (by simp)
+      (by simp [OrderDual.toDual_le])⟩⟩
 
 namespace IsAtomic
 
@@ -523,7 +607,7 @@ theorem le_iff_atom_le_imp {α} [BooleanAlgebra α] [IsAtomic α] {x y : α} :
     have ⟨hx, hy'⟩ := le_inf_iff.1 hle
     have hy := h a ha hx
     have : a ≤ y ⊓ yᶜ := le_inf_iff.2 ⟨hy, hy'⟩
-    ha.1 (by simpa using this)
+    ha.ne_bot (by simpa using this)
   exact (eq_compl_iff_isCompl.1 (by simp)).inf_right_eq_bot_iff.1 this
 
 theorem eq_iff_atom_le_iff {α} [BooleanAlgebra α] [IsAtomic α] {x y : α} :
@@ -574,11 +658,13 @@ variable {α}
 
 @[simp]
 theorem isCoatomistic_dual_iff_isAtomistic [OrderBot α] : IsCoatomistic αᵒᵈ ↔ IsAtomistic α :=
-  ⟨fun h => ⟨fun b => by apply h.isGLB_coatoms⟩, fun h => ⟨fun b => by apply h.isLUB_atoms⟩⟩
+  ⟨fun h => ⟨fun b => (h.isGLB_coatoms b).imp fun _ hs => ⟨hs.1, fun a ha => (hs.2 a ha).dual⟩⟩,
+    fun h => ⟨fun b => (h.isLUB_atoms b).imp fun _ hs => ⟨hs.1, fun a ha => (hs.2 a ha).dual⟩⟩⟩
 
 @[simp]
 theorem isAtomistic_dual_iff_isCoatomistic [OrderTop α] : IsAtomistic αᵒᵈ ↔ IsCoatomistic α :=
-  ⟨fun h => ⟨fun b => by apply h.isLUB_atoms⟩, fun h => ⟨fun b => by apply h.isGLB_coatoms⟩⟩
+  ⟨fun h => ⟨fun b => (h.isLUB_atoms b).imp fun _ hs => ⟨hs.1, fun a ha => (hs.2 a ha).dual⟩⟩,
+    fun h => ⟨fun b => (h.isGLB_coatoms b).imp fun _ hs => ⟨hs.1, fun a ha => (hs.2 a ha).dual⟩⟩⟩
 
 namespace IsAtomistic
 
@@ -677,11 +763,14 @@ instance {α} [CompleteAtomicBooleanAlgebra α] : IsAtomistic α :=
     rw [← this]; clear this
     simp_rw [iInf_iSup_eq, iSup_le_iff]; intro g
     if h : (⨅ a, b ⊓ cond (g a) a (aᶜ)) = ⊥ then simp [h] else
-    refine le_sSup ⟨⟨h, fun c hc => ?_⟩, le_trans (by rfl) (le_iSup _ g)⟩; clear h
+    refine le_sSup ⟨⟨⊥, ⟨bot_lt_iff_ne_bot.2 h, fun c hcb hc => ?_⟩, fun _ _ => bot_le⟩,
+      le_trans (by rfl) (le_iSup _ g)⟩; clear h
     have := lt_of_lt_of_le hc (le_trans (iInf_le _ c) inf_le_right)
     revert this
     nontriviality α
-    cases g c <;> simp
+    cases g c with
+    | false => simpa [bot_lt_iff_ne_bot] using hcb
+    | true => simp
 
 instance {α} [CompleteAtomicBooleanAlgebra α] : IsCoatomistic α :=
   isAtomistic_dual_iff_isCoatomistic.1 inferInstance
@@ -697,8 +786,8 @@ lemma eq_setOf_le_sSup_and_isAtom {α} [CompleteAtomicBooleanAlgebra α] {S : Se
   refine ⟨fun h => ⟨le_sSup h, hS a h⟩, fun ⟨hale, hatom⟩ => ?_⟩
   obtain ⟨b, hbS, hba⟩ := (IsAtom.le_sSup hatom).mp hale
   obtain rfl | rfl := (hS b hbS).le_iff.mp hba
-  · simpa using hatom.1
-  assumption
+  · simpa using hatom.ne_bot
+  exact hbS
 
 /--
 Representation theorem for complete atomic boolean algebras:
@@ -787,18 +876,18 @@ protected def IsSimpleOrder.linearOrder [DecidableEq α] : LinearOrder α :=
     toDecidableEq := ‹_› }
 
 theorem isAtom_top : IsAtom (⊤ : α) :=
-  ⟨top_ne_bot, fun a ha => Or.resolve_right (eq_bot_or_eq_top a) (ne_of_lt ha)⟩
+  bot_covBy_iff.1 ⟨bot_lt_top, fun c => by obtain rfl | rfl := eq_bot_or_eq_top c <;> simp⟩
 
 @[simp]
 theorem isAtom_iff_eq_top {a : α} : IsAtom a ↔ a = ⊤ :=
-  ⟨fun h ↦ (eq_bot_or_eq_top a).resolve_left h.1, (· ▸ isAtom_top)⟩
+  ⟨fun h ↦ (eq_bot_or_eq_top a).resolve_left h.ne_bot, (· ▸ isAtom_top)⟩
 
 theorem isCoatom_bot : IsCoatom (⊥ : α) :=
   isAtom_dual_iff_isCoatom.1 isAtom_top
 
 @[simp]
 theorem isCoatom_iff_eq_bot {a : α} : IsCoatom a ↔ a = ⊥ :=
-  ⟨fun h ↦ (eq_bot_or_eq_top a).resolve_right h.1, (· ▸ isCoatom_bot)⟩
+  ⟨fun h ↦ (eq_bot_or_eq_top a).resolve_right h.ne_top, (· ▸ isCoatom_bot)⟩
 
 theorem bot_covBy_top : (⊥ : α) ⋖ ⊤ :=
   isAtom_top.bot_covBy
@@ -954,34 +1043,31 @@ end IsSimpleOrder
 theorem isSimpleOrder_iff_isAtom_top [PartialOrder α] [BoundedOrder α] :
     IsSimpleOrder α ↔ IsAtom (⊤ : α) :=
   ⟨fun h => @isAtom_top _ _ _ h, fun h =>
-    { exists_pair_ne := ⟨⊤, ⊥, h.1⟩
-      eq_bot_or_eq_top := fun a => ((eq_or_lt_of_le le_top).imp_right (h.2 a)).symm }⟩
+    { exists_pair_ne := ⟨⊤, ⊥, h.ne_bot⟩
+      eq_bot_or_eq_top _ := h.bot_covBy.eq_or_eq bot_le le_top }⟩
 
 theorem isSimpleOrder_iff_isCoatom_bot [PartialOrder α] [BoundedOrder α] :
     IsSimpleOrder α ↔ IsCoatom (⊥ : α) :=
-  isSimpleOrder_iff_isSimpleOrder_orderDual.trans isSimpleOrder_iff_isAtom_top
+  (isSimpleOrder_iff_isSimpleOrder_orderDual.trans
+    isSimpleOrder_iff_isAtom_top).trans isAtom_dual_iff_isCoatom
 
 namespace Set
 
 theorem isSimpleOrder_Iic_iff_isAtom [PartialOrder α] [OrderBot α] {a : α} :
-    IsSimpleOrder (Iic a) ↔ IsAtom a :=
-  isSimpleOrder_iff_isAtom_top.trans <|
-    and_congr (not_congr Subtype.mk_eq_mk)
-      ⟨fun h b ab => Subtype.mk_eq_mk.1 (h ⟨b, le_of_lt ab⟩ ab), fun h ⟨b, _⟩ hbotb =>
-        Subtype.mk_eq_mk.2 (h b (Subtype.mk_lt_mk.1 hbotb))⟩
+    IsSimpleOrder (Iic a) ↔ IsAtom a := by
+  rw [isSimpleOrder_iff_isAtom_top, ← Set.Iic.coe_top a]
+  exact ⟨IsAtom.of_isAtom_coe_Iic, fun h => h.Iic _⟩
 
 theorem isSimpleOrder_Ici_iff_isCoatom [PartialOrder α] [OrderTop α] {a : α} :
-    IsSimpleOrder (Ici a) ↔ IsCoatom a :=
-  isSimpleOrder_iff_isCoatom_bot.trans <|
-    and_congr (not_congr Subtype.mk_eq_mk)
-      ⟨fun h b ab => Subtype.mk_eq_mk.1 (h ⟨b, le_of_lt ab⟩ ab), fun h ⟨b, _⟩ hbotb =>
-        Subtype.mk_eq_mk.2 (h b (Subtype.mk_lt_mk.1 hbotb))⟩
+    IsSimpleOrder (Ici a) ↔ IsCoatom a := by
+  rw [isSimpleOrder_iff_isCoatom_bot, ← Set.Ici.coe_bot a]
+  exact ⟨IsCoatom.of_isCoatom_coe_Ici, fun h => h.Ici _⟩
 
 end Set
 
 namespace OrderEmbedding
 
-variable [PartialOrder α] [PartialOrder β]
+variable [Preorder α] [Preorder β]
 
 theorem isAtom_of_map_bot_of_image [OrderBot α] [OrderBot β] (f : β ↪o α) (hbot : f ⊥ = ⊥) {b : β}
     (hb : IsAtom (f b)) : IsAtom b := by
@@ -990,7 +1076,7 @@ theorem isAtom_of_map_bot_of_image [OrderBot α] [OrderBot β] (f : β ↪o α) 
 
 theorem isCoatom_of_map_top_of_image [OrderTop α] [OrderTop β] (f : β ↪o α) (htop : f ⊤ = ⊤)
     {b : β} (hb : IsCoatom (f b)) : IsCoatom b :=
-  f.dual.isAtom_of_map_bot_of_image htop hb
+  (f.dual.isAtom_of_map_bot_of_image htop hb.dual).dual
 
 end OrderEmbedding
 
@@ -1008,14 +1094,15 @@ theorem isAtom_iff [OrderBot α] [IsAtomic α] [OrderBot β] {l : α → β} {u 
     IsAtom (l a) ↔ IsAtom a := by
   refine ⟨fun hla => ?_, fun ha => gi.isAtom_of_u_bot hbot ((h_atom a ha).symm ▸ ha)⟩
   obtain ⟨a', ha', hab'⟩ :=
-    (eq_bot_or_exists_atom_le (u (l a))).resolve_left (hbot ▸ fun h => hla.1 (gi.u_injective h))
+    (eq_bot_or_exists_atom_le (u (l a))).resolve_left
+      (hbot ▸ fun h => hla.ne_bot (gi.u_injective h))
   have :=
     (hla.le_iff.mp <| (gi.l_u_eq (l a) ▸ gi.gc.monotone_l hab' : l a' ≤ l a)).resolve_left fun h =>
-      ha'.1 (hbot ▸ h_atom a' ha' ▸ congr_arg u h)
+      ha'.ne_bot (hbot ▸ h_atom a' ha' ▸ congr_arg u h)
   have haa' : a = a' :=
     (ha'.le_iff.mp <|
           (gi.gc.le_u_l a).trans_eq (h_atom a' ha' ▸ congr_arg u this.symm)).resolve_left
-      (mt (congr_arg l) (gi.gc.l_bot.symm ▸ hla.1))
+      (mt (congr_arg l) (gi.gc.l_bot.symm ▸ hla.ne_bot))
   exact haa'.symm ▸ ha'
 
 theorem isAtom_iff' [OrderBot α] [IsAtomic α] [OrderBot β] {l : α → β} {u : β → α}
@@ -1033,10 +1120,10 @@ theorem isCoatom_iff [OrderTop α] [IsCoatomic α] [OrderTop β] {l : α → β}
   refine ⟨fun hb => gi.isCoatom_of_image hb, fun hb => ?_⟩
   obtain ⟨a, ha, hab⟩ :=
     (eq_top_or_exists_le_coatom (u b)).resolve_left fun h =>
-      hb.1 <| (gi.gc.u_top ▸ gi.l_u_eq ⊤ : l ⊤ = ⊤) ▸ gi.l_u_eq b ▸ congr_arg l h
+      hb.ne_top <| (gi.gc.u_top ▸ gi.l_u_eq ⊤ : l ⊤ = ⊤) ▸ gi.l_u_eq b ▸ congr_arg l h
   have : l a = b :=
     (hb.le_iff.mp (gi.l_u_eq b ▸ gi.gc.monotone_l hab : b ≤ l a)).resolve_left fun hla =>
-      ha.1 (gi.gc.u_top ▸ h_coatom a ha ▸ congr_arg u hla)
+      ha.ne_top (gi.gc.u_top ▸ h_coatom a ha ▸ congr_arg u hla)
   exact this ▸ (h_coatom a ha).symm ▸ ha
 
 end GaloisInsertion
@@ -1047,26 +1134,32 @@ variable [PartialOrder α] [PartialOrder β]
 
 theorem isCoatom_of_l_top [OrderTop α] [OrderTop β] {l : α → β} {u : β → α}
     (gi : GaloisCoinsertion l u) (hbot : l ⊤ = ⊤) {a : α} (hb : IsCoatom (l a)) : IsCoatom a :=
-  gi.dual.isAtom_of_u_bot hbot hb.dual
+  (gi.dual.isAtom_of_u_bot hbot hb.dual).dual
 
 theorem isCoatom_iff [OrderTop α] [OrderTop β] [IsCoatomic β] {l : α → β} {u : β → α}
     (gi : GaloisCoinsertion l u) (htop : l ⊤ = ⊤) (h_coatom : ∀ b, IsCoatom b → l (u b) = b)
     (b : β) : IsCoatom (u b) ↔ IsCoatom b :=
-  gi.dual.isAtom_iff htop h_coatom b
+  (isAtom_dual_iff_isCoatom.symm.trans
+    (gi.dual.isAtom_iff htop (fun b hb => h_coatom (OrderDual.toDual b) hb.dual) b)).trans
+    isAtom_dual_iff_isCoatom
 
 theorem isCoatom_iff' [OrderTop α] [OrderTop β] [IsCoatomic β] {l : α → β} {u : β → α}
     (gi : GaloisCoinsertion l u) (htop : l ⊤ = ⊤) (h_coatom : ∀ b, IsCoatom b → l (u b) = b)
     (a : α) : IsCoatom (l a) ↔ IsCoatom a :=
-  gi.dual.isAtom_iff' htop h_coatom a
+  (isAtom_dual_iff_isCoatom.symm.trans
+    (gi.dual.isAtom_iff' htop (fun b hb => h_coatom (OrderDual.toDual b) hb.dual) a)).trans
+    isAtom_dual_iff_isCoatom
 
 theorem isAtom_of_image [OrderBot α] [OrderBot β] {l : α → β} {u : β → α}
     (gi : GaloisCoinsertion l u) {a : α} (hb : IsAtom (l a)) : IsAtom a :=
-  gi.dual.isCoatom_of_image hb.dual
+  (gi.dual.isCoatom_of_image hb.dual).dual
 
 theorem isAtom_iff [OrderBot α] [OrderBot β] [IsAtomic β] {l : α → β} {u : β → α}
     (gi : GaloisCoinsertion l u) (h_atom : ∀ b, IsAtom b → l (u b) = b) (a : α) :
     IsAtom (l a) ↔ IsAtom a :=
-  gi.dual.isCoatom_iff h_atom a
+  (isCoatom_dual_iff_isAtom.symm.trans
+    (gi.dual.isCoatom_iff (fun b hb => h_atom (OrderDual.toDual b) hb.dual) a)).trans
+    isCoatom_dual_iff_isAtom
 
 end GaloisCoinsertion
 
@@ -1082,7 +1175,7 @@ theorem isAtom_iff [OrderBot α] [OrderBot β] (f : α ≃o β) (a : α) : IsAto
 @[simp]
 theorem isCoatom_iff [OrderTop α] [OrderTop β] (f : α ≃o β) (a : α) :
     IsCoatom (f a) ↔ IsCoatom a :=
-  f.dual.isAtom_iff a
+  isAtom_dual_iff_isCoatom.symm.trans <| (f.dual.isAtom_iff a).trans isAtom_dual_iff_isCoatom
 
 theorem isSimpleOrder_iff [BoundedOrder α] [BoundedOrder β] (f : α ≃o β) :
     IsSimpleOrder α ↔ IsSimpleOrder β := by
@@ -1282,7 +1375,7 @@ end BooleanAlgebra
 namespace Set
 
 theorem isAtom_singleton (x : α) : IsAtom ({x} : Set α) :=
-  ⟨singleton_ne_empty _, fun _ hs => ssubset_singleton_iff.mp hs⟩
+  ⟨∅, by simp⟩
 
 theorem isAtom_iff {s : Set α} : IsAtom s ↔ ∃ x, s = {x} := by
   refine

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -105,7 +105,6 @@ lemma IsAtom.bot_lt (ha : IsAtom a) : ⊥ < a :=
 lemma IsAtom.ne_bot (ha : IsAtom a) : a ≠ ⊥ :=
   ha.bot_lt.ne'
 
-@[simp]
 theorem bot_covBy_iff : ⊥ ⋖ a ↔ IsAtom a := by
   refine ⟨fun h => ⟨⊥, h, fun _ _ => bot_le⟩, fun h => ⟨h.bot_lt, fun x hxb hxa => ?_⟩⟩
   obtain ⟨b, hba, hbb⟩ := h
@@ -226,7 +225,6 @@ lemma IsCoatom.lt_top (ha : IsCoatom a) : a < ⊤ :=
 lemma IsCoatom.ne_top (ha : IsCoatom a) : a ≠ ⊤ :=
   ha.lt_top.ne
 
-@[simp]
 theorem covBy_top_iff : a ⋖ ⊤ ↔ IsCoatom a :=
   (toDual_covBy_toDual_iff.symm.trans
     (@bot_covBy_iff αᵒᵈ _ a _)).trans isAtom_dual_iff_isCoatom

--- a/Mathlib/Order/BooleanGenerators.lean
+++ b/Mathlib/Order/BooleanGenerators.lean
@@ -113,11 +113,11 @@ lemma mem_of_isAtom_of_le_sSup_atoms (hS : BooleanGenerators S) (a : α) (ha : I
   obtain ⟨T, hT, rfl⟩ := hS.atomistic a haS
   obtain rfl | ⟨a, haT⟩ := T.eq_empty_or_nonempty
   · simp only [sSup_empty] at ha
-    exact (ha.1 rfl).elim
+    exact (ha.ne_bot rfl).elim
   suffices sSup T = a from this ▸ hT haT
   have : a ≤ sSup T := le_sSup haT
   rwa [ha.le_iff_eq, eq_comm] at this
-  exact (hS.isAtom a (hT haT)).1
+  exact (hS.isAtom a (hT haT)).ne_bot
 
 lemma sSup_inter (hS : BooleanGenerators S) {T₁ T₂ : Set α} (hT₁ : T₁ ⊆ S) (hT₂ : T₂ ⊆ S) :
     sSup (T₁ ∩ T₂) = (sSup T₁) ⊓ (sSup T₂) := by

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -557,8 +557,8 @@ theorem Iic_coatomic_of_compact_element {k : α} (h : IsCompactElement k) :
   · left; ext; simp only [Set.Iic.coe_top]
   right
   have ⟨a, ba, h⟩ := zorn_le_nonempty₀ (Set.Iio k) ?_ b (lt_of_le_of_ne hbk H)
-  · refine ⟨⟨a, le_of_lt h.prop⟩, ⟨ne_of_lt h.prop, fun c hck => by_contradiction fun c₀ => ?_⟩, ba⟩
-    cases h.eq_of_le (y := c.1) (lt_of_le_of_ne c.2 fun con ↦ c₀ (Subtype.ext con)) hck.le
+  · refine ⟨⟨a, le_of_lt h.prop⟩, covBy_top_iff.1 ⟨h.prop, fun c hck c₀ => ?_⟩, ba⟩
+    cases h.eq_of_le (y := c.1) (lt_of_le_of_ne c.2 fun con ↦ c₀.ne (Subtype.ext con)) hck.le
     exact lt_irrefl _ hck
   · intro S SC cC I _
     by_cases hS : S.Nonempty
@@ -630,7 +630,7 @@ instance (priority := 100) isAtomistic_of_complementedLattice [ComplementedLatti
       obtain ⟨c, hc⟩ := exists_isCompl (⟨sSup { a : α | IsAtom a ∧ a ≤ b }, hle⟩ : Set.Iic b)
       obtain rfl | ⟨a, ha, hac⟩ := eq_bot_or_exists_atom_le c
       · exact ne_of_lt con (Subtype.ext_iff.1 (eq_top_of_isCompl_bot hc))
-      · apply ha.1
+      · apply ha.ne_bot
         rw [eq_bot_iff]
         apply le_trans (le_inf _ hac) hc.disjoint.le_bot
         rw [← Subtype.coe_le_coe, Subtype.coe_mk]
@@ -669,7 +669,7 @@ theorem exists_sSupIndep_disjoint_sSup_atoms (b c : α) (hbc : b ≤ c)
   rw [← h, sSup_le_iff]
   intro a ha
   rw [← inf_eq_left]
-  refine (ha.2.le_iff.mp inf_le_left).resolve_left fun con => ha.2.1 ?_
+  refine (ha.2.le_iff.mp inf_le_left).resolve_left fun con => ha.2.ne_bot ?_
   rw [← con, eq_comm, inf_eq_left]
   refine (le_sSup ?_).trans le_sup_right
   rw [← disjoint_iff] at con

--- a/Mathlib/Order/Filter/Ultrafilter/Defs.lean
+++ b/Mathlib/Order/Filter/Ultrafilter/Defs.lean
@@ -65,7 +65,7 @@ instance neBot (f : Ultrafilter α) : NeBot (f : Filter α) :=
   f.neBot'
 
 protected theorem isAtom (f : Ultrafilter α) : IsAtom (f : Filter α) :=
-  ⟨f.neBot.ne, fun _ hgf => by_contra fun hg => hgf.ne <| f.unique hgf.le ⟨hg⟩⟩
+  isAtom_iff_le_of_ge.2 ⟨f.neBot.ne, fun g hgb hg => f.le_of_le g ⟨hgb⟩ hg⟩
 
 @[simp, norm_cast]
 theorem mem_coe : s ∈ (f : Filter α) ↔ s ∈ f :=
@@ -129,7 +129,7 @@ def ofComplNotMemIff (f : Filter α) (h : ∀ s, sᶜ ∉ f ↔ s ∈ f) : Ultra
 /-- If `f : Filter α` is an atom, then it is an ultrafilter. -/
 def ofAtom (f : Filter α) (hf : IsAtom f) : Ultrafilter α where
   toFilter := f
-  neBot' := ⟨hf.1⟩
+  neBot' := ⟨hf.ne_bot⟩
   le_of_le g hg := (isAtom_iff_le_of_ge.1 hf).2 g hg.ne
 
 theorem nonempty_of_mem (hs : s ∈ f) : s.Nonempty :=

--- a/Mathlib/Order/Ideal.lean
+++ b/Mathlib/Order/Ideal.lean
@@ -222,19 +222,20 @@ theorem IsProper.ne_top (_ : IsProper I) : I ≠ ⊤ :=
   fun h ↦ IsProper.ne_univ <| congr_arg SetLike.coe h
 
 theorem _root_.IsCoatom.isProper (hI : IsCoatom I) : IsProper I :=
-  isProper_of_ne_top hI.1
+  isProper_of_ne_top hI.ne_top
 
 theorem isProper_iff_ne_top : IsProper I ↔ I ≠ ⊤ :=
   ⟨fun h ↦ h.ne_top, fun h ↦ isProper_of_ne_top h⟩
 
-theorem IsMaximal.isCoatom (_ : IsMaximal I) : IsCoatom I :=
-  ⟨IsMaximal.toIsProper.ne_top, fun _ h ↦ ext <| IsMaximal.maximal_proper h⟩
+theorem IsMaximal.isCoatom (h : IsMaximal I) : IsCoatom I :=
+  isCoatom_iff_ge_of_le.2 ⟨h.ne_top, fun _ hJt hJl => Classical.byContradiction fun hlJ =>
+    hJt (Ideal.ext (h.maximal_proper (lt_of_le_not_ge hJl hlJ)))⟩
 
 theorem IsMaximal.isCoatom' [IsMaximal I] : IsCoatom I :=
   IsMaximal.isCoatom ‹_›
 
 theorem _root_.IsCoatom.isMaximal (hI : IsCoatom I) : IsMaximal I :=
-  { IsCoatom.isProper hI with maximal_proper := fun _ hJ ↦ by simp [hI.2 _ hJ] }
+  { IsCoatom.isProper hI with maximal_proper := fun _ hJ ↦ by simp [(hI.isMax_of_gt hJ).eq_top] }
 
 theorem isMaximal_iff_isCoatom : IsMaximal I ↔ IsCoatom I :=
   ⟨fun h ↦ h.isCoatom, fun h ↦ IsCoatom.isMaximal h⟩

--- a/Mathlib/Order/Partition/Finpartition.lean
+++ b/Mathlib/Order/Partition/Finpartition.lean
@@ -226,14 +226,14 @@ instance instNonempty : Nonempty (Finpartition a) := by
 -- See note [reducible non-instances]
 /-- There's a unique partition of an atom. -/
 abbrev _root_.IsAtom.uniqueFinpartition (ha : IsAtom a) : Unique (Finpartition a) where
-  default := indiscrete ha.1
+  default := indiscrete ha.ne_bot
   uniq P := by
     have h : ∀ b ∈ P.parts, b = a := fun _ hb ↦
       (ha.le_iff.mp <| P.le hb).resolve_left (P.ne_bot hb)
     ext b
     refine Iff.trans ⟨h b, ?_⟩ mem_singleton.symm
     rintro rfl
-    obtain ⟨c, hc⟩ := P.parts_nonempty ha.1
+    obtain ⟨c, hc⟩ := P.parts_nonempty ha.ne_bot
     simp_rw [← h c hc]
     exact hc
 

--- a/Mathlib/Order/Radical.lean
+++ b/Mathlib/Order/Radical.lean
@@ -21,7 +21,7 @@ The infimum of all coatoms.
 This notion specializes, e.g. in the subgroup lattice of a group to the Frattini subgroup,
 or in the lattices of ideals in a ring `R` to the Jacobson ideal.
 -/
-def Order.radical (α : Type*) [Preorder α] [OrderTop α] [InfSet α] : α :=
+def Order.radical (α : Type*) [CompleteLattice α] : α :=
   ⨅ a ∈ {H | IsCoatom H}, a
 
 variable {α : Type*} [CompleteLattice α]

--- a/Mathlib/Order/Radical.lean
+++ b/Mathlib/Order/Radical.lean
@@ -47,4 +47,4 @@ theorem Order.radical_nongenerating [IsCoatomic α] {a : α} (h : a ⊔ radical 
     have q : a ⊔ radical α ≤ m := sup_le le (radical_le_coatom c)
     -- Now note that `a ⊔ radical α ≤ m` since both `a ≤ m` and `radical α ≤ m`.
     rw [h, top_le_iff] at q
-    simpa using c.1 q
+    simpa using c.ne_top q

--- a/Mathlib/Order/SuccPred/Tree.lean
+++ b/Mathlib/Order/SuccPred/Tree.lean
@@ -75,17 +75,14 @@ lemma findAtom_ne_bot {r : α} :
 
 lemma isAtom_findAtom {r : α} (hr : r ≠ ⊥) :
     IsAtom (findAtom r) := by
-  constructor
-  · simp [hr]
-  · intro b hb
-    apply Order.le_pred_of_lt at hb
-    simpa using hb
+  rw [← bot_covBy_iff, ← pred_findAtom r]
+  exact Order.pred_covBy_of_not_isMin fun h => hr (findAtom_eq_bot.1 (h.eq_bot))
 
 @[simp]
 lemma isAtom_findAtom_iff {r : α} :
     IsAtom (findAtom r) ↔ r ≠ ⊥ where
   mpr := isAtom_findAtom
-  mp h nh := by simp only [nh, findAtom_bot] at h; exact h.1 rfl
+  mp h nh := by simp only [nh, findAtom_bot] at h; exact h.ne_bot rfl
 
 end DecidableEq
 
@@ -180,7 +177,7 @@ variable {t : RootedTree}
 lemma SubRootedTree.root_ne_bot_of_mem_subtrees (r : SubRootedTree t) (hr : r ∈ t.subtrees) :
     r.root ≠ ⊥ := by
   simp only [RootedTree.subtrees, Set.mem_setOf_eq] at hr
-  exact hr.1
+  exact hr.ne_bot
 
 lemma RootedTree.mem_subtrees_disjoint_iff {t₁ t₂ : SubRootedTree t}
     (ht₁ : t₁ ∈ t.subtrees) (ht₂ : t₂ ∈ t.subtrees) (v₁ v₂ : t) (h₁ : v₁ ∈ t₁)
@@ -202,7 +199,7 @@ lemma RootedTree.mem_subtrees_disjoint_iff {t₁ t₂ : SubRootedTree t}
     · simp_all [RootedTree.subtrees, IsAtom.lt_iff]
     rw [le_inf_iff] at oh
     ext
-    simpa only [ht₂.le_iff_eq ht₁.1, ht₁.le_iff_eq ht₂.1, eq_comm, or_self] using
+    simpa only [ht₂.le_iff_eq ht₁.ne_bot, ht₁.le_iff_eq ht₂.ne_bot, eq_comm, or_self] using
       le_total_of_directed oh.2 h₂
 
 lemma RootedTree.subtrees_disjoint : t.subtrees.PairwiseDisjoint ((↑) : _ → Set t) := by

--- a/Mathlib/Order/ZornAtoms.lean
+++ b/Mathlib/Order/ZornAtoms.lean
@@ -29,7 +29,7 @@ theorem IsCoatomic.of_isChain_bounded {α : Type*} [PartialOrder α] [OrderTop �
   refine ⟨fun x => le_top.eq_or_lt.imp_right fun hx => ?_⟩
   have := zorn_le_nonempty₀ (Ico x ⊤) (fun c hxc hc y hy => ?_) x (left_mem_Ico.2 hx)
   · obtain ⟨y, hxy, hmax⟩ := this
-    refine ⟨y, ⟨hmax.prop.2.ne, fun z hyz ↦ le_top.eq_or_lt.resolve_right fun hz => ?_⟩, hxy⟩
+    refine ⟨y, (covBy_top_iff.1 ⟨hmax.prop.2, fun z hyz hz ↦ ?_⟩), hxy⟩
     exact hyz.ne <| hmax.eq_of_le ⟨hxy.trans hyz.le, hz⟩ hyz.le
   rcases h c hc ⟨y, hy⟩ fun h => (hxc h).2.ne rfl with ⟨z, hz, hcz⟩
   exact ⟨z, ⟨le_trans (hxc hy).1 (hcz hy), hz.lt_top⟩, hcz⟩

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -45,22 +45,16 @@ variable {M : Type*} [CommMonoidWithZero M] [IsCancelMulZero M]
 
 theorem Associates.isAtom_iff {p : Associates M} (h₁ : p ≠ 0) : IsAtom p ↔ Irreducible p :=
   ⟨fun hp =>
-    ⟨by simpa only [Associates.isUnit_iff_eq_one] using! hp.1, fun a b h =>
+    ⟨by simpa only [Associates.isUnit_iff_eq_one] using! hp.ne_bot, fun a b h =>
       (hp.le_iff.mp ⟨_, h⟩).casesOn (fun ha => Or.inl (a.isUnit_iff_eq_one.mpr ha)) fun ha =>
         Or.inr
           (show IsUnit b by
             rw [ha] at h
             apply isUnit_of_associated_mul (show Associated (p * b) p by conv_rhs => rw [h]) h₁)⟩,
     fun hp =>
-    ⟨by simpa only [Associates.isUnit_iff_eq_one, Associates.bot_eq_one] using! hp.1,
-      fun b ⟨⟨a, hab⟩, hb⟩ =>
-      (hp.isUnit_or_isUnit hab).casesOn
-        (fun hb => show b = ⊥ by rwa [Associates.isUnit_iff_eq_one, ← Associates.bot_eq_one] at hb)
-        fun ha =>
-        absurd
-          (show p ∣ b from
-            ⟨(ha.unit⁻¹ : Units _), by rw [hab, mul_assoc, IsUnit.mul_val_inv ha, mul_one]⟩)
-          hb⟩⟩
+      bot_covBy_iff.1 ⟨bot_lt_iff_ne_bot.2 (by simp [bot_eq_one, hp.ne_one]), fun c hcb hcp =>
+        (hp.dvd_iff.1 hcp.le).elim (fun hc => hcb.ne' (isUnit_iff_eq_bot.1 hc))
+          (fun hc => hcp.not_ge hc.dvd)⟩⟩
 
 open UniqueFactorizationMonoid Irreducible Associates
 
@@ -100,11 +94,12 @@ theorem second_of_chain_is_irreducible {q : Associates M} {n : ℕ} (hn : n ≠ 
     {c : Fin (n + 1) → Associates M} (h₁ : StrictMono c) (h₂ : ∀ {r}, r ≤ q ↔ ∃ i, r = c i)
     (hq : q ≠ 0) : Irreducible (c 1) := by
   rcases n with - | n; · contradiction
-  refine (Associates.isAtom_iff (ne_zero_of_dvd_ne_zero hq (h₂.2 ⟨1, rfl⟩))).mp ⟨?_, fun b hb => ?_⟩
-  · exact ne_bot_of_gt (h₁ zero_lt_one)
+  refine (Associates.isAtom_iff (ne_zero_of_dvd_ne_zero hq (h₂.2 ⟨1, rfl⟩))).mp
+    (bot_covBy_iff.1 ⟨?_, fun b hbb hb => ?_⟩)
+  · exact bot_lt_of_lt (h₁ zero_lt_one)
   obtain ⟨⟨i, hi⟩, rfl⟩ := h₂.1 (hb.le.trans (h₂.2 ⟨1, rfl⟩))
   cases i
-  · exact (Associates.isUnit_iff_eq_one _).mp (first_of_chain_isUnit h₁ @h₂)
+  · exact hbb.ne' <| Associates.isUnit_iff_eq_bot.mp (first_of_chain_isUnit h₁ @h₂)
   · simpa [Fin.lt_def] using h₁.lt_iff_lt.mp hb
 
 theorem eq_second_of_chain_of_prime_dvd {p q r : Associates M} {n : ℕ} (hn : n ≠ 0)
@@ -283,8 +278,9 @@ theorem map_prime_of_factor_orderIso {m p : Associates M} {n : Associates N} (hn
     Prime (d ⟨p, dvd_of_mem_normalizedFactors hp⟩ : Associates N) := by
   rw [← irreducible_iff_prime]
   refine (Associates.isAtom_iff <|
-    ne_zero_of_dvd_ne_zero hn (d ⟨p, _⟩).prop).mp ⟨?_, fun b hb => ?_⟩
-  · rw [Ne, ← Associates.isUnit_iff_eq_bot, Associates.isUnit_iff_eq_one,
+    ne_zero_of_dvd_ne_zero hn (d ⟨p, _⟩).prop).mp <|
+      bot_covBy_iff.1 ⟨?_, fun b hbb hb => ?_⟩
+  · rw [bot_lt_iff_ne_bot, ne_eq, ← Associates.isUnit_iff_eq_bot, Associates.isUnit_iff_eq_one,
       coe_factor_orderIso_map_eq_one_iff _ d]
     rintro rfl
     exact (prime_of_normalized_factor 1 hp).not_unit isUnit_one
@@ -295,14 +291,14 @@ theorem map_prime_of_factor_orderIso {m p : Associates M} {n : Associates N} (hn
     letI : OrderBot { l : Associates N // l ≤ n } := Subtype.orderBot bot_le
     suffices x = ⊥ by
       rw [this, OrderIso.map_bot d] at hx
-      refine (Subtype.mk_eq_bot_iff ?_ _).mp hx.symm
+      refine hbb.ne' <| (Subtype.mk_eq_bot_iff ?_ _).mp hx.symm
       simp
     obtain ⟨a, ha⟩ := x
     rw [Subtype.mk_eq_bot_iff]
     · exact
-        ((Associates.isAtom_iff <| Prime.ne_zero <| prime_of_normalized_factor p hp).mpr <|
-              irreducible_of_normalized_factor p hp).right
-          a (Subtype.mk_lt_mk.mp <| d.lt_iff_lt.mp hb)
+        (((Associates.isAtom_iff <| Prime.ne_zero <| prime_of_normalized_factor p hp).mpr <|
+              irreducible_of_normalized_factor p hp).isMin_of_lt
+          (Subtype.mk_lt_mk.mp <| d.lt_iff_lt.mp hb)).eq_bot
     simp
 
 theorem mem_normalizedFactors_factor_orderIso_of_mem_normalizedFactors {m p : Associates M}

--- a/Mathlib/RingTheory/DedekindDomain/Dvr.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Dvr.lean
@@ -69,7 +69,8 @@ theorem Ring.DimensionLEOne.localization {R : Type*} (Rₘ : Type*) [CommRing R]
     [CommRing Rₘ] [Algebra R Rₘ] {M : Submonoid R} [IsLocalization M Rₘ] (hM : M ≤ R⁰)
     [h : Ring.DimensionLEOne R] : Ring.DimensionLEOne Rₘ := ⟨by
   intro p hp0 hpp
-  refine Ideal.isMaximal_def.mpr ⟨hpp.ne_top, Ideal.maximal_of_no_maximal fun P hpP hPm => ?_⟩
+  refine Ideal.isMaximal_def.mpr <| covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 hpp.ne_top, fun J hJ =>
+    (Ideal.maximal_of_no_maximal (fun P hpP hPm => ?_) J hJ).not_lt⟩
   have hpP' : (⟨p, hpp⟩ : { p : Ideal Rₘ // p.IsPrime }) < ⟨P, hPm.isPrime⟩ := hpP
   rw [← (IsLocalization.orderIsoOfPrime M Rₘ).lt_iff_lt] at hpP'
   refine h.not_lt_lt ⊥ (p.under R) (P.under R) ⟨?_, hpP'⟩

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Basic.lean
@@ -138,13 +138,14 @@ theorem dimensionLEOne : DimensionLEOne A := by
   let := h.commGroupWithZero (K := FractionRing A)
   constructor
   rintro P P_ne hP
-  refine Ideal.isMaximal_def.mpr ⟨hP.ne_top, fun M hM => ?_⟩
+  refine Ideal.isMaximal_def.mpr (covBy_top_iff.mp ⟨lt_top_iff_ne_top.2 hP.ne_top, fun M hM => ?_⟩)
   -- We may assume `P` and `M` (as fractional ideals) are nonzero.
   have P'_ne : (P : FractionalIdeal A⁰ (FractionRing A)) ≠ 0 := coeIdeal_ne_zero.mpr P_ne
   have M'_ne : (M : FractionalIdeal A⁰ (FractionRing A)) ≠ 0 := coeIdeal_ne_zero.mpr hM.ne_bot
   -- In particular, we'll show `M⁻¹ * P ≤ P`
   suffices (M⁻¹ : FractionalIdeal A⁰ (FractionRing A)) * P ≤ P by
-    rw [eq_top_iff, ← coeIdeal_le_coeIdeal (FractionRing A), coeIdeal_top]
+    rw [lt_top_iff_ne_top, not_ne_iff, eq_top_iff,
+      ← coeIdeal_le_coeIdeal (FractionRing A), coeIdeal_top]
     calc
       (1 : FractionalIdeal A⁰ (FractionRing A)) = (↑M)⁻¹ * P * ((↑P)⁻¹ * M) := by
         simp [mul_assoc, *]
@@ -433,10 +434,10 @@ instance Ideal.uniqueFactorizationMonoid : UniqueFactorizationMonoid (Ideal A) :
       intro P
       exact ⟨fun hirr => ⟨hirr.ne_zero, hirr.not_isUnit, fun I J => by
         have : P.IsMaximal := by
-          refine ⟨⟨mt Ideal.isUnit_iff.mpr hirr.not_isUnit, ?_⟩⟩
-          intro J hJ
+          refine ⟨covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 (mt Ideal.isUnit_iff.mpr hirr.not_isUnit),
+            fun J hJ => ?_⟩⟩
           obtain ⟨_J_ne, H, hunit, P_eq⟩ := Ideal.dvdNotUnit_iff_lt.mpr hJ
-          exact Ideal.isUnit_iff.mp ((hirr.isUnit_or_isUnit P_eq).resolve_right hunit)
+          exact (Ideal.isUnit_iff.mp ((hirr.isUnit_or_isUnit P_eq).resolve_right hunit)).not_lt
         rw [Ideal.dvd_iff_le, Ideal.dvd_iff_le, Ideal.dvd_iff_le, SetLike.le_def, SetLike.le_def,
           SetLike.le_def]
         contrapose!

--- a/Mathlib/RingTheory/DualNumber.lean
+++ b/Mathlib/RingTheory/DualNumber.lean
@@ -132,11 +132,10 @@ lemma ideal_trichotomy [DivisionRing K] (I : Ideal K[ε]) :
     exact Ideal.mul_mem_left _ _ hyI
 
 lemma isMaximal_span_singleton_eps [DivisionRing K] :
-    (Ideal.span {ε} : Ideal K[ε]).IsMaximal := by
-  refine ⟨?_, fun I hI ↦ ?_⟩
-  · simp [ne_eq, Ideal.eq_top_iff_one, Ideal.mem_span_singleton', TrivSqZeroExt.ext_iff]
-  · rcases ideal_trichotomy I with rfl | rfl | rfl <;>
-    first | simp at hI | simp
+    (Ideal.span {ε} : Ideal K[ε]).IsMaximal where
+  out := isCoatom_iff_ge_of_le.2 ⟨mt (Ideal.eq_top_iff_one _).1
+      (mt Ideal.mem_span_singleton'.1 (by simp [TrivSqZeroExt.ext_iff]) ),
+      fun I ht hI => (ideal_trichotomy I).elim3 (·.trans_le bot_le) Eq.le (Not.elim ht)⟩
 
 lemma maximalIdeal_eq_span_singleton_eps [Field K] :
     IsLocalRing.maximalIdeal K[ε] = Ideal.span {ε} :=

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -266,7 +266,8 @@ theorem exists_maximal_of_not_isField [Nontrivial R] (h : ¬ IsField R) :
     ∃ p : Ideal R, p ≠ ⊥ ∧ p.IsMaximal := by
   contrapose! h
   simp only [← bot_lt_iff_ne_bot] at h
-  refine isField_iff_maximal_bot.mpr ⟨⟨bot_ne_top, Ideal.maximal_of_no_maximal h⟩⟩
+  refine isField_iff_maximal_bot.mpr ⟨covBy_top_iff.1
+    ⟨bot_lt_top, fun p hp hpt => hpt.ne (Ideal.maximal_of_no_maximal h p hp)⟩⟩
 
 theorem not_isField_of_ne_of_ne [Nontrivial R] {I : Ideal R} (h_bot : I ≠ ⊥) (h_top : I ≠ ⊤) :
     ¬ IsField R := by

--- a/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -170,12 +170,13 @@ theorem comap_ne_bot_of_root_mem [IsDomain S] {r : S} (r_ne_zero : r ≠ 0) (hr 
   absurd (mem_bot.mp (eq_bot_iff.mp h mem)) hi
 
 theorem isMaximal_of_isIntegral_of_isMaximal_comap [Algebra R S] [Algebra.IsIntegral R S]
-    (I : Ideal S) [I.IsPrime] (hI : IsMaximal (I.comap (algebraMap R S))) : IsMaximal I :=
-  ⟨⟨mt comap_eq_top_iff.mpr hI.1.1, fun _ I_lt_J =>
+    (I : Ideal S) [I.IsPrime] (hI : IsMaximal (I.comap (algebraMap R S))) : IsMaximal I where
+  out := covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 (mt comap_eq_top_iff.mpr hI.1.ne_top),
+    fun _ I_lt_J J_not_top =>
       let ⟨I_le_J, x, hxJ, hxI⟩ := SetLike.lt_iff_le_and_exists.mp I_lt_J
-      comap_eq_top_iff.1 <|
-        hI.1.2 _ (comap_lt_comap_of_integral_mem_sdiff I_le_J ⟨hxJ, hxI⟩
-          (Algebra.IsIntegral.isIntegral x))⟩⟩
+      J_not_top.ne <| comap_eq_top_iff.1 <|
+        (hI.1.isMax_of_gt (comap_lt_comap_of_integral_mem_sdiff I_le_J ⟨hxJ, hxI⟩
+          (Algebra.IsIntegral.isIntegral x))).eq_top⟩
 
 theorem isMaximal_of_isIntegral_of_isMaximal_comap' (f : R →+* S) (hf : f.IsIntegral) (I : Ideal S)
     [I.IsPrime] (hI : IsMaximal (I.comap f)) : IsMaximal I :=

--- a/Mathlib/RingTheory/Ideal/Maps.lean
+++ b/Mathlib/RingTheory/Ideal/Maps.lean
@@ -397,8 +397,9 @@ def orderEmbeddingOfSurjective (hf : Function.Surjective f) : Ideal S ↪o Ideal
 
 theorem map_eq_top_or_isMaximal_of_surjective (hf : Function.Surjective f) {I : Ideal R}
     (H : IsMaximal I) : map f I = ⊤ ∨ IsMaximal (map f I) :=
-  or_iff_not_imp_left.2 fun ne_top ↦ ⟨⟨ne_top, fun _J hJ ↦ comap_injective_of_surjective f hf <|
-    H.1.2 _ (le_comap_map.trans_lt <| (orderEmbeddingOfSurjective f hf).strictMono hJ)⟩⟩
+  or_iff_not_imp_left.2 fun h => ⟨((gc_map_comap f).toGaloisInsertion fun b =>
+    (map_comap_of_surjective f hf b).ge).isCoatom_of_image
+      (H.eq_of_le (comap_ne_top f h) I.le_comap_map ▸ H.out)⟩
 
 end Surjective
 
@@ -602,19 +603,13 @@ def relIsoOfSurjective (hf : Function.Surjective f) :
 
 -- May not hold if `R` is a semiring: consider `ℕ →+* ZMod 2`.
 theorem comap_isMaximal_of_surjective (hf : Function.Surjective f) {K : Ideal S} [H : IsMaximal K] :
-    IsMaximal (comap f K) := by
-  refine ⟨⟨comap_ne_top _ H.1.1, fun J hJ => ?_⟩⟩
-  suffices map f J = ⊤ by
-    have := congr_arg (comap f) this
-    rw [comap_top, comap_map_of_surjective _ hf, eq_top_iff] at this
-    rw [eq_top_iff]
-    exact le_trans this (sup_le (le_of_eq rfl) (le_trans (comap_mono bot_le) (le_of_lt hJ)))
-  refine
-    H.1.2 (map f J)
-      (lt_of_le_of_ne (le_map_of_comap_le_of_surjective _ hf (le_of_lt hJ)) fun h =>
-        ne_of_lt hJ (_root_.trans (congr_arg (comap f) h) ?_))
-  rw [comap_map_of_surjective _ hf, sup_eq_left]
-  exact le_trans (comap_mono bot_le) (le_of_lt hJ)
+    IsMaximal (comap f K) where
+  out := covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 (comap_ne_top f H.ne_top), fun q lt ↦ by
+    rw [lt_top_iff_ne_top, not_ne_iff, ← sup_eq_right.2 lt.le,
+      ← sup_eq_left.2 (comap_mono (f := f) bot_le), sup_right_comm,
+      ← comap_map_of_surjective f hf, map_sup, ← comap_top (f := f)]
+    refine congrArg (comap f) (H.out.isMax_of_gt ?_).eq_top
+    simpa only [map_comap_of_surjective f hf, left_lt_sup, map_le_iff_le_comap] using lt.not_ge⟩
 
 end Surjective
 

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -53,7 +53,7 @@ theorem isMaximal_def {I : Ideal α} : I.IsMaximal ↔ IsCoatom I :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩
 
 theorem IsMaximal.ne_top {I : Ideal α} (h : I.IsMaximal) : I ≠ ⊤ :=
-  (isMaximal_def.1 h).1
+  (isMaximal_def.1 h).ne_top
 
 theorem IsMaximal.lt_top {I : Ideal α} (h : I.IsMaximal) : I < ⊤ :=
   h.ne_top.lt_top
@@ -63,7 +63,7 @@ theorem isMaximal_iff {I : Ideal α} :
   simp_rw [isMaximal_def, SetLike.isCoatom_iff, Ideal.ne_top_iff_one, ← Ideal.eq_top_iff_one]
 
 theorem IsMaximal.eq_of_le {I J : Ideal α} (hI : I.IsMaximal) (hJ : J ≠ ⊤) (IJ : I ≤ J) : I = J :=
-  eq_iff_le_not_lt.2 ⟨IJ, fun h => hJ (hI.1.2 _ h)⟩
+  ((hI.out.ne_iff_eq_top IJ).not_right.2 hJ).symm
 
 theorem IsMaximal.eq_iff_le {I J : Ideal α} (hI : I.IsMaximal) (hJ : J ≠ ⊤) : I = J ↔ I ≤ J :=
   ⟨by aesop, Ideal.IsMaximal.eq_of_le hI hJ⟩
@@ -95,8 +95,8 @@ theorem ne_top_iff_exists_maximal {I : Ideal α} : I ≠ ⊤ ↔ ∃ M : Ideal �
   exact IsMaximal.ne_top hMmax
 
 instance [Nontrivial α] : Nontrivial (Ideal α) := by
-  rcases @exists_maximal α _ _ with ⟨M, hM, _⟩
-  exact nontrivial_of_ne M ⊤ hM
+  rcases @exists_maximal α _ _ with ⟨M, hM⟩
+  exact nontrivial_of_ne M ⊤ hM.ne_top
 
 /-- If P is not properly contained in any maximal ideal then it is not properly contained
   in any proper ideal -/
@@ -149,7 +149,7 @@ theorem span_singleton_prime {p : α} (hp : p ≠ 0) : IsPrime (span ({p} : Set 
   simp [isPrime_iff, Prime, span_singleton_eq_top, hp, mem_span_singleton]
 
 theorem IsMaximal.isPrime {I : Ideal α} (H : I.IsMaximal) : I.IsPrime :=
-  ⟨H.1.1, @fun x y hxy =>
+  ⟨H.ne_top, @fun x y hxy =>
     or_iff_not_imp_left.2 fun hx => by
       let J : Ideal α := Submodule.span α (insert x ↑I)
       have IJ : I ≤ J := Set.Subset.trans (subset_insert _ _) subset_span
@@ -169,7 +169,7 @@ instance (priority := 100) IsMaximal.isPrime' (I : Ideal α) : ∀ [_H : I.IsMax
 theorem exists_disjoint_powers_of_span_eq_top (s : Set α) (hs : span s = ⊤) (I : Ideal α)
     (hI : I ≠ ⊤) : ∃ r ∈ s, Disjoint (I : Set α) (Submonoid.powers r) := by
   have ⟨M, hM, le⟩ := exists_le_maximal I hI
-  have := hM.1.1
+  have := hM.ne_top
   rw [Ne, eq_top_iff, ← hs, span_le, Set.not_subset] at this
   have ⟨a, has, haM⟩ := this
   exact ⟨a, has, Set.disjoint_left.mpr fun x hx ⟨n, hn⟩ ↦
@@ -255,9 +255,8 @@ variable {K : Type u} [DivisionSemiring K] (I : Ideal K)
 
 namespace Ideal
 
-theorem bot_isMaximal : IsMaximal (⊥ : Ideal K) :=
-  ⟨⟨fun h => absurd ((eq_top_iff_one (⊤ : Ideal K)).mp rfl) (by rw [← h]; simp), fun I hI =>
-      or_iff_not_imp_left.mp (eq_bot_or_top I) (ne_of_gt hI)⟩⟩
+theorem bot_isMaximal : IsMaximal (⊥ : Ideal K) where
+  out := covBy_top_iff.1 ⟨bot_lt_top, fun c hb ht => c.eq_bot_or_top.elim hb.ne' ht.ne⟩
 
 end Ideal
 

--- a/Mathlib/RingTheory/Ideal/Quotient/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Basic.lean
@@ -122,7 +122,7 @@ protected noncomputable abbrev groupWithZero [hI : I.IsMaximal] :
     mul_inv_cancel := fun a (ha : a ≠ 0) =>
       show a * dite _ _ _ = _ by rw [dif_neg ha]; exact Classical.choose_spec (exists_inv ha)
     inv_zero := dif_pos rfl
-    __ := Quotient.nontrivial_iff.mpr hI.out.1 }
+    __ := Quotient.nontrivial_iff.mpr hI.out.ne_top }
 
 /-- The quotient by a two-sided ideal that is maximal as a left ideal is a division ring.
 This is a `def` rather than `instance`, since users

--- a/Mathlib/RingTheory/Jacobson/Ideal.lean
+++ b/Mathlib/RingTheory/Jacobson/Ideal.lean
@@ -93,8 +93,7 @@ theorem jacobson_eq_self_of_isMaximal [H : IsMaximal I] : I.jacobson = I :=
   le_antisymm (sInf_le ⟨le_of_eq rfl, H⟩) le_jacobson
 
 instance (priority := 100) jacobson.isMaximal [H : IsMaximal I] : IsMaximal (jacobson I) :=
-  ⟨⟨fun htop => H.1.1 (jacobson_eq_top_iff.1 htop), fun _ hJ =>
-    H.1.2 _ (lt_of_le_of_lt le_jacobson hJ)⟩⟩
+  (jacobson_eq_self_of_isMaximal (I := I)).symm ▸ H
 
 theorem mem_jacobson_iff {x : R} : x ∈ jacobson I ↔ ∀ y, ∃ z, z * y * x + z - 1 ∈ I :=
   ⟨fun hx y =>
@@ -107,12 +106,12 @@ theorem mem_jacobson_iff {x : R} : x ∈ jacobson I ↔ ∀ y, ∃ z, z * y * x 
           exact I.neg_mem hpi⟩)
       fun hxy : I ⊔ span {y * x + 1} ≠ ⊤ => let ⟨M, hm1, hm2⟩ := exists_le_maximal _ hxy
       suffices x ∉ M from (this <| mem_sInf.1 hx ⟨le_trans le_sup_left hm2, hm1⟩).elim
-      fun hxm => hm1.1.1 <| (eq_top_iff_one _).2 <| add_sub_cancel_left (y * x) 1 ▸
+      fun hxm => hm1.1.ne_top <| (eq_top_iff_one _).2 <| add_sub_cancel_left (y * x) 1 ▸
         M.sub_mem (le_sup_right.trans hm2 <| subset_span rfl) (M.mul_mem_left _ hxm),
     fun hx => mem_sInf.2 fun M ⟨him, hm⟩ => by_contradiction fun hxm =>
       let ⟨y, i, hi, df⟩ := hm.exists_inv hxm
       let ⟨z, hz⟩ := hx (-y)
-      hm.1.1 <| (eq_top_iff_one _).2 <| sub_sub_cancel (z * -y * x + z) 1 ▸
+      hm.1.ne_top <| (eq_top_iff_one _).2 <| sub_sub_cancel (z * -y * x + z) 1 ▸
         M.sub_mem (by
           rw [mul_assoc, ← mul_add_one, neg_mul, ← sub_eq_iff_eq_add.mpr df.symm, neg_sub,
             sub_add_cancel]
@@ -146,18 +145,12 @@ theorem eq_jacobson_iff_sInf_maximal :
 theorem eq_jacobson_iff_sInf_maximal' :
     I.jacobson = I ↔ ∃ M : Set (Ideal R), (∀ J ∈ M, ∀ (K : Ideal R), J < K → K = ⊤) ∧ I = sInf M :=
   eq_jacobson_iff_sInf_maximal.trans
-    ⟨fun h =>
-      let ⟨M, hM⟩ := h
-      ⟨M,
-        ⟨fun J hJ K hK =>
-          Or.recOn (hM.1 J hJ) (fun h => h.1.2 K hK) fun h => eq_top_iff.2 (le_of_lt (h ▸ hK)),
-          hM.2⟩⟩,
-      fun h =>
-      let ⟨M, hM⟩ := h
-      ⟨M,
-        ⟨fun J hJ =>
-          Or.recOn (Classical.em (J = ⊤)) (fun h => Or.inr h) fun h => Or.inl ⟨⟨h, hM.1 J hJ⟩⟩,
-          hM.2⟩⟩⟩
+    ⟨fun h => h.imp fun _ hM =>
+      ⟨fun J hJ _ hK => (hM.1 J hJ).elim (fun h => (h.1.isMax_of_gt hK).eq_top) fun h =>
+        eq_top_iff.2 (le_of_lt (h ▸ hK)), hM.2⟩,
+    fun h => h.imp fun _ hM =>
+      ⟨fun J hJ => or_iff_not_imp_right.2 fun h =>
+        ⟨covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 h, fun K hK => (hM.1 J hJ K hK).not_lt⟩⟩, hM.2⟩⟩
 
 /-- An ideal `I` equals its Jacobson radical if and only if every element outside `I`
 also lies outside of a maximal ideal containing `I`. -/
@@ -358,7 +351,7 @@ theorem isLocal_of_isMaximal_radical {I : Ideal R} (hi : IsMaximal (radical I)) 
 theorem IsLocal.le_jacobson {I J : Ideal R} (hi : IsLocal I) (hij : I ≤ J) (hj : J ≠ ⊤) :
     J ≤ jacobson I :=
   let ⟨_, hm, hjm⟩ := exists_le_maximal J hj
-  le_trans hjm <| le_of_eq <| Eq.symm <| hi.1.eq_of_le hm.1.1 <| sInf_le ⟨le_trans hij hjm, hm⟩
+  le_trans hjm <| le_of_eq <| Eq.symm <| hi.1.eq_of_le hm.1.ne_top <| sInf_le ⟨le_trans hij hjm, hm⟩
 
 theorem IsLocal.mem_jacobson_or_exists_inv {I : Ideal R} (hi : IsLocal I) (x : R) :
     x ∈ jacobson I ∨ ∃ y, y * x - 1 ∈ I :=

--- a/Mathlib/RingTheory/Jacobson/Radical.lean
+++ b/Mathlib/RingTheory/Jacobson/Radical.lean
@@ -99,7 +99,7 @@ theorem jacobson_quotient_jacobson : jacobson R (M ⧸ jacobson R M) = ⊥ := by
 
 theorem jacobson_lt_top [Nontrivial M] [IsCoatomic (Submodule R M)] : jacobson R M < ⊤ := by
   obtain ⟨m, hm, -⟩ := (eq_top_or_exists_le_coatom (⊥ : Submodule R M)).resolve_left bot_ne_top
-  exact (sInf_le <| Set.mem_setOf.mpr hm).trans_lt hm.1.lt_top
+  exact (sInf_le <| Set.mem_setOf.mpr hm).trans_lt hm.lt_top
 
 example [Nontrivial M] [Module.Finite R M] : jacobson R M < ⊤ := jacobson_lt_top R M
 

--- a/Mathlib/RingTheory/Jacobson/Ring.lean
+++ b/Mathlib/RingTheory/Jacobson/Ring.lean
@@ -181,7 +181,7 @@ theorem IsLocalization.isMaximal_iff_isMaximal_disjoint [H : IsJacobsonRing R] (
         refine isPrime_of_isPrime_disjoint (powers y) _ I hIm.isPrime ?_
         rwa [disjoint_powers_iff_notMem_of_isPrime]
       have : J ≤ I.map (algebraMap R S) := map_under (Submonoid.powers y) S J ▸ map_mono hJI
-      exact absurd (h.1.2 _ (lt_of_le_of_ne this hJ)) hI_p.1
+      exact absurd (h.1.isMax_of_gt (lt_of_le_of_ne this hJ)).eq_top hI_p.1
   · simp only [Ideal.mem_comap, and_imp]
     exact (fun _ _ ↦ IsMaximal.of_isLocalization_of_disjoint (powers y))
 

--- a/Mathlib/RingTheory/KrullDimension/Zero.lean
+++ b/Mathlib/RingTheory/KrullDimension/Zero.lean
@@ -86,11 +86,11 @@ lemma Ring.krullDimLE_zero_and_isLocalRing_tfae :
     rw [nilradical, Ideal.radical_eq_sInf]
     simp [← Ideal.isMaximal_iff_isPrime, IsLocalRing.isMaximal_iff]
   tfae_have 3 → 4 := by
-    refine fun H ↦ ⟨fun e ↦ ?_, fun I hI ↦ ?_⟩
-    · obtain ⟨n, hn⟩ := (Ideal.eq_top_iff_one _).mp e
+    refine fun H ↦ Ideal.isMaximal_iff.2 ⟨fun h => ?_, fun I x hI hx' hx => ?_⟩
+    · obtain ⟨n, hn⟩ := h
       exact (H 0).mp .zero ((show (1 : R) = 0 by simpa using hn) ▸ isUnit_one)
-    · obtain ⟨x, hx, hx'⟩ := (SetLike.lt_iff_le_and_exists.mp hI).2
-      exact Ideal.eq_top_of_isUnit_mem _ hx (not_not.mp ((H x).not.mp hx'))
+    · exact (Ideal.mem_iff_of_associated
+        (associated_one_iff_isUnit.2 (not_not.mp ((H x).not.mp hx')))).1 hx
   tfae_have 4 → 2 := fun H ↦ ⟨_, H.isPrime, fun p (hp : p.IsPrime) ↦
       (H.eq_of_le hp.ne_top (nilradical_le_prime p)).symm⟩
   tfae_have 2 → 1 := by

--- a/Mathlib/RingTheory/LocalRing/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/Basic.lean
@@ -47,24 +47,25 @@ theorem of_unique_max_ideal (h : ∃! I : Ideal R, I.IsMaximal) : IsLocalRing R 
   @of_nonunits_add _ _
     (nontrivial_of_ne (0 : R) 1 <|
       let ⟨I, Imax, _⟩ := h
-      fun H : 0 = 1 => Imax.1.1 <| I.eq_top_iff_one.2 <| H ▸ I.zero_mem)
+      fun H : 0 = 1 => Imax.1.ne_top <| I.eq_top_iff_one.2 <| H ▸ I.zero_mem)
     fun x y hx hy H =>
     let ⟨I, Imax, Iuniq⟩ := h
     let ⟨Ix, Ixmax, Hx⟩ := exists_max_ideal_of_mem_nonunits hx
     let ⟨Iy, Iymax, Hy⟩ := exists_max_ideal_of_mem_nonunits hy
     have xmemI : x ∈ I := Iuniq Ix Ixmax ▸ Hx
     have ymemI : y ∈ I := Iuniq Iy Iymax ▸ Hy
-    Imax.1.1 <| I.eq_top_of_isUnit_mem (I.add_mem xmemI ymemI) H
+    Imax.1.ne_top <| I.eq_top_of_isUnit_mem (I.add_mem xmemI ymemI) H
 
 theorem of_unique_nonzero_prime (h : ∃! P : Ideal R, P ≠ ⊥ ∧ Ideal.IsPrime P) : IsLocalRing R :=
   of_unique_max_ideal
     (by
       rcases h with ⟨P, ⟨hPnonzero, hPnot_top, _⟩, hPunique⟩
-      refine ⟨P, ⟨⟨hPnot_top, ?_⟩⟩, fun M hM => hPunique _ ⟨?_, Ideal.IsMaximal.isPrime hM⟩⟩
-      · refine Ideal.maximal_of_no_maximal fun M hPM hM => ne_of_lt hPM ?_
+      refine ⟨P, ⟨covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 hPnot_top, fun c hcP hct => ?_⟩⟩,
+        fun M hM => hPunique _ ⟨?_, Ideal.IsMaximal.isPrime hM⟩⟩
+      · refine hct.ne <| Ideal.maximal_of_no_maximal (fun M hPM hM => ne_of_lt hPM ?_) c hcP
         exact (hPunique _ ⟨ne_bot_of_gt hPM, Ideal.IsMaximal.isPrime hM⟩).symm
       · rintro rfl
-        exact hPnot_top (hM.1.2 P (bot_lt_iff_ne_bot.2 hPnonzero)))
+        exact hPnot_top (hM.1.isMax_of_gt (bot_lt_iff_ne_bot.2 hPnonzero)).eq_top)
 
 variable [IsLocalRing R]
 

--- a/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
@@ -45,7 +45,8 @@ instance maximalIdeal.isMaximal : (maximalIdeal R).IsMaximal := by
     simpa using I.mul_mem_left (↑u⁻¹) H
 
 theorem isMaximal_iff {I : Ideal R} : I.IsMaximal ↔ I = maximalIdeal R where
-  mp hI := hI.eq_of_le (maximalIdeal.isMaximal R).1.1 fun _ h ↦ hI.1.1 ∘ I.eq_top_of_isUnit_mem h
+  mp hI := hI.eq_of_le (maximalIdeal.isMaximal R).1.ne_top fun _ h ↦
+    hI.1.ne_top ∘ I.eq_top_of_isUnit_mem h
   mpr e := e ▸ maximalIdeal.isMaximal R
 
 theorem maximal_ideal_unique : ∃! I : Ideal R, I.IsMaximal := by

--- a/Mathlib/RingTheory/PrincipalIdealDomain.lean
+++ b/Mathlib/RingTheory/PrincipalIdealDomain.lean
@@ -321,14 +321,12 @@ namespace PrincipalIdealRing
 open IsPrincipalIdealRing
 
 theorem isMaximal_of_irreducible [CommSemiring R] [IsPrincipalIdealRing R] {p : R}
-    (hp : Irreducible p) : Ideal.IsMaximal (span R ({p} : Set R)) :=
-  ⟨⟨mt Ideal.span_singleton_eq_top.1 hp.1, fun I hI => by
-      rcases principal I with ⟨a, rfl⟩
-      rw [Ideal.submodule_span_eq, Ideal.span_singleton_eq_top]
-      rcases Ideal.span_singleton_le_span_singleton.1 (le_of_lt hI) with ⟨b, rfl⟩
-      refine (of_irreducible_mul hp).resolve_right (mt (fun hb => ?_) (not_le_of_gt hI))
-      rw [Ideal.submodule_span_eq, Ideal.submodule_span_eq,
-        Ideal.span_singleton_le_span_singleton, IsUnit.mul_right_dvd hb]⟩⟩
+    (hp : Irreducible p) : Ideal.IsMaximal (span R ({p} : Set R)) where
+  out := isCoatom_iff_ge_of_le.2 ⟨Ideal.span_singleton_ne_top hp.not_isUnit, fun I ht hI => by
+    obtain ⟨q, rfl⟩ := principal I
+    rw [Ideal.span_singleton_le_span_singleton] at hI ⊢
+    rw [ne_eq, Ideal.span_singleton_eq_top] at ht
+    exact ((hp.dvd_iff.1 hI).resolve_left ht).dvd⟩
 
 variable [CommRing R] [IsDomain R] [IsPrincipalIdealRing R]
 

--- a/Mathlib/RingTheory/SimpleModule/Isotypic.lean
+++ b/Mathlib/RingTheory/SimpleModule/Isotypic.lean
@@ -231,7 +231,7 @@ theorem Submodule.linearEquiv_of_sSup_eq_top [h : ∀ m : s, IsSimpleModule R m]
     (sSup_eq_iSup' s ▸ hs)
   have ⟨m, hm, _S, le, ⟨e⟩⟩ := N.le_linearEquiv_of_sSup_eq_top _ hs
   have := isSimpleModule_iff_isAtom.mp (IsSimpleModule.congr e.symm)
-  have := ((isSimpleModule_iff_isAtom.mp <| h ⟨m, hm⟩).le_iff_eq this.1).mp le
+  have := ((isSimpleModule_iff_isAtom.mp <| h ⟨m, hm⟩).le_iff_eq this.ne_bot).mp le
   ⟨m, hm, ⟨e.trans (.ofEq _ _ this)⟩⟩
 
 /-- If a simple module is contained in a sum of semisimple modules, it must be isomorphic
@@ -252,7 +252,7 @@ theorem Submodule.linearEquiv_of_le_sSup [simple : ∀ m : s, IsSimpleModule R m
     (hs : N ≤ sSup s) : ∃ S ∈ s, Nonempty (N ≃ₗ[R] S) :=
   have ⟨m, hm, _S, le, ⟨e⟩⟩ := N.le_linearEquiv_of_le_sSup _ hs
   have := isSimpleModule_iff_isAtom.mp (.congr e.symm)
-  have := ((isSimpleModule_iff_isAtom.mp <| simple ⟨m, hm⟩).le_iff_eq this.1).mp le
+  have := ((isSimpleModule_iff_isAtom.mp <| simple ⟨m, hm⟩).le_iff_eq this.ne_bot).mp le
   ⟨m, hm, ⟨e.trans (.ofEq _ _ this)⟩⟩
 
 end SimpleSubmodule

--- a/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
@@ -399,9 +399,10 @@ instance {R : Type*} [Field R] : Unique (PrimeSpectrum R) where
 /-- Also see `PrimeSpectrum.isClosed_singleton_iff_isMaximal` -/
 lemma isMax_iff {x : PrimeSpectrum R} :
     IsMax x ↔ x.asIdeal.IsMaximal := by
-  refine ⟨fun hx ↦ ⟨⟨x.2.ne_top, fun I hI ↦ ?_⟩⟩, fun hx y e ↦ (hx.eq_of_le y.2.ne_top e).ge⟩
+  refine ⟨fun hx ↦ ⟨covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 x.2.ne_top, fun I hI ↦ ?_⟩⟩,
+    fun hx y e ↦ (hx.eq_of_le y.2.ne_top e).ge⟩
   by_contra e
-  obtain ⟨m, hm, hm'⟩ := Ideal.exists_le_maximal I e
+  obtain ⟨m, hm, hm'⟩ := Ideal.exists_le_maximal I e.ne
   exact hx.not_lt (show x < ⟨m, hm.isPrime⟩ from hI.trans_le hm')
 
 lemma zeroLocus_eq_singleton (m : Ideal R) [m.IsMaximal] :

--- a/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
@@ -399,9 +399,8 @@ instance {R : Type*} [Field R] : Unique (PrimeSpectrum R) where
 /-- Also see `PrimeSpectrum.isClosed_singleton_iff_isMaximal` -/
 lemma isMax_iff {x : PrimeSpectrum R} :
     IsMax x ↔ x.asIdeal.IsMaximal := by
-  refine ⟨fun hx ↦ ⟨covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 x.2.ne_top, fun I hI ↦ ?_⟩⟩,
+  refine ⟨fun hx ↦ ⟨covBy_top_iff.1 ⟨lt_top_iff_ne_top.2 x.2.ne_top, fun I hI e ↦ ?_⟩⟩,
     fun hx y e ↦ (hx.eq_of_le y.2.ne_top e).ge⟩
-  by_contra e
   obtain ⟨m, hm, hm'⟩ := Ideal.exists_le_maximal I e.ne
   exact hx.not_lt (show x < ⟨m, hm.isPrime⟩ from hI.trans_le hm')
 

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -284,7 +284,7 @@ variable {α}
 
 lemma Closeds.coe_eq_singleton_of_isAtom [T0Space α] {s : Closeds α} (hs : IsAtom s) :
     ∃ a, (s : Set α) = {a} := by
-  refine minimal_nonempty_closed_eq_singleton s.2 (coe_nonempty.2 hs.1) fun t hts ht ht' ↦ ?_
+  refine minimal_nonempty_closed_eq_singleton s.2 (coe_nonempty.2 hs.ne_bot) fun t hts ht ht' ↦ ?_
   lift t to Closeds α using ht'
   exact SetLike.coe_injective.eq_iff.2 <| (hs.le_iff_eq <| coe_nonempty.1 ht).1 hts
 


### PR DESCRIPTION
We choose for `IsAtom a` to mean `∃ b, b ⋖ a ∧ ∀ c, c < a → b ≤ c`, which is equivalent to the current definition in the case of a `PartialOrder` with `OrderBot`. See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60IsAtom.60.20is.20wrong.20for.20preorders/near/601014129).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
