### PR TITLE
[Merged by Bors] - feat(Order/SuccPred): `succ a ≤ b ↔ a < b` when `b` is not maximal

### DIFF
--- a/Mathlib/Algebra/Order/SuccPred.lean
+++ b/Mathlib/Algebra/Order/SuccPred.lean
@@ -53,6 +53,9 @@ theorem add_one_le_of_lt (h : x < y) : x + 1 ≤ y := by
 theorem add_one_le_iff_of_not_isMax (hx : ¬ IsMax x) : x + 1 ≤ y ↔ x < y := by
   rw [← succ_eq_add_one, succ_le_iff_of_not_isMax hx]
 
+theorem add_one_le_iff_of_not_isMax' (hy : ¬ IsMax y) : x + 1 ≤ y ↔ x < y := by
+  rw [← succ_eq_add_one, succ_le_iff_of_not_isMax' hy]
+
 @[simp]
 theorem add_one_le_iff [NoMaxOrder α] : x + 1 ≤ y ↔ x < y :=
   add_one_le_iff_of_not_isMax (not_isMax x)
@@ -230,6 +233,9 @@ theorem le_of_lt_add_one (h : x < y + 1) : x ≤ y := by
 
 theorem lt_add_one_iff_of_not_isMax (hy : ¬ IsMax y) : x < y + 1 ↔ x ≤ y := by
   rw [← succ_eq_add_one, lt_succ_iff_of_not_isMax hy]
+
+theorem lt_add_one_iff_of_not_isMax' (hx : ¬ IsMax x) : x < y + 1 ↔ x ≤ y := by
+  rw [← succ_eq_add_one, lt_succ_iff_of_not_isMax' hx]
 
 @[simp]
 theorem lt_add_one_iff [NoMaxOrder α] : x < y + 1 ↔ x ≤ y :=

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -299,8 +299,11 @@ lemma lt_one_iff_eq_zero : n < 1 ↔ n = 0 :=
 lemma le_one_iff_eq_zero_or_eq_one : n ≤ 1 ↔ n = 0 ∨ n = 1 :=
   Order.le_one_iff
 
-theorem lt_add_one_iff (hm : n ≠ ⊤) : m < n + 1 ↔ m ≤ n :=
-  Order.lt_add_one_iff_of_not_isMax (not_isMax_iff_ne_top.mpr hm)
+theorem lt_add_one_iff (hn : n ≠ ⊤) : m < n + 1 ↔ m ≤ n :=
+  Order.lt_add_one_iff_of_not_isMax (not_isMax_iff_ne_top.mpr hn)
+
+theorem lt_add_one_iff' (hm : m ≠ ⊤) : m < n + 1 ↔ m ≤ n :=
+  Order.lt_add_one_iff_of_not_isMax' (not_isMax_iff_ne_top.mpr hm)
 
 @[simp]
 theorem lt_two_iff : n < 2 ↔ n ≤ 1 := by
@@ -313,10 +316,6 @@ theorem add_le_add_iff_left {m n k : ENat} (h : k ≠ ⊤) :
 theorem add_le_add_iff_right {m n k : ENat} (h : k ≠ ⊤) :
     n + k ≤ m + k ↔ n ≤ m :=
   WithTop.add_le_add_iff_right h
-
-theorem lt_add_one_iff' {m n : ENat} (hm : m ≠ ⊤) :
-    m < n + 1 ↔ m ≤ n := by
-  rw [← add_one_le_iff hm, add_le_add_iff_right one_ne_top]
 
 theorem lt_coe_add_one_iff {m : ℕ∞} {n : ℕ} : m < n + 1 ↔ m ≤ n :=
   lt_add_one_iff (coe_ne_top n)

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -282,10 +282,8 @@ theorem succ_def (m : ℕ∞) : Order.succ m = m + 1 :=
 theorem add_one_le_iff (hm : m ≠ ⊤) : m + 1 ≤ n ↔ m < n :=
   Order.add_one_le_iff_of_not_isMax (not_isMax_iff_ne_top.mpr hm)
 
-theorem add_one_le_iff' (hn : n ≠ ⊤) : m + 1 ≤ n ↔ m < n := by
-  rcases eq_or_ne m ⊤ with rfl | hm
-  · simpa
-  · exact add_one_le_iff hm
+theorem add_one_le_iff' (hn : n ≠ ⊤) : m + 1 ≤ n ↔ m < n :=
+  Order.add_one_le_iff_of_not_isMax' (not_isMax_iff_ne_top.mpr hn)
 
 @[deprecated Order.one_le_iff_ne_zero (since := "2026-05-25")]
 protected theorem one_le_iff_ne_zero : 1 ≤ n ↔ n ≠ 0 :=

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -186,6 +186,12 @@ theorem lt_succ_of_le_of_not_isMax (hab : b ≤ a) (ha : ¬IsMax a) : b < succ a
 theorem succ_le_iff_of_not_isMax (ha : ¬IsMax a) : succ a ≤ b ↔ a < b :=
   ⟨(lt_succ_of_not_isMax ha).trans_le, succ_le_of_lt⟩
 
+@[to_dual le_pred_iff_of_not_isMin']
+theorem succ_le_iff_of_not_isMax' (hb : ¬IsMax b) : succ a ≤ b ↔ a < b := by
+  by_cases ha : IsMax a
+  · grind [le_succ, IsMax.mono]
+  · exact succ_le_iff_of_not_isMax ha
+
 @[to_dual]
 lemma succ_lt_succ_of_not_isMax (h : a < b) (hb : ¬ IsMax b) : succ a < succ b :=
   lt_succ_of_le_of_not_isMax (succ_le_of_lt h) hb
@@ -417,13 +423,19 @@ variable [LinearOrder α] [SuccOrder α] {a b : α}
 @[to_dual] lemma succ_min (a b : α) : succ (min a b) = min (succ a) (succ b) := succ_mono.map_min
 
 @[to_dual le_of_pred_lt]
-theorem le_of_lt_succ {a b : α} : a < succ b → a ≤ b := fun h ↦ by
-  by_contra! nh
-  exact (h.trans_le (succ_le_of_lt nh)).false
+theorem le_of_lt_succ {a b : α} : a < succ b → a ≤ b := by
+  contrapose!
+  exact succ_le_of_lt
 
 @[to_dual pred_lt_iff_of_not_isMin]
-theorem lt_succ_iff_of_not_isMax (ha : ¬IsMax a) : b < succ a ↔ b ≤ a :=
-  ⟨le_of_lt_succ, fun h => h.trans_lt <| lt_succ_of_not_isMax ha⟩
+theorem lt_succ_iff_of_not_isMax (ha : ¬IsMax a) : b < succ a ↔ b ≤ a := by
+  contrapose!
+  exact succ_le_iff_of_not_isMax ha
+
+@[to_dual pred_lt_iff_of_not_isMin']
+theorem lt_succ_iff_of_not_isMax' (hb : ¬IsMax b) : b < succ a ↔ b ≤ a := by
+  contrapose!
+  exact succ_le_iff_of_not_isMax' hb
 
 @[to_dual (reorder := ha hb)]
 theorem succ_lt_succ_iff_of_not_isMax (ha : ¬IsMax a) (hb : ¬IsMax b) :


### PR DESCRIPTION
This is `succ_le_iff_of_not_isMax'` (the unprimed version takes `IsMax a` instead).
Also adds a `LinearOrder` version with the negated inequalities, versions for `SuccAddOrder`, and golfs the matching `ENat` theorems with those.

---
`le_of_lt_succ` and `lt_succ_iff_of_not_isMax` are also negated versions of `Preorder` theorems, so we can golf them with `contrapose!`.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
