### PR TITLE
[Merged by Bors] - chore: avoid `meta`-importing math files

### DIFF
--- a/Mathlib/Data/Rat/Floor.lean
+++ b/Mathlib/Data/Rat/Floor.lean
@@ -9,7 +9,6 @@ public import Mathlib.Algebra.Order.Round
 public import Mathlib.Data.Rat.Cast.Order
 public import Mathlib.Tactic.FieldSimp
 public import Mathlib.Tactic.Ring
-meta import Mathlib.Algebra.Order.Floor.Defs
 public meta import Mathlib.Algebra.Order.Round
 
 /-!

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -8,8 +8,7 @@ module
 public import Mathlib.LinearAlgebra.TensorProduct.Tower
 public import Mathlib.RingTheory.Coalgebra.Equiv
 
-meta import Mathlib.RingTheory.Coalgebra.CoassocSimps
-
+import Mathlib.RingTheory.Coalgebra.CoassocSimps
 import Mathlib.Algebra.Algebra.Bilinear
 
 /-!

--- a/Mathlib/Tactic/CancelDenoms/Core.lean
+++ b/Mathlib/Tactic/CancelDenoms/Core.lean
@@ -6,7 +6,6 @@ Authors: Robert Y. Lewis
 module
 
 public meta import Mathlib.Data.Tree.Basic
-public meta import Mathlib.Logic.Basic
 public import Mathlib.Algebra.Field.Basic
 public meta import Mathlib.Algebra.Group.Nat.Defs
 public import Mathlib.Algebra.Order.Ring.Defs

--- a/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
@@ -5,7 +5,6 @@ Authors: Yuma Mizuno
 -/
 module
 
-public meta import Mathlib.CategoryTheory.Bicategory.Free
 public import Mathlib.CategoryTheory.Bicategory.Free
 public import Mathlib.Tactic.CategoryTheory.BicategoricalComp
 
@@ -22,7 +21,7 @@ tactic is given in `Mathlib/Tactic/CategoryTheory/Coherence.lean` at the same ti
 tactic for monoidal categories.
 -/
 
-public meta section
+public section
 
 noncomputable section
 
