### PR TITLE
[Merged by Bors] - feat(Algebra/Algebra/Tower): add `restrictScalarsHom`

### DIFF
--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -323,6 +323,11 @@ def extendScalarsHomOfSurjective (h : Function.Surjective ⇑(algebraMap R S)) :
   __ := extendScalarsOfSurjective h
   map_mul' _ _ := rfl
 
+@[simp]
+lemma toMonoidHom_symm_extendScalarsHomOfSurjective (h : Function.Surjective (algebraMap R S)) :
+    (extendScalarsHomOfSurjective h (A := A).symm : (A ≃ₐ[S] A) →* _) = restrictScalarsHom R :=
+  rfl
+
 end
 
 end AlgEquiv

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -267,6 +267,23 @@ lemma coe_restrictScalars_symm (f : A ≃ₐ[S] B) :
 lemma coe_restrictScalars_symm' (f : A ≃ₐ[S] B) :
     ((restrictScalars R f).symm : B → A) = f.symm := rfl
 
+/-- `AlgEquiv.restrictScalars` as a homomorphism. -/
+def restrictScalarsHom : (A ≃ₐ[S] A) →* (A ≃ₐ[R] A) :=
+  MulSemiringAction.toAlgAut (A ≃ₐ[S] A) R A
+
+@[simp]
+theorem restrictScalarsHom_apply (f : A ≃ₐ[S] A) : f.restrictScalarsHom R = f.restrictScalars R :=
+  rfl
+
+@[simp]
+theorem restrictScalarsHom_apply_symm (f : A ≃ₐ[S] A) :
+    f.symm.restrictScalarsHom R = (f.restrictScalars R).symm :=
+  rfl
+
+theorem restrictScalarsHom_injective :
+    Function.Injective (restrictScalarsHom R : (A ≃ₐ[S] A) →* (A ≃ₐ[R] A)) :=
+  restrictScalars_injective R
+
 section
 
 variable {R}

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -271,7 +271,6 @@ lemma coe_restrictScalars_symm' (f : A ≃ₐ[S] B) :
 def restrictScalarsHom : (A ≃ₐ[S] A) →* (A ≃ₐ[R] A) :=
   MulSemiringAction.toAlgAut (A ≃ₐ[S] A) R A
 
-@[simp]
 theorem restrictScalarsHom_apply (f : A ≃ₐ[S] A) : f.restrictScalarsHom R = f.restrictScalars R :=
   rfl
 

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -247,10 +247,12 @@ theorem restrictScalars_apply (f : A ≃ₐ[S] B) (x : A) : f.restrictScalars R 
     (f.restrictScalars R).toLinearEquiv = f.toLinearEquiv.restrictScalars R := rfl
 
 @[simp]
-theorem coe_restrictScalars (f : A ≃ₐ[S] B) : (f.restrictScalars R : A ≃+* B) = f := rfl
+theorem toMulEquiv_restrictScalars (f : A ≃ₐ[S] B) : (f.restrictScalars R : A ≃+* B) = f := rfl
 
 @[simp]
-theorem coe_restrictScalars' (f : A ≃ₐ[S] B) : (restrictScalars R f : A → B) = f := rfl
+theorem coe_restrictScalars (f : A ≃ₐ[S] B) : (restrictScalars R f : A → B) = f := rfl
+
+@[deprecated (since := "2026-07-06")] alias coe_restrictScalars' := coe_restrictScalars
 
 theorem restrictScalars_injective :
     Function.Injective (restrictScalars R : (A ≃ₐ[S] B) → A ≃ₐ[R] B) := fun _ _ h =>
@@ -260,12 +262,14 @@ lemma restrictScalars_symm_apply (f : A ≃ₐ[S] B) (x : B) :
     (f.restrictScalars R).symm x = f.symm x := rfl
 
 @[simp]
-lemma coe_restrictScalars_symm (f : A ≃ₐ[S] B) :
+lemma toMulEquiv_restrictScalars_symm (f : A ≃ₐ[S] B) :
     ((f.restrictScalars R).symm : B ≃+* A) = f.symm := rfl
 
 @[simp]
-lemma coe_restrictScalars_symm' (f : A ≃ₐ[S] B) :
+lemma coe_restrictScalars_symm (f : A ≃ₐ[S] B) :
     ((restrictScalars R f).symm : B → A) = f.symm := rfl
+
+@[deprecated (since := "2026-07-06")] alias coe_restrictScalars_symm' := coe_restrictScalars_symm
 
 /-- `AlgEquiv.restrictScalars` as a homomorphism. -/
 def restrictScalarsHom : (A ≃ₐ[S] A) →* (A ≃ₐ[R] A) :=
@@ -276,8 +280,8 @@ theorem restrictScalarsHom_apply (f : A ≃ₐ[S] A) : f.restrictScalarsHom R = 
   rfl
 
 @[simp]
