### PR TITLE
[Merged by Bors] - fix(ClickSuggestions): instantiate all metavariables in the local context

### DIFF
--- a/Mathlib/Lean/Meta/KAbstractPositions.lean
+++ b/Mathlib/Lean/Meta/KAbstractPositions.lean
@@ -33,7 +33,6 @@ namespace Lean.Meta
 /-- Return the positions that `kabstract` would abstract for pattern `p` in expression `e`.
 i.e. the positions that unify with `p`. -/
 def kabstractPositions (p e : Expr) : MetaM (Array SubExpr.Pos) := do
-  let e ← instantiateMVars e
   let mctx ← getMCtx
   let pHeadIdx := p.toHeadIndex
   let pNumArgs := p.headNumArgs

--- a/Mathlib/Tactic/ClickSuggestions.lean
+++ b/Mathlib/Tactic/ClickSuggestions.lean
@@ -72,12 +72,13 @@ def viewKAbstractSubExpr' {m α}
 /-- Compute the suggestions. Use `token` for the output. -/
 public def generateSuggestions (loc : SubExpr.GoalsLocation) (parentDecl? : Option Name)
     (token : RefreshToken) : ClickSuggestionsM Unit := withReducible do
+  -- Instantiate all metavariables, so that we won't need to worry about this later on.
+  instantiateMVarDeclMVars loc.mvarId
+  loc.mvarId.withContext do
   -- TODO: instead of just putting `✝` after inaccessible names,
   -- we should figure out how to use `rename_i` to actually refer to shadowed local variables.
   let lctx := (← getLCtx).sanitizeNames.run' { options := (← getOptions) }
   Meta.withLCtx' lctx do
-  -- Instantiate all metavariables, so that we will not need to do this later on.
-  instantiateMVarDeclMVars loc.mvarId
   trackingComputation "click_suggestions" do
   let (fvarId?, pos) ← match loc.loc with
     | .hypType fvarId pos  => pure (some fvarId, pos)

--- a/MathlibTest/ClickSuggestions/Test.lean
+++ b/MathlibTest/ClickSuggestions/Test.lean
@@ -184,3 +184,10 @@ example (a b c : Nat) : a + b + c = a + b := by
   click_test "/1" => "nth_rw 2 [Nat.add_comm a b]"
   click_test "/0/1/0/1" => "nth_rw 1 [Nat.add_comm a b]"
   exact test_sorry
+
+-- This example used to panic
+example : True := by
+  by_cases h : False
+  · click_test h "" => "rw [← true_eq_false_of_false h] at h"
+    trivial
+  · trivial


### PR DESCRIPTION
This PR fixes the panic in `#click_suggestions` that was reported at https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.23click_suggestions.20doesn.27t.20find.20lemma/near/606231763

There are two separate problems that this PR fixes:
1. The implementation of `#click_suggestion` assumes all metavariables have already been instantiated. This is valid because they are all instantiated at the very beginning. However, this was not done properly, causing the types of free variables to still be able to contain metavariables.
2. The function `viewKAbstractSubExpr` was able to reach its `unreachable!` block. The reason is that `kabstractPositions` calls `instantiateMVars` on the expression `e` but not on the pattern `p`, causing a discrepancy. This is fixed by removing the `instantiateMVars` call. This is fine, because in both of the use cases (`rw??` and `#click_suggestions`), the expressions already have instantiated metavariables at this point.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
