### PR TITLE
[Merged by Bors] - refactor(CategoryTheory): more data in the PushoutObjObj structure

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/Inner/PushoutProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/Inner/PushoutProduct.lean
@@ -110,41 +110,35 @@ lemma innerAnodyneExtensions_pushoutObjObjι'
 
 end
 
-set_option backward.defeqAttrib.useBackward true in
 lemma innerAnodyneExtensions_unionProd_ι
     {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex)
     (hB : innerAnodyneExtensions B.ι) :
     innerAnodyneExtensions (A.unionProd B).ι :=
   innerAnodyneExtensions_pushoutObjObjι (Subcomplex.unionProd.pushoutObjObj A B) hB
 
-set_option backward.defeqAttrib.useBackward true in
 lemma innerAnodyneExtensions_unionProd_ι'
     {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex)
     (hA : innerAnodyneExtensions A.ι) :
     innerAnodyneExtensions (A.unionProd B).ι :=
   innerAnodyneExtensions_pushoutObjObjι' (Subcomplex.unionProd.pushoutObjObj A B) hA
 
-set_option backward.defeqAttrib.useBackward true in
 lemma innerAnodyneExtensions.whiskerRight
     {X Y : SSet.{u}} {f : X ⟶ Y} (hf : innerAnodyneExtensions f) (Z : SSet.{u}) :
     innerAnodyneExtensions (f ▷ Z) :=
   innerAnodyneExtensions_pushoutObjObjι'
     (.ofIsInitialRight (curriedTensor _) f (initial.to Z) initialIsInitial) hf
 
-set_option backward.defeqAttrib.useBackward true in
 lemma innerAnodyneExtensions.whiskerLeft
     {X Y : SSet.{u}} {f : X ⟶ Y} (hf : innerAnodyneExtensions f) (Z : SSet.{u}) :
     innerAnodyneExtensions (Z ◁ f) :=
   innerAnodyneExtensions_pushoutObjObjι
     (.ofIsInitialLeft (curriedTensor _) (initial.to Z) f initialIsInitial) hf
 
-set_option backward.defeqAttrib.useBackward true in
 instance {E B X : SSet.{u}} (p : E ⟶ B) [InnerFibration p] :
     InnerFibration ((ihom X).map p) :=
   innerFibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsInitial
     MonoidalClosed.internalHom (initial.to X) p initialIsInitial)
 
-set_option backward.isDefEq.respectTransparency false in
 instance {A B : SSet.{u}} (i : A ⟶ B) [Mono i] (X : SSet.{u}) [Quasicategory X] :
     InnerFibration ((MonoidalClosed.pre i).app X) :=
   innerFibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsTerminal

--- a/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/Inner/PushoutProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/Inner/PushoutProduct.lean
@@ -114,40 +114,40 @@ set_option backward.defeqAttrib.useBackward true in
 lemma innerAnodyneExtensions_unionProd_ι
     {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex)
     (hB : innerAnodyneExtensions B.ι) :
-    innerAnodyneExtensions (A.unionProd B).ι := by
-  simpa using innerAnodyneExtensions_pushoutObjObjι (Subcomplex.unionProd.pushoutObjObj A B) hB
+    innerAnodyneExtensions (A.unionProd B).ι :=
+  innerAnodyneExtensions_pushoutObjObjι (Subcomplex.unionProd.pushoutObjObj A B) hB
 
 set_option backward.defeqAttrib.useBackward true in
 lemma innerAnodyneExtensions_unionProd_ι'
     {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex)
     (hA : innerAnodyneExtensions A.ι) :
-    innerAnodyneExtensions (A.unionProd B).ι := by
-  simpa using innerAnodyneExtensions_pushoutObjObjι' (Subcomplex.unionProd.pushoutObjObj A B) hA
+    innerAnodyneExtensions (A.unionProd B).ι :=
+  innerAnodyneExtensions_pushoutObjObjι' (Subcomplex.unionProd.pushoutObjObj A B) hA
 
 set_option backward.defeqAttrib.useBackward true in
 lemma innerAnodyneExtensions.whiskerRight
     {X Y : SSet.{u}} {f : X ⟶ Y} (hf : innerAnodyneExtensions f) (Z : SSet.{u}) :
-    innerAnodyneExtensions (f ▷ Z) := by
-  simpa using innerAnodyneExtensions_pushoutObjObjι'
+    innerAnodyneExtensions (f ▷ Z) :=
+  innerAnodyneExtensions_pushoutObjObjι'
     (.ofIsInitialRight (curriedTensor _) f (initial.to Z) initialIsInitial) hf
 
 set_option backward.defeqAttrib.useBackward true in
 lemma innerAnodyneExtensions.whiskerLeft
     {X Y : SSet.{u}} {f : X ⟶ Y} (hf : innerAnodyneExtensions f) (Z : SSet.{u}) :
