### PR TITLE
feat(NumberTheory): first-order Euler-Maclaurin summation formula

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5682,6 +5682,7 @@ public import Mathlib.NumberTheory.DirichletCharacter.GaussSum
 public import Mathlib.NumberTheory.DirichletCharacter.Orthogonality
 public import Mathlib.NumberTheory.Divisors
 public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+public import Mathlib.NumberTheory.EulerMaclaurin
 public import Mathlib.NumberTheory.EulerProduct.Basic
 public import Mathlib.NumberTheory.EulerProduct.DirichletLSeries
 public import Mathlib.NumberTheory.EulerProduct.ExpLog

--- a/Mathlib/NumberTheory/EulerMaclaurin.lean
+++ b/Mathlib/NumberTheory/EulerMaclaurin.lean
@@ -141,16 +141,9 @@ private lemma integral_deriv_mul_floor_add_one (ha : 0 ≤ a) (hab : a ≤ b)
     conv => lhs; arg 1; arg 1; ext t; rw [mul_comm]
     rw [integral_deriv_mul_add_const _ hab h_cont.intervalIntegrable hf_diff]
 
-/-- **First-order Euler-Maclaurin summation formula**. For `f : ℝ → 𝕜` with `[RCLike 𝕜]`,
-`0 ≤ a ≤ b`, `f` differentiable on `Set.Icc a b` and `deriv f` continuous on `[[a, b]]`, the sum of
-`f` over the integers in `Finset.Ioc ⌊a⌋ ⌊b⌋` equals its integral plus a boundary correction and
-an error integral against the periodized first Bernoulli function. -/
-theorem sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1 (ha : 0 ≤ a) (hab : a ≤ b)
-    (hf_diff : ∀ t ∈ Set.Icc a b, DifferentiableAt ℝ f t)
-    (h_cont : ContinuousOn (deriv f) [[a, b]]) :
-    ∑ k ∈ Ioc ⌊a⌋ ⌊b⌋, f k =
-      f a * periodizedBernoulli1 a - f b * periodizedBernoulli1 b + (∫ t in a..b, f t)
-        + ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
+/-- Reindex the nonnegative integer interval between its `Int.floor` and `Nat.floor` endpoints. -/
+private lemma sum_Ioc_intFloor_eq_sum_Ioc_natFloor (ha : 0 ≤ a) (hab : a ≤ b) :
+    (∑ k ∈ Ioc ⌊a⌋ ⌊b⌋, f k) = ∑ k ∈ Ioc ⌊a⌋₊ ⌊b⌋₊, f k := by
   have hIoc : (Ioc ⌊a⌋ ⌊b⌋ : Finset ℤ) =
       (Ioc ⌊a⌋₊ ⌊b⌋₊).map (Nat.castEmbedding (R := ℤ)) := by
     have hfa : ((⌊a⌋₊ : ℤ)) = ⌊a⌋ := Int.natCast_floor_eq_floor ha
