### PR TITLE
[Merged by Bors] - fix: revert #40181

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -804,22 +804,7 @@ jobs:
         run: |
           lake env lean scripts/create_deprecated_modules.lean
           lake env lean scripts/autolabel.lean
-          lake exe check_title_labels --labels "t-algebra" "feat: dummy PR for testing" "dummy PR body" > title_output.txt
-          if grep -qE "Missing positional argument " "title_output.txt"; then
-              echo ""
-              echo "=============================================================================="
-              echo "ERROR: Your branch predates the current 'check title' configuration."
-              echo "Please merge 'master' into your PR branch and push again."
-              echo ""
-              echo "You can do this with:"
-              echo "  git fetch upstream"
-              echo "  git merge upstream/master"
-              echo "  git push"
-              echo "=============================================================================="
-              echo ""
-              exit 1
-          fi
-          cat title_output.txt
+          lake exe check_title_labels --labels "t-algebra" "feat: dummy PR for testing"
 
       - name: build everything
         # make sure everything is available for test/import_all.lean

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -34,7 +34,6 @@ jobs:
         if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'master'
         env:
           TITLE: ${{ github.event.pull_request.title }}
-          BODY: ${{ github.event.pull_request.body }}
           PR_LABELS: ${{ toJson(github.event.pull_request.labels) }}
         run: |
           set -o pipefail
@@ -54,7 +53,7 @@ jobs:
 
           set +e
           # Capture output and exit code
-          output=$(lake exe check_title_labels --labels "$label_names" "$TITLE" "$BODY" 2>&1)
+          output=$(lake exe check_title_labels --labels "$label_names" "$TITLE" 2>&1)
           exit_code=$?
           set -e
 

--- a/Mathlib/Tactic/Linter/ValidatePRTitle.lean
+++ b/Mathlib/Tactic/Linter/ValidatePRTitle.lean
@@ -11,13 +11,10 @@ import Mathlib.Tactic.Linter.TextBased.UnicodeLinter
 
 /-!
 # Checker for well-formed title and labels
