### PR TITLE
[Merged by Bors] - feat(MeasureTheory/Integral/IntegrableOn): add IntegrableAtFilter.congr'_enorm

### DIFF
--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -541,7 +541,6 @@ lemma integrableAtFilter_congr (h : f =ᵐ[μ] g) :
 
 lemma IntegrableAtFilter.congr'_enorm
     (hf : IntegrableAtFilter f l μ) (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :
-    (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :
     IntegrableAtFilter g l μ :=
   let ⟨s, hs, hf⟩ := hf; ⟨s, hs, hf.congr'_enorm hg.restrict (ae_restrict_le h)⟩
 

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -539,6 +539,11 @@ lemma integrableAtFilter_congr (h : f =ᵐ[μ] g) :
     IntegrableAtFilter f l μ ↔ IntegrableAtFilter g l μ :=
   ⟨(·.congr h), (·.congr h.symm)⟩
 
+lemma IntegrableAtFilter.congr'_enorm {g : α → ε'} (hf : IntegrableAtFilter f l μ)
+    (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :
+    IntegrableAtFilter g l μ :=
+  Exists.casesOn hf fun s hs ↦ ⟨s, hs.1, hs.2.congr'_enorm hg.restrict (ae_restrict_le h)⟩
+
 @[simp]
 lemma integrableAtFilter_zero : IntegrableAtFilter (0 : α → E) l μ :=
   ⟨univ, by simp, integrableOn_univ.mpr (integrable_zero ..)⟩

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -539,10 +539,11 @@ lemma integrableAtFilter_congr (h : f =ᵐ[μ] g) :
     IntegrableAtFilter f l μ ↔ IntegrableAtFilter g l μ :=
   ⟨(·.congr h), (·.congr h.symm)⟩
 
-lemma IntegrableAtFilter.congr'_enorm
-    (hf : IntegrableAtFilter f l μ) (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :
-    IntegrableAtFilter g l μ :=
-  let ⟨s, hs, hf⟩ := hf; ⟨s, hs, hf.congr'_enorm hg.restrict (ae_restrict_le h)⟩
+lemma IntegrableAtFilter.congr'_enorm {ε'' : Type*} [TopologicalSpace ε''] [ContinuousENorm ε'']
+    {r : α → ε''} (hf : IntegrableAtFilter f l μ) (hr : AEStronglyMeasurable r μ)
+    (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖r a‖ₑ) :
+    IntegrableAtFilter r l μ :=
+  let ⟨s, hs, hf⟩ := hf; ⟨s, hs, hf.congr'_enorm hr.restrict (ae_restrict_le h)⟩
 
 @[simp]
 lemma integrableAtFilter_zero : IntegrableAtFilter (0 : α → E) l μ :=

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -542,7 +542,7 @@ lemma integrableAtFilter_congr (h : f =ᵐ[μ] g) :
 lemma IntegrableAtFilter.congr'_enorm {g : α → ε'} (hf : IntegrableAtFilter f l μ)
     (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :
     IntegrableAtFilter g l μ :=
-  Exists.casesOn hf fun s hs ↦ ⟨s, hs.1, hs.2.congr'_enorm hg.restrict (ae_restrict_le h)⟩
+  let ⟨s, hs, hf⟩ := hf; ⟨s, hs, hf.congr'_enorm hg.restrict (ae_restrict_le h)⟩
 
 @[simp]
 lemma integrableAtFilter_zero : IntegrableAtFilter (0 : α → E) l μ :=

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -540,10 +540,10 @@ lemma integrableAtFilter_congr (h : f =ᵐ[μ] g) :
   ⟨(·.congr h), (·.congr h.symm)⟩
 
 lemma IntegrableAtFilter.congr'_enorm {ε'' : Type*} [TopologicalSpace ε''] [ContinuousENorm ε'']
-    {r : α → ε''} (hf : IntegrableAtFilter f l μ) (hr : AEStronglyMeasurable r μ)
-    (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖r a‖ₑ) :
-    IntegrableAtFilter r l μ :=
-  let ⟨s, hs, hf⟩ := hf; ⟨s, hs, hf.congr'_enorm hr.restrict (ae_restrict_le h)⟩
+    {g : α → ε''} (hf : IntegrableAtFilter f l μ) (hg : AEStronglyMeasurable g μ)
+    (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :
+    IntegrableAtFilter g l μ :=
+  let ⟨s, hs, hf⟩ := hf; ⟨s, hs, hf.congr'_enorm hg.restrict (ae_restrict_le h)⟩
 
 @[simp]
 lemma integrableAtFilter_zero : IntegrableAtFilter (0 : α → E) l μ :=

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -539,7 +539,8 @@ lemma integrableAtFilter_congr (h : f =ᵐ[μ] g) :
     IntegrableAtFilter f l μ ↔ IntegrableAtFilter g l μ :=
   ⟨(·.congr h), (·.congr h.symm)⟩
 
-lemma IntegrableAtFilter.congr'_enorm {g : α → ε'} (hf : IntegrableAtFilter f l μ)
+lemma IntegrableAtFilter.congr'_enorm
+    (hf : IntegrableAtFilter f l μ) (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :
     (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :
     IntegrableAtFilter g l μ :=
   let ⟨s, hs, hf⟩ := hf; ⟨s, hs, hf.congr'_enorm hg.restrict (ae_restrict_le h)⟩


### PR DESCRIPTION
From the Carleson project.

---

**Upstreaming from Carleson: [Carleson/ToMathlib/MeasureTheory/Integral/IntegrableOn.lean](https://github.com/fpvandoorn/carleson/blob/master/Carleson/ToMathlib/MeasureTheory/Integral/IntegrableOn.lean)**

Changes from the Carleson version:

1. changed `theorem` to `lemma` (rationale: similar result in line 534 is a lemma)
2. `{μ : Measure α} [TopologicalSpace ε] [ContinuousENorm ε] {f : α → ε}  {l : Filter α}` - removed because they are defined earlier in the file
3. `[TopologicalSpace ε'] [ContinuousENorm ε']` - removed because they are not used in a lemma (lean warning)
4. the body of the proof is changed from `Exists.casesOn hf fun s hs ↦ ⟨s, hs.1, hs.2.congr'_enorm hg.restrict (ae_restrict_le h)⟩` to `let ⟨s, hs, hf⟩ := hf; ⟨s, hs, hf.congr'_enorm hg.restrict (ae_restrict_le h)⟩` to match the style of neighbouring proofs (e.g. `lemma IntegrableAtFilter.congr`)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
