### PR TITLE
Change: rough prototype, clean up after enough exceptions fixed

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -521,11 +521,22 @@ def doubleUnderscore : Linter where run := withSetOptionIn fun stx => do
           Linter.logLint linter.style.nameCheck id
             m!"The declaration `{id}` contains '__', which does not follow the mathlib naming \
               conventions. Consider using single underscores instead."
-        -- If the last component of a lemma is uppercase, this is are definitely an error.
-        let nameIsUpper := declName.components.getLast!.toString.toList.head!.isUpper
-        if nameIsUpper && ((← getEnv).find? declName).get!.isTheorem then
-          Linter.logLint linter.style.nameCheck id m!"The theorem `{id}` has an upper-case name: \
-          this certainly violates the naming convention: please fix"
+
+open Batteries.Tactic.Lint in
+/-- Linter that checks for lemmas whose name starts in uppercams:
+such names violate the naming convention. -/
+@[env_linter] public def lemmasUppercase : Batteries.Tactic.Lint.Linter where
+  noErrorsFound := "no lemmas with uppercase names found."
+  errorsFound := "FOUND lemmas with uppercase names."
+  test declName := do
+    unless ((← getEnv).find? declName).get!.isTheorem && !(← isAutoDecl declName) do return none
+    if ((← getEnv).find? declName).get!.type.isConstOf `Lean.Meta.Simp.Simproc then return none
+    -- If the last component of a lemma is uppercase, this is are definitely an error.
+    let nameIsUpper := declName.components.getLast!.toString.toList.head!.isUpper
+    if nameIsUpper then
+      return m!"The theorem `{declName}` has an upper-case name: \
+        this certainly violates the naming convention: please fix"
+    else return none
 
 -- tests to add
 -- Foo.my_lemma_name is fine (even though *first* component is capitalized)

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -501,6 +501,7 @@ public register_option linter.style.nameCheck : Bool := {
 
 namespace Style.nameCheck
 
+-- TODO: need to rename this linter, etc... merge into the uppercase components linter!
 @[inherit_doc linter.style.nameCheck]
 def doubleUnderscore : Linter where run := withSetOptionIn fun stx => do
     unless getLinterValue linter.style.nameCheck (← getLinterOptions) do
@@ -518,8 +519,17 @@ def doubleUnderscore : Linter where run := withSetOptionIn fun stx => do
         -- Check whether the declaration name contains "__".
         if 1 < (declName.toString.splitOn "__").length then
           Linter.logLint linter.style.nameCheck id
-            m!"The declaration '{id}' contains '__', which does not follow the mathlib naming \
+            m!"The declaration `{id}` contains '__', which does not follow the mathlib naming \
               conventions. Consider using single underscores instead."
+        -- If the last component of a lemma is uppercase, this is are definitely an error.
+        let nameIsUpper := declName.components.getLast!.toString.toList.head!.isUpper
+        if nameIsUpper && ((← getEnv).find? declName).get!.isTheorem then
+          Linter.logLint linter.style.nameCheck id m!"The theorem `{id}` has an upper-case name: \
+          this certainly violates the naming convention: please fix"
+
+-- tests to add
+-- Foo.my_lemma_name is fine (even though *first* component is capitalized)
+-- should fire on Foo.My_lemma_name and MyConcept_some_lemma
 
 initialize addLinter doubleUnderscore
 


### PR DESCRIPTION
Fixme: allow Icc and friends as first components, are exceptions to this rule??!!

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
