### PR TITLE
[Merged by Bors] - fix(Util/AddRelatedDecl): error instead of panicking when the target declaration already exists

### DIFF
--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -69,16 +69,17 @@ def addRelatedDecl (src tgt : Name) (ref : Syntax)
   -- If `tgt` already exists in an imported module, the `addDeclarationRangesFromSyntax` call
   -- below panics (and if it exists in the current module, `addDecl` would fail with a less
   -- helpful message), so we check for a pre-existing declaration up front.
-  let env := (← getEnv).setExporting false
-  if env.contains tgt then
-    match env.getModuleIdxFor? tgt with
-    | some idx =>
-      throwError "cannot create related declaration `{tgt}`: \
-        it has already been declared in the imported module \
-        `{env.header.moduleNames[idx.toNat]!}`"
-    | none =>
-      throwError "cannot create related declaration `{tgt}`: \
-        it has already been declared in the current module"
+  withoutExporting do
+    let env ← getEnv
+    if env.contains tgt then
+      match env.getModuleIdxFor? tgt with
+      | some idx =>
+        throwError "cannot create related declaration `{tgt}`: \
+          it has already been declared in the imported module \
+          `{env.header.moduleNames[idx.toNat]!}`"
+      | none =>
+        throwError "cannot create related declaration `{tgt}`: \
+          it has already been declared in the current module"
   addDeclarationRangesFromSyntax tgt (← getRef) ref
   let info ← withoutExporting <| getConstInfo src
   let value := .const src (info.levelParams.map mkLevelParam)

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -34,6 +34,8 @@ and has been factored out to avoid code duplication.
 Feel free to add features as needed for other applications.
 
 This helper:
+* throws an error if a declaration named `tgt` already exists
+  (in the current module or in an imported one),
 * calls `addDeclarationRangesFromSyntax`, so jump-to-definition works,
 * copies the `protected` status of the existing declaration, and
 * supports copying attributes.
@@ -64,6 +66,19 @@ def addRelatedDecl (src tgt : Name) (ref : Syntax)
     (docstringPrefix? : Option String := none)
     (hoverInfo : Bool := false) :
     MetaM Unit := do
+  -- If `tgt` already exists in an imported module, the `addDeclarationRangesFromSyntax` call
+  -- below panics (and if it exists in the current module, `addDecl` would fail with a less
+  -- helpful message), so we check for a pre-existing declaration up front.
+  let env := (← getEnv).setExporting false
+  if env.contains tgt then
+    match env.getModuleIdxFor? tgt with
+    | some idx =>
+      throwError "cannot create related declaration `{tgt}`: \
+        it has already been declared in the imported module \
+        `{env.header.moduleNames[idx.toNat]!}`"
+    | none =>
+      throwError "cannot create related declaration `{tgt}`: \
+        it has already been declared in the current module"
   addDeclarationRangesFromSyntax tgt (← getRef) ref
   let info ← withoutExporting <| getConstInfo src
   let value := .const src (info.levelParams.map mkLevelParam)

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -69,17 +69,7 @@ def addRelatedDecl (src tgt : Name) (ref : Syntax)
   -- If `tgt` already exists in an imported module, the `addDeclarationRangesFromSyntax` call
   -- below panics (and if it exists in the current module, `addDecl` would fail with a less
   -- helpful message), so we check for a pre-existing declaration up front.
-  withoutExporting do
-    let env ← getEnv
-    if env.contains tgt then
-      match env.getModuleIdxFor? tgt with
-      | some idx =>
-        throwError "cannot create related declaration `{tgt}`: \
-          it has already been declared in the imported module \
-          `{env.header.moduleNames[idx.toNat]!}`"
-      | none =>
-        throwError "cannot create related declaration `{tgt}`: \
-          it has already been declared in the current module"
+  checkNotAlreadyDeclared tgt
   addDeclarationRangesFromSyntax tgt (← getRef) ref
   let info ← withoutExporting <| getConstInfo src
   let value := .const src (info.levelParams.map mkLevelParam)

