### PR TITLE
[Merged by Bors] - feat: add normalization simproc for Bird's determinant algorithm

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5091,6 +5091,7 @@ public import Mathlib.LinearAlgebra.Matrix.Circulant
 public import Mathlib.LinearAlgebra.Matrix.ConjTranspose
 public import Mathlib.LinearAlgebra.Matrix.Defs
 public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+public import Mathlib.LinearAlgebra.Matrix.Determinant.Bird
 public import Mathlib.LinearAlgebra.Matrix.Determinant.Misc
 public import Mathlib.LinearAlgebra.Matrix.Determinant.TotallyUnimodular
 public import Mathlib.LinearAlgebra.Matrix.Diagonal

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7272,6 +7272,9 @@ public import Mathlib.Tactic.DeriveCountable
 public import Mathlib.Tactic.DeriveEncodable
 public import Mathlib.Tactic.DeriveFintype
 public import Mathlib.Tactic.DeriveTraversable
+public import Mathlib.Tactic.Determinant.Bird
+public import Mathlib.Tactic.Determinant.Bird.Cert
+public import Mathlib.Tactic.Determinant.Bird.Meta
 public import Mathlib.Tactic.ENatToNat
 public import Mathlib.Tactic.Eqns
 public import Mathlib.Tactic.ErwQuestion

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
@@ -45,11 +45,11 @@ stored in `A` in row-major order.
 
 The function does not check the matrix index bounds.
 -/
-def get (n : Nat) (A : Array R) (i j : Nat) : R :=
+def get (n : ℕ) (A : Array R) (i j : ℕ) : R :=
   A.getD (i * n + j) 0
 
 /-- Sum `f lo + ... + f (n - 1)`. Returns zero when `n <= lo`. -/
-def sumFrom (n lo : Nat) (f : Nat → R) : R :=
+def sumFrom (n lo : ℕ) (f : ℕ → R) : R :=
   if lo < n then f lo + sumFrom n (lo + 1) f else 0
 
 /--
@@ -83,7 +83,7 @@ F_{t+1} i j =
   + ∑ k from i+1 to n-1, (F_t i k) * (A k j)
 ```
 -/
-def iter (n : Nat) (A : Array R) (t : Nat) (F : Nat → Nat → R) : Nat → Nat → R :=
+def iter (n : ℕ) (A : Array R) (t : ℕ) (F : ℕ → ℕ → R) : ℕ → ℕ → R :=
   match t with
   | 0 => F
   | t + 1 => fun i j =>
@@ -94,34 +94,34 @@ def iter (n : Nat) (A : Array R) (t : Nat) (F : Nat → Nat → R) : Nat → Nat
 `birdDet n A` computes the determinant of the `n × n` matrix whose entries are
 stored in `A` in row-major order.
 -/
-def birdDet (n : Nat) (A : Array R) : R :=
+def birdDet (n : ℕ) (A : Array R) : R :=
   match n with
   | 0 => 1
   | k + 1 => (-1 : R) ^ k * iter n A k (get n A) 0 0
 
 /- Unfolding lemmas -/
 
-theorem sumFrom_step (n lo : Nat) (f : Nat → R) (h : lo < n) :
+theorem sumFrom_step (n lo : ℕ) (f : ℕ → R) (h : lo < n) :
     sumFrom n lo f = f lo + sumFrom n (lo + 1) f := by
       rw [sumFrom]
       simp [h]
 
-theorem sumFrom_stop (n lo : Nat) (f : Nat → R) (h : ¬ lo < n) :
+theorem sumFrom_stop (n lo : ℕ) (f : ℕ → R) (h : ¬ lo < n) :
     sumFrom n lo f = 0 := by
       rw [sumFrom]
       simp [h]
 
-theorem iter_zero (n : Nat) (A : Array R) (F : Nat → Nat → R) (i j : Nat) :
+theorem iter_zero (n : ℕ) (A : Array R) (F : ℕ → ℕ → R) (i j : ℕ) :
     iter n A 0 F i j = F i j := rfl
 
-theorem iter_succ (n : Nat) (A : Array R) (t : Nat) (F : Nat → Nat → R) (i j : Nat) :
+theorem iter_succ (n : ℕ) (A : Array R) (t : ℕ) (F : ℕ → ℕ → R) (i j : ℕ) :
     iter n A (t + 1) F i j =
     -(sumFrom n (i + 1) fun k => iter n A t F k k) * get n A i j
     + sumFrom n (i + 1) fun k => iter n A t F i k * get n A k j := rfl
 
 theorem birdDet_zero (A : Array R) : birdDet 0 A = 1 := rfl
 
-theorem birdDet_eq (n k : Nat) (A : Array R) (hn : n = k + 1) :
+theorem birdDet_eq (n k : ℕ) (A : Array R) (hn : n = k + 1) :
     birdDet n A = (-1 : R) ^ k * iter n A k (get n A) 0 0 := by
       subst hn
       rfl

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
@@ -37,9 +37,7 @@ The lemmas in this file are unfolding equations.
 
 namespace BirdDet
 
-variable
-  {R : Type*}
-  [CommRing R]
+variable {R : Type*} [CommRing R]
 
 /--
 `get n A i j` returns the (i, j)th entry of the `n × n` matrix whose entries are

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 Paul Cadman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Cadman
+-/
+module
+
+public import Mathlib.Algebra.Ring.Defs
+
+/-!
+
+# A division-free determinant algorithm
+
+This file defines `birdDet`, an implementation of an division-free algorithm for
+computing determinants.
+
+This determinant algorithm comes from:
+
+Title:  A simple division-free algorithm for computing determinants.
+Author: Richard S. Bird
+URL:    https://doi.org/10.1016/j.ipl.2011.08.006
+
+## Main definitions
+
+- `BirdDet.birdDet`: The entrypoint for the determinant calculation.
+- `BirdDet.get`: matrix entry lookup.
+- `BirdDet.sumFrom`: The sum `f lo + ... + f (n - 1)`.
+- `BirdDet.iter`: The internal scalar recurrence for Bird's algorithm.
+
+## Main lemmas
+
+The lemmas in this file are unfolding equations.
+
+-/
+
+@[expose] public section
+
+namespace BirdDet
+
+variable
+  {R : Type*}
+  [CommRing R]
+
+/--
+`get n A i j` returns the (i, j)th entry of the `n × n` matrix whose entries are
+stored in `A` in row-major order.
+
+The function does not check the matrix index bounds.
+-/
+def get (n : Nat) (A : Array R) (i j : Nat) : R :=
+  A.getD (i * n + j) 0
+
+/-- Sum `f lo + ... + f (n - 1)`. Returns zero when `n <= lo`. -/
+def sumFrom (n lo : Nat) (f : Nat → R) : R :=
+  if lo < n then f lo + sumFrom n (lo + 1) f else 0
+
+/--
+# Scalar formula for one recurrence step.
+
+Bird's paper defines a matrix recursion for an `n × n` matrix `A`:
+
+```
+F_0 = A
+F_{t+1} = μ(F_t) * A
+```
+
+where `μ(F_t)` is obtained from `F_t` by replacing each diagonal entry
+`F_t k k` with the negative sum of the diagonal entries below it, setting the
+entries in the lower triangular part to 0, and leaving all other entries
+unchanged:
+
+```
+μ(F_t) =
+  0                                   if i >= j
+  - ∑ k from i+1 to n-1, F_t k k      if i = j
+  F_t i j                             if i < j
+```
+
+If we write out the entry-wise matrix multiplication `F_{t+1} i j = (μ(F_t) * A) i j`
+we obtain:
+
+```
+F_{t+1} i j =
+  - (∑ k from i+1 to n-1, F_t k k) * (A i j)
+  + ∑ k from i+1 to n-1, (F_t i k) * (A k j)
+```
+-/
+def iter (n : Nat) (A : Array R) (t : Nat) (F : Nat → Nat → R) : Nat → Nat → R :=
+  match t with
+  | 0 => F
+  | t + 1 => fun i j =>
+    -(sumFrom n (i + 1) fun k => iter n A t F k k) * get n A i j
+    + sumFrom n (i + 1) fun k => iter n A t F i k * get n A k j
+
+/--
+`birdDet n A` computes the determinant of the `n × n` matrix whose entries are
+stored in `A` in row-major order.
+-/
+def birdDet (n : Nat) (A : Array R) : R :=
+  match n with
+  | 0 => 1
+  | k + 1 => (-1 : R) ^ k * iter n A k (get n A) 0 0
+
+/- Unfolding lemmas -/
+
+theorem sumFrom_step (n lo : Nat) (f : Nat → R) (h : lo < n) :
+    sumFrom n lo f = f lo + sumFrom n (lo + 1) f := by
+      rw [sumFrom]
+      simp [h]
+
+theorem sumFrom_stop (n lo : Nat) (f : Nat → R) (h : ¬ lo < n) :
+    sumFrom n lo f = 0 := by
+      rw [sumFrom]
+      simp [h]
+
+theorem iter_zero (n : Nat) (A : Array R) (F : Nat → Nat → R) (i j : Nat) :
+    iter n A 0 F i j = F i j := rfl
+
+theorem iter_succ (n : Nat) (A : Array R) (t : Nat) (F : Nat → Nat → R) (i j : Nat) :
+    iter n A (t + 1) F i j =
+    -(sumFrom n (i + 1) fun k => iter n A t F k k) * get n A i j
+    + sumFrom n (i + 1) fun k => iter n A t F i k * get n A k j := rfl
+
+theorem birdDet_zero (A : Array R) : birdDet 0 A = 1 := rfl
+
+theorem birdDet_eq (n k : Nat) (A : Array R) (hn : n = k + 1) :
+    birdDet n A = (-1 : R) ^ k * iter n A k (get n A) 0 0 := by
+      subst hn
+      rfl
+
+end BirdDet
+
+end

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
@@ -103,13 +103,13 @@ stored in `A` in row-major order.
 
 theorem sumFrom_step (n lo : ℕ) (f : ℕ → R) (h : lo < n) :
     BirdDet.sumFrom n lo f = f lo + BirdDet.sumFrom n (lo + 1) f := by
-      rw [BirdDet.sumFrom]
-      simp [h]
+  rw [BirdDet.sumFrom]
+  simp [h]
 
 theorem sumFrom_stop (n lo : ℕ) (f : ℕ → R) (h : ¬ lo < n) :
     BirdDet.sumFrom n lo f = 0 := by
-      rw [BirdDet.sumFrom]
-      simp [h]
+  rw [BirdDet.sumFrom]
+  simp [h]
 
 theorem iter_zero (n : ℕ) (A : Array R) (F : ℕ → ℕ → R) (i j : ℕ) :
     BirdDet.iter n A 0 F i j = F i j := rfl
@@ -123,8 +123,8 @@ theorem birdDet_zero (A : Array R) : birdDet 0 A = 1 := rfl
 
 theorem birdDet_eq (n k : ℕ) (A : Array R) (hn : n = k + 1) :
     birdDet n A = (-1 : R) ^ k * BirdDet.iter n A k (BirdDet.get n A) 0 0 := by
-      subst hn
-      rfl
+  subst hn
+  rfl
 
 end BirdDet
 

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Ring.Defs
 # A division-free determinant algorithm
 
 This file defines `birdDet`, an implementation of an division-free algorithm for
-computing determinants.
+computing determinants. The algorithm runs in O(n^4) for an n-by-n matrix.
 
 This determinant algorithm comes from:
 

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Bird.lean
@@ -33,7 +33,7 @@ The lemmas in this file are unfolding equations.
 
 -/
 
-@[expose] public section
+public section
 
 namespace BirdDet
 
@@ -45,12 +45,12 @@ stored in `A` in row-major order.
 
 The function does not check the matrix index bounds.
 -/
-def get (n : ℕ) (A : Array R) (i j : ℕ) : R :=
+@[expose] protected def get (n : ℕ) (A : Array R) (i j : ℕ) : R :=
   A.getD (i * n + j) 0
 
 /-- Sum `f lo + ... + f (n - 1)`. Returns zero when `n <= lo`. -/
-def sumFrom (n lo : ℕ) (f : ℕ → R) : R :=
-  if lo < n then f lo + sumFrom n (lo + 1) f else 0
+@[expose] protected def sumFrom (n lo : ℕ) (f : ℕ → R) : R :=
+  if lo < n then f lo + BirdDet.sumFrom n (lo + 1) f else 0
 
 /--
 # Scalar formula for one recurrence step.
@@ -83,46 +83,46 @@ F_{t+1} i j =
   + ∑ k from i+1 to n-1, (F_t i k) * (A k j)
 ```
 -/
