### PR TITLE
[Merged by Bors] - feat(Algebra/Star/Unitary): characterize unitary elements in rings with trivial star

### DIFF
--- a/Mathlib/Algebra/Star/Unitary.lean
+++ b/Mathlib/Algebra/Star/Unitary.lean
@@ -430,14 +430,14 @@ theorem mem_iff_eq_one_or_eq_neg_one [Ring R] [StarRing R] [TrivialStar R] [NoZe
     {a : R} : a ∈ unitary R ↔ a = 1 ∨ a = -1 := by
   simp [mem_iff, mul_self_eq_one_iff]
 
+end Unitary
+
 /-- In a ring without zero divisors and with trivial star, the unitary elements are exactly `1`
 and `-1`. -/
-theorem coe_unitary_eq_insert_neg_one (R : Type*) [Ring R] [StarRing R] [TrivialStar R]
+theorem coe_unitary_eq_one_neg_one (R : Type*) [Ring R] [StarRing R] [TrivialStar R]
     [NoZeroDivisors R] : (unitary R : Set R) = {1, -1} := by
   ext a
-  simp [mem_iff_eq_one_or_eq_neg_one]
-
-end Unitary
+  simp [Unitary.mem_iff_eq_one_or_eq_neg_one]
 
 theorem IsStarProjection.two_mul_sub_one_mem_unitary {R : Type*} [Ring R] [StarRing R] {p : R}
     (hp : IsStarProjection p) : 2 * p - 1 ∈ unitary R := by

--- a/Mathlib/Algebra/Star/Unitary.lean
+++ b/Mathlib/Algebra/Star/Unitary.lean
@@ -434,10 +434,9 @@ end Unitary
 
 /-- In a ring without zero divisors and with trivial star, the unitary elements are exactly `1`
 and `-1`. -/
-theorem coe_unitary_eq_one_neg_one (R : Type*) [Ring R] [StarRing R] [TrivialStar R]
-    [NoZeroDivisors R] : (unitary R : Set R) = {1, -1} := by
-  ext a
-  simp [Unitary.mem_iff_eq_one_or_eq_neg_one]
+theorem coe_unitary_eq_neg_one_one (R : Type*) [Ring R] [StarRing R] [TrivialStar R]
+    [NoZeroDivisors R] : (unitary R : Set R) = {-1, 1} := by
+  simp [Set.ext_iff, Unitary.mem_iff_eq_one_or_eq_neg_one, or_comm]
 
 theorem IsStarProjection.two_mul_sub_one_mem_unitary {R : Type*} [Ring R] [StarRing R] {p : R}
     (hp : IsStarProjection p) : 2 * p - 1 ∈ unitary R := by

--- a/Mathlib/Algebra/Star/Unitary.lean
+++ b/Mathlib/Algebra/Star/Unitary.lean
@@ -432,12 +432,6 @@ theorem mem_iff_eq_one_or_eq_neg_one [Ring R] [StarRing R] [TrivialStar R] [NoZe
 
 end Unitary
 
-/-- In a ring without zero divisors and with trivial star, the unitary elements are exactly `1`
-and `-1`. -/
-theorem coe_unitary_eq_neg_one_one (R : Type*) [Ring R] [StarRing R] [TrivialStar R]
-    [NoZeroDivisors R] : (unitary R : Set R) = {-1, 1} := by
-  simp [Set.ext_iff, Unitary.mem_iff_eq_one_or_eq_neg_one, or_comm]
-
 theorem IsStarProjection.two_mul_sub_one_mem_unitary {R : Type*} [Ring R] [StarRing R] {p : R}
     (hp : IsStarProjection p) : 2 * p - 1 ∈ unitary R := by
   simp only [two_mul, Unitary.mem_iff, star_sub, star_add,

--- a/Mathlib/Algebra/Star/Unitary.lean
+++ b/Mathlib/Algebra/Star/Unitary.lean
@@ -424,6 +424,19 @@ lemma spectrum_star_left_conjugate {a : A} {U : unitary A} :
 
 end UnitaryConjugate
 
+/-- In a ring without zero divisors and with trivial star, the only unitary elements are `1`
+and `-1`. -/
+theorem mem_iff_eq_one_or_eq_neg_one [Ring R] [StarRing R] [TrivialStar R] [NoZeroDivisors R]
+    {a : R} : a ∈ unitary R ↔ a = 1 ∨ a = -1 := by
+  simp [mem_iff, mul_self_eq_one_iff]
+
+/-- In a ring without zero divisors and with trivial star, the unitary elements are exactly `1`
+and `-1`. -/
+theorem coe_unitary_eq_insert_neg_one (R : Type*) [Ring R] [StarRing R] [TrivialStar R]
+    [NoZeroDivisors R] : (unitary R : Set R) = {1, -1} := by
+  ext a
+  simp [mem_iff_eq_one_or_eq_neg_one]
+
 end Unitary
 
 theorem IsStarProjection.two_mul_sub_one_mem_unitary {R : Type*} [Ring R] [StarRing R] {p : R}


### PR DESCRIPTION
In a ring without zero divisors and with trivial star, the only unitary elements are `1` and `-1`.