### PR TITLE
[Merged by Bors] - chore(Analysis/SumIntegralComparisons): golf proofs

### DIFF
--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -53,20 +53,16 @@ lemma sum_Ico_le_integral_of_le (hab : a ≤ b)
     (hg : IntegrableOn g (Ico a b)) : ∑ i ∈ .Ico a b, f i ≤ ∫ x in a..b, g x := by
   have A i (hi : i ∈ Finset.Ico a b) : IntervalIntegrable g volume i ↑(i + 1) := by
     rw [intervalIntegrable_iff_integrableOn_Ico_of_le (by simp)]
-    apply hg.mono _ le_rfl
-    rintro x ⟨hx, h'x⟩
-    simp only [Finset.mem_Ico, mem_Ico] at hi ⊢
-    exact ⟨le_trans (mod_cast hi.1) hx, h'x.trans_le (mod_cast hi.2)⟩
+    simp only [Finset.mem_Ico, ← Nat.add_one_le_iff] at hi
+    rify at hi
+    exact hg.mono (by grind) le_rfl
   calc
-  ∑ i ∈ .Ico a b, f i
   _ = ∑ i ∈ .Ico a b, (∫ x in (i : ℝ)..↑(i + 1), f i) := by simp
   _ ≤ ∑ i ∈ .Ico a b, (∫ x in (i : ℝ)..↑(i + 1), g x) := by
     gcongr with i hi
     apply integral_mono_on_of_le_Ioo (by simp) (by simp) (A _ hi) (fun x hx ↦ ?_)
     exact h _ (by simpa using hi) _ (Ioo_subset_Ico_self hx)
-  _ = ∫ x in a..b, g x := by
-    rw [sum_integral_adjacent_intervals_Ico (a := (↑·)) hab]
-    grind
+  _ = _ := by rw [sum_integral_adjacent_intervals_Ico (a := (↑·)) hab]; grind
 
 lemma integral_le_sum_Ico_of_le (hab : a ≤ b)
     (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) ↑(i + 1), g x ≤ f i)
@@ -74,23 +70,24 @@ lemma integral_le_sum_Ico_of_le (hab : a ≤ b)
   convert! neg_le_neg (sum_Ico_le_integral_of_le (f := -f) (g := -g) hab
     (fun i hi x hx ↦ neg_le_neg (h i hi x hx)) hg.neg) <;> simp
 
+private theorem AntitoneOn.intervalIntegrable_subset (hf : AntitoneOn f (Icc x₀ (x₀ + a)))
+    (k : ℕ) (hk : k + 1 ≤ a) : IntervalIntegrable f volume (x₀ + k) (x₀ + ↑(k + 1)) := by
+  refine (hf.mono ?_).intervalIntegrable
+  rw [uIcc_of_le (by simp)]
+  apply Icc_subset_Icc <;> simp [-Nat.cast_add, hk]
+
 theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
-    ∫ x in x₀..x₀ + a, f x ≤ ∑ i ∈ .range a, f (x₀ + i) := by
-  have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + ↑(k + 1)) := by
-    refine fun k hk ↦ (hf.mono ?_).intervalIntegrable
-    rw [uIcc_of_le (by simp)]
-    apply Icc_subset_Icc <;> simp [-Nat.cast_add, hk]
-  calc
-    ∫ x in x₀..x₀ + a, f x = ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + ↑(i + 1), f x := by
-      convert! (sum_integral_adjacent_intervals hint).symm
-      simp
-    _ ≤ ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + ↑(i + 1), f (x₀ + i) := by
-      gcongr with i hi
-      simp only [Finset.mem_range] at hi
-      refine integral_mono_on (by simp) (hint _ hi) (by simp) fun x hx ↦ ?_
-      apply hf (by simp [hi.le]) _ hx.1
-      exact mem_Icc.2 ⟨le_trans (by simp) hx.1, le_trans hx.2 (by simp [-Nat.cast_add, hi])⟩
-    _ = ∑ i ∈ .range a, f (x₀ + i) := by simp
+    ∫ x in x₀..x₀ + a, f x ≤ ∑ i ∈ .range a, f (x₀ + i) := calc
+  _ = ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + ↑(i + 1), f x := by
+    convert! (sum_integral_adjacent_intervals hf.intervalIntegrable_subset).symm
+    simp
+  _ ≤ ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + ↑(i + 1), f (x₀ + i) := by
+    gcongr with i hi
+    rw [Finset.mem_range, ← Nat.add_one_le_iff] at hi
+    have := hf.intervalIntegrable_subset _ hi
+    rify at hi this ⊢
+    refine integral_mono_on (by simp) this (by simp) fun _ _ ↦ by apply hf <;> grind
+  _ = _ := by simp
 
 theorem AntitoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.Icc a b)) :
     ∫ x in a..b, f x ≤ ∑ x ∈ .Ico a b, f x := by
@@ -100,24 +97,17 @@ theorem AntitoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.I
   exact AntitoneOn.integral_le_sum (by simp only [hf, hab, Nat.cast_sub, add_sub_cancel])
 
 theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
-    ∑ i ∈ .range a, f (x₀ + ↑(i + 1)) ≤ ∫ x in x₀..x₀ + a, f x := by
-  have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + (k + 1 : ℕ)) := by
-    refine fun k hk ↦ (hf.mono ?_).intervalIntegrable
-    rw [uIcc_of_le (by simp [-Nat.cast_add])]
-    apply Icc_subset_Icc <;> simp [-Nat.cast_add, hk]
-  calc
-    (∑ i ∈ .range a, f (x₀ + ↑(i + 1)))
-      = ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + ↑(i + 1), f (x₀ + ↑(i + 1)) := by simp
-    _ ≤ ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + ↑(i + 1), f x := by
-      gcongr with i hi
-      simp only [Finset.mem_range] at hi
-      refine integral_mono_on (by simp) (by simp) (hint _ hi) fun x hx ↦
-        hf (mem_Icc.2 ?_) (mem_Icc.2 ?_) hx.2
-      · exact ⟨by grind, le_trans hx.2 (by simp [-Nat.cast_add, hi])⟩
-      · exact ⟨by grind, by simp [-Nat.cast_add, hi]⟩
-    _ = ∫ x in x₀..x₀ + a, f x := by
-      convert! sum_integral_adjacent_intervals hint
-      simp [-Nat.cast_add]
+    ∑ i ∈ .range a, f (x₀ + ↑(i + 1)) ≤ ∫ x in x₀..x₀ + a, f x := calc
+  _ = ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + ↑(i + 1), f (x₀ + ↑(i + 1)) := by simp
+  _ ≤ ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + ↑(i + 1), f x := by
+    gcongr with i hi
+    rw [Finset.mem_range, ← Nat.add_one_le_iff] at hi
+    have := hf.intervalIntegrable_subset _ hi
+    rify at hi this ⊢
+    exact integral_mono_on (by simp) (by simp) this fun _ _ ↦ by apply hf <;> grind
+  _ = _ := by
+    convert! sum_integral_adjacent_intervals hf.intervalIntegrable_subset
+    simp [-Nat.cast_add]
 
 theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Icc a b)) :
     ∑ i ∈ .Ico a b, f ↑(i + 1) ≤ ∫ x in a..b, f x := by
@@ -152,8 +142,7 @@ lemma sum_mul_Ico_le_integral_of_monotone_antitone
     ∑ i ∈ .Ico a b, f i * g i ≤ ∫ x in a..b, f x * g (x - 1) := by
   apply sum_Ico_le_integral_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
-    simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have : ↑i ∈ Icc (a : ℝ) (b - 1) := by simp only [mem_Icc]; norm_cast; lia
+    simp only [Nat.cast_add, Nat.cast_one, mem_Ico, ← Nat.add_one_le_iff] at hx hi
     rify at hi
     gcongr
     · grw [gpos]; apply hg <;> grind
@@ -172,8 +161,7 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
     ∫ x in a..b, f x * g (x - 1) ≤ ∑ i ∈ .Ico a b, f i * g i := by
   apply integral_le_sum_Ico_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
-    simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have : ↑i ∈ Icc (a : ℝ) (b - 1) := by simp only [mem_Icc, le_sub_iff_add_le]; norm_cast
+    simp only [Nat.cast_add, Nat.cast_one, mem_Ico, ← Nat.add_one_le_iff] at hx hi
     rify at hi
     gcongr
     · grw [gpos]; apply hg <;> grind

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -237,8 +237,7 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
     have I2 : x ∈ Icc (a : ℝ) b := mem_Icc.mpr ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
     gcongr
     · exact gpos.trans <| hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1)
-    · exact fpos.trans (hf ⟨mod_cast hi.1, mod_cast hi.2.le⟩ (by simpa using hab)
-        (mod_cast hi.2.le))
+    · exact fpos.trans <| by apply hf <;> { simp; grind }
     · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
     · apply hg _ I1 (by simpa [sub_le_iff_le_add] using hx.2.le)
       simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -246,11 +246,7 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
       simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
       exact ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
   · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
-    apply Integrable.mul_of_top_left
-    · exact hf.integrableOn_isCompact isCompact_Icc
-    · apply MonotoneOn.memLp_isCompact isCompact_Icc
-      intro x hx y hy hxy
-      apply hg
-      · simpa using hx
-      · simpa using hy
-      · simpa using hxy
+    apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
+    apply MonotoneOn.memLp_isCompact isCompact_Icc
+    intros x hx y hy hxy
+    apply hg <;> grind

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -1,8 +1,7 @@
 /-
 Copyright (c) 2022 Kevin H. Wilson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kevin H. Wilson, Alastair Irving, Terence Tao
