### PR TITLE
refactor(Combinatorics/SimpleGraph/CycleGraph): golf cycleGraph_isContained_iff via getVert

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/CycleGraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/CycleGraph.lean
@@ -178,26 +178,22 @@ lemma cycleGraph_isContained_iff {n : ℕ} (hn : 2 < n) :
     refine ⟨h.toHom ⟨0, by lia⟩, Walk.map h.toHom <| cycleGraph.cycle (n - 3), ?_, ?_⟩
     · exact (map_isCycle_iff_of_injective h.injective).mpr cycleGraph.isCycle_cycle
     · simp [cycleGraph.length_cycle, ← this]
-  · obtain ⟨a, p, hp₁, hp₂⟩ := h'
-    refine ⟨⟨⟨fun n ↦ p.support[n.succ]'(?_), ?_⟩, ?_⟩⟩
-    · grind [hp₁.three_le_length, length_tail_add_one, not_nil_iff_lt_length]
-    · intro ⟨x, hx⟩ ⟨y, hy⟩ hab
-      have hne : x ≠ y := fun _ ↦ by simp_all
-      wlog hle : x > y
-      · exact this hn a p hp₁ hp₂ y hy x hx hab.symm hne.symm (by lia) |>.symm
-      rcases cycleGraph_adj'.mp hab with hab | hab
-      · simp_rw [show x = y + 1 by grind [Fin.sub_val_of_le]]
-        exact p.isChain_adj_support.getElem _ _ |>.symm
-      · rw [Fin.coe_sub_iff_lt.mpr hle] at hab
-        simp_rw [show x = n - 1 by lia, show y = 0 by lia, Fin.succ_mk, show n - 1 + 1 = n by lia]
-        simp [← hp₂, p.adj_snd hp₁.not_nil]
-    · have hlen : p.tail.support.length = n := by
-        grind [length_tail_add_one, not_nil_iff_lt_length]
-      have (m : Fin n) : p.support[m.succ]'(by grind) = p.tail.support[m] := by
-        simp [p.support_tail_of_not_nil hp₁.not_nil]
-      simp_rw [this]
-      have := IsPath.mk' <| (support_tail_of_not_nil _ hp₁.not_nil) ▸ hp₁.support_nodup
-      exact hlen ▸ (isPath_iff_injective_get_support _ |>.mp this)
+  · obtain ⟨u, p, hp, rfl⟩ := h'
+    -- The copy sends `i : Fin p.length` to the `i`-th vertex of the cycle `p`.
+    have key (i j : Fin p.length) (h : (j - i).val = 1) :
+        G.Adj (p.getVert i) (p.getVert j) := by
+      have hi := i.isLt
+      rcases Nat.lt_or_ge (j : ℕ) (i : ℕ) with hij | hij
+      · -- wraparound: `i` is the last vertex of `p` and `j` the first
+        rw [Fin.coe_sub_iff_lt.mpr (Fin.lt_def.mpr hij)] at h
+        rw [show (i : ℕ) = p.length - 1 by lia, show (j : ℕ) = 0 by lia, getVert_zero]
+        exact p.adj_penultimate hp.not_nil
+      · rw [show (j : ℕ) = i + 1 by rw [Fin.sub_val_of_le (Fin.le_def.mpr hij)] at h; lia]
+        exact p.adj_getVert_succ hi
+    exact ⟨⟨fun i ↦ p.getVert i,
+        fun hij ↦ (cycleGraph_adj'.mp hij).elim (fun h ↦ (key _ _ h).symm) (key _ _)⟩,
+      fun i j hij ↦ Fin.ext <| hp.getVert_injOn'
+        (Nat.le_sub_one_of_lt i.isLt) (Nat.le_sub_one_of_lt j.isLt) hij⟩
 
 end IsContained
 


### PR DESCRIPTION
This PR rewrites the reverse direction of `cycleGraph_isContained_iff` from https://github.com/leanprover-community/mathlib4/pull/35255. Building the copy on `Walk.getVert` instead of `support` indexing makes the vertex map total, dispatches both adjacency cases through a single cyclic-successor helper (no `wlog`), handles the wraparound with `adj_penultimate`, and gets injectivity directly from `IsCycle.getVert_injOn'`.

🤖 Prepared with Claude Code