### PR TITLE
[Merged by Bors] - feat(RingTheory): a ring is nontrivial iff it has nontrivial Krull dimension

### DIFF
--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -756,4 +756,7 @@ lemma add_le_add_natCast_left_iff {a b : WithBot ℕ∞} {c : ℕ} : c + a ≤ c
 lemma add_le_add_one_left_iff {a b : WithBot ℕ∞} : 1 + a ≤ 1 + b ↔ a ≤ b :=
   WithBot.add_le_add_natCast_left_iff
 
+theorem ne_bot_iff_zero_le {n : WithBot ℕ∞} : n ≠ ⊥ ↔ 0 ≤ n := by
+  cases n <;> simp
+
 end ENat.WithBot

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -756,7 +756,4 @@ lemma add_le_add_natCast_left_iff {a b : WithBot ℕ∞} {c : ℕ} : c + a ≤ c
 lemma add_le_add_one_left_iff {a b : WithBot ℕ∞} : 1 + a ≤ 1 + b ↔ a ≤ b :=
   WithBot.add_le_add_natCast_left_iff
 
-theorem ne_bot_iff_zero_le {n : WithBot ℕ∞} : n ≠ ⊥ ↔ 0 ≤ n := by
-  cases n <;> simp
-
 end ENat.WithBot

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -573,6 +573,9 @@ theorem le_coe_unbotD (x : WithBot α) (b : α) : x ≤ x.unbotD b := by cases x
 @[to_dual (attr := simp) coe_top_lt]
 theorem lt_coe_bot [OrderBot α] : x < (⊥ : α) ↔ x = ⊥ := by cases x <;> simp
 
+@[to_dual (attr := simp) le_coe_top]
+theorem coe_bot_le [OrderBot α] : (⊥ : α) ≤ x ↔ x ≠ ⊥ := by cases x <;> simp
+
 @[to_dual eq_top_iff_forall_gt]
 lemma eq_bot_iff_forall_lt : x = ⊥ ↔ ∀ b : α, x < b := by
   cases x <;> simp; simpa using ⟨_, lt_irrefl _⟩

--- a/Mathlib/RingTheory/KrullDimension/Basic.lean
+++ b/Mathlib/RingTheory/KrullDimension/Basic.lean
@@ -50,7 +50,7 @@ lemma ringKrullDim_eq_bot_of_subsingleton [Subsingleton R] : ringKrullDim R = �
 lemma zero_le_ringKrullDim_iff_nontrivial : 0 ≤ ringKrullDim R ↔ Nontrivial R := by
   refine ⟨fun h ↦ ?_, fun h ↦ krullDim_nonneg⟩
   contrapose! h
-  simp [ringKrullDim_eq_bot_of_subsingleton]
+  exact WithBot.lt_coe_bot.mpr krullDim_eq_bot
 
 lemma ringKrullDim_nonneg_of_nontrivial [Nontrivial R] : 0 ≤ ringKrullDim R :=
   krullDim_nonneg

--- a/Mathlib/RingTheory/KrullDimension/Basic.lean
+++ b/Mathlib/RingTheory/KrullDimension/Basic.lean
@@ -48,9 +48,8 @@ lemma ringKrullDim_eq_bot_of_subsingleton [Subsingleton R] : ringKrullDim R = �
   krullDim_eq_bot
 
 lemma zero_le_ringKrullDim_iff_nontrivial : 0 ≤ ringKrullDim R ↔ Nontrivial R := by
-  refine ⟨fun h ↦ ?_, fun h ↦ krullDim_nonneg⟩
-  contrapose! h
-  exact WithBot.lt_coe_bot.mpr krullDim_eq_bot
+  contrapose!
+  rw [WithBot.lt_zero_iff_eq_bot, ringKrullDim_eq_bot_iff_subsingleton]
 
 lemma ringKrullDim_nonneg_of_nontrivial [Nontrivial R] : 0 ≤ ringKrullDim R :=
   krullDim_nonneg

--- a/Mathlib/RingTheory/KrullDimension/Basic.lean
+++ b/Mathlib/RingTheory/KrullDimension/Basic.lean
@@ -41,7 +41,7 @@ lemma Ring.krullDimLE_iff {n : ℕ} :
 lemma ringKrullDim_eq_bot_iff_subsingleton : ringKrullDim R = ⊥ ↔ Subsingleton R := by
   refine ⟨fun h ↦ ?_, fun h ↦ krullDim_eq_bot⟩
   contrapose! h
-  exact ENat.WithBot.ne_bot_iff_zero_le.mpr krullDim_nonneg
+  exact WithBot.coe_bot_le.mp krullDim_nonneg
 
 @[nontriviality]
 lemma ringKrullDim_eq_bot_of_subsingleton [Subsingleton R] : ringKrullDim R = ⊥ :=

--- a/Mathlib/RingTheory/KrullDimension/Basic.lean
+++ b/Mathlib/RingTheory/KrullDimension/Basic.lean
@@ -38,13 +38,21 @@ variable {R S : Type*} [CommSemiring R] [CommSemiring S]
 lemma Ring.krullDimLE_iff {n : ℕ} :
     KrullDimLE n R ↔ ringKrullDim R ≤ n := Order.krullDimLE_iff n (PrimeSpectrum R)
 
+lemma ringKrullDim_eq_bot_iff_subsingleton : ringKrullDim R = ⊥ ↔ Subsingleton R := by
+  refine ⟨fun h ↦ ?_, fun h ↦ krullDim_eq_bot⟩
+  contrapose! h
+  exact ENat.WithBot.ne_bot_iff_zero_le.mpr krullDim_nonneg
+
 @[nontriviality]
-lemma ringKrullDim_eq_bot_of_subsingleton [Subsingleton R] :
-    ringKrullDim R = ⊥ :=
+lemma ringKrullDim_eq_bot_of_subsingleton [Subsingleton R] : ringKrullDim R = ⊥ :=
   krullDim_eq_bot
 
-lemma ringKrullDim_nonneg_of_nontrivial [Nontrivial R] :
-    0 ≤ ringKrullDim R :=
+lemma zero_le_ringKrullDim_iff_nontrivial : 0 ≤ ringKrullDim R ↔ Nontrivial R := by
+  refine ⟨fun h ↦ ?_, fun h ↦ krullDim_nonneg⟩
+  contrapose! h
+  simp [ringKrullDim_eq_bot_of_subsingleton]
+
+lemma ringKrullDim_nonneg_of_nontrivial [Nontrivial R] : 0 ≤ ringKrullDim R :=
   krullDim_nonneg
 
 /-- If `f : R →+* S` is surjective, then `ringKrullDim S ≤ ringKrullDim R`. -/


### PR DESCRIPTION



---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
