### PR TITLE
doc(ModelTheory): fix partial equivalence theorem reference

### DIFF
--- a/Mathlib/ModelTheory/PartialEquiv.lean
+++ b/Mathlib/ModelTheory/PartialEquiv.lean
@@ -29,9 +29,9 @@ This file defines partial isomorphisms between first-order structures.
 - `FirstOrder.Language.embedding_from_cg` shows that if structures `M` and `N` form an equivalence
   pair with `M` countably-generated, then any finite-generated partial equivalence between them
   can be extended to an embedding `M ↪[L] N`.
-- `FirstOrder.Language.equiv_from_cg` shows that if countably-generated structures `M` and `N` form
-  an equivalence pair in both directions, then any finite-generated partial equivalence between them
-  can be extended to an isomorphism `M ↪[L] N`.
+- `FirstOrder.Language.equiv_between_cg` shows that if countably-generated structures `M` and `N`
+  form an equivalence pair in both directions, then any finite-generated partial equivalence between
+  them can be extended to an isomorphism `M ≃[L] N`.
 - The proofs of these results are adapted in part from David Wärn's approach to countable dense
   linear orders, a special case of this phenomenon in the case where `L = Language.order`.
 


### PR DESCRIPTION
Fix a stale module doc reference in `ModelTheory.PartialEquiv`: the theorem is `equiv_between_cg`, and the conclusion is an isomorphism `M ≃[L] N`.

---

This documentation-only PR was split out from #41111 following review feedback.

Please note that ChatGPT Codex was used to help prepare this documentation-only PR.