### PR TITLE
doc(1000-yaml): add Goodstein's theorem and the Kirby–Paris theorem

### DIFF
--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1433,14 +1433,14 @@ Q1149022:
 
 Q1149185X:
   title: Kirby–Paris theorem
-  url: https://github.com/gotrevor/goodstein-independence/blob/3c41d35b45f3ed6f2ec55af17e735fa7300cee62/src/GoodsteinPA/Statement.lean#L50
+  url: https://github.com/gotrevor/goodstein-independence/blob/main/src/GoodsteinPA/Statement.lean
   authors: Trevor Morris
   date: 2026-07-03
   comment: "Peano Arithmetic does not prove that every Goodstein sequence terminates (Kirby–Paris, 1982). Standalone Lean 4 formalization built on the FormalizedFormalLogic/Foundation library."
 
 Q1149185:
   title: Goodstein's theorem
-  url: https://github.com/gotrevor/lean-gallery/blob/f4c466986d0fa75a3e5260e2f7825fad301f5fde/LeanGallery/Logic/Goodstein/Statement.lean#L42
+  url: https://github.com/gotrevor/lean-gallery/blob/main/LeanGallery/Logic/Goodstein/Statement.lean
   authors: Trevor Morris
 
 Q1149458:

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1433,9 +1433,15 @@ Q1149022:
 
 Q1149185X:
   title: Kirby–Paris theorem
+  url: https://github.com/gotrevor/goodstein-independence/blob/3c41d35b45f3ed6f2ec55af17e735fa7300cee62/src/GoodsteinPA/Statement.lean#L50
+  authors: Trevor Morris
+  date: 2026-07-03
+  comment: "Peano Arithmetic does not prove that every Goodstein sequence terminates (Kirby–Paris, 1982). Standalone Lean 4 formalization built on the FormalizedFormalLogic/Foundation library."
 
 Q1149185:
   title: Goodstein's theorem
+  url: https://github.com/gotrevor/lean-gallery/blob/f4c466986d0fa75a3e5260e2f7825fad301f5fde/LeanGallery/Logic/Goodstein/Statement.lean#L42
+  authors: Trevor Morris
 
 Q1149458:
   title: Compactness theorem


### PR DESCRIPTION
Claims two listed-but-unclaimed entries in the 1000+ theorems scoreboard by adding external-formalization pointers (no mathlib declaration; same pattern as Löb's theorem [`Q204884`](https://github.com/leanprover-community/mathlib4/blob/master/docs/1000.yaml#L201), the flypitch continuum-hypothesis independence [`Q208416`](https://github.com/leanprover-community/mathlib4/blob/master/docs/1000.yaml#L216), and Arrow's impossibility theorem [`Q33481`](https://github.com/leanprover-community/mathlib4/blob/master/docs/1000.yaml#L30)).

## Entries

| Wikidata | Theorem | Formalization |
|----------|---------|---------------|
| `Q1149185` | **Goodstein's theorem** — every Goodstein sequence terminates | [`lean-gallery`](https://github.com/gotrevor/lean-gallery/blob/main/LeanGallery/Logic/Goodstein/Statement.lean) (ordinal-descent proof) |
| `Q1149185X` | **Kirby–Paris theorem** — PA does not prove that every Goodstein sequence terminates | [`goodstein-independence`](https://github.com/gotrevor/goodstein-independence/blob/main/src/GoodsteinPA/Statement.lean) |

## Notes

- **`Q1149185X` (Kirby–Paris, 1982)** is built on the [`FormalizedFormalLogic/Foundation`](https://github.com/FormalizedFormalLogic/Foundation) library (the same library that backs the existing Löb's-theorem entry [`Q204884`](https://github.com/leanprover-community/mathlib4/blob/master/docs/1000.yaml#L201)), via the Wainer growth-rate route (`Goodstein` outgrows every PA-provably-total function). The headline `peano_not_proves_goodstein` is sorry-free and `#print axioms`-clean — it rests on exactly `[propext, Classical.choice, Quot.sound]`.
- **`Q1149185`** is Goodstein's theorem proper (the termination statement, provable in ZFC / Lean); mathlib does not currently contain it.
- Both formalizations are by Trevor Morris, developed with AI assistance: Claude Code (Fable 5, Opus), Codex, and Harmonic's Aristotle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)