### PR TITLE
feat(Topology/FiberBundle): continuous sections of fibre bundles

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7829,6 +7829,7 @@ public import Mathlib.Topology.ExtendFrom
 public import Mathlib.Topology.ExtremallyDisconnected
 public import Mathlib.Topology.FiberBundle.Basic
 public import Mathlib.Topology.FiberBundle.Constructions
+public import Mathlib.Topology.FiberBundle.ContinuousSection
 public import Mathlib.Topology.FiberBundle.IsHomeomorphicTrivialBundle
 public import Mathlib.Topology.FiberBundle.Trivialization
 public import Mathlib.Topology.FiberPartition

--- a/Mathlib/Data/Bundle.lean
+++ b/Mathlib/Data/Bundle.lean
@@ -96,6 +96,10 @@ theorem TotalSpace.range_mk (b : B) : range ((↑) : E b → TotalSpace F E) = �
   · rintro ⟨_, x⟩ rfl
     exact ⟨x, rfl⟩
 
+@[simps]
+instance {M : Type*} [∀ b, SMul M (E b)] : SMul M (TotalSpace F E) where
+  smul g x := ⟨_, g • x.2⟩
+
 /-- Notation for the direct sum of two bundles over the same base. -/
 notation:100 E₁ " ×ᵇ " E₂ => fun x => E₁ x × E₂ x
 

--- a/Mathlib/Topology/FiberBundle/Constructions.lean
+++ b/Mathlib/Topology/FiberBundle/Constructions.lean
@@ -49,6 +49,9 @@ variable [TopologicalSpace B] [TopologicalSpace F]
 theorem isInducing_toProd : IsInducing (TotalSpace.toProd B F) :=
   ⟨by simp only [instTopologicalSpaceProd, induced_inf, induced_compose]; rfl⟩
 
+lemma _root_.Bundle.TotalSpace.continuous_trivialSnd : Continuous (TotalSpace.trivialSnd B F) :=
+  continuous_iff_le_induced.2 inf_le_right
+
 /-- Homeomorphism between the total space of the trivial bundle and the Cartesian product. -/
 @[simps!]
 def homeomorphProd : TotalSpace F (Trivial B F) ≃ₜ B × F :=
@@ -274,6 +277,12 @@ irreducible_def pullbackTopology : TopologicalSpace (TotalSpace F (f *ᵖ E)) :=
 the projections to the base and the map to the original bundle are continuous. -/
 instance Pullback.TotalSpace.topologicalSpace : TopologicalSpace (TotalSpace F (f *ᵖ E)) :=
   pullbackTopology F E f
