### PR TITLE
[Merged by Bors] - chore: prerequisite options for the Lake cache

### DIFF
--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -183,12 +183,10 @@ jobs:
           from pathlib import Path
           p = Path("lakefile.lean")
           src = p.read_text()
-          marker = '  testDriver := "MathlibTest"'
+          marker = '  restoreAllArtifacts := true'
           inject = (
-              '  testDriver := "MathlibTest"\n'
-              '  fixedToolchain := true\n'
-              '  enableArtifactCache := true\n'
-              '  restoreAllArtifacts := true'
+              '  restoreAllArtifacts := true\n'
+              '  enableArtifactCache := true'
           )
           if marker not in src:
               raise SystemExit("lakefile.lean shape changed; update the shadow patch in lake_cache_shadow.yml")
@@ -437,12 +435,10 @@ jobs:
           from pathlib import Path
           p = Path("lakefile.lean")
           src = p.read_text()
-          marker = '  testDriver := "MathlibTest"'
+          marker = '  restoreAllArtifacts := true'
           inject = (
-              '  testDriver := "MathlibTest"\n'
-              '  fixedToolchain := true\n'
-              '  enableArtifactCache := true\n'
-              '  restoreAllArtifacts := true'
+              '  restoreAllArtifacts := true\n'
+              '  enableArtifactCache := true'
           )
           if marker not in src:
               raise SystemExit("lakefile.lean shape changed")

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -83,4 +83,4 @@
    "configFile": "lakefile.toml"}],
  "name": "mathlib",
  "lakeDir": ".lake",
- "fixedToolchain": false}
+ "fixedToolchain": true}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -50,6 +50,12 @@ package mathlib where
   testDriver := "MathlibTest"
   lintDriver := "batteries/runLinter"
   lintDriverArgs := #["Mathlib"]
+  -- A version of Mathlib only supports the toolchain it is built with.
+  fixedToolchain := true
+  -- Mathlib oleans are built on Linux CI and used across platforms.
+  platformIndependent := true
+  -- Mathlib currently expects artifacts to be in the build directory.
+  restoreAllArtifacts := true
   -- These are additional settings which do not affect the lake hash,
   -- so they can be enabled in CI and disabled locally or vice versa.
   -- Warning: Do not put any options here that actually change the olean files,


### PR DESCRIPTION
This PR sets Lake options that are prerequisites for using the Lake cache (i.e., `lake cache`) but are also compatible with the current setup. It does not enable the local Lake artifact cache by default (e.g., `enableArtifactCache := true`), because the local cache is largely redundant with `lake exe cache get`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
