### PR TITLE
[Merged by Bors] - chore(FieldTheory/IsGaloisGroup): move `mulEquivAlgEquiv` to ring theory folder

### DIFF
--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -126,21 +126,6 @@ theorem card_eq_finrank' : Nat.card G = Module.finrank A B := by
   rw [IsGaloisGroup.card_eq_finrank G (FractionRing A) (FractionRing B),
     Algebra.IsAlgebraic.finrank_of_isFractionRing A (FractionRing A) B (FractionRing B)]
 
-attribute [local instance] FractionRing.liftAlgebra in
-/-- If `G` is a finite Galois group for `B/A`, then `G` is isomorphic to `Gal(B/A)`. -/
-@[simps!] noncomputable def mulEquivAlgEquiv : G ≃* Gal(B/A) :=
-  MulEquiv.ofBijective (MulSemiringAction.toAlgAut G A B) (by
-    have := IsDomain.of_faithfulSMul A B
-    letI K := FractionRing A
-    letI L := FractionRing B
-    letI := IsFractionRing.mulSemiringAction G B L
-    have := isGalois G K L
-    have := finiteDimensional G K L
-    refine .of_comp_left ?_ (IsFractionRing.fieldEquivOfAlgEquivHom_injective A B K L)
-    rw [Nat.bijective_iff_injective_and_card, card_eq_finrank G K L,
-      IsGalois.card_aut_eq_finrank K L]
-    exact ⟨fun _ _ ↦ (faithful K).eq_of_smul_eq_smul ∘ DFunLike.ext_iff.mp, rfl⟩)
-
 @[simp]
 theorem map_mulEquivAlgEquiv_fixingSubgroup [IsGaloisGroup G K L] (F : IntermediateField K L) :
     (fixingSubgroup G (F : Set L)).map (mulEquivAlgEquiv G K L) = F.fixingSubgroup := by

--- a/Mathlib/RingTheory/IsGaloisGroup/Basic.lean
+++ b/Mathlib/RingTheory/IsGaloisGroup/Basic.lean
@@ -126,16 +126,27 @@ instance IsGaloisGroup.toFractionRing [IsDomain A] [IsDomain B] [Finite G]
 
 end Field
 
-variable (G G' K L : Type*) [Group G] [Group G'] [Field K] [Field L] [Algebra K L]
-  [MulSemiringAction G L] [MulSemiringAction G' L]
+variable (G : Type*) [Group G]
 
 namespace IsGaloisGroup
 
 section IsDomain
 
 variable (A B : Type*) [CommRing A] [CommRing B] [IsDomain B] [Algebra A B] [FaithfulSMul A B]
-  [MulSemiringAction G B] [MulSemiringAction G' B] [IsGaloisGroup G A B] [IsGaloisGroup G' A B]
-  [Finite G] [Finite G']
+  [MulSemiringAction G B] [IsGaloisGroup G A B] [Finite G]
+
+attribute [local instance] FractionRing.liftAlgebra in
+/-- If `G` is a finite Galois group for `B/A`, then `G` is isomorphic to `Gal(B/A)`. -/
+@[simps!] noncomputable def mulEquivAlgEquiv : G ≃* Gal(B/A) :=
+  MulEquiv.ofBijective (MulSemiringAction.toAlgAut G A B) (by
+    have := IsDomain.of_faithfulSMul A B
+    have : FaithfulSMul G B := IsGaloisGroup.faithful A
+    refine ⟨fun _ _ ↦ eq_of_smul_eq_smul ∘ DFunLike.ext_iff.mp, fun φ ↦ ?_⟩
+    obtain ⟨g, hg⟩ := Ideal.Quotient.stabilizerHom_surjective G ⊥ ⊥
+      (Ideal.Quotient.algEquivOfEqMap (⊥ : Ideal A) φ Ideal.map_bot.symm)
+    use g
+    rw [AlgEquiv.ext_iff] at hg ⊢
+    exact fun x ↦ (AlgEquiv.quotientBot A B).symm.injective (hg x))
 
 end IsDomain
 
@@ -233,6 +244,8 @@ def smulCommClassQuotient [N.Normal] [Algebra A B] [IsScalarTower A B C] [SMulCo
       simp [algebraMap.smul, algebraMap.smul', smul_comm])⟩
 
 end Semiring
+
+variable {K L : Type*} [Field K] [Field L] [Algebra K L] [MulSemiringAction G L]
 
 variable (F : IntermediateField K L) (N : Subgroup G) [N.Normal] [IsGaloisGroup N F L]
 


### PR DESCRIPTION
The isomorphism `G ≃* Gal(B/A)` does not require Galois theory to be proved so it can be moved to the ring theory folder.

I also cleaned up some messed up variables left over from the file split.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
