### PR TITLE
[Merged by Bors] - feat(Topology/UniformSpace): tag `UniformContinuous` with `@[fun_prop]`

### DIFF
--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -118,6 +118,7 @@ theorem antilipschitz_equivRealProd : AntilipschitzWith (NNReal.sqrt 2) equivRea
   AddMonoidHomClass.antilipschitz_of_bound equivRealProdLm fun z ↦ by
     simpa only [Real.coe_sqrt, NNReal.coe_ofNat] using! norm_le_sqrt_two_mul_max z
 
+@[fun_prop]
 theorem isUniformEmbedding_equivRealProd : IsUniformEmbedding equivRealProd :=
   antilipschitz_equivRealProd.isUniformEmbedding lipschitz_equivRealProd.uniformContinuous
 
@@ -153,6 +154,7 @@ def reCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_re : Continuous re :=
   reCLM.continuous
 
+@[fun_prop]
 lemma uniformContinuous_re : UniformContinuous re :=
   reCLM.uniformContinuous
 
@@ -175,6 +177,7 @@ def imCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_im : Continuous im :=
   imCLM.continuous
 
+@[fun_prop]
 lemma uniformContinuous_im : UniformContinuous im :=
   imCLM.uniformContinuous
 

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -222,9 +222,11 @@ theorem LipschitzWith.vsub [PseudoEMetricSpace α] {f g : α → P} {Kf Kg : ℝ
     _ ≤ Kf * edist x y + Kg * edist x y := add_le_add (hf x y) (hg x y)
     _ = (Kf + Kg) * edist x y := (add_mul _ _ _).symm
 
+@[fun_prop]
 theorem uniformContinuous_vadd : UniformContinuous fun x : V × P => x.1 +ᵥ x.2 :=
   (LipschitzWith.prod_fst.vadd LipschitzWith.prod_snd).uniformContinuous
 
+@[fun_prop]
 theorem uniformContinuous_vsub : UniformContinuous fun x : P × P => x.1 -ᵥ x.2 :=
   (LipschitzWith.prod_fst.vsub LipschitzWith.prod_snd).uniformContinuous
 

--- a/Mathlib/Analysis/Normed/Group/Uniform.lean
+++ b/Mathlib/Analysis/Normed/Group/Uniform.lean
@@ -185,11 +185,11 @@ theorem lipschitzWith_one_norm' : LipschitzWith 1 (norm : E → ℝ) := by
 theorem lipschitzWith_one_nnnorm' : LipschitzWith 1 (NNNorm.nnnorm : E → ℝ≥0) :=
   lipschitzWith_one_norm'
 
-@[to_additive uniformContinuous_norm]
+@[to_additive (attr := fun_prop) uniformContinuous_norm]
 theorem uniformContinuous_norm' : UniformContinuous (norm : E → ℝ) :=
   lipschitzWith_one_norm'.uniformContinuous
 
-@[to_additive uniformContinuous_nnnorm]
+@[to_additive (attr := fun_prop) uniformContinuous_nnnorm]
 theorem uniformContinuous_nnnorm' : UniformContinuous fun a : E => ‖a‖₊ :=
   uniformContinuous_norm'.subtype_mk _
 

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -565,10 +565,12 @@ instance secondCountableTopology [Countable ι] [∀ i, TopologicalSpace (β i)]
 instance uniformSpace [∀ i, UniformSpace (β i)] : UniformSpace (PiLp p β) :=
   (Pi.uniformSpace β).comap ofLp
 
+@[fun_prop]
 lemma uniformContinuous_ofLp [∀ i, UniformSpace (β i)] :
     UniformContinuous (@ofLp p (∀ i, β i)) :=
   uniformContinuous_comap
 
+@[fun_prop]
 lemma uniformContinuous_toLp [∀ i, UniformSpace (β i)] :
     UniformContinuous (@toLp p (∀ i, β i)) :=
   uniformContinuous_comap' uniformContinuous_id

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -517,9 +517,11 @@ variable [UniformSpace α] [UniformSpace β]
 instance instProdUniformSpace : UniformSpace (WithLp p (α × β)) :=
   instUniformSpaceProd.comap ofLp
 
+@[fun_prop]
 lemma prod_uniformContinuous_toLp : UniformContinuous (@toLp p (α × β)) :=
   uniformContinuous_comap' uniformContinuous_id
 
+@[fun_prop]
 lemma prod_uniformContinuous_ofLp : UniformContinuous (@ofLp p (α × β)) :=
   uniformContinuous_comap
 
@@ -681,6 +683,7 @@ instance instProdSeminormedAddCommGroup [SeminormedAddCommGroup α] [SeminormedA
         prod_norm_eq_add (zero_lt_one.trans_le h), dist_eq_norm, ← norm_neg_add]
       rfl
 
+@[fun_prop]
 lemma isUniformInducing_toLp [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
     IsUniformInducing (@toLp p (α × β)) :=
   (prod_antilipschitzWith_toLp p α β).isUniformInducing

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -636,6 +636,7 @@ section CoeToLp
 
 variable [Fact (1 ≤ p)]
 
+@[fun_prop]
 protected theorem uniformContinuous : UniformContinuous ((↑) : Lp.simpleFunc E p μ → Lp E p μ) :=
   uniformContinuous_comap
 

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
@@ -202,12 +202,12 @@ variable [UniformSpace α] [Group α] [IsUniformGroup α]
 theorem uniformContinuous_div : UniformContinuous fun p : α × α => p.1 / p.2 :=
   IsUniformGroup.uniformContinuous_div
 
-@[to_additive]
+@[to_additive (attr := fun_prop)]
 theorem UniformContinuous.div [UniformSpace β] {f : β → α} {g : β → α} (hf : UniformContinuous f)
     (hg : UniformContinuous g) : UniformContinuous fun x => f x / g x :=
   uniformContinuous_div.comp (hf.prodMk hg)
 
-@[to_additive]
+@[to_additive (attr := fun_prop)]
 theorem UniformContinuous.inv [UniformSpace β] {f : β → α} (hf : UniformContinuous f) :
     UniformContinuous fun x => (f x)⁻¹ := by
   have : UniformContinuous fun x => 1 / f x := uniformContinuous_const.div hf
@@ -217,7 +217,7 @@ theorem UniformContinuous.inv [UniformSpace β] {f : β → α} (hf : UniformCon
 theorem uniformContinuous_inv : UniformContinuous fun x : α => x⁻¹ :=
   uniformContinuous_id.inv
 
-@[to_additive]
+@[to_additive (attr := fun_prop)]
 theorem UniformContinuous.mul [UniformSpace β] {f : β → α} {g : β → α} (hf : UniformContinuous f)
     (hg : UniformContinuous g) : UniformContinuous fun x => f x * g x := by
   have : UniformContinuous fun x => f x / (g x)⁻¹ := hf.div hg.inv
@@ -314,7 +314,7 @@ theorem Filter.Tendsto.uniformity_mul_iff_left {ι : Type*} {f g : ι → α × 
     Tendsto (f * g) l (𝓤 α) ↔ Tendsto f l (𝓤 α) :=
   ⟨fun hfg ↦ by simpa using hfg.uniformity_mul hg.uniformity_inv, fun hf ↦ hf.uniformity_mul hg⟩
 
-@[to_additive UniformContinuous.const_nsmul]
+@[to_additive (attr := fun_prop) UniformContinuous.const_nsmul]
 theorem UniformContinuous.pow_const [UniformSpace β] {f : β → α} (hf : UniformContinuous f) :
     ∀ n : ℕ, UniformContinuous fun x => f x ^ n
   | 0 => by
@@ -328,7 +328,7 @@ theorem UniformContinuous.pow_const [UniformSpace β] {f : β → α} (hf : Unif
 theorem uniformContinuous_pow_const (n : ℕ) : UniformContinuous fun x : α => x ^ n :=
   uniformContinuous_id.pow_const n
 
-@[to_additive UniformContinuous.const_zsmul]
+@[to_additive (attr := fun_prop) UniformContinuous.const_zsmul]
 theorem UniformContinuous.zpow_const [UniformSpace β] {f : β → α} (hf : UniformContinuous f) :
     ∀ n : ℤ, UniformContinuous fun x => f x ^ n
   | (n : ℕ) => by

--- a/Mathlib/Topology/Algebra/Module/Multilinear/Topology.lean
+++ b/Mathlib/Topology/Algebra/Module/Multilinear/Topology.lean
@@ -87,11 +87,13 @@ lemma isEmbedding_toUniformOnFun :
       ((Π i, E i) →ᵤ[{s | IsVonNBounded 𝕜 s}] F)) :=
   isUniformEmbedding_toUniformOnFun.isEmbedding
 
+@[fun_prop]
 theorem uniformContinuous_coe_fun [∀ i, ContinuousSMul 𝕜 (E i)] :
     UniformContinuous (DFunLike.coe : ContinuousMultilinearMap 𝕜 E F → (Π i, E i) → F) :=
   (UniformOnFun.uniformContinuous_toFun sUnion_isVonNBounded_eq_univ).comp
     isUniformEmbedding_toUniformOnFun.uniformContinuous
 
+@[fun_prop]
 theorem uniformContinuous_eval_const [∀ i, ContinuousSMul 𝕜 (E i)] (x : Π i, E i) :
     UniformContinuous fun f : ContinuousMultilinearMap 𝕜 E F ↦ f x :=
   uniformContinuous_pi.1 uniformContinuous_coe_fun x
@@ -107,6 +109,7 @@ instance instUniformContinuousConstSMul {M : Type*}
   haveI := uniformContinuousConstSMul_of_continuousConstSMul M F
   isUniformEmbedding_toUniformOnFun.uniformContinuousConstSMul fun _ _ ↦ rfl
 
+@[fun_prop]
 theorem isUniformInducing_postcomp
     {G : Type*} [AddCommGroup G] [UniformSpace G] [IsUniformAddGroup G] [Module 𝕜 G]
     (g : F →L[𝕜] G) (hg : IsUniformInducing g) :
@@ -155,6 +158,7 @@ variable (𝕜' : Type*) [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜' �
   [∀ i, ContinuousSMul 𝕜 (E i)]
 
 set_option backward.isDefEq.respectTransparency false in
+@[fun_prop]
 theorem isUniformEmbedding_restrictScalars :
     IsUniformEmbedding
       (restrictScalars 𝕜' : ContinuousMultilinearMap 𝕜 E F → ContinuousMultilinearMap 𝕜' E F) := by
@@ -164,6 +168,7 @@ theorem isUniformEmbedding_restrictScalars :
   convert! isUniformEmbedding_toUniformOnFun using 4 with s
   exact ⟨fun h ↦ h.extend_scalars _, fun h ↦ h.restrict_scalars _⟩
 
+@[fun_prop]
 theorem uniformContinuous_restrictScalars :
     UniformContinuous
       (restrictScalars 𝕜' : ContinuousMultilinearMap 𝕜 E F → ContinuousMultilinearMap 𝕜' E F) :=

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Section.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Section.lean
@@ -78,14 +78,17 @@ section VectorSpaceUniform
 variable (K E : Type*) [DivisionRing K] [AddCommGroup E] [Module K E]
     [UniformSpace E] [IsUniformAddGroup E] [ContinuousConstSMul K E]
 
+@[fun_prop]
 theorem outCLM_isUniformInducing : IsUniformInducing (outCLM K E) := by
   rw [← isUniformInducing_mk.of_comp_iff, mk_comp_outCLM]
   exact .id
 
+@[fun_prop]
 theorem outCLM_isUniformEmbedding : IsUniformEmbedding (outCLM K E) where
   injective := outCLM_injective K E
   toIsUniformInducing := outCLM_isUniformInducing K E
 
+@[fun_prop]
 theorem outCLM_uniformContinuous : UniformContinuous (outCLM K E) :=
   (outCLM_isUniformInducing K E).uniformContinuous
 

--- a/Mathlib/Topology/Algebra/UniformMulAction.lean
+++ b/Mathlib/Topology/Algebra/UniformMulAction.lean
@@ -89,7 +89,7 @@ instance (priority := 100) UniformContinuousConstSMul.to_continuousConstSMul
 
 variable {M X Y}
 
-@[to_additive]
+@[to_additive (attr := fun_prop)]
 theorem UniformContinuous.const_smul [UniformContinuousConstSMul M X] {f : Y → X}
     (hf : UniformContinuous f) (c : M) : UniformContinuous (c • f) :=
   (uniformContinuous_const_smul c).comp hf
@@ -127,10 +127,12 @@ section Ring
 
 variable {R β : Type*} [Ring R] [UniformSpace R] [UniformSpace β]
 
+@[fun_prop]
 theorem UniformContinuous.const_mul' [UniformContinuousConstSMul R R] {f : β → R}
     (hf : UniformContinuous f) (a : R) : UniformContinuous fun x ↦ a * f x :=
   hf.const_smul a
 
+@[fun_prop]
 theorem UniformContinuous.mul_const' [UniformContinuousConstSMul Rᵐᵒᵖ R] {f : β → R}
     (hf : UniformContinuous f) (a : R) : UniformContinuous fun x ↦ f x * a :=
   hf.const_smul (MulOpposite.op a)
@@ -143,6 +145,7 @@ theorem uniformContinuous_mul_right' [UniformContinuousConstSMul Rᵐᵒᵖ R] (
     UniformContinuous fun b : R => b * a :=
   uniformContinuous_id.mul_const' _
 
+@[fun_prop]
 theorem UniformContinuous.div_const' {R β : Type*} [DivisionRing R] [UniformSpace R]
     [UniformContinuousConstSMul Rᵐᵒᵖ R] [UniformSpace β] {f : β → R}
     (hf : UniformContinuous f) (a : R) :

--- a/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
@@ -280,6 +280,7 @@ theorem lipschitz_eval_const (x : α) : LipschitzWith 1 fun f : α →ᵇ β => 
 @[deprecated (since := "2025-11-29")]
 alias lipschitz_evalx := lipschitz_eval_const
 
+@[fun_prop]
 theorem uniformContinuous_coe : @UniformContinuous (α →ᵇ β) (α → β) _ _ (⇑) :=
   uniformContinuous_pi.2 fun x => (lipschitz_eval_const x).uniformContinuous
 
@@ -391,6 +392,7 @@ theorem lipschitz_comp {G : β → γ} {C : ℝ≥0} (H : LipschitzWith C G) :
         dist (G (f x)) (G (g x)) ≤ C * dist (f x) (g x) := H.dist_le_mul _ _
         _ ≤ C * dist f g := by gcongr; apply dist_coe_le_dist
 
+@[fun_prop]
 /-- The composition operator (in the target) with a Lipschitz map is uniformly continuous. -/
 theorem uniformContinuous_comp {G : β → γ} {C : ℝ≥0} (H : LipschitzWith C G) :
     UniformContinuous (comp G H : (α →ᵇ β) → α →ᵇ γ) :=

--- a/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
@@ -392,8 +392,8 @@ theorem lipschitz_comp {G : β → γ} {C : ℝ≥0} (H : LipschitzWith C G) :
         dist (G (f x)) (G (g x)) ≤ C * dist (f x) (g x) := H.dist_le_mul _ _
         _ ≤ C * dist f g := by gcongr; apply dist_coe_le_dist
 
-@[fun_prop]
 /-- The composition operator (in the target) with a Lipschitz map is uniformly continuous. -/
+@[fun_prop]
 theorem uniformContinuous_comp {G : β → γ} {C : ℝ≥0} (H : LipschitzWith C G) :
     UniformContinuous (comp G H : (α →ᵇ β) → α →ᵇ γ) :=
   (lipschitz_comp H).uniformContinuous

--- a/Mathlib/Topology/UniformSpace/AbstractCompletion.lean
+++ b/Mathlib/Topology/UniformSpace/AbstractCompletion.lean
@@ -94,6 +94,7 @@ theorem closure_range : closure (range ι) = univ :=
 theorem isDenseInducing : IsDenseInducing ι :=
   ⟨pkg.isUniformInducing.isInducing, pkg.dense⟩
 
+@[fun_prop]
 theorem uniformContinuous_coe : UniformContinuous ι :=
   IsUniformInducing.uniformContinuous pkg.isUniformInducing
 
@@ -136,6 +137,7 @@ theorem extend_coe [T2Space β] (hf : UniformContinuous f) (a : α) : (pkg.exten
 
 variable [CompleteSpace β]
 
+@[fun_prop]
 theorem uniformContinuous_extend : UniformContinuous (pkg.extend f) := by
   by_cases hf : UniformContinuous f
   · rw [pkg.extend_def hf]
@@ -147,6 +149,7 @@ theorem uniformContinuous_extend : UniformContinuous (pkg.extend f) := by
 theorem continuous_extend : Continuous (pkg.extend f) :=
   pkg.uniformContinuous_extend.continuous
 
+@[fun_prop]
 lemma isUniformInducing_extend (h : IsUniformInducing f) :
     IsUniformInducing (pkg.extend f) := by
   rw [extend_def _ h.uniformContinuous]
@@ -183,6 +186,7 @@ local notation "map" => pkg.map pkg'
 
 variable (f : α → β)
 
+@[fun_prop]
 theorem uniformContinuous_map : UniformContinuous (map f) :=
   pkg.uniformContinuous_extend
 
@@ -254,6 +258,7 @@ variable (pkg' : AbstractCompletion.{vα'} α)
 def compare : pkg.space → pkg'.space :=
   pkg.extend pkg'.coe
 
+@[fun_prop]
 theorem uniformContinuous_compare : UniformContinuous (pkg.compare pkg') :=
   pkg.uniformContinuous_extend
 
@@ -277,9 +282,11 @@ def compareEquiv : pkg.space ≃ᵤ pkg'.space where
   uniformContinuous_toFun := uniformContinuous_compare _ _
   uniformContinuous_invFun := uniformContinuous_compare _ _
 
+@[fun_prop]
 theorem uniformContinuous_compareEquiv : UniformContinuous (pkg.compareEquiv pkg') :=
   pkg.uniformContinuous_compare pkg'
 
+@[fun_prop]
 theorem uniformContinuous_compareEquiv_symm : UniformContinuous (pkg.compareEquiv pkg').symm :=
   pkg'.uniformContinuous_compare pkg
 
@@ -373,6 +380,7 @@ end T0Space
 variable {f : α → β → γ}
 variable [CompleteSpace γ] (f)
 
+@[fun_prop]
 theorem uniformContinuous_extension₂ : UniformContinuous₂ (pkg.extend₂ pkg' f) := by
   rw [uniformContinuous₂_def, AbstractCompletion.extend₂, uncurry_curry]
   apply uniformContinuous_extend
@@ -399,6 +407,7 @@ local notation f " ∘₂ " g => bicompr f g
 protected def map₂ (f : α → β → γ) : hatα → hatβ → hatγ :=
   pkg.extend₂ pkg' (pkg''.coe ∘₂ f)
 
+@[fun_prop]
 theorem uniformContinuous_map₂ (f : α → β → γ) : UniformContinuous₂ (pkg.map₂ pkg' pkg'' f) :=
   AbstractCompletion.uniformContinuous_extension₂ pkg pkg' _
 

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -521,10 +521,12 @@ section
 
 variable [UniformSpace α] [UniformSpace β] [UniformSpace γ] {f : α → β} {s t : Set α}
 
+@[fun_prop]
 theorem UniformContinuous.continuous (hf : UniformContinuous f) : Continuous f :=
   continuous_iff_le_induced.mpr <| UniformSpace.toTopologicalSpace_mono <|
     uniformContinuous_iff_le_comap.1 hf
 
+@[fun_prop]
 lemma UniformContinuous.uniformContinuousOn (hf : UniformContinuous f) :
     UniformContinuousOn f s :=
   tendsto_inf_left hf
@@ -540,6 +542,7 @@ lemma UniformContinuousOn.congr {f g : α → β} {s : Set α}
   apply EventuallyEq.filter_mono _ inf_le_right
   filter_upwards [mem_principal_self _] with ⟨a, b⟩ ⟨ha, hb⟩ using by simp [h ha, h hb]
 
+@[fun_prop]
 lemma UniformContinuousOn.comp {g : β → γ} {t : Set β} (hg : UniformContinuousOn g t)
     (hf : UniformContinuousOn f s) (hst : MapsTo f s t) : UniformContinuousOn (g ∘ f) s := by
   change Tendsto ((fun x ↦ (g x.1, g x.2)) ∘ (fun x ↦ (f x.1, f x.2))) (𝓤 α ⊓ 𝓟 (s ×ˢ s)) (𝓤 γ)
@@ -548,6 +551,7 @@ lemma UniformContinuousOn.comp {g : β → γ} {t : Set β} (hg : UniformContinu
   simp only [tendsto_principal, mem_prod, eventually_principal, and_imp, Prod.forall]
   exact fun a b ha hb ↦ ⟨hst ha, hst hb⟩
 
+@[fun_prop]
 lemma UniformContinuous.comp_uniformContinuousOn {g : β → γ}
     (hg : UniformContinuous g) (hf : UniformContinuousOn f s) : UniformContinuousOn (g ∘ f) s :=
   (hg.uniformContinuousOn (s := univ)).comp hf (mapsTo_univ _ _)
@@ -623,15 +627,19 @@ open Additive Multiplicative
 instance : UniformSpace (Additive α) := ‹UniformSpace α›
 instance : UniformSpace (Multiplicative α) := ‹UniformSpace α›
 
+@[fun_prop]
 theorem uniformContinuous_ofMul : UniformContinuous (ofMul : α → Additive α) :=
   uniformContinuous_id
 
+@[fun_prop]
 theorem uniformContinuous_toMul : UniformContinuous (toMul : Additive α → α) :=
   uniformContinuous_id
 
+@[fun_prop]
 theorem uniformContinuous_ofAdd : UniformContinuous (ofAdd : α → Multiplicative α) :=
   uniformContinuous_id
 
+@[fun_prop]
 theorem uniformContinuous_toAdd : UniformContinuous (toAdd : Multiplicative α → α) :=
   uniformContinuous_id
 
@@ -656,10 +664,12 @@ theorem map_uniformity_set_coe {s : Set α} [UniformSpace α] :
     map (Prod.map (↑) (↑)) (𝓤 s) = 𝓤 α ⊓ 𝓟 (s ×ˢ s) := by
   rw [uniformity_setCoe, map_comap, range_prodMap, Subtype.range_val]
 
+@[fun_prop]
 theorem uniformContinuous_subtype_val {p : α → Prop} [UniformSpace α] :
     UniformContinuous (Subtype.val : { a : α // p a } → α) :=
   uniformContinuous_comap
 
+@[fun_prop]
 theorem UniformContinuous.subtype_mk {p : α → Prop} [UniformSpace α] [UniformSpace β] {f : β → α}
     (hf : UniformContinuous f) (h : ∀ x, p (f x)) :
     UniformContinuous (fun x => ⟨f x, h x⟩ : β → Subtype p) :=
@@ -684,6 +694,7 @@ theorem tendsto_of_uniformContinuous_subtype [UniformSpace α] [UniformSpace β]
   rw [(@map_nhds_subtype_coe_eq_nhds α _ (· ∈ s) a (mem_of_mem_nhds ha) ha).symm]
   exact tendsto_map' hf.continuous.continuousAt
 
+@[fun_prop]
 theorem UniformContinuousOn.continuousOn [UniformSpace α] [UniformSpace β] {f : α → β} {s : Set α}
     (h : UniformContinuousOn f s) : ContinuousOn f s := by
   rw [uniformContinuousOn_iff_restrict] at h
@@ -709,11 +720,11 @@ theorem comap_uniformity_mulOpposite [UniformSpace α] :
 
 namespace MulOpposite
 
-@[to_additive]
+@[to_additive (attr := fun_prop)]
 theorem uniformContinuous_unop [UniformSpace α] : UniformContinuous (unop : αᵐᵒᵖ → α) :=
   uniformContinuous_comap
 
-@[to_additive]
+@[to_additive (attr := fun_prop)]
 theorem uniformContinuous_op [UniformSpace α] : UniformContinuous (op : α → αᵐᵒᵖ) :=
   uniformContinuous_comap' uniformContinuous_id
 
@@ -819,16 +830,19 @@ theorem tendsto_prod_uniformity_snd [UniformSpace α] [UniformSpace β] :
     Tendsto (fun p : (α × β) × α × β => (p.1.2, p.2.2)) (𝓤 (α × β)) (𝓤 β) :=
   le_trans (map_mono inf_le_right) map_comap_le
 
+@[fun_prop]
 theorem uniformContinuous_fst [UniformSpace α] [UniformSpace β] :
     UniformContinuous fun p : α × β => p.1 :=
   tendsto_prod_uniformity_fst
 
+@[fun_prop]
 theorem uniformContinuous_snd [UniformSpace α] [UniformSpace β] :
     UniformContinuous fun p : α × β => p.2 :=
   tendsto_prod_uniformity_snd
 
 variable [UniformSpace α] [UniformSpace β] [UniformSpace γ]
 
+@[fun_prop]
 theorem UniformContinuous.prodMk {f₁ : α → β} {f₂ : α → γ} (h₁ : UniformContinuous f₁)
     (h₂ : UniformContinuous f₂) : UniformContinuous fun a => (f₁ a, f₂ a) := by
   rw [UniformContinuous, uniformity_prod]
@@ -842,10 +856,12 @@ theorem UniformContinuous.prodMk_right {f : α × β → γ} (h : UniformContinu
     UniformContinuous fun b => f (a, b) :=
   h.comp (uniformContinuous_const.prodMk uniformContinuous_id)
 
+@[fun_prop]
 theorem UniformContinuous.prodMap [UniformSpace δ] {f : α → γ} {g : β → δ}
     (hf : UniformContinuous f) (hg : UniformContinuous g) : UniformContinuous (Prod.map f g) :=
   (hf.comp uniformContinuous_fst).prodMk (hg.comp uniformContinuous_snd)
 
+@[fun_prop]
 lemma uniformContinuous_swap :
     UniformContinuous (Prod.swap : α × β → β × α) :=
   uniformContinuous_snd.prodMk uniformContinuous_fst
@@ -905,6 +921,7 @@ variable {δ' : Type*} [UniformSpace α] [UniformSpace β] [UniformSpace γ] [Un
 local notation f " ∘₂ " g => Function.bicompr f g
 
 /-- Uniform continuity for functions of two variables. -/
+@[fun_prop]
 def UniformContinuous₂ (f : α → β → γ) :=
   UniformContinuous (uncurry f)
 
@@ -920,10 +937,12 @@ theorem uniformContinuous₂_curry (f : α × β → γ) :
     UniformContinuous₂ (Function.curry f) ↔ UniformContinuous f := by
   rw [UniformContinuous₂, uncurry_curry]
 
+@[fun_prop]
 theorem UniformContinuous₂.comp {f : α → β → γ} {g : γ → δ} (hg : UniformContinuous g)
     (hf : UniformContinuous₂ f) : UniformContinuous₂ (g ∘₂ f) :=
   hg.comp hf
 
+@[fun_prop]
 theorem UniformContinuous₂.bicompl {f : α → β → γ} {ga : δ → α} {gb : δ' → β}
     (hf : UniformContinuous₂ f) (hga : UniformContinuous ga) (hgb : UniformContinuous gb) :
     UniformContinuous₂ (bicompl f ga gb) :=
@@ -971,8 +990,8 @@ theorem union_mem_uniformity_sum {a : SetRel α α} (ha : a ∈ 𝓤 α) {b : Se
 theorem Sum.uniformity : 𝓤 (α ⊕ β) = map (Prod.map inl inl) (𝓤 α) ⊔ map (Prod.map inr inr) (𝓤 β) :=
   rfl
 
-lemma uniformContinuous_inl : UniformContinuous (Sum.inl : α → α ⊕ β) := le_sup_left
-lemma uniformContinuous_inr : UniformContinuous (Sum.inr : β → α ⊕ β) := le_sup_right
+@[fun_prop] lemma uniformContinuous_inl : UniformContinuous (Sum.inl : α → α ⊕ β) := le_sup_left
+@[fun_prop] lemma uniformContinuous_inr : UniformContinuous (Sum.inr : β → α ⊕ β) := le_sup_right
 
 instance [IsCountablyGenerated (𝓤 α)] [IsCountablyGenerated (𝓤 β)] :
     IsCountablyGenerated (𝓤 (α ⊕ β)) := by

--- a/Mathlib/Topology/UniformSpace/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Completion.lean
@@ -238,6 +238,7 @@ end T0Space
 
 variable [CompleteSpace β]
 
+@[fun_prop]
 theorem uniformContinuous_extend {f : α → β} : UniformContinuous (extend f) := by
   by_cases hf : UniformContinuous f
   · rw [extend, if_pos hf]
@@ -344,6 +345,7 @@ attribute [local instance]
 theorem nonempty_completion_iff : Nonempty (Completion α) ↔ Nonempty α :=
   cPkg.dense.nonempty_iff.symm
 
+@[fun_prop]
 theorem uniformContinuous_coe : UniformContinuous ((↑) : α → Completion α) :=
   cPkg.uniformContinuous_coe
 
@@ -431,6 +433,7 @@ section CompleteSpace
 
 variable [CompleteSpace β]
 
+@[fun_prop]
 theorem uniformContinuous_extension : UniformContinuous (Completion.extension f) :=
   cPkg.uniformContinuous_extend
 
@@ -474,6 +477,7 @@ variable {f : α → β}
 protected def map (f : α → β) : Completion α → Completion β :=
   cPkg.map cPkg f
 
+@[fun_prop]
 theorem uniformContinuous_map : UniformContinuous (Completion.map f) :=
   cPkg.uniformContinuous_map cPkg f
 
@@ -535,10 +539,12 @@ def completionSeparationQuotientEquiv (α : Type u) [UniformSpace α] :
     rw [map_coe uniformContinuous_mk, extension_coe (uniformContinuous_lift' _),
       lift'_mk (uniformContinuous_coe _)]
 
+@[fun_prop]
 theorem uniformContinuous_completionSeparationQuotientEquiv :
     UniformContinuous (completionSeparationQuotientEquiv α) :=
   uniformContinuous_extension
 
+@[fun_prop]
 theorem uniformContinuous_completionSeparationQuotientEquiv_symm :
     UniformContinuous (completionSeparationQuotientEquiv α).symm :=
   uniformContinuous_map
@@ -567,6 +573,7 @@ end T0Space
 
 variable [CompleteSpace γ]
 
+@[fun_prop]
 theorem uniformContinuous_extension₂ : UniformContinuous₂ (Completion.extension₂ f) :=
   cPkg.uniformContinuous_extension₂ cPkg f
 
@@ -580,6 +587,7 @@ open Function
 protected def map₂ (f : α → β → γ) : Completion α → Completion β → Completion γ :=
   cPkg.map₂ cPkg cPkg f
 
+@[fun_prop]
 theorem uniformContinuous_map₂ (f : α → β → γ) : UniformContinuous₂ (Completion.map₂ f) :=
   cPkg.uniformContinuous_map₂ cPkg cPkg f
 

--- a/Mathlib/Topology/UniformSpace/Defs.lean
+++ b/Mathlib/Topology/UniformSpace/Defs.lean
@@ -627,6 +627,7 @@ variable [UniformSpace β]
 /-- A function `f : α → β` is *uniformly continuous* if `(f x, f y)` tends to the diagonal
 as `(x, y)` tends to the diagonal. In other words, if `x` is sufficiently close to `y`, then
 `f x` is close to `f y` no matter where `x` and `y` are located in `α`. -/
+@[fun_prop]
 def UniformContinuous (f : α → β) :=
   Tendsto (fun x : α × α => (f x.1, f x.2)) (𝓤 α) (𝓤 β)
 
@@ -637,6 +638,7 @@ scoped[Uniformity] notation "UniformContinuous[" u₁ ", " u₂ "]" => @UniformC
 the diagonal as `(x, y)` tends to the diagonal while remaining in `s ×ˢ s`.
 In other words, if `x` is sufficiently close to `y`, then `f x` is close to
 `f y` no matter where `x` and `y` are located in `s`. -/
+@[fun_prop]
 def UniformContinuousOn (f : α → β) (s : Set α) : Prop :=
   Tendsto (fun x : α × α => (f x.1, f x.2)) (𝓤 α ⊓ 𝓟 (s ×ˢ s)) (𝓤 β)
 
@@ -658,17 +660,21 @@ theorem uniformContinuous_of_const {c : α → β} (h : ∀ a b, c a = c b) :
     eq_univ_iff_forall.2 fun ⟨a, b⟩ => h a b
   le_trans (map_le_iff_le_comap.2 <| by simp [comap_principal, this]) refl_le_uniformity
 
+@[fun_prop]
 theorem uniformContinuous_id : UniformContinuous (@id α) := tendsto_id
 
+@[fun_prop]
 theorem uniformContinuous_const {b : β} : UniformContinuous fun _ : α => b :=
   uniformContinuous_of_const fun _ _ => rfl
 
+@[fun_prop]
 nonrec theorem UniformContinuous.comp [UniformSpace γ] {g : β → γ} {f : α → β}
     (hg : UniformContinuous g) (hf : UniformContinuous f) : UniformContinuous (g ∘ f) :=
   hg.comp hf
 
 /-- If a function `T` is uniformly continuous in a uniform space `β`,
 then its `n`-th iterate `T^[n]` is also uniformly continuous. -/
+@[fun_prop]
 theorem UniformContinuous.iterate (T : β → β) (n : ℕ) (h : UniformContinuous T) :
     UniformContinuous T^[n] := by
   induction n with
@@ -692,7 +698,7 @@ theorem Filter.HasBasis.uniformContinuousOn_iff {ι'} {p : ι → Prop}
 /-- A map `f : α → β` between uniform spaces is called *uniform inducing* if the uniformity filter
 on `α` is the pullback of the uniformity filter on `β` under `Prod.map f f`. If `α` is a separated
 space, then this implies that `f` is injective, hence it is a `IsUniformEmbedding`. -/
-@[mk_iff]
+@[mk_iff, fun_prop]
 structure IsUniformInducing (f : α → β) : Prop where
   /-- The uniformity filter on the domain is the pullback of the uniformity filter on the codomain
   under `Prod.map f f`. -/
@@ -700,7 +706,7 @@ structure IsUniformInducing (f : α → β) : Prop where
 
 /-- A map `f : α → β` between uniform spaces is a *uniform embedding* if it is uniform inducing and
 injective. If `α` is a separated space, then the latter assumption follows from the former. -/
-@[mk_iff]
+@[mk_iff, fun_prop]
 structure IsUniformEmbedding (f : α → β) : Prop extends IsUniformInducing f where
   /-- A uniform embedding is injective. -/
   injective : Function.Injective f

--- a/Mathlib/Topology/UniformSpace/Separation.lean
+++ b/Mathlib/Topology/UniformSpace/Separation.lean
@@ -263,6 +263,7 @@ instance instUniformSpace : UniformSpace (SeparationQuotient α) where
 
 theorem uniformity_eq : 𝓤 (SeparationQuotient α) = (𝓤 α).map (Prod.map mk mk) := rfl
 
+@[fun_prop]
 theorem uniformContinuous_mk : UniformContinuous (mk : α → SeparationQuotient α) :=
   le_rfl
 
@@ -299,6 +300,7 @@ def lift' [T0Space β] (f : α → β) : SeparationQuotient α → β :=
 theorem lift'_mk [T0Space β] {f : α → β} (h : UniformContinuous f) (a : α) :
     lift' f (mk a) = f a := by rw [lift', dif_pos h, lift_mk]
 
+@[fun_prop]
 theorem uniformContinuous_lift' [T0Space β] (f : α → β) : UniformContinuous (lift' f) := by
   by_cases hf : UniformContinuous f
   · rwa [lift', dif_pos hf, uniformContinuous_lift]
@@ -311,6 +313,7 @@ def map (f : α → β) : SeparationQuotient α → SeparationQuotient β := lif
 theorem map_mk {f : α → β} (h : UniformContinuous f) (a : α) : map f (mk a) = mk (f a) := by
   rw [map, lift'_mk (uniformContinuous_mk.comp h)]; rfl
 
+@[fun_prop]
 theorem uniformContinuous_map (f : α → β) : UniformContinuous (map f) :=
   uniformContinuous_lift' _
 
@@ -349,6 +352,7 @@ lemma eq_top_iff_indiscrete : u = ⊤ ↔ IndiscreteTopology α :=
   ⟨fun h ↦ IndiscreteTopology.mk <| h ▸ UniformSpace.toTopologicalSpace_top (α := α),
   fun _ ↦ eq_top_uniformSpace⟩
 
+@[fun_prop]
 lemma uniformContinuous [IndiscreteTopology β] {f : α → β} : UniformContinuous f := by
   rw [UniformContinuous, eq_top_uniformSpace (α := β), top_uniformity]
   exact Filter.tendsto_top


### PR DESCRIPTION
and tag all the relevant lemmas (found via Loogle). Do the same for the other function properties.

The precise list of tagged function properties is `UniformContinuous`, `UniformContinuousOn`, `IsUniformInducing`, `IsUniformEmbedding`, `UniformContinuous₂`.

From MeanFourier


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
