### PR TITLE
[Merged by Bors] - chore: properly deprecate the `linter.style.commandStart` option

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -81,7 +81,7 @@ public def isSetOption : Syntax → Bool :=
 /-- The `setOption` linter: this lints any `set_option` command, term or tactic
 which sets a `debug`, `pp`, `profiler` or `trace` option.
 This also warns if an option containing `maxHeartbeats` (typically, the `maxHeartbeats` or
-`synthInstance.maxHeartbeats` option) or the `linter.flexible`, `linter.style.commandStart` or
+`synthInstance.maxHeartbeats` option) or the `linter.flexible` or
 `backward.inferInstanceAs.wrap.reuseSubInstances ` option is set.
 
 **Why is this bad?** The `debug`, `pp`, `profiler` and `trace` options are good for debugging,
@@ -92,8 +92,7 @@ explaining the need for them; another linter enforces this).
 The `linter.flexible` option should be scoped as `set_option opt in ...`.
 
 **How to fix this?** The `maxHeartbeats` and `linter.flexible` option changes can be scoped to
-individual commands, if they are truly necessary. The `linter.style.commandStart` option is
-deprecated and should be replaced by `linter.style.whitespace`.
+individual commands, if they are truly necessary.
 New `backward.inferInstanceAs.wrap.reuseSubInstances` instances are technical debt,
 and should not be introduced.
 
@@ -120,9 +119,6 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
           Please scope this to individual declarations, as in\n```\nset_option {name} in\n\
           -- comment explaining why this is necessary\n\
           example : ... := ...\n```"
-        else if name == `linter.style.commandStart then
-          logWarningAt stx "The `linter.style.commandStart` option is deprecated, \
-            use `linter.style.whitespace` instead."
         else if name == `backward.inferInstanceAs.wrap.reuseSubInstances then
           logWarningAt stx "The `backward.inferInstanceAs.wrap.reuseSubInstances` option \
             marks the introduction of technical debt, so please don't use it."

--- a/Mathlib/Tactic/Linter/Whitespace.lean
+++ b/Mathlib/Tactic/Linter/Whitespace.lean
@@ -43,10 +43,10 @@ public register_option linter.style.whitespace : Bool := {
 }
 
 /-- Deprecated in favour of `linter.style.whitespace` -/
-@[deprecated linter.style.whitespace (since := "2026-01-07")]
 public register_option linter.style.commandStart : Bool := {
   defValue := false
   descr := "deprecated: use the `linter.style.whitespace` option instead"
+  deprecation? := some { since := "2026-01-07", text? := "use the `linter.style.whitespace` option instead" }
 }
 
 /-- If the `linter.style.whitespace.verbose` option is `true`, the `whitespace` linter

--- a/MathlibTest/Linter/Whitespace.lean
+++ b/MathlibTest/Linter/Whitespace.lean
@@ -10,9 +10,16 @@ section
 
 set_option linter.style.setOption true
 
+/--
+warning: `linter.style.commandStart` has been deprecated: use the `linter.style.whitespace` option instead
+-/
 #guard_msgs in
 set_option linter.style.commandStart true
 
+/--
+warning: `linter.style.commandStart` has been deprecated: use the `linter.style.whitespace` option instead
+-/
+#guard_msgs in
 set_option linter.style.commandStart true in
 example : Nat := 0
 

--- a/MathlibTest/Linter/Whitespace.lean
+++ b/MathlibTest/Linter/Whitespace.lean
@@ -10,9 +10,6 @@ section
 
 set_option linter.style.setOption true
 
-/--
-warning: The `linter.style.commandStart` option is deprecated, use `linter.style.whitespace` instead.
--/
 #guard_msgs in
 set_option linter.style.commandStart true
 


### PR DESCRIPTION
- use the correct syntax for deprecating it: the previous one silently did nothing - as confirmed on Zulip: [#lean4 > No warning on use of deprecated options @ 💬](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/No.20warning.20on.20use.20of.20deprecated.20options/near/608661359)
- remove the check for the `linter.style.commandStart` option in the `set_option` linter: it just duplicates the linter's check

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
