### PR TITLE
[Merged by Bors] - feat(RepresentationTheory/Intertwining): a central element of the MonoidAlgebra acts on a representation as self-intertwining map

### DIFF
--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -592,18 +592,21 @@ def centralMul (g : G) (hg : g ∈ Submonoid.center G) : IntertwiningMap ρ ρ w
   toLinearMap := ρ g
   isIntertwining' x := LinearMap.ext <| (isIntertwiningMap_of_mem_center ρ g hg).isIntertwining x
 
-noncomputable def centralAlgebraMul (z : A[G]) (hz : z ∈ Submonoid.center A[G]) :
+/-- If `z` is a central element of the monoid algebra `A[G]`, then this is the action of `z`,
+  considered as an intertwining map from any representation of `G` to itself. -/
+noncomputable def centralAlgebraMul {z : A[G]} (hz : z ∈ Submonoid.center A[G]) :
     ρ.IntertwiningMap ρ where
   toLinearMap := ρ.asAlgebraHom z
   isIntertwining' _ := by simp_rw [← ρ.asAlgebraHom_of, ← Module.End.mul_eq_comp,
     ← map_mul, Submonoid.mem_center_iff.1 hz]
 
-@[simp]
-lemma centralAlgebraMul_apply {z : A[G]} (hz : z ∈ Submonoid.center A[G]) (v : V) :
-    centralAlgebraMul ρ z hz v = ρ.asAlgebraHom z v := rfl
+@[simp] lemma centralAlgebraMul_apply {z : A[G]} (hz : z ∈ Submonoid.center A[G]) (v : V) :
+    centralAlgebraMul ρ hz v = ρ.asAlgebraHom z v := rfl
 