--/
+Authors: Kevin H. Wilson
 module
 
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -236,7 +236,7 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
       exact ⟨by norm_cast; lia, I0⟩
     have I2 : x ∈ Icc (a : ℝ) b := mem_Icc.mpr ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
     gcongr
-    · exact gpos.trans (hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1))
+    · exact gpos.trans <| hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1)
     · exact fpos.trans (hf ⟨mod_cast hi.1, mod_cast hi.2.le⟩ (by simpa using hab)
         (mod_cast hi.2.le))
     · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -36,11 +36,6 @@ At the moment it contains several lemmas in this direction, for antitone or mono
   by the integral of `f x * g (x - 1)` if `f` is monotone and `g` is antitone.
 * `integral_le_sum_mul_Ico_of_antitone_monotone`: the sum of `f i * g i` on an interval is bounded
   below by the integral of `f x * g (x - 1)` if `f` is antitone and `g` is monotone.
-* `AntitoneOn.summable_of_integrable`: a nonnegative antitone function that is integrable on
-  `(0, ∞)` is summable over `ℕ`.
-* `AntitoneOn.sum_range_le_integral`, `AntitoneOn.tsum_add_one_le_integral`,
-  `AntitoneOn.tsum_le_integral`: bounds on (partial) sums of a nonnegative antitone function by its
-  integral over `(0, ∞)`.
 
 ## Tags
 

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -58,14 +58,14 @@ lemma sum_Ico_le_integral_of_le (hab : a ≤ b)
     simp only [Finset.mem_Ico, mem_Ico] at hi ⊢
     exact ⟨le_trans (mod_cast hi.1) hx, h'x.trans_le (mod_cast hi.2)⟩
   calc
-  ∑ i ∈ Finset.Ico a b, f i
-  _ = ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..↑(i + 1), f i) := by simp
-  _ ≤ ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..↑(i + 1), g x) := by
+  ∑ i ∈ .Ico a b, f i
+  _ = ∑ i ∈ .Ico a b, (∫ x in (i : ℝ)..↑(i + 1), f i) := by simp
+  _ ≤ ∑ i ∈ .Ico a b, (∫ x in (i : ℝ)..↑(i + 1), g x) := by
     gcongr with i hi
     apply integral_mono_on_of_le_Ioo (by simp) (by simp) (A _ hi) (fun x hx ↦ ?_)
     exact h _ (by simpa using hi) _ (Ioo_subset_Ico_self hx)
   _ = ∫ x in a..b, g x := by
-    rw [sum_integral_adjacent_intervals_Ico (a := fun i ↦ i) hab]
+    rw [sum_integral_adjacent_intervals_Ico (a := (↑·)) hab]
     grind
 
 lemma integral_le_sum_Ico_of_le (hab : a ≤ b)
@@ -77,27 +77,20 @@ lemma integral_le_sum_Ico_of_le (hab : a ≤ b)
 
 theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
     (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ .range a, f (x₀ + i) := by
-  have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + (k + 1 : ℕ)) := by
-    intro k hk
-    refine (hf.mono ?_).intervalIntegrable
-    rw [uIcc_of_le]
-    · apply Icc_subset_Icc
-      · simp
-      · simp [-Nat.cast_add, hk]
-    · simp
+  have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + ↑(k + 1)) := by
+    refine fun k hk ↦ (hf.mono ?_).intervalIntegrable
+    rw [uIcc_of_le (by simp)]
+    apply Icc_subset_Icc <;> simp [-Nat.cast_add, hk]
   calc
-    ∫ x in x₀..x₀ + a, f x = ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
+    ∫ x in x₀..x₀ + a, f x = ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + ↑(i + 1), f x := by
       convert! (sum_integral_adjacent_intervals hint).symm
-      simp only [Nat.cast_zero, add_zero]
-    _ ≤ ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + i) := by
+      simp
+    _ ≤ ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + ↑(i + 1), f (x₀ + i) := by
       gcongr with i hi
-      have ia : i < a := Finset.mem_range.1 hi
-      refine intervalIntegral.integral_mono_on (by simp) (hint _ ia) (by simp) fun x hx => ?_
-      apply hf _ _ hx.1
-      · simp only [ia.le, mem_Icc, le_add_iff_nonneg_right, Nat.cast_nonneg, add_le_add_iff_left,
-          Nat.cast_le, and_self_iff]
-      · refine mem_Icc.2 ⟨le_trans (by simp) hx.1, le_trans hx.2 ?_⟩
-        simp only [add_le_add_iff_left, Nat.cast_le, Nat.succ_le_of_lt ia]
+      simp only [Finset.mem_range] at hi
+      refine integral_mono_on (by simp) (hint _ hi) (by simp) fun x hx ↦ ?_
+      apply hf (by simp [hi.le]) _ hx.1
+      exact mem_Icc.2 ⟨le_trans (by simp) hx.1, le_trans hx.2 (by simp [-Nat.cast_add, hi])⟩
     _ = ∑ i ∈ .range a, f (x₀ + i) := by simp
 
 theorem AntitoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.Icc a b)) :
@@ -105,28 +98,27 @@ theorem AntitoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.I
   suffices ∫ x in a..a + ↑(b - a), f x ≤ ∑ x ∈ .Ico (0 + a) (b - a + a), f x by simp_all
   rw [← Finset.sum_Ico_add, Nat.Ico_zero_eq_range]
   suffices ∫ x in a..a + ↑(b - a), f x ≤ ∑ x ∈ .range (b - a), f (a + x) by simp_all
-  apply AntitoneOn.integral_le_sum
-  simp only [hf, hab, Nat.cast_sub, add_sub_cancel]
+  exact AntitoneOn.integral_le_sum (by simp only [hf, hab, Nat.cast_sub, add_sub_cancel])
 
 theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
-    (∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ))) ≤ ∫ x in x₀..x₀ + a, f x := by
+    (∑ i ∈ .range a, f (x₀ + ↑(i + 1))) ≤ ∫ x in x₀..x₀ + a, f x := by
   have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + (k + 1 : ℕ)) := by
     refine fun k hk ↦ (hf.mono ?_).intervalIntegrable
     rw [uIcc_of_le (by simp [-Nat.cast_add])]
     apply Icc_subset_Icc <;> simp [-Nat.cast_add, hk]
   calc
-    (∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ))) =
-        ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + (i + 1 : ℕ)) := by simp
-    _ ≤ ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
-      apply Finset.sum_le_sum fun i hi => ?_
-      have ia : i + 1 ≤ a := Finset.mem_range.1 hi
-      refine integral_mono_on (by simp) (by simp) (hint _ ia) fun x hx ↦ ?_
-      apply hf (mem_Icc.2 _) (mem_Icc.2 _) hx.2
-      · exact ⟨by grind, le_trans hx.2 (by simp [-Nat.cast_add, ia])⟩
-      · exact ⟨by grind, by simp [-Nat.cast_add, ia]⟩
+    (∑ i ∈ .range a, f (x₀ + ↑(i + 1))) =
+        ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + ↑(i + 1), f (x₀ + ↑(i + 1)) := by simp
+    _ ≤ ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + ↑(i + 1), f x := by
+      gcongr with i hi
+      simp only [Finset.mem_range] at hi
+      refine integral_mono_on (by simp) (by simp) (hint _ hi) fun x hx ↦
+        hf (mem_Icc.2 ?_) (mem_Icc.2 ?_) hx.2
+      · exact ⟨by grind, le_trans hx.2 (by simp [-Nat.cast_add, hi])⟩
+      · exact ⟨by grind, by simp [-Nat.cast_add, hi]⟩
     _ = ∫ x in x₀..x₀ + a, f x := by
       convert! sum_integral_adjacent_intervals hint
-      simp only [Nat.cast_zero, add_zero]
+      simp [-Nat.cast_add]
 
 theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Icc a b)) :
     (∑ i ∈ .Ico a b, f (i + 1 : ℕ)) ≤ ∫ x in a..b, f x := by
@@ -134,8 +126,7 @@ theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Icc a
   rw [← Finset.sum_Ico_add, Nat.Ico_zero_eq_range]
   suffices ∑ x ∈ .range (b - a), f (a + ↑(x + 1)) ≤ ∫ x in a..a + ↑(b - a), f x by
     simp_all [add_assoc]
-  apply AntitoneOn.sum_le_integral
-  simp only [hf, hab, Nat.cast_sub, add_sub_cancel]
+  exact AntitoneOn.sum_le_integral (by simp [hf, hab])
 
 theorem MonotoneOn.sum_le_integral (hf : MonotoneOn f (Icc x₀ (x₀ + a))) :
     (∑ i ∈ .range a, f (x₀ + i)) ≤ ∫ x in x₀..x₀ + a, f x := by
@@ -148,12 +139,12 @@ theorem MonotoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : MonotoneOn f (Set.I
   exact hf.neg.integral_le_sum_Ico hab
 
 theorem MonotoneOn.integral_le_sum (hf : MonotoneOn f (Icc x₀ (x₀ + a))) :
-    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ)) := by
+    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ .range a, f (x₀ + ↑(i + 1)) := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.sum_le_integral
 
 theorem MonotoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : MonotoneOn f (Set.Icc a b)) :
-    (∫ x in a..b, f x) ≤ ∑ i ∈ .Ico a b, f (i + 1 : ℕ) := by
+    (∫ x in a..b, f x) ≤ ∑ i ∈ .Ico a b, f ↑(i + 1) := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.sum_le_integral_Ico hab
 
@@ -164,20 +155,18 @@ lemma sum_mul_Ico_le_integral_of_monotone_antitone
   apply sum_Ico_le_integral_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
     simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have I0 : (i : ℝ) ≤ b - 1 := by norm_cast; lia
