### PR TITLE
feat(NumberTheory): the double coset API for abstract Hecke rings

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5734,6 +5734,7 @@ public import Mathlib.NumberTheory.Harmonic.EulerMascheroni
 public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
+public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5734,6 +5734,7 @@ public import Mathlib.NumberTheory.Harmonic.EulerMascheroni
 public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
+public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve
 public import Mathlib.NumberTheory.Height.MvPolynomial

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -569,5 +569,10 @@ lemma conjAct_pointwise_smul_eq_self {H : Subgroup G} {g : G} (hg : g ∈ normal
     ConjAct.toConjAct g • H = H :=
   conjAct_pointwise_smul_iff.2 hg
 
+lemma mem_conjAct_pointwise_smul_iff {H : Subgroup G} {g x : G} :
+    x ∈ ConjAct.toConjAct g • H ↔ g⁻¹ * x * g ∈ H := by
+  rw [mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv, ConjAct.smul_def,
+    ConjAct.ofConjAct_toConjAct, inv_inv]
+
 end Group
 end Subgroup

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -55,6 +55,14 @@ lemma doubleCoset_eq_of_mem {H K : Subgroup G} {a b : G} (hb : b ∈ doubleCoset
     mul_assoc, mul_assoc, Subgroup.singleton_mul_subgroup hk, ← mul_assoc, ← mul_assoc,
     Subgroup.subgroup_mul_singleton hh]
 
+lemma doubleCoset_mul_left {H : Subgroup G} (K : Subgroup G) {h : G} (hh : h ∈ H) (a : G) :
+    doubleCoset (h * a) H K = doubleCoset a H K :=
+  doubleCoset_eq_of_mem (mem_doubleCoset.mpr ⟨h, hh, 1, K.one_mem, (mul_one _).symm⟩)
+
+lemma doubleCoset_mul_right (H : Subgroup G) {K : Subgroup G} {k : G} (hk : k ∈ K) (a : G) :
+    doubleCoset (a * k) H K = doubleCoset a H K :=
+  doubleCoset_eq_of_mem (mem_doubleCoset.mpr ⟨1, H.one_mem, k, hk, by rw [one_mul]⟩)
+
 lemma mem_doubleCoset_of_not_disjoint {H K : Subgroup G} {a b : G}
     (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) : b ∈ doubleCoset a H K := by
   rw [Set.not_disjoint_iff] at h
@@ -190,6 +198,26 @@ lemma doubleCoset_union_leftCoset (H K : Subgroup G) (a : G) :
     simp only [hxy, ← mul_assoc, hy, one_mul, inv_mul_cancel, inv_mul_cancel_right]
 
 open Quotient QuotientGroup
+
+/-- A double coset `HaK` is the union of the left cosets `(h * a) • K` where `h` ranges over
+representatives of the quotient of `H` by the stabiliser `H ∩ aKa⁻¹`. -/
+lemma doubleCoset_eq_iUnion_leftCosets (H K : Subgroup G) (a : G) :
+    doubleCoset a H K =
+      ⋃ i : H ⧸ (ConjAct.toConjAct a • K).subgroupOf H, ((i.out : G) * a) • (K : Set G) := by
+  ext x
+  simp only [Set.mem_iUnion, mem_doubleCoset, mem_leftCoset_iff, SetLike.mem_coe]
+  constructor
+  · rintro ⟨h, hh, k, hk, rfl⟩
+    refine ⟨QuotientGroup.mk ⟨h, hh⟩, ?_⟩
+    obtain ⟨n, hn⟩ := QuotientGroup.mk_out_eq_mul ((ConjAct.toConjAct a • K).subgroupOf H) ⟨h, hh⟩
+    have hn' : a⁻¹ * ((n : H) : G) * a ∈ K :=
+      Subgroup.mem_conjAct_pointwise_smul_iff.mp (Subgroup.mem_subgroupOf.mp n.2)
+    rw [hn, show (((⟨h, hh⟩ : H) * (n : H) : H) : G) = h * ((n : H) : G) from rfl,
+      show (h * ((n : H) : G) * a)⁻¹ * (h * a * k) = (a⁻¹ * ((n : H) : G) * a)⁻¹ * k by
+        simp [mul_assoc]]
+    exact K.mul_mem (K.inv_mem hn') hk
+  · rintro ⟨i, hx⟩
+    exact ⟨(i.out : G), i.out.2, ((i.out : G) * a)⁻¹ * x, hx, (mul_inv_cancel_left _ _).symm⟩
 
 lemma left_bot_eq_left_quot (H : Subgroup G) :
     Quotient (⊥ : Subgroup G) (H : Set G) = (G ⧸ H) := by

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -1,0 +1,270 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.HeckeRing.Defs
+public import Mathlib.GroupTheory.Index
+public import Mathlib.Tactic.Group
+
+/-!
+# Hecke rings: the double coset API
+
+Basic API for the double cosets `HeckeCoset` that index an abstract Hecke ring, following
+Shimura, *Introduction to the Arithmetic Theory of Automorphic Functions*, Ch. 3. This file develops
+representatives of double cosets, the characterisation of when two elements give the same double
+coset, the decomposition of a double coset into left cosets of `H`, and the finite decomposition
+quotient `H / (H ∩ gHg⁻¹)` used to define the Hecke product in later files.
+
+## Main definitions
+
+* `HeckeCoset.toSet`: the underlying set `HgH` of a double coset.
+* `HeckeCoset.rep`: a chosen representative in `Δ`.
+* `HeckeCoset.one`: the identity double coset `H1H = H`.
+* `HeckeRing.decompQuot`: the finite quotient `H / (H ∩ gHg⁻¹)` indexing the left cosets in `HgH`.
+
+## Main results
+
+* `HeckeCoset.eq_iff`: `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`.
+* `HeckeRing.doubleCoset_eq_iUnion_leftCosets`: a double coset `HgH` as a union of left cosets.
+
+## Implementation notes
+
+`HeckeRing.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
+`attribute [local instance]` so that the quotient notation `⟦·⟧` is available for `HeckeCoset`.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup
+open scoped Pointwise
+
+variable {G : Type*} [Group G]
+
+attribute [local instance] doubleCosetSetoid
+
+variable (H : Subgroup G)
+
+namespace HeckeRing
+
+/-- The conjugation action on `H` as a set product: `gHg⁻¹ = {g} * H * {g⁻¹}`. -/
+lemma conjAct_smul_coe_eq (g : G) :
+    ((ConjAct.toConjAct g • H) : Set G) = {g} * H * {g⁻¹} := by
+  ext x
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · obtain ⟨a, ha⟩ := Set.mem_smul_set.mp h
+    rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct] at ha
+    rw [← ha.2]
+    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
+      inv_inv, mem_preimage, inv_mul_cancel_right, inv_mul_cancel_left, ha.1]
+  · refine Set.mem_smul_set.mpr ⟨g⁻¹ * x * g, ?_,
+      by rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct]; group⟩
+    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
+      inv_inv, mem_preimage, SetLike.mem_coe] at *
+    rwa [← mul_assoc] at h
+
+/-- Conjugation by an element of `H` fixes `H`. -/
+lemma conjAct_smul_elt_eq (h : H) : ConjAct.toConjAct (h : G) • H = H := by
+  have : ConjAct.toConjAct (h : G) • (H : Set G) = H := by
+    rw [conjAct_smul_coe_eq, Subgroup.singleton_mul_subgroup h.2,
+      Subgroup.subgroup_mul_singleton (by simp)]
+  rw [← Subgroup.coe_pointwise_smul] at this; exact_mod_cast this
+
+/-- Scalar multiplication by a group element is the same as singleton set multiplication. -/
+lemma smul_eq_singleton_mul (s : Set G) (g : G) : g • s = {g} * s :=
+  Set.singleton_smul.symm
+
+/-- A subgroup `H` is the union of left cosets of any sub-subgroup `K ≤ H`. -/
+lemma set_eq_iUnion_leftCosets (K : Subgroup G) (hK : K ≤ H) :
+    (H : Set G) = ⋃ (i : H ⧸ K.subgroupOf H), (i.out : G) • (K : Set G) := by
+  ext a
+  refine ⟨fun ha ↦ ?_, fun ha ↦ ?_⟩
+  · simp only [Set.mem_iUnion]
+    refine ⟨(⟨a, ha⟩ : H), ?_⟩
+    obtain ⟨h, hh⟩ := QuotientGroup.mk_out_eq_mul (K.subgroupOf H) (⟨a, ha⟩ : H)
+    rw [hh]
+    simp only [coe_mul]
+    refine Set.mem_smul_set.mpr ⟨h⁻¹, ?_, ?_⟩
+    · simpa using Subgroup.mem_subgroupOf.mp (SetLike.coe_mem h)
+    · simp
+  · simp only [Set.mem_iUnion] at ha
+    obtain ⟨i, h, hh, rfl⟩ := ha
+    change ((Quotient.out i : H) : G) * h ∈ H
+    exact mul_mem (by simp) (hK hh)
+
+/-- The conjugate subgroup `gHg⁻¹` is closed under multiplication. -/
+lemma conjAct_mul_self_eq_self (g : G) :
+    ((ConjAct.toConjAct g • H) : Set G) * (ConjAct.toConjAct g • H) =
+    (ConjAct.toConjAct g • H) := by
+  rw [conjAct_smul_coe_eq,
+    show {g} * (H : Set G) * {g⁻¹} * ({g} * ↑H * {g⁻¹}) =
+      {g} * ↑H * (({g⁻¹} * {g}) * ↑H) * {g⁻¹} by simp_rw [← mul_assoc],
+    Set.singleton_mul_singleton]
+  conv => enter [1, 1, 2]; simp only [inv_mul_cancel, Set.singleton_one, one_mul]
+  conv => enter [1, 1]; rw [mul_assoc, coe_mul_coe H]
+
+/-- The intersection `H ∩ gHg⁻¹` acts trivially on `gHg⁻¹` by left multiplication. -/
+lemma inter_mul_conjAct_eq_conjAct (g : G) :
+    ((H : Set G) ∩ (ConjAct.toConjAct g • H)) * (ConjAct.toConjAct g • H) =
+    (ConjAct.toConjAct g • H) :=
+  Subset.antisymm
+    (le_trans (Set.inter_mul_subset (s₁ := (H : Set G))
+      (s₂ := (ConjAct.toConjAct g • H)) (t := (ConjAct.toConjAct g • H)))
+      (by simp [conjAct_mul_self_eq_self]))
+    (subset_mul_right _ ⟨Subgroup.one_mem H, Subgroup.one_mem (ConjAct.toConjAct g • H)⟩)
+
+/-- Right multiplication by a singleton is cancellative. -/
+lemma mul_singleton_right_cancel (g : G) (K L : Set G) (h : K * {g} = L * {g}) : K = L := by
+  have h2 := congrFun (congrArg HMul.hMul h) {g⁻¹}
+  simp_rw [mul_assoc, Set.singleton_mul_singleton] at h2; simpa using h2
+
+/-- A double coset `HgH` decomposes as a union of left cosets of `H`. -/
+lemma doubleCoset_eq_iUnion_leftCosets (g : G) :
+    DoubleCoset.doubleCoset g H H =
+    ⋃ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
+      (i.out * g) • (H : Set G) := by
+  rw [DoubleCoset.doubleCoset]
+  have := set_eq_iUnion_leftCosets H
+    (((ConjAct.toConjAct g • H).subgroupOf H).map H.subtype)
+  simp only [Subgroup.subgroupOf_map_subtype, inf_le_right, Subgroup.coe_inf,
+    Subgroup.coe_pointwise_smul, true_implies] at this
+  have h2 := congrFun (congrArg HMul.hMul this)
+    ((ConjAct.toConjAct g • H) : Set G)
+  rw [Set.iUnion_mul, inter_comm] at h2
+  apply mul_singleton_right_cancel g⁻¹
+  rw [conjAct_smul_coe_eq] at *
+  simp_rw [← mul_assoc] at h2
+  rw [h2, show (Subgroup.map H.subtype
+    ((ConjAct.toConjAct g • H).subgroupOf H)).subgroupOf H =
+    (ConjAct.toConjAct g • H).subgroupOf H by simp]
+  have h1 : ∀ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
+      ((i.out) : G) • ((H : Set G) ∩ ({g} * ↑H * {g⁻¹})) *
+        {g} * ↑H * {g⁻¹} =
+      (↑(Quotient.out i) * g) • ↑H * {g⁻¹} := by
+    intro i
+    have := inter_mul_conjAct_eq_conjAct H g
+    rw [conjAct_smul_coe_eq] at this
+    simp_rw [smul_mul_assoc]
+    simp_rw [← mul_assoc] at this
+    conv => enter [1, 2]; rw [this]
+    simp_rw [smul_eq_singleton_mul, ← Set.singleton_mul_singleton, ← mul_assoc]
+  convert Set.iUnion_congr h1
+  rw [Set.iUnion_mul]
+
+end HeckeRing
+
+namespace HeckeCoset
+
+variable {P : HeckePair G}
+
+/-- The underlying set `HgH`, well-defined on the quotient. -/
+noncomputable def toSet (D : HeckeCoset P) : Set G :=
+  Quotient.lift (fun (g : P.Δ) ↦ DoubleCoset.doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
+
+/-- A representative `g : Δ` (via `Quotient.out`). -/
+noncomputable def rep (D : HeckeCoset P) : P.Δ := Quotient.out D
+
+/-- The representative of a `HeckeCoset` maps back to the coset under `⟦·⟧`. -/
+lemma mk_rep (D : HeckeCoset P) : (⟦HeckeCoset.rep D⟧ : HeckeCoset P) = D :=
+  Quotient.out_eq D
+
+/-- `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`. -/
+lemma eq_iff (g h : P.Δ) : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
+    DoubleCoset.doubleCoset (g : G) P.H P.H = DoubleCoset.doubleCoset (h : G) P.H P.H :=
+  Quotient.eq
+
+/-- The carrier set of `⟦g⟧` is definitionally `HgH`. -/
+@[simp] lemma toSet_mk (g : P.Δ) :
+    HeckeCoset.toSet (⟦g⟧ : HeckeCoset P) = DoubleCoset.doubleCoset (g : G) P.H P.H := rfl
+
+/-- The carrier set equals the double coset of the representative. -/
+lemma toSet_eq_rep (D : HeckeCoset P) :
+    HeckeCoset.toSet D = DoubleCoset.doubleCoset (HeckeCoset.rep D : G) P.H P.H := by
+  refine Quotient.inductionOn D fun g ↦ ?_
+  simpa only [toSet_mk, HeckeCoset.rep] using
+    (Quotient.exact (Quotient.out_eq (⟦g⟧ : HeckeCoset P))).symm
+
+/-- The representative lies in its double coset. -/
+lemma rep_mem (D : HeckeCoset P) : (HeckeCoset.rep D : G) ∈ HeckeCoset.toSet D :=
+  toSet_eq_rep D ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
+
+/-- If `x ∈ HgH`, then `HxH = HgH`. The fundamental double coset absorption lemma. -/
+lemma doubleCoset_eq_of_mem {g : P.Δ} {x : G}
+    (hx : x ∈ DoubleCoset.doubleCoset (g : G) P.H P.H) :
+    DoubleCoset.doubleCoset x P.H P.H = DoubleCoset.doubleCoset (g : G) P.H P.H := by
+  obtain ⟨_, ⟨l, hl, _, rfl, rfl⟩, r, hr, rfl⟩ := hx
+  simp only [DoubleCoset.doubleCoset]
+  ext y; simp only [Set.mem_mul, Set.mem_singleton_iff, SetLike.mem_coe]
+  constructor
+  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
+    exact ⟨_, ⟨a * l, P.H.mul_mem ha hl, _, rfl, rfl⟩, r * b, P.H.mul_mem hr hb, by group⟩
+  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
+    exact ⟨_, ⟨a * l⁻¹, P.H.mul_mem ha (P.H.inv_mem hl), _, rfl, rfl⟩,
+      r⁻¹ * b, P.H.mul_mem (P.H.inv_mem hr) hb, by group⟩
+
+/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` is in the double coset of `g₂`. -/
+lemma eq_mk_of_mem {g₁ g₂ : P.Δ}
+    (h : (g₁ : G) ∈ DoubleCoset.doubleCoset (g₂ : G) P.H P.H) :
+    (⟦g₁⟧ : HeckeCoset P) = ⟦g₂⟧ :=
+  (eq_iff g₁ g₂).mpr (doubleCoset_eq_of_mem h)
+
+/-- The identity double coset `H1H = H`. -/
+def one (P : HeckePair G) : HeckeCoset P := ⟦⟨1, P.Δ.one_mem⟩⟧
+
+/-- Induction: to prove something for all double cosets, prove it for `⟦g⟧`. -/
+protected lemma ind {motive : HeckeCoset P → Prop}
+    (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D := Quotient.ind h
+
+/-- Two-argument induction. -/
+protected lemma ind₂ {motive : HeckeCoset P → HeckeCoset P → Prop}
+    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) :
+    ∀ D₁ D₂, motive D₁ D₂ := Quotient.ind₂ h
+
+/-- The representative of `HeckeCoset.one` belongs to `H`. -/
+lemma one_rep_mem_H (P : HeckePair G) : ((one P).rep : G) ∈ P.H := by
+  have hm := rep_mem (one P)
+  rw [toSet_eq_rep,
+    show DoubleCoset.doubleCoset ((rep (one P)) : G) P.H P.H =
+      DoubleCoset.doubleCoset (1 : G) P.H P.H from
+    Quotient.exact (Quotient.out_eq (⟦⟨(1 : G), P.Δ.one_mem⟩⟧ : HeckeCoset P)),
+    mem_doubleCoset] at hm
+  obtain ⟨a, ha, b, hb, hab⟩ := hm
+  rw [mul_one] at hab
+  exact hab ▸ P.H.mul_mem ha hb
+
+end HeckeCoset
+
+namespace HeckeRing
+
+/-- Left-multiplying the representative by an element of `H` does not change the double coset. -/
+lemma doubleCoset_mul_left_eq_self (P : HeckePair G) (h : P.H) (g : G) :
+    DoubleCoset.doubleCoset ((h : G) * g) P.H P.H =
+    DoubleCoset.doubleCoset g P.H P.H := by
+  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
+  conv => enter [1, 1, 1]; rw [Subgroup.subgroup_mul_singleton h.2]
+
+/-- Right-multiplying the representative by an element of `H` does not change the double coset. -/
+lemma doubleCoset_mul_right_eq_self (P : HeckePair G)
+    (h : P.H) (g : G) : DoubleCoset.doubleCoset (g * h) P.H P.H =
+    DoubleCoset.doubleCoset g P.H P.H := by
+  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
+  conv => enter [1]; rw [mul_assoc, Subgroup.singleton_mul_subgroup h.2]
+
+/-- The decomposition quotient `H / (H ∩ gHg⁻¹)` for a concrete `g : Δ`.
+Indexes the left cosets in the decomposition of `HgH`. -/
+abbrev decompQuot (P : HeckePair G) (g : P.Δ) :=
+  P.H ⧸ (ConjAct.toConjAct (g : G) • P.H).subgroupOf P.H
+
+/-- The decomposition quotient is finite because `Δ ≤ commensurator H`. -/
+noncomputable instance (P : HeckePair G) (g : P.Δ) :
+    Fintype (decompQuot P g) :=
+  Subgroup.fintypeOfIndexNeZero (P.h₁ g.2).1
+
+/-- Products of the form `a * h * b` with `h ∈ H`, `a, b ∈ Δ` remain in `Δ`. -/
+lemma delta_mul_mem (Δ : Submonoid G) (i : H) (a b : Δ) (h₀ : H.toSubmonoid ≤ Δ) :
+    a * (i : G) * b ∈ Δ := by
+  rw [mul_assoc]; exact Submonoid.mul_mem _ a.2 (Submonoid.mul_mem _ (h₀ i.2) b.2)
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -7,264 +7,112 @@ module
 
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.GroupTheory.Index
-public import Mathlib.Tactic.Group
 
 /-!
 # Hecke rings: the double coset API
 
-Basic API for the double cosets `HeckeCoset` that index an abstract Hecke ring, following
-Shimura, *Introduction to the Arithmetic Theory of Automorphic Functions*, Ch. 3. This file develops
-representatives of double cosets, the characterisation of when two elements give the same double
-coset, the decomposition of a double coset into left cosets of `H`, and the finite decomposition
-quotient `H / (H ∩ gHg⁻¹)` used to define the Hecke product in later files.
+Basic API for the double cosets `HeckeCoset` indexing an abstract Hecke ring, following
+[Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
+characterisation of when two elements give the same double coset, and the quotient
+`Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
+define the Hecke product in later files and is finite in the Hecke pair setting.
 
 ## Main definitions
 
 * `HeckeCoset.toSet`: the underlying set `HgH` of a double coset.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
-* `HeckeCoset.one`: the identity double coset `H1H = H`.
-* `HeckeRing.decompQuot`: the finite quotient `H / (H ∩ gHg⁻¹)` indexing the left cosets in `HgH`.
+* `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
+  in `Γ₁gΓ₂`; finite for a Hecke pair.
 
 ## Main results
 
 * `HeckeCoset.eq_iff`: `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`.
-* `HeckeRing.doubleCoset_eq_iUnion_leftCosets`: a double coset `HgH` as a union of left cosets.
+* `HeckeCoset.toSet_injective`: a double coset is determined by its underlying set.
 
 ## Implementation notes
 
-`HeckeRing.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
+`HeckePair.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
 `attribute [local instance]` so that the quotient notation `⟦·⟧` is available for `HeckeCoset`.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup
+open DoubleCoset Subgroup
 open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
-attribute [local instance] doubleCosetSetoid
-
-variable (H : Subgroup G)
-
-namespace HeckeRing
-
-/-- The conjugation action on `H` as a set product: `gHg⁻¹ = {g} * H * {g⁻¹}`. -/
-lemma conjAct_smul_coe_eq (g : G) :
-    ((ConjAct.toConjAct g • H) : Set G) = {g} * H * {g⁻¹} := by
-  ext x
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · obtain ⟨a, ha⟩ := Set.mem_smul_set.mp h
-    rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct] at ha
-    rw [← ha.2]
-    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
-      inv_inv, mem_preimage, inv_mul_cancel_right, inv_mul_cancel_left, ha.1]
-  · refine Set.mem_smul_set.mpr ⟨g⁻¹ * x * g, ?_,
-      by rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct]; group⟩
-    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
-      inv_inv, mem_preimage, SetLike.mem_coe] at *
-    rwa [← mul_assoc] at h
-
-/-- Conjugation by an element of `H` fixes `H`. -/
-lemma conjAct_smul_elt_eq (h : H) : ConjAct.toConjAct (h : G) • H = H := by
-  have : ConjAct.toConjAct (h : G) • (H : Set G) = H := by
-    rw [conjAct_smul_coe_eq, Subgroup.singleton_mul_subgroup h.2,
-      Subgroup.subgroup_mul_singleton (by simp)]
-  rw [← Subgroup.coe_pointwise_smul] at this; exact_mod_cast this
-
-/-- Scalar multiplication by a group element is the same as singleton set multiplication. -/
-lemma smul_eq_singleton_mul (s : Set G) (g : G) : g • s = {g} * s :=
-  Set.singleton_smul.symm
-
-/-- A subgroup `H` is the union of left cosets of any sub-subgroup `K ≤ H`. -/
-lemma set_eq_iUnion_leftCosets (K : Subgroup G) (hK : K ≤ H) :
-    (H : Set G) = ⋃ (i : H ⧸ K.subgroupOf H), (i.out : G) • (K : Set G) := by
-  ext a
-  refine ⟨fun ha ↦ ?_, fun ha ↦ ?_⟩
-  · simp only [Set.mem_iUnion]
-    refine ⟨(⟨a, ha⟩ : H), ?_⟩
-    obtain ⟨h, hh⟩ := QuotientGroup.mk_out_eq_mul (K.subgroupOf H) (⟨a, ha⟩ : H)
-    rw [hh]
-    simp only [coe_mul]
-    refine Set.mem_smul_set.mpr ⟨h⁻¹, ?_, ?_⟩
-    · simpa using Subgroup.mem_subgroupOf.mp (SetLike.coe_mem h)
-    · simp
-  · simp only [Set.mem_iUnion] at ha
-    obtain ⟨i, h, hh, rfl⟩ := ha
-    change ((Quotient.out i : H) : G) * h ∈ H
-    exact mul_mem (by simp) (hK hh)
-
-/-- The conjugate subgroup `gHg⁻¹` is closed under multiplication. -/
-lemma conjAct_mul_self_eq_self (g : G) :
-    ((ConjAct.toConjAct g • H) : Set G) * (ConjAct.toConjAct g • H) =
-    (ConjAct.toConjAct g • H) := by
-  rw [conjAct_smul_coe_eq,
-    show {g} * (H : Set G) * {g⁻¹} * ({g} * ↑H * {g⁻¹}) =
-      {g} * ↑H * (({g⁻¹} * {g}) * ↑H) * {g⁻¹} by simp_rw [← mul_assoc],
-    Set.singleton_mul_singleton]
-  conv => enter [1, 1, 2]; simp only [inv_mul_cancel, Set.singleton_one, one_mul]
-  conv => enter [1, 1]; rw [mul_assoc, coe_mul_coe H]
-
-/-- The intersection `H ∩ gHg⁻¹` acts trivially on `gHg⁻¹` by left multiplication. -/
-lemma inter_mul_conjAct_eq_conjAct (g : G) :
-    ((H : Set G) ∩ (ConjAct.toConjAct g • H)) * (ConjAct.toConjAct g • H) =
-    (ConjAct.toConjAct g • H) :=
-  Subset.antisymm
-    (le_trans (Set.inter_mul_subset (s₁ := (H : Set G))
-      (s₂ := (ConjAct.toConjAct g • H)) (t := (ConjAct.toConjAct g • H)))
-      (by simp [conjAct_mul_self_eq_self]))
-    (subset_mul_right _ ⟨Subgroup.one_mem H, Subgroup.one_mem (ConjAct.toConjAct g • H)⟩)
-
-/-- Right multiplication by a singleton is cancellative. -/
-lemma mul_singleton_right_cancel (g : G) (K L : Set G) (h : K * {g} = L * {g}) : K = L := by
-  have h2 := congrFun (congrArg HMul.hMul h) {g⁻¹}
-  simp_rw [mul_assoc, Set.singleton_mul_singleton] at h2; simpa using h2
-
-/-- A double coset `HgH` decomposes as a union of left cosets of `H`. -/
-lemma doubleCoset_eq_iUnion_leftCosets (g : G) :
-    DoubleCoset.doubleCoset g H H =
-    ⋃ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
-      (i.out * g) • (H : Set G) := by
-  rw [DoubleCoset.doubleCoset]
-  have := set_eq_iUnion_leftCosets H
-    (((ConjAct.toConjAct g • H).subgroupOf H).map H.subtype)
-  simp only [Subgroup.subgroupOf_map_subtype, inf_le_right, Subgroup.coe_inf,
-    Subgroup.coe_pointwise_smul, true_implies] at this
-  have h2 := congrFun (congrArg HMul.hMul this)
-    ((ConjAct.toConjAct g • H) : Set G)
-  rw [Set.iUnion_mul, inter_comm] at h2
-  apply mul_singleton_right_cancel g⁻¹
-  rw [conjAct_smul_coe_eq] at *
-  simp_rw [← mul_assoc] at h2
-  rw [h2, show (Subgroup.map H.subtype
-    ((ConjAct.toConjAct g • H).subgroupOf H)).subgroupOf H =
-    (ConjAct.toConjAct g • H).subgroupOf H by simp]
-  have h1 : ∀ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
-      ((i.out) : G) • ((H : Set G) ∩ ({g} * ↑H * {g⁻¹})) *
-        {g} * ↑H * {g⁻¹} =
-      (↑(Quotient.out i) * g) • ↑H * {g⁻¹} := by
-    intro i
-    have := inter_mul_conjAct_eq_conjAct H g
-    rw [conjAct_smul_coe_eq] at this
-    simp_rw [smul_mul_assoc]
-    simp_rw [← mul_assoc] at this
-    conv => enter [1, 2]; rw [this]
-    simp_rw [smul_eq_singleton_mul, ← Set.singleton_mul_singleton, ← mul_assoc]
-  convert Set.iUnion_congr h1
-  rw [Set.iUnion_mul]
-
-end HeckeRing
+attribute [local instance] HeckePair.doubleCosetSetoid
 
 namespace HeckeCoset
 
 variable {P : HeckePair G}
 
