### PR TITLE
[Merged by Bors] - feat(RingTheory): characterizing lemma for rings of infinite Krull dimension

### DIFF
--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -756,4 +756,8 @@ lemma add_le_add_natCast_left_iff {a b : WithBot ℕ∞} {c : ℕ} : c + a ≤ c
 lemma add_le_add_one_left_iff {a b : WithBot ℕ∞} : 1 + a ≤ 1 + b ↔ a ≤ b :=
   WithBot.add_le_add_natCast_left_iff
 
+theorem eq_top_iff_forall_ge {n : WithBot ℕ∞} : n = ⊤ ↔ ∀ (m : ℕ), ↑m ≤ n := by
+  cases n <;> simp [ENat.eq_top_iff_forall_ge]
+  norm_cast
+
 end ENat.WithBot

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -756,8 +756,4 @@ lemma add_le_add_natCast_left_iff {a b : WithBot ℕ∞} {c : ℕ} : c + a ≤ c
 lemma add_le_add_one_left_iff {a b : WithBot ℕ∞} : 1 + a ≤ 1 + b ↔ a ≤ b :=
   WithBot.add_le_add_natCast_left_iff
 
-theorem eq_top_iff_forall_ge {n : WithBot ℕ∞} : n = ⊤ ↔ ∀ (m : ℕ), ↑m ≤ n := by
-  cases n <;> simp [ENat.eq_top_iff_forall_ge]
-  norm_cast
-
 end ENat.WithBot

--- a/Mathlib/RingTheory/Ideal/Height.lean
+++ b/Mathlib/RingTheory/Ideal/Height.lean
@@ -197,6 +197,23 @@ lemma Ideal.exists_isMaximal_height [FiniteRingKrullDim R] :
   · norm_cast
     exact height_mono hle
 
+/-- For all `n ≤ dim R`, there exists a prime ideal `p` with `n ≤ ht p`. -/
+lemma Ideal.exists_isPrime_le_height {n : ℕ} (h : n ≤ ringKrullDim R) :
+    ∃ (p : Ideal R), p.IsPrime ∧ n ≤ p.height := by
+  obtain ⟨l, rfl⟩ := Order.le_krullDim_iff.mp h
+  refine ⟨l.last, PrimeSpectrum.isPrime _, ?_⟩
+  grw [PrimeSpectrum.height_eq_orderHeight, ← Order.length_le_height_last]
+
+theorem Ideal.ringKrullDim_eq_top_iff :
+    ringKrullDim R = ⊤ ↔ ∀ n : ℕ, ∃ I : Ideal R, I ≠ ⊤ ∧ n ≤ I.height := by
+  rw [ENat.WithBot.eq_top_iff_forall_ge]
+  refine ⟨fun h n ↦ ?_, fun h m ↦ ?_⟩
+  · obtain ⟨p, hp₁, hp₂⟩ := Ideal.exists_isPrime_le_height (h n)
+    exact ⟨p, IsPrime.ne_top', hp₂⟩
+  · obtain ⟨I, h₁, h₂⟩ := h m
+    grw [← Ideal.height_le_ringKrullDim_of_ne_top h₁]
+    norm_cast
+
 instance (priority := 900) Ideal.finiteHeight_of_finiteRingKrullDim {I : Ideal R}
     [FiniteRingKrullDim R] : I.FiniteHeight := by
   rw [finiteHeight_iff, or_iff_not_imp_left, ← lt_top_iff_ne_top, ← WithBot.coe_lt_coe]


### PR DESCRIPTION
Show that the Krull dimension of a ring R is infinite if and only if it has ideals of unbounded height.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
