### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Triangulated/WeakKernels): remove unused variable

### DIFF
--- a/Mathlib/CategoryTheory/Triangulated/WeakKernels.lean
+++ b/Mathlib/CategoryTheory/Triangulated/WeakKernels.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.CategoryTheory.Triangulated.Pretriangulated
 public import Mathlib.CategoryTheory.Limits.WeakLimits.WeakKernels
 
-
 /-!
 # Weak kernels in pretriangulated categories
 
@@ -29,8 +28,6 @@ open Limits Category Preadditive Pretriangulated
 
 variable {C : Type*} [Category* C] [Preadditive C] [HasZeroObject C] [HasShift C ℤ]
   [∀ n : ℤ, Functor.Additive (shiftFunctor C n)] [Pretriangulated C]
-
-variable {X Y : C} (f : X ⟶ Y)
 
 /-- If `T` is a distinguished triangle, then `T.mor₁` defines a kernel fork for `T.mor₂`. -/
 def kernelForkOfDistTriangle (T : Triangle C) (dT : T ∈ distTriang C) :


### PR DESCRIPTION
This PR removes an unused `variable {X Y : C} (f : X ⟶ Y)` line and a stray double blank line in `WeakKernels.lean`. Neither def in the file uses these binders (both take `T : Triangle C`, and the `HasWeakKernels` instance binds its own `f`), so the `variable` command is inert. A follow-up to https://github.com/leanprover-community/mathlib4/pull/41162.

🤖 Prepared with Claude Code