### PR TITLE
[Merged by Bors] - feat(Analysis/InnerProductSpace): bounded point evaluation in an RKHS

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
@@ -147,7 +147,7 @@ lemma norm_kernel_sq_le (x y) : ‖kernel H x y‖ ^ 2 ≤ ‖kernel H x x‖ * 
 variable {H} in
 /-- The evaluation of an element `f` of a reproducing kernel Hilbert space at a point `x` is
 bounded by `‖f‖` times the square root of the kernel diagonal `‖kernel H x x‖` at `x`. -/
-lemma norm_eval_le (f : H) (x : X) : ‖f x‖ ≤ ‖f‖ * √‖kernel H x x‖ := by
+lemma norm_apply_le (f : H) (x : X) : ‖f x‖ ≤ ‖f‖ * √‖kernel H x x‖ := by
   grw [← adjoint_kerFun, le_opNorm, norm_map, norm_kerFun_eq_sqrt_norm_kernel, mul_comm]
 
 /-- The span of the kernel functions is dense. -/

--- a/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
@@ -138,6 +138,22 @@ lemma norm_kernel_le (x y) : ‖kernel H x y‖ ≤ √‖kernel H x x‖ * √�
 lemma norm_kernel_sq_le (x y) : ‖kernel H x y‖ ^ 2 ≤ ‖kernel H x x‖ * ‖kernel H y y‖ := by
   grw [norm_kernel_le]; simp [mul_pow]
 
+variable {H} in
+/-- Bounded point evaluation: every element of a reproducing kernel Hilbert space is pointwise
+bounded by its norm times the square root of the diagonal of the kernel. -/
+lemma norm_eval_le (f : H) (x : X) : ‖f x‖ ≤ ‖f‖ * √‖kernel H x x‖ := by
+  have hk : ‖kerFun H x‖ = √‖kernel H x x‖ := norm_kerFun_eq_sqrt_norm_kernel H x
+  have hsq : ‖f x‖ ^ 2 ≤ ‖f‖ * ‖kerFun H x‖ * ‖f x‖ := by
+    have e : ⟪f x, f x⟫_𝕜 = ⟪f, kerFun H x (f x)⟫_𝕜 := (inner_kerFun x (f x) f).symm
+    calc ‖f x‖ ^ 2 = RCLike.re ⟪f x, f x⟫_𝕜 := by rw [inner_self_eq_norm_sq]
+      _ = RCLike.re ⟪f, kerFun H x (f x)⟫_𝕜 := by rw [e]
+      _ ≤ ‖⟪f, kerFun H x (f x)⟫_𝕜‖ := RCLike.re_le_norm _
+      _ ≤ ‖f‖ * ‖kerFun H x (f x)‖ := norm_inner_le_norm _ _
+      _ ≤ ‖f‖ * (‖kerFun H x‖ * ‖f x‖) := by gcongr; exact (kerFun H x).le_opNorm (f x)
+      _ = ‖f‖ * ‖kerFun H x‖ * ‖f x‖ := by ring
+  rw [← hk]
+  nlinarith [norm_nonneg (f x), mul_nonneg (norm_nonneg f) (norm_nonneg (kerFun H x)), hsq]
+
 /-- The span of the kernel functions is dense. -/
 theorem kerFun_dense : topologicalClosure (span 𝕜 {kerFun H x v | (x) (v)}) = ⊤ := by
   refine (orthogonal_eq_bot_iff.mp ((Submodule.eq_bot_iff _).mpr fun f fin ↦ DFunLike.ext f 0 ?_))

--- a/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
@@ -109,6 +109,12 @@ lemma kernel_apply (x y : X) : kernel H x y = (kerFun H x).adjoint ∘L kerFun H
   simp [kerFun, kernel]
 
 variable {H} in
+/-- Point evaluation `f ↦ f x` is the adjoint of the kernel function `kerFun H x`. -/
+@[simp]
+lemma adjoint_kerFun (x : X) (f : H) : (kerFun H x).adjoint f = f x := by
+  rw [kerFun, ContinuousLinearMap.adjoint_adjoint]; rfl
+
+variable {H} in
 /-- The "reproducing" property of the kernel functions, left version. -/
 @[simp]
 lemma kerFun_inner (x : X) (v : V) (f : H) : ⟪kerFun H x v, f⟫_𝕜 = ⟪v, f x⟫_𝕜 := by
@@ -142,9 +148,7 @@ variable {H} in
 /-- The evaluation of an element `f` of a reproducing kernel Hilbert space at a point `x` is
 bounded by `‖f‖` times the square root of the kernel diagonal `‖kernel H x x‖` at `x`. -/
 lemma norm_eval_le (f : H) (x : X) : ‖f x‖ ≤ ‖f‖ * √‖kernel H x x‖ := by
-  have hfx : f x = (kerFun H x).adjoint f := by
-    rw [kerFun, ContinuousLinearMap.adjoint_adjoint]; rfl
-  rw [hfx, ← norm_kerFun_eq_sqrt_norm_kernel, mul_comm]
+  rw [← adjoint_kerFun x f, ← norm_kerFun_eq_sqrt_norm_kernel, mul_comm]
   grw [(kerFun H x).adjoint.le_opNorm f, ContinuousLinearMap.adjoint.norm_map (kerFun H x)]
 
 /-- The span of the kernel functions is dense. -/

