### PR TITLE
chore(NumberTheory/PrimeCounting): minor golf

### DIFF
--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -169,14 +169,14 @@ lemma two_le_of_mem_primesLE (hp : p ∈ primesLE n) : 2 ≤ p := two_le_of_mem_
 lemma primesBelow_eq_filter_Ico_zero (n : ℕ) : primesBelow n = filter Prime (Ico 0 n) := by
   simp [primesBelow_eq_filter_range]
 
-lemma primesLE_eq_filter_Icc_zero (n : ℕ) : primesLE n = filter Prime (Icc 0 n) := by
-  ext; simp [primesLE_eq_filter_range]
+lemma primesLE_eq_filter_Icc_zero (n : ℕ) : primesLE n = filter Prime (Icc 0 n) :=
+  primesBelow_eq_filter_Ico_zero _
 
 lemma primesBelow_eq_filter_Ioo_zero (n : ℕ) : primesBelow n = filter Prime (Ioo 0 n) := by
   ext; simp +contextual [primesBelow_eq_filter_range, Prime.pos]
 
-lemma primesLE_eq_filter_Ioc_zero (n : ℕ) : primesLE n = filter Prime (Ioc 0 n) := by
-  ext; simp +contextual [primesLE_eq_filter_range, Prime.pos]
+lemma primesLE_eq_filter_Ioc_zero (n : ℕ) : primesLE n = filter Prime (Ioc 0 n) :=
+  primesBelow_eq_filter_Ioo_zero _
 
 lemma primesBelow_eq_filter_Ico_one (n : ℕ) : primesBelow n = filter Prime (Ico 1 n) :=
   primesBelow_eq_filter_Ioo_zero n
@@ -187,8 +187,8 @@ lemma primesLE_eq_filter_Icc_one (n : ℕ) : primesLE n = filter Prime (Icc 1 n)
 lemma primesBelow_eq_filter_Ioo_one (n : ℕ) : primesBelow n = filter Prime (Ioo 1 n) := by
   ext; simp +contextual [primesBelow_eq_filter_range, Prime.one_lt]
 
-lemma primesLE_eq_filter_Ioc_one (n : ℕ) : primesLE n = filter Prime (Ioc 1 n) := by
-  ext; simp +contextual [primesLE_eq_filter_range, Prime.one_lt]
+lemma primesLE_eq_filter_Ioc_one (n : ℕ) : primesLE n = filter Prime (Ioc 1 n) :=
+  primesBelow_eq_filter_Ioo_one _
 
 lemma primesBelow_eq_filter_Ico_two (n : ℕ) : primesBelow n = filter Prime (Ico 2 n) :=
   primesBelow_eq_filter_Ioo_one n

--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -117,15 +117,15 @@ section PrimeSets
 
 variable {p k n : ℕ}
 
-/-- `primesBelow n` is the set of primes less than `n` as a `Finset`. -/
+/-- `n.primesBelow` is the set of primes less than `n` as a `Finset`. -/
 def primesBelow (n : ℕ) : Finset ℕ := {p ∈ range n | p.Prime}
 
-/-- `primesLE n` is the set of primes less than or equal to `n` as a `Finset`. -/
+/-- `n.primesLE` is the set of primes less than or equal to `n` as a `Finset`. -/
 def primesLE (n : ℕ) : Finset ℕ := primesBelow (n + 1)
 
-lemma primesBelow_eq_filter_range (n : ℕ) : primesBelow n = filter Prime (range n) := rfl
+lemma primesBelow_eq_filter_range (n : ℕ) : n.primesBelow = filter Prime (range n) := rfl
 
-lemma primesLE_eq_filter_range (n : ℕ) : primesLE n = filter Prime (range (n + 1)) := rfl
+lemma primesLE_eq_filter_range (n : ℕ) : n.primesLE = filter Prime (range (n + 1)) := rfl
 
 @[simp]
 lemma primesBelow_zero : primesBelow 0 = ∅ := by decide
@@ -142,58 +142,58 @@ lemma primesLE_zero : primesLE 0 = ∅ := primesBelow_one
 @[simp]
 lemma primesLE_one : primesLE 1 = ∅ := primesBelow_two
 
-theorem primesBelow_eq_primesLE_sub_one (n : ℕ) : primesBelow n = primesLE (n - 1) := by
+theorem primesBelow_eq_primesLE_sub_one (n : ℕ) : n.primesBelow = primesLE (n - 1) := by
   cases n <;> simp [primesLE]
 
 lemma mem_primesBelow : n ∈ primesBelow k ↔ n < k ∧ n.Prime := by simp [primesBelow]
 
-lemma mem_primesLE : p ∈ primesLE n ↔ p ≤ n ∧ p.Prime := by simp [primesLE, mem_primesBelow]
+lemma mem_primesLE : p ∈ n.primesLE ↔ p ≤ n ∧ p.Prime := by simp [primesLE, mem_primesBelow]
 
 lemma prime_of_mem_primesBelow (h : p ∈ n.primesBelow) : p.Prime := (mem_filter.mp h).2
 
-lemma prime_of_mem_primesLE (hp : p ∈ primesLE n) : p.Prime := prime_of_mem_primesBelow hp
+lemma prime_of_mem_primesLE (hp : p ∈ n.primesLE) : p.Prime := prime_of_mem_primesBelow hp
 
 lemma lt_of_mem_primesBelow (h : p ∈ n.primesBelow) : p < n := (mem_primesBelow.mp h).1
 
-lemma le_of_mem_primesLE (hp : p ∈ primesLE n) : p ≤ n := (mem_primesLE.mp hp).1
+lemma le_of_mem_primesLE (hp : p ∈ n.primesLE) : p ≤ n := (mem_primesLE.mp hp).1
 
-lemma one_lt_of_mem_primesBelow (hp : p ∈ primesBelow n) : 1 < p :=
+lemma one_lt_of_mem_primesBelow (hp : p ∈ n.primesBelow) : 1 < p :=
   (prime_of_mem_primesBelow hp).one_lt
 
-lemma one_lt_of_mem_primesLE (hp : p ∈ primesLE n) : 1 < p := one_lt_of_mem_primesBelow hp
+lemma one_lt_of_mem_primesLE (hp : p ∈ n.primesLE) : 1 < p := one_lt_of_mem_primesBelow hp
 
