### PR TITLE
[Merged by Bors] - feat: add Algebra.IsUnramifiedIn

### DIFF
--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
@@ -23,7 +23,7 @@ This file studies the ramification of infinite places of a number field.
   if the restriction has the same multiplicity.
 * `NumberField.InfinitePlace.not_isUnramified_iff`: an infinite place is not unramified
   (i.e., is ramified) iff it is a complex place above a real place.
-* `NumberField.InfinitePlace.IsUnramifiedIn`: an infinite place of the base field is unramified
+* `NumberField.InfinitePlace.IsUnramifiedOver`: an infinite place of the base field is unramified
   in a field extension if every infinite place over it is unramified.
 * `IsUnramifiedAtInfinitePlaces`: a field extension is unramified at infinite places if every
   infinite place is unramified.
@@ -441,27 +441,27 @@ lemma isUnramified_smul_iff :
 variable (K) in
 /-- An infinite place of the base field is unramified in a field extension if every
 infinite place over it is unramified. -/
-def IsUnramifiedIn (w : InfinitePlace k) : Prop :=
+def IsUnramifiedOver (w : InfinitePlace k) : Prop :=
   ∀ v, comap v (algebraMap k K) = w → IsUnramified k v
 
-lemma isUnramifiedIn_comap [IsGalois k K] {w : InfinitePlace K} :
-    (w.comap (algebraMap k K)).IsUnramifiedIn K ↔ w.IsUnramified k := by
+lemma isUnramifiedOver_comap [IsGalois k K] {w : InfinitePlace K} :
+    (w.comap (algebraMap k K)).IsUnramifiedOver K ↔ w.IsUnramified k := by
   refine ⟨fun H ↦ H _ rfl, fun H v hv ↦ ?_⟩
   obtain ⟨σ, rfl⟩ := exists_smul_eq_of_comap_eq hv
   rwa [isUnramified_smul_iff] at H
 
-lemma even_card_aut_of_not_isUnramifiedIn [IsGalois k K]
-    {w : InfinitePlace k} (hw : ¬ w.IsUnramifiedIn K) :
+lemma even_card_aut_of_not_isUnramifiedOver [IsGalois k K]
+    {w : InfinitePlace k} (hw : ¬ w.IsUnramifiedOver K) :
     Even (Nat.card Gal(K/k)) := by
   obtain ⟨v, rfl⟩ := comap_surjective (K := K) w
-  rw [isUnramifiedIn_comap] at hw
+  rw [isUnramifiedOver_comap] at hw
   exact even_card_aut_of_not_isUnramified hw
 
-lemma even_finrank_of_not_isUnramifiedIn
-    [IsGalois k K] {w : InfinitePlace k} (hw : ¬ w.IsUnramifiedIn K) :
+lemma even_finrank_of_not_isUnramifiedOver
+    [IsGalois k K] {w : InfinitePlace k} (hw : ¬ w.IsUnramifiedOver K) :
     Even (finrank k K) := by
   obtain ⟨v, rfl⟩ := comap_surjective (K := K) w
-  rw [isUnramifiedIn_comap] at hw
+  rw [isUnramifiedOver_comap] at hw
   exact even_finrank_of_not_isUnramified hw
 
 variable (k K)
@@ -471,10 +471,10 @@ open Finset in
 open scoped Classical in
 lemma card_isUnramified [NumberField k] [IsGalois k K] :
     #{w : InfinitePlace K | w.IsUnramified k} =
-      #{w : InfinitePlace k | w.IsUnramifiedIn K} * finrank k K := by
+      #{w : InfinitePlace k | w.IsUnramifiedOver K} * finrank k K := by
   rw [← IsGalois.card_aut_eq_finrank,
     Finset.card_eq_sum_card_fiberwise (f := (comap · (algebraMap k K)))
-    (t := {w : InfinitePlace k | w.IsUnramifiedIn K}), ← smul_eq_mul, ← sum_const]
+    (t := {w : InfinitePlace k | w.IsUnramifiedOver K}), ← smul_eq_mul, ← sum_const]
   · refine sum_congr rfl (fun w hw ↦ ?_)
     obtain ⟨w, rfl⟩ := comap_surjective (K := K) w
     rw [mem_filter_univ] at hw
@@ -482,22 +482,22 @@ lemma card_isUnramified [NumberField k] [IsGalois k K] :
     · congr; ext w'
       rw [mem_filter, mem_filter_univ, Set.mem_toFinset, mem_orbit_iff, @eq_comm _ (comap w' _),
         and_iff_right_iff_imp]
-      intro e; rwa [← isUnramifiedIn_comap, ← e]
+      intro e; rwa [← isUnramifiedOver_comap, ← e]
     · rw [Nat.card_eq_fintype_card,
         ← MulAction.card_orbit_mul_card_stabilizer_eq_card_group _ w,
         ← Nat.card_eq_fintype_card (α := Stab w), card_stabilizer, if_pos,
         mul_one, Set.toFinset_card]
-      rwa [← isUnramifiedIn_comap]
-  · simp [Set.MapsTo, isUnramifiedIn_comap]
+      rwa [← isUnramifiedOver_comap]
+  · simp [Set.MapsTo, isUnramifiedOver_comap]
 
 open Finset in
 open scoped Classical in
 lemma card_isUnramified_compl [NumberField k] [IsGalois k K] :
     #({w : InfinitePlace K | w.IsUnramified k} : Finset _)ᶜ =
-      #({w : InfinitePlace k | w.IsUnramifiedIn K} : Finset _)ᶜ * (finrank k K / 2) := by
+      #({w : InfinitePlace k | w.IsUnramifiedOver K} : Finset _)ᶜ * (finrank k K / 2) := by
   rw [← IsGalois.card_aut_eq_finrank,
     Finset.card_eq_sum_card_fiberwise (f := (comap · (algebraMap k K)))
-    (t := ({w : InfinitePlace k | w.IsUnramifiedIn K} : Finset _)ᶜ), ← smul_eq_mul, ← sum_const]
+    (t := ({w : InfinitePlace k | w.IsUnramifiedOver K} : Finset _)ᶜ), ← smul_eq_mul, ← sum_const]
   · refine sum_congr rfl (fun w hw ↦ ?_)
     obtain ⟨w, rfl⟩ := comap_surjective (K := K) w
     rw [compl_filter, mem_filter_univ] at hw
