### PR TITLE
feat(CategoryTheory): bracket of a functor with a copresheaf

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2693,6 +2693,7 @@ public import Mathlib.CategoryTheory.FinCategory.AsType
 public import Mathlib.CategoryTheory.FinCategory.Basic
 public import Mathlib.CategoryTheory.FintypeCat
 public import Mathlib.CategoryTheory.Functor.Basic
+public import Mathlib.CategoryTheory.Functor.Bracket
 public import Mathlib.CategoryTheory.Functor.Category
 public import Mathlib.CategoryTheory.Functor.Const
 public import Mathlib.CategoryTheory.Functor.Currying

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -51,6 +51,10 @@ def Functor.Elements (F : C ⥤ Type w) :=
 /-- Constructor for the type `F.Elements` when `F` is a functor to types. -/
 abbrev Functor.elementsMk (F : C ⥤ Type w) (X : C) (x : F.obj X) : F.Elements := ⟨X, x⟩
 
+lemma Functor.elementsMk_surjective {F : C ⥤ Type w} (A : F.Elements) :
+    ∃ (X : C) (x : F.obj X), A = F.elementsMk X x :=
+  ⟨A.1, A.2, rfl⟩
+
 lemma Functor.Elements.ext {F : C ⥤ Type w} (x y : F.Elements) (h₁ : x.fst = y.fst)
     (h₂ : F.map (eqToHom h₁) x.snd = y.snd) : x = y := by
   cases x
@@ -84,6 +88,10 @@ namespace CategoryOfElements
 def homMk {F : C ⥤ Type w} (x y : F.Elements) (f : x.1 ⟶ y.1) (hf : F.map f x.snd = y.snd) :
     x ⟶ y :=
   ⟨f, hf⟩
+
+lemma homMk_surjective {F : C ⥤ Type w} {A B : F.Elements} (f : A ⟶ B) :
+    ∃ (u : A.1 ⟶ B.1) (hu : F.map u A.2 = B.2), f = homMk _ _ u hu :=
+  ⟨f.1, f.2, rfl⟩
 
 @[ext]
 theorem ext (F : C ⥤ Type w) {x y : F.Elements} (f g : x ⟶ y) (w : f.val = g.val) : f = g :=
@@ -165,6 +173,21 @@ def map {F₁ F₂ : C ⥤ Type w} (α : F₁ ⟶ F₂) : F₁.Elements ⥤ F₂
 @[simp]
 theorem map_π {F₁ F₂ : C ⥤ Type w} (α : F₁ ⟶ F₂) : map α ⋙ π F₂ = π F₁ :=
   rfl
+
+@[simp]
+lemma map_id_obj {F : C ⥤ Type w} (j : F.Elements) : (map (𝟙 F)).obj j = j :=
+  rfl
+
+@[simp]
+lemma map_comp_obj {F G H : C ⥤ Type w} (f : F ⟶ G) (g : G ⟶ H) (j : F.Elements) :
+    (map (f ≫ g)).obj j = (map g).obj ((map f).obj j) :=
+  rfl
+
+/-- The natural isomorphism witnessing the compatiblity of `CategoryOfElements.map` with
+the projection. -/
+@[simps!]
+def mapπiso {F G : C ⥤ Type w} (f : F ⟶ G) : map f ⋙ π G ≅ π F :=
+  NatIso.ofComponents fun _ ↦ Iso.refl _
 
 /-- The forward direction of the equivalence `F.Elements ≅ (*, F)`. -/
 def toStructuredArrow : F.Elements ⥤ StructuredArrow PUnit F where

