### PR TITLE
[Merged by Bors] - chore: deprime FiberBundle.contMDiffAt_extend'

### DIFF
--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -687,8 +687,7 @@ lemma exists_contMDiffOn_extend [(x : M) → Module 𝕜 (V x)] [VectorBundle �
   have : CMDiff[t.baseSet] k (fun (_x : M) ↦ w) := contMDiffOn_const
   exact this.congr (fun x hx ↦ by simp [extend, t, w, hx])
 
-lemma contMDiffAt_extend' {x : M} (σ₀ : V x) :
-    CMDiffAt k (T% (extend F σ₀)) x := by
+lemma contMDiffAt_extend {x : M} (σ₀ : V x) : CMDiffAt k (T% (extend F σ₀)) x := by
   rw [contMDiffAt_section]
   set t := trivializationAt F V x
   let w : F := (t ⟨x, σ₀⟩).2
@@ -700,6 +699,8 @@ lemma contMDiffAt_extend' {x : M} (σ₀ : V x) :
     simp [extend, t, hx, w]
   · exact FiberBundle.mem_baseSet_trivializationAt' x
 
+@[deprecated (since := "2026-06-30")] alias contMDiffAt_extend' := contMDiffAt_extend
+
 lemma exists_mdifferentiableOn_extend [∀ x, Module 𝕜 (V x)] [VectorBundle 𝕜 F V]
     [ContMDiffVectorBundle 1 F V I] {x₀ : M} (σ₀ : V x₀) :
     ∃ s ∈ 𝓝 x₀, MDiff[s] (T% (extend F σ₀)) := by
@@ -708,7 +709,7 @@ lemma exists_mdifferentiableOn_extend [∀ x, Module 𝕜 (V x)] [VectorBundle �
 
 lemma mdifferentiableAt_extend {x : M} (σ₀ : V x) :
     MDiffAt (T% (extend F σ₀)) x :=
-  (contMDiffAt_extend' (k := 1) I F σ₀).mdifferentiableAt one_ne_zero
+  (contMDiffAt_extend (k := 1) I F σ₀).mdifferentiableAt one_ne_zero
 
 variable (V) in
 lemma _root_.VectorBundle.injective_eval_mdifferentiableAt_sec [∀ x, Module 𝕜 (V x)]
@@ -728,7 +729,7 @@ lemma _root_.VectorBundle.injective_eval_contMDiffAt_sec {n : WithTop ℕ∞} [�
         fun (Z : Π x, V x) (_ : CMDiffAt n (T% Z) x) ↦ A (Z x)) := by
   intro X X' h
   ext σ₀
-  simpa using congr($h (extend F σ₀) (contMDiffAt_extend' ..))
+  simpa using congr($h (extend F σ₀) (contMDiffAt_extend ..))
 
 end FiberBundle
 end extend


### PR DESCRIPTION
The original name was primed to avoid ambiguity with `contMDiffAt_extend`: a previous PR moved this
under the `OpenPartialHomeomorph` namespace, so this ambiguity is no longer present.

---

- [x] depends on: ##41174 
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