@@ -505,19 +505,19 @@ lemma card_isUnramified_compl [NumberField k] [IsGalois k K] :
     · congr; ext w'
       rw [mem_filter, compl_filter, mem_filter_univ, @eq_comm _ (comap w' _), Set.mem_toFinset,
         mem_orbit_iff, and_iff_right_iff_imp]
-      intro e; rwa [← isUnramifiedIn_comap, ← e]
+      intro e; rwa [← isUnramifiedOver_comap, ← e]
     · rw [Nat.card_eq_fintype_card,
         ← MulAction.card_orbit_mul_card_stabilizer_eq_card_group _ w,
         ← Nat.card_eq_fintype_card (α := Stab w), InfinitePlace.card_stabilizer, if_neg,
         Nat.mul_div_cancel _ zero_lt_two, Set.toFinset_card]
-      rwa [← isUnramifiedIn_comap]
-  · simp [Set.MapsTo, isUnramifiedIn_comap]
+      rwa [← isUnramifiedOver_comap]
+  · simp [Set.MapsTo, isUnramifiedOver_comap]
 
 open scoped Classical in
-lemma card_eq_card_isUnramifiedIn [NumberField k] [IsGalois k K] :
+lemma card_eq_card_isUnramifiedOver [NumberField k] [IsGalois k K] :
     Fintype.card (InfinitePlace K) =
-      #{w : InfinitePlace k | w.IsUnramifiedIn K} * finrank k K +
-      #({w : InfinitePlace k | w.IsUnramifiedIn K} : Finset _)ᶜ * (finrank k K / 2) := by
+      #{w : InfinitePlace k | w.IsUnramifiedOver K} * finrank k K +
+      #({w : InfinitePlace k | w.IsUnramifiedOver K} : Finset _)ᶜ * (finrank k K / 2) := by
   rw [← card_isUnramified, ← card_isUnramified_compl, Finset.card_add_card_compl]
 
 end NumberField.InfinitePlace
@@ -559,8 +559,8 @@ lemma NumberField.InfinitePlace.isUnramified [IsUnramifiedAtInfinitePlaces k K]
 
 variable {k} (K)
 
-lemma NumberField.InfinitePlace.isUnramifiedIn [IsUnramifiedAtInfinitePlaces k K]
-    (w : InfinitePlace k) : IsUnramifiedIn K w := fun v _ ↦ v.isUnramified k
+lemma NumberField.InfinitePlace.isUnramifiedOver [IsUnramifiedAtInfinitePlaces k K]
+    (w : InfinitePlace k) : IsUnramifiedOver K w := fun v _ ↦ v.isUnramified k
 
 variable {K}
 
@@ -579,11 +579,11 @@ lemma IsUnramifiedAtInfinitePlaces.card_infinitePlace [NumberField k] [NumberFie
     [IsGalois k K] [IsUnramifiedAtInfinitePlaces k K] :
     Fintype.card (InfinitePlace K) = Fintype.card (InfinitePlace k) * finrank k K := by
   classical
-  rw [InfinitePlace.card_eq_card_isUnramifiedIn (k := k) (K := K), Finset.filter_true_of_mem,
+  rw [InfinitePlace.card_eq_card_isUnramifiedOver (k := k) (K := K), Finset.filter_true_of_mem,
     Finset.card_univ, Finset.card_eq_zero.mpr, zero_mul, add_zero]
   · exact Finset.compl_univ
   simp only [Finset.mem_univ, forall_true_left]
-  exact InfinitePlace.isUnramifiedIn K
+  exact InfinitePlace.isUnramifiedOver K
 
 namespace NumberField.InfinitePlace
 

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
@@ -23,7 +23,7 @@ This file studies the ramification of infinite places of a number field.
   if the restriction has the same multiplicity.
 * `NumberField.InfinitePlace.not_isUnramified_iff`: an infinite place is not unramified
   (i.e., is ramified) iff it is a complex place above a real place.
-* `NumberField.InfinitePlace.IsUnramifiedOver`: an infinite place of the base field is unramified
+* `NumberField.InfinitePlace.IsUnramifiedIn`: an infinite place of the base field is unramified
   in a field extension if every infinite place over it is unramified.
 * `IsUnramifiedAtInfinitePlaces`: a field extension is unramified at infinite places if every
   infinite place is unramified.
@@ -441,27 +441,27 @@ lemma isUnramified_smul_iff :
 variable (K) in
 /-- An infinite place of the base field is unramified in a field extension if every
 infinite place over it is unramified. -/
-def IsUnramifiedOver (w : InfinitePlace k) : Prop :=
+def IsUnramifiedIn (w : InfinitePlace k) : Prop :=
   ∀ v, comap v (algebraMap k K) = w → IsUnramified k v
 
-lemma isUnramifiedOver_comap [IsGalois k K] {w : InfinitePlace K} :
-    (w.comap (algebraMap k K)).IsUnramifiedOver K ↔ w.IsUnramified k := by
+lemma isUnramifiedIn_comap [IsGalois k K] {w : InfinitePlace K} :
+    (w.comap (algebraMap k K)).IsUnramifiedIn K ↔ w.IsUnramified k := by
   refine ⟨fun H ↦ H _ rfl, fun H v hv ↦ ?_⟩
   obtain ⟨σ, rfl⟩ := exists_smul_eq_of_comap_eq hv
   rwa [isUnramified_smul_iff] at H
 
-lemma even_card_aut_of_not_isUnramifiedOver [IsGalois k K]
-    {w : InfinitePlace k} (hw : ¬ w.IsUnramifiedOver K) :
+lemma even_card_aut_of_not_isUnramifiedIn [IsGalois k K]
+    {w : InfinitePlace k} (hw : ¬ w.IsUnramifiedIn K) :
     Even (Nat.card Gal(K/k)) := by
   obtain ⟨v, rfl⟩ := comap_surjective (K := K) w
-  rw [isUnramifiedOver_comap] at hw
+  rw [isUnramifiedIn_comap] at hw
   exact even_card_aut_of_not_isUnramified hw
 
-lemma even_finrank_of_not_isUnramifiedOver
-    [IsGalois k K] {w : InfinitePlace k} (hw : ¬ w.IsUnramifiedOver K) :
+lemma even_finrank_of_not_isUnramifiedIn
+    [IsGalois k K] {w : InfinitePlace k} (hw : ¬ w.IsUnramifiedIn K) :
     Even (finrank k K) := by
   obtain ⟨v, rfl⟩ := comap_surjective (K := K) w
-  rw [isUnramifiedOver_comap] at hw
+  rw [isUnramifiedIn_comap] at hw
   exact even_finrank_of_not_isUnramified hw
 
 variable (k K)
@@ -471,10 +471,10 @@ open Finset in
 open scoped Classical in
 lemma card_isUnramified [NumberField k] [IsGalois k K] :
     #{w : InfinitePlace K | w.IsUnramified k} =
-      #{w : InfinitePlace k | w.IsUnramifiedOver K} * finrank k K := by
+      #{w : InfinitePlace k | w.IsUnramifiedIn K} * finrank k K := by
   rw [← IsGalois.card_aut_eq_finrank,
     Finset.card_eq_sum_card_fiberwise (f := (comap · (algebraMap k K)))
-    (t := {w : InfinitePlace k | w.IsUnramifiedOver K}), ← smul_eq_mul, ← sum_const]
+    (t := {w : InfinitePlace k | w.IsUnramifiedIn K}), ← smul_eq_mul, ← sum_const]
   · refine sum_congr rfl (fun w hw ↦ ?_)
     obtain ⟨w, rfl⟩ := comap_surjective (K := K) w
     rw [mem_filter_univ] at hw
@@ -482,22 +482,22 @@ lemma card_isUnramified [NumberField k] [IsGalois k K] :
     · congr; ext w'
       rw [mem_filter, mem_filter_univ, Set.mem_toFinset, mem_orbit_iff, @eq_comm _ (comap w' _),
         and_iff_right_iff_imp]
-      intro e; rwa [← isUnramifiedOver_comap, ← e]
+      intro e; rwa [← isUnramifiedIn_comap, ← e]
     · rw [Nat.card_eq_fintype_card,
         ← MulAction.card_orbit_mul_card_stabilizer_eq_card_group _ w,
         ← Nat.card_eq_fintype_card (α := Stab w), card_stabilizer, if_pos,
         mul_one, Set.toFinset_card]
-      rwa [← isUnramifiedOver_comap]
-  · simp [Set.MapsTo, isUnramifiedOver_comap]
+      rwa [← isUnramifiedIn_comap]
+  · simp [Set.MapsTo, isUnramifiedIn_comap]
 
 open Finset in
 open scoped Classical in
 lemma card_isUnramified_compl [NumberField k] [IsGalois k K] :
     #({w : InfinitePlace K | w.IsUnramified k} : Finset _)ᶜ =
-      #({w : InfinitePlace k | w.IsUnramifiedOver K} : Finset _)ᶜ * (finrank k K / 2) := by
+      #({w : InfinitePlace k | w.IsUnramifiedIn K} : Finset _)ᶜ * (finrank k K / 2) := by
   rw [← IsGalois.card_aut_eq_finrank,
     Finset.card_eq_sum_card_fiberwise (f := (comap · (algebraMap k K)))
-    (t := ({w : InfinitePlace k | w.IsUnramifiedOver K} : Finset _)ᶜ), ← smul_eq_mul, ← sum_const]
+    (t := ({w : InfinitePlace k | w.IsUnramifiedIn K} : Finset _)ᶜ), ← smul_eq_mul, ← sum_const]
   · refine sum_congr rfl (fun w hw ↦ ?_)
     obtain ⟨w, rfl⟩ := comap_surjective (K := K) w
     rw [compl_filter, mem_filter_univ] at hw
@@ -505,19 +505,19 @@ lemma card_isUnramified_compl [NumberField k] [IsGalois k K] :
     · congr; ext w'
       rw [mem_filter, compl_filter, mem_filter_univ, @eq_comm _ (comap w' _), Set.mem_toFinset,
         mem_orbit_iff, and_iff_right_iff_imp]
-      intro e; rwa [← isUnramifiedOver_comap, ← e]
+      intro e; rwa [← isUnramifiedIn_comap, ← e]
     · rw [Nat.card_eq_fintype_card,
         ← MulAction.card_orbit_mul_card_stabilizer_eq_card_group _ w,
         ← Nat.card_eq_fintype_card (α := Stab w), InfinitePlace.card_stabilizer, if_neg,
         Nat.mul_div_cancel _ zero_lt_two, Set.toFinset_card]
-      rwa [← isUnramifiedOver_comap]
-  · simp [Set.MapsTo, isUnramifiedOver_comap]
+      rwa [← isUnramifiedIn_comap]
+  · simp [Set.MapsTo, isUnramifiedIn_comap]
 
 open scoped Classical in
-lemma card_eq_card_isUnramifiedOver [NumberField k] [IsGalois k K] :
+lemma card_eq_card_isUnramifiedIn [NumberField k] [IsGalois k K] :
     Fintype.card (InfinitePlace K) =
-      #{w : InfinitePlace k | w.IsUnramifiedOver K} * finrank k K +
-      #({w : InfinitePlace k | w.IsUnramifiedOver K} : Finset _)ᶜ * (finrank k K / 2) := by
+      #{w : InfinitePlace k | w.IsUnramifiedIn K} * finrank k K +
+      #({w : InfinitePlace k | w.IsUnramifiedIn K} : Finset _)ᶜ * (finrank k K / 2) := by
   rw [← card_isUnramified, ← card_isUnramified_compl, Finset.card_add_card_compl]
 
 end NumberField.InfinitePlace
@@ -559,8 +559,8 @@ lemma NumberField.InfinitePlace.isUnramified [IsUnramifiedAtInfinitePlaces k K]
 
 variable {k} (K)
 
-lemma NumberField.InfinitePlace.isUnramifiedOver [IsUnramifiedAtInfinitePlaces k K]
-    (w : InfinitePlace k) : IsUnramifiedOver K w := fun v _ ↦ v.isUnramified k
+lemma NumberField.InfinitePlace.isUnramifiedIn [IsUnramifiedAtInfinitePlaces k K]
+    (w : InfinitePlace k) : IsUnramifiedIn K w := fun v _ ↦ v.isUnramified k
 
 variable {K}
 
@@ -579,11 +579,11 @@ lemma IsUnramifiedAtInfinitePlaces.card_infinitePlace [NumberField k] [NumberFie
     [IsGalois k K] [IsUnramifiedAtInfinitePlaces k K] :
     Fintype.card (InfinitePlace K) = Fintype.card (InfinitePlace k) * finrank k K := by
   classical
-  rw [InfinitePlace.card_eq_card_isUnramifiedOver (k := k) (K := K), Finset.filter_true_of_mem,
+  rw [InfinitePlace.card_eq_card_isUnramifiedIn (k := k) (K := K), Finset.filter_true_of_mem,
     Finset.card_univ, Finset.card_eq_zero.mpr, zero_mul, add_zero]
   · exact Finset.compl_univ
   simp only [Finset.mem_univ, forall_true_left]
-  exact InfinitePlace.isUnramifiedOver K
+  exact InfinitePlace.isUnramifiedIn K
 
 namespace NumberField.InfinitePlace
 

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -104,13 +104,45 @@ lemma Algebra.isUnramifiedAt_iff_of_isDedekindDomain
     (nonZeroDivisors (R ⧸ p.under R))
   infer_instance
 
+/-- In characteristic zero the generic point is unramified: if `S` is a domain that is integral
+over a characteristic-zero domain `R` and `R → S` is injective, then `S` is unramified at the zero
+ideal. -/
+theorem Algebra.isUnramifiedAt_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZero R]
+    [Algebra.IsIntegral R S] : IsUnramifiedAt R (⊥ : Ideal S) := by
+  have : IsFractionRing S (Localization.AtPrime (⊥ : Ideal S)) := by
+    simpa [Ideal.primeCompl_bot] using Localization.isLocalization (M := (⊥ : Ideal S).primeCompl)
+  let : Field (Localization.AtPrime (⊥ : Ideal S)) := IsFractionRing.toField S
+  have : FaithfulSMul R (Localization.AtPrime (⊥ : Ideal S)) := by
+    rw [faithfulSMul_iff_algebraMap_injective,
+      IsScalarTower.algebraMap_eq R S (Localization.AtPrime ⊥)]
+    exact (IsFractionRing.injective S _).comp (FaithfulSMul.algebraMap_injective R S)
+  let := FractionRing.liftAlgebra R (Localization.AtPrime (⊥ : Ideal S))
+  have : Algebra.IsAlgebraic (FractionRing R) (Localization.AtPrime ⊥) :=
+    isAlgebraic_of_isFractionRing R S (FractionRing R) (Localization.AtPrime (⊥ : Ideal S))
+  have : FormallyUnramified (FractionRing R) (Localization.AtPrime (⊥ : Ideal S)) :=
+    FormallyUnramified.of_isSeparable _ _
+  exact FormallyUnramified.comp R (FractionRing R) (Localization.AtPrime ⊥)
+
 /-- Let `S` be a Dedekind domain that is torsion-free over a domain `R`, and let `p ≠ ⊥` be an
 ideal of `R`. Then `p` is unramified in `S` if and only if `S` is unramified at every maximal
-ideal `P` of `S` lying over `p`. -/
-theorem Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDomain S]
+ideal `P` of `S` lying over `p`.
+
+See `Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain` if `R` is of characteristic zero. -/
+theorem Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain' [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] {p : Ideal R} (hp : p ≠ ⊥) :
+    IsUnramifiedIn S p ↔
+      ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P :=
+  ⟨fun h P hP hlo ↦ h P hP.isPrime hlo,
+    fun h P hP hlo ↦ h P (hP.isMaximal (Ideal.ne_bot_of_liesOver_of_ne_bot hp P)) hlo⟩
+
+/-- Let `S` be a Dedekind domain that is integral and torsion-free over a characteristic-zero
+domain `R`. Then an ideal `p` of `R` is unramified in `S` if and only if `S` is unramified at every
+maximal ideal `P` of `S` lying over `p`. -/
+theorem Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDomain S]
+    [Module.IsTorsionFree R S] [CharZero R] [Algebra.IsIntegral R S] {p : Ideal R} :
     IsUnramifiedIn S p ↔
       ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P := by
   refine ⟨fun h P hP hlo ↦ h P hP.isPrime hlo, fun h P hP hlo ↦ ?_⟩
-  haveI := hlo
-  exact h P (hP.isMaximal (Ideal.ne_bot_of_liesOver_of_ne_bot hp P)) hlo
+  rcases eq_or_ne P ⊥ with rfl | hPbot
+  · exact isUnramifiedAt_bot
+  · exact h P (hP.isMaximal hPbot) hlo

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -76,12 +76,15 @@ lemma IsUnramifiedAt.of_liesOver_of_ne_bot
   refine this (H.trans (Ideal.pow_right_mono ?_ _))
   exact Ideal.map_le_iff_le_comap.mpr Ideal.LiesOver.over.le
 
+section IsUnramifiedIn
+namespace Algebra
+
 variable (R) in
 /--
 Up to technical conditions, If `T/S/R` is a tower of algebras, `P` is a prime of `T` unramified
 in `R`, then `P ∩ S` (as a prime of `S`) is also unramified in `R`.
 -/
-lemma Algebra.IsUnramifiedAt.of_liesOver
+lemma IsUnramifiedAt.of_liesOver
     (p : Ideal S) (P : Ideal T) [P.LiesOver p] [p.IsPrime] [P.IsPrime]
     [IsUnramifiedAt R P] [EssFiniteType R S] [EssFiniteType R T]
     [IsDedekindDomain S] [IsDomain T] [Module.IsTorsionFree S T] : IsUnramifiedAt R p :=
@@ -90,7 +93,7 @@ lemma Algebra.IsUnramifiedAt.of_liesOver
 
 /-- Let `R` be a domain of characteristic 0, finite rank over `ℤ`, `S` be a Dedekind domain
 that is a finite `R`-algebra. Let `p` be a prime of `S`, then `p` is unramified iff `e(p) = 1`. -/
-lemma Algebra.isUnramifiedAt_iff_of_isDedekindDomain
+lemma isUnramifiedAt_iff_of_isDedekindDomain
     {p : Ideal S} [p.IsPrime] [IsDedekindDomain S] [EssFiniteType R S] [IsDomain R]
     [Module.Finite ℤ R] [CharZero R] [Algebra.IsIntegral R S]
     (hp : p ≠ ⊥) :
@@ -107,7 +110,7 @@ lemma Algebra.isUnramifiedAt_iff_of_isDedekindDomain
 /-- In characteristic zero the generic point is unramified: if `S` is a domain that is integral
 over a characteristic-zero domain `R` and `R → S` is injective, then `S` is unramified at the zero
 ideal. -/
-theorem Algebra.isUnramifiedAt_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZero R]
+theorem isUnramifiedAt_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZero R]
     [Algebra.IsIntegral R S] : IsUnramifiedAt R (⊥ : Ideal S) := by
   have : IsFractionRing S (Localization.AtPrime (⊥ : Ideal S)) := by
     simpa [Ideal.primeCompl_bot] using Localization.isLocalization (M := (⊥ : Ideal S).primeCompl)
