### PR TITLE
[Merged by Bors] - refactor(Archive/Imo/Imo2000Q2): replace SOS certificate with classical AM-GM argument

### DIFF
--- a/Archive/Imo/Imo2000Q2.lean
+++ b/Archive/Imo/Imo2000Q2.lean
@@ -17,21 +17,14 @@ We follow the first solution from
 <https://artofproblemsolving.com/wiki/index.php?title=2000_IMO_Problems/Problem_2>.
 
 We parametrize `A = x / y`, `B = y / z`, `C = z / x` where `x, y, z > 0`.
-This reduces the problem to proving `(x - y + z)(y - z + x)(z - x + y) ≤ 8xyz`.
+This reduces the problem to proving `(x - y + z)(y - z + x)(z - x + y) ≤ xyz`.
 
-We then reparametrize `x = q + r`, `y = r + p`, `z = p + q` where `p, q, r ∈ ℝ`,
-which transforms the inequality to `8pqr ≤ (q + r)(r + p)(p + q)`.
-
-The proof splits into cases based on the signs of `p`, `q`, `r`.
-When all are positive, AM-GM gives the result.
-When at least one is negative or zero, the inequality is verified by sign analysis.
-
-## Implementation notes
-
-- The inequality is reduced via `A = x / y`, `B = y / z`, `C = z / x`, then the substitution
-  `x = q + r`, `y = r + p`, `z = p + q`.
-- Helper lemmas prove `8pqr ≤ (p + q)(r + p)(q + r)` by AM-GM when `p, q, r > 0` and by sign
-  analysis otherwise; the main proof closes with `grind`.
+Writing `u = x - y + z`, `v = y - z + x`, `w = z - x + y`, we have `u + v = 2x`,
+`v + w = 2y`, `w + u = 2z`, so any two of `u`, `v`, `w` have a positive sum and hence
+at most one of them can be nonpositive. If one is nonpositive the left-hand side is
+nonpositive and the inequality is clear. Otherwise all three are positive, and by AM-GM
+`uv ≤ ((u + v) / 2) ^ 2 = x ^ 2`, and similarly `vw ≤ y ^ 2` and `wu ≤ z ^ 2`; multiplying
+these gives `(uvw) ^ 2 ≤ (xyz) ^ 2`, from which the inequality follows.
 
 ## References
 
@@ -41,48 +34,39 @@ When at least one is negative or zero, the inequality is verified by sign analys
 
 namespace Imo2000Q2
 
