### PR TITLE
[Merged by Bors] - fix: remove [IsMinimal R W] from HasSplitMultiplicativeReduction

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean
@@ -319,7 +319,7 @@ the polynomial `c₄ T ^ 2 + a₁ c₄ T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)` 
 To see how this expression arises, note that the node `(x₀, y₀)` has second order Taylor expansion
 `(Y - y₀)^2 + a_1(X - x₀)(Y - y₀) - (3x₀ + a_2)(X - x₀)^2` where `x₀ = (18 b₆ - b₂ b₄) / c₄`. -/
 @[mk_iff]
-class HasSplitMultiplicativeReduction (W : WeierstrassCurve K) [IsMinimal R W] : Prop
+class HasSplitMultiplicativeReduction (W : WeierstrassCurve K) : Prop
     extends W.HasMultiplicativeReduction R where
   splitMultiplicativeReduction : letI I := W.integralModel R
     Splits <| .map (algebraMap R (ResidueField R)) <|


### PR DESCRIPTION
Currently we have
```
class HasMultiplicativeReduction (W : WeierstrassCurve K) : Prop extends IsMinimal R W where ...
```
and
```
class HasSplitMultiplicativeReduction (W : WeierstrassCurve K) [IsMinimal R W] : Prop
    extends W.HasMultiplicativeReduction R where
```

and in particular the second declaration asks for `IsMinimal` but also extends the first, which already has it.
This PR removes `[IsMinimal R W]` from the second declaration.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The current setup causes problems. If one wants to define an invariant of an elliptic curve with split multiplicative reduction then currently one has to ask both for `[E.HasSplitMultiplicativeReduction R]` and `[E.IsMinimal R]`, and this then triggers the overlapping instance linter.