-    have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
-      simp only [mem_Icc, tsub_le_iff_right]
-      exact ⟨by norm_cast; lia, I0⟩
+    have I1 : ↑i ∈ Icc (a - 1 : ℝ) (b - 1) := by
+      simp only [mem_Icc, tsub_le_iff_right]; norm_cast; lia
     have I2 : x ∈ Icc (a : ℝ) b := mem_Icc.mpr ⟨le_trans (mod_cast hi.1) hx.1, by grind⟩
     gcongr
     · grw [gpos]; apply hg <;> grind
     · grw [fpos]; apply hf <;> grind
     · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
     · apply hg <;> grind
-  · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
-    apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
-    apply AntitoneOn.memLp_isCompact isCompact_Icc
-    intro x hx y hy hxy
+  · apply ((hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
+      (AntitoneOn.memLp_isCompact isCompact_Icc _)).mono_measure
+      (volume.restrict_mono_set Ico_subset_Icc_self)
+    intro _ _ _ _ _
     apply hg <;> grind
 
 lemma integral_le_sum_mul_Ico_of_antitone_monotone
@@ -187,18 +176,16 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
   apply integral_le_sum_Ico_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
     simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have I0 : (i : ℝ) ≤ b - 1 := by simp only [le_sub_iff_add_le]; norm_cast; lia
-    have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
-      simp only [mem_Icc, tsub_le_iff_right]
-      exact ⟨by norm_cast; lia, I0⟩
+    have I1 : ↑i ∈ Icc (a - 1 : ℝ) (b - 1) := by
+      simp only [mem_Icc, tsub_le_iff_right, le_sub_iff_add_le]; norm_cast; lia
     have I2 : x ∈ Icc (a : ℝ) b := mem_Icc.mpr ⟨le_trans (mod_cast hi.1) hx.1, by grind⟩
     gcongr
     · grw [gpos]; apply hg <;> grind
     · grw [fpos]; apply hf <;> { simp; grind }
     · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
     · apply hg <;> grind
-  · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
-    apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
-    apply MonotoneOn.memLp_isCompact isCompact_Icc
-    intros _ _ _ _ _
+  · apply ((hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
+       (MonotoneOn.memLp_isCompact isCompact_Icc _)).mono_measure
+      (volume.restrict_mono_set Ico_subset_Icc_self)
+    intro _ _ _ _ _
     apply hg <;> grind

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Kevin H. Wilson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kevin H. Wilson
+Authors: Kevin H. Wilson, Alastair Irving, Terence Tao
 -/
 module
 
@@ -20,16 +20,14 @@ that.
 At the moment it contains several lemmas in this direction, for antitone or monotone functions
 (or products of antitone and monotone functions), formulated for sums on `range i` or `Ico a b`.
 
-`TODO`: Add more lemmas to the API to directly address limiting issues
-
 ## Main Results
 
 * `AntitoneOn.integral_le_sum`: The integral of an antitone function is at most the sum of its
-  values at integer steps aligning with the left-hand side of the interval
+  values at integer steps aligning with the left-hand side of the interval.
 * `AntitoneOn.sum_le_integral`: The sum of an antitone function along integer steps aligning with
   the right-hand side of the interval is at most the integral of the function along that interval
 * `MonotoneOn.integral_le_sum`: The integral of a monotone function is at most the sum of its
-  values at integer steps aligning with the right-hand side of the interval
+  values at integer steps aligning with the right-hand side of the interval.
 * `MonotoneOn.sum_le_integral`: The sum of a monotone function along integer steps aligning with
   the left-hand side of the interval is at most the integral of the function along that interval
 * `sum_mul_Ico_le_integral_of_monotone_antitone`: the sum of `f i * g i` on an interval is bounded
@@ -44,15 +42,14 @@ analysis, comparison, asymptotics
 
 public section
 
-
-open Set MeasureTheory MeasureSpace
+open Set MeasureTheory MeasureSpace intervalIntegral
 
 variable {x₀ : ℝ} {a b : ℕ} {f g : ℝ → ℝ}
 
 lemma sum_Ico_le_integral_of_le
     (hab : a ≤ b) (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) (i + 1 : ℕ), f i ≤ g x)
-    (hg : IntegrableOn g (Set.Ico a b)) :
-    ∑ i ∈ Finset.Ico a b, f i ≤ ∫ x in a..b, g x := by
+    (hg : IntegrableOn g (Ico a b)) :
+    ∑ i ∈ .Ico a b, f i ≤ ∫ x in a..b, g x := by
   have A i (hi : i ∈ Finset.Ico a b) : IntervalIntegrable g volume i (i + 1 : ℕ) := by
     rw [intervalIntegrable_iff_integrableOn_Ico_of_le (by simp)]
     apply hg.mono _ le_rfl
@@ -64,37 +61,37 @@ lemma sum_Ico_le_integral_of_le
   _ = ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..(i + 1 : ℕ), f i) := by simp
   _ ≤ ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..(i + 1 : ℕ), g x) := by
     gcongr with i hi
-    apply intervalIntegral.integral_mono_on_of_le_Ioo (by simp) (by simp) (A _ hi) (fun x hx ↦ ?_)
+    apply integral_mono_on_of_le_Ioo (by simp) (by simp) (A _ hi) (fun x hx ↦ ?_)
     exact h _ (by simpa using hi) _ (Ioo_subset_Ico_self hx)
   _ = ∫ x in a..b, g x := by
-    rw [intervalIntegral.sum_integral_adjacent_intervals_Ico (a := fun i ↦ i) hab]
+    rw [sum_integral_adjacent_intervals_Ico (a := fun i ↦ i) hab]
     intro i hi
     exact A _ (by simpa using hi)
 
 lemma integral_le_sum_Ico_of_le
     (hab : a ≤ b) (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) (i + 1 : ℕ), g x ≤ f i)
-    (hg : IntegrableOn g (Set.Ico a b)) :
-    ∫ x in a..b, g x ≤ ∑ i ∈ Finset.Ico a b, f i := by
+    (hg : IntegrableOn g (Ico a b)) :
+    ∫ x in a..b, g x ≤ ∑ i ∈ .Ico a b, f i := by
   convert!
     neg_le_neg
       (sum_Ico_le_integral_of_le (f := -f) (g := -g) hab (fun i hi x hx ↦ neg_le_neg (h i hi x hx))
         hg.neg) <;> simp
 
 theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
-    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ Finset.range a, f (x₀ + i) := by
+    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ .range a, f (x₀ + i) := by
   have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + (k + 1 : ℕ)) := by
     intro k hk
     refine (hf.mono ?_).intervalIntegrable
     rw [uIcc_of_le]
     · apply Icc_subset_Icc
-      · simp only [le_add_iff_nonneg_right, Nat.cast_nonneg]
-      · simp only [add_le_add_iff_left, Nat.cast_le, Nat.succ_le_of_lt hk]
-    · simp only [add_le_add_iff_left, Nat.cast_le, Nat.le_succ]
+      · simp
+      · simp [-Nat.cast_one, -Nat.cast_add, hk]
+    · simp
   calc
-    ∫ x in x₀..x₀ + a, f x = ∑ i ∈ Finset.range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
-      convert! (intervalIntegral.sum_integral_adjacent_intervals hint).symm
+    ∫ x in x₀..x₀ + a, f x = ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
+      convert! (sum_integral_adjacent_intervals hint).symm
       simp only [Nat.cast_zero, add_zero]
-    _ ≤ ∑ i ∈ Finset.range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + i) := by
+    _ ≤ ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + i) := by
       gcongr with i hi
       have ia : i < a := Finset.mem_range.1 hi
       refine intervalIntegral.integral_mono_on (by simp) (hint _ ia) (by simp) fun x hx => ?_
@@ -103,7 +100,7 @@ theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
           Nat.cast_le, and_self_iff]
       · refine mem_Icc.2 ⟨le_trans (by simp) hx.1, le_trans hx.2 ?_⟩
         simp only [add_le_add_iff_left, Nat.cast_le, Nat.succ_le_of_lt ia]
-    _ = ∑ i ∈ Finset.range a, f (x₀ + i) := by simp
+    _ = ∑ i ∈ .range a, f (x₀ + i) := by simp
 
 theorem AntitoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.Icc a b)) :
     (∫ x in a..b, f x) ≤ ∑ x ∈ Finset.Ico a b, f x := by
@@ -130,7 +127,7 @@ theorem AntitoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.I
   simp only [hf, hab, Nat.cast_sub, add_sub_cancel]
 
 theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
-    (∑ i ∈ Finset.range a, f (x₀ + (i + 1 : ℕ))) ≤ ∫ x in x₀..x₀ + a, f x := by
+    (∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ))) ≤ ∫ x in x₀..x₀ + a, f x := by
   have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + (k + 1 : ℕ)) := by
     intro k hk
     refine (hf.mono ?_).intervalIntegrable
@@ -140,12 +137,12 @@ theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
       · simp only [add_le_add_iff_left, Nat.cast_le, Nat.succ_le_of_lt hk]
     · simp only [add_le_add_iff_left, Nat.cast_le, Nat.le_succ]
   calc
-    (∑ i ∈ Finset.range a, f (x₀ + (i + 1 : ℕ))) =
-        ∑ i ∈ Finset.range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + (i + 1 : ℕ)) := by simp
-    _ ≤ ∑ i ∈ Finset.range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
+    (∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ))) =
+        ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + (i + 1 : ℕ)) := by simp
+    _ ≤ ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
       apply Finset.sum_le_sum fun i hi => ?_
       have ia : i + 1 ≤ a := Finset.mem_range.1 hi
