### PR TITLE
[Merged by Bors] - fix(cache): cross-repo PRs from the nightly-testing fork

### DIFF
--- a/.github/actions/cache-trust-dispatch/action.yml
+++ b/.github/actions/cache-trust-dispatch/action.yml
@@ -66,6 +66,18 @@ runs:
         # be 403'd by Azure regardless. The dispatch exists so the workflow
         # does the right thing in the honest case; defence in depth is RBAC.
 
+        # Privileged containers (master, nightly-testing, pr-toolchain-tests) are
+        # writable only by a repo's own native CI, whose OIDC token is RBAC-scoped
+        # to match. A cross-repo pull request is built by build_fork.yml with
+        # fork-trust credentials whatever repo the PR head lives on (e.g. a `bump/*`
+        # branch on the mathlib4-nightly-testing fork), so it can only write
+        # `forks`. `GITHUB_REPOSITORY` is the repo the workflow runs as (the base
+        # repo for `pull_request_target`), i.e. the one whose credentials this job
+        # holds; when it differs from `$REPO`, the build is a fork and targets
+        # `forks` regardless of the head repo's own trust class.
+        if [ "$REPO" != "$GITHUB_REPOSITORY" ]; then
+          PRIMARY="forks"
+        else
         case "$REPO" in
           "leanprover-community/mathlib4")
             case "$BRANCH" in
@@ -121,6 +133,7 @@ runs:
             PRIMARY="forks"
             ;;
         esac
+        fi
 
         # Per-commit cache namespace, only for fork-trust uploads. Closes the
         # within-fork temporal replay attack: each commit's CI run gets its

--- a/.github/actions/cache-trust-dispatch/action.yml
+++ b/.github/actions/cache-trust-dispatch/action.yml
@@ -76,16 +76,10 @@ runs:
         # holds; when it differs from `$REPO`, the build is a fork and targets
         # `forks` regardless of the head repo's own trust class.
         if [ "$REPO" != "$GITHUB_REPOSITORY" ]; then
+          # Reads use the cache tool's per-repo default chain, which includes
+          # `forks` for every repo this case covers, so the upload is reachable
+          # without a `MATHLIB_CACHE_FROM` override here.
           PRIMARY="forks"
-          # The cache tool's default read chain for the head repo must include
-          # `forks` so this upload (and the post-build verification) are
-          # reachable. A foreign fork already defaults to [master, forks,
-          # legacy]; the mathlib4-nightly-testing fork defaults to
-          # [nightly-testing, legacy], which omits `forks`, so widen it —
-          # preferring the head repo's own nightly cache for unchanged deps.
-          if [ "$REPO" = "leanprover-community/mathlib4-nightly-testing" ]; then
-            READ_CHAIN="nightly-testing,forks,legacy"
-          fi
         else
         case "$REPO" in
           "leanprover-community/mathlib4")

--- a/.github/actions/cache-trust-dispatch/action.yml
+++ b/.github/actions/cache-trust-dispatch/action.yml
@@ -77,6 +77,15 @@ runs:
         # `forks` regardless of the head repo's own trust class.
         if [ "$REPO" != "$GITHUB_REPOSITORY" ]; then
           PRIMARY="forks"
+          # The cache tool's default read chain for the head repo must include
+          # `forks` so this upload (and the post-build verification) are
+          # reachable. A foreign fork already defaults to [master, forks,
+          # legacy]; the mathlib4-nightly-testing fork defaults to
+          # [nightly-testing, legacy], which omits `forks`, so widen it —
+          # preferring the head repo's own nightly cache for unchanged deps.
+          if [ "$REPO" = "leanprover-community/mathlib4-nightly-testing" ]; then
+            READ_CHAIN="nightly-testing,forks,legacy"
+          fi
         else
         case "$REPO" in
           "leanprover-community/mathlib4")

--- a/.github/actions/cache-trust-dispatch/action.yml
+++ b/.github/actions/cache-trust-dispatch/action.yml
@@ -76,9 +76,6 @@ runs:
         # holds; when it differs from `$REPO`, the build is a fork and targets
         # `forks` regardless of the head repo's own trust class.
         if [ "$REPO" != "$GITHUB_REPOSITORY" ]; then
-          # Reads use the cache tool's per-repo default chain, which includes
-          # `forks` for every repo this case covers, so the upload is reachable
-          # without a `MATHLIB_CACHE_FROM` override here.
           PRIMARY="forks"
         else
         case "$REPO" in

--- a/Cache/Infra.lean
+++ b/Cache/Infra.lean
@@ -140,11 +140,17 @@ def defaultContainersForRepo (repo : String) : List Container :=
     [.master, .legacy]
   else if repo == NIGHTLY_TESTING_REPO then
     -- Trusted-nightly consumers (`nightly-testing`, `nightly-testing-green`,
-    -- `bump/*`) read only `nightly-testing` + `legacy`; `pr-toolchain-tests` is
-    -- excluded so low-trust toolchain-PR uploads can't reach them. Toolchain-PR
-    -- branches opt into reading their own uploads with `--cache-from=...` (or,
-    -- in CI, via the `MATHLIB_CACHE_FROM` env var).
-    [.nightlyTesting, .legacy]
+    -- `bump/*`) read `nightly-testing` for the bulk, then `forks`, then `legacy`.
+    -- `forks` covers a cross-repo PR opened from this repo: it is built by
+    -- `build_fork.yml`, which can only upload to `forks`, so the artifacts for
+    -- such a commit live there rather than in `nightly-testing`. Reading them is
+    -- no wider a trust grant than `nightly-testing` itself: `forks` reads are
+    -- HEAD-scoped and namespaced under `/f/{repo}/...`, so a consumer only ever
+    -- reads artifacts built for its exact checked-out commit by a writer with
+    -- push access to this repo. `pr-toolchain-tests` stays excluded — those
+    -- uploads are unscoped and come from arbitrary-toolchain `lean-pr-testing-*`
+    -- branches, which opt in with `--cache-from=...` (or `MATHLIB_CACHE_FROM`).
+    [.nightlyTesting, .forks, .legacy]
   else
     -- Forks and everything else: `master` for shared upstream deps, the fork's
     -- own container for PR-specific files, then `legacy`.

