### PR TITLE
[Merged by Bors] - feat(Algebra/Category/ModuleCat): submodules of sheaves of modules

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -212,6 +212,7 @@ public import Mathlib.Algebra.Category.ModuleCat.Sheaf.PullbackContinuous
 public import Mathlib.Algebra.Category.ModuleCat.Sheaf.PullbackFree
 public import Mathlib.Algebra.Category.ModuleCat.Sheaf.PushforwardContinuous
 public import Mathlib.Algebra.Category.ModuleCat.Sheaf.Quasicoherent
+public import Mathlib.Algebra.Category.ModuleCat.Sheaf.Submodule
 public import Mathlib.Algebra.Category.ModuleCat.Simple
 public import Mathlib.Algebra.Category.ModuleCat.Stalk
 public import Mathlib.Algebra.Category.ModuleCat.Subobject

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Submodule.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Submodule.lean
@@ -6,6 +6,7 @@ Authors: Christian Merten
 module
 
 public import Mathlib.Algebra.Category.ModuleCat.Presheaf.EpiMono
+public import Mathlib.CategoryTheory.Subfunctor.Basic
 
 /-!
 # Submodules of presheaves of modules
@@ -98,6 +99,15 @@ instance (N₁ N₂ : M.Submodule) (hle : N₁ ≤ N₂) : Mono (homOfLE hle) :=
 
 @[reassoc (attr := simp)]
 lemma homOfLE_ι {N₁ N₂ : M.Submodule} (hle : N₁ ≤ N₂) : homOfLE hle ≫ N₂.ι = N₁.ι := rfl
