### PR TITLE
[Merged by Bors] - ci: make lake cache shadow shells uniform

### DIFF
--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -126,7 +126,6 @@ jobs:
       - name: install elan
         shell: bash
         run: |
-          set -o pipefail
           curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
           chmod +x elan-init.sh
           ./elan-init.sh -y --default-toolchain none
@@ -275,6 +274,11 @@ jobs:
     env:
       LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
       LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
+    defaults:
+      run:
+        # `shell: bash` adds `-o pipefail`; the implicit `bash -e` default lacks
+        # it, masking failures before `| tee` (e.g. `lake cache put-staged | tee`).
+        shell: bash
     steps:
       - name: Checkout mathlib (for lean-toolchain pin)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -286,7 +290,6 @@ jobs:
       - name: install elan + matching lake
         shell: bash
         run: |
-          set -o pipefail
           curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
           chmod +x elan-init.sh
           ./elan-init.sh -y --default-toolchain none
@@ -336,7 +339,8 @@ jobs:
           base="${AUTH%/artifacts}/analysis"
           sha="${{ needs.build_and_stage.outputs.sha }}"
           sig=(--aws-sigv4 aws:amz:auto:s3 --user "$LAKE_CACHE_KEY")
-          grep -oE 'uploaded artifact [0-9a-f]+' /tmp/put.log | awk '{print $3}' | sort -u > /tmp/today.txt
+          # grep exits 1 on no match (handled by the total==0 branch); tolerate it under pipefail.
+          grep -oE 'uploaded artifact [0-9a-f]+' /tmp/put.log | awk '{print $3}' | sort -u > /tmp/today.txt || true
           total=$(wc -l < /tmp/today.txt)
           if [ "$total" -eq 0 ]; then
             echo "::warning::no uploaded artifacts parsed from put.log — skipping carryover (manifest/pointer left unchanged)"
@@ -408,6 +412,11 @@ jobs:
       # authenticated S3 API endpoint used by the `upload` job's PUTs.
       LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
       LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+    defaults:
+      run:
+        # `shell: bash` adds `-o pipefail`; without it a `lake build | tee` failure
+        # is hidden and the provenance grep reads 0 rebuilds and reports success.
+        shell: bash
     steps:
       - name: Checkout mathlib
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -418,7 +427,6 @@ jobs:
 
       - name: install elan
         run: |
-          set -o pipefail
           curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
           chmod +x elan-init.sh
           ./elan-init.sh -y --default-toolchain none
@@ -458,7 +466,8 @@ jobs:
           # Artifacts fetched here = the root-package outputs served from cache
           # (a non-verbose build replays them silently). Hand the count to the
           # provenance step.
-          FETCHED=$(find ~/.elan/toolchains -name '*.ltar' 2>/dev/null | wc -l)
+          # `|| true`: an informational count must not trip pipefail if find fails.
+          FETCHED=$(find ~/.elan/toolchains -name '*.ltar' 2>/dev/null | wc -l || true)
           echo "ltar count after get: $FETCHED"
           echo "FETCHED_ARTIFACTS=$FETCHED" >> "$GITHUB_ENV"
 

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -62,6 +62,10 @@ concurrency:
   group: lake-cache-shadow-${{ inputs.mathlib_ref || 'master' }}
   cancel-in-progress: false
 
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
 env:
   # Scope prefix for all puts and gets in this workflow. Namespaces the
   # workflow's artifacts within the cache bucket.
@@ -87,7 +91,7 @@ jobs:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI --env LAKE_CACHE_DIR --env LAKE_NO_CACHE --env STAGE_TARGETS --env SHADOW_SCOPE -- bash -euxo pipefail {0}
     steps:
       - name: job info
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: echo "::notice::Lake cache shadow on ref ${{ inputs.mathlib_ref || 'master' }} run ${{ github.run_id }}"
 
       - name: Setup jq
@@ -108,7 +112,7 @@ jobs:
 
       - name: Resolve sha & toolchain
         id: resolve
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: |
           cd pr-branch
           SHA="$(git rev-parse HEAD)"
