### PR TITLE
refactor(Geometry/Manifold/Submersion): golf contMDiffOn by composing in the flat model

### DIFF
--- a/Mathlib/Geometry/Manifold/Submersion.lean
+++ b/Mathlib/Geometry/Manifold/Submersion.lean
@@ -368,17 +368,8 @@ theorem contMDiffOn (h : IsSubmersionAtOfComplement F I J n f x) :
   rw [← contMDiffOn_writtenInExtend_iff h.domChart_mem_maximalAtlas
     h.codChart_mem_maximalAtlas le_rfl h.mapsto_domChart_source_codChart_source,
     ← h.domChart.extend_target_eq_image_source]
-  have : CMDiff n (Prod.fst ∘ h.equiv) := by
-  -- Note that we cannot use `h₁.comp contMDiff_fst` since `h₁` and `contMDiff_fst` require
-  -- different models with corners on `E'' × F`. The former uses `𝓘(𝕜, E'' × F)` while the latter
-  -- uses `(𝓘(𝕜, E'')).prod (𝓘(𝕜, F)`.
-    have h₁ : ContMDiff 𝓘(𝕜, E) 𝓘(𝕜, E'' × F) n h.equiv := by
-      rw [contMDiff_iff_contDiff]
-      exact h.equiv.contDiff
-    apply ContMDiff.comp ?_ h₁
-    rw [contMDiff_iff_contDiff]
-    exact contDiff_fst
-  exact this.contMDiffOn.congr h.writtenInCharts
+  exact (contMDiff_iff_contDiff.mpr
+    (contDiff_fst.comp h.equiv.contDiff)).contMDiffOn.congr h.writtenInCharts
 
 /-- A `C^n` submersion at `x` is `C^n` at `x`. -/
 theorem contMDiffAt (h : IsSubmersionAtOfComplement F I J n f x) : CMDiffAt n f x :=


### PR DESCRIPTION
This PR golfs `IsSubmersionAtOfComplement.contMDiffOn` from https://github.com/leanprover-community/mathlib4/pull/40547. Composing `Prod.fst` with `h.equiv` via `ContDiff.comp` and crossing to `ContMDiff` once at the end avoids the model-with-corners mismatch entirely, collapsing the workaround block (and its comment) to a single term. The same collapse applies to the immersion analogue; left for a follow-up.

cc @grunweg per the file header note about coordinating changes to this file.

🤖 Prepared with Claude Code