### PR TITLE
[Merged by Bors] - refactor(RingTheory/RamificationInertia/Inertia): swap `inertiaDeg` and `inertiaDeg'`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -143,7 +143,7 @@ The way this theorem should be used is to first compute `⌊(M K)⌋₊` and the
 to deal with the finite number of primes `p` in the interval. -/
 theorem isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc
     (h : ∀ p ∈ Finset.Icc 1 ⌊(M K)⌋₊, p.Prime → ∀ (P : Ideal (𝓞 K)),
-      P ∈ primesOver (span {(p : ℤ)}) (𝓞 K) → p ^ P.inertiaDeg' ℤ ≤ ⌊(M K)⌋₊ →
+      P ∈ primesOver (span {(p : ℤ)}) (𝓞 K) → p ^ P.inertiaDeg ℤ ≤ ⌊(M K)⌋₊ →
       Submodule.IsPrincipal P) : IsPrincipalIdealRing (𝓞 K) := by
   refine isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime <|
     fun ⟨P, HP⟩ hP hPN ↦ ?_
@@ -157,18 +157,18 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_I
     simpa [h, span_singleton_neg p, ← submodule_span_eq, ← hp] using over_under P
   have hspan : span {↑p.natAbs} = span {p} := by
     rcases abs_choice p with h | h <;> simp [h]
-  have hple : p.natAbs ^ P.inertiaDeg' ℤ ≤ ⌊(M K)⌋₊ := by
+  have hple : p.natAbs ^ P.inertiaDeg ℤ ≤ ⌊(M K)⌋₊ := by
     refine le_floor ?_
     have : P.IsMaximal := hP.isMaximal (by simpa using HP.2)
     have : (span {p}).IsMaximal := (hpprime (.under ℤ P)).isMaximal_span_singleton
