### PR TITLE
[Merged by Bors] - chore(Topology/Algebra/Valued/WithVal): clean up instances

### DIFF
--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -267,9 +267,8 @@ instance {P : Type*} [Ring S] [SMul P R] [SMul S R] [SMul P S]
   smul_assoc := by simp [smul_right_def, smul_left_def, -toVal_smul]
 
 instance [AddCommMonoid S] [Module R S] : Module (WithVal v) S :=
-  .compHom S (equiv v).toRingHom
+  fast_instance% .compHom S (equiv v).toRingHom
 
-set_option backward.isDefEq.respectTransparency false in
 instance [AddCommMonoid S] [Module R S] [Module.Finite R S] :
     Module.Finite (WithVal v) S := .of_restrictScalars_finite R (WithVal v) S
 
@@ -300,7 +299,7 @@ section left
 variable [CommRing R] (v : Valuation R Γ₀) [Semiring S] [Algebra R S]
 
 instance : Algebra (WithVal v) S := fast_instance% {
-  __ := (inferInstance : Module (WithVal v) S)
+  algebraMap.toFun r := algebraMap R S (ofVal r)
   __ := Algebra.compHom S (equiv v).toRingHom }
 
 theorem algebraMap_left_apply (s : WithVal v) :
@@ -318,7 +317,9 @@ section right
 
 variable [CommSemiring R] [Ring S] [Algebra R S] (v : Valuation S Γ₀)
 
-instance : Algebra R (WithVal v) := fast_instance% (equiv v).algebra R
+instance : Algebra R (WithVal v) := fast_instance% {
+  (equiv v).algebra R with
+  algebraMap.toFun r := toVal v (algebraMap R S r) }
 
 theorem algebraMap_right_apply (r : R) :
     algebraMap R (WithVal v) r = toVal v (algebraMap R S r) := rfl
@@ -344,12 +345,9 @@ instance {S : Type*} [CommRing S] [Algebra R S] (M : Submonoid R) [IsLocalizatio
 
 end Algebra
 
-section Field
+section DivisionRing
 
-instance [DivisionRing R] (v : Valuation R Γ₀) : DivisionRing (WithVal v) := fast_instance%
-  (equiv v).divisionRing
-
-variable [Field R] (v : Valuation R Γ₀)
+variable [DivisionRing R] (v : Valuation R Γ₀)
 
 instance : Div (WithVal v) where div x y := toVal _ (x.ofVal / y.ofVal)
 instance : Inv (WithVal v) where inv x := toVal _ x.ofVal⁻¹
@@ -376,6 +374,14 @@ instance : RatCast (WithVal v) where ratCast q := toVal _ q
 @[simp] lemma toVal_ratCast (q : ℚ) : toVal v q = q := rfl
 
 @[simp] lemma ofVal_ratCast (q : ℚ) : ofVal (q : WithVal v) = q := rfl
+
+instance : DivisionRing (WithVal v) := fast_instance% (equiv v).divisionRing
+
+end DivisionRing
+
+section Field
+
+variable [Field R] (v : Valuation R Γ₀)
 
 instance : Field (WithVal v) := fast_instance% ofVal_injective v |>.field _
   (ofVal_zero _) (ofVal_one _) (ofVal_add _) (ofVal_mul _) (ofVal_neg _) (ofVal_sub _)
@@ -673,7 +679,6 @@ instance : CoeHead (𝓞 (WithVal v)) (WithVal v) where
 instance (R : Type*) [CommRing R] [Algebra R K] [IsIntegralClosure R ℤ K] :
     IsIntegralClosure R ℤ (WithVal v) := .of_algEquiv _ (WithVal.algEquiv ℤ v).symm (fun _ ↦ rfl)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The ring equivalence between `𝓞 (WithVal v)` and an integral closure of
 `ℤ` in `K`. -/
 @[simps!]


### PR DESCRIPTION
This PR cleans up some instance diamonds around `WithVal`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
