### PR TITLE
CategoryTheory: add naturality and whiskering reference examples

### DIFF
--- a/Mathlib/CategoryTheory/Functor/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/Basic.lean
@@ -150,6 +150,17 @@ lemma toPrefunctor_injective {F G : C ⥤ D} (h : F.toPrefunctor = G.toPrefuncto
   obtain rfl : @map = @map' := by simpa [Functor.toPrefunctor] using h
   rfl
 
+example (F : C ⥤ D) (X : C) : F.map (𝟙 X) = 𝟙 (F.obj X) := by
+  simp
+
+example (F : C ⥤ D) {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    F.map (f ≫ g) = F.map f ≫ F.map g := by
+  simp
+
+example (F : C ⥤ D) (G : D ⥤ E) (X : C) :
+    (F ⋙ G).map (𝟙 X) = 𝟙 ((F ⋙ G).obj X) := by
+  simp only [Functor.map_id]
+
 end
 
 end Functor

--- a/Mathlib/CategoryTheory/NatTrans.lean
+++ b/Mathlib/CategoryTheory/NatTrans.lean
@@ -74,6 +74,10 @@ attribute [reassoc (attr := simp)] NatTrans.naturality
 
 attribute [grind _=_] NatTrans.naturality
 
+example {F G : C ⥤ D} (η : NatTrans F G) {X Y : C} (f : X ⟶ Y) :
+    η.app X ≫ G.map f = F.map f ≫ η.app Y := by
+  rw [← NatTrans.naturality]
+
 @[to_dual self]
 theorem congr_app {F G : C ⥤ D} {α β : NatTrans F G} (h : α = β) (X : C) : α.app X = β.app X := by
   cat_disch

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -70,6 +70,22 @@ lemma hcomp_id {G H : C ⥤ D} (α : G ⟶ H) (F : D ⥤ E) : α ◫ 𝟙 F = wh
   ext
   simp
 
+example {F G : C ⥤ D} (H : D ⥤ E) (η : F ⟶ G) (X : C) :
+    (whiskerRight η H).app X = H.map (η.app X) := by
+  simp [whiskerRight_app]
+
+example {F : C ⥤ D} (G H : D ⥤ E) (η : G ⟶ H) (X : C) :
+    (whiskerLeft F η).app X = η.app (F.obj X) := by
+  simp [whiskerLeft_app]
+
+example {F G : C ⥤ D} (H : D ⥤ E) (η : F ⟶ G) {X Y : C} (f : X ⟶ Y) :
+    (whiskerRight η H).app X ≫ (G ⋙ H).map f = (F ⋙ H).map f ≫ (whiskerRight η H).app Y := by
+  rw [← NatTrans.naturality]
+
+example {F : C ⥤ D} (G H : D ⥤ E) (η : G ⟶ H) {X Y : C} (f : X ⟶ Y) :
+    (whiskerLeft F η).app X ≫ (F ⋙ H).map f = (F ⋙ G).map f ≫ (whiskerLeft F η).app Y := by
+  rw [← NatTrans.naturality]
+
 variable (C D E)
 
 set_option backward.defeqAttrib.useBackward true in

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -47,6 +47,11 @@ def yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁ where
   map f :=
     { app _ := ↾fun g ↦ g ≫ f }
 
+example {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D] (F : C ⥤ D) {X Y : C}
+    (f : X ⟶ Y) :
+    ((F ⋙ yoneda).map f).app (op (F.obj Y)) = (yoneda.map (F.map f)).app (op (F.obj Y)) := by
+  simp
+
 /-- Unification hint for `(yoneda.obj X).obj (op Y) = Y ⟶ X`. -/
 unif_hint yoneda_obj_obj_eq_hom (X X' Y Y' : C) where
   X ≟ X'


### PR DESCRIPTION
## Summary

- Add a naturality square example in `NatTrans.lean` closing via `rw [← NatTrans.naturality]`.
- Add whiskering component and naturality square examples in `Whiskering.lean` (`whiskerRight_app`, `whiskerLeft_app`, and `rw [← NatTrans.naturality]`).
- Add functoriality reference examples in `Functor/Basic.lean` (`map_id`, `map_comp`, composed-functor `map_id`).
- Add a Yoneda composite-map usage example in `Yoneda.lean`.

These are reference examples from a category-theory proof friction survey; no new lemmas or imports.

## Test plan

- [x] `lake build Mathlib.CategoryTheory.Functor.Basic`
- [x] `lake build Mathlib.CategoryTheory.NatTrans`
- [x] `lake build Mathlib.CategoryTheory.Whiskering`
- [x] `lake build Mathlib.CategoryTheory.Yoneda`
- [ ] No new `import` lines; examples use lemmas already in scope