### PR TITLE
[Merged by Bors] - feat: add isCoprime_of_not_zeta_sub_one_dvd and related lemmas

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean
@@ -187,6 +187,10 @@ end CharZero
 
 lemma coe_toInteger {k : ℕ} [NeZero k] (hζ : IsPrimitiveRoot ζ k) : hζ.toInteger.1 = ζ := rfl
 
+@[simp]
+lemma toInteger_coe {k : ℕ} [NeZero k] {x : 𝓞 K} (hx : IsPrimitiveRoot (x : K) k) :
+    hx.toInteger = x := rfl
+
 /-- `𝓞 K ⧸ Ideal.span {ζ - 1}` is finite. -/
 lemma finite_quotient_toInteger_sub_one [NumberField K] {k : ℕ} (hk : 1 < k)
     (hζ : IsPrimitiveRoot ζ k) :

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -182,6 +182,42 @@ instance isPrime_span_zeta_sub_one' : IsPrime (span {hζ.toInteger - 1}) := by
   rw [← pow_one p] at hK hζ
   exact isPrime_span_zeta_sub_one p 0 hζ
 
+/-- If `2 < p`, then `2` is not in the ideal `(ζ - 1)`, where `ζ` is a primitive `p`-th root of
+unity. -/
+theorem two_not_mem_span_zeta_sub_one' (h : 2 < p) : (2 : 𝓞 K) ∉ span {hζ.toInteger - 1} := by
+  rw [Ideal.mem_span_singleton]
+  rw [← pow_one p] at hK hζ
+  exact hζ.toInteger_sub_one_not_dvd_two h.ne'
+
+omit [NumberField K] hK in
+open Polynomial in
+/-- `(ζ - 1) ^ (p - 1)` is associated to `p`, where `ζ` is a primitive `p`-th root of unity and
+`p` is prime. -/
+theorem associated_zeta_sub_one_pow_prime :
+    Associated ((hζ.toInteger - 1) ^ (p - 1)) (p : 𝓞 K) := by
+  rw [← eval_one_cyclotomic_prime (R := 𝓞 K) (p := p),
+    cyclotomic_eq_prod_X_sub_primitiveRoots hζ.toInteger_isPrimitiveRoot, eval_prod]
+  simp only [eval_sub, eval_X, eval_C]
+  rw [← Nat.totient_prime hp.out, ← hζ.toInteger_isPrimitiveRoot.card_primitiveRoots,
+    ← Finset.prod_const]
+  apply Associated.prod
+  intro η hη
+  refine hζ.toInteger_isPrimitiveRoot.ntRootsFinset_pairwise_associated_sub_one_sub_of_prime
+    hp.out (one_mem_nthRootsFinset hp.out.pos) ?_ ?_
+  · exact (isPrimitiveRoot_of_mem_primitiveRoots hη).mem_nthRootsFinset hp.out.pos
+  · exact ((isPrimitiveRoot_of_mem_primitiveRoots hη).ne_one hp.out.one_lt).symm
+
+/-- If `ζ - 1` does not divide `x`, then `p` and `x` are coprime, where `ζ` is a primitive `p`-th
+root of unity and `p` is prime. -/
+theorem isCoprime_of_not_zeta_sub_one_dvd {x : 𝓞 K} (hx : ¬ hζ.toInteger - 1 ∣ x) :
+    IsCoprime (p : 𝓞 K) x := by
+  rwa [← Ideal.isCoprime_span_singleton_iff,
+    ← Ideal.span_singleton_eq_span_singleton.mpr (associated_zeta_sub_one_pow_prime p hζ),
+    ← Ideal.span_singleton_pow, IsCoprime.pow_left_iff, Ideal.isCoprime_iff_gcd,
+    (Ideal.prime_span_singleton_iff.mpr hζ.zeta_sub_one_prime').irreducible.gcd_eq_one_iff,
+    Ideal.dvd_span_singleton, Ideal.mem_span_singleton]
+  · simpa only [ge_iff_le, tsub_pos_iff_lt] using hp.out.one_lt
+
 theorem inertiaDeg_span_zeta_sub_one' : inertiaDeg' (span {hζ.toInteger - 1}) ℤ = 1 := by
   rw [← pow_one p] at hK hζ
   exact inertiaDeg_span_zeta_sub_one p 0 hζ

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -208,8 +208,7 @@ theorem associated_zeta_sub_one_pow_prime :
   simp only [eval_sub, eval_X, eval_C]
   rw [← Nat.totient_prime hp.out, ← hζ.toInteger_isPrimitiveRoot.card_primitiveRoots,
     ← Finset.prod_const]
-  apply Associated.prod
-  intro η hη
+  refine Associated.prod _ _ _ fun η hη ↦ ?_
   have hη' : IsPrimitiveRoot (η : K) p :=
     (isPrimitiveRoot_of_mem_primitiveRoots hη).map_of_injective RingOfIntegers.coe_injective
   have hηtoInteger : hη'.toInteger = η := RingOfIntegers.ext rfl

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -193,10 +193,7 @@ omit hp hK [NumberField K] in
 lemma associated_one_sub_of_isPrimitiveRoot [NeZero p] {η : K} (hη : IsPrimitiveRoot η p) :
     Associated (1 - hζ.toInteger) (1 - hη.toInteger) := by
   obtain ⟨i, -, hi, hζη⟩ := hζ.isPrimitiveRoot_iff.mp hη
-  have htoInteger : hη.toInteger = hζ.toInteger ^ i := by
-    apply RingOfIntegers.ext
-    exact hζη.symm
-  rw [htoInteger]
+  rw [show hη.toInteger = hζ.toInteger ^ i from RingOfIntegers.ext hζη.symm]
   simpa only [neg_sub] using
     (hζ.toInteger_isPrimitiveRoot.associated_sub_one_pow_sub_one_of_coprime hi).neg_left.neg_right
 

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -47,9 +47,9 @@ namespace IsCyclotomicExtension.Rat
 open Ideal NumberField RingOfIntegers
 
 variable (n m p k : ℕ) [hp : Fact (Nat.Prime p)] (K : Type*) [Field K] [NumberField K]
-  (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver (Ideal.span {(p : ℤ)})]
+  (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver (span {(p : ℤ)})]
 
-local notation3 "𝒑" => (Ideal.span {(p : ℤ)})
+local notation3 "𝒑" => (span {(p : ℤ)})
 
 section PrimePow
 
@@ -57,7 +57,7 @@ variable {K} [hK : IsCyclotomicExtension {p ^ (k + 1)} ℚ K] {ζ : K}
   (hζ : IsPrimitiveRoot ζ (p ^ (k + 1)))
 
 instance isPrime_span_zeta_sub_one : IsPrime (span {hζ.toInteger - 1}) := by
-  rw [Ideal.span_singleton_prime]
+  rw [span_singleton_prime]
   · exact hζ.zeta_sub_one_prime
   · exact Prime.ne_zero hζ.zeta_sub_one_prime
 
@@ -77,7 +77,7 @@ theorem absNorm_span_zeta_sub_one : absNorm (span {hζ.toInteger - 1}) = p := by
     span_singleton_eq_span_singleton.mpr <| associated_norm_zeta_sub_one p k hζ
 
 theorem p_mem_span_zeta_sub_one : (p : 𝓞 K) ∈ span {hζ.toInteger - 1} := by
-  convert! Ideal.absNorm_mem _
+  convert! absNorm_mem _
   exact (absNorm_span_zeta_sub_one ..).symm
 
 theorem span_zeta_sub_one_ne_bot : span {hζ.toInteger - 1} ≠ ⊥ :=
@@ -85,7 +85,7 @@ theorem span_zeta_sub_one_ne_bot : span {hζ.toInteger - 1} ≠ ⊥ :=
 
 instance liesOver_span_zeta_sub_one : (span {hζ.toInteger - 1}).LiesOver 𝒑 := by
   rw [liesOver_iff]
-  refine Ideal.IsMaximal.eq_of_le (Int.ideal_span_isMaximal_of_prime p) IsPrime.ne_top' ?_
+  refine IsMaximal.eq_of_le (Int.ideal_span_isMaximal_of_prime p) IsPrime.ne_top' ?_
   rw [span_singleton_le_iff_mem, mem_comap, algebraMap_int_eq, map_natCast]
   exact p_mem_span_zeta_sub_one p k hζ
 
@@ -185,7 +185,7 @@ instance isPrime_span_zeta_sub_one' : IsPrime (span {hζ.toInteger - 1}) := by
 /-- If `2 < p`, then `2` is not in the ideal `(ζ - 1)`, where `ζ` is a primitive `p`-th root of
 unity. -/
 theorem two_not_mem_span_zeta_sub_one' (h : 2 < p) : (2 : 𝓞 K) ∉ span {hζ.toInteger - 1} := by
-  rw [Ideal.mem_span_singleton]
+  rw [mem_span_singleton]
   rw [← pow_one p] at hK hζ
   exact hζ.toInteger_sub_one_not_dvd_two h.ne'
 
@@ -223,12 +223,10 @@ theorem associated_zeta_sub_one_pow_prime :
 root of unity and `p` is prime. -/
 theorem isCoprime_of_not_zeta_sub_one_dvd {x : 𝓞 K} (hx : ¬ hζ.toInteger - 1 ∣ x) :
     IsCoprime (p : 𝓞 K) x := by
-  rwa [← Ideal.isCoprime_span_singleton_iff,
-    ← Ideal.span_singleton_eq_span_singleton.mpr (associated_zeta_sub_one_pow_prime p hζ),
-    ← Ideal.span_singleton_pow, IsCoprime.pow_left_iff (by grind [hp.out.one_lt]),
-    Ideal.isCoprime_iff_gcd,
-    (Ideal.prime_span_singleton_iff.mpr hζ.zeta_sub_one_prime').irreducible.gcd_eq_one_iff,
-    Ideal.dvd_span_singleton, Ideal.mem_span_singleton]
+  rwa [← isCoprime_span_singleton_iff,  ← span_singleton_eq_span_singleton.mpr
+    (associated_zeta_sub_one_pow_prime p hζ), ← span_singleton_pow, IsCoprime.pow_left_iff
+    (by grind [hp.out.one_lt]), isCoprime_iff_gcd, (prime_span_singleton_iff.mpr
+    hζ.zeta_sub_one_prime').irreducible.gcd_eq_one_iff, dvd_span_singleton, mem_span_singleton]
 
 theorem inertiaDeg_span_zeta_sub_one' : inertiaDeg' (span {hζ.toInteger - 1}) ℤ = 1 := by
   rw [← pow_one p] at hK hζ

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -196,11 +196,6 @@ lemma associated_sub_one_of_isPrimitiveRoot [NeZero p] {η : K} (hη : IsPrimiti
   rw [show hη.toInteger = hζ.toInteger ^ i from RingOfIntegers.ext hζη.symm]
   exact hζ.toInteger_isPrimitiveRoot.associated_sub_one_pow_sub_one_of_coprime hi
 
-@[deprecated "The statement has been changed to use the `ζ - 1` spelling rather than `1 - ζ`, \
-for consistency with the rest of the API, so the type is now different. \
-Use `associated_sub_one_of_isPrimitiveRoot` instead." (since := "2026-06-23")]
-alias associated_one_sub_of_isPrimitiveRoot := associated_sub_one_of_isPrimitiveRoot
-
 omit [NumberField K] hK in
 open Polynomial in
 /-- `(ζ - 1) ^ (p - 1)` is associated to `p`, where `ζ` is a primitive `p`-th root of unity and

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -190,12 +190,16 @@ theorem two_not_mem_span_zeta_sub_one' (h : 2 < p) : (2 : 𝓞 K) ∉ span {hζ.
   exact hζ.toInteger_sub_one_not_dvd_two h.ne'
 
 omit hp hK [NumberField K] in
-lemma associated_one_sub_of_isPrimitiveRoot [NeZero p] {η : K} (hη : IsPrimitiveRoot η p) :
-    Associated (1 - hζ.toInteger) (1 - hη.toInteger) := by
+lemma associated_sub_one_of_isPrimitiveRoot [NeZero p] {η : K} (hη : IsPrimitiveRoot η p) :
+    Associated (hζ.toInteger - 1) (hη.toInteger - 1) := by
   obtain ⟨i, -, hi, hζη⟩ := hζ.isPrimitiveRoot_iff.mp hη
   rw [show hη.toInteger = hζ.toInteger ^ i from RingOfIntegers.ext hζη.symm]
-  simpa only [neg_sub] using
-    (hζ.toInteger_isPrimitiveRoot.associated_sub_one_pow_sub_one_of_coprime hi).neg_left.neg_right
+  exact hζ.toInteger_isPrimitiveRoot.associated_sub_one_pow_sub_one_of_coprime hi
+
+@[deprecated "The statement has been changed to use the `ζ - 1` spelling rather than `1 - ζ`, \
+for consistency with the rest of the API, so the type is now different. \
+Use `associated_sub_one_of_isPrimitiveRoot` instead." (since := "2026-06-23")]
+alias associated_one_sub_of_isPrimitiveRoot := associated_sub_one_of_isPrimitiveRoot
 
 omit [NumberField K] hK in
 open Polynomial in
@@ -211,7 +215,7 @@ theorem associated_zeta_sub_one_pow_prime :
   refine Associated.prod _ _ _ fun η hη ↦ ?_
   have hη' : IsPrimitiveRoot (η : K) p :=
     (isPrimitiveRoot_of_mem_primitiveRoots hη).map_of_injective RingOfIntegers.coe_injective
-  simpa using (associated_one_sub_of_isPrimitiveRoot p hζ hη').neg_left
+  simpa using (associated_sub_one_of_isPrimitiveRoot p hζ hη').neg_right
 
 /-- If `ζ - 1` does not divide `x`, then `p` and `x` are coprime, where `ζ` is a primitive `p`-th
 root of unity and `p` is prime. -/

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -220,8 +220,9 @@ root of unity and `p` is prime. -/
 theorem isCoprime_of_not_zeta_sub_one_dvd {x : 𝓞 K} (hx : ¬ hζ.toInteger - 1 ∣ x) :
     IsCoprime (p : 𝓞 K) x := by
   rwa [← isCoprime_span_singleton_iff,  ← span_singleton_eq_span_singleton.mpr
-    (associated_zeta_sub_one_pow_prime p hζ), ← span_singleton_pow, IsCoprime.pow_left_iff
-    (by grind [hp.out.one_lt]), isCoprime_iff_gcd, (prime_span_singleton_iff.mpr
+    (associated_zeta_sub_one_pow_prime p hζ), ← span_singleton_pow,
+    IsCoprime.pow_left_iff (by grind [hp.out.one_lt]), isCoprime_iff_gcd,
+    (prime_span_singleton_iff.mpr
     hζ.zeta_sub_one_prime').irreducible.gcd_eq_one_iff, dvd_span_singleton, mem_span_singleton]
 
 theorem inertiaDeg_span_zeta_sub_one' : inertiaDeg' (span {hζ.toInteger - 1}) ℤ = 1 := by

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -211,9 +211,7 @@ theorem associated_zeta_sub_one_pow_prime :
   refine Associated.prod _ _ _ fun η hη ↦ ?_
   have hη' : IsPrimitiveRoot (η : K) p :=
     (isPrimitiveRoot_of_mem_primitiveRoots hη).map_of_injective RingOfIntegers.coe_injective
-  have hηtoInteger : hη'.toInteger = η := RingOfIntegers.ext rfl
-  simpa only [hηtoInteger, neg_sub] using
-    (associated_one_sub_of_isPrimitiveRoot p hζ hη').neg_left
+  simpa using (associated_one_sub_of_isPrimitiveRoot p hζ hη').neg_left
 
 /-- If `ζ - 1` does not divide `x`, then `p` and `x` are coprime, where `ζ` is a primitive `p`-th
 root of unity and `p` is prime. -/

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -225,10 +225,10 @@ theorem isCoprime_of_not_zeta_sub_one_dvd {x : 𝓞 K} (hx : ¬ hζ.toInteger - 
     IsCoprime (p : 𝓞 K) x := by
   rwa [← Ideal.isCoprime_span_singleton_iff,
     ← Ideal.span_singleton_eq_span_singleton.mpr (associated_zeta_sub_one_pow_prime p hζ),
-    ← Ideal.span_singleton_pow, IsCoprime.pow_left_iff, Ideal.isCoprime_iff_gcd,
+    ← Ideal.span_singleton_pow, IsCoprime.pow_left_iff (by grind [hp.out.one_lt]),
+    Ideal.isCoprime_iff_gcd,
     (Ideal.prime_span_singleton_iff.mpr hζ.zeta_sub_one_prime').irreducible.gcd_eq_one_iff,
     Ideal.dvd_span_singleton, Ideal.mem_span_singleton]
-  · simpa only [ge_iff_le, tsub_pos_iff_lt] using hp.out.one_lt
 
 theorem inertiaDeg_span_zeta_sub_one' : inertiaDeg' (span {hζ.toInteger - 1}) ℤ = 1 := by
   rw [← pow_one p] at hK hζ

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -189,6 +189,17 @@ theorem two_not_mem_span_zeta_sub_one' (h : 2 < p) : (2 : 𝓞 K) ∉ span {hζ.
   rw [← pow_one p] at hK hζ
   exact hζ.toInteger_sub_one_not_dvd_two h.ne'
 
+omit hp hK [NumberField K] in
+lemma associated_one_sub_of_isPrimitiveRoot [NeZero p] {η : K} (hη : IsPrimitiveRoot η p) :
+    Associated (1 - hζ.toInteger) (1 - hη.toInteger) := by
+  obtain ⟨i, -, hi, hζη⟩ := hζ.isPrimitiveRoot_iff.mp hη
+  have htoInteger : hη.toInteger = hζ.toInteger ^ i := by
+    apply RingOfIntegers.ext
+    exact hζη.symm
+  rw [htoInteger]
+  simpa only [neg_sub] using
+    (hζ.toInteger_isPrimitiveRoot.associated_sub_one_pow_sub_one_of_coprime hi).neg_left.neg_right
+
 omit [NumberField K] hK in
 open Polynomial in
 /-- `(ζ - 1) ^ (p - 1)` is associated to `p`, where `ζ` is a primitive `p`-th root of unity and
@@ -202,10 +213,11 @@ theorem associated_zeta_sub_one_pow_prime :
     ← Finset.prod_const]
   apply Associated.prod
   intro η hη
-  refine hζ.toInteger_isPrimitiveRoot.ntRootsFinset_pairwise_associated_sub_one_sub_of_prime
-    hp.out (one_mem_nthRootsFinset hp.out.pos) ?_ ?_
-  · exact (isPrimitiveRoot_of_mem_primitiveRoots hη).mem_nthRootsFinset hp.out.pos
-  · exact ((isPrimitiveRoot_of_mem_primitiveRoots hη).ne_one hp.out.one_lt).symm
+  have hη' : IsPrimitiveRoot (η : K) p :=
+    (isPrimitiveRoot_of_mem_primitiveRoots hη).map_of_injective RingOfIntegers.coe_injective
+  have hηtoInteger : hη'.toInteger = η := RingOfIntegers.ext rfl
+  simpa only [hηtoInteger, neg_sub] using
+    (associated_one_sub_of_isPrimitiveRoot p hζ hη').neg_left
 
 /-- If `ζ - 1` does not divide `x`, then `p` and `x` are coprime, where `ζ` is a primitive `p`-th
 root of unity and `p` is prime. -/

--- a/Mathlib/RingTheory/RootsOfUnity/CyclotomicUnits.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/CyclotomicUnits.lean
@@ -120,8 +120,7 @@ theorem associated_pow_add_sub_sub_one (hζ : IsPrimitiveRoot ζ n) (hn : 2 ≤ 
   associated for all distinct `p`-th roots of unity `η₁` and `η₂`. -/
 lemma nthRootsFinset_pairwise_associated_sub_one_sub_of_prime (hζ : IsPrimitiveRoot ζ p)
     (hp : p.Prime) :
-    Set.Pairwise (nthRootsFinset p (1 : A)) (fun η₁ η₂ ↦ Associated (ζ - 1) (η₁ - η₂)) :=
-  by
+    Set.Pairwise (nthRootsFinset p (1 : A)) fun η₁ η₂ ↦ Associated (ζ - 1) (η₁ - η₂) := by
   intro η₁ hη₁ η₂ hη₂ e
   have : NeZero p := ⟨hp.ne_zero⟩
   obtain ⟨i, hi, rfl⟩ := hζ.eq_pow_of_pow_eq_one ((Polynomial.mem_nthRootsFinset hp.pos 1).1 hη₁)

--- a/Mathlib/RingTheory/RootsOfUnity/CyclotomicUnits.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/CyclotomicUnits.lean
@@ -118,20 +118,23 @@ theorem associated_pow_add_sub_sub_one (hζ : IsPrimitiveRoot ζ n) (hn : 2 ≤ 
 
 /-- If `p` is prime and `ζ` is a `p`-th primitive root of unity, then `ζ - 1` and `η₁ - η₂` are
   associated for all distinct `p`-th roots of unity `η₁` and `η₂`. -/
-lemma ntRootsFinset_pairwise_associated_sub_one_sub_of_prime (hζ : IsPrimitiveRoot ζ p)
+lemma nthRootsFinset_pairwise_associated_sub_one_sub_of_prime (hζ : IsPrimitiveRoot ζ p)
     (hp : p.Prime) :
-    Set.Pairwise (nthRootsFinset p (1 : A)) (fun η₁ η₂ ↦ Associated (ζ - 1) (η₁ - η₂)) := by
+    Set.Pairwise (nthRootsFinset p (1 : A)) (fun η₁ η₂ ↦ Associated (ζ - 1) (η₁ - η₂)) :=
+  by
   intro η₁ hη₁ η₂ hη₂ e
   have : NeZero p := ⟨hp.ne_zero⟩
-  obtain ⟨i, hi, rfl⟩ :=
-    hζ.eq_pow_of_pow_eq_one ((Polynomial.mem_nthRootsFinset hp.pos 1).1 hη₁)
-  obtain ⟨j, hj, rfl⟩ :=
-    hζ.eq_pow_of_pow_eq_one ((Polynomial.mem_nthRootsFinset hp.pos 1).1 hη₂)
+  obtain ⟨i, hi, rfl⟩ := hζ.eq_pow_of_pow_eq_one ((Polynomial.mem_nthRootsFinset hp.pos 1).1 hη₁)
+  obtain ⟨j, hj, rfl⟩ := hζ.eq_pow_of_pow_eq_one ((Polynomial.mem_nthRootsFinset hp.pos 1).1 hη₂)
   wlog hij : j ≤ i
   · simpa using (this hζ ‹_› ‹_› _ hj ‹_› _ hi ‹_› e.symm (by lia)).neg_right
   have H : (i - j).Coprime p := (coprime_of_lt_prime (by grind) (by grind) hp).symm
   obtain ⟨u, h⟩ := hζ.associated_pow_add_sub_sub_one hp.two_le j H
   simp only [hij, add_tsub_cancel_of_le] at h
   rw [← h, associated_mul_unit_right_iff]
+
+@[deprecated (since := "2026-06-23")]
+alias ntRootsFinset_pairwise_associated_sub_one_sub_of_prime :=
+  nthRootsFinset_pairwise_associated_sub_one_sub_of_prime
 
 end IsPrimitiveRoot


### PR DESCRIPTION
From flt-regular.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
