### PR TITLE
feat(Tactic/ComputablePolynomial): poly_decide, axiom-free reflection for Polynomial

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7254,6 +7254,7 @@ public import Mathlib.Tactic.ClickSuggestions.Util
 public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.Basic
+public import Mathlib.Tactic.ComputablePolynomial.OfList
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7255,6 +7255,7 @@ public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.Basic
 public import Mathlib.Tactic.ComputablePolynomial.OfList
+public import Mathlib.Tactic.ComputablePolynomial.Reflect
 public import Mathlib.Tactic.ComputablePolynomial.Ring
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7253,6 +7253,7 @@ public import Mathlib.Tactic.ClickSuggestions.Unfold
 public import Mathlib.Tactic.ClickSuggestions.Util
 public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
+public import Mathlib.Tactic.ComputablePolynomial.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7255,6 +7255,7 @@ public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.Basic
 public import Mathlib.Tactic.ComputablePolynomial.OfList
+public import Mathlib.Tactic.ComputablePolynomial.Ring
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -70,6 +70,7 @@ public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.Basic
 public import Mathlib.Tactic.ComputablePolynomial.OfList
+public import Mathlib.Tactic.ComputablePolynomial.Ring
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -68,6 +68,7 @@ public import Mathlib.Tactic.ClickSuggestions.Unfold
 public import Mathlib.Tactic.ClickSuggestions.Util
 public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
+public import Mathlib.Tactic.ComputablePolynomial.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -70,6 +70,7 @@ public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.Basic
 public import Mathlib.Tactic.ComputablePolynomial.OfList
+public import Mathlib.Tactic.ComputablePolynomial.Reflect
 public import Mathlib.Tactic.ComputablePolynomial.Ring
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -69,6 +69,7 @@ public import Mathlib.Tactic.ClickSuggestions.Util
 public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.Basic