+
+theorem Pullback.continuous_iff (f : B' → B) {X : Type*} [TopologicalSpace X]
+    (g : X → TotalSpace F (f *ᵖ E)) :
+    Continuous g ↔ Continuous (TotalSpace.proj ∘ g) ∧ Continuous (Pullback.lift f ∘ g) := by
+  simp [continuous_iff_le_induced, TotalSpace.topologicalSpace, pullbackTopology_def,
+    induced_compose]
 
 theorem Pullback.continuous_proj (f : B' → B) : Continuous (π F (f *ᵖ E)) := by
   rw [continuous_iff_le_induced, Pullback.TotalSpace.topologicalSpace, pullbackTopology_def]

--- a/Mathlib/Topology/FiberBundle/ContinuousSection.lean
+++ b/Mathlib/Topology/FiberBundle/ContinuousSection.lean
@@ -44,6 +44,7 @@ the `Bundle` namespace. -/
 structure ContinuousSection (F : Type*) [TopologicalSpace F] {B : Type*} [TopologicalSpace B]
     (E : B → Type*) [∀ b, TopologicalSpace (E b)] [TopologicalSpace (TotalSpace F E)]
     [FiberBundle F E] where
+  /-- The underlying function of the section. -/
   toFun : ∀ b, E b
   continuous_toFun : Continuous fun b ↦ (⟨b, toFun b⟩ : TotalSpace F E)
 

--- a/Mathlib/Topology/FiberBundle/ContinuousSection.lean
+++ b/Mathlib/Topology/FiberBundle/ContinuousSection.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 Ben Eltschig. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ben Eltschig
+-/
+module
+
+public import Mathlib.Topology.ContinuousMap.Algebra
+public import Mathlib.Topology.FiberBundle.Basic
+
+/-!
+# Continuous sections of fibre bundles
+
+In this file we define continuous sections of topological fibre bundles and prove that if a bundle
+carries a continuous fibrewise action by a topological group `G`, its sections are acted on by both
+`G` and `G`-valued functions on the base space.
+
+## TODO
+* Introduce typeclasses for continuity of other fibrewise algebraic structures and show that
+  sections inherit the corresponding structures in these cases.
+* Show that vector bundles satisfy these typeclasses, so that this API in particular applies
+  to them.
+-/
+
+@[expose] public section
+
+open Bundle FiberBundle Function Filter
+
+variable (F : Type*) [TopologicalSpace F] {B : Type*} [TopologicalSpace B]
+  (E : B → Type*) [∀ b, TopologicalSpace (E b)] [TopologicalSpace (TotalSpace F E)]
+  [FiberBundle F E]
+
+/-- The type of continuous sections of a topological `FiberBundle F E`, written `Cₛ(F, E)` in
+the `Bundle` namespace. -/
+structure ContinuousSection (F : Type*) [TopologicalSpace F] {B : Type*} [TopologicalSpace B]
+    (E : B → Type*) [∀ b, TopologicalSpace (E b)] [TopologicalSpace (TotalSpace F E)]
+    [FiberBundle F E] where
+  toFun : ∀ b, E b
+  continuous_toFun : Continuous fun b ↦ (⟨b, toFun b⟩ : TotalSpace F E)
+
+@[inherit_doc] scoped[Bundle] notation "Cₛ⟮" F ", " E "⟯" => ContinuousSection F E
+
+namespace ContinuousSection
+
+variable {F E}
+
+instance : DFunLike Cₛ⟮F, E⟯ B E where
+  coe := ContinuousSection.toFun
+  coe_injective := by rintro ⟨⟩ ⟨⟩ h; congr
+
+variable {s t : Cₛ⟮F, E⟯}
+
+@[simp]
+theorem coeFn_mk (s : ∀ b, E b) (hs : Continuous fun b ↦ (⟨b, s b⟩ : TotalSpace F E)) :
+    (mk s hs : ∀ b, E b) = s := rfl
+
+protected theorem continuous (s : Cₛ⟮F, E⟯) : Continuous fun b ↦ (⟨b, s b⟩ : TotalSpace F E) :=
+  s.continuous_toFun
+
+theorem coe_inj ⦃s t : Cₛ⟮F, E⟯⦄ (h : (s : ∀ b, E b) = t) : s = t :=
+  DFunLike.ext' h
+
+theorem coe_injective : Injective ((↑) : Cₛ⟮F, E⟯ → ∀ b, E b) :=
+  coe_inj
+
+@[ext]
+theorem ext (h : ∀ x, s x = t x) : s = t := DFunLike.ext _ _ h
+
+end ContinuousSection
+
+section Operations
+
+variable {F E}
+
+
+omit [TopologicalSpace F] [(b : B) → TopologicalSpace (E b)] [FiberBundle F E] in
+lemma ContinuousWithinAt.smul_section {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] {f : B → G} {s : ∀ b, E b} {u : Set B} {b : B}
+    (hf : ContinuousWithinAt f u b)
+    (hs : ContinuousWithinAt (fun b ↦ (⟨b, s b⟩ : TotalSpace F E)) u b) :
+    ContinuousWithinAt (fun b ↦ (⟨b, (f • s) b⟩ : TotalSpace F E)) u b :=
+  hf.smul hs
+
+omit [TopologicalSpace F] [(b : B) → TopologicalSpace (E b)] [FiberBundle F E] in
+lemma ContinuousAt.smul_section {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] {f : B → G} {s : ∀ b, E b} {b : B}
+    (hf : ContinuousAt f b) (hs : ContinuousAt (fun b ↦ (⟨b, s b⟩ : TotalSpace F E)) b) :
+    ContinuousAt (fun b ↦ (⟨b, (f • s) b⟩ : TotalSpace F E)) b :=
+  hf.smul hs
+
+omit [TopologicalSpace F] [(b : B) → TopologicalSpace (E b)] [FiberBundle F E] in
+lemma ContinuousOn.smul_section {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] {f : B → G} {s : ∀ b, E b} {u : Set B}
+    (hf : ContinuousOn f u) (hs : ContinuousOn (fun b ↦ (⟨b, s b⟩ : TotalSpace F E)) u) :
+    ContinuousOn (fun b ↦ (⟨b, (f • s) b⟩ : TotalSpace F E)) u :=
+  hf.smul hs
+
+omit [TopologicalSpace F] [(b : B) → TopologicalSpace (E b)] [FiberBundle F E] in
+lemma Continuous.smul_section {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] {f : B → G} {s : ∀ b, E b}
+    (hf : Continuous f) (hs : Continuous (fun b ↦ (⟨b, s b⟩ : TotalSpace F E))) :
+    Continuous (fun b ↦ (⟨b, (f • s) b⟩ : TotalSpace F E)) :=
+  hf.smul hs
+
+omit [TopologicalSpace F] [(b : B) → TopologicalSpace (E b)] [FiberBundle F E] in
+lemma ContinuousWithinAt.const_smul_section {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] {s : ∀ b, E b} {u : Set B} {b : B}
+    (g : G) (hs : ContinuousWithinAt (fun b ↦ (⟨b, s b⟩ : TotalSpace F E)) u b) :
+    ContinuousWithinAt (fun b ↦ (⟨b, (g • s) b⟩ : TotalSpace F E)) u b :=
+  continuousWithinAt_const.smul_section hs
+
+omit [TopologicalSpace F] [(b : B) → TopologicalSpace (E b)] [FiberBundle F E] in
+lemma ContinuousAt.const_smul_section {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] {s : ∀ b, E b} {b : B}
+    (g : G) (hs : ContinuousAt (fun b ↦ (⟨b, s b⟩ : TotalSpace F E)) b) :
+    ContinuousAt (fun b ↦ (⟨b, (g • s) b⟩ : TotalSpace F E)) b :=
+  continuousAt_const.smul_section hs
+
+omit [TopologicalSpace F] [(b : B) → TopologicalSpace (E b)] [FiberBundle F E] in
+lemma ContinuousOn.const_smul_section {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] {s : ∀ b, E b} {u : Set B}
+    (g : G) (hs : ContinuousOn (fun b ↦ (⟨b, s b⟩ : TotalSpace F E)) u) :
+    ContinuousOn (fun b ↦ (⟨b, (g • s) b⟩ : TotalSpace F E)) u :=
+  continuousOn_const.smul_section hs
+
+omit [TopologicalSpace F] [(b : B) → TopologicalSpace (E b)] [FiberBundle F E] in
+lemma Continuous.const_smul_section {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] {s : ∀ b, E b}
+    (g : G) (hs : Continuous (fun b ↦ (⟨b, s b⟩ : TotalSpace F E))) :
+    Continuous (fun b ↦ (⟨b, (g • s) b⟩ : TotalSpace F E)) :=
+  continuous_const.smul_section hs
+
+namespace ContinuousSection
+
+/-- For every bundle `E` with a continuous fibrewise `G`-action, the type `Cₛ⟮F, E⟯` of sections
+of `E` carries a `G`-action too. -/
+instance instSMul {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] : SMul G Cₛ⟮F, E⟯ :=
+  ⟨fun c s ↦ ⟨c • ⇑s, s.continuous.const_smul_section c⟩⟩
+
+@[simp]
+theorem coe_smul {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] (g : G) (s : Cₛ⟮F, E⟯) : ⇑(g • s) = g • ⇑s :=
+  rfl
+
+/-- For every bundle `E` with a continuous fibrewise `G`-action, the continuous functions `B → G`
+act on the continuous sections of `E`. -/
+instance instSMul' {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] : SMul C(B, G) Cₛ⟮F, E⟯ :=
+  ⟨fun f s ↦ ⟨⇑f • ⇑s, f.continuous.smul_section s.continuous⟩⟩
+
+@[simp]
+theorem coe_smul' {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]
+    [ContinuousSMul G (TotalSpace F E)] (f : C(B, G)) (s : Cₛ⟮F, E⟯) : ⇑(f • s) = ⇑f • ⇑s :=
+  rfl
+
+instance {G : Type*} [SMul G G] [TopologicalSpace G] [ContinuousConstSMul G G]
+    [∀ b, SMul G (E b)] [∀ b, IsScalarTower G G (E b)] [ContinuousSMul G (TotalSpace F E)] :
+    IsScalarTower G C(B, G) Cₛ⟮F, E⟯ where
+  smul_assoc g f s := by ext x; simp
+
+end ContinuousSection
+
+end Operations

--- a/Mathlib/Topology/FiberBundle/ContinuousSection.lean
+++ b/Mathlib/Topology/FiberBundle/ContinuousSection.lean
@@ -6,7 +6,7 @@ Authors: Ben Eltschig
 module
 
 public import Mathlib.Topology.ContinuousMap.Algebra
-public import Mathlib.Topology.FiberBundle.Basic
+public import Mathlib.Topology.FiberBundle.Constructions
 
 /-!
 # Continuous sections of fibre bundles
@@ -14,6 +14,15 @@ public import Mathlib.Topology.FiberBundle.Basic
 In this file we define continuous sections of topological fibre bundles and prove that if a bundle
 carries a continuous fibrewise action by a topological group `G`, its sections are acted on by both
 `G` and `G`-valued functions on the base space.
+
+## Main results / definitions
+* `ContinuousSection F E`: the type of continuous sections of `E`. Denoted `Cₛ⟮F, E⟯`.
+* `ContinuousSection.equivContinuousMap`: continuous sections of a trivial bundle `Trivial B F`
+  correspond to continuous maps `B → F`.
+* `ContinuousSection.prodEquiv`: continuous sections of a product bundle `E ×ᵇ E'` correspond to
+  pairs of continuous sections of `E` and `E'`.
+* `ContinuousSection.pullback f s`: the continuous section of the pullback bundle `f *ᵖ E` given
+  by precomposing a given continuous section `s` of `E` with `f`.
 
 ## TODO
 * Introduce typeclasses for continuity of other fibrewise algebraic structures and show that
@@ -66,12 +75,42 @@ theorem coe_injective : Injective ((↑) : Cₛ⟮F, E⟯ → ∀ b, E b) :=
 @[ext]
 theorem ext (h : ∀ x, s x = t x) : s = t := DFunLike.ext _ _ h
 
+/-- Continuous sections of trivial bundles are equivalently continuous maps. -/
+@[simps]
+def equivContinuousMap : Cₛ⟮F, Trivial B F⟯ ≃ C(B, F) where
+  toFun s := ⟨fun b ↦ s b, (TotalSpace.continuous_trivialSnd B F).comp s.continuous⟩
+  invFun f := ⟨fun b ↦ f b, (Trivial.homeomorphProd B F).symm.continuous.comp <|
+    continuous_id.prodMk f.continuous⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- Continuous sections of product bundles correspond to pairs of continuous sections
+of the factors. -/
+noncomputable def prodEquiv {F' : Type*} [TopologicalSpace F'] {E' : B → Type*}
+    [∀ b, TopologicalSpace (E' b)] [TopologicalSpace (TotalSpace F' E')] [FiberBundle F' E']
+    [∀ x, Zero (E x)] [∀ x, Zero (E' x)] : Cₛ⟮F × F', E ×ᵇ E'⟯ ≃ Cₛ⟮F, E⟯ × Cₛ⟮F', E'⟯ where
+  toFun s := ⟨⟨fun b ↦ (s b).1, continuous_fst.comp <|
+    (Prod.isInducing_diag F E F' E').continuous.comp s.continuous⟩, ⟨fun b ↦ (s b).2,
+        continuous_snd.comp <| (Prod.isInducing_diag F E F' E').continuous.comp s.continuous⟩⟩
+  invFun s := ⟨fun b ↦ (s.1 b, s.2 b), (Prod.isInducing_diag F E F' E').continuous_iff.2 <|
+    continuous_prodMk.2 ⟨s.1.continuous, s.2.continuous⟩⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- The pullback of a continuous section of `E` to the pullback bundle `f *ᵖ E` given by
+precomposition with `f`. -/
+@[simps]
+def pullback {B' : Type*} [TopologicalSpace B'] [∀ _b, Zero (E _b)] {K : Type*} [FunLike K B' B]
+    [ContinuousMapClass K B' B] (f : K) (s : Cₛ⟮F, E⟯) : Cₛ⟮F, f *ᵖ E⟯ where
+  toFun b := s (f b)
+  continuous_toFun :=
+    (Pullback.continuous_iff F E f _).2 ⟨continuous_id, s.continuous.comp (map_continuous f)⟩
+
 end ContinuousSection
 
 section Operations
 
 variable {F E}
-
 
 omit [TopologicalSpace F] [(b : B) → TopologicalSpace (E b)] [FiberBundle F E] in
 lemma ContinuousWithinAt.smul_section {G : Type*} [TopologicalSpace G] [∀ b, SMul G (E b)]

--- a/Mathlib/Topology/FiberBundle/ContinuousSection.lean
+++ b/Mathlib/Topology/FiberBundle/ContinuousSection.lean
@@ -72,12 +72,8 @@ theorem coeFn_mk (s : ∀ b, E b) (hs : Continuous fun b ↦ (⟨b, s b⟩ : Tot
 protected theorem continuous (s : Cₛ⟮F, E⟯) : Continuous fun b ↦ (⟨b, s b⟩ : TotalSpace F E) :=
   s.continuous_toFun
 
-@[simp]
-theorem coe_inj {s t : Cₛ⟮F, E⟯} : (s : ∀ b, E b) = t ↔ s = t :=
-  ⟨fun h ↦ DFunLike.ext' h, fun h ↦ by rw [h]⟩
-
 theorem coe_injective : Injective ((↑) : Cₛ⟮F, E⟯ → ∀ b, E b) :=
-  fun _ _ ↦ coe_inj.1
+  DFunLike.coe_injective
 
 @[ext]
 theorem ext (h : ∀ x, s x = t x) : s = t := DFunLike.ext _ _ h

--- a/Mathlib/Topology/FiberBundle/ContinuousSection.lean
+++ b/Mathlib/Topology/FiberBundle/ContinuousSection.lean
@@ -15,7 +15,7 @@ In this file we define continuous sections of topological fibre bundles and prov
 carries a continuous fibrewise action by a topological group `G`, its sections are acted on by both
 `G` and `G`-valued functions on the base space.
 
-## Main results / definitions
+## Main definitions and results
 * `ContinuousSection F E`: the type of continuous sections of `E`. Denoted `Cₛ⟮F, E⟯`.
 * `ContinuousSection.equivContinuousMap`: continuous sections of a trivial bundle `Trivial B F`
   correspond to continuous maps `B → F`.
@@ -24,7 +24,12 @@ carries a continuous fibrewise action by a topological group `G`, its sections a
 * `ContinuousSection.pullback f s`: the continuous section of the pullback bundle `f *ᵖ E` given
   by precomposing a given continuous section `s` of `E` with `f`.
 
-## TODO
+## Notation
+
+`Cₛ⟮F, E⟯` is notation for `ContinuousSection F E`. Note that these are not parentheses but special
+brackets that can be typed with `\([])'`.
+
+## TODO (@peabrainiac)
 * Introduce typeclasses for continuity of other fibrewise algebraic structures and show that
   sections inherit the corresponding structures in these cases.
 * Show that vector bundles satisfy these typeclasses, so that this API in particular applies
@@ -56,7 +61,7 @@ variable {F E}
 
 instance : DFunLike Cₛ⟮F, E⟯ B E where
   coe := ContinuousSection.toFun
-  coe_injective := by rintro ⟨⟩ ⟨⟩ h; congr
+  coe_injective f g _ := by cases f; cases g; congr
 
 variable {s t : Cₛ⟮F, E⟯}
 
@@ -67,11 +72,12 @@ theorem coeFn_mk (s : ∀ b, E b) (hs : Continuous fun b ↦ (⟨b, s b⟩ : Tot
 protected theorem continuous (s : Cₛ⟮F, E⟯) : Continuous fun b ↦ (⟨b, s b⟩ : TotalSpace F E) :=
   s.continuous_toFun
 
-theorem coe_inj ⦃s t : Cₛ⟮F, E⟯⦄ (h : (s : ∀ b, E b) = t) : s = t :=
-  DFunLike.ext' h
+@[simp]
+theorem coe_inj {s t : Cₛ⟮F, E⟯} : (s : ∀ b, E b) = t ↔ s = t :=
+  ⟨fun h ↦ DFunLike.ext' h, fun h ↦ by rw [h]⟩
 
 theorem coe_injective : Injective ((↑) : Cₛ⟮F, E⟯ → ∀ b, E b) :=
-  coe_inj
+  fun _ _ ↦ coe_inj.1
 
 @[ext]
 theorem ext (h : ∀ x, s x = t x) : s = t := DFunLike.ext _ _ h


### PR DESCRIPTION
Define continuous sections of fibre bundles, provide API for sections of trivial bundles, product bundles and pullback bundles, and show that when the bundle carries a continuous fibrewise `G`-action the continuous sections are acted on
by both `G` and `C(B, G)` too.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
Note that `Mathlib.Geometry.Manifold.VectorBundle.ContMDiffSection` already similarly defines $C^n$ sections of vector bundles, which in the case $n=0$ of course specializes to continuous sections. The API here is more general however, because it applies to fibre bundles over any topological space instead of just vector bundles over any manifold.

While `Mathlib.Geometry.Manifold.VectorBundle.ContMDiffSection` shows that $C^n$ sections of any vector bundle form a module, I have not done so here yet. The reason is not just that I wanted to keep the PR short, but also that I do not think vector bundles are the right generality: instead of proving that sections can be added, subtracted, scaled etc. in vector bundles we should introduce typeclasses `ContinuousBundleAdd`, `ContinuousBundleSub` etc. for these operations and prove these lemmas for bundles carrying them. Scalar multiplication is the only operation for which introducing such a typeclass would not make sense because global continuity of a fibrewise action is already equivalent to `ContinuousSMul G (TotalSpace F E)`, so I've already included the lemmas for scalar multiplication here.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
