### PR TITLE
[Merged by Bors] - feat(CategoryTheory/ObjectProperty): preservation of limits is closed under isomorphisms

### DIFF
--- a/Mathlib/CategoryTheory/ObjectProperty/CompleteLattice.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/CompleteLattice.lean
@@ -97,6 +97,13 @@ instance [∀ a, (P a).IsClosedUnderIsomorphisms] :
   simp only [isClosedUnderIsomorphisms_iff_isoClosure_eq_self,
     isoClosure_iSup, isoClosure_eq_self]
 
+instance [∀ a, (P a).IsClosedUnderIsomorphisms] :
+    ((⨅ (a : α), P a)).IsClosedUnderIsomorphisms where
+  of_iso e h := by
+    simp only [iInf_apply, iInf_Prop_eq] at h ⊢
+    intro a
+    exact (P a).prop_of_iso e (h a)
+
 end
 
 @[push]

--- a/Mathlib/CategoryTheory/ObjectProperty/FunctorCategory/PreservesLimits.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/FunctorCategory/PreservesLimits.lean
@@ -45,6 +45,9 @@ lemma congr_preservesLimit {F F' : K ⥤ J} (e : F ≅ F') :
   exact ⟨fun h ↦ preservesLimit_of_iso_diagram _ e,
     fun h ↦ preservesLimit_of_iso_diagram _ e.symm⟩
 
+instance (F : K ⥤ J) : (preservesLimit (C := C) F).IsClosedUnderIsomorphisms where
+  of_iso e _ := preservesLimit_of_natIso _ e
+
 variable {K} in
 /-- The property of objects in the functor category `J ⥤ C`
 which preserves the colimit of a functor `F : K ⥤ J`. -/
@@ -60,6 +63,9 @@ lemma congr_preservesColimit {F F' : K ⥤ J} (e : F ≅ F') :
   simp_rw [preservesColimit_iff]
   exact ⟨fun h ↦ preservesColimit_of_iso_diagram _ e,
     fun h ↦ preservesColimit_of_iso_diagram _ e.symm⟩
+
+instance (F : K ⥤ J) : (preservesColimit (C := C) F).IsClosedUnderIsomorphisms where
+  of_iso e _ := preservesColimit_of_natIso _ e
 
 /-- The property of objects in the functor category `J ⥤ C`
 which preserves limits of shape `K`. -/
@@ -84,6 +90,10 @@ lemma congr_preservesLimitsOfShape (e : K ≌ K') :
   exact ⟨fun _ ↦ preservesLimitsOfShape_of_equiv e _,
     fun _ ↦ preservesLimitsOfShape_of_equiv e.symm _⟩
 
+instance : (preservesLimitsOfShape (J := J) (C := C) K).IsClosedUnderIsomorphisms := by
+  rw [preservesLimitsOfShape_eq_iSup]
+  infer_instance
+
 /-- The property of objects in the functor category `J ⥤ C`
 which preserves colimits of shape `K`. -/
 abbrev preservesColimitsOfShape : ObjectProperty (J ⥤ C) := PreservesColimitsOfShape K
@@ -107,6 +117,10 @@ lemma congr_preservesColimitsOfShape (e : K ≌ K') :
   exact ⟨fun _ ↦ preservesColimitsOfShape_of_equiv e _,
     fun _ ↦ preservesColimitsOfShape_of_equiv e.symm _⟩
 
+instance : (preservesColimitsOfShape (J := J) (C := C) K).IsClosedUnderIsomorphisms := by
+  rw [preservesColimitsOfShape_eq_iSup]
+  infer_instance
+
 /-- The property of objects in the functor category `J ⥤ C`
 which preserves finite limits. -/
 abbrev preservesFiniteLimits : ObjectProperty (J ⥤ C) := PreservesFiniteLimits
@@ -115,9 +129,15 @@ abbrev preservesFiniteLimits : ObjectProperty (J ⥤ C) := PreservesFiniteLimits
 lemma preservesFiniteLimits_iff (F : J ⥤ C) :
     preservesFiniteLimits F ↔ PreservesFiniteLimits F := Iff.rfl
 
+instance : (preservesFiniteLimits (J := J) (C := C)).IsClosedUnderIsomorphisms where
+  of_iso e _ := preservesFiniteLimits_of_natIso e
+
 /-- The property of objects in the functor category `J ⥤ C`
 which preserves finite colimits. -/
 abbrev preservesFiniteColimits : ObjectProperty (J ⥤ C) := PreservesFiniteColimits
+
+instance : (preservesFiniteColimits (J := J) (C := C)).IsClosedUnderIsomorphisms where
+  of_iso e _ := preservesFiniteColimits_of_natIso e
 
 @[simp]
 lemma preservesFiniteColimits_iff (F : J ⥤ C) :


### PR DESCRIPTION
This is only the translation of this statement in terms of some `ObjectProperty` in functor categories.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
