### PR TITLE
[testing] Verify multi-container fork-PR cache upload (do not merge)

### DIFF
--- a/Mathlib/Algebra/BigOperators/ModEq.lean
+++ b/Mathlib/Algebra/BigOperators/ModEq.lean
@@ -18,6 +18,8 @@ and similarly for sums.
 We prove it for lists, multisets, and finsets, as well as for natural and integer numbers.
 -/
 
+-- CI: verifying multi-container fork-PR cache upload (#40035 follow-up); safe to revert.
+
 public section
 
 namespace Nat


### PR DESCRIPTION
**Do not merge — verification PR; will be closed after testing.**

Exercises the fork-PR path of the new multi-container cache (#40035) end-to-end, from an actual fork (`marcelolynch/mathlib4`).

The change is a single comment in a **leaf** module (`Mathlib/Algebra/BigOperators/ModEq.lean`, imported by nothing), so exactly one `.olean` rebuilds — minimal CI cost — while still producing a fresh artifact to upload.

### What this verifies
- `pull_request_target` runs master's `build_template` and master's cache binary (not fork code).
- Build reads `[master, forks, legacy]` — bulk served from `master`.
- The rebuilt olean uploads to the **`forks`** container, SHA-scoped (`/f/marcelolynch/mathlib4/<sha>/…`), `PRIMARY=forks`.
- No write to `master`/`nightly` (the OIDC token is RBAC-scoped to `forks`).
- `post_steps` verification finds the just-uploaded fork artifact.
- (Optional follow-up) push a 2nd commit → reads via HEAD-scope default, uploads under the new SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