-      refine intervalIntegral.integral_mono_on (by simp) (by simp) (hint _ ia) fun x hx => ?_
+      refine integral_mono_on (by simp) (by simp) (hint _ ia) fun x hx => ?_
       apply hf _ _ hx.2
       · refine mem_Icc.2 ⟨le_trans (le_add_of_nonneg_right (Nat.cast_nonneg _)) hx.1,
           le_trans hx.2 ?_⟩
@@ -153,11 +150,11 @@ theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
       · refine mem_Icc.2 ⟨le_add_of_nonneg_right (Nat.cast_nonneg _), ?_⟩
         simp only [add_le_add_iff_left, Nat.cast_le, ia]
     _ = ∫ x in x₀..x₀ + a, f x := by
-      convert! intervalIntegral.sum_integral_adjacent_intervals hint
+      convert! sum_integral_adjacent_intervals hint
       simp only [Nat.cast_zero, add_zero]
 
-theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.Icc a b)) :
-    (∑ i ∈ Finset.Ico a b, f (i + 1 : ℕ)) ≤ ∫ x in a..b, f x := by
+theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Icc a b)) :
+    (∑ i ∈ .Ico a b, f (i + 1 : ℕ)) ≤ ∫ x in a..b, f x := by
   rw [(Nat.sub_add_cancel hab).symm, Nat.cast_add]
   conv =>
     congr
@@ -180,112 +177,72 @@ theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.I
   simp only [hf, hab, Nat.cast_sub, add_sub_cancel]
 
 theorem MonotoneOn.sum_le_integral (hf : MonotoneOn f (Icc x₀ (x₀ + a))) :
-    (∑ i ∈ Finset.range a, f (x₀ + i)) ≤ ∫ x in x₀..x₀ + a, f x := by
+    (∑ i ∈ .range a, f (x₀ + i)) ≤ ∫ x in x₀..x₀ + a, f x := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.integral_le_sum
 
 theorem MonotoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : MonotoneOn f (Set.Icc a b)) :
-    ∑ x ∈ Finset.Ico a b, f x ≤ ∫ x in a..b, f x := by
+    ∑ x ∈ .Ico a b, f x ≤ ∫ x in a..b, f x := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.integral_le_sum_Ico hab
 
 theorem MonotoneOn.integral_le_sum (hf : MonotoneOn f (Icc x₀ (x₀ + a))) :
-    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ Finset.range a, f (x₀ + (i + 1 : ℕ)) := by
+    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ)) := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.sum_le_integral
 
 theorem MonotoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : MonotoneOn f (Set.Icc a b)) :
-    (∫ x in a..b, f x) ≤ ∑ i ∈ Finset.Ico a b, f (i + 1 : ℕ) := by
+    (∫ x in a..b, f x) ≤ ∑ i ∈ .Ico a b, f (i + 1 : ℕ) := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.sum_le_integral_Ico hab
 
 lemma sum_mul_Ico_le_integral_of_monotone_antitone
     (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) (hg : AntitoneOn g (Icc (a - 1) (b - 1)))
     (fpos : 0 ≤ f a) (gpos : 0 ≤ g (b - 1)) :
-    ∑ i ∈ Finset.Ico a b, f i * g i ≤ ∫ x in a..b, f x * g (x - 1) := by
+    ∑ i ∈ .Ico a b, f i * g i ≤ ∫ x in a..b, f x * g (x - 1) := by
   apply sum_Ico_le_integral_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
     simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have I0 : (i : ℝ) ≤ b - 1 := by
-      simp only [le_sub_iff_add_le]
-      norm_cast
-      lia
+    have I0 : (i : ℝ) ≤ b - 1 := by simp only [le_sub_iff_add_le]; norm_cast; lia
     have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
       simp only [mem_Icc, tsub_le_iff_right]
       exact ⟨by norm_cast; lia, I0⟩
-    have I2 : x ∈ Icc (a : ℝ) b := by
-      refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
-      norm_cast
-      lia
-    apply mul_le_mul
-    · apply hf
-      · simp only [mem_Icc, Nat.cast_le]
-        exact ⟨hi.1, hi.2.le⟩
-      · exact I2
-      · exact hx.1
-    · apply hg
-      · simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
-        refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
-        norm_cast
-        lia
-      · exact I1
-      · simpa [sub_le_iff_le_add] using hx.2.le
-    · apply gpos.trans
-      apply hg I1 (by simp [hab]) I0
-    · apply fpos.trans
-      apply hf (by simp [hab]) I2
-      exact le_trans (mod_cast hi.1) hx.1
+    have I2 : x ∈ Icc (a : ℝ) b := ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
+    gcongr
+    · exact gpos.trans (hg I1 (by simp [hab]) I0)
+    · exact fpos.trans (hf (by simp [hab]) I2 (le_trans (mod_cast hi.1) hx.1))
+    · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
+    · apply hg _ I1 (by simpa [sub_le_iff_le_add] using hx.2.le)
+      simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
+      exact ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
   · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
-    apply Integrable.mul_of_top_left
-    · exact hf.integrableOn_isCompact isCompact_Icc
-    · apply AntitoneOn.memLp_isCompact isCompact_Icc
-      intro x hx y hy hxy
-      apply hg
-      · simpa using hx
-      · simpa using hy
-      · simpa using hxy
+    apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
+    apply AntitoneOn.memLp_isCompact isCompact_Icc
+    intro x hx y hy hxy
+    apply hg <;> grind
 
 lemma integral_le_sum_mul_Ico_of_antitone_monotone
     (hab : a ≤ b) (hf : AntitoneOn f (Icc a b)) (hg : MonotoneOn g (Icc (a - 1) (b - 1)))
     (fpos : 0 ≤ f b) (gpos : 0 ≤ g (a - 1)) :
-    ∫ x in a..b, f x * g (x - 1) ≤ ∑ i ∈ Finset.Ico a b, f i * g i := by
+    ∫ x in a..b, f x * g (x - 1) ≤ ∑ i ∈ .Ico a b, f i * g i := by
   apply integral_le_sum_Ico_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
     simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have I0 : (i : ℝ) ≤ b - 1 := by
-      simp only [le_sub_iff_add_le]
-      norm_cast
-      lia
+    have I0 : (i : ℝ) ≤ b - 1 := by simp only [le_sub_iff_add_le]; norm_cast; lia
     have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
       simp only [mem_Icc, tsub_le_iff_right]
       exact ⟨by norm_cast; lia, I0⟩
-    have I2 : x ∈ Icc (a : ℝ) b := by
-      refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
-      norm_cast
-      lia
-    apply mul_le_mul
-    · apply hf
-      · simp only [mem_Icc, Nat.cast_le]
-        exact ⟨hi.1, hi.2.le⟩
-      · exact I2
-      · exact hx.1
-    · apply hg
-      · simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
-        refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
-        norm_cast
-        lia
-      · exact I1
-      · simpa [sub_le_iff_le_add] using hx.2.le
-    · apply gpos.trans
-      apply hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1)
-    · apply fpos.trans
-      apply hf ⟨mod_cast hi.1, mod_cast hi.2.le⟩ (by simpa using hab) (mod_cast hi.2.le)
+    have I2 : x ∈ Icc (a : ℝ) b := ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
+    gcongr
+    · exact gpos.trans (hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1))
+    · exact fpos.trans (hf ⟨mod_cast hi.1, mod_cast hi.2.le⟩ (by simpa using hab)
+        (mod_cast hi.2.le))
+    · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
+    · apply hg _ I1 (by simpa [sub_le_iff_le_add] using hx.2.le)
+      simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
+      exact ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
   · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
-    apply Integrable.mul_of_top_left
-    · exact hf.integrableOn_isCompact isCompact_Icc
-    · apply MonotoneOn.memLp_isCompact isCompact_Icc
-      intro x hx y hy hxy
-      apply hg
-      · simpa using hx
-      · simpa using hy
-      · simpa using hxy
+    apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
+    apply MonotoneOn.memLp_isCompact isCompact_Icc
+    intros x hx y hy hxy
+    apply hg <;> grind

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -149,9 +149,9 @@ lemma sum_mul_Ico_le_integral_of_monotone_antitone
     · grw [fpos]; apply hf <;> grind
     · apply hf <;> grind
     · apply hg <;> grind
-  · apply ((hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
-      (AntitoneOn.memLp_isCompact isCompact_Icc _)).mono_measure
-      (volume.restrict_mono_set Ico_subset_Icc_self)
+  · apply Integrable.mono_measure _ (volume.restrict_mono_set Ico_subset_Icc_self)
+    apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
+    apply AntitoneOn.memLp_isCompact isCompact_Icc
     intro _ _ _ _ _
     apply hg <;> grind
 
@@ -168,8 +168,8 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
     · grw [fpos]; apply hf <;> grind
     · apply hf <;> grind
     · apply hg <;> grind
-  · apply ((hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
-       (MonotoneOn.memLp_isCompact isCompact_Icc _)).mono_measure
-      (volume.restrict_mono_set Ico_subset_Icc_self)
+  · apply Integrable.mono_measure _ (volume.restrict_mono_set Ico_subset_Icc_self)
+    apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
+    apply MonotoneOn.memLp_isCompact isCompact_Icc
     intro _ _ _ _ _
     apply hg <;> grind

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -71,12 +71,11 @@ lemma sum_Ico_le_integral_of_le (hab : a ≤ b)
 lemma integral_le_sum_Ico_of_le (hab : a ≤ b)
     (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) ↑(i + 1), g x ≤ f i)
     (hg : IntegrableOn g (Ico a b)) : ∫ x in a..b, g x ≤ ∑ i ∈ .Ico a b, f i := by
-  convert!
-    neg_le_neg (sum_Ico_le_integral_of_le (f := -f) (g := -g) hab (fun i hi x hx ↦ neg_le_neg
-      (h i hi x hx)) hg.neg) <;> simp
+  convert! neg_le_neg (sum_Ico_le_integral_of_le (f := -f) (g := -g) hab
+    (fun i hi x hx ↦ neg_le_neg (h i hi x hx)) hg.neg) <;> simp
 
 theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
-    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ .range a, f (x₀ + i) := by
+    ∫ x in x₀..x₀ + a, f x ≤ ∑ i ∈ .range a, f (x₀ + i) := by
   have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + ↑(k + 1)) := by
     refine fun k hk ↦ (hf.mono ?_).intervalIntegrable
     rw [uIcc_of_le (by simp)]