+
+/-- The subfunctor of the underlying type-valued presheaf of `M` induced by a submodule `N`. -/
+def toSubfunctor : Subfunctor (M.presheaf ⋙ CategoryTheory.forget AddCommGrpCat.{v}) where
+  obj X := {r : M.obj X | r ∈ N.obj X}
+  map := fun {_ _} f _ hr ↦ N.map_mem f hr
+
+@[simp]
+lemma mem_toSubfunctor_obj {X : Cᵒᵖ} (r : M.obj X) :
+    r ∈ N.toSubfunctor.obj X ↔ r ∈ N.obj X := Iff.rfl
 
 @[simps sup_obj inf_obj sSup_obj sInf_obj top_obj bot_obj]
 instance : CompleteLattice M.Submodule where

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Submodule.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Submodule.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Submodule
+public import Mathlib.Algebra.Category.Grp.ForgetCorepresentable
+public import Mathlib.Algebra.Category.ModuleCat.Sheaf
+public import Mathlib.CategoryTheory.Sites.Subsheaf
+public import Mathlib.CategoryTheory.Sites.Whiskering
+
+/-!
+# Submodules of sheaves of modules
+
+Given a sheaf of modules `M`, a `SheafOfModules.Submodule M` is a submodule `N` of its underlying
+presheaf of modules whose membership condition is local.
+
+## Main definitions
+
+- `SheafOfModules.Submodule`: a submodule of (the underlying presheaf of modules of) a sheaf of
+  modules whose membership is local.
+- `SheafOfModules.Submodule.toSheafOfModules`: the associated sheaf of modules.
+-/
+
+@[expose] public section
+
+universe v v₁ u₁ u
+
+open CategoryTheory Opposite
+
+namespace SheafOfModules
+
+open PresheafOfModules
+
+variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
+  {R : Sheaf J RingCat.{u}}
+
+/-- A submodule of a sheaf of modules `M`: a submodule `N` of the underlying presheaf of modules
+whose membership condition is local. -/
+structure Submodule (M : SheafOfModules.{v} R) extends M.val.Submodule where
+  isSheaf ⦃X : Cᵒᵖ⦄ (s : M.val.obj X) :
+    toSubmodule.toSubfunctor.sieveOfSection s ∈ J X.unop → s ∈ toSubmodule.obj X
+
+namespace Submodule
+
+variable {M : SheafOfModules.{v} R} (N : M.Submodule)
+
+@[ext]
+lemma ext {N₁ N₂ : M.Submodule} (h : N₁.toSubmodule = N₂.toSubmodule) : N₁ = N₂ := by
+  cases N₁
+  cases N₂
+  subst h
+  rfl
+
+/-- The sheaf of modules associated to a submodule of a sheaf of modules. -/
+noncomputable def toSheafOfModules : SheafOfModules.{v} R where
+  val := N.toPresheafOfModules
+  isSheaf := by
+    suffices Presieve.IsSheaf J N.toSubfunctor.toFunctor by
+      apply Presheaf.isSheaf_of_isSheaf_comp J (s := CategoryTheory.forget AddCommGrpCat)
+      rwa [isSheaf_iff_isSheaf_of_type]
+    rw [N.toSubfunctor.isSheaf_iff]
+    · exact N.isSheaf
+    · rw [← isSheaf_iff_isSheaf_of_type]
+      exact GrothendieckTopology.HasSheafCompose.isSheaf _ M.isSheaf
+
+/-- The inclusion of the sheaf of modules associated to a submodule `N` into `M`. -/
+noncomputable def ι : N.toSheafOfModules ⟶ M :=
+  ⟨N.toSubmodule.ι⟩
+
+@[simp]
+lemma ι_val : N.ι.val = N.toSubmodule.ι := rfl
+
+instance : Mono N.ι :=
+  (forget R).mono_of_mono_map <| inferInstanceAs (Mono N.toSubmodule.ι)
+
+instance : PartialOrder M.Submodule :=
+  PartialOrder.lift toSubmodule fun _ _ ↦ ext
+
+lemma le_iff {N₁ N₂ : M.Submodule} : N₁ ≤ N₂ ↔ N₁.toSubmodule ≤ N₂.toSubmodule := .rfl
+
+instance : InfSet M.Submodule where
+  sInf s :=
+    { toSubmodule := sInf ((·.toSubmodule) '' s)
+      isSheaf X x hx := by
+        simp only [PresheafOfModules.Submodule.sInf_obj, Submodule.mem_iInf]
+        rintro _ ⟨N', hN', rfl⟩
+        refine N'.isSheaf x (J.superset_covering (fun V f hf ↦ ?_) hx)
+        exact (sInf_le (Set.mem_image_of_mem (·.toSubmodule) hN')) (op V) hf }
+
+instance : Min M.Submodule where
+  min N₁ N₂ :=
+    { toSubmodule := N₁.toSubmodule ⊓ N₂.toSubmodule
+      isSheaf := by
+        rw [← sInf_pair, ← Set.image_pair (·.toSubmodule) N₁ N₂]
+        exact (sInf {N₁, N₂}).isSheaf }
+
+noncomputable instance : CompleteLattice M.Submodule where
+  __ := completeLatticeOfInf M.Submodule fun s ↦
+    ⟨fun _ hN ↦ le_iff.mpr (sInf_le (Set.mem_image_of_mem _ hN)),
+      fun _ hb ↦ le_iff.mpr <| le_sInf <| by
+        rintro _ ⟨N', hN', rfl⟩
+        exact le_iff.mp (hb hN')⟩
+  inf := (· ⊓ ·)
+  inf_le_left := fun _ _ ↦ le_iff.mpr inf_le_left
+  inf_le_right := fun _ _ ↦ le_iff.mpr inf_le_right
+  le_inf := fun _ _ _ h₁ h₂ ↦ le_iff.mpr (le_inf (le_iff.mp h₁) (le_iff.mp h₂))
+
+@[simp]
+lemma toSubmodule_sInf (s : Set M.Submodule) :
+    (sInf s).toSubmodule = sInf ((·.toSubmodule) '' s) :=
+  rfl
+
+@[simp]
+lemma toSubmodule_iInf {ι : Sort*} (N : ι → M.Submodule) :
+    (⨅ i, N i).toSubmodule = ⨅ i, (N i).toSubmodule := by
+  rw [iInf, toSubmodule_sInf, ← Set.range_comp, iInf, Function.comp_def]
+
+@[simp]
+lemma toSubmodule_inf (N₁ N₂ : M.Submodule) :
+    (N₁ ⊓ N₂).toSubmodule = N₁.toSubmodule ⊓ N₂.toSubmodule :=
+  rfl
+
+end Submodule
+
+end SheafOfModules

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -174,4 +174,15 @@ lemma Presheaf.IsSheaf.isSeparated {F : Cᵒᵖ ⥤ A} {FA : A → A → Type*} 
     Presheaf.IsSeparated J F :=
   Sheaf.isSeparated ⟨F, hF⟩
 
+variable {FA : A → A → Type*} {CA : A → Type v₂} [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)]
+  [ConcreteCategory A FA]
+
+/-- If the forgetful functor of a concrete category is corepresentable, then it preserves
+sheaves. -/
+instance [(forget A).IsCorepresentable] : J.HasSheafCompose (forget A) where
+  isSheaf P hP := by
+    rw [isSheaf_iff_isSheaf_of_type]
+    exact Presieve.isSheaf_iso J (Functor.isoWhiskerLeft P (forget A).coreprW)
+      (hP (forget A).coreprX)
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -177,8 +177,6 @@ lemma Presheaf.IsSheaf.isSeparated {F : Cᵒᵖ ⥤ A} {FA : A → A → Type*} 
 variable {FA : A → A → Type*} {CA : A → Type v₂} [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)]
   [ConcreteCategory A FA]
 
-/-- If the forgetful functor of a concrete category is corepresentable, then it preserves
-sheaves. -/
 instance [(forget A).IsCorepresentable] : J.HasSheafCompose (forget A) where
   isSheaf P hP := by
     rw [isSheaf_iff_isSheaf_of_type]


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
