### PR TITLE
[Merged by Bors] - chore: rename `TwoSidedIdeal.mk`

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Ideal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Ideal.lean
@@ -261,7 +261,7 @@ theorem matrix_monotone : Monotone (matrix (R := R) n) :=
 theorem matrix_strictMono_of_nonempty [h : Nonempty n] :
     StrictMono (matrix (R := R) n) :=
   matrix_monotone n |>.strictMono_of_injective <|
-    .comp (fun _ _ => mk.inj) <| (RingCon.matrix_injective n).comp ringCon_injective
+    .comp (fun _ _ => ofRingCon.inj) <| (RingCon.matrix_injective n).comp ringCon_injective
 
 @[simp]
 theorem matrix_bot : (⊥ : TwoSidedIdeal R).matrix n = ⊥ :=

--- a/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
@@ -36,7 +36,9 @@ A two-sided ideal of a ring `R` is a subset of `R` that contains `0` and is clos
 negation, and absorbs multiplication on both sides.
 -/
 structure TwoSidedIdeal (R : Type*) [NonUnitalNonAssocRing R] where
-  /-- every two-sided-ideal is induced by a congruence relation on the ring. -/
+  /-- In a ring, every two-sided ideal is induced by a ring congruence relation. -/
+  ofRingCon ::
+  /-- The congruence relation induced by this ideal. -/
   ringCon : RingCon R
 
 end definitions
@@ -69,9 +71,19 @@ instance : PartialOrder (TwoSidedIdeal R) := .ofSetLike (TwoSidedIdeal R) R
 lemma mem_iff (x : R) : x ∈ I ↔ I.ringCon x 0 := Iff.rfl
 
 @[simp]
-lemma mem_mk {x : R} {c : RingCon R} : x ∈ mk c ↔ c x 0 := Iff.rfl
+lemma mem_ofRingCon {x : R} {c : RingCon R} : x ∈ ofRingCon c ↔ c x 0 := Iff.rfl
 
 @[simp, norm_cast]
+lemma coe_ofRingCon {c : RingCon R} : (ofRingCon c : Set R) = {x | c x 0} := rfl
+
+/-- A deprecated alias for `ofRingCon`. -/
+@[deprecated mk (since := "2026-06-18")]
+abbrev mk (c : RingCon R) : TwoSidedIdeal R := ofRingCon c
+
+@[deprecated mem_ofRingCon (since := "2026-06-18")]
+lemma mem_mk {x : R} {c : RingCon R} : x ∈ mk c ↔ c x 0 := Iff.rfl
+
+@[deprecated coe_ofRingCon (since := "2026-06-18")]
 lemma coe_mk {c : RingCon R} : (mk c : Set R) = {x | c x 0} := rfl
 
 lemma rel_iff (x y : R) : I.ringCon x y ↔ x - y ∈ I := by
@@ -95,7 +107,7 @@ lemma le_iff {I J : TwoSidedIdeal R} : I ≤ J ↔ (I : Set R) ⊆ (J : Set R) :
 @[simps apply symm_apply]
 def orderIsoRingCon : TwoSidedIdeal R ≃o RingCon R where
   toFun := TwoSidedIdeal.ringCon
-  invFun := .mk
+  invFun := ofRingCon
   map_rel_iff' {I J} := Iff.symm <| le_iff.trans ⟨fun h x y r => by rw [rel_iff] at r ⊢; exact h r,
     fun h x hx => by rw [SetLike.mem_coe, mem_iff] at hx ⊢; exact h hx⟩
 

--- a/Mathlib/RingTheory/TwoSidedIdeal/Kernel.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Kernel.lean
@@ -31,7 +31,8 @@ variable (f : F)
 The kernel of a ring homomorphism, as a two-sided ideal.
 -/
 def ker : TwoSidedIdeal R :=
-  .mk
+  .ofRingCon
+  -- TODO: use `RingCon.ker`
   { r := fun x y ↦ f x = f y
     iseqv := by constructor <;> aesop
     mul' := by intro; simp_all


### PR DESCRIPTION
Since this is an implemention detail and doesn't match the docstring, let's give it a more explicit name.

If we in future refactor `mk'` to be the real constructor (to generalize to semirings, for instance), then we can keep this new `ofRingCon` name for the conversion function.

Zulip: [#mathlib4 > Two sided ideals and Ring congruences @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Two.20sided.20ideals.20and.20Ring.20congruences/near/604588344)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