-/-- When `p`, `q`, `r > 0`, `8pqr ≤ (p + q)(r + p)(q + r)`, by writing the difference of squares as
-a sum of nonnegative squares. -/
-lemma eight_mul_le_prod_add_of_pos {p q r : ℝ} (p_pos : 0 < p)
-    (q_pos : 0 < q) (r_pos : 0 < r) :
-    8 * p * q * r ≤ (p + q) * (q + r) * (r + p) := by
-  suffices 0 ≤ ((p + q) * (q + r) * (r + p)) ^ 2 - (8 * p * q * r) ^ 2 from
-    le_of_sq_le_sq (le_of_sub_nonneg this) (by positivity)
-  calc 0 ≤ (p * (q - r) ^ 2 + q * (r - p) ^ 2 + r * (p - q) ^ 2)
-             * ((p + q) * (q + r) * (r + p) + 8 * p * q * r) := by positivity
-       _ = ((p + q) * (q + r) * (r + p)) ^ 2 - (8 * p * q * r) ^ 2 := by ring
-
-/-- When `p ≤ 0` but `q`, `r > 0` and both pairwise sums are positive, the left side is
-nonpositive so the inequality holds. -/
-lemma eight_mul_le_prod_add_of_nonpos {p q r : ℝ} (p_nonpos : p ≤ 0) (r_pos : 0 < r) (q_pos : 0 < q)
-    (p_add_q_pos : 0 < p + q) (r_add_p_pos : 0 < r + p) :
-    8 * p * q * r ≤ (p + q) * (r + p) * (q + r) := by
-  calc 8 * p * q * r ≤ 0 := by grw [mul_nonpos_of_nonpos_of_nonneg ?_ (by positivity)]
-                               grw [mul_nonpos_of_nonpos_of_nonneg (by grind) (by positivity)]
-                   _ ≤ (p + q) * (r + p) * (q + r) := by positivity
-
-/-- When all three pairwise sums `p + q`, `r + p`, `q + r` are positive, the inequality holds by
-casing on the signs of `p`, `q`, `r`. -/
-lemma eight_mul_le_prod_add_of_add_pos (p q r : ℝ)
-    (hpq : 0 < p + q := by grind)
-    (hqr : 0 < q + r := by grind)
-    (hrp : 0 < r + p := by grind) :
-    8 * p * q * r ≤ (p + q) * (q + r) * (r + p) := by
-  rcases lt_or_ge 0 p with p_pos | p_nonpos <;>
-  rcases lt_or_ge 0 q with q_pos | q_nonpos <;>
-  rcases lt_or_ge 0 r with r_pos | r_nonpos
-  -- At most one of `p`, `q`, `r` can be negative; otherwise some pairwise sum is nonpositive.
-  · exact eight_mul_le_prod_add_of_pos p_pos q_pos r_pos
-  · -- `r` is the unique nonpositive variable.
-    convert eight_mul_le_prod_add_of_nonpos r_nonpos q_pos p_pos hrp hqr using 1 <;> ring
-  · -- `q` is the unique nonpositive variable.
-    convert eight_mul_le_prod_add_of_nonpos q_nonpos p_pos r_pos hqr hpq using 1 <;> ring
-  · linarith
-  · -- `p` is the unique nonpositive variable.
-    convert eight_mul_le_prod_add_of_nonpos p_nonpos r_pos q_pos hpq hrp using 1; ring
-  · linarith
-  · linarith
-  · linarith
+/-- For positive reals `x`, `y`, `z` we have `(x - y + z)(y - z + x)(z - x + y) ≤ xyz`. -/
+lemma prod_sub_add_le {x y z : ℝ} (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) :
+    (x - y + z) * (y - z + x) * (z - x + y) ≤ x * y * z := by
+  -- At most one of the three factors can be nonpositive, since any two of them
+  -- sum to twice one of `x`, `y`, `z`. If one is nonpositive, so is the product.
+  rcases le_or_gt (x - y + z) 0 with hu | hu
+  · have hv : 0 < y - z + x := by linarith
+    have hw : 0 < z - x + y := by linarith
+    calc (x - y + z) * (y - z + x) * (z - x + y)
+        ≤ 0 := mul_nonpos_of_nonpos_of_nonneg
+                (mul_nonpos_of_nonpos_of_nonneg hu hv.le) hw.le
+      _ ≤ x * y * z := by positivity
+  rcases le_or_gt (y - z + x) 0 with hv | hv
+  · have hw : 0 < z - x + y := by linarith
+    calc (x - y + z) * (y - z + x) * (z - x + y)
+        ≤ 0 := mul_nonpos_of_nonpos_of_nonneg
+                (mul_nonpos_of_nonneg_of_nonpos hu.le hv) hw.le
+      _ ≤ x * y * z := by positivity
+  rcases le_or_gt (z - x + y) 0 with hw | hw
+  · calc (x - y + z) * (y - z + x) * (z - x + y)
+        ≤ 0 := mul_nonpos_of_nonneg_of_nonpos (mul_nonneg hu.le hv.le) hw
+      _ ≤ x * y * z := by positivity
+  -- All three factors are positive. By AM-GM each pairwise product is bounded by a square:
+  have h1 : (x - y + z) * (y - z + x) ≤ x ^ 2 := by linarith [sq_nonneg (y - z)]
+  have h2 : (y - z + x) * (z - x + y) ≤ y ^ 2 := by linarith [sq_nonneg (z - x)]
+  have h3 : (z - x + y) * (x - y + z) ≤ z ^ 2 := by linarith [sq_nonneg (x - y)]
+  -- Multiplying the three bounds gives the squared inequality, and both sides are positive.
+  refine le_of_sq_le_sq ?_ (by positivity)
+  calc ((x - y + z) * (y - z + x) * (z - x + y)) ^ 2
+      = ((x - y + z) * (y - z + x)) * ((y - z + x) * (z - x + y))
+          * ((z - x + y) * (x - y + z)) := by ring
+    _ ≤ x ^ 2 * y ^ 2 * z ^ 2 := by gcongr
+    _ = (x * y * z) ^ 2 := by ring
 
 /-- **IMO 2000 Q2**. If `A`, `B`, `C > 0` and `ABC = 1`, then
 `(A - 1 + 1 / B)(B - 1 + 1 / C)(C - 1 + 1 / A) ≤ 1`. -/
@@ -92,9 +76,10 @@ theorem imo2000_q2 {A B C : ℝ}
   obtain ⟨x, y, z, x_pos, y_pos, z_pos, rfl, rfl, rfl⟩ :
       ∃ x y z, 0 < x ∧ 0 < y ∧ 0 < z ∧ A = x / y ∧ B = y / z ∧ C = z / x :=
     ⟨A, 1, 1 / B, by grind only [inv_pos]⟩
-  -- If `x = q + r`, `y = r + p`, `z = p + q`, it suffices to show `8pqr ≤ (q + r)(r + p)(p + q)`.
-  have := eight_mul_le_prod_add_of_add_pos ((y + z - x) / 2) ((z + x - y) / 2) ((x + y - z) / 2)
-  field_simp
-  grind
+  have key : (x / y - 1 + 1 / (y / z)) * (y / z - 1 + 1 / (z / x)) * (z / x - 1 + 1 / (x / y))
+      = (x - y + z) * (y - z + x) * (z - x + y) / (x * y * z) := by
+    field_simp
+  rw [key, div_le_one (by positivity)]
+  exact prod_sub_add_le x_pos y_pos z_pos
 
 end Imo2000Q2


### PR DESCRIPTION
This PR rewrites the proof of IMO 2000 Q2 from https://github.com/leanprover-community/mathlib4/pull/40286. It drops the second (Ravi) substitution and the SOS-solver-found certificate in favour of the classical argument: at most one of the three factors is nonpositive, and in the all-positive case each pairwise product is bounded by a square via AM-GM. One helper lemma instead of three, and every inequality step is a visible `sq_nonneg`. Supersedes #41263.

🤖 Prepared with Claude Code