### PR TITLE
feat(Linter/Header): make the broad imports check environment-aware

### DIFF
--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -301,29 +301,31 @@ public register_option linter.style.header : Bool := {
 
 namespace Style.header
 
-/-- Check the `Syntax` `imports` for broad imports:
-`Mathlib.Tactic`, any import starting with `Lake`, or `Mathlib.Tactic.{Have,Replace}`. -/
-def broadImportsCheck (imports : Array Syntax) (mainModule : Name) : CommandElabM Unit := do
-  for i in imports do
-    match i.getId with
+/-- Check the imported modules for broad imports:
+- `Lean`, `Std`, `Mathlib.Tactic` and any import starting with `Lake` are too broad.
+- `Mathlib.Tactic.{Have,Replace}` are not allowed in mathlib. -/
+def broadImportsCheck (ref : Syntax) (mainModule : Name) : CommandElabM Unit := do
+  -- Loop in reverse order, so that explicitly written imports are checked first.
+  (← getEnv).allImportedModuleNames.forRevM fun i ↦ do
+    match i with
     | `Mathlib.Tactic | `Lean | `Lean.Elab | `Std =>
-      Linter.logLint linter.style.header i
-        s!"Files in mathlib cannot import the whole `{i.getId}` folder. \
+      Linter.logLint linter.style.header ref
+        s!"Files in mathlib cannot import the whole `{i}` folder. \
         Doing so would cause imports to be unnecessarily slow."
     | `Mathlib.Tactic.Replace =>
       if mainModule != `Mathlib.Tactic then
-        Linter.logLint linter.style.header i
-          "'Mathlib.Tactic.Replace' defines a deprecated form of the 'replace' tactic; \
+        Linter.logLint linter.style.header ref
+          "`Mathlib.Tactic.Replace` defines a deprecated form of the 'replace' tactic; \
           please do not use it in mathlib."
     | `Mathlib.Tactic.Have =>
       if ![`Mathlib.Tactic, `Mathlib.Tactic.Replace].contains mainModule then
-        Linter.logLint linter.style.header i
-          "'Mathlib.Tactic.Have' defines a deprecated form of the 'have' tactic; \
+        Linter.logLint linter.style.header ref
+          "`Mathlib.Tactic.Have` defines a deprecated form of the 'have' tactic; \
           please do not use it in mathlib."
     | modName =>
       if modName.getRoot == `Lake then
-      Linter.logLint linter.style.header i
-        "In the past, importing 'Lake' in mathlib has led to dramatic slow-downs of the linter \
+      Linter.logLint linter.style.header ref
+        "In the past, importing `Lake` in mathlib has led to dramatic slow-downs of the linter \
         (see e.g. https://github.com/leanprover-community/mathlib4/pull/13779). Please consider carefully if this import is useful and \
         make sure to benchmark it. If this is fine, feel free to silence this linter."
 
@@ -422,7 +424,7 @@ def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
   -- directory dependency, etc.) since they are just import-redirect stubs.
   if let some (.node _ ``Lean.Parser.Command.deprecated_module _) := afterImports then return
   -- Report on broad or duplicate imports.
-  broadImportsCheck importIds mainModule
+  broadImportsCheck upToStx mainModule
   duplicateImportsCheck imports
   let errors ← directoryDependencyCheck mainModule
   if errors.size > 0 then


### PR DESCRIPTION
This PR makes the broad import linter also look at transitively imported modules.

A slight disadvantage is that the warning is now shown on all imports instead of just the offending one.

I have recently reduced imports in Qq, Aesop, Plausible and ProofWidgets, because they contained broad imports. All of these issues would have been caught by this improved linter.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
