### PR TITLE
[Merged by Bors] - chore(Algebra/Polynomial/Splits): remove field hypothesis from `map_aroots_algebraMap`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -569,25 +569,33 @@ end
 
 section
 
-variable {A B : Type*} [CommRing R] [Field A] [Algebra R A]
+variable {A B : Type*} [CommRing R] [CommRing A] [IsDomain A] [Algebra R A]
   [CommRing B] [IsDomain B] [Algebra R B] {f : R[X]}
 
-theorem Splits.map_aroots_algebraMap [Algebra A B] [IsScalarTower R A B]
-    (hf : (f.map (algebraMap R A)).Splits) :
-    (f.aroots A).map (algebraMap A B) = f.aroots B := by
-  rw [← aroots_map B A, aroots, aroots, hf.roots_map]
-
-theorem Splits.image_rootSet (hf : (f.map (algebraMap R A)).Splits)
+theorem Splits.image_rootSet [IsSimpleRing A] (hf : (f.map (algebraMap R A)).Splits)
     (g : A →ₐ[R] B) : g '' f.rootSet A = f.rootSet B := by
   classical
   rw [rootSet, ← Finset.coe_image, ← Multiset.toFinset_map, ← g.coe_toRingHom,
-    ← hf.roots_map, map_map, g.comp_algebraMap, ← rootSet]
+    ← hf.roots_map_of_injective, map_map, g.comp_algebraMap, ← rootSet]
+  exact g.injective
 
-theorem Splits.adjoin_rootSet_eq_range
+theorem Splits.adjoin_rootSet_eq_range [IsSimpleRing A]
     (hf : (f.map (algebraMap R A)).Splits) (g : A →ₐ[R] B) :
     Algebra.adjoin R (f.rootSet B) = g.range ↔ Algebra.adjoin R (f.rootSet A) = ⊤ := by
   rw [← hf.image_rootSet g, Algebra.adjoin_image, ← Algebra.map_top]
   exact (Subalgebra.map_injective g.injective).eq_iff
+
+variable [Algebra A B] [FaithfulSMul A B] [IsScalarTower R A B]
+
+theorem Splits.map_aroots_algebraMap (hf : (f.map (algebraMap R A)).Splits) :
+    (f.aroots A).map (algebraMap A B) = f.aroots B := by
+  rw [← aroots_map B A, aroots, aroots,
+    hf.roots_map_of_injective (FaithfulSMul.algebraMap_injective A B)]
+
+theorem Splits.image_rootSet_algebraMap (hf : (f.map (algebraMap R A)).Splits) :
+    (algebraMap A B) '' f.rootSet A = f.rootSet B := by
+  classical
+  rw [rootSet, ← Finset.coe_image, ← Multiset.toFinset_map, hf.map_aroots_algebraMap, ← rootSet]
 
 end
 

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -576,8 +576,7 @@ theorem Splits.image_rootSet (hf : (f.map (algebraMap R A)).Splits)
     (g : A →ₐ[R] B) : g '' f.rootSet A = f.rootSet B := by
   classical
   rw [rootSet, ← Finset.coe_image, ← Multiset.toFinset_map, ← g.coe_toRingHom,
-    ← hf.roots_map_of_injective, map_map, g.comp_algebraMap, ← rootSet]
-  exact g.injective
+    ← hf.roots_map, map_map, g.comp_algebraMap, ← rootSet]
 
 theorem Splits.adjoin_rootSet_eq_range
     (hf : (f.map (algebraMap R A)).Splits) (g : A →ₐ[R] B) :

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -569,23 +569,28 @@ end
 
 section
 
-variable {A B : Type*} [CommRing R] [CommRing A] [IsDomain A] [Algebra R A]
+variable {A B : Type*} [CommRing R] [Field A] [Algebra R A]
   [CommRing B] [IsDomain B] [Algebra R B] {f : R[X]}
 
-theorem Splits.image_rootSet [IsSimpleRing A] (hf : (f.map (algebraMap R A)).Splits)
+theorem Splits.image_rootSet (hf : (f.map (algebraMap R A)).Splits)
     (g : A →ₐ[R] B) : g '' f.rootSet A = f.rootSet B := by
   classical
   rw [rootSet, ← Finset.coe_image, ← Multiset.toFinset_map, ← g.coe_toRingHom,
     ← hf.roots_map_of_injective, map_map, g.comp_algebraMap, ← rootSet]
   exact g.injective
 
-theorem Splits.adjoin_rootSet_eq_range [IsSimpleRing A]
+theorem Splits.adjoin_rootSet_eq_range
     (hf : (f.map (algebraMap R A)).Splits) (g : A →ₐ[R] B) :
     Algebra.adjoin R (f.rootSet B) = g.range ↔ Algebra.adjoin R (f.rootSet A) = ⊤ := by
   rw [← hf.image_rootSet g, Algebra.adjoin_image, ← Algebra.map_top]
   exact (Subalgebra.map_injective g.injective).eq_iff
 
-variable [Algebra A B] [FaithfulSMul A B] [IsScalarTower R A B]
+end
+
+section
+
+variable {A B : Type*} [CommRing R] [CommRing A] [IsDomain A] [Algebra R A] [CommRing B]
+  [IsDomain B] [Algebra R B] [Algebra A B] [FaithfulSMul A B] [IsScalarTower R A B] {f : R[X]}
 
 theorem Splits.map_aroots_algebraMap (hf : (f.map (algebraMap R A)).Splits) :
     (f.aroots A).map (algebraMap A B) = f.aroots B := by


### PR DESCRIPTION
Currently `Polynomial.Splits.map_aroots_algebraMap` assumes that `A` is a field. But actually it is enough to assume that the map from `A` to `B` is injective. This PR also adds a `rootSet` version `Polynomial.Splits.image_rootSet_algebraMap`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
