### PR TITLE
chore(NumberTheory/RamificationInertia): deprecate theorems

### DIFF
--- a/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
@@ -91,17 +91,20 @@ theorem inertiaDeg'_algebraMap [P.LiesOver p] :
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_algebraMap := inertiaDeg'_algebraMap
 
+@[deprecated "Use `Ideal.inertiaDeg_pos` instead." (since := "2026-07-04")]
 theorem inertiaDeg'_pos [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] : 0 < inertiaDeg' p P :=
   have : Nontrivial (S ⧸ P) := Quotient.nontrivial_of_liesOver_of_isPrime P p
   finrank_pos.trans_eq (inertiaDeg'_algebraMap p P).symm
 
 /-- Variant with a weaker constraint, but on the prime upstairs instead. -/
+@[deprecated "Use `Ideal.inertiaDeg_pos` instead." (since := "2026-07-04")]
 theorem inertiaDeg'_pos' [P.IsPrime] [Module.Finite R S] [P.LiesOver p] : 0 < inertiaDeg' p P :=
   have : p.IsPrime := Ideal.over_def P p ▸ inferInstance
   Module.finrank_pos.trans_eq (inertiaDeg'_algebraMap p P).symm
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_pos' := inertiaDeg'_pos'
 
+@[deprecated "Use `Ideal.inertiaDeg_pos` instead." (since := "2026-07-04")]
 theorem inertiaDeg'_ne_zero [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] :
     inertiaDeg' p P ≠ 0 :=
   (Nat.ne_of_lt (inertiaDeg'_pos p P)).symm
@@ -139,6 +142,7 @@ theorem inertiaDeg'_bot [Nontrivial R] [IsDomain S] [Algebra.IsIntegral R S]
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_bot := inertiaDeg'_bot
 
+@[deprecated "Use `Ideal.inertiaDeg_above_le`." (since := "2026-07-04")]
 theorem inertiaDeg'_le_inertiaDeg' {T : Type*} [CommRing T] [Algebra R T] [Algebra S T]
     [IsScalarTower R S T] [Module.Finite R T] (Q : Ideal T) [P.LiesOver p] [Q.LiesOver P]
     [p.IsPrime] : inertiaDeg' P Q ≤ inertiaDeg' p Q := by
@@ -155,6 +159,7 @@ end DecEq
 
 section absNorm
 
+@[deprecated "Use `Ideal.absNorm_pow_inertiaDeg` instead." (since := "2026-07-04")]
 lemma absNorm_eq_pow_inertiaDeg'_of_liesOver {S : Type*} [CommRing S] [IsDedekindDomain S]
     [Module.Free ℤ S] [IsDedekindDomain R] [Module.Free ℤ R] [Algebra S R] [Module.Finite S R]
     (P : Ideal R) (p : Ideal S) [P.LiesOver p] (hp : p.IsPrime) (hp_ne_bot : p ≠ ⊥) :
@@ -169,6 +174,7 @@ lemma absNorm_eq_pow_inertiaDeg'_of_liesOver {S : Type*} [CommRing S] [IsDedekin
 /-- The absolute norm of an ideal `P` above a rational prime `p` is
 `|p| ^ ((span {p}).inertiaDeg' P)`.
 See `absNorm_eq_pow_inertiaDeg'` for a version with `p` of type `ℕ`. -/
+@[deprecated "Use `Ideal.absNorm_pow_inertiaDeg` instead." (since := "2026-07-04")]
 lemma absNorm_eq_pow_inertiaDeg [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] {p : ℤ}
     (P : Ideal R) [P.LiesOver (span {p})] (hp : Prime p) :
     absNorm P = p.natAbs ^ ((span {p}).inertiaDeg' P) := by
@@ -178,6 +184,7 @@ lemma absNorm_eq_pow_inertiaDeg [IsDedekindDomain R] [Module.Free ℤ R] [Module
 /-- The absolute norm of an ideal `P` above a rational (positive) prime `p` is
 `p ^ ((span {p}).inertiaDeg' P)`.
 See `absNorm_eq_pow_inertiaDeg` for a version with `p` of type `ℤ`. -/
+@[deprecated "Use `Ideal.absNorm_pow_inertiaDeg` instead." (since := "2026-07-04")]
 lemma absNorm_eq_pow_inertiaDeg' [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] {p : ℕ}
     (P : Ideal R) [P.LiesOver (span {(p : ℤ)})] (hp : p.Prime) :
     absNorm P = p ^ ((span {(p : ℤ)}).inertiaDeg' P) :=
@@ -193,6 +200,7 @@ variable [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
 /-- Let `T / S / R` be a tower of algebras, `p, P, I` be ideals in `R, S, T`, respectively,
   and `p` and `P` are maximal. If `p = P ∩ S` and `P = I ∩ S`,
   then `f (I | p) = f (P | p) * f (I | P)`. -/
+@[deprecated "Use `Ideal.inertiaDeg_tower`." (since := "2026-07-04")]
 theorem inertiaDeg'_algebra_tower (p : Ideal R) (P : Ideal S) (I : Ideal T) [p.IsMaximal]
     [P.IsMaximal] [P.LiesOver p] [I.LiesOver P] : inertiaDeg' p I =
     inertiaDeg' p P * inertiaDeg' P I := by

--- a/Mathlib/NumberTheory/RamificationInertia/Ramification.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Ramification.lean
@@ -239,6 +239,7 @@ theorem ramificationIdx'_map_self_eq_one [IsDedekindDomain S]
   ramificationIdx'_map_self_eq_one
 
 variable (p P) in
+@[deprecated "Use `Ideal.ramificationIdx_above_le` instead." (since := "2026-07-04")]
 theorem ramificationIdx'_le_ramificationIdx' {T : Type*} [CommRing T] [Algebra R T]
     [Algebra S T] [IsScalarTower R S T] (Q : Ideal T) (hp : p = comap f P)
     (h : ramificationIdx' p Q ≠ 0) : ramificationIdx' P Q ≤ ramificationIdx' p Q := by
@@ -254,6 +255,8 @@ namespace IsDedekindDomain
 
 variable [IsDedekindDomain S]
 
+@[deprecated "Use Ideal.IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count."
+  (since := "2026-07-04")]
 theorem ramificationIdx'_eq_normalizedFactors_count
     (hp0 : map f p ≠ ⊥) (hP : P.IsPrime)
     (hP0 : P ≠ ⊥) : ramificationIdx' p P = (normalizedFactors (map f p)).count P := by
@@ -264,6 +267,8 @@ theorem ramificationIdx'_eq_normalizedFactors_count
       Multiset.nsmul_singleton, ← Multiset.le_count_iff_replicate_le]
   exact (Nat.lt_succ_self _).not_ge
 
+@[deprecated "Use `Ideal.IsDedekindDomain.ramificationIdx_eq_multiplicity` instead."
+  (since := "2026-07-04")]
 theorem ramificationIdx'_eq_multiplicity (hp : map f p ≠ ⊥) (hP : P.IsPrime) :
     ramificationIdx' p P = multiplicity P (Ideal.map f p) := by
   classical
@@ -275,12 +280,15 @@ theorem ramificationIdx'_eq_multiplicity (hp : map f p ≠ ⊥) (hP : P.IsPrime)
     ← UniqueFactorizationMonoid.emultiplicity_eq_count_normalizedFactors _ hp, normalize_eq]
   exact irreducible_iff_prime.mpr <| prime_of_isPrime hP₂ hP
 
+@[deprecated "Use `Ideal.IsDedekindDomain.ramificationIdx_eq_factors_count` instead."
+  (since := "2026-07-04")]
 theorem ramificationIdx'_eq_factors_count
     (hp0 : map f p ≠ ⊥) (hP : P.IsPrime) (hP0 : P ≠ ⊥) :
     ramificationIdx' p P = (factors (map f p)).count P := by
   rw [IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count hp0 hP hP0,
     factors_eq_normalizedFactors]
 
+@[deprecated "Use `Ideal.ramificationIdx_pos` instead." (since := "2026-07-04")]
 theorem ramificationIdx'_ne_zero (hp0 : map f p ≠ ⊥) (hP : P.IsPrime) (le : map f p ≤ P) :
     ramificationIdx' p P ≠ 0 := by
   classical
@@ -295,6 +303,7 @@ theorem ramificationIdx'_ne_zero (hp0 : map f p ≠ ⊥) (hP : P.IsPrime) (le : 
 
 @[deprecated (since := "2026-07-01")] alias ramificationIdx_ne_zero := ramificationIdx'_ne_zero
 
+@[deprecated "Use `Ideal.ramificationIdx_pos` instead." (since := "2026-07-04")]
 theorem ramificationIdx'_ne_zero_of_liesOver [IsDomain R] [IsTorsionFree R S]
     (P : Ideal S) [hP : P.IsPrime] {p : Ideal R} (hp : p ≠ ⊥) [hPp : P.LiesOver p] :
     ramificationIdx' p P ≠ 0 :=
@@ -326,6 +335,7 @@ lemma ramificationIdx'_eq_one_iff
 @[deprecated (since := "2026-07-01")] alias ramificationIdx_eq_one_iff :=
   ramificationIdx'_eq_one_iff
 
+@[deprecated "Use `Ideal.ramificationIdx_above_le` instead." (since := "2026-07-04")]
 theorem ramificationIdx'_le_ramificationIdx' [IsDomain R] [IsTorsionFree R S] {S₀ : Type*}
     [CommRing S₀] [Algebra R S₀] [Algebra S₀ S] [IsScalarTower R S₀ S] (p : Ideal R)
     (P : Ideal S₀) (Q : Ideal S) [Q.LiesOver p] [hP : P.LiesOver p] [Q.IsPrime] (hp : p ≠ ⊥) :
@@ -391,6 +401,7 @@ variable [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
 
 /-- Let `T / S / R` be a tower of algebras, `p, P, Q` be ideals in `R, S, T` respectively,
   and `P` and `Q` are prime. If `P = Q ∩ S`, then `e (Q | p) = e (P | p) * e (Q | P)`. -/
+@[deprecated "Use `Ideal.ramificationIdx_tower` instead." (since := "2026-07-04")]
 theorem ramificationIdx'_algebra_tower [IsDedekindDomain S] [IsDedekindDomain T]
     {p : Ideal R} {P : Ideal S} {Q : Ideal T} [hpm : P.IsPrime] [hqm : Q.IsPrime]
     (hg0 : map (algebraMap S T) P ≠ ⊥)
@@ -421,6 +432,7 @@ theorem ramificationIdx'_algebra_tower [IsDedekindDomain S] [IsDedekindDomain T]
 @[deprecated (since := "2026-07-01")] alias ramificationIdx_algebra_tower :=
   ramificationIdx'_algebra_tower
 
+@[deprecated "Use `Ideal.ramificationIdx_tower` instead." (since := "2026-07-04")]
 theorem ramificationIdx'_algebra_tower' [IsDedekindDomain S] [IsDedekindDomain T] [IsDomain R]
     [Module.IsTorsionFree R S] [Module.IsTorsionFree S T] (p : Ideal R) (P : Ideal S) (Q : Ideal T)
     [Q.IsPrime] [Q.LiesOver P] [P.LiesOver p] :


### PR DESCRIPTION
This PR deprecates theorems in `NumberTheory/RamificationInertia.Inertia` and `NumberTheory/RamificationInertia.Ramification` in favor of analogous theorems in `RingTheory/RamificationInertia.Inertia` and `RingTheory/RamificationInertia.Ramification`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