-
 This script checks if a PR title matches
 [mathlib's commit conventions](https://leanprover-community.github.io/contribute/commit.html).
 Not all checks from the commit conventions are implemented: for instance, no effort is made to
 verify whether the title or body are written in present imperative tense.
-
-It also verifies if the PR description matches some basic sanity checks for good descriptions.
 -/
 
 open Std.Internal.Parsec String
@@ -139,48 +136,3 @@ public def validateTitle (title : String) : Array String := Id.run do
       errors := errors.push s!"error: the PR contains {badChars.length} Unicode characters \
         which are not allowed: {err}"
     return errors
-
-/-- Check if `description` matches some basic checks for good PR descriptions
-(a subset of the ones at <https://leanprover-community.github.io/contribute/commit.html>,
-plus a few basic sanity checks).
-
-`isLabelledEasy` denotes whether a PR is labelled as easy: if so, an empty description is allowed.
-
-Return all error messages for violations found.
--/
-public def validatePRBody (description : String) (isLabelledEasy : Bool) : Array String := Id.run do
-  if description.trimAscii.isEmpty && !isLabelledEasy then
-    return #["error: the PR description is empty"]
-
-  -- Find all lines in the PR description before a "fold". bors truncates the squash
-  -- commit message at the first line starting with "---" (its `cut_body_after = "\n---"`),
-  -- so that is exactly what we treat as a fold here.
-  let before := description.lines.toList.takeWhile (fun l ↦ !l.startsWith "---")
-  -- If `after` is non-empty, there is a fold.
-  let after := description.lines.toList.drop before.length
-  let mut errors := #[]
-  if let some l := before.getLast? then
-    if !after.isEmpty && l != "" then
-      errors := errors.push
-        "error: there should be a blank line between the PR description and the fold"
-  if before.any (· == "## Summary") then
-    errors := errors.push "error: do not include a 'summary' header in the PR body"
-  if before.any (· == "## Testing plan") then
-    errors := errors.push "error: usually, a section 'Testing plan' is superfluous \
-      (particularly if it only mentions checks done in CI anyway)\n\
-      If you have done particular testing, please mention this --- but no need for the header."
-  -- Should this error on any headings in the PR description?
-
-  -- Just whitespace, or a period before the fold also count as empty descriptions.
-  let beforeContainsText := before.any (·.any (·.isAlpha))
-  if !beforeContainsText then
-    -- We drop the leading "---" line.
-    let afterContainsText := after.drop 1 |>.any (·.any (·.isAlpha))
-    if afterContainsText then
-      errors := errors.push
-        "warning: your PR description is non-empty, but everything is after the '---' line\n\
-        note: the final PR commit message only uses what is above that line"
-    else
-      errors := errors.push "error: the PR description is empty"
-
-  return errors

--- a/MathlibTest/ValidatePRTitle.lean
+++ b/MathlibTest/ValidatePRTitle.lean
@@ -1,8 +1,6 @@
 import Mathlib.Tactic.Linter.ValidatePRTitle
 
-/-! Tests for the PR title validation logic. -/
-section title
-
+-- Tests for the PR title validation logic.
 open Lean in
 /--
 `#check_title title` takes as input the `String` `title`, expected to be a mathlib PR title.
@@ -188,82 +186,3 @@ info: Message: 'error: the PR title contains multiple consecutive spaces; please
 -/
 #guard_msgs in
 #check_title "feat(Mathlib/Algebra.lean):  title."
-
-end title
-
--- Tests for the PR description validation logic.
-section description
-
-open Lean in
-/--
-`#check_description desc` takes as input the `String` `desc`, expected to be a mathlib PR body.
-It logs details of what the linter would report if the description is "malformed".
--/
-elab "#check_description " desc:str : command => do
-  let title := desc.getString
-  for err in validatePRBody title false do
-    logInfo m!"Message: '{err}'"
-
-/-- info: Message: 'error: the PR description is empty' -/
-#guard_msgs in
-#check_description ""
-
-/-- info: Message: 'error: the PR description is empty' -/
-#guard_msgs in
-#check_description "    " -- whitespace only PR bodies should also get linted
-
--- This description is virtually empty: just whitespace.
-/-- info: Message: 'error: the PR description is empty' -/
-#guard_msgs in
-#check_description "\n\n---"
-
-/-- info: Message: 'error: the PR description is empty' -/
-#guard_msgs in
-#check_description ".\n\n---"
-
-/-- info: Message: 'error: there should be a blank line between the PR description and the fold' -/
-#guard_msgs in
-#check_description "A word\n----\n"
-
-/-- info: Message: 'error: there should be a blank line between the PR description and the fold' -/
-#guard_msgs in
-#check_description "A word\n----\nSome content\nAnother fold\n"
-
--- Regression test against confusing errors with just a fold.
-/-- info: Message: 'error: the PR description is empty' -/
-#guard_msgs in
-#check_description "---"
-
-/--
-info: Message: 'warning: your PR description is non-empty, but everything is after the '---' line
-note: the final PR commit message only uses what is above that line'
--/
-#guard_msgs in
-#check_description "----\nA helpful description after the fold\n"
-
-/-- info: Message: 'error: do not include a 'summary' header in the PR body' -/
-#guard_msgs in
-#check_description "## Summary\nSome other content\n"
-
-/--
-info: Message: 'error: usually, a section 'Testing plan' is superfluous (particularly if it only mentions checks done in CI anyway)
-If you have done particular testing, please mention this --- but no need for the header.'
--/
-#guard_msgs in
-#check_description "Some actual PR body containing useful content.\n## Testing plan\nLake build passes\n"
-
-/--
-info: Message: 'error: do not include a 'summary' header in the PR body'
----
-info: Message: 'error: usually, a section 'Testing plan' is superfluous (particularly if it only mentions checks done in CI anyway)
-If you have done particular testing, please mention this --- but no need for the header.'
--/
-#guard_msgs in
-#check_description "Some actual PR body containing useful content.\n## Testing plan\n## Summary\nLake build passes\n"
-
--- Tests for false positives around a bug in recognising the "fold".
-#guard_msgs in #check_description "First paragraph.\n\nSecond paragraph.\n"
-
-#guard_msgs in #check_description "My description.\n\n---\n\nMeta info after the fold.\n"
-
-end description

--- a/scripts/check_title_labels.lean
+++ b/scripts/check_title_labels.lean
@@ -21,10 +21,10 @@ open Cli in
 The exit code is the number of violations found. -/
 def checkTitleLabelsCLI (args : Parsed) : IO UInt32 := do
   let title := (args.positionalArg! "title").value
-  let body := (args.positionalArg! "body").value
   let labels : List String := match args.flag? "labels" with
   | some f => (f.as! String).splitOn "\n"
   | none => []
+  IO.println s!"labels are {labels}"
   -- We do not validate titles of WIP PRs.
   if labels.contains "WIP" then return 0
 
@@ -33,11 +33,6 @@ def checkTitleLabelsCLI (args : Parsed) : IO UInt32 := do
   let titleErrors : Array String := validateTitle title
   numberErrors := UInt32.ofNat titleErrors.size
   for err in titleErrors do
-    IO.println err
-  -- Enforce some properties of the PR description.
-  let descriptionErrors : Array String := validatePRBody body (labels.contains "easy")
-  numberErrors := numberErrors + UInt32.ofNat descriptionErrors.size
-  for err in descriptionErrors do
     IO.println err
   return min numberErrors 125
 
@@ -50,18 +45,16 @@ def checkTitleLabels : Cmd := `[Cli|
   If this PR is a feature PR, also verify that it has a topic label,
   and that there are no contradictory labels.
 
-  If the input title does not pass validation, output a list of errors."
+  If the inpupt title does not pass validation, output a list of errors."
 
   FLAGS:
     "labels" : String; "newline-separated list of label names of this PR\
-      These are optional; we use a WIP label to skip all checks, and an `easy` label \
-      to skip some PR description checks"
+      These are optional; we merely use a WIP label to skip any checks of the PR title"
 
   ARGS:
     title : String; "this PR's title"
-    body : String; "this PR's body"
 
 ]
 
-/-- The entrypoint to the `lake exe check_title_labels` command. -/
+/-- The entrypoint to the `lake exe check-title-labels` command. -/
 def main (args : List String) : IO UInt32 := checkTitleLabels.validate args


### PR DESCRIPTION
This revert #40181: right now, any PR with empty description breaks the "check PR title" workflow.
Let's revert the change while we investigate.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
