### PR TITLE
[Merged by Bors] - feat(RingTheory): etale local decomposition of finite extensions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6658,6 +6658,7 @@ public import Mathlib.RingTheory.Ideal.Quotient.Index
 public import Mathlib.RingTheory.Ideal.Quotient.Nilpotent
 public import Mathlib.RingTheory.Ideal.Quotient.Noetherian
 public import Mathlib.RingTheory.Ideal.Quotient.Operations
+public import Mathlib.RingTheory.Ideal.Quotient.Over
 public import Mathlib.RingTheory.Ideal.Quotient.PowTransition
 public import Mathlib.RingTheory.Ideal.Span
 public import Mathlib.RingTheory.IdealFilter.Basic

--- a/Mathlib/Logic/Equiv/Fin/Basic.lean
+++ b/Mathlib/Logic/Equiv/Fin/Basic.lean
@@ -127,6 +127,9 @@ theorem finSuccEquiv_succ (m : Fin n) : (finSuccEquiv n) m.succ = some m :=
   finSuccEquiv'_above (Fin.zero_le _)
 
 @[simp]
+theorem finSuccEquiv_last (n : ℕ) : finSuccEquiv (n + 1) (Fin.last (n + 1)) = Fin.last n := rfl
+
+@[simp]
 theorem finSuccEquiv_symm_none : (finSuccEquiv n).symm none = 0 :=
   finSuccEquiv'_symm_none _
 

--- a/Mathlib/RingTheory/Etale/QuasiFinite.lean
+++ b/Mathlib/RingTheory/Etale/QuasiFinite.lean
@@ -541,7 +541,7 @@ private lemma Algebra.exists_etale_completeOrthogonalIdempotents_forall_liesOver
         ⟨⟨by simp [IsIdempotentElem],
           by simp only [Nat.reduceAdd, Pi.one_apply, mul_one, Subsingleton.pairwise]⟩,
           by simp⟩, nofun, nofun, nofun, ?_, nofun, ?_⟩
-      · convert show Function.Bijective (AlgHom.id R _) from Function.bijective_id; ext
+      · rw! [ofId_self, Ideal.ResidueField.mapₐ_id]; exact Function.bijective_id
       · exact fun P h₁ h₂ ↦ (this.le
           ⟨show (P.comap Algebra.TensorProduct.includeRight.toRingHom).IsPrime from inferInstance,
           ⟨by simp [P.over_def p, Ideal.under, Ideal.comap_comap]⟩⟩).elim
@@ -557,10 +557,8 @@ private lemma Algebra.exists_etale_completeOrthogonalIdempotents_forall_liesOver
     obtain ⟨R'', _, _, _, Q, _, _, n, e' : _ → R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}),
       he', Q' : _ → Ideal (R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e})), _, _, hPQ, hQ', H'⟩ :=
       IH _ this (R := R') (S := R' ⊗[R] S ⧸ Ideal.span {e}) P rfl
