### PR TITLE
[Merged by Bors] - refactor(RepresentationTheory/Rep/Res): refactor resFunctor

### DIFF
--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
@@ -524,7 +524,7 @@ noncomputable def resNatTrans (n : ℕ) :
     simp only [functor_map, Functor.comp_map,
       ← cancel_epi (groupCohomology.π _ n), HomologicalComplex.homologyπ_naturality_assoc,
       HomologicalComplex.homologyπ_naturality, ← HomologicalComplex.cyclesMap_comp_assoc,
-      ← cochainsMap_comp, res_obj_ρ, Category.comp_id, Rep.hom_id]
+      ← cochainsMap_comp, res_obj_ρ, Category.comp_id]
     rfl
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/Functoriality.lean
@@ -826,10 +826,8 @@ noncomputable def coresNatTrans (n : ℕ) :
     simp only [← cancel_epi (groupHomology.π _ n), Functor.comp_map,
       functor_map, HomologicalComplex.homologyπ_naturality_assoc,
       HomologicalComplex.homologyπ_naturality, ← HomologicalComplex.cyclesMap_comp_assoc,
-      ← chainsMap_comp, res_obj_ρ, Rep.hom_id, Category.id_comp]
+      ← chainsMap_comp, Category.id_comp]
     rfl
-
-
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Given a normal subgroup `S ≤ G`, this sends `A : Rep k G` to the `n`th "coinflation" map

--- a/Mathlib/RepresentationTheory/Induced.lean
+++ b/Mathlib/RepresentationTheory/Induced.lean
@@ -262,8 +262,7 @@ noncomputable def coinvariantsTensorIndNatIso :
     (coinvariantsTensor k H).obj (ind φ A) ≅ resFunctor φ ⋙ (coinvariantsTensor k G).obj A :=
   NatIso.ofComponents (fun B => coinvariantsTensorIndIso φ A B) fun {X Y} f => by
     ext
-    simp [coinvariantsTensorIndHom, coinvariantsTensorMk,
-      hom_comm_apply, Representation.IntertwiningMap.toLinearMap_apply]
+    simp [coinvariantsTensorIndHom, coinvariantsTensorMk, hom_comm_apply]
 
 end
 end Rep

--- a/Mathlib/RepresentationTheory/Invariants.lean
+++ b/Mathlib/RepresentationTheory/Invariants.lean
@@ -266,7 +266,7 @@ noncomputable def quotientToInvariantsFunctor (S : Subgroup G) [S.Normal] :
     Rep.{w} k G ⥤ Rep k (G ⧸ S) where
   obj X := X.quotientToInvariants S
   map {X Y} f := Rep.ofHom ⟨((invariantsFunctor k S).map ((Rep.resFunctor S.subtype).map f)).hom,
-    fun g ↦ QuotientGroup.induction_on g fun g ↦ by ext x; simp [hom_comm_apply]⟩
+    fun g ↦ QuotientGroup.induction_on g fun g ↦ by ext; simp [hom_comm_apply]⟩
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The adjunction between the functor equipping a module with the trivial representation, and

--- a/Mathlib/RepresentationTheory/Rep/Res.lean
+++ b/Mathlib/RepresentationTheory/Rep/Res.lean
@@ -26,6 +26,8 @@ open CategoryTheory
 
 namespace Rep
 
+/-- The map induced by a monoid homomorphism `f : H →* G` on morphisms between
+`G`-representations. -/
 @[implicit_reducible]
 def resMap {X Y : Rep k G} (f : H →* G) (p : X ⟶ Y) :
     of (X := X.V) (X.ρ.comp f) ⟶ of (X := Y.V) (Y.ρ.comp f) :=

--- a/Mathlib/RepresentationTheory/Rep/Res.lean
+++ b/Mathlib/RepresentationTheory/Rep/Res.lean
@@ -54,10 +54,8 @@ lemma resMap_hom_toLinearMap {M N : Rep k G} (p : M ⟶ N) :
 
 @[simp]
 lemma resMap_hom_apply {M N : Rep k G} (p : M ⟶ N) (x : M.V) :
-    @DFunLike.coe (Representation.IntertwiningMap (MonoidHom.comp M.ρ f) (MonoidHom.comp N.ρ f))
-      M.V (fun _ : M.V ↦ N.V) (Representation.IntertwiningMap.instFunLike
-      (MonoidHom.comp M.ρ f) (MonoidHom.comp N.ρ f))
-      (Hom.hom (resMap f p)) x = p.hom x := rfl
+    @DFunLike.coe (Representation.IntertwiningMap (M.ρ.comp f) (N.ρ.comp f)) _ _ _
+      (resMap f p).hom x = p.hom x := rfl
 
 section
 

