### PR TITLE
[Merged by Bors] - feat(Algebra/MonoidAlgebra): more general `algHom_ext`

### DIFF
--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -457,7 +457,7 @@ for example.
 noncomputable def equivMonoidAlgebraFreeMonoid : FreeAlgebra R X ≃ₐ[R] R[FreeMonoid X] :=
   .ofAlgHom (lift R fun x ↦ .of R (FreeMonoid X) (.of x))
     (MonoidAlgebra.lift R (FreeAlgebra R X) (FreeMonoid X) (FreeMonoid.lift (ι R)))
-    (by ext; simp) (by ext; simp)
+    (MonoidAlgebra.algHom_ext' (by ext; simp) (by ext)) (by ext; simp)
 
 /-- `FreeAlgebra R X` is nontrivial when `R` is. -/
 instance [Nontrivial R] : Nontrivial (FreeAlgebra R X) :=

--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -203,20 +203,32 @@ def liftNCAlgHom (f : A →ₐ[R] B) (g : M →* B) (h_comm : ∀ x y, Commute (
 @[simp] lemma coe_liftNCAlgHom (f : A →ₐ[R] B) (g : M →* B) (h_comm) :
     ⇑(liftNCAlgHom f g h_comm) = liftNC f g := rfl
 
-/-- A `R`-algebra homomorphism from `R[M]` is uniquely defined by its
-values on the functions `single a 1`. -/
-@[to_additive (dont_translate := R) /--
-A `R`-algebra homomorphism from `R[M]` is uniquely defined by its
-values on the functions `single a 1`. -/]
-theorem algHom_ext ⦃φ₁ φ₂ : R[M] →ₐ[R] A⦄ (h : ∀ x, φ₁ (single x 1) = φ₂ (single x 1)) : φ₁ = φ₂ :=
-  AlgHom.toLinearMap_injective <| lhom_ext' fun a ↦ LinearMap.ext_ring (h a)
-
 -- The priority must be `high`.
-/-- See note [partially-applied ext lemmas]. -/
-@[ext high]
-theorem algHom_ext' ⦃φ₁ φ₂ : R[M] →ₐ[R] A⦄
-    (h : (φ₁ : R[M] →* A).comp (of R M) = (φ₂ : R[M] →* A).comp (of R M)) : φ₁ = φ₂ :=
-  algHom_ext <| DFunLike.congr_fun h
+/-- A `R`-algebra homomorphism from `A[M]` is uniquely defined by its
+values on the functions `single m 1` and `single 1 a`.
+
+See note [partially-applied ext lemmas]. Note that the first assumption isn't written as an
+equality of `MonoidHom`s because `of` doesn't additivise. -/
+@[to_additive (dont_translate := R A B) (attr := ext high) /--
+A `R`-algebra homomorphism from `R[M]` is uniquely defined by its
+values on the functions `single m 1` and `single 1 a`.
+
+See note [partially-applied ext lemmas]. Note that the first assumption isn't written as an
+equality of `AddMonoidHom`s because `of` doesn't multiplicativise. -/]
+lemma algHom_ext ⦃φ₁ φ₂ : A[M] →ₐ[R] B⦄ (single_one_right : ∀ m, φ₁ (single m 1) = φ₂ (single m 1))
+    (single_one_left : φ₁.comp singleOneAlgHom = φ₂.comp singleOneAlgHom) :
+    φ₁ = φ₂ := by
+  ext x
+  induction x using induction_linear with
+  | zero => simp
+  | add => simp_all
+  | single m a => simpa [← map_mul] using congr($(single_one_right m) * $single_one_left a)
+
+/-- Version of `algHom_ext` where both assumptions are written as equalities of bundled homs. -/
+lemma algHom_ext' ⦃φ₁ φ₂ : A[M] →ₐ[R] B⦄
+    (single_one_right : (φ₁ : A[M] →* B).comp (of A M) = (φ₂ : A[M] →* B).comp (of A M))
+    (single_one_left : φ₁.comp singleOneAlgHom = φ₂.comp singleOneAlgHom) : φ₁ = φ₂ :=
+  algHom_ext (congr($single_one_right ·)) single_one_left
 
 variable (R A M) in
 /-- Any monoid homomorphism `M →* A` can be lifted to an algebra homomorphism `R[M] →ₐ[R] A`. -/
@@ -276,14 +288,13 @@ def mapDomainAlgHom (f : M →* N) : A[M] →ₐ[R] A[N] where
   toRingHom := mapDomainRingHom A f
   commutes' := by simp
 
-@[to_additive (attr := simp)]
-lemma mapDomainAlgHom_id : mapDomainAlgHom R A (.id M) = .id R A[M] := by
-  ext; simp [MonoidHom.id, ← Function.id_def]
+@[to_additive (dont_translate := A) (attr := simp)]
+lemma mapDomainAlgHom_id : mapDomainAlgHom R A (.id M) = .id R A[M] := by ext <;> simp
 
-@[to_additive (attr := simp)]
+@[to_additive (dont_translate := A) (attr := simp)]
 lemma mapDomainAlgHom_comp (f : M →* N) (g : N →* O) :
     mapDomainAlgHom R A (g.comp f) = (mapDomainAlgHom R A g).comp (mapDomainAlgHom R A f) := by
-  ext; simp [mapDomain_comp]
+  ext <;> simp
 
 variable (R A) in
 /-- If `e : M ≃* N` is a multiplicative equivalence between two monoids, then
@@ -407,16 +418,12 @@ lemma mapAlgHom_single (f : A →ₐ[R] B) (m : M) (a : A) :
     mapAlgHom M f (single m a) = single m (f a) := by
   classical ext; simp [single_apply, apply_ite f]
 
-@[to_additive (attr := simp)]
-lemma mapAlgHom_id {k R G} [CommSemiring k] [Semiring R] [Algebra k R] [Monoid G] :
-    mapAlgHom G (AlgHom.id k R) = AlgHom.id k (MonoidAlgebra R G) := by
-  ext; simp
+@[to_additive (dont_translate := A) (attr := simp)]
+lemma mapAlgHom_id : mapAlgHom M (.id R A) = .id R A[M] := by ext <;> simp
 
-@[to_additive (attr := simp)]
-lemma mapRangeAlgHom_comp {k R S T G} [CommSemiring k] [Semiring R] [Algebra k R] [Semiring S]
-    [Algebra k S] [Semiring T] [Algebra k T] [Monoid G] (f : R →ₐ[k] S) (g : S →ₐ[k] T) :
-    mapAlgHom G (g.comp f) = (mapAlgHom G g).comp (mapAlgHom G f) := by
-  ext; simp
+@[to_additive (dont_translate := A B C) (attr := simp)]
+lemma mapRangeAlgHom_comp (f : A →ₐ[R] B) (g : B →ₐ[R] C) :
+    mapAlgHom M (g.comp f) = (mapAlgHom M g).comp (mapAlgHom M f) := by ext <;> simp
 
 @[deprecated (since := "2026-06-18")] alias mapRangeAlgHom_single := mapAlgHom_single
 
@@ -580,12 +587,11 @@ def liftNCAlgHom (f : A →ₐ[R] B) (g : Multiplicative M →* B) (h_comm : ∀
 @[simp] lemma coe_liftNCAlgHom (f : A →ₐ[R] B) (g : Multiplicative M →* B) (h_comm) :
     ⇑(liftNCAlgHom f g h_comm) = liftNC f g := rfl
 
-/-- See note [partially-applied ext lemmas]. -/
-@[ext high]
-theorem algHom_ext' ⦃φ₁ φ₂ : R[M] →ₐ[R] A⦄
-    (h : (φ₁ : R[M] →* A).comp (of R M) = (φ₂ : R[M] →* A).comp (of R M)) :
-    φ₁ = φ₂ :=
-  algHom_ext <| DFunLike.congr_fun h
+/-- Version of `algHom_ext` where both assumptions are written as equalities of bundled homs. -/
+lemma algHom_ext' ⦃φ₁ φ₂ : A[M] →ₐ[R] B⦄
+    (single_one_right : (φ₁ : A[M] →* B).comp (of A M) = (φ₂ : A[M] →* B).comp (of A M))
+    (single_one_left : φ₁.comp singleZeroAlgHom = φ₂.comp singleZeroAlgHom) : φ₁ = φ₂ :=
+  algHom_ext (congr($single_one_right ·)) single_one_left
 
 variable (R M A) in
 /-- Any monoid homomorphism `M →* A` can be lifted to an algebra homomorphism
@@ -645,9 +651,6 @@ lemma lift_mapRingHom_algebraMap [CommSemiring S] [Algebra S A] [Algebra R S] [I
 
 @[deprecated (since := "2026-06-18")]
 alias lift_mapRangeRingHom_algebraMap := lift_mapRingHom_algebraMap
-
-lemma algHom_ext_iff {φ₁ φ₂ : R[M] →ₐ[R] A} : (∀ x, φ₁ (single x 1) = φ₂ (single x 1)) ↔ φ₁ = φ₂ :=
-  ⟨fun h => algHom_ext h, by rintro rfl _; rfl⟩
 
 variable (R A) in
 /-- `AddMonoidAlgebra.domCongr` as an `AddMonoidHom` from `AddAut`. -/

--- a/Mathlib/Algebra/MonoidAlgebra/Grading.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Grading.lean
@@ -155,12 +155,7 @@ theorem decomposeAux_coe {i : ι} (x : gradeBy R f i) :
     congr 2
 
 instance gradeBy.gradedAlgebra : GradedAlgebra (gradeBy R f) :=
-  GradedAlgebra.ofAlgHom _ (decomposeAux f)
-    (by
-      ext : 4
-      dsimp
-      rw [decomposeAux_single, DirectSum.coeAlgHom_of, Subtype.coe_mk])
-    fun i x => by rw [decomposeAux_coe f x]
+  .ofAlgHom _ (decomposeAux f) (by ext; simp [decomposeAux_single]) <| by simp [decomposeAux_coe]
 
 @[simp]
 theorem decomposeAux_eq_decompose :

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -419,7 +419,7 @@ theorem is_id (f : MvPolynomial σ R →+* MvPolynomial σ R) (hC : f.comp C = C
 
 /-- See note [partially-applied ext lemmas].
 
-We set the priority higher than that of `AddMonoidAlgebra.algHom_ext'`. -/
+We set the priority higher than that of `AddMonoidAlgebra.algHom_ext`. -/
 @[ext high + 1]
 theorem algHom_ext' {A B : Type*} [CommSemiring A] [CommSemiring B] [Algebra R A] [Algebra R B]
     {f g : MvPolynomial σ A →ₐ[R] B}
@@ -435,7 +435,7 @@ We set the priority higher than that of `MvPolynomial.algHom_ext'`. -/
 @[ext high + 2]
 theorem algHom_ext {A : Type*} [Semiring A] [Algebra R A] {f g : MvPolynomial σ R →ₐ[R] A}
     (hf : ∀ i : σ, f (X i) = g (X i)) : f = g :=
-  AddMonoidAlgebra.algHom_ext' (mulHom_ext' fun X : σ => MonoidHom.ext_mnat (hf X))
+  AddMonoidAlgebra.algHom_ext' (mulHom_ext' fun X : σ => MonoidHom.ext_mnat (hf X)) (by ext)
 
 @[simp]
 theorem algHom_C {A : Type*} [Semiring A] [Algebra R A] (f : MvPolynomial σ R →ₐ[R] A) (r : R) :


### PR DESCRIPTION
Generalise `algHom_ext` and `algHom_ext` from `R[M] →ₐ[R] A` to `A[M] →ₐ[R] B` by adding a second hypothesis that is automatically satisfied for `R[M] →ₐ[R] A` (see `AlgHom.ext_id`).

Since the new extensionality lemma is more general, it applies in a bunch more places. Unfortunately, if it is stated using `MonoidAlgebra.of` then it isn't additivisable, meaning that a lot of previously additivised lemmas must now be written by hand. I therefore decided to drop the `of` spelling by unbundling the first hypothesis. This is justified by the fact that the users of the more bundled ext lemma are for `M := Nat`, `Int` or `Free(Abelian)Group`, none of which can be additivised.

`algHom_ext` is now the partially bundled version, tagged with `ext`, and `algHom_ext'` the fully bundled version.

From Toric


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
