### PR TITLE
[Merged by Bors] - feat: `HasSmallInductiveDimensionLT` is monotonic

### DIFF
--- a/Mathlib/Topology/SmallInductiveDimension.lean
+++ b/Mathlib/Topology/SmallInductiveDimension.lean
@@ -79,4 +79,25 @@ lemma hasSmallInductiveDimensionLT_one_iff :
 @[deprecated (since := "2026-06-21")]
 alias HasSmallInductiveDimensionLT_one_iff := hasSmallInductiveDimensionLT_one_iff
 
-end
+theorem HasSmallInductiveDimensionLT.mono {m n : ℕ} (hmn : m ≤ n)
+    (H : HasSmallInductiveDimensionLT X m) : HasSmallInductiveDimensionLT X n := by
+  induction n generalizing m X with
+  | zero => simp_all
+  | succ m IH =>
+    cases H with
+    | zero => exact .succ _ ∅ (by simpa) (by simp)
+    | succ n s hs h =>
+      refine .succ _ s hs fun U hU ↦ IH ?_ (h U hU)
+      rwa [add_le_add_iff_right] at hmn
+
+theorem HasSmallInductiveDimensionLE.mono {m n : ℕ} (hmn : m ≤ n)
+    (H : HasSmallInductiveDimensionLE X m) : HasSmallInductiveDimensionLE X n := by
+  apply HasSmallInductiveDimensionLT.mono _ H
+  rwa [add_le_add_iff_right]
+
+theorem HasSmallInductiveDimensionLT.hasSmallInductiveDimensionLE {n : ℕ}
+    (H : HasSmallInductiveDimensionLT X n) : HasSmallInductiveDimensionLE X n :=
+  HasSmallInductiveDimensionLT.mono n.le_succ H
+
+instance (n : ℕ) [IsEmpty X] : HasSmallInductiveDimensionLT X n :=
+  .mono zero_le <| hasSmallInductiveDimensionLT_zero_iff.2 ‹_›


### PR DESCRIPTION
We prove that `HasSmallInductiveDimensionLT m` implies `HasSmallInductiveDimensionLT n` whenever `m ≤ n`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
