### PR TITLE
[Merged by Bors] - feat: a submodule disjoint from a coFG module is FG

### DIFF
--- a/Mathlib/RingTheory/Finiteness/Cofinite.lean
+++ b/Mathlib/RingTheory/Finiteness/Cofinite.lean
@@ -54,10 +54,10 @@ theorem CoFG.fg_of_disjoint [IsNoetherianRing R] {S T : Submodule R M} (hST : Di
     (hT : T.CoFG) : S.FG :=
   .of_disjoint_of_isNoetherian_quotient hST
 
-/-- If `S` and `T` are co-disjoint and `T` is FG, then `S` is CoFG. -/
-theorem FG.cofg_of_codisjoint {S T : Submodule R M} (hST : Codisjoint S T) (hT : S.FG) :
+/-- If `S` and `T` are co-disjoint and `S` is FG, then `T` is CoFG. -/
+theorem FG.cofg_of_codisjoint {S T : Submodule R M} (hST : Codisjoint S T) (hS : S.FG) :
     T.CoFG :=
-  have := Module.Finite.iff_fg.mpr hT
+  have := Module.Finite.iff_fg.mpr hS
   .of_surjective (T.mkQ.domRestrict S) (by simp [← LinearMap.range_eq_top, hST.symm.eq_top])
 
 /-- A complement of an FG submodule is CoFG. -/

--- a/Mathlib/RingTheory/Finiteness/Cofinite.lean
+++ b/Mathlib/RingTheory/Finiteness/Cofinite.lean
@@ -49,10 +49,20 @@ theorem _root_.Module.Finite.iff_cofg_bot : (⊥ : Submodule R M).CoFG ↔ Modul
 theorem CoFG.fg_of_isCompl {S T : Submodule R M} (hST : IsCompl S T) (hS : S.CoFG) : T.FG :=
   Module.Finite.iff_fg.mp <| Module.Finite.equiv <| quotientEquivOfIsCompl S T hST
 
+/-- Over a noetherian ring, if `S` and `T` are disjoint and `T` is CoFG, then `S` is FG. -/
+theorem CoFG.fg_of_disjoint [IsNoetherianRing R] {S T : Submodule R M} (hST : Disjoint S T)
+    (hT : T.CoFG) : S.FG :=
+  .of_disjoint_of_isNoetherian_quotient hST
+
+/-- If `S` and `T` are co-disjoint and `T` is FG, then `S` is CoFG. -/
+theorem FG.cofg_of_codisjoint {S T : Submodule R M} (hST : Codisjoint S T) (hT : S.FG) :
+    T.CoFG :=
+  have := Module.Finite.iff_fg.mpr hT
+  .of_surjective (T.mkQ.domRestrict S) (by simp [← LinearMap.range_eq_top, hST.symm.eq_top])
+
 /-- A complement of an FG submodule is CoFG. -/
-theorem FG.cofg_of_isCompl {S T : Submodule R M} (hST : IsCompl S T) (hS : S.FG) : T.CoFG := by
-  haveI := Module.Finite.iff_fg.mpr hS
-  exact Module.Finite.equiv (quotientEquivOfIsCompl T S hST.symm).symm
+theorem FG.cofg_of_isCompl {S T : Submodule R M} (hST : IsCompl S T) (hS : S.FG) : T.CoFG :=
+  hS.cofg_of_codisjoint hST.codisjoint
 
 /-- A submodule that contains a CoFG submodule is CoFG. -/
 theorem CoFG.of_le {S T : Submodule R M} (hT : S ≤ T) (hS : S.CoFG) : T.CoFG := by

--- a/Mathlib/RingTheory/Noetherian/Basic.lean
+++ b/Mathlib/RingTheory/Noetherian/Basic.lean
@@ -382,6 +382,12 @@ lemma FG.of_le [IsNoetherianRing R] {S T : Submodule R M} (hT : T.FG) (hST : S �
   rw [← Module.Finite.iff_fg] at hT
   exact FG.of_le_of_isNoetherian hST
 
+/-- If `S` is disjoint from `T` and `M ⧸ T` is a noetherian module, then `S` is FG.
+See also `Submodule.CoFG.fg_of_disjoint`. -/
+theorem FG.of_disjoint_of_isNoetherian_quotient {S T : Submodule R M} [IsNoetherian R (M ⧸ T)]
+    (hST : Disjoint S T) : S.FG :=
+  Module.Finite.iff_fg.mp <| .of_injective (T.mkQ.domRestrict S) (by simp [hST.eq_bot])
+
 end Submodule
 
 universe w v u


### PR DESCRIPTION
... over a noetherian ring.

Also, over an arbitrary ring, a submodule codisjoint from a fg module is cofg.

This is a prerequisite for Fredholm operators.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
