### PR TITLE
[Merged by Bors] - refactor(RingTheory/RamificationInertia/Inertia): remove last occurances of `inertiaDeg_eq_inertiaDeg'`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Completion/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/Completion/Ramification.lean
@@ -94,7 +94,7 @@ theorem inertiaDeg_of_liesOver [w.1.LiesOver v.1] :
 
 theorem inertiaDeg_eq_finrank [w.1.LiesOver v.1] :
     v.inertiaDeg w = Module.finrank v.Completion w.Completion := by
-  rw [inertiaDeg_of_liesOver, Ideal.inertiaDeg'_eq' ⊥]
+  rw [inertiaDeg_of_liesOver, Ideal.inertiaDeg'_eq_of_isMaximal ⊥]
   exact Algebra.finrank_eq_of_equiv_equiv (RingEquiv.quotientBot v.Completion)
     (RingEquiv.quotientBot w.Completion) (by ext; simp [RingHom.algebraMap_toAlgebra])
 

--- a/Mathlib/NumberTheory/NumberField/Completion/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/Completion/Ramification.lean
@@ -6,7 +6,7 @@ Authors: Salvatore Mercuri
 module
 
 public import Mathlib.NumberTheory.NumberField.Completion.LiesOverInstances
-public import Mathlib.NumberTheory.RamificationInertia.Basic
+public import Mathlib.RingTheory.RamificationInertia.Inertia
 
 /-!
 # Ramification theory of completions of number fields
@@ -86,16 +86,15 @@ variable (w)
 open scoped Classical in
 /-- The inertia degree of `w` over `v`. -/
 protected noncomputable def inertiaDeg : ℕ :=
-  if _ : w.1.LiesOver v.1 then (⊥ : Ideal v.Completion).inertiaDeg (⊥ : Ideal w.Completion) else 0
+  if _ : w.1.LiesOver v.1 then (⊥ : Ideal w.Completion).inertiaDeg' v.Completion else 0
 
 theorem inertiaDeg_of_liesOver [w.1.LiesOver v.1] :
-    v.inertiaDeg w = (⊥ : Ideal v.Completion).inertiaDeg (⊥ : Ideal w.Completion) := by
+    v.inertiaDeg w = (⊥ : Ideal w.Completion).inertiaDeg' v.Completion := by
   simp only [InfinitePlace.inertiaDeg, dif_pos]
 
 theorem inertiaDeg_eq_finrank [w.1.LiesOver v.1] :
     v.inertiaDeg w = Module.finrank v.Completion w.Completion := by
-  simp only [inertiaDeg_of_liesOver, Ideal.inertiaDeg, Ideal.comap_bot_of_injective _ <|
-    FaithfulSMul.algebraMap_injective v.Completion w.Completion]
+  rw [inertiaDeg_of_liesOver, Ideal.inertiaDeg'_eq' ⊥]
   exact Algebra.finrank_eq_of_equiv_equiv (RingEquiv.quotientBot v.Completion)
     (RingEquiv.quotientBot w.Completion) (by ext; simp [RingHom.algebraMap_toAlgebra])
 

--- a/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
@@ -218,7 +218,7 @@ theorem inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply (hp : ¬ p ∣ 
     apply Ideal.primesOver.isMaximal
   have := liesOver_primesOverSpanEquivMonicFactorsMod_symm hp hQ
   rw [primesOverSpanEquivMonicFactorsMod_symm_apply_eq_span,
-    ← inertiaDeg_eq_inertiaDeg' (span {(p : ℤ)}), inertiaDeg_algebraMap,
+    inertiaDeg'_eq' (span {(p : ℤ)}),
     ← finrank_quotient_span_eq_natDegree]
   refine Algebra.finrank_eq_of_equiv_equiv (Int.quotientSpanNatEquivZMod p) ?_ (by ext; simp)
   exact (ZModXQuotSpanEquivQuotSpanPair hp hQ).symm

--- a/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
@@ -218,7 +218,7 @@ theorem inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply (hp : ¬ p ∣ 
     apply Ideal.primesOver.isMaximal
   have := liesOver_primesOverSpanEquivMonicFactorsMod_symm hp hQ
   rw [primesOverSpanEquivMonicFactorsMod_symm_apply_eq_span,
-    inertiaDeg'_eq' (span {(p : ℤ)}),
+    inertiaDeg'_eq_of_isMaximal (span {(p : ℤ)}),
     ← finrank_quotient_span_eq_natDegree]
   refine Algebra.finrank_eq_of_equiv_equiv (Int.quotientSpanNatEquivZMod p) ?_ (by ext; simp)
   exact (ZModXQuotSpanEquivQuotSpanPair hp hQ).symm

--- a/Mathlib/NumberTheory/RamificationInertia/HilbertTheory.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/HilbertTheory.lean
@@ -297,8 +297,7 @@ private lemma ramificationIdxIn_eq_and_inertiaDegIn_eq (hp : p ≠ ⊥) :
     exact 𝓟D.ramificationIdx_above_le P
   · rw [inertiaDegIn_eq_inertiaDeg p P Gal(L/K),
       inertiaDegIn_eq_inertiaDeg _ P (stabilizer Gal(L/K) P)]
-    rw [← inertiaDeg_eq_inertiaDeg' p, ← inertiaDeg_eq_inertiaDeg' 𝓟D]
-    exact inertiaDeg_le_inertiaDeg p 𝓟D P
+    exact inertiaDeg'_above_le 𝓟D P
   · have := ncard_primesOver_mul_ramificationIdxIn_mul_inertiaDegIn 𝓟D B (stabilizer Gal(L/K) P)
     rw [primesOver_eq_singleton K L P D 𝓞D, Set.ncard_singleton, one_mul] at this
     rw [this, IsGaloisGroup.card_eq_finrank (stabilizer Gal(L/K) P) D L,

--- a/Mathlib/NumberTheory/RamificationInertia/HilbertTheory.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/HilbertTheory.lean
@@ -283,7 +283,6 @@ private lemma instances (hp : p ≠ ⊥) :
   exact ⟨inst₁, inst₂, inst₃, inst₄, inst₅, Ideal.ne_bot_of_liesOver_of_ne_bot hp 𝓟D⟩
 
 variable [FiniteDimensional K L] [Ring.HasFiniteQuotients A] [𝓟D.IsMaximal] [P.IsMaximal]
-  [p.IsMaximal]
 
 include K L D P in
 private lemma ramificationIdxIn_eq_and_inertiaDegIn_eq (hp : p ≠ ⊥) :

--- a/Mathlib/RingTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Inertia.lean
@@ -77,25 +77,30 @@ theorem inertiaDeg'_eq [q.LiesOver p] [q.IsPrime] [p.IsPrime]
   exact inertiaDeg'_def q R
 
 theorem inertiaDeg'_eq_of_isFractionRing [q.LiesOver p] [p.IsPrime] [q.IsPrime]
-    (K L : Type*) [Field K] [Field L] [Algebra (R ⧸ p) K] [Algebra (S ⧸ q) L]
-    [IsFractionRing (R ⧸ p) K] [IsFractionRing (S ⧸ q) L] [Algebra K L]
-    [Algebra (R ⧸ p) L] [IsScalarTower (R ⧸ p) K L] [IsScalarTower (R ⧸ p) (S ⧸ q) L] :
+    (K L : Type*) [Field K] [Field L]
+    [Algebra (R ⧸ p) K] [IsFractionRing (R ⧸ p) K]
+    [Algebra (S ⧸ q) L] [IsFractionRing (S ⧸ q) L]
+    [Algebra R K] [IsScalarTower R (R ⧸ p) K]
+    [Algebra S L] [IsScalarTower S (S ⧸ q) L]
+    [Algebra K L] [Algebra R L] [IsScalarTower R K L] [IsScalarTower R S L] :
     q.inertiaDeg' R = Module.finrank K L := by
   let := Localization.AtPrime.algebraOfLiesOver p q
   rw [inertiaDeg'_eq p q]
-  let f : (R ⧸ p) ≃ₐ[R ⧸ p] (R ⧸ p) := AlgEquiv.refl
-  let g : (S ⧸ q) ≃ₐ[S ⧸ q] (S ⧸ q) := AlgEquiv.refl
-  let f' : p.ResidueField ≃ₐ[R ⧸ p] K := IsFractionRing.algEquivOfAlgEquiv f
-  let g' : q.ResidueField ≃ₐ[S ⧸ q] L := IsFractionRing.algEquivOfAlgEquiv g
-  apply Algebra.finrank_eq_of_equiv_equiv f' g'
+  apply Algebra.finrank_eq_of_equiv_equiv
+    (IsFractionRing.algEquivOfAlgEquiv (R := R) (A := R ⧸ p) (K := p.ResidueField) (L := K) .refl)
+    (IsFractionRing.algEquivOfAlgEquiv (R := S) (A := S ⧸ q) (K := q.ResidueField) (L := L) .refl)
   apply IsFractionRing.ringHom_ext (A := R ⧸ p)
   intro x
-  suffices ∀ x, (algebraMap p.ResidueField q.ResidueField) ((algebraMap (R ⧸ p) p.ResidueField) x) =
-      ((algebraMap (S ⧸ q) q.ResidueField) ((algebraMap (R ⧸ p) (S ⧸ q)) x)) by
-    simp [← IsScalarTower.algebraMap_apply, this]
-  intro x
-  obtain ⟨y, rfl⟩ := Ideal.Quotient.mk_surjective x
-  simp [← IsScalarTower.algebraMap_apply]
+  obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective x
+  simp [← IsScalarTower.algebraMap_apply R p.ResidueField q.ResidueField,
+    IsScalarTower.algebraMap_apply R S q.ResidueField,
+    ← IsScalarTower.algebraMap_apply R K L, ← IsScalarTower.algebraMap_apply R S L]
+
+theorem inertiaDeg'_eq' [q.LiesOver p] [q.IsPrime] [p.IsPrime]
+    [Algebra (Localization.AtPrime p) (Localization.AtPrime q)]
+    [Localization.AtPrime.IsLiesOverAlgebra p q] :
+    q.inertiaDeg' R = Module.finrank p.ResidueField q.ResidueField := by
+  exact inertiaDeg'_eq_of_isFractionRing p q p.ResidueField q.ResidueField
 
 theorem inertiaDeg'_eq_of_isMaximal [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
     q.inertiaDeg' R = Module.finrank (R ⧸ p) (S ⧸ q) := by

--- a/Mathlib/RingTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Inertia.lean
@@ -68,8 +68,6 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
   [Algebra R S] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
   (p : Ideal R) (q : Ideal S) (r : Ideal T)
 
-/-- Inertia degree for prime ideals equals degree of the residue fields.
-See `inertiaDeg'_eq'` for the maximal ideal version. -/
 theorem inertiaDeg'_eq [q.LiesOver p] [q.IsPrime] [p.IsPrime]
     [Algebra (Localization.AtPrime p) (Localization.AtPrime q)]
     [Localization.AtPrime.IsLiesOverAlgebra p q] :
@@ -99,8 +97,6 @@ theorem inertiaDeg'_eq_of_isFractionRing [q.LiesOver p] [p.IsPrime] [q.IsPrime]
   obtain ⟨y, rfl⟩ := Ideal.Quotient.mk_surjective x
   simp [← IsScalarTower.algebraMap_apply]
 
-/-- Inertia degree for maximal ideals equals degree of the quotient fields.
-See `inertiaDeg'_eq'` for the prime ideal version. -/
 theorem inertiaDeg'_eq_of_isMaximal [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
     q.inertiaDeg' R = Module.finrank (R ⧸ p) (S ⧸ q) := by
   let : Field (R ⧸ p) := Quotient.field p

--- a/Mathlib/RingTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Inertia.lean
@@ -96,12 +96,6 @@ theorem inertiaDeg'_eq_of_isFractionRing [q.LiesOver p] [p.IsPrime] [q.IsPrime]
     IsScalarTower.algebraMap_apply R S q.ResidueField,
     ← IsScalarTower.algebraMap_apply R K L, ← IsScalarTower.algebraMap_apply R S L]
 
-theorem inertiaDeg'_eq' [q.LiesOver p] [q.IsPrime] [p.IsPrime]
-    [Algebra (Localization.AtPrime p) (Localization.AtPrime q)]
-    [Localization.AtPrime.IsLiesOverAlgebra p q] :
-    q.inertiaDeg' R = Module.finrank p.ResidueField q.ResidueField := by
-  exact inertiaDeg'_eq_of_isFractionRing p q p.ResidueField q.ResidueField
-
 theorem inertiaDeg'_eq_of_isMaximal [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
     q.inertiaDeg' R = Module.finrank (R ⧸ p) (S ⧸ q) := by
   let : Field (R ⧸ p) := Quotient.field p

--- a/Mathlib/RingTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Inertia.lean
@@ -92,40 +92,24 @@ theorem inertiaDeg'_eq_of_isFractionRing [q.LiesOver p] [p.IsPrime] [q.IsPrime]
   apply Algebra.finrank_eq_of_equiv_equiv f' g'
   apply IsFractionRing.ringHom_ext (A := R ⧸ p)
   intro x
-  suffices (algebraMap p.ResidueField q.ResidueField) ((algebraMap (R ⧸ p) p.ResidueField) x) =
+  suffices ∀ x, (algebraMap p.ResidueField q.ResidueField) ((algebraMap (R ⧸ p) p.ResidueField) x) =
       ((algebraMap (S ⧸ q) q.ResidueField) ((algebraMap (R ⧸ p) (S ⧸ q)) x)) by
     simp [← IsScalarTower.algebraMap_apply, this]
+  intro x
   obtain ⟨y, rfl⟩ := Ideal.Quotient.mk_surjective x
-  simp
-  rw [IsScalarTower.algebraMap_apply R (Localization.AtPrime p),
-    ← IsScalarTower.algebraMap_apply,
-    IsScalarTower.algebraMap_apply (Localization.AtPrime p) (Localization.AtPrime q)]
-  sorry
-
-  -- just transfer degree across the isomorphism!
+  simp [← IsScalarTower.algebraMap_apply]
 
 /-- Inertia degree for maximal ideals equals degree of the quotient fields.
 See `inertiaDeg'_eq'` for the prime ideal version. -/
-theorem inertiaDeg'_eq' [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
+theorem inertiaDeg'_eq_of_isMaximal [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
     q.inertiaDeg' R = Module.finrank (R ⧸ p) (S ⧸ q) := by
   let : Field (R ⧸ p) := Quotient.field p
   let : Field (S ⧸ q) := Quotient.field q
-  let := Localization.AtPrime.algebraOfLiesOver p q
-  rw [inertiaDeg'_eq p q]
-  let f := (algebraMap (S ⧸ q) q.ResidueField).comp (algebraMap (R ⧸ p) (S ⧸ q))
-  let g := (algebraMap p.ResidueField q.ResidueField).comp (algebraMap (R ⧸ p) p.ResidueField)
-  have h : f = g := by ext; simp [f, g, ← IsScalarTower.algebraMap_apply]
-  let : Algebra (R ⧸ p) q.ResidueField := f.toAlgebra
-  have : IsScalarTower (R ⧸ p) (S ⧸ q) q.ResidueField := IsScalarTower.of_algebraMap_eq' rfl
-  have : IsScalarTower (R ⧸ p) p.ResidueField q.ResidueField := IsScalarTower.of_algebraMap_eq' h
-  rw [← mul_one (Module.finrank (R ⧸ p) (S ⧸ q)),
-    ← Module.finrank_of_bijective_algebraMap (bijective_algebraMap_quotient_residueField q),
-    Module.finrank_mul_finrank, ← Module.finrank_mul_finrank (R ⧸ p) p.ResidueField q.ResidueField,
-    Module.finrank_of_bijective_algebraMap (bijective_algebraMap_quotient_residueField p), one_mul]
+  exact inertiaDeg'_eq_of_isFractionRing p q (R ⧸ p) (S ⧸ q)
 
 theorem inertiaDeg_eq_inertiaDeg' [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
     p.inertiaDeg q = q.inertiaDeg' R := by
-  rw [inertiaDeg'_eq' p q, inertiaDeg_algebraMap]
+  rw [inertiaDeg_algebraMap, inertiaDeg'_eq_of_isMaximal p q]
 
 theorem inertiaDeg'_tower [r.LiesOver q] :
     r.inertiaDeg' R = q.inertiaDeg' R * r.inertiaDeg' S := by

--- a/Mathlib/RingTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Inertia.lean
@@ -82,7 +82,8 @@ theorem inertiaDeg'_eq_of_isFractionRing [q.LiesOver p] [p.IsPrime] [q.IsPrime]
     [Algebra (S ⧸ q) L] [IsFractionRing (S ⧸ q) L]
     [Algebra R K] [IsScalarTower R (R ⧸ p) K]
     [Algebra S L] [IsScalarTower S (S ⧸ q) L]
-    [Algebra K L] [Algebra R L] [IsScalarTower R K L] [IsScalarTower R S L] :
+    [Algebra R L] [IsScalarTower R S L]
+    [Algebra K L] [IsScalarTower R K L] :
     q.inertiaDeg' R = Module.finrank K L := by
   let := Localization.AtPrime.algebraOfLiesOver p q
   rw [inertiaDeg'_eq p q]

--- a/Mathlib/RingTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Inertia.lean
@@ -68,6 +68,8 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
   [Algebra R S] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
   (p : Ideal R) (q : Ideal S) (r : Ideal T)
 
+/-- Inertia degree for prime ideals equals degree of the residue fields.
+See `inertiaDeg'_eq'` for the maximal ideal version. -/
 theorem inertiaDeg'_eq [q.LiesOver p] [q.IsPrime] [p.IsPrime]
     [Algebra (Localization.AtPrime p) (Localization.AtPrime q)]
     [Localization.AtPrime.IsLiesOverAlgebra p q] :
@@ -76,12 +78,40 @@ theorem inertiaDeg'_eq [q.LiesOver p] [q.IsPrime] [p.IsPrime]
   subst this
   exact inertiaDeg'_def q R
 
-theorem inertiaDeg_eq_inertiaDeg' [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
-    p.inertiaDeg q = q.inertiaDeg' R := by
+theorem inertiaDeg'_eq_of_isFractionRing [q.LiesOver p] [p.IsPrime] [q.IsPrime]
+    (K L : Type*) [Field K] [Field L] [Algebra (R ⧸ p) K] [Algebra (S ⧸ q) L]
+    [IsFractionRing (R ⧸ p) K] [IsFractionRing (S ⧸ q) L] [Algebra K L]
+    [Algebra (R ⧸ p) L] [IsScalarTower (R ⧸ p) K L] [IsScalarTower (R ⧸ p) (S ⧸ q) L] :
+    q.inertiaDeg' R = Module.finrank K L := by
+  let := Localization.AtPrime.algebraOfLiesOver p q
+  rw [inertiaDeg'_eq p q]
+  let f : (R ⧸ p) ≃ₐ[R ⧸ p] (R ⧸ p) := AlgEquiv.refl
+  let g : (S ⧸ q) ≃ₐ[S ⧸ q] (S ⧸ q) := AlgEquiv.refl
+  let f' : p.ResidueField ≃ₐ[R ⧸ p] K := IsFractionRing.algEquivOfAlgEquiv f
+  let g' : q.ResidueField ≃ₐ[S ⧸ q] L := IsFractionRing.algEquivOfAlgEquiv g
+  apply Algebra.finrank_eq_of_equiv_equiv f' g'
+  apply IsFractionRing.ringHom_ext (A := R ⧸ p)
+  intro x
+  suffices (algebraMap p.ResidueField q.ResidueField) ((algebraMap (R ⧸ p) p.ResidueField) x) =
+      ((algebraMap (S ⧸ q) q.ResidueField) ((algebraMap (R ⧸ p) (S ⧸ q)) x)) by
+    simp [← IsScalarTower.algebraMap_apply, this]
+  obtain ⟨y, rfl⟩ := Ideal.Quotient.mk_surjective x
+  simp
+  rw [IsScalarTower.algebraMap_apply R (Localization.AtPrime p),
+    ← IsScalarTower.algebraMap_apply,
+    IsScalarTower.algebraMap_apply (Localization.AtPrime p) (Localization.AtPrime q)]
+  sorry
+
+  -- just transfer degree across the isomorphism!
+
+/-- Inertia degree for maximal ideals equals degree of the quotient fields.
+See `inertiaDeg'_eq'` for the prime ideal version. -/
+theorem inertiaDeg'_eq' [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
+    q.inertiaDeg' R = Module.finrank (R ⧸ p) (S ⧸ q) := by
   let : Field (R ⧸ p) := Quotient.field p
   let : Field (S ⧸ q) := Quotient.field q
   let := Localization.AtPrime.algebraOfLiesOver p q
-  rw [inertiaDeg'_eq p q, inertiaDeg_algebraMap]
+  rw [inertiaDeg'_eq p q]
   let f := (algebraMap (S ⧸ q) q.ResidueField).comp (algebraMap (R ⧸ p) (S ⧸ q))
   let g := (algebraMap p.ResidueField q.ResidueField).comp (algebraMap (R ⧸ p) p.ResidueField)
   have h : f = g := by ext; simp [f, g, ← IsScalarTower.algebraMap_apply]
@@ -92,6 +122,10 @@ theorem inertiaDeg_eq_inertiaDeg' [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
     ← Module.finrank_of_bijective_algebraMap (bijective_algebraMap_quotient_residueField q),
     Module.finrank_mul_finrank, ← Module.finrank_mul_finrank (R ⧸ p) p.ResidueField q.ResidueField,
     Module.finrank_of_bijective_algebraMap (bijective_algebraMap_quotient_residueField p), one_mul]
+
+theorem inertiaDeg_eq_inertiaDeg' [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
+    p.inertiaDeg q = q.inertiaDeg' R := by
+  rw [inertiaDeg'_eq' p q, inertiaDeg_algebraMap]
 
 theorem inertiaDeg'_tower [r.LiesOver q] :
     r.inertiaDeg' R = q.inertiaDeg' R * r.inertiaDeg' S := by
@@ -104,6 +138,24 @@ theorem inertiaDeg'_tower [r.LiesOver q] :
     rw [inertiaDeg'_def, inertiaDeg'_eq (r.under R), inertiaDeg'_eq q, eq_comm]
     apply Module.finrank_mul_finrank
   · rw [inertiaDeg'_of_not_isPrime r R hr, inertiaDeg'_of_not_isPrime r S hr, mul_zero]
+
+theorem inertiaDeg'_below_dvd [r.LiesOver q] :
+    q.inertiaDeg' R ∣ r.inertiaDeg' R := by
+  use r.inertiaDeg' S
+  rw [← inertiaDeg'_tower]
+
+theorem inertiaDeg'_above_dvd [r.LiesOver q] :
+    r.inertiaDeg' S ∣ r.inertiaDeg' R := by
+  use q.inertiaDeg' R
+  rw [mul_comm, ← inertiaDeg'_tower]
+
+theorem inertiaDeg'_below_le [r.IsPrime] [r.LiesOver q] [Module.Finite R T] :
+    q.inertiaDeg' R ≤ r.inertiaDeg' R :=
+  Nat.le_of_dvd (r.inertiaDeg'_pos R) (q.inertiaDeg'_below_dvd r)
+
+theorem inertiaDeg'_above_le [r.IsPrime] [r.LiesOver q] [Module.Finite R T] :
+    r.inertiaDeg' S ≤ r.inertiaDeg' R :=
+  Nat.le_of_dvd (r.inertiaDeg'_pos R) (q.inertiaDeg'_above_dvd r)
 
 variable (R) in
 open Pointwise in


### PR DESCRIPTION
This PR adds a bit more API for `RingTheory/RamificationInertia/Inertia` in order to remove the last occurances of `inertiaDeg_eq_inertiaDeg'`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
