### PR TITLE
feat(Tactic/ComputablePolynomial): mv_mem, axiom-free ideal membership for MvPolynomial

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7253,6 +7253,7 @@ public import Mathlib.Tactic.ClickSuggestions.Unfold
 public import Mathlib.Tactic.ClickSuggestions.Util
 public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
+public import Mathlib.Tactic.ComputablePolynomial.MvBasic
 public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7258,6 +7258,7 @@ public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
 public import Mathlib.Tactic.ComputablePolynomial.MvMul
 public import Mathlib.Tactic.ComputablePolynomial.MvOfList
+public import Mathlib.Tactic.ComputablePolynomial.MvToPoly
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7253,6 +7253,7 @@ public import Mathlib.Tactic.ClickSuggestions.Unfold
 public import Mathlib.Tactic.ClickSuggestions.Util
 public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
+public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7258,6 +7258,7 @@ public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
 public import Mathlib.Tactic.ComputablePolynomial.MvMul
 public import Mathlib.Tactic.ComputablePolynomial.MvOfList
+public import Mathlib.Tactic.ComputablePolynomial.MvReflect
 public import Mathlib.Tactic.ComputablePolynomial.MvRing
 public import Mathlib.Tactic.ComputablePolynomial.MvToPoly
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7254,6 +7254,7 @@ public import Mathlib.Tactic.ClickSuggestions.Util
 public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
+public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7256,6 +7256,7 @@ public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.MvBasic
 public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
+public import Mathlib.Tactic.ComputablePolynomial.MvMul
 public import Mathlib.Tactic.ComputablePolynomial.MvOfList
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7256,6 +7256,7 @@ public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.MvBasic
 public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
+public import Mathlib.Tactic.ComputablePolynomial.MvMem
 public import Mathlib.Tactic.ComputablePolynomial.MvMul
 public import Mathlib.Tactic.ComputablePolynomial.MvOfList
 public import Mathlib.Tactic.ComputablePolynomial.MvReflect

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7256,6 +7256,7 @@ public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.MvBasic
 public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
+public import Mathlib.Tactic.ComputablePolynomial.MvOfList
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7258,6 +7258,7 @@ public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
 public import Mathlib.Tactic.ComputablePolynomial.MvMul
 public import Mathlib.Tactic.ComputablePolynomial.MvOfList
+public import Mathlib.Tactic.ComputablePolynomial.MvRing
 public import Mathlib.Tactic.ComputablePolynomial.MvToPoly
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -68,6 +68,7 @@ public import Mathlib.Tactic.ClickSuggestions.Unfold
 public import Mathlib.Tactic.ClickSuggestions.Util
 public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
+public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -71,6 +71,7 @@ public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.MvBasic
 public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
+public import Mathlib.Tactic.ComputablePolynomial.MvOfList
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -73,6 +73,7 @@ public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
 public import Mathlib.Tactic.ComputablePolynomial.MvMul
 public import Mathlib.Tactic.ComputablePolynomial.MvOfList
+public import Mathlib.Tactic.ComputablePolynomial.MvReflect
 public import Mathlib.Tactic.ComputablePolynomial.MvRing
 public import Mathlib.Tactic.ComputablePolynomial.MvToPoly
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -71,6 +71,7 @@ public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.MvBasic
 public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
+public import Mathlib.Tactic.ComputablePolynomial.MvMul
 public import Mathlib.Tactic.ComputablePolynomial.MvOfList
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -71,6 +71,7 @@ public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.MvBasic
 public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
+public import Mathlib.Tactic.ComputablePolynomial.MvMem
 public import Mathlib.Tactic.ComputablePolynomial.MvMul
 public import Mathlib.Tactic.ComputablePolynomial.MvOfList
 public import Mathlib.Tactic.ComputablePolynomial.MvReflect

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -73,6 +73,7 @@ public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
 public import Mathlib.Tactic.ComputablePolynomial.MvMul
 public import Mathlib.Tactic.ComputablePolynomial.MvOfList
+public import Mathlib.Tactic.ComputablePolynomial.MvToPoly
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -69,6 +69,7 @@ public import Mathlib.Tactic.ClickSuggestions.Util
 public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
+public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basis

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -73,6 +73,7 @@ public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
 public import Mathlib.Tactic.ComputablePolynomial.MvMul
 public import Mathlib.Tactic.ComputablePolynomial.MvOfList
+public import Mathlib.Tactic.ComputablePolynomial.MvRing
 public import Mathlib.Tactic.ComputablePolynomial.MvToPoly
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas
 public import Mathlib.Tactic.ComputeAsymptotics.Multiseries.Basic

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -68,6 +68,7 @@ public import Mathlib.Tactic.ClickSuggestions.Unfold
 public import Mathlib.Tactic.ClickSuggestions.Util
 public import Mathlib.Tactic.Coe
 public import Mathlib.Tactic.Common
+public import Mathlib.Tactic.ComputablePolynomial.MvBasic
 public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
 public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
 public import Mathlib.Tactic.ComputeAsymptotics.Lemmas