-    innerAnodyneExtensions (Z ◁ f) := by
-  simpa using innerAnodyneExtensions_pushoutObjObjι
+    innerAnodyneExtensions (Z ◁ f) :=
+  innerAnodyneExtensions_pushoutObjObjι
     (.ofIsInitialLeft (curriedTensor _) (initial.to Z) f initialIsInitial) hf
 
 set_option backward.defeqAttrib.useBackward true in
 instance {E B X : SSet.{u}} (p : E ⟶ B) [InnerFibration p] :
-    InnerFibration ((ihom X).map p) := by
-  simpa using innerFibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsInitial
+    InnerFibration ((ihom X).map p) :=
+  innerFibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsInitial
     MonoidalClosed.internalHom (initial.to X) p initialIsInitial)
 
 set_option backward.isDefEq.respectTransparency false in
 instance {A B : SSet.{u}} (i : A ⟶ B) [Mono i] (X : SSet.{u}) [Quasicategory X] :
-    InnerFibration ((MonoidalClosed.pre i).app X) := by
-  simpa using innerFibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsTerminal
+    InnerFibration ((MonoidalClosed.pre i).app X) :=
+  innerFibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsTerminal
     MonoidalClosed.internalHom i (terminal.from X) terminalIsTerminal)
 
 instance (A : SSet.{u}) : Quasicategory ((ihom A).obj (⊤_ _)) := by

--- a/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/PushoutProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/PushoutProduct.lean
@@ -112,41 +112,35 @@ lemma anodyneExtensions_pushoutObjObjι'
 
 end
 
-set_option backward.defeqAttrib.useBackward true in
 lemma anodyneExtensions_unionProd_ι
     {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex)
     (hB : anodyneExtensions B.ι) :
     anodyneExtensions (A.unionProd B).ι :=
   anodyneExtensions_pushoutObjObjι (Subcomplex.unionProd.pushoutObjObj A B) hB
 
-set_option backward.defeqAttrib.useBackward true in
 lemma anodyneExtensions_unionProd_ι'
     {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex)
     (hA : anodyneExtensions A.ι) :
     anodyneExtensions (A.unionProd B).ι :=
   anodyneExtensions_pushoutObjObjι' (Subcomplex.unionProd.pushoutObjObj A B) hA
 
-set_option backward.defeqAttrib.useBackward true in
 lemma anodyneExtensions.whiskerRight
     {X Y : SSet.{u}} {f : X ⟶ Y} (hf : anodyneExtensions f) (Z : SSet.{u}) :
     anodyneExtensions (f ▷ Z) :=
   anodyneExtensions_pushoutObjObjι'
     (.ofIsInitialRight (curriedTensor _) f (initial.to Z) initialIsInitial) hf
 
-set_option backward.defeqAttrib.useBackward true in
 lemma anodyneExtensions.whiskerLeft
     {X Y : SSet.{u}} {f : X ⟶ Y} (hf : anodyneExtensions f) (Z : SSet.{u}) :
     anodyneExtensions (Z ◁ f) :=
   anodyneExtensions_pushoutObjObjι
     (.ofIsInitialLeft (curriedTensor _) (initial.to Z) f initialIsInitial) hf
 
-set_option backward.defeqAttrib.useBackward true in
 instance {E B X : SSet.{u}} (p : E ⟶ B) [Fibration p] :
     Fibration ((ihom X).map p) :=
   fibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsInitial
     MonoidalClosed.internalHom (initial.to X) p initialIsInitial)
 
-set_option backward.isDefEq.respectTransparency false in
 instance {A B : SSet.{u}} (i : A ⟶ B) [Mono i] (X : SSet.{u}) [KanComplex X] :
     Fibration ((MonoidalClosed.pre i).app X) :=
   fibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsTerminal

--- a/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/PushoutProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/PushoutProduct.lean
@@ -116,40 +116,40 @@ set_option backward.defeqAttrib.useBackward true in
 lemma anodyneExtensions_unionProd_ι
     {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex)
     (hB : anodyneExtensions B.ι) :