@@ -117,14 +121,14 @@ jobs:
           echo "toolchain=$TC" >> "$GITHUB_OUTPUT"
 
       - name: Create empty directories (landrun prerequisites)
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: |
           mkdir -p pr-branch/.lake/
           mkdir -p .cache/mathlib/
           mkdir -p _work
 
       - name: install elan
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: |
           curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
           chmod +x elan-init.sh
@@ -132,7 +136,7 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - name: set toolchain directory
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: |
           cd pr-branch
           LAKE_PATH=$(elan which lake)
@@ -140,7 +144,7 @@ jobs:
           echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> "$GITHUB_ENV"
 
       - name: set LEAN_SRC_PATH
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: |
           cd pr-branch
           LEAN_SRC_PATH=".:$TOOLCHAIN_DIR/src/lean/lake"
@@ -153,7 +157,7 @@ jobs:
           echo "LEAN_SRC_PATH=$LEAN_SRC_PATH" >> "$GITHUB_ENV"
 
       - name: build tools-branch tools
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: |
           cd tools-branch
           lake build cache
@@ -165,13 +169,13 @@ jobs:
           lake env
 
       - name: Hydrate .lake/build via legacy cache
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: |
           cd pr-branch
           ../tools-branch/.lake/build/bin/cache get
 
       - name: Patch lakefile to enable Lake's artifact cache
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: |
           cd pr-branch
           if grep -q 'enableArtifactCache' lakefile.lean; then
@@ -227,7 +231,7 @@ jobs:
       # write to it. Same pattern as build_template.yml uses for the legacy
       # cache-staging dir.
       - name: Create staging directory
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: mkdir -p lake-cache-staging
 
       - name: Stage cache for upload
@@ -244,7 +248,7 @@ jobs:
       # free-tier / lifecycle budget. Logs the size first, so a trip still tells
       # us how big the build got.
       - name: Guard upload size (bail if staging > 1 GB)
-        shell: bash
+        shell: bash -euo pipefail {0}
         run: |
           MAX=$((1 * 1000 * 1000 * 1000))   # 1 GB — ~2.5x the measured ~389 MB full build (runaway guard)
           BYTES=$(du -sb lake-cache-staging | cut -f1)
@@ -274,11 +278,6 @@ jobs:
     env:
       LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
       LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
-    defaults:
-      run:
-        # `shell: bash` adds `-o pipefail`; the implicit `bash -e` default lacks
-        # it, masking failures before `| tee` (e.g. `lake cache put-staged | tee`).
-        shell: bash
     steps:
       - name: Checkout mathlib (for lean-toolchain pin)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -288,7 +287,6 @@ jobs:
           fetch-depth: 1
 
       - name: install elan + matching lake
-        shell: bash
         run: |
           curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
           chmod +x elan-init.sh
@@ -412,11 +410,6 @@ jobs:
       # authenticated S3 API endpoint used by the `upload` job's PUTs.
       LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
       LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
-    defaults:
-      run:
-        # `shell: bash` adds `-o pipefail`; without it a `lake build | tee` failure
-        # is hidden and the provenance grep reads 0 rebuilds and reports success.
-        shell: bash
     steps:
       - name: Checkout mathlib
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -523,7 +516,6 @@ jobs:
     steps:
       - name: Compose Zulip message
         id: compose
-        shell: bash
         env:
           BUILD: ${{ needs.build_and_stage.result }}
           UPLOAD: ${{ needs.upload.result }}


### PR DESCRIPTION
Sets one workflow-level default shell (`bash -euo pipefail {0}`) so every `run` step shares the same strict mode, instead of relying on the implicit per-step `shell: bash`. `upload`/`consume`/`report` inherit it; `build_and_stage` keeps its landrun sandbox as its job default, and its setup steps spell out the same flags to opt out of the sandbox.

This also fixes some observed issues related to not passing pipefail in places.