### PR TITLE
feat(CategoryTheory): torsors in a cartesian monoidal category

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3090,6 +3090,7 @@ public import Mathlib.CategoryTheory.Monoidal.Cartesian.Normal
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Over
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Ring
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.ShrinkYoneda
+public import Mathlib.CategoryTheory.Monoidal.Cartesian.Torsor
 public import Mathlib.CategoryTheory.Monoidal.Category
 public import Mathlib.CategoryTheory.Monoidal.Center
 public import Mathlib.CategoryTheory.Monoidal.Closed.Basic

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Mod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Mod.lean
@@ -5,7 +5,7 @@ Authors: Paul Lezeau, Christian Merten
 -/
 module
 
-public import Mathlib.CategoryTheory.Monoidal.Cartesian.Mon
+public import Mathlib.CategoryTheory.Monoidal.Cartesian.Grp
 public import Mathlib.CategoryTheory.Monoidal.Mod
 public import Mathlib.GroupTheory.GroupAction.Hom
 
@@ -107,11 +107,24 @@ lemma lift_leftSMul_eq_lift_iff (Z : C) (x y : Z ⟶ X) (m : Z ⟶ M) :
     lift m x ≫ leftSMul M X = lift y x ↔ m • x = y := by
   simp [Hom.smul_def, leftSMul, CartesianMonoidalCategory.hom_ext_iff]
 
+attribute [local instance] ModObj.regular in
+lemma leftSMul_self : leftSMul M M = lift μ (snd M M) :=
+  rfl
+
+/-- A module object `X` is homogeneous over `M`, if the action is simply transitive, i.e.,
+the morphism `(m, x) ↦ (m • x, x)` is an isomorphism. -/
+abbrev IsHomogeneous (M : C) [MonObj M] (X : C) [ModObj M X] : Prop :=
+  IsIso (leftSMul M X)
+
+@[reassoc (attr := simp)]
+lemma inv_leftSMul_snd [IsHomogeneous M X] : inv (leftSMul M X) ≫ snd M X = snd _ _ := by
+  simp
+
 open CartesianMonoidalCategory in
 /-- The morphism `(m, x) ↦ (m • x, x)` is an isomorphism if and only if the induced
 action is pointwise simply transitive. -/
-lemma isIso_leftSMul_iff :
-    IsIso (leftSMul M X) ↔ ∀ (Z : C) (x y : Z ⟶ X), ∃! (m : Z ⟶ M), m • x = y := by
+lemma isHomogeneous_iff :
+    IsHomogeneous M X ↔ ∀ (Z : C) (x y : Z ⟶ X), ∃! (m : Z ⟶ M), m • x = y := by
   have H (Z : C) (x : Z ⟶ X) (m : Z ⟶ M) :
       lift m x ≫ leftSMul M X = lift (m • x) x := by
     ext <;> simp [Hom.smul_def]
@@ -119,7 +132,7 @@ lemma isIso_leftSMul_iff :
       lift m x ≫ leftSMul M X = lift f g ↔ x = g ∧ m • x = f := by
     simp [← lift_leftSMul_eq_lift_iff, CartesianMonoidalCategory.hom_ext_iff]
     grind
-  rw [isIso_iff_yoneda_map_bijective]
+  rw [IsHomogeneous, isIso_iff_yoneda_map_bijective]
   congr! with Z
   rw [← Function.Bijective.of_comp_iff _ liftEquiv.bijective, Function.bijective_iff_existsUnique]
   simp only [liftEquiv.surjective.forall, liftEquiv_apply, Prod.forall, Function.comp_apply, h]
@@ -127,6 +140,20 @@ lemma isIso_leftSMul_iff :
   congr! 2 with f g
   exact Equiv.existsUnique_subtype_congr ⟨fun a ↦ ⟨a.val.fst, by grind⟩,
     fun a ↦ ⟨⟨a.val, f⟩, by grind⟩, by cat_disch, by cat_disch⟩
