### PR TITLE
chore(Data/Vector/Basic): remove defeq abuse

### DIFF
--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -551,7 +551,7 @@ theorem eraseIdx_insertIdx' {v : Vector α (n + 1)} :
       eraseIdx (j.succAbove i) (insertIdx a j v) = insertIdx a (i.predAbove j) (eraseIdx i v)
   | ⟨i, hi⟩, ⟨j, hj⟩ => by
     dsimp [insertIdx, eraseIdx, Fin.succAbove, Fin.predAbove]
-    erw [Subtype.mk_eq_mk]
+    congr 1
     simp only [Fin.lt_def]
     split_ifs with hij
     · rcases Nat.exists_eq_succ_of_ne_zero

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -52,11 +52,10 @@ instance zero_subsingleton : Subsingleton (Vector α 0) :=
 theorem cons_val (a : α) : ∀ v : Vector α n, (a ::ᵥ v).val = a :: v.val
   | ⟨_, _⟩ => rfl
 
-set_option backward.isDefEq.respectTransparency false in
 theorem eq_cons_iff (a : α) (v : Vector α n.succ) (v' : Vector α n) :
     v = a ::ᵥ v' ↔ v.head = a ∧ v.tail = v' :=
   ⟨fun h => h.symm ▸ ⟨head_cons a v', tail_cons a v'⟩, fun h =>
-    _root_.trans (cons_head_tail v).symm (by rw [h.1, h.2])⟩
+    _root_.trans (cons_head_tail v).symm (by simp [h])⟩
 
 theorem ne_cons_iff (a : α) (v : Vector α n.succ) (v' : Vector α n) :
     v ≠ a ::ᵥ v' ↔ v.head ≠ a ∨ v.tail ≠ v' := by rw [Ne, eq_cons_iff a v v', not_and_or]
@@ -100,12 +99,11 @@ theorem head_map {β : Type*} (v : Vector α (n + 1)) (f : α → β) : (v.map f
   obtain ⟨a, v', h⟩ := Vector.exists_eq_cons v
   rw [h, map_cons, head_cons, head_cons]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem tail_map {β : Type*} (v : Vector α (n + 1)) (f : α → β) :
     (v.map f).tail = v.tail.map f := by
   obtain ⟨a, v', h⟩ := Vector.exists_eq_cons v
-  rw [h, map_cons, tail_cons, tail_cons]
+  simp_rw [h, map_cons, tail_cons, Nat.add_one_sub_one]
 
 @[simp]
 theorem getElem_map {β : Type*} (v : Vector α n) (f : α → β) {i : ℕ} (hi : i < n) :
@@ -117,23 +115,24 @@ theorem toList_pmap {p : α → Prop} (f : (a : α) → p a → β) (v : Vector 
     (hp : ∀ x ∈ v.toList, p x) :
     (v.pmap f hp).toList = v.toList.pmap f hp := by cases v; rfl
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem head_pmap {p : α → Prop} (f : (a : α) → p a → β) (v : Vector α (n + 1))
     (hp : ∀ x ∈ v.toList, p x) :
     (v.pmap f hp).head = f v.head (hp _ <| by
-      rw [← cons_head_tail v, toList_cons, head_cons, List.mem_cons]; exact .inl rfl) := by
+      rw [← cons_head_tail v]
+      simp) := by
   obtain ⟨a, v', h⟩ := Vector.exists_eq_cons v
   simp_rw [h, pmap_cons, head_cons]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem tail_pmap {p : α → Prop} (f : (a : α) → p a → β) (v : Vector α (n + 1))
     (hp : ∀ x ∈ v.toList, p x) :
     (v.pmap f hp).tail = v.tail.pmap f (fun x hx ↦ hp _ <| by
-      rw [← cons_head_tail v, toList_cons, List.mem_cons]; exact .inr hx) := by
+      rw [← cons_head_tail v]
+      simp_rw [Nat.succ_eq_add_one, Nat.add_one_sub_one, toList_cons v.head, List.mem_cons]
+      exact .inr hx) := by
   obtain ⟨a, v', h⟩ := Vector.exists_eq_cons v
-  simp_rw [h, pmap_cons, tail_cons]
+  simp_rw [h, pmap_cons, tail_cons, Nat.add_one_sub_one]
 
 @[simp]
 theorem getElem_pmap {p : α → Prop} (f : (a : α) → p a → β) (v : Vector α n)
@@ -274,10 +273,9 @@ of one element `x : α` is `x` itself. -/
 theorem get_cons_nil : ∀ {ix : Fin 1} (x : α), get (x ::ᵥ nil) ix = x
   | ⟨0, _⟩, _ => rfl
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem get_cons_succ (a : α) (v : Vector α n) (i : Fin n) : get (a ::ᵥ v) i.succ = get v i := by
-  rw [← get_tail_succ, tail_cons]
+  simp_rw [← get_tail_succ, tail_cons, Nat.succ_eq_add_one, Nat.add_one_sub_one]
 
 /-- The last element of a `Vector`, given that the vector is at least one element. -/
 def last (v : Vector α (n + 1)) : α :=
@@ -354,7 +352,6 @@ theorem scanl_head : (scanl f b v).head = b := by
   · rw [← cons_head_tail v]
     simp [← get_zero, get_eq_get_toList]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- For an index `i : Fin n`, the nth element of `scanl` of a
 vector `v : Vector α n` at `i.succ`, is equal to the application
 function `f : β → α → β` of the `castSucc i` element of
@@ -372,7 +369,8 @@ theorem scanl_get (i : Fin n) :
     have i0 : i = 0 := Fin.eq_zero _
     simp [scanl_singleton, i0, get_zero]; simp [get_eq_get_toList]
   | succ n hn =>
-    rw [← cons_head_tail v, scanl_cons, get_cons_succ]
+    rw [← cons_head_tail v]
+    simp_rw [Nat.succ_eq_add_one, Nat.add_one_sub_one, scanl_cons, get_cons_succ]
     refine Fin.cases ?_ ?_ i
     · simp
     · intro i'
@@ -547,14 +545,13 @@ theorem eraseIdx_insertIdx_self {v : Vector α n} {i : Fin (n + 1)} :
     eraseIdx i (insertIdx a i v) = v :=
   Subtype.ext (List.eraseIdx_insertIdx_self ..)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Erasing an element after inserting an element, at different indices. -/
 theorem eraseIdx_insertIdx' {v : Vector α (n + 1)} :
     ∀ {i : Fin (n + 1)} {j : Fin (n + 2)},
       eraseIdx (j.succAbove i) (insertIdx a j v) = insertIdx a (i.predAbove j) (eraseIdx i v)
   | ⟨i, hi⟩, ⟨j, hj⟩ => by
     dsimp [insertIdx, eraseIdx, Fin.succAbove, Fin.predAbove]
-    rw [Subtype.mk_eq_mk]
+    erw [Subtype.mk_eq_mk]
     simp only [Fin.lt_def]
     split_ifs with hij
     · rcases Nat.exists_eq_succ_of_ne_zero


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