-def iter (n : ℕ) (A : Array R) (t : ℕ) (F : ℕ → ℕ → R) : ℕ → ℕ → R :=
+@[expose] protected def iter (n : ℕ) (A : Array R) (t : ℕ) (F : ℕ → ℕ → R) : ℕ → ℕ → R :=
   match t with
   | 0 => F
   | t + 1 => fun i j =>
-    -(sumFrom n (i + 1) fun k => iter n A t F k k) * get n A i j
-    + sumFrom n (i + 1) fun k => iter n A t F i k * get n A k j
+    -(BirdDet.sumFrom n (i + 1) fun k => BirdDet.iter n A t F k k) * BirdDet.get n A i j
+    + BirdDet.sumFrom n (i + 1) fun k => BirdDet.iter n A t F i k * BirdDet.get n A k j
 
 /--
 `birdDet n A` computes the determinant of the `n × n` matrix whose entries are
 stored in `A` in row-major order.
 -/
-def birdDet (n : ℕ) (A : Array R) : R :=
+@[expose] def birdDet (n : ℕ) (A : Array R) : R :=
   match n with
   | 0 => 1
-  | k + 1 => (-1 : R) ^ k * iter n A k (get n A) 0 0
+  | k + 1 => (-1 : R) ^ k * BirdDet.iter n A k (BirdDet.get n A) 0 0
 
 /- Unfolding lemmas -/
 
 theorem sumFrom_step (n lo : ℕ) (f : ℕ → R) (h : lo < n) :
-    sumFrom n lo f = f lo + sumFrom n (lo + 1) f := by
-      rw [sumFrom]
+    BirdDet.sumFrom n lo f = f lo + BirdDet.sumFrom n (lo + 1) f := by
+      rw [BirdDet.sumFrom]
       simp [h]
 
 theorem sumFrom_stop (n lo : ℕ) (f : ℕ → R) (h : ¬ lo < n) :
-    sumFrom n lo f = 0 := by
-      rw [sumFrom]
+    BirdDet.sumFrom n lo f = 0 := by
+      rw [BirdDet.sumFrom]
       simp [h]
 
 theorem iter_zero (n : ℕ) (A : Array R) (F : ℕ → ℕ → R) (i j : ℕ) :
-    iter n A 0 F i j = F i j := rfl
+    BirdDet.iter n A 0 F i j = F i j := rfl
 
 theorem iter_succ (n : ℕ) (A : Array R) (t : ℕ) (F : ℕ → ℕ → R) (i j : ℕ) :
-    iter n A (t + 1) F i j =
-    -(sumFrom n (i + 1) fun k => iter n A t F k k) * get n A i j
-    + sumFrom n (i + 1) fun k => iter n A t F i k * get n A k j := rfl
+    BirdDet.iter n A (t + 1) F i j =
+    -(BirdDet.sumFrom n (i + 1) fun k => BirdDet.iter n A t F k k) * BirdDet.get n A i j
+    + BirdDet.sumFrom n (i + 1) fun k => BirdDet.iter n A t F i k * BirdDet.get n A k j := rfl
 
 theorem birdDet_zero (A : Array R) : birdDet 0 A = 1 := rfl
 
 theorem birdDet_eq (n k : ℕ) (A : Array R) (hn : n = k + 1) :
-    birdDet n A = (-1 : R) ^ k * iter n A k (get n A) 0 0 := by
+    birdDet n A = (-1 : R) ^ k * BirdDet.iter n A k (BirdDet.get n A) 0 0 := by
       subst hn
       rfl
 

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -99,6 +99,9 @@ public import Mathlib.Tactic.DeriveCountable
 public import Mathlib.Tactic.DeriveEncodable
 public import Mathlib.Tactic.DeriveFintype
 public import Mathlib.Tactic.DeriveTraversable
+public import Mathlib.Tactic.Determinant.Bird
+public import Mathlib.Tactic.Determinant.Bird.Cert
+public import Mathlib.Tactic.Determinant.Bird.Meta
 public import Mathlib.Tactic.ENatToNat
 public import Mathlib.Tactic.Eqns
 public import Mathlib.Tactic.ErwQuestion

