### PR TITLE
[Merged by Bors] - feat(Geometry/Manifold/Notation): add (d)elaborators for `UniqueMDiffOn` and `UniqueMDiffWithinAt`

### DIFF
--- a/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
@@ -69,7 +69,7 @@ protected theorem ContMDiffWithinAt.mfderivWithin {x₀ : N} {f : N → M → M'
     {t : Set N} {u : Set M}
     (hf : CMDiffAt[t ×ˢ u] n (Function.uncurry f) (x₀, g x₀))
     (hg : CMDiffAt[t] m g x₀) (hx₀ : x₀ ∈ t)
-    (hu : MapsTo g t u) (hmn : m + 1 ≤ n) (h'u : UniqueMDiffOn I u) :
+    (hu : MapsTo g t u) (hmn : m + 1 ≤ n) (h'u : UniqueMDiff[u]) :
     CMDiffAt[t] m (inTangentCoordinates I I' g (fun x ↦ f x (g x))
       (fun x ↦ mfderiv[u] (f x) (g x)) x₀) x₀ := by
   -- first localize the result to a smaller set, to make sure everything happens in chart domains
@@ -148,8 +148,7 @@ protected theorem ContMDiffWithinAt.mfderivWithin {x₀ : N} {f : N → M → M'
   apply nhdsWithin_mono _ ht't
   filter_upwards [h2f, h4f, h2g, self_mem_nhdsWithin] with x hx h'x h2 hxt
   have h1 : g x ∈ u := hu hxt
-  have h3 : UniqueMDiffWithinAt 𝓘(𝕜, E)
-      ((extChartAt I (g x₀)).target ∩ (extChartAt I (g x₀)).symm ⁻¹' u)
+  have h3 : UniqueMDiffAt[(extChartAt I (g x₀)).target ∩ (extChartAt I (g x₀)).symm ⁻¹' u]
       ((extChartAt I (g x₀)) (g x)) := by
     apply UniqueDiffWithinAt.uniqueMDiffWithinAt
     apply UniqueMDiffOn.uniqueDiffOn_target_inter h'u
@@ -191,7 +190,7 @@ This is a special case of `ContMDiffWithinAt.mfderivWithin` where `f` does not c
 parameters and `g = id`.
 -/
 theorem ContMDiffWithinAt.mfderivWithin_const {x₀ : M} {f : M → M'}
-    (hf : CMDiffAt[s] n f x₀) (hmn : m + 1 ≤ n) (hx : x₀ ∈ s) (hs : UniqueMDiffOn I s) :
+    (hf : CMDiffAt[s] n f x₀) (hmn : m + 1 ≤ n) (hx : x₀ ∈ s) (hs : UniqueMDiff[s]) :
     CMDiffAt[s] m (inTangentCoordinates I I' id f (mfderiv[s] f) x₀) x₀ := by
   have : CMDiffAt[s ×ˢ s] n (fun x : M × M ↦ f x.2) (x₀, x₀) :=
     hf.comp (x₀, x₀) contMDiffWithinAt_snd mapsTo_snd_prod
@@ -210,7 +209,7 @@ theorem ContMDiffWithinAt.mfderivWithin_apply {x₀ : N'}
     (hf : CMDiffAt[t ×ˢ u] n (Function.uncurry f) (g₁ x₀, g (g₁ x₀)))
     (hg : CMDiffAt[t] m g (g₁ x₀)) (hg₁ : CMDiffAt[v] m g₁ x₀)
     (hg₂ : CMDiffAt[v] m g₂ x₀) (hmn : m + 1 ≤ n) (h'g₁ : MapsTo g₁ v t)
-    (hg₁x₀ : g₁ x₀ ∈ t) (h'g : MapsTo g t u) (hu : UniqueMDiffOn I u) :
+    (hg₁x₀ : g₁ x₀ ∈ t) (h'g : MapsTo g t u) (hu : UniqueMDiff[u]) :
     CMDiffAt[v] m (fun x ↦ (inTangentCoordinates I I' g (fun x ↦ f x (g x))
       (fun x ↦ mfderiv[u] (f x) (g x)) (g₁ x₀) (g₁ x)) (g₂ x)) x₀ :=
   ((hf.mfderivWithin hg hg₁x₀ h'g hmn hu).comp_of_eq hg₁ h'g₁ rfl).clm_apply hg₂
@@ -273,7 +272,7 @@ variable [Is : IsManifold I 1 M] [I's : IsManifold I' 1 M']
 /-- If a function is `C^n` on a domain with unique derivatives, then its bundled derivative
 is `C^m` when `m+1 ≤ n`. -/
 theorem ContMDiffOn.contMDiffOn_tangentMapWithin
-    (hf : CMDiff[s] n f) (hmn : m + 1 ≤ n) (hs : UniqueMDiffOn I s) :
+    (hf : CMDiff[s] n f) (hmn : m + 1 ≤ n) (hs : UniqueMDiff[s]) :
     CMDiff[(π E (TangentSpace I) ⁻¹' s)] m (tangentMap[s] f) := by
   intro x₀ hx₀
   let s' : Set (TangentBundle I M) := (π E (TangentSpace I) ⁻¹' s)
@@ -298,7 +297,7 @@ theorem ContMDiffOn.contMDiffOn_tangentMapWithin
 /-- If a function is `C^n` on a domain with unique derivatives, with `1 ≤ n`, then its bundled
 derivative is continuous there. -/
 theorem ContMDiffOn.continuousOn_tangentMapWithin (hf : CMDiff[s] n f) (hmn : 1 ≤ n)
-    (hs : UniqueMDiffOn I s) :
+    (hs : UniqueMDiff[s]) :
     ContinuousOn (tangentMap[s] f) (π E (TangentSpace I) ⁻¹' s) := by
   have : CMDiff[π E (TangentSpace I) ⁻¹' s] 0 (tangentMap[s] f) :=
     hf.contMDiffOn_tangentMapWithin hmn hs

--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -338,19 +338,19 @@ theorem toOpenPartialHomeomorph_mdifferentiable (h : M ≃ₘ^n⟮I, J⟯ N) (hn
   ⟨h.mdifferentiableOn _ hn, h.symm.mdifferentiableOn _ hn⟩
 
 theorem uniqueMDiffOn_image_aux (h : M ≃ₘ^n⟮I, J⟯ N) (hn : n ≠ 0) {s : Set M}
-    (hs : UniqueMDiffOn I s) : UniqueMDiffOn J (h '' s) := by
+    (hs : UniqueMDiff[s]) : UniqueMDiff[h '' s] := by
   convert! hs.uniqueMDiffOn_preimage (h.toOpenPartialHomeomorph_mdifferentiable hn)
   simp [h.image_eq_preimage_symm]
 
 @[simp]
 theorem uniqueMDiffOn_image (h : M ≃ₘ^n⟮I, J⟯ N) (hn : n ≠ 0) {s : Set M} :
-    UniqueMDiffOn J (h '' s) ↔ UniqueMDiffOn I s :=
+    UniqueMDiff[h '' s] ↔ UniqueMDiff[s] :=
   ⟨fun hs => h.symm_image_image s ▸ h.symm.uniqueMDiffOn_image_aux hn hs,
     h.uniqueMDiffOn_image_aux hn⟩
 
 @[simp]
 theorem uniqueMDiffOn_preimage (h : M ≃ₘ^n⟮I, J⟯ N) (hn : n ≠ 0) {s : Set N} :
-    UniqueMDiffOn I (h ⁻¹' s) ↔ UniqueMDiffOn J s :=
+    UniqueMDiff[h ⁻¹' s] ↔ UniqueMDiff[s] :=
   h.symm_image_eq_preimage s ▸ h.symm.uniqueMDiffOn_image hn
 
 @[simp]

--- a/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
@@ -269,7 +269,7 @@ lemma mfderiv_extChartAt_comp_mfderivWithin_extChartAt_symm {x : M}
     {y : E} (hy : y ∈ (extChartAt I x).target) :
     (mfderiv% (extChartAt I x) ((extChartAt I x).symm y)) ∘L
       (mfderiv[range I] (extChartAt I x).symm y) = ContinuousLinearMap.id _ _ := by
-  have U : UniqueMDiffWithinAt 𝓘(𝕜, E) (range ↑I) y := by
+  have U : UniqueMDiffAt[range ↑I] y := by
     apply I.uniqueMDiffOn
     exact extChartAt_target_subset_range x hy
   have h'y : (extChartAt I x).symm y ∈ (extChartAt I x).source := (extChartAt I x).map_target hy
@@ -306,7 +306,7 @@ lemma mfderivWithin_extChartAt_symm_comp_mfderiv_extChartAt
   have h'y : (extChartAt I x).symm y ∈ (extChartAt I x).source := (extChartAt I x).map_target hy
   have h''y : (extChartAt I x).symm y ∈ (chartAt H x).source := by
     rwa [← extChartAt_source (I := I)]
-  have U' : UniqueMDiffWithinAt I (extChartAt I x).source ((extChartAt I x).symm y) :=
+  have U' : UniqueMDiffAt[(extChartAt I x).source] ((extChartAt I x).symm y) :=
     (isOpen_extChartAt_source x).uniqueMDiffWithinAt h'y
   have : mfderiv% (extChartAt I x) ((extChartAt I x).symm y)
       = mfderiv[(extChartAt I x).source] (extChartAt I x) ((extChartAt I x).symm y) := by

--- a/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
@@ -269,7 +269,7 @@ lemma mfderiv_extChartAt_comp_mfderivWithin_extChartAt_symm {x : M}
     {y : E} (hy : y ∈ (extChartAt I x).target) :
     (mfderiv% (extChartAt I x) ((extChartAt I x).symm y)) ∘L
       (mfderiv[range I] (extChartAt I x).symm y) = ContinuousLinearMap.id _ _ := by
-  have U : UniqueMDiffAt[range ↑I] y := by
+  have U : UniqueMDiffAt[range I] y := by
     apply I.uniqueMDiffOn
     exact extChartAt_target_subset_range x hy
   have h'y : (extChartAt I x).symm y ∈ (extChartAt I x).source := (extChartAt I x).map_target hy

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.Calculus.TangentCone.Prod
 public import Mathlib.Geometry.Manifold.MFDeriv.Defs
 public import Mathlib.Geometry.Manifold.ContMDiff.Defs
+import Mathlib.Geometry.Manifold.Notation
 
 /-!
 # Basic properties of the manifold Fréchet derivative
@@ -49,7 +50,7 @@ variable
   {M'' : Type*} [TopologicalSpace M''] [ChartedSpace H'' M'']
   {f f₁ : M → M'} {x : M} {s t : Set M} {g : M' → M''} {u : Set M'}
 
-theorem uniqueMDiffWithinAt_univ : UniqueMDiffWithinAt I univ x := by
+theorem uniqueMDiffWithinAt_univ : UniqueMDiffAt[(univ : Set M)] x := by
   unfold UniqueMDiffWithinAt
   simp only [preimage_univ, univ_inter]
   exact I.uniqueDiffOn _ (mem_range_self _)
@@ -57,57 +58,57 @@ theorem uniqueMDiffWithinAt_univ : UniqueMDiffWithinAt I univ x := by
 variable {I}
 
 theorem uniqueMDiffWithinAt_iff_inter_range {s : Set M} {x : M} :
-    UniqueMDiffWithinAt I s x ↔
+    UniqueMDiffAt[s] x ↔
       UniqueDiffWithinAt 𝕜 ((extChartAt I x).symm ⁻¹' s ∩ range I)
         ((extChartAt I x) x) := Iff.rfl
 
 theorem uniqueMDiffWithinAt_iff {s : Set M} {x : M} :
-    UniqueMDiffWithinAt I s x ↔
+    UniqueMDiffAt[s] x ↔
       UniqueDiffWithinAt 𝕜 ((extChartAt I x).symm ⁻¹' s ∩ (extChartAt I x).target)
         ((extChartAt I x) x) := by
   apply uniqueDiffWithinAt_congr
   rw [nhdsWithin_inter, nhdsWithin_inter, nhdsWithin_extChartAt_target_eq]
 
-nonrec theorem UniqueMDiffWithinAt.mono_nhds {s t : Set M} {x : M} (hs : UniqueMDiffWithinAt I s x)
-    (ht : 𝓝[s] x ≤ 𝓝[t] x) : UniqueMDiffWithinAt I t x :=
+nonrec theorem UniqueMDiffWithinAt.mono_nhds {s t : Set M} {x : M} (hs : UniqueMDiffAt[s] x)
+    (ht : 𝓝[s] x ≤ 𝓝[t] x) : UniqueMDiffAt[t] x :=
   hs.mono_nhds <| by simpa only [← map_extChartAt_nhdsWithin] using Filter.map_mono ht
 
 theorem UniqueMDiffWithinAt.mono_of_mem_nhdsWithin {s t : Set M} {x : M}
-    (hs : UniqueMDiffWithinAt I s x) (ht : t ∈ 𝓝[s] x) : UniqueMDiffWithinAt I t x :=
+    (hs : UniqueMDiffAt[s] x) (ht : t ∈ 𝓝[s] x) : UniqueMDiffAt[t] x :=
   hs.mono_nhds (nhdsWithin_le_iff.2 ht)
 
-theorem UniqueMDiffWithinAt.mono (h : UniqueMDiffWithinAt I s x) (st : s ⊆ t) :
-    UniqueMDiffWithinAt I t x :=
+theorem UniqueMDiffWithinAt.mono (h : UniqueMDiffAt[s] x) (st : s ⊆ t) :
+    UniqueMDiffAt[t] x :=
   UniqueDiffWithinAt.mono h <| inter_subset_inter (preimage_mono st) (Subset.refl _)
 
-theorem UniqueMDiffWithinAt.inter' (hs : UniqueMDiffWithinAt I s x) (ht : t ∈ 𝓝[s] x) :
-    UniqueMDiffWithinAt I (s ∩ t) x :=
+theorem UniqueMDiffWithinAt.inter' (hs : UniqueMDiffAt[s] x) (ht : t ∈ 𝓝[s] x) :
+    UniqueMDiffAt[s ∩ t] x :=
   hs.mono_of_mem_nhdsWithin (Filter.inter_mem self_mem_nhdsWithin ht)
 
-theorem UniqueMDiffWithinAt.inter (hs : UniqueMDiffWithinAt I s x) (ht : t ∈ 𝓝 x) :
-    UniqueMDiffWithinAt I (s ∩ t) x :=
+theorem UniqueMDiffWithinAt.inter (hs : UniqueMDiffAt[s] x) (ht : t ∈ 𝓝 x) :
+    UniqueMDiffAt[s ∩ t] x :=
   hs.inter' (nhdsWithin_le_nhds ht)
 
-theorem IsOpen.uniqueMDiffWithinAt (hs : IsOpen s) (xs : x ∈ s) : UniqueMDiffWithinAt I s x :=
+theorem IsOpen.uniqueMDiffWithinAt (hs : IsOpen s) (xs : x ∈ s) : UniqueMDiffAt[s] x :=
   (uniqueMDiffWithinAt_univ I).mono_of_mem_nhdsWithin <| nhdsWithin_le_nhds <| hs.mem_nhds xs
 
-theorem UniqueMDiffOn.inter (hs : UniqueMDiffOn I s) (ht : IsOpen t) : UniqueMDiffOn I (s ∩ t) :=
+theorem UniqueMDiffOn.inter (hs : UniqueMDiff[s]) (ht : IsOpen t) : UniqueMDiff[s ∩ t] :=
   fun _x hx => UniqueMDiffWithinAt.inter (hs _ hx.1) (ht.mem_nhds hx.2)
 
-theorem IsOpen.uniqueMDiffOn (hs : IsOpen s) : UniqueMDiffOn I s :=
+theorem IsOpen.uniqueMDiffOn (hs : IsOpen s) : UniqueMDiff[s] :=
   fun _x hx => hs.uniqueMDiffWithinAt hx
 
-theorem uniqueMDiffOn_univ : UniqueMDiffOn I (univ : Set M) :=
+theorem uniqueMDiffOn_univ : UniqueMDiff[(univ : Set M)] :=
   isOpen_univ.uniqueMDiffOn
 
-nonrec theorem UniqueMDiffWithinAt.prod {x : M} {y : M'} {s t} (hs : UniqueMDiffWithinAt I s x)
-    (ht : UniqueMDiffWithinAt I' t y) : UniqueMDiffWithinAt (I.prod I') (s ×ˢ t) (x, y) := by
+nonrec theorem UniqueMDiffWithinAt.prod {x : M} {y : M'} {s : Set M} {t : Set M'}
+    (hs : UniqueMDiffAt[s] x) (ht : UniqueMDiffAt[t] y) : UniqueMDiffAt[s ×ˢ t] (x, y) := by
   refine (hs.prod ht).mono ?_
   rw [ModelWithCorners.range_prod, ← prod_inter_prod]
   rfl
 
-theorem UniqueMDiffOn.prod {s : Set M} {t : Set M'} (hs : UniqueMDiffOn I s)
-    (ht : UniqueMDiffOn I' t) : UniqueMDiffOn (I.prod I') (s ×ˢ t) := fun x h ↦
+theorem UniqueMDiffOn.prod {s : Set M} {t : Set M'} (hs : UniqueMDiff[s])
+    (ht : UniqueMDiff[t]) : UniqueMDiff[s ×ˢ t] := fun x h ↦
   (hs x.1 h.1).prod (ht x.2 h.2)
 
 theorem MDifferentiableWithinAt.mono (hst : s ⊆ t) (h : MDifferentiableWithinAt I I' f t x) :
@@ -517,12 +518,12 @@ variable {f' f₀' f₁' : TangentSpace I x →L[𝕜] TangentSpace I' (f x)}
 
 set_option backward.isDefEq.respectTransparency false in
 /-- `UniqueMDiffWithinAt` achieves its goal: it implies the uniqueness of the derivative. -/
-protected nonrec theorem UniqueMDiffWithinAt.eq (U : UniqueMDiffWithinAt I s x)
+protected nonrec theorem UniqueMDiffWithinAt.eq (U : UniqueMDiffAt[s] x)
     (h : HasMFDerivWithinAt I I' f s x f') (h₁ : HasMFDerivWithinAt I I' f s x f₁') : f' = f₁' := by
   -- `by apply` because the instances can be found in the term but not in the goal.
   apply U.eq h.2 h₁.2
 
-protected theorem UniqueMDiffOn.eq (U : UniqueMDiffOn I s) (hx : x ∈ s)
+protected theorem UniqueMDiffOn.eq (U : UniqueMDiff[s]) (hx : x ∈ s)
     (h : HasMFDerivWithinAt I I' f s x f') (h₁ : HasMFDerivWithinAt I I' f s x f₁') : f' = f₁' :=
   UniqueMDiffWithinAt.eq (U _ hx) h h₁
 
@@ -685,7 +686,7 @@ protected theorem HasMFDerivAt.mfderiv (h : HasMFDerivAt I I' f x f') : mfderiv 
   (hasMFDerivAt_unique h h.mdifferentiableAt.hasMFDerivAt).symm
 
 protected theorem HasMFDerivWithinAt.mfderivWithin (h : HasMFDerivWithinAt I I' f s x f')
-    (hxs : UniqueMDiffWithinAt I s x) : mfderivWithin I I' f s x = f' := by
+    (hxs : UniqueMDiffAt[s] x) : mfderivWithin I I' f s x = f' := by
   ext
   rw [hxs.eq h h.mdifferentiableWithinAt.hasMFDerivWithinAt]
 
@@ -698,11 +699,11 @@ theorem HasMFDerivWithinAt.mfderivWithin_eq_zero (h : HasMFDerivWithinAt I I' f 
   exact h.2
 
 theorem MDifferentiable.mfderivWithin (h : MDifferentiableAt I I' f x)
-    (hxs : UniqueMDiffWithinAt I s x) : mfderivWithin I I' f s x = mfderiv I I' f x := by
+    (hxs : UniqueMDiffAt[s] x) : mfderivWithin I I' f s x = mfderiv I I' f x := by
   apply HasMFDerivWithinAt.mfderivWithin _ hxs
   exact h.hasMFDerivAt.hasMFDerivWithinAt
 
-theorem mfderivWithin_subset (st : s ⊆ t) (hs : UniqueMDiffWithinAt I s x)
+theorem mfderivWithin_subset (st : s ⊆ t) (hs : UniqueMDiffAt[s] x)
     (h : MDifferentiableWithinAt I I' f t x) :
     mfderivWithin I I' f s x = mfderivWithin I I' f t x :=
   ((MDifferentiableWithinAt.hasMFDerivWithinAt h).mono st).mfderivWithin hs
@@ -755,7 +756,7 @@ theorem hasMFDerivWithinAt_sdiff_singleton (y : M) :
 @[deprecated (since := "2026-06-03")]
 alias hasMFDerivWithinAt_diff_singleton := hasMFDerivWithinAt_sdiff_singleton
 
-theorem mfderivWithin_eq_mfderiv (hs : UniqueMDiffWithinAt I s x) (h : MDifferentiableAt I I' f x) :
+theorem mfderivWithin_eq_mfderiv (hs : UniqueMDiffAt[s] x) (h : MDifferentiableAt I I' f x) :
     mfderivWithin I I' f s x = mfderiv I I' f x := by
   rw [← mfderivWithin_univ]
   exact mfderivWithin_subset (subset_univ _) hs h.mdifferentiableWithinAt
@@ -839,7 +840,7 @@ theorem HasMFDerivAt.continuousAt (h : HasMFDerivAt I I' f x f') : ContinuousAt 
   h.1
 
 theorem tangentMapWithin_subset {p : TangentBundle I M} (st : s ⊆ t)
-    (hs : UniqueMDiffWithinAt I s p.1) (h : MDifferentiableWithinAt I I' f t p.1) :
+    (hs : UniqueMDiffAt[s] p.1) (h : MDifferentiableWithinAt I I' f t p.1) :
     tangentMapWithin I I' f s p = tangentMapWithin I I' f t p := by
   simp only [tangentMapWithin, mfld_simps]
   rw [mfderivWithin_subset st hs h]
@@ -848,7 +849,7 @@ theorem tangentMapWithin_univ : tangentMapWithin I I' f univ = tangentMap I I' f
   ext p : 1
   simp only [tangentMapWithin, tangentMap, mfld_simps]
 
-theorem tangentMapWithin_eq_tangentMap {p : TangentBundle I M} (hs : UniqueMDiffWithinAt I s p.1)
+theorem tangentMapWithin_eq_tangentMap {p : TangentBundle I M} (hs : UniqueMDiffAt[s] p.1)
     (h : MDifferentiableAt I I' f p.1) : tangentMapWithin I I' f s p = tangentMap I I' f p := by
   rw [← mdifferentiableWithinAt_univ] at h
   rw [← tangentMapWithin_univ]
@@ -1054,17 +1055,17 @@ theorem MDifferentiableAt.congr_of_eventuallyEq (h : MDifferentiableAt I I' f x)
   (h.hasMFDerivAt.congr_of_eventuallyEq hL).mdifferentiableAt
 
 theorem MDifferentiableWithinAt.mfderivWithin_congr_mono (h : MDifferentiableWithinAt I I' f s x)
-    (hs : ∀ x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (hxt : UniqueMDiffWithinAt I t x) (h₁ : t ⊆ s) :
+    (hs : ∀ x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (hxt : UniqueMDiffAt[t] x) (h₁ : t ⊆ s) :
     mfderivWithin I I' f₁ t x = mfderivWithin I I' f s x :=
   (HasMFDerivWithinAt.congr_mono h.hasMFDerivWithinAt hs hx h₁).mfderivWithin hxt
 
 theorem MDifferentiableWithinAt.mfderivWithin_mono (h : MDifferentiableWithinAt I I' f s x)
-    (hxt : UniqueMDiffWithinAt I t x) (h₁ : t ⊆ s) :
+    (hxt : UniqueMDiffAt[t] x) (h₁ : t ⊆ s) :
     mfderivWithin I I' f t x = mfderivWithin I I' f s x :=
   h.mfderivWithin_congr_mono (fun _ _ ↦ rfl) rfl hxt h₁
 
 theorem MDifferentiableWithinAt.mfderivWithin_mono_of_mem_nhdsWithin
-    (h : MDifferentiableWithinAt I I' f s x) (hxt : UniqueMDiffWithinAt I t x) (h₁ : s ∈ 𝓝[t] x) :
+    (h : MDifferentiableWithinAt I I' f s x) (hxt : UniqueMDiffAt[t] x) (h₁ : s ∈ 𝓝[t] x) :
     mfderivWithin I I' f t x = mfderivWithin I I' f s x :=
   (HasMFDerivWithinAt.mono_of_mem_nhdsWithin h.hasMFDerivWithinAt h₁).mfderivWithin hxt
 
@@ -1207,14 +1208,14 @@ theorem MDifferentiableAt.comp_mdifferentiableWithinAt_of_eq {y : M'}
   subst hy; exact hg.comp_mdifferentiableWithinAt _ hf
 
 theorem mfderivWithin_comp (hg : MDifferentiableWithinAt I' I'' g u (f x))
-    (hf : MDifferentiableWithinAt I I' f s x) (h : s ⊆ f ⁻¹' u) (hxs : UniqueMDiffWithinAt I s x) :
+    (hf : MDifferentiableWithinAt I I' f s x) (h : s ⊆ f ⁻¹' u) (hxs : UniqueMDiffAt[s] x) :
     mfderivWithin I I'' (g ∘ f) s x =
       (mfderivWithin I' I'' g u (f x)).comp (mfderivWithin I I' f s x) := by
   apply HasMFDerivWithinAt.mfderivWithin _ hxs
   exact HasMFDerivWithinAt.comp x hg.hasMFDerivWithinAt hf.hasMFDerivWithinAt h
 
 theorem mfderivWithin_comp_of_eq {x : M} {y : M'} (hg : MDifferentiableWithinAt I' I'' g u y)
-    (hf : MDifferentiableWithinAt I I' f s x) (h : s ⊆ f ⁻¹' u) (hxs : UniqueMDiffWithinAt I s x)
+    (hf : MDifferentiableWithinAt I I' f s x) (h : s ⊆ f ⁻¹' u) (hxs : UniqueMDiffAt[s] x)
     (hy : f x = y) :
     mfderivWithin I I'' (g ∘ f) s x =
       (mfderivWithin I' I'' g u y).comp (mfderivWithin I I' f s x) := by
@@ -1223,7 +1224,7 @@ theorem mfderivWithin_comp_of_eq {x : M} {y : M'} (hg : MDifferentiableWithinAt 
 theorem mfderivWithin_comp_of_preimage_mem_nhdsWithin
     (hg : MDifferentiableWithinAt I' I'' g u (f x))
     (hf : MDifferentiableWithinAt I I' f s x) (h : f ⁻¹' u ∈ 𝓝[s] x)
-    (hxs : UniqueMDiffWithinAt I s x) :
+    (hxs : UniqueMDiffAt[s] x) :
     mfderivWithin I I'' (g ∘ f) s x =
       (mfderivWithin I' I'' g u (f x)).comp (mfderivWithin I I' f s x) := by
   have A : s ∩ f ⁻¹' u ∈ 𝓝[s] x := Filter.inter_mem self_mem_nhdsWithin h
@@ -1238,20 +1239,20 @@ theorem mfderivWithin_comp_of_preimage_mem_nhdsWithin
 theorem mfderivWithin_comp_of_preimage_mem_nhdsWithin_of_eq {y : M'}
     (hg : MDifferentiableWithinAt I' I'' g u y)
     (hf : MDifferentiableWithinAt I I' f s x) (h : f ⁻¹' u ∈ 𝓝[s] x)
-    (hxs : UniqueMDiffWithinAt I s x) (hy : f x = y) :
+    (hxs : UniqueMDiffAt[s] x) (hy : f x = y) :
     mfderivWithin I I'' (g ∘ f) s x =
       (mfderivWithin I' I'' g u y).comp (mfderivWithin I I' f s x) := by
   subst hy; exact mfderivWithin_comp_of_preimage_mem_nhdsWithin _ hg hf h hxs
 
 theorem mfderiv_comp_mfderivWithin (hg : MDifferentiableAt I' I'' g (f x))
-    (hf : MDifferentiableWithinAt I I' f s x) (hxs : UniqueMDiffWithinAt I s x) :
+    (hf : MDifferentiableWithinAt I I' f s x) (hxs : UniqueMDiffAt[s] x) :
     mfderivWithin I I'' (g ∘ f) s x =
       (mfderiv I' I'' g (f x)).comp (mfderivWithin I I' f s x) := by
   rw [← mfderivWithin_univ]
   exact mfderivWithin_comp _ hg.mdifferentiableWithinAt hf (by simp) hxs
 
 theorem mfderiv_comp_mfderivWithin_of_eq {x : M} {y : M'} (hg : MDifferentiableAt I' I'' g y)
-    (hf : MDifferentiableWithinAt I I' f s x) (hxs : UniqueMDiffWithinAt I s x) (hy : f x = y) :
+    (hf : MDifferentiableWithinAt I I' f s x) (hxs : UniqueMDiffAt[s] x) (hy : f x = y) :
     mfderivWithin I I'' (g ∘ f) s x =
       (mfderiv I' I'' g y).comp (mfderivWithin I I' f s x) := by
   subst hy; exact mfderiv_comp_mfderivWithin x hg hf hxs
@@ -1291,7 +1292,7 @@ theorem MDifferentiable.comp (hg : MDifferentiable I' I'' g) (hf : MDifferentiab
 
 theorem tangentMapWithin_comp_at (p : TangentBundle I M)
     (hg : MDifferentiableWithinAt I' I'' g u (f p.1)) (hf : MDifferentiableWithinAt I I' f s p.1)
-    (h : s ⊆ f ⁻¹' u) (hps : UniqueMDiffWithinAt I s p.1) :
+    (h : s ⊆ f ⁻¹' u) (hps : UniqueMDiffAt[s] p.1) :
     tangentMapWithin I I'' (g ∘ f) s p =
       tangentMapWithin I' I'' g u (tangentMapWithin I I' f s p) := by
   simp only [tangentMapWithin, mfld_simps]

--- a/Mathlib/Geometry/Manifold/MFDeriv/FDeriv.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/FDeriv.lean
@@ -29,19 +29,19 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCom
 section MFDerivFDeriv
 
 theorem uniqueMDiffWithinAt_iff_uniqueDiffWithinAt :
-    UniqueMDiffWithinAt 𝓘(𝕜, E) s x ↔ UniqueDiffWithinAt 𝕜 s x := by
+    UniqueMDiffAt[s] x ↔ UniqueDiffWithinAt 𝕜 s x := by
   simp only [UniqueMDiffWithinAt, mfld_simps]
 
 alias ⟨UniqueMDiffWithinAt.uniqueDiffWithinAt, UniqueDiffWithinAt.uniqueMDiffWithinAt⟩ :=
   uniqueMDiffWithinAt_iff_uniqueDiffWithinAt
 
-theorem uniqueMDiffOn_iff_uniqueDiffOn : UniqueMDiffOn 𝓘(𝕜, E) s ↔ UniqueDiffOn 𝕜 s := by
+theorem uniqueMDiffOn_iff_uniqueDiffOn : UniqueMDiff[s] ↔ UniqueDiffOn 𝕜 s := by
   simp [UniqueMDiffOn, UniqueDiffOn, uniqueMDiffWithinAt_iff_uniqueDiffWithinAt]
 
 alias ⟨UniqueMDiffOn.uniqueDiffOn, UniqueDiffOn.uniqueMDiffOn⟩ := uniqueMDiffOn_iff_uniqueDiffOn
 
 theorem ModelWithCorners.uniqueMDiffOn {H : Type*} [TopologicalSpace H]
-    (I : ModelWithCorners 𝕜 E H) : UniqueMDiffOn 𝓘(𝕜, E) (Set.range I) :=
+    (I : ModelWithCorners 𝕜 E H) : UniqueMDiff[Set.range I] :=
   I.uniqueDiffOn.uniqueMDiffOn
 
 @[simp, mfld_simps]

--- a/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
@@ -486,27 +486,27 @@ lemma mvfderivWithin_const (c : F) {x : M} : d[s] (fun _ : M ↦ c) x = 0 := by
 
 @[simp, to_fun mvfderivWithin_fun_add]
 lemma mvfderivWithin_add {g g' : M → F} {x : M}
-    (hg : MDiffAt[s] g x) (hg' : MDiffAt[s] g' x) (hs : UniqueMDiffWithinAt I s x) :
+    (hg : MDiffAt[s] g x) (hg' : MDiffAt[s] g' x) (hs : UniqueMDiffAt[s] x) :
     d[s](g + g') x = d[s]g x + d[s]g' x := by
   simp [mvfderivWithin, mfderivWithin_add hg hg' hs]
   rfl
 
 @[simp, to_fun mvfderivWithin_fun_sub]
 lemma mvfderivWithin_sub {g g' : M → F} {x : M}
-    (hg : MDiffAt[s] g x) (hg' : MDiffAt[s] g' x) (hs : UniqueMDiffWithinAt I s x) :
+    (hg : MDiffAt[s] g x) (hg' : MDiffAt[s] g' x) (hs : UniqueMDiffAt[s] x) :
     d[s](g - g') x = d[s]g x - d[s]g' x := by
   simp [mvfderivWithin, mfderivWithin_sub hg hg' hs]
   rfl
 
 @[simp, to_fun mvfderivWithin_fun_neg]
-lemma mvfderivWithin_neg {g : M → F} {x : M} (hs : UniqueMDiffWithinAt I s x) :
+lemma mvfderivWithin_neg {g : M → F} {x : M} (hs : UniqueMDiffAt[s] x) :
     d[s](-g) x = -d[s]g x := by
   simp [mvfderivWithin, mfderivWithin_neg hs]
   rfl
 
 @[simp, to_fun mvfderivWithin_fun_smul]
 lemma mvfderivWithin_smul {a : M → 𝕜} (ha : MDiffAt[s] a x) {g : M → F} (hg : MDiffAt[s] g x)
-    (hs : UniqueMDiffWithinAt I s x) :
+    (hs : UniqueMDiffAt[s] x) :
     d[s](a • g) x =
       a x • d[s] g x + (d[s] a x).smulRight (g x) := by
   refine HasMFDerivWithinAt.mfderivWithin ⟨ha.1.smul hg.1, ?_⟩ hs
@@ -516,14 +516,14 @@ lemma mvfderivWithin_smul {a : M → 𝕜} (ha : MDiffAt[s] a x) {g : M → F} (
 
 @[simp, to_fun mvfderivWithin_fun_mul]
 lemma mvfderivWithin_mul {f g : M → 𝕜} {x : M} (hf : MDiffAt[s] f x) (hg : MDiffAt[s] g x)
-    (hs : UniqueMDiffWithinAt I s x) :
+    (hs : UniqueMDiffAt[s] x) :
     d[s](f * g) x = f x • d[s]g x + (g x) • (d[s]f x) := by
   convert! mvfderivWithin_smul hf hg hs
   ext v
   simp [mul_comm]
 
 @[simp]
-lemma mvfderivWithin_zero {s : Set M} (hs : UniqueMDiffWithinAt I s x) :
+lemma mvfderivWithin_zero {s : Set M} (hs : UniqueMDiffAt[s] x) :
     d[s] (0 : M → F) x = 0 := by
   have : d[s] (0 : M → F) x + d[s] (0 : M → F) x = d[s] (0 : M → F) x := by
     rw [← mvfderivWithin_add (by exact mdifferentiableWithinAt_const)

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -83,7 +83,7 @@ protected theorem mdifferentiable : MDiff f :=
 theorem mfderiv_eq : mfderiv% f x = f :=
   f.hasMFDerivAt.mfderiv
 
-theorem mfderivWithin_eq (hs : UniqueMDiffWithinAt 𝓘(𝕜, E) s x) : mfderiv[s] f x = f :=
+theorem mfderivWithin_eq (hs : UniqueMDiffAt[s] x) : mfderiv[s] f x = f :=
   f.hasMFDerivWithinAt.mfderivWithin hs
 
 end ContinuousLinearMap
@@ -113,7 +113,7 @@ protected theorem mdifferentiable : MDiff f :=
 theorem mfderiv_eq : mfderiv% f x = (f : E →L[𝕜] E') :=
   f.hasMFDerivAt.mfderiv
 
-theorem mfderivWithin_eq (hs : UniqueMDiffWithinAt 𝓘(𝕜, E) s x) :
+theorem mfderivWithin_eq (hs : UniqueMDiffAt[s] x) :
     mfderiv[s] f x = (f : E →L[𝕜] E') :=
   f.hasMFDerivWithinAt.mfderivWithin hs
 
@@ -153,7 +153,7 @@ theorem mdifferentiableOn_id : MDiff[s] (@id M) :=
 theorem mfderiv_id : mfderiv% (@id M) x = ContinuousLinearMap.id 𝕜 (TangentSpace% x) :=
   (hasMFDerivAt_id x).mfderiv
 
-theorem mfderivWithin_id (hxs : UniqueMDiffWithinAt I s x) :
+theorem mfderivWithin_id (hxs : UniqueMDiffAt[s] x) :
     mfderiv[s] (@id M) x = ContinuousLinearMap.id 𝕜 (TangentSpace% x) := by
   rw [MDifferentiable.mfderivWithin mdifferentiableAt_id hxs]
   exact mfderiv_id
@@ -162,7 +162,7 @@ set_option backward.isDefEq.respectTransparency false in
 @[simp, mfld_simps]
 theorem tangentMap_id : tangentMap% (@id M) = id := by ext1 ⟨x, v⟩; simp [tangentMap]
 
-theorem tangentMapWithin_id {p : TangentBundle I M} (hs : UniqueMDiffWithinAt I s p.proj) :
+theorem tangentMapWithin_id {p : TangentBundle I M} (hs : UniqueMDiffAt[s] p.proj) :
     tangentMap[s] (id : M → M) p = p := by
   simp only [tangentMapWithin, id]
   rw [mfderivWithin_id]
@@ -227,7 +227,7 @@ theorem HasMFDerivWithinAt.prodMk {f : M → M'} {g : M → M''}
   ⟨hf.1.prodMk hg.1, hf.2.prodMk hg.2⟩
 
 lemma mfderivWithin_prodMk {f : M → M'} {g : M → M''} (hf : MDiffAt[s] f x) (hg : MDiffAt[s] g x)
-    (hs : UniqueMDiffWithinAt I s x) :
+    (hs : UniqueMDiffAt[s] x) :
     mfderiv[s] (fun x ↦ (f x, g x)) x = (mfderiv[s] f x).prod (mfderiv[s] g x) :=
   (hf.hasMFDerivWithinAt.prodMk hg.hasMFDerivWithinAt).mfderivWithin hs
 
@@ -316,7 +316,7 @@ theorem mfderiv_fst {x : M × M'} :
   (hasMFDerivAt_fst x).mfderiv
 
 theorem mfderivWithin_fst {s : Set (M × M')} {x : M × M'}
-    (hxs : UniqueMDiffWithinAt (I.prod I') s x) :
+    (hxs : UniqueMDiffAt[s] x) :
     mfderiv[s] (@Prod.fst M M') x =
       ContinuousLinearMap.fst 𝕜 (TangentSpace% x.1) (TangentSpace% x.2) := by
   rw [MDifferentiable.mfderivWithin mdifferentiableAt_fst hxs]; exact mfderiv_fst
@@ -327,7 +327,7 @@ theorem tangentMap_prodFst {p : TangentBundle (I.prod I') (M × M')} :
   simp [tangentMap]; rfl
 
 theorem tangentMapWithin_prodFst {s : Set (M × M')} {p : TangentBundle (I.prod I') (M × M')}
-    (hs : UniqueMDiffWithinAt (I.prod I') s p.proj) :
+    (hs : UniqueMDiffAt[s] p.proj) :
     tangentMap[s] (@Prod.fst M M') p = ⟨p.proj.1, p.2.1⟩ := by
   simp only [tangentMapWithin]
   rw [mfderivWithin_fst]
@@ -375,7 +375,7 @@ theorem mfderiv_snd {x : M × M'} :
   (hasMFDerivAt_snd x).mfderiv
 
 theorem mfderivWithin_snd {s : Set (M × M')} {x : M × M'}
-    (hxs : UniqueMDiffWithinAt (I.prod I') s x) :
+    (hxs : UniqueMDiffAt[s] x) :
     mfderiv[s] (@Prod.snd M M') x =
       ContinuousLinearMap.snd 𝕜 (TangentSpace% x.1) (TangentSpace% x.2) := by
   rw [MDifferentiable.mfderivWithin mdifferentiableAt_snd hxs]; exact mfderiv_snd
@@ -516,7 +516,7 @@ lemma HasMFDerivAt.prodMap {p : M × M'} {f : M → N} {g : M' → N'}
 -- could be a strict superset of `s`.
 lemma mfderivWithin_prodMap {p : M × M'} {t : Set M'} {f : M → N} {g : M' → N'}
     (hf : MDiffAt[s] f p.1) (hg : MDiffAt[t] g p.2)
-    (hs : UniqueMDiffWithinAt I s p.1) (ht : UniqueMDiffWithinAt I' t p.2) :
+    (hs : UniqueMDiffAt[s] p.1) (ht : UniqueMDiffAt[t] p.2) :
     mfderiv[s ×ˢ t] (Prod.map f g) p = (mfderiv[s] f p.1).prodMap (mfderiv[t] g p.2) := by
   have hf' : HasMFDerivAt[Prod.fst '' s ×ˢ t] f p.1 (mfderiv[s] f p.1) :=
     hf.hasMFDerivWithinAt.mono (by grind)
@@ -539,7 +539,7 @@ theorem tangentMap_prodSnd {p : TangentBundle (I.prod I') (M × M')} :
   simp [tangentMap]; rfl
 
 theorem tangentMapWithin_prodSnd {s : Set (M × M')} {p : TangentBundle (I.prod I') (M × M')}
-    (hs : UniqueMDiffWithinAt (I.prod I') s p.proj) :
+    (hs : UniqueMDiffAt[s] p.proj) :
     tangentMap[s] (@Prod.snd M M') p = ⟨p.proj.2, p.2.2⟩ := by
   simp only [tangentMapWithin]
   rw [mfderivWithin_snd hs]
@@ -671,7 +671,7 @@ theorem hasMFDerivAt_sumSwap :
     cases p <;> simp
 
 @[simp]
-theorem mfderivWithin_sumSwap {s : Set (M ⊕ M')} (hs : UniqueMDiffWithinAt I s p) :
+theorem mfderivWithin_sumSwap {s : Set (M ⊕ M')} (hs : UniqueMDiffAt[s] p) :
     mfderiv[s] (@Sum.swap M M') p = ContinuousLinearMap.id 𝕜 (TangentSpace% p) :=
   hasMFDerivAt_sumSwap.hasMFDerivWithinAt.mfderivWithin hs
 
@@ -732,7 +732,7 @@ theorem hasMFDerivAt_inr :
     HasMFDerivAt% (@Sum.inr M M') q' (ContinuousLinearMap.id 𝕜 (TangentSpace% p)) := by
   simpa [HasMFDerivAt, hasMFDerivWithinAt_univ] using! hasMFDerivWithinAt_inr (t := Set.univ)
 
-theorem mfderivWithin_sumInl (hU : UniqueMDiffWithinAt I s q) :
+theorem mfderivWithin_sumInl (hU : UniqueMDiffAt[s] q) :
     mfderiv[s] (@Sum.inl M M') q = ContinuousLinearMap.id 𝕜 (TangentSpace% p) :=
   hasMFDerivWithinAt_inl.mfderivWithin hU
 
@@ -740,7 +740,7 @@ theorem mfderiv_sumInl :
     mfderiv% (@Sum.inl M M') q = ContinuousLinearMap.id 𝕜 (TangentSpace% p) := by
   simpa [mfderivWithin_univ] using (mfderivWithin_sumInl (uniqueMDiffWithinAt_univ I))
 
-theorem mfderivWithin_sumInr {t : Set M'} (hU : UniqueMDiffWithinAt I t q') :
+theorem mfderivWithin_sumInr {t : Set M'} (hU : UniqueMDiffAt[t] q') :
     mfderiv[t] (@Sum.inr M M') q' = ContinuousLinearMap.id 𝕜 (TangentSpace% q') :=
   hasMFDerivWithinAt_inr.mfderivWithin hU
 
@@ -794,7 +794,7 @@ theorem mfderiv_add (hf : MDiffAt f z) (hg : MDiffAt g z) :
   (hf.hasMFDerivAt.add hg.hasMFDerivAt).mfderiv
 
 theorem mfderivWithin_add (hf : MDiffAt[s] f z) (hg : MDiffAt[s] g z)
-    (hs : UniqueMDiffWithinAt I s z) :
+    (hs : UniqueMDiffAt[s] z) :
     (mfderiv[s] (f + g) z : TangentSpace% z →L[𝕜] E') =
       (by exact mfderiv[s] f z) + (by exact mfderiv[s] g z) :=
   (hf.hasMFDerivWithinAt.add hg.hasMFDerivWithinAt).mfderivWithin hs
@@ -881,7 +881,7 @@ theorem mdifferentiableAt_neg : MDiffAt (-f) z ↔ MDiffAt f z :=
 theorem MDifferentiable.neg (hf : MDiff f) : MDiff (-f) := fun x ↦ (hf x).neg
 
 set_option backward.isDefEq.respectTransparency false in
-theorem mfderivWithin_neg (hs : UniqueMDiffWithinAt I s x) :
+theorem mfderivWithin_neg (hs : UniqueMDiffAt[s] x) :
     mfderiv[s] (-f) x = -mfderiv[s] f x := by
   simp_rw [mfderivWithin]
   by_cases hf : MDiffAt[s] f x
@@ -914,7 +914,7 @@ theorem MDifferentiable.sub (hf : MDiff f) (hg : MDiff g) : MDiff (f - g) :=
   fun x ↦ (hf x).sub (hg x)
 
 theorem mfderivWithin_sub (hf : MDiffAt[s] f z) (hg : MDiffAt[s] g z)
-    (hs : UniqueMDiffWithinAt I s z) :
+    (hs : UniqueMDiffAt[s] z) :
     (mfderiv[s] (f - g) z : TangentSpace% z →L[𝕜] E') =
       (by exact mfderiv[s] f z) - (by exact mfderiv[s] g z) :=
   (hf.hasMFDerivWithinAt.sub hg.hasMFDerivWithinAt).mfderivWithin hs

--- a/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
@@ -45,9 +45,9 @@ section
 
 /-- If `s` has the unique differential property at `x`, `f` is differentiable within `s` at `x` and
 its derivative has dense range, then `f '' s` has the unique differential property at `f x`. -/
-theorem UniqueMDiffWithinAt.image_denseRange (hs : UniqueMDiffWithinAt I s x)
+theorem UniqueMDiffWithinAt.image_denseRange (hs : UniqueMDiffAt[s] x)
     {f : M → M'} {f' : E →L[𝕜] E'} (hf : HasMFDerivAt[s] f x f')
-    (hd : DenseRange f') : UniqueMDiffWithinAt I' (f '' s) (f x) := by
+    (hd : DenseRange f') : UniqueMDiffAt[f '' s] (f x) := by
   /- Rewrite in coordinates, apply `HasFDerivWithinAt.uniqueDiffWithinAt`. -/
   have := hs.inter' <| hf.1 (extChartAt_source_mem_nhds (I := I') (f x))
   refine (((hf.2.mono ?sub1).uniqueDiffWithinAt this hd).mono ?sub2).congr_pt ?pt
@@ -60,22 +60,22 @@ theorem UniqueMDiffWithinAt.image_denseRange (hs : UniqueMDiffWithinAt I s x)
 /-- If `s` has the unique differential property, `f` is differentiable on `s` and its derivative
 at every point of `s` has dense range, then `f '' s` has the unique differential property.
 This version uses the `HasMFDerivWithinAt` predicate. -/
-theorem UniqueMDiffOn.image_denseRange' (hs : UniqueMDiffOn I s) {f : M → M'}
+theorem UniqueMDiffOn.image_denseRange' (hs : UniqueMDiff[s]) {f : M → M'}
     {f' : M → E →L[𝕜] E'} (hf : ∀ x ∈ s, HasMFDerivAt[s] f x (f' x))
     (hd : ∀ x ∈ s, DenseRange (f' x)) :
-    UniqueMDiffOn I' (f '' s) :=
+    UniqueMDiff[f '' s] :=
   forall_mem_image.2 fun x hx ↦ (hs x hx).image_denseRange (hf x hx) (hd x hx)
 
 /-- If `s` has the unique differential property, `f` is differentiable on `s` and its derivative
 at every point of `s` has dense range, then `f '' s` has the unique differential property. -/
-theorem UniqueMDiffOn.image_denseRange (hs : UniqueMDiffOn I s) {f : M → M'}
+theorem UniqueMDiffOn.image_denseRange (hs : UniqueMDiff[s]) {f : M → M'}
     (hf : MDiff[s] f) (hd : ∀ x ∈ s, DenseRange (mfderiv[s] f x)) :
-    UniqueMDiffOn I' (f '' s) :=
+    UniqueMDiff[f '' s] :=
   hs.image_denseRange' (fun x hx ↦ (hf x hx).hasMFDerivWithinAt) hd
 
 protected theorem UniqueMDiffWithinAt.preimage_openPartialHomeomorph
-    (hs : UniqueMDiffWithinAt I s x) {e : OpenPartialHomeomorph M M'} (he : e.MDifferentiable I I')
-    (hx : x ∈ e.source) : UniqueMDiffWithinAt I' (e.target ∩ e.symm ⁻¹' s) (e x) := by
+    (hs : UniqueMDiffAt[s] x) {e : OpenPartialHomeomorph M M'} (he : e.MDifferentiable I I')
+    (hx : x ∈ e.source) : UniqueMDiffAt[e.target ∩ e.symm ⁻¹' s] (e x) := by
   rw [← e.image_source_inter_eq', inter_comm]
   exact (hs.inter (e.open_source.mem_nhds hx)).image_denseRange
     (he.mdifferentiableAt hx).hasMFDerivAt.hasMFDerivWithinAt
@@ -83,16 +83,16 @@ protected theorem UniqueMDiffWithinAt.preimage_openPartialHomeomorph
 
 /-- If a set has the unique differential property, then its image under a local
 diffeomorphism also has the unique differential property. -/
-theorem UniqueMDiffOn.uniqueMDiffOn_preimage (hs : UniqueMDiffOn I s)
+theorem UniqueMDiffOn.uniqueMDiffOn_preimage (hs : UniqueMDiff[s])
     {e : OpenPartialHomeomorph M M'} (he : e.MDifferentiable I I') :
-    UniqueMDiffOn I' (e.target ∩ e.symm ⁻¹' s) := fun _x hx ↦
+    UniqueMDiff[e.target ∩ e.symm ⁻¹' s] := fun _x hx ↦
   e.right_inv hx.1 ▸ (hs _ hx.2).preimage_openPartialHomeomorph he (e.map_target hx.1)
 
 variable [IsManifold I 1 M] in
 /-- If a set in a manifold has the unique derivative property, then its pullback by any extended
 chart, in the vector space, also has the unique derivative property. -/
-theorem UniqueMDiffOn.uniqueMDiffOn_target_inter (hs : UniqueMDiffOn I s) (x : M) :
-    UniqueMDiffOn 𝓘(𝕜, E) ((extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s) := by
+theorem UniqueMDiffOn.uniqueMDiffOn_target_inter (hs : UniqueMDiff[s]) (x : M) :
+    UniqueMDiff[(extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s] := by
   -- this is just a reformulation of `UniqueMDiffOn.uniqueMDiffOn_preimage`, using as `e`
   -- the local chart at `x`.
   rw [← PartialEquiv.image_source_inter_eq', inter_comm, extChartAt_source]
@@ -103,12 +103,12 @@ theorem UniqueMDiffOn.uniqueMDiffOn_target_inter (hs : UniqueMDiffOn I s) (x : M
 variable [IsManifold I 1 M] in
 /-- If a set in a manifold has the unique derivative property, then its pullback by any extended
 chart, in the vector space, also has the unique derivative property. -/
-theorem UniqueMDiffOn.uniqueDiffOn_target_inter (hs : UniqueMDiffOn I s) (x : M) :
+theorem UniqueMDiffOn.uniqueDiffOn_target_inter (hs : UniqueMDiff[s]) (x : M) :
     UniqueDiffOn 𝕜 ((extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s) :=
   (hs.uniqueMDiffOn_target_inter x).uniqueDiffOn
 
 variable [IsManifold I 1 M] in
-theorem UniqueMDiffOn.uniqueDiffWithinAt_range_inter (hs : UniqueMDiffOn I s) (x : M) (y : E)
+theorem UniqueMDiffOn.uniqueDiffWithinAt_range_inter (hs : UniqueMDiff[s]) (x : M) (y : E)
     (hy : y ∈ (extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s) :
     UniqueDiffWithinAt 𝕜 (range I ∩ (extChartAt I x).symm ⁻¹' s) y := by
   apply (hs.uniqueDiffOn_target_inter x y hy).mono
@@ -118,11 +118,11 @@ variable [IsManifold I 1 M] in
 /-- When considering functions between manifolds, this statement shows up often. It entails
 the unique differential of the pullback in extended charts of the set where the function can
 be read in the charts. -/
-theorem UniqueMDiffOn.uniqueDiffOn_inter_preimage (hs : UniqueMDiffOn I s) (x : M) (y : M'')
+theorem UniqueMDiffOn.uniqueDiffOn_inter_preimage (hs : UniqueMDiff[s]) (x : M) (y : M'')
     {f : M → M''} (hf : ContinuousOn f s) :
     UniqueDiffOn 𝕜
       ((extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' (s ∩ f ⁻¹' (extChartAt I' y).source)) :=
-  haveI : UniqueMDiffOn I (s ∩ f ⁻¹' (extChartAt I' y).source) := by
+  haveI : UniqueMDiff[s ∩ f ⁻¹' (extChartAt I' y).source] := by
     intro z hz
     apply (hs z hz.1).inter'
     apply (hf z hz.1).preimage_mem_nhdsWithin
@@ -138,7 +138,7 @@ variable {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {Z : M → Type
 
 set_option backward.isDefEq.respectTransparency false in
 private lemma UniqueMDiffWithinAt.bundle_preimage_aux {p : TotalSpace F Z}
-    (hs : UniqueMDiffWithinAt I s p.proj) (h's : s ⊆ (trivializationAt F Z p.proj).baseSet) :
+    (hs : UniqueMDiffAt[s] p.proj) (h's : s ⊆ (trivializationAt F Z p.proj).baseSet) :
     UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) p := by
   suffices ((extChartAt I p.proj).symm ⁻¹' s ∩ range I) ×ˢ univ ⊆
       (extChartAt (I.prod 𝓘(𝕜, F)) p).symm ⁻¹' (TotalSpace.proj ⁻¹' s) ∩ range (I.prod 𝓘(𝕜, F)) by
@@ -170,7 +170,7 @@ private lemma UniqueMDiffWithinAt.bundle_preimage_aux {p : TotalSpace F Z}
 /-- In a fiber bundle, the preimage under the projection of a set with unique differentials
 in the base has unique differentials in the bundle. -/
 theorem UniqueMDiffWithinAt.bundle_preimage {p : TotalSpace F Z}
-    (hs : UniqueMDiffWithinAt I s p.proj) :
+    (hs : UniqueMDiffAt[s] p.proj) :
     UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) p := by
   suffices UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F))
     (π F Z ⁻¹' (s ∩ (trivializationAt F Z p.proj).baseSet)) p from this.mono (by simp)
@@ -182,13 +182,13 @@ variable (Z)
 
 /-- In a fiber bundle, the preimage under the projection of a set with unique differentials
 in the base has unique differentials in the bundle. Version with a point `⟨b, x⟩`. -/
-theorem UniqueMDiffWithinAt.bundle_preimage' {b : M} (hs : UniqueMDiffWithinAt I s b)
+theorem UniqueMDiffWithinAt.bundle_preimage' {b : M} (hs : UniqueMDiffAt[s] b)
     (x : Z b) : UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) ⟨b, x⟩ :=
   hs.bundle_preimage (p := ⟨b, x⟩)
 
 /-- In a fiber bundle, the preimage under the projection of a set with unique differentials
 in the base has unique differentials in the bundle. -/
-theorem UniqueMDiffOn.bundle_preimage (hs : UniqueMDiffOn I s) :
+theorem UniqueMDiffOn.bundle_preimage (hs : UniqueMDiff[s]) :
     UniqueMDiffOn (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) := fun _p hp ↦
   (hs _ hp).bundle_preimage
 

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -1149,14 +1149,14 @@ arguments that can use the `T%` elaborator. -/
     let fs ← withNaryArg 20 <| delab
     `(MDiffAt[$ss] $fs) >>= annotateGoToSyntaxDef
 
-/-- Delaborator for `UniqueMDiffOn` using the custom elaborator .-/
+/-- Delaborator for `UniqueMDiffOn` using the custom elaborator. -/
 @[app_delab UniqueMDiffOn] meta def delabUniqueMDiffOn : Delab := do
   whenPPOption getPPNotation do
   withOverApp 12 do
   let ss ← withAppArg delab
   `(UniqueMDiff[$ss]) >>= annotateGoToSyntaxDef
 
-/-- Delaborator for `UniqueMDiffWithinAt` using the custom elaborator .-/
+/-- Delaborator for `UniqueMDiffWithinAt` using the custom elaborator. -/
 @[app_delab UniqueMDiffWithinAt] meta def delabUniqueMDiffWithinAt : Delab := do
   whenPPOption getPPNotation do
   withOverApp 12 do

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -43,7 +43,6 @@ including inference of the model with corners.
 | `UniqueMDiff[s]`         | `UniqueMDiffOn I s`                 |
 | `UniqueMDiffAt[s] x`     | `UniqueMDiffWithinAt I s x`         |
 
-
 In each of these cases, the models with corners are inferred from the domain and codomain of `f`.
 The search for models with corners uses the local context and is (almost) only based on expression
 structure, hence hopefully fast enough to always run.

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -1149,12 +1149,14 @@ arguments that can use the `T%` elaborator. -/
     let fs ← withNaryArg 20 <| delab
     `(MDiffAt[$ss] $fs) >>= annotateGoToSyntaxDef
 
+/-- Delaborator for `UniqueMDiffOn` using the custom elaborator .-/
 @[app_delab UniqueMDiffOn] meta def delabUniqueMDiffOn : Delab := do
   whenPPOption getPPNotation do
   withOverApp 12 do
   let ss ← withAppArg delab
   `(UniqueMDiff[$ss]) >>= annotateGoToSyntaxDef
 
+/-- Delaborator for `UniqueMDiffWithinAt` using the custom elaborator .-/
 @[app_delab UniqueMDiffWithinAt] meta def delabUniqueMDiffWithinAt : Delab := do
   whenPPOption getPPNotation do
   withOverApp 12 do

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -40,6 +40,9 @@ including inference of the model with corners.
 | `TangentSpace% x`        | `TangentSpace I x`                  |
 | `tangentMap[s] f`        | `tangentMapWithin I J f s`          |
 | `tangentMap% f`          | `tangentMap I J f`                  |
+| `UniqueMDiff[s]`         | `UniqueMDiffOn I s`                 |
+| `UniqueMDiffAt[s] x`     | `UniqueMDiffWithinAt I s x`         |
+
 
 In each of these cases, the models with corners are inferred from the domain and codomain of `f`.
 The search for models with corners uses the local context and is (almost) only based on expression

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -967,6 +967,29 @@ scoped elab:max "tangentMap%" ppSpace f:term:arg : term => do
   let (srcI, tgtI) ← findModels ef none
   mkAppM ``tangentMap #[srcI, tgtI, ef]
 
+/-- `UniqueMDiff[s]` elaborates to `UniqueMDiffOn I s`,
+trying to determine `I` from the local context. -/
+scoped elab:max "UniqueMDiff[" s:term "]" : term => do
+  let es ← Term.elabTerm s none
+  let estype : Expr ← inferType es
+  match_expr estype with
+  | Set α =>
+    let I ← findModel α
+    mkAppM ``UniqueMDiffOn #[I, es]
+  | _ => throwError "`{es}` has type `{estype}` which is not of the form `Set α` for some `α`."
+
+/-- `UniqueMDiffAt[s] x` elaborates to `UniqueMDiffWithinAt I s x`
+trying to determine `I` from the local context.
+The argument `x` can be omitted. -/
+scoped elab:max "UniqueMDiffAt[" s:term "]" : term => do
+  let es ← Term.elabTerm s none
+  let estype : Expr ← inferType es
+  match_expr estype with
+  | Set α =>
+    let I ← findModel α
+    mkAppM ``UniqueMDiffWithinAt #[I, es]
+  | _ => throwError "`{es}` has type `{estype}` which is not of the form `Set α` for some `α`."
+
 end Manifold
 
 section trace
@@ -1125,6 +1148,18 @@ arguments that can use the `T%` elaborator. -/
   catch _ =>
     let fs ← withNaryArg 20 <| delab
     `(MDiffAt[$ss] $fs) >>= annotateGoToSyntaxDef
+
+@[app_delab UniqueMDiffOn] meta def delabUniqueMDiffOn : Delab := do
+  whenPPOption getPPNotation do
+  withOverApp 12 do
+  let ss ← withAppArg delab
+  `(UniqueMDiff[$ss]) >>= annotateGoToSyntaxDef
+
+@[app_delab UniqueMDiffWithinAt] meta def delabUniqueMDiffWithinAt : Delab := do
+  whenPPOption getPPNotation do
+  withOverApp 12 do
+  let ss ← withAppArg delab
+  `(UniqueMDiffAt[$ss]) >>= annotateGoToSyntaxDef
 
 -- TODO: add more delaborators (and tests) for
 -- ContMDiff, ContMDiffOn, ContMDiffAt, ContMDiffWithinAt, HasMFDerivAt, HasMFDerivWithinAt

--- a/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
@@ -360,7 +360,7 @@ Product rule for Lie brackets: given two vector fields `V` and `W` on `M` and a 
 -/
 lemma mlieBracketWithin_smul_right {f : M → 𝕜} (hf : MDiffAt[s] f x)
     (hW : MDiffAt[s] (fun x ↦ (W x : TangentBundle I M)) x)
-    (hs : UniqueMDiffWithinAt I s x) :
+    (hs : UniqueMDiffAt[s] x) :
     mlieBracketWithin I V (f • W) s x =
       d[s] f x (V x) • (W x) + (f x) • mlieBracketWithin I V W s x := by
   simp only [mlieBracketWithin, mpullbackWithin_smul]
@@ -401,7 +401,7 @@ Product rule for Lie brackets: given two vector fields `V` and `W` on `M` and a 
 -/
 lemma mlieBracketWithin_smul_left {f : M → 𝕜} (hf : MDiffAt[s] f x)
     (hV : MDiffAt[s] (fun x ↦ (V x : TangentBundle I M)) x)
-    (hs : UniqueMDiffWithinAt I s x) :
+    (hs : UniqueMDiffAt[s] x) :
     mlieBracketWithin I (f • V) W s x =
       - d[s] f x (W x) • (V x) + (f x) • mlieBracketWithin I V W s x := by
   rw [mlieBracketWithin_swap, Pi.neg_apply, mlieBracketWithin_smul_right hf hV (V := W) hs,
@@ -420,7 +420,7 @@ lemma mlieBracket_smul_left {f : M → 𝕜} (hf : MDiffAt f x)
   exact mlieBracketWithin_smul_left hf hV (uniqueMDiffWithinAt_univ I)
 
 lemma mlieBracketWithin_const_smul_left
-    (hV : MDiffAt[s] (T% V) x) (hs : UniqueMDiffWithinAt I s x) :
+    (hV : MDiffAt[s] (T% V) x) (hs : UniqueMDiffAt[s] x) :
     mlieBracketWithin I (c • V) W s x = c • mlieBracketWithin I V W s x := by
   simpa [mfderivWithin_const, mvfderivWithin] using!
     mlieBracketWithin_smul_left (mdifferentiableWithinAt_const (c := c)) (W := W) hV hs
@@ -431,7 +431,7 @@ lemma mlieBracket_const_smul_left (hV : MDiffAt (T% V) x) :
   exact mlieBracketWithin_const_smul_left hV (uniqueMDiffWithinAt_univ _)
 
 lemma mlieBracketWithin_const_smul_right
-    (hW : MDiffAt[s] (T% W) x) (hs : UniqueMDiffWithinAt I s x) :
+    (hW : MDiffAt[s] (T% W) x) (hs : UniqueMDiffAt[s] x) :
     mlieBracketWithin I V (c • W) s x = c • mlieBracketWithin I V W s x := by
   simpa [mfderivWithin_const, mvfderivWithin] using!
     mlieBracketWithin_smul_right (mdifferentiableWithinAt_const (c := c)) (V := V) hW hs
@@ -443,7 +443,7 @@ lemma mlieBracket_const_smul_right (hW : MDiffAt (T% W) x) :
 
 set_option backward.isDefEq.respectTransparency false in
 lemma mlieBracketWithin_add_left
-    (hV : MDiffAt[s] (T% V) x) (hV₁ : MDiffAt[s] (T% V₁) x) (hs : UniqueMDiffWithinAt I s x) :
+    (hV : MDiffAt[s] (T% V) x) (hV₁ : MDiffAt[s] (T% V₁) x) (hs : UniqueMDiffAt[s] x) :
     mlieBracketWithin I (V + V₁) W s x =
       mlieBracketWithin I V W s x + mlieBracketWithin I V₁ W s x := by
   simp only [mlieBracketWithin_apply]
@@ -458,7 +458,7 @@ lemma mlieBracket_add_left (hV : MDiffAt (T% V) x) (hV₁ : MDiffAt (T% V₁) x)
   exact mlieBracketWithin_add_left hV hV₁ (uniqueMDiffWithinAt_univ _)
 
 lemma mlieBracketWithin_add_right
-    (hW : MDiffAt[s] (T% W) x) (hW₁ : MDiffAt[s] (T% W₁) x) (hs : UniqueMDiffWithinAt I s x) :
+    (hW : MDiffAt[s] (T% W) x) (hW₁ : MDiffAt[s] (T% W₁) x) (hs : UniqueMDiffAt[s] x) :
     mlieBracketWithin I V (W + W₁) s x =
       mlieBracketWithin I V W s x + mlieBracketWithin I V W₁ s x := by
   rw [mlieBracketWithin_swap, Pi.neg_apply, mlieBracketWithin_add_left hW hW₁ hs,
@@ -470,7 +470,7 @@ lemma mlieBracket_add_right (hW : MDiffAt (T% W) x) (hW₁ : MDiffAt (T% W₁) x
   simp only [← mlieBracketWithin_univ] at hW hW₁ ⊢
   exact mlieBracketWithin_add_right hW hW₁ (uniqueMDiffWithinAt_univ _)
 
-theorem mlieBracketWithin_of_mem_nhdsWithin (st : t ∈ 𝓝[s] x) (hs : UniqueMDiffWithinAt I s x)
+theorem mlieBracketWithin_of_mem_nhdsWithin (st : t ∈ 𝓝[s] x) (hs : UniqueMDiffAt[s] x)
     (hV : MDiffAt[t] (T% V) x) (hW : MDiffAt[t] (T% W) x) :
     mlieBracketWithin I V W s x = mlieBracketWithin I V W t x := by
   simp only [mlieBracketWithin_apply]
@@ -484,12 +484,12 @@ theorem mlieBracketWithin_of_mem_nhdsWithin (st : t ∈ 𝓝[s] x) (hs : UniqueM
   · exact hV.differentiableWithinAt_mpullbackWithin_vectorField
   · exact hW.differentiableWithinAt_mpullbackWithin_vectorField
 
-theorem mlieBracketWithin_subset (st : s ⊆ t) (ht : UniqueMDiffWithinAt I s x)
+theorem mlieBracketWithin_subset (st : s ⊆ t) (ht : UniqueMDiffAt[s] x)
     (hV : MDiffAt[t] (T% V) x) (hW : MDiffAt[t] (T% W) x) :
     mlieBracketWithin I V W s x = mlieBracketWithin I V W t x :=
   mlieBracketWithin_of_mem_nhdsWithin (nhdsWithin_mono _ st self_mem_nhdsWithin) ht hV hW
 
-theorem mlieBracketWithin_eq_mlieBracket (hs : UniqueMDiffWithinAt I s x)
+theorem mlieBracketWithin_eq_mlieBracket (hs : UniqueMDiffAt[s] x)
     (hV : MDiffAt (T% V) x) (hW : MDiffAt (T% W) x) :
     mlieBracketWithin I V W s x = mlieBracket I V W x := by
   simp only [← mlieBracketWithin_univ, ← mdifferentiableWithinAt_univ] at hV hW ⊢
@@ -498,7 +498,7 @@ theorem mlieBracketWithin_eq_mlieBracket (hs : UniqueMDiffWithinAt I s x)
 theorem _root_.DifferentiableWithinAt.mlieBracketWithin_congr_mono
     (hV : MDiffAt[s] (T% V) x) (hVs : EqOn V₁ V t) (hVx : V₁ x = V x)
     (hW : MDiffAt[s] (T% W) x) (hWs : EqOn W₁ W t) (hWx : W₁ x = W x)
-    (hxt : UniqueMDiffWithinAt I t x) (h₁ : t ⊆ s) :
+    (hxt : UniqueMDiffAt[t] x) (h₁ : t ⊆ s) :
     mlieBracketWithin I V₁ W₁ t x = mlieBracketWithin I V W s x := by
   rw [mlieBracketWithin_congr hVs hVx hWs hWx]
   exact mlieBracketWithin_subset h₁ hxt hV hW
@@ -516,7 +516,7 @@ in chart domains. -/
 private lemma mpullbackWithin_mlieBracketWithin_aux [CompleteSpace E']
     {f : M → M'} {V W : Π (x : M'), TangentSpace I' x} {x₀ : M} {s : Set M} {t : Set M'}
     (hV : MDiffAt[t] (T% V) (f x₀)) (hW : MDiffAt[t] (T% W) (f x₀))
-    (hu : UniqueMDiffOn I s) (hf : CMDiff[s] 2 f) (hx₀ : x₀ ∈ s)
+    (hu : UniqueMDiff[s]) (hf : CMDiff[s] 2 f) (hx₀ : x₀ ∈ s)
     (ht : t ⊆ (extChartAt I' (f x₀)).source) (hst : MapsTo f s t)
     (hsymm : IsSymmSndFDerivWithinAt 𝕜 ((extChartAt I' (f x₀)) ∘ f ∘ (extChartAt I x₀).symm)
       ((extChartAt I x₀).symm ⁻¹' s ∩ range I) (extChartAt I x₀ x₀)) :
@@ -578,7 +578,7 @@ private lemma mpullbackWithin_mlieBracketWithin_aux [CompleteSpace E']
     filter_upwards [self_mem_nhdsWithin, this] with y hy h'''y
     have h'y : f ((extChartAt I x₀).symm y) ∈ (extChartAt I' (f x₀)).source := ht (hst hy.1)
     have h''y : f ((extChartAt I x₀).symm y) ∈ (chartAt H' (f x₀)).source := by simpa using h'y
-    have huy : UniqueMDiffWithinAt 𝓘(𝕜, E) ((extChartAt I x₀).symm ⁻¹' s ∩ range I) y := by
+    have huy : UniqueMDiffAt[(extChartAt I x₀).symm ⁻¹' s ∩ range I] y := by
       apply UniqueDiffWithinAt.uniqueMDiffWithinAt
       rw [inter_comm]
       apply hu.uniqueDiffWithinAt_range_inter
@@ -652,7 +652,7 @@ diffeomorphisms. -/
 lemma mpullbackWithin_mlieBracketWithin_of_isSymmSndFDerivWithinAt
     {f : M → M'} {V W : Π (x : M'), TangentSpace I' x} {x₀ : M} {s : Set M} {t : Set M'}
     (hV : MDiffAt[t] (T% V) (f x₀)) (hW : MDiffAt[t] (T% W) (f x₀))
-    (hu : UniqueMDiffOn I s) (hf : CMDiffAt[s] 2 f x₀) (hx₀ : x₀ ∈ s)
+    (hu : UniqueMDiff[s]) (hf : CMDiffAt[s] 2 f x₀) (hx₀ : x₀ ∈ s)
     (hst : f ⁻¹' t ∈ 𝓝[s] x₀)
     (hsymm : IsSymmSndFDerivWithinAt 𝕜 ((extChartAt I' (f x₀)) ∘ f ∘ (extChartAt I x₀).symm)
       ((extChartAt I x₀).symm ⁻¹' s ∩ range I) (extChartAt I x₀ x₀)) :
@@ -741,7 +741,7 @@ becomes easier to check.) -/
 lemma mpullbackWithin_mlieBracketWithin'
     {f : M → M'} {V W : Π (x : M'), TangentSpace I' x} {x₀ : M} {s u : Set M} {t : Set M'}
     (hV : MDiffAt[t] (T% V) (f x₀)) (hW : MDiffAt[t] (T% W) (f x₀))
-    (hs : UniqueMDiffOn I s) (hu : UniqueMDiffOn I u)
+    (hs : UniqueMDiff[s]) (hu : UniqueMDiff[u])
     (hf : CMDiffAt[u] n f x₀) (hx₀ : x₀ ∈ s) (hn : minSmoothness 𝕜 2 ≤ n)
     (hst : f ⁻¹' t ∈ 𝓝[s] x₀) (h'x₀ : x₀ ∈ closure (interior u)) (hsu : s ⊆ u) :
     mpullbackWithin I I' f (mlieBracketWithin I' V W t) s x₀ =
@@ -777,7 +777,7 @@ lemma mpullbackWithin_mlieBracketWithin'
 lemma mpullbackWithin_mlieBracketWithin
     {f : M → M'} {V W : Π (x : M'), TangentSpace I' x} {x₀ : M} {s : Set M} {t : Set M'}
     (hV : MDiffAt[t] (T% V) (f x₀)) (hW : MDiffAt[t] (T% W) (f x₀))
-    (hu : UniqueMDiffOn I s) (hf : CMDiffAt[s] n f x₀) (hx₀ : x₀ ∈ s)
+    (hu : UniqueMDiff[s]) (hf : CMDiffAt[s] n f x₀) (hx₀ : x₀ ∈ s)
     (hn : minSmoothness 𝕜 2 ≤ n)
     (hst : f ⁻¹' t ∈ 𝓝[s] x₀) (h'x₀ : x₀ ∈ closure (interior s)) :
     mpullbackWithin I I' f (mlieBracketWithin I' V W t) s x₀ =
@@ -788,7 +788,7 @@ lemma mpullbackWithin_mlieBracketWithin
 lemma mpullback_mlieBracketWithin
     {f : M → M'} {V W : Π (x : M'), TangentSpace I' x} {x₀ : M} {s : Set M} {t : Set M'}
     (hV : MDiffAt[t] (T% V) (f x₀)) (hW : MDiffAt[t] (T% W) (f x₀))
-    (hu : UniqueMDiffOn I s) (hf : CMDiffAt n f x₀) (hx₀ : x₀ ∈ s)
+    (hu : UniqueMDiff[s]) (hf : CMDiffAt n f x₀) (hx₀ : x₀ ∈ s)
     (hn : minSmoothness 𝕜 2 ≤ n) (hst : f ⁻¹' t ∈ 𝓝[s] x₀) :
     mpullback I I' f (mlieBracketWithin I' V W t) x₀ =
       mlieBracketWithin I (mpullback I I' f V) (mpullback I I' f W) s x₀ := by
@@ -830,7 +830,7 @@ protected lemma _root_.ContMDiffWithinAt.mlieBracketWithin_vectorField
     [IsManifold I (n + 1) M] {m : ℕ∞ω}
     {U V : Π (x : M), TangentSpace I x} {s : Set M} {x : M}
     (hU : CMDiffAt[s] n (T% U) x) (hV : CMDiffAt[s] n (T% V) x)
-    (hs : UniqueMDiffOn I s) (hx : x ∈ s) (hmn : minSmoothness 𝕜 (m + 1) ≤ n) :
+    (hs : UniqueMDiff[s]) (hx : x ∈ s) (hmn : minSmoothness 𝕜 (m + 1) ≤ n) :
     CMDiffAt[s] m (T% (mlieBracketWithin I U V s)) x := by
   /- The statement is not obvious, since at different points the Lie bracket is defined using
   different charts. However, since we know that the Lie bracket is invariant under diffeos, we can
@@ -902,7 +902,7 @@ lemma _root_.ContMDiffAt.mlieBracket_vectorField {m n : ℕ∞}
 lemma _root_.ContMDiffOn.mlieBracketWithin_vectorField {m n : ℕ∞}
     [IsManifold I (n + 1) M] {U V : Π (x : M), TangentSpace I x}
     (hU : CMDiff[s] n (T% U)) (hV : CMDiff[s] n (T% V))
-    (hs : UniqueMDiffOn I s) (hmn : minSmoothness 𝕜 (m + 1) ≤ n) :
+    (hs : UniqueMDiff[s]) (hmn : minSmoothness 𝕜 (m + 1) ≤ n) :
     CMDiff[s] m (T% (mlieBracketWithin I U V s)) :=
   fun x hx ↦ (hU x hx).mlieBracketWithin_vectorField (hV x hx) hs hx hmn
 
@@ -924,7 +924,7 @@ variable [IsManifold I (minSmoothness 𝕜 3) M] [CompleteSpace E]
 `[U, [V, W]] = [[U, V], W] + [V, [U, W]]` (also called Jacobi identity). -/
 theorem leibniz_identity_mlieBracketWithin_apply
     {U V W : Π (x : M), TangentSpace I x} {s : Set M} {x : M}
-    (hs : UniqueMDiffOn I s) (h's : x ∈ closure (interior s)) (hx : x ∈ s)
+    (hs : UniqueMDiff[s]) (h's : x ∈ closure (interior s)) (hx : x ∈ s)
     (hU : CMDiffAt[s] (minSmoothness 𝕜 2) (T% U) x)
     (hV : CMDiffAt[s] (minSmoothness 𝕜 2) (T% V) x)
     (hW : CMDiffAt[s] (minSmoothness 𝕜 2) (T% W) x) :

--- a/Mathlib/Geometry/Manifold/VectorField/Pullback.lean
+++ b/Mathlib/Geometry/Manifold/VectorField/Pullback.lean
@@ -154,7 +154,7 @@ lemma mpullbackWithin_neg :
   simp [mpullbackWithin_apply]
 
 set_option backward.isDefEq.respectTransparency false in
-lemma mpullbackWithin_id {V : Π (x : M), TangentSpace I x} (h : UniqueMDiffWithinAt I s x) :
+lemma mpullbackWithin_id {V : Π (x : M), TangentSpace I x} (h : UniqueMDiffAt[s] x) :
     mpullbackWithin I I id V s x = V x := by
   simp [mpullbackWithin_apply, mfderivWithin_id h]
 
@@ -222,7 +222,7 @@ set_option backward.isDefEq.respectTransparency false in
 lemma mpullbackWithin_comp_of_left
     {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x} {s : Set M} {t : Set M'}
     {x₀ : M} (hf : MDiffAt[s] f x₀) (h : Set.MapsTo f s t)
-    (hu : UniqueMDiffWithinAt I s x₀) (hg' : (mfderiv[t] g (f x₀)).IsInvertible) :
+    (hu : UniqueMDiffAt[s] x₀) (hg' : (mfderiv[t] g (f x₀)).IsInvertible) :
     mpullbackWithin I I'' (g ∘ f) V s x₀ =
       mpullbackWithin I I' f (mpullbackWithin I' I'' g V t) s x₀ := by
   simp only [mpullbackWithin]
@@ -235,7 +235,7 @@ set_option backward.isDefEq.respectTransparency false in
 lemma mpullbackWithin_comp_of_right
     {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x} {s : Set M} {t : Set M'}
     {x₀ : M} (hg : MDiffAt[t] g (f x₀)) (h : Set.MapsTo f s t)
-    (hu : UniqueMDiffWithinAt I s x₀) (hf' : (mfderiv[s] f x₀).IsInvertible) :
+    (hu : UniqueMDiffAt[s] x₀) (hf' : (mfderiv[s] f x₀).IsInvertible) :
     mpullbackWithin I I'' (g ∘ f) V s x₀ =
       mpullbackWithin I I' f (mpullbackWithin I' I'' g V t) s x₀ := by
   simp only [mpullbackWithin]
@@ -260,7 +260,7 @@ variable [IsManifold I 2 M] [IsManifold I' 2 M'] [CompleteSpace E]
 differentiable. Version within a set at a point. -/
 protected lemma _root_.MDifferentiableWithinAt.mpullbackWithin_vectorField_inter
     (hV : MDiffAt[t] (T% V) (f x₀)) (hf : CMDiffAt[s] n f x₀) (hf' : (mfderiv[s] f x₀).IsInvertible)
-    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : 2 ≤ n) :
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiff[s]) (hmn : 2 ≤ n) :
     MDiffAt[s ∩ f ⁻¹' t] (T% (mpullbackWithin I I' f V s)) x₀ := by
   /- We want to apply the theorem `MDifferentiableWithinAt.clm_apply_of_inCoordinates`,
   stating that applying linear maps to vector fields gives a smooth result when the linear map and
@@ -324,7 +324,7 @@ protected lemma _root_.MDifferentiableWithinAt.mpullbackWithin_vectorField_inter
 lemma _root_.MDifferentiableWithinAt.mpullbackWithin_vectorField_inter_of_eq
     (hV : MDiffAt[t] (T% V) y₀) (hf : CMDiffAt[s] n f x₀)
     (hf' : (mfderiv[s] f x₀).IsInvertible)
-    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : 2 ≤ n) (h : y₀ = f x₀) :
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiff[s]) (hmn : 2 ≤ n) (h : y₀ = f x₀) :
     MDiffAt[s ∩ f ⁻¹' t] (T% (mpullbackWithin I I' f V s)) x₀ := by
   subst h
   exact hV.mpullbackWithin_vectorField_inter hf hf' hx₀ hs hmn
@@ -334,7 +334,7 @@ differentiable. Version on a set. -/
 protected lemma _root_.MDifferentiableOn.mpullbackWithin_vectorField_inter
     (hV : MDiff[t] (T% V)) (hf : CMDiff[s] n f)
     (hf' : ∀ x ∈ s ∩ f ⁻¹' t, (mfderiv[s] f x).IsInvertible)
-    (hs : UniqueMDiffOn I s) (hmn : 2 ≤ n) :
+    (hs : UniqueMDiff[s]) (hmn : 2 ≤ n) :
     MDiff[(s ∩ f ⁻¹' t)] (T% (mpullbackWithin I I' f V s)) :=
   fun _ hx₀ ↦ MDifferentiableWithinAt.mpullbackWithin_vectorField_inter
     (hV _ hx₀.2) (hf _ hx₀.1) (hf' _ hx₀) hx₀.1 hs hmn
@@ -395,7 +395,7 @@ Version within a set at a point. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter
     (hV : CMDiffAt[t] m (T% V) (f x₀)) (hf : CMDiffAt[s] n f x₀)
     (hf' : (mfderiv[s] f x₀).IsInvertible)
-    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) :
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiff[s]) (hmn : m + 1 ≤ n) :
     CMDiffAt[s ∩ f ⁻¹' t] m (T% (mpullbackWithin I I' f V s)) x₀ := by
   /- We want to apply the theorem `ContMDiffWithinAt.clm_apply_of_inCoordinates`, stating
   that applying linear maps to vector fields gives a smooth result when the linear map and the
@@ -454,7 +454,7 @@ protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter
 
 lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter_of_eq
     (hV : CMDiffAt[t] m (T% V) y₀) (hf : CMDiffAt[s] n f x₀) (hf' : (mfderiv[s] f x₀).IsInvertible)
-    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (h : f x₀ = y₀) :
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiff[s]) (hmn : m + 1 ≤ n) (h : f x₀ = y₀) :
     CMDiffAt[s ∩ f ⁻¹' t] m (T% (mpullbackWithin I I' f V s)) x₀ := by
   subst h
   exact ContMDiffWithinAt.mpullbackWithin_vectorField_inter hV hf hf' hx₀ hs hmn
@@ -465,7 +465,7 @@ Version within a set at a point. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem
     (hV : CMDiffAt[t] m (T% V) (f x₀)) (hf : CMDiffAt[s] n f x₀)
     (hf' : (mfderiv[s] f x₀).IsInvertible)
-    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (hst : f ⁻¹' t ∈ 𝓝[s] x₀) :
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiff[s]) (hmn : m + 1 ≤ n) (hst : f ⁻¹' t ∈ 𝓝[s] x₀) :
     CMDiffAt[s] m (T% (mpullbackWithin I I' f V s)) x₀ := by
   apply (ContMDiffWithinAt.mpullbackWithin_vectorField_inter
     hV hf hf' hx₀ hs hmn).mono_of_mem_nhdsWithin
@@ -476,7 +476,7 @@ with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem_of_eq
     (hV : CMDiffAt[t] m (T% V) y₀) (hf : CMDiffAt[s] n f x₀) (hf' : (mfderiv[s] f x₀).IsInvertible)
-    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (hst : f ⁻¹' t ∈ 𝓝[s] x₀)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiff[s]) (hmn : m + 1 ≤ n) (hst : f ⁻¹' t ∈ 𝓝[s] x₀)
     (hy₀ : f x₀ = y₀) :
     CMDiffAt[s] m (T% (mpullbackWithin I I' f V s)) x₀ := by
   subst hy₀
@@ -488,7 +488,7 @@ Version within a set at a point. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField
     (hV : CMDiffAt[t] m (T% V) (f x₀)) (hf : CMDiffAt[s] n f x₀)
     (hf' : (mfderiv[s] f x₀).IsInvertible)
-    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (hst : MapsTo f s t) :
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiff[s]) (hmn : m + 1 ≤ n) (hst : MapsTo f s t) :
     CMDiffAt[s] m (T% (mpullbackWithin I I' f V s)) x₀ :=
   ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem hV hf hf' hx₀ hs hmn
     hst.preimage_mem_nhdsWithin
@@ -498,7 +498,7 @@ with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_eq
     (hV : CMDiffAt[t] m (T% V) y₀) (hf : CMDiffAt[s] n f x₀) (hf' : (mfderiv[s] f x₀).IsInvertible)
-    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (hst : MapsTo f s t) (h : f x₀ = y₀) :
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiff[s]) (hmn : m + 1 ≤ n) (hst : MapsTo f s t) (h : f x₀ = y₀) :
     CMDiffAt[s] m (T% (mpullbackWithin I I' f V s)) x₀ := by
   subst h
   exact ContMDiffWithinAt.mpullbackWithin_vectorField hV hf hf' hx₀ hs hmn hst
@@ -509,7 +509,7 @@ Version within a set at a point, with a set used for the pullback possibly large
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField' {u : Set M}
     (hV : CMDiffAt[t] m (T% V) (f x₀))
     (hf : CMDiffAt[u] n f x₀) (hf' : (mfderiv[u] f x₀).IsInvertible)
-    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiff[s]) (hmn : m + 1 ≤ n)
     (hst : f ⁻¹' t ∈ 𝓝[s] x₀) (hu : s ⊆ u) :
     CMDiffAt[s] m (T% (mpullbackWithin I I' f V u)) x₀ := by
   have hn : 1 ≤ n := le_trans (by simp) hmn
@@ -530,7 +530,7 @@ with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point, with a set used for the pullback possibly larger. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_eq' {u : Set M}
     (hV : CMDiffAt[t] m (T% V) y₀) (hf : CMDiffAt[u] n f x₀) (hf' : (mfderiv[u] f x₀).IsInvertible)
-    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (hst : f ⁻¹' t ∈ 𝓝[s] x₀)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiff[s]) (hmn : m + 1 ≤ n) (hst : f ⁻¹' t ∈ 𝓝[s] x₀)
     (hu : s ⊆ u) (hy₀ : f x₀ = y₀) :
     CMDiffAt[s] m (T% (mpullbackWithin I I' f V u)) x₀ := by
   subst hy₀
@@ -542,7 +542,7 @@ Version on a set. -/
 protected lemma _root_.ContMDiffOn.mpullbackWithin_vectorField_inter
     (hV : CMDiff[t] m (T% V)) (hf : CMDiff[s] n f)
     (hf' : ∀ x ∈ s ∩ f ⁻¹' t, (mfderiv[s] f x).IsInvertible)
-    (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) :
+    (hs : UniqueMDiff[s]) (hmn : m + 1 ≤ n) :
     CMDiff[s ∩ f ⁻¹' t] m (T% (mpullbackWithin I I' f V s)) :=
   fun _ hx₀ ↦ ContMDiffWithinAt.mpullbackWithin_vectorField_inter
     (hV _ hx₀.2) (hf _ hx₀.1) (hf' _ hx₀) hx₀.1 hs hmn
@@ -616,7 +616,7 @@ protected lemma _root_.ContMDiff.mpullback_vectorField
 
 lemma contMDiffWithinAt_mpullbackWithin_extChartAt_symm
     {V : Π (x : M), TangentSpace I x} (hV : CMDiffAt[s] m (T% V) x)
-    (hs : UniqueMDiffOn I s) (hx : x ∈ s) (hmn : m + 1 ≤ n) :
+    (hs : UniqueMDiff[s]) (hx : x ∈ s) (hmn : m + 1 ≤ n) :
     CMDiffAt[(extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s] m
       (T% (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (range I))) (extChartAt I x x) :=
   ContMDiffWithinAt.mpullbackWithin_vectorField_of_eq' hV
@@ -628,7 +628,7 @@ lemma contMDiffWithinAt_mpullbackWithin_extChartAt_symm
 
 lemma eventually_contMDiffWithinAt_mpullbackWithin_extChartAt_symm
     {V : Π (x : M), TangentSpace I x} (hV : CMDiffAt[s] m (T% V) x)
-    (hs : UniqueMDiffOn I s) (hx : x ∈ s) (hmn : m + 1 ≤ n) (hm : m ≠ ∞) :
+    (hs : UniqueMDiff[s]) (hx : x ∈ s) (hmn : m + 1 ≤ n) (hm : m ≠ ∞) :
     ∀ᶠ y in 𝓝[s] x, CMDiffAt[(extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s] m
     (T% (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (range I))) (extChartAt I x y) := by
   have T := nhdsWithin_mono _ (subset_insert _ _)

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -237,6 +237,26 @@ variable {φ : OpenPartialHomeomorph M E} {ψ : PartialEquiv M E}
 #guard_msgs in
 #check MDiffAt[s] ψ
 
+/-- info: UniqueMDiffOn I s : Prop -/
+#guard_msgs in
+#check UniqueMDiff[s]
+
+/-- info: UniqueMDiffOn (modelWithCornersSelf Real Real) (Set.Icc 0 1) : Prop -/
+#guard_msgs in
+#check UniqueMDiff[(Set.Icc 0 1 : Set ℝ)]
+
+/-- error: `Real` has type `Type` which is not of the form `Set α` for some `α`. -/
+#guard_msgs in
+#check UniqueMDiff[ℝ]
+
+/-- info: UniqueMDiffWithinAt I s : M → Prop -/
+#guard_msgs in
+#check UniqueMDiffAt[s]
+
+/-- info: UniqueMDiffWithinAt I s m : Prop -/
+#guard_msgs in
+#check UniqueMDiffAt[s] m
+
 -- Testing an error message.
 section
 

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -530,11 +530,9 @@ end
 end differentiability
 
 /-! Tests for the elaborators for `UniqueMDiff{WithinAt,On}`. -/
-section unique
+section UniqueMDiff
 
-variable {EM' : Type*} [NormedAddCommGroup EM']
-  [NormedSpace 𝕜 EM'] {H' : Type*} [TopologicalSpace H'] (I' : ModelWithCorners 𝕜 EM' H')
-  {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M'] {f : M → M'} {s : Set M} {m : M}
+variable {s : Set M} {m : M}
 
 /-- info: UniqueMDiffOn I s : Prop -/
 #guard_msgs in
@@ -594,7 +592,7 @@ in the application
 set_option pp.mvars.anonymous false in
 #check UniqueMDiffOn I s
 
-end unique
+end UniqueMDiff
 
 /-! Tests for the custom elaborators for `ContMDiff{WithinAt,At,On}` -/
 section smoothness

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -237,39 +237,6 @@ variable {φ : OpenPartialHomeomorph M E} {ψ : PartialEquiv M E}
 #guard_msgs in
 #check MDiffAt[s] ψ
 
-/-- info: UniqueMDiffOn I s : Prop -/
-#guard_msgs in
-#check UniqueMDiff[s]
-
-/-- info: UniqueMDiffOn (modelWithCornersSelf Real Real) (Set.Icc 0 1) : Prop -/
-#guard_msgs in
-#check UniqueMDiff[(Set.Icc 0 1 : Set ℝ)]
-
-/-- error: `Real` has type `Type` which is not of the form `Set α` for some `α`. -/
-#guard_msgs in
-#check UniqueMDiff[ℝ]
-
-/-- info: UniqueMDiffWithinAt I s : M → Prop -/
-#guard_msgs in
-#check UniqueMDiffAt[s]
-
-/-- info: UniqueMDiffWithinAt I s m : Prop -/
-#guard_msgs in
-#check UniqueMDiffAt[s] m
-
-/-- info: UniqueMDiffWithinAt I Set.univ m : Prop -/
-#guard_msgs in
-#check UniqueMDiffAt[(Set.univ : Set M)] m
-
--- In the future, the elaborators should take the type of `m` into account.
-/--
-error: Could not find a model with corners for `?m.52`.
-
-Hint: the expected type contains metavariables, maybe you need to provide an implicit argument
--/
-#guard_msgs in
-#check UniqueMDiffAt[Set.univ] m
-
 -- Testing an error message.
 section
 
@@ -561,6 +528,73 @@ Hint: you can use the `T%` elaborator to convert a dependent function to a non-d
 end
 
 end differentiability
+
+/-! Tests for the elaborators for `UniqueMDiff{WithinAt,On}`. -/
+section unique
+
+variable {EM' : Type*} [NormedAddCommGroup EM']
+  [NormedSpace 𝕜 EM'] {H' : Type*} [TopologicalSpace H'] (I' : ModelWithCorners 𝕜 EM' H')
+  {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M'] {f : M → M'} {s : Set M} {m : M}
+
+/-- info: UniqueMDiffOn I s : Prop -/
+#guard_msgs in
+#check UniqueMDiff[s]
+
+/-- info: UniqueMDiffOn (modelWithCornersSelf Real Real) (Set.Icc 0 1) : Prop -/
+#guard_msgs in
+#check UniqueMDiff[(Set.Icc 0 1 : Set ℝ)]
+
+/-- error: `Real` has type `Type` which is not of the form `Set α` for some `α`. -/
+#guard_msgs in
+#check UniqueMDiff[ℝ]
+
+/-- info: UniqueMDiffWithinAt I s : M → Prop -/
+#guard_msgs in
+#check UniqueMDiffAt[s]
+
+/-- info: UniqueMDiffWithinAt I s m : Prop -/
+#guard_msgs in
+#check UniqueMDiffAt[s] m
+
+/-- info: UniqueMDiffWithinAt I Set.univ m : Prop -/
+#guard_msgs in
+#check UniqueMDiffAt[(Set.univ : Set M)] m
+
+-- In the future, the elaborators should take the type of `m` into account.
+/--
+error: Could not find a model with corners for `?_`.
+
+Hint: the expected type contains metavariables, maybe you need to provide an implicit argument
+-/
+#guard_msgs in
+set_option pp.mvars.anonymous false in
+#check UniqueMDiffAt[Set.univ] m
+
+variable {s : TopologicalSpace.Opens M}
+
+/-- info: UniqueMDiffOn I s.carrier : Prop -/
+#guard_msgs in
+#check UniqueMDiff[s.carrier]
+
+/-- error: `s` has type `TopologicalSpace.Opens M` which is not of the form `Set α` for some `α`. -/
+#guard_msgs in
+#check UniqueMDiff[s]
+
+/--
+error: Application type mismatch: The argument
+  s
+has type
+  TopologicalSpace.Opens M
+but is expected to have type
+  Set ?_
+in the application
+  UniqueMDiffOn I s
+-/
+#guard_msgs in
+set_option pp.mvars.anonymous false in
+#check UniqueMDiffOn I s
+
+end unique
 
 /-! Tests for the custom elaborators for `ContMDiff{WithinAt,At,On}` -/
 section smoothness

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -257,6 +257,19 @@ variable {φ : OpenPartialHomeomorph M E} {ψ : PartialEquiv M E}
 #guard_msgs in
 #check UniqueMDiffAt[s] m
 
+/-- info: UniqueMDiffWithinAt I Set.univ m : Prop -/
+#guard_msgs in
+#check UniqueMDiffAt[(Set.univ : Set M)] m
+
+-- In the future, the elaborators should take the type of `m` into account.
+/--
+error: Could not find a model with corners for `?m.52`.
+
+Hint: the expected type contains metavariables, maybe you need to provide an implicit argument
+-/
+#guard_msgs in
+#check UniqueMDiffAt[Set.univ] m
+
 -- Testing an error message.
 section
 

--- a/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
@@ -82,6 +82,21 @@ variable
 #guard_msgs in
 #check TotalSpace.mk (F := E) x (v x)
 
+/-- info: UniqueMDiff[s] : Prop -/
+#guard_msgs in
+#check UniqueMDiffOn I s
+
+/-- info: UniqueMDiffAt[s] : M → Prop -/
+#guard_msgs in
+#check UniqueMDiffWithinAt I s
+
+/-- info: UniqueMDiffAt[s] x : Prop -/
+#guard_msgs in
+#check UniqueMDiffWithinAt I s x
+
+/-- info: UniqueMDiffAt[s] : M → Prop -/
+#guard_msgs in
+#check UniqueMDiffWithinAt (𝕜 := ℝ) I s
 section ambiguity
 
 variable {g : E × E → M} in

--- a/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
@@ -97,6 +97,7 @@ variable
 /-- info: UniqueMDiffAt[s] : M → Prop -/
 #guard_msgs in
 #check UniqueMDiffWithinAt (𝕜 := ℝ) I s
+
 section ambiguity
 
 variable {g : E × E → M} in


### PR DESCRIPTION
This PR adds elaborators and delaborators for `UniqueMDiffOn` and `UniqueMDiffWithinAt`. The elaborators currently don't work for finding a model with corners on `TotalSpace`s since they don't provide `baseInfo`. This should hopefully be fixed by #40047. 


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
