### PR TITLE
[Merged by Bors] - fix(cache): skip fork-PR diagnostics on nightly-testing

### DIFF
--- a/Cache/Infra.lean
+++ b/Cache/Infra.lean
@@ -24,6 +24,11 @@ def MATHLIBREPO := "leanprover-community/mathlib4"
 /-- The full name of the Mathlib nightly-testing GitHub repository. -/
 def NIGHTLY_TESTING_REPO := "leanprover-community/mathlib4-nightly-testing"
 
+/-- Whether `repo` is a first-party Mathlib repo rather than a fork. Forks cache
+into the per-commit `forks` namespace; the canonical repos do not. -/
+def isCanonicalRepo (repo : String) : Bool :=
+  repo == MATHLIBREPO || repo == NIGHTLY_TESTING_REPO
+
 /--
 Canonical form of a GitHub `owner/repo` name for use as a cache blob path
 segment.

--- a/Cache/Query.lean
+++ b/Cache/Query.lean
@@ -161,9 +161,15 @@ def resolveQueryRepo (repoExplicit? : Option String) : IO String := do
 Boolean probe for a single commit: prints `cached` or `not cached` and exits
 with status 0 / 1 respectively. Intended for scripting.
 
-Probes the `forks` container's per-SHA marker, the only SHA-scoped container.
+Probes the `forks` per-SHA marker, the only SHA-scoped container. Canonical repos
+have no per-commit namespace, so it exits non-zero with a note instead of a
+misleading `not cached`.
 -/
 def cacheQuerySingle (repo sha : String) : IO Unit := do
+  if isCanonicalRepo repo then
+    IO.eprintln s!"{repo} caches by file hash, not per commit, so there is no per-commit build to query."
+    (← IO.getStderr).flush
+    IO.Process.exit 1
   let cached ← probeContainerForSHA Container.forks repo sha
   if cached then
     IO.println s!"cached: {sha}"
@@ -183,6 +189,10 @@ This is a diagnostic-only command: it prints the SHA to stdout but does not
 auto-apply it. The user manually passes the result to `cache get` if desired.
 -/
 def cacheQuery (repo : String) (cap : Nat := 50) (cwd : FilePath := ".") : IO Unit := do
+  if isCanonicalRepo repo then
+    IO.println s!"`cache query` locates a fork PR's per-commit cache. {repo} reads \
+      its own cache container directly, so there is nothing to query for it."
+    return
   -- Determine merge base with master. If not reachable, use cap-only walk.
   let mergeBase? ← gitMergeBase "master" cwd
   let stopRef := mergeBase?.getD ""

--- a/Cache/Warning.lean
+++ b/Cache/Warning.lean
@@ -179,8 +179,8 @@ Fires only on naive `cache get` invocations:
   picked a scope and the non-default-scope warning is doing the talking)
 - no `--cache-from` override (else they've already taken explicit
   responsibility for the lookup chain)
-- the resolved repo's default lookup chain reads from `forks` (otherwise SHA
-  scoping is not relevant)
+- the repo is a fork, not a first-party repo: the canonical repos don't build
+  into the per-commit `forks` namespace this note checks
 - HEAD is not already an ancestor of `master`. From a personal-fork checkout
   sitting on `master` (or an undiverged branch), the fork's SHA-scoped marker is
   structurally absent, but `master` is first in the fork lookup chain and serves
@@ -195,7 +195,7 @@ mix with `cache get`'s stdout output.
 def informIfHeadNotBuilt (repo : String) : IO Unit := do
   if (← getRepoScope).isSome then return
   if (← cacheFromOverride.get).isSome then return
-  unless (defaultContainersForRepo repo).contains Container.forks do return
+  if isCanonicalRepo repo then return
   -- HEAD already on (an ancestor of) master: master CI builds these commits and
   -- the master container (first in the fork lookup chain) serves their artifacts
   -- by hash, so there is nothing fork-specific to build. The forks marker is


### PR DESCRIPTION
On `nightly-testing` / `nightly-testing-green`, `cache get` prints a spurious "no cache found for HEAD … on fork …" note and `cache query` reports "no cached CI build found for fork …", even though the cache reads fine from the `nightly-testing` container.

These are fork-PR diagnostics about the per-commit `forks` namespace. They gated on "is `forks` in the read chain", which became true for the nightly-testing repo once it gained a `forks` fallback (#40770) so they now misfire on the canonical repos. Gate on a new `isCanonicalRepo` predicate instead; `cache query` on a canonical repo now says it only applies to fork PRs.

Follow-up to #40770 / #40035.