### PR TITLE
perf(Algebra/Ring/Defs): improve `NonUnitalSemiring` and `NonAssocSemiring` definitions

### DIFF
--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -121,11 +121,12 @@ TODO: clean this once https://github.com/leanprover/lean4/issues/2115 is fixed
 class NonUnitalNonAssocSemiring (α : Type u) extends AddCommMonoid α, Distrib α, MulZeroClass α
 
 /-- An associative but not-necessarily unital semiring. -/
-class NonUnitalSemiring (α : Type u) extends NonUnitalNonAssocSemiring α, SemigroupWithZero α
+class NonUnitalSemiring (α : Type u) extends AddCommMonoid α, SemigroupWithZero α,
+    NonUnitalNonAssocSemiring α
 
 /-- A unital but not-necessarily-associative semiring. -/
-class NonAssocSemiring (α : Type u) extends NonUnitalNonAssocSemiring α, MulZeroOneClass α,
-    AddCommMonoidWithOne α
+class NonAssocSemiring (α : Type u) extends AddCommMonoid α, MulZeroOneClass α,
+    AddCommMonoidWithOne α, NonUnitalNonAssocSemiring α
 
 /-- A not-necessarily-unital, not-necessarily-associative ring. -/
 class NonUnitalNonAssocRing (α : Type u) extends AddCommGroup α, NonUnitalNonAssocSemiring α
@@ -148,10 +149,16 @@ class Semiring (α : Type u) extends AddCommMonoid α, MonoidWithZero α, NonUni
 class Ring (R : Type u) extends Semiring R, AddCommGroup R, AddGroupWithOne R
 
 -- Add some short-cut instances to avoid going through the less used ring type classes.
+instance [NonUnitalSemiring α] : Distrib α := inferInstance
+instance [NonAssocSemiring α] : Distrib α := inferInstance
 instance [Semiring α] : Distrib α := inferInstance
+instance [NonUnitalSemiring α] : MulZeroClass α := inferInstance
+instance [NonAssocSemiring α] : MulZeroClass α := inferInstance
 instance [Semiring α] : MulZeroClass α := inferInstance
+instance [Semiring α] : SemigroupWithZero α := inferInstance
 instance [Semiring α] : MulZeroOneClass α := inferInstance
-attribute [instance] Semiring.toAddCommMonoid Semiring.toMonoid
+instance [Semiring α] : AddCommMonoidWithOne α := inferInstance
+attribute [instance] NonAssocSemiring.toAddCommMonoid Semiring.toAddCommMonoid Semiring.toMonoid
 
 /-!
 ### Semirings

--- a/Mathlib/Algebra/Ring/Ext.lean
+++ b/Mathlib/Algebra/Ring/Ext.lean
@@ -71,8 +71,8 @@ namespace NonUnitalNonAssocSemiring
 theorem toDistrib_injective : Function.Injective (@toDistrib R) := by
   intro _ _ h
   ext x y
-  · exact congrArg (·.toAdd.add x y) h
-  · exact congrArg (·.toMul.mul x y) h
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 end NonUnitalNonAssocSemiring
 
@@ -81,7 +81,10 @@ namespace NonUnitalSemiring
 
 theorem toNonUnitalNonAssocSemiring_injective :
     Function.Injective (@toNonUnitalNonAssocSemiring R) := by
-  rintro ⟨⟩ ⟨⟩ _; congr
+  rintro ⟨⟩ ⟨⟩ h
+  congr
+  · ext x y; exact congrArg (·.add x y) h
+  · ext x y; exact congrArg (·.mul x y) h
 
 @[ext] theorem ext ⦃inst₁ inst₂ : NonUnitalSemiring R⦄
     (h_add : local_hAdd[R, inst₁] = local_hAdd[R, inst₂])
@@ -135,28 +138,30 @@ defined in `Mathlib/Algebra/GroupWithZero/Defs.lean` as well. -/
     (h_add : local_hAdd[R, inst₁] = local_hAdd[R, inst₂])
     (h_mul : local_hMul[R, inst₁] = local_hMul[R, inst₂]) :
     inst₁ = inst₂ := by
-  have h : inst₁.toNonUnitalNonAssocSemiring = inst₂.toNonUnitalNonAssocSemiring := by
+  have h : inst₁.toAddCommMonoid = inst₂.toAddCommMonoid := by
     ext : 1 <;> assumption
   have h_zero : (inst₁.toMulZeroClass).toZero.zero = (inst₂.toMulZeroClass).toZero.zero :=
-    congrArg (fun inst => (inst.toMulZeroClass).toZero.zero) h
-  have h_one' : (inst₁.toMulZeroOneClass).toMulOneClass.toOne
-                = (inst₂.toMulZeroOneClass).toMulOneClass.toOne := by
-    congr 2; ext : 1; exact h_mul
+    congrArg (fun inst => inst.toZero.zero) h
+  have h_mul_one : (inst₁.toMulZeroOneClass).toMulOneClass
+                = (inst₂.toMulZeroOneClass).toMulOneClass := by
+    ext : 1; exact h_mul
   have h_one : (inst₁.toMulZeroOneClass).toMulOneClass.toOne.one
-               = (inst₂.toMulZeroOneClass).toMulOneClass.toOne.one :=
-    congrArg (@One.one R) h_one'
+               = (inst₂.toMulZeroOneClass).toMulOneClass.toOne.one := by
+    congr
   have : inst₁.toAddCommMonoidWithOne = inst₂.toAddCommMonoidWithOne := by
     ext : 1 <;> assumption
   have : inst₁.toNatCast = inst₂.toNatCast :=
     congrArg (·.toNatCast) this
-  -- Split into `NonUnitalNonAssocSemiring`, `One` and `natCast` instances.
+  -- Split into `AddCommMonoid`, `MulOne` and `NatCast` instances.
   cases inst₁; cases inst₂
   congr
 
 theorem toNonUnitalNonAssocSemiring_injective :
     Function.Injective (@toNonUnitalNonAssocSemiring R) := by
-  intro _ _ _
-  ext <;> congr
+  rintro _ _ h
+  ext x y
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 end NonAssocSemiring
 
@@ -176,8 +181,8 @@ theorem toNonUnitalNonAssocSemiring_injective :
   intro _ _ h
   -- Use above extensionality lemma to prove injectivity by showing that `h_add` and `h_mul` hold.
   ext x y
-  · exact congrArg (·.toAdd.add x y) h
-  · exact congrArg (·.toMul.mul x y) h
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 end NonUnitalNonAssocRing
 
@@ -198,13 +203,15 @@ theorem toNonUnitalSemiring_injective :
     Function.Injective (@toNonUnitalSemiring R) := by
   intro _ _ h
   ext x y
-  · exact congrArg (·.toAdd.add x y) h
-  · exact congrArg (·.toMul.mul x y) h
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 theorem toNonUnitalNonAssocring_injective :
     Function.Injective (@toNonUnitalNonAssocRing R) := by
-  intro _ _ _
-  ext <;> congr
+  rintro _ _ h
+  ext x y
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 end NonUnitalRing
 
@@ -262,13 +269,15 @@ theorem toNonAssocSemiring_injective :
     Function.Injective (@toNonAssocSemiring R) := by
   intro _ _ h
   ext x y
-  · exact congrArg (·.toAdd.add x y) h
-  · exact congrArg (·.toMul.mul x y) h
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 theorem toNonUnitalNonAssocring_injective :
     Function.Injective (@toNonUnitalNonAssocRing R) := by
-  intro _ _ _
-  ext <;> congr
+  rintro _ _ h
+  ext x y
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 end NonAssocRing
 
@@ -296,15 +305,15 @@ theorem toNonUnitalSemiring_injective :
     Function.Injective (@toNonUnitalSemiring R) := by
   intro _ _ h
   ext x y
-  · exact congrArg (·.toAdd.add x y) h
-  · exact congrArg (·.toMul.mul x y) h
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 theorem toNonAssocSemiring_injective :
     Function.Injective (@toNonAssocSemiring R) := by
   intro _ _ h
   ext x y
-  · exact congrArg (·.toAdd.add x y) h
-  · exact congrArg (·.toMul.mul x y) h
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 end Semiring
 
@@ -333,22 +342,22 @@ theorem toNonUnitalRing_injective :
     Function.Injective (@toNonUnitalRing R) := by
   intro _ _ h
   ext x y
-  · exact congrArg (·.toAdd.add x y) h
-  · exact congrArg (·.toMul.mul x y) h
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 theorem toNonAssocRing_injective :
     Function.Injective (@toNonAssocRing R) := by
   intro _ _ h
   ext x y
-  · exact congrArg (·.toAdd.add x y) h
-  · exact congrArg (·.toMul.mul x y) h
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 theorem toSemiring_injective :
     Function.Injective (@toSemiring R) := by
   intro _ _ h
   ext x y
-  · exact congrArg (·.toAdd.add x y) h
-  · exact congrArg (·.toMul.mul x y) h
+  · exact congrArg (·.add x y) h
+  · exact congrArg (·.mul x y) h
 
 end Ring
 


### PR DESCRIPTION
This PR redefines `NonUnitalSemiring` and `NonAssocSemiring` in the same way that `Semiring` was recently redefined, to improve performance.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
