### PR TITLE
feat: add `List.insertIdx_eraseIdx_getElem_perm`

### DIFF
--- a/Mathlib/Data/List/Perm/Basic.lean
+++ b/Mathlib/Data/List/Perm/Basic.lean
@@ -59,7 +59,7 @@ theorem getElem_cons_eraseIdx_perm {n : ℕ} (h : n < l.length) :
 theorem insertIdx_eraseIdx_getElem_perm {m n : ℕ} (hm : m < l.length)
     (hn : n ≤ (l.eraseIdx m).length) :
     (l.eraseIdx m).insertIdx n l[m] ~ l :=
-  (perm_insertIdx l[m] (l.eraseIdx m) hn).trans (getElem_cons_eraseIdx_perm hm)
+  (perm_insertIdx _ _ hn).trans (getElem_cons_eraseIdx_perm hm)
 
 theorem perm_insertIdx_iff_of_le {l₁ l₂ : List α} {m n : ℕ} (hm : m ≤ l₁.length)
     (hn : n ≤ l₂.length) (a : α) : l₁.insertIdx m a ~ l₂.insertIdx n a ↔ l₁ ~ l₂ := by

--- a/Mathlib/Data/List/Perm/Basic.lean
+++ b/Mathlib/Data/List/Perm/Basic.lean
@@ -56,6 +56,11 @@ theorem getElem_cons_eraseIdx_perm {n : ℕ} (h : n < l.length) :
     l[n] :: l.eraseIdx n ~ l := by
   simpa [h] using (set_perm_cons_eraseIdx h l[n]).symm
 
+theorem insertIdx_eraseIdx_getElem_perm {m n : ℕ} (hm : m < l.length)
+    (hn : n ≤ (l.eraseIdx m).length) :
+    (l.eraseIdx m).insertIdx n l[m] ~ l :=
+  (perm_insertIdx l[m] (l.eraseIdx m) hn).trans (getElem_cons_eraseIdx_perm hm)
+
 theorem perm_insertIdx_iff_of_le {l₁ l₂ : List α} {m n : ℕ} (hm : m ≤ l₁.length)
     (hn : n ≤ l₂.length) (a : α) : l₁.insertIdx m a ~ l₂.insertIdx n a ↔ l₁ ~ l₂ := by
   rw [rel_congr_left (perm_insertIdx _ _ hm), rel_congr_right (perm_insertIdx _ _ hn), perm_cons]


### PR DESCRIPTION
Adds `List.insertIdx_eraseIdx_getElem_perm`, showing that erasing an element by index and inserting it at any valid position gives a permutation of the original list.

This packages the existing lemmas `List.perm_insertIdx` and `List.getElem_cons_eraseIdx_perm` into a direct API lemma.

AI assistance was used in preparing this PR; I reviewed the statement and proof.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)