### PR TITLE
feat(EReal): addition of real as an orderIso

### DIFF
--- a/Mathlib/Topology/Instances/EReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/EReal/Lemmas.lean
@@ -245,6 +245,50 @@ lemma add_iInf_le_iInf_add : (⨅ x, u x) + ⨅ x, v x ≤ ⨅ x, (u + v) x :=
 lemma iSup_add_le_add_iSup : ⨆ x, (u + v) x ≤ (⨆ x, u x) + ⨆ x, v x :=
   iSup_le fun i ↦ add_le_add (le_iSup u i) (le_iSup v i)
 
+/-- Translation by a real number is an order isomorphism of `EReal`. -/
+@[simps! toEquiv apply symm_apply]
+def addCoeLeftOrderIso (a : ℝ) : EReal ≃o EReal where
+  toFun x := a + x
+  invFun x := -a + x
+  left_inv e := by
+    dsimp only
+    cases e <;> norm_cast
+    simp
+  right_inv e := by
+    dsimp only
+    cases e <;> norm_cast
+    simp
+  map_rel_iff' := (EReal.addLECancellable_coe _).add_le_add_iff_left
+
+/-- Translation by a real number is an order isomorphism of `EReal`. -/
+@[simps! toEquiv apply symm_apply]
+def addCoeRightOrderIso (a : ℝ) : EReal ≃o EReal where
+  toFun x := x + a
+  invFun x := x - a
+  left_inv e := by
+    dsimp only
+    cases e <;> norm_cast
+    simp
+  right_inv e := by
+    dsimp only
+    cases e <;> norm_cast
+    simp
+  map_rel_iff' := by
+    simp_rw [add_comm (b := (a : EReal))]
+    exact addCoeLeftOrderIso a |>.map_rel_iff
+
+lemma coe_add_iSup (a : ℝ) : a + ⨆ i, u i = ⨆ i, a + u i :=
+  addCoeLeftOrderIso _ |>.map_iSup _
+
+lemma coe_add_iInf (a : ℝ) : a + ⨅ i, u i = ⨅ i, a + u i :=
+  addCoeLeftOrderIso _ |>.map_iInf _
+
+lemma iSup_add_coe (a : ℝ) : (⨆ i, u i) + a = ⨆ i, u i + a :=
+  addCoeRightOrderIso _ |>.map_iSup _
+
+lemma iInf_add_coe (a : ℝ) : (⨅ i, u i) + a = ⨅ i, u i + a :=
+  addCoeRightOrderIso _ |>.map_iInf _
+
 /-! ### Liminfs and Limsups -/
 
 section LimInfSup


### PR DESCRIPTION
The addition of a real number as an `OrderIso` of `EReal`, and some consequences for `iSup`, `iInf`.

---

Shoud the `iSup`, `iInf` lemmas be `@[simp]`, or should it be the version assuming that `a : EReal` is `≠ ⊤` and `≠ ⊥` instead?

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
