### PR TITLE
[Merged by Bors] - feat: expand API for `StarAlgEquiv`

### DIFF
--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -907,7 +907,7 @@ lemma toNonUnitalStarAlgHom_comp (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₂ : A₂ �
 /-- If `A₁` is equivalent to `A₁'` and `A₂` is equivalent to `A₂'` as star algebras, then the type
 of maps `A₁ →⋆ₙₐ[R] A₂` is equivalent to the type of maps `A₁' →⋆ₙₐ[R] A₂'`.
 
-For unital star algebra homomorphisms, see `arrowCongr`. -/
+For unital star algebra homomorphisms, see `StarAlgEquiv.arrowCongr`. -/
 @[simps apply]
 def arrowCongr' (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') :
     (A₁ →⋆ₙₐ[R] A₂) ≃ (A₁' →⋆ₙₐ[R] A₂') where
@@ -998,7 +998,9 @@ lemma toStarAlgHom_comp (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₂ : A₂ ≃⋆ₐ[R
     e₂.toStarAlgHom.comp e₁.toStarAlgHom = (e₁.trans e₂).toStarAlgHom := rfl
 
 /-- If `A₁` is equivalent to `A₁'` and `A₂` is equivalent to `A₂'` as star algebras, then the type
-of maps `A₁ →⋆ₐ[R] A₂` is equivalent to the type of maps `A₁' →⋆ₐ[R] A₂'`. -/
+of maps `A₁ →⋆ₐ[R] A₂` is equivalent to the type of maps `A₁' →⋆ₐ[R] A₂'`.
+
+For non-unital star algebra homomorphisms, see `StarAlgEquiv.arrowCongr'`. -/
 @[simps apply]
 def arrowCongr (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') : (A₁ →⋆ₐ[R] A₂) ≃ (A₁' →⋆ₐ[R] A₂') where
   toFun f := (e₂.toStarAlgHom.comp f).comp e₁.symm.toStarAlgHom

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -905,7 +905,9 @@ lemma toNonUnitalStarAlgHom_comp (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₂ : A₂ �
       (e₁.trans e₂).toNonUnitalStarAlgHom := rfl
 
 /-- If `A₁` is equivalent to `A₁'` and `A₂` is equivalent to `A₂'` as star algebras, then the type
-of maps `A₁ →⋆ₙₐ[R] A₂` is equivalent to the type of maps `A₁' →⋆ₙₐ[R] A₂'`. -/
+of maps `A₁ →⋆ₙₐ[R] A₂` is equivalent to the type of maps `A₁' →⋆ₙₐ[R] A₂'`.
+
+For unital star algebra homomorphisms, see `arrowCongr`. -/
 @[simps apply]
 def arrowCongr' (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') :
     (A₁ →⋆ₙₐ[R] A₂) ≃ (A₁' →⋆ₙₐ[R] A₂') where

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -931,7 +931,7 @@ theorem arrowCongr'_trans (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₁' : A₁' ≃⋆�
   rfl
 
 @[simp]
-theorem arrowCongr'_symm (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') :
+theorem symm_arrowCongr' (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') :
     (arrowCongr' e₁ e₂).symm = arrowCongr' e₁.symm e₂.symm :=
   rfl
 
@@ -980,9 +980,7 @@ variable {R A₁ A₂ A₃ A₁' A₂' A₃' : Type*}
 def toStarAlgHom : A₁ →⋆ₐ[R] A₂ :=
   { e with
     toFun := e
-    map_zero' := map_zero e
-    map_one' := map_one e
-    commutes' := e.toAlgEquiv.commutes }
+    __ := e.toAlgEquiv.toAlgHom }
 
 @[simp]
 lemma toNonUnitalStarAlgHom_toStarAlgHom (e : A₁ ≃⋆ₐ[R] A₂) :
@@ -1023,7 +1021,7 @@ theorem arrowCongr_trans (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₁' : A₁' ≃⋆�
   rfl
 
 @[simp]
-theorem arrowCongr_symm (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') :
+theorem symm_arrowCongr (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') :
     (arrowCongr e₁ e₂).symm = arrowCongr e₁.symm e₂.symm :=
   rfl
 
@@ -1038,7 +1036,7 @@ def ofStarAlgHom {R A B : Type*} [CommSemiring R]
     invFun := g
     left_inv x := congr($h₁ x)
     right_inv x := congr($h₂ x)
-    map_smul' := map_smul f}
+    map_smul' := map_smul f }
 
 @[simp]
 lemma toStarAlgHom_ofStarAlgHom (f : A₁ →⋆ₐ[R] A₂) (g : A₂ →⋆ₐ[R] A₁)

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -876,6 +876,146 @@ end AlgEquiv
 
 end Basic
 
+section NonUnitalArrowCongr
+
+variable {R A₁ A₂ A₃ A₁' A₂' A₃' : Type*} [Monoid R]
+  [NonUnitalNonAssocSemiring A₁] [DistribMulAction R A₁] [Star A₁]
+  [NonUnitalNonAssocSemiring A₂] [DistribMulAction R A₂] [Star A₂]
+  [NonUnitalNonAssocSemiring A₃] [DistribMulAction R A₃] [Star A₃]
+  [NonUnitalNonAssocSemiring A₁'] [DistribMulAction R A₁'] [Star A₁']
+  [NonUnitalNonAssocSemiring A₂'] [DistribMulAction R A₂'] [Star A₂']
+  [NonUnitalNonAssocSemiring A₃'] [DistribMulAction R A₃'] [Star A₃']
+  (e : A₁ ≃⋆ₐ[R] A₂)
+
+/-- Reintrepret a star algebra equivalence as a non-unital star algebra homomorphism. -/
+@[simps]
+def toNonUnitalStarAlgHom : A₁ →⋆ₙₐ[R] A₂ :=
+  { e with
+    toFun := e
+    map_zero' := map_zero e }
+
+@[simp]
+lemma toNonUnitalStarAlgHom_comp (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₂ : A₂ ≃⋆ₐ[R] A₃) :
+    e₂.toNonUnitalStarAlgHom.comp e₁.toNonUnitalStarAlgHom =
+      (e₁.trans e₂).toNonUnitalStarAlgHom := rfl
+
+/-- If `A₁` is equivalent to `A₁'` and `A₂` is equivalent to `A₂'` as star algebras, then the type
+of maps `A₁ →⋆ₙₐ[R] A₂` is equivalent to the type of maps `A₁' →⋆ₙₐ[R] A₂'`. -/
+@[simps apply]
+def arrowCongr' (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') :
+    (A₁ →⋆ₙₐ[R] A₂) ≃ (A₁' →⋆ₙₐ[R] A₂') where
+  toFun f := (e₂.toNonUnitalStarAlgHom.comp f).comp e₁.symm.toNonUnitalStarAlgHom
+  invFun f := (e₂.symm.toNonUnitalStarAlgHom.comp f).comp e₁.toNonUnitalStarAlgHom
+  left_inv f := by ext; simp
+  right_inv f := by ext; simp
+
+theorem arrowCongr'_comp (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂')
+    (e₃ : A₃ ≃⋆ₐ[R] A₃') (f : A₁ →⋆ₙₐ[R] A₂) (g : A₂ →⋆ₙₐ[R] A₃) :
+    arrowCongr' e₁ e₃ (g.comp f) = (arrowCongr' e₂ e₃ g).comp (arrowCongr' e₁ e₂ f) := by
+  ext
+  simp
+
+@[simp]
+theorem arrowCongr'_refl : arrowCongr' .refl .refl = Equiv.refl (A₁ →⋆ₙₐ[R] A₂) :=
+  rfl
+
+@[simp]
+theorem arrowCongr'_trans (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₁' : A₁' ≃⋆ₐ[R] A₂')
+    (e₂ : A₂ ≃⋆ₐ[R] A₃) (e₂' : A₂' ≃⋆ₐ[R] A₃') :
+    arrowCongr' (e₁.trans e₂) (e₁'.trans e₂') = (arrowCongr' e₁ e₁').trans (arrowCongr' e₂ e₂') :=
+  rfl
+
+@[simp]
+theorem arrowCongr'_symm (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') :
+    (arrowCongr' e₁ e₂).symm = arrowCongr' e₁.symm e₂.symm :=
+  rfl
+
+/-- Construct a star algebra equivalence from a pair of non-unital star algebra homomorphisms. -/
+@[simps]
+def ofHomInv' (f : A₁ →⋆ₙₐ[R] A₂) (g : A₂ →⋆ₙₐ[R] A₁) (h₁ : g.comp f = .id R A₁)
+    (h₂ : f.comp g = .id R A₂) : A₁ ≃⋆ₐ[R] A₂ :=
+  { f with
+    toFun := f
+    invFun := g
+    left_inv x := congr($h₁ x)
+    right_inv x := congr($h₂ x) }
+
+end NonUnitalArrowCongr
+
+section Unital
+
+variable {R A₁ A₂ A₃ A₁' A₂' A₃' : Type*}
+  [CommSemiring R] [Semiring A₁] [Semiring A₂] [Semiring A₃]
+  [Semiring A₁'] [Semiring A₂'] [Semiring A₃']
+  [Algebra R A₁] [Algebra R A₂] [Algebra R A₃]
+  [Algebra R A₁'] [Algebra R A₂'] [Algebra R A₃']
+  [Star A₁] [Star A₂] [Star A₃]
+  [Star A₁'] [Star A₂'] [Star A₃']
+  (e : A₁ ≃⋆ₐ[R] A₂)
+
+/-- Reintrepret a star algebra equivalence as a star algebra homomorphism. -/
+@[simps]
+def toStarAlgHom : A₁ →⋆ₐ[R] A₂ :=
+  { e with
+    toFun := e
+    map_zero' := map_zero e
+    map_one' := map_one e
+    commutes' := e.toAlgEquiv.commutes }
+
+@[simp]
+lemma toNonUnitalStarAlgHom_toStarAlgHom (e : A₁ ≃⋆ₐ[R] A₂) :
+    e.toStarAlgHom.toNonUnitalStarAlgHom = e.toNonUnitalStarAlgHom :=
+  rfl
+
+@[simp]
+lemma toStarAlgHom_comp (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₂ : A₂ ≃⋆ₐ[R] A₃) :
+    e₂.toStarAlgHom.comp e₁.toStarAlgHom = (e₁.trans e₂).toStarAlgHom := rfl
+
+/-- If `A₁` is equivalent to `A₁'` and `A₂` is equivalent to `A₂'` as star algebras, then the type
+of maps `A₁ →⋆ₐ[R] A₂` is equivalent to the type of maps `A₁' →⋆ₐ[R] A₂'`. -/
+@[simps apply]
+def arrowCongr (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') : (A₁ →⋆ₐ[R] A₂) ≃ (A₁' →⋆ₐ[R] A₂') where
+  toFun f := (e₂.toStarAlgHom.comp f).comp e₁.symm.toStarAlgHom
+  invFun f := (e₂.symm.toStarAlgHom.comp f).comp e₁.toStarAlgHom
+  left_inv f := by ext; simp
+  right_inv f := by ext; simp
+
+theorem arrowCongr_comp (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂')
+    (e₃ : A₃ ≃⋆ₐ[R] A₃') (f : A₁ →⋆ₐ[R] A₂) (g : A₂ →⋆ₐ[R] A₃) :
+    arrowCongr e₁ e₃ (g.comp f) = (arrowCongr e₂ e₃ g).comp (arrowCongr e₁ e₂ f) := by
+  ext
+  simp
+
+@[simp]
+theorem arrowCongr_refl : arrowCongr .refl .refl = Equiv.refl (A₁ →⋆ₐ[R] A₂) :=
+  rfl
+
+@[simp]
+theorem arrowCongr_trans (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₁' : A₁' ≃⋆ₐ[R] A₂')
+    (e₂ : A₂ ≃⋆ₐ[R] A₃) (e₂' : A₂' ≃⋆ₐ[R] A₃') :
+    arrowCongr (e₁.trans e₂) (e₁'.trans e₂') = (arrowCongr e₁ e₁').trans (arrowCongr e₂ e₂') :=
+  rfl
+
+@[simp]
+theorem arrowCongr_symm (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[R] A₂') :
+    (arrowCongr e₁ e₂).symm = arrowCongr e₁.symm e₂.symm :=
+  rfl
+
+/-- Construct a star algebra equivalence from a pair of star algebra homomorphisms. -/
+@[simps]
+def ofHomInv {R A B : Type*} [CommSemiring R]
+    [Semiring A] [Algebra R A] [Star A] [Semiring B] [Algebra R B] [Star B]
+    (f : A →⋆ₐ[R] B) (g : B →⋆ₐ[R] A) (h₁ : g.comp f = .id R A) (h₂ : f.comp g = .id R B) :
+    A ≃⋆ₐ[R] B :=
+  { f with
+    toFun := f
+    invFun := g
+    left_inv x := congr($h₁ x)
+    right_inv x := congr($h₂ x)
+    map_smul' := map_smul f}
+
+end Unital
+
 section Bijective
 
 variable {F G R A B : Type*} [Monoid R]

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -723,17 +723,18 @@ theorem toRingEquiv_eq_coe (e : A ≃⋆ₐ[R] B) : e.toRingEquiv = e :=
 theorem ext {f g : A ≃⋆ₐ[R] B} (h : ∀ a, f a = g a) : f = g :=
   DFunLike.ext f g h
 
+variable (R A) in
 /-- The identity map is a star algebra isomorphism. -/
 @[refl]
-def refl : A ≃⋆ₐ[R] A :=
+protected def refl : A ≃⋆ₐ[R] A :=
   { StarRingEquiv.refl (A := A) with
     map_smul' := fun _ _ => rfl }
 
 instance : Inhabited (A ≃⋆ₐ[R] A) :=
-  ⟨refl⟩
+  ⟨.refl R A⟩
 
 @[simp]
-theorem coe_refl : ⇑(refl : A ≃⋆ₐ[R] A) = id :=
+theorem coe_refl : ⇑(StarAlgEquiv.refl R A) = id :=
   rfl
 
 /-- The inverse of a star algebra isomorphism is a star algebra isomorphism. -/
@@ -775,7 +776,7 @@ theorem symm_mk (e : A ≃⋆+* B) (h₁) : dsimp%
   rfl
 
 @[simp]
-theorem refl_symm : (StarAlgEquiv.refl : A ≃⋆ₐ[R] A).symm = StarAlgEquiv.refl :=
+theorem refl_symm : (StarAlgEquiv.refl R A).symm = .refl R A :=
   rfl
 
 @[simp]
@@ -845,7 +846,7 @@ theorem toAlgEquiv_injective : Function.Injective (toAlgEquiv (R := R) (A := A) 
   fun _ _ h => ext <| AlgEquiv.congr_fun h
 
 @[simp]
-theorem toAlgEquiv_refl : (refl : A ≃⋆ₐ[R] A).toAlgEquiv = AlgEquiv.refl := rfl
+theorem toAlgEquiv_refl : (StarAlgEquiv.refl R A).toAlgEquiv = AlgEquiv.refl := rfl
 
 /-- Upgrade an algebra equivalence to a ⋆-algebra equivalence given that it preserves the
 `star` operation. -/
@@ -895,6 +896,10 @@ def toNonUnitalStarAlgHom : A₁ →⋆ₙₐ[R] A₂ :=
     map_zero' := map_zero e }
 
 @[simp]
+lemma toNonUnitalStarAlgHom_refl : (StarAlgEquiv.refl R A₁).toNonUnitalStarAlgHom = .id R A₁ :=
+  rfl
+
+@[simp]
 lemma toNonUnitalStarAlgHom_comp (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₂ : A₂ ≃⋆ₐ[R] A₃) :
     e₂.toNonUnitalStarAlgHom.comp e₁.toNonUnitalStarAlgHom =
       (e₁.trans e₂).toNonUnitalStarAlgHom := rfl
@@ -916,7 +921,7 @@ theorem arrowCongr'_comp (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ
   simp
 
 @[simp]
-theorem arrowCongr'_refl : arrowCongr' .refl .refl = Equiv.refl (A₁ →⋆ₙₐ[R] A₂) :=
+theorem arrowCongr'_refl : arrowCongr' (.refl _ _) (.refl _ _) = Equiv.refl (A₁ →⋆ₙₐ[R] A₂) :=
   rfl
 
 @[simp]
@@ -932,13 +937,30 @@ theorem arrowCongr'_symm (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ
 
 /-- Construct a star algebra equivalence from a pair of non-unital star algebra homomorphisms. -/
 @[simps]
-def ofHomInv' (f : A₁ →⋆ₙₐ[R] A₂) (g : A₂ →⋆ₙₐ[R] A₁) (h₁ : g.comp f = .id R A₁)
+def ofNonUnitalStarAlgHom (f : A₁ →⋆ₙₐ[R] A₂) (g : A₂ →⋆ₙₐ[R] A₁) (h₁ : g.comp f = .id R A₁)
     (h₂ : f.comp g = .id R A₂) : A₁ ≃⋆ₐ[R] A₂ :=
   { f with
     toFun := f
     invFun := g
     left_inv x := congr($h₁ x)
     right_inv x := congr($h₂ x) }
+
+@[simp]
+lemma toNonUnitalStarAlgHom_ofNonUnitalStarAlgHom (f : A₁ →⋆ₙₐ[R] A₂) (g : A₂ →⋆ₙₐ[R] A₁)
+    (h₁ : g.comp f = .id R A₁) (h₂ : f.comp g = .id R A₂) :
+    (ofNonUnitalStarAlgHom f g h₁ h₂).toNonUnitalStarAlgHom = f :=
+  rfl
+
+lemma symm_ofNonUnitalStarAlgHom (f : A₁ →⋆ₙₐ[R] A₂) (g : A₂ →⋆ₙₐ[R] A₁)
+    (h₁ : g.comp f = .id R A₁) (h₂ : f.comp g = .id R A₂) :
+    (ofNonUnitalStarAlgHom f g h₁ h₂).symm = ofNonUnitalStarAlgHom g f h₂ h₁ :=
+  rfl
+
+@[simp]
+lemma toNonUnitalStarAlgHom_symm_ofNonUnitalStarAlgHom (f : A₁ →⋆ₙₐ[R] A₂) (g : A₂ →⋆ₙₐ[R] A₁)
+    (h₁ : g.comp f = .id R A₁) (h₂ : f.comp g = .id R A₂) :
+    (ofNonUnitalStarAlgHom f g h₁ h₂).symm.toNonUnitalStarAlgHom = g :=
+  rfl
 
 end NonUnitalArrowCongr
 
@@ -968,6 +990,10 @@ lemma toNonUnitalStarAlgHom_toStarAlgHom (e : A₁ ≃⋆ₐ[R] A₂) :
   rfl
 
 @[simp]
+lemma toStarAlgHom_refl : (StarAlgEquiv.refl R A₁).toStarAlgHom = .id R A₁ :=
+  rfl
+
+@[simp]
 lemma toStarAlgHom_comp (e₁ : A₁ ≃⋆ₐ[R] A₂) (e₂ : A₂ ≃⋆ₐ[R] A₃) :
     e₂.toStarAlgHom.comp e₁.toStarAlgHom = (e₁.trans e₂).toStarAlgHom := rfl
 
@@ -987,7 +1013,7 @@ theorem arrowCongr_comp (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[
   simp
 
 @[simp]
-theorem arrowCongr_refl : arrowCongr .refl .refl = Equiv.refl (A₁ →⋆ₐ[R] A₂) :=
+theorem arrowCongr_refl : arrowCongr (.refl _ _) (.refl _ _) = Equiv.refl (A₁ →⋆ₐ[R] A₂) :=
   rfl
 
 @[simp]
@@ -1003,7 +1029,7 @@ theorem arrowCongr_symm (e₁ : A₁ ≃⋆ₐ[R] A₁') (e₂ : A₂ ≃⋆ₐ[
 
 /-- Construct a star algebra equivalence from a pair of star algebra homomorphisms. -/
 @[simps]
-def ofHomInv {R A B : Type*} [CommSemiring R]
+def ofStarAlgHom {R A B : Type*} [CommSemiring R]
     [Semiring A] [Algebra R A] [Star A] [Semiring B] [Algebra R B] [Star B]
     (f : A →⋆ₐ[R] B) (g : B →⋆ₐ[R] A) (h₁ : g.comp f = .id R A) (h₂ : f.comp g = .id R B) :
     A ≃⋆ₐ[R] B :=
@@ -1014,6 +1040,23 @@ def ofHomInv {R A B : Type*} [CommSemiring R]
     right_inv x := congr($h₂ x)
     map_smul' := map_smul f}
 
+@[simp]
+lemma toStarAlgHom_ofStarAlgHom (f : A₁ →⋆ₐ[R] A₂) (g : A₂ →⋆ₐ[R] A₁)
+    (h₁ : g.comp f = .id R A₁) (h₂ : f.comp g = .id R A₂) :
+    (ofStarAlgHom f g h₁ h₂).toStarAlgHom = f :=
+  rfl
+
+lemma symm_ofStarAlgHom (f : A₁ →⋆ₐ[R] A₂) (g : A₂ →⋆ₐ[R] A₁)
+    (h₁ : g.comp f = .id R A₁) (h₂ : f.comp g = .id R A₂) :
+    (ofStarAlgHom f g h₁ h₂).symm = ofStarAlgHom g f h₂ h₁ :=
+  rfl
+
+@[simp]
+lemma toStarAlgHom_symm_ofStarAlgHom (f : A₁ →⋆ₐ[R] A₂) (g : A₂ →⋆ₐ[R] A₁)
+    (h₁ : g.comp f = .id R A₁) (h₂ : f.comp g = .id R A₂) :
+    (ofStarAlgHom f g h₁ h₂).symm.toStarAlgHom = g :=
+  rfl
+
 end Unital
 
 section Bijective
@@ -1023,19 +1066,6 @@ variable [NonUnitalNonAssocSemiring A] [DistribMulAction R A] [Star A]
 variable [NonUnitalNonAssocSemiring B] [DistribMulAction R B] [Star B]
 variable [FunLike F A B] [NonUnitalAlgHomClass F R A B] [StarHomClass F A B]
 variable [FunLike G B A] [NonUnitalAlgHomClass G R B A] [StarHomClass G B A]
-
-/-- If a (unital or non-unital) star algebra morphism has an inverse, it is an isomorphism of
-star algebras. -/
-@[simps]
-def ofStarAlgHom (f : F) (g : G) (h₁ : ∀ x, g (f x) = x) (h₂ : ∀ x, f (g x) = x) : A ≃⋆ₐ[R] B where
-  toFun := f
-  invFun := g
-  left_inv := h₁
-  right_inv := h₂
-  map_add' := map_add f
-  map_mul' := map_mul f
-  map_smul' := map_smul f
-  map_star' := map_star f
 
 /-- Promote a bijective star algebra homomorphism to a star algebra equivalence. -/
 noncomputable def ofBijective (f : F) (hf : Function.Bijective f) : A ≃⋆ₐ[R] B :=
@@ -1062,7 +1092,7 @@ variable {S R : Type*} [Mul R] [Add R] [Star R] [SMul S R]
 
 @[simps -isSimp one mul]
 instance aut : Group (R ≃⋆ₐ[S] R) where
-  one := refl
+  one := .refl _ _
   mul a b := b.trans a
   one_mul _ := rfl
   mul_one _ := rfl

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -869,6 +869,32 @@ end StarAlgHom
 
 section RestrictScalars
 
+section Equiv
+
+variable (R : Type*) {S A B : Type*} [CommSemiring R] [CommSemiring S]
+  [NonUnitalNonAssocSemiring A] [NonUnitalNonAssocSemiring B] [MulAction R S] [Module S A]
+  [Module S B] [Module R A] [Module R B] [IsScalarTower R S A] [IsScalarTower R S B]
+  [Star A] [Star B]
+
+/-- Restrict the scalar ring of a star algebra equivalence. -/
+@[simps]
+def StarAlgEquiv.restrictScalars (f : A ≃⋆ₐ[S] B) : A ≃⋆ₐ[R] B :=
+  { (f : A →ₗ[S] B).restrictScalars R, f with
+    toFun := f }
+
+theorem StarAlgEquiv.restrictScalars_injective :
+    Function.Injective (StarAlgEquiv.restrictScalars R : (A ≃⋆ₐ[S] B) → A ≃⋆ₐ[R] B) :=
+  fun _ _ h => ext (DFunLike.congr_fun h ·)
+
+@[simp]
+theorem StarAlgEquiv.toNonUnitalStarAlgHom_restrictScalars (e : A ≃⋆ₐ[S] B) :
+    (e.restrictScalars R).toNonUnitalStarAlgHom = e.toNonUnitalStarAlgHom.restrictScalars R :=
+  rfl
+
+end Equiv
+
+section Unital
+
 variable (R : Type*) {S A B : Type*} [CommSemiring R]
   [CommSemiring S] [Semiring A] [Semiring B] [Algebra R S] [Algebra S A] [Algebra S B]
   [Algebra R A] [Algebra R B] [IsScalarTower R S A] [IsScalarTower R S B] [Star A] [Star B]
@@ -883,16 +909,12 @@ theorem StarAlgHom.restrictScalars_injective :
   fun f g h => StarAlgHom.ext fun x =>
     show f.restrictScalars R x = g.restrictScalars R x from DFunLike.congr_fun h x
 
-@[simps]
-def StarAlgEquiv.restrictScalars (f : A ≃⋆ₐ[S] B) : A ≃⋆ₐ[R] B :=
-  { (f : A →⋆ₐ[S] B).restrictScalars R, f with
-    toFun := f
-    map_smul' := map_smul ((f : A →⋆ₐ[S] B).restrictScalars R) }
+@[simp]
+theorem StarAlgEquiv.toStarAlgHom_restrictScalars (e : A ≃⋆ₐ[S] B) :
+    (e.restrictScalars R).toStarAlgHom = e.toStarAlgHom.restrictScalars R :=
+  rfl
 
-theorem StarAlgEquiv.restrictScalars_injective :
-    Function.Injective (StarAlgEquiv.restrictScalars R : (A ≃⋆ₐ[S] B) → A ≃⋆ₐ[R] B) :=
-  fun f g h => StarAlgEquiv.ext fun x =>
-    show f.restrictScalars R x = g.restrictScalars R x from DFunLike.congr_fun h x
+end Unital
 
 end RestrictScalars
 

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -891,7 +891,7 @@ lemma conjStarAlgEquiv_apply (e : H ≃ₗᵢ[𝕜] K) (x : H →L[𝕜] H) :
 @[simp] lemma symm_conjStarAlgEquiv (e : H ≃ₗᵢ[𝕜] K) :
     e.conjStarAlgEquiv.symm = e.symm.conjStarAlgEquiv := rfl
 
-@[simp] theorem conjStarAlgEquiv_refl : conjStarAlgEquiv (.refl 𝕜 H) = .refl := rfl
+@[simp] theorem conjStarAlgEquiv_refl : conjStarAlgEquiv (.refl 𝕜 H) = .refl _ _ := rfl
 
 theorem conjStarAlgEquiv_trans {G : Type*} [NormedAddCommGroup G] [InnerProductSpace 𝕜 G]
     [CompleteSpace G] (e : H ≃ₗᵢ[𝕜] K) (f : K ≃ₗᵢ[𝕜] G) :


### PR DESCRIPTION
This PR adds API for `StarAlgEquiv`. It provides:

+ `StarAlgEquiv.toNonUnitalStarAlgHom`
+ `StarAlgEquiv.toStarAlgHom`
+ `StarAlgEquiv.arrowCongr'` (non-unital morphisms)
+ `StarAlgEquiv.arrowCongr` (unital morphisms)
+ `StarAlgEquiv.ofNonUnitalStarAlgHom` (non-unital morphisms)
+ `StarAlgEquiv.ofStarAlgHom` (unital morphisms); this was pre-existing, but used morphism classes instead of actual morphisms. This PR fixes that.

It also generalizes the type class hypothesis in `StarAlgEquiv.restrictScalars` so that it applies to non-unital algebras.

In addition, `StarAlgEquiv.refl` is protected and its type arguments made explicit.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