-    change ∀ (P'' : Ideal (R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}))), P''.IsPrime → P''.LiesOver Q →
-      e' (Fin.last n) ∈ P'' ∧ ∀ (i : Fin n), e' i.castSucc ∉ P'' → P'' = Q' i at H'
-    letI : Algebra R R'' := .compHom _ (algebraMap R R')
-    haveI : IsScalarTower R R' R'' := .of_algebraMap_eq' rfl
+    let : Algebra R R'' := .compHom _ (algebraMap R R')
+    have : IsScalarTower R R' R'' := .of_algebraMap_eq' rfl
     let φ := Algebra.TensorProduct.map (Algebra.ofId R' R'') (AlgHom.id R S)
     let e₁ : R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}) ≃ₐ[R''] (R'' ⊗[R] S ⧸ Ideal.span {φ e}) :=
       tensorQuotientTensorEquiv (R'' := R'') e
@@ -574,8 +572,7 @@ private lemma Algebra.exists_etale_completeOrthogonalIdempotents_forall_liesOver
       ((CompleteOrthogonalIdempotents.equiv (finSuccEquiv _)).mpr he'') rfl
       (Q' · |>.comap (e₁.symm.toAlgHom.comp (Ideal.Quotient.mkₐ _ _))) hPQ
       (fun i ↦ by rw [Function.comp_def]; simpa [← hψe''] using hQ' i) ?_
-    simp only [Function.comp_apply, finSuccEquiv_zero,
-      show finSuccEquiv (n + 1) (Fin.last (n + 1)) = Fin.last n from rfl, Fin.castSucc_succ,
+    simp only [Function.comp_apply, finSuccEquiv_zero, finSuccEquiv_last, Fin.castSucc_succ,
       finSuccEquiv_succ]
     intro P'' heP'' _ _
     have : (P''.map (Ideal.Quotient.mk (.span {φ e}))).IsPrime :=
@@ -594,6 +591,7 @@ private lemma Algebra.exists_etale_completeOrthogonalIdempotents_forall_liesOver
       Ideal.mem_map_span_singleton_iff_of_isIdempotentElem (he.map φ),
       Ideal.IsPrime.mul_mem_left_iff hP''] at this
     refine ⟨this.1, fun i hi ↦ (this.2 i hi).symm ▸ ?_⟩
+    -- TODO: clean-up when `Ideal.comap` is refactored to take a `RingHom`
     change _ = Ideal.comap (Ideal.Quotient.mk _) (Ideal.comap (e₁.symm.trans e₁).toRingHom _)
     simp only [AlgEquiv.symm_trans_self, RingEquiv.toRingHom_eq_coe,
       AlgEquiv.toRingEquiv_toRingHom, AlgEquiv.refl_toRingHom, Ideal.comap_id]
@@ -601,12 +599,14 @@ private lemma Algebra.exists_etale_completeOrthogonalIdempotents_forall_liesOver
     simpa [left_eq_sup, ← RingHom.ker_eq_comap_bot, Ideal.span_le] using heP''
 
 /--
-If `S` is finite over `R`, and `p` is a prime of `R`, then there exists a etale neighborhood
+If `S` is finite over `R`, and `p` is a prime of `R`, then there exists an étale neighborhood
 `(R', P)` of `p` with `κ(p) = κ(P)` such that `R' ⊗[R] S ≃ₐ[R'] R₁ × ... × Rₙ × A`,
 each `Rᵢ` has a unique prime `Pᵢ` lying over `P`, and no other prime in `R' ⊗[R] S` lies over `P`.
 
-This is merely a iterated application of `Algebra.exists_etale_isIdempotentElem_forall_liesOver_eq`.
-This is weaker than the corresponding statement of stacks project, and the only reason is that
+This is merely an iterated application of `exists_etale_isIdempotentElem_forall_liesOver_eq`.
+This is weaker than the corresponding statement of stacks project (in particular we asked for
+`Module.Finite` instead of quasi finite when localized at `p`, so that we don't need to keep
+track of this when passing to quotients and tensor products), and the only reason is that
 the corresponding stronger statement is even harder to state and even more annoying to prove.
 -/
 @[stacks 00UL]

--- a/Mathlib/RingTheory/Etale/QuasiFinite.lean
+++ b/Mathlib/RingTheory/Etale/QuasiFinite.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.RingTheory.Polynomial.UniversalFactorizationRing
 public import Mathlib.RingTheory.ZariskisMainTheorem
+public import Mathlib.RingTheory.Ideal.Quotient.Over
 
 /-!
 # Etale local structure of finite maps
@@ -435,3 +436,198 @@ lemma Algebra.exists_etale_isIdempotentElem_forall_liesOver_eq
       (Localization.Away f ⊗[R] S) (.powers (f ⊗ₜ 1)) (a₁ := ⟨P'', ‹_›⟩)
       (a₂ := ⟨P'f, ‹_›⟩) (PrimeSpectrum.ext ?_)).1)
     exact (H (P''.under _) inferInstance inferInstance hP'').trans (P'f.over_def P')
+
+open TensorProduct
+
+attribute [local instance] RingHom.ker_isPrime
+
+open scoped nonZeroDivisors
+
+attribute [local instance] Localization.AtPrime.algebraOfLiesOver
+
+/-- A key induction step of `exists_etale_completeOrthogonalIdempotents_forall_liesOver_eq`. -/
+private theorem Algebra.exists_etale_completeOrthogonalIdempotents_forall_liesOver_eq_aux
+    {R : Type u} {S : Type (max u v)} [CommRing R] [CommRing S] [Algebra R S] [Module.Finite R S]
+    (p : Ideal R) [p.IsPrime] (q : Ideal S) [q.IsPrime]
+    [q.LiesOver p] (R' : Type u) [CommRing R'] [Algebra R R'] [Algebra.Etale R R'] (P : Ideal R')
+    [P.IsPrime] [P.LiesOver p] (e : R' ⊗[R] S) (P' : Ideal (R' ⊗[R] S))
+    [P'.IsPrime] [P'.LiesOver P]
+    (hP'q : Ideal.comap Algebra.TensorProduct.includeRight.toRingHom P' = q)
+    (heP' : e ∉ P') (hpP : Function.Bijective
+      (Ideal.ResidueField.mapₐ p P (Algebra.ofId _ _) (P.over_def p)))
+    (H : ∀ (P'' : Ideal (R' ⊗[R] S)), P''.IsPrime → P''.LiesOver P → e ∉ P'' → P'' = P')
+    (R'' : Type u) [CommRing R''] [Algebra R' R''] [Algebra R R''] [IsScalarTower R R' R'']
+    [Algebra.Etale R' R''] (Q : Ideal R'')
+    [Q.IsPrime] [Q.LiesOver P] (n : ℕ)
+    (e' : Fin ((n + 1) + 1) → R'' ⊗[R] S)
+    (he' : CompleteOrthogonalIdempotents e')
+    (he'0 : e' 0 = Algebra.TensorProduct.map (Algebra.ofId R' R'') (AlgHom.id R S) e)
+    (Q' : Fin n → Ideal (R'' ⊗[R] S)) [∀ i, (Q' i).IsPrime] [∀ i, (Q' i).LiesOver Q]
+    (hPQ : Function.Bijective (Ideal.ResidueField.mapₐ P Q (Algebra.ofId _ _) (Q.over_def P)))
+    (hQ' : ∀ (i : Fin n), e' i.succ.castSucc ∉ Q' i)
+    (H' : ∀ (P'' : Ideal (R'' ⊗[R] S)), e' 0 ∈ P'' → P''.IsPrime → P''.LiesOver Q →
+      e' (.last _) ∈ P'' ∧ ∀ (i : Fin n), e' i.succ.castSucc ∉ P'' → P'' = Q' i) :
+    ∃ (R' : Type u) (_ : CommRing R') (_ : Algebra R R') (_ : Algebra.Etale R R') (P : Ideal R')
+      (_ : P.IsPrime) (_ : P.LiesOver p) (n : ℕ) (e : Fin (n + 1) → R' ⊗[R] S)
+      (_ : CompleteOrthogonalIdempotents e) (P' : Fin n → Ideal (R' ⊗[R] S))
+      (_ : ∀ i, (P' i).IsPrime) (_ : ∀ i, (P' i).LiesOver P),
+      Function.Bijective (Ideal.ResidueField.mapₐ p P (Algebra.ofId _ _) (P.over_def p)) ∧
+      (∀ i, e i.castSucc ∉ P' i) ∧
+      ∀ (P'' : Ideal (R' ⊗[R] S)), P''.IsPrime → P''.LiesOver P →
+        e (.last n) ∈ P'' ∧ ∀ i, e i.castSucc ∉ P'' → P'' = P' i := by
+  let φ := Algebra.TensorProduct.map (Algebra.ofId R' R'') (AlgHom.id R S)
+  have : Q.LiesOver p := .trans _ P _
+  have hpQ :
+    Function.Bijective (Ideal.ResidueField.mapₐ p Q (Algebra.ofId _ _) (Q.over_def p)) := by
+    convert hPQ.comp hpP
+    rw [← @AlgHom.coe_restrictScalars' R R', ← AlgHom.coe_comp]; congr 1; ext
+  let P'φ := (Ideal.fiberIsoOfBijectiveResidueField hpQ).symm
+    (Ideal.fiberIsoOfBijectiveResidueField hpP ⟨P', ‹_›, ‹_›⟩)
+  have : P'φ.1.LiesOver P := .trans _ Q _
+  have : (P'φ.1.comap φ.toRingHom).LiesOver P := inferInstanceAs ((P'φ.1.comap φ).LiesOver P)
+  have hP'φ : P'φ.1.comap φ.toRingHom = P' := by
+    apply Ideal.eq_of_comap_eq_comap_of_bijective_residueFieldMap hpP
+    rw [Ideal.comap_comap]
+    convert Ideal.comap_fiberIsoOfBijectiveResidueField_symm hpQ _
+    · ext; simp [φ]
+    · simp; rfl
+  refine ⟨R'', inferInstance, _, .comp R R' R'', Q, ‹_›, .trans _ P _, _, _, he', Fin.cons P'φ
+    Q', Fin.cases P'φ.2.1 ?_, Fin.cases P'φ.2.2 ?_, hpQ, Fin.cases ?_ ?_, ?_⟩
+  · intro P'' _ _
+    by_cases heP'' : e ∈ P''.comap φ
+    · obtain ⟨h₁, h₂⟩ := H' P'' (by simpa [he'0]) inferInstance inferInstance
+      exact ⟨h₁, Fin.cases (fun h ↦ (h (by simpa [he'0])).elim) (by simpa)⟩
+    · have : P''.LiesOver P := .trans _ Q _
+      obtain rfl := H _ inferInstance inferInstance heP''
+      have : ∀ i ≠ 0, e' i ∈ P'' := by
+        intro j hj
+        rw [← Ideal.IsPrime.mul_mem_left_iff (I := P'') heP'']
+        simp [φ, ← he'0, he'.ortho hj.symm]
+      refine ⟨by simp [this], Fin.cases (fun _ ↦ ?_) (by simp [this])⟩
+      simp only [Fin.cons_zero]
+      apply Ideal.eq_of_comap_eq_comap_of_bijective_residueFieldMap hpQ
+      have : (φ.restrictScalars _).comp Algebra.TensorProduct.includeRight =
+          Algebra.TensorProduct.includeRight := by ext; simp [φ]
+      rw [← this]
+      exact congr(($hP'φ).comap Algebra.TensorProduct.includeRight).symm
+  · simp only [Fin.cons_succ]; infer_instance
+  · simp only [Fin.cons_succ]; infer_instance
+  · rw [← hP'φ] at heP'; simpa [he'0]
+  · simpa
+
+set_option backward.isDefEq.respectTransparency false in
+/-- A less universe polymorphic version of
+`exists_etale_completeOrthogonalIdempotents_forall_liesOver_eq`. Use that instead. -/
+private lemma Algebra.exists_etale_completeOrthogonalIdempotents_forall_liesOver_eq'
+    {R : Type u} {S : Type max u v} [CommRing R] [CommRing S] [Algebra R S] [Module.Finite R S]
+    (p : Ideal R) [p.IsPrime] :
+    ∃ (R' : Type u) (_ : CommRing R') (_ : Algebra R R') (_ : Algebra.Etale R R') (P : Ideal R')
+      (_ : P.IsPrime) (_ : P.LiesOver p) (n : ℕ) (e : Fin (n + 1) → R' ⊗[R] S)
+      (_ : CompleteOrthogonalIdempotents e) (P' : Fin n → Ideal (R' ⊗[R] S))
+      (_ : ∀ i, (P' i).IsPrime) (_ : ∀ i, (P' i).LiesOver P),
+      Function.Bijective (Ideal.ResidueField.mapₐ p P (Algebra.ofId _ _) (P.over_def p)) ∧
+      (∀ i, e i.castSucc ∉ P' i) ∧
+      ∀ (P'' : Ideal (R' ⊗[R] S)), P''.IsPrime → P''.LiesOver P →
+        e (.last n) ∈ P'' ∧ ∀ i, e i.castSucc ∉ P'' → P'' = P' i := by
+  induction h : (p.primesOver S).ncard using Nat.strong_induction_on generalizing R S with
+  | h n IH =>
+    have : IsArtinianRing (p.ResidueField ⊗[R] S) := IsArtinianRing.of_finite p.ResidueField _
+    have hpSfin : (p.primesOver S).Finite :=
+      (PrimeSpectrum.primesOverOrderIsoFiber R S p).finite_iff.mpr inferInstance
+    cases n with
+    | zero =>
+      have := (Set.ncard_eq_zero hpSfin).mp h
+      refine ⟨R, inferInstance, inferInstance, inferInstance, p, inferInstance, ⟨rfl⟩, 0, 1,
+        ⟨⟨by simp [IsIdempotentElem],
+          by simp only [Nat.reduceAdd, Pi.one_apply, mul_one, Subsingleton.pairwise]⟩,
+          by simp⟩, nofun, nofun, nofun, ?_, nofun, ?_⟩
+      · convert show Function.Bijective (AlgHom.id R _) from Function.bijective_id; ext
+      · exact fun P h₁ h₂ ↦ (this.le
+          ⟨show (P.comap Algebra.TensorProduct.includeRight.toRingHom).IsPrime from inferInstance,
+          ⟨by simp [P.over_def p, Ideal.under, Ideal.comap_comap]⟩⟩).elim
+    | succ n =>
+    obtain ⟨q, hq, hq'⟩ := Set.nonempty_of_ncard_ne_zero (h.trans_ne (by simp))
+    obtain ⟨R', _, _, _, P, _, _, e, he, P', _, _, hP'q, heP', hpP, _, H⟩ :=
+      Algebra.exists_etale_isIdempotentElem_forall_liesOver_eq p q
+    have : (P.primesOver (R' ⊗[R] S ⧸ Ideal.span {e})).ncard < n + 1 := by
+      let F := Ideal.fiberIsoOfBijectiveResidueField hpP (S := S)
+      refine (Ideal.ncard_primesOver_quotient_singleton_lt_of_notMem _ _
+        P' heP' (F.finite_iff.mpr hpSfin)).trans_le ?_
+      rw [← h, ← Nat.card_coe_set_eq, ← Nat.card_coe_set_eq, Nat.card_congr F.toEquiv]
+    obtain ⟨R'', _, _, _, Q, _, _, n, e' : _ → R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}),
+      he', Q' : _ → Ideal (R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e})), _, _, hPQ, hQ', H'⟩ :=
+      IH _ this (R := R') (S := R' ⊗[R] S ⧸ Ideal.span {e}) P rfl
+    change ∀ (P'' : Ideal (R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}))), P''.IsPrime → P''.LiesOver Q →
+      e' (Fin.last n) ∈ P'' ∧ ∀ (i : Fin n), e' i.castSucc ∉ P'' → P'' = Q' i at H'
+    letI : Algebra R R'' := .compHom _ (algebraMap R R')
+    haveI : IsScalarTower R R' R'' := .of_algebraMap_eq' rfl
+    let φ := Algebra.TensorProduct.map (Algebra.ofId R' R'') (AlgHom.id R S)
+    let e₁ : R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}) ≃ₐ[R''] (R'' ⊗[R] S ⧸ Ideal.span {φ e}) :=
+      tensorQuotientTensorEquiv (R'' := R'') e
+    obtain ⟨e'', he'', he''e'⟩ := CompleteOrthogonalIdempotents.exists_eq_comp_of_ker_eq_span
+      (Ideal.Quotient.mk (Ideal.span {φ e})) (I := Fin (n + 1)) (φ e) (he.map φ) (by simp)
+      (e₁ ∘ e') (he'.map e₁.toRingHom) (fun _ ↦ Ideal.Quotient.mk_surjective _)
+    have he''e'' (i : _) : e₁ (e' i) = e'' i := congr_fun he''e' i
+    have hψe'' (i : _) : (e' i) = e₁.symm (e'' i) := e₁.eq_symm_apply.mpr (he''e'' i)
+    refine exists_etale_completeOrthogonalIdempotents_forall_liesOver_eq_aux p q R' P e P'
+      hP'q heP' hpP (fun P'' h₁ h₂ heP'' ↦ H P'' h₁ h₂ heP'') R'' Q n _
+      ((CompleteOrthogonalIdempotents.equiv (finSuccEquiv _)).mpr he'') rfl
+      (Q' · |>.comap (e₁.symm.toAlgHom.comp (Ideal.Quotient.mkₐ _ _))) hPQ
+      (fun i ↦ by rw [Function.comp_def]; simpa [← hψe''] using hQ' i) ?_
+    simp only [Function.comp_apply, finSuccEquiv_zero,
+      show finSuccEquiv (n + 1) (Fin.last (n + 1)) = Fin.last n from rfl, Fin.castSucc_succ,
+      finSuccEquiv_succ]
+    intro P'' heP'' _ _
+    have : (P''.map (Ideal.Quotient.mk (.span {φ e}))).IsPrime :=
+      Ideal.map_isPrime_of_surjective Ideal.Quotient.mk_surjective (by simpa [Ideal.span_le])
+    have : (P''.map (Ideal.Quotient.mk (.span {φ e}))).LiesOver Q := ⟨by
+      have : P'' ⊔ Ideal.span {φ e} = P'' := by simpa [Ideal.span_le]
+      rw [← Ideal.under_under (B := R'' ⊗[R] S)]
+      simpa [Ideal.under, Ideal.comap_map_of_surjective _ Ideal.Quotient.mk_surjective,
+        ← RingHom.ker_eq_comap_bot, this] using P''.over_def Q⟩
+    have := H' ((P''.map (Ideal.Quotient.mk (.span {φ e}))).comap e₁) inferInstance
+      (inferInstanceAs <| ((P''.map (Ideal.Quotient.mk (.span {φ e}))).comap
+        e₁.toAlgHom).LiesOver Q)
+    have hP'' : (1 - φ e) ∉ P'' :=
+      fun h ↦ ‹P''.IsPrime›.one_notMem (by convert add_mem heP'' h; ring)
+    simp only [Ideal.mem_comap, he''e'',
+      Ideal.mem_map_span_singleton_iff_of_isIdempotentElem (he.map φ),
+      Ideal.IsPrime.mul_mem_left_iff hP''] at this
+    refine ⟨this.1, fun i hi ↦ (this.2 i hi).symm ▸ ?_⟩
+    change _ = Ideal.comap (Ideal.Quotient.mk _) (Ideal.comap (e₁.symm.trans e₁).toRingHom _)
+    simp only [AlgEquiv.symm_trans_self, RingEquiv.toRingHom_eq_coe,
+      AlgEquiv.toRingEquiv_toRingHom, AlgEquiv.refl_toRingHom, Ideal.comap_id]
+    rw [Ideal.comap_map_of_surjective _ Ideal.Quotient.mk_surjective]
+    simpa [left_eq_sup, ← RingHom.ker_eq_comap_bot, Ideal.span_le] using heP''
+
+/--
+If `S` is finite over `R`, and `p` is a prime of `R`, then there exists a etale neighborhood
+`(R', P)` of `p` with `κ(p) = κ(P)` such that `R' ⊗[R] S ≃ₐ[R'] R₁ × ... × Rₙ × A`,
+each `Rᵢ` has a unique prime `Pᵢ` lying over `P`, and no other prime in `R' ⊗[R] S` lies over `P`.
+
+This is merely a iterated application of `Algebra.exists_etale_isIdempotentElem_forall_liesOver_eq`.
+This is weaker than the corresponding statement of stacks project, and the only reason is that
+the corresponding stronger statement is even harder to state and even more annoying to prove.
+-/
+@[stacks 00UL]
+lemma Algebra.exists_etale_completeOrthogonalIdempotents_forall_liesOver_eq
+    {R : Type u} {S : Type v} [CommRing R] [CommRing S] [Algebra R S] [Module.Finite R S]
+    (p : Ideal R) [p.IsPrime] :
+    ∃ (R' : Type u) (_ : CommRing R') (_ : Algebra R R') (_ : Algebra.Etale R R') (P : Ideal R')
+      (_ : P.IsPrime) (_ : P.LiesOver p) (n : ℕ) (e : Fin (n + 1) → R' ⊗[R] S)
+      (_ : CompleteOrthogonalIdempotents e) (P' : Fin n → Ideal (R' ⊗[R] S))
+      (_ : ∀ i, (P' i).IsPrime) (_ : ∀ i, (P' i).LiesOver P),
+      Function.Bijective (Ideal.ResidueField.mapₐ p P (Algebra.ofId _ _) (P.over_def p)) ∧
+      (∀ i, e i.castSucc ∉ P' i) ∧
+      ∀ (P'' : Ideal (R' ⊗[R] S)), P''.IsPrime → P''.LiesOver P →
+        e (.last n) ∈ P'' ∧ ∀ i, e i.castSucc ∉ P'' → P'' = P' i := by
+  have ⟨R', _, _, _, P, _, _, n, e, he, P', _, _, hP, hP', H⟩ :=
+    exists_etale_completeOrthogonalIdempotents_forall_liesOver_eq' (S := ULift.{u} S) p
+  let e₁ : R' ⊗[R] S ≃ₐ[R'] R' ⊗[R] ULift.{u} S :=
+    Algebra.TensorProduct.congr .refl ULift.algEquiv.symm
+  refine ⟨R', _, _, ‹_›, P, ‹_›, ‹_›, n, e₁.symm ∘ e, he.map _,
+    fun i ↦ (P' i).comap e₁.toAlgHom, inferInstance, inferInstance, hP, by simpa,
+    fun P'' _ _ ↦ ?_⟩
+  have := H (P''.comap e₁.symm.toAlgHom) inferInstance inferInstance
+  refine ⟨by simpa using this.1, fun i hi ↦ ?_⟩
+  simp [← this.2 i (by simpa), Ideal.comap_comapₐ]

--- a/Mathlib/RingTheory/Ideal/Quotient/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Over.lean
@@ -12,8 +12,15 @@ public import Mathlib.RingTheory.Ideal.Over
 
 @[expose] public section
 
+variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T]
+
+/-- Given a prime `P` of `R` and an ideal `I` in an `R`-algebra `S`.
+Suppose we can find a prime `P'` over `P`, not containing `I`,
+then the number of primes of `S / I` over `P`
+is strictly less than primes of `S` over `P` (provided they are finite).
+
+The lemma is stated in terms of surjections for syntactic generality. -/
 lemma Ideal.ncard_primesOver_lt_of_not_le
-    {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T]
     (f : S →ₐ[R] T) (Hf : Function.Surjective f)
     (P : Ideal R) [P.IsPrime] (P' : Ideal S) [P'.IsPrime] [P'.LiesOver P]
     (hkP' : ¬ RingHom.ker f.toRingHom ≤ P') (H : (P.primesOver S).Finite) :
@@ -25,7 +32,6 @@ lemma Ideal.ncard_primesOver_lt_of_not_le
   · rintro ⟨q, ⟨_, _⟩, rfl⟩; exact hkP' (Ideal.ker_le_comap _)
 
 lemma Ideal.ncard_primesOver_quotient_singleton_lt_of_notMem
-    {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
     (P : Ideal R) [P.IsPrime] (e : S) (P' : Ideal S) [P'.IsPrime] [P'.LiesOver P]
     (heP' : e ∉ P') (H : (P.primesOver S).Finite) :
     (P.primesOver (S ⧸ Ideal.span {e})).ncard < (P.primesOver S).ncard :=

--- a/Mathlib/RingTheory/Ideal/Quotient/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Over.lean
@@ -22,7 +22,7 @@ is strictly less than primes of `S` over `P` (provided they are finite).
 The lemma is stated in terms of surjections for syntactic generality. -/
 lemma Ideal.ncard_primesOver_lt_of_not_le
     (f : S →ₐ[R] T) (Hf : Function.Surjective f)
-    (P : Ideal R) [P.IsPrime] (P' : Ideal S) [P'.IsPrime] [P'.LiesOver P]
+    (P : Ideal R) (P' : Ideal S) [P'.IsPrime] [P'.LiesOver P]
     (hkP' : ¬ RingHom.ker f.toRingHom ≤ P') (H : (P.primesOver S).Finite) :
     (P.primesOver T).ncard < (P.primesOver S).ncard := by
   rw [← Set.ncard_image_of_injective _ (Ideal.comap_injective_of_surjective _ Hf)]
@@ -32,7 +32,7 @@ lemma Ideal.ncard_primesOver_lt_of_not_le
   · rintro ⟨q, ⟨_, _⟩, rfl⟩; exact hkP' (Ideal.ker_le_comap _)
 
 lemma Ideal.ncard_primesOver_quotient_singleton_lt_of_notMem
-    (P : Ideal R) [P.IsPrime] (e : S) (P' : Ideal S) [P'.IsPrime] [P'.LiesOver P]
+    (P : Ideal R) (e : S) (P' : Ideal S) [P'.IsPrime] [P'.LiesOver P]
     (heP' : e ∉ P') (H : (P.primesOver S).Finite) :
     (P.primesOver (S ⧸ Ideal.span {e})).ncard < (P.primesOver S).ncard :=
   Ideal.ncard_primesOver_lt_of_not_le _ (Ideal.Quotient.mkₐ_surjective R _) _ P' (by simpa) H

--- a/Mathlib/RingTheory/Ideal/Quotient/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Over.lean
@@ -8,9 +8,9 @@ module
 public import Mathlib.Data.Set.Card
 public import Mathlib.RingTheory.Ideal.Over
 
-@[expose] public section
-
 /-! # Lemmas about `primesOver` in quotient rings. -/
+
+@[expose] public section
 
 lemma Ideal.ncard_primesOver_lt_of_not_le
     {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T]

--- a/Mathlib/RingTheory/Ideal/Quotient/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Over.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
+module
+
+public import Mathlib.Data.Set.Card
+public import Mathlib.RingTheory.Ideal.Over
+
+@[expose] public section
+
+/-! # Lemmas about `primesOver` in quotient rings. -/
+
+lemma Ideal.ncard_primesOver_lt_of_not_le
+    {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T]
+    (f : S →ₐ[R] T) (Hf : Function.Surjective f)
+    (P : Ideal R) [P.IsPrime] (P' : Ideal S) [P'.IsPrime] [P'.LiesOver P]
+    (hkP' : ¬ RingHom.ker f.toRingHom ≤ P') (H : (P.primesOver S).Finite) :
+    (P.primesOver T).ncard < (P.primesOver S).ncard := by
+  rw [← Set.ncard_image_of_injective _ (Ideal.comap_injective_of_surjective _ Hf)]
+  refine Set.ncard_lt_ncard (Set.ssubset_iff_exists.mpr ⟨?_, P', ⟨‹_›, ‹_›⟩, ?_⟩) H
+  · rintro _ ⟨q, ⟨_, _⟩, rfl⟩
+    exact ⟨inferInstance, inferInstanceAs ((q.comap f).LiesOver _)⟩
+  · rintro ⟨q, ⟨_, _⟩, rfl⟩; exact hkP' (Ideal.ker_le_comap _)
+
+lemma Ideal.ncard_primesOver_quotient_singleton_lt_of_notMem
+    {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
+    (P : Ideal R) [P.IsPrime] (e : S) (P' : Ideal S) [P'.IsPrime] [P'.LiesOver P]
+    (heP' : e ∉ P') (H : (P.primesOver S).Finite) :
+    (P.primesOver (S ⧸ Ideal.span {e})).ncard < (P.primesOver S).ncard :=
+  Ideal.ncard_primesOver_lt_of_not_le _ (Ideal.Quotient.mkₐ_surjective R _) _ P' (by simpa) H

--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.BigOperators.Fin
 public import Mathlib.Algebra.Ring.GeomSum
 public import Mathlib.RingTheory.Ideal.Quotient.Operations
+public import Mathlib.Tactic.LinearCombination
 
 /-!
 
@@ -478,6 +479,33 @@ noncomputable def AlgEquiv.prodQuotientOfIsIdempotentElem
   AlgEquiv.ofBijective ((Ideal.Quotient.mkₐ _ _).prod (Ideal.Quotient.mkₐ _ _)) <|
     RingHom.prod_bijective_of_isIdempotentElem he hf hef₁ hef₂
 
+/-- One can lift complete orthogonal idempotents of `R/e` to get one on `R`. -/
+lemma CompleteOrthogonalIdempotents.exists_eq_comp_of_ker_eq_span
+    (f : R →+* S) (e₀ : R) (he₀ : IsIdempotentElem e₀) (hfe₀ : RingHom.ker f = .span {e₀})
+    (e : I → S) (he : CompleteOrthogonalIdempotents e) (he : ∀ i, e i ∈ f.range) :
+    ∃ e', CompleteOrthogonalIdempotents (Option.rec e₀ e') ∧ e = f ∘ e' := by
+  choose e' he' using he
+  choose k hk using fun i ↦ Ideal.mem_span_singleton.mp
+      (hfe₀.le (show f (e' i * e' i - e' i) = 0 by simp [he', (he.1.1 i).eq]))
+  refine ⟨(1 - e₀) • e', ⟨⟨Option.rec he₀ fun i ↦ ?_, ?_⟩, ?_⟩, ?_⟩
+  · rintro (_|i) (_|j) h
+    · simp at h
+    · dsimp; linear_combination - he₀.eq * e' j
+    · dsimp; linear_combination - he₀.eq * e' i
+    · obtain ⟨k, hk⟩ := Ideal.mem_span_singleton.mp
+        (hfe₀.le (show f (e' i * e' j) = 0 by simp [he', he.1.2 (by simpa using h)]))
+      dsimp
+      rw [mul_mul_mul_comm, hk, he₀.one_sub.eq, ← mul_assoc, he₀.one_sub_mul_self, zero_mul]
+  · obtain ⟨k, hk⟩ := Ideal.mem_span_singleton.mp
+      (hfe₀.le (show f (∑ i, e' i - 1) = 0 by simpa [he', sub_eq_zero] using he.2))
+    simp only [Fintype.sum_option, Pi.smul_apply, smul_eq_mul, ← Finset.mul_sum,
+      sub_eq_iff_eq_add.mp hk]
+    linear_combination - he₀.eq * k
+  · have : f e₀ = 0 := by simpa using hfe₀.ge (Ideal.mem_span_singleton_self _)
+    aesop
+  · dsimp [IsIdempotentElem]
+    linear_combination congr($(he₀.eq) * ((e' i) ^ 2 - k i) + (1 - e₀) * $(hk i))
+
 end CommRing
 
 section corner
@@ -588,5 +616,15 @@ give rise to a direct product decomposition. -/
 def CompleteOrthogonalIdempotents.ringEquivOfComm [CommSemiring R]
     (he : CompleteOrthogonalIdempotents e) : R ≃+* Π i, (he.idem i).Corner :=
   he.ringEquivOfIsMulCentral fun _ ↦ Semigroup.mem_center_iff.mpr fun _ ↦ mul_comm ..
+
+lemma Ideal.mem_map_span_singleton_iff_of_isIdempotentElem
+    [CommRing R] {e r : R} (he : IsIdempotentElem e) {I : Ideal R} :
+    Ideal.Quotient.mk _ r ∈ I.map (Ideal.Quotient.mk (Ideal.span {e})) ↔ (1 - e) * r ∈ I := by
+  simp only [Ideal.mem_map_iff_of_surjective _ Ideal.Quotient.mk_surjective,
+    Ideal.Quotient.mk_eq_mk_iff_sub_mem, Ideal.mem_span_singleton]
+  refine ⟨?_, fun H ↦ ⟨_, H, by simp [sub_mul]⟩⟩
+  rintro ⟨s, hs, t, hrst⟩
+  convert I.mul_mem_left (1 - e) hs using 1
+  linear_combination he.eq * t - (1 - e) * hrst
 
 end corner

--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -481,12 +481,13 @@ noncomputable def AlgEquiv.prodQuotientOfIsIdempotentElem
 
 /-- One can lift a family of complete orthogonal idempotents of `R/e₀` to get one on `R`.
 
-Note that the lemma itself is stated in terms of surjections instead for syntactic generality. -/
+Note that the lemma itself is stated in terms of surjections (where `T = S / I`)
+instead for syntactic generality. -/
 lemma CompleteOrthogonalIdempotents.exists_eq_comp_of_ker_eq_span
     (f : R →+* S) (e₀ : R) (he₀ : IsIdempotentElem e₀) (hfe₀ : RingHom.ker f = .span {e₀})
-    (e : I → S) (he : CompleteOrthogonalIdempotents e) (he : ∀ i, e i ∈ f.range) :
+    (e : I → S) (he : CompleteOrthogonalIdempotents e) (hef : ∀ i, e i ∈ f.range) :
     ∃ e', CompleteOrthogonalIdempotents (Option.rec e₀ e') ∧ e = f ∘ e' := by
-  choose e' he' using he
+  choose e' he' using hef
   choose k hk using fun i ↦ Ideal.mem_span_singleton.mp
       (hfe₀.le (show f (e' i * e' i - e' i) = 0 by simp [he', (he.1.1 i).eq]))
   refine ⟨(1 - e₀) • e', ⟨⟨Option.rec he₀ fun i ↦ ?_, ?_⟩, ?_⟩, ?_⟩

--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -479,7 +479,9 @@ noncomputable def AlgEquiv.prodQuotientOfIsIdempotentElem
   AlgEquiv.ofBijective ((Ideal.Quotient.mkₐ _ _).prod (Ideal.Quotient.mkₐ _ _)) <|
     RingHom.prod_bijective_of_isIdempotentElem he hf hef₁ hef₂
 
-/-- One can lift complete orthogonal idempotents of `R/e` to get one on `R`. -/
+/-- One can lift a family of complete orthogonal idempotents of `R/e₀` to get one on `R`.
+
+Note that the lemma itself is stated in terms of surjections instead for syntactic generality. -/
 lemma CompleteOrthogonalIdempotents.exists_eq_comp_of_ker_eq_span
     (f : R →+* S) (e₀ : R) (he₀ : IsIdempotentElem e₀) (hfe₀ : RingHom.ker f = .span {e₀})
     (e : I → S) (he : CompleteOrthogonalIdempotents e) (he : ∀ i, e i ∈ f.range) :

--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -625,7 +625,7 @@ lemma Ideal.mem_map_span_singleton_iff_of_isIdempotentElem
   simp only [Ideal.mem_map_iff_of_surjective _ Ideal.Quotient.mk_surjective,
     Ideal.Quotient.mk_eq_mk_iff_sub_mem, Ideal.mem_span_singleton]
   refine ⟨?_, fun H ↦ ⟨_, H, by simp [sub_mul]⟩⟩
-  rintro ⟨s, hs, t, hrst⟩
+  intro ⟨s, hs, t, hrst⟩
   convert I.mul_mem_left (1 - e) hs using 1
   linear_combination he.eq * t - (1 - e) * hrst
 

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Ideal.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Ideal.lean
@@ -246,3 +246,6 @@ lemma Ideal.ResidueField.ringHom_ext {I : Ideal R} [I.IsPrime]
 lemma Ideal.ResidueField.algHom_ext {I : Ideal A} [I.IsPrime] {f g : I.ResidueField →ₐ[R] B}
     (H : f.comp (IsScalarTower.toAlgHom R A _) = g.comp (IsScalarTower.toAlgHom R A _)) : f = g :=
   AlgHom.coe_ringHom_injective (ringHom_ext congr($H))
+
+@[simp] lemma Ideal.ResidueField.mapₐ_id (I : Ideal A) [I.IsPrime] :
+    Ideal.ResidueField.mapₐ I I (.id R A) rfl = .id _ _ := by ext; simp

--- a/Mathlib/RingTheory/TensorProduct/Quotient.lean
+++ b/Mathlib/RingTheory/TensorProduct/Quotient.lean
@@ -159,7 +159,8 @@ variable {R R' R'' S : Type*} [CommRing R] [CommRing R'] [CommRing R''] [CommRin
 variable (R'') in
 set_option backward.isDefEq.respectTransparency false in
 attribute [local ext high] Ideal.Quotient.algHom_ext in
-/-- Let `e` be an element of `R' ⊗[R] S`. Then `R'' ⊗[R'] (R' ⊗[R] S / <e>) = R'' ⊗[R] S / <e>`. -/
+/-- Let `e` be an element of `R' ⊗[R] S`. Then `R'' ⊗[R'] ((R' ⊗[R] S) / e)` is isomorphic to
+`(R'' ⊗[R] S) / e` as `R''`-algebras. -/
 noncomputable
 def Algebra.tensorQuotientTensorEquiv (e : R' ⊗[R] S) :
     R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}) ≃ₐ[R'']

--- a/Mathlib/RingTheory/TensorProduct/Quotient.lean
+++ b/Mathlib/RingTheory/TensorProduct/Quotient.lean
@@ -164,7 +164,7 @@ attribute [local ext high] Ideal.Quotient.algHom_ext in
 noncomputable
 def Algebra.tensorQuotientTensorEquiv (e : R' ⊗[R] S) :
     R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}) ≃ₐ[R'']
-    (R'' ⊗[R] S ⧸ Ideal.span {Algebra.TensorProduct.map (Algebra.ofId R' R'') (AlgHom.id R S) e}) :=
+    (R'' ⊗[R] S ⧸ Ideal.span {Algebra.TensorProduct.rTensor S (Algebra.ofId R' R'') e}) :=
   letI φ := Algebra.TensorProduct.rTensor S (Algebra.ofId R' R'')
   letI ψ : R'' ⊗[R] S →ₐ[R''] R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}) :=
     Algebra.TensorProduct.lift (Algebra.ofId _ _)

--- a/Mathlib/RingTheory/TensorProduct/Quotient.lean
+++ b/Mathlib/RingTheory/TensorProduct/Quotient.lean
@@ -160,10 +160,11 @@ variable (R'') in
 set_option backward.isDefEq.respectTransparency false in
 attribute [local ext high] Ideal.Quotient.algHom_ext in
 /-- Let `e` be an element of `R' ⊗[R] S`. Then `R'' ⊗[R'] (R' ⊗[R] S / <e>) = R'' ⊗[R] S / <e>`. -/
+noncomputable
 def Algebra.tensorQuotientTensorEquiv (e : R' ⊗[R] S) :
     R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}) ≃ₐ[R'']
     (R'' ⊗[R] S ⧸ Ideal.span {Algebra.TensorProduct.map (Algebra.ofId R' R'') (AlgHom.id R S) e}) :=
-  letI φ := Algebra.TensorProduct.map (Algebra.ofId R' R'') (AlgHom.id R S)
+  letI φ := Algebra.TensorProduct.rTensor S (Algebra.ofId R' R'')
   letI ψ : R'' ⊗[R] S →ₐ[R''] R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}) :=
     Algebra.TensorProduct.lift (Algebra.ofId _ _)
       ((Algebra.TensorProduct.includeRight.restrictScalars R).comp

--- a/Mathlib/RingTheory/TensorProduct/Quotient.lean
+++ b/Mathlib/RingTheory/TensorProduct/Quotient.lean
@@ -150,3 +150,42 @@ lemma Ideal.subtype_rTensor_range {R : Type*} [CommRing R] (M : Type*) [AddCommG
     ← Submodule.map_symm_eq_iff, ← Submodule.comap_equiv_eq_map_symm, ← LinearMap.ker_comp,
     ← TensorProduct.quotTensorEquivQuotSMul_comp_mkQ_rTensor, LinearEquiv.ker_comp]
   exact LinearMap.exact_iff.mp (rTensor_exact M (LinearMap.exact_subtype_mkQ I) I.mkQ_surjective)
+
+section
+
+variable {R R' R'' S : Type*} [CommRing R] [CommRing R'] [CommRing R''] [CommRing S]
+  [Algebra R R'] [Algebra R R''] [Algebra R' R''] [IsScalarTower R R' R''] [Algebra R S]
+
+variable (R'') in
+set_option backward.isDefEq.respectTransparency false in
+attribute [local ext high] Ideal.Quotient.algHom_ext in
+/-- Let `e` be an element of `R' ⊗[R] S`. Then `R'' ⊗[R'] (R' ⊗[R] S / <e>) = R'' ⊗[R] S / <e>`. -/
+def Algebra.tensorQuotientTensorEquiv (e : R' ⊗[R] S) :
+    R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}) ≃ₐ[R'']
+    (R'' ⊗[R] S ⧸ Ideal.span {Algebra.TensorProduct.map (Algebra.ofId R' R'') (AlgHom.id R S) e}) :=
+  letI φ := Algebra.TensorProduct.map (Algebra.ofId R' R'') (AlgHom.id R S)
+  letI ψ : R'' ⊗[R] S →ₐ[R''] R'' ⊗[R'] (R' ⊗[R] S ⧸ Ideal.span {e}) :=
+    Algebra.TensorProduct.lift (Algebra.ofId _ _)
+      ((Algebra.TensorProduct.includeRight.restrictScalars R).comp
+      ((Ideal.Quotient.mkₐ _ _).comp Algebra.TensorProduct.includeRight)) fun _ _ ↦ .all _ _
+  haveI hψφ : (ψ.restrictScalars R').comp φ =
+      (Algebra.TensorProduct.includeRight.restrictScalars R').comp (Ideal.Quotient.mkₐ _ _) := by
+    ext; simp [ψ, φ]
+  haveI heψ : Ideal.span {φ e} ≤ RingHom.ker ψ := by simpa [Ideal.span_le] using congr($hψφ e)
+  AlgEquiv.ofAlgHom (Algebra.TensorProduct.lift (Algebra.ofId _ _) (Ideal.quotientMapₐ _ φ
+    (Ideal.map_le_iff_le_comap.mp (by simp [Ideal.map_span, φ]))) fun _ _ ↦ .all _ _)
+    (Ideal.Quotient.liftₐ _ ψ heψ) (by ext; simp [ψ, φ]) (by ext; simp [φ, ψ])
+
+@[simp]
+lemma Algebra.tensorQuotientTensorEquiv_tmul (e : R' ⊗[R] S) (a : R'') (b : R') (c : S) :
+    Algebra.tensorQuotientTensorEquiv R'' e (a ⊗ₜ Ideal.Quotient.mk _ (b ⊗ₜ c)) =
+      Ideal.Quotient.mk _ ((a * algebraMap R' R'' b) ⊗ₜ c) := by
+  simp [Algebra.tensorQuotientTensorEquiv, ← Ideal.Quotient.mk_algebraMap, ← map_mul]
+
+@[simp]
+lemma Algebra.tensorQuotientTensorEquiv_symm_tmul (e : R' ⊗[R] S) (a : R'') (b : S) :
+    (Algebra.tensorQuotientTensorEquiv R'' e).symm (Ideal.Quotient.mk _ (a ⊗ₜ b)) =
+      a ⊗ₜ Ideal.Quotient.mk _ (1 ⊗ₜ b) := by
+  simp [Algebra.tensorQuotientTensorEquiv]
+
+end


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
