### PR TITLE
[Merged by Bors] - doc(CategoryTheory/Preadditive/LeftExact): fix stale declaration names in module docstring

### DIFF
--- a/Mathlib/CategoryTheory/Preadditive/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Preadditive/LeftExact.lean
@@ -18,8 +18,8 @@ preserves kernels. The dual result holds for right exact functors and cokernels.
 ## Main results
 
 * We first derive preservation of binary products in the lemma
-  `preservesBinaryProductsOfPreservesKernels`,
-* then show the preservation of equalizers in `preservesEqualizerOfPreservesKernels`,
+  `preservesBinaryProducts_of_preservesKernels`,
+* then show the preservation of equalizers in `preservesEqualizer_of_preservesKernels`,
 * and then derive the preservation of all finite limits with the usual construction.
 
 -/


### PR DESCRIPTION
This PR updates two references in the module docstring to the actual (underscore-style) declaration names `preservesBinaryProducts_of_preservesKernels` and `preservesEqualizer_of_preservesKernels`, completing the docstring fixes of https://github.com/leanprover-community/mathlib4/pull/41237.

🤖 Prepared with Claude Code