### PR TITLE
doc: improve calc? tactic docstring

### DIFF
--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -134,7 +134,13 @@ def CalcPanel : Component CalcParams :=
 namespace Lean.Elab.Tactic
 
 open Lean Meta Tactic TryThis in
-/-- Create a `calc` proof. -/
+/--
+Create a skeleton `calc` proof for the current goal.
+
+This tactic works when the target is a relation accepted by the `calc` elaborator, such as
+an equality, inequality, or order relation. It suggests a `calc` block starting from the current
+target and leaves the justification as `by sorry`.
+-/
 elab stx:"calc?" : tactic => withMainContext do
   let goalType ← whnfR (← getMainTarget)
   unless (← Lean.Elab.Term.getCalcRelation? goalType).isSome do


### PR DESCRIPTION
This PR improves the docstring for the `calc?` tactic.

The previous docstring only said that the tactic creates a `calc` proof. The new text explains that `calc?` suggests a skeleton `calc` block for targets accepted by the `calc` elaborator, such as equality, inequality, or order-relation goals, and leaves the justification as `by sorry`.

This should make the tactic's intended use clearer to users reading the generated docs or browsing the declaration.

Closes #25503.

Verification:
- `git diff --check origin/master..HEAD`
- `lake env lean Mathlib/Tactic/Widget/Calc.lean`
- `lake build Mathlib.Tactic.Widget.Calc`