### PR TITLE
[Merged by Bors] - feat(NumberTheory/Primorial): a few simple facts

### DIFF
--- a/Mathlib/NumberTheory/Primorial.lean
+++ b/Mathlib/NumberTheory/Primorial.lean
@@ -43,6 +43,10 @@ local notation x "#" => primorial x
 
 lemma primorial_eq_prod_primesLE (n : ℕ) : n # = ∏ p ∈ primesLE n, p := rfl
 
+lemma primorial_primeFactors (n : ℕ) : primeFactors (n#) = primesLE n := by
+  rw [primorial_eq_prod_primesLE]
+  exact primeFactors_prod fun _ hp ↦ prime_of_mem_primesLE hp
+
 @[simp] theorem primorial_zero : 0 # = 1 := by decide
 
 @[simp] theorem primorial_one : 1 # = 1 := by decide
@@ -51,6 +55,8 @@ lemma primorial_eq_prod_primesLE (n : ℕ) : n # = ∏ p ∈ primesLE n, p := rf
 
 theorem primorial_pos (n : ℕ) : 0 < n# :=
   prod_pos fun _p hp ↦ (mem_filter.1 hp).2.pos
+
+lemma primorial_ne_zero (n : ℕ) : n# ≠ 0 := _root_.ne_of_gt <| primorial_pos n
 
 theorem primorial_mono {m n : ℕ} (h : m ≤ n) : m# ≤ n# :=
   prod_le_prod_of_subset_of_one_le' (by gcongr) (by grind)
@@ -139,3 +145,11 @@ theorem primorial_le_four_pow (n : ℕ) : n# ≤ 4 ^ n := by
   · exact (primorial_lt_four_pow n hn).le
 
 @[deprecated (since := "2026-03-21")] alias primorial_le_4_pow := primorial_le_four_pow
+
+lemma primorial_squarefree (n : ℕ) : Squarefree (n#) := by
+  rw [primorial_eq_prod_primesLE]
+  refine Finset.squarefree_prod_of_pairwise_isCoprime ?_ <|
+    fun _ hp => (prime_of_mem_primesLE hp).squarefree
+  intro _ hp _ hq hpq
+  simp only [← coprime_iff_isRelPrime]
+  exact (coprime_primes (prime_of_mem_primesLE hp) (prime_of_mem_primesLE hq)).mpr hpq

--- a/Mathlib/NumberTheory/Primorial.lean
+++ b/Mathlib/NumberTheory/Primorial.lean
@@ -148,8 +148,7 @@ theorem primorial_le_four_pow (n : ℕ) : n# ≤ 4 ^ n := by
 
 lemma primorial_squarefree (n : ℕ) : Squarefree (n#) := by
   rw [primorial_eq_prod_primesLE]
-  refine Finset.squarefree_prod_of_pairwise_isCoprime ?_ <|
-    fun _ hp => (prime_of_mem_primesLE hp).squarefree
-  intro _ hp _ hq hpq
+  refine Finset.squarefree_prod_of_pairwise_isCoprime (fun _ hp _ hq hpq ↦ ?_) 
+    fun _ hp ↦ (prime_of_mem_primesLE hp).squarefree
   simp only [← coprime_iff_isRelPrime]
   exact (coprime_primes (prime_of_mem_primesLE hp) (prime_of_mem_primesLE hq)).mpr hpq

--- a/Mathlib/NumberTheory/Primorial.lean
+++ b/Mathlib/NumberTheory/Primorial.lean
@@ -146,7 +146,7 @@ theorem primorial_le_four_pow (n : ℕ) : n# ≤ 4 ^ n := by
 
 @[deprecated (since := "2026-03-21")] alias primorial_le_4_pow := primorial_le_four_pow
 
-lemma primorial_squarefree (n : ℕ) : Squarefree (n#) := by
+lemma squarefree_primorial (n : ℕ) : Squarefree (n#) := by
   rw [primorial_eq_prod_primesLE]
   refine Finset.squarefree_prod_of_pairwise_isCoprime (fun _ hp _ hq hpq ↦ ?_) 
     fun _ hp ↦ (prime_of_mem_primesLE hp).squarefree

--- a/Mathlib/NumberTheory/Primorial.lean
+++ b/Mathlib/NumberTheory/Primorial.lean
@@ -43,7 +43,7 @@ local notation x "#" => primorial x
 
 lemma primorial_eq_prod_primesLE (n : ℕ) : n # = ∏ p ∈ primesLE n, p := rfl
 
-lemma primorial_primeFactors (n : ℕ) : primeFactors (n#) = primesLE n := by
+lemma primeFactors_primorial (n : ℕ) : primeFactors (n#) = primesLE n := by
   rw [primorial_eq_prod_primesLE]
   exact primeFactors_prod fun _ hp ↦ prime_of_mem_primesLE hp
 

--- a/Mathlib/NumberTheory/Primorial.lean
+++ b/Mathlib/NumberTheory/Primorial.lean
@@ -56,7 +56,7 @@ lemma primeFactors_primorial (n : ℕ) : primeFactors (n#) = primesLE n := by
 theorem primorial_pos (n : ℕ) : 0 < n# :=
   prod_pos fun _p hp ↦ (mem_filter.1 hp).2.pos
 
-lemma primorial_ne_zero (n : ℕ) : n# ≠ 0 := _root_.ne_of_gt <| primorial_pos n
+lemma primorial_ne_zero (n : ℕ) : n# ≠ 0 := (primorial_pos n).ne'
 
 theorem primorial_mono {m n : ℕ} (h : m ≤ n) : m# ≤ n# :=
   prod_le_prod_of_subset_of_one_le' (by gcongr) (by grind)

--- a/Mathlib/NumberTheory/Primorial.lean
+++ b/Mathlib/NumberTheory/Primorial.lean
@@ -148,7 +148,7 @@ theorem primorial_le_four_pow (n : ℕ) : n# ≤ 4 ^ n := by
 
 lemma squarefree_primorial (n : ℕ) : Squarefree (n#) := by
   rw [primorial_eq_prod_primesLE]
-  refine Finset.squarefree_prod_of_pairwise_isCoprime (fun _ hp _ hq hpq ↦ ?_) 
+  refine Finset.squarefree_prod_of_pairwise_isCoprime (fun _ hp _ hq hpq ↦ ?_)
     fun _ hp ↦ (prime_of_mem_primesLE hp).squarefree
   simp only [← coprime_iff_isRelPrime]
   exact (coprime_primes (prime_of_mem_primesLE hp) (prime_of_mem_primesLE hq)).mpr hpq


### PR DESCRIPTION
We prove
- the primorial is squarefree
- the prime factors of the primorial are precisely `primesLE`

We also add that it is non-zero (mere convenience API).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
