### PR TITLE
[Merged by Bors] - chore: move things out of the RingQuot file

### DIFF
--- a/Mathlib/Algebra/Field/Subfield/Basic.lean
+++ b/Mathlib/Algebra/Field/Subfield/Basic.lean
@@ -556,7 +556,7 @@ protected theorem prod_mem {ι : Type*} {t : Finset ι} {f : ι → K} (h : ∀ 
   prod_mem h
 
 instance toAlgebra : Algebra s K :=
-  fast_instance% RingHom.toAlgebra s.subtype
+  inferInstance
 
 theorem algebraMap_ofSubfield : algebraMap s K = s.subtype :=
   rfl

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -33,29 +33,6 @@ variable {S : Type uS} [CommSemiring S]
 variable {T : Type uT}
 variable {A : Type uA} [Semiring A] [Algebra S A]
 
-namespace RingCon
-
-instance (c : RingCon A) : Algebra S c.Quotient where
-  algebraMap := c.mk'.comp (algebraMap S A)
-  commutes' _ := Quotient.ind' fun _ ↦ congr_arg Quotient.mk'' <| Algebra.commutes _ _
-  smul_def' _ := Quotient.ind' fun _ ↦ congr_arg Quotient.mk'' <| Algebra.smul_def _ _
-
-variable (S) in
-/-- The algebra morphism from `A` to the quotient by a ring congruence. -/
-@[simps!] def mkₐ (c : RingCon A) : A →ₐ[S] c.Quotient :=
-  { mk' c with commutes' _ := rfl }
-
-theorem mkₐ_surjective (c : RingCon A) :
-    Function.Surjective (c.mkₐ (S := S)) :=
-  mk'_surjective c
-
-@[simp, norm_cast]
-theorem coe_algebraMap (c : RingCon A) (s : S) :
-    (algebraMap S A s : c.Quotient) = algebraMap S c.Quotient s :=
-  rfl
-
-end RingCon
-
 namespace RingQuot
 
 /-- Given an arbitrary relation `r` on a ring, we strengthen it to a relation `Rel r`,

--- a/Mathlib/RingTheory/Congruence/Basic.lean
+++ b/Mathlib/RingTheory/Congruence/Basic.lean
@@ -5,8 +5,8 @@ Authors: Eric Wieser
 -/
 module
 
-public import Mathlib.Algebra.Ring.Action.Basic
 public import Mathlib.Algebra.Algebra.Hom
+public import Mathlib.Algebra.Ring.Action.Basic
 public import Mathlib.GroupTheory.Congruence.Basic
 public import Mathlib.RingTheory.Congruence.Defs
 

--- a/Mathlib/RingTheory/Congruence/Basic.lean
+++ b/Mathlib/RingTheory/Congruence/Basic.lean
@@ -105,6 +105,11 @@ instance (c : RingCon R) : Algebra α c.Quotient where
   commutes' _ := Quotient.ind' fun _ ↦ congr_arg Quotient.mk'' <| Algebra.commutes _ _
   smul_def' _ := Quotient.ind' fun _ ↦ congr_arg Quotient.mk'' <| Algebra.smul_def _ _
 
+@[simp, norm_cast]
+theorem coe_algebraMap (c : RingCon R) (s : α) :
+    (algebraMap α R s : c.Quotient) = algebraMap α c.Quotient s :=
+  rfl
+
 variable (α) in
 /-- The algebra morphism from `R` to the quotient by a ring congruence. -/
 @[simps!] def mkₐ (c : RingCon R) : R →ₐ[α] c.Quotient :=
@@ -113,11 +118,6 @@ variable (α) in
 theorem mkₐ_surjective (c : RingCon R) :
     Function.Surjective (c.mkₐ (α := α)) :=
   mk'_surjective c
-
-@[simp, norm_cast]
-theorem coe_algebraMap (c : RingCon R) (s : α) :
-    (algebraMap α R s : c.Quotient) = algebraMap α c.Quotient s :=
-  rfl
 
 end
 

--- a/Mathlib/RingTheory/Congruence/Basic.lean
+++ b/Mathlib/RingTheory/Congruence/Basic.lean
@@ -6,6 +6,7 @@ Authors: Eric Wieser
 module
 
 public import Mathlib.Algebra.Ring.Action.Basic
+public import Mathlib.Algebra.Algebra.Hom
 public import Mathlib.GroupTheory.Congruence.Basic
 public import Mathlib.RingTheory.Congruence.Defs
 
@@ -95,6 +96,30 @@ instance [Monoid α] [Semiring R] [MulSemiringAction α R] [IsScalarTower α R R
   smul_one := fun _ => congr_arg toQuotient <| smul_one _
   smul_mul := fun _ => Quotient.ind₂' fun _ _ => congr_arg toQuotient <|
     MulSemiringAction.smul_mul _ _ _
+
+section
+variable [CommSemiring α] [Semiring R] [Algebra α R]
+
+instance (c : RingCon R) : Algebra α c.Quotient where
+  algebraMap := c.mk'.comp (algebraMap α R)
+  commutes' _ := Quotient.ind' fun _ ↦ congr_arg Quotient.mk'' <| Algebra.commutes _ _
+  smul_def' _ := Quotient.ind' fun _ ↦ congr_arg Quotient.mk'' <| Algebra.smul_def _ _
+
+variable (α) in
+/-- The algebra morphism from `R` to the quotient by a ring congruence. -/
+@[simps!] def mkₐ (c : RingCon R) : R →ₐ[α] c.Quotient :=
+  { mk' c with commutes' _ := rfl }
+
+theorem mkₐ_surjective (c : RingCon R) :
+    Function.Surjective (c.mkₐ (α := α)) :=
+  mk'_surjective c
+
+@[simp, norm_cast]
+theorem coe_algebraMap (c : RingCon R) (s : α) :
+    (algebraMap α R s : c.Quotient) = algebraMap α c.Quotient s :=
+  rfl
+
+end
 
 end Algebraic
 

--- a/Mathlib/RingTheory/SimpleRing/Basic.lean
+++ b/Mathlib/RingTheory/SimpleRing/Basic.lean
@@ -25,8 +25,6 @@ A ring `R` is **simple** if it has only two two-sided ideals, namely `⊥` and `
 
 public section
 
-assert_not_exists Finset
-
 variable (R : Type*) [NonUnitalNonAssocRing R]
 
 namespace IsSimpleRing

--- a/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
@@ -27,8 +27,6 @@ In this file, for any `Ring R`, we reinterpret `I : RingCon R` as a two-sided-id
 
 @[expose] public section
 
-assert_not_exists LinearMap
-
 open MulOpposite
 
 section definitions

--- a/Mathlib/RingTheory/TwoSidedIdeal/Kernel.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Kernel.lean
@@ -19,8 +19,6 @@ We put this in a separate file so that we could import it in
 
 @[expose] public section
 
-assert_not_exists Finset
-
 namespace TwoSidedIdeal
 
 section ker


### PR DESCRIPTION
Unfortunately to get away with this some `assert_not_exists` need to change. I think both of these were not particularly reasonable:

* `LinearMap` not being available for two-sided ideals seems overly aggressive given it is needed for `Ideal`.
* `Finset` ones place `TwoSidedIdeal` at odds with all the other subobjects; these import big operators far earlier.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