-    simpa only [hspan, ← cast_pow, ← natAbs_pow_inertiaDeg' p P] using hPN
+    simpa only [hspan, ← cast_pow, ← natAbs_pow_inertiaDeg p P] using hPN
   have hpabsprime := Int.prime_iff_natAbs_prime.mp (hpprime (hP.under _))
   refine h _ ?_ hpabsprime _ ⟨hP, ?_⟩ hple
-  · suffices 0 < P.inertiaDeg' ℤ by
+  · suffices 0 < P.inertiaDeg ℤ by
       exact Finset.mem_Icc.mpr ⟨hpabsprime.one_le, le_trans (le_pow this) hple⟩
     have := (isPrime_of_prime (prime_span_singleton_iff.mpr <|
       hpprime (hP.under _))).isMaximal <| by simp [((hpprime (hP.under _))).ne_zero]
-    exact inertiaDeg'_pos ..
+    exact inertiaDeg_pos ..
   · exact hspan ▸ hlies
 
 /-- Let `K` be a number field such that `K/ℚ` is Galois and let `M K` be the Minkowski bound of `K`.
@@ -183,7 +183,7 @@ to deal with the finite number of primes `p` in the interval. -/
 theorem isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOver_of_mem_Icc
     [IsGalois ℚ K] (h : ∀ p ∈ Finset.Icc 1 ⌊(M K)⌋₊, p.Prime →
       ∃ P ∈ primesOver (span {(p : ℤ)}) (𝓞 K),
-        ⌊(M K)⌋₊ < p ^ P.inertiaDeg' ℤ ∨
+        ⌊(M K)⌋₊ < p ^ P.inertiaDeg ℤ ∨
           Submodule.IsPrincipal P) :
       IsPrincipalIdealRing (𝓞 K) := by
   refine isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc
@@ -191,7 +191,7 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOv
   obtain ⟨Q, ⟨hQ1, hQ2⟩, H⟩ := h p hpmem hp
   have := (isPrime_of_prime (prime_span_singleton_iff.mpr (prime_iff_prime_int.mp hp))).isMaximal
     (by simp [hp.ne_zero])
-  by_cases h : ⌊(M K)⌋₊ < p ^ P.inertiaDeg' ℤ
+  by_cases h : ⌊(M K)⌋₊ < p ^ P.inertiaDeg ℤ
   · linarith
   rw [inertiaDeg_eq_of_isGaloisGroup (span {↑p}) Q P (K ≃ₐ[ℚ] K)] at H
   obtain ⟨σ, rfl⟩ := exists_smul_eq_of_isGaloisGroup (span ({↑p} : Set ℤ)) Q P (K ≃ₐ[ℚ] K)

--- a/Mathlib/NumberTheory/NumberField/Completion/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/Completion/Ramification.lean
@@ -86,15 +86,15 @@ variable (w)
 open scoped Classical in
 /-- The inertia degree of `w` over `v`. -/
 protected noncomputable def inertiaDeg : ℕ :=
-  if _ : w.1.LiesOver v.1 then (⊥ : Ideal w.Completion).inertiaDeg' v.Completion else 0
+  if _ : w.1.LiesOver v.1 then (⊥ : Ideal w.Completion).inertiaDeg v.Completion else 0
 
 theorem inertiaDeg_of_liesOver [w.1.LiesOver v.1] :
-    v.inertiaDeg w = (⊥ : Ideal w.Completion).inertiaDeg' v.Completion := by
+    v.inertiaDeg w = (⊥ : Ideal w.Completion).inertiaDeg v.Completion := by
   simp only [InfinitePlace.inertiaDeg, dif_pos]
 
 theorem inertiaDeg_eq_finrank [w.1.LiesOver v.1] :
     v.inertiaDeg w = Module.finrank v.Completion w.Completion := by
-  rw [inertiaDeg_of_liesOver, Ideal.inertiaDeg'_eq_of_isMaximal ⊥]
+  rw [inertiaDeg_of_liesOver, Ideal.inertiaDeg_eq_of_isMaximal ⊥]
   exact Algebra.finrank_eq_of_equiv_equiv (RingEquiv.quotientBot v.Completion)
     (RingEquiv.quotientBot w.Completion) (by ext; simp [RingHom.algebraMap_toAlgebra])
 

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Galois.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Galois.lean
@@ -122,7 +122,7 @@ theorem mem_zpowers_galEquivZMod_of_mem_stabilizer {σ : Gal(K/ℚ)} (hσ : σ �
   have h₀ : IsPrimitiveRoot (Ideal.Quotient.mk P hζ.toInteger) n := by
     refine hζ.toInteger_isPrimitiveRoot.idealQuotient_mk
       (by simpa using IsMaximal.ne_top inferInstance) ?_
-    rw [← pow_inertiaDeg' p]
+    rw [← pow_inertiaDeg p]
     exact Nat.Coprime.pow_left _ hn
   have h₁ := IsFractionRing.stabilizerHom_apply_apply_mk Gal(K/ℚ) (Ideal.span {(p : ℤ)}) P
       (ℤ ⧸ span {(p : ℤ)}) (𝓞 K ⧸ P) ⟨σ, hσ⟩ hζ.toInteger

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -97,9 +97,9 @@ instance liesOver_span_zeta_sub_one : (span {hζ.toInteger - 1}).LiesOver 𝒑 :
   rw [span_singleton_le_iff_mem, mem_comap, algebraMap_int_eq, map_natCast]
   exact p_mem_span_zeta_sub_one p k hζ
 
-theorem inertiaDeg_span_zeta_sub_one : inertiaDeg' (span {hζ.toInteger - 1}) ℤ = 1 := by
+theorem inertiaDeg_span_zeta_sub_one : inertiaDeg (span {hζ.toInteger - 1}) ℤ = 1 := by
   have : IsMaximal (span {hζ.toInteger - 1}) := .of_liesOver_isMaximal _ 𝒑
-  rw [← Nat.pow_right_inj hp.out.one_lt, pow_one, pow_inertiaDeg',
+  rw [← Nat.pow_right_inj hp.out.one_lt, pow_one, pow_inertiaDeg,
     absNorm_span_zeta_sub_one]
 
 attribute [local instance] FractionRing.liftAlgebra in
@@ -156,7 +156,7 @@ theorem eq_span_zeta_sub_one_of_liesOver (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime
 
 include hK in
 theorem inertiaDeg_eq_of_prime_pow (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver 𝒑] :
-    inertiaDeg' P ℤ = 1 := by
+    inertiaDeg P ℤ = 1 := by
   rw [eq_span_zeta_sub_one_of_liesOver p k K hK.zeta_spec P, inertiaDeg_span_zeta_sub_one]
 
 include hK in
@@ -228,7 +228,7 @@ theorem isCoprime_of_not_zeta_sub_one_dvd {x : 𝓞 K} (hx : ¬ hζ.toInteger - 
     (prime_span_singleton_iff.mpr
     hζ.zeta_sub_one_prime').irreducible.gcd_eq_one_iff, dvd_span_singleton, mem_span_singleton]
 
-theorem inertiaDeg_span_zeta_sub_one' : inertiaDeg' (span {hζ.toInteger - 1}) ℤ = 1 := by
+theorem inertiaDeg_span_zeta_sub_one' : inertiaDeg (span {hζ.toInteger - 1}) ℤ = 1 := by
   rw [← pow_one p] at hK hζ
   exact inertiaDeg_span_zeta_sub_one p 0 hζ
 
@@ -259,7 +259,7 @@ theorem eq_span_zeta_sub_one_of_liesOver' (P : Ideal (𝓞 K)) [hP₁ : P.IsPrim
 
 include hK in
 theorem inertiaDeg_eq_of_prime (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver 𝒑] :
-    inertiaDeg' P ℤ = 1 := by
+    inertiaDeg P ℤ = 1 := by
   rw [eq_span_zeta_sub_one_of_liesOver' p K hK.zeta_spec P, inertiaDeg_span_zeta_sub_one']
 
 include hK in
@@ -291,7 +291,7 @@ open NumberField.Ideal Polynomial
 variable {m} [NeZero m] [hK : IsCyclotomicExtension {m} ℚ K]
 
 theorem inertiaDeg_eq_of_not_dvd (hm : ¬ p ∣ m) :
-    inertiaDeg' P ℤ = orderOf (p : ZMod m) := by
+    inertiaDeg P ℤ = orderOf (p : ZMod m) := by
   replace hm : p.Coprime m := hp.out.coprime_iff_not_dvd.mpr hm
   let ζ := (zeta_spec m ℚ K).toInteger
   have h₁ : ¬ p ∣ exponent ζ := by
@@ -427,7 +427,7 @@ theorem ramificationIdxIn_eq (hn : n = p ^ (k + 1) * m) (hm : ¬ p ∣ m) :
   (inertiaDegIn_ramificationIdxIn_aux n K hn hm).2
 
 theorem inertiaDeg_eq (hn : n = p ^ (k + 1) * m) (hm : ¬ p ∣ m) :
-    inertiaDeg' P ℤ = orderOf (p : ZMod m) := by
+    inertiaDeg P ℤ = orderOf (p : ZMod m) := by
   have : IsGalois ℚ K := isGalois {n} ℚ K
   rw [← inertiaDegIn_eq_inertiaDeg 𝒑 P Gal(K/ℚ), inertiaDegIn_eq n K hn hm]
 

--- a/Mathlib/NumberTheory/NumberField/Discriminant/Different.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant/Different.lean
@@ -189,9 +189,9 @@ lemma not_dvd_discr_iff_forall_liesOver [IsIntegralClosure 𝒪 ℤ K] {p : ℤ}
     exact ⟨P, hP, ⟨h₁.symm⟩, h₂⟩
   · rintro ⟨P, hP, hP', hP''⟩
     have := Ideal.absNorm_dvd_absNorm_of_le (Ideal.dvd_iff_le.mp hP'')
-    rw [absNorm_differentIdeal K, ← Ideal.natAbs_pow_inertiaDeg' p,
+    rw [absNorm_differentIdeal K, ← Ideal.natAbs_pow_inertiaDeg p,
       ← Int.natAbs_pow, Int.natAbs_dvd_natAbs] at this
-    exact (dvd_pow_self _ (Ideal.inertiaDeg'_pos ..).ne').trans this
+    exact (dvd_pow_self _ (Ideal.inertiaDeg_pos ..).ne').trans this
 
 /-- A prime `p` does not divide `discr K` if and only if `p` (as the ideal `span {p}`) is
 unramified in the ring of integers `𝒪`.

--- a/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
@@ -209,7 +209,7 @@ The residual degree of the ideal corresponding to the class of `Q ∈ ℤ[X]` mo
 -/
 theorem inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply (hp : ¬ p ∣ exponent θ)
     {Q : ℤ[X]} (hQ : Q.map (Int.castRingHom (ZMod p)) ∈ monicFactorsMod θ p) :
-    inertiaDeg' ((primesOverSpanEquivMonicFactorsMod hp).symm
+    inertiaDeg ((primesOverSpanEquivMonicFactorsMod hp).symm
       ⟨Q.map (Int.castRingHom (ZMod p)), hQ⟩ : Ideal (𝓞 K)) ℤ =
         natDegree (Q.map (Int.castRingHom (ZMod p))) := by
   -- This is needed for `inertiaDeg_algebraMap` below to work
@@ -218,14 +218,14 @@ theorem inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply (hp : ¬ p ∣ 
     apply Ideal.primesOver.isMaximal
   have := liesOver_primesOverSpanEquivMonicFactorsMod_symm hp hQ
   rw [primesOverSpanEquivMonicFactorsMod_symm_apply_eq_span,
-    inertiaDeg'_eq_of_isMaximal (span {(p : ℤ)}),
+    inertiaDeg_eq_of_isMaximal (span {(p : ℤ)}),
     ← finrank_quotient_span_eq_natDegree]
   refine Algebra.finrank_eq_of_equiv_equiv (Int.quotientSpanNatEquivZMod p) ?_ (by ext; simp)
   exact (ZModXQuotSpanEquivQuotSpanPair hp hQ).symm
 
 theorem inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply' (hp : ¬ p ∣ exponent θ)
     {Q : (ZMod p)[X]} (hQ : Q ∈ monicFactorsMod θ p) :
-    inertiaDeg'
+    inertiaDeg
       ((primesOverSpanEquivMonicFactorsMod hp).symm ⟨Q, hQ⟩ : Ideal (𝓞 K)) ℤ = natDegree Q := by
   obtain ⟨S, rfl⟩ := (map_surjective _ (ZMod.ringHom_surjective (Int.castRingHom (ZMod p)))) Q
   rw [inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply]

--- a/Mathlib/NumberTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Basic.lean
@@ -527,8 +527,8 @@ open scoped Classical in
 theorem Factors.finrank_pow_ramificationIdx [p.IsMaximal]
     (P : (factors (map (algebraMap R S) p)).toFinset) :
     finrank (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx' p P.1) =
-      ramificationIdx' p P.1 * inertiaDeg p (P : Ideal S) := by
-  rw [finrank_prime_pow_ramificationIdx, inertiaDeg_algebraMap]
+      ramificationIdx' p P.1 * inertiaDeg' p (P : Ideal S) := by
+  rw [finrank_prime_pow_ramificationIdx, inertiaDeg'_algebraMap]
   exacts [Factors.ne_bot p P, NeZero.ne _]
 
 open scoped Classical in
@@ -537,7 +537,7 @@ instance Factors.finiteDimensional_quotient_pow [Module.Finite R S] [p.IsMaximal
     FiniteDimensional (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx' p P.1) := by
   refine .of_finrank_pos ?_
   rw [pos_iff_ne_zero, Factors.finrank_pow_ramificationIdx]
-  exact mul_ne_zero (Factors.ramificationIdx_ne_zero p P) (inertiaDeg_pos p P.1).ne'
+  exact mul_ne_zero (Factors.ramificationIdx_ne_zero p P) (inertiaDeg'_pos p P.1).ne'
 
 universe w
 
@@ -595,10 +595,10 @@ here `S` is a finite `R`-module (and thus `Frac(S) : Frac(R)` is a finite extens
 is maximal. -/
 theorem sum_ramification_inertia {p : Ideal R} [p.IsMaximal] (hp0 : p ≠ ⊥) :
     ∑ P ∈ IsDedekindDomain.primesOverFinset p S,
-        ramificationIdx' p P * inertiaDeg p P = finrank K L := by
+        ramificationIdx' p P * inertiaDeg' p P = finrank K L := by
   set e := ramificationIdx' p (S := S)
   calc
-    ∑ P ∈ (factors (map (algebraMap R S) p)).toFinset, e P * inertiaDeg p P =
+    ∑ P ∈ (factors (map (algebraMap R S) p)).toFinset, e P * inertiaDeg' p P =
         ∑ P ∈ (factors (map (algebraMap R S) p)).toFinset.attach,
           finrank (R ⧸ p) (S ⧸ (P : Ideal S) ^ e P) := ?_
     _ = finrank (R ⧸ p)
@@ -616,7 +616,7 @@ theorem sum_ramification_inertia {p : Ideal R} [p.IsMaximal] (hp0 : p ≠ ⊥) :
 
 theorem inertiaDeg_le_finrank [NoZeroSMulDivisors R S] {p : Ideal R} [p.IsMaximal]
     (P : Ideal S) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver p] (hp0 : p ≠ ⊥) :
-    p.inertiaDeg P ≤ Module.finrank K L := by
+    p.inertiaDeg' P ≤ Module.finrank K L := by
   classical
   have hP : P ∈ IsDedekindDomain.primesOverFinset p S :=
     (IsDedekindDomain.mem_primesOverFinset_iff hp0 _).mpr ⟨hP₁, hP₂⟩
@@ -634,7 +634,7 @@ theorem ramificationIdx_le_finrank [NoZeroSMulDivisors R S] {p : Ideal R} [p.IsM
     (IsDedekindDomain.mem_primesOverFinset_iff hp0 _).mpr ⟨hP₁, hP₂⟩
   rw [← sum_ramification_inertia S K L hp0, ← Finset.add_sum_erase _ _ hP]
   refine le_trans (Nat.le_mul_of_pos_right _ ?_) (Nat.le_add_right _ _)
-  exact Nat.pos_iff_ne_zero.mpr <| inertiaDeg_ne_zero p P
+  exact Nat.pos_iff_ne_zero.mpr <| inertiaDeg'_ne_zero p P
 
 theorem card_primesOverFinset_le_finrank [NoZeroSMulDivisors R S] {p : Ideal R} [p.IsMaximal]
     (hp0 : p ≠ ⊥) : Finset.card (IsDedekindDomain.primesOverFinset p S) ≤ Module.finrank K L := by
@@ -644,13 +644,13 @@ theorem card_primesOverFinset_le_finrank [NoZeroSMulDivisors R S] {p : Ideal R} 
   have : P.LiesOver p := ((IsDedekindDomain.mem_primesOverFinset_iff hp0 _).mp hP).2
   refine Right.one_le_mul ?_ ?_
   · exact Nat.pos_iff_ne_zero.mpr <| IsDedekindDomain.ramificationIdx'_ne_zero_of_liesOver _ hp0
-  · exact Nat.pos_iff_ne_zero.mpr <| inertiaDeg_ne_zero p P
+  · exact Nat.pos_iff_ne_zero.mpr <| inertiaDeg'_ne_zero p P
 
 /-- `Ideal.sum_ramification_inertia`, in the local (DVR) case. -/
 lemma ramificationIdx_mul_inertiaDeg_of_isLocalRing [IsLocalRing S] {p : Ideal R} [p.IsMaximal]
     (hp0 : p ≠ ⊥) :
     ramificationIdx' p (IsLocalRing.maximalIdeal S) *
-      p.inertiaDeg (IsLocalRing.maximalIdeal S) = Module.finrank K L := by
+      p.inertiaDeg' (IsLocalRing.maximalIdeal S) = Module.finrank K L := by
   have := FaithfulSMul.of_field_isFractionRing R S K L
   simp_rw [← sum_ramification_inertia S K L hp0, IsLocalRing.primesOverFinset_eq S hp0,
     Finset.sum_singleton]

--- a/Mathlib/NumberTheory/RamificationInertia/Galois.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Galois.lean
@@ -67,7 +67,7 @@ open scoped Classical in
   maximal ideal `p` of `A` are the same, which we define as `Ideal.inertiaDegIn`. -/
 noncomputable def inertiaDegIn {A : Type*} [CommRing A] (p : Ideal A)
     (B : Type*) [CommRing B] [Algebra A B] : ℕ :=
-  if h : ∃ P : Ideal B, P.IsPrime ∧ P.LiesOver p then h.choose.inertiaDeg' A else 0
+  if h : ∃ P : Ideal B, P.IsPrime ∧ P.LiesOver p then h.choose.inertiaDeg A else 0
 
 section MulAction
 
@@ -145,9 +145,9 @@ theorem ramificationIdx_eq_of_isGaloisGroup :
 include p G in
 /-- All the `Ideal.inertiaDeg` over a fixed maximal ideal are the same. -/
 theorem inertiaDeg_eq_of_isGaloisGroup :
-    P.inertiaDeg' A = Q.inertiaDeg' A := by
+    P.inertiaDeg A = Q.inertiaDeg A := by
   rcases exists_smul_eq_of_isGaloisGroup p P Q G with ⟨σ, rfl⟩
-  rw [inertiaDeg'_smul]
+  rw [inertiaDeg_smul]
 
 include p G in
 /-- The `ramificationIdxIn` is equal to any ramification index over the same ideal. -/
@@ -168,7 +168,7 @@ theorem ramificationIdxIn_ne_zero [Module.Finite A B] [FaithfulSMul A B] {p : Id
 include G in
 /-- The `inertiaDegIn` is equal to any ramification index over the same ideal. -/
 theorem inertiaDegIn_eq_inertiaDeg :
-    inertiaDegIn p B = P.inertiaDeg' A := by
+    inertiaDegIn p B = P.inertiaDeg A := by
   have h : ∃ P : Ideal B, P.IsPrime ∧ P.LiesOver p := ⟨P, hPp, hp⟩
   obtain ⟨_, _⟩ := h.choose_spec
   rw [inertiaDegIn, dif_pos h]
@@ -179,7 +179,7 @@ theorem inertiaDegIn_ne_zero [Module.Finite A B] [FaithfulSMul A B] {p : Ideal A
     inertiaDegIn p B ≠ 0 := by
   obtain ⟨P⟩ := (inferInstance : Nonempty (primesOver p B))
   rw [inertiaDegIn_eq_inertiaDeg p P G]
-  exact (P.1.inertiaDeg'_pos A).ne'
+  exact (P.1.inertiaDeg_pos A).ne'
 
 section tower
 
@@ -194,7 +194,7 @@ theorem inertiaDegIn_mul_inertiaDegIn :
   obtain ⟨⟨Q, _, _⟩⟩ := (inferInstance : Nonempty (primesOver P C))
   have : Q.LiesOver p := LiesOver.trans Q P p
   rw [inertiaDegIn_eq_inertiaDeg p P G, inertiaDegIn_eq_inertiaDeg p Q GAC,
-    inertiaDegIn_eq_inertiaDeg P Q GBC, ← inertiaDeg'_tower P Q]
+    inertiaDegIn_eq_inertiaDeg P Q GBC, ← inertiaDeg_tower P Q]
 
 variable {p} in
 include G GAC GBC in
@@ -286,7 +286,7 @@ open Algebra
 attribute [local instance] Ideal.Quotient.field in
 theorem card_stabilizer_eq_card_inertia_mul_finrank (p : Ideal R) [p.IsPrime]
     (P : Ideal S) [P.LiesOver p] [P.IsPrime] [PerfectField p.ResidueField] :
-    Nat.card (MulAction.stabilizer G P) = Nat.card (inertia G P) * P.inertiaDeg' R := by
+    Nat.card (MulAction.stabilizer G P) = Nat.card (inertia G P) * P.inertiaDeg R := by
   let := Localization.AtPrime.algebraOfLiesOver p P
   have heq : (algebraMap (S ⧸ P) P.ResidueField).comp (algebraMap (R ⧸ p) (S ⧸ P)) =
       (algebraMap p.ResidueField P.ResidueField).comp (algebraMap (R ⧸ p) p.ResidueField) := by
@@ -301,14 +301,14 @@ theorem card_stabilizer_eq_card_inertia_mul_finrank (p : Ideal R) [p.IsPrime]
     Ideal.IsFractionRing.finite_of_isInvariant G p P p.ResidueField P.ResidueField
   have : Subgroup.index _ = _ := Nat.card_congr
     (IsFractionRing.stabilizerQuotientInertiaEquiv G p P p.ResidueField P.ResidueField).toEquiv
-  rw [inertiaDeg'_eq p P, ← IsGalois.card_aut_eq_finrank p.ResidueField P.ResidueField, ← this,
+  rw [inertiaDeg_eq p P, ← IsGalois.card_aut_eq_finrank p.ResidueField P.ResidueField, ← this,
     ← ((inertia G P).subgroupOf (MulAction.stabilizer G P)).card_mul_index,
     Nat.card_congr (Subgroup.subgroupOfEquivOfLe (inertia_le_stabilizer (M := G) P)).toEquiv,
     AddSubgroup.subgroupOf_inertia]
 
 lemma ncard_primesOver_mul_card_inertia_mul_finrank (p : Ideal R) [p.IsPrime]
     (P : Ideal S) [P.LiesOver p] [P.IsPrime] [PerfectField p.ResidueField] :
-    (p.primesOver S).ncard * Nat.card (P.inertia G) * P.inertiaDeg' R = Nat.card G := by
+    (p.primesOver S).ncard * Nat.card (P.inertia G) * P.inertiaDeg R = Nat.card G := by
   rw [mul_assoc, ← card_stabilizer_eq_card_inertia_mul_finrank p P,
     ← IsInvariant.orbit_eq_primesOver R S G p P]
   simpa using Nat.card_congr (MulAction.orbitProdStabilizerEquivGroup G P)

--- a/Mathlib/NumberTheory/RamificationInertia/HilbertTheory.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/HilbertTheory.lean
@@ -296,7 +296,7 @@ private lemma ramificationIdxIn_eq_and_inertiaDegIn_eq (hp : p ≠ ⊥) :
     exact 𝓟D.ramificationIdx_above_le P
   · rw [inertiaDegIn_eq_inertiaDeg p P Gal(L/K),
       inertiaDegIn_eq_inertiaDeg _ P (stabilizer Gal(L/K) P)]
-    exact inertiaDeg'_above_le 𝓟D P
+    exact inertiaDeg_above_le 𝓟D P
   · have := ncard_primesOver_mul_ramificationIdxIn_mul_inertiaDegIn 𝓟D B (stabilizer Gal(L/K) P)
     rw [primesOver_eq_singleton K L P D 𝓞D, Set.ncard_singleton, one_mul] at this
     rw [this, IsGaloisGroup.card_eq_finrank (stabilizer Gal(L/K) P) D L,
@@ -339,9 +339,9 @@ Let `D` be the decomposition field of `P` in `L/K`. Let `𝓟D` be a prime ideal
 then the inertia degree of `𝓟D` over `K` is equal to `1`.
 -/
 theorem inertiaDeg_eq (hp : p ≠ ⊥) :
-    𝓟D.inertiaDeg' A = 1 := by
+    𝓟D.inertiaDeg A = 1 := by
   obtain ⟨_, _, _, _, _, _⟩ := instances A K L P D 𝓞D 𝓟D hp
-  have := inertiaDeg'_tower (R := A) 𝓟D P
+  have := inertiaDeg_tower (R := A) 𝓟D P
   rwa [← inertiaDegIn_eq_inertiaDeg p P Gal(L/K), ← inertiaDegIn_eq A K L P D 𝓞D 𝓟D hp,
     ← inertiaDegIn_eq_inertiaDeg 𝓟D P (stabilizer Gal(L/K) P),
     right_eq_mul₀ <| inertiaDegIn_ne_zero (stabilizer Gal(L/K) P)] at this

--- a/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
@@ -102,7 +102,8 @@ theorem inertiaDeg'_pos' [P.IsPrime] [Module.Finite R S] [P.LiesOver p] : 0 < in
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_pos' := inertiaDeg'_pos'
 
-theorem inertiaDeg'_ne_zero [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] : inertiaDeg' p P ≠ 0 :=
+theorem inertiaDeg'_ne_zero [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] :
+    inertiaDeg' p P ≠ 0 :=
   (Nat.ne_of_lt (inertiaDeg'_pos p P)).symm
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_ne_zero := inertiaDeg'_ne_zero

--- a/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
@@ -13,7 +13,7 @@ public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 
 Given `P : Ideal S` lying over `p : Ideal R` for the ring extension `f : R →+* S`
 (assuming `P` and `p` are prime or maximal where needed),
-the **inertia degree** `Ideal.inertiaDeg p P` is the degree of the field extension
+the **inertia degree** `Ideal.inertiaDeg' p P` is the degree of the field extension
 `(S / P) : (R / p)`.
 
 ## Implementation notes
@@ -62,12 +62,12 @@ extension `(S / P) : (R / p)`.
 
 We do not assume `P` lies over `p` in the definition; we return `0` instead.
 
-See `inertiaDeg_algebraMap` for the common case where `f = algebraMap R S`
+See `inertiaDeg'_algebraMap` for the common case where `f = algebraMap R S`
 and there is an algebra structure `R / p → S / P`.
 
-Note: This definition of inertia degree will eventually be replaced by `Ideal.inertiaDeg'`.
+Note: This definition of inertia degree will eventually be replaced by `Ideal.inertiaDeg`.
 -/
-noncomputable def inertiaDeg : ℕ :=
+noncomputable def inertiaDeg' : ℕ :=
   if hPp : comap f P = p then
     letI : Algebra (R ⧸ p) (S ⧸ P) := Quotient.algebraQuotientOfLEComap hPp.ge
     finrank (R ⧸ p) (S ⧸ P)
@@ -75,91 +75,111 @@ noncomputable def inertiaDeg : ℕ :=
 
 -- Useful for the `nontriviality` tactic using `comap_eq_of_scalar_tower_quotient`.
 @[simp]
-theorem inertiaDeg_of_subsingleton [hp : p.IsMaximal] [hQ : Subsingleton (S ⧸ P)] :
-    inertiaDeg p P = 0 := by
+theorem inertiaDeg'_of_subsingleton [hp : p.IsMaximal] [hQ : Subsingleton (S ⧸ P)] :
+    inertiaDeg' p P = 0 := by
   have := Ideal.Quotient.subsingleton_iff.mp hQ
   subst this
   exact dif_neg fun h => hp.ne_top <| h.symm.trans comap_top
 
-@[simp]
-theorem inertiaDeg_algebraMap [P.LiesOver p] :
-    inertiaDeg p P = finrank (R ⧸ p) (S ⧸ P) := by
-  rw [inertiaDeg, dif_pos (over_def P p).symm]
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_of_subsingleton :=
+  inertiaDeg'_of_subsingleton
 
-theorem inertiaDeg_pos [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] : 0 < inertiaDeg p P :=
+@[simp]
+theorem inertiaDeg'_algebraMap [P.LiesOver p] :
+    inertiaDeg' p P = finrank (R ⧸ p) (S ⧸ P) := by
+  rw [inertiaDeg', dif_pos (over_def P p).symm]
+
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_algebraMap := inertiaDeg'_algebraMap
+
+theorem inertiaDeg'_pos [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] : 0 < inertiaDeg' p P :=
   have : Nontrivial (S ⧸ P) := Quotient.nontrivial_of_liesOver_of_isPrime P p
-  finrank_pos.trans_eq (inertiaDeg_algebraMap p P).symm
+  finrank_pos.trans_eq (inertiaDeg'_algebraMap p P).symm
 
 /-- Variant with a weaker constraint, but on the prime upstairs instead. -/
-theorem inertiaDeg_pos' [P.IsPrime] [Module.Finite R S] [P.LiesOver p] : 0 < inertiaDeg p P :=
+theorem inertiaDeg'_pos' [P.IsPrime] [Module.Finite R S] [P.LiesOver p] : 0 < inertiaDeg' p P :=
   have : p.IsPrime := Ideal.over_def P p ▸ inferInstance
-  Module.finrank_pos.trans_eq (inertiaDeg_algebraMap p P).symm
+  Module.finrank_pos.trans_eq (inertiaDeg'_algebraMap p P).symm
 
-theorem inertiaDeg_ne_zero [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] : inertiaDeg p P ≠ 0 :=
-  (Nat.ne_of_lt (inertiaDeg_pos p P)).symm
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_pos' := inertiaDeg'_pos'
 
-lemma inertiaDeg_comap_eq (e : S ≃ₐ[R] S₁) (P : Ideal S₁) :
-    inertiaDeg p (P.comap e) = inertiaDeg p P := by
+theorem inertiaDeg'_ne_zero [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] : inertiaDeg' p P ≠ 0 :=
+  (Nat.ne_of_lt (inertiaDeg'_pos p P)).symm
+
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_ne_zero := inertiaDeg'_ne_zero
+
+lemma inertiaDeg'_comap_eq (e : S ≃ₐ[R] S₁) (P : Ideal S₁) :
+    inertiaDeg' p (P.comap e) = inertiaDeg' p P := by
   have he : (P.comap e).comap (algebraMap R S) = p ↔ P.comap (algebraMap R S₁) = p := by
     rw [← comap_coe e, comap_comap, ← e.toAlgHom_toRingHom, AlgHom.comp_algebraMap]
   by_cases h : P.LiesOver p
-  · rw [inertiaDeg_algebraMap, inertiaDeg_algebraMap]
+  · rw [inertiaDeg'_algebraMap, inertiaDeg'_algebraMap]
     exact (Quotient.algEquivOfEqComap p e rfl).toLinearEquiv.finrank_eq
-  · rw [inertiaDeg, dif_neg (fun eq => h ⟨(he.mp eq).symm⟩)]
-    rw [inertiaDeg, dif_neg (fun eq => h ⟨eq.symm⟩)]
+  · rw [inertiaDeg', dif_neg (fun eq => h ⟨(he.mp eq).symm⟩)]
+    rw [inertiaDeg', dif_neg (fun eq => h ⟨eq.symm⟩)]
 
-lemma inertiaDeg_map_eq (P : Ideal S)
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_comap_eq := inertiaDeg'_comap_eq
+
+lemma inertiaDeg'_map_eq (P : Ideal S)
     {E : Type*} [EquivLike E S S₁] [AlgEquivClass E R S S₁] (e : E) :
-    inertiaDeg p (P.map e) = inertiaDeg p P := by
+    inertiaDeg' p (P.map e) = inertiaDeg' p P := by
   rw [show P.map e = _ from map_comap_of_equiv (RingEquivClass.toRingEquiv e : S ≃+* S₁)]
-  exact p.inertiaDeg_comap_eq (AlgEquivClass.toAlgEquiv e).symm P
+  exact p.inertiaDeg'_comap_eq (AlgEquivClass.toAlgEquiv e).symm P
 
-theorem inertiaDeg_bot [Nontrivial R] [IsDomain S] [Algebra.IsIntegral R S]
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_map_eq := inertiaDeg'_map_eq
+
+theorem inertiaDeg'_bot [Nontrivial R] [IsDomain S] [Algebra.IsIntegral R S]
     [hP : P.LiesOver (⊥ : Ideal R)] :
-    (⊥ : Ideal R).inertiaDeg P = finrank R S := by
-  rw [inertiaDeg, dif_pos (over_def P (⊥ : Ideal R)).symm]
+    (⊥ : Ideal R).inertiaDeg' P = finrank R S := by
+  rw [inertiaDeg', dif_pos (over_def P (⊥ : Ideal R)).symm]
   replace hP : P = ⊥ := eq_bot_of_liesOver_bot R P
   rw [Algebra.finrank_eq_of_equiv_equiv (RingEquiv.quotientBot R).symm
     ((quotEquivOfEq hP).trans (RingEquiv.quotientBot S)).symm]
   rfl
 
-theorem inertiaDeg_le_inertiaDeg {T : Type*} [CommRing T] [Algebra R T] [Algebra S T]
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_bot := inertiaDeg'_bot
+
+theorem inertiaDeg'_le_inertiaDeg' {T : Type*} [CommRing T] [Algebra R T] [Algebra S T]
     [IsScalarTower R S T] [Module.Finite R T] (Q : Ideal T) [P.LiesOver p] [Q.LiesOver P]
-    [p.IsPrime] : inertiaDeg P Q ≤ inertiaDeg p Q := by
+    [p.IsPrime] : inertiaDeg' P Q ≤ inertiaDeg' p Q := by
   have : Q.LiesOver p := LiesOver.trans Q P p
-  rw [inertiaDeg_algebraMap, inertiaDeg_algebraMap]
+  rw [inertiaDeg'_algebraMap, inertiaDeg'_algebraMap]
   have : IsScalarTower (R ⧸ p) (S ⧸ P) (T ⧸ Q) := IsScalarTower.of_algebraMap_eq <| by
     rintro ⟨x⟩
     simp [Submodule.Quotient.quot_mk_eq_mk, IsScalarTower.algebraMap_apply R (S ⧸ P) (T ⧸ Q)]
   exact finrank_top_le_finrank_of_isScalarTower ..
 
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_le_inertiaDeg := inertiaDeg'_le_inertiaDeg'
+
 end DecEq
 
 section absNorm
 
-lemma absNorm_eq_pow_inertiaDeg_of_liesOver {S : Type*} [CommRing S] [IsDedekindDomain S]
+lemma absNorm_eq_pow_inertiaDeg'_of_liesOver {S : Type*} [CommRing S] [IsDedekindDomain S]
     [Module.Free ℤ S] [IsDedekindDomain R] [Module.Free ℤ R] [Algebra S R] [Module.Finite S R]
     (P : Ideal R) (p : Ideal S) [P.LiesOver p] (hp : p.IsPrime) (hp_ne_bot : p ≠ ⊥) :
-    absNorm P = absNorm p ^ (p.inertiaDeg P) := by
+    absNorm P = absNorm p ^ (p.inertiaDeg' P) := by
   have : p.IsMaximal := hp.isMaximal hp_ne_bot
   let _ : Field (S ⧸ p) := Quotient.field p
   simpa [absNorm_apply, Submodule.cardQuot_apply] using Module.natCard_eq_pow_finrank (K := S ⧸ p)
 
+@[deprecated (since := "2026-07-03")] alias absNorm_eq_pow_inertiaDeg_of_liesOver :=
+  absNorm_eq_pow_inertiaDeg'_of_liesOver
+
 /-- The absolute norm of an ideal `P` above a rational prime `p` is
-`|p| ^ ((span {p}).inertiaDeg P)`.
+`|p| ^ ((span {p}).inertiaDeg' P)`.
 See `absNorm_eq_pow_inertiaDeg'` for a version with `p` of type `ℕ`. -/
 lemma absNorm_eq_pow_inertiaDeg [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] {p : ℤ}
     (P : Ideal R) [P.LiesOver (span {p})] (hp : Prime p) :
-    absNorm P = p.natAbs ^ ((span {p}).inertiaDeg P) := by
-  simpa using absNorm_eq_pow_inertiaDeg_of_liesOver P (span {p})
+    absNorm P = p.natAbs ^ ((span {p}).inertiaDeg' P) := by
+  simpa using absNorm_eq_pow_inertiaDeg'_of_liesOver P (span {p})
     (by rwa [span_singleton_prime hp.ne_zero]) (by simpa using hp.ne_zero)
 
 /-- The absolute norm of an ideal `P` above a rational (positive) prime `p` is
-`p ^ ((span {p}).inertiaDeg P)`.
+`p ^ ((span {p}).inertiaDeg' P)`.
 See `absNorm_eq_pow_inertiaDeg` for a version with `p` of type `ℤ`. -/
 lemma absNorm_eq_pow_inertiaDeg' [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] {p : ℕ}
     (P : Ideal R) [P.LiesOver (span {(p : ℤ)})] (hp : p.Prime) :
-    absNorm P = p ^ ((span {(p : ℤ)}).inertiaDeg P) :=
+    absNorm P = p ^ ((span {(p : ℤ)}).inertiaDeg' P) :=
   absNorm_eq_pow_inertiaDeg P (Nat.prime_iff_prime_int.mp hp)
 
 end absNorm
@@ -172,19 +192,21 @@ variable [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
 /-- Let `T / S / R` be a tower of algebras, `p, P, I` be ideals in `R, S, T`, respectively,
   and `p` and `P` are maximal. If `p = P ∩ S` and `P = I ∩ S`,
   then `f (I | p) = f (P | p) * f (I | P)`. -/
-theorem inertiaDeg_algebra_tower (p : Ideal R) (P : Ideal S) (I : Ideal T) [p.IsMaximal]
-    [P.IsMaximal] [P.LiesOver p] [I.LiesOver P] : inertiaDeg p I =
-    inertiaDeg p P * inertiaDeg P I := by
+theorem inertiaDeg'_algebra_tower (p : Ideal R) (P : Ideal S) (I : Ideal T) [p.IsMaximal]
+    [P.IsMaximal] [P.LiesOver p] [I.LiesOver P] : inertiaDeg' p I =
+    inertiaDeg' p P * inertiaDeg' P I := by
   have h₁ := P.over_def p
   have h₂ := I.over_def P
   have h₃ := (LiesOver.trans I P p).over
-  simp only [inertiaDeg, dif_pos h₁.symm, dif_pos h₂.symm, dif_pos h₃.symm]
+  simp only [inertiaDeg', dif_pos h₁.symm, dif_pos h₂.symm, dif_pos h₃.symm]
   letI : Algebra (R ⧸ p) (S ⧸ P) := Ideal.Quotient.algebraQuotientOfLEComap h₁.le
   letI : Algebra (S ⧸ P) (T ⧸ I) := Ideal.Quotient.algebraQuotientOfLEComap h₂.le
   letI : Algebra (R ⧸ p) (T ⧸ I) := Ideal.Quotient.algebraQuotientOfLEComap h₃.le
   letI : IsScalarTower (R ⧸ p) (S ⧸ P) (T ⧸ I) := IsScalarTower.of_algebraMap_eq <| by
     rintro ⟨x⟩; exact congr_arg _ (IsScalarTower.algebraMap_apply R S T x)
   exact (finrank_mul_finrank (R ⧸ p) (S ⧸ P) (T ⧸ I)).symm
+
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_algebra_tower := inertiaDeg'_algebra_tower
 
 end tower
 

--- a/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
@@ -398,20 +398,20 @@ See `Ideal.relNorm_eq_pow_of_isMaximal` for a statement that does not require th
 be Galois.
 -/
 theorem relNorm_eq_pow_of_isPrime_isGalois [p.IsMaximal] [P.IsPrime]
-    [IsGalois (FractionRing R) (FractionRing S)] : relNorm R P = p ^ P.inertiaDeg' R := by
+    [IsGalois (FractionRing R) (FractionRing S)] : relNorm R P = p ^ P.inertiaDeg R := by
   have : P.IsMaximal := IsMaximal.of_liesOver_isMaximal P p
   let G := Gal(FractionRing S/FractionRing R)
   let := IsIntegralClosure.MulSemiringAction R (FractionRing R) (FractionRing S) S
   have := IsGaloisGroup.of_isFractionRing G R S (FractionRing R) (FractionRing S)
   by_cases hp : p = ⊥
-  · have h : P.inertiaDeg' R ≠ 0 := (inertiaDeg'_pos P R).ne'
+  · have h : P.inertiaDeg R ≠ 0 := (inertiaDeg_pos P R).ne'
     have hP : P = ⊥ := by
       rw [hp] at hPp
       exact eq_bot_of_liesOver_bot R P
     rw [hp, hP, relNorm_bot, bot_pow]
     rwa [hP] at h
   obtain ⟨s, hs⟩ := exists_relNorm_eq_pow_of_isPrime P p
-  suffices s = P.inertiaDeg' R by rwa [this] at hs
+  suffices s = P.inertiaDeg R by rwa [this] at hs
   have h₀ : ∀ Q ∈ (p.primesOver S).toFinset,
       relNorm R Q ^ Q.ramificationIdx R = p ^ ((p.ramificationIdxIn S) * s) := by
     intro Q hQ
@@ -434,7 +434,7 @@ theorem relNorm_eq_pow_of_isPrime_isGalois [p.IsMaximal] [P.IsPrime]
   exact IsMaximal.ne_top inferInstance
 
 theorem relNorm_eq_pow_of_isMaximal [PerfectField (FractionRing R)] [P.IsMaximal] [p.IsMaximal] :
-    relNorm R P = p ^ P.inertiaDeg' R := by
+    relNorm R P = p ^ P.inertiaDeg R := by
   let T := Ring.NormalClosure R S
   obtain ⟨Q, hQ₁, hQ₂⟩ : ∃ Q : Ideal T, Q.IsMaximal ∧ Q.LiesOver P :=
     exists_maximal_ideal_liesOver_of_isIntegral P
@@ -443,7 +443,7 @@ theorem relNorm_eq_pow_of_isMaximal [PerfectField (FractionRing R)] [P.IsMaximal
   have : IsGalois (FractionRing S) (FractionRing T) :=
     IsGalois.tower_top_of_isGalois (FractionRing R) (FractionRing S) (FractionRing T)
   rwa [← relNorm_relNorm R S, relNorm_eq_pow_of_isPrime_isGalois Q P, map_pow,
-    inertiaDeg'_tower (R := R) P Q, pow_mul, pow_left_inj (inertiaDeg'_pos Q S).ne'] at h
+    inertiaDeg_tower (R := R) P Q, pow_mul, pow_left_inj (inertiaDeg_pos Q S).ne'] at h
 
 end relNorm_prime
 
@@ -469,8 +469,8 @@ theorem absNorm_relNorm [PerfectField (FractionRing R)] (I : Ideal S) :
     let P := under R Q
     let p := absNorm (under ℤ P)
     have : Q.LiesOver (span {(p : ℤ)}) := LiesOver.trans Q P _
-    rw [relNorm_eq_pow_of_isMaximal Q P, map_pow, ← pow_inertiaDeg' p, ← pow_inertiaDeg' p,
-      ← pow_mul, ← inertiaDeg'_tower]
+    rw [relNorm_eq_pow_of_isMaximal Q P, map_pow, ← pow_inertiaDeg p, ← pow_inertiaDeg p,
+      ← pow_mul, ← inertiaDeg_tower]
 
 theorem relNorm_int (I : Ideal S) :
     relNorm ℤ I = Ideal.span {(absNorm I : ℤ)} := by

--- a/Mathlib/RingTheory/Localization/AtPrime/Extension.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Extension.lean
@@ -168,8 +168,8 @@ theorem equivQuotientMapMaximalIdeal_apply_mk [p.IsMaximal] (x : S) :
 
 theorem inertiaDeg_map_eq_inertiaDeg [p.IsMaximal] [P.IsMaximal]
     [(Ideal.map (algebraMap S Sₚ) P).LiesOver (maximalIdeal Rₚ)] :
-    (maximalIdeal Rₚ).inertiaDeg (P.map (algebraMap S Sₚ)) = p.inertiaDeg P := by
-  rw [inertiaDeg_algebraMap, inertiaDeg_algebraMap]
+    (maximalIdeal Rₚ).inertiaDeg' (P.map (algebraMap S Sₚ)) = p.inertiaDeg' P := by
+  rw [inertiaDeg'_algebraMap, inertiaDeg'_algebraMap]
   refine Algebra.finrank_eq_of_equiv_equiv (equivQuotMaximalIdeal p Rₚ).symm
     (equivQuotientMapOfIsMaximal p Sₚ P).symm ?_
   ext x
@@ -238,8 +238,8 @@ theorem primesOverEquivPrimesOver_symm_apply (hp : p ≠ ⊥) (Q : (maximalIdeal
     ((primesOverEquivPrimesOver p Rₚ Sₚ hp).symm Q).1 = Ideal.comap (algebraMap S Sₚ) Q := rfl
 
 theorem primesOverEquivPrimesOver_inertiagDeg_eq [p.IsMaximal] (hp : p ≠ ⊥) (P : p.primesOver S) :
-    (maximalIdeal Rₚ).inertiaDeg (primesOverEquivPrimesOver p Rₚ Sₚ hp P : Ideal Sₚ) =
-      p.inertiaDeg P.val := by
+    (maximalIdeal Rₚ).inertiaDeg' (primesOverEquivPrimesOver p Rₚ Sₚ hp P : Ideal Sₚ) =
+      p.inertiaDeg' P.val := by
   have : NeZero p := ⟨hp⟩
   have : P.val.IsMaximal := Ring.DimensionLEOne.maximalOfPrime
     (ne_bot_of_mem_primesOver (NeZero.ne _) P.prop) inferInstance

--- a/Mathlib/RingTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Basic.lean
@@ -43,7 +43,7 @@ variable {R : Type*} [CommRing R] (p : Ideal R) [p.IsPrime] (S : Type*) [CommRin
 open IsLocalRing Module OrderIso PrimeSpectrum in
 theorem sum_ramification_inertia_eq_finrank_fiber
     [Algebra.QuasiFinite R S] [Fintype (p.primesOver S)] :
-    ∑ q : p.primesOver S, q.1.ramificationIdx R * q.1.inertiaDeg' R =
+    ∑ q : p.primesOver S, q.1.ramificationIdx R * q.1.inertiaDeg R =
       finrank p.ResidueField (p.Fiber S) := by
   let := Fintype.ofFinite (PrimeSpectrum (p.Fiber S))
   rw [IsArtinianRing.finrank_eq_sum_primeSpectrum, ← (primesOverOrderIsoFiber R S p).symm.sum_comp]
@@ -52,7 +52,7 @@ theorem sum_ramification_inertia_eq_finrank_fiber
   simp_rw [toEquiv_symm, coe_symm_toEquiv, coe_primesOverOrderIsoFiber_symm_apply]
   set r := q.1.comap Algebra.TensorProduct.includeRight
   let := Localization.AtPrime.algebraOfLiesOver p r
-  rw [ramificationIdx_eq p r, inertiaDeg'_eq p r]
+  rw [ramificationIdx_eq p r, inertiaDeg_eq p r]
   let Rp := Localization.AtPrime p
   let Sq := Localization.AtPrime q.1
   let Sr := Localization.AtPrime r
@@ -71,7 +71,7 @@ ideal of `R`. Then the sum over all prime ideals `q` of `S` lying over `p` of th
 index of `q` times the inertia degree of `q` equals the rank of `S` as an `R`-module. -/
 theorem sum_ramification_inertia_eq_finrank
     [IsDomain R] [Module.Finite R S] [Module.Flat R S] [Fintype (p.primesOver S)] :
-    ∑ q : p.primesOver S, q.1.ramificationIdx R * q.1.inertiaDeg' R = Module.finrank R S := by
+    ∑ q : p.primesOver S, q.1.ramificationIdx R * q.1.inertiaDeg R = Module.finrank R S := by
   rw [sum_ramification_inertia_eq_finrank_fiber, finrank_fiber_eq_finrank]
 
 /-- Let `S/R` be a finite flat extension of integral domains, and let `p` be prime ideal of `R`.
@@ -81,7 +81,7 @@ degree of `q` equals the cardinality of `G`. -/
 theorem sum_ramification_inertia_eq_card
     [IsDomain R] [IsDomain S] [Module.Finite R S] [Module.Flat R S] [Fintype (p.primesOver S)]
     {G : Type*} [Group G] [MulSemiringAction G S] [IsGaloisGroup G R S] :
-    ∑ q : p.primesOver S, q.1.ramificationIdx R * q.1.inertiaDeg' R = Nat.card G := by
+    ∑ q : p.primesOver S, q.1.ramificationIdx R * q.1.inertiaDeg R = Nat.card G := by
   let := IsGaloisGroup.finite G R S
   rw [sum_ramification_inertia_eq_finrank, IsGaloisGroup.card_eq_finrank' G R S]
 

--- a/Mathlib/RingTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Inertia.lean
@@ -16,13 +16,13 @@ to be the degree of the residue field of `q` over the residue field of its preim
 
 ## Main definitions
 
-* `Ideal.inertiaDeg' q R`: The inertia degree of `q` over `R`.
+* `Ideal.inertiaDeg q R`: The inertia degree of `q` over `R`.
 
 ## Main statements
 
-* `inertiaDeg_eq_inertiaDeg'`: The inertia degree agrees with the usual definition in the case of
+* `inertiaDeg'_eq_inertiaDeg`: The inertia degree agrees with the usual definition in the case of
   maximal ideals.
-* `inertiaDeg'_tower`: Inertia degree is multiplicative in towers.
+* `inertiaDeg_tower`: Inertia degree is multiplicative in towers.
 -/
 
 @[expose] public section
@@ -39,25 +39,30 @@ to be the degree of the residue field of `q` over the residue field of its preim
 
 When `q` is not prime, we use a junk value of `0`.
 
-This will eventually replace the existing definition of `Ideal.inertiaDeg`. -/
-noncomputable def inertiaDeg' : ℕ :=
+This will eventually replace the existing definition of `Ideal.inertiaDeg'`. -/
+noncomputable def inertiaDeg : ℕ :=
   if _ : q.IsPrime then
     letI := Localization.AtPrime.algebraOfLiesOver (q.under R) q
     Module.finrank (q.under R).ResidueField q.ResidueField else 0
 
-theorem inertiaDeg'_def [hq : q.IsPrime]
+theorem inertiaDeg_def [hq : q.IsPrime]
     [Algebra (Localization.AtPrime (q.under R)) (Localization.AtPrime q)]
     [Localization.AtPrime.IsLiesOverAlgebra (q.under R) q] :
-    q.inertiaDeg' R = Module.finrank (q.under R).ResidueField q.ResidueField := by
+    q.inertiaDeg R = Module.finrank (q.under R).ResidueField q.ResidueField := by
   convert! dif_pos hq
   simp [Algebra.algebra_ext_iff, Localization.AtPrime.IsLiesOverAlgebra.algebraMap_eq]
 
-theorem inertiaDeg'_of_not_isPrime (hq : ¬ q.IsPrime) : q.inertiaDeg' R = 0 :=
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_def := inertiaDeg_def
+
+theorem inertiaDeg_of_not_isPrime (hq : ¬ q.IsPrime) : q.inertiaDeg R = 0 :=
   dif_neg hq
 
-theorem inertiaDeg'_pos [hq : q.IsPrime] [Module.Finite R S] : 0 < q.inertiaDeg' R := by
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_of_not_isPrime :=
+  inertiaDeg_of_not_isPrime
+
+theorem inertiaDeg_pos [hq : q.IsPrime] [Module.Finite R S] : 0 < q.inertiaDeg R := by
   let := Localization.AtPrime.algebraOfLiesOver (q.under R) q
-  rw [inertiaDeg'_def]
+  rw [inertiaDeg_def]
   apply Module.finrank_pos
 
 end
@@ -68,15 +73,17 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
   [Algebra R S] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
   (p : Ideal R) (q : Ideal S) (r : Ideal T)
 
-theorem inertiaDeg'_eq [q.LiesOver p] [q.IsPrime] [p.IsPrime]
+theorem inertiaDeg_eq [q.LiesOver p] [q.IsPrime] [p.IsPrime]
     [Algebra (Localization.AtPrime p) (Localization.AtPrime q)]
     [Localization.AtPrime.IsLiesOverAlgebra p q] :
-    q.inertiaDeg' R = Module.finrank p.ResidueField q.ResidueField := by
+    q.inertiaDeg R = Module.finrank p.ResidueField q.ResidueField := by
   have := Ideal.over_def q p
   subst this
-  exact inertiaDeg'_def q R
+  exact inertiaDeg_def q R
 
-theorem inertiaDeg'_eq_of_isFractionRing [q.LiesOver p] [p.IsPrime] [q.IsPrime]
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_eq := inertiaDeg_eq
+
+theorem inertiaDeg_eq_of_isFractionRing [q.LiesOver p] [p.IsPrime] [q.IsPrime]
     (K L : Type*) [Field K] [Field L]
     [Algebra (R ⧸ p) K] [IsFractionRing (R ⧸ p) K]
     [Algebra (S ⧸ q) L] [IsFractionRing (S ⧸ q) L]
@@ -84,9 +91,9 @@ theorem inertiaDeg'_eq_of_isFractionRing [q.LiesOver p] [p.IsPrime] [q.IsPrime]
     [Algebra S L] [IsScalarTower S (S ⧸ q) L]
     [Algebra R L] [IsScalarTower R S L]
     [Algebra K L] [IsScalarTower R K L] :
-    q.inertiaDeg' R = Module.finrank K L := by
+    q.inertiaDeg R = Module.finrank K L := by
   let := Localization.AtPrime.algebraOfLiesOver p q
-  rw [inertiaDeg'_eq p q]
+  rw [inertiaDeg_eq p q]
   apply Algebra.finrank_eq_of_equiv_equiv
     (IsFractionRing.algEquivOfAlgEquiv (R := R) (A := R ⧸ p) (K := p.ResidueField) (L := K) .refl)
     (IsFractionRing.algEquivOfAlgEquiv (R := S) (A := S ⧸ q) (K := q.ResidueField) (L := L) .refl)
@@ -97,87 +104,113 @@ theorem inertiaDeg'_eq_of_isFractionRing [q.LiesOver p] [p.IsPrime] [q.IsPrime]
     IsScalarTower.algebraMap_apply R S q.ResidueField,
     ← IsScalarTower.algebraMap_apply R K L, ← IsScalarTower.algebraMap_apply R S L]
 
-theorem inertiaDeg'_eq_of_isMaximal [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
-    q.inertiaDeg' R = Module.finrank (R ⧸ p) (S ⧸ q) := by
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_eq_of_isFractionRing :=
+inertiaDeg_eq_of_isFractionRing
+
+theorem inertiaDeg_eq_of_isMaximal [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
+    q.inertiaDeg R = Module.finrank (R ⧸ p) (S ⧸ q) := by
   let : Field (R ⧸ p) := Quotient.field p
   let : Field (S ⧸ q) := Quotient.field q
-  exact inertiaDeg'_eq_of_isFractionRing p q (R ⧸ p) (S ⧸ q)
+  exact inertiaDeg_eq_of_isFractionRing p q (R ⧸ p) (S ⧸ q)
 
-theorem inertiaDeg_eq_inertiaDeg' [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
-    p.inertiaDeg q = q.inertiaDeg' R := by
-  rw [inertiaDeg_algebraMap, inertiaDeg'_eq_of_isMaximal p q]
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_eq_of_isMaximal :=
+  inertiaDeg_eq_of_isMaximal
 
-theorem inertiaDeg'_tower [r.LiesOver q] :
-    r.inertiaDeg' R = q.inertiaDeg' R * r.inertiaDeg' S := by
+theorem inertiaDeg'_eq_inertiaDeg [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
+    p.inertiaDeg' q = q.inertiaDeg R := by
+  rw [inertiaDeg'_algebraMap, inertiaDeg_eq_of_isMaximal p q]
+
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_eq_inertiaDeg' := inertiaDeg'_eq_inertiaDeg
+
+theorem inertiaDeg_tower [r.LiesOver q] :
+    r.inertiaDeg R = q.inertiaDeg R * r.inertiaDeg S := by
   by_cases hr : r.IsPrime
   · have : q.IsPrime := isPrime_of_liesOver r q
     have : q.LiesOver (r.under R) := LiesOver.tower_bot r q (r.under R)
     let := Localization.AtPrime.algebraOfLiesOver (r.under R) r
     let := Localization.AtPrime.algebraOfLiesOver (r.under R) q
     let := Localization.AtPrime.algebraOfLiesOver q r
-    rw [inertiaDeg'_def, inertiaDeg'_eq (r.under R), inertiaDeg'_eq q, eq_comm]
+    rw [inertiaDeg_def, inertiaDeg_eq (r.under R), inertiaDeg_eq q, eq_comm]
     apply Module.finrank_mul_finrank
-  · rw [inertiaDeg'_of_not_isPrime r R hr, inertiaDeg'_of_not_isPrime r S hr, mul_zero]
+  · rw [inertiaDeg_of_not_isPrime r R hr, inertiaDeg_of_not_isPrime r S hr, mul_zero]
 
-theorem inertiaDeg'_below_dvd [r.LiesOver q] :
-    q.inertiaDeg' R ∣ r.inertiaDeg' R := by
-  use r.inertiaDeg' S
-  rw [← inertiaDeg'_tower]
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_tower := inertiaDeg_tower
 
-theorem inertiaDeg'_above_dvd [r.LiesOver q] :
-    r.inertiaDeg' S ∣ r.inertiaDeg' R := by
-  use q.inertiaDeg' R
-  rw [mul_comm, ← inertiaDeg'_tower]
+theorem inertiaDeg_below_dvd [r.LiesOver q] :
+    q.inertiaDeg R ∣ r.inertiaDeg R := by
+  use r.inertiaDeg S
+  rw [← inertiaDeg_tower]
 
-theorem inertiaDeg'_below_le [r.IsPrime] [r.LiesOver q] [Module.Finite R T] :
-    q.inertiaDeg' R ≤ r.inertiaDeg' R :=
-  Nat.le_of_dvd (r.inertiaDeg'_pos R) (q.inertiaDeg'_below_dvd r)
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_below_dvd := inertiaDeg_below_dvd
 
-theorem inertiaDeg'_above_le [r.IsPrime] [r.LiesOver q] [Module.Finite R T] :
-    r.inertiaDeg' S ≤ r.inertiaDeg' R :=
-  Nat.le_of_dvd (r.inertiaDeg'_pos R) (q.inertiaDeg'_above_dvd r)
+theorem inertiaDeg_above_dvd [r.LiesOver q] :
+    r.inertiaDeg S ∣ r.inertiaDeg R := by
+  use q.inertiaDeg R
+  rw [mul_comm, ← inertiaDeg_tower]
+
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_above_dvd := inertiaDeg_above_dvd
+
+theorem inertiaDeg_below_le [r.IsPrime] [r.LiesOver q] [Module.Finite R T] :
+    q.inertiaDeg R ≤ r.inertiaDeg R :=
+  Nat.le_of_dvd (r.inertiaDeg_pos R) (q.inertiaDeg_below_dvd r)
+
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_below_le := inertiaDeg_below_le
+
+theorem inertiaDeg_above_le [r.IsPrime] [r.LiesOver q] [Module.Finite R T] :
+    r.inertiaDeg S ≤ r.inertiaDeg R :=
+  Nat.le_of_dvd (r.inertiaDeg_pos R) (q.inertiaDeg_above_dvd r)
+
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_above_le := inertiaDeg_above_le
 
 variable (R) in
 open Pointwise in
 @[simp]
-theorem inertiaDeg'_smul {G : Type*} [Group G] [MulSemiringAction G S] [SMulCommClass G R S]
-    (g : G) : (g • q).inertiaDeg' R = q.inertiaDeg' R := by
+theorem inertiaDeg_smul {G : Type*} [Group G] [MulSemiringAction G S] [SMulCommClass G R S]
+    (g : G) : (g • q).inertiaDeg R = q.inertiaDeg R := by
   by_cases hq : q.IsPrime; swap
-  · rw [inertiaDeg'_of_not_isPrime, inertiaDeg'_of_not_isPrime] <;> simpa
+  · rw [inertiaDeg_of_not_isPrime, inertiaDeg_of_not_isPrime] <;> simpa
   · let p := q.under R
     let f₀ := MulSemiringAction.toAlgAut G R S g
     let := Localization.AtPrime.algebraOfLiesOver p q
     let := Localization.AtPrime.algebraOfLiesOver p (g • q)
-    rw [inertiaDeg'_eq p q, inertiaDeg'_eq p (g • q)]
+    rw [inertiaDeg_eq p q, inertiaDeg_eq p (g • q)]
     let e₂ := Ideal.residueFieldAlgEquiv' p (g • q) q f₀.symm (comap_symm f₀.toRingEquiv).symm
     exact e₂.toLinearEquiv.finrank_eq
 
-theorem cardQuot_pow_inertiaDeg' [Module.Finite R S] [p.IsMaximal] [q.IsMaximal] [q.LiesOver p] :
-    p.cardQuot ^ q.inertiaDeg' R = q.cardQuot := by
+@[deprecated (since := "2026-07-03")] alias inertiaDeg'_smul := inertiaDeg_smul
+
+theorem cardQuot_pow_inertiaDeg [Module.Finite R S] [p.IsMaximal] [q.IsMaximal] [q.LiesOver p] :
+    p.cardQuot ^ q.inertiaDeg R = q.cardQuot := by
   let _ : Field (R ⧸ p) := Quotient.field p
-  rw [← inertiaDeg_eq_inertiaDeg' p q, inertiaDeg_algebraMap p q]
+  rw [← inertiaDeg'_eq_inertiaDeg p q, inertiaDeg'_algebraMap p q]
   exact Module.natCard_eq_pow_finrank.symm
 
-theorem absNorm_pow_inertiaDeg' [Module.Finite R S] [q.IsPrime] [q.LiesOver p]
+@[deprecated (since := "2026-07-03")] alias cardQuot_pow_inertiaDeg' := cardQuot_pow_inertiaDeg
+
+theorem absNorm_pow_inertiaDeg [Module.Finite R S] [q.IsPrime] [q.LiesOver p]
     [IsDedekindDomain R] [IsDedekindDomain S] [Module.Free ℤ R] [Module.Free ℤ S] :
-    p.absNorm ^ q.inertiaDeg' R = q.absNorm := by
+    p.absNorm ^ q.inertiaDeg R = q.absNorm := by
   by_cases hp : p = ⊥
   · subst hp
-    simpa [eq_bot_of_liesOver_bot R q] using (inertiaDeg'_pos q R).ne'
+    simpa [eq_bot_of_liesOver_bot R q] using (inertiaDeg_pos q R).ne'
   have := isPrime_of_liesOver q p
   have := isMaximal_of_isPrime_of_ne_bot p hp
   have := IsMaximal.of_liesOver_isMaximal q p
-  exact cardQuot_pow_inertiaDeg' p q
+  exact cardQuot_pow_inertiaDeg p q
 
-theorem natAbs_pow_inertiaDeg' [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] (p : ℤ)
+@[deprecated (since := "2026-07-03")] alias absNorm_pow_inertiaDeg' := absNorm_pow_inertiaDeg
+
+theorem natAbs_pow_inertiaDeg [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] (p : ℤ)
     (P : Ideal R) [P.IsPrime] [P.LiesOver (span {p})] :
-    p.natAbs ^ P.inertiaDeg' ℤ = absNorm P := by
-  simpa using absNorm_pow_inertiaDeg' (span {p}) P
+    p.natAbs ^ P.inertiaDeg ℤ = absNorm P := by
+  simpa using absNorm_pow_inertiaDeg (span {p}) P
 
-theorem pow_inertiaDeg' [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] (p : ℕ)
+@[deprecated (since := "2026-07-03")] alias natAbs_pow_inertiaDeg' := natAbs_pow_inertiaDeg
+
+theorem pow_inertiaDeg [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] (p : ℕ)
     (P : Ideal R) [P.IsPrime] [P.LiesOver (span {(p : ℤ)})] :
-    p ^ P.inertiaDeg' ℤ = absNorm P :=
-  natAbs_pow_inertiaDeg' p P
+    p ^ P.inertiaDeg ℤ = absNorm P :=
+  natAbs_pow_inertiaDeg p P
 
 end
 


### PR DESCRIPTION
This PR swaps `inertiaDeg` and `inertiaDeg'`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