@@ -123,12 +126,18 @@ theorem Algebra.isUnramifiedAt_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] 
     FormallyUnramified.of_isSeparable _ _
   exact FormallyUnramified.comp R (FractionRing R) (Localization.AtPrime ⊥)
 
+/-- In characteristic zero, the zero ideal is unramified in an integral domain extension. -/
+theorem isUnramifiedIn_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZero R]
+    [Algebra.IsIntegral R S] : IsUnramifiedIn S (⊥ : Ideal R) := by
+  intro P _ hP
+  simpa [Ideal.eq_bot_of_liesOver_bot R P] using isUnramifiedAt_bot
+
 /-- Let `S` be a Dedekind domain that is torsion-free over a domain `R`, and let `p ≠ ⊥` be an
 ideal of `R`. Then `p` is unramified in `S` if and only if `S` is unramified at every maximal
 ideal `P` of `S` lying over `p`.
 
 See `Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain` if `R` is of characteristic zero. -/
-theorem Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain' [IsDomain R] [IsDedekindDomain S]
+theorem isUnramifiedIn_iff_forall_of_isDedekindDomain' [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] {p : Ideal R} (hp : p ≠ ⊥) :
     IsUnramifiedIn S p ↔
       ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P :=
@@ -138,7 +147,7 @@ theorem Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain' [IsDomain R] [IsD
 /-- Let `S` be a Dedekind domain that is integral and torsion-free over a characteristic-zero
 domain `R`. Then an ideal `p` of `R` is unramified in `S` if and only if `S` is unramified at every
 maximal ideal `P` of `S` lying over `p`. -/