-lemma two_le_of_mem_primesBelow (hp : p ∈ primesBelow n) : 2 ≤ p := one_lt_of_mem_primesBelow hp
+lemma two_le_of_mem_primesBelow (hp : p ∈ n.primesBelow) : 2 ≤ p := one_lt_of_mem_primesBelow hp
 
-lemma two_le_of_mem_primesLE (hp : p ∈ primesLE n) : 2 ≤ p := two_le_of_mem_primesBelow hp
+lemma two_le_of_mem_primesLE (hp : p ∈ n.primesLE) : 2 ≤ p := two_le_of_mem_primesBelow hp
 
-lemma primesBelow_eq_filter_Ico_zero (n : ℕ) : primesBelow n = filter Prime (Ico 0 n) := by
+lemma primesBelow_eq_filter_Ico_zero (n : ℕ) : n.primesBelow = filter Prime (Ico 0 n) := by
   simp [primesBelow_eq_filter_range]
 
-lemma primesLE_eq_filter_Icc_zero (n : ℕ) : primesLE n = filter Prime (Icc 0 n) :=
+lemma primesLE_eq_filter_Icc_zero (n : ℕ) : n.primesLE = filter Prime (Icc 0 n) :=
   primesBelow_eq_filter_Ico_zero _
 
-lemma primesBelow_eq_filter_Ioo_zero (n : ℕ) : primesBelow n = filter Prime (Ioo 0 n) := by
+lemma primesBelow_eq_filter_Ioo_zero (n : ℕ) : n.primesBelow = filter Prime (Ioo 0 n) := by
   ext; simp +contextual [primesBelow_eq_filter_range, Prime.pos]
 
-lemma primesLE_eq_filter_Ioc_zero (n : ℕ) : primesLE n = filter Prime (Ioc 0 n) :=
+lemma primesLE_eq_filter_Ioc_zero (n : ℕ) : n.primesLE = filter Prime (Ioc 0 n) :=
   primesBelow_eq_filter_Ioo_zero _
 
-lemma primesBelow_eq_filter_Ico_one (n : ℕ) : primesBelow n = filter Prime (Ico 1 n) :=
+lemma primesBelow_eq_filter_Ico_one (n : ℕ) : n.primesBelow = filter Prime (Ico 1 n) :=
   primesBelow_eq_filter_Ioo_zero n
 
-lemma primesLE_eq_filter_Icc_one (n : ℕ) : primesLE n = filter Prime (Icc 1 n) :=
+lemma primesLE_eq_filter_Icc_one (n : ℕ) : n.primesLE = filter Prime (Icc 1 n) :=
   primesLE_eq_filter_Ioc_zero n
 
-lemma primesBelow_eq_filter_Ioo_one (n : ℕ) : primesBelow n = filter Prime (Ioo 1 n) := by
+lemma primesBelow_eq_filter_Ioo_one (n : ℕ) : n.primesBelow = filter Prime (Ioo 1 n) := by
   ext; simp +contextual [primesBelow_eq_filter_range, Prime.one_lt]
 
-lemma primesLE_eq_filter_Ioc_one (n : ℕ) : primesLE n = filter Prime (Ioc 1 n) :=
+lemma primesLE_eq_filter_Ioc_one (n : ℕ) : n.primesLE = filter Prime (Ioc 1 n) :=
   primesBelow_eq_filter_Ioo_one _
 
-lemma primesBelow_eq_filter_Ico_two (n : ℕ) : primesBelow n = filter Prime (Ico 2 n) :=
+lemma primesBelow_eq_filter_Ico_two (n : ℕ) : n.primesBelow = filter Prime (Ico 2 n) :=
   primesBelow_eq_filter_Ioo_one n
 
-lemma primesLE_eq_filter_Icc_two (n : ℕ) : primesLE n = filter Prime (Icc 2 n) :=
+lemma primesLE_eq_filter_Icc_two (n : ℕ) : n.primesLE = filter Prime (Icc 2 n) :=
   primesLE_eq_filter_Ioc_one n
 
 lemma primesBelow_mono : Monotone primesBelow := by intro _ _ _ _; grind [mem_primesBelow]
