### PR TITLE
doc(CategoryTheory/Limits): add reference examples for binary products and coproducts

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -1598,5 +1598,30 @@ def BinaryFan.rightUnitor {X : C} {s : Cone (Functor.empty.{0} C)} (P : IsLimit 
       rintro ⟨⟨⟩⟩
 
 end unitor
+
+section ReferenceExamples
+
+/-- The canonical cone for a binary product diagram is a limit. -/
+noncomputable example (X Y : C) [HasBinaryProduct X Y] :
+    IsLimit (limit.cone (pair X Y)) :=
+  limit.isLimit (pair X Y)
+
+/-- Any limit cone for `pair X Y` is isomorphic to the canonical one. -/
+noncomputable example (X Y : C) [HasBinaryProduct X Y] {c : Cone (pair X Y)} (hc : IsLimit c) :
+    c ≅ limit.cone (pair X Y) :=
+  hc.uniqueUpToIso (limit.isLimit (pair X Y))
+
+/-- The canonical cocone for a binary coproduct diagram is a colimit. -/
+noncomputable example (X Y : C) [HasBinaryCoproduct X Y] :
+    IsColimit (colimit.cocone (pair X Y)) :=
+  colimit.isColimit (pair X Y)
+
+/-- Any colimit cocone for `pair X Y` is isomorphic to the canonical one. -/
+noncomputable example (X Y : C) [HasBinaryCoproduct X Y] {c : Cocone (pair X Y)} (hc : IsColimit c) :
+    c ≅ colimit.cocone (pair X Y) :=
+  hc.uniqueUpToIso (colimit.isColimit (pair X Y))
+
+end ReferenceExamples
+
 end CategoryTheory.Limits
 set_option linter.style.longFile 1700

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -1617,7 +1617,8 @@ noncomputable example (X Y : C) [HasBinaryCoproduct X Y] :
   colimit.isColimit (pair X Y)
 
 /-- Any colimit cocone for `pair X Y` is isomorphic to the canonical one. -/
-noncomputable example (X Y : C) [HasBinaryCoproduct X Y] {c : Cocone (pair X Y)} (hc : IsColimit c) :
+noncomputable example (X Y : C) [HasBinaryCoproduct X Y] {c : Cocone (pair X Y)}
+    (hc : IsColimit c) :
     c ≅ colimit.cocone (pair X Y) :=
   hc.uniqueUpToIso (colimit.isColimit (pair X Y))
 


### PR DESCRIPTION
## Summary

Examples-only PR: four `noncomputable example` blocks in a new `section ReferenceExamples` of `BinaryProducts.lean`. No API, automation, or attribute changes.

The lemmas used (`limit.isLimit`, `colimit.isColimit`, `uniqueUpToIso`) are already in Mathlib; these examples document the canonical universal-property pattern for binary (co)product diagrams.

## Examples added

1. Canonical product cone is a limit: `IsLimit (limit.cone (pair X Y))` via `limit.isLimit (pair X Y)`
2. Uniqueness up to iso for limits: `c ≅ limit.cone (pair X Y)` via `hc.uniqueUpToIso (limit.isLimit (pair X Y))`
3. Canonical coproduct cocone is a colimit: `IsColimit (colimit.cocone (pair X Y))` via `colimit.isColimit (pair X Y)`
4. Uniqueness up to iso for colimits: `c ≅ colimit.cocone (pair X Y)` via `hc.uniqueUpToIso (colimit.isColimit (pair X Y))`

## Test plan

- [ ] `lake build Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts`
- [ ] CI green

## Notes

Branch is based on tag `v4.31.0`. Targeting `master` (currently ahead of v4.31.0); the example API matches the current `limit.isLimit` / `colimit.isColimit` / `uniqueUpToIso` names on that release.