-theorem restrictScalarsHom_apply_symm (f : A ≃ₐ[S] A) :
-    f.symm.restrictScalarsHom R = (f.restrictScalars R).symm :=
+theorem restrictScalars_symm (f : A ≃ₐ[S] B) :
+    f.symm.restrictScalars R = (f.restrictScalars R).symm :=
   rfl
 
 theorem restrictScalarsHom_injective :

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -258,6 +258,12 @@ theorem restrictScalars_injective :
     Function.Injective (restrictScalars R : (A ≃ₐ[S] B) → A ≃ₐ[R] B) := fun _ _ h =>
   AlgEquiv.ext (AlgEquiv.congr_fun h :)
 
+@[simp]
+lemma restrictScalars_symm (f : A ≃ₐ[S] B) :
+    f.symm.restrictScalars R = (f.restrictScalars R).symm :=
+  rfl
+
+@[simp]
 lemma restrictScalars_symm_apply (f : A ≃ₐ[S] B) (x : B) :
     (f.restrictScalars R).symm x = f.symm x := rfl
 
@@ -275,12 +281,8 @@ lemma coe_restrictScalars_symm (f : A ≃ₐ[S] B) :
 def restrictScalarsHom : (A ≃ₐ[S] A) →* (A ≃ₐ[R] A) :=
   MulSemiringAction.toAlgAut (A ≃ₐ[S] A) R A
 
-theorem restrictScalarsHom_apply (f : A ≃ₐ[S] A) : f.restrictScalarsHom R = f.restrictScalars R :=
-  rfl
-
 @[simp]
-theorem restrictScalars_symm (f : A ≃ₐ[S] B) :
-    f.symm.restrictScalars R = (f.restrictScalars R).symm :=
+theorem restrictScalarsHom_apply (f : A ≃ₐ[S] A) : f.restrictScalarsHom R = f.restrictScalars R :=
   rfl
 
 theorem restrictScalarsHom_injective :

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -247,7 +247,7 @@ theorem restrictScalars_apply (f : A ≃ₐ[S] B) (x : A) : f.restrictScalars R 
     (f.restrictScalars R).toLinearEquiv = f.toLinearEquiv.restrictScalars R := rfl
 
 @[simp]
-theorem toMulEquiv_restrictScalars (f : A ≃ₐ[S] B) : (f.restrictScalars R : A ≃+* B) = f := rfl
+theorem toRingEquiv_restrictScalars (f : A ≃ₐ[S] B) : (f.restrictScalars R : A ≃+* B) = f := rfl
 
 @[simp]
 theorem coe_restrictScalars (f : A ≃ₐ[S] B) : (restrictScalars R f : A → B) = f := rfl
@@ -262,7 +262,7 @@ lemma restrictScalars_symm_apply (f : A ≃ₐ[S] B) (x : B) :
     (f.restrictScalars R).symm x = f.symm x := rfl
 
 @[simp]
-lemma toMulEquiv_restrictScalars_symm (f : A ≃ₐ[S] B) :
+lemma toRingEquiv_restrictScalars_symm (f : A ≃ₐ[S] B) :
     ((f.restrictScalars R).symm : B ≃+* A) = f.symm := rfl
 
 @[simp]

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -263,14 +263,17 @@ lemma restrictScalars_symm (f : A ≃ₐ[S] B) :
     (f.restrictScalars R).symm = f.symm.restrictScalars R :=
   rfl
 
+@[deprecated "Use `restrictScalars_symm` instead." (since := "2026-07-06")]
 lemma restrictScalars_symm_apply (f : A ≃ₐ[S] B) (x : B) :
     (f.restrictScalars R).symm x = f.symm x := by
   simp
 
+@[deprecated "Use `restrictScalars_symm` instead." (since := "2026-07-06")]
 lemma toRingEquiv_restrictScalars_symm (f : A ≃ₐ[S] B) :
     ((f.restrictScalars R).symm : B ≃+* A) = f.symm := by
   simp
 
+@[deprecated "Use `restrictScalars_symm` instead." (since := "2026-07-06")]
 lemma coe_restrictScalars_symm (f : A ≃ₐ[S] B) :
     ((restrictScalars R f).symm : B → A) = f.symm := by
   simp

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -259,21 +259,21 @@ theorem restrictScalars_injective :
   AlgEquiv.ext (AlgEquiv.congr_fun h :)
 
 @[simp]
-lemma restrictScalars_symm (f : A ≃ₐ[S] B) :
+lemma symm_restrictScalars (f : A ≃ₐ[S] B) :
     (f.restrictScalars R).symm = f.symm.restrictScalars R :=
   rfl
 
