### PR TITLE
feat: `EnvT` for running actions that take `MonadEnv m`

### DIFF
--- a/Mathlib/Lean/Environment.lean
+++ b/Mathlib/Lean/Environment.lean
@@ -57,6 +57,7 @@ end Environment
 
 public section envT
 
+-- I kind of want a "one-way abbrev" here, where `EnvT` has all the instances `StateT Environment` has but not vice-versa...
 /-- An abbreviation for `StateT Environment` with a `MonadEnv` instance. -/
 abbrev EnvT := StateT Environment
 

--- a/Mathlib/Lean/Environment.lean
+++ b/Mathlib/Lean/Environment.lean
@@ -53,4 +53,49 @@ def findTheoremConstVal? (env : Environment) (decl : Name)
 
 end constKind
 
-end Lean.Environment
+end Environment
+
+public section envT
+
+/-- An abbreviation for `StateT Environment` with a `MonadEnv` instance. -/
+abbrev EnvT := StateT Environment
+
+instance {m} [Monad m] : MonadEnv (EnvT m) where
+  getEnv := get
+  modifyEnv := modify
+
+/-- Runs an `EnvT := StateT Environment` action with the supplied `Environment`.
+
+A monad-generic action `x` of type `[MonadEnv m] → m α` may be run with `EnvT.run (env := env) x`,
+or alternatively with dot notation as `env.run x` via the alias `Environment.run`. See also
+`env.runPure` for use in pure contexts (`m := Id`). -/
+nonrec def EnvT.run.{v} {m : Type → Type v} {α : Type} (x : EnvT m α) (env : Environment) :
+    m (α × Environment) := x.run env
+
+/-- Runs an `EnvT := StateT Environment` action with the supplied `Environment`, discarding the
+resulting `Environment`.
+
+A monad-generic action `x` of type `[MonadEnv m] → m α` may be run with `EnvT.run' (env := env) x`,
+or alternatively with dot notation as `env.run' x` via the alias `Environment.run'`. See also
+`env.runPure'` for use in pure contexts (`m := Id`) without the `Id` annotation, for convenience. -/
+nonrec def EnvT.run'.{v} {m : Type → Type v} [Functor m] {α : Type} (x : EnvT m α)
+    (env : Environment) : m α := x.run' env
+
+namespace Environment
+
+export EnvT (run run')
+
+/-- Runs a monad-generic action `x : [MonadEnv m] → m α` with `env` as the state of the monad. -/
+@[inline] def runPure {α : Type} (x : EnvT Id α)
+    (env : Environment) : α × Environment := x.run env
+
+/-- Runs a monad-generic action `x : [MonadEnv m] → m α` with `env` as the state of the monad,
+discarding the resulting environment. -/
+@[inline] def runPure' {α : Type} (x : EnvT Id α)
+    (env : Environment) : α := x.run' env
+
+end Environment
+
+end envT
+
+end Lean


### PR DESCRIPTION
This PR allows us to conveniently run monad-generic actions that take in `MonadEnv m` in contexts where we have an explicit `env` available but not the appropriate monad, e.g. pure contexts or `IO` after `importModules`:
```
-- in a pure context:
let ranges? := env.runPure' <| findDeclarationRangesCore? decl
```
```
-- in IO, where `findDeclarationRanges?` requires a lift from BaseIO:
let ranges? ← env.run' <| findDeclarationRanges? decl
```

Discussion thread on zulip [here](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Equipping.20a.20monad.20with.20MonadEnv/with/604311225)

---

I've run into this a few times (see e.g. `findDeclarationRanges?`); it would be nice to have an escape hatch!

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
