### PR TITLE
[Merged by Bors] - fix(cache): lowercase fork repo in cache blob paths

### DIFF
--- a/Cache/Infra.lean
+++ b/Cache/Infra.lean
@@ -25,6 +25,17 @@ def MATHLIBREPO := "leanprover-community/mathlib4"
 def NIGHTLY_TESTING_REPO := "leanprover-community/mathlib4-nightly-testing"
 
 /--
+Canonical form of a GitHub `owner/repo` name for use as a cache blob path
+segment.
+
+GitHub treats owner and repository names case-insensitively, while Azure Blob
+Storage paths are case-sensitive. Lowercasing yields one shared key whatever
+capitalization a remote URL or the GitHub Actions context supplies, so a fork's
+uploads and downloads always meet at the same path.
+-/
+def normalizeRepo (repo : String) : String := repo.toLower
+
+/--
 Trust-classified Azure storage containers for the Mathlib cache.
 
 Each variant maps to one Azure Blob Storage container on the `lakecache` storage

--- a/Cache/Marker.lean
+++ b/Cache/Marker.lean
@@ -20,7 +20,9 @@ namespace Cache.Requests
 open System (FilePath)
 
 /--
-URL for the per-SHA marker blob: `{container}/m/{repo}/{sha}`.
+URL for the per-SHA marker blob: `{container}/m/{repo}/{sha}`, where `repo` is
+lowercased via `normalizeRepo` so the path is case-insensitive in the GitHub
+owner/repo name.
 
 The marker is uploaded by `put-staged` as the last step when an upload is
 SHA-scoped (`MATHLIB_CACHE_REPO_SCOPE` set). Its presence at this URL
@@ -29,7 +31,7 @@ indicates that the full `.ltar` upload completed for this commit, and lets
 a blob-listing call.
 -/
 def markerURL (container : Container) (repo sha : String) : String :=
-  s!"{container.azureURL}/m/{repo}/{sha}"
+  s!"{container.azureURL}/m/{normalizeRepo repo}/{sha}"
 
 /--
 Upload a tiny marker blob to `/m/{repo}/{sha}` in the given container. The

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -348,9 +348,13 @@ container (see `Container.flatPath`), not the repo: the same hash under
 `container` is `none` for the user-supplied `MATHLIB_CACHE_GET_URL` /
 `MATHLIB_CACHE_PUT_URL` URLs, where no container policy applies; the path then
 follows the repo directly — flat for `MATHLIBREPO`, prefixed otherwise.
+
+`repo` is lowercased via `normalizeRepo` so the repo-namespaced path is
+case-insensitive in the GitHub owner/repo name.
 -/
 def mkFileURL (container : Option Container) (repo containerURL fileName : String)
     (repoScope : Option String := none) : String :=
+  let repo := normalizeRepo repo
   let flat := match container with
     | some c => c.flatPath repo
     | none => repo == MATHLIBREPO

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -279,6 +279,11 @@ def test_mkFileURL : IO Unit := do
   assertEq "scope is ignored on a flat legacy path"
     "https://lakecache.blob.core.windows.net/mathlib4/f/abc.ltar"
     (mkFileURL (some .legacy) MATHLIBREPO Container.legacy.azureURL "abc.ltar" (some "abc123def"))
+  -- The repo segment is lowercased, so a mixed-case GitHub owner resolves to the
+  -- same path whether it reaches the cache from CI or a local remote URL.
+  assertEq "fork repo is lowercased in the path"
+    "https://lakecache.blob.core.windows.net/mathlib4-forks/f/alice/mathlib4/abc.ltar"
+    (mkFileURL (some .forks) "Alice/Mathlib4" Container.forks.azureURL "abc.ltar")
 
 end MkFileURL
 
@@ -476,6 +481,11 @@ def test_markerURL : IO Unit := do
   assertEq "marker URL respects the container base"
     "https://lakecache.blob.core.windows.net/mathlib4/m/someorg/mathlib4/sha9999"
     (markerURL .legacy "someorg/mathlib4" "sha9999")
+  -- The repo segment is lowercased, so an upload and a probe for the same fork
+  -- meet at one path regardless of how the owner name was capitalized.
+  assertEq "marker repo is lowercased in the path"
+    "https://lakecache.blob.core.windows.net/mathlib4-forks/m/alice/mathlib4/abc123"
+    (markerURL .forks "Alice/Mathlib4" "abc123")
 
 end Marker
 


### PR DESCRIPTION
Azure Blob Storage paths are case-sensitive, but GitHub owner/repo names are not. CI uploads a fork's cache under its "canonical" (according to GitHub) repo name, while `cache get`/`query` derive the repo from a local git remote URL (often lowercased).

Lowercase the repo path segment in `mkFileURL` and `markerURL` so uploads and downloads always meet at one key.

Follow-up to #40035.