### PR TITLE
Add a reachability characterization for PFun.fix

### DIFF
--- a/Mathlib/Computability/TuringMachine/Config.lean
+++ b/Mathlib/Computability/TuringMachine/Config.lean
@@ -355,22 +355,13 @@ theorem exists_code {n} {f : List.Vector ℕ n →. ℕ} (hf : Nat.Partrec' f) :
         obtain h | rfl := Nat.lt_succ_iff_lt_or_eq.1 h'
         exacts [hm _ h, h]
     · rintro ⟨n, ⟨hn, hm⟩, rfl⟩
-      refine ⟨n.succ::v.1, ?_, rfl⟩
-      have : (n.succ::v.1 : List ℕ) ∈
-        PFun.fix (fun v =>
-          (cf.eval v).bind fun y =>
-            Part.some <|
-              if y.headI = 0 then Sum.inl (v.headI.succ :: v.tail)
-                else Sum.inr (v.headI.succ :: v.tail))
-            (n::v.val) :=
-        PFun.mem_fix_iff.2 (Or.inl (by simp [hf, hn]))
-      generalize (n.succ :: v.1 : List ℕ) = w at this ⊢
+      refine ⟨n.succ::v.1,
+        PFun.mem_fix_of_reflTransGen (a' := n :: v.val) ?_ (by simp [hf, hn]), rfl⟩
       clear hn
       induction n with
-      | zero => exact this
+      | zero => exact .refl
       | succ n IH =>
-        refine IH (fun {m} h' => hm (Nat.lt_succ_of_lt h'))
-          (PFun.mem_fix_iff.2 (Or.inr ⟨_, ?_, this⟩))
+        refine (IH fun {m} h' => hm (Nat.lt_succ_of_lt h')).tail ?_
         simp only [hf, hm n.lt_succ_self, Part.bind_some, List.headI, if_false,
           Part.mem_some_iff, List.tail_cons]
 

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -335,6 +335,29 @@ theorem fixInduction'_fwd {C : α → Sort*} {f : α →. β ⊕ α} {b : β} {a
     (Part.get_eq_of_mem fa (dom_of_mem_fix h)).symm
   simp
 
+/-- Membership in `f.fix a` is equivalent to following zero or more forward `Sum.inr` steps
+from `a`, then stopping with a `Sum.inl` value. -/
+theorem mem_fix_iff_exists_reflTransGen {f : α →. β ⊕ α} {a : α} {b : β} :
+    b ∈ f.fix a ↔
+      ∃ a', Relation.ReflTransGen (fun x y => Sum.inr y ∈ f x) a a' ∧
+        Sum.inl b ∈ f a' := by
+  constructor
+  · exact fun h =>
+      fixInduction' h (fun a' hb => ⟨a', .refl, hb⟩)
+        fun a₀ a₁ _ ha₁ ⟨a', hreach, hb⟩ => ⟨a', .head ha₁ hreach, hb⟩
+  · rintro ⟨a', hreach, hb⟩
+    induction hreach using Relation.ReflTransGen.head_induction_on with
+    | refl => exact fix_stop hb
+    | head hstep _ ih => exact mem_fix_iff.2 (Or.inr ⟨_, hstep, ih⟩)
+
+/-- If following zero or more forward `Sum.inr` steps from `a` reaches a state where `f` stops
+with `b`, then `b ∈ f.fix a`. -/
+theorem mem_fix_of_reflTransGen {f : α →. β ⊕ α} {a a' : α} {b : β}
+    (hreach : Relation.ReflTransGen (fun x y => Sum.inr y ∈ f x) a a')
+    (hb : Sum.inl b ∈ f a') :
+    b ∈ f.fix a :=
+  mem_fix_iff_exists_reflTransGen.2 ⟨a', hreach, hb⟩
+
 variable (f : α →. β)
 
 /-- Image of a set under a partial function. -/


### PR DESCRIPTION
Add a `ReflTransGen` characterization of `PFun.fix` and use it to simplify one Turing machine proof.