@@ -94,21 +93,21 @@ theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
     _ = ∑ i ∈ .range a, f (x₀ + i) := by simp
 
 theorem AntitoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.Icc a b)) :
-    (∫ x in a..b, f x) ≤ ∑ x ∈ Finset.Ico a b, f x := by
+    ∫ x in a..b, f x ≤ ∑ x ∈ .Ico a b, f x := by
   suffices ∫ x in a..a + ↑(b - a), f x ≤ ∑ x ∈ .Ico (0 + a) (b - a + a), f x by simp_all
   rw [← Finset.sum_Ico_add, Nat.Ico_zero_eq_range]
   suffices ∫ x in a..a + ↑(b - a), f x ≤ ∑ x ∈ .range (b - a), f (a + x) by simp_all
   exact AntitoneOn.integral_le_sum (by simp only [hf, hab, Nat.cast_sub, add_sub_cancel])
 
 theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
-    (∑ i ∈ .range a, f (x₀ + ↑(i + 1))) ≤ ∫ x in x₀..x₀ + a, f x := by
+    ∑ i ∈ .range a, f (x₀ + ↑(i + 1)) ≤ ∫ x in x₀..x₀ + a, f x := by
   have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + (k + 1 : ℕ)) := by
     refine fun k hk ↦ (hf.mono ?_).intervalIntegrable
     rw [uIcc_of_le (by simp [-Nat.cast_add])]
     apply Icc_subset_Icc <;> simp [-Nat.cast_add, hk]
   calc
-    (∑ i ∈ .range a, f (x₀ + ↑(i + 1))) =
-        ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + ↑(i + 1), f (x₀ + ↑(i + 1)) := by simp
+    (∑ i ∈ .range a, f (x₀ + ↑(i + 1)))
+      = ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + ↑(i + 1), f (x₀ + ↑(i + 1)) := by simp
     _ ≤ ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + ↑(i + 1), f x := by
       gcongr with i hi
       simp only [Finset.mem_range] at hi
@@ -121,15 +120,14 @@ theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
       simp [-Nat.cast_add]
 
 theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Icc a b)) :
-    (∑ i ∈ .Ico a b, f (i + 1 : ℕ)) ≤ ∫ x in a..b, f x := by
+    ∑ i ∈ .Ico a b, f ↑(i + 1) ≤ ∫ x in a..b, f x := by
   suffices ∑ i ∈ .Ico (0 + a) (b - a + a), f ↑(i + 1) ≤ ∫ x in a..a + ↑(b - a), f x by simp_all
-  rw [← Finset.sum_Ico_add, Nat.Ico_zero_eq_range]
-  suffices ∑ x ∈ .range (b - a), f (a + ↑(x + 1)) ≤ ∫ x in a..a + ↑(b - a), f x by
-    simp_all [add_assoc]
+  simp_rw [← Finset.sum_Ico_add, Nat.Ico_zero_eq_range, add_assoc]
+  suffices ∑ x ∈ .range (b - a), f (a + ↑(x + 1)) ≤ ∫ x in a..a + ↑(b - a), f x by simp_all
   exact AntitoneOn.sum_le_integral (by simp [hf, hab])
 
 theorem MonotoneOn.sum_le_integral (hf : MonotoneOn f (Icc x₀ (x₀ + a))) :
-    (∑ i ∈ .range a, f (x₀ + i)) ≤ ∫ x in x₀..x₀ + a, f x := by
+    ∑ i ∈ .range a, f (x₀ + i) ≤ ∫ x in x₀..x₀ + a, f x := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.integral_le_sum
 
@@ -139,12 +137,12 @@ theorem MonotoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : MonotoneOn f (Set.I
   exact hf.neg.integral_le_sum_Ico hab
 
 theorem MonotoneOn.integral_le_sum (hf : MonotoneOn f (Icc x₀ (x₀ + a))) :
-    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ .range a, f (x₀ + ↑(i + 1)) := by
+    ∫ x in x₀..x₀ + a, f x ≤ ∑ i ∈ .range a, f (x₀ + ↑(i + 1)) := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.sum_le_integral
 
 theorem MonotoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : MonotoneOn f (Set.Icc a b)) :
-    (∫ x in a..b, f x) ≤ ∑ i ∈ .Ico a b, f ↑(i + 1) := by
+    ∫ x in a..b, f x ≤ ∑ i ∈ .Ico a b, f ↑(i + 1) := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.sum_le_integral_Ico hab
 
@@ -155,13 +153,12 @@ lemma sum_mul_Ico_le_integral_of_monotone_antitone
   apply sum_Ico_le_integral_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
     simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have I1 : ↑i ∈ Icc (a - 1 : ℝ) (b - 1) := by
-      simp only [mem_Icc, tsub_le_iff_right]; norm_cast; lia
-    have I2 : x ∈ Icc (a : ℝ) b := mem_Icc.mpr ⟨le_trans (mod_cast hi.1) hx.1, by grind⟩
+    have : ↑i ∈ Icc (a : ℝ) (b - 1) := by simp only [mem_Icc]; norm_cast; lia
+    rify at hi
     gcongr
     · grw [gpos]; apply hg <;> grind
     · grw [fpos]; apply hf <;> grind
-    · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
+    · apply hf <;> grind
     · apply hg <;> grind
   · apply ((hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
       (AntitoneOn.memLp_isCompact isCompact_Icc _)).mono_measure
@@ -176,13 +173,12 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
   apply integral_le_sum_Ico_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
     simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have I1 : ↑i ∈ Icc (a - 1 : ℝ) (b - 1) := by
-      simp only [mem_Icc, tsub_le_iff_right, le_sub_iff_add_le]; norm_cast; lia
-    have I2 : x ∈ Icc (a : ℝ) b := mem_Icc.mpr ⟨le_trans (mod_cast hi.1) hx.1, by grind⟩
+    have : ↑i ∈ Icc (a : ℝ) (b - 1) := by simp only [mem_Icc, le_sub_iff_add_le]; norm_cast
+    rify at hi
     gcongr
     · grw [gpos]; apply hg <;> grind
-    · grw [fpos]; apply hf <;> { simp; grind }
-    · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
+    · grw [fpos]; apply hf <;> grind
+    · apply hf <;> grind
     · apply hg <;> grind
   · apply ((hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
        (MonotoneOn.memLp_isCompact isCompact_Icc _)).mono_measure

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Kevin H. Wilson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kevin H. Wilson
+Authors: Kevin H. Wilson, Alastair Irving, Terence Tao
 -/
 module
 
@@ -20,22 +20,25 @@ that.
 At the moment it contains several lemmas in this direction, for antitone or monotone functions
 (or products of antitone and monotone functions), formulated for sums on `range i` or `Ico a b`.
 
-`TODO`: Add more lemmas to the API to directly address limiting issues
-
 ## Main Results
 
 * `AntitoneOn.integral_le_sum`: The integral of an antitone function is at most the sum of its
-  values at integer steps aligning with the left-hand side of the interval
+  values at integer steps aligning with the left-hand side of the interval.
 * `AntitoneOn.sum_le_integral`: The sum of an antitone function along integer steps aligning with
   the right-hand side of the interval is at most the integral of the function along that interval
 * `MonotoneOn.integral_le_sum`: The integral of a monotone function is at most the sum of its
-  values at integer steps aligning with the right-hand side of the interval
+  values at integer steps aligning with the right-hand side of the interval.
 * `MonotoneOn.sum_le_integral`: The sum of a monotone function along integer steps aligning with
   the left-hand side of the interval is at most the integral of the function along that interval
 * `sum_mul_Ico_le_integral_of_monotone_antitone`: the sum of `f i * g i` on an interval is bounded
   by the integral of `f x * g (x - 1)` if `f` is monotone and `g` is antitone.
 * `integral_le_sum_mul_Ico_of_antitone_monotone`: the sum of `f i * g i` on an interval is bounded
   below by the integral of `f x * g (x - 1)` if `f` is antitone and `g` is monotone.
+* `AntitoneOn.summable_of_integrable`: a nonnegative antitone function that is integrable on
+  `(0, ∞)` is summable over `ℕ`.
+* `AntitoneOn.sum_range_le_integral`, `AntitoneOn.tsum_add_one_le_integral`,
+  `AntitoneOn.tsum_le_integral`: bounds on (partial) sums of a nonnegative antitone function by its
+  integral over `(0, ∞)`.
 
 ## Tags
 
@@ -44,15 +47,14 @@ analysis, comparison, asymptotics
 
 public section
 
-
-open Set MeasureTheory MeasureSpace
+open Set MeasureTheory MeasureSpace intervalIntegral
 
 variable {x₀ : ℝ} {a b : ℕ} {f g : ℝ → ℝ}
 
 lemma sum_Ico_le_integral_of_le
     (hab : a ≤ b) (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) (i + 1 : ℕ), f i ≤ g x)
-    (hg : IntegrableOn g (Set.Ico a b)) :
-    ∑ i ∈ Finset.Ico a b, f i ≤ ∫ x in a..b, g x := by
+    (hg : IntegrableOn g (Ico a b)) :
+    ∑ i ∈ .Ico a b, f i ≤ ∫ x in a..b, g x := by
   have A i (hi : i ∈ Finset.Ico a b) : IntervalIntegrable g volume i (i + 1 : ℕ) := by
     rw [intervalIntegrable_iff_integrableOn_Ico_of_le (by simp)]
     apply hg.mono _ le_rfl
@@ -64,37 +66,37 @@ lemma sum_Ico_le_integral_of_le
   _ = ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..(i + 1 : ℕ), f i) := by simp
   _ ≤ ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..(i + 1 : ℕ), g x) := by
     gcongr with i hi