--- a/Mathlib/CategoryTheory/Functor/Bracket.lean
+++ b/Mathlib/CategoryTheory/Functor/Bracket.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 Robin Carlier, Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier, Christian Merten
+-/
+module
+
+public import Mathlib.CategoryTheory.Elements
+public import Mathlib.CategoryTheory.Limits.FunctorCategory.Basic
+public import Mathlib.CategoryTheory.Limits.Preserves.Opposites
+public import Mathlib.CategoryTheory.Limits.Types.Colimits
+
+/-!
+# Bracket operation on copresheaves
+
+Given a functor `X : C ⥤ A` and a copresheaf `K : C ⥤ Type w`, we define the object
+`X[K] : A`, which is the limit over the diagram `CategoryOfElements.π K ⋙ X : ∫ K ⥤ A`.
+
+This is used to define a bracket operation of a (semi)simplicial object with a (semi)simplicial
+set.
+
+## Main declarations
+
+- `CategoryTheory.Functor.bracket`: The bracket `X[K]` if it exists.
+- `CategoryTheory.Functor.isLimitMapConeBracketFunctor`: The bracket sends
+  colimits to limits: `X[colimⱼ Kⱼ] ≅ limⱼ X[Kⱼ]`.
+-/
+
+@[expose] public section
+
+universe w u
+
+open CategoryTheory
+
+namespace CategoryTheory.Functor
+
+open Limits
+
+variable {C A : Type*} [Category* C] [Category* A]
+  (X : C ⥤ A) (K : C ⥤ Type w)
+
+/-- The diagram defining the bracket `X[K]` given by `CategoryOfElements.π K ⋙ X`. -/
+abbrev bracketDiag : K.Elements ⥤ A :=
+  CategoryOfElements.π K ⋙ X
+
+/-- The bracket `X[K]` exists if the limit over `bracketDiag X K` exists. -/
+abbrev HasBracket : Prop :=
+  HasLimit (bracketDiag X K)
+
+/-- The object property of existence of `X[-]`. -/
+abbrev hasBracket : ObjectProperty (C ⥤ Type w) :=
+  fun K ↦ HasBracket X K
+
+instance (K : (hasBracket X).FullSubcategory) : HasBracket X K.obj := K.property
+
+instance (K : (hasBracket X).FullSubcategory) : HasBracket X ((hasBracket X).ι.obj K) := K.property
+
+/-- The bracket `X[K]` of a functor `X : C ⥤ A` and a copresheaf `K : C ⥤ Type w` is
+the limit over the diagram `CategoryOfElements.π K ⋙ X`. -/
+noncomputable abbrev bracket [HasBracket X K] : A :=
+  limit (bracketDiag X K)
+
+variable {K L M : C ⥤ Type w} [HasBracket X K] [HasBracket X L] [HasBracket X M]
+
+/-- The bracket `X[-]` is functorial in the copresheaf. -/
+noncomputable def bracketMap (f : K ⟶ L) : bracket X L ⟶ bracket X K :=
+  haveI : HasLimit (CategoryOfElements.map f ⋙ bracketDiag X L) :=
+    hasLimit_of_iso (Functor.isoWhiskerRight (CategoryOfElements.mapπiso f) _).symm
+  limit.pre (bracketDiag _ _) (CategoryOfElements.map f) ≫
+    (HasLimit.isoOfNatIso <| (Functor.associator _ _ _).symm ≪≫
+      Functor.isoWhiskerRight (CategoryOfElements.mapπiso _) _).hom
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc (attr := simp)]
+lemma bracketMap_π (f : K ⟶ L) (j : K.Elements) :
+    bracketMap X f ≫ limit.π _ j = limit.π _ ((CategoryOfElements.map f).obj j) := by
+  simp [bracketMap]
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+@[simp]
+lemma bracketMap_id : bracketMap X (𝟙 K) = 𝟙 (bracket X K) := by cat_disch
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+@[simp]
+lemma bracketMap_comp (f : K ⟶ L) (g : L ⟶ M) :
+    bracketMap X (f ≫ g) = bracketMap X g ≫ bracketMap X f := by cat_disch
+
+/-- The bracket `X[-]` as a functor on the subcategory where the brackets exist. -/
+@[simps]
+noncomputable def bracketFunctor : (hasBracket.{w} X).FullSubcategoryᵒᵖ ⥤ A where
+  obj K := bracket X K.unop.obj
+  map f := bracketMap X f.unop.hom
+
+attribute [local instance] preservesLimitsOfShape_op
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+/-- `X[-]` sends colimits of copresheaves to limits: `X[colimⱼ Kⱼ] ≅ limⱼ X[Kⱼ]`.
+Here the colimits are taken in `C ⥤ Type w`. -/
+noncomputable
+def isLimitMapConeBracketFunctor {J : Type*} [Category* J] [HasColimitsOfShape J (Type w)]
+    (D : J ⥤ (hasBracket.{w} X).FullSubcategory)
+    (c : Cocone D) (hc : IsColimit ((hasBracket X).ι.mapCocone c)) :
+    IsLimit ((bracketFunctor X).mapCone c.op) := by
+  let c'' (s : Cone (D.op ⋙ bracketFunctor X)) (U : C) :
+      ((D ⋙ (hasBracket X).ι) ⋙ (evaluation C (Type w)).obj U).CoconeTypes :=
+    { pt := s.pt ⟶ X.obj U
+      ι j x := s.π.app (.op j) ≫ limit.π (bracketDiag X (D.obj j).obj) (Functor.elementsMk _ U x)
+      ι_naturality u := by
+        ext
+        simp [← dsimp% s.w u.op, CategoryOfElements.map] }
+  have hU (U : C) := (Types.isColimit_iff_coconeTypesIsColimit _).mp
+    ⟨isColimitOfPreserves ((evaluation _ _).obj U) hc⟩
+  let hom (s : Cone (D.op ⋙ bracketFunctor X)) (U : C) : c.pt.obj.obj U → (s.pt ⟶ X.obj U) :=
+    (hU U).desc (c'' s U)
+  have hom_fac (s : Cone (D.op ⋙ bracketFunctor X)) (U : C) (j : J) (x) :
+      hom s U (((c.ι.app j).hom.app U) x) =
+        s.π.app (.op j) ≫ limit.π (bracketDiag X (D.obj j).obj) (Functor.elementsMk _ U x) :=
+    (hU U).fac_apply (c'' s U) j x
+  have hom_comp (s : Cone (D.op ⋙ bracketFunctor X)) (U V : C) (f : U ⟶ V) :
+      hom s V ∘ c.pt.obj.map f = (· ≫ X.map f) ∘ hom s U := by
+    refine (hU U).funext fun j ↦ ?_
+    ext x
+    dsimp
+    rw [dsimp% hom_fac, ← ConcreteCategory.comp_apply, ← dsimp% (c.ι.app j).hom.naturality f]
+    dsimp
+    rw [dsimp% hom_fac]
+    have := limit.w (bracketDiag X (D.obj j).obj)
+      (CategoryOfElements.homMk (Functor.elementsMk _ U x)
+        (Functor.elementsMk _ V ((D.obj j).obj.map f x)) f rfl)
+    simp [dsimp% this]
+  refine ⟨fun s ↦ ?_, ?_, ?_⟩
+  · refine limit.lift (bracketDiag X c.pt.obj)
+      { pt := s.pt
+        π.app U := hom s U.1 U.2
+        π.naturality := ?_ }
+    · intro A B f
+      obtain ⟨U, x, rfl⟩ := Functor.elementsMk_surjective A
+      obtain ⟨V, y, rfl⟩ := Functor.elementsMk_surjective B
+      obtain ⟨f, hf, rfl⟩ := CategoryOfElements.homMk_surjective f
+      simp [← dsimp% congr($(hom_comp s _ _ f) x), dsimp% hf]
+  · intro s j
+    apply limit.hom_ext
+    intro A
+    obtain ⟨U, x, rfl⟩ := Functor.elementsMk_surjective A
+    simp [dsimp% hom_fac]
+  · intro s m hm
+    apply limit.hom_ext (F := bracketDiag X c.pt.obj)
+    intro A
+    obtain ⟨U, x, rfl⟩ := Functor.elementsMk_surjective A
+    obtain ⟨j, a, rfl⟩ := (hU U).ι_jointly_surjective x
+    simp [dsimp% hom_fac, ← hm, CategoryOfElements.map]
+
+end CategoryTheory.Functor


### PR DESCRIPTION
Given a functor `X : C ⥤ A` and a copresheaf `K : C ⥤ Type w`, we define the object
`X[K] : A`, which is the limit over the diagram `CategoryOfElements.π K ⋙ X : ∫ K ⥤ A`.

This is used to define a bracket operation of a (semi)simplicial object with a (semi)simplicial
set, which appears in the definition of a hypercover.

Co-authored by: Robin Carlier <robin.carlier@ens-lyon.fr>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I have no idea how this construction is usually called, so I welcome any name suggestions.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
