### PR TITLE
[Merged by Bors] - feat(Data/List/Perm): characterise permutations of a pair

### DIFF
--- a/Mathlib/Data/List/Perm/Basic.lean
+++ b/Mathlib/Data/List/Perm/Basic.lean
@@ -203,20 +203,6 @@ theorem perm_option_toList {o₁ o₂ : Option α} : o₁.toList ~ o₂.toList �
   · cases p.length_eq
   · exact Option.mem_toList.1 (p.symm.subset <| by simp)
 
-/-- The pair `[a, b]` is a permutation of a list if and only if that list is equal to `[a, b]` or
-to `[b, a]`. -/
-theorem pair_perm {a b : α} : [a, b] ~ l ↔ l = [a, b] ∨ l = [b, a] := by
-  generalize hl' : [a, b] = l'
-  constructor
-  · intro h
-    induction h generalizing a b <;> grind [singleton_perm]
-  · rintro (rfl | rfl) <;> grind [Perm]
-
-/-- A list is a permutation of the pair `[a, b]` if and only if it is equal to `[a, b]` or to
-`[b, a]`. -/
-theorem perm_pair {a b : α} : l ~ [a, b] ↔ l = [a, b] ∨ l = [b, a] :=
-  perm_comm.trans pair_perm
-
 theorem perm_replicate_append_replicate
     [DecidableEq α] {l : List α} {a b : α} {m n : ℕ} (h : a ≠ b) :
     l ~ replicate m a ++ replicate n b ↔ count a l = m ∧ count b l = n ∧ l ⊆ [a, b] := by

--- a/Mathlib/Data/List/Perm/Basic.lean
+++ b/Mathlib/Data/List/Perm/Basic.lean
@@ -203,6 +203,20 @@ theorem perm_option_toList {o₁ o₂ : Option α} : o₁.toList ~ o₂.toList �
   · cases p.length_eq
   · exact Option.mem_toList.1 (p.symm.subset <| by simp)
 
+/-- The pair `[a, b]` is a permutation of a list if and only if that list is equal to `[a, b]` or
+to `[b, a]`. -/
+theorem pair_perm {a b : α} : [a, b] ~ l ↔ l = [a, b] ∨ l = [b, a] := by
+  generalize hl' : [a, b] = l'
+  constructor
+  · intro h
+    induction h generalizing a b <;> grind [singleton_perm]
+  · rintro (rfl | rfl) <;> grind [Perm]
+
+/-- A list is a permutation of the pair `[a, b]` if and only if it is equal to `[a, b]` or to
+`[b, a]`. -/
+theorem perm_pair {a b : α} : l ~ [a, b] ↔ l = [a, b] ∨ l = [b, a] :=
+  perm_comm.trans pair_perm
+
 theorem perm_replicate_append_replicate
     [DecidableEq α] {l : List α} {a b : α} {m n : ℕ} (h : a ≠ b) :
     l ~ replicate m a ++ replicate n b ↔ count a l = m ∧ count b l = n ∧ l ⊆ [a, b] := by

--- a/Mathlib/Data/List/Permutation.lean
+++ b/Mathlib/Data/List/Permutation.lean
@@ -314,6 +314,17 @@ theorem mem_permutationsAux_of_perm :
 theorem mem_permutations {s t : List α} : s ∈ permutations t ↔ s ~ t :=
   ⟨perm_of_mem_permutations, mem_permutations_of_perm_lemma mem_permutationsAux_of_perm⟩
 
+/-- A list is a permutation of the pair `[a, b]` if and only if it is equal to `[a, b]` or to
+`[b, a]`. -/
+theorem perm_pair {a b : α} {l : List α} : l ~ [a, b] ↔ l = [a, b] ∨ l = [b, a] := by
+  have : [a, b].permutations = [[a, b], [b, a]] := by cbv
+  grind [=_ mem_permutations]
+
+/-- The pair `[a, b]` is a permutation of a list if and only if that list is equal to `[a, b]` or
+to `[b, a]`. -/
+theorem pair_perm {a b : α} {l : List α} : [a, b] ~ l ↔ l = [a, b] ∨ l = [b, a] :=
+  perm_comm.trans perm_pair
+
 theorem perm_permutations'Aux_comm (a b : α) (l : List α) :
     (permutations'Aux a l).flatMap (permutations'Aux b) ~
       (permutations'Aux b l).flatMap (permutations'Aux a) := by


### PR DESCRIPTION
This PR adds `List.pair_perm` and `List.perm_pair`, characterising when a list is a permutation of a two-element list: `[a, b] ~ l` (resp. `l ~ [a, b]`) holds iff `l = [a, b]` or `l = [b, a]`. These are in analogy with the existing singleton_perm / perm_singleton pair from core. They live next to the other permutation characterisations in Mathlib/Data/List/Perm/Basic.lean.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
