### PR TITLE
[Merged by Bors] - feat(Topology/MetricSpace): fix two non-terminal simps

### DIFF
--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -920,19 +920,15 @@ attribute [scoped instance] PiCountable.dist
 lemma dist_eq_tsum (x y : ∀ i, F i) : dist x y = ∑' i, min (2⁻¹ ^ encode i) (dist (x i) (y i)) :=
   rfl
 
-lemma dist_nonneg (x y : ∀ i, F i) : 0 ≤ dist x y := by
-  rw [dist_eq_tsum]
-  positivity
-
 lemma dist_summable (x y : ∀ i, F i) :
     Summable fun i ↦ min (2⁻¹ ^ encode i) (dist (x i) (y i)) := by
   refine .of_nonneg_of_le (fun i => ?_) (fun i => min_le_left _ _) <| by
     simpa [one_div] using summable_geometric_two_encode
-  exact le_min (by positivity) _root_.dist_nonneg
+  exact le_min (by positivity) dist_nonneg
 
 lemma min_dist_le_dist_pi (x y : ∀ i, F i) (i : ι) :
     min (2⁻¹ ^ encode i) (dist (x i) (y i)) ≤ dist x y :=
-  (dist_summable x y).le_tsum i fun j _ => le_min (by simp) _root_.dist_nonneg
+  (dist_summable x y).le_tsum i fun j _ => le_min (by simp) dist_nonneg
 
 lemma dist_le_dist_pi_of_dist_lt (h : dist x y < 2⁻¹ ^ encode i) : dist (x i) (y i) ≤ dist x y := by
   simpa only [not_le.2 h, false_or] using min_le_iff.1 (min_dist_le_dist_pi x y i)
@@ -943,7 +939,8 @@ It is highly non-canonical, though, and therefore not registered as a global ins
 The distance we use here is `dist x y = ∑' i, min (1/2)^(encode i) (dist (x i) (y i))`. -/
 @[instance_reducible]
 protected def pseudoMetricSpace : PseudoMetricSpace (∀ i, F i) :=
-  PseudoEMetricSpace.toPseudoMetricSpaceOfDist dist dist_nonneg fun x y ↦ by
+  PseudoEMetricSpace.toPseudoMetricSpaceOfDist dist (fun x y ↦ by rw [dist_eq_tsum]; positivity)
+  fun x y ↦ by
     rw [edist_eq_tsum, dist_eq_tsum,
       ENNReal.ofReal_tsum_of_nonneg (fun _ ↦ by positivity) (dist_summable ..)]
     congr! with a

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -920,34 +920,34 @@ attribute [scoped instance] PiCountable.dist
 lemma dist_eq_tsum (x y : ∀ i, F i) : dist x y = ∑' i, min (2⁻¹ ^ encode i) (dist (x i) (y i)) :=
   rfl
 
+lemma dist_nonneg (x y : ∀ i, F i) : 0 ≤ dist x y := by
+  rw [dist_eq_tsum]
+  positivity
+
 lemma dist_summable (x y : ∀ i, F i) :
     Summable fun i ↦ min (2⁻¹ ^ encode i) (dist (x i) (y i)) := by
   refine .of_nonneg_of_le (fun i => ?_) (fun i => min_le_left _ _) <| by
     simpa [one_div] using summable_geometric_two_encode
-  exact le_min (by positivity) dist_nonneg
+  exact le_min (by positivity) _root_.dist_nonneg
 
 lemma min_dist_le_dist_pi (x y : ∀ i, F i) (i : ι) :
     min (2⁻¹ ^ encode i) (dist (x i) (y i)) ≤ dist x y :=
-  (dist_summable x y).le_tsum i fun j _ => le_min (by simp) dist_nonneg
+  (dist_summable x y).le_tsum i fun j _ => le_min (by simp) _root_.dist_nonneg
 
 lemma dist_le_dist_pi_of_dist_lt (h : dist x y < 2⁻¹ ^ encode i) : dist (x i) (y i) ≤ dist x y := by
   simpa only [not_le.2 h, false_or] using min_le_iff.1 (min_dist_le_dist_pi x y i)
 
--- TODO: fix two non-terminal simps below; second one uses a long lemma list
-set_option linter.flexible false in
 /-- Given a countable family of metric spaces, one may put a distance on their product `Π i, E i`.
 
 It is highly non-canonical, though, and therefore not registered as a global instance.
 The distance we use here is `dist x y = ∑' i, min (1/2)^(encode i) (dist (x i) (y i))`. -/
 @[instance_reducible]
 protected def pseudoMetricSpace : PseudoMetricSpace (∀ i, F i) :=
-  PseudoEMetricSpace.toPseudoMetricSpaceOfDist dist
-    (fun x y ↦ by simp [dist_eq_tsum]; positivity) fun x y ↦ by
-      rw [edist_eq_tsum, dist_eq_tsum,
-        ENNReal.ofReal_tsum_of_nonneg (fun _ ↦ by positivity) (dist_summable ..)]
-      simp [edist, ENNReal.inv_pow]
-      congr! with a
-      exact PseudoMetricSpace.edist_dist (x a) (y a)
+  PseudoEMetricSpace.toPseudoMetricSpaceOfDist dist dist_nonneg fun x y ↦ by
+    rw [edist_eq_tsum, dist_eq_tsum,
+      ENNReal.ofReal_tsum_of_nonneg (fun _ ↦ by positivity) (dist_summable ..)]
+    congr! with a
+    simp [edist, ENNReal.inv_pow, PseudoMetricSpace.edist_dist (x a) (y a)]
 
 end PseudoMetricSpace
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
