### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits/WeakLimits): fix weak pullbacks theorem name and docstrings

### DIFF
--- a/Mathlib/CategoryTheory/Limits/WeakLimits/WeakKernels.lean
+++ b/Mathlib/CategoryTheory/Limits/WeakLimits/WeakKernels.lean
@@ -12,7 +12,7 @@ public import Mathlib.CategoryTheory.Preadditive.Basic
 /-!
 # Weak kernels
 
-These are weak equalizes for functors of the form `ParallelPair f 0`.
+These are weak equalizers for functors of the form `parallelPair f 0`.
 
 If the category is preadditive, then weak equalizers exist if and only if weak kernels exist.
 (See `hasWeakEqualizer_of_hasWeakKernel` and `hasWeakKernel_of_hasWeakEqualizer`.)

--- a/Mathlib/CategoryTheory/Limits/WeakLimits/WeakPullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/WeakLimits/WeakPullbacks.lean
@@ -12,8 +12,8 @@ public import Mathlib.CategoryTheory.Limits.WeakLimits.WeakEqualizers
 
 These are weak limits for diagrams of shape `WalkingCospan`.
 
-If a category has binary products and weak equalizers, then it has weak kernels
-(see `hasWeakPullbacks_of_hasBinaryProducts_of_hasWeakKernels`).
+If a category has binary products and weak equalizers, then it has weak pullbacks
+(see `hasWeakPullbacks_of_hasBinaryProducts_of_hasWeakEqualizers`).
 
 -/
 
@@ -211,7 +211,7 @@ def weakPullbackIsWeakPullback {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasWeakP
 
 variable (C)
 
-/-- A category `HasPullbacks` if it has all weak limits of shape `WalkingCospan`, i.e. if it
+/-- A category `HasWeakPullbacks` if it has all weak limits of shape `WalkingCospan`, i.e. if it
 has a weak pullback for every pair of morphisms with the same codomain. -/
 abbrev HasWeakPullbacks :=
   HasWeakLimitsOfShape WalkingCospan C
@@ -242,7 +242,7 @@ attribute [local instance] hasWeakLimit_cospan_of_hasLimit_pair_of_hasWeakLimit_
 /-- If a category has all binary products and all weak equalizers, then it also has all
 weak pullbacks. As usual, this is not an instance, since there may be a more direct way to
 construct weak pullbacks. -/
-theorem hasWeakPullbacks_of_hasBinaryProducts_of_hasWeakKernels
+theorem hasWeakPullbacks_of_hasBinaryProducts_of_hasWeakEqualizers
     [HasBinaryProducts C] [HasWeakEqualizers C] : HasWeakPullbacks C where
   hasWeakLimit F := hasWeakLimit_of_iso (diagramIsoCospan F).symm
 


### PR DESCRIPTION
This PR renames `hasWeakPullbacks_of_hasBinaryProducts_of_hasWeakKernels` to `hasWeakPullbacks_of_hasBinaryProducts_of_hasWeakEqualizers`, since its hypothesis is `HasWeakEqualizers`, not weak kernels, and fixes several docstring typos in `WeakPullbacks.lean` and `WeakKernels.lean`. These are follow-ups to https://github.com/leanprover-community/mathlib4/pull/41075.

🤖 Prepared with Claude Code