### PR TITLE
[Merged by Bors] - chore: fix some diamonds around `Lex`/`Colex`

### DIFF
--- a/Mathlib/Combinatorics/Colex.lean
+++ b/Mathlib/Combinatorics/Colex.lean
@@ -69,8 +69,6 @@ namespace Finset
 
 open Colex
 
-instance : Inhabited (Colex (Finset α)) := ⟨toColex ∅⟩
-
 namespace Colex
 section PartialOrder
 variable [PartialOrder α] [PartialOrder β] {f : α → β} {𝒜 𝒜₁ 𝒜₂ : Finset (Finset α)}

--- a/Mathlib/Data/DFinsupp/Lex.lean
+++ b/Mathlib/Data/DFinsupp/Lex.lean
@@ -105,6 +105,7 @@ instance Colex.isStrictOrder [∀ i, PartialOrder (α i)] :
 See `DFinsupp.Lex.linearOrder` for a proof that this partial order is in fact linear. -/
 instance Lex.partialOrder [∀ i, PartialOrder (α i)] : PartialOrder (Lex (Π₀ i, α i)) where
   le x y := ⇑(ofLex x) = ⇑(ofLex y) ∨ x < y
+  toLT := instLTLex
   __ := PartialOrder.lift (fun x : Lex (Π₀ i, α i) ↦ toLex (⇑(ofLex x)))
     (DFunLike.coe_injective (F := DFinsupp α))
 
@@ -112,6 +113,7 @@ instance Lex.partialOrder [∀ i, PartialOrder (α i)] : PartialOrder (Lex (Π�
 See `DFinsupp.Colex.linearOrder` for a proof that this partial order is in fact linear. -/
 instance Colex.partialOrder [∀ i, PartialOrder (α i)] : PartialOrder (Colex (Π₀ i, α i)) where
   le x y := ⇑(ofColex x) = ⇑(ofColex y) ∨ x < y
+  toLT := instLTColex
   __ := PartialOrder.lift (fun x : Colex (Π₀ i, α i) ↦ toColex (⇑(ofColex x)))
     (DFunLike.coe_injective (F := DFinsupp α))
 
@@ -175,14 +177,12 @@ instance Colex.decidableLT : DecidableLT (Colex (Π₀ i, α i)) :=
 
 /-- The linear order on `DFinsupp`s obtained by the lexicographic ordering. -/
 instance Lex.linearOrder : LinearOrder (Lex (Π₀ i, α i)) where
-  __ := Lex.partialOrder
   le_total := total_of _
   toDecidableLT := decidableLT
   toDecidableLE := decidableLE
 
 /-- The linear order on `DFinsupp`s obtained by the colexicographic ordering. -/
 instance Colex.linearOrder : LinearOrder (Colex (Π₀ i, α i)) where
-  __ := Colex.partialOrder
   le_total := total_of _
   toDecidableLT := decidableLT
   toDecidableLE := decidableLE

--- a/Mathlib/Order/PiLex.lean
+++ b/Mathlib/Order/PiLex.lean
@@ -81,11 +81,13 @@ theorem trichotomous_lex [∀ i, Std.Trichotomous (α := β i) s] (wf : WellFoun
 
 @[deprecated (since := "2026-01-24")] alias isTrichotomous_lex := trichotomous_lex
 
+-- We would like to mark these instances `@[semireducible]`, but the linter doesn't allow this,
+-- so we wrap them in `id` instead.
 instance [LT ι] [∀ a, LT (β a)] : LT (Lex (∀ i, β i)) :=
-  ⟨Pi.Lex (· < ·) (· < ·)⟩
+  id ⟨Pi.Lex (· < ·) (· < ·)⟩
 
 instance [LT ι] [∀ a, LT (β a)] : LT (Colex (∀ i, β i)) :=
-  ⟨Pi.Lex (· > ·) (· < ·)⟩
+  id ⟨Pi.Lex (· > ·) (· < ·)⟩
 
 -- If `Lex` and `Colex` are ever made into one-field structures, we need a `CoeFun` instance.
 -- This will make `x i` syntactically equal to `ofLex x i` for `x : Πₗ i, α i`, thus making

--- a/Mathlib/Order/PiLex.lean
+++ b/Mathlib/Order/PiLex.lean
@@ -81,8 +81,11 @@ theorem trichotomous_lex [∀ i, Std.Trichotomous (α := β i) s] (wf : WellFoun
 
 @[deprecated (since := "2026-01-24")] alias isTrichotomous_lex := trichotomous_lex
 
--- We would like to mark these instances `@[semireducible]`, but the linter doesn't allow this,
--- so we wrap them in `id` instead.
+/-
+These instances are leaky, because they define the relation on `∀ i, β i` instead of
+`Lex (∀ i, β i)`/`Colex (∀ i, β i)`. So, we would like to mark them `@[semireducible]`.
+But the linter doesn't allow this, so we wrap them in `id` instead.
+-/
 instance [LT ι] [∀ a, LT (β a)] : LT (Lex (∀ i, β i)) :=
   id ⟨Pi.Lex (· < ·) (· < ·)⟩
 


### PR DESCRIPTION
This PR fixes some instance diamonds found by the instance diamond linter (#38781)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