--- a/MathlibTest/CategoryTheory/Elementwise.lean
+++ b/MathlibTest/CategoryTheory/Elementwise.lean
@@ -237,25 +237,14 @@ section AlreadyDeclared
 
 open CategoryTheory.Limits
 
--- Regenerating an `_apply` lemma that was already generated in an imported module
--- (here `Mathlib.CategoryTheory.ConcreteCategory.Elementwise`) gives a clear error
--- instead of a panic in `addDeclarationRangesFromSyntax`.
+-- Regression test: regenerating an `_apply` lemma that was already generated in an imported
+-- module (here `Mathlib.CategoryTheory.ConcreteCategory.Elementwise`) must error via
+-- `checkNotAlreadyDeclared` instead of panicking in `addDeclarationRangesFromSyntax`.
 /--
-error: cannot create related declaration `CategoryTheory.Limits.limit.w_apply`: it has already been declared in the imported module `Mathlib.CategoryTheory.ConcreteCategory.Elementwise`
+error: `CategoryTheory.Limits.limit.w_apply` has already been declared
 -/
 #guard_msgs in
 attribute [elementwise] limit.w
-
-@[elementwise]
-theorem dup [Category C] {M N K : C} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) :
-    f ≫ 𝟙 N ≫ g = h := by
-  simp [w]
-
-/--
-error: cannot create related declaration `ElementwiseTest.dup_apply`: it has already been declared in the current module
--/
-#guard_msgs in
-attribute [elementwise] dup
 
 end AlreadyDeclared
 

--- a/MathlibTest/CategoryTheory/Elementwise.lean
+++ b/MathlibTest/CategoryTheory/Elementwise.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic.CategoryTheory.Elementwise
 import Mathlib.Algebra.Category.MonCat.Basic
+import Mathlib.CategoryTheory.ConcreteCategory.Elementwise
 
 set_option autoImplicit true
 
@@ -231,5 +232,31 @@ example {α β : Type} (f g : α ⟶ β) (w : f ≫ 𝟙 β = g) (a : α) : f a 
   rw [w]
 
 end ConcreteCategory
+
+section AlreadyDeclared
+
+open CategoryTheory.Limits
+
+-- Regenerating an `_apply` lemma that was already generated in an imported module
+-- (here `Mathlib.CategoryTheory.ConcreteCategory.Elementwise`) gives a clear error
+-- instead of a panic in `addDeclarationRangesFromSyntax`.
+/--
+error: cannot create related declaration `CategoryTheory.Limits.limit.w_apply`: it has already been declared in the imported module `Mathlib.CategoryTheory.ConcreteCategory.Elementwise`
+-/
+#guard_msgs in
+attribute [elementwise] limit.w
+
+@[elementwise]
+theorem dup [Category C] {M N K : C} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) :
+    f ≫ 𝟙 N ≫ g = h := by
+  simp [w]
+
+/--
+error: cannot create related declaration `ElementwiseTest.dup_apply`: it has already been declared in the current module
+-/
+#guard_msgs in
+attribute [elementwise] dup
+
+end AlreadyDeclared
 
 end ElementwiseTest


### PR DESCRIPTION
If `addRelatedDecl` is asked to create a declaration that already exists in an imported module, the　`addDeclarationRangesFromSyntax` call panics with `cannot insert ... into Lean.declRangeExt, it is not defined in the current module` (aborting the build with no usable diagnostic); a duplicate in the current module only failed later at `addDecl`. Check up front and throw a clear error naming the module that already declares the target.

This was hit when `shake --fix` added `import Mathlib.CategoryTheory.ConcreteCategory.Elementwise` to `Mathlib/CategoryTheory/Limits/Types/{Limits,Colimits}.lean` in #40343 (and previous iterations).

Zulip: [#mathlib4 > shake --fix causes elementwise to panic](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/shake.20--fix.20causes.20elementwise.20to.20panic/with/601797502)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
