### PR TITLE
[Merged by Bors] - feat(FieldTheory/Perfect): a field isomorphic to a perfect field is perfect

### DIFF
--- a/Mathlib/FieldTheory/Perfect.lean
+++ b/Mathlib/FieldTheory/Perfect.lean
@@ -342,7 +342,7 @@ instance Algebra.IsAlgebraic.isSeparable_of_perfectField {K L : Type*} [Field K]
     minpoly.irreducible (Algebra.IsIntegral.isIntegral x)⟩
 
 /-- If `L / K` is an algebraic extension, `K` is a perfect field, then so is `L`. -/
-theorem Algebra.IsAlgebraic.perfectField {K L : Type*} [Field K] [Field L] [Algebra K L]
+theorem Algebra.IsAlgebraic.perfectField (K : Type*) {L : Type*} [Field K] [Field L] [Algebra K L]
     [Algebra.IsAlgebraic K L] [PerfectField K] : PerfectField L := ⟨fun {f} hf ↦ by
   obtain ⟨_, _, hi, h⟩ := hf.exists_dvd_monic_irreducible_of_isIntegral (K := K)
   exact (PerfectField.separable_of_irreducible hi).map |>.of_dvd h⟩
@@ -350,7 +350,7 @@ theorem Algebra.IsAlgebraic.perfectField {K L : Type*} [Field K] [Field L] [Alge
 theorem PerfectField.of_ringEquiv {K L : Type*} [Field K] [Field L] (h : K ≃+* L) [PerfectField K] :
     PerfectField L := by
   let := h.toRingHom.toAlgebra
-  exact Algebra.IsAlgebraic.perfectField (K := K)
+  exact Algebra.IsAlgebraic.perfectField
 
 namespace Polynomial
 

--- a/Mathlib/FieldTheory/Perfect.lean
+++ b/Mathlib/FieldTheory/Perfect.lean
@@ -350,7 +350,7 @@ theorem Algebra.IsAlgebraic.perfectField (K : Type*) {L : Type*} [Field K] [Fiel
 theorem PerfectField.of_ringEquiv {K L : Type*} [Field K] [Field L] (h : K ≃+* L) [PerfectField K] :
     PerfectField L := by
   let := h.toRingHom.toAlgebra
-  exact Algebra.IsAlgebraic.perfectField
+  exact Algebra.IsAlgebraic.perfectField K
 
 namespace Polynomial
 

--- a/Mathlib/FieldTheory/Perfect.lean
+++ b/Mathlib/FieldTheory/Perfect.lean
@@ -347,6 +347,11 @@ theorem Algebra.IsAlgebraic.perfectField {K L : Type*} [Field K] [Field L] [Alge
   obtain ⟨_, _, hi, h⟩ := hf.exists_dvd_monic_irreducible_of_isIntegral (K := K)
   exact (PerfectField.separable_of_irreducible hi).map |>.of_dvd h⟩
 
+theorem PerfectField.of_ringEquiv {K L : Type*} [Field K] [Field L] (h : K ≃+* L) [PerfectField K] :
+    PerfectField L := by
+  let := h.toRingHom.toAlgebra
+  exact Algebra.IsAlgebraic.perfectField (K := K)
+
 namespace Polynomial
 
 variable {R : Type*} [CommRing R] [IsDomain R] (p n : ℕ) [ExpChar R p] (f : R[X])

--- a/Mathlib/FieldTheory/Perfect.lean
+++ b/Mathlib/FieldTheory/Perfect.lean
@@ -348,9 +348,9 @@ theorem Algebra.IsAlgebraic.perfectField (K : Type*) {L : Type*} [Field K] [Fiel
   exact (PerfectField.separable_of_irreducible hi).map |>.of_dvd h⟩
 
 theorem PerfectField.of_ringEquiv {K L : Type*} [Field K] [Field L] (h : K ≃+* L) [PerfectField K] :
-    PerfectField L := by
+    PerfectField L :=
   let := h.toRingHom.toAlgebra
-  exact Algebra.IsAlgebraic.perfectField K
+  Algebra.IsAlgebraic.perfectField K
 
 namespace Polynomial
 

--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -467,6 +467,9 @@ theorem of_surjective (f : A →+* B) (hf : Surjective f) : f.Finite :=
 lemma _root_.RingEquiv.finite (e : A ≃+* B) : e.toRingHom.Finite :=
   .of_surjective _ e.surjective
 
+instance (h : A ≃+* B) : letI := h.toRingHom.toAlgebra; Module.Finite A B :=
+  h.finite
+
 theorem comp {g : B →+* C} {f : A →+* B} (hg : g.Finite) (hf : f.Finite) : (g.comp f).Finite := by
   algebraize [f, g, g.comp f]
   exact .trans B C


### PR DESCRIPTION
This PR proves that a field isomorphic to a perfect field is perfect.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