-    anodyneExtensions (A.unionProd B).ι := by
-  simpa using anodyneExtensions_pushoutObjObjι (Subcomplex.unionProd.pushoutObjObj A B) hB
+    anodyneExtensions (A.unionProd B).ι :=
+  anodyneExtensions_pushoutObjObjι (Subcomplex.unionProd.pushoutObjObj A B) hB
 
 set_option backward.defeqAttrib.useBackward true in
 lemma anodyneExtensions_unionProd_ι'
     {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex)
     (hA : anodyneExtensions A.ι) :
-    anodyneExtensions (A.unionProd B).ι := by
-  simpa using anodyneExtensions_pushoutObjObjι' (Subcomplex.unionProd.pushoutObjObj A B) hA
+    anodyneExtensions (A.unionProd B).ι :=
+  anodyneExtensions_pushoutObjObjι' (Subcomplex.unionProd.pushoutObjObj A B) hA
 
 set_option backward.defeqAttrib.useBackward true in
 lemma anodyneExtensions.whiskerRight
     {X Y : SSet.{u}} {f : X ⟶ Y} (hf : anodyneExtensions f) (Z : SSet.{u}) :
-    anodyneExtensions (f ▷ Z) := by
-  simpa using anodyneExtensions_pushoutObjObjι'
+    anodyneExtensions (f ▷ Z) :=
+  anodyneExtensions_pushoutObjObjι'
     (.ofIsInitialRight (curriedTensor _) f (initial.to Z) initialIsInitial) hf
 
 set_option backward.defeqAttrib.useBackward true in
 lemma anodyneExtensions.whiskerLeft
     {X Y : SSet.{u}} {f : X ⟶ Y} (hf : anodyneExtensions f) (Z : SSet.{u}) :
-    anodyneExtensions (Z ◁ f) := by
-  simpa using anodyneExtensions_pushoutObjObjι
+    anodyneExtensions (Z ◁ f) :=
+  anodyneExtensions_pushoutObjObjι
     (.ofIsInitialLeft (curriedTensor _) (initial.to Z) f initialIsInitial) hf
 
 set_option backward.defeqAttrib.useBackward true in
 instance {E B X : SSet.{u}} (p : E ⟶ B) [Fibration p] :
-    Fibration ((ihom X).map p) := by
-  simpa using fibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsInitial
+    Fibration ((ihom X).map p) :=
+  fibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsInitial
     MonoidalClosed.internalHom (initial.to X) p initialIsInitial)
 
 set_option backward.isDefEq.respectTransparency false in
 instance {A B : SSet.{u}} (i : A ⟶ B) [Mono i] (X : SSet.{u}) [KanComplex X] :
-    Fibration ((MonoidalClosed.pre i).app X) := by
-  simpa using fibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsTerminal
+    Fibration ((MonoidalClosed.pre i).app X) :=
+  fibration_pullbackObjObjπ (Functor.PullbackObjObj.ofIsTerminal
     MonoidalClosed.internalHom i (terminal.from X) terminalIsTerminal)
 
 instance (A : SSet.{u}) : KanComplex ((ihom A).obj (⊤_ _)) := by

--- a/Mathlib/AlgebraicTopology/SimplicialSet/PushoutProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/PushoutProduct.lean
@@ -36,8 +36,10 @@ set_option backward.defeqAttrib.useBackward true in
 noncomputable
 def ιIso : Arrow.mk (S.unionProd T).ι ≅ S.ι □ T.ι :=
   Arrow.isoMk' _ _ (isPushout S T).isoPushout (Iso.refl _)
-    (by apply (unionProd.isPushout S T).hom_ext <;>
-      simp [Functor.PushoutObjObj.ofHasPushout, Functor.PushoutObjObj.ι])
+    (by
+      apply (unionProd.isPushout S T).hom_ext
+      · simp [Limits.pushout.inl_desc]
+      · simp [Limits.pushout.inr_desc])
 
 /-- Given subcomplexes `S` and `T` of simplicial sets, this if a `Functor.PushoutObjObj`
 structure for the chosen binary products on `SSet`, with point `S.unionProd T`. -/
@@ -47,15 +49,7 @@ noncomputable def pushoutObjObj : (curriedTensor _).PushoutObjObj S.ι T.ι wher
   inl := unionProd.ι₁ S T
   inr := unionProd.ι₂ S T
   isPushout := unionProd.isPushout S T
