### PR TITLE
[Merged by Bors] - feat: a function which is continuous outside of a countable set is strongly measurable

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -498,7 +498,7 @@ is ae-measurable. -/
 theorem Continuous.aemeasurable {f : α → γ} (h : Continuous f) {μ : Measure α} : AEMeasurable f μ :=
   h.measurable.aemeasurable
 
-/-- If a function is continuous outside of a countable set, then it is measurable. -/
+/-- If a function is continuous outside of a countable set, it is measurable. -/
 theorem ContinuousOn.measurable_of_countable_compl [MeasurableSingletonClass α]
     {f : α → γ} {s : Set α} (hf : ContinuousOn f s)
     (hs : (sᶜ).Countable) : Measurable f := by

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -498,6 +498,22 @@ is ae-measurable. -/
 theorem Continuous.aemeasurable {f : α → γ} (h : Continuous f) {μ : Measure α} : AEMeasurable f μ :=
   h.measurable.aemeasurable
 
+/-- If a function is continuous outside of a countable set, then it is measurable. -/
+theorem ContinuousOn.measurable_of_countable_compl [MeasurableSingletonClass α]
+    {f : α → γ} {s : Set α} (hf : ContinuousOn f s)
+    (hs : (sᶜ).Countable) : Measurable f := by
+  apply measurable_of_measurable_on_compl_countable _ hs
+  rw [compl_compl]
+  exact (continuousOn_iff_continuous_restrict.1 hf).measurable
+
+/-- If a function is continuous outside of a countable set, then it is measurable. -/
+theorem measurable_of_countable_not_continuousAt [MeasurableSingletonClass α]
+    {f : α → γ} (hf : Set.Countable {x | ¬ ContinuousAt f x}) : Measurable f := by
+  have : ContinuousOn f {x | ContinuousAt f x} := fun x hx ↦ hx.continuousWithinAt
+  apply this.measurable_of_countable_compl
+  convert hf
+  grind
+
 theorem Topology.IsClosedEmbedding.measurable {f : α → γ} (hf : IsClosedEmbedding f) :
     Measurable f :=
   hf.continuous.measurable

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -500,8 +500,7 @@ theorem Continuous.aemeasurable {f : α → γ} (h : Continuous f) {μ : Measure
 
 /-- If a function is continuous outside of a countable set, it is measurable. -/
 theorem ContinuousOn.measurable_of_countable_compl [MeasurableSingletonClass α]
-    {f : α → γ} {s : Set α} (hf : ContinuousOn f s)
-    (hs : (sᶜ).Countable) : Measurable f := by
+    {f : α → γ} {s : Set α} (hf : ContinuousOn f s) (hs : (sᶜ).Countable) : Measurable f := by
   apply measurable_of_measurable_on_compl_countable _ hs
   rw [compl_compl]
   exact (continuousOn_iff_continuous_restrict.1 hf).measurable

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -221,6 +221,16 @@ theorem piecewise_same (f : α →ₛ β) {s : Set α} (hs : MeasurableSet s) :
     piecewise s hs f f = f :=
   coe_injective <| Set.piecewise_same _ _
 
+open scoped Classical in
+/-- Dependent If-then-else as a `SimpleFunc`. -/
+@[simps]
+def dite (s : Set α) (hs : MeasurableSet s) (f : s →ₛ β) (g : (sᶜ : Set α) →ₛ β) : α →ₛ β where
+  toFun x := if hx : x ∈ s then f ⟨x, hx⟩ else g ⟨x, hx⟩
+  measurableSet_fiber' x := by
+    letI : MeasurableSpace β := ⊤
+    exact Measurable.dite f.measurable g.measurable hs trivial
+  finite_range' := (f.finite_range.union g.finite_range).subset (by grind)
+
 theorem support_indicator [Zero β] {s : Set α} (hs : MeasurableSet s) (f : α →ₛ β) :
     Function.support (f.piecewise s hs (SimpleFunc.const α 0)) = s ∩ Function.support f :=
   Set.support_indicator

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -221,12 +221,12 @@ theorem piecewise_same (f : α →ₛ β) {s : Set α} (hs : MeasurableSet s) :
     piecewise s hs f f = f :=
   coe_injective <| Set.piecewise_same _ _
 
-open scoped Classical in
 /-- Dependent If-then-else as a `SimpleFunc`. -/
 @[simps]
 def dite (s : Set α) (hs : MeasurableSet s) (f : s →ₛ β) (g : (sᶜ : Set α) →ₛ β) : α →ₛ β where
-  toFun x := if hx : x ∈ s then f ⟨x, hx⟩ else g ⟨x, hx⟩
+  toFun x := open scoped Classical in if hx : x ∈ s then f ⟨x, hx⟩ else g ⟨x, hx⟩
   measurableSet_fiber' x := by
+    classical
     letI : MeasurableSpace β := ⊤
     exact Measurable.dite f.measurable g.measurable hs trivial
   finite_range' := (f.finite_range.union g.finite_range).subset (by grind)

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -821,7 +821,7 @@ protected theorem dite {s : Set α} {m : MeasurableSpace α} [TopologicalSpace �
     [(x : α) → Decidable (x ∈ s)] {f : ↑s → β} (hf : StronglyMeasurable f)
     {g : ↑sᶜ → β} (hg : StronglyMeasurable g) (hs : MeasurableSet s) :
     StronglyMeasurable fun x ↦ if hx : x ∈ s then f ⟨x, hx⟩ else g ⟨x, hx⟩ := by
-  refine ⟨fun n => SimpleFunc.dite s hs (hf.approx n) (hg.approx n), fun x => ?_⟩
+  refine ⟨fun n ↦ SimpleFunc.dite s hs (hf.approx n) (hg.approx n), fun x ↦ ?_⟩
   by_cases hx : x ∈ s
   · simpa [hx] using hf.tendsto_approx ⟨x, hx⟩
   · simpa [hx] using hg.tendsto_approx ⟨x, hx⟩
@@ -836,7 +836,7 @@ theorem _root_.ContinuousOn.stronglyMeasurable_of_countable_compl [MeasurableSpa
   have h's : MeasurableSet s := by simpa using hs.measurableSet.compl
   have : f = fun x ↦ if hx : x ∈ s then f (⟨x, hx⟩ : s) else f (⟨x, hx⟩ : (sᶜ : Set α)) := by simp
   rw [this]
-  apply StronglyMeasurable.dite (f := f) (g := f) ?_ ?_ h's
+  apply StronglyMeasurable.dite (f := fun x ↦ f x) (g := fun x ↦ f x) ?_ ?_ h's
   · have : SecondCountableTopologyEither s β := by cases h.out <;> infer_instance
     exact (continuousOn_iff_continuous_restrict.1 hf).stronglyMeasurable
   · have := hs.to_subtype

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -836,7 +836,7 @@ theorem _root_.ContinuousOn.stronglyMeasurable_of_countable_compl [MeasurableSpa
   have h's : MeasurableSet s := by simpa using hs.measurableSet.compl
   have : f = fun x ↦ if hx : x ∈ s then f (⟨x, hx⟩ : s) else f (⟨x, hx⟩ : (sᶜ : Set α)) := by simp
   rw [this]
-  apply StronglyMeasurable.dite (f := fun x ↦ f x) (g := fun x ↦ f x) ?_ ?_ h's
+  apply StronglyMeasurable.dite (f := f) (g := f) ?_ ?_ h's
   · have : SecondCountableTopologyEither s β := by cases h.out <;> infer_instance
     exact (continuousOn_iff_continuous_restrict.1 hf).stronglyMeasurable
   · have := hs.to_subtype

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -817,6 +817,42 @@ protected theorem ite {_ : MeasurableSpace α} [TopologicalSpace β] {p : α →
     (hg : StronglyMeasurable g) : StronglyMeasurable fun x => ite (p x) (f x) (g x) :=
   StronglyMeasurable.piecewise hp hf hg
 
+protected theorem dite {s : Set α} {m : MeasurableSpace α} [TopologicalSpace β]
+    [(x : α) → Decidable (x ∈ s)] {f : ↑s → β} (hf : StronglyMeasurable f)
+    {g : ↑sᶜ → β} (hg : StronglyMeasurable g) (hs : MeasurableSet s) :
+    StronglyMeasurable fun x ↦ if hx : x ∈ s then f ⟨x, hx⟩ else g ⟨x, hx⟩ := by
+  refine ⟨fun n => SimpleFunc.dite s hs (hf.approx n) (hg.approx n), fun x => ?_⟩
+  by_cases hx : x ∈ s
+  · simpa [hx] using hf.tendsto_approx ⟨x, hx⟩
+  · simpa [hx] using hg.tendsto_approx ⟨x, hx⟩
+
+/-- If a function is continuous outside of a countable set, then it is strongly measurable. -/
+theorem _root_.ContinuousOn.stronglyMeasurable_of_countable_compl [MeasurableSpace α]
+    [TopologicalSpace α] [OpensMeasurableSpace α] [MeasurableSingletonClass α]
+    [TopologicalSpace β] [PseudoMetrizableSpace β]
+    [h : SecondCountableTopologyEither α β] {f : α → β} {s : Set α} (hf : ContinuousOn f s)
+    (hs : (sᶜ).Countable) : StronglyMeasurable f := by
+  classical
+  have h's : MeasurableSet s := by simpa using hs.measurableSet.compl
+  have : f = fun x ↦ if hx : x ∈ s then f (⟨x, hx⟩ : s) else f (⟨x, hx⟩ : (sᶜ : Set α)) := by simp
+  rw [this]
+  apply StronglyMeasurable.dite (f := fun x ↦ f x) (g := fun x ↦ f x) ?_ ?_ h's
+  · have : SecondCountableTopologyEither s β := by cases h.out <;> infer_instance
+    exact (continuousOn_iff_continuous_restrict.1 hf).stronglyMeasurable
+  · have := hs.to_subtype
+    exact MeasureTheory.StronglyMeasurable.of_discrete
+
+/-- If a function is continuous outside of a countable set, then it is strongly measurable. -/
+theorem of_countable_not_continuousAt [MeasurableSpace α] [TopologicalSpace α]
+    [OpensMeasurableSpace α] [MeasurableSingletonClass α]
+    [TopologicalSpace β] [PseudoMetrizableSpace β]
+    [h : SecondCountableTopologyEither α β] {f : α → β}
+    (hf : Set.Countable {x | ¬ ContinuousAt f x}) : StronglyMeasurable f := by
+  have : ContinuousOn f {x | ContinuousAt f x} := fun x hx ↦ hx.continuousWithinAt
+  apply this.stronglyMeasurable_of_countable_compl
+  convert hf
+  grind
+
 @[fun_prop]
 theorem _root_.MeasurableEmbedding.stronglyMeasurable_extend {f : α → β} {g : α → γ} {g' : γ → β}
     {mα : MeasurableSpace α} {mγ : MeasurableSpace γ} [TopologicalSpace β]

--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -279,6 +279,11 @@ theorem measurable_of_measurable_on_compl_finite [MeasurableSingletonClass α] {
   have := hs.to_subtype
   measurable_of_restrict_of_restrict_compl hs.measurableSet (measurable_of_finite _) hf
 
+theorem measurable_of_measurable_on_compl_countable [MeasurableSingletonClass α] {f : α → β}
+    (s : Set α) (hs : s.Countable) (hf : Measurable (sᶜ.restrict f)) : Measurable f :=
+  have := hs.to_subtype
+  measurable_of_restrict_of_restrict_compl hs.measurableSet (measurable_of_countable _) hf
+
 theorem measurable_of_measurable_on_compl_singleton [MeasurableSingletonClass α] {f : α → β} (a : α)
     (hf : Measurable ({ x | x ≠ a }.restrict f)) : Measurable f :=
   measurable_of_measurable_on_compl_finite {a} (finite_singleton a) hf


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
