### PR TITLE
Draft

### DIFF
--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -47,9 +47,7 @@ synthesized value{indentExpr val}\nis not definitionally equal to{indentExpr x}"
 
 /-- Synthesize arguments `xs` either with typeclass synthesis, with `fun_prop` or with
 discharger. -/
-def synthesizeArgs (thmId : Origin) (xs : Array Expr)
-    (funProp : Expr → FunPropM (Option Result)) :
-    FunPropM Bool := do
+def synthesizeArgs (thmId : Origin) (xs : Array Expr) : FunPropM Bool := do
   let mut postponed : Array Expr := #[]
   for x in xs do
     let type ← inferType x
@@ -61,8 +59,8 @@ def synthesizeArgs (thmId : Origin) (xs : Array Expr)
           continue
       else if (← isFunPropGoal type) then
         -- try function property
-        if let some ⟨proof⟩ ← funProp type then
-          if (← isDefEq x proof) then
+        if let some r ← funProp type then
+          if (← isDefEq x r.proof) then
             continue
           else do
             trace[Meta.Tactic.fun_prop]
@@ -113,14 +111,14 @@ def synthesizeArgs (thmId : Origin) (xs : Array Expr)
 
 
 /-- Try to apply theorem - core function -/
-def tryTheoremCore (xs : Array Expr) (val : Expr) (type : Expr) (e : Expr)
-    (thmId : Origin) (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
+def tryTheoremCore (xs : Array Expr) (val : Expr) (type : Expr) (e : Expr) (thmId : Origin) :
+    FunPropM (Option Result) := do
   withTraceNode `Meta.Tactic.fun_prop
     (fun _ => return s!"applying: {← ppOrigin' thmId}") do
 
   if (← isDefEq type e) then
 
-    if ¬(← synthesizeArgs thmId xs funProp) then
+    if ¬(← synthesizeArgs thmId xs) then
       return none
     let proof ← instantiateMVars (mkAppN val xs)
 
@@ -132,8 +130,7 @@ def tryTheoremCore (xs : Array Expr) (val : Expr) (type : Expr) (e : Expr)
 
 /-- Try to apply a theorem provided some of the theorem arguments. -/
 def tryTheoremWithHint? (e : Expr) (thmOrigin : Origin)
-    (hint : Array (Nat × Expr))
-    (funProp : Expr → FunPropM (Option Result)) (newMCtxDepth : Bool := false) :
+    (hint : Array (Nat × Expr)) (newMCtxDepth : Bool := false) :
     FunPropM (Option Result) := do
   let go : FunPropM (Option Result) := do
     let thmProof ← thmOrigin.getValue
@@ -149,7 +146,7 @@ def tryTheoremWithHint? (e : Expr) (thmOrigin : Origin)
         trace[Debug.Meta.Tactic.fun_prop]
           "failed to use hint {i} `{← ppExpr x} when applying theorem {← ppOrigin thmOrigin}"
 
-    tryTheoremCore xs thmProof type e thmOrigin funProp
+    tryTheoremCore xs thmProof type e thmOrigin
 
   -- `simp` introduces new meta variable context depth for some reason
   -- This is probably to avoid mvar assignment when trying a theorem fails
@@ -171,9 +168,9 @@ def tryTheoremWithHint? (e : Expr) (thmOrigin : Origin)
 
 
 /-- Try to apply a theorem `thmOrigin` to the goal `e`. -/
-def tryTheorem? (e : Expr) (thmOrigin : Origin) (funProp : Expr → FunPropM (Option Result))
-    (newMCtxDepth : Bool := false) : FunPropM (Option Result) :=
-  tryTheoremWithHint? e thmOrigin #[] funProp newMCtxDepth
+def tryTheorem? (e : Expr) (thmOrigin : Origin) (newMCtxDepth : Bool := false) :
+    FunPropM (Option Result) :=
+  tryTheoremWithHint? e thmOrigin #[] newMCtxDepth
 
 
 /--
@@ -181,8 +178,7 @@ Try to prove `e` using the *identity lambda theorem*.
 
 For example, `e = q(Continuous fun x ↦ x)` and `funPropDecl` is `FunPropDecl` for `Continuous`.
 -/
-def applyIdRule (funPropDecl : FunPropDecl) (e : Expr)
-    (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
+def applyIdRule (funPropDecl : FunPropDecl) (e : Expr) : FunPropM (Option Result) := do
   let thms ← getLambdaTheorems funPropDecl.funPropName .id
   if thms.size = 0 then
     let msg := s!"missing identity rule to prove `{← ppExpr e}`"
@@ -191,7 +187,7 @@ def applyIdRule (funPropDecl : FunPropDecl) (e : Expr)
     return none
 
   for thm in thms do
-    if let some r ← tryTheoremWithHint? e (.decl thm.thmName) #[] funProp then
+    if let some r ← tryTheoremWithHint? e (.decl thm.thmName) #[] then
       return r
 
   return none
@@ -201,8 +197,8 @@ Try to prove `e` using the *constant lambda theorem*.
 
 For example, `e = q(Continuous fun x ↦ y)` and `funPropDecl` is `FunPropDecl` for `Continuous`.
 -/
-def applyConstRule (funPropDecl : FunPropDecl) (e : Expr)
-    (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
+def applyConstRule (funPropDecl : FunPropDecl) (e : Expr) :
+    FunPropM (Option Result) := do
   let thms ← getLambdaTheorems funPropDecl.funPropName .const
   if thms.size = 0 then
     let msg := s!"missing constant rule to prove `{← ppExpr e}`"
@@ -211,7 +207,7 @@ def applyConstRule (funPropDecl : FunPropDecl) (e : Expr)
     return none
   for thm in thms do
     let .const := thm.thmArgs | return none
-    if let some r ← tryTheorem? e (.decl thm.thmName) funProp then
+    if let some r ← tryTheorem? e (.decl thm.thmName) then
       return r
 
   return none
@@ -221,11 +217,10 @@ Try to prove `e` using the *apply lambda theorem*.
 
 For example, `e = q(Continuous fun f ↦ f x)` and `funPropDecl` is `FunPropDecl` for `Continuous`.
 -/
-def applyApplyRule (funPropDecl : FunPropDecl) (e : Expr)
-    (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
+def applyApplyRule (funPropDecl : FunPropDecl) (e : Expr) : FunPropM (Option Result) := do
   let thms := (← getLambdaTheorems funPropDecl.funPropName .apply)
   for thm in thms do
-    if let some r ← tryTheoremWithHint? e (.decl thm.thmName) #[] funProp then
+    if let some r ← tryTheoremWithHint? e (.decl thm.thmName) #[] then
       return r
 
   return none
@@ -237,8 +232,7 @@ For example, `e = q(Continuous fun x ↦ f (g x))` and `funPropDecl` is `FunProp
 `Continuous`
 
 You also have to provide the functions `f` and `g`. -/
-def applyCompRule (funPropDecl : FunPropDecl) (e f g : Expr)
-    (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
+def applyCompRule (funPropDecl : FunPropDecl) (e f g : Expr) : FunPropM (Option Result) := do
 
   let thms ← getLambdaTheorems funPropDecl.funPropName .comp
   if thms.size = 0 then
@@ -249,7 +243,7 @@ def applyCompRule (funPropDecl : FunPropDecl) (e f g : Expr)
 
   for thm in thms do
     let .comp id_f id_g := thm.thmArgs | return none
-    if let some r ← tryTheoremWithHint? e (.decl thm.thmName) #[(id_f, f), (id_g, g)] funProp then
+    if let some r ← tryTheoremWithHint? e (.decl thm.thmName) #[(id_f, f), (id_g, g)] then
       return r
 
   return none
@@ -260,8 +254,7 @@ Try to prove `e` using *pi lambda theorem*.
 For example, `e = q(Continuous fun x y ↦ f x y)` and `funPropDecl` is `FunPropDecl` for
 `Continuous`
 -/
-def applyPiRule (funPropDecl : FunPropDecl) (e : Expr)
-    (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
+def applyPiRule (funPropDecl : FunPropDecl) (e : Expr) : FunPropM (Option Result) := do
 
   let thms ← getLambdaTheorems funPropDecl.funPropName .pi
   if thms.size = 0 then
@@ -271,7 +264,7 @@ def applyPiRule (funPropDecl : FunPropDecl) (e : Expr)
     return none
 
   for thm in thms do
-    if let some r ← tryTheoremWithHint? e (.decl thm.thmName) #[] funProp then
+    if let some r ← tryTheoremWithHint? e (.decl thm.thmName) #[] then
       return r
 
   return none
@@ -285,8 +278,7 @@ For example,
   - `e = q(Continuous fun x ↦ let y := φ x; ψ x y)`
   - `f = q(fun x ↦ let y := φ x; ψ x y)`
 -/
-def letCase (funPropDecl : FunPropDecl) (e : Expr) (f : Expr)
-    (funProp : Expr → FunPropM (Option Result)) :
+def letCase (funPropDecl : FunPropDecl) (e : Expr) (f : Expr) :
     FunPropM (Option Result) := do
   match f with
   | .lam xName xType (.letE yName yType yValue yBody _) xBi => do
@@ -312,12 +304,12 @@ def letCase (funPropDecl : FunPropDecl) (e : Expr) (f : Expr)
       let f ← mkUncurryFun 2 (Expr.lam xName xType (.lam yName yType yBody default) xBi)
       let g := Expr.lam xName xType (binderInfo := default)
         (mkAppN (← mkConstWithFreshMVarLevels ``Prod.mk) #[xType,yType,.bvar 0, yValue])
-      applyCompRule funPropDecl e f g funProp
+      applyCompRule funPropDecl e f g
 
     | true, false =>
       let f := Expr.lam yName yType yBody default
       let g := Expr.lam xName xType yValue default
-      applyCompRule funPropDecl e f g funProp
+      applyCompRule funPropDecl e f g
 
     | false, _ =>
       let f := Expr.lam xName xType (yBody.lowerLooseBVars 1 1) xBi
@@ -327,8 +319,8 @@ def letCase (funPropDecl : FunPropDecl) (e : Expr) (f : Expr)
 
 
 /-- Prove function property of using *morphism theorems*. -/
-def applyMorRules (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
-    (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
+def applyMorRules (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData) :
+    FunPropM (Option Result) := do
   trace[Debug.Meta.Tactic.fun_prop] "applying morphism theorems to {← ppExpr e}"
 
   -- get theorems
@@ -338,24 +330,23 @@ def applyMorRules (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 
   -- try theorems
   for c in candidates do
-    if let some r ← tryTheorem? e (.decl c.thmName) funProp then
+    if let some r ← tryTheorem? e (.decl c.thmName) then
       return r
 
   -- if all failed try to add/remove arguments
   match ← fData.isMorApplication with
   | .none => throwError "fun_prop bug: invalid use of mor rules on {← ppExpr e}"
   | .underApplied =>
-    applyPiRule funPropDecl e funProp
+    applyPiRule funPropDecl e
   | .overApplied =>
     let .comp f g ← fData.peeloffArgDecomposition | return none
-    applyCompRule funPropDecl e f g funProp
+    applyCompRule funPropDecl e f g
   | .exact =>
     trace[Debug.Meta.Tactic.fun_prop] "no theorem matched"
     return none
 
 /-- Prove function property of using *transition theorems*. -/
-def applyTransitionRules (e : Expr) (funProp : Expr → FunPropM (Option Result)) :
-    FunPropM (Option Result) := do
+def applyTransitionRules (e : Expr) : FunPropM (Option Result) := do
   withIncreasedTransitionDepth do
 
   let candidates ← getTransitionTheorems e
@@ -364,7 +355,7 @@ def applyTransitionRules (e : Expr) (funProp : Expr → FunPropM (Option Result)
     "candidate transition theorems: {← candidates.mapM fun c => ppOrigin (.decl c.thmName)}"
 
   for c in candidates do
-    if let some r ← tryTheorem? e (.decl c.thmName) funProp then
+    if let some r ← tryTheorem? e (.decl c.thmName) then
       return r
 
   trace[Debug.Meta.Tactic.fun_prop] "no theorem matched"
@@ -379,8 +370,7 @@ For example
 
 This tries to prove `Continuous fun x ↦ foo (bar x) y` from `Continuous fun x ↦ foo (bar x)`
 -/
-def removeArgRule (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
-    (funProp : Expr → FunPropM (Option Result)) :
+def removeArgRule (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData) :
     FunPropM (Option Result) := do
 
   match h : fData.args.size with
@@ -390,23 +380,23 @@ def removeArgRule (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 
     if arg.coe.isSome then
       -- if have to apply morphisms rules if we deal with morphisms
-      return ← applyMorRules funPropDecl e fData funProp
+      return ← applyMorRules funPropDecl e fData
     else
       let .comp f g ← fData.peeloffArgDecomposition | return none
-      applyCompRule funPropDecl e f g funProp
+      applyCompRule funPropDecl e f g
 
 
 /-- Prove function property of `fun f ↦ f x₁ ... xₙ`. -/
 def bvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
-    (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
+    : FunPropM (Option Result) := do
 
   if (← fData.isMorApplication) != .none then
-    applyMorRules funPropDecl e fData funProp
+    applyMorRules funPropDecl e fData
   else
     if let .comp f g ← fData.decomposition then
-      applyCompRule funPropDecl e f g funProp
+      applyCompRule funPropDecl e f g
     else
-      applyApplyRule funPropDecl e funProp
+      applyApplyRule funPropDecl e
 
 /--
 Get candidate theorems from the environment for function property `funPropDecl` and
@@ -482,7 +472,7 @@ def getLocalTheorems (funPropDecl : FunPropDecl) (funOrigin : Origin)
 
 /-- Try to apply *function theorems* `thms` to `e`. -/
 def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
-    (thms : Array FunctionTheorem) (funProp : Expr → FunPropM (Option Result)) :
+    (thms : Array FunctionTheorem) :
     FunPropM (Option Result) := do
 
   -- none - decomposition not tried
@@ -496,17 +486,17 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     match compare thm.appliedArgs fData.args.size with
     | .lt =>
       trace[Meta.Tactic.fun_prop] s!"removing argument to later use {← ppOrigin' thm.thmOrigin}"
-      if let some r ← removeArgRule funPropDecl e fData funProp then
+      if let some r ← removeArgRule funPropDecl e fData then
         return r
       continue
     | .gt =>
       trace[Meta.Tactic.fun_prop] s!"adding argument to later use {← ppOrigin' thm.thmOrigin}"
-      if let some r ← applyPiRule funPropDecl e funProp then
+      if let some r ← applyPiRule funPropDecl e then
         return r
       continue
     | .eq =>
       if thm.form == .comp then
-        if let some r ← tryTheorem? e thm.thmOrigin funProp then
+        if let some r ← tryTheorem? e thm.thmOrigin then
           return r
       else
 
@@ -518,10 +508,10 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
             trace[Meta.Tactic.fun_prop]
               s!"decomposing to later use {←ppOrigin' thm.thmOrigin} as:
                    ({← ppExpr f}) ∘ ({← ppExpr g})"
-            if let some r ← applyCompRule funPropDecl e f g funProp then
+            if let some r ← applyCompRule funPropDecl e f g then
               return r
           | some _ =>
-            if let some r ← tryTheorem? e thm.thmOrigin funProp then
+            if let some r ← tryTheorem? e thm.thmOrigin  then
               return r
           | none => unreachable!
         else
@@ -529,18 +519,18 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
           trace[Meta.Tactic.fun_prop]
             s!"decomposing to later use {←ppOrigin' thm.thmOrigin} as:
                  ({← ppExpr f}) ∘ ({← ppExpr g})"
-          if let some r ← applyCompRule funPropDecl e f g funProp then
+          if let some r ← applyCompRule funPropDecl e f g then
             return r
       -- todo: decompose if uncurried and arguments do not match exactly
   return none
 
 /-- Prove function property of `fun x ↦ f x₁ ... xₙ` where `f` is free variable. -/
-def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
-    (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
+def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData) :
+    FunPropM (Option Result) := do
 
   -- fvar theorems are almost exclusively in uncurried form so we decompose if we can
   if let .comp f g ← fData.decomposition then
-    applyCompRule funPropDecl e f g funProp
+    applyCompRule funPropDecl e f g
   else
     let .fvar id := fData.fn | throwError "fun_prop bug: invalid use of fvar app case"
     let thms ← getLocalTheorems funPropDecl (.fvar id) fData.mainArgs fData.args.size
@@ -548,7 +538,7 @@ def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
       s!"candidate local theorems for {←ppExpr (.fvar id)} \
          {← thms.mapM fun thm => ppOrigin' thm.thmOrigin}"
 
-    if let some r ← tryTheorems funPropDecl e fData thms funProp then
+    if let some r ← tryTheorems funPropDecl e fData thms then
       return r
 
     if let some f ← fData.unfoldHeadFVar? then
@@ -557,10 +547,10 @@ def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
         return r
 
     if (← fData.isMorApplication) != .none then
-      if let some r ← applyMorRules funPropDecl e fData funProp then
+      if let some r ← applyMorRules funPropDecl e fData then
         return r
 
-    if let some r ← applyTransitionRules e funProp then
+    if let some r ← applyTransitionRules e then
       return r
 
     if thms.size = 0 then
@@ -570,8 +560,8 @@ def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 
 
 /-- Prove function property of `fun x ↦ f x₁ ... xₙ` where `f` is declared function. -/
-def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
-    (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
+def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData) :
+    FunPropM (Option Result) := do
 
   let some (funName, _) := fData.fn.const?
     | throwError "fun_prop bug: invelid use of const app case"
@@ -580,7 +570,7 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
   trace[Meta.Tactic.fun_prop]
     s!"candidate theorems for {funName} {← globalThms.mapM fun thm => ppOrigin' thm.thmOrigin}"
 
-  if let some r ← tryTheorems funPropDecl e fData globalThms funProp then
+  if let some r ← tryTheorems funPropDecl e fData globalThms then
     return r
 
   -- Try local theorems - this is useful for recursive functions
@@ -589,7 +579,7 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     trace[Meta.Tactic.fun_prop]
       s!"candidate local theorems for {funName} \
         {← localThms.mapM fun thm => ppOrigin' thm.thmOrigin}"
-  if let some r ← tryTheorems funPropDecl e fData localThms funProp then
+  if let some r ← tryTheorems funPropDecl e fData localThms then
     return r
 
   -- log error if no global or local theorems were found
@@ -597,7 +587,7 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
      logError s!"No theorems found for `{funName}` in order to prove `{← ppExpr e}`"
 
   if (← fData.isMorApplication) != .none then
-    if let some r ← applyMorRules funPropDecl e fData funProp then
+    if let some r ← applyMorRules funPropDecl e fData then
       return r
 
   if let .comp f g ← fData.decomposition then
@@ -605,14 +595,14 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
       s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
          trying again after decomposing function as: `({← ppExpr f}) ∘ ({← ppExpr g})`"
 
-    if let some r ← applyCompRule funPropDecl e f g funProp then
+    if let some r ← applyCompRule funPropDecl e f g then
       return r
   else
     trace[Meta.Tactic.fun_prop]
       s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
          now trying to prove `{funPropDecl.funPropName}` from another function property"
 
-    if let some r ← applyTransitionRules e funProp then
+    if let some r ← applyTransitionRules e then
       return r
 
 
@@ -628,90 +618,74 @@ def cacheResult (e : Expr) (r : Result) : FunPropM Result := do -- return proof?
 def cacheFailure (e : Expr) : FunPropM Unit := do -- return proof?
   modify (fun s => { s with failureCache := s.failureCache.insert e })
 
+/-- Main `funProp` function. Returns proof of `e`. -/
+partial def main (e : Expr) : FunPropM (Option Result) := do
 
-mutual
-  /-- Main `funProp` function. Returns proof of `e`. -/
-  partial def funProp (e : Expr) : FunPropM (Option Result) := do
+  let some (funPropDecl, f) ← getFunProp? e
+    | return none
 
-    let e ← instantiateMVars e
+  increaseSteps
 
-    withTraceNode `Meta.Tactic.fun_prop
-      (fun _ => do pure s!"{← ppExpr e}") do
+  -- if function starts with let bindings move them the top of `e` and try again
+  if f.isLet then
+    return ← funProp (← mapLetTelescope f fun _ b => pure <| e.setArg funPropDecl.funArgId b)
 
-    -- check cache for successful goals
-    if let some { expr := _, proof? := some proof, .. } := (← get).cache.find? e then
-      trace[Meta.Tactic.fun_prop] "reusing previously found proof for {e}"
-      return some { proof := proof }
-    else if (← get).failureCache.contains e then
-      trace[Meta.Tactic.fun_prop] "skipping proof search, proving {e} was tried already and failed"
+  match ← getFunctionData? f (← unfoldNamePred) with
+  | .letE f =>
+    trace[Debug.Meta.Tactic.fun_prop] "let case on {← ppExpr f}"
+    let e := e.setArg funPropDecl.funArgId f -- update e with reduced f
+    letCase funPropDecl e f
+  | .lam f =>
+    trace[Debug.Meta.Tactic.fun_prop] "pi case on {← ppExpr f}"
+    let e := e.setArg funPropDecl.funArgId f -- update e with reduced f
+    applyPiRule funPropDecl e
+  | .data fData =>
+    let e := e.setArg funPropDecl.funArgId (← fData.toExpr) -- update e with reduced f
+
+    if fData.isIdentityFun then
+      if let some r ← applyIdRule funPropDecl e then
+        return r
+
+    if fData.isConstantFun then
+      if let some r ← applyConstRule funPropDecl e  then
+        return r
+
+    match fData.fn with
+    | .fvar id =>
+      if id == fData.mainVar.fvarId! then
+        bvarAppCase funPropDecl e fData
+      else
+        fvarAppCase funPropDecl e fData
+    | .const .. | .proj .. => do
+      constAppCase funPropDecl e fData
+    | _ =>
+      trace[Debug.Meta.Tactic.fun_prop] "unknown case, ctor: {f.ctorName}\n{e}"
       return none
+
+/-- Wrapper around `main` that does caching. -/
+def funPropCoreImpl (e : Expr) : FunPropM (Option Result) := do
+
+  withTraceNode `Meta.Tactic.fun_prop
+    (fun _ => do pure m!"{← ppExpr e}") do
+
+  -- check cache for successful goals
+  if let some { expr := _, proof? := some proof, .. } := (← get).cache.find? e then
+    trace[Meta.Tactic.fun_prop] "reusing previously found proof for {← ppExpr e}"
+    return some {proof := proof }
+  else if (← get).failureCache.contains e then
+    trace[Meta.Tactic.fun_prop]
+      "skipping proof search, proving {← ppExpr e} was tried already and failed"
+    return none
+  else
+    -- run main
+    if let some r ← main e then
+      cacheResult e r
     else
-      -- take care of forall and let binders and run main
-      match e with
-      | .letE .. =>
-        letTelescope e fun xs b => do
-          let some r ← funProp b
-            | return none
-          cacheResult e {proof := ← mkLambdaFVars (generalizeNondepLet := false) xs r.proof }
-      | .forallE .. =>
-        forallTelescope e fun xs b => do
-          let some r ← funProp b
-            | return none
-          cacheResult e {proof := ← mkLambdaFVars xs r.proof }
-      | .mdata _ e' => funProp e'
-      | _ =>
-        if let some r ← main e then
-          cacheResult e r
-        else
-          cacheFailure e
-          return none
+      cacheFailure e
+      return none
 
-
-  /-- Main `funProp` function. Returns proof of `e`. -/
-  private partial def main (e : Expr) : FunPropM (Option Result) := do
-
-    let some (funPropDecl, f) ← getFunProp? e
-      | return none
-
-    increaseSteps
-
-    -- if function starts with let bindings move them the top of `e` and try again
-    if f.isLet then
-      return ← funProp (← mapLetTelescope f fun _ b => pure <| e.setArg funPropDecl.funArgId b)
-
-    match ← getFunctionData? f (← unfoldNamePred) with
-    | .letE f =>
-      trace[Debug.Meta.Tactic.fun_prop] "let case on {← ppExpr f}"
-      let e := e.setArg funPropDecl.funArgId f -- update e with reduced f
-      letCase funPropDecl e f funProp
-    | .lam f =>
-      trace[Debug.Meta.Tactic.fun_prop] "pi case on {← ppExpr f}"
-      let e := e.setArg funPropDecl.funArgId f -- update e with reduced f
-      applyPiRule funPropDecl e funProp
-    | .data fData =>
-      let e := e.setArg funPropDecl.funArgId (← fData.toExpr) -- update e with reduced f
-
-      if fData.isIdentityFun then
-        if let some r ← applyIdRule funPropDecl e funProp then
-          return r
-
-      if fData.isConstantFun then
-        if let some r ← applyConstRule funPropDecl e funProp then
-          return r
-
-      match fData.fn with
-      | .fvar id =>
-        if id == fData.mainVar.fvarId! then
-          bvarAppCase funPropDecl e fData funProp
-        else
-          fvarAppCase funPropDecl e fData funProp
-      | .const .. | .proj .. => do
-        constAppCase funPropDecl e fData funProp
-      | _ =>
-        trace[Debug.Meta.Tactic.fun_prop] "unknown case, ctor: {f.ctorName}\n{e}"
-        return none
-
-end
+-- initialize the forward declaration with the actual implementation
+initialize funPropCoreImplRef.set funPropCoreImpl
 
 end Meta.FunProp
 

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -24,6 +24,35 @@ open Lean Meta Qq
 
 namespace Meta.FunProp
 
+/-- Forward declaration of main `funProp` function -/
+initialize funPropCoreImplRef : IO.Ref (Expr → FunPropM (Option Result)) ←
+  .mkRef fun _ => return none
+
+/-- Solve `fun_prop` goal like `Continuous f` or `Differentiable ℝ fun x : ℝ => exp x + x` -/
+def funPropCore (e : Expr) : FunPropM (Option Result) := do
+  let impl ← funPropCoreImplRef.get
+  impl e
+
+/-- Main `funProp` function. Returns proof of `e`. -/
+partial def funProp (e : Expr) : FunPropM (Option Result) := do
+
+  let e ← instantiateMVars e
+
+  match e with
+  | .letE .. =>
+    letTelescope e fun xs b => do
+      let some r ← funProp b
+        | return none
+      -- cacheResult e {proof := ← mkLambdaFVars (generalizeNondepLet := false) xs r.proof }
+      return some { proof := ← mkLambdaFVars (generalizeNondepLet := false) xs r.proof }
+  | .forallE .. =>
+    forallTelescope e fun xs b => do
+      let some r ← funProp b
+        | return none
+      -- cacheResult e {proof := ← mkLambdaFVars xs r.proof }
+      return some { proof := ← mkLambdaFVars xs r.proof }
+  | .mdata _ e' => funProp e'
+  | _ => funPropCore e
 
 /-- Synthesize instance of type `type` and
   1. assign it to `x` if `x` is meta variable

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -194,36 +194,6 @@ def logError (msg : String) : FunPropM Unit := do
         else
           msg::s.msgLog}
 
-/-- Forward declaration of main `funProp` function -/
-initialize funPropCoreImplRef : IO.Ref (Expr → FunPropM (Option Result)) ←
-  .mkRef fun _ => return none
-
-/-- Solve `fun_prop` goal like `Continuous f` or `Differentiable ℝ fun x : ℝ => exp x + x` -/
-def funPropCore (e : Expr) : FunPropM (Option Result) := do
-  let impl ← funPropCoreImplRef.get
-  impl e
-
-/-- Main `funProp` function. Returns proof of `e`. -/
-partial def funProp (e : Expr) : FunPropM (Option Result) := do
-
-  let e ← instantiateMVars e
-
-  match e with
-  | .letE .. =>
-    letTelescope e fun xs b => do
-      let some r ← funProp b
-        | return none
-      -- cacheResult e {proof := ← mkLambdaFVars (generalizeNondepLet := false) xs r.proof }
-      return some { proof := ← mkLambdaFVars (generalizeNondepLet := false) xs r.proof }
-  | .forallE .. =>
-    forallTelescope e fun xs b => do
-      let some r ← funProp b
-        | return none
-      -- cacheResult e {proof := ← mkLambdaFVars xs r.proof }
-      return some { proof := ← mkLambdaFVars xs r.proof }
-  | .mdata _ e' => funProp e'
-  | _ => funPropCore e
-
 end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -194,6 +194,7 @@ def logError (msg : String) : FunPropM Unit := do
         else
           msg::s.msgLog}
 
+/-- Forward declaration of main `funProp` function -/
 initialize funPropCoreImplRef : IO.Ref (Expr → FunPropM (Option Result)) ←
   .mkRef fun _ => return none
 

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -7,6 +7,7 @@ module
 
 public meta import Mathlib.Lean.Meta.RefinedDiscrTree.Basic
 public import Mathlib.Tactic.FunProp.FunctionData
+public import Mathlib.Tactic.FunProp.Decl
 
 /-!
 ## `funProp`
@@ -192,6 +193,47 @@ def logError (msg : String) : FunPropM Unit := do
           s.msgLog
         else
           msg::s.msgLog}
+
+initialize funPropCoreImplRef : IO.Ref (Expr → FunPropM (Option Result)) ←
+  .mkRef fun _ => return none
+
+/-- Solve `fun_prop` goal like `Continuous f` or `Differentiable ℝ fun x : ℝ => exp x + x` -/
+def funPropCore (goal : Expr) : FunPropM (Option Result) := do
+  let impl ← funPropCoreImplRef.get
+  impl goal
+
+/-- Main `funProp` function. Returns proof of `e`. -/
+partial def funProp (e : Expr) : FunPropM (Option Result) := do
+
+  let e ← instantiateMVars e
+
+  match e with
+  | .letE .. =>
+    letTelescope e fun xs b => do
+      let some r ← funProp b
+        | return none
+      -- cacheResult e {proof := ← mkLambdaFVars (generalizeNondepLet := false) xs r.proof }
+      return some { proof := ← mkLambdaFVars (generalizeNondepLet := false) xs r.proof }
+  | .forallE .. =>
+    forallTelescope e fun xs b => do
+      let some r ← funProp b
+        | return none
+      -- cacheResult e {proof := ← mkLambdaFVars xs r.proof }
+      return some { proof := ← mkLambdaFVars xs r.proof }
+  | .mdata _ e' => funProp e'
+  | _ =>
+    let some (_, goal) ← getFunProp? e | return none
+
+    if let some r ← funPropCore goal then
+      -- assign mvars in `e` from the result throuh defeq check
+      let t ← inferType r.proof
+      if (← isDefEq e t) then
+        return r
+      else
+        logError s!"Failed to assign result {← ppExpr t} to {← ppExpr e}!"
+        return none
+    else
+      return none
 
 end Meta.FunProp
 

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -198,9 +198,9 @@ initialize funPropCoreImplRef : IO.Ref (Expr → FunPropM (Option Result)) ←
   .mkRef fun _ => return none
 
 /-- Solve `fun_prop` goal like `Continuous f` or `Differentiable ℝ fun x : ℝ => exp x + x` -/
-def funPropCore (goal : Expr) : FunPropM (Option Result) := do
+def funPropCore (e : Expr) : FunPropM (Option Result) := do
   let impl ← funPropCoreImplRef.get
-  impl goal
+  impl e
 
 /-- Main `funProp` function. Returns proof of `e`. -/
 partial def funProp (e : Expr) : FunPropM (Option Result) := do
@@ -221,19 +221,7 @@ partial def funProp (e : Expr) : FunPropM (Option Result) := do
       -- cacheResult e {proof := ← mkLambdaFVars xs r.proof }
       return some { proof := ← mkLambdaFVars xs r.proof }
   | .mdata _ e' => funProp e'
-  | _ =>
-    let some (_, goal) ← getFunProp? e | return none
-
-    if let some r ← funPropCore goal then
-      -- assign mvars in `e` from the result throuh defeq check
-      let t ← inferType r.proof
-      if (← isDefEq e t) then
-        return r
-      else
-        logError s!"Failed to assign result {← ppExpr t} to {← ppExpr e}!"
-        return none
-    else
-      return none
+  | _ => funPropCore e
 
 end Meta.FunProp
 

--- a/MathlibTest/FunPropMinimal.lean
+++ b/MathlibTest/FunPropMinimal.lean
@@ -75,8 +75,6 @@ theorem prod_mk_Con (fst : α → β) (snd : α → γ) (hfst : Con fst) (hsnd :
 theorem prod_mk_Lin (fst : α → β) (snd : α → γ) (hfst : Lin fst) (hsnd : Lin snd) :
     Lin fun x => (fst x, snd x) := silentSorry
 
-
-
 -- "simple form" of theorems
 @[fun_prop] theorem fst_Con : Con fun x : α×β => x.1 := silentSorry
 @[fun_prop] theorem snd_Con : Con fun x : α×β => x.2 := silentSorry
@@ -542,15 +540,14 @@ example [Add α] (a : α) :
 -- Test that local theorem is being used
 /--
 trace: [Meta.Tactic.fun_prop] ✅️ Con fun x => f x y
-  [Meta.Tactic.fun_prop] ✅️ Con fun x => f x y
-    [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
-    [Meta.Tactic.fun_prop] removing argument to later use this : Con f
-    [Meta.Tactic.fun_prop] ✅️ applying: Con_comp
-      [Meta.Tactic.fun_prop] ✅️ Con fun f => f y
-        [Meta.Tactic.fun_prop] ✅️ applying: Con_apply
-      [Meta.Tactic.fun_prop] ✅️ Con fun x => f x
-        [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
-        [Meta.Tactic.fun_prop] ✅️ applying: this : Con f
+  [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
+  [Meta.Tactic.fun_prop] removing argument to later use this : Con f
+  [Meta.Tactic.fun_prop] ✅️ applying: Con_comp
+    [Meta.Tactic.fun_prop] ✅️ Con fun f => f y
+      [Meta.Tactic.fun_prop] ✅️ applying: Con_apply
+    [Meta.Tactic.fun_prop] ✅️ Con fun x => f x
+      [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
+      [Meta.Tactic.fun_prop] ✅️ applying: this : Con f
 -/
 #guard_msgs in
 example [Add α] (y : α):


### PR DESCRIPTION
Refactors `fun_prop` to use forward declaration trick rather than having to pass a funProp argument to each of the helper functions. This is just extracting one of the main orthogonal changes in #37056 to a separate PR. 