-
-set_option backward.defeqAttrib.useBackward true in
-@[simp]
-lemma pushoutObjObj_ι : (pushoutObjObj S T).ι = (S.unionProd T).ι := by
-  apply (pushoutObjObj S T).hom_ext
-  · rw [(pushoutObjObj S T).inl_ι]
-    simp
-  · rw [(pushoutObjObj S T).inr_ι]
-    simp
+  ι := (S.unionProd T).ι
 
 end unionProd
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/PushoutProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/PushoutProduct.lean
@@ -37,9 +37,8 @@ noncomputable
 def ιIso : Arrow.mk (S.unionProd T).ι ≅ S.ι □ T.ι :=
   Arrow.isoMk' _ _ (isPushout S T).isoPushout (Iso.refl _)
     (by
-      apply (unionProd.isPushout S T).hom_ext
-      · simp [Limits.pushout.inl_desc]
-      · simp [Limits.pushout.inr_desc])
+      apply (unionProd.isPushout S T).hom_ext <;>
+      simp [Limits.pushout.inl_desc, Limits.pushout.inr_desc])
 
 /-- Given subcomplexes `S` and `T` of simplicial sets, this if a `Functor.PushoutObjObj`
 structure for the chosen binary products on `SSet`, with point `S.unionProd T`. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
@@ -186,7 +186,7 @@ noncomputable def ofIsInitialRight : F.PushoutObjObj f₁ f₂ where
     · exact isIso_of_isInitial hX₁ hY₁ _
     · exact ⟨hX₁.hom_ext _ _⟩
   ι := (F.map f₁).app Y₂
-  inl_ι := (IsInitial.isInitialObj (F.obj Y₁) _ h).hom_ext _ _
+  inl_ι := (IsInitial.isInitialObj (F.obj Y₁) _ h).hom_ext ..
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
@@ -78,11 +78,17 @@ structure PushoutObjObj where
   /-- the second inclusion -/
   inr : (F.obj X₁).obj Y₂ ⟶ pt
   isPushout : IsPushout ((F.map f₁).app X₂) ((F.obj X₁).map f₂) inl inr
+  /-- the Leibniz pushout -/
+  ι : pt ⟶ (F.obj Y₁).obj Y₂ := isPushout.desc ((F.obj Y₁).map f₂) ((F.map f₁).app Y₂) (by simp)
+  inl_ι : inl ≫ ι = (F.obj Y₁).map f₂ := by cat_disch
+  inr_ι : inr ≫ ι = (F.map f₁).app Y₂ := by cat_disch
 
 namespace PushoutObjObj
 
+attribute [reassoc (attr := simp)] inl_ι inr_ι
+
 /-- The `PushoutObjObj` structure given by the pushout of the colimits API. -/
-@[simps -isSimp]
+@[simps]
 noncomputable def ofHasPushout
     [HasPushout ((F.map f₁).app X₂) ((F.obj X₁).map f₂)] :
     F.PushoutObjObj f₁ f₂ where
@@ -90,25 +96,18 @@ noncomputable def ofHasPushout
   inl := pushout.inl _ _
   inr := pushout.inr _ _
   isPushout := IsPushout.of_hasPushout _ _
+  ι := pushout.desc ((F.obj Y₁).map f₂) ((F.map f₁).app Y₂) (by simp)
+  inl_ι := pushout.inl_desc ..
+  inr_ι := pushout.inr_desc ..
 
 variable {F f₁ f₂} (sq : F.PushoutObjObj f₁ f₂)
-
-/-- The "inclusion" `sq.pt ⟶ (F.obj Y₁).obj Y₂` when
-`sq : F.PushoutObjObj f₁ f₂`. -/
-noncomputable def ι : sq.pt ⟶ (F.obj Y₁).obj Y₂ :=
-  sq.isPushout.desc ((F.obj Y₁).map f₂) ((F.map f₁).app Y₂) (by simp)
-
-@[reassoc (attr := simp)]
-lemma inl_ι : sq.inl ≫ sq.ι = (F.obj Y₁).map f₂ := by simp [ι]
-
-@[reassoc (attr := simp)]
-lemma inr_ι : sq.inr ≫ sq.ι = (F.map f₁).app Y₂ := by simp [ι]
 
 @[ext]
 lemma hom_ext {X₃ : C₃} {f g : sq.pt ⟶ X₃} (hₗ : sq.inl ≫ f = sq.inl ≫ g)
     (hᵣ : sq.inr ≫ f = sq.inr ≫ g) : f = g :=
   sq.isPushout.hom_ext hₗ hᵣ
 
+set_option backward.defeqAttrib.useBackward true in
 /-- Given `sq : F.PushoutObjObj f₁ f₂`, flipping the pushout square gives
 `sq.flip : F.flip.PushoutObjObj f₂ f₁`. -/
 @[simps]
@@ -117,13 +116,7 @@ def flip : F.flip.PushoutObjObj f₂ f₁ where
   inl := sq.inr
   inr := sq.inl
   isPushout := sq.isPushout.flip
