### PR TITLE
[Merged by Bors] - feat: well founded relations on a nonempty type are not left/right total

### DIFF
--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -95,6 +95,21 @@ theorem has_min {α} {r : α → α → Prop} (H : WellFounded r) (s : Set α) :
         not_imp_not.1 fun hne hx => hne <| ⟨x, hx, fun y hy hyx => hne <| IH y hyx hy⟩)
       ha
 
+theorem nonempty_not_rightTotal (wf : WellFounded r) [Nonempty α] : ¬ Relator.RightTotal r := by
+  intro h
+  obtain ⟨a, -, ha⟩ := wf.has_min Set.univ Set.univ_nonempty
+  obtain ⟨b, hba⟩ := h a
+  specialize ha b (Set.mem_univ b)
+  contradiction
+
+theorem nonempty_not_leftTotal (wf : WellFounded (Function.swap r)) [Nonempty α] :
+    ¬ Relator.LeftTotal r := by
+  intro h
+  obtain ⟨a, -, ha⟩ := wf.has_min Set.univ Set.univ_nonempty
+  obtain ⟨b, hab⟩ := h a
+  specialize ha b (Set.mem_univ b)
+  contradiction
+
 /-- A minimal element of a nonempty set in a well-founded order.
 
 If you're working with a nonempty linear order, consider defining a

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -95,14 +95,14 @@ theorem has_min {α} {r : α → α → Prop} (H : WellFounded r) (s : Set α) :
         not_imp_not.1 fun hne hx => hne <| ⟨x, hx, fun y hy hyx => hne <| IH y hyx hy⟩)
       ha
 
-theorem nonempty_not_rightTotal (wf : WellFounded r) [Nonempty α] : ¬ Relator.RightTotal r := by
+theorem not_rightTotal (wf : WellFounded r) [Nonempty α] : ¬ Relator.RightTotal r := by
   intro h
   obtain ⟨a, -, ha⟩ := wf.has_min Set.univ Set.univ_nonempty
   obtain ⟨b, hba⟩ := h a
   specialize ha b (Set.mem_univ b)
   contradiction
 
-theorem nonempty_not_leftTotal (wf : WellFounded (Function.swap r)) [Nonempty α] :
+theorem not_leftTotal (wf : WellFounded (Function.swap r)) [Nonempty α] :
     ¬ Relator.LeftTotal r := by
   intro h
   obtain ⟨a, -, ha⟩ := wf.has_min Set.univ Set.univ_nonempty


### PR DESCRIPTION
Discussed in [this thread](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/finite.2C.20nonempty.20strict.20order.20is.20not.20left.2Fright.20total/with/606017061). I use `Function.swap` for the dual (as opposed to `flip`) because having this be reducible is nice.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
