### PR TITLE
feat(Algebra/Group): characterize Monoid npow as semigroup iterated mul

### DIFF
--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -348,6 +348,18 @@ instance [MulHomClass F M N] : CoeTC F (M →ₙ* N) :=
 @[to_additive (attr := simp)]
 theorem MulHom.coe_coe [MulHomClass F M N] (f : F) : ((f : MulHom M N) : M → N) = f := rfl
 
+-- TODO: update when we have `pnpow`
+@[to_additive pnsmul_map]
+lemma MulHom.map_pnpow {M N : Type*} [Semigroup M] [Monoid N] (f : M →ₙ* N)
+    (a : M) {n : ℕ} (hn : n ≠ 0) : (f a) ^ n = f ((a * ·)^[n - 1] a) := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hn
+  clear hn
+  simp only [Nat.succ_eq_add_one, Nat.add_one_sub_one, pow_succ']
+  induction n with
+  | zero => simp
+  | succ n IH =>
+    simp only [pow_succ', IH, Function.iterate_succ', Function.comp_apply, map_mul]
+
 end Mul
 
 section mul_one

--- a/Mathlib/Algebra/Group/Nat/Hom.lean
+++ b/Mathlib/Algebra/Group/Nat/Hom.lean
@@ -86,6 +86,11 @@ lemma MonoidHom.ext_mnat ⦃f g : Multiplicative ℕ →* M⦄
     (h : f (Multiplicative.ofAdd 1) = g (Multiplicative.ofAdd 1)) : f = g :=
   MonoidHom.ext fun n ↦ by rw [f.apply_mnat, g.apply_mnat, h]
 
+@[to_additive]
+lemma iterate_mul_left_eq_pow {M : Type*} [Monoid M] (a : M) (n : ℕ) :
+    (a * ·)^[n] a = a ^ (n + 1) := by
+  cases n <;> simp [pow_succ, ← mul_assoc]
+
 end Monoid
 
 section AddCommMonoid

--- a/Mathlib/Algebra/Group/WithOne/Basic.lean
+++ b/Mathlib/Algebra/Group/WithOne/Basic.lean
@@ -43,6 +43,12 @@ def coeMulHom [Mul α] : α →ₙ* WithOne α where
   toFun := coe
   map_mul' _ _ := rfl
 
+-- TODO: update when we have `pnpow`
+@[to_additive]
+lemma coe_pnpow [Semigroup α] (a : α) {n : ℕ} (hn : n ≠ 0) :
+    (↑a : WithOne α) ^ n = (a * ·)^[n - 1] a :=
+  coeMulHom.map_pnpow a hn
+
 end
 
 section lift


### PR DESCRIPTION
Couldn't find a better place for some of the lemmas In lieu of pnpow for now

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
