### PR TITLE
[Merged by Bors] - chore(RingTheory/Spectrum/Prime/FreeLocus): unsqueeze terminal `simp`s

### DIFF
--- a/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
@@ -68,11 +68,7 @@ lemma mem_freeLocus_of_isLocalization (p : PrimeSpectrum R)
   intro r x
   obtain ⟨r, s, rfl⟩ := IsLocalization.exists_mk'_eq p.asIdeal.primeCompl r
   apply ((Module.End.isUnit_iff _).mp (IsLocalizedModule.map_units f s)).1
-  simp only [e, AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, LinearEquiv.coe_coe,
-    algebraMap_end_apply,
-    AlgEquiv.toRingEquiv_toRingHom, RingHom.coe_coe, IsLocalization.algEquiv_apply,
-    IsLocalization.map_id_mk']
-  simp only [← map_smul, ← smul_assoc, IsLocalization.smul_mk'_self, algebraMap_smul]
+  simp [e, ← map_smul, ← smul_assoc]
 
 attribute [local instance] RingHomInvPair.of_ringEquiv in
 lemma mem_freeLocus_iff_tensor (p : PrimeSpectrum R)


### PR DESCRIPTION
As recommended in the style guide. Extracted from #40793.

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)