### PR TITLE
[Merged by Bors] - chore(cache): stop dual-writing the cache to the legacy container

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -694,21 +694,8 @@ jobs:
           # $MATHLIB_CACHE_PRIMARY is set by the `Compute cache trust dispatch`
           # step above, from the shared composite action that owns the (repo,
           # branch) → container mapping for both this job and the read-side
-          # jobs (build, post_steps).
-          # Dual-write to the legacy `mathlib4` container first, then the
-          # primary. Only master CI dual-writes: older cache tools read only
-          # `legacy`, so it must stay fresh for them, while forks and nightly
-          # never write `legacy` (keeping low-trust artifacts out of what those
-          # readers trust). Writing `legacy` first keeps it a superset of
-          # `master` for as long as we dual-write: with `set -e`, a failed
-          # legacy write aborts the step before `master` gets artifacts that
-          # `legacy` lacks. (`put-staged` exits non-zero on real upload
-          # failures; already-present 409/412 blobs are not failures.)
-          if [ "$MATHLIB_CACHE_PRIMARY" = "master" ]; then
-            echo "Dual-writing to legacy container first (keeps legacy a superset of master)..."
-            lake env "$CACHE_BIN" put-staged --container=legacy --staging-dir="cache-staging" --repo="$REPO"
-          fi
-
+          # jobs (build, post_steps). Each job writes only into its own trust-level
+          # container.
           echo "Uploading cache to Azure (container: $MATHLIB_CACHE_PRIMARY)..."
           lake env "$CACHE_BIN" put-staged --container="$MATHLIB_CACHE_PRIMARY" --staging-dir="cache-staging" --repo="$REPO"
 

--- a/Cache/Infra.lean
+++ b/Cache/Infra.lean
@@ -51,10 +51,11 @@ inductive Container where
   | nightlyTesting
   /-- Container for toolchain-PR test runs. -/
   | prToolchainTests
-  /-- The bare `mathlib4` container that older cache clients read from. Only
-  master CI writes here (mirroring its `mathlib4-master` upload), so those
-  clients keep finding master-built artifacts; forks and nightly-testing stay
-  out to keep low-trust writes from reaching readers that predate the split. -/
+  /-- The bare `mathlib4` container that older cache clients read from. CI does
+  not upload here; it is a read-only store of the master-built artifacts that
+  were mirrored from `mathlib4-master`, kept reachable so those older clients
+  can resolve them. The `master` container is a self-contained cache, so reads
+  fall back to `legacy` only for artifacts predating the write cutover. -/
   | legacy
   deriving DecidableEq, Repr, BEq, Inhabited
 


### PR DESCRIPTION
With this PR, master CI now uploads only to the `master` container, and the `legacy` (bare `mathlib4`) container stays as a read-only endpoint for pre-refactor artifacts.