### PR TITLE
feat: add delaborators for `ContMDiffWithinAt`, `ContMDiffAt`, `ContMDiffOn`, `ContMDiff`

### DIFF
--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -1261,8 +1261,91 @@ arguments that can use the `T%` elaborator. -/
   let ss ← withAppArg delab
   `(UniqueMDiffAt[$ss]) >>= annotateGoToSyntaxDef
 
--- TODO: add more delaborators (and tests) for
--- ContMDiff, ContMDiffOn, ContMDiffAt, ContMDiffWithinAt
+/-- Delaborator for `ContMDiffWithinAt` using the custom elaborator, and special-casing
+arguments that can use the `T%` elaborator. -/
+@[app_delab ContMDiffWithinAt] meta def delabContMDiffWithinAt : Delab := do
+  whenPPOption getPPNotation do
+  withOverApp 23 do
+  let ss ← withAppArg delab
+  let m ← withNaryArg 20 delab
+  try
+    let f := (← getExpr).getAppArgs[21]!
+    let .lam n _ b _ := f | failure
+    guard <| b.isAppOf ``Bundle.TotalSpace.mk'
+    let s := b.getAppArgs[4]!.getAppFn
+    guard <| s.isFVar
+    let σe := b.getAppArgs[4]!.getAppFn
+    guard <| σe.isFVar
+    let Tσs ← withNaryArg 21 do
+      let σs ← withBindingBody n <| withNaryArg 4 <| withNaryFn delab
+      `((T% $σs)) >>= annotateGoToSyntaxDef
+    `(CMDiffAt[$ss] $m $Tσs) >>= annotateGoToSyntaxDef
+  catch _ =>
+    let fs ← withNaryArg 21 delab
+    `(CMDiffAt[$ss] $m $fs) >>= annotateGoToSyntaxDef
+
+/-- Delaborator for `ContMDiffAt` using the custom elaborator, and special-casing
+arguments that can use the `T%` elaborator. -/
+@[app_delab ContMDiffAt] meta def delabContMDiffAt : Delab := do
+  whenPPOption getPPNotation do
+  withOverApp 22 do
+  let m ← withNaryArg 20 delab
+  try
+    let fe := (← getExpr).appArg!
+    let .lam n _ b _ := fe | failure
+    guard <| b.isAppOf ``Bundle.TotalSpace.mk'
+    let σe := b.getAppArgs[4]!.getAppFn
+    guard <| σe.isFVar
+    let Tσs ← withAppArg do
+      let σs ← withBindingBody n <| withNaryArg 4 <| withNaryFn delab
+      `((T% $σs)) >>= annotateGoToSyntaxDef
+    `(CMDiffAt $m $Tσs) >>= annotateGoToSyntaxDef
+  catch _ =>
+    let fs ← withAppArg delab
+    `(CMDiffAt $m $fs) >>= annotateGoToSyntaxDef
+
+/-- Delaborator for `ContMDiffOn` using the custom elaborator, and special-casing
+arguments that can use the `T%` elaborator. -/
+@[app_delab ContMDiffOn] meta def delabContMDiffOn : Delab := do
+  whenPPOption getPPNotation do
+  withOverApp 23 do
+  let ss ← withAppArg delab
+  let m ← withNaryArg 20 delab
+  try
+    let f := (← getExpr).getAppArgs[21]!
+    let .lam n _ b _ := f | failure
+    guard <| b.isAppOf ``Bundle.TotalSpace.mk'
+    let s := b.getAppArgs[4]!.getAppFn
+    guard <| s.isFVar
+    let σe := b.getAppArgs[4]!.getAppFn
+    guard <| σe.isFVar
+    let Tσs ← withNaryArg 21 do
+      let σs ← withBindingBody n <| withNaryArg 4 <| withNaryFn delab
+      `((T% $σs)) >>= annotateGoToSyntaxDef
+    `(CMDiff[$ss] $m $Tσs) >>= annotateGoToSyntaxDef
+  catch _ =>
+    let fs ← withNaryArg 21 <| delab
+    `(CMDiff[$ss] $m $fs) >>= annotateGoToSyntaxDef
+
+/-- Delaborator for `ContMDiff` using the custom elaborator, and special-casing
+arguments that can use the `T%` elaborator. -/
+@[app_delab ContMDiff] meta def delabContMDiff : Delab := do
+  whenPPOption getPPNotation do
+  withOverApp 22 do
+  let m ← withNaryArg 20 delab
+  try
+    let fe := (← getExpr).appArg!
+    let .lam n _ b _ := fe | failure
+    guard <| b.isAppOf ``Bundle.TotalSpace.mk'
+    let σe := b.getAppArgs[4]!.getAppFn
+    guard <| σe.isFVar
+    let Tσs ← withAppArg do
+      let σs ← withBindingBody n <| withNaryArg 4 <| withNaryFn delab
+      `((T% $σs)) >>= annotateGoToSyntaxDef
+    `(CMDiff $m $Tσs) >>= annotateGoToSyntaxDef
+  catch _ =>
+    let fs ← withAppArg delab
+    `(CMDiff $m $fs) >>= annotateGoToSyntaxDef
 
 -- TODO: when adding more elaborators, also add the corresponding delaborators
 

--- a/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
@@ -19,7 +19,7 @@ variable
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H} {M : Type*} [TopologicalSpace M]
   [ChartedSpace H M] [IsManifold I ∞ M]
   (f : M → M) (x : M) (s : Set M) (f' : TangentSpace I x →L[ℝ] TangentSpace I (f x))
-  (v : (x : M) → TangentSpace I x)
+  (v : (x : M) → TangentSpace I x) (n : ℕ)
 
 /-- info: MDiff f : Prop -/
 #guard_msgs in
@@ -122,6 +122,38 @@ variable
 #guard_msgs in
 #check HasMFDerivAt% f x f'
 
+/-- info: CMDiffAt[s] (↑n) f x : Prop -/
+#guard_msgs in
+#check CMDiffAt[s] n f x
+
+/-- info: CMDiffAt[s] (↑n) f x : Prop -/
+#guard_msgs in
+#check ContMDiffWithinAt I I n f s x
+
+/-- info: CMDiffAt (↑n) f x : Prop -/
+#guard_msgs in
+#check CMDiffAt n f x
+
+/-- info: CMDiffAt (↑n) f x : Prop -/
+#guard_msgs in
+#check ContMDiffAt I I n f x
+
+/-- info: CMDiff[s] (↑n) f : Prop -/
+#guard_msgs in
+#check ContMDiffOn I I n f s
+
+/-- info: CMDiff[s] (↑n) f : Prop -/
+#guard_msgs in
+#check CMDiff[s] n f
+
+/-- info: CMDiff (↑n) f : Prop -/
+#guard_msgs in
+#check ContMDiff I I n f
+
+/-- info: CMDiff (↑n) f : Prop -/
+#guard_msgs in
+#check CMDiff n f
+
 section TotalSpace
 
 variable {𝕜 B : Type*} {E : B → Type*}
@@ -209,6 +241,38 @@ info: mfderiv% (T% s) : (x : B) → TangentSpace I x →L[𝕜] TangentSpace (I.
 #guard_msgs in
 #check HasMFDerivAt% (T% s) x₀ f'
 
+/-- info: CMDiffAt[u] ↑n (T% s) : B → Prop -/
+#guard_msgs in
+#check ContMDiffWithinAt I (I.prod 𝓘(𝕜, F)) n (T% s) u
+
+/-- info: CMDiffAt[u] ↑n (T% s) : B → Prop -/
+#guard_msgs in
+#check CMDiffAt[u] n (T% s)
+
+/-- info: CMDiffAt ↑n (T% s) : B → Prop -/
+#guard_msgs in
+#check ContMDiffAt I (I.prod 𝓘(𝕜, F)) n (T% s)
+
+/-- info: CMDiffAt ↑n (T% s) : B → Prop -/
+#guard_msgs in
+#check CMDiffAt n (T% s)
+
+/-- info: CMDiff[u] ↑n (T% s) : Prop -/
+#guard_msgs in
+#check ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (T% s) u
+
+/-- info: CMDiff[u] ↑n (T% s) : Prop -/
+#guard_msgs in
+#check CMDiff[u] n (T% s)
+
+/-- info: CMDiff ↑n (T% s) : Prop -/
+#guard_msgs in
+#check ContMDiff I (I.prod 𝓘(𝕜, F)) n (T% s)
+
+/-- info: CMDiff ↑n (T% s) : Prop -/
+#guard_msgs in
+#check CMDiff n (T% s)
+
 end TotalSpace
 
 section ambiguity
@@ -257,6 +321,7 @@ x : M
 s : Set M
 f' : TangentSpace I x →L[ℝ] TangentSpace I (f x)
 v : (x : M) → TangentSpace I x
+n : ℕ
 g✝ g : E × E → E × E
 ⊢ MDiff id
 -/

--- a/MathlibTest/DifferentialGeometry/Notation/Sphere.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Sphere.lean
@@ -32,7 +32,7 @@ variable {E'' : Type*} [NormedAddCommGroup E''] [NormedSpace ℝ E''] {J : Model
 
 variable {g : Circle → N} {h : E'' → Circle} {k : Circle → ℝ} {y : Circle}
 
-/-- info: ContMDiff (𝓡 1) J 2 g : Prop -/
+/-- info: CMDiff 2 g : Prop -/
 #guard_msgs in
 #check CMDiff 2 g
 
@@ -124,22 +124,22 @@ end
 variable {f : (Metric.sphere (0 : E'') 1) → ℝ} {g : M → (Metric.sphere (0 : E'') 1)}
 
 variable [Fact (Module.finrank ℝ E'' = n + 1)] in
-/-- info: ContMDiff (𝓡 n) 𝓘(ℝ, ℝ) 2 f : Prop -/
+/-- info: CMDiff 2 f : Prop -/
 #guard_msgs in
 #check ContMDiff (𝓡 n) 𝓘(ℝ) 2 f
 
 variable [Fact (Module.finrank ℝ E'' = n + 1)] in
-/-- info: ContMDiff (𝓡 n) 𝓘(ℝ, ℝ) 2 f : Prop -/
+/-- info: CMDiff 2 f : Prop -/
 #guard_msgs in
 #check CMDiff 2 f
 
 variable [Fact (Module.finrank ℝ E'' = 2 * n + 1)] in
-/-- info: ContMDiff I (𝓡 2 * n) 2 g : Prop -/
+/-- info: CMDiff 2 g : Prop -/
 #guard_msgs in
 #check ContMDiff I (𝓡 (2 * n)) 2 g
 
 variable [Fact (Module.finrank ℝ E'' = 2 * n + 1)] in
-/-- info: ContMDiff I (𝓡 2 * n) 2 g : Prop -/
+/-- info: CMDiff 2 g : Prop -/
 #guard_msgs in
 #check CMDiff 2 g
 
@@ -147,11 +147,11 @@ variable [Fact (Module.finrank ℝ E'' = 2 * n + 1)] in
 section
 variable [Fact (Module.finrank ℝ E'' = n + 2 * n + 3)]
 
-/-- info: ContMDiff (𝓡 n + 2 * n + 2) 𝓘(ℝ, ℝ) ω f : Prop -/
+/-- info: CMDiff ω f : Prop -/
 #guard_msgs in
 #check CMDiff ω f
 
-/-- info: ContMDiff I (𝓡 n + 2 * n + 2) ∞ g : Prop -/
+/-- info: CMDiff ∞ g : Prop -/
 #guard_msgs in
 #check CMDiff ∞ g
 end
@@ -161,12 +161,12 @@ section
 -- Note: 3 and 2 + 1 are treated the same \o/
 -- (since our implementation uses qq matching, which does unification).
 variable [Fact (Module.finrank ℝ E'' = 3)] in
-/-- info: ContMDiff I (𝓡 2) ∞ g : Prop -/
+/-- info: CMDiff ∞ g : Prop -/
 #guard_msgs in
 #check CMDiff ∞ g
 
 variable [Fact (Module.finrank ℝ E'' = 2 + 1)] in
-/-- info: ContMDiff I (𝓡 2) ∞ g : Prop -/
+/-- info: CMDiff ∞ g : Prop -/
 #guard_msgs in
 #check CMDiff ∞ g
 


### PR DESCRIPTION
---

- [x] depends on: #42289

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
