### PR TITLE
[Merged by Bors] - chore(CI): allow PR title to start with 'E2'

### DIFF
--- a/Mathlib/Tactic/Linter/ValidatePRTitle.lean
+++ b/Mathlib/Tactic/Linter/ValidatePRTitle.lean
@@ -69,6 +69,12 @@ def prTitle : Parser (String × Option String × String) := do
 #guard_msgs in
 #eval Parser.run prTitle "chore: test"
 
+/--
+Check if `word` looks like an abbreviation, like `JSON` or `E2` or `W3C`.
+-/
+def isAbbreviation (word : String.Slice) : Bool :=
+  word.all (fun c => c.isUpper || c.isDigit)
+
 open Mathlib.Linter.TextBased in
 /--
 Check if `title` matches the mathlib conventions for PR titles
@@ -115,7 +121,7 @@ public def validateTitle (title : String) : Array String := Id.run do
     -- Titles should be lower-cased (but we allow abbreviations).
     if subject.front.toLower != subject.front then
       let firstWord := subject.takeWhile (!·.isWhitespace)
-      if !(firstWord.all (·.isUpper)) then
+      if !isAbbreviation firstWord then
         errors := errors.push "error: the PR subject should be lowercased"
     if subject.endsWith "." then
       errors := errors.push "error: the PR title should not end with a full stop"

--- a/Mathlib/Tactic/Linter/ValidatePRTitle.lean
+++ b/Mathlib/Tactic/Linter/ValidatePRTitle.lean
@@ -73,7 +73,7 @@ def prTitle : Parser (String × Option String × String) := do
 Check if `word` looks like an abbreviation, like `JSON` or `E2` or `W3C`.
 -/
 def isAbbreviation (word : String.Slice) : Bool :=
-  word.all (fun c => c.isUpper || c.isDigit) && 1 < word.chars.length
+  word.all (fun c => c.isUpper || c.isDigit) && word.chars.length != 1
 
 open Mathlib.Linter.TextBased in
 /--

--- a/Mathlib/Tactic/Linter/ValidatePRTitle.lean
+++ b/Mathlib/Tactic/Linter/ValidatePRTitle.lean
@@ -73,7 +73,7 @@ def prTitle : Parser (String × Option String × String) := do
 Check if `word` looks like an abbreviation, like `JSON` or `E2` or `W3C`.
 -/
 def isAbbreviation (word : String.Slice) : Bool :=
-  word.all (fun c => c.isUpper || c.isDigit)
+  word.all (fun c => c.isUpper || c.isDigit) && 1 < word.chars.length
 
 open Mathlib.Linter.TextBased in
 /--

--- a/MathlibTest/ValidatePRTitle.lean
+++ b/MathlibTest/ValidatePRTitle.lean
@@ -186,3 +186,19 @@ info: Message: 'error: the PR title contains multiple consecutive spaces; please
 -/
 #guard_msgs in
 #check_title "feat(Mathlib/Algebra.lean):  title."
+
+#guard_msgs in
+#check_title "feat(ModularForm): E2 is bounded at ImInfty"
+
+#guard_msgs in
+#check_title "feat(ModuleForm): 2E is bounded at ImInfty"
+
+#guard_msgs in
+#check_title "feat(ModuleForm): 2e is less than 6"
+
+/-- info: Message: 'error: the PR subject should be lowercased' -/
+#guard_msgs in
+#check_title "feat(ModuleForm): W3c"
+
+#guard_msgs in
+#check_title "feat(ModuleForm): W3C"

--- a/MathlibTest/ValidatePRTitle.lean
+++ b/MathlibTest/ValidatePRTitle.lean
@@ -202,3 +202,7 @@ info: Message: 'error: the PR title contains multiple consecutive spaces; please
 
 #guard_msgs in
 #check_title "feat(ModuleForm): W3C"
+
+/-- info: Message: 'error: the PR subject should be lowercased' -/
+#guard_msgs in
+#check_title "feat(ModuleForm): A new lemma"


### PR DESCRIPTION
This PR relaxes the check at `ValidatePRTitle` to allow titles like `feat(ModularForm): E2 is bounded at ImInfty`.

This came up in #40765.

Zulip discussion (reviewers only): [#mathlib reviewers > Check PR title](https://leanprover.zulipchat.com/#narrow/channel/345428-mathlib-reviewers/topic/Check.20PR.20title/with/604860804)