### PR TITLE
[Merged by Bors] - feat(SetTheory/Cardinal/Finite): add a NeZero instance for Nat.card

### DIFF
--- a/Mathlib/NumberTheory/Cyclotomic/CyclotomicCharacter.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/CyclotomicCharacter.lean
@@ -131,7 +131,6 @@ local notation "χ₀" => modularCyclotomicCharacter.toFun
 /-- The formula which characterises the output of `modularCyclotomicCharacter g n`. -/
 theorem toFun_spec (g : L ≃+* L) {n : ℕ} [NeZero n] (t : rootsOfUnity n L) :
     g (t : Lˣ) = (t ^ (χ₀ n g).val : Lˣ) := by
-  have : NeZero (Nat.card (rootsOfUnity n L)) := ⟨Nat.card_pos.ne'⟩
   rw [modularCyclotomicCharacter.aux_spec g n t, ← zpow_natCast, modularCyclotomicCharacter.toFun,
     ZMod.val_intCast, ← Subgroup.coe_zpow]
   exact Units.ext_iff.1 <| SetCoe.ext_iff.2 <|
@@ -169,7 +168,6 @@ lemma id : χ₀ n (RingEquiv.refl L) = 1 := by
 
 lemma comp (g h : L ≃+* L) : χ₀ n (g * h) =
     χ₀ n g * χ₀ n h := by
-  have : NeZero (Nat.card (rootsOfUnity n L)) := ⟨Nat.card_pos.ne'⟩
   refine (toFun_unique n (g * h) _ <| fun ζ ↦ ?_).symm
   change g (h (ζ : Lˣ)) = _
   rw [toFun_spec, ← Subgroup.coe_pow, toFun_spec, mul_comm, Subgroup.coe_pow, ← pow_mul,

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -84,6 +84,8 @@ lemma card_pos_iff : 0 < Nat.card α ↔ Nonempty α ∧ Finite α := by
 
 @[simp] lemma card_pos [Nonempty α] [Finite α] : 0 < Nat.card α := card_pos_iff.2 ⟨‹_›, ‹_›⟩
 
+instance [Nonempty α] [Finite α] : NeZero (Nat.card α) := ⟨card_pos.ne'⟩
+
 theorem finite_of_card_ne_zero (h : Nat.card α ≠ 0) : Finite α := (card_ne_zero.1 h).2
 
 theorem card_congr (f : α ≃ β) : Nat.card α = Nat.card β :=


### PR DESCRIPTION
This PR adds `instance [Nonempty α] [Finite α] : NeZero (Nat.card α)`, paralleling the existing `NeZero (Fintype.card α)` instance, and removes the two manual `have : NeZero (Nat.card _)` workarounds it obsoletes in `CyclotomicCharacter.lean`. Prompted by https://github.com/leanprover-community/mathlib4/pull/41210, whose `Fintype.card` → `Nat.card` migration needed exactly this instance.

🤖 Prepared with Claude Code