### PR TITLE
[Merged by Bors] - feat(Analysis/Real): characterise when `√x ≤ x` and `x ≤ √x`

### DIFF
--- a/Mathlib/Analysis/Real/Sqrt.lean
+++ b/Mathlib/Analysis/Real/Sqrt.lean
@@ -312,6 +312,9 @@ lemma sqrt_le_sqrt_iff' (hx : 0 < x) : √x ≤ √y ↔ x ≤ y := by
   · simp [hx.trans]
   · rw [le_sqrt' hx, sq, mul_le_iff_le_one_left hx]
 
+@[simp] lemma sqrt_lt_self : √x < x ↔ 1 < x := by simp [← not_le]
+@[simp] lemma lt_sqrt_self : x < √x ↔ x ≠ 0 ∧ x < 1 := by simp [← not_le]
+
 end Real
 
 namespace Mathlib.Meta.Positivity

--- a/Mathlib/Analysis/Real/Sqrt.lean
+++ b/Mathlib/Analysis/Real/Sqrt.lean
@@ -303,17 +303,17 @@ lemma sqrt_le_sqrt_iff' (hx : 0 < x) : √x ≤ √y ↔ x ≤ y := by
 @[simp] lemma isSquare_iff : IsSquare x ↔ 0 ≤ x :=
   ⟨(·.nonneg), (⟨√x, mul_self_sqrt · |>.symm⟩)⟩
 
-@[simp] lemma sqrt_le_self : √x ≤ x ↔ x = 0 ∨ 1 ≤ x := by
+@[simp] lemma sqrt_le_self_iff : √x ≤ x ↔ x = 0 ∨ 1 ≤ x := by
   rw [sqrt_le_iff, ← sub_nonneg (a := x ^ 2), sq, ← mul_sub_one]
   grind [mul_nonneg_iff]
 
-@[simp] lemma le_sqrt_self : x ≤ √x ↔ x ≤ 1 := by
+@[simp] lemma le_sqrt_self_iff : x ≤ √x ↔ x ≤ 1 := by
   obtain hx | hx := le_or_gt x 0
   · simp [hx.trans]
   · rw [le_sqrt' hx, sq, mul_le_iff_le_one_left hx]
 
-@[simp] lemma sqrt_lt_self : √x < x ↔ 1 < x := by simp [← not_le]
-@[simp] lemma lt_sqrt_self : x < √x ↔ x ≠ 0 ∧ x < 1 := by simp [← not_le]
+@[simp] lemma sqrt_lt_self_iff : √x < x ↔ 1 < x := by simp [← not_le]
+@[simp] lemma lt_sqrt_self_iff : x < √x ↔ x ≠ 0 ∧ x < 1 := by simp [← not_le]
 
 end Real
 

--- a/Mathlib/Analysis/Real/Sqrt.lean
+++ b/Mathlib/Analysis/Real/Sqrt.lean
@@ -303,6 +303,16 @@ lemma sqrt_le_sqrt_iff' (hx : 0 < x) : √x ≤ √y ↔ x ≤ y := by
 @[simp] lemma isSquare_iff : IsSquare x ↔ 0 ≤ x :=
   ⟨(·.nonneg), (⟨√x, mul_self_sqrt · |>.symm⟩)⟩
 
+@[simp] lemma sqrt_le_self : √x ≤ x ↔ x = 0 ∨ 1 ≤ x := by
+  obtain hx | hx := le_or_gt x 0
+  · simp [sqrt_eq_zero_of_nonpos hx, le_antisymm_iff, hx, not_le.2 (hx.trans_lt zero_lt_one)]
+  · simp [sqrt_le_iff, sq, le_mul_iff_one_le_right hx, hx.le, hx.ne']
+
+@[simp] lemma le_sqrt_self : x ≤ √x ↔ x ≤ 1 := by
+  obtain hx | hx := le_or_gt x 0
+  · simp [hx.trans]
+  · rw [le_sqrt' hx, sq, mul_le_iff_le_one_left hx]
+
 end Real
 
 namespace Mathlib.Meta.Positivity

--- a/Mathlib/Analysis/Real/Sqrt.lean
+++ b/Mathlib/Analysis/Real/Sqrt.lean
@@ -304,9 +304,8 @@ lemma sqrt_le_sqrt_iff' (hx : 0 < x) : √x ≤ √y ↔ x ≤ y := by
   ⟨(·.nonneg), (⟨√x, mul_self_sqrt · |>.symm⟩)⟩
 
 @[simp] lemma sqrt_le_self : √x ≤ x ↔ x = 0 ∨ 1 ≤ x := by
-  obtain hx | hx := le_or_gt x 0
-  · simp [sqrt_eq_zero_of_nonpos hx, le_antisymm_iff, hx, not_le.2 (hx.trans_lt zero_lt_one)]
-  · simp [sqrt_le_iff, sq, le_mul_iff_one_le_right hx, hx.le, hx.ne']
+  rw [sqrt_le_iff, ← sub_nonneg (a := x ^ 2), sq, ← mul_sub_one]
+  grind [mul_nonneg_iff]
 
 @[simp] lemma le_sqrt_self : x ≤ √x ↔ x ≤ 1 := by
   obtain hx | hx := le_or_gt x 0


### PR DESCRIPTION
From APAP


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