-/-- The underlying set `HgH`, well-defined on the quotient. -/
-noncomputable def toSet (D : HeckeCoset P) : Set G :=
-  Quotient.lift (fun (g : P.Δ) ↦ DoubleCoset.doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
+/-- The underlying set `HgH` of a double coset, well-defined on the quotient. -/
+def toSet (D : HeckeCoset P) : Set G :=
+  Quotient.lift (fun g : P.Δ ↦ doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
 
-/-- A representative `g : Δ` (via `Quotient.out`). -/
+/-- A representative `g : Δ` of a double coset (via `Quotient.out`). -/
 noncomputable def rep (D : HeckeCoset P) : P.Δ := Quotient.out D
 
-/-- The representative of a `HeckeCoset` maps back to the coset under `⟦·⟧`. -/
-lemma mk_rep (D : HeckeCoset P) : (⟦HeckeCoset.rep D⟧ : HeckeCoset P) = D :=
-  Quotient.out_eq D
+@[simp] lemma mk_rep (D : HeckeCoset P) : (⟦D.rep⟧ : HeckeCoset P) = D := Quotient.out_eq D
 
-/-- `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`. -/
-lemma eq_iff (g h : P.Δ) : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
-    DoubleCoset.doubleCoset (g : G) P.H P.H = DoubleCoset.doubleCoset (h : G) P.H P.H :=
-  Quotient.eq
+lemma eq_iff {g h : P.Δ} : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
+    doubleCoset (g : G) P.H P.H = doubleCoset (h : G) P.H P.H := Quotient.eq
 
-/-- The carrier set of `⟦g⟧` is definitionally `HgH`. -/
 @[simp] lemma toSet_mk (g : P.Δ) :
-    HeckeCoset.toSet (⟦g⟧ : HeckeCoset P) = DoubleCoset.doubleCoset (g : G) P.H P.H := rfl
+    toSet (⟦g⟧ : HeckeCoset P) = doubleCoset (g : G) P.H P.H := rfl
 
-/-- The carrier set equals the double coset of the representative. -/
-lemma toSet_eq_rep (D : HeckeCoset P) :
-    HeckeCoset.toSet D = DoubleCoset.doubleCoset (HeckeCoset.rep D : G) P.H P.H := by
-  refine Quotient.inductionOn D fun g ↦ ?_
-  simpa only [toSet_mk, HeckeCoset.rep] using
-    (Quotient.exact (Quotient.out_eq (⟦g⟧ : HeckeCoset P))).symm
+lemma toSet_eq_doubleCoset_rep (D : HeckeCoset P) :
+    D.toSet = doubleCoset (D.rep : G) P.H P.H := by rw [← toSet_mk, mk_rep]
 
-/-- The representative lies in its double coset. -/
-lemma rep_mem (D : HeckeCoset P) : (HeckeCoset.rep D : G) ∈ HeckeCoset.toSet D :=
-  toSet_eq_rep D ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
+lemma toSet_injective : Function.Injective (toSet : HeckeCoset P → Set G) := fun D₁ D₂ ↦
+  Quotient.inductionOn₂ D₁ D₂ fun _ _ h ↦ Quotient.sound h
 
-/-- If `x ∈ HgH`, then `HxH = HgH`. The fundamental double coset absorption lemma. -/
-lemma doubleCoset_eq_of_mem {g : P.Δ} {x : G}
-    (hx : x ∈ DoubleCoset.doubleCoset (g : G) P.H P.H) :
-    DoubleCoset.doubleCoset x P.H P.H = DoubleCoset.doubleCoset (g : G) P.H P.H := by
-  obtain ⟨_, ⟨l, hl, _, rfl, rfl⟩, r, hr, rfl⟩ := hx
-  simp only [DoubleCoset.doubleCoset]
-  ext y; simp only [Set.mem_mul, Set.mem_singleton_iff, SetLike.mem_coe]
-  constructor
-  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
-    exact ⟨_, ⟨a * l, P.H.mul_mem ha hl, _, rfl, rfl⟩, r * b, P.H.mul_mem hr hb, by group⟩
-  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
-    exact ⟨_, ⟨a * l⁻¹, P.H.mul_mem ha (P.H.inv_mem hl), _, rfl, rfl⟩,
-      r⁻¹ * b, P.H.mul_mem (P.H.inv_mem hr) hb, by group⟩
+lemma rep_mem (D : HeckeCoset P) : (D.rep : G) ∈ D.toSet :=
+  D.toSet_eq_doubleCoset_rep ▸ mem_doubleCoset_self P.H P.H _
 
-/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` is in the double coset of `g₂`. -/
-lemma eq_mk_of_mem {g₁ g₂ : P.Δ}
-    (h : (g₁ : G) ∈ DoubleCoset.doubleCoset (g₂ : G) P.H P.H) :
+/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` lies in the double coset of `g₂`. -/
+lemma mk_eq_mk_of_mem {g₁ g₂ : P.Δ} (h : (g₁ : G) ∈ doubleCoset (g₂ : G) P.H P.H) :
     (⟦g₁⟧ : HeckeCoset P) = ⟦g₂⟧ :=
-  (eq_iff g₁ g₂).mpr (doubleCoset_eq_of_mem h)
-
-/-- The identity double coset `H1H = H`. -/
-def one (P : HeckePair G) : HeckeCoset P := ⟦⟨1, P.Δ.one_mem⟩⟧
+  eq_iff.mpr (doubleCoset_eq_of_mem h)
 
 /-- Induction: to prove something for all double cosets, prove it for `⟦g⟧`. -/
-protected lemma ind {motive : HeckeCoset P → Prop}
-    (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D := Quotient.ind h
+protected lemma ind {motive : HeckeCoset P → Prop} (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D :=
+  Quotient.ind h
 
-/-- Two-argument induction. -/
+/-- Two-argument induction for double cosets. -/
 protected lemma ind₂ {motive : HeckeCoset P → HeckeCoset P → Prop}
-    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) :
-    ∀ D₁ D₂, motive D₁ D₂ := Quotient.ind₂ h
+    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) : ∀ D₁ D₂, motive D₁ D₂ :=
+  Quotient.ind₂ h
 
-/-- The representative of `HeckeCoset.one` belongs to `H`. -/
-lemma one_rep_mem_H (P : HeckePair G) : ((one P).rep : G) ∈ P.H := by
-  have hm := rep_mem (one P)
-  rw [toSet_eq_rep,
-    show DoubleCoset.doubleCoset ((rep (one P)) : G) P.H P.H =
-      DoubleCoset.doubleCoset (1 : G) P.H P.H from
-    Quotient.exact (Quotient.out_eq (⟦⟨(1 : G), P.Δ.one_mem⟩⟧ : HeckeCoset P)),
-    mem_doubleCoset] at hm
-  obtain ⟨a, ha, b, hb, hab⟩ := hm
-  rw [mul_one] at hab
-  exact hab ▸ P.H.mul_mem ha hb
+@[simp] lemma toSet_one : toSet (1 : HeckeCoset P) = (P.H : Set G) := by
+  change (P.H : Set G) * {(1 : G)} * P.H = (P.H : Set G)
+  rw [Subgroup.subgroup_mul_singleton P.H.one_mem, coe_mul_coe]
+
+lemma rep_one_mem : (rep (1 : HeckeCoset P) : G) ∈ P.H := by
+  simpa using rep_mem (1 : HeckeCoset P)
 
 end HeckeCoset
 
-namespace HeckeRing
+namespace DoubleCoset
 
-/-- Left-multiplying the representative by an element of `H` does not change the double coset. -/
-lemma doubleCoset_mul_left_eq_self (P : HeckePair G) (h : P.H) (g : G) :
-    DoubleCoset.doubleCoset ((h : G) * g) P.H P.H =
-    DoubleCoset.doubleCoset g P.H P.H := by
-  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
-  conv => enter [1, 1, 1]; rw [Subgroup.subgroup_mul_singleton h.2]
+/-- The decomposition quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)`, indexing the left cosets of `Γ₂` inside
+the double coset `Γ₁gΓ₂`; see `DoubleCoset.doubleCoset_eq_iUnion_leftCosets`. -/
+abbrev DecompQuotient (Γ₁ Γ₂ : Subgroup G) (g : G) :=
+  Γ₁ ⧸ (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁
 
-/-- Right-multiplying the representative by an element of `H` does not change the double coset. -/
-lemma doubleCoset_mul_right_eq_self (P : HeckePair G)
-    (h : P.H) (g : G) : DoubleCoset.doubleCoset (g * h) P.H P.H =
-    DoubleCoset.doubleCoset g P.H P.H := by
-  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
-  conv => enter [1]; rw [mul_assoc, Subgroup.singleton_mul_subgroup h.2]
+instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ₂ g) :=
+  ⟨QuotientGroup.mk 1⟩
 
-/-- The decomposition quotient `H / (H ∩ gHg⁻¹)` for a concrete `g : Δ`.
-Indexes the left cosets in the decomposition of `HgH`. -/
-abbrev decompQuot (P : HeckePair G) (g : P.Δ) :=
-  P.H ⧸ (ConjAct.toConjAct (g : G) • P.H).subgroupOf P.H
+end DoubleCoset
 
-/-- The decomposition quotient is finite because `Δ ≤ commensurator H`. -/
+namespace HeckePair
+
+/-- For a Hecke pair, the decomposition quotient of any `g : Δ` is finite, because `Δ` lies in
+the commensurator of `H`. -/
 noncomputable instance (P : HeckePair G) (g : P.Δ) :
-    Fintype (decompQuot P g) :=
-  Subgroup.fintypeOfIndexNeZero (P.h₁ g.2).1
+    Fintype (DecompQuotient P.H P.H (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (P.le_commensurator g.2).1
 
-/-- Products of the form `a * h * b` with `h ∈ H`, `a, b ∈ Δ` remain in `Δ`. -/
-lemma delta_mul_mem (Δ : Submonoid G) (i : H) (a b : Δ) (h₀ : H.toSubmonoid ≤ Δ) :
-    a * (i : G) * b ∈ Δ := by
-  rw [mul_assoc]; exact Submonoid.mul_mem _ a.2 (Submonoid.mul_mem _ (h₀ i.2) b.2)
-
-end HeckeRing
+end HeckePair

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -110,11 +110,4 @@ noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTripl
     (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) :=
   Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_right g).1
 
-/-- The decomposition quotient with the two subgroups swapped is finite from the same datum,
-since `Δ` also commensurates the left subgroup (`le_commensurator_left`). Lower priority, so
-that the unswapped instance is preferred in the diagonal case. -/
-noncomputable instance (priority := 900) {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
-    [IsHeckeTriple Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_left g).1
-
 end IsHeckeTriple

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -15,14 +15,14 @@ Basic API for the double cosets `HeckeCoset` indexing a Hecke coset module, foll
 [Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
 characterisation of when two elements give the same double coset, and the quotient
 `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
-define the Hecke product in later files and is finite for a Hecke coset module datum.
+define the Hecke product in later files and is finite for a Hecke triple.
 
 ## Main definitions
 
 * `HeckeCoset.toSet`: the underlying set `H₁gH₂` of a double coset.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
 * `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
-  in `Γ₁gΓ₂`; finite for a Hecke coset module datum.
+  in `Γ₁gΓ₂`; finite for a Hecke triple.
 
 ## Main results
 
@@ -102,19 +102,19 @@ instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ�
 
 end DoubleCoset
 
-namespace IsHeckeCosetModule
+namespace IsHeckeTriple
 
-/-- For a Hecke coset module datum, the decomposition quotient of any `g : Δ` is finite: `Δ`
+/-- For a Hecke triple, the decomposition quotient of any `g : Δ` is finite: `Δ`
 commensurates `H₂`, which is commensurable with `H₁`. -/
-noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
+noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]
     (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_right g).1
+  Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_right g).1
 
 /-- The decomposition quotient with the two subgroups swapped is finite from the same datum,
 since `Δ` also commensurates the left subgroup (`le_commensurator_left`). Lower priority, so
 that the unswapped instance is preferred in the diagonal case. -/
 noncomputable instance (priority := 900) {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
-    [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_left g).1
+    [IsHeckeTriple Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_left g).1
 
-end IsHeckeCosetModule
+end IsHeckeTriple

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -11,28 +11,23 @@ public import Mathlib.GroupTheory.Index
 /-!
 # Hecke rings: the double coset API
 
-Basic API for the double cosets `HeckeCoset` indexing an abstract Hecke ring, following
+Basic API for the double cosets `HeckeCoset` indexing a Hecke coset module, following
 [Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
 characterisation of when two elements give the same double coset, and the quotient
 `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
-define the Hecke product in later files and is finite in the Hecke pair setting.
+define the Hecke product in later files and is finite for a Hecke coset module datum.
 
 ## Main definitions
 
-* `HeckeCoset.toSet`: the underlying set `HgH` of a double coset.
+* `HeckeCoset.toSet`: the underlying set `H₁gH₂` of a double coset.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
 * `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
-  in `Γ₁gΓ₂`; finite for a Hecke pair.
+  in `Γ₁gΓ₂`; finite for a Hecke coset module datum.
 
 ## Main results
 
-* `HeckeCoset.eq_iff`: `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`.
+* `HeckeCoset.eq_iff`: `mk H₁ H₂ g = mk H₁ H₂ h ↔ H₁gH₂ = H₁hH₂`.
 * `HeckeCoset.toSet_injective`: a double coset is determined by its underlying set.
-
-## Implementation notes
-
-`HeckePair.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
-`attribute [local instance]` so that the quotient notation `⟦·⟧` is available for `HeckeCoset`.
 -/
 
 @[expose] public section
@@ -42,56 +37,56 @@ open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
-attribute [local instance] HeckePair.doubleCosetSetoid
-
 namespace HeckeCoset
 
-variable {P : HeckePair G}
+variable {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
 
-/-- The underlying set `HgH` of a double coset, well-defined on the quotient. -/
-def toSet (D : HeckeCoset P) : Set G :=
-  Quotient.lift (fun g : P.Δ ↦ doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
+/-- The underlying set `H₁gH₂` of a double coset, well-defined on the quotient. -/
+def toSet (D : HeckeCoset Δ H₁ H₂) : Set G :=
+  Quotient.lift (fun g : Δ ↦ doubleCoset (g : G) H₁ H₂) (fun _ _ h ↦ h) D
 
 /-- A representative `g : Δ` of a double coset (via `Quotient.out`). -/
-noncomputable def rep (D : HeckeCoset P) : P.Δ := Quotient.out D
+noncomputable def rep (D : HeckeCoset Δ H₁ H₂) : Δ := Quotient.out D
 
-@[simp] lemma mk_rep (D : HeckeCoset P) : (⟦D.rep⟧ : HeckeCoset P) = D := Quotient.out_eq D
+@[simp] lemma mk_rep (D : HeckeCoset Δ H₁ H₂) : mk H₁ H₂ D.rep = D := Quotient.out_eq' D
 
-lemma eq_iff {g h : P.Δ} : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
-    doubleCoset (g : G) P.H P.H = doubleCoset (h : G) P.H P.H := Quotient.eq
+lemma eq_iff {g h : Δ} : mk H₁ H₂ g = mk H₁ H₂ h ↔
+    doubleCoset (g : G) H₁ H₂ = doubleCoset (h : G) H₁ H₂ := Quotient.eq''
 
-@[simp] lemma toSet_mk (g : P.Δ) :
-    toSet (⟦g⟧ : HeckeCoset P) = doubleCoset (g : G) P.H P.H := rfl
+@[simp] lemma toSet_mk (g : Δ) : toSet (mk H₁ H₂ g) = doubleCoset (g : G) H₁ H₂ := rfl
 
-lemma toSet_eq_doubleCoset_rep (D : HeckeCoset P) :
-    D.toSet = doubleCoset (D.rep : G) P.H P.H := by rw [← toSet_mk, mk_rep]
+lemma toSet_eq_doubleCoset_rep (D : HeckeCoset Δ H₁ H₂) :
+    D.toSet = doubleCoset (D.rep : G) H₁ H₂ := by rw [← toSet_mk, mk_rep]
 
-lemma toSet_injective : Function.Injective (toSet : HeckeCoset P → Set G) := fun D₁ D₂ ↦
-  Quotient.inductionOn₂ D₁ D₂ fun _ _ h ↦ Quotient.sound h
+lemma toSet_injective : Function.Injective (toSet : HeckeCoset Δ H₁ H₂ → Set G) := fun D₁ D₂ ↦
+  Quotient.inductionOn₂' D₁ D₂ fun _ _ h ↦ Quotient.sound' h
 
-lemma rep_mem (D : HeckeCoset P) : (D.rep : G) ∈ D.toSet :=
-  D.toSet_eq_doubleCoset_rep ▸ mem_doubleCoset_self P.H P.H _
+lemma rep_mem (D : HeckeCoset Δ H₁ H₂) : (D.rep : G) ∈ D.toSet :=
+  D.toSet_eq_doubleCoset_rep ▸ mem_doubleCoset_self H₁ H₂ _
 
-/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` lies in the double coset of `g₂`. -/
-lemma mk_eq_mk_of_mem {g₁ g₂ : P.Δ} (h : (g₁ : G) ∈ doubleCoset (g₂ : G) P.H P.H) :
-    (⟦g₁⟧ : HeckeCoset P) = ⟦g₂⟧ :=
+/-- `mk H₁ H₂ g₁ = mk H₁ H₂ g₂` when `g₁` lies in the double coset of `g₂`. -/
+lemma mk_eq_mk_of_mem {g₁ g₂ : Δ} (h : (g₁ : G) ∈ doubleCoset (g₂ : G) H₁ H₂) :
+    mk H₁ H₂ g₁ = mk H₁ H₂ g₂ :=
   eq_iff.mpr (doubleCoset_eq_of_mem h)
 
-/-- Induction: to prove something for all double cosets, prove it for `⟦g⟧`. -/
-protected lemma ind {motive : HeckeCoset P → Prop} (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D :=
-  Quotient.ind h
+/-- Induction: to prove something for all double cosets, prove it for `mk H₁ H₂ g`. -/
+protected lemma ind {motive : HeckeCoset Δ H₁ H₂ → Prop} (h : ∀ g : Δ, motive (mk H₁ H₂ g)) :
+    ∀ D, motive D :=
+  Quotient.ind' h
 
 /-- Two-argument induction for double cosets. -/
-protected lemma ind₂ {motive : HeckeCoset P → HeckeCoset P → Prop}
-    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) : ∀ D₁ D₂, motive D₁ D₂ :=
-  Quotient.ind₂ h
+protected lemma ind₂ {motive : HeckeCoset Δ H₁ H₂ → HeckeCoset Δ H₁ H₂ → Prop}
+    (h : ∀ g₁ g₂ : Δ, motive (mk H₁ H₂ g₁) (mk H₁ H₂ g₂)) : ∀ D₁ D₂, motive D₁ D₂ := fun D₁ D₂ ↦
+  Quotient.inductionOn₂' D₁ D₂ h
 
-@[simp] lemma toSet_one : toSet (1 : HeckeCoset P) = (P.H : Set G) := by
-  change (P.H : Set G) * {(1 : G)} * P.H = (P.H : Set G)
-  rw [Subgroup.subgroup_mul_singleton P.H.one_mem, coe_mul_coe]
+variable {H : Subgroup G}
 
-lemma rep_one_mem : (rep (1 : HeckeCoset P) : G) ∈ P.H := by
-  simpa using rep_mem (1 : HeckeCoset P)
+@[simp] lemma toSet_one : toSet (1 : HeckeCoset Δ H H) = (H : Set G) := by
+  change (H : Set G) * {(1 : G)} * H = (H : Set G)
+  rw [Subgroup.subgroup_mul_singleton H.one_mem, coe_mul_coe]
+
+lemma rep_one_mem : (rep (1 : HeckeCoset Δ H H) : G) ∈ H := by
+  simpa using rep_mem (1 : HeckeCoset Δ H H)
 
 end HeckeCoset
 
@@ -107,12 +102,15 @@ instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ�
 
 end DoubleCoset
 
-namespace HeckePair
+namespace IsHeckeCosetModule
 
-/-- For a Hecke pair, the decomposition quotient of any `g : Δ` is finite, because `Δ` lies in
-the commensurator of `H`. -/
-noncomputable instance (P : HeckePair G) (g : P.Δ) :
-    Fintype (DecompQuotient P.H P.H (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (P.le_commensurator g.2).1
+/-- For a Hecke coset module datum, the decomposition quotient of any `g : Δ` is finite: `Δ`
+commensurates `H₂`, which is commensurable with `H₁`. -/
+noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
+    (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) := by
+  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ :=
+    IsHeckeCosetModule.le_commensurator H₁ g.2
+  exact Subgroup.fintypeOfIndexNeZero
+    (hg.trans (IsHeckeCosetModule.commensurable (Δ := Δ)).symm).1
 
-end HeckePair
+end IsHeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -107,10 +107,14 @@ namespace IsHeckeCosetModule
 /-- For a Hecke coset module datum, the decomposition quotient of any `g : Δ` is finite: `Δ`
 commensurates `H₂`, which is commensurable with `H₁`. -/
 noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
-    (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) := by
-  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ :=
-    IsHeckeCosetModule.le_commensurator H₁ g.2
-  exact Subgroup.fintypeOfIndexNeZero
-    (hg.trans (IsHeckeCosetModule.commensurable (Δ := Δ)).symm).1
+    (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_right g).1
+
+/-- The decomposition quotient with the two subgroups swapped is finite from the same datum,
+since `Δ` also commensurates the left subgroup (`le_commensurator_left`). Lower priority, so
+that the unswapped instance is preferred in the diagonal case. -/
+noncomputable instance (priority := 900) {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
+    [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_left g).1
 
 end IsHeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -12,14 +12,15 @@ public import Mathlib.GroupTheory.DoubleCoset
 /-!
 # Hecke rings: definitions
 
-The abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the Hecke coset modules
-attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971], Chapter 3, and
-[Krieg][krieg1990], Chapter I. This file sets up the underlying types: the compatibility
+This file introduces the abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the
+Hecke coset modules attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971],
+Chapter 3, and [Krieg][krieg1990], Chapter I. It sets up the underlying types: the compatibility
 conditions `IsHeckeTriple Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
 double-coset quotient `HeckeCoset Δ H₁ H₂` of `Δ` by `H₁gH₂ = H₁hH₂`, and the Hecke coset module
-`𝕋 Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets. The convolution
-product `𝕋 Δ H₁ H₂ Z × 𝕋 Δ H₂ H₃ Z → 𝕋 Δ H₁ H₃ Z` and the ring structure on the diagonal
-`𝕋 Δ H H Z` are developed in later files.
+`HeckeCosetModule Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets.
+The convolution product `HeckeCosetModule Δ H₁ H₂ Z × HeckeCosetModule Δ H₂ H₃ Z →
+HeckeCosetModule Δ H₁ H₃ Z` and the ring structure on the diagonal Hecke ring `𝕋 Δ H Z` are
+developed in later files.
 
 The relevance of the submonoid `Δ` may not be immediately obvious; a natural example is
 `H = GL₂(ℤ)` inside `G = GL₂(ℚ)` with `Δ` the submonoid of integral matrices with nonzero
@@ -35,15 +36,17 @@ subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.
   `IsHeckeTriple Δ H H`.
 * `HeckeCoset Δ H₁ H₂`: the quotient of `Δ` by the relation `H₁gH₂ = H₁hH₂`, i.e. the double
   cosets `H₁\Δ/H₂` forming the basis of the Hecke coset module.
-* `HeckeCosetModule Δ H₁ H₂ Z`, notation `𝕋 Δ H₁ H₂ Z`: the Hecke coset module with
-  coefficients in `Z`, the finitely-supported `Z`-linear combinations of double cosets. For
-  `H₁ = H₂` this is the underlying module of the Hecke ring.
+* `HeckeCosetModule Δ H₁ H₂ Z`: the Hecke coset module with coefficients in `Z`, the
+  finitely-supported `Z`-linear combinations of double cosets.
+* `HeckeRing Δ H Z`, notation `𝕋 Δ H Z`: the Hecke ring, the diagonal case
+  `HeckeCosetModule Δ H H Z` of the Hecke coset module.
 
 ## Implementation notes
 
 The data `(Δ, H₁, H₂)` enters unbundled, with the compatibility conditions collected in the
-Prop-valued class `IsHeckeTriple`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
-built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all levels
+Prop-valued class `IsHeckeTriple`: the types `HeckeCoset Δ H₁ H₂` and `HeckeCosetModule Δ H₁ H₂ Z`
+are built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all
+levels
 (as in [Shimura][shimura1971]) means products of double cosets over different subgroups,
 `H₁g₁H₂ * H₂g₂H₃ ⊆ Δ`, need no compatibility hypotheses. The conditions are only needed for the
 finiteness of the coset decompositions, which enters through the `Fintype` instance on
@@ -77,7 +80,7 @@ class IsHeckeTriple (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
   commensurable : Commensurable H₁ H₂
   /-- The submonoid `Δ` lies in the commensurator of the right subgroup (hence, the subgroups
   being commensurable, also in that of the left one; see `le_commensurator_left`). -/
-  le_commensurator : Δ ≤ (commensurator H₂).toSubmonoid
+  le_commensurator_right : Δ ≤ (commensurator H₂).toSubmonoid
 
 namespace IsHeckeTriple
 
@@ -90,25 +93,25 @@ theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
 
 /-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
+theorem mem_of_mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
   left_le (H₂ := H₂) hx
 
 /-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
+theorem mem_of_mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
   right_le (H₁ := H₁) hx
 
 /-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
-theorem le_commensurator_left [IsHeckeTriple Δ H₁ H₂] :
+theorem le_commensurator_left [h : IsHeckeTriple Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
-  rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
-  exact le_commensurator H₁
+  rw [h.commensurable.eq]
+  exact h.le_commensurator_right
 
 /-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
 explicit, since it cannot be inferred. -/
 theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₂ :=
-  le_commensurator H₁ g.2
+  le_commensurator_right H₁ g.2
 
 /-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
 explicit, since it cannot be inferred. -/
@@ -117,23 +120,12 @@ theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] 
   le_commensurator_left (H₂ := H₂) g.2
 
 /-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
-the left one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₁ H₂`. -/
+the left one; the intersection `H₁ ∩ gH₂g⁻¹` this bounds is the one underlying
+`DoubleCoset.DecompQuotient H₁ H₂ g`. -/
 theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
   exact hg.trans (commensurable (Δ := Δ)).symm
-
-/-- Conjugating the left subgroup by an element of `Δ` gives a subgroup commensurable with
-the right one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₂ H₁`. -/
-theorem commensurable_conjAct_left [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
-    Commensurable (ConjAct.toConjAct (g : G) • H₁) H₂ := by
-  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₁) H₁ := mem_commensurator_left H₂ g
-  exact hg.trans (commensurable (Δ := Δ))
-
-/-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
-theorem symm [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₁ :=
-  ⟨right_le (H₁ := H₁), left_le (H₂ := H₂), (commensurable (Δ := Δ)).symm,
-    le_commensurator_left (H₂ := H₂)⟩
 
 /-- Hecke coset module data compose. Not an instance, since the middle subgroup cannot be
 inferred from the goal. -/
@@ -142,7 +134,7 @@ theorem trans [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] :
   ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
     (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
       (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
-    le_commensurator (H₁ := H₂)⟩
+    le_commensurator_right (H₁ := H₂)⟩
 
 /-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
 theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
@@ -150,7 +142,7 @@ theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
 
 /-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
 theorem diag_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
-  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator (H₁ := H₁)⟩
+  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator_right (H₁ := H₁)⟩
 
 end IsHeckeTriple
 
@@ -158,8 +150,8 @@ end IsHeckeTriple
 back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
 
 This is a `def` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred from
-the type `↥Δ`, so this cannot participate in instance search (and a global instance would also
-create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
+the submonoid `Δ`, so this cannot participate in instance search (and a global instance would
+also create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
 `HeckeCoset.mk`. -/
 @[reducible] def HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
   (DoubleCoset.setoid (H₁ : Set G) H₂).comap Subtype.val
@@ -187,34 +179,41 @@ lemma one_def (H : Subgroup G) : (1 : HeckeCoset Δ H H) = mk H H ⟨1, Δ.one_m
 
 end HeckeCoset
 
-/-- The Hecke coset module with coefficients in `Z`, denoted `𝕋 Δ H₁ H₂ Z`: the
-finitely-supported `Z`-linear combinations of double cosets `H₁\Δ/H₂`. For `H₁ = H₂` this is the
-underlying module of the Hecke ring. The coefficients `Z` need only carry a `Zero` for the type
-to make sense; algebraic structure is added by the instances below at the weakest level each
+/-- The Hecke coset module with coefficients in `Z`: the finitely-supported `Z`-linear
+combinations of double cosets `H₁\Δ/H₂`. For `H₁ = H₂` this is the underlying module of the
+Hecke ring `𝕋 Δ H Z` (see `HeckeRing`). The coefficients `Z` need only carry a `Zero` for the
+type to make sense; algebraic structure is added by the instances below at the weakest level each
 requires. -/
 def HeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*) [Zero Z] :=
   HeckeCoset Δ H₁ H₂ →₀ Z
 
-namespace HeckeCosetModule
+/-- The Hecke ring `𝕋 Δ H Z` with coefficients in `Z`: the diagonal Hecke coset module
+`HeckeCosetModule Δ H H Z`, the finitely-supported `Z`-linear combinations of double cosets
+`H\Δ/H`. The convolution product making it a ring is developed in later files. -/
+abbrev HeckeRing (Δ : Submonoid G) (H : Subgroup G) (Z : Type*) [Zero Z] :=
+  HeckeCosetModule Δ H H Z
 
 @[inherit_doc]
-scoped notation "𝕋" => HeckeCosetModule
+scoped[HeckeCosetModule] notation "𝕋" => HeckeRing
+
+namespace HeckeCosetModule
 
 variable (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*)
 
-/-- Elements of `𝕋 Δ H₁ H₂ Z` are functions `HeckeCoset Δ H₁ H₂ → Z` (finitely supported). -/
-instance [Zero Z] : FunLike (𝕋 Δ H₁ H₂ Z) (HeckeCoset Δ H₁ H₂) Z :=
+/-- Elements of `HeckeCosetModule Δ H₁ H₂ Z` are functions `HeckeCoset Δ H₁ H₂ → Z` (finitely
+supported). -/
+instance [Zero Z] : FunLike (HeckeCosetModule Δ H₁ H₂ Z) (HeckeCoset Δ H₁ H₂) Z :=
   inferInstanceAs (FunLike (HeckeCoset Δ H₁ H₂ →₀ Z) (HeckeCoset Δ H₁ H₂) Z)
 
-noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 Δ H₁ H₂ Z) :=
+noncomputable instance [AddCommMonoid Z] : AddCommMonoid (HeckeCosetModule Δ H₁ H₂ Z) :=
   inferInstanceAs (AddCommMonoid (HeckeCoset Δ H₁ H₂ →₀ Z))
 
-noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 Δ H₁ H₂ Z) :=
+noncomputable instance [AddCommGroup Z] : AddCommGroup (HeckeCosetModule Δ H₁ H₂ Z) :=
   inferInstanceAs (AddCommGroup (HeckeCoset Δ H₁ H₂ →₀ Z))
 
 @[ext]
-lemma ext {Δ : Submonoid G} {H₁ H₂ : Subgroup G} {Z : Type*} [Zero Z] {f g : 𝕋 Δ H₁ H₂ Z}
-    (h : ∀ D, f D = g D) : f = g :=
+lemma ext {Δ : Submonoid G} {H₁ H₂ : Subgroup G} {Z : Type*} [Zero Z]
+    {f g : HeckeCosetModule Δ H₁ H₂ Z} (h : ∀ D, f D = g D) : f = g :=
   Finsupp.ext h
 
 end HeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -12,20 +12,40 @@ public import Mathlib.GroupTheory.DoubleCoset
 /-!
 # Hecke rings: definitions
 
-The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following Shimura, *Introduction to the
-Arithmetic Theory of Automorphic Functions*, Chapter 3. This file sets up the underlying types: the
-Hecke pair, the double-coset quotient that indexes the ring, and the Hecke ring itself as formal
+The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following [Shimura][shimura1971], Chapter 3,
+and [Krieg][krieg1990], Chapter I. This file sets up the underlying types: the Hecke pair, the
+double-coset quotient that indexes the ring, and the Hecke ring itself as formal
 finitely-supported linear combinations of double cosets. The convolution product and the ring
 structure are developed in later files.
 
+The relevance of the submonoid `Δ` may not be immediately obvious; a natural example is
+`H = GL₂(ℤ)` inside `G = GL₂(ℚ)` with `Δ` the submonoid of integral matrices with nonzero
+determinant, which is the Hecke pair underlying the classical Hecke operators `T_n`.
+
 ## Main definitions
 
-* `HeckePair G`: an arithmetic pair, a subgroup `H` together with a submonoid `Δ` of `G`
+* `HeckePair G`: a Hecke pair, a subgroup `H` together with a submonoid `Δ` of `G`
   satisfying `H ≤ Δ ≤ commensurator H`.
 * `HeckeCoset P`: the quotient of `Δ` by the relation `HgH = HhH`, i.e. the double cosets
-  forming the basis of the Hecke ring.
+  `H\Δ/H` forming the basis of the Hecke ring.
 * `HeckeRing P Z`, notation `𝕋 P Z`: the Hecke ring with coefficients in `Z`, the
   finitely-supported `Z`-linear combinations of double cosets.
+
+## Implementation notes
+
+`HeckePair` is a bundled structure rather than an unbundled pair with an `IsHeckePair` Prop
+class: the types `HeckeCoset P` and `𝕋 P Z` depend on the pair, and types depending on instance
+arguments are brittle. Requiring `Δ` to be a submonoid rather than a subsemigroup loses no
+generality, since `H ≤ Δ` already forces `1 ∈ Δ`.
+
+The combinatorial layer behind the Hecke product (Shimura's multiplicity) is developed for
+mixed double cosets `Γ₁gΓ₂` of arbitrary subgroups in later files; only the ring structure
+itself is specific to a Hecke pair.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971]
+* [A. Krieg, *Hecke algebras*][krieg1990]
 -/
 
 @[expose] public section
@@ -34,7 +54,7 @@ open Subgroup.Commensurable
 
 variable {G : Type*} [Group G]
 
-/-- An arithmetic pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
+/-- A Hecke pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
 `H ≤ Δ ≤ commensurator H`. -/
 @[ext]
 structure HeckePair (G : Type*) [Group G] where
@@ -43,9 +63,9 @@ structure HeckePair (G : Type*) [Group G] where
   /-- The submonoid `Δ` of elements commensurating `H`. -/
   Δ : Submonoid G
   /-- The subgroup `H` is contained in `Δ`. -/
-  h₀ : H.toSubmonoid ≤ Δ
+  subgroup_le : H.toSubmonoid ≤ Δ
   /-- The submonoid `Δ` lies in the commensurator of `H`. -/
-  h₁ : Δ ≤ (commensurator H).toSubmonoid
+  le_commensurator : Δ ≤ (commensurator H).toSubmonoid
 
 /-- The setoid on `Δ` identifying elements with the same double coset `HgH = HhH`, pulled back
 from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
@@ -53,41 +73,50 @@ from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
 This is a `def` rather than a global instance to avoid a `Setoid` diamond on `↥Δ` (the left-coset
 setoid is another). Files that form `HeckeCoset`s opt in with `attribute [local instance]`; it is
 marked `@[reducible]` so that opt-in is warning-free. -/
-@[reducible] def doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
+@[reducible] def HeckePair.doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
   (DoubleCoset.setoid (P.H : Set G) P.H).comap Subtype.val
 
-/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the basis
-type for the Hecke ring. -/
-def HeckeCoset (P : HeckePair G) := Quotient (doubleCosetSetoid P)
+/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the
+basis type for the Hecke ring. -/
+def HeckeCoset (P : HeckePair G) := Quotient P.doubleCosetSetoid
 
-noncomputable instance (P : HeckePair G) : DecidableEq (HeckeCoset P) :=
-  Classical.decEq _
+namespace HeckeCoset
+
+variable (P : HeckePair G)
+
+/-- The identity double coset `H1H = H`. -/
+instance : One (HeckeCoset P) := ⟨Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩⟩
+
+instance : Inhabited (HeckeCoset P) := ⟨1⟩
+
+lemma one_def : (1 : HeckeCoset P) = Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩ := rfl
+
+end HeckeCoset
 
 /-- The Hecke ring with coefficients in `Z`, denoted `𝕋 P Z`: the finitely-supported `Z`-linear
 combinations of double cosets. The coefficients `Z` need only carry a `Zero` for the type to make
 sense; algebraic structure is added by the instances below at the weakest level each requires. -/
-def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := Finsupp (HeckeCoset P) Z
+def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := HeckeCoset P →₀ Z
 
 namespace HeckeRing
 
 @[inherit_doc]
 scoped notation "𝕋" => HeckeRing
 
+variable (P : HeckePair G) (Z : Type*)
+
 /-- Elements of `𝕋 P Z` are functions `HeckeCoset P → Z` (finitely supported). -/
-instance (P : HeckePair G) (Z : Type*) [Zero Z] :
-    FunLike (𝕋 P Z) (HeckeCoset P) Z :=
+instance [Zero Z] : FunLike (𝕋 P Z) (HeckeCoset P) Z :=
   inferInstanceAs (FunLike (HeckeCoset P →₀ Z) (HeckeCoset P) Z)
 
-/-- The additive commutative monoid structure on the Hecke ring, for any `AddCommMonoid` of
-coefficients. -/
-noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommMonoid Z] :
-    AddCommMonoid (𝕋 P Z) :=
-  inferInstanceAs (AddCommMonoid ((HeckeCoset P) →₀ Z))
+noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 P Z) :=
+  inferInstanceAs (AddCommMonoid (HeckeCoset P →₀ Z))
 
-/-- The additive commutative group structure on the Hecke ring, when the coefficients form an
-`AddCommGroup`. -/
-noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommGroup Z] :
-    AddCommGroup (𝕋 P Z) :=
-  inferInstanceAs (AddCommGroup ((HeckeCoset P) →₀ Z))
+noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 P Z) :=
+  inferInstanceAs (AddCommGroup (HeckeCoset P →₀ Z))
+
+@[ext]
+lemma ext {P : HeckePair G} {Z : Type*} [Zero Z] {f g : 𝕋 P Z} (h : ∀ D, f D = g D) : f = g :=
+  Finsupp.ext h
 
 end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -59,6 +59,7 @@ subsemigroup loses no generality, since `H₁ ≤ Δ` already forces `1 ∈ Δ`.
 @[expose] public section
 
 open Subgroup Subgroup.Commensurable
+open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
@@ -101,6 +102,32 @@ theorem le_commensurator_left [IsHeckeCosetModule Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
   rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
   exact le_commensurator H₁
+
+/-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
+explicit, since it cannot be inferred. -/
+theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    (g : G) ∈ commensurator H₂ :=
+  le_commensurator H₁ g.2
+
+/-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
+explicit, since it cannot be inferred. -/
+theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    (g : G) ∈ commensurator H₁ :=
+  le_commensurator_left (H₂ := H₂) g.2
+
+/-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
+the left one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₁ H₂`. -/
+theorem commensurable_conjAct_right [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
+  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
+  exact hg.trans (commensurable (Δ := Δ)).symm
+
+/-- Conjugating the left subgroup by an element of `Δ` gives a subgroup commensurable with
+the right one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₂ H₁`. -/
+theorem commensurable_conjAct_left [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    Commensurable (ConjAct.toConjAct (g : G) • H₁) H₂ := by
+  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₁) H₁ := mem_commensurator_left H₂ g
+  exact hg.trans (commensurable (Δ := Δ))
 
 /-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
 theorem symm [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₁ :=

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -12,35 +12,43 @@ public import Mathlib.GroupTheory.DoubleCoset
 /-!
 # Hecke rings: definitions
 
-The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following [Shimura][shimura1971], Chapter 3,
-and [Krieg][krieg1990], Chapter I. This file sets up the underlying types: the Hecke pair, the
-double-coset quotient that indexes the ring, and the Hecke ring itself as formal
-finitely-supported linear combinations of double cosets. The convolution product and the ring
-structure are developed in later files.
+The abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the Hecke coset modules
+attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971], Chapter 3, and
+[Krieg][krieg1990], Chapter I. This file sets up the underlying types: the compatibility
+conditions `IsHeckeCosetModule Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
+double-coset quotient `HeckeCoset Δ H₁ H₂` of `Δ` by `H₁gH₂ = H₁hH₂`, and the Hecke coset module
+`𝕋 Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets. The convolution
+product `𝕋 Δ H₁ H₂ Z × 𝕋 Δ H₂ H₃ Z → 𝕋 Δ H₁ H₃ Z` and the ring structure on the diagonal
+`𝕋 Δ H H Z` are developed in later files.
 
 The relevance of the submonoid `Δ` may not be immediately obvious; a natural example is
 `H = GL₂(ℤ)` inside `G = GL₂(ℚ)` with `Δ` the submonoid of integral matrices with nonzero
-determinant, which is the Hecke pair underlying the classical Hecke operators `T_n`.
+determinant, which is the Hecke pair underlying the classical Hecke operators `T_n`. Mixed
+subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.g. `H₁ = Γ₀(N)` and
+`H₂ = Γ₀(M)` inside the same `Δ`.
 
 ## Main definitions
 
-* `HeckePair G`: a Hecke pair, a subgroup `H` together with a submonoid `Δ` of `G`
-  satisfying `H ≤ Δ ≤ commensurator H`.
-* `HeckeCoset P`: the quotient of `Δ` by the relation `HgH = HhH`, i.e. the double cosets
-  `H\Δ/H` forming the basis of the Hecke ring.
-* `HeckeRing P Z`, notation `𝕋 P Z`: the Hecke ring with coefficients in `Z`, the
-  finitely-supported `Z`-linear combinations of double cosets.
+* `IsHeckeCosetModule Δ H₁ H₂`: the compatibility conditions `H₁ ≤ Δ`, `H₂ ≤ Δ`,
+  `Commensurable H₁ H₂` and `Δ ≤ commensurator H₂` making the double cosets `H₁\Δ/H₂` finite
+  unions of left cosets. The classical Hecke pair `(H, Δ)` is the diagonal case
+  `IsHeckeCosetModule Δ H H`.
+* `HeckeCoset Δ H₁ H₂`: the quotient of `Δ` by the relation `H₁gH₂ = H₁hH₂`, i.e. the double
+  cosets `H₁\Δ/H₂` forming the basis of the Hecke coset module.
+* `HeckeCosetModule Δ H₁ H₂ Z`, notation `𝕋 Δ H₁ H₂ Z`: the Hecke coset module with
+  coefficients in `Z`, the finitely-supported `Z`-linear combinations of double cosets. For
+  `H₁ = H₂` this is the underlying module of the Hecke ring.
 
 ## Implementation notes
 
-`HeckePair` is a bundled structure rather than an unbundled pair with an `IsHeckePair` Prop
-class: the types `HeckeCoset P` and `𝕋 P Z` depend on the pair, and types depending on instance
-arguments are brittle. Requiring `Δ` to be a submonoid rather than a subsemigroup loses no
-generality, since `H ≤ Δ` already forces `1 ∈ Δ`.
-
-The combinatorial layer behind the Hecke product (Shimura's multiplicity) is developed for
-mixed double cosets `Γ₁gΓ₂` of arbitrary subgroups in later files; only the ring structure
-itself is specific to a Hecke pair.
+The data `(Δ, H₁, H₂)` enters unbundled, with the compatibility conditions collected in the
+Prop-valued class `IsHeckeCosetModule`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
+built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all levels
+(as in [Shimura][shimura1971]) means products of double cosets over different subgroups,
+`H₁g₁H₂ * H₂g₂H₃ ⊆ Δ`, need no compatibility hypotheses. The conditions are only needed for the
+finiteness of the coset decompositions, which enters through the `Fintype` instance on
+`DoubleCoset.DecompQuotient` in later files. Requiring `Δ` to be a submonoid rather than a
+subsemigroup loses no generality, since `H₁ ≤ Δ` already forces `1 ∈ Δ`.
 
 ## References
 
@@ -50,73 +58,135 @@ itself is specific to a Hecke pair.
 
 @[expose] public section
 
-open Subgroup.Commensurable
+open Subgroup Subgroup.Commensurable
 
 variable {G : Type*} [Group G]
 
-/-- A Hecke pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
-`H ≤ Δ ≤ commensurator H`. -/
-@[ext]
-structure HeckePair (G : Type*) [Group G] where
-  /-- The subgroup `H` of the pair. -/
-  H : Subgroup G
-  /-- The submonoid `Δ` of elements commensurating `H`. -/
-  Δ : Submonoid G
-  /-- The subgroup `H` is contained in `Δ`. -/
-  subgroup_le : H.toSubmonoid ≤ Δ
-  /-- The submonoid `Δ` lies in the commensurator of `H`. -/
-  le_commensurator : Δ ≤ (commensurator H).toSubmonoid
+/-- The compatibility conditions on a submonoid `Δ` and a pair of subgroups `H₁, H₂` of `G`
+making the double cosets `H₁\Δ/H₂` finite unions of left cosets: both subgroups are contained
+in `Δ`, they are commensurable, and `Δ` commensurates them. The classical Hecke pair `(H, Δ)`
+of [Shimura][shimura1971], Chapter 3, is the diagonal case `IsHeckeCosetModule Δ H H`. -/
+class IsHeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
+  /-- The left subgroup is contained in `Δ`. -/
+  left_le : H₁.toSubmonoid ≤ Δ
+  /-- The right subgroup is contained in `Δ`. -/
+  right_le : H₂.toSubmonoid ≤ Δ
+  /-- The two subgroups are commensurable. -/
+  commensurable : Commensurable H₁ H₂
+  /-- The submonoid `Δ` lies in the commensurator of the right subgroup (hence, the subgroups
+  being commensurable, also in that of the left one; see `le_commensurator_left`). -/
+  le_commensurator : Δ ≤ (commensurator H₂).toSubmonoid
 
-/-- The setoid on `Δ` identifying elements with the same double coset `HgH = HhH`, pulled back
-from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
+namespace IsHeckeCosetModule
 
-This is a `def` rather than a global instance to avoid a `Setoid` diamond on `↥Δ` (the left-coset
-setoid is another). Files that form `HeckeCoset`s opt in with `attribute [local instance]`; it is
-marked `@[reducible]` so that opt-in is warning-free. -/
-@[reducible] def HeckePair.doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
-  (DoubleCoset.setoid (P.H : Set G) P.H).comap Subtype.val
+variable {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 
-/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the
-basis type for the Hecke ring. -/
-def HeckeCoset (P : HeckePair G) := Quotient P.doubleCosetSetoid
+/-- A Hecke pair `(H, Δ)` with `H ≤ Δ ≤ commensurator H` is the diagonal case. -/
+theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
+    (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeCosetModule Δ H H :=
+  ⟨h, h, .refl H, hc⟩
+
+/-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
+be inferred. -/
+theorem mem_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
+  left_le (H₂ := H₂) hx
+
+/-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
+be inferred. -/
+theorem mem_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
+  right_le (H₁ := H₁) hx
+
+/-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
+theorem le_commensurator_left [IsHeckeCosetModule Δ H₁ H₂] :
+    Δ ≤ (commensurator H₁).toSubmonoid := by
+  rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
+  exact le_commensurator H₁
+
+/-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
+theorem symm [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₁ :=
+  ⟨right_le (H₁ := H₁), left_le (H₂ := H₂), (commensurable (Δ := Δ)).symm,
+    le_commensurator_left (H₂ := H₂)⟩
+
+/-- Hecke coset module data compose. Not an instance, since the middle subgroup cannot be
+inferred from the goal. -/
+theorem trans [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃] :
+    IsHeckeCosetModule Δ H₁ H₃ :=
+  ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
+    (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
+      (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
+    le_commensurator (H₁ := H₂)⟩
+
+/-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
+theorem diag_left [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₁ H₁ :=
+  ⟨left_le (H₂ := H₂), left_le (H₂ := H₂), .refl H₁, le_commensurator_left (H₂ := H₂)⟩
+
+/-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
+theorem diag_right [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₂ :=
+  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator (H₁ := H₁)⟩
+
+end IsHeckeCosetModule
+
+/-- The setoid on `Δ` identifying elements with the same double coset `H₁gH₂ = H₁hH₂`, pulled
+back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
+
+This is a `def` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred from
+the type `↥Δ`, so this cannot participate in instance search (and a global instance would also
+create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
+`HeckeCoset.mk`. -/
+@[reducible] def HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
+  (DoubleCoset.setoid (H₁ : Set G) H₂).comap Subtype.val
+
+/-- A Hecke double coset: an equivalence class of `Δ`-elements under `H₁gH₂ = H₁hH₂`. This is
+the basis type for the Hecke coset module. -/
+def HeckeCoset (Δ : Submonoid G) (H₁ H₂ : Subgroup G) := Quotient (HeckeCoset.setoid Δ H₁ H₂)
 
 namespace HeckeCoset
 
-variable (P : HeckePair G)
+variable {Δ : Submonoid G}
 
-/-- The identity double coset `H1H = H`. -/
-instance : One (HeckeCoset P) := ⟨Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩⟩
+/-- The double coset `H₁gH₂` of an element `g : Δ`. -/
+def mk (H₁ H₂ : Subgroup G) (g : Δ) : HeckeCoset Δ H₁ H₂ :=
+  Quotient.mk (setoid Δ H₁ H₂) g
 
-instance : Inhabited (HeckeCoset P) := ⟨1⟩
+variable (Δ) in
+instance (H₁ H₂ : Subgroup G) : Inhabited (HeckeCoset Δ H₁ H₂) := ⟨mk H₁ H₂ ⟨1, Δ.one_mem⟩⟩
 
-lemma one_def : (1 : HeckeCoset P) = Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩ := rfl
+variable (Δ) in
+/-- The identity double coset `H1H = H` of the diagonal (Hecke pair) case. -/
+instance (H : Subgroup G) : One (HeckeCoset Δ H H) := ⟨mk H H ⟨1, Δ.one_mem⟩⟩
+
+lemma one_def (H : Subgroup G) : (1 : HeckeCoset Δ H H) = mk H H ⟨1, Δ.one_mem⟩ := rfl
 
 end HeckeCoset
 
-/-- The Hecke ring with coefficients in `Z`, denoted `𝕋 P Z`: the finitely-supported `Z`-linear
-combinations of double cosets. The coefficients `Z` need only carry a `Zero` for the type to make
-sense; algebraic structure is added by the instances below at the weakest level each requires. -/
-def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := HeckeCoset P →₀ Z
+/-- The Hecke coset module with coefficients in `Z`, denoted `𝕋 Δ H₁ H₂ Z`: the
+finitely-supported `Z`-linear combinations of double cosets `H₁\Δ/H₂`. For `H₁ = H₂` this is the
+underlying module of the Hecke ring. The coefficients `Z` need only carry a `Zero` for the type
+to make sense; algebraic structure is added by the instances below at the weakest level each
+requires. -/
+def HeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*) [Zero Z] :=
+  HeckeCoset Δ H₁ H₂ →₀ Z
 
-namespace HeckeRing
+namespace HeckeCosetModule
 
 @[inherit_doc]
-scoped notation "𝕋" => HeckeRing
+scoped notation "𝕋" => HeckeCosetModule
 
-variable (P : HeckePair G) (Z : Type*)
+variable (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*)
 
-/-- Elements of `𝕋 P Z` are functions `HeckeCoset P → Z` (finitely supported). -/
-instance [Zero Z] : FunLike (𝕋 P Z) (HeckeCoset P) Z :=
-  inferInstanceAs (FunLike (HeckeCoset P →₀ Z) (HeckeCoset P) Z)
+/-- Elements of `𝕋 Δ H₁ H₂ Z` are functions `HeckeCoset Δ H₁ H₂ → Z` (finitely supported). -/
+instance [Zero Z] : FunLike (𝕋 Δ H₁ H₂ Z) (HeckeCoset Δ H₁ H₂) Z :=
+  inferInstanceAs (FunLike (HeckeCoset Δ H₁ H₂ →₀ Z) (HeckeCoset Δ H₁ H₂) Z)
 
-noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 P Z) :=
-  inferInstanceAs (AddCommMonoid (HeckeCoset P →₀ Z))
+noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 Δ H₁ H₂ Z) :=
+  inferInstanceAs (AddCommMonoid (HeckeCoset Δ H₁ H₂ →₀ Z))
 
-noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 P Z) :=
-  inferInstanceAs (AddCommGroup (HeckeCoset P →₀ Z))
+noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 Δ H₁ H₂ Z) :=
+  inferInstanceAs (AddCommGroup (HeckeCoset Δ H₁ H₂ →₀ Z))
 
 @[ext]
-lemma ext {P : HeckePair G} {Z : Type*} [Zero Z] {f g : 𝕋 P Z} (h : ∀ D, f D = g D) : f = g :=
+lemma ext {Δ : Submonoid G} {H₁ H₂ : Subgroup G} {Z : Type*} [Zero Z] {f g : 𝕋 Δ H₁ H₂ Z}
+    (h : ∀ D, f D = g D) : f = g :=
   Finsupp.ext h
 
-end HeckeRing
+end HeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -15,7 +15,7 @@ public import Mathlib.GroupTheory.DoubleCoset
 The abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the Hecke coset modules
 attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971], Chapter 3, and
 [Krieg][krieg1990], Chapter I. This file sets up the underlying types: the compatibility
-conditions `IsHeckeCosetModule Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
+conditions `IsHeckeTriple Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
 double-coset quotient `HeckeCoset Δ H₁ H₂` of `Δ` by `H₁gH₂ = H₁hH₂`, and the Hecke coset module
 `𝕋 Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets. The convolution
 product `𝕋 Δ H₁ H₂ Z × 𝕋 Δ H₂ H₃ Z → 𝕋 Δ H₁ H₃ Z` and the ring structure on the diagonal
@@ -29,10 +29,10 @@ subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.
 
 ## Main definitions
 
-* `IsHeckeCosetModule Δ H₁ H₂`: the compatibility conditions `H₁ ≤ Δ`, `H₂ ≤ Δ`,
-  `Commensurable H₁ H₂` and `Δ ≤ commensurator H₂` making the double cosets `H₁\Δ/H₂` finite
+* `IsHeckeTriple Δ H₁ H₂`: `(H₁, Δ, H₂)` is a Hecke triple, i.e. `H₁ ≤ Δ`, `H₂ ≤ Δ`,
+  `Commensurable H₁ H₂` and `Δ ≤ commensurator H₂`, making the double cosets `H₁\Δ/H₂` finite
   unions of left cosets. The classical Hecke pair `(H, Δ)` is the diagonal case
-  `IsHeckeCosetModule Δ H H`.
+  `IsHeckeTriple Δ H H`.
 * `HeckeCoset Δ H₁ H₂`: the quotient of `Δ` by the relation `H₁gH₂ = H₁hH₂`, i.e. the double
   cosets `H₁\Δ/H₂` forming the basis of the Hecke coset module.
 * `HeckeCosetModule Δ H₁ H₂ Z`, notation `𝕋 Δ H₁ H₂ Z`: the Hecke coset module with
@@ -42,7 +42,7 @@ subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.
 ## Implementation notes
 
 The data `(Δ, H₁, H₂)` enters unbundled, with the compatibility conditions collected in the
-Prop-valued class `IsHeckeCosetModule`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
+Prop-valued class `IsHeckeTriple`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
 built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all levels
 (as in [Shimura][shimura1971]) means products of double cosets over different subgroups,
 `H₁g₁H₂ * H₂g₂H₃ ⊆ Δ`, need no compatibility hypotheses. The conditions are only needed for the
@@ -63,11 +63,12 @@ open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
-/-- The compatibility conditions on a submonoid `Δ` and a pair of subgroups `H₁, H₂` of `G`
-making the double cosets `H₁\Δ/H₂` finite unions of left cosets: both subgroups are contained
-in `Δ`, they are commensurable, and `Δ` commensurates them. The classical Hecke pair `(H, Δ)`
-of [Shimura][shimura1971], Chapter 3, is the diagonal case `IsHeckeCosetModule Δ H H`. -/
-class IsHeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
+/-- A *Hecke triple* `(H₁, Δ, H₂)`: the compatibility conditions on a submonoid `Δ` and a pair
+of subgroups `H₁, H₂` of `G` making the double cosets `H₁\Δ/H₂` finite unions of left cosets:
+both subgroups are contained in `Δ`, they are commensurable, and `Δ` commensurates them. The
+classical Hecke pair `(H, Δ)` of [Shimura][shimura1971], Chapter 3, is the diagonal case
+`IsHeckeTriple Δ H H`. -/
+class IsHeckeTriple (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
   /-- The left subgroup is contained in `Δ`. -/
   left_le : H₁.toSubmonoid ≤ Δ
   /-- The right subgroup is contained in `Δ`. -/
@@ -78,80 +79,80 @@ class IsHeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop wher
   being commensurable, also in that of the left one; see `le_commensurator_left`). -/
   le_commensurator : Δ ≤ (commensurator H₂).toSubmonoid
 
-namespace IsHeckeCosetModule
+namespace IsHeckeTriple
 
 variable {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 
 /-- A Hecke pair `(H, Δ)` with `H ≤ Δ ≤ commensurator H` is the diagonal case. -/
 theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
-    (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeCosetModule Δ H H :=
+    (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeTriple Δ H H :=
   ⟨h, h, .refl H, hc⟩
 
 /-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
+theorem mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
   left_le (H₂ := H₂) hx
 
 /-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
+theorem mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
   right_le (H₁ := H₁) hx
 
 /-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
-theorem le_commensurator_left [IsHeckeCosetModule Δ H₁ H₂] :
+theorem le_commensurator_left [IsHeckeTriple Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
   rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
   exact le_commensurator H₁
 
 /-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
 explicit, since it cannot be inferred. -/
-theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₂ :=
   le_commensurator H₁ g.2
 
 /-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
 explicit, since it cannot be inferred. -/
-theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₁ :=
   le_commensurator_left (H₂ := H₂) g.2
 
 /-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
 the left one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₁ H₂`. -/
-theorem commensurable_conjAct_right [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
   exact hg.trans (commensurable (Δ := Δ)).symm
 
 /-- Conjugating the left subgroup by an element of `Δ` gives a subgroup commensurable with
 the right one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₂ H₁`. -/
-theorem commensurable_conjAct_left [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem commensurable_conjAct_left [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₁) H₂ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₁) H₁ := mem_commensurator_left H₂ g
   exact hg.trans (commensurable (Δ := Δ))
 
 /-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
-theorem symm [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₁ :=
+theorem symm [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₁ :=
   ⟨right_le (H₁ := H₁), left_le (H₂ := H₂), (commensurable (Δ := Δ)).symm,
     le_commensurator_left (H₂ := H₂)⟩
 
 /-- Hecke coset module data compose. Not an instance, since the middle subgroup cannot be
 inferred from the goal. -/
-theorem trans [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃] :
-    IsHeckeCosetModule Δ H₁ H₃ :=
+theorem trans [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] :
+    IsHeckeTriple Δ H₁ H₃ :=
   ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
     (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
       (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
     le_commensurator (H₁ := H₂)⟩
 
 /-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
-theorem diag_left [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₁ H₁ :=
+theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
   ⟨left_le (H₂ := H₂), left_le (H₂ := H₂), .refl H₁, le_commensurator_left (H₂ := H₂)⟩
 
 /-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
-theorem diag_right [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₂ :=
+theorem diag_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
   ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator (H₁ := H₁)⟩
 
-end IsHeckeCosetModule
+end IsHeckeTriple
 
 /-- The setoid on `Δ` identifying elements with the same double coset `H₁gH₂ = H₁hH₂`, pulled
 back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
@@ -91,37 +91,32 @@ theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
     (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeTriple Δ H H :=
   ⟨h, h, .refl H, hc⟩
 
-/-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
-be inferred. -/
+/-- Elements of the left subgroup lie in `Δ`. -/
 theorem mem_of_mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
-  left_le (H₂ := H₂) hx
+  left_le H₂ hx
 
-/-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
-be inferred. -/
+/-- Elements of the right subgroup lie in `Δ`. -/
 theorem mem_of_mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
-  right_le (H₁ := H₁) hx
+  right_le H₁ hx
 
 /-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
-theorem le_commensurator_left [h : IsHeckeTriple Δ H₁ H₂] :
+theorem le_commensurator_left (H₂ : Subgroup G) [h : IsHeckeTriple Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
   rw [h.commensurable.eq]
   exact h.le_commensurator_right
 
-/-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
-explicit, since it cannot be inferred. -/
+/-- Elements of `Δ` lie in the commensurator of the right subgroup. -/
 theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₂ :=
   le_commensurator_right H₁ g.2
 
-/-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
-explicit, since it cannot be inferred. -/
+/-- Elements of `Δ` lie in the commensurator of the left subgroup. -/
 theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₁ :=
-  le_commensurator_left (H₂ := H₂) g.2
+  le_commensurator_left H₂ g.2
 
 /-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
-the left one; the intersection `H₁ ∩ gH₂g⁻¹` this bounds is the one underlying
-`DoubleCoset.DecompQuotient H₁ H₂ g`. -/
+the left one. -/
 theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
@@ -131,29 +126,29 @@ theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
 inferred from the goal. -/
 theorem trans [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] :
     IsHeckeTriple Δ H₁ H₃ :=
-  ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
+  ⟨left_le H₂, right_le H₂,
     (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
       (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
-    le_commensurator_right (H₁ := H₂)⟩
+    le_commensurator_right H₂⟩
 
 /-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
 theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
-  ⟨left_le (H₂ := H₂), left_le (H₂ := H₂), .refl H₁, le_commensurator_left (H₂ := H₂)⟩
+  ⟨left_le H₂, left_le H₂, .refl H₁, le_commensurator_left H₂⟩
 
 /-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
 theorem diag_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
-  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator_right (H₁ := H₁)⟩
+  ⟨right_le H₁, right_le H₁, .refl H₂, le_commensurator_right H₁⟩
 
 end IsHeckeTriple
 
 /-- The setoid on `Δ` identifying elements with the same double coset `H₁gH₂ = H₁hH₂`, pulled
 back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
 
-This is a `def` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred from
-the submonoid `Δ`, so this cannot participate in instance search (and a global instance would
-also create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
+This is an `abbrev` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred
+from the submonoid `Δ`, so this cannot participate in instance search (and a global instance
+would also create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
 `HeckeCoset.mk`. -/
-@[reducible] def HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
+abbrev HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
   (DoubleCoset.setoid (H₁ : Set G) H₂).comap Subtype.val
 
 /-- A Hecke double coset: an equivalence class of `Δ`-elements under `H₁gH₂ = H₁hH₂`. This is

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Algebra.Group.Finsupp
+public import Mathlib.GroupTheory.Commensurable
+public import Mathlib.GroupTheory.DoubleCoset
+
+/-!
+# Hecke rings: definitions
+
+The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following Shimura, *Introduction to the
+Arithmetic Theory of Automorphic Functions*, Chapter 3. This file sets up the underlying types: the
+Hecke pair, the double-coset quotient that indexes the ring, and the Hecke ring itself as formal
+finitely-supported linear combinations of double cosets. The convolution product and the ring
+structure are developed in later files.
+
+## Main definitions
+
+* `HeckePair G`: an arithmetic pair, a subgroup `H` together with a submonoid `Δ` of `G`
+  satisfying `H ≤ Δ ≤ commensurator H`.
+* `HeckeCoset P`: the quotient of `Δ` by the relation `HgH = HhH`, i.e. the double cosets
+  forming the basis of the Hecke ring.
+* `HeckeRing P Z`, notation `𝕋 P Z`: the Hecke ring with coefficients in `Z`, the
+  finitely-supported `Z`-linear combinations of double cosets.
+-/
+
+@[expose] public section
+
+open Subgroup.Commensurable
+
+variable {G : Type*} [Group G]
+
+/-- An arithmetic pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
+`H ≤ Δ ≤ commensurator H`. -/
+@[ext]
+structure HeckePair (G : Type*) [Group G] where
+  /-- The subgroup `H` of the pair. -/
+  H : Subgroup G
+  /-- The submonoid `Δ` of elements commensurating `H`. -/
+  Δ : Submonoid G
+  /-- The subgroup `H` is contained in `Δ`. -/
+  h₀ : H.toSubmonoid ≤ Δ
+  /-- The submonoid `Δ` lies in the commensurator of `H`. -/
+  h₁ : Δ ≤ (commensurator H).toSubmonoid
+
+/-- The setoid on `Δ` identifying elements with the same double coset `HgH = HhH`, pulled back
+from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
+
+This is a `def` rather than a global instance to avoid a `Setoid` diamond on `↥Δ` (the left-coset
+setoid is another). Files that form `HeckeCoset`s opt in with `attribute [local instance]`; it is
+marked `@[reducible]` so that opt-in is warning-free. -/
+@[reducible] def doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
+  (DoubleCoset.setoid (P.H : Set G) P.H).comap Subtype.val
+
+/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the basis
+type for the Hecke ring. -/
+def HeckeCoset (P : HeckePair G) := Quotient (doubleCosetSetoid P)
+
+noncomputable instance (P : HeckePair G) : DecidableEq (HeckeCoset P) :=
+  Classical.decEq _
+
+/-- The Hecke ring with coefficients in `Z`, denoted `𝕋 P Z`: the finitely-supported `Z`-linear
+combinations of double cosets. The coefficients `Z` need only carry a `Zero` for the type to make
+sense; algebraic structure is added by the instances below at the weakest level each requires. -/
+def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := Finsupp (HeckeCoset P) Z
+
+namespace HeckeRing
+
+@[inherit_doc]
+scoped notation "𝕋" => HeckeRing
+
+/-- Elements of `𝕋 P Z` are functions `HeckeCoset P → Z` (finitely supported). -/
+instance (P : HeckePair G) (Z : Type*) [Zero Z] :
+    FunLike (𝕋 P Z) (HeckeCoset P) Z :=
+  inferInstanceAs (FunLike (HeckeCoset P →₀ Z) (HeckeCoset P) Z)
+
+/-- The additive commutative monoid structure on the Hecke ring, for any `AddCommMonoid` of
+coefficients. -/
+noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommMonoid Z] :
+    AddCommMonoid (𝕋 P Z) :=
+  inferInstanceAs (AddCommMonoid ((HeckeCoset P) →₀ Z))
+
+/-- The additive commutative group structure on the Hecke ring, when the coefficients form an
+`AddCommGroup`. -/
+noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommGroup Z] :
+    AddCommGroup (𝕋 P Z) :=
+  inferInstanceAs (AddCommGroup ((HeckeCoset P) →₀ Z))
+
+end HeckeRing

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -3661,6 +3661,21 @@
   school        = {University of British Columbia}
 }
 
+@Book{            krieg1990,
+  author        = {Krieg, Aloys},
+  title         = {Hecke algebras},
+  series        = {Memoirs of the American Mathematical Society},
+  volume        = {87},
+  number        = {435},
+  publisher     = {American Mathematical Society, Providence, RI},
+  year          = {1990},
+  pages         = {x+158},
+  issn          = {0065-9266},
+  mrnumber      = {1027069},
+  doi           = {10.1090/memo/0435},
+  url           = {https://doi.org/10.1090/memo/0435}
+}
+
 @Book{            kung_rota_yan2009,
   author        = {Kung, Joseph P. S. and Rota, Gian-Carlo and Yan, Catherine
                   H.},
@@ -5383,6 +5398,20 @@
   keywords      = {00B15,14-06},
   zbmath        = {3370272},
   zbl           = {0234.00007}
+}
+
+@Book{            shimura1971,
+  author        = {Shimura, Goro},
+  title         = {Introduction to the arithmetic theory of automorphic
+                  functions},
+  series        = {Publications of the Mathematical Society of Japan},
+  volume        = {11},
+  note          = {Kan\^{o} Memorial Lectures, No. 1},
+  publisher     = {Iwanami Shoten Publishers, Tokyo; Princeton University
+                  Press, Princeton, NJ},
+  year          = {1971},
+  pages         = {xiv+267},
+  mrnumber      = {0314766}
 }
 
 @Book{            sierpinski1958,


### PR DESCRIPTION
API for the mixed double cosets `H₁\Δ/H₂` indexing a Hecke coset module: representatives, `mk H₁ H₂ g = mk H₁ H₂ h ↔ H₁gH₂ = H₁hH₂`, and the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` (`DoubleCoset.DecompQuotient`) indexing the left cosets inside a double coset, finite for a Hecke coset module datum `IsHeckeTriple Δ H₁ H₂`.

General lemmas go to their proper homes: `DoubleCoset.doubleCoset_eq_iUnion_leftCosets` and `doubleCoset_mul_left/right` in `GroupTheory/DoubleCoset.lean`; `Subgroup.mem_conjAct_pointwise_smul_iff` in `Algebra/Group/Subgroup/Pointwise.lean`.

- [x] depends on: #41251

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
