### PR TITLE
[Merged by Bors] - feat(Topology/SmallInductiveDimension): fix small style issues

### DIFF
--- a/Mathlib/Topology/SmallInductiveDimension.lean
+++ b/Mathlib/Topology/SmallInductiveDimension.lean
@@ -55,6 +55,7 @@ variable (X) in
 abbrev HasSmallInductiveDimensionLE (n : ℕ) :=
   HasSmallInductiveDimensionLT X (n + 1)
 
+variable (X) in
 /-- The small inductive dimension of a topological space. -/
 noncomputable def smallInductiveDimension : WithBot ℕ∞ :=
   sInf {n : WithBot ℕ∞ | ∀ (i : ℕ), n < i → HasSmallInductiveDimensionLT X i}

--- a/Mathlib/Topology/SmallInductiveDimension.lean
+++ b/Mathlib/Topology/SmallInductiveDimension.lean
@@ -78,29 +78,4 @@ lemma hasSmallInductiveDimensionLT_one_iff :
 @[deprecated (since := "2026-06-21")]
 alias HasSmallInductiveDimensionLT_one_iff := hasSmallInductiveDimensionLT_one_iff
 
-theorem HasSmallInductiveDimensionLT.mono {m n : ℕ} (hmn : m ≤ n)
-    (H : HasSmallInductiveDimensionLT X m) : HasSmallInductiveDimensionLT X n := by
-  induction n generalizing m X with
-  | zero => simp_all
-  | succ m IH =>
-    cases H with
-    | zero => exact .succ _ ∅ (by simpa) (by simp)
-    | succ n s hs h =>
-      refine .succ _ s hs fun U hU ↦ IH ?_ (h U hU)
-      rwa [add_le_add_iff_right] at hmn
-
-theorem HasSmallInductiveDimensionLE.mono {m n : ℕ} (hmn : m ≤ n)
-    (H : HasSmallInductiveDimensionLE X m) : HasSmallInductiveDimensionLE X n := by
-  apply HasSmallInductiveDimensionLT.mono _ H
-  rwa [add_le_add_iff_right]
-
-instance hasSmallInductiveDimensionLT_one_of_discreteTopology [DiscreteTopology X] :
-    HasSmallInductiveDimensionLT X 1 := by
-  rw [hasSmallInductiveDimensionLT_one_iff]
-  simpa using isTopologicalBasis_opens (α := X)
-
-instance hasSmallInductiveDimensionLE_zero_of_discreteTopology [DiscreteTopology X] :
-    HasSmallInductiveDimensionLE X 0 :=
-  inferInstanceAs (HasSmallInductiveDimensionLT X 1)
-
 end

--- a/Mathlib/Topology/SmallInductiveDimension.lean
+++ b/Mathlib/Topology/SmallInductiveDimension.lean
@@ -48,8 +48,9 @@ class inductive HasSmallInductiveDimensionLT.{u} :
       (h : ∀ U ∈ s, HasSmallInductiveDimensionLT ↑(frontier U) n) :
       HasSmallInductiveDimensionLT X (n + 1)
 
-variable (X : Type) [TopologicalSpace X]
+variable {X : Type*} [TopologicalSpace X]
 
+variable (X) in
 /-- A topological space has dimension `≤ n` if it has dimension `< n + 1`. -/
 abbrev HasSmallInductiveDimensionLE (n : ℕ) :=
   HasSmallInductiveDimensionLT X (n + 1)
@@ -58,11 +59,13 @@ abbrev HasSmallInductiveDimensionLE (n : ℕ) :=
 noncomputable def smallInductiveDimension : WithBot ℕ∞ :=
   sInf {n : WithBot ℕ∞ | ∀ (i : ℕ), n < i → HasSmallInductiveDimensionLT X i}
 
-lemma HasSmallInductiveDimensionLT_zero_iff :
-    HasSmallInductiveDimensionLT X 0 ↔ IsEmpty X :=
+lemma hasSmallInductiveDimensionLT_zero_iff : HasSmallInductiveDimensionLT X 0 ↔ IsEmpty X :=
   ⟨fun h ↦ by cases h; assumption, fun _ ↦ .zero⟩
 
-lemma HasSmallInductiveDimensionLT_one_iff :
+@[deprecated (since := "2026-06-21")]
+alias HasSmallInductiveDimensionLT_zero_iff := hasSmallInductiveDimensionLT_zero_iff
+
+lemma hasSmallInductiveDimensionLT_one_iff :
     HasSmallInductiveDimensionLT X 1 ↔ IsTopologicalBasis { s : Set X | IsClopen s } := by
   constructor
   · intro (.succ _ s hs h)
@@ -71,5 +74,33 @@ lemma HasSmallInductiveDimensionLT_one_iff :
     cases h U hU
     rwa [isEmpty_coe_sort, (hs.isOpen hU).frontier_eq, sdiff_eq_empty] at ‹_›
   · exact fun h ↦ .succ 0 _ h fun _ hU ↦ hU.frontier_eq ▸ .zero
+
+@[deprecated (since := "2026-06-21")]
+alias HasSmallInductiveDimensionLT_one_iff := hasSmallInductiveDimensionLT_one_iff
+
+theorem HasSmallInductiveDimensionLT.mono {m n : ℕ} (hmn : m ≤ n)
+    (H : HasSmallInductiveDimensionLT X m) : HasSmallInductiveDimensionLT X n := by
+  induction n generalizing m X with
+  | zero => simp_all
+  | succ m IH =>
+    cases H with
+    | zero => exact .succ _ ∅ (by simpa) (by simp)
+    | succ n s hs h =>
+      refine .succ _ s hs fun U hU ↦ IH ?_ (h U hU)
+      rwa [add_le_add_iff_right] at hmn
+
+theorem HasSmallInductiveDimensionLE.mono {m n : ℕ} (hmn : m ≤ n)
+    (H : HasSmallInductiveDimensionLE X m) : HasSmallInductiveDimensionLE X n := by
+  apply HasSmallInductiveDimensionLT.mono _ H
+  rwa [add_le_add_iff_right]
+
+instance hasSmallInductiveDimensionLT_one_of_discreteTopology [DiscreteTopology X] :
+    HasSmallInductiveDimensionLT X 1 := by
+  rw [hasSmallInductiveDimensionLT_one_iff]
+  simpa using isTopologicalBasis_opens (α := X)
+
+instance hasSmallInductiveDimensionLE_zero_of_discreteTopology [DiscreteTopology X] :
+    HasSmallInductiveDimensionLE X 0 :=
+  inferInstanceAs (HasSmallInductiveDimensionLT X 1)
 
 end


### PR DESCRIPTION
We make some arguments implicit, change `Type` to `Type*`, and fix some capitalization.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