-noncomputable def centralAlgebraMulHom : Submonoid.center A[G] →* ρ.IntertwiningMap ρ where
-  toFun z := centralAlgebraMul _ z.1 z.2
+/-- `centralAlgebraMul` as monoid homomorphism from the center of `A[G]` to intertwining map
+  from any representation of `G` to itself. -/
+@[simps] noncomputable def centralAlgebraMulHom : Submonoid.center A[G] →* ρ.IntertwiningMap ρ where
+  toFun z := centralAlgebraMul _ z.2
   map_one' := by ext; simp
   map_mul' _ _ := by ext; simp
 

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -586,26 +586,26 @@ theorem isIntertwiningMap_of_mem_center (g : G) (hg : g ∈ Submonoid.center G) 
   rw [Submonoid.mem_center_iff] at hg
   rw [← Module.End.mul_apply, ← Module.End.mul_apply, ← ρ.map_mul, ← hg g', ρ.map_mul]
 
-theorem isIntertwiningMap_of_mem_center_algebra (z : A[G]) (hz : z ∈ Submonoid.center A[G]) :
-    IsIntertwiningMap ρ ρ (ρ.asAlgebraHom z) := by
-  rw [isIntertwiningMap_iff]
-  intros
-  rw [← Module.End.mul_apply, ← Module.End.mul_apply, ← asAlgebraHom_of, ← map_mul,
-    ← Submonoid.mem_center_iff.1 hz, map_mul, asAlgebraHom_of]
-
 /-- If `g` is a central element of a monoid `G`, then this is the action of `g`, considered as an
   intertwining map from any representation of `G` to itself. -/
 def centralMul (g : G) (hg : g ∈ Submonoid.center G) : IntertwiningMap ρ ρ where
   toLinearMap := ρ g
   isIntertwining' x := LinearMap.ext <| (isIntertwiningMap_of_mem_center ρ g hg).isIntertwining x
 
-/-- If `z` is a central element of the monoid algebra `A[G]`, then this is the action of `z`,
-  considered as an intertwining map from any representation of `G` to itself. -/
 noncomputable def centralAlgebraMul (z : A[G]) (hz : z ∈ Submonoid.center A[G]) :
     ρ.IntertwiningMap ρ where
   toLinearMap := ρ.asAlgebraHom z
-  isIntertwining' x := LinearMap.ext <|
-    (isIntertwiningMap_of_mem_center_algebra ρ z hz).isIntertwining x
+  isIntertwining' _ := by simp_rw [← ρ.asAlgebraHom_of, ← Module.End.mul_eq_comp,
+    ← map_mul, Submonoid.mem_center_iff.1 hz]
+
+@[simp]
+lemma centralAlgebraMul_apply {z : A[G]} (hz : z ∈ Submonoid.center A[G]) (v : V) :
+    centralAlgebraMul ρ z hz v = ρ.asAlgebraHom z v := rfl
+
+noncomputable def centralAlgebraMulHom : Submonoid.center A[G] →* ρ.IntertwiningMap ρ where
+  toFun z := centralAlgebraMul _ z.1 z.2
+  map_one' := by ext; simp
+  map_mul' _ _ := by ext; simp
 
 /-- `IntertwiningMap.toLinearMap` as a linear map. -/
 @[simps] def toLinearMapl : IntertwiningMap ρ σ →ₗ[A] V →ₗ[A] W where

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -586,18 +586,24 @@ theorem isIntertwiningMap_of_mem_center (g : G) (hg : g ∈ Submonoid.center G) 
   rw [Submonoid.mem_center_iff] at hg
   rw [← Module.End.mul_apply, ← Module.End.mul_apply, ← ρ.map_mul, ← hg g', ρ.map_mul]
 
+theorem isIntertwiningMap_of_mem_center_algebra (z : A[G]) (hz : z ∈ Submonoid.center A[G]) :
+    IsIntertwiningMap ρ ρ (ρ.asAlgebraHom z) := by
+  rw [isIntertwiningMap_iff]
+  intros
+  rw [← Module.End.mul_apply, ← Module.End.mul_apply, ← asAlgebraHom_of, ← map_mul,
+    ← Submonoid.mem_center_iff.1 hz _, map_mul, asAlgebraHom_of]
+
 /-- If `g` is a central element of a monoid `G`, then this is the action of `g`, considered as an
   intertwining map from any representation of `G` to itself. -/
 def centralMul (g : G) (hg : g ∈ Submonoid.center G) : IntertwiningMap ρ ρ where
   toLinearMap := ρ g
   isIntertwining' x := LinearMap.ext <| (isIntertwiningMap_of_mem_center ρ g hg).isIntertwining x
 
-noncomputable def centralAlgebraMul (z : A[G]) (hg : z ∈ Submonoid.center A[G]) :
+noncomputable def centralAlgebraMul (z : A[G]) (hz : z ∈ Submonoid.center A[G]) :
     ρ.IntertwiningMap ρ where
   toLinearMap := ρ.asAlgebraHom z
-  isIntertwining' _ := by
-    rw [← Module.End.mul_eq_comp, ← Module.End.mul_eq_comp, ← asAlgebraHom_of,
-      ← map_mul, ← Submonoid.mem_center_iff.1 hg _, map_mul, asAlgebraHom_of]
+  isIntertwining' x := LinearMap.ext <|
+    (isIntertwiningMap_of_mem_center_algebra ρ z hz).isIntertwining x
 
 /-- `IntertwiningMap.toLinearMap` as a linear map. -/
 @[simps] def toLinearMapl : IntertwiningMap ρ σ →ₗ[A] V →ₗ[A] W where

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -592,6 +592,13 @@ def centralMul (g : G) (hg : g ∈ Submonoid.center G) : IntertwiningMap ρ ρ w
   toLinearMap := ρ g
   isIntertwining' x := LinearMap.ext <| (isIntertwiningMap_of_mem_center ρ g hg).isIntertwining x
 
+noncomputable def centralAlgebraMul (z : A[G]) (hg : z ∈ Submonoid.center A[G]) :
+    ρ.IntertwiningMap ρ where
+  toLinearMap := ρ.asAlgebraHom z
+  isIntertwining' _ := by
+    rw [← Module.End.mul_eq_comp, ← Module.End.mul_eq_comp, ← asAlgebraHom_of,
+      ← map_mul, ← Submonoid.mem_center_iff.1 hg _, map_mul, asAlgebraHom_of]
+
 /-- `IntertwiningMap.toLinearMap` as a linear map. -/
 @[simps] def toLinearMapl : IntertwiningMap ρ σ →ₗ[A] V →ₗ[A] W where
   toFun := toLinearMap

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -599,6 +599,8 @@ def centralMul (g : G) (hg : g ∈ Submonoid.center G) : IntertwiningMap ρ ρ w
   toLinearMap := ρ g
   isIntertwining' x := LinearMap.ext <| (isIntertwiningMap_of_mem_center ρ g hg).isIntertwining x
 
+/-- If `z` is a central element of the monoid algebra `A[G]`, then this is the action of `z`,
+  considered as an intertwining map from any representation of `G` to itself. -/
 noncomputable def centralAlgebraMul (z : A[G]) (hz : z ∈ Submonoid.center A[G]) :
     ρ.IntertwiningMap ρ where
   toLinearMap := ρ.asAlgebraHom z

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -591,7 +591,7 @@ theorem isIntertwiningMap_of_mem_center_algebra (z : A[G]) (hz : z ∈ Submonoid
   rw [isIntertwiningMap_iff]
   intros
   rw [← Module.End.mul_apply, ← Module.End.mul_apply, ← asAlgebraHom_of, ← map_mul,
-    ← Submonoid.mem_center_iff.1 hz _, map_mul, asAlgebraHom_of]
+    ← Submonoid.mem_center_iff.1 hz, map_mul, asAlgebraHom_of]
 
 /-- If `g` is a central element of a monoid `G`, then this is the action of `g`, considered as an
   intertwining map from any representation of `G` to itself. -/


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