-
-set_option backward.isDefEq.respectTransparency false in
-@[simp]
-lemma ι_flip : sq.flip.ι = sq.ι := by
-  apply sq.flip.isPushout.hom_ext
-  · rw [inl_ι, flip_inl, inr_ι, flip_obj_map]
-  · rw [inr_ι, flip_inr, inl_ι, flip_map_app]
+  ι := sq.ι
 
 section
 
@@ -138,22 +131,9 @@ def ofNatIso : F'.PushoutObjObj f₁ f₂ where
   isPushout :=
     sq.isPushout.of_iso ((e.app _).app _) ((e.app _).app _) ((e.app _).app _) (Iso.refl _)
       (by simp) (by simp) (by simp) (by simp)
-
-set_option backward.defeqAttrib.useBackward true in
-@[simp, reassoc]
-lemma ofNatIso_ι :
-    (sq.ofNatIso e).ι = sq.ι ≫ (e.hom.app _).app _ := by
-  apply sq.hom_ext
-  · simp [← (sq.ofNatIso e).inl_ι]
-  · simp [← (sq.ofNatIso e).inr_ι]
+  ι := sq.ι ≫ (e.hom.app _).app _
 
 end
-
-set_option backward.isDefEq.respectTransparency false in
-lemma ofHasPushout_ι [HasPushout ((F.map f₁).app X₂) ((F.obj X₁).map f₂)] :
-    (ofHasPushout F f₁ f₂).ι =
-      pushout.desc ((F.obj Y₁).map f₂) ((F.map f₁).app Y₂) (by simp) := by
-  ext <;> simp [PushoutObjObj.ι, ofHasPushout_inl, ofHasPushout_inr]
 
 section
 
@@ -162,6 +142,7 @@ variable (F f₁ f₂)
   [PreservesColimitsOfShape (Discrete PEmpty.{1}) (F.flip.obj Y₂)]
   (h : IsInitial X₁)
 
+set_option backward.defeqAttrib.useBackward true in
 /-- A `Functor.PushoutObjObj` structure for a functor `F : C₁ ⥤ C₂ ⥤ C₃` and
 morphisms `f₁ : X₁ ⟶ Y₁` and `f₂ : X₂ ⟶ Y₂` when `X₁` is initial and both
 `F.flip.obj X₂` and `F.flip.obj Y₂` preserve the initial object. -/
@@ -176,11 +157,8 @@ noncomputable def ofIsInitialLeft : F.PushoutObjObj f₁ f₂ where
     apply +allowSynthFailures IsPushout.of_vert_isIso
     · exact isIso_of_isInitial hX₂ hY₂ _
     · exact ⟨hX₂.hom_ext _ _⟩
-
-set_option backward.defeqAttrib.useBackward true in
-@[simp]
-lemma ofIsInitialLeft_ι : (ofIsInitialLeft F f₁ f₂ h).ι = (F.obj Y₁).map f₂ := by
-  simpa using (ofIsInitialLeft F f₁ f₂ h).inl_ι
+  ι := (F.obj Y₁).map f₂
+  inr_ι := (IsInitial.isInitialObj (F.flip.obj Y₂) _ h).hom_ext _ _
 
 end
 
@@ -205,11 +183,8 @@ noncomputable def ofIsInitialRight : F.PushoutObjObj f₁ f₂ where
     apply +allowSynthFailures IsPushout.of_horiz_isIso
     · exact isIso_of_isInitial hX₁ hY₁ _
     · exact ⟨hX₁.hom_ext _ _⟩
-
-set_option backward.defeqAttrib.useBackward true in
-@[simp]
-lemma ofIsInitialRight_ι : (ofIsInitialRight F f₁ f₂ h).ι = (F.map f₁).app Y₂ := by
-  simpa using (ofIsInitialRight F f₁ f₂ h).inr_ι
+  ι := (F.map f₁).app Y₂
+  inl_ι := (IsInitial.isInitialObj (F.obj Y₁) _ h).hom_ext _ _
 
 end
 
@@ -360,11 +335,19 @@ structure PullbackObjObj where
   snd : pt ⟶ (G.obj (op Y₁)).obj Y₃
   isPullback : IsPullback fst snd ((G.obj (op X₁)).map f₃)
     ((G.map f₁.op).app Y₃)
