### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Module): monotonicity of scalar multiplication

### DIFF
--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -327,6 +327,26 @@ lemma strictMono_smul_left_of_pos [PosSMulStrictMono α β] (ha : 0 < a) :
 @[gcongr] lemma smul_lt_smul_of_pos_left [PosSMulStrictMono α β] (hb : b₁ < b₂) (ha : 0 < a) :
     a • b₁ < a • b₂ := strictMono_smul_left_of_pos ha hb
 
+/-- Scalar multiplication on the left by a nonnegative element preserves monotonicity. -/
+lemma Monotone.const_smul [PosSMulMono α β] {γ : Type*} [Preorder γ] {f : γ → β}
+    (hf : Monotone f) (ha : 0 ≤ a) : Monotone fun x ↦ a • f x :=
+  (monotone_smul_left_of_nonneg ha).comp hf
+
+/-- Scalar multiplication on the left by a nonnegative element preserves antitonicity. -/
+lemma Antitone.const_smul [PosSMulMono α β] {γ : Type*} [Preorder γ] {f : γ → β}
+    (hf : Antitone f) (ha : 0 ≤ a) : Antitone fun x ↦ a • f x :=
+  (monotone_smul_left_of_nonneg ha).comp_antitone hf
+
+/-- Scalar multiplication on the left by a positive element preserves strict monotonicity. -/
+lemma StrictMono.const_smul [PosSMulStrictMono α β] {γ : Type*} [Preorder γ] {f : γ → β}
+    (hf : StrictMono f) (ha : 0 < a) : StrictMono fun x ↦ a • f x :=
+  (strictMono_smul_left_of_pos ha).comp hf
+
+/-- Scalar multiplication on the left by a positive element preserves strict antitonicity. -/
+lemma StrictAnti.const_smul [PosSMulStrictMono α β] {γ : Type*} [Preorder γ] {f : γ → β}
+    (hf : StrictAnti f) (ha : 0 < a) : StrictAnti fun x ↦ a • f x :=
+  (strictMono_smul_left_of_pos ha).comp_strictAnti hf
+
 lemma lt_of_smul_lt_smul_left [PosSMulReflectLT α β] (h : a • b₁ < a • b₂) (ha : 0 ≤ a) : b₁ < b₂ :=
   PosSMulReflectLT.lt_of_smul_lt_smul_left ha h
 
@@ -356,6 +376,26 @@ lemma monotone_smul_right_of_nonneg [SMulPosMono α β] (hb : 0 ≤ b) : Monoton
 
 lemma strictMono_smul_right_of_pos [SMulPosStrictMono α β] (hb : 0 < b) :
     StrictMono ((· • b) : α → β) := SMulPosStrictMono.smul_lt_smul_of_pos_right hb
+
+/-- Scalar multiplication on the right by a nonnegative element preserves monotonicity. -/
+lemma Monotone.smul_const [SMulPosMono α β] {γ : Type*} [Preorder γ] {f : γ → α}
+    (hf : Monotone f) (hb : 0 ≤ b) : Monotone fun x ↦ f x • b :=
+  (monotone_smul_right_of_nonneg hb).comp hf
+
+/-- Scalar multiplication on the right by a nonnegative element preserves antitonicity. -/
+lemma Antitone.smul_const [SMulPosMono α β] {γ : Type*} [Preorder γ] {f : γ → α}
+    (hf : Antitone f) (hb : 0 ≤ b) : Antitone fun x ↦ f x • b :=
+  (monotone_smul_right_of_nonneg hb).comp_antitone hf
+
+/-- Scalar multiplication on the right by a positive element preserves strict monotonicity. -/
+lemma StrictMono.smul_const [SMulPosStrictMono α β] {γ : Type*} [Preorder γ] {f : γ → α}
+    (hf : StrictMono f) (hb : 0 < b) : StrictMono fun x ↦ f x • b :=
+  (strictMono_smul_right_of_pos hb).comp hf
+
+/-- Scalar multiplication on the right by a positive element preserves strict antitonicity. -/
+lemma StrictAnti.smul_const [SMulPosStrictMono α β] {γ : Type*} [Preorder γ] {f : γ → α}
+    (hf : StrictAnti f) (hb : 0 < b) : StrictAnti fun x ↦ f x • b :=
+  (strictMono_smul_right_of_pos hb).comp_strictAnti hf
 
 @[gcongr] lemma smul_le_smul_of_nonneg_right [SMulPosMono α β] (ha : a₁ ≤ a₂) (hb : 0 ≤ b) :
     a₁ • b ≤ a₂ • b := monotone_smul_right_of_nonneg hb ha


### PR DESCRIPTION
# Summary

Add the `const_smul`/`smul_const` family of monotonicity lemmas in `Algebra/Order/Module/Defs`: left/right scalar multiplication by a nonnegative (resp. positive) element preserves (anti/strict)tonicity.

* `Monotone.const_smul`, `Antitone.const_smul`, `StrictMono.const_smul`,
  `StrictAnti.const_smul` (`a • f x`, `PosSMulMono`/`PosSMulStrictMono`)
* `Monotone.smul_const`, `Antitone.smul_const`, `StrictMono.smul_const`,
  `StrictAnti.smul_const` (`f x • b`, `SMulPosMono`/`SMulPosStrictMono`)

These are the `smul` analogues of the existing `Monotone.const_mul`/ `mul_const` family, proved by composing with `monotone_smul_left_of_nonneg`/ `monotone_smul_right_of_nonneg` (and their strict counterparts).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
