### PR TITLE
feat: normal_of_le_center

### DIFF
--- a/Mathlib/GroupTheory/Subgroup/Center.lean
+++ b/Mathlib/GroupTheory/Subgroup/Center.lean
@@ -112,8 +112,8 @@ variable {H : Subgroup G}
 section Normalizer
 
 @[to_additive]
-theorem normal_of_le_center (h : H ≤ Subgroup.center G) : H.Normal :=
-  ⟨ fun n hn g => by grind [(h hn).comm g, mul_assoc, mul_inv_cancel, mul_one] ⟩
+theorem normal_of_le_center (h : H ≤ Subgroup.center G) : H.Normal where
+  conj_mem n hn g := by simpa [← (h hn).comm g |>.eq]
 
 @[to_additive]
 instance instNormalCenter : (center G).Normal := normal_of_le_center le_rfl

--- a/Mathlib/GroupTheory/Subgroup/Center.lean
+++ b/Mathlib/GroupTheory/Subgroup/Center.lean
@@ -112,8 +112,11 @@ variable {H : Subgroup G}
 section Normalizer
 
 @[to_additive]
-instance instNormalCenter : (center G).Normal :=
-  ⟨fun a ha b ↦ by simpa [mem_center_iff.mp ha b]⟩
+theorem normal_of_le_center (h : H ≤ Subgroup.center G) : H.Normal :=
+  ⟨ fun n hn g => by grind [(h hn).comm g, mul_assoc, mul_inv_cancel, mul_one] ⟩
+
+@[to_additive]
+instance instNormalCenter : (center G).Normal := normal_of_le_center le_rfl
 
 @[to_additive]
 theorem center_le_normalizer (s : Set G) : center G ≤ normalizer s := by


### PR DESCRIPTION
`instNormalCenter` states that the center of a group is normal

Actually, a more general statement is true: every subgroup of the center is normal.

This PR proves the more general statement as `normal_of_le_center` and makes `instNormalCenter` a special case of that

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
