### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean): obtuse and right angle criteria from inner product sign

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
@@ -363,7 +363,14 @@ theorem sin_arccos (x : ℝ) : sin (arccos x) = √(1 - x ^ 2) := by
 theorem arccos_le_pi_div_two {x} : arccos x ≤ π / 2 ↔ 0 ≤ x := by simp [arccos]
 
 @[simp]
+theorem pi_div_two_le_arccos {x : ℝ} : π / 2 ≤ arccos x ↔ x ≤ 0 := by simp [arccos]
+
+@[simp]
 theorem arccos_lt_pi_div_two {x : ℝ} : arccos x < π / 2 ↔ 0 < x := by simp [arccos]
+
+@[simp]
+theorem pi_div_two_lt_arccos {x : ℝ} : π / 2 < arccos x ↔ x < 0 :=
+  lt_iff_lt_of_le_iff_le arccos_le_pi_div_two
 
 @[simp]
 theorem arccos_le_pi_div_four {x} : arccos x ≤ π / 4 ↔ √2 / 2 ≤ x := by

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
@@ -211,6 +211,29 @@ them is π/2. -/
 theorem inner_eq_zero_iff_angle_eq_pi_div_two (x y : V) : ⟪x, y⟫ = 0 ↔ angle x y = π / 2 :=
   Iff.symm <| by simp +contextual [angle, or_imp]
 
+/-- The inner product of two vectors is nonpositive if and only if the angle between them is
+at least `π / 2`. -/
+theorem inner_nonpos_iff_pi_div_two_le_angle {x y : V} :
+    ⟪x, y⟫ ≤ 0 ↔ π / 2 ≤ angle x y := by
+  rw [angle, Real.pi_div_two_le_arccos]
+  refine ⟨fun h => div_nonpos_of_nonpos_of_nonneg h (by positivity), fun h => ?_⟩
+  by_contra hpos
+  push Not at hpos
+  exact absurd h (not_le.2 (div_pos hpos (hpos.trans_le (real_inner_le_norm x y))))
+
+/-- The inner product of two vectors is negative if and only if the angle between them exceeds
+`π / 2`. -/
+theorem inner_neg_iff_pi_div_two_lt_angle {x y : V} :
+    ⟪x, y⟫ < 0 ↔ π / 2 < angle x y := by
+  rw [angle, Real.pi_div_two_lt_arccos]
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · have hx : x ≠ 0 := by rintro rfl; simp at h
+    have hy : y ≠ 0 := by rintro rfl; simp at h
+    exact div_neg_of_neg_of_pos h (mul_pos (norm_pos_iff.2 hx) (norm_pos_iff.2 hy))
+  · by_contra hnonneg
+    push Not at hnonneg
+    exact absurd h (not_lt.2 (div_nonneg hnonneg (by positivity)))
+
 /-- If the angle between two vectors is π, the inner product equals the negative product
 of the norms. -/
 theorem inner_eq_neg_mul_norm_of_angle_eq_pi {x y : V} (h : angle x y = π) :

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/RightAngle.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/RightAngle.lean
@@ -332,6 +332,17 @@ theorem dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two (p₁ p₂ p₃ :
     dist_eq_norm_vsub V p₂ p₃, angle, ← norm_sub_sq_eq_norm_sq_add_norm_sq_iff_angle_eq_pi_div_two,
     vsub_sub_vsub_cancel_right p₁, ← neg_vsub_eq_vsub_rev p₂ p₃, norm_neg]
 
+/-- The angle at `p₂` is at least `π / 2` if and only if the square of the opposite side is at
+least the sum of the squares of the other two sides. -/
+theorem dist_sq_add_dist_sq_le_dist_sq_iff_pi_div_two_le_angle {p₁ p₂ p₃ : P} :
+    dist p₁ p₂ * dist p₁ p₂ + dist p₃ p₂ * dist p₃ p₂ ≤ dist p₁ p₃ * dist p₁ p₃ ↔
+      π / 2 ≤ ∠ p₁ p₂ p₃ := by
+  rw [angle, ← inner_nonpos_iff_pi_div_two_le_angle, dist_eq_norm_vsub V p₁ p₃,
+    dist_eq_norm_vsub V p₁ p₂, dist_eq_norm_vsub V p₃ p₂,
+    show (p₁ -ᵥ p₃ : V) = (p₁ -ᵥ p₂) - (p₃ -ᵥ p₂) from (vsub_sub_vsub_cancel_right p₁ p₃ p₂).symm,
+    norm_sub_mul_self_real]
+  constructor <;> intro h <;> linarith
+
 /-- An angle in a right-angled triangle expressed using `arccos`. -/
 theorem angle_eq_arccos_of_angle_eq_pi_div_two {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = π / 2) :
     ∠ p₂ p₃ p₁ = Real.arccos (dist p₃ p₂ / dist p₁ p₃) := by


### PR DESCRIPTION
This PR adds criteria characterising when an unoriented angle is at least, or
strictly greater than, `π / 2`, in terms of the sign of an inner product or a
comparison of squared distances. They are the obtuse/right-angle counterparts of
the existing equality results `InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two`
and the if-and-only-if Pythagorean theorem
`EuclideanGeometry.dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two`.

### New lemmas

`Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean`
- `Real.pi_div_two_le_arccos : π / 2 ≤ arccos x ↔ x ≤ 0`
- `Real.pi_div_two_lt_arccos : π / 2 < arccos x ↔ x < 0`

  Duals of the existing `Real.arccos_le_pi_div_two` / `Real.arccos_lt_pi_div_two`,
  both `@[simp]`.

`Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean`
- `InnerProductGeometry.inner_nonpos_iff_pi_div_two_le_angle`
- `InnerProductGeometry.inner_neg_iff_pi_div_two_lt_angle`

`Mathlib/Geometry/Euclidean/Angle/Unoriented/RightAngle.lean`
- `EuclideanGeometry.dist_sq_add_dist_sq_le_dist_sq_iff_pi_div_two_le_angle`