### PR TITLE
[Merged by Bors] - chore: remove duplicate of List.take_one_drop_eq_of_lt_length

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -620,11 +620,6 @@ theorem get_length_sub_one {l : List α} (h : l.length - 1 < l.length) :
     l.get ⟨l.length - 1, h⟩ = l.getLast (by rintro rfl; exact Nat.lt_irrefl 0 h) :=
   (getLast_eq_getElem _).symm
 
-theorem take_one_drop_eq_of_lt_length {l : List α} {n : ℕ} (h : n < l.length) :
-    (l.drop n).take 1 = [l.get ⟨n, h⟩] := by
-  rw [drop_eq_getElem_cons h, take, take]
-  simp
-
 theorem ext_getElem?' {l₁ l₂ : List α} (h' : ∀ n < max l₁.length l₂.length, l₁[n]? = l₂[n]?) :
     l₁ = l₂ := by
   apply ext_getElem?


### PR DESCRIPTION
Leave the other copy in Mathlib.Data.List.TakeDrop. Follow-up to #21232.

Deletions:
- List.take_one_drop_eq_of_lt_length
