### PR TITLE
[Merged by Bors] - feat(GroupTheory/Descent): add versions showing finiteness of torsion

### DIFF
--- a/Mathlib/GroupTheory/Descent.lean
+++ b/Mathlib/GroupTheory/Descent.lean
@@ -188,14 +188,12 @@ theorem CommGroup.finite_torsion_of_descent {G : Type*} [CommGroup G] {n : ℕ} 
 
 /--
 If `G` is a commutative group and `n : ℕ`, `h : G → ℝ` satisfy
-* `0 ≤ h x` for all `x : G`,
 * there is `C : ℝ` such that for all `x y : G`, `|h (x * y) + h(x / y) - 2 * (h x + h y)| ≤ C`,
 * for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`,
 
 then the torsion subgroup of `G` is finite.
 -/
 @[to_additive /-- If `G` is a commutative additive group and `n : ℕ`, `h : G → ℝ` satisfy
-* `0 ≤ h x` for all `x : G`,
 * there is `C : ℝ` such that for all `x y : G`, `|h (x + y) + h(x - y) - 2 * (h x + h y)| ≤ C`,
 * for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`,
 

--- a/Mathlib/GroupTheory/Descent.lean
+++ b/Mathlib/GroupTheory/Descent.lean
@@ -8,8 +8,11 @@ module
 public import Mathlib.Data.Real.Basic
 public import Mathlib.GroupTheory.Finiteness
 public import Mathlib.GroupTheory.Index
+public import Mathlib.GroupTheory.Torsion
 public import Mathlib.Order.Northcott
 
+import Mathlib.Algebra.Order.Archimedean.Real.Basic
+import Mathlib.Data.Fintype.Order
 import Mathlib.Data.Set.Finite.Lemmas
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
@@ -42,6 +45,8 @@ See `CommGroup.fg_of_descent` / `AddCommGroup.fg_of_descent` and
 This last version is one of the main ingredients of the standard proof of the
 **Mordell-Weil Theorem**. It allows to reduce the statement to showing that `G / 2 • G` is finite
 (where `G` is the Mordell-Weil group).
+
+We also provide versions that prove that the torsion subgroup is finite under weaker assumptions.
 
 ### Implementation note
 
@@ -149,5 +154,64 @@ theorem CommGroup.fg_of_descent' {G : Type*} [CommGroup G] {h : G → ℝ} {C : 
   have H₃' x : 4 * h x - (h 1 + C) ≤ h (x ^ 2) := by grind [pow_two, div_self']
   have H₂' g x : h x ≤ 2 * h (g * x) + (2 * h g⁻¹ + C) := by grind [mul_inv_cancel_comm]
   exact fg_of_descent (b := 4) (by norm_num) (by norm_num) H₁ H₂' H₃'
