### PR TITLE
feat(Analysis): the inclusion of the general linear group into linear maps is an open embedding for finite-dimensional TVS

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2236,6 +2236,7 @@ public import Mathlib.Analysis.Normed.Order.Lattice
 public import Mathlib.Analysis.Normed.Order.UpperLower
 public import Mathlib.Analysis.Normed.Ring.Basic
 public import Mathlib.Analysis.Normed.Ring.Finite
+public import Mathlib.Analysis.Normed.Ring.FiniteDimensional
 public import Mathlib.Analysis.Normed.Ring.InfiniteProd
 public import Mathlib.Analysis.Normed.Ring.InfiniteSum
 public import Mathlib.Analysis.Normed.Ring.Int

--- a/Mathlib/Analysis/Normed/Ring/FiniteDimensional.lean
+++ b/Mathlib/Analysis/Normed/Ring/FiniteDimensional.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 Ben Eltschig. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ben Eltschig
+-/
+module
+
+public import Mathlib.Analysis.Normed.Operator.NormedSpace
+public import Mathlib.Analysis.Normed.Ring.Units
+public import Mathlib.Topology.Algebra.Module.FiniteDimension
+
+/-! # The inclusion of the general linear group into linear maps is an open embedding
+
+In this file we prove that for every finite-dimensional Hausdorff topological vector space `E`,
+the inclusion of the general linear group `(E →L[𝕜] E)ˣ` into `E →L[𝕜] E` is an open embedding.
+This is not trivial: the group of units `Mˣ` of a monoid `M` is generally equipped with the coarsest
+topology making both `Units.val : Mˣ → X` and `Units.inv : Mˣ → M` continuous, so it only coincides
+with the subspace topology here because inversion of continuous maps is already continuous away from
+non-invertible maps.
+
+The ingredients for this this (any finite-dimensional Hausdorff TVS is isomorphic to a
+Banach space, `E →L[𝕜] E` is a Banach ring when `E` is a Banach space, every Banach ring satisfies
+`IsOpenUnits`) already exist in various different files; we assemble them only here
+to avoid adding imports to those other files.
+-/
+
+public section
+
+/-- For any finite-dimensional Hausdorff topological vector space `E`, the general linear group
+`(E →L[𝕜] E)ˣ` is open in `E →L[𝕜] E` and equipped with the subspace topology. -/
+instance {𝕜 : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+    {E : Type*} [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E] [IsTopologicalAddGroup E]
+    [ContinuousSMul 𝕜 E] [T2Space E] [FiniteDimensional 𝕜 E] : IsOpenUnits (E →L[𝕜] E) :=
+  ContinuousMulEquiv.isOpenUnits {
+      ((Module.finBasis 𝕜 E).equivFunL.arrowCongr (Module.finBasis 𝕜 E).equivFunL).toHomeomorph with
+    map_mul' := by intros; ext; simp }

--- a/Mathlib/Analysis/Normed/Ring/Units.lean
+++ b/Mathlib/Analysis/Normed/Ring/Units.lean
@@ -193,28 +193,18 @@ theorem inverse_continuousAt (x : Rˣ) : ContinuousAt inverse (x : R) := by
   rw [ContinuousAt, tendsto_iff_norm_sub_tendsto_zero, inverse_unit]
   simpa [Function.comp_def] using h_is_o.norm_left.tendsto_div_nhds_zero.comp h_lim
 
+/-- In a normed ring with summable geometric series, the coercion from `Rˣ` (equipped with the
+induced topology from the embedding in `R × R`) to `R` is an open embedding.
+
+You can use this fact using the lemma `Units.isOpenEmbedding_val` that is part of the
+`IsOpenUnits`-API. -/
+instance instIsOpenUnits : IsOpenUnits R where
+  isOpenEmbedding_unitsVal := {
+    toIsEmbedding := Units.isEmbedding_val_mk'
+      (fun _ ⟨u, hu⟩ ↦ hu ▸ (inverse_continuousAt u).continuousWithinAt) Ring.inverse_unit
+    isOpen_range := Units.isOpen }
+
 end NormedRing
-
-namespace Units
-
-open MulOpposite Filter NormedRing
-
-/-- In a normed ring with summable geometric series, the coercion from `Rˣ` (equipped with the
-induced topology from the embedding in `R × R`) to `R` is an open embedding. -/
-theorem isOpenEmbedding_val : IsOpenEmbedding (val : Rˣ → R) where
-  toIsEmbedding := isEmbedding_val_mk'
-    (fun _ ⟨u, hu⟩ ↦ hu ▸ (inverse_continuousAt u).continuousWithinAt) Ring.inverse_unit
-  isOpen_range := Units.isOpen
-
-/-- In a normed ring with summable geometric series, the coercion from `Rˣ` (equipped with the
-induced topology from the embedding in `R × R`) to `R` is an open map. -/
-theorem isOpenMap_val : IsOpenMap (val : Rˣ → R) :=
-  isOpenEmbedding_val.isOpenMap
-
-end Units
-
-instance NormedRing.instIsOpenUnits : IsOpenUnits R where
-  isOpenEmbedding_unitsVal := Units.isOpenEmbedding_val
 
 namespace Ideal
 

--- a/Mathlib/Analysis/Normed/Ring/Units.lean
+++ b/Mathlib/Analysis/Normed/Ring/Units.lean
@@ -6,6 +6,7 @@ Authors: Heather Macbeth
 module
 
 public import Mathlib.Analysis.SpecificLimits.Normed
+public import Mathlib.Topology.Algebra.IsOpenUnits
 public import Mathlib.Topology.Algebra.Ring.Ideal
 public import Mathlib.RingTheory.Ideal.Nonunits
 
@@ -22,7 +23,9 @@ state, in varying forms, that perturbations of a unit are units. They are not st
 in their optimal form; more precise versions would use the spectral radius.
 
 The first main result is `Units.isOpen`: the group of units of a normed ring with summable
-geometric series is an open subset of the ring.
+geometric series is an open subset of the ring. Furthermore, the topology `Rˣ` comes equipped with
+(induced by the map `Rˣ → R × R` given by `a ↦ (a, a⁻¹)`) coincides with the subspace topology;
+together we provide this in the form of an `IsOpenUnits`-instance.
 
 The function `Ring.inverse` (defined elsewhere), for a ring `R`, sends `a : R` to `a⁻¹` if `a` is a
 unit and `0` if not.  The other major results of this file (notably `NormedRing.inverse_add`,
@@ -209,6 +212,9 @@ theorem isOpenMap_val : IsOpenMap (val : Rˣ → R) :=
   isOpenEmbedding_val.isOpenMap
 
 end Units
+
+instance NormedRing.instIsOpenUnits : IsOpenUnits R where
+  isOpenEmbedding_unitsVal := Units.isOpenEmbedding_val
 
 namespace Ideal
 

--- a/Mathlib/Topology/Algebra/Constructions.lean
+++ b/Mathlib/Topology/Algebra/Constructions.lean
@@ -192,4 +192,15 @@ lemma _root_.Topology.IsEmbedding.units_map {f : M →* N} (hf : IsEmbedding f) 
   exact hf.prodMap (opHomeomorph.isEmbedding.comp <| hf.comp opHomeomorph.symm.isEmbedding)
     |>.comp isEmbedding_embedProduct
 
+@[to_additive]
+lemma _root_.Topology.IsOpenEmbedding.units_map {f : M →* N} (hf : IsOpenEmbedding f) :
+    IsOpenEmbedding (Units.map f) := by
+  refine ⟨hf.isEmbedding.units_map, ?_⟩
+  convert (hf.isOpen_range.preimage Units.continuous_val).inter
+    (hf.isOpen_range.preimage Units.continuous_coe_inv)
+  ext n
+  refine ⟨fun ⟨m, hm⟩ ↦ by simp [← hm], fun ⟨⟨m, hm⟩, ⟨m', hm'⟩⟩ ↦ ?_⟩
+  refine ⟨⟨m, m', hf.injective ?_, hf.injective ?_⟩, by ext; simp [hm]⟩
+    <;> simp [f.map_mul, hm, hm']
+
 end Units

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -1300,10 +1300,6 @@ def toUnits_homeomorph [Group G] [TopologicalSpace G] [ContinuousInv G] : G ≃�
   toEquiv := toUnits.toEquiv
   continuous_toFun := Units.continuous_iff.2 ⟨continuous_id, continuous_inv⟩
 
-@[to_additive] theorem Units.isEmbedding_val [Group G] [TopologicalSpace G] [ContinuousInv G] :
-    IsEmbedding (val : Gˣ → G) :=
-  toUnits_homeomorph.symm.isEmbedding
-
 lemma Continuous.of_coeHom_comp [Group G] [Monoid H] [TopologicalSpace G] [TopologicalSpace H]
     [ContinuousInv G] {f : G →* Hˣ} (hf : Continuous ((Units.coeHom H).comp f)) : Continuous f := by
   apply continuous_induced_rng.mpr ?_

--- a/Mathlib/Topology/Algebra/IsOpenUnits.lean
+++ b/Mathlib/Topology/Algebra/IsOpenUnits.lean
@@ -5,9 +5,8 @@ Authors: Andrew Yang
 -/
 module
 
-public import Mathlib.RingTheory.Jacobson.Ideal
+public import Mathlib.Topology.Algebra.Group.Basic
 public import Mathlib.Topology.Algebra.GroupWithZero
-public import Mathlib.Topology.Algebra.Nonarchimedean.AdicTopology
 
 /-!
 
@@ -58,40 +57,3 @@ instance (priority := 900) {M : Type*} [GroupWithZero M]
     ext
     simp only [Set.mem_range, Set.mem_compl_iff, Set.mem_singleton_iff]
     exact isUnit_iff_ne_zero
-
-/-- If `R` has the `I`-adic topology where `I` is contained in the Jacobson radical
-(e.g. when `R` is complete or local), then `Rˣ` is an open subspace of `R`. -/
-lemma IsOpenUnits.of_isAdic {R : Type*} [CommRing R] [TopologicalSpace R] [IsTopologicalRing R]
-    {I : Ideal R}
-    (hR : IsAdic I) (hI : I ≤ Ideal.jacobson ⊥) :
-    IsOpenUnits R := by
-  refine ⟨.of_continuous_injective_isOpenMap Units.continuous_val Units.val_injective ?_⟩
-  refine (IsTopologicalGroup.isOpenMap_iff_nhds_one (f := Units.coeHom R)).mpr ?_
-  rw [nhds_induced, nhds_prod_eq]
-  simp only [Units.embedProduct_apply, Units.val_one, inv_one, MulOpposite.op_one]
-  intro s hs
-  have H := hR ▸ Ideal.hasBasis_nhds_adic I 1
-  have := (H.prod (H.comap MulOpposite.opHomeomorph.symm))
-  simp only [Homeomorph.comap_nhds_eq, Homeomorph.symm_symm, MulOpposite.opHomeomorph_apply,
-    MulOpposite.op_one, and_self, Set.image_add_left] at this
-  have : ∃ n₁ n₂, ∀ (u : Rˣ), (-1 + u : R) ∈ I ^ n₁ → (-1 + u⁻¹ : R) ∈ I ^ n₂ → ↑u ∈ s := by
-    simpa [Set.subset_def, forall_comm (β := Rˣ), forall_comm (β := _ = _)] using
-      (((this.comap (Units.embedProduct R)).map (Units.coeHom R)).1 _).mp hs
-  obtain ⟨n, hn, hn'⟩ : ∃ n ≠ 0, ∀ (u : Rˣ), (-1 + u : R) ∈ I ^ n →
-      (-1 + u⁻¹ : R) ∈ I ^ n → ↑u ∈ s := by
-    obtain ⟨n₁, n₂, H⟩ := this
-    exact ⟨n₁ ⊔ n₂ ⊔ 1, by simp, fun u h₁ h₂ ↦ H u
-      (Ideal.pow_le_pow_right (by simp) h₁)
-      (Ideal.pow_le_pow_right (by simp) h₂)⟩
-  rw [H.1]
-  refine ⟨n, trivial, ?_⟩
-  rintro _ ⟨x, hx, rfl⟩
-  have := Ideal.mem_jacobson_bot.mp (hI (Ideal.pow_le_self hn hx)) 1
-  rw [mul_one, add_comm] at this
-  refine hn' this.unit (by simpa using hx) ?_
-  have : -1 + ↑this.unit⁻¹ = -this.unit⁻¹ * x := by
-    trans this.unit⁻¹ * (-(1 + x) + 1)
-    · rw [mul_add, mul_neg, IsUnit.val_inv_mul, mul_one]
-    · simp
-  rw [this]
-  exact Ideal.mul_mem_left _ _ hx

--- a/Mathlib/Topology/Algebra/IsOpenUnits.lean
+++ b/Mathlib/Topology/Algebra/IsOpenUnits.lean
@@ -5,6 +5,7 @@ Authors: Andrew Yang
 -/
 module
 
+public import Mathlib.Topology.Algebra.ContinuousMonoidHom
 public import Mathlib.Topology.Algebra.Group.Basic
 public import Mathlib.Topology.Algebra.GroupWithZero
 
@@ -16,7 +17,9 @@ We say that a topological monoid `M` has open units (`IsOpenUnits`) if `Mˣ` is 
 has the subspace topology (i.e. inverse is continuous).
 
 Typical examples include monoids with discrete topology, topological groups (or fields),
-and rings `R` equipped with the `I`-adic topology where `I ≤ J(R)` (`IsOpenUnits.of_isAdic`).
+complete normed rings (for example the ring `E →L[𝕜] E` of continuous linear endomorphisms of any
+Banach space `E`), and rings `R` equipped with the `I`-adic topology where `I ≤ J(R)`
+(`IsOpenUnits.of_isAdic`).
 
 A non-example is `𝔸ₖ`, because the topology on ideles is not the induced topology from adeles.
 
@@ -33,7 +36,7 @@ We say that a topological monoid `M` has open units if `Mˣ` is open in `M` and
 has the subspace topology (i.e. inverse is continuous).
 
 Typical examples include monoids with discrete topology, topological groups (or fields),
-and rings `R` equipped with the `I`-adic topology where `I ≤ J(R)`.
+complete normed rings, and rings `R` equipped with the `I`-adic topology where `I ≤ J(R)`.
 -/
 @[mk_iff]
 class IsOpenUnits (M : Type*) [Monoid M] [TopologicalSpace M] : Prop where
@@ -49,6 +52,15 @@ lemma isOpenEmbedding_val : IsOpenEmbedding (Units.val : Mˣ → M) :=
 lemma isOpenMap_val : IsOpenMap (Units.val : Mˣ → M) := isOpenEmbedding_val.isOpenMap
 
 end Units
+
+/-- Transport an `IsOpenUnits`-instance along an isomorphism. -/
+lemma ContinuousMulEquiv.isOpenUnits {M N : Type*} [TopologicalSpace M] [TopologicalSpace N]
+    [Monoid M] [Monoid N] (e : M ≃ₜ* N) [IsOpenUnits N] : IsOpenUnits M where
+  isOpenEmbedding_unitsVal := by
+    convert e.symm.isOpenEmbedding.comp <| IsOpenUnits.isOpenEmbedding_unitsVal.comp <|
+      e.isOpenEmbedding.units_map (f := e.toMonoidHom)
+    ext m
+    exact (e.symm_apply_apply m).symm
 
 instance (priority := 900) (M : Type*) [Monoid M] [TopologicalSpace M] [DiscreteTopology M] :
     IsOpenUnits M where

--- a/Mathlib/Topology/Algebra/IsOpenUnits.lean
+++ b/Mathlib/Topology/Algebra/IsOpenUnits.lean
@@ -51,6 +51,10 @@ lemma isOpenEmbedding_val : IsOpenEmbedding (Units.val : Mˣ → M) :=
 
 lemma isOpenMap_val : IsOpenMap (Units.val : Mˣ → M) := isOpenEmbedding_val.isOpenMap
 
+lemma isEmbedding_val : IsEmbedding (Units.val : Mˣ → M) := isOpenEmbedding_val.isEmbedding
+
+lemma isInducing_val : IsInducing (Units.val : Mˣ → M) := isOpenEmbedding_val.isInducing
+
 end Units
 
 /-- Transport an `IsOpenUnits`-instance along an isomorphism. -/

--- a/Mathlib/Topology/Algebra/IsOpenUnits.lean
+++ b/Mathlib/Topology/Algebra/IsOpenUnits.lean
@@ -39,6 +39,17 @@ and rings `R` equipped with the `I`-adic topology where `I ≤ J(R)`.
 class IsOpenUnits (M : Type*) [Monoid M] [TopologicalSpace M] : Prop where
   isOpenEmbedding_unitsVal : IsOpenEmbedding (Units.val : Mˣ → M)
 
+namespace Units
+
+variable {M : Type*} [Monoid M] [TopologicalSpace M] [IsOpenUnits M]
+
+lemma isOpenEmbedding_val : IsOpenEmbedding (Units.val : Mˣ → M) :=
+  IsOpenUnits.isOpenEmbedding_unitsVal
+
+lemma isOpenMap_val : IsOpenMap (Units.val : Mˣ → M) := isOpenEmbedding_val.isOpenMap
+
+end Units
+
 instance (priority := 900) (M : Type*) [Monoid M] [TopologicalSpace M] [DiscreteTopology M] :
     IsOpenUnits M where
   isOpenEmbedding_unitsVal :=

--- a/Mathlib/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -5,7 +5,8 @@ Authors: Patrick Massot
 -/
 module
 
-public import Mathlib.RingTheory.Ideal.Maps
+public import Mathlib.RingTheory.Jacobson.Ideal
+public import Mathlib.Topology.Algebra.IsOpenUnits
 public import Mathlib.Topology.Algebra.IsUniformGroup.Defs
 public import Mathlib.Topology.Algebra.Nonarchimedean.Bases
 public import Mathlib.Topology.Algebra.TopologicallyNilpotent
@@ -38,6 +39,8 @@ corresponding adic topology to the type class inference system.
 * `isAdic_iff`: A topological ring is `J`-adic if and only if it admits the powers of `J` as
   a basis of open neighborhoods of zero.
 * `WithIdeal`: a class registering an ideal in a ring.
+* `IsOpenUnits.of_isAdic`: when `R` carries the `I`-adic topology and `I` is contained in the
+  Jacobson radical, `Rˣ` is open in `R` and equipped with the subspace topology.
 
 ## Implementation notes
 
@@ -228,6 +231,44 @@ omit [IsTopologicalRing R] in
 theorem IsAdic.hasBasis_nhds {I : Ideal R} (hI : IsAdic I) (x : R) :
     (𝓝 x).HasBasis (fun _ ↦ True) fun n ↦ (x + ·) '' ↑(I ^ n) :=
   hI ▸ Ideal.hasBasis_nhds_adic I x
+
+/-- If `R` has the `I`-adic topology where `I` is contained in the Jacobson radical
+(e.g. when `R` is complete or local), then `Rˣ` is an open subspace of `R`. -/
+lemma IsOpenUnits.of_isAdic {R : Type*} [CommRing R] [TopologicalSpace R] [IsTopologicalRing R]
+    {I : Ideal R}
+    (hR : IsAdic I) (hI : I ≤ Ideal.jacobson ⊥) :
+    IsOpenUnits R := by
+  refine ⟨.of_continuous_injective_isOpenMap Units.continuous_val Units.val_injective ?_⟩
+  refine (IsTopologicalGroup.isOpenMap_iff_nhds_one (f := Units.coeHom R)).mpr ?_
+  rw [nhds_induced, nhds_prod_eq]
+  simp only [Units.embedProduct_apply, Units.val_one, inv_one, MulOpposite.op_one]
+  intro s hs
+  have H := hR ▸ Ideal.hasBasis_nhds_adic I 1
+  have := (H.prod (H.comap MulOpposite.opHomeomorph.symm))
+  simp only [Homeomorph.comap_nhds_eq, Homeomorph.symm_symm, MulOpposite.opHomeomorph_apply,
+    MulOpposite.op_one, and_self, Set.image_add_left] at this
+  have : ∃ n₁ n₂, ∀ (u : Rˣ), (-1 + u : R) ∈ I ^ n₁ → (-1 + u⁻¹ : R) ∈ I ^ n₂ → ↑u ∈ s := by
+    simpa [Set.subset_def, forall_comm (β := Rˣ), forall_comm (β := _ = _)] using
+      (((this.comap (Units.embedProduct R)).map (Units.coeHom R)).1 _).mp hs
+  obtain ⟨n, hn, hn'⟩ : ∃ n ≠ 0, ∀ (u : Rˣ), (-1 + u : R) ∈ I ^ n →
+      (-1 + u⁻¹ : R) ∈ I ^ n → ↑u ∈ s := by
+    obtain ⟨n₁, n₂, H⟩ := this
+    exact ⟨n₁ ⊔ n₂ ⊔ 1, by simp, fun u h₁ h₂ ↦ H u
+      (Ideal.pow_le_pow_right (by simp) h₁)
+      (Ideal.pow_le_pow_right (by simp) h₂)⟩
+  rw [H.1]
+  refine ⟨n, trivial, ?_⟩
+  rintro _ ⟨x, hx, rfl⟩
+  have := Ideal.mem_jacobson_bot.mp (hI (Ideal.pow_le_self hn hx)) 1
+  rw [mul_one, add_comm] at this
+  refine hn' this.unit (by simpa using hx) ?_
+  have : -1 + ↑this.unit⁻¹ = -this.unit⁻¹ * x := by
+    trans this.unit⁻¹ * (-(1 + x) + 1)
+    · rw [mul_add, mul_neg, IsUnit.val_inv_mul, mul_one]
+    · simp
+  rw [this]
+  exact Ideal.mul_mem_left _ _ hx
+
 
 end IsAdic
 


### PR DESCRIPTION
Add an instance of `IsOpenUnits (E →L[𝕜] E)` for every finite-dimensional Hausdorff TVS `E`, showing that the inclusion of the general linear group `(E →L[𝕜] E)ˣ` of `E` into `E →L[𝕜] E` is an open embedding.

This instance can already inferred for Banach spaces, and of course every finite-dimensional Hausdorff TVS can be made into a Banach space, but putting those pieces together was complicated enough that I think it is worth having this as a separate instance. Even when `E` already carries a norm, `CompleteSpace E` can't be synthesized from `FiniteDimensional 𝕜 E` because `𝕜` can't be inferred, so this is still useful for making `IsOpenUnits (E →L[𝕜] E)` available then.

Since I couldn't find a file with all necessary imports I started a new file just for this instance, but I'm not sure where to place it either; hopefully the current place is fine.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [ ] depends on: #40379
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
