### PR TITLE
feat(NumberTheory): multiplicity positivity on the Hecke product support

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5737,6 +5737,7 @@ public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
 public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.HeckeRing.Multiplicity
+public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve
 public import Mathlib.NumberTheory.Height.MvPolynomial

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5734,6 +5734,7 @@ public import Mathlib.NumberTheory.Harmonic.EulerMascheroni
 public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
+public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5737,6 +5737,7 @@ public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
 public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.HeckeRing.Multiplicity
+public import Mathlib.NumberTheory.HeckeRing.MultiplicitySupport
 public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5736,6 +5736,7 @@ public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
 public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
+public import Mathlib.NumberTheory.HeckeRing.Multiplicity
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve
 public import Mathlib.NumberTheory.Height.MvPolynomial

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5734,6 +5734,7 @@ public import Mathlib.NumberTheory.Harmonic.EulerMascheroni
 public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
+public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve
 public import Mathlib.NumberTheory.Height.MvPolynomial

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -569,5 +569,10 @@ lemma conjAct_pointwise_smul_eq_self {H : Subgroup G} {g : G} (hg : g ∈ normal
     ConjAct.toConjAct g • H = H :=
   conjAct_pointwise_smul_iff.2 hg
 
+lemma mem_conjAct_pointwise_smul_iff {H : Subgroup G} {g x : G} :
+    x ∈ ConjAct.toConjAct g • H ↔ g⁻¹ * x * g ∈ H := by
+  rw [mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv, ConjAct.smul_def,
+    ConjAct.ofConjAct_toConjAct, inv_inv]
+
 end Group
 end Subgroup

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -55,6 +55,14 @@ lemma doubleCoset_eq_of_mem {H K : Subgroup G} {a b : G} (hb : b ∈ doubleCoset
     mul_assoc, mul_assoc, Subgroup.singleton_mul_subgroup hk, ← mul_assoc, ← mul_assoc,
     Subgroup.subgroup_mul_singleton hh]
 
+lemma doubleCoset_mul_left {H : Subgroup G} (K : Subgroup G) {h : G} (hh : h ∈ H) (a : G) :
+    doubleCoset (h * a) H K = doubleCoset a H K :=
+  doubleCoset_eq_of_mem (mem_doubleCoset.mpr ⟨h, hh, 1, K.one_mem, (mul_one _).symm⟩)
+
+lemma doubleCoset_mul_right (H : Subgroup G) {K : Subgroup G} {k : G} (hk : k ∈ K) (a : G) :
+    doubleCoset (a * k) H K = doubleCoset a H K :=
+  doubleCoset_eq_of_mem (mem_doubleCoset.mpr ⟨1, H.one_mem, k, hk, by rw [one_mul]⟩)
+
 lemma mem_doubleCoset_of_not_disjoint {H K : Subgroup G} {a b : G}
     (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) : b ∈ doubleCoset a H K := by
   rw [Set.not_disjoint_iff] at h
@@ -190,6 +198,26 @@ lemma doubleCoset_union_leftCoset (H K : Subgroup G) (a : G) :
     simp only [hxy, ← mul_assoc, hy, one_mul, inv_mul_cancel, inv_mul_cancel_right]
 
 open Quotient QuotientGroup
+
+/-- A double coset `HaK` is the union of the left cosets `(h * a) • K` where `h` ranges over
+representatives of the quotient of `H` by the stabiliser `H ∩ aKa⁻¹`. -/
+lemma doubleCoset_eq_iUnion_leftCosets (H K : Subgroup G) (a : G) :
+    doubleCoset a H K =
+      ⋃ i : H ⧸ (ConjAct.toConjAct a • K).subgroupOf H, ((i.out : G) * a) • (K : Set G) := by
+  ext x
+  simp only [Set.mem_iUnion, mem_doubleCoset, mem_leftCoset_iff, SetLike.mem_coe]
+  constructor
+  · rintro ⟨h, hh, k, hk, rfl⟩
+    refine ⟨QuotientGroup.mk ⟨h, hh⟩, ?_⟩
+    obtain ⟨n, hn⟩ := QuotientGroup.mk_out_eq_mul ((ConjAct.toConjAct a • K).subgroupOf H) ⟨h, hh⟩
+    have hn' : a⁻¹ * ((n : H) : G) * a ∈ K :=
+      Subgroup.mem_conjAct_pointwise_smul_iff.mp (Subgroup.mem_subgroupOf.mp n.2)
+    rw [hn, show (((⟨h, hh⟩ : H) * (n : H) : H) : G) = h * ((n : H) : G) from rfl,
+      show (h * ((n : H) : G) * a)⁻¹ * (h * a * k) = (a⁻¹ * ((n : H) : G) * a)⁻¹ * k by
+        simp [mul_assoc]]
+    exact K.mul_mem (K.inv_mem hn') hk
+  · rintro ⟨i, hx⟩
+    exact ⟨(i.out : G), i.out.2, ((i.out : G) * a)⁻¹ * x, hx, (mul_inv_cancel_left _ _).symm⟩
 
 lemma left_bot_eq_left_quot (H : Subgroup G) :
     Quotient (⊥ : Subgroup G) (H : Set G) = (G ⧸ H) := by

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -1,0 +1,270 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.HeckeRing.Defs
+public import Mathlib.GroupTheory.Index
+public import Mathlib.Tactic.Group
+
+/-!
+# Hecke rings: the double coset API
+
+Basic API for the double cosets `HeckeCoset` that index an abstract Hecke ring, following
+Shimura, *Introduction to the Arithmetic Theory of Automorphic Functions*, Ch. 3. This file develops
+representatives of double cosets, the characterisation of when two elements give the same double
+coset, the decomposition of a double coset into left cosets of `H`, and the finite decomposition
+quotient `H / (H ∩ gHg⁻¹)` used to define the Hecke product in later files.
+
+## Main definitions
+
+* `HeckeCoset.toSet`: the underlying set `HgH` of a double coset.
+* `HeckeCoset.rep`: a chosen representative in `Δ`.
+* `HeckeCoset.one`: the identity double coset `H1H = H`.
+* `HeckeRing.decompQuot`: the finite quotient `H / (H ∩ gHg⁻¹)` indexing the left cosets in `HgH`.
+
+## Main results
+
+* `HeckeCoset.eq_iff`: `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`.
+* `HeckeRing.doubleCoset_eq_iUnion_leftCosets`: a double coset `HgH` as a union of left cosets.
+
+## Implementation notes
+
+`HeckeRing.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
+`attribute [local instance]` so that the quotient notation `⟦·⟧` is available for `HeckeCoset`.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup
+open scoped Pointwise
+
+variable {G : Type*} [Group G]
+
+attribute [local instance] doubleCosetSetoid
+
+variable (H : Subgroup G)
+
+namespace HeckeRing
+
+/-- The conjugation action on `H` as a set product: `gHg⁻¹ = {g} * H * {g⁻¹}`. -/
+lemma conjAct_smul_coe_eq (g : G) :
+    ((ConjAct.toConjAct g • H) : Set G) = {g} * H * {g⁻¹} := by
+  ext x
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · obtain ⟨a, ha⟩ := Set.mem_smul_set.mp h
+    rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct] at ha
+    rw [← ha.2]
+    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
+      inv_inv, mem_preimage, inv_mul_cancel_right, inv_mul_cancel_left, ha.1]
+  · refine Set.mem_smul_set.mpr ⟨g⁻¹ * x * g, ?_,
+      by rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct]; group⟩
+    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
+      inv_inv, mem_preimage, SetLike.mem_coe] at *
+    rwa [← mul_assoc] at h
+
+/-- Conjugation by an element of `H` fixes `H`. -/
+lemma conjAct_smul_elt_eq (h : H) : ConjAct.toConjAct (h : G) • H = H := by
+  have : ConjAct.toConjAct (h : G) • (H : Set G) = H := by
+    rw [conjAct_smul_coe_eq, Subgroup.singleton_mul_subgroup h.2,
+      Subgroup.subgroup_mul_singleton (by simp)]
+  rw [← Subgroup.coe_pointwise_smul] at this; exact_mod_cast this
+
+/-- Scalar multiplication by a group element is the same as singleton set multiplication. -/
+lemma smul_eq_singleton_mul (s : Set G) (g : G) : g • s = {g} * s :=
+  Set.singleton_smul.symm
+
+/-- A subgroup `H` is the union of left cosets of any sub-subgroup `K ≤ H`. -/
+lemma set_eq_iUnion_leftCosets (K : Subgroup G) (hK : K ≤ H) :
+    (H : Set G) = ⋃ (i : H ⧸ K.subgroupOf H), (i.out : G) • (K : Set G) := by
+  ext a
+  refine ⟨fun ha ↦ ?_, fun ha ↦ ?_⟩
+  · simp only [Set.mem_iUnion]
+    refine ⟨(⟨a, ha⟩ : H), ?_⟩
+    obtain ⟨h, hh⟩ := QuotientGroup.mk_out_eq_mul (K.subgroupOf H) (⟨a, ha⟩ : H)
+    rw [hh]
+    simp only [coe_mul]
+    refine Set.mem_smul_set.mpr ⟨h⁻¹, ?_, ?_⟩
+    · simpa using Subgroup.mem_subgroupOf.mp (SetLike.coe_mem h)
+    · simp
+  · simp only [Set.mem_iUnion] at ha
+    obtain ⟨i, h, hh, rfl⟩ := ha
+    change ((Quotient.out i : H) : G) * h ∈ H
+    exact mul_mem (by simp) (hK hh)
+
+/-- The conjugate subgroup `gHg⁻¹` is closed under multiplication. -/
+lemma conjAct_mul_self_eq_self (g : G) :
+    ((ConjAct.toConjAct g • H) : Set G) * (ConjAct.toConjAct g • H) =
+    (ConjAct.toConjAct g • H) := by
+  rw [conjAct_smul_coe_eq,
+    show {g} * (H : Set G) * {g⁻¹} * ({g} * ↑H * {g⁻¹}) =
+      {g} * ↑H * (({g⁻¹} * {g}) * ↑H) * {g⁻¹} by simp_rw [← mul_assoc],
+    Set.singleton_mul_singleton]
+  conv => enter [1, 1, 2]; simp only [inv_mul_cancel, Set.singleton_one, one_mul]
+  conv => enter [1, 1]; rw [mul_assoc, coe_mul_coe H]
+
+/-- The intersection `H ∩ gHg⁻¹` acts trivially on `gHg⁻¹` by left multiplication. -/
+lemma inter_mul_conjAct_eq_conjAct (g : G) :
+    ((H : Set G) ∩ (ConjAct.toConjAct g • H)) * (ConjAct.toConjAct g • H) =
+    (ConjAct.toConjAct g • H) :=
+  Subset.antisymm
+    (le_trans (Set.inter_mul_subset (s₁ := (H : Set G))
+      (s₂ := (ConjAct.toConjAct g • H)) (t := (ConjAct.toConjAct g • H)))
+      (by simp [conjAct_mul_self_eq_self]))
+    (subset_mul_right _ ⟨Subgroup.one_mem H, Subgroup.one_mem (ConjAct.toConjAct g • H)⟩)
+
+/-- Right multiplication by a singleton is cancellative. -/
+lemma mul_singleton_right_cancel (g : G) (K L : Set G) (h : K * {g} = L * {g}) : K = L := by
+  have h2 := congrFun (congrArg HMul.hMul h) {g⁻¹}
+  simp_rw [mul_assoc, Set.singleton_mul_singleton] at h2; simpa using h2
+
+/-- A double coset `HgH` decomposes as a union of left cosets of `H`. -/
+lemma doubleCoset_eq_iUnion_leftCosets (g : G) :
+    DoubleCoset.doubleCoset g H H =
+    ⋃ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
+      (i.out * g) • (H : Set G) := by
+  rw [DoubleCoset.doubleCoset]
+  have := set_eq_iUnion_leftCosets H
+    (((ConjAct.toConjAct g • H).subgroupOf H).map H.subtype)
+  simp only [Subgroup.subgroupOf_map_subtype, inf_le_right, Subgroup.coe_inf,
+    Subgroup.coe_pointwise_smul, true_implies] at this
+  have h2 := congrFun (congrArg HMul.hMul this)
+    ((ConjAct.toConjAct g • H) : Set G)
+  rw [Set.iUnion_mul, inter_comm] at h2
+  apply mul_singleton_right_cancel g⁻¹
+  rw [conjAct_smul_coe_eq] at *
+  simp_rw [← mul_assoc] at h2
+  rw [h2, show (Subgroup.map H.subtype
+    ((ConjAct.toConjAct g • H).subgroupOf H)).subgroupOf H =
+    (ConjAct.toConjAct g • H).subgroupOf H by simp]
+  have h1 : ∀ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
+      ((i.out) : G) • ((H : Set G) ∩ ({g} * ↑H * {g⁻¹})) *
+        {g} * ↑H * {g⁻¹} =
+      (↑(Quotient.out i) * g) • ↑H * {g⁻¹} := by
+    intro i
+    have := inter_mul_conjAct_eq_conjAct H g
+    rw [conjAct_smul_coe_eq] at this
+    simp_rw [smul_mul_assoc]
+    simp_rw [← mul_assoc] at this
+    conv => enter [1, 2]; rw [this]
+    simp_rw [smul_eq_singleton_mul, ← Set.singleton_mul_singleton, ← mul_assoc]
+  convert Set.iUnion_congr h1
+  rw [Set.iUnion_mul]
+
+end HeckeRing
+
+namespace HeckeCoset
+
+variable {P : HeckePair G}
+
+/-- The underlying set `HgH`, well-defined on the quotient. -/
+noncomputable def toSet (D : HeckeCoset P) : Set G :=
+  Quotient.lift (fun (g : P.Δ) ↦ DoubleCoset.doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
+
+/-- A representative `g : Δ` (via `Quotient.out`). -/
+noncomputable def rep (D : HeckeCoset P) : P.Δ := Quotient.out D
+
+/-- The representative of a `HeckeCoset` maps back to the coset under `⟦·⟧`. -/
+lemma mk_rep (D : HeckeCoset P) : (⟦HeckeCoset.rep D⟧ : HeckeCoset P) = D :=
+  Quotient.out_eq D
+
+/-- `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`. -/
+lemma eq_iff (g h : P.Δ) : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
+    DoubleCoset.doubleCoset (g : G) P.H P.H = DoubleCoset.doubleCoset (h : G) P.H P.H :=
+  Quotient.eq
+
+/-- The carrier set of `⟦g⟧` is definitionally `HgH`. -/
+@[simp] lemma toSet_mk (g : P.Δ) :
+    HeckeCoset.toSet (⟦g⟧ : HeckeCoset P) = DoubleCoset.doubleCoset (g : G) P.H P.H := rfl
+
+/-- The carrier set equals the double coset of the representative. -/
+lemma toSet_eq_rep (D : HeckeCoset P) :
+    HeckeCoset.toSet D = DoubleCoset.doubleCoset (HeckeCoset.rep D : G) P.H P.H := by
+  refine Quotient.inductionOn D fun g ↦ ?_
+  simpa only [toSet_mk, HeckeCoset.rep] using
+    (Quotient.exact (Quotient.out_eq (⟦g⟧ : HeckeCoset P))).symm
+
+/-- The representative lies in its double coset. -/
+lemma rep_mem (D : HeckeCoset P) : (HeckeCoset.rep D : G) ∈ HeckeCoset.toSet D :=
+  toSet_eq_rep D ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
+
+/-- If `x ∈ HgH`, then `HxH = HgH`. The fundamental double coset absorption lemma. -/
+lemma doubleCoset_eq_of_mem {g : P.Δ} {x : G}
+    (hx : x ∈ DoubleCoset.doubleCoset (g : G) P.H P.H) :
+    DoubleCoset.doubleCoset x P.H P.H = DoubleCoset.doubleCoset (g : G) P.H P.H := by
+  obtain ⟨_, ⟨l, hl, _, rfl, rfl⟩, r, hr, rfl⟩ := hx
+  simp only [DoubleCoset.doubleCoset]
+  ext y; simp only [Set.mem_mul, Set.mem_singleton_iff, SetLike.mem_coe]
+  constructor
+  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
+    exact ⟨_, ⟨a * l, P.H.mul_mem ha hl, _, rfl, rfl⟩, r * b, P.H.mul_mem hr hb, by group⟩
+  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
+    exact ⟨_, ⟨a * l⁻¹, P.H.mul_mem ha (P.H.inv_mem hl), _, rfl, rfl⟩,
+      r⁻¹ * b, P.H.mul_mem (P.H.inv_mem hr) hb, by group⟩
+
+/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` is in the double coset of `g₂`. -/
+lemma eq_mk_of_mem {g₁ g₂ : P.Δ}
+    (h : (g₁ : G) ∈ DoubleCoset.doubleCoset (g₂ : G) P.H P.H) :
+    (⟦g₁⟧ : HeckeCoset P) = ⟦g₂⟧ :=
+  (eq_iff g₁ g₂).mpr (doubleCoset_eq_of_mem h)
+
+/-- The identity double coset `H1H = H`. -/
+def one (P : HeckePair G) : HeckeCoset P := ⟦⟨1, P.Δ.one_mem⟩⟧
+
+/-- Induction: to prove something for all double cosets, prove it for `⟦g⟧`. -/
+protected lemma ind {motive : HeckeCoset P → Prop}
+    (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D := Quotient.ind h
+
+/-- Two-argument induction. -/
+protected lemma ind₂ {motive : HeckeCoset P → HeckeCoset P → Prop}
+    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) :
+    ∀ D₁ D₂, motive D₁ D₂ := Quotient.ind₂ h
+
+/-- The representative of `HeckeCoset.one` belongs to `H`. -/
+lemma one_rep_mem_H (P : HeckePair G) : ((one P).rep : G) ∈ P.H := by
+  have hm := rep_mem (one P)
+  rw [toSet_eq_rep,
+    show DoubleCoset.doubleCoset ((rep (one P)) : G) P.H P.H =
+      DoubleCoset.doubleCoset (1 : G) P.H P.H from
+    Quotient.exact (Quotient.out_eq (⟦⟨(1 : G), P.Δ.one_mem⟩⟧ : HeckeCoset P)),
+    mem_doubleCoset] at hm
+  obtain ⟨a, ha, b, hb, hab⟩ := hm
+  rw [mul_one] at hab
+  exact hab ▸ P.H.mul_mem ha hb
+
+end HeckeCoset
+
+namespace HeckeRing
+
+/-- Left-multiplying the representative by an element of `H` does not change the double coset. -/
+lemma doubleCoset_mul_left_eq_self (P : HeckePair G) (h : P.H) (g : G) :
+    DoubleCoset.doubleCoset ((h : G) * g) P.H P.H =
+    DoubleCoset.doubleCoset g P.H P.H := by
+  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
+  conv => enter [1, 1, 1]; rw [Subgroup.subgroup_mul_singleton h.2]
+
+/-- Right-multiplying the representative by an element of `H` does not change the double coset. -/
+lemma doubleCoset_mul_right_eq_self (P : HeckePair G)
+    (h : P.H) (g : G) : DoubleCoset.doubleCoset (g * h) P.H P.H =
+    DoubleCoset.doubleCoset g P.H P.H := by
+  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
+  conv => enter [1]; rw [mul_assoc, Subgroup.singleton_mul_subgroup h.2]
+
+/-- The decomposition quotient `H / (H ∩ gHg⁻¹)` for a concrete `g : Δ`.
+Indexes the left cosets in the decomposition of `HgH`. -/
+abbrev decompQuot (P : HeckePair G) (g : P.Δ) :=
+  P.H ⧸ (ConjAct.toConjAct (g : G) • P.H).subgroupOf P.H
+
+/-- The decomposition quotient is finite because `Δ ≤ commensurator H`. -/
+noncomputable instance (P : HeckePair G) (g : P.Δ) :
+    Fintype (decompQuot P g) :=
+  Subgroup.fintypeOfIndexNeZero (P.h₁ g.2).1
+
+/-- Products of the form `a * h * b` with `h ∈ H`, `a, b ∈ Δ` remain in `Δ`. -/
+lemma delta_mul_mem (Δ : Submonoid G) (i : H) (a b : Δ) (h₀ : H.toSubmonoid ≤ Δ) :
+    a * (i : G) * b ∈ Δ := by
+  rw [mul_assoc]; exact Submonoid.mul_mem _ a.2 (Submonoid.mul_mem _ (h₀ i.2) b.2)
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -7,264 +7,112 @@ module
 
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.GroupTheory.Index
-public import Mathlib.Tactic.Group
 
 /-!
 # Hecke rings: the double coset API
 
-Basic API for the double cosets `HeckeCoset` that index an abstract Hecke ring, following
-Shimura, *Introduction to the Arithmetic Theory of Automorphic Functions*, Ch. 3. This file develops
-representatives of double cosets, the characterisation of when two elements give the same double
-coset, the decomposition of a double coset into left cosets of `H`, and the finite decomposition
-quotient `H / (H ∩ gHg⁻¹)` used to define the Hecke product in later files.
+Basic API for the double cosets `HeckeCoset` indexing an abstract Hecke ring, following
+[Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
+characterisation of when two elements give the same double coset, and the quotient
+`Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
+define the Hecke product in later files and is finite in the Hecke pair setting.
 
 ## Main definitions
 
 * `HeckeCoset.toSet`: the underlying set `HgH` of a double coset.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
-* `HeckeCoset.one`: the identity double coset `H1H = H`.
-* `HeckeRing.decompQuot`: the finite quotient `H / (H ∩ gHg⁻¹)` indexing the left cosets in `HgH`.
+* `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
+  in `Γ₁gΓ₂`; finite for a Hecke pair.
 
 ## Main results
 
 * `HeckeCoset.eq_iff`: `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`.
-* `HeckeRing.doubleCoset_eq_iUnion_leftCosets`: a double coset `HgH` as a union of left cosets.
+* `HeckeCoset.toSet_injective`: a double coset is determined by its underlying set.
 
 ## Implementation notes
 
-`HeckeRing.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
+`HeckePair.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
 `attribute [local instance]` so that the quotient notation `⟦·⟧` is available for `HeckeCoset`.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup
+open DoubleCoset Subgroup
 open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
-attribute [local instance] doubleCosetSetoid
-
-variable (H : Subgroup G)
-
-namespace HeckeRing
-
-/-- The conjugation action on `H` as a set product: `gHg⁻¹ = {g} * H * {g⁻¹}`. -/
-lemma conjAct_smul_coe_eq (g : G) :
-    ((ConjAct.toConjAct g • H) : Set G) = {g} * H * {g⁻¹} := by
-  ext x
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · obtain ⟨a, ha⟩ := Set.mem_smul_set.mp h
-    rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct] at ha
-    rw [← ha.2]
-    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
-      inv_inv, mem_preimage, inv_mul_cancel_right, inv_mul_cancel_left, ha.1]
-  · refine Set.mem_smul_set.mpr ⟨g⁻¹ * x * g, ?_,
-      by rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct]; group⟩
-    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
-      inv_inv, mem_preimage, SetLike.mem_coe] at *
-    rwa [← mul_assoc] at h
-
-/-- Conjugation by an element of `H` fixes `H`. -/
-lemma conjAct_smul_elt_eq (h : H) : ConjAct.toConjAct (h : G) • H = H := by
-  have : ConjAct.toConjAct (h : G) • (H : Set G) = H := by
-    rw [conjAct_smul_coe_eq, Subgroup.singleton_mul_subgroup h.2,
-      Subgroup.subgroup_mul_singleton (by simp)]
-  rw [← Subgroup.coe_pointwise_smul] at this; exact_mod_cast this
-
-/-- Scalar multiplication by a group element is the same as singleton set multiplication. -/
-lemma smul_eq_singleton_mul (s : Set G) (g : G) : g • s = {g} * s :=
-  Set.singleton_smul.symm
-
-/-- A subgroup `H` is the union of left cosets of any sub-subgroup `K ≤ H`. -/
-lemma set_eq_iUnion_leftCosets (K : Subgroup G) (hK : K ≤ H) :
-    (H : Set G) = ⋃ (i : H ⧸ K.subgroupOf H), (i.out : G) • (K : Set G) := by
-  ext a
-  refine ⟨fun ha ↦ ?_, fun ha ↦ ?_⟩
-  · simp only [Set.mem_iUnion]
-    refine ⟨(⟨a, ha⟩ : H), ?_⟩
-    obtain ⟨h, hh⟩ := QuotientGroup.mk_out_eq_mul (K.subgroupOf H) (⟨a, ha⟩ : H)
-    rw [hh]
-    simp only [coe_mul]
-    refine Set.mem_smul_set.mpr ⟨h⁻¹, ?_, ?_⟩
-    · simpa using Subgroup.mem_subgroupOf.mp (SetLike.coe_mem h)
-    · simp
-  · simp only [Set.mem_iUnion] at ha
-    obtain ⟨i, h, hh, rfl⟩ := ha
-    change ((Quotient.out i : H) : G) * h ∈ H
-    exact mul_mem (by simp) (hK hh)
-
-/-- The conjugate subgroup `gHg⁻¹` is closed under multiplication. -/
-lemma conjAct_mul_self_eq_self (g : G) :
-    ((ConjAct.toConjAct g • H) : Set G) * (ConjAct.toConjAct g • H) =
-    (ConjAct.toConjAct g • H) := by
-  rw [conjAct_smul_coe_eq,
-    show {g} * (H : Set G) * {g⁻¹} * ({g} * ↑H * {g⁻¹}) =
-      {g} * ↑H * (({g⁻¹} * {g}) * ↑H) * {g⁻¹} by simp_rw [← mul_assoc],
-    Set.singleton_mul_singleton]
-  conv => enter [1, 1, 2]; simp only [inv_mul_cancel, Set.singleton_one, one_mul]
-  conv => enter [1, 1]; rw [mul_assoc, coe_mul_coe H]
-
-/-- The intersection `H ∩ gHg⁻¹` acts trivially on `gHg⁻¹` by left multiplication. -/
-lemma inter_mul_conjAct_eq_conjAct (g : G) :
-    ((H : Set G) ∩ (ConjAct.toConjAct g • H)) * (ConjAct.toConjAct g • H) =
-    (ConjAct.toConjAct g • H) :=
-  Subset.antisymm
-    (le_trans (Set.inter_mul_subset (s₁ := (H : Set G))
-      (s₂ := (ConjAct.toConjAct g • H)) (t := (ConjAct.toConjAct g • H)))
-      (by simp [conjAct_mul_self_eq_self]))
-    (subset_mul_right _ ⟨Subgroup.one_mem H, Subgroup.one_mem (ConjAct.toConjAct g • H)⟩)
-
-/-- Right multiplication by a singleton is cancellative. -/
-lemma mul_singleton_right_cancel (g : G) (K L : Set G) (h : K * {g} = L * {g}) : K = L := by
-  have h2 := congrFun (congrArg HMul.hMul h) {g⁻¹}
-  simp_rw [mul_assoc, Set.singleton_mul_singleton] at h2; simpa using h2
-
-/-- A double coset `HgH` decomposes as a union of left cosets of `H`. -/
-lemma doubleCoset_eq_iUnion_leftCosets (g : G) :
-    DoubleCoset.doubleCoset g H H =
-    ⋃ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
-      (i.out * g) • (H : Set G) := by
-  rw [DoubleCoset.doubleCoset]
-  have := set_eq_iUnion_leftCosets H
-    (((ConjAct.toConjAct g • H).subgroupOf H).map H.subtype)
-  simp only [Subgroup.subgroupOf_map_subtype, inf_le_right, Subgroup.coe_inf,
-    Subgroup.coe_pointwise_smul, true_implies] at this
-  have h2 := congrFun (congrArg HMul.hMul this)
-    ((ConjAct.toConjAct g • H) : Set G)
-  rw [Set.iUnion_mul, inter_comm] at h2
-  apply mul_singleton_right_cancel g⁻¹
-  rw [conjAct_smul_coe_eq] at *
-  simp_rw [← mul_assoc] at h2
-  rw [h2, show (Subgroup.map H.subtype
-    ((ConjAct.toConjAct g • H).subgroupOf H)).subgroupOf H =
-    (ConjAct.toConjAct g • H).subgroupOf H by simp]
-  have h1 : ∀ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
-      ((i.out) : G) • ((H : Set G) ∩ ({g} * ↑H * {g⁻¹})) *
-        {g} * ↑H * {g⁻¹} =
-      (↑(Quotient.out i) * g) • ↑H * {g⁻¹} := by
-    intro i
-    have := inter_mul_conjAct_eq_conjAct H g
-    rw [conjAct_smul_coe_eq] at this
-    simp_rw [smul_mul_assoc]
-    simp_rw [← mul_assoc] at this
-    conv => enter [1, 2]; rw [this]
-    simp_rw [smul_eq_singleton_mul, ← Set.singleton_mul_singleton, ← mul_assoc]
-  convert Set.iUnion_congr h1
-  rw [Set.iUnion_mul]
-
-end HeckeRing
+attribute [local instance] HeckePair.doubleCosetSetoid
 
 namespace HeckeCoset
 
 variable {P : HeckePair G}
 
-/-- The underlying set `HgH`, well-defined on the quotient. -/
-noncomputable def toSet (D : HeckeCoset P) : Set G :=
-  Quotient.lift (fun (g : P.Δ) ↦ DoubleCoset.doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
+/-- The underlying set `HgH` of a double coset, well-defined on the quotient. -/
+def toSet (D : HeckeCoset P) : Set G :=
+  Quotient.lift (fun g : P.Δ ↦ doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
 
-/-- A representative `g : Δ` (via `Quotient.out`). -/
+/-- A representative `g : Δ` of a double coset (via `Quotient.out`). -/
 noncomputable def rep (D : HeckeCoset P) : P.Δ := Quotient.out D
 
-/-- The representative of a `HeckeCoset` maps back to the coset under `⟦·⟧`. -/
-lemma mk_rep (D : HeckeCoset P) : (⟦HeckeCoset.rep D⟧ : HeckeCoset P) = D :=
-  Quotient.out_eq D
+@[simp] lemma mk_rep (D : HeckeCoset P) : (⟦D.rep⟧ : HeckeCoset P) = D := Quotient.out_eq D
 
-/-- `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`. -/
-lemma eq_iff (g h : P.Δ) : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
-    DoubleCoset.doubleCoset (g : G) P.H P.H = DoubleCoset.doubleCoset (h : G) P.H P.H :=
-  Quotient.eq
+lemma eq_iff {g h : P.Δ} : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
+    doubleCoset (g : G) P.H P.H = doubleCoset (h : G) P.H P.H := Quotient.eq
 
-/-- The carrier set of `⟦g⟧` is definitionally `HgH`. -/
 @[simp] lemma toSet_mk (g : P.Δ) :
-    HeckeCoset.toSet (⟦g⟧ : HeckeCoset P) = DoubleCoset.doubleCoset (g : G) P.H P.H := rfl
+    toSet (⟦g⟧ : HeckeCoset P) = doubleCoset (g : G) P.H P.H := rfl
 
-/-- The carrier set equals the double coset of the representative. -/
-lemma toSet_eq_rep (D : HeckeCoset P) :
-    HeckeCoset.toSet D = DoubleCoset.doubleCoset (HeckeCoset.rep D : G) P.H P.H := by
-  refine Quotient.inductionOn D fun g ↦ ?_
-  simpa only [toSet_mk, HeckeCoset.rep] using
-    (Quotient.exact (Quotient.out_eq (⟦g⟧ : HeckeCoset P))).symm
+lemma toSet_eq_doubleCoset_rep (D : HeckeCoset P) :
+    D.toSet = doubleCoset (D.rep : G) P.H P.H := by rw [← toSet_mk, mk_rep]
 
-/-- The representative lies in its double coset. -/
-lemma rep_mem (D : HeckeCoset P) : (HeckeCoset.rep D : G) ∈ HeckeCoset.toSet D :=
-  toSet_eq_rep D ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
+lemma toSet_injective : Function.Injective (toSet : HeckeCoset P → Set G) := fun D₁ D₂ ↦
+  Quotient.inductionOn₂ D₁ D₂ fun _ _ h ↦ Quotient.sound h
 
-/-- If `x ∈ HgH`, then `HxH = HgH`. The fundamental double coset absorption lemma. -/
-lemma doubleCoset_eq_of_mem {g : P.Δ} {x : G}
-    (hx : x ∈ DoubleCoset.doubleCoset (g : G) P.H P.H) :
-    DoubleCoset.doubleCoset x P.H P.H = DoubleCoset.doubleCoset (g : G) P.H P.H := by
-  obtain ⟨_, ⟨l, hl, _, rfl, rfl⟩, r, hr, rfl⟩ := hx
-  simp only [DoubleCoset.doubleCoset]
-  ext y; simp only [Set.mem_mul, Set.mem_singleton_iff, SetLike.mem_coe]
-  constructor
-  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
-    exact ⟨_, ⟨a * l, P.H.mul_mem ha hl, _, rfl, rfl⟩, r * b, P.H.mul_mem hr hb, by group⟩
-  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
-    exact ⟨_, ⟨a * l⁻¹, P.H.mul_mem ha (P.H.inv_mem hl), _, rfl, rfl⟩,
-      r⁻¹ * b, P.H.mul_mem (P.H.inv_mem hr) hb, by group⟩
+lemma rep_mem (D : HeckeCoset P) : (D.rep : G) ∈ D.toSet :=
+  D.toSet_eq_doubleCoset_rep ▸ mem_doubleCoset_self P.H P.H _
 
-/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` is in the double coset of `g₂`. -/
-lemma eq_mk_of_mem {g₁ g₂ : P.Δ}
-    (h : (g₁ : G) ∈ DoubleCoset.doubleCoset (g₂ : G) P.H P.H) :
+/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` lies in the double coset of `g₂`. -/
+lemma mk_eq_mk_of_mem {g₁ g₂ : P.Δ} (h : (g₁ : G) ∈ doubleCoset (g₂ : G) P.H P.H) :
     (⟦g₁⟧ : HeckeCoset P) = ⟦g₂⟧ :=
-  (eq_iff g₁ g₂).mpr (doubleCoset_eq_of_mem h)
-
-/-- The identity double coset `H1H = H`. -/
-def one (P : HeckePair G) : HeckeCoset P := ⟦⟨1, P.Δ.one_mem⟩⟧
+  eq_iff.mpr (doubleCoset_eq_of_mem h)
 
 /-- Induction: to prove something for all double cosets, prove it for `⟦g⟧`. -/
-protected lemma ind {motive : HeckeCoset P → Prop}
-    (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D := Quotient.ind h
+protected lemma ind {motive : HeckeCoset P → Prop} (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D :=
+  Quotient.ind h
 
-/-- Two-argument induction. -/
+/-- Two-argument induction for double cosets. -/
 protected lemma ind₂ {motive : HeckeCoset P → HeckeCoset P → Prop}
-    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) :
-    ∀ D₁ D₂, motive D₁ D₂ := Quotient.ind₂ h
+    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) : ∀ D₁ D₂, motive D₁ D₂ :=
+  Quotient.ind₂ h
 
-/-- The representative of `HeckeCoset.one` belongs to `H`. -/
-lemma one_rep_mem_H (P : HeckePair G) : ((one P).rep : G) ∈ P.H := by
-  have hm := rep_mem (one P)
-  rw [toSet_eq_rep,
-    show DoubleCoset.doubleCoset ((rep (one P)) : G) P.H P.H =
-      DoubleCoset.doubleCoset (1 : G) P.H P.H from
-    Quotient.exact (Quotient.out_eq (⟦⟨(1 : G), P.Δ.one_mem⟩⟧ : HeckeCoset P)),
-    mem_doubleCoset] at hm
-  obtain ⟨a, ha, b, hb, hab⟩ := hm
-  rw [mul_one] at hab
-  exact hab ▸ P.H.mul_mem ha hb
+@[simp] lemma toSet_one : toSet (1 : HeckeCoset P) = (P.H : Set G) := by
+  change (P.H : Set G) * {(1 : G)} * P.H = (P.H : Set G)
+  rw [Subgroup.subgroup_mul_singleton P.H.one_mem, coe_mul_coe]
+
+lemma rep_one_mem : (rep (1 : HeckeCoset P) : G) ∈ P.H := by
+  simpa using rep_mem (1 : HeckeCoset P)
 
 end HeckeCoset
 
-namespace HeckeRing
+namespace DoubleCoset
 
-/-- Left-multiplying the representative by an element of `H` does not change the double coset. -/
-lemma doubleCoset_mul_left_eq_self (P : HeckePair G) (h : P.H) (g : G) :
-    DoubleCoset.doubleCoset ((h : G) * g) P.H P.H =
-    DoubleCoset.doubleCoset g P.H P.H := by
-  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
-  conv => enter [1, 1, 1]; rw [Subgroup.subgroup_mul_singleton h.2]
+/-- The decomposition quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)`, indexing the left cosets of `Γ₂` inside
+the double coset `Γ₁gΓ₂`; see `DoubleCoset.doubleCoset_eq_iUnion_leftCosets`. -/
+abbrev DecompQuotient (Γ₁ Γ₂ : Subgroup G) (g : G) :=
+  Γ₁ ⧸ (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁
 
-/-- Right-multiplying the representative by an element of `H` does not change the double coset. -/
-lemma doubleCoset_mul_right_eq_self (P : HeckePair G)
-    (h : P.H) (g : G) : DoubleCoset.doubleCoset (g * h) P.H P.H =
-    DoubleCoset.doubleCoset g P.H P.H := by
-  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
-  conv => enter [1]; rw [mul_assoc, Subgroup.singleton_mul_subgroup h.2]
+instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ₂ g) :=
+  ⟨QuotientGroup.mk 1⟩
 
-/-- The decomposition quotient `H / (H ∩ gHg⁻¹)` for a concrete `g : Δ`.
-Indexes the left cosets in the decomposition of `HgH`. -/
-abbrev decompQuot (P : HeckePair G) (g : P.Δ) :=
-  P.H ⧸ (ConjAct.toConjAct (g : G) • P.H).subgroupOf P.H
+end DoubleCoset
 
-/-- The decomposition quotient is finite because `Δ ≤ commensurator H`. -/
+namespace HeckePair
+
+/-- For a Hecke pair, the decomposition quotient of any `g : Δ` is finite, because `Δ` lies in
+the commensurator of `H`. -/
 noncomputable instance (P : HeckePair G) (g : P.Δ) :
-    Fintype (decompQuot P g) :=
-  Subgroup.fintypeOfIndexNeZero (P.h₁ g.2).1
+    Fintype (DecompQuotient P.H P.H (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (P.le_commensurator g.2).1
 
-/-- Products of the form `a * h * b` with `h ∈ H`, `a, b ∈ Δ` remain in `Δ`. -/
-lemma delta_mul_mem (Δ : Submonoid G) (i : H) (a b : Δ) (h₀ : H.toSubmonoid ≤ Δ) :
-    a * (i : G) * b ∈ Δ := by
-  rw [mul_assoc]; exact Submonoid.mul_mem _ a.2 (Submonoid.mul_mem _ (h₀ i.2) b.2)
-
-end HeckeRing
+end HeckePair

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -110,11 +110,4 @@ noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTripl
     (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) :=
   Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_right g).1
 
-/-- The decomposition quotient with the two subgroups swapped is finite from the same datum,
-since `Δ` also commensurates the left subgroup (`le_commensurator_left`). Lower priority, so
-that the unswapped instance is preferred in the diagonal case. -/
-noncomputable instance (priority := 900) {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
-    [IsHeckeTriple Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_left g).1
-
 end IsHeckeTriple

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -15,14 +15,14 @@ Basic API for the double cosets `HeckeCoset` indexing a Hecke coset module, foll
 [Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
 characterisation of when two elements give the same double coset, and the quotient
 `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
-define the Hecke product in later files and is finite for a Hecke coset module datum.
+define the Hecke product in later files and is finite for a Hecke triple.
 
 ## Main definitions
 
 * `HeckeCoset.toSet`: the underlying set `H₁gH₂` of a double coset.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
 * `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
-  in `Γ₁gΓ₂`; finite for a Hecke coset module datum.
+  in `Γ₁gΓ₂`; finite for a Hecke triple.
 
 ## Main results
 
@@ -102,19 +102,19 @@ instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ�
 
 end DoubleCoset
 
-namespace IsHeckeCosetModule
+namespace IsHeckeTriple
 
-/-- For a Hecke coset module datum, the decomposition quotient of any `g : Δ` is finite: `Δ`
+/-- For a Hecke triple, the decomposition quotient of any `g : Δ` is finite: `Δ`
 commensurates `H₂`, which is commensurable with `H₁`. -/
-noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
+noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]
     (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_right g).1
+  Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_right g).1
 
 /-- The decomposition quotient with the two subgroups swapped is finite from the same datum,
 since `Δ` also commensurates the left subgroup (`le_commensurator_left`). Lower priority, so
 that the unswapped instance is preferred in the diagonal case. -/
 noncomputable instance (priority := 900) {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
-    [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_left g).1
+    [IsHeckeTriple Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_left g).1
 
-end IsHeckeCosetModule
+end IsHeckeTriple

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -11,28 +11,23 @@ public import Mathlib.GroupTheory.Index
 /-!
 # Hecke rings: the double coset API
 
-Basic API for the double cosets `HeckeCoset` indexing an abstract Hecke ring, following
+Basic API for the double cosets `HeckeCoset` indexing a Hecke coset module, following
 [Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
 characterisation of when two elements give the same double coset, and the quotient
 `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
-define the Hecke product in later files and is finite in the Hecke pair setting.
+define the Hecke product in later files and is finite for a Hecke coset module datum.
 
 ## Main definitions
 
-* `HeckeCoset.toSet`: the underlying set `HgH` of a double coset.
+* `HeckeCoset.toSet`: the underlying set `H₁gH₂` of a double coset.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
 * `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
-  in `Γ₁gΓ₂`; finite for a Hecke pair.
+  in `Γ₁gΓ₂`; finite for a Hecke coset module datum.
 
 ## Main results
 
-* `HeckeCoset.eq_iff`: `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`.
+* `HeckeCoset.eq_iff`: `mk H₁ H₂ g = mk H₁ H₂ h ↔ H₁gH₂ = H₁hH₂`.
 * `HeckeCoset.toSet_injective`: a double coset is determined by its underlying set.
-
-## Implementation notes
-
-`HeckePair.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
-`attribute [local instance]` so that the quotient notation `⟦·⟧` is available for `HeckeCoset`.
 -/
 
 @[expose] public section
@@ -42,56 +37,56 @@ open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
-attribute [local instance] HeckePair.doubleCosetSetoid
-
 namespace HeckeCoset
 
-variable {P : HeckePair G}
+variable {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
 
-/-- The underlying set `HgH` of a double coset, well-defined on the quotient. -/
-def toSet (D : HeckeCoset P) : Set G :=
-  Quotient.lift (fun g : P.Δ ↦ doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
+/-- The underlying set `H₁gH₂` of a double coset, well-defined on the quotient. -/
+def toSet (D : HeckeCoset Δ H₁ H₂) : Set G :=
+  Quotient.lift (fun g : Δ ↦ doubleCoset (g : G) H₁ H₂) (fun _ _ h ↦ h) D
 
 /-- A representative `g : Δ` of a double coset (via `Quotient.out`). -/
-noncomputable def rep (D : HeckeCoset P) : P.Δ := Quotient.out D
+noncomputable def rep (D : HeckeCoset Δ H₁ H₂) : Δ := Quotient.out D
 
-@[simp] lemma mk_rep (D : HeckeCoset P) : (⟦D.rep⟧ : HeckeCoset P) = D := Quotient.out_eq D
+@[simp] lemma mk_rep (D : HeckeCoset Δ H₁ H₂) : mk H₁ H₂ D.rep = D := Quotient.out_eq' D
 
-lemma eq_iff {g h : P.Δ} : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
-    doubleCoset (g : G) P.H P.H = doubleCoset (h : G) P.H P.H := Quotient.eq
+lemma eq_iff {g h : Δ} : mk H₁ H₂ g = mk H₁ H₂ h ↔
+    doubleCoset (g : G) H₁ H₂ = doubleCoset (h : G) H₁ H₂ := Quotient.eq''
 
-@[simp] lemma toSet_mk (g : P.Δ) :
-    toSet (⟦g⟧ : HeckeCoset P) = doubleCoset (g : G) P.H P.H := rfl
+@[simp] lemma toSet_mk (g : Δ) : toSet (mk H₁ H₂ g) = doubleCoset (g : G) H₁ H₂ := rfl
 
-lemma toSet_eq_doubleCoset_rep (D : HeckeCoset P) :
-    D.toSet = doubleCoset (D.rep : G) P.H P.H := by rw [← toSet_mk, mk_rep]
+lemma toSet_eq_doubleCoset_rep (D : HeckeCoset Δ H₁ H₂) :
+    D.toSet = doubleCoset (D.rep : G) H₁ H₂ := by rw [← toSet_mk, mk_rep]
 
-lemma toSet_injective : Function.Injective (toSet : HeckeCoset P → Set G) := fun D₁ D₂ ↦
-  Quotient.inductionOn₂ D₁ D₂ fun _ _ h ↦ Quotient.sound h
+lemma toSet_injective : Function.Injective (toSet : HeckeCoset Δ H₁ H₂ → Set G) := fun D₁ D₂ ↦
+  Quotient.inductionOn₂' D₁ D₂ fun _ _ h ↦ Quotient.sound' h
 
-lemma rep_mem (D : HeckeCoset P) : (D.rep : G) ∈ D.toSet :=
-  D.toSet_eq_doubleCoset_rep ▸ mem_doubleCoset_self P.H P.H _
+lemma rep_mem (D : HeckeCoset Δ H₁ H₂) : (D.rep : G) ∈ D.toSet :=
+  D.toSet_eq_doubleCoset_rep ▸ mem_doubleCoset_self H₁ H₂ _
 
-/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` lies in the double coset of `g₂`. -/
-lemma mk_eq_mk_of_mem {g₁ g₂ : P.Δ} (h : (g₁ : G) ∈ doubleCoset (g₂ : G) P.H P.H) :
-    (⟦g₁⟧ : HeckeCoset P) = ⟦g₂⟧ :=
+/-- `mk H₁ H₂ g₁ = mk H₁ H₂ g₂` when `g₁` lies in the double coset of `g₂`. -/
+lemma mk_eq_mk_of_mem {g₁ g₂ : Δ} (h : (g₁ : G) ∈ doubleCoset (g₂ : G) H₁ H₂) :
+    mk H₁ H₂ g₁ = mk H₁ H₂ g₂ :=
   eq_iff.mpr (doubleCoset_eq_of_mem h)
 
-/-- Induction: to prove something for all double cosets, prove it for `⟦g⟧`. -/
-protected lemma ind {motive : HeckeCoset P → Prop} (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D :=
-  Quotient.ind h
+/-- Induction: to prove something for all double cosets, prove it for `mk H₁ H₂ g`. -/
+protected lemma ind {motive : HeckeCoset Δ H₁ H₂ → Prop} (h : ∀ g : Δ, motive (mk H₁ H₂ g)) :
+    ∀ D, motive D :=
+  Quotient.ind' h
 
 /-- Two-argument induction for double cosets. -/
-protected lemma ind₂ {motive : HeckeCoset P → HeckeCoset P → Prop}
-    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) : ∀ D₁ D₂, motive D₁ D₂ :=
-  Quotient.ind₂ h
+protected lemma ind₂ {motive : HeckeCoset Δ H₁ H₂ → HeckeCoset Δ H₁ H₂ → Prop}
+    (h : ∀ g₁ g₂ : Δ, motive (mk H₁ H₂ g₁) (mk H₁ H₂ g₂)) : ∀ D₁ D₂, motive D₁ D₂ := fun D₁ D₂ ↦
+  Quotient.inductionOn₂' D₁ D₂ h
 
-@[simp] lemma toSet_one : toSet (1 : HeckeCoset P) = (P.H : Set G) := by
-  change (P.H : Set G) * {(1 : G)} * P.H = (P.H : Set G)
-  rw [Subgroup.subgroup_mul_singleton P.H.one_mem, coe_mul_coe]
+variable {H : Subgroup G}
 
-lemma rep_one_mem : (rep (1 : HeckeCoset P) : G) ∈ P.H := by
-  simpa using rep_mem (1 : HeckeCoset P)
+@[simp] lemma toSet_one : toSet (1 : HeckeCoset Δ H H) = (H : Set G) := by
+  change (H : Set G) * {(1 : G)} * H = (H : Set G)
+  rw [Subgroup.subgroup_mul_singleton H.one_mem, coe_mul_coe]
+
+lemma rep_one_mem : (rep (1 : HeckeCoset Δ H H) : G) ∈ H := by
+  simpa using rep_mem (1 : HeckeCoset Δ H H)
 
 end HeckeCoset
 
@@ -107,12 +102,15 @@ instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ�
 
 end DoubleCoset
 
-namespace HeckePair
+namespace IsHeckeCosetModule
 
-/-- For a Hecke pair, the decomposition quotient of any `g : Δ` is finite, because `Δ` lies in
-the commensurator of `H`. -/
-noncomputable instance (P : HeckePair G) (g : P.Δ) :
-    Fintype (DecompQuotient P.H P.H (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (P.le_commensurator g.2).1
+/-- For a Hecke coset module datum, the decomposition quotient of any `g : Δ` is finite: `Δ`
+commensurates `H₂`, which is commensurable with `H₁`. -/
+noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
+    (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) := by
+  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ :=
+    IsHeckeCosetModule.le_commensurator H₁ g.2
+  exact Subgroup.fintypeOfIndexNeZero
+    (hg.trans (IsHeckeCosetModule.commensurable (Δ := Δ)).symm).1
 
-end HeckePair
+end IsHeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -107,10 +107,14 @@ namespace IsHeckeCosetModule
 /-- For a Hecke coset module datum, the decomposition quotient of any `g : Δ` is finite: `Δ`
 commensurates `H₂`, which is commensurable with `H₁`. -/
 noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
-    (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) := by
-  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ :=
-    IsHeckeCosetModule.le_commensurator H₁ g.2
-  exact Subgroup.fintypeOfIndexNeZero
-    (hg.trans (IsHeckeCosetModule.commensurable (Δ := Δ)).symm).1
+    (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_right g).1
+
+/-- The decomposition quotient with the two subgroups swapped is finite from the same datum,
+since `Δ` also commensurates the left subgroup (`le_commensurator_left`). Lower priority, so
+that the unswapped instance is preferred in the diagonal case. -/
+noncomputable instance (priority := 900) {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
+    [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_left g).1
 
 end IsHeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -12,14 +12,15 @@ public import Mathlib.GroupTheory.DoubleCoset
 /-!
 # Hecke rings: definitions
 
-The abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the Hecke coset modules
-attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971], Chapter 3, and
-[Krieg][krieg1990], Chapter I. This file sets up the underlying types: the compatibility
+This file introduces the abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the
+Hecke coset modules attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971],
+Chapter 3, and [Krieg][krieg1990], Chapter I. It sets up the underlying types: the compatibility
 conditions `IsHeckeTriple Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
 double-coset quotient `HeckeCoset Δ H₁ H₂` of `Δ` by `H₁gH₂ = H₁hH₂`, and the Hecke coset module
-`𝕋 Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets. The convolution
-product `𝕋 Δ H₁ H₂ Z × 𝕋 Δ H₂ H₃ Z → 𝕋 Δ H₁ H₃ Z` and the ring structure on the diagonal
-`𝕋 Δ H H Z` are developed in later files.
+`HeckeCosetModule Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets.
+The convolution product `HeckeCosetModule Δ H₁ H₂ Z × HeckeCosetModule Δ H₂ H₃ Z →
+HeckeCosetModule Δ H₁ H₃ Z` and the ring structure on the diagonal Hecke ring `𝕋 Δ H Z` are
+developed in later files.
 
 The relevance of the submonoid `Δ` may not be immediately obvious; a natural example is
 `H = GL₂(ℤ)` inside `G = GL₂(ℚ)` with `Δ` the submonoid of integral matrices with nonzero
@@ -35,15 +36,17 @@ subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.
   `IsHeckeTriple Δ H H`.
 * `HeckeCoset Δ H₁ H₂`: the quotient of `Δ` by the relation `H₁gH₂ = H₁hH₂`, i.e. the double
   cosets `H₁\Δ/H₂` forming the basis of the Hecke coset module.
-* `HeckeCosetModule Δ H₁ H₂ Z`, notation `𝕋 Δ H₁ H₂ Z`: the Hecke coset module with
-  coefficients in `Z`, the finitely-supported `Z`-linear combinations of double cosets. For
-  `H₁ = H₂` this is the underlying module of the Hecke ring.
+* `HeckeCosetModule Δ H₁ H₂ Z`: the Hecke coset module with coefficients in `Z`, the
+  finitely-supported `Z`-linear combinations of double cosets.
+* `HeckeRing Δ H Z`, notation `𝕋 Δ H Z`: the Hecke ring, the diagonal case
+  `HeckeCosetModule Δ H H Z` of the Hecke coset module.
 
 ## Implementation notes
 
 The data `(Δ, H₁, H₂)` enters unbundled, with the compatibility conditions collected in the
-Prop-valued class `IsHeckeTriple`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
-built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all levels
+Prop-valued class `IsHeckeTriple`: the types `HeckeCoset Δ H₁ H₂` and `HeckeCosetModule Δ H₁ H₂ Z`
+are built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all
+levels
 (as in [Shimura][shimura1971]) means products of double cosets over different subgroups,
 `H₁g₁H₂ * H₂g₂H₃ ⊆ Δ`, need no compatibility hypotheses. The conditions are only needed for the
 finiteness of the coset decompositions, which enters through the `Fintype` instance on
@@ -77,7 +80,7 @@ class IsHeckeTriple (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
   commensurable : Commensurable H₁ H₂
   /-- The submonoid `Δ` lies in the commensurator of the right subgroup (hence, the subgroups
   being commensurable, also in that of the left one; see `le_commensurator_left`). -/
-  le_commensurator : Δ ≤ (commensurator H₂).toSubmonoid
+  le_commensurator_right : Δ ≤ (commensurator H₂).toSubmonoid
 
 namespace IsHeckeTriple
 
@@ -90,25 +93,25 @@ theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
 
 /-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
+theorem mem_of_mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
   left_le (H₂ := H₂) hx
 
 /-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
+theorem mem_of_mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
   right_le (H₁ := H₁) hx
 
 /-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
-theorem le_commensurator_left [IsHeckeTriple Δ H₁ H₂] :
+theorem le_commensurator_left [h : IsHeckeTriple Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
-  rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
-  exact le_commensurator H₁
+  rw [h.commensurable.eq]
+  exact h.le_commensurator_right
 
 /-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
 explicit, since it cannot be inferred. -/
 theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₂ :=
-  le_commensurator H₁ g.2
+  le_commensurator_right H₁ g.2
 
 /-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
 explicit, since it cannot be inferred. -/
@@ -117,23 +120,12 @@ theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] 
   le_commensurator_left (H₂ := H₂) g.2
 
 /-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
-the left one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₁ H₂`. -/
+the left one; the intersection `H₁ ∩ gH₂g⁻¹` this bounds is the one underlying
+`DoubleCoset.DecompQuotient H₁ H₂ g`. -/
 theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
   exact hg.trans (commensurable (Δ := Δ)).symm
-
-/-- Conjugating the left subgroup by an element of `Δ` gives a subgroup commensurable with
-the right one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₂ H₁`. -/
-theorem commensurable_conjAct_left [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
-    Commensurable (ConjAct.toConjAct (g : G) • H₁) H₂ := by
-  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₁) H₁ := mem_commensurator_left H₂ g
-  exact hg.trans (commensurable (Δ := Δ))
-
-/-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
-theorem symm [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₁ :=
-  ⟨right_le (H₁ := H₁), left_le (H₂ := H₂), (commensurable (Δ := Δ)).symm,
-    le_commensurator_left (H₂ := H₂)⟩
 
 /-- Hecke coset module data compose. Not an instance, since the middle subgroup cannot be
 inferred from the goal. -/
@@ -142,7 +134,7 @@ theorem trans [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] :
   ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
     (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
       (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
-    le_commensurator (H₁ := H₂)⟩
+    le_commensurator_right (H₁ := H₂)⟩
 
 /-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
 theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
@@ -150,7 +142,7 @@ theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
 
 /-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
 theorem diag_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
-  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator (H₁ := H₁)⟩
+  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator_right (H₁ := H₁)⟩
 
 end IsHeckeTriple
 
@@ -158,8 +150,8 @@ end IsHeckeTriple
 back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
 
 This is a `def` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred from
-the type `↥Δ`, so this cannot participate in instance search (and a global instance would also
-create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
+the submonoid `Δ`, so this cannot participate in instance search (and a global instance would
+also create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
 `HeckeCoset.mk`. -/
 @[reducible] def HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
   (DoubleCoset.setoid (H₁ : Set G) H₂).comap Subtype.val
@@ -187,34 +179,41 @@ lemma one_def (H : Subgroup G) : (1 : HeckeCoset Δ H H) = mk H H ⟨1, Δ.one_m
 
 end HeckeCoset
 
-/-- The Hecke coset module with coefficients in `Z`, denoted `𝕋 Δ H₁ H₂ Z`: the
-finitely-supported `Z`-linear combinations of double cosets `H₁\Δ/H₂`. For `H₁ = H₂` this is the
-underlying module of the Hecke ring. The coefficients `Z` need only carry a `Zero` for the type
-to make sense; algebraic structure is added by the instances below at the weakest level each
+/-- The Hecke coset module with coefficients in `Z`: the finitely-supported `Z`-linear
+combinations of double cosets `H₁\Δ/H₂`. For `H₁ = H₂` this is the underlying module of the
+Hecke ring `𝕋 Δ H Z` (see `HeckeRing`). The coefficients `Z` need only carry a `Zero` for the
+type to make sense; algebraic structure is added by the instances below at the weakest level each
 requires. -/
 def HeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*) [Zero Z] :=
   HeckeCoset Δ H₁ H₂ →₀ Z
 
-namespace HeckeCosetModule
+/-- The Hecke ring `𝕋 Δ H Z` with coefficients in `Z`: the diagonal Hecke coset module
+`HeckeCosetModule Δ H H Z`, the finitely-supported `Z`-linear combinations of double cosets
+`H\Δ/H`. The convolution product making it a ring is developed in later files. -/
+abbrev HeckeRing (Δ : Submonoid G) (H : Subgroup G) (Z : Type*) [Zero Z] :=
+  HeckeCosetModule Δ H H Z
 
 @[inherit_doc]
-scoped notation "𝕋" => HeckeCosetModule
+scoped[HeckeCosetModule] notation "𝕋" => HeckeRing
+
+namespace HeckeCosetModule
 
 variable (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*)
 
-/-- Elements of `𝕋 Δ H₁ H₂ Z` are functions `HeckeCoset Δ H₁ H₂ → Z` (finitely supported). -/
-instance [Zero Z] : FunLike (𝕋 Δ H₁ H₂ Z) (HeckeCoset Δ H₁ H₂) Z :=
+/-- Elements of `HeckeCosetModule Δ H₁ H₂ Z` are functions `HeckeCoset Δ H₁ H₂ → Z` (finitely
+supported). -/
+instance [Zero Z] : FunLike (HeckeCosetModule Δ H₁ H₂ Z) (HeckeCoset Δ H₁ H₂) Z :=
   inferInstanceAs (FunLike (HeckeCoset Δ H₁ H₂ →₀ Z) (HeckeCoset Δ H₁ H₂) Z)
 
-noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 Δ H₁ H₂ Z) :=
+noncomputable instance [AddCommMonoid Z] : AddCommMonoid (HeckeCosetModule Δ H₁ H₂ Z) :=
   inferInstanceAs (AddCommMonoid (HeckeCoset Δ H₁ H₂ →₀ Z))
 
-noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 Δ H₁ H₂ Z) :=
+noncomputable instance [AddCommGroup Z] : AddCommGroup (HeckeCosetModule Δ H₁ H₂ Z) :=
   inferInstanceAs (AddCommGroup (HeckeCoset Δ H₁ H₂ →₀ Z))
 
 @[ext]
-lemma ext {Δ : Submonoid G} {H₁ H₂ : Subgroup G} {Z : Type*} [Zero Z] {f g : 𝕋 Δ H₁ H₂ Z}
-    (h : ∀ D, f D = g D) : f = g :=
+lemma ext {Δ : Submonoid G} {H₁ H₂ : Subgroup G} {Z : Type*} [Zero Z]
+    {f g : HeckeCosetModule Δ H₁ H₂ Z} (h : ∀ D, f D = g D) : f = g :=
   Finsupp.ext h
 
 end HeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -12,20 +12,40 @@ public import Mathlib.GroupTheory.DoubleCoset
 /-!
 # Hecke rings: definitions
 
-The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following Shimura, *Introduction to the
-Arithmetic Theory of Automorphic Functions*, Chapter 3. This file sets up the underlying types: the
-Hecke pair, the double-coset quotient that indexes the ring, and the Hecke ring itself as formal
+The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following [Shimura][shimura1971], Chapter 3,
+and [Krieg][krieg1990], Chapter I. This file sets up the underlying types: the Hecke pair, the
+double-coset quotient that indexes the ring, and the Hecke ring itself as formal
 finitely-supported linear combinations of double cosets. The convolution product and the ring
 structure are developed in later files.
 
+The relevance of the submonoid `Δ` may not be immediately obvious; a natural example is
+`H = GL₂(ℤ)` inside `G = GL₂(ℚ)` with `Δ` the submonoid of integral matrices with nonzero
+determinant, which is the Hecke pair underlying the classical Hecke operators `T_n`.
+
 ## Main definitions
 
-* `HeckePair G`: an arithmetic pair, a subgroup `H` together with a submonoid `Δ` of `G`
+* `HeckePair G`: a Hecke pair, a subgroup `H` together with a submonoid `Δ` of `G`
   satisfying `H ≤ Δ ≤ commensurator H`.
 * `HeckeCoset P`: the quotient of `Δ` by the relation `HgH = HhH`, i.e. the double cosets
-  forming the basis of the Hecke ring.
+  `H\Δ/H` forming the basis of the Hecke ring.
 * `HeckeRing P Z`, notation `𝕋 P Z`: the Hecke ring with coefficients in `Z`, the
   finitely-supported `Z`-linear combinations of double cosets.
+
+## Implementation notes
+
+`HeckePair` is a bundled structure rather than an unbundled pair with an `IsHeckePair` Prop
+class: the types `HeckeCoset P` and `𝕋 P Z` depend on the pair, and types depending on instance
+arguments are brittle. Requiring `Δ` to be a submonoid rather than a subsemigroup loses no
+generality, since `H ≤ Δ` already forces `1 ∈ Δ`.
+
+The combinatorial layer behind the Hecke product (Shimura's multiplicity) is developed for
+mixed double cosets `Γ₁gΓ₂` of arbitrary subgroups in later files; only the ring structure
+itself is specific to a Hecke pair.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971]
+* [A. Krieg, *Hecke algebras*][krieg1990]
 -/
 
 @[expose] public section
@@ -34,7 +54,7 @@ open Subgroup.Commensurable
 
 variable {G : Type*} [Group G]
 
-/-- An arithmetic pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
+/-- A Hecke pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
 `H ≤ Δ ≤ commensurator H`. -/
 @[ext]
 structure HeckePair (G : Type*) [Group G] where
@@ -43,9 +63,9 @@ structure HeckePair (G : Type*) [Group G] where
   /-- The submonoid `Δ` of elements commensurating `H`. -/
   Δ : Submonoid G
   /-- The subgroup `H` is contained in `Δ`. -/
-  h₀ : H.toSubmonoid ≤ Δ
+  subgroup_le : H.toSubmonoid ≤ Δ
   /-- The submonoid `Δ` lies in the commensurator of `H`. -/
-  h₁ : Δ ≤ (commensurator H).toSubmonoid
+  le_commensurator : Δ ≤ (commensurator H).toSubmonoid
 
 /-- The setoid on `Δ` identifying elements with the same double coset `HgH = HhH`, pulled back
 from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
@@ -53,41 +73,50 @@ from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
 This is a `def` rather than a global instance to avoid a `Setoid` diamond on `↥Δ` (the left-coset
 setoid is another). Files that form `HeckeCoset`s opt in with `attribute [local instance]`; it is
 marked `@[reducible]` so that opt-in is warning-free. -/
-@[reducible] def doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
+@[reducible] def HeckePair.doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
   (DoubleCoset.setoid (P.H : Set G) P.H).comap Subtype.val
 
-/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the basis
-type for the Hecke ring. -/
-def HeckeCoset (P : HeckePair G) := Quotient (doubleCosetSetoid P)
+/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the
+basis type for the Hecke ring. -/
+def HeckeCoset (P : HeckePair G) := Quotient P.doubleCosetSetoid
 
-noncomputable instance (P : HeckePair G) : DecidableEq (HeckeCoset P) :=
-  Classical.decEq _
+namespace HeckeCoset
+
+variable (P : HeckePair G)
+
+/-- The identity double coset `H1H = H`. -/
+instance : One (HeckeCoset P) := ⟨Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩⟩
+
+instance : Inhabited (HeckeCoset P) := ⟨1⟩
+
+lemma one_def : (1 : HeckeCoset P) = Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩ := rfl
+
+end HeckeCoset
 
 /-- The Hecke ring with coefficients in `Z`, denoted `𝕋 P Z`: the finitely-supported `Z`-linear
 combinations of double cosets. The coefficients `Z` need only carry a `Zero` for the type to make
 sense; algebraic structure is added by the instances below at the weakest level each requires. -/
-def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := Finsupp (HeckeCoset P) Z
+def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := HeckeCoset P →₀ Z
 
 namespace HeckeRing
 
 @[inherit_doc]
 scoped notation "𝕋" => HeckeRing
 
+variable (P : HeckePair G) (Z : Type*)
+
 /-- Elements of `𝕋 P Z` are functions `HeckeCoset P → Z` (finitely supported). -/
-instance (P : HeckePair G) (Z : Type*) [Zero Z] :
-    FunLike (𝕋 P Z) (HeckeCoset P) Z :=
+instance [Zero Z] : FunLike (𝕋 P Z) (HeckeCoset P) Z :=
   inferInstanceAs (FunLike (HeckeCoset P →₀ Z) (HeckeCoset P) Z)
 
-/-- The additive commutative monoid structure on the Hecke ring, for any `AddCommMonoid` of
-coefficients. -/
-noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommMonoid Z] :
-    AddCommMonoid (𝕋 P Z) :=
-  inferInstanceAs (AddCommMonoid ((HeckeCoset P) →₀ Z))
+noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 P Z) :=
+  inferInstanceAs (AddCommMonoid (HeckeCoset P →₀ Z))
 
-/-- The additive commutative group structure on the Hecke ring, when the coefficients form an
-`AddCommGroup`. -/
-noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommGroup Z] :
-    AddCommGroup (𝕋 P Z) :=
-  inferInstanceAs (AddCommGroup ((HeckeCoset P) →₀ Z))
+noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 P Z) :=
+  inferInstanceAs (AddCommGroup (HeckeCoset P →₀ Z))
+
+@[ext]
+lemma ext {P : HeckePair G} {Z : Type*} [Zero Z] {f g : 𝕋 P Z} (h : ∀ D, f D = g D) : f = g :=
+  Finsupp.ext h
 
 end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -59,6 +59,7 @@ subsemigroup loses no generality, since `H₁ ≤ Δ` already forces `1 ∈ Δ`.
 @[expose] public section
 
 open Subgroup Subgroup.Commensurable
+open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
@@ -101,6 +102,32 @@ theorem le_commensurator_left [IsHeckeCosetModule Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
   rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
   exact le_commensurator H₁
+
+/-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
+explicit, since it cannot be inferred. -/
+theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    (g : G) ∈ commensurator H₂ :=
+  le_commensurator H₁ g.2
+
+/-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
+explicit, since it cannot be inferred. -/
+theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    (g : G) ∈ commensurator H₁ :=
+  le_commensurator_left (H₂ := H₂) g.2
+
+/-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
+the left one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₁ H₂`. -/
+theorem commensurable_conjAct_right [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
+  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
+  exact hg.trans (commensurable (Δ := Δ)).symm
+
+/-- Conjugating the left subgroup by an element of `Δ` gives a subgroup commensurable with
+the right one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₂ H₁`. -/
+theorem commensurable_conjAct_left [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    Commensurable (ConjAct.toConjAct (g : G) • H₁) H₂ := by
+  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₁) H₁ := mem_commensurator_left H₂ g
+  exact hg.trans (commensurable (Δ := Δ))
 
 /-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
 theorem symm [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₁ :=

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -12,35 +12,43 @@ public import Mathlib.GroupTheory.DoubleCoset
 /-!
 # Hecke rings: definitions
 
-The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following [Shimura][shimura1971], Chapter 3,
-and [Krieg][krieg1990], Chapter I. This file sets up the underlying types: the Hecke pair, the
-double-coset quotient that indexes the ring, and the Hecke ring itself as formal
-finitely-supported linear combinations of double cosets. The convolution product and the ring
-structure are developed in later files.
+The abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the Hecke coset modules
+attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971], Chapter 3, and
+[Krieg][krieg1990], Chapter I. This file sets up the underlying types: the compatibility
+conditions `IsHeckeCosetModule Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
+double-coset quotient `HeckeCoset Δ H₁ H₂` of `Δ` by `H₁gH₂ = H₁hH₂`, and the Hecke coset module
+`𝕋 Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets. The convolution
+product `𝕋 Δ H₁ H₂ Z × 𝕋 Δ H₂ H₃ Z → 𝕋 Δ H₁ H₃ Z` and the ring structure on the diagonal
+`𝕋 Δ H H Z` are developed in later files.
 
 The relevance of the submonoid `Δ` may not be immediately obvious; a natural example is
 `H = GL₂(ℤ)` inside `G = GL₂(ℚ)` with `Δ` the submonoid of integral matrices with nonzero
-determinant, which is the Hecke pair underlying the classical Hecke operators `T_n`.
+determinant, which is the Hecke pair underlying the classical Hecke operators `T_n`. Mixed
+subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.g. `H₁ = Γ₀(N)` and
+`H₂ = Γ₀(M)` inside the same `Δ`.
 
 ## Main definitions
 
-* `HeckePair G`: a Hecke pair, a subgroup `H` together with a submonoid `Δ` of `G`
-  satisfying `H ≤ Δ ≤ commensurator H`.
-* `HeckeCoset P`: the quotient of `Δ` by the relation `HgH = HhH`, i.e. the double cosets
-  `H\Δ/H` forming the basis of the Hecke ring.
-* `HeckeRing P Z`, notation `𝕋 P Z`: the Hecke ring with coefficients in `Z`, the
-  finitely-supported `Z`-linear combinations of double cosets.
+* `IsHeckeCosetModule Δ H₁ H₂`: the compatibility conditions `H₁ ≤ Δ`, `H₂ ≤ Δ`,
+  `Commensurable H₁ H₂` and `Δ ≤ commensurator H₂` making the double cosets `H₁\Δ/H₂` finite
+  unions of left cosets. The classical Hecke pair `(H, Δ)` is the diagonal case
+  `IsHeckeCosetModule Δ H H`.
+* `HeckeCoset Δ H₁ H₂`: the quotient of `Δ` by the relation `H₁gH₂ = H₁hH₂`, i.e. the double
+  cosets `H₁\Δ/H₂` forming the basis of the Hecke coset module.
+* `HeckeCosetModule Δ H₁ H₂ Z`, notation `𝕋 Δ H₁ H₂ Z`: the Hecke coset module with
+  coefficients in `Z`, the finitely-supported `Z`-linear combinations of double cosets. For
+  `H₁ = H₂` this is the underlying module of the Hecke ring.
 
 ## Implementation notes
 
-`HeckePair` is a bundled structure rather than an unbundled pair with an `IsHeckePair` Prop
-class: the types `HeckeCoset P` and `𝕋 P Z` depend on the pair, and types depending on instance
-arguments are brittle. Requiring `Δ` to be a submonoid rather than a subsemigroup loses no
-generality, since `H ≤ Δ` already forces `1 ∈ Δ`.
-
-The combinatorial layer behind the Hecke product (Shimura's multiplicity) is developed for
-mixed double cosets `Γ₁gΓ₂` of arbitrary subgroups in later files; only the ring structure
-itself is specific to a Hecke pair.
+The data `(Δ, H₁, H₂)` enters unbundled, with the compatibility conditions collected in the
+Prop-valued class `IsHeckeCosetModule`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
+built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all levels
+(as in [Shimura][shimura1971]) means products of double cosets over different subgroups,
+`H₁g₁H₂ * H₂g₂H₃ ⊆ Δ`, need no compatibility hypotheses. The conditions are only needed for the
+finiteness of the coset decompositions, which enters through the `Fintype` instance on
+`DoubleCoset.DecompQuotient` in later files. Requiring `Δ` to be a submonoid rather than a
+subsemigroup loses no generality, since `H₁ ≤ Δ` already forces `1 ∈ Δ`.
 
 ## References
 
@@ -50,73 +58,135 @@ itself is specific to a Hecke pair.
 
 @[expose] public section
 
-open Subgroup.Commensurable
+open Subgroup Subgroup.Commensurable
 
 variable {G : Type*} [Group G]
 
-/-- A Hecke pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
-`H ≤ Δ ≤ commensurator H`. -/
-@[ext]
-structure HeckePair (G : Type*) [Group G] where
-  /-- The subgroup `H` of the pair. -/
-  H : Subgroup G
-  /-- The submonoid `Δ` of elements commensurating `H`. -/
-  Δ : Submonoid G
-  /-- The subgroup `H` is contained in `Δ`. -/
-  subgroup_le : H.toSubmonoid ≤ Δ
-  /-- The submonoid `Δ` lies in the commensurator of `H`. -/
-  le_commensurator : Δ ≤ (commensurator H).toSubmonoid
+/-- The compatibility conditions on a submonoid `Δ` and a pair of subgroups `H₁, H₂` of `G`
+making the double cosets `H₁\Δ/H₂` finite unions of left cosets: both subgroups are contained
+in `Δ`, they are commensurable, and `Δ` commensurates them. The classical Hecke pair `(H, Δ)`
+of [Shimura][shimura1971], Chapter 3, is the diagonal case `IsHeckeCosetModule Δ H H`. -/
+class IsHeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
+  /-- The left subgroup is contained in `Δ`. -/
+  left_le : H₁.toSubmonoid ≤ Δ
+  /-- The right subgroup is contained in `Δ`. -/
+  right_le : H₂.toSubmonoid ≤ Δ
+  /-- The two subgroups are commensurable. -/
+  commensurable : Commensurable H₁ H₂
+  /-- The submonoid `Δ` lies in the commensurator of the right subgroup (hence, the subgroups
+  being commensurable, also in that of the left one; see `le_commensurator_left`). -/
+  le_commensurator : Δ ≤ (commensurator H₂).toSubmonoid
 
-/-- The setoid on `Δ` identifying elements with the same double coset `HgH = HhH`, pulled back
-from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
+namespace IsHeckeCosetModule
 
-This is a `def` rather than a global instance to avoid a `Setoid` diamond on `↥Δ` (the left-coset
-setoid is another). Files that form `HeckeCoset`s opt in with `attribute [local instance]`; it is
-marked `@[reducible]` so that opt-in is warning-free. -/
-@[reducible] def HeckePair.doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
-  (DoubleCoset.setoid (P.H : Set G) P.H).comap Subtype.val
+variable {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 
-/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the
-basis type for the Hecke ring. -/
-def HeckeCoset (P : HeckePair G) := Quotient P.doubleCosetSetoid
+/-- A Hecke pair `(H, Δ)` with `H ≤ Δ ≤ commensurator H` is the diagonal case. -/
+theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
+    (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeCosetModule Δ H H :=
+  ⟨h, h, .refl H, hc⟩
+
+/-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
+be inferred. -/
+theorem mem_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
+  left_le (H₂ := H₂) hx
+
+/-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
+be inferred. -/
+theorem mem_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
+  right_le (H₁ := H₁) hx
+
+/-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
+theorem le_commensurator_left [IsHeckeCosetModule Δ H₁ H₂] :
+    Δ ≤ (commensurator H₁).toSubmonoid := by
+  rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
+  exact le_commensurator H₁
+
+/-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
+theorem symm [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₁ :=
+  ⟨right_le (H₁ := H₁), left_le (H₂ := H₂), (commensurable (Δ := Δ)).symm,
+    le_commensurator_left (H₂ := H₂)⟩
+
+/-- Hecke coset module data compose. Not an instance, since the middle subgroup cannot be
+inferred from the goal. -/
+theorem trans [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃] :
+    IsHeckeCosetModule Δ H₁ H₃ :=
+  ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
+    (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
+      (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
+    le_commensurator (H₁ := H₂)⟩
+
+/-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
+theorem diag_left [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₁ H₁ :=
+  ⟨left_le (H₂ := H₂), left_le (H₂ := H₂), .refl H₁, le_commensurator_left (H₂ := H₂)⟩
+
+/-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
+theorem diag_right [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₂ :=
+  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator (H₁ := H₁)⟩
+
+end IsHeckeCosetModule
+
+/-- The setoid on `Δ` identifying elements with the same double coset `H₁gH₂ = H₁hH₂`, pulled
+back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
+
+This is a `def` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred from
+the type `↥Δ`, so this cannot participate in instance search (and a global instance would also
+create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
+`HeckeCoset.mk`. -/
+@[reducible] def HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
+  (DoubleCoset.setoid (H₁ : Set G) H₂).comap Subtype.val
+
+/-- A Hecke double coset: an equivalence class of `Δ`-elements under `H₁gH₂ = H₁hH₂`. This is
+the basis type for the Hecke coset module. -/
+def HeckeCoset (Δ : Submonoid G) (H₁ H₂ : Subgroup G) := Quotient (HeckeCoset.setoid Δ H₁ H₂)
 
 namespace HeckeCoset
 
-variable (P : HeckePair G)
+variable {Δ : Submonoid G}
 
-/-- The identity double coset `H1H = H`. -/
-instance : One (HeckeCoset P) := ⟨Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩⟩
+/-- The double coset `H₁gH₂` of an element `g : Δ`. -/
+def mk (H₁ H₂ : Subgroup G) (g : Δ) : HeckeCoset Δ H₁ H₂ :=
+  Quotient.mk (setoid Δ H₁ H₂) g
 
-instance : Inhabited (HeckeCoset P) := ⟨1⟩
+variable (Δ) in
+instance (H₁ H₂ : Subgroup G) : Inhabited (HeckeCoset Δ H₁ H₂) := ⟨mk H₁ H₂ ⟨1, Δ.one_mem⟩⟩
 
-lemma one_def : (1 : HeckeCoset P) = Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩ := rfl
+variable (Δ) in
+/-- The identity double coset `H1H = H` of the diagonal (Hecke pair) case. -/
+instance (H : Subgroup G) : One (HeckeCoset Δ H H) := ⟨mk H H ⟨1, Δ.one_mem⟩⟩
+
+lemma one_def (H : Subgroup G) : (1 : HeckeCoset Δ H H) = mk H H ⟨1, Δ.one_mem⟩ := rfl
 
 end HeckeCoset
 
-/-- The Hecke ring with coefficients in `Z`, denoted `𝕋 P Z`: the finitely-supported `Z`-linear
-combinations of double cosets. The coefficients `Z` need only carry a `Zero` for the type to make
-sense; algebraic structure is added by the instances below at the weakest level each requires. -/
-def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := HeckeCoset P →₀ Z
+/-- The Hecke coset module with coefficients in `Z`, denoted `𝕋 Δ H₁ H₂ Z`: the
+finitely-supported `Z`-linear combinations of double cosets `H₁\Δ/H₂`. For `H₁ = H₂` this is the
+underlying module of the Hecke ring. The coefficients `Z` need only carry a `Zero` for the type
+to make sense; algebraic structure is added by the instances below at the weakest level each
+requires. -/
+def HeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*) [Zero Z] :=
+  HeckeCoset Δ H₁ H₂ →₀ Z
 
-namespace HeckeRing
+namespace HeckeCosetModule
 
 @[inherit_doc]
-scoped notation "𝕋" => HeckeRing
+scoped notation "𝕋" => HeckeCosetModule
 
-variable (P : HeckePair G) (Z : Type*)
+variable (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*)
 
-/-- Elements of `𝕋 P Z` are functions `HeckeCoset P → Z` (finitely supported). -/
-instance [Zero Z] : FunLike (𝕋 P Z) (HeckeCoset P) Z :=
-  inferInstanceAs (FunLike (HeckeCoset P →₀ Z) (HeckeCoset P) Z)
+/-- Elements of `𝕋 Δ H₁ H₂ Z` are functions `HeckeCoset Δ H₁ H₂ → Z` (finitely supported). -/
+instance [Zero Z] : FunLike (𝕋 Δ H₁ H₂ Z) (HeckeCoset Δ H₁ H₂) Z :=
+  inferInstanceAs (FunLike (HeckeCoset Δ H₁ H₂ →₀ Z) (HeckeCoset Δ H₁ H₂) Z)
 
-noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 P Z) :=
-  inferInstanceAs (AddCommMonoid (HeckeCoset P →₀ Z))
+noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 Δ H₁ H₂ Z) :=
+  inferInstanceAs (AddCommMonoid (HeckeCoset Δ H₁ H₂ →₀ Z))
 
-noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 P Z) :=
-  inferInstanceAs (AddCommGroup (HeckeCoset P →₀ Z))
+noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 Δ H₁ H₂ Z) :=
+  inferInstanceAs (AddCommGroup (HeckeCoset Δ H₁ H₂ →₀ Z))
 
 @[ext]
-lemma ext {P : HeckePair G} {Z : Type*} [Zero Z] {f g : 𝕋 P Z} (h : ∀ D, f D = g D) : f = g :=
+lemma ext {Δ : Submonoid G} {H₁ H₂ : Subgroup G} {Z : Type*} [Zero Z] {f g : 𝕋 Δ H₁ H₂ Z}
+    (h : ∀ D, f D = g D) : f = g :=
   Finsupp.ext h
 
-end HeckeRing
+end HeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -15,7 +15,7 @@ public import Mathlib.GroupTheory.DoubleCoset
 The abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the Hecke coset modules
 attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971], Chapter 3, and
 [Krieg][krieg1990], Chapter I. This file sets up the underlying types: the compatibility
-conditions `IsHeckeCosetModule Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
+conditions `IsHeckeTriple Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
 double-coset quotient `HeckeCoset Δ H₁ H₂` of `Δ` by `H₁gH₂ = H₁hH₂`, and the Hecke coset module
 `𝕋 Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets. The convolution
 product `𝕋 Δ H₁ H₂ Z × 𝕋 Δ H₂ H₃ Z → 𝕋 Δ H₁ H₃ Z` and the ring structure on the diagonal
@@ -29,10 +29,10 @@ subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.
 
 ## Main definitions
 
-* `IsHeckeCosetModule Δ H₁ H₂`: the compatibility conditions `H₁ ≤ Δ`, `H₂ ≤ Δ`,
-  `Commensurable H₁ H₂` and `Δ ≤ commensurator H₂` making the double cosets `H₁\Δ/H₂` finite
+* `IsHeckeTriple Δ H₁ H₂`: `(H₁, Δ, H₂)` is a Hecke triple, i.e. `H₁ ≤ Δ`, `H₂ ≤ Δ`,
+  `Commensurable H₁ H₂` and `Δ ≤ commensurator H₂`, making the double cosets `H₁\Δ/H₂` finite
   unions of left cosets. The classical Hecke pair `(H, Δ)` is the diagonal case
-  `IsHeckeCosetModule Δ H H`.
+  `IsHeckeTriple Δ H H`.
 * `HeckeCoset Δ H₁ H₂`: the quotient of `Δ` by the relation `H₁gH₂ = H₁hH₂`, i.e. the double
   cosets `H₁\Δ/H₂` forming the basis of the Hecke coset module.
 * `HeckeCosetModule Δ H₁ H₂ Z`, notation `𝕋 Δ H₁ H₂ Z`: the Hecke coset module with
@@ -42,7 +42,7 @@ subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.
 ## Implementation notes
 
 The data `(Δ, H₁, H₂)` enters unbundled, with the compatibility conditions collected in the
-Prop-valued class `IsHeckeCosetModule`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
+Prop-valued class `IsHeckeTriple`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
 built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all levels
 (as in [Shimura][shimura1971]) means products of double cosets over different subgroups,
 `H₁g₁H₂ * H₂g₂H₃ ⊆ Δ`, need no compatibility hypotheses. The conditions are only needed for the
@@ -63,11 +63,12 @@ open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
-/-- The compatibility conditions on a submonoid `Δ` and a pair of subgroups `H₁, H₂` of `G`
-making the double cosets `H₁\Δ/H₂` finite unions of left cosets: both subgroups are contained
-in `Δ`, they are commensurable, and `Δ` commensurates them. The classical Hecke pair `(H, Δ)`
-of [Shimura][shimura1971], Chapter 3, is the diagonal case `IsHeckeCosetModule Δ H H`. -/
-class IsHeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
+/-- A *Hecke triple* `(H₁, Δ, H₂)`: the compatibility conditions on a submonoid `Δ` and a pair
+of subgroups `H₁, H₂` of `G` making the double cosets `H₁\Δ/H₂` finite unions of left cosets:
+both subgroups are contained in `Δ`, they are commensurable, and `Δ` commensurates them. The
+classical Hecke pair `(H, Δ)` of [Shimura][shimura1971], Chapter 3, is the diagonal case
+`IsHeckeTriple Δ H H`. -/
+class IsHeckeTriple (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
   /-- The left subgroup is contained in `Δ`. -/
   left_le : H₁.toSubmonoid ≤ Δ
   /-- The right subgroup is contained in `Δ`. -/
@@ -78,80 +79,80 @@ class IsHeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop wher
   being commensurable, also in that of the left one; see `le_commensurator_left`). -/
   le_commensurator : Δ ≤ (commensurator H₂).toSubmonoid
 
-namespace IsHeckeCosetModule
+namespace IsHeckeTriple
 
 variable {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 
 /-- A Hecke pair `(H, Δ)` with `H ≤ Δ ≤ commensurator H` is the diagonal case. -/
 theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
-    (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeCosetModule Δ H H :=
+    (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeTriple Δ H H :=
   ⟨h, h, .refl H, hc⟩
 
 /-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
+theorem mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
   left_le (H₂ := H₂) hx
 
 /-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
+theorem mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
   right_le (H₁ := H₁) hx
 
 /-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
-theorem le_commensurator_left [IsHeckeCosetModule Δ H₁ H₂] :
+theorem le_commensurator_left [IsHeckeTriple Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
   rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
   exact le_commensurator H₁
 
 /-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
 explicit, since it cannot be inferred. -/
-theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₂ :=
   le_commensurator H₁ g.2
 
 /-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
 explicit, since it cannot be inferred. -/
-theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₁ :=
   le_commensurator_left (H₂ := H₂) g.2
 
 /-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
 the left one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₁ H₂`. -/
-theorem commensurable_conjAct_right [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
   exact hg.trans (commensurable (Δ := Δ)).symm
 
 /-- Conjugating the left subgroup by an element of `Δ` gives a subgroup commensurable with
 the right one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₂ H₁`. -/
-theorem commensurable_conjAct_left [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem commensurable_conjAct_left [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₁) H₂ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₁) H₁ := mem_commensurator_left H₂ g
   exact hg.trans (commensurable (Δ := Δ))
 
 /-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
-theorem symm [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₁ :=
+theorem symm [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₁ :=
   ⟨right_le (H₁ := H₁), left_le (H₂ := H₂), (commensurable (Δ := Δ)).symm,
     le_commensurator_left (H₂ := H₂)⟩
 
 /-- Hecke coset module data compose. Not an instance, since the middle subgroup cannot be
 inferred from the goal. -/
-theorem trans [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃] :
-    IsHeckeCosetModule Δ H₁ H₃ :=
+theorem trans [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] :
+    IsHeckeTriple Δ H₁ H₃ :=
   ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
     (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
       (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
     le_commensurator (H₁ := H₂)⟩
 
 /-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
-theorem diag_left [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₁ H₁ :=
+theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
   ⟨left_le (H₂ := H₂), left_le (H₂ := H₂), .refl H₁, le_commensurator_left (H₂ := H₂)⟩
 
 /-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
-theorem diag_right [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₂ :=
+theorem diag_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
   ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator (H₁ := H₁)⟩
 
-end IsHeckeCosetModule
+end IsHeckeTriple
 
 /-- The setoid on `Δ` identifying elements with the same double coset `H₁gH₂ = H₁hH₂`, pulled
 back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
@@ -91,37 +91,32 @@ theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
     (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeTriple Δ H H :=
   ⟨h, h, .refl H, hc⟩
 
-/-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
-be inferred. -/
+/-- Elements of the left subgroup lie in `Δ`. -/
 theorem mem_of_mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
-  left_le (H₂ := H₂) hx
+  left_le H₂ hx
 
-/-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
-be inferred. -/
+/-- Elements of the right subgroup lie in `Δ`. -/
 theorem mem_of_mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
-  right_le (H₁ := H₁) hx
+  right_le H₁ hx
 
 /-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
-theorem le_commensurator_left [h : IsHeckeTriple Δ H₁ H₂] :
+theorem le_commensurator_left (H₂ : Subgroup G) [h : IsHeckeTriple Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
   rw [h.commensurable.eq]
   exact h.le_commensurator_right
 
-/-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
-explicit, since it cannot be inferred. -/
+/-- Elements of `Δ` lie in the commensurator of the right subgroup. -/
 theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₂ :=
   le_commensurator_right H₁ g.2
 
-/-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
-explicit, since it cannot be inferred. -/
+/-- Elements of `Δ` lie in the commensurator of the left subgroup. -/
 theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₁ :=
-  le_commensurator_left (H₂ := H₂) g.2
+  le_commensurator_left H₂ g.2
 
 /-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
-the left one; the intersection `H₁ ∩ gH₂g⁻¹` this bounds is the one underlying
-`DoubleCoset.DecompQuotient H₁ H₂ g`. -/
+the left one. -/
 theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
@@ -131,29 +126,29 @@ theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
 inferred from the goal. -/
 theorem trans [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] :
     IsHeckeTriple Δ H₁ H₃ :=
-  ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
+  ⟨left_le H₂, right_le H₂,
     (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
       (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
-    le_commensurator_right (H₁ := H₂)⟩
+    le_commensurator_right H₂⟩
 
 /-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
 theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
-  ⟨left_le (H₂ := H₂), left_le (H₂ := H₂), .refl H₁, le_commensurator_left (H₂ := H₂)⟩
+  ⟨left_le H₂, left_le H₂, .refl H₁, le_commensurator_left H₂⟩
 
 /-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
 theorem diag_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
-  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator_right (H₁ := H₁)⟩
+  ⟨right_le H₁, right_le H₁, .refl H₂, le_commensurator_right H₁⟩
 
 end IsHeckeTriple
 
 /-- The setoid on `Δ` identifying elements with the same double coset `H₁gH₂ = H₁hH₂`, pulled
 back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
 
-This is a `def` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred from
-the submonoid `Δ`, so this cannot participate in instance search (and a global instance would
-also create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
+This is an `abbrev` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred
+from the submonoid `Δ`, so this cannot participate in instance search (and a global instance
+would also create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
 `HeckeCoset.mk`. -/
-@[reducible] def HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
+abbrev HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
   (DoubleCoset.setoid (H₁ : Set G) H₂).comap Subtype.val
 
 /-- A Hecke double coset: an equivalence class of `Δ`-elements under `H₁gH₂ = H₁hH₂`. This is

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Algebra.Group.Finsupp
+public import Mathlib.GroupTheory.Commensurable
+public import Mathlib.GroupTheory.DoubleCoset
+
+/-!
+# Hecke rings: definitions
+
+The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following Shimura, *Introduction to the
+Arithmetic Theory of Automorphic Functions*, Chapter 3. This file sets up the underlying types: the
+Hecke pair, the double-coset quotient that indexes the ring, and the Hecke ring itself as formal
+finitely-supported linear combinations of double cosets. The convolution product and the ring
+structure are developed in later files.
+
+## Main definitions
+
+* `HeckePair G`: an arithmetic pair, a subgroup `H` together with a submonoid `Δ` of `G`
+  satisfying `H ≤ Δ ≤ commensurator H`.
+* `HeckeCoset P`: the quotient of `Δ` by the relation `HgH = HhH`, i.e. the double cosets
+  forming the basis of the Hecke ring.
+* `HeckeRing P Z`, notation `𝕋 P Z`: the Hecke ring with coefficients in `Z`, the
+  finitely-supported `Z`-linear combinations of double cosets.
+-/
+
+@[expose] public section
+
+open Subgroup.Commensurable
+
+variable {G : Type*} [Group G]
+
+/-- An arithmetic pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
+`H ≤ Δ ≤ commensurator H`. -/
+@[ext]
+structure HeckePair (G : Type*) [Group G] where
+  /-- The subgroup `H` of the pair. -/
+  H : Subgroup G
+  /-- The submonoid `Δ` of elements commensurating `H`. -/
+  Δ : Submonoid G
+  /-- The subgroup `H` is contained in `Δ`. -/
+  h₀ : H.toSubmonoid ≤ Δ
+  /-- The submonoid `Δ` lies in the commensurator of `H`. -/
+  h₁ : Δ ≤ (commensurator H).toSubmonoid
+
+/-- The setoid on `Δ` identifying elements with the same double coset `HgH = HhH`, pulled back
+from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
+
+This is a `def` rather than a global instance to avoid a `Setoid` diamond on `↥Δ` (the left-coset
+setoid is another). Files that form `HeckeCoset`s opt in with `attribute [local instance]`; it is
+marked `@[reducible]` so that opt-in is warning-free. -/
+@[reducible] def doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
+  (DoubleCoset.setoid (P.H : Set G) P.H).comap Subtype.val
+
+/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the basis
+type for the Hecke ring. -/
+def HeckeCoset (P : HeckePair G) := Quotient (doubleCosetSetoid P)
+
+noncomputable instance (P : HeckePair G) : DecidableEq (HeckeCoset P) :=
+  Classical.decEq _
+
+/-- The Hecke ring with coefficients in `Z`, denoted `𝕋 P Z`: the finitely-supported `Z`-linear
+combinations of double cosets. The coefficients `Z` need only carry a `Zero` for the type to make
+sense; algebraic structure is added by the instances below at the weakest level each requires. -/
+def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := Finsupp (HeckeCoset P) Z
+
+namespace HeckeRing
+
+@[inherit_doc]
+scoped notation "𝕋" => HeckeRing
+
+/-- Elements of `𝕋 P Z` are functions `HeckeCoset P → Z` (finitely supported). -/
+instance (P : HeckePair G) (Z : Type*) [Zero Z] :
+    FunLike (𝕋 P Z) (HeckeCoset P) Z :=
+  inferInstanceAs (FunLike (HeckeCoset P →₀ Z) (HeckeCoset P) Z)
+
+/-- The additive commutative monoid structure on the Hecke ring, for any `AddCommMonoid` of
+coefficients. -/
+noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommMonoid Z] :
+    AddCommMonoid (𝕋 P Z) :=
+  inferInstanceAs (AddCommMonoid ((HeckeCoset P) →₀ Z))
+
+/-- The additive commutative group structure on the Hecke ring, when the coefficients form an
+`AddCommGroup`. -/
+noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommGroup Z] :
+    AddCommGroup (𝕋 P Z) :=
+  inferInstanceAs (AddCommGroup ((HeckeCoset P) →₀ Z))
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -99,8 +99,8 @@ noncomputable def mulMap (H₁ H₂ H₃ : Subgroup G) [IsHeckeTriple Δ H₁ H�
     [IsHeckeTriple Δ H₂ H₃] (g₁ g₂ : Δ)
     (p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)) : HeckeCoset Δ H₁ H₃ :=
   mk H₁ H₃ ⟨(p.1.out : G) * g₁ * ((p.2.out : G) * g₂),
-    Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_left H₂ p.1.out.2) g₁.2)
-      (Δ.mul_mem (IsHeckeTriple.mem_left H₃ p.2.out.2) g₂.2)⟩
+    Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_of_mem_left H₂ p.1.out.2) g₁.2)
+      (Δ.mul_mem (IsHeckeTriple.mem_of_mem_left H₃ p.2.out.2) g₂.2)⟩
 
 /-- If `σᵢ g₁ τⱼ g₂ H₃ = d H₃` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`. -/
 lemma mulMap_eq_of_mk_eq {H₁ H₂ H₃ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.HeckeRing.Basic
+
+/-!
+# Hecke rings: the multiplicity function
+
+Shimura's multiplicity `heckeMultiplicity` (Proposition 3.2 of *Introduction to the Arithmetic
+Theory of Automorphic Functions*) counts, for double cosets `Hg₁H`, `Hg₂H` and `HdH`, the pairs of
+left-coset representatives `(σᵢ, τⱼ)` with `σᵢ τⱼ H = d H`. These integers are the structure
+constants of the Hecke product defined in later files. This file sets up the multiplicity, the map
+`mulMap` on pairs of representatives, and the structural lemmas on the coset decomposition.
+
+## Main definitions
+
+* `HeckeRing.mulMap`: the double coset `H(σᵢ τⱼ)H` of a pair of coset representatives.
+* `HeckeRing.heckeMultiplicity`: Shimura's multiplicity, an integer structure constant.
+* `HeckeRing.mulSupport`: the finite set of double cosets appearing in a product.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup
+open scoped Pointwise
+
+namespace HeckeRing
+
+variable {G : Type*} [Group G] (H : Subgroup G) (Δ : Submonoid G) (P : HeckePair G)
+
+attribute [local instance] doubleCosetSetoid
+
+/-- Two `HeckeCoset` elements are equal iff their `toSet`s are equal. -/
+lemma HeckeCoset_ext_toSet {D₁ D₂ : HeckeCoset P}
+    (h : HeckeCoset.toSet D₁ = HeckeCoset.toSet D₂) : D₁ = D₂ := by
+  revert h
+  refine Quotient.ind₂ (motive := fun D₁ D₂ ↦
+    HeckeCoset.toSet D₁ = HeckeCoset.toSet D₂ → D₁ = D₂)
+    (fun g₁ g₂ h ↦ ?_) D₁ D₂
+  simp only [HeckeCoset.toSet_mk] at h
+  exact Quotient.sound h
+
+/-- The stabilizer quotient for the identity double coset is trivial. -/
+lemma decompQuot_one_eq_top :
+    (ConjAct.toConjAct ((HeckeCoset.one P).rep : G) • P.H).subgroupOf P.H = ⊤ := by
+  have h := HeckeCoset.one_rep_mem_H P
+  rw [Subgroup.subgroupOf_eq_top]
+  intro x hx
+  rw [← @SetLike.mem_coe]
+  simp only [Subgroup.coe_pointwise_smul]
+  rw [conjAct_smul_coe_eq, Subgroup.singleton_mul_subgroup h,
+    Subgroup.subgroup_mul_singleton (by simp [h])]
+  exact hx
+
+/-- The decomposition quotient for `HeckeCoset.one` is nonempty. -/
+lemma one_in_decompQuot_one :
+    Nonempty (decompQuot P (HeckeCoset.one P).rep) :=
+  ⟨(1 : P.H)⟩
+
+/-- The decomposition quotient for `HeckeCoset.one` is a subsingleton. -/
+lemma subsingleton_decompQuot_one :
+    Subsingleton (decompQuot P (HeckeCoset.one P).rep) := by
+  unfold decompQuot
+  rw [decompQuot_one_eq_top]
+  exact QuotientGroup.subsingleton_quotient_top
+
+private lemma conjAct_mem_of_leftCoset_eq (d : Δ) (h h' : H)
+    (hyp : {(h : G)} * {(d : G)} * (H : Set G) =
+      {(h' : G)} * {(d : G)} * (H : Set G)) :
+    (h')⁻¹ * h ∈ (ConjAct.toConjAct (d : G) • H).subgroupOf H := by
+  have h_mem_lhs : (h : G) * (d : G) ∈ {(h : G)} * {(d : G)} * (H : Set G) := by
+    rw [Set.singleton_mul_singleton]
+    exact ⟨(h : G) * (d : G), Set.mem_singleton _, 1, H.one_mem, by simp⟩
+  rw [hyp, Set.singleton_mul_singleton] at h_mem_lhs
+  obtain ⟨_, rfl, k, hk, hkk⟩ := h_mem_lhs
+  have hkk' : ↑h' * ↑d * k = ↑h * ↑d := hkk
+  have key : (h' : G)⁻¹ * (h : G) = (d : G) * k * (d : G)⁻¹ := by
+    apply mul_right_cancel (b := (d : G))
+    rw [mul_assoc, mul_assoc, inv_mul_cancel, mul_one]
+    apply mul_left_cancel (a := (h' : G))
+    rw [mul_inv_cancel_left, ← mul_assoc]
+    exact hkk'.symm
+  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
+    ConjAct.smul_def]
+  simp only [map_inv, ConjAct.ofConjAct_toConjAct, Subgroup.coe_mul,
+    Subgroup.coe_inv]
+  rw [inv_inv, key]
+  simp only [mul_assoc, inv_mul_cancel, mul_one, inv_mul_cancel_left]
+  exact hk
+
+/-- Distinct elements of `decompQuot` give distinct left cosets. -/
+lemma decompQuot_coset_diff (g : P.Δ) (i j : decompQuot P g) (hij : i ≠ j) :
+    {((i.out : G) * (g : G))} * (P.H : Set G) ≠ {((j.out : G) * (g : G))} * (P.H : Set G) := by
+  intro h
+  simp_rw [← Set.singleton_mul_singleton] at h
+  have := conjAct_mem_of_leftCoset_eq P.H P.Δ g i.out j.out h
+  rw [← @QuotientGroup.leftRel_apply, ← @Quotient.eq''] at this
+  simp only [Quotient.out_eq'] at this
+  exact hij this.symm
+
+/-- Two left cosets that are not disjoint must be equal. -/
+lemma leftCoset_eq_of_not_disjoint (f g : G)
+    (h : ¬ Disjoint (g • (H : Set G)) (f • H)) :
+    {g} * (H : Set G) = {f} * H := by
+  simp_rw [← Set.singleton_smul] at *
+  rw [not_disjoint_iff] at h
+  obtain ⟨a, ha, ha2⟩ := h
+  simp only [smul_eq_mul, singleton_mul, image_mul_left, mem_preimage,
+    SetLike.mem_coe] at ha ha2
+  ext Y
+  simp only [singleton_mul, image_mul_left, mem_preimage, SetLike.mem_coe]
+  simp_rw [← QuotientGroup.eq] at *
+  rw [← ha] at ha2
+  rw [ha2]
+
+/-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the double coset
+of their product `H(σᵢ τⱼ)H`. -/
+noncomputable def mulMap (g₁ g₂ : P.Δ) (i : decompQuot P g₁ × decompQuot P g₂) :
+    HeckeCoset P :=
+  ⟦⟨i.1.out * g₁ * (i.2.out * g₂),
+    Submonoid.mul_mem _ (Submonoid.mul_mem _ (P.h₀ i.1.out.2) g₁.2)
+      (Submonoid.mul_mem _ (P.h₀ i.2.out.2) g₂.2)⟩⟧
+
+/-- Shimura's multiplicity (Proposition 3.2): `heckeMultiplicity g₁ g₂ d` counts pairs
+`(i, j)` such that `σᵢ τⱼ H = ξ H`. -/
+noncomputable def heckeMultiplicity (g₁ g₂ d : P.Δ) : ℤ :=
+  Nat.card {⟨i, j⟩ : decompQuot P g₁ × decompQuot P g₂ |
+    ({(i.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G)}
+
+/-- The finite set of double cosets appearing in the product `D₁ * D₂`. -/
+noncomputable def mulSupport (g₁ g₂ : P.Δ) : Finset (HeckeCoset P) :=
+  Finset.image (mulMap P g₁ g₂) ⊤
+
+/-- If `σᵢ τⱼ H = ξ H` then the double coset of `σᵢ τⱼ` equals that of `ξ`. -/
+lemma doubleCoset_eq_of_rightCoset_eq (g₁ g₂ d : P.Δ)
+    (p : decompQuot P g₁ × decompQuot P g₂)
+    (heq : ({(p.1.out : G) * (g₁ : G)} : Set G) * {(p.2.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G)) :
+    mulMap P g₁ g₂ p = (⟦d⟧ : HeckeCoset P) := by
+  unfold mulMap
+  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
+  rw [HeckeCoset.eq_iff]
+  have h_mem : (p.1.out : G) * (g₁ : G) * ((p.2.out : G) * (g₂ : G)) ∈
+      ({(d : G)} : Set G) * (P.H : Set G) := by
+    rw [← heq, Set.singleton_mul_singleton]
+    exact ⟨_, rfl, 1, P.H.one_mem, by simp⟩
+  obtain ⟨_, hd_eq, h, hh, hprod⟩ := h_mem
+  simp only [Set.mem_singleton_iff] at hd_eq
+  subst hd_eq
+  dsimp only at hprod ⊢
+  rw [← hprod]
+  exact doubleCoset_mul_right_eq_self P ⟨h, hh⟩ _
+
+/-- Left multiplication by a singleton set is cancellative. -/
+lemma set_singleton_mul_left_cancel (a : G) {S T : Set G}
+    (h : ({a} : Set G) * S = ({a} : Set G) * T) : S = T := by
+  rw [Set.singleton_mul, Set.singleton_mul] at h
+  exact Set.image_injective.mpr (mul_right_injective a) h
+
+/-- When the first-component representatives agree, the second-component
+representatives must also agree (by left-cancellation on the common prefix). -/
+lemma decompQuot_snd_eq_of_fst_eq (g₁ g₂ d : P.Δ) (i : decompQuot P g₁)
+    (j₁ j₂ : decompQuot P g₂)
+    (h₁ : ({(i.out : G) * (g₁ : G)} : Set G) * {(j₁.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G))
+    (h₂ : ({(i.out : G) * (g₁ : G)} : Set G) * {(j₂.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G)) :
+    j₁ = j₂ := by
+  by_contra hne
+  refine decompQuot_coset_diff P g₂ j₁ j₂ hne
+    (set_singleton_mul_left_cancel ((i.out : G) * (g₁ : G)) ?_)
+  have := h₁.trans h₂.symm
+  rwa [mul_assoc, mul_assoc] at this
+
+/-- When `j.out * g₂ ∈ H`, the second factor collapses and
+first-component injectivity follows from coset disjointness. -/
+lemma decompQuot_fst_eq_of_snd_mem_H (g₁ g₂ d : P.Δ) (i₁ i₂ : decompQuot P g₁)
+    (j : decompQuot P g₂) (hj : (j.out : G) * (g₂ : G) ∈ P.H)
+    (h₁ : ({(i₁.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G))
+    (h₂ : ({(i₂.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G)) :
+    i₁ = i₂ := by
+  by_contra hne
+  refine decompQuot_coset_diff P g₁ i₁ i₂ hne ?_
+  simp only [mul_assoc, Subgroup.singleton_mul_subgroup hj] at h₁ h₂
+  exact h₁.trans h₂.symm
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -14,14 +14,16 @@ Shimura's multiplicity (Proposition 3.2 of [Shimura][shimura1971]) counts, for d
 `Γ₁gΓ₂`, `Γ₂hΓ₃` and `Γ₁dΓ₃`, the pairs of left-coset representatives `(σᵢ, τⱼ)` with
 `σᵢ g τⱼ h Γ₃ = d Γ₃`. These natural numbers are the structure constants of the Hecke product
 defined in later files: the diagonal case `Γ₁ = Γ₂ = Γ₃` gives the multiplication of the Hecke
-ring, and the general case gives the composition of Hecke bimodules. This file defines the
-multiplicity, the map `mulMap` sending a pair of representatives to the double coset of their
-product, and the uniqueness lemmas for the fibres of the multiplicity.
+ring, and the general case gives the composition of Hecke coset modules between different
+levels. This file defines the multiplicity, the map `mulMap` sending a pair of representatives
+to the mixed double coset of their product, and the uniqueness lemmas for the fibres of the
+multiplicity.
 
 ## Main definitions
 
 * `DoubleCoset.multiplicity`: Shimura's multiplicity, a natural number structure constant.
-* `HeckePair.mulMap`: the double coset `H (σᵢ g₁ τⱼ g₂) H` of a pair of coset representatives.
+* `HeckeCoset.mulMap`: the double coset `H₁ (σᵢ g₁ τⱼ g₂) H₃` of a pair of coset
+  representatives.
 -/
 
 @[expose] public section
@@ -85,29 +87,29 @@ lemma fst_eq_of_mul_snd_mem {Γ₁ Γ₂ : Subgroup G} {g h d : G} {i₁ i₂ : 
 
 end DoubleCoset
 
-namespace HeckePair
+namespace HeckeCoset
 
 open DoubleCoset
 
-variable {G : Type*} [Group G] (P : HeckePair G)
+variable {G : Type*} [Group G] {Δ : Submonoid G}
 
-attribute [local instance] HeckePair.doubleCosetSetoid
+/-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the mixed double coset
+`H₁ (σᵢ g₁ τⱼ g₂) H₃` of their product. -/
+noncomputable def mulMap (H₁ H₂ H₃ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂]
+    [IsHeckeCosetModule Δ H₂ H₃] (g₁ g₂ : Δ)
+    (p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)) : HeckeCoset Δ H₁ H₃ :=
+  mk H₁ H₃ ⟨(p.1.out : G) * g₁ * ((p.2.out : G) * g₂),
+    Δ.mul_mem (Δ.mul_mem (IsHeckeCosetModule.mem_left H₂ p.1.out.2) g₁.2)
+      (Δ.mul_mem (IsHeckeCosetModule.mem_left H₃ p.2.out.2) g₂.2)⟩
 
-/-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the double coset
-of their product `H (σᵢ g₁ τⱼ g₂) H`. -/
-noncomputable def mulMap (g₁ g₂ : P.Δ)
-    (p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H (g₂ : G)) : HeckeCoset P :=
-  ⟦⟨(p.1.out : G) * g₁ * ((p.2.out : G) * g₂),
-    P.Δ.mul_mem (P.Δ.mul_mem (P.subgroup_le p.1.out.2) g₁.2)
-      (P.Δ.mul_mem (P.subgroup_le p.2.out.2) g₂.2)⟩⟧
-
-/-- If `σᵢ g₁ τⱼ g₂ H = d H` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`. -/
-lemma mulMap_eq_of_mk_eq {g₁ g₂ d : P.Δ}
-    {p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H (g₂ : G)}
-    (h : ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ P.H) = ((d : G) : G ⧸ P.H)) :
-    P.mulMap g₁ g₂ p = (⟦d⟧ : HeckeCoset P) := by
+/-- If `σᵢ g₁ τⱼ g₂ H₃ = d H₃` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`. -/
+lemma mulMap_eq_of_mk_eq {H₁ H₂ H₃ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
+    [IsHeckeCosetModule Δ H₂ H₃] {g₁ g₂ d : Δ}
+    {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)}
+    (h : ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ H₃) = ((d : G) : G ⧸ H₃)) :
+    mulMap H₁ H₂ H₃ g₁ g₂ p = mk H₁ H₃ d := by
   rw [QuotientGroup.eq] at h
   exact HeckeCoset.mk_eq_mk_of_mem (DoubleCoset.mem_doubleCoset.mpr
-    ⟨1, P.H.one_mem, _, P.H.inv_mem h, by rw [one_mul, mul_inv_rev, inv_inv, mul_inv_cancel_left]⟩)
+    ⟨1, H₁.one_mem, _, H₃.inv_mem h, by rw [one_mul, mul_inv_rev, inv_inv, mul_inv_cancel_left]⟩)
 
-end HeckePair
+end HeckeCoset

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -95,16 +95,16 @@ variable {G : Type*} [Group G] {Δ : Submonoid G}
 
 /-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the mixed double coset
 `H₁ (σᵢ g₁ τⱼ g₂) H₃` of their product. -/
-noncomputable def mulMap (H₁ H₂ H₃ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂]
-    [IsHeckeCosetModule Δ H₂ H₃] (g₁ g₂ : Δ)
+noncomputable def mulMap (H₁ H₂ H₃ : Subgroup G) [IsHeckeTriple Δ H₁ H₂]
+    [IsHeckeTriple Δ H₂ H₃] (g₁ g₂ : Δ)
     (p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)) : HeckeCoset Δ H₁ H₃ :=
   mk H₁ H₃ ⟨(p.1.out : G) * g₁ * ((p.2.out : G) * g₂),
-    Δ.mul_mem (Δ.mul_mem (IsHeckeCosetModule.mem_left H₂ p.1.out.2) g₁.2)
-      (Δ.mul_mem (IsHeckeCosetModule.mem_left H₃ p.2.out.2) g₂.2)⟩
+    Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_left H₂ p.1.out.2) g₁.2)
+      (Δ.mul_mem (IsHeckeTriple.mem_left H₃ p.2.out.2) g₂.2)⟩
 
 /-- If `σᵢ g₁ τⱼ g₂ H₃ = d H₃` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`. -/
-lemma mulMap_eq_of_mk_eq {H₁ H₂ H₃ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
-    [IsHeckeCosetModule Δ H₂ H₃] {g₁ g₂ d : Δ}
+lemma mulMap_eq_of_mk_eq {H₁ H₂ H₃ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]
+    [IsHeckeTriple Δ H₂ H₃] {g₁ g₂ d : Δ}
     {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)}
     (h : ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ H₃) = ((d : G) : G ⧸ H₃)) :
     mulMap H₁ H₂ H₃ g₁ g₂ p = mk H₁ H₃ d := by

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -10,185 +10,104 @@ public import Mathlib.NumberTheory.HeckeRing.Basic
 /-!
 # Hecke rings: the multiplicity function
 
-Shimura's multiplicity `heckeMultiplicity` (Proposition 3.2 of *Introduction to the Arithmetic
-Theory of Automorphic Functions*) counts, for double cosets `Hg₁H`, `Hg₂H` and `HdH`, the pairs of
-left-coset representatives `(σᵢ, τⱼ)` with `σᵢ τⱼ H = d H`. These integers are the structure
-constants of the Hecke product defined in later files. This file sets up the multiplicity, the map
-`mulMap` on pairs of representatives, and the structural lemmas on the coset decomposition.
+Shimura's multiplicity (Proposition 3.2 of [Shimura][shimura1971]) counts, for double cosets
+`Γ₁gΓ₂`, `Γ₂hΓ₃` and `Γ₁dΓ₃`, the pairs of left-coset representatives `(σᵢ, τⱼ)` with
+`σᵢ g τⱼ h Γ₃ = d Γ₃`. These natural numbers are the structure constants of the Hecke product
+defined in later files: the diagonal case `Γ₁ = Γ₂ = Γ₃` gives the multiplication of the Hecke
+ring, and the general case gives the composition of Hecke bimodules. This file defines the
+multiplicity, the map `mulMap` sending a pair of representatives to the double coset of their
+product, and the uniqueness lemmas for the fibres of the multiplicity.
 
 ## Main definitions
 
-* `HeckeRing.mulMap`: the double coset `H(σᵢ τⱼ)H` of a pair of coset representatives.
-* `HeckeRing.heckeMultiplicity`: Shimura's multiplicity, an integer structure constant.
-* `HeckeRing.mulSupport`: the finite set of double cosets appearing in a product.
+* `DoubleCoset.multiplicity`: Shimura's multiplicity, a natural number structure constant.
+* `HeckePair.mulMap`: the double coset `H (σᵢ g₁ τⱼ g₂) H` of a pair of coset representatives.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup
+open Subgroup
 open scoped Pointwise
 
-namespace HeckeRing
+namespace DoubleCoset
 
-variable {G : Type*} [Group G] (H : Subgroup G) (Δ : Submonoid G) (P : HeckePair G)
+variable {G : Type*} [Group G]
 
-attribute [local instance] doubleCosetSetoid
-
-/-- Two `HeckeCoset` elements are equal iff their `toSet`s are equal. -/
-lemma HeckeCoset_ext_toSet {D₁ D₂ : HeckeCoset P}
-    (h : HeckeCoset.toSet D₁ = HeckeCoset.toSet D₂) : D₁ = D₂ := by
-  revert h
-  refine Quotient.ind₂ (motive := fun D₁ D₂ ↦
-    HeckeCoset.toSet D₁ = HeckeCoset.toSet D₂ → D₁ = D₂)
-    (fun g₁ g₂ h ↦ ?_) D₁ D₂
-  simp only [HeckeCoset.toSet_mk] at h
-  exact Quotient.sound h
-
-/-- The stabilizer quotient for the identity double coset is trivial. -/
-lemma decompQuot_one_eq_top :
-    (ConjAct.toConjAct ((HeckeCoset.one P).rep : G) • P.H).subgroupOf P.H = ⊤ := by
-  have h := HeckeCoset.one_rep_mem_H P
-  rw [Subgroup.subgroupOf_eq_top]
-  intro x hx
-  rw [← @SetLike.mem_coe]
-  simp only [Subgroup.coe_pointwise_smul]
-  rw [conjAct_smul_coe_eq, Subgroup.singleton_mul_subgroup h,
-    Subgroup.subgroup_mul_singleton (by simp [h])]
-  exact hx
-
-/-- The decomposition quotient for `HeckeCoset.one` is nonempty. -/
-lemma one_in_decompQuot_one :
-    Nonempty (decompQuot P (HeckeCoset.one P).rep) :=
-  ⟨(1 : P.H)⟩
-
-/-- The decomposition quotient for `HeckeCoset.one` is a subsingleton. -/
-lemma subsingleton_decompQuot_one :
-    Subsingleton (decompQuot P (HeckeCoset.one P).rep) := by
-  unfold decompQuot
-  rw [decompQuot_one_eq_top]
+lemma subsingleton_decompQuotient {Γ₁ Γ₂ : Subgroup G} {g : G}
+    (h : Γ₁ ≤ ConjAct.toConjAct g • Γ₂) : Subsingleton (DecompQuotient Γ₁ Γ₂ g) := by
+  change Subsingleton (Γ₁ ⧸ (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁)
+  rw [Subgroup.subgroupOf_eq_top.mpr h]
   exact QuotientGroup.subsingleton_quotient_top
 
-private lemma conjAct_mem_of_leftCoset_eq (d : Δ) (h h' : H)
-    (hyp : {(h : G)} * {(d : G)} * (H : Set G) =
-      {(h' : G)} * {(d : G)} * (H : Set G)) :
-    (h')⁻¹ * h ∈ (ConjAct.toConjAct (d : G) • H).subgroupOf H := by
-  have h_mem_lhs : (h : G) * (d : G) ∈ {(h : G)} * {(d : G)} * (H : Set G) := by
-    rw [Set.singleton_mul_singleton]
-    exact ⟨(h : G) * (d : G), Set.mem_singleton _, 1, H.one_mem, by simp⟩
-  rw [hyp, Set.singleton_mul_singleton] at h_mem_lhs
-  obtain ⟨_, rfl, k, hk, hkk⟩ := h_mem_lhs
-  have hkk' : ↑h' * ↑d * k = ↑h * ↑d := hkk
-  have key : (h' : G)⁻¹ * (h : G) = (d : G) * k * (d : G)⁻¹ := by
-    apply mul_right_cancel (b := (d : G))
-    rw [mul_assoc, mul_assoc, inv_mul_cancel, mul_one]
-    apply mul_left_cancel (a := (h' : G))
-    rw [mul_inv_cancel_left, ← mul_assoc]
-    exact hkk'.symm
-  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
-    ConjAct.smul_def]
-  simp only [map_inv, ConjAct.ofConjAct_toConjAct, Subgroup.coe_mul,
-    Subgroup.coe_inv]
-  rw [inv_inv, key]
-  simp only [mul_assoc, inv_mul_cancel, mul_one, inv_mul_cancel_left]
-  exact hk
+lemma subsingleton_decompQuotient_of_mem {Γ : Subgroup G} {g : G} (hg : g ∈ Γ) :
+    Subsingleton (DecompQuotient Γ Γ g) :=
+  subsingleton_decompQuotient
+    (Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hg)).ge
 
-/-- Distinct elements of `decompQuot` give distinct left cosets. -/
-lemma decompQuot_coset_diff (g : P.Δ) (i j : decompQuot P g) (hij : i ≠ j) :
-    {((i.out : G) * (g : G))} * (P.H : Set G) ≠ {((j.out : G) * (g : G))} * (P.H : Set G) := by
-  intro h
-  simp_rw [← Set.singleton_mul_singleton] at h
-  have := conjAct_mem_of_leftCoset_eq P.H P.Δ g i.out j.out h
-  rw [← @QuotientGroup.leftRel_apply, ← @Quotient.eq''] at this
-  simp only [Quotient.out_eq'] at this
-  exact hij this.symm
+/-- The left cosets `σᵢ g Γ₂` of the decomposition of `Γ₁gΓ₂` are pairwise distinct: the map
+`i ↦ σᵢ g Γ₂` into `G ⧸ Γ₂` is injective. -/
+lemma mk_out_mul_injective (Γ₁ Γ₂ : Subgroup G) (g : G) :
+    Function.Injective fun i : DecompQuotient Γ₁ Γ₂ g ↦ (((i.out : G) * g : G) : G ⧸ Γ₂) := by
+  intro i j hij
+  simp only [QuotientGroup.eq] at hij
+  rw [← QuotientGroup.out_eq' i, ← QuotientGroup.out_eq' j, QuotientGroup.eq,
+    Subgroup.mem_subgroupOf, Subgroup.mem_conjAct_pointwise_smul_iff]
+  simpa [mul_assoc] using hij
 
-/-- Two left cosets that are not disjoint must be equal. -/
-lemma leftCoset_eq_of_not_disjoint (f g : G)
-    (h : ¬ Disjoint (g • (H : Set G)) (f • H)) :
-    {g} * (H : Set G) = {f} * H := by
-  simp_rw [← Set.singleton_smul] at *
-  rw [not_disjoint_iff] at h
-  obtain ⟨a, ha, ha2⟩ := h
-  simp only [smul_eq_mul, singleton_mul, image_mul_left, mem_preimage,
-    SetLike.mem_coe] at ha ha2
-  ext Y
-  simp only [singleton_mul, image_mul_left, mem_preimage, SetLike.mem_coe]
-  simp_rw [← QuotientGroup.eq] at *
-  rw [← ha] at ha2
-  rw [ha2]
+/-- Shimura's multiplicity (Proposition 3.2 of [Shimura][shimura1971]): the number of pairs
+`(i, j)` of coset representatives such that `σᵢ g τⱼ h Γ₃ = d Γ₃`. The diagonal case
+`Γ₁ = Γ₂ = Γ₃` gives the structure constants of the Hecke ring. -/
+noncomputable def multiplicity (Γ₁ Γ₂ Γ₃ : Subgroup G) (g h d : G) : ℕ :=
+  Nat.card {p : DecompQuotient Γ₁ Γ₂ g × DecompQuotient Γ₂ Γ₃ h |
+    ((p.1.out : G) * g * ((p.2.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃)}
+
+/-- When the first components of two pairs in the fibre of the multiplicity agree, the second
+components agree. -/
+lemma snd_eq_of_fst_eq {Γ₁ Γ₂ Γ₃ : Subgroup G} {g h d : G} {i : DecompQuotient Γ₁ Γ₂ g}
+    {j₁ j₂ : DecompQuotient Γ₂ Γ₃ h}
+    (h₁ : ((i.out : G) * g * ((j₁.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃))
+    (h₂ : ((i.out : G) * g * ((j₂.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃)) :
+    j₁ = j₂ := by
+  refine mk_out_mul_injective Γ₂ Γ₃ h ?_
+  have h := h₁.trans h₂.symm
+  rw [QuotientGroup.eq] at h ⊢
+  simpa [mul_assoc] using h
+
+/-- When the common second component of two pairs in the fibre of the multiplicity satisfies
+`τⱼ h ∈ Γ₂`, the first components agree. -/
+lemma fst_eq_of_mul_snd_mem {Γ₁ Γ₂ : Subgroup G} {g h d : G} {i₁ i₂ : DecompQuotient Γ₁ Γ₂ g}
+    {j : DecompQuotient Γ₂ Γ₂ h} (hj : (j.out : G) * h ∈ Γ₂)
+    (h₁ : ((i₁.out : G) * g * ((j.out : G) * h) : G ⧸ Γ₂) = (d : G ⧸ Γ₂))
+    (h₂ : ((i₂.out : G) * g * ((j.out : G) * h) : G ⧸ Γ₂) = (d : G ⧸ Γ₂)) :
+    i₁ = i₂ := by
+  rw [QuotientGroup.mk_mul_of_mem _ hj] at h₁ h₂
+  exact mk_out_mul_injective Γ₁ Γ₂ g (h₁.trans h₂.symm)
+
+end DoubleCoset
+
+namespace HeckePair
+
+open DoubleCoset
+
+variable {G : Type*} [Group G] (P : HeckePair G)
+
+attribute [local instance] HeckePair.doubleCosetSetoid
 
 /-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the double coset
-of their product `H(σᵢ τⱼ)H`. -/
-noncomputable def mulMap (g₁ g₂ : P.Δ) (i : decompQuot P g₁ × decompQuot P g₂) :
-    HeckeCoset P :=
-  ⟦⟨i.1.out * g₁ * (i.2.out * g₂),
-    Submonoid.mul_mem _ (Submonoid.mul_mem _ (P.h₀ i.1.out.2) g₁.2)
-      (Submonoid.mul_mem _ (P.h₀ i.2.out.2) g₂.2)⟩⟧
+of their product `H (σᵢ g₁ τⱼ g₂) H`. -/
+noncomputable def mulMap (g₁ g₂ : P.Δ)
+    (p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H (g₂ : G)) : HeckeCoset P :=
+  ⟦⟨(p.1.out : G) * g₁ * ((p.2.out : G) * g₂),
+    P.Δ.mul_mem (P.Δ.mul_mem (P.subgroup_le p.1.out.2) g₁.2)
+      (P.Δ.mul_mem (P.subgroup_le p.2.out.2) g₂.2)⟩⟧
 
-/-- Shimura's multiplicity (Proposition 3.2): `heckeMultiplicity g₁ g₂ d` counts pairs
-`(i, j)` such that `σᵢ τⱼ H = ξ H`. -/
-noncomputable def heckeMultiplicity (g₁ g₂ d : P.Δ) : ℤ :=
-  Nat.card {⟨i, j⟩ : decompQuot P g₁ × decompQuot P g₂ |
-    ({(i.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G)}
+/-- If `σᵢ g₁ τⱼ g₂ H = d H` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`. -/
+lemma mulMap_eq_of_mk_eq {g₁ g₂ d : P.Δ}
+    {p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H (g₂ : G)}
+    (h : ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ P.H) = ((d : G) : G ⧸ P.H)) :
+    P.mulMap g₁ g₂ p = (⟦d⟧ : HeckeCoset P) := by
+  rw [QuotientGroup.eq] at h
+  exact HeckeCoset.mk_eq_mk_of_mem (DoubleCoset.mem_doubleCoset.mpr
+    ⟨1, P.H.one_mem, _, P.H.inv_mem h, by rw [one_mul, mul_inv_rev, inv_inv, mul_inv_cancel_left]⟩)
 
-/-- The finite set of double cosets appearing in the product `D₁ * D₂`. -/
-noncomputable def mulSupport (g₁ g₂ : P.Δ) : Finset (HeckeCoset P) :=
-  Finset.image (mulMap P g₁ g₂) ⊤
-
-/-- If `σᵢ τⱼ H = ξ H` then the double coset of `σᵢ τⱼ` equals that of `ξ`. -/
-lemma doubleCoset_eq_of_rightCoset_eq (g₁ g₂ d : P.Δ)
-    (p : decompQuot P g₁ × decompQuot P g₂)
-    (heq : ({(p.1.out : G) * (g₁ : G)} : Set G) * {(p.2.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G)) :
-    mulMap P g₁ g₂ p = (⟦d⟧ : HeckeCoset P) := by
-  unfold mulMap
-  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
-  rw [HeckeCoset.eq_iff]
-  have h_mem : (p.1.out : G) * (g₁ : G) * ((p.2.out : G) * (g₂ : G)) ∈
-      ({(d : G)} : Set G) * (P.H : Set G) := by
-    rw [← heq, Set.singleton_mul_singleton]
-    exact ⟨_, rfl, 1, P.H.one_mem, by simp⟩
-  obtain ⟨_, hd_eq, h, hh, hprod⟩ := h_mem
-  simp only [Set.mem_singleton_iff] at hd_eq
-  subst hd_eq
-  dsimp only at hprod ⊢
-  rw [← hprod]
-  exact doubleCoset_mul_right_eq_self P ⟨h, hh⟩ _
-
-/-- Left multiplication by a singleton set is cancellative. -/
-lemma set_singleton_mul_left_cancel (a : G) {S T : Set G}
-    (h : ({a} : Set G) * S = ({a} : Set G) * T) : S = T := by
-  rw [Set.singleton_mul, Set.singleton_mul] at h
-  exact Set.image_injective.mpr (mul_right_injective a) h
-
-/-- When the first-component representatives agree, the second-component
-representatives must also agree (by left-cancellation on the common prefix). -/
-lemma decompQuot_snd_eq_of_fst_eq (g₁ g₂ d : P.Δ) (i : decompQuot P g₁)
-    (j₁ j₂ : decompQuot P g₂)
-    (h₁ : ({(i.out : G) * (g₁ : G)} : Set G) * {(j₁.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G))
-    (h₂ : ({(i.out : G) * (g₁ : G)} : Set G) * {(j₂.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G)) :
-    j₁ = j₂ := by
-  by_contra hne
-  refine decompQuot_coset_diff P g₂ j₁ j₂ hne
-    (set_singleton_mul_left_cancel ((i.out : G) * (g₁ : G)) ?_)
-  have := h₁.trans h₂.symm
-  rwa [mul_assoc, mul_assoc] at this
-
-/-- When `j.out * g₂ ∈ H`, the second factor collapses and
-first-component injectivity follows from coset disjointness. -/
-lemma decompQuot_fst_eq_of_snd_mem_H (g₁ g₂ d : P.Δ) (i₁ i₂ : decompQuot P g₁)
-    (j : decompQuot P g₂) (hj : (j.out : G) * (g₂ : G) ∈ P.H)
-    (h₁ : ({(i₁.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G))
-    (h₂ : ({(i₂.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G)) :
-    i₁ = i₂ := by
-  by_contra hne
-  refine decompQuot_coset_diff P g₁ i₁ i₂ hne ?_
-  simp only [mul_assoc, Subgroup.singleton_mul_subgroup hj] at h₁ h₂
-  exact h₁.trans h₂.symm
-
-end HeckeRing
+end HeckePair

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
@@ -8,169 +8,112 @@ module
 public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
 
 /-!
-# Hecke rings: positivity of the multiplicity on the product support
+# Hecke rings: the support of the multiplicity
 
-The product `D₁ * D₂` of two double cosets is supported on the finite set `mulSupport`. This file
-relates membership of `mulSupport` to positivity of Shimura's multiplicity: `heckeMultiplicity` is
-positive exactly on the double cosets that occur in the product, and zero off the support.
+Shimura's multiplicity `m(g, h; d)` is nonzero exactly when `d` lies in the product set
+`Γ₁gΓ₂hΓ₃` of the two double cosets. For a Hecke pair this identifies the support of the
+structure constants of the Hecke product with the image of `HeckePair.mulMap`, which is a
+finite set; this is what makes the convolution product of the Hecke ring well-defined in the
+next file.
 
 ## Main results
 
-* `HeckeRing.heckeMultiplicity_pos_of_mem`: the multiplicity is positive on the support.
-* `HeckeRing.heckeMultiplicity_eq_zero_of_nmem_mulSupport`: zero off the support.
-* `HeckeRing.mem_mulSupport_of_product_mem`: a product in `HdH` witnesses membership.
+* `DoubleCoset.multiplicity_ne_zero_iff`: `m(g, h; d) ≠ 0 ↔ d ∈ Γ₁gΓ₂hΓ₃`.
+* `HeckePair.mem_image_mulMap_iff`: the support of the structure constants at `(g₁, g₂)` is the
+  image of `mulMap`.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup
+open Subgroup
 open scoped Pointwise
 
-namespace HeckeRing
+namespace DoubleCoset
 
-variable {G : Type*} [Group G]
+variable {G : Type*} [Group G] {Γ₁ Γ₂ Γ₃ : Subgroup G}
 
-attribute [local instance] doubleCosetSetoid
+/-- Shimura's multiplicity `m(g, h; d)` is nonzero exactly when `d` lies in the product set
+`Γ₁gΓ₂hΓ₃` of the double cosets of `g` and `h`. -/
+theorem multiplicity_ne_zero_iff {g h d : G} [Finite (DecompQuotient Γ₁ Γ₂ g)]
+    [Finite (DecompQuotient Γ₂ Γ₃ h)] :
+    multiplicity Γ₁ Γ₂ Γ₃ g h d ≠ 0 ↔ d ∈ doubleCoset h (doubleCoset g Γ₁ Γ₂) Γ₃ := by
+  rw [multiplicity, Nat.card_ne_zero]
+  constructor
+  · rintro ⟨⟨p, hp⟩, -⟩
+    have hp' : _ = (d : G ⧸ Γ₃) := hp
+    rw [QuotientGroup.eq] at hp'
+    refine mem_doubleCoset.mpr ⟨(p.1.out : G) * g * p.2.out,
+      mem_doubleCoset.mpr ⟨p.1.out, p.1.out.2, p.2.out, p.2.out.2, rfl⟩, _, hp', ?_⟩
+    simp [mul_assoc]
+  · intro hd
+    refine ⟨?_, inferInstance⟩
+    obtain ⟨w, hw, k, hk, rfl⟩ := mem_doubleCoset.mp hd
+    rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hw
+    obtain ⟨i, hi⟩ := hw
+    rw [mem_leftCoset_iff] at hi
+    have hch : (((i.out : G) * g)⁻¹ * w) * h ∈ doubleCoset h Γ₂ Γ₃ :=
+      mem_doubleCoset.mpr ⟨_, hi, 1, Γ₃.one_mem, by rw [mul_one]⟩
+    rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hch
+    obtain ⟨j, hj⟩ := hch
+    rw [mem_leftCoset_iff] at hj
+    refine ⟨⟨(i, j), ?_⟩⟩
+    rw [Set.mem_setOf_eq, QuotientGroup.eq]
+    have : ((i.out : G) * g * ((j.out : G) * h))⁻¹ * (w * h * k) =
+        (((j.out : G) * h)⁻¹ * ((((i.out : G) * g)⁻¹ * w) * h)) * k := by
+      simp [mul_assoc]
+    rw [this]
+    exact Γ₃.mul_mem hj hk
 
-variable (P : HeckePair G)
+end DoubleCoset
 
-/-- If the double coset of `σ_{i₀} τ_{j₀}` equals `HcH`, then the fibre defining the multiplicity
-at `c` is nonempty: some pair of representatives multiplies into the right coset `cH`. -/
-private lemma nonempty_witness_of_doubleCoset_eq (g₁ g₂ : P.Δ) (c : G)
-    (i₀ : decompQuot P g₁) (j₀ : decompQuot P g₂)
-    (hset_eq : DoubleCoset.doubleCoset
-      ((↑i₀.out : G) * (↑g₁ : G) * ((↑j₀.out : G) * (↑g₂ : G)))
-      (P.H : Set G) (P.H : Set G) =
-      DoubleCoset.doubleCoset c P.H P.H) :
-    Nonempty ↑{x : decompQuot P g₁ × decompQuot P g₂ |
-      ({(↑x.1.out : G) * (↑g₁ : G)} : Set G) *
-        {(↑x.2.out : G) * (↑g₂ : G)} * P.H = {c} * (P.H : Set G)} := by
-  obtain ⟨h₁, hh₁, h₂, hh₂, hprod⟩ := (DoubleCoset.eq P.H P.H _ _).mp
-    (DoubleCoset.mk_eq_of_doubleCoset_eq hset_eq)
-  set α := (↑g₁ : G)
-  set β := (↑g₂ : G)
-  set K₁ := (ConjAct.toConjAct α • P.H).subgroupOf P.H
-  set i' : decompQuot P g₁ := ⟦⟨h₁ * ↑i₀.out, P.H.mul_mem hh₁ i₀.out.2⟩⟧
-  obtain ⟨κ₁, hκ₁_eq⟩ := QuotientGroup.mk_out_eq_mul K₁
-    ⟨h₁ * ↑i₀.out, P.H.mul_mem hh₁ i₀.out.2⟩
-  have hκ₁_conj : α⁻¹ * (κ₁.val : G) * α ∈ P.H :=
-    inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) κ₁
-  set K₂ := (ConjAct.toConjAct β • P.H).subgroupOf P.H
-  set j' : decompQuot P g₂ := ⟦⟨(α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out,
-    P.H.mul_mem (P.H.inv_mem hκ₁_conj) j₀.out.2⟩⟧
-  obtain ⟨κ₂, hκ₂_eq⟩ := QuotientGroup.mk_out_eq_mul K₂
-    ⟨(α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out,
-      P.H.mul_mem (P.H.inv_mem hκ₁_conj) j₀.out.2⟩
-  have hκ₂_conj : β⁻¹ * (κ₂.val : G) * β ∈ P.H :=
-    inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) κ₂
-  have hi'_coe : (↑i'.out : G) = h₁ * ↑i₀.out * (κ₁.val : G) := by
-    have := congr_arg (Subtype.val : P.H → G) hκ₁_eq
-    simpa [Subgroup.coe_mul] using this
-  have hj'_coe : (↑j'.out : G) =
-      (α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out * (κ₂.val : G) := by
-    have h := hκ₂_eq
-    apply_fun (↑· : ↥P.H → G) at h
-    simp only [Subgroup.coe_mul] at h
-    exact h
-  refine ⟨⟨(i', j'), ?_⟩⟩
-  simp only [Set.mem_setOf_eq]
-  have hprod_main : (↑i'.out : G) * α * ((↑j'.out : G) * β) =
-      c * (h₂⁻¹ * (β⁻¹ * (κ₂.val : G) * β)) := by
-    rw [hi'_coe, hj'_coe]
-    have hprod' : c = h₁ * (↑i₀.out * α * (↑j₀.out * β)) * h₂ := hprod
-    rw [hprod']
-    group
-  rw [Set.singleton_mul_singleton, hprod_main, ← Set.singleton_mul_singleton, mul_assoc,
-    Subgroup.singleton_mul_subgroup (P.H.mul_mem (P.H.inv_mem hh₂) hκ₂_conj)]
+namespace HeckePair
 
-/-- The multiplicity is nonzero for double cosets in the product support. -/
-lemma heckeMultiplicity_pos_of_mem_mulSupport (g₁ g₂ : P.Δ) (d : HeckeCoset P)
-    (hd : d ∈ mulSupport P g₁ g₂) :
-    heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) ≠ 0 := by
-  rw [heckeMultiplicity]
-  simp only [ne_eq, Nat.cast_eq_zero]
-  rw [Nat.card_eq_zero, not_or, not_isEmpty_iff]
-  refine ⟨?_, not_infinite_iff_finite.mpr inferInstance⟩
-  rw [mulSupport] at hd
-  simp only [Finset.top_eq_univ, Finset.mem_image, Finset.mem_univ, true_and,
-    Prod.exists] at hd
-  obtain ⟨i₀, j₀, hmap⟩ := hd
-  exact nonempty_witness_of_doubleCoset_eq P g₁ g₂ (HeckeCoset.rep d) i₀ j₀
-    ((HeckeCoset.eq_iff _ _).mp (hmap.trans (Quotient.out_eq d).symm))
+open DoubleCoset
 
-/-- The multiplicity is zero for double cosets outside the product support. -/
-lemma heckeMultiplicity_eq_zero_of_nmem_mulSupport (g₁ g₂ : P.Δ) (d : HeckeCoset P)
-    (hd : d ∉ mulSupport P g₁ g₂) :
-    heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) = 0 := by
-  simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
-  left
-  rintro ⟨i, j⟩ hij
-  refine hd ?_
-  rw [mulSupport]
-  simp only [Finset.top_eq_univ, Finset.mem_image, Finset.mem_univ, true_and, Prod.exists]
-  exact ⟨i, j, (doubleCoset_eq_of_rightCoset_eq P g₁ g₂ (HeckeCoset.rep d) (i, j) hij).trans
-    (Quotient.out_eq d)⟩
+variable {G : Type*} [Group G] (P : HeckePair G)
 
-/-- A multiplicity that is both at most one and positive must equal one. -/
-lemma heckeMultiplicity_eq_one_of_le_one_and_pos (g₁ g₂ d : P.Δ)
-    (h_le : heckeMultiplicity P g₁ g₂ d ≤ 1)
-    (h_pos : 0 < heckeMultiplicity P g₁ g₂ d) :
-    heckeMultiplicity P g₁ g₂ d = 1 := by omega
+attribute [local instance] HeckePair.doubleCosetSetoid
 
-/-- The multiplicity is positive for double cosets in the product support. -/
-lemma heckeMultiplicity_pos_of_mem (g₁ g₂ : P.Δ) (d : HeckeCoset P)
-    (hd : d ∈ mulSupport P g₁ g₂) :
-    0 < heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) := by
-  have h_ne := heckeMultiplicity_pos_of_mem_mulSupport P g₁ g₂ d hd
-  have h_nonneg : (0 : ℤ) ≤ heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) := by
-    simp only [heckeMultiplicity]
-    exact_mod_cast Nat.zero_le _
-  exact lt_of_le_of_ne h_nonneg (Ne.symm h_ne)
+/-- The support of the structure constants of the Hecke product at `(g₁, g₂)` is the image
+of `HeckePair.mulMap`: the multiplicity of a double coset `D` in the product `Hg₁H * Hg₂H` is
+nonzero exactly when `D` is the double coset of `σᵢ g₁ τⱼ g₂` for some pair of coset
+representatives. -/
+theorem mem_image_mulMap_iff [DecidableEq (HeckeCoset P)] (g₁ g₂ : P.Δ) (D : HeckeCoset P) :
+    D ∈ Finset.univ.image (P.mulMap g₁ g₂) ↔
+      multiplicity P.H P.H P.H (g₁ : G) (g₂ : G) (D.rep : G) ≠ 0 := by
+  rw [multiplicity_ne_zero_iff]
+  constructor
+  · intro hD
+    simp only [Finset.mem_image, Finset.mem_univ, true_and] at hD
+    obtain ⟨p, hp⟩ := hD
+    have hrep : (D.rep : G) ∈
+        doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) P.H P.H := by
+      rw [show doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) P.H P.H =
+          doubleCoset (D.rep : G) P.H P.H from HeckeCoset.eq_iff.mp (hp.trans D.mk_rep.symm)]
+      exact mem_doubleCoset_self P.H P.H _
+    obtain ⟨h₁, hh₁, h₂, hh₂, hrep_eq⟩ := mem_doubleCoset.mp hrep
+    rw [hrep_eq]
+    refine mem_doubleCoset.mpr ⟨h₁ * p.1.out * g₁ * p.2.out,
+      mem_doubleCoset.mpr ⟨h₁ * p.1.out, P.H.mul_mem hh₁ p.1.out.2, p.2.out, p.2.out.2, rfl⟩,
+      h₂, hh₂, by simp [mul_assoc]⟩
+  · intro hD
+    obtain ⟨w, hw, k, hk, hd⟩ := mem_doubleCoset.mp hD
+    rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hw
+    obtain ⟨i, hi⟩ := hw
+    rw [mem_leftCoset_iff] at hi
+    have hch : (((i.out : G) * g₁)⁻¹ * w) * g₂ ∈ doubleCoset (g₂ : G) P.H P.H :=
+      mem_doubleCoset.mpr ⟨_, hi, 1, P.H.one_mem, by rw [mul_one]⟩
+    rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hch
+    obtain ⟨j, hj⟩ := hch
+    rw [mem_leftCoset_iff] at hj
+    refine Finset.mem_image.mpr ⟨(i, j), Finset.mem_univ _, ?_⟩
+    rw [← D.mk_rep]
+    refine P.mulMap_eq_of_mk_eq ?_
+    rw [QuotientGroup.eq, hd]
+    have : ((i.out : G) * g₁ * ((j.out : G) * g₂))⁻¹ * (w * g₂ * k) =
+        (((j.out : G) * g₂)⁻¹ * ((((i.out : G) * g₁)⁻¹ * w) * g₂)) * k := by
+      simp [mul_assoc]
+    rw [this]
+    exact P.H.mul_mem hj hk
 
-/-- If `h₁ g₁ (h₂ g₂) ∈ HdH` (with `h₁, h₂ ∈ H`), then `⟦d⟧ ∈ mulSupport g₁ g₂`. -/
-lemma mem_mulSupport_of_product_mem (g₁ g₂ d : P.Δ) (h₁ h₂ : P.H)
-    (hmem : (h₁ : G) * g₁ * ((h₂ : G) * g₂) ∈
-      DoubleCoset.doubleCoset (d : G) P.H P.H) :
-    (⟦d⟧ : HeckeCoset P) ∈ mulSupport P g₁ g₂ := by
-  have key : mulMap P g₁ g₂ (⟦⟨h₁, h₁.2⟩⟧, ⟦⟨h₂, h₂.2⟩⟧) =
-      (⟦d⟧ : HeckeCoset P) := by
-    unfold mulMap
-    change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
-    rw [HeckeCoset.eq_iff]
-    dsimp only
-    obtain ⟨n₁, hn₁⟩ := QuotientGroup.mk_out_eq_mul
-      ((ConjAct.toConjAct (g₁ : G) • P.H).subgroupOf P.H) ⟨(h₁ : G), h₁.2⟩
-    obtain ⟨n₂, hn₂⟩ := QuotientGroup.mk_out_eq_mul
-      ((ConjAct.toConjAct (g₂ : G) • P.H).subgroupOf P.H) ⟨(h₂ : G), h₂.2⟩
-    have hi : ((⟦⟨(h₁ : G), h₁.2⟩⟧ : decompQuot P g₁).out : G) = h₁ * n₁ := by
-      have := congr_arg (Subtype.val : P.H → G) hn₁
-      simpa [Subgroup.coe_mul]
-    have hj : ((⟦⟨(h₂ : G), h₂.2⟩⟧ : decompQuot P g₂).out : G) = h₂ * n₂ := by
-      have := congr_arg (Subtype.val : P.H → G) hn₂
-      simpa [Subgroup.coe_mul]
-    have hn₂c : (g₂ : G)⁻¹ * ↑n₂ * g₂ ∈ P.H :=
-      inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) n₂
-    rw [hi, hj]
-    apply HeckeCoset.doubleCoset_eq_of_mem
-    rw [DoubleCoset.mem_doubleCoset] at hmem
-    obtain ⟨a, ha, b, hb, hab⟩ := hmem
-    rw [DoubleCoset.mem_doubleCoset]
-    refine ⟨(h₁ : G) * ↑↑n₁ * (h₁ : G)⁻¹ * a,
-      P.H.mul_mem (P.H.mul_mem (P.H.mul_mem h₁.2 (SetLike.coe_mem n₁.val))
-        (P.H.inv_mem h₁.2)) ha,
-      b * ((g₂ : G)⁻¹ * ↑↑n₂ * g₂), P.H.mul_mem hb hn₂c, ?_⟩
-    have key : (↑h₁ * ↑↑n₁ * (↑h₁ : G)⁻¹ * a) * ↑d *
-        (b * ((↑g₂ : G)⁻¹ * ↑↑n₂ * ↑g₂)) =
-        (↑h₁ * ↑↑n₁) * (↑g₁ : G) * ((↑h₂ * ↑↑n₂) * ↑g₂) :=
-      calc (↑h₁ * ↑↑n₁ * (↑h₁ : G)⁻¹ * a) * ↑d
-          * (b * ((↑g₂ : G)⁻¹ * ↑↑n₂ * ↑g₂))
-          = ↑h₁ * ↑↑n₁ * (↑h₁)⁻¹ * (a * ↑d * b) *
-            ((↑g₂)⁻¹ * ↑↑n₂ * ↑g₂) := by group
-        _ = ↑h₁ * ↑↑n₁ * (↑h₁)⁻¹ * (↑h₁ * ↑g₁ * (↑h₂ * ↑g₂)) *
-            ((↑g₂)⁻¹ * ↑↑n₂ * ↑g₂) := by rw [hab]
-        _ = (↑h₁ * ↑↑n₁) * ↑g₁ * ((↑h₂ * ↑↑n₂) * ↑g₂) := by group
-    exact key.symm
-  unfold mulSupport
-  exact key ▸ Finset.mem_image_of_mem (mulMap P g₁ g₂) (Finset.mem_univ _)
-
-end HeckeRing
+end HeckePair

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
+
+/-!
+# Hecke rings: positivity of the multiplicity on the product support
+
+The product `D₁ * D₂` of two double cosets is supported on the finite set `mulSupport`. This file
+relates membership of `mulSupport` to positivity of Shimura's multiplicity: `heckeMultiplicity` is
+positive exactly on the double cosets that occur in the product, and zero off the support.
+
+## Main results
+
+* `HeckeRing.heckeMultiplicity_pos_of_mem`: the multiplicity is positive on the support.
+* `HeckeRing.heckeMultiplicity_eq_zero_of_nmem_mulSupport`: zero off the support.
+* `HeckeRing.mem_mulSupport_of_product_mem`: a product in `HdH` witnesses membership.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup
+open scoped Pointwise
+
+namespace HeckeRing
+
+variable {G : Type*} [Group G]
+
+attribute [local instance] doubleCosetSetoid
+
+variable (P : HeckePair G)
+
+/-- If the double coset of `σ_{i₀} τ_{j₀}` equals `HcH`, then the fibre defining the multiplicity
+at `c` is nonempty: some pair of representatives multiplies into the right coset `cH`. -/
+private lemma nonempty_witness_of_doubleCoset_eq (g₁ g₂ : P.Δ) (c : G)
+    (i₀ : decompQuot P g₁) (j₀ : decompQuot P g₂)
+    (hset_eq : DoubleCoset.doubleCoset
+      ((↑i₀.out : G) * (↑g₁ : G) * ((↑j₀.out : G) * (↑g₂ : G)))
+      (P.H : Set G) (P.H : Set G) =
+      DoubleCoset.doubleCoset c P.H P.H) :
+    Nonempty ↑{x : decompQuot P g₁ × decompQuot P g₂ |
+      ({(↑x.1.out : G) * (↑g₁ : G)} : Set G) *
+        {(↑x.2.out : G) * (↑g₂ : G)} * P.H = {c} * (P.H : Set G)} := by
+  obtain ⟨h₁, hh₁, h₂, hh₂, hprod⟩ := (DoubleCoset.eq P.H P.H _ _).mp
+    (DoubleCoset.mk_eq_of_doubleCoset_eq hset_eq)
+  set α := (↑g₁ : G)
+  set β := (↑g₂ : G)
+  set K₁ := (ConjAct.toConjAct α • P.H).subgroupOf P.H
+  set i' : decompQuot P g₁ := ⟦⟨h₁ * ↑i₀.out, P.H.mul_mem hh₁ i₀.out.2⟩⟧
+  obtain ⟨κ₁, hκ₁_eq⟩ := QuotientGroup.mk_out_eq_mul K₁
+    ⟨h₁ * ↑i₀.out, P.H.mul_mem hh₁ i₀.out.2⟩
+  have hκ₁_conj : α⁻¹ * (κ₁.val : G) * α ∈ P.H :=
+    inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) κ₁
+  set K₂ := (ConjAct.toConjAct β • P.H).subgroupOf P.H
+  set j' : decompQuot P g₂ := ⟦⟨(α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out,
+    P.H.mul_mem (P.H.inv_mem hκ₁_conj) j₀.out.2⟩⟧
+  obtain ⟨κ₂, hκ₂_eq⟩ := QuotientGroup.mk_out_eq_mul K₂
+    ⟨(α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out,
+      P.H.mul_mem (P.H.inv_mem hκ₁_conj) j₀.out.2⟩
+  have hκ₂_conj : β⁻¹ * (κ₂.val : G) * β ∈ P.H :=
+    inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) κ₂
+  have hi'_coe : (↑i'.out : G) = h₁ * ↑i₀.out * (κ₁.val : G) := by
+    have := congr_arg (Subtype.val : P.H → G) hκ₁_eq
+    simpa [Subgroup.coe_mul] using this
+  have hj'_coe : (↑j'.out : G) =
+      (α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out * (κ₂.val : G) := by
+    have h := hκ₂_eq
+    apply_fun (↑· : ↥P.H → G) at h
+    simp only [Subgroup.coe_mul] at h
+    exact h
+  refine ⟨⟨(i', j'), ?_⟩⟩
+  simp only [Set.mem_setOf_eq]
+  have hprod_main : (↑i'.out : G) * α * ((↑j'.out : G) * β) =
+      c * (h₂⁻¹ * (β⁻¹ * (κ₂.val : G) * β)) := by
+    rw [hi'_coe, hj'_coe]
+    have hprod' : c = h₁ * (↑i₀.out * α * (↑j₀.out * β)) * h₂ := hprod
+    rw [hprod']
+    group
+  rw [Set.singleton_mul_singleton, hprod_main, ← Set.singleton_mul_singleton, mul_assoc,
+    Subgroup.singleton_mul_subgroup (P.H.mul_mem (P.H.inv_mem hh₂) hκ₂_conj)]
+
+/-- The multiplicity is nonzero for double cosets in the product support. -/
+lemma heckeMultiplicity_pos_of_mem_mulSupport (g₁ g₂ : P.Δ) (d : HeckeCoset P)
+    (hd : d ∈ mulSupport P g₁ g₂) :
+    heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) ≠ 0 := by
+  rw [heckeMultiplicity]
+  simp only [ne_eq, Nat.cast_eq_zero]
+  rw [Nat.card_eq_zero, not_or, not_isEmpty_iff]
+  refine ⟨?_, not_infinite_iff_finite.mpr inferInstance⟩
+  rw [mulSupport] at hd
+  simp only [Finset.top_eq_univ, Finset.mem_image, Finset.mem_univ, true_and,
+    Prod.exists] at hd
+  obtain ⟨i₀, j₀, hmap⟩ := hd
+  exact nonempty_witness_of_doubleCoset_eq P g₁ g₂ (HeckeCoset.rep d) i₀ j₀
+    ((HeckeCoset.eq_iff _ _).mp (hmap.trans (Quotient.out_eq d).symm))
+
+/-- The multiplicity is zero for double cosets outside the product support. -/
+lemma heckeMultiplicity_eq_zero_of_nmem_mulSupport (g₁ g₂ : P.Δ) (d : HeckeCoset P)
+    (hd : d ∉ mulSupport P g₁ g₂) :
+    heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) = 0 := by
+  simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
+  left
+  rintro ⟨i, j⟩ hij
+  refine hd ?_
+  rw [mulSupport]
+  simp only [Finset.top_eq_univ, Finset.mem_image, Finset.mem_univ, true_and, Prod.exists]
+  exact ⟨i, j, (doubleCoset_eq_of_rightCoset_eq P g₁ g₂ (HeckeCoset.rep d) (i, j) hij).trans
+    (Quotient.out_eq d)⟩
+
+/-- A multiplicity that is both at most one and positive must equal one. -/
+lemma heckeMultiplicity_eq_one_of_le_one_and_pos (g₁ g₂ d : P.Δ)
+    (h_le : heckeMultiplicity P g₁ g₂ d ≤ 1)
+    (h_pos : 0 < heckeMultiplicity P g₁ g₂ d) :
+    heckeMultiplicity P g₁ g₂ d = 1 := by omega
+
+/-- The multiplicity is positive for double cosets in the product support. -/
+lemma heckeMultiplicity_pos_of_mem (g₁ g₂ : P.Δ) (d : HeckeCoset P)
+    (hd : d ∈ mulSupport P g₁ g₂) :
+    0 < heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) := by
+  have h_ne := heckeMultiplicity_pos_of_mem_mulSupport P g₁ g₂ d hd
+  have h_nonneg : (0 : ℤ) ≤ heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) := by
+    simp only [heckeMultiplicity]
+    exact_mod_cast Nat.zero_le _
+  exact lt_of_le_of_ne h_nonneg (Ne.symm h_ne)
+
+/-- If `h₁ g₁ (h₂ g₂) ∈ HdH` (with `h₁, h₂ ∈ H`), then `⟦d⟧ ∈ mulSupport g₁ g₂`. -/
+lemma mem_mulSupport_of_product_mem (g₁ g₂ d : P.Δ) (h₁ h₂ : P.H)
+    (hmem : (h₁ : G) * g₁ * ((h₂ : G) * g₂) ∈
+      DoubleCoset.doubleCoset (d : G) P.H P.H) :
+    (⟦d⟧ : HeckeCoset P) ∈ mulSupport P g₁ g₂ := by
+  have key : mulMap P g₁ g₂ (⟦⟨h₁, h₁.2⟩⟧, ⟦⟨h₂, h₂.2⟩⟧) =
+      (⟦d⟧ : HeckeCoset P) := by
+    unfold mulMap
+    change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
+    rw [HeckeCoset.eq_iff]
+    dsimp only
+    obtain ⟨n₁, hn₁⟩ := QuotientGroup.mk_out_eq_mul
+      ((ConjAct.toConjAct (g₁ : G) • P.H).subgroupOf P.H) ⟨(h₁ : G), h₁.2⟩
+    obtain ⟨n₂, hn₂⟩ := QuotientGroup.mk_out_eq_mul
+      ((ConjAct.toConjAct (g₂ : G) • P.H).subgroupOf P.H) ⟨(h₂ : G), h₂.2⟩
+    have hi : ((⟦⟨(h₁ : G), h₁.2⟩⟧ : decompQuot P g₁).out : G) = h₁ * n₁ := by
+      have := congr_arg (Subtype.val : P.H → G) hn₁
+      simpa [Subgroup.coe_mul]
+    have hj : ((⟦⟨(h₂ : G), h₂.2⟩⟧ : decompQuot P g₂).out : G) = h₂ * n₂ := by
+      have := congr_arg (Subtype.val : P.H → G) hn₂
+      simpa [Subgroup.coe_mul]
+    have hn₂c : (g₂ : G)⁻¹ * ↑n₂ * g₂ ∈ P.H :=
+      inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) n₂
+    rw [hi, hj]
+    apply HeckeCoset.doubleCoset_eq_of_mem
+    rw [DoubleCoset.mem_doubleCoset] at hmem
+    obtain ⟨a, ha, b, hb, hab⟩ := hmem
+    rw [DoubleCoset.mem_doubleCoset]
+    refine ⟨(h₁ : G) * ↑↑n₁ * (h₁ : G)⁻¹ * a,
+      P.H.mul_mem (P.H.mul_mem (P.H.mul_mem h₁.2 (SetLike.coe_mem n₁.val))
+        (P.H.inv_mem h₁.2)) ha,
+      b * ((g₂ : G)⁻¹ * ↑↑n₂ * g₂), P.H.mul_mem hb hn₂c, ?_⟩
+    have key : (↑h₁ * ↑↑n₁ * (↑h₁ : G)⁻¹ * a) * ↑d *
+        (b * ((↑g₂ : G)⁻¹ * ↑↑n₂ * ↑g₂)) =
+        (↑h₁ * ↑↑n₁) * (↑g₁ : G) * ((↑h₂ * ↑↑n₂) * ↑g₂) :=
+      calc (↑h₁ * ↑↑n₁ * (↑h₁ : G)⁻¹ * a) * ↑d
+          * (b * ((↑g₂ : G)⁻¹ * ↑↑n₂ * ↑g₂))
+          = ↑h₁ * ↑↑n₁ * (↑h₁)⁻¹ * (a * ↑d * b) *
+            ((↑g₂)⁻¹ * ↑↑n₂ * ↑g₂) := by group
+        _ = ↑h₁ * ↑↑n₁ * (↑h₁)⁻¹ * (↑h₁ * ↑g₁ * (↑h₂ * ↑g₂)) *
+            ((↑g₂)⁻¹ * ↑↑n₂ * ↑g₂) := by rw [hab]
+        _ = (↑h₁ * ↑↑n₁) * ↑g₁ * ((↑h₂ * ↑↑n₂) * ↑g₂) := by group
+    exact key.symm
+  unfold mulSupport
+  exact key ▸ Finset.mem_image_of_mem (mulMap P g₁ g₂) (Finset.mem_univ _)
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
@@ -11,7 +11,7 @@ public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
 # Hecke rings: the support of the multiplicity
 
 Shimura's multiplicity `m(g, h; d)` is nonzero exactly when `d` lies in the product set
-`Γ₁gΓ₂hΓ₃` of the two double cosets. For a Hecke coset module datum this identifies the support
+`Γ₁gΓ₂hΓ₃` of the two double cosets. For a Hecke triple this identifies the support
 of the structure constants of the Hecke product with the image of `HeckeCoset.mulMap`, which is
 a finite set; this is what makes the convolution product of Hecke coset modules well-defined in
 the next file.
@@ -76,7 +76,7 @@ variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 of `HeckeCoset.mulMap`: the multiplicity of a double coset `D` in the product `H₁g₁H₂ * H₂g₂H₃`
 is nonzero exactly when `D` is the double coset of `σᵢ g₁ τⱼ g₂` for some pair of coset
 representatives. -/
-theorem mem_image_mulMap_iff [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+theorem mem_image_mulMap_iff [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     [DecidableEq (HeckeCoset Δ H₁ H₃)] (g₁ g₂ : Δ) (D : HeckeCoset Δ H₁ H₃) :
     D ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂) ↔
       multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (D.rep : G) ≠ 0 := by

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
@@ -11,16 +11,16 @@ public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
 # Hecke rings: the support of the multiplicity
 
 Shimura's multiplicity `m(g, h; d)` is nonzero exactly when `d` lies in the product set
-`Γ₁gΓ₂hΓ₃` of the two double cosets. For a Hecke pair this identifies the support of the
-structure constants of the Hecke product with the image of `HeckePair.mulMap`, which is a
-finite set; this is what makes the convolution product of the Hecke ring well-defined in the
-next file.
+`Γ₁gΓ₂hΓ₃` of the two double cosets. For a Hecke coset module datum this identifies the support
+of the structure constants of the Hecke product with the image of `HeckeCoset.mulMap`, which is
+a finite set; this is what makes the convolution product of Hecke coset modules well-defined in
+the next file.
 
 ## Main results
 
 * `DoubleCoset.multiplicity_ne_zero_iff`: `m(g, h; d) ≠ 0 ↔ d ∈ Γ₁gΓ₂hΓ₃`.
-* `HeckePair.mem_image_mulMap_iff`: the support of the structure constants at `(g₁, g₂)` is the
-  image of `mulMap`.
+* `HeckeCoset.mem_image_mulMap_iff`: the support of the structure constants at `(g₁, g₂)` is
+  the image of `mulMap`.
 -/
 
 @[expose] public section
@@ -66,54 +66,53 @@ theorem multiplicity_ne_zero_iff {g h d : G} [Finite (DecompQuotient Γ₁ Γ₂
 
 end DoubleCoset
 
-namespace HeckePair
+namespace HeckeCoset
 
 open DoubleCoset
 
-variable {G : Type*} [Group G] (P : HeckePair G)
-
-attribute [local instance] HeckePair.doubleCosetSetoid
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 
 /-- The support of the structure constants of the Hecke product at `(g₁, g₂)` is the image
-of `HeckePair.mulMap`: the multiplicity of a double coset `D` in the product `Hg₁H * Hg₂H` is
-nonzero exactly when `D` is the double coset of `σᵢ g₁ τⱼ g₂` for some pair of coset
+of `HeckeCoset.mulMap`: the multiplicity of a double coset `D` in the product `H₁g₁H₂ * H₂g₂H₃`
+is nonzero exactly when `D` is the double coset of `σᵢ g₁ τⱼ g₂` for some pair of coset
 representatives. -/
-theorem mem_image_mulMap_iff [DecidableEq (HeckeCoset P)] (g₁ g₂ : P.Δ) (D : HeckeCoset P) :
-    D ∈ Finset.univ.image (P.mulMap g₁ g₂) ↔
-      multiplicity P.H P.H P.H (g₁ : G) (g₂ : G) (D.rep : G) ≠ 0 := by
+theorem mem_image_mulMap_iff [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    [DecidableEq (HeckeCoset Δ H₁ H₃)] (g₁ g₂ : Δ) (D : HeckeCoset Δ H₁ H₃) :
+    D ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂) ↔
+      multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (D.rep : G) ≠ 0 := by
   rw [multiplicity_ne_zero_iff]
   constructor
   · intro hD
     simp only [Finset.mem_image, Finset.mem_univ, true_and] at hD
     obtain ⟨p, hp⟩ := hD
     have hrep : (D.rep : G) ∈
-        doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) P.H P.H := by
-      rw [show doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) P.H P.H =
-          doubleCoset (D.rep : G) P.H P.H from HeckeCoset.eq_iff.mp (hp.trans D.mk_rep.symm)]
-      exact mem_doubleCoset_self P.H P.H _
+        doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) H₁ H₃ := by
+      rw [show doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) H₁ H₃ =
+          doubleCoset (D.rep : G) H₁ H₃ from HeckeCoset.eq_iff.mp (hp.trans D.mk_rep.symm)]
+      exact mem_doubleCoset_self H₁ H₃ _
     obtain ⟨h₁, hh₁, h₂, hh₂, hrep_eq⟩ := mem_doubleCoset.mp hrep
     rw [hrep_eq]
     refine mem_doubleCoset.mpr ⟨h₁ * p.1.out * g₁ * p.2.out,
-      mem_doubleCoset.mpr ⟨h₁ * p.1.out, P.H.mul_mem hh₁ p.1.out.2, p.2.out, p.2.out.2, rfl⟩,
+      mem_doubleCoset.mpr ⟨h₁ * p.1.out, H₁.mul_mem hh₁ p.1.out.2, p.2.out, p.2.out.2, rfl⟩,
       h₂, hh₂, by simp [mul_assoc]⟩
   · intro hD
     obtain ⟨w, hw, k, hk, hd⟩ := mem_doubleCoset.mp hD
     rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hw
     obtain ⟨i, hi⟩ := hw
     rw [mem_leftCoset_iff] at hi
-    have hch : (((i.out : G) * g₁)⁻¹ * w) * g₂ ∈ doubleCoset (g₂ : G) P.H P.H :=
-      mem_doubleCoset.mpr ⟨_, hi, 1, P.H.one_mem, by rw [mul_one]⟩
+    have hch : (((i.out : G) * g₁)⁻¹ * w) * g₂ ∈ doubleCoset (g₂ : G) H₂ H₃ :=
+      mem_doubleCoset.mpr ⟨_, hi, 1, H₃.one_mem, by rw [mul_one]⟩
     rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hch
     obtain ⟨j, hj⟩ := hch
     rw [mem_leftCoset_iff] at hj
     refine Finset.mem_image.mpr ⟨(i, j), Finset.mem_univ _, ?_⟩
     rw [← D.mk_rep]
-    refine P.mulMap_eq_of_mk_eq ?_
+    refine mulMap_eq_of_mk_eq ?_
     rw [QuotientGroup.eq, hd]
     have : ((i.out : G) * g₁ * ((j.out : G) * g₂))⁻¹ * (w * g₂ * k) =
         (((j.out : G) * g₂)⁻¹ * ((((i.out : G) * g₁)⁻¹ * w) * g₂)) * k := by
       simp [mul_assoc]
     rw [this]
-    exact P.H.mul_mem hj hk
+    exact H₃.mul_mem hj hk
 
-end HeckePair
+end HeckeCoset

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.HeckeRing.Multiplicity
+
+/-!
+# Hecke rings: the multiplicity of the identity double coset
+
+The identity double coset `HeckeCoset.one` acts as the unit for the Hecke product. This file proves
+the two computations that express this at the level of Shimura's multiplicity: for the identity on
+either side, `heckeMultiplicity` is `1` exactly on the diagonal `⟦g⟧ = ⟦d⟧` and `0` elsewhere.
+
+## Main results
+
+* `HeckeRing.heckeMultiplicity_mul_one`: `⟦g⟧ = ⟦d⟧ ↔ heckeMultiplicity g (one).rep d = 1`.
+* `HeckeRing.heckeMultiplicity_one_mul`: `⟦g⟧ = ⟦d⟧ ↔ heckeMultiplicity (one).rep g d = 1`.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup
+open scoped Pointwise
+
+namespace HeckeRing
+
+variable {G : Type*} [Group G]
+
+attribute [local instance] doubleCosetSetoid
+
+/-- Membership in `(ConjAct.toConjAct a • H).subgroupOf H` unfolds to conjugation by `a`
+landing back in `H`. -/
+lemma inv_mul_mul_mem_of_mem_subgroupOf (H : Subgroup G) {a : G}
+    (x : (ConjAct.toConjAct a • H).subgroupOf H) : a⁻¹ * (x.val : G) * a ∈ H := by
+  have := x.2
+  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
+    ConjAct.smul_def] at this
+  simpa [ConjAct.ofConjAct_toConjAct] using this
+
+variable (P : HeckePair G)
+
+/-- If `Hg₁H = HdH`, the fibre defining the multiplicity for right multiplication by the
+identity double coset is nonempty. -/
+private lemma nonempty_mul_one_witness_of_doubleCoset_eq (g₁ d : P.Δ)
+    (hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
+      DoubleCoset.doubleCoset (d : G) P.H P.H) :
+    Nonempty ↑{x : decompQuot P g₁ × decompQuot P (HeckeCoset.one P).rep |
+      ({(↑x.1.out : G) * (↑g₁ : G)} : Set G) *
+        {(↑x.2.out : G) * (↑(HeckeCoset.one P).rep : G)} * P.H =
+        {(↑d : G)} * (P.H : Set G)} := by
+  have hd_in_g₁ : (↑d : G) ∈ doubleCoset (↑g₁ : G) P.H P.H :=
+    hg₁d ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
+  rw [doubleCoset_eq_iUnion_leftCosets] at hd_in_g₁
+  simp only [Set.mem_iUnion] at hd_in_g₁
+  obtain ⟨k, hk⟩ := hd_in_g₁
+  rw [smul_eq_singleton_mul] at hk
+  obtain ⟨j₀⟩ := one_in_decompQuot_one P
+  refine ⟨⟨(k, j₀), ?_⟩⟩
+  simp only [Set.mem_setOf_eq]
+  have hmem : (j₀.out : G) * ((HeckeCoset.one P).rep : G) ∈ P.H :=
+    Subgroup.mul_mem _ (SetLike.coe_mem j₀.out) (HeckeCoset.one_rep_mem_H P)
+  rw [mul_assoc, Subgroup.singleton_mul_subgroup hmem]
+  apply (leftCoset_eq_of_not_disjoint (H := P.H) _ _ _).symm
+  rw [not_disjoint_iff]
+  refine ⟨↑d, Set.mem_smul_set.mpr ⟨1, P.H.one_mem, by simp⟩, ?_⟩
+  rw [Set.mem_smul_set]
+  rw [singleton_mul] at hk
+  simp only [image_mul_left, mem_preimage, SetLike.mem_coe] at hk
+  exact ⟨(↑k.out * (↑g₁ : G))⁻¹ * ↑d, hk,
+    show (↑k.out * (↑g₁ : G)) * ((↑k.out * ↑g₁)⁻¹ * ↑d) = ↑d by group⟩
+
+/-- Right multiplication by the identity double coset sends every pair of representatives
+to `⟦g₁⟧`. -/
+lemma mulMap_mul_one_eq (g₁ : P.Δ) (i : decompQuot P g₁)
+    (j : decompQuot P (HeckeCoset.one P).rep) :
+    mulMap P g₁ (HeckeCoset.one P).rep (i, j) = (⟦g₁⟧ : HeckeCoset P) := by
+  unfold mulMap
+  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
+  rw [HeckeCoset.eq_iff]
+  dsimp only
+  rw [mul_assoc, doubleCoset_mul_left_eq_self]
+  apply doubleCoset_mul_right_eq_self P
+    ⟨j.out * (HeckeCoset.one P).rep,
+      Subgroup.mul_mem _ (by simp) (HeckeCoset.one_rep_mem_H P)⟩
+
+/-- Right multiplication by `HeckeCoset.one` has multiplicity `1` on the diagonal and `0`
+elsewhere. -/
+lemma heckeMultiplicity_mul_one (g₁ d : P.Δ) :
+    (⟦g₁⟧ : HeckeCoset P) = ⟦d⟧ ↔
+      heckeMultiplicity P g₁ (HeckeCoset.one P).rep d = 1 := by
+  constructor
+  · intro h
+    have hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
+        DoubleCoset.doubleCoset (d : G) P.H P.H := (HeckeCoset.eq_iff g₁ d).mp h
+    simp only [heckeMultiplicity]
+    norm_cast
+    rw [Nat.card_eq_one_iff_unique]
+    have : Subsingleton (decompQuot P (HeckeCoset.one P).rep) :=
+      subsingleton_decompQuot_one P
+    refine ⟨⟨?_⟩, nonempty_mul_one_witness_of_doubleCoset_eq P g₁ d hg₁d⟩
+    intro ⟨⟨i₁, j₁⟩, h₁⟩ ⟨⟨i₂, j₂⟩, h₂⟩
+    have hj : j₁ = j₂ := Subsingleton.elim j₁ j₂
+    subst hj
+    simp only [Set.mem_setOf_eq] at h₁ h₂
+    exact Subtype.ext (Prod.ext
+      (decompQuot_fst_eq_of_snd_mem_H P g₁ (HeckeCoset.one P).rep d i₁ i₂ j₁
+        (Subgroup.mul_mem _ (SetLike.coe_mem j₁.out) (HeckeCoset.one_rep_mem_H P)) h₁ h₂)
+      rfl)
+  · intro hm
+    by_contra hne
+    have : heckeMultiplicity P g₁ (HeckeCoset.one P).rep d = 0 := by
+      simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
+      left
+      intro ⟨i, j⟩ heq
+      exact hne ((mulMap_mul_one_eq P g₁ i j).symm.trans
+        (doubleCoset_eq_of_rightCoset_eq P g₁ (HeckeCoset.one P).rep d (i, j) heq))
+    omega
+
+/-- Left multiplication by the identity double coset sends every pair of representatives
+to `⟦g₁⟧`. -/
+lemma mulMap_one_mul_eq (g₁ : P.Δ) (i : decompQuot P (HeckeCoset.one P).rep)
+    (j : decompQuot P g₁) :
+    mulMap P (HeckeCoset.one P).rep g₁ (i, j) = (⟦g₁⟧ : HeckeCoset P) := by
+  unfold mulMap
+  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
+  rw [HeckeCoset.eq_iff]
+  dsimp only
+  rw [mul_assoc]
+  simp_rw [doubleCoset_mul_left_eq_self,
+    doubleCoset_mul_left_eq_self P ⟨(HeckeCoset.one P).rep, HeckeCoset.one_rep_mem_H P⟩,
+    doubleCoset_mul_left_eq_self]
+
+/-- If `Hg₁H = HdH`, the fibre defining the multiplicity for left multiplication by the
+identity double coset is nonempty. -/
+private lemma nonempty_one_mul_witness_of_doubleCoset_eq (g₁ d : P.Δ)
+    (hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
+      DoubleCoset.doubleCoset (d : G) P.H P.H) :
+    Nonempty ↑{x : decompQuot P (HeckeCoset.one P).rep × decompQuot P g₁ |
+      ({(↑x.1.out : G) * (↑(HeckeCoset.one P).rep : G)} : Set G) *
+        {(↑x.2.out : G) * (↑g₁ : G)} * P.H = {(↑d : G)} * (P.H : Set G)} := by
+  have hd_in : (↑d : G) ∈ doubleCoset (↑g₁ : G) P.H P.H :=
+    hg₁d ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
+  rw [doubleCoset_eq_iUnion_leftCosets] at hd_in
+  simp only [Set.mem_iUnion] at hd_in
+  obtain ⟨j', hj'⟩ := hd_in
+  rw [smul_eq_singleton_mul, singleton_mul] at hj'
+  simp only [image_mul_left, mem_preimage, SetLike.mem_coe] at hj'
+  obtain ⟨i₀⟩ := one_in_decompQuot_one P
+  have h₀_mem : (↑i₀.out : G) * ((HeckeCoset.one P).rep : G) ∈ P.H :=
+    Subgroup.mul_mem _ (SetLike.coe_mem i₀.out) (HeckeCoset.one_rep_mem_H P)
+  set h₀ := ↑i₀.out * ((HeckeCoset.one P).rep : G) with hh₀_def
+  set j₀ : decompQuot P g₁ :=
+    ⟦⟨h₀⁻¹ * ↑j'.out, P.H.mul_mem (P.H.inv_mem h₀_mem) j'.out.2⟩⟧
+  obtain ⟨n, hn_eq⟩ := QuotientGroup.mk_out_eq_mul
+    ((ConjAct.toConjAct (↑g₁ : G) • P.H).subgroupOf P.H)
+    ⟨h₀⁻¹ * ↑j'.out, P.H.mul_mem (P.H.inv_mem h₀_mem) j'.out.2⟩
+  have hn_coe : (j₀.out : G) = h₀⁻¹ * ↑j'.out * (n : G) := by
+    have := congr_arg (Subtype.val : ↥P.H → G) hn_eq
+    simpa [Subgroup.coe_mul] using this
+  have hn_conj : (↑g₁ : G)⁻¹ * (n : G) * ↑g₁ ∈ P.H :=
+    inv_mul_mul_mem_of_mem_subgroupOf P.H n
+  refine ⟨⟨(i₀, j₀), ?_⟩⟩
+  simp only [Set.mem_setOf_eq, Set.singleton_mul_singleton]
+  apply (leftCoset_eq_of_not_disjoint (H := P.H) _ _ _).symm
+  rw [not_disjoint_iff]
+  refine ⟨↑d, Set.mem_smul_set.mpr ⟨1, P.H.one_mem, by simp⟩, ?_⟩
+  rw [Set.mem_smul_set]
+  refine ⟨(h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d, ?_, by
+    change (↑i₀.out * (HeckeCoset.one P).rep * (↑j₀.out * (↑g₁ : G))) *
+      ((h₀ * ↑j₀.out * ↑g₁)⁻¹ * ↑d) = ↑d
+    simp only [hh₀_def]
+    group⟩
+  change (h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d ∈ P.H
+  have key : (h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d =
+      ((↑g₁ : G)⁻¹ * (↑n : G)⁻¹ * ↑g₁) *
+        ((↑j'.out * (↑g₁ : G))⁻¹ * ↑d) := by
+    rw [hn_coe]
+    group
+  rw [key]
+  exact P.H.mul_mem (by convert P.H.inv_mem hn_conj using 1; group) hj'
+
+/-- Left multiplication by `HeckeCoset.one` has multiplicity `1` on the diagonal and `0`
+elsewhere. -/
+lemma heckeMultiplicity_one_mul (g₁ d : P.Δ) :
+    (⟦g₁⟧ : HeckeCoset P) = ⟦d⟧ ↔
+      heckeMultiplicity P (HeckeCoset.one P).rep g₁ d = 1 := by
+  constructor
+  · intro h
+    have hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
+        DoubleCoset.doubleCoset (d : G) P.H P.H := (HeckeCoset.eq_iff g₁ d).mp h
+    simp only [heckeMultiplicity]
+    norm_cast
+    rw [Nat.card_eq_one_iff_unique]
+    have : Subsingleton (decompQuot P (HeckeCoset.one P).rep) :=
+      subsingleton_decompQuot_one P
+    refine ⟨⟨?_⟩, nonempty_one_mul_witness_of_doubleCoset_eq P g₁ d hg₁d⟩
+    intro ⟨⟨i₁, j₁⟩, h₁⟩ ⟨⟨i₂, j₂⟩, h₂⟩
+    have hi : i₁ = i₂ := Subsingleton.elim i₁ i₂
+    subst hi
+    simp only [Set.mem_setOf_eq] at h₁ h₂
+    exact Subtype.ext (Prod.ext rfl
+      (decompQuot_snd_eq_of_fst_eq P (HeckeCoset.one P).rep g₁ d i₁ j₁ j₂ h₁ h₂))
+  · intro hm
+    by_contra hne
+    have : heckeMultiplicity P (HeckeCoset.one P).rep g₁ d = 0 := by
+      simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
+      left
+      intro ⟨i, j⟩ heq
+      exact hne ((mulMap_one_mul_eq P g₁ i j).symm.trans
+        (doubleCoset_eq_of_rightCoset_eq P (HeckeCoset.one P).rep g₁ d (i, j) heq))
+    omega
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
@@ -10,207 +10,145 @@ public import Mathlib.NumberTheory.HeckeRing.Multiplicity
 /-!
 # Hecke rings: the multiplicity of the identity double coset
 
-The identity double coset `HeckeCoset.one` acts as the unit for the Hecke product. This file proves
-the two computations that express this at the level of Shimura's multiplicity: for the identity on
-either side, `heckeMultiplicity` is `1` exactly on the diagonal `⟦g⟧ = ⟦d⟧` and `0` elsewhere.
+For `e ∈ Γ₂` the double coset `Γ₂eΓ₂` is `Γ₂` itself, the identity of the Hecke ring of `Γ₂`;
+this file proves the two computations expressing this at the level of Shimura's multiplicity:
+multiplying by such an `e` on either side, the multiplicity is `1` exactly on the diagonal
+`Γ₁gΓ₂ = Γ₁dΓ₂`. Specialised to a Hecke pair, these compute the products `T(g) * T(1)` and
+`T(1) * T(g)` in later files.
 
 ## Main results
 
-* `HeckeRing.heckeMultiplicity_mul_one`: `⟦g⟧ = ⟦d⟧ ↔ heckeMultiplicity g (one).rep d = 1`.
-* `HeckeRing.heckeMultiplicity_one_mul`: `⟦g⟧ = ⟦d⟧ ↔ heckeMultiplicity (one).rep g d = 1`.
+* `DoubleCoset.multiplicity_eq_one_iff_of_mem_right`: for `e ∈ Γ₂`,
+  `multiplicity Γ₁ Γ₂ Γ₂ g e d = 1 ↔ Γ₁gΓ₂ = Γ₁dΓ₂`.
+* `DoubleCoset.multiplicity_eq_one_iff_of_mem_left`: for `e ∈ Γ₁`,
+  `multiplicity Γ₁ Γ₁ Γ₂ e g d = 1 ↔ Γ₁gΓ₂ = Γ₁dΓ₂`.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup
+open Subgroup
 open scoped Pointwise
 
-namespace HeckeRing
+namespace DoubleCoset
 
-variable {G : Type*} [Group G]
+variable {G : Type*} [Group G] {Γ₁ Γ₂ : Subgroup G}
 
-attribute [local instance] doubleCosetSetoid
+/-- Every pair of representatives multiplies into the coset of `g` when the second element
+lies in `Γ₂`. -/
+private lemma exists_fibre_of_mem_right {g e d : G} (he : e ∈ Γ₂)
+    (hd : d ∈ doubleCoset g Γ₁ Γ₂) :
+    ∃ p : DecompQuotient Γ₁ Γ₂ g × DecompQuotient Γ₂ Γ₂ e,
+      ((p.1.out : G) * g * ((p.2.out : G) * e) : G ⧸ Γ₂) = (d : G ⧸ Γ₂) := by
+  rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hd
+  obtain ⟨i₀, hi₀⟩ := hd
+  obtain ⟨j₀⟩ : Nonempty (DecompQuotient Γ₂ Γ₂ e) := inferInstance
+  rw [mem_leftCoset_iff] at hi₀
+  refine ⟨(i₀, j₀), ?_⟩
+  rw [QuotientGroup.mk_mul_of_mem _ (Γ₂.mul_mem j₀.out.2 he), QuotientGroup.eq]
+  exact hi₀
 
-/-- Membership in `(ConjAct.toConjAct a • H).subgroupOf H` unfolds to conjugation by `a`
-landing back in `H`. -/
-lemma inv_mul_mul_mem_of_mem_subgroupOf (H : Subgroup G) {a : G}
-    (x : (ConjAct.toConjAct a • H).subgroupOf H) : a⁻¹ * (x.val : G) * a ∈ H := by
-  have := x.2
-  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
-    ConjAct.smul_def] at this
-  simpa [ConjAct.ofConjAct_toConjAct] using this
+private lemma exists_fibre_of_mem_left {e g d : G} (he : e ∈ Γ₁)
+    (hd : d ∈ doubleCoset g Γ₁ Γ₂) :
+    ∃ p : DecompQuotient Γ₁ Γ₁ e × DecompQuotient Γ₁ Γ₂ g,
+      ((p.1.out : G) * e * ((p.2.out : G) * g) : G ⧸ Γ₂) = (d : G ⧸ Γ₂) := by
+  obtain ⟨i₀⟩ : Nonempty (DecompQuotient Γ₁ Γ₁ e) := inferInstance
+  set a := (i₀.out : G) * e with ha_def
+  have ha : a ∈ Γ₁ := Γ₁.mul_mem i₀.out.2 he
+  have hd' : a⁻¹ * d ∈ doubleCoset g Γ₁ Γ₂ := by
+    obtain ⟨h₁, hh₁, h₂, hh₂, rfl⟩ := mem_doubleCoset.mp hd
+    exact mem_doubleCoset.mpr ⟨a⁻¹ * h₁, Γ₁.mul_mem (Γ₁.inv_mem ha) hh₁, h₂, hh₂,
+      by simp [mul_assoc]⟩
+  rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hd'
+  obtain ⟨j₀, hj₀⟩ := hd'
+  rw [mem_leftCoset_iff] at hj₀
+  refine ⟨(i₀, j₀), ?_⟩
+  rw [QuotientGroup.eq]
+  simpa [ha_def, mul_assoc] using hj₀
 
-variable (P : HeckePair G)
-
-/-- If `Hg₁H = HdH`, the fibre defining the multiplicity for right multiplication by the
-identity double coset is nonempty. -/
-private lemma nonempty_mul_one_witness_of_doubleCoset_eq (g₁ d : P.Δ)
-    (hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
-      DoubleCoset.doubleCoset (d : G) P.H P.H) :
-    Nonempty ↑{x : decompQuot P g₁ × decompQuot P (HeckeCoset.one P).rep |
-      ({(↑x.1.out : G) * (↑g₁ : G)} : Set G) *
-        {(↑x.2.out : G) * (↑(HeckeCoset.one P).rep : G)} * P.H =
-        {(↑d : G)} * (P.H : Set G)} := by
-  have hd_in_g₁ : (↑d : G) ∈ doubleCoset (↑g₁ : G) P.H P.H :=
-    hg₁d ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
-  rw [doubleCoset_eq_iUnion_leftCosets] at hd_in_g₁
-  simp only [Set.mem_iUnion] at hd_in_g₁
-  obtain ⟨k, hk⟩ := hd_in_g₁
-  rw [smul_eq_singleton_mul] at hk
-  obtain ⟨j₀⟩ := one_in_decompQuot_one P
-  refine ⟨⟨(k, j₀), ?_⟩⟩
-  simp only [Set.mem_setOf_eq]
-  have hmem : (j₀.out : G) * ((HeckeCoset.one P).rep : G) ∈ P.H :=
-    Subgroup.mul_mem _ (SetLike.coe_mem j₀.out) (HeckeCoset.one_rep_mem_H P)
-  rw [mul_assoc, Subgroup.singleton_mul_subgroup hmem]
-  apply (leftCoset_eq_of_not_disjoint (H := P.H) _ _ _).symm
-  rw [not_disjoint_iff]
-  refine ⟨↑d, Set.mem_smul_set.mpr ⟨1, P.H.one_mem, by simp⟩, ?_⟩
-  rw [Set.mem_smul_set]
-  rw [singleton_mul] at hk
-  simp only [image_mul_left, mem_preimage, SetLike.mem_coe] at hk
-  exact ⟨(↑k.out * (↑g₁ : G))⁻¹ * ↑d, hk,
-    show (↑k.out * (↑g₁ : G)) * ((↑k.out * ↑g₁)⁻¹ * ↑d) = ↑d by group⟩
-
-/-- Right multiplication by the identity double coset sends every pair of representatives
-to `⟦g₁⟧`. -/
-lemma mulMap_mul_one_eq (g₁ : P.Δ) (i : decompQuot P g₁)
-    (j : decompQuot P (HeckeCoset.one P).rep) :
-    mulMap P g₁ (HeckeCoset.one P).rep (i, j) = (⟦g₁⟧ : HeckeCoset P) := by
-  unfold mulMap
-  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
-  rw [HeckeCoset.eq_iff]
-  dsimp only
-  rw [mul_assoc, doubleCoset_mul_left_eq_self]
-  apply doubleCoset_mul_right_eq_self P
-    ⟨j.out * (HeckeCoset.one P).rep,
-      Subgroup.mul_mem _ (by simp) (HeckeCoset.one_rep_mem_H P)⟩
-
-/-- Right multiplication by `HeckeCoset.one` has multiplicity `1` on the diagonal and `0`
-elsewhere. -/
-lemma heckeMultiplicity_mul_one (g₁ d : P.Δ) :
-    (⟦g₁⟧ : HeckeCoset P) = ⟦d⟧ ↔
-      heckeMultiplicity P g₁ (HeckeCoset.one P).rep d = 1 := by
+/-- For `e ∈ Γ₂`, right multiplication by the identity double coset `Γ₂eΓ₂ = Γ₂` has
+multiplicity `1` exactly on the diagonal. -/
+theorem multiplicity_eq_one_iff_of_mem_right {g e d : G} (he : e ∈ Γ₂) :
+    multiplicity Γ₁ Γ₂ Γ₂ g e d = 1 ↔ doubleCoset g Γ₁ Γ₂ = doubleCoset d Γ₁ Γ₂ := by
+  rw [multiplicity, Nat.card_eq_one_iff_unique]
   constructor
+  · rintro ⟨-, ⟨p, hp⟩⟩
+    have hp' : _ = (d : G ⧸ Γ₂) := hp
+    rw [QuotientGroup.mk_mul_of_mem _ (Γ₂.mul_mem p.2.out.2 he), QuotientGroup.eq] at hp'
+    exact (doubleCoset_eq_of_mem (mem_doubleCoset.mpr
+      ⟨(p.1.out : G), p.1.out.2, _, hp', (mul_inv_cancel_left _ _).symm⟩)).symm
   · intro h
-    have hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
-        DoubleCoset.doubleCoset (d : G) P.H P.H := (HeckeCoset.eq_iff g₁ d).mp h
-    simp only [heckeMultiplicity]
-    norm_cast
-    rw [Nat.card_eq_one_iff_unique]
-    have : Subsingleton (decompQuot P (HeckeCoset.one P).rep) :=
-      subsingleton_decompQuot_one P
-    refine ⟨⟨?_⟩, nonempty_mul_one_witness_of_doubleCoset_eq P g₁ d hg₁d⟩
-    intro ⟨⟨i₁, j₁⟩, h₁⟩ ⟨⟨i₂, j₂⟩, h₂⟩
-    have hj : j₁ = j₂ := Subsingleton.elim j₁ j₂
-    subst hj
-    simp only [Set.mem_setOf_eq] at h₁ h₂
-    exact Subtype.ext (Prod.ext
-      (decompQuot_fst_eq_of_snd_mem_H P g₁ (HeckeCoset.one P).rep d i₁ i₂ j₁
-        (Subgroup.mul_mem _ (SetLike.coe_mem j₁.out) (HeckeCoset.one_rep_mem_H P)) h₁ h₂)
-      rfl)
-  · intro hm
-    by_contra hne
-    have : heckeMultiplicity P g₁ (HeckeCoset.one P).rep d = 0 := by
-      simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
-      left
-      intro ⟨i, j⟩ heq
-      exact hne ((mulMap_mul_one_eq P g₁ i j).symm.trans
-        (doubleCoset_eq_of_rightCoset_eq P g₁ (HeckeCoset.one P).rep d (i, j) heq))
-    omega
+    haveI := subsingleton_decompQuotient_of_mem he
+    obtain ⟨p, hp⟩ := exists_fibre_of_mem_right he (h ▸ mem_doubleCoset_self Γ₁ Γ₂ d)
+    refine ⟨⟨fun q₁ q₂ ↦ Subtype.ext ?_⟩, ⟨p, hp⟩⟩
+    have hsnd : q₁.1.2 = q₂.1.2 := Subsingleton.elim _ _
+    have h₁ : _ = (d : G ⧸ Γ₂) := q₁.2
+    have h₂ : _ = (d : G ⧸ Γ₂) := q₂.2
+    rw [← hsnd] at h₂
+    exact Prod.ext (fst_eq_of_mul_snd_mem (Γ₂.mul_mem q₁.1.2.out.2 he) h₁ h₂) hsnd
 
-/-- Left multiplication by the identity double coset sends every pair of representatives
-to `⟦g₁⟧`. -/
-lemma mulMap_one_mul_eq (g₁ : P.Δ) (i : decompQuot P (HeckeCoset.one P).rep)
-    (j : decompQuot P g₁) :
-    mulMap P (HeckeCoset.one P).rep g₁ (i, j) = (⟦g₁⟧ : HeckeCoset P) := by
-  unfold mulMap
-  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
-  rw [HeckeCoset.eq_iff]
-  dsimp only
-  rw [mul_assoc]
-  simp_rw [doubleCoset_mul_left_eq_self,
-    doubleCoset_mul_left_eq_self P ⟨(HeckeCoset.one P).rep, HeckeCoset.one_rep_mem_H P⟩,
-    doubleCoset_mul_left_eq_self]
-
-/-- If `Hg₁H = HdH`, the fibre defining the multiplicity for left multiplication by the
-identity double coset is nonempty. -/
-private lemma nonempty_one_mul_witness_of_doubleCoset_eq (g₁ d : P.Δ)
-    (hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
-      DoubleCoset.doubleCoset (d : G) P.H P.H) :
-    Nonempty ↑{x : decompQuot P (HeckeCoset.one P).rep × decompQuot P g₁ |
-      ({(↑x.1.out : G) * (↑(HeckeCoset.one P).rep : G)} : Set G) *
-        {(↑x.2.out : G) * (↑g₁ : G)} * P.H = {(↑d : G)} * (P.H : Set G)} := by
-  have hd_in : (↑d : G) ∈ doubleCoset (↑g₁ : G) P.H P.H :=
-    hg₁d ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
-  rw [doubleCoset_eq_iUnion_leftCosets] at hd_in
-  simp only [Set.mem_iUnion] at hd_in
-  obtain ⟨j', hj'⟩ := hd_in
-  rw [smul_eq_singleton_mul, singleton_mul] at hj'
-  simp only [image_mul_left, mem_preimage, SetLike.mem_coe] at hj'
-  obtain ⟨i₀⟩ := one_in_decompQuot_one P
-  have h₀_mem : (↑i₀.out : G) * ((HeckeCoset.one P).rep : G) ∈ P.H :=
-    Subgroup.mul_mem _ (SetLike.coe_mem i₀.out) (HeckeCoset.one_rep_mem_H P)
-  set h₀ := ↑i₀.out * ((HeckeCoset.one P).rep : G) with hh₀_def
-  set j₀ : decompQuot P g₁ :=
-    ⟦⟨h₀⁻¹ * ↑j'.out, P.H.mul_mem (P.H.inv_mem h₀_mem) j'.out.2⟩⟧
-  obtain ⟨n, hn_eq⟩ := QuotientGroup.mk_out_eq_mul
-    ((ConjAct.toConjAct (↑g₁ : G) • P.H).subgroupOf P.H)
-    ⟨h₀⁻¹ * ↑j'.out, P.H.mul_mem (P.H.inv_mem h₀_mem) j'.out.2⟩
-  have hn_coe : (j₀.out : G) = h₀⁻¹ * ↑j'.out * (n : G) := by
-    have := congr_arg (Subtype.val : ↥P.H → G) hn_eq
-    simpa [Subgroup.coe_mul] using this
-  have hn_conj : (↑g₁ : G)⁻¹ * (n : G) * ↑g₁ ∈ P.H :=
-    inv_mul_mul_mem_of_mem_subgroupOf P.H n
-  refine ⟨⟨(i₀, j₀), ?_⟩⟩
-  simp only [Set.mem_setOf_eq, Set.singleton_mul_singleton]
-  apply (leftCoset_eq_of_not_disjoint (H := P.H) _ _ _).symm
-  rw [not_disjoint_iff]
-  refine ⟨↑d, Set.mem_smul_set.mpr ⟨1, P.H.one_mem, by simp⟩, ?_⟩
-  rw [Set.mem_smul_set]
-  refine ⟨(h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d, ?_, by
-    change (↑i₀.out * (HeckeCoset.one P).rep * (↑j₀.out * (↑g₁ : G))) *
-      ((h₀ * ↑j₀.out * ↑g₁)⁻¹ * ↑d) = ↑d
-    simp only [hh₀_def]
-    group⟩
-  change (h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d ∈ P.H
-  have key : (h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d =
-      ((↑g₁ : G)⁻¹ * (↑n : G)⁻¹ * ↑g₁) *
-        ((↑j'.out * (↑g₁ : G))⁻¹ * ↑d) := by
-    rw [hn_coe]
-    group
-  rw [key]
-  exact P.H.mul_mem (by convert P.H.inv_mem hn_conj using 1; group) hj'
-
-/-- Left multiplication by `HeckeCoset.one` has multiplicity `1` on the diagonal and `0`
-elsewhere. -/
-lemma heckeMultiplicity_one_mul (g₁ d : P.Δ) :
-    (⟦g₁⟧ : HeckeCoset P) = ⟦d⟧ ↔
-      heckeMultiplicity P (HeckeCoset.one P).rep g₁ d = 1 := by
+/-- For `e ∈ Γ₁`, left multiplication by the identity double coset `Γ₁eΓ₁ = Γ₁` has
+multiplicity `1` exactly on the diagonal. -/
+theorem multiplicity_eq_one_iff_of_mem_left {e g d : G} (he : e ∈ Γ₁) :
+    multiplicity Γ₁ Γ₁ Γ₂ e g d = 1 ↔ doubleCoset g Γ₁ Γ₂ = doubleCoset d Γ₁ Γ₂ := by
+  rw [multiplicity, Nat.card_eq_one_iff_unique]
   constructor
+  · rintro ⟨-, ⟨p, hp⟩⟩
+    have hp' : _ = (d : G ⧸ Γ₂) := hp
+    rw [QuotientGroup.eq] at hp'
+    exact (doubleCoset_eq_of_mem (mem_doubleCoset.mpr
+      ⟨(p.1.out : G) * e * p.2.out, Γ₁.mul_mem (Γ₁.mul_mem p.1.out.2 he) p.2.out.2, _, hp',
+        by simp [mul_assoc]⟩)).symm
   · intro h
-    have hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
-        DoubleCoset.doubleCoset (d : G) P.H P.H := (HeckeCoset.eq_iff g₁ d).mp h
-    simp only [heckeMultiplicity]
-    norm_cast
-    rw [Nat.card_eq_one_iff_unique]
-    have : Subsingleton (decompQuot P (HeckeCoset.one P).rep) :=
-      subsingleton_decompQuot_one P
-    refine ⟨⟨?_⟩, nonempty_one_mul_witness_of_doubleCoset_eq P g₁ d hg₁d⟩
-    intro ⟨⟨i₁, j₁⟩, h₁⟩ ⟨⟨i₂, j₂⟩, h₂⟩
-    have hi : i₁ = i₂ := Subsingleton.elim i₁ i₂
-    subst hi
-    simp only [Set.mem_setOf_eq] at h₁ h₂
-    exact Subtype.ext (Prod.ext rfl
-      (decompQuot_snd_eq_of_fst_eq P (HeckeCoset.one P).rep g₁ d i₁ j₁ j₂ h₁ h₂))
-  · intro hm
-    by_contra hne
-    have : heckeMultiplicity P (HeckeCoset.one P).rep g₁ d = 0 := by
-      simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
-      left
-      intro ⟨i, j⟩ heq
-      exact hne ((mulMap_one_mul_eq P g₁ i j).symm.trans
-        (doubleCoset_eq_of_rightCoset_eq P (HeckeCoset.one P).rep g₁ d (i, j) heq))
-    omega
+    haveI := subsingleton_decompQuotient_of_mem he
+    obtain ⟨p, hp⟩ := exists_fibre_of_mem_left he (h ▸ mem_doubleCoset_self Γ₁ Γ₂ d)
+    refine ⟨⟨fun q₁ q₂ ↦ Subtype.ext ?_⟩, ⟨p, hp⟩⟩
+    have hfst : q₁.1.1 = q₂.1.1 := Subsingleton.elim _ _
+    have h₁ : _ = (d : G ⧸ Γ₂) := q₁.2
+    have h₂ : _ = (d : G ⧸ Γ₂) := q₂.2
+    rw [← hfst] at h₂
+    exact Prod.ext hfst (snd_eq_of_fst_eq h₁ h₂)
 
-end HeckeRing
+end DoubleCoset
+
+namespace HeckePair
+
+open DoubleCoset
+
+variable {G : Type*} [Group G] (P : HeckePair G)
+
+attribute [local instance] HeckePair.doubleCosetSetoid
+
+/-- Every pair of representatives multiplies into `⟦g₁⟧` when the second double coset is the
+identity. -/
+lemma mulMap_one_right (g₁ : P.Δ)
+    (p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H ((1 : HeckeCoset P).rep : G)) :
+    P.mulMap g₁ (1 : HeckeCoset P).rep p = (⟦g₁⟧ : HeckeCoset P) :=
+  HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr ⟨(p.1.out : G), p.1.out.2,
+    (p.2.out : G) * ((1 : HeckeCoset P).rep : G),
+    P.H.mul_mem p.2.out.2 HeckeCoset.rep_one_mem, rfl⟩)
+
+/-- Every pair of representatives multiplies into `⟦g₁⟧` when the first double coset is the
+identity. -/
+lemma mulMap_one_left (g₁ : P.Δ)
+    (p : DecompQuotient P.H P.H ((1 : HeckeCoset P).rep : G) × DecompQuotient P.H P.H (g₁ : G)) :
+    P.mulMap (1 : HeckeCoset P).rep g₁ p = (⟦g₁⟧ : HeckeCoset P) :=
+  HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
+    ⟨(p.1.out : G) * ((1 : HeckeCoset P).rep : G) * (p.2.out : G),
+      P.H.mul_mem (P.H.mul_mem p.1.out.2 HeckeCoset.rep_one_mem) p.2.out.2, 1, P.H.one_mem,
+      by simp [mul_assoc]⟩)
+
+/-- Right multiplication by the identity double coset has multiplicity `1` exactly on the
+diagonal. -/
+theorem multiplicity_mul_one (g d : P.Δ) :
+    multiplicity P.H P.H P.H (g : G) ((1 : HeckeCoset P).rep : G) (d : G) = 1 ↔
+      (⟦g⟧ : HeckeCoset P) = ⟦d⟧ := by
+  rw [multiplicity_eq_one_iff_of_mem_right HeckeCoset.rep_one_mem, HeckeCoset.eq_iff]
+
+/-- Left multiplication by the identity double coset has multiplicity `1` exactly on the
+diagonal. -/
+theorem multiplicity_one_mul (g d : P.Δ) :
+    multiplicity P.H P.H P.H ((1 : HeckeCoset P).rep : G) (g : G) (d : G) = 1 ↔
+      (⟦g⟧ : HeckeCoset P) = ⟦d⟧ := by
+  rw [multiplicity_eq_one_iff_of_mem_left HeckeCoset.rep_one_mem, HeckeCoset.eq_iff]
+
+end HeckePair

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
@@ -13,8 +13,8 @@ public import Mathlib.NumberTheory.HeckeRing.Multiplicity
 For `e ∈ Γ₂` the double coset `Γ₂eΓ₂` is `Γ₂` itself, the identity of the Hecke ring of `Γ₂`;
 this file proves the two computations expressing this at the level of Shimura's multiplicity:
 multiplying by such an `e` on either side, the multiplicity is `1` exactly on the diagonal
-`Γ₁gΓ₂ = Γ₁dΓ₂`. Specialised to a Hecke pair, these compute the products `T(g) * T(1)` and
-`T(1) * T(g)` in later files.
+`Γ₁gΓ₂ = Γ₁dΓ₂`. Specialised to a Hecke coset module, these compute the products `T(g) * T(1)`
+and `T(1) * T(g)` in later files.
 
 ## Main results
 
@@ -110,45 +110,45 @@ theorem multiplicity_eq_one_iff_of_mem_left {e g d : G} (he : e ∈ Γ₁) :
 
 end DoubleCoset
 
-namespace HeckePair
+namespace HeckeCoset
 
 open DoubleCoset
 
-variable {G : Type*} [Group G] (P : HeckePair G)
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
 
-attribute [local instance] HeckePair.doubleCosetSetoid
-
-/-- Every pair of representatives multiplies into `⟦g₁⟧` when the second double coset is the
-identity. -/
-lemma mulMap_one_right (g₁ : P.Δ)
-    (p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H ((1 : HeckeCoset P).rep : G)) :
-    P.mulMap g₁ (1 : HeckeCoset P).rep p = (⟦g₁⟧ : HeckeCoset P) :=
+/-- Every pair of representatives multiplies into `mk H₁ H₂ g₁` when the second double coset is
+the identity. -/
+lemma mulMap_one_right [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₂] (g₁ : Δ)
+    (p : DecompQuotient H₁ H₂ (g₁ : G) ×
+      DecompQuotient H₂ H₂ (((1 : HeckeCoset Δ H₂ H₂).rep : G))) :
+    mulMap H₁ H₂ H₂ g₁ (1 : HeckeCoset Δ H₂ H₂).rep p = mk H₁ H₂ g₁ :=
   HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr ⟨(p.1.out : G), p.1.out.2,
-    (p.2.out : G) * ((1 : HeckeCoset P).rep : G),
-    P.H.mul_mem p.2.out.2 HeckeCoset.rep_one_mem, rfl⟩)
+    (p.2.out : G) * ((1 : HeckeCoset Δ H₂ H₂).rep : G),
+    H₂.mul_mem p.2.out.2 HeckeCoset.rep_one_mem, rfl⟩)
 
-/-- Every pair of representatives multiplies into `⟦g₁⟧` when the first double coset is the
-identity. -/
-lemma mulMap_one_left (g₁ : P.Δ)
-    (p : DecompQuotient P.H P.H ((1 : HeckeCoset P).rep : G) × DecompQuotient P.H P.H (g₁ : G)) :
-    P.mulMap (1 : HeckeCoset P).rep g₁ p = (⟦g₁⟧ : HeckeCoset P) :=
+/-- Every pair of representatives multiplies into `mk H₁ H₂ g₁` when the first double coset is
+the identity. -/
+lemma mulMap_one_left [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H₂] (g₁ : Δ)
+    (p : DecompQuotient H₁ H₁ (((1 : HeckeCoset Δ H₁ H₁).rep : G)) ×
+      DecompQuotient H₁ H₂ (g₁ : G)) :
+    mulMap H₁ H₁ H₂ (1 : HeckeCoset Δ H₁ H₁).rep g₁ p = mk H₁ H₂ g₁ :=
   HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
-    ⟨(p.1.out : G) * ((1 : HeckeCoset P).rep : G) * (p.2.out : G),
-      P.H.mul_mem (P.H.mul_mem p.1.out.2 HeckeCoset.rep_one_mem) p.2.out.2, 1, P.H.one_mem,
+    ⟨(p.1.out : G) * ((1 : HeckeCoset Δ H₁ H₁).rep : G) * (p.2.out : G),
+      H₁.mul_mem (H₁.mul_mem p.1.out.2 HeckeCoset.rep_one_mem) p.2.out.2, 1, H₂.one_mem,
       by simp [mul_assoc]⟩)
 
 /-- Right multiplication by the identity double coset has multiplicity `1` exactly on the
 diagonal. -/
-theorem multiplicity_mul_one (g d : P.Δ) :
-    multiplicity P.H P.H P.H (g : G) ((1 : HeckeCoset P).rep : G) (d : G) = 1 ↔
-      (⟦g⟧ : HeckeCoset P) = ⟦d⟧ := by
+theorem multiplicity_mul_one (g d : Δ) :
+    multiplicity H₁ H₂ H₂ (g : G) ((1 : HeckeCoset Δ H₂ H₂).rep : G) (d : G) = 1 ↔
+      mk H₁ H₂ g = mk H₁ H₂ d := by
   rw [multiplicity_eq_one_iff_of_mem_right HeckeCoset.rep_one_mem, HeckeCoset.eq_iff]
 
 /-- Left multiplication by the identity double coset has multiplicity `1` exactly on the
 diagonal. -/
-theorem multiplicity_one_mul (g d : P.Δ) :
-    multiplicity P.H P.H P.H ((1 : HeckeCoset P).rep : G) (g : G) (d : G) = 1 ↔
-      (⟦g⟧ : HeckeCoset P) = ⟦d⟧ := by
+theorem multiplicity_one_mul (g d : Δ) :
+    multiplicity H₁ H₁ H₂ ((1 : HeckeCoset Δ H₁ H₁).rep : G) (g : G) (d : G) = 1 ↔
+      mk H₁ H₂ g = mk H₁ H₂ d := by
   rw [multiplicity_eq_one_iff_of_mem_left HeckeCoset.rep_one_mem, HeckeCoset.eq_iff]
 
-end HeckePair
+end HeckeCoset

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
@@ -118,7 +118,7 @@ variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
 
 /-- Every pair of representatives multiplies into `mk H₁ H₂ g₁` when the second double coset is
 the identity. -/
-lemma mulMap_one_right [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₂] (g₁ : Δ)
+lemma mulMap_one_right [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₂] (g₁ : Δ)
     (p : DecompQuotient H₁ H₂ (g₁ : G) ×
       DecompQuotient H₂ H₂ (((1 : HeckeCoset Δ H₂ H₂).rep : G))) :
     mulMap H₁ H₂ H₂ g₁ (1 : HeckeCoset Δ H₂ H₂).rep p = mk H₁ H₂ g₁ :=
@@ -128,7 +128,7 @@ lemma mulMap_one_right [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ 
 
 /-- Every pair of representatives multiplies into `mk H₁ H₂ g₁` when the first double coset is
 the identity. -/
-lemma mulMap_one_left [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H₂] (g₁ : Δ)
+lemma mulMap_one_left [IsHeckeTriple Δ H₁ H₁] [IsHeckeTriple Δ H₁ H₂] (g₁ : Δ)
     (p : DecompQuotient H₁ H₁ (((1 : HeckeCoset Δ H₁ H₁).rep : G)) ×
       DecompQuotient H₁ H₂ (g₁ : G)) :
     mulMap H₁ H₁ H₂ (1 : HeckeCoset Δ H₁ H₁).rep g₁ p = mk H₁ H₂ g₁ :=

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -3661,6 +3661,21 @@
   school        = {University of British Columbia}
 }
 
+@Book{            krieg1990,
+  author        = {Krieg, Aloys},
+  title         = {Hecke algebras},
+  series        = {Memoirs of the American Mathematical Society},
+  volume        = {87},
+  number        = {435},
+  publisher     = {American Mathematical Society, Providence, RI},
+  year          = {1990},
+  pages         = {x+158},
+  issn          = {0065-9266},
+  mrnumber      = {1027069},
+  doi           = {10.1090/memo/0435},
+  url           = {https://doi.org/10.1090/memo/0435}
+}
+
 @Book{            kung_rota_yan2009,
   author        = {Kung, Joseph P. S. and Rota, Gian-Carlo and Yan, Catherine
                   H.},
@@ -5383,6 +5398,20 @@
   keywords      = {00B15,14-06},
   zbmath        = {3370272},
   zbl           = {0234.00007}
+}
+
+@Book{            shimura1971,
+  author        = {Shimura, Goro},
+  title         = {Introduction to the arithmetic theory of automorphic
+                  functions},
+  series        = {Publications of the Mathematical Society of Japan},
+  volume        = {11},
+  note          = {Kan\^{o} Memorial Lectures, No. 1},
+  publisher     = {Iwanami Shoten Publishers, Tokyo; Princeton University
+                  Press, Princeton, NJ},
+  year          = {1971},
+  pages         = {xiv+267},
+  mrnumber      = {0314766}
 }
 
 @Book{            sierpinski1958,


### PR DESCRIPTION
The support of Shimura's multiplicity: `DoubleCoset.multiplicity_ne_zero_iff : m(g, h; d) ≠ 0 ↔ d ∈ Γ₁gΓ₂hΓ₃` in mixed generality, and, for Hecke coset module data, the identification of the support of the structure constants with the (finite) image of `HeckeCoset.mulMap` — which is what makes the convolution product of Hecke coset modules well-defined in the next PR.

_Prepared by Claude._

- [ ] depends on: #41255