### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Shift): left composition with a shift sequence

### DIFF
--- a/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
@@ -291,7 +291,7 @@ set_option backward.isDefEq.respectTransparency false in
 /-- Given an isomorphism `π ⋙ H ≅ F`, where `π` is a functor which commutes
 with the shift by `M` and `H` is equipped with a shift sequence,
 then this is the shift sequence for `F` induced by composition. -/
-@[implicit_reducible]
+@[implicit_reducible, simps]
 def leftComp [π.CommShift M] [H.ShiftSequence M] : F.ShiftSequence M where
   sequence n := π ⋙ H.shift n
   isoZero := isoWhiskerLeft π (H.isoShiftZero M) ≪≫ e

--- a/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
@@ -5,7 +5,7 @@ Authors: Joël Riou
 -/
 module
 
-public import Mathlib.CategoryTheory.Shift.Basic
+public import Mathlib.CategoryTheory.Shift.CommShift
 public import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
 
 /-! # Sequences of functors from a category equipped with a shift
@@ -33,8 +33,9 @@ set_option backward.defeqAttrib.useBackward true
 
 open CategoryTheory Category ZeroObject Limits
 
-variable {C A : Type*} [Category* C] [Category* A] (F : C ⥤ A)
-  (M : Type*) [AddMonoid M] [HasShift C M]
+variable {C D A : Type*} [Category* C] [Category* D] [Category* A] (F : C ⥤ A)
+  {π : C ⥤ D} {H : D ⥤ A} (e : π ⋙ H ≅ F)
+  (M : Type*) [AddMonoid M] [HasShift C M] [HasShift D M]
   {G : Type*} [AddGroup G] [HasShift C G]
 
 namespace CategoryTheory
@@ -282,6 +283,37 @@ instance (n : M) : (F.shift n).Additive := additive_of_iso (F.isoShift n)
 end
 
 end
+
+namespace ShiftSequence
+
+variable {F} in
+set_option backward.isDefEq.respectTransparency false in
+/-- Given an isomorphism `π ⋙ H ≅ F`, where `π` is a functor which commutes
+with the shift by `M` and `H` is equipped with a shift sequence,
+then this is the shift sequence for `F` induced by composition. -/
+@[implicit_reducible]
+def leftComp [π.CommShift M] [H.ShiftSequence M] : F.ShiftSequence M where
+  sequence n := π ⋙ H.shift n
+  isoZero := isoWhiskerLeft π (H.isoShiftZero M) ≪≫ e
+  shiftIso n a a' ha' :=
+    (Functor.associator _ _ _).symm ≪≫
+      isoWhiskerRight (π.commShiftIso n) _ ≪≫ Functor.associator _ _ _ ≪≫
+      isoWhiskerLeft π (H.shiftIso n a a' ha')
+  shiftIso_zero a := by
+    ext K
+    simp [← Functor.map_comp, commShiftIso_zero]
+  shiftIso_add n m a a' a'' ha' ha'':= by
+    ext K
+    dsimp
+    simp only [H.shiftIso_add_hom_app n m a a' a'' ha' ha'', assoc,
+      commShiftIso_add, CommShift.isoAdd_hom_app, ← Functor.map_comp_assoc,
+      id_comp, Iso.inv_hom_id_app, comp_obj, comp_id]
+    simp
+
+instance [π.CommShift M] [H.ShiftSequence M] : (π ⋙ H).ShiftSequence M :=
+  leftComp (Iso.refl _) _
+
+end ShiftSequence
 
 end Functor
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