-    apply intervalIntegral.integral_mono_on_of_le_Ioo (by simp) (by simp) (A _ hi) (fun x hx ↦ ?_)
+    apply integral_mono_on_of_le_Ioo (by simp) (by simp) (A _ hi) (fun x hx ↦ ?_)
     exact h _ (by simpa using hi) _ (Ioo_subset_Ico_self hx)
   _ = ∫ x in a..b, g x := by
-    rw [intervalIntegral.sum_integral_adjacent_intervals_Ico (a := fun i ↦ i) hab]
+    rw [sum_integral_adjacent_intervals_Ico (a := fun i ↦ i) hab]
     intro i hi
     exact A _ (by simpa using hi)
 
 lemma integral_le_sum_Ico_of_le
     (hab : a ≤ b) (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) (i + 1 : ℕ), g x ≤ f i)
-    (hg : IntegrableOn g (Set.Ico a b)) :
-    ∫ x in a..b, g x ≤ ∑ i ∈ Finset.Ico a b, f i := by
+    (hg : IntegrableOn g (Ico a b)) :
+    ∫ x in a..b, g x ≤ ∑ i ∈ .Ico a b, f i := by
   convert!
     neg_le_neg
       (sum_Ico_le_integral_of_le (f := -f) (g := -g) hab (fun i hi x hx ↦ neg_le_neg (h i hi x hx))
         hg.neg) <;> simp
 
 theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
-    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ Finset.range a, f (x₀ + i) := by
+    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ .range a, f (x₀ + i) := by
   have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + (k + 1 : ℕ)) := by
     intro k hk
     refine (hf.mono ?_).intervalIntegrable
     rw [uIcc_of_le]
     · apply Icc_subset_Icc
-      · simp only [le_add_iff_nonneg_right, Nat.cast_nonneg]
-      · simp only [add_le_add_iff_left, Nat.cast_le, Nat.succ_le_of_lt hk]
-    · simp only [add_le_add_iff_left, Nat.cast_le, Nat.le_succ]
+      · simp
+      · simp [-Nat.cast_one, -Nat.cast_add, hk]
+    · simp
   calc
-    ∫ x in x₀..x₀ + a, f x = ∑ i ∈ Finset.range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
-      convert! (intervalIntegral.sum_integral_adjacent_intervals hint).symm
+    ∫ x in x₀..x₀ + a, f x = ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
+      convert! (sum_integral_adjacent_intervals hint).symm
       simp only [Nat.cast_zero, add_zero]
-    _ ≤ ∑ i ∈ Finset.range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + i) := by
+    _ ≤ ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + i) := by
       gcongr with i hi
       have ia : i < a := Finset.mem_range.1 hi
       refine intervalIntegral.integral_mono_on (by simp) (hint _ ia) (by simp) fun x hx => ?_
@@ -103,7 +105,7 @@ theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
           Nat.cast_le, and_self_iff]
       · refine mem_Icc.2 ⟨le_trans (by simp) hx.1, le_trans hx.2 ?_⟩
         simp only [add_le_add_iff_left, Nat.cast_le, Nat.succ_le_of_lt ia]
-    _ = ∑ i ∈ Finset.range a, f (x₀ + i) := by simp
+    _ = ∑ i ∈ .range a, f (x₀ + i) := by simp
 
 theorem AntitoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.Icc a b)) :
     (∫ x in a..b, f x) ≤ ∑ x ∈ Finset.Ico a b, f x := by
@@ -130,7 +132,7 @@ theorem AntitoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.I
   simp only [hf, hab, Nat.cast_sub, add_sub_cancel]
 
 theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
-    (∑ i ∈ Finset.range a, f (x₀ + (i + 1 : ℕ))) ≤ ∫ x in x₀..x₀ + a, f x := by
+    (∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ))) ≤ ∫ x in x₀..x₀ + a, f x := by
   have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + (k + 1 : ℕ)) := by
     intro k hk
     refine (hf.mono ?_).intervalIntegrable
@@ -140,12 +142,12 @@ theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
       · simp only [add_le_add_iff_left, Nat.cast_le, Nat.succ_le_of_lt hk]
     · simp only [add_le_add_iff_left, Nat.cast_le, Nat.le_succ]
   calc
-    (∑ i ∈ Finset.range a, f (x₀ + (i + 1 : ℕ))) =
-        ∑ i ∈ Finset.range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + (i + 1 : ℕ)) := by simp
-    _ ≤ ∑ i ∈ Finset.range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
+    (∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ))) =
+        ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + (i + 1 : ℕ)) := by simp
+    _ ≤ ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
       apply Finset.sum_le_sum fun i hi => ?_
       have ia : i + 1 ≤ a := Finset.mem_range.1 hi
-      refine intervalIntegral.integral_mono_on (by simp) (by simp) (hint _ ia) fun x hx => ?_
+      refine integral_mono_on (by simp) (by simp) (hint _ ia) fun x hx => ?_
       apply hf _ _ hx.2
       · refine mem_Icc.2 ⟨le_trans (le_add_of_nonneg_right (Nat.cast_nonneg _)) hx.1,
           le_trans hx.2 ?_⟩
@@ -153,11 +155,11 @@ theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
       · refine mem_Icc.2 ⟨le_add_of_nonneg_right (Nat.cast_nonneg _), ?_⟩
         simp only [add_le_add_iff_left, Nat.cast_le, ia]
     _ = ∫ x in x₀..x₀ + a, f x := by
-      convert! intervalIntegral.sum_integral_adjacent_intervals hint
+      convert! sum_integral_adjacent_intervals hint
       simp only [Nat.cast_zero, add_zero]
 
-theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.Icc a b)) :
-    (∑ i ∈ Finset.Ico a b, f (i + 1 : ℕ)) ≤ ∫ x in a..b, f x := by
+theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Icc a b)) :
+    (∑ i ∈ .Ico a b, f (i + 1 : ℕ)) ≤ ∫ x in a..b, f x := by
   rw [(Nat.sub_add_cancel hab).symm, Nat.cast_add]
   conv =>
     congr
@@ -180,112 +182,106 @@ theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.I
   simp only [hf, hab, Nat.cast_sub, add_sub_cancel]
 
 theorem MonotoneOn.sum_le_integral (hf : MonotoneOn f (Icc x₀ (x₀ + a))) :
-    (∑ i ∈ Finset.range a, f (x₀ + i)) ≤ ∫ x in x₀..x₀ + a, f x := by
+    (∑ i ∈ .range a, f (x₀ + i)) ≤ ∫ x in x₀..x₀ + a, f x := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.integral_le_sum
 
 theorem MonotoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : MonotoneOn f (Set.Icc a b)) :
-    ∑ x ∈ Finset.Ico a b, f x ≤ ∫ x in a..b, f x := by
+    ∑ x ∈ .Ico a b, f x ≤ ∫ x in a..b, f x := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.integral_le_sum_Ico hab
 
 theorem MonotoneOn.integral_le_sum (hf : MonotoneOn f (Icc x₀ (x₀ + a))) :
-    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ Finset.range a, f (x₀ + (i + 1 : ℕ)) := by
+    (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ)) := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.sum_le_integral
 
 theorem MonotoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : MonotoneOn f (Set.Icc a b)) :
-    (∫ x in a..b, f x) ≤ ∑ i ∈ Finset.Ico a b, f (i + 1 : ℕ) := by
+    (∫ x in a..b, f x) ≤ ∑ i ∈ .Ico a b, f (i + 1 : ℕ) := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.sum_le_integral_Ico hab
 
 lemma sum_mul_Ico_le_integral_of_monotone_antitone
     (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) (hg : AntitoneOn g (Icc (a - 1) (b - 1)))
     (fpos : 0 ≤ f a) (gpos : 0 ≤ g (b - 1)) :
-    ∑ i ∈ Finset.Ico a b, f i * g i ≤ ∫ x in a..b, f x * g (x - 1) := by
+    ∑ i ∈ .Ico a b, f i * g i ≤ ∫ x in a..b, f x * g (x - 1) := by
   apply sum_Ico_le_integral_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
     simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have I0 : (i : ℝ) ≤ b - 1 := by
-      simp only [le_sub_iff_add_le]
-      norm_cast
-      lia
+    have I0 : (i : ℝ) ≤ b - 1 := by simp only [le_sub_iff_add_le]; norm_cast; lia
     have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
       simp only [mem_Icc, tsub_le_iff_right]
       exact ⟨by norm_cast; lia, I0⟩
