### PR TITLE
[Merged by Bors] - chore: fix non-reducible diamond in representations

### DIFF
--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -366,11 +366,10 @@ end OfQuotient
 
 section AddCommGroup
 
-variable {k G V : Type*} [Ring k] [Monoid G] [I : AddCommGroup V] [Module k V]
+variable {k G V : Type*} [Ring k] [Monoid G] [AddCommGroup V] [Module k V]
 variable (ρ : Representation k G V)
 
-instance : AddCommGroup ρ.asModule :=
-  I
+instance : AddCommGroup ρ.asModule := inferInstanceAs <| AddCommGroup V
 
 /- Given a representation `(V, ρ)` of a monoid `G`, this says
 `(ρ(g) - Id)(x + ρ(g)(x) + ... + ρ(gⁿ)(x)) = ρ(gⁿ⁺¹)(x) - x` for all `n : ℕ, g : G` and `x : V`. -/


### PR DESCRIPTION
The following fails before the PR, works after it:
```
example : (ρ.instAddCommGroupAsModule.toAdd : Add ρ.asModule) = 
    ρ.instAddCommMonoidAsModule.toAddCommSemigroup.toAddCommMagma.toAdd := by
  with_reducible_and_instances rfl
```

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
