### PR TITLE
[Merged by Bors] - perf(RingTheory/Kaehler/JacobiZariski): remove useless instances

### DIFF
--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -130,11 +130,7 @@ def CotangentSpace.compEquiv :
   (Q.comp P).cotangentSpaceBasis.repr.trans
     (Q.cotangentSpaceBasis.prod (P.cotangentSpaceBasis.baseChange T)).repr.symm
 
-section instanceProblem
-
--- Note: these instances are needed to prevent instance search timeouts.
-attribute [local instance 999999] Zero.toOfNat0 SemilinearMapClass.distribMulActionSemiHomClass
-  SemilinearEquivClass.instSemilinearMapClass instAddZeroClassTensorProduct AddZero.toZero
+-- section instanceProblem
 
 lemma CotangentSpace.compEquiv_symm_inr :
     (compEquiv Q P).symm.toLinearMap ∘ₗ
@@ -447,8 +443,6 @@ lemma exact_map_δ' (f : Hom W Q) :
   exact exact_map_δ Q P
 
 end H1Cotangent
-
-end instanceProblem
 
 end Generators
 

--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -326,7 +326,7 @@ def δ :
   SnakeLemma.δ'
     (P.toExtension.cotangentComplex.baseChange T)
     (Q.comp P).toExtension.cotangentComplex
-    Q.toExtension.cotangentC  omplex
+    Q.toExtension.cotangentComplex
     ((Extension.Cotangent.map (toComp Q P).toExtensionHom).liftBaseChange T)
     (Extension.Cotangent.map (ofComp Q P).toExtensionHom)
     (Cotangent.exact Q P)

--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -130,8 +130,6 @@ def CotangentSpace.compEquiv :
   (Q.comp P).cotangentSpaceBasis.repr.trans
     (Q.cotangentSpaceBasis.prod (P.cotangentSpaceBasis.baseChange T)).repr.symm
 
--- section instanceProblem
-
 lemma CotangentSpace.compEquiv_symm_inr :
     (compEquiv Q P).symm.toLinearMap ∘ₗ
       LinearMap.inr T Q.toExtension.CotangentSpace (T ⊗[S] P.toExtension.CotangentSpace) =
@@ -328,7 +326,7 @@ def δ :
   SnakeLemma.δ'
     (P.toExtension.cotangentComplex.baseChange T)
     (Q.comp P).toExtension.cotangentComplex
-    Q.toExtension.cotangentComplex
+    Q.toExtension.cotangentC  omplex
     ((Extension.Cotangent.map (toComp Q P).toExtensionHom).liftBaseChange T)
     (Extension.Cotangent.map (ofComp Q P).toExtensionHom)
     (Cotangent.exact Q P)


### PR DESCRIPTION
This PR removes some instances that were previously needed to avoid some timeouts.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