@@ -93,11 +92,11 @@ instance liftHom₂WhiskerRight {f g : a ⟶ b} (η : f ⟶ g) [LiftHom f] [Lift
 open Lean Elab Tactic Meta
 
 /-- Helper function for throwing exceptions. -/
-def exception {α : Type} (g : MVarId) (msg : MessageData) : MetaM α :=
+meta def exception {α : Type} (g : MVarId) (msg : MessageData) : MetaM α :=
   throwTacticEx `bicategorical_coherence g msg
 
 /-- Helper function for throwing exceptions with respect to the main goal. -/
-def exception' (msg : MessageData) : TacticM Unit := do
+meta def exception' (msg : MessageData) : TacticM Unit := do
   try
     liftMetaTactic (exception (msg := msg))
   catch _ =>
@@ -108,13 +107,13 @@ set_option quotPrecheck false in
 /-- Auxiliary definition for `bicategorical_coherence`. -/
 -- We could construct this expression directly without using `elabTerm`,
 -- but it would require preparing many implicit arguments by hand.
-def mkLiftMap₂LiftExpr (e : Expr) : TermElabM Expr := do
+meta def mkLiftMap₂LiftExpr (e : Expr) : TermElabM Expr := do
   Term.elabTerm
     (← ``((FreeBicategory.lift (Prefunctor.id _)).map₂ (LiftHom₂.lift $(← Term.exprToSyntax e))))
     none
 
 /-- Coherence tactic for bicategories. -/
-def bicategoryCoherence (g : MVarId) : TermElabM Unit := g.withContext do
+meta def bicategoryCoherence (g : MVarId) : TermElabM Unit := g.withContext do
   withOptions (fun opts => synthInstance.maxSize.set opts
     (max 256 (synthInstance.maxSize.get opts))) do
   let thms := [``BicategoricalCoherence.iso, ``Iso.trans, ``Iso.symm, ``Iso.refl,

--- a/Mathlib/Tactic/CategoryTheory/Coherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence.lean
@@ -5,10 +5,7 @@ Authors: Kim Morrison, Yuma Mizuno, Oleksandr Manzyuk
 -/
 module
 
-public meta import Mathlib.Lean.Meta
 public import Mathlib.CategoryTheory.Monoidal.Free.Basic
-public meta import Mathlib.CategoryTheory.Monoidal.Free.Basic
-public import Mathlib.Lean.Meta
 public import Mathlib.Tactic.CategoryTheory.BicategoryCoherence
 public import Mathlib.Tactic.CategoryTheory.MonoidalComp
 
@@ -27,7 +24,7 @@ are equal.
 
 -/
 
-public meta section
+public section
 
 universe v u
 
@@ -112,11 +109,11 @@ end lifting
 open Lean Meta Elab Tactic
 
 /-- Helper function for throwing exceptions. -/
-def exception {α : Type} (g : MVarId) (msg : MessageData) : MetaM α :=
+meta def exception {α : Type} (g : MVarId) (msg : MessageData) : MetaM α :=
   throwTacticEx `monoidal_coherence g msg
 
 /-- Helper function for throwing exceptions with respect to the main goal. -/
-def exception' (msg : MessageData) : TacticM Unit := do
+meta def exception' (msg : MessageData) : TacticM Unit := do
   try
     liftMetaTactic (exception (msg := msg))
   catch _ =>
@@ -126,13 +123,13 @@ def exception' (msg : MessageData) : TacticM Unit := do
 /-- Auxiliary definition for `monoidal_coherence`. -/
 -- We could construct this expression directly without using `elabTerm`,
 -- but it would require preparing many implicit arguments by hand.
-def mkProjectMapExpr (e : Expr) : TermElabM Expr := do
+meta def mkProjectMapExpr (e : Expr) : TermElabM Expr := do
   Term.elabTerm
     (← ``(FreeMonoidalCategory.projectMap _root_.id _ _ (LiftHom.lift $(← Term.exprToSyntax e))))
     none
 
 /-- Coherence tactic for monoidal categories. -/
-def monoidalCoherence (g : MVarId) : TermElabM Unit := g.withContext do
+meta def monoidalCoherence (g : MVarId) : TermElabM Unit := g.withContext do
   withOptions (fun opts => synthInstance.maxSize.set opts
     (max 512 (synthInstance.maxSize.get opts))) do
   let thms := [``MonoidalCoherence.iso, ``Iso.trans, ``Iso.symm, ``Iso.refl,
@@ -157,7 +154,7 @@ open Mathlib.Tactic.BicategoryCoherence
 /--
 If set to `false`, the warning on the use of the deprecated coherence tactic is disabled.
 -/
-register_option warn.refl_coherence : Bool := {
+meta register_option warn.refl_coherence : Bool := {
   defValue := true
   descr := "warn when the deprecated coherence tactic is used"
 }
@@ -233,7 +230,7 @@ lemma insert_id_rhs {C : Type*} [Category* C] {X Y : C} (f g : X ⟶ Y) (w : f =
   simpa using w
 
 /-- If either the lhs or rhs is not a composition, compose it on the right with an identity. -/
-def insertTrailingIds (g : MVarId) : MetaM MVarId := do
+meta def insertTrailingIds (g : MVarId) : MetaM MVarId := do
   let some (_, lhs, rhs) := (← withReducible g.getType').eq? | exception g "Not an equality."
   let mut g := g
   if !(lhs.isAppOf ``CategoryStruct.comp) then
@@ -248,7 +245,7 @@ def insertTrailingIds (g : MVarId) : MetaM MVarId := do
 -- Porting note: this is an ugly port, using too many `evalTactic`s.
 -- We can refactor later into either a `macro` (but the flow control is awkward)
 -- or a `MetaM` tactic.
-def coherenceLoop (maxSteps := 37) : TacticM Unit :=
+meta def coherenceLoop (maxSteps := 37) : TacticM Unit :=
   match maxSteps with
   | 0 => exception' "`coherence` tactic reached iteration limit"
   | maxSteps' + 1 => do

--- a/Mathlib/Tactic/CongrExclamation.lean
+++ b/Mathlib/Tactic/CongrExclamation.lean
@@ -10,7 +10,7 @@ public meta import Lean.Elab.Tactic.RCases
 public meta import Lean.Meta.Tactic.Assumption
 public meta import Lean.Meta.Tactic.Rfl
 public meta import Mathlib.Lean.Meta.CongrTheorems
-public meta import Mathlib.Logic.Basic
+public import Mathlib.Logic.Basic
 public import Mathlib.Lean.Meta.CongrTheorems
 
 /-!

--- a/Mathlib/Tactic/IntervalCases.lean
+++ b/Mathlib/Tactic/IntervalCases.lean
@@ -5,7 +5,6 @@ Authors: Kim Morrison, Mario Carneiro
 -/
 module
 
-public meta import Mathlib.Control.Basic
 public import Mathlib.Data.Finset.Attr
 public import Mathlib.Tactic.NormNum
 

--- a/Mathlib/Tactic/ModCases.lean
+++ b/Mathlib/Tactic/ModCases.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro, Heather Macbeth
 -/
 module
 
-public meta import Mathlib.Data.Int.ModEq
 public import Mathlib.Data.Int.ModEq
 public import Mathlib.Tactic.HaveI
 
@@ -15,7 +14,7 @@ The `mod_cases` tactic does case disjunction on `e % n`, where `e : ℤ` or `e :
 to yield `n` new subgoals corresponding to the possible values of `e` modulo `n`.
 -/
 
-public meta section
+public section
 
 namespace Mathlib.Tactic.ModCases
 open Lean Meta Elab Tactic Term Qq
@@ -66,7 +65,7 @@ and the `a ≡ b (mod n) → p` case becomes a subgoal.
 Proves an expression of the form `OnModCases n a b p` where `n` and `b` are raw nat literals
 and `b ≤ n`. Returns the list of subgoals `?gi : a ≡ i [ZMOD n] → p`.
 -/
-partial def proveOnModCases {u : Level} (n : Q(ℕ)) (a : Q(ℤ)) (b : Q(ℕ)) (p : Q(Sort u)) :
+meta partial def proveOnModCases {u : Level} (n : Q(ℕ)) (a : Q(ℤ)) (b : Q(ℕ)) (p : Q(Sort u)) :
     MetaM (Q(OnModCases $n $a $b $p) × List MVarId) := do
   if n.natLit! ≤ b.natLit! then
     haveI' : $b =Q $n := ⟨⟩
@@ -82,7 +81,7 @@ partial def proveOnModCases {u : Level} (n : Q(ℕ)) (a : Q(ℤ)) (b : Q(ℕ)) (
 /--
 Int case of `mod_cases h : e % n`.
 -/
-def modCases (h : TSyntax `Lean.binderIdent) (e : Q(ℤ)) (n : ℕ) : TacticM Unit := do
+meta def modCases (h : TSyntax `Lean.binderIdent) (e : Q(ℤ)) (n : ℕ) : TacticM Unit := do
   let ⟨u, p, g⟩ ← inferTypeQ (.mvar (← getMainGoal))
   have lit : Q(ℕ) := mkRawNatLit n
   have p₁ : Nat.ble 1 $lit =Q true := ⟨⟩
@@ -142,7 +141,7 @@ and the `a ≡ b (mod n) → p` case becomes a subgoal.
 Proves an expression of the form `OnModCases n a b p` where `n` and `b` are raw nat literals
 and `b ≤ n`. Returns the list of subgoals `?gi : a ≡ i [MOD n] → p`.
 -/
-partial def proveOnModCases {u : Level} (n : Q(ℕ)) (a : Q(ℕ)) (b : Q(ℕ)) (p : Q(Sort u)) :
+meta partial def proveOnModCases {u : Level} (n : Q(ℕ)) (a : Q(ℕ)) (b : Q(ℕ)) (p : Q(Sort u)) :
     MetaM (Q(OnModCases $n $a $b $p) × List MVarId) := do
   if n.natLit! ≤ b.natLit! then
     have : $b =Q $n := ⟨⟩
@@ -157,7 +156,7 @@ partial def proveOnModCases {u : Level} (n : Q(ℕ)) (a : Q(ℕ)) (b : Q(ℕ)) (
 /--
 Nat case of `mod_cases h : e % n`.
 -/
-def modCases (h : TSyntax `Lean.binderIdent) (e : Q(ℕ)) (n : ℕ) : TacticM Unit := do
+meta def modCases (h : TSyntax `Lean.binderIdent) (e : Q(ℕ)) (n : ℕ) : TacticM Unit := do
   let ⟨u, p, g⟩ ← inferTypeQ (.mvar (← getMainGoal))
   have lit : Q(ℕ) := mkRawNatLit n
   let p₁ : Q(Nat.ble 1 $lit = true) := (q(Eq.refl true) : Expr)

--- a/Mathlib/Tactic/NormNum/LegendreSymbol.lean
+++ b/Mathlib/Tactic/NormNum/LegendreSymbol.lean
@@ -5,7 +5,6 @@ Authors: Michael Stoll
 -/
 module
 
-public meta import Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol
 public import Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol
 
 /-!
@@ -47,7 +46,7 @@ where we encode the residue classes mod 2, mod 4, or mod 8 by using hypotheses l
 are the ones occurring in the use of QR above.
 -/
 
-public meta section
+public section
 
 
 section Lemmas
@@ -193,6 +192,8 @@ end Mathlib.Meta.NormNum
 
 end Lemmas
 
+meta section
+
 section Evaluation
 
 /-!
@@ -208,7 +209,7 @@ namespace Mathlib.Meta.NormNum
 open Lean Elab Tactic Qq
 
 -- TODO: redefined here for reduction; should this be special-handled in quote4?
-private meta def mkRawIntLit' (n : ℤ) : Q(ℤ) :=
+private def mkRawIntLit' (n : ℤ) : Q(ℤ) :=
   let lit : Q(ℕ) := .lit <| .natVal n.natAbs
   if 0 ≤ n then q(.ofNat $lit) else q(.negOfNat $lit)
 

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -11,7 +11,6 @@ public import Mathlib.Data.Nat.Factorial.Basic  -- shake: keep (Qq dependency)
 public import Mathlib.Data.Int.CharZero  -- shake: keep (Qq dependency)
 public import Mathlib.Data.PNat.Defs  -- shake: keep (Qq dependency)
 public import Mathlib.Algebra.Order.Ring.Basic  -- shake: keep (Qq dependency)
-public meta import Mathlib.Algebra.Notation.Defs
 public import Mathlib.Algebra.Order.Hom.Basic
 public import Mathlib.Data.NNRat.Defs
 public import Mathlib.Tactic.Positivity.Core

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -5,10 +5,8 @@ Authors: Mario Carneiro, Aurélien Saue, Anne Baanen
 -/
 module
 
-public import Mathlib.Tactic.NormNum.Inv
-public import Mathlib.Tactic.NormNum.Pow
 public import Mathlib.Tactic.Ring.Common
-meta import Mathlib.Tactic.Ring.Common
+public meta import Mathlib.Algebra.Order.Ring.Unbundled.Rat
 
 /-!
 # `ring` tactic

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -6,7 +6,7 @@ Authors: Mario Carneiro, Aurélien Saue, Anne Baanen
 module
 
 public import Mathlib.Tactic.Ring.Common
-public meta import Mathlib.Algebra.Order.Ring.Unbundled.Rat
+public meta import Mathlib.Algebra.Order.Ring.Unbundled.Rat -- for the `Ord Rat` instance
 
 /-!
 # `ring` tactic

--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -7,9 +7,6 @@ module
 
 public import Mathlib.Tactic.NormNum.Inv
 public import Mathlib.Tactic.NormNum.Pow
-public meta import Mathlib.Tactic.NormNum.Result
-
-meta import Mathlib.Algebra.Order.Ring.Unbundled.Rat
 
 /-!
 # `ring`-like tactics

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -6,7 +6,6 @@ Authors: Mario Carneiro
 module
 
 public import Mathlib.Algebra.Group.Nat.Defs
-public meta import Mathlib.Algebra.Notation.Defs
 public import Mathlib.Tactic.Push
 
 /-!

--- a/Mathlib/Tactic/Simproc/Divisors.lean
+++ b/Mathlib/Tactic/Simproc/Divisors.lean
@@ -5,7 +5,7 @@ Authors: Paul Lezeau, Bhavik Mehta
 -/
 module
 
-public meta import Mathlib.NumberTheory.Divisors -- TODO: check if `meta` is still needed after https://github.com/leanprover/lean4/pull/13043
+public meta import Mathlib.NumberTheory.Divisors
 public meta import Mathlib.Tactic.ToAdditive
 public meta import Mathlib.Util.Qq
 

--- a/Mathlib/Tactic/Simproc/Factors.lean
+++ b/Mathlib/Tactic/Simproc/Factors.lean
@@ -6,7 +6,6 @@ Authors: Mario Carneiro, Eric Wieser
 module
 
 import all Mathlib.Tactic.NormNum.Prime  -- for accessing `evalMinFac.core`
-public meta import Mathlib.Algebra.BigOperators.Group.List.Defs
 public import Mathlib.Data.Nat.Factors
 public import Mathlib.Tactic.NormNum.Prime
 


### PR DESCRIPTION
It should never be neccessary to meta import a maths file, so this PR removes some such imports. In some cases this was caused by a `public meta section` at the top of a tactic file, even though there are some definitions in the file that should not be meta (because they are used as part of the generated proofs).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