-theorem Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDomain S]
+theorem isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [CharZero R] [Algebra.IsIntegral R S] {p : Ideal R} :
     IsUnramifiedIn S p ↔
       ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P := by
@@ -146,3 +155,30 @@ theorem Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDe
   rcases eq_or_ne P ⊥ with rfl | hPbot
   · exact isUnramifiedAt_bot
   · exact h P (hP.isMaximal hPbot) hlo
+
+/-- For a prime `𝔓` of `S` lying over an unramified prime `𝔭` of `R`, the ramification index
+`e(𝔓 ∣ 𝔭)` equals `1`. -/
+theorem UnramifiedIn.ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
+    [Module.IsTorsionFree R S] [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
+    [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedIn S 𝔭) (h𝔭 : 𝔭 ≠ ⊥) {𝔓 : Ideal S}
+    [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx 𝔭 𝔓 = 1 := by
+  rw [(Ideal.liesOver_iff 𝔓 𝔭).mp hP]
+  exact (isUnramifiedAt_iff_of_isDedekindDomain (Ideal.ne_bot_of_liesOver_of_ne_bot h𝔭 𝔓)).mp
+    (hunr 𝔓 inferInstance hP)
+
+/-- A nonzero ideal of `R` is unramified in `S` if and only if every prime ideal of `S` lying
+over it has ramification index `1`. -/
+theorem isUnramifiedIn_iff_forall_ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
+    [Module.IsTorsionFree R S] [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
+    [Algebra.IsIntegral R S] {𝔭 : Ideal R} (h𝔭 : 𝔭 ≠ ⊥) :
+    IsUnramifiedIn S 𝔭 ↔
+      ∀ (𝔓 : Ideal S) [𝔓.IsPrime], 𝔓.LiesOver 𝔭 → Ideal.ramificationIdx 𝔭 𝔓 = 1 := by
+  refine ⟨fun hunr 𝔓 _ hP ↦ UnramifiedIn.ramificationIdx_eq_one hunr h𝔭 hP, fun h 𝔓 _ hP ↦ ?_⟩
+  apply (isUnramifiedAt_iff_of_isDedekindDomain
+    (Ideal.ne_bot_of_liesOver_of_ne_bot h𝔭 𝔓)).mpr
+  rw [← (Ideal.liesOver_iff 𝔓 𝔭).mp hP]
+  exact h 𝔓 hP
+
+end Algebra
+
+end IsUnramifiedIn

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -159,7 +159,7 @@ theorem isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDo
 
 /-- For a prime `𝔓` of `S` lying over an unramified prime `𝔭` of `R`, the ramification index
 `e(𝔓 ∣ 𝔭)` equals `1`. -/
-theorem UnramifiedIn.ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
+theorem IsUnramifiedIn.ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedIn S 𝔭) (h𝔭 : 𝔭 ≠ ⊥) {𝔓 : Ideal S}
     [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx 𝔭 𝔓 = 1 := by
@@ -174,7 +174,7 @@ theorem isUnramifiedIn_iff_forall_ramificationIdx_eq_one [IsDomain R] [IsDedekin
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} (h𝔭 : 𝔭 ≠ ⊥) :
     IsUnramifiedIn S 𝔭 ↔
       ∀ (𝔓 : Ideal S) [𝔓.IsPrime], 𝔓.LiesOver 𝔭 → Ideal.ramificationIdx 𝔭 𝔓 = 1 := by
-  refine ⟨fun hunr 𝔓 _ hP ↦ UnramifiedIn.ramificationIdx_eq_one hunr h𝔭 hP, fun h 𝔓 _ hP ↦ ?_⟩
+  refine ⟨fun hunr 𝔓 _ hP ↦ hunr.ramificationIdx_eq_one h𝔭 hP, fun h 𝔓 _ hP ↦ ?_⟩
   apply (isUnramifiedAt_iff_of_isDedekindDomain
     (Ideal.ne_bot_of_liesOver_of_ne_bot h𝔭 𝔓)).mpr
   rw [← (Ideal.liesOver_iff 𝔓 𝔭).mp hP]

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -77,6 +77,7 @@ lemma IsUnramifiedAt.of_liesOver_of_ne_bot
   exact Ideal.map_le_iff_le_comap.mpr Ideal.LiesOver.over.le
 
 section IsUnramifiedIn
+
 namespace Algebra
 
 variable (R) in

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -76,7 +76,7 @@ lemma IsUnramifiedAt.of_liesOver_of_ne_bot
   refine this (H.trans (Ideal.pow_right_mono ?_ _))
   exact Ideal.map_le_iff_le_comap.mpr Ideal.LiesOver.over.le
 
-section IsUnramifiedIn
+section IsUnramifiedOver
 
 namespace Algebra
 
@@ -128,8 +128,8 @@ theorem isUnramifiedAt_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZer
   exact FormallyUnramified.comp R (FractionRing R) (Localization.AtPrime ⊥)
 
 /-- In characteristic zero, the zero ideal is unramified in an integral domain extension. -/
-theorem isUnramifiedIn_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZero R]
-    [Algebra.IsIntegral R S] : IsUnramifiedIn S (⊥ : Ideal R) := by
+theorem isUnramifiedOver_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZero R]
+    [Algebra.IsIntegral R S] : IsUnramifiedOver S (⊥ : Ideal R) := by
   intro P _ hP
   simpa [Ideal.eq_bot_of_liesOver_bot R P] using isUnramifiedAt_bot
 
@@ -137,10 +137,10 @@ theorem isUnramifiedIn_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZer
 ideal of `R`. Then `p` is unramified in `S` if and only if `S` is unramified at every maximal
 ideal `P` of `S` lying over `p`.
 
-See `Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain` if `R` is of characteristic zero. -/
-theorem isUnramifiedIn_iff_forall_of_isDedekindDomain' [IsDomain R] [IsDedekindDomain S]
+See `Algebra.isUnramifiedOver_iff_forall_of_isDedekindDomain` if `R` is of characteristic zero. -/
+theorem isUnramifiedOver_iff_forall_of_isDedekindDomain' [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] {p : Ideal R} (hp : p ≠ ⊥) :
-    IsUnramifiedIn S p ↔
+    IsUnramifiedOver S p ↔
       ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P :=
   ⟨fun h P hP hlo ↦ h P hP.isPrime hlo,
     fun h P hP hlo ↦ h P (hP.isMaximal (Ideal.ne_bot_of_liesOver_of_ne_bot hp P)) hlo⟩
@@ -148,9 +148,9 @@ theorem isUnramifiedIn_iff_forall_of_isDedekindDomain' [IsDomain R] [IsDedekindD
 /-- Let `S` be a Dedekind domain that is integral and torsion-free over a characteristic-zero
 domain `R`. Then an ideal `p` of `R` is unramified in `S` if and only if `S` is unramified at every
 maximal ideal `P` of `S` lying over `p`. -/
-theorem isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDomain S]
+theorem isUnramifiedOver_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [CharZero R] [Algebra.IsIntegral R S] {p : Ideal R} :
-    IsUnramifiedIn S p ↔
+    IsUnramifiedOver S p ↔
       ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P := by
   refine ⟨fun h P hP hlo ↦ h P hP.isPrime hlo, fun h P hP hlo ↦ ?_⟩
   rcases eq_or_ne P ⊥ with rfl | hPbot