+  /-- the Leibniz pullback -/
+  π : (G.obj (op Y₁)).obj X₃ ⟶ pt :=
+    isPullback.lift ((G.map f₁.op).app X₃) ((G.obj (op Y₁)).map f₃) (by simp)
+  π_fst : π ≫ fst = (G.map f₁.op).app X₃ := by cat_disch
+  π_snd : π ≫ snd = (G.obj (op Y₁)).map f₃ := by cat_disch
 
 namespace PullbackObjObj
 
+attribute [reassoc (attr := simp)] π_fst π_snd
+
+set_option backward.isDefEq.respectTransparency false in
 /-- The `PullbackObjObj` structure given by the pullback of the limits API. -/
-@[simps -isSimp]
+@[simps]
 noncomputable def ofHasPullback
     [HasPullback ((G.obj (op X₁)).map f₃) ((G.map f₁.op).app Y₃)] :
     G.PullbackObjObj f₁ f₃ where
@@ -372,31 +355,14 @@ noncomputable def ofHasPullback
   fst := pullback.fst _ _
   snd := pullback.snd _ _
   isPullback := IsPullback.of_hasPullback _ _
+  π := pullback.lift ((G.map f₁.op).app X₃) ((G.obj (op Y₁)).map f₃) (by simp)
 
 variable {G f₁ f₃} (sq : G.PullbackObjObj f₁ f₃)
-
-/-- The projection `(G.obj (op Y₁)).obj X₃ ⟶ sq.pt` when
-`sq : G.PullbackObjObj f₁ f₃`. -/
-noncomputable def π : (G.obj (op Y₁)).obj X₃ ⟶ sq.pt :=
-  sq.isPullback.lift ((G.map f₁.op).app X₃) ((G.obj (op Y₁)).map f₃) (by simp)
-
-@[reassoc (attr := simp)]
-lemma π_fst : sq.π ≫ sq.fst = (G.map f₁.op).app X₃ := by simp [π]
-
-@[reassoc (attr := simp)]
-lemma π_snd : sq.π ≫ sq.snd = (G.obj (op Y₁)).map f₃ := by simp [π]
 
 @[ext]
 lemma hom_ext {X₂ : C₂} {f g : X₂ ⟶ sq.pt} (h₁ : f ≫ sq.fst = g ≫ sq.fst)
     (h₂ : f ≫ sq.snd = g ≫ sq.snd) : f = g :=
   sq.isPullback.hom_ext h₁ h₂
-
-set_option backward.isDefEq.respectTransparency false in
-lemma ofHasPullback_π
-    [HasPullback ((G.obj (op X₁)).map f₃) ((G.map f₁.op).app Y₃)] :
-    (ofHasPullback G f₁ f₃).π =
-      pullback.lift ((G.map f₁.op).app X₃) ((G.obj (op Y₁)).map f₃) (by simp) := by
-  ext <;> simp [PullbackObjObj.π, ofHasPullback_fst, ofHasPullback_snd]
 
 section
 
@@ -419,11 +385,8 @@ noncomputable def ofIsInitial : G.PullbackObjObj f₁ f₃ where
     apply +allowSynthFailures IsPullback.of_vert_isIso
     · exact isIso_of_isTerminal hX₃ hY₃ _
     · exact ⟨hY₃.hom_ext _ _⟩
-
-set_option backward.defeqAttrib.useBackward true in
-@[simp]
-lemma ofIsInitial_π : (ofIsInitial G f₁ f₃ h).π = (G.obj (op Y₁)).map f₃ := by
-  simpa using (ofIsInitial G f₁ f₃ h).π_snd
+  π := (G.obj (op Y₁)).map f₃
+  π_fst := (IsTerminal.isTerminalObj (G.flip.obj X₃) _ h.op).hom_ext _ _
 
 end
 
@@ -448,11 +411,8 @@ noncomputable def ofIsTerminal : G.PullbackObjObj f₁ f₃ where
     apply +allowSynthFailures IsPullback.of_horiz_isIso
     · exact isIso_of_isTerminal hY₁ hX₁ _
     · exact ⟨hX₁.hom_ext _ _⟩
-
-set_option backward.defeqAttrib.useBackward true in
-@[simp]
-lemma ofIsTerminal_π : (ofIsTerminal G f₁ f₃ h).π = (G.map f₁.op).app X₃ := by
-  simpa using (ofIsTerminal G f₁ f₃ h).π_fst
+  π := (G.map f₁.op).app X₃
+  π_snd := (IsTerminal.isTerminalObj (G.obj (op Y₁)) _ h).hom_ext _ _
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
@@ -118,6 +118,8 @@ def flip : F.flip.PushoutObjObj f₂ f₁ where
   isPushout := sq.isPushout.flip
   ι := sq.ι
 
