### PR TITLE
[Merged by Bors] - refactor(NumberTheory/NumberField/ExistsRamified): extract `Algebra.IsUnramifiedIn` version

### DIFF
--- a/Mathlib/NumberTheory/NumberField/ExistsRamified.lean
+++ b/Mathlib/NumberTheory/NumberField/ExistsRamified.lean
@@ -27,20 +27,25 @@ open scoped NumberField nonZeroDivisors
 variable {K 𝒪 : Type*} [Field K] [NumberField K] [CommRing 𝒪] [Algebra 𝒪 K]
 variable [IsIntegralClosure 𝒪 ℤ K]
 
+/-- If `K` is a number field with positive rank, then some prime is ramified in `K`. -/
+lemma NumberField.exists_not_isUnramifiedIn (H : Module.finrank ℚ K ≠ 1) :
+    ∃ p : ℕ, p.Prime ∧ ¬ Algebra.IsUnramifiedIn 𝒪 (Ideal.span {(p : ℤ)}) := by
+  have : 0 < Module.finrank ℚ K := Module.finrank_pos
+  have : 2 < |discr K| := abs_discr_gt_two (by lia)
+  obtain ⟨p, hp1, hp2⟩ := (discr K).exists_prime_and_dvd (by linarith)
+  use p.natAbs, p.prime_iff_natAbs_prime.mp hp1
+  simpa [← not_dvd_discr_iff_isUnramifiedIn K 𝒪 hp1]
+
 /-- If `K` is a number field with positive rank, then there exists some maximal ideal of `𝓞 K`
 that is ramified over `ℤ`. -/
 lemma NumberField.exists_not_isUnramifiedAt_int (H : Module.finrank ℚ K ≠ 1) :
     ∃ (P : Ideal 𝒪) (_ : P.IsMaximal), ¬ Algebra.IsUnramifiedAt ℤ P := by
+  obtain ⟨p, hp1, hp2⟩ := NumberField.exists_not_isUnramifiedIn (𝒪 := 𝒪) H
   have := (IsIntegralClosure.algebraMap_injective 𝒪 ℤ K).isDomain
   have := IsIntegralClosure.isDedekindDomain ℤ ℚ K 𝒪
-  have := CharZero.of_module (R := 𝒪) K
-  have := Module.finrank_pos (R := ℚ) (M := K)
-  have := NumberField.abs_discr_gt_two (K := K) (by lia)
-  obtain ⟨q, hq, hqK⟩ := Int.exists_prime_and_dvd (n := discr K) (by zify; linarith)
-  have := (not_dvd_discr_iff_forall_mem K 𝒪 hq).not_right.mp hqK
-  push Not at this
-  obtain ⟨P, hP, h, H⟩ := this
-  exact ⟨P, hP.isMaximal (by aesop), H⟩
+  have := IsIntegralClosure.isTorsionFree ℤ (A := 𝒪) K
+  have := IsIntegralClosure.isIntegral_algebra ℤ (A := 𝒪) K
+  grind [Algebra.isUnramifiedIn_iff_forall_of_isDedekindDomain]
 
 /-- Any number field that is unramified over `ℚ` has rank `1`. -/
 lemma NumberField.finrank_eq_one_of_unramified [Algebra.Unramified ℤ 𝒪] :


### PR DESCRIPTION
This PR extracts an `Algebra.IsUnramifiedIn` version of the existence of ramified primes in number fields.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
