### PR TITLE
[Merged by Bors] - feat(Analysis/Complex/ExponentialBounds): add log 4 and log 10 lemmas

### DIFF
--- a/Mathlib/Analysis/Complex/ExponentialBounds.lean
+++ b/Mathlib/Analysis/Complex/ExponentialBounds.lean
@@ -124,7 +124,6 @@ theorem log_five_gt_d9 : 1.6094379123 < log 5 :=
 theorem log_five_lt_d9 : log 5 < 1.6094379126 :=
   lt_of_le_of_lt (sub_le_iff_le_add.1 (abs_sub_le_iff.1 log_five_near_10).1) (by norm_num)
 
-theorem log_ten_eq : log 10 = log 2 + log 5 := by
-  norm_num [← log_mul]
+theorem log_ten_eq : log 10 = log 2 + log 5 := by norm_num [← log_mul]
 
 end Real

--- a/Mathlib/Analysis/Complex/ExponentialBounds.lean
+++ b/Mathlib/Analysis/Complex/ExponentialBounds.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Complex.Exponential
 public import Mathlib.Analysis.SpecialFunctions.Log.Deriv
+public import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 /-!
 # Bounds on specific values of the exponential
@@ -103,6 +104,8 @@ theorem log_three_gt_d9 : 1.0986122885 < log 3 :=
 theorem log_three_lt_d9 : log 3 < 1.0986122888 :=
   lt_of_le_of_lt (sub_le_iff_le_add.1 (abs_sub_le_iff.1 log_three_near_10).1) (by norm_num)
 
+theorem log_four_eq : log 4 = 2 * log 2 := by rw [← log_rpow two_pos]; norm_num
+
 theorem log_five_near_10 : |log 5 - 160943791243 / 100000000000| ≤ 1 / 10 ^ 10 := by
   suffices |log 5 - 160943791243 / 100000000000| ≤
       (4 / 5) ^ 131 / 5⁻¹ + (1 / 10 ^ 10 - (4 / 5) ^ 131 / 5⁻¹) by
@@ -120,5 +123,8 @@ theorem log_five_gt_d9 : 1.6094379123 < log 5 :=
 
 theorem log_five_lt_d9 : log 5 < 1.6094379126 :=
   lt_of_le_of_lt (sub_le_iff_le_add.1 (abs_sub_le_iff.1 log_five_near_10).1) (by norm_num)
+
+theorem log_ten_eq : log 10 = log 2 + log 5 := by
+  rw [← log_mul two_ne_zero (by norm_num)]; norm_num
 
 end Real

--- a/Mathlib/Analysis/Complex/ExponentialBounds.lean
+++ b/Mathlib/Analysis/Complex/ExponentialBounds.lean
@@ -125,6 +125,6 @@ theorem log_five_lt_d9 : log 5 < 1.6094379126 :=
   lt_of_le_of_lt (sub_le_iff_le_add.1 (abs_sub_le_iff.1 log_five_near_10).1) (by norm_num)
 
 theorem log_ten_eq : log 10 = log 2 + log 5 := by
-  rw [← log_mul two_ne_zero (by norm_num)]; norm_num
+  norm_num [← log_mul]
 
 end Real

--- a/Mathlib/Analysis/Complex/ExponentialBounds.lean
+++ b/Mathlib/Analysis/Complex/ExponentialBounds.lean
@@ -104,7 +104,7 @@ theorem log_three_gt_d9 : 1.0986122885 < log 3 :=
 theorem log_three_lt_d9 : log 3 < 1.0986122888 :=
   lt_of_le_of_lt (sub_le_iff_le_add.1 (abs_sub_le_iff.1 log_three_near_10).1) (by norm_num)
 
-theorem log_four_eq : log 4 = 2 * log 2 := by rw [← log_rpow two_pos]; norm_num
+theorem log_four_eq : log 4 = 2 * log 2 := by norm_num [← log_rpow]
 
 theorem log_five_near_10 : |log 5 - 160943791243 / 100000000000| ≤ 1 / 10 ^ 10 := by
   suffices |log 5 - 160943791243 / 100000000000| ≤


### PR DESCRIPTION
---
Adds two small lemmas `log_four_eq` and `log_ten_eq` to `Analysis/Complex/ExponentialBounds.lean`, which decomposes `log 4` and `log 10` into `2 * log 2` and `log 2 + log 5` respectively.  This plays well with the existing lemmas in this file which provide various high precision bounds on `log 2` and `log 5`.  For instance, one can now conclude high precision bounds on `log 10` via `linarith`.

One could of course make similar lemmas for `log 6`, `log 8`, `log 9`, `log 12`, `log 16`, `log 20`, etc., but I believe these two logarithms of composite numbers will be the most commonly used ones (the latter due to conversion between natural logarithms and base ten logarithms).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