+@[deprecated (since := "2026-06-19")] alias ι_flip := flip_ι
+
 section
 
 variable {F' : C₁ ⥤ C₂ ⥤ C₃} (e : F ≅ F')

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
@@ -160,7 +160,7 @@ noncomputable def ofIsInitialLeft : F.PushoutObjObj f₁ f₂ where
     · exact isIso_of_isInitial hX₂ hY₂ _
     · exact ⟨hX₂.hom_ext _ _⟩
   ι := (F.obj Y₁).map f₂
-  inr_ι := (IsInitial.isInitialObj (F.flip.obj Y₂) _ h).hom_ext _ _
+  inr_ι := (IsInitial.isInitialObj (F.flip.obj Y₂) _ h).hom_ext ..
 
 end
 

--- a/Mathlib/CategoryTheory/Monoidal/Braided/PushoutObjObj.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/PushoutObjObj.lean
@@ -36,9 +36,4 @@ obtain a similar structure for `f₂` and `f₁`. -/
 def flipTensor : (curriedTensor C).PushoutObjObj f₂ f₁ :=
   sq.flip.ofNatIso (BraidedCategory.curriedBraidingNatIso _).symm
 
-set_option backward.defeqAttrib.useBackward true in
-@[simp]
-lemma flipTensor_ι : dsimp% sq.flipTensor.ι = sq.ι ≫ (β_ _ _).inv := by
-  simp [flipTensor]
-
 end CategoryTheory.Functor.PushoutObjObj

--- a/Mathlib/CategoryTheory/Monoidal/PushoutProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/PushoutProduct.lean
@@ -119,8 +119,8 @@ def whiskerLeftIso
       (associator_inv_naturality_middle W _ _).symm (associator_inv_naturality_right W _ _).symm))
     (α_ W _ _).symm
     (((tensorLeft W).map_isPushout
-      (IsPushout.of_hasPushout (X₁.hom ▷ X₂.left) (X₁.left ◁ X₂.hom))).hom_ext (by
-      simp) (by simp))
+      (IsPushout.of_hasPushout (X₁.hom ▷ X₂.left) (X₁.left ◁ X₂.hom))).hom_ext
+        (by simp [← whiskerLeft_comp_assoc]) (by simp [← whiskerLeft_comp_assoc]))
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
@@ -138,7 +138,8 @@ def whiskerRightIso
       (associator_naturality_left _ _ W).symm (associator_naturality_middle _ _ W).symm))
     (α_ _ _ W)
     (((tensorRight W).map_isPushout
-      (IsPushout.of_hasPushout (X₁.hom ▷ X₂.left) (X₁.left ◁ X₂.hom))).hom_ext (by simp) (by simp))
+      (IsPushout.of_hasPushout (X₁.hom ▷ X₂.left) (X₁.left ◁ X₂.hom))).hom_ext
+      (by simp [← comp_whiskerRight_assoc]) (by simp [← comp_whiskerRight_assoc]))
 
 -- helper instance for `PushoutProduct.associator`
 local instance {F : C ⥤ C}
@@ -165,16 +166,19 @@ def associator
           pushout.desc (_ ◁ pushout.inr _ _ ≫ pushout.inl _ _) (pushout.inr _ _)
           (by simp [Limits.pushout.associator_naturality_left_condition]))
         (((tensorRight _).map_isPushout (IsPushout.of_hasPushout _ _)).hom_ext
-          (by simp [Limits.pushout.whiskerLeft_condition_assoc, ← whisker_exchange_assoc])
-          (by simp [← whisker_exchange_assoc, Limits.pushout.associator_naturality_left_condition]))
+          (by simp [Limits.pushout.whiskerLeft_condition_assoc, ← whisker_exchange_assoc,
+            ← comp_whiskerRight_assoc])
+          (by simp [← whisker_exchange_assoc, Limits.pushout.associator_naturality_left_condition,
+            ← comp_whiskerRight_assoc]))
     · exact pushout.desc ((whiskerLeftIso _ _).hom.left ≫
           pushout.desc (pushout.inl _ _) ((pushout.inl _ _ ▷ _) ≫ pushout.inr _ _)
           (by simp [Limits.pushout.associator_inv_naturality_right_condition]))
         ((α_ _ _ _).inv ≫ (pushout.inr _ _) ▷ _ ≫ pushout.inr _ _)
         (((tensorLeft _).map_isPushout (IsPushout.of_hasPushout _ _)).hom_ext
           (by simp [whisker_exchange_assoc,
-            Limits.pushout.associator_inv_naturality_right_condition])
-          (by simp [whisker_exchange_assoc, Limits.pushout.condition_whiskerRight_assoc]))
+            Limits.pushout.associator_inv_naturality_right_condition, ← whiskerLeft_comp_assoc])
+          (by simp [whisker_exchange_assoc, Limits.pushout.condition_whiskerRight_assoc,
+            ← whiskerLeft_comp_assoc]))
     · apply pushout.hom_ext (by simp)
       apply ((tensorRight _).map_isPushout (IsPushout.of_hasPushout _ _)).hom_ext <;> simp
     · refine pushout.hom_ext ?_ (by simp)