--- a/Mathlib/RepresentationTheory/Rep/Res.lean
+++ b/Mathlib/RepresentationTheory/Rep/Res.lean
@@ -63,7 +63,6 @@ section
 
 instance : (resFunctor (k := k) f).Faithful where
   map_injective h := by
-    ext : 2
     simpa [Rep.hom_ext_iff, Representation.IntertwiningMap.ext_iff] using h
 
 /-- Morphism between `X Y : Rep k G` can be lifted from restrictions associated with `f : H →* G`
@@ -80,10 +79,10 @@ lemma full_res (hf : (⇑f).Surjective) : (resFunctor (k := k) f).Full where
   map_surjective {X Y} f' := ⟨liftHomOfSurj f hf f', by ext; simp⟩
 
 instance : (resFunctor (k := k) f).Additive where
-  map_add {_ _} _ _ := by ext; simp [add_hom]
+  map_add {_ _} _ _ := by ext : 2; simp [add_hom]
 
 instance {k : Type u} [CommSemiring k] : (resFunctor (k := k) f).Linear k where
-  map_smul {X Y} l r := by ext; simp [smul_hom]
+  map_smul {_ _} _ _ := by ext : 2; simp [smul_hom]
 
 noncomputable section
 

--- a/Mathlib/RepresentationTheory/Rep/Res.lean
+++ b/Mathlib/RepresentationTheory/Rep/Res.lean
@@ -52,6 +52,9 @@ lemma res_obj_V : (res f M).V = M.V := rfl
 lemma resMap_hom_toLinearMap {M N : Rep k G} (p : M ⟶ N) :
     (resMap f p).hom.toLinearMap = p.hom.toLinearMap := rfl
 
+@[deprecated (since := "26/06/2026")]
+alias res_map_hom_toLinearMap := resMap_hom_toLinearMap
+
 @[simp]
 lemma resMap_hom_apply {M N : Rep k G} (p : M ⟶ N) (x : M.V) :
     @DFunLike.coe (Representation.IntertwiningMap (M.ρ.comp f) (N.ρ.comp f)) _ _ _

--- a/Mathlib/RepresentationTheory/Rep/Res.lean
+++ b/Mathlib/RepresentationTheory/Rep/Res.lean
@@ -17,10 +17,9 @@ Given a group homomorphism `f : H →* G`, we have the restriction functor
 
 @[expose] public section
 
-universe t w u v v1 v2 v3
+universe t w u v v1 v2
 
-variable {k : Type u} [Semiring k] {G : Type v1} {H : Type v2} {K : Type v3}
-  [Monoid G] [Monoid H] [Monoid K]
+variable {k : Type u} [Semiring k] {G : Type v1} {H : Type v2} [Monoid G] [Monoid H]
 
 open CategoryTheory
 

--- a/Mathlib/RepresentationTheory/Rep/Res.lean
+++ b/Mathlib/RepresentationTheory/Rep/Res.lean
@@ -15,20 +15,26 @@ Given a group homomorphism `f : H →* G`, we have the restriction functor
 
 -/
 
-public section
+@[expose] public section
 
-universe t w u v v1 v2
+universe t w u v v1 v2 v3
 
-variable {k : Type u} [Semiring k] {G : Type v1} {H : Type v2} [Monoid G] [Monoid H]
+variable {k : Type u} [Semiring k] {G : Type v1} {H : Type v2} {K : Type v3}
+  [Monoid G] [Monoid H] [Monoid K]
 
 open CategoryTheory
 
 namespace Rep
 
+@[implicit_reducible]
+def resMap {X Y : Rep k G} (f : H →* G) (p : X ⟶ Y) :
+    of (X := X.V) (X.ρ.comp f) ⟶ of (X := Y.V) (Y.ρ.comp f) :=
+  ofHom ⟨p.hom, fun h ↦ by simpa using p.hom.2 (f h)⟩
+
 /-- The restriction functor `Rep R G ⥤ Rep R H` for a subgroup `H` of `G`. -/
 abbrev resFunctor (f : H →* G) : Rep.{t} k G ⥤ Rep k H where
   obj A := of (X := A.V) (A.ρ.comp f)
-  map f' := ofHom ⟨f'.hom, fun h ↦ by simpa using f'.hom.2 (f h)⟩
+  map f' := resMap f f'
 
 /-- The restriction of `X : Rep k G` associated to a monoid homomorphism `f : H →* G` -/
 abbrev res (f : H →* G) (M : Rep k G) := (resFunctor f).obj M
