### PR TITLE
[Merged by Bors] - feat(RingTheory/Ideal/Defs): add `Ideal.coe_mem_inertia`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -1061,26 +1061,34 @@ def noncenter (G : Type*) [Monoid G] : Set (ConjClasses G) :=
 
 end ConjClasses
 
+namespace AddSubgroup
+
+variable {M : Type*} [AddGroup M] (I : AddSubgroup M) (G : Type*)
+    [Group G] [MulAction G M]
+
 /-- Suppose `G` acts on `M` and `I` is a subgroup of `M`.
 The inertia subgroup of `I` is the subgroup of `G` whose action is trivial mod `I`. -/
-def AddSubgroup.inertia {M : Type*} [AddGroup M] (I : AddSubgroup M) (G : Type*)
-    [Group G] [MulAction G M] : Subgroup G where
+def inertia : Subgroup G where
   carrier := { σ | ∀ x, σ • x - x ∈ I }
   mul_mem' {a b} ha hb x := by simpa [mul_smul] using add_mem (ha (b • x)) (hb x)
   one_mem' := by simp [zero_mem]
   inv_mem' {a} ha x := by simpa using sub_mem_comm_iff.mp (ha (a⁻¹ • x))
 
-@[simp] lemma AddSubgroup.mem_inertia {M : Type*} [AddGroup M] {I : AddSubgroup M} {G : Type*}
-    [Group G] [MulAction G M] {σ : G} : σ ∈ I.inertia G ↔ ∀ x, σ • x - x ∈ I := .rfl
-
+variable {I G} in
 @[simp]
-lemma AddSubgroup.subgroupOf_inertia {M : Type*} [AddGroup M] (I : AddSubgroup M)
-    {G : Type*} [Group G] [MulAction G M] (H : Subgroup G) :
-    (I.inertia G).subgroupOf H = I.inertia H :=
+lemma mem_inertia {σ : G} : σ ∈ I.inertia G ↔ ∀ x, σ • x - x ∈ I := .rfl
+
+variable {G} in
+@[simp]
+lemma subgroupOf_inertia (H : Subgroup G) : (I.inertia G).subgroupOf H = I.inertia H :=
   rfl
 
+variable {I G} in
+lemma coe_mem_inertia {H : Subgroup G} {σ : H} : ↑σ ∈ I.inertia G ↔ σ ∈ I.inertia H := .rfl
+
+variable {G} in
 @[simp]
-lemma AddSubgroup.inertia_map_subtype {M : Type*} [AddGroup M] (I : AddSubgroup M)
-    {G : Type*} [Group G] [MulAction G M] (H : Subgroup G) :
-    (I.inertia H).map H.subtype = I.inertia G ⊓ H := by
+lemma inertia_map_subtype (H : Subgroup G) : (I.inertia H).map H.subtype = I.inertia G ⊓ H := by
   rw [← AddSubgroup.subgroupOf_inertia, Subgroup.subgroupOf_map_subtype]
+
+end AddSubgroup

--- a/Mathlib/RingTheory/Ideal/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Defs.lean
@@ -146,11 +146,18 @@ theorem mul_sub_mul_mem [I.IsTwoSided]
   rw [show a * c - b * d = (a - b) * c + b * (c - d) by rw [sub_mul, mul_sub]; abel]
   exact I.add_mem (I.mul_mem_right _ h1) (I.mul_mem_left _ h2)
 
-/--
-The subgroup of elements `g` of `G` such that `∀ x, g • x - x ∈ I`.
--/
-abbrev inertia (G : Type*) [Group G] [MulAction G α] (I : Ideal α) :
-    Subgroup G := AddSubgroup.inertia I.toAddSubgroup G
+section inertia
+
+variable (I : Ideal α) (G : Type*) [Group G] [MulAction G α]
+
+/-- The subgroup of elements `g` of `G` such that `∀ x, g • x - x ∈ I`. -/
+abbrev inertia : Subgroup G := I.toAddSubgroup.inertia G
+
+variable {I G} in
+theorem coe_mem_inertia {H : Subgroup G} {σ : H} : ↑σ ∈ I.inertia G ↔ σ ∈ I.inertia H :=
+  I.toAddSubgroup.coe_mem_inertia
+
+end inertia
 
 end Ideal
 

