### PR TITLE
feat: search for an IsManifold hypothesis first

### DIFF
--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -370,6 +370,7 @@ This implementation is not maximally robust yet.
 -- TODO: consider lowering monad to `MetaM`
 def findModelInner (e : Expr) (baseInfo : Option (Expr × Expr) := none) :
     TermElabM (Option FindModelResult) := do
+  if let some m ← tryStrategy "instance assumption" fromAssumption      then return some m
   if let some m ← tryStrategy "TotalSpace"          fromTotalSpace      then return some m
   if let some m ← tryStrategy "TangentBundle"       fromTangentBundle   then return some m
   if let some m ← tryStrategy "NormedSpace"         fromNormedSpace     then return some m
@@ -389,6 +390,19 @@ def findModelInner (e : Expr) (baseInfo : Option (Expr × Expr) := none) :
 where
   /- Note that errors thrown in the following are caught by `tryStrategy` and converted to trace
   messages. -/
+  /-- Attempt to find a model with corners on `M` by looking for an `IsManifold I _ M` hypothesis
+  in the local context. -/
+  fromAssumption : TermElabM FindModelResult := do
+    let some I ← findSomeLocalInstanceOf? ``IsManifold fun inst type ↦ do
+        match_expr type with
+        | IsManifold _k _ _E _ _ _H _ I _n M _ _ =>
+          trace[Elab.DiffGeo.MDiff] "trying `IsManifold` instance `{inst}` of type `{type}`"
+          if ← withReducible (pureIsDefEq M e) then return some I
+          else return none
+        | _ => return none
+      | throwError "Couldn't find an `IsManifold` hypothesis involving `{e}` among local instances."
+    trace[Elab.DiffGeo.MDiff] "`{e}` is a manifold over the model with corners `{I}`"
+    return { model := I }
   /-- Attempt to find a model from a `TotalSpace` first by attempting to use any provided
   `baseInfo`, then by seeing if it is the total space of a tangent bundle. -/
   fromTotalSpace : TermElabM FindModelResult := do

--- a/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
@@ -231,12 +231,18 @@ error: failed to synthesize
 Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `TotalSpace F (TangentSpace I)`
+[Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] Failed with error:
+      Couldn't find an `IsManifold` hypothesis involving `TotalSpace F (TangentSpace I)` among local instances.
 [Elab.DiffGeo.MDiff] ✅️ TotalSpace
   [Elab.DiffGeo.MDiff] ✅️ TangentSpace
     [Elab.DiffGeo.MDiff] `TangentSpace I` is the total space of the `TangentBundle` of `M`
     [Elab.DiffGeo.MDiff] Found model: `I.tangent`
   [Elab.DiffGeo.MDiff] Found model: `I.tangent`
 [Elab.DiffGeo.MDiff] Finding a model with corners for: `F`
+[Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] Failed with error:
+      Couldn't find an `IsManifold` hypothesis involving `F` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
   [Elab.DiffGeo.MDiff] Failed with error:
       `F` is not a `Bundle.TotalSpace`.
