### PR TITLE
[Merged by Bors] - chore: move RingQuot results

### DIFF
--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -5,7 +5,7 @@ Authors: Kim Morrison
 -/
 module
 
-public import Mathlib.Algebra.Algebra.Hom
+public import Mathlib.Algebra.Algebra.Equiv
 public import Mathlib.RingTheory.Congruence.Basic
 public import Mathlib.RingTheory.Ideal.Quotient.Defs
 public import Mathlib.RingTheory.Ideal.Span
@@ -545,6 +545,38 @@ theorem liftAlgHom_unique (f : A →ₐ[S] B) {s : A → A → Prop} (w : ∀ �
 theorem eq_liftAlgHom_comp_mkAlgHom {s : A → A → Prop} (f : RingQuot s →ₐ[S] B) :
     f = liftAlgHom S ⟨f.comp (mkAlgHom S s), fun _ _ h ↦ congr_arg f (mkAlgHom_rel S h)⟩ :=
   liftAlgHom_unique S (f.comp (mkAlgHom S s)) (fun _ _ h ↦ congr_arg (⇑f) (mkAlgHom_rel S h)) f rfl
+
+open scoped Function -- required for scoped `on` notation
+
+variable {S}
+
+/-- If two `S`-algebras are `S`-equivalent and their quotients by a relation `rel` are defined,
+then their quotients are also `S`-equivalent.
+
+(Special case of the third isomorphism theorem.) -/
+def algEquivQuotAlgEquiv (f : A ≃ₐ[S] B) (rel : A → A → Prop) :
+    RingQuot rel ≃ₐ[S] RingQuot (rel on f.symm) :=
+  AlgEquiv.ofAlgHom
+    (RingQuot.liftAlgHom S (s := rel)
+      ⟨AlgHom.comp (RingQuot.mkAlgHom S (rel on f.symm)) f,
+      fun x y h_rel ↦ by
+        apply RingQuot.mkAlgHom_rel
+        simpa [Function.onFun]⟩)
+    ((RingQuot.liftAlgHom S (s := rel on f.symm)
+      ⟨AlgHom.comp (RingQuot.mkAlgHom S rel) f.symm,
+      fun x y h ↦ by apply RingQuot.mkAlgHom_rel; simpa⟩))
+    (by ext b; simp) (by ext a; simp)
+
+/-- If two (semi)rings are equivalent and their quotients by a relation `rel` are defined,
+then their quotients are also equivalent.
+
+(Special case of `algEquivQuotAlgEquiv` when `S = ℕ`, which in turn is a special
+case of the third isomorphism theorem.) -/
+def equivQuotEquiv (f : A ≃+* B) (rel : A → A → Prop) :
+    RingQuot rel ≃+* RingQuot (rel on f.symm) :=
+  let f_alg : A ≃ₐ[ℕ] B :=
+    AlgEquiv.ofRingEquiv (f := f) (fun n ↦ by simp)
+  algEquivQuotAlgEquiv f_alg rel |>.toRingEquiv
 
 end Algebra
 

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -65,43 +65,6 @@ theorem induction_lon {R : Type*} [Semiring R] {ι : Type*} [DecidableEq ι]
 
 end DirectSum
 
-namespace RingQuot
-universe uS uA uB
-
-open scoped Function -- required for scoped `on` notation
-
-/-- If two `R`-algebras are `R`-equivalent and their quotients by a relation `rel` are defined,
-then their quotients are also `R`-equivalent.
-
-(Special case of the third isomorphism theorem.) -/
-def algEquivQuotAlgEquiv
-    {R : Type u} [CommSemiring R] {A B : Type v} [Semiring A] [Semiring B]
-    [Algebra R A] [Algebra R B] (f : A ≃ₐ[R] B) (rel : A → A → Prop) :
-    RingQuot rel ≃ₐ[R] RingQuot (rel on f.symm) :=
-  AlgEquiv.ofAlgHom
-    (RingQuot.liftAlgHom R (s := rel)
-      ⟨AlgHom.comp (RingQuot.mkAlgHom R (rel on f.symm)) f,
-      fun x y h_rel ↦ by
-        apply RingQuot.mkAlgHom_rel
-        simpa [Function.onFun]⟩)
-    ((RingQuot.liftAlgHom R (s := rel on f.symm)
-      ⟨AlgHom.comp (RingQuot.mkAlgHom R rel) f.symm,
-      fun x y h ↦ by apply RingQuot.mkAlgHom_rel; simpa⟩))
-    (by ext b; simp) (by ext a; simp)
-
-/-- If two (semi)rings are equivalent and their quotients by a relation `rel` are defined,
-then their quotients are also equivalent.
-
-(Special case of `algEquiv_quot_algEquiv` when `R = ℕ`, which in turn is a special
-case of the third isomorphism theorem.) -/
-def equivQuotEquiv {A B : Type v} [Semiring A] [Semiring B] (f : A ≃+* B) (rel : A → A → Prop) :
-    RingQuot rel ≃+* RingQuot (rel on f.symm) :=
-  let f_alg : A ≃ₐ[ℕ] B :=
-    AlgEquiv.ofRingEquiv (f := f) (fun n ↦ by simp)
-  algEquivQuotAlgEquiv f_alg rel |>.toRingEquiv
-
-end RingQuot
-
 open TensorAlgebra DirectSum TensorPower
 
 variable {I : Type u} [DecidableEq I] {i : I} -- The type of the indexing set


### PR DESCRIPTION
This is prework for swapping `FreeProduct` to use `RingCon` instead of `RingQuot`; at which point this would allow the import to be removed from that file entirely.

I renamed `R` to `S` in the move, to match the ambient variables in the destination.

I haven't attempted to golf the proofs since my intent is to ultimately deprecate the entire destination file.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