--- a/Mathlib/RingTheory/Ideal/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Defs.lean
@@ -148,7 +148,7 @@ theorem mul_sub_mul_mem [I.IsTwoSided]
 
 section inertia
 
-variable (I : Ideal α) (G : Type*) [Group G] [MulAction G α]
+variable (G : Type*) [Group G] [MulAction G α] (I : Ideal α)
 
 /-- The subgroup of elements `g` of `G` such that `∀ x, g • x - x ∈ I`. -/
 abbrev inertia : Subgroup G := I.toAddSubgroup.inertia G

--- a/Mathlib/RingTheory/Ideal/Pointwise.lean
+++ b/Mathlib/RingTheory/Ideal/Pointwise.lean
@@ -150,7 +150,7 @@ theorem IsPrime.smul_iff {I : Ideal R} (g : M) : (g • I).IsPrime ↔ I.IsPrime
   ⟨fun H ↦ inv_smul_smul g I ▸ H.smul g⁻¹, fun H ↦ H.smul g⟩
 
 theorem inertia_le_stabilizer {R : Type*} [Ring R] (P : Ideal R) [MulSemiringAction M R] :
-    inertia M P ≤ MulAction.stabilizer M P := by
+    P.inertia M ≤ MulAction.stabilizer M P := by
   refine fun σ hσ ↦ SetLike.ext fun x ↦ ?_
   rw [Ideal.mem_pointwise_smul_iff_inv_smul_mem,
     ← P.add_mem_iff_left (a := x) ((inv_mem hσ) x), add_sub_cancel]
@@ -194,13 +194,13 @@ of `I` in `N`.
 -/
 def inertiaEquiv {R : Type*} [Ring R] [MulSemiringAction M R] [MulSemiringAction N R] (I : Ideal R)
     (e : M ≃* N) (he : ∀ (m : M) (x : R), (e m) • x = m • x) :
-    inertia M I ≃* inertia N I where
+    I.inertia M ≃* I.inertia N where
   toEquiv := Equiv.subtypeEquiv e fun _ ↦ by simp [he]
   map_mul' := by simp
 
 @[simp]
 theorem inertiaEquiv_apply_smul {R : Type*} [Ring R] [MulSemiringAction M R] [MulSemiringAction N R]
-    (I : Ideal R) (e : M ≃* N) (he : ∀ (m : M) (x : R), (e m) • x = m • x) (m : inertia M I)
+    (I : Ideal R) (e : M ≃* N) (he : ∀ (m : M) (x : R), (e m) • x = m • x) (m : I.inertia M)
     (x : R) :
     inertiaEquiv I e he m • x = m • x := by
   simp [inertiaEquiv, MulAction.subgroup_smul_def, ← he m x]
