### PR TITLE
[Merged by Bors] - feat(RingTheory): `Ideal.span` corollaries of Krull's height theorem

### DIFF
--- a/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
+++ b/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
@@ -245,8 +245,7 @@ lemma Ideal.height_le_card_of_mem_minimalPrimes_span_finset {p : Ideal R} {s : F
 lemma Ideal.height_span_le_card_of_span_ne_top {s : Finset R} (ht : Ideal.span (s : Set R) ≠ ⊤) :
     (Ideal.span (s : Set R)).height ≤ s.card := by
   obtain ⟨p, hp⟩ := Ideal.nonempty_minimalPrimes ht
-  rw [Ideal.height_eq_inf_minimalPrimes]
-  exact iInf₂_le_of_le p hp (height_le_card_of_mem_minimalPrimes_span_finset hp)
+  grw [height_mono hp.1.2, height_le_card_of_mem_minimalPrimes_span_finset hp]
 
 lemma Ideal.height_le_ncard_of_mem_minimalPrimes_span {p : Ideal R} {s : Set R}
     (hs : s.Finite) (hI : p ∈ (Ideal.span s).minimalPrimes) :
@@ -259,11 +258,9 @@ alias Ideal.height_le_card_of_mem_minimalPrimes_span :=
   Ideal.height_le_ncard_of_mem_minimalPrimes_span
 
 lemma Ideal.height_span_le_ncard_of_span_ne_top {s : Set R} (hs : s.Finite)
-    (ht : Ideal.span s ≠ ⊤) :
-    (Ideal.span s).height ≤ s.ncard := by
+    (ht : Ideal.span s ≠ ⊤) : (Ideal.span s).height ≤ s.ncard := by
   obtain ⟨p, hp⟩ := Ideal.nonempty_minimalPrimes ht
-  rw [Ideal.height_eq_inf_minimalPrimes]
-  exact iInf₂_le_of_le p hp (height_le_ncard_of_mem_minimalPrimes_span hs hp)
+  grw [height_mono hp.1.2, height_le_ncard_of_mem_minimalPrimes_span hs hp]
 
 lemma Ideal.height_le_encard_of_mem_minimalPrimes_span {p : Ideal R} {s : Set R}
     (hI : p ∈ (Ideal.span s).minimalPrimes) : p.height ≤ s.encard := by
@@ -274,8 +271,7 @@ lemma Ideal.height_le_encard_of_mem_minimalPrimes_span {p : Ideal R} {s : Set R}
 lemma Ideal.height_span_le_encard_of_span_ne_top {s : Set R} (ht : Ideal.span s ≠ ⊤) :
     (Ideal.span s).height ≤ s.encard := by
   obtain ⟨p, hp⟩ := Ideal.nonempty_minimalPrimes ht
-  rw [Ideal.height_eq_inf_minimalPrimes]
-  exact iInf₂_le_of_le p hp (height_le_encard_of_mem_minimalPrimes_span hp)
+  grw [height_mono hp.1.2, height_le_encard_of_mem_minimalPrimes_span hp]
 
 /-- In a commutative Noetherian ring `R`, the height of a (finitely-generated) ideal is smaller
 than or equal to the minimum number of generators for this ideal. -/

--- a/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
+++ b/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
@@ -242,11 +242,40 @@ lemma Ideal.height_le_card_of_mem_minimalPrimes_span_finset {p : Ideal R} {s : F
   · exact Ideal.height_le_spanRank_toENat_of_mem_minimalPrimes _ _ hI
   · simpa using Submodule.spanRank_span_le_card (s : Set R)
 
-lemma Ideal.height_le_card_of_mem_minimalPrimes_span {p : Ideal R} {s : Set R}
+lemma Ideal.height_span_le_card_of_span_ne_top {s : Finset R} (ht : Ideal.span (s : Set R) ≠ ⊤) :
+    (Ideal.span (s : Set R)).height ≤ s.card := by
+  obtain ⟨p, hp⟩ := Ideal.nonempty_minimalPrimes ht
+  rw [Ideal.height_eq_inf_minimalPrimes]
+  exact iInf₂_le_of_le p hp (height_le_card_of_mem_minimalPrimes_span_finset hp)
+
+lemma Ideal.height_le_ncard_of_mem_minimalPrimes_span {p : Ideal R} {s : Set R}
     (hs : s.Finite) (hI : p ∈ (Ideal.span s).minimalPrimes) :
     p.height ≤ s.ncard := by
   rw [s.ncard_eq_toFinset_card hs]
   exact Ideal.height_le_card_of_mem_minimalPrimes_span_finset (by simpa)
+
+@[deprecated (since := "2026-06-29")]
+alias Ideal.height_le_card_of_mem_minimalPrimes_span :=
+  Ideal.height_le_ncard_of_mem_minimalPrimes_span
+
+lemma Ideal.height_span_le_ncard_of_span_ne_top {s : Set R} (hs : s.Finite)
+    (ht : Ideal.span s ≠ ⊤) :
+    (Ideal.span s).height ≤ s.ncard := by
+  obtain ⟨p, hp⟩ := Ideal.nonempty_minimalPrimes ht
+  rw [Ideal.height_eq_inf_minimalPrimes]
+  exact iInf₂_le_of_le p hp (height_le_ncard_of_mem_minimalPrimes_span hs hp)
+
+lemma Ideal.height_le_encard_of_mem_minimalPrimes_span {p : Ideal R} {s : Set R}
+    (hI : p ∈ (Ideal.span s).minimalPrimes) : p.height ≤ s.encard := by
+  by_cases! hs : s.Finite
+  · exact hs.cast_ncard_eq ▸ Ideal.height_le_ncard_of_mem_minimalPrimes_span hs hI
+  · simp [hs]
+
+lemma Ideal.height_span_le_encard_of_span_ne_top {s : Set R} (ht : Ideal.span s ≠ ⊤) :
+    (Ideal.span s).height ≤ s.encard := by
+  obtain ⟨p, hp⟩ := Ideal.nonempty_minimalPrimes ht
+  rw [Ideal.height_eq_inf_minimalPrimes]
+  exact iInf₂_le_of_le p hp (height_le_encard_of_mem_minimalPrimes_span hp)
 
 /-- In a commutative Noetherian ring `R`, the height of a (finitely-generated) ideal is smaller
 than or equal to the minimum number of generators for this ideal. -/


### PR DESCRIPTION
Currently we have statements bounding the height of minimal primes of `Ideal.span S`. Add the obvious corollaries to bound the height of `Ideal.span S` directly.

Also add a `Set.encard`-valued statement of Krull's height theorem. In a Noetherian ring we know the bound should always be finite, but this is useful in downstream applications that are using `ENat`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