+public import Mathlib.Tactic.ComputablePolynomial.OfList
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib/Tactic/ComputablePolynomial/Basic.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/Basic.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+module
+
+public import Mathlib.Algebra.Polynomial.AlgebraMap
+public import Mathlib.Tactic.Common
+public import Mathlib.Tactic.Ring
+
+/-!
+# Computable univariate polynomials (`SparsePoly`): definition and addition
+
+A computational representation of univariate polynomials over a commutative ring `R` with
+`DecidableEq R`. A `SparsePoly R` is stored as a list of `(exponent, coefficient)` pairs in `ℕ × R`
+with the exponents in strictly decreasing order and all coefficients nonzero (so the zero
+polynomial is the empty list). This invariant makes the representation canonical.
+
+This file defines the structure, the semantics `toPoly : SparsePoly R → Polynomial R`, and
+addition. Further files in this directory build up to a `CommRing` instance, an `AlgEquiv` with
+`Polynomial R`, division, and the reflection tactics (`poly_decide`, `poly_eval`, `poly_dvd`),
+for which this library is the computational backend.
+
+## Implementation notes
+
+`DecidableEq R` is required so that zero coefficients can be recognised and dropped, keeping the
+list canonical (hence equality of `SparsePoly R` is decidable by structural comparison).
+
+J. Davenport notes that Lean permits the trivial ring (in which `0 = 1`); supporting it here costs
+extra case analysis, and one may wish to rethink whether to allow it.
+
+## Provenance
+
+Started by Mario Carneiro at the Hausdorff Institute, June 2024, with design notes and an
+original Lean prototype by James Davenport
+(https://github.com/JamesHDavenport/Dagstuhl23401, `verify-irred/VerifyIrred`); the
+multivariate analogue (`MvSparsePoly`) and the reflection tactics were developed subsequently.
+-/
+
+@[expose] public section
+
+/-- A computable univariate polynomial over `R`, stored as a list of `(exponent, coefficient)`
+pairs with exponents in strictly decreasing order and all coefficients nonzero (so the zero
+polynomial is `[]`). These invariants make the representation canonical. -/
+@[ext] structure SparsePoly (R : Type) [CommRing R] : Type where
+  /-- The underlying list of `(exponent, coefficient)` pairs, ordered by strictly decreasing
+  exponent with all coefficients nonzero. -/
+  coeffs : List (ℕ × R)
+  sorted : coeffs.Pairwise (·.1 > ·.1)
+  nonzero : ∀ x ∈ coeffs, x.2 ≠ 0
+
+namespace SparsePoly
+open Polynomial
+
+variable {R}
+
+instance [CommRing R] [Lean.ToFormat R] : Lean.ToFormat (SparsePoly R) where
+  format x :=
+    have := x.coeffs.foldl (init := none) fun (f : Option Lean.Format) (i, x) =>
+      let monomial := if i = 0 then f!"({x})" else if i = 1 then f!"({x})*X" else f!"({x})*X^{i}"
+      match f with
+      | none => monomial
+      | some f => f ++ " + " ++ monomial
+    this.getD f!"0"
+
+variable [CommRing R] [DecidableEq R]
+/-- Builds a `SparsePoly R` from a list already sorted by strictly decreasing exponent, dropping
+any pairs with zero coefficient to restore the canonical invariant. -/
+def ofSortedList
+    (coeffs : List (ℕ × R)) (sorted : coeffs.Pairwise (·.1 > ·.1)) :
+    SparsePoly R where
+  coeffs := coeffs.filter (·.2 ≠ 0)
+  sorted := sorted.sublist (List.filter_sublist)
+  nonzero := by simp [List.mem_filter]
+
+theorem ofSortedList_of_nonzero {R : Type} [CommRing R] [DecidableEq R]
+    (coeffs : List (ℕ × R)) (nonzero : ∀ x ∈ coeffs, x.2 ≠ 0) (sorted) :
+    (ofSortedList coeffs sorted).coeffs = coeffs := by
+  simp (config := {contextual := true}) [ofSortedList, nonzero]
+
+instance : Zero (SparsePoly R) where
+  zero := { coeffs := [], sorted := .nil, nonzero := nofun }
+
+/-- The constant polynomial. `ofSortedList` drops the term when `r = 0`. -/
+def C (r : R) : SparsePoly R := ofSortedList [(0, r)] (List.pairwise_singleton _ _)
+
+instance : One (SparsePoly R) where
+  one := C 1
+
+/-- `degLt a l` holds when every pair in `l` has exponent strictly less than `a`. -/
+def degLt (a : ℕ) (l : List (ℕ × R)) : Prop := ∀ x ∈ l, x.1 < a
+
+/-- Interprets a list of `(exponent, coefficient)` pairs as the Mathlib polynomial
+`∑ Polynomial.C a * Polynomial.X ^ i`. -/
+noncomputable def toPolyCore : List (ℕ × R) → R[X]
+  | [] => 0
+  | (i, a) :: x => Polynomial.C a * Polynomial.X^i + toPolyCore x
+
+/-- The Mathlib `Polynomial R` represented by a `SparsePoly R`. -/
+noncomputable def toPoly (x : SparsePoly R) : Polynomial R :=
+  toPolyCore x.coeffs
+
+/-- Adds two exponent-sorted coefficient lists by merging on exponent, summing coefficients on
+matching exponents and dropping any term whose sum is zero. -/
+def addCore : List (ℕ × R) → List (ℕ × R) → List (ℕ × R)
+  | [], yy => yy
+  | xx, [] => xx
+  | xx@((i, a) :: x), yy@((j, b) :: y) =>
+    if i < j then
+      (j, b) :: addCore xx y
+    else if j < i then
+      (i, a) :: addCore x yy
+    else
+      ( fun c => if c=0 then addCore x y else (i, c) :: addCore x y) (a+b)
+    termination_by xx yy => xx.length + yy.length
+
+theorem addCore_degLt {n : ℕ} : ∀ {x y : List (ℕ × R)},
+    degLt n x → degLt n y → degLt n (addCore x y)
+  | [], yy, _, hy => by
+    unfold addCore
+    exact hy
+  | (i, a) :: x, [], hx, _ => by
+    unfold addCore
+    exact hx
+  | xx@((i, a) :: x), yy@((j, b) :: y), hx, hy => by
+    have hx_head : i < n := hx (i, a) List.mem_cons_self
+    have hx_tail : degLt n x := fun e he => hx e (List.mem_cons_of_mem _ he)
+    have hy_head : j < n := hy (j, b) List.mem_cons_self
+    have hy_tail : degLt n y := fun e he => hy e (List.mem_cons_of_mem _ he)
+    unfold addCore
+    split
+    · intro e he
+      simp only [List.mem_cons] at he
+      rcases he with rfl | he
+      · exact hy_head
+      · exact addCore_degLt hx hy_tail e he
+    · split
+      · intro e he
+        simp only [List.mem_cons] at he
+        rcases he with rfl | he
+        · exact hx_head
+        · exact addCore_degLt hx_tail hy e he
+      · dsimp only
+        split
+        · exact addCore_degLt hx_tail hy_tail
+        · intro e he
+          simp only [List.mem_cons] at he
+          rcases he with rfl | he
+          · exact hx_head
+          · exact addCore_degLt hx_tail hy_tail e he
+termination_by x y => x.length + y.length
+
+theorem addCore_sorted : ∀ {x y : List (ℕ × R)},
+    x.Pairwise (·.1 > ·.1) → y.Pairwise (·.1 > ·.1) →
+    (addCore x y).Pairwise (·.1 > ·.1)
+  | [], yy, _, hy => by
+    unfold addCore
+    exact hy
+  | (i, a) :: x, [], hx, _ => by
+    unfold addCore
+    exact hx
+  | xx@((i, a) :: x), yy@((j, b) :: y), hx, hy => by
+    have ⟨hi, hx'⟩ := List.pairwise_cons.1 hx
+    have ⟨hj, hy'⟩ := List.pairwise_cons.1 hy
+    unfold addCore
+    split
+    · next ij =>
+      constructor
+      · apply addCore_degLt
+        · intro
+          | _, .head _ => exact ij
+          | p, .tail _ hp => exact (hi _ hp).trans ij
+        · exact hj
+      · exact addCore_sorted hx hy'
+    · split
+      · next ji =>
+        constructor
+        · apply addCore_degLt
+          · exact hi
+          · intro
+            | _, .head _ => exact ji
+            | p, .tail _ hp => exact (hj _ hp).trans ji
+        · exact addCore_sorted hx' hy
+      · cases (by omega : i = j)
+        dsimp only
+        split
+        · exact addCore_sorted hx' hy'
+        · constructor
+          · exact addCore_degLt hi hj
+          · exact addCore_sorted hx' hy'
+termination_by x y => x.length + y.length
+
+instance : Add (SparsePoly R) where
+  add x y :=
+    let coeffs := addCore x.coeffs y.coeffs
+    ofSortedList coeffs (addCore_sorted x.sorted y.sorted)
+
+end SparsePoly

--- a/Mathlib/Tactic/ComputablePolynomial/OfList.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/OfList.lean
@@ -1,0 +1,299 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.Basic
+
+/-!
+# `SparsePoly`: construction from unsorted lists and injectivity of `toPoly`
+
+`ofList` builds a canonical `SparsePoly R` from an arbitrary `(exponent, coefficient)` list by
+sorting and merging; `X` is the sparse variable. The main result is `toPoly_injective`: the
+canonical-form invariant makes the semantics map injective, which is what the reflection tactics
+rely on to transport decidable equality.
+-/
+
+@[expose] public section
+
+namespace SparsePoly
+
+open Polynomial
+
+variable {R : Type} [CommRing R] [DecidableEq R]
+
+/-- Collapses adjacent entries with equal exponents in a list by summing their coefficients,
+turning a list sorted by nonincreasing exponents into one with distinct exponents. -/
+def dedupList : List (ℕ × R) → List (ℕ × R)
+  | (i, a) :: (j, b) :: x =>
+    if i = j then
+      dedupList ((i, a + b) :: x)
+    else
+      (i, a) :: dedupList ((j, b) :: x)
+  | x => x
+
+omit [DecidableEq R] in
+lemma dedupList_degLt {n : ℕ} : ∀ (l : List (ℕ × R)),
+    degLt n l → degLt n (dedupList l)
+  | [] => fun h => by
+    unfold dedupList
+    exact h
+  | [(i, a)] => fun h => by
+    unfold dedupList
+    exact h
+  | (i, a) :: (j, b) :: xs => fun h => by
+    unfold dedupList
+    split
+    · apply dedupList_degLt
+      intro e he
+      simp only [List.mem_cons] at he
+      rcases he with rfl | he
+      · exact h (i, a) List.mem_cons_self
+      · exact h e (List.mem_cons_of_mem _ (List.mem_cons_of_mem _ he))
+    · intro e he
+      simp only [List.mem_cons] at he
+      rcases he with rfl | he
+      · exact h (i, a) List.mem_cons_self
+      · have h_tail : degLt n ((j, b) :: xs) := fun x hx => h x (List.mem_cons_of_mem _ hx)
+        exact dedupList_degLt ((j, b) :: xs) h_tail e he
+termination_by l => l.length
+
+omit [DecidableEq R] in
+theorem dedupList_sorted : ∀ (coeffs : List (ℕ × R)),
+    coeffs.Pairwise (·.1 ≥ ·.1) →
+    (dedupList coeffs).Pairwise (·.1 > ·.1)
+  | [] => fun _ => by
+    unfold dedupList
+    exact List.Pairwise.nil
+  | [(i, a)] => fun _ => by
+    unfold dedupList
+    rw [List.pairwise_cons]
+    exact ⟨fun e he => by contradiction, List.Pairwise.nil⟩
+  | (i, a) :: (j, b) :: xs => fun h => by
+    have h_ij : i ≥ j := (List.pairwise_cons.1 h).1 (j, b) List.mem_cons_self
+    have h_tail : ((j, b) :: xs).Pairwise (·.1 ≥ ·.1) := (List.pairwise_cons.1 h).2
+    unfold dedupList
+    split
+    · apply dedupList_sorted
+      rw [List.pairwise_cons]
+      refine ⟨fun e he => ?_, (List.pairwise_cons.1 h_tail).2⟩
+      have h_je : j ≥ e.1 := (List.pairwise_cons.1 h_tail).1 e he
+      omega
+    · next hneq =>
+      have hij_strict : i > j := by omega
+      rw [List.pairwise_cons]
+      refine ⟨?_, dedupList_sorted ((j, b) :: xs) h_tail⟩
+      apply dedupList_degLt
+      intro e he
+      simp only [List.mem_cons] at he
+      rcases he with rfl | he
+      · exact hij_strict
+      · have h_je : j ≥ e.1 := (List.pairwise_cons.1 h_tail).1 e he
+        omega
+termination_by coeffs => coeffs.length
+
+/-- Builds a `SparsePoly R` from an arbitrary list of `(exponent, coefficient)` pairs by sorting on
+exponent, merging duplicate exponents, and dropping zero coefficients. -/
+def ofList (coeffs : List (ℕ × R)) : SparsePoly R :=
+  let r : ℕ × R → ℕ × R → Bool := fun a b => decide (a.1 ≥ b.1)
+  let coeffs' := coeffs.mergeSort r
+  have h_trans : ∀ a b c, r a b = true → r b c = true → r a c = true := by
+    intro a b c hab hbc
+    simp only [r, decide_eq_true_eq] at *
+    omega
+  have h_total : ∀ a b, (r a b || r b a) = true := by
+    intro a b
+    simp only [r, Bool.or_eq_true, decide_eq_true_eq]
+    omega
+  have h_sorted_bool : coeffs'.Pairwise (fun a b => r a b = true) :=
+    List.pairwise_mergeSort h_trans h_total coeffs
+  have h_sorted : coeffs'.Pairwise (·.1 ≥ ·.1) :=
+    List.Pairwise.imp (fun h => of_decide_eq_true h) h_sorted_bool
+  ofSortedList (dedupList coeffs')
+    (dedupList_sorted coeffs' h_sorted)
+
+/-- The indeterminate `X`, i.e. the monomial `X^1` with coefficient `1`. -/
+def X : SparsePoly R := ofSortedList [(1, 1)] (List.pairwise_singleton _ _)
+
+instance : Mul (SparsePoly R) where
+  mul x y :=
+    ofList do
+      let (i, a) ← x.coeffs
+      let (j, b) ← y.coeffs
+      return (i + j, a * b)
+
+instance : Neg (SparsePoly R) where
+  neg x := C (-1) * x
+
+/-- Filtering out zero coefficients doesn't change the underlying polynomial,
+since `C 0 * X^i = 0`. -/
+theorem toPolyCore_filter_nonzero (l : List (ℕ × R)) :
+    toPolyCore (l.filter (·.2 ≠ 0)) = toPolyCore l := by
+  induction l with
+  | nil => rfl
+  | cons hd tl ih =>
+    rcases hd with ⟨i, a⟩
+    simp only [List.filter_cons]
+    split
+    · rw [toPolyCore, toPolyCore, ih]
+    · unfold toPolyCore
+      aesop
+
+theorem toPolyCore_addCore : ∀ (x y : List (ℕ × R)),
+    toPolyCore (addCore x y) = toPolyCore x + toPolyCore y
+  | [], yy => by simp [addCore, toPolyCore]
+  | (i, a) :: x, [] => by simp [addCore, toPolyCore]
+  | xx@((i, a) :: x), yy@((j, b) :: y) => by
+    unfold addCore
+    split
+    · dsimp only [toPolyCore]
+      rw [toPolyCore_addCore ((i, a) :: x) y]
+      dsimp only [toPolyCore]
+      ring
+    · split
+      · dsimp only [toPolyCore]
+        rw [toPolyCore_addCore x ((j, b) :: y)]
+        dsimp only [toPolyCore]
+        ring
+      · cases (by omega : i = j)
+        dsimp only
+        split
+        · next hab =>
+          dsimp only [toPolyCore]
+          rw [toPolyCore_addCore x y]
+          have h_zero : Polynomial.C a * Polynomial.X ^ i +
+              Polynomial.C b * Polynomial.X ^ i = 0 := by
+            rw [← add_mul, ← map_add, hab, map_zero, zero_mul]
+          rw [show Polynomial.C a * Polynomial.X ^ i + toPolyCore x +
+            (Polynomial.C b * Polynomial.X ^ i + toPolyCore y) =
+            (Polynomial.C a * Polynomial.X ^ i + Polynomial.C b * Polynomial.X ^ i) +
+            (toPolyCore x + toPolyCore y) by ring, h_zero, zero_add]
+        · dsimp only [toPolyCore]
+          rw [toPolyCore_addCore x y, map_add, add_mul]
+          ring
+termination_by x y => x.length + y.length
+
+/-- `SparsePoly` addition mirrors `Polynomial` addition. -/
+theorem toPoly_add (x y : SparsePoly R) :
+    toPoly (x + y) = toPoly x + toPoly y := by
+  change toPolyCore ((addCore x.coeffs y.coeffs).filter (·.2 ≠ 0)) = _
+  rw [toPolyCore_filter_nonzero]
+  exact toPolyCore_addCore x.coeffs y.coeffs
+
+omit [CommRing R] [DecidableEq R] in
+lemma degLt_of_sorted_cons {i : ℕ} {a : R} {xs : List (ℕ × R)}
+    (h : ((i, a) :: xs).Pairwise (·.1 > ·.1)) : degLt i xs :=
+  fun x hx => (List.pairwise_cons.1 h).1 x hx
+
+omit [DecidableEq R] in
+theorem coeff_toPolyCore_of_degLt {n : ℕ} (xs : List (ℕ × R)) (h : degLt n xs) :
+    Polynomial.coeff (toPolyCore xs) n = 0 := by
+  induction xs with
+  | nil => rfl
+  | cons hd tl ih =>
+    rcases hd with ⟨i, a⟩
+    dsimp only [toPolyCore]
+    rw [Polynomial.coeff_add]
+    have h_deg : i < n := h (i, a) List.mem_cons_self
+    have h_ne : i ≠ n := ne_of_lt h_deg
+    rw [Polynomial.coeff_C_mul_X_pow]
+    have h_tl : degLt n tl := fun x hx => h x (List.mem_cons_of_mem _ hx)
+    rw [ih h_tl, add_zero]
+    grind
+
+omit [DecidableEq R] in
+theorem coeff_toPolyCore_head {i : ℕ} {a : R} (xs : List (ℕ × R)) (h : degLt i xs) :
+    Polynomial.coeff (toPolyCore ((i, a) :: xs)) i = a := by
+  dsimp only [toPolyCore]
+  rw [Polynomial.coeff_add, Polynomial.coeff_C_mul_X_pow, if_pos rfl]
+  rw [coeff_toPolyCore_of_degLt xs h, add_zero]
+
+omit [DecidableEq R] in
+theorem toPolyCore_injective_of_sorted : ∀ (l1 l2 : List (ℕ × R)),
+    l1.Pairwise (·.1 > ·.1) → l2.Pairwise (·.1 > ·.1) →
+    (∀ x ∈ l1, x.2 ≠ 0) → (∀ x ∈ l2, x.2 ≠ 0) →
+    toPolyCore l1 = toPolyCore l2 → l1 = l2
+  | [], [], _, _, _, _, _ => rfl
+  | [], (j, b) :: ys, _, s2, _, nz2, heq => by
+    have h_coeff := congrArg (Polynomial.coeff · j) heq
+    change (0 : Polynomial R).coeff j = _ at h_coeff
+    rw [Polynomial.coeff_zero] at h_coeff
+    rw [coeff_toPolyCore_head ys (degLt_of_sorted_cons s2)] at h_coeff
+    have hb_nz := nz2 (j, b) List.mem_cons_self
+    exact False.elim (hb_nz h_coeff.symm)
+  | (i, a) :: xs, [], s1, _, nz1, _, heq => by
+    have h_coeff := congrArg (Polynomial.coeff · i) heq
+    change _ = (0 : Polynomial R).coeff i at h_coeff
+    rw [Polynomial.coeff_zero] at h_coeff
+    rw [coeff_toPolyCore_head xs (degLt_of_sorted_cons s1)] at h_coeff
+    have ha_nz := nz1 (i, a) List.mem_cons_self
+    exact False.elim (ha_nz h_coeff)
+  | (i, a) :: xs, (j, b) :: ys, s1, s2, nz1, nz2, heq => by
+    have h_deg_x : degLt i xs := degLt_of_sorted_cons s1
+    have h_deg_y : degLt j ys := degLt_of_sorted_cons s2
+    obtain hij | rfl | hji := lt_trichotomy i j
+    · have h_coeff := congrArg (Polynomial.coeff · j) heq
+      rw [coeff_toPolyCore_head ys h_deg_y] at h_coeff
+      have h_xs_j : degLt j xs := fun e he => lt_trans (h_deg_x e he) hij
+      have h_lhs : Polynomial.coeff (toPolyCore ((i, a) :: xs)) j = 0 := by
+        dsimp only [toPolyCore]
+        rw [Polynomial.coeff_add]
+        have hne : i ≠ j := ne_of_lt hij
+        rw [Polynomial.coeff_C_mul_X_pow]
+        rw [coeff_toPolyCore_of_degLt xs h_xs_j]
+        grind
+      rw [h_lhs] at h_coeff
+      have hb_nz := nz2 (j, b) List.mem_cons_self
+      exact False.elim (hb_nz h_coeff.symm)
+    · have h_coeff := congrArg (Polynomial.coeff · i) heq
+      rw [coeff_toPolyCore_head xs h_deg_x, coeff_toPolyCore_head ys h_deg_y] at h_coeff
+      subst h_coeff
+      dsimp only [toPolyCore] at heq
+      have heq_xs_ys : toPolyCore xs = toPolyCore ys := add_left_cancel heq
+      have s1_xs : xs.Pairwise (·.1 > ·.1) := (List.pairwise_cons.1 s1).2
+      have s2_ys : ys.Pairwise (·.1 > ·.1) := (List.pairwise_cons.1 s2).2
+      have nz1_xs : ∀ x ∈ xs, x.2 ≠ 0 := fun e he => nz1 e (List.mem_cons_of_mem _ he)
+      have nz2_ys : ∀ x ∈ ys, x.2 ≠ 0 := fun e he => nz2 e (List.mem_cons_of_mem _ he)
+      rw [toPolyCore_injective_of_sorted xs ys s1_xs s2_ys nz1_xs nz2_ys heq_xs_ys]
+    · have h_coeff := congrArg (Polynomial.coeff · i) heq
+      rw [coeff_toPolyCore_head xs h_deg_x] at h_coeff
+      have h_ys_i : degLt i ys := fun e he => lt_trans (h_deg_y e he) hji
+      have h_rhs : Polynomial.coeff (toPolyCore ((j, b) :: ys)) i = 0 := by
+        dsimp only [toPolyCore]
+        rw [Polynomial.coeff_add]
+        have hne : j ≠ i := ne_of_lt hji
+        rw [Polynomial.coeff_C_mul_X_pow]
+        rw [coeff_toPolyCore_of_degLt ys h_ys_i]
+        grind
+      rw [h_rhs] at h_coeff
+      have ha_nz := nz1 (i, a) List.mem_cons_self
+      exact False.elim (ha_nz h_coeff)
+
+omit [DecidableEq R] in
+theorem toPoly_injective : Function.Injective (toPoly (R := R)) := by
+  intro x y h
+  ext1
+  exact toPolyCore_injective_of_sorted x.coeffs y.coeffs x.sorted y.sorted x.nonzero y.nonzero h
+
+omit [DecidableEq R] in
+/-- `toPoly` of the zero `SparsePoly` is the zero `Polynomial`. -/
+theorem toPoly_zero : toPoly (0 : SparsePoly R) = 0 := rfl
+
+/-- `toPoly` of a constant `SparsePoly` is the constant `Polynomial`. -/
+theorem toPoly_C (r : R) : toPoly (C r) = Polynomial.C r := by
+  unfold C toPoly ofSortedList
+  dsimp only
+  by_cases hr : r = 0 <;> simp [hr, toPolyCore]
+
+/-- Bridge: the sparse variable `X` translates to the Mathlib variable `X`. -/
+@[simp]
+theorem toPoly_X : toPoly (X : SparsePoly R) = Polynomial.X := by
+  unfold X toPoly ofSortedList
+  dsimp only
+  by_cases h1 : (1 : R) = 0
+  · simp [h1, toPolyCore]; aesop
+  · simp [h1, toPolyCore]
+
+end SparsePoly

--- a/Mathlib/Tactic/ComputablePolynomial/Reflect.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/Reflect.lean
@@ -1,0 +1,314 @@
+/-
+Copyright (c) 2026 Michail Karatarakis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.Ring
+public import Mathlib.Tactic.LinearCombination
+
+/-!
+# Axiom-free reflection for **univariate** `Polynomial R`
+
+`poly_decide` (and its synonym `poly_compute`)
+prove equalities and inequalities of Mathlib's noncomputable `Polynomial R` by reflecting onto
+kernel-reducible normal-form coefficient lists (`List (ℕ × R)`), proving each operation correct
+against the semantics `toPolyCore`, and closing with kernel `decide +kernel` —
+**no `native_decide`**.
+
+The univariate case is cleaner than the multivariate one: an exponent is a single `ℕ`, so product
+exponents are `ℕ` addition (which the kernel reduces) — there is no `Array.zipWith` obstacle, hence
+no need for the `addDegK` workaround. Full ring identities (`+`, `-`, `*`, `^`) decide axiom-free.
+
+Trade-off (as always for kernel reflection): `decide +kernel` runs in the kernel interpreter, so it
+is for small/medium goals.
+-/
+
+@[expose] public section
+
+open Lean Elab Tactic Meta
+
+namespace SparsePoly.Kernel
+
+open SparsePoly
+
+variable {R : Type} [CommRing R] [DecidableEq R]
+
+/-- A raw coefficient list (the data of a `SparsePoly`, without the sorted/nonzero proofs). -/
+abbrev TL (R : Type) := List (ℕ × R)
+
+/-- Structural insert-merge into a descending-sorted coefficient list (kernel-reducible). -/
+def insertK (t : ℕ × R) : TL R → TL R
+  | [] => [t]
+  | (j, b) :: rest =>
+    match compare t.1 j with
+    | .gt => t :: (j, b) :: rest
+    | .eq => (j, t.2 + b) :: rest
+    | .lt => (j, b) :: insertK t rest
+
+/-- Structural (kernel-reducible) addition of raw coefficient lists. -/
+def kAdd (a b : TL R) : TL R := a.foldr insertK b
+/-- Structural (kernel-reducible) negation of a raw coefficient list. -/
+def kNeg (a : TL R) : TL R := a.map (fun t => (t.1, -t.2))
+/-- Structural (kernel-reducible) subtraction of raw coefficient lists. -/
+def kSub (a b : TL R) : TL R := kAdd a (kNeg b)
+/-- Structural (kernel-reducible) multiplication of raw coefficient lists. -/
+def kMul (a b : TL R) : TL R :=
+  a.foldr (fun t acc => kAdd (b.flatMap (fun s => [(t.1 + s.1, t.2 * s.2)])) acc) []
+/-- Structural (kernel-reducible) power of a raw coefficient list. -/
+def kPow (a : TL R) : ℕ → TL R
+  | 0 => (1 : SparsePoly R).coeffs
+  | k + 1 => kMul a (kPow a k)
+
+/-! ### Correctness with respect to `toPolyCore` -/
+
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_cons (t : ℕ × R) (l : TL R) :
+    toPolyCore (t :: l) = Polynomial.C t.2 * Polynomial.X ^ t.1 + toPolyCore l := rfl
+
+omit [DecidableEq R] in
+lemma toPolyCore_insertK (i : ℕ) (c : R) (l : TL R) :
+    toPolyCore (insertK (i, c) l) = Polynomial.C c * Polynomial.X ^ i + toPolyCore l := by
+  induction l with
+  | nil => simp [insertK, toPolyCore]
+  | cons hd tl ih =>
+    obtain ⟨j, b⟩ := hd
+    rw [insertK]
+    rcases hc : compare i j with _ | _ | _
+    · simp only [toPolyCore_cons, ih]; abel
+    · obtain rfl := compare_eq_iff_eq.mp hc
+      simp only [toPolyCore_cons]
+      rw [map_add, add_mul]; abel
+    · simp only [toPolyCore_cons]
+
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_kAdd (a b : TL R) :
+    toPolyCore (kAdd a b) = toPolyCore a + toPolyCore b := by
+  induction a with
+  | nil => simp [kAdd, toPolyCore]
+  | cons hd tl ih =>
+    obtain ⟨i, c⟩ := hd
+    rw [kAdd, List.foldr_cons, ← kAdd, toPolyCore_insertK, ih, toPolyCore_cons, add_assoc]
+
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_kNeg (a : TL R) : toPolyCore (kNeg a) = - toPolyCore a := by
+  change toPolyCore (a.map (fun t => (t.1, -t.2))) = - toPolyCore a
+  induction a with
+  | nil => simp [toPolyCore]
+  | cons hd tl ih =>
+    obtain ⟨i, c⟩ := hd
+    simp only [List.map_cons, toPolyCore_cons, ih, map_neg, neg_mul]
+    abel
+
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_kSub (a b : TL R) :
+    toPolyCore (kSub a b) = toPolyCore a - toPolyCore b := by
+  rw [kSub, toPolyCore_kAdd, toPolyCore_kNeg, sub_eq_add_neg]
+
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_kMul (a b : TL R) :
+    toPolyCore (kMul a b) = toPolyCore a * toPolyCore b := by
+  induction a with
+  | nil => simp [kMul, toPolyCore]
+  | cons hd tl ih =>
+    obtain ⟨i, c⟩ := hd
+    rw [kMul, List.foldr_cons, ← kMul, toPolyCore_kAdd, ih, toPolyCore_mul_y, toPolyCore_cons,
+      add_mul]
+
+@[simp] lemma toPolyCore_kPow (a : TL R) (k : ℕ) :
+    toPolyCore (kPow a k) = (toPolyCore a) ^ k := by
+  induction k with
+  | zero => rw [kPow, pow_zero]; exact toPoly_one
+  | succ m ih => rw [kPow, toPolyCore_kMul, ih, pow_succ, mul_comm]
+
+-- Leaf bridges: `toPoly = toPolyCore ∘ coeffs`, so these are the existing homomorphism lemmas.
+@[simp] lemma toPolyCore_X_coeffs : toPolyCore (X : SparsePoly R).coeffs = Polynomial.X := toPoly_X
+@[simp] lemma toPolyCore_C_coeffs (r : R) :
+    toPolyCore (C r : SparsePoly R).coeffs = Polynomial.C r := toPoly_C r
+@[simp] lemma toPolyCore_one_coeffs : toPolyCore (1 : SparsePoly R).coeffs = 1 := toPoly_one
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_zero_coeffs : toPolyCore (0 : SparsePoly R).coeffs = 0 := toPoly_zero
+
+/-- Soundness for `=` goals (compares normal forms after dropping zero coefficients). -/
+theorem eq_of_core {p q : Polynomial R} (l₁ l₂ : TL R)
+    (h₁ : toPolyCore l₁ = p) (h₂ : toPolyCore l₂ = q)
+    (h : l₁.filter (·.2 ≠ 0) = l₂.filter (·.2 ≠ 0)) : p = q := by
+  rw [← h₁, ← h₂, ← toPolyCore_filter_nonzero l₁, ← toPolyCore_filter_nonzero l₂, h]
+
+/-! ### Axiom-free `≠` (a differing coefficient witnesses inequality — no canonical-form needed) -/
+
+/-- Coefficient of degree `D` read directly off a coefficient list. -/
+def listCoeff (D : ℕ) (l : TL R) : R :=
+  (l.filter (fun t => t.1 = D)).foldr (fun t s => t.2 + s) 0
+
+omit [DecidableEq R] in
+/-- The list-level coefficient agrees with `Polynomial.coeff` — for *any* list (no sortedness). -/
+lemma coeff_toPolyCore_listCoeff (D : ℕ) (l : TL R) :
+    (toPolyCore l).coeff D = listCoeff D l := by
+  induction l with
+  | nil => simp [toPolyCore, listCoeff]
+  | cons hd tl ih =>
+    obtain ⟨i, a⟩ := hd
+    rw [toPolyCore_cons, Polynomial.coeff_add, Polynomial.coeff_C_mul, Polynomial.coeff_X_pow, ih]
+    by_cases h : i = D
+    · subst h; simp [listCoeff]
+    · have h' : D ≠ i := Ne.symm h
+      simp [listCoeff, h, h']
+
+/-- Boolean test: some degree appearing in either list has different coefficients. -/
+def polyNeBool (l₁ l₂ : TL R) : Bool :=
+  (l₁ ++ l₂).any (fun t => decide (listCoeff t.1 l₁ ≠ listCoeff t.1 l₂))
+
+/-- Soundness for `≠` goals: a witnessing coefficient difference (decided in the kernel). -/
+theorem ne_of_core {p q : Polynomial R} (l₁ l₂ : TL R)
+    (h₁ : toPolyCore l₁ = p) (h₂ : toPolyCore l₂ = q) (h : polyNeBool l₁ l₂ = true) : p ≠ q := by
+  subst h₁ h₂
+  obtain ⟨t, _, ht⟩ := List.any_eq_true.mp h
+  intro he
+  exact (of_decide_eq_true ht)
+    (by rw [← coeff_toPolyCore_listCoeff, ← coeff_toPolyCore_listCoeff, he])
+
+/-! ### Axiom-free divisibility via kernel-reducible long division -/
+
+/-- Kernel-reducible univariate long division of coefficient lists (structural on `fuel`). Returns
+`(quotient, remainder)`. Needs `Div R`; the division *identity* `q = p·quo + rem` holds for any `R`
+(`toPolyCore_divModK`), so it is sound regardless of whether `p`'s leading coefficient divides. -/
+def divModK [Div R] : ℕ → TL R → TL R → TL R × TL R
+  | 0, q, _ => ([], q)
+  | fuel + 1, q, p =>
+    match q, p with
+    | [], _ => ([], [])
+    | _, [] => ([], q)
+    | (dq, cq) :: qt, (dp, cp) :: pt =>
+      if cq = 0 then divModK fuel qt ((dp, cp) :: pt)   -- drop a spurious zero leading term
+      else if dq < dp then ([], (dq, cq) :: qt)
+      else
+        let term : ℕ × R := (dq - dp, cq / cp)
+        let r := divModK fuel (kSub ((dq, cq) :: qt) (kMul [term] ((dp, cp) :: pt)))
+          ((dp, cp) :: pt)
+        (term :: r.1, r.2)
+
+omit [DecidableEq R] in
+/-- `toPolyCore` splits a cons into the head monomial plus the tail
+(head kept as `toPolyCore [t]`). -/
+lemma toPolyCore_cons_split (t : ℕ × R) (l : TL R) :
+    toPolyCore (t :: l) = toPolyCore [t] + toPolyCore l := by simp [toPolyCore]
+
+/-- The division identity, through `toPolyCore` (holds for *any* fuel and `R`). -/
+lemma toPolyCore_divModK [Div R] : ∀ (n : ℕ) (q p : TL R),
+    toPolyCore q = toPolyCore p * toPolyCore (divModK n q p).1 + toPolyCore (divModK n q p).2
+  | 0, q, p => by simp [divModK, toPolyCore]
+  | n + 1, q, p => by
+    match q, p with
+    | [], _ => simp [divModK, toPolyCore]
+    | _ :: _, [] => simp [divModK, toPolyCore]
+    | (dq, cq) :: qt, (dp, cp) :: pt =>
+      by_cases hz : cq = 0
+      · -- a spurious zero leading term is dropped; `C 0 * X^dq = 0`, so `toPolyCore` is unchanged
+        simp only [divModK, toPolyCore_cons, hz, map_zero, zero_mul, zero_add]
+        exact toPolyCore_divModK n qt ((dp, cp) :: pt)
+      · by_cases h : dq < dp
+        · simp [divModK, if_neg hz, h, toPolyCore]
+        · simp only [divModK, if_neg hz, if_neg h]
+          have ih := toPolyCore_divModK n
+            (kSub ((dq, cq) :: qt) (kMul [(dq - dp, cq / cp)] ((dp, cp) :: pt))) ((dp, cp) :: pt)
+          rw [toPolyCore_kSub, toPolyCore_kMul] at ih
+          -- keep `toPolyCore p` and `toPolyCore [term]` atomic; only split the *quotient* cons
+          rw [toPolyCore_cons_split (dq - dp, cq / cp)]
+          linear_combination ih
+
+/-- Divisor with a self-computed fuel bound. Each step strictly lowers the working *degree*, but an
+exact cancellation can leave a zero-coefficient head consumed by an extra drop step, so we allow up
+to `2·(maxdeg) + length + 2` steps — comfortably above the worst case. -/
+def divMod [Div R] (q p : TL R) : TL R × TL R :=
+  divModK (2 * (q.map Prod.fst).foldr Nat.max 0 + q.length + 2) q p
+
+/-- The division identity for `divMod`. -/
+lemma toPolyCore_divMod [Div R] (q p : TL R) :
+    toPolyCore q = toPolyCore p * toPolyCore (divMod q p).1 + toPolyCore (divMod q p).2 :=
+  toPolyCore_divModK _ q p
+
+/-- Soundness: if `divMod` leaves no nonzero remainder, `p ∣ q`. -/
+theorem dvd_of_divMod [Div R] {p q : Polynomial R} (l_p l_q : TL R)
+    (h_p : toPolyCore l_p = p) (h_q : toPolyCore l_q = q)
+    (h : (divMod l_q l_p).2.filter (·.2 ≠ 0) = []) : p ∣ q := by
+  refine ⟨toPolyCore (divMod l_q l_p).1, ?_⟩
+  have hrem : toPolyCore (divMod l_q l_p).2 = 0 := by
+    rw [← toPolyCore_filter_nonzero, h]; rfl
+  rw [← h_q, ← h_p, toPolyCore_divMod l_q l_p, hrem, add_zero]
+
+end SparsePoly.Kernel
+
+public meta section
+
+/-! ## The axiom-free tactic -/
+
+namespace SparsePoly.Kernel
+
+/-- Translate a `Polynomial R` expression into a kernel-reducible normal-form coefficient list. -/
+partial def reifyK (R : Expr) (e : Expr) : MetaM Expr := do
+  let leaf (p : Expr) : MetaM Expr := mkAppM ``SparsePoly.coeffs #[p]
+  match e.getAppFnArgs with
+  | (``HAdd.hAdd, #[_, _, _, _, a, b]) => mkAppM ``kAdd #[← reifyK R a, ← reifyK R b]
+  | (``HMul.hMul, #[_, _, _, _, a, b]) => mkAppM ``kMul #[← reifyK R a, ← reifyK R b]
+  | (``HSub.hSub, #[_, _, _, _, a, b]) => mkAppM ``kSub #[← reifyK R a, ← reifyK R b]
+  | (``HPow.hPow, #[_, _, _, _, a, k]) => mkAppM ``kPow #[← reifyK R a, k]
+  | (``Neg.neg, #[_, _, a])            => mkAppM ``kNeg #[← reifyK R a]
+  | (``Polynomial.X, _)                => leaf (← mkAppOptM ``SparsePoly.X #[R, none, none])
+  | (``DFunLike.coe, #[_, _, _, _, f, c]) =>
+      match f.getAppFnArgs with
+      | (``Polynomial.C, _) => leaf (← mkAppOptM ``SparsePoly.C #[R, none, none, c])
+      | _ => throwError "poly_decide: cannot reify {e}"
+  | (``OfNat.ofNat, #[_, lit, _]) =>   -- numeral `n` ↦ `(C (n : R)).coeffs`  (bridge: `map_ofNat`)
+      leaf (← mkAppOptM ``SparsePoly.C #[R, none, none, ← mkAppOptM ``OfNat.ofNat #[R, lit, none]])
+  | _ => throwError "poly_decide: cannot reify {e} into a coefficient list"
+
+/-- The `simp` context of `toPolyCore`-homomorphism lemmas used to bridge a reified coefficient list
+back to its original `Polynomial R` expression (used by `poly_decide` and related tactics). -/
+def bridgeSimpK : MetaM Simp.Context := do
+  let lemmas := #[``SparsePoly.Kernel.toPolyCore_kAdd, ``SparsePoly.Kernel.toPolyCore_kMul,
+    ``SparsePoly.Kernel.toPolyCore_kSub, ``SparsePoly.Kernel.toPolyCore_kNeg,
+    ``SparsePoly.Kernel.toPolyCore_kPow, ``SparsePoly.Kernel.toPolyCore_X_coeffs,
+    ``SparsePoly.Kernel.toPolyCore_C_coeffs, ``SparsePoly.Kernel.toPolyCore_one_coeffs,
+    ``SparsePoly.Kernel.toPolyCore_zero_coeffs, ``map_ofNat, ``map_one, ``map_zero]
+  let mut s : SimpTheorems := {}
+  for l in lemmas do s ← s.addConst l
+  Simp.mkContext {} (simpTheorems := #[s]) (congrTheorems := ← getSimpCongrTheorems)
+
+end SparsePoly.Kernel
+
+/-- Prove a `Polynomial R` **equality or inequality** by reflecting onto kernel-reducible normal
+forms and closing with kernel `decide +kernel` — **axiom-free**. -/
+elab "poly_decide" : tactic => withMainContext do
+  let g ← getMainGoal
+  let tgt ← whnfR (← g.getType)
+  let (isNeg, p, q) ←
+    if let some (_, a, b) := tgt.eq? then pure (false, a, b)
+    else if let some inner := tgt.not? then
+      if let some (_, a, b) := (← whnfR inner).eq? then pure (true, a, b)
+      else throwError "poly_decide: goal is not an (in)equality of Polynomials"
+    else throwError "poly_decide: goal is not an (in)equality of Polynomials"
+  let (``Polynomial, #[R, _]) := (← inferType p).getAppFnArgs
+    | throwError "poly_decide: goal type is not Polynomial R"
+  let l₁ ← SparsePoly.Kernel.reifyK R p
+  let l₂ ← SparsePoly.Kernel.reifyK R q
+  let mkBridge (l orig : Expr) : MetaM Expr := do
+    let m ← mkFreshExprSyntheticOpaqueMVar (← mkEq (← mkAppM ``SparsePoly.toPolyCore #[l]) orig)
+    let (res, _) ← simpGoal m.mvarId! (← SparsePoly.Kernel.bridgeSimpK)
+    if let some (_, m2) := res then m2.refl
+    instantiateMVars m
+  let hp ← mkBridge l₁ p
+  let hq ← mkBridge l₂ q
+  let lem := if isNeg then ``SparsePoly.Kernel.ne_of_core else ``SparsePoly.Kernel.eq_of_core
+  let partialPf ← mkAppM lem #[l₁, l₂, hp, hq]
+  let coreTy := (← inferType partialPf).bindingDomain!
+  let mCore ← mkFreshExprSyntheticOpaqueMVar coreTy
+  g.assign (.app partialPf mCore)
+  replaceMainGoal [mCore.mvarId!]
+  evalTactic (← `(tactic| decide +kernel))
+
+/-- `poly_compute` is a synonym for the axiom-free `poly_decide`. -/
+macro "poly_compute" : tactic => `(tactic| poly_decide)
+
+attribute [nolint defsWithUnderscore] tacticPoly_decide tacticPoly_compute

--- a/Mathlib/Tactic/ComputablePolynomial/Ring.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/Ring.lean
@@ -1,0 +1,269 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.OfList
+
+/-!
+# `SparsePoly`: multiplication and the `CommRing` and `Algebra` instances
+
+`toPoly` is shown to preserve `1`, multiplication and negation, and `SparsePoly R` is given its
+`CommRing` and `Algebra R` instances, with `CHom : R →+* SparsePoly R` the constant ring hom.
+-/
+
+@[expose] public section
+
+namespace SparsePoly
+
+open Polynomial
+
+variable {R : Type} [CommRing R] [DecidableEq R]
+
+omit [DecidableEq R] in
+theorem toPolyCore_append (l1 l2 : List (ℕ × R)) :
+    toPolyCore (l1 ++ l2) = toPolyCore l1 + toPolyCore l2 := by
+  induction l1 with
+  | nil => simp [toPolyCore]
+  | cons hd tl ih =>
+    rcases hd with ⟨i, a⟩
+    calc
+      toPolyCore ((i, a) :: tl ++ l2)
+          = Polynomial.C a * Polynomial.X ^ i + toPolyCore (tl ++ l2) := by
+              simp [List.cons_append, toPolyCore]
+      _ = Polynomial.C a * Polynomial.X ^ i + (toPolyCore tl + toPolyCore l2) := by
+            rw [ih]
+      _ = toPolyCore ((i, a) :: tl) + toPolyCore l2 := by
+            simp [toPolyCore, add_assoc]
+
+omit [DecidableEq R] in
+theorem toPolyCore_perm {l1 l2 : List (ℕ × R)} (h : List.Perm l1 l2) :
+    toPolyCore l1 = toPolyCore l2 := by
+  induction h with
+  | nil => rfl
+  | cons x _ ih =>
+    rcases x with ⟨i, a⟩
+    dsimp only [toPolyCore]
+    rw [ih]
+  | swap x y l =>
+    rcases x with ⟨i, a⟩
+    rcases y with ⟨j, b⟩
+    dsimp only [toPolyCore]
+    ring
+  | trans _ _ ih1 ih2 =>
+    exact Eq.trans ih1 ih2
+
+omit [DecidableEq R] in
+theorem toPolyCore_mergeSort (l : List (ℕ × R)) (r : ℕ × R → ℕ × R → Bool) :
+    toPolyCore (l.mergeSort r) = toPolyCore l :=
+  toPolyCore_perm (List.mergeSort_perm l r)
+
+omit [DecidableEq R] in
+theorem toPolyCore_dedupList : ∀ (l : List (ℕ × R)),
+    toPolyCore (dedupList l) = toPolyCore l
+  | [] => by
+    simp [dedupList, toPolyCore]
+  | [(i, a)] => by
+    simp [dedupList, toPolyCore]
+  | (i, a) :: (j, b) :: xs => by
+    unfold dedupList
+    split
+    · next heq =>
+      subst heq
+      rw [toPolyCore_dedupList ((i, a + b) :: xs)]
+      dsimp only [toPolyCore]
+      rw [map_add, add_mul]
+      ring
+    · dsimp only [toPolyCore]
+      rw [toPolyCore_dedupList ((j, b) :: xs)]
+      simp [toPolyCore]
+
+theorem toPoly_ofList (l : List (ℕ × R)) :
+    toPoly (ofList l) = toPolyCore l := by
+  unfold toPoly ofList ofSortedList
+  dsimp only
+  rw [toPolyCore_filter_nonzero, toPolyCore_dedupList, toPolyCore_mergeSort]
+
+omit [DecidableEq R] in
+lemma toPolyCore_mul_y (i : ℕ) (a : R) (y : List (ℕ × R)) :
+    toPolyCore (y.flatMap fun ⟨j, b⟩ => [(i + j, a * b)]) =
+      (Polynomial.C a * Polynomial.X ^ i) * toPolyCore y := by
+  induction y with
+  | nil => simp [toPolyCore, List.flatMap]
+  | cons hd tl ih =>
+    rcases hd with ⟨j, b⟩
+    change toPolyCore ([(i + j, a * b)] ++ tl.flatMap _) = _
+    rw [toPolyCore_append, ih]
+    dsimp only [toPolyCore]
+    rw [show Polynomial.C (a * b) * Polynomial.X ^ (i + j) =
+        Polynomial.C a * Polynomial.X ^ i * (Polynomial.C b * Polynomial.X ^ j) by
+      rw [map_mul, pow_add]; ring]
+    ring
+
+omit [DecidableEq R] in
+lemma toPolyCore_mul_x (x y : List (ℕ × R)) :
+    toPolyCore (x.flatMap fun ⟨i, a⟩ => y.flatMap fun ⟨j, b⟩ => [(i + j, a * b)]) =
+    toPolyCore x * toPolyCore y := by
+  induction x with
+  | nil => simp [toPolyCore, List.flatMap]
+  | cons hd tl ih =>
+    rcases hd with ⟨i, a⟩
+    change toPolyCore ((y.flatMap fun ⟨j, b⟩ => [(i + j, a * b)]) ++ tl.flatMap _) = _
+    rw [toPolyCore_append, ih, toPolyCore_mul_y]
+    dsimp only [toPolyCore]
+    ring
+
+theorem toPoly_one : toPoly (1 : SparsePoly R) = 1 := by
+  change toPoly (C 1) = 1
+  rw [toPoly_C]
+  exact map_one (Polynomial.C (R := R))
+
+theorem toPoly_mul (x y : SparsePoly R) : toPoly (x * y) = toPoly x * toPoly y := by
+  rw [show x * y = ofList (x.coeffs.flatMap fun ⟨i, a⟩ =>
+    y.coeffs.flatMap fun ⟨j, b⟩ => [(i + j, a * b)]) from rfl, toPoly_ofList]
+  exact toPolyCore_mul_x x.coeffs y.coeffs
+
+theorem toPoly_neg (x : SparsePoly R) : toPoly (-x) = -toPoly x := by
+  change toPoly (C (-1) * x) = -toPoly x
+  rw [toPoly_mul, toPoly_C]
+  simp
+
+instance : CommRing (SparsePoly R) where
+  add := (·+·)
+  zero := 0
+  mul := (·*·)
+  one := 1
+  neg := (-·)
+  sub x y := x + -y
+  nsmul := nsmulRec
+  zsmul := zsmulRec
+  npow := npowRec
+  natCast n := C (n : R)
+  intCast z := C (z : R)
+
+  add_assoc := by
+    intro x y z
+    apply toPoly_injective
+    rw [toPoly_add, toPoly_add, toPoly_add, toPoly_add]
+    exact add_assoc (toPoly x) (toPoly y) (toPoly z)
+  zero_add := by
+    intro a
+    apply toPoly_injective
+    rw [toPoly_add, toPoly_zero, zero_add]
+
+  add_zero := by
+    intro a
+    apply toPoly_injective
+    rw [toPoly_add, toPoly_zero, add_zero]
+
+  add_comm := by
+    intro a b
+    apply toPoly_injective
+    rw [toPoly_add, toPoly_add, add_comm]
+
+  neg_add_cancel := by
+    intro a
+    apply toPoly_injective
+    rw [toPoly_add, toPoly_neg, toPoly_zero, neg_add_cancel]
+
+  mul_assoc := by
+    intro a b c
+    apply toPoly_injective
+    rw [toPoly_mul, toPoly_mul, toPoly_mul, toPoly_mul, mul_assoc]
+
+  one_mul := by
+    intro a
+    apply toPoly_injective
+    rw [toPoly_mul, toPoly_one, one_mul]
+
+  mul_one := by
+    intro a
+    apply toPoly_injective
+    rw [toPoly_mul, toPoly_one, mul_one]
+
+  left_distrib := by
+    intro a b c
+    apply toPoly_injective
+    rw [toPoly_mul, toPoly_add, toPoly_add, toPoly_mul, toPoly_mul, left_distrib]
+
+  right_distrib := by
+    intro a b c
+    apply toPoly_injective
+    rw [toPoly_mul, toPoly_add, toPoly_add, toPoly_mul, toPoly_mul, right_distrib]
+
+  zero_mul := by
+    intro a
+    apply toPoly_injective
+    rw [toPoly_mul, toPoly_zero, zero_mul]
+
+  mul_zero := by
+    intro a
+    apply toPoly_injective
+    rw [toPoly_mul, toPoly_zero,  mul_zero]
+
+  mul_comm := by
+    intro a b
+    apply toPoly_injective
+    rw [toPoly_mul, toPoly_mul, mul_comm]
+
+  nsmul_zero := by intros; rfl
+  nsmul_succ := by intros; rfl
+  zsmul_zero' := by intros; rfl
+  zsmul_succ' := by intros; rfl
+  zsmul_neg' := by intros; rfl
+  natCast_zero := by
+    apply toPoly_injective
+    rw [toPoly_C, toPoly_zero]
+    push_cast
+    exact map_zero Polynomial.C
+
+  natCast_succ := by
+    intro n
+    apply toPoly_injective
+    show toPoly (C ((n + 1 : ℕ) : R)) = toPoly (C (n : R) + 1)
+    rw [toPoly_C, toPoly_add, toPoly_C, toPoly_one]
+    push_cast
+    grind
+
+  intCast_ofNat := by
+    intro n
+    apply toPoly_injective
+    change toPoly (C ((Int.ofNat n : ℤ) : R)) = toPoly (C (n : R))
+    rw [toPoly_C, toPoly_C]
+    aesop
+
+  intCast_negSucc := by
+    intro n
+    apply toPoly_injective
+    change toPoly (C _) = toPoly (- C _)
+    rw [toPoly_C, toPoly_neg, toPoly_C]
+    push_cast
+    grind
+
+/-- The ring homomorphism `R →+* SparsePoly R` sending `r` to the constant polynomial `C r`. -/
+def CHom : R →+* SparsePoly R where
+  toFun := C
+  map_zero' := by
+    apply toPoly_injective
+    simp only [toPoly_C, toPoly_zero, map_zero]
+  map_one' := by
+    apply toPoly_injective
+    simp only [toPoly_C, toPoly_one, map_one]
+  map_add' := by
+    intro x y
+    apply toPoly_injective
+    simp only [toPoly_add, toPoly_C, map_add]
+  map_mul' := by
+    intro x y
+    apply toPoly_injective
+    simp only [toPoly_mul, toPoly_C, map_mul]
+
+instance : Algebra R (SparsePoly R) where
+  smul := fun a r => C a * r
+  algebraMap := CHom
+  commutes' r p := mul_comm (C r) p
+  smul_def' _ _ := rfl
+
+end SparsePoly

--- a/MathlibTest/ComputablePolynomial/PolyDecide.lean
+++ b/MathlibTest/ComputablePolynomial/PolyDecide.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+import Mathlib.Tactic.ComputablePolynomial.Reflect
+
+/-!
+# Tests for `poly_decide`
+
+Axiom-free `Polynomial` identities: the `#guard_msgs` check asserts the axiom set is exactly
+`[propext, Classical.choice, Quot.sound]` — no `native_decide` / `Lean.ofReduceBool`.
+-/
+
+open Polynomial
+
+
+example : ((X + C 1) ^ 2 : Polynomial ℤ) = X ^ 2 + C 2 * X + C 1 := by poly_decide
+example : (X ^ 2 - C 1 : Polynomial ℤ) = (X - C 1) * (X + C 1) := by poly_decide
+example : ((X + C 1) ^ 3 : Polynomial ℤ) = X ^ 3 + C 3 * X ^ 2 + C 3 * X + C 1 := by poly_decide
+example : (X ^ 2 - C 1 - (X - C 1) * (X + C 1) : Polynomial ℤ) = 0 := by poly_decide
+-- bare numerals (no `C`) also work, axiom-free:
+example : ((X + 1) * (X + 2) : Polynomial ℤ) = X ^ 2 + 3 * X + 2 := by poly_decide
+
+-- The trust check: only the three standard axioms — no `Lean.ofReduceBool`.
+theorem sq_expand : ((X + C 1) ^ 2 : Polynomial ℤ) = X ^ 2 + C 2 * X + C 1 := by poly_decide
+/-- info: 'sq_expand' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms sq_expand
+

--- a/MathlibTest/ComputablePolynomial/PolyDecide.lean
+++ b/MathlibTest/ComputablePolynomial/PolyDecide.lean
@@ -27,4 +27,3 @@ theorem sq_expand : ((X + C 1) ^ 2 : Polynomial ℤ) = X ^ 2 + C 2 * X + C 1 := 
 /-- info: 'sq_expand' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms sq_expand
-


### PR DESCRIPTION
The `poly_decide` / `poly_compute` tactic: prove equalities and inequalities of `Polynomial R` by reflecting onto kernel-reducible normal-form coefficient lists (structural recursion, so `decide +kernel` reduces them) — **axiom-free**, no `native_decide`. The `#guard_msgs`-checked `#print axioms` test asserts exactly `[propext, Classical.choice, Quot.sound]`. Depends only on parts 1–3 (not on the division/gcd line).

- [ ] depends on: #41341