--- a/Mathlib/Tactic/Determinant/Bird.lean
+++ b/Mathlib/Tactic/Determinant/Bird.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 Paul Cadman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Cadman
+-/
+module
+
+public import Mathlib.Tactic.Determinant.Bird.Cert
+
+/-!
+# `norm_det` simproc and `eval_det` tactic
+
+A tactic for normalizing matrix determinants.
+-/
+
+public meta section
+
+open Lean Meta Elab Tactic Simp
+open Mathlib.Tactic.Determinant
+
+/-- reify a `BirdDet` call and normalize it using the certificate-chain evaluator -/
+def normalizeBirdDet (e : Expr) : MetaM Simp.Result := do
+  let info ← reifyBirdDet e
+  let ctx := Ctx.ofBirdDetInfo info
+  let detNorm ← certBirdDet.run' {} |>.run ctx |>.run .reducible
+  Mathlib.Tactic.RingNF.cleanup {} {expr := detNorm.norm, proof? := some detNorm.proof}
+
+/-- Normalize a literal `birdDet` call using the certificate-chain evaluator. -/
+simproc_decl norm_det (BirdDet.birdDet _ _) := fun e => do
+  return .done (← normalizeBirdDet e)
+
+/-- Normalize `birdDet` calls in the target using the certificate-chain simproc. -/
+macro (name := evalDet) "eval_det" : tactic => `(tactic| simp only [norm_det])
+
+end

--- a/Mathlib/Tactic/Determinant/Bird.lean
+++ b/Mathlib/Tactic/Determinant/Bird.lean
@@ -20,9 +20,8 @@ open Mathlib.Tactic.Determinant
 
 /-- reify a `BirdDet` call and normalize it using the certificate-chain evaluator -/
 def normalizeBirdDet (e : Expr) : MetaM Simp.Result := do
-  let info ← reifyBirdDet e
-  let ctx := Ctx.ofBirdDetInfo info
-  let detNorm ← certBirdDet.run' {} |>.run ctx |>.run .reducible
+  let ⟨rα, ctx⟩ ← reifyBirdDet e
+  let detNorm ← certBirdDet (rα := rα) |>.run' {} |>.run ctx |>.run .reducible
   Mathlib.Tactic.RingNF.cleanup {} {expr := detNorm.norm, proof? := some detNorm.proof}
 
 /-- Normalize a literal `birdDet` call using the certificate-chain evaluator. -/

--- a/Mathlib/Tactic/Determinant/Bird/Cert.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Cert.lean
@@ -328,7 +328,7 @@ partial def certIter (t i j : Nat) : CertM rα (Cert rα) := do
       let negDiagSum := q(-$(ctx.sumFrom (i + 1) diagSummand))
       let entryCert ← certEntry i j
       let diagProdCert ←
-        -- If `get n A i j= 0` then we can skip computation of
+        -- If `get n A i j = 0` then we can skip computation of
         --  `-(sumFrom n (i + 1) fun k => F_t k k)`
         if entryCert.isZero then
           zeroProdCert negDiagSum entryCert

--- a/Mathlib/Tactic/Determinant/Bird/Cert.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Cert.lean
@@ -1,0 +1,440 @@
+/-
+Copyright (c) 2026 Paul Cadman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Cadman
+-/
+module
+
+public meta import Mathlib.Tactic.Determinant.Bird.Meta
+public meta import Mathlib.Tactic.Ring
+
+/-!
+
+# Certificate-chain evaluator for `BirdDet.birdDet`
+
+This file contains an evaulator that computes the ring tactic normal form of
+`Mathlib.LinearAlgebra.Matrix.Determinant.Bird.birdDet` via iteratively
+unfolding its definition, using the ring tactic for ring operations, and caching
+intermediate certificates.
+
+The structure `Cert rα` carries the proof certificate and the evaluator builds
+larger certificates as `birdDet` is unfolded.
+
+The entrypoint of the evaluator `certBirdDet` follows the two branches (n=0,
+n=k+1) of the `birdDet` function:
+
+```
+certBirdDet (birdDet n A)
+  n = 0:
+    birdDet n A
+      = 1 -- via BirdDet.birdDet_zero
+      = ring normal form of 1 -- via certEval
+  n = k + 1:
+    birdDet n A
+      = (-1)^k * iter n A k (get n A) 0 0 -- via BirdDet.birdDet_eq
+      = ring normal form of the product -- certMul (certBirdSign k) (certIter k 0 0)
+```
+
+The `iter n A k (get n A) i j` function branches on k, (k=0, k=t+1) and
+therefore the `certIter` function has two branches:
+
+```
+certIter k i j
+  k = 0:
+    iter n A 0 F i j = F i j -- via BirdDet.iter_zero
+                     = ring normal form of A[i][j] -- via certEntry i j
+  k = t + 1:
+    iter n A (t + 1) F i j
+      = -(sumFrom n (i + 1) fun k => iter n A t F k k) * get n A i j
+          + sumFrom n (i + 1) fun k => iter n A t F i k * get n A k j
+        -- via BirdDet.iter_succ
+      = normal form of the first summand + normal form of the second summand
+        -- via certAdd
+                 (certMul (certNeg (certDiag t (i + 1))) (certEntry i j))
+                 (certTail t i j (i + 1))
+```
+
+Then the `certDiag` and `certTail` functions certify the two kinds of `sumFrom`
+expressions.
+
+The evaulator also memoizes the `certIter`, `certDiag` and `certEntry` functions
+to improve performance.
+
+## Main definitions
+
+- `certEntry` certifies `BirdDet.get`.
+- `certSumFromStop` and `certSumFromStep` certifies `BirdDet.sumFrom_stop` and
+  `BirdDet.sumFrom_step`.
+- `certIter` certifies `BirdDet.iter_zero` and `BirdDet.iter_succ`.
+- `certBirdDet` certifies `BirdDet.birdDet_zero` and `BirdDet.birdDet_eq`.
+-/
+
+public meta section
+
+open Lean Meta Qq
+open Mathlib.Tactic.Ring
+
+variable
+  {u : Level}
+  {α : Q(Type u)}
+  {rα : Q(CommRing $α)}
+
+namespace Mathlib.Tactic.Determinant
+
+/-- Construct a `CommSemiring` instance expression from a `CommRing` instance expression -/
+abbrev commSemiringOfCommRing {u : Level} {α : Q(Type u)}
+    (rα : Q(CommRing $α)) : Q(CommSemiring $α) :=
+  q(CommRing.toCommSemiring (α := $α) (s := $rα))
+
+/-- The ring tactic normal-form value. -/
+abbrev CertVal {u : Level} {α : Q(Type u)}
+    (rα : Q(CommRing $α)) (e : Q($α)) :=
+  Common.ExSum RatCoeff (commSemiringOfCommRing rα) e
+
+/-- The ring tactic result carried by a certificate. -/
+abbrev CertResult {u : Level} {α : Q(Type u)}
+    (rα : Q(CommRing $α)) (subject : Q($α)) :=
+  Common.Result (CertVal rα) subject
+
+/-- The context for a certificate evaluation -/
+structure Ctx {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) where
+  /-- `Ring` evaluation cache for the scalar ring. -/
+  cα : Common.Cache (commSemiringOfCommRing rα)
+  /-- Proof-producing ring arithmetic. -/
+  rc : Common.RingCompute RatCoeff (commSemiringOfCommRing rα)
+  /-- The reified determinant payload. -/
+  info : BirdDetData rα
+
+namespace Ctx
+
+/-- Construct a `Ctx` from a `BirdDetInfo` -/
+def ofBirdDetInfo (info : BirdDetInfo) : Ctx info.rα :=
+  let sα := commSemiringOfCommRing info.rα
+  let cα : Common.Cache sα := { rα := some info.rα
+                                dsα := none
+                                czα := none }
+  { cα
+    rc := ringCompute cα
+    info := info.data }
+
+/-- Return an expression for the partially applied function `iter n A t (get n A)` -/
+def iterP (ctx : Ctx rα) (t : Nat) : Q(Nat → Nat → $α) :=
+  let dim : Q(Nat) := ctx.info.dimensionLit
+  let A : Q(Array $α) := ctx.info.arrayExpr
+  q(BirdDet.iter $dim $A $t (BirdDet.get $dim $A))
+
+/-- Return an expression `sumFrom n lo f` -/
+def sumFrom (ctx : Ctx rα) (lo : Nat) (f : Q(Nat → $α)) : Q($α) :=
+  let dim : Q(Nat) := ctx.info.dimensionLit
+  q(BirdDet.sumFrom $dim $lo $f)
+
+end Ctx
+
+/-- A certificate that proves `subject = result.norm` via `result.proof` -/
+structure Cert {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) where
+  /-- The expression being certified. -/
+  {subject : Q($α)}
+  /-- The result of evaluating `subject` using the ring tactic. -/
+  result : CertResult rα subject
+  /-- `true` when `norm` is zero, used as a hint to the evaluator. -/
+  isZero : Bool
+
+namespace Cert
+
+variable
+  {u : Level}
+  {α : Q(Type u)}
+  {rα : Q(CommRing $α)}
+
+/-- The ring tactic normal form of `c.subject` -/
+def norm (c : Cert rα) : Q($α) :=
+  c.result.expr
+
+/-- The internal ring tactic representation of `c.norm` -/
+def val (c : Cert rα) : CertVal rα c.norm :=
+  c.result.val
+
+/-- The proof that `c.subject = c.norm` -/
+def proof (c : Cert rα) : Q($c.subject = $c.norm) :=
+  c.result.proof
+
+/-- Prepend an equality to an existing normalized certificate.
+
+Given `c.proof : s.subject = c.norm` and `h : lhs = s.subject` return a
+certificate with `proof : lhs = c.norm`.
+-/
+def chainProof {lhs rhs : Q($α)} (c : Cert rα) (h : Q($lhs = $rhs)) : Cert rα :=
+  have : $rhs =Q $c.subject := ⟨⟩
+  let hProof : Q($lhs = $c.subject) := h
+  let proof : Q($lhs = $c.norm) := q(Eq.trans $hProof $c.proof)
+  {
+    result := {
+      expr := c.norm
+      val := c.val
+      proof
+    }
+    isZero := c.isZero
+  }
+
+end Cert
+
+/-- Cache certificates that are reused by the recursive Bird evaluator. -/
+structure CertCache {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) where
+  /-- Cache for entry certificates, keyed by matrix indices. -/
+  entryCache : Std.HashMap (Nat × Nat) (Cert rα) := {}
+  /-- Cache for `iter` certificates, keyed by recursion index and matrix indices. -/
+  iterCache : Std.HashMap (Nat × Nat × Nat) (Cert rα) := {}
+  /-- Cache for diagonal-tail certificates, keyed by recursion index and lower bound. -/
+  diagCache : Std.HashMap (Nat × Nat) (Cert rα) := {}
+
+/-- The monad used by the certificate-chaining evaluator -/
+abbrev CertM {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) :=
+  StateT (CertCache rα) (ReaderT (Ctx rα) AtomM)
+
+/-- Checks if `val` is zero according to the ring tactic -/
+def isZeroVal {e : Q($α)} (val : CertVal rα e) : Bool :=
+  match val with
+  | .zero => true
+  | .add .. => false
+
+/-- Construct a `Cert rα` from a ring tactic result -/
+def toCert {e : Q($α)} (res : Common.Result (CertVal rα) e) : Cert rα :=
+  { result := res
+    isZero := isZeroVal res.val }
+
+/-- Build a zero certificate from a proof `lhs = 0`. -/
+def zeroCertOfProof {lhs : Q($α)} (h : Q($lhs = 0)) : Cert rα :=
+  {
+    result := {
+      expr := q(0)
+      val := .zero
+      proof := h
+
+    }
+    isZero := true
+  }
+
+/-- If c.norm = 0, return a certificate with proof `x * c.subject = 0` without
+recursively certifying `x`. -/
+def zeroProdCert (x : Q($α)) (c : Cert rα) :
+    MetaM (Cert rα) := do
+  let zero : Q($α) := q(0)
+  have : $c.norm =Q $zero := ⟨⟩
+  let h : Q($x * $c.subject = $x * $zero) :=
+    q(congrArg (fun y => $x * y) $c.proof)
+  return zeroCertOfProof q(Eq.trans $h (mul_zero $x))
+
+/-- Certify `e = norm` by evaluating `e` with the `ring` normalizer. -/
+def certEval (e : Q($α)) : CertM rα (Cert rα) := do
+  let ctx ← read
+  let res ← Common.eval rcℕ ctx.rc ctx.cα e
+  return toCert res
+
+/-- Certify `a.subject + b.subject` from certificates for `a` and `b`. -/
+def certAdd (a b : Cert rα) : CertM rα (Cert rα) := do
+  let ctx ← read
+  let c ← toCert <$> Common.evalAdd ctx.rc rcℕ a.val b.val
+  let h : Q($a.subject + $b.subject = $a.norm + $b.norm) :=
+    q(congr (congrArg (fun x y => x + y) $a.proof) $b.proof)
+  return c.chainProof h
+
+/-- Certify `a.subject * b.subject` from certificates for `a` and `b`. -/
+def certMul (a b : Cert rα) : CertM rα (Cert rα) := do
+  let ctx ← read
+  let c ← toCert <$> Common.evalMul ctx.rc rcℕ a.val b.val
+  let h : Q($a.subject * $b.subject = $a.norm * $b.norm) :=
+    q(congr (congrArg (fun x y => x * y) $a.proof) $b.proof)
+  return c.chainProof h
+
+/-- Certify `-a.subject` from a certificate for `a`. -/
+def certNeg (a : Cert rα) : CertM rα (Cert rα) := do
+  let ctx ← read
+  let c ← toCert <$> Common.evalNeg ctx.rc rα a.val
+  let h : Q(-$a.subject = -$a.norm) :=
+    q(congrArg (fun x => -x) $a.proof)
+  return c.chainProof h
+
+/-- Certify the sign factor `(-1)^k` from `BirdDet.birdDet_eq`. -/
+def certBirdSign (k : Nat) : CertM rα (Cert rα) := do
+  certEval q((-1 : $α) ^ $k)
+
+/-- Certify one matrix entry lookup `BirdDet.get n A i j`. -/
+def certEntry (i j : Nat) : CertM rα (Cert rα) := do
+  if let some c := (← get).entryCache[(i, j)]? then
+    return c
+  let ctx ← read
+  let {dimension := dim, dimensionLit := dimLit, arrayExpr := A, arrayEntries, ..} := ctx.info
+  let lhs : Q($α) := q(BirdDet.get $dimLit $A $i $j)
+  -- The index of the matrix entry (i, j) in arrayEntries
+  let idx := i * dim + j
+  let entry := arrayEntries.getD idx q(0)
+  let ce ← certEval entry
+  have : $lhs =Q $entry := ⟨⟩
+  let h : Q($lhs = $entry) := q(rfl)
+  let cert := ce.chainProof h
+  modify fun s => {s with entryCache := s.entryCache.insert (i, j) cert}
+  return cert
+
+/-- Certify the stop branch of `BirdDet.sumFrom`.
+
+This corresponds to the `else 0` branch of:
+
+```
+sumFrom n lo f = if lo < n then f lo + sumFrom n (lo + 1) f else 0
+```
+-/
+def certSumFromStop (lo : Nat) (f : Q(Nat → $α)) : CertM rα (Cert rα) := do
+  let ctx ← read
+  have dimLit : Q(Nat) := ctx.info.dimensionLit
+  let hNot : Q(¬ $lo < $dimLit) ← mkDecideProofQ q(¬ $lo < $dimLit)
+  return zeroCertOfProof q(BirdDet.sumFrom_stop $dimLit $lo $f $hNot)
+
+/-- Certify the step branch of `BirdDet.sumFrom`.
+
+This corresponds to the `lo < n` branch of:
+
+```
+sumFrom n lo f = if lo < n then f lo + sumFrom n (lo + 1) f else 0
+```
+-/
+def certSumFromStep
+    (lo : Nat) (f : Q(Nat → $α))
+    (headCert tailCert : CertM rα (Cert rα)) : CertM rα (Cert rα) := do
+  let ctx ← read
+  have dim : Q(Nat) := ctx.info.dimensionLit
+  let hLt : Q($lo < $dim) ← mkDecideProofQ q($lo < $dim)
+  let sumCert ← certAdd (← headCert) (← tailCert)
+  return sumCert.chainProof q(BirdDet.sumFrom_step $dim $lo $f $hLt)
+
+mutual
+
+/-- Certify a `BirdDet.iter` call. -/
+partial def certIter (t i j : Nat) : CertM rα (Cert rα) := do
+  if let some c := (← get).iterCache[(t, i, j)]? then
+    return c
+  let ctx ← read
+  let {dimensionLit := dimLit, arrayExpr := A, ..} := ctx.info
+  let cert ← match t with
+    -- The t=0 branch of `BirdDet.iter`, unfold using `BirdDet.iter_zero`
+    | 0 => do
+      let ce ← certEntry i j
+      let h := q(BirdDet.iter_zero $dimLit $A (BirdDet.get $dimLit $A) $i $j)
+      pure (ce.chainProof h)
+    -- The t=t+1 branch of `BirdDet.iter`, unfold using `BirdDet.iter_succ`
+    | t' + 1 => do
+      -- First summand in `BirdDet.iter_succ`:
+      --   -(sumFrom n (i + 1) fun k => F_t k k) * get n A i j
+      let diagSummand := q(fun k => $(ctx.iterP t') k k)
+      let negDiagSum := q(-$(ctx.sumFrom (i + 1) diagSummand))
+      let entryCert ← certEntry i j
+      let diagProdCert ←
+        -- If `get n A i j= 0` then we can skip computation of
+        --  `-(sumFrom n (i + 1) fun k => F_t k k)`
+        if entryCert.isZero then
+          zeroProdCert negDiagSum entryCert
+        else do
+          let diagSumCert ← certDiag t' (i + 1)
+          let negDiagSumCert ← certNeg diagSumCert
+          certMul negDiagSumCert entryCert
+      -- Second summand in `BirdDet.iter_succ`:
+      --   sumFrom n (i + 1) fun k => F_t i k * get n A k j
+      let tailSumCert ← certTail t' i j (i + 1)
+      let rhsCert ← certAdd diagProdCert tailSumCert
+      let h := q(BirdDet.iter_succ $dimLit $A $t' (BirdDet.get $dimLit $A) $i $j)
+      pure (rhsCert.chainProof h)
+  modify fun s => {s with iterCache := s.iterCache.insert (t, i, j) cert}
+  return cert
+
+
+/-- Certify the diagonal tail sum from `BirdDet.iter_succ`:
+
+```
+sumFrom n (i + 1) fun k => iter n A t F k k)
+```
+-/
+partial def certDiag (t lo : Nat) : CertM rα (Cert rα) := do
+  if let some c := (← get).diagCache[(t, lo)]? then
+    return c
+  let ctx ← read
+  let diagonalSummand := q(fun k => $(ctx.iterP t) k k)
+  let cert ←
+    if lo < ctx.info.dimension
+    then do
+      let headCert := certIter t lo lo
+      let tailCert := certDiag t (lo + 1)
+      certSumFromStep
+        lo
+        diagonalSummand
+        headCert
+        tailCert
+    else
+      certSumFromStop lo diagonalSummand
+  modify fun s => {s with diagCache := s.diagCache.insert (t, lo) cert}
+  return cert
+
+/-- Certify the upper-tail sum from `BirdDet.iter_succ`:
+
+```
+sumFrom n (i + 1) fun k => iter n A t F i k * get n A k j
+```
+-/
+partial def certTail (t i j lo : Nat) : CertM rα (Cert rα) := do
+  let ctx ← read
+  let {dimensionLit := dimLit, arrayExpr := A, ..} := ctx.info
+  let tailSummand :=
+    q(fun k =>
+      $(ctx.iterP t) $i k *
+        BirdDet.get $dimLit $A k $j)
+  if lo < ctx.info.dimension
+  then do
+    -- headCert certifies `iter n A t F i lo * get n A lo j`
+    let headCert := do
+      let entryCert ← certEntry lo j
+      -- If `get n A lo j = 0` then we can skip computation of
+      --  `iter n A t F i lo`
+      if entryCert.isZero
+      then
+        zeroProdCert
+          q($(ctx.iterP t) $i $lo)
+          entryCert
+      else do
+        let iterCert ← certIter t i lo
+        certMul iterCert entryCert
+    let tailCert := certTail t i j (lo + 1)
+    certSumFromStep
+      lo
+      tailSummand
+      headCert
+      tailCert
+  else
+    certSumFromStop lo tailSummand
+
+end
+
+/-- Certify a `BirdDet.birdDet n A` call. -/
+def certBirdDet : CertM rα (Cert rα) := do
+  let ctx ← read
+  let {dimension := dim, dimensionLit := dimLit, arrayExpr, ..} := ctx.info
+  if dim == 0
+  then
+    let ce ← certEval q(1 : $α)
+    have : $dimLit =Q 0 := ⟨⟩
+    have A : Q(Array $α) := arrayExpr
+    let h := q(BirdDet.birdDet_zero $A)
+    return ce.chainProof h
+  else
+    -- The non-zero `BirdDet.birdDet_eq` branch matches `k + 1`
+    -- so we set k := `ctx.info.dimension - 1`.
+    let k := dim - 1
+    let cs ← certBirdSign k
+    let ci ← certIter k 0 0
+    let cm ← certMul cs ci
+    have kLit := mkNatLitQ k
+    have : $dimLit =Q $kLit + 1 := ⟨⟩
+    let hn : Q($dimLit = $kLit + 1) := q(rfl)
+    let h := q(BirdDet.birdDet_eq $dimLit $kLit $arrayExpr $hn)
+    return cm.chainProof h
+
+end Mathlib.Tactic.Determinant
+
+end

--- a/Mathlib/Tactic/Determinant/Bird/Cert.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Cert.lean
@@ -74,10 +74,7 @@ public meta section
 open Lean Meta Qq
 open Mathlib.Tactic.Ring
 
-variable
-  {u : Level}
-  {α : Q(Type u)}
-  {rα : Q(CommRing $α)}
+variable {u : Level} {α : Q(Type u)} {rα : Q(CommRing $α)}
 
 namespace Mathlib.Tactic.Determinant
 

--- a/Mathlib/Tactic/Determinant/Bird/Cert.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Cert.lean
@@ -167,13 +167,9 @@ def chainProof {lhs rhs : Q($α)} (c : Cert rα) (h : Q($lhs = $rhs)) : Cert rα
   have : $rhs =Q $c.subject := ⟨⟩
   let hProof : Q($lhs = $c.subject) := h
   let proof : Q($lhs = $c.norm) := q(Eq.trans $hProof $c.proof)
-  {
-    result := {
-      expr := c.norm
-      val := c.val
-      proof
-    }
-    isZero := c.isZero
+  { c with
+    subject := lhs
+    result.proof := proof
   }
 
 end Cert
@@ -203,16 +199,11 @@ def toCert {e : Q($α)} (res : Common.Result (CertVal rα) e) : Cert rα :=
     isZero := isZeroVal res.val }
 
 /-- Build a zero certificate from a proof `lhs = 0`. -/
-def zeroCertOfProof {lhs : Q($α)} (h : Q($lhs = 0)) : Cert rα :=
-  {
-    result := {
-      expr := q(0)
-      val := .zero
-      proof := h
-
-    }
-    isZero := true
-  }
+def zeroCertOfProof {lhs : Q($α)} (h : Q($lhs = 0)) : Cert rα where
+  result.expr := q(0)
+  result.val := .zero
+  result.proof := h
+  isZero := true
 
 /-- If c.norm = 0, return a certificate with proof `x * c.subject = 0` without
 recursively certifying `x`. -/

--- a/Mathlib/Tactic/Determinant/Bird/Cert.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Cert.lean
@@ -81,11 +81,6 @@ variable
 
 namespace Mathlib.Tactic.Determinant
 
-/-- Construct a `CommSemiring` instance expression from a `CommRing` instance expression -/
-abbrev commSemiringOfCommRing {u : Level} {α : Q(Type u)}
-    (rα : Q(CommRing $α)) : Q(CommSemiring $α) :=
-  q(CommRing.toCommSemiring (α := $α) (s := $rα))
-
 /-- The ring tactic normal-form value. -/
 abbrev CertVal {u : Level} {α : Q(Type u)}
     (rα : Q(CommRing $α)) (e : Q($α)) :=
@@ -96,36 +91,17 @@ abbrev CertResult {u : Level} {α : Q(Type u)}
     (rα : Q(CommRing $α)) (subject : Q($α)) :=
   Common.Result (CertVal rα) subject
 
-/-- The context for a certificate evaluation -/
-structure Ctx {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) where
-  /-- `Ring` evaluation cache for the scalar ring. -/
-  cα : Common.Cache (commSemiringOfCommRing rα)
-  /-- Proof-producing ring arithmetic. -/
-  rc : Common.RingCompute RatCoeff (commSemiringOfCommRing rα)
-  /-- The reified determinant payload. -/
-  info : BirdDetData rα
-
 namespace Ctx
-
-/-- Construct a `Ctx` from a `BirdDetInfo` -/
-def ofBirdDetInfo (info : BirdDetInfo) : Ctx info.rα :=
-  let sα := commSemiringOfCommRing info.rα
-  let cα : Common.Cache sα := { rα := some info.rα
-                                dsα := none
-                                czα := none }
-  { cα
-    rc := ringCompute cα
-    info := info.data }
 
 /-- Return an expression for the partially applied function `iter n A t (get n A)` -/
 def iterP (ctx : Ctx rα) (t : ℕ) : Q(ℕ → ℕ → $α) :=
-  let dim : Q(ℕ) := ctx.info.dimensionLit
-  let A : Q(Array $α) := ctx.info.arrayExpr
+  let dim : Q(ℕ) := ctx.dimensionLit
+  let A : Q(Array $α) := ctx.arrayExpr
   q(BirdDet.iter $dim $A $t (BirdDet.get $dim $A))
 
 /-- Return an expression `sumFrom n lo f` -/
 def sumFrom (ctx : Ctx rα) (lo : ℕ) (f : Q(ℕ → $α)) : Q($α) :=
-  let dim : Q(ℕ) := ctx.info.dimensionLit
+  let dim : Q(ℕ) := ctx.dimensionLit
   q(BirdDet.sumFrom $dim $lo $f)
 
 end Ctx
@@ -254,7 +230,7 @@ def certEntry (i j : ℕ) : CertM rα (Cert rα) := do
   if let some c := (← get).entryCache[(i, j)]? then
     return c
   let ctx ← read
-  let {dimension := dim, dimensionLit := dimLit, arrayExpr := A, arrayEntries, ..} := ctx.info
+  let {dimension := dim, dimensionLit := dimLit, arrayExpr := A, arrayEntries, ..} := ctx
   let lhs : Q($α) := q(BirdDet.get $dimLit $A $i $j)
   -- The index of the matrix entry (i, j) in arrayEntries
   let idx := i * dim + j
@@ -276,7 +252,7 @@ sumFrom n lo f = if lo < n then f lo + sumFrom n (lo + 1) f else 0
 -/
 def certSumFromStop (lo : ℕ) (f : Q(ℕ → $α)) : CertM rα (Cert rα) := do
   let ctx ← read
-  have dimLit : Q(ℕ) := ctx.info.dimensionLit
+  have dimLit : Q(ℕ) := ctx.dimensionLit
   let hNot : Q(¬ $lo < $dimLit) ← mkDecideProofQ q(¬ $lo < $dimLit)
   return zeroCertOfProof q(BirdDet.sumFrom_stop $dimLit $lo $f $hNot)
 
@@ -292,7 +268,7 @@ def certSumFromStep
     (lo : ℕ) (f : Q(ℕ → $α))
     (headCert tailCert : CertM rα (Cert rα)) : CertM rα (Cert rα) := do
   let ctx ← read
-  have dim : Q(ℕ) := ctx.info.dimensionLit
+  have dim : Q(ℕ) := ctx.dimensionLit
   let hLt : Q($lo < $dim) ← mkDecideProofQ q($lo < $dim)
   let sumCert ← certAdd (← headCert) (← tailCert)
   return sumCert.chainProof q(BirdDet.sumFrom_step $dim $lo $f $hLt)
@@ -304,7 +280,7 @@ partial def certIter (t i j : ℕ) : CertM rα (Cert rα) := do
   if let some c := (← get).iterCache[(t, i, j)]? then
     return c
   let ctx ← read
-  let {dimensionLit := dimLit, arrayExpr := A, ..} := ctx.info
+  let {dimensionLit := dimLit, arrayExpr := A, ..} := ctx
   let cert ← match t with
     -- The t=0 branch of `BirdDet.iter`, unfold using `BirdDet.iter_zero`
     | 0 => do
@@ -349,7 +325,7 @@ partial def certDiag (t lo : ℕ) : CertM rα (Cert rα) := do
   let ctx ← read
   let diagonalSummand := q(fun k => $(ctx.iterP t) k k)
   let cert ←
-    if lo < ctx.info.dimension
+    if lo < ctx.dimension
     then do
       let headCert := certIter t lo lo
       let tailCert := certDiag t (lo + 1)
@@ -371,12 +347,12 @@ sumFrom n (i + 1) fun k => iter n A t F i k * get n A k j
 -/
 partial def certTail (t i j lo : ℕ) : CertM rα (Cert rα) := do
   let ctx ← read
-  let {dimensionLit := dimLit, arrayExpr := A, ..} := ctx.info
+  let {dimensionLit := dimLit, arrayExpr := A, ..} := ctx
   let tailSummand :=
     q(fun k =>
       $(ctx.iterP t) $i k *
         BirdDet.get $dimLit $A k $j)
-  if lo < ctx.info.dimension
+  if lo < ctx.dimension
   then do
     -- headCert certifies `iter n A t F i lo * get n A lo j`
     let headCert := do
@@ -405,7 +381,7 @@ end
 /-- Certify a `BirdDet.birdDet n A` call. -/
 def certBirdDet : CertM rα (Cert rα) := do
   let ctx ← read
-  let {dimension := dim, dimensionLit := dimLit, arrayExpr, ..} := ctx.info
+  let {dimension := dim, dimensionLit := dimLit, arrayExpr, ..} := ctx
   if dim == 0
   then
     let ce ← certEval q(1 : $α)
@@ -415,7 +391,7 @@ def certBirdDet : CertM rα (Cert rα) := do
     return ce.chainProof h
   else
     -- The non-zero `BirdDet.birdDet_eq` branch matches `k + 1`
-    -- so we set k := `ctx.info.dimension - 1`.
+    -- so we set k := `ctx.dimension - 1`.
     let k := dim - 1
     let cs ← certBirdSign k
     let ci ← certIter k 0 0

--- a/Mathlib/Tactic/Determinant/Bird/Cert.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Cert.lean
@@ -249,9 +249,13 @@ This corresponds to the `else 0` branch of:
 ```
 sumFrom n lo f = if lo < n then f lo + sumFrom n (lo + 1) f else 0
 ```
+
+Throws a meta-level error if called with `lo` such that `lo < ctx.dimension`.
 -/
 def certSumFromStop (lo : ℕ) (f : Q(ℕ → $α)) : CertM rα (Cert rα) := do
   let ctx ← read
+  if lo < ctx.dimension then
+    throwError "certSumFromStop called with {lo} such that {lo} < {ctx.dimension}"
   have dimLit : Q(ℕ) := ctx.dimensionLit
   let hNot : Q(¬ $lo < $dimLit) ← mkDecideProofQ q(¬ $lo < $dimLit)
   return zeroCertOfProof q(BirdDet.sumFrom_stop $dimLit $lo $f $hNot)
@@ -263,11 +267,15 @@ This corresponds to the `lo < n` branch of:
 ```
 sumFrom n lo f = if lo < n then f lo + sumFrom n (lo + 1) f else 0
 ```
+
+Throws a meta-level error if called with `lo` such that `¬ lo < ctx.dimension`.
 -/
 def certSumFromStep
     (lo : ℕ) (f : Q(ℕ → $α))
     (headCert tailCert : CertM rα (Cert rα)) : CertM rα (Cert rα) := do
   let ctx ← read
+  unless lo < ctx.dimension do
+    throwError "certSumFromStep called with {lo} such that ¬ {lo} < {ctx.dimension}"
   have dim : Q(ℕ) := ctx.dimensionLit
   let hLt : Q($lo < $dim) ← mkDecideProofQ q($lo < $dim)
   let sumCert ← certAdd (← headCert) (← tailCert)

--- a/Mathlib/Tactic/Determinant/Bird/Cert.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Cert.lean
@@ -118,14 +118,14 @@ def ofBirdDetInfo (info : BirdDetInfo) : Ctx info.rα :=
     info := info.data }
 
 /-- Return an expression for the partially applied function `iter n A t (get n A)` -/
-def iterP (ctx : Ctx rα) (t : Nat) : Q(Nat → Nat → $α) :=
-  let dim : Q(Nat) := ctx.info.dimensionLit
+def iterP (ctx : Ctx rα) (t : ℕ) : Q(ℕ → ℕ → $α) :=
+  let dim : Q(ℕ) := ctx.info.dimensionLit
   let A : Q(Array $α) := ctx.info.arrayExpr
   q(BirdDet.iter $dim $A $t (BirdDet.get $dim $A))
 
 /-- Return an expression `sumFrom n lo f` -/
-def sumFrom (ctx : Ctx rα) (lo : Nat) (f : Q(Nat → $α)) : Q($α) :=
-  let dim : Q(Nat) := ctx.info.dimensionLit
+def sumFrom (ctx : Ctx rα) (lo : ℕ) (f : Q(ℕ → $α)) : Q($α) :=
+  let dim : Q(ℕ) := ctx.info.dimensionLit
   q(BirdDet.sumFrom $dim $lo $f)
 
 end Ctx
@@ -181,11 +181,11 @@ end Cert
 /-- Cache certificates that are reused by the recursive Bird evaluator. -/
 structure CertCache {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) where
   /-- Cache for entry certificates, keyed by matrix indices. -/
-  entryCache : Std.HashMap (Nat × Nat) (Cert rα) := {}
+  entryCache : Std.HashMap (ℕ × ℕ) (Cert rα) := {}
   /-- Cache for `iter` certificates, keyed by recursion index and matrix indices. -/
-  iterCache : Std.HashMap (Nat × Nat × Nat) (Cert rα) := {}
+  iterCache : Std.HashMap (ℕ × ℕ × ℕ) (Cert rα) := {}
   /-- Cache for diagonal-tail certificates, keyed by recursion index and lower bound. -/
-  diagCache : Std.HashMap (Nat × Nat) (Cert rα) := {}
+  diagCache : Std.HashMap (ℕ × ℕ) (Cert rα) := {}
 
 /-- The monad used by the certificate-chaining evaluator -/
 abbrev CertM {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) :=
@@ -255,11 +255,11 @@ def certNeg (a : Cert rα) : CertM rα (Cert rα) := do
   return c.chainProof h
 
 /-- Certify the sign factor `(-1)^k` from `BirdDet.birdDet_eq`. -/
-def certBirdSign (k : Nat) : CertM rα (Cert rα) := do
+def certBirdSign (k : ℕ) : CertM rα (Cert rα) := do
   certEval q((-1 : $α) ^ $k)
 
 /-- Certify one matrix entry lookup `BirdDet.get n A i j`. -/
-def certEntry (i j : Nat) : CertM rα (Cert rα) := do
+def certEntry (i j : ℕ) : CertM rα (Cert rα) := do
   if let some c := (← get).entryCache[(i, j)]? then
     return c
   let ctx ← read
@@ -283,9 +283,9 @@ This corresponds to the `else 0` branch of:
 sumFrom n lo f = if lo < n then f lo + sumFrom n (lo + 1) f else 0
 ```
 -/
