### PR TITLE
[Merged by Bors] - feat(Analysis/Asymptotics): a function continuous at a point is bounded near it

### DIFF
--- a/Mathlib/Analysis/Asymptotics/Lemmas.lean
+++ b/Mathlib/Analysis/Asymptotics/Lemmas.lean
@@ -192,15 +192,20 @@ theorem IsLittleO.trans_tendsto (hfg : f'' =o[l] g'') (hg : Tendsto g'' l (𝓝 
 lemma isLittleO_id_one [One F''] [NeZero (1 : F'')] : (fun x : E'' => x) =o[𝓝 0] (1 : E'' → F'') :=
   isLittleO_id_const one_ne_zero
 
-theorem continuousAt_iff_isLittleO {α : Type*} {E : Type*} [NormedRing E] [NormOneClass E]
+theorem continuousAt_iff_isLittleO {α : Type*} {E : Type*} [NormedRing E] [One F] [NormOneClass F]
     [TopologicalSpace α] {f : α → E} {x : α} :
-    (ContinuousAt f x) ↔ (fun (y : α) ↦ f y - f x) =o[𝓝 x] (fun (_ : α) ↦ (1 : E)) := by
+    (ContinuousAt f x) ↔ (f · - f x) =o[𝓝 x] (fun (_ : α) ↦ (1 : F)) := by
   simp [ContinuousAt, ← tendsto_sub_nhds_zero_iff]
 
-theorem _root_.ContinuousAt.isBigO {α : Type*} {E : Type*} [NormedRing E] [NormOneClass E]
+theorem _root_.ContinuousAt.isLittleO {α : Type*} {E : Type*} [NormedRing E] [One F]
+    [NormOneClass F] [TopologicalSpace α] {f : α → E} {x : α} (hcont : ContinuousAt f x) :
+    (f · - f x) =o[𝓝 x] (fun _ ↦ (1 : F)) :=
+  continuousAt_iff_isLittleO.mp hcont
+
+theorem _root_.ContinuousAt.isBigO {α : Type*} {E : Type*} [NormedRing E] [One F] [NormOneClass F]
     [TopologicalSpace α] {f : α → E} {x : α} (hcont : ContinuousAt f x) :
-    f =O[𝓝 x] (fun _ ↦ (1 : E)) :=
-  (continuousAt_iff_isLittleO.mp hcont).isBigO.congr_of_sub.mpr (isBigO_const_one ..)
+    f =O[𝓝 x] (fun _ ↦ (1 : F)) :=
+  hcont.isLittleO.isBigO.congr_of_sub.mpr (isBigO_const_one ..)
 
 /-! ### Multiplication -/
 

--- a/Mathlib/Analysis/Asymptotics/Lemmas.lean
+++ b/Mathlib/Analysis/Asymptotics/Lemmas.lean
@@ -197,6 +197,11 @@ theorem continuousAt_iff_isLittleO {α : Type*} {E : Type*} [NormedRing E] [Norm
     (ContinuousAt f x) ↔ (fun (y : α) ↦ f y - f x) =o[𝓝 x] (fun (_ : α) ↦ (1 : E)) := by
   simp [ContinuousAt, ← tendsto_sub_nhds_zero_iff]
 
+theorem _root_.ContinuousAt.isBigO {α : Type*} {E : Type*} [NormedRing E] [NormOneClass E]
+    [TopologicalSpace α] {f : α → E} {x : α} (hcont : ContinuousAt f x) :
+    f =O[𝓝 x] (fun _ ↦ (1 : E)) :=
+  (continuousAt_iff_isLittleO.mp hcont).isBigO.congr_of_sub.mpr (isBigO_const_one ..)
+
 /-! ### Multiplication -/
 
 theorem IsBigO.of_pow {f : α → 𝕜} {g : α → R} {n : ℕ} (hn : n ≠ 0) (h : (f ^ n) =O[l] (g ^ n)) :


### PR DESCRIPTION
Add `ContinuousAt.isBigO`: if `f` is continuous at `x` then `f =O[𝓝 x] (fun _ ↦ 1)`. This is a corollary of `continuousAt_iff_isLittleO` and has been placed accordingly.

---

This lemma was written by myself (and needed for a forthcoming PR on asymptotics of the Riemann zeta function), but I used AI to assist with the pull request.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
