### PR TITLE
chore(Algebra/Module/Submodule/Ker): state injective_domRestrict_iff with Disjoint

### DIFF
--- a/Mathlib/Algebra/Module/Submodule/Ker.lean
+++ b/Mathlib/Algebra/Module/Submodule/Ker.lean
@@ -197,8 +197,8 @@ theorem ker_eq_bot {f : M →ₛₗ[τ₁₂] M₂} : ker f = ⊥ ↔ Injective 
 alias _root_.LinearMapClass.ker_eq_bot := ker_eq_bot
 
 @[simp] lemma injective_domRestrict_iff {f : M →ₛₗ[τ₁₂] M₂} {S : Submodule R M} :
-    Injective (f.domRestrict S) ↔ S ⊓ LinearMap.ker f = ⊥ := by
-  rw [← LinearMap.ker_eq_bot]
+    Injective (f.domRestrict S) ↔ Disjoint S (LinearMap.ker f) := by
+  rw [disjoint_iff, ← LinearMap.ker_eq_bot]
   refine ⟨fun h ↦ le_bot_iff.1 ?_, fun h ↦ le_bot_iff.1 ?_⟩
   · intro x ⟨hx, h'x⟩
     have : ⟨x, hx⟩ ∈ LinearMap.ker (LinearMap.domRestrict f S) := by simpa using h'x
@@ -212,8 +212,7 @@ alias _root_.LinearMapClass.ker_eq_bot := ker_eq_bot
 @[simp] theorem injective_restrict_iff_disjoint {p : Submodule R M} {f : M →ₗ[R] M}
     (hf : ∀ x ∈ p, f x ∈ p) :
     Injective (f.restrict hf) ↔ Disjoint p (ker f) := by
-  rw [← ker_eq_bot, ker_restrict hf, ← ker_domRestrict, ker_eq_bot, injective_domRestrict_iff,
-    disjoint_iff]
+  rw [← ker_eq_bot, ker_restrict hf, ← ker_domRestrict, ker_eq_bot, injective_domRestrict_iff]
 
 end Ring
 

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -260,7 +260,7 @@ lemma Submodule.disjoint_ker_of_finrank_le [IsDomain R] [IsTorsionFree R M] {N :
     [AddCommGroup N] [Module R N] {L : Submodule R M} [Module.Finite R L] (f : M →ₗ[R] N)
     (h : finrank R L ≤ finrank R (L.map f)) :
     Disjoint L (LinearMap.ker f) := by
-  refine disjoint_iff.mpr <| LinearMap.injective_domRestrict_iff.mp <| LinearMap.ker_eq_bot.mp <|
+  refine LinearMap.injective_domRestrict_iff.mp <| LinearMap.ker_eq_bot.mp <|
     Submodule.rank_eq_zero.mp ?_
   rw [← Submodule.finrank_eq_rank, Nat.cast_eq_zero]
   rw [← LinearMap.range_domRestrict] at h

--- a/Mathlib/MeasureTheory/Measure/Haar/Disintegration.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Disintegration.lean
@@ -63,7 +63,7 @@ theorem LinearMap.exists_map_addHaar_eq_smul_addHaar' (h : Function.Surjective L
   let P : S × T →ₗ[𝕜] T := LinearMap.snd 𝕜 S T
   have P_cont : Continuous P := LinearMap.continuous_of_finiteDimensional _
   have I : Function.Bijective (LinearMap.domRestrict L T) :=
-    ⟨LinearMap.injective_domRestrict_iff.2 (IsCompl.inf_eq_bot hT.symm),
+    ⟨LinearMap.injective_domRestrict_iff.2 hT.symm.disjoint,
     (LinearMap.surjective_domRestrict_iff h).2 hT.symm.codisjoint⟩
   let L' : T ≃ₗ[𝕜] F := LinearEquiv.ofBijective (LinearMap.domRestrict L T) I
   have L'_cont : Continuous L' := LinearMap.continuous_of_finiteDimensional _

--- a/Mathlib/RingTheory/Noetherian/Basic.lean
+++ b/Mathlib/RingTheory/Noetherian/Basic.lean
@@ -386,7 +386,7 @@ lemma FG.of_le [IsNoetherianRing R] {S T : Submodule R M} (hT : T.FG) (hST : S â
 See also `Submodule.CoFG.fg_of_disjoint`. -/
 theorem FG.of_disjoint_of_isNoetherian_quotient {S T : Submodule R M} [IsNoetherian R (M â§¸ T)]
     (hST : Disjoint S T) : S.FG :=
-  Module.Finite.iff_fg.mp <| .of_injective (T.mkQ.domRestrict S) (by simp [hST.eq_bot])
+  Module.Finite.iff_fg.mp <| .of_injective (T.mkQ.domRestrict S) (by simpa using hST)
 
 end Submodule
 


### PR DESCRIPTION
This PR restates `LinearMap.injective_domRestrict_iff` with `Disjoint S (LinearMap.ker f)` instead of `S ⊓ LinearMap.ker f = ⊥`, dual to the `Codisjoint` form `surjective_domRestrict_iff` acquired in https://github.com/leanprover-community/mathlib4/pull/41235, and simplifies the call sites accordingly.

🤖 Prepared with Claude Code