+
+open Subgroup QuotientGroup in
+/--
+If `G` is a commutative group and `n : ℕ`, `h : G → ℝ` satisfy
+* for all `x : G`, `h (x ^ n) ≥ b * h x - c₀`,
+* for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`,
+
+where `1 < b` and `c₀` are real numbers, then the torsion subgroup of `G` is finite.
+-/
+@[to_additive /-- If `G` is a commutative additive group and `n : ℕ`, `h : G → ℝ` satisfy
+* for all `x : G`, `h (n • x) ≥ b * h x - c₀`,
+* for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`,
+
+where `1 < b` and `c₀` are real numbers, then the torsion subgroup of `G` is finite. -/]
+theorem CommGroup.finite_torsion_of_descent {G : Type*} [CommGroup G] {n : ℕ} {h : G → ℝ}
+    {b c₀ : ℝ} (H₀ : 1 < b) (H₃ : ∀ x, b * h x - c₀ ≤ h (x ^ n)) [Northcott h] :
+    Finite (torsion G) := by
+  by_cases! H : ∃ C, ∀ x, h x ≤ C
+  · obtain ⟨C, hC⟩ := H
+    have : Finite G := by
+      suffices {x | h x ≤ C}.Finite by
+        simp only [hC, Set.setOf_true] at this
+        exact Set.finite_univ_iff.mp this
+      exact Northcott.finite_le C
+    exact instFiniteSubtypeMem _
+  have H' := Northcott.finite_le (h := h) (c₀ / (b - 1))
+  refine Set.Finite.subset (Set.finite_coe_iff.mp H') fun t ht ↦ ?_
+  rw [SetLike.mem_coe, mem_torsion, ← finite_powers] at ht
+  have ht' : Finite ↥(Submonoid.powers t) := ht
+  let C : ℝ := ⨆ g : Submonoid.powers t, h g
+  have hC : ∀ g ∈ Submonoid.powers t, h g ≤ C :=
+    fun g hg ↦ Finite.le_ciSup (fun g : Submonoid.powers t ↦ h g) ⟨g, hg⟩
+  have hC' : C ≤ c₀ / (b - 1) := by
+    obtain ⟨t₀, ht₀⟩ : ∃ g : Submonoid.powers t, h g = C := exists_eq_ciSup_of_finite
+    replace H₃ := (H₃ t₀).trans <| hC _ <| Submonoid.pow_mem _ (SetLike.coe_mem t₀) n
+    rw [ht₀] at H₃
+    rw [le_div_iff₀' (by grind)]
+    grind
+  exact (hC t (Submonoid.mem_powers t)).trans hC'
+
+/--
+If `G` is a commutative group and `n : ℕ`, `h : G → ℝ` satisfy
+* `0 ≤ h x` for all `x : G`,
+* there is `C : ℝ` such that for all `x y : G`, `|h (x * y) + h(x / y) - 2 * (h x + h y)| ≤ C`,
+* for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`,
+
+then the torsion subgroup of `G` is finite.
+-/
+@[to_additive /-- If `G` is a commutative additive group and `n : ℕ`, `h : G → ℝ` satisfy
+* `0 ≤ h x` for all `x : G`,
+* there is `C : ℝ` such that for all `x y : G`, `|h (x + y) + h(x - y) - 2 * (h x + h y)| ≤ C`,
+* for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`,
+
+then the torsion subgroup of `G` is finite. -/]
+theorem CommGroup.finite_torsion_of_descent' {G : Type*} [CommGroup G] {h : G → ℝ} {C : ℝ}
+    (H₃ : ∀ x y, |h (x * y) + h (x / y) - 2 * (h x + h y)| ≤ C) [Northcott h] :
+    Finite (torsion G) := by
+  have H x : 4 * h x - (h 1 + C) ≤ h (x ^ 2) := by grind [pow_two, div_self']
+  exact finite_torsion_of_descent (b := 4) (by norm_num) H
 
 end

--- a/Mathlib/GroupTheory/Descent.lean
+++ b/Mathlib/GroupTheory/Descent.lean
@@ -171,14 +171,6 @@ where `1 < b` and `c₀` are real numbers, then the torsion subgroup of `G` is f
 theorem CommGroup.finite_torsion_of_descent {G : Type*} [CommGroup G] {n : ℕ} {h : G → ℝ}
     {b c₀ : ℝ} (H₀ : 1 < b) (H₃ : ∀ x, b * h x - c₀ ≤ h (x ^ n)) [Northcott h] :
     Finite (torsion G) := by
-  by_cases! H : ∃ C, ∀ x, h x ≤ C
-  · obtain ⟨C, hC⟩ := H
-    have : Finite G := by
-      suffices {x | h x ≤ C}.Finite by
-        simp only [hC, Set.setOf_true] at this
-        exact Set.finite_univ_iff.mp this
-      exact Northcott.finite_le C
-    exact instFiniteSubtypeMem _
   have H' := Northcott.finite_le (h := h) (c₀ / (b - 1))
   refine Set.Finite.subset (Set.finite_coe_iff.mp H') fun t ht ↦ ?_
   rw [SetLike.mem_coe, mem_torsion, ← finite_powers] at ht

--- a/Mathlib/GroupTheory/Descent.lean
+++ b/Mathlib/GroupTheory/Descent.lean
@@ -171,18 +171,15 @@ is finite. -/]
 theorem Monoid.finite_torsion_of_descent {M : Type*} [Monoid M] {n : ℕ} {h : M → ℝ}
     {b c₀ : ℝ} (hb : 1 < b) (H : ∀ x, b * h x - c₀ ≤ h (x ^ n)) [Northcott h] :
     Finite { x : M | IsOfFinOrder x } := by
-  have H' := Northcott.finite_le (h := h) (c₀ / (b - 1))
-  refine Set.Finite.subset (Set.finite_coe_iff.mp H') fun t ht ↦ ?_
-  have ht' : Finite ↥(Submonoid.powers t) := ht.finite_powers
+  refine (Northcott.finite_le (h := h) (c₀ / (b - 1))).subset fun t ht ↦ ?_
+  have : Finite ↥(Submonoid.powers t) := ht.finite_powers
   let C : ℝ := ⨆ g : Submonoid.powers t, h g
   have hC : ∀ g ∈ Submonoid.powers t, h g ≤ C :=
     fun g hg ↦ Finite.le_ciSup (fun g : Submonoid.powers t ↦ h g) ⟨g, hg⟩
   refine (hC t (Submonoid.mem_powers t)).trans ?_
   obtain ⟨t₀, ht₀⟩ : ∃ g : Submonoid.powers t, h g = C := exists_eq_ciSup_of_finite
-  replace H := (H t₀).trans <| hC _ <| Submonoid.pow_mem _ (SetLike.coe_mem t₀) n
-  rw [ht₀] at H
   rw [le_div_iff₀' (by grind)]
-  grind
+  grind [Submonoid.pow_mem]
 
 /--
 If `G` is a commutative group and `n : ℕ`, `h : G → ℝ` satisfy

--- a/Mathlib/GroupTheory/Descent.lean
+++ b/Mathlib/GroupTheory/Descent.lean
@@ -160,7 +160,7 @@ If `M` is a monoid and `n : ℕ`, `h : M → ℝ` satisfy
 * for all `M : G`, `h (x ^ n) ≥ b * h x - c₀`,
 * for all `B : ℝ`, there are only finitely many `x : M` such that `h x ≤ B`,
 
-where `1 < b` and `c₀` are real numbers, then set of elements of finite order in `M` is finite.
+where `1 < b` and `c₀` are real numbers, then the set of elements of finite order in `M` is finite.
 -/
 @[to_additive /-- If `M` is an additive monoid and `n : ℕ`, `h : M → ℝ` satisfy
 * for all `x : M`, `h (n • x) ≥ b * h x - c₀`,

--- a/Mathlib/GroupTheory/Descent.lean
+++ b/Mathlib/GroupTheory/Descent.lean
@@ -155,7 +155,35 @@ theorem CommGroup.fg_of_descent' {G : Type*} [CommGroup G] {h : G → ℝ} {C : 
   have H₂' g x : h x ≤ 2 * h (g * x) + (2 * h g⁻¹ + C) := by grind [mul_inv_cancel_comm]
   exact fg_of_descent (b := 4) (by norm_num) (by norm_num) H₁ H₂' H₃'
 
-open Subgroup QuotientGroup in
+/--
+If `M` is a monoid and `n : ℕ`, `h : M → ℝ` satisfy
+* for all `M : G`, `h (x ^ n) ≥ b * h x - c₀`,
+* for all `B : ℝ`, there are only finitely many `x : M` such that `h x ≤ B`,
+
+where `1 < b` and `c₀` are real numbers, then set of elements of finite order in `M` is finite.
+-/
+@[to_additive /-- If `M` is an additive monoid and `n : ℕ`, `h : M → ℝ` satisfy
+* for all `x : M`, `h (n • x) ≥ b * h x - c₀`,
+* for all `B : ℝ`, there are only finitely many `x : M` such that `h x ≤ B`,
+
+where `1 < b` and `c₀` are real numbers, then the set of elements of finite order in `M`
+is finite. -/]
+theorem Monoid.finite_torsion_of_descent {M : Type*} [Monoid M] {n : ℕ} {h : M → ℝ}
+    {b c₀ : ℝ} (hb : 1 < b) (H : ∀ x, b * h x - c₀ ≤ h (x ^ n)) [Northcott h] :
+    Finite { x : M | IsOfFinOrder x } := by
+  have H' := Northcott.finite_le (h := h) (c₀ / (b - 1))
+  refine Set.Finite.subset (Set.finite_coe_iff.mp H') fun t ht ↦ ?_
+  have ht' : Finite ↥(Submonoid.powers t) := ht.finite_powers
+  let C : ℝ := ⨆ g : Submonoid.powers t, h g
+  have hC : ∀ g ∈ Submonoid.powers t, h g ≤ C :=
+    fun g hg ↦ Finite.le_ciSup (fun g : Submonoid.powers t ↦ h g) ⟨g, hg⟩
+  refine (hC t (Submonoid.mem_powers t)).trans ?_
+  obtain ⟨t₀, ht₀⟩ : ∃ g : Submonoid.powers t, h g = C := exists_eq_ciSup_of_finite
+  replace H := (H t₀).trans <| hC _ <| Submonoid.pow_mem _ (SetLike.coe_mem t₀) n
+  rw [ht₀] at H
+  rw [le_div_iff₀' (by grind)]
+  grind
+
 /--
 If `G` is a commutative group and `n : ℕ`, `h : G → ℝ` satisfy
 * for all `x : G`, `h (x ^ n) ≥ b * h x - c₀`,
@@ -169,22 +197,9 @@ where `1 < b` and `c₀` are real numbers, then the torsion subgroup of `G` is f
 
 where `1 < b` and `c₀` are real numbers, then the torsion subgroup of `G` is finite. -/]
 theorem CommGroup.finite_torsion_of_descent {G : Type*} [CommGroup G] {n : ℕ} {h : G → ℝ}
-    {b c₀ : ℝ} (H₀ : 1 < b) (H₃ : ∀ x, b * h x - c₀ ≤ h (x ^ n)) [Northcott h] :
-    Finite (torsion G) := by
-  have H' := Northcott.finite_le (h := h) (c₀ / (b - 1))
-  refine Set.Finite.subset (Set.finite_coe_iff.mp H') fun t ht ↦ ?_
-  rw [SetLike.mem_coe, mem_torsion, ← finite_powers] at ht
-  have ht' : Finite ↥(Submonoid.powers t) := ht
-  let C : ℝ := ⨆ g : Submonoid.powers t, h g
-  have hC : ∀ g ∈ Submonoid.powers t, h g ≤ C :=
-    fun g hg ↦ Finite.le_ciSup (fun g : Submonoid.powers t ↦ h g) ⟨g, hg⟩
-  have hC' : C ≤ c₀ / (b - 1) := by
-    obtain ⟨t₀, ht₀⟩ : ∃ g : Submonoid.powers t, h g = C := exists_eq_ciSup_of_finite
-    replace H₃ := (H₃ t₀).trans <| hC _ <| Submonoid.pow_mem _ (SetLike.coe_mem t₀) n
-    rw [ht₀] at H₃
-    rw [le_div_iff₀' (by grind)]
-    grind
-  exact (hC t (Submonoid.mem_powers t)).trans hC'
+    {b c₀ : ℝ} (hb : 1 < b) (H : ∀ x, b * h x - c₀ ≤ h (x ^ n)) [Northcott h] :
+    Finite (torsion G) :=
+  Monoid.finite_torsion_of_descent hb H
 
 /--
 If `G` is a commutative group and `n : ℕ`, `h : G → ℝ` satisfy
@@ -199,9 +214,9 @@ then the torsion subgroup of `G` is finite.
 
 then the torsion subgroup of `G` is finite. -/]
 theorem CommGroup.finite_torsion_of_descent' {G : Type*} [CommGroup G] {h : G → ℝ} {C : ℝ}
-    (H₃ : ∀ x y, |h (x * y) + h (x / y) - 2 * (h x + h y)| ≤ C) [Northcott h] :
+    (H : ∀ x y, |h (x * y) + h (x / y) - 2 * (h x + h y)| ≤ C) [Northcott h] :
     Finite (torsion G) := by
-  have H x : 4 * h x - (h 1 + C) ≤ h (x ^ 2) := by grind [pow_two, div_self']
-  exact finite_torsion_of_descent (b := 4) (by norm_num) H
+  have H' x : 4 * h x - (h 1 + C) ≤ h (x ^ 2) := by grind [pow_two, div_self']
+  exact finite_torsion_of_descent (b := 4) (by norm_num) H'
 
 end

--- a/Mathlib/GroupTheory/Descent.lean
+++ b/Mathlib/GroupTheory/Descent.lean
@@ -168,7 +168,7 @@ where `1 < b` and `c₀` are real numbers, then set of elements of finite order 
 
 where `1 < b` and `c₀` are real numbers, then the set of elements of finite order in `M`
 is finite. -/]
-theorem Monoid.finite_torsion_of_descent {M : Type*} [Monoid M] {n : ℕ} {h : M → ℝ}
+theorem Monoid.finite_set_isOfFiniteOrder_of_descent {M : Type*} [Monoid M] {n : ℕ} {h : M → ℝ}
     {b c₀ : ℝ} (hb : 1 < b) (H : ∀ x, b * h x - c₀ ≤ h (x ^ n)) [Northcott h] :
     Finite { x : M | IsOfFinOrder x } := by
   refine (Northcott.finite_le (h := h) (c₀ / (b - 1))).subset fun t ht ↦ ?_
@@ -196,7 +196,7 @@ where `1 < b` and `c₀` are real numbers, then the torsion subgroup of `G` is f
 theorem CommGroup.finite_torsion_of_descent {G : Type*} [CommGroup G] {n : ℕ} {h : G → ℝ}
     {b c₀ : ℝ} (hb : 1 < b) (H : ∀ x, b * h x - c₀ ≤ h (x ^ n)) [Northcott h] :
     Finite (torsion G) :=
-  Monoid.finite_torsion_of_descent hb H
+  Monoid.finite_set_isOfFiniteOrder_of_descent hb H
 
 /--
 If `G` is a commutative group and `n : ℕ`, `h : G → ℝ` satisfy


### PR DESCRIPTION
This adds results showing that the torsion subgroup of an (additive) commutative group is finite when it admits a height function with certain properties (weaker than needed to show finite generation).

Once the approximate parallelogram law on elliptic curves is in, this will give a proof that the torsion subgroup of the group of `K`-rational points on an elliptic curve over a number field `K` is finite.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
