### PR TITLE
chore: use explicit data instances in order dual

### DIFF
--- a/Mathlib/Algebra/Order/Group/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Synonym.lean
@@ -26,25 +26,25 @@ variable {α β : Type*}
 
 namespace OrderDual
 
-set_option backward.inferInstanceAs.wrap.instances false in
-@[to_additive] instance [One α] : One αᵒᵈ := inferInstanceAs <| One α
+@[to_additive] instance [One α] : One αᵒᵈ where
+  one := toDual 1
 
-set_option backward.inferInstanceAs.wrap.instances false in
-@[to_additive] instance [Mul α] : Mul αᵒᵈ := inferInstanceAs <| Mul α
+@[to_additive] instance [Mul α] : Mul αᵒᵈ where
+  mul x y := toDual (ofDual x * ofDual y)
 
-set_option backward.inferInstanceAs.wrap.instances false in
-@[to_additive] instance [Inv α] : Inv αᵒᵈ := inferInstanceAs <| Inv α
+@[to_additive] instance [Inv α] : Inv αᵒᵈ where
+  inv x := toDual (ofDual x)⁻¹
 
-set_option backward.inferInstanceAs.wrap.instances false in
-@[to_additive] instance [Div α] : Div αᵒᵈ := inferInstanceAs <| Div α
+@[to_additive] instance [Div α] : Div αᵒᵈ where
+  div x y := toDual (ofDual x / ofDual y)
 
-set_option backward.inferInstanceAs.wrap.instances false in
 @[to_additive (attr := to_additive) (reorder := 1 2) OrderDual.instSMul]
-instance [Pow α β] : Pow αᵒᵈ β := inferInstanceAs <| Pow α β
+instance [Pow α β] : Pow αᵒᵈ β where
+  pow a b := toDual ((ofDual a) ^ b)
 
-set_option backward.inferInstanceAs.wrap.instances false in
 @[to_additive (attr := to_additive) (reorder := 1 2) OrderDual.instSMul']
-instance [Pow α β] : Pow α βᵒᵈ := inferInstanceAs <| Pow α β
+instance [Pow α β] : Pow α βᵒᵈ where
+  pow a b := a ^ (ofDual b)
 
 @[to_additive] instance [Semigroup α] : Semigroup αᵒᵈ := inferInstanceAs <| Semigroup α
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This is a test to see if it builds fine or if Lean is confused

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