-def certSumFromStop (lo : Nat) (f : Q(Nat → $α)) : CertM rα (Cert rα) := do
+def certSumFromStop (lo : ℕ) (f : Q(ℕ → $α)) : CertM rα (Cert rα) := do
   let ctx ← read
-  have dimLit : Q(Nat) := ctx.info.dimensionLit
+  have dimLit : Q(ℕ) := ctx.info.dimensionLit
   let hNot : Q(¬ $lo < $dimLit) ← mkDecideProofQ q(¬ $lo < $dimLit)
   return zeroCertOfProof q(BirdDet.sumFrom_stop $dimLit $lo $f $hNot)
 
@@ -298,10 +298,10 @@ sumFrom n lo f = if lo < n then f lo + sumFrom n (lo + 1) f else 0
 ```
 -/
 def certSumFromStep
-    (lo : Nat) (f : Q(Nat → $α))
+    (lo : ℕ) (f : Q(ℕ → $α))
     (headCert tailCert : CertM rα (Cert rα)) : CertM rα (Cert rα) := do
   let ctx ← read
-  have dim : Q(Nat) := ctx.info.dimensionLit
+  have dim : Q(ℕ) := ctx.info.dimensionLit
   let hLt : Q($lo < $dim) ← mkDecideProofQ q($lo < $dim)
   let sumCert ← certAdd (← headCert) (← tailCert)
   return sumCert.chainProof q(BirdDet.sumFrom_step $dim $lo $f $hLt)
@@ -309,7 +309,7 @@ def certSumFromStep
 mutual
 
 /-- Certify a `BirdDet.iter` call. -/
-partial def certIter (t i j : Nat) : CertM rα (Cert rα) := do
+partial def certIter (t i j : ℕ) : CertM rα (Cert rα) := do
   if let some c := (← get).iterCache[(t, i, j)]? then
     return c
   let ctx ← read
@@ -352,7 +352,7 @@ partial def certIter (t i j : Nat) : CertM rα (Cert rα) := do
 sumFrom n (i + 1) fun k => iter n A t F k k)
 ```
 -/