@@ -173,11 +166,20 @@ theorem sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1 (ha : 0 ≤ 
       constructor
       · exact_mod_cast hn.1
       · exact_mod_cast hn.2
-  have hsum_reindex :
-      (∑ k ∈ Ioc ⌊a⌋ ⌊b⌋, f k) = ∑ k ∈ Ioc ⌊a⌋₊ ⌊b⌋₊, f k := by
-    rw [hIoc, sum_map]
-    rfl
-  rw [hsum_reindex]
+  rw [hIoc, sum_map]
+  rfl
+
+/-- **First-order Euler-Maclaurin summation formula**. For `f : ℝ → 𝕜` with `[RCLike 𝕜]`,
+`0 ≤ a ≤ b`, `f` differentiable on `Set.Icc a b` and `deriv f` continuous on `[[a, b]]`, the sum of
+`f` over the integers in `Finset.Ioc ⌊a⌋ ⌊b⌋` equals its integral plus a boundary correction and
+an error integral against the periodized first Bernoulli function. -/
+theorem sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1 (ha : 0 ≤ a) (hab : a ≤ b)
+    (hf_diff : ∀ t ∈ Set.Icc a b, DifferentiableAt ℝ f t)
+    (h_cont : ContinuousOn (deriv f) [[a, b]]) :
+    ∑ k ∈ Ioc ⌊a⌋ ⌊b⌋, f k =
+      f a * periodizedBernoulli1 a - f b * periodizedBernoulli1 b + (∫ t in a..b, f t)
+        + ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
+  rw [sum_Ioc_intFloor_eq_sum_Ioc_natFloor ha hab]
   have h_sum := sum_mul_eq_sub_sub_integral_mul (fun _ ↦ 1) ha hab hf_diff
     (Set.uIcc_of_le hab ▸ h_cont).integrableOn_Icc
   simp only [mul_one, sum_const, Nat.card_Icc, tsub_zero, nsmul_eq_mul, Nat.cast_add,
@@ -206,3 +208,18 @@ theorem sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1 (ha : 0 ≤ 
     exact_mod_cast hfloor_int
   rw [hfloor_a, hfloor_b]
   ring_nf
+
+/-- Nat-endpoint version of the first-order Euler-Maclaurin summation formula. -/
+theorem sum_natFloor_eq_integral_add_integral_deriv_mul_periodizedBernoulli1
+    (ha : 0 ≤ a) (hab : a ≤ b)
+    (hf_diff : ∀ t ∈ Set.Icc a b, DifferentiableAt ℝ f t)
+    (h_cont : ContinuousOn (deriv f) [[a, b]]) :
+    ∑ k ∈ Ioc ⌊a⌋₊ ⌊b⌋₊, f (k : ℝ) =
+      f a * periodizedBernoulli1 a - f b * periodizedBernoulli1 b + (∫ t in a..b, f t)
+        + ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
+  calc
+    ∑ k ∈ Ioc ⌊a⌋₊ ⌊b⌋₊, f (k : ℝ) = ∑ k ∈ Ioc ⌊a⌋ ⌊b⌋, f (k : ℝ) := by
+      exact (sum_Ioc_intFloor_eq_sum_Ioc_natFloor (f := f) ha hab).symm
+    _ = f a * periodizedBernoulli1 a - f b * periodizedBernoulli1 b + (∫ t in a..b, f t)
+          + ∫ t in a..b, deriv f t * periodizedBernoulli1 t :=
+      sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1 ha hab hf_diff h_cont

--- a/Mathlib/NumberTheory/EulerMaclaurin.lean
+++ b/Mathlib/NumberTheory/EulerMaclaurin.lean
@@ -1,60 +1,90 @@
 /-
-Copyright (c) 2026 Rob Sneiderman. All rights reserved.
+Copyright (c) 2026 Robert Sneiderman. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Rob Sneiderman
+Authors: Robert Sneiderman
 -/
 module
 
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+public import Mathlib.MeasureTheory.Function.Floor
 public import Mathlib.NumberTheory.AbelSummation
+public import Mathlib.NumberTheory.ZetaValues
 
 /-!
-# Euler-Maclaurin summation formula
+# First-order Euler-Maclaurin summation formula
 
-This file proves a first-order Euler-Maclaurin summation formula. The proof specializes Abel
-summation to the constant coefficient sequence and rewrites the floor correction by integration by
-parts.
+This file proves the first-order Euler-Maclaurin formula, relating a sum of a function over the
+integers in an interval to its integral, a boundary correction, and an error integral against the
+periodized first Bernoulli function (the sawtooth function).
 
-## Main declarations
+## Main definitions
 
-* `periodizedBernoulli1`: the first periodized Bernoulli function, `x ↦ Int.fract x - 1 / 2`.
-* `sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1`: a first-order Euler-Maclaurin
-  summation formula for functions `ℝ → 𝕜`, with `[RCLike 𝕜]`.
+* `periodizedBernoulli1`: the periodized first Bernoulli function
+  `x ↦ bernoulliFun 1 (Int.fract x)`, the one-periodic sawtooth taking values in `[-1/2, 1/2)`.
+  This is the `n = 1` case of the periodized Bernoulli family; the general
+  `periodizedBernoulli n := bernoulliFun n ∘ Int.fract` and the corresponding n-order
+  Euler-Maclaurin formula are queued as a follow-up PR.
+
+## Main statements
+
+* `sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1`: for `f : ℝ → 𝕜` with `[RCLike 𝕜]`,
+  `0 ≤ a ≤ b`, `f` differentiable on `Set.Icc a b` and `deriv f` continuous on `[[a, b]]`,
+  `∑ k ∈ Finset.Ioc ⌊a⌋ ⌊b⌋, f k` equals
+  `f a * periodizedBernoulli1 a - f b * periodizedBernoulli1 b + (∫ t in a..b, f t)
+    + ∫ t in a..b, deriv f t * periodizedBernoulli1 t`.
+
+The proof specializes Abel summation (`sum_mul_eq_sub_sub_integral_mul`) to the constant
+coefficient `1`, then rewrites the floor correction by integration by parts.
+
+This complements the existing `bernoulliFun` (the polynomial `x ↦ x - 1 / 2` at `n = 1`) and the
+`UnitAddCircle`-valued `periodizedBernoulli`; here we provide the `ℝ → ℝ` periodization used in
+summation estimates, expressed directly in terms of `bernoulliFun`.
+
+## Floor convention
+
+This file standardizes on `Int.floor` (`⌊·⌋`) rather than `Nat.floor` (`⌊·⌋₊`) throughout the main
+theorem statement. On the range `[a, b]` with `0 ≤ a`, the two floors agree (witnessed by
+`natFloor_cast_eq_intFloor_cast` below), so the underlying Nat-indexed Abel summation method is
+preserved while the public statement matches the convention needed for any general
+`periodizedBernoulli n : ℝ → ℝ` extension.
 -/
 
 @[expose] public section
-
-noncomputable section
 
 open Finset Interval MeasureTheory
 
 variable {𝕜 : Type*} [RCLike 𝕜] {f : ℝ → 𝕜} {a b : ℝ}
 
-/-- The first periodized Bernoulli function, written on `ℝ` using the fractional part. -/
-def periodizedBernoulli1 (x : ℝ) : ℝ :=
-  Int.fract x - 1 / 2
+/-- The periodized first Bernoulli function, the one-periodic sawtooth
+`x ↦ bernoulliFun 1 (Int.fract x)`. Equivalent to `Int.fract x - 1 / 2`.
 
-/-- The first periodized Bernoulli function is strongly measurable. -/
+This is the `n = 1` case of the periodized Bernoulli functions
+`periodizedBernoulli n := bernoulliFun n ∘ Int.fract`; the general family and the n-order
+Euler-Maclaurin formula are queued as a follow-up PR. -/
+noncomputable def periodizedBernoulli1 (x : ℝ) : ℝ := bernoulliFun 1 (Int.fract x)
+
+/-- Unfold lemma for `periodizedBernoulli1` to the explicit sawtooth form. -/
+lemma periodizedBernoulli1_eq (x : ℝ) : periodizedBernoulli1 x = Int.fract x - 1 / 2 := by
+  unfold periodizedBernoulli1
+  rw [bernoulliFun_one]
+
 @[fun_prop]
 lemma aestronglyMeasurable_periodizedBernoulli1 :
     AEStronglyMeasurable periodizedBernoulli1 := by
-  unfold periodizedBernoulli1
+  simp_rw [funext periodizedBernoulli1_eq]
   fun_prop
 
-/-- The first periodized Bernoulli function has absolute value at most `1 / 2`. -/
-lemma abs_periodizedBernoulli1_le_half (x : ℝ) :
-    |periodizedBernoulli1 x| ≤ 1 / 2 := by
-  unfold periodizedBernoulli1
+/-- The periodized first Bernoulli function is bounded in absolute value by `1 / 2`. -/
+lemma abs_periodizedBernoulli1_le_half (x : ℝ) : |periodizedBernoulli1 x| ≤ 1 / 2 := by
+  rw [periodizedBernoulli1_eq]
   refine abs_le.mpr ⟨?_, ?_⟩
-  · linarith [Int.fract_nonneg x]
-  · linarith [Int.fract_lt_one x]
+  · grind [Int.fract_nonneg x]
+  · grind [Int.fract_lt_one x]
 
-/-- Integration by parts for multiplying a derivative by an affine function. -/
+/-- Integration by parts against the affine function `t ↦ t + c`. -/
 lemma integral_deriv_mul_add_const (c : 𝕜) (hab : a ≤ b)
     (h_int : IntervalIntegrable (deriv f) volume a b)
     (hf_diff : ∀ t ∈ Set.Icc a b, DifferentiableAt ℝ f t) :
-    ∫ t in a..b, (t + c) * deriv f t =
-      (b + c) * f b - (a + c) * f a - ∫ t in a..b, f t := by
+    ∫ t in a..b, (t + c) * deriv f t = (b + c) * f b - (a + c) * f a - ∫ t in a..b, f t := by
   rw [← Set.uIcc_of_le hab] at hf_diff
   have h_deriv_left : ∀ t ∈ [[a, b]], HasDerivAt (fun t : ℝ ↦ t + c) 1 t := by
     intro t ht
@@ -65,74 +95,114 @@ lemma integral_deriv_mul_add_const (c : 𝕜) (hab : a ≤ b)
   rw [intervalIntegral.integral_mul_deriv_eq_deriv_mul h_deriv_left hf_diff (by simp) h_int]
   simp
 
-/-- Multiplying a continuous derivative by `periodizedBernoulli1` is interval integrable. -/
+/-- The integrand `deriv f · periodizedBernoulli1` is interval integrable. -/
 lemma intervalIntegrable_deriv_mul_periodizedBernoulli1 (hab : a ≤ b)
     (h_cont : ContinuousOn (deriv f) [[a, b]]) :
     IntervalIntegrable (fun t ↦ deriv f t * periodizedBernoulli1 t) volume a b := by
   refine IntervalIntegrable.continuousOn_mul ?_ h_cont
   rw [intervalIntegrable_iff']
   apply MeasureTheory.Measure.integrableOn_of_bounded (by simp) (by fun_prop) (M := 1 / 2)
-  filter_upwards [self_mem_ae_restrict (by measurability)] with x hx
-  simpa only [RCLike.norm_ofReal] using abs_periodizedBernoulli1_le_half x
+  filter_upwards [self_mem_ae_restrict (by measurability)] with x _
+  norm_cast
+  exact abs_periodizedBernoulli1_le_half x
 
-private lemma natFloor_cast_eq_intFloor_cast {t : ℝ} (ht : 0 ≤ t) :
-    ((⌊t⌋₊ : ℕ) : 𝕜) = (⌊t⌋ : ℤ) := by
-  have hfloor_nonneg : 0 ≤ ⌊t⌋ := Int.floor_nonneg.2 ht
-  have hfloor_nat : ((⌊t⌋₊ : ℕ) : ℤ) = ⌊t⌋ := by
-    rw [← Int.floor_toNat t, Int.toNat_of_nonneg hfloor_nonneg]
-  exact_mod_cast hfloor_nat
+/-- Bridge: on nonneg reals, casting `Nat.floor x` to `ℤ` equals `Int.floor x`. -/
+lemma natFloor_cast_eq_intFloor_cast (x : ℝ) (hx : (0 : ℝ) ≤ x) :
+    ((⌊x⌋₊ : ℤ) : ℝ) = ⌊x⌋ := by
+  rw [Int.natCast_floor_eq_floor hx]
 
-private lemma natFloor_add_one_eq_add_half_sub_periodizedBernoulli1 {t : ℝ} (ht : 0 ≤ t) :
-    ((⌊t⌋₊ : ℕ) : 𝕜) + 1 =
-      (t + (1 / 2 : 𝕜)) - (periodizedBernoulli1 t : 𝕜) := by
-  rw [natFloor_cast_eq_intFloor_cast (𝕜 := 𝕜) ht, periodizedBernoulli1, Int.fract]
-  push_cast
-  ring
-
+/-- The error integral against the floor function, rewritten via integration by parts.
+Stated with `Int.floor` for consistency with the public theorem; the Nat.floor version
+is recovered by the bridge `natFloor_cast_eq_intFloor_cast` on `0 ≤ a ≤ b`. -/
 private lemma integral_deriv_mul_floor_add_one (ha : 0 ≤ a) (hab : a ≤ b)
     (hf_diff : ∀ t ∈ Set.Icc a b, DifferentiableAt ℝ f t)
     (h_cont : ContinuousOn (deriv f) [[a, b]]) :
-    ∫ t in a..b, deriv f t * (⌊t⌋₊ + 1) =
-      (b + 1 / 2) * f b - (a + 1 / 2) * f a - (∫ t in a..b, f t) -
-        ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
+    ∫ t in a..b, deriv f t * (⌊t⌋ + 1) =
+      (b + 1 / 2) * f b - (a + 1 / 2) * f a - (∫ t in a..b, f t)
+        - ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
   calc
-    _ = ∫ t in a..b, deriv f t * (t + 1 / 2) -
-          deriv f t * periodizedBernoulli1 t := by
-        apply intervalIntegral.integral_congr
-        intro t ht
-        rw [Set.uIcc_of_le hab] at ht
-        have ht_nonneg : 0 ≤ t := ha.trans ht.1
-        change deriv f t * (((⌊t⌋₊ : ℕ) : 𝕜) + 1) =
-          deriv f t * (t + (1 / 2 : 𝕜)) -
-            deriv f t * (periodizedBernoulli1 t : 𝕜)
-        rw [natFloor_add_one_eq_add_half_sub_periodizedBernoulli1 (𝕜 := 𝕜) ht_nonneg]
-        ring
-    _ = (∫ t in a..b, deriv f t * (t + 1 / 2)) -
-        ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
-      exact intervalIntegral.integral_sub (ContinuousOn.intervalIntegrable (by fun_prop))
-        (intervalIntegrable_deriv_mul_periodizedBernoulli1 hab h_cont)
-    _ = _ := by
-      conv => lhs; arg 1; arg 1; ext; rw [mul_comm]
-      rw [integral_deriv_mul_add_const _ hab h_cont.intervalIntegrable hf_diff]
+  _ = ∫ t in a..b, (deriv f t * (t + 1 / 2) - deriv f t * periodizedBernoulli1 t) := by
+    refine intervalIntegral.integral_congr fun t ht ↦ ?_
+    rw [Set.uIcc_of_le hab, Set.mem_Icc] at ht
+    have ht0 : 0 ≤ t := ha.trans ht.1
+    have hft : ((⌊t⌋ : 𝕜)) = ((t : ℝ) : 𝕜) - ((Int.fract t : ℝ) : 𝕜) := by
+      have : ((⌊t⌋ : ℝ)) = t - Int.fract t := Int.self_sub_fract t |>.symm
+      rw [← RCLike.ofReal_intCast, this]
+      push_cast
+      ring
+    rw [periodizedBernoulli1_eq, hft]
+    push_cast
+    ring
+  _ = (∫ t in a..b, deriv f t * (t + 1 / 2))
+        - ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
+    exact intervalIntegral.integral_sub (ContinuousOn.intervalIntegrable (by fun_prop))
+      (intervalIntegrable_deriv_mul_periodizedBernoulli1 hab h_cont)
+  _ = _ := by
+    conv => lhs; arg 1; arg 1; ext t; rw [mul_comm]
+    rw [integral_deriv_mul_add_const _ hab h_cont.intervalIntegrable hf_diff]
 
-/-- The first-order Euler-Maclaurin summation formula. -/
+/-- **First-order Euler-Maclaurin summation formula**. For `f : ℝ → 𝕜` with `[RCLike 𝕜]`,
+`0 ≤ a ≤ b`, `f` differentiable on `Set.Icc a b` and `deriv f` continuous on `[[a, b]]`, the sum of
+`f` over the integers in `Finset.Ioc ⌊a⌋ ⌊b⌋` equals its integral plus a boundary correction and
+an error integral against the periodized first Bernoulli function. -/
 theorem sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1 (ha : 0 ≤ a) (hab : a ≤ b)
     (hf_diff : ∀ t ∈ Set.Icc a b, DifferentiableAt ℝ f t)
     (h_cont : ContinuousOn (deriv f) [[a, b]]) :
-    ∑ k ∈ Ioc ⌊a⌋₊ ⌊b⌋₊, f k =
-      f a * periodizedBernoulli1 a - f b * periodizedBernoulli1 b + (∫ t in a..b, f t) +
-        ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
+    ∑ k ∈ Ioc ⌊a⌋ ⌊b⌋, f k =
+      f a * periodizedBernoulli1 a - f b * periodizedBernoulli1 b + (∫ t in a..b, f t)
+        + ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
+  have hIoc : (Ioc ⌊a⌋ ⌊b⌋ : Finset ℤ) =
+      (Ioc ⌊a⌋₊ ⌊b⌋₊).map (Nat.castEmbedding (R := ℤ)) := by
+    have hfa : ((⌊a⌋₊ : ℤ)) = ⌊a⌋ := Int.natCast_floor_eq_floor ha
+    have hfb : ((⌊b⌋₊ : ℤ)) = ⌊b⌋ := Int.natCast_floor_eq_floor (ha.trans hab)
+    rw [← hfa, ← hfb]
+    ext z
+    simp only [mem_Ioc, mem_map, Nat.castEmbedding_apply]
+    constructor
+    · intro hz
+      have hz0 : 0 ≤ z := le_trans (Int.natCast_nonneg ⌊a⌋₊) hz.1.le
+      refine ⟨z.toNat, ?_, ?_⟩
+      · have hzt : ((z.toNat : ℕ) : ℤ) = z := Int.toNat_of_nonneg hz0
+        constructor
+        · rw [← hzt] at hz
+          exact_mod_cast hz.1
+        · rw [← hzt] at hz
+          exact_mod_cast hz.2
+      · exact Int.toNat_of_nonneg hz0
+    · rintro ⟨n, hn, rfl⟩
+      constructor
+      · exact_mod_cast hn.1
+      · exact_mod_cast hn.2
+  have hsum_reindex :
+      (∑ k ∈ Ioc ⌊a⌋ ⌊b⌋, f k) = ∑ k ∈ Ioc ⌊a⌋₊ ⌊b⌋₊, f k := by
+    rw [hIoc, sum_map]
+    rfl
+  rw [hsum_reindex]
   have h_sum := sum_mul_eq_sub_sub_integral_mul (fun _ ↦ 1) ha hab hf_diff
     (Set.uIcc_of_le hab ▸ h_cont).integrableOn_Icc
   simp only [mul_one, sum_const, Nat.card_Icc, tsub_zero, nsmul_eq_mul, Nat.cast_add,
     Nat.cast_one] at h_sum
   rw [h_sum, ← intervalIntegral.integral_of_le hab]
+  have h_nat_int_integral :
+      (∫ t in a..b, deriv f t * (⌊t⌋₊ + 1)) =
+        ∫ t in a..b, deriv f t * (⌊t⌋ + 1) := by
+    refine intervalIntegral.integral_congr fun t ht ↦ ?_
+    rw [Set.uIcc_of_le hab, Set.mem_Icc] at ht
+    have ht0 : 0 ≤ t := ha.trans ht.1
+    have hfloor : (((⌊t⌋₊ : ℕ) : 𝕜)) = ((⌊t⌋ : ℤ) : 𝕜) := by
+      have hfloor_int : ((⌊t⌋₊ : ℤ)) = ⌊t⌋ := Int.natCast_floor_eq_floor ht0
+      exact_mod_cast hfloor_int
+    rw [hfloor]
+  rw [h_nat_int_integral]
   rw [integral_deriv_mul_floor_add_one ha hab hf_diff h_cont]
-  unfold periodizedBernoulli1
+  rw [periodizedBernoulli1_eq, periodizedBernoulli1_eq]
   rw [Int.fract, Int.fract]
   push_cast
-  rw [natFloor_cast_eq_intFloor_cast (𝕜 := 𝕜) ha,
-    natFloor_cast_eq_intFloor_cast (𝕜 := 𝕜) (ha.trans hab)]
+  have hfloor_a : (((⌊a⌋₊ : ℕ) : 𝕜)) = ((⌊a⌋ : ℤ) : 𝕜) := by
+    have hfloor_int : ((⌊a⌋₊ : ℤ)) = ⌊a⌋ := Int.natCast_floor_eq_floor ha
+    exact_mod_cast hfloor_int
+  have hfloor_b : (((⌊b⌋₊ : ℕ) : 𝕜)) = ((⌊b⌋ : ℤ) : 𝕜) := by
+    have hfloor_int : ((⌊b⌋₊ : ℤ)) = ⌊b⌋ := Int.natCast_floor_eq_floor (ha.trans hab)
+    exact_mod_cast hfloor_int
+  rw [hfloor_a, hfloor_b]
   ring_nf
-
-end

--- a/Mathlib/NumberTheory/EulerMaclaurin.lean
+++ b/Mathlib/NumberTheory/EulerMaclaurin.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 Rob Sneiderman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rob Sneiderman
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+public import Mathlib.NumberTheory.AbelSummation
+
+/-!
+# Euler-Maclaurin summation formula
+
+This file proves a first-order Euler-Maclaurin summation formula. The proof specializes Abel
+summation to the constant coefficient sequence and rewrites the floor correction by integration by
+parts.
+
+## Main declarations
+
+* `periodizedBernoulli1`: the first periodized Bernoulli function, `x ↦ Int.fract x - 1 / 2`.
+* `sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1`: a first-order Euler-Maclaurin
+  summation formula for functions `ℝ → 𝕜`, with `[RCLike 𝕜]`.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Finset Interval MeasureTheory
+
+variable {𝕜 : Type*} [RCLike 𝕜] {f : ℝ → 𝕜} {a b : ℝ}
+
+/-- The first periodized Bernoulli function, written on `ℝ` using the fractional part. -/
+def periodizedBernoulli1 (x : ℝ) : ℝ :=
+  Int.fract x - 1 / 2
+
+/-- The first periodized Bernoulli function is strongly measurable. -/
+@[fun_prop]
+lemma aestronglyMeasurable_periodizedBernoulli1 :
+    AEStronglyMeasurable periodizedBernoulli1 := by
+  unfold periodizedBernoulli1
+  fun_prop
+
+/-- The first periodized Bernoulli function has absolute value at most `1 / 2`. -/
+lemma abs_periodizedBernoulli1_le_half (x : ℝ) :
+    |periodizedBernoulli1 x| ≤ 1 / 2 := by
+  unfold periodizedBernoulli1
+  refine abs_le.mpr ⟨?_, ?_⟩
+  · linarith [Int.fract_nonneg x]
+  · linarith [Int.fract_lt_one x]
+
+/-- Integration by parts for multiplying a derivative by an affine function. -/
+lemma integral_deriv_mul_add_const (c : 𝕜) (hab : a ≤ b)
+    (h_int : IntervalIntegrable (deriv f) volume a b)
+    (hf_diff : ∀ t ∈ Set.Icc a b, DifferentiableAt ℝ f t) :
+    ∫ t in a..b, (t + c) * deriv f t =
+      (b + c) * f b - (a + c) * f a - ∫ t in a..b, f t := by
+  rw [← Set.uIcc_of_le hab] at hf_diff
+  have h_deriv_left : ∀ t ∈ [[a, b]], HasDerivAt (fun t : ℝ ↦ t + c) 1 t := by
+    intro t ht
+    simp only [hasDerivAt_add_const_iff]
+    simpa only [RCLike.ofRealCLM_apply, map_one] using
+      (RCLike.ofRealCLM (K := 𝕜)).hasDerivAt
+  replace hf_diff := fun t ht ↦ (hf_diff t ht).hasDerivAt
+  rw [intervalIntegral.integral_mul_deriv_eq_deriv_mul h_deriv_left hf_diff (by simp) h_int]
+  simp
+
+/-- Multiplying a continuous derivative by `periodizedBernoulli1` is interval integrable. -/
+lemma intervalIntegrable_deriv_mul_periodizedBernoulli1 (hab : a ≤ b)
+    (h_cont : ContinuousOn (deriv f) [[a, b]]) :
+    IntervalIntegrable (fun t ↦ deriv f t * periodizedBernoulli1 t) volume a b := by
+  refine IntervalIntegrable.continuousOn_mul ?_ h_cont
+  rw [intervalIntegrable_iff']
+  apply MeasureTheory.Measure.integrableOn_of_bounded (by simp) (by fun_prop) (M := 1 / 2)
+  filter_upwards [self_mem_ae_restrict (by measurability)] with x hx
+  simpa only [RCLike.norm_ofReal] using abs_periodizedBernoulli1_le_half x
+
+private lemma natFloor_cast_eq_intFloor_cast {t : ℝ} (ht : 0 ≤ t) :
+    ((⌊t⌋₊ : ℕ) : 𝕜) = (⌊t⌋ : ℤ) := by
+  have hfloor_nonneg : 0 ≤ ⌊t⌋ := Int.floor_nonneg.2 ht
+  have hfloor_nat : ((⌊t⌋₊ : ℕ) : ℤ) = ⌊t⌋ := by
+    rw [← Int.floor_toNat t, Int.toNat_of_nonneg hfloor_nonneg]
+  exact_mod_cast hfloor_nat
+
+private lemma natFloor_add_one_eq_add_half_sub_periodizedBernoulli1 {t : ℝ} (ht : 0 ≤ t) :
+    ((⌊t⌋₊ : ℕ) : 𝕜) + 1 =
+      (t + (1 / 2 : 𝕜)) - (periodizedBernoulli1 t : 𝕜) := by
+  rw [natFloor_cast_eq_intFloor_cast (𝕜 := 𝕜) ht, periodizedBernoulli1, Int.fract]
+  push_cast
+  ring
+
+private lemma integral_deriv_mul_floor_add_one (ha : 0 ≤ a) (hab : a ≤ b)
+    (hf_diff : ∀ t ∈ Set.Icc a b, DifferentiableAt ℝ f t)
+    (h_cont : ContinuousOn (deriv f) [[a, b]]) :
+    ∫ t in a..b, deriv f t * (⌊t⌋₊ + 1) =
+      (b + 1 / 2) * f b - (a + 1 / 2) * f a - (∫ t in a..b, f t) -
+        ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
+  calc
+    _ = ∫ t in a..b, deriv f t * (t + 1 / 2) -
+          deriv f t * periodizedBernoulli1 t := by
+        apply intervalIntegral.integral_congr
+        intro t ht
+        rw [Set.uIcc_of_le hab] at ht
+        have ht_nonneg : 0 ≤ t := ha.trans ht.1
+        change deriv f t * (((⌊t⌋₊ : ℕ) : 𝕜) + 1) =
+          deriv f t * (t + (1 / 2 : 𝕜)) -
+            deriv f t * (periodizedBernoulli1 t : 𝕜)
+        rw [natFloor_add_one_eq_add_half_sub_periodizedBernoulli1 (𝕜 := 𝕜) ht_nonneg]
+        ring
+    _ = (∫ t in a..b, deriv f t * (t + 1 / 2)) -
+        ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
+      exact intervalIntegral.integral_sub (ContinuousOn.intervalIntegrable (by fun_prop))
+        (intervalIntegrable_deriv_mul_periodizedBernoulli1 hab h_cont)
+    _ = _ := by
+      conv => lhs; arg 1; arg 1; ext; rw [mul_comm]
+      rw [integral_deriv_mul_add_const _ hab h_cont.intervalIntegrable hf_diff]
+
+/-- The first-order Euler-Maclaurin summation formula. -/
+theorem sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1 (ha : 0 ≤ a) (hab : a ≤ b)
+    (hf_diff : ∀ t ∈ Set.Icc a b, DifferentiableAt ℝ f t)
+    (h_cont : ContinuousOn (deriv f) [[a, b]]) :
+    ∑ k ∈ Ioc ⌊a⌋₊ ⌊b⌋₊, f k =
+      f a * periodizedBernoulli1 a - f b * periodizedBernoulli1 b + (∫ t in a..b, f t) +
+        ∫ t in a..b, deriv f t * periodizedBernoulli1 t := by
+  have h_sum := sum_mul_eq_sub_sub_integral_mul (fun _ ↦ 1) ha hab hf_diff
+    (Set.uIcc_of_le hab ▸ h_cont).integrableOn_Icc
+  simp only [mul_one, sum_const, Nat.card_Icc, tsub_zero, nsmul_eq_mul, Nat.cast_add,
+    Nat.cast_one] at h_sum
+  rw [h_sum, ← intervalIntegral.integral_of_le hab]
+  rw [integral_deriv_mul_floor_add_one ha hab hf_diff h_cont]
+  unfold periodizedBernoulli1
+  rw [Int.fract, Int.fract]
+  push_cast
+  rw [natFloor_cast_eq_intFloor_cast (𝕜 := 𝕜) ha,
+    natFloor_cast_eq_intFloor_cast (𝕜 := 𝕜) (ha.trans hab)]
+  ring_nf
+
+end


### PR DESCRIPTION
This adds the first-order Euler–Maclaurin summation formula to `Mathlib/NumberTheory/`.

It introduces `periodizedBernoulli1 x = Int.fract x - 1/2` (the 1-periodic first Bernoulli function) with the unconditional bound `|periodizedBernoulli1 x| ≤ 1/2`, and proves, for `f` continuously differentiable on `[a, b]` with `0 ≤ a ≤ b`,

```
∑ n ∈ Ioc a b, f n = ∫ x in a..b, f x + ∫ x in a..b, deriv f x * periodizedBernoulli1 x
```

as `sum_eq_integral_add_integral_deriv_mul_periodizedBernoulli1`.

Opened as a draft to settle naming first: `bernoulliFun` and `periodizedBernoulli` (on `UnitAddCircle`) are nearby, and `periodizedBernoulli1` may be better expressed in terms of one of them.

Lean Code and research is developed with AI assistance (Claude Code CLI, the model used was Opus 4.8).
Results are kernel checked locally, and I am writing these posts myself in order to fully comply with mathlib4's strict anti-ai policies. 

I have opened a discussion on zulip for any feedback in regard to this PR, and to address any issues, questions or comments.


Update 1: following feedback

periodizedBernoulli1 is now bernoulliFun 1 (Int.fract x), which connects it to the existing bernoulliFun infrastructure rather than an ad-hoc named expression, without growing this PR's scope. The general periodizedBernoulli n := bernoulliFun n ∘ Int.fract family and the n-order Euler-Maclaurin formula are queued as a follow-up PR.

The statement is standardized on Int.floor throughout (the main theorem and the private floor-correction lemma). The Abel-summation step stays Nat-indexed internally, bridged to the Int.floor statement by a small cast helper, so the Nat/Int mixture is gone.

Update 2:

On the index set: I have kept a single floor type, so the main statement stays on Int.floor, and I added a Nat-endpoint corollary recovering ∑ k ∈ Ioc ⌊a⌋₊ ⌊b⌋₊, f k. Under 0 ≤ a ≤ b the two floors agree, so it is a short cast over the existing bridge lemma rather than a second proof, the same both-forms shape AbelSummation already uses with sum_mul_eq_sub_sub_integral_mul and sum_mul_eq_sub_sub_integral_mul'. Callers who want the ℕ-indexed sum then get it directly.

The sum over ℤ holds without a, b positive and only the Abel-summation proof needs it; translating the range to be positive and reapplying the Nat result would give that. This PR is intentionally kept minimal, so I will plan to add the unrestricted-ℤ form in the follow-up that introduces the general periodized Bernoulli family.

Rob