@@ -41,16 +47,23 @@ lemma coe_res_obj_ρ' (h : H) : (res f M).ρ h = M.ρ (f h) := rfl
 
 lemma res_obj_V : (res f M).V = M.V := rfl
 
-lemma res_map_hom_toLinearMap {M N : Rep k G} (p : M ⟶ N) :
-    ((resFunctor f).map p).hom.toLinearMap = p.hom.toLinearMap := rfl
+@[simp]
+lemma resMap_hom_toLinearMap {M N : Rep k G} (p : M ⟶ N) :
+    (resMap f p).hom.toLinearMap = p.hom.toLinearMap := rfl
+
+@[simp]
+lemma resMap_hom_apply {M N : Rep k G} (p : M ⟶ N) (x : M.V) :
+    @DFunLike.coe (Representation.IntertwiningMap (MonoidHom.comp M.ρ f) (MonoidHom.comp N.ρ f))
+      M.V (fun _ : M.V ↦ N.V) (Representation.IntertwiningMap.instFunLike
+      (MonoidHom.comp M.ρ f) (MonoidHom.comp N.ρ f))
+      (Hom.hom (resMap f p)) x = p.hom x := rfl
 
 section
 
 instance : (resFunctor (k := k) f).Faithful where
   map_injective h := by
     ext : 2
-    rw [Rep.hom_ext_iff, Representation.IntertwiningMap.ext_iff] at h
-    simpa using h
+    simpa [Rep.hom_ext_iff, Representation.IntertwiningMap.ext_iff] using h
 
 /-- Morphism between `X Y : Rep k G` can be lifted from restrictions associated with `f : H →* G`
   when `f` is surjective. -/
@@ -63,21 +76,13 @@ lemma liftHomOfSurj_toLinearMap {X Y : Rep k G} (hf : Function.Surjective f)
       f'.hom.toLinearMap := rfl
 
 lemma full_res (hf : (⇑f).Surjective) : (resFunctor (k := k) f).Full where
-  map_surjective {X Y} f' := ⟨liftHomOfSurj f hf f', by
-    ext : 2; rw [res_map_hom_toLinearMap, liftHomOfSurj_toLinearMap]⟩
+  map_surjective {X Y} f' := ⟨liftHomOfSurj f hf f', by ext; simp⟩
 
 instance : (resFunctor (k := k) f).Additive where
-  map_add {_ _} _ _ := by
-    ext : 2;
-    simp only [add_hom, Representation.IntertwiningMap.add_toLinearMap]
-    rfl
+  map_add {_ _} _ _ := by ext; simp [add_hom]
 
 instance {k : Type u} [CommSemiring k] : (resFunctor (k := k) f).Linear k where
-  map_smul {X Y} l r := by
-    ext : 2;
-    rw [smul_hom, Representation.IntertwiningMap.toLinearMap_smul,
-      res_map_hom_toLinearMap, smul_hom, Representation.IntertwiningMap.toLinearMap_smul,
-      res_map_hom_toLinearMap]
+  map_smul {X Y} l r := by ext; simp [smul_hom]
 
 noncomputable section
 

--- a/Mathlib/RepresentationTheory/Rep/Res.lean
+++ b/Mathlib/RepresentationTheory/Rep/Res.lean
@@ -15,7 +15,7 @@ Given a group homomorphism `f : H →* G`, we have the restriction functor
 
 -/
 
-@[expose] public section
+public section
 
 universe t w u v v1 v2
 
@@ -27,7 +27,7 @@ namespace Rep
 
 /-- The map induced by a monoid homomorphism `f : H →* G` on morphisms between
 `G`-representations. -/
-@[implicit_reducible]
+@[expose, implicit_reducible]
 def resMap {X Y : Rep k G} (f : H →* G) (p : X ⟶ Y) :
     of (X := X.V) (X.ρ.comp f) ⟶ of (X := Y.V) (Y.ρ.comp f) :=
   ofHom ⟨p.hom, fun h ↦ by simpa using p.hom.2 (f h)⟩


### PR DESCRIPTION

This PR refactors the definition of `resFunctor`, in the current master since the whole definition is an `abbrev`, everything is exposed and if one does `ext; simp` one of the possible outcome in the infoview would be 
```
ofHom { toLinearMap := (Hom.hom ..).toLinearMap, isIntertwining' := ⋯ }
```
which is not helpful unfolds too much, this PR seals the `map` part of the functor to make it less transparent while keep the definition of `resFunctor` as an `abbrev` to maintain the full transparency on the underlying type.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