@@ -208,7 +208,7 @@ theorem inertiaEquiv_apply_smul {R : Type*} [Ring R] [MulSemiringAction M R] [Mu
 @[simp]
 theorem inertiaEquiv_symm_apply_smul {R : Type*} [Ring R] [MulSemiringAction M R]
     [MulSemiringAction N R] (I : Ideal R) (e : M ≃* N) (he : ∀ (m : M) (x : R), (e m) • x = m • x)
-    (n : inertia N I) (x : R) :
+    (n : I.inertia N) (x : R) :
     (inertiaEquiv I e he).symm n • x = n • x := by
   rw [← (inertiaEquiv I e he).apply_symm_apply n, inertiaEquiv_apply_smul,
     (inertiaEquiv I e he).apply_symm_apply]

--- a/Mathlib/RingTheory/Ideal/Pointwise.lean
+++ b/Mathlib/RingTheory/Ideal/Pointwise.lean
@@ -150,7 +150,7 @@ theorem IsPrime.smul_iff {I : Ideal R} (g : M) : (g • I).IsPrime ↔ I.IsPrime
   ⟨fun H ↦ inv_smul_smul g I ▸ H.smul g⁻¹, fun H ↦ H.smul g⟩
 
 theorem inertia_le_stabilizer {R : Type*} [Ring R] (P : Ideal R) [MulSemiringAction M R] :
-    inertia M I ≤ MulAction.stabilizer M P := by
+    inertia M P ≤ MulAction.stabilizer M P := by
   refine fun σ hσ ↦ SetLike.ext fun x ↦ ?_
   rw [Ideal.mem_pointwise_smul_iff_inv_smul_mem,
     ← P.add_mem_iff_left (a := x) ((inv_mem hσ) x), add_sub_cancel]

--- a/Mathlib/RingTheory/Ideal/Pointwise.lean
+++ b/Mathlib/RingTheory/Ideal/Pointwise.lean
@@ -150,7 +150,7 @@ theorem IsPrime.smul_iff {I : Ideal R} (g : M) : (g • I).IsPrime ↔ I.IsPrime
   ⟨fun H ↦ inv_smul_smul g I ▸ H.smul g⁻¹, fun H ↦ H.smul g⟩
 
 theorem inertia_le_stabilizer {R : Type*} [Ring R] (P : Ideal R) [MulSemiringAction M R] :
-    P.inertia M ≤ MulAction.stabilizer M P := by
+    inertia M I ≤ MulAction.stabilizer M P := by
   refine fun σ hσ ↦ SetLike.ext fun x ↦ ?_
   rw [Ideal.mem_pointwise_smul_iff_inv_smul_mem,
     ← P.add_mem_iff_left (a := x) ((inv_mem hσ) x), add_sub_cancel]
@@ -194,13 +194,13 @@ of `I` in `N`.
 -/
 def inertiaEquiv {R : Type*} [Ring R] [MulSemiringAction M R] [MulSemiringAction N R] (I : Ideal R)
     (e : M ≃* N) (he : ∀ (m : M) (x : R), (e m) • x = m • x) :
-    I.inertia M ≃* I.inertia N where
+    inertia M I ≃* inertia N I where
   toEquiv := Equiv.subtypeEquiv e fun _ ↦ by simp [he]
   map_mul' := by simp
 
 @[simp]
 theorem inertiaEquiv_apply_smul {R : Type*} [Ring R] [MulSemiringAction M R] [MulSemiringAction N R]
-    (I : Ideal R) (e : M ≃* N) (he : ∀ (m : M) (x : R), (e m) • x = m • x) (m : I.inertia M)
+    (I : Ideal R) (e : M ≃* N) (he : ∀ (m : M) (x : R), (e m) • x = m • x) (m : inertia M I)
     (x : R) :
     inertiaEquiv I e he m • x = m • x := by
   simp [inertiaEquiv, MulAction.subgroup_smul_def, ← he m x]
@@ -208,7 +208,7 @@ theorem inertiaEquiv_apply_smul {R : Type*} [Ring R] [MulSemiringAction M R] [Mu
 @[simp]
 theorem inertiaEquiv_symm_apply_smul {R : Type*} [Ring R] [MulSemiringAction M R]
     [MulSemiringAction N R] (I : Ideal R) (e : M ≃* N) (he : ∀ (m : M) (x : R), (e m) • x = m • x)
-    (n : I.inertia N) (x : R) :
+    (n : inertia N I) (x : R) :
     (inertiaEquiv I e he).symm n • x = n • x := by
   rw [← (inertiaEquiv I e he).apply_symm_apply n, inertiaEquiv_apply_smul,
     (inertiaEquiv I e he).apply_symm_apply]


### PR DESCRIPTION
This PR adds a lemma `coe_mem_inertia` for the situation when a coercion from a subgroup lies in an inertia subgroup. I added both an `AddSubgroup` version and an `Ideal` version to allow for better rewriting.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
