### PR TITLE
feat(Analysis): adjoints of the L2 product inclusions and projections

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
@@ -5,6 +5,7 @@ Authors: Moritz Doll
 -/
 module
 
+public import Mathlib.Analysis.InnerProductSpace.Adjoint
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.Analysis.Normed.Lp.ProdLp
 
@@ -46,6 +47,37 @@ noncomputable instance instProdInnerProductSpace :
 @[simp]
 theorem prod_inner_apply (x y : WithLp 2 (E × F)) :
     ⟪x, y⟫_𝕜 = ⟪(ofLp x).fst, (ofLp y).fst⟫_𝕜 + ⟪(ofLp x).snd, (ofLp y).snd⟫_𝕜 := rfl
+
+section Adjoint
+
+variable (𝕜 E F)
+variable [CompleteSpace E] [CompleteSpace F]
+
+/-- The adjoint of the inclusion of the first factor into `WithLp 2 (E × F)` is the projection
+onto the first factor. -/
+theorem adjoint_inlL : ContinuousLinearMap.adjoint (inlL 2 𝕜 E F) = fstL 2 𝕜 E F := by
+  rw [eq_comm, ContinuousLinearMap.eq_adjoint_iff]
+  intro x y
+  simp
+
+/-- The adjoint of the inclusion of the second factor into `WithLp 2 (E × F)` is the projection
+onto the second factor. -/
+theorem adjoint_inrL : ContinuousLinearMap.adjoint (inrL 2 𝕜 E F) = sndL 2 𝕜 E F := by
+  rw [eq_comm, ContinuousLinearMap.eq_adjoint_iff]
+  intro x y
+  simp
+
+/-- The adjoint of the projection onto the first factor of `WithLp 2 (E × F)` is the inclusion
+of the first factor. -/
+theorem adjoint_fstL : ContinuousLinearMap.adjoint (fstL 2 𝕜 E F) = inlL 2 𝕜 E F := by
+  rw [← adjoint_inlL, ContinuousLinearMap.adjoint_adjoint]
+
+/-- The adjoint of the projection onto the second factor of `WithLp 2 (E × F)` is the inclusion
+of the second factor. -/
+theorem adjoint_sndL : ContinuousLinearMap.adjoint (sndL 2 𝕜 E F) = inrL 2 𝕜 E F := by
+  rw [← adjoint_inrL, ContinuousLinearMap.adjoint_adjoint]
+
+end Adjoint
 
 end WithLp
 

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -130,6 +130,20 @@ def sndₗ : WithLp p (α × β) →ₗ[𝕜] β where
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 
+/-- The inclusion of the first factor into `WithLp p (α × β)`, as a linear map. -/
+def inlₗ : α →ₗ[𝕜] WithLp p (α × β) :=
+  (WithLp.linearEquiv p 𝕜 (α × β)).symm.toLinearMap ∘ₗ LinearMap.inl 𝕜 α β
+
+/-- The inclusion of the second factor into `WithLp p (α × β)`, as a linear map. -/
+def inrₗ : β →ₗ[𝕜] WithLp p (α × β) :=
+  (WithLp.linearEquiv p 𝕜 (α × β)).symm.toLinearMap ∘ₗ LinearMap.inr 𝕜 α β
+
+@[simp]
+theorem inlₗ_apply (x : α) : inlₗ p 𝕜 α β x = toLp p (x, 0) := rfl
+
+@[simp]
+theorem inrₗ_apply (y : β) : inrₗ p 𝕜 α β y = toLp p (0, y) := rfl
+
 end algebra
 
 /-! Note that the unapplied versions of these lemmas are deliberately omitted, as they break
@@ -570,6 +584,22 @@ def fstL : WithLp p (α × β) →L[𝕜] α where
 @[simps! coe apply]
 def sndL : WithLp p (α × β) →L[𝕜] β where
   __ := sndₗ ..
+
+/-- The inclusion of the first factor into `WithLp p (α × β)`, as a continuous linear map. -/
+def inlL : α →L[𝕜] WithLp p (α × β) where
+  __ := inlₗ p 𝕜 α β
+  cont := (prod_continuous_toLp p α β).comp (continuous_id.prodMk continuous_const)
+
+/-- The inclusion of the second factor into `WithLp p (α × β)`, as a continuous linear map. -/
+def inrL : β →L[𝕜] WithLp p (α × β) where
+  __ := inrₗ p 𝕜 α β
+  cont := (prod_continuous_toLp p α β).comp (continuous_const.prodMk continuous_id)
+
+@[simp]
+theorem inlL_apply (x : α) : inlL p 𝕜 α β x = toLp p (x, 0) := rfl
+
+@[simp]
+theorem inrL_apply (y : β) : inrL p 𝕜 α β y = toLp p (0, y) := rfl
 
 end ContinuousLinearEquiv
 


### PR DESCRIPTION
We record that, for the `L²` product `WithLp 2 (E × F)` of inner product spaces, the adjoint of the canonical inclusion of a factor is the projection onto that factor (and conversely, via `adjoint_adjoint`).

New definitions (in `Mathlib/Analysis/Normed/Lp/ProdLp.lean`, mirroring `fstₗ`/`fstL`):
- `WithLp.inlₗ`, `WithLp.inrₗ`: the factor inclusions as linear maps;
- `WithLp.inlL`, `WithLp.inrL`: the factor inclusions as continuous linear maps.

New lemmas (in `Mathlib/Analysis/InnerProductSpace/ProdL2.lean`, under `[CompleteSpace E] [CompleteSpace F]`):
- `WithLp.adjoint_inlL : ContinuousLinearMap.adjoint (inlL 2 𝕜 E F) = fstL 2 𝕜 E F`
- `WithLp.adjoint_inrL : ContinuousLinearMap.adjoint (inrL 2 𝕜 E F) = sndL 2 𝕜 E F`
- `WithLp.adjoint_fstL`, `WithLp.adjoint_sndL` (the converses).

This completes the adjoint API for the `ProdL2` structure and pairs naturally with the existing `Submodule.orthogonalDecomposition` material: the inclusions and projections form the canonical isometry/co-isometry pair of the orthogonal decomposition.

Note on placement: this adds `Mathlib.Analysis.InnerProductSpace.Adjoint` to the imports of `ProdL2.lean`. If preferred, the `Adjoint` section can move to a separate file to keep the imports of `ProdL2` light — happy to restructure.