@@ -201,29 +201,29 @@ lemma primesBelow_mono : Monotone primesBelow := by intro _ _ _ _; grind [mem_pr
 lemma primesLE_mono : Monotone primesLE := by intro _ _ _ _; grind [mem_primesLE]
 
 lemma primesBelow_succ (n : ℕ) :
-    primesBelow (n + 1) = if n.Prime then insert n (primesBelow n) else primesBelow n := by
+    (n + 1).primesBelow = if n.Prime then insert n n.primesBelow else n.primesBelow := by
   rw [primesBelow, primesBelow, range_add_one, filter_insert]
 
 lemma primesLE_succ (n : ℕ) :
-    primesLE (n + 1) = if (n + 1).Prime then insert (n + 1) (primesLE n) else primesLE n :=
+    (n + 1).primesLE = if (n + 1).Prime then insert (n + 1) n.primesLE else n.primesLE :=
   primesBelow_succ _
 
-lemma notMem_primesBelow (n : ℕ) : n ∉ primesBelow n :=
+lemma notMem_primesBelow (n : ℕ) : n ∉ n.primesBelow :=
   fun hn ↦ (lt_of_mem_primesBelow hn).false
 
-lemma notMem_primesLE (n : ℕ) : n + 1 ∉ primesLE n := notMem_primesBelow _
+lemma notMem_primesLE (n : ℕ) : n + 1 ∉ n.primesLE := notMem_primesBelow _
 
 end PrimeSets
 
-/-- The cardinality of the finset `primesBelow n` equals the counting function
+/-- The cardinality of the finset `n.primesBelow` equals the counting function
 `primeCounting'` at `n`. -/
 theorem primesBelow_card_eq_primeCounting' (n : ℕ) : #n.primesBelow = π' n := by
   simpa [primesBelow, primeCounting'] using (count_eq_card_filter_range Prime n).symm
 
-/-- The cardinality of the finset `primesLE n` equals the counting function
+/-- The cardinality of the finset `n.primesLE` equals the counting function
 `primeCounting` at `n`. -/
 @[simp]
-theorem primesLE_card_eq_primeCounting (n : ℕ) : #(primesLE n) = π n := by
+theorem primesLE_card_eq_primeCounting (n : ℕ) : #n.primesLE = π n := by
   simp only [primesLE, primeCounting, primesBelow_card_eq_primeCounting']
 
 /-- A linear upper bound on the size of the `primeCounting'` function -/

--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -230,7 +230,7 @@ theorem primeCounting'_add_le (h0 : a ≠ 0) (h1 : a < k) (n : ℕ) :
   calc
     _ ≤ #{p ∈ range k | p.Prime} + #{p ∈ Ico k (k + n) | p.Prime} := by
       simp_rw [primeCounting', count_eq_card_filter_range, range_eq_Ico,
-      ← Ico_union_Ico_eq_Ico (zero_le k) le_self_add, filter_union]
+        ← Ico_union_Ico_eq_Ico (zero_le k) le_self_add, filter_union]
       apply card_union_le
     _ ≤ π' k + #{p ∈ Ico k (k + n) | p.Prime} := by rw [primeCounting', count_eq_card_filter_range]
     _ ≤ π' k + #{b ∈ Ico k (k + n) | a.Coprime b} := by

--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -48,29 +48,25 @@ open Finset
 *strictly* less than the input. More convenient for avoiding off-by-one errors.
 
 With `open scoped Nat.Prime`, this has notation `π'`. -/
-def primeCounting' : ℕ → ℕ :=
-  Nat.count Prime
+def primeCounting' : ℕ → ℕ := count Prime
 
 /-- The prime counting function: Returns the number of primes less than or equal to the input.
 
 With `open scoped Nat.Prime`, this has notation `π`. -/
-def primeCounting (n : ℕ) : ℕ :=
-  primeCounting' (n + 1)
+def primeCounting (n : ℕ) : ℕ := primeCounting' (n + 1)
 
-@[inherit_doc] scoped[Nat.Prime] notation "π" => Nat.primeCounting
+@[inherit_doc] scoped[Nat.Prime] notation "π" => primeCounting
 
-@[inherit_doc] scoped[Nat.Prime] notation "π'" => Nat.primeCounting'
+@[inherit_doc] scoped[Nat.Prime] notation "π'" => primeCounting'
 
 open scoped Nat.Prime
 
 theorem primeCounting_eq_primeCounting'_succ (n : ℕ) : π n = π' (n + 1) := rfl
 
 @[simp]
-theorem primeCounting_sub_one (n : ℕ) : π (n - 1) = π' n := by
-  cases n <;> rfl
+theorem primeCounting_sub_one (n : ℕ) : π (n - 1) = π' n := by cases n <;> rfl
 
-theorem monotone_primeCounting' : Monotone primeCounting' :=
-  count_monotone Prime
+theorem monotone_primeCounting' : Monotone primeCounting' := count_monotone Prime
 
 theorem monotone_primeCounting : Monotone primeCounting :=
   monotone_primeCounting'.comp (monotone_id.add_const _)
@@ -84,10 +80,10 @@ theorem add_two_le_nth_prime (n : ℕ) : n + 2 ≤ nth Prime n :=
   nth_prime_zero_eq_two ▸ (nth_strictMono infinite_setOf_prime).add_le_nat n 0
 
 theorem surjective_primeCounting' : Function.Surjective π' :=
-  Nat.surjective_count_of_infinite_setOf infinite_setOf_prime
+  surjective_count_of_infinite_setOf infinite_setOf_prime
 
 theorem surjective_primeCounting : Function.Surjective π := by
-  suffices Function.Surjective (π ∘ fun n => n - 1) from this.of_comp
+  suffices Function.Surjective (π ∘ fun n ↦ n - 1) from this.of_comp
   convert! surjective_primeCounting'
   ext
   exact primeCounting_sub_one _
@@ -107,45 +103,40 @@ theorem prime_nth_prime (n : ℕ) : Prime (nth Prime n) :=
 
 @[simp]
 lemma primeCounting'_eq_zero_iff {n : ℕ} : n.primeCounting' = 0 ↔ n ≤ 2 := by
-  rw [primeCounting', Nat.count_eq_zero ⟨_, Nat.prime_two⟩, Nat.nth_prime_zero_eq_two]
+  rw [primeCounting', Nat.count_eq_zero ⟨_, prime_two⟩, nth_prime_zero_eq_two]
 
 @[simp]
 lemma primeCounting_eq_zero_iff {n : ℕ} : n.primeCounting = 0 ↔ n ≤ 1 := by
   simp [primeCounting, -Order.add_one_le_iff]
 
 @[simp]
-lemma primeCounting_zero : primeCounting 0 = 0 :=
-  primeCounting_eq_zero_iff.mpr zero_le_one
+lemma primeCounting_zero : primeCounting 0 = 0 := primeCounting_eq_zero_iff.mpr zero_le_one
 
 @[simp]
-lemma primeCounting_one : primeCounting 1 = 0 :=
-  primeCounting_eq_zero_iff.mpr le_rfl
+lemma primeCounting_one : primeCounting 1 = 0 := primeCounting_eq_zero_iff.mpr le_rfl
 
 section PrimeSets
 
 variable {p k n : ℕ}
 
 /-- `primesBelow n` is the set of primes less than `n` as a `Finset`. -/
-def primesBelow (n : ℕ) : Finset ℕ := {p ∈ Finset.range n | p.Prime}
+def primesBelow (n : ℕ) : Finset ℕ := {p ∈ range n | p.Prime}
 
 /-- `primesLE n` is the set of primes less than or equal to `n` as a `Finset`. -/
 def primesLE (n : ℕ) : Finset ℕ := primesBelow (n + 1)
 
-lemma primesBelow_eq_filter_range (n : ℕ) : primesBelow n = filter Nat.Prime (range n) := rfl
+lemma primesBelow_eq_filter_range (n : ℕ) : primesBelow n = filter Prime (range n) := rfl
 
-lemma primesLE_eq_filter_range (n : ℕ) : primesLE n = filter Nat.Prime (range (n + 1)) := rfl
-
-@[simp]
-lemma primesBelow_zero : primesBelow 0 = ∅ := by
-  decide
+lemma primesLE_eq_filter_range (n : ℕ) : primesLE n = filter Prime (range (n + 1)) := rfl
 
 @[simp]
-lemma primesBelow_one : primesBelow 1 = ∅ := by
-  decide
+lemma primesBelow_zero : primesBelow 0 = ∅ := by decide
 
 @[simp]
-lemma primesBelow_two : primesBelow 2 = ∅ := by
-  decide
+lemma primesBelow_one : primesBelow 1 = ∅ := by decide
+
+@[simp]
+lemma primesBelow_two : primesBelow 2 = ∅ := by decide
 
 @[simp]
 lemma primesLE_zero : primesLE 0 = ∅ := primesBelow_one
@@ -156,86 +147,64 @@ lemma primesLE_one : primesLE 1 = ∅ := primesBelow_two
 theorem primesBelow_eq_primesLE_sub_one (n : ℕ) : primesBelow n = primesLE (n - 1) := by
   cases n <;> simp [primesLE]
 
-lemma mem_primesBelow :
-    n ∈ primesBelow k ↔ n < k ∧ n.Prime := by simp [primesBelow]
+lemma mem_primesBelow : n ∈ primesBelow k ↔ n < k ∧ n.Prime := by simp [primesBelow]
 
-lemma mem_primesLE : p ∈ primesLE n ↔ p ≤ n ∧ p.Prime := by
-  simp [primesLE, mem_primesBelow]
+lemma mem_primesLE : p ∈ primesLE n ↔ p ≤ n ∧ p.Prime := by simp [primesLE, mem_primesBelow]
 
-lemma prime_of_mem_primesBelow (h : p ∈ n.primesBelow) : p.Prime :=
-  (Finset.mem_filter.mp h).2
+lemma prime_of_mem_primesBelow (h : p ∈ n.primesBelow) : p.Prime := (mem_filter.mp h).2
 
-lemma prime_of_mem_primesLE (hp : p ∈ primesLE n) : p.Prime :=
-  prime_of_mem_primesBelow hp
+lemma prime_of_mem_primesLE (hp : p ∈ primesLE n) : p.Prime := prime_of_mem_primesBelow hp
 
-lemma lt_of_mem_primesBelow (h : p ∈ n.primesBelow) : p < n :=
-  Finset.mem_range.mp <| Finset.mem_of_mem_filter p h
+lemma lt_of_mem_primesBelow (h : p ∈ n.primesBelow) : p < n := (mem_primesBelow.mp h).1
 
 lemma le_of_mem_primesLE (hp : p ∈ primesLE n) : p ≤ n := (mem_primesLE.mp hp).1
 
 lemma one_lt_of_mem_primesBelow (hp : p ∈ primesBelow n) : 1 < p :=
   (prime_of_mem_primesBelow hp).one_lt
 
-lemma one_lt_of_mem_primesLE (hp : p ∈ primesLE n) : 1 < p :=
-  one_lt_of_mem_primesBelow hp
+lemma one_lt_of_mem_primesLE (hp : p ∈ primesLE n) : 1 < p := one_lt_of_mem_primesBelow hp
 
-lemma two_le_of_mem_primesBelow (hp : p ∈ primesBelow n) : 2 ≤ p :=
-  (prime_of_mem_primesBelow hp).two_le
+lemma two_le_of_mem_primesBelow (hp : p ∈ primesBelow n) : 2 ≤ p := one_lt_of_mem_primesBelow hp
 
-lemma two_le_of_mem_primesLE (hp : p ∈ primesLE n) : 2 ≤ p :=
-  two_le_of_mem_primesBelow hp
+lemma two_le_of_mem_primesLE (hp : p ∈ primesLE n) : 2 ≤ p := two_le_of_mem_primesBelow hp
 
-lemma primesBelow_eq_filter_Ico_zero (n : ℕ) : primesBelow n = filter Nat.Prime (Ico 0 n) := by
-  ext p
+lemma primesBelow_eq_filter_Ico_zero (n : ℕ) : primesBelow n = filter Prime (Ico 0 n) := by
   simp [primesBelow_eq_filter_range]
 
-lemma primesLE_eq_filter_Icc_zero (n : ℕ) : primesLE n = filter Nat.Prime (Icc 0 n) := by
-  ext p
-  simp [primesLE_eq_filter_range]
+lemma primesLE_eq_filter_Icc_zero (n : ℕ) : primesLE n = filter Prime (Icc 0 n) := by
+  ext; simp [primesLE_eq_filter_range]
 
-lemma primesBelow_eq_filter_Ioo_zero (n : ℕ) : primesBelow n = filter Nat.Prime (Ioo 0 n) := by
-  ext p
-  simp +contextual [primesBelow_eq_filter_range, Nat.Prime.pos]
+lemma primesBelow_eq_filter_Ioo_zero (n : ℕ) : primesBelow n = filter Prime (Ioo 0 n) := by
+  ext; simp +contextual [primesBelow_eq_filter_range, Prime.pos]
 
-lemma primesLE_eq_filter_Ioc_zero (n : ℕ) : primesLE n = filter Nat.Prime (Ioc 0 n) := by
-  ext p
-  simp +contextual [primesLE_eq_filter_range, Nat.Prime.pos]
+lemma primesLE_eq_filter_Ioc_zero (n : ℕ) : primesLE n = filter Prime (Ioc 0 n) := by
+  ext; simp +contextual [primesLE_eq_filter_range, Prime.pos]
 
-lemma primesBelow_eq_filter_Ico_one (n : ℕ) : primesBelow n = filter Nat.Prime (Ico 1 n) := by
-  ext p
-  simp +contextual [primesBelow_eq_filter_range, Nat.Prime.one_le]
+lemma primesBelow_eq_filter_Ico_one (n : ℕ) : primesBelow n = filter Prime (Ico 1 n) :=
+  primesBelow_eq_filter_Ioo_zero n
 
-lemma primesLE_eq_filter_Icc_one (n : ℕ) : primesLE n = filter Nat.Prime (Icc 1 n) := by
-  ext p
-  simp +contextual [primesLE_eq_filter_range, Nat.Prime.one_le]
+lemma primesLE_eq_filter_Icc_one (n : ℕ) : primesLE n = filter Prime (Icc 1 n) :=
+  primesLE_eq_filter_Ioc_zero n
 
-lemma primesBelow_eq_filter_Ioo_one (n : ℕ) : primesBelow n = filter Nat.Prime (Ioo 1 n) := by
-  ext p
-  simp +contextual [primesBelow_eq_filter_range, Nat.Prime.one_lt]
+lemma primesBelow_eq_filter_Ioo_one (n : ℕ) : primesBelow n = filter Prime (Ioo 1 n) := by
+  ext; simp +contextual [primesBelow_eq_filter_range, Prime.one_lt]
 
-lemma primesLE_eq_filter_Ioc_one (n : ℕ) : primesLE n = filter Nat.Prime (Ioc 1 n) := by
-  ext p
-  simp +contextual [primesLE_eq_filter_range, Nat.Prime.one_lt]
+lemma primesLE_eq_filter_Ioc_one (n : ℕ) : primesLE n = filter Prime (Ioc 1 n) := by
+  ext; simp +contextual [primesLE_eq_filter_range, Prime.one_lt]
 
-lemma primesBelow_eq_filter_Ico_two (n : ℕ) : primesBelow n = filter Nat.Prime (Ico 2 n) := by
-  ext p
-  simp +contextual [primesBelow_eq_filter_range, Nat.Prime.two_le]
+lemma primesBelow_eq_filter_Ico_two (n : ℕ) : primesBelow n = filter Prime (Ico 2 n) :=
+  primesBelow_eq_filter_Ioo_one n
 
-lemma primesLE_eq_filter_Icc_two (n : ℕ) : primesLE n = filter Nat.Prime (Icc 2 n) := by
-  ext p
-  simp +contextual [primesLE_eq_filter_range, Nat.Prime.two_le]
+lemma primesLE_eq_filter_Icc_two (n : ℕ) : primesLE n = filter Prime (Icc 2 n) :=
+  primesLE_eq_filter_Ioc_one n
 
-lemma primesBelow_mono : Monotone primesBelow := by
-  intros n m _ p
-  simp [mem_primesBelow]; grind
+lemma primesBelow_mono : Monotone primesBelow := by intro _ _ _ _; grind [mem_primesBelow]
 
-lemma primesLE_mono : Monotone primesLE := by
-  intros n m _ p
-  simp [mem_primesLE]; grind
+lemma primesLE_mono : Monotone primesLE := by intros _ _ _ _; grind [mem_primesLE]
 
 lemma primesBelow_succ (n : ℕ) :
     primesBelow (n + 1) = if n.Prime then insert n (primesBelow n) else primesBelow n := by
-  rw [primesBelow, primesBelow, Finset.range_add_one, Finset.filter_insert]
+  rw [primesBelow, primesBelow, range_add_one, filter_insert]
 
 lemma primesLE_succ (n : ℕ) :
     primesLE (n + 1) = if (n + 1).Prime then insert (n + 1) (primesLE n) else primesLE n :=
@@ -244,16 +213,14 @@ lemma primesLE_succ (n : ℕ) :
 lemma notMem_primesBelow (n : ℕ) : n ∉ primesBelow n :=
   fun hn ↦ (lt_of_mem_primesBelow hn).false
 
-lemma notMem_primesLE (n : ℕ) : n + 1 ∉ primesLE n :=
-  notMem_primesBelow (n + 1)
+lemma notMem_primesLE (n : ℕ) : n + 1 ∉ primesLE n := notMem_primesBelow (n + 1)
 
 end PrimeSets
 
 /-- The cardinality of the finset `primesBelow n` equals the counting function
 `primeCounting'` at `n`. -/
 theorem primesBelow_card_eq_primeCounting' (n : ℕ) : #n.primesBelow = π' n := by
-  simp only [primesBelow, primeCounting']
-  exact (count_eq_card_filter_range Prime n).symm
+  simpa [primesBelow, primeCounting'] using (count_eq_card_filter_range Prime n).symm
 
 /-- The cardinality of the finset `primesLE n` equals the counting function
 `primeCounting` at `n`. -/
@@ -263,7 +230,7 @@ theorem primesLE_card_eq_primeCounting (n : ℕ) : #(primesLE n) = π n := by
 
 /-- A linear upper bound on the size of the `primeCounting'` function -/
 theorem primeCounting'_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a < k) (n : ℕ) :
-    π' (k + n) ≤ π' k + Nat.totient a * (n / a + 1) :=
+    π' (k + n) ≤ π' k + totient a * (n / a + 1) :=
   calc
     π' (k + n) ≤ #{p ∈ range k | p.Prime} + #{p ∈ Ico k (k + n) | p.Prime} := by
       rw [primeCounting', count_eq_card_filter_range, range_eq_Ico, range_eq_Ico, ←
@@ -276,8 +243,7 @@ theorem primeCounting'_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a < k) (n : ℕ) 
       rw [coprime_comm]
       exact coprime_of_lt_prime h0 <| h1.trans_le (mem_Ico.1 hp).1
     _ ≤ π' k + totient a * (n / a + 1) := by
-      rw [add_le_add_iff_left]
-      exact Ico_filter_coprime_le k n h0
+      simpa using Ico_filter_coprime_le k n h0
 
 theorem primeCounting_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a ≤ k) (n : ℕ) :
     π (k + n) ≤ π k + totient a * (n / a + 1) := by

--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -44,6 +44,8 @@ namespace Nat
 
 open Finset Filter Order Function
 
+variable {a p k n : ℕ}
+
 /-- A variant of the traditional prime counting function which gives the number of primes
 *strictly* less than the input. More convenient for avoiding off-by-one errors.
 
@@ -98,11 +100,11 @@ theorem prime_nth_prime (n : ℕ) : Prime (nth Prime n) :=
   nth_mem_of_infinite infinite_setOf_prime _
 
 @[simp]
-lemma primeCounting'_eq_zero_iff {n : ℕ} : π' n = 0 ↔ n ≤ 2 := by
+lemma primeCounting'_eq_zero_iff : π' n = 0 ↔ n ≤ 2 := by
   rw [primeCounting', Nat.count_eq_zero ⟨_, prime_two⟩, nth_prime_zero_eq_two]
 
 @[simp]
-lemma primeCounting_eq_zero_iff {n : ℕ} : π n = 0 ↔ n ≤ 1 := by
+lemma primeCounting_eq_zero_iff : π n = 0 ↔ n ≤ 1 := by
   simp [primeCounting, -Order.add_one_le_iff]
 
 @[simp]
@@ -112,8 +114,6 @@ lemma primeCounting_zero : π 0 = 0 := primeCounting_eq_zero_iff.mpr zero_le_one
 lemma primeCounting_one : π 1 = 0 := primeCounting_eq_zero_iff.mpr le_rfl
 
 section PrimeSets
-
-variable {p k n : ℕ}
 
 /-- `n.primesBelow` is the set of primes less than `n` as a `Finset`. -/
 def primesBelow (n : ℕ) : Finset ℕ := {p ∈ range n | p.Prime}
@@ -143,7 +143,7 @@ lemma primesLE_one : primesLE 1 = ∅ := primesBelow_two
 theorem primesBelow_eq_primesLE_sub_one (n : ℕ) : n.primesBelow = primesLE (n - 1) := by
   cases n <;> simp [primesLE]
 
-lemma mem_primesBelow : n ∈ primesBelow k ↔ n < k ∧ n.Prime := by simp [primesBelow]
+lemma mem_primesBelow : p ∈ primesBelow n ↔ p < n ∧ p.Prime := by simp [primesBelow]
 
 lemma mem_primesLE : p ∈ n.primesLE ↔ p ≤ n ∧ p.Prime := by simp [primesLE, mem_primesBelow]
 
@@ -164,52 +164,52 @@ lemma two_le_of_mem_primesBelow (hp : p ∈ n.primesBelow) : 2 ≤ p := one_lt_o
 
 lemma two_le_of_mem_primesLE (hp : p ∈ n.primesLE) : 2 ≤ p := two_le_of_mem_primesBelow hp
 
-lemma primesBelow_eq_filter_Ico_zero (n : ℕ) : n.primesBelow = filter Prime (Ico 0 n) := by
-  simp [primesBelow_eq_filter_range]
+variable (n : ℕ)
 
-lemma primesLE_eq_filter_Icc_zero (n : ℕ) : n.primesLE = filter Prime (Icc 0 n) :=
+lemma primesBelow_eq_filter_Ico_zero : n.primesBelow = filter Prime (Ico 0 n) := by
+  simp [primesBelow]
+
+lemma primesLE_eq_filter_Icc_zero : n.primesLE = filter Prime (Icc 0 n) :=
   primesBelow_eq_filter_Ico_zero _
 
-lemma primesBelow_eq_filter_Ioo_zero (n : ℕ) : n.primesBelow = filter Prime (Ioo 0 n) := by
+lemma primesBelow_eq_filter_Ioo_zero : n.primesBelow = filter Prime (Ioo 0 n) := by
   ext; simp +contextual [primesBelow_eq_filter_range, Prime.pos]
 
-lemma primesLE_eq_filter_Ioc_zero (n : ℕ) : n.primesLE = filter Prime (Ioc 0 n) :=
+lemma primesLE_eq_filter_Ioc_zero : n.primesLE = filter Prime (Ioc 0 n) :=
   primesBelow_eq_filter_Ioo_zero _
 
-lemma primesBelow_eq_filter_Ico_one (n : ℕ) : n.primesBelow = filter Prime (Ico 1 n) :=
+lemma primesBelow_eq_filter_Ico_one : n.primesBelow = filter Prime (Ico 1 n) :=
   primesBelow_eq_filter_Ioo_zero n
 
-lemma primesLE_eq_filter_Icc_one (n : ℕ) : n.primesLE = filter Prime (Icc 1 n) :=
+lemma primesLE_eq_filter_Icc_one : n.primesLE = filter Prime (Icc 1 n) :=
   primesLE_eq_filter_Ioc_zero n
 
-lemma primesBelow_eq_filter_Ioo_one (n : ℕ) : n.primesBelow = filter Prime (Ioo 1 n) := by
-  ext; simp +contextual [primesBelow_eq_filter_range, Prime.one_lt]
+lemma primesBelow_eq_filter_Ioo_one : n.primesBelow = filter Prime (Ioo 1 n) := by
+  ext; simp +contextual [primesBelow, Prime.one_lt]
 
-lemma primesLE_eq_filter_Ioc_one (n : ℕ) : n.primesLE = filter Prime (Ioc 1 n) :=
+lemma primesLE_eq_filter_Ioc_one : n.primesLE = filter Prime (Ioc 1 n) :=
   primesBelow_eq_filter_Ioo_one _
 
-lemma primesBelow_eq_filter_Ico_two (n : ℕ) : n.primesBelow = filter Prime (Ico 2 n) :=
+lemma primesBelow_eq_filter_Ico_two : n.primesBelow = filter Prime (Ico 2 n) :=
   primesBelow_eq_filter_Ioo_one n
 
-lemma primesLE_eq_filter_Icc_two (n : ℕ) : n.primesLE = filter Prime (Icc 2 n) :=
+lemma primesLE_eq_filter_Icc_two : n.primesLE = filter Prime (Icc 2 n) :=
   primesLE_eq_filter_Ioc_one n
 
 lemma primesBelow_mono : Monotone primesBelow := by intro _ _ _ _; grind [mem_primesBelow]
 
 lemma primesLE_mono : Monotone primesLE := by intro _ _ _ _; grind [mem_primesLE]
 
-lemma primesBelow_succ (n : ℕ) :
-    (n + 1).primesBelow = if n.Prime then insert n n.primesBelow else n.primesBelow := by
+lemma primesBelow_succ : (n + 1).primesBelow =
+    if n.Prime then insert n n.primesBelow else n.primesBelow := by
   simp [primesBelow, range_add_one, filter_insert]
 
-lemma primesLE_succ (n : ℕ) :
-    (n + 1).primesLE = if (n + 1).Prime then insert (n + 1) n.primesLE else n.primesLE :=
-  primesBelow_succ _
+lemma primesLE_succ : (n + 1).primesLE =
+    if (n + 1).Prime then insert (n + 1) n.primesLE else n.primesLE := primesBelow_succ _
 
-lemma notMem_primesBelow (n : ℕ) : n ∉ n.primesBelow :=
-  fun hn ↦ (lt_of_mem_primesBelow hn).false
+lemma notMem_primesBelow : n ∉ n.primesBelow := fun hn ↦ (lt_of_mem_primesBelow hn).false
 
-lemma notMem_primesLE (n : ℕ) : n + 1 ∉ n.primesLE := notMem_primesBelow _
+lemma notMem_primesLE : n + 1 ∉ n.primesLE := notMem_primesBelow _
 
 end PrimeSets
 
@@ -225,7 +225,7 @@ theorem primesLE_card_eq_primeCounting (n : ℕ) : #n.primesLE = π n :=
   primesBelow_card_eq_primeCounting' _
 
 /-- A linear upper bound on the size of the `primeCounting'` function -/
-theorem primeCounting'_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a < k) (n : ℕ) :
+theorem primeCounting'_add_le (h0 : a ≠ 0) (h1 : a < k) (n : ℕ) :
     π' (k + n) ≤ π' k + a.totient * (n / a + 1) :=
   calc
     _ ≤ #{p ∈ range k | p.Prime} + #{p ∈ Ico k (k + n) | p.Prime} := by
@@ -239,7 +239,7 @@ theorem primeCounting'_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a < k) (n : ℕ) 
       exact coprime_of_lt_prime h0 <| h1.trans_le (mem_Ico.1 hp).1
     _ ≤ _ := by simpa using Ico_filter_coprime_le k n h0
 
-theorem primeCounting_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a ≤ k) (n : ℕ) :
+theorem primeCounting_add_le (h0 : a ≠ 0) (h1 : a ≤ k) (n : ℕ) :
     π (k + n) ≤ π k + a.totient * (n / a + 1) := by
   rw [primeCounting_eq_primeCounting'_succ, add_right_comm]
   exact primeCounting'_add_le h0 (lt_add_one_iff.mpr h1) n

--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -42,7 +42,7 @@ function (and `π'` to represent the reindexed version).
 
 namespace Nat
 
-open Finset
+open Finset Filter Order Function
 
 /-- A variant of the traditional prime counting function which gives the number of primes
 *strictly* less than the input. More convenient for avoiding off-by-one errors.
@@ -66,9 +66,9 @@ theorem primeCounting_eq_primeCounting'_succ (n : ℕ) : π n = π' (n + 1) := r
 @[simp]
 theorem primeCounting_sub_one (n : ℕ) : π (n - 1) = π' n := by cases n <;> rfl
 
-theorem monotone_primeCounting' : Monotone primeCounting' := count_monotone Prime
+theorem monotone_primeCounting' : Monotone π' := count_monotone Prime
 
-theorem monotone_primeCounting : Monotone primeCounting :=
+theorem monotone_primeCounting : Monotone π :=
   monotone_primeCounting'.comp (monotone_id.add_const _)
 
 @[simp]
@@ -79,14 +79,12 @@ theorem primeCounting'_nth_eq (n : ℕ) : π' (nth Prime n) = n :=
 theorem add_two_le_nth_prime (n : ℕ) : n + 2 ≤ nth Prime n :=
   nth_prime_zero_eq_two ▸ (nth_strictMono infinite_setOf_prime).add_le_nat n 0
 
-theorem surjective_primeCounting' : Function.Surjective π' :=
+theorem surjective_primeCounting' : Surjective π' :=
   surjective_count_of_infinite_setOf infinite_setOf_prime
 
-theorem surjective_primeCounting : Function.Surjective π := by
-  suffices Function.Surjective (π ∘ fun n ↦ n - 1) from this.of_comp
-  simpa [Function.comp_def] using surjective_primeCounting'
-
-open Filter
+theorem surjective_primeCounting : Surjective π := by
+  suffices Surjective (π ∘ (· - 1)) from this.of_comp
+  simpa [comp_def] using surjective_primeCounting'
 
 theorem tendsto_primeCounting' : Tendsto π' atTop atTop := by
   apply tendsto_atTop_atTop_of_monotone' monotone_primeCounting'
@@ -100,18 +98,18 @@ theorem prime_nth_prime (n : ℕ) : Prime (nth Prime n) :=
   nth_mem_of_infinite infinite_setOf_prime _
 
 @[simp]
-lemma primeCounting'_eq_zero_iff {n : ℕ} : n.primeCounting' = 0 ↔ n ≤ 2 := by
+lemma primeCounting'_eq_zero_iff {n : ℕ} : π' n = 0 ↔ n ≤ 2 := by
   rw [primeCounting', Nat.count_eq_zero ⟨_, prime_two⟩, nth_prime_zero_eq_two]
 
 @[simp]
-lemma primeCounting_eq_zero_iff {n : ℕ} : n.primeCounting = 0 ↔ n ≤ 1 := by
+lemma primeCounting_eq_zero_iff {n : ℕ} : π n = 0 ↔ n ≤ 1 := by
   simp [primeCounting, -Order.add_one_le_iff]
 
 @[simp]
-lemma primeCounting_zero : primeCounting 0 = 0 := primeCounting_eq_zero_iff.mpr zero_le_one
+lemma primeCounting_zero : π 0 = 0 := primeCounting_eq_zero_iff.mpr zero_le_one
 
 @[simp]
-lemma primeCounting_one : primeCounting 1 = 0 := primeCounting_eq_zero_iff.mpr le_rfl
+lemma primeCounting_one : π 1 = 0 := primeCounting_eq_zero_iff.mpr le_rfl
 
 section PrimeSets
 
@@ -202,7 +200,7 @@ lemma primesLE_mono : Monotone primesLE := by intro _ _ _ _; grind [mem_primesLE
 
 lemma primesBelow_succ (n : ℕ) :
     (n + 1).primesBelow = if n.Prime then insert n n.primesBelow else n.primesBelow := by
-  rw [primesBelow, primesBelow, range_add_one, filter_insert]
+  simp [primesBelow, range_add_one, filter_insert]
 
 lemma primesLE_succ (n : ℕ) :
     (n + 1).primesLE = if (n + 1).Prime then insert (n + 1) n.primesLE else n.primesLE :=
@@ -223,29 +221,27 @@ theorem primesBelow_card_eq_primeCounting' (n : ℕ) : #n.primesBelow = π' n :=
 /-- The cardinality of the finset `n.primesLE` equals the counting function
 `primeCounting` at `n`. -/
 @[simp]
-theorem primesLE_card_eq_primeCounting (n : ℕ) : #n.primesLE = π n := by
-  simp only [primesLE, primeCounting, primesBelow_card_eq_primeCounting']
+theorem primesLE_card_eq_primeCounting (n : ℕ) : #n.primesLE = π n :=
+  primesBelow_card_eq_primeCounting' _
 
 /-- A linear upper bound on the size of the `primeCounting'` function -/
 theorem primeCounting'_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a < k) (n : ℕ) :
-    π' (k + n) ≤ π' k + totient a * (n / a + 1) :=
+    π' (k + n) ≤ π' k + a.totient * (n / a + 1) :=
   calc
-    π' (k + n) ≤ #{p ∈ range k | p.Prime} + #{p ∈ Ico k (k + n) | p.Prime} := by
-      rw [primeCounting', count_eq_card_filter_range, range_eq_Ico, range_eq_Ico, ←
-        Ico_union_Ico_eq_Ico (zero_le k) le_self_add, filter_union]
+    _ ≤ #{p ∈ range k | p.Prime} + #{p ∈ Ico k (k + n) | p.Prime} := by
+      simp_rw [primeCounting', count_eq_card_filter_range, range_eq_Ico,
+      ← Ico_union_Ico_eq_Ico (zero_le k) le_self_add, filter_union]
       apply card_union_le
-    _ ≤ π' k + #{p ∈ Ico k (k + n) | p.Prime} := by
-      rw [primeCounting', count_eq_card_filter_range]
+    _ ≤ π' k + #{p ∈ Ico k (k + n) | p.Prime} := by rw [primeCounting', count_eq_card_filter_range]
     _ ≤ π' k + #{b ∈ Ico k (k + n) | a.Coprime b} := by
       gcongr with p hp
       rw [coprime_comm]
       exact coprime_of_lt_prime h0 <| h1.trans_le (mem_Ico.1 hp).1
-    _ ≤ π' k + totient a * (n / a + 1) := by
-      simpa using Ico_filter_coprime_le k n h0
+    _ ≤ _ := by simpa using Ico_filter_coprime_le k n h0
 
 theorem primeCounting_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a ≤ k) (n : ℕ) :
-    π (k + n) ≤ π k + totient a * (n / a + 1) := by
+    π (k + n) ≤ π k + a.totient * (n / a + 1) := by
   rw [primeCounting_eq_primeCounting'_succ, add_right_comm]
-  exact primeCounting'_add_le h0 (Order.lt_add_one_iff.mpr h1) n
+  exact primeCounting'_add_le h0 (lt_add_one_iff.mpr h1) n
 
 end Nat

--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -84,9 +84,7 @@ theorem surjective_primeCounting' : Function.Surjective π' :=
 
 theorem surjective_primeCounting : Function.Surjective π := by
   suffices Function.Surjective (π ∘ fun n ↦ n - 1) from this.of_comp
-  convert! surjective_primeCounting'
-  ext
-  exact primeCounting_sub_one _
+  simpa [Function.comp_def] using surjective_primeCounting'
 
 open Filter
 
@@ -200,7 +198,7 @@ lemma primesLE_eq_filter_Icc_two (n : ℕ) : primesLE n = filter Prime (Icc 2 n)
 
 lemma primesBelow_mono : Monotone primesBelow := by intro _ _ _ _; grind [mem_primesBelow]
 
-lemma primesLE_mono : Monotone primesLE := by intros _ _ _ _; grind [mem_primesLE]
+lemma primesLE_mono : Monotone primesLE := by intro _ _ _ _; grind [mem_primesLE]
 
 lemma primesBelow_succ (n : ℕ) :
     primesBelow (n + 1) = if n.Prime then insert n (primesBelow n) else primesBelow n := by
@@ -208,12 +206,12 @@ lemma primesBelow_succ (n : ℕ) :
 
 lemma primesLE_succ (n : ℕ) :
     primesLE (n + 1) = if (n + 1).Prime then insert (n + 1) (primesLE n) else primesLE n :=
-  primesBelow_succ (n + 1)
+  primesBelow_succ _
 
 lemma notMem_primesBelow (n : ℕ) : n ∉ primesBelow n :=
   fun hn ↦ (lt_of_mem_primesBelow hn).false
 
-lemma notMem_primesLE (n : ℕ) : n + 1 ∉ primesLE n := notMem_primesBelow (n + 1)
+lemma notMem_primesLE (n : ℕ) : n + 1 ∉ primesLE n := notMem_primesBelow _
 
 end PrimeSets
 
@@ -247,8 +245,7 @@ theorem primeCounting'_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a < k) (n : ℕ) 
 
 theorem primeCounting_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a ≤ k) (n : ℕ) :
     π (k + n) ≤ π k + totient a * (n / a + 1) := by
-  rw [primeCounting_eq_primeCounting'_succ]
-  convert! primeCounting'_add_le h0 (Order.lt_add_one_iff.mpr h1) n using 2
-  omega
+  rw [primeCounting_eq_primeCounting'_succ, add_right_comm]
+  exact primeCounting'_add_le h0 (Order.lt_add_one_iff.mpr h1) n
 
 end Nat

--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -160,7 +160,8 @@ lemma one_lt_of_mem_primesBelow (hp : p ∈ n.primesBelow) : 1 < p :=
 
 lemma one_lt_of_mem_primesLE (hp : p ∈ n.primesLE) : 1 < p := one_lt_of_mem_primesBelow hp
 
-lemma two_le_of_mem_primesBelow (hp : p ∈ n.primesBelow) : 2 ≤ p := one_lt_of_mem_primesBelow hp
+lemma two_le_of_mem_primesBelow (hp : p ∈ n.primesBelow) : 2 ≤ p :=
+  (prime_of_mem_primesBelow hp).two_le
 
 lemma two_le_of_mem_primesLE (hp : p ∈ n.primesLE) : 2 ≤ p := two_le_of_mem_primesBelow hp
 
@@ -196,9 +197,9 @@ lemma primesBelow_eq_filter_Ico_two : n.primesBelow = filter Prime (Ico 2 n) :=
 lemma primesLE_eq_filter_Icc_two : n.primesLE = filter Prime (Icc 2 n) :=
   primesLE_eq_filter_Ioc_one n
 
-lemma primesBelow_mono : Monotone primesBelow := by intro _ _ _ _; grind [mem_primesBelow]
+lemma primesBelow_mono : Monotone primesBelow := fun _ _ _ _ ↦ by grind [mem_primesBelow]
 
-lemma primesLE_mono : Monotone primesLE := by intro _ _ _ _; grind [mem_primesLE]
+lemma primesLE_mono : Monotone primesLE := fun _ _ _ _ ↦ by grind [mem_primesLE]
 
 lemma primesBelow_succ : (n + 1).primesBelow =
     if n.Prime then insert n n.primesBelow else n.primesBelow := by


### PR DESCRIPTION
Inspired by [this comment](https://github.com/leanprover-community/mathlib4/pull/40654#issuecomment-4753093121) to #40654, I have done a golfing pass on` PrimeCounting.lean`, shortening some proofs to a single term and saving about 30 lines of code (largely through whitespace reduction).  *However*, some of these golfs rely on defeq abuse, for instance using the fact that `Ioo 0 n` and `Ico 1 n` are definitionally equivalent.  I would appreciate some feedback as to whether such abuse is tolerated on Mathlib.  I'm happy to drop this PR if this is not the case.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