-    have I2 : x ∈ Icc (a : ℝ) b := by
-      refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
-      norm_cast
-      lia
-    apply mul_le_mul
-    · apply hf
-      · simp only [mem_Icc, Nat.cast_le]
-        exact ⟨hi.1, hi.2.le⟩
-      · exact I2
-      · exact hx.1
-    · apply hg
-      · simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
-        refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
-        norm_cast
-        lia
-      · exact I1
-      · simpa [sub_le_iff_le_add] using hx.2.le
-    · apply gpos.trans
-      apply hg I1 (by simp [hab]) I0
-    · apply fpos.trans
-      apply hf (by simp [hab]) I2
-      exact le_trans (mod_cast hi.1) hx.1
+    have I2 : x ∈ Icc (a : ℝ) b := ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
+    gcongr
+    · exact gpos.trans (hg I1 (by simp [hab]) I0)
+    · exact fpos.trans (hf (by simp [hab]) I2 (le_trans (mod_cast hi.1) hx.1))
+    · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
+    · apply hg _ I1 (by simpa [sub_le_iff_le_add] using hx.2.le)
+      simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
+      exact ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
   · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
-    apply Integrable.mul_of_top_left
-    · exact hf.integrableOn_isCompact isCompact_Icc
-    · apply AntitoneOn.memLp_isCompact isCompact_Icc
-      intro x hx y hy hxy
-      apply hg
-      · simpa using hx
-      · simpa using hy
-      · simpa using hxy
+    apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
+    apply AntitoneOn.memLp_isCompact isCompact_Icc
+    intro x hx y hy hxy
+    apply hg <;> grind
 
 lemma integral_le_sum_mul_Ico_of_antitone_monotone
     (hab : a ≤ b) (hf : AntitoneOn f (Icc a b)) (hg : MonotoneOn g (Icc (a - 1) (b - 1)))
     (fpos : 0 ≤ f b) (gpos : 0 ≤ g (a - 1)) :
-    ∫ x in a..b, f x * g (x - 1) ≤ ∑ i ∈ Finset.Ico a b, f i * g i := by
+    ∫ x in a..b, f x * g (x - 1) ≤ ∑ i ∈ .Ico a b, f i * g i := by
   apply integral_le_sum_Ico_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
     simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have I0 : (i : ℝ) ≤ b - 1 := by
-      simp only [le_sub_iff_add_le]
-      norm_cast
-      lia
+    have I0 : (i : ℝ) ≤ b - 1 := by simp only [le_sub_iff_add_le]; norm_cast; lia
     have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
       simp only [mem_Icc, tsub_le_iff_right]
       exact ⟨by norm_cast; lia, I0⟩
-    have I2 : x ∈ Icc (a : ℝ) b := by
-      refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
-      norm_cast
-      lia
-    apply mul_le_mul
-    · apply hf
-      · simp only [mem_Icc, Nat.cast_le]
-        exact ⟨hi.1, hi.2.le⟩
-      · exact I2
-      · exact hx.1
-    · apply hg
-      · simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
-        refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
-        norm_cast
-        lia
-      · exact I1
-      · simpa [sub_le_iff_le_add] using hx.2.le
-    · apply gpos.trans
-      apply hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1)
-    · apply fpos.trans
-      apply hf ⟨mod_cast hi.1, mod_cast hi.2.le⟩ (by simpa using hab) (mod_cast hi.2.le)
+    have I2 : x ∈ Icc (a : ℝ) b := ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
+    gcongr
+    · exact gpos.trans (hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1))
+    · exact fpos.trans (hf ⟨mod_cast hi.1, mod_cast hi.2.le⟩ (by simpa using hab)
+        (mod_cast hi.2.le))
+    · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
+    · apply hg _ I1 (by simpa [sub_le_iff_le_add] using hx.2.le)
+      simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
+      exact ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
   · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
-    apply Integrable.mul_of_top_left
-    · exact hf.integrableOn_isCompact isCompact_Icc
-    · apply MonotoneOn.memLp_isCompact isCompact_Icc
-      intro x hx y hy hxy
-      apply hg
-      · simpa using hx
-      · simpa using hy
-      · simpa using hxy
+    apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
+    apply MonotoneOn.memLp_isCompact isCompact_Icc
+    intros x hx y hy hxy
+    apply hg <;> grind
+
+theorem AntitoneOn.sum_range_le_integral (N : ℕ) (anti : AntitoneOn f (Icc 0 (N : ℝ)))
+    (integrable : IntegrableOn f (Ioi 0)) (nonneg : ∀ t ∈ Ioi 0, 0 ≤ f t) :
+    ∑ n ∈ .range N, f (n + 1 : ℕ) ≤ ∫ x in Ioi 0, f x := by
+  trans ∫ x in 0..N, f x
+  · convert AntitoneOn.sum_le_integral (x₀ := 0) (a := N) (f := f) (by simpa) using 2
+    · simp
+    · ring
+  · rw [intervalIntegral.integral_of_le (by simp)]
+    apply setIntegral_mono_set integrable _ (Ioc_subset_Ioi_self.eventuallyLE)
+    · filter_upwards [ae_restrict_mem (by measurability)] with t ht using nonneg t ht
+
+theorem AntitoneOn.summable_of_integrable (anti : AntitoneOn f (Ici 0))
+    (integrable : IntegrableOn f (Ioi 0)) (nonneg : ∀ t ∈ Ioi 0, 0 ≤ f t) :
+    Summable (fun (n : ℕ) ↦ f n) := by
+  rw [← summable_nat_add_iff 1]
+  apply summable_of_sum_range_le
+  · exact fun n ↦ nonneg _ (by simp; grind)
+  · exact fun N ↦ (anti.mono Icc_subset_Ici_self).sum_range_le_integral _ integrable nonneg
+
+theorem AntitoneOn.tsum_add_one_le_integral (anti : AntitoneOn f (Ici 0))
+    (integrable : IntegrableOn f (Ioi 0)) (nonneg : ∀ t ∈ Ioi 0, 0 ≤ f t) :
+    ∑' (n : ℕ), f (n + 1 : ℕ) ≤ ∫ x in Ioi 0, f x := by
+  apply Summable.tsum_le_of_sum_range_le
+  · exact summable_nat_add_iff _ |>.mpr (anti.summable_of_integrable integrable nonneg)
+  · exact fun N ↦ (anti.mono Icc_subset_Ici_self).sum_range_le_integral _ integrable nonneg
+
+theorem AntitoneOn.tsum_le_integral (anti : AntitoneOn f (Ici 0))
+    (integrable : IntegrableOn f (Ioi 0)) (nonneg : ∀ t ∈ Ioi 0, 0 ≤ f t) :
+    ∑' (n : ℕ), f n ≤ f 0 + ∫ x in Ioi 0, f x := by
+  rw [(anti.summable_of_integrable integrable nonneg).tsum_eq_zero_add]
+  gcongr
+  · simp
+  · exact anti.tsum_add_one_le_integral integrable nonneg

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -20,6 +20,8 @@ that.
 At the moment it contains several lemmas in this direction, for antitone or monotone functions
 (or products of antitone and monotone functions), formulated for sums on `range i` or `Ico a b`.
 
+`TODO`: Add more lemmas to the API to directly address limiting issues
+
 ## Main Results
 
 * `AntitoneOn.integral_le_sum`: The integral of an antitone function is at most the sum of its

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -87,7 +87,7 @@ theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
     rw [uIcc_of_le]
     · apply Icc_subset_Icc
       · simp
-      · simp [-Nat.cast_one, -Nat.cast_add, hk]
+      · simp [-Nat.cast_add, hk]
     · simp
   calc
     ∫ x in x₀..x₀ + a, f x = ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -205,7 +205,7 @@ lemma sum_mul_Ico_le_integral_of_monotone_antitone
   apply sum_Ico_le_integral_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
     simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have I0 : (i : ℝ) ≤ b - 1 := by simp only [le_sub_iff_add_le]; norm_cast; lia
+    have I0 : (i : ℝ) ≤ b - 1 := by norm_cast; lia
     have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
       simp only [mem_Icc, tsub_le_iff_right]
       exact ⟨by norm_cast; lia, I0⟩

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -234,7 +234,7 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
     have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
       simp only [mem_Icc, tsub_le_iff_right]
       exact ⟨by norm_cast; lia, I0⟩
-    have I2 : x ∈ Icc (a : ℝ) b := ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
+    have I2 : x ∈ Icc (a : ℝ) b := mem_Icc.mpr ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
     gcongr
     · exact gpos.trans (hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1))
     · exact fpos.trans (hf ⟨mod_cast hi.1, mod_cast hi.2.le⟩ (by simpa using hab)

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2022 Kevin H. Wilson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin H. Wilson
+-/
 module
 
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -239,9 +239,7 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
     · exact gpos.trans <| hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1)
     · exact fpos.trans <| by apply hf <;> { simp; grind }
     · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
-    · apply hg _ I1 (by simpa [sub_le_iff_le_add] using hx.2.le)
-      simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
-      exact ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
+    · apply hg _ I1 (by simpa using hx.2.le); grind
   · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
     apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
     apply MonotoneOn.memLp_isCompact isCompact_Icc

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -48,11 +48,10 @@ open Set MeasureTheory MeasureSpace intervalIntegral
 
 variable {x₀ : ℝ} {a b : ℕ} {f g : ℝ → ℝ}
 
-lemma sum_Ico_le_integral_of_le
-    (hab : a ≤ b) (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) (i + 1 : ℕ), f i ≤ g x)
-    (hg : IntegrableOn g (Ico a b)) :
-    ∑ i ∈ .Ico a b, f i ≤ ∫ x in a..b, g x := by
-  have A i (hi : i ∈ Finset.Ico a b) : IntervalIntegrable g volume i (i + 1 : ℕ) := by
+lemma sum_Ico_le_integral_of_le (hab : a ≤ b)
+    (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) ↑(i + 1), f i ≤ g x)
+    (hg : IntegrableOn g (Ico a b)) : ∑ i ∈ .Ico a b, f i ≤ ∫ x in a..b, g x := by
+  have A i (hi : i ∈ Finset.Ico a b) : IntervalIntegrable g volume i ↑(i + 1) := by
     rw [intervalIntegrable_iff_integrableOn_Ico_of_le (by simp)]
     apply hg.mono _ le_rfl
     rintro x ⟨hx, h'x⟩
