### PR TITLE
[Merged by Bors] - feat(NumberTheory/GaussSum): results on Gauss sums of trivial characters

### DIFF
--- a/Mathlib/NumberTheory/GaussSum.lean
+++ b/Mathlib/NumberTheory/GaussSum.lean
@@ -96,6 +96,40 @@ lemma star_gaussSum_eq (χ : MulChar R ℂ) (ψ : AddChar R ℂ) :
 end GaussSumDef
 
 /-!
+### Gauss sums of trivial characters
+-/
+
+section GaussSumTrivial
+
+variable {R : Type u} [CommRing R] [Fintype R] {R' : Type v} [CommRing R']
+
+/-- The Gauss sum of the two trivial characters is the cardinality of the unit group of `R`. -/
+theorem gaussSum_one_one : gaussSum (1 : MulChar R R') (1 : AddChar R R') = Nat.card Rˣ := by
+  classical
+  simp [gaussSum, MulChar.sum_one_eq_card_units]
+
+/-- The Gauss sum of a nontrivial multiplicative character and the trivial additive character
+vanishes. -/
+theorem gaussSum_one_right [IsDomain R'] {χ : MulChar R R'} (hχ : χ ≠ 1) :
+    gaussSum χ (1 : AddChar R R') = 0 := by
+  simpa [gaussSum] using MulChar.sum_eq_zero_of_ne_one hχ
+
+/-- The Gauss sum of the trivial multiplicative character and a nontrivial additive character,
+over a finite field, is `-1`. -/
+theorem gaussSum_one_left {R : Type u} [Field R] [Fintype R] {R' : Type v} [CommRing R']
+    [IsDomain R'] {ψ : AddChar R R'} (hψ : ψ ≠ 1) : gaussSum (1 : MulChar R R') ψ = -1 := by
+  classical
+  rw [gaussSum, ← Finset.univ.add_sum_erase _ (Finset.mem_univ 0), MulChar.map_zero, zero_mul,
+    zero_add]
+  have : ∀ x ∈ Finset.univ.erase (0 : R), (1 : MulChar R R') x = 1 :=
+    fun x hx ↦ MulChar.one_apply <| isUnit_iff_ne_zero.mpr <| Finset.ne_of_mem_erase hx
+  simp_rw +contextual [this, one_mul]
+  rw [Finset.sum_erase_eq_sub (Finset.mem_univ 0), AddChar.map_zero_eq_one, AddChar.sum_eq_ite,
+    ite_sub, zero_sub, if_neg (by rwa [← AddChar.one_eq_zero])]
+
+end GaussSumTrivial
+
+/-!
 ### The product of two Gauss sums
 -/
 

--- a/Mathlib/NumberTheory/GaussSum.lean
+++ b/Mathlib/NumberTheory/GaussSum.lean
@@ -114,10 +114,16 @@ theorem gaussSum_one_right [IsDomain R'] {χ : MulChar R R'} (hχ : χ ≠ 1) :
     gaussSum χ (1 : AddChar R R') = 0 := by
   simpa [gaussSum] using MulChar.sum_eq_zero_of_ne_one hχ
 
+end GaussSumTrivial
+
+section GaussSumTrivialField
+
+variable {R : Type u} [Field R] [Fintype R] {R' : Type v} [CommRing R'] [IsDomain R']
+
 /-- The Gauss sum of the trivial multiplicative character and a nontrivial additive character,
 over a finite field, is `-1`. -/
-theorem gaussSum_one_left {R : Type u} [Field R] [Fintype R] {R' : Type v} [CommRing R']
-    [IsDomain R'] {ψ : AddChar R R'} (hψ : ψ ≠ 1) : gaussSum (1 : MulChar R R') ψ = -1 := by
+theorem gaussSum_one_left {ψ : AddChar R R'} (hψ : ψ ≠ 1) :
+    gaussSum (1 : MulChar R R') ψ = -1 := by
   classical
   rw [gaussSum, ← Finset.univ.add_sum_erase _ (Finset.mem_univ 0), MulChar.map_zero, zero_mul,
     zero_add]
@@ -127,7 +133,7 @@ theorem gaussSum_one_left {R : Type u} [Field R] [Fintype R] {R' : Type v} [Comm
   rw [Finset.sum_erase_eq_sub (Finset.mem_univ 0), AddChar.map_zero_eq_one, AddChar.sum_eq_ite,
     ite_sub, zero_sub, if_neg (by rwa [← AddChar.one_eq_zero])]
 
-end GaussSumTrivial
+end GaussSumTrivialField
 
 /-!
 ### The product of two Gauss sums

--- a/Mathlib/NumberTheory/GaussSum.lean
+++ b/Mathlib/NumberTheory/GaussSum.lean
@@ -101,9 +101,10 @@ end GaussSumDef
 
 section GaussSumTrivial
 
-variable {R : Type u} [CommRing R] [Fintype R] {R' : Type v} [CommRing R']
+variable {R R' : Type*} [CommRing R] [Fintype R] [CommRing R']
 
 /-- The Gauss sum of the two trivial characters is the cardinality of the unit group of `R`. -/
+@[simp]
 theorem gaussSum_one_one : gaussSum (1 : MulChar R R') (1 : AddChar R R') = Nat.card Rˣ := by
   classical
   simp [gaussSum, MulChar.sum_one_eq_card_units]
@@ -118,20 +119,22 @@ end GaussSumTrivial
 
 section GaussSumTrivialField
 
-variable {R : Type u} [Field R] [Fintype R] {R' : Type v} [CommRing R'] [IsDomain R']
+variable {R R' : Type*} [Field R] [Fintype R] [CommRing R'] [IsDomain R']
 
 /-- The Gauss sum of the trivial multiplicative character and a nontrivial additive character,
 over a finite field, is `-1`. -/
 theorem gaussSum_one_left {ψ : AddChar R R'} (hψ : ψ ≠ 1) :
     gaussSum (1 : MulChar R R') ψ = -1 := by
   classical
-  rw [gaussSum, ← Finset.univ.add_sum_erase _ (Finset.mem_univ 0), MulChar.map_zero, zero_mul,
-    zero_add]
-  have : ∀ x ∈ Finset.univ.erase (0 : R), (1 : MulChar R R') x = 1 :=
-    fun x hx ↦ MulChar.one_apply <| isUnit_iff_ne_zero.mpr <| Finset.ne_of_mem_erase hx
-  simp_rw +contextual [this, one_mul]
-  rw [Finset.sum_erase_eq_sub (Finset.mem_univ 0), AddChar.map_zero_eq_one, AddChar.sum_eq_ite,
-    ite_sub, zero_sub, if_neg (by rwa [← AddChar.one_eq_zero])]
+  simp only [gaussSum, ← add_eq_zero_iff_eq_neg]
+  calc ∑ a, (1 : MulChar R R') a * ψ a + 1
+  _ = ∑ a ∈ {0}ᶜ, (1 : MulChar R R') a * ψ a + 1 := by
+    simp [← ({0} : Finset R).sum_compl_add_sum]
+  _ = ∑ a ∈ {0}ᶜ, ψ a + ψ 0 := by
+    congr! <;> aesop (add simp MulChar.one_apply)
+  _ = 0 := by
+    rw [← AddChar.sum_eq_zero_of_ne_one hψ, ← Finset.sum_compl_add_sum (s := {0})]
+    simp
 
 end GaussSumTrivialField
 


### PR DESCRIPTION
Add the special values of the Gauss sum when one or both of the characters is trivial:

* `gaussSum_one_one`: the Gauss sum of the two trivial characters equals the number of units of `R`;
* `gaussSum_one_right`: the Gauss sum of a nontrivial multiplicative character and the trivial additive character vanishes;
* `gaussSum_one_left`: the Gauss sum of the trivial multiplicative character and a nontrivial additive character, over a finite field, equals `-1`.

:robot: This PR was extracted from the [SKW project](https://github.com/xroblot/SKW) by Claude.