+
+@[deprecated (since := "2026-06-28")]
+alias isIso_leftSMul_iff := isHomogeneous_iff
+
+attribute [local instance] ModObj.regular in
+instance (G : C) [GrpObj G] : IsHomogeneous G G := by
+  refine ⟨lift (G ◁ ι ≫ μ) (snd _ _), ?_, ?_⟩
+  · ext
+    · simp [leftSMul_self, GrpObj.lift_inv_right_eq]
+    · simp
+  · ext
+    · have : G ◁ ι[G] = lift (fst G G) (snd G G ≫ ι) := by ext <;> simp
+      simp [this, ← Hom.mul_def, ← Hom.inv_def]
+    · simp
 
 end ModObj
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Mod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Mod.lean
@@ -88,7 +88,7 @@ namespace ModObj
 
 variable (M X) in
 /-- The morphism `(m, x) ↦ (m • x, x)`. -/
-@[to_additive]
+@[to_additive /-- The morphism `(m, x) ↦ (m +ᵥ x, x)`. -/]
 def leftSMul : M ⊗ X ⟶ X ⊗ X :=
   lift γ[M, X] (snd _ _)
 
@@ -116,7 +116,8 @@ lemma leftSMul_self : leftSMul M M = lift μ (snd M M) :=
 
 /-- A module object `X` is homogeneous over `M`, if the action is simply transitive, i.e.,
 the morphism `(m, x) ↦ (m • x, x)` is an isomorphism. -/
-@[to_additive]
+@[to_additive /-- An additive module object `X` is homogeneous over `M`, if the action is simply
+transitive, i.e., the morphism `(m, x) ↦ (m • x, x)` is an isomorphism. -/]
 abbrev IsHomogeneous (M : C) [MonObj M] (X : C) [ModObj M X] : Prop :=
   IsIso (leftSMul M X)
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Mod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Mod.lean
@@ -88,41 +88,46 @@ namespace ModObj
 
 variable (M X) in
 /-- The morphism `(m, x) ↦ (m • x, x)`. -/
+@[to_additive]
 def leftSMul : M ⊗ X ⟶ X ⊗ X :=
   lift γ[M, X] (snd _ _)
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma leftSMul_fst : leftSMul M X ≫ fst _ _ = γ[M, X] := by
   simp [leftSMul]
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma leftSMul_snd : leftSMul M X ≫ snd _ _ = snd _ _ := by
   simp [leftSMul]
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma lift_leftSMul (Z : C) (x : Z ⟶ X) (m : Z ⟶ M) : lift m x ≫ leftSMul M X = lift (m • x) x := by
   ext <;> simp [Hom.smul_def]
 
+@[to_additive]
 lemma lift_leftSMul_eq_lift_iff (Z : C) (x y : Z ⟶ X) (m : Z ⟶ M) :
     lift m x ≫ leftSMul M X = lift y x ↔ m • x = y := by
   simp [Hom.smul_def, leftSMul, CartesianMonoidalCategory.hom_ext_iff]
 
 attribute [local instance] ModObj.regular in
+@[to_additive]
 lemma leftSMul_self : leftSMul M M = lift μ (snd M M) :=
   rfl
 
 /-- A module object `X` is homogeneous over `M`, if the action is simply transitive, i.e.,
 the morphism `(m, x) ↦ (m • x, x)` is an isomorphism. -/
+@[to_additive]
 abbrev IsHomogeneous (M : C) [MonObj M] (X : C) [ModObj M X] : Prop :=
   IsIso (leftSMul M X)
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma inv_leftSMul_snd [IsHomogeneous M X] : inv (leftSMul M X) ≫ snd M X = snd _ _ := by
   simp
 
 open CartesianMonoidalCategory in
 /-- The morphism `(m, x) ↦ (m • x, x)` is an isomorphism if and only if the induced
 action is pointwise simply transitive. -/
+@[to_additive]
 lemma isHomogeneous_iff :
     IsHomogeneous M X ↔ ∀ (Z : C) (x y : Z ⟶ X), ∃! (m : Z ⟶ M), m • x = y := by
   have H (Z : C) (x : Z ⟶ X) (m : Z ⟶ M) :
@@ -145,6 +150,7 @@ lemma isHomogeneous_iff :
 alias isIso_leftSMul_iff := isHomogeneous_iff
 
 attribute [local instance] ModObj.regular in
