### PR TITLE
[Merged by Bors] - refactor: make `{Con,AddCon,RingCon}.congr` match `Quotient.congr`

### DIFF
--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -80,7 +80,7 @@ theorem congr_mk {c : Con M} {d : Con N} (e : M ≃* N) (h : c = d.comap e (map_
 @[to_additive (attr := simp)]
 theorem congr_symm {c : Con M} {d : Con N} (e : M ≃* N) (h : c = d.comap e (map_mul e)) :
     (Con.congr e h).symm =
-      Con.congr e.symm (ext <| e.surjective.forall₂.2 fun x y => by simp [h]) :=
+      Con.congr e.symm (ext <| e.surjective.forall₂.2 <| by simp [h]) :=
   rfl
 
 @[to_additive]

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -77,6 +77,12 @@ protected def congr {c : Con M} {d : Con N} (e : M ≃* N) (h : c = d.comap e (m
 theorem congr_mk {c : Con M} {d : Con N} (e : M ≃* N) (h : c = d.comap e (map_mul e)) (a : M) :
     Con.congr e h (a : c.Quotient) = (e a : d.Quotient) := rfl
 
+@[to_additive (attr := simp)]
+theorem congr_symm {c : Con M} {d : Con N} (e : M ≃* N) (h : c = d.comap e (map_mul e)) :
+    (Con.congr e h).symm =
+      Con.congr e.symm (ext <| e.surjective.forall₂.2 fun x y => by simp [h]) :=
+  rfl
+
 @[to_additive]
 theorem le_comap_conGen {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -63,17 +63,19 @@ def pi {ι : Type*} {f : ι → Type*} [∀ i, Mul (f i)] (C : ∀ i, Con (f i))
   { @piSetoid _ _ fun i => (C i).toSetoid with
     mul' := fun h1 h2 i => (C i).mul (h1 i) (h2 i) }
 
-/-- Makes an isomorphism of quotients by two congruence relations, given that the relations are
-equal. -/
-@[to_additive /-- Makes an additive isomorphism of quotients by two additive congruence relations,
-given that the relations are equal. -/]
-protected def congr {c d : Con M} (h : c = d) : c.Quotient ≃* d.Quotient :=
-  { Quotient.congr (Equiv.refl M) <| by apply Con.ext_iff.mp h with
-    map_mul' := fun x y => by rcases x with ⟨⟩; rcases y with ⟨⟩; rfl }
+/-- A multiplicative equivalence `e : α ≃* β` generates an equivalence between quotient spaces,
+if it is compatible with the relations. -/
+@[to_additive
+/-- An additive equivalence `e : α ≃+ β` generates an equivalence between quotient spaces,
+if it is compatible with the relations. -/]
+protected def congr {c : Con M} {d : Con N} (e : M ≃* N) (h : c = d.comap e (map_mul e)) :
+    c.Quotient ≃* d.Quotient where
+  __ := Quotient.congr e <| by apply Con.ext_iff.mp h
+  map_mul' := by rintro ⟨x⟩ ⟨y⟩; exact congrArg toQuotient (e.map_mul x y)
 
 @[to_additive (attr := simp)]
-theorem congr_mk {c d : Con M} (h : c = d) (a : M) :
-    Con.congr h (a : c.Quotient) = (a : d.Quotient) := rfl
+theorem congr_mk {c : Con M} {d : Con N} (e : M ≃* N) (h : c = d.comap e (map_mul e)) (a : M) :
+    Con.congr e h (a : c.Quotient) = (e a : d.Quotient) := rfl
 
 @[to_additive]
 theorem le_comap_conGen {M N : Type*} [Mul M] [Mul N] (f : M → N)
@@ -239,7 +241,7 @@ noncomputable def quotientKerEquivOfSurjective (f : M →* P) (hf : Surjective f
 AddCon N -/]
 noncomputable def comapQuotientEquivOfSurj (c : Con M) (f : N →* M) (hf : Function.Surjective f) :
     (Con.comap f f.map_mul c).Quotient ≃* c.Quotient :=
-  (Con.congr Con.comap_eq).trans <| Con.quotientKerEquivOfSurjective (c.mk'.comp f) <|
+  (Con.congr (.refl _) Con.comap_eq).trans <| Con.quotientKerEquivOfSurjective (c.mk'.comp f) <|
     Con.mk'_surjective.comp hf
 
 @[to_additive (attr := simp)]
@@ -263,7 +265,7 @@ lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
 @[to_additive /-- The second isomorphism theorem for `AddMonoid`s. -/]
 noncomputable def comapQuotientEquiv (f : N →* M) :
     (comap f f.map_mul c).Quotient ≃* MonoidHom.mrange (c.mk'.comp f) :=
-  (Con.congr comap_eq).trans <| quotientKerEquivRange <| c.mk'.comp f
+  (Con.congr (.refl _) comap_eq).trans <| quotientKerEquivRange <| c.mk'.comp f
 
 /-- The **third isomorphism theorem for monoids**. -/
 @[to_additive /-- The third isomorphism theorem for `AddMonoid`s. -/]

--- a/Mathlib/RingTheory/Congruence/Hom.lean
+++ b/Mathlib/RingTheory/Congruence/Hom.lean
@@ -91,6 +91,11 @@ protected def congr {c : RingCon M} {d : RingCon N} (e : M ≃+* N) (h : c = d.c
 @[simp] theorem congr_mk {c : RingCon M} {d : RingCon N} (e : M ≃+* N) (h : c = d.comap e) (a : M) :
     RingCon.congr e h (a : c.Quotient) = (e a : d.Quotient) := rfl
 
+@[simp] theorem congr_symm {c : RingCon M} {d : RingCon N} (e : M ≃+* N) (h : c = d.comap e) :
+    (RingCon.congr e h).symm =
+      RingCon.congr e.symm (ext <| e.surjective.forall₂.2 fun x y => by simp [h]) :=
+  rfl
+
 /-- Given a function `f`, the smallest ring congruence relation containing the binary
 relation on `f`'s image defined by '`x ≈ y` iff the elements of `f⁻¹(x)` are related to
 the elements of `f⁻¹(y)` by a ring congruence relation `c`.' -/

--- a/Mathlib/RingTheory/Congruence/Hom.lean
+++ b/Mathlib/RingTheory/Congruence/Hom.lean
@@ -80,16 +80,16 @@ theorem comap_eq {g : N →+* M} :
     c.comap g = ker (c.mk'.comp g) := by
   rw [ker_comp, ker_mk'_eq]
 
-/-- Makes an isomorphism of quotients by two ring congruence
-relations, given that the relations are equal. -/
-protected def congr (h : c = d) :
-    c.Quotient ≃+* d.Quotient :=
-  { Quotient.congr (Equiv.refl M) <| by apply RingCon.ext_iff.mp h with
-    map_add' x y := by rcases x with ⟨⟩; rcases y with ⟨⟩; rfl
-    map_mul' x y := by rcases x with ⟨⟩; rcases y with ⟨⟩; rfl }
+/-- Makes an isomorphism of quotients by two ring congruence relations
+whose underlying rings are isomorphic, given that the relations are compatible. -/
+protected def congr {c : RingCon M} {d : RingCon N} (e : M ≃+* N) (h : c = d.comap e) :
+    c.Quotient ≃+* d.Quotient where
+  __ := Quotient.congr e <| by apply RingCon.ext_iff.mp h
+  map_mul' := by rintro ⟨x⟩ ⟨y⟩; exact congrArg toQuotient (e.map_mul x y)
+  map_add' := by rintro ⟨x⟩ ⟨y⟩; exact congrArg toQuotient (e.map_add x y)
 
-@[simp] theorem congr_mk (h : c = d) (a : M) :
-    RingCon.congr h (a : c.Quotient) = (a : d.Quotient) := rfl
+@[simp] theorem congr_mk {c : RingCon M} {d : RingCon N} (e : M ≃+* N) (h : c = d.comap e) (a : M) :
+    RingCon.congr e h (a : c.Quotient) = (e a : d.Quotient) := rfl
 
 /-- Given a function `f`, the smallest ring congruence relation containing the binary
 relation on `f`'s image defined by '`x ≈ y` iff the elements of `f⁻¹(x)` are related to
@@ -321,7 +321,7 @@ noncomputable def comapQuotientEquivOfSurj
     (c : RingCon M) (f : N →+* M) (hf : Function.Surjective f)
     {d : RingCon N} (hcd : d = c.comap f) :
     d.Quotient ≃+* c.Quotient :=
-  (RingCon.congr (hcd.trans c.comap_eq)).trans
+  (RingCon.congr (.refl _) (hcd.trans c.comap_eq)).trans
     <| RingCon.quotientKerEquivOfSurjective (c.mk'.comp f)
     (c.mk'_surjective.comp hf)
 
@@ -348,7 +348,7 @@ noncomputable def comapQuotientEquivOfSurj
 noncomputable def comapQuotientEquivRangeS (f : N →+* M)
     {d : RingCon N} (hcd : d = comap c f) :
     d.Quotient ≃+* RingHom.rangeS (c.mk'.comp f) :=
-  (RingCon.congr (hcd.trans comap_eq)).trans <| quotientKerEquivRangeS <| c.mk'.comp f
+  (RingCon.congr (.refl _) (hcd.trans comap_eq)).trans <| quotientKerEquivRangeS <| c.mk'.comp f
 
 @[simp] theorem comapQuotientEquivRangeS_mk (f : N →+* M)
     {d : RingCon N} (hcd : d = comap c f) (x : N) :
@@ -451,13 +451,13 @@ variable {c d : RingCon M} {f : M →ₐ[R] P}
 variable (R) in
 /-- Makes an algebra isomorphism of quotients by two ring congruence
 relations, given that the relations are equal. -/
-protected def congrₐ {c d : RingCon M} (h : c = d) :
-    c.Quotient ≃ₐ[R] d.Quotient :=
-  { RingCon.congr h with
-    commutes' _ := rfl }
+protected def congrₐ {c : RingCon M} {d : RingCon N} (e : M ≃ₐ[R] N) (h : c = d.comap e) :
+    c.Quotient ≃ₐ[R] d.Quotient where
+  __ := RingCon.congr e h
+  commutes' r := by simp [← coe_algebraMap]
 
-theorem congrₐ_mk {c d : RingCon M} (h : c = d) (a : M) :
-    RingCon.congrₐ R h (a : c.Quotient) = (a : d.Quotient) :=
+theorem congrₐ_mk {c : RingCon M} {d : RingCon N} (e : M ≃ₐ[R] N) (h : c = d.comap e) (a : M) :
+    RingCon.congrₐ R e h (a : c.Quotient) = (e a : d.Quotient) :=
   rfl
 
 theorem range_mkₐ : AlgHom.range (mkₐ R c) = ⊤ :=
@@ -570,7 +570,7 @@ theorem quotientKerEquivRangeₐ_comp_mkₐ (φ : M →ₐ[R] N) :
 /-- The **second isomorphism theorem for algebras**. -/
 noncomputable def comapQuotientEquivRangeₐ (f : N →ₐ[R] M) {d : RingCon N} (h : d = comap c f) :
     d.Quotient ≃ₐ[R] AlgHom.range ((c.mkₐ _).comp f) :=
-  (RingCon.congrₐ R (h.trans comap_eq)).trans <| quotientKerEquivRangeₐ ((c.mkₐ _).comp f)
+  (RingCon.congrₐ R .refl (h.trans comap_eq)).trans <| quotientKerEquivRangeₐ ((c.mkₐ _).comp f)
 
 theorem comapQuotientEquivRangeₐ_mk (f : N →ₐ[R] M) {d : RingCon N} (h : d = comap c f) (x : N) :
     c.comapQuotientEquivRangeₐ f h x = ⟨f x, AlgHom.mem_range_self _ x⟩ :=

--- a/Mathlib/RingTheory/Congruence/Hom.lean
+++ b/Mathlib/RingTheory/Congruence/Hom.lean
@@ -80,8 +80,8 @@ theorem comap_eq {g : N →+* M} :
     c.comap g = ker (c.mk'.comp g) := by
   rw [ker_comp, ker_mk'_eq]
 
-/-- Makes an isomorphism of quotients by two ring congruence relations
-whose underlying rings are isomorphic, given that the relations are compatible. -/
+/-- An isomorphism of rings `e : M ≃+* N` generates an isomorphism between quotient spaces,
+if it is compatible with the relations. -/
 protected def congr {c : RingCon M} {d : RingCon N} (e : M ≃+* N) (h : c = d.comap e) :
     c.Quotient ≃+* d.Quotient where
   __ := Quotient.congr e <| by apply RingCon.ext_iff.mp h
@@ -93,7 +93,7 @@ protected def congr {c : RingCon M} {d : RingCon N} (e : M ≃+* N) (h : c = d.c
 
 @[simp] theorem congr_symm {c : RingCon M} {d : RingCon N} (e : M ≃+* N) (h : c = d.comap e) :
     (RingCon.congr e h).symm =
-      RingCon.congr e.symm (ext <| e.surjective.forall₂.2 fun x y => by simp [h]) :=
+      RingCon.congr e.symm (ext <| e.surjective.forall₂.2 <| by simp [h]) :=
   rfl
 
 /-- Given a function `f`, the smallest ring congruence relation containing the binary
@@ -454,8 +454,8 @@ variable {R : Type*} [CommSemiring R]
 variable {c d : RingCon M} {f : M →ₐ[R] P}
 
 variable (R) in
-/-- Makes an algebra isomorphism of quotients by two ring congruence
-relations, given that the relations are equal. -/
+/-- An isomorphism of algebras `e : M ≃ₐ[R] N` generates an isomorphism between quotient spaces,
+if it is compatible with the relations. -/
 protected def congrₐ {c : RingCon M} {d : RingCon N} (e : M ≃ₐ[R] N) (h : c = d.comap e) :
     c.Quotient ≃ₐ[R] d.Quotient where
   __ := RingCon.congr e h
@@ -468,7 +468,7 @@ theorem congrₐ_mk {c : RingCon M} {d : RingCon N} (e : M ≃ₐ[R] N) (h : c =
 
 @[simp] theorem congrₐ_symm {c : RingCon M} {d : RingCon N} (e : M ≃ₐ[R] N) (h : c = d.comap e) :
     (RingCon.congrₐ R e h).symm =
-      RingCon.congrₐ R e.symm (ext <| e.surjective.forall₂.2 fun x y => by simp [h]) :=
+      RingCon.congrₐ R e.symm (ext <| e.surjective.forall₂.2 <| by simp [h]) :=
   rfl
 
 theorem range_mkₐ : AlgHom.range (mkₐ R c) = ⊤ :=

--- a/Mathlib/RingTheory/Congruence/Hom.lean
+++ b/Mathlib/RingTheory/Congruence/Hom.lean
@@ -461,8 +461,14 @@ protected def congrₐ {c : RingCon M} {d : RingCon N} (e : M ≃ₐ[R] N) (h : 
   __ := RingCon.congr e h
   commutes' r := by simp [← coe_algebraMap]
 
+@[simp]
 theorem congrₐ_mk {c : RingCon M} {d : RingCon N} (e : M ≃ₐ[R] N) (h : c = d.comap e) (a : M) :
     RingCon.congrₐ R e h (a : c.Quotient) = (e a : d.Quotient) :=
+  rfl
+
+@[simp] theorem congrₐ_symm {c : RingCon M} {d : RingCon N} (e : M ≃ₐ[R] N) (h : c = d.comap e) :
+    (RingCon.congrₐ R e h).symm =
+      RingCon.congrₐ R e.symm (ext <| e.surjective.forall₂.2 fun x y => by simp [h]) :=
   rfl
 
 theorem range_mkₐ : AlgHom.range (mkₐ R c) = ⊤ :=


### PR DESCRIPTION
This adds an explicit equivalence argument, rather than defaulting it to `refl`.

Also adds a missing `symm` lemma for each.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