--- a/Mathlib/Tactic/ComputablePolynomial/MvBasic.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvBasic.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.MvDegreesOrder
+public import Mathlib.Algebra.MvPolynomial.Basic
+
+/-!
+# Computable multivariate polynomials (`MvSparsePoly`): definition and addition
+
+A computational, sparse, distributed representation of multivariate polynomials over a
+commutative ring `R` with `DecidableEq R`: a list of `(exponent-vector, coefficient)` terms kept
+strictly decreasing in the monomial order with all coefficients nonzero, giving a canonical
+normal form. This file defines the structure, the semantics `toPoly` into Mathlib's
+`MvPolynomial (Fin nvars) R`, and addition.
+
+## Implementation notes
+
+`DecidableEq R` is required so that zero coefficients can be recognised and dropped, keeping the
+term list canonical.
+
+J. Davenport notes that Lean permits the trivial ring (in which `0 = 1`); supporting it here costs
+extra case analysis, and one may wish to rethink whether to allow it.
+-/
+
+@[expose] public section
+
+variable {nvars : ℕ}
+
+/-- A computable sparse multivariate polynomial over `R` in `nvars` variables: the list of its
+`(exponent-vector, coefficient)` terms, kept strictly decreasing in the monomial order and with all
+coefficients non-zero, giving a canonical normal form. -/
+@[ext] structure MvSparsePoly (R : Type) [CommRing R] (nvars : ℕ)
+    [WOrdering nvars] : Type where
+  /-- The list of `(exponent-vector, coefficient)` terms making up the polynomial. -/
+  terms : List (MvDegrees nvars × R)
+  /-- The terms are strictly decreasing in the monomial order (so degrees are distinct). -/
+  sorted : terms.Pairwise (·.1 > ·.1)
+  /-- Every stored coefficient is non-zero. -/
+  nonzero : ∀ x ∈ terms, x.2 ≠ 0
+
+namespace MvSparsePoly
+
+open MvPolynomial
+
+variable {R : Type} [CommRing R] [DecidableEq R]
+
+/-- Build a polynomial from a sorted term list, dropping zero coefficients. -/
+def ofSortedList
+    (terms : List (MvDegrees nvars × R)) (sorted : terms.Pairwise (·.1 > ·.1)) :
+    MvSparsePoly R nvars where
+  terms := terms.filter (·.2 ≠ 0)
+  sorted := sorted.sublist List.filter_sublist
+  nonzero := by simp [List.mem_filter]
+
+instance : Zero (MvSparsePoly R nvars) where
+  zero := { terms := [], sorted := .nil, nonzero := nofun }
+
+/-- The constant polynomial. `ofSortedList` handles `r = 0` (where `0` is the zero of the
+`MvDegrees` monoid). -/
+def C (r : R) : MvSparsePoly R nvars := ofSortedList [(0, r)] (by simp)
+
+instance : One (MvSparsePoly R nvars) where
+  one := C 1
+
+/-- All exponents in a term list are strictly below `a`. -/
+def degLt (a : MvDegrees nvars) (l : List (MvDegrees nvars × R)) : Prop :=
+  ∀ x ∈ l, x.1 < a
+
+/-- The `Finsupp` underlying an `MvDegrees`, bridging to Mathlib's `MvPolynomial`. -/
+noncomputable def MvDegrees.toFinsupp (deg : MvDegrees nvars) : Fin nvars →₀ ℕ :=
+  Finsupp.onFinset Finset.univ (fun i => deg.degrees[i]'(by simp [deg.correct, i.2])) (by simp)
+
+/-- Interpret a raw term list as an honest `MvPolynomial`, by summing the monomials
+`monomial (toFinsupp i) a` over the terms. This is the noncomputable semantics against which the
+computable operations are proved correct. -/
+noncomputable def toPolyCore : List (MvDegrees nvars × R) → MvPolynomial (Fin nvars) R
+  | [] => 0
+  | (i, a) :: x => monomial (MvDegrees.toFinsupp i) a + toPolyCore x
+
+/-- Interpret an `MvSparsePoly` as the corresponding Mathlib `MvPolynomial`, via `toPolyCore` on its
+term list. -/
+noncomputable def toPoly (x : MvSparsePoly R nvars) : MvPolynomial (Fin nvars) R :=
+  toPolyCore x.terms
+
+/-- Add two sorted term lists by a single merge pass: at each step keep the larger-degree head,
+and on equal degrees add the coefficients (dropping the term if the sum is zero). Preserves the
+strictly-decreasing sortedness. -/
+def addCore : List (MvDegrees nvars × R) → List (MvDegrees nvars × R) → List (MvDegrees nvars × R)
+  | [], yy => yy
+  | xx, [] => xx
+  | xx@((i, a) :: x), yy@((j, b) :: y) =>
+    if i < j then
+      (j, b) :: addCore xx y
+    else if j < i then
+      (i, a) :: addCore x yy
+    else
+      ( fun c => if c=0 then addCore x y else (i, c) :: addCore x y) (a+b)
+    termination_by xx yy => xx.length + yy.length
+
+/-- `addCore` preserves the `degLt` bound. -/
+theorem addCore_degLt {n : MvDegrees nvars} : ∀ {x y : List (MvDegrees nvars × R)},
+    degLt n x → degLt n y → degLt n (addCore x y) := by
+  intro x y hx hy
+  unfold addCore
+  split
+  · exact hy
+  · exact hx
+  · next i a x' j b y' =>
+    let ⟨hi, hx'⟩ := List.forall_mem_cons.1 hx
+    let ⟨hj, hy'⟩ := List.forall_mem_cons.1 hy
+    split
+    · next ij =>
+      unfold degLt
+      intro x hx_mem
+      cases hx_mem with
+      | head => exact hj
+      | tail h => exact addCore_degLt hx hy' x (by aesop)
+    split
+    · next ji =>
+      unfold degLt
+      intro x hx_mem
+      cases hx_mem with
+      | head => exact hi
+      | tail h => exact addCore_degLt hx' hy x (by aesop)
+    · next h_not_ij h_not_ji =>
+      dsimp only
+      split
+      · exact addCore_degLt hx' hy'
+      · unfold degLt
+        intro x hx_mem
+        cases hx_mem with
+        | head => exact hi
+        | tail h => exact addCore_degLt hx' hy' x (by aesop)
+termination_by x y => x.length + y.length
+
+theorem addCore_sorted : ∀ {x y : List (MvDegrees nvars × R)},
+    x.Pairwise (·.1 > ·.1) → y.Pairwise (·.1 > ·.1) →
+    (addCore x y).Pairwise (·.1 > ·.1) := by
+  intro x y hx hy
+  unfold addCore
+  split
+  · exact hy
+  · exact hx
+  · next i a x j b y =>
+    let .cons hi hx' := hx
+    let .cons hj hy' := hy
+    split
+    · next ij =>
+      constructor
+      · apply addCore_degLt
+        · intro
+          | _, .head _ => exact ij
+          | p, .tail _ hp => exact (hi _ hp).trans ij
+        · exact hj
+      · exact addCore_sorted hx hy'
+    split
+    · next ji =>
+      constructor
+      · apply addCore_degLt
+        · exact hi
+        · intro
+          | _, .head _ => exact ji
+          | p, .tail _ hp => exact (hj _ hp).trans ji
+      · exact addCore_sorted hx' hy
+    · have eq_ij : i = j := by
+        rcases lt_trichotomy i j with hlt | heq | hgt
+        · contradiction
+        · exact heq
+        · contradiction
+      subst eq_ij
+      dsimp only
+      split
+      · exact addCore_sorted hx' hy'
+      · exact .cons (addCore_degLt hi hj) (addCore_sorted hx' hy')
+termination_by x y => x.length + y.length
+
+instance : Add (MvSparsePoly R nvars) where
+  add x y := ofSortedList (addCore x.terms y.terms) (addCore_sorted x.sorted y.sorted)
+
+
+end MvSparsePoly

--- a/Mathlib/Tactic/ComputablePolynomial/MvDegrees.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvDegrees.lean
@@ -297,4 +297,3 @@ instance : AddCommMonoid (MvDegrees nvars) where
       exact array_nsmul_succ a.degrees n
     · change a.totalDegree * (n + 1) = a.totalDegree * n + a.totalDegree
       grind
-

--- a/Mathlib/Tactic/ComputablePolynomial/MvDegrees.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvDegrees.lean
@@ -1,0 +1,300 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.Common
+public import Mathlib.Tactic.Ring
+
+/-!
+# Exponent vectors for computable multivariate polynomials
+
+`MvDegrees nvars` is an exponent vector for a monomial in `nvars` variables: an array of
+per-variable exponents together with its cached total degree. This file gives the `AddCommMonoid`
+structure (pointwise addition) and the `List`/`Array` folding lemmas the rest of the computable
+multivariate polynomial library (`MvSparsePoly`) is built on.
+
+## Provenance
+
+Based on the univariate `SparsePoly`, started by Mario Carneiro at the Hausdorff Institute,
+June 2024, with design notes and an original Lean prototype by James Davenport
+(https://github.com/JamesHDavenport/Dagstuhl23401, `verify-irred/VerifyIrred`).
+-/
+
+@[expose] public section
+
+/-- An exponent vector for a monomial in `nvars` variables: an array of length `nvars` giving each
+variable's exponent, together with its (cached) total degree. -/
+@[ext] structure MvDegrees (nvars : ℕ) where
+  /-- The per-variable exponents, one entry per variable. -/
+  degrees : Array ℕ
+  /-- The exponent array has exactly `nvars` entries. -/
+  correct: degrees.size = nvars
+  /-- The cached total degree (the sum of all exponents). -/
+  totalDegree : ℕ
+  /-- The cached `totalDegree` equals the sum of the exponents. -/
+  totalDegree_eq : totalDegree = degrees.foldl (· + ·) 0
+
+/-- Pull the accumulator out of a pure `List.foldl` add loop. -/
+lemma list_foldl_add_acc (l : List ℕ) (acc : ℕ) :
+    l.foldl (· + ·) acc = acc + l.foldl (· + ·) 0 := by
+  induction l generalizing acc with
+  | nil => rfl
+  | cons x xs ih => simp only [List.foldl_cons]; rw [ih (acc + x), ih (0 + x)]; omega
+
+/-- Summing a pointwise list addition splits over the two summands. -/
+lemma list_zipWith_foldl_add (la lb : List ℕ) (h : la.length = lb.length) :
+    (List.zipWith (· + ·) la lb).foldl (· + ·) 0 =
+    la.foldl (· + ·) 0 + lb.foldl (· + ·) 0 := by
+  induction la generalizing lb with
+  | nil => cases lb with
+    | nil => rfl
+    | cons y ys => simp at h
+  | cons x xs ih =>
+    cases lb with
+    | nil => simp at h
+    | cons y ys =>
+      simp only [List.zipWith, List.foldl_cons, List.length_cons, Nat.succ.injEq] at h ⊢
+      rw [list_foldl_add_acc (List.zipWith (· + ·) xs ys) (0 + (x + y)), ih ys h,
+        list_foldl_add_acc xs (0 + x), list_foldl_add_acc ys (0 + y)]
+      omega
+
+/-- Array version of `list_zipWith_foldl_add`. -/
+lemma array_zipWith_foldl_add (a b : Array ℕ) (h : a.size = b.size) :
+    (Array.zipWith (· + ·) a b).foldl (· + ·) 0 =
+    a.foldl (· + ·) 0 + b.foldl (· + ·) 0 := by
+  simp only [← Array.foldl_toList, Array.toList_zipWith]
+  exact list_zipWith_foldl_add a.toList b.toList h
+
+/-- Folding a list of zeros gives `0`. -/
+lemma list_replicate_zero_foldl (n : ℕ) :
+    (List.replicate n 0).foldl (· + ·) 0 = 0 := by
+  induction n with
+  | zero => rfl
+  | succ k ih =>
+    change (0 :: List.replicate k 0).foldl (· + ·) 0 = 0
+    rw [List.foldl_cons, list_foldl_add_acc (List.replicate k 0) (0 + 0)]
+    omega
+
+/-- Array version of `list_replicate_zero_foldl`. -/
+lemma array_replicate_zero_foldl (n : ℕ) :
+    ((List.replicate n 0).toArray).foldl (· + ·) 0 = 0 := by
+  simp only [← Array.foldl_toList]
+  exact list_replicate_zero_foldl n
+
+/-- Scalar multiplication distributes over a `List.foldl` sum. -/
+lemma list_map_mul_foldl (l : List ℕ) (n : ℕ) :
+    (l.map (· * n)).foldl (· + ·) 0 = l.foldl (· + ·) 0 * n := by
+  induction l with
+  | nil => grind
+  | cons x xs ih =>
+    simp only [List.map_cons, List.foldl_cons]
+    rw [list_foldl_add_acc (xs.map (· * n)) (0 + x * n), list_foldl_add_acc xs (0 + x), ih,
+      Nat.add_mul]
+    grind
+
+/-- Array version of `list_map_mul_foldl`. -/
+lemma array_map_mul_foldl (a : Array ℕ) (n : ℕ) :
+    (a.map (· * n)).foldl (· + ·) 0 = a.foldl (· + ·) 0 * n := by
+  simp only [← Array.foldl_toList, Array.toList_map]
+  exact list_map_mul_foldl a.toList n
+
+/-- Arrays are equal if their underlying lists are equal. -/
+lemma array_eq_of_toList_eq {α} {a b : Array α} (h : a.toList = b.toList) : a = b := by
+  cases a; cases b; simp_all
+
+/-- Associativity of pointwise list addition. -/
+lemma list_zipWith_add_assoc (a b c : List ℕ) :
+  List.zipWith (· + ·) (List.zipWith (· + ·) a b) c =
+  List.zipWith (· + ·) a (List.zipWith (· + ·) b c) := by
+  induction a generalizing b c with
+  | nil => rfl
+  | cons x xs ih =>
+    cases b with
+    | nil => rfl
+    | cons y ys =>
+      cases c with
+      | nil => rfl
+      | cons z zs => simp only [List.zipWith]; rw [ih]; grind
+
+/-- Commutativity of pointwise list addition. -/
+lemma list_zipWith_add_comm (a b : List ℕ) :
+  List.zipWith (· + ·) a b = List.zipWith (· + ·) b a := by
+  induction a generalizing b with
+  | nil => cases b <;> rfl
+  | cons x xs ih =>
+    cases b with
+    | nil => rfl
+    | cons y ys => simp only [List.zipWith]; rw [ih]; grind
+
+/-- Left identity for pointwise list addition. -/
+lemma list_zipWith_zero_add (a : List ℕ) :
+  List.zipWith (· + ·) (List.replicate a.length 0) a = a := by
+  induction a with
+  | nil => rfl
+  | cons x xs ih =>
+    change List.zipWith (· + ·) (0 :: List.replicate xs.length 0) (x :: xs) = x :: xs
+    simp only [List.zipWith]; rw [ih]; grind
+
+/-- Right identity for pointwise list addition. -/
+lemma list_zipWith_add_zero (a : List ℕ) :
+  List.zipWith (· + ·) a (List.replicate a.length 0) = a := by
+  induction a with
+  | nil => rfl
+  | cons x xs ih =>
+    change List.zipWith (· + ·) (x :: xs) (0 :: List.replicate xs.length 0) = x :: xs
+    simp only [List.zipWith]; rw [ih]; grind
+
+lemma list_zipWith_add_right_cancel {la lb lc : List ℕ}
+    (h1 : la.length = lc.length) (h2 : lb.length = lc.length)
+    (h : List.zipWith (· + ·) la lc = List.zipWith (· + ·) lb lc) : la = lb := by
+  induction la generalizing lb lc with
+  | nil =>
+    cases lc with
+    | nil => cases lb with | nil => rfl | cons => simp at h2
+    | cons => simp at h1
+  | cons a as ih =>
+    cases lc with
+    | nil => simp at h1
+    | cons c cs =>
+      cases lb with
+      | nil => simp at h2
+      | cons b bs =>
+        simp only [List.zipWith_cons_cons, List.cons.injEq] at h
+        simp only [List.length_cons, Nat.succ.injEq] at h1 h2
+        obtain ⟨hab, htail⟩ := h
+        rw [show a = b by omega, ih h1 h2 htail]
+
+/-- `map (· * 0)` produces a list of zeros. -/
+lemma list_map_zero (a : List ℕ) :
+  a.map (· * 0) = List.replicate a.length 0 := by
+  induction a with
+  | nil => rfl
+  | cons x xs ih =>
+    change (x * 0) :: (xs.map (· * 0)) = 0 :: List.replicate xs.length 0
+    rw [ih]; rfl
+
+/-- `nsmul` successor step for pointwise list scalar multiplication. -/
+lemma list_nsmul_succ (a : List ℕ) (n : ℕ) :
+  a.map (· * (n + 1)) = List.zipWith (· + ·) a (a.map (· * n)) := by
+  induction a with
+  | nil => rfl
+  | cons x xs ih => simp only [List.map, List.zipWith]; rw [ih]; grind
+
+/-- The size of any `MvDegrees` array is exactly `nvars`. -/
+@[simp]
+lemma MvDegrees.size_eq {nvars : ℕ} (x : MvDegrees nvars) : x.degrees.size = nvars :=
+  x.correct
+
+/-- Array version of `list_zipWith_add_assoc`. -/
+lemma array_zipWith_add_assoc (a b c : Array ℕ) :
+    Array.zipWith (· + ·) (Array.zipWith (· + ·) a b) c =
+    Array.zipWith (· + ·) a (Array.zipWith (· + ·) b c) := by
+  apply array_eq_of_toList_eq
+  simp only [Array.toList_zipWith]
+  exact list_zipWith_add_assoc a.toList b.toList c.toList
+
+/-- Array version of `list_zipWith_zero_add`. -/
+lemma array_zipWith_zero_add (a : Array ℕ) (nvars : ℕ) (h : a.size = nvars) :
+    Array.zipWith (· + ·) (List.replicate nvars 0).toArray a = a := by
+  apply array_eq_of_toList_eq
+  simp only [Array.toList_zipWith]
+  rw [show nvars = a.toList.length from h.symm]
+  exact list_zipWith_zero_add a.toList
+
+/-- Array version of `list_zipWith_add_zero`. -/
+lemma array_zipWith_add_zero (a : Array ℕ) (nvars : ℕ) (h : a.size = nvars) :
+    Array.zipWith (· + ·) a (List.replicate nvars 0).toArray = a := by
+  apply array_eq_of_toList_eq
+  simp only [Array.toList_zipWith]
+  rw [show nvars = a.toList.length from h.symm]
+  exact list_zipWith_add_zero a.toList
+
+/-- Array version of `list_zipWith_add_comm`. -/
+lemma array_zipWith_add_comm (a b : Array ℕ) :
+    Array.zipWith (· + ·) a b = Array.zipWith (· + ·) b a := by
+  apply array_eq_of_toList_eq
+  simp only [Array.toList_zipWith]
+  exact list_zipWith_add_comm a.toList b.toList
+
+/-- Array version of `list_map_zero`. -/
+lemma array_map_zero (a : Array ℕ) (nvars : ℕ) (h : a.size = nvars) :
+    a.map (· * 0) = (List.replicate nvars 0).toArray := by
+  apply array_eq_of_toList_eq
+  simp only [Array.toList_map]
+  rw [show nvars = a.toList.length from h.symm]
+  exact list_map_zero a.toList
+
+/-- `nsmul` successor step for pointwise array scalar multiplication. -/
+lemma array_nsmul_succ (a : Array ℕ) (n : ℕ) :
+    a.map (· * (n + 1)) = Array.zipWith (· + ·) (a.map (· * n)) a := by
+  apply array_eq_of_toList_eq
+  simp only [Array.toList_map, Array.toList_zipWith]
+  ext i j
+  grind
+
+variable {nvars : ℕ}
+
+instance : AddCommMonoid (MvDegrees nvars) where
+  add a b := {
+    degrees := Array.zipWith (· + ·) a.degrees b.degrees
+    correct := by simp [a.correct, b.correct]
+    totalDegree := a.totalDegree + b.totalDegree
+    totalDegree_eq := by
+      rw [a.totalDegree_eq, b.totalDegree_eq]
+      have h_size : a.degrees.size = b.degrees.size := by rw [a.correct, b.correct]
+      grind [array_zipWith_foldl_add]
+  }
+  zero := {
+    degrees := (List.replicate nvars 0).toArray
+    correct := by simp
+    totalDegree := 0
+    totalDegree_eq := (array_replicate_zero_foldl nvars).symm
+  }
+  nsmul n a := {
+    degrees := Array.map (· * n) a.degrees
+    correct := by simp [a.correct]
+    totalDegree := a.totalDegree * n
+    totalDegree_eq := by rw [a.totalDegree_eq]; exact (array_map_mul_foldl a.degrees n).symm
+  }
+  add_assoc a b c := by
+    apply MvDegrees.ext
+    · change Array.zipWith (· + ·) (Array.zipWith (· + ·) a.degrees b.degrees) c.degrees =
+             Array.zipWith (· + ·) a.degrees (Array.zipWith (· + ·) b.degrees c.degrees)
+      exact array_zipWith_add_assoc a.degrees b.degrees c.degrees
+    · change (a.totalDegree + b.totalDegree) + c.totalDegree =
+             a.totalDegree + (b.totalDegree + c.totalDegree)
+      omega
+  zero_add a := by
+    apply MvDegrees.ext
+    · change Array.zipWith (· + ·) (List.replicate nvars 0).toArray a.degrees = a.degrees
+      exact array_zipWith_zero_add a.degrees nvars a.correct
+    · change 0 + a.totalDegree = a.totalDegree
+      omega
+  add_zero a := by
+    apply MvDegrees.ext
+    · change Array.zipWith (· + ·) a.degrees (List.replicate nvars 0).toArray = a.degrees
+      exact array_zipWith_add_zero a.degrees nvars a.correct
+    · change a.totalDegree + 0 = a.totalDegree
+      omega
+  add_comm a b := by
+    apply MvDegrees.ext
+    · change Array.zipWith (· + ·) a.degrees b.degrees = Array.zipWith (· + ·) b.degrees a.degrees
+      exact array_zipWith_add_comm a.degrees b.degrees
+    · change a.totalDegree + b.totalDegree = b.totalDegree + a.totalDegree
+      omega
+  nsmul_zero a := by
+    apply MvDegrees.ext
+    · change a.degrees.map (· * 0) = (List.replicate nvars 0).toArray
+      exact array_map_zero a.degrees nvars a.correct
+    · change a.totalDegree * 0 = 0
+      omega
+  nsmul_succ n a := by
+    apply MvDegrees.ext
+    · change a.degrees.map (· * (n + 1)) = Array.zipWith (· + ·) (a.degrees.map (· * n)) a.degrees
+      exact array_nsmul_succ a.degrees n
+    · change a.totalDegree * (n + 1) = a.totalDegree * n + a.totalDegree
+      grind
+

--- a/Mathlib/Tactic/ComputablePolynomial/MvDegreesOrder.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvDegreesOrder.lean
@@ -1,0 +1,268 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.MvDegrees
+public import Mathlib.Data.DFinsupp.WellFounded
+
+/-!
+# The lexicographic monomial order on `MvDegrees`
+
+`WOrdering nvars` packages an admissible monomial order on `MvDegrees nvars`: a linear order that
+is well-founded, has `0` least, and is compatible with addition. The instance provided is the
+lexicographic order, implemented by a kernel-friendly list comparison (`listLex`) and proved
+well-founded via `Pi.Lex.wellFounded`.
+-/
+
+@[expose] public section
+
+variable {nvars : ℕ}
+
+/-- A monomial ordering on `MvDegrees nvars`: a linear order compatible with the monoid structure
+(`0` is the least element, addition is monotone) and well-founded, so it can serve as an admissible
+term order for the sparse polynomial arithmetic. -/
+@[ext] class WOrdering (nvars : ℕ) extends LinearOrder (MvDegrees nvars) where
+  zero_le {x : MvDegrees nvars} : 0 ≤ x
+  add_le_add {x y z : MvDegrees nvars} : x ≤ y → x + z ≤ y + z
+  wf : WellFounded (fun (a b : MvDegrees nvars) => a < b)
+
+/-- Pure-list functional definition of lexicographic order. -/
+def listLex : List ℕ → List ℕ → Bool
+| [], _ => true
+| _, [] => true
+| (x::xs), (y::ys) =>
+  if x < y then true
+  else if y < x then false
+  else listLex xs ys
+
+/-- Lexicographic order on lists is total. -/
+lemma list_lex_total (l1 l2 : List ℕ) : listLex l1 l2 = true ∨ listLex l2 l1 = true := by
+  induction l1 generalizing l2 with
+  | nil => simp [listLex]
+  | cons x xs ih =>
+    cases l2 with
+    | nil => simp [listLex]
+    | cons y ys =>
+      unfold listLex
+      rcases Nat.lt_trichotomy x y with hlt | heq | hgt
+      · simp [hlt, show ¬(y < x) by omega]
+      · subst heq; simp; grind
+      · simp [show ¬(x < y) by omega, hgt]
+
+/-- The per-step state machine for the lexicographic `forIn` loop. -/
+def lexStep (p : ℕ × ℕ) (_acc : Bool) : ForInStep Bool :=
+  if p.1 < p.2 then ForInStep.done true
+  else if p.1 > p.2 then ForInStep.done false
+  else ForInStep.yield true
+
+/-- Bridge the array `forIn` loop to the list one. -/
+lemma array_forIn_eq_list_forIn (a b : Array ℕ) :
+    Id.run (ForIn.forIn (a.zip b) true lexStep) =
+    Id.run (ForIn.forIn (a.toList.zip b.toList) true lexStep) := by
+  grind [Array.toList_zip]
+
+/-- The executable implementation of `lexorder`, kept as the compiled engine. -/
+def lexorderImpl (a b : MvDegrees nvars) : Bool := Id.run do
+  for ai in a.degrees, bi in b.degrees do
+     if ai < bi then return true
+     else if ai > bi then return false
+  return true
+
+/-- Lexicographic comparison of `MvDegrees`, evaluated via `listLex` but run via
+`lexorderImpl`. -/
+@[implemented_by lexorderImpl]
+def lexorder (a b : MvDegrees nvars) : Bool :=
+  listLex a.degrees.toList b.degrees.toList
+
+/-- Antisymmetry of lexicographic order on lists. -/
+lemma list_lex_antisymm {l1 l2 : List ℕ} (hlen : l1.length = l2.length)
+    (h1 : listLex l1 l2 = true) (h2 : listLex l2 l1 = true) : l1 = l2 := by
+  induction l1 generalizing l2 with
+  | nil => cases l2 <;> simp_all
+  | cons x xs ih =>
+    cases l2 with
+    | nil => simp at hlen
+    | cons y ys =>
+      unfold listLex at h1 h2
+      split_ifs at h1 h2 <;> try omega
+      obtain rfl : x = y := by omega
+      simp only [List.length_cons, Nat.add_right_cancel_iff] at hlen
+      rw [ih hlen h1 h2]
+
+/-- `lexorder` agrees with `listLex` on the underlying lists. -/
+lemma lexorder_eq_list_lex (a b : MvDegrees nvars) :
+    lexorder a b = listLex a.degrees.toList b.degrees.toList := rfl
+
+/-- Transitivity of lexicographic order on lists. -/
+lemma list_lex_trans {l1 l2 l3 : List ℕ} (h12 : l1.length = l2.length) (h23 : l2.length = l3.length)
+    (h1 : listLex l1 l2 = true) (h2 : listLex l2 l3 = true) : listLex l1 l3 = true := by
+  induction l1 generalizing l2 l3 with
+  | nil => rfl
+  | cons x xs ih =>
+    cases l2 with | nil => simp at h12 | cons y ys =>
+    cases l3 with | nil => simp at h23 | cons z zs =>
+      unfold listLex at h1 h2 ⊢
+      split_ifs at h1 h2 ⊢ <;> try omega
+      simp only [List.length_cons, Nat.add_right_cancel_iff] at h12 h23
+      exact ih h12 h23 h1 h2
+
+/-- The zero list is lexicographically below any list of the same length. -/
+lemma list_lex_zero_le (l : List ℕ) : listLex (List.replicate l.length 0) l = true := by
+  induction l with
+  | nil => rfl
+  | cons x xs ih =>
+    change listLex (0 :: List.replicate xs.length 0) (x :: xs) = true
+    unfold listLex
+    split_ifs <;> try omega
+    grind
+
+/-- Lexicographic order is preserved by pointwise addition of a common list. -/
+lemma list_lex_add_le_add (la lb lc : List ℕ) (h1 : la.length = lb.length)
+    (h2 : lb.length = lc.length) (hab : listLex la lb = true) :
+    listLex (List.zipWith (· + ·) la lc) (List.zipWith (· + ·) lb lc) = true := by
+  induction la generalizing lb lc with
+  | nil => rfl
+  | cons x xs ih =>
+    cases lb with | nil => simp at h1 | cons y ys =>
+    cases lc with | nil => simp at h2 | cons z zs =>
+      unfold listLex at hab ⊢
+      simp only [List.zipWith]
+      split_ifs at hab ⊢ <;> try omega
+      simp at h1 h2
+      grind
+
+/-- Totality of `lexorder`. -/
+theorem lexorder_total (a b : MvDegrees nvars) : lexorder a b = true ∨ lexorder b a = true :=
+  list_lex_total a.degrees.toList b.degrees.toList
+
+/-- Antisymmetry of `lexorder`. -/
+lemma lexorder_antisymm (a b : MvDegrees nvars) (hab : lexorder a b = true)
+    (hba : lexorder b a = true) : a = b := by
+  have h1 : a.degrees.toList.length = b.degrees.toList.length := by aesop
+  have hlist := list_lex_antisymm h1 hab hba
+  apply MvDegrees.ext
+  · exact array_eq_of_toList_eq hlist
+  · rw [a.totalDegree_eq, b.totalDegree_eq, array_eq_of_toList_eq hlist]
+
+/-- The strict lexicographic order is witnessed by the first differing coordinate. -/
+lemma list_lex_strict_first_diff : ∀ {l1 l2 : List ℕ}, l1.length = l2.length →
+    listLex l1 l2 = true → ¬ (listLex l2 l1 = true) →
+    ∃ n, n < l1.length ∧ (∀ m, m < n → l1[m]! = l2[m]!) ∧ l1[n]! < l2[n]! := by
+  intro l1
+  induction l1 with
+  | nil =>
+    intro l2 hlen h1 h2
+    cases l2 with
+    | nil => exact absurd rfl h2
+    | cons y ys => simp at hlen
+  | cons x xs ih =>
+    intro l2 hlen h1 h2
+    cases l2 with
+    | nil => simp at hlen
+    | cons y ys =>
+      have hlen' : xs.length = ys.length := by simpa using hlen
+      simp only [listLex] at h1 h2
+      rcases lt_trichotomy x y with hxy | hxy | hxy
+      · exact ⟨0, by simp, fun m hm => absurd hm (by omega), by simpa using hxy⟩
+      · subst hxy
+        simp only [lt_self_iff_false, if_false] at h1 h2
+        obtain ⟨n, hn, heq, hlt⟩ := ih hlen' h1 h2
+        refine ⟨n + 1, by simpa using hn, fun m hm => ?_, by simpa using hlt⟩
+        cases m with
+        | zero => rfl
+        | succ k => simpa using heq k (by omega)
+      · exfalso
+        rw [if_neg (asymm hxy), if_pos hxy] at h1
+        exact absurd h1 (by simp)
+
+/-- Bridge `toList[k]!` to the bounded array access. -/
+private lemma mvDegrees_getElem!_toList (d : MvDegrees nvars) (k : ℕ) (hk : k < nvars) :
+    d.degrees.toList[k]! = d.degrees[k]'(by rw [d.correct]; exact hk) := by
+  rw [getElem!_pos d.degrees.toList k (by rw [Array.length_toList, d.correct]; exact hk)]
+  exact (Array.getElem_toList ..).symm
+
+/-- Well-foundedness of the lexicographic monomial order, via `Pi.Lex.wellFounded` on
+`Fin nvars → ℕ` (a finite index ordering each well-founded `ℕ`). -/
+lemma mvDegrees_lex_wf :
+    WellFounded (fun a b : MvDegrees nvars => lexorder a b = true ∧ ¬ (lexorder b a = true)) := by
+  let f : MvDegrees nvars → (Fin nvars → ℕ) :=
+    fun d k => d.degrees[(k : ℕ)]'(by rw [d.correct]; exact k.2)
+  have hpi := Pi.Lex.wellFounded (α := fun _ : Fin nvars => ℕ) (· < ·)
+    (fun _ => wellFounded_lt)
+  refine Subrelation.wf ?_ (InvImage.wf f hpi)
+  intro a b hab
+  obtain ⟨hab1, hab2⟩ := hab
+  change listLex a.degrees.toList b.degrees.toList = true at hab1
+  change ¬ (listLex b.degrees.toList a.degrees.toList = true) at hab2
+  have hlen : a.degrees.toList.length = b.degrees.toList.length := by
+    rw [Array.length_toList, Array.length_toList, a.correct, b.correct]
+  obtain ⟨n, hn, heq, hlt⟩ := list_lex_strict_first_diff hlen hab1 hab2
+  have hn' : n < nvars := by rwa [Array.length_toList, a.correct] at hn
+  refine ⟨⟨n, hn'⟩, fun j hj => ?_, ?_⟩
+  · have hjn : (j : ℕ) < n := hj
+    have hh := heq (j : ℕ) hjn
+    rwa [mvDegrees_getElem!_toList a (j : ℕ) (lt_trans hjn hn'),
+      mvDegrees_getElem!_toList b (j : ℕ) (lt_trans hjn hn')] at hh
+  · have hh := hlt
+    rwa [mvDegrees_getElem!_toList a n hn', mvDegrees_getElem!_toList b n hn'] at hh
+
+instance : WOrdering nvars where
+  le a b := lexorder a b
+  le_refl a := or_self_iff.1 (lexorder_total _ _)
+
+  le_trans a b c hab hbc := by
+    change listLex a.degrees.toList b.degrees.toList = true at hab
+    change listLex b.degrees.toList c.degrees.toList = true at hbc
+    change listLex a.degrees.toList c.degrees.toList = true
+    have h1 : a.degrees.toList.length = b.degrees.toList.length := by aesop
+    have h2 : b.degrees.toList.length = c.degrees.toList.length := by aesop
+    exact list_lex_trans h1 h2 hab hbc
+
+  le_antisymm a b hab hba := by
+    have h1 : a.degrees.toList.length = b.degrees.toList.length := by aesop
+    change listLex a.degrees.toList b.degrees.toList = true at hab
+    change listLex b.degrees.toList a.degrees.toList = true at hba
+    have hlist := list_lex_antisymm h1 hab hba
+    apply MvDegrees.ext
+    · exact array_eq_of_toList_eq hlist
+    · rw [a.totalDegree_eq, b.totalDegree_eq, array_eq_of_toList_eq hlist]
+  min a b := if lexorder a b = true then a else b
+  max a b := if lexorder a b = true then b else a
+  compare a b :=
+    if lexorder a b = true ∧ ¬(lexorder b a = true) then .lt
+    else if lexorder a b = true then .eq
+    else .gt
+
+  le_total := lexorder_total
+  toDecidableLE := fun a b => inferInstanceAs (Decidable (lexorder a b = true))
+  compare_eq_compareOfLessAndEq a b := by
+    have h_anti := lexorder_antisymm a b
+    dsimp [compare, compareOfLessAndEq]
+    split_ifs
+    · rfl
+    · subst ‹a = b›
+      have h_refl : lexorder a a = true := by rcases lexorder_total a a with h | h <;> exact h
+      grind
+    · have heq := h_anti ‹lexorder a b = true› (by tauto)
+      contradiction
+    · subst ‹a = b›
+      have h_refl : lexorder a a = true := by rcases lexorder_total a a with h | h <;> exact h
+      contradiction
+    · rfl
+  zero_le {a} := by
+    change listLex (List.replicate nvars 0) (a : MvDegrees nvars).degrees.toList = true
+    have h : nvars = (a : MvDegrees nvars).degrees.toList.length := by aesop
+    grind [list_lex_zero_le (a : MvDegrees nvars).degrees.toList]
+  add_le_add {a b c} hab := by
+    change listLex a.degrees.toList b.degrees.toList = true at hab
+    change listLex (Array.zipWith (· + ·) a.degrees c.degrees).toList
+      (Array.zipWith (· + ·) b.degrees c.degrees).toList = true
+    simp only [Array.toList_zipWith]
+    have h1 : a.degrees.toList.length = b.degrees.toList.length := by aesop
+    have h2 : b.degrees.toList.length = c.degrees.toList.length := by aesop
+    exact list_lex_add_le_add a.degrees.toList b.degrees.toList c.degrees.toList h1 h2 hab
+  wf := mvDegrees_lex_wf
+

--- a/Mathlib/Tactic/ComputablePolynomial/MvDegreesOrder.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvDegreesOrder.lean
@@ -265,4 +265,3 @@ instance : WOrdering nvars where
     have h2 : b.degrees.toList.length = c.degrees.toList.length := by aesop
     exact list_lex_add_le_add a.degrees.toList b.degrees.toList c.degrees.toList h1 h2 hab
   wf := mvDegrees_lex_wf
-

--- a/Mathlib/Tactic/ComputablePolynomial/MvMem.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvMem.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2026 Michail Karatarakis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.MvReflect
+public import Mathlib.RingTheory.Ideal.Span
+
+/-!
+# `mv_mem`: axiom-free ideal membership for `MvPolynomial`
+
+Proves `p ∈ Ideal.span {g₁, …, gₖ}` by a kernel-reducible multidivisor reduction: cancel the
+leading term of the running polynomial by the first generator whose leading monomial divides it,
+recording the cofactor; if the remainder reaches `0`, the recorded telescoping identity
+`p = Σ cofactorᵢ · gᵢ` exhibits `p` as an explicit combination of the generators, hence in their
+span (`mem_span_of_mReduce`) — checked by kernel `decide +kernel`, **axiom-free** (no
+`native_decide`). Sound for any generators; it succeeds whenever the reduction terminates at `0`
+(e.g. when the generators form a Gröbner basis for the lexicographic order).
+-/
+
+@[expose] public section
+
+namespace MvSparsePoly.Kernel
+
+open MvSparsePoly
+
+variable {R : Type} [CommRing R] [DecidableEq R] {nvars : ℕ}
+
+/-! ### Axiom-free ideal membership (`p ∈ Ideal.span {g₁,…,gₖ}`)
+
+A kernel-reducible multivariate multidivisor reduction. At each step we cancel the leading term of
+the running polynomial using the first generator whose leading monomial divides it, **recording**
+the `(cofactor, generator)` pair. By telescoping, `p = Σ (cofactorᵢ · genᵢ) + remainder` holds
+*for any* ring (`toPolyCore_mReduceK`), so if the remainder is `0` then `p` is an explicit
+combination of the
+generators, hence in their span. Sound regardless of whether the generators form a Gröbner basis
+(it just may fail to reach `0` if they do not). No `native_decide`. -/
+
+/-- Kernel-reducible monomial exponent subtraction (componentwise `Nat` subtraction). -/
+def subMonK (a b : MvDegrees nvars) : MvDegrees nvars where
+  degrees := ⟨List.zipWith (· - ·) a.degrees.toList b.degrees.toList⟩
+  correct := by simp [a.correct, b.correct]
+  totalDegree :=
+    (⟨List.zipWith (· - ·) a.degrees.toList b.degrees.toList⟩ : Array ℕ).foldl (· + ·) 0
+  totalDegree_eq := rfl
+
+/-- Kernel-reducible monomial divisibility: `b` divides `a` iff `b` is componentwise `≤ a`. -/
+def dvdMonK (b a : MvDegrees nvars) : Bool :=
+  (List.zipWith (fun x y => decide (x ≤ y)) b.degrees.toList a.degrees.toList).all (·)
+
+/-- First generator whose leading monomial divides `dp`, with its leading `(monomial, coeff)`. -/
+def findDiv (dp : MvDegrees nvars) :
+    List (TL R nvars) → Option (TL R nvars × MvDegrees nvars × R)
+  | [] => none
+  | g :: gs =>
+    match g with
+    | [] => findDiv dp gs
+    | (dg, cg) :: _ => if dvdMonK dg dp then some (g, dg, cg) else findDiv dp gs
+
+omit [CommRing R] [DecidableEq R] in
+lemma findDiv_mem (dp : MvDegrees nvars) :
+    ∀ {gs : List (TL R nvars)} {g dg cg}, findDiv dp gs = some (g, dg, cg) → g ∈ gs
+  | [], _, _, _, h => by simp [findDiv] at h
+  | [] :: gs, g, dg, cg, h => by
+    simp only [findDiv] at h
+    exact List.mem_cons_of_mem _ (findDiv_mem dp h)
+  | ((d, c) :: rest) :: gs, g, dg, cg, h => by
+    simp only [findDiv] at h
+    by_cases hd : dvdMonK d dp
+    · rw [if_pos hd] at h
+      simp only [Option.some.injEq] at h
+      obtain ⟨rfl, _, _⟩ := h; exact List.mem_cons_self ..
+    · rw [if_neg hd] at h; exact List.mem_cons_of_mem _ (findDiv_mem dp h)
+
+/-- Multidivisor reduction. Returns the recorded `(cofactor, generator)` steps and the remainder. -/
+def mReduceK [Div R] :
+    ℕ → TL R nvars → List (TL R nvars) → List (TL R nvars × TL R nvars) × TL R nvars
+  | 0, p, _ => ([], p)
+  | fuel + 1, p, gs =>
+    match p with
+    | [] => ([], [])
+    | (dp, cp) :: pt =>
+      if cp = 0 then mReduceK fuel pt gs    -- drop a spurious zero leading term
+      else
+        match findDiv dp gs with
+        | none => ([], (dp, cp) :: pt)      -- leading term irreducible: stop (sound, maybe
+                                            -- incomplete)
+        | some (g, _, cg) =>
+          let term : TL R nvars := [(subMonK dp ((g.headD (0, 0)).1), cp / cg)]
+          let r := mReduceK fuel (kSub ((dp, cp) :: pt) (kMul term g)) gs
+          ((term, g) :: r.1, r.2)
+
+/-- The reduction identity, through `toPolyCore` (holds for *any* fuel and `R`). -/
+lemma toPolyCore_mReduceK [Div R] : ∀ (n : ℕ) (p : TL R nvars) (gs : List (TL R nvars)),
+    toPolyCore p =
+      (mReduceK n p gs).1.foldr (fun s acc => toPolyCore s.1 * toPolyCore s.2 + acc) 0
+        + toPolyCore (mReduceK n p gs).2
+  | 0, p, _ => by simp [mReduceK]
+  | n + 1, p, gs => by
+    match p with
+    | [] => simp [mReduceK, toPolyCore]
+    | (dp, cp) :: pt =>
+      by_cases hz : cp = 0
+      · simp only [mReduceK, toPolyCore_cons, hz, map_zero, zero_add]
+        exact toPolyCore_mReduceK n pt gs
+      · simp only [mReduceK, if_neg hz]
+        match hf : findDiv dp gs with
+        | none => simp [toPolyCore]
+        | some (g, dg, cg) =>
+          simp only [List.foldr_cons]
+          have ih := toPolyCore_mReduceK n
+            (kSub ((dp, cp) :: pt) (kMul [(subMonK dp ((g.headD (0, 0)).1), cp / cg)] g)) gs
+          rw [toPolyCore_kSub, toPolyCore_kMul] at ih
+          linear_combination ih
+
+/-- Every generator recorded in the reduction came from `gs`. -/
+lemma mReduceK_gens_mem [Div R] : ∀ (n : ℕ) (p : TL R nvars) (gs : List (TL R nvars))
+    (s : TL R nvars × TL R nvars), s ∈ (mReduceK n p gs).1 → s.2 ∈ gs
+  | 0, p, gs, s, h => by simp [mReduceK] at h
+  | n + 1, p, gs, s, h => by
+    match p with
+    | [] => simp [mReduceK] at h
+    | (dp, cp) :: pt =>
+      by_cases hz : cp = 0
+      · rw [mReduceK, if_pos hz] at h; exact mReduceK_gens_mem n pt gs s h
+      · rw [mReduceK, if_neg hz] at h
+        match hf : findDiv dp gs with
+        | none => rw [hf] at h; simp at h
+        | some (g, dg, cg) =>
+          rw [hf] at h
+          simp only [List.mem_cons] at h
+          rcases h with h | h
+          · subst h; exact findDiv_mem dp hf
+          · exact mReduceK_gens_mem n _ gs s h
+
+omit [DecidableEq R] in
+/-- A recorded combination `Σ cofactorᵢ · genᵢ` lies in the span of the generators. -/
+lemma foldr_mem_span {S : Set (MvPolynomial (Fin nvars) R)}
+    (steps : List (TL R nvars × TL R nvars)) (h : ∀ s ∈ steps, toPolyCore s.2 ∈ S) :
+    (steps.foldr (fun s acc => toPolyCore s.1 * toPolyCore s.2 + acc) 0) ∈ Ideal.span S := by
+  induction steps with
+  | nil => simp only [List.foldr_nil]; exact Ideal.zero_mem _
+  | cons hd tl ih =>
+    simp only [List.foldr_cons]
+    refine Ideal.add_mem _ ?_ (ih fun s hs => h s (List.mem_cons_of_mem _ hs))
+    exact Ideal.mul_mem_left _ _ (Ideal.subset_span (h hd (List.mem_cons_self ..)))
+
+/-- Fuel bound: large enough that the reduction terminates for the goals we run (each step strictly
+lowers the leading monomial); since `mReduceK` stops as soon as the polynomial is empty or
+irreducible, an overestimate costs nothing. -/
+def mReduce [Div R] (p : TL R nvars) (gs : List (TL R nvars)) :
+    List (TL R nvars × TL R nvars) × TL R nvars :=
+  let fuel := ((p.map (fun t => t.1.totalDegree)).foldr Nat.max 0 + 1) ^ (nvars + 1) + p.length + 2
+  mReduceK fuel p gs
+
+/-- The reduction identity for `mReduce`. -/
+lemma toPolyCore_mReduce [Div R] (p : TL R nvars) (gs : List (TL R nvars)) :
+    toPolyCore p =
+      (mReduce p gs).1.foldr (fun s acc => toPolyCore s.1 * toPolyCore s.2 + acc) 0
+        + toPolyCore (mReduce p gs).2 :=
+  toPolyCore_mReduceK _ p gs
+
+/-- **Soundness of `mv_mem`**: if the multidivisor reduction of `p` by the generators leaves no
+nonzero remainder, then `p` is in the ideal they span. -/
+theorem mem_span_of_mReduce [Div R] {p : MvPolynomial (Fin nvars) R}
+    {S : Set (MvPolynomial (Fin nvars) R)} (lp : TL R nvars) (lgs : List (TL R nvars))
+    (h_p : toPolyCore lp = p) (h_gs : ∀ lg ∈ lgs, toPolyCore lg ∈ S)
+    (h : (mReduce lp lgs).2.filter (·.2 ≠ 0) = []) : p ∈ Ideal.span S := by
+  have hrem : toPolyCore (mReduce lp lgs).2 = 0 := by
+    rw [← toPolyCore_filter_nonzero, h]; rfl
+  rw [← h_p, toPolyCore_mReduce lp lgs, hrem, add_zero]
+  exact foldr_mem_span _ fun s hs => h_gs s.2 (mReduceK_gens_mem _ _ _ s hs)
+
+
+end MvSparsePoly.Kernel
+
+public meta section
+
+open Lean Elab Tactic Meta MvSparsePoly.Kernel
+
+/-- Extract the generator expressions from a set literal `{g₁, …, gₖ}`
+(`insert`/singleton/empty). -/
+partial def extractGens (S : Expr) : MetaM (List Expr) := do
+  match (← whnfR S).getAppFnArgs with
+  | (``Insert.insert, #[_, _, _, a, s]) => return a :: (← extractGens s)
+  | (``Singleton.singleton, #[_, _, _, a]) => return [a]
+  | (``EmptyCollection.emptyCollection, _) => return []
+  | _ => throwError "mv_mem: cannot read generators from the span set {S}"
+
+/-- Prove `p ∈ Ideal.span {g₁, …, gₖ}` for `MvPolynomial`s by a kernel-reducible multidivisor
+reduction (`mReduce`): reflect `p` and the generators, then `decide +kernel` that the reduction
+remainder is `0`. **Axiom-free** (no `native_decide`). Sound always; succeeds when the generators
+reduce `p` to `0` (e.g. when they form a Gröbner basis for the relevant order). -/
+elab "mv_mem" : tactic => withMainContext do
+  let g ← getMainGoal
+  let tgt ← instantiateMVars (← g.getType)
+  let (``Membership.mem, args) := tgt.getAppFnArgs
+    | throwError "mv_mem: goal is not `p ∈ Ideal.span S`"
+  let a1 := args[args.size - 1]!
+  let a2 := args[args.size - 2]!
+  let (coll, elem) ←
+    if a1.getAppFnArgs.1 == ``Ideal.span then pure (a1, a2)
+    else if a2.getAppFnArgs.1 == ``Ideal.span then pure (a2, a1)
+    else throwError "mv_mem: goal is not membership in an `Ideal.span`"
+  let S := coll.appArg!
+  let (``MvPolynomial, #[σ, R, _]) := (← inferType elem).getAppFnArgs
+    | throwError "mv_mem: element is not an MvPolynomial (Fin n) R"
+  let n := (← whnfR σ).appArg!
+  let mkBridge (l orig : Expr) : MetaM Expr := do
+    let m ← mkFreshExprSyntheticOpaqueMVar (← mkEq (← mkAppM ``MvSparsePoly.toPolyCore #[l]) orig)
+    let (res, _) ← simpGoal m.mvarId! (← bridgeSimpK)
+    if let some (_, m2) := res then m2.refl
+    instantiateMVars m
+  let lp ← reifyK R n elem
+  let hp ← mkBridge lp elem
+  let gens ← extractGens S
+  let lgs ← gens.mapM (fun gExpr => reifyK R n gExpr)
+  let elemTy ← inferType (lgs.headD lp)
+  let lgsLit ← mkListLit elemTy lgs
+  -- `mem_span_of_mReduce lp lgs hp` leaves two goals: `h_gs` (generators in `S`) and the remainder.
+  -- `S` is implicit, so supply it explicitly (positions: R,inst,inst,nvars,inst,p,S,lp,lgs,h_p).
+  let pf ← mkAppOptM ``MvSparsePoly.Kernel.mem_span_of_mReduce
+    #[none, none, none, none, none, none, some S, some lp, some lgsLit, some hp]
+  let goals ← g.apply pf
+  let (m_gs, m_h) ← match goals with
+    | [a, b] => pure (a, b)
+    | _ => throwError "mv_mem: expected two residual goals, got {goals.length}"
+  -- 1) every reflected generator's image is in the span set `S`
+  replaceMainGoal [m_gs]
+  evalTactic (← `(tactic| intro lg hlg; fin_cases hlg <;>
+    simp only [MvSparsePoly.Kernel.toPolyCore_kAdd, MvSparsePoly.Kernel.toPolyCore_kMul,
+      MvSparsePoly.Kernel.toPolyCore_kSub, MvSparsePoly.Kernel.toPolyCore_kNeg,
+      MvSparsePoly.Kernel.toPolyCore_kPow, MvSparsePoly.Kernel.toPolyCore_X_terms,
+      MvSparsePoly.Kernel.toPolyCore_C_terms, MvSparsePoly.Kernel.toPolyCore_one_terms,
+      MvSparsePoly.Kernel.toPolyCore_zero_terms, map_ofNat, map_one, map_zero,
+      Set.mem_insert_iff, Set.mem_singleton_iff, eq_self_iff_true, true_or, or_true, or_false]))
+  let rem ← getGoals
+  unless rem.isEmpty do throwError "mv_mem h_gs residual: {← rem.mapM fun x => x.getType}"
+  -- 2) the kernel-decided remainder is empty
+  setGoals [m_h]
+  evalTactic (← `(tactic| decide +kernel))
+
+attribute [nolint defsWithUnderscore] tacticMv_mem

--- a/Mathlib/Tactic/ComputablePolynomial/MvMul.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvMul.lean
@@ -1,0 +1,242 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.MvOfList
+
+/-!
+# `MvSparsePoly`: multiplication and negation
+
+`mulFast` (balanced-merge multiplication, Johnson/Monagan–Pearce style), `mulPacked` (packed
+exponent encoding for the single-variable case), the reference `mulCore`, and negation, together
+with the algebraic preparation lemmas (`addCore` commutativity, zero laws) for the ring
+instance.
+-/
+
+@[expose] public section
+
+variable {nvars : ℕ}
+
+namespace MvSparsePoly
+
+open MvPolynomial
+
+variable {R : Type} [CommRing R] [DecidableEq R]
+
+/-- Fast multiplication by a **balanced merge** (mergesort tree): multiply `y` by each term of `x`
+(each product `monomialMul tᵢ y` is already sorted), then merge the `#x` sorted rows pairwise in a
+balanced tree. Same result as the reference `mulCore` (each polynomial has a unique sorted normal
+form), but `O(#x · #y · log #x)` *time* instead of generating all `#x·#y` products and sorting
+them.
+
+Relation to Davenport's notes (Ch. 2, "What are polynomials?"): he notes the sorted approach is
+`O(mn log m)`, and that "naïve construction of all the terms followed by sorting would take `O(mn)`
+space ... we can do better with heapsort [Joh74]". This `balancedSum` achieves the *time* bound but
+NOT the space bound — it still materialises all `#x` rows (so peak `O(#x·#y)`). A true Johnson heap
+of size `#x` would stream the output in `O(#x)` working space. For multiplication the rows have
+equal size `#y`, so the balanced merge is efficient (unlike the division case — see the note on
+`normalForm`); the only thing a real heap would buy here is peak memory, so we keep the simpler,
+verifiable merge. -/
+def mulFast (x y : MvSparsePoly R nvars) : MvSparsePoly R nvars :=
+  balancedSum (x.terms.map (fun t => monomialMul t.1 t.2 y))
+
+/-- Runtime-only **packed** multiplication — the Davenport / Monagan–Pearce exponent-packing trick.
+
+`mulFast` represents each monomial as an `Array ℕ`, so every one of the `#x·#y` partial products
+allocates a fresh boxed-`Nat` array and every merge comparison walks an array. When the product's
+exponents are small enough that each variable fits in a `b`-bit field with `nvars·b ≤ 64`, we
+instead encode a whole monomial as a single `UInt64` (variable `0` in the most-significant field).
+Then:
+
+* the monomial order is plain `UInt64` comparison (`lexorder` is lex with var `0` most significant),
+* monomial multiplication `i + j` is a single `UInt64` add (fields can't carry, since each field sum
+  `≤ 2·maxDeg < 2^b`).
+
+So the whole `#x·#y` inner loop runs on unboxed machine words; we merge/dedup in packed space and
+only unpack the `≤ #product` survivors back to `MvDegrees`. When the exponents don't fit in 64 bits
+(or `nvars = 0`) we fall back to `mulFast`. This is the *time*-constant-factor win Davenport's notes
+point at (Ch. 2, exponent encoding); same result as `mulCore` (wired via `@[implemented_by]`), and
+cross-checked against `mulFast`/`mulCore` by `#guard`. -/
+def mulPacked (x y : MvSparsePoly R nvars) : MvSparsePoly R nvars :=
+  if nvars = 0 then mulFast x y else
+  Id.run do
+    let mut maxDeg : ℕ := 0
+    for t in x.terms do
+      for e in t.1.degrees do
+        if e > maxDeg then maxDeg := e
+    for t in y.terms do
+      for e in t.1.degrees do
+        if e > maxDeg then maxDeg := e
+    let fieldBound : ℕ := 2 * maxDeg + 1
+    let b : ℕ := Nat.log2 fieldBound + 1
+    if nvars * b > 64 then
+      return mulFast x y
+    let bb : UInt64 := b.toUInt64
+    let mask : UInt64 := (1 <<< bb) - 1
+    let pack : MvDegrees nvars → UInt64 := fun d => Id.run do
+      let mut k : UInt64 := 0
+      for e in d.degrees do
+        k := (k <<< bb) ||| (e.toUInt64 &&& mask)
+      return k
+    let unpack : UInt64 → MvDegrees nvars := fun k =>
+      let degs : Array ℕ := Array.ofFn (n := nvars) (fun j : Fin nvars =>
+        ((k >>> (((nvars - 1 - j.val) * b).toUInt64)) &&& mask).toNat)
+      { degrees := degs, correct := by simp [degs], totalDegree := degs.foldl (· + ·) 0,
+        totalDegree_eq := rfl }
+    let yk : Array (UInt64 × R) := (y.terms.map (fun t => (pack t.1, t.2))).toArray
+    let mut prods : Array (UInt64 × R) := Array.mkEmpty (x.terms.length * yk.size)
+    for t in x.terms do
+      let xkey := pack t.1
+      let xc := t.2
+      for p in yk do
+        prods := prods.push (xkey + p.1, xc * p.2)
+    let sorted := prods.qsort (fun a c => decide (c.1 < a.1))
+    let mut merged : Array (UInt64 × R) := Array.mkEmpty sorted.size
+    for p in sorted do
+      match merged.back? with
+      | some q => if q.1 == p.1 then merged := merged.set! (merged.size - 1) (p.1, q.2 + p.2)
+                  else merged := merged.push p
+      | none => merged := merged.push p
+    let mut out : List (MvDegrees nvars × R) := []
+    for p in merged do
+      if p.2 ≠ 0 then out := (unpack p.1, p.2) :: out
+    return ofList out
+
+/-- Reference multiplication: generate every product term, then sort/dedup/filter via `ofList`.
+The proofs use this; compiled code uses the equivalent `mulPacked` via `@[implemented_by]`. -/
+@[implemented_by mulPacked]
+def mulCore (x y : MvSparsePoly R nvars) : MvSparsePoly R nvars :=
+  ofList do
+    let (i, a) ← x.terms
+    let (j, b) ← y.terms
+    return (i + j, a * b)
+
+instance : Mul (MvSparsePoly R nvars) where
+  mul := mulCore
+
+instance : Neg (MvSparsePoly R nvars) where
+  neg x := C (-1) * x
+
+/-- Native computational negation, negating every coefficient. -/
+def negCore (x : List (MvDegrees nvars × R)) : List (MvDegrees nvars × R) :=
+  x.map (fun p => (p.1, -p.2))
+
+omit [DecidableEq R] in
+lemma negCore_sorted {x : List (MvDegrees nvars × R)} (h : x.Pairwise (·.1 > ·.1)) :
+    (negCore x).Pairwise (·.1 > ·.1) := by
+  induction x with
+  | nil => exact List.Pairwise.nil
+  | cons head tail ih =>
+    simp only [negCore, List.map_cons, List.pairwise_cons] at h ⊢
+    refine ⟨fun p hp => ?_, ih h.2⟩
+    rcases List.mem_map.1 hp with ⟨p', hp', heq⟩
+    subst heq
+    exact h.1 p' hp'
+
+/-- Negating non-zero elements keeps them non-zero. -/
+lemma negCore_filter (x : List (MvDegrees nvars × R)) (hx : ∀ p ∈ x, p.2 ≠ 0) :
+    (negCore x).filter (·.2 ≠ 0) = negCore x := by
+  apply List.filter_eq_self.mpr
+  intro p hp
+  rcases List.mem_map.1 hp with ⟨p', hp', heq⟩
+  subst heq
+  have h_not_zero := hx p' hp'
+  grind
+/-- Adding a polynomial to its negation cancels to the empty list. -/
+lemma addCore_negCore (x : List (MvDegrees nvars × R)) :
+    addCore x (negCore x) = [] := by
+  induction x with
+  | nil => simp [addCore, negCore]
+  | cons head tail ih =>
+    rcases head with ⟨i, a⟩
+    unfold addCore
+    have h_not_lt : ¬(i < i) := lt_irrefl i
+    simp only [negCore]
+    have h_zero : a + -a = 0 := add_neg_cancel a
+    aesop
+
+instance : Neg (MvSparsePoly R nvars) where
+  neg p := ofSortedList (negCore p.terms) (negCore_sorted p.sorted)
+
+lemma addCore_nil_left (x : List (MvDegrees nvars × R)) : addCore [] x = x := by
+  cases x <;> simp [addCore]
+
+lemma addCore_nil_right (x : List (MvDegrees nvars × R)) : addCore x [] = x := by
+  cases x <;> simp [addCore]
+
+/-- `addCore` is commutative. -/
+lemma addCore_comm : ∀ (x y : List (MvDegrees nvars × R)),
+    addCore x y = addCore y x
+  | [], yy => by cases yy <;> simp [addCore]
+  | (i, a) :: x, [] => by simp [addCore]
+  | (i, a) :: x, (j, b) :: y => by
+    unfold addCore
+    rcases lt_trichotomy i j with hlt | heq | hgt
+    · have h_not_ji : ¬(j < i) := fun h => lt_irrefl i (lt_trans hlt h)
+      simp only [hlt, h_not_ji, ite_true, ite_false]
+      rw [addCore_comm ((i, a) :: x) y]
+    · subst heq
+      have h_not_lt : ¬(i < i) := lt_irrefl i
+      simp only [h_not_lt, ite_false, add_comm a b, addCore_comm x y]
+    · have h_not_ij : ¬(i < j) := fun h => lt_irrefl j (lt_trans hgt h)
+      simp only [hgt, h_not_ij, ite_true, ite_false]
+      rw [addCore_comm x ((j, b) :: y)]
+termination_by x y => x.length + y.length
+
+/-- The `ofSortedList` filter does not change an already-valid polynomial. -/
+lemma filter_nonzero_eq_self (p : MvSparsePoly R nvars) :
+    p.terms.filter (·.2 ≠ 0) = p.terms := by
+  apply List.filter_eq_self.mpr
+  intro x hx
+  exact decide_eq_true (p.nonzero x hx)
+
+lemma poly_zero_add (p : MvSparsePoly R nvars) : 0 + p = p := by
+  apply MvSparsePoly.ext
+  change (addCore [] p.terms).filter (·.2 ≠ 0) = p.terms
+  rw [addCore_nil_left]
+  exact filter_nonzero_eq_self p
+
+lemma poly_add_zero (p : MvSparsePoly R nvars) : p + 0 = p := by
+  apply MvSparsePoly.ext
+  change (addCore p.terms []).filter (·.2 ≠ 0) = p.terms
+  rw [addCore_nil_right]
+  exact filter_nonzero_eq_self p
+
+lemma poly_add_comm (p q : MvSparsePoly R nvars) : p + q = q + p := by
+  apply MvSparsePoly.ext
+  change (addCore p.terms q.terms).filter (·.2 ≠ 0) =
+    (addCore q.terms p.terms).filter (·.2 ≠ 0)
+  rw [addCore_comm]
+
+lemma poly_add_left_neg (p : MvSparsePoly R nvars) : -p + p = 0 := by
+  apply MvSparsePoly.ext
+  change (addCore ((negCore p.terms).filter (·.2 ≠ 0)) p.terms).filter (·.2 ≠ 0) = []
+  rw [negCore_filter p.terms p.nonzero, addCore_comm (negCore p.terms) p.terms,
+    addCore_negCore p.terms]
+  rfl
+
+/-- `ofList` of the empty list is the zero polynomial. -/
+lemma ofList_nil : ofList (R := R) (nvars := nvars) [] = 0 := by
+  apply MvSparsePoly.ext
+  simp [ofList]
+  simp [ofSortedList, dedupList]
+  rfl
+
+lemma poly_zero_mul (p : MvSparsePoly R nvars) : 0 * p = 0 := by
+  change ofList [] = 0
+  exact ofList_nil
+
+lemma poly_mul_zero (p : MvSparsePoly R nvars) : p * 0 = 0 := by
+  change ofList (p.terms.flatMap (fun _ => [])) = 0
+  have h_bind : p.terms.flatMap
+    (fun _ => ([] : List (MvDegrees nvars × R))) = [] := by
+    induction p.terms with
+    | nil => rfl
+    | cons head tail ih => exact ih
+  rw [h_bind]
+  exact ofList_nil
+
+end MvSparsePoly

--- a/Mathlib/Tactic/ComputablePolynomial/MvOfList.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvOfList.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.MvBasic
+public import Mathlib.Data.List.Sort
+
+/-!
+# `MvSparsePoly`: construction from unsorted term lists, `X`, and monomial multiplication
+
+`ofList` builds a canonical `MvSparsePoly` from an arbitrary term list by sorting and merging
+(`dedupList`); `X v` is the sparse variable. `monomialMul` multiplies by a single monomial, and
+`balancedSum` merges a list of polynomials as a balanced tree, the building block of the fast
+multiplication.
+-/
+
+@[expose] public section
+
+variable {nvars : ℕ}
+
+namespace MvSparsePoly
+
+open MvPolynomial
+
+variable {R : Type} [CommRing R] [DecidableEq R]
+
+/-- Merge adjacent equal-degree terms, summing coefficients. -/
+def dedupList : List (MvDegrees nvars × R) → List (MvDegrees nvars × R)
+  | (i, a) :: (j, b) :: x =>
+    if i = j then
+      dedupList ((i, a + b) :: x)
+    else
+      (i, a) :: dedupList ((j, b) :: x)
+  | x => x
+
+omit [DecidableEq R] in
+lemma dedupList_bound : ∀ (terms : List (MvDegrees nvars × R)) (k : MvDegrees nvars),
+    (∀ p ∈ terms, k ≥ p.1) → ∀ p ∈ dedupList terms, k ≥ p.1
+  | [], k, h => by
+    simp [dedupList]
+  | [(i, a)], k, h => by
+    intro x hx
+    rw [show dedupList [(i, a)] = [(i, a)] by unfold dedupList; rfl] at hx
+    exact h x hx
+  | (i, a) :: (j, b) :: x, k, h => by
+    unfold dedupList
+    split
+    · next heq =>
+      apply dedupList_bound ((i, a + b) :: x) k
+      intro p hp
+      simp only [List.mem_cons] at hp
+      rcases hp with rfl | hp_in_x
+      · exact h (i, a) (by simp)
+      · exact h p (by simp [hp_in_x])
+    · next hneq =>
+      intro p hp
+      simp only [List.mem_cons] at hp
+      rcases hp with rfl | hp_in_dedup
+      · exact h (i, a) (by simp)
+      · apply dedupList_bound ((j, b) :: x) k _ p hp_in_dedup
+        intro p' hp'
+        exact h p' (by simp [hp'])
+termination_by terms => terms.length
+
+omit [DecidableEq R] in
+lemma dedupList_sorted_aux : ∀ (terms : List (MvDegrees nvars × R)),
+    terms.Pairwise (fun p1 p2 => p2.1 ≤ p1.1) →
+    (dedupList terms).Pairwise (fun p1 p2 => p2.1 < p1.1)
+  | [] => fun _ => by unfold dedupList; constructor
+  | [(i, a)] => fun _ => by
+    rw [show dedupList [(i, a)] = [(i, a)] by unfold dedupList; rfl]
+    constructor <;> grind
+  | (i, a) :: (j, b) :: x => fun h => by
+    unfold dedupList
+    split
+    · next heq =>
+      have h_next : ((i, a + b) :: x).Pairwise (fun p1 p2 => p2.1 ≤ p1.1) := by
+        simp only [List.pairwise_cons] at h ⊢
+        rcases h with ⟨hi, hj_x⟩
+        exact ⟨fun p hp => hi p (List.mem_cons_of_mem _ hp), by grind⟩
+      exact dedupList_sorted_aux ((i, a + b) :: x) h_next
+    · next hneq =>
+      have ih := dedupList_sorted_aux ((j, b) :: x) h.of_cons
+      simp only [List.pairwise_cons] at h ⊢
+      rcases h with ⟨hi, hj_x⟩
+      refine ⟨fun p hp => ?_, ih⟩
+      have hj_bound : ∀ p' ∈ ((j, b) :: x), p'.1 ≤ j := by
+        intro p' hp'
+        simp only [List.mem_cons] at hp'
+        rcases hp' with rfl | hp_x
+        · exact le_rfl
+        · exact hj_x.1 p' hp_x
+      have hp_le_j : p.1 ≤ j := dedupList_bound ((j, b) :: x) j hj_bound p hp
+      have j_lt_i : j < i := lt_of_le_of_ne (hi (j, b) List.mem_cons_self) (Ne.symm hneq)
+      exact lt_of_le_of_lt hp_le_j j_lt_i
+termination_by terms => terms.length
+
+omit [DecidableEq R] in
+theorem dedupList_sorted (terms : List (MvDegrees nvars × R))
+  (sorted : terms.Pairwise (·.1 ≥ ·.1)) :
+  (dedupList terms).Pairwise (·.1 > ·.1) := dedupList_sorted_aux terms sorted
+
+/-- Sort an arbitrary term list and merge duplicate degrees into a canonical polynomial. -/
+def ofList (terms : List (MvDegrees nvars × R)) : MvSparsePoly R nvars :=
+  let terms' := terms.mergeSort (fun a b => decide (b.1 ≤ a.1))
+  have hSorted : terms'.Pairwise (·.1 ≥ ·.1) := by
+    apply List.Pairwise.imp (R := fun a b => decide (b.1 ≤ a.1) = true)
+    · intro a b h
+      change b.1 ≤ a.1
+      exact of_decide_eq_true h
+    · apply List.pairwise_mergeSort
+      · exact fun a b c hab hbc =>
+          decide_eq_true (le_trans (of_decide_eq_true hbc) (of_decide_eq_true hab))
+      · intro a b
+        rcases le_total b.1 a.1 with h1 | h2
+        · simp only [decide_eq_true h1, Bool.true_or]
+        · simp only [decide_eq_true h2, Bool.or_true]
+  ofSortedList (dedupList terms') (dedupList_sorted terms' hSorted)
+
+/-- Summing a list of zeros with exactly one entry set to `1` gives `1`. -/
+lemma list_set_one_zero_foldl : ∀ (n : ℕ) (i : ℕ) (_h : i < n),
+    ((List.replicate n 0).set i 1).foldl (· + ·) 0 = 1
+  | 0, i, h => by omega
+  | n + 1, 0, h => by
+    change (1 :: List.replicate n 0).foldl (· + ·) 0 = 1
+    rw [List.foldl_cons, list_foldl_add_acc (List.replicate n 0) (0 + 1),
+      list_replicate_zero_foldl n]
+  | n + 1, i + 1, h => by
+    change (0 :: (List.replicate n 0).set i 1).foldl (· + ·) 0 = 1
+    rw [List.foldl_cons]
+    change ((List.replicate n 0).set i 1).foldl (· + ·) 0 = 1
+    exact list_set_one_zero_foldl n i (by omega)
+
+
+/-- The exponent vector of the single variable `v`: exponent `1` in position `v` and `0` elsewhere
+(total degree `1`). -/
+def singleDegree (v : Fin nvars) : MvDegrees nvars := {
+  degrees := ((List.replicate nvars 0).set v.val 1).toArray
+  correct := by simp
+  totalDegree := 1
+  totalDegree_eq := by
+    symm
+    simp only [← Array.foldl_toList]
+    change ((List.replicate nvars 0).set v.val 1).foldl (· + ·) 0 = 1
+    exact list_set_one_zero_foldl nvars v.val v.isLt
+}
+
+/-- The polynomial consisting of the single variable `v`. -/
+def X (v : Fin nvars) : MvSparsePoly R nvars :=
+  ofSortedList [(singleDegree v, 1)] (List.pairwise_singleton _ _)
+
+/-- Exponent addition is right-cancellative (proved on the underlying arrays). -/
+lemma mvDegrees_add_right_cancel {a b c : MvDegrees nvars} (h : a + c = b + c) : a = b := by
+  have hd : a.degrees = b.degrees := by
+    apply array_eq_of_toList_eq
+    apply list_zipWith_add_right_cancel (lc := c.degrees.toList)
+    · simp [a.correct, c.correct]
+    · simp [b.correct, c.correct]
+    · show List.zipWith (· + ·) a.degrees.toList c.degrees.toList
+        = List.zipWith (· + ·) b.degrees.toList c.degrees.toList
+      rw [← Array.toList_zipWith, ← Array.toList_zipWith]
+      change (a + c).degrees.toList = (b + c).degrees.toList
+      rw [h]
+  obtain ⟨ad, hac, at_, hae⟩ := a
+  obtain ⟨bd, hbc, bt, hbe⟩ := b
+  subst hd
+  simp only [MvDegrees.mk.injEq, true_and]
+  rw [hae, hbe]
+
+/-- Addition by a fixed exponent is strictly monotone in the monomial order. -/
+lemma mvDegrees_add_lt_add_left {i j₁ j₂ : MvDegrees nvars} (h : j₂ < j₁) : i + j₂ < i + j₁ := by
+  rw [add_comm i j₂, add_comm i j₁]
+  refine lt_of_le_of_ne (WOrdering.add_le_add (le_of_lt h)) ?_
+  intro he
+  exact (ne_of_lt h) (mvDegrees_add_right_cancel he)
+
+omit [DecidableEq R] in
+lemma monomialMul_sorted (i : MvDegrees nvars) (a : R) (y : MvSparsePoly R nvars) :
+    (y.terms.map (fun t => (i + t.1, a * t.2))).Pairwise (·.1 > ·.1) :=
+  List.Pairwise.map _ (fun _ _ hpq => mvDegrees_add_lt_add_left hpq) y.sorted
+
+/-- `monomialMul i a y = (a · Xⁱ) * y`, computed directly (no re-sort, since the result is
+already sorted). The building block of the fast Johnson/Monagan–Pearce multiplication. -/
+def monomialMul (i : MvDegrees nvars) (a : R) (y : MvSparsePoly R nvars) : MvSparsePoly R nvars :=
+  ofSortedList (y.terms.map (fun t => (i + t.1, a * t.2))) (monomialMul_sorted i a y)
+
+/-- Fuel-recursive worker for `balancedSum`: split the list in half and recurse, summing the two
+halves. -/
+def balancedSumGo : ℕ → List (MvSparsePoly R nvars) → MvSparsePoly R nvars
+  | _, [] => 0
+  | _, [p] => p
+  | 0, l => l.foldl (· + ·) 0
+  | fuel + 1, l => balancedSumGo fuel (l.take (l.length / 2)) +
+    balancedSumGo fuel (l.drop (l.length / 2))
+
+/-- Sum a list of polynomials by a balanced (divide-and-conquer) merge tree, so building an
+`n`-term result costs `O(n log #summands)` merges instead of the `O(n · #summands)` of a left
+fold. -/
+def balancedSum (l : List (MvSparsePoly R nvars)) : MvSparsePoly R nvars :=
+  balancedSumGo l.length l
+
+
+end MvSparsePoly

--- a/Mathlib/Tactic/ComputablePolynomial/MvReflect.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvReflect.lean
@@ -1,0 +1,310 @@
+/-
+Copyright (c) 2026 Michail Karatarakis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.MvRing
+public import Mathlib.Tactic.LinearCombination
+
+/-!
+# Axiom-free reflection: kernel-reducible normal forms for `MvPolynomial`
+
+This is the reflection tactic for `MvPolynomial`: `mv_decide` (and its synonym `mv_compute`) prove
+an equality or inequality of Mathlib's noncomputable `MvPolynomial` by reflecting onto
+`MvSparsePoly` and closing with kernel `decide +kernel` — **axiom-free** (no
+`native_decide`/`Lean.ofReduceBool`, which Mathlib forbids; its `lean4checker` rejects the extra
+axiom).
+
+The subtlety is that our *runtime* arithmetic (`addCore`, `mulCore`, `ofList`)
+is defined by **well-founded recursion**, which the kernel does not reduce — so plain `decide` gets
+stuck. This file provides an **axiom-free** path: a parallel set of polynomial operations on raw
+term lists defined by **structural** recursion (so the kernel *can* reduce them), each proved
+correct with respect to `toPolyCore` (the noncomputable semantics). A goal is then decided by kernel
+`decide` on the two normal-form lists.
+
+One subtlety, already handled: building *product* monomials needs exponent-vector addition, and
+`MvDegrees`' own `+` is `Array.zipWith`, which the kernel does **not** reduce either. So `kMul` uses
+`addDegK` — a `List.zipWith` form that does reduce — proved equal to `+` by `addDegK_eq_add`, so the
+`toPolyCore` proofs are unaffected. With that in place, full ring identities (`+`, `-`, `*`, `^`)
+decide axiom-free.
+
+The trade-off is the usual one for kernel reflection: `decide` runs in the kernel interpreter, so it
+is only practical for small/medium goals — but it is **axiom-free**.
+-/
+
+@[expose] public section
+
+namespace MvSparsePoly.Kernel
+
+open MvSparsePoly
+
+variable {R : Type} [CommRing R] [DecidableEq R] {nvars : ℕ}
+
+/-- A raw term list (the data of an `MvSparsePoly`, without the sortedness/nonzero proofs). -/
+abbrev TL (R : Type) (nvars : ℕ) := List (MvDegrees nvars × R)
+
+/-- Insert one term into a descending-sorted, merged term list — **structural** recursion on the
+list, so the kernel reduces it. Combines coefficients on an equal monomial. Zero coefficients (e.g.
+from
+cancellation) are removed once, at the end, by `List.filter` (see `toPolyCore_filter_nonzero`). -/
+def insertK (t : MvDegrees nvars × R) : TL R nvars → TL R nvars
+  | [] => [t]
+  | (j, b) :: rest =>
+    match compare t.1 j with
+    | .gt => t :: (j, b) :: rest
+    | .eq => (j, t.2 + b) :: rest
+    | .lt => (j, b) :: insertK t rest
+
+/-- Addition: insert each term of `a` into `b`. -/
+def kAdd (a b : TL R nvars) : TL R nvars := a.foldr insertK b
+
+/-- Negation. -/
+def kNeg (a : TL R nvars) : TL R nvars := a.map (fun t => (t.1, -t.2))
+
+/-- Subtraction. -/
+def kSub (a b : TL R nvars) : TL R nvars := kAdd a (kNeg b)
+
+/-- Kernel-reducible exponent-vector addition. `MvDegrees`' own `+` uses `Array.zipWith`, which the
+kernel does **not** reduce; this `List.zipWith` form does. It is `propositionally` equal to `+`
+(`addDegK_eq_add`), so all the `toPolyCore` correctness proofs transfer. -/
+def addDegK (a b : MvDegrees nvars) : MvDegrees nvars where
+  degrees := ⟨List.zipWith (· + ·) a.degrees.toList b.degrees.toList⟩
+  correct := by simp [a.correct, b.correct]
+  totalDegree :=
+    (⟨List.zipWith (· + ·) a.degrees.toList b.degrees.toList⟩ : Array ℕ).foldl (· + ·) 0
+  totalDegree_eq := rfl
+
+lemma addDegK_eq_add (a b : MvDegrees nvars) : addDegK a b = a + b := by
+  have hsz : a.degrees.size = b.degrees.size := by rw [a.correct, b.correct]
+  have hdeg : (⟨List.zipWith (· + ·) a.degrees.toList b.degrees.toList⟩ : Array ℕ)
+            = Array.zipWith (· + ·) a.degrees b.degrees := by
+    apply Array.ext'; simp [Array.toList_zipWith]
+  apply MvDegrees.ext
+  · exact hdeg
+  · change (⟨List.zipWith (· + ·) a.degrees.toList b.degrees.toList⟩ : Array ℕ).foldl (· + ·) 0
+       = a.totalDegree + b.totalDegree
+    rw [hdeg, array_zipWith_foldl_add a.degrees b.degrees hsz, ← a.totalDegree_eq,
+      ← b.totalDegree_eq]
+
+/-- Multiply a whole list by a single monomial `c·X^d`, then add into the accumulator. Uses
+`addDegK` (kernel-reducible) for the product exponents. -/
+def kMul (a b : TL R nvars) : TL R nvars :=
+  a.foldr (fun t acc => kAdd (b.map (fun s => (addDegK t.1 s.1, t.2 * s.2))) acc) []
+
+/-- Powers, by repeated `kMul` (structural on the exponent). -/
+def kPow (a : TL R nvars) : ℕ → TL R nvars
+  | 0 => (1 : MvSparsePoly R nvars).terms
+  | k + 1 => kMul a (kPow a k)
+
+/-! ### Correctness with respect to `toPolyCore` -/
+
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_cons (t : MvDegrees nvars × R) (l : TL R nvars) :
+    toPolyCore (t :: l) = MvPolynomial.monomial (MvDegrees.toFinsupp t.1) t.2 + toPolyCore l := rfl
+
+omit [DecidableEq R] in
+/-- `insertK` adds one monomial, as seen through `toPolyCore`. -/
+lemma toPolyCore_insertK (d : MvDegrees nvars) (c : R) (l : TL R nvars) :
+    toPolyCore (insertK (d, c) l)
+      = MvPolynomial.monomial (MvDegrees.toFinsupp d) c + toPolyCore l := by
+  induction l with
+  | nil => simp [insertK, toPolyCore]
+  | cons hd tl ih =>
+    obtain ⟨j, b⟩ := hd
+    rw [insertK]
+    rcases hc : compare d j with _ | _ | _
+    · -- lt
+      simp only [toPolyCore_cons, ih]
+      abel
+    · -- eq : `d = j`, so combine the coefficients via additivity of `monomial`
+      obtain rfl := compare_eq_iff_eq.mp hc
+      simp only [toPolyCore_cons]
+      rw [map_add]
+      abel
+    · -- gt
+      simp only [toPolyCore_cons]
+
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_kAdd (a b : TL R nvars) :
+    toPolyCore (kAdd a b) = toPolyCore a + toPolyCore b := by
+  induction a with
+  | nil => simp [kAdd, toPolyCore]
+  | cons hd tl ih =>
+    obtain ⟨d, c⟩ := hd
+    rw [kAdd, List.foldr_cons, ← kAdd, toPolyCore_insertK, ih, toPolyCore_cons, add_assoc]
+
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_kNeg (a : TL R nvars) : toPolyCore (kNeg a) = - toPolyCore a := by
+  change toPolyCore (a.map (fun t => (t.1, -t.2))) = - toPolyCore a
+  induction a with
+  | nil => simp [toPolyCore]
+  | cons hd tl ih =>
+    obtain ⟨d, c⟩ := hd
+    simp only [List.map_cons, toPolyCore_cons, ih, map_neg]
+    abel
+
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_kSub (a b : TL R nvars) :
+    toPolyCore (kSub a b) = toPolyCore a - toPolyCore b := by
+  rw [kSub, toPolyCore_kAdd, toPolyCore_kNeg, sub_eq_add_neg]
+
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_kMul (a b : TL R nvars) :
+    toPolyCore (kMul a b) = toPolyCore a * toPolyCore b := by
+  induction a with
+  | nil => simp [kMul, toPolyCore]
+  | cons hd tl ih =>
+    obtain ⟨d, c⟩ := hd
+    rw [kMul, List.foldr_cons, ← kMul]
+    simp only [addDegK_eq_add]
+    rw [toPolyCore_kAdd, ih, toPolyCore_monomial_mul, toPolyCore_cons, add_mul]
+
+@[simp] lemma toPolyCore_kPow (a : TL R nvars) (k : ℕ) :
+    toPolyCore (kPow a k) = (toPolyCore a) ^ k := by
+  induction k with
+  | zero => rw [kPow, pow_zero]; exact toPoly_one
+  | succ m ih => rw [kPow, toPolyCore_kMul, ih, pow_succ, mul_comm]
+
+-- Leaf bridges: `toPoly = toPolyCore ∘ terms`, so these are just the existing homomorphism lemmas.
+@[simp] lemma toPolyCore_X_terms (i : Fin nvars) :
+    toPolyCore (X i : MvSparsePoly R nvars).terms = MvPolynomial.X i := toPoly_X i
+@[simp] lemma toPolyCore_C_terms (r : R) :
+    toPolyCore (C r : MvSparsePoly R nvars).terms = MvPolynomial.C r := toPoly_C r
+@[simp] lemma toPolyCore_one_terms :
+    toPolyCore (1 : MvSparsePoly R nvars).terms = 1 := toPoly_one
+omit [DecidableEq R] in
+@[simp] lemma toPolyCore_zero_terms :
+    toPolyCore (0 : MvSparsePoly R nvars).terms = 0 := toPoly_zero
+
+/-- Soundness for `=` goals. `l₁`, `l₂` are the (kernel-computed) normal-form lists; the final
+hypothesis compares them *after dropping zero coefficients* (so cancellations like `X·X - X·X`
+match `0`). This direction needs no canonical-form invariant — `toPolyCore` is the semantics, and
+`toPolyCore_filter_nonzero` says dropping zeros doesn't change it. (A `≠` tactic would also need
+`kAdd`/`kMul` to produce *sorted* lists, to invoke `toPolyCore_injective_of_sorted`.) -/
+theorem eq_of_core {p q : MvPolynomial (Fin nvars) R} (l₁ l₂ : TL R nvars)
+    (h₁ : toPolyCore l₁ = p) (h₂ : toPolyCore l₂ = q)
+    (h : l₁.filter (·.2 ≠ 0) = l₂.filter (·.2 ≠ 0)) : p = q := by
+  rw [← h₁, ← h₂, ← toPolyCore_filter_nonzero l₁, ← toPolyCore_filter_nonzero l₂, h]
+
+/-! ### Axiom-free `≠` (a differing coefficient witnesses inequality — no canonical-form needed) -/
+
+/-- Coefficient of monomial `D` read directly off a term list (sum over matching terms). -/
+def listCoeff (D : MvDegrees nvars) (l : TL R nvars) : R :=
+  (l.filter (fun t => t.1 = D)).foldr (fun t s => t.2 + s) 0
+
+omit [DecidableEq R] in
+/-- The list-level coefficient agrees with `MvPolynomial.coeff` — for *any* list (no sortedness). -/
+lemma coeff_toPolyCore_listCoeff (D : MvDegrees nvars) (l : TL R nvars) :
+    MvPolynomial.coeff (MvDegrees.toFinsupp D) (toPolyCore l) = listCoeff D l := by
+  induction l with
+  | nil => simp [toPolyCore, listCoeff]
+  | cons hd tl ih =>
+    obtain ⟨i, a⟩ := hd
+    rw [toPolyCore_cons, MvPolynomial.coeff_add, MvPolynomial.coeff_monomial, ih]
+    by_cases h : i = D
+    · subst h; simp [listCoeff]
+    · rw [if_neg (fun he => h (toFinsupp_inj.mp he))]
+      simp [listCoeff, h]
+
+/-- Boolean test: some monomial appearing in either list has different coefficients. -/
+def polyNeBool (l₁ l₂ : TL R nvars) : Bool :=
+  (l₁ ++ l₂).any (fun t => decide (listCoeff t.1 l₁ ≠ listCoeff t.1 l₂))
+
+/-- Soundness for `≠` goals: a witnessing coefficient difference (decided in the kernel). -/
+theorem ne_of_core {p q : MvPolynomial (Fin nvars) R} (l₁ l₂ : TL R nvars)
+    (h₁ : toPolyCore l₁ = p) (h₂ : toPolyCore l₂ = q) (h : polyNeBool l₁ l₂ = true) : p ≠ q := by
+  subst h₁ h₂
+  obtain ⟨t, _, ht⟩ := List.any_eq_true.mp h
+  intro he
+  exact (of_decide_eq_true ht)
+    (by rw [← coeff_toPolyCore_listCoeff, ← coeff_toPolyCore_listCoeff, he])
+
+
+end MvSparsePoly.Kernel
+
+public meta section
+
+/-! ## The axiom-free tactic -/
+
+open Lean Elab Tactic Meta MvSparsePoly.Kernel
+
+namespace MvSparsePoly.Kernel
+
+/-- Translate a `MvPolynomial (Fin n) R` expression into a kernel-reducible normal-form term list
+`TL R n`, built from the structural ops `kAdd/kMul/kPow/kNeg/kSub` and the leaf term lists
+`(X i).terms`, `(C r).terms`, `(1).terms`. -/
+partial def reifyK (R n : Expr) (e : Expr) : MetaM Expr := do
+  let leafTerms (p : Expr) : MetaM Expr := mkAppM ``MvSparsePoly.terms #[p]
+  match e.getAppFnArgs with
+  | (``HAdd.hAdd, #[_, _, _, _, a, b]) => mkAppM ``kAdd #[← reifyK R n a, ← reifyK R n b]
+  | (``HMul.hMul, #[_, _, _, _, a, b]) => mkAppM ``kMul #[← reifyK R n a, ← reifyK R n b]
+  | (``HSub.hSub, #[_, _, _, _, a, b]) => mkAppM ``kSub #[← reifyK R n a, ← reifyK R n b]
+  | (``HPow.hPow, #[_, _, _, _, a, k]) => mkAppM ``kPow #[← reifyK R n a, k]
+  | (``Neg.neg, #[_, _, a])            => mkAppM ``kNeg #[← reifyK R n a]
+  | (``MvPolynomial.X, #[_, _, _, i])  =>
+      leafTerms (← mkAppOptM ``MvSparsePoly.X #[n, R, none, none, i])
+  | (``DFunLike.coe, #[_, _, _, _, f, c]) =>
+      match f.getAppFnArgs with
+      | (``MvPolynomial.C, _) => leafTerms (← mkAppOptM ``MvSparsePoly.C #[n, R, none, none, c])
+      | _ => throwError "mv_decide: cannot reify {e}"
+  | (``OfNat.ofNat, #[_, lit, _]) =>   -- numeral `m` ↦ `(C (m : R)).terms`  (bridge: `map_ofNat`)
+      let cm ← mkAppOptM ``OfNat.ofNat #[R, lit, none]
+      leafTerms (← mkAppOptM ``MvSparsePoly.C #[n, R, none, none, cm])
+  | _ => throwError "mv_decide: cannot reify {e} into a term list"
+
+end MvSparsePoly.Kernel
+
+/-- The bridge simp set: the `@[simp]` homomorphism lemmas that rewrite `toPolyCore (reified)` back
+into the original `MvPolynomial`. -/
+def bridgeSimpK : MetaM Simp.Context := do
+  let lemmas := #[``MvSparsePoly.Kernel.toPolyCore_kAdd, ``MvSparsePoly.Kernel.toPolyCore_kMul,
+    ``MvSparsePoly.Kernel.toPolyCore_kSub, ``MvSparsePoly.Kernel.toPolyCore_kNeg,
+    ``MvSparsePoly.Kernel.toPolyCore_kPow, ``MvSparsePoly.Kernel.toPolyCore_X_terms,
+    ``MvSparsePoly.Kernel.toPolyCore_C_terms, ``MvSparsePoly.Kernel.toPolyCore_one_terms,
+    ``MvSparsePoly.Kernel.toPolyCore_zero_terms, ``map_ofNat, ``map_one, ``map_zero]
+  let mut s : SimpTheorems := {}
+  for l in lemmas do s ← s.addConst l
+  Simp.mkContext {} (simpTheorems := #[s]) (congrTheorems := ← getSimpCongrTheorems)
+
+/-- Prove a `MvPolynomial` **equality or inequality** by reflecting onto kernel-reducible
+normal-form term lists and closing with kernel `decide +kernel` — **axiom-free** (no
+`native_decide`/compiler
+trust). Practical for small/medium goals; the kernel interpreter is the bottleneck. -/
+elab "mv_decide" : tactic => withMainContext do
+  let g ← getMainGoal
+  let tgt ← whnfR (← g.getType)
+  let (isNeg, p, q) ←
+    if let some (_, a, b) := tgt.eq? then pure (false, a, b)
+    else if let some inner := tgt.not? then
+      if let some (_, a, b) := (← whnfR inner).eq? then pure (true, a, b)
+      else throwError "mv_decide: goal is not an (in)equality of MvPolynomials"
+    else throwError "mv_decide: goal is not an (in)equality of MvPolynomials"
+  let (``MvPolynomial, #[σ, R, _]) := (← inferType p).getAppFnArgs
+    | throwError "mv_decide: goal type is not MvPolynomial (Fin n) R"
+  let n := (← whnfR σ).appArg!
+  let l₁ ← reifyK R n p
+  let l₂ ← reifyK R n q
+  -- bridge proofs `toPolyCore lᵢ = p/q`
+  let mkBridge (l orig : Expr) : MetaM Expr := do
+    let m ← mkFreshExprSyntheticOpaqueMVar (← mkEq (← mkAppM ``MvSparsePoly.toPolyCore #[l]) orig)
+    let (res, _) ← simpGoal m.mvarId! (← bridgeSimpK)
+    if let some (_, m2) := res then m2.refl
+    instantiateMVars m
+  let hp ← mkBridge l₁ p
+  let hq ← mkBridge l₂ q
+  let lem := if isNeg then ``ne_of_core else ``eq_of_core
+  let partialPf ← mkAppM lem #[l₁, l₂, hp, hq]
+  let coreTy := (← inferType partialPf).bindingDomain!
+  let mCore ← mkFreshExprSyntheticOpaqueMVar coreTy
+  g.assign (.app partialPf mCore)
+  replaceMainGoal [mCore.mvarId!]
+  evalTactic (← `(tactic| decide +kernel))
+
+/-- `mv_compute` is a synonym for the axiom-free `mv_decide` (kept for the name; both are kernel,
+no `native_decide`). -/
+macro "mv_compute" : tactic => `(tactic| mv_decide)
+
+
+attribute [nolint defsWithUnderscore] tacticMv_decide tacticMv_compute

--- a/Mathlib/Tactic/ComputablePolynomial/MvRing.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvRing.lean
@@ -1,0 +1,224 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.MvToPoly
+
+/-!
+# `MvSparsePoly`: multiplicativity of `toPoly` and the `CommRing` and `Algebra` instances
+
+`toPoly` preserves multiplication (via the `flatMap` expansion of `mulCore`), giving the
+`CommRing` and `Algebra R` instances on `MvSparsePoly R nvars`, the constant ring hom `CHom`,
+the bridge `toPoly_X`, and decidable equality.
+-/
+
+@[expose] public section
+
+variable {nvars : ℕ}
+
+namespace MvSparsePoly
+
+open MvPolynomial
+
+variable {R : Type} [CommRing R] [DecidableEq R]
+
+omit [DecidableEq R] in
+theorem toPolyCore_perm {l1 l2 : List (MvDegrees nvars × R)} (h : l1.Perm l2) :
+    toPolyCore l1 = toPolyCore l2 := by
+  induction h with
+  | nil => rfl
+  | cons x _ ih => dsimp [toPolyCore]; rw [ih]
+  | swap x y l => dsimp [toPolyCore]; ring
+  | trans _ _ ih1 ih2 => exact ih1.trans ih2
+
+omit [DecidableEq R] in
+/-- `mergeSort` is a permutation, so it preserves the polynomial. -/
+theorem toPolyCore_mergeSort (l : List (MvDegrees nvars × R))
+  (r : (MvDegrees nvars × R) → (MvDegrees nvars × R) → Bool) :
+    toPolyCore (l.mergeSort r) = toPolyCore l :=
+  toPolyCore_perm (l.mergeSort_perm r)
+
+omit [DecidableEq R] in
+theorem toPolyCore_dedupList : ∀ (l : List (MvDegrees nvars × R)),
+    toPolyCore (dedupList l) = toPolyCore l
+  | [] => by simp [dedupList, toPolyCore]
+  | [x] => by simp [dedupList, toPolyCore]
+  | (i, a) :: (j, b) :: xs => by
+      unfold dedupList
+      split
+      · next heq =>
+        subst heq
+        rw [toPolyCore_dedupList ((i, a + b) :: xs)]
+        dsimp [toPolyCore]
+        rw [map_add]
+        ring
+      · next hneq =>
+        dsimp [toPolyCore]
+        rw [toPolyCore_dedupList ((j, b) :: xs)]
+        simp only [toPolyCore]
+
+/-- The master bridge: `toPoly (ofList l) = toPolyCore l`. -/
+theorem toPoly_ofList (l : List (MvDegrees nvars × R)) :
+    toPoly (ofList l) = toPolyCore l := by
+  unfold toPoly ofList ofSortedList
+  dsimp only
+  rw [toPolyCore_filter_nonzero, toPolyCore_dedupList, toPolyCore_mergeSort]
+
+omit [DecidableEq R] in
+/-- Multiplying a term list by a single monomial `(i, a)`. -/
+theorem toPolyCore_monomial_mul (l : List (MvDegrees nvars × R)) (i : MvDegrees nvars) (a : R) :
+    toPolyCore (l.map fun ⟨j, b⟩ => (i + j, a * b)) =
+    (MvPolynomial.monomial (MvDegrees.toFinsupp i) a) * toPolyCore l := by
+  induction l with
+  | nil => simp [toPolyCore]
+  | cons hd tl ih =>
+    rcases hd with ⟨j, b⟩
+    dsimp [toPolyCore]
+    rw [mul_add, ← ih]
+    congr 1
+    rw [MvPolynomial.monomial_mul, toFinsupp_add, mul_comm a b, add_comm]
+
+theorem toPolyCore_ofList_terms (l : List (MvDegrees nvars × R)) :
+    toPolyCore (ofList l).terms = toPolyCore l := by
+  unfold ofList ofSortedList
+  dsimp
+  rw [toPolyCore_filter_nonzero, toPolyCore_dedupList, toPolyCore_mergeSort]
+
+omit [DecidableEq R] in
+/-- `toPolyCore` distributes over list append. -/
+theorem toPolyCore_append (l1 l2 : List (MvDegrees nvars × R)) :
+    toPolyCore (l1 ++ l2) = toPolyCore l1 + toPolyCore l2 := by
+  induction l1 with
+  | nil => simp [toPolyCore]
+  | cons hd tl ih =>
+    dsimp [toPolyCore]
+    rw [ih, add_assoc]
+
+omit [DecidableEq R] in
+/-- `flatMap` form of `toPolyCore_monomial_mul`. -/
+theorem toPolyCore_monomial_mul_flatMap (l : List (MvDegrees nvars × R))
+      (i : MvDegrees nvars) (a : R) :
+    toPolyCore (l.flatMap fun x => [(i + x.1, a * x.2)]) =
+    (MvPolynomial.monomial (MvDegrees.toFinsupp i) a) * toPolyCore l := by
+  induction l with
+  | nil => simp [toPolyCore, List.flatMap]
+  | cons hd tl ih =>
+    change (MvPolynomial.monomial (MvDegrees.toFinsupp (i + hd.1))) (a * hd.2) +
+           toPolyCore (tl.flatMap fun x => [(i + x.1, a * x.2)]) = _
+    rw [ih]
+    erw [mul_add]
+    congr 1
+    rw [MvPolynomial.monomial_mul, toFinsupp_add, mul_comm a hd.2, add_comm]
+
+omit [DecidableEq R] in
+/-- The product of two term lists, expanded via `flatMap`, computes the polynomial product. -/
+theorem toPolyCore_mul_flatMap (l1 l2 : List (MvDegrees nvars × R)) :
+    toPolyCore (l1.flatMap fun x => l2.flatMap fun y => [(x.1 + y.1, x.2 * y.2)]) =
+    toPolyCore l1 * toPolyCore l2 := by
+  induction l1 with
+  | nil => simp [toPolyCore, List.flatMap]
+  | cons hd tl ih =>
+    change toPolyCore ((l2.flatMap fun y => [(hd.1 + y.1, hd.2 * y.2)]) ++
+                       (tl.flatMap fun x => l2.flatMap fun y => [(x.1 + y.1, x.2 * y.2)])) = _
+    rw [toPolyCore_append, toPolyCore_monomial_mul_flatMap, ih]
+    dsimp [toPolyCore]
+    rw [add_mul]
+
+lemma toPoly_mul (a b : MvSparsePoly R nvars) :
+    toPoly (a * b) = toPoly a * toPoly b := by
+  unfold toPoly
+  dsimp [HMul.hMul, Mul.mul, mulCore]
+  rw [toPolyCore_ofList_terms]
+  exact toPolyCore_mul_flatMap a.terms b.terms
+
+instance : CommRing (MvSparsePoly R nvars) where
+  add := (·+·)
+  zero := 0
+  zero_add := poly_zero_add
+  add_zero := poly_add_zero
+  add_comm := poly_add_comm
+  neg := (-·)
+  neg_add_cancel := poly_add_left_neg
+  mul := (·*·)
+  one := 1
+  zero_mul := poly_zero_mul
+  mul_zero := poly_mul_zero
+  nsmul := nsmulRec
+  zsmul := zsmulRec
+  nsmul_zero := by intros; rfl
+  nsmul_succ := by intros; rfl
+  zsmul_zero' := by intros; rfl
+  zsmul_succ' := by intros; rfl
+  natCast n := nsmulRec n 1
+  natCast_zero := rfl
+  natCast_succ := by intros; rfl
+  zsmul_neg' := by intros; rfl
+  add_assoc a b c := toPoly_injective (by simp only [toPoly_add, add_assoc])
+  mul_assoc a b c := toPoly_injective (by simp only [toPoly_mul, mul_assoc])
+  mul_comm a b := toPoly_injective (by simp only [toPoly_mul, mul_comm])
+  left_distrib a b c := toPoly_injective (by simp only [toPoly_add, toPoly_mul, left_distrib])
+  right_distrib a b c := toPoly_injective (by simp only [toPoly_add, toPoly_mul, right_distrib])
+  one_mul a := toPoly_injective (by simp only [toPoly_mul, toPoly_one, one_mul])
+  mul_one a := toPoly_injective (by simp only [toPoly_mul, toPoly_one, mul_one])
+
+omit [DecidableEq R] in
+lemma toPoly_zero : toPoly (0 : MvSparsePoly R nvars) = 0 := rfl
+
+/-- The constant-polynomial inclusion `R → MvSparsePoly R nvars` as a ring homomorphism. -/
+def CHom : R →+* MvSparsePoly R nvars where
+  toFun := C
+  map_zero' := by
+    apply toPoly_injective
+    simp only [toPoly_C, toPoly_zero, map_zero]
+  map_one' := by
+    apply toPoly_injective
+    simp only [toPoly_C, toPoly_one, map_one]
+  map_add' := by
+    intro x y
+    apply toPoly_injective
+    simp only [toPoly_add, toPoly_C, map_add]
+  map_mul' := by
+    intro x y
+    apply toPoly_injective
+    simp only [toPoly_mul, toPoly_C, map_mul]
+
+instance : Algebra R (MvSparsePoly R nvars) where
+  smul r p := C r * p
+  algebraMap := CHom
+  commutes' r p := mul_comm (C r) p
+  smul_def' _ _ := rfl
+
+
+lemma toFinsupp_singleDegree (v : Fin nvars) :
+    MvDegrees.toFinsupp (singleDegree v) = Finsupp.single v 1 := by
+  ext i
+  rw [Finsupp.single_apply]
+  unfold MvDegrees.toFinsupp singleDegree
+  simp only [Finsupp.onFinset_apply]
+  rw [Fin.getElem_fin, ← Array.getElem_toList]
+  simp only [List.getElem_set, List.getElem_replicate]
+  by_cases h : v = i
+  · subst h; simp
+  · rw [if_neg h]
+    split
+    · rename_i hc
+      exact absurd (Fin.ext (show (v : ℕ) = (i : ℕ) by omega)) h
+    · rfl
+
+@[simp]
+theorem toPoly_X (v : Fin nvars) :
+    (X v : MvSparsePoly R nvars).toPoly = MvPolynomial.X v := by
+  unfold X toPoly ofSortedList
+  dsimp only
+  rw [toPolyCore_filter_nonzero]
+  simp only [toPolyCore, add_zero]
+  rw [toFinsupp_singleDegree]
+  rfl
+
+instance : DecidableEq (MvSparsePoly R nvars) := fun a b =>
+  decidable_of_iff' (a.terms = b.terms) (MvSparsePoly.ext_iff ..)
+
+end MvSparsePoly

--- a/Mathlib/Tactic/ComputablePolynomial/MvToPoly.lean
+++ b/Mathlib/Tactic/ComputablePolynomial/MvToPoly.lean
@@ -1,0 +1,274 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+module
+
+public import Mathlib.Tactic.ComputablePolynomial.MvMul
+
+/-!
+# `MvSparsePoly`: the `Finsupp` bridge and injectivity of `toPoly`
+
+The bridge between `MvDegrees` and the `Fin nvars →₀ ℕ` exponents of Mathlib's `MvPolynomial`
+(`toFinsupp_inj`, `toFinsupp_add`), the semantics of constants and `1`, and the key
+`toPoly_injective`: the canonical-form invariant makes the semantics map injective. Ends with
+additivity, `toPoly_add`.
+-/
+
+@[expose] public section
+
+variable {nvars : ℕ}
+
+namespace MvSparsePoly
+
+open MvPolynomial
+
+variable {R : Type} [CommRing R] [DecidableEq R]
+
+/-! ### The Mathlib `Finsupp` bridge, identity and injectivity -/
+
+open MvPolynomial
+
+/-- `MvDegrees.toFinsupp` is injective. -/
+lemma toFinsupp_inj {i j : MvDegrees nvars} :
+    MvDegrees.toFinsupp i = MvDegrees.toFinsupp j ↔ i = j := by
+  constructor
+  · intro h
+    have h_arr : i.degrees = j.degrees := by
+      apply Array.ext
+      · exact i.correct.trans j.correct.symm
+      · intro v hv1 hv2
+        have hv_fin : v < nvars := by aesop
+        exact Finsupp.ext_iff.mp h ⟨v, hv_fin⟩
+    have h_tot : i.totalDegree = j.totalDegree := by
+      rw [i.totalDegree_eq, j.totalDegree_eq, h_arr]
+    cases i
+    cases j
+    simp_all
+  · intro h
+    rw [h]
+
+/-- `MvDegrees.toFinsupp` is additive. -/
+lemma toFinsupp_add (i j : MvDegrees nvars) :
+    MvDegrees.toFinsupp (i + j) =
+    MvDegrees.toFinsupp i + MvDegrees.toFinsupp j := by
+  ext v
+  rw [Finsupp.add_apply]
+  unfold MvDegrees.toFinsupp
+  simp only [Finsupp.onFinset_apply]
+  dsimp only [HAdd.hAdd, Add.add]
+  simp
+
+/-- `MvDegrees.toFinsupp` sends `0` to `0`. -/
+lemma toFinsupp_zero :
+    MvDegrees.toFinsupp (0 : MvDegrees nvars) = 0 := by
+  ext v
+  rw [Finsupp.zero_apply]
+  unfold MvDegrees.toFinsupp
+  simp only [Finsupp.onFinset_apply]
+  have h_zero_def : (0 : MvDegrees nvars).degrees =
+    (List.replicate nvars 0).toArray := rfl
+  simp only [h_zero_def]
+  grind
+
+/-- `toPoly` of a constant polynomial is the constant `MvPolynomial`. -/
+theorem toPoly_C (r : R) : toPoly (C r : MvSparsePoly R nvars) =
+    MvPolynomial.C r := by
+  unfold C toPoly ofSortedList
+  dsimp only
+  by_cases hr : r = 0
+  · subst hr
+    unfold toPolyCore
+    grind
+  · have h_filter : ([(0, r)] : List (MvDegrees nvars × R)).filter (·.2 ≠ 0) = [(0, r)] := by
+      simp [hr]
+    rw [h_filter]
+    change MvPolynomial.monomial (MvDegrees.toFinsupp 0) r +
+      toPolyCore [] = MvPolynomial.C r
+    unfold toPolyCore
+    rw [add_zero]
+    have h_zero : MvDegrees.toFinsupp (0 : MvDegrees nvars) = 0 := toFinsupp_zero
+    aesop
+
+/-- `toPoly` of `1` is `1`. -/
+lemma toPoly_one : toPoly (1 : MvSparsePoly R nvars) = 1 := by
+  change toPoly (C 1 : MvSparsePoly R nvars) = 1
+  rw [toPoly_C]
+  exact map_one (MvPolynomial.C)
+
+omit [DecidableEq R] in
+/-- The coefficient at `n` of a polynomial with all degrees `< n` is zero. -/
+theorem coeff_toPolyCore_of_degLt {n : MvDegrees nvars}
+     (xs : List (MvDegrees nvars × R)) (h : degLt n xs) :
+    MvPolynomial.coeff (MvDegrees.toFinsupp n) (toPolyCore xs) = 0 := by
+  induction xs with
+  | nil => rfl
+  | cons hd tl ih =>
+    rcases hd with ⟨i, a⟩
+    dsimp only [toPolyCore]
+    rw [MvPolynomial.coeff_add]
+    have h_deg : i < n := h (i, a) List.mem_cons_self
+    have h_finsupp_ne : MvDegrees.toFinsupp i ≠ MvDegrees.toFinsupp n :=
+      fun h_eq => ne_of_lt h_deg (toFinsupp_inj.mp h_eq)
+    rw [MvPolynomial.coeff_monomial, if_neg h_finsupp_ne,
+      ih (fun x hx => h x (List.mem_cons_of_mem _ hx)), zero_add]
+
+omit [DecidableEq R] in
+/-- The coefficient of the head term at its own exponent `i` is its coefficient. -/
+theorem coeff_toPolyCore_head {i : MvDegrees nvars} {a : R}
+  (xs : List (MvDegrees nvars × R)) (h : degLt i xs) :
+    MvPolynomial.coeff (MvDegrees.toFinsupp i) (toPolyCore ((i, a) :: xs)) = a := by
+  dsimp only [toPolyCore]
+  simp only [MvPolynomial.coeff_add]
+  rw [MvPolynomial.coeff_monomial, if_pos rfl, coeff_toPolyCore_of_degLt xs h, add_zero]
+
+omit [CommRing R] [DecidableEq R] in
+/-- Extract `degLt` from `Pairwise` sortedness. -/
+lemma degLt_of_sorted_cons {i : MvDegrees nvars} {a : R}
+  {xs : List (MvDegrees nvars × R)}
+    (h : ((i, a) :: xs).Pairwise (·.1 > ·.1)) : degLt i xs :=
+  fun x hx => (List.pairwise_cons.1 h).1 x hx
+
+omit [DecidableEq R] in
+/-- `toPolyCore` is injective on sorted term lists. -/
+theorem toPolyCore_injective_of_sorted : ∀ (l1 l2 : List (MvDegrees nvars × R)),
+    l1.Pairwise (·.1 > ·.1) → l2.Pairwise (·.1 > ·.1) →
+    (∀ x ∈ l1, x.2 ≠ 0) → (∀ x ∈ l2, x.2 ≠ 0) →
+    toPolyCore l1 = toPolyCore l2 → l1 = l2
+  | [], [], _, _, _, _, _ => rfl
+  | [], (j, b) :: ys, _, s2, _, nz2, heq => by
+    have h_coeff : MvPolynomial.coeff (MvDegrees.toFinsupp j) (toPolyCore []) =
+                   MvPolynomial.coeff (MvDegrees.toFinsupp j)
+                   (toPolyCore ((j, b) :: ys)) := by
+                    rw [heq]
+    change 0 = _ at h_coeff
+    rw [coeff_toPolyCore_head ys (degLt_of_sorted_cons s2)] at h_coeff
+    have hb_nz := nz2 (j, b) List.mem_cons_self
+    exact False.elim (hb_nz h_coeff.symm)
+  | (i, a) :: xs, [], s1, _, nz1, _, heq => by
+    have h_coeff : MvPolynomial.coeff (MvDegrees.toFinsupp i)
+                   (toPolyCore ((i, a) :: xs)) =
+                   MvPolynomial.coeff (MvDegrees.toFinsupp i)
+                   (toPolyCore []) := by rw [heq]
+    change _ = 0 at h_coeff
+    rw [coeff_toPolyCore_head xs (degLt_of_sorted_cons s1)] at h_coeff
+    have ha_nz := nz1 (i, a) List.mem_cons_self
+    exact False.elim (ha_nz h_coeff)
+  | (i, a) :: xs, (j, b) :: ys, s1, s2, nz1, nz2, heq => by
+    have h_deg_x : degLt i xs := degLt_of_sorted_cons s1
+    have h_deg_y : degLt j ys := degLt_of_sorted_cons s2
+    obtain hij | rfl | hji := lt_trichotomy i j
+    · have h_coeff : MvPolynomial.coeff (MvDegrees.toFinsupp j)
+                     (toPolyCore ((i, a) :: xs)) =
+                     MvPolynomial.coeff (MvDegrees.toFinsupp j) (toPolyCore ((j, b) :: ys)) := by
+                     rw [heq]
+      rw [coeff_toPolyCore_head ys h_deg_y] at h_coeff
+      have h_xs_j : degLt j xs := fun e he => lt_trans (h_deg_x e he) hij
+      have h_lhs : MvPolynomial.coeff (MvDegrees.toFinsupp j) (toPolyCore ((i, a) :: xs)) = 0 := by
+        dsimp only [toPolyCore]
+        simp only [MvPolynomial.coeff_add]
+        have h_finsupp_ne : MvDegrees.toFinsupp i ≠ MvDegrees.toFinsupp j :=
+          fun h_eq => (ne_of_lt hij) (toFinsupp_inj.mp h_eq)
+        rw [MvPolynomial.coeff_monomial, if_neg h_finsupp_ne,
+          coeff_toPolyCore_of_degLt xs h_xs_j, zero_add]
+      rw [h_lhs] at h_coeff
+      have hb_nz := nz2 (j, b) List.mem_cons_self
+      exact False.elim (hb_nz h_coeff.symm)
+    · have h_coeff : MvPolynomial.coeff (MvDegrees.toFinsupp i) (toPolyCore ((i, a) :: xs)) =
+                     MvPolynomial.coeff (MvDegrees.toFinsupp i) (toPolyCore ((i, b) :: ys)) := by
+                     rw [heq]
+      rw [coeff_toPolyCore_head xs h_deg_x, coeff_toPolyCore_head ys h_deg_y] at h_coeff
+      subst h_coeff
+      dsimp only [toPolyCore] at heq
+      have heq_xs_ys : toPolyCore xs = toPolyCore ys := add_left_cancel heq
+      have s1_xs : xs.Pairwise (·.1 > ·.1) := (List.pairwise_cons.1 s1).2
+      have s2_ys : ys.Pairwise (·.1 > ·.1) := (List.pairwise_cons.1 s2).2
+      have nz1_xs : ∀ x ∈ xs, x.2 ≠ 0 := fun e he => nz1 e (List.mem_cons_of_mem _ he)
+      have nz2_ys : ∀ x ∈ ys, x.2 ≠ 0 := fun e he => nz2 e (List.mem_cons_of_mem _ he)
+      rw [toPolyCore_injective_of_sorted xs ys s1_xs s2_ys nz1_xs nz2_ys heq_xs_ys]
+    · have h_coeff : MvPolynomial.coeff (MvDegrees.toFinsupp i) (toPolyCore ((i, a) :: xs)) =
+                     MvPolynomial.coeff (MvDegrees.toFinsupp i) (toPolyCore ((j, b) :: ys)) := by
+                     rw [heq]
+      rw [coeff_toPolyCore_head xs h_deg_x] at h_coeff
+      have h_ys_i : degLt i ys := fun e he => lt_trans (h_deg_y e he) hji
+      have h_rhs : MvPolynomial.coeff (MvDegrees.toFinsupp i) (toPolyCore ((j, b) :: ys)) = 0 := by
+        dsimp only [toPolyCore]
+        simp only [MvPolynomial.coeff_add]
+        have h_finsupp_ne : MvDegrees.toFinsupp j ≠ MvDegrees.toFinsupp i :=
+          fun h_eq => (ne_of_lt hji) (toFinsupp_inj.mp h_eq)
+        rw [MvPolynomial.coeff_monomial, if_neg h_finsupp_ne,
+          coeff_toPolyCore_of_degLt ys h_ys_i, zero_add]
+      rw [h_rhs] at h_coeff
+      have ha_nz := nz1 (i, a) List.mem_cons_self
+      exact False.elim (ha_nz h_coeff)
+
+omit [DecidableEq R] in
+lemma toPoly_injective : Function.Injective (toPoly (R := R) (nvars := nvars)) := by
+  intro x y h
+  ext1
+  exact toPolyCore_injective_of_sorted x.terms y.terms x.sorted y.sorted x.nonzero y.nonzero h
+
+/-- Filtering out zero coefficients does not change the `MvPolynomial`. -/
+theorem toPolyCore_filter_nonzero (l : List (MvDegrees nvars × R)) :
+    toPolyCore (l.filter (·.2 ≠ 0)) = toPolyCore l := by
+  induction l with
+  | nil => rfl
+  | cons hd tl ih =>
+    rcases hd with ⟨i, a⟩
+    simp only [List.filter_cons]
+    split
+    · next h_nonzero => unfold toPolyCore; rw [ih]
+    · next h_zero =>
+      have ha0 : a = 0 := by aesop
+      unfold toPolyCore
+      rw [ha0, map_zero, zero_add]
+      aesop
+
+/-- `addCore` mirrors `MvPolynomial` addition. -/
+theorem toPolyCore_addCore : ∀ (x y : List (MvDegrees nvars × R)),
+    toPolyCore (addCore x y) = toPolyCore x + toPolyCore y
+  | [], yy => by simp [addCore, toPolyCore]
+  | (i, a) :: x, [] => by simp [addCore, toPolyCore]
+  | (i, a) :: x, (j, b) :: y => by
+    simp only [addCore]
+    rcases lt_trichotomy i j with hlt | heq | hgt
+    · have h_not_ji : ¬(j < i) := fun h_contra => lt_irrefl i (lt_trans hlt h_contra)
+      simp only [hlt, ↓reduceIte]
+      dsimp only [toPolyCore]
+      rw [toPolyCore_addCore]
+      simp only [toPolyCore]
+      ring
+    · subst heq
+      simp only [lt_self_iff_false, ↓reduceIte]
+      split
+      · next hab =>
+          dsimp only [toPolyCore]
+          rw [toPolyCore_addCore]
+          have h_rearrange : (MvPolynomial.monomial (MvDegrees.toFinsupp i) a + toPolyCore x) +
+                             (MvPolynomial.monomial (MvDegrees.toFinsupp i) b + toPolyCore y) =
+                             (MvPolynomial.monomial (MvDegrees.toFinsupp i) a +
+                              MvPolynomial.monomial (MvDegrees.toFinsupp i) b) +
+                             (toPolyCore x + toPolyCore y) := by ring
+          rw [h_rearrange, ← map_add, hab, map_zero, zero_add]
+      · next hab =>
+          dsimp only [toPolyCore]
+          rw [toPolyCore_addCore, map_add]
+          ring
+    · have h_not_ij : ¬(i < j) := fun h_contra => lt_irrefl j (lt_trans hgt h_contra)
+      simp only [h_not_ij, ↓reduceIte, hgt]
+      dsimp only [toPolyCore]
+      rw [toPolyCore_addCore]
+      simp only [toPolyCore]
+      ring
+termination_by x y => x.length + y.length
+
+lemma toPoly_add (a b : MvSparsePoly R nvars) : toPoly (a + b) = toPoly a + toPoly b := by
+  unfold toPoly
+  change toPolyCore ((addCore a.terms b.terms).filter (·.2 ≠ 0)) =
+         toPolyCore a.terms + toPolyCore b.terms
+  rw [toPolyCore_filter_nonzero]
+  exact toPolyCore_addCore a.terms b.terms
+
+
+end MvSparsePoly

--- a/MathlibTest/ComputablePolynomial/MvDecide.lean
+++ b/MathlibTest/ComputablePolynomial/MvDecide.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+import Mathlib.Tactic.ComputablePolynomial.MvReflect
+
+/-!
+# Tests for `mv_decide`
+
+Axiom-free `MvPolynomial` ring identities; the `#guard_msgs` check asserts the axiom set is
+exactly `[propext, Classical.choice, Quot.sound]` — no `native_decide`.
+-/
+
+open MvPolynomial
+
+
+-- Reordering and cancellation (additive):
+example : (X 0 + X 1 + X 2 : MvPolynomial (Fin 3) ℤ) = X 2 + X 0 + X 1 := by mv_decide
+example : (X 0 + X 1 - X 1 : MvPolynomial (Fin 2) ℤ) = X 0 := by mv_decide
+
+-- Multiplication, with like terms merging to coefficient `2`:
+example : ((X 0 + X 1) ^ 2 : MvPolynomial (Fin 2) ℤ) = X 0 ^ 2 + C 2 * (X 0 * X 1) + X 1 ^ 2 := by
+  mv_decide
+
+-- Difference of squares — the cross terms cancel to a *zero* coefficient (dropped by the
+-- `filter (·.2 ≠ 0)` in `eq_of_core`):
+example : ((X 0 + X 1) * (X 0 - X 1) : MvPolynomial (Fin 2) ℤ) = X 0 ^ 2 - X 1 ^ 2 := by mv_decide
+
+-- A factored form equals its expansion:
+example : ((X 0 + X 1) ^ 2 * (X 0 - X 1) : MvPolynomial (Fin 2) ℤ)
+    = (X 0 + X 1) * (X 0 ^ 2 - X 1 ^ 2) := by mv_decide
+
+-- The trust check: this proof depends only on the standard logical axioms — crucially **not**
+-- `Lean.ofReduceBool` (which `native_decide` would add).
+theorem sq_expand : ((X 0 + X 1) ^ 2 : MvPolynomial (Fin 2) ℤ)
+    = X 0 ^ 2 + C 2 * (X 0 * X 1) + X 1 ^ 2 := by mv_decide
+/-- info: 'sq_expand' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms sq_expand
+
+-- bare numerals (no `C`) also work, axiom-free:
+example : ((X 0 + 1) * (X 0 + 2) : MvPolynomial (Fin 1) ℤ) = X 0 ^ 2 + 3 * X 0 + 2 := by
+  mv_decide
+

--- a/MathlibTest/ComputablePolynomial/MvDecide.lean
+++ b/MathlibTest/ComputablePolynomial/MvDecide.lean
@@ -42,4 +42,3 @@ theorem sq_expand : ((X 0 + X 1) ^ 2 : MvPolynomial (Fin 2) ℤ)
 -- bare numerals (no `C`) also work, axiom-free:
 example : ((X 0 + 1) * (X 0 + 2) : MvPolynomial (Fin 1) ℤ) = X 0 ^ 2 + 3 * X 0 + 2 := by
   mv_decide
-

--- a/MathlibTest/ComputablePolynomial/MvMem.lean
+++ b/MathlibTest/ComputablePolynomial/MvMem.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, James Davenport, Michail Karatarakis
+-/
+import Mathlib.Tactic.ComputablePolynomial.MvMem
+
+/-!
+# Tests for `mv_mem`
+
+Axiom-free ideal membership for `MvPolynomial` via kernel-reducible multidivisor reduction.
+-/
+
+open MvPolynomial
+
+
+-- `x·y + y` is in `⟨x, y⟩` (reduces: `−y·x` then `−1·y` to `0`):
+example : (X 0 * X 1 + X 1 : MvPolynomial (Fin 2) ℤ) ∈ Ideal.span {X 0, X 1} := by mv_mem
+
+-- `x² − y ∈ ⟨x, y⟩` (reduces by `x` then by `y`):
+theorem mem_demo : (X 0 ^ 2 - X 1 : MvPolynomial (Fin 2) ℤ) ∈ Ideal.span {X 0, X 1} := by mv_mem
+/-- info: 'mem_demo' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms mem_demo


### PR DESCRIPTION
The `mv_mem` tactic: prove `p ∈ Ideal.span {g₁, …, gₖ}` by a kernel-reducible multidivisor reduction that records cofactors, so a zero remainder exhibits `p` as an explicit combination of the generators (`mem_span_of_mReduce`).

- [ ] depends on: #41355
