### PR TITLE
chore(MeasureTheory/Constructions/BorelSpace): remove some `erw`'s

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -410,8 +410,12 @@ theorem Dense.borel_eq_generateFrom_Ioc_mem_aux {α : Type*} [TopologicalSpace �
   · ext s
     constructor <;> rintro ⟨l, hl, u, hu, hlt, rfl⟩
     exacts [⟨u, hu, l, hl, hlt, Ico_toDual⟩, ⟨u, hu, l, hl, hlt, Ioc_toDual⟩]
-  · erw [Ioo_toDual]
-    exact he
+  · calc
+      _ = OrderDual.ofDual '' (Ioo x y) := by
+        ext
+        simp only [mem_Ioo, mem_image_equiv, OrderDual.ofDual_symm_eq, OrderDual.toDual_of_op]
+        exact And.comm
+      _ = _ := by rw [he, image_empty]
 
 theorem Dense.borel_eq_generateFrom_Ioc_mem {α : Type*} [TopologicalSpace α] [LinearOrder α]
     [OrderTopology α] [SecondCountableTopology α] [DenselyOrdered α] [NoMaxOrder α] {s : Set α}
@@ -463,9 +467,10 @@ theorem ext_of_Ioc_finite {α : Type*} [TopologicalSpace α] {m : MeasurableSpac
     [SecondCountableTopology α] [LinearOrder α] [OrderTopology α] [BorelSpace α] (μ ν : Measure α)
     [IsFiniteMeasure μ] (hμν : μ univ = ν univ) (h : ∀ ⦃a b⦄, a < b → μ (Ioc a b) = ν (Ioc a b)) :
     μ = ν := by
-  refine @ext_of_Ico_finite αᵒᵈ _ _ _ _ _ ‹_› μ ν _ hμν fun a b hab => ?_
-  erw [Ico_toDual (α := α)]
-  exact h hab
+  refine ext_of_generate_finite _ (BorelSpace.measurable_eq.trans (borel_eq_generateFrom_Ioc α))
+      (isPiSystem_Ioc (id : α → α) id) ?_ hμν
+  rintro - ⟨a, b, hlt, rfl⟩
+  exact h hlt
 
 /-- Two measures which are finite on closed-open intervals are equal if they agree on all
 closed-open intervals. -/
@@ -498,7 +503,10 @@ theorem ext_of_Ioc' {α : Type*} [TopologicalSpace α] {m : MeasurableSpace α}
     [SecondCountableTopology α] [LinearOrder α] [OrderTopology α] [BorelSpace α] [NoMinOrder α]
     (μ ν : Measure α) (hμ : ∀ ⦃a b⦄, a < b → μ (Ioc a b) ≠ ∞)
     (h : ∀ ⦃a b⦄, a < b → μ (Ioc a b) = ν (Ioc a b)) : μ = ν := by
-  refine @ext_of_Ico' αᵒᵈ _ _ _ _ _ ‹_› _ μ ν ?_ ?_ <;> intro a b hab <;> erw [Ico_toDual (α := α)]
+  refine @ext_of_Ico' αᵒᵈ _ _ _ _ _ ‹_› _ μ ν ?_ ?_
+  all_goals
+    intro a b hab
+    rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b, Ico_toDual]
   exacts [hμ hab, h hab]
 
 /-- Two measures which are finite on closed-open intervals are equal if they agree on all

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -145,6 +145,17 @@ theorem Ico_ofDual {x y : αᵒᵈ} : Ico (ofDual y) (ofDual x) = toDual ⁻¹' 
 theorem Ioo_ofDual {x y : αᵒᵈ} : Ioo (ofDual y) (ofDual x) = toDual ⁻¹' Ioo x y :=
   Set.ext fun _ => and_comm
 
+@[to_dual]
+theorem OrderDual.ofDual_Ioc_preimage_Ioc (a b : αᵒᵈ) :
+    Ico a b = ⇑OrderDual.ofDual ⁻¹' Ioc (α := α) (↑b : α) a := by
+  conv_lhs => rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b]
+  exact Ico_toDual
+
+theorem OrderDual.ofDual_Ioo_preimage_Ioo (a b : αᵒᵈ) :
+    Ioo a b = ⇑OrderDual.ofDual ⁻¹' Ioo (α := α) (↑b : α) a := by
+  conv_lhs => rw [← OrderDual.toDual_of_op a, ← OrderDual.toDual_of_op b]
+  rw [Ioo_toDual (α := α)]
+
 @[to_dual (attr := simp)]
 theorem nonempty_Iio [NoMinOrder α] : (Iio a).Nonempty :=
   exists_lt a

--- a/Mathlib/Order/OrderDual.lean
+++ b/Mathlib/Order/OrderDual.lean
@@ -141,6 +141,8 @@ def ofDual : αᵒᵈ ≃ α :=
 @[simp] theorem toDual_comp_ofDual : (toDual (α := α)) ∘ ofDual = id := rfl
 @[simp] theorem ofDual_comp_toDual : (ofDual (α := α)) ∘ toDual = id := rfl
 
+theorem toDual_of_op (a : αᵒᵈ) : OrderDual.toDual (α := α) a = a := rfl
+
 theorem toDual_inj {a b : α} : toDual a = toDual b ↔ a = b := by simp
 theorem ofDual_inj {a b : αᵒᵈ} : ofDual a = ofDual b ↔ a = b := by simp
 


### PR DESCRIPTION
Extracted from #40348

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
