### PR TITLE
feat(NumberTheory): associativity of the Hecke coset module product

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5734,7 +5734,8 @@ public import Mathlib.NumberTheory.Harmonic.EulerMascheroni
 public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
-public import Mathlib.NumberTheory.HeckeRing.Basic
+public import Mathlib.NumberTheory.HeckeRing.Associativity
+import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.HeckeRing.Multiplication
 public import Mathlib.NumberTheory.HeckeRing.Multiplicity

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5735,7 +5735,7 @@ public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
 public import Mathlib.NumberTheory.HeckeRing.Associativity
-import Mathlib.NumberTheory.HeckeRing.Basic
+public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.HeckeRing.Multiplication
 public import Mathlib.NumberTheory.HeckeRing.Multiplicity

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5737,6 +5737,7 @@ public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
 public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.HeckeRing.Multiplicity
+public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve
 public import Mathlib.NumberTheory.Height.MvPolynomial

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5734,6 +5734,7 @@ public import Mathlib.NumberTheory.Harmonic.EulerMascheroni
 public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
+public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5737,6 +5737,7 @@ public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
 public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.HeckeRing.Multiplicity
+public import Mathlib.NumberTheory.HeckeRing.MultiplicitySupport
 public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5736,6 +5736,7 @@ public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
 public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
+public import Mathlib.NumberTheory.HeckeRing.Multiplicity
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve
 public import Mathlib.NumberTheory.Height.MvPolynomial

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5736,6 +5736,7 @@ public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
 public import Mathlib.NumberTheory.HeckeRing.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
+public import Mathlib.NumberTheory.HeckeRing.Multiplication
 public import Mathlib.NumberTheory.HeckeRing.Multiplicity
 public import Mathlib.NumberTheory.HeckeRing.MultiplicitySupport
 public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5740,6 +5740,7 @@ public import Mathlib.NumberTheory.HeckeRing.Multiplication
 public import Mathlib.NumberTheory.HeckeRing.Multiplicity
 public import Mathlib.NumberTheory.HeckeRing.MultiplicitySupport
 public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
+public import Mathlib.NumberTheory.HeckeRing.One
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve
 public import Mathlib.NumberTheory.Height.MvPolynomial

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5734,6 +5734,7 @@ public import Mathlib.NumberTheory.Harmonic.EulerMascheroni
 public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
+public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve
 public import Mathlib.NumberTheory.Height.MvPolynomial

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -569,5 +569,10 @@ lemma conjAct_pointwise_smul_eq_self {H : Subgroup G} {g : G} (hg : g ∈ normal
     ConjAct.toConjAct g • H = H :=
   conjAct_pointwise_smul_iff.2 hg
 
+lemma mem_conjAct_pointwise_smul_iff {H : Subgroup G} {g x : G} :
+    x ∈ ConjAct.toConjAct g • H ↔ g⁻¹ * x * g ∈ H := by
+  rw [mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv, ConjAct.smul_def,
+    ConjAct.ofConjAct_toConjAct, inv_inv]
+
 end Group
 end Subgroup

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -55,6 +55,14 @@ lemma doubleCoset_eq_of_mem {H K : Subgroup G} {a b : G} (hb : b ∈ doubleCoset
     mul_assoc, mul_assoc, Subgroup.singleton_mul_subgroup hk, ← mul_assoc, ← mul_assoc,
     Subgroup.subgroup_mul_singleton hh]
 
+lemma doubleCoset_mul_left {H : Subgroup G} (K : Subgroup G) {h : G} (hh : h ∈ H) (a : G) :
+    doubleCoset (h * a) H K = doubleCoset a H K :=
+  doubleCoset_eq_of_mem (mem_doubleCoset.mpr ⟨h, hh, 1, K.one_mem, (mul_one _).symm⟩)
+
+lemma doubleCoset_mul_right (H : Subgroup G) {K : Subgroup G} {k : G} (hk : k ∈ K) (a : G) :
+    doubleCoset (a * k) H K = doubleCoset a H K :=
+  doubleCoset_eq_of_mem (mem_doubleCoset.mpr ⟨1, H.one_mem, k, hk, by rw [one_mul]⟩)
+
 lemma mem_doubleCoset_of_not_disjoint {H K : Subgroup G} {a b : G}
     (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) : b ∈ doubleCoset a H K := by
   rw [Set.not_disjoint_iff] at h
@@ -190,6 +198,26 @@ lemma doubleCoset_union_leftCoset (H K : Subgroup G) (a : G) :
     simp only [hxy, ← mul_assoc, hy, one_mul, inv_mul_cancel, inv_mul_cancel_right]
 
 open Quotient QuotientGroup
+
+/-- A double coset `HaK` is the union of the left cosets `(h * a) • K` where `h` ranges over
+representatives of the quotient of `H` by the stabiliser `H ∩ aKa⁻¹`. -/
+lemma doubleCoset_eq_iUnion_leftCosets (H K : Subgroup G) (a : G) :
+    doubleCoset a H K =
+      ⋃ i : H ⧸ (ConjAct.toConjAct a • K).subgroupOf H, ((i.out : G) * a) • (K : Set G) := by
+  ext x
+  simp only [Set.mem_iUnion, mem_doubleCoset, mem_leftCoset_iff, SetLike.mem_coe]
+  constructor
+  · rintro ⟨h, hh, k, hk, rfl⟩
+    refine ⟨QuotientGroup.mk ⟨h, hh⟩, ?_⟩
+    obtain ⟨n, hn⟩ := QuotientGroup.mk_out_eq_mul ((ConjAct.toConjAct a • K).subgroupOf H) ⟨h, hh⟩
+    have hn' : a⁻¹ * ((n : H) : G) * a ∈ K :=
+      Subgroup.mem_conjAct_pointwise_smul_iff.mp (Subgroup.mem_subgroupOf.mp n.2)
+    rw [hn, show (((⟨h, hh⟩ : H) * (n : H) : H) : G) = h * ((n : H) : G) from rfl,
+      show (h * ((n : H) : G) * a)⁻¹ * (h * a * k) = (a⁻¹ * ((n : H) : G) * a)⁻¹ * k by
+        simp [mul_assoc]]
+    exact K.mul_mem (K.inv_mem hn') hk
+  · rintro ⟨i, hx⟩
+    exact ⟨(i.out : G), i.out.2, ((i.out : G) * a)⁻¹ * x, hx, (mul_inv_cancel_left _ _).symm⟩
 
 lemma left_bot_eq_left_quot (H : Subgroup G) :
     Quotient (⊥ : Subgroup G) (H : Set G) = (G ⧸ H) := by

--- a/Mathlib/NumberTheory/HeckeRing/Associativity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Associativity.lean
@@ -12,8 +12,9 @@ public import Mathlib.NumberTheory.HeckeRing.One
 # Hecke rings: associativity
 
 Associativity of the convolution product of Hecke coset modules, in the mixed-level generality
-`𝕋 Δ H₁ H₂ R × 𝕋 Δ H₂ H₃ R × 𝕋 Δ H₃ H₄ R`, following Proposition 3.2 of
-[Shimura][shimura1971]. The combinatorial input is the invariance of Shimura's multiplicity
+`HeckeCosetModule Δ H₁ H₂ R × HeckeCosetModule Δ H₂ H₃ R × HeckeCosetModule Δ H₃ H₄ R`, following
+Proposition 3.2 of [Shimura][shimura1971]. The combinatorial input is the invariance of Shimura's
+multiplicity
 `m(g, h; d)` in `d` under the double coset of `d`: both associations of a triple product then
 count the triples of representatives `(σᵢ, τⱼ, υₖ)` with `σᵢ g₁ τⱼ g₂ υₖ g₃ Γ₄ = d Γ₄`, and the
 two bookkeepings are matched through the one-sided description of the multiplicity
@@ -26,7 +27,7 @@ two bookkeepings are matched through the one-sided description of the multiplici
 * `DoubleCoset.multiplicity_doubleCoset_congr`: `m(g, h; d)` depends on `d` only through the
   double coset `Γ₁dΓ₃`.
 * `HeckeCosetModule.mul_assoc'`: associativity of the convolution product at mixed levels.
-* the `Semiring (𝕋 Δ H H R)` instance.
+* the `Semiring (𝕋 Δ H R)` instance.
 -/
 
 @[expose] public section
@@ -190,8 +191,8 @@ private lemma sum_ite_mem_multiplicity [IsHeckeTriple Δ H₂ H₃] [IsHeckeTrip
     obtain ⟨w, hw, y, hy, rfl⟩ := mem_doubleCoset.mp (multiplicity_ne_zero_iff.mp hne)
     obtain ⟨β, hβ, c, hc, rfl⟩ := mem_doubleCoset.mp hw
     have hxΔ : β * (g₂ : G) * c * (g₃ : G) * y ∈ Δ :=
-      Δ.mul_mem (Δ.mul_mem (Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_left H₃ hβ) g₂.2)
-        (IsHeckeTriple.mem_left H₄ hc)) g₃.2) (IsHeckeTriple.mem_right H₃ hy)
+      Δ.mul_mem (Δ.mul_mem (Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_of_mem_left H₃ hβ) g₂.2)
+        (IsHeckeTriple.mem_of_mem_left H₄ hc)) g₃.2) (IsHeckeTriple.mem_of_mem_right H₃ hy)
     set xΔ : Δ := ⟨β * (g₂ : G) * c * (g₃ : G) * y, hxΔ⟩
     have hrep : ((HeckeCoset.mk H₂ H₄ xΔ).rep : G) ∈ doubleCoset (xΔ : G) H₂ H₄ := by
       have h1 := HeckeCoset.rep_mem (HeckeCoset.mk H₂ H₄ xΔ)
@@ -294,8 +295,8 @@ lemma sum_image_mulMap_multiplicity_left [IsHeckeTriple Δ H₁ H₂]
   -- product of the representatives of `p`.
   set wG : G := (p.1.out : G) * g₁ * ((p.2.out : G) * g₂) with hwG
   have hwΔ : wG ∈ Δ :=
-    Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_left H₂ p.1.out.2) g₁.2)
-      (Δ.mul_mem (IsHeckeTriple.mem_left H₃ p.2.out.2) g₂.2)
+    Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_of_mem_left H₂ p.1.out.2) g₁.2)
+      (Δ.mul_mem (IsHeckeTriple.mem_of_mem_left H₃ p.2.out.2) g₂.2)
   set E₀ : HeckeCoset Δ H₁ H₃ := HeckeCoset.mk H₁ H₃ ⟨wG, hwΔ⟩ with hE₀def
   have hE₀mem : E₀ ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂) :=
     Finset.mem_image.mpr ⟨p, Finset.mem_univ p, rfl⟩
@@ -379,41 +380,42 @@ private lemma support_structureConstants_subset [IsHeckeTriple Δ H₁ H₂]
       Finset.univ.image (HeckeCoset.mulMap H₁ H₂ H₃ g₁ g₂) :=
   Finsupp.support_onFinset_subset
 
-/-- `Finsupp.sum_smul_index`, restated for the wrapper type `𝕋 Δ H₁ H₂ R`. -/
-private lemma sum_smul_index_T {N : Type*} [AddCommMonoid N] (a : R) (f : 𝕋 Δ H₁ H₂ R)
-    (F : HeckeCoset Δ H₁ H₂ → R → N) (h0 : ∀ D, F D 0 = 0) :
+/-- `Finsupp.sum_smul_index`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R`. -/
+private lemma sum_smul_index_T {N : Type*} [AddCommMonoid N] (a : R)
+    (f : HeckeCosetModule Δ H₁ H₂ R) (F : HeckeCoset Δ H₁ H₂ → R → N) (h0 : ∀ D, F D 0 = 0) :
     (a • f).sum F = f.sum fun D c ↦ F D (a * c) :=
   Finsupp.sum_smul_index h0
 
-/-- `Finsupp.smul_apply`, restated for the wrapper type `𝕋 Δ H₁ H₂ R`. -/
-private lemma smul_apply_T (a : R) (f : 𝕋 Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
+/-- `Finsupp.smul_apply`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R`. -/
+private lemma smul_apply_T (a : R) (f : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
     (a • f) D = a * f D :=
   rfl
 
 /-- Unfolding `Finsupp.sum` with the wrapper-type coercion. -/
-private lemma sum_eq_sum_T {N : Type*} [AddCommMonoid N] (f : 𝕋 Δ H₁ H₂ R)
+private lemma sum_eq_sum_T {N : Type*} [AddCommMonoid N] (f : HeckeCosetModule Δ H₁ H₂ R)
     (F : HeckeCoset Δ H₁ H₂ → R → N) : f.sum F = ∑ D ∈ f.support, F D (f D) :=
   rfl
 
-/-- `Finsupp.notMem_support_iff`, restated for the wrapper type `𝕋 Δ H₁ H₂ R`. -/
-private lemma apply_eq_zero_of_notMem_support_T (f : 𝕋 Δ H₁ H₂ R)
+/-- `Finsupp.notMem_support_iff`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R`. -/
+private lemma apply_eq_zero_of_notMem_support_T (f : HeckeCosetModule Δ H₁ H₂ R)
     (D : HeckeCoset Δ H₁ H₂) (h : D ∉ f.support) : f D = 0 :=
   Finsupp.notMem_support_iff.mp h
 
-/-- `Finsupp.zero_apply`, restated for the wrapper type `𝕋 Δ H₁ H₂ R`. -/
-private lemma zero_apply_T (D : HeckeCoset Δ H₁ H₂) : (0 : 𝕋 Δ H₁ H₂ R) D = 0 :=
+/-- `Finsupp.zero_apply`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R`. -/
+private lemma zero_apply_T (D : HeckeCoset Δ H₁ H₂) : (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 :=
   rfl
 
-/-- `Finsupp.sum_apply`, restated for the wrapper type `𝕋 Δ H₁ H₂ R`. -/
-private lemma sum_apply_T {H₁ H₂ H₃ H₄ : Subgroup G} (f : 𝕋 Δ H₁ H₂ R)
-    (F : HeckeCoset Δ H₁ H₂ → R → 𝕋 Δ H₃ H₄ R) (D : HeckeCoset Δ H₃ H₄) :
+/-- `Finsupp.sum_apply`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R`. -/
+private lemma sum_apply_T {H₁ H₂ H₃ H₄ : Subgroup G} (f : HeckeCosetModule Δ H₁ H₂ R)
+    (F : HeckeCoset Δ H₁ H₂ → R → HeckeCosetModule Δ H₃ H₄ R) (D : HeckeCoset Δ H₃ H₄) :
     (f.sum F) D = f.sum fun E c ↦ F E c D :=
   Finsupp.sum_apply
 
 /-- The convolution product commutes with scalar multiplication on the left factor. (Note
 that the corresponding statement for the right factor fails over a noncommutative `R`.) -/
 lemma smul_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] (a : R)
-    (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) : mul R (a • f) g = a • mul R f g := by
+    (f : HeckeCosetModule Δ H₁ H₂ R) (g : HeckeCosetModule Δ H₂ H₃ R) :
+    mul R (a • f) g = a • mul R f g := by
   rw [mul_eq_sum, mul_eq_sum, sum_smul_index_T R a f _ fun D₁ ↦ by simp,
     Finsupp.sum, Finsupp.sum, Finset.smul_sum]
   refine Finset.sum_congr rfl fun D₁ _ ↦ ?_
@@ -422,7 +424,7 @@ lemma smul_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] (a : R)
 
 /-- Evaluation of the convolution product against a basis element on the left. -/
 lemma single_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
-    (D₁ : HeckeCoset Δ H₁ H₂) (b₁ : R) (g : 𝕋 Δ H₂ H₃ R) :
+    (D₁ : HeckeCoset Δ H₁ H₂) (b₁ : R) (g : HeckeCosetModule Δ H₂ H₃ R) :
     mul R (single R D₁ b₁) g =
       g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep := by
   rw [mul_eq_sum, single]
@@ -430,16 +432,17 @@ lemma single_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
 
 /-- Evaluation of the convolution product against a basis element on the right. -/
 lemma mul_single [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
-    (f : 𝕋 Δ H₁ H₂ R) (D₂ : HeckeCoset Δ H₂ H₃) (b₂ : R) :
+    (f : HeckeCosetModule Δ H₁ H₂ R) (D₂ : HeckeCoset Δ H₂ H₃) (b₂ : R) :
     mul R f (single R D₂ b₂) =
       f.sum fun D₁ b₁ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep := by
   rw [mul_eq_sum]
   exact Finsupp.sum_congr fun D₁ _ ↦ Finsupp.sum_single_index (by simp)
 
-/-- `Finsupp.induction_linear`, restated for the wrapper type `𝕋 Δ H₁ H₂ R` so that the
-hypotheses match the `HeckeCosetModule` vocabulary. -/
-private lemma induction_linear {p : 𝕋 Δ H₁ H₂ R → Prop} (f : 𝕋 Δ H₁ H₂ R) (h0 : p 0)
-    (hadd : ∀ f g : 𝕋 Δ H₁ H₂ R, p f → p g → p (f + g))
+/-- `Finsupp.induction_linear`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R` so
+that the hypotheses match the `HeckeCosetModule` vocabulary. -/
+private lemma induction_linear {p : HeckeCosetModule Δ H₁ H₂ R → Prop}
+    (f : HeckeCosetModule Δ H₁ H₂ R) (h0 : p 0)
+    (hadd : ∀ f g : HeckeCosetModule Δ H₁ H₂ R, p f → p g → p (f + g))
     (hsingle : ∀ (D : HeckeCoset Δ H₁ H₂) (b : R), p (single R D b)) : p f :=
   Finsupp.induction_linear f h0 hadd hsingle
 
@@ -447,7 +450,8 @@ private lemma induction_linear {p : 𝕋 Δ H₁ H₂ R → Prop} (f : 𝕋 Δ H
 (Proposition 3.2 of [Shimura][shimura1971]). -/
 theorem mul_assoc' [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     [IsHeckeTriple Δ H₃ H₄] [IsHeckeTriple Δ H₁ H₃] [IsHeckeTriple Δ H₂ H₄]
-    (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) (h : 𝕋 Δ H₃ H₄ R) :
+    (f : HeckeCosetModule Δ H₁ H₂ R) (g : HeckeCosetModule Δ H₂ H₃ R)
+    (h : HeckeCosetModule Δ H₃ H₄ R) :
     mul R (mul R f g) h = mul R f (mul R g h) := by
   classical
   induction f using HeckeCosetModule.induction_linear with
@@ -498,8 +502,8 @@ theorem mul_assoc' [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
           (HeckeCoset.sum_multiplicity_assoc D₁.rep D₂.rep D₃.rep D.rep)
 
 /-- The Hecke ring is a semiring: the convolution product is associative. -/
-noncomputable instance {H : Subgroup G} [IsHeckeTriple Δ H H] : Semiring (𝕋 Δ H H R) :=
-  { (inferInstance : NonAssocSemiring (𝕋 Δ H H R)) with
+noncomputable instance {H : Subgroup G} [IsHeckeTriple Δ H H] : Semiring (𝕋 Δ H R) :=
+  { (inferInstance : NonAssocSemiring (𝕋 Δ H R)) with
     mul_assoc := fun f g h ↦ mul_assoc' R f g h }
 
 end HeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Associativity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Associativity.lean
@@ -1,0 +1,505 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.GroupWithZero.Action
+public import Mathlib.NumberTheory.HeckeRing.One
+
+/-!
+# Hecke rings: associativity
+
+Associativity of the convolution product of Hecke coset modules, in the mixed-level generality
+`𝕋 Δ H₁ H₂ R × 𝕋 Δ H₂ H₃ R × 𝕋 Δ H₃ H₄ R`, following Proposition 3.2 of
+[Shimura][shimura1971]. The combinatorial input is the invariance of Shimura's multiplicity
+`m(g, h; d)` in `d` under the double coset of `d`: both associations of a triple product then
+count the triples of representatives `(σᵢ, τⱼ, υₖ)` with `σᵢ g₁ τⱼ g₂ υₖ g₃ Γ₄ = d Γ₄`, and the
+two bookkeepings are matched through the one-sided description of the multiplicity
+(`multiplicity_eq_card_filter`).
+
+## Main results
+
+* `DoubleCoset.multiplicity_eq_card_filter`: `m(g, h; d)` counts the `σᵢ` with
+  `(σᵢg)⁻¹d ∈ Γ₂hΓ₃`.
+* `DoubleCoset.multiplicity_doubleCoset_congr`: `m(g, h; d)` depends on `d` only through the
+  double coset `Γ₁dΓ₃`.
+* `HeckeCosetModule.mul_assoc'`: associativity of the convolution product at mixed levels.
+* the `Semiring (𝕋 Δ H H R)` instance.
+-/
+
+@[expose] public section
+
+open Subgroup DoubleCoset Finsupp
+open scoped Pointwise
+
+namespace DoubleCoset
+
+variable {G : Type*} [Group G] {Γ₁ Γ₂ Γ₃ : Subgroup G}
+
+/-- Splitting the count of a set of pairs along the first coordinate. -/
+private lemma nat_card_prod_setOf {A B : Type*} [Fintype A] [Finite B] (P : A × B → Prop) :
+    Nat.card {p : A × B | P p} = ∑ a : A, Nat.card {b : B | P (a, b)} :=
+  calc Nat.card {p : A × B | P p}
+      = Nat.card (Σ a : A, {b : B | P (a, b)}) :=
+        Nat.card_congr (Equiv.subtypeProdEquivSigmaSubtype fun a b ↦ P (a, b))
+    _ = ∑ a : A, Nat.card {b : B | P (a, b)} := Nat.card_sigma
+
+open Classical in
+/-- Counting a set as a sum of indicators. -/
+private lemma nat_card_setOf_eq_sum {A : Type*} [Fintype A] (P : A → Prop) :
+    Nat.card {a : A | P a} = ∑ a : A, if P a then 1 else 0 := by
+  rw [Nat.card_eq_fintype_card, Fintype.card_subtype, Finset.card_filter]
+  simp [Set.mem_setOf_eq]
+
+/-- Membership in a double coset is invariant under left multiplication by the left
+subgroup. -/
+private lemma mul_mem_doubleCoset_iff {β : G} (hβ : β ∈ Γ₂) {a z : G} :
+    β * z ∈ doubleCoset a Γ₂ Γ₃ ↔ z ∈ doubleCoset a Γ₂ Γ₃ := by
+  constructor
+  · intro hz
+    obtain ⟨x, hx, y, hy, hxy⟩ := mem_doubleCoset.mp hz
+    refine mem_doubleCoset.mpr ⟨β⁻¹ * x, Γ₂.mul_mem (Γ₂.inv_mem hβ) hx, y, hy, ?_⟩
+    rw [mul_assoc, mul_assoc, ← mul_assoc x, ← hxy, inv_mul_cancel_left]
+  · intro hz
+    obtain ⟨x, hx, y, hy, rfl⟩ := mem_doubleCoset.mp hz
+    exact mem_doubleCoset.mpr ⟨β * x, Γ₂.mul_mem hβ hx, y, hy, by
+      simp only [mul_assoc]⟩
+
+open Classical in
+/-- The fibre of the multiplicity over a fixed first representative: for fixed `w`, there is
+exactly one representative `τⱼ` with `w τⱼ h Γ₃ = d Γ₃` if `w⁻¹d ∈ Γ₂hΓ₃`, and none
+otherwise. -/
+lemma nat_card_fiber (Γ₂ Γ₃ : Subgroup G) (h w d : G) :
+    Nat.card {j : DecompQuotient Γ₂ Γ₃ h | (w * ((j.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃)} =
+      if w⁻¹ * d ∈ doubleCoset h Γ₂ Γ₃ then 1 else 0 := by
+  have hcond : ∀ j : DecompQuotient Γ₂ Γ₃ h,
+      ((w * ((j.out : G) * h) : G) : G ⧸ Γ₃) = (d : G ⧸ Γ₃) ↔
+        (((j.out : G) * h : G) : G ⧸ Γ₃) = ((w⁻¹ * d : G) : G ⧸ Γ₃) := by
+    intro j
+    simp only [QuotientGroup.eq, mul_inv_rev, mul_assoc]
+  split_ifs with hd
+  · rw [Nat.card_eq_one_iff_unique]
+    constructor
+    · exact ⟨fun j₁ j₂ ↦ Subtype.ext (mk_out_mul_injective Γ₂ Γ₃ h
+        (((hcond _).mp j₁.2).trans ((hcond _).mp j₂.2).symm))⟩
+    · rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hd
+      obtain ⟨j, hj⟩ := hd
+      rw [mem_leftCoset_iff] at hj
+      exact ⟨⟨j, (hcond j).mpr (QuotientGroup.eq.mpr hj)⟩⟩
+  · have : IsEmpty {j : DecompQuotient Γ₂ Γ₃ h |
+        (w * ((j.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃)} := by
+      rw [Set.isEmpty_coe_sort, Set.eq_empty_iff_forall_notMem]
+      intro j hj
+      have hj' := QuotientGroup.eq.mp ((hcond j).mp hj)
+      exact hd (mem_doubleCoset.mpr ⟨j.out, j.out.2, _, hj', by
+        rw [mul_inv_cancel_left]⟩)
+    rw [Nat.card_of_isEmpty]
+
+/-- Shimura's multiplicity as a one-sided count: the second component of a pair in the fibre
+is determined by the first, so `m(g, h; d)` counts the representatives `σᵢ` with
+`(σᵢg)⁻¹d ∈ Γ₂hΓ₃`. -/
+theorem multiplicity_eq_card_filter (g h d : G) [Finite (DecompQuotient Γ₁ Γ₂ g)]
+    [Finite (DecompQuotient Γ₂ Γ₃ h)] :
+    multiplicity Γ₁ Γ₂ Γ₃ g h d =
+      Nat.card {i : DecompQuotient Γ₁ Γ₂ g | ((i.out : G) * g)⁻¹ * d ∈ doubleCoset h Γ₂ Γ₃} := by
+  classical
+  have : Fintype (DecompQuotient Γ₁ Γ₂ g) := Fintype.ofFinite _
+  have step1 : Nat.card {p : DecompQuotient Γ₁ Γ₂ g × DecompQuotient Γ₂ Γ₃ h |
+      ((p.1.out : G) * g * ((p.2.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃)} =
+      ∑ i : DecompQuotient Γ₁ Γ₂ g, Nat.card {j : DecompQuotient Γ₂ Γ₃ h |
+        ((i.out : G) * g * ((j.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃)} := by
+    exact nat_card_prod_setOf _
+  rw [multiplicity, step1, nat_card_setOf_eq_sum]
+  refine Finset.sum_congr rfl fun i _ ↦ ?_
+  rw [nat_card_fiber Γ₂ Γ₃ h ((i.out : G) * g) d]
+
+/-- Shimura's multiplicity is invariant under left translation of the target by `Γ₁`. -/
+theorem multiplicity_mul_left {γ : G} (hγ : γ ∈ Γ₁) (g h d : G)
+    [Finite (DecompQuotient Γ₁ Γ₂ g)] [Finite (DecompQuotient Γ₂ Γ₃ h)] :
+    multiplicity Γ₁ Γ₂ Γ₃ g h (γ * d) = multiplicity Γ₁ Γ₂ Γ₃ g h d := by
+  rw [multiplicity_eq_card_filter, multiplicity_eq_card_filter]
+  set γ' : Γ₁ := ⟨γ, hγ⟩ with hγ'def
+  refine Nat.card_congr (Equiv.subtypeEquiv (MulAction.toPerm γ'⁻¹) fun i ↦ ?_)
+  simp only [Set.mem_setOf_eq, MulAction.toPerm_apply]
+  have h1 : QuotientGroup.mk (γ'⁻¹ * i.out) = γ'⁻¹ • i := by
+    rw [← smul_eq_mul]
+    exact MulAction.Quotient.mk_smul_out _ γ'⁻¹ i
+  have hk : (γ'⁻¹ * i.out)⁻¹ * (γ'⁻¹ • i).out ∈
+      (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁ :=
+    QuotientGroup.eq.mp (h1.trans (QuotientGroup.out_eq' _).symm)
+  have hβ : g⁻¹ * ((((γ'⁻¹ * i.out)⁻¹ * (γ'⁻¹ • i).out : Γ₁) : G)) * g ∈ Γ₂ :=
+    Subgroup.mem_conjAct_pointwise_smul_iff.mp (Subgroup.mem_subgroupOf.mp hk)
+  have hy : ((γ'⁻¹ • i).out : G) =
+      γ⁻¹ * (i.out : G) * (((γ'⁻¹ * i.out)⁻¹ * (γ'⁻¹ • i).out : Γ₁) : G) := by
+    rw [show γ⁻¹ * (i.out : G) = ((γ'⁻¹ * i.out : Γ₁) : G) from rfl, ← Subgroup.coe_mul,
+      mul_inv_cancel_left]
+  have hcalc : (((γ'⁻¹ • i).out : G) * g)⁻¹ * d =
+      (g⁻¹ * ((((γ'⁻¹ * i.out)⁻¹ * (γ'⁻¹ • i).out : Γ₁) : G)) * g)⁻¹ *
+        (((i.out : G) * g)⁻¹ * (γ * d)) := by
+    rw [hy]
+    simp only [mul_inv_rev, inv_inv, mul_assoc, mul_inv_cancel_left]
+  rw [hcalc, mul_mem_doubleCoset_iff (Γ₂.inv_mem hβ)]
+
+/-- Shimura's multiplicity is invariant under right translation of the target by `Γ₃`. -/
+theorem multiplicity_mul_right {γ : G} (hγ : γ ∈ Γ₃) (g h d : G) :
+    multiplicity Γ₁ Γ₂ Γ₃ g h (d * γ) = multiplicity Γ₁ Γ₂ Γ₃ g h d := by
+  simp only [multiplicity, QuotientGroup.mk_mul_of_mem d hγ]
+
+/-- Shimura's multiplicity depends on the target only through its double coset. -/
+theorem multiplicity_doubleCoset_congr (g h : G) {d d' : G}
+    (hd : d' ∈ doubleCoset d Γ₁ Γ₃) [Finite (DecompQuotient Γ₁ Γ₂ g)]
+    [Finite (DecompQuotient Γ₂ Γ₃ h)] :
+    multiplicity Γ₁ Γ₂ Γ₃ g h d' = multiplicity Γ₁ Γ₂ Γ₃ g h d := by
+  obtain ⟨x, hx, y, hy, rfl⟩ := mem_doubleCoset.mp hd
+  rw [mul_assoc, multiplicity_mul_left hx, multiplicity_mul_right hy]
+
+end DoubleCoset
+
+namespace HeckeCoset
+
+open DoubleCoset
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ H₄ : Subgroup G}
+
+open Classical in
+/-- Summing the multiplicities of the double cosets in the support of a product against the
+indicator of containing a fixed element recovers the multiplicity of that element: the double
+cosets in the support are pairwise disjoint, each contributing its (constant) multiplicity, and
+elements outside every double coset of the support have multiplicity zero. -/
+private lemma sum_ite_mem_multiplicity [IsHeckeCosetModule Δ H₂ H₃] [IsHeckeCosetModule Δ H₃ H₄]
+    [DecidableEq (HeckeCoset Δ H₂ H₄)] (g₂ g₃ : Δ) (x : G) :
+    ∑ F ∈ Finset.univ.image (mulMap H₂ H₃ H₄ g₂ g₃),
+        (if x ∈ doubleCoset (F.rep : G) H₂ H₄ then
+          multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (F.rep : G) else 0) =
+      multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) x := by
+  by_cases hx : ∃ F₀ ∈ Finset.univ.image (mulMap H₂ H₃ H₄ g₂ g₃),
+      x ∈ doubleCoset (F₀.rep : G) H₂ H₄
+  · obtain ⟨F₀, hF₀, hxF₀⟩ := hx
+    rw [Finset.sum_eq_single_of_mem F₀ hF₀ fun F hF hne ↦ if_neg fun hxF ↦
+      hne (HeckeCoset.toSet_injective (by
+        rw [HeckeCoset.toSet_eq_doubleCoset_rep, HeckeCoset.toSet_eq_doubleCoset_rep,
+          ← doubleCoset_eq_of_mem hxF, ← doubleCoset_eq_of_mem hxF₀])),
+      if_pos hxF₀]
+    exact (multiplicity_doubleCoset_congr _ _ hxF₀).symm
+  · simp only [not_exists, not_and] at hx
+    rw [Finset.sum_eq_zero fun F hF ↦ if_neg (hx F hF)]
+    by_contra h0
+    have hne : multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) x ≠ 0 := fun hh ↦ h0 hh.symm
+    obtain ⟨w, hw, y, hy, rfl⟩ := mem_doubleCoset.mp (multiplicity_ne_zero_iff.mp hne)
+    obtain ⟨β, hβ, c, hc, rfl⟩ := mem_doubleCoset.mp hw
+    have hxΔ : β * (g₂ : G) * c * (g₃ : G) * y ∈ Δ :=
+      Δ.mul_mem (Δ.mul_mem (Δ.mul_mem (Δ.mul_mem (IsHeckeCosetModule.mem_left H₃ hβ) g₂.2)
+        (IsHeckeCosetModule.mem_left H₄ hc)) g₃.2) (IsHeckeCosetModule.mem_right H₃ hy)
+    set xΔ : Δ := ⟨β * (g₂ : G) * c * (g₃ : G) * y, hxΔ⟩
+    have hrep : ((HeckeCoset.mk H₂ H₄ xΔ).rep : G) ∈ doubleCoset (xΔ : G) H₂ H₄ := by
+      have h1 := HeckeCoset.rep_mem (HeckeCoset.mk H₂ H₄ xΔ)
+      rwa [HeckeCoset.toSet_mk] at h1
+    refine hx (HeckeCoset.mk H₂ H₄ xΔ) ?_ ?_
+    · rw [HeckeCoset.mem_image_mulMap_iff, multiplicity_doubleCoset_congr _ _ hrep]
+      exact hne
+    · rw [doubleCoset_eq_of_mem hrep]
+      exact mem_doubleCoset_self H₂ H₄ _
+
+open Classical in
+/-- The right-handed Fubini step: summing the structure constants against a further
+multiplicity over the double cosets of the product `H₂g₂H₃g₃H₄` counts, for each representative
+`σᵢ` of `H₁g₁H₂`, the multiplicity of `(σᵢg₁)⁻¹d`. -/
+lemma sum_image_mulMap_multiplicity_right [IsHeckeCosetModule Δ H₁ H₂]
+    [IsHeckeCosetModule Δ H₂ H₃] [IsHeckeCosetModule Δ H₃ H₄]
+    [DecidableEq (HeckeCoset Δ H₂ H₄)] (g₁ g₂ g₃ d : Δ) :
+    ∑ F ∈ Finset.univ.image (mulMap H₂ H₃ H₄ g₂ g₃),
+        multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (F.rep : G) *
+          multiplicity H₁ H₂ H₄ (g₁ : G) (F.rep : G) (d : G) =
+      ∑ i : DecompQuotient H₁ H₂ (g₁ : G),
+        multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (((i.out : G) * g₁)⁻¹ * d) := by
+  haveI : IsHeckeCosetModule Δ H₂ H₄ := IsHeckeCosetModule.trans (H₂ := H₃)
+  have hstep : ∀ F ∈ Finset.univ.image (mulMap H₂ H₃ H₄ g₂ g₃),
+      multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (F.rep : G) *
+        multiplicity H₁ H₂ H₄ (g₁ : G) (F.rep : G) (d : G) =
+      ∑ i : DecompQuotient H₁ H₂ (g₁ : G),
+        (if ((i.out : G) * g₁)⁻¹ * d ∈ doubleCoset (F.rep : G) H₂ H₄ then
+          multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (F.rep : G) else 0) := by
+    intro F _
+    rw [multiplicity_eq_card_filter (Γ₁ := H₁) (g₁ : G) (F.rep : G) (d : G),
+      nat_card_setOf_eq_sum, Finset.mul_sum]
+    exact Finset.sum_congr rfl fun i _ ↦ by rw [mul_ite, mul_one, mul_zero]
+  rw [Finset.sum_congr rfl hstep, Finset.sum_comm]
+  exact Finset.sum_congr rfl fun i _ ↦ sum_ite_mem_multiplicity g₂ g₃ _
+
+/-- Joining the right-handed Fubini step with the one-sided count: the right association counts
+pairs of representatives whose product moves `d` into `H₃g₃H₄`. -/
+lemma sum_multiplicity_eq_card [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    [IsHeckeCosetModule Δ H₃ H₄] (g₁ g₂ g₃ d : Δ) :
+    ∑ i : DecompQuotient H₁ H₂ (g₁ : G),
+        multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (((i.out : G) * g₁)⁻¹ * d) =
+      Nat.card {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G) |
+        ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂))⁻¹ * d ∈ doubleCoset (g₃ : G) H₃ H₄} := by
+  classical
+  have step : Nat.card {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G) |
+      ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂))⁻¹ * d ∈ doubleCoset (g₃ : G) H₃ H₄} =
+      ∑ i : DecompQuotient H₁ H₂ (g₁ : G), Nat.card {j : DecompQuotient H₂ H₃ (g₂ : G) |
+        ((i.out : G) * g₁ * ((j.out : G) * g₂))⁻¹ * d ∈ doubleCoset (g₃ : G) H₃ H₄} := by
+    exact nat_card_prod_setOf _
+  rw [step]
+  refine Finset.sum_congr rfl fun i _ ↦ ?_
+  rw [multiplicity_eq_card_filter (Γ₁ := H₂) (g₂ : G) (g₃ : G) (((i.out : G) * g₁)⁻¹ * d)]
+  exact Nat.card_congr (Equiv.setCongr (by
+    ext j
+    simp only [Set.mem_setOf_eq, mul_inv_rev, mul_assoc]))
+
+open Classical in
+/-- The left-handed Fubini step: the left association also counts pairs of representatives
+whose product moves `d` into `H₃g₃H₄`, using the invariance of the multiplicity across the
+left cosets of a double coset. -/
+lemma sum_image_mulMap_multiplicity_left [IsHeckeCosetModule Δ H₁ H₂]
+    [IsHeckeCosetModule Δ H₂ H₃] [IsHeckeCosetModule Δ H₃ H₄]
+    [DecidableEq (HeckeCoset Δ H₁ H₃)] (g₁ g₂ g₃ d : Δ) :
+    ∑ E ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂),
+        multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (E.rep : G) *
+          multiplicity H₁ H₃ H₄ (E.rep : G) (g₃ : G) (d : G) =
+      Nat.card {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G) |
+        ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂))⁻¹ * d ∈ doubleCoset (g₃ : G) H₃ H₄} := by
+  haveI h13 : IsHeckeCosetModule Δ H₁ H₃ := IsHeckeCosetModule.trans (H₂ := H₂)
+  have hA : ∀ E ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂),
+      multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (E.rep : G) *
+        multiplicity H₁ H₃ H₄ (E.rep : G) (g₃ : G) (d : G) =
+      ∑ l : DecompQuotient H₁ H₃ (E.rep : G),
+        ∑ p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G),
+          if (((l.out : G) * E.rep)⁻¹ * d ∈ doubleCoset (g₃ : G) H₃ H₄) ∧
+              ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ H₃) =
+                (((l.out : G) * E.rep : G) : G ⧸ H₃) then 1 else 0 := by
+    intro E _
+    rw [multiplicity_eq_card_filter (Γ₁ := H₁) (E.rep : G) (g₃ : G) (d : G),
+      nat_card_setOf_eq_sum, Finset.mul_sum]
+    refine Finset.sum_congr rfl fun l _ ↦ ?_
+    rw [mul_ite, mul_one, mul_zero]
+    split_ifs with hcond
+    · rw [show multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (E.rep : G) =
+          multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) ((l.out : G) * E.rep) from
+          (multiplicity_mul_left l.out.2 _ _ _).symm,
+        multiplicity, nat_card_setOf_eq_sum]
+      refine Finset.sum_congr rfl fun p _ ↦ ?_
+      by_cases hm : ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ H₃) =
+          (((l.out : G) * E.rep : G) : G ⧸ H₃)
+      · rw [if_pos hm, if_pos ⟨hcond, hm⟩]
+      · rw [if_neg hm, if_neg fun hh ↦ hm hh.2]
+    · exact (Finset.sum_eq_zero fun p _ ↦ if_neg fun hh ↦ hcond hh.1).symm
+  rw [Finset.sum_congr rfl hA,
+    Finset.sum_congr rfl fun (E : HeckeCoset Δ H₁ H₃) _ ↦ Finset.sum_comm, Finset.sum_comm,
+    nat_card_setOf_eq_sum]
+  refine Finset.sum_congr rfl fun p _ ↦ ?_
+  -- Step E: for each pair `p` there is exactly one pair `(E, l)` matching the coset of the
+  -- product of the representatives of `p`.
+  set wG : G := (p.1.out : G) * g₁ * ((p.2.out : G) * g₂) with hwG
+  have hwΔ : wG ∈ Δ :=
+    Δ.mul_mem (Δ.mul_mem (IsHeckeCosetModule.mem_left H₂ p.1.out.2) g₁.2)
+      (Δ.mul_mem (IsHeckeCosetModule.mem_left H₃ p.2.out.2) g₂.2)
+  set E₀ : HeckeCoset Δ H₁ H₃ := HeckeCoset.mk H₁ H₃ ⟨wG, hwΔ⟩ with hE₀def
+  have hE₀mem : E₀ ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂) :=
+    Finset.mem_image.mpr ⟨p, Finset.mem_univ p, rfl⟩
+  have hw_rep : wG ∈ doubleCoset ((E₀.rep : Δ) : G) H₁ H₃ := by
+    have h1 := HeckeCoset.rep_mem E₀
+    rw [hE₀def, HeckeCoset.toSet_mk] at h1
+    rw [doubleCoset_eq_of_mem h1]
+    exact mem_doubleCoset_self H₁ H₃ _
+  have hdec := hw_rep
+  rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hdec
+  obtain ⟨l₀, hl₀⟩ := hdec
+  rw [mem_leftCoset_iff] at hl₀
+  have hmk : ((wG : G) : G ⧸ H₃) = (((l₀.out : G) * (E₀.rep : G) : G) : G ⧸ H₃) :=
+    (QuotientGroup.eq.mpr hl₀).symm
+  rw [Finset.sum_eq_single_of_mem E₀ hE₀mem ?hEne]
+  case hEne =>
+    intro E hE hne
+    refine Finset.sum_eq_zero fun l _ ↦ if_neg ?_
+    rintro ⟨-, hmatch⟩
+    have hwE : wG ∈ doubleCoset ((E.rep : Δ) : G) H₁ H₃ := by
+      have h2 := QuotientGroup.eq.mp hmatch
+      refine mem_doubleCoset.mpr ⟨(l.out : G), l.out.2, ((l.out : G) * E.rep)⁻¹ * wG,
+        by simpa [mul_inv_rev, mul_assoc] using H₃.inv_mem h2, (mul_inv_cancel_left _ _).symm⟩
+    refine hne (HeckeCoset.toSet_injective ?_)
+    rw [HeckeCoset.toSet_eq_doubleCoset_rep, hE₀def, HeckeCoset.toSet_mk]
+    exact (doubleCoset_eq_of_mem hwE).symm
+  rw [Finset.sum_eq_single_of_mem l₀ (Finset.mem_univ _) ?hlne]
+  case hlne =>
+    intro l _ hlne
+    refine if_neg ?_
+    rintro ⟨-, hmatch⟩
+    exact hlne (mk_out_mul_injective H₁ H₃ ((E₀.rep : Δ) : G) (hmatch.symm.trans hmk))
+  have hiff : ((((l₀.out : G) * (E₀.rep : G))⁻¹ * d ∈ doubleCoset (g₃ : G) H₃ H₄) ∧
+      ((wG : G) : G ⧸ H₃) = (((l₀.out : G) * (E₀.rep : G) : G) : G ⧸ H₃)) ↔
+      (wG⁻¹ * (d : G) ∈ doubleCoset (g₃ : G) H₃ H₄) := by
+    have hw2 : wG⁻¹ * (d : G) =
+        (((l₀.out : G) * (E₀.rep : G))⁻¹ * wG)⁻¹ *
+          ((((l₀.out : G) * (E₀.rep : G)))⁻¹ * d) := by
+      simp only [mul_inv_rev, inv_inv, mul_assoc, mul_inv_cancel_left]
+    constructor
+    · intro hh
+      rw [hw2, mul_mem_doubleCoset_iff (H₃.inv_mem hl₀)]
+      exact hh.1
+    · intro hh
+      refine ⟨?_, hmk⟩
+      rw [hw2, mul_mem_doubleCoset_iff (H₃.inv_mem hl₀)] at hh
+      exact hh
+  by_cases hd4 : wG⁻¹ * (d : G) ∈ doubleCoset (g₃ : G) H₃ H₄
+  · rw [if_pos (hiff.mpr hd4), if_pos hd4]
+  · rw [if_neg fun hh ↦ hd4 (hiff.mp hh), if_neg hd4]
+
+/-- Associativity of the structure constants of the Hecke product (Proposition 3.2 of
+[Shimura][shimura1971]): both associations of a triple product of double cosets have the same
+structure constants. -/
+theorem sum_multiplicity_assoc [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    [IsHeckeCosetModule Δ H₃ H₄] [DecidableEq (HeckeCoset Δ H₁ H₃)]
+    [DecidableEq (HeckeCoset Δ H₂ H₄)] (g₁ g₂ g₃ d : Δ) :
+    ∑ E ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂),
+        multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (E.rep : G) *
+          multiplicity H₁ H₃ H₄ (E.rep : G) (g₃ : G) (d : G) =
+      ∑ F ∈ Finset.univ.image (mulMap H₂ H₃ H₄ g₂ g₃),
+        multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (F.rep : G) *
+          multiplicity H₁ H₂ H₄ (g₁ : G) (F.rep : G) (d : G) := by
+  rw [sum_image_mulMap_multiplicity_left g₁ g₂ g₃ d,
+    sum_image_mulMap_multiplicity_right g₁ g₂ g₃ d, sum_multiplicity_eq_card g₁ g₂ g₃ d]
+
+end HeckeCoset
+
+namespace HeckeCosetModule
+
+open DoubleCoset
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ H₄ : Subgroup G}
+  (R : Type*) [Semiring R]
+
+open Classical in
+/-- The support of the structure constants is contained in the image of `mulMap`. -/
+private lemma support_structureConstants_subset [IsHeckeCosetModule Δ H₁ H₂]
+    [IsHeckeCosetModule Δ H₂ H₃] (g₁ g₂ : Δ) :
+    (structureConstants R H₁ H₂ H₃ g₁ g₂).support ⊆
+      Finset.univ.image (HeckeCoset.mulMap H₁ H₂ H₃ g₁ g₂) :=
+  Finsupp.support_onFinset_subset
+
+/-- `Finsupp.sum_smul_index`, restated for the wrapper type `𝕋 Δ H₁ H₂ R`. -/
+private lemma sum_smul_index_T {N : Type*} [AddCommMonoid N] (a : R) (f : 𝕋 Δ H₁ H₂ R)
+    (F : HeckeCoset Δ H₁ H₂ → R → N) (h0 : ∀ D, F D 0 = 0) :
+    (a • f).sum F = f.sum fun D c ↦ F D (a * c) :=
+  Finsupp.sum_smul_index h0
+
+/-- `Finsupp.smul_apply`, restated for the wrapper type `𝕋 Δ H₁ H₂ R`. -/
+private lemma smul_apply_T (a : R) (f : 𝕋 Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
+    (a • f) D = a * f D :=
+  rfl
+
+/-- Unfolding `Finsupp.sum` with the wrapper-type coercion. -/
+private lemma sum_eq_sum_T {N : Type*} [AddCommMonoid N] (f : 𝕋 Δ H₁ H₂ R)
+    (F : HeckeCoset Δ H₁ H₂ → R → N) : f.sum F = ∑ D ∈ f.support, F D (f D) :=
+  rfl
+
+/-- `Finsupp.notMem_support_iff`, restated for the wrapper type `𝕋 Δ H₁ H₂ R`. -/
+private lemma apply_eq_zero_of_notMem_support_T (f : 𝕋 Δ H₁ H₂ R)
+    (D : HeckeCoset Δ H₁ H₂) (h : D ∉ f.support) : f D = 0 :=
+  Finsupp.notMem_support_iff.mp h
+
+/-- `Finsupp.zero_apply`, restated for the wrapper type `𝕋 Δ H₁ H₂ R`. -/
+private lemma zero_apply_T (D : HeckeCoset Δ H₁ H₂) : (0 : 𝕋 Δ H₁ H₂ R) D = 0 :=
+  rfl
+
+/-- `Finsupp.sum_apply`, restated for the wrapper type `𝕋 Δ H₁ H₂ R`. -/
+private lemma sum_apply_T {H₁ H₂ H₃ H₄ : Subgroup G} (f : 𝕋 Δ H₁ H₂ R)
+    (F : HeckeCoset Δ H₁ H₂ → R → 𝕋 Δ H₃ H₄ R) (D : HeckeCoset Δ H₃ H₄) :
+    (f.sum F) D = f.sum fun E c ↦ F E c D :=
+  Finsupp.sum_apply
+
+/-- The convolution product commutes with scalar multiplication on the left factor. (Note
+that the corresponding statement for the right factor fails over a noncommutative `R`.) -/
+lemma smul_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃] (a : R)
+    (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) : mul R (a • f) g = a • mul R f g := by
+  rw [mul_eq_sum, mul_eq_sum, sum_smul_index_T R a f _ fun D₁ ↦ by simp,
+    Finsupp.sum, Finsupp.sum, Finset.smul_sum]
+  refine Finset.sum_congr rfl fun D₁ _ ↦ ?_
+  rw [Finsupp.sum, Finsupp.sum, Finset.smul_sum]
+  exact Finset.sum_congr rfl fun D₂ _ ↦ by rw [mul_smul]
+
+/-- Evaluation of the convolution product against a basis element on the left. -/
+lemma single_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    (D₁ : HeckeCoset Δ H₁ H₂) (b₁ : R) (g : 𝕋 Δ H₂ H₃ R) :
+    mul R (single R D₁ b₁) g =
+      g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep := by
+  rw [mul_eq_sum, single]
+  exact Finsupp.sum_single_index (by simp)
+
+/-- Evaluation of the convolution product against a basis element on the right. -/
+lemma mul_single [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    (f : 𝕋 Δ H₁ H₂ R) (D₂ : HeckeCoset Δ H₂ H₃) (b₂ : R) :
+    mul R f (single R D₂ b₂) =
+      f.sum fun D₁ b₁ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep := by
+  rw [mul_eq_sum]
+  exact Finsupp.sum_congr fun D₁ _ ↦ Finsupp.sum_single_index (by simp)
+
+/-- `Finsupp.induction_linear`, restated for the wrapper type `𝕋 Δ H₁ H₂ R` so that the
+hypotheses match the `HeckeCosetModule` vocabulary. -/
+private lemma induction_linear {p : 𝕋 Δ H₁ H₂ R → Prop} (f : 𝕋 Δ H₁ H₂ R) (h0 : p 0)
+    (hadd : ∀ f g : 𝕋 Δ H₁ H₂ R, p f → p g → p (f + g))
+    (hsingle : ∀ (D : HeckeCoset Δ H₁ H₂) (b : R), p (single R D b)) : p f :=
+  Finsupp.induction_linear f h0 hadd hsingle
+
+/-- Associativity of the convolution product of Hecke coset modules, at mixed levels
+(Proposition 3.2 of [Shimura][shimura1971]). -/
+theorem mul_assoc' [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    [IsHeckeCosetModule Δ H₃ H₄] [IsHeckeCosetModule Δ H₁ H₃] [IsHeckeCosetModule Δ H₂ H₄]
+    (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) (h : 𝕋 Δ H₃ H₄ R) :
+    mul R (mul R f g) h = mul R f (mul R g h) := by
+  classical
+  induction f using HeckeCosetModule.induction_linear with
+  | h0 => simp only [HeckeCosetModule.zero_mul]
+  | hadd f₁ f₂ h₁ h₂ => simp only [HeckeCosetModule.add_mul, h₁, h₂]
+  | hsingle D₁ b₁ =>
+    induction g using HeckeCosetModule.induction_linear with
+    | h0 => simp only [HeckeCosetModule.zero_mul, HeckeCosetModule.mul_zero]
+    | hadd g₁ g₂ h₁ h₂ =>
+      simp only [HeckeCosetModule.mul_add, HeckeCosetModule.add_mul, h₁, h₂]
+    | hsingle D₂ b₂ =>
+      induction h using HeckeCosetModule.induction_linear with
+      | h0 => simp only [HeckeCosetModule.mul_zero]
+      | hadd h₁ h₂ hh₁ hh₂ => simp only [HeckeCosetModule.mul_add, hh₁, hh₂]
+      | hsingle D₃ b₃ =>
+        rw [mul_single_single R D₁ D₂ b₁ b₂, smul_mul, smul_mul, mul_single,
+          mul_single_single R D₂ D₃ b₂ b₃, single_mul,
+          sum_smul_index_T R b₂ _ _ fun F ↦ by simp,
+          sum_smul_index_T R b₃ _ _ fun F ↦ by simp]
+        ext D
+        rw [smul_apply_T, smul_apply_T, sum_apply_T, sum_apply_T, sum_eq_sum_T, sum_eq_sum_T,
+          Finset.sum_subset (support_structureConstants_subset R D₁.rep D₂.rep)
+            (fun E _ hE ↦ by
+              simp [apply_eq_zero_of_notMem_support_T _ _ _ hE, zero_apply_T]),
+          Finset.sum_subset (support_structureConstants_subset R D₂.rep D₃.rep)
+            (fun F _ hF ↦ by
+              simp [apply_eq_zero_of_notMem_support_T _ _ _ hF, zero_apply_T])]
+        simp only [smul_apply_T, structureConstants_apply]
+        have hL : ∀ E : HeckeCoset Δ H₁ H₃,
+            ((multiplicity H₁ H₂ H₃ (D₁.rep : G) (D₂.rep : G) (E.rep : G) : R) *
+              (b₃ * (multiplicity H₁ H₃ H₄ (E.rep : G) (D₃.rep : G) (D.rep : G) : R))) =
+            b₃ * ((multiplicity H₁ H₂ H₃ (D₁.rep : G) (D₂.rep : G) (E.rep : G) *
+              multiplicity H₁ H₃ H₄ (E.rep : G) (D₃.rep : G) (D.rep : G) : ℕ) : R) := by
+          intro E
+          rw [(Nat.cast_commute (multiplicity H₁ H₂ H₃ (D₁.rep : G) (D₂.rep : G) (E.rep : G))
+            b₃).left_comm, Nat.cast_mul]
+        have hR : ∀ F : HeckeCoset Δ H₂ H₄,
+            (b₁ * ((b₂ * (b₃ * (multiplicity H₂ H₃ H₄ (D₂.rep : G) (D₃.rep : G) (F.rep : G) :
+              R))) * (multiplicity H₁ H₂ H₄ (D₁.rep : G) (F.rep : G) (D.rep : G) : R))) =
+            b₁ * (b₂ * (b₃ * ((multiplicity H₂ H₃ H₄ (D₂.rep : G) (D₃.rep : G) (F.rep : G) *
+              multiplicity H₁ H₂ H₄ (D₁.rep : G) (F.rep : G) (D.rep : G) : ℕ) : R))) := by
+          intro F
+          rw [Nat.cast_mul, mul_assoc, mul_assoc]
+        rw [Finset.sum_congr rfl fun E _ ↦ hL E, Finset.sum_congr rfl fun F _ ↦ hR F,
+          ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum,
+          ← Nat.cast_sum, ← Nat.cast_sum]
+        exact congrArg (fun n : ℕ ↦ b₁ * (b₂ * (b₃ * (n : R))))
+          (HeckeCoset.sum_multiplicity_assoc D₁.rep D₂.rep D₃.rep D.rep)
+
+/-- The Hecke ring is a semiring: the convolution product is associative. -/
+noncomputable instance {H : Subgroup G} [IsHeckeCosetModule Δ H H] : Semiring (𝕋 Δ H H R) :=
+  { (inferInstance : NonAssocSemiring (𝕋 Δ H H R)) with
+    mul_assoc := fun f g h ↦ mul_assoc' R f g h }
+
+end HeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Associativity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Associativity.lean
@@ -168,7 +168,7 @@ open Classical in
 indicator of containing a fixed element recovers the multiplicity of that element: the double
 cosets in the support are pairwise disjoint, each contributing its (constant) multiplicity, and
 elements outside every double coset of the support have multiplicity zero. -/
-private lemma sum_ite_mem_multiplicity [IsHeckeCosetModule Δ H₂ H₃] [IsHeckeCosetModule Δ H₃ H₄]
+private lemma sum_ite_mem_multiplicity [IsHeckeTriple Δ H₂ H₃] [IsHeckeTriple Δ H₃ H₄]
     [DecidableEq (HeckeCoset Δ H₂ H₄)] (g₂ g₃ : Δ) (x : G) :
     ∑ F ∈ Finset.univ.image (mulMap H₂ H₃ H₄ g₂ g₃),
         (if x ∈ doubleCoset (F.rep : G) H₂ H₄ then
@@ -190,8 +190,8 @@ private lemma sum_ite_mem_multiplicity [IsHeckeCosetModule Δ H₂ H₃] [IsHeck
     obtain ⟨w, hw, y, hy, rfl⟩ := mem_doubleCoset.mp (multiplicity_ne_zero_iff.mp hne)
     obtain ⟨β, hβ, c, hc, rfl⟩ := mem_doubleCoset.mp hw
     have hxΔ : β * (g₂ : G) * c * (g₃ : G) * y ∈ Δ :=
-      Δ.mul_mem (Δ.mul_mem (Δ.mul_mem (Δ.mul_mem (IsHeckeCosetModule.mem_left H₃ hβ) g₂.2)
-        (IsHeckeCosetModule.mem_left H₄ hc)) g₃.2) (IsHeckeCosetModule.mem_right H₃ hy)
+      Δ.mul_mem (Δ.mul_mem (Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_left H₃ hβ) g₂.2)
+        (IsHeckeTriple.mem_left H₄ hc)) g₃.2) (IsHeckeTriple.mem_right H₃ hy)
     set xΔ : Δ := ⟨β * (g₂ : G) * c * (g₃ : G) * y, hxΔ⟩
     have hrep : ((HeckeCoset.mk H₂ H₄ xΔ).rep : G) ∈ doubleCoset (xΔ : G) H₂ H₄ := by
       have h1 := HeckeCoset.rep_mem (HeckeCoset.mk H₂ H₄ xΔ)
@@ -206,15 +206,15 @@ open Classical in
 /-- The right-handed Fubini step: summing the structure constants against a further
 multiplicity over the double cosets of the product `H₂g₂H₃g₃H₄` counts, for each representative
 `σᵢ` of `H₁g₁H₂`, the multiplicity of `(σᵢg₁)⁻¹d`. -/
-lemma sum_image_mulMap_multiplicity_right [IsHeckeCosetModule Δ H₁ H₂]
-    [IsHeckeCosetModule Δ H₂ H₃] [IsHeckeCosetModule Δ H₃ H₄]
+lemma sum_image_mulMap_multiplicity_right [IsHeckeTriple Δ H₁ H₂]
+    [IsHeckeTriple Δ H₂ H₃] [IsHeckeTriple Δ H₃ H₄]
     [DecidableEq (HeckeCoset Δ H₂ H₄)] (g₁ g₂ g₃ d : Δ) :
     ∑ F ∈ Finset.univ.image (mulMap H₂ H₃ H₄ g₂ g₃),
         multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (F.rep : G) *
           multiplicity H₁ H₂ H₄ (g₁ : G) (F.rep : G) (d : G) =
       ∑ i : DecompQuotient H₁ H₂ (g₁ : G),
         multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (((i.out : G) * g₁)⁻¹ * d) := by
-  haveI : IsHeckeCosetModule Δ H₂ H₄ := IsHeckeCosetModule.trans (H₂ := H₃)
+  haveI : IsHeckeTriple Δ H₂ H₄ := IsHeckeTriple.trans (H₂ := H₃)
   have hstep : ∀ F ∈ Finset.univ.image (mulMap H₂ H₃ H₄ g₂ g₃),
       multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (F.rep : G) *
         multiplicity H₁ H₂ H₄ (g₁ : G) (F.rep : G) (d : G) =
@@ -230,8 +230,8 @@ lemma sum_image_mulMap_multiplicity_right [IsHeckeCosetModule Δ H₁ H₂]
 
 /-- Joining the right-handed Fubini step with the one-sided count: the right association counts
 pairs of representatives whose product moves `d` into `H₃g₃H₄`. -/
-lemma sum_multiplicity_eq_card [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
-    [IsHeckeCosetModule Δ H₃ H₄] (g₁ g₂ g₃ d : Δ) :
+lemma sum_multiplicity_eq_card [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
+    [IsHeckeTriple Δ H₃ H₄] (g₁ g₂ g₃ d : Δ) :
     ∑ i : DecompQuotient H₁ H₂ (g₁ : G),
         multiplicity H₂ H₃ H₄ (g₂ : G) (g₃ : G) (((i.out : G) * g₁)⁻¹ * d) =
       Nat.card {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G) |
@@ -253,15 +253,15 @@ open Classical in
 /-- The left-handed Fubini step: the left association also counts pairs of representatives
 whose product moves `d` into `H₃g₃H₄`, using the invariance of the multiplicity across the
 left cosets of a double coset. -/
-lemma sum_image_mulMap_multiplicity_left [IsHeckeCosetModule Δ H₁ H₂]
-    [IsHeckeCosetModule Δ H₂ H₃] [IsHeckeCosetModule Δ H₃ H₄]
+lemma sum_image_mulMap_multiplicity_left [IsHeckeTriple Δ H₁ H₂]
+    [IsHeckeTriple Δ H₂ H₃] [IsHeckeTriple Δ H₃ H₄]
     [DecidableEq (HeckeCoset Δ H₁ H₃)] (g₁ g₂ g₃ d : Δ) :
     ∑ E ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂),
         multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (E.rep : G) *
           multiplicity H₁ H₃ H₄ (E.rep : G) (g₃ : G) (d : G) =
       Nat.card {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G) |
         ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂))⁻¹ * d ∈ doubleCoset (g₃ : G) H₃ H₄} := by
-  haveI h13 : IsHeckeCosetModule Δ H₁ H₃ := IsHeckeCosetModule.trans (H₂ := H₂)
+  haveI h13 : IsHeckeTriple Δ H₁ H₃ := IsHeckeTriple.trans (H₂ := H₂)
   have hA : ∀ E ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂),
       multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (E.rep : G) *
         multiplicity H₁ H₃ H₄ (E.rep : G) (g₃ : G) (d : G) =
@@ -294,8 +294,8 @@ lemma sum_image_mulMap_multiplicity_left [IsHeckeCosetModule Δ H₁ H₂]
   -- product of the representatives of `p`.
   set wG : G := (p.1.out : G) * g₁ * ((p.2.out : G) * g₂) with hwG
   have hwΔ : wG ∈ Δ :=
-    Δ.mul_mem (Δ.mul_mem (IsHeckeCosetModule.mem_left H₂ p.1.out.2) g₁.2)
-      (Δ.mul_mem (IsHeckeCosetModule.mem_left H₃ p.2.out.2) g₂.2)
+    Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_left H₂ p.1.out.2) g₁.2)
+      (Δ.mul_mem (IsHeckeTriple.mem_left H₃ p.2.out.2) g₂.2)
   set E₀ : HeckeCoset Δ H₁ H₃ := HeckeCoset.mk H₁ H₃ ⟨wG, hwΔ⟩ with hE₀def
   have hE₀mem : E₀ ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂) :=
     Finset.mem_image.mpr ⟨p, Finset.mem_univ p, rfl⟩
@@ -350,8 +350,8 @@ lemma sum_image_mulMap_multiplicity_left [IsHeckeCosetModule Δ H₁ H₂]
 /-- Associativity of the structure constants of the Hecke product (Proposition 3.2 of
 [Shimura][shimura1971]): both associations of a triple product of double cosets have the same
 structure constants. -/
-theorem sum_multiplicity_assoc [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
-    [IsHeckeCosetModule Δ H₃ H₄] [DecidableEq (HeckeCoset Δ H₁ H₃)]
+theorem sum_multiplicity_assoc [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
+    [IsHeckeTriple Δ H₃ H₄] [DecidableEq (HeckeCoset Δ H₁ H₃)]
     [DecidableEq (HeckeCoset Δ H₂ H₄)] (g₁ g₂ g₃ d : Δ) :
     ∑ E ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂),
         multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (E.rep : G) *
@@ -373,8 +373,8 @@ variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ H₄ : Subgrou
 
 open Classical in
 /-- The support of the structure constants is contained in the image of `mulMap`. -/
-private lemma support_structureConstants_subset [IsHeckeCosetModule Δ H₁ H₂]
-    [IsHeckeCosetModule Δ H₂ H₃] (g₁ g₂ : Δ) :
+private lemma support_structureConstants_subset [IsHeckeTriple Δ H₁ H₂]
+    [IsHeckeTriple Δ H₂ H₃] (g₁ g₂ : Δ) :
     (structureConstants R H₁ H₂ H₃ g₁ g₂).support ⊆
       Finset.univ.image (HeckeCoset.mulMap H₁ H₂ H₃ g₁ g₂) :=
   Finsupp.support_onFinset_subset
@@ -412,7 +412,7 @@ private lemma sum_apply_T {H₁ H₂ H₃ H₄ : Subgroup G} (f : 𝕋 Δ H₁ H
 
 /-- The convolution product commutes with scalar multiplication on the left factor. (Note
 that the corresponding statement for the right factor fails over a noncommutative `R`.) -/
-lemma smul_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃] (a : R)
+lemma smul_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] (a : R)
     (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) : mul R (a • f) g = a • mul R f g := by
   rw [mul_eq_sum, mul_eq_sum, sum_smul_index_T R a f _ fun D₁ ↦ by simp,
     Finsupp.sum, Finsupp.sum, Finset.smul_sum]
@@ -421,7 +421,7 @@ lemma smul_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H�
   exact Finset.sum_congr rfl fun D₂ _ ↦ by rw [mul_smul]
 
 /-- Evaluation of the convolution product against a basis element on the left. -/
-lemma single_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+lemma single_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (D₁ : HeckeCoset Δ H₁ H₂) (b₁ : R) (g : 𝕋 Δ H₂ H₃ R) :
     mul R (single R D₁ b₁) g =
       g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep := by
@@ -429,7 +429,7 @@ lemma single_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H
   exact Finsupp.sum_single_index (by simp)
 
 /-- Evaluation of the convolution product against a basis element on the right. -/
-lemma mul_single [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+lemma mul_single [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (f : 𝕋 Δ H₁ H₂ R) (D₂ : HeckeCoset Δ H₂ H₃) (b₂ : R) :
     mul R f (single R D₂ b₂) =
       f.sum fun D₁ b₁ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep := by
@@ -445,8 +445,8 @@ private lemma induction_linear {p : 𝕋 Δ H₁ H₂ R → Prop} (f : 𝕋 Δ H
 
 /-- Associativity of the convolution product of Hecke coset modules, at mixed levels
 (Proposition 3.2 of [Shimura][shimura1971]). -/
-theorem mul_assoc' [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
-    [IsHeckeCosetModule Δ H₃ H₄] [IsHeckeCosetModule Δ H₁ H₃] [IsHeckeCosetModule Δ H₂ H₄]
+theorem mul_assoc' [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
+    [IsHeckeTriple Δ H₃ H₄] [IsHeckeTriple Δ H₁ H₃] [IsHeckeTriple Δ H₂ H₄]
     (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) (h : 𝕋 Δ H₃ H₄ R) :
     mul R (mul R f g) h = mul R f (mul R g h) := by
   classical
@@ -498,7 +498,7 @@ theorem mul_assoc' [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂
           (HeckeCoset.sum_multiplicity_assoc D₁.rep D₂.rep D₃.rep D.rep)
 
 /-- The Hecke ring is a semiring: the convolution product is associative. -/
-noncomputable instance {H : Subgroup G} [IsHeckeCosetModule Δ H H] : Semiring (𝕋 Δ H H R) :=
+noncomputable instance {H : Subgroup G} [IsHeckeTriple Δ H H] : Semiring (𝕋 Δ H H R) :=
   { (inferInstance : NonAssocSemiring (𝕋 Δ H H R)) with
     mul_assoc := fun f g h ↦ mul_assoc' R f g h }
 

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -1,0 +1,270 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.HeckeRing.Defs
+public import Mathlib.GroupTheory.Index
+public import Mathlib.Tactic.Group
+
+/-!
+# Hecke rings: the double coset API
+
+Basic API for the double cosets `HeckeCoset` that index an abstract Hecke ring, following
+Shimura, *Introduction to the Arithmetic Theory of Automorphic Functions*, Ch. 3. This file develops
+representatives of double cosets, the characterisation of when two elements give the same double
+coset, the decomposition of a double coset into left cosets of `H`, and the finite decomposition
+quotient `H / (H ∩ gHg⁻¹)` used to define the Hecke product in later files.
+
+## Main definitions
+
+* `HeckeCoset.toSet`: the underlying set `HgH` of a double coset.
+* `HeckeCoset.rep`: a chosen representative in `Δ`.
+* `HeckeCoset.one`: the identity double coset `H1H = H`.
+* `HeckeRing.decompQuot`: the finite quotient `H / (H ∩ gHg⁻¹)` indexing the left cosets in `HgH`.
+
+## Main results
+
+* `HeckeCoset.eq_iff`: `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`.
+* `HeckeRing.doubleCoset_eq_iUnion_leftCosets`: a double coset `HgH` as a union of left cosets.
+
+## Implementation notes
+
+`HeckeRing.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
+`attribute [local instance]` so that the quotient notation `⟦·⟧` is available for `HeckeCoset`.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup
+open scoped Pointwise
+
+variable {G : Type*} [Group G]
+
+attribute [local instance] doubleCosetSetoid
+
+variable (H : Subgroup G)
+
+namespace HeckeRing
+
+/-- The conjugation action on `H` as a set product: `gHg⁻¹ = {g} * H * {g⁻¹}`. -/
+lemma conjAct_smul_coe_eq (g : G) :
+    ((ConjAct.toConjAct g • H) : Set G) = {g} * H * {g⁻¹} := by
+  ext x
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · obtain ⟨a, ha⟩ := Set.mem_smul_set.mp h
+    rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct] at ha
+    rw [← ha.2]
+    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
+      inv_inv, mem_preimage, inv_mul_cancel_right, inv_mul_cancel_left, ha.1]
+  · refine Set.mem_smul_set.mpr ⟨g⁻¹ * x * g, ?_,
+      by rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct]; group⟩
+    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
+      inv_inv, mem_preimage, SetLike.mem_coe] at *
+    rwa [← mul_assoc] at h
+
+/-- Conjugation by an element of `H` fixes `H`. -/
+lemma conjAct_smul_elt_eq (h : H) : ConjAct.toConjAct (h : G) • H = H := by
+  have : ConjAct.toConjAct (h : G) • (H : Set G) = H := by
+    rw [conjAct_smul_coe_eq, Subgroup.singleton_mul_subgroup h.2,
+      Subgroup.subgroup_mul_singleton (by simp)]
+  rw [← Subgroup.coe_pointwise_smul] at this; exact_mod_cast this
+
+/-- Scalar multiplication by a group element is the same as singleton set multiplication. -/
+lemma smul_eq_singleton_mul (s : Set G) (g : G) : g • s = {g} * s :=
+  Set.singleton_smul.symm
+
+/-- A subgroup `H` is the union of left cosets of any sub-subgroup `K ≤ H`. -/
+lemma set_eq_iUnion_leftCosets (K : Subgroup G) (hK : K ≤ H) :
+    (H : Set G) = ⋃ (i : H ⧸ K.subgroupOf H), (i.out : G) • (K : Set G) := by
+  ext a
+  refine ⟨fun ha ↦ ?_, fun ha ↦ ?_⟩
+  · simp only [Set.mem_iUnion]
+    refine ⟨(⟨a, ha⟩ : H), ?_⟩
+    obtain ⟨h, hh⟩ := QuotientGroup.mk_out_eq_mul (K.subgroupOf H) (⟨a, ha⟩ : H)
+    rw [hh]
+    simp only [coe_mul]
+    refine Set.mem_smul_set.mpr ⟨h⁻¹, ?_, ?_⟩
+    · simpa using Subgroup.mem_subgroupOf.mp (SetLike.coe_mem h)
+    · simp
+  · simp only [Set.mem_iUnion] at ha
+    obtain ⟨i, h, hh, rfl⟩ := ha
+    change ((Quotient.out i : H) : G) * h ∈ H
+    exact mul_mem (by simp) (hK hh)
+
+/-- The conjugate subgroup `gHg⁻¹` is closed under multiplication. -/
+lemma conjAct_mul_self_eq_self (g : G) :
+    ((ConjAct.toConjAct g • H) : Set G) * (ConjAct.toConjAct g • H) =
+    (ConjAct.toConjAct g • H) := by
+  rw [conjAct_smul_coe_eq,
+    show {g} * (H : Set G) * {g⁻¹} * ({g} * ↑H * {g⁻¹}) =
+      {g} * ↑H * (({g⁻¹} * {g}) * ↑H) * {g⁻¹} by simp_rw [← mul_assoc],
+    Set.singleton_mul_singleton]
+  conv => enter [1, 1, 2]; simp only [inv_mul_cancel, Set.singleton_one, one_mul]
+  conv => enter [1, 1]; rw [mul_assoc, coe_mul_coe H]
+
+/-- The intersection `H ∩ gHg⁻¹` acts trivially on `gHg⁻¹` by left multiplication. -/
+lemma inter_mul_conjAct_eq_conjAct (g : G) :
+    ((H : Set G) ∩ (ConjAct.toConjAct g • H)) * (ConjAct.toConjAct g • H) =
+    (ConjAct.toConjAct g • H) :=
+  Subset.antisymm
+    (le_trans (Set.inter_mul_subset (s₁ := (H : Set G))
+      (s₂ := (ConjAct.toConjAct g • H)) (t := (ConjAct.toConjAct g • H)))
+      (by simp [conjAct_mul_self_eq_self]))
+    (subset_mul_right _ ⟨Subgroup.one_mem H, Subgroup.one_mem (ConjAct.toConjAct g • H)⟩)
+
+/-- Right multiplication by a singleton is cancellative. -/
+lemma mul_singleton_right_cancel (g : G) (K L : Set G) (h : K * {g} = L * {g}) : K = L := by
+  have h2 := congrFun (congrArg HMul.hMul h) {g⁻¹}
+  simp_rw [mul_assoc, Set.singleton_mul_singleton] at h2; simpa using h2
+
+/-- A double coset `HgH` decomposes as a union of left cosets of `H`. -/
+lemma doubleCoset_eq_iUnion_leftCosets (g : G) :
+    DoubleCoset.doubleCoset g H H =
+    ⋃ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
+      (i.out * g) • (H : Set G) := by
+  rw [DoubleCoset.doubleCoset]
+  have := set_eq_iUnion_leftCosets H
+    (((ConjAct.toConjAct g • H).subgroupOf H).map H.subtype)
+  simp only [Subgroup.subgroupOf_map_subtype, inf_le_right, Subgroup.coe_inf,
+    Subgroup.coe_pointwise_smul, true_implies] at this
+  have h2 := congrFun (congrArg HMul.hMul this)
+    ((ConjAct.toConjAct g • H) : Set G)
+  rw [Set.iUnion_mul, inter_comm] at h2
+  apply mul_singleton_right_cancel g⁻¹
+  rw [conjAct_smul_coe_eq] at *
+  simp_rw [← mul_assoc] at h2
+  rw [h2, show (Subgroup.map H.subtype
+    ((ConjAct.toConjAct g • H).subgroupOf H)).subgroupOf H =
+    (ConjAct.toConjAct g • H).subgroupOf H by simp]
+  have h1 : ∀ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
+      ((i.out) : G) • ((H : Set G) ∩ ({g} * ↑H * {g⁻¹})) *
+        {g} * ↑H * {g⁻¹} =
+      (↑(Quotient.out i) * g) • ↑H * {g⁻¹} := by
+    intro i
+    have := inter_mul_conjAct_eq_conjAct H g
+    rw [conjAct_smul_coe_eq] at this
+    simp_rw [smul_mul_assoc]
+    simp_rw [← mul_assoc] at this
+    conv => enter [1, 2]; rw [this]
+    simp_rw [smul_eq_singleton_mul, ← Set.singleton_mul_singleton, ← mul_assoc]
+  convert Set.iUnion_congr h1
+  rw [Set.iUnion_mul]
+
+end HeckeRing
+
+namespace HeckeCoset
+
+variable {P : HeckePair G}
+
+/-- The underlying set `HgH`, well-defined on the quotient. -/
+noncomputable def toSet (D : HeckeCoset P) : Set G :=
+  Quotient.lift (fun (g : P.Δ) ↦ DoubleCoset.doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
+
+/-- A representative `g : Δ` (via `Quotient.out`). -/
+noncomputable def rep (D : HeckeCoset P) : P.Δ := Quotient.out D
+
+/-- The representative of a `HeckeCoset` maps back to the coset under `⟦·⟧`. -/
+lemma mk_rep (D : HeckeCoset P) : (⟦HeckeCoset.rep D⟧ : HeckeCoset P) = D :=
+  Quotient.out_eq D
+
+/-- `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`. -/
+lemma eq_iff (g h : P.Δ) : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
+    DoubleCoset.doubleCoset (g : G) P.H P.H = DoubleCoset.doubleCoset (h : G) P.H P.H :=
+  Quotient.eq
+
+/-- The carrier set of `⟦g⟧` is definitionally `HgH`. -/
+@[simp] lemma toSet_mk (g : P.Δ) :
+    HeckeCoset.toSet (⟦g⟧ : HeckeCoset P) = DoubleCoset.doubleCoset (g : G) P.H P.H := rfl
+
+/-- The carrier set equals the double coset of the representative. -/
+lemma toSet_eq_rep (D : HeckeCoset P) :
+    HeckeCoset.toSet D = DoubleCoset.doubleCoset (HeckeCoset.rep D : G) P.H P.H := by
+  refine Quotient.inductionOn D fun g ↦ ?_
+  simpa only [toSet_mk, HeckeCoset.rep] using
+    (Quotient.exact (Quotient.out_eq (⟦g⟧ : HeckeCoset P))).symm
+
+/-- The representative lies in its double coset. -/
+lemma rep_mem (D : HeckeCoset P) : (HeckeCoset.rep D : G) ∈ HeckeCoset.toSet D :=
+  toSet_eq_rep D ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
+
+/-- If `x ∈ HgH`, then `HxH = HgH`. The fundamental double coset absorption lemma. -/
+lemma doubleCoset_eq_of_mem {g : P.Δ} {x : G}
+    (hx : x ∈ DoubleCoset.doubleCoset (g : G) P.H P.H) :
+    DoubleCoset.doubleCoset x P.H P.H = DoubleCoset.doubleCoset (g : G) P.H P.H := by
+  obtain ⟨_, ⟨l, hl, _, rfl, rfl⟩, r, hr, rfl⟩ := hx
+  simp only [DoubleCoset.doubleCoset]
+  ext y; simp only [Set.mem_mul, Set.mem_singleton_iff, SetLike.mem_coe]
+  constructor
+  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
+    exact ⟨_, ⟨a * l, P.H.mul_mem ha hl, _, rfl, rfl⟩, r * b, P.H.mul_mem hr hb, by group⟩
+  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
+    exact ⟨_, ⟨a * l⁻¹, P.H.mul_mem ha (P.H.inv_mem hl), _, rfl, rfl⟩,
+      r⁻¹ * b, P.H.mul_mem (P.H.inv_mem hr) hb, by group⟩
+
+/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` is in the double coset of `g₂`. -/
+lemma eq_mk_of_mem {g₁ g₂ : P.Δ}
+    (h : (g₁ : G) ∈ DoubleCoset.doubleCoset (g₂ : G) P.H P.H) :
+    (⟦g₁⟧ : HeckeCoset P) = ⟦g₂⟧ :=
+  (eq_iff g₁ g₂).mpr (doubleCoset_eq_of_mem h)
+
+/-- The identity double coset `H1H = H`. -/
+def one (P : HeckePair G) : HeckeCoset P := ⟦⟨1, P.Δ.one_mem⟩⟧
+
+/-- Induction: to prove something for all double cosets, prove it for `⟦g⟧`. -/
+protected lemma ind {motive : HeckeCoset P → Prop}
+    (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D := Quotient.ind h
+
+/-- Two-argument induction. -/
+protected lemma ind₂ {motive : HeckeCoset P → HeckeCoset P → Prop}
+    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) :
+    ∀ D₁ D₂, motive D₁ D₂ := Quotient.ind₂ h
+
+/-- The representative of `HeckeCoset.one` belongs to `H`. -/
+lemma one_rep_mem_H (P : HeckePair G) : ((one P).rep : G) ∈ P.H := by
+  have hm := rep_mem (one P)
+  rw [toSet_eq_rep,
+    show DoubleCoset.doubleCoset ((rep (one P)) : G) P.H P.H =
+      DoubleCoset.doubleCoset (1 : G) P.H P.H from
+    Quotient.exact (Quotient.out_eq (⟦⟨(1 : G), P.Δ.one_mem⟩⟧ : HeckeCoset P)),
+    mem_doubleCoset] at hm
+  obtain ⟨a, ha, b, hb, hab⟩ := hm
+  rw [mul_one] at hab
+  exact hab ▸ P.H.mul_mem ha hb
+
+end HeckeCoset
+
+namespace HeckeRing
+
+/-- Left-multiplying the representative by an element of `H` does not change the double coset. -/
+lemma doubleCoset_mul_left_eq_self (P : HeckePair G) (h : P.H) (g : G) :
+    DoubleCoset.doubleCoset ((h : G) * g) P.H P.H =
+    DoubleCoset.doubleCoset g P.H P.H := by
+  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
+  conv => enter [1, 1, 1]; rw [Subgroup.subgroup_mul_singleton h.2]
+
+/-- Right-multiplying the representative by an element of `H` does not change the double coset. -/
+lemma doubleCoset_mul_right_eq_self (P : HeckePair G)
+    (h : P.H) (g : G) : DoubleCoset.doubleCoset (g * h) P.H P.H =
+    DoubleCoset.doubleCoset g P.H P.H := by
+  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
+  conv => enter [1]; rw [mul_assoc, Subgroup.singleton_mul_subgroup h.2]
+
+/-- The decomposition quotient `H / (H ∩ gHg⁻¹)` for a concrete `g : Δ`.
+Indexes the left cosets in the decomposition of `HgH`. -/
+abbrev decompQuot (P : HeckePair G) (g : P.Δ) :=
+  P.H ⧸ (ConjAct.toConjAct (g : G) • P.H).subgroupOf P.H
+
+/-- The decomposition quotient is finite because `Δ ≤ commensurator H`. -/
+noncomputable instance (P : HeckePair G) (g : P.Δ) :
+    Fintype (decompQuot P g) :=
+  Subgroup.fintypeOfIndexNeZero (P.h₁ g.2).1
+
+/-- Products of the form `a * h * b` with `h ∈ H`, `a, b ∈ Δ` remain in `Δ`. -/
+lemma delta_mul_mem (Δ : Submonoid G) (i : H) (a b : Δ) (h₀ : H.toSubmonoid ≤ Δ) :
+    a * (i : G) * b ∈ Δ := by
+  rw [mul_assoc]; exact Submonoid.mul_mem _ a.2 (Submonoid.mul_mem _ (h₀ i.2) b.2)
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -7,264 +7,112 @@ module
 
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.GroupTheory.Index
-public import Mathlib.Tactic.Group
 
 /-!
 # Hecke rings: the double coset API
 
-Basic API for the double cosets `HeckeCoset` that index an abstract Hecke ring, following
-Shimura, *Introduction to the Arithmetic Theory of Automorphic Functions*, Ch. 3. This file develops
-representatives of double cosets, the characterisation of when two elements give the same double
-coset, the decomposition of a double coset into left cosets of `H`, and the finite decomposition
-quotient `H / (H ∩ gHg⁻¹)` used to define the Hecke product in later files.
+Basic API for the double cosets `HeckeCoset` indexing an abstract Hecke ring, following
+[Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
+characterisation of when two elements give the same double coset, and the quotient
+`Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
+define the Hecke product in later files and is finite in the Hecke pair setting.
 
 ## Main definitions
 
 * `HeckeCoset.toSet`: the underlying set `HgH` of a double coset.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
-* `HeckeCoset.one`: the identity double coset `H1H = H`.
-* `HeckeRing.decompQuot`: the finite quotient `H / (H ∩ gHg⁻¹)` indexing the left cosets in `HgH`.
+* `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
+  in `Γ₁gΓ₂`; finite for a Hecke pair.
 
 ## Main results
 
 * `HeckeCoset.eq_iff`: `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`.
-* `HeckeRing.doubleCoset_eq_iUnion_leftCosets`: a double coset `HgH` as a union of left cosets.
+* `HeckeCoset.toSet_injective`: a double coset is determined by its underlying set.
 
 ## Implementation notes
 
-`HeckeRing.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
+`HeckePair.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
 `attribute [local instance]` so that the quotient notation `⟦·⟧` is available for `HeckeCoset`.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup
+open DoubleCoset Subgroup
 open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
-attribute [local instance] doubleCosetSetoid
-
-variable (H : Subgroup G)
-
-namespace HeckeRing
-
-/-- The conjugation action on `H` as a set product: `gHg⁻¹ = {g} * H * {g⁻¹}`. -/
-lemma conjAct_smul_coe_eq (g : G) :
-    ((ConjAct.toConjAct g • H) : Set G) = {g} * H * {g⁻¹} := by
-  ext x
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · obtain ⟨a, ha⟩ := Set.mem_smul_set.mp h
-    rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct] at ha
-    rw [← ha.2]
-    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
-      inv_inv, mem_preimage, inv_mul_cancel_right, inv_mul_cancel_left, ha.1]
-  · refine Set.mem_smul_set.mpr ⟨g⁻¹ * x * g, ?_,
-      by rw [ConjAct.smul_def, ConjAct.ofConjAct_toConjAct]; group⟩
-    simp only [singleton_mul, image_mul_left, mul_singleton, image_mul_right,
-      inv_inv, mem_preimage, SetLike.mem_coe] at *
-    rwa [← mul_assoc] at h
-
-/-- Conjugation by an element of `H` fixes `H`. -/
-lemma conjAct_smul_elt_eq (h : H) : ConjAct.toConjAct (h : G) • H = H := by
-  have : ConjAct.toConjAct (h : G) • (H : Set G) = H := by
-    rw [conjAct_smul_coe_eq, Subgroup.singleton_mul_subgroup h.2,
-      Subgroup.subgroup_mul_singleton (by simp)]
-  rw [← Subgroup.coe_pointwise_smul] at this; exact_mod_cast this
-
-/-- Scalar multiplication by a group element is the same as singleton set multiplication. -/
-lemma smul_eq_singleton_mul (s : Set G) (g : G) : g • s = {g} * s :=
-  Set.singleton_smul.symm
-
-/-- A subgroup `H` is the union of left cosets of any sub-subgroup `K ≤ H`. -/
-lemma set_eq_iUnion_leftCosets (K : Subgroup G) (hK : K ≤ H) :
-    (H : Set G) = ⋃ (i : H ⧸ K.subgroupOf H), (i.out : G) • (K : Set G) := by
-  ext a
-  refine ⟨fun ha ↦ ?_, fun ha ↦ ?_⟩
-  · simp only [Set.mem_iUnion]
-    refine ⟨(⟨a, ha⟩ : H), ?_⟩
-    obtain ⟨h, hh⟩ := QuotientGroup.mk_out_eq_mul (K.subgroupOf H) (⟨a, ha⟩ : H)
-    rw [hh]
-    simp only [coe_mul]
-    refine Set.mem_smul_set.mpr ⟨h⁻¹, ?_, ?_⟩
-    · simpa using Subgroup.mem_subgroupOf.mp (SetLike.coe_mem h)
-    · simp
-  · simp only [Set.mem_iUnion] at ha
-    obtain ⟨i, h, hh, rfl⟩ := ha
-    change ((Quotient.out i : H) : G) * h ∈ H
-    exact mul_mem (by simp) (hK hh)
-
-/-- The conjugate subgroup `gHg⁻¹` is closed under multiplication. -/
-lemma conjAct_mul_self_eq_self (g : G) :
-    ((ConjAct.toConjAct g • H) : Set G) * (ConjAct.toConjAct g • H) =
-    (ConjAct.toConjAct g • H) := by
-  rw [conjAct_smul_coe_eq,
-    show {g} * (H : Set G) * {g⁻¹} * ({g} * ↑H * {g⁻¹}) =
-      {g} * ↑H * (({g⁻¹} * {g}) * ↑H) * {g⁻¹} by simp_rw [← mul_assoc],
-    Set.singleton_mul_singleton]
-  conv => enter [1, 1, 2]; simp only [inv_mul_cancel, Set.singleton_one, one_mul]
-  conv => enter [1, 1]; rw [mul_assoc, coe_mul_coe H]
-
-/-- The intersection `H ∩ gHg⁻¹` acts trivially on `gHg⁻¹` by left multiplication. -/
-lemma inter_mul_conjAct_eq_conjAct (g : G) :
-    ((H : Set G) ∩ (ConjAct.toConjAct g • H)) * (ConjAct.toConjAct g • H) =
-    (ConjAct.toConjAct g • H) :=
-  Subset.antisymm
-    (le_trans (Set.inter_mul_subset (s₁ := (H : Set G))
-      (s₂ := (ConjAct.toConjAct g • H)) (t := (ConjAct.toConjAct g • H)))
-      (by simp [conjAct_mul_self_eq_self]))
-    (subset_mul_right _ ⟨Subgroup.one_mem H, Subgroup.one_mem (ConjAct.toConjAct g • H)⟩)
-
-/-- Right multiplication by a singleton is cancellative. -/
-lemma mul_singleton_right_cancel (g : G) (K L : Set G) (h : K * {g} = L * {g}) : K = L := by
-  have h2 := congrFun (congrArg HMul.hMul h) {g⁻¹}
-  simp_rw [mul_assoc, Set.singleton_mul_singleton] at h2; simpa using h2
-
-/-- A double coset `HgH` decomposes as a union of left cosets of `H`. -/
-lemma doubleCoset_eq_iUnion_leftCosets (g : G) :
-    DoubleCoset.doubleCoset g H H =
-    ⋃ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
-      (i.out * g) • (H : Set G) := by
-  rw [DoubleCoset.doubleCoset]
-  have := set_eq_iUnion_leftCosets H
-    (((ConjAct.toConjAct g • H).subgroupOf H).map H.subtype)
-  simp only [Subgroup.subgroupOf_map_subtype, inf_le_right, Subgroup.coe_inf,
-    Subgroup.coe_pointwise_smul, true_implies] at this
-  have h2 := congrFun (congrArg HMul.hMul this)
-    ((ConjAct.toConjAct g • H) : Set G)
-  rw [Set.iUnion_mul, inter_comm] at h2
-  apply mul_singleton_right_cancel g⁻¹
-  rw [conjAct_smul_coe_eq] at *
-  simp_rw [← mul_assoc] at h2
-  rw [h2, show (Subgroup.map H.subtype
-    ((ConjAct.toConjAct g • H).subgroupOf H)).subgroupOf H =
-    (ConjAct.toConjAct g • H).subgroupOf H by simp]
-  have h1 : ∀ (i : H ⧸ (ConjAct.toConjAct g • H).subgroupOf H),
-      ((i.out) : G) • ((H : Set G) ∩ ({g} * ↑H * {g⁻¹})) *
-        {g} * ↑H * {g⁻¹} =
-      (↑(Quotient.out i) * g) • ↑H * {g⁻¹} := by
-    intro i
-    have := inter_mul_conjAct_eq_conjAct H g
-    rw [conjAct_smul_coe_eq] at this
-    simp_rw [smul_mul_assoc]
-    simp_rw [← mul_assoc] at this
-    conv => enter [1, 2]; rw [this]
-    simp_rw [smul_eq_singleton_mul, ← Set.singleton_mul_singleton, ← mul_assoc]
-  convert Set.iUnion_congr h1
-  rw [Set.iUnion_mul]
-
-end HeckeRing
+attribute [local instance] HeckePair.doubleCosetSetoid
 
 namespace HeckeCoset
 
 variable {P : HeckePair G}
 
-/-- The underlying set `HgH`, well-defined on the quotient. -/
-noncomputable def toSet (D : HeckeCoset P) : Set G :=
-  Quotient.lift (fun (g : P.Δ) ↦ DoubleCoset.doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
+/-- The underlying set `HgH` of a double coset, well-defined on the quotient. -/
+def toSet (D : HeckeCoset P) : Set G :=
+  Quotient.lift (fun g : P.Δ ↦ doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
 
-/-- A representative `g : Δ` (via `Quotient.out`). -/
+/-- A representative `g : Δ` of a double coset (via `Quotient.out`). -/
 noncomputable def rep (D : HeckeCoset P) : P.Δ := Quotient.out D
 
-/-- The representative of a `HeckeCoset` maps back to the coset under `⟦·⟧`. -/
-lemma mk_rep (D : HeckeCoset P) : (⟦HeckeCoset.rep D⟧ : HeckeCoset P) = D :=
-  Quotient.out_eq D
+@[simp] lemma mk_rep (D : HeckeCoset P) : (⟦D.rep⟧ : HeckeCoset P) = D := Quotient.out_eq D
 
-/-- `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`. -/
-lemma eq_iff (g h : P.Δ) : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
-    DoubleCoset.doubleCoset (g : G) P.H P.H = DoubleCoset.doubleCoset (h : G) P.H P.H :=
-  Quotient.eq
+lemma eq_iff {g h : P.Δ} : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
+    doubleCoset (g : G) P.H P.H = doubleCoset (h : G) P.H P.H := Quotient.eq
 
-/-- The carrier set of `⟦g⟧` is definitionally `HgH`. -/
 @[simp] lemma toSet_mk (g : P.Δ) :
-    HeckeCoset.toSet (⟦g⟧ : HeckeCoset P) = DoubleCoset.doubleCoset (g : G) P.H P.H := rfl
+    toSet (⟦g⟧ : HeckeCoset P) = doubleCoset (g : G) P.H P.H := rfl
 
-/-- The carrier set equals the double coset of the representative. -/
-lemma toSet_eq_rep (D : HeckeCoset P) :
-    HeckeCoset.toSet D = DoubleCoset.doubleCoset (HeckeCoset.rep D : G) P.H P.H := by
-  refine Quotient.inductionOn D fun g ↦ ?_
-  simpa only [toSet_mk, HeckeCoset.rep] using
-    (Quotient.exact (Quotient.out_eq (⟦g⟧ : HeckeCoset P))).symm
+lemma toSet_eq_doubleCoset_rep (D : HeckeCoset P) :
+    D.toSet = doubleCoset (D.rep : G) P.H P.H := by rw [← toSet_mk, mk_rep]
 
-/-- The representative lies in its double coset. -/
-lemma rep_mem (D : HeckeCoset P) : (HeckeCoset.rep D : G) ∈ HeckeCoset.toSet D :=
-  toSet_eq_rep D ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
+lemma toSet_injective : Function.Injective (toSet : HeckeCoset P → Set G) := fun D₁ D₂ ↦
+  Quotient.inductionOn₂ D₁ D₂ fun _ _ h ↦ Quotient.sound h
 
-/-- If `x ∈ HgH`, then `HxH = HgH`. The fundamental double coset absorption lemma. -/
-lemma doubleCoset_eq_of_mem {g : P.Δ} {x : G}
-    (hx : x ∈ DoubleCoset.doubleCoset (g : G) P.H P.H) :
-    DoubleCoset.doubleCoset x P.H P.H = DoubleCoset.doubleCoset (g : G) P.H P.H := by
-  obtain ⟨_, ⟨l, hl, _, rfl, rfl⟩, r, hr, rfl⟩ := hx
-  simp only [DoubleCoset.doubleCoset]
-  ext y; simp only [Set.mem_mul, Set.mem_singleton_iff, SetLike.mem_coe]
-  constructor
-  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
-    exact ⟨_, ⟨a * l, P.H.mul_mem ha hl, _, rfl, rfl⟩, r * b, P.H.mul_mem hr hb, by group⟩
-  · rintro ⟨_, ⟨a, ha, _, rfl, rfl⟩, b, hb, rfl⟩
-    exact ⟨_, ⟨a * l⁻¹, P.H.mul_mem ha (P.H.inv_mem hl), _, rfl, rfl⟩,
-      r⁻¹ * b, P.H.mul_mem (P.H.inv_mem hr) hb, by group⟩
+lemma rep_mem (D : HeckeCoset P) : (D.rep : G) ∈ D.toSet :=
+  D.toSet_eq_doubleCoset_rep ▸ mem_doubleCoset_self P.H P.H _
 
-/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` is in the double coset of `g₂`. -/
-lemma eq_mk_of_mem {g₁ g₂ : P.Δ}
-    (h : (g₁ : G) ∈ DoubleCoset.doubleCoset (g₂ : G) P.H P.H) :
+/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` lies in the double coset of `g₂`. -/
+lemma mk_eq_mk_of_mem {g₁ g₂ : P.Δ} (h : (g₁ : G) ∈ doubleCoset (g₂ : G) P.H P.H) :
     (⟦g₁⟧ : HeckeCoset P) = ⟦g₂⟧ :=
-  (eq_iff g₁ g₂).mpr (doubleCoset_eq_of_mem h)
-
-/-- The identity double coset `H1H = H`. -/
-def one (P : HeckePair G) : HeckeCoset P := ⟦⟨1, P.Δ.one_mem⟩⟧
+  eq_iff.mpr (doubleCoset_eq_of_mem h)
 
 /-- Induction: to prove something for all double cosets, prove it for `⟦g⟧`. -/
-protected lemma ind {motive : HeckeCoset P → Prop}
-    (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D := Quotient.ind h
+protected lemma ind {motive : HeckeCoset P → Prop} (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D :=
+  Quotient.ind h
 
-/-- Two-argument induction. -/
+/-- Two-argument induction for double cosets. -/
 protected lemma ind₂ {motive : HeckeCoset P → HeckeCoset P → Prop}
-    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) :
-    ∀ D₁ D₂, motive D₁ D₂ := Quotient.ind₂ h
+    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) : ∀ D₁ D₂, motive D₁ D₂ :=
+  Quotient.ind₂ h
 
-/-- The representative of `HeckeCoset.one` belongs to `H`. -/
-lemma one_rep_mem_H (P : HeckePair G) : ((one P).rep : G) ∈ P.H := by
-  have hm := rep_mem (one P)
-  rw [toSet_eq_rep,
-    show DoubleCoset.doubleCoset ((rep (one P)) : G) P.H P.H =
-      DoubleCoset.doubleCoset (1 : G) P.H P.H from
-    Quotient.exact (Quotient.out_eq (⟦⟨(1 : G), P.Δ.one_mem⟩⟧ : HeckeCoset P)),
-    mem_doubleCoset] at hm
-  obtain ⟨a, ha, b, hb, hab⟩ := hm
-  rw [mul_one] at hab
-  exact hab ▸ P.H.mul_mem ha hb
+@[simp] lemma toSet_one : toSet (1 : HeckeCoset P) = (P.H : Set G) := by
+  change (P.H : Set G) * {(1 : G)} * P.H = (P.H : Set G)
+  rw [Subgroup.subgroup_mul_singleton P.H.one_mem, coe_mul_coe]
+
+lemma rep_one_mem : (rep (1 : HeckeCoset P) : G) ∈ P.H := by
+  simpa using rep_mem (1 : HeckeCoset P)
 
 end HeckeCoset
 
-namespace HeckeRing
+namespace DoubleCoset
 
-/-- Left-multiplying the representative by an element of `H` does not change the double coset. -/
-lemma doubleCoset_mul_left_eq_self (P : HeckePair G) (h : P.H) (g : G) :
-    DoubleCoset.doubleCoset ((h : G) * g) P.H P.H =
-    DoubleCoset.doubleCoset g P.H P.H := by
-  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
-  conv => enter [1, 1, 1]; rw [Subgroup.subgroup_mul_singleton h.2]
+/-- The decomposition quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)`, indexing the left cosets of `Γ₂` inside
+the double coset `Γ₁gΓ₂`; see `DoubleCoset.doubleCoset_eq_iUnion_leftCosets`. -/
+abbrev DecompQuotient (Γ₁ Γ₂ : Subgroup G) (g : G) :=
+  Γ₁ ⧸ (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁
 
-/-- Right-multiplying the representative by an element of `H` does not change the double coset. -/
-lemma doubleCoset_mul_right_eq_self (P : HeckePair G)
-    (h : P.H) (g : G) : DoubleCoset.doubleCoset (g * h) P.H P.H =
-    DoubleCoset.doubleCoset g P.H P.H := by
-  simp_rw [DoubleCoset.doubleCoset, ← Set.singleton_mul_singleton, ← mul_assoc]
-  conv => enter [1]; rw [mul_assoc, Subgroup.singleton_mul_subgroup h.2]
+instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ₂ g) :=
+  ⟨QuotientGroup.mk 1⟩
 
-/-- The decomposition quotient `H / (H ∩ gHg⁻¹)` for a concrete `g : Δ`.
-Indexes the left cosets in the decomposition of `HgH`. -/
-abbrev decompQuot (P : HeckePair G) (g : P.Δ) :=
-  P.H ⧸ (ConjAct.toConjAct (g : G) • P.H).subgroupOf P.H
+end DoubleCoset
 
-/-- The decomposition quotient is finite because `Δ ≤ commensurator H`. -/
+namespace HeckePair
+
+/-- For a Hecke pair, the decomposition quotient of any `g : Δ` is finite, because `Δ` lies in
+the commensurator of `H`. -/
 noncomputable instance (P : HeckePair G) (g : P.Δ) :
-    Fintype (decompQuot P g) :=
-  Subgroup.fintypeOfIndexNeZero (P.h₁ g.2).1
+    Fintype (DecompQuotient P.H P.H (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (P.le_commensurator g.2).1
 
-/-- Products of the form `a * h * b` with `h ∈ H`, `a, b ∈ Δ` remain in `Δ`. -/
-lemma delta_mul_mem (Δ : Submonoid G) (i : H) (a b : Δ) (h₀ : H.toSubmonoid ≤ Δ) :
-    a * (i : G) * b ∈ Δ := by
-  rw [mul_assoc]; exact Submonoid.mul_mem _ a.2 (Submonoid.mul_mem _ (h₀ i.2) b.2)
-
-end HeckeRing
+end HeckePair

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -110,11 +110,4 @@ noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTripl
     (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) :=
   Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_right g).1
 
-/-- The decomposition quotient with the two subgroups swapped is finite from the same datum,
-since `Δ` also commensurates the left subgroup (`le_commensurator_left`). Lower priority, so
-that the unswapped instance is preferred in the diagonal case. -/
-noncomputable instance (priority := 900) {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
-    [IsHeckeTriple Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_left g).1
-
 end IsHeckeTriple

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -15,14 +15,14 @@ Basic API for the double cosets `HeckeCoset` indexing a Hecke coset module, foll
 [Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
 characterisation of when two elements give the same double coset, and the quotient
 `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
-define the Hecke product in later files and is finite for a Hecke coset module datum.
+define the Hecke product in later files and is finite for a Hecke triple.
 
 ## Main definitions
 
 * `HeckeCoset.toSet`: the underlying set `H₁gH₂` of a double coset.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
 * `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
-  in `Γ₁gΓ₂`; finite for a Hecke coset module datum.
+  in `Γ₁gΓ₂`; finite for a Hecke triple.
 
 ## Main results
 
@@ -102,19 +102,19 @@ instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ�
 
 end DoubleCoset
 
-namespace IsHeckeCosetModule
+namespace IsHeckeTriple
 
-/-- For a Hecke coset module datum, the decomposition quotient of any `g : Δ` is finite: `Δ`
+/-- For a Hecke triple, the decomposition quotient of any `g : Δ` is finite: `Δ`
 commensurates `H₂`, which is commensurable with `H₁`. -/
-noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
+noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]
     (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_right g).1
+  Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_right g).1
 
 /-- The decomposition quotient with the two subgroups swapped is finite from the same datum,
 since `Δ` also commensurates the left subgroup (`le_commensurator_left`). Lower priority, so
 that the unswapped instance is preferred in the diagonal case. -/
 noncomputable instance (priority := 900) {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
-    [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_left g).1
+    [IsHeckeTriple Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_left g).1
 
-end IsHeckeCosetModule
+end IsHeckeTriple

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -11,28 +11,23 @@ public import Mathlib.GroupTheory.Index
 /-!
 # Hecke rings: the double coset API
 
-Basic API for the double cosets `HeckeCoset` indexing an abstract Hecke ring, following
+Basic API for the double cosets `HeckeCoset` indexing a Hecke coset module, following
 [Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
 characterisation of when two elements give the same double coset, and the quotient
 `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
-define the Hecke product in later files and is finite in the Hecke pair setting.
+define the Hecke product in later files and is finite for a Hecke coset module datum.
 
 ## Main definitions
 
-* `HeckeCoset.toSet`: the underlying set `HgH` of a double coset.
+* `HeckeCoset.toSet`: the underlying set `H₁gH₂` of a double coset.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
 * `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
-  in `Γ₁gΓ₂`; finite for a Hecke pair.
+  in `Γ₁gΓ₂`; finite for a Hecke coset module datum.
 
 ## Main results
 
-* `HeckeCoset.eq_iff`: `⟦g⟧ = ⟦h⟧ ↔ HgH = HhH`.
+* `HeckeCoset.eq_iff`: `mk H₁ H₂ g = mk H₁ H₂ h ↔ H₁gH₂ = H₁hH₂`.
 * `HeckeCoset.toSet_injective`: a double coset is determined by its underlying set.
-
-## Implementation notes
-
-`HeckePair.doubleCosetSetoid` is a `def`, not a global instance; this file opts in to it with
-`attribute [local instance]` so that the quotient notation `⟦·⟧` is available for `HeckeCoset`.
 -/
 
 @[expose] public section
@@ -42,56 +37,56 @@ open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
-attribute [local instance] HeckePair.doubleCosetSetoid
-
 namespace HeckeCoset
 
-variable {P : HeckePair G}
+variable {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
 
-/-- The underlying set `HgH` of a double coset, well-defined on the quotient. -/
-def toSet (D : HeckeCoset P) : Set G :=
-  Quotient.lift (fun g : P.Δ ↦ doubleCoset (g : G) P.H P.H) (fun _ _ h ↦ h) D
+/-- The underlying set `H₁gH₂` of a double coset, well-defined on the quotient. -/
+def toSet (D : HeckeCoset Δ H₁ H₂) : Set G :=
+  Quotient.lift (fun g : Δ ↦ doubleCoset (g : G) H₁ H₂) (fun _ _ h ↦ h) D
 
 /-- A representative `g : Δ` of a double coset (via `Quotient.out`). -/
-noncomputable def rep (D : HeckeCoset P) : P.Δ := Quotient.out D
+noncomputable def rep (D : HeckeCoset Δ H₁ H₂) : Δ := Quotient.out D
 
-@[simp] lemma mk_rep (D : HeckeCoset P) : (⟦D.rep⟧ : HeckeCoset P) = D := Quotient.out_eq D
+@[simp] lemma mk_rep (D : HeckeCoset Δ H₁ H₂) : mk H₁ H₂ D.rep = D := Quotient.out_eq' D
 
-lemma eq_iff {g h : P.Δ} : (⟦g⟧ : HeckeCoset P) = ⟦h⟧ ↔
-    doubleCoset (g : G) P.H P.H = doubleCoset (h : G) P.H P.H := Quotient.eq
+lemma eq_iff {g h : Δ} : mk H₁ H₂ g = mk H₁ H₂ h ↔
+    doubleCoset (g : G) H₁ H₂ = doubleCoset (h : G) H₁ H₂ := Quotient.eq''
 
-@[simp] lemma toSet_mk (g : P.Δ) :
-    toSet (⟦g⟧ : HeckeCoset P) = doubleCoset (g : G) P.H P.H := rfl
+@[simp] lemma toSet_mk (g : Δ) : toSet (mk H₁ H₂ g) = doubleCoset (g : G) H₁ H₂ := rfl
 
-lemma toSet_eq_doubleCoset_rep (D : HeckeCoset P) :
-    D.toSet = doubleCoset (D.rep : G) P.H P.H := by rw [← toSet_mk, mk_rep]
+lemma toSet_eq_doubleCoset_rep (D : HeckeCoset Δ H₁ H₂) :
+    D.toSet = doubleCoset (D.rep : G) H₁ H₂ := by rw [← toSet_mk, mk_rep]
 
-lemma toSet_injective : Function.Injective (toSet : HeckeCoset P → Set G) := fun D₁ D₂ ↦
-  Quotient.inductionOn₂ D₁ D₂ fun _ _ h ↦ Quotient.sound h
+lemma toSet_injective : Function.Injective (toSet : HeckeCoset Δ H₁ H₂ → Set G) := fun D₁ D₂ ↦
+  Quotient.inductionOn₂' D₁ D₂ fun _ _ h ↦ Quotient.sound' h
 
-lemma rep_mem (D : HeckeCoset P) : (D.rep : G) ∈ D.toSet :=
-  D.toSet_eq_doubleCoset_rep ▸ mem_doubleCoset_self P.H P.H _
+lemma rep_mem (D : HeckeCoset Δ H₁ H₂) : (D.rep : G) ∈ D.toSet :=
+  D.toSet_eq_doubleCoset_rep ▸ mem_doubleCoset_self H₁ H₂ _
 
-/-- `⟦g₁⟧ = ⟦g₂⟧` when `g₁` lies in the double coset of `g₂`. -/
-lemma mk_eq_mk_of_mem {g₁ g₂ : P.Δ} (h : (g₁ : G) ∈ doubleCoset (g₂ : G) P.H P.H) :
-    (⟦g₁⟧ : HeckeCoset P) = ⟦g₂⟧ :=
+/-- `mk H₁ H₂ g₁ = mk H₁ H₂ g₂` when `g₁` lies in the double coset of `g₂`. -/
+lemma mk_eq_mk_of_mem {g₁ g₂ : Δ} (h : (g₁ : G) ∈ doubleCoset (g₂ : G) H₁ H₂) :
+    mk H₁ H₂ g₁ = mk H₁ H₂ g₂ :=
   eq_iff.mpr (doubleCoset_eq_of_mem h)
 
-/-- Induction: to prove something for all double cosets, prove it for `⟦g⟧`. -/
-protected lemma ind {motive : HeckeCoset P → Prop} (h : ∀ g : P.Δ, motive ⟦g⟧) : ∀ D, motive D :=
-  Quotient.ind h
+/-- Induction: to prove something for all double cosets, prove it for `mk H₁ H₂ g`. -/
+protected lemma ind {motive : HeckeCoset Δ H₁ H₂ → Prop} (h : ∀ g : Δ, motive (mk H₁ H₂ g)) :
+    ∀ D, motive D :=
+  Quotient.ind' h
 
 /-- Two-argument induction for double cosets. -/
-protected lemma ind₂ {motive : HeckeCoset P → HeckeCoset P → Prop}
-    (h : ∀ g₁ g₂ : P.Δ, motive ⟦g₁⟧ ⟦g₂⟧) : ∀ D₁ D₂, motive D₁ D₂ :=
-  Quotient.ind₂ h
+protected lemma ind₂ {motive : HeckeCoset Δ H₁ H₂ → HeckeCoset Δ H₁ H₂ → Prop}
+    (h : ∀ g₁ g₂ : Δ, motive (mk H₁ H₂ g₁) (mk H₁ H₂ g₂)) : ∀ D₁ D₂, motive D₁ D₂ := fun D₁ D₂ ↦
+  Quotient.inductionOn₂' D₁ D₂ h
 
-@[simp] lemma toSet_one : toSet (1 : HeckeCoset P) = (P.H : Set G) := by
-  change (P.H : Set G) * {(1 : G)} * P.H = (P.H : Set G)
-  rw [Subgroup.subgroup_mul_singleton P.H.one_mem, coe_mul_coe]
+variable {H : Subgroup G}
 
-lemma rep_one_mem : (rep (1 : HeckeCoset P) : G) ∈ P.H := by
-  simpa using rep_mem (1 : HeckeCoset P)
+@[simp] lemma toSet_one : toSet (1 : HeckeCoset Δ H H) = (H : Set G) := by
+  change (H : Set G) * {(1 : G)} * H = (H : Set G)
+  rw [Subgroup.subgroup_mul_singleton H.one_mem, coe_mul_coe]
+
+lemma rep_one_mem : (rep (1 : HeckeCoset Δ H H) : G) ∈ H := by
+  simpa using rep_mem (1 : HeckeCoset Δ H H)
 
 end HeckeCoset
 
@@ -107,12 +102,15 @@ instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ�
 
 end DoubleCoset
 
-namespace HeckePair
+namespace IsHeckeCosetModule
 
-/-- For a Hecke pair, the decomposition quotient of any `g : Δ` is finite, because `Δ` lies in
-the commensurator of `H`. -/
-noncomputable instance (P : HeckePair G) (g : P.Δ) :
-    Fintype (DecompQuotient P.H P.H (g : G)) :=
-  Subgroup.fintypeOfIndexNeZero (P.le_commensurator g.2).1
+/-- For a Hecke coset module datum, the decomposition quotient of any `g : Δ` is finite: `Δ`
+commensurates `H₂`, which is commensurable with `H₁`. -/
+noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
+    (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) := by
+  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ :=
+    IsHeckeCosetModule.le_commensurator H₁ g.2
+  exact Subgroup.fintypeOfIndexNeZero
+    (hg.trans (IsHeckeCosetModule.commensurable (Δ := Δ)).symm).1
 
-end HeckePair
+end IsHeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Basic.lean
@@ -107,10 +107,14 @@ namespace IsHeckeCosetModule
 /-- For a Hecke coset module datum, the decomposition quotient of any `g : Δ` is finite: `Δ`
 commensurates `H₂`, which is commensurable with `H₁`. -/
 noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
-    (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) := by
-  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ :=
-    IsHeckeCosetModule.le_commensurator H₁ g.2
-  exact Subgroup.fintypeOfIndexNeZero
-    (hg.trans (IsHeckeCosetModule.commensurable (Δ := Δ)).symm).1
+    (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_right g).1
+
+/-- The decomposition quotient with the two subgroups swapped is finite from the same datum,
+since `Δ` also commensurates the left subgroup (`le_commensurator_left`). Lower priority, so
+that the unswapped instance is preferred in the diagonal case. -/
+noncomputable instance (priority := 900) {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
+    [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) : Fintype (DecompQuotient H₂ H₁ (g : G)) :=
+  Subgroup.fintypeOfIndexNeZero (IsHeckeCosetModule.commensurable_conjAct_left g).1
 
 end IsHeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -12,14 +12,15 @@ public import Mathlib.GroupTheory.DoubleCoset
 /-!
 # Hecke rings: definitions
 
-The abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the Hecke coset modules
-attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971], Chapter 3, and
-[Krieg][krieg1990], Chapter I. This file sets up the underlying types: the compatibility
+This file introduces the abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the
+Hecke coset modules attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971],
+Chapter 3, and [Krieg][krieg1990], Chapter I. It sets up the underlying types: the compatibility
 conditions `IsHeckeTriple Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
 double-coset quotient `HeckeCoset Δ H₁ H₂` of `Δ` by `H₁gH₂ = H₁hH₂`, and the Hecke coset module
-`𝕋 Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets. The convolution
-product `𝕋 Δ H₁ H₂ Z × 𝕋 Δ H₂ H₃ Z → 𝕋 Δ H₁ H₃ Z` and the ring structure on the diagonal
-`𝕋 Δ H H Z` are developed in later files.
+`HeckeCosetModule Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets.
+The convolution product `HeckeCosetModule Δ H₁ H₂ Z × HeckeCosetModule Δ H₂ H₃ Z →
+HeckeCosetModule Δ H₁ H₃ Z` and the ring structure on the diagonal Hecke ring `𝕋 Δ H Z` are
+developed in later files.
 
 The relevance of the submonoid `Δ` may not be immediately obvious; a natural example is
 `H = GL₂(ℤ)` inside `G = GL₂(ℚ)` with `Δ` the submonoid of integral matrices with nonzero
@@ -35,15 +36,17 @@ subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.
   `IsHeckeTriple Δ H H`.
 * `HeckeCoset Δ H₁ H₂`: the quotient of `Δ` by the relation `H₁gH₂ = H₁hH₂`, i.e. the double
   cosets `H₁\Δ/H₂` forming the basis of the Hecke coset module.
-* `HeckeCosetModule Δ H₁ H₂ Z`, notation `𝕋 Δ H₁ H₂ Z`: the Hecke coset module with
-  coefficients in `Z`, the finitely-supported `Z`-linear combinations of double cosets. For
-  `H₁ = H₂` this is the underlying module of the Hecke ring.
+* `HeckeCosetModule Δ H₁ H₂ Z`: the Hecke coset module with coefficients in `Z`, the
+  finitely-supported `Z`-linear combinations of double cosets.
+* `HeckeRing Δ H Z`, notation `𝕋 Δ H Z`: the Hecke ring, the diagonal case
+  `HeckeCosetModule Δ H H Z` of the Hecke coset module.
 
 ## Implementation notes
 
 The data `(Δ, H₁, H₂)` enters unbundled, with the compatibility conditions collected in the
-Prop-valued class `IsHeckeTriple`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
-built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all levels
+Prop-valued class `IsHeckeTriple`: the types `HeckeCoset Δ H₁ H₂` and `HeckeCosetModule Δ H₁ H₂ Z`
+are built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all
+levels
 (as in [Shimura][shimura1971]) means products of double cosets over different subgroups,
 `H₁g₁H₂ * H₂g₂H₃ ⊆ Δ`, need no compatibility hypotheses. The conditions are only needed for the
 finiteness of the coset decompositions, which enters through the `Fintype` instance on
@@ -77,7 +80,7 @@ class IsHeckeTriple (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
   commensurable : Commensurable H₁ H₂
   /-- The submonoid `Δ` lies in the commensurator of the right subgroup (hence, the subgroups
   being commensurable, also in that of the left one; see `le_commensurator_left`). -/
-  le_commensurator : Δ ≤ (commensurator H₂).toSubmonoid
+  le_commensurator_right : Δ ≤ (commensurator H₂).toSubmonoid
 
 namespace IsHeckeTriple
 
@@ -90,25 +93,25 @@ theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
 
 /-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
+theorem mem_of_mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
   left_le (H₂ := H₂) hx
 
 /-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
+theorem mem_of_mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
   right_le (H₁ := H₁) hx
 
 /-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
-theorem le_commensurator_left [IsHeckeTriple Δ H₁ H₂] :
+theorem le_commensurator_left [h : IsHeckeTriple Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
-  rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
-  exact le_commensurator H₁
+  rw [h.commensurable.eq]
+  exact h.le_commensurator_right
 
 /-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
 explicit, since it cannot be inferred. -/
 theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₂ :=
-  le_commensurator H₁ g.2
+  le_commensurator_right H₁ g.2
 
 /-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
 explicit, since it cannot be inferred. -/
@@ -117,23 +120,12 @@ theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] 
   le_commensurator_left (H₂ := H₂) g.2
 
 /-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
-the left one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₁ H₂`. -/
+the left one; the intersection `H₁ ∩ gH₂g⁻¹` this bounds is the one underlying
+`DoubleCoset.DecompQuotient H₁ H₂ g`. -/
 theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
   exact hg.trans (commensurable (Δ := Δ)).symm
-
-/-- Conjugating the left subgroup by an element of `Δ` gives a subgroup commensurable with
-the right one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₂ H₁`. -/
-theorem commensurable_conjAct_left [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
-    Commensurable (ConjAct.toConjAct (g : G) • H₁) H₂ := by
-  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₁) H₁ := mem_commensurator_left H₂ g
-  exact hg.trans (commensurable (Δ := Δ))
-
-/-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
-theorem symm [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₁ :=
-  ⟨right_le (H₁ := H₁), left_le (H₂ := H₂), (commensurable (Δ := Δ)).symm,
-    le_commensurator_left (H₂ := H₂)⟩
 
 /-- Hecke coset module data compose. Not an instance, since the middle subgroup cannot be
 inferred from the goal. -/
@@ -142,7 +134,7 @@ theorem trans [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] :
   ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
     (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
       (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
-    le_commensurator (H₁ := H₂)⟩
+    le_commensurator_right (H₁ := H₂)⟩
 
 /-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
 theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
@@ -150,7 +142,7 @@ theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
 
 /-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
 theorem diag_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
-  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator (H₁ := H₁)⟩
+  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator_right (H₁ := H₁)⟩
 
 end IsHeckeTriple
 
@@ -158,8 +150,8 @@ end IsHeckeTriple
 back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
 
 This is a `def` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred from
-the type `↥Δ`, so this cannot participate in instance search (and a global instance would also
-create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
+the submonoid `Δ`, so this cannot participate in instance search (and a global instance would
+also create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
 `HeckeCoset.mk`. -/
 @[reducible] def HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
   (DoubleCoset.setoid (H₁ : Set G) H₂).comap Subtype.val
@@ -187,34 +179,41 @@ lemma one_def (H : Subgroup G) : (1 : HeckeCoset Δ H H) = mk H H ⟨1, Δ.one_m
 
 end HeckeCoset
 
-/-- The Hecke coset module with coefficients in `Z`, denoted `𝕋 Δ H₁ H₂ Z`: the
-finitely-supported `Z`-linear combinations of double cosets `H₁\Δ/H₂`. For `H₁ = H₂` this is the
-underlying module of the Hecke ring. The coefficients `Z` need only carry a `Zero` for the type
-to make sense; algebraic structure is added by the instances below at the weakest level each
+/-- The Hecke coset module with coefficients in `Z`: the finitely-supported `Z`-linear
+combinations of double cosets `H₁\Δ/H₂`. For `H₁ = H₂` this is the underlying module of the
+Hecke ring `𝕋 Δ H Z` (see `HeckeRing`). The coefficients `Z` need only carry a `Zero` for the
+type to make sense; algebraic structure is added by the instances below at the weakest level each
 requires. -/
 def HeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*) [Zero Z] :=
   HeckeCoset Δ H₁ H₂ →₀ Z
 
-namespace HeckeCosetModule
+/-- The Hecke ring `𝕋 Δ H Z` with coefficients in `Z`: the diagonal Hecke coset module
+`HeckeCosetModule Δ H H Z`, the finitely-supported `Z`-linear combinations of double cosets
+`H\Δ/H`. The convolution product making it a ring is developed in later files. -/
+abbrev HeckeRing (Δ : Submonoid G) (H : Subgroup G) (Z : Type*) [Zero Z] :=
+  HeckeCosetModule Δ H H Z
 
 @[inherit_doc]
-scoped notation "𝕋" => HeckeCosetModule
+scoped[HeckeCosetModule] notation "𝕋" => HeckeRing
+
+namespace HeckeCosetModule
 
 variable (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*)
 
-/-- Elements of `𝕋 Δ H₁ H₂ Z` are functions `HeckeCoset Δ H₁ H₂ → Z` (finitely supported). -/
-instance [Zero Z] : FunLike (𝕋 Δ H₁ H₂ Z) (HeckeCoset Δ H₁ H₂) Z :=
+/-- Elements of `HeckeCosetModule Δ H₁ H₂ Z` are functions `HeckeCoset Δ H₁ H₂ → Z` (finitely
+supported). -/
+instance [Zero Z] : FunLike (HeckeCosetModule Δ H₁ H₂ Z) (HeckeCoset Δ H₁ H₂) Z :=
   inferInstanceAs (FunLike (HeckeCoset Δ H₁ H₂ →₀ Z) (HeckeCoset Δ H₁ H₂) Z)
 
-noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 Δ H₁ H₂ Z) :=
+noncomputable instance [AddCommMonoid Z] : AddCommMonoid (HeckeCosetModule Δ H₁ H₂ Z) :=
   inferInstanceAs (AddCommMonoid (HeckeCoset Δ H₁ H₂ →₀ Z))
 
-noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 Δ H₁ H₂ Z) :=
+noncomputable instance [AddCommGroup Z] : AddCommGroup (HeckeCosetModule Δ H₁ H₂ Z) :=
   inferInstanceAs (AddCommGroup (HeckeCoset Δ H₁ H₂ →₀ Z))
 
 @[ext]
-lemma ext {Δ : Submonoid G} {H₁ H₂ : Subgroup G} {Z : Type*} [Zero Z] {f g : 𝕋 Δ H₁ H₂ Z}
-    (h : ∀ D, f D = g D) : f = g :=
+lemma ext {Δ : Submonoid G} {H₁ H₂ : Subgroup G} {Z : Type*} [Zero Z]
+    {f g : HeckeCosetModule Δ H₁ H₂ Z} (h : ∀ D, f D = g D) : f = g :=
   Finsupp.ext h
 
 end HeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -12,20 +12,40 @@ public import Mathlib.GroupTheory.DoubleCoset
 /-!
 # Hecke rings: definitions
 
-The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following Shimura, *Introduction to the
-Arithmetic Theory of Automorphic Functions*, Chapter 3. This file sets up the underlying types: the
-Hecke pair, the double-coset quotient that indexes the ring, and the Hecke ring itself as formal
+The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following [Shimura][shimura1971], Chapter 3,
+and [Krieg][krieg1990], Chapter I. This file sets up the underlying types: the Hecke pair, the
+double-coset quotient that indexes the ring, and the Hecke ring itself as formal
 finitely-supported linear combinations of double cosets. The convolution product and the ring
 structure are developed in later files.
 
+The relevance of the submonoid `Δ` may not be immediately obvious; a natural example is
+`H = GL₂(ℤ)` inside `G = GL₂(ℚ)` with `Δ` the submonoid of integral matrices with nonzero
+determinant, which is the Hecke pair underlying the classical Hecke operators `T_n`.
+
 ## Main definitions
 
-* `HeckePair G`: an arithmetic pair, a subgroup `H` together with a submonoid `Δ` of `G`
+* `HeckePair G`: a Hecke pair, a subgroup `H` together with a submonoid `Δ` of `G`
   satisfying `H ≤ Δ ≤ commensurator H`.
 * `HeckeCoset P`: the quotient of `Δ` by the relation `HgH = HhH`, i.e. the double cosets
-  forming the basis of the Hecke ring.
+  `H\Δ/H` forming the basis of the Hecke ring.
 * `HeckeRing P Z`, notation `𝕋 P Z`: the Hecke ring with coefficients in `Z`, the
   finitely-supported `Z`-linear combinations of double cosets.
+
+## Implementation notes
+
+`HeckePair` is a bundled structure rather than an unbundled pair with an `IsHeckePair` Prop
+class: the types `HeckeCoset P` and `𝕋 P Z` depend on the pair, and types depending on instance
+arguments are brittle. Requiring `Δ` to be a submonoid rather than a subsemigroup loses no
+generality, since `H ≤ Δ` already forces `1 ∈ Δ`.
+
+The combinatorial layer behind the Hecke product (Shimura's multiplicity) is developed for
+mixed double cosets `Γ₁gΓ₂` of arbitrary subgroups in later files; only the ring structure
+itself is specific to a Hecke pair.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971]
+* [A. Krieg, *Hecke algebras*][krieg1990]
 -/
 
 @[expose] public section
@@ -34,7 +54,7 @@ open Subgroup.Commensurable
 
 variable {G : Type*} [Group G]
 
-/-- An arithmetic pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
+/-- A Hecke pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
 `H ≤ Δ ≤ commensurator H`. -/
 @[ext]
 structure HeckePair (G : Type*) [Group G] where
@@ -43,9 +63,9 @@ structure HeckePair (G : Type*) [Group G] where
   /-- The submonoid `Δ` of elements commensurating `H`. -/
   Δ : Submonoid G
   /-- The subgroup `H` is contained in `Δ`. -/
-  h₀ : H.toSubmonoid ≤ Δ
+  subgroup_le : H.toSubmonoid ≤ Δ
   /-- The submonoid `Δ` lies in the commensurator of `H`. -/
-  h₁ : Δ ≤ (commensurator H).toSubmonoid
+  le_commensurator : Δ ≤ (commensurator H).toSubmonoid
 
 /-- The setoid on `Δ` identifying elements with the same double coset `HgH = HhH`, pulled back
 from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
@@ -53,41 +73,50 @@ from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
 This is a `def` rather than a global instance to avoid a `Setoid` diamond on `↥Δ` (the left-coset
 setoid is another). Files that form `HeckeCoset`s opt in with `attribute [local instance]`; it is
 marked `@[reducible]` so that opt-in is warning-free. -/
-@[reducible] def doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
+@[reducible] def HeckePair.doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
   (DoubleCoset.setoid (P.H : Set G) P.H).comap Subtype.val
 
-/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the basis
-type for the Hecke ring. -/
-def HeckeCoset (P : HeckePair G) := Quotient (doubleCosetSetoid P)
+/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the
+basis type for the Hecke ring. -/
+def HeckeCoset (P : HeckePair G) := Quotient P.doubleCosetSetoid
 
-noncomputable instance (P : HeckePair G) : DecidableEq (HeckeCoset P) :=
-  Classical.decEq _
+namespace HeckeCoset
+
+variable (P : HeckePair G)
+
+/-- The identity double coset `H1H = H`. -/
+instance : One (HeckeCoset P) := ⟨Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩⟩
+
+instance : Inhabited (HeckeCoset P) := ⟨1⟩
+
+lemma one_def : (1 : HeckeCoset P) = Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩ := rfl
+
+end HeckeCoset
 
 /-- The Hecke ring with coefficients in `Z`, denoted `𝕋 P Z`: the finitely-supported `Z`-linear
 combinations of double cosets. The coefficients `Z` need only carry a `Zero` for the type to make
 sense; algebraic structure is added by the instances below at the weakest level each requires. -/
-def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := Finsupp (HeckeCoset P) Z
+def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := HeckeCoset P →₀ Z
 
 namespace HeckeRing
 
 @[inherit_doc]
 scoped notation "𝕋" => HeckeRing
 
+variable (P : HeckePair G) (Z : Type*)
+
 /-- Elements of `𝕋 P Z` are functions `HeckeCoset P → Z` (finitely supported). -/
-instance (P : HeckePair G) (Z : Type*) [Zero Z] :
-    FunLike (𝕋 P Z) (HeckeCoset P) Z :=
+instance [Zero Z] : FunLike (𝕋 P Z) (HeckeCoset P) Z :=
   inferInstanceAs (FunLike (HeckeCoset P →₀ Z) (HeckeCoset P) Z)
 
-/-- The additive commutative monoid structure on the Hecke ring, for any `AddCommMonoid` of
-coefficients. -/
-noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommMonoid Z] :
-    AddCommMonoid (𝕋 P Z) :=
-  inferInstanceAs (AddCommMonoid ((HeckeCoset P) →₀ Z))
+noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 P Z) :=
+  inferInstanceAs (AddCommMonoid (HeckeCoset P →₀ Z))
 
-/-- The additive commutative group structure on the Hecke ring, when the coefficients form an
-`AddCommGroup`. -/
-noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommGroup Z] :
-    AddCommGroup (𝕋 P Z) :=
-  inferInstanceAs (AddCommGroup ((HeckeCoset P) →₀ Z))
+noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 P Z) :=
+  inferInstanceAs (AddCommGroup (HeckeCoset P →₀ Z))
+
+@[ext]
+lemma ext {P : HeckePair G} {Z : Type*} [Zero Z] {f g : 𝕋 P Z} (h : ∀ D, f D = g D) : f = g :=
+  Finsupp.ext h
 
 end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -59,6 +59,7 @@ subsemigroup loses no generality, since `H₁ ≤ Δ` already forces `1 ∈ Δ`.
 @[expose] public section
 
 open Subgroup Subgroup.Commensurable
+open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
@@ -101,6 +102,32 @@ theorem le_commensurator_left [IsHeckeCosetModule Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
   rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
   exact le_commensurator H₁
+
+/-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
+explicit, since it cannot be inferred. -/
+theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    (g : G) ∈ commensurator H₂ :=
+  le_commensurator H₁ g.2
+
+/-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
+explicit, since it cannot be inferred. -/
+theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    (g : G) ∈ commensurator H₁ :=
+  le_commensurator_left (H₂ := H₂) g.2
+
+/-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
+the left one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₁ H₂`. -/
+theorem commensurable_conjAct_right [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
+  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
+  exact hg.trans (commensurable (Δ := Δ)).symm
+
+/-- Conjugating the left subgroup by an element of `Δ` gives a subgroup commensurable with
+the right one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₂ H₁`. -/
+theorem commensurable_conjAct_left [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+    Commensurable (ConjAct.toConjAct (g : G) • H₁) H₂ := by
+  have hg : Commensurable (ConjAct.toConjAct (g : G) • H₁) H₁ := mem_commensurator_left H₂ g
+  exact hg.trans (commensurable (Δ := Δ))
 
 /-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
 theorem symm [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₁ :=

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -12,35 +12,43 @@ public import Mathlib.GroupTheory.DoubleCoset
 /-!
 # Hecke rings: definitions
 
-The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following [Shimura][shimura1971], Chapter 3,
-and [Krieg][krieg1990], Chapter I. This file sets up the underlying types: the Hecke pair, the
-double-coset quotient that indexes the ring, and the Hecke ring itself as formal
-finitely-supported linear combinations of double cosets. The convolution product and the ring
-structure are developed in later files.
+The abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the Hecke coset modules
+attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971], Chapter 3, and
+[Krieg][krieg1990], Chapter I. This file sets up the underlying types: the compatibility
+conditions `IsHeckeCosetModule Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
+double-coset quotient `HeckeCoset Δ H₁ H₂` of `Δ` by `H₁gH₂ = H₁hH₂`, and the Hecke coset module
+`𝕋 Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets. The convolution
+product `𝕋 Δ H₁ H₂ Z × 𝕋 Δ H₂ H₃ Z → 𝕋 Δ H₁ H₃ Z` and the ring structure on the diagonal
+`𝕋 Δ H H Z` are developed in later files.
 
 The relevance of the submonoid `Δ` may not be immediately obvious; a natural example is
 `H = GL₂(ℤ)` inside `G = GL₂(ℚ)` with `Δ` the submonoid of integral matrices with nonzero
-determinant, which is the Hecke pair underlying the classical Hecke operators `T_n`.
+determinant, which is the Hecke pair underlying the classical Hecke operators `T_n`. Mixed
+subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.g. `H₁ = Γ₀(N)` and
+`H₂ = Γ₀(M)` inside the same `Δ`.
 
 ## Main definitions
 
-* `HeckePair G`: a Hecke pair, a subgroup `H` together with a submonoid `Δ` of `G`
-  satisfying `H ≤ Δ ≤ commensurator H`.
-* `HeckeCoset P`: the quotient of `Δ` by the relation `HgH = HhH`, i.e. the double cosets
-  `H\Δ/H` forming the basis of the Hecke ring.
-* `HeckeRing P Z`, notation `𝕋 P Z`: the Hecke ring with coefficients in `Z`, the
-  finitely-supported `Z`-linear combinations of double cosets.
+* `IsHeckeCosetModule Δ H₁ H₂`: the compatibility conditions `H₁ ≤ Δ`, `H₂ ≤ Δ`,
+  `Commensurable H₁ H₂` and `Δ ≤ commensurator H₂` making the double cosets `H₁\Δ/H₂` finite
+  unions of left cosets. The classical Hecke pair `(H, Δ)` is the diagonal case
+  `IsHeckeCosetModule Δ H H`.
+* `HeckeCoset Δ H₁ H₂`: the quotient of `Δ` by the relation `H₁gH₂ = H₁hH₂`, i.e. the double
+  cosets `H₁\Δ/H₂` forming the basis of the Hecke coset module.
+* `HeckeCosetModule Δ H₁ H₂ Z`, notation `𝕋 Δ H₁ H₂ Z`: the Hecke coset module with
+  coefficients in `Z`, the finitely-supported `Z`-linear combinations of double cosets. For
+  `H₁ = H₂` this is the underlying module of the Hecke ring.
 
 ## Implementation notes
 
-`HeckePair` is a bundled structure rather than an unbundled pair with an `IsHeckePair` Prop
-class: the types `HeckeCoset P` and `𝕋 P Z` depend on the pair, and types depending on instance
-arguments are brittle. Requiring `Δ` to be a submonoid rather than a subsemigroup loses no
-generality, since `H ≤ Δ` already forces `1 ∈ Δ`.
-
-The combinatorial layer behind the Hecke product (Shimura's multiplicity) is developed for
-mixed double cosets `Γ₁gΓ₂` of arbitrary subgroups in later files; only the ring structure
-itself is specific to a Hecke pair.
+The data `(Δ, H₁, H₂)` enters unbundled, with the compatibility conditions collected in the
+Prop-valued class `IsHeckeCosetModule`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
+built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all levels
+(as in [Shimura][shimura1971]) means products of double cosets over different subgroups,
+`H₁g₁H₂ * H₂g₂H₃ ⊆ Δ`, need no compatibility hypotheses. The conditions are only needed for the
+finiteness of the coset decompositions, which enters through the `Fintype` instance on
+`DoubleCoset.DecompQuotient` in later files. Requiring `Δ` to be a submonoid rather than a
+subsemigroup loses no generality, since `H₁ ≤ Δ` already forces `1 ∈ Δ`.
 
 ## References
 
@@ -50,73 +58,135 @@ itself is specific to a Hecke pair.
 
 @[expose] public section
 
-open Subgroup.Commensurable
+open Subgroup Subgroup.Commensurable
 
 variable {G : Type*} [Group G]
 
-/-- A Hecke pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
-`H ≤ Δ ≤ commensurator H`. -/
-@[ext]
-structure HeckePair (G : Type*) [Group G] where
-  /-- The subgroup `H` of the pair. -/
-  H : Subgroup G
-  /-- The submonoid `Δ` of elements commensurating `H`. -/
-  Δ : Submonoid G
-  /-- The subgroup `H` is contained in `Δ`. -/
-  subgroup_le : H.toSubmonoid ≤ Δ
-  /-- The submonoid `Δ` lies in the commensurator of `H`. -/
-  le_commensurator : Δ ≤ (commensurator H).toSubmonoid
+/-- The compatibility conditions on a submonoid `Δ` and a pair of subgroups `H₁, H₂` of `G`
+making the double cosets `H₁\Δ/H₂` finite unions of left cosets: both subgroups are contained
+in `Δ`, they are commensurable, and `Δ` commensurates them. The classical Hecke pair `(H, Δ)`
+of [Shimura][shimura1971], Chapter 3, is the diagonal case `IsHeckeCosetModule Δ H H`. -/
+class IsHeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
+  /-- The left subgroup is contained in `Δ`. -/
+  left_le : H₁.toSubmonoid ≤ Δ
+  /-- The right subgroup is contained in `Δ`. -/
+  right_le : H₂.toSubmonoid ≤ Δ
+  /-- The two subgroups are commensurable. -/
+  commensurable : Commensurable H₁ H₂
+  /-- The submonoid `Δ` lies in the commensurator of the right subgroup (hence, the subgroups
+  being commensurable, also in that of the left one; see `le_commensurator_left`). -/
+  le_commensurator : Δ ≤ (commensurator H₂).toSubmonoid
 
-/-- The setoid on `Δ` identifying elements with the same double coset `HgH = HhH`, pulled back
-from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
+namespace IsHeckeCosetModule
 
-This is a `def` rather than a global instance to avoid a `Setoid` diamond on `↥Δ` (the left-coset
-setoid is another). Files that form `HeckeCoset`s opt in with `attribute [local instance]`; it is
-marked `@[reducible]` so that opt-in is warning-free. -/
-@[reducible] def HeckePair.doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
-  (DoubleCoset.setoid (P.H : Set G) P.H).comap Subtype.val
+variable {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 
-/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the
-basis type for the Hecke ring. -/
-def HeckeCoset (P : HeckePair G) := Quotient P.doubleCosetSetoid
+/-- A Hecke pair `(H, Δ)` with `H ≤ Δ ≤ commensurator H` is the diagonal case. -/
+theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
+    (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeCosetModule Δ H H :=
+  ⟨h, h, .refl H, hc⟩
+
+/-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
+be inferred. -/
+theorem mem_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
+  left_le (H₂ := H₂) hx
+
+/-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
+be inferred. -/
+theorem mem_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
+  right_le (H₁ := H₁) hx
+
+/-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
+theorem le_commensurator_left [IsHeckeCosetModule Δ H₁ H₂] :
+    Δ ≤ (commensurator H₁).toSubmonoid := by
+  rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
+  exact le_commensurator H₁
+
+/-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
+theorem symm [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₁ :=
+  ⟨right_le (H₁ := H₁), left_le (H₂ := H₂), (commensurable (Δ := Δ)).symm,
+    le_commensurator_left (H₂ := H₂)⟩
+
+/-- Hecke coset module data compose. Not an instance, since the middle subgroup cannot be
+inferred from the goal. -/
+theorem trans [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃] :
+    IsHeckeCosetModule Δ H₁ H₃ :=
+  ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
+    (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
+      (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
+    le_commensurator (H₁ := H₂)⟩
+
+/-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
+theorem diag_left [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₁ H₁ :=
+  ⟨left_le (H₂ := H₂), left_le (H₂ := H₂), .refl H₁, le_commensurator_left (H₂ := H₂)⟩
+
+/-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
+theorem diag_right [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₂ :=
+  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator (H₁ := H₁)⟩
+
+end IsHeckeCosetModule
+
+/-- The setoid on `Δ` identifying elements with the same double coset `H₁gH₂ = H₁hH₂`, pulled
+back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
+
+This is a `def` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred from
+the type `↥Δ`, so this cannot participate in instance search (and a global instance would also
+create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
+`HeckeCoset.mk`. -/
+@[reducible] def HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
+  (DoubleCoset.setoid (H₁ : Set G) H₂).comap Subtype.val
+
+/-- A Hecke double coset: an equivalence class of `Δ`-elements under `H₁gH₂ = H₁hH₂`. This is
+the basis type for the Hecke coset module. -/
+def HeckeCoset (Δ : Submonoid G) (H₁ H₂ : Subgroup G) := Quotient (HeckeCoset.setoid Δ H₁ H₂)
 
 namespace HeckeCoset
 
-variable (P : HeckePair G)
+variable {Δ : Submonoid G}
 
-/-- The identity double coset `H1H = H`. -/
-instance : One (HeckeCoset P) := ⟨Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩⟩
+/-- The double coset `H₁gH₂` of an element `g : Δ`. -/
+def mk (H₁ H₂ : Subgroup G) (g : Δ) : HeckeCoset Δ H₁ H₂ :=
+  Quotient.mk (setoid Δ H₁ H₂) g
 
-instance : Inhabited (HeckeCoset P) := ⟨1⟩
+variable (Δ) in
+instance (H₁ H₂ : Subgroup G) : Inhabited (HeckeCoset Δ H₁ H₂) := ⟨mk H₁ H₂ ⟨1, Δ.one_mem⟩⟩
 
-lemma one_def : (1 : HeckeCoset P) = Quotient.mk P.doubleCosetSetoid ⟨1, P.Δ.one_mem⟩ := rfl
+variable (Δ) in
+/-- The identity double coset `H1H = H` of the diagonal (Hecke pair) case. -/
+instance (H : Subgroup G) : One (HeckeCoset Δ H H) := ⟨mk H H ⟨1, Δ.one_mem⟩⟩
+
+lemma one_def (H : Subgroup G) : (1 : HeckeCoset Δ H H) = mk H H ⟨1, Δ.one_mem⟩ := rfl
 
 end HeckeCoset
 
-/-- The Hecke ring with coefficients in `Z`, denoted `𝕋 P Z`: the finitely-supported `Z`-linear
-combinations of double cosets. The coefficients `Z` need only carry a `Zero` for the type to make
-sense; algebraic structure is added by the instances below at the weakest level each requires. -/
-def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := HeckeCoset P →₀ Z
+/-- The Hecke coset module with coefficients in `Z`, denoted `𝕋 Δ H₁ H₂ Z`: the
+finitely-supported `Z`-linear combinations of double cosets `H₁\Δ/H₂`. For `H₁ = H₂` this is the
+underlying module of the Hecke ring. The coefficients `Z` need only carry a `Zero` for the type
+to make sense; algebraic structure is added by the instances below at the weakest level each
+requires. -/
+def HeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*) [Zero Z] :=
+  HeckeCoset Δ H₁ H₂ →₀ Z
 
-namespace HeckeRing
+namespace HeckeCosetModule
 
 @[inherit_doc]
-scoped notation "𝕋" => HeckeRing
+scoped notation "𝕋" => HeckeCosetModule
 
-variable (P : HeckePair G) (Z : Type*)
+variable (Δ : Submonoid G) (H₁ H₂ : Subgroup G) (Z : Type*)
 
-/-- Elements of `𝕋 P Z` are functions `HeckeCoset P → Z` (finitely supported). -/
-instance [Zero Z] : FunLike (𝕋 P Z) (HeckeCoset P) Z :=
-  inferInstanceAs (FunLike (HeckeCoset P →₀ Z) (HeckeCoset P) Z)
+/-- Elements of `𝕋 Δ H₁ H₂ Z` are functions `HeckeCoset Δ H₁ H₂ → Z` (finitely supported). -/
+instance [Zero Z] : FunLike (𝕋 Δ H₁ H₂ Z) (HeckeCoset Δ H₁ H₂) Z :=
+  inferInstanceAs (FunLike (HeckeCoset Δ H₁ H₂ →₀ Z) (HeckeCoset Δ H₁ H₂) Z)
 
-noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 P Z) :=
-  inferInstanceAs (AddCommMonoid (HeckeCoset P →₀ Z))
+noncomputable instance [AddCommMonoid Z] : AddCommMonoid (𝕋 Δ H₁ H₂ Z) :=
+  inferInstanceAs (AddCommMonoid (HeckeCoset Δ H₁ H₂ →₀ Z))
 
-noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 P Z) :=
-  inferInstanceAs (AddCommGroup (HeckeCoset P →₀ Z))
+noncomputable instance [AddCommGroup Z] : AddCommGroup (𝕋 Δ H₁ H₂ Z) :=
+  inferInstanceAs (AddCommGroup (HeckeCoset Δ H₁ H₂ →₀ Z))
 
 @[ext]
-lemma ext {P : HeckePair G} {Z : Type*} [Zero Z] {f g : 𝕋 P Z} (h : ∀ D, f D = g D) : f = g :=
+lemma ext {Δ : Submonoid G} {H₁ H₂ : Subgroup G} {Z : Type*} [Zero Z] {f g : 𝕋 Δ H₁ H₂ Z}
+    (h : ∀ D, f D = g D) : f = g :=
   Finsupp.ext h
 
-end HeckeRing
+end HeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -15,7 +15,7 @@ public import Mathlib.GroupTheory.DoubleCoset
 The abstract Hecke ring of a *Hecke pair* `(H, Δ)` and, more generally, the Hecke coset modules
 attached to a triple `(H₁, Δ, H₂)`, following [Shimura][shimura1971], Chapter 3, and
 [Krieg][krieg1990], Chapter I. This file sets up the underlying types: the compatibility
-conditions `IsHeckeCosetModule Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
+conditions `IsHeckeTriple Δ H₁ H₂` on a submonoid `Δ` and a pair of subgroups, the
 double-coset quotient `HeckeCoset Δ H₁ H₂` of `Δ` by `H₁gH₂ = H₁hH₂`, and the Hecke coset module
 `𝕋 Δ H₁ H₂ Z` of formal finitely-supported linear combinations of double cosets. The convolution
 product `𝕋 Δ H₁ H₂ Z × 𝕋 Δ H₂ H₃ Z → 𝕋 Δ H₁ H₃ Z` and the ring structure on the diagonal
@@ -29,10 +29,10 @@ subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.
 
 ## Main definitions
 
-* `IsHeckeCosetModule Δ H₁ H₂`: the compatibility conditions `H₁ ≤ Δ`, `H₂ ≤ Δ`,
-  `Commensurable H₁ H₂` and `Δ ≤ commensurator H₂` making the double cosets `H₁\Δ/H₂` finite
+* `IsHeckeTriple Δ H₁ H₂`: `(H₁, Δ, H₂)` is a Hecke triple, i.e. `H₁ ≤ Δ`, `H₂ ≤ Δ`,
+  `Commensurable H₁ H₂` and `Δ ≤ commensurator H₂`, making the double cosets `H₁\Δ/H₂` finite
   unions of left cosets. The classical Hecke pair `(H, Δ)` is the diagonal case
-  `IsHeckeCosetModule Δ H H`.
+  `IsHeckeTriple Δ H H`.
 * `HeckeCoset Δ H₁ H₂`: the quotient of `Δ` by the relation `H₁gH₂ = H₁hH₂`, i.e. the double
   cosets `H₁\Δ/H₂` forming the basis of the Hecke coset module.
 * `HeckeCosetModule Δ H₁ H₂ Z`, notation `𝕋 Δ H₁ H₂ Z`: the Hecke coset module with
@@ -42,7 +42,7 @@ subgroups `H₁ ≠ H₂` arise for Hecke operators between different levels, e.
 ## Implementation notes
 
 The data `(Δ, H₁, H₂)` enters unbundled, with the compatibility conditions collected in the
-Prop-valued class `IsHeckeCosetModule`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
+Prop-valued class `IsHeckeTriple`: the types `HeckeCoset Δ H₁ H₂` and `𝕋 Δ H₁ H₂ Z` are
 built from the data alone and depend on no proofs, and a single ambient `Δ` shared by all levels
 (as in [Shimura][shimura1971]) means products of double cosets over different subgroups,
 `H₁g₁H₂ * H₂g₂H₃ ⊆ Δ`, need no compatibility hypotheses. The conditions are only needed for the
@@ -63,11 +63,12 @@ open scoped Pointwise
 
 variable {G : Type*} [Group G]
 
-/-- The compatibility conditions on a submonoid `Δ` and a pair of subgroups `H₁, H₂` of `G`
-making the double cosets `H₁\Δ/H₂` finite unions of left cosets: both subgroups are contained
-in `Δ`, they are commensurable, and `Δ` commensurates them. The classical Hecke pair `(H, Δ)`
-of [Shimura][shimura1971], Chapter 3, is the diagonal case `IsHeckeCosetModule Δ H H`. -/
-class IsHeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
+/-- A *Hecke triple* `(H₁, Δ, H₂)`: the compatibility conditions on a submonoid `Δ` and a pair
+of subgroups `H₁, H₂` of `G` making the double cosets `H₁\Δ/H₂` finite unions of left cosets:
+both subgroups are contained in `Δ`, they are commensurable, and `Δ` commensurates them. The
+classical Hecke pair `(H, Δ)` of [Shimura][shimura1971], Chapter 3, is the diagonal case
+`IsHeckeTriple Δ H H`. -/
+class IsHeckeTriple (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop where
   /-- The left subgroup is contained in `Δ`. -/
   left_le : H₁.toSubmonoid ≤ Δ
   /-- The right subgroup is contained in `Δ`. -/
@@ -78,80 +79,80 @@ class IsHeckeCosetModule (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Prop wher
   being commensurable, also in that of the left one; see `le_commensurator_left`). -/
   le_commensurator : Δ ≤ (commensurator H₂).toSubmonoid
 
-namespace IsHeckeCosetModule
+namespace IsHeckeTriple
 
 variable {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 
 /-- A Hecke pair `(H, Δ)` with `H ≤ Δ ≤ commensurator H` is the diagonal case. -/
 theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
-    (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeCosetModule Δ H H :=
+    (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeTriple Δ H H :=
   ⟨h, h, .refl H, hc⟩
 
 /-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
+theorem mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
   left_le (H₂ := H₂) hx
 
 /-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
 be inferred. -/
-theorem mem_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
+theorem mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
   right_le (H₁ := H₁) hx
 
 /-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
-theorem le_commensurator_left [IsHeckeCosetModule Δ H₁ H₂] :
+theorem le_commensurator_left [IsHeckeTriple Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
   rw [Subgroup.Commensurable.eq (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂))]
   exact le_commensurator H₁
 
 /-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
 explicit, since it cannot be inferred. -/
-theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₂ :=
   le_commensurator H₁ g.2
 
 /-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
 explicit, since it cannot be inferred. -/
-theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₁ :=
   le_commensurator_left (H₂ := H₂) g.2
 
 /-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
 the left one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₁ H₂`. -/
-theorem commensurable_conjAct_right [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
   exact hg.trans (commensurable (Δ := Δ)).symm
 
 /-- Conjugating the left subgroup by an element of `Δ` gives a subgroup commensurable with
 the right one; this is the finiteness underlying `DoubleCoset.DecompQuotient H₂ H₁`. -/
-theorem commensurable_conjAct_left [IsHeckeCosetModule Δ H₁ H₂] (g : Δ) :
+theorem commensurable_conjAct_left [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₁) H₂ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₁) H₁ := mem_commensurator_left H₂ g
   exact hg.trans (commensurable (Δ := Δ))
 
 /-- The reversed datum `(H₂, Δ, H₁)`. Not an instance, since instance search would loop. -/
-theorem symm [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₁ :=
+theorem symm [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₁ :=
   ⟨right_le (H₁ := H₁), left_le (H₂ := H₂), (commensurable (Δ := Δ)).symm,
     le_commensurator_left (H₂ := H₂)⟩
 
 /-- Hecke coset module data compose. Not an instance, since the middle subgroup cannot be
 inferred from the goal. -/
-theorem trans [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃] :
-    IsHeckeCosetModule Δ H₁ H₃ :=
+theorem trans [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] :
+    IsHeckeTriple Δ H₁ H₃ :=
   ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
     (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
       (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
     le_commensurator (H₁ := H₂)⟩
 
 /-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
-theorem diag_left [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₁ H₁ :=
+theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
   ⟨left_le (H₂ := H₂), left_le (H₂ := H₂), .refl H₁, le_commensurator_left (H₂ := H₂)⟩
 
 /-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
-theorem diag_right [IsHeckeCosetModule Δ H₁ H₂] : IsHeckeCosetModule Δ H₂ H₂ :=
+theorem diag_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
   ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator (H₁ := H₁)⟩
 
-end IsHeckeCosetModule
+end IsHeckeTriple
 
 /-- The setoid on `Δ` identifying elements with the same double coset `H₁gH₂ = H₁hH₂`, pulled
 back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
@@ -91,37 +91,32 @@ theorem of_diagonal {H : Subgroup G} (h : H.toSubmonoid ≤ Δ)
     (hc : Δ ≤ (commensurator H).toSubmonoid) : IsHeckeTriple Δ H H :=
   ⟨h, h, .refl H, hc⟩
 
-/-- Elements of the left subgroup lie in `Δ`. The right subgroup is explicit, since it cannot
-be inferred. -/
+/-- Elements of the left subgroup lie in `Δ`. -/
 theorem mem_of_mem_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₁) : x ∈ Δ :=
-  left_le (H₂ := H₂) hx
+  left_le H₂ hx
 
-/-- Elements of the right subgroup lie in `Δ`. The left subgroup is explicit, since it cannot
-be inferred. -/
+/-- Elements of the right subgroup lie in `Δ`. -/
 theorem mem_of_mem_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] {x : G} (hx : x ∈ H₂) : x ∈ Δ :=
-  right_le (H₁ := H₁) hx
+  right_le H₁ hx
 
 /-- The submonoid `Δ` also lies in the commensurator of the left subgroup. -/
-theorem le_commensurator_left [h : IsHeckeTriple Δ H₁ H₂] :
+theorem le_commensurator_left (H₂ : Subgroup G) [h : IsHeckeTriple Δ H₁ H₂] :
     Δ ≤ (commensurator H₁).toSubmonoid := by
   rw [h.commensurable.eq]
   exact h.le_commensurator_right
 
-/-- Elements of `Δ` lie in the commensurator of the right subgroup. The left subgroup is
-explicit, since it cannot be inferred. -/
+/-- Elements of `Δ` lie in the commensurator of the right subgroup. -/
 theorem mem_commensurator_right (H₁ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₂ :=
   le_commensurator_right H₁ g.2
 
-/-- Elements of `Δ` lie in the commensurator of the left subgroup. The right subgroup is
-explicit, since it cannot be inferred. -/
+/-- Elements of `Δ` lie in the commensurator of the left subgroup. -/
 theorem mem_commensurator_left (H₂ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     (g : G) ∈ commensurator H₁ :=
-  le_commensurator_left (H₂ := H₂) g.2
+  le_commensurator_left H₂ g.2
 
 /-- Conjugating the right subgroup by an element of `Δ` gives a subgroup commensurable with
-the left one; the intersection `H₁ ∩ gH₂g⁻¹` this bounds is the one underlying
-`DoubleCoset.DecompQuotient H₁ H₂ g`. -/
+the left one. -/
 theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
     Commensurable (ConjAct.toConjAct (g : G) • H₂) H₁ := by
   have hg : Commensurable (ConjAct.toConjAct (g : G) • H₂) H₂ := mem_commensurator_right H₁ g
@@ -131,29 +126,29 @@ theorem commensurable_conjAct_right [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
 inferred from the goal. -/
 theorem trans [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] :
     IsHeckeTriple Δ H₁ H₃ :=
-  ⟨left_le (H₂ := H₂), right_le (H₁ := H₂),
+  ⟨left_le H₂, right_le H₂,
     (commensurable (Δ := Δ) (H₁ := H₁) (H₂ := H₂)).trans
       (commensurable (Δ := Δ) (H₁ := H₂) (H₂ := H₃)),
-    le_commensurator_right (H₁ := H₂)⟩
+    le_commensurator_right H₂⟩
 
 /-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
 theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
-  ⟨left_le (H₂ := H₂), left_le (H₂ := H₂), .refl H₁, le_commensurator_left (H₂ := H₂)⟩
+  ⟨left_le H₂, left_le H₂, .refl H₁, le_commensurator_left H₂⟩
 
 /-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
 theorem diag_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
-  ⟨right_le (H₁ := H₁), right_le (H₁ := H₁), .refl H₂, le_commensurator_right (H₁ := H₁)⟩
+  ⟨right_le H₁, right_le H₁, .refl H₂, le_commensurator_right H₁⟩
 
 end IsHeckeTriple
 
 /-- The setoid on `Δ` identifying elements with the same double coset `H₁gH₂ = H₁hH₂`, pulled
 back from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
 
-This is a `def` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred from
-the submonoid `Δ`, so this cannot participate in instance search (and a global instance would
-also create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
+This is an `abbrev` rather than a global instance: the subgroups `H₁, H₂` cannot be inferred
+from the submonoid `Δ`, so this cannot participate in instance search (and a global instance
+would also create a `Setoid` diamond on `↥Δ` with the left-coset setoid). The quotient map is
 `HeckeCoset.mk`. -/
-@[reducible] def HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
+abbrev HeckeCoset.setoid (Δ : Submonoid G) (H₁ H₂ : Subgroup G) : Setoid Δ :=
   (DoubleCoset.setoid (H₁ : Set G) H₂).comap Subtype.val
 
 /-- A Hecke double coset: an equivalence class of `Δ`-elements under `H₁gH₂ = H₁hH₂`. This is

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Algebra.Group.Finsupp
+public import Mathlib.GroupTheory.Commensurable
+public import Mathlib.GroupTheory.DoubleCoset
+
+/-!
+# Hecke rings: definitions
+
+The abstract Hecke ring of a *Hecke pair* `(H, Δ)`, following Shimura, *Introduction to the
+Arithmetic Theory of Automorphic Functions*, Chapter 3. This file sets up the underlying types: the
+Hecke pair, the double-coset quotient that indexes the ring, and the Hecke ring itself as formal
+finitely-supported linear combinations of double cosets. The convolution product and the ring
+structure are developed in later files.
+
+## Main definitions
+
+* `HeckePair G`: an arithmetic pair, a subgroup `H` together with a submonoid `Δ` of `G`
+  satisfying `H ≤ Δ ≤ commensurator H`.
+* `HeckeCoset P`: the quotient of `Δ` by the relation `HgH = HhH`, i.e. the double cosets
+  forming the basis of the Hecke ring.
+* `HeckeRing P Z`, notation `𝕋 P Z`: the Hecke ring with coefficients in `Z`, the
+  finitely-supported `Z`-linear combinations of double cosets.
+-/
+
+@[expose] public section
+
+open Subgroup.Commensurable
+
+variable {G : Type*} [Group G]
+
+/-- An arithmetic pair `(H, Δ)`: a subgroup `H` and a submonoid `Δ` of a group `G` satisfying
+`H ≤ Δ ≤ commensurator H`. -/
+@[ext]
+structure HeckePair (G : Type*) [Group G] where
+  /-- The subgroup `H` of the pair. -/
+  H : Subgroup G
+  /-- The submonoid `Δ` of elements commensurating `H`. -/
+  Δ : Submonoid G
+  /-- The subgroup `H` is contained in `Δ`. -/
+  h₀ : H.toSubmonoid ≤ Δ
+  /-- The submonoid `Δ` lies in the commensurator of `H`. -/
+  h₁ : Δ ≤ (commensurator H).toSubmonoid
+
+/-- The setoid on `Δ` identifying elements with the same double coset `HgH = HhH`, pulled back
+from `DoubleCoset.setoid` along the inclusion `Δ ↪ G`.
+
+This is a `def` rather than a global instance to avoid a `Setoid` diamond on `↥Δ` (the left-coset
+setoid is another). Files that form `HeckeCoset`s opt in with `attribute [local instance]`; it is
+marked `@[reducible]` so that opt-in is warning-free. -/
+@[reducible] def doubleCosetSetoid (P : HeckePair G) : Setoid P.Δ :=
+  (DoubleCoset.setoid (P.H : Set G) P.H).comap Subtype.val
+
+/-- A Hecke double coset: an equivalence class of `Δ`-elements under `HgH = HhH`. This is the basis
+type for the Hecke ring. -/
+def HeckeCoset (P : HeckePair G) := Quotient (doubleCosetSetoid P)
+
+noncomputable instance (P : HeckePair G) : DecidableEq (HeckeCoset P) :=
+  Classical.decEq _
+
+/-- The Hecke ring with coefficients in `Z`, denoted `𝕋 P Z`: the finitely-supported `Z`-linear
+combinations of double cosets. The coefficients `Z` need only carry a `Zero` for the type to make
+sense; algebraic structure is added by the instances below at the weakest level each requires. -/
+def HeckeRing (P : HeckePair G) (Z : Type*) [Zero Z] := Finsupp (HeckeCoset P) Z
+
+namespace HeckeRing
+
+@[inherit_doc]
+scoped notation "𝕋" => HeckeRing
+
+/-- Elements of `𝕋 P Z` are functions `HeckeCoset P → Z` (finitely supported). -/
+instance (P : HeckePair G) (Z : Type*) [Zero Z] :
+    FunLike (𝕋 P Z) (HeckeCoset P) Z :=
+  inferInstanceAs (FunLike (HeckeCoset P →₀ Z) (HeckeCoset P) Z)
+
+/-- The additive commutative monoid structure on the Hecke ring, for any `AddCommMonoid` of
+coefficients. -/
+noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommMonoid Z] :
+    AddCommMonoid (𝕋 P Z) :=
+  inferInstanceAs (AddCommMonoid ((HeckeCoset P) →₀ Z))
+
+/-- The additive commutative group structure on the Hecke ring, when the coefficients form an
+`AddCommGroup`. -/
+noncomputable instance (P : HeckePair G) (Z : Type*) [AddCommGroup Z] :
+    AddCommGroup (𝕋 P Z) :=
+  inferInstanceAs (AddCommGroup ((HeckeCoset P) →₀ Z))
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Multiplication.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplication.lean
@@ -44,14 +44,14 @@ open Classical in
 /-- The structure constants of the Hecke product: `structureConstants H₁ H₂ H₃ R g₁ g₂` is the
 formal sum `∑_D m(g₁, g₂; D) [D]` over mixed double cosets, with Shimura's multiplicities cast
 into `R`. -/
-noncomputable def structureConstants (H₁ H₂ H₃ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂]
-    [IsHeckeCosetModule Δ H₂ H₃] (g₁ g₂ : Δ) : 𝕋 Δ H₁ H₃ R :=
+noncomputable def structureConstants (H₁ H₂ H₃ : Subgroup G) [IsHeckeTriple Δ H₁ H₂]
+    [IsHeckeTriple Δ H₂ H₃] (g₁ g₂ : Δ) : 𝕋 Δ H₁ H₃ R :=
   Finsupp.onFinset (Finset.univ.image (HeckeCoset.mulMap H₁ H₂ H₃ g₁ g₂))
     (fun D ↦ (multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (D.rep : G) : R))
     (fun D hD ↦ (HeckeCoset.mem_image_mulMap_iff g₁ g₂ D).mpr
       fun h0 ↦ hD (by rw [h0, Nat.cast_zero]))
 
-@[simp] lemma structureConstants_apply [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+@[simp] lemma structureConstants_apply [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (g₁ g₂ : Δ) (D : HeckeCoset Δ H₁ H₃) :
     structureConstants R H₁ H₂ H₃ g₁ g₂ D =
       (multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (D.rep : G) : R) := rfl
@@ -61,21 +61,21 @@ noncomputable instance : Module R (𝕋 Δ H₁ H₂ R) :=
 
 /-- The convolution product of Hecke coset modules, defined via the structure constants. The
 diagonal case is the multiplication of the Hecke ring; see the `Mul (𝕋 Δ H H R)` instance. -/
-noncomputable def mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+noncomputable def mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) : 𝕋 Δ H₁ H₃ R :=
   f.sum fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep
 
-lemma mul_eq_sum [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+lemma mul_eq_sum [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) : mul R f g =
       f.sum fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep :=
   rfl
 
 /-- The multiplication of the Hecke ring: the diagonal case of the convolution product
 `HeckeCosetModule.mul`. -/
-noncomputable instance {H : Subgroup G} [IsHeckeCosetModule Δ H H] : Mul (𝕋 Δ H H R) where
+noncomputable instance {H : Subgroup G} [IsHeckeTriple Δ H H] : Mul (𝕋 Δ H H R) where
   mul f g := mul R f g
 
-lemma mul_def {H : Subgroup G} [IsHeckeCosetModule Δ H H] (f g : 𝕋 Δ H H R) :
+lemma mul_def {H : Subgroup G} [IsHeckeTriple Δ H H] (f g : 𝕋 Δ H H R) :
     f * g = mul R f g := rfl
 
 /-- A basis element of the Hecke coset module: `single R D b` is the formal sum `b • [D]`. As
@@ -92,7 +92,7 @@ lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1
 lemma sum_single (f : 𝕋 Δ H₁ H₂ R) : f.sum (single R) = f := Finsupp.sum_single f
 
 /-- The convolution product of two basis elements. -/
-lemma mul_single_single [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+lemma mul_single_single [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (D₁ : HeckeCoset Δ H₁ H₂) (D₂ : HeckeCoset Δ H₂ H₃) (a b : R) :
     mul R (single R D₁ a) (single R D₂ b) =
       a • b • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep := by
@@ -100,13 +100,13 @@ lemma mul_single_single [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ
   simp [single, Finsupp.sum_single_index]
 
 /-- The product of two basis elements of the Hecke ring. -/
-lemma single_mul_single {H : Subgroup G} [IsHeckeCosetModule Δ H H]
+lemma single_mul_single {H : Subgroup G} [IsHeckeTriple Δ H H]
     (D₁ D₂ : HeckeCoset Δ H H) (a b : R) :
     single R D₁ a * single R D₂ b = a • b • structureConstants R H H H D₁.rep D₂.rep :=
   mul_single_single R D₁ D₂ a b
 
 /-- The convolution product distributes over addition on the right. -/
-lemma mul_add [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+lemma mul_add [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (f : 𝕋 Δ H₁ H₂ R) (g h : 𝕋 Δ H₂ H₃ R) : mul R f (g + h) = mul R f g + mul R f h := by
   classical
   simp only [mul_eq_sum]
@@ -115,7 +115,7 @@ lemma mul_add [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃
     (fun _ _ b b' ↦ by rw [add_smul, smul_add])
 
 /-- The convolution product distributes over addition on the left. -/
-lemma add_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+lemma add_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (f g : 𝕋 Δ H₁ H₂ R) (h : 𝕋 Δ H₂ H₃ R) : mul R (f + g) h = mul R f h + mul R g h := by
   classical
   simp only [mul_eq_sum]
@@ -124,20 +124,20 @@ lemma add_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃
     exact Finsupp.sum_congr fun D₂ _ ↦ by rw [add_smul]
 
 /-- The convolution product vanishes on the left zero. -/
-lemma zero_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+lemma zero_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (f : 𝕋 Δ H₂ H₃ R) : mul R (0 : 𝕋 Δ H₁ H₂ R) f = 0 := by
   simp only [mul_eq_sum]
   exact Finsupp.sum_zero_index
 
 /-- The convolution product vanishes on the right zero. -/
-lemma mul_zero [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+lemma mul_zero [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (f : 𝕋 Δ H₁ H₂ R) : mul R f (0 : 𝕋 Δ H₂ H₃ R) = 0 := by
   simp only [mul_eq_sum]
   exact (congrArg (Finsupp.sum f) (funext₂ fun _ _ ↦ Finsupp.sum_zero_index)).trans
     (Finsupp.sum_fun_zero f)
 
 /-- The Hecke ring is a non-unital non-associative semiring (distributivity and zero laws). -/
-noncomputable instance {H : Subgroup G} [IsHeckeCosetModule Δ H H] :
+noncomputable instance {H : Subgroup G} [IsHeckeTriple Δ H H] :
     NonUnitalNonAssocSemiring (𝕋 Δ H H R) :=
   { (inferInstance : AddCommMonoid (𝕋 Δ H H R)), (inferInstance : Mul (𝕋 Δ H H R)) with
     left_distrib := fun f g h ↦ mul_add R f g h

--- a/Mathlib/NumberTheory/HeckeRing/Multiplication.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplication.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Finsupp.Basic
+public import Mathlib.Data.Finsupp.SMul
+public import Mathlib.NumberTheory.HeckeRing.MultiplicitySupport
+
+/-!
+# Hecke rings: the convolution product
+
+The convolution product on the Hecke ring `𝕋 P R` with coefficients in a commutative ring `R`,
+following Shimura, *Introduction to the Arithmetic Theory of Automorphic Functions*, Ch. 3. On
+basis elements the product is `[D₁] * [D₂] = ∑_d m(D₁, D₂, d) [d]`, where the structure constants
+`m` are Shimura's integer multiplicities; for general coefficients they are cast into `R`.
+
+## Main definitions
+
+* `HeckeRing.m`: the integer structure-constant finsupp `∑_d heckeMultiplicity(g₁, g₂, d) [d]`.
+* `HeckeRing.mCast`: `m` with its coefficients cast into `R`.
+* `HeckeRing.tSingle`: the basis element `b • [D]`.
+
+## Main results
+
+* `HeckeRing.mul_def`: the product as a double `Finsupp.sum` over structure constants.
+* `HeckeRing.mul_single`: the product of two basis elements.
+* the `NonUnitalNonAssocSemiring (𝕋 P R)` instance.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup Finsupp
+open scoped Pointwise
+
+namespace HeckeRing
+
+variable {G : Type*} [Group G]
+
+attribute [local instance] doubleCosetSetoid
+
+variable (P : HeckePair G)
+
+/-- The integer structure-constant finsupp: `m g₁ g₂` is the formal sum
+`∑_d heckeMultiplicity g₁ g₂ d • [d]` encoding the product of two double cosets. -/
+noncomputable def m (g₁ g₂ : P.Δ) : (HeckeCoset P) →₀ ℤ :=
+  ⟨mulSupport P g₁ g₂,
+    fun d ↦ heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d),
+    fun a ↦
+      ⟨heckeMultiplicity_pos_of_mem_mulSupport P g₁ g₂ a,
+        fun hm ↦ by
+          by_contra hemp
+          exact hm (heckeMultiplicity_eq_zero_of_nmem_mulSupport P g₁ g₂ a hemp)⟩⟩
+
+variable (R : Type*) [CommRing R]
+
+/-- The structure constants cast into the coefficient ring `R`. -/
+noncomputable def mCast (g₁ g₂ : P.Δ) : (HeckeCoset P) →₀ R :=
+  (m P g₁ g₂).mapRange (Int.cast) Int.cast_zero
+
+/-- The convolution product on the Hecke ring, defined via the structure constants `mCast`. -/
+noncomputable instance : Mul (𝕋 P R) where
+  mul f g := Finsupp.sum f fun D₁ b₁ ↦
+    g.sum fun D₂ b₂ ↦
+      b₁ • b₂ • mCast P R (HeckeCoset.rep D₁) (HeckeCoset.rep D₂)
+
+/-- The convolution product unfolds as a double `Finsupp.sum` over structure constants. -/
+lemma mul_def (f g : 𝕋 P R) : f * g = Finsupp.sum f
+    (fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦
+      b₁ • b₂ • mCast P R (HeckeCoset.rep D₁) (HeckeCoset.rep D₂)) := rfl
+
+/-- A basis element of the Hecke ring: `tSingle D b` is the formal sum `b • [D]`. -/
+noncomputable abbrev tSingle (a : HeckeCoset P) (b : R) : 𝕋 P R :=
+  Finsupp.single a b
+
+/-- The product of two basis elements of the Hecke ring. -/
+lemma mul_single (D₁ D₂ : HeckeCoset P) (a b : R) :
+    tSingle P R D₁ a * tSingle P R D₂ b =
+      a • b • mCast P R (HeckeCoset.rep D₁) (HeckeCoset.rep D₂) := by
+  rw [mul_def]
+  simp [tSingle, Finsupp.sum_single_index]
+
+/-- The Hecke ring is a non-unital non-associative semiring (distributivity and zero laws). -/
+noncomputable instance :
+    NonUnitalNonAssocSemiring (𝕋 P R) :=
+  { (inferInstance : AddCommGroup (𝕋 P R)) with
+    left_distrib := fun f g h ↦ by
+      simp only [mul_def]
+      refine Eq.trans (congr_arg (Finsupp.sum f)
+        (funext₂ fun a₁ b₁ ↦ Finsupp.sum_add_index ?_ ?_)) ?_
+      · intros; simp
+      · intro D₁ _ a b
+        simp_rw [← smul_assoc, smul_eq_mul]
+        ring_nf
+        rw [add_smul]
+      · exact Finsupp.sum_add
+    right_distrib := fun f g h ↦ by
+      simp only [mul_def]
+      refine Eq.trans (Finsupp.sum_add_index ?_ ?_) ?_
+      · intros
+        simp only [zero_smul, Finsupp.sum_fun_zero]
+        rfl
+      · intro D₁ _ a b
+        refine Finsupp.ext fun t ↦ ?_
+        change (Finsupp.sum h fun D₂ b₂ ↦ (a + b) • b₂ • mCast P R D₁.rep D₂.rep) t =
+            ((Finsupp.sum h fun D₂ b₂ ↦ a • b₂ • mCast P R D₁.rep D₂.rep) +
+              Finsupp.sum h fun D₂ b₂ ↦ b • b₂ • mCast P R D₁.rep D₂.rep) t
+        rw [Finsupp.add_apply]
+        simp only [Finsupp.sum, Finset.sum_apply', Finsupp.coe_smul, Pi.smul_apply,
+          smul_eq_mul]
+        simp_rw [add_mul]
+        rw [Finset.sum_add_distrib]
+      · rfl
+    zero_mul := fun _ ↦ by simp only [mul_def]; exact Finsupp.sum_zero_index
+    mul_zero := fun f ↦ by
+      simp only [mul_def]
+      exact Eq.trans (congr_arg (sum f) (funext₂ fun _ _ ↦ sum_zero_index)) (sum_fun_zero f) }
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Multiplication.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplication.lean
@@ -12,110 +12,94 @@ public import Mathlib.NumberTheory.HeckeRing.MultiplicitySupport
 /-!
 # Hecke rings: the convolution product
 
-The convolution product on the Hecke ring `𝕋 P R` with coefficients in a commutative ring `R`,
-following Shimura, *Introduction to the Arithmetic Theory of Automorphic Functions*, Ch. 3. On
-basis elements the product is `[D₁] * [D₂] = ∑_d m(D₁, D₂, d) [d]`, where the structure constants
-`m` are Shimura's integer multiplicities; for general coefficients they are cast into `R`.
+The convolution product on the Hecke ring `𝕋 P R` with coefficients in a semiring `R`,
+following [Shimura][shimura1971], Chapter 3. On basis elements the product is
+`[D₁] * [D₂] = ∑_D m(D₁, D₂; D) [D]`, where the structure constants `m` are Shimura's
+multiplicities cast into `R`.
 
 ## Main definitions
 
-* `HeckeRing.m`: the integer structure-constant finsupp `∑_d heckeMultiplicity(g₁, g₂, d) [d]`.
-* `HeckeRing.mCast`: `m` with its coefficients cast into `R`.
-* `HeckeRing.tSingle`: the basis element `b • [D]`.
+* `HeckeRing.structureConstants`: the formal sum `∑_D m(g₁, g₂; D) [D]` of the structure
+  constants of a product of two double cosets.
 
 ## Main results
 
-* `HeckeRing.mul_def`: the product as a double `Finsupp.sum` over structure constants.
-* `HeckeRing.mul_single`: the product of two basis elements.
+* `HeckeRing.single_mul_single`: the product of two basis elements.
 * the `NonUnitalNonAssocSemiring (𝕋 P R)` instance.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup Finsupp
+open DoubleCoset Finsupp
 open scoped Pointwise
 
 namespace HeckeRing
 
-variable {G : Type*} [Group G]
+variable {G : Type*} [Group G] (P : HeckePair G) (R : Type*) [Semiring R]
 
-attribute [local instance] doubleCosetSetoid
+attribute [local instance] HeckePair.doubleCosetSetoid
 
-variable (P : HeckePair G)
+open Classical in
+/-- The structure constants of the Hecke product: `structureConstants P R g₁ g₂` is the formal
+sum `∑_D m(g₁, g₂; D) [D]` over double cosets, with Shimura's multiplicities cast into `R`. -/
+noncomputable def structureConstants (g₁ g₂ : P.Δ) : 𝕋 P R :=
+  Finsupp.onFinset (Finset.univ.image (P.mulMap g₁ g₂))
+    (fun D ↦ (multiplicity P.H P.H P.H (g₁ : G) (g₂ : G) (D.rep : G) : R))
+    (fun D hD ↦ (P.mem_image_mulMap_iff g₁ g₂ D).mpr fun h0 ↦ hD (by rw [h0, Nat.cast_zero]))
 
-/-- The integer structure-constant finsupp: `m g₁ g₂` is the formal sum
-`∑_d heckeMultiplicity g₁ g₂ d • [d]` encoding the product of two double cosets. -/
-noncomputable def m (g₁ g₂ : P.Δ) : (HeckeCoset P) →₀ ℤ :=
-  ⟨mulSupport P g₁ g₂,
-    fun d ↦ heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d),
-    fun a ↦
-      ⟨heckeMultiplicity_pos_of_mem_mulSupport P g₁ g₂ a,
-        fun hm ↦ by
-          by_contra hemp
-          exact hm (heckeMultiplicity_eq_zero_of_nmem_mulSupport P g₁ g₂ a hemp)⟩⟩
+@[simp] lemma structureConstants_apply (g₁ g₂ : P.Δ) (D : HeckeCoset P) :
+    structureConstants P R g₁ g₂ D =
+      (multiplicity P.H P.H P.H (g₁ : G) (g₂ : G) (D.rep : G) : R) := rfl
 
-variable (R : Type*) [CommRing R]
+noncomputable instance : Module R (𝕋 P R) := inferInstanceAs (Module R (HeckeCoset P →₀ R))
 
-/-- The structure constants cast into the coefficient ring `R`. -/
-noncomputable def mCast (g₁ g₂ : P.Δ) : (HeckeCoset P) →₀ R :=
-  (m P g₁ g₂).mapRange (Int.cast) Int.cast_zero
-
-/-- The convolution product on the Hecke ring, defined via the structure constants `mCast`. -/
+/-- The convolution product on the Hecke ring, defined via the structure constants. -/
 noncomputable instance : Mul (𝕋 P R) where
-  mul f g := Finsupp.sum f fun D₁ b₁ ↦
-    g.sum fun D₂ b₂ ↦
-      b₁ • b₂ • mCast P R (HeckeCoset.rep D₁) (HeckeCoset.rep D₂)
+  mul f g := f.sum fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants P R D₁.rep D₂.rep
 
-/-- The convolution product unfolds as a double `Finsupp.sum` over structure constants. -/
-lemma mul_def (f g : 𝕋 P R) : f * g = Finsupp.sum f
-    (fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦
-      b₁ • b₂ • mCast P R (HeckeCoset.rep D₁) (HeckeCoset.rep D₂)) := rfl
+lemma mul_def (f g : 𝕋 P R) : f * g =
+    f.sum (fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants P R D₁.rep D₂.rep) := rfl
 
-/-- A basis element of the Hecke ring: `tSingle D b` is the formal sum `b • [D]`. -/
-noncomputable abbrev tSingle (a : HeckeCoset P) (b : R) : 𝕋 P R :=
-  Finsupp.single a b
+/-- A basis element of the Hecke ring: `single D b` is the formal sum `b • [D]`. As for
+`Finsupp` itself, this is the type-correct way to produce elements of `𝕋 P R`. -/
+noncomputable def single (D : HeckeCoset P) (b : R) : 𝕋 P R := Finsupp.single D b
+
+lemma single_apply {D A : HeckeCoset P} {b : R} [Decidable (D = A)] :
+    single P R D b A = if D = A then b else 0 :=
+  Finsupp.single_apply
+
+lemma smul_single_one (D : HeckeCoset P) (b : R) : b • single P R D 1 = single P R D b :=
+  Finsupp.smul_single_one D b
+
+lemma sum_single (f : 𝕋 P R) : f.sum (single P R) = f := Finsupp.sum_single f
 
 /-- The product of two basis elements of the Hecke ring. -/
-lemma mul_single (D₁ D₂ : HeckeCoset P) (a b : R) :
-    tSingle P R D₁ a * tSingle P R D₂ b =
-      a • b • mCast P R (HeckeCoset.rep D₁) (HeckeCoset.rep D₂) := by
+lemma single_mul_single (D₁ D₂ : HeckeCoset P) (a b : R) :
+    single P R D₁ a * single P R D₂ b = a • b • structureConstants P R D₁.rep D₂.rep := by
   rw [mul_def]
-  simp [tSingle, Finsupp.sum_single_index]
+  simp [single, Finsupp.sum_single_index]
 
 /-- The Hecke ring is a non-unital non-associative semiring (distributivity and zero laws). -/
-noncomputable instance :
-    NonUnitalNonAssocSemiring (𝕋 P R) :=
-  { (inferInstance : AddCommGroup (𝕋 P R)) with
+noncomputable instance : NonUnitalNonAssocSemiring (𝕋 P R) :=
+  { (inferInstance : AddCommMonoid (𝕋 P R)), (inferInstance : Mul (𝕋 P R)) with
     left_distrib := fun f g h ↦ by
+      classical
       simp only [mul_def]
-      refine Eq.trans (congr_arg (Finsupp.sum f)
-        (funext₂ fun a₁ b₁ ↦ Finsupp.sum_add_index ?_ ?_)) ?_
-      · intros; simp
-      · intro D₁ _ a b
-        simp_rw [← smul_assoc, smul_eq_mul]
-        ring_nf
-        rw [add_smul]
-      · exact Finsupp.sum_add
+      rw [← Finsupp.sum_add]
+      exact Finsupp.sum_congr fun D₁ _ ↦ Finsupp.sum_add_index (fun _ _ ↦ by simp)
+        (fun _ _ b b' ↦ by rw [add_smul, smul_add])
     right_distrib := fun f g h ↦ by
+      classical
       simp only [mul_def]
-      refine Eq.trans (Finsupp.sum_add_index ?_ ?_) ?_
-      · intros
-        simp only [zero_smul, Finsupp.sum_fun_zero]
-        rfl
-      · intro D₁ _ a b
-        refine Finsupp.ext fun t ↦ ?_
-        change (Finsupp.sum h fun D₂ b₂ ↦ (a + b) • b₂ • mCast P R D₁.rep D₂.rep) t =
-            ((Finsupp.sum h fun D₂ b₂ ↦ a • b₂ • mCast P R D₁.rep D₂.rep) +
-              Finsupp.sum h fun D₂ b₂ ↦ b • b₂ • mCast P R D₁.rep D₂.rep) t
-        rw [Finsupp.add_apply]
-        simp only [Finsupp.sum, Finset.sum_apply', Finsupp.coe_smul, Pi.smul_apply,
-          smul_eq_mul]
-        simp_rw [add_mul]
-        rw [Finset.sum_add_distrib]
-      · rfl
-    zero_mul := fun _ ↦ by simp only [mul_def]; exact Finsupp.sum_zero_index
+      exact Finsupp.sum_add_index (fun _ _ ↦ by simp) fun _ _ b b' ↦ by
+        rw [← Finsupp.sum_add]
+        exact Finsupp.sum_congr fun D₂ _ ↦ by rw [add_smul]
+    zero_mul := fun f ↦ by
+      simp only [mul_def]
+      exact Finsupp.sum_zero_index
     mul_zero := fun f ↦ by
       simp only [mul_def]
-      exact Eq.trans (congr_arg (sum f) (funext₂ fun _ _ ↦ sum_zero_index)) (sum_fun_zero f) }
+      exact (congrArg (Finsupp.sum f) (funext₂ fun _ _ ↦ Finsupp.sum_zero_index)).trans
+        (Finsupp.sum_fun_zero f) }
 
 end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Multiplication.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplication.lean
@@ -12,22 +12,24 @@ public import Mathlib.NumberTheory.HeckeRing.MultiplicitySupport
 /-!
 # Hecke rings: the convolution product
 
-The convolution product `𝕋 Δ H₁ H₂ R × 𝕋 Δ H₂ H₃ R → 𝕋 Δ H₁ H₃ R` of Hecke coset modules with
-coefficients in a semiring `R`, following [Shimura][shimura1971], Chapter 3. On basis elements
-the product is `[D₁] * [D₂] = ∑_D m(D₁, D₂; D) [D]`, where the structure constants `m` are
-Shimura's multiplicities cast into `R`. On the diagonal `H₁ = H₂ = H₃` this is the
-multiplication of the Hecke ring.
+The convolution product
+`HeckeCosetModule Δ H₁ H₂ R × HeckeCosetModule Δ H₂ H₃ R → HeckeCosetModule Δ H₁ H₃ R`
+of Hecke coset modules with coefficients in a semiring `R`, following [Shimura][shimura1971],
+Chapter 3. On basis elements the product is `[D₁] * [D₂] = ∑_D m(D₁, D₂; D) [D]`, where the
+structure constants `m` are Shimura's multiplicities cast into `R`. On the diagonal
+`H₁ = H₂ = H₃` this is the multiplication of the Hecke ring.
 
 ## Main definitions
 
 * `HeckeCosetModule.structureConstants`: the formal sum `∑_D m(g₁, g₂; D) [D]` of the structure
   constants of a product of two double cosets.
-* `HeckeCosetModule.mul`: the convolution product `𝕋 Δ H₁ H₂ R → 𝕋 Δ H₂ H₃ R → 𝕋 Δ H₁ H₃ R`.
+* `HeckeCosetModule.mul`: the convolution product
+  `HeckeCosetModule Δ H₁ H₂ R → HeckeCosetModule Δ H₂ H₃ R → HeckeCosetModule Δ H₁ H₃ R`.
 
 ## Main results
 
 * `HeckeCosetModule.single_mul_single`: the product of two basis elements.
-* the `NonUnitalNonAssocSemiring (𝕋 Δ H H R)` instance.
+* the `NonUnitalNonAssocSemiring (𝕋 Δ H R)` instance.
 -/
 
 @[expose] public section
@@ -45,7 +47,7 @@ open Classical in
 formal sum `∑_D m(g₁, g₂; D) [D]` over mixed double cosets, with Shimura's multiplicities cast
 into `R`. -/
 noncomputable def structureConstants (H₁ H₂ H₃ : Subgroup G) [IsHeckeTriple Δ H₁ H₂]
-    [IsHeckeTriple Δ H₂ H₃] (g₁ g₂ : Δ) : 𝕋 Δ H₁ H₃ R :=
+    [IsHeckeTriple Δ H₂ H₃] (g₁ g₂ : Δ) : HeckeCosetModule Δ H₁ H₃ R :=
   Finsupp.onFinset (Finset.univ.image (HeckeCoset.mulMap H₁ H₂ H₃ g₁ g₂))
     (fun D ↦ (multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (D.rep : G) : R))
     (fun D hD ↦ (HeckeCoset.mem_image_mulMap_iff g₁ g₂ D).mpr
@@ -56,31 +58,34 @@ noncomputable def structureConstants (H₁ H₂ H₃ : Subgroup G) [IsHeckeTripl
     structureConstants R H₁ H₂ H₃ g₁ g₂ D =
       (multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (D.rep : G) : R) := rfl
 
-noncomputable instance : Module R (𝕋 Δ H₁ H₂ R) :=
+noncomputable instance : Module R (HeckeCosetModule Δ H₁ H₂ R) :=
   inferInstanceAs (Module R (HeckeCoset Δ H₁ H₂ →₀ R))
 
 /-- The convolution product of Hecke coset modules, defined via the structure constants. The
-diagonal case is the multiplication of the Hecke ring; see the `Mul (𝕋 Δ H H R)` instance. -/
+diagonal case is the multiplication of the Hecke ring; see the `Mul (𝕋 Δ H R)` instance. -/
 noncomputable def mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
-    (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) : 𝕋 Δ H₁ H₃ R :=
+    (f : HeckeCosetModule Δ H₁ H₂ R) (g : HeckeCosetModule Δ H₂ H₃ R) :
+    HeckeCosetModule Δ H₁ H₃ R :=
   f.sum fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep
 
 lemma mul_eq_sum [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
-    (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) : mul R f g =
+    (f : HeckeCosetModule Δ H₁ H₂ R) (g : HeckeCosetModule Δ H₂ H₃ R) : mul R f g =
       f.sum fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep :=
   rfl
 
 /-- The multiplication of the Hecke ring: the diagonal case of the convolution product
 `HeckeCosetModule.mul`. -/
-noncomputable instance {H : Subgroup G} [IsHeckeTriple Δ H H] : Mul (𝕋 Δ H H R) where
+noncomputable instance {H : Subgroup G} [IsHeckeTriple Δ H H] : Mul (𝕋 Δ H R) where
   mul f g := mul R f g
 
-lemma mul_def {H : Subgroup G} [IsHeckeTriple Δ H H] (f g : 𝕋 Δ H H R) :
+lemma mul_def {H : Subgroup G} [IsHeckeTriple Δ H H] (f g : 𝕋 Δ H R) :
     f * g = mul R f g := rfl
 
 /-- A basis element of the Hecke coset module: `single R D b` is the formal sum `b • [D]`. As
-for `Finsupp` itself, this is the type-correct way to produce elements of `𝕋 Δ H₁ H₂ R`. -/
-noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) : 𝕋 Δ H₁ H₂ R := Finsupp.single D b
+for `Finsupp` itself, this is the type-correct way to produce elements of
+`HeckeCosetModule Δ H₁ H₂ R`. -/
+noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) : HeckeCosetModule Δ H₁ H₂ R :=
+  Finsupp.single D b
 
 lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
     single R D b A = if D = A then b else 0 :=
@@ -89,7 +94,7 @@ lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
 lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1 = single R D b :=
   Finsupp.smul_single_one D b
 
-lemma sum_single (f : 𝕋 Δ H₁ H₂ R) : f.sum (single R) = f := Finsupp.sum_single f
+lemma sum_single (f : HeckeCosetModule Δ H₁ H₂ R) : f.sum (single R) = f := Finsupp.sum_single f
 
 /-- The convolution product of two basis elements. -/
 lemma mul_single_single [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
@@ -107,7 +112,8 @@ lemma single_mul_single {H : Subgroup G} [IsHeckeTriple Δ H H]
 
 /-- The convolution product distributes over addition on the right. -/
 lemma mul_add [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
-    (f : 𝕋 Δ H₁ H₂ R) (g h : 𝕋 Δ H₂ H₃ R) : mul R f (g + h) = mul R f g + mul R f h := by
+    (f : HeckeCosetModule Δ H₁ H₂ R) (g h : HeckeCosetModule Δ H₂ H₃ R) :
+    mul R f (g + h) = mul R f g + mul R f h := by
   classical
   simp only [mul_eq_sum]
   rw [← Finsupp.sum_add]
@@ -116,7 +122,8 @@ lemma mul_add [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
 
 /-- The convolution product distributes over addition on the left. -/
 lemma add_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
-    (f g : 𝕋 Δ H₁ H₂ R) (h : 𝕋 Δ H₂ H₃ R) : mul R (f + g) h = mul R f h + mul R g h := by
+    (f g : HeckeCosetModule Δ H₁ H₂ R) (h : HeckeCosetModule Δ H₂ H₃ R) :
+    mul R (f + g) h = mul R f h + mul R g h := by
   classical
   simp only [mul_eq_sum]
   exact Finsupp.sum_add_index (fun _ _ ↦ by simp) fun _ _ b b' ↦ by
@@ -125,21 +132,21 @@ lemma add_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
 
 /-- The convolution product vanishes on the left zero. -/
 lemma zero_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
-    (f : 𝕋 Δ H₂ H₃ R) : mul R (0 : 𝕋 Δ H₁ H₂ R) f = 0 := by
+    (f : HeckeCosetModule Δ H₂ H₃ R) : mul R (0 : HeckeCosetModule Δ H₁ H₂ R) f = 0 := by
   simp only [mul_eq_sum]
   exact Finsupp.sum_zero_index
 
 /-- The convolution product vanishes on the right zero. -/
 lemma mul_zero [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
-    (f : 𝕋 Δ H₁ H₂ R) : mul R f (0 : 𝕋 Δ H₂ H₃ R) = 0 := by
+    (f : HeckeCosetModule Δ H₁ H₂ R) : mul R f (0 : HeckeCosetModule Δ H₂ H₃ R) = 0 := by
   simp only [mul_eq_sum]
   exact (congrArg (Finsupp.sum f) (funext₂ fun _ _ ↦ Finsupp.sum_zero_index)).trans
     (Finsupp.sum_fun_zero f)
 
 /-- The Hecke ring is a non-unital non-associative semiring (distributivity and zero laws). -/
 noncomputable instance {H : Subgroup G} [IsHeckeTriple Δ H H] :
-    NonUnitalNonAssocSemiring (𝕋 Δ H H R) :=
-  { (inferInstance : AddCommMonoid (𝕋 Δ H H R)), (inferInstance : Mul (𝕋 Δ H H R)) with
+    NonUnitalNonAssocSemiring (𝕋 Δ H R) :=
+  { (inferInstance : AddCommMonoid (𝕋 Δ H R)), (inferInstance : Mul (𝕋 Δ H R)) with
     left_distrib := fun f g h ↦ mul_add R f g h
     right_distrib := fun f g h ↦ add_mul R f g h
     zero_mul := fun f ↦ zero_mul R f

--- a/Mathlib/NumberTheory/HeckeRing/Multiplication.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplication.lean
@@ -12,20 +12,22 @@ public import Mathlib.NumberTheory.HeckeRing.MultiplicitySupport
 /-!
 # Hecke rings: the convolution product
 
-The convolution product on the Hecke ring `𝕋 P R` with coefficients in a semiring `R`,
-following [Shimura][shimura1971], Chapter 3. On basis elements the product is
-`[D₁] * [D₂] = ∑_D m(D₁, D₂; D) [D]`, where the structure constants `m` are Shimura's
-multiplicities cast into `R`.
+The convolution product `𝕋 Δ H₁ H₂ R × 𝕋 Δ H₂ H₃ R → 𝕋 Δ H₁ H₃ R` of Hecke coset modules with
+coefficients in a semiring `R`, following [Shimura][shimura1971], Chapter 3. On basis elements
+the product is `[D₁] * [D₂] = ∑_D m(D₁, D₂; D) [D]`, where the structure constants `m` are
+Shimura's multiplicities cast into `R`. On the diagonal `H₁ = H₂ = H₃` this is the
+multiplication of the Hecke ring.
 
 ## Main definitions
 
-* `HeckeRing.structureConstants`: the formal sum `∑_D m(g₁, g₂; D) [D]` of the structure
+* `HeckeCosetModule.structureConstants`: the formal sum `∑_D m(g₁, g₂; D) [D]` of the structure
   constants of a product of two double cosets.
+* `HeckeCosetModule.mul`: the convolution product `𝕋 Δ H₁ H₂ R → 𝕋 Δ H₂ H₃ R → 𝕋 Δ H₁ H₃ R`.
 
 ## Main results
 
-* `HeckeRing.single_mul_single`: the product of two basis elements.
-* the `NonUnitalNonAssocSemiring (𝕋 P R)` instance.
+* `HeckeCosetModule.single_mul_single`: the product of two basis elements.
+* the `NonUnitalNonAssocSemiring (𝕋 Δ H H R)` instance.
 -/
 
 @[expose] public section
@@ -33,73 +35,114 @@ multiplicities cast into `R`.
 open DoubleCoset Finsupp
 open scoped Pointwise
 
-namespace HeckeRing
+namespace HeckeCosetModule
 
-variable {G : Type*} [Group G] (P : HeckePair G) (R : Type*) [Semiring R]
-
-attribute [local instance] HeckePair.doubleCosetSetoid
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
+  (R : Type*) [Semiring R]
 
 open Classical in
-/-- The structure constants of the Hecke product: `structureConstants P R g₁ g₂` is the formal
-sum `∑_D m(g₁, g₂; D) [D]` over double cosets, with Shimura's multiplicities cast into `R`. -/
-noncomputable def structureConstants (g₁ g₂ : P.Δ) : 𝕋 P R :=
-  Finsupp.onFinset (Finset.univ.image (P.mulMap g₁ g₂))
-    (fun D ↦ (multiplicity P.H P.H P.H (g₁ : G) (g₂ : G) (D.rep : G) : R))
-    (fun D hD ↦ (P.mem_image_mulMap_iff g₁ g₂ D).mpr fun h0 ↦ hD (by rw [h0, Nat.cast_zero]))
+/-- The structure constants of the Hecke product: `structureConstants H₁ H₂ H₃ R g₁ g₂` is the
+formal sum `∑_D m(g₁, g₂; D) [D]` over mixed double cosets, with Shimura's multiplicities cast
+into `R`. -/
+noncomputable def structureConstants (H₁ H₂ H₃ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂]
+    [IsHeckeCosetModule Δ H₂ H₃] (g₁ g₂ : Δ) : 𝕋 Δ H₁ H₃ R :=
+  Finsupp.onFinset (Finset.univ.image (HeckeCoset.mulMap H₁ H₂ H₃ g₁ g₂))
+    (fun D ↦ (multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (D.rep : G) : R))
+    (fun D hD ↦ (HeckeCoset.mem_image_mulMap_iff g₁ g₂ D).mpr
+      fun h0 ↦ hD (by rw [h0, Nat.cast_zero]))
 
-@[simp] lemma structureConstants_apply (g₁ g₂ : P.Δ) (D : HeckeCoset P) :
-    structureConstants P R g₁ g₂ D =
-      (multiplicity P.H P.H P.H (g₁ : G) (g₂ : G) (D.rep : G) : R) := rfl
+@[simp] lemma structureConstants_apply [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    (g₁ g₂ : Δ) (D : HeckeCoset Δ H₁ H₃) :
+    structureConstants R H₁ H₂ H₃ g₁ g₂ D =
+      (multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (D.rep : G) : R) := rfl
 
-noncomputable instance : Module R (𝕋 P R) := inferInstanceAs (Module R (HeckeCoset P →₀ R))
+noncomputable instance : Module R (𝕋 Δ H₁ H₂ R) :=
+  inferInstanceAs (Module R (HeckeCoset Δ H₁ H₂ →₀ R))
 
-/-- The convolution product on the Hecke ring, defined via the structure constants. -/
-noncomputable instance : Mul (𝕋 P R) where
-  mul f g := f.sum fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants P R D₁.rep D₂.rep
+/-- The convolution product of Hecke coset modules, defined via the structure constants. The
+diagonal case is the multiplication of the Hecke ring; see the `Mul (𝕋 Δ H H R)` instance. -/
+noncomputable def mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) : 𝕋 Δ H₁ H₃ R :=
+  f.sum fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep
 
-lemma mul_def (f g : 𝕋 P R) : f * g =
-    f.sum (fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants P R D₁.rep D₂.rep) := rfl
+lemma mul_eq_sum [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    (f : 𝕋 Δ H₁ H₂ R) (g : 𝕋 Δ H₂ H₃ R) : mul R f g =
+      f.sum fun D₁ b₁ ↦ g.sum fun D₂ b₂ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep :=
+  rfl
 
-/-- A basis element of the Hecke ring: `single D b` is the formal sum `b • [D]`. As for
-`Finsupp` itself, this is the type-correct way to produce elements of `𝕋 P R`. -/
-noncomputable def single (D : HeckeCoset P) (b : R) : 𝕋 P R := Finsupp.single D b
+/-- The multiplication of the Hecke ring: the diagonal case of the convolution product
+`HeckeCosetModule.mul`. -/
+noncomputable instance {H : Subgroup G} [IsHeckeCosetModule Δ H H] : Mul (𝕋 Δ H H R) where
+  mul f g := mul R f g
 
-lemma single_apply {D A : HeckeCoset P} {b : R} [Decidable (D = A)] :
-    single P R D b A = if D = A then b else 0 :=
+lemma mul_def {H : Subgroup G} [IsHeckeCosetModule Δ H H] (f g : 𝕋 Δ H H R) :
+    f * g = mul R f g := rfl
+
+/-- A basis element of the Hecke coset module: `single R D b` is the formal sum `b • [D]`. As
+for `Finsupp` itself, this is the type-correct way to produce elements of `𝕋 Δ H₁ H₂ R`. -/
+noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) : 𝕋 Δ H₁ H₂ R := Finsupp.single D b
+
+lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
+    single R D b A = if D = A then b else 0 :=
   Finsupp.single_apply
 
-lemma smul_single_one (D : HeckeCoset P) (b : R) : b • single P R D 1 = single P R D b :=
+lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1 = single R D b :=
   Finsupp.smul_single_one D b
 
-lemma sum_single (f : 𝕋 P R) : f.sum (single P R) = f := Finsupp.sum_single f
+lemma sum_single (f : 𝕋 Δ H₁ H₂ R) : f.sum (single R) = f := Finsupp.sum_single f
 
-/-- The product of two basis elements of the Hecke ring. -/
-lemma single_mul_single (D₁ D₂ : HeckeCoset P) (a b : R) :
-    single P R D₁ a * single P R D₂ b = a • b • structureConstants P R D₁.rep D₂.rep := by
-  rw [mul_def]
+/-- The convolution product of two basis elements. -/
+lemma mul_single_single [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    (D₁ : HeckeCoset Δ H₁ H₂) (D₂ : HeckeCoset Δ H₂ H₃) (a b : R) :
+    mul R (single R D₁ a) (single R D₂ b) =
+      a • b • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep := by
+  rw [mul_eq_sum]
   simp [single, Finsupp.sum_single_index]
 
-/-- The Hecke ring is a non-unital non-associative semiring (distributivity and zero laws). -/
-noncomputable instance : NonUnitalNonAssocSemiring (𝕋 P R) :=
-  { (inferInstance : AddCommMonoid (𝕋 P R)), (inferInstance : Mul (𝕋 P R)) with
-    left_distrib := fun f g h ↦ by
-      classical
-      simp only [mul_def]
-      rw [← Finsupp.sum_add]
-      exact Finsupp.sum_congr fun D₁ _ ↦ Finsupp.sum_add_index (fun _ _ ↦ by simp)
-        (fun _ _ b b' ↦ by rw [add_smul, smul_add])
-    right_distrib := fun f g h ↦ by
-      classical
-      simp only [mul_def]
-      exact Finsupp.sum_add_index (fun _ _ ↦ by simp) fun _ _ b b' ↦ by
-        rw [← Finsupp.sum_add]
-        exact Finsupp.sum_congr fun D₂ _ ↦ by rw [add_smul]
-    zero_mul := fun f ↦ by
-      simp only [mul_def]
-      exact Finsupp.sum_zero_index
-    mul_zero := fun f ↦ by
-      simp only [mul_def]
-      exact (congrArg (Finsupp.sum f) (funext₂ fun _ _ ↦ Finsupp.sum_zero_index)).trans
-        (Finsupp.sum_fun_zero f) }
+/-- The product of two basis elements of the Hecke ring. -/
+lemma single_mul_single {H : Subgroup G} [IsHeckeCosetModule Δ H H]
+    (D₁ D₂ : HeckeCoset Δ H H) (a b : R) :
+    single R D₁ a * single R D₂ b = a • b • structureConstants R H H H D₁.rep D₂.rep :=
+  mul_single_single R D₁ D₂ a b
 
-end HeckeRing
+/-- The convolution product distributes over addition on the right. -/
+lemma mul_add [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    (f : 𝕋 Δ H₁ H₂ R) (g h : 𝕋 Δ H₂ H₃ R) : mul R f (g + h) = mul R f g + mul R f h := by
+  classical
+  simp only [mul_eq_sum]
+  rw [← Finsupp.sum_add]
+  exact Finsupp.sum_congr fun D₁ _ ↦ Finsupp.sum_add_index (fun _ _ ↦ by simp)
+    (fun _ _ b b' ↦ by rw [add_smul, smul_add])
+
+/-- The convolution product distributes over addition on the left. -/
+lemma add_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    (f g : 𝕋 Δ H₁ H₂ R) (h : 𝕋 Δ H₂ H₃ R) : mul R (f + g) h = mul R f h + mul R g h := by
+  classical
+  simp only [mul_eq_sum]
+  exact Finsupp.sum_add_index (fun _ _ ↦ by simp) fun _ _ b b' ↦ by
+    rw [← Finsupp.sum_add]
+    exact Finsupp.sum_congr fun D₂ _ ↦ by rw [add_smul]
+
+/-- The convolution product vanishes on the left zero. -/
+lemma zero_mul [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    (f : 𝕋 Δ H₂ H₃ R) : mul R (0 : 𝕋 Δ H₁ H₂ R) f = 0 := by
+  simp only [mul_eq_sum]
+  exact Finsupp.sum_zero_index
+
+/-- The convolution product vanishes on the right zero. -/
+lemma mul_zero [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    (f : 𝕋 Δ H₁ H₂ R) : mul R f (0 : 𝕋 Δ H₂ H₃ R) = 0 := by
+  simp only [mul_eq_sum]
+  exact (congrArg (Finsupp.sum f) (funext₂ fun _ _ ↦ Finsupp.sum_zero_index)).trans
+    (Finsupp.sum_fun_zero f)
+
+/-- The Hecke ring is a non-unital non-associative semiring (distributivity and zero laws). -/
+noncomputable instance {H : Subgroup G} [IsHeckeCosetModule Δ H H] :
+    NonUnitalNonAssocSemiring (𝕋 Δ H H R) :=
+  { (inferInstance : AddCommMonoid (𝕋 Δ H H R)), (inferInstance : Mul (𝕋 Δ H H R)) with
+    left_distrib := fun f g h ↦ mul_add R f g h
+    right_distrib := fun f g h ↦ add_mul R f g h
+    zero_mul := fun f ↦ zero_mul R f
+    mul_zero := fun f ↦ mul_zero R f }
+
+end HeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -99,8 +99,8 @@ noncomputable def mulMap (H₁ H₂ H₃ : Subgroup G) [IsHeckeTriple Δ H₁ H�
     [IsHeckeTriple Δ H₂ H₃] (g₁ g₂ : Δ)
     (p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)) : HeckeCoset Δ H₁ H₃ :=
   mk H₁ H₃ ⟨(p.1.out : G) * g₁ * ((p.2.out : G) * g₂),
-    Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_left H₂ p.1.out.2) g₁.2)
-      (Δ.mul_mem (IsHeckeTriple.mem_left H₃ p.2.out.2) g₂.2)⟩
+    Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_of_mem_left H₂ p.1.out.2) g₁.2)
+      (Δ.mul_mem (IsHeckeTriple.mem_of_mem_left H₃ p.2.out.2) g₂.2)⟩
 
 /-- If `σᵢ g₁ τⱼ g₂ H₃ = d H₃` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`. -/
 lemma mulMap_eq_of_mk_eq {H₁ H₂ H₃ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.HeckeRing.Basic
+
+/-!
+# Hecke rings: the multiplicity function
+
+Shimura's multiplicity `heckeMultiplicity` (Proposition 3.2 of *Introduction to the Arithmetic
+Theory of Automorphic Functions*) counts, for double cosets `Hg₁H`, `Hg₂H` and `HdH`, the pairs of
+left-coset representatives `(σᵢ, τⱼ)` with `σᵢ τⱼ H = d H`. These integers are the structure
+constants of the Hecke product defined in later files. This file sets up the multiplicity, the map
+`mulMap` on pairs of representatives, and the structural lemmas on the coset decomposition.
+
+## Main definitions
+
+* `HeckeRing.mulMap`: the double coset `H(σᵢ τⱼ)H` of a pair of coset representatives.
+* `HeckeRing.heckeMultiplicity`: Shimura's multiplicity, an integer structure constant.
+* `HeckeRing.mulSupport`: the finite set of double cosets appearing in a product.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup
+open scoped Pointwise
+
+namespace HeckeRing
+
+variable {G : Type*} [Group G] (H : Subgroup G) (Δ : Submonoid G) (P : HeckePair G)
+
+attribute [local instance] doubleCosetSetoid
+
+/-- Two `HeckeCoset` elements are equal iff their `toSet`s are equal. -/
+lemma HeckeCoset_ext_toSet {D₁ D₂ : HeckeCoset P}
+    (h : HeckeCoset.toSet D₁ = HeckeCoset.toSet D₂) : D₁ = D₂ := by
+  revert h
+  refine Quotient.ind₂ (motive := fun D₁ D₂ ↦
+    HeckeCoset.toSet D₁ = HeckeCoset.toSet D₂ → D₁ = D₂)
+    (fun g₁ g₂ h ↦ ?_) D₁ D₂
+  simp only [HeckeCoset.toSet_mk] at h
+  exact Quotient.sound h
+
+/-- The stabilizer quotient for the identity double coset is trivial. -/
+lemma decompQuot_one_eq_top :
+    (ConjAct.toConjAct ((HeckeCoset.one P).rep : G) • P.H).subgroupOf P.H = ⊤ := by
+  have h := HeckeCoset.one_rep_mem_H P
+  rw [Subgroup.subgroupOf_eq_top]
+  intro x hx
+  rw [← @SetLike.mem_coe]
+  simp only [Subgroup.coe_pointwise_smul]
+  rw [conjAct_smul_coe_eq, Subgroup.singleton_mul_subgroup h,
+    Subgroup.subgroup_mul_singleton (by simp [h])]
+  exact hx
+
+/-- The decomposition quotient for `HeckeCoset.one` is nonempty. -/
+lemma one_in_decompQuot_one :
+    Nonempty (decompQuot P (HeckeCoset.one P).rep) :=
+  ⟨(1 : P.H)⟩
+
+/-- The decomposition quotient for `HeckeCoset.one` is a subsingleton. -/
+lemma subsingleton_decompQuot_one :
+    Subsingleton (decompQuot P (HeckeCoset.one P).rep) := by
+  unfold decompQuot
+  rw [decompQuot_one_eq_top]
+  exact QuotientGroup.subsingleton_quotient_top
+
+private lemma conjAct_mem_of_leftCoset_eq (d : Δ) (h h' : H)
+    (hyp : {(h : G)} * {(d : G)} * (H : Set G) =
+      {(h' : G)} * {(d : G)} * (H : Set G)) :
+    (h')⁻¹ * h ∈ (ConjAct.toConjAct (d : G) • H).subgroupOf H := by
+  have h_mem_lhs : (h : G) * (d : G) ∈ {(h : G)} * {(d : G)} * (H : Set G) := by
+    rw [Set.singleton_mul_singleton]
+    exact ⟨(h : G) * (d : G), Set.mem_singleton _, 1, H.one_mem, by simp⟩
+  rw [hyp, Set.singleton_mul_singleton] at h_mem_lhs
+  obtain ⟨_, rfl, k, hk, hkk⟩ := h_mem_lhs
+  have hkk' : ↑h' * ↑d * k = ↑h * ↑d := hkk
+  have key : (h' : G)⁻¹ * (h : G) = (d : G) * k * (d : G)⁻¹ := by
+    apply mul_right_cancel (b := (d : G))
+    rw [mul_assoc, mul_assoc, inv_mul_cancel, mul_one]
+    apply mul_left_cancel (a := (h' : G))
+    rw [mul_inv_cancel_left, ← mul_assoc]
+    exact hkk'.symm
+  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
+    ConjAct.smul_def]
+  simp only [map_inv, ConjAct.ofConjAct_toConjAct, Subgroup.coe_mul,
+    Subgroup.coe_inv]
+  rw [inv_inv, key]
+  simp only [mul_assoc, inv_mul_cancel, mul_one, inv_mul_cancel_left]
+  exact hk
+
+/-- Distinct elements of `decompQuot` give distinct left cosets. -/
+lemma decompQuot_coset_diff (g : P.Δ) (i j : decompQuot P g) (hij : i ≠ j) :
+    {((i.out : G) * (g : G))} * (P.H : Set G) ≠ {((j.out : G) * (g : G))} * (P.H : Set G) := by
+  intro h
+  simp_rw [← Set.singleton_mul_singleton] at h
+  have := conjAct_mem_of_leftCoset_eq P.H P.Δ g i.out j.out h
+  rw [← @QuotientGroup.leftRel_apply, ← @Quotient.eq''] at this
+  simp only [Quotient.out_eq'] at this
+  exact hij this.symm
+
+/-- Two left cosets that are not disjoint must be equal. -/
+lemma leftCoset_eq_of_not_disjoint (f g : G)
+    (h : ¬ Disjoint (g • (H : Set G)) (f • H)) :
+    {g} * (H : Set G) = {f} * H := by
+  simp_rw [← Set.singleton_smul] at *
+  rw [not_disjoint_iff] at h
+  obtain ⟨a, ha, ha2⟩ := h
+  simp only [smul_eq_mul, singleton_mul, image_mul_left, mem_preimage,
+    SetLike.mem_coe] at ha ha2
+  ext Y
+  simp only [singleton_mul, image_mul_left, mem_preimage, SetLike.mem_coe]
+  simp_rw [← QuotientGroup.eq] at *
+  rw [← ha] at ha2
+  rw [ha2]
+
+/-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the double coset
+of their product `H(σᵢ τⱼ)H`. -/
+noncomputable def mulMap (g₁ g₂ : P.Δ) (i : decompQuot P g₁ × decompQuot P g₂) :
+    HeckeCoset P :=
+  ⟦⟨i.1.out * g₁ * (i.2.out * g₂),
+    Submonoid.mul_mem _ (Submonoid.mul_mem _ (P.h₀ i.1.out.2) g₁.2)
+      (Submonoid.mul_mem _ (P.h₀ i.2.out.2) g₂.2)⟩⟧
+
+/-- Shimura's multiplicity (Proposition 3.2): `heckeMultiplicity g₁ g₂ d` counts pairs
+`(i, j)` such that `σᵢ τⱼ H = ξ H`. -/
+noncomputable def heckeMultiplicity (g₁ g₂ d : P.Δ) : ℤ :=
+  Nat.card {⟨i, j⟩ : decompQuot P g₁ × decompQuot P g₂ |
+    ({(i.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G)}
+
+/-- The finite set of double cosets appearing in the product `D₁ * D₂`. -/
+noncomputable def mulSupport (g₁ g₂ : P.Δ) : Finset (HeckeCoset P) :=
+  Finset.image (mulMap P g₁ g₂) ⊤
+
+/-- If `σᵢ τⱼ H = ξ H` then the double coset of `σᵢ τⱼ` equals that of `ξ`. -/
+lemma doubleCoset_eq_of_rightCoset_eq (g₁ g₂ d : P.Δ)
+    (p : decompQuot P g₁ × decompQuot P g₂)
+    (heq : ({(p.1.out : G) * (g₁ : G)} : Set G) * {(p.2.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G)) :
+    mulMap P g₁ g₂ p = (⟦d⟧ : HeckeCoset P) := by
+  unfold mulMap
+  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
+  rw [HeckeCoset.eq_iff]
+  have h_mem : (p.1.out : G) * (g₁ : G) * ((p.2.out : G) * (g₂ : G)) ∈
+      ({(d : G)} : Set G) * (P.H : Set G) := by
+    rw [← heq, Set.singleton_mul_singleton]
+    exact ⟨_, rfl, 1, P.H.one_mem, by simp⟩
+  obtain ⟨_, hd_eq, h, hh, hprod⟩ := h_mem
+  simp only [Set.mem_singleton_iff] at hd_eq
+  subst hd_eq
+  dsimp only at hprod ⊢
+  rw [← hprod]
+  exact doubleCoset_mul_right_eq_self P ⟨h, hh⟩ _
+
+/-- Left multiplication by a singleton set is cancellative. -/
+lemma set_singleton_mul_left_cancel (a : G) {S T : Set G}
+    (h : ({a} : Set G) * S = ({a} : Set G) * T) : S = T := by
+  rw [Set.singleton_mul, Set.singleton_mul] at h
+  exact Set.image_injective.mpr (mul_right_injective a) h
+
+/-- When the first-component representatives agree, the second-component
+representatives must also agree (by left-cancellation on the common prefix). -/
+lemma decompQuot_snd_eq_of_fst_eq (g₁ g₂ d : P.Δ) (i : decompQuot P g₁)
+    (j₁ j₂ : decompQuot P g₂)
+    (h₁ : ({(i.out : G) * (g₁ : G)} : Set G) * {(j₁.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G))
+    (h₂ : ({(i.out : G) * (g₁ : G)} : Set G) * {(j₂.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G)) :
+    j₁ = j₂ := by
+  by_contra hne
+  refine decompQuot_coset_diff P g₂ j₁ j₂ hne
+    (set_singleton_mul_left_cancel ((i.out : G) * (g₁ : G)) ?_)
+  have := h₁.trans h₂.symm
+  rwa [mul_assoc, mul_assoc] at this
+
+/-- When `j.out * g₂ ∈ H`, the second factor collapses and
+first-component injectivity follows from coset disjointness. -/
+lemma decompQuot_fst_eq_of_snd_mem_H (g₁ g₂ d : P.Δ) (i₁ i₂ : decompQuot P g₁)
+    (j : decompQuot P g₂) (hj : (j.out : G) * (g₂ : G) ∈ P.H)
+    (h₁ : ({(i₁.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G))
+    (h₂ : ({(i₂.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
+      {(d : G)} * (P.H : Set G)) :
+    i₁ = i₂ := by
+  by_contra hne
+  refine decompQuot_coset_diff P g₁ i₁ i₂ hne ?_
+  simp only [mul_assoc, Subgroup.singleton_mul_subgroup hj] at h₁ h₂
+  exact h₁.trans h₂.symm
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -14,14 +14,16 @@ Shimura's multiplicity (Proposition 3.2 of [Shimura][shimura1971]) counts, for d
 `Γ₁gΓ₂`, `Γ₂hΓ₃` and `Γ₁dΓ₃`, the pairs of left-coset representatives `(σᵢ, τⱼ)` with
 `σᵢ g τⱼ h Γ₃ = d Γ₃`. These natural numbers are the structure constants of the Hecke product
 defined in later files: the diagonal case `Γ₁ = Γ₂ = Γ₃` gives the multiplication of the Hecke
-ring, and the general case gives the composition of Hecke bimodules. This file defines the
-multiplicity, the map `mulMap` sending a pair of representatives to the double coset of their
-product, and the uniqueness lemmas for the fibres of the multiplicity.
+ring, and the general case gives the composition of Hecke coset modules between different
+levels. This file defines the multiplicity, the map `mulMap` sending a pair of representatives
+to the mixed double coset of their product, and the uniqueness lemmas for the fibres of the
+multiplicity.
 
 ## Main definitions
 
 * `DoubleCoset.multiplicity`: Shimura's multiplicity, a natural number structure constant.
-* `HeckePair.mulMap`: the double coset `H (σᵢ g₁ τⱼ g₂) H` of a pair of coset representatives.
+* `HeckeCoset.mulMap`: the double coset `H₁ (σᵢ g₁ τⱼ g₂) H₃` of a pair of coset
+  representatives.
 -/
 
 @[expose] public section
@@ -85,29 +87,29 @@ lemma fst_eq_of_mul_snd_mem {Γ₁ Γ₂ : Subgroup G} {g h d : G} {i₁ i₂ : 
 
 end DoubleCoset
 
-namespace HeckePair
+namespace HeckeCoset
 
 open DoubleCoset
 
-variable {G : Type*} [Group G] (P : HeckePair G)
+variable {G : Type*} [Group G] {Δ : Submonoid G}
 
-attribute [local instance] HeckePair.doubleCosetSetoid
+/-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the mixed double coset
+`H₁ (σᵢ g₁ τⱼ g₂) H₃` of their product. -/
+noncomputable def mulMap (H₁ H₂ H₃ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂]
+    [IsHeckeCosetModule Δ H₂ H₃] (g₁ g₂ : Δ)
+    (p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)) : HeckeCoset Δ H₁ H₃ :=
+  mk H₁ H₃ ⟨(p.1.out : G) * g₁ * ((p.2.out : G) * g₂),
+    Δ.mul_mem (Δ.mul_mem (IsHeckeCosetModule.mem_left H₂ p.1.out.2) g₁.2)
+      (Δ.mul_mem (IsHeckeCosetModule.mem_left H₃ p.2.out.2) g₂.2)⟩
 
-/-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the double coset
-of their product `H (σᵢ g₁ τⱼ g₂) H`. -/
-noncomputable def mulMap (g₁ g₂ : P.Δ)
-    (p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H (g₂ : G)) : HeckeCoset P :=
-  ⟦⟨(p.1.out : G) * g₁ * ((p.2.out : G) * g₂),
-    P.Δ.mul_mem (P.Δ.mul_mem (P.subgroup_le p.1.out.2) g₁.2)
-      (P.Δ.mul_mem (P.subgroup_le p.2.out.2) g₂.2)⟩⟧
-
-/-- If `σᵢ g₁ τⱼ g₂ H = d H` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`. -/
-lemma mulMap_eq_of_mk_eq {g₁ g₂ d : P.Δ}
-    {p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H (g₂ : G)}
-    (h : ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ P.H) = ((d : G) : G ⧸ P.H)) :
-    P.mulMap g₁ g₂ p = (⟦d⟧ : HeckeCoset P) := by
+/-- If `σᵢ g₁ τⱼ g₂ H₃ = d H₃` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`. -/
+lemma mulMap_eq_of_mk_eq {H₁ H₂ H₃ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
+    [IsHeckeCosetModule Δ H₂ H₃] {g₁ g₂ d : Δ}
+    {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)}
+    (h : ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ H₃) = ((d : G) : G ⧸ H₃)) :
+    mulMap H₁ H₂ H₃ g₁ g₂ p = mk H₁ H₃ d := by
   rw [QuotientGroup.eq] at h
   exact HeckeCoset.mk_eq_mk_of_mem (DoubleCoset.mem_doubleCoset.mpr
-    ⟨1, P.H.one_mem, _, P.H.inv_mem h, by rw [one_mul, mul_inv_rev, inv_inv, mul_inv_cancel_left]⟩)
+    ⟨1, H₁.one_mem, _, H₃.inv_mem h, by rw [one_mul, mul_inv_rev, inv_inv, mul_inv_cancel_left]⟩)
 
-end HeckePair
+end HeckeCoset

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -95,16 +95,16 @@ variable {G : Type*} [Group G] {Δ : Submonoid G}
 
 /-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the mixed double coset
 `H₁ (σᵢ g₁ τⱼ g₂) H₃` of their product. -/
-noncomputable def mulMap (H₁ H₂ H₃ : Subgroup G) [IsHeckeCosetModule Δ H₁ H₂]
-    [IsHeckeCosetModule Δ H₂ H₃] (g₁ g₂ : Δ)
+noncomputable def mulMap (H₁ H₂ H₃ : Subgroup G) [IsHeckeTriple Δ H₁ H₂]
+    [IsHeckeTriple Δ H₂ H₃] (g₁ g₂ : Δ)
     (p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)) : HeckeCoset Δ H₁ H₃ :=
   mk H₁ H₃ ⟨(p.1.out : G) * g₁ * ((p.2.out : G) * g₂),
-    Δ.mul_mem (Δ.mul_mem (IsHeckeCosetModule.mem_left H₂ p.1.out.2) g₁.2)
-      (Δ.mul_mem (IsHeckeCosetModule.mem_left H₃ p.2.out.2) g₂.2)⟩
+    Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_left H₂ p.1.out.2) g₁.2)
+      (Δ.mul_mem (IsHeckeTriple.mem_left H₃ p.2.out.2) g₂.2)⟩
 
 /-- If `σᵢ g₁ τⱼ g₂ H₃ = d H₃` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`. -/
-lemma mulMap_eq_of_mk_eq {H₁ H₂ H₃ : Subgroup G} [IsHeckeCosetModule Δ H₁ H₂]
-    [IsHeckeCosetModule Δ H₂ H₃] {g₁ g₂ d : Δ}
+lemma mulMap_eq_of_mk_eq {H₁ H₂ H₃ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]
+    [IsHeckeTriple Δ H₂ H₃] {g₁ g₂ d : Δ}
     {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)}
     (h : ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ H₃) = ((d : G) : G ⧸ H₃)) :
     mulMap H₁ H₂ H₃ g₁ g₂ p = mk H₁ H₃ d := by

--- a/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Multiplicity.lean
@@ -10,185 +10,104 @@ public import Mathlib.NumberTheory.HeckeRing.Basic
 /-!
 # Hecke rings: the multiplicity function
 
-Shimura's multiplicity `heckeMultiplicity` (Proposition 3.2 of *Introduction to the Arithmetic
-Theory of Automorphic Functions*) counts, for double cosets `Hg₁H`, `Hg₂H` and `HdH`, the pairs of
-left-coset representatives `(σᵢ, τⱼ)` with `σᵢ τⱼ H = d H`. These integers are the structure
-constants of the Hecke product defined in later files. This file sets up the multiplicity, the map
-`mulMap` on pairs of representatives, and the structural lemmas on the coset decomposition.
+Shimura's multiplicity (Proposition 3.2 of [Shimura][shimura1971]) counts, for double cosets
+`Γ₁gΓ₂`, `Γ₂hΓ₃` and `Γ₁dΓ₃`, the pairs of left-coset representatives `(σᵢ, τⱼ)` with
+`σᵢ g τⱼ h Γ₃ = d Γ₃`. These natural numbers are the structure constants of the Hecke product
+defined in later files: the diagonal case `Γ₁ = Γ₂ = Γ₃` gives the multiplication of the Hecke
+ring, and the general case gives the composition of Hecke bimodules. This file defines the
+multiplicity, the map `mulMap` sending a pair of representatives to the double coset of their
+product, and the uniqueness lemmas for the fibres of the multiplicity.
 
 ## Main definitions
 
-* `HeckeRing.mulMap`: the double coset `H(σᵢ τⱼ)H` of a pair of coset representatives.
-* `HeckeRing.heckeMultiplicity`: Shimura's multiplicity, an integer structure constant.
-* `HeckeRing.mulSupport`: the finite set of double cosets appearing in a product.
+* `DoubleCoset.multiplicity`: Shimura's multiplicity, a natural number structure constant.
+* `HeckePair.mulMap`: the double coset `H (σᵢ g₁ τⱼ g₂) H` of a pair of coset representatives.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup
+open Subgroup
 open scoped Pointwise
 
-namespace HeckeRing
+namespace DoubleCoset
 
-variable {G : Type*} [Group G] (H : Subgroup G) (Δ : Submonoid G) (P : HeckePair G)
+variable {G : Type*} [Group G]
 
-attribute [local instance] doubleCosetSetoid
-
-/-- Two `HeckeCoset` elements are equal iff their `toSet`s are equal. -/
-lemma HeckeCoset_ext_toSet {D₁ D₂ : HeckeCoset P}
-    (h : HeckeCoset.toSet D₁ = HeckeCoset.toSet D₂) : D₁ = D₂ := by
-  revert h
-  refine Quotient.ind₂ (motive := fun D₁ D₂ ↦
-    HeckeCoset.toSet D₁ = HeckeCoset.toSet D₂ → D₁ = D₂)
-    (fun g₁ g₂ h ↦ ?_) D₁ D₂
-  simp only [HeckeCoset.toSet_mk] at h
-  exact Quotient.sound h
-
-/-- The stabilizer quotient for the identity double coset is trivial. -/
-lemma decompQuot_one_eq_top :
-    (ConjAct.toConjAct ((HeckeCoset.one P).rep : G) • P.H).subgroupOf P.H = ⊤ := by
-  have h := HeckeCoset.one_rep_mem_H P
-  rw [Subgroup.subgroupOf_eq_top]
-  intro x hx
-  rw [← @SetLike.mem_coe]
-  simp only [Subgroup.coe_pointwise_smul]
-  rw [conjAct_smul_coe_eq, Subgroup.singleton_mul_subgroup h,
-    Subgroup.subgroup_mul_singleton (by simp [h])]
-  exact hx
-
-/-- The decomposition quotient for `HeckeCoset.one` is nonempty. -/
-lemma one_in_decompQuot_one :
-    Nonempty (decompQuot P (HeckeCoset.one P).rep) :=
-  ⟨(1 : P.H)⟩
-
-/-- The decomposition quotient for `HeckeCoset.one` is a subsingleton. -/
-lemma subsingleton_decompQuot_one :
-    Subsingleton (decompQuot P (HeckeCoset.one P).rep) := by
-  unfold decompQuot
-  rw [decompQuot_one_eq_top]
+lemma subsingleton_decompQuotient {Γ₁ Γ₂ : Subgroup G} {g : G}
+    (h : Γ₁ ≤ ConjAct.toConjAct g • Γ₂) : Subsingleton (DecompQuotient Γ₁ Γ₂ g) := by
+  change Subsingleton (Γ₁ ⧸ (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁)
+  rw [Subgroup.subgroupOf_eq_top.mpr h]
   exact QuotientGroup.subsingleton_quotient_top
 
-private lemma conjAct_mem_of_leftCoset_eq (d : Δ) (h h' : H)
-    (hyp : {(h : G)} * {(d : G)} * (H : Set G) =
-      {(h' : G)} * {(d : G)} * (H : Set G)) :
-    (h')⁻¹ * h ∈ (ConjAct.toConjAct (d : G) • H).subgroupOf H := by
-  have h_mem_lhs : (h : G) * (d : G) ∈ {(h : G)} * {(d : G)} * (H : Set G) := by
-    rw [Set.singleton_mul_singleton]
-    exact ⟨(h : G) * (d : G), Set.mem_singleton _, 1, H.one_mem, by simp⟩
-  rw [hyp, Set.singleton_mul_singleton] at h_mem_lhs
-  obtain ⟨_, rfl, k, hk, hkk⟩ := h_mem_lhs
-  have hkk' : ↑h' * ↑d * k = ↑h * ↑d := hkk
-  have key : (h' : G)⁻¹ * (h : G) = (d : G) * k * (d : G)⁻¹ := by
-    apply mul_right_cancel (b := (d : G))
-    rw [mul_assoc, mul_assoc, inv_mul_cancel, mul_one]
-    apply mul_left_cancel (a := (h' : G))
-    rw [mul_inv_cancel_left, ← mul_assoc]
-    exact hkk'.symm
-  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
-    ConjAct.smul_def]
-  simp only [map_inv, ConjAct.ofConjAct_toConjAct, Subgroup.coe_mul,
-    Subgroup.coe_inv]
-  rw [inv_inv, key]
-  simp only [mul_assoc, inv_mul_cancel, mul_one, inv_mul_cancel_left]
-  exact hk
+lemma subsingleton_decompQuotient_of_mem {Γ : Subgroup G} {g : G} (hg : g ∈ Γ) :
+    Subsingleton (DecompQuotient Γ Γ g) :=
+  subsingleton_decompQuotient
+    (Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hg)).ge
 
-/-- Distinct elements of `decompQuot` give distinct left cosets. -/
-lemma decompQuot_coset_diff (g : P.Δ) (i j : decompQuot P g) (hij : i ≠ j) :
-    {((i.out : G) * (g : G))} * (P.H : Set G) ≠ {((j.out : G) * (g : G))} * (P.H : Set G) := by
-  intro h
-  simp_rw [← Set.singleton_mul_singleton] at h
-  have := conjAct_mem_of_leftCoset_eq P.H P.Δ g i.out j.out h
-  rw [← @QuotientGroup.leftRel_apply, ← @Quotient.eq''] at this
-  simp only [Quotient.out_eq'] at this
-  exact hij this.symm
+/-- The left cosets `σᵢ g Γ₂` of the decomposition of `Γ₁gΓ₂` are pairwise distinct: the map
+`i ↦ σᵢ g Γ₂` into `G ⧸ Γ₂` is injective. -/
+lemma mk_out_mul_injective (Γ₁ Γ₂ : Subgroup G) (g : G) :
+    Function.Injective fun i : DecompQuotient Γ₁ Γ₂ g ↦ (((i.out : G) * g : G) : G ⧸ Γ₂) := by
+  intro i j hij
+  simp only [QuotientGroup.eq] at hij
+  rw [← QuotientGroup.out_eq' i, ← QuotientGroup.out_eq' j, QuotientGroup.eq,
+    Subgroup.mem_subgroupOf, Subgroup.mem_conjAct_pointwise_smul_iff]
+  simpa [mul_assoc] using hij
 
-/-- Two left cosets that are not disjoint must be equal. -/
-lemma leftCoset_eq_of_not_disjoint (f g : G)
-    (h : ¬ Disjoint (g • (H : Set G)) (f • H)) :
-    {g} * (H : Set G) = {f} * H := by
-  simp_rw [← Set.singleton_smul] at *
-  rw [not_disjoint_iff] at h
-  obtain ⟨a, ha, ha2⟩ := h
-  simp only [smul_eq_mul, singleton_mul, image_mul_left, mem_preimage,
-    SetLike.mem_coe] at ha ha2
-  ext Y
-  simp only [singleton_mul, image_mul_left, mem_preimage, SetLike.mem_coe]
-  simp_rw [← QuotientGroup.eq] at *
-  rw [← ha] at ha2
-  rw [ha2]
+/-- Shimura's multiplicity (Proposition 3.2 of [Shimura][shimura1971]): the number of pairs
+`(i, j)` of coset representatives such that `σᵢ g τⱼ h Γ₃ = d Γ₃`. The diagonal case
+`Γ₁ = Γ₂ = Γ₃` gives the structure constants of the Hecke ring. -/
+noncomputable def multiplicity (Γ₁ Γ₂ Γ₃ : Subgroup G) (g h d : G) : ℕ :=
+  Nat.card {p : DecompQuotient Γ₁ Γ₂ g × DecompQuotient Γ₂ Γ₃ h |
+    ((p.1.out : G) * g * ((p.2.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃)}
+
+/-- When the first components of two pairs in the fibre of the multiplicity agree, the second
+components agree. -/
+lemma snd_eq_of_fst_eq {Γ₁ Γ₂ Γ₃ : Subgroup G} {g h d : G} {i : DecompQuotient Γ₁ Γ₂ g}
+    {j₁ j₂ : DecompQuotient Γ₂ Γ₃ h}
+    (h₁ : ((i.out : G) * g * ((j₁.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃))
+    (h₂ : ((i.out : G) * g * ((j₂.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃)) :
+    j₁ = j₂ := by
+  refine mk_out_mul_injective Γ₂ Γ₃ h ?_
+  have h := h₁.trans h₂.symm
+  rw [QuotientGroup.eq] at h ⊢
+  simpa [mul_assoc] using h
+
+/-- When the common second component of two pairs in the fibre of the multiplicity satisfies
+`τⱼ h ∈ Γ₂`, the first components agree. -/
+lemma fst_eq_of_mul_snd_mem {Γ₁ Γ₂ : Subgroup G} {g h d : G} {i₁ i₂ : DecompQuotient Γ₁ Γ₂ g}
+    {j : DecompQuotient Γ₂ Γ₂ h} (hj : (j.out : G) * h ∈ Γ₂)
+    (h₁ : ((i₁.out : G) * g * ((j.out : G) * h) : G ⧸ Γ₂) = (d : G ⧸ Γ₂))
+    (h₂ : ((i₂.out : G) * g * ((j.out : G) * h) : G ⧸ Γ₂) = (d : G ⧸ Γ₂)) :
+    i₁ = i₂ := by
+  rw [QuotientGroup.mk_mul_of_mem _ hj] at h₁ h₂
+  exact mk_out_mul_injective Γ₁ Γ₂ g (h₁.trans h₂.symm)
+
+end DoubleCoset
+
+namespace HeckePair
+
+open DoubleCoset
+
+variable {G : Type*} [Group G] (P : HeckePair G)
+
+attribute [local instance] HeckePair.doubleCosetSetoid
 
 /-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the double coset
-of their product `H(σᵢ τⱼ)H`. -/
-noncomputable def mulMap (g₁ g₂ : P.Δ) (i : decompQuot P g₁ × decompQuot P g₂) :
-    HeckeCoset P :=
-  ⟦⟨i.1.out * g₁ * (i.2.out * g₂),
-    Submonoid.mul_mem _ (Submonoid.mul_mem _ (P.h₀ i.1.out.2) g₁.2)
-      (Submonoid.mul_mem _ (P.h₀ i.2.out.2) g₂.2)⟩⟧
+of their product `H (σᵢ g₁ τⱼ g₂) H`. -/
+noncomputable def mulMap (g₁ g₂ : P.Δ)
+    (p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H (g₂ : G)) : HeckeCoset P :=
+  ⟦⟨(p.1.out : G) * g₁ * ((p.2.out : G) * g₂),
+    P.Δ.mul_mem (P.Δ.mul_mem (P.subgroup_le p.1.out.2) g₁.2)
+      (P.Δ.mul_mem (P.subgroup_le p.2.out.2) g₂.2)⟩⟧
 
-/-- Shimura's multiplicity (Proposition 3.2): `heckeMultiplicity g₁ g₂ d` counts pairs
-`(i, j)` such that `σᵢ τⱼ H = ξ H`. -/
-noncomputable def heckeMultiplicity (g₁ g₂ d : P.Δ) : ℤ :=
-  Nat.card {⟨i, j⟩ : decompQuot P g₁ × decompQuot P g₂ |
-    ({(i.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G)}
+/-- If `σᵢ g₁ τⱼ g₂ H = d H` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`. -/
+lemma mulMap_eq_of_mk_eq {g₁ g₂ d : P.Δ}
+    {p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H (g₂ : G)}
+    (h : ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ P.H) = ((d : G) : G ⧸ P.H)) :
+    P.mulMap g₁ g₂ p = (⟦d⟧ : HeckeCoset P) := by
+  rw [QuotientGroup.eq] at h
+  exact HeckeCoset.mk_eq_mk_of_mem (DoubleCoset.mem_doubleCoset.mpr
+    ⟨1, P.H.one_mem, _, P.H.inv_mem h, by rw [one_mul, mul_inv_rev, inv_inv, mul_inv_cancel_left]⟩)
 
-/-- The finite set of double cosets appearing in the product `D₁ * D₂`. -/
-noncomputable def mulSupport (g₁ g₂ : P.Δ) : Finset (HeckeCoset P) :=
-  Finset.image (mulMap P g₁ g₂) ⊤
-
-/-- If `σᵢ τⱼ H = ξ H` then the double coset of `σᵢ τⱼ` equals that of `ξ`. -/
-lemma doubleCoset_eq_of_rightCoset_eq (g₁ g₂ d : P.Δ)
-    (p : decompQuot P g₁ × decompQuot P g₂)
-    (heq : ({(p.1.out : G) * (g₁ : G)} : Set G) * {(p.2.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G)) :
-    mulMap P g₁ g₂ p = (⟦d⟧ : HeckeCoset P) := by
-  unfold mulMap
-  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
-  rw [HeckeCoset.eq_iff]
-  have h_mem : (p.1.out : G) * (g₁ : G) * ((p.2.out : G) * (g₂ : G)) ∈
-      ({(d : G)} : Set G) * (P.H : Set G) := by
-    rw [← heq, Set.singleton_mul_singleton]
-    exact ⟨_, rfl, 1, P.H.one_mem, by simp⟩
-  obtain ⟨_, hd_eq, h, hh, hprod⟩ := h_mem
-  simp only [Set.mem_singleton_iff] at hd_eq
-  subst hd_eq
-  dsimp only at hprod ⊢
-  rw [← hprod]
-  exact doubleCoset_mul_right_eq_self P ⟨h, hh⟩ _
-
-/-- Left multiplication by a singleton set is cancellative. -/
-lemma set_singleton_mul_left_cancel (a : G) {S T : Set G}
-    (h : ({a} : Set G) * S = ({a} : Set G) * T) : S = T := by
-  rw [Set.singleton_mul, Set.singleton_mul] at h
-  exact Set.image_injective.mpr (mul_right_injective a) h
-
-/-- When the first-component representatives agree, the second-component
-representatives must also agree (by left-cancellation on the common prefix). -/
-lemma decompQuot_snd_eq_of_fst_eq (g₁ g₂ d : P.Δ) (i : decompQuot P g₁)
-    (j₁ j₂ : decompQuot P g₂)
-    (h₁ : ({(i.out : G) * (g₁ : G)} : Set G) * {(j₁.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G))
-    (h₂ : ({(i.out : G) * (g₁ : G)} : Set G) * {(j₂.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G)) :
-    j₁ = j₂ := by
-  by_contra hne
-  refine decompQuot_coset_diff P g₂ j₁ j₂ hne
-    (set_singleton_mul_left_cancel ((i.out : G) * (g₁ : G)) ?_)
-  have := h₁.trans h₂.symm
-  rwa [mul_assoc, mul_assoc] at this
-
-/-- When `j.out * g₂ ∈ H`, the second factor collapses and
-first-component injectivity follows from coset disjointness. -/
-lemma decompQuot_fst_eq_of_snd_mem_H (g₁ g₂ d : P.Δ) (i₁ i₂ : decompQuot P g₁)
-    (j : decompQuot P g₂) (hj : (j.out : G) * (g₂ : G) ∈ P.H)
-    (h₁ : ({(i₁.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G))
-    (h₂ : ({(i₂.out : G) * (g₁ : G)} : Set G) * {(j.out : G) * (g₂ : G)} * P.H =
-      {(d : G)} * (P.H : Set G)) :
-    i₁ = i₂ := by
-  by_contra hne
-  refine decompQuot_coset_diff P g₁ i₁ i₂ hne ?_
-  simp only [mul_assoc, Subgroup.singleton_mul_subgroup hj] at h₁ h₂
-  exact h₁.trans h₂.symm
-
-end HeckeRing
+end HeckePair

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
@@ -8,169 +8,112 @@ module
 public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
 
 /-!
-# Hecke rings: positivity of the multiplicity on the product support
+# Hecke rings: the support of the multiplicity
 
-The product `D₁ * D₂` of two double cosets is supported on the finite set `mulSupport`. This file
-relates membership of `mulSupport` to positivity of Shimura's multiplicity: `heckeMultiplicity` is
-positive exactly on the double cosets that occur in the product, and zero off the support.
+Shimura's multiplicity `m(g, h; d)` is nonzero exactly when `d` lies in the product set
+`Γ₁gΓ₂hΓ₃` of the two double cosets. For a Hecke pair this identifies the support of the
+structure constants of the Hecke product with the image of `HeckePair.mulMap`, which is a
+finite set; this is what makes the convolution product of the Hecke ring well-defined in the
+next file.
 
 ## Main results
 
-* `HeckeRing.heckeMultiplicity_pos_of_mem`: the multiplicity is positive on the support.
-* `HeckeRing.heckeMultiplicity_eq_zero_of_nmem_mulSupport`: zero off the support.
-* `HeckeRing.mem_mulSupport_of_product_mem`: a product in `HdH` witnesses membership.
+* `DoubleCoset.multiplicity_ne_zero_iff`: `m(g, h; d) ≠ 0 ↔ d ∈ Γ₁gΓ₂hΓ₃`.
+* `HeckePair.mem_image_mulMap_iff`: the support of the structure constants at `(g₁, g₂)` is the
+  image of `mulMap`.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup
+open Subgroup
 open scoped Pointwise
 
-namespace HeckeRing
+namespace DoubleCoset
 
-variable {G : Type*} [Group G]
+variable {G : Type*} [Group G] {Γ₁ Γ₂ Γ₃ : Subgroup G}
 
-attribute [local instance] doubleCosetSetoid
+/-- Shimura's multiplicity `m(g, h; d)` is nonzero exactly when `d` lies in the product set
+`Γ₁gΓ₂hΓ₃` of the double cosets of `g` and `h`. -/
+theorem multiplicity_ne_zero_iff {g h d : G} [Finite (DecompQuotient Γ₁ Γ₂ g)]
+    [Finite (DecompQuotient Γ₂ Γ₃ h)] :
+    multiplicity Γ₁ Γ₂ Γ₃ g h d ≠ 0 ↔ d ∈ doubleCoset h (doubleCoset g Γ₁ Γ₂) Γ₃ := by
+  rw [multiplicity, Nat.card_ne_zero]
+  constructor
+  · rintro ⟨⟨p, hp⟩, -⟩
+    have hp' : _ = (d : G ⧸ Γ₃) := hp
+    rw [QuotientGroup.eq] at hp'
+    refine mem_doubleCoset.mpr ⟨(p.1.out : G) * g * p.2.out,
+      mem_doubleCoset.mpr ⟨p.1.out, p.1.out.2, p.2.out, p.2.out.2, rfl⟩, _, hp', ?_⟩
+    simp [mul_assoc]
+  · intro hd
+    refine ⟨?_, inferInstance⟩
+    obtain ⟨w, hw, k, hk, rfl⟩ := mem_doubleCoset.mp hd
+    rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hw
+    obtain ⟨i, hi⟩ := hw
+    rw [mem_leftCoset_iff] at hi
+    have hch : (((i.out : G) * g)⁻¹ * w) * h ∈ doubleCoset h Γ₂ Γ₃ :=
+      mem_doubleCoset.mpr ⟨_, hi, 1, Γ₃.one_mem, by rw [mul_one]⟩
+    rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hch
+    obtain ⟨j, hj⟩ := hch
+    rw [mem_leftCoset_iff] at hj
+    refine ⟨⟨(i, j), ?_⟩⟩
+    rw [Set.mem_setOf_eq, QuotientGroup.eq]
+    have : ((i.out : G) * g * ((j.out : G) * h))⁻¹ * (w * h * k) =
+        (((j.out : G) * h)⁻¹ * ((((i.out : G) * g)⁻¹ * w) * h)) * k := by
+      simp [mul_assoc]
+    rw [this]
+    exact Γ₃.mul_mem hj hk
 
-variable (P : HeckePair G)
+end DoubleCoset
 
-/-- If the double coset of `σ_{i₀} τ_{j₀}` equals `HcH`, then the fibre defining the multiplicity
-at `c` is nonempty: some pair of representatives multiplies into the right coset `cH`. -/
-private lemma nonempty_witness_of_doubleCoset_eq (g₁ g₂ : P.Δ) (c : G)
-    (i₀ : decompQuot P g₁) (j₀ : decompQuot P g₂)
-    (hset_eq : DoubleCoset.doubleCoset
-      ((↑i₀.out : G) * (↑g₁ : G) * ((↑j₀.out : G) * (↑g₂ : G)))
-      (P.H : Set G) (P.H : Set G) =
-      DoubleCoset.doubleCoset c P.H P.H) :
-    Nonempty ↑{x : decompQuot P g₁ × decompQuot P g₂ |
-      ({(↑x.1.out : G) * (↑g₁ : G)} : Set G) *
-        {(↑x.2.out : G) * (↑g₂ : G)} * P.H = {c} * (P.H : Set G)} := by
-  obtain ⟨h₁, hh₁, h₂, hh₂, hprod⟩ := (DoubleCoset.eq P.H P.H _ _).mp
-    (DoubleCoset.mk_eq_of_doubleCoset_eq hset_eq)
-  set α := (↑g₁ : G)
-  set β := (↑g₂ : G)
-  set K₁ := (ConjAct.toConjAct α • P.H).subgroupOf P.H
-  set i' : decompQuot P g₁ := ⟦⟨h₁ * ↑i₀.out, P.H.mul_mem hh₁ i₀.out.2⟩⟧
-  obtain ⟨κ₁, hκ₁_eq⟩ := QuotientGroup.mk_out_eq_mul K₁
-    ⟨h₁ * ↑i₀.out, P.H.mul_mem hh₁ i₀.out.2⟩
-  have hκ₁_conj : α⁻¹ * (κ₁.val : G) * α ∈ P.H :=
-    inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) κ₁
-  set K₂ := (ConjAct.toConjAct β • P.H).subgroupOf P.H
-  set j' : decompQuot P g₂ := ⟦⟨(α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out,
-    P.H.mul_mem (P.H.inv_mem hκ₁_conj) j₀.out.2⟩⟧
-  obtain ⟨κ₂, hκ₂_eq⟩ := QuotientGroup.mk_out_eq_mul K₂
-    ⟨(α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out,
-      P.H.mul_mem (P.H.inv_mem hκ₁_conj) j₀.out.2⟩
-  have hκ₂_conj : β⁻¹ * (κ₂.val : G) * β ∈ P.H :=
-    inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) κ₂
-  have hi'_coe : (↑i'.out : G) = h₁ * ↑i₀.out * (κ₁.val : G) := by
-    have := congr_arg (Subtype.val : P.H → G) hκ₁_eq
-    simpa [Subgroup.coe_mul] using this
-  have hj'_coe : (↑j'.out : G) =
-      (α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out * (κ₂.val : G) := by
-    have h := hκ₂_eq
-    apply_fun (↑· : ↥P.H → G) at h
-    simp only [Subgroup.coe_mul] at h
-    exact h
-  refine ⟨⟨(i', j'), ?_⟩⟩
-  simp only [Set.mem_setOf_eq]
-  have hprod_main : (↑i'.out : G) * α * ((↑j'.out : G) * β) =
-      c * (h₂⁻¹ * (β⁻¹ * (κ₂.val : G) * β)) := by
-    rw [hi'_coe, hj'_coe]
-    have hprod' : c = h₁ * (↑i₀.out * α * (↑j₀.out * β)) * h₂ := hprod
-    rw [hprod']
-    group
-  rw [Set.singleton_mul_singleton, hprod_main, ← Set.singleton_mul_singleton, mul_assoc,
-    Subgroup.singleton_mul_subgroup (P.H.mul_mem (P.H.inv_mem hh₂) hκ₂_conj)]
+namespace HeckePair
 
-/-- The multiplicity is nonzero for double cosets in the product support. -/
-lemma heckeMultiplicity_pos_of_mem_mulSupport (g₁ g₂ : P.Δ) (d : HeckeCoset P)
-    (hd : d ∈ mulSupport P g₁ g₂) :
-    heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) ≠ 0 := by
-  rw [heckeMultiplicity]
-  simp only [ne_eq, Nat.cast_eq_zero]
-  rw [Nat.card_eq_zero, not_or, not_isEmpty_iff]
-  refine ⟨?_, not_infinite_iff_finite.mpr inferInstance⟩
-  rw [mulSupport] at hd
-  simp only [Finset.top_eq_univ, Finset.mem_image, Finset.mem_univ, true_and,
-    Prod.exists] at hd
-  obtain ⟨i₀, j₀, hmap⟩ := hd
-  exact nonempty_witness_of_doubleCoset_eq P g₁ g₂ (HeckeCoset.rep d) i₀ j₀
-    ((HeckeCoset.eq_iff _ _).mp (hmap.trans (Quotient.out_eq d).symm))
+open DoubleCoset
 
-/-- The multiplicity is zero for double cosets outside the product support. -/
-lemma heckeMultiplicity_eq_zero_of_nmem_mulSupport (g₁ g₂ : P.Δ) (d : HeckeCoset P)
-    (hd : d ∉ mulSupport P g₁ g₂) :
-    heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) = 0 := by
-  simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
-  left
-  rintro ⟨i, j⟩ hij
-  refine hd ?_
-  rw [mulSupport]
-  simp only [Finset.top_eq_univ, Finset.mem_image, Finset.mem_univ, true_and, Prod.exists]
-  exact ⟨i, j, (doubleCoset_eq_of_rightCoset_eq P g₁ g₂ (HeckeCoset.rep d) (i, j) hij).trans
-    (Quotient.out_eq d)⟩
+variable {G : Type*} [Group G] (P : HeckePair G)
 
-/-- A multiplicity that is both at most one and positive must equal one. -/
-lemma heckeMultiplicity_eq_one_of_le_one_and_pos (g₁ g₂ d : P.Δ)
-    (h_le : heckeMultiplicity P g₁ g₂ d ≤ 1)
-    (h_pos : 0 < heckeMultiplicity P g₁ g₂ d) :
-    heckeMultiplicity P g₁ g₂ d = 1 := by omega
+attribute [local instance] HeckePair.doubleCosetSetoid
 
-/-- The multiplicity is positive for double cosets in the product support. -/
-lemma heckeMultiplicity_pos_of_mem (g₁ g₂ : P.Δ) (d : HeckeCoset P)
-    (hd : d ∈ mulSupport P g₁ g₂) :
-    0 < heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) := by
-  have h_ne := heckeMultiplicity_pos_of_mem_mulSupport P g₁ g₂ d hd
-  have h_nonneg : (0 : ℤ) ≤ heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) := by
-    simp only [heckeMultiplicity]
-    exact_mod_cast Nat.zero_le _
-  exact lt_of_le_of_ne h_nonneg (Ne.symm h_ne)
+/-- The support of the structure constants of the Hecke product at `(g₁, g₂)` is the image
+of `HeckePair.mulMap`: the multiplicity of a double coset `D` in the product `Hg₁H * Hg₂H` is
+nonzero exactly when `D` is the double coset of `σᵢ g₁ τⱼ g₂` for some pair of coset
+representatives. -/
+theorem mem_image_mulMap_iff [DecidableEq (HeckeCoset P)] (g₁ g₂ : P.Δ) (D : HeckeCoset P) :
+    D ∈ Finset.univ.image (P.mulMap g₁ g₂) ↔
+      multiplicity P.H P.H P.H (g₁ : G) (g₂ : G) (D.rep : G) ≠ 0 := by
+  rw [multiplicity_ne_zero_iff]
+  constructor
+  · intro hD
+    simp only [Finset.mem_image, Finset.mem_univ, true_and] at hD
+    obtain ⟨p, hp⟩ := hD
+    have hrep : (D.rep : G) ∈
+        doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) P.H P.H := by
+      rw [show doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) P.H P.H =
+          doubleCoset (D.rep : G) P.H P.H from HeckeCoset.eq_iff.mp (hp.trans D.mk_rep.symm)]
+      exact mem_doubleCoset_self P.H P.H _
+    obtain ⟨h₁, hh₁, h₂, hh₂, hrep_eq⟩ := mem_doubleCoset.mp hrep
+    rw [hrep_eq]
+    refine mem_doubleCoset.mpr ⟨h₁ * p.1.out * g₁ * p.2.out,
+      mem_doubleCoset.mpr ⟨h₁ * p.1.out, P.H.mul_mem hh₁ p.1.out.2, p.2.out, p.2.out.2, rfl⟩,
+      h₂, hh₂, by simp [mul_assoc]⟩
+  · intro hD
+    obtain ⟨w, hw, k, hk, hd⟩ := mem_doubleCoset.mp hD
+    rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hw
+    obtain ⟨i, hi⟩ := hw
+    rw [mem_leftCoset_iff] at hi
+    have hch : (((i.out : G) * g₁)⁻¹ * w) * g₂ ∈ doubleCoset (g₂ : G) P.H P.H :=
+      mem_doubleCoset.mpr ⟨_, hi, 1, P.H.one_mem, by rw [mul_one]⟩
+    rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hch
+    obtain ⟨j, hj⟩ := hch
+    rw [mem_leftCoset_iff] at hj
+    refine Finset.mem_image.mpr ⟨(i, j), Finset.mem_univ _, ?_⟩
+    rw [← D.mk_rep]
+    refine P.mulMap_eq_of_mk_eq ?_
+    rw [QuotientGroup.eq, hd]
+    have : ((i.out : G) * g₁ * ((j.out : G) * g₂))⁻¹ * (w * g₂ * k) =
+        (((j.out : G) * g₂)⁻¹ * ((((i.out : G) * g₁)⁻¹ * w) * g₂)) * k := by
+      simp [mul_assoc]
+    rw [this]
+    exact P.H.mul_mem hj hk
 
-/-- If `h₁ g₁ (h₂ g₂) ∈ HdH` (with `h₁, h₂ ∈ H`), then `⟦d⟧ ∈ mulSupport g₁ g₂`. -/
-lemma mem_mulSupport_of_product_mem (g₁ g₂ d : P.Δ) (h₁ h₂ : P.H)
-    (hmem : (h₁ : G) * g₁ * ((h₂ : G) * g₂) ∈
-      DoubleCoset.doubleCoset (d : G) P.H P.H) :
-    (⟦d⟧ : HeckeCoset P) ∈ mulSupport P g₁ g₂ := by
-  have key : mulMap P g₁ g₂ (⟦⟨h₁, h₁.2⟩⟧, ⟦⟨h₂, h₂.2⟩⟧) =
-      (⟦d⟧ : HeckeCoset P) := by
-    unfold mulMap
-    change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
-    rw [HeckeCoset.eq_iff]
-    dsimp only
-    obtain ⟨n₁, hn₁⟩ := QuotientGroup.mk_out_eq_mul
-      ((ConjAct.toConjAct (g₁ : G) • P.H).subgroupOf P.H) ⟨(h₁ : G), h₁.2⟩
-    obtain ⟨n₂, hn₂⟩ := QuotientGroup.mk_out_eq_mul
-      ((ConjAct.toConjAct (g₂ : G) • P.H).subgroupOf P.H) ⟨(h₂ : G), h₂.2⟩
-    have hi : ((⟦⟨(h₁ : G), h₁.2⟩⟧ : decompQuot P g₁).out : G) = h₁ * n₁ := by
-      have := congr_arg (Subtype.val : P.H → G) hn₁
-      simpa [Subgroup.coe_mul]
-    have hj : ((⟦⟨(h₂ : G), h₂.2⟩⟧ : decompQuot P g₂).out : G) = h₂ * n₂ := by
-      have := congr_arg (Subtype.val : P.H → G) hn₂
-      simpa [Subgroup.coe_mul]
-    have hn₂c : (g₂ : G)⁻¹ * ↑n₂ * g₂ ∈ P.H :=
-      inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) n₂
-    rw [hi, hj]
-    apply HeckeCoset.doubleCoset_eq_of_mem
-    rw [DoubleCoset.mem_doubleCoset] at hmem
-    obtain ⟨a, ha, b, hb, hab⟩ := hmem
-    rw [DoubleCoset.mem_doubleCoset]
-    refine ⟨(h₁ : G) * ↑↑n₁ * (h₁ : G)⁻¹ * a,
-      P.H.mul_mem (P.H.mul_mem (P.H.mul_mem h₁.2 (SetLike.coe_mem n₁.val))
-        (P.H.inv_mem h₁.2)) ha,
-      b * ((g₂ : G)⁻¹ * ↑↑n₂ * g₂), P.H.mul_mem hb hn₂c, ?_⟩
-    have key : (↑h₁ * ↑↑n₁ * (↑h₁ : G)⁻¹ * a) * ↑d *
-        (b * ((↑g₂ : G)⁻¹ * ↑↑n₂ * ↑g₂)) =
-        (↑h₁ * ↑↑n₁) * (↑g₁ : G) * ((↑h₂ * ↑↑n₂) * ↑g₂) :=
-      calc (↑h₁ * ↑↑n₁ * (↑h₁ : G)⁻¹ * a) * ↑d
-          * (b * ((↑g₂ : G)⁻¹ * ↑↑n₂ * ↑g₂))
-          = ↑h₁ * ↑↑n₁ * (↑h₁)⁻¹ * (a * ↑d * b) *
-            ((↑g₂)⁻¹ * ↑↑n₂ * ↑g₂) := by group
-        _ = ↑h₁ * ↑↑n₁ * (↑h₁)⁻¹ * (↑h₁ * ↑g₁ * (↑h₂ * ↑g₂)) *
-            ((↑g₂)⁻¹ * ↑↑n₂ * ↑g₂) := by rw [hab]
-        _ = (↑h₁ * ↑↑n₁) * ↑g₁ * ((↑h₂ * ↑↑n₂) * ↑g₂) := by group
-    exact key.symm
-  unfold mulSupport
-  exact key ▸ Finset.mem_image_of_mem (mulMap P g₁ g₂) (Finset.mem_univ _)
-
-end HeckeRing
+end HeckePair

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
+
+/-!
+# Hecke rings: positivity of the multiplicity on the product support
+
+The product `D₁ * D₂` of two double cosets is supported on the finite set `mulSupport`. This file
+relates membership of `mulSupport` to positivity of Shimura's multiplicity: `heckeMultiplicity` is
+positive exactly on the double cosets that occur in the product, and zero off the support.
+
+## Main results
+
+* `HeckeRing.heckeMultiplicity_pos_of_mem`: the multiplicity is positive on the support.
+* `HeckeRing.heckeMultiplicity_eq_zero_of_nmem_mulSupport`: zero off the support.
+* `HeckeRing.mem_mulSupport_of_product_mem`: a product in `HdH` witnesses membership.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup
+open scoped Pointwise
+
+namespace HeckeRing
+
+variable {G : Type*} [Group G]
+
+attribute [local instance] doubleCosetSetoid
+
+variable (P : HeckePair G)
+
+/-- If the double coset of `σ_{i₀} τ_{j₀}` equals `HcH`, then the fibre defining the multiplicity
+at `c` is nonempty: some pair of representatives multiplies into the right coset `cH`. -/
+private lemma nonempty_witness_of_doubleCoset_eq (g₁ g₂ : P.Δ) (c : G)
+    (i₀ : decompQuot P g₁) (j₀ : decompQuot P g₂)
+    (hset_eq : DoubleCoset.doubleCoset
+      ((↑i₀.out : G) * (↑g₁ : G) * ((↑j₀.out : G) * (↑g₂ : G)))
+      (P.H : Set G) (P.H : Set G) =
+      DoubleCoset.doubleCoset c P.H P.H) :
+    Nonempty ↑{x : decompQuot P g₁ × decompQuot P g₂ |
+      ({(↑x.1.out : G) * (↑g₁ : G)} : Set G) *
+        {(↑x.2.out : G) * (↑g₂ : G)} * P.H = {c} * (P.H : Set G)} := by
+  obtain ⟨h₁, hh₁, h₂, hh₂, hprod⟩ := (DoubleCoset.eq P.H P.H _ _).mp
+    (DoubleCoset.mk_eq_of_doubleCoset_eq hset_eq)
+  set α := (↑g₁ : G)
+  set β := (↑g₂ : G)
+  set K₁ := (ConjAct.toConjAct α • P.H).subgroupOf P.H
+  set i' : decompQuot P g₁ := ⟦⟨h₁ * ↑i₀.out, P.H.mul_mem hh₁ i₀.out.2⟩⟧
+  obtain ⟨κ₁, hκ₁_eq⟩ := QuotientGroup.mk_out_eq_mul K₁
+    ⟨h₁ * ↑i₀.out, P.H.mul_mem hh₁ i₀.out.2⟩
+  have hκ₁_conj : α⁻¹ * (κ₁.val : G) * α ∈ P.H :=
+    inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) κ₁
+  set K₂ := (ConjAct.toConjAct β • P.H).subgroupOf P.H
+  set j' : decompQuot P g₂ := ⟦⟨(α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out,
+    P.H.mul_mem (P.H.inv_mem hκ₁_conj) j₀.out.2⟩⟧
+  obtain ⟨κ₂, hκ₂_eq⟩ := QuotientGroup.mk_out_eq_mul K₂
+    ⟨(α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out,
+      P.H.mul_mem (P.H.inv_mem hκ₁_conj) j₀.out.2⟩
+  have hκ₂_conj : β⁻¹ * (κ₂.val : G) * β ∈ P.H :=
+    inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) κ₂
+  have hi'_coe : (↑i'.out : G) = h₁ * ↑i₀.out * (κ₁.val : G) := by
+    have := congr_arg (Subtype.val : P.H → G) hκ₁_eq
+    simpa [Subgroup.coe_mul] using this
+  have hj'_coe : (↑j'.out : G) =
+      (α⁻¹ * (κ₁.val : G) * α)⁻¹ * ↑j₀.out * (κ₂.val : G) := by
+    have h := hκ₂_eq
+    apply_fun (↑· : ↥P.H → G) at h
+    simp only [Subgroup.coe_mul] at h
+    exact h
+  refine ⟨⟨(i', j'), ?_⟩⟩
+  simp only [Set.mem_setOf_eq]
+  have hprod_main : (↑i'.out : G) * α * ((↑j'.out : G) * β) =
+      c * (h₂⁻¹ * (β⁻¹ * (κ₂.val : G) * β)) := by
+    rw [hi'_coe, hj'_coe]
+    have hprod' : c = h₁ * (↑i₀.out * α * (↑j₀.out * β)) * h₂ := hprod
+    rw [hprod']
+    group
+  rw [Set.singleton_mul_singleton, hprod_main, ← Set.singleton_mul_singleton, mul_assoc,
+    Subgroup.singleton_mul_subgroup (P.H.mul_mem (P.H.inv_mem hh₂) hκ₂_conj)]
+
+/-- The multiplicity is nonzero for double cosets in the product support. -/
+lemma heckeMultiplicity_pos_of_mem_mulSupport (g₁ g₂ : P.Δ) (d : HeckeCoset P)
+    (hd : d ∈ mulSupport P g₁ g₂) :
+    heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) ≠ 0 := by
+  rw [heckeMultiplicity]
+  simp only [ne_eq, Nat.cast_eq_zero]
+  rw [Nat.card_eq_zero, not_or, not_isEmpty_iff]
+  refine ⟨?_, not_infinite_iff_finite.mpr inferInstance⟩
+  rw [mulSupport] at hd
+  simp only [Finset.top_eq_univ, Finset.mem_image, Finset.mem_univ, true_and,
+    Prod.exists] at hd
+  obtain ⟨i₀, j₀, hmap⟩ := hd
+  exact nonempty_witness_of_doubleCoset_eq P g₁ g₂ (HeckeCoset.rep d) i₀ j₀
+    ((HeckeCoset.eq_iff _ _).mp (hmap.trans (Quotient.out_eq d).symm))
+
+/-- The multiplicity is zero for double cosets outside the product support. -/
+lemma heckeMultiplicity_eq_zero_of_nmem_mulSupport (g₁ g₂ : P.Δ) (d : HeckeCoset P)
+    (hd : d ∉ mulSupport P g₁ g₂) :
+    heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) = 0 := by
+  simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
+  left
+  rintro ⟨i, j⟩ hij
+  refine hd ?_
+  rw [mulSupport]
+  simp only [Finset.top_eq_univ, Finset.mem_image, Finset.mem_univ, true_and, Prod.exists]
+  exact ⟨i, j, (doubleCoset_eq_of_rightCoset_eq P g₁ g₂ (HeckeCoset.rep d) (i, j) hij).trans
+    (Quotient.out_eq d)⟩
+
+/-- A multiplicity that is both at most one and positive must equal one. -/
+lemma heckeMultiplicity_eq_one_of_le_one_and_pos (g₁ g₂ d : P.Δ)
+    (h_le : heckeMultiplicity P g₁ g₂ d ≤ 1)
+    (h_pos : 0 < heckeMultiplicity P g₁ g₂ d) :
+    heckeMultiplicity P g₁ g₂ d = 1 := by omega
+
+/-- The multiplicity is positive for double cosets in the product support. -/
+lemma heckeMultiplicity_pos_of_mem (g₁ g₂ : P.Δ) (d : HeckeCoset P)
+    (hd : d ∈ mulSupport P g₁ g₂) :
+    0 < heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) := by
+  have h_ne := heckeMultiplicity_pos_of_mem_mulSupport P g₁ g₂ d hd
+  have h_nonneg : (0 : ℤ) ≤ heckeMultiplicity P g₁ g₂ (HeckeCoset.rep d) := by
+    simp only [heckeMultiplicity]
+    exact_mod_cast Nat.zero_le _
+  exact lt_of_le_of_ne h_nonneg (Ne.symm h_ne)
+
+/-- If `h₁ g₁ (h₂ g₂) ∈ HdH` (with `h₁, h₂ ∈ H`), then `⟦d⟧ ∈ mulSupport g₁ g₂`. -/
+lemma mem_mulSupport_of_product_mem (g₁ g₂ d : P.Δ) (h₁ h₂ : P.H)
+    (hmem : (h₁ : G) * g₁ * ((h₂ : G) * g₂) ∈
+      DoubleCoset.doubleCoset (d : G) P.H P.H) :
+    (⟦d⟧ : HeckeCoset P) ∈ mulSupport P g₁ g₂ := by
+  have key : mulMap P g₁ g₂ (⟦⟨h₁, h₁.2⟩⟧, ⟦⟨h₂, h₂.2⟩⟧) =
+      (⟦d⟧ : HeckeCoset P) := by
+    unfold mulMap
+    change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
+    rw [HeckeCoset.eq_iff]
+    dsimp only
+    obtain ⟨n₁, hn₁⟩ := QuotientGroup.mk_out_eq_mul
+      ((ConjAct.toConjAct (g₁ : G) • P.H).subgroupOf P.H) ⟨(h₁ : G), h₁.2⟩
+    obtain ⟨n₂, hn₂⟩ := QuotientGroup.mk_out_eq_mul
+      ((ConjAct.toConjAct (g₂ : G) • P.H).subgroupOf P.H) ⟨(h₂ : G), h₂.2⟩
+    have hi : ((⟦⟨(h₁ : G), h₁.2⟩⟧ : decompQuot P g₁).out : G) = h₁ * n₁ := by
+      have := congr_arg (Subtype.val : P.H → G) hn₁
+      simpa [Subgroup.coe_mul]
+    have hj : ((⟦⟨(h₂ : G), h₂.2⟩⟧ : decompQuot P g₂).out : G) = h₂ * n₂ := by
+      have := congr_arg (Subtype.val : P.H → G) hn₂
+      simpa [Subgroup.coe_mul]
+    have hn₂c : (g₂ : G)⁻¹ * ↑n₂ * g₂ ∈ P.H :=
+      inv_mul_mul_mem_of_mem_subgroupOf (H := P.H) n₂
+    rw [hi, hj]
+    apply HeckeCoset.doubleCoset_eq_of_mem
+    rw [DoubleCoset.mem_doubleCoset] at hmem
+    obtain ⟨a, ha, b, hb, hab⟩ := hmem
+    rw [DoubleCoset.mem_doubleCoset]
+    refine ⟨(h₁ : G) * ↑↑n₁ * (h₁ : G)⁻¹ * a,
+      P.H.mul_mem (P.H.mul_mem (P.H.mul_mem h₁.2 (SetLike.coe_mem n₁.val))
+        (P.H.inv_mem h₁.2)) ha,
+      b * ((g₂ : G)⁻¹ * ↑↑n₂ * g₂), P.H.mul_mem hb hn₂c, ?_⟩
+    have key : (↑h₁ * ↑↑n₁ * (↑h₁ : G)⁻¹ * a) * ↑d *
+        (b * ((↑g₂ : G)⁻¹ * ↑↑n₂ * ↑g₂)) =
+        (↑h₁ * ↑↑n₁) * (↑g₁ : G) * ((↑h₂ * ↑↑n₂) * ↑g₂) :=
+      calc (↑h₁ * ↑↑n₁ * (↑h₁ : G)⁻¹ * a) * ↑d
+          * (b * ((↑g₂ : G)⁻¹ * ↑↑n₂ * ↑g₂))
+          = ↑h₁ * ↑↑n₁ * (↑h₁)⁻¹ * (a * ↑d * b) *
+            ((↑g₂)⁻¹ * ↑↑n₂ * ↑g₂) := by group
+        _ = ↑h₁ * ↑↑n₁ * (↑h₁)⁻¹ * (↑h₁ * ↑g₁ * (↑h₂ * ↑g₂)) *
+            ((↑g₂)⁻¹ * ↑↑n₂ * ↑g₂) := by rw [hab]
+        _ = (↑h₁ * ↑↑n₁) * ↑g₁ * ((↑h₂ * ↑↑n₂) * ↑g₂) := by group
+    exact key.symm
+  unfold mulSupport
+  exact key ▸ Finset.mem_image_of_mem (mulMap P g₁ g₂) (Finset.mem_univ _)
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
@@ -11,7 +11,7 @@ public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
 # Hecke rings: the support of the multiplicity
 
 Shimura's multiplicity `m(g, h; d)` is nonzero exactly when `d` lies in the product set
-`Γ₁gΓ₂hΓ₃` of the two double cosets. For a Hecke coset module datum this identifies the support
+`Γ₁gΓ₂hΓ₃` of the two double cosets. For a Hecke triple this identifies the support
 of the structure constants of the Hecke product with the image of `HeckeCoset.mulMap`, which is
 a finite set; this is what makes the convolution product of Hecke coset modules well-defined in
 the next file.
@@ -76,7 +76,7 @@ variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 of `HeckeCoset.mulMap`: the multiplicity of a double coset `D` in the product `H₁g₁H₂ * H₂g₂H₃`
 is nonzero exactly when `D` is the double coset of `σᵢ g₁ τⱼ g₂` for some pair of coset
 representatives. -/
-theorem mem_image_mulMap_iff [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+theorem mem_image_mulMap_iff [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     [DecidableEq (HeckeCoset Δ H₁ H₃)] (g₁ g₂ : Δ) (D : HeckeCoset Δ H₁ H₃) :
     D ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂) ↔
       multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (D.rep : G) ≠ 0 := by

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicitySupport.lean
@@ -11,16 +11,16 @@ public import Mathlib.NumberTheory.HeckeRing.MultiplicityUnit
 # Hecke rings: the support of the multiplicity
 
 Shimura's multiplicity `m(g, h; d)` is nonzero exactly when `d` lies in the product set
-`Γ₁gΓ₂hΓ₃` of the two double cosets. For a Hecke pair this identifies the support of the
-structure constants of the Hecke product with the image of `HeckePair.mulMap`, which is a
-finite set; this is what makes the convolution product of the Hecke ring well-defined in the
-next file.
+`Γ₁gΓ₂hΓ₃` of the two double cosets. For a Hecke coset module datum this identifies the support
+of the structure constants of the Hecke product with the image of `HeckeCoset.mulMap`, which is
+a finite set; this is what makes the convolution product of Hecke coset modules well-defined in
+the next file.
 
 ## Main results
 
 * `DoubleCoset.multiplicity_ne_zero_iff`: `m(g, h; d) ≠ 0 ↔ d ∈ Γ₁gΓ₂hΓ₃`.
-* `HeckePair.mem_image_mulMap_iff`: the support of the structure constants at `(g₁, g₂)` is the
-  image of `mulMap`.
+* `HeckeCoset.mem_image_mulMap_iff`: the support of the structure constants at `(g₁, g₂)` is
+  the image of `mulMap`.
 -/
 
 @[expose] public section
@@ -66,54 +66,53 @@ theorem multiplicity_ne_zero_iff {g h d : G} [Finite (DecompQuotient Γ₁ Γ₂
 
 end DoubleCoset
 
-namespace HeckePair
+namespace HeckeCoset
 
 open DoubleCoset
 
-variable {G : Type*} [Group G] (P : HeckePair G)
-
-attribute [local instance] HeckePair.doubleCosetSetoid
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 
 /-- The support of the structure constants of the Hecke product at `(g₁, g₂)` is the image
-of `HeckePair.mulMap`: the multiplicity of a double coset `D` in the product `Hg₁H * Hg₂H` is
-nonzero exactly when `D` is the double coset of `σᵢ g₁ τⱼ g₂` for some pair of coset
+of `HeckeCoset.mulMap`: the multiplicity of a double coset `D` in the product `H₁g₁H₂ * H₂g₂H₃`
+is nonzero exactly when `D` is the double coset of `σᵢ g₁ τⱼ g₂` for some pair of coset
 representatives. -/
-theorem mem_image_mulMap_iff [DecidableEq (HeckeCoset P)] (g₁ g₂ : P.Δ) (D : HeckeCoset P) :
-    D ∈ Finset.univ.image (P.mulMap g₁ g₂) ↔
-      multiplicity P.H P.H P.H (g₁ : G) (g₂ : G) (D.rep : G) ≠ 0 := by
+theorem mem_image_mulMap_iff [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₃]
+    [DecidableEq (HeckeCoset Δ H₁ H₃)] (g₁ g₂ : Δ) (D : HeckeCoset Δ H₁ H₃) :
+    D ∈ Finset.univ.image (mulMap H₁ H₂ H₃ g₁ g₂) ↔
+      multiplicity H₁ H₂ H₃ (g₁ : G) (g₂ : G) (D.rep : G) ≠ 0 := by
   rw [multiplicity_ne_zero_iff]
   constructor
   · intro hD
     simp only [Finset.mem_image, Finset.mem_univ, true_and] at hD
     obtain ⟨p, hp⟩ := hD
     have hrep : (D.rep : G) ∈
-        doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) P.H P.H := by
-      rw [show doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) P.H P.H =
-          doubleCoset (D.rep : G) P.H P.H from HeckeCoset.eq_iff.mp (hp.trans D.mk_rep.symm)]
-      exact mem_doubleCoset_self P.H P.H _
+        doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) H₁ H₃ := by
+      rw [show doubleCoset ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂)) H₁ H₃ =
+          doubleCoset (D.rep : G) H₁ H₃ from HeckeCoset.eq_iff.mp (hp.trans D.mk_rep.symm)]
+      exact mem_doubleCoset_self H₁ H₃ _
     obtain ⟨h₁, hh₁, h₂, hh₂, hrep_eq⟩ := mem_doubleCoset.mp hrep
     rw [hrep_eq]
     refine mem_doubleCoset.mpr ⟨h₁ * p.1.out * g₁ * p.2.out,
-      mem_doubleCoset.mpr ⟨h₁ * p.1.out, P.H.mul_mem hh₁ p.1.out.2, p.2.out, p.2.out.2, rfl⟩,
+      mem_doubleCoset.mpr ⟨h₁ * p.1.out, H₁.mul_mem hh₁ p.1.out.2, p.2.out, p.2.out.2, rfl⟩,
       h₂, hh₂, by simp [mul_assoc]⟩
   · intro hD
     obtain ⟨w, hw, k, hk, hd⟩ := mem_doubleCoset.mp hD
     rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hw
     obtain ⟨i, hi⟩ := hw
     rw [mem_leftCoset_iff] at hi
-    have hch : (((i.out : G) * g₁)⁻¹ * w) * g₂ ∈ doubleCoset (g₂ : G) P.H P.H :=
-      mem_doubleCoset.mpr ⟨_, hi, 1, P.H.one_mem, by rw [mul_one]⟩
+    have hch : (((i.out : G) * g₁)⁻¹ * w) * g₂ ∈ doubleCoset (g₂ : G) H₂ H₃ :=
+      mem_doubleCoset.mpr ⟨_, hi, 1, H₃.one_mem, by rw [mul_one]⟩
     rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hch
     obtain ⟨j, hj⟩ := hch
     rw [mem_leftCoset_iff] at hj
     refine Finset.mem_image.mpr ⟨(i, j), Finset.mem_univ _, ?_⟩
     rw [← D.mk_rep]
-    refine P.mulMap_eq_of_mk_eq ?_
+    refine mulMap_eq_of_mk_eq ?_
     rw [QuotientGroup.eq, hd]
     have : ((i.out : G) * g₁ * ((j.out : G) * g₂))⁻¹ * (w * g₂ * k) =
         (((j.out : G) * g₂)⁻¹ * ((((i.out : G) * g₁)⁻¹ * w) * g₂)) * k := by
       simp [mul_assoc]
     rw [this]
-    exact P.H.mul_mem hj hk
+    exact H₃.mul_mem hj hk
 
-end HeckePair
+end HeckeCoset

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.HeckeRing.Multiplicity
+
+/-!
+# Hecke rings: the multiplicity of the identity double coset
+
+The identity double coset `HeckeCoset.one` acts as the unit for the Hecke product. This file proves
+the two computations that express this at the level of Shimura's multiplicity: for the identity on
+either side, `heckeMultiplicity` is `1` exactly on the diagonal `⟦g⟧ = ⟦d⟧` and `0` elsewhere.
+
+## Main results
+
+* `HeckeRing.heckeMultiplicity_mul_one`: `⟦g⟧ = ⟦d⟧ ↔ heckeMultiplicity g (one).rep d = 1`.
+* `HeckeRing.heckeMultiplicity_one_mul`: `⟦g⟧ = ⟦d⟧ ↔ heckeMultiplicity (one).rep g d = 1`.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup
+open scoped Pointwise
+
+namespace HeckeRing
+
+variable {G : Type*} [Group G]
+
+attribute [local instance] doubleCosetSetoid
+
+/-- Membership in `(ConjAct.toConjAct a • H).subgroupOf H` unfolds to conjugation by `a`
+landing back in `H`. -/
+lemma inv_mul_mul_mem_of_mem_subgroupOf (H : Subgroup G) {a : G}
+    (x : (ConjAct.toConjAct a • H).subgroupOf H) : a⁻¹ * (x.val : G) * a ∈ H := by
+  have := x.2
+  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
+    ConjAct.smul_def] at this
+  simpa [ConjAct.ofConjAct_toConjAct] using this
+
+variable (P : HeckePair G)
+
+/-- If `Hg₁H = HdH`, the fibre defining the multiplicity for right multiplication by the
+identity double coset is nonempty. -/
+private lemma nonempty_mul_one_witness_of_doubleCoset_eq (g₁ d : P.Δ)
+    (hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
+      DoubleCoset.doubleCoset (d : G) P.H P.H) :
+    Nonempty ↑{x : decompQuot P g₁ × decompQuot P (HeckeCoset.one P).rep |
+      ({(↑x.1.out : G) * (↑g₁ : G)} : Set G) *
+        {(↑x.2.out : G) * (↑(HeckeCoset.one P).rep : G)} * P.H =
+        {(↑d : G)} * (P.H : Set G)} := by
+  have hd_in_g₁ : (↑d : G) ∈ doubleCoset (↑g₁ : G) P.H P.H :=
+    hg₁d ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
+  rw [doubleCoset_eq_iUnion_leftCosets] at hd_in_g₁
+  simp only [Set.mem_iUnion] at hd_in_g₁
+  obtain ⟨k, hk⟩ := hd_in_g₁
+  rw [smul_eq_singleton_mul] at hk
+  obtain ⟨j₀⟩ := one_in_decompQuot_one P
+  refine ⟨⟨(k, j₀), ?_⟩⟩
+  simp only [Set.mem_setOf_eq]
+  have hmem : (j₀.out : G) * ((HeckeCoset.one P).rep : G) ∈ P.H :=
+    Subgroup.mul_mem _ (SetLike.coe_mem j₀.out) (HeckeCoset.one_rep_mem_H P)
+  rw [mul_assoc, Subgroup.singleton_mul_subgroup hmem]
+  apply (leftCoset_eq_of_not_disjoint (H := P.H) _ _ _).symm
+  rw [not_disjoint_iff]
+  refine ⟨↑d, Set.mem_smul_set.mpr ⟨1, P.H.one_mem, by simp⟩, ?_⟩
+  rw [Set.mem_smul_set]
+  rw [singleton_mul] at hk
+  simp only [image_mul_left, mem_preimage, SetLike.mem_coe] at hk
+  exact ⟨(↑k.out * (↑g₁ : G))⁻¹ * ↑d, hk,
+    show (↑k.out * (↑g₁ : G)) * ((↑k.out * ↑g₁)⁻¹ * ↑d) = ↑d by group⟩
+
+/-- Right multiplication by the identity double coset sends every pair of representatives
+to `⟦g₁⟧`. -/
+lemma mulMap_mul_one_eq (g₁ : P.Δ) (i : decompQuot P g₁)
+    (j : decompQuot P (HeckeCoset.one P).rep) :
+    mulMap P g₁ (HeckeCoset.one P).rep (i, j) = (⟦g₁⟧ : HeckeCoset P) := by
+  unfold mulMap
+  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
+  rw [HeckeCoset.eq_iff]
+  dsimp only
+  rw [mul_assoc, doubleCoset_mul_left_eq_self]
+  apply doubleCoset_mul_right_eq_self P
+    ⟨j.out * (HeckeCoset.one P).rep,
+      Subgroup.mul_mem _ (by simp) (HeckeCoset.one_rep_mem_H P)⟩
+
+/-- Right multiplication by `HeckeCoset.one` has multiplicity `1` on the diagonal and `0`
+elsewhere. -/
+lemma heckeMultiplicity_mul_one (g₁ d : P.Δ) :
+    (⟦g₁⟧ : HeckeCoset P) = ⟦d⟧ ↔
+      heckeMultiplicity P g₁ (HeckeCoset.one P).rep d = 1 := by
+  constructor
+  · intro h
+    have hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
+        DoubleCoset.doubleCoset (d : G) P.H P.H := (HeckeCoset.eq_iff g₁ d).mp h
+    simp only [heckeMultiplicity]
+    norm_cast
+    rw [Nat.card_eq_one_iff_unique]
+    have : Subsingleton (decompQuot P (HeckeCoset.one P).rep) :=
+      subsingleton_decompQuot_one P
+    refine ⟨⟨?_⟩, nonempty_mul_one_witness_of_doubleCoset_eq P g₁ d hg₁d⟩
+    intro ⟨⟨i₁, j₁⟩, h₁⟩ ⟨⟨i₂, j₂⟩, h₂⟩
+    have hj : j₁ = j₂ := Subsingleton.elim j₁ j₂
+    subst hj
+    simp only [Set.mem_setOf_eq] at h₁ h₂
+    exact Subtype.ext (Prod.ext
+      (decompQuot_fst_eq_of_snd_mem_H P g₁ (HeckeCoset.one P).rep d i₁ i₂ j₁
+        (Subgroup.mul_mem _ (SetLike.coe_mem j₁.out) (HeckeCoset.one_rep_mem_H P)) h₁ h₂)
+      rfl)
+  · intro hm
+    by_contra hne
+    have : heckeMultiplicity P g₁ (HeckeCoset.one P).rep d = 0 := by
+      simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
+      left
+      intro ⟨i, j⟩ heq
+      exact hne ((mulMap_mul_one_eq P g₁ i j).symm.trans
+        (doubleCoset_eq_of_rightCoset_eq P g₁ (HeckeCoset.one P).rep d (i, j) heq))
+    omega
+
+/-- Left multiplication by the identity double coset sends every pair of representatives
+to `⟦g₁⟧`. -/
+lemma mulMap_one_mul_eq (g₁ : P.Δ) (i : decompQuot P (HeckeCoset.one P).rep)
+    (j : decompQuot P g₁) :
+    mulMap P (HeckeCoset.one P).rep g₁ (i, j) = (⟦g₁⟧ : HeckeCoset P) := by
+  unfold mulMap
+  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
+  rw [HeckeCoset.eq_iff]
+  dsimp only
+  rw [mul_assoc]
+  simp_rw [doubleCoset_mul_left_eq_self,
+    doubleCoset_mul_left_eq_self P ⟨(HeckeCoset.one P).rep, HeckeCoset.one_rep_mem_H P⟩,
+    doubleCoset_mul_left_eq_self]
+
+/-- If `Hg₁H = HdH`, the fibre defining the multiplicity for left multiplication by the
+identity double coset is nonempty. -/
+private lemma nonempty_one_mul_witness_of_doubleCoset_eq (g₁ d : P.Δ)
+    (hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
+      DoubleCoset.doubleCoset (d : G) P.H P.H) :
+    Nonempty ↑{x : decompQuot P (HeckeCoset.one P).rep × decompQuot P g₁ |
+      ({(↑x.1.out : G) * (↑(HeckeCoset.one P).rep : G)} : Set G) *
+        {(↑x.2.out : G) * (↑g₁ : G)} * P.H = {(↑d : G)} * (P.H : Set G)} := by
+  have hd_in : (↑d : G) ∈ doubleCoset (↑g₁ : G) P.H P.H :=
+    hg₁d ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
+  rw [doubleCoset_eq_iUnion_leftCosets] at hd_in
+  simp only [Set.mem_iUnion] at hd_in
+  obtain ⟨j', hj'⟩ := hd_in
+  rw [smul_eq_singleton_mul, singleton_mul] at hj'
+  simp only [image_mul_left, mem_preimage, SetLike.mem_coe] at hj'
+  obtain ⟨i₀⟩ := one_in_decompQuot_one P
+  have h₀_mem : (↑i₀.out : G) * ((HeckeCoset.one P).rep : G) ∈ P.H :=
+    Subgroup.mul_mem _ (SetLike.coe_mem i₀.out) (HeckeCoset.one_rep_mem_H P)
+  set h₀ := ↑i₀.out * ((HeckeCoset.one P).rep : G) with hh₀_def
+  set j₀ : decompQuot P g₁ :=
+    ⟦⟨h₀⁻¹ * ↑j'.out, P.H.mul_mem (P.H.inv_mem h₀_mem) j'.out.2⟩⟧
+  obtain ⟨n, hn_eq⟩ := QuotientGroup.mk_out_eq_mul
+    ((ConjAct.toConjAct (↑g₁ : G) • P.H).subgroupOf P.H)
+    ⟨h₀⁻¹ * ↑j'.out, P.H.mul_mem (P.H.inv_mem h₀_mem) j'.out.2⟩
+  have hn_coe : (j₀.out : G) = h₀⁻¹ * ↑j'.out * (n : G) := by
+    have := congr_arg (Subtype.val : ↥P.H → G) hn_eq
+    simpa [Subgroup.coe_mul] using this
+  have hn_conj : (↑g₁ : G)⁻¹ * (n : G) * ↑g₁ ∈ P.H :=
+    inv_mul_mul_mem_of_mem_subgroupOf P.H n
+  refine ⟨⟨(i₀, j₀), ?_⟩⟩
+  simp only [Set.mem_setOf_eq, Set.singleton_mul_singleton]
+  apply (leftCoset_eq_of_not_disjoint (H := P.H) _ _ _).symm
+  rw [not_disjoint_iff]
+  refine ⟨↑d, Set.mem_smul_set.mpr ⟨1, P.H.one_mem, by simp⟩, ?_⟩
+  rw [Set.mem_smul_set]
+  refine ⟨(h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d, ?_, by
+    change (↑i₀.out * (HeckeCoset.one P).rep * (↑j₀.out * (↑g₁ : G))) *
+      ((h₀ * ↑j₀.out * ↑g₁)⁻¹ * ↑d) = ↑d
+    simp only [hh₀_def]
+    group⟩
+  change (h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d ∈ P.H
+  have key : (h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d =
+      ((↑g₁ : G)⁻¹ * (↑n : G)⁻¹ * ↑g₁) *
+        ((↑j'.out * (↑g₁ : G))⁻¹ * ↑d) := by
+    rw [hn_coe]
+    group
+  rw [key]
+  exact P.H.mul_mem (by convert P.H.inv_mem hn_conj using 1; group) hj'
+
+/-- Left multiplication by `HeckeCoset.one` has multiplicity `1` on the diagonal and `0`
+elsewhere. -/
+lemma heckeMultiplicity_one_mul (g₁ d : P.Δ) :
+    (⟦g₁⟧ : HeckeCoset P) = ⟦d⟧ ↔
+      heckeMultiplicity P (HeckeCoset.one P).rep g₁ d = 1 := by
+  constructor
+  · intro h
+    have hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
+        DoubleCoset.doubleCoset (d : G) P.H P.H := (HeckeCoset.eq_iff g₁ d).mp h
+    simp only [heckeMultiplicity]
+    norm_cast
+    rw [Nat.card_eq_one_iff_unique]
+    have : Subsingleton (decompQuot P (HeckeCoset.one P).rep) :=
+      subsingleton_decompQuot_one P
+    refine ⟨⟨?_⟩, nonempty_one_mul_witness_of_doubleCoset_eq P g₁ d hg₁d⟩
+    intro ⟨⟨i₁, j₁⟩, h₁⟩ ⟨⟨i₂, j₂⟩, h₂⟩
+    have hi : i₁ = i₂ := Subsingleton.elim i₁ i₂
+    subst hi
+    simp only [Set.mem_setOf_eq] at h₁ h₂
+    exact Subtype.ext (Prod.ext rfl
+      (decompQuot_snd_eq_of_fst_eq P (HeckeCoset.one P).rep g₁ d i₁ j₁ j₂ h₁ h₂))
+  · intro hm
+    by_contra hne
+    have : heckeMultiplicity P (HeckeCoset.one P).rep g₁ d = 0 := by
+      simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
+      left
+      intro ⟨i, j⟩ heq
+      exact hne ((mulMap_one_mul_eq P g₁ i j).symm.trans
+        (doubleCoset_eq_of_rightCoset_eq P (HeckeCoset.one P).rep g₁ d (i, j) heq))
+    omega
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
@@ -10,207 +10,145 @@ public import Mathlib.NumberTheory.HeckeRing.Multiplicity
 /-!
 # Hecke rings: the multiplicity of the identity double coset
 
-The identity double coset `HeckeCoset.one` acts as the unit for the Hecke product. This file proves
-the two computations that express this at the level of Shimura's multiplicity: for the identity on
-either side, `heckeMultiplicity` is `1` exactly on the diagonal `⟦g⟧ = ⟦d⟧` and `0` elsewhere.
+For `e ∈ Γ₂` the double coset `Γ₂eΓ₂` is `Γ₂` itself, the identity of the Hecke ring of `Γ₂`;
+this file proves the two computations expressing this at the level of Shimura's multiplicity:
+multiplying by such an `e` on either side, the multiplicity is `1` exactly on the diagonal
+`Γ₁gΓ₂ = Γ₁dΓ₂`. Specialised to a Hecke pair, these compute the products `T(g) * T(1)` and
+`T(1) * T(g)` in later files.
 
 ## Main results
 
-* `HeckeRing.heckeMultiplicity_mul_one`: `⟦g⟧ = ⟦d⟧ ↔ heckeMultiplicity g (one).rep d = 1`.
-* `HeckeRing.heckeMultiplicity_one_mul`: `⟦g⟧ = ⟦d⟧ ↔ heckeMultiplicity (one).rep g d = 1`.
+* `DoubleCoset.multiplicity_eq_one_iff_of_mem_right`: for `e ∈ Γ₂`,
+  `multiplicity Γ₁ Γ₂ Γ₂ g e d = 1 ↔ Γ₁gΓ₂ = Γ₁dΓ₂`.
+* `DoubleCoset.multiplicity_eq_one_iff_of_mem_left`: for `e ∈ Γ₁`,
+  `multiplicity Γ₁ Γ₁ Γ₂ e g d = 1 ↔ Γ₁gΓ₂ = Γ₁dΓ₂`.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup
+open Subgroup
 open scoped Pointwise
 
-namespace HeckeRing
+namespace DoubleCoset
 
-variable {G : Type*} [Group G]
+variable {G : Type*} [Group G] {Γ₁ Γ₂ : Subgroup G}
 
-attribute [local instance] doubleCosetSetoid
+/-- Every pair of representatives multiplies into the coset of `g` when the second element
+lies in `Γ₂`. -/
+private lemma exists_fibre_of_mem_right {g e d : G} (he : e ∈ Γ₂)
+    (hd : d ∈ doubleCoset g Γ₁ Γ₂) :
+    ∃ p : DecompQuotient Γ₁ Γ₂ g × DecompQuotient Γ₂ Γ₂ e,
+      ((p.1.out : G) * g * ((p.2.out : G) * e) : G ⧸ Γ₂) = (d : G ⧸ Γ₂) := by
+  rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hd
+  obtain ⟨i₀, hi₀⟩ := hd
+  obtain ⟨j₀⟩ : Nonempty (DecompQuotient Γ₂ Γ₂ e) := inferInstance
+  rw [mem_leftCoset_iff] at hi₀
+  refine ⟨(i₀, j₀), ?_⟩
+  rw [QuotientGroup.mk_mul_of_mem _ (Γ₂.mul_mem j₀.out.2 he), QuotientGroup.eq]
+  exact hi₀
 
-/-- Membership in `(ConjAct.toConjAct a • H).subgroupOf H` unfolds to conjugation by `a`
-landing back in `H`. -/
-lemma inv_mul_mul_mem_of_mem_subgroupOf (H : Subgroup G) {a : G}
-    (x : (ConjAct.toConjAct a • H).subgroupOf H) : a⁻¹ * (x.val : G) * a ∈ H := by
-  have := x.2
-  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
-    ConjAct.smul_def] at this
-  simpa [ConjAct.ofConjAct_toConjAct] using this
+private lemma exists_fibre_of_mem_left {e g d : G} (he : e ∈ Γ₁)
+    (hd : d ∈ doubleCoset g Γ₁ Γ₂) :
+    ∃ p : DecompQuotient Γ₁ Γ₁ e × DecompQuotient Γ₁ Γ₂ g,
+      ((p.1.out : G) * e * ((p.2.out : G) * g) : G ⧸ Γ₂) = (d : G ⧸ Γ₂) := by
+  obtain ⟨i₀⟩ : Nonempty (DecompQuotient Γ₁ Γ₁ e) := inferInstance
+  set a := (i₀.out : G) * e with ha_def
+  have ha : a ∈ Γ₁ := Γ₁.mul_mem i₀.out.2 he
+  have hd' : a⁻¹ * d ∈ doubleCoset g Γ₁ Γ₂ := by
+    obtain ⟨h₁, hh₁, h₂, hh₂, rfl⟩ := mem_doubleCoset.mp hd
+    exact mem_doubleCoset.mpr ⟨a⁻¹ * h₁, Γ₁.mul_mem (Γ₁.inv_mem ha) hh₁, h₂, hh₂,
+      by simp [mul_assoc]⟩
+  rw [doubleCoset_eq_iUnion_leftCosets, Set.mem_iUnion] at hd'
+  obtain ⟨j₀, hj₀⟩ := hd'
+  rw [mem_leftCoset_iff] at hj₀
+  refine ⟨(i₀, j₀), ?_⟩
+  rw [QuotientGroup.eq]
+  simpa [ha_def, mul_assoc] using hj₀
 
-variable (P : HeckePair G)
-
-/-- If `Hg₁H = HdH`, the fibre defining the multiplicity for right multiplication by the
-identity double coset is nonempty. -/
-private lemma nonempty_mul_one_witness_of_doubleCoset_eq (g₁ d : P.Δ)
-    (hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
-      DoubleCoset.doubleCoset (d : G) P.H P.H) :
-    Nonempty ↑{x : decompQuot P g₁ × decompQuot P (HeckeCoset.one P).rep |
-      ({(↑x.1.out : G) * (↑g₁ : G)} : Set G) *
-        {(↑x.2.out : G) * (↑(HeckeCoset.one P).rep : G)} * P.H =
-        {(↑d : G)} * (P.H : Set G)} := by
-  have hd_in_g₁ : (↑d : G) ∈ doubleCoset (↑g₁ : G) P.H P.H :=
-    hg₁d ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
-  rw [doubleCoset_eq_iUnion_leftCosets] at hd_in_g₁
-  simp only [Set.mem_iUnion] at hd_in_g₁
-  obtain ⟨k, hk⟩ := hd_in_g₁
-  rw [smul_eq_singleton_mul] at hk
-  obtain ⟨j₀⟩ := one_in_decompQuot_one P
-  refine ⟨⟨(k, j₀), ?_⟩⟩
-  simp only [Set.mem_setOf_eq]
-  have hmem : (j₀.out : G) * ((HeckeCoset.one P).rep : G) ∈ P.H :=
-    Subgroup.mul_mem _ (SetLike.coe_mem j₀.out) (HeckeCoset.one_rep_mem_H P)
-  rw [mul_assoc, Subgroup.singleton_mul_subgroup hmem]
-  apply (leftCoset_eq_of_not_disjoint (H := P.H) _ _ _).symm
-  rw [not_disjoint_iff]
-  refine ⟨↑d, Set.mem_smul_set.mpr ⟨1, P.H.one_mem, by simp⟩, ?_⟩
-  rw [Set.mem_smul_set]
-  rw [singleton_mul] at hk
-  simp only [image_mul_left, mem_preimage, SetLike.mem_coe] at hk
-  exact ⟨(↑k.out * (↑g₁ : G))⁻¹ * ↑d, hk,
-    show (↑k.out * (↑g₁ : G)) * ((↑k.out * ↑g₁)⁻¹ * ↑d) = ↑d by group⟩
-
-/-- Right multiplication by the identity double coset sends every pair of representatives
-to `⟦g₁⟧`. -/
-lemma mulMap_mul_one_eq (g₁ : P.Δ) (i : decompQuot P g₁)
-    (j : decompQuot P (HeckeCoset.one P).rep) :
-    mulMap P g₁ (HeckeCoset.one P).rep (i, j) = (⟦g₁⟧ : HeckeCoset P) := by
-  unfold mulMap
-  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
-  rw [HeckeCoset.eq_iff]
-  dsimp only
-  rw [mul_assoc, doubleCoset_mul_left_eq_self]
-  apply doubleCoset_mul_right_eq_self P
-    ⟨j.out * (HeckeCoset.one P).rep,
-      Subgroup.mul_mem _ (by simp) (HeckeCoset.one_rep_mem_H P)⟩
-
-/-- Right multiplication by `HeckeCoset.one` has multiplicity `1` on the diagonal and `0`
-elsewhere. -/
-lemma heckeMultiplicity_mul_one (g₁ d : P.Δ) :
-    (⟦g₁⟧ : HeckeCoset P) = ⟦d⟧ ↔
-      heckeMultiplicity P g₁ (HeckeCoset.one P).rep d = 1 := by
+/-- For `e ∈ Γ₂`, right multiplication by the identity double coset `Γ₂eΓ₂ = Γ₂` has
+multiplicity `1` exactly on the diagonal. -/
+theorem multiplicity_eq_one_iff_of_mem_right {g e d : G} (he : e ∈ Γ₂) :
+    multiplicity Γ₁ Γ₂ Γ₂ g e d = 1 ↔ doubleCoset g Γ₁ Γ₂ = doubleCoset d Γ₁ Γ₂ := by
+  rw [multiplicity, Nat.card_eq_one_iff_unique]
   constructor
+  · rintro ⟨-, ⟨p, hp⟩⟩
+    have hp' : _ = (d : G ⧸ Γ₂) := hp
+    rw [QuotientGroup.mk_mul_of_mem _ (Γ₂.mul_mem p.2.out.2 he), QuotientGroup.eq] at hp'
+    exact (doubleCoset_eq_of_mem (mem_doubleCoset.mpr
+      ⟨(p.1.out : G), p.1.out.2, _, hp', (mul_inv_cancel_left _ _).symm⟩)).symm
   · intro h
-    have hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
-        DoubleCoset.doubleCoset (d : G) P.H P.H := (HeckeCoset.eq_iff g₁ d).mp h
-    simp only [heckeMultiplicity]
-    norm_cast
-    rw [Nat.card_eq_one_iff_unique]
-    have : Subsingleton (decompQuot P (HeckeCoset.one P).rep) :=
-      subsingleton_decompQuot_one P
-    refine ⟨⟨?_⟩, nonempty_mul_one_witness_of_doubleCoset_eq P g₁ d hg₁d⟩
-    intro ⟨⟨i₁, j₁⟩, h₁⟩ ⟨⟨i₂, j₂⟩, h₂⟩
-    have hj : j₁ = j₂ := Subsingleton.elim j₁ j₂
-    subst hj
-    simp only [Set.mem_setOf_eq] at h₁ h₂
-    exact Subtype.ext (Prod.ext
-      (decompQuot_fst_eq_of_snd_mem_H P g₁ (HeckeCoset.one P).rep d i₁ i₂ j₁
-        (Subgroup.mul_mem _ (SetLike.coe_mem j₁.out) (HeckeCoset.one_rep_mem_H P)) h₁ h₂)
-      rfl)
-  · intro hm
-    by_contra hne
-    have : heckeMultiplicity P g₁ (HeckeCoset.one P).rep d = 0 := by
-      simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
-      left
-      intro ⟨i, j⟩ heq
-      exact hne ((mulMap_mul_one_eq P g₁ i j).symm.trans
-        (doubleCoset_eq_of_rightCoset_eq P g₁ (HeckeCoset.one P).rep d (i, j) heq))
-    omega
+    haveI := subsingleton_decompQuotient_of_mem he
+    obtain ⟨p, hp⟩ := exists_fibre_of_mem_right he (h ▸ mem_doubleCoset_self Γ₁ Γ₂ d)
+    refine ⟨⟨fun q₁ q₂ ↦ Subtype.ext ?_⟩, ⟨p, hp⟩⟩
+    have hsnd : q₁.1.2 = q₂.1.2 := Subsingleton.elim _ _
+    have h₁ : _ = (d : G ⧸ Γ₂) := q₁.2
+    have h₂ : _ = (d : G ⧸ Γ₂) := q₂.2
+    rw [← hsnd] at h₂
+    exact Prod.ext (fst_eq_of_mul_snd_mem (Γ₂.mul_mem q₁.1.2.out.2 he) h₁ h₂) hsnd
 
-/-- Left multiplication by the identity double coset sends every pair of representatives
-to `⟦g₁⟧`. -/
-lemma mulMap_one_mul_eq (g₁ : P.Δ) (i : decompQuot P (HeckeCoset.one P).rep)
-    (j : decompQuot P g₁) :
-    mulMap P (HeckeCoset.one P).rep g₁ (i, j) = (⟦g₁⟧ : HeckeCoset P) := by
-  unfold mulMap
-  change (⟦_⟧ : HeckeCoset P) = ⟦_⟧
-  rw [HeckeCoset.eq_iff]
-  dsimp only
-  rw [mul_assoc]
-  simp_rw [doubleCoset_mul_left_eq_self,
-    doubleCoset_mul_left_eq_self P ⟨(HeckeCoset.one P).rep, HeckeCoset.one_rep_mem_H P⟩,
-    doubleCoset_mul_left_eq_self]
-
-/-- If `Hg₁H = HdH`, the fibre defining the multiplicity for left multiplication by the
-identity double coset is nonempty. -/
-private lemma nonempty_one_mul_witness_of_doubleCoset_eq (g₁ d : P.Δ)
-    (hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
-      DoubleCoset.doubleCoset (d : G) P.H P.H) :
-    Nonempty ↑{x : decompQuot P (HeckeCoset.one P).rep × decompQuot P g₁ |
-      ({(↑x.1.out : G) * (↑(HeckeCoset.one P).rep : G)} : Set G) *
-        {(↑x.2.out : G) * (↑g₁ : G)} * P.H = {(↑d : G)} * (P.H : Set G)} := by
-  have hd_in : (↑d : G) ∈ doubleCoset (↑g₁ : G) P.H P.H :=
-    hg₁d ▸ DoubleCoset.mem_doubleCoset_self P.H P.H _
-  rw [doubleCoset_eq_iUnion_leftCosets] at hd_in
-  simp only [Set.mem_iUnion] at hd_in
-  obtain ⟨j', hj'⟩ := hd_in
-  rw [smul_eq_singleton_mul, singleton_mul] at hj'
-  simp only [image_mul_left, mem_preimage, SetLike.mem_coe] at hj'
-  obtain ⟨i₀⟩ := one_in_decompQuot_one P
-  have h₀_mem : (↑i₀.out : G) * ((HeckeCoset.one P).rep : G) ∈ P.H :=
-    Subgroup.mul_mem _ (SetLike.coe_mem i₀.out) (HeckeCoset.one_rep_mem_H P)
-  set h₀ := ↑i₀.out * ((HeckeCoset.one P).rep : G) with hh₀_def
-  set j₀ : decompQuot P g₁ :=
-    ⟦⟨h₀⁻¹ * ↑j'.out, P.H.mul_mem (P.H.inv_mem h₀_mem) j'.out.2⟩⟧
-  obtain ⟨n, hn_eq⟩ := QuotientGroup.mk_out_eq_mul
-    ((ConjAct.toConjAct (↑g₁ : G) • P.H).subgroupOf P.H)
-    ⟨h₀⁻¹ * ↑j'.out, P.H.mul_mem (P.H.inv_mem h₀_mem) j'.out.2⟩
-  have hn_coe : (j₀.out : G) = h₀⁻¹ * ↑j'.out * (n : G) := by
-    have := congr_arg (Subtype.val : ↥P.H → G) hn_eq
-    simpa [Subgroup.coe_mul] using this
-  have hn_conj : (↑g₁ : G)⁻¹ * (n : G) * ↑g₁ ∈ P.H :=
-    inv_mul_mul_mem_of_mem_subgroupOf P.H n
-  refine ⟨⟨(i₀, j₀), ?_⟩⟩
-  simp only [Set.mem_setOf_eq, Set.singleton_mul_singleton]
-  apply (leftCoset_eq_of_not_disjoint (H := P.H) _ _ _).symm
-  rw [not_disjoint_iff]
-  refine ⟨↑d, Set.mem_smul_set.mpr ⟨1, P.H.one_mem, by simp⟩, ?_⟩
-  rw [Set.mem_smul_set]
-  refine ⟨(h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d, ?_, by
-    change (↑i₀.out * (HeckeCoset.one P).rep * (↑j₀.out * (↑g₁ : G))) *
-      ((h₀ * ↑j₀.out * ↑g₁)⁻¹ * ↑d) = ↑d
-    simp only [hh₀_def]
-    group⟩
-  change (h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d ∈ P.H
-  have key : (h₀ * ↑j₀.out * (↑g₁ : G))⁻¹ * ↑d =
-      ((↑g₁ : G)⁻¹ * (↑n : G)⁻¹ * ↑g₁) *
-        ((↑j'.out * (↑g₁ : G))⁻¹ * ↑d) := by
-    rw [hn_coe]
-    group
-  rw [key]
-  exact P.H.mul_mem (by convert P.H.inv_mem hn_conj using 1; group) hj'
-
-/-- Left multiplication by `HeckeCoset.one` has multiplicity `1` on the diagonal and `0`
-elsewhere. -/
-lemma heckeMultiplicity_one_mul (g₁ d : P.Δ) :
-    (⟦g₁⟧ : HeckeCoset P) = ⟦d⟧ ↔
-      heckeMultiplicity P (HeckeCoset.one P).rep g₁ d = 1 := by
+/-- For `e ∈ Γ₁`, left multiplication by the identity double coset `Γ₁eΓ₁ = Γ₁` has
+multiplicity `1` exactly on the diagonal. -/
+theorem multiplicity_eq_one_iff_of_mem_left {e g d : G} (he : e ∈ Γ₁) :
+    multiplicity Γ₁ Γ₁ Γ₂ e g d = 1 ↔ doubleCoset g Γ₁ Γ₂ = doubleCoset d Γ₁ Γ₂ := by
+  rw [multiplicity, Nat.card_eq_one_iff_unique]
   constructor
+  · rintro ⟨-, ⟨p, hp⟩⟩
+    have hp' : _ = (d : G ⧸ Γ₂) := hp
+    rw [QuotientGroup.eq] at hp'
+    exact (doubleCoset_eq_of_mem (mem_doubleCoset.mpr
+      ⟨(p.1.out : G) * e * p.2.out, Γ₁.mul_mem (Γ₁.mul_mem p.1.out.2 he) p.2.out.2, _, hp',
+        by simp [mul_assoc]⟩)).symm
   · intro h
-    have hg₁d : DoubleCoset.doubleCoset (g₁ : G) P.H P.H =
-        DoubleCoset.doubleCoset (d : G) P.H P.H := (HeckeCoset.eq_iff g₁ d).mp h
-    simp only [heckeMultiplicity]
-    norm_cast
-    rw [Nat.card_eq_one_iff_unique]
-    have : Subsingleton (decompQuot P (HeckeCoset.one P).rep) :=
-      subsingleton_decompQuot_one P
-    refine ⟨⟨?_⟩, nonempty_one_mul_witness_of_doubleCoset_eq P g₁ d hg₁d⟩
-    intro ⟨⟨i₁, j₁⟩, h₁⟩ ⟨⟨i₂, j₂⟩, h₂⟩
-    have hi : i₁ = i₂ := Subsingleton.elim i₁ i₂
-    subst hi
-    simp only [Set.mem_setOf_eq] at h₁ h₂
-    exact Subtype.ext (Prod.ext rfl
-      (decompQuot_snd_eq_of_fst_eq P (HeckeCoset.one P).rep g₁ d i₁ j₁ j₂ h₁ h₂))
-  · intro hm
-    by_contra hne
-    have : heckeMultiplicity P (HeckeCoset.one P).rep g₁ d = 0 := by
-      simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
-      left
-      intro ⟨i, j⟩ heq
-      exact hne ((mulMap_one_mul_eq P g₁ i j).symm.trans
-        (doubleCoset_eq_of_rightCoset_eq P (HeckeCoset.one P).rep g₁ d (i, j) heq))
-    omega
+    haveI := subsingleton_decompQuotient_of_mem he
+    obtain ⟨p, hp⟩ := exists_fibre_of_mem_left he (h ▸ mem_doubleCoset_self Γ₁ Γ₂ d)
+    refine ⟨⟨fun q₁ q₂ ↦ Subtype.ext ?_⟩, ⟨p, hp⟩⟩
+    have hfst : q₁.1.1 = q₂.1.1 := Subsingleton.elim _ _
+    have h₁ : _ = (d : G ⧸ Γ₂) := q₁.2
+    have h₂ : _ = (d : G ⧸ Γ₂) := q₂.2
+    rw [← hfst] at h₂
+    exact Prod.ext hfst (snd_eq_of_fst_eq h₁ h₂)
 
-end HeckeRing
+end DoubleCoset
+
+namespace HeckePair
+
+open DoubleCoset
+
+variable {G : Type*} [Group G] (P : HeckePair G)
+
+attribute [local instance] HeckePair.doubleCosetSetoid
+
+/-- Every pair of representatives multiplies into `⟦g₁⟧` when the second double coset is the
+identity. -/
+lemma mulMap_one_right (g₁ : P.Δ)
+    (p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H ((1 : HeckeCoset P).rep : G)) :
+    P.mulMap g₁ (1 : HeckeCoset P).rep p = (⟦g₁⟧ : HeckeCoset P) :=
+  HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr ⟨(p.1.out : G), p.1.out.2,
+    (p.2.out : G) * ((1 : HeckeCoset P).rep : G),
+    P.H.mul_mem p.2.out.2 HeckeCoset.rep_one_mem, rfl⟩)
+
+/-- Every pair of representatives multiplies into `⟦g₁⟧` when the first double coset is the
+identity. -/
+lemma mulMap_one_left (g₁ : P.Δ)
+    (p : DecompQuotient P.H P.H ((1 : HeckeCoset P).rep : G) × DecompQuotient P.H P.H (g₁ : G)) :
+    P.mulMap (1 : HeckeCoset P).rep g₁ p = (⟦g₁⟧ : HeckeCoset P) :=
+  HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
+    ⟨(p.1.out : G) * ((1 : HeckeCoset P).rep : G) * (p.2.out : G),
+      P.H.mul_mem (P.H.mul_mem p.1.out.2 HeckeCoset.rep_one_mem) p.2.out.2, 1, P.H.one_mem,
+      by simp [mul_assoc]⟩)
+
+/-- Right multiplication by the identity double coset has multiplicity `1` exactly on the
+diagonal. -/
+theorem multiplicity_mul_one (g d : P.Δ) :
+    multiplicity P.H P.H P.H (g : G) ((1 : HeckeCoset P).rep : G) (d : G) = 1 ↔
+      (⟦g⟧ : HeckeCoset P) = ⟦d⟧ := by
+  rw [multiplicity_eq_one_iff_of_mem_right HeckeCoset.rep_one_mem, HeckeCoset.eq_iff]
+
+/-- Left multiplication by the identity double coset has multiplicity `1` exactly on the
+diagonal. -/
+theorem multiplicity_one_mul (g d : P.Δ) :
+    multiplicity P.H P.H P.H ((1 : HeckeCoset P).rep : G) (g : G) (d : G) = 1 ↔
+      (⟦g⟧ : HeckeCoset P) = ⟦d⟧ := by
+  rw [multiplicity_eq_one_iff_of_mem_left HeckeCoset.rep_one_mem, HeckeCoset.eq_iff]
+
+end HeckePair

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
@@ -13,8 +13,8 @@ public import Mathlib.NumberTheory.HeckeRing.Multiplicity
 For `e ∈ Γ₂` the double coset `Γ₂eΓ₂` is `Γ₂` itself, the identity of the Hecke ring of `Γ₂`;
 this file proves the two computations expressing this at the level of Shimura's multiplicity:
 multiplying by such an `e` on either side, the multiplicity is `1` exactly on the diagonal
-`Γ₁gΓ₂ = Γ₁dΓ₂`. Specialised to a Hecke pair, these compute the products `T(g) * T(1)` and
-`T(1) * T(g)` in later files.
+`Γ₁gΓ₂ = Γ₁dΓ₂`. Specialised to a Hecke coset module, these compute the products `T(g) * T(1)`
+and `T(1) * T(g)` in later files.
 
 ## Main results
 
@@ -110,45 +110,45 @@ theorem multiplicity_eq_one_iff_of_mem_left {e g d : G} (he : e ∈ Γ₁) :
 
 end DoubleCoset
 
-namespace HeckePair
+namespace HeckeCoset
 
 open DoubleCoset
 
-variable {G : Type*} [Group G] (P : HeckePair G)
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
 
-attribute [local instance] HeckePair.doubleCosetSetoid
-
-/-- Every pair of representatives multiplies into `⟦g₁⟧` when the second double coset is the
-identity. -/
-lemma mulMap_one_right (g₁ : P.Δ)
-    (p : DecompQuotient P.H P.H (g₁ : G) × DecompQuotient P.H P.H ((1 : HeckeCoset P).rep : G)) :
-    P.mulMap g₁ (1 : HeckeCoset P).rep p = (⟦g₁⟧ : HeckeCoset P) :=
+/-- Every pair of representatives multiplies into `mk H₁ H₂ g₁` when the second double coset is
+the identity. -/
+lemma mulMap_one_right [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₂] (g₁ : Δ)
+    (p : DecompQuotient H₁ H₂ (g₁ : G) ×
+      DecompQuotient H₂ H₂ (((1 : HeckeCoset Δ H₂ H₂).rep : G))) :
+    mulMap H₁ H₂ H₂ g₁ (1 : HeckeCoset Δ H₂ H₂).rep p = mk H₁ H₂ g₁ :=
   HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr ⟨(p.1.out : G), p.1.out.2,
-    (p.2.out : G) * ((1 : HeckeCoset P).rep : G),
-    P.H.mul_mem p.2.out.2 HeckeCoset.rep_one_mem, rfl⟩)
+    (p.2.out : G) * ((1 : HeckeCoset Δ H₂ H₂).rep : G),
+    H₂.mul_mem p.2.out.2 HeckeCoset.rep_one_mem, rfl⟩)
 
-/-- Every pair of representatives multiplies into `⟦g₁⟧` when the first double coset is the
-identity. -/
-lemma mulMap_one_left (g₁ : P.Δ)
-    (p : DecompQuotient P.H P.H ((1 : HeckeCoset P).rep : G) × DecompQuotient P.H P.H (g₁ : G)) :
-    P.mulMap (1 : HeckeCoset P).rep g₁ p = (⟦g₁⟧ : HeckeCoset P) :=
+/-- Every pair of representatives multiplies into `mk H₁ H₂ g₁` when the first double coset is
+the identity. -/
+lemma mulMap_one_left [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H₂] (g₁ : Δ)
+    (p : DecompQuotient H₁ H₁ (((1 : HeckeCoset Δ H₁ H₁).rep : G)) ×
+      DecompQuotient H₁ H₂ (g₁ : G)) :
+    mulMap H₁ H₁ H₂ (1 : HeckeCoset Δ H₁ H₁).rep g₁ p = mk H₁ H₂ g₁ :=
   HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
-    ⟨(p.1.out : G) * ((1 : HeckeCoset P).rep : G) * (p.2.out : G),
-      P.H.mul_mem (P.H.mul_mem p.1.out.2 HeckeCoset.rep_one_mem) p.2.out.2, 1, P.H.one_mem,
+    ⟨(p.1.out : G) * ((1 : HeckeCoset Δ H₁ H₁).rep : G) * (p.2.out : G),
+      H₁.mul_mem (H₁.mul_mem p.1.out.2 HeckeCoset.rep_one_mem) p.2.out.2, 1, H₂.one_mem,
       by simp [mul_assoc]⟩)
 
 /-- Right multiplication by the identity double coset has multiplicity `1` exactly on the
 diagonal. -/
-theorem multiplicity_mul_one (g d : P.Δ) :
-    multiplicity P.H P.H P.H (g : G) ((1 : HeckeCoset P).rep : G) (d : G) = 1 ↔
-      (⟦g⟧ : HeckeCoset P) = ⟦d⟧ := by
+theorem multiplicity_mul_one (g d : Δ) :
+    multiplicity H₁ H₂ H₂ (g : G) ((1 : HeckeCoset Δ H₂ H₂).rep : G) (d : G) = 1 ↔
+      mk H₁ H₂ g = mk H₁ H₂ d := by
   rw [multiplicity_eq_one_iff_of_mem_right HeckeCoset.rep_one_mem, HeckeCoset.eq_iff]
 
 /-- Left multiplication by the identity double coset has multiplicity `1` exactly on the
 diagonal. -/
-theorem multiplicity_one_mul (g d : P.Δ) :
-    multiplicity P.H P.H P.H ((1 : HeckeCoset P).rep : G) (g : G) (d : G) = 1 ↔
-      (⟦g⟧ : HeckeCoset P) = ⟦d⟧ := by
+theorem multiplicity_one_mul (g d : Δ) :
+    multiplicity H₁ H₁ H₂ ((1 : HeckeCoset Δ H₁ H₁).rep : G) (g : G) (d : G) = 1 ↔
+      mk H₁ H₂ g = mk H₁ H₂ d := by
   rw [multiplicity_eq_one_iff_of_mem_left HeckeCoset.rep_one_mem, HeckeCoset.eq_iff]
 
-end HeckePair
+end HeckeCoset

--- a/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
+++ b/Mathlib/NumberTheory/HeckeRing/MultiplicityUnit.lean
@@ -118,7 +118,7 @@ variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
 
 /-- Every pair of representatives multiplies into `mk H₁ H₂ g₁` when the second double coset is
 the identity. -/
-lemma mulMap_one_right [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₂] (g₁ : Δ)
+lemma mulMap_one_right [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₂] (g₁ : Δ)
     (p : DecompQuotient H₁ H₂ (g₁ : G) ×
       DecompQuotient H₂ H₂ (((1 : HeckeCoset Δ H₂ H₂).rep : G))) :
     mulMap H₁ H₂ H₂ g₁ (1 : HeckeCoset Δ H₂ H₂).rep p = mk H₁ H₂ g₁ :=
@@ -128,7 +128,7 @@ lemma mulMap_one_right [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ 
 
 /-- Every pair of representatives multiplies into `mk H₁ H₂ g₁` when the first double coset is
 the identity. -/
-lemma mulMap_one_left [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H₂] (g₁ : Δ)
+lemma mulMap_one_left [IsHeckeTriple Δ H₁ H₁] [IsHeckeTriple Δ H₁ H₂] (g₁ : Δ)
     (p : DecompQuotient H₁ H₁ (((1 : HeckeCoset Δ H₁ H₁).rep : G)) ×
       DecompQuotient H₁ H₂ (g₁ : G)) :
     mulMap H₁ H₁ H₂ (1 : HeckeCoset Δ H₁ H₁).rep g₁ p = mk H₁ H₂ g₁ :=

--- a/Mathlib/NumberTheory/HeckeRing/One.lean
+++ b/Mathlib/NumberTheory/HeckeRing/One.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.HeckeRing.Multiplication
+
+/-!
+# Hecke rings: the identity and the unital non-associative semiring
+
+The identity double coset `HeckeCoset.one` gives the multiplicative identity of the Hecke ring
+`𝕋 P R`, following Shimura, *Introduction to the Arithmetic Theory of Automorphic Functions*,
+Ch. 3. This file proves that the structure-constant finsupp collapses to a single basis element on
+multiplication by the identity, deduces that `tSingle (one) 1` is a two-sided unit, and assembles
+the `NonAssocSemiring (𝕋 P R)` instance.
+
+## Main results
+
+* `HeckeRing.one_def`: `(1 : 𝕋 P R) = tSingle (HeckeCoset.one P) 1`.
+* the `NonAssocSemiring (𝕋 P R)` instance.
+-/
+
+@[expose] public section
+
+open Set DoubleCoset Subgroup Finsupp
+open scoped Pointwise
+
+namespace HeckeRing
+
+variable {G : Type*} [Group G]
+
+attribute [local instance] doubleCosetSetoid
+
+variable (P : HeckePair G)
+
+/-- If every pair maps to a single double coset `D_out` under `mulMap`, the multiplicity vanishes
+on every other double coset. -/
+lemma heckeMultiplicity_eq_zero_of_mulMap_unique (g₁ g₂ : P.Δ) (D_out A : HeckeCoset P)
+    (hA : A ≠ D_out)
+    (h : ∀ p : decompQuot P g₁ × decompQuot P g₂, mulMap P g₁ g₂ p = D_out) :
+    heckeMultiplicity P g₁ g₂ (HeckeCoset.rep A) = 0 :=
+  heckeMultiplicity_eq_zero_of_nmem_mulSupport P g₁ g₂ A (by
+    rw [mulSupport]
+    simp only [Finset.top_eq_univ, Finset.mem_image, Finset.mem_univ, true_and,
+      Prod.exists, not_exists]
+    intro i j heq
+    exact hA (heq ▸ h (i, j)))
+
+/-- When the multiplicity is one on a single double coset and zero elsewhere, the
+structure-constant finsupp is a single basis element. -/
+lemma m_eq_single (g₁ g₂ : P.Δ) (D_out : HeckeCoset P)
+    (h_one : heckeMultiplicity P g₁ g₂ (HeckeCoset.rep D_out) = 1)
+    (h_zero : ∀ A, A ≠ D_out → heckeMultiplicity P g₁ g₂ (HeckeCoset.rep A) = 0) :
+    m P g₁ g₂ = Finsupp.single D_out 1 := by
+  ext A
+  simp only [m, Finsupp.coe_mk, Finsupp.single_apply]
+  split_ifs with h1
+  · exact h1 ▸ h_one
+  · exact h_zero A (ne_comm.mp h1)
+
+/-- The off-diagonal multiplicity for right multiplication by `HeckeCoset.one` is zero. -/
+lemma heckeMultiplicity_mul_one_eq_zero (g₁ : P.Δ) (A : HeckeCoset P)
+    (h : A ≠ (⟦g₁⟧ : HeckeCoset P)) :
+    heckeMultiplicity P g₁ (HeckeCoset.one P).rep (HeckeCoset.rep A) = 0 := by
+  simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
+  left
+  intro ⟨i, j⟩ heq
+  refine h ?_
+  rw [show A = ⟦HeckeCoset.rep A⟧ from (Quotient.out_eq A).symm]
+  exact ((mulMap_mul_one_eq P g₁ i j).symm.trans
+    (doubleCoset_eq_of_rightCoset_eq P g₁ (HeckeCoset.one P).rep (HeckeCoset.rep A)
+      (i, j) heq)).symm
+
+/-- Right multiplication by `HeckeCoset.one` acts as the identity on the structure constants. -/
+lemma m_mul_one_eq_single (g₁ : P.Δ) :
+    m P g₁ (HeckeCoset.one P).rep = Finsupp.single (⟦g₁⟧ : HeckeCoset P) 1 :=
+  m_eq_single P g₁ (HeckeCoset.one P).rep (⟦g₁⟧ : HeckeCoset P)
+    ((heckeMultiplicity_mul_one P g₁ (HeckeCoset.rep (⟦g₁⟧ : HeckeCoset P))).mp
+      (Quotient.out_eq (⟦g₁⟧ : HeckeCoset P)).symm)
+    (heckeMultiplicity_mul_one_eq_zero P g₁)
+
+/-- The off-diagonal multiplicity for left multiplication by `HeckeCoset.one` is zero. -/
+lemma heckeMultiplicity_one_mul_eq_zero (g₁ : P.Δ) (A : HeckeCoset P)
+    (h : A ≠ (⟦g₁⟧ : HeckeCoset P)) :
+    heckeMultiplicity P (HeckeCoset.one P).rep g₁ (HeckeCoset.rep A) = 0 := by
+  simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
+  left
+  intro ⟨i, j⟩ heq
+  refine h ?_
+  rw [show A = ⟦HeckeCoset.rep A⟧ from (Quotient.out_eq A).symm]
+  exact ((mulMap_one_mul_eq P g₁ i j).symm.trans
+    (doubleCoset_eq_of_rightCoset_eq P (HeckeCoset.one P).rep g₁ (HeckeCoset.rep A)
+      (i, j) heq)).symm
+
+/-- Left multiplication by `HeckeCoset.one` acts as the identity on the structure constants. -/
+lemma m_one_mul_eq_single (g₁ : P.Δ) :
+    m P (HeckeCoset.one P).rep g₁ = Finsupp.single (⟦g₁⟧ : HeckeCoset P) 1 :=
+  m_eq_single P (HeckeCoset.one P).rep g₁ (⟦g₁⟧ : HeckeCoset P)
+    ((heckeMultiplicity_one_mul P g₁ (HeckeCoset.rep (⟦g₁⟧ : HeckeCoset P))).mp
+      (Quotient.out_eq (⟦g₁⟧ : HeckeCoset P)).symm)
+    (heckeMultiplicity_one_mul_eq_zero P g₁)
+
+variable (R : Type*) [CommRing R]
+
+/-- Right multiplication by `HeckeCoset.one` on the cast structure constants. -/
+lemma mCast_mul_one_eq_single (g₁ : P.Δ) :
+    mCast P R g₁ (HeckeCoset.one P).rep = Finsupp.single (⟦g₁⟧ : HeckeCoset P) 1 := by
+  unfold mCast
+  rw [m_mul_one_eq_single]
+  exact Finsupp.mapRange_single.trans (congrArg (Finsupp.single ⟦g₁⟧) Int.cast_one)
+
+/-- Left multiplication by `HeckeCoset.one` on the cast structure constants. -/
+lemma mCast_one_mul_eq_single (g₁ : P.Δ) :
+    mCast P R (HeckeCoset.one P).rep g₁ = Finsupp.single (⟦g₁⟧ : HeckeCoset P) 1 := by
+  unfold mCast
+  rw [m_one_mul_eq_single]
+  exact Finsupp.mapRange_single.trans (congrArg (Finsupp.single ⟦g₁⟧) Int.cast_one)
+
+/-- `tSingle D b` is fixed by right multiplication by the identity basis element. -/
+lemma mul_tSingle_one (D : HeckeCoset P) (b : R) :
+    tSingle P R D b * tSingle P R (HeckeCoset.one P) 1 = tSingle P R D b := by
+  rw [mul_single, mCast_mul_one_eq_single, HeckeCoset.mk_rep]
+  simp only [one_smul]
+  exact Finsupp.smul_single_one D b
+
+/-- `tSingle D b` is fixed by left multiplication by the identity basis element. -/
+lemma one_mul_tSingle (D : HeckeCoset P) (b : R) :
+    tSingle P R (HeckeCoset.one P) 1 * tSingle P R D b = tSingle P R D b := by
+  rw [mul_single, mCast_one_mul_eq_single, HeckeCoset.mk_rep]
+  simp only [one_smul]
+  exact Finsupp.smul_single_one D b
+
+/-- The multiplicative identity of the Hecke ring is `tSingle (HeckeCoset.one P) 1`. -/
+noncomputable instance : One (𝕋 P R) :=
+  ⟨tSingle P R (HeckeCoset.one P) 1⟩
+
+/-- The one element of the Hecke ring unfolds to `tSingle (HeckeCoset.one P) 1`. -/
+theorem one_def : (1 : 𝕋 P R) = tSingle P R (HeckeCoset.one P) 1 := rfl
+
+/-- The Hecke ring is a non-associative semiring: `HeckeCoset.one` is a two-sided identity. -/
+noncomputable instance : NonAssocSemiring (𝕋 P R) :=
+  { (inferInstance : NonUnitalNonAssocSemiring (𝕋 P R)) with
+    natCast := fun n ↦ tSingle P R (HeckeCoset.one P) n
+    natCast_zero := by simp only [Nat.cast_zero, single_zero]; rfl
+    natCast_succ := fun _ ↦ by simp only [Nat.cast_add, Nat.cast_one, single_add]; rfl
+    one_mul := fun f ↦ by
+      simp only [one_def, mul_def, tSingle]
+      simp only [Finsupp.sum_single_index, one_smul, zero_smul, Finsupp.sum_fun_zero]
+      nth_rw 2 [← Finsupp.sum_single f]
+      congr
+      ext D z v
+      have := one_mul_tSingle P R D z
+      simp_rw [tSingle] at *
+      rw [← this, mul_single, one_smul]
+    mul_one := fun f ↦ by
+      simp only [one_def, mul_def, zero_smul, smul_zero, sum_single_index, one_smul]
+      nth_rw 2 [← Finsupp.sum_single f]
+      congr
+      ext D z v
+      have := mul_tSingle_one P R D z
+      simp_rw [tSingle] at this
+      rw [← this, mul_single, one_smul] }
+
+end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/One.lean
+++ b/Mathlib/NumberTheory/HeckeRing/One.lean
@@ -11,18 +11,18 @@ public import Mathlib.NumberTheory.HeckeRing.Multiplication
 # Hecke rings: the identity and the unital non-associative semiring
 
 The identity double coset `(1 : HeckeCoset Δ H H)` gives the multiplicative identity of the
-Hecke ring `𝕋 Δ H H R`, following [Shimura][shimura1971], Chapter 3. This file proves that the
+Hecke ring `𝕋 Δ H R`, following [Shimura][shimura1971], Chapter 3. This file proves that the
 structure constants collapse to a single basis element on convolution by the identity, deduces
 the unit laws `1 * f = f` and `f * 1 = f` of the convolution product of Hecke coset modules
 (where the two identities live at the two different levels), and assembles the
-`NonAssocSemiring (𝕋 Δ H H R)` instance.
+`NonAssocSemiring (𝕋 Δ H R)` instance.
 
 ## Main results
 
-* `HeckeCosetModule.one_def`: `(1 : 𝕋 Δ H H R) = single R 1 1`.
+* `HeckeCosetModule.one_def`: `(1 : 𝕋 Δ H R) = single R 1 1`.
 * `HeckeCosetModule.one_mul'`, `HeckeCosetModule.mul_one'`: the identities of the diagonal
   Hecke rings are one-sided units for the convolution product of Hecke coset modules.
-* the `NonAssocSemiring (𝕋 Δ H H R)` instance.
+* the `NonAssocSemiring (𝕋 Δ H R)` instance.
 -/
 
 @[expose] public section
@@ -82,14 +82,14 @@ lemma structureConstants_one_left [IsHeckeTriple Δ H₁ H₁] [IsHeckeTriple Δ
 
 /-- The multiplicative identity of the Hecke ring is the basis element of the identity double
 coset. -/
-noncomputable instance {H : Subgroup G} : One (𝕋 Δ H H R) := ⟨single R 1 1⟩
+noncomputable instance {H : Subgroup G} : One (𝕋 Δ H R) := ⟨single R 1 1⟩
 
-theorem one_def {H : Subgroup G} : (1 : 𝕋 Δ H H R) = single R 1 1 := rfl
+theorem one_def {H : Subgroup G} : (1 : 𝕋 Δ H R) = single R 1 1 := rfl
 
 /-- The identity of the Hecke ring at the left level is a left unit for the convolution
 product of Hecke coset modules. -/
 theorem one_mul' [IsHeckeTriple Δ H₁ H₁] [IsHeckeTriple Δ H₁ H₂]
-    (f : 𝕋 Δ H₁ H₂ R) : mul R (1 : 𝕋 Δ H₁ H₁ R) f = f := by
+    (f : HeckeCosetModule Δ H₁ H₂ R) : mul R (1 : 𝕋 Δ H₁ R) f = f := by
   classical
   rw [one_def, mul_eq_sum, single, Finsupp.sum_single_index (by simp)]
   have inner : ∀ (D₂ : HeckeCoset Δ H₁ H₂) (b₂ : R),
@@ -102,7 +102,7 @@ theorem one_mul' [IsHeckeTriple Δ H₁ H₁] [IsHeckeTriple Δ H₁ H₂]
 /-- The identity of the Hecke ring at the right level is a right unit for the convolution
 product of Hecke coset modules. -/
 theorem mul_one' [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₂]
-    (f : 𝕋 Δ H₁ H₂ R) : mul R f (1 : 𝕋 Δ H₂ H₂ R) = f := by
+    (f : HeckeCosetModule Δ H₁ H₂ R) : mul R f (1 : HeckeCosetModule Δ H₂ H₂ R) = f := by
   classical
   rw [one_def, mul_eq_sum, single]
   have inner : ∀ (D₁ : HeckeCoset Δ H₁ H₂) (b₁ : R),
@@ -117,9 +117,9 @@ theorem mul_one' [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₂]
 /-- The Hecke ring is a non-associative semiring: the identity double coset is a two-sided
 identity. -/
 noncomputable instance {H : Subgroup G} [IsHeckeTriple Δ H H] :
-    NonAssocSemiring (𝕋 Δ H H R) :=
-  { (inferInstance : NonUnitalNonAssocSemiring (𝕋 Δ H H R)),
-    (inferInstance : One (𝕋 Δ H H R)) with
+    NonAssocSemiring (𝕋 Δ H R) :=
+  { (inferInstance : NonUnitalNonAssocSemiring (𝕋 Δ H R)),
+    (inferInstance : One (𝕋 Δ H R)) with
     natCast := fun n ↦ single R 1 n
     natCast_zero := by rw [Nat.cast_zero, single, Finsupp.single_zero]; rfl
     natCast_succ := fun n ↦ by

--- a/Mathlib/NumberTheory/HeckeRing/One.lean
+++ b/Mathlib/NumberTheory/HeckeRing/One.lean
@@ -10,15 +10,19 @@ public import Mathlib.NumberTheory.HeckeRing.Multiplication
 /-!
 # Hecke rings: the identity and the unital non-associative semiring
 
-The identity double coset `(1 : HeckeCoset P)` gives the multiplicative identity of the Hecke
-ring `𝕋 P R`, following [Shimura][shimura1971], Chapter 3. This file proves that the structure
-constants collapse to a single basis element on multiplication by the identity, deduces that
-`single 1 1` is a two-sided unit, and assembles the `NonAssocSemiring (𝕋 P R)` instance.
+The identity double coset `(1 : HeckeCoset Δ H H)` gives the multiplicative identity of the
+Hecke ring `𝕋 Δ H H R`, following [Shimura][shimura1971], Chapter 3. This file proves that the
+structure constants collapse to a single basis element on convolution by the identity, deduces
+the unit laws `1 * f = f` and `f * 1 = f` of the convolution product of Hecke coset modules
+(where the two identities live at the two different levels), and assembles the
+`NonAssocSemiring (𝕋 Δ H H R)` instance.
 
 ## Main results
 
-* `HeckeRing.one_def`: `(1 : 𝕋 P R) = single P R 1 1`.
-* the `NonAssocSemiring (𝕋 P R)` instance.
+* `HeckeCosetModule.one_def`: `(1 : 𝕋 Δ H H R) = single R 1 1`.
+* `HeckeCosetModule.one_mul'`, `HeckeCosetModule.mul_one'`: the identities of the diagonal
+  Hecke rings are one-sided units for the convolution product of Hecke coset modules.
+* the `NonAssocSemiring (𝕋 Δ H H R)` instance.
 -/
 
 @[expose] public section
@@ -26,87 +30,102 @@ constants collapse to a single basis element on multiplication by the identity, 
 open DoubleCoset Finsupp
 open scoped Pointwise
 
-namespace HeckeRing
+namespace HeckeCosetModule
 
-variable {G : Type*} [Group G] (P : HeckePair G) (R : Type*) [Semiring R]
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ : Subgroup G} (R : Type*) [Semiring R]
 
-attribute [local instance] HeckePair.doubleCosetSetoid
-
-/-- The multiplicity for right multiplication by the identity double coset vanishes off the
+/-- The multiplicity for right convolution by the identity double coset vanishes off the
 diagonal. -/
-lemma multiplicity_one_right_eq_zero (g : P.Δ) {A : HeckeCoset P} (hA : A ≠ ⟦g⟧) :
-    multiplicity P.H P.H P.H (g : G) ((1 : HeckeCoset P).rep : G) (A.rep : G) = 0 := by
+lemma multiplicity_one_right_eq_zero [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₂]
+    (g : Δ) {A : HeckeCoset Δ H₁ H₂} (hA : A ≠ HeckeCoset.mk H₁ H₂ g) :
+    multiplicity H₁ H₂ H₂ (g : G) ((1 : HeckeCoset Δ H₂ H₂).rep : G) (A.rep : G) = 0 := by
   by_contra h0
   obtain ⟨⟨p, hp⟩⟩ := (Nat.card_ne_zero.mp h0).1
   refine hA ?_
-  rw [← A.mk_rep, ← P.mulMap_eq_of_mk_eq hp]
-  exact P.mulMap_one_right g p
+  rw [← A.mk_rep, ← HeckeCoset.mulMap_eq_of_mk_eq hp]
+  exact HeckeCoset.mulMap_one_right g p
 
-/-- The multiplicity for left multiplication by the identity double coset vanishes off the
+/-- The multiplicity for left convolution by the identity double coset vanishes off the
 diagonal. -/
-lemma multiplicity_one_left_eq_zero (g : P.Δ) {A : HeckeCoset P} (hA : A ≠ ⟦g⟧) :
-    multiplicity P.H P.H P.H ((1 : HeckeCoset P).rep : G) (g : G) (A.rep : G) = 0 := by
+lemma multiplicity_one_left_eq_zero [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H₂]
+    (g : Δ) {A : HeckeCoset Δ H₁ H₂} (hA : A ≠ HeckeCoset.mk H₁ H₂ g) :
+    multiplicity H₁ H₁ H₂ ((1 : HeckeCoset Δ H₁ H₁).rep : G) (g : G) (A.rep : G) = 0 := by
   by_contra h0
   obtain ⟨⟨p, hp⟩⟩ := (Nat.card_ne_zero.mp h0).1
   refine hA ?_
-  rw [← A.mk_rep, ← P.mulMap_eq_of_mk_eq hp]
-  exact P.mulMap_one_left g p
+  rw [← A.mk_rep, ← HeckeCoset.mulMap_eq_of_mk_eq hp]
+  exact HeckeCoset.mulMap_one_left g p
 
-/-- The structure constants for right multiplication by the identity double coset collapse to
+/-- The structure constants for right convolution by the identity double coset collapse to
 a single basis element. -/
-lemma structureConstants_one_right (g : P.Δ) :
-    structureConstants P R g (1 : HeckeCoset P).rep = single P R ⟦g⟧ 1 := by
+lemma structureConstants_one_right [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₂]
+    (g : Δ) : structureConstants R H₁ H₂ H₂ g (1 : HeckeCoset Δ H₂ H₂).rep =
+      single R (HeckeCoset.mk H₁ H₂ g) 1 := by
   classical
   ext A
   rw [structureConstants_apply, single_apply]
   split_ifs with h
-  · rw [(P.multiplicity_mul_one g A.rep).mpr (h.trans A.mk_rep.symm), Nat.cast_one]
-  · rw [multiplicity_one_right_eq_zero P g fun hA ↦ h hA.symm, Nat.cast_zero]
+  · rw [(HeckeCoset.multiplicity_mul_one g A.rep).mpr (h.trans A.mk_rep.symm), Nat.cast_one]
+  · rw [multiplicity_one_right_eq_zero g fun hA ↦ h hA.symm, Nat.cast_zero]
 
-/-- The structure constants for left multiplication by the identity double coset collapse to
+/-- The structure constants for left convolution by the identity double coset collapse to
 a single basis element. -/
-lemma structureConstants_one_left (g : P.Δ) :
-    structureConstants P R (1 : HeckeCoset P).rep g = single P R ⟦g⟧ 1 := by
+lemma structureConstants_one_left [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H₂]
+    (g : Δ) : structureConstants R H₁ H₁ H₂ (1 : HeckeCoset Δ H₁ H₁).rep g =
+      single R (HeckeCoset.mk H₁ H₂ g) 1 := by
   classical
   ext A
   rw [structureConstants_apply, single_apply]
   split_ifs with h
-  · rw [(P.multiplicity_one_mul g A.rep).mpr (h.trans A.mk_rep.symm), Nat.cast_one]
-  · rw [multiplicity_one_left_eq_zero P g fun hA ↦ h hA.symm, Nat.cast_zero]
+  · rw [(HeckeCoset.multiplicity_one_mul g A.rep).mpr (h.trans A.mk_rep.symm), Nat.cast_one]
+  · rw [multiplicity_one_left_eq_zero g fun hA ↦ h hA.symm, Nat.cast_zero]
 
 /-- The multiplicative identity of the Hecke ring is the basis element of the identity double
 coset. -/
-noncomputable instance : One (𝕋 P R) := ⟨single P R 1 1⟩
+noncomputable instance {H : Subgroup G} : One (𝕋 Δ H H R) := ⟨single R 1 1⟩
 
-theorem one_def : (1 : 𝕋 P R) = single P R 1 1 := rfl
+theorem one_def {H : Subgroup G} : (1 : 𝕋 Δ H H R) = single R 1 1 := rfl
+
+/-- The identity of the Hecke ring at the left level is a left unit for the convolution
+product of Hecke coset modules. -/
+theorem one_mul' [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H₂]
+    (f : 𝕋 Δ H₁ H₂ R) : mul R (1 : 𝕋 Δ H₁ H₁ R) f = f := by
+  classical
+  rw [one_def, mul_eq_sum, single, Finsupp.sum_single_index (by simp)]
+  have inner : ∀ (D₂ : HeckeCoset Δ H₁ H₂) (b₂ : R),
+      (1 : R) • b₂ • structureConstants R H₁ H₁ H₂ (1 : HeckeCoset Δ H₁ H₁).rep D₂.rep =
+        single R D₂ b₂ := fun D₂ b₂ ↦ by
+    rw [one_smul, structureConstants_one_left, HeckeCoset.mk_rep, smul_single_one]
+  simp only [inner]
+  exact sum_single R f
+
+/-- The identity of the Hecke ring at the right level is a right unit for the convolution
+product of Hecke coset modules. -/
+theorem mul_one' [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₂]
+    (f : 𝕋 Δ H₁ H₂ R) : mul R f (1 : 𝕋 Δ H₂ H₂ R) = f := by
+  classical
+  rw [one_def, mul_eq_sum, single]
+  have inner : ∀ (D₁ : HeckeCoset Δ H₁ H₂) (b₁ : R),
+      (Finsupp.single (1 : HeckeCoset Δ H₂ H₂) (1 : R)).sum
+        (fun D₂ b₂ ↦ b₁ • b₂ • structureConstants R H₁ H₂ H₂ D₁.rep D₂.rep) =
+        single R D₁ b₁ := fun D₁ b₁ ↦ by
+    rw [Finsupp.sum_single_index (by simp), one_smul, structureConstants_one_right,
+      HeckeCoset.mk_rep, smul_single_one]
+  simp only [inner]
+  exact sum_single R f
 
 /-- The Hecke ring is a non-associative semiring: the identity double coset is a two-sided
 identity. -/
-noncomputable instance : NonAssocSemiring (𝕋 P R) :=
-  { (inferInstance : NonUnitalNonAssocSemiring (𝕋 P R)), (inferInstance : One (𝕋 P R)) with
-    natCast := fun n ↦ single P R 1 n
+noncomputable instance {H : Subgroup G} [IsHeckeCosetModule Δ H H] :
+    NonAssocSemiring (𝕋 Δ H H R) :=
+  { (inferInstance : NonUnitalNonAssocSemiring (𝕋 Δ H H R)),
+    (inferInstance : One (𝕋 Δ H H R)) with
+    natCast := fun n ↦ single R 1 n
     natCast_zero := by rw [Nat.cast_zero, single, Finsupp.single_zero]; rfl
     natCast_succ := fun n ↦ by
       rw [Nat.cast_add, Nat.cast_one, single, Finsupp.single_add]
       rfl
-    one_mul := fun f ↦ by
-      classical
-      rw [one_def, mul_def, single, Finsupp.sum_single_index (by simp)]
-      have inner : ∀ (D₂ : HeckeCoset P) (b₂ : R),
-          (1 : R) • b₂ • structureConstants P R (1 : HeckeCoset P).rep D₂.rep =
-            single P R D₂ b₂ := fun D₂ b₂ ↦ by
-        rw [one_smul, structureConstants_one_left, HeckeCoset.mk_rep, smul_single_one]
-      simp only [inner]
-      exact sum_single P R f
-    mul_one := fun f ↦ by
-      classical
-      rw [one_def, mul_def, single]
-      have inner : ∀ (D₁ : HeckeCoset P) (b₁ : R), (Finsupp.single (1 : HeckeCoset P) (1 : R)).sum
-          (fun D₂ b₂ ↦ b₁ • b₂ • structureConstants P R D₁.rep D₂.rep) =
-            single P R D₁ b₁ := fun D₁ b₁ ↦ by
-        rw [Finsupp.sum_single_index (by simp), one_smul, structureConstants_one_right,
-          HeckeCoset.mk_rep, smul_single_one]
-      simp only [inner]
-      exact sum_single P R f }
+    one_mul := fun f ↦ one_mul' R f
+    mul_one := fun f ↦ mul_one' R f }
 
-end HeckeRing
+end HeckeCosetModule

--- a/Mathlib/NumberTheory/HeckeRing/One.lean
+++ b/Mathlib/NumberTheory/HeckeRing/One.lean
@@ -10,157 +10,103 @@ public import Mathlib.NumberTheory.HeckeRing.Multiplication
 /-!
 # Hecke rings: the identity and the unital non-associative semiring
 
-The identity double coset `HeckeCoset.one` gives the multiplicative identity of the Hecke ring
-`𝕋 P R`, following Shimura, *Introduction to the Arithmetic Theory of Automorphic Functions*,
-Ch. 3. This file proves that the structure-constant finsupp collapses to a single basis element on
-multiplication by the identity, deduces that `tSingle (one) 1` is a two-sided unit, and assembles
-the `NonAssocSemiring (𝕋 P R)` instance.
+The identity double coset `(1 : HeckeCoset P)` gives the multiplicative identity of the Hecke
+ring `𝕋 P R`, following [Shimura][shimura1971], Chapter 3. This file proves that the structure
+constants collapse to a single basis element on multiplication by the identity, deduces that
+`single 1 1` is a two-sided unit, and assembles the `NonAssocSemiring (𝕋 P R)` instance.
 
 ## Main results
 
-* `HeckeRing.one_def`: `(1 : 𝕋 P R) = tSingle (HeckeCoset.one P) 1`.
+* `HeckeRing.one_def`: `(1 : 𝕋 P R) = single P R 1 1`.
 * the `NonAssocSemiring (𝕋 P R)` instance.
 -/
 
 @[expose] public section
 
-open Set DoubleCoset Subgroup Finsupp
+open DoubleCoset Finsupp
 open scoped Pointwise
 
 namespace HeckeRing
 
-variable {G : Type*} [Group G]
+variable {G : Type*} [Group G] (P : HeckePair G) (R : Type*) [Semiring R]
 
-attribute [local instance] doubleCosetSetoid
+attribute [local instance] HeckePair.doubleCosetSetoid
 
-variable (P : HeckePair G)
+/-- The multiplicity for right multiplication by the identity double coset vanishes off the
+diagonal. -/
+lemma multiplicity_one_right_eq_zero (g : P.Δ) {A : HeckeCoset P} (hA : A ≠ ⟦g⟧) :
+    multiplicity P.H P.H P.H (g : G) ((1 : HeckeCoset P).rep : G) (A.rep : G) = 0 := by
+  by_contra h0
+  obtain ⟨⟨p, hp⟩⟩ := (Nat.card_ne_zero.mp h0).1
+  refine hA ?_
+  rw [← A.mk_rep, ← P.mulMap_eq_of_mk_eq hp]
+  exact P.mulMap_one_right g p
 
-/-- If every pair maps to a single double coset `D_out` under `mulMap`, the multiplicity vanishes
-on every other double coset. -/
-lemma heckeMultiplicity_eq_zero_of_mulMap_unique (g₁ g₂ : P.Δ) (D_out A : HeckeCoset P)
-    (hA : A ≠ D_out)
-    (h : ∀ p : decompQuot P g₁ × decompQuot P g₂, mulMap P g₁ g₂ p = D_out) :
-    heckeMultiplicity P g₁ g₂ (HeckeCoset.rep A) = 0 :=
-  heckeMultiplicity_eq_zero_of_nmem_mulSupport P g₁ g₂ A (by
-    rw [mulSupport]
-    simp only [Finset.top_eq_univ, Finset.mem_image, Finset.mem_univ, true_and,
-      Prod.exists, not_exists]
-    intro i j heq
-    exact hA (heq ▸ h (i, j)))
+/-- The multiplicity for left multiplication by the identity double coset vanishes off the
+diagonal. -/
+lemma multiplicity_one_left_eq_zero (g : P.Δ) {A : HeckeCoset P} (hA : A ≠ ⟦g⟧) :
+    multiplicity P.H P.H P.H ((1 : HeckeCoset P).rep : G) (g : G) (A.rep : G) = 0 := by
+  by_contra h0
+  obtain ⟨⟨p, hp⟩⟩ := (Nat.card_ne_zero.mp h0).1
+  refine hA ?_
+  rw [← A.mk_rep, ← P.mulMap_eq_of_mk_eq hp]
+  exact P.mulMap_one_left g p
 
-/-- When the multiplicity is one on a single double coset and zero elsewhere, the
-structure-constant finsupp is a single basis element. -/
-lemma m_eq_single (g₁ g₂ : P.Δ) (D_out : HeckeCoset P)
-    (h_one : heckeMultiplicity P g₁ g₂ (HeckeCoset.rep D_out) = 1)
-    (h_zero : ∀ A, A ≠ D_out → heckeMultiplicity P g₁ g₂ (HeckeCoset.rep A) = 0) :
-    m P g₁ g₂ = Finsupp.single D_out 1 := by
+/-- The structure constants for right multiplication by the identity double coset collapse to
+a single basis element. -/
+lemma structureConstants_one_right (g : P.Δ) :
+    structureConstants P R g (1 : HeckeCoset P).rep = single P R ⟦g⟧ 1 := by
+  classical
   ext A
-  simp only [m, Finsupp.coe_mk, Finsupp.single_apply]
-  split_ifs with h1
-  · exact h1 ▸ h_one
-  · exact h_zero A (ne_comm.mp h1)
+  rw [structureConstants_apply, single_apply]
+  split_ifs with h
+  · rw [(P.multiplicity_mul_one g A.rep).mpr (h.trans A.mk_rep.symm), Nat.cast_one]
+  · rw [multiplicity_one_right_eq_zero P g fun hA ↦ h hA.symm, Nat.cast_zero]
 
-/-- The off-diagonal multiplicity for right multiplication by `HeckeCoset.one` is zero. -/
-lemma heckeMultiplicity_mul_one_eq_zero (g₁ : P.Δ) (A : HeckeCoset P)
-    (h : A ≠ (⟦g₁⟧ : HeckeCoset P)) :
-    heckeMultiplicity P g₁ (HeckeCoset.one P).rep (HeckeCoset.rep A) = 0 := by
-  simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
-  left
-  intro ⟨i, j⟩ heq
-  refine h ?_
-  rw [show A = ⟦HeckeCoset.rep A⟧ from (Quotient.out_eq A).symm]
-  exact ((mulMap_mul_one_eq P g₁ i j).symm.trans
-    (doubleCoset_eq_of_rightCoset_eq P g₁ (HeckeCoset.one P).rep (HeckeCoset.rep A)
-      (i, j) heq)).symm
+/-- The structure constants for left multiplication by the identity double coset collapse to
+a single basis element. -/
+lemma structureConstants_one_left (g : P.Δ) :
+    structureConstants P R (1 : HeckeCoset P).rep g = single P R ⟦g⟧ 1 := by
+  classical
+  ext A
+  rw [structureConstants_apply, single_apply]
+  split_ifs with h
+  · rw [(P.multiplicity_one_mul g A.rep).mpr (h.trans A.mk_rep.symm), Nat.cast_one]
+  · rw [multiplicity_one_left_eq_zero P g fun hA ↦ h hA.symm, Nat.cast_zero]
 
-/-- Right multiplication by `HeckeCoset.one` acts as the identity on the structure constants. -/
-lemma m_mul_one_eq_single (g₁ : P.Δ) :
-    m P g₁ (HeckeCoset.one P).rep = Finsupp.single (⟦g₁⟧ : HeckeCoset P) 1 :=
-  m_eq_single P g₁ (HeckeCoset.one P).rep (⟦g₁⟧ : HeckeCoset P)
-    ((heckeMultiplicity_mul_one P g₁ (HeckeCoset.rep (⟦g₁⟧ : HeckeCoset P))).mp
-      (Quotient.out_eq (⟦g₁⟧ : HeckeCoset P)).symm)
-    (heckeMultiplicity_mul_one_eq_zero P g₁)
+/-- The multiplicative identity of the Hecke ring is the basis element of the identity double
+coset. -/
+noncomputable instance : One (𝕋 P R) := ⟨single P R 1 1⟩
 
-/-- The off-diagonal multiplicity for left multiplication by `HeckeCoset.one` is zero. -/
-lemma heckeMultiplicity_one_mul_eq_zero (g₁ : P.Δ) (A : HeckeCoset P)
-    (h : A ≠ (⟦g₁⟧ : HeckeCoset P)) :
-    heckeMultiplicity P (HeckeCoset.one P).rep g₁ (HeckeCoset.rep A) = 0 := by
-  simp only [heckeMultiplicity, Nat.cast_eq_zero, Nat.card_eq_zero, isEmpty_subtype]
-  left
-  intro ⟨i, j⟩ heq
-  refine h ?_
-  rw [show A = ⟦HeckeCoset.rep A⟧ from (Quotient.out_eq A).symm]
-  exact ((mulMap_one_mul_eq P g₁ i j).symm.trans
-    (doubleCoset_eq_of_rightCoset_eq P (HeckeCoset.one P).rep g₁ (HeckeCoset.rep A)
-      (i, j) heq)).symm
+theorem one_def : (1 : 𝕋 P R) = single P R 1 1 := rfl
 
-/-- Left multiplication by `HeckeCoset.one` acts as the identity on the structure constants. -/
-lemma m_one_mul_eq_single (g₁ : P.Δ) :
-    m P (HeckeCoset.one P).rep g₁ = Finsupp.single (⟦g₁⟧ : HeckeCoset P) 1 :=
-  m_eq_single P (HeckeCoset.one P).rep g₁ (⟦g₁⟧ : HeckeCoset P)
-    ((heckeMultiplicity_one_mul P g₁ (HeckeCoset.rep (⟦g₁⟧ : HeckeCoset P))).mp
-      (Quotient.out_eq (⟦g₁⟧ : HeckeCoset P)).symm)
-    (heckeMultiplicity_one_mul_eq_zero P g₁)
-
-variable (R : Type*) [CommRing R]
-
-/-- Right multiplication by `HeckeCoset.one` on the cast structure constants. -/
-lemma mCast_mul_one_eq_single (g₁ : P.Δ) :
-    mCast P R g₁ (HeckeCoset.one P).rep = Finsupp.single (⟦g₁⟧ : HeckeCoset P) 1 := by
-  unfold mCast
-  rw [m_mul_one_eq_single]
-  exact Finsupp.mapRange_single.trans (congrArg (Finsupp.single ⟦g₁⟧) Int.cast_one)
-
-/-- Left multiplication by `HeckeCoset.one` on the cast structure constants. -/
-lemma mCast_one_mul_eq_single (g₁ : P.Δ) :
-    mCast P R (HeckeCoset.one P).rep g₁ = Finsupp.single (⟦g₁⟧ : HeckeCoset P) 1 := by
-  unfold mCast
-  rw [m_one_mul_eq_single]
-  exact Finsupp.mapRange_single.trans (congrArg (Finsupp.single ⟦g₁⟧) Int.cast_one)
-
-/-- `tSingle D b` is fixed by right multiplication by the identity basis element. -/
-lemma mul_tSingle_one (D : HeckeCoset P) (b : R) :
-    tSingle P R D b * tSingle P R (HeckeCoset.one P) 1 = tSingle P R D b := by
-  rw [mul_single, mCast_mul_one_eq_single, HeckeCoset.mk_rep]
-  simp only [one_smul]
-  exact Finsupp.smul_single_one D b
-
-/-- `tSingle D b` is fixed by left multiplication by the identity basis element. -/
-lemma one_mul_tSingle (D : HeckeCoset P) (b : R) :
-    tSingle P R (HeckeCoset.one P) 1 * tSingle P R D b = tSingle P R D b := by
-  rw [mul_single, mCast_one_mul_eq_single, HeckeCoset.mk_rep]
-  simp only [one_smul]
-  exact Finsupp.smul_single_one D b
-
-/-- The multiplicative identity of the Hecke ring is `tSingle (HeckeCoset.one P) 1`. -/
-noncomputable instance : One (𝕋 P R) :=
-  ⟨tSingle P R (HeckeCoset.one P) 1⟩
-
-/-- The one element of the Hecke ring unfolds to `tSingle (HeckeCoset.one P) 1`. -/
-theorem one_def : (1 : 𝕋 P R) = tSingle P R (HeckeCoset.one P) 1 := rfl
-
-/-- The Hecke ring is a non-associative semiring: `HeckeCoset.one` is a two-sided identity. -/
+/-- The Hecke ring is a non-associative semiring: the identity double coset is a two-sided
+identity. -/
 noncomputable instance : NonAssocSemiring (𝕋 P R) :=
-  { (inferInstance : NonUnitalNonAssocSemiring (𝕋 P R)) with
-    natCast := fun n ↦ tSingle P R (HeckeCoset.one P) n
-    natCast_zero := by simp only [Nat.cast_zero, single_zero]; rfl
-    natCast_succ := fun _ ↦ by simp only [Nat.cast_add, Nat.cast_one, single_add]; rfl
+  { (inferInstance : NonUnitalNonAssocSemiring (𝕋 P R)), (inferInstance : One (𝕋 P R)) with
+    natCast := fun n ↦ single P R 1 n
+    natCast_zero := by rw [Nat.cast_zero, single, Finsupp.single_zero]; rfl
+    natCast_succ := fun n ↦ by
+      rw [Nat.cast_add, Nat.cast_one, single, Finsupp.single_add]
+      rfl
     one_mul := fun f ↦ by
-      simp only [one_def, mul_def, tSingle]
-      simp only [Finsupp.sum_single_index, one_smul, zero_smul, Finsupp.sum_fun_zero]
-      nth_rw 2 [← Finsupp.sum_single f]
-      congr
-      ext D z v
-      have := one_mul_tSingle P R D z
-      simp_rw [tSingle] at *
-      rw [← this, mul_single, one_smul]
+      classical
+      rw [one_def, mul_def, single, Finsupp.sum_single_index (by simp)]
+      have inner : ∀ (D₂ : HeckeCoset P) (b₂ : R),
+          (1 : R) • b₂ • structureConstants P R (1 : HeckeCoset P).rep D₂.rep =
+            single P R D₂ b₂ := fun D₂ b₂ ↦ by
+        rw [one_smul, structureConstants_one_left, HeckeCoset.mk_rep, smul_single_one]
+      simp only [inner]
+      exact sum_single P R f
     mul_one := fun f ↦ by
-      simp only [one_def, mul_def, zero_smul, smul_zero, sum_single_index, one_smul]
-      nth_rw 2 [← Finsupp.sum_single f]
-      congr
-      ext D z v
-      have := mul_tSingle_one P R D z
-      simp_rw [tSingle] at this
-      rw [← this, mul_single, one_smul] }
+      classical
+      rw [one_def, mul_def, single]
+      have inner : ∀ (D₁ : HeckeCoset P) (b₁ : R), (Finsupp.single (1 : HeckeCoset P) (1 : R)).sum
+          (fun D₂ b₂ ↦ b₁ • b₂ • structureConstants P R D₁.rep D₂.rep) =
+            single P R D₁ b₁ := fun D₁ b₁ ↦ by
+        rw [Finsupp.sum_single_index (by simp), one_smul, structureConstants_one_right,
+          HeckeCoset.mk_rep, smul_single_one]
+      simp only [inner]
+      exact sum_single P R f }
 
 end HeckeRing

--- a/Mathlib/NumberTheory/HeckeRing/One.lean
+++ b/Mathlib/NumberTheory/HeckeRing/One.lean
@@ -36,7 +36,7 @@ variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ : Subgroup G} (R : 
 
 /-- The multiplicity for right convolution by the identity double coset vanishes off the
 diagonal. -/
-lemma multiplicity_one_right_eq_zero [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₂]
+lemma multiplicity_one_right_eq_zero [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₂]
     (g : Δ) {A : HeckeCoset Δ H₁ H₂} (hA : A ≠ HeckeCoset.mk H₁ H₂ g) :
     multiplicity H₁ H₂ H₂ (g : G) ((1 : HeckeCoset Δ H₂ H₂).rep : G) (A.rep : G) = 0 := by
   by_contra h0
@@ -47,7 +47,7 @@ lemma multiplicity_one_right_eq_zero [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeC
 
 /-- The multiplicity for left convolution by the identity double coset vanishes off the
 diagonal. -/
-lemma multiplicity_one_left_eq_zero [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H₂]
+lemma multiplicity_one_left_eq_zero [IsHeckeTriple Δ H₁ H₁] [IsHeckeTriple Δ H₁ H₂]
     (g : Δ) {A : HeckeCoset Δ H₁ H₂} (hA : A ≠ HeckeCoset.mk H₁ H₂ g) :
     multiplicity H₁ H₁ H₂ ((1 : HeckeCoset Δ H₁ H₁).rep : G) (g : G) (A.rep : G) = 0 := by
   by_contra h0
@@ -58,7 +58,7 @@ lemma multiplicity_one_left_eq_zero [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCo
 
 /-- The structure constants for right convolution by the identity double coset collapse to
 a single basis element. -/
-lemma structureConstants_one_right [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₂]
+lemma structureConstants_one_right [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₂]
     (g : Δ) : structureConstants R H₁ H₂ H₂ g (1 : HeckeCoset Δ H₂ H₂).rep =
       single R (HeckeCoset.mk H₁ H₂ g) 1 := by
   classical
@@ -70,7 +70,7 @@ lemma structureConstants_one_right [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCos
 
 /-- The structure constants for left convolution by the identity double coset collapse to
 a single basis element. -/
-lemma structureConstants_one_left [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H₂]
+lemma structureConstants_one_left [IsHeckeTriple Δ H₁ H₁] [IsHeckeTriple Δ H₁ H₂]
     (g : Δ) : structureConstants R H₁ H₁ H₂ (1 : HeckeCoset Δ H₁ H₁).rep g =
       single R (HeckeCoset.mk H₁ H₂ g) 1 := by
   classical
@@ -88,7 +88,7 @@ theorem one_def {H : Subgroup G} : (1 : 𝕋 Δ H H R) = single R 1 1 := rfl
 
 /-- The identity of the Hecke ring at the left level is a left unit for the convolution
 product of Hecke coset modules. -/
-theorem one_mul' [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H₂]
+theorem one_mul' [IsHeckeTriple Δ H₁ H₁] [IsHeckeTriple Δ H₁ H₂]
     (f : 𝕋 Δ H₁ H₂ R) : mul R (1 : 𝕋 Δ H₁ H₁ R) f = f := by
   classical
   rw [one_def, mul_eq_sum, single, Finsupp.sum_single_index (by simp)]
@@ -101,7 +101,7 @@ theorem one_mul' [IsHeckeCosetModule Δ H₁ H₁] [IsHeckeCosetModule Δ H₁ H
 
 /-- The identity of the Hecke ring at the right level is a right unit for the convolution
 product of Hecke coset modules. -/
-theorem mul_one' [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H₂]
+theorem mul_one' [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₂]
     (f : 𝕋 Δ H₁ H₂ R) : mul R f (1 : 𝕋 Δ H₂ H₂ R) = f := by
   classical
   rw [one_def, mul_eq_sum, single]
@@ -116,7 +116,7 @@ theorem mul_one' [IsHeckeCosetModule Δ H₁ H₂] [IsHeckeCosetModule Δ H₂ H
 
 /-- The Hecke ring is a non-associative semiring: the identity double coset is a two-sided
 identity. -/
-noncomputable instance {H : Subgroup G} [IsHeckeCosetModule Δ H H] :
+noncomputable instance {H : Subgroup G} [IsHeckeTriple Δ H H] :
     NonAssocSemiring (𝕋 Δ H H R) :=
   { (inferInstance : NonUnitalNonAssocSemiring (𝕋 Δ H H R)),
     (inferInstance : One (𝕋 Δ H H R)) with

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -3661,6 +3661,21 @@
   school        = {University of British Columbia}
 }
 
+@Book{            krieg1990,
+  author        = {Krieg, Aloys},
+  title         = {Hecke algebras},
+  series        = {Memoirs of the American Mathematical Society},
+  volume        = {87},
+  number        = {435},
+  publisher     = {American Mathematical Society, Providence, RI},
+  year          = {1990},
+  pages         = {x+158},
+  issn          = {0065-9266},
+  mrnumber      = {1027069},
+  doi           = {10.1090/memo/0435},
+  url           = {https://doi.org/10.1090/memo/0435}
+}
+
 @Book{            kung_rota_yan2009,
   author        = {Kung, Joseph P. S. and Rota, Gian-Carlo and Yan, Catherine
                   H.},
@@ -5383,6 +5398,20 @@
   keywords      = {00B15,14-06},
   zbmath        = {3370272},
   zbl           = {0234.00007}
+}
+
+@Book{            shimura1971,
+  author        = {Shimura, Goro},
+  title         = {Introduction to the arithmetic theory of automorphic
+                  functions},
+  series        = {Publications of the Mathematical Society of Japan},
+  volume        = {11},
+  note          = {Kan\^{o} Memorial Lectures, No. 1},
+  publisher     = {Iwanami Shoten Publishers, Tokyo; Princeton University
+                  Press, Princeton, NJ},
+  year          = {1971},
+  pages         = {xiv+267},
+  mrnumber      = {0314766}
 }
 
 @Book{            sierpinski1958,


### PR DESCRIPTION
Associativity of the convolution product of Hecke coset modules, in mixed-coset generality (Proposition 3.2 of Shimura): Shimura's multiplicity `m(g, h; d)` depends on `d` only through its double coset `Γ₁dΓ₃` (`DoubleCoset.multiplicity_doubleCoset_congr`, via the one-sided description `multiplicity_eq_card_filter` — the second representative in a fibre pair is determined by the first — and an explicit fibre bijection for left translation), so both associations of a triple product count the pairs of representatives moving `d` into `H₃g₃H₄`, giving `sum_multiplicity_assoc` for the structure constants and `HeckeCosetModule.mul_assoc'` at the level of `𝕋 Δ H₁ H₂ R × 𝕋 Δ H₂ H₃ R × 𝕋 Δ H₃ H₄ R`. The diagonal Hecke ring `𝕋 Δ H H R` is accordingly upgraded to a `Semiring`.

_Prepared by Claude._

- [ ] depends on: #41279