### PR TITLE
[Merged by Bors] - feat: conditions for commuting with every element of a span in non-unital algebras

### DIFF
--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -692,3 +692,30 @@ theorem LinearEquiv.isPrincipal_iff (e : M ≃ₗ[R] M₂) :
     Module.IsPrincipal R M ↔ Module.IsPrincipal R M₂ where
   mp := (·.of_surjective _ e.surjective)
   mpr := (·.of_surjective _ e.symm.surjective)
+
+section NonUnitalAlgebra
+
+open Submodule
+
+variable {R A : Type*} [Semiring R] [NonUnitalNonAssocSemiring A] [Module R A]
+  [IsScalarTower R A A] [SMulCommClass R A A]
+
+/-- In a non-unital algebra, if every element of a set `s` commutes with `x`, then every element of
+`Submodule.span R s` commutes with `x`. -/
+theorem Commute.span_left {s : Set A} {x : A} (h : ∀ y ∈ s, Commute y x) :
+    ∀ y ∈ span R s, Commute y x := by
+  intro y hy
+  induction hy using span_induction with
+  | mem _ _ => aesop
+  | zero => exact .zero_left _
+  | add _ _ _ _ h₁ h₂ => exact h₁.add_left h₂
+  | smul _ _ _ h => exact h.smul_left _
+
+/-- In a non-unital algebra, If every element of a set `s` commutes with `x`, then every element of
+`Submodule.span R s` commutes with `x`. -/
+theorem Commute.span_right {s : Set A} {x : A} (h : ∀ y ∈ s, Commute x y) :
+    ∀ y ∈ span R s, Commute x y := by
+  simp only [Commute.symm_iff (a := x)] at *
+  exact .span_left h
+
+end NonUnitalAlgebra

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -711,8 +711,8 @@ theorem Commute.span_left {s : Set A} {x : A} (h : ∀ y ∈ s, Commute y x) :
   | add _ _ _ _ h₁ h₂ => exact h₁.add_left h₂
   | smul _ _ _ h => exact h.smul_left _
 
-/-- In a non-unital algebra, If every element of a set `s` commutes with `x`, then every element of
-`Submodule.span R s` commutes with `x`. -/
+/-- In a non-unital algebra, if `x` commutes with every element of a set `s`, then `x` commutes
+with every element of `Submodule.span R s`. -/
 theorem Commute.span_right {s : Set A} {x : A} (h : ∀ y ∈ s, Commute x y) :
     ∀ y ∈ span R s, Commute x y := by
   simp only [Commute.symm_iff (a := x)] at *


### PR DESCRIPTION
If `x` commutes with every element of `s`, then `x` commutes with every element of `span R s`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
