### PR TITLE
[Merged by Bors] - feat(NumberTheory/FactorizationProperties): add positivity lemmas

### DIFF
--- a/Mathlib/NumberTheory/FactorisationProperties.lean
+++ b/Mathlib/NumberTheory/FactorisationProperties.lean
@@ -105,7 +105,7 @@ theorem not_weird_zero : ¬ Weird 0 := by
 theorem weird_seventy : Weird 70 := by
   decide +kernel
 
-def Deficient.pos (h : Deficient n) : 0 < n := by
+lemma Deficient.pos (h : Deficient n) : 0 < n := by
   grind only [not_deficient_zero]
 
 lemma Abundant.pos (h : Abundant n) : 0 < n := by

--- a/Mathlib/NumberTheory/FactorisationProperties.lean
+++ b/Mathlib/NumberTheory/FactorisationProperties.lean
@@ -77,15 +77,12 @@ deriving Decidable
 /-- `abundancyIndex n` is the sum of the divisors of `n` divided by `n`. -/
 def abundancyIndex (n : ℕ) : ℚ := (∑ i ∈ n.divisors, i) / (n : ℚ)
 
-lemma Abundant.pos (h : Abundant n) : 0 < n := by
-  grind [Abundant, Nat.properDivisors_zero]
-
-lemma Weird.pos (h : Weird n) : 0 < n :=
-  h.1.pos
-
 theorem not_pseudoperfect_iff_forall :
     ¬ Pseudoperfect n ↔ n = 0 ∨ ∀ s ⊆ properDivisors n, ∑ i ∈ s, i ≠ n := by
   grind [Pseudoperfect]
+
+theorem not_deficient_zero : ¬ Deficient 0 := by
+  decide
 
 theorem deficient_one : Deficient 1 := by
   decide
@@ -102,8 +99,20 @@ theorem not_abundant_zero : ¬ Abundant 0 := by
 theorem abundant_twelve : Abundant 12 := by
   decide
 
+theorem not_weird_zero : ¬ Weird 0 := by
+  decide
+
 theorem weird_seventy : Weird 70 := by
   decide +kernel
+
+def Deficient.pos (h : Deficient n) : 0 < n := by
+  grind only [not_deficient_zero]
+
+lemma Abundant.pos (h : Abundant n) : 0 < n := by
+  grind only [not_abundant_zero]
+
+lemma Weird.pos (h : Weird n) : 0 < n := by
+  grind only [not_weird_zero]
 
 lemma deficient_iff_not_abundant_and_not_perfect (hn : n ≠ 0) :
     Deficient n ↔ ¬ Abundant n ∧ ¬ Perfect n := by

--- a/Mathlib/NumberTheory/FactorisationProperties.lean
+++ b/Mathlib/NumberTheory/FactorisationProperties.lean
@@ -77,6 +77,12 @@ deriving Decidable
 /-- `abundancyIndex n` is the sum of the divisors of `n` divided by `n`. -/
 def abundancyIndex (n : ℕ) : ℚ := (∑ i ∈ n.divisors, i) / (n : ℚ)
 
+lemma Abundant.pos (h : Abundant n) : 0 < n := by
+  grind [Abundant, Nat.properDivisors_zero]
+
+lemma Weird.pos (h : Weird n) : 0 < n :=
+  h.1.pos
+
 theorem not_pseudoperfect_iff_forall :
     ¬ Pseudoperfect n ↔ n = 0 ∨ ∀ s ⊆ properDivisors n, ∑ i ∈ s, i ≠ n := by
   grind [Pseudoperfect]


### PR DESCRIPTION
This PR proves the basic fact that abundant, deficient, and weird numbers are positive.

This was done as a part of Project Numina's LeanTriathlon project with the help of AI (Claude Code and Numina's lean agent)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
