### PR TITLE
feat(Data/Nat/Prime): add not_prime_four and not_prime_six

### DIFF
--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -166,7 +166,11 @@ theorem prime_two : Prime 2 := by decide
 
 theorem prime_three : Prime 3 := by decide
 
+theorem not_prime_four : ¬ Prime 4 := by decide
+
 theorem prime_five : Prime 5 := by decide
+
+theorem not_prime_six : ¬ Prime 6 := by decide
 
 theorem prime_seven : Prime 7 := by decide
 


### PR DESCRIPTION
Mathlib already contains the lemmas `Nat.not_prime_zero`,  `Nat.not_prime_one`, `Nat.prime_two`, `Nat.prime_three`, `Nat.prime_five`, `Nat.prime_seven`, and `Nat.prime.eleven` in `Data.Nat.Prime.Defs`.  (See also a more general `not_prime_zero` and `not_prime_one` in `Algebra.Prime.Defs`.)

 This PR fills in some holes by adding `Nat.not_prime_four` and `Nat.not_prime_six`.  This permits for instance the ability to compute sums over primes up to `n` via `simp` type tactics for `n` as large as seven.  One could of course continue filling in more holes but this should suffice for most applications, and it is obvious how to continue the pattern if needed.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
