### PR TITLE
[Merged by Bors] - chore(RingTheory/RamificationInertia/RamificationIdx): swap primes on `ramificationIdx` and `ramificationIdx'`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -123,11 +123,11 @@ theorem map_eq_span_zeta_sub_one_pow :
     ← Nat.card_eq_fintype_card, IsGalois.card_aut_eq_finrank]
 
 theorem ramificationIdx_span_zeta_sub_one :
-    ramificationIdx' (span {hζ.toInteger - 1}) ℤ = p ^ k * (p - 1) := by
+    ramificationIdx (span {hζ.toInteger - 1}) ℤ = p ^ k * (p - 1) := by
   have h := isPrime_span_zeta_sub_one p k hζ
   have hp0 : 𝒑 ≠ ⊥ := by simpa using hp.out.ne_zero
   rw [← Nat.totient_prime_pow_succ hp.out, ← finrank _ K,
-    IsDedekindDomain.ramificationIdx'_eq_multiplicity 𝒑, map_eq_span_zeta_sub_one_pow p k hζ,
+    IsDedekindDomain.ramificationIdx_eq_multiplicity 𝒑, map_eq_span_zeta_sub_one_pow p k hζ,
     multiplicity_pow_self (span_zeta_sub_one_ne_bot p k hζ) (isUnit_iff.not.mpr h.ne_top)]
   exact map_ne_bot_of_ne_bot hp0
 
