### PR TITLE
feat(Data/Finset/Sym): add Finset.sum_count_sym_eq_val_sum

### DIFF
--- a/Mathlib/Data/Finset/Sym.lean
+++ b/Mathlib/Data/Finset/Sym.lean
@@ -5,10 +5,11 @@ Authors: Yaël Dillies
 -/
 module
 
-public import Mathlib.Data.Finset.Lattice.Fold
+public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+public import Mathlib.Algebra.Group.Finsupp
+public import Mathlib.Algebra.Module.NatInt
 public import Mathlib.Data.Fintype.Vector
 public import Mathlib.Data.Multiset.Sym
-public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 
 /-!
 # Symmetric powers of a finset
@@ -298,6 +299,21 @@ theorem val_prod_eq_prod_count_pow [CommMonoid α] {n : ℕ} {k : Sym α n}
   simp only [Sym.val_eq_coe, Multiset.mem_toFinset, Sym.mem_coe] at hx
   simp only [Finset.mem_sym_iff] at hk
   exact hk x hx
+
+theorem sum_count_sym_eq_val_sum {ι : Type*} [DecidableEq ι] {n : ℕ} {k : Sym (ι →₀ ℕ) n}
+    {s : Finset (ι →₀ ℕ)} (hk : k ∈ s.sym n) :
+    ∑ d ∈ s, Multiset.count d k • d = k.val.sum := by
+  induction n with
+  | zero =>
+    have : k = 0 := Sym.uniqueZero.eq_default k
+    simp [this]
+  | succ n hrec =>
+    simp only [sym_succ, Nat.succ_eq_add_one, mem_sup, mem_image] at hk
+    obtain ⟨a, hat, k, hk, rfl⟩ := hk
+    simp only [Sym.coe_cons, Multiset.count_cons, add_smul, ite_smul, one_smul, zero_nsmul,
+      Sym.val_eq_coe, Nat.succ_eq_add_one, Multiset.sum_cons, sum_add_distrib]
+    nth_rewrite 2 [sum_eq_single a (fun _ _ hab ↦ by rw [if_neg hab]) (fun has ↦ (has hat).elim)]
+    rw [if_pos rfl, add_comm, hrec hk, Sym.val_eq_coe]
 
 end Sym
 


### PR DESCRIPTION
Co-authored by: @AntoineChambert-Loir 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
