### PR TITLE
[Merged by Bors] - fix(cache): correct the marker probe on Windows, add Windows test

### DIFF
--- a/.github/workflows/cache_test.yml
+++ b/.github/workflows/cache_test.yml
@@ -43,9 +43,11 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Install elan and the toolchain cross-platform. Build/test/lint and the
-      # Mathlib cache are all disabled, so this is a toolchain-only setup; the
-      # `lake` steps below then build and run just the `cache-test` target.
+      # Install elan and the toolchain cross-platform. Build/test/lint, the
+      # Mathlib cache, and the GitHub cache are all disabled, so this is a
+      # toolchain-only setup; the `lake` steps below then build and run just the
+      # `cache-test` target. (The GitHub cache cannot be written from fork PRs
+      # and buys little for this small build, so it stays off.)
       - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
         with:
           auto-config: "false"
@@ -53,6 +55,7 @@ jobs:
           test: "false"
           lint: "false"
           use-mathlib-cache: "false"
+          use-github-cache: "false"
 
       - name: build cache-test
         run: lake build cache-test

--- a/.github/workflows/cache_test.yml
+++ b/.github/workflows/cache_test.yml
@@ -14,6 +14,8 @@ on:
       # a bump can break the tool's compilation even with `Cache/` untouched.
       - 'lakefile.lean'
       - 'lean-toolchain'
+      # Re-run when the workflow itself changes.
+      - '.github/workflows/cache_test.yml'
 
 concurrency:
   group: cache-test-${{ github.ref }}
@@ -32,6 +34,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # `leanprover/lean-action` installs elan from a bash step and adds it to the
+    # path in that shell's form, so the `lake` steps below must also run under
+    # bash (available on Windows runners as Git Bash) to find it.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/cache_test.yml
+++ b/.github/workflows/cache_test.yml
@@ -1,8 +1,9 @@
-# Runs the cache tool's unit tests (`lake exe cache-test`) on PRs that touch
-# the cache code. The suite is deliberately network-free (see the module
-# docstring in `Cache/Test.lean`), so the job only needs the toolchain and the
-# package dependencies' sources — not a Mathlib build — and finishes in a few
-# minutes on a hosted runner.
+# Runs the cache tool's unit tests (`lake exe cache-test`) on Linux and Windows
+# for PRs that touch the cache code. The suite is deliberately network-free (see
+# the module docstring in `Cache/Test.lean`), so the job only needs the toolchain
+# and the package dependencies' sources — not a Mathlib build — and finishes in a
+# few minutes on a hosted runner. The Windows job guards the tool's cross-platform
+# behavior, such as the null device the marker probe and tests discard output to.
 name: cache tests
 
 on:
@@ -24,20 +25,29 @@ permissions:
 jobs:
   cache-test:
     if: github.repository == 'leanprover-community/mathlib4'
-    runs-on: ubuntu-latest
+    strategy:
+      # Report both platforms even if one fails, so a Windows-only break is
+      # never hidden by a Linux failure (or vice versa).
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: install elan
-        run: |
-          set -o pipefail
-          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
-          chmod +x elan-init.sh
-          ./elan-init.sh -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+      # Install elan and the toolchain cross-platform. Build/test/lint and the
+      # Mathlib cache are all disabled, so this is a toolchain-only setup; the
+      # `lake` steps below then build and run just the `cache-test` target.
+      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
+        with:
+          auto-config: "false"
+          build: "false"
+          test: "false"
+          lint: "false"
+          use-mathlib-cache: "false"
 
       - name: build cache-test
         run: lake build cache-test
 
       - name: run cache tests
-        run: .lake/build/bin/cache-test
+        run: lake exe cache-test

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -82,6 +82,10 @@ def CURLBIN :=
 
 def EXE := if System.Platform.isWindows then ".exe" else ""
 
+/-- The platform's null device, for discarding a command's output: `NUL` on
+Windows, `/dev/null` elsewhere. -/
+def nullDevice : String := if System.Platform.isWindows then "NUL" else "/dev/null"
+
 def LAKEPACKAGESDIR : FilePath :=
   ".lake" / "packages"
 

--- a/Cache/Query.lean
+++ b/Cache/Query.lean
@@ -86,9 +86,11 @@ billed as a Read op.
 def probeContainerForSHA (container : Container) (repo sha : String) :
     IO Bool := do
   let url := markerURL container repo sha
+  -- Discard the response body to the platform null device (`NUL` on Windows),
+  -- so curl reports a write error only on a genuine failure, not on every probe.
   let out ← IO.Process.output
     {cmd := (← IO.getCurl),
-     args := #["-s", "-o", "/dev/null", "-w", "%{http_code}", "-I", url],
+     args := #["-s", "-o", IO.nullDevice, "-w", "%{http_code}", "-I", url],
      cwd := "."}
   if out.exitCode != 0 then
     -- Network error; assume no cache at this SHA

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -74,14 +74,14 @@ def assertEq (name expected actual : String) : IO Unit := do
     IO.eprintln s!"  FAIL: {name}\n    expected: {expected}\n    actual:   {actual}"
     failures.modify (· + 1)
 
-/-- Run `action` with both stdout and stderr redirected to /dev/null. Restores
-both on completion, including on exception. Apply this to every production code
-call in tests so diagnostic prints never mix with test output, regardless of
-whether the production code currently produces any. -/
+/-- Run `action` with both stdout and stderr redirected to the platform null
+device. Restores both on completion, including on exception. Apply this to every
+production code call in tests so diagnostic prints never mix with test output,
+regardless of whether the production code currently produces any. -/
 private def withSuppressedOutput (action : IO α) : IO α := do
   let savedOut ← IO.getStdout
   let savedErr ← IO.getStderr
-  let sink ← IO.FS.Handle.mk "/dev/null" IO.FS.Mode.append
+  let sink ← IO.FS.Handle.mk Cache.IO.nullDevice IO.FS.Mode.append
   let sinkStream := IO.FS.Stream.ofHandle sink
   -- `IO.setStdout`/`IO.setStderr` return the previous stream; we already saved it,
   -- so discard the return value here.


### PR DESCRIPTION
On Windows, `cache query` and the "HEAD not built by CI" note always report no cache, even though the commit is cached and `cache get` downloads it. `probeContainerForSHA` discards curl's output to `/dev/null`, which isn't a valid path on Windows, so curl exits non-zero and the probe reads every marker as absent.

The fix is to use a platform null device (`NUL` on Windows) in the probe.

Also adds a `windows-latest` leg to the cache-test workflow to catch such regressions.

Follow-up to #40035