@@ -159,9 +159,9 @@ theorem isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDo
 
 /-- For a prime `𝔓` of `S` lying over an unramified prime `𝔭` of `R`, the ramification index
 `e(𝔓 ∣ 𝔭)` equals `1`. -/
-theorem IsUnramifiedIn.ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
+theorem IsUnramifiedOver.ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
-    [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedIn S 𝔭) (h𝔭 : 𝔭 ≠ ⊥) {𝔓 : Ideal S}
+    [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedOver S 𝔭) (h𝔭 : 𝔭 ≠ ⊥) {𝔓 : Ideal S}
     [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx 𝔭 𝔓 = 1 := by
   rw [(Ideal.liesOver_iff 𝔓 𝔭).mp hP]
   exact (isUnramifiedAt_iff_of_isDedekindDomain (Ideal.ne_bot_of_liesOver_of_ne_bot h𝔭 𝔓)).mp
@@ -169,10 +169,10 @@ theorem IsUnramifiedIn.ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
 
 /-- A nonzero ideal of `R` is unramified in `S` if and only if every prime ideal of `S` lying
 over it has ramification index `1`. -/
-theorem isUnramifiedIn_iff_forall_ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
+theorem isUnramifiedOver_iff_forall_ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} (h𝔭 : 𝔭 ≠ ⊥) :
-    IsUnramifiedIn S 𝔭 ↔
+    IsUnramifiedOver S 𝔭 ↔
       ∀ (𝔓 : Ideal S) [𝔓.IsPrime], 𝔓.LiesOver 𝔭 → Ideal.ramificationIdx 𝔭 𝔓 = 1 := by
   refine ⟨fun hunr 𝔓 _ hP ↦ hunr.ramificationIdx_eq_one h𝔭 hP, fun h 𝔓 _ hP ↦ ?_⟩
   apply (isUnramifiedAt_iff_of_isDedekindDomain
@@ -182,4 +182,4 @@ theorem isUnramifiedIn_iff_forall_ramificationIdx_eq_one [IsDomain R] [IsDedekin
 
 end Algebra
 
-end IsUnramifiedIn
+end IsUnramifiedOver

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -103,3 +103,14 @@ lemma Algebra.isUnramifiedAt_iff_of_isDedekindDomain
   have : Finite ((p.under R).ResidueField) := IsLocalization.finite _
     (nonZeroDivisors (R ⧸ p.under R))
   infer_instance
+
+/-- Let `S` be a Dedekind domain that is torsion-free over a domain `R`, and let `p ≠ ⊥` be an
+ideal of `R`. Then `p` is unramified in `S` if and only if `S` is unramified at every maximal
+ideal `P` of `S` lying over `p`. -/
+theorem Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDomain S]
+    [Module.IsTorsionFree R S] {p : Ideal R} (hp : p ≠ ⊥) :
+    IsUnramifiedIn S p ↔
+      ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P := by
+  refine ⟨fun h P hP hlo ↦ h P hP.isPrime hlo, fun h P hP hlo ↦ ?_⟩
+  haveI := hlo
+  exact h P (hP.isMaximal (Ideal.ne_bot_of_liesOver_of_ne_bot hp P)) hlo

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -129,7 +129,7 @@ theorem isUnramifiedAt_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZer
 
 /-- In characteristic zero, the zero ideal is unramified in an integral domain extension. -/
 theorem isUnramifiedOver_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZero R]