+@[to_additive]
 instance (G : C) [GrpObj G] : IsHomogeneous G G := by
   refine ⟨lift (G ◁ ι ≫ μ) (snd _ _), ?_, ?_⟩
   · ext

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Torsor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Torsor.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+module
+
+public import Mathlib.CategoryTheory.Monoidal.Cartesian.Mod
+public import Mathlib.CategoryTheory.Sites.CoversTop.Basic
+
+/-!
+# Torsors in a cartesian monoidal category
+
+A module object `X` over a monoid object `M` is a torsor for the topology
+`J` if `M` acts simply transitively on `X` and `locally `X` is trivial on some `J`-cover.
+-/
+
+@[expose] public section
+
+universe v u
+
+namespace CategoryTheory.ModObj
+
+variable {C : Type u} [Category.{v} C] [CartesianMonoidalCategory C]
+  {M : C} [MonObj M] {X Y : C} [ModObj M Y] [ModObj M X]
+  {G : C} [GrpObj G] [ModObj G X]
+
+attribute [local instance] ModObj.regular
+
+open Limits
+
+open CategoryTheory MonoidalCategory CartesianMonoidalCategory MonObj
+
+variable (J : GrothendieckTopology C)
+
+/-- A homogeneous module object is trivial over `U : C`, if there exists a morphism `U ⟶ X ⊗ U`. -/
+@[mk_iff]
+class IsTrivialOver (M : C) [MonObj M] (X : C) [ModObj M X] (U : C) [IsHomogeneous M X] where
+  nonempty_hom : Nonempty (U ⟶ X)
+
+lemma isTrivialOver_iff_isSplitEpi [IsHomogeneous M X] (U : C) :
+    IsTrivialOver M X U ↔ IsSplitEpi (snd X U) :=
+  ⟨fun h ↦ ⟨⟨⟨lift h.nonempty_hom.some (𝟙 _), by simp⟩⟩⟩, fun ⟨h⟩ ↦ ⟨⟨h.some.section_ ≫ fst _ _⟩⟩⟩
+
+variable (M X) in
+/-- A module object `X` over a monoid object `M` is a torsor for the Grothendieck topology `J`,
+if `M` acts simply transitively on `X` and there exists a `J`-covering that trivializes `X`. -/
+class IsTorsor (J : GrothendieckTopology C) (M : C) [MonObj M] (X : C) [ModObj M X] where
+  isHomogeneous : IsHomogeneous M X := by infer_instance
+  exists_coversTop : ∃ (I : Type max u v) (U : I → C),
+    J.CoversTop U ∧ ∀ (i : I), IsTrivialOver M X (U i)
+
+namespace IsTorsor
+
+instance : IsTorsor J G G where
+  exists_coversTop := by
+    refine ⟨PUnit, fun _ ↦ 𝟙_ _, ?_, ?_⟩
+    · rw [J.coversTop_iff_of_isTerminal _ isTerminalTensorUnit,
+        Sieve.pullback_ofObjects_eq_top (i := ⟨⟩) _ (𝟙 _)]
+      simp
+    · simp only [isTrivialOver_iff, forall_const]
+      exact ⟨η⟩
+
+end IsTorsor
+
+variable (M) in
+/-- A morphism `s : U ⟶ X` trivializes a homogeneous module object over `U`, i.e.,
+`X ⊗ U` is isomorphic to `M ⊗ U`.
+This corresponds to `X` being the trivial torsor when restricted to `Over U`. -/
+noncomputable
+def isoTensorOfHom {U : C} (s : U ⟶ X) [IsHomogeneous M X] : M ⊗ U ≅ X ⊗ U where
+  hom := lift (𝟙 _ ⊗ₘ s) (snd _ _) ≫ γ[M, X] ▷ U
+  inv := lift (𝟙 _ ⊗ₘ s) (snd _ _) ≫ inv (leftSMul M X) ▷ U ≫ fst _ _ ▷ U
+  hom_inv_id := by
+    have : (lift (𝟙 M ⊗ₘ s) (snd M U) ≫ γ[M, X] ▷ U) ≫ lift (𝟙 X ⊗ₘ s) (snd X U) =
+        lift (𝟙 M ⊗ₘ s) (snd _ _) ≫ leftSMul M X ▷ U := by
+      ext <;> simp
+    rw [Category.assoc, reassoc_of% this]
+    simp
+  inv_hom_id := by
+    have h1 :
+        lift (𝟙 X ⊗ₘ s) (snd X U) ≫ inv (leftSMul M X) ▷ U ≫ fst M X ▷ U ≫
+          lift (𝟙 M ⊗ₘ s) (snd M U) =
+          lift (𝟙 X ⊗ₘ s) (snd X U) ≫ inv (leftSMul M X) ▷ U := by
+      ext <;> simp
+    have h2 : inv (leftSMul M X) ≫ γ[M, X] = fst X X := by simp
+    simp only [Category.assoc, reassoc_of% h1]
+    simp [h2]
+
+@[reassoc (attr := simp)]
+lemma isoTensorOfHom_hom_fst {U : C} (s : U ⟶ X) [IsHomogeneous M X] :
+    (isoTensorOfHom M s).hom ≫ fst _ _ = _ ◁ s ≫ γ[M, X] := by
+  simp [isoTensorOfHom]
+
+@[reassoc (attr := simp)]
+lemma isoTensorOfHom_hom_snd {U : C} (s : U ⟶ X) [IsHomogeneous M X] :
+    (isoTensorOfHom M s).hom ≫ snd _ _ = snd _ _ := by
+  simp [isoTensorOfHom]
+
+@[reassoc (attr := simp)]
+lemma isoTensorOfHom_inv_snd {U : C} (s : U ⟶ X) [IsHomogeneous M X] :
+    (isoTensorOfHom M s).inv ≫ snd _ _ = snd _ _ := by
+  simp [isoTensorOfHom]
+
+/-- `isoTensorOfHom` is a module object homomorphism in `Over U`. To avoid passing
+to `Over U`, we state this as an equality of morphisms `C`. -/
+@[reassoc]
+lemma smul_isoTensorOfHom_hom {U : C} (s : U ⟶ X) [IsHomogeneous M X] :
+    μ ▷ U ≫ (isoTensorOfHom M s).hom =
+      (α_ _ _ _).hom ≫ M ◁ (isoTensorOfHom M s).hom ≫ (α_ _ _ _).inv ≫ γ[M, X] ▷ U := by
+  ext
+  · have : M ◁ M ◁ s ≫ M ◁ γ[M, X] =
+        (M ◁ lift (M ◁ s ≫ γ[M, X]) (snd M U) ≫ (α_ M X U).inv) ≫ fst (M ⊗ X) U := by
+      ext <;> simp
+    simp [isoTensorOfHom, ← whisker_exchange_assoc, reassoc_of% this]
+  · simp
+
+variable (M) in
+/-- Any global section section `𝟙_ C ⟶ X`, induces an isomorphism `M ≅ X`. This
+is compatible with the module structure. -/
+noncomputable def isoOfHom (s : 𝟙_ C ⟶ X) [IsHomogeneous M X] : M ≅ X :=
+  (ρ_ _).symm ≪≫ isoTensorOfHom M s ≪≫ ρ_ _
+
+instance (s : 𝟙_ C ⟶ X) [IsHomogeneous M X] :
+    IsModHom M (isoOfHom M s).hom where
+  smul_hom := by
+    have : μ ≫ (ρ_ M).inv = (ρ_ _).inv ≫ μ ▷ 𝟙_ C := by simp
+    dsimp [isoOfHom]
+    simp only [Iso.trans_hom, Iso.symm_hom, reassoc_of% this, smul_isoTensorOfHom_hom_assoc]
+    simp
+
+lemma isTrivialOver_iff_nonempty_iso [IsHomogeneous M X] (U : C) :
+    IsTrivialOver M X U ↔ Nonempty (M ⊗ U ≅ X ⊗ U) :=
+  ⟨fun h ↦ ⟨isoTensorOfHom _ h.nonempty_hom.some⟩,
+    fun ⟨u⟩ ↦ ⟨⟨lift (toUnit _ ≫ η) (𝟙 _) ≫ u.hom ≫ fst _ _⟩⟩⟩
+
+end CategoryTheory.ModObj

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Torsor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Torsor.lean
@@ -141,7 +141,7 @@ variable (M) in
 /-- Any global section `𝟙_ C ⟶ X`, induces an isomorphism `M ≅ X`. This
 is compatible with the module structure. -/
 @[to_additive
-/-- Any global section section `𝟙_ C ⟶ X`, induces an isomorphism `M ≅ X`. This
+/-- Any global section `𝟙_ C ⟶ X`, induces an isomorphism `M ≅ X`. This
 is compatible with the additive module structure. -/]
 noncomputable def isoOfHom (s : 𝟙_ C ⟶ X) [IsHomogeneous M X] : M ≅ X :=
   (ρ_ _).symm ≪≫ isoTensorOfHom M s ≪≫ ρ_ _

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Torsor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Torsor.lean
@@ -138,7 +138,7 @@ lemma smul_isoTensorOfHom_hom {U : C} (s : U ⟶ X) [IsHomogeneous M X] :
   · simp
 
 variable (M) in
-/-- Any global section section `𝟙_ C ⟶ X`, induces an isomorphism `M ≅ X`. This
+/-- Any global section `𝟙_ C ⟶ X`, induces an isomorphism `M ≅ X`. This
 is compatible with the module structure. -/
 @[to_additive
 /-- Any global section section `𝟙_ C ⟶ X`, induces an isomorphism `M ≅ X`. This

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Torsor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Torsor.lean
@@ -33,18 +33,35 @@ open CategoryTheory MonoidalCategory CartesianMonoidalCategory MonObj
 
 variable (J : GrothendieckTopology C)
 
-/-- A homogeneous module object is trivial over `U : C`, if there exists a morphism `U ⟶ X ⊗ U`. -/
+/-- An additive homogeneous module object is trivial over `U : C`, if there exists a morphism
+`U ⟶ X`. -/
 @[mk_iff]
+class _root_.CategoryTheory.AddModObj.IsTrivialOver (M : C) [AddMonObj M] (X : C) [AddModObj M X]
+    (U : C) [AddModObj.IsHomogeneous M X] where
+  nonempty_hom : Nonempty (U ⟶ X)
+
+/-- A homogeneous module object is trivial over `U : C`, if there exists a morphism `U ⟶ X`. -/
+@[mk_iff, to_additive existing]
 class IsTrivialOver (M : C) [MonObj M] (X : C) [ModObj M X] (U : C) [IsHomogeneous M X] where
   nonempty_hom : Nonempty (U ⟶ X)
 
+@[to_additive]
 lemma isTrivialOver_iff_isSplitEpi [IsHomogeneous M X] (U : C) :
     IsTrivialOver M X U ↔ IsSplitEpi (snd X U) :=
   ⟨fun h ↦ ⟨⟨⟨lift h.nonempty_hom.some (𝟙 _), by simp⟩⟩⟩, fun ⟨h⟩ ↦ ⟨⟨h.some.section_ ≫ fst _ _⟩⟩⟩
 
-variable (M X) in
+/-- An additive module object `X` over a monoid object `M` is an additive torsor for the
+Grothendieck topology `J`, if `M` acts simply transitively on `X` and there exists a `J`-covering
+that trivializes `X`. -/
+class _root_.CategoryTheory.AddModObj.IsAddTorsor (J : GrothendieckTopology C) (M : C) [AddMonObj M]
+    (X : C) [AddModObj M X] where
+  isHomogeneous : AddModObj.IsHomogeneous M X := by infer_instance
+  exists_coversTop : ∃ (I : Type max u v) (U : I → C),
+    J.CoversTop U ∧ ∀ (i : I), AddModObj.IsTrivialOver M X (U i)
+
 /-- A module object `X` over a monoid object `M` is a torsor for the Grothendieck topology `J`,
 if `M` acts simply transitively on `X` and there exists a `J`-covering that trivializes `X`. -/
+@[to_additive existing]
 class IsTorsor (J : GrothendieckTopology C) (M : C) [MonObj M] (X : C) [ModObj M X] where
   isHomogeneous : IsHomogeneous M X := by infer_instance
   exists_coversTop : ∃ (I : Type max u v) (U : I → C),
@@ -52,6 +69,7 @@ class IsTorsor (J : GrothendieckTopology C) (M : C) [MonObj M] (X : C) [ModObj M
 
 namespace IsTorsor
 
+@[to_additive]
 instance : IsTorsor J G G where
   exists_coversTop := by
     refine ⟨PUnit, fun _ ↦ 𝟙_ _, ?_, ?_⟩
@@ -67,8 +85,10 @@ variable (M) in
 /-- A morphism `s : U ⟶ X` trivializes a homogeneous module object over `U`, i.e.,
 `X ⊗ U` is isomorphic to `M ⊗ U`.
 This corresponds to `X` being the trivial torsor when restricted to `Over U`. -/
-noncomputable
-def isoTensorOfHom {U : C} (s : U ⟶ X) [IsHomogeneous M X] : M ⊗ U ≅ X ⊗ U where
+@[to_additive /-- A morphism `s : U ⟶ X` trivializes an additive homogeneous module object over
+`U`, i.e., `X ⊗ U` is isomorphic to `M ⊗ U`. This corresponds to `X` being the trivial torsor when
+restricted to `Over U`. -/]
+noncomputable def isoTensorOfHom {U : C} (s : U ⟶ X) [IsHomogeneous M X] : M ⊗ U ≅ X ⊗ U where
   hom := lift (𝟙 _ ⊗ₘ s) (snd _ _) ≫ γ[M, X] ▷ U
   inv := lift (𝟙 _ ⊗ₘ s) (snd _ _) ≫ inv (leftSMul M X) ▷ U ≫ fst _ _ ▷ U
   hom_inv_id := by
@@ -87,24 +107,26 @@ def isoTensorOfHom {U : C} (s : U ⟶ X) [IsHomogeneous M X] : M ⊗ U ≅ X ⊗
     simp only [Category.assoc, reassoc_of% h1]
     simp [h2]
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma isoTensorOfHom_hom_fst {U : C} (s : U ⟶ X) [IsHomogeneous M X] :
     (isoTensorOfHom M s).hom ≫ fst _ _ = _ ◁ s ≫ γ[M, X] := by
   simp [isoTensorOfHom]
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma isoTensorOfHom_hom_snd {U : C} (s : U ⟶ X) [IsHomogeneous M X] :
     (isoTensorOfHom M s).hom ≫ snd _ _ = snd _ _ := by
   simp [isoTensorOfHom]
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma isoTensorOfHom_inv_snd {U : C} (s : U ⟶ X) [IsHomogeneous M X] :
     (isoTensorOfHom M s).inv ≫ snd _ _ = snd _ _ := by
   simp [isoTensorOfHom]
 
 /-- `isoTensorOfHom` is a module object homomorphism in `Over U`. To avoid passing
 to `Over U`, we state this as an equality of morphisms `C`. -/
-@[reassoc]
+@[to_additive (attr := reassoc)
+/-- `isoTensorOfHom` is an additive module object homomorphism in `Over U`. To avoid passing
+to `Over U`, we state this as an equality of morphisms `C`. -/]
 lemma smul_isoTensorOfHom_hom {U : C} (s : U ⟶ X) [IsHomogeneous M X] :
     μ ▷ U ≫ (isoTensorOfHom M s).hom =
       (α_ _ _ _).hom ≫ M ◁ (isoTensorOfHom M s).hom ≫ (α_ _ _ _).inv ≫ γ[M, X] ▷ U := by
@@ -118,9 +140,13 @@ lemma smul_isoTensorOfHom_hom {U : C} (s : U ⟶ X) [IsHomogeneous M X] :
 variable (M) in
 /-- Any global section section `𝟙_ C ⟶ X`, induces an isomorphism `M ≅ X`. This
 is compatible with the module structure. -/
+@[to_additive
+/-- Any global section section `𝟙_ C ⟶ X`, induces an isomorphism `M ≅ X`. This
+is compatible with the additive module structure. -/]
 noncomputable def isoOfHom (s : 𝟙_ C ⟶ X) [IsHomogeneous M X] : M ≅ X :=
   (ρ_ _).symm ≪≫ isoTensorOfHom M s ≪≫ ρ_ _
 
+@[to_additive]
 instance (s : 𝟙_ C ⟶ X) [IsHomogeneous M X] :
     IsModHom M (isoOfHom M s).hom where
   smul_hom := by
@@ -129,6 +155,7 @@ instance (s : 𝟙_ C ⟶ X) [IsHomogeneous M X] :
     simp only [Iso.trans_hom, Iso.symm_hom, reassoc_of% this, smul_isoTensorOfHom_hom_assoc]
     simp
 
+@[to_additive]
 lemma isTrivialOver_iff_nonempty_iso [IsHomogeneous M X] (U : C) :
     IsTrivialOver M X U ↔ Nonempty (M ⊗ U ≅ X ⊗ U) :=
   ⟨fun h ↦ ⟨isoTensorOfHom _ h.nonempty_hom.some⟩,


### PR DESCRIPTION
We define a predicate `ModObj.IsTorsor`: A module object `X` with action by a monoid object `M` is a torsor for a Grothendieck topology `J` if `M` acts simply transitively on `X` and there exists a `J`-covering that trivializes `X`, i.e. after restricting to the cover, `X` admits a section.
We show that having a section is the same as being isomorphic to `M`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
