### PR TITLE
Rename Real rpow order lemmas

### DIFF
--- a/Mathlib/Algebra/Module/ZLattice/Summable.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Summable.lean
@@ -123,7 +123,7 @@ lemma sum_piFinset_Icc_rpow_le {ι : Type*} [Fintype ι] [DecidableEq ι]
     _ ≤ ∑ k ∈ range n, ∑ p ∈ (s (k + 1) \ s k), ((k + 1) * ε) ^ r := by
         gcongr ∑ k ∈ Finset.range n, ∑ p ∈ (s (k + 1) \ s k), ?_ with k hk v hv
         rw [← Nat.cast_one, ← Nat.cast_add]
-        refine Real.rpow_le_rpow_of_nonpos (by positivity) ?_ hr'.le
+        refine Real.rpow_le_rpow_left_of_exponent_nonpos (by positivity) ?_ hr'.le
         obtain ⟨j, hj⟩ : ∃ i, v i ∉ Icc (-k : ℤ) k := by simpa [s] using (mem_sdiff.mp hv).2
         refine mul_comm _ ε ▸ le_norm_of_le_abs_repr b _ _ j ?_
         suffices ↑k + 1 ≤ |v j| by simpa [Finsupp.single_apply] using this
@@ -252,7 +252,8 @@ lemma summable_norm_sub_rpow (r : ℝ) (hr : r < -Module.finrank ℤ L) (x : E) 
   · simpa [show t = x by simpa [sub_eq_zero] using ht₂, two_mul] using t.2
   have : 0 < Module.finrank ℤ L := Module.finrank_pos
   have : ‖t - x‖ < 2⁻¹ * ‖t‖ := by
