### PR TITLE
[Merged by Bors] - chore(PiTensorProduct/ProjectiveNorm): cleaner reducible defeqs

### DIFF
--- a/Mathlib/Analysis/Normed/Module/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Module/PiTensorProduct/InjectiveSeminorm.lean
@@ -52,21 +52,20 @@ variable (F) in
 /-- The linear map from `⨂[𝕜] i, Eᵢ` to `ContinuousMultilinearMap 𝕜 E F →L[𝕜] F` sending
 `x` in `⨂[𝕜] i, Eᵢ` to the map `f ↦ f.lift x`. -/
 @[simps!]
-noncomputable def toDualContinuousMultilinearMap : (⨂[𝕜] i, E i) →ₗ[𝕜]
-    ContinuousMultilinearMap 𝕜 E F →L[𝕜] F where
+noncomputable def toDualContinuousMultilinearMap :
+    (⨂[𝕜] i, E i) →ₗ[𝕜] ContinuousMultilinearMap 𝕜 E F →L[𝕜] F where
   toFun x := LinearMap.mkContinuous
-    (lift.toLinearMap.flip x ∘ₗ ContinuousMultilinearMap.toMultilinearMapLinear)
-    (projectiveSeminorm x)
-    (fun _ ↦ by simpa [mul_comm] using! norm_eval_le_projectiveSeminorm ..)
+    (lift.toLinearMap.flip x ∘ₗ ContinuousMultilinearMap.toMultilinearMapLinear) ‖x‖
+    (fun f ↦ by simpa [mul_comm] using norm_eval_le_projectiveSeminorm f x)
   map_add' x y := by
     ext; simp
   map_smul' a x := by
     ext; simp
 
 theorem toDualContinuousMultilinearMap_le_projectiveSeminorm (x : ⨂[𝕜] i, E i) :
-    ‖toDualContinuousMultilinearMap F x‖ ≤ projectiveSeminorm x := by
+    ‖toDualContinuousMultilinearMap F x‖ ≤ ‖x‖ := by
   simp only [toDualContinuousMultilinearMap, LinearMap.coe_mk, AddHom.coe_mk]
-  apply LinearMap.mkContinuous_norm_le _ (apply_nonneg _ _)
+  apply LinearMap.mkContinuous_norm_le _ (by positivity)
 
 /-- The injective seminorm on `⨂[𝕜] i, Eᵢ`. Morally, it sends `x` in `⨂[𝕜] i, Eᵢ` to the
 `sup` of the operator norms of the `PiTensorProduct.toDualContinuousMultilinearMap F x`, for all
@@ -89,7 +88,7 @@ lemma dualSeminorms_bounded : BddAbove {p | ∃ (G : Type (max uι u𝕜 uE))
   use projectiveSeminorm
   simp only [mem_upperBounds, Set.mem_setOf_eq, forall_exists_index]
   intro p G _ _ hp x
-  simpa [hp] using toDualContinuousMultilinearMap_le_projectiveSeminorm _
+  simpa [hp] using! toDualContinuousMultilinearMap_le_projectiveSeminorm _
 
 @[deprecated
   "`injectiveSeminorm` is deprecated in favor of the extensionally equal `projectiveSeminorm`"

--- a/Mathlib/Analysis/Normed/Module/PiTensorProduct/ProjectiveSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Module/PiTensorProduct/ProjectiveSeminorm.lean
@@ -120,7 +120,7 @@ theorem projectiveSeminorm_smul_le (a : 𝕜) (x : ⨂[𝕜] i, E i) : ‖a • 
 infimum over all expressions of `x` as `∑ j, ⨂ₜ[𝕜] mⱼ i` (with the `mⱼ` ∈ `Π i, Eᵢ`)
 of `∑ j, Π i, ‖mⱼ i‖`. -/
 noncomputable def projectiveSeminorm : Seminorm 𝕜 (⨂[𝕜] i, E i) := .ofSMulLE
-    _ projectiveSeminorm_zero projectiveSeminorm_add_le projectiveSeminorm_smul_le
+    norm projectiveSeminorm_zero projectiveSeminorm_add_le projectiveSeminorm_smul_le
 
 noncomputable instance : SeminormedAddCommGroup (⨂[𝕜] i, E i) :=
   fast_instance% AddGroupSeminorm.toSeminormedAddCommGroup projectiveSeminorm.toAddGroupSeminorm
@@ -132,10 +132,11 @@ theorem projectiveSeminorm_apply (x : ⨂[𝕜] i, E i) :
     projectiveSeminorm x = iInf (fun (p : lifts x) ↦ projectiveSeminormAux p.1) := rfl
 
 theorem projectiveSeminorm_tprod_le (m : Π i, E i) :
-    projectiveSeminorm (⨂ₜ[𝕜] i, m i) ≤ ∏ i, ‖m i‖ := by
-  convert! ciInf_le (bddBelow_projectiveSemiNormAux _) ⟨FreeAddMonoid.of ((1 : 𝕜), m), ?_⟩
-  · simp [projectiveSeminormAux]
-  · simp [mem_lifts_iff]
+    ‖(⨂ₜ[𝕜] i, m i)‖ ≤ ∏ i, ‖m i‖ := by
+   have hle := ciInf_le (bddBelow_projectiveSemiNormAux (⨂ₜ[𝕜] i, m i))
+    ⟨FreeAddMonoid.of (1, m), by simp [mem_lifts_iff]⟩
+   grw [norm_def, hle]
+   simp [projectiveSeminormAux]
 
 end NormedField
 


### PR DESCRIPTION
This PR replaces `projectiveSeminorm x` by `‖x‖` in the definitions of `toDualContinuousMultilinearMap`, `toDualContinuousMultilinearMap_le_projectiveSeminorm`, and `projectiveSeminorm_tprod_le`. The two terms are defeq, but not at reducible transparency. The new definition allows us to get rid of a `convert!` and a `using!`, and is more consistent with the rest of the module.

---

Remarks:
* Originally, this PR also fixed an instance diamond. But the same issue was addressed in #40452, which got merged first. See also discussion at #35569. 
* The PR also _adds_ a `using!`, but in a deprecated definition.

- [x] depends on: #35569

Co-authored-by: Davood H. T. Tehrani

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