@@ -324,6 +330,9 @@ variable {f : M → E'' →SL[id'] E'''} in
 error: Could not find a model with corners for `ContinuousLinearMap id' E'' E'''`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `M`
+[Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] Failed with error:
+      Couldn't find an `IsManifold` hypothesis involving `M` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
   [Elab.DiffGeo.MDiff] Failed with error:
       `M` is not a `Bundle.TotalSpace`.
@@ -338,6 +347,9 @@ trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `M`
   [Elab.DiffGeo.MDiff] `M` is a charted space over `H` via `inst✝²²`
   [Elab.DiffGeo.MDiff] Found model: `I`
 [Elab.DiffGeo.MDiff] Finding a model with corners for: `ContinuousLinearMap id' E'' E'''`
+[Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] Failed with error:
+      Couldn't find an `IsManifold` hypothesis involving `ContinuousLinearMap id' E'' E'''` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
   [Elab.DiffGeo.MDiff] Failed with error:
       `ContinuousLinearMap id' E'' E'''` is not a `Bundle.TotalSpace`.
@@ -427,6 +439,9 @@ variable {f : M → E'' →SL[σ] E''''} in
 error: Could not find a model with corners for `ContinuousLinearMap σ E'' E''''`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `M`
+[Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] Failed with error:
+      Couldn't find an `IsManifold` hypothesis involving `M` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
   [Elab.DiffGeo.MDiff] Failed with error:
       `M` is not a `Bundle.TotalSpace`.
@@ -441,6 +456,9 @@ trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `M`
   [Elab.DiffGeo.MDiff] `M` is a charted space over `H` via `inst✝²⁵`
   [Elab.DiffGeo.MDiff] Found model: `I`
 [Elab.DiffGeo.MDiff] Finding a model with corners for: `ContinuousLinearMap σ E'' E''''`
+[Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] Failed with error:
+      Couldn't find an `IsManifold` hypothesis involving `ContinuousLinearMap σ E'' E''''` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
   [Elab.DiffGeo.MDiff] Failed with error:
       `ContinuousLinearMap σ E'' E''''` is not a `Bundle.TotalSpace`.
@@ -646,6 +664,9 @@ set_option trace.Elab.DiffGeo.MDiff true in
 error: Could not find a model with corners for `↑(Set.Icc x y)`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `↑(Set.Icc x y)`
+[Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] Failed with error:
+      Couldn't find an `IsManifold` hypothesis involving `↑(Set.Icc x y)` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
   [Elab.DiffGeo.MDiff] Failed with error:
       `↑(Set.Icc x y)` is not a `Bundle.TotalSpace`.

--- a/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
@@ -232,6 +232,8 @@ Hint: Additional diagnostic information may be available using the `set_option d
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `TotalSpace F (TangentSpace I)`
 [Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] trying `IsManifold` instance `inst✝¹` of type `IsManifold I 1 M`
+  [Elab.DiffGeo.MDiff] trying `IsManifold` instance `inst✝` of type `IsManifold I 2 M`
   [Elab.DiffGeo.MDiff] Failed with error:
       Couldn't find an `IsManifold` hypothesis involving `TotalSpace F (TangentSpace I)` among local instances.
 [Elab.DiffGeo.MDiff] ✅️ TotalSpace
@@ -241,6 +243,8 @@ trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `TotalSpace F (Tan
   [Elab.DiffGeo.MDiff] Found model: `I.tangent`
 [Elab.DiffGeo.MDiff] Finding a model with corners for: `F`
 [Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] trying `IsManifold` instance `inst✝¹` of type `IsManifold I 1 M`
+  [Elab.DiffGeo.MDiff] trying `IsManifold` instance `inst✝` of type `IsManifold I 2 M`
   [Elab.DiffGeo.MDiff] Failed with error:
       Couldn't find an `IsManifold` hypothesis involving `F` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
@@ -330,24 +334,13 @@ variable {f : M → E'' →SL[id'] E'''} in
 error: Could not find a model with corners for `ContinuousLinearMap id' E'' E'''`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `M`
-[Elab.DiffGeo.MDiff] 💥️ instance assumption
-  [Elab.DiffGeo.MDiff] Failed with error:
-      Couldn't find an `IsManifold` hypothesis involving `M` among local instances.
-[Elab.DiffGeo.MDiff] 💥️ TotalSpace
-  [Elab.DiffGeo.MDiff] Failed with error:
-      `M` is not a `Bundle.TotalSpace`.
-[Elab.DiffGeo.MDiff] 💥️ TangentBundle
-  [Elab.DiffGeo.MDiff] Failed with error:
-      `M` is not a `TangentBundle`
-[Elab.DiffGeo.MDiff] 💥️ NormedSpace
-  [Elab.DiffGeo.MDiff] Failed with error:
-      Couldn't find a `NormedSpace` structure on `M` among local instances.
-[Elab.DiffGeo.MDiff] ✅️ Manifold
-  [Elab.DiffGeo.MDiff] considering instance of type `ChartedSpace H M`
-  [Elab.DiffGeo.MDiff] `M` is a charted space over `H` via `inst✝²²`
+[Elab.DiffGeo.MDiff] ✅️ instance assumption
+  [Elab.DiffGeo.MDiff] trying `IsManifold` instance `inst✝⁴` of type `IsManifold I 1 M`
+  [Elab.DiffGeo.MDiff] `M` is a manifold over the model with corners `I`
   [Elab.DiffGeo.MDiff] Found model: `I`
 [Elab.DiffGeo.MDiff] Finding a model with corners for: `ContinuousLinearMap id' E'' E'''`
 [Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] trying `IsManifold` instance `inst✝⁴` of type `IsManifold I 1 M`
   [Elab.DiffGeo.MDiff] Failed with error:
       Couldn't find an `IsManifold` hypothesis involving `ContinuousLinearMap id' E'' E'''` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
@@ -439,24 +432,13 @@ variable {f : M → E'' →SL[σ] E''''} in
 error: Could not find a model with corners for `ContinuousLinearMap σ E'' E''''`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `M`
-[Elab.DiffGeo.MDiff] 💥️ instance assumption
-  [Elab.DiffGeo.MDiff] Failed with error:
-      Couldn't find an `IsManifold` hypothesis involving `M` among local instances.
-[Elab.DiffGeo.MDiff] 💥️ TotalSpace
-  [Elab.DiffGeo.MDiff] Failed with error:
-      `M` is not a `Bundle.TotalSpace`.
-[Elab.DiffGeo.MDiff] 💥️ TangentBundle
-  [Elab.DiffGeo.MDiff] Failed with error:
-      `M` is not a `TangentBundle`
-[Elab.DiffGeo.MDiff] 💥️ NormedSpace
-  [Elab.DiffGeo.MDiff] Failed with error:
-      Couldn't find a `NormedSpace` structure on `M` among local instances.
-[Elab.DiffGeo.MDiff] ✅️ Manifold
-  [Elab.DiffGeo.MDiff] considering instance of type `ChartedSpace H M`
-  [Elab.DiffGeo.MDiff] `M` is a charted space over `H` via `inst✝²⁵`
+[Elab.DiffGeo.MDiff] ✅️ instance assumption
+  [Elab.DiffGeo.MDiff] trying `IsManifold` instance `inst✝⁷` of type `IsManifold I 1 M`
+  [Elab.DiffGeo.MDiff] `M` is a manifold over the model with corners `I`
   [Elab.DiffGeo.MDiff] Found model: `I`
 [Elab.DiffGeo.MDiff] Finding a model with corners for: `ContinuousLinearMap σ E'' E''''`
 [Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] trying `IsManifold` instance `inst✝⁷` of type `IsManifold I 1 M`
   [Elab.DiffGeo.MDiff] Failed with error:
       Couldn't find an `IsManifold` hypothesis involving `ContinuousLinearMap σ E'' E''''` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
@@ -665,6 +647,8 @@ error: Could not find a model with corners for `↑(Set.Icc x y)`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `↑(Set.Icc x y)`
 [Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] trying `IsManifold` instance `inst✝⁷` of type `IsManifold I 1 M`
+  [Elab.DiffGeo.MDiff] trying `IsManifold` instance `inst✝²` of type `IsManifold J 2 N`
   [Elab.DiffGeo.MDiff] Failed with error:
       Couldn't find an `IsManifold` hypothesis involving `↑(Set.Icc x y)` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace

--- a/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
@@ -827,7 +827,6 @@ variable {g : ℍ → N} {h : E'' → ℍ} {k : ℍ → ℂ} {y : ℍ}
 
 /-- info: ContMDiff (modelWithCornersSelf Complex Complex) J 2 g : Prop -/
 #guard_msgs in
-variable {g : ℍ → M} in
 #check CMDiff 2 g
 
 /-- info: ContMDiff (modelWithCornersSelf Complex Complex) J 2 g : Prop -/

--- a/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
@@ -508,7 +508,19 @@ variable {E'' : Type*} [NormedAddCommGroup E''] [NormedSpace ℝ E''] {J : Model
   {N : Type} [TopologicalSpace N] [ChartedSpace H N] [IsManifold J 2 N]
 
 variable {g : unitInterval → M} in
-/-- info: MDifferentiable (modelWithCornersEuclideanHalfSpace 1) J g : Prop -/
+/--
+error: Application type mismatch: The argument
+  I
+has type
+  ModelWithCorners.{u_1, u_2, u_3} 𝕜 E H
+but is expected to have type
+  ModelWithCorners.{0, ?u.150, ?u.151} Real ?E' ?H'
+in the application
+  @MDifferentiable Real DenselyNormedField.toNontriviallyNormedField (EuclideanSpace Real (Fin 1))
+    (PiLp.normedAddCommGroup 2 fun x ↦ Real) (PiLp.normedSpace 2 Real fun x ↦ Real) (EuclideanHalfSpace 1)
+    (instTopologicalSpaceEuclideanHalfSpace 1) (modelWithCornersEuclideanHalfSpace 1) ?M ?inst✝ ?inst✝¹ ?E' ?inst✝²
+    ?inst✝³ ?H' ?inst✝⁴ I
+-/
 #guard_msgs in
 #check MDiff g
 
@@ -530,10 +542,17 @@ info: MDifferentiable (modelWithCornersEuclideanHalfSpace 1) (modelWithCornersSe
 variable {x y : ℝ} {g : Set.Icc x y → N} {h : E'' → Set.Icc x y} {k : Set.Icc x y → ℝ}
 
 /--
-error: failed to synthesize
-  ChartedSpace (EuclideanHalfSpace 1) ↑(Set.Icc 0 2)
-
-Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+error: Application type mismatch: The argument
+  I
+has type
+  ModelWithCorners.{u_1, u_2, u_3} 𝕜 E H
+but is expected to have type
+  ModelWithCorners.{0, ?u.176, ?u.177} Real ?E' ?H'
+in the application
+  @ContMDiff Real DenselyNormedField.toNontriviallyNormedField (EuclideanSpace Real (Fin 1))
+    (PiLp.normedAddCommGroup 2 fun x ↦ Real) (PiLp.normedSpace 2 Real fun x ↦ Real) (EuclideanHalfSpace 1)
+    (instTopologicalSpaceEuclideanHalfSpace 1) (modelWithCornersEuclideanHalfSpace 1) ?M ?inst✝ ?inst✝¹ ?E' ?inst✝²
+    ?inst✝³ ?H' ?inst✝⁴ I
 -/
 #guard_msgs in
 variable {g : Set.Icc (0 : ℝ) (2 : ℝ) → M} in
@@ -599,7 +618,21 @@ variable {α : Type*} [Preorder α] {x' y' : α} {k : ℝ → Set.Icc x' y'} in
 -- Now, with a fact about x < y: these should behave well.
 variable {x y : ℝ} [Fact (x < y)] {g : Set.Icc x y → N} {h : E'' → Set.Icc x y} {k : Set.Icc x y → ℝ}
 
-/-- info: MDifferentiable (modelWithCornersEuclideanHalfSpace 1) J g : Prop -/
+#where
+set_option trace.Elab.DiffGeo.MDiff true in
+/--
+error: Application type mismatch: The argument
+  I
+has type
+  ModelWithCorners.{u_1, u_2, u_3} 𝕜 E H
+but is expected to have type
+  ModelWithCorners.{0, ?u.203, ?u.204} Real ?E' ?H'
+in the application
+  @MDifferentiable Real DenselyNormedField.toNontriviallyNormedField (EuclideanSpace Real (Fin 1))
+    (PiLp.normedAddCommGroup 2 fun x ↦ Real) (PiLp.normedSpace 2 Real fun x ↦ Real) (EuclideanHalfSpace 1)
+    (instTopologicalSpaceEuclideanHalfSpace 1) (modelWithCornersEuclideanHalfSpace 1) ?M ?inst✝ ?inst✝¹ ?E' ?inst✝²
+    ?inst✝³ ?H' ?inst✝⁴ I
+-/
 #guard_msgs in
 variable [h: Fact ((0 : ℝ) < (2 : ℝ))] {g : Set.Icc (0 : ℝ) (2 : ℝ) → M} in
 #check MDiff g

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -1072,6 +1072,48 @@ Hint: failures to find a model with corners can be debugged with the command `se
 
 end
 
+/-! Inferring a model with corners from a local `IsManifold` assumption. -/
+section fromAssumption
+
+open scoped ContDiff
+
+variable {X Y : Type*} [TopologicalSpace X] [ChartedSpace ℝ X] [IsManifold 𝓘(ℝ) ω X]
+  [TopologicalSpace Y] [ChartedSpace ℝ Y] [IsManifold 𝓘(ℝ) ω Y] {f : X → Y}
+
+/--
+info: ContMDiff (modelWithCornersSelf Real Real) (modelWithCornersSelf Real Real) Top.top f : Prop
+-/
+#guard_msgs in
+#check CMDiff ω f
+
+variable {f : X → ℝ} in /--
+info: MDifferentiable (modelWithCornersSelf Real Real) (modelWithCornersSelf Real Real) f : Prop
+-/
+#guard_msgs in #check MDiff f
+
+variable {X : Type*} [TopologicalSpace X] [ChartedSpace F X] [IsManifold 𝓘(𝕜, F) ω X] {f : X → 𝕜} in
+/-- info: MDifferentiable (modelWithCornersSelf 𝕜 F) (modelWithCornersSelf 𝕜 𝕜) f : Prop -/
+#guard_msgs in
+#check MDiff f
+
+-- This even works when the model with corners would otherwise be ambiguous,
+-- such as on a product of two normed spaces.
+variable {X : Type*} [TopologicalSpace X] [ChartedSpace (F × F) X] [IsManifold 𝓘(𝕜, F × F) ω X] {f : X → 𝕜} in
+/--
+error: Could not find a model with corners for `X`.
+
+Hint: failures to find a model with corners can be debugged with the command `set_option trace.Elab.DiffGeo.MDiff true`.
+-/
+#guard_msgs in
+#check MDiff f
+
+-- When there are two such hypotheses in context, we pick the first one.
+-- (In practice, there should not be two conflicting ones.)
+-- TODO or should pick the last one instead?
+
+end fromAssumption
+#exit
+
 /-! Tests for the elaborators for `tangentMap(Within)` and `TangentSpace` -/
 section
 

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -1035,13 +1035,13 @@ open ContDiff in -- for the ∞ notation
 
 end
 
-/-! Inferring a model with corners on a normed space, for an `IsManifold` hypothesis -/
+/-! Inferring a model with corners on a normed space, even without an `IsManifold` hypothesis -/
 section
 
 open scoped ContDiff
 
-variable {X Y : Type*} [TopologicalSpace X] [ChartedSpace ℝ X] [IsManifold 𝓘(ℝ) ω X]
-  [TopologicalSpace Y] [ChartedSpace ℝ Y] [IsManifold 𝓘(ℝ) ω Y] {f : X → Y}
+variable {X Y : Type*} [TopologicalSpace X] [ChartedSpace ℝ X]
+  [TopologicalSpace Y] [ChartedSpace ℝ Y] {f : X → Y}
 
 /--
 info: ContMDiff (modelWithCornersSelf Real Real) (modelWithCornersSelf Real Real) Top.top f : Prop
@@ -1054,14 +1054,14 @@ info: MDifferentiable (modelWithCornersSelf Real Real) (modelWithCornersSelf Rea
 -/
 #guard_msgs in #check MDiff f
 
-variable {X : Type*} [TopologicalSpace X] [ChartedSpace F X] [IsManifold 𝓘(𝕜, F) ω X] {f : X → 𝕜} in
+variable {X : Type*} [TopologicalSpace X] [ChartedSpace F X] {f : X → 𝕜} in
 /-- info: MDifferentiable (modelWithCornersSelf 𝕜 F) (modelWithCornersSelf 𝕜 𝕜) f : Prop -/
 #guard_msgs in
 #check MDiff f
 
 -- This test is expected to fail: it passing would amount to guessing a model with corners on
 -- a product of two normed spaces (which is ambiguous).
-variable {X : Type*} [TopologicalSpace X] [ChartedSpace (F × F) X] [IsManifold 𝓘(𝕜, F × F) ω X] {f : X → 𝕜} in
+variable {X : Type*} [TopologicalSpace X] [ChartedSpace (F × F) X] {f : X → 𝕜} in
 /--
 error: Could not find a model with corners for `X`.
 

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -1077,6 +1077,8 @@ section fromAssumption
 
 open scoped ContDiff
 
+section
+
 variable {X Y : Type*} [TopologicalSpace X] [ChartedSpace ℝ X] [IsManifold 𝓘(ℝ) ω X]
   [TopologicalSpace Y] [ChartedSpace ℝ Y] [IsManifold 𝓘(ℝ) ω Y] {f : X → Y}
 
@@ -1103,14 +1105,30 @@ variable {X : Type*} [TopologicalSpace X] [ChartedSpace (F × F) X] [IsManifold 
 #guard_msgs in
 #check MDiff f
 
--- TODO: is there something else to copy over from the phrasebook test?
-
 -- When there are two such hypotheses in context, we pick the first one.
+-- This can lead to confusing error messages: TODO change this.
+-- Or should we pick the last hypothesis instead?
 -- (In practice, there should not be two conflicting ones.)
--- TODO or should pick the last one instead?
+set_option pp.mvars.anonymous false in
+variable [ChartedSpace (F × F) X] [IsManifold 𝓘(𝕜, F × F) ω X] {f : X → 𝕜} in
+/--
+error: Application type mismatch: The argument
+  modelWithCornersSelf 𝕜 𝕜
+has type
+  ModelWithCorners.{u_1, u_1, u_1} 𝕜 𝕜 𝕜
+but is expected to have type
+  ModelWithCorners.{0, _, _} Real ?E' ?H'
+in the application
+  @MDifferentiable Real DenselyNormedField.toNontriviallyNormedField Real Real.normedAddCommGroup
+    NormedField.toNormedSpace Real PseudoMetricSpace.toUniformSpace.toTopologicalSpace (modelWithCornersSelf Real Real)
+    ?M ?inst✝ ?inst✝¹ ?E' ?inst✝² ?inst✝³ ?H' ?inst✝⁴ (modelWithCornersSelf 𝕜 𝕜)
+-/
+#guard_msgs in
+#check MDiff f
+
+end
 
 end fromAssumption
-#exit
 
 /-! Tests for the elaborators for `tangentMap(Within)` and `TangentSpace` -/
 section

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -1476,6 +1476,9 @@ variable {f : Unit → Unit}
 error: Could not find a model with corners for `Unit`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `Unit`
+[Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] Failed with error:
+      Couldn't find an `IsManifold` hypothesis involving `Unit` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
   [Elab.DiffGeo.MDiff] Failed with error:
       `Unit` is not a `Bundle.TotalSpace`.

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -1099,13 +1099,11 @@ variable {X : Type*} [TopologicalSpace X] [ChartedSpace F X] [IsManifold 𝓘(�
 -- This even works when the model with corners would otherwise be ambiguous,
 -- such as on a product of two normed spaces.
 variable {X : Type*} [TopologicalSpace X] [ChartedSpace (F × F) X] [IsManifold 𝓘(𝕜, F × F) ω X] {f : X → 𝕜} in
-/--
-error: Could not find a model with corners for `X`.
-
-Hint: failures to find a model with corners can be debugged with the command `set_option trace.Elab.DiffGeo.MDiff true`.
--/
+/-- info: MDifferentiable (modelWithCornersSelf 𝕜 (Prod F F)) (modelWithCornersSelf 𝕜 𝕜) f : Prop -/
 #guard_msgs in
 #check MDiff f
+
+-- TODO: is there something else to copy over from the phrasebook test?
 
 -- When there are two such hypotheses in context, we pick the first one.
 -- (In practice, there should not be two conflicting ones.)

--- a/MathlibTest/DifferentialGeometry/Notation/Sphere.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Sphere.lean
@@ -186,6 +186,9 @@ variable [Fact (Module.finrank ℝ E = 3)] in
 error: Could not find a model with corners for `↑(Metric.sphere 0 1)`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `↑(Metric.sphere 0 1)`
+[Elab.DiffGeo.MDiff] 💥️ instance assumption
+  [Elab.DiffGeo.MDiff] Failed with error:
+      Couldn't find an `IsManifold` hypothesis involving `↑(Metric.sphere 0 1)` among local instances.
 [Elab.DiffGeo.MDiff] 💥️ TotalSpace
   [Elab.DiffGeo.MDiff] Failed with error:
       `↑(Metric.sphere 0 1)` is not a `Bundle.TotalSpace`.


### PR DESCRIPTION
In the differential geometry elaborators, search for an `IsManifold` hypothesis first.
If we have an explicit IsManifold hypothesis in the local context, we almost definitely want to use it.

This seems logical at first glance, but is more subtle on second thought: what should we do, for instance,
if the local context has several such hypotheses? This may be desired, but needs more thought for sure.

It is also worth noting that the current elaborators seem to work well enough, so it's not clear how pressing the need for this is. (The original cases motivating this branch have been solved.)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