-    rw [← Real.rpow_lt_rpow_iff_of_neg (by positivity) (by positivity) (hr.trans (by simpa))]
+    rw [← Real.rpow_lt_rpow_iff_left_of_exponent_neg (by positivity) (by positivity)
+      (hr.trans (by simpa))]
     simpa [Real.mul_rpow, abs_eq_self.mpr (show 0 ≤ ‖t - x‖ ^ r by positivity)] using ht
   have := (norm_sub_norm_le _ _).trans_lt this
   rw [sub_lt_iff_lt_add, ← sub_lt_iff_lt_add', AddSubgroupClass.coe_norm] at this

--- a/Mathlib/Analysis/AbsoluteValue/Equivalence.lean
+++ b/Mathlib/Analysis/AbsoluteValue/Equivalence.lean
@@ -353,7 +353,7 @@ theorem IsEquiv.equivWithAbs_image_mem_nhds_zero (h : v.IsEquiv w) {U : Set (Wit
   rw [← RingEquiv.apply_symm_apply (WithAbs.congr v w (.refl F)) x]
   refine Set.mem_image_of_mem _ (hU ?_)
   rw [Metric.mem_ball, dist_zero_right, WithAbs.norm_eq_apply_ofAbs, ← funext_iff.1 hvw,
-    rpow_lt_rpow_iff (v.nonneg _) hε.le hc] at hx
+    rpow_lt_rpow_iff_left (v.nonneg _) hε.le hc] at hx
   simpa [WithAbs.norm_eq_apply_ofAbs]
 
 open Topology IsTopologicalAddGroup in

--- a/Mathlib/Analysis/Complex/Hadamard.lean
+++ b/Mathlib/Analysis/Complex/Hadamard.lean
@@ -173,7 +173,7 @@ lemma F_BddAbove (f : ℂ → E) (ε : ℝ) (hε : ε > 0)
     · rw [not_le] at hM0_one; apply le_trans _ (le_max_right _ _)
       simp only [norm_cpow_eq_rpow_re_of_pos (sSupNormIm_eps_pos f hε 0), sub_re,
         one_re]
-      apply Real.rpow_le_rpow_of_exponent_ge (sSupNormIm_eps_pos f hε 0) (le_of_lt hM0_one) _
+      apply Real.rpow_le_rpow_right_of_base_le_one (sSupNormIm_eps_pos f hε 0) (le_of_lt hM0_one) _
       simp only [neg_le_sub_iff_le_add, le_add_iff_nonneg_left, hset.1]
   · by_cases hM1_one : 1 ≤ ε + sSupNormIm f 1
     -- `1 ≤ sSupNormIm f 1`
@@ -184,7 +184,7 @@ lemma F_BddAbove (f : ℂ → E) (ε : ℝ) (hε : ε > 0)
     -- `0 < sSupNormIm f 1 < 1`
     · rw [not_le] at hM1_one; apply le_trans _ (le_max_right _ _)
       simp only [norm_cpow_eq_rpow_re_of_pos (sSupNormIm_eps_pos f hε 1),
-        neg_re, Real.rpow_le_rpow_of_exponent_ge (sSupNormIm_eps_pos f hε 1)
+        neg_re, Real.rpow_le_rpow_right_of_base_le_one (sSupNormIm_eps_pos f hε 1)
         (le_of_lt hM1_one) (neg_le_neg_iff.mpr hset.2)]
 
 /-- Proof that `F` is bounded by one on the edges. -/
@@ -508,7 +508,7 @@ lemma norm_le_interp_of_mem_verticalClosedStrip₀₁' (f : ℂ → E) {z : ℂ}
         and_imp, forall_apply_eq_imp_iff₂] using ha
     · use ‖(f 0)‖, 0
       simp
-  · apply Real.rpow_le_rpow (sSupNormIm_nonneg f _) _ hz.1
+  · apply Real.rpow_le_rpow_left (sSupNormIm_nonneg f _) _ hz.1
     · rw [sSupNormIm]
       apply csSup_le _
       · simpa [comp_apply, mem_image, forall_exists_index,

--- a/Mathlib/Analysis/Complex/PhragmenLindelof.lean
+++ b/Mathlib/Analysis/Complex/PhragmenLindelof.lean
@@ -791,7 +791,7 @@ theorem eq_zero_on_right_half_plane_of_superexponential_decay (hd : DiffContOnCl
     · calc
         z.re ≤ ‖z‖ := re_le_norm _
         _ = ‖z‖ ^ (1 : ℝ) := (Real.rpow_one _).symm
-        _ ≤ ‖z‖ ^ max c 1 := Real.rpow_le_rpow_of_exponent_le hz (le_max_right _ _)
+        _ ≤ ‖z‖ ^ max c 1 := Real.rpow_le_rpow_right hz (le_max_right _ _)
     exacts [le_max_left _ _, le_max_left _ _]
   · rw [tendsto_zero_iff_norm_tendsto_zero]; simp only [hg]
     exact hre n

--- a/Mathlib/Analysis/Distribution/SchwartzSpace/Basic.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace/Basic.lean
@@ -159,7 +159,7 @@ theorem isBigO_cocompact_rpow [ProperSpace E] (s : ℝ) :
   refine ⟨1, (Filter.eventually_ge_atTop 1).mono fun x hx ↦ ?_⟩
   rw [one_mul, Real.norm_of_nonneg (by positivity), Real.norm_of_nonneg (by positivity),
     ← Real.rpow_intCast, Int.cast_neg, Int.cast_natCast]
-  exact Real.rpow_le_rpow_of_exponent_le hx hk
+  exact Real.rpow_le_rpow_right hx hk
 
 theorem isBigO_cocompact_zpow [ProperSpace E] (k : ℤ) :
     f =O[cocompact E] (‖·‖ ^ k) := by

--- a/Mathlib/Analysis/Distribution/TemperateGrowth.lean
+++ b/Mathlib/Analysis/Distribution/TemperateGrowth.lean
@@ -381,8 +381,8 @@ theorem hasTemperateGrowth_one_add_norm_sq_rpow (r : ℝ) :
   by_cases! h : 0 ≤ r - n
   · have : r - n ≤ k := by simpa using hk₁.trans (by simp)
     rw [← Real.rpow_natCast]
-    exact (Real.rpow_le_rpow (by positivity) (by simp) h).trans
-      (Real.rpow_le_rpow_of_exponent_le (by simp) this)
+    exact (Real.rpow_le_rpow_left (by positivity) (by simp) h).trans
+      (Real.rpow_le_rpow_right (by simp) this)
   have h : 0 < n - r := by grind
   calc
     /- In the case `0 < n - r`, we need the factor `Real.log 2 / (Real.log (3 / 2))` to control
@@ -470,7 +470,7 @@ lemma _root_.pow_mul_le_of_le_of_pow_mul_le {C₁ C₂ : ℝ} {k l : ℕ} {x f :
       simp
     _ ≤ ((1 + x) / 2) ^ (-(l : ℝ)) * (C₁ + C₂) := by
       apply mul_le_mul _ _ (by positivity) (by positivity)
-      · exact Real.rpow_le_rpow_of_nonpos (by positivity) (by linarith) (by simp)
+      · exact Real.rpow_le_rpow_left_of_exponent_nonpos (by positivity) (by linarith) (by simp)
       · exact h₂.trans (by linarith)
 
 variable [NormedAddCommGroup F]

--- a/Mathlib/Analysis/Fourier/PoissonSummation.lean
+++ b/Mathlib/Analysis/Fourier/PoissonSummation.lean
@@ -135,7 +135,7 @@ theorem isBigO_norm_Icc_restrict_atTop {f : C(ℝ, E)} {b : ℝ} (hb : 0 < b)
     rw [max_lt_iff] at hx
     obtain ⟨hx1, hx2⟩ := hx
     rw [← mul_rpow] <;> try positivity
-    apply rpow_le_rpow_of_nonpos <;> linarith
+    apply rpow_le_rpow_left_of_exponent_nonpos <;> linarith
   -- Now the main proof.
   obtain ⟨c, hc, hc'⟩ := hf.exists_pos
   simp only [IsBigO, IsBigOWith, eventually_atTop] at hc' ⊢

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -903,9 +903,9 @@ theorem Lp_add_le (hp : 1 ≤ p) :
   have := NNReal.coe_le_coe.2
     (NNReal.Lp_add_le s (fun i => .mk _ (abs_nonneg (f i))) (fun i => .mk _ (abs_nonneg (g i))) hp)
   push_cast at this
-  refine le_trans (rpow_le_rpow ?_ (sum_le_sum fun i _ => ?_) ?_) this <;>
+  refine le_trans (rpow_le_rpow_left ?_ (sum_le_sum fun i _ => ?_) ?_) this <;>
     simp [sum_nonneg, rpow_nonneg, abs_nonneg, le_trans zero_le_one hp, abs_add_le,
-      rpow_le_rpow]
+      rpow_le_rpow_left]
 
 variable {f g}
 
@@ -1000,7 +1000,7 @@ theorem Lr_le_Lp_mul_Lq_tsum_of_nonneg (hpqr : p.HolderTriple q r) (hf : ∀ i, 
   have hg' : 0 ≤ ∑' i, g i ^ q := tsum_nonneg fun i ↦ rpow_nonneg (hg i) q
   have hr := hpqr.pos'
   convert
-    rpow_le_rpow_iff (tsum_nonneg fun i ↦ by positivity [hf i, hg i]) (by positivity)
+    rpow_le_rpow_iff_left (tsum_nonneg fun i ↦ by positivity [hf i, hg i]) (by positivity)
           (inv_eq_one_div r ▸ inv_pos.mpr hr) |>.mpr <|
       Lr_rpow_le_Lp_mul_Lq_tsum_of_nonneg hpqr hf hg hf_sum hg_sum
   rw [mul_rpow (rpow_nonneg hf' _) (rpow_nonneg hg' _), ← Real.rpow_mul hg', ← Real.rpow_mul hf']

--- a/Mathlib/Analysis/MeanInequalitiesPow.lean
+++ b/Mathlib/Analysis/MeanInequalitiesPow.lean
@@ -79,7 +79,8 @@ theorem arith_mean_le_rpow_mean (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
     (hz : ∀ i ∈ s, 0 ≤ z i) {p : ℝ} (hp : 1 ≤ p) :
     ∑ i ∈ s, w i * z i ≤ (∑ i ∈ s, w i * z i ^ p) ^ (1 / p) := by
   have : 0 < p := by positivity
-  rw [← rpow_le_rpow_iff _ _ this, ← rpow_mul, one_div_mul_cancel (ne_of_gt this), rpow_one]
+  rw [← rpow_le_rpow_iff_left _ _ this, ← rpow_mul, one_div_mul_cancel (ne_of_gt this),
+    rpow_one]
   · exact rpow_arith_mean_le_arith_mean_rpow s w z hw hw' hz hp
   all_goals
     apply_rules [sum_nonneg, rpow_nonneg]

--- a/Mathlib/Analysis/MellinTransform.lean
+++ b/Mathlib/Analysis/MellinTransform.lean
@@ -352,14 +352,14 @@ theorem mellin_hasDerivAt_of_isBigO_rpow [NormedSpace ℂ E] {a b : ℝ}
     gcongr
     rw [norm_cpow_eq_rpow_re_of_pos ht]
     rcases le_or_gt 1 t with h | h
-    · refine le_add_of_le_of_nonneg (rpow_le_rpow_of_exponent_le h ?_)
+    · refine le_add_of_le_of_nonneg (rpow_le_rpow_right h ?_)
         (by positivity)
       rw [sub_re, one_re, sub_le_sub_iff_right]
       rw [mem_ball_iff_norm] at hz
       have hz' := (re_le_norm _).trans hz.le
       rwa [sub_re, sub_le_iff_le_add'] at hz'
-    · refine
-        le_add_of_nonneg_of_le (rpow_pos_of_pos ht _).le (rpow_le_rpow_of_exponent_ge ht h.le ?_)
+    · refine le_add_of_nonneg_of_le (rpow_pos_of_pos ht _).le ?_
+      refine rpow_le_rpow_right_of_base_le_one ht h.le ?_
       rw [sub_re, one_re, sub_le_iff_le_add, sub_add_cancel]
       rw [mem_ball_iff_norm'] at hz
       have hz' := (re_le_norm _).trans hz.le

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -237,7 +237,7 @@ theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (
     rintro x ⟨i, rfl⟩
     have : 0 ≤ ‖f i‖ ^ q.toReal := by positivity
     simpa [← Real.rpow_mul, mul_inv_cancel₀ hq.ne'] using
-      Real.rpow_le_rpow this (hA ⟨i, rfl⟩) (inv_nonneg.mpr hq.le)
+      Real.rpow_le_rpow_left this (hA ⟨i, rfl⟩) (inv_nonneg.mpr hq.le)
   · apply memℓp_gen
     have hf' := hfq.summable hq
     refine .of_norm_bounded_eventually hf' (@Set.Finite.subset _ { i | 1 ≤ ‖f i‖ } ?_ _ ?_)
@@ -249,7 +249,7 @@ theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (
       have : 0 ≤ ‖f i‖ ^ p.toReal := by positivity
       simp only [abs_of_nonneg, this] at hi
       contrapose! hi
-      exact Real.rpow_le_rpow_of_exponent_ge' (norm_nonneg _) hi.le hq.le hpq'
+      exact Real.rpow_le_rpow_right_of_base_le_one' (norm_nonneg _) hi.le hq.le hpq'
 
 theorem add {f g : ∀ i, E i} (hf : Memℓp f p) (hg : Memℓp g p) : Memℓp (f + g) p := by
   rcases p.trichotomy with (rfl | rfl | hp)
@@ -269,7 +269,7 @@ theorem add {f g : ∀ i, E i} (hf : Memℓp f p) (hg : Memℓp g p) : Memℓp (
   let C : ℝ := if p.toReal < 1 then 1 else (2 : ℝ) ^ (p.toReal - 1)
   refine .of_nonneg_of_le ?_ (fun i => ?_) (((hf.summable hp).add (hg.summable hp)).mul_left C)
   · intro; positivity
-  · refine (Real.rpow_le_rpow (norm_nonneg _) (norm_add_le _ _) hp.le).trans ?_
+  · refine (Real.rpow_le_rpow_left (norm_nonneg _) (norm_add_le _ _) hp.le).trans ?_
     dsimp only [C]
     split_ifs with h
     · simpa using! NNReal.coe_le_coe.2 (NNReal.rpow_add_le_add_rpow ‖f i‖₊ ‖g i‖₊ hp.le h.le)
@@ -565,7 +565,7 @@ instance normedAddCommGroup [hp : Fact (1 ≤ p)] : NormedAddCommGroup (lp E p) 
           obtain ⟨C, hC₁, hC₂, hCfg⟩ :=
             Real.Lp_add_le_hasSum_of_nonneg hp' hf₁ hg₁ (norm_nonneg' _) (norm_nonneg' _) hf₂ hg₂
           refine le_trans ?_ hC₂
-          rw [← Real.rpow_le_rpow_iff (norm_nonneg' (f + g)) hC₁ hp'']
+          rw [← Real.rpow_le_rpow_iff_left (norm_nonneg' (f + g)) hC₁ hp'']
           refine hasSum_le ?_ (lp.hasSum_norm hp'' (f + g)) hCfg
           intro i
           gcongr
@@ -603,7 +603,7 @@ theorem norm_apply_le_norm (hp : p ≠ 0) (f : lp E p) (i : α) : ‖f i‖ ≤ 
     exact (isLUB_norm f).1 ⟨i, rfl⟩
   have hp'' : 0 < p.toReal := ENNReal.toReal_pos hp hp'
   have : ∀ i, 0 ≤ ‖f i‖ ^ p.toReal := fun i ↦ by positivity
-  rw [← Real.rpow_le_rpow_iff (norm_nonneg _) (norm_nonneg' _) hp'']
+  rw [← Real.rpow_le_rpow_iff_left (norm_nonneg _) (norm_nonneg' _) hp'']
   convert! le_hasSum (hasSum_norm hp'' f) i fun i _ => this i
 
 lemma lipschitzWith_one_eval (p : ℝ≥0∞) [Fact (1 ≤ p)] (i : α) :
@@ -633,7 +633,7 @@ theorem norm_le_of_forall_le {f : lp E ∞} {C : ℝ} (hC : 0 ≤ C) (hCf : ∀ 
 
 theorem norm_le_of_tsum_le (hp : 0 < p.toReal) {C : ℝ} (hC : 0 ≤ C) {f : lp E p}
     (hf : ∑' i, ‖f i‖ ^ p.toReal ≤ C ^ p.toReal) : ‖f‖ ≤ C := by
-  rw [← Real.rpow_le_rpow_iff (norm_nonneg' _) hC hp, norm_rpow_eq_tsum hp]
+  rw [← Real.rpow_le_rpow_iff_left (norm_nonneg' _) hC hp, norm_rpow_eq_tsum hp]
   exact hf
 
 theorem norm_le_of_forall_sum_le (hp : 0 < p.toReal) {C : ℝ} (hC : 0 ≤ C) {f : lp E p}
@@ -1175,7 +1175,7 @@ protected theorem hasSum_single [Fact (1 ≤ p)] (hp : p ≠ ⊤) (f : lp E p) :
   intro ε hε
   refine (this _ (Real.rpow_pos_of_pos hε p.toReal)).mono ?_
   intro s hs
-  rw [← Real.rpow_lt_rpow_iff dist_nonneg (le_of_lt hε) hp']
+  rw [← Real.rpow_lt_rpow_iff_left dist_nonneg (le_of_lt hε) hp']
   rw [dist_comm] at hs
   simp only [dist_eq_norm, Real.norm_eq_abs] at hs ⊢
   have H : ‖(∑ i ∈ s, lp.single p i (f i : E i)) - f‖ ^ p.toReal =

--- a/Mathlib/Analysis/Normed/Unbundled/SmoothingSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SmoothingSeminorm.lean
@@ -190,7 +190,7 @@ theorem tendsto_smoothingFun_of_ne_zero (hμ1 : μ 1 ≤ 1) {x : R} (hx : μ x �
     have h1 : (μ (x ^ (m1 : ℕ)) ^ (n / (m1 : ℕ))) ^ (1 / (n : ℝ)) <
         (L + ε / 2) * (L + ε / 2) ^ (-(((n % m1 : ℕ) : ℝ) / (n : ℝ))) := by
       have hm10 : (m1 : ℝ) ≠ 0 := cast_ne_zero.mpr (_root_.ne_of_gt (PNat.pos m1))
-      rw [← rpow_lt_rpow_iff (rpow_nonneg (apply_nonneg μ _) _) (le_of_lt hL0')
+      rw [← rpow_lt_rpow_iff_left (rpow_nonneg (apply_nonneg μ _) _) (le_of_lt hL0')
         (cast_pos.mpr (PNat.pos m1)), ← rpow_mul (apply_nonneg μ _), one_div_mul_cancel hm10,
         rpow_one] at hm1
       nth_rw 1 [← rpow_one (L + ε / 2)]
@@ -203,13 +203,16 @@ theorem tendsto_smoothingFun_of_ne_zero (hμ1 : μ 1 ≤ 1) {x : R} (hx : μ x �
       rw [← rpow_natCast, ← rpow_add hL0', ← neg_div, ← add_div, Nat.cast_add,
         add_neg_cancel_right, Nat.cast_mul, ← rpow_mul (apply_nonneg μ _), mul_one_div,
         mul_div_assoc, rpow_mul (le_of_lt hL0')]
-      exact rpow_lt_rpow (apply_nonneg μ _) hm1 h_lt
+      exact rpow_lt_rpow_left (apply_nonneg μ _) hm1 h_lt
     /- We again use the submultiplicativity of `μ` to deduce
     `μ (x ^ (n % m1)) ^ (1 / n) ≤ (μ x ^ (n % m1)) ^ (1 / n)`. -/
     have h2 : μ (x ^ (n % m1)) ^ (1 / (n : ℝ)) ≤ (μ x ^ (n % m1)) ^ (1 / (n : ℝ)) := by
       by_cases hnm1 : n % m1 = 0
-      · simpa [hnm1, pow_zero] using rpow_le_rpow (apply_nonneg μ _) hμ1 (one_div_cast_nonneg _)
-      · exact rpow_le_rpow (apply_nonneg μ _) (map_pow_le_pow μ _ hnm1) (one_div_cast_nonneg _)
+      · simpa [hnm1, pow_zero] using
+          rpow_le_rpow_left (apply_nonneg μ _) hμ1 (one_div_cast_nonneg _)
+      · exact
+          rpow_le_rpow_left (apply_nonneg μ _) (map_pow_le_pow μ _ hnm1)
+            (one_div_cast_nonneg _)
     /- We bound `(L + ε / 2) ^ (1 -n % m1) / n) * (μ x ^ (n % m1)) ^ (1 / n)` by `L + ε`. -/
     have h3 : (L + ε / 2) * (L + ε / 2) ^ (-(((n % m1 : ℕ) : ℝ) / (n : ℝ))) *
           (μ x ^ (n % m1)) ^ (1 / (n : ℝ)) ≤ L + ε := by
@@ -226,7 +229,7 @@ theorem tendsto_smoothingFun_of_ne_zero (hμ1 : μ 1 ≤ 1) {x : R} (hx : μ x �
     calc μ (x ^ ((m1 : ℕ) * (n / (m1 : ℕ)) + n % m1)) ^ (1 / (n : ℝ)) =
           μ (x ^ ((m1 : ℕ) * (n / (m1 : ℕ))) * x ^ (n % m1)) ^ (1 / (n : ℝ)) := by rw [pow_add]
       _ ≤ (μ (x ^ ((m1 : ℕ) * (n / (m1 : ℕ)))) * μ (x ^ (n % m1))) ^ (1 / (n : ℝ)) :=
-        (rpow_le_rpow (apply_nonneg μ _) (map_mul_le_mul μ _ _) (one_div_cast_nonneg _))
+        (rpow_le_rpow_left (apply_nonneg μ _) (map_mul_le_mul μ _ _) (one_div_cast_nonneg _))
       _ = μ (x ^ ((m1 : ℕ) * (n / (m1 : ℕ)))) ^ (1 / (n : ℝ)) *
           μ (x ^ (n % m1)) ^ (1 / (n : ℝ)) :=
         (mul_rpow (apply_nonneg μ _) (apply_nonneg μ _))
@@ -264,7 +267,7 @@ theorem smoothingFun_one_le (hμ1 : μ 1 ≤ 1) : smoothingFun μ 1 ≤ 1 := by
     apply _root_.div_pos zero_lt_one
     rw [← cast_zero, cast_lt]
     exact succ_le_iff.mp hn
-  exact (rpow_le_rpow_iff (apply_nonneg μ _) zero_le_one hn1).mpr hμ1
+  exact (rpow_le_rpow_iff_left (apply_nonneg μ _) zero_le_one hn1).mpr hμ1
 
 /-- For any `x` and any positive `n`, `smoothingFun μ x ≤ μ (x ^ (n : ℕ))^(1 / n : ℝ)`. -/
 theorem smoothingFun_le (x : R) (n : PNat) :
@@ -316,16 +319,16 @@ private theorem μ_bddAbove (hμ1 : μ 1 ≤ 1) {s : ℕ → ℕ} (hs : ∀ n : 
   · use 1
     simp only [mem_upperBounds, Set.mem_range, forall_exists_index]
     rintro _ n rfl
-    apply le_trans (rpow_le_rpow (apply_nonneg _ _) (map_pow_le_pow' hμ1 _ _) (hψ n))
+    apply le_trans (rpow_le_rpow_left (apply_nonneg _ _) (map_pow_le_pow' hμ1 _ _) (hψ n))
     rw [← rpow_natCast, ← rpow_mul (apply_nonneg _ _), mul_one_div]
     exact rpow_le_one (apply_nonneg _ _) hx (div_nonneg (cast_nonneg _) (cast_nonneg _))
   · use μ x
     simp only [mem_upperBounds, Set.mem_range, forall_exists_index]
     rintro _ n rfl
-    apply le_trans (rpow_le_rpow (apply_nonneg _ _) (map_pow_le_pow' hμ1 _ _) (hψ n))
+    apply le_trans (rpow_le_rpow_left (apply_nonneg _ _) (map_pow_le_pow' hμ1 _ _) (hψ n))
     rw [← rpow_natCast, ← rpow_mul (apply_nonneg _ _), mul_one_div]
     conv_rhs => rw [← rpow_one (μ x)]
-    rw [rpow_le_rpow_left_iff hx]
+    rw [rpow_le_rpow_iff_right hx]
     exact div_le_one_of_le₀ (cast_le.mpr (hs (ψ n))) (cast_nonneg _)
 
 private theorem μ_bddAbove' (hμ1 : μ 1 ≤ 1) {s : ℕ → ℕ} (hs : ∀ n : ℕ, s n ≤ n) (x : R)
@@ -348,7 +351,7 @@ private theorem μ_nonempty {s : ℕ → ℕ} (hs_le : ∀ n : ℕ, s n ≤ n) {
     use 0
     intro b _
     nth_rw 2 [← rpow_one (μ x)]
-    apply rpow_le_rpow_of_exponent_le (not_lt.mp hμx)
+    apply rpow_le_rpow_right (not_lt.mp hμx)
     rw [mul_one_div]
     exact div_le_one_of_le₀ (cast_le.mpr (hs_le (ψ b))) (cast_nonneg _)
 
@@ -487,13 +490,13 @@ theorem isNonarchimedean_smoothingFun (hμ1 : μ 1 ≤ 1) (hna : IsNonarchimedea
     split_ifs with h
     · rw [add_le_add_iff_right]
       apply le_trans (mul_le_mul_of_nonneg_right
-        (rpow_le_rpow (smoothingFun_nonneg μ hμ1 _) h a_in.1)
+        (rpow_le_rpow_left (smoothingFun_nonneg μ hμ1 _) h a_in.1)
         (rpow_nonneg (smoothingFun_nonneg μ hμ1 _) _))
       rw [hb, ← rpow_add_of_nonneg (smoothingFun_nonneg μ hμ1 _) a_in.1
         (sub_nonneg.mpr a_in.2), add_sub, add_sub_cancel_left, rpow_one]
     · rw [add_le_add_iff_right]
       apply le_trans (mul_le_mul_of_nonneg_left
-        (rpow_le_rpow (smoothingFun_nonneg μ hμ1 _) (le_of_lt (not_le.mp h)) b_in.1)
+        (rpow_le_rpow_left (smoothingFun_nonneg μ hμ1 _) (le_of_lt (not_le.mp h)) b_in.1)
         (rpow_nonneg (smoothingFun_nonneg μ hμ1 _) _))
       rw [hb, ← rpow_add_of_nonneg (smoothingFun_nonneg μ hμ1 _) a_in.1
         (sub_nonneg.mpr a_in.2), add_sub, add_sub_cancel_left, rpow_one]

--- a/Mathlib/Analysis/Normed/Unbundled/SpectralNorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SpectralNorm.lean
@@ -310,8 +310,9 @@ theorem max_norm_root_eq_spectralValue [DecidableEq L] {f : AlgebraNorm K L} (hf
     by_cases hm : m < p.natDegree
     · rw [spectralValueTerms_of_lt_natDegree _ hm]
       have h : 0 < (p.natDegree - m : ℝ) := by rw [sub_pos, Nat.cast_lt]; exact hm
-      rw [← rpow_le_rpow_iff (rpow_nonneg (norm_nonneg _) _) h_le h, ← rpow_mul (norm_nonneg _),
-        one_div_mul_cancel (ne_of_gt h), rpow_one, ← Nat.cast_sub (le_of_lt hm), rpow_natCast]
+      rw [← rpow_le_rpow_iff_left (rpow_nonneg (norm_nonneg _) _) h_le h,
+        ← rpow_mul (norm_nonneg _), one_div_mul_cancel (ne_of_gt h), rpow_one,
+        ← Nat.cast_sub (le_of_lt hm), rpow_natCast]
       have hps : card s = p.natDegree := by
         rw [← natDegree_map (algebraMap K L), ← mapAlg_eq_map, hp,
           natDegree_multiset_prod_X_sub_C_eq_card]

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -145,7 +145,7 @@ theorem integrableOn_Ioi_rpow_iff {s t : ℝ} (ht : 0 < t) :
     have x_one : 1 ≤ x := ((le_max_left _ _).trans_lt (mem_Ioi.1 hx)).le
     simp only [norm_inv, Real.norm_eq_abs, abs_of_nonneg (zero_le_one.trans x_one)]
     rw [← Real.rpow_neg_one x]
-    exact Real.rpow_le_rpow_of_exponent_le x_one h
+    exact Real.rpow_le_rpow_right x_one h
   exact not_integrableOn_Ioi_inv this
 
 theorem integrableAtFilter_rpow_atTop_iff {s : ℝ} :

--- a/Mathlib/Analysis/SpecialFunctions/Integrability/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrability/Basic.lean
@@ -82,7 +82,7 @@ lemma integrableOn_Ioo_rpow_iff {s t : ℝ} (ht : 0 < t) :
     apply H'.mono' measurable_inv.aestronglyMeasurable
     filter_upwards [ae_restrict_mem measurableSet_Ioo] with x hx
     simp only [norm_inv, Real.norm_eq_abs, abs_of_nonneg (le_of_lt hx.1)]
-    rwa [← Real.rpow_neg_one x, Real.rpow_le_rpow_left_iff_of_base_lt_one hx.1]
+    rwa [← Real.rpow_neg_one x, Real.rpow_le_rpow_iff_right_of_base_lt_one hx.1]
     exact lt_of_lt_of_le hx.2 (min_le_left _ _)
   have : IntervalIntegrable (fun x ↦ x⁻¹) volume 0 (min 1 t) := by
     rwa [intervalIntegrable_iff_integrableOn_Ioo_of_le I.le]

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -204,16 +204,20 @@ theorem logb_lt_logb_iff (hx : 0 < x) (hy : 0 < y) : logb b x < logb b y ↔ x <
   exact log_lt_log_iff hx hy
 
 theorem logb_le_iff_le_rpow (hx : 0 < x) : logb b x ≤ y ↔ x ≤ b ^ y := by
-  rw [← rpow_le_rpow_left_iff hb, rpow_logb (b_pos hb) (b_ne_one' hb) hx]
+  rw [← rpow_le_rpow_iff_right hb,
+    rpow_logb (b_pos hb) (b_ne_one' hb) hx]
 
 theorem logb_lt_iff_lt_rpow (hx : 0 < x) : logb b x < y ↔ x < b ^ y := by
-  rw [← rpow_lt_rpow_left_iff hb, rpow_logb (b_pos hb) (b_ne_one' hb) hx]
+  rw [← rpow_lt_rpow_iff_right hb,
+    rpow_logb (b_pos hb) (b_ne_one' hb) hx]
 
 theorem le_logb_iff_rpow_le (hy : 0 < y) : x ≤ logb b y ↔ b ^ x ≤ y := by
-  rw [← rpow_le_rpow_left_iff hb, rpow_logb (b_pos hb) (b_ne_one' hb) hy]
+  rw [← rpow_le_rpow_iff_right hb,
+    rpow_logb (b_pos hb) (b_ne_one' hb) hy]
 
 theorem lt_logb_iff_rpow_lt (hy : 0 < y) : x < logb b y ↔ b ^ x < y := by
-  rw [← rpow_lt_rpow_left_iff hb, rpow_logb (b_pos hb) (b_ne_one' hb) hy]
+  rw [← rpow_lt_rpow_iff_right hb,
+    rpow_logb (b_pos hb) (b_ne_one' hb) hy]
 
 theorem logb_pos_iff (hx : 0 < x) : 0 < logb b x ↔ 1 < x := by
   rw [← @logb_one b]
@@ -294,16 +298,20 @@ theorem logb_lt_logb_iff_of_base_lt_one (hx : 0 < x) (hy : 0 < y) :
   exact log_lt_log_iff hy hx
 
 theorem logb_le_iff_le_rpow_of_base_lt_one (hx : 0 < x) : logb b x ≤ y ↔ b ^ y ≤ x := by
-  rw [← rpow_le_rpow_left_iff_of_base_lt_one b_pos b_lt_one, rpow_logb b_pos (b_ne_one b_lt_one) hx]
+  rw [← rpow_le_rpow_iff_right_of_base_lt_one b_pos b_lt_one,
+    rpow_logb b_pos (b_ne_one b_lt_one) hx]
 
 theorem logb_lt_iff_lt_rpow_of_base_lt_one (hx : 0 < x) : logb b x < y ↔ b ^ y < x := by
-  rw [← rpow_lt_rpow_left_iff_of_base_lt_one b_pos b_lt_one, rpow_logb b_pos (b_ne_one b_lt_one) hx]
+  rw [← rpow_lt_rpow_iff_right_of_base_lt_one b_pos b_lt_one,
+    rpow_logb b_pos (b_ne_one b_lt_one) hx]
 
 theorem le_logb_iff_rpow_le_of_base_lt_one (hy : 0 < y) : x ≤ logb b y ↔ y ≤ b ^ x := by
-  rw [← rpow_le_rpow_left_iff_of_base_lt_one b_pos b_lt_one, rpow_logb b_pos (b_ne_one b_lt_one) hy]
+  rw [← rpow_le_rpow_iff_right_of_base_lt_one b_pos b_lt_one,
+    rpow_logb b_pos (b_ne_one b_lt_one) hy]
 
 theorem lt_logb_iff_rpow_lt_of_base_lt_one (hy : 0 < y) : x < logb b y ↔ y < b ^ x := by
-  rw [← rpow_lt_rpow_left_iff_of_base_lt_one b_pos b_lt_one, rpow_logb b_pos (b_ne_one b_lt_one) hy]
+  rw [← rpow_lt_rpow_iff_right_of_base_lt_one b_pos b_lt_one,
+    rpow_logb b_pos (b_ne_one b_lt_one) hy]
 
 theorem logb_pos_iff_of_base_lt_one (hx : 0 < x) : 0 < logb b x ↔ x < 1 := by
   rw [← @logb_one b, logb_lt_logb_iff_of_base_lt_one b_pos b_lt_one zero_lt_one hx]
@@ -370,7 +378,7 @@ theorem floor_logb_natCast {b : ℕ} {r : ℝ} (hr : 0 ≤ r) :
     apply le_antisymm
     · rw [← Int.zpow_le_iff_le_log hb hr, ← rpow_intCast b]
       refine le_of_le_of_eq ?_ (rpow_logb (zero_lt_one.trans hb1') hb1'.ne' hr)
-      exact rpow_le_rpow_of_exponent_le hb1'.le (Int.floor_le _)
+      exact rpow_le_rpow_right hb1'.le (Int.floor_le _)
     · rw [Int.le_floor, le_logb_iff_rpow_le hb1' hr, rpow_intCast]
       exact Int.zpow_log_le_self hb hr
   · rw [Nat.one_lt_iff_ne_zero_and_ne_one, ← or_iff_not_and_not] at hb
@@ -390,7 +398,7 @@ theorem ceil_logb_natCast {b : ℕ} {r : ℝ} (hr : 0 ≤ r) :
       exact Int.self_le_zpow_clog hb r
     · rw [← Int.le_zpow_iff_clog_le hb hr, ← rpow_intCast b]
       refine (rpow_logb (zero_lt_one.trans hb1') hb1'.ne' hr).symm.trans_le ?_
-      exact rpow_le_rpow_of_exponent_le hb1'.le (Int.le_ceil _)
+      exact rpow_le_rpow_right hb1'.le (Int.le_ceil _)
   · rw [Nat.one_lt_iff_ne_zero_and_ne_one, ← or_iff_not_and_not] at hb
     cases hb
     · simp_all only [CharP.cast_eq_zero, logb_zero_left, Int.ceil_zero, Int.clog_zero_left]

--- a/Mathlib/Analysis/SpecialFunctions/Log/Monotone.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Monotone.lean
@@ -72,7 +72,7 @@ theorem log_div_self_rpow_antitoneOn {a : ℝ} (ha : 0 < a) :
     mul_div_assoc, mul_le_mul_iff_right₀ (one_div_pos.mpr ha)]
   have hbound {z : ℝ} (hz : z ∈ Ici (rexp a⁻¹)) : z ^ a ∈ {b | rexp 1 ≤ b} := by
     rw [mem_setOf_eq]
-    convert! rpow_le_rpow _ hz (le_of_lt ha) using 1
+    convert! rpow_le_rpow_left _ hz (le_of_lt ha) using 1
     · simp only [← exp_mul, Real.exp_eq_exp, field]
     positivity
   refine log_div_self_antitoneOn (hbound hex) (hbound (hex.trans hxy)) ?_

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -127,7 +127,7 @@ theorem tendsto_exp_div_rpow_atTop (s : ℝ) : Tendsto (fun x : ℝ => exp x / x
   refine tendsto_atTop_mono' _ ?_ (tendsto_exp_div_pow_atTop n)
   filter_upwards [eventually_gt_atTop (0 : ℝ), eventually_ge_atTop (1 : ℝ)] with x hx₀ hx₁
   gcongr
-  simpa using rpow_le_rpow_of_exponent_le hx₁ hn.le
+  simpa using rpow_le_rpow_right hx₁ hn.le
 
 /-- The function `exp (b * x) / x ^ s` tends to `+∞` at `+∞`, for any real `s` and `b > 0`. -/
 theorem tendsto_exp_mul_div_rpow_atTop (s : ℝ) (b : ℝ) (hb : 0 < b) :
@@ -288,7 +288,7 @@ theorem IsBigO.mul_atTop_rpow_of_isBigO_rpow {f g : ℝ → E}
   filter_upwards [eventually_ge_atTop 1] with t ht
   rw [← Real.rpow_add (zero_lt_one.trans_le ht), Real.norm_of_nonneg (Real.rpow_nonneg
     (zero_le_one.trans ht) (a + b))]
-  exact Real.rpow_le_rpow_of_exponent_le ht h
+  exact Real.rpow_le_rpow_right ht h
 
 theorem IsBigO.mul_atTop_rpow_natCast_of_isBigO_rpow {f g : ℕ → E}
     (hf : f =O[atTop] fun n ↦ (n : ℝ) ^ a) (hg : g =O[atTop] fun n ↦ (n : ℝ) ^ b)
@@ -299,14 +299,14 @@ theorem IsBigO.mul_atTop_rpow_natCast_of_isBigO_rpow {f g : ℕ → E}
   replace ht : 1 ≤ (t : ℝ) := Nat.one_le_cast.mpr ht
   rw [← Real.rpow_add (zero_lt_one.trans_le ht), Real.norm_of_nonneg (Real.rpow_nonneg
     (zero_le_one.trans ht) (a + b))]
-  exact Real.rpow_le_rpow_of_exponent_le ht h
+  exact Real.rpow_le_rpow_right ht h
 
 /-- If `a ≤ b`, then `x^b = O(x^a)` as `x → 0`, `x ≥ 0`, unless `b = 0` and `a ≠ 0`. -/
 theorem IsBigO.rpow_rpow_nhdsGE_zero_of_le_of_imp {a b : ℝ} (h : a ≤ b) (himp : b = 0 → a = 0) :
     (· ^ b : ℝ → ℝ) =O[𝓝[≥] 0] (· ^ a) :=
   .of_bound' <| mem_of_superset (Icc_mem_nhdsGE one_pos) fun x hx ↦ by
     simpa [Real.abs_rpow_of_nonneg hx.1, abs_of_nonneg hx.1]
-     using Real.rpow_le_rpow_of_exponent_ge_of_imp hx.1 hx.2 h fun _ ↦ himp
+     using Real.rpow_le_rpow_right_of_base_le_one_of_imp hx.1 hx.2 h fun _ ↦ himp
 
 /-- If `a ≤ b`, `b ≠ 0`, then `x^b = O(x^a)` as `x → 0`, `x ≥ 0`. -/
 theorem IsBigO.rpow_rpow_nhdsGE_zero_of_le {a b : ℝ} (h : a ≤ b) (hb : b ≠ 0) :

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -263,16 +263,16 @@ theorem _root_.Real.finsetProd_rpow
 end Real
 
 @[gcongr] theorem rpow_le_rpow {x y : ℝ≥0} {z : ℝ} (h₁ : x ≤ y) (h₂ : 0 ≤ z) : x ^ z ≤ y ^ z :=
-  Real.rpow_le_rpow x.2 h₁ h₂
+  Real.rpow_le_rpow_left x.2 h₁ h₂
 
 @[gcongr] theorem rpow_lt_rpow {x y : ℝ≥0} {z : ℝ} (h₁ : x < y) (h₂ : 0 < z) : x ^ z < y ^ z :=
-  Real.rpow_lt_rpow x.2 h₁ h₂
+  Real.rpow_lt_rpow_left x.2 h₁ h₂
 
 theorem rpow_lt_rpow_iff {x y : ℝ≥0} {z : ℝ} (hz : 0 < z) : x ^ z < y ^ z ↔ x < y :=
-  Real.rpow_lt_rpow_iff x.2 y.2 hz
+  Real.rpow_lt_rpow_iff_left x.2 y.2 hz
 
 theorem rpow_le_rpow_iff {x y : ℝ≥0} {z : ℝ} (hz : 0 < z) : x ^ z ≤ y ^ z ↔ x ≤ y :=
-  Real.rpow_le_rpow_iff x.2 y.2 hz
+  Real.rpow_le_rpow_iff_left x.2 y.2 hz
 
 theorem le_rpow_inv_iff {x y : ℝ≥0} {z : ℝ} (hz : 0 < z) : x ≤ y ^ z⁻¹ ↔ x ^ z ≤ y := by
   rw [← rpow_le_rpow_iff hz, ← one_div, rpow_self_rpow_inv hz.ne']
@@ -290,16 +290,16 @@ section
 variable {y : ℝ≥0}
 
 lemma rpow_lt_rpow_of_neg (hx : 0 < x) (hxy : x < y) (hz : z < 0) : y ^ z < x ^ z :=
-  Real.rpow_lt_rpow_of_neg hx hxy hz
+  Real.rpow_lt_rpow_left_of_exponent_neg hx hxy hz
 
 lemma rpow_le_rpow_of_nonpos (hx : 0 < x) (hxy : x ≤ y) (hz : z ≤ 0) : y ^ z ≤ x ^ z :=
-  Real.rpow_le_rpow_of_nonpos hx hxy hz
+  Real.rpow_le_rpow_left_of_exponent_nonpos hx hxy hz
 
 lemma rpow_lt_rpow_iff_of_neg (hx : 0 < x) (hy : 0 < y) (hz : z < 0) : x ^ z < y ^ z ↔ y < x :=
-  Real.rpow_lt_rpow_iff_of_neg hx hy hz
+  Real.rpow_lt_rpow_iff_left_of_exponent_neg hx hy hz
 
 lemma rpow_le_rpow_iff_of_neg (hx : 0 < x) (hy : 0 < y) (hz : z < 0) : x ^ z ≤ y ^ z ↔ y ≤ x :=
-  Real.rpow_le_rpow_iff_of_neg hx hy hz
+  Real.rpow_le_rpow_iff_left_of_exponent_neg hx hy hz
 
 lemma le_rpow_inv_iff_of_pos (hy : 0 ≤ y) (hz : 0 < z) (x : ℝ≥0) : x ≤ y ^ z⁻¹ ↔ x ^ z ≤ y :=
   Real.le_rpow_inv_iff_of_pos x.2 hy hz
@@ -329,19 +329,19 @@ end
 
 @[gcongr] theorem rpow_lt_rpow_of_exponent_lt {x : ℝ≥0} {y z : ℝ} (hx : 1 < x) (hyz : y < z) :
     x ^ y < x ^ z :=
-  Real.rpow_lt_rpow_of_exponent_lt hx hyz
+  Real.rpow_lt_rpow_right hx hyz
 
 @[gcongr] theorem rpow_le_rpow_of_exponent_le {x : ℝ≥0} {y z : ℝ} (hx : 1 ≤ x) (hyz : y ≤ z) :
     x ^ y ≤ x ^ z :=
-  Real.rpow_le_rpow_of_exponent_le hx hyz
+  Real.rpow_le_rpow_right hx hyz
 
 theorem rpow_lt_rpow_of_exponent_gt {x : ℝ≥0} {y z : ℝ} (hx0 : 0 < x) (hx1 : x < 1) (hyz : z < y) :
     x ^ y < x ^ z :=
-  Real.rpow_lt_rpow_of_exponent_gt hx0 hx1 hyz
+  Real.rpow_lt_rpow_right_of_base_lt_one hx0 hx1 hyz
 
 theorem rpow_le_rpow_of_exponent_ge {x : ℝ≥0} {y z : ℝ} (hx0 : 0 < x) (hx1 : x ≤ 1) (hyz : z ≤ y) :
     x ^ y ≤ x ^ z :=
-  Real.rpow_le_rpow_of_exponent_ge hx0 hx1 hyz
+  Real.rpow_le_rpow_right_of_base_le_one hx0 hx1 hyz
 
 theorem rpow_pos {p : ℝ} {x : ℝ≥0} (hx_pos : 0 < x) : 0 < x ^ p := by
   have rpow_pos_of_nonneg : ∀ {p : ℝ}, 0 < p → 0 < x ^ p := by

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -533,57 +533,88 @@ in `Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean` instead. -/
 
 
 @[gcongr, bound]
-theorem rpow_lt_rpow (hx : 0 ≤ x) (hxy : x < y) (hz : 0 < z) : x ^ z < y ^ z := by
+theorem rpow_lt_rpow_left (hx : 0 ≤ x) (hxy : x < y) (hz : 0 < z) : x ^ z < y ^ z := by
   rw [le_iff_eq_or_lt] at hx; rcases hx with hx | hx
   · rw [← hx, zero_rpow (ne_of_gt hz)]
     exact rpow_pos_of_pos (by rwa [← hx] at hxy) _
   · rw [rpow_def_of_pos hx, rpow_def_of_pos (lt_trans hx hxy), exp_lt_exp]
     exact mul_lt_mul_of_pos_right (log_lt_log hx hxy) hz
 
+@[deprecated rpow_lt_rpow_left (since := "2026-07-06")]
+alias rpow_lt_rpow := rpow_lt_rpow_left
+
 theorem strictMonoOn_rpow_Ici_of_exponent_pos {r : ℝ} (hr : 0 < r) :
     StrictMonoOn (fun (x : ℝ) => x ^ r) (Set.Ici 0) :=
-  fun _ ha _ _ hab => rpow_lt_rpow ha hab hr
+  fun _ ha _ _ hab => rpow_lt_rpow_left ha hab hr
 
 @[gcongr, bound]
-theorem rpow_le_rpow {x y z : ℝ} (h : 0 ≤ x) (h₁ : x ≤ y) (h₂ : 0 ≤ z) : x ^ z ≤ y ^ z := by
+theorem rpow_le_rpow_left {x y z : ℝ} (h : 0 ≤ x) (h₁ : x ≤ y) (h₂ : 0 ≤ z) :
+    x ^ z ≤ y ^ z := by
   rcases eq_or_lt_of_le h₁ with (rfl | h₁'); · rfl
   rcases eq_or_lt_of_le h₂ with (rfl | h₂'); · simp
-  exact le_of_lt (rpow_lt_rpow h h₁' h₂')
+  exact le_of_lt (rpow_lt_rpow_left h h₁' h₂')
+
+@[deprecated rpow_le_rpow_left (since := "2026-07-06")]
+alias rpow_le_rpow := rpow_le_rpow_left
 
 theorem monotoneOn_rpow_Ici_of_exponent_nonneg {r : ℝ} (hr : 0 ≤ r) :
     MonotoneOn (fun (x : ℝ) => x ^ r) (Set.Ici 0) :=
-  fun _ ha _ _ hab => rpow_le_rpow ha hab hr
+  fun _ ha _ _ hab => rpow_le_rpow_left ha hab hr
 
-lemma rpow_lt_rpow_of_neg (hx : 0 < x) (hxy : x < y) (hz : z < 0) : y ^ z < x ^ z := by
+lemma rpow_lt_rpow_left_of_exponent_neg (hx : 0 < x) (hxy : x < y) (hz : z < 0) :
+    y ^ z < x ^ z := by
   have := hx.trans hxy
   rw [← inv_lt_inv₀, ← rpow_neg, ← rpow_neg]
-  on_goal 1 => refine rpow_lt_rpow ?_ hxy (neg_pos.2 hz)
+  on_goal 1 => refine rpow_lt_rpow_left ?_ hxy (neg_pos.2 hz)
   all_goals positivity
 
-lemma rpow_le_rpow_of_nonpos (hx : 0 < x) (hxy : x ≤ y) (hz : z ≤ 0) : y ^ z ≤ x ^ z := by
+@[deprecated rpow_lt_rpow_left_of_exponent_neg (since := "2026-07-06")]
+alias rpow_lt_rpow_of_neg := rpow_lt_rpow_left_of_exponent_neg
+
+lemma rpow_le_rpow_left_of_exponent_nonpos (hx : 0 < x) (hxy : x ≤ y) (hz : z ≤ 0) :
+    y ^ z ≤ x ^ z := by
   have := hx.trans_le hxy
   rw [← inv_le_inv₀, ← rpow_neg, ← rpow_neg]
-  on_goal 1 => refine rpow_le_rpow ?_ hxy (neg_nonneg.2 hz)
+  on_goal 1 => refine rpow_le_rpow_left ?_ hxy (neg_nonneg.2 hz)
   all_goals positivity
 
-theorem rpow_lt_rpow_iff (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 < z) : x ^ z < y ^ z ↔ x < y :=
+@[deprecated rpow_le_rpow_left_of_exponent_nonpos (since := "2026-07-06")]
+alias rpow_le_rpow_of_nonpos := rpow_le_rpow_left_of_exponent_nonpos
+
+theorem rpow_lt_rpow_iff_left (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 < z) :
+    x ^ z < y ^ z ↔ x < y :=
   ⟨lt_imp_lt_of_le_imp_le fun h ↦ by gcongr, fun h ↦ by gcongr⟩
 
-theorem rpow_le_rpow_iff (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 < z) : x ^ z ≤ y ^ z ↔ x ≤ y :=
-  le_iff_le_iff_lt_iff_lt.2 <| rpow_lt_rpow_iff hy hx hz
+@[deprecated rpow_lt_rpow_iff_left (since := "2026-07-06")]
+alias rpow_lt_rpow_iff := rpow_lt_rpow_iff_left
 
-lemma rpow_lt_rpow_iff_of_neg (hx : 0 < x) (hy : 0 < y) (hz : z < 0) : x ^ z < y ^ z ↔ y < x :=
-  ⟨lt_imp_lt_of_le_imp_le fun h ↦ rpow_le_rpow_of_nonpos hx h hz.le,
-    fun h ↦ rpow_lt_rpow_of_neg hy h hz⟩
+theorem rpow_le_rpow_iff_left (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 < z) :
+    x ^ z ≤ y ^ z ↔ x ≤ y :=
+  le_iff_le_iff_lt_iff_lt.2 <| rpow_lt_rpow_iff_left hy hx hz
 
-lemma rpow_le_rpow_iff_of_neg (hx : 0 < x) (hy : 0 < y) (hz : z < 0) : x ^ z ≤ y ^ z ↔ y ≤ x :=
-  le_iff_le_iff_lt_iff_lt.2 <| rpow_lt_rpow_iff_of_neg hy hx hz
+@[deprecated rpow_le_rpow_iff_left (since := "2026-07-06")]
+alias rpow_le_rpow_iff := rpow_le_rpow_iff_left
+
+lemma rpow_lt_rpow_iff_left_of_exponent_neg (hx : 0 < x) (hy : 0 < y) (hz : z < 0) :
+    x ^ z < y ^ z ↔ y < x :=
+  ⟨lt_imp_lt_of_le_imp_le fun h ↦ rpow_le_rpow_left_of_exponent_nonpos hx h hz.le,
+    fun h ↦ rpow_lt_rpow_left_of_exponent_neg hy h hz⟩
+
+@[deprecated rpow_lt_rpow_iff_left_of_exponent_neg (since := "2026-07-06")]
+alias rpow_lt_rpow_iff_of_neg := rpow_lt_rpow_iff_left_of_exponent_neg
+
+lemma rpow_le_rpow_iff_left_of_exponent_neg (hx : 0 < x) (hy : 0 < y) (hz : z < 0) :
+    x ^ z ≤ y ^ z ↔ y ≤ x :=
+  le_iff_le_iff_lt_iff_lt.2 <| rpow_lt_rpow_iff_left_of_exponent_neg hy hx hz
+
+@[deprecated rpow_le_rpow_iff_left_of_exponent_neg (since := "2026-07-06")]
+alias rpow_le_rpow_iff_of_neg := rpow_le_rpow_iff_left_of_exponent_neg
 
 lemma le_rpow_inv_iff_of_pos (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 < z) : x ≤ y ^ z⁻¹ ↔ x ^ z ≤ y := by
-  rw [← rpow_le_rpow_iff hx _ hz, rpow_inv_rpow] <;> positivity
+  rw [← rpow_le_rpow_iff_left hx _ hz, rpow_inv_rpow] <;> positivity
 
 lemma rpow_inv_le_iff_of_pos (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 < z) : x ^ z⁻¹ ≤ y ↔ x ≤ y ^ z := by
-  rw [← rpow_le_rpow_iff _ hy hz, rpow_inv_rpow] <;> positivity
+  rw [← rpow_le_rpow_iff_left _ hy hz, rpow_inv_rpow] <;> positivity
 
 lemma lt_rpow_inv_iff_of_pos (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 < z) : x < y ^ z⁻¹ ↔ x ^ z < y :=
   lt_iff_lt_of_le_iff_le <| rpow_inv_le_iff_of_pos hy hx hz
@@ -593,85 +624,111 @@ lemma rpow_inv_lt_iff_of_pos (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 < z) : x ^ z�
 
 theorem le_rpow_inv_iff_of_neg (hx : 0 < x) (hy : 0 < y) (hz : z < 0) :
     x ≤ y ^ z⁻¹ ↔ y ≤ x ^ z := by
-  rw [← rpow_le_rpow_iff_of_neg _ hx hz, rpow_inv_rpow _ hz.ne] <;> positivity
+  rw [← rpow_le_rpow_iff_left_of_exponent_neg _ hx hz, rpow_inv_rpow _ hz.ne] <;> positivity
 
 theorem lt_rpow_inv_iff_of_neg (hx : 0 < x) (hy : 0 < y) (hz : z < 0) :
     x < y ^ z⁻¹ ↔ y < x ^ z := by
-  rw [← rpow_lt_rpow_iff_of_neg _ hx hz, rpow_inv_rpow _ hz.ne] <;> positivity
+  rw [← rpow_lt_rpow_iff_left_of_exponent_neg _ hx hz, rpow_inv_rpow _ hz.ne] <;> positivity
 
 theorem rpow_inv_lt_iff_of_neg (hx : 0 < x) (hy : 0 < y) (hz : z < 0) :
     x ^ z⁻¹ < y ↔ y ^ z < x := by
-  rw [← rpow_lt_rpow_iff_of_neg hy _ hz, rpow_inv_rpow _ hz.ne] <;> positivity
+  rw [← rpow_lt_rpow_iff_left_of_exponent_neg hy _ hz, rpow_inv_rpow _ hz.ne] <;> positivity
 
 theorem rpow_inv_le_iff_of_neg (hx : 0 < x) (hy : 0 < y) (hz : z < 0) :
     x ^ z⁻¹ ≤ y ↔ y ^ z ≤ x := by
-  rw [← rpow_le_rpow_iff_of_neg hy _ hz, rpow_inv_rpow _ hz.ne] <;> positivity
+  rw [← rpow_le_rpow_iff_left_of_exponent_neg hy _ hz, rpow_inv_rpow _ hz.ne] <;> positivity
 
-theorem rpow_lt_rpow_of_exponent_lt (hx : 1 < x) (hyz : y < z) : x ^ y < x ^ z := by
+theorem rpow_lt_rpow_right (hx : 1 < x) (hyz : y < z) : x ^ y < x ^ z := by
   repeat' rw [rpow_def_of_pos (lt_trans zero_lt_one hx)]
   rw [exp_lt_exp]; exact mul_lt_mul_of_pos_left hyz (log_pos hx)
 
+@[deprecated rpow_lt_rpow_right (since := "2026-07-06")]
+alias rpow_lt_rpow_of_exponent_lt := rpow_lt_rpow_right
+
 @[gcongr]
-theorem rpow_le_rpow_of_exponent_le (hx : 1 ≤ x) (hyz : y ≤ z) : x ^ y ≤ x ^ z := by
+theorem rpow_le_rpow_right (hx : 1 ≤ x) (hyz : y ≤ z) : x ^ y ≤ x ^ z := by
   repeat' rw [rpow_def_of_pos (lt_of_lt_of_le zero_lt_one hx)]
   rw [exp_le_exp]; gcongr; exact log_nonneg hx
 
+@[deprecated rpow_le_rpow_right (since := "2026-07-06")]
+alias rpow_le_rpow_of_exponent_le := rpow_le_rpow_right
+
 theorem strictAntiOn_rpow_Ioi_of_exponent_neg {r : ℝ} (hr : r < 0) :
     StrictAntiOn (fun (x : ℝ) => x ^ r) (Set.Ioi 0) :=
-  fun _ ha _ _ hab => rpow_lt_rpow_of_neg ha hab hr
+  fun _ ha _ _ hab => rpow_lt_rpow_left_of_exponent_neg ha hab hr
 
 theorem antitoneOn_rpow_Ioi_of_exponent_nonpos {r : ℝ} (hr : r ≤ 0) :
     AntitoneOn (fun (x : ℝ) => x ^ r) (Set.Ioi 0) :=
-  fun _ ha _ _ hab => rpow_le_rpow_of_nonpos ha hab hr
+  fun _ ha _ _ hab => rpow_le_rpow_left_of_exponent_nonpos ha hab hr
 
 @[simp]
-theorem rpow_le_rpow_left_iff (hx : 1 < x) : x ^ y ≤ x ^ z ↔ y ≤ z := by
+theorem rpow_le_rpow_iff_right (hx : 1 < x) : x ^ y ≤ x ^ z ↔ y ≤ z := by
   have x_pos : 0 < x := lt_trans zero_lt_one hx
   rw [← log_le_log_iff (rpow_pos_of_pos x_pos y) (rpow_pos_of_pos x_pos z), log_rpow x_pos,
     log_rpow x_pos, mul_le_mul_iff_left₀ (log_pos hx)]
 
-@[simp]
-theorem rpow_lt_rpow_left_iff (hx : 1 < x) : x ^ y < x ^ z ↔ y < z := by
-  rw [lt_iff_not_ge, rpow_le_rpow_left_iff hx, lt_iff_not_ge]
+@[deprecated rpow_le_rpow_iff_right (since := "2026-07-06")]
+alias rpow_le_rpow_left_iff := rpow_le_rpow_iff_right
 
-theorem rpow_lt_rpow_of_exponent_gt (hx0 : 0 < x) (hx1 : x < 1) (hyz : z < y) : x ^ y < x ^ z := by
+@[simp]
+theorem rpow_lt_rpow_iff_right (hx : 1 < x) : x ^ y < x ^ z ↔ y < z := by
+  rw [lt_iff_not_ge, rpow_le_rpow_iff_right hx, lt_iff_not_ge]
+
+@[deprecated rpow_lt_rpow_iff_right (since := "2026-07-06")]
+alias rpow_lt_rpow_left_iff := rpow_lt_rpow_iff_right
+
+theorem rpow_lt_rpow_right_of_base_lt_one (hx0 : 0 < x) (hx1 : x < 1) (hyz : z < y) :
+    x ^ y < x ^ z := by
   repeat' rw [rpow_def_of_pos hx0]
   rw [exp_lt_exp]; exact mul_lt_mul_of_neg_left hyz (log_neg hx0 hx1)
 
-theorem rpow_le_rpow_of_exponent_ge (hx0 : 0 < x) (hx1 : x ≤ 1) (hyz : z ≤ y) : x ^ y ≤ x ^ z := by
+@[deprecated rpow_lt_rpow_right_of_base_lt_one (since := "2026-07-06")]
+alias rpow_lt_rpow_of_exponent_gt := rpow_lt_rpow_right_of_base_lt_one
+
+theorem rpow_le_rpow_right_of_base_le_one (hx0 : 0 < x) (hx1 : x ≤ 1) (hyz : z ≤ y) :
+    x ^ y ≤ x ^ z := by
   repeat' rw [rpow_def_of_pos hx0]
   rw [exp_le_exp]; exact mul_le_mul_of_nonpos_left hyz (log_nonpos (le_of_lt hx0) hx1)
 
+@[deprecated rpow_le_rpow_right_of_base_le_one (since := "2026-07-06")]
+alias rpow_le_rpow_of_exponent_ge := rpow_le_rpow_right_of_base_le_one
+
 @[simp]
-theorem rpow_le_rpow_left_iff_of_base_lt_one (hx0 : 0 < x) (hx1 : x < 1) :
+theorem rpow_le_rpow_iff_right_of_base_lt_one (hx0 : 0 < x) (hx1 : x < 1) :
     x ^ y ≤ x ^ z ↔ z ≤ y := by
   rw [← log_le_log_iff (rpow_pos_of_pos hx0 y) (rpow_pos_of_pos hx0 z), log_rpow hx0, log_rpow hx0,
     mul_le_mul_right_of_neg (log_neg hx0 hx1)]
 
+@[deprecated rpow_le_rpow_iff_right_of_base_lt_one (since := "2026-07-06")]
+alias rpow_le_rpow_left_iff_of_base_lt_one := rpow_le_rpow_iff_right_of_base_lt_one
+
 @[simp]
-theorem rpow_lt_rpow_left_iff_of_base_lt_one (hx0 : 0 < x) (hx1 : x < 1) :
+theorem rpow_lt_rpow_iff_right_of_base_lt_one (hx0 : 0 < x) (hx1 : x < 1) :
     x ^ y < x ^ z ↔ z < y := by
-  rw [lt_iff_not_ge, rpow_le_rpow_left_iff_of_base_lt_one hx0 hx1, lt_iff_not_ge]
+  rw [lt_iff_not_ge, rpow_le_rpow_iff_right_of_base_lt_one hx0 hx1, lt_iff_not_ge]
+
+@[deprecated rpow_lt_rpow_iff_right_of_base_lt_one (since := "2026-07-06")]
+alias rpow_lt_rpow_left_iff_of_base_lt_one := rpow_lt_rpow_iff_right_of_base_lt_one
 
 theorem rpow_lt_one {x z : ℝ} (hx1 : 0 ≤ x) (hx2 : x < 1) (hz : 0 < z) : x ^ z < 1 := by
   rw [← one_rpow z]
-  exact rpow_lt_rpow hx1 hx2 hz
+  exact rpow_lt_rpow_left hx1 hx2 hz
 
 theorem rpow_le_one {x z : ℝ} (hx1 : 0 ≤ x) (hx2 : x ≤ 1) (hz : 0 ≤ z) : x ^ z ≤ 1 := by
   rw [← one_rpow z]
   gcongr
 
 theorem rpow_lt_one_of_one_lt_of_neg {x z : ℝ} (hx : 1 < x) (hz : z < 0) : x ^ z < 1 := by
-  convert! rpow_lt_rpow_of_exponent_lt hx hz
+  convert! rpow_lt_rpow_right hx hz
   exact (rpow_zero x).symm
 
 theorem rpow_le_one_of_one_le_of_nonpos {x z : ℝ} (hx : 1 ≤ x) (hz : z ≤ 0) : x ^ z ≤ 1 := by
-  convert! rpow_le_rpow_of_exponent_le hx hz
+  convert! rpow_le_rpow_right hx hz
   exact (rpow_zero x).symm
 
 theorem one_lt_rpow {x z : ℝ} (hx : 1 < x) (hz : 0 < z) : 1 < x ^ z := by
   rw [← one_rpow z]
-  exact rpow_lt_rpow zero_le_one hx hz
+  exact rpow_lt_rpow_left zero_le_one hx hz
 
 theorem one_le_rpow {x z : ℝ} (hx : 1 ≤ x) (hz : 0 ≤ z) : 1 ≤ x ^ z := by
   rw [← one_rpow z]
@@ -679,12 +736,12 @@ theorem one_le_rpow {x z : ℝ} (hx : 1 ≤ x) (hz : 0 ≤ z) : 1 ≤ x ^ z := b
 
 theorem one_lt_rpow_of_pos_of_lt_one_of_neg (hx1 : 0 < x) (hx2 : x < 1) (hz : z < 0) :
     1 < x ^ z := by
-  convert! rpow_lt_rpow_of_exponent_gt hx1 hx2 hz
+  convert! rpow_lt_rpow_right_of_base_lt_one hx1 hx2 hz
   exact (rpow_zero x).symm
 
 theorem one_le_rpow_of_pos_of_le_one_of_nonpos (hx1 : 0 < x) (hx2 : x ≤ 1) (hz : z ≤ 0) :
     1 ≤ x ^ z := by
-  convert! rpow_le_rpow_of_exponent_ge hx1 hx2 hz
+  convert! rpow_le_rpow_right_of_base_le_one hx1 hx2 hz
   exact (rpow_zero x).symm
 
 theorem rpow_lt_one_iff_of_pos (hx : 0 < x) : x ^ y < 1 ↔ 1 < x ∧ y < 0 ∨ x < 1 ∧ 0 < y := by
@@ -698,7 +755,7 @@ theorem rpow_lt_one_iff (hx : 0 ≤ x) :
 
 theorem rpow_lt_one_iff' {x y : ℝ} (hx : 0 ≤ x) (hy : 0 < y) :
     x ^ y < 1 ↔ x < 1 := by
-  rw [← Real.rpow_lt_rpow_iff hx zero_le_one hy, Real.one_rpow]
+  rw [← Real.rpow_lt_rpow_iff_left hx zero_le_one hy, Real.one_rpow]
 
 theorem one_lt_rpow_iff_of_pos (hx : 0 < x) : 1 < x ^ y ↔ 1 < x ∧ 0 < y ∨ x < 1 ∧ y < 0 := by
   rw [rpow_def_of_pos hx, one_lt_exp_iff, mul_pos_iff, log_pos_iff hx.le, log_neg_iff hx]
@@ -708,9 +765,9 @@ theorem one_lt_rpow_iff (hx : 0 ≤ x) : 1 < x ^ y ↔ 1 < x ∧ 0 < y ∨ 0 < x
   · rcases _root_.em (y = 0) with (rfl | hy) <;> simp [*, (zero_lt_one' ℝ).not_gt]
   · simp [one_lt_rpow_iff_of_pos hx, hx]
 
-/-- This is a more general but less convenient version of `rpow_le_rpow_of_exponent_ge`.
+/-- This is a more general but less convenient version of `rpow_le_rpow_right_of_base_le_one`.
 This version allows `x = 0`, so it explicitly forbids `x = y = 0`, `z ≠ 0`. -/
-theorem rpow_le_rpow_of_exponent_ge_of_imp (hx0 : 0 ≤ x) (hx1 : x ≤ 1) (hyz : z ≤ y)
+theorem rpow_le_rpow_right_of_base_le_one_of_imp (hx0 : 0 ≤ x) (hx1 : x ≤ 1) (hyz : z ≤ y)
     (h : x = 0 → y = 0 → z = 0) :
     x ^ y ≤ x ^ z := by
   rcases eq_or_lt_of_le hx0 with (rfl | hx0')
@@ -718,13 +775,21 @@ theorem rpow_le_rpow_of_exponent_ge_of_imp (hx0 : 0 ≤ x) (hx1 : x ≤ 1) (hyz 
     · rw [h rfl rfl]
     · rw [zero_rpow hy0]
       apply zero_rpow_nonneg
-  · exact rpow_le_rpow_of_exponent_ge hx0' hx1 hyz
+  · exact rpow_le_rpow_right_of_base_le_one hx0' hx1 hyz
 
-/-- This version of `rpow_le_rpow_of_exponent_ge` allows `x = 0` but requires `0 ≤ z`.
-See also `rpow_le_rpow_of_exponent_ge_of_imp` for the most general version. -/
-theorem rpow_le_rpow_of_exponent_ge' (hx0 : 0 ≤ x) (hx1 : x ≤ 1) (hz : 0 ≤ z) (hyz : z ≤ y) :
+@[deprecated rpow_le_rpow_right_of_base_le_one_of_imp (since := "2026-07-06")]
+alias rpow_le_rpow_of_exponent_ge_of_imp := rpow_le_rpow_right_of_base_le_one_of_imp
+
+/-- This version of `rpow_le_rpow_right_of_base_le_one` allows `x = 0` but requires `0 ≤ z`.
+See also `rpow_le_rpow_right_of_base_le_one_of_imp` for the most general version. -/
+theorem rpow_le_rpow_right_of_base_le_one' (hx0 : 0 ≤ x) (hx1 : x ≤ 1) (hz : 0 ≤ z)
+    (hyz : z ≤ y) :
     x ^ y ≤ x ^ z :=
-  rpow_le_rpow_of_exponent_ge_of_imp hx0 hx1 hyz fun _ hy ↦ le_antisymm (hyz.trans_eq hy) hz
+  rpow_le_rpow_right_of_base_le_one_of_imp hx0 hx1 hyz fun _ hy ↦
+    le_antisymm (hyz.trans_eq hy) hz
+
+@[deprecated rpow_le_rpow_right_of_base_le_one' (since := "2026-07-06")]
+alias rpow_le_rpow_of_exponent_ge' := rpow_le_rpow_right_of_base_le_one'
 
 lemma rpow_max {x y p : ℝ} (hx : 0 ≤ x) (hy : 0 ≤ y) (hp : 0 ≤ p) :
     (max x y) ^ p = max (x ^ p) (y ^ p) := by
@@ -734,29 +799,30 @@ lemma rpow_max {x y p : ℝ} (hx : 0 ≤ x) (hy : 0 ≤ y) (hp : 0 ≤ p) :
 
 theorem self_le_rpow_of_le_one (h₁ : 0 ≤ x) (h₂ : x ≤ 1) (h₃ : y ≤ 1) : x ≤ x ^ y := by
   simpa only [rpow_one]
-    using rpow_le_rpow_of_exponent_ge_of_imp h₁ h₂ h₃ fun _ ↦ (absurd · one_ne_zero)
+    using rpow_le_rpow_right_of_base_le_one_of_imp h₁ h₂ h₃ fun _ ↦ (absurd · one_ne_zero)
 
 theorem self_le_rpow_of_one_le (h₁ : 1 ≤ x) (h₂ : 1 ≤ y) : x ≤ x ^ y := by
-  simpa only [rpow_one] using rpow_le_rpow_of_exponent_le h₁ h₂
+  simpa only [rpow_one] using rpow_le_rpow_right h₁ h₂
 
 theorem rpow_le_self_of_le_one (h₁ : 0 ≤ x) (h₂ : x ≤ 1) (h₃ : 1 ≤ y) : x ^ y ≤ x := by
   simpa only [rpow_one]
-    using rpow_le_rpow_of_exponent_ge_of_imp h₁ h₂ h₃ fun _ ↦ (absurd · (one_pos.trans_le h₃).ne')
+    using rpow_le_rpow_right_of_base_le_one_of_imp h₁ h₂ h₃ fun _ ↦
+      (absurd · (one_pos.trans_le h₃).ne')
 
 theorem rpow_le_self_of_one_le (h₁ : 1 ≤ x) (h₂ : y ≤ 1) : x ^ y ≤ x := by
-  simpa only [rpow_one] using rpow_le_rpow_of_exponent_le h₁ h₂
+  simpa only [rpow_one] using rpow_le_rpow_right h₁ h₂
 
 theorem self_lt_rpow_of_lt_one (h₁ : 0 < x) (h₂ : x < 1) (h₃ : y < 1) : x < x ^ y := by
-  simpa only [rpow_one] using rpow_lt_rpow_of_exponent_gt h₁ h₂ h₃
+  simpa only [rpow_one] using rpow_lt_rpow_right_of_base_lt_one h₁ h₂ h₃
 
 theorem self_lt_rpow_of_one_lt (h₁ : 1 < x) (h₂ : 1 < y) : x < x ^ y := by
-  simpa only [rpow_one] using rpow_lt_rpow_of_exponent_lt h₁ h₂
+  simpa only [rpow_one] using rpow_lt_rpow_right h₁ h₂
 
 theorem rpow_lt_self_of_lt_one (h₁ : 0 < x) (h₂ : x < 1) (h₃ : 1 < y) : x ^ y < x := by
-  simpa only [rpow_one] using rpow_lt_rpow_of_exponent_gt h₁ h₂ h₃
+  simpa only [rpow_one] using rpow_lt_rpow_right_of_base_lt_one h₁ h₂ h₃
 
 theorem rpow_lt_self_of_one_lt (h₁ : 1 < x) (h₂ : y < 1) : x ^ y < x := by
-  simpa only [rpow_one] using rpow_lt_rpow_of_exponent_lt h₁ h₂
+  simpa only [rpow_one] using rpow_lt_rpow_right h₁ h₂
 
 theorem rpow_left_injOn {x : ℝ} (hx : x ≠ 0) : InjOn (fun y : ℝ => y ^ x) { y : ℝ | 0 ≤ y } := by
   rintro y hy z hz (hyz : y ^ x = z ^ x)
@@ -923,11 +989,14 @@ lemma rpow_right_inj (hx₀ : 0 < x) (hx₁ : x ≠ 1) : x ^ y = x ^ z ↔ y = z
 
 /-- Guessing rule for the `bound` tactic: when trying to prove `x ^ y ≤ x ^ z`, we can either assume
 `1 ≤ x` or `0 < x ≤ 1`. -/
-@[bound] lemma rpow_le_rpow_of_exponent_le_or_ge {x y z : ℝ}
+@[bound] lemma rpow_le_rpow_right_of_base_ge_one_or_le_one {x y z : ℝ}
     (h : 1 ≤ x ∧ y ≤ z ∨ 0 < x ∧ x ≤ 1 ∧ z ≤ y) : x ^ y ≤ x ^ z := by
   rcases h with ⟨x1, yz⟩ | ⟨x0, x1, zy⟩
-  · exact Real.rpow_le_rpow_of_exponent_le x1 yz
-  · exact Real.rpow_le_rpow_of_exponent_ge x0 x1 zy
+  · exact Real.rpow_le_rpow_right x1 yz
+  · exact Real.rpow_le_rpow_right_of_base_le_one x0 x1 zy
+
+@[deprecated rpow_le_rpow_right_of_base_ge_one_or_le_one (since := "2026-07-06")]
+alias rpow_le_rpow_of_exponent_le_or_ge := rpow_le_rpow_right_of_base_ge_one_or_le_one
 
 end Real
 
@@ -936,10 +1005,10 @@ namespace Complex
 lemma norm_prime_cpow_le_one_half (p : Nat.Primes) {s : ℂ} (hs : 1 < s.re) :
     ‖(p : ℂ) ^ (-s)‖ ≤ 1 / 2 := by
   rw [norm_natCast_cpow_of_re_ne_zero p <| by rw [neg_re]; linarith only [hs]]
-  refine (Real.rpow_le_rpow_of_nonpos zero_lt_two (Nat.cast_le.mpr p.prop.two_le) <|
+  refine (Real.rpow_le_rpow_left_of_exponent_nonpos zero_lt_two (Nat.cast_le.mpr p.prop.two_le) <|
     by rw [neg_re]; linarith only [hs]).trans ?_
   rw [one_div, ← Real.rpow_neg_one]
-  exact Real.rpow_le_rpow_of_exponent_le one_le_two <| (neg_lt_neg hs).le
+  exact Real.rpow_le_rpow_right one_le_two <| (neg_lt_neg hs).le
 
 lemma one_sub_prime_cpow_ne_zero {p : ℕ} (hp : p.Prime) {s : ℂ} (hs : 1 < s.re) :
     1 - (p : ℂ) ^ (-s) ≠ 0 := by
@@ -953,12 +1022,12 @@ lemma norm_natCast_cpow_le_norm_natCast_cpow_of_pos {n : ℕ} (hn : 0 < n) {w z 
     (h : w.re ≤ z.re) :
     ‖(n : ℂ) ^ w‖ ≤ ‖(n : ℂ) ^ z‖ := by
   simp_rw [norm_natCast_cpow_of_pos hn]
-  exact Real.rpow_le_rpow_of_exponent_le (by exact_mod_cast hn) h
+  exact Real.rpow_le_rpow_right (by exact_mod_cast hn) h
 
 lemma norm_natCast_cpow_le_norm_natCast_cpow_iff {n : ℕ} (hn : 1 < n) {w z : ℂ} :
     ‖(n : ℂ) ^ w‖ ≤ ‖(n : ℂ) ^ z‖ ↔ w.re ≤ z.re := by
   simp_rw [norm_natCast_cpow_of_pos (Nat.zero_lt_of_lt hn),
-    Real.rpow_le_rpow_left_iff (Nat.one_lt_cast.mpr hn)]
+    Real.rpow_le_rpow_iff_right (Nat.one_lt_cast.mpr hn)]
 
 lemma norm_log_natCast_le_rpow_div (n : ℕ) {ε : ℝ} (hε : 0 < ε) : ‖log n‖ ≤ n ^ ε / ε := by
   rcases n.eq_zero_or_pos with rfl | h

--- a/Mathlib/Analysis/SpecificLimits/FloorPow.lean
+++ b/Mathlib/Analysis/SpecificLimits/FloorPow.lean
@@ -242,7 +242,7 @@ theorem sum_div_pow_sq_le_div_sq (N : ℕ) {j : ℝ} (hj : 0 < j) {c : ℝ} (hc 
     _ ≤ (c⁻¹ ^ 2) ^ (Real.log j / Real.log c - 1) / ((1 : ℝ) - c⁻¹ ^ 2) := by
       gcongr
       rw [← Real.rpow_natCast]
-      exact Real.rpow_le_rpow_of_exponent_ge A C.le (Nat.sub_one_lt_floor _).le
+      exact Real.rpow_le_rpow_right_of_base_le_one A C.le (Nat.sub_one_lt_floor _).le
     _ = c ^ 2 * ((1 : ℝ) - c⁻¹ ^ 2)⁻¹ / j ^ 2 := by
       have I : (c⁻¹ ^ 2) ^ (Real.log j / Real.log c) = (1 : ℝ) / j ^ 2 := by
         apply Real.log_injOn_pos (Real.rpow_pos_of_pos A _)

--- a/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
@@ -382,7 +382,7 @@ theorem le_N (hN : 2 ≤ N) : (2 * dValue N - 1) ^ nValue N ≤ N := by
   suffices ((2 * dValue N) ^ nValue N : ℝ) ≤ N from mod_cast this
   suffices i : (2 * dValue N : ℝ) ≤ (N : ℝ) ^ (nValue N : ℝ)⁻¹ by
     rw [← rpow_natCast]
-    apply (rpow_le_rpow (mul_nonneg zero_le_two (cast_nonneg _)) i (cast_nonneg _)).trans
+    apply (rpow_le_rpow_left (mul_nonneg zero_le_two (cast_nonneg _)) i (cast_nonneg _)).trans
     rw [← rpow_mul (cast_nonneg _), inv_mul_cancel₀, rpow_one]
     rw [cast_ne_zero]
     apply (nValue_pos hN).ne'

--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -570,10 +570,10 @@ protected lemma GrowsPolynomially.rpow (p : ℝ) (hf : GrowsPolynomially f)
       refine ⟨?lb, ?ub⟩
       case lb => calc
         c₂ ^ p * (f x) ^ p = (c₂ * f x) ^ p := by rw [mul_rpow (le_of_lt hc₂_mem) (le_of_lt hf_pos)]
-          _ ≤ _ := rpow_le_rpow_of_nonpos (hf_pos₂ u hu.1) (hf₁ u hu).2 (le_of_lt hp)
+          _ ≤ _ := rpow_le_rpow_left_of_exponent_nonpos (hf_pos₂ u hu.1) (hf₁ u hu).2 (le_of_lt hp)
       case ub => calc
         (f u) ^ p ≤ (c₁ * f x) ^ p := by
-              exact rpow_le_rpow_of_nonpos (by positivity) (hf₁ u hu).1 (le_of_lt hp)
+              exact rpow_le_rpow_left_of_exponent_nonpos (by positivity) (hf₁ u hu).1 (le_of_lt hp)
           _ = _ := by rw [← mul_rpow (le_of_lt hc₁_mem) (le_of_lt hf_pos)]
     | .inr (.inr hneg) => -- eventually negative (which is impossible)
       have : ∀ᶠ (_ : ℝ) in atTop, False := by

--- a/Mathlib/Computability/AkraBazzi/SumTransform.lean
+++ b/Mathlib/Computability/AkraBazzi/SumTransform.lean
@@ -652,7 +652,7 @@ lemma eventually_atTop_sumTransform_le :
         have : 0 < u := calc
           0 < r i n := by exact hrpos_i
           _ ≤ u := by exact hu.1
-        exact rpow_le_rpow_of_nonpos (by positivity)
+        exact rpow_le_rpow_left_of_exponent_nonpos (by positivity)
           (by exact_mod_cast (le_of_lt hu.2)) (le_of_lt hp)
       _ ≤ n ^ p a b * #(Ico (r i n) n) • (c₂ * g n / n ^ (p a b + 1)) := by
         gcongr; exact Finset.sum_le_card_nsmul _ _ _ (fun x _ => by rfl)
@@ -734,7 +734,7 @@ lemma eventually_atTop_sumTransform_ge :
                       _ ≤ u := hu.1
           positivity
         · rw [Finset.mem_Ico] at hu
-          exact rpow_le_rpow_of_nonpos (by positivity)
+          exact rpow_le_rpow_left_of_exponent_nonpos (by positivity)
             (by exact_mod_cast hu.1) (le_of_lt hp)
       _ ≥ n ^ p a b * #(Ico (r i n) n) • (c₂ * g n / r i n ^ (p a b + 1)) := by
           gcongr; exact Finset.card_nsmul_le_sum _ _ _ (fun x _ => by rfl)
@@ -742,7 +742,7 @@ lemma eventually_atTop_sumTransform_ge :
           rw [nsmul_eq_mul, mul_assoc]
       _ ≥ n ^ p a b * #(Ico (r i n) n) * (c₂ * g n / (c₁ * n) ^ (p a b + 1)) := by
           gcongr n ^ p a b * #(Ico (r i n) n) * (c₂ * g n / ?_)
-          exact rpow_le_rpow_of_nonpos (by positivity) (hn₁ i) (le_of_lt hp)
+          exact rpow_le_rpow_left_of_exponent_nonpos (by positivity) (hn₁ i) (le_of_lt hp)
       _ = n ^ (p a b) * (n - r i n) * (c₂ * g n / (c₁ * n) ^ ((p a b) + 1)) := by
           congr; rw [Nat.card_Ico, Nat.cast_sub (le_of_lt <| hr_lt_n i)]
       _ ≥ n ^ (p a b) * (n - c₃ * n) * (c₂ * g n / (c₁ * n) ^ ((p a b) + 1)) := by

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondJensen.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondJensen.lean
@@ -271,7 +271,7 @@ theorem Integrable.norm_condExp_rpow_le {p : ℝ} (hp : 1 ≤ p)
   have hl := (Real.continuous_rpow_const hp'.le).lowerSemicontinuous.lowerSemicontinuousOn (Ici 0)
   have := (convexOn_rpow hp).map_condExp_le hm hl (by simp) isClosed_Ici hf_int.norm hfint
   filter_upwards [norm_condExp_le f, this] with a ha hb
-  exact (Real.rpow_le_rpow (norm_nonneg _) ha hp'.le).trans hb
+  exact (Real.rpow_le_rpow_left (norm_nonneg _) ha hp'.le).trans hb
 
 /-- **Conditional Jensen's inequality**: in a finite dimensional Banach space `E` with a measure
 `μ` that is σ-finite on a sub-σ-algebra `m`, if `φ : E → ℝ` is convex, then for any `f : α → E` such

--- a/Mathlib/MeasureTheory/Function/ContinuousMapDense.lean
+++ b/Mathlib/MeasureTheory/Function/ContinuousMapDense.lean
@@ -203,7 +203,7 @@ theorem MemLp.exists_hasCompactSupport_integral_rpow_sub_le
   refine ⟨g, g_support, ?_, g_cont, g_mem⟩
   rwa [(hf.sub g_mem).eLpNorm_eq_integral_rpow_norm B ENNReal.coe_ne_top,
     ENNReal.ofReal_le_ofReal_iff I.le, one_div, ENNReal.toReal_ofReal hp.le,
-    Real.rpow_le_rpow_iff _ hε.le (inv_pos.2 hp)] at hg
+    Real.rpow_le_rpow_iff_left _ hε.le (inv_pos.2 hp)] at hg
   positivity
 
 
@@ -293,7 +293,7 @@ theorem MemLp.exists_boundedContinuous_integral_rpow_sub_le [μ.WeaklyRegular] {
   refine ⟨g, ?_, g_mem⟩
   rwa [(hf.sub g_mem).eLpNorm_eq_integral_rpow_norm B ENNReal.coe_ne_top,
     ENNReal.ofReal_le_ofReal_iff I.le, one_div, ENNReal.toReal_ofReal hp.le,
-    Real.rpow_le_rpow_iff _ hε.le (inv_pos.2 hp)] at hg
+    Real.rpow_le_rpow_iff_left _ hε.le (inv_pos.2 hp)] at hg
   positivity
 
 /-- Any integrable function can be approximated by bounded continuous functions,

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -289,7 +289,7 @@ theorem MemLp.eLpNorm_indicator_norm_ge_le (hf : MemLp f p μ) (hmeas : Strongly
   rw [enorm_indicator_eq_indicator_enorm, enorm_indicator_eq_indicator_enorm]
   have hiff : M ^ (1 / p.toReal) ≤ ‖f x‖₊ ↔ M ≤ ‖‖f x‖ ^ p.toReal‖₊ := by
     rw [coe_nnnorm, coe_nnnorm, Real.norm_rpow_of_nonneg (norm_nonneg _), norm_norm,
-      ← Real.rpow_le_rpow_iff hM' (by positivity)
+      ← Real.rpow_le_rpow_iff_left hM' (by positivity)
         (one_div_pos.2 <| ENNReal.toReal_pos hp_ne_zero hp_ne_top), ← Real.rpow_mul (norm_nonneg _),
       mul_one_div_cancel (ENNReal.toReal_pos hp_ne_zero hp_ne_top).ne.symm, Real.rpow_one]
   by_cases hx : x ∈ { x : α | M ^ (1 / p.toReal) ≤ ‖f x‖₊ }

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -1139,8 +1139,8 @@ theorem integral_comp_rpow_Ioi (g : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
       intro x hx y hy hxy
       rw [← inv_lt_inv₀ (rpow_pos_of_pos hx p) (rpow_pos_of_pos hy p), ← rpow_neg (le_of_lt hx),
         ← rpow_neg (le_of_lt hy)]
-      exact rpow_lt_rpow (le_of_lt hx) hxy (neg_pos.mpr h)
-    exact StrictMonoOn.injOn fun x hx y _ hxy => rpow_lt_rpow (mem_Ioi.mp hx).le hxy h
+      exact rpow_lt_rpow_left (le_of_lt hx) hxy (neg_pos.mpr h)
+    exact StrictMonoOn.injOn fun x hx y _ hxy => rpow_lt_rpow_left (mem_Ioi.mp hx).le hxy h
   have a3 : (fun t : ℝ => t ^ p) '' S = S := by
     ext1 x; rw [mem_image]; constructor
     · rintro ⟨y, hy, rfl⟩; exact rpow_pos_of_pos hy p
@@ -1193,8 +1193,8 @@ theorem integrableOn_Ioi_comp_rpow_iff [NormedSpace ℝ E] (f : ℝ → E) {p : 
       intro x hx y hy hxy
       rw [← inv_lt_inv₀ (rpow_pos_of_pos hx p) (rpow_pos_of_pos hy p), ← rpow_neg (le_of_lt hx), ←
         rpow_neg (le_of_lt hy)]
-      exact rpow_lt_rpow (le_of_lt hx) hxy (neg_pos.mpr h)
-    exact StrictMonoOn.injOn fun x hx y _hy hxy => rpow_lt_rpow (mem_Ioi.mp hx).le hxy h
+      exact rpow_lt_rpow_left (le_of_lt hx) hxy (neg_pos.mpr h)
+    exact StrictMonoOn.injOn fun x hx y _hy hxy => rpow_lt_rpow_left (mem_Ioi.mp hx).le hxy h
   have a3 : (fun t : ℝ => t ^ p) '' S = S := by
     ext1 x; rw [mem_image]; constructor
     · rintro ⟨y, hy, rfl⟩; exact rpow_pos_of_pos hy p

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -199,7 +199,7 @@ theorem MeasureTheory.volume_sum_rpow_lt [Nonempty ι] {p : ℝ} (hp : 1 ≤ p) 
     simp_rw [← Set.preimage_smul_inv₀ (ne_of_gt hr), Set.preimage_setOf_eq, Pi.smul_apply,
       smul_eq_mul, abs_mul, mul_rpow (abs_nonneg _) (abs_nonneg _), abs_inv,
       inv_rpow (abs_nonneg _), ← Finset.mul_sum, abs_eq_self.mpr (le_of_lt hr),
-      inv_mul_lt_iff₀ (rpow_pos_of_pos hr _), mul_one, ← rpow_lt_rpow_iff
+      inv_mul_lt_iff₀ (rpow_pos_of_pos hr _), mul_one, ← rpow_lt_rpow_iff_left
       (rpow_nonneg (h₁ _) _) (le_of_lt hr) (by linarith : 0 < p), ← rpow_mul
       (h₁ _), div_mul_cancel₀ _ (ne_of_gt (by linarith) : p ≠ 0), Real.rpow_one]
 
@@ -274,7 +274,7 @@ theorem Complex.volume_sum_rpow_lt [Nonempty ι] {p : ℝ} (hp : 1 ≤ p) (r : �
     · simp_rw [← Set.preimage_smul_inv₀ (ne_of_gt hr), Set.preimage_setOf_eq, Pi.smul_apply,
         norm_smul, mul_rpow (norm_nonneg _) (norm_nonneg _), Real.norm_eq_abs, abs_inv, inv_rpow
         (abs_nonneg _), ← Finset.mul_sum, abs_eq_self.mpr (le_of_lt hr), inv_mul_lt_iff₀
-        (rpow_pos_of_pos hr _), mul_one, ← rpow_lt_rpow_iff (rpow_nonneg (h₁ _) _)
+        (rpow_pos_of_pos hr _), mul_one, ← rpow_lt_rpow_iff_left (rpow_nonneg (h₁ _) _)
         (le_of_lt hr) (by linarith : 0 < p), ← rpow_mul (h₁ _), div_mul_cancel₀ _
         (ne_of_gt (by linarith) : p ≠ 0), Real.rpow_one]
     · simp_rw [finrank_pi_fintype ℝ, Complex.finrank_real_complex, Finset.sum_const, smul_eq_mul,

--- a/Mathlib/NumberTheory/Bertrand.lean
+++ b/Mathlib/NumberTheory/Bertrand.lean
@@ -111,7 +111,7 @@ theorem real_main_inequality {x : ℝ} (x_large : (512 : ℝ) ≤ x) :
     rw [rpow_natCast, ← pow_mul, ← pow_add]
     conv in 4 => equals 2 ^ (2 : ℝ) => rw [rpow_two]; norm_num1
     rw [← rpow_mul, ← rpow_natCast]
-    on_goal 1 => apply rpow_le_rpow_of_exponent_le
+    on_goal 1 => apply rpow_le_rpow_right
     all_goals norm_num1
 
 end Bertrand

--- a/Mathlib/NumberTheory/Harmonic/EulerMascheroni.lean
+++ b/Mathlib/NumberTheory/Harmonic/EulerMascheroni.lean
@@ -103,10 +103,10 @@ lemma eulerMascheroniSeq'_six_lt_two_thirds : eulerMascheroniSeq' 6 < 2 / 3 := b
     norm_num
   rw [h1, sub_lt_iff_lt_add, ← sub_lt_iff_lt_add', lt_log_iff_exp_lt (by positivity)]
   norm_num
-  have := rpow_lt_rpow (exp_pos _).le exp_one_lt_d9 (by simp : (0 : ℝ) < 107 / 60)
+  have := rpow_lt_rpow_left (exp_pos _).le exp_one_lt_d9 (by simp : (0 : ℝ) < 107 / 60)
   rw [exp_one_rpow] at this
   refine lt_trans this ?_
-  rw [← rpow_lt_rpow_iff (z := 60), ← rpow_mul, div_mul_cancel₀, ← Nat.cast_ofNat,
+  rw [← rpow_lt_rpow_iff_left (z := 60), ← rpow_mul, div_mul_cancel₀, ← Nat.cast_ofNat,
     ← Nat.cast_ofNat, rpow_natCast, Nat.cast_ofNat, ← Nat.cast_ofNat (n := 60), rpow_natCast]
   · norm_num
   all_goals positivity

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -433,7 +433,7 @@ lemma not_summable_residueClass_prime_div (ha : IsUnit a) :
       · simp
       · refine div_le_div_of_nonneg_left (residueClass_nonneg a _) (mod_cast hn) ?_
         conv_lhs => rw [← Real.rpow_one n]
-        exact Real.rpow_le_rpow_of_exponent_le (by norm_cast) hx.le
+        exact Real.rpow_le_rpow_right (by norm_cast) hx.le
     · exact summable_real_of_abscissaOfAbsConv_lt <|
         (abscissaOfAbsConv_residueClass_le_one a).trans_lt <| mod_cast hx
   obtain ⟨C', hC'⟩ := LSeries_residueClass_lower_bound ha

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Summable.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Summable.lean
@@ -148,15 +148,15 @@ lemma summand_bound {k : ℝ} (hk : 0 ≤ k) (x : Fin 2 → ℤ) :
     · rw [h, Real.rpow_zero, Real.rpow_zero, one_mul]
     · rw [Real.zero_rpow h, mul_zero]
   · rw [← Real.mul_rpow (r_pos _).le (norm_nonneg _)]
-    exact Real.rpow_le_rpow_of_nonpos (mul_pos (r_pos _) (norm_pos_iff.mpr hx)) (r_mul_max_le z hx)
-      (neg_nonpos.mpr hk)
+    exact Real.rpow_le_rpow_left_of_exponent_nonpos
+      (mul_pos (r_pos _) (norm_pos_iff.mpr hx)) (r_mul_max_le z hx) (neg_nonpos.mpr hk)
 
 variable {z} in
 lemma summand_bound_of_mem_verticalStrip {k : ℝ} (hk : 0 ≤ k) (x : Fin 2 → ℤ)
     {A B : ℝ} (hB : 0 < B) (hz : z ∈ verticalStrip A B) :
     ‖x 0 * (z : ℂ) + x 1‖ ^ (-k) ≤ r ⟨⟨A, B⟩, hB⟩ ^ (-k) * ‖x‖ ^ (-k) := by
   refine (summand_bound z hk x).trans (mul_le_mul_of_nonneg_right ?_ (by positivity))
-  exact Real.rpow_le_rpow_of_nonpos (r_pos _) (r_lower_bound_on_verticalStrip z hB hz)
+  exact Real.rpow_le_rpow_left_of_exponent_nonpos (r_pos _) (r_lower_bound_on_verticalStrip z hB hz)
     (neg_nonpos.mpr hk)
 
 lemma linear_isTheta_right_add (c e : ℤ) (z : ℂ) :

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -597,7 +597,7 @@ theorem exists_ne_zero_mem_ideal_of_norm_le {B : ℝ}
   rw [mem_toAddSubgroup, mem_span_fractionalIdealLatticeBasis] at hx
   obtain ⟨a, ha, rfl⟩ := hx
   refine ⟨a, ha, by simpa using h_nz, ?_⟩
-  rw [← rpow_natCast, ← rpow_le_rpow_iff (by simp only [Rat.cast_abs, abs_nonneg])
+  rw [← rpow_natCast, ← rpow_le_rpow_iff_left (by simp only [Rat.cast_abs, abs_nonneg])
       (rpow_nonneg h2 _) h1, ← rpow_mul h2, mul_inv_cancel₀ (Nat.cast_ne_zero.mpr
       (ne_of_gt finrank_pos)), rpow_one, le_div_iff₀' (Nat.cast_pos.mpr finrank_pos)]
   refine le_trans ?_ ((convexBodySum_mem K B).mp h_mem)

--- a/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
@@ -231,8 +231,9 @@ theorem abs_discr_rpow_ge_of_isTotallyComplex [IsTotallyComplex K] :
     (finrank ℚ K) ^ 2 / ((4 / π) * (finrank ℚ K).factorial ^ (2 * (finrank ℚ K : ℝ)⁻¹)) ≤
         |discr K| ^ (finrank ℚ K : ℝ)⁻¹ := by
   have h : 0 < (finrank ℚ K : ℝ) := Nat.cast_pos.mpr finrank_pos
-  rw [← Real.rpow_le_rpow_iff (z := finrank ℚ K) (by positivity) (by positivity) h, Real.div_rpow
-    (by positivity) (by positivity), ← Real.rpow_mul (by positivity), inv_mul_cancel₀ h.ne',
+  rw [← Real.rpow_le_rpow_iff_left (z := finrank ℚ K) (by positivity) (by positivity) h,
+    Real.div_rpow (by positivity) (by positivity), ← Real.rpow_mul (by positivity),
+    inv_mul_cancel₀ h.ne',
     Real.rpow_one, Real.mul_rpow (by positivity) (by positivity), Real.rpow_natCast,
     Real.rpow_natCast, ← pow_mul, ← Real.rpow_mul (by positivity),
     inv_mul_cancel_right₀ h.ne', Real.rpow_two]
@@ -357,7 +358,7 @@ theorem rank_le_rankOfDiscrBdd :
       rw [← Real.rpow_natCast]
       rw [Real.log_div_log] at h
       refine lt_of_le_of_lt ?_ (mul_lt_mul_of_pos_left
-        (Real.rpow_lt_rpow_of_exponent_lt h₂ h) (by positivity : (0 : ℝ) < 4 / 9))
+        (Real.rpow_lt_rpow_right h₂ h) (by positivity : (0 : ℝ) < 4 / 9))
       rw [Real.rpow_logb (lt_trans zero_lt_one h₂) (ne_of_gt h₂) (by positivity), ← mul_assoc,
             ← inv_div, inv_mul_cancel₀ (by simp), one_mul, Int.cast_natCast]
     · refine div_nonneg (Real.log_nonneg ?_) (Real.log_nonneg (le_of_lt h₂))

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -189,12 +189,12 @@ lemma eq_one_of_not_dvd {m : ℕ} (hpm : ¬ p ∣ m) : f m = 1 := by
     calc
     x ^ k = x ^ (k : ℝ) := (rpow_natCast x k).symm
     _ < x ^ M.logb (1 / 2) := by
-      apply rpow_lt_rpow_of_exponent_gt hx0 hx1
+      apply rpow_lt_rpow_right_of_base_lt_one hx0 hx1
       rw [hk]
       push_cast
       exact lt_add_of_le_of_pos (Nat.le_ceil _) zero_lt_one
     _ ≤ x ^ x.logb (1 / 2) := by
-      apply rpow_le_rpow_of_exponent_ge hx0 hx1.le
+      apply rpow_le_rpow_right_of_base_le_one hx0 hx1.le
       simp only [one_div, ← log_div_log, log_inv, neg_div, ← div_neg, hM]
       gcongr
       simp only [Left.neg_pos_iff]
@@ -384,7 +384,7 @@ private lemma param_upperbound {k : ℕ} (hk : k ≠ 0) :
     _ ≤ ↑m * f ↑m / (f ↑m - 1) * f ↑m ^ logb ↑m ↑n := by
       gcongr
       · exact (expr_pos hm notbdd).le
-      · rw [← rpow_natCast, rpow_le_rpow_left_iff (one_lt_of_not_bounded notbdd hm)]
+      · rw [← rpow_natCast, rpow_le_rpow_iff_right (one_lt_of_not_bounded notbdd hm)]
         exact natLog_le_logb n m
   apply le_of_pow_le_pow_left₀ hk <| mul_nonneg (rpow_nonneg (expr_pos hm notbdd).le _)
     (rpow_nonneg (apply_nonneg f ↑m) _)
@@ -410,7 +410,7 @@ lemma le_pow_log : f n ≤ f m ^ logb m n := by
 include hm hn notbdd in
 /-- Given `m, n ≥ 2` and `f m = m ^ s`, `f n = n ^ t` for `s, t > 0`, we have `t ≤ s`. -/
 private lemma le_of_eq_pow {s t : ℝ} (hfm : f m = m ^ s) (hfn : f n = n ^ t) : t ≤ s := by
-  rw [← rpow_le_rpow_left_iff (x := n) (mod_cast hn), ← hfn]
+  rw [← rpow_le_rpow_iff_right (x := n) (mod_cast hn), ← hfn]
   apply le_trans <| le_pow_log hm hn notbdd
   rw [hfm, ← rpow_mul (Nat.cast_nonneg m), mul_comm, rpow_mul (Nat.cast_nonneg m),
     rpow_logb (mod_cast zero_lt_of_lt hm) (mod_cast hm.ne') (mod_cast zero_lt_of_lt hn)]

--- a/Mathlib/NumberTheory/SumPrimeReciprocals.lean
+++ b/Mathlib/NumberTheory/SumPrimeReciprocals.lean
@@ -101,4 +101,4 @@ theorem Nat.Primes.summable_rpow {r : ℝ} :
     refine fun H ↦ Nat.Primes.not_summable_one_div <| H.of_nonneg_of_le (fun _ ↦ by positivity) ?_
     intro p
     rw [one_div, ← Real.rpow_neg_one]
-    exact Real.rpow_le_rpow_of_exponent_le (by exact_mod_cast p.prop.one_lt.le) <| not_lt.mp h
+    exact Real.rpow_le_rpow_right (by exact_mod_cast p.prop.one_lt.le) <| not_lt.mp h

--- a/Mathlib/NumberTheory/Transcendental/Liouville/Measure.lean
+++ b/Mathlib/NumberTheory/Transcendental/Liouville/Measure.lean
@@ -60,7 +60,7 @@ theorem setOf_liouvilleWith_subset_aux :
     calc
       (b : ℝ) = (b : ℝ) ^ (1 : ℝ) := (rpow_one _).symm
       _ ≤ (b : ℝ) ^ (2 + 1 / (n + 1 : ℕ) : ℝ) :=
-        rpow_le_rpow_of_exponent_le hb (one_le_two.trans ?_)
+        rpow_le_rpow_right hb (one_le_two.trans ?_)
     simpa using n.cast_add_one_pos.le
   rw [sub_div' hb0.ne', abs_div, abs_of_pos hb0, div_lt_div_iff_of_pos_right hb0, abs_sub_lt_iff,
     sub_lt_iff_lt_add, sub_lt_iff_lt_add, ← sub_lt_iff_lt_add'] at hlt

--- a/Mathlib/Topology/MetricSpace/Snowflaking.lean
+++ b/Mathlib/Topology/MetricSpace/Snowflaking.lean
@@ -463,7 +463,7 @@ theorem dist_ofSnowflaking_ofSnowflaking (x y : Snowflaking X α hα₀ hα₁) 
 theorem preimage_ofSnowflaking_ball (x : X) {r : ℝ} (hr : 0 ≤ r) :
     ofSnowflaking ⁻¹' ball x r = ball (toSnowflaking x : Snowflaking X α hα₀ hα₁) (r ^ α) := by
   ext ⟨y⟩
-  simp (disch := positivity) [Real.rpow_lt_rpow_iff]
+  simp (disch := positivity) [Real.rpow_lt_rpow_iff_left]
 
 @[simp]
 theorem image_toSnowflaking_ball (x : X) {r : ℝ} (hr : 0 ≤ r) :
@@ -486,7 +486,7 @@ theorem preimage_ofSnowflaking_closedBall (x : X) {r : ℝ} (hr : 0 ≤ r) :
     ofSnowflaking ⁻¹' closedBall x r =
       closedBall (toSnowflaking x : Snowflaking X α hα₀ hα₁) (r ^ α) := by
   ext ⟨y⟩
-  simp (disch := positivity) [Real.rpow_le_rpow_iff]
+  simp (disch := positivity) [Real.rpow_le_rpow_iff_left]
 
 @[simp]
 theorem image_toSnowflaking_closedBall (x : X) {r : ℝ} (hr : 0 ≤ r) :


### PR DESCRIPTION
﻿Closes #13544.

This renames the `Real.rpow` order lemmas so the names indicate which argument is being varied:

- `_left` for monotonicity/strict monotonicity in the base
- `_right` for monotonicity/strict monotonicity in the exponent

The old `Real` names are kept as deprecated aliases, and downstream `Real` usages in Mathlib are updated to the new names. The public `NNReal` and `ENNReal` theorem names are intentionally left unchanged.