--- a/Cache/Infra.lean
+++ b/Cache/Infra.lean
@@ -139,17 +139,9 @@ def defaultContainersForRepo (repo : String) : List Container :=
   if repo == MATHLIBREPO then
     [.master, .legacy]
   else if repo == NIGHTLY_TESTING_REPO then
-    -- Trusted-nightly consumers (`nightly-testing`, `nightly-testing-green`,
-    -- `bump/*`) read `nightly-testing` for the bulk, then `forks`, then `legacy`.
-    -- `forks` covers a cross-repo PR opened from this repo: it is built by
-    -- `build_fork.yml`, which can only upload to `forks`, so the artifacts for
-    -- such a commit live there rather than in `nightly-testing`. Reading them is
-    -- no wider a trust grant than `nightly-testing` itself: `forks` reads are
-    -- HEAD-scoped and namespaced under `/f/{repo}/...`, so a consumer only ever
-    -- reads artifacts built for its exact checked-out commit by a writer with
-    -- push access to this repo. `pr-toolchain-tests` stays excluded — those
-    -- uploads are unscoped and come from arbitrary-toolchain `lean-pr-testing-*`
-    -- branches, which opt in with `--cache-from=...` (or `MATHLIB_CACHE_FROM`).
+    -- `forks` is needed for PRs opened from this repo into mathlib4: those build
+    -- on `build_fork.yml`, which uploads only to `forks`. `pr-toolchain-tests`
+    -- stays excluded.
     [.nightlyTesting, .forks, .legacy]
   else
     -- Forks and everything else: `master` for shared upstream deps, the fork's

--- a/Cache/Infra.lean
+++ b/Cache/Infra.lean
@@ -139,9 +139,8 @@ def defaultContainersForRepo (repo : String) : List Container :=
   if repo == MATHLIBREPO then
     [.master, .legacy]
   else if repo == NIGHTLY_TESTING_REPO then
-    -- `forks` is needed for PRs opened from this repo into mathlib4: those build
-    -- on `build_fork.yml`, which uploads only to `forks`. `pr-toolchain-tests`
-    -- stays excluded.
+    -- `forks` is needed for PRs opened from this repo into mathlib4: their CI
+    -- uploads land in `forks`. `pr-toolchain-tests` is excluded.
     [.nightlyTesting, .forks, .legacy]
   else
     -- Forks and everything else: `master` for shared upstream deps, the fork's

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -200,8 +200,8 @@ def test_defaultContainersForRepo : IO Unit := do
   IO.println "defaultContainersForRepo:"
   assert "canonical repo → [master, legacy]"
     (defaultContainersForRepo MATHLIBREPO == [.master, .legacy])
-  assert "nightly-testing repo → [nightly-testing, legacy], no pr-toolchain-tests"
-    (defaultContainersForRepo NIGHTLY_TESTING_REPO == [.nightlyTesting, .legacy])
+  assert "nightly-testing repo → [nightly-testing, forks, legacy], no pr-toolchain-tests"
+    (defaultContainersForRepo NIGHTLY_TESTING_REPO == [.nightlyTesting, .forks, .legacy])
   assert "fork repo → [master, forks, legacy]"
     (defaultContainersForRepo "alice/mathlib4" == [.master, .forks, .legacy])
   assert "unknown repo falls back to the fork chain"


### PR DESCRIPTION
A PR opened from the `mathlib4-nightly-testing` fork into mathlib4 (e.g. #40732, a `bump/*` toolchain bump) is a cross-repo PR, built by `build_fork.yml` with fork-trust credentials — so its cache can only live in the `forks` container. Two things broke:

- **Upload (CI):** the trust dispatch keyed the container on the head repo, so it targeted `nightly-testing` and Azure RBAC returned 403. Classify any build whose repo differs from `$GITHUB_REPOSITORY` (the credential context) as a fork → `forks`.
- **Read (tool):** `defaultContainersForRepo` for the nightly-testing repo was `[nightly-testing, legacy]`, omitting `forks` — so neither the contributor's local `lake exe cache get` nor CI could find the upload. Add `forks` to the chain. It's no wider a trust grant than `nightly-testing` itself: `forks` reads are HEAD-scoped and namespaced under `/f/{repo}/…`, so only artifacts built for the exact checked-out commit by a push-access writer are served. `pr-toolchain-tests` stays excluded (unscoped, arbitrary-toolchain).

Native master/nightly/pr-toolchain and ordinary fork PRs are unchanged.

Follow-up to #40035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)