@@ -214,7 +218,8 @@ def isInitialIso (X : Arrow C) {I : C} (i : IsInitial I) {W : C} :
   haveI : IsPushout (X.hom ▷ I) (_ ◁ i.to W) ((i.ofIso (zeroMul i).symm).to _) (𝟙 _) :=
     .of_horiz_isIso (sq := ⟨(i.ofIso (zeroMul i).symm).hom_ext ..⟩)
   Arrow.isoMk' _ _ this.isoPushout.symm (Iso.refl _)
-    (pushout.hom_ext ((i.ofIso (zeroMul i).symm).hom_ext _ _) (by simp))
+    (pushout.hom_ext ((i.ofIso (zeroMul i).symm).hom_ext _ _) (by
+      simp [pushout.inr_desc]))
 
 set_option backward.defeqAttrib.useBackward true in
 /-- The arrow isomorphism `(∅ ⟶ W) □ X ≅ W ◁ X` in a braided CCC with pushouts and
@@ -227,7 +232,7 @@ def isInitialIso' [BraidedCategory C] (X : Arrow C) {I : C} (i : IsInitial I) {W
   haveI : IsPushout (i.to W ▷ _) (I ◁ X.hom) (𝟙 _) ((i.ofIso (mulZero i).symm).to _) :=
     .of_vert_isIso (sq := ⟨(i.ofIso (mulZero i).symm).hom_ext ..⟩)
   Arrow.isoMk' _ _ this.isoPushout.symm (Iso.refl _)
-    (pushout.hom_ext (by simp) ((i.ofIso (mulZero i).symm).hom_ext _ _))
+    (pushout.hom_ext (by simp [pushout.inl_desc]) ((i.ofIso (mulZero i).symm).hom_ext _ _))
 
 /-- The arrow isomorphism `X □ (∅ ⟶ ⋆) ≅ X` in a CCC with pushouts, an initial object, and a
 terminal object. -/

--- a/Mathlib/CategoryTheory/Monoidal/PushoutProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/PushoutProduct.lean
@@ -218,8 +218,7 @@ def isInitialIso (X : Arrow C) {I : C} (i : IsInitial I) {W : C} :
   haveI : IsPushout (X.hom ▷ I) (_ ◁ i.to W) ((i.ofIso (zeroMul i).symm).to _) (𝟙 _) :=
     .of_horiz_isIso (sq := ⟨(i.ofIso (zeroMul i).symm).hom_ext ..⟩)
   Arrow.isoMk' _ _ this.isoPushout.symm (Iso.refl _)
-    (pushout.hom_ext ((i.ofIso (zeroMul i).symm).hom_ext _ _) (by
-      simp [pushout.inr_desc]))
+    (pushout.hom_ext ((i.ofIso (zeroMul i).symm).hom_ext ..) (by simp [pushout.inr_desc]))
 
 set_option backward.defeqAttrib.useBackward true in
 /-- The arrow isomorphism `(∅ ⟶ W) □ X ≅ W ◁ X` in a braided CCC with pushouts and


### PR DESCRIPTION
Given a bifunctor `F : C₁ ⥤ C₂ ⥤ C₃`, and morphisms `f₁ : X₁ ⟶ Y₁` in `C₁` and `f₂ : X₂ ⟶ Y₂` in `C₂`, one can form a commutative square in the category `C₃`, and the `PushoutObjObj` structure contains the data of a pushout of the top and left maps in this square. Then, `PushoutObjObj.ι` is the induced map from the pushout to the bottom-right object of the square.
Until this PR, `PushoutObjObj.ι` was a definition. In this PR, we make it a field of the structure `PushoutObjObj` instead. This allows a better control on the definitional properties of `ι`. This already simplifies proofs in the file `Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/PushoutProduct.lean` and I plan to take advantage of this in the formalization of the Reedy model category structure https://github.com/joelriou/reedy because in the study of similar structures for trifunctors obtained as compositions of bifunctors, these `ι` will appear as parameters of certain dependent types.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
