### PR TITLE
[Merged by Bors] - refactor(FieldTheory/*): swap imports of `IsSepClosed` and `SeparableClosure`

### DIFF
--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.FieldTheory.Fixed
 public import Mathlib.FieldTheory.Normal.Closure
 public import Mathlib.FieldTheory.PrimitiveElement
+public import Mathlib.FieldTheory.SeparableClosure
 public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
 
 /-!
@@ -502,6 +503,8 @@ theorem of_card_aut_eq_finrank [FiniteDimensional F E]
 variable {F} {E}
 variable {p : F[X]}
 
+@[deprecated "No replacement; this was an auxiliary lemma used to prove \
+`Algebra.isSeparable_of_separable_splitting_field`." (since := "2026-06-12")]
 theorem of_separable_splitting_field_aux [hFE : FiniteDimensional F E] [sp : p.IsSplittingField F E]
     (hp : p.Separable) (K : Type*) [Field K] [Algebra F K] [Algebra K E] [IsScalarTower F K E]
     {x : E} (hx : x ∈ p.aroots E) :
@@ -532,37 +535,10 @@ theorem of_separable_splitting_field_aux [hFE : FiniteDimensional F E] [sp : p.I
   · apply sp.splits.of_dvd (Polynomial.map_ne_zero h1)
     rwa [← f.comp_algebraMap, ← p.map_map, RingHom.algebraMap_toAlgebra, Polynomial.map_dvd_map']
 
-theorem of_separable_splitting_field [sp : p.IsSplittingField F E] (hp : p.Separable) :
-    IsGalois F E := by
-  haveI hFE : FiniteDimensional F E := Polynomial.IsSplittingField.finiteDimensional E p
-  letI := Classical.decEq E
-  let s := p.rootSet E
-  have adjoin_root : IntermediateField.adjoin F s = ⊤ := by
-    apply IntermediateField.toSubalgebra_injective
-    rw [IntermediateField.top_toSubalgebra, ← top_le_iff, ← sp.adjoin_rootSet]
-    apply IntermediateField.algebra_adjoin_le_adjoin
-  let P : IntermediateField F E → Prop := fun K => Nat.card (K →ₐ[F] E) = finrank F K
-  suffices P (IntermediateField.adjoin F s) by
-    rw [adjoin_root] at this
-    apply of_card_aut_eq_finrank
-    rw [← Eq.trans this (LinearEquiv.finrank_eq IntermediateField.topEquiv.toLinearEquiv)]
-    exact Nat.card_congr ((algEquivEquivAlgHom F E).toEquiv.trans
-      (IntermediateField.topEquiv.symm.arrowCongr AlgEquiv.refl))
-  apply IntermediateField.induction_on_adjoin_finset _ P
-  · have key := IntermediateField.card_algHom_adjoin_integral F (K := E)
-      (show IsIntegral F (0 : E) from isIntegral_zero)
-    rw [IsSeparable, minpoly.zero, Polynomial.natDegree_X] at key
-    specialize key Polynomial.separable_X (Polynomial.Splits.X.map (algebraMap F E))
-    rw [← @Subalgebra.finrank_bot F E _ _ _, ← IntermediateField.bot_toSubalgebra] at key
-    refine Eq.trans ?_ key
-    apply Nat.card_congr
-    rw [IntermediateField.adjoin_zero]
-  intro K x hx hK
-  simp only [P] at *
-  rw [of_separable_splitting_field_aux hp K (Multiset.mem_toFinset.mp hx), hK, finrank_mul_finrank]
-  symm
-  refine LinearEquiv.finrank_eq ?_
-  rfl
+theorem of_separable_splitting_field [p.IsSplittingField F E] (hp : p.Separable) :
+    IsGalois F E :=
+  { to_isSeparable := Algebra.isSeparable_of_separable_splitting_field F E hp,
+    to_normal := Normal.of_isSplittingField p }
 
 /-- Equivalent characterizations of a Galois extension of finite degree. -/
 theorem tfae [FiniteDimensional F E] : List.TFAE [

--- a/Mathlib/FieldTheory/Galois/GaloisClosure.lean
+++ b/Mathlib/FieldTheory/Galois/GaloisClosure.lean
@@ -5,8 +5,7 @@ Authors: Nailin Guan, Yuyang Zhao
 -/
 module
 
-public import Mathlib.FieldTheory.Normal.Closure
-public import Mathlib.FieldTheory.SeparableClosure
+public import Mathlib.FieldTheory.Galois.Basic
 
 /-!
 

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -6,6 +6,7 @@ Authors: Jz Pan
 module
 
 public import Mathlib.FieldTheory.Galois.Basic
+public import Mathlib.FieldTheory.SeparableClosure
 
 /-!
 # Separably Closed Field
@@ -311,3 +312,43 @@ noncomputable def equiv : L ≃ₐ[K] M :=
     (IsSepClosed.lift : L →ₐ[K] M) (IsSepClosed.lift : M →ₐ[K] L)).1
 
 end IsSepClosure
+
+section separableClosure
+
+variable (F E : Type*) [Field F] [Field E] [Algebra F E]
+
+/-- If `E` is normal over `F`, then the separable closure of `F` in `E` is Galois (i.e.
+normal and separable) over `F`. -/
+@[stacks 0EXK]
+instance separableClosure.isGalois [Normal F E] : IsGalois F (separableClosure F E) where
+  to_isSeparable := separableClosure.isSeparable F E
+  to_normal := by
+    rw [← separableClosure.normalClosure_eq_self]
+    exact normalClosure.normal F _ E
+
+/-- If `E / F` is a field extension and `E` is separably closed, then the separable closure
+of `F` in `E` is equal to `F` if and only if `F` is separably closed. -/
+theorem IsSepClosed.separableClosure_eq_bot_iff [IsSepClosed E] :
+    separableClosure F E = ⊥ ↔ IsSepClosed F := by
+  refine ⟨fun h ↦ IsSepClosed.of_exists_root _ fun p _ hirr hsep ↦ ?_,
+    fun _ ↦ IntermediateField.eq_bot_of_isSepClosed_of_isSeparable _⟩
+  obtain ⟨x, hx⟩ := IsSepClosed.exists_aeval_eq_zero E p (degree_pos_of_irreducible hirr).ne' hsep
+  obtain ⟨x, rfl⟩ := h ▸ mem_separableClosure_iff.2 (hsep.of_dvd <| minpoly.dvd _ x hx)
+  exact ⟨x, by simpa [Algebra.ofId_apply] using hx⟩
+
+/-- If `E` is separably closed, then the separable closure of `F` in `E` is an absolute
+separable closure of `F`. -/
+instance separableClosure.isSepClosure [IsSepClosed E] : IsSepClosure F (separableClosure F E) :=
+  ⟨(IsSepClosed.separableClosure_eq_bot_iff _ E).mp (separableClosure.separableClosure_eq_bot F E),
+    isSeparable F E⟩
+
+/-- The absolute separable closure is defined to be the relative separable closure inside the
+algebraic closure. It is indeed a separable closure (`IsSepClosure`) by
+`separableClosure.isSepClosure`, and it is Galois (`IsGalois`) by `separableClosure.isGalois`
+or `IsSepClosure.isGalois`, and every separable extension embeds into it (`IsSepClosed.lift`). -/
+abbrev SeparableClosure : Type _ := separableClosure F (AlgebraicClosure F)
+
+instance SeparableClosure.isSepClosed : IsSepClosed (SeparableClosure F) :=
+  (inferInstance : IsSepClosure F (SeparableClosure F)).sep_closed
+
+end separableClosure

--- a/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
@@ -6,7 +6,7 @@ Authors: Jz Pan
 module
 
 public import Mathlib.Algebra.CharP.IntermediateField
-public import Mathlib.FieldTheory.SeparableClosure
+public import Mathlib.FieldTheory.IsSepClosed
 
 /-!
 

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -755,6 +755,12 @@ lemma Algebra.IsSeparable.of_equiv_equiv [Algebra.IsSeparable A₁ B₁] : Algeb
   ⟨fun x ↦ (e₂.apply_symm_apply x) ▸ _root_.IsSeparable.of_equiv_equiv e₁ e₂ he
     (Algebra.IsSeparable.isSeparable _ _)⟩
 
+lemma Algebra.IsSeparable.iff_of_equiv_equiv : Algebra.IsSeparable A₁ B₁ ↔ Algebra.IsSeparable A₂ B₂ :=
+  ⟨fun _ ↦ Algebra.IsSeparable.of_equiv_equiv e₁ e₂ he,
+    fun _ ↦ Algebra.IsSeparable.of_equiv_equiv e₁.symm e₂.symm (by
+      ext x
+      simpa [RingEquiv.eq_symm_apply] using (RingHom.ext_iff.mp he (e₁.symm x)).symm)⟩
+
 end AlgEquiv
 
 section CardAlgHom

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -755,7 +755,8 @@ lemma Algebra.IsSeparable.of_equiv_equiv [Algebra.IsSeparable A₁ B₁] : Algeb
   ⟨fun x ↦ (e₂.apply_symm_apply x) ▸ _root_.IsSeparable.of_equiv_equiv e₁ e₂ he
     (Algebra.IsSeparable.isSeparable _ _)⟩
 
-lemma Algebra.IsSeparable.iff_of_equiv_equiv : Algebra.IsSeparable A₁ B₁ ↔ Algebra.IsSeparable A₂ B₂ :=
+lemma Algebra.IsSeparable.iff_of_equiv_equiv :
+    Algebra.IsSeparable A₁ B₁ ↔ Algebra.IsSeparable A₂ B₂ :=
   ⟨fun _ ↦ Algebra.IsSeparable.of_equiv_equiv e₁ e₂ he,
     fun _ ↦ Algebra.IsSeparable.of_equiv_equiv e₁.symm e₂.symm (by
       ext x

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -187,6 +187,14 @@ theorem IntermediateField.isSeparable_adjoin_iff_isSeparable {S : Set E} :
     Algebra.IsSeparable F (adjoin F S) ↔ ∀ x ∈ S, IsSeparable F x :=
   (le_separableClosure_iff F E _).symm.trans adjoin_le_iff
 
+/-- If `p` is a separable polynomial with splitting field `E` over `F`, then `E / F` is a
+separable extension. -/
+theorem Algebra.isSeparable_of_separable_splitting_field {p : F[X]}
+    [sp : p.IsSplittingField F E] (hp : p.Separable) : Algebra.IsSeparable F E := by
+  rw [← isSeparable_top, ← (isSplittingField_iff_intermediateField.mp sp).2,
+    isSeparable_adjoin_iff_isSeparable]
+  exact fun x hx ↦ hp.of_dvd (minpoly.dvd F x (aeval_eq_zero_of_mem_rootSet hx))
+
 /-- The separable closure of `F` in `E` is equal to `E` if and only if `E / F` is
 separable. -/
 theorem separableClosure.eq_top_iff : separableClosure F E = ⊤ ↔ Algebra.IsSeparable F E :=

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -6,7 +6,6 @@ Authors: Jz Pan
 module
 
 public import Mathlib.FieldTheory.SeparableDegree
-public import Mathlib.FieldTheory.IsSepClosed
 public import Mathlib.RingTheory.AlgebraicIndependent.AlgebraicClosure
 
 /-!
@@ -63,6 +62,8 @@ separable degree, degree, separable closure
 -/
 
 @[expose] public section
+
+assert_not_exists IsGalois
 
 open Module Polynomial IntermediateField Field
 
@@ -179,40 +180,6 @@ theorem separableClosure.normalClosure_eq_self :
     have : Algebra.IsSeparable F i.fieldRange :=
       (AlgEquiv.Algebra.isSeparable (AlgEquiv.ofInjectiveField i))
     le_separableClosure F E _) (le_normalClosure _)
-
-/-- If `E` is normal over `F`, then the separable closure of `F` in `E` is Galois (i.e.
-normal and separable) over `F`. -/
-@[stacks 0EXK]
-instance separableClosure.isGalois [Normal F E] : IsGalois F (separableClosure F E) where
-  to_isSeparable := separableClosure.isSeparable F E
-  to_normal := by
-    rw [← separableClosure.normalClosure_eq_self]
-    exact normalClosure.normal F _ E
-
-/-- If `E / F` is a field extension and `E` is separably closed, then the separable closure
-of `F` in `E` is equal to `F` if and only if `F` is separably closed. -/
-theorem IsSepClosed.separableClosure_eq_bot_iff [IsSepClosed E] :
-    separableClosure F E = ⊥ ↔ IsSepClosed F := by
-  refine ⟨fun h ↦ IsSepClosed.of_exists_root _ fun p _ hirr hsep ↦ ?_,
-    fun _ ↦ IntermediateField.eq_bot_of_isSepClosed_of_isSeparable _⟩
-  obtain ⟨x, hx⟩ := IsSepClosed.exists_aeval_eq_zero E p (degree_pos_of_irreducible hirr).ne' hsep
-  obtain ⟨x, rfl⟩ := h ▸ mem_separableClosure_iff.2 (hsep.of_dvd <| minpoly.dvd _ x hx)
-  exact ⟨x, by simpa [Algebra.ofId_apply] using hx⟩
-
-/-- If `E` is separably closed, then the separable closure of `F` in `E` is an absolute
-separable closure of `F`. -/
-instance separableClosure.isSepClosure [IsSepClosed E] : IsSepClosure F (separableClosure F E) :=
-  ⟨(IsSepClosed.separableClosure_eq_bot_iff _ E).mp (separableClosure.separableClosure_eq_bot F E),
-    isSeparable F E⟩
-
-/-- The absolute separable closure is defined to be the relative separable closure inside the
-algebraic closure. It is indeed a separable closure (`IsSepClosure`) by
-`separableClosure.isSepClosure`, and it is Galois (`IsGalois`) by `separableClosure.isGalois`
-or `IsSepClosure.isGalois`, and every separable extension embeds into it (`IsSepClosed.lift`). -/
-abbrev SeparableClosure : Type _ := separableClosure F (AlgebraicClosure F)
-
-instance SeparableClosure.isSepClosed : IsSepClosed (SeparableClosure F) :=
-  (inferInstance : IsSepClosure F (SeparableClosure F)).sep_closed
 
 /-- `F(S) / F` is a separable extension if and only if all elements of `S` are
 separable elements. -/

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -196,6 +196,12 @@ theorem finSepDegree_top : finSepDegree F (⊤ : IntermediateField E K) = finSep
 
 end Tower
 
+theorem isSeparable_bot : Algebra.IsSeparable F (⊥ : IntermediateField F E) :=
+  AlgEquiv.Algebra.isSeparable (IntermediateField.botEquiv F E).symm
+
+theorem isSeparable_top : Algebra.IsSeparable F (⊤ : IntermediateField F E) ↔ Algebra.IsSeparable F E :=
+  Algebra.IsSeparable.iff_of_equiv_equiv (RingEquiv.refl F) topEquiv.toRingEquiv (by ext; simp)
+
 end IntermediateField
 
 namespace Field

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -199,7 +199,8 @@ end Tower
 theorem isSeparable_bot : Algebra.IsSeparable F (⊥ : IntermediateField F E) :=
   AlgEquiv.Algebra.isSeparable (IntermediateField.botEquiv F E).symm
 
-theorem isSeparable_top : Algebra.IsSeparable F (⊤ : IntermediateField F E) ↔ Algebra.IsSeparable F E :=
+theorem isSeparable_top :
+    Algebra.IsSeparable F (⊤ : IntermediateField F E) ↔ Algebra.IsSeparable F E :=
   Algebra.IsSeparable.iff_of_equiv_equiv (RingEquiv.refl F) topEquiv.toRingEquiv (by ext; simp)
 
 end IntermediateField


### PR DESCRIPTION
This PR swaps the imports order between `IsSepClosed.lean` and `SeparableClosure.lean`. This allows basic facts like adjoining separable elements gives a separable extension to be used to golf a proof in `Galois/Basic.lean`.

These basic facts basically require knowing the existence of the separable closure, but right now `SeparableClosure.lean` imports `IsSepClosed.lean` which imports `Galois/Basic.lean`.

This PR is a slight modification of #40339.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