-partial def certDiag (t lo : Nat) : CertM rα (Cert rα) := do
+partial def certDiag (t lo : ℕ) : CertM rα (Cert rα) := do
   if let some c := (← get).diagCache[(t, lo)]? then
     return c
   let ctx ← read
@@ -378,7 +378,7 @@ partial def certDiag (t lo : Nat) : CertM rα (Cert rα) := do
 sumFrom n (i + 1) fun k => iter n A t F i k * get n A k j
 ```
 -/
-partial def certTail (t i j lo : Nat) : CertM rα (Cert rα) := do
+partial def certTail (t i j lo : ℕ) : CertM rα (Cert rα) := do
   let ctx ← read
   let {dimensionLit := dimLit, arrayExpr := A, ..} := ctx.info
   let tailSummand :=

--- a/Mathlib/Tactic/Determinant/Bird/Meta.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Meta.lean
@@ -29,11 +29,11 @@ namespace Mathlib.Tactic.Determinant
 
 /-- Parse an array literal into an array of element expressions.
 
-Compared to `getArrayLit?`, this also performs `whnf` and zeta-reduction.
+Compared to `getArrayLit?`, this also performs `whnf`.
 -/
 def arrayLiteral? (e : Expr) : MetaM (Option (Array Expr)) := do
   if let some elems ← getArrayLit? e then return some elems
-  let e ← zetaReduce (← whnf e)
+  let e ← whnf e
   match_expr e with
   | Array.mk _ xs => getListLit? xs
   | _ => return none

--- a/Mathlib/Tactic/Determinant/Bird/Meta.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Meta.lean
@@ -41,9 +41,9 @@ def arrayLiteral? (e : Expr) : MetaM (Option (Array Expr)) := do
 /-- The matrix data parsed from a `birdDet` call. -/
 structure BirdDetData {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) where
   /-- The dimension of the reified matrix -/
-  dimension : Nat
+  dimension : ℕ
   /-- The quoted dimension expression from the reified determinant call. -/
-  dimensionLit : Q(Nat)
+  dimensionLit : Q(ℕ)
   /-- The array of matrix entries as an Expr -/
   arrayExpr : Q(Array $α)
   /-- An array of matrix entry `Expr`s` -/
