### PR TITLE
[Merged by Bors] - chore(ci): skip deployment records for cache-upload environment

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -614,7 +614,11 @@ jobs:
     # Pins the OIDC `sub` claim to `...:environment:<cache_environment>`, which the Azure cache
     # app's federated credential is scoped to. A token minted by any job without this environment
     # (e.g. the untrusted build/post_steps/style_lint jobs) cannot satisfy that trust.
-    environment: ${{ inputs.cache_environment }}
+    environment:
+      name: ${{ inputs.cache_environment }}
+      # Skip creating a GitHub deployment record/UI; we use the environment only to
+      # pin the OIDC `sub` claim and gate access to its federated credential.
+      deployment: false
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Uses the `environment: { name, deployment: false }` object form for the `upload_cache` job so GitHub stops creating a deployment record (and the associated "deployment" UI) on every CI run.

The job still references the environment, so its OIDC `sub` claim (`...:environment:<name>`) and the Azure federated-credential gating are unchanged — only the deployment object is suppressed.