@@ -162,7 +162,7 @@ theorem inertiaDeg_eq_of_prime_pow (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP�
 
 include hK in
 theorem ramificationIdx_eq_of_prime_pow (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver 𝒑] :
-    ramificationIdx' P ℤ = p ^ k * (p - 1) := by
+    ramificationIdx P ℤ = p ^ k * (p - 1) := by
   rw [eq_span_zeta_sub_one_of_liesOver p k K hK.zeta_spec P, ramificationIdx_span_zeta_sub_one]
 
 include hK in
@@ -234,7 +234,7 @@ theorem inertiaDeg_span_zeta_sub_one' : inertiaDeg' (span {hζ.toInteger - 1}) �
   exact inertiaDeg_span_zeta_sub_one p 0 hζ
 
 theorem ramificationIdx_span_zeta_sub_one' :
-    ramificationIdx' (span {hζ.toInteger - 1}) ℤ = p - 1 := by
+    ramificationIdx (span {hζ.toInteger - 1}) ℤ = p - 1 := by
   rw [← pow_one p] at hK hζ
   rw [ramificationIdx_span_zeta_sub_one p 0 hζ, pow_zero, one_mul]
 
@@ -265,7 +265,7 @@ theorem inertiaDeg_eq_of_prime (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP₂ :
 
 include hK in
 theorem ramificationIdx_eq_of_prime (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver 𝒑] :
-    ramificationIdx' P ℤ = p - 1 := by
+    ramificationIdx P ℤ = p - 1 := by
   rw [eq_span_zeta_sub_one_of_liesOver' p K hK.zeta_spec P, ramificationIdx_span_zeta_sub_one']
 
 include hK in
@@ -315,7 +315,7 @@ theorem inertiaDeg_eq_of_not_dvd (hm : ¬ p ∣ m) :
 alias inertiaDeg_of_not_dvd := inertiaDeg_eq_of_not_dvd
 
 theorem ramificationIdx_eq_of_not_dvd (hm : ¬ p ∣ m) :
-    ramificationIdx' P ℤ = 1 := by
+    ramificationIdx P ℤ = 1 := by
   let ζ := (zeta_spec m ℚ K).toInteger
   have h₁ : ¬ p ∣ exponent ζ := by
     rw [exponent_eq_one_iff.mpr <| adjoin_singleton_eq_top (zeta_spec m ℚ K)]
@@ -433,7 +433,7 @@ theorem inertiaDeg_eq (hn : n = p ^ (k + 1) * m) (hm : ¬ p ∣ m) :
   rw [← inertiaDegIn_eq_inertiaDeg 𝒑 P Gal(K/ℚ), inertiaDegIn_eq n K hn hm]
 
 theorem ramificationIdx_eq (hn : n = p ^ (k + 1) * m) (hm : ¬ p ∣ m) :
-    ramificationIdx' P ℤ = p ^ k * (p - 1) := by
+    ramificationIdx P ℤ = p ^ k * (p - 1) := by
   have : IsGalois ℚ K := isGalois {n} ℚ K
   rw [← ramificationIdxIn_eq_ramificationIdx 𝒑 P Gal(K/ℚ), ramificationIdxIn_eq n K hn hm]
 

--- a/Mathlib/NumberTheory/NumberField/ExistsRamified.lean
+++ b/Mathlib/NumberTheory/NumberField/ExistsRamified.lean
@@ -84,6 +84,6 @@ lemma NumberField.exists_not_isUnramifiedAt_int_of_isGalois [IsGalois ℚ K]
     (map_dvd (algebraMap _ _) p.associated_natAbs.symm.dvd) (by simpa using hQ)
   have : .span {p} = Ideal.under ℤ Q :=
     ((Ideal.liesOver_span_iff Ideal.IsPrime.ne_top' this).mpr hQ).1
-  rwa [← Ideal.ramificationIdx'_eq_one_iff,
+  rwa [← Ideal.ramificationIdx_eq_one_iff,
     ← Ideal.ramificationIdxIn_eq_ramificationIdx (Q.under ℤ) _ Gal(K/ℚ), ← this, ← hp,
-    Ideal.ramificationIdxIn_eq_ramificationIdx _ P Gal(K/ℚ), Ideal.ramificationIdx'_eq_one_iff]
+    Ideal.ramificationIdxIn_eq_ramificationIdx _ P Gal(K/ℚ), Ideal.ramificationIdx_eq_one_iff]

--- a/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
@@ -237,12 +237,12 @@ The ramification index of the ideal corresponding to the class of `Q ∈ ℤ[X]`
 -/
 theorem ramificationIdx_primesOverSpanEquivMonicFactorsMod_symm_apply (hp : ¬ p ∣ exponent θ)
     {Q : ℤ[X]} (hQ : Q.map (Int.castRingHom (ZMod p)) ∈ monicFactorsMod θ p) :
-    ramificationIdx'
+    ramificationIdx
       ((primesOverSpanEquivMonicFactorsMod hp).symm
         ⟨Q.map (Int.castRingHom (ZMod p)), hQ⟩ : Ideal (𝓞 K)) ℤ =
           multiplicity (Q.map (Int.castRingHom (ZMod p)))
             ((minpoly ℤ θ).map (Int.castRingHom (ZMod p))) := by
-  rw [ramificationIdx'_eq_multiplicity (span {↑p}) _ (map_ne_bot_of_ne_bot (by simp [NeZero.ne p]))]
+  rw [ramificationIdx_eq_multiplicity (span {↑p}) _ (map_ne_bot_of_ne_bot (by simp [NeZero.ne p]))]
   · apply multiplicity_eq_of_emultiplicity_eq
     rw [← emultiplicity_map_eq (mapEquiv (Int.quotientSpanNatEquivZMod p).symm),
       emultiplicity_factors_map_eq_emultiplicity inferInstance (by simp [NeZero.ne p])
@@ -255,7 +255,7 @@ theorem ramificationIdx_primesOverSpanEquivMonicFactorsMod_symm_apply (hp : ¬ p
 
 theorem ramificationIdx_primesOverSpanEquivMonicFactorsMod_symm_apply' (hp : ¬ p ∣ exponent θ)
     {Q : (ZMod p)[X]} (hQ : Q ∈ monicFactorsMod θ p) :
-    ramificationIdx'
+    ramificationIdx
       ((primesOverSpanEquivMonicFactorsMod hp).symm ⟨Q, hQ⟩ : Ideal (𝓞 K)) ℤ =
         multiplicity Q ((minpoly ℤ θ).map (Int.castRingHom (ZMod p))) := by
   obtain ⟨S, rfl⟩ := (map_surjective _ (ZMod.ringHom_surjective (Int.castRingHom (ZMod p)))) Q

--- a/Mathlib/NumberTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Basic.lean
@@ -271,12 +271,12 @@ end FinrankQuotientMap
 
 section FactLeComap
 
-local notation "e" => ramificationIdx p P
+local notation "e" => ramificationIdx' p P
 
 /-- `R / p` has a canonical map to `S / (P ^ e)`, where `e` is the ramification index
 of `P` over `p`. -/
 noncomputable instance Quotient.algebraQuotientPowRamificationIdx : Algebra (R ⧸ p) (S ⧸ P ^ e) :=
-  Quotient.algebraQuotientOfLEComap (Ideal.map_le_iff_le_comap.mp le_pow_ramificationIdx)
+  Quotient.algebraQuotientOfLEComap (Ideal.map_le_iff_le_comap.mp le_pow_ramificationIdx')
 
 @[simp]
 theorem Quotient.algebraMap_quotient_pow_ramificationIdx (x : R) :
@@ -289,7 +289,7 @@ This can't be an instance since the map `f : R → S` is generally not inferable
 @[instance_reducible]
 def Quotient.algebraQuotientOfRamificationIdxNeZero [hfp : NeZero e] :
     Algebra (R ⧸ p) (S ⧸ P) :=
-  Quotient.algebraQuotientOfLEComap (le_comap_of_ramificationIdx_ne_zero hfp.out)
+  Quotient.algebraQuotientOfLEComap (le_comap_of_ramificationIdx'_ne_zero hfp.out)
 
 attribute [local instance] Ideal.Quotient.algebraQuotientOfRamificationIdxNeZero
 
@@ -336,7 +336,7 @@ theorem quotientToQuotientRangePowQuotSuccAux_mk {i : ℕ} {a : S} (a_mem : a �
   apply Quotient.map'_mk''
 
 section
-variable [hfp : NeZero (ramificationIdx p P)]
+variable [hfp : NeZero (ramificationIdx' p P)]
 
 /-- `S ⧸ P` embeds into the quotient by `P^(i+1) ⧸ P^e` as a subspace of `P^i ⧸ P^e`. -/
 noncomputable def quotientToQuotientRangePowQuotSucc
@@ -502,13 +502,13 @@ instance Factors.isPrime (P : (factors (map (algebraMap R S) p)).toFinset) :
 
 open scoped Classical in
 theorem Factors.ramificationIdx_ne_zero (P : (factors (map (algebraMap R S) p)).toFinset) :
-    ramificationIdx p P.1 ≠ 0 :=
-  IsDedekindDomain.ramificationIdx_ne_zero (ne_zero_of_mem_factors (Multiset.mem_toFinset.mp P.2))
+    ramificationIdx' p P.1 ≠ 0 :=
+  IsDedekindDomain.ramificationIdx'_ne_zero (ne_zero_of_mem_factors (Multiset.mem_toFinset.mp P.2))
     (Factors.isPrime p P) (Ideal.le_of_dvd (dvd_of_mem_factors (Multiset.mem_toFinset.mp P.2)))
 
 open scoped Classical in
 instance Factors.fact_ramificationIdx_neZero (P : (factors (map (algebraMap R S) p)).toFinset) :
-    NeZero (ramificationIdx p P.1) :=
+    NeZero (ramificationIdx' p P.1) :=
   ⟨Factors.ramificationIdx_ne_zero p P⟩
 
 attribute [local instance] Quotient.algebraQuotientOfRamificationIdxNeZero
@@ -526,15 +526,15 @@ instance Factors.liesOver [p.IsMaximal] (P : (factors (map (algebraMap R S) p)).
 open scoped Classical in
 theorem Factors.finrank_pow_ramificationIdx [p.IsMaximal]
     (P : (factors (map (algebraMap R S) p)).toFinset) :
-    finrank (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx p P.1) =
-      ramificationIdx p P.1 * inertiaDeg p (P : Ideal S) := by
+    finrank (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx' p P.1) =
+      ramificationIdx' p P.1 * inertiaDeg p (P : Ideal S) := by
   rw [finrank_prime_pow_ramificationIdx, inertiaDeg_algebraMap]
   exacts [Factors.ne_bot p P, NeZero.ne _]
 
 open scoped Classical in
 instance Factors.finiteDimensional_quotient_pow [Module.Finite R S] [p.IsMaximal]
     (P : (factors (map (algebraMap R S) p)).toFinset) :
-    FiniteDimensional (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx p P.1) := by
+    FiniteDimensional (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx' p P.1) := by
   refine .of_finrank_pos ?_
   rw [pos_iff_ne_zero, Factors.finrank_pow_ramificationIdx]
   exact mul_ne_zero (Factors.ramificationIdx_ne_zero p P) (inertiaDeg_pos p P.1).ne'
@@ -547,14 +547,14 @@ factors in `S` as `∏ i, P i ^ e i`, then `S ⧸ I` factors as `Π i, R ⧸ (P 
 noncomputable def Factors.piQuotientEquiv (p : Ideal R) (hp : map (algebraMap R S) p ≠ ⊥) :
     S ⧸ map (algebraMap R S) p ≃+*
       ∀ P : (factors (map (algebraMap R S) p)).toFinset,
-        S ⧸ (P : Ideal S) ^ ramificationIdx p P.1 :=
+        S ⧸ (P : Ideal S) ^ ramificationIdx' p P.1 :=
   (IsDedekindDomain.quotientEquivPiFactors hp).trans <|
     @RingEquiv.piCongrRight (factors (map (algebraMap R S) p)).toFinset
       (fun P => S ⧸ (P : Ideal S) ^ (factors (map (algebraMap R S) p)).count (P : Ideal S))
-      (fun P => S ⧸ (P : Ideal S) ^ ramificationIdx p P.1) _ _
+      (fun P => S ⧸ (P : Ideal S) ^ ramificationIdx' p P.1) _ _
       fun P : (factors (map (algebraMap R S) p)).toFinset =>
       Ideal.quotEquivOfEq <| by
-        rw [IsDedekindDomain.ramificationIdx_eq_factors_count hp (Factors.isPrime p P)
+        rw [IsDedekindDomain.ramificationIdx'_eq_factors_count hp (Factors.isPrime p P)
             (Factors.ne_bot p P)]
 
 @[simp]
@@ -575,7 +575,7 @@ then `S ⧸ I` factors `R ⧸ I`-linearly as `Π i, R ⧸ (P i ^ e i)`. -/
 noncomputable def Factors.piQuotientLinearEquiv (p : Ideal R) (hp : map (algebraMap R S) p ≠ ⊥) :
     (S ⧸ map (algebraMap R S) p) ≃ₗ[R ⧸ p]
       ∀ P : (factors (map (algebraMap R S) p)).toFinset,
-        S ⧸ (P : Ideal S) ^ ramificationIdx p P.1 :=
+        S ⧸ (P : Ideal S) ^ ramificationIdx' p P.1 :=
   { Factors.piQuotientEquiv p hp with
     map_smul' := by
       rintro ⟨c⟩ ⟨x⟩; ext P
@@ -595,8 +595,8 @@ here `S` is a finite `R`-module (and thus `Frac(S) : Frac(R)` is a finite extens
 is maximal. -/
 theorem sum_ramification_inertia {p : Ideal R} [p.IsMaximal] (hp0 : p ≠ ⊥) :
     ∑ P ∈ IsDedekindDomain.primesOverFinset p S,
-        ramificationIdx p P * inertiaDeg p P = finrank K L := by
-  set e := ramificationIdx p (S := S)
+        ramificationIdx' p P * inertiaDeg p P = finrank K L := by
+  set e := ramificationIdx' p (S := S)
   calc
     ∑ P ∈ (factors (map (algebraMap R S) p)).toFinset, e P * inertiaDeg p P =
         ∑ P ∈ (factors (map (algebraMap R S) p)).toFinset.attach,
@@ -622,11 +622,11 @@ theorem inertiaDeg_le_finrank [NoZeroSMulDivisors R S] {p : Ideal R} [p.IsMaxima
     (IsDedekindDomain.mem_primesOverFinset_iff hp0 _).mpr ⟨hP₁, hP₂⟩
   rw [← sum_ramification_inertia S K L hp0, ← Finset.add_sum_erase _ _ hP]
   refine le_trans (Nat.le_mul_of_pos_left _ ?_) (Nat.le_add_right _ _)
-  exact Nat.pos_iff_ne_zero.mpr <| IsDedekindDomain.ramificationIdx_ne_zero_of_liesOver _ hp0
+  exact Nat.pos_iff_ne_zero.mpr <| IsDedekindDomain.ramificationIdx'_ne_zero_of_liesOver _ hp0
 
 theorem ramificationIdx_le_finrank [NoZeroSMulDivisors R S] {p : Ideal R} [p.IsMaximal]
     (P : Ideal S) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver p] :
-    p.ramificationIdx P ≤ Module.finrank K L := by
+    p.ramificationIdx' P ≤ Module.finrank K L := by
   classical
   by_cases hp0 : p = ⊥
   · simp [hp0]
@@ -643,13 +643,13 @@ theorem card_primesOverFinset_le_finrank [NoZeroSMulDivisors R S] {p : Ideal R} 
   have : P.IsPrime := ((IsDedekindDomain.mem_primesOverFinset_iff hp0 _).mp hP).1
   have : P.LiesOver p := ((IsDedekindDomain.mem_primesOverFinset_iff hp0 _).mp hP).2
   refine Right.one_le_mul ?_ ?_
-  · exact Nat.pos_iff_ne_zero.mpr <| IsDedekindDomain.ramificationIdx_ne_zero_of_liesOver _ hp0
+  · exact Nat.pos_iff_ne_zero.mpr <| IsDedekindDomain.ramificationIdx'_ne_zero_of_liesOver _ hp0
   · exact Nat.pos_iff_ne_zero.mpr <| inertiaDeg_ne_zero p P
 
 /-- `Ideal.sum_ramification_inertia`, in the local (DVR) case. -/
 lemma ramificationIdx_mul_inertiaDeg_of_isLocalRing [IsLocalRing S] {p : Ideal R} [p.IsMaximal]
     (hp0 : p ≠ ⊥) :
-    ramificationIdx p (IsLocalRing.maximalIdeal S) *
+    ramificationIdx' p (IsLocalRing.maximalIdeal S) *
       p.inertiaDeg (IsLocalRing.maximalIdeal S) = Module.finrank K L := by
   have := FaithfulSMul.of_field_isFractionRing R S K L
   simp_rw [← sum_ramification_inertia S K L hp0, IsLocalRing.primesOverFinset_eq S hp0,

--- a/Mathlib/NumberTheory/RamificationInertia/Galois.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Galois.lean
@@ -58,7 +58,7 @@ open scoped Classical in
   maximal ideal `p` of `A` are the same, which we define as `Ideal.ramificationIdxIn`. -/
 noncomputable def ramificationIdxIn {A : Type*} [CommRing A] (p : Ideal A)
     (B : Type*) [CommRing B] [Algebra A B] : ℕ :=
-  if h : ∃ P : Ideal B, P.IsPrime ∧ P.LiesOver p then h.choose.ramificationIdx' A
+  if h : ∃ P : Ideal B, P.IsPrime ∧ P.LiesOver p then h.choose.ramificationIdx A
   else 0
 
 open scoped Classical in
@@ -138,9 +138,9 @@ instance isPretransitive_of_isGaloisGroup : MulAction.IsPretransitive G (primesO
 include p G in
 /-- All the `Ideal.ramificationIdx` over a fixed maximal ideal are the same. -/
 theorem ramificationIdx_eq_of_isGaloisGroup :
-    P.ramificationIdx' A = Q.ramificationIdx' A := by
+    P.ramificationIdx A = Q.ramificationIdx A := by
   rcases exists_smul_eq_of_isGaloisGroup p P Q G with ⟨σ, rfl⟩
-  rw [ramificationIdx'_smul]
+  rw [ramificationIdx_smul]
 
 include p G in
 /-- All the `Ideal.inertiaDeg` over a fixed maximal ideal are the same. -/
@@ -152,7 +152,7 @@ theorem inertiaDeg_eq_of_isGaloisGroup :
 include p G in
 /-- The `ramificationIdxIn` is equal to any ramification index over the same ideal. -/
 theorem ramificationIdxIn_eq_ramificationIdx :
-    ramificationIdxIn p B = P.ramificationIdx' A := by
+    ramificationIdxIn p B = P.ramificationIdx A := by
   have h : ∃ P : Ideal B, P.IsPrime ∧ P.LiesOver p := ⟨P, hPp, hp⟩
   obtain ⟨_, _⟩ := h.choose_spec
   rw [ramificationIdxIn, dif_pos h]
@@ -163,7 +163,7 @@ theorem ramificationIdxIn_ne_zero [Module.Finite A B] [FaithfulSMul A B] {p : Id
     p.ramificationIdxIn B ≠ 0 := by
   obtain ⟨P⟩ := (inferInstance : Nonempty (primesOver p B))
   rw [ramificationIdxIn_eq_ramificationIdx p P G]
-  exact (P.1.ramificationIdx'_pos A).ne'
+  exact (P.1.ramificationIdx_pos A).ne'
 
 include G in
 /-- The `inertiaDegIn` is equal to any ramification index over the same ideal. -/
@@ -203,7 +203,7 @@ theorem ramificationIdxIn_mul_ramificationIdxIn [Flat B C] :
   obtain ⟨⟨Q, _, hQ⟩⟩ := (inferInstance : Nonempty (primesOver P C))
   have : Q.LiesOver p := LiesOver.trans Q P p
   rw [ramificationIdxIn_eq_ramificationIdx p P G, ramificationIdxIn_eq_ramificationIdx p Q GAC,
-    ramificationIdxIn_eq_ramificationIdx P Q GBC, ← ramificationIdx'_tower P Q]
+    ramificationIdxIn_eq_ramificationIdx P Q GBC, ← ramificationIdx_tower P Q]
 
 @[deprecated (since := "2026-06-18")] alias ramificationIdxIn_mul_ramificationIdxIn' :=
   ramificationIdxIn_mul_ramificationIdxIn

--- a/Mathlib/NumberTheory/RamificationInertia/HilbertTheory.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/HilbertTheory.lean
@@ -294,7 +294,7 @@ private lemma ramificationIdxIn_eq_and_inertiaDegIn_eq (hp : p ≠ ⊥) :
   · exact Nat.pos_of_ne_zero <| inertiaDegIn_ne_zero (stabilizer Gal(L/K) P)
   · rw [ramificationIdxIn_eq_ramificationIdx p P Gal(L/K),
       ramificationIdxIn_eq_ramificationIdx _ P (stabilizer Gal(L/K) P)]
-    exact 𝓟D.ramificationIdx'_above_le P
+    exact 𝓟D.ramificationIdx_above_le P
   · rw [inertiaDegIn_eq_inertiaDeg p P Gal(L/K),
       inertiaDegIn_eq_inertiaDeg _ P (stabilizer Gal(L/K) P)]
     rw [← inertiaDeg_eq_inertiaDeg' p, ← inertiaDeg_eq_inertiaDeg' 𝓟D]
@@ -328,12 +328,12 @@ Let `D` be the decomposition field of `P` in `L/K`. Let `𝓟D` be a prime ideal
 then `𝓟D` is unramified over `K`.
 -/
 theorem ramificationIdx_eq (hp : p ≠ ⊥) :
-    𝓟D.ramificationIdx' A = 1 := by
+    𝓟D.ramificationIdx A = 1 := by
   obtain ⟨_, _, _, _, _, h𝓟⟩ := instances A K L P D 𝓞D 𝓟D hp
-  have := ramificationIdx'_tower (R := A) 𝓟D P
+  have := ramificationIdx_tower (R := A) 𝓟D P
   rwa [← ramificationIdxIn_eq_ramificationIdx 𝓟D P (stabilizer Gal(L/K) P),
     ramificationIdxIn_eq A K L P D 𝓞D 𝓟D hp, ramificationIdxIn_eq_ramificationIdx p P Gal(L/K),
-    right_eq_mul₀ <| (ramificationIdx'_pos P A).ne'] at this
+    right_eq_mul₀ <| (ramificationIdx_pos P A).ne'] at this
 
 include K L D P in
 /--

--- a/Mathlib/NumberTheory/RamificationInertia/Ramification.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Ramification.lean
@@ -14,7 +14,7 @@ public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
 
 Given `P : Ideal S` lying over `p : Ideal R` for the ring extension `f : R →+* S`
 (assuming `P` and `p` are prime or maximal where needed),
-the **ramification index** `Ideal.ramificationIdx p P` is the multiplicity of `P` in `map f p`.
+the **ramification index** `Ideal.ramificationIdx' p P` is the multiplicity of `P` in `map f p`.
 
 ## Implementation notes
 
@@ -59,38 +59,44 @@ section DecEq
 
 In particular, if `p` is not contained in `P^n`, then the ramification index is 0.
 
-If there is no largest such `n` (e.g. because `p = ⊥`), then `ramificationIdx` is
+If there is no largest such `n` (e.g. because `p = ⊥`), then `ramificationIdx'` is
 defined to be 0.
 
-Note: This definition of ramification index will eventually be replaced by `Ideal.ramificationIdx'`.
+Note: This definition of ramification index will eventually be replaced by `Ideal.ramificationIdx`.
 -/
-noncomputable def ramificationIdx : ℕ := sSup {n | map f p ≤ P ^ n}
+noncomputable def ramificationIdx' : ℕ := sSup {n | map f p ≤ P ^ n}
 
 variable {p P}
 
-theorem ramificationIdx_eq_find [DecidablePred fun n ↦ ∀ (k : ℕ), map f p ≤ P ^ k → k ≤ n]
+theorem ramificationIdx'_eq_find [DecidablePred fun n ↦ ∀ (k : ℕ), map f p ≤ P ^ k → k ≤ n]
     (h : ∃ n, ∀ k, map f p ≤ P ^ k → k ≤ n) :
-    ramificationIdx p P = Nat.find h := by
+    ramificationIdx' p P = Nat.find h := by
   convert! Nat.sSup_def h
 
-theorem ramificationIdx_eq_zero (h : ∀ n : ℕ, ∃ k, map f p ≤ P ^ k ∧ n < k) :
-    ramificationIdx p P = 0 :=
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_eq_find := ramificationIdx'_eq_find
+
+theorem ramificationIdx'_eq_zero (h : ∀ n : ℕ, ∃ k, map f p ≤ P ^ k ∧ n < k) :
+    ramificationIdx' p P = 0 :=
   dif_neg (by push Not; exact h)
 
-theorem ramificationIdx_spec {n : ℕ} (hle : map f p ≤ P ^ n) (hgt : ¬map f p ≤ P ^ (n + 1)) :
-    ramificationIdx p P = n := by
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_eq_zero := ramificationIdx'_eq_zero
+
+theorem ramificationIdx'_spec {n : ℕ} (hle : map f p ≤ P ^ n) (hgt : ¬map f p ≤ P ^ (n + 1)) :
+    ramificationIdx' p P = n := by
   classical
   let Q : ℕ → Prop := fun m => ∀ k : ℕ, map f p ≤ P ^ k → k ≤ m
   have : Q n := by
     intro k hk
     refine le_of_not_gt fun hnk => ?_
     exact hgt (hk.trans (Ideal.pow_le_pow_right hnk))
-  rw [ramificationIdx_eq_find ⟨n, this⟩]
+  rw [ramificationIdx'_eq_find ⟨n, this⟩]
   refine le_antisymm (Nat.find_min' _ this) (le_of_not_gt fun h : Nat.find _ < n => ?_)
   obtain this' := Nat.find_spec ⟨n, this⟩
   exact h.not_ge (this' _ hle)
 
-theorem ramificationIdx_lt {n : ℕ} (hgt : ¬map f p ≤ P ^ n) : ramificationIdx p P < n := by
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_spec := ramificationIdx'_spec
+
+theorem ramificationIdx'_lt {n : ℕ} (hgt : ¬map f p ≤ P ^ n) : ramificationIdx' p P < n := by
   classical
   rcases n with - | n
   · simp at hgt
@@ -98,45 +104,66 @@ theorem ramificationIdx_lt {n : ℕ} (hgt : ¬map f p ≤ P ^ n) : ramificationI
     have : ∀ k, map f p ≤ P ^ k → k ≤ n := by
       refine fun k hk => le_of_not_gt fun hnk => ?_
       exact hgt (hk.trans (Ideal.pow_le_pow_right hnk))
-    rw [ramificationIdx_eq_find ⟨n, this⟩]
+    rw [ramificationIdx'_eq_find ⟨n, this⟩]
     exact Nat.find_min' ⟨n, this⟩ this
 
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_lt := ramificationIdx'_lt
+
 @[simp]
-theorem ramificationIdx_bot : ramificationIdx (⊥ : Ideal R) P = 0 :=
+theorem ramificationIdx'_bot : ramificationIdx' (⊥ : Ideal R) P = 0 :=
   dif_neg <| not_exists.mpr fun n hn => n.lt_succ_self.not_ge (hn _ (by simp))
 
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_bot := ramificationIdx'_bot
+
 @[simp]
-theorem ramificationIdx_of_not_le (h : ¬map f p ≤ P) : ramificationIdx p P = 0 :=
-  ramificationIdx_spec (by simp) (by simpa using h)
+theorem ramificationIdx'_of_not_le (h : ¬map f p ≤ P) : ramificationIdx' p P = 0 :=
+  ramificationIdx'_spec (by simp) (by simpa using h)
 
-theorem ramificationIdx_bot' (hp : p ≠ ⊥) (hf : Function.Injective f) :
-    ramificationIdx p (⊥ : Ideal S) = 0 :=
-  ramificationIdx_of_not_le <| le_bot_iff.not.mpr <| (map_eq_bot_iff_of_injective hf).not.mpr hp
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_of_not_le := ramificationIdx'_of_not_le
 
-theorem ramificationIdx_ne_zero {e : ℕ} (he : e ≠ 0) (hle : map f p ≤ P ^ e)
-    (hnle : ¬map f p ≤ P ^ (e + 1)) : ramificationIdx p P ≠ 0 := by
-  rwa [ramificationIdx_spec hle hnle]
+theorem ramificationIdx'_bot' (hp : p ≠ ⊥) (hf : Function.Injective f) :
+    ramificationIdx' p (⊥ : Ideal S) = 0 :=
+  ramificationIdx'_of_not_le <| le_bot_iff.not.mpr <| (map_eq_bot_iff_of_injective hf).not.mpr hp
 
-theorem le_pow_of_le_ramificationIdx {n : ℕ} (hn : n ≤ ramificationIdx p P) :
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_bot' := ramificationIdx'_bot'
+
+theorem ramificationIdx'_ne_zero {e : ℕ} (he : e ≠ 0) (hle : map f p ≤ P ^ e)
+    (hnle : ¬map f p ≤ P ^ (e + 1)) : ramificationIdx' p P ≠ 0 := by
+  rwa [ramificationIdx'_spec hle hnle]
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_ne_zero := ramificationIdx'_ne_zero
+
+theorem le_pow_of_le_ramificationIdx' {n : ℕ} (hn : n ≤ ramificationIdx' p P) :
     map f p ≤ P ^ n := by
   contrapose! hn
-  exact ramificationIdx_lt hn
+  exact ramificationIdx'_lt hn
 
-theorem le_pow_ramificationIdx : map f p ≤ P ^ ramificationIdx p P :=
-  le_pow_of_le_ramificationIdx (le_refl _)
+@[deprecated (since := "2026-07-01")] alias le_pow_of_le_ramificationIdx :=
+  le_pow_of_le_ramificationIdx'
 
-theorem le_comap_pow_ramificationIdx : p ≤ comap f (P ^ ramificationIdx p P) :=
-  map_le_iff_le_comap.mp le_pow_ramificationIdx
+theorem le_pow_ramificationIdx' : map f p ≤ P ^ ramificationIdx' p P :=
+  le_pow_of_le_ramificationIdx' (le_refl _)
 
-theorem le_comap_of_ramificationIdx_ne_zero (h : ramificationIdx p P ≠ 0) : p ≤ comap f P :=
-  Ideal.map_le_iff_le_comap.mp <| le_pow_ramificationIdx.trans <| Ideal.pow_le_self <| h
+@[deprecated (since := "2026-07-01")] alias le_pow_ramificationIdx := le_pow_ramificationIdx'
+
+theorem le_comap_pow_ramificationIdx' : p ≤ comap f (P ^ ramificationIdx' p P) :=
+  map_le_iff_le_comap.mp le_pow_ramificationIdx'
+
+@[deprecated (since := "2026-07-01")] alias le_comap_pow_ramificationIdx :=
+  le_comap_pow_ramificationIdx'
+
+theorem le_comap_of_ramificationIdx'_ne_zero (h : ramificationIdx' p P ≠ 0) : p ≤ comap f P :=
+  Ideal.map_le_iff_le_comap.mp <| le_pow_ramificationIdx'.trans <| Ideal.pow_le_self <| h
+
+@[deprecated (since := "2026-07-01")] alias le_comap_of_ramificationIdx_ne_zero :=
+  le_comap_of_ramificationIdx'_ne_zero
 
 variable {S₁ : Type*} [CommRing S₁] [Algebra R S₁]
 
 variable (p) in
-lemma ramificationIdx_comap_eq (e : S ≃ₐ[R] S₁) (P : Ideal S₁) :
-    ramificationIdx p (P.comap e) = ramificationIdx p P := by
-  dsimp only [ramificationIdx]
+lemma ramificationIdx'_comap_eq (e : S ≃ₐ[R] S₁) (P : Ideal S₁) :
+    ramificationIdx' p (P.comap e) = ramificationIdx' p P := by
+  dsimp only [ramificationIdx']
   congr 1
   ext n
   simp only [Set.mem_setOf_eq, Ideal.map_le_iff_le_comap]
@@ -145,20 +172,24 @@ lemma ramificationIdx_comap_eq (e : S ≃ₐ[R] S₁) (P : Ideal S₁) :
     comap_comap, RingEquiv.symm_symm, e.toRingEquiv_toRingHom, ← e.toAlgHom_toRingHom,
     AlgHom.comp_algebraMap]
 
-variable (p) in
-lemma ramificationIdx_map_eq {E : Type*} [EquivLike E S S₁] [AlgEquivClass E R S S₁]
-    (P : Ideal S) (e : E) :
-    ramificationIdx p (P.map e) = ramificationIdx p P := by
-  rw [show P.map e = _ from P.map_comap_of_equiv (RingEquivClass.toRingEquiv e : S ≃+* S₁)]
-  exact p.ramificationIdx_comap_eq (AlgEquivClass.toAlgEquiv e).symm P
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_comap_eq := ramificationIdx'_comap_eq
 
-lemma ramificationIdx_ne_one_iff (hp : map f p ≤ P) :
-    ramificationIdx p P ≠ 1 ↔ p.map f ≤ P ^ 2 := by
+variable (p) in
+lemma ramificationIdx'_map_eq {E : Type*} [EquivLike E S S₁] [AlgEquivClass E R S S₁]
+    (P : Ideal S) (e : E) :
+    ramificationIdx' p (P.map e) = ramificationIdx' p P := by
+  rw [show P.map e = _ from P.map_comap_of_equiv (RingEquivClass.toRingEquiv e : S ≃+* S₁)]
+  exact p.ramificationIdx'_comap_eq (AlgEquivClass.toAlgEquiv e).symm P
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_map_eq := ramificationIdx'_map_eq
+
+lemma ramificationIdx'_ne_one_iff (hp : map f p ≤ P) :
+    ramificationIdx' p P ≠ 1 ↔ p.map f ≤ P ^ 2 := by
   classical
   by_cases! H : ∀ n : ℕ, ∃ k, p.map f ≤ P ^ k ∧ n < k
   · obtain ⟨k, hk, h2k⟩ := H 2
-    simp [Ideal.ramificationIdx_eq_zero H, hk.trans (Ideal.pow_le_pow_right h2k.le)]
-  rw [Ideal.ramificationIdx_eq_find H]
+    simp [Ideal.ramificationIdx'_eq_zero H, hk.trans (Ideal.pow_le_pow_right h2k.le)]
+  rw [Ideal.ramificationIdx'_eq_find H]
   constructor
   · intro he
     have : 1 ≤ Nat.find H := Nat.find_spec H 1 (by simpa)
@@ -170,15 +201,18 @@ lemma ramificationIdx_ne_one_iff (hp : map f p ≤ P) :
     have := Nat.find_spec H 2 he
     lia
 
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_ne_one_iff :=
+  ramificationIdx'_ne_one_iff
+
 open IsLocalRing in
 /-- The converse is true when `S` is a Dedekind domain.
-See `Ideal.ramificationIdx_eq_one_iff_of_isDedekindDomain`. -/
-lemma ramificationIdx_eq_one_of_map_localization
+See `Ideal.ramificationIdx'_eq_one_iff_of_isDedekindDomain`. -/
+lemma ramificationIdx'_eq_one_of_map_localization
     {p : Ideal R} {P : Ideal S} [P.IsPrime] [IsNoetherianRing S]
     (hpP : map (algebraMap R S) p ≤ P) (hp : P ≠ ⊥) (hp' : P.primeCompl ≤ nonZeroDivisors S)
     (H : p.map (algebraMap R (Localization.AtPrime P)) = maximalIdeal (Localization.AtPrime P)) :
-    ramificationIdx p P = 1 := by
-  rw [← not_ne_iff (b := 1), Ideal.ramificationIdx_ne_one_iff hpP]
+    ramificationIdx' p P = 1 := by
+  rw [← not_ne_iff (b := 1), Ideal.ramificationIdx'_ne_one_iff hpP]
   intro h₂
   replace h₂ := Ideal.map_mono («f» := algebraMap S (Localization.AtPrime P)) h₂
   rw [Ideal.map_pow, Localization.AtPrime.map_eq_maximalIdeal, Ideal.map_map,
@@ -189,82 +223,96 @@ lemma ramificationIdx_eq_one_of_map_localization
   · exact hp this
   · exact IsLocalization.injective _ hp'
 
-theorem ramificationIdx_map_self_eq_one [IsDedekindDomain S] (h₁ : map f p ≠ ⊤) (h₂ : map f p ≠ ⊥) :
-    ramificationIdx p (map f p) = 1 := by
-  refine ramificationIdx_spec (by simp) fun h ↦ ?_
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_eq_one_of_map_localization :=
+  ramificationIdx'_eq_one_of_map_localization
+
+theorem ramificationIdx'_map_self_eq_one [IsDedekindDomain S]
+    (h₁ : map f p ≠ ⊤) (h₂ : map f p ≠ ⊥) : ramificationIdx' p (map f p) = 1 := by
+  refine ramificationIdx'_spec (by simp) fun h ↦ ?_
   have : map f p ^ 1 = (map f p) ^ 2 := by
     rw [pow_one]
     exact le_antisymm h <| pow_le_self two_ne_zero
   have := IsMulTorsionFree.pow_right_injective₀ (by rwa [one_eq_top]) h₂ this
   simp_all
 
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_map_self_eq_one :=
+  ramificationIdx'_map_self_eq_one
+
 variable (p P) in
-theorem ramificationIdx_le_ramificationIdx {T : Type*} [CommRing T] [Algebra R T]
+theorem ramificationIdx'_le_ramificationIdx' {T : Type*} [CommRing T] [Algebra R T]
     [Algebra S T] [IsScalarTower R S T] (Q : Ideal T) (hp : p = comap f P)
-    (h : ramificationIdx p Q ≠ 0) : ramificationIdx P Q ≤ ramificationIdx p Q := by
-  simp_rw [ramificationIdx, Ne] at *
+    (h : ramificationIdx' p Q ≠ 0) : ramificationIdx' P Q ≤ ramificationIdx' p Q := by
+  simp_rw [ramificationIdx', Ne] at *
   refine csSup_le_csSup' (h.imp_symm Nat.sSup_of_not_bddAbove) fun n hn ↦ ?_
   simp_rw [hp, IsScalarTower.algebraMap_eq R S T, ← map_map, map_le_iff_le_comap]
   exact comap_mono <| by rwa [← map_le_iff_le_comap]
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_le_ramificationIdx :=
+  ramificationIdx'_le_ramificationIdx'
 
 namespace IsDedekindDomain
 
 variable [IsDedekindDomain S]
 
-theorem ramificationIdx_eq_normalizedFactors_count
+theorem ramificationIdx'_eq_normalizedFactors_count
     (hp0 : map f p ≠ ⊥) (hP : P.IsPrime)
-    (hP0 : P ≠ ⊥) : ramificationIdx p P = (normalizedFactors (map f p)).count P := by
+    (hP0 : P ≠ ⊥) : ramificationIdx' p P = (normalizedFactors (map f p)).count P := by
   have hPirr := (Ideal.prime_of_isPrime hP0 hP).irreducible
-  refine ramificationIdx_spec (Ideal.le_of_dvd ?_) (mt Ideal.dvd_iff_le.mpr ?_) <;>
+  refine ramificationIdx'_spec (Ideal.le_of_dvd ?_) (mt Ideal.dvd_iff_le.mpr ?_) <;>
     rw [dvd_iff_normalizedFactors_le_normalizedFactors (pow_ne_zero _ hP0) hp0,
       normalizedFactors_pow, normalizedFactors_irreducible hPirr, normalize_eq,
       Multiset.nsmul_singleton, ← Multiset.le_count_iff_replicate_le]
   exact (Nat.lt_succ_self _).not_ge
 
-theorem ramificationIdx_eq_multiplicity (hp : map f p ≠ ⊥) (hP : P.IsPrime) :
-    ramificationIdx p P = multiplicity P (Ideal.map f p) := by
+theorem ramificationIdx'_eq_multiplicity (hp : map f p ≠ ⊥) (hP : P.IsPrime) :
+    ramificationIdx' p P = multiplicity P (Ideal.map f p) := by
   classical
   by_cases hP₂ : P = ⊥
   · rw [hP₂, ← Ideal.zero_eq_bot, multiplicity_zero_eq_zero_of_ne_zero _ hp]
-    exact Ideal.ramificationIdx_of_not_le (mt le_bot_iff.mp hp)
+    exact Ideal.ramificationIdx'_of_not_le (mt le_bot_iff.mp hp)
   rw [multiplicity_eq_of_emultiplicity_eq_some]
-  rw [ramificationIdx_eq_normalizedFactors_count hp hP hP₂, ← normalize_eq P,
+  rw [ramificationIdx'_eq_normalizedFactors_count hp hP hP₂, ← normalize_eq P,
     ← UniqueFactorizationMonoid.emultiplicity_eq_count_normalizedFactors _ hp, normalize_eq]
   exact irreducible_iff_prime.mpr <| prime_of_isPrime hP₂ hP
 
-theorem ramificationIdx_eq_factors_count
+theorem ramificationIdx'_eq_factors_count
     (hp0 : map f p ≠ ⊥) (hP : P.IsPrime) (hP0 : P ≠ ⊥) :
-    ramificationIdx p P = (factors (map f p)).count P := by
-  rw [IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hp0 hP hP0,
+    ramificationIdx' p P = (factors (map f p)).count P := by
+  rw [IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count hp0 hP hP0,
     factors_eq_normalizedFactors]
 
-theorem ramificationIdx_ne_zero (hp0 : map f p ≠ ⊥) (hP : P.IsPrime) (le : map f p ≤ P) :
-    ramificationIdx p P ≠ 0 := by
+theorem ramificationIdx'_ne_zero (hp0 : map f p ≠ ⊥) (hP : P.IsPrime) (le : map f p ≤ P) :
+    ramificationIdx' p P ≠ 0 := by
   classical
   have hP0 : P ≠ ⊥ := by
     rintro rfl
     exact hp0 (le_bot_iff.mp le)
   have hPirr := (Ideal.prime_of_isPrime hP0 hP).irreducible
-  rw [IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hp0 hP hP0]
+  rw [IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count hp0 hP hP0]
   obtain ⟨P', hP', P'_eq⟩ :=
     exists_mem_normalizedFactors_of_dvd hp0 hPirr (Ideal.dvd_iff_le.mpr le)
   rwa [Multiset.count_ne_zero, associated_iff_eq.mp P'_eq]
 
-theorem ramificationIdx_ne_zero_of_liesOver [IsDomain R] [IsTorsionFree R S]
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_ne_zero := ramificationIdx'_ne_zero
+
+theorem ramificationIdx'_ne_zero_of_liesOver [IsDomain R] [IsTorsionFree R S]
     (P : Ideal S) [hP : P.IsPrime] {p : Ideal R} (hp : p ≠ ⊥) [hPp : P.LiesOver p] :
-    ramificationIdx p P ≠ 0 :=
-  IsDedekindDomain.ramificationIdx_ne_zero (map_ne_bot_of_ne_bot hp) hP <|
+    ramificationIdx' p P ≠ 0 :=
+  IsDedekindDomain.ramificationIdx'_ne_zero (map_ne_bot_of_ne_bot hp) hP <|
     map_le_iff_le_comap.mpr <| le_of_eq <| (liesOver_iff _ _).mp hPp
 
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_ne_zero_of_liesOver :=
+  ramificationIdx'_ne_zero_of_liesOver
+
 open IsLocalRing in
-lemma ramificationIdx_eq_one_iff
+lemma ramificationIdx'_eq_one_iff
     {p : Ideal R} {P : Ideal S} [P.IsPrime]
     (hp : P ≠ ⊥) (hpP : p.map (algebraMap R S) ≤ P) :
-    ramificationIdx p P = 1 ↔
+    ramificationIdx' p P = 1 ↔
       p.map (algebraMap R (Localization.AtPrime P)) = maximalIdeal (Localization.AtPrime P) := by
-  refine ⟨?_, ramificationIdx_eq_one_of_map_localization hpP hp (primeCompl_le_nonZeroDivisors _)⟩
+  refine ⟨?_, ramificationIdx'_eq_one_of_map_localization hpP hp (primeCompl_le_nonZeroDivisors _)⟩
   let Sₚ := Localization.AtPrime P
-  rw [← not_ne_iff (b := 1), ramificationIdx_ne_one_iff hpP, pow_two]
+  rw [← not_ne_iff (b := 1), ramificationIdx'_ne_one_iff hpP, pow_two]
   intro H₁
   obtain ⟨a, ha⟩ : P ∣ p.map (algebraMap R S) := Ideal.dvd_iff_le.mpr hpP
   have ha' : ¬ a ≤ P := fun h ↦ H₁ (ha.trans_le (Ideal.mul_mono_right h))
@@ -275,12 +323,18 @@ lemma ramificationIdx_eq_one_iff
   rw [← not_ne_iff, IsLocalization.map_algebraMap_ne_top_iff_disjoint P.primeCompl]
   simpa [primeCompl, Set.disjoint_compl_left_iff_subset]
 
-theorem ramificationIdx_le_ramificationIdx [IsDomain R] [IsTorsionFree R S] {S₀ : Type*}
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_eq_one_iff :=
+  ramificationIdx'_eq_one_iff
+
+theorem ramificationIdx'_le_ramificationIdx' [IsDomain R] [IsTorsionFree R S] {S₀ : Type*}
     [CommRing S₀] [Algebra R S₀] [Algebra S₀ S] [IsScalarTower R S₀ S] (p : Ideal R)
     (P : Ideal S₀) (Q : Ideal S) [Q.LiesOver p] [hP : P.LiesOver p] [Q.IsPrime] (hp : p ≠ ⊥) :
-    Ideal.ramificationIdx P Q ≤ Ideal.ramificationIdx p Q :=
-  p.ramificationIdx_le_ramificationIdx P Q ((liesOver_iff ..).mp hP) <|
-    ramificationIdx_ne_zero_of_liesOver _ hp
+    Ideal.ramificationIdx' P Q ≤ Ideal.ramificationIdx' p Q :=
+  p.ramificationIdx'_le_ramificationIdx' P Q ((liesOver_iff ..).mp hP) <|
+    ramificationIdx'_ne_zero_of_liesOver _ hp
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_le_ramificationIdx :=
+  ramificationIdx'_le_ramificationIdx'
 
 theorem emultiplicity_map_eq_zero_of_ne [IsDedekindDomain R] {v : Ideal R}
     {w : Ideal S} {p : Ideal R} (hv : Irreducible v) (hp : Prime p) (hvp : v ≠ p) [w.LiesOver v] :
@@ -289,17 +343,17 @@ theorem emultiplicity_map_eq_zero_of_ne [IsDedekindDomain R] {v : Ideal R}
   rw [Ideal.dvd_iff_le, Ideal.map_le_iff_le_comap, ← under_def, ← Ideal.over_def w v] at h
   exact ((isPrime_of_prime hp).isMaximal hp.ne_zero).eq_of_le (isPrime_of_prime hv.prime).ne_top h
 
-/-- Use the more general result `emultiplicity_map_eq_ramificationIdx_mul`.
+/-- Use the more general result `emultiplicity_map_eq_ramificationIdx'_mul`.
 This is a helper lemma. -/
-private theorem emultiplicity_map_eq_ramificationIdx_mul_of_prime [IsDedekindDomain R]
+private theorem emultiplicity_map_eq_ramificationIdx'_mul_of_prime [IsDedekindDomain R]
     [FaithfulSMul R S] {v : Ideal R} {w : Ideal S} {p : Ideal R}
     (hv : Irreducible v) (hp : Prime p) (hw : Irreducible w) (hw_bot : w ≠ ⊥)
     [w.LiesOver v] : emultiplicity w (p.map (algebraMap R S)) =
-      v.ramificationIdx w * emultiplicity v p := by
+      v.ramificationIdx' w * emultiplicity v p := by
   have hp_bot : p.map (algebraMap R S) ≠ ⊥ := map_ne_bot_of_ne_bot hp.ne_zero
   by_cases hvp : v = p
   · simp [hvp, (FiniteMultiplicity.of_prime_left hp hp.ne_zero).emultiplicity_self,
-      ramificationIdx_eq_normalizedFactors_count hp_bot (isPrime_of_prime hw.prime) hw_bot,
+      ramificationIdx'_eq_normalizedFactors_count hp_bot (isPrime_of_prime hw.prime) hw_bot,
       emultiplicity_eq_count_normalizedFactors hw hp_bot]
   · rw [emultiplicity_eq_zero_of_irreducible_ne hv hp.irreducible hvp, mul_zero,
       emultiplicity_map_eq_zero_of_ne hv hp hvp]
@@ -307,11 +361,11 @@ private theorem emultiplicity_map_eq_ramificationIdx_mul_of_prime [IsDedekindDom
 /-- If `v` is an irreducible ideal of `R`, `w` is an irreducible ideal of `S` lying over `v`, and
 `I` is an ideal of `R`, then the multiplicity of `w` in `I.map (algebraMap R S)` is given by
 the multiplicity of `v` in `I` multiplied by the ramification index of `w` over `v`. -/
-theorem emultiplicity_map_eq_ramificationIdx_mul [IsDedekindDomain R]
+theorem emultiplicity_map_eq_ramificationIdx'_mul [IsDedekindDomain R]
     [FaithfulSMul R S] {v : Ideal R} {w : Ideal S} {I : Ideal R} (h : I ≠ ⊥)
     (hv : Irreducible v) (hw : Irreducible w) (hw_bot : w ≠ ⊥) [w.LiesOver v] :
     emultiplicity w (I.map (algebraMap R S)) =
-      v.ramificationIdx w * emultiplicity v I := by
+      v.ramificationIdx' w * emultiplicity v I := by
   induction I using induction_on_prime with
   | h₁ => aesop
   | h₂ I hI =>
@@ -321,7 +375,10 @@ theorem emultiplicity_map_eq_ramificationIdx_mul [IsDedekindDomain R]
     simp
   | h₃ I p hI hp IH =>
     rw [Ideal.map_mul, emultiplicity_mul hw.prime, emultiplicity_mul hv.prime, IH hI, mul_add,
-      emultiplicity_map_eq_ramificationIdx_mul_of_prime hv hp hw hw_bot]
+      emultiplicity_map_eq_ramificationIdx'_mul_of_prime hv hp hw hw_bot]
+
+@[deprecated (since := "2026-07-01")] alias emultiplicity_map_eq_ramificationIdx_mul :=
+  emultiplicity_map_eq_ramificationIdx'_mul
 
 end IsDedekindDomain
 
@@ -334,12 +391,12 @@ variable [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
 
 /-- Let `T / S / R` be a tower of algebras, `p, P, Q` be ideals in `R, S, T` respectively,
   and `P` and `Q` are prime. If `P = Q ∩ S`, then `e (Q | p) = e (P | p) * e (Q | P)`. -/
-theorem ramificationIdx_algebra_tower [IsDedekindDomain S] [IsDedekindDomain T]
+theorem ramificationIdx'_algebra_tower [IsDedekindDomain S] [IsDedekindDomain T]
     {p : Ideal R} {P : Ideal S} {Q : Ideal T} [hpm : P.IsPrime] [hqm : Q.IsPrime]
     (hg0 : map (algebraMap S T) P ≠ ⊥)
     (hfg : map (algebraMap R T) p ≠ ⊥) (hg : map (algebraMap S T) P ≤ Q) :
-    ramificationIdx p Q =
-    ramificationIdx p P * ramificationIdx P Q := by
+    ramificationIdx' p Q =
+    ramificationIdx' p P * ramificationIdx' P Q := by
   classical
   have hf0 : map (algebraMap R S) p ≠ ⊥ := by
     rw [IsScalarTower.algebraMap_eq R S T, ← map_map] at hfg
@@ -347,9 +404,9 @@ theorem ramificationIdx_algebra_tower [IsDedekindDomain S] [IsDedekindDomain T]
   have hp0 : P ≠ ⊥ := ne_bot_of_map_ne_bot hg0
   have hq0 : Q ≠ ⊥ := ne_bot_of_le_ne_bot hg0 hg
   letI : P.IsMaximal := Ring.DimensionLEOne.maximalOfPrime hp0 hpm
-  rw [IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hf0 hpm hp0,
-    IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hg0 hqm hq0,
-    IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hfg hqm hq0,
+  rw [IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count hf0 hpm hp0,
+    IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count hg0 hqm hq0,
+    IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count hfg hqm hq0,
     IsScalarTower.algebraMap_eq R S T, ← map_map]
   rcases eq_prime_pow_mul_coprime hf0 P with ⟨I, hcp, heq⟩
   have hcp : ⊤ = map (algebraMap S T) P ⊔ map (algebraMap S T) I := by rw [← map_sup, hcp, map_top]
@@ -361,13 +418,14 @@ theorem ramificationIdx_algebra_tower [IsDedekindDomain S] [IsDedekindDomain T]
   exact add_eq_left.mpr <| Decidable.byContradiction fun h ↦ hntq <| hcp.trans_le <|
     sup_le hg <| le_of_dvd <| dvd_of_mem_normalizedFactors <| Multiset.count_ne_zero.mp h
 
-@[deprecated (since := "2026-03-25")] alias ramificationIdx_tower := ramificationIdx_algebra_tower
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_algebra_tower :=
+  ramificationIdx'_algebra_tower
 
-theorem ramificationIdx_algebra_tower' [IsDedekindDomain S] [IsDedekindDomain T] [IsDomain R]
+theorem ramificationIdx'_algebra_tower' [IsDedekindDomain S] [IsDedekindDomain T] [IsDomain R]
     [Module.IsTorsionFree R S] [Module.IsTorsionFree S T] (p : Ideal R) (P : Ideal S) (Q : Ideal T)
     [Q.IsPrime] [Q.LiesOver P] [P.LiesOver p] :
-    ramificationIdx p Q =
-      ramificationIdx p P * ramificationIdx P Q := by
+    ramificationIdx' p Q =
+      ramificationIdx' p P * ramificationIdx' P Q := by
   obtain rfl | hp := eq_or_ne p ⊥
   · simp
   have : P.IsPrime := isPrime_of_liesOver Q P
@@ -375,8 +433,11 @@ theorem ramificationIdx_algebra_tower' [IsDedekindDomain S] [IsDedekindDomain T]
     refine Module.IsTorsionFree.of_smul_eq_zero fun r m h ↦ ?_
     rwa [algebra_compatible_smul S, smul_eq_zero, FaithfulSMul.algebraMap_eq_zero_iff] at h
   have hP : P ≠ ⊥ := ne_bot_of_liesOver_of_ne_bot hp _
-  exact ramificationIdx_algebra_tower (map_ne_bot_of_ne_bot hP) (map_ne_bot_of_ne_bot hp)
+  exact ramificationIdx'_algebra_tower (map_ne_bot_of_ne_bot hP) (map_ne_bot_of_ne_bot hp)
     <| map_le_iff_le_comap.mpr <| le_of_eq <| over_def Q P
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_algebra_tower' :=
+  ramificationIdx'_algebra_tower'
 
 end tower
 

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -27,14 +27,14 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
 variable [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
 
 local notation3 "e(" P "|" R ")" =>
-  Ideal.ramificationIdx' P R
+  Ideal.ramificationIdx P R
 
 open IsLocalRing Algebra
 
 lemma Ideal.ramificationIdx_eq_one_of_isUnramifiedAt
     {p : Ideal S} [p.IsPrime] [IsUnramifiedAt R p] [EssFiniteType R S] :
     e(p|R) = 1 :=
-  p.ramificationIdx'_eq_one R
+  p.ramificationIdx_eq_one R
 
 variable (R) in
 lemma IsUnramifiedAt.of_liesOver_of_ne_bot
@@ -59,12 +59,12 @@ lemma IsUnramifiedAt.of_liesOver_of_ne_bot
       exact le_bot_iff.mp (Ideal.map_comap_le)
     rw [IsScalarTower.algebraMap_eq _ S, ← Ideal.map_map, this,
       Localization.AtPrime.map_eq_maximalIdeal]
-  rw [← Ideal.IsDedekindDomain.ramificationIdx_eq_one_iff hp Ideal.map_comap_le,
-    ← not_ne_iff, Ideal.ramificationIdx_ne_one_iff Ideal.map_comap_le]
+  rw [← Ideal.IsDedekindDomain.ramificationIdx'_eq_one_iff hp Ideal.map_comap_le,
+    ← not_ne_iff, Ideal.ramificationIdx'_ne_one_iff Ideal.map_comap_le]
   intro H
-  have := Ideal.ramificationIdx_eq_one_of_map_localization
+  have := Ideal.ramificationIdx'_eq_one_of_map_localization
     (hp₀ ▸ Ideal.map_comap_le) (hP₂ hp) hP₁ h₂
-  rw [← not_ne_iff, Ideal.ramificationIdx_ne_one_iff (hp₀ ▸ Ideal.map_comap_le)] at this
+  rw [← not_ne_iff, Ideal.ramificationIdx'_ne_one_iff (hp₀ ▸ Ideal.map_comap_le)] at this
   replace H := Ideal.map_mono (f := algebraMap S T) H
   rw [Ideal.map_map, ← IsScalarTower.algebraMap_eq, Ideal.map_pow] at H
   refine this (H.trans (Ideal.pow_right_mono ?_ _))
@@ -150,8 +150,8 @@ theorem isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDo
 theorem IsUnramifiedIn.ramificationIdx_eq_one [IsDomain R]
     [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedIn S 𝔭) {𝔓 : Ideal S}
-    [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx' 𝔓 R = 1 :=
-  Ideal.ramificationIdx'_eq_one_iff.mpr
+    [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx 𝔓 R = 1 :=
+  Ideal.ramificationIdx_eq_one_iff.mpr
     (hunr 𝔓 inferInstance hP)
 
 /-- A nonzero ideal of `R` is unramified in `S` if and only if every prime ideal of `S` lying
@@ -160,9 +160,9 @@ theorem isUnramifiedIn_iff_forall_ramificationIdx_eq_one [IsDomain R]
     [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} :
     IsUnramifiedIn S 𝔭 ↔
-      ∀ (𝔓 : Ideal S) [𝔓.IsPrime], 𝔓.LiesOver 𝔭 → Ideal.ramificationIdx' 𝔓 R = 1 := by
+      ∀ (𝔓 : Ideal S) [𝔓.IsPrime], 𝔓.LiesOver 𝔭 → Ideal.ramificationIdx 𝔓 R = 1 := by
   refine ⟨fun hunr 𝔓 _ hP ↦ hunr.ramificationIdx_eq_one hP, fun h 𝔓 _ hP ↦ ?_⟩
-  rw [← Ideal.ramificationIdx'_eq_one_iff]
+  rw [← Ideal.ramificationIdx_eq_one_iff]
   exact h 𝔓 hP
 
 end Algebra

--- a/Mathlib/NumberTheory/RamificationInertia/Valuation.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Valuation.lean
@@ -44,7 +44,7 @@ variable (v : HeightOneSpectrum A) (w : HeightOneSpectrum B) [w.asIdeal.LiesOver
 theorem intValuation_liesOver (x : A) :
     v.intValuation x ^ (v.asIdeal.ramificationIdx' w.asIdeal) =
       w.intValuation (algebraMap A B x) := by
-  rcases eq_or_ne x 0 with rfl | hx;
+  rcases eq_or_ne x 0 with rfl | hx
   · simp [ramificationIdx'_ne_zero_of_liesOver w.asIdeal v.ne_bot]
   rw [intValuation_eq_exp_neg_multiplicity v hx, intValuation_eq_exp_neg_multiplicity w (by simpa),
     ← Set.image_singleton, ← Ideal.map_span, exp_neg, exp_neg, inv_pow, ← exp_nsmul,

--- a/Mathlib/NumberTheory/RamificationInertia/Valuation.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Valuation.lean
@@ -42,19 +42,20 @@ variable [Algebra B L] [IsFractionRing B L] [IsScalarTower A B L]
 variable (v : HeightOneSpectrum A) (w : HeightOneSpectrum B) [w.asIdeal.LiesOver v.asIdeal]
 
 theorem intValuation_liesOver (x : A) :
-    v.intValuation x ^ (v.asIdeal.ramificationIdx w.asIdeal) =
+    v.intValuation x ^ (v.asIdeal.ramificationIdx' w.asIdeal) =
       w.intValuation (algebraMap A B x) := by
-  rcases eq_or_ne x 0 with rfl | hx; · simp [ramificationIdx_ne_zero_of_liesOver w.asIdeal v.ne_bot]
+  rcases eq_or_ne x 0 with rfl | hx;
+  · simp [ramificationIdx'_ne_zero_of_liesOver w.asIdeal v.ne_bot]
   rw [intValuation_eq_exp_neg_multiplicity v hx, intValuation_eq_exp_neg_multiplicity w (by simpa),
     ← Set.image_singleton, ← Ideal.map_span, exp_neg, exp_neg, inv_pow, ← exp_nsmul,
     Int.nsmul_eq_mul, inv_inj, exp_inj, ← Nat.cast_mul, Nat.cast_inj]
   refine multiplicity_eq_of_emultiplicity_eq_some ?_ |>.symm
   replace hx : Ideal.span {x} ≠ ⊥ := by simp [hx]
-  rw [emultiplicity_map_eq_ramificationIdx_mul hx v.irreducible w.irreducible w.ne_bot,
+  rw [emultiplicity_map_eq_ramificationIdx'_mul hx v.irreducible w.irreducible w.ne_bot,
     Nat.cast_mul, (FiniteMultiplicity.of_prime_left v.prime hx).emultiplicity_eq_multiplicity]
 
 theorem valuation_liesOver (x : K) :
-    v.valuation K x ^ v.asIdeal.ramificationIdx w.asIdeal =
+    v.valuation K x ^ v.asIdeal.ramificationIdx' w.asIdeal =
       w.valuation L (algebraMap K L x) := by
   obtain ⟨x, y, hy, rfl⟩ := IsFractionRing.div_surjective (A := A) x
   simp [valuation_of_algebraMap, div_pow, ← IsScalarTower.algebraMap_apply A K L,
@@ -81,7 +82,7 @@ theorem uniformContinuous_algebraMap_liesOver :
             v                                                         v
   `γL : ValuativeRel.ValueGroupWithZero Lʷ`       `γK: ValuativeRel.ValueGroupWithZero Kᵛ`
   -/
-  let e := v.asIdeal.ramificationIdx w.asIdeal
+  let e := v.asIdeal.ramificationIdx' w.asIdeal
   -- push `γL` to `ℤᵐ⁰`
   let σL := WithVal.valueGroupOrderIso₀ (w.valuation L)
   let σw := valueGroup₀_equiv_withZeroMulInt (w.valuation L)
@@ -110,7 +111,7 @@ theorem uniformContinuous_algebraMap_liesOver :
     ← log_lt_log (by simp_all) (by simp [EmbeddingLike.map_eq_zero_iff (f := σwV)]), log_pow,
     nsmul_eq_mul, mul_comm]
   exact Int.mul_lt_of_lt_ediv
-    (mod_cast pos_of_ne_zero (ramificationIdx_ne_zero_of_liesOver w.asIdeal v.ne_bot)) hx
+    (mod_cast pos_of_ne_zero (ramificationIdx'_ne_zero_of_liesOver w.asIdeal v.ne_bot)) hx
 
 end AKLB
 

--- a/Mathlib/RingTheory/DedekindDomain/Different.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Different.lean
@@ -938,8 +938,8 @@ theorem not_dvd_differentIdeal_iff
       · suffices Algebra.IsSeparable (A ⧸ P.under A) (B ⧸ P) by infer_instance
         contrapose H
         exact dvd_differentIdeal_of_not_isSeparable A hp P H
-      · rw [← Ideal.IsDedekindDomain.ramificationIdx_eq_one_iff hPbot Ideal.map_comap_le]
-        apply Ideal.ramificationIdx_spec
+      · rw [← Ideal.IsDedekindDomain.ramificationIdx'_eq_one_iff hPbot Ideal.map_comap_le]
+        apply Ideal.ramificationIdx'_spec
         · simp [Ideal.map_le_iff_le_comap]
         · contrapose H
           rw [← pow_one P, show 1 = 2 - 1 by simp]
@@ -947,7 +947,7 @@ theorem not_dvd_differentIdeal_iff
           simpa [Ideal.dvd_iff_le] using H
   · intro H
     obtain ⟨Q, h₁, h₂⟩ := Ideal.eq_prime_pow_mul_coprime hp' P
-    rw [← Ideal.IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count _ _ hp',
+    rw [← Ideal.IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count _ _ hp',
       Ideal.ramificationIdx_eq_one_of_isUnramifiedAt, pow_one] at h₂
     obtain ⟨h₃, h₄⟩ := (Algebra.isUnramifiedAt_iff_map_eq (p := P.under A) _ _).mp H
     exact not_dvd_differentIdeal_of_isCoprime_of_isSeparable

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -819,7 +819,7 @@ If `p` is a maximal ideal, then the lift of `p` in an extension is the product o
 over `p` to the power the ramification index.
 -/
 theorem Ideal.map_algebraMap_eq_finsetProd_pow {p : Ideal S} [p.IsMaximal] (hp : p ≠ 0) :
-    map (algebraMap S R) p = ∏ P ∈ p.primesOver R, P ^ P.ramificationIdx' S := by
+    map (algebraMap S R) p = ∏ P ∈ p.primesOver R, P ^ P.ramificationIdx S := by
   classical
   have h : map (algebraMap S R) p ≠ 0 := map_ne_bot_of_ne_bot hp
   rw [← finprod_heightOneSpectrum_factorization (I := p.map (algebraMap S R)) h]
@@ -831,7 +831,7 @@ theorem Ideal.map_algebraMap_eq_finsetProd_pow {p : Ideal S} [p.IsMaximal] (hp :
   · let _ : Fintype {v : HeightOneSpectrum R // v.asIdeal ∣ map (algebraMap S R) p} := hF
     refine Fintype.prod_equiv (equivPrimesOver _ hp) _ _ fun ⟨v, _⟩ ↦ ?_
     have : v.asIdeal.LiesOver p := by rwa [Ideal.liesOver_iff_dvd_map v.2.ne_top]
-    simp [maxPowDividing_eq_pow_multiset_count _ h, ramificationIdx'_eq_factors_count p v h]
+    simp [maxPowDividing_eq_pow_multiset_count _ h, ramificationIdx_eq_factors_count p v h]
   · intro v hv
     simpa [maxPowDividing, Function.mem_mulSupport, IsPrime.ne_top _,
       Associates.count_ne_zero_iff_dvd h (irreducible v)] using hv

--- a/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
@@ -413,7 +413,7 @@ theorem relNorm_eq_pow_of_isPrime_isGalois [p.IsMaximal] [P.IsPrime]
   obtain ⟨s, hs⟩ := exists_relNorm_eq_pow_of_isPrime P p
   suffices s = P.inertiaDeg' R by rwa [this] at hs
   have h₀ : ∀ Q ∈ (p.primesOver S).toFinset,
-      relNorm R Q ^ Q.ramificationIdx' R = p ^ ((p.ramificationIdxIn S) * s) := by
+      relNorm R Q ^ Q.ramificationIdx R = p ^ ((p.ramificationIdxIn S) * s) := by
     intro Q hQ
     rw [Set.mem_toFinset] at hQ
     have : Q.IsPrime := hQ.1

--- a/Mathlib/RingTheory/Localization/AtPrime/Extension.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Extension.lean
@@ -177,12 +177,12 @@ theorem inertiaDeg_map_eq_inertiaDeg [p.IsMaximal] [P.IsMaximal]
 
 include p in
 theorem ramificationIdx_map_eq_ramificationIdx [P.IsPrime] :
-    (P.map (algebraMap S Sₚ)).ramificationIdx' Rₚ = P.ramificationIdx' R := by
+    (P.map (algebraMap S Sₚ)).ramificationIdx Rₚ = P.ramificationIdx R := by
   have := liesOver_map_of_liesOver p Rₚ Sₚ P
   have := IsLocalization.liesOver_map_of_isPrime_disjoint (algebraMapSubmonoid S p.primeCompl) Sₚ
     (Set.disjoint_image_left.mpr (Set.disjoint_compl_left_iff_subset.mpr hPp.over.ge))
   have := isPrime_map_of_liesOver S p Sₚ P
-  rw [ramificationIdx'_eq (maximalIdeal Rₚ) (P.map (algebraMap S Sₚ)), ramificationIdx'_eq p P]
+  rw [ramificationIdx_eq (maximalIdeal Rₚ) (P.map (algebraMap S Sₚ)), ramificationIdx_eq p P]
   let R₁ := Localization.AtPrime (P.map (algebraMap S Sₚ))
   let R₂ := Localization.AtPrime P
   let : Algebra R₂ R₁ := Localization.AtPrime.algebraOfLiesOver P (P.map (algebraMap S Sₚ))
@@ -247,8 +247,8 @@ theorem primesOverEquivPrimesOver_inertiagDeg_eq [p.IsMaximal] (hp : p ≠ ⊥) 
   exact inertiaDeg_map_eq_inertiaDeg p _ _ _
 
 theorem primesOverEquivPrimesOver_ramificationIdx_eq (hp : p ≠ ⊥) (P : p.primesOver S) :
-    (primesOverEquivPrimesOver p Rₚ Sₚ hp P : Ideal Sₚ).ramificationIdx' Rₚ =
-      P.val.ramificationIdx' R :=
+    (primesOverEquivPrimesOver p Rₚ Sₚ hp P : Ideal Sₚ).ramificationIdx Rₚ =
+      P.val.ramificationIdx R :=
   ramificationIdx_map_eq_ramificationIdx p _ _ _
 
 end IsDedekindDomain

--- a/Mathlib/RingTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Basic.lean
@@ -43,7 +43,7 @@ variable {R : Type*} [CommRing R] (p : Ideal R) [p.IsPrime] (S : Type*) [CommRin
 open IsLocalRing Module OrderIso PrimeSpectrum in
 theorem sum_ramification_inertia_eq_finrank_fiber
     [Algebra.QuasiFinite R S] [Fintype (p.primesOver S)] :
-    ∑ q : p.primesOver S, q.1.ramificationIdx' R * q.1.inertiaDeg' R =
+    ∑ q : p.primesOver S, q.1.ramificationIdx R * q.1.inertiaDeg' R =
       finrank p.ResidueField (p.Fiber S) := by
   let := Fintype.ofFinite (PrimeSpectrum (p.Fiber S))
   rw [IsArtinianRing.finrank_eq_sum_primeSpectrum, ← (primesOverOrderIsoFiber R S p).symm.sum_comp]
@@ -52,7 +52,7 @@ theorem sum_ramification_inertia_eq_finrank_fiber
   simp_rw [toEquiv_symm, coe_symm_toEquiv, coe_primesOverOrderIsoFiber_symm_apply]
   set r := q.1.comap Algebra.TensorProduct.includeRight
   let := Localization.AtPrime.algebraOfLiesOver p r
-  rw [ramificationIdx'_eq p r, inertiaDeg'_eq p r]
+  rw [ramificationIdx_eq p r, inertiaDeg'_eq p r]
   let Rp := Localization.AtPrime p
   let Sq := Localization.AtPrime q.1
   let Sr := Localization.AtPrime r
@@ -71,7 +71,7 @@ ideal of `R`. Then the sum over all prime ideals `q` of `S` lying over `p` of th
 index of `q` times the inertia degree of `q` equals the rank of `S` as an `R`-module. -/
 theorem sum_ramification_inertia_eq_finrank
     [IsDomain R] [Module.Finite R S] [Module.Flat R S] [Fintype (p.primesOver S)] :
-    ∑ q : p.primesOver S, q.1.ramificationIdx' R * q.1.inertiaDeg' R = Module.finrank R S := by
+    ∑ q : p.primesOver S, q.1.ramificationIdx R * q.1.inertiaDeg' R = Module.finrank R S := by
   rw [sum_ramification_inertia_eq_finrank_fiber, finrank_fiber_eq_finrank]
 
 /-- Let `S/R` be a finite flat extension of integral domains, and let `p` be prime ideal of `R`.
@@ -81,7 +81,7 @@ degree of `q` equals the cardinality of `G`. -/
 theorem sum_ramification_inertia_eq_card
     [IsDomain R] [IsDomain S] [Module.Finite R S] [Module.Flat R S] [Fintype (p.primesOver S)]
     {G : Type*} [Group G] [MulSemiringAction G S] [IsGaloisGroup G R S] :
-    ∑ q : p.primesOver S, q.1.ramificationIdx' R * q.1.inertiaDeg' R = Nat.card G := by
+    ∑ q : p.primesOver S, q.1.ramificationIdx R * q.1.inertiaDeg' R = Nat.card G := by
   let := IsGaloisGroup.finite G R S
   rw [sum_ramification_inertia_eq_finrank, IsGaloisGroup.card_eq_finrank' G R S]
 

--- a/Mathlib/RingTheory/RamificationInertia/Ramification.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Ramification.lean
@@ -214,7 +214,7 @@ theorem ramificationIdx_tower' [q.IsPrime] [r.IsPrime] [r.LiesOver q]
 
 @[deprecated (since := "2026-07-01")] alias ramificationIdx'_tower' := ramificationIdx_tower'
 
-/-- See `ramificationIdx'_tower'` for a version that only assumes local flatness. -/
+/-- See `ramificationIdx_tower'` for a version that only assumes local flatness. -/
 theorem ramificationIdx_tower [r.LiesOver q] [Module.Flat S T] :
     r.ramificationIdx R = q.ramificationIdx R * r.ramificationIdx S := by
   by_cases hr : r.IsPrime

--- a/Mathlib/RingTheory/RamificationInertia/Ramification.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Ramification.lean
@@ -21,13 +21,13 @@ an `Sq`-module.
 
 ## Main definitions
 
-* `Ideal.ramificationIdx' q R`: The ramification index of `q` over `R`.
+* `Ideal.ramificationIdx q R`: The ramification index of `q` over `R`.
 
 ## Main statements
 
-* `ramificationIdx_eq_ramificationIdx'`: The ramification index agrees with the usual definition in
+* `ramificationIdx'_eq_ramificationIdx`: The ramification index agrees with the usual definition in
   the case of Dedekind domains.
-* `ramificationIdx'_tower`: Ramification index is multiplicative in towers.
+* `ramificationIdx_tower`: Ramification index is multiplicative in towers.
 
 -/
 
@@ -47,25 +47,30 @@ an `Sq`-module.
 
 When `q` is not prime, we use a junk value of `0`.
 
-This will eventually replace the existing definition of `Ideal.ramificationIdx`. -/
-noncomputable def ramificationIdx' : ℕ :=
+This will eventually replace the existing definition of `Ideal.ramificationIdx'`. -/
+noncomputable def ramificationIdx : ℕ :=
   if _ : q.IsPrime then
     letI Sq := Localization.AtPrime q
     (Module.length Sq (Sq ⧸ (q.under R).map (algebraMap R Sq))).toNat
   else 0
 
-theorem ramificationIdx'_def [q.IsPrime] :
+theorem ramificationIdx_def [q.IsPrime] :
     letI Sq := Localization.AtPrime q
-    q.ramificationIdx' R = (Module.length Sq (Sq ⧸ (q.under R).map (algebraMap R Sq))).toNat :=
+    q.ramificationIdx R = (Module.length Sq (Sq ⧸ (q.under R).map (algebraMap R Sq))).toNat :=
   dif_pos _
 
-theorem ramificationIdx'_of_not_isPrime (hq : ¬ q.IsPrime) : q.ramificationIdx' R = 0 :=
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_def := ramificationIdx_def
+
+theorem ramificationIdx_of_not_isPrime (hq : ¬ q.IsPrime) : q.ramificationIdx R = 0 :=
   dif_neg hq
 
-theorem ramificationIdx'_pos [q.IsPrime] [Module.Finite R S] : 0 < q.ramificationIdx' R := by
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_of_not_isPrime :=
+  ramificationIdx_of_not_isPrime
+
+theorem ramificationIdx_pos [q.IsPrime] [Module.Finite R S] : 0 < q.ramificationIdx R := by
   let p := q.under R
   let Sq := Localization.AtPrime q
-  rw [ramificationIdx'_def]
+  rw [ramificationIdx_def]
   apply ENat.toNat_pos
   · rw [← pos_iff_ne_zero, Module.length_pos_iff, Submodule.Quotient.nontrivial_iff,
       IsScalarTower.algebraMap_eq R S, ← map_map, ← lt_top_iff_ne_top]
@@ -80,24 +85,28 @@ theorem ramificationIdx'_pos [q.IsPrime] [Module.Finite R S] : 0 < q.ramificatio
     rwa [Module.length_eq_of_surjective (R := Sq ⧸ p.map (algebraMap R Sq)) Quotient.mk_surjective,
       Module.length_ne_top_iff, ← isArtinianRing_iff_isFiniteLength]
 
-theorem ramificationIdx'_eq_one [q.IsPrime] [Algebra.EssFiniteType R S]
-    [Algebra.IsUnramifiedAt R q] : q.ramificationIdx' R = 1 := by
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_pos := ramificationIdx_pos
+
+theorem ramificationIdx_eq_one [q.IsPrime] [Algebra.EssFiniteType R S]
+    [Algebra.IsUnramifiedAt R q] : q.ramificationIdx R = 1 := by
   let p := q.under R
   let Rp := Localization.AtPrime p
   let Sq := Localization.AtPrime q
   let : Algebra Rp Sq := Localization.AtPrime.algebraOfLiesOver p q
   have : Algebra.EssFiniteType Rp Sq := Algebra.EssFiniteType.of_comp R Rp Sq
-  rw [ramificationIdx'_def, ENat.toNat_eq_iff_eq_coe, Nat.cast_one, Module.length_eq_one_iff,
+  rw [ramificationIdx_def, ENat.toNat_eq_iff_eq_coe, Nat.cast_one, Module.length_eq_one_iff,
     isSimpleModule_iff_isCoatom, ← Ideal.isMaximal_def, IsLocalRing.isMaximal_iff,
     IsScalarTower.algebraMap_eq R Rp Sq, ← map_map, Localization.AtPrime.map_eq_maximalIdeal]
   exact Algebra.FormallyUnramified.map_maximalIdeal
 
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_eq_one := ramificationIdx_eq_one
+
 variable {q R} in
-theorem ramificationIdx'_eq_one_iff [q.IsPrime] [Algebra.EssFiniteType R S]
+theorem ramificationIdx_eq_one_iff [q.IsPrime] [Algebra.EssFiniteType R S]
     [Algebra.IsIntegral R S] [PerfectField (q.under R).ResidueField] :
-    q.ramificationIdx' R = 1 ↔ Algebra.IsUnramifiedAt R q := by
-  refine ⟨fun h ↦ ?_, fun _ ↦ ramificationIdx'_eq_one q R⟩
-  rw [ramificationIdx'_def, ENat.toNat_eq_iff_eq_coe, Nat.cast_one, Module.length_eq_one_iff,
+    q.ramificationIdx R = 1 ↔ Algebra.IsUnramifiedAt R q := by
+  refine ⟨fun h ↦ ?_, fun _ ↦ ramificationIdx_eq_one q R⟩
+  rw [ramificationIdx_def, ENat.toNat_eq_iff_eq_coe, Nat.cast_one, Module.length_eq_one_iff,
     isSimpleModule_iff_isCoatom, ← Ideal.isMaximal_def, IsLocalRing.isMaximal_iff] at h
   let p := q.under R
   let Rp := Localization.AtPrime p
@@ -109,6 +118,9 @@ theorem ramificationIdx'_eq_one_iff [q.IsPrime] [Algebra.EssFiniteType R S]
     ← Localization.AtPrime.map_eq_maximalIdeal, map_map, ← IsScalarTower.algebraMap_eq]
   exact ⟨Algebra.IsAlgebraic.isSeparable_of_perfectField, h⟩
 
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_eq_one_iff :=
+  ramificationIdx_eq_one_iff
+
 end
 
 section
@@ -117,15 +129,17 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
   [Algebra R S] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
   (p : Ideal R) (q : Ideal S) (r : Ideal T)
 
-theorem ramificationIdx'_eq [q.LiesOver p] [q.IsPrime] :
+theorem ramificationIdx_eq [q.LiesOver p] [q.IsPrime] :
     letI Sq := Localization.AtPrime q
-    q.ramificationIdx' R = (Module.length Sq (Sq ⧸ p.map (algebraMap R Sq))).toNat := by
-  rw [ramificationIdx'_def, over_def q p]
+    q.ramificationIdx R = (Module.length Sq (Sq ⧸ p.map (algebraMap R Sq))).toNat := by
+  rw [ramificationIdx_def, over_def q p]
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_eq := ramificationIdx_eq
 
 open Localization IsLocalization.AtPrime in
-theorem ramificationIdx_eq_ramificationIdx'' [IsDedekindDomain S]
+theorem ramificationIdx'_eq_ramificationIdx' [IsDedekindDomain S]
     [q.LiesOver p] [hq : q.IsPrime] (hpS : p.map (algebraMap R S) ≠ ⊥) :
-    p.ramificationIdx q = q.ramificationIdx' R := by
+    p.ramificationIdx' q = q.ramificationIdx R := by
   have hq' : q ≠ ⊥ := ne_bot_of_le_ne_bot hpS (map_le_of_le_comap (q.over_def p).le)
   have : q.IsMaximal := hq.isMaximal hq'
   obtain ⟨I, hqI, h⟩ := Ideal.eq_prime_pow_mul_coprime hpS q
@@ -133,99 +147,118 @@ theorem ramificationIdx_eq_ramificationIdx'' [IsDedekindDomain S]
     contrapose! hqI
     rw [sup_of_le_left hqI]
     exact hq.ne_top
-  rw [← IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hpS hq hq'] at h
+  rw [← IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count hpS hq hq'] at h
   apply_fun (map (algebraMap S (Localization.AtPrime q))) at h
   rw [map_map, ← IsScalarTower.algebraMap_eq, Ideal.map_mul, Ideal.map_pow,
     map_eq_top_of_not_le (Localization.AtPrime q) hqI, mul_top, AtPrime.map_eq_maximalIdeal] at h
   have hSq := isDiscreteValuationRing_of_dedekind_domain S hq' (Localization.AtPrime q)
-  rw [ramificationIdx'_eq p q, h, hSq.length_quotient_pow_maximalIdeal, ENat.toNat_coe]
+  rw [ramificationIdx_eq p q, h, hSq.length_quotient_pow_maximalIdeal, ENat.toNat_coe]
 
-theorem ramificationIdx_eq_ramificationIdx' [IsDomain R] [IsDedekindDomain S]
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_eq_ramificationIdx'' :=
+  ramificationIdx'_eq_ramificationIdx'
+
+theorem ramificationIdx'_eq_ramificationIdx [IsDomain R] [IsDedekindDomain S]
     [Module.IsTorsionFree R S] [q.LiesOver p] [hq : q.IsPrime] (hp : p ≠ ⊥) :
-    p.ramificationIdx q = q.ramificationIdx' R := by
+    p.ramificationIdx' q = q.ramificationIdx R := by
   have hpS : p.map (algebraMap R S) ≠ ⊥ := map_ne_bot_of_ne_bot hp
-  exact ramificationIdx_eq_ramificationIdx'' p q hpS
+  exact ramificationIdx'_eq_ramificationIdx' p q hpS
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx_eq_ramificationIdx' :=
+  ramificationIdx'_eq_ramificationIdx
 
 namespace IsDedekindDomain
 
 open UniqueFactorizationMonoid
 
-theorem ramificationIdx'_eq_factors_count [IsDedekindDomain S]
+theorem ramificationIdx_eq_factors_count [IsDedekindDomain S]
     [q.LiesOver p] (hp0 : p.map (algebraMap R S) ≠ ⊥) :
-    q.ramificationIdx' R = (factors (p.map (algebraMap R S))).count q := by
+    q.ramificationIdx R = (factors (p.map (algebraMap R S))).count q := by
   by_cases hq : q.IsPrime; swap
-  · rw [ramificationIdx'_of_not_isPrime q R hq, eq_comm, Multiset.count_eq_zero]
+  · rw [ramificationIdx_of_not_isPrime q R hq, eq_comm, Multiset.count_eq_zero]
     contrapose! hq
     exact isPrime_of_prime (prime_of_factor q hq)
   have hq0 : q ≠ ⊥ := ne_bot_of_le_ne_bot hp0 (map_le_of_le_comap (q.over_def p).le)
-  rw [← ramificationIdx_eq_ramificationIdx'' p q hp0, ramificationIdx_eq_factors_count hp0 ‹_› hq0]
+  rw [← ramificationIdx'_eq_ramificationIdx' p q hp0, ramificationIdx'_eq_factors_count hp0 ‹_› hq0]
 
 open UniqueFactorizationMonoid in
-theorem ramificationIdx'_eq_normalizedFactors_count [IsDedekindDomain S]
+theorem ramificationIdx_eq_normalizedFactors_count [IsDedekindDomain S]
     [q.LiesOver p] (hp0 : p.map (algebraMap R S) ≠ ⊥) :
-    q.ramificationIdx' R = (normalizedFactors (p.map (algebraMap R S))).count q := by
-  rw [← factors_eq_normalizedFactors, ← ramificationIdx'_eq_factors_count p q hp0]
+    q.ramificationIdx R = (normalizedFactors (p.map (algebraMap R S))).count q := by
+  rw [← factors_eq_normalizedFactors, ← ramificationIdx_eq_factors_count p q hp0]
 
 open UniqueFactorizationMonoid in
-theorem ramificationIdx'_eq_multiplicity [IsDedekindDomain S]
+theorem ramificationIdx_eq_multiplicity [IsDedekindDomain S]
     [q.IsPrime] [q.LiesOver p] (hp : p.map (algebraMap R S) ≠ ⊥) :
-    q.ramificationIdx' R = multiplicity q (p.map (algebraMap R S)) := by
+    q.ramificationIdx R = multiplicity q (p.map (algebraMap R S)) := by
   have hq : q ≠ ⊥ := ne_bot_of_le_ne_bot hp (map_le_of_le_comap (q.over_def p).le)
-  rw [ramificationIdx'_eq_normalizedFactors_count p q hp,
+  rw [ramificationIdx_eq_normalizedFactors_count p q hp,
     multiplicity_eq_of_emultiplicity_eq_some (emultiplicity_eq_count_normalizedFactors
       (prime_of_isPrime hq inferInstance).irreducible hp), normalize_eq]
 
 end IsDedekindDomain
 
-/-- See `ramificationIdx'_tower` for a version that does not assume primality. -/
-theorem ramificationIdx'_tower' [q.IsPrime] [r.IsPrime] [r.LiesOver q]
+/-- See `ramificationIdx_tower` for a version that does not assume primality. -/
+theorem ramificationIdx_tower' [q.IsPrime] [r.IsPrime] [r.LiesOver q]
     [Algebra (Localization.AtPrime q) (Localization.AtPrime r)]
     [Localization.AtPrime.IsLiesOverAlgebra q r]
     [Module.Flat (Localization.AtPrime q) (Localization.AtPrime r)] :
-    r.ramificationIdx' R = q.ramificationIdx' R * r.ramificationIdx' S := by
+    r.ramificationIdx R = q.ramificationIdx R * r.ramificationIdx S := by
   have : q.LiesOver (r.under R) := LiesOver.tower_bot r q (r.under R)
   let f := (Ideal.quotientEquivAlgOfEq (Localization.AtPrime r)
     (by rw [map_map, ← IsScalarTower.algebraMap_eq])).trans
       (Algebra.TensorProduct.quotIdealMapEquivTensorQuot (Localization.AtPrime r)
         ((r.under R).map (algebraMap R (Localization.AtPrime q))))
-  rw [ramificationIdx'_def, ramificationIdx'_eq (r.under R), ramificationIdx'_eq q,
+  rw [ramificationIdx_def, ramificationIdx_eq (r.under R), ramificationIdx_eq q,
     f.toLinearEquiv.length_eq, IsLocalRing.length_baseChange, ENat.toNat_mul,
     ← Localization.AtPrime.map_eq_maximalIdeal, map_map, ← IsScalarTower.algebraMap_eq]
 
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_tower' := ramificationIdx_tower'
+
 /-- See `ramificationIdx'_tower'` for a version that only assumes local flatness. -/
-theorem ramificationIdx'_tower [r.LiesOver q] [Module.Flat S T] :
-    r.ramificationIdx' R = q.ramificationIdx' R * r.ramificationIdx' S := by
+theorem ramificationIdx_tower [r.LiesOver q] [Module.Flat S T] :
+    r.ramificationIdx R = q.ramificationIdx R * r.ramificationIdx S := by
   by_cases hr : r.IsPrime
   · have : q.IsPrime := isPrime_of_liesOver r q
     let := Localization.AtPrime.algebraOfLiesOver q r
-    apply ramificationIdx'_tower'
-  · rw [ramificationIdx'_of_not_isPrime r R hr, ramificationIdx'_of_not_isPrime r S hr, mul_zero]
+    apply ramificationIdx_tower'
+  · rw [ramificationIdx_of_not_isPrime r R hr, ramificationIdx_of_not_isPrime r S hr, mul_zero]
 
-theorem ramificationIdx'_below_dvd [r.LiesOver q] [Module.Flat S T] :
-    q.ramificationIdx' R ∣ r.ramificationIdx' R := by
-  use r.ramificationIdx' S
-  rw [← ramificationIdx'_tower]
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_tower := ramificationIdx_tower
 
-theorem ramificationIdx'_above_dvd [r.LiesOver q] [Module.Flat S T] :
-    r.ramificationIdx' S ∣ r.ramificationIdx' R := by
-  use q.ramificationIdx' R
-  rw [mul_comm, ← ramificationIdx'_tower]
+theorem ramificationIdx_below_dvd [r.LiesOver q] [Module.Flat S T] :
+    q.ramificationIdx R ∣ r.ramificationIdx R := by
+  use r.ramificationIdx S
+  rw [← ramificationIdx_tower]
 
-theorem ramificationIdx'_below_le [r.IsPrime] [r.LiesOver q] [Module.Finite R T] [Module.Flat S T] :
-    q.ramificationIdx' R ≤ r.ramificationIdx' R :=
-  Nat.le_of_dvd (r.ramificationIdx'_pos R) (q.ramificationIdx'_below_dvd r)
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_below_dvd := ramificationIdx_below_dvd
 
-theorem ramificationIdx'_above_le [r.IsPrime] [r.LiesOver q] [Module.Finite R T] [Module.Flat S T] :
-    r.ramificationIdx' S ≤ r.ramificationIdx' R :=
-  Nat.le_of_dvd (r.ramificationIdx'_pos R) (q.ramificationIdx'_above_dvd r)
+theorem ramificationIdx_above_dvd [r.LiesOver q] [Module.Flat S T] :
+    r.ramificationIdx S ∣ r.ramificationIdx R := by
+  use q.ramificationIdx R
+  rw [mul_comm, ← ramificationIdx_tower]
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_above_dvd := ramificationIdx_above_dvd
+
+theorem ramificationIdx_below_le [r.IsPrime] [r.LiesOver q] [Module.Finite R T] [Module.Flat S T] :
+    q.ramificationIdx R ≤ r.ramificationIdx R :=
+  Nat.le_of_dvd (r.ramificationIdx_pos R) (q.ramificationIdx_below_dvd r)
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_below_le :=
+  ramificationIdx_below_le
+
+theorem ramificationIdx_above_le [r.IsPrime] [r.LiesOver q] [Module.Finite R T] [Module.Flat S T] :
+    r.ramificationIdx S ≤ r.ramificationIdx R :=
+  Nat.le_of_dvd (r.ramificationIdx_pos R) (q.ramificationIdx_above_dvd r)
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_above_le := ramificationIdx_above_le
 
 variable (R) in
 open Pointwise in
 @[simp]
-theorem ramificationIdx'_smul {G : Type*} [Group G] [MulSemiringAction G S] [SMulCommClass G R S]
-    (g : G) : (g • q).ramificationIdx' R = q.ramificationIdx' R := by
+theorem ramificationIdx_smul {G : Type*} [Group G] [MulSemiringAction G S] [SMulCommClass G R S]
+    (g : G) : (g • q).ramificationIdx R = q.ramificationIdx R := by
   by_cases hq : q.IsPrime; swap
-  · rw [ramificationIdx'_of_not_isPrime, ramificationIdx'_of_not_isPrime] <;> simpa
+  · rw [ramificationIdx_of_not_isPrime, ramificationIdx_of_not_isPrime] <;> simpa
   · let p := q.under R
     let f₀ := MulSemiringAction.toAlgAut G R S g
     have hg : g • q = q.map f₀ := q.pointwise_smul_def
@@ -239,8 +272,10 @@ theorem ramificationIdx'_smul {G : Type*} [Group G] [MulSemiringAction G S] [SMu
       Ideal.quotientEquivAlg _ _ (AlgEquiv.ofBijective (Algebra.ofId Sq Sq') f.bijective)
         (by rw [IsScalarTower.algebraMap_eq R Sq Sq', Ideal.map_map,
           ← AlgEquiv.toAlgHom_toRingHom, AlgEquiv.toAlgHom_ofBijective, Algebra.toRingHom_ofId])
-    rw [hg, ramificationIdx'_eq p q, ramificationIdx'_eq p (q.map f₀),
+    rw [hg, ramificationIdx_eq p q, ramificationIdx_eq p (q.map f₀),
       e.toLinearEquiv.length_eq, Module.length_eq_of_surjective f.surjective]
+
+@[deprecated (since := "2026-07-01")] alias ramificationIdx'_smul := ramificationIdx_smul
 
 end
 


### PR DESCRIPTION
There's still a bit of work left to do, but I think now is a reasonable time to swap which of `ramificationIdx` and `ramificationIdx'` is primed.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