@@ -69,10 +69,10 @@ def reifyBirdDet (e : Expr) : MetaM BirdDetInfo := do
   let some rα ← checkTypeQ birdRingInst q(CommRing $α)
     | throwError "expected `birdDet` ring instance to have type {q(CommRing $α)}"
   let dimensionExpr ← whnf dimensionExpr
-  let some dimensionLit ← checkTypeQ dimensionExpr q(Nat)
-    | throwError "expected the dimension to have type `Nat`, got {dimensionExpr}"
+  let some dimensionLit ← checkTypeQ dimensionExpr q(ℕ)
+    | throwError "expected the dimension to have type `ℕ`, got {dimensionExpr}"
   let some dimension ← getNatValue? dimensionLit
-    | throwError "expected the dimension to be a `Nat` literal, got {dimensionLit}"
+    | throwError "expected the dimension to be a `ℕ` literal, got {dimensionLit}"
   let some arrayExpr ← checkTypeQ arrayExpr q(Array $α)
     | throwError "expected the array to have type {q(Array $α)}"
   let some arrayEntries ← arrayLiteral? arrayExpr

--- a/Mathlib/Tactic/Determinant/Bird/Meta.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Meta.lean
@@ -6,26 +6,33 @@ Authors: Paul Cadman
 module
 
 public import Mathlib.LinearAlgebra.Matrix.Determinant.Bird
