### PR TITLE
[Merged by Bors] - chore: fix non-reducible diamond in `ConjAct`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Action/ConjAct.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/ConjAct.lean
@@ -21,7 +21,7 @@ variable {α G₀ : Type*}
 namespace ConjAct
 variable [GroupWithZero G₀]
 
-instance : GroupWithZero (ConjAct G₀) := ‹GroupWithZero G₀›
+instance : GroupWithZero (ConjAct G₀) := inferInstanceAs <| GroupWithZero G₀
 
 @[simp] lemma ofConjAct_zero : ofConjAct 0 = (0 : G₀) := rfl
 @[simp] lemma toConjAct_zero : toConjAct (0 : G₀) = 0 := rfl

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -49,21 +49,6 @@ open MulAction Subgroup
 
 variable {M G}
 
-/-- Canonical bijection between `ConjAct G` and `G`. Use instead the bundled version `ofConjAct`. -/
-def ofConjActEquiv : ConjAct G ≃ G := Equiv.refl G
-
-instance [One G] : One (ConjAct G) where
-  one := ofConjActEquiv.symm (1 : G)
-
-instance [Mul G] : Mul (ConjAct G) where
-  mul x y := ofConjActEquiv.symm (ofConjActEquiv x * ofConjActEquiv y)
-
-instance [Inv G] : Inv (ConjAct G) where
-  inv x := ofConjActEquiv.symm (ofConjActEquiv x)⁻¹
-
-instance [Div G] : Div (ConjAct G) where
-  div x y := ofConjActEquiv.symm (ofConjActEquiv x / ofConjActEquiv y)
-
 instance [DivInvMonoid G] : DivInvMonoid (ConjAct G) := inferInstanceAs <| DivInvMonoid G
 
 instance [Group G] : Group (ConjAct G) := inferInstanceAs <| Group G
@@ -83,7 +68,8 @@ instance : Inhabited (ConjAct G) :=
 
 /-- Reinterpret `g : ConjAct G` as an element of `G`. -/
 def ofConjAct : ConjAct G ≃* G where
-  __ := ofConjActEquiv
+  toFun := id
+  invFun := id
   map_mul' := fun _ _ => rfl
 
 /-- Reinterpret `g : G` as an element of `ConjAct G`. -/
@@ -269,7 +255,7 @@ theorem _root_.MulAut.conjNormal_apply {H : Subgroup G} [H.Normal] (g : G) (h : 
 @[simp]
 theorem _root_.MulAut.conjNormal_symm_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
     ↑((MulAut.conjNormal g).symm h) = g⁻¹ * h * g := by
-  change _ * _⁻¹⁻¹ = _
+  change _ * g⁻¹⁻¹ = _
   rw [inv_inv]
   rfl
 

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -52,16 +52,17 @@ variable {M G}
 /-- Canonical bijection between `ConjAct G` and `G`. Use instead the bundled version `ofConjAct`. -/
 def ofConjActEquiv : ConjAct G ≃ G := Equiv.refl G
 
-instance [One G] : One (ConjAct G) := ⟨ofConjActEquiv.symm (1 : G)⟩
+instance [One G] : One (ConjAct G) where
+  one := ofConjActEquiv.symm (1 : G)
 
-instance [Mul G] : Mul (ConjAct G) :=
-  ⟨fun x y ↦ ofConjActEquiv.symm (ofConjActEquiv x * ofConjActEquiv y)⟩
+instance [Mul G] : Mul (ConjAct G) where
+  mul x y := ofConjActEquiv.symm (ofConjActEquiv x * ofConjActEquiv y)
 
-instance [Inv G] : Inv (ConjAct G) :=
-  ⟨fun x ↦ ofConjActEquiv.symm (ofConjActEquiv x)⁻¹⟩
+instance [Inv G] : Inv (ConjAct G) where
+  inv x := ofConjActEquiv.symm (ofConjActEquiv x)⁻¹
 
-instance [Div G] : Div (ConjAct G) :=
-  ⟨fun x y ↦ ofConjActEquiv.symm (ofConjActEquiv x / ofConjActEquiv y)⟩
+instance [Div G] : Div (ConjAct G) where
+  div x y := ofConjActEquiv.symm (ofConjActEquiv x / ofConjActEquiv y)
 
 instance [DivInvMonoid G] : DivInvMonoid (ConjAct G) := inferInstanceAs <| DivInvMonoid G
 

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -49,11 +49,25 @@ open MulAction Subgroup
 
 variable {M G}
 
-instance [Group G] : Group (ConjAct G) := ‹Group G›
+/-- Canonical bijection between `ConjAct G` and `G`. Use instead the bundled version `ofConjAct`. -/
+def ofConjActEquiv : ConjAct G ≃ G := Equiv.refl G
 
-instance [DivInvMonoid G] : DivInvMonoid (ConjAct G) := ‹DivInvMonoid G›
+instance [One G] : One (ConjAct G) := ⟨ofConjActEquiv.symm (1 : G)⟩
 
-instance [Fintype G] : Fintype (ConjAct G) := ‹Fintype G›
+instance [Mul G] : Mul (ConjAct G) :=
+  ⟨fun x y ↦ ofConjActEquiv.symm (ofConjActEquiv x * ofConjActEquiv y)⟩
+
+instance [Inv G] : Inv (ConjAct G) :=
+  ⟨fun x ↦ ofConjActEquiv.symm (ofConjActEquiv x)⁻¹⟩
+
+instance [Div G] : Div (ConjAct G) :=
+  ⟨fun x y ↦ ofConjActEquiv.symm (ofConjActEquiv x / ofConjActEquiv y)⟩
+
+instance [DivInvMonoid G] : DivInvMonoid (ConjAct G) := inferInstanceAs <| DivInvMonoid G
+
+instance [Group G] : Group (ConjAct G) := inferInstanceAs <| Group G
+
+instance [Fintype G] : Fintype (ConjAct G) := inferInstanceAs <| Fintype G
 
 @[simp]
 theorem card [Fintype G] : Fintype.card (ConjAct G) = Fintype.card G :=
@@ -68,8 +82,7 @@ instance : Inhabited (ConjAct G) :=
 
 /-- Reinterpret `g : ConjAct G` as an element of `G`. -/
 def ofConjAct : ConjAct G ≃* G where
-  toFun := id
-  invFun := id
+  __ := ofConjActEquiv
   map_mul' := fun _ _ => rfl
 
 /-- Reinterpret `g : G` as an element of `ConjAct G`. -/


### PR DESCRIPTION
The following fails before the PR, suceeds after it
```
example : (ConjAct.instGroupWithZero.toDivInvMonoid : DivInvMonoid (ConjAct G₀)) = 
    ConjAct.instDivInvMonoid := by
  with_reducible_and_instances rfl
```

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