--- a/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
@@ -139,20 +139,13 @@ lemma norm_kernel_sq_le (x y) : ‖kernel H x y‖ ^ 2 ≤ ‖kernel H x x‖ * 
   grw [norm_kernel_le]; simp [mul_pow]
 
 variable {H} in
-/-- Bounded point evaluation: every element of a reproducing kernel Hilbert space is pointwise
-bounded by its norm times the square root of the diagonal of the kernel. -/
+/-- The evaluation of an element `f` of a reproducing kernel Hilbert space at a point `x` is
+bounded by `‖f‖` times the square root of the kernel diagonal `‖kernel H x x‖` at `x`. -/
 lemma norm_eval_le (f : H) (x : X) : ‖f x‖ ≤ ‖f‖ * √‖kernel H x x‖ := by
-  have hk : ‖kerFun H x‖ = √‖kernel H x x‖ := norm_kerFun_eq_sqrt_norm_kernel H x
-  have hsq : ‖f x‖ ^ 2 ≤ ‖f‖ * ‖kerFun H x‖ * ‖f x‖ := by
-    have e : ⟪f x, f x⟫_𝕜 = ⟪f, kerFun H x (f x)⟫_𝕜 := (inner_kerFun x (f x) f).symm
-    calc ‖f x‖ ^ 2 = RCLike.re ⟪f x, f x⟫_𝕜 := by rw [inner_self_eq_norm_sq]
-      _ = RCLike.re ⟪f, kerFun H x (f x)⟫_𝕜 := by rw [e]
-      _ ≤ ‖⟪f, kerFun H x (f x)⟫_𝕜‖ := RCLike.re_le_norm _
-      _ ≤ ‖f‖ * ‖kerFun H x (f x)‖ := norm_inner_le_norm _ _
-      _ ≤ ‖f‖ * (‖kerFun H x‖ * ‖f x‖) := by gcongr; exact (kerFun H x).le_opNorm (f x)
-      _ = ‖f‖ * ‖kerFun H x‖ * ‖f x‖ := by ring
-  rw [← hk]
-  nlinarith [norm_nonneg (f x), mul_nonneg (norm_nonneg f) (norm_nonneg (kerFun H x)), hsq]
+  have hfx : f x = (kerFun H x).adjoint f := by
+    rw [kerFun, ContinuousLinearMap.adjoint_adjoint]; rfl
+  rw [hfx, ← norm_kerFun_eq_sqrt_norm_kernel, mul_comm]
+  grw [(kerFun H x).adjoint.le_opNorm f, ContinuousLinearMap.adjoint.norm_map (kerFun H x)]
 
 /-- The span of the kernel functions is dense. -/
 theorem kerFun_dense : topologicalClosure (span 𝕜 {kerFun H x v | (x) (v)}) = ⊤ := by

--- a/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
@@ -112,7 +112,7 @@ variable {H} in
 /-- Point evaluation `f ↦ f x` is the adjoint of the kernel function `kerFun H x`. -/
 @[simp]
 lemma adjoint_kerFun (x : X) (f : H) : (kerFun H x).adjoint f = f x := by
-  rw [kerFun, ContinuousLinearMap.adjoint_adjoint]; rfl
+  simp [kerFun]
 
 variable {H} in
 /-- The "reproducing" property of the kernel functions, left version. -/
@@ -148,8 +148,7 @@ variable {H} in
 /-- The evaluation of an element `f` of a reproducing kernel Hilbert space at a point `x` is
 bounded by `‖f‖` times the square root of the kernel diagonal `‖kernel H x x‖` at `x`. -/
 lemma norm_eval_le (f : H) (x : X) : ‖f x‖ ≤ ‖f‖ * √‖kernel H x x‖ := by
-  rw [← adjoint_kerFun x f, ← norm_kerFun_eq_sqrt_norm_kernel, mul_comm]
-  grw [(kerFun H x).adjoint.le_opNorm f, ContinuousLinearMap.adjoint.norm_map (kerFun H x)]
+  grw [← adjoint_kerFun, le_opNorm, norm_map, norm_kerFun_eq_sqrt_norm_kernel, mul_comm]
 
 /-- The span of the kernel functions is dense. -/
 theorem kerFun_dense : topologicalClosure (span 𝕜 {kerFun H x v | (x) (v)}) = ⊤ := by


### PR DESCRIPTION
Adds `RKHS.norm_eval_le`, the element-wise bound `‖f x‖ ≤ ‖f‖ * √‖kernel H x x‖` on point evaluations in a reproducing kernel Hilbert space, complementing the existing matrix-level bound `norm_kernel_le`. It is stated directly on `f x` (like `continuous_eval`), so it does not depend on the explicit `eval` from #37666.

Discussed and named on Zulip: [#mathlib4 > RKHS bounded point evaluation](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/RKHS.20bounded.20point.20evaluation) (thanks to Hampus Nyberg, Amlal El Mahrouss, Tjeerd Jan Heeringa, Yaël Dillies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------

**AI disclosure.** I used Claude Code (Claude Opus 4.8) to draft and iterate the Lean proof against the current mathlib API. I work in kernel methods / RKHS, and have reviewed the statement and proof, understand the design choices, and can justify them to reviewers; the statement and naming were coordinated with maintainers on the Zulip thread above.