+public meta import Mathlib.Tactic.Ring
 public meta import Mathlib.Util.Qq
 
 /-!
 # Reification support for the determinant tactic
 
-This file contains the meta-level parser used by `normalizeBirdDet` to parse
-`BirdDet.birdDet` calls into `BirdDetInfo`, that is used by the
-certificate-chaining evaluator.
+This file contains the meta-level parser, `refiyBirdDet`,  used by
+`normalizeBirdDet` to turn `BirdDet.birdDet` calls into the context used by the
+certificate-chain evaluator.
 
 ## Main definitions
 
-- `reifyBirdDet`: Parse a call to `BirdDet.birdDet` into `BirdDetInfo`
+- `reifyBirdDet`: Parse a call to `BirdDet.birdDet`.
 
 -/
 
 public meta section
 
 open Lean Meta Qq
+open Mathlib.Tactic.Ring
 
 namespace Mathlib.Tactic.Determinant
+
+/-- Construct a `CommSemiring` instance expression from a `CommRing` instance expression -/
+abbrev commSemiringOfCommRing {u : Level} {α : Q(Type u)}
+    (rα : Q(CommRing $α)) : Q(CommSemiring $α) :=
+  q(CommRing.toCommSemiring (α := $α) (s := $rα))
 
 /-- Parse an array literal into an array of element expressions.
 
@@ -38,8 +45,12 @@ def arrayLiteral? (e : Expr) : MetaM (Option (Array Expr)) := do
   | Array.mk _ xs => getListLit? xs
   | _ => return none
 
-/-- The matrix data parsed from a `birdDet` call. -/
-structure BirdDetData {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) where
+/-- The context for a certificate evaluation. -/
+structure Ctx {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) where
+  /-- `Ring` evaluation cache for the scalar ring. -/
+  cα : Common.Cache (commSemiringOfCommRing rα)
+  /-- Proof-producing ring arithmetic. -/
+  rc : Common.RingCompute RatCoeff (commSemiringOfCommRing rα)
   /-- The dimension of the reified matrix -/
   dimension : ℕ
   /-- The quoted dimension expression from the reified determinant call. -/
@@ -49,19 +60,19 @@ structure BirdDetData {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) where
   /-- An array of matrix entry `Expr`s` -/
   arrayEntries : Array Q($α)
 
-/-- Information parsed by `reifyBirdDet`. -/
-structure BirdDetInfo where
+/-- The ring instance and evaluator context parsed by `reifyBirdDet`. -/
+structure ReifiedBirdDet where
   /-- The universe level associated with the `birdDet` call -/
   {u : Level}
   /-- The type of a matrix entry -/
   {α : Q(Type u)}
   /-- The `CommRing` instance for matrix entries -/
   rα : Q(CommRing $α)
-  /-- The typed matrix data parsed from the determinant expression. -/
-  data : BirdDetData rα
+  /-- The evaluator context for the parsed determinant expression. -/
+  ctx : Ctx rα
 
-/-- Recognise a `birdDet` call and reify the matrix argument into `BirdDetInfo`. -/
-def reifyBirdDet (e : Expr) : MetaM BirdDetInfo := do
+/-- Recognise a `birdDet` call and reify it into an evaluator context. -/
+def reifyBirdDet (e : Expr) : MetaM ReifiedBirdDet := do
   let e ← instantiateMVars e
   let ⟨_, α, _⟩ ← inferTypeQ' e
   let_expr BirdDet.birdDet _ birdRingInst dimensionExpr arrayExpr := e
@@ -84,9 +95,17 @@ def reifyBirdDet (e : Expr) : MetaM BirdDetInfo := do
     let some entry ← checkTypeQ entry α
       | throwError "expected array entry to have type {α}"
     return entry
+  let sα := commSemiringOfCommRing rα
+  let cα : Common.Cache sα := {
+    rα := some rα
+    dsα := none
+    czα := none
+  }
   return {
     rα
-    data := {
+    ctx := {
+      cα
+      rc := ringCompute cα
       dimension
       dimensionLit
       arrayExpr

--- a/Mathlib/Tactic/Determinant/Bird/Meta.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Meta.lean
@@ -27,7 +27,10 @@ open Lean Meta Qq
 
 namespace Mathlib.Tactic.Determinant
 
-/-- Parse an array literal into an array of element expressions. -/
+/-- Parse an array literal into an array of element expressions.
+
+Compared to `getArrayLit?`, this also performs `whnf` and zeta-reduction.
+-/
 def arrayLiteral? (e : Expr) : MetaM (Option (Array Expr)) := do
   if let some elems ← getArrayLit? e then return some elems
   let e ← zetaReduce (← whnf e)

--- a/Mathlib/Tactic/Determinant/Bird/Meta.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Meta.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 Paul Cadman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Cadman
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.Determinant.Bird
+public meta import Mathlib.Util.Qq
+
+/-!
+# Reification support for the determinant tactic
+
+This file contains the meta-level parser used by `normalizeBirdDet` to parse
+`BirdDet.birdDet` calls into `BirdDetInfo`, that is used by the
+certificate-chaining evaluator.
+
+## Main definitions
+
+- `reifyBirdDet`: Parse a call to `BirdDet.birdDet` into `BirdDetInfo`
+
+-/
+
+public meta section
+
+open Lean Meta Qq
+
+namespace Mathlib.Tactic.Determinant
+
+/-- Parse an array literal into an array of element expressions. -/
+def arrayLiteral? (e : Expr) : MetaM (Option (Array Expr)) := do
+  if let some elems ← getArrayLit? e then return some elems
+  let e ← zetaReduce (← whnf e)
+  match_expr e with
+  | Array.mk _ xs => getListLit? xs
+  | _ => return none
+
+/-- The matrix data parsed from a `birdDet` call. -/
+structure BirdDetData {u : Level} {α : Q(Type u)} (rα : Q(CommRing $α)) where
+  /-- The dimension of the reified matrix -/
+  dimension : Nat
+  /-- The quoted dimension expression from the reified determinant call. -/
+  dimensionLit : Q(Nat)
+  /-- The array of matrix entries as an Expr -/
+  arrayExpr : Q(Array $α)
+  /-- An array of matrix entry `Expr`s` -/
+  arrayEntries : Array Q($α)
+
+/-- Information parsed by `reifyBirdDet`. -/
+structure BirdDetInfo where
+  /-- The universe level associated with the `birdDet` call -/
+  {u : Level}
+  /-- The type of a matrix entry -/
+  {α : Q(Type u)}
+  /-- The `CommRing` instance for matrix entries -/
+  rα : Q(CommRing $α)
+  /-- The typed matrix data parsed from the determinant expression. -/
+  data : BirdDetData rα
+
+/-- Recognise a `birdDet` call and reify the matrix argument into `BirdDetInfo`. -/
+def reifyBirdDet (e : Expr) : MetaM BirdDetInfo := do
+  let e ← instantiateMVars e
+  let ⟨_, α, _⟩ ← inferTypeQ' e
+  let_expr BirdDet.birdDet _ birdRingInst dimensionExpr arrayExpr := e
+    | throwError "expected an application of `birdDet, got {e}"
+  let some rα ← checkTypeQ birdRingInst q(CommRing $α)
+    | throwError "expected `birdDet` ring instance to have type {q(CommRing $α)}"
+  let dimensionExpr ← whnf dimensionExpr
+  let some dimensionLit ← checkTypeQ dimensionExpr q(Nat)
+    | throwError "expected the dimension to have type `Nat`, got {dimensionExpr}"
+  let some dimension ← getNatValue? dimensionLit
+    | throwError "expected the dimension to be a `Nat` literal, got {dimensionLit}"
+  let some arrayExpr ← checkTypeQ arrayExpr q(Array $α)
+    | throwError "expected the array to have type {q(Array $α)}"
+  let some arrayEntries ← arrayLiteral? arrayExpr
+    | throwError "expected an array literal matrix, got {arrayExpr}"
+  unless arrayEntries.size == dimension * dimension do
+    throwError "matrix size mismatch: array has {arrayEntries.size} entries, \
+      expected {dimension * dimension}"
+  let arrayEntries ← arrayEntries.mapM fun entry => do
+    let some entry ← checkTypeQ entry α
+      | throwError "expected array entry to have type {α}"
+    return entry
+  return {
+    rα
+    data := {
+      dimension
+      dimensionLit
+      arrayExpr
+      arrayEntries
+    }
+  }
+
+end Mathlib.Tactic.Determinant
+
+end