-    [Algebra.IsIntegral R S] : IsUnramifiedOver S (⊥ : Ideal R) := by
+    [Algebra.IsIntegral R S] : IsUnramifiedOver (⊥ : Ideal R) S := by
   intro P _ hP
   simpa [Ideal.eq_bot_of_liesOver_bot R P] using isUnramifiedAt_bot
 
@@ -140,7 +140,7 @@ ideal `P` of `S` lying over `p`.
 See `Algebra.isUnramifiedOver_iff_forall_of_isDedekindDomain` if `R` is of characteristic zero. -/
 theorem isUnramifiedOver_iff_forall_of_isDedekindDomain' [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] {p : Ideal R} (hp : p ≠ ⊥) :
-    IsUnramifiedOver S p ↔
+    IsUnramifiedOver p S ↔
       ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P :=
   ⟨fun h P hP hlo ↦ h P hP.isPrime hlo,
     fun h P hP hlo ↦ h P (hP.isMaximal (Ideal.ne_bot_of_liesOver_of_ne_bot hp P)) hlo⟩
@@ -150,7 +150,7 @@ domain `R`. Then an ideal `p` of `R` is unramified in `S` if and only if `S` is 
 maximal ideal `P` of `S` lying over `p`. -/
 theorem isUnramifiedOver_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [CharZero R] [Algebra.IsIntegral R S] {p : Ideal R} :
-    IsUnramifiedOver S p ↔
+    IsUnramifiedOver p S ↔
       ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P := by
   refine ⟨fun h P hP hlo ↦ h P hP.isPrime hlo, fun h P hP hlo ↦ ?_⟩
   rcases eq_or_ne P ⊥ with rfl | hPbot
@@ -161,7 +161,7 @@ theorem isUnramifiedOver_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekind
 `e(𝔓 ∣ 𝔭)` equals `1`. -/
 theorem IsUnramifiedOver.ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