-@[deprecated "Use `restrictScalars_symm` instead." (since := "2026-07-06")]
+@[deprecated "Use `symm_restrictScalars` instead." (since := "2026-07-06")]
 lemma restrictScalars_symm_apply (f : A ≃ₐ[S] B) (x : B) :
     (f.restrictScalars R).symm x = f.symm x := by
   simp
 
-@[deprecated "Use `restrictScalars_symm` instead." (since := "2026-07-06")]
+@[deprecated "Use `symm_restrictScalars` instead." (since := "2026-07-06")]
 lemma toRingEquiv_restrictScalars_symm (f : A ≃ₐ[S] B) :
     ((f.restrictScalars R).symm : B ≃+* A) = f.symm := by
   simp
 
-@[deprecated "Use `restrictScalars_symm` instead." (since := "2026-07-06")]
+@[deprecated "Use `symm_restrictScalars` instead." (since := "2026-07-06")]
 lemma coe_restrictScalars_symm (f : A ≃ₐ[S] B) :
     ((restrictScalars R f).symm : B → A) = f.symm := by
   simp

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -269,16 +269,14 @@ lemma restrictScalars_symm_apply (f : A ≃ₐ[S] B) (x : B) :
   simp
 
 @[deprecated "Use `symm_restrictScalars` instead." (since := "2026-07-06")]
-lemma toRingEquiv_restrictScalars_symm (f : A ≃ₐ[S] B) :
+lemma coe_restrictScalars_symm (f : A ≃ₐ[S] B) :
     ((f.restrictScalars R).symm : B ≃+* A) = f.symm := by
   simp
 
 @[deprecated "Use `symm_restrictScalars` instead." (since := "2026-07-06")]
-lemma coe_restrictScalars_symm (f : A ≃ₐ[S] B) :
+lemma coe_restrictScalars_symm' (f : A ≃ₐ[S] B) :
     ((restrictScalars R f).symm : B → A) = f.symm := by
   simp
-
-@[deprecated (since := "2026-07-06")] alias coe_restrictScalars_symm' := coe_restrictScalars_symm
 
 /-- `AlgEquiv.restrictScalars` as a homomorphism. -/
 def restrictScalarsHom : (A ≃ₐ[S] A) →* (A ≃ₐ[R] A) :=

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -260,20 +260,20 @@ theorem restrictScalars_injective :
 
 @[simp]
 lemma restrictScalars_symm (f : A ≃ₐ[S] B) :
-    f.symm.restrictScalars R = (f.restrictScalars R).symm :=
+    (f.restrictScalars R).symm = f.symm.restrictScalars R :=
   rfl
 
-@[simp]
 lemma restrictScalars_symm_apply (f : A ≃ₐ[S] B) (x : B) :
-    (f.restrictScalars R).symm x = f.symm x := rfl
+    (f.restrictScalars R).symm x = f.symm x := by
+  simp
 
-@[simp]
 lemma toRingEquiv_restrictScalars_symm (f : A ≃ₐ[S] B) :
-    ((f.restrictScalars R).symm : B ≃+* A) = f.symm := rfl
+    ((f.restrictScalars R).symm : B ≃+* A) = f.symm := by
+  simp
 
-@[simp]
 lemma coe_restrictScalars_symm (f : A ≃ₐ[S] B) :
-    ((restrictScalars R f).symm : B → A) = f.symm := rfl
+    ((restrictScalars R f).symm : B → A) = f.symm := by
+  simp
 
 @[deprecated (since := "2026-07-06")] alias coe_restrictScalars_symm' := coe_restrictScalars_symm
 

--- a/Mathlib/RingTheory/Smooth/IntegralClosure.lean
+++ b/Mathlib/RingTheory/Smooth/IntegralClosure.lean
@@ -177,7 +177,7 @@ lemma TensorProduct.toIntegralClosure_bijective_of_isLocalization
   convert!
     (IsLocalization.algEquiv (Algebra.algebraMapSubmonoid (integralClosure R B) M)
         (S ⊗[R] integralClosure R B) (integralClosure S (S ⊗[R] B))).bijective
-  rw [← AlgHom.coe_restrictScalars' R, ← AlgEquiv.coe_restrictScalars' R, ← AlgEquiv.coe_toAlgHom]
+  rw [← AlgHom.coe_restrictScalars' R, ← AlgEquiv.coe_restrictScalars R, ← AlgEquiv.coe_toAlgHom]
   congr 1
   ext1
   · apply IsLocalization.algHom_ext M; ext


### PR DESCRIPTION
This PR adds `AlgEquiv.restrictScalarsHom`, analogous to the existing `AlgEquiv.extendScalarsHomOfSurjective`.

This PR also renames `coe_restrictScalars -> toRingEquiv_restrictScalars` without a deprecation to make way for `coe_restrictScalars' -> coe_restrictScalars`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