--- a/MathlibTest/matrix.lean
+++ b/MathlibTest/matrix.lean
@@ -6,6 +6,8 @@ import Mathlib.GroupTheory.Perm.Fin
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.Determinant.Bird
 import Mathlib.LinearAlgebra.Matrix.Notation
+import Mathlib.RingTheory.Polynomial.Basic
+import Mathlib.Tactic.Determinant.Bird
 import Qq
 
 open Qq
@@ -191,18 +193,56 @@ section BirdDet
 
 open BirdDet
 
+variable
+  {R : Type*}
+  [CommRing R]
+
 example : birdDet 0 #[] = (1 : ℤ) := by
-  cbv
+  eval_det
 
 example : birdDet 1 #[-1] = -1 := by
-  cbv
+  eval_det
 
 example : birdDet 2 #[1, 2, 3, 4] = -2 := by
-  cbv
+  eval_det
 
-example {R : Type*} [CommRing R] (a b c d : R) :
+example (a b c d : R) :
     birdDet 2 #[a, b, c, d] = a * d - b * c := by
-  simp [birdDet, iter, BirdDet.get, sumFrom]
+  eval_det
+  ring
+
+example (a b c d : R) :
+    birdDet 2 #[a, b, c, d] = a * d - b * c := by
+  simp only [norm_det]
+  ring
+
+example : birdDet 2 #[1, 2, 2, 4] + birdDet 2 #[2, 3, 4, 5] = -2 := by
+  simp only [norm_det]
+  norm_num
+
+example : birdDet 2 #[birdDet 2 #[2, 3, 4, 5], 2, 2, 4] = -12 := by
+  simp only [norm_det]
+
+example :
+  birdDet 8
+    #[ 2,  0, -1,  0,  0,  0,  0,  0,
+       0,  2,  0, -1,  0,  0,  0,  0,
+      -1,  0,  2, -1,  0,  0,  0,  0,
+       0, -1, -1,  2, -1,  0,  0,  0,
+       0,  0,  0, -1,  2, -1,  0,  0,
+       0,  0,  0,  0, -1,  2, -1,  0,
+       0,  0,  0,  0,  0, -1,  2, -1,
+       0,  0,  0,  0,  0,  0, -1,  2] = 1 := by
+  simp only [norm_det]
+
+open MvPolynomial in
+lemma test_case_11 :
+    birdDet (R := MvPolynomial (Fin 3) R)
+      3
+      #[1 , X 0, (X 0) ^ 2,
+        1 , X 1, (X 1) ^ 2,
+        1 , X 2, (X 2) ^ 2] = (X 0 - X 1) * (X 1 - X 2) * (X 2 - X 0) := by
+  simp only [norm_det]
   ring
 
 end BirdDet

--- a/MathlibTest/matrix.lean
+++ b/MathlibTest/matrix.lean
@@ -4,6 +4,7 @@ https://github.com/leanprover-community/mathlib/blob/4f4a1c875d0baa92ab5d92f3fb1
 -/
 import Mathlib.GroupTheory.Perm.Fin
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.LinearAlgebra.Matrix.Determinant.Bird
 import Mathlib.LinearAlgebra.Matrix.Notation
 import Qq
 
@@ -185,5 +186,25 @@ example (ι : Type*) [Inhabited ι] : Matrix.replicateRow ι (fun (_ : Fin 3) =>
 example (ι : Type*) [Inhabited ι] : Matrix.replicateCol ι (fun (_ : Fin 3) => 0) = 0 := by
   simp_all
   rfl
+
+section BirdDet
+
+open BirdDet
+
+example : birdDet 0 #[] = (1 : ℤ) := by
+  cbv
+
+example : birdDet 1 #[-1] = -1 := by
+  cbv
+
+example : birdDet 2 #[1, 2, 3, 4] = -2 := by
+  cbv
+
+example {R : Type*} [CommRing R] (a b c d : R) :
+    birdDet 2 #[a, b, c, d] = a * d - b * c := by
+  simp [birdDet, iter, BirdDet.get, sumFrom]
+  ring
+
+end BirdDet
 
 end Matrix

--- a/MathlibTest/matrix.lean
+++ b/MathlibTest/matrix.lean
@@ -206,6 +206,9 @@ example : birdDet 1 #[-1] = -1 := by
 example : birdDet 2 #[1, 2, 3, 4] = -2 := by
   eval_det
 
+example : birdDet 2 (let A := #[1, 2, 3, 4]; A) = -2 := by
+  eval_det
+
 example (a b c d : R) :
     birdDet 2 #[a, b, c, d] = a * d - b * c := by
   eval_det


### PR DESCRIPTION
add `birdDet`, an implementation of a division-free determinant algorithm [1], and `norm_det` / `eval_det` frontend for normalizing expressions that use `birdDet`. The algorithm can be used for matrices with symbolic entries over a `CommRing` (see example below).

The normalizer uses the ring tactic's normalisation infrastructure to produce a certificate chain between the `birdDet` expression and the computed determinant. I chose this particular algorithm because it is efficient enough to work with ~10x10 matrices, and is division-free and so can work with matrices with elements in a general commutative ring. 

For example:

```lean
example {R: Type*} [CommRing R] (a b c d : R) :
    birdDet 2 #[a, b, c, d] = a * d - b * c := by
  simp only [norm_det]
  ring
``` 

[1]: https://doi.org/10.1016/j.ipl.2011.08.006


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

In subsequent PRs I will add a proof that the determinant computed by `birdDet` is equal to the mathlib `Matrix.det` and I'll update the tactic / simproc to work with `Matrix.det`.

I tried using `cbv` with custom `cbv_simprocs` (and `cbv_opaque` defs for wrapping ring operations) with the `birdDet` definition in a tactic to prove determinant equalities. However this approach has worse performance than the manual certificate chaining approach. I think a big part of the difference is due to the certificate chaining approach using memoization.

Some benchmarks (combined elab + kernel time):

| Determinant | `cbv` | certificate chaining |
| ----------  | ----- | -------------------- |
| Cartan E8 (8x8) | 3.106744s | 0.161053s |
| Sylvester quartic (7x7) | 5.319664s | 0.874215s  |
| 14x14 dense numeric | recursion limit / simp step limit reached | 4.289387s |

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