-    [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedOver S 𝔭) (h𝔭 : 𝔭 ≠ ⊥) {𝔓 : Ideal S}
+    [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedOver 𝔭 S) (h𝔭 : 𝔭 ≠ ⊥) {𝔓 : Ideal S}
     [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx 𝔭 𝔓 = 1 := by
   rw [(Ideal.liesOver_iff 𝔓 𝔭).mp hP]
   exact (isUnramifiedAt_iff_of_isDedekindDomain (Ideal.ne_bot_of_liesOver_of_ne_bot h𝔭 𝔓)).mp
@@ -172,7 +172,7 @@ over it has ramification index `1`. -/
 theorem isUnramifiedOver_iff_forall_ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} (h𝔭 : 𝔭 ≠ ⊥) :
-    IsUnramifiedOver S 𝔭 ↔
+    IsUnramifiedOver 𝔭 S ↔
       ∀ (𝔓 : Ideal S) [𝔓.IsPrime], 𝔓.LiesOver 𝔭 → Ideal.ramificationIdx 𝔭 𝔓 = 1 := by
   refine ⟨fun hunr 𝔓 _ hP ↦ hunr.ramificationIdx_eq_one h𝔭 hP, fun h 𝔓 _ hP ↦ ?_⟩
   apply (isUnramifiedAt_iff_of_isDedekindDomain

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -76,7 +76,7 @@ lemma IsUnramifiedAt.of_liesOver_of_ne_bot
   refine this (H.trans (Ideal.pow_right_mono ?_ _))
   exact Ideal.map_le_iff_le_comap.mpr Ideal.LiesOver.over.le
 
-section IsUnramifiedOver
+section IsUnramifiedIn
 
 namespace Algebra
 
@@ -111,7 +111,7 @@ lemma isUnramifiedAt_iff_of_isDedekindDomain
 /-- In characteristic zero the generic point is unramified: if `S` is a domain that is integral
 over a characteristic-zero domain `R` and `R → S` is injective, then `S` is unramified at the zero
 ideal. -/
-theorem isUnramifiedAt_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZero R]
+theorem isUnramifiedAt_bot [IsDomain R] [IsDomain S] [Module.IsTorsionFree R S] [CharZero R]
     [Algebra.IsIntegral R S] : IsUnramifiedAt R (⊥ : Ideal S) := by
   have : IsFractionRing S (Localization.AtPrime (⊥ : Ideal S)) := by
     simpa [Ideal.primeCompl_bot] using Localization.isLocalization (M := (⊥ : Ideal S).primeCompl)
@@ -128,8 +128,8 @@ theorem isUnramifiedAt_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZer
   exact FormallyUnramified.comp R (FractionRing R) (Localization.AtPrime ⊥)
 
 /-- In characteristic zero, the zero ideal is unramified in an integral domain extension. -/
-theorem isUnramifiedOver_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZero R]
-    [Algebra.IsIntegral R S] : IsUnramifiedOver (⊥ : Ideal R) S := by
+theorem isUnramifiedIn_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZero R]
+    [Algebra.IsIntegral R S] : IsUnramifiedIn S (⊥ : Ideal R) := by
   intro P _ hP
   simpa [Ideal.eq_bot_of_liesOver_bot R P] using isUnramifiedAt_bot
 
@@ -137,10 +137,10 @@ theorem isUnramifiedOver_bot [IsDomain R] [IsDomain S] [FaithfulSMul R S] [CharZ
 ideal of `R`. Then `p` is unramified in `S` if and only if `S` is unramified at every maximal
 ideal `P` of `S` lying over `p`.
 
-See `Algebra.isUnramifiedOver_iff_forall_of_isDedekindDomain` if `R` is of characteristic zero. -/
-theorem isUnramifiedOver_iff_forall_of_isDedekindDomain' [IsDomain R] [IsDedekindDomain S]
+See `Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain` if `R` is of characteristic zero. -/
+theorem isUnramifiedIn_iff_forall_of_isDedekindDomain' [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] {p : Ideal R} (hp : p ≠ ⊥) :
-    IsUnramifiedOver p S ↔
+    IsUnramifiedIn S p ↔
       ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P :=
   ⟨fun h P hP hlo ↦ h P hP.isPrime hlo,
     fun h P hP hlo ↦ h P (hP.isMaximal (Ideal.ne_bot_of_liesOver_of_ne_bot hp P)) hlo⟩
@@ -148,9 +148,9 @@ theorem isUnramifiedOver_iff_forall_of_isDedekindDomain' [IsDomain R] [IsDedekin
 /-- Let `S` be a Dedekind domain that is integral and torsion-free over a characteristic-zero
 domain `R`. Then an ideal `p` of `R` is unramified in `S` if and only if `S` is unramified at every
 maximal ideal `P` of `S` lying over `p`. -/
-theorem isUnramifiedOver_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDomain S]
+theorem isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [CharZero R] [Algebra.IsIntegral R S] {p : Ideal R} :
-    IsUnramifiedOver p S ↔
+    IsUnramifiedIn S p ↔
       ∀ (P : Ideal S) (_ : P.IsMaximal), P.LiesOver p → IsUnramifiedAt R P := by
   refine ⟨fun h P hP hlo ↦ h P hP.isPrime hlo, fun h P hP hlo ↦ ?_⟩
   rcases eq_or_ne P ⊥ with rfl | hPbot
@@ -159,9 +159,9 @@ theorem isUnramifiedOver_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekind
 
 /-- For a prime `𝔓` of `S` lying over an unramified prime `𝔭` of `R`, the ramification index
 `e(𝔓 ∣ 𝔭)` equals `1`. -/
