### PR TITLE
[Merged by Bors] - feat(Analysis/Complex/RealDeriv,CauchyIntegral): real and complex differentiability lemmas

### DIFF
--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -656,6 +656,11 @@ protected theorem _root_.Differentiable.contDiff
     ContDiff ℂ n f :=
   contDiff_iff_contDiffAt.mpr fun z ↦ (hf.analyticAt z).contDiffAt
 
+@[fun_prop]
+theorem _root_.Differentiable.deriv {f : ℂ → E} (hf : Differentiable ℂ f) :
+    Differentiable ℂ (deriv f) :=
+  hf.contDiff.differentiable_deriv_two
+
 /-- When `f : ℂ → E` is differentiable, the `cauchyPowerSeries f z R` represents `f` as a power
 series centered at `z` in the entirety of `ℂ`, regardless of `R : ℝ≥0`, with `0 < R`. -/
 protected theorem _root_.Differentiable.hasFPowerSeriesOnBall {f : ℂ → E} (h : Differentiable ℂ f)

--- a/Mathlib/Analysis/Complex/RealDeriv.lean
+++ b/Mathlib/Analysis/Complex/RealDeriv.lean
@@ -134,7 +134,8 @@ lemma DifferentiableAt.real_of_complex (hf : DifferentiableAt ℂ f z) : Differe
 
 @[fun_prop]
 lemma DifferentiableWithinAt.real_of_complex (hf : DifferentiableWithinAt ℂ f s z) :
-    DifferentiableWithinAt ℝ f s z := hf.restrictScalars (𝕜 := ℝ)
+    DifferentiableWithinAt ℝ f s z :=
+  hf.restrictScalars (𝕜 := ℝ)
 
 @[fun_prop]
 lemma DifferentiableOn.real_of_complex (hf : DifferentiableOn ℂ f s) : DifferentiableOn ℝ f s :=

--- a/Mathlib/Analysis/Complex/RealDeriv.lean
+++ b/Mathlib/Analysis/Complex/RealDeriv.lean
@@ -109,4 +109,35 @@ theorem HasDerivWithinAt.ofReal_comp {f : ℝ → ℝ} {s : Set ℝ} {u : ℝ}
   simpa only [Function.comp_apply, ofRealCLM_apply] using!
     ofRealCLM.hasFDerivAt.comp_hasDerivWithinAt z hf
 
+@[fun_prop]
+lemma Complex.differentiable_re : Differentiable ℝ Complex.re := reCLM.differentiable
+
+@[fun_prop]
+lemma Complex.differentiable_im : Differentiable ℝ Complex.im := imCLM.differentiable
+
+@[fun_prop]
+lemma Complex.differentiable_ofReal : Differentiable ℝ Complex.ofReal := ofRealCLM.differentiable
+
+open ComplexConjugate in
+@[fun_prop]
+lemma Complex.differentiable_conj : Differentiable ℝ (conj : ℂ → ℂ) := conjCLE.differentiable
+
+variable {f : ℂ → E} {s : Set ℂ} {z : ℂ}
+
+@[fun_prop]
+lemma Differentiable.real_of_complex (hf : Differentiable ℂ f) : Differentiable ℝ f :=
+  hf.restrictScalars (𝕜 := ℝ)
+
+@[fun_prop]
+lemma DifferentiableAt.real_of_complex (hf : DifferentiableAt ℂ f z) : DifferentiableAt ℝ f z :=
+  hf.restrictScalars (𝕜 := ℝ)
+
+@[fun_prop]
+lemma DifferentiableWithinAt.real_of_complex (hf : DifferentiableWithinAt ℂ f s z) :
+    DifferentiableWithinAt ℝ f s z := hf.restrictScalars (𝕜 := ℝ)
+
+@[fun_prop]
+lemma DifferentiableOn.real_of_complex (hf : DifferentiableOn ℂ f s) : DifferentiableOn ℝ f s :=
+  hf.restrictScalars (𝕜 := ℝ)
+
 end RealDerivOfComplex


### PR DESCRIPTION
Some easy `@[fun_prop]` lemmas on the real-differentiability of various complex functions, and the fact that the derivative of an entire function is entire. ~~Also some very minor golf of `CauchyIntegral.lean`.~~

---
New `@[fun_prop]` lemmas:

* The real differentiability of `Complex.re`, `Complex.im`, `Complex.ofReal`, and `conj`.  
* The real differentiability of any complex differentiable function.
* The derivative of an entire function is again entire.

There may be a case for tagging some related lemmas in `CauchyIntegral.lean` to be `@[fun_prop]` as well, but I have refrained from doing so.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
