### PR TITLE
[Merged by Bors] - doc(NumberTheory): fix Bernoulli polynomial theorem link

### DIFF
--- a/Mathlib/NumberTheory/BernoulliPolynomials.lean
+++ b/Mathlib/NumberTheory/BernoulliPolynomials.lean
@@ -29,7 +29,7 @@ Bernoulli polynomials are defined using `bernoulli`, the Bernoulli numbers.
 
 ## Main theorems
 
-- `sum_bernoulli`: The sum of the $k^\mathrm{th}$ Bernoulli polynomial with binomial
+- `Polynomial.sum_bernoulli`: The sum of the $k^\mathrm{th}$ Bernoulli polynomial with binomial
   coefficients up to `n` is `(n + 1) * X^n`.
 - `Polynomial.bernoulli_generating_function`: The Bernoulli polynomials act as generating functions
   for the exponential.


### PR DESCRIPTION
This fully qualifies the module-doc reference to `Polynomial.sum_bernoulli` so the generated docs link to the Bernoulli polynomial theorem in this file, rather than the root `sum_bernoulli` theorem for Bernoulli numbers.