### PR TITLE
doc(LinearAlgebra/Dimension/Free): fix broken cross-reference in module docstring

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -14,7 +14,7 @@ public import Mathlib.SetTheory.Cardinal.Finsupp
 # Rank of free modules
 
 ## Main result
-- `Module.nonempty_equiv_iff_lift_rank_eq`:
+- `Module.nonempty_linearEquiv_iff_lift_rank_eq`:
   Two free modules are isomorphic iff they have the same dimension.
 - `Module.finBasis`:
   An arbitrary basis of a finite free module indexed by `Fin n` given `finrank R M = n`.


### PR DESCRIPTION
This PR corrects a broken cross-reference in the module docstring of `Mathlib/LinearAlgebra/Dimension/Free.lean`. PR #41211 renamed the lemma to `Module.nonempty_linearEquiv_iff_lift_rank_eq`, but left the "Main result" section of the module docstring pointing at the non-existent `Module.nonempty_equiv_iff_lift_rank_eq`. Update the reference to the correct name.

🤖 Prepared with Claude Code