### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits/Types): change imports to avoid generating elementwise lemmas twice

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Types/Colimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Colimits.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Logic.UnivLE
 public import Mathlib.CategoryTheory.Limits.HasLimits
 public import Mathlib.CategoryTheory.Limits.Types.ColimitType
+public import Mathlib.CategoryTheory.ConcreteCategory.Elementwise
 
 /-!
 # Colimits in the category of types
@@ -175,9 +176,11 @@ theorem colimitEquivColimitType_apply (j : J) (x : F.obj j) :
   apply (colimitEquivColimitType F).symm.injective
   simp
 
--- We don’t want to add `simp` to the original lemmas here
-attribute [elementwise] colimit.w colimit.ι_desc colimit.ι_map
-attribute [simp] colimit.w_apply colimit.ι_desc_apply colimit.ι_map_apply
+-- We don’t want to add `simp` to the original lemmas here.
+-- `colimit.w_apply` and `colimit.ι_desc_apply` are generated (and tagged `simp`)
+-- in `Mathlib/CategoryTheory/ConcreteCategory/Elementwise.lean`.
+attribute [elementwise] colimit.ι_map
+attribute [simp] colimit.ι_map_apply
 
 variable {F} in
 @[deprecated colimit.w_apply (since := "2026-03-06")]

--- a/Mathlib/CategoryTheory/Limits/Types/Limits.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Limits.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Logic.UnivLE
 public import Mathlib.CategoryTheory.Limits.HasLimits
+public import Mathlib.CategoryTheory.ConcreteCategory.Elementwise
 
 /-!
 # Limits in the category of types.
@@ -241,8 +242,10 @@ theorem limit_ext_iff' (F' : J ⥤ Type v) (x y : limit F') :
     x = y ↔ ∀ j, limit.π F' j x = limit.π F' j y :=
   ⟨fun t _ => t ▸ rfl, limit_ext' _ _ _⟩
 
-attribute [elementwise] limit.lift_π limMap_π limit.w
-attribute [simp] limit.lift_π_apply limMap_π_apply limit.w_apply
+-- `limit.lift_π_apply` and `limit.w_apply` are generated (and tagged `simp`)
+-- in `Mathlib/CategoryTheory/ConcreteCategory/Elementwise.lean`.
+attribute [elementwise] limMap_π
+attribute [simp] limMap_π_apply
 
 variable {F} in
 @[deprecated limit.w_apply (since := "2026-02-17")]


### PR DESCRIPTION
The `@[elementwise]`-generated lemmas `limit.lift_π_apply`, `limit.w_apply`, `colimit.w_apply` and `colimit.ι_desc_apply` were generated twice: once in `CategoryTheory/ConcreteCategory/Elementwise.lean` and once in `CategoryTheory/Limits/Types/{Limits,Colimits}.lean`. This was harmless only because no module imported both generation sites; importing both makes `@[elementwise]` panic (cf. #40343 and previous iterations; this panic is fixed in #41422).

This PR adds the import `Mathlib.CategoryTheory.ConcreteCategory.Elementwise` to the two `Types` files so they only generate the lemmas unique to them (`limMap_π_apply`, `colimit.ι_map_apply`).


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
