### PR TITLE
[Merged by Bors] - feat(Algebra/Module/LinearMap/FiniteRange): iff version of isQuasiInverse_subtype_projectionOnto

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap/FiniteRange.lean
+++ b/Mathlib/Algebra/Module/LinearMap/FiniteRange.lean
@@ -456,12 +456,16 @@ lemma IsQuasiInverse.of_comp_right {u : V →ₗ[K] V₂} {v : V₂ →ₗ[K] V�
     (w ∘ₗ v).IsQuasiInverse u :=
   ⟨hw.1, IsRightQuasiInverse.of_comp_right hv.1 hw.2⟩
 
+lemma isQuasiInverse_subtype_projectionOnto_iff {S T : Submodule K V} (hST : IsCompl S T) :
+    IsQuasiInverse S.subtype (S.projectionOnto T hST) ↔ IsNoetherian K T := by
+  rw [IsQuasiInverse, and_iff_left (by simp [IsRightQuasiInverse, projectionOnto_comp_subtype]),
+    IsLeftQuasiInverse, ← projection,
+    FiniteRangeSetoid.projection_equiv_id_iff_isNoetherian hST]
+
 lemma isQuasiInverse_subtype_projectionOnto {S T : Submodule K V} [IsNoetherian K T]
     (hST : IsCompl S T) :
-    IsQuasiInverse S.subtype (S.projectionOnto T hST) := by
-  constructor
-  · grw [IsLeftQuasiInverse, ← FiniteRangeSetoid.projection_equiv_id hST, projection]
-  · simp [IsRightQuasiInverse, projectionOnto_comp_subtype]
+    IsQuasiInverse S.subtype (S.projectionOnto T hST) :=
+  isQuasiInverse_subtype_projectionOnto_iff hST |>.mpr inferInstance
 
 end QuasiInverse
 


### PR DESCRIPTION
This PR strengthens `isQuasiInverse_subtype_projectionOnto` to an iff (`... ↔ IsNoetherian K T`), matching the iff/instance lemma pairs established in https://github.com/leanprover-community/mathlib4/pull/41038, and derives the original statement from it.

🤖 Prepared with Claude Code
