### PR TITLE
[Merged by Bors] - chore(MeasureTheory/SetSemiring): golf some proofs

### DIFF
--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -72,6 +72,79 @@ structure IsSetRing (C : Set (Set α)) : Prop where
   union_mem ⦃s t : Set α⦄ : s ∈ C → t ∈ C → s ∪ t ∈ C
   sdiff_mem ⦃s t : Set α⦄ : s ∈ C → t ∈ C → s \ t ∈ C
 
+namespace IsSetRing
+
+lemma inter_mem (hC : IsSetRing C) (hs : s ∈ C) (ht : t ∈ C) : s ∩ t ∈ C := by
+  rw [← sdiff_sdiff_right_self]; exact hC.sdiff_mem hs (hC.sdiff_mem hs ht)
+
+lemma isSetSemiring (hC : IsSetRing C) : IsSetSemiring C where
+  empty_mem := hC.empty_mem
+  inter_mem := fun _ hs _ ht => hC.inter_mem hs ht
+  sdiff_eq_sUnion' := by
+    refine fun s hs t ht => ⟨{s \ t}, ?_, ?_, ?_⟩
+    · simp only [coe_singleton, Set.singleton_subset_iff]
+      exact hC.sdiff_mem hs ht
+    · simp only [coe_singleton, pairwiseDisjoint_singleton]
+    · simp only [coe_singleton, sUnion_singleton]
+
+lemma biUnion_mem {ι : Type*} (hC : IsSetRing C) {s : ι → Set α}
+    (S : Finset ι) (hs : ∀ n ∈ S, s n ∈ C) :
+    ⋃ i ∈ S, s i ∈ C := by
+  classical
+  induction S using Finset.induction with
+  | empty => simp [hC.empty_mem]
+  | insert i S _ h =>
+    simp_rw [← Finset.mem_coe, Finset.coe_insert, Set.biUnion_insert]
+    refine hC.union_mem (hs i (mem_insert_self i S)) ?_
+    exact h (fun n hnS ↦ hs n (mem_insert_of_mem hnS))
+
+lemma biInter_mem {ι : Type*} (hC : IsSetRing C) {s : ι → Set α}
+    (S : Finset ι) (hS : S.Nonempty) (hs : ∀ n ∈ S, s n ∈ C) :
+    ⋂ i ∈ S, s i ∈ C := by
+  classical
+  induction hS using Finset.Nonempty.cons_induction with
+  | singleton => simpa using hs
+  | cons i S hiS _ h =>
+    simp_rw [← Finset.mem_coe, Finset.coe_cons, Set.biInter_insert]
+    simp only [cons_eq_insert, Finset.mem_insert, forall_eq_or_imp] at hs
+    refine hC.inter_mem hs.1 ?_
+    exact h (fun n hnS ↦ hs.2 n hnS)
+
+lemma finsetSup_mem (hC : IsSetRing C) {ι : Type*} {s : ι → Set α} {t : Finset ι}
+    (hs : ∀ i ∈ t, s i ∈ C) :
+    t.sup s ∈ C := by
+  simpa using biUnion_mem hC _ hs
+
+lemma partialSups_mem {ι : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    (hC : IsSetRing C) {s : ι → Set α} (hs : ∀ n, s n ∈ C) (n : ι) :
+    partialSups s n ∈ C := by
+  simpa only [partialSups_apply, sup'_eq_sup] using hC.finsetSup_mem (fun i hi ↦ hs i)
+
+lemma disjointed_mem {ι : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    (hC : IsSetRing C) {s : ι → Set α} (hs : ∀ j, s j ∈ C) (i : ι) :
+    disjointed s i ∈ C :=
+  disjointedRec (fun _ j ht ↦ hC.sdiff_mem ht <| hs j) (hs i)
+
+theorem iUnion_le_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ n, s n ∈ C) (n : ℕ) :
+    (⋃ i ≤ n, s i) ∈ C := by
+  induction n with
+  | zero => simp [hs 0]
+  | succ n hn => rw [biUnion_le_succ]; exact hC.union_mem hn (hs _)
+
+theorem iInter_le_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ n, s n ∈ C) (n : ℕ) :
+    (⋂ i ≤ n, s i) ∈ C := by
+  induction n with
+  | zero => simp [hs 0]
+  | succ n hn => rw [biInter_le_succ]; exact hC.inter_mem hn (hs _)
+
+theorem accumulate_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ i, s i ∈ C) (n : ℕ) :
+    accumulate s n ∈ C := by
+  induction n with
+  | zero => simp [hs 0]
+  | succ n hn => rw [accumulate_succ]; exact hC.union_mem hn (hs _)
+
+end IsSetRing
+
 namespace IsSetSemiring
 
 lemma isPiSystem (hC : IsSetSemiring C) : IsPiSystem C := fun s hs t ht _ ↦ hC.inter_mem s hs t ht
@@ -534,78 +607,5 @@ protected lemma Ioc [LinearOrder α] [Nonempty α] :
     grind
 
 end IsSetSemiring
-
-namespace IsSetRing
-
-lemma inter_mem (hC : IsSetRing C) (hs : s ∈ C) (ht : t ∈ C) : s ∩ t ∈ C := by
-  rw [← sdiff_sdiff_right_self]; exact hC.sdiff_mem hs (hC.sdiff_mem hs ht)
-
-lemma isSetSemiring (hC : IsSetRing C) : IsSetSemiring C where
-  empty_mem := hC.empty_mem
-  inter_mem := fun _ hs _ ht => hC.inter_mem hs ht
-  sdiff_eq_sUnion' := by
-    refine fun s hs t ht => ⟨{s \ t}, ?_, ?_, ?_⟩
-    · simp only [coe_singleton, Set.singleton_subset_iff]
-      exact hC.sdiff_mem hs ht
-    · simp only [coe_singleton, pairwiseDisjoint_singleton]
-    · simp only [coe_singleton, sUnion_singleton]
-
-lemma biUnion_mem {ι : Type*} (hC : IsSetRing C) {s : ι → Set α}
-    (S : Finset ι) (hs : ∀ n ∈ S, s n ∈ C) :
-    ⋃ i ∈ S, s i ∈ C := by
-  classical
-  induction S using Finset.induction with
-  | empty => simp [hC.empty_mem]
-  | insert i S _ h =>
-    simp_rw [← Finset.mem_coe, Finset.coe_insert, Set.biUnion_insert]
-    refine hC.union_mem (hs i (mem_insert_self i S)) ?_
-    exact h (fun n hnS ↦ hs n (mem_insert_of_mem hnS))
-
-lemma biInter_mem {ι : Type*} (hC : IsSetRing C) {s : ι → Set α}
-    (S : Finset ι) (hS : S.Nonempty) (hs : ∀ n ∈ S, s n ∈ C) :
-    ⋂ i ∈ S, s i ∈ C := by
-  classical
-  induction hS using Finset.Nonempty.cons_induction with
-  | singleton => simpa using hs
-  | cons i S hiS _ h =>
-    simp_rw [← Finset.mem_coe, Finset.coe_cons, Set.biInter_insert]
-    simp only [cons_eq_insert, Finset.mem_insert, forall_eq_or_imp] at hs
-    refine hC.inter_mem hs.1 ?_
-    exact h (fun n hnS ↦ hs.2 n hnS)
-
-lemma finsetSup_mem (hC : IsSetRing C) {ι : Type*} {s : ι → Set α} {t : Finset ι}
-    (hs : ∀ i ∈ t, s i ∈ C) :
-    t.sup s ∈ C := by
-  simpa using biUnion_mem hC _ hs
-
-lemma partialSups_mem {ι : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    (hC : IsSetRing C) {s : ι → Set α} (hs : ∀ n, s n ∈ C) (n : ι) :
-    partialSups s n ∈ C := by
-  simpa only [partialSups_apply, sup'_eq_sup] using hC.finsetSup_mem (fun i hi ↦ hs i)
-
-lemma disjointed_mem {ι : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    (hC : IsSetRing C) {s : ι → Set α} (hs : ∀ j, s j ∈ C) (i : ι) :
-    disjointed s i ∈ C :=
-  disjointedRec (fun _ j ht ↦ hC.sdiff_mem ht <| hs j) (hs i)
-
-theorem iUnion_le_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ n, s n ∈ C) (n : ℕ) :
-    (⋃ i ≤ n, s i) ∈ C := by
-  induction n with
-  | zero => simp [hs 0]
-  | succ n hn => rw [biUnion_le_succ]; exact hC.union_mem hn (hs _)
-
-theorem iInter_le_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ n, s n ∈ C) (n : ℕ) :
-    (⋂ i ≤ n, s i) ∈ C := by
-  induction n with
-  | zero => simp [hs 0]
-  | succ n hn => rw [biInter_le_succ]; exact hC.inter_mem hn (hs _)
-
-theorem accumulate_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ i, s i ∈ C) (n : ℕ) :
-    accumulate s n ∈ C := by
-  induction n with
-  | zero => simp [hs 0]
-  | succ n hn => rw [accumulate_succ]; exact hC.union_mem hn (hs _)
-
-end IsSetRing
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -49,7 +49,7 @@ A ring of sets is a set of sets containing `∅`, stable by union, set differenc
 
 -/
 
-@[expose] public section
+public section
 
 open Finset Set
 
@@ -225,41 +225,29 @@ gives an arbitrary `Finset (Set α)` that satisfies the equality.
 We remove the empty set to ensure that `t ∉ hC.disjointOfDiff hs ht` even if `t = ∅`. -/
 noncomputable def disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
     Finset (Set α) :=
-  (hC.sdiff_eq_sUnion' s hs t ht).choose \ {∅}
+  (hC.exists_finpartition_sdiff hs ht).choose.parts
 
 lemma empty_notMem_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
-    ∅ ∉ hC.disjointOfDiff hs ht := by
-  simp only [disjointOfDiff, Finset.mem_sdiff, Finset.mem_singleton,
-    not_true, and_false, not_false_iff]
+    ∅ ∉ hC.disjointOfDiff hs ht :=
+  Finpartition.bot_notMem _
 
 lemma subset_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
-    ↑(hC.disjointOfDiff hs ht) ⊆ C := by
-  simp only [disjointOfDiff, coe_sdiff, coe_singleton, sdiff_singleton_subset_iff]
-  exact (hC.sdiff_eq_sUnion' s hs t ht).choose_spec.1.trans (Set.subset_insert _ _)
+    ↑(hC.disjointOfDiff hs ht) ⊆ C :=
+  (hC.exists_finpartition_sdiff hs ht).choose_spec
 
 lemma pairwiseDisjoint_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
-    PairwiseDisjoint (hC.disjointOfDiff hs ht : Set (Set α)) id := by
-  simp only [disjointOfDiff, coe_sdiff, coe_singleton]
-  exact Set.PairwiseDisjoint.subset (hC.sdiff_eq_sUnion' s hs t ht).choose_spec.2.1
-      sdiff_subset
+    PairwiseDisjoint (hC.disjointOfDiff hs ht : Set (Set α)) id :=
+  Finpartition.supIndep _ |>.pairwiseDisjoint
 
 lemma sUnion_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
-    ⋃₀ hC.disjointOfDiff hs ht = s \ t := by
-  rw [(hC.sdiff_eq_sUnion' s hs t ht).choose_spec.2.2]
-  simp only [disjointOfDiff, coe_sdiff, coe_singleton]
-  rw [sUnion_sdiff_singleton_empty]
+    ⋃₀ hC.disjointOfDiff hs ht = s \ t :=
+  (sup_id_eq_sSup _).symm.trans (Finpartition.sup_parts _)
 
 lemma notMem_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
     t ∉ hC.disjointOfDiff hs ht := by
   intro hs_mem
-  suffices t ⊆ s \ t by
-    have h := @disjoint_sdiff_self_right _ t s _
-    specialize h le_rfl this
-    simp only [Set.bot_eq_empty, subset_empty_iff] at h
-    refine hC.empty_notMem_disjointOfDiff hs ht ?_
-    rwa [← h]
-  rw [← hC.sUnion_disjointOfDiff hs ht]
-  exact subset_sUnion_of_mem hs_mem
+  cases disjoint_sdiff_self_right.eq_bot_of_le (Finpartition.le _ hs_mem)
+  exact hC.empty_notMem_disjointOfDiff hs ht hs_mem
 
 lemma sUnion_insert_disjointOfDiff (hC : IsSetSemiring C) (hs : s ∈ C)
     (ht : t ∈ C) (hst : t ⊆ s) :
@@ -287,73 +275,11 @@ section disjointOfDiffUnion
 
 variable {I : Finset (Set α)}
 
-/-- In a semiring of sets `C`, for all set `s ∈ C` and finite set of sets `I ⊆ C`, there is a
-finite set of sets in `C` whose union is `s \ ⋃₀ I`.
-See `IsSetSemiring.disjointOfDiffUnion` for a definition that gives such a set. -/
-lemma exists_disjoint_finset_sdiff_eq (hC : IsSetSemiring C) (hs : s ∈ C) (hI : ↑I ⊆ C) :
-    ∃ J : Finset (Set α), ↑J ⊆ C ∧ PairwiseDisjoint (J : Set (Set α)) id ∧
-      s \ ⋃₀ I = ⋃₀ J := by
-  induction I using Finset.induction with
-  | empty =>
-    simp only [coe_empty, sUnion_empty, sdiff_empty]
-    refine ⟨{s}, singleton_subset_set_iff.mpr hs, ?_⟩
-    simp only [coe_singleton, pairwiseDisjoint_singleton, sUnion_singleton,
-      and_self_iff]
-  | insert t I' _ h => ?_
-  rw [coe_insert] at hI
-  have ht : t ∈ C := hI (Set.mem_insert _ _)
-  obtain ⟨J, h_ss, h_dis, h_eq⟩ := h ((Set.subset_insert _ _).trans hI)
-  let Ju : ∀ u ∈ C, Finset (Set α) := fun u hu ↦ hC.disjointOfDiff hu ht
-  have hJu_subset : ∀ (u) (hu : u ∈ C), ↑(Ju u hu) ⊆ C := by
-    intro u hu x hx
-    exact hC.subset_disjointOfDiff hu ht hx
-  have hJu_disj : ∀ (u) (hu : u ∈ C), (Ju u hu : Set (Set α)).PairwiseDisjoint id := fun u hu ↦
-    hC.pairwiseDisjoint_disjointOfDiff hu ht
-  have hJu_sUnion : ∀ (u) (hu : u ∈ C), ⋃₀ (Ju u hu : Set (Set α)) = u \ t :=
-    fun u hu ↦ hC.sUnion_disjointOfDiff hu ht
-  have hJu_disj' : ∀ (u) (hu : u ∈ C) (v) (hv : v ∈ C) (_h_dis : Disjoint u v),
-      Disjoint (⋃₀ (Ju u hu : Set (Set α))) (⋃₀ ↑(Ju v hv)) := by
-    intro u hu v hv huv_disj
-    rw [hJu_sUnion, hJu_sUnion]
-    exact disjoint_of_subset Set.sdiff_subset Set.sdiff_subset huv_disj
-  let J' : Finset (Set α) := Finset.biUnion (Finset.univ : Finset J) fun u ↦ Ju u (h_ss u.prop)
-  have hJ'_subset : ↑J' ⊆ C := by
-    intro u
-    simp only [J', univ_eq_attach, coe_biUnion, mem_coe, mem_attach, iUnion_true,
-      mem_iUnion, Finset.exists_coe, exists₂_imp]
-    intro v hv huvt
-    exact hJu_subset v (h_ss hv) huvt
-  refine ⟨J', hJ'_subset, ?_, ?_⟩
-  · rw [Finset.coe_biUnion]
-    refine PairwiseDisjoint.biUnion ?_ ?_
-    · simp only [univ_eq_attach, mem_coe, id, iSup_eq_iUnion]
-      simp_rw [PairwiseDisjoint, Set.Pairwise]
-      intro x _ y _ hxy
-      have hxy_disj : Disjoint (x : Set α) y := by
-        by_contra h_contra
-        refine hxy ?_
-        refine Subtype.ext ?_
-        exact h_dis.elim x.prop y.prop h_contra
-      convert! hJu_disj' (x : Set α) (h_ss x.prop) y (h_ss y.prop) hxy_disj
-      · rw [sUnion_eq_biUnion]
-        congr
-      · rw [sUnion_eq_biUnion]
-        congr
-    · exact fun u _ ↦ hJu_disj _ _
-  · rw [coe_insert, sUnion_insert, Set.union_comm, ← Set.sdiff_sdiff, h_eq]
-    simp_rw [J', sUnion_eq_biUnion, Set.iUnion_sdiff]
-    simp only [mem_coe, Finset.mem_biUnion, Finset.mem_univ,
-      Finset.exists_coe, iUnion_exists, true_and]
-    rw [iUnion_comm]
-    refine iUnion_congr fun i ↦ ?_
-    by_cases hi : i ∈ J
-    · simp only [hi, iUnion_true]
-      rw [← hJu_sUnion i (h_ss hi), sUnion_eq_biUnion]
-      simp only [mem_coe]
-    · simp only [hi, iUnion_of_empty, iUnion_empty]
-
-@[deprecated (since := "2026-06-03")]
-alias exists_disjoint_finset_diff_eq := exists_disjoint_finset_sdiff_eq
+private theorem exists_finpartition_sdiff_sUnion (hC : IsSetSemiring C) (hs : s ∈ C) (hI : ↑I ⊆ C) :
+    ∃ P : Finpartition (s \ ⋃₀ I), ↑P.parts ⊆ C := by
+  rw [← hC.mem_supClosure_iff, ← sSup_eq_sUnion, ← sup_id_eq_sSup]
+  have hC' := hC.isSetRing_supClosure
+  exact hC'.sdiff_mem (subset_supClosure hs) <| hC'.finsetSup_mem <| hI.trans subset_supClosure
 
 /-- In a semiring of sets `C`, for all set `s ∈ C` and finite set of sets `I ⊆ C`,
 `disjointOfDiffUnion` is a finite set of sets in `C` such that
@@ -362,33 +288,41 @@ alias exists_disjoint_finset_diff_eq := exists_disjoint_finset_sdiff_eq
 singleton. -/
 noncomputable def disjointOfDiffUnion (hC : IsSetSemiring C) (hs : s ∈ C) (hI : ↑I ⊆ C) :
     Finset (Set α) :=
-  (hC.exists_disjoint_finset_sdiff_eq hs hI).choose \ {∅}
+  (hC.exists_finpartition_sdiff_sUnion hs hI).choose.parts
 
 lemma empty_notMem_disjointOfDiffUnion (hC : IsSetSemiring C) (hs : s ∈ C)
     (hI : ↑I ⊆ C) :
-    ∅ ∉ hC.disjointOfDiffUnion hs hI := by
-  simp only [disjointOfDiffUnion, Finset.mem_sdiff, Finset.mem_singleton,
-    not_true, and_false, not_false_iff]
+    ∅ ∉ hC.disjointOfDiffUnion hs hI :=
+  Finpartition.bot_notMem _
 
 lemma disjointOfDiffUnion_subset (hC : IsSetSemiring C) (hs : s ∈ C) (hI : ↑I ⊆ C) :
-    ↑(hC.disjointOfDiffUnion hs hI) ⊆ C := by
-  simp only [disjointOfDiffUnion, coe_sdiff, coe_singleton, sdiff_singleton_subset_iff]
-  exact (hC.exists_disjoint_finset_sdiff_eq hs hI).choose_spec.1.trans (Set.subset_insert _ _)
+    ↑(hC.disjointOfDiffUnion hs hI) ⊆ C :=
+  (hC.exists_finpartition_sdiff_sUnion hs hI).choose_spec
 
 lemma pairwiseDisjoint_disjointOfDiffUnion (hC : IsSetSemiring C) (hs : s ∈ C)
-    (hI : ↑I ⊆ C) : PairwiseDisjoint (hC.disjointOfDiffUnion hs hI : Set (Set α)) id := by
-  simp only [disjointOfDiffUnion, coe_sdiff, coe_singleton]
-  exact Set.PairwiseDisjoint.subset
-    (hC.exists_disjoint_finset_sdiff_eq hs hI).choose_spec.2.1 sdiff_subset
+    (hI : ↑I ⊆ C) : PairwiseDisjoint (hC.disjointOfDiffUnion hs hI : Set (Set α)) id :=
+  (Finpartition.supIndep _).pairwiseDisjoint
 
 lemma sdiff_sUnion_eq_sUnion_disjointOfDiffUnion (hC : IsSetSemiring C) (hs : s ∈ C)
-    (hI : ↑I ⊆ C) : s \ ⋃₀ I = ⋃₀ hC.disjointOfDiffUnion hs hI := by
-  rw [(hC.exists_disjoint_finset_sdiff_eq hs hI).choose_spec.2.2]
-  simp only [disjointOfDiffUnion, coe_sdiff, coe_singleton]
-  rw [sUnion_sdiff_singleton_empty]
+    (hI : ↑I ⊆ C) : s \ ⋃₀ I = ⋃₀ hC.disjointOfDiffUnion hs hI :=
+  (Finpartition.sup_parts _).symm.trans (sup_id_eq_sSup _)
 
 @[deprecated (since := "2026-06-03")]
 alias diff_sUnion_eq_sUnion_disjointOfDiffUnion := sdiff_sUnion_eq_sUnion_disjointOfDiffUnion
+
+/-- In a semiring of sets `C`, for all set `s ∈ C` and finite set of sets `I ⊆ C`, there is a
+finite set of sets in `C` whose union is `s \ ⋃₀ I`.
+See `IsSetSemiring.disjointOfDiffUnion` for a definition that gives such a set. -/
+lemma exists_disjoint_finset_sdiff_eq (hC : IsSetSemiring C) (hs : s ∈ C) (hI : ↑I ⊆ C) :
+    ∃ J : Finset (Set α), ↑J ⊆ C ∧ PairwiseDisjoint (J : Set (Set α)) id ∧
+      s \ ⋃₀ I = ⋃₀ J :=
+  ⟨hC.disjointOfDiffUnion hs hI,
+   hC.disjointOfDiffUnion_subset hs hI,
+   hC.pairwiseDisjoint_disjointOfDiffUnion hs hI,
+   hC.sdiff_sUnion_eq_sUnion_disjointOfDiffUnion hs hI⟩
+
+@[deprecated (since := "2026-06-03")]
+alias exists_disjoint_finset_diff_eq := exists_disjoint_finset_sdiff_eq
 
 lemma sUnion_disjointOfDiffUnion_subset (hC : IsSetSemiring C) (hs : s ∈ C)
     (hI : ↑I ⊆ C) : ⋃₀ (hC.disjointOfDiffUnion hs hI : Set (Set α)) ⊆ s := by
@@ -456,6 +390,77 @@ variable {j : Set α} {J : Finset (Set α)}
 
 open MeasureTheory Order
 
+private theorem exists_partition_disjointed (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (j : J) :
+    ∃ P : Finpartition (disjointed (fun i ↦ (J.equivFin.symm i : Set α)) (J.equivFin j)),
+      ↑P.parts ⊆ C :=
+  hC.mem_supClosure_iff.mp <|
+    hC.isSetRing_supClosure.disjointed_mem (fun _ ↦ subset_supClosure (hJ (Subtype.coe_prop _))) _
+
+/-- For some `hJ : J ⊆ C` and `j : Set α`, where `hC : IsSetSemiring C`, this is
+a `Finset (Set α)` such that `K j := hC.disjointOfUnion hJ` are disjoint
+and `⋃₀ K j ⊆ j`, for `j ∈ J`.
+Using these we write `⋃₀ J` as a disjoint union `⋃₀ J = ⋃₀ ⋃ x ∈ J, (K x)`.
+See `MeasureTheory.IsSetSemiring.disjointOfUnion_props`. -/
+noncomputable def disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (j : Set α) :
+    Finset (Set α) :=
+  if hj : j ∈ J then (hC.exists_partition_disjointed hJ ⟨j, hj⟩).choose.parts else ∅
+
+private theorem disjointOfUnion_coe (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (j : J) :
+    hC.disjointOfUnion hJ j = (hC.exists_partition_disjointed hJ j).choose.parts := by
+  rw [disjointOfUnion, dif_pos j.2]
+
+lemma pairwiseDisjoint_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
+    PairwiseDisjoint J (hC.disjointOfUnion hJ) := by
+  refine Pairwise.set_of_subtype _ _ fun j k hjk ↦ ?_
+  simp_rw [Function.onFun, hC.disjointOfUnion_coe hJ, Finset.disjoint_iff_ne]
+  exact fun s hs t ht ↦ Disjoint.ne (Finpartition.ne_bot _ hs) <|
+    .mono (Finpartition.le _ hs) (Finpartition.le _ ht) <|
+    disjoint_disjointed _ <| J.equivFin.injective.ne hjk
+
+lemma disjointOfUnion_subset (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
+    (disjointOfUnion hC hJ j : Set (Set α)) ⊆ C := by
+  lift j to J using hj
+  rw [hC.disjointOfUnion_coe hJ]
+  exact (hC.exists_partition_disjointed hJ j).choose_spec
+
+lemma pairwiseDisjoint_disjointOfUnion_of_mem (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
+    PairwiseDisjoint (hC.disjointOfUnion hJ j : Set (Set α)) id := by
+  lift j to J using hj
+  rw [disjointOfUnion_coe, ← supIndep_iff_pairwiseDisjoint]
+  exact Finpartition.supIndep _
+
+lemma pairwiseDisjoint_biUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
+    PairwiseDisjoint (⋃ x ∈ J, (hC.disjointOfUnion hJ x : Set (Set α))) id := by
+  simp_rw [← SetLike.mem_coe]
+  refine Set.PairwiseDisjoint.biUnion
+    (Pairwise.set_of_subtype _ _ ?_)
+    (fun _ ↦ hC.pairwiseDisjoint_disjointOfUnion_of_mem hJ)
+  simp_rw [Function.onFun, disjointOfUnion_coe, SetLike.mem_coe, ← Finset.sup_eq_iSup,
+    Finpartition.sup_parts]
+  exact (disjoint_disjointed _).comp_of_injective J.equivFin.injective
+
+lemma disjointOfUnion_subset_of_mem (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
+    ⋃₀ hC.disjointOfUnion hJ j ⊆ j := by
+  lift j to J using hj
+  grw [disjointOfUnion_coe, ← Finset.sup_id_set_eq_sUnion, Finpartition.sup_parts,
+    disjointed_subset, Equiv.symm_apply_apply]
+
+lemma subset_of_mem_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) {x : Set α}
+    (hx : x ∈ (hC.disjointOfUnion hJ) j) : x ⊆ j :=
+  sUnion_subset_iff.mp (hC.disjointOfUnion_subset_of_mem hJ hj) x hx
+
+lemma empty_notMem_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
+    ∅ ∉ hC.disjointOfUnion hJ j := by
+  lift j to J using hj
+  rw [disjointOfUnion_coe]
+  exact Finpartition.bot_notMem _
+
+lemma sUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
+    ⋃₀ ⋃ x ∈ J, (hC.disjointOfUnion hJ x : Set (Set α)) = ⋃₀ J := by
+  simp_rw [sUnion_iUnion, ← iSup_eq_iUnion, iSup_subtype', disjointOfUnion_coe,
+    ← Finset.sup_id_set_eq_sUnion, Finpartition.sup_parts, J.equivFin.surjective.iSup_comp,
+    iSup_disjointed, J.equivFin.symm.surjective.iSup_comp, iSup_subtype, Finset.sup_eq_iSup, id]
+
 theorem disjointOfUnion_props (hC : IsSetSemiring C) (h1 : ↑J ⊆ C) :
     ∃ K : Set α → Finset (Set α),
       PairwiseDisjoint J K
@@ -463,116 +468,14 @@ theorem disjointOfUnion_props (hC : IsSetSemiring C) (h1 : ↑J ⊆ C) :
       ∧ PairwiseDisjoint (⋃ x ∈ J, (K x : Set (Set α))) id
       ∧ (∀ j ∈ J, ⋃₀ K j ⊆ j)
       ∧ (∀ j ∈ J, ∅ ∉ K j)
-      ∧ ⋃₀ J = ⋃₀ (⋃ x ∈ J, (K x : Set (Set α))) := by
-  induction J using Finset.cons_induction with
-  | empty => simp
-  | cons s J hJ hind =>
-    rw [cons_eq_insert, coe_insert, Set.insert_subset_iff] at h1
-    obtain ⟨K, hK0, ⟨hK1, hK2, hK3, hK4, hK5⟩⟩ := hind h1.2
-    let K1 : Set α → Finset (Set α) := fun (t : Set α) ↦
-      if t = s then (hC.disjointOfDiffUnion h1.1 h1.2) else K t
-    have hK1s : K1 s = hC.disjointOfDiffUnion h1.1 h1.2 := by simp [K1]
-    have hK1_of_ne t (ht : t ≠ s) : K1 t = K t := by simp [K1, ht]
-    use K1
-    simp only [cons_eq_insert,
-      mem_coe, Finset.mem_insert, sUnion_subset_iff,
-      forall_eq_or_imp, coe_insert, sUnion_insert]
-    -- two simplification rules for induction hypothesis
-    have ht1' : ∀ x ∈ J, K1 x = K x := fun x hx ↦ hK1_of_ne _ (fun h_eq ↦ hJ (h_eq ▸ hx))
-    have ht2 : (⋃ x ∈ J, (K1 x : Set (Set α))) = ⋃ x ∈ J, ((K x : Set (Set α))) := by
-      apply iUnion₂_congr
-      intro x hx
-      exact_mod_cast hK1_of_ne _ (ne_of_mem_of_not_mem hx hJ)
-    simp only [hK1s]
-    refine ⟨?_, ⟨hC.disjointOfDiffUnion_subset h1.1 h1.2, ?_⟩, ?_,
-      ⟨hC.subset_of_mem_disjointOfDiffUnion h1.1 h1.2, ?_⟩, ?_, ?_⟩
-    · apply Set.Pairwise.insert
-      · intro j hj i hi hij
-        rw [Function.onFun, ht1' j hj, ht1' i hi]
-        exact hK0 hj hi hij
-      · intro i hi _
-        have h7 : Disjoint ↑(hC.disjointOfDiffUnion h1.1 h1.2) (K i : Set (Set α)) := by
-          refine disjoint_of_sSup_disjoint_of_le_of_le
-            (hC.subset_of_diffUnion_disjointOfDiffUnion h1.1 h1.2) ?_
-            (@disjoint_sdiff_left _ (⋃₀ J) s) (Or.inl
-              (hC.empty_notMem_disjointOfDiffUnion h1.1 h1.2))
-          apply sUnion_subset_iff.mp
-          exact (hK3 i hi).trans (subset_sUnion_of_mem hi)
-        have h8 : Function.onFun Disjoint K1 s i := by
-          refine Finset.disjoint_iff_inter_eq_empty.mpr ?_
-          rw [ht1' i hi, hK1s]
-          rw [Set.disjoint_iff_inter_eq_empty] at h7
-          exact_mod_cast h7
-        exact ⟨h8, Disjoint.symm h8⟩
-    · intro i hi
-      rw [ht1' i hi]
-      exact hK1 i hi
-    · simp only [iUnion_iUnion_eq_or_left]
-      refine pairwiseDisjoint_union.mpr ⟨?_, ?_, ?_⟩
-      · rw [hK1s]
-        exact hC.pairwiseDisjoint_disjointOfDiffUnion h1.1 h1.2
-      · simpa [ht2]
-      · simp only [mem_coe, mem_iUnion, exists_prop, ne_eq, id_eq, forall_exists_index, and_imp]
-        intro i hi j x hx h3 h4
-        obtain ki : i ⊆ s \ ⋃₀ J := hC.subset_of_diffUnion_disjointOfDiffUnion h1.1 h1.2 _
-          (hK1s ▸ hi)
-        obtain hx2 : j ⊆ x := subset_trans (subset_sUnion_of_mem (ht1' x hx ▸ h3)) (hK3 x hx)
-        obtain kj : j ⊆ ⋃₀ J := hx2.trans <| subset_sUnion_of_mem hx
-        exact disjoint_of_subset ki kj disjoint_sdiff_left
-    · intro a ha
-      simp_rw [hK1_of_ne _ (ne_of_mem_of_not_mem ha hJ)]
-      change ∀ t' ∈ (K a : Set (Set α)), t' ⊆ a
-      rw [← sUnion_subset_iff]
-      exact hK3 a ha
-    · refine ⟨hC.empty_notMem_disjointOfDiffUnion h1.1 h1.2, ?_⟩
-      intro a ha
-      rw [ht1' a ha]
-      exact hK4 a ha
-    · simp only [iUnion_iUnion_eq_or_left, sUnion_union, ht2, K1]
-      simp_rw [apply_ite, hK5,
-      ← hC.sdiff_sUnion_eq_sUnion_disjointOfDiffUnion h1.1 h1.2, hK5]
-      simp only [↓reduceIte, sdiff_union_self]
-
-/-- For some `hJ : J ⊆ C` and `j : Set α`, where `hC : IsSetSemiring C`, this is
-a `Finset (Set α)` such that `K j := hC.disjointOfUnion hJ` are disjoint
-and `⋃₀ K j ⊆ j`, for `j ∈ J`.
-Using these we write `⋃₀ J` as a disjoint union `⋃₀ J = ⋃₀ ⋃ x ∈ J, (K x)`.
-See `MeasureTheory.IsSetSemiring.disjointOfUnion_props`. -/
-noncomputable def disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (j : Set α) :=
-  (hC.disjointOfUnion_props hJ).choose j
-
-lemma pairwiseDisjoint_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
-    PairwiseDisjoint J (hC.disjointOfUnion hJ) :=
-  (Exists.choose_spec (hC.disjointOfUnion_props hJ)).1
-
-lemma disjointOfUnion_subset (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
-    (disjointOfUnion hC hJ j : Set (Set α)) ⊆ C :=
-  (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.1 _ hj
-
-lemma pairwiseDisjoint_biUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
-    PairwiseDisjoint (⋃ x ∈ J, (hC.disjointOfUnion hJ x : Set (Set α))) id :=
-  (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.2.1
-
-lemma pairwiseDisjoint_disjointOfUnion_of_mem (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
-    PairwiseDisjoint (hC.disjointOfUnion hJ j : Set (Set α)) id := by
-  apply PairwiseDisjoint.subset (hC.pairwiseDisjoint_biUnion_disjointOfUnion hJ)
-  exact subset_iUnion₂_of_subset j hj fun ⦃a⦄ a ↦ a
-
-lemma disjointOfUnion_subset_of_mem (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
-    ⋃₀ hC.disjointOfUnion hJ j ⊆ j :=
-  (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.2.2.1 j hj
-
-lemma subset_of_mem_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) {x : Set α}
-    (hx : x ∈ (hC.disjointOfUnion hJ) j) : x ⊆ j :=
-  sUnion_subset_iff.mp (hC.disjointOfUnion_subset_of_mem hJ hj) x hx
-
-lemma empty_notMem_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) (hj : j ∈ J) :
-    ∅ ∉ hC.disjointOfUnion hJ j :=
-  (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.2.2.2.1 j hj
-
-lemma sUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
-    ⋃₀ ⋃ x ∈ J, (hC.disjointOfUnion hJ x : Set (Set α)) = ⋃₀ J :=
-  (Exists.choose_spec (hC.disjointOfUnion_props hJ)).2.2.2.2.2.symm
+      ∧ ⋃₀ J = ⋃₀ (⋃ x ∈ J, (K x : Set (Set α))) :=
+  ⟨hC.disjointOfUnion h1,
+   hC.pairwiseDisjoint_disjointOfUnion h1,
+   fun _ ↦ hC.disjointOfUnion_subset h1,
+   hC.pairwiseDisjoint_biUnion_disjointOfUnion h1,
+   fun _ ↦ hC.disjointOfUnion_subset_of_mem h1,
+   fun _ ↦ hC.empty_notMem_disjointOfUnion h1,
+   (hC.sUnion_disjointOfUnion h1).symm⟩
 
 end disjointOfUnion
 


### PR DESCRIPTION
The constructions which are defined using choice are unexposed and redefined to allow for these simplifications.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The contents of `namespace IsSetRing` are moved near the top of the file without changes. To make reviewing easier, this move is in a separate commit.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
