### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Sites/Spaces): relate `IsOpenCover` and `GrothendieckTopology.CoversTop`

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Spaces.lean
+++ b/Mathlib/CategoryTheory/Sites/Spaces.lean
@@ -5,10 +5,10 @@ Authors: Bhavik Mehta
 -/
 module
 
-public import Mathlib.CategoryTheory.Sites.Grothendieck
+public import Mathlib.CategoryTheory.Sites.CoversTop.Basic
 public import Mathlib.CategoryTheory.Sites.Pretopology
 public import Mathlib.CategoryTheory.Limits.Lattice
-public import Mathlib.Topology.Sets.Opens
+public import Mathlib.Topology.Sets.OpenCover
 
 /-!
 # Grothendieck topology on a topological space
@@ -95,5 +95,17 @@ theorem pretopology_toGrothendieck :
     (Opens.pretopology T).toGrothendieck = Opens.grothendieckTopology T := by
   rw [← toPretopology_grothendieckTopology]
   apply (Pretopology.gi (Opens T)).l_u_eq
+
+lemma coversTop_iff {ι : Type*} (U : ι → Opens T) :
+    (grothendieckTopology T).CoversTop U ↔ IsOpenCover U := by
+  rw [GrothendieckTopology.coversTop_iff_of_isTerminal _ ⊤ isTerminalTop]
+  dsimp [Opens.grothendieckTopology]
+  simp only [IsOpenCover, eq_top_iff, SetLike.le_def, exists_and_right, Opens.mem_top,
+    Opens.mem_iSup, forall_const]
+  refine ⟨fun h x ↦ ?_, fun hU x hx ↦ ?_⟩
+  · obtain ⟨V, ⟨u, ⟨i, ⟨hi⟩⟩⟩, hx⟩ := h x trivial
+    use i, leOfHom hi hx
+  · obtain ⟨i, hi⟩ := hU (x := x)
+    exact ⟨U i, ⟨homOfLE le_top, ⟨i, ⟨𝟙 _⟩⟩⟩, hi⟩
 
 end Opens

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -49,6 +49,7 @@ We define order structures on both `Opens α` (`CompleteLattice`, `Frame`) and `
 
 @[expose] public section
 
+universe u
 
 open Filter Function Order Set
 
@@ -344,6 +345,14 @@ theorem isBasis_iff_cover {B : Set (Opens α)} :
     rcases h U with ⟨Us, hUs, rfl⟩
     rcases mem_sSup.1 hx with ⟨U, Us, xU⟩
     exact ⟨U, hUs Us, xU, le_sSup Us⟩
+
+lemma IsBasis.exists_iSup_eq {X : Type u} [TopologicalSpace X] {ι : Type*}
+    {U : ι → TopologicalSpace.Opens X} (hU : TopologicalSpace.Opens.IsBasis (Set.range U))
+    (W : TopologicalSpace.Opens X) : ∃ (κ : Type u) (a : κ → ι), W = ⨆ (k : κ), U (a k) := by
+  obtain ⟨Us, hsub, hUs⟩ := Opens.isBasis_iff_cover.mp hU W
+  choose a ha using hsub
+  use Us, fun i ↦ a i.2
+  simp [hUs, ha, sSup_eq_iSup' Us]
 
 /-- If `α` has a basis consisting of compact opens, then an open set in `α` is compact open iff
   it is a finite union of some elements in the basis -/


### PR DESCRIPTION
We also add a lemma about `TopologicalSpace.Opens.IsBasis`, which is not directly related but also used in #40052.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I think the import increases is fine, but I am happy to move the lemma to a new file if someone tells me to.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
