### PR TITLE
[Merged by Bors] - feat(FinitelyPresentedGroup): comap of finitely generated normal subgroup

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -528,6 +528,13 @@ theorem conj_mem_conjugatesOfSet {x c : G} :
   rcases mem_conjugatesOfSet_iff.1 H with ⟨a, h₁, h₂⟩
   exact mem_conjugatesOfSet_iff.2 ⟨a, h₁, h₂.trans (isConj_iff.2 ⟨c, rfl⟩)⟩
 
+/-- The set of conjugates of the union of two sets is the union of the conjugates -/
+@[to_additive /-- The set of additive conjugates of the union of two sets is the union
+of the additive conjugates. -/]
+theorem conjugatesOfSet_union {G : Type*} [Group G] (s t : Set G) :
+    conjugatesOfSet (s ∪ t) = conjugatesOfSet s ∪ conjugatesOfSet t := by
+  simp_rw [conjugatesOfSet, Set.biUnion_union]
+
 end Group
 
 namespace Subgroup
@@ -619,6 +626,12 @@ theorem normalClosure_closure_eq_normalClosure {s : Set G} :
 @[to_additive (attr := simp)]
 lemma normalClosure_empty : normalClosure (∅ : Set G) = (⊥ : Subgroup G) := by
   rw [← normalClosure_closure_eq_normalClosure, closure_empty, normalClosure_eq_self]
+
+/-- The normal closure of the union of sets is the join of the normal closures of each set. -/
+@[to_additive]
+theorem normalClosure_union {G : Type*} [Group G] (s t : Set G) :
+    normalClosure (s ∪ t) = normalClosure s ⊔ normalClosure t := by
+  simp_rw [normalClosure, Group.conjugatesOfSet_union, closure_union]
 
 /-- The normal core of a subgroup `H` is the largest normal subgroup of `G` contained in `H`,
 as shown by `Subgroup.normalCore_eq_iSup`. -/

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -98,6 +98,14 @@ theorem equiv (iso : G ≃* H) (h : IsFinitelyPresented G) : IsFinitelyPresented
   refine ⟨n, (iso : G →* H).comp φ, iso.surjective.comp hφsurj, ?_⟩
   rwa [φ.ker_mulEquiv_comp iso]
 
+theorem of_surjective [hG : IsFinitelyPresented G] (f : G →* H)
+    (hf_surj : Function.Surjective f) (hf_ker : f.ker.IsNormalClosureFG) :
+    IsFinitelyPresented H := by
+  obtain ⟨n, φ, hφ_surj, hφ_ker⟩ := hG.out
+  refine ⟨n, f.comp φ, hf_surj.comp hφ_surj, ?_⟩
+  rw [← MonoidHom.comap_ker]
+  exact hf_ker.comap hφ_surj hφ_ker
+
 /-- A free group with a finite number of generators is finitely presented. -/
 @[to_additive /-- A free additive group with a finite number of generators is finitely presented. -/
 ]

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -51,6 +51,23 @@ protected theorem map {N : Subgroup G} (hN : N.IsNormalClosureFG)
   refine ⟨f '' S, hSfinite.image _, ?_⟩
   rw [← hSclosure, Subgroup.map_normalClosure _ _ hf]
 
+open Function Set Subgroup in
+/-- The preimage of a finitely generated normal subgroup by a surjective homomorphism with
+a finitely generated kernel is finitely generated. -/
+@[to_additive /-- The preimage of a finitely generated normal subgroup by a surjective additive
+homomorphism with a finitely generated kernel is finitely generated. -/]
+protected theorem comap {N : Subgroup H} (hN : N.IsNormalClosureFG)
+    {f : G →* H} (hf : Surjective f) (hf' : f.ker.IsNormalClosureFG) :
+    (N.comap f).IsNormalClosureFG := by
+  obtain ⟨S, hS_fin, hS⟩ := hN
+  obtain ⟨T, hT_fin, hT⟩ := hf'
+  have : ∃ S', S'.Finite ∧ f '' S' = S :=
+    ⟨surjInv hf '' S, hS_fin.image _, by rw [← image_comp, comp_surjInv, image_id]⟩
+  clear hS_fin
+  obtain ⟨S, hS_fin, rfl⟩ := this
+  refine ⟨S ∪ T, hS_fin.union hT_fin, ?_⟩
+  rw [← hS, ← map_normalClosure S f hf, comap_map_eq, ← hT, normalClosure_union]
+
 /-- The trivial group is the normal closure of a finite set of relations. -/
 @[to_additive /-- The trivial additive group is the normal closure of a finite set of relations. -/]
 protected theorem bot : (⊥ : Subgroup G).IsNormalClosureFG :=


### PR DESCRIPTION
@tb65536 suggested this addition for the FinitelyPresentedGroup project in  [#40200](https://github.com/leanprover-community/mathlib4/pull/40200). 

[#38114](https://github.com/leanprover-community/mathlib4/pull/38114) will also be simplified using this theorem.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
