### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Preadditive/LeftExact): fix doc strings

### DIFF
--- a/Mathlib/CategoryTheory/Preadditive/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Preadditive/LeftExact.lean
@@ -17,7 +17,7 @@ preserves kernels. The dual result holds for right exact functors and cokernels.
 
 ## Main results
 
-* We first derive preservation of binary product in the lemma
+* We first derive preservation of binary products in the lemma
   `preservesBinaryProductsOfPreservesKernels`,
 * then show the preservation of equalizers in `preservesEqualizerOfPreservesKernels`,
 * and then derive the preservation of all finite limits with the usual construction.
@@ -187,8 +187,8 @@ lemma preservesCoequalizer_of_preservesCokernels
       (isColimitCoforkOfCokernelCofork ((IsColimit.precomposeHomEquiv p.symm _).symm iFc))
       (Cofork.ext (Iso.refl _) (by simp [p]))
 
-/-- A functor between preadditive categories preserves all coequalizers if it preserves all kernels.
--/
+/-- A functor between preadditive categories preserves all coequalizers if it preserves all
+cokernels.-/
 lemma preservesCoequalizers_of_preservesCokernels
     [∀ {X Y} (f : X ⟶ Y), PreservesColimit (parallelPair f 0) F] :
     PreservesColimitsOfShape WalkingParallelPair F where
@@ -197,8 +197,8 @@ lemma preservesCoequalizers_of_preservesCokernels
         (K.map Limits.WalkingParallelPairHom.right)
     apply preservesColimit_of_iso_diagram F (diagramIsoParallelPair K).symm
 
-/-- A functor between preadditive categories which preserves kernels preserves all finite limits.
--/
+/-- A functor between preadditive categories which preserves cokernels preserves all finite
+colimits. -/
 lemma preservesFiniteColimits_of_preservesCokernels [HasFiniteCoproducts C] [HasCoequalizers C]
     [HasZeroObject C] [HasZeroObject D]
     [∀ {X Y} (f : X ⟶ Y), PreservesColimit (parallelPair f 0) F] : PreservesFiniteColimits F := by

--- a/Mathlib/CategoryTheory/Preadditive/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Preadditive/LeftExact.lean
@@ -188,7 +188,7 @@ lemma preservesCoequalizer_of_preservesCokernels
       (Cofork.ext (Iso.refl _) (by simp [p]))
 
 /-- A functor between preadditive categories preserves all coequalizers if it preserves all
-cokernels.-/
+cokernels. -/
 lemma preservesCoequalizers_of_preservesCokernels
     [∀ {X Y} (f : X ⟶ Y), PreservesColimit (parallelPair f 0) F] :
     PreservesColimitsOfShape WalkingParallelPair F where


### PR DESCRIPTION
Fix insufficiently dualized doc strings.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
