### PR TITLE
[Merged by Bors] - feat(Analysis/Calculus): add `uniqueDiffOn_uIcc`

### DIFF
--- a/Mathlib/Analysis/Calculus/TangentCone/Real.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Real.lean
@@ -99,6 +99,9 @@ theorem uniqueDiffOn_Iio (a : ℝ) : UniqueDiffOn ℝ (Iio a) :=
 theorem uniqueDiffOn_Icc {a b : ℝ} (hab : a < b) : UniqueDiffOn ℝ (Icc a b) :=
   uniqueDiffOn_convex (convex_Icc a b) <| by simp only [interior_Icc, nonempty_Ioo, hab]
 
+theorem uniqueDiffOn_uIcc {a b : ℝ} (hab : a ≠ b) : UniqueDiffOn ℝ (uIcc a b) :=
+  uniqueDiffOn_Icc <| min_lt_max.mpr hab
+
 theorem uniqueDiffOn_Ico (a b : ℝ) : UniqueDiffOn ℝ (Ico a b) :=
   if hab : a < b then
     uniqueDiffOn_convex (convex_Ico a b) <| by simp only [interior_Ico, nonempty_Ioo, hab]


### PR DESCRIPTION
---
Add `uniqueDiffOn_uIcc` in response to comment here:

https://github.com/leanprover-community/mathlib4/pull/39406#discussion_r3424276069

Did not also add `uniqueDiffOn_uIoo` and `uniqueDiffOn_uIoc`, because they are special cases of the ordered lemmas.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
