### PR TITLE
[Merged by Bors] - chore(Geometry/Manifold): local diffeomorphism is stable under composition

### DIFF
--- a/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
@@ -64,14 +64,14 @@ open Manifold Set TopologicalSpace
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-  {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V]
-  {H : Type*} [TopologicalSpace H]
-  {G : Type*} [TopologicalSpace G]
-  {W : Type*} [TopologicalSpace W]
-  (I : ModelWithCorners 𝕜 E H) (J : ModelWithCorners 𝕜 F G) (K : ModelWithCorners 𝕜 V W)
-  (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
-  (N : Type*) [TopologicalSpace N] [ChartedSpace G N]
-  (P : Type*) [TopologicalSpace P] [ChartedSpace W P] (n : WithTop ℕ∞)
+  {F' : Type*} [NormedAddCommGroup F'] [NormedSpace 𝕜 F']
+  {H₁ : Type*} [TopologicalSpace H₁]
+  {H₂ : Type*} [TopologicalSpace H₂]
+  {H₃ : Type*} [TopologicalSpace H₃]
+  (I : ModelWithCorners 𝕜 E H₁) (J : ModelWithCorners 𝕜 F H₂) (K : ModelWithCorners 𝕜 F' H₃)
+  (M : Type*) [TopologicalSpace M] [ChartedSpace H₁ M]
+  (N : Type*) [TopologicalSpace N] [ChartedSpace H₂ N]
+  (P : Type*) [TopologicalSpace P] [ChartedSpace H₃ P] (n : WithTop ℕ∞)
 
 section PartialDiffeomorph
 /-- A partial diffeomorphism on `s` is a function `f : M → N` such that `f` restricts to a

--- a/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
@@ -64,11 +64,14 @@ open Manifold Set TopologicalSpace
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V]
   {H : Type*} [TopologicalSpace H]
   {G : Type*} [TopologicalSpace G]
-  (I : ModelWithCorners 𝕜 E H) (J : ModelWithCorners 𝕜 F G)
+  {W : Type*} [TopologicalSpace W]
+  (I : ModelWithCorners 𝕜 E H) (J : ModelWithCorners 𝕜 F G) (K : ModelWithCorners 𝕜 V W)
   (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
-  (N : Type*) [TopologicalSpace N] [ChartedSpace G N] (n : WithTop ℕ∞)
+  (N : Type*) [TopologicalSpace N] [ChartedSpace G N]
+  (P : Type*) [TopologicalSpace P] [ChartedSpace W P] (n : WithTop ℕ∞)
 
 section PartialDiffeomorph
 /-- A partial diffeomorphism on `s` is a function `f : M → N` such that `f` restricts to a
@@ -86,7 +89,7 @@ as `toFun` doesn't determine `invFun` outside of `target`. -/
 instance : CoeFun (PartialDiffeomorph I J M N n) fun _ => M → N :=
   ⟨fun Φ => Φ.toFun⟩
 
-variable {I J M N n}
+variable {I J K M N P n}
 
 /-- A diffeomorphism is a partial diffeomorphism. -/
 def Diffeomorph.toPartialDiffeomorph (h : Diffeomorph I J M N n) :
@@ -102,6 +105,7 @@ namespace PartialDiffeomorph
 variable (Φ : PartialDiffeomorph I J M N n)
 
 /-- A partial diffeomorphism is also a local homeomorphism. -/
+@[expose, simps toPartialEquiv]
 def toOpenPartialHomeomorph : OpenPartialHomeomorph M N where
   toPartialEquiv := Φ.toPartialEquiv
   open_source := Φ.open_source
@@ -110,6 +114,7 @@ def toOpenPartialHomeomorph : OpenPartialHomeomorph M N where
   continuousOn_invFun := Φ.contMDiffOn_invFun.continuousOn
 
 /-- The inverse of a local diffeomorphism. -/
+@[expose, simps toPartialEquiv]
 protected def symm : PartialDiffeomorph J I N M n where
   toPartialEquiv := Φ.toPartialEquiv.symm
   open_source := Φ.open_target
@@ -125,6 +130,15 @@ protected theorem mdifferentiableOn (hn : n ≠ 0) : MDiff[Φ.source] Φ :=
 protected theorem mdifferentiableAt (hn : n ≠ 0) {x : M} (hx : x ∈ Φ.source) :
     MDiffAt Φ x :=
   (Φ.mdifferentiableOn hn x hx).mdifferentiableAt (Φ.open_source.mem_nhds hx)
+
+/-- Composition of partial diffeomorphisms. -/
+@[expose, simps toPartialEquiv]
+protected def trans (Ψ : PartialDiffeomorph J K N P n) : PartialDiffeomorph I K M P n where
+  __ := Φ.toOpenPartialHomeomorph.trans Ψ.toOpenPartialHomeomorph
+  contMDiffOn_toFun :=
+    Ψ.contMDiffOn_toFun.comp (Φ.contMDiffOn_toFun.mono inter_subset_left) inter_subset_right
+  contMDiffOn_invFun :=
+    Φ.contMDiffOn_invFun.comp (Ψ.contMDiffOn_invFun.mono inter_subset_left) inter_subset_right
 
 /- We could add lots of additional API (following `Diffeomorph` and `OpenPartialHomeomorph`),
 such as
@@ -221,6 +235,16 @@ lemma localInverse_contMDiffAt (hf : IsLocalDiffeomorphAt I J n f x) :
 lemma localInverse_mdifferentiableAt (hf : IsLocalDiffeomorphAt I J n f x) (hn : n ≠ 0) :
     MDiffAt hf.localInverse (f x) :=
   hf.localInverse_contMDiffAt.mdifferentiableAt hn
+
+lemma comp (hf : IsLocalDiffeomorphAt I J n f x) {g : N → P}
+    (hg : IsLocalDiffeomorphAt J K n g (f x)) :
+    IsLocalDiffeomorphAt I K n (g ∘ f) x := by
+  obtain ⟨Φ, hx, heq⟩ := hf
+  obtain ⟨Ψ, hy, heq'⟩ := hg
+  refine ⟨Φ.trans Ψ, by simp [hx, ← heq.eq_of_mem hx, hy], ?_⟩
+  intro y ⟨hyl, hyr⟩
+  have hfy : f y ∈ Ψ.source := by rwa [heq.eq_of_mem hyl]
+  simp [← heq.eq_of_mem hyl, ← heq'.eq_of_mem hfy]
 
 end IsLocalDiffeomorphAt
 


### PR DESCRIPTION
We also add some `@[expose]` tags to constructions of `PartialDiffeomorph` to allow `@[simps]` to generate projection lemmas. It seems sensible to me to expose the def-eqs of these constructions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