-theorem IsUnramifiedOver.ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
+theorem IsUnramifiedIn.ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
-    [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedOver 𝔭 S) (h𝔭 : 𝔭 ≠ ⊥) {𝔓 : Ideal S}
+    [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedIn S 𝔭) (h𝔭 : 𝔭 ≠ ⊥) {𝔓 : Ideal S}
     [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx 𝔭 𝔓 = 1 := by
   rw [(Ideal.liesOver_iff 𝔓 𝔭).mp hP]
   exact (isUnramifiedAt_iff_of_isDedekindDomain (Ideal.ne_bot_of_liesOver_of_ne_bot h𝔭 𝔓)).mp
@@ -169,10 +169,10 @@ theorem IsUnramifiedOver.ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S
 
 /-- A nonzero ideal of `R` is unramified in `S` if and only if every prime ideal of `S` lying
 over it has ramification index `1`. -/
-theorem isUnramifiedOver_iff_forall_ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
+theorem isUnramifiedIn_iff_forall_ramificationIdx_eq_one [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} (h𝔭 : 𝔭 ≠ ⊥) :
-    IsUnramifiedOver 𝔭 S ↔
+    IsUnramifiedIn S 𝔭 ↔
       ∀ (𝔓 : Ideal S) [𝔓.IsPrime], 𝔓.LiesOver 𝔭 → Ideal.ramificationIdx 𝔭 𝔓 = 1 := by
   refine ⟨fun hunr 𝔓 _ hP ↦ hunr.ramificationIdx_eq_one h𝔭 hP, fun h 𝔓 _ hP ↦ ?_⟩
   apply (isUnramifiedAt_iff_of_isDedekindDomain
@@ -182,4 +182,4 @@ theorem isUnramifiedOver_iff_forall_ramificationIdx_eq_one [IsDomain R] [IsDedek
 
 end Algebra
 
-end IsUnramifiedOver
+end IsUnramifiedIn

--- a/Mathlib/RingTheory/Unramified/Locus.lean
+++ b/Mathlib/RingTheory/Unramified/Locus.lean
@@ -98,6 +98,9 @@ unramified . -/
 def IsUnramifiedIn (𝔭 : Ideal R) : Prop :=
   ∀ (𝔓 : Ideal A) (_ : 𝔓.IsPrime), 𝔓.LiesOver 𝔭 → Algebra.IsUnramifiedAt R 𝔓
 
+theorem isUnramifiedIn_top : IsUnramifiedIn A (⊤ : Ideal R) :=
+  fun P hP _ ↦ (hP.ne_top ((Ideal.eq_top_iff_of_liesOver P (⊤ : Ideal R)).mpr rfl)).elim
+
 end IsUnramifiedIn
 section
 

--- a/Mathlib/RingTheory/Unramified/Locus.lean
+++ b/Mathlib/RingTheory/Unramified/Locus.lean
@@ -91,14 +91,16 @@ end
 
 section IsUnramifiedOver
 
-variable {R : Type*} (A : Type*) [CommRing R] [CommRing A] [Algebra R A]
+variable {R : Type*} [CommRing R]
 
 /-- A prime `𝔭` of `R` is unramified in `A` if every prime ideal `𝔓` of `A` lying over `𝔭` is
 unramified . -/
-def IsUnramifiedOver (𝔭 : Ideal R) : Prop :=
+def IsUnramifiedOver (𝔭 : Ideal R) (A : Type*) [CommRing A] [Algebra R A] : Prop :=
   ∀ (𝔓 : Ideal A) (_ : 𝔓.IsPrime), 𝔓.LiesOver 𝔭 → Algebra.IsUnramifiedAt R 𝔓
 
-theorem isUnramifiedOver_top : IsUnramifiedOver A (⊤ : Ideal R) :=
+variable (A : Type*) [CommRing A] [Algebra R A]
+
+theorem isUnramifiedOver_top : IsUnramifiedOver (⊤ : Ideal R) A :=
   fun P hP _ ↦ (hP.ne_top ((Ideal.eq_top_iff_of_liesOver P (⊤ : Ideal R)).mpr rfl)).elim
 
 end IsUnramifiedOver

--- a/Mathlib/RingTheory/Unramified/Locus.lean
+++ b/Mathlib/RingTheory/Unramified/Locus.lean
@@ -89,21 +89,21 @@ theorem IsUnramifiedAt.residueField
 
 end
 
-section IsUnramifiedOver
+section IsUnramifiedIn
 
 variable {R : Type*} [CommRing R]
 
 /-- A prime `𝔭` of `R` is unramified in `A` if every prime ideal `𝔓` of `A` lying over `𝔭` is
 unramified . -/
-def IsUnramifiedOver (𝔭 : Ideal R) (A : Type*) [CommRing A] [Algebra R A] : Prop :=
+def IsUnramifiedIn (A : Type*) [CommRing A] [Algebra R A] (𝔭 : Ideal R) : Prop :=
   ∀ (𝔓 : Ideal A) (_ : 𝔓.IsPrime), 𝔓.LiesOver 𝔭 → Algebra.IsUnramifiedAt R 𝔓
 
 variable (A : Type*) [CommRing A] [Algebra R A]
 
-theorem isUnramifiedOver_top : IsUnramifiedOver (⊤ : Ideal R) A :=
+theorem isUnramifiedIn_top : IsUnramifiedIn A (⊤ : Ideal R) :=
   fun P hP _ ↦ (hP.ne_top ((Ideal.eq_top_iff_of_liesOver P (⊤ : Ideal R)).mpr rfl)).elim
 
-end IsUnramifiedOver
+end IsUnramifiedIn
 section
 
 variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]

--- a/Mathlib/RingTheory/Unramified/Locus.lean
+++ b/Mathlib/RingTheory/Unramified/Locus.lean
@@ -89,19 +89,19 @@ theorem IsUnramifiedAt.residueField
 
 end
 
-section IsUnramifiedIn
+section IsUnramifiedOver
 
 variable {R : Type*} (A : Type*) [CommRing R] [CommRing A] [Algebra R A]
 
 /-- A prime `𝔭` of `R` is unramified in `A` if every prime ideal `𝔓` of `A` lying over `𝔭` is
 unramified . -/
-def IsUnramifiedIn (𝔭 : Ideal R) : Prop :=
+def IsUnramifiedOver (𝔭 : Ideal R) : Prop :=
   ∀ (𝔓 : Ideal A) (_ : 𝔓.IsPrime), 𝔓.LiesOver 𝔭 → Algebra.IsUnramifiedAt R 𝔓
 
-theorem isUnramifiedIn_top : IsUnramifiedIn A (⊤ : Ideal R) :=
+theorem isUnramifiedOver_top : IsUnramifiedOver A (⊤ : Ideal R) :=
   fun P hP _ ↦ (hP.ne_top ((Ideal.eq_top_iff_of_liesOver P (⊤ : Ideal R)).mpr rfl)).elim
 
-end IsUnramifiedIn
+end IsUnramifiedOver
 section
 
 variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]

--- a/Mathlib/RingTheory/Unramified/Locus.lean
+++ b/Mathlib/RingTheory/Unramified/Locus.lean
@@ -89,6 +89,16 @@ theorem IsUnramifiedAt.residueField
 
 end
 
+section IsUnramifiedIn
+
+variable {R : Type*} (A : Type*) [CommRing R] [CommRing A] [Algebra R A]
+
+/-- A prime `𝔭` of `R` is unramified in `A` if every prime ideal `𝔓` of `A` lying over `𝔭` is
+unramified . -/
+def IsUnramifiedIn (𝔭 : Ideal R) : Prop :=
+  ∀ (𝔓 : Ideal A) (_ : 𝔓.IsPrime), 𝔓.LiesOver 𝔭 → Algebra.IsUnramifiedAt R 𝔓
+
+end IsUnramifiedIn
 section
 
 variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]


### PR DESCRIPTION

---

I am not 100% sure about the name, but note that we already have [NumberField.InfinitePlace.IsUnramifiedIn](https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.html#NumberField.InfinitePlace.IsUnramifiedIn) and I think it's reasonable to follow the same convention. We can change everything later.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
