### PR TITLE
[Merged by Bors] - fix(Translate): preserve binder names when reordering lambdas

### DIFF
--- a/Mathlib/Tactic/Translate/Reorder.lean
+++ b/Mathlib/Tactic/Translate/Reorder.lean
@@ -213,15 +213,13 @@ partial def reorderForall (reorder : ArgReorder) (e : Expr) : MetaM Expr := do
 
 /-- Reorder the arguments of a function using the given `ArgReorder`. -/
 partial def reorderLambda (reorder : ArgReorder) (e : Expr) : MetaM Expr := do
-  let (mvars, bis, e) ← lambdaMetaTelescope e reorder.range
-  let (mvars', bis', _) ← forallMetaBoundedTelescope (← inferType e) (reorder.range - mvars.size)
-  let mut mvars := mvars ++ mvars'
+  let (mvars, bis, _) ← forallMetaBoundedTelescope (← inferType e) reorder.range
   unless mvars.size = reorder.range do
     throwError "the permutation (reorder := {reorder}) is out of bounds, \
       the function{indentExpr e}\nhas only {mvars.size} arguments"
-  let bis := reorder.permute! (bis ++ bis') |>.toList
+  let bis := reorder.permute! bis |>.toList
   -- Note that `mkLambdaFVars` also works with mvars.
-  fixBinderInfos bis <$> mkLambdaFVars (← reorderMVars mvars reorder) (mkAppN e mvars')
+  fixBinderInfos bis <$> mkLambdaFVars (← reorderMVars mvars reorder) (e.beta mvars)
 
 end
 

--- a/MathlibTest/Attribute/ToDual.lean
+++ b/MathlibTest/Attribute/ToDual.lean
@@ -55,16 +55,17 @@ def SemilatticeSup.casesOn' {α} {motive : SemilatticeSup α → Sort*} (t : Sem
   t.casesOn mk
 
 /--
-info: SemilatticeInf.casesOn'.{u_1} {α : Type} {motive : SemilatticeInf α → Sort u_1}
-  (mk :
-    [inst : Min α] →
-      [inst_1 : PartialOrder α] →
-        (sup_le : ∀ (b a c : α), c ≤ a → c ≤ b → c ≤ a ⊓ b) →
-          motive { toPartialOrder := inst_1, toMin := inst, le_inf := ⋯ })
-  (t : SemilatticeInf α) : motive t
+info: @[expose] def SemilatticeInf.casesOn'.{u_1} : {α : Type} →
+  {motive : SemilatticeInf α → Sort u_1} →
+    ([inst : Min α] →
+        [inst_1 : PartialOrder α] →
+          (sup_le : ∀ (b a c : α), c ≤ a → c ≤ b → c ≤ a ⊓ b) →
+            motive { toPartialOrder := inst_1, toMin := inst, le_inf := ⋯ }) →
+      (t : SemilatticeInf α) → motive t :=
+fun {α} {motive} mk t => SemilatticeInf.casesOn t fun [PartialOrder α] [Min α] sup_le => mk ⋯
 -/
 #guard_msgs in
-#check SemilatticeInf.casesOn'
+#print SemilatticeInf.casesOn'
 
 class Semilattice (α : Type) extends SemilatticeInf α, SemilatticeSup α
 attribute [to_dual existing] Semilattice.toSemilatticeSup


### PR DESCRIPTION
To my surprise, `lambdaMetaTelescope` does not use the lambda binder names to give names to the introduced metavariables. As a result, `reorderLambda` would rename all lambda binder names to `x`. This is fixed by only using `forallMetaTelescope` to introduce the metavariables.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
