### PR TITLE
[Merged by Bors] - chore: remove unnecessary Std imports

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Arthur Paulino. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Jon Eugster
 -/
-import Std.Data.TreeSet
 import Cache.Lean
 import Lake.Load.Toml
 import Batteries.Tactic.OpenPrivate

--- a/Mathlib/Lean/MessageData/Trace.lean
+++ b/Mathlib/Lean/MessageData/Trace.lean
@@ -7,7 +7,6 @@ module
 
 import Mathlib.Init
 public import Lean.Message
-public import Std.Data.HashSet.Basic
 
 /-!
 # Utilities for analyzing `MessageData`

--- a/Mathlib/Lean/Name.lean
+++ b/Mathlib/Lean/Name.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Init
 public import Lean.Meta.Match.MatcherInfo
-public import Std.Data.HashMap.Basic
 
 /-!
 # Additional functions on `Lean.Name`.

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -9,7 +9,6 @@ module
 public meta import Mathlib.Tactic.FunProp.Mor
 public import Mathlib.Tactic.FunProp.Mor
 public import Mathlib.Tactic.FunProp.ToBatteries
-public meta import Std.Do
 
 /-!
 ## `funProp` data structure holding information about a function

--- a/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/Datatypes.lean
@@ -6,7 +6,6 @@ Authors: Vasily Nesterov
 module
 
 public import Mathlib.Init
-public meta import Std.Data.HashMap.Basic
 
 /-!
 # Datatypes for the Simplex Algorithm implementation

--- a/Mathlib/Tactic/Linter/DocString.lean
+++ b/Mathlib/Tactic/Linter/DocString.lean
@@ -9,7 +9,6 @@ public meta import Mathlib.Tactic.Linter.Header  -- shake: keep
 public meta import Std.Data.Iterators.Combinators.Zip
 public import Lean.Parser.Command
 meta import Std.Data.Iterators.Producers.Range
-import Std.Data.Iterators
 
 /-!
 # The "DocString" style linter

--- a/Mathlib/Tactic/Linter/ValidatePRTitle.lean
+++ b/Mathlib/Tactic/Linter/ValidatePRTitle.lean
@@ -8,7 +8,6 @@ module
 
 import Mathlib.Init
 import Mathlib.Tactic.Linter.TextBased.UnicodeLinter
-import Std.Internal.Parsec.String
 
 /-!
 # Checker for well-formed title and labels

--- a/Mathlib/Util/MemoFix.lean
+++ b/Mathlib/Util/MemoFix.lean
@@ -5,7 +5,6 @@ Authors: Gabriel Ebner, Edward Ayers
 -/
 module
 
-public import Std.Data.HashMap.Basic
 public import Mathlib.Init
 
 /-!


### PR DESCRIPTION
It turns out most imports of things in `Std` are redundant, so this PR removes them.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