@@ -60,24 +59,21 @@ lemma sum_Ico_le_integral_of_le
     exact ⟨le_trans (mod_cast hi.1) hx, h'x.trans_le (mod_cast hi.2)⟩
   calc
   ∑ i ∈ Finset.Ico a b, f i
-  _ = ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..(i + 1 : ℕ), f i) := by simp
-  _ ≤ ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..(i + 1 : ℕ), g x) := by
+  _ = ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..↑(i + 1), f i) := by simp
+  _ ≤ ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..↑(i + 1), g x) := by
     gcongr with i hi
     apply integral_mono_on_of_le_Ioo (by simp) (by simp) (A _ hi) (fun x hx ↦ ?_)
     exact h _ (by simpa using hi) _ (Ioo_subset_Ico_self hx)
   _ = ∫ x in a..b, g x := by
     rw [sum_integral_adjacent_intervals_Ico (a := fun i ↦ i) hab]
-    intro i hi
-    exact A _ (by simpa using hi)
+    grind
 
-lemma integral_le_sum_Ico_of_le
-    (hab : a ≤ b) (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) (i + 1 : ℕ), g x ≤ f i)
-    (hg : IntegrableOn g (Ico a b)) :
-    ∫ x in a..b, g x ≤ ∑ i ∈ .Ico a b, f i := by
+lemma integral_le_sum_Ico_of_le (hab : a ≤ b)
+    (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) ↑(i + 1), g x ≤ f i)
+    (hg : IntegrableOn g (Ico a b)) : ∫ x in a..b, g x ≤ ∑ i ∈ .Ico a b, f i := by
   convert!
-    neg_le_neg
-      (sum_Ico_le_integral_of_le (f := -f) (g := -g) hab (fun i hi x hx ↦ neg_le_neg (h i hi x hx))
-        hg.neg) <;> simp
+    neg_le_neg (sum_Ico_le_integral_of_le (f := -f) (g := -g) hab (fun i hi x hx ↦ neg_le_neg
+      (h i hi x hx)) hg.neg) <;> simp
 
 theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
     (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ .range a, f (x₀ + i) := by
@@ -106,75 +102,38 @@ theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
 
 theorem AntitoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : AntitoneOn f (Set.Icc a b)) :
     (∫ x in a..b, f x) ≤ ∑ x ∈ Finset.Ico a b, f x := by
-  rw [(Nat.sub_add_cancel hab).symm, Nat.cast_add]
-  conv =>
-    congr
-    congr
-    · skip
-    · skip
-    rw [add_comm]
-    · skip
-    · skip
-    congr
-    congr
-    rw [← zero_add a]
+  suffices ∫ x in a..a + ↑(b - a), f x ≤ ∑ x ∈ .Ico (0 + a) (b - a + a), f x by simp_all
   rw [← Finset.sum_Ico_add, Nat.Ico_zero_eq_range]
-  conv =>
-    rhs
-    congr
-    · skip
-    ext
-    rw [Nat.cast_add]
+  suffices ∫ x in a..a + ↑(b - a), f x ≤ ∑ x ∈ .range (b - a), f (a + x) by simp_all
   apply AntitoneOn.integral_le_sum
   simp only [hf, hab, Nat.cast_sub, add_sub_cancel]
 
 theorem AntitoneOn.sum_le_integral (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
     (∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ))) ≤ ∫ x in x₀..x₀ + a, f x := by
   have hint : ∀ k : ℕ, k < a → IntervalIntegrable f volume (x₀ + k) (x₀ + (k + 1 : ℕ)) := by
-    intro k hk
-    refine (hf.mono ?_).intervalIntegrable
-    rw [uIcc_of_le]
-    · apply Icc_subset_Icc
-      · simp only [le_add_iff_nonneg_right, Nat.cast_nonneg]
-      · simp only [add_le_add_iff_left, Nat.cast_le, Nat.succ_le_of_lt hk]
-    · simp only [add_le_add_iff_left, Nat.cast_le, Nat.le_succ]
+    refine fun k hk ↦ (hf.mono ?_).intervalIntegrable
+    rw [uIcc_of_le (by simp [-Nat.cast_add])]
+    apply Icc_subset_Icc <;> simp [-Nat.cast_add, hk]
   calc
     (∑ i ∈ .range a, f (x₀ + (i + 1 : ℕ))) =
         ∑ i ∈ .range a, ∫ _ in x₀ + i..x₀ + (i + 1 : ℕ), f (x₀ + (i + 1 : ℕ)) := by simp
     _ ≤ ∑ i ∈ .range a, ∫ x in x₀ + i..x₀ + (i + 1 : ℕ), f x := by
       apply Finset.sum_le_sum fun i hi => ?_
       have ia : i + 1 ≤ a := Finset.mem_range.1 hi
-      refine integral_mono_on (by simp) (by simp) (hint _ ia) fun x hx => ?_
-      apply hf _ _ hx.2
-      · refine mem_Icc.2 ⟨le_trans (le_add_of_nonneg_right (Nat.cast_nonneg _)) hx.1,
-          le_trans hx.2 ?_⟩
-        simp only [Nat.cast_le, add_le_add_iff_left, ia]
-      · refine mem_Icc.2 ⟨le_add_of_nonneg_right (Nat.cast_nonneg _), ?_⟩
-        simp only [add_le_add_iff_left, Nat.cast_le, ia]
+      refine integral_mono_on (by simp) (by simp) (hint _ ia) fun x hx ↦ ?_
+      apply hf (mem_Icc.2 _) (mem_Icc.2 _) hx.2
+      · exact ⟨by grind, le_trans hx.2 (by simp [-Nat.cast_add, ia])⟩
+      · exact ⟨by grind, by simp [-Nat.cast_add, ia]⟩
     _ = ∫ x in x₀..x₀ + a, f x := by
       convert! sum_integral_adjacent_intervals hint
       simp only [Nat.cast_zero, add_zero]
 
 theorem AntitoneOn.sum_le_integral_Ico (hab : a ≤ b) (hf : AntitoneOn f (Icc a b)) :
     (∑ i ∈ .Ico a b, f (i + 1 : ℕ)) ≤ ∫ x in a..b, f x := by
-  rw [(Nat.sub_add_cancel hab).symm, Nat.cast_add]
-  conv =>
-    congr
-    congr
-    congr
-    rw [← zero_add a]
-    · skip
-    · skip
-    · skip
-    rw [add_comm]
+  suffices ∑ i ∈ .Ico (0 + a) (b - a + a), f ↑(i + 1) ≤ ∫ x in a..a + ↑(b - a), f x by simp_all
   rw [← Finset.sum_Ico_add, Nat.Ico_zero_eq_range]
-  conv =>
-    lhs
-    congr
-    congr
-    · skip
-    ext
-    rw [add_assoc, Nat.cast_add]
+  suffices ∑ x ∈ .range (b - a), f (a + ↑(x + 1)) ≤ ∫ x in a..a + ↑(b - a), f x by
+    simp_all [add_assoc]
   apply AntitoneOn.sum_le_integral
   simp only [hf, hab, Nat.cast_sub, add_sub_cancel]
 
@@ -209,14 +168,12 @@ lemma sum_mul_Ico_le_integral_of_monotone_antitone
     have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
       simp only [mem_Icc, tsub_le_iff_right]
       exact ⟨by norm_cast; lia, I0⟩
-    have I2 : x ∈ Icc (a : ℝ) b := ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
+    have I2 : x ∈ Icc (a : ℝ) b := mem_Icc.mpr ⟨le_trans (mod_cast hi.1) hx.1, by grind⟩
     gcongr
-    · exact gpos.trans (hg I1 (by simp [hab]) I0)
-    · exact fpos.trans (hf (by simp [hab]) I2 (le_trans (mod_cast hi.1) hx.1))
+    · grw [gpos]; apply hg <;> grind
+    · grw [fpos]; apply hf <;> grind
     · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
-    · apply hg _ I1 (by simpa [sub_le_iff_le_add] using hx.2.le)
-      simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
-      exact ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
+    · apply hg <;> grind
   · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
     apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
     apply AntitoneOn.memLp_isCompact isCompact_Icc
@@ -234,14 +191,14 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
     have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
       simp only [mem_Icc, tsub_le_iff_right]
       exact ⟨by norm_cast; lia, I0⟩
-    have I2 : x ∈ Icc (a : ℝ) b := mem_Icc.mpr ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans (by grind)⟩
+    have I2 : x ∈ Icc (a : ℝ) b := mem_Icc.mpr ⟨le_trans (mod_cast hi.1) hx.1, by grind⟩
     gcongr
-    · exact gpos.trans <| hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1)
-    · exact fpos.trans <| by apply hf <;> { simp; grind }
+    · grw [gpos]; apply hg <;> grind
+    · grw [fpos]; apply hf <;> { simp; grind }
     · exact hf (by simpa using ⟨hi.1, hi.2.le⟩) I2 hx.1
-    · apply hg _ I1 (by simpa using hx.2.le); grind
+    · apply hg <;> grind
   · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
     apply (hf.integrableOn_isCompact isCompact_Icc).mul_of_top_left
     apply MonotoneOn.memLp_isCompact isCompact_Icc
-    intros x hx y hy hxy
+    intros _ _ _ _ _
     apply hg <;> grind


### PR DESCRIPTION
Golfed the existing code in `SumIntegralComparisons.lean`.  I had also added some additional API lemmas, but this is now done in #40588 and I have removed the redundant additions to simplify the PR.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
