### PR TITLE
feat(Topology/ContinuousMap): domMulAct action on bounded continuous maps

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7849,6 +7849,7 @@ public import Mathlib.Topology.ContinuousMap.CompactlySupported
 public import Mathlib.Topology.ContinuousMap.ContinuousMapZero
 public import Mathlib.Topology.ContinuousMap.ContinuousSqrt
 public import Mathlib.Topology.ContinuousMap.Defs
+public import Mathlib.Topology.ContinuousMap.DomAct
 public import Mathlib.Topology.ContinuousMap.Ideals
 public import Mathlib.Topology.ContinuousMap.Interval
 public import Mathlib.Topology.ContinuousMap.Lattice

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7840,6 +7840,7 @@ public import Mathlib.Topology.ContinuousMap.Algebra
 public import Mathlib.Topology.ContinuousMap.Basic
 public import Mathlib.Topology.ContinuousMap.Bounded.ArzelaAscoli
 public import Mathlib.Topology.ContinuousMap.Bounded.Basic
+public import Mathlib.Topology.ContinuousMap.Bounded.DomAct
 public import Mathlib.Topology.ContinuousMap.Bounded.Normed
 public import Mathlib.Topology.ContinuousMap.Bounded.Star
 public import Mathlib.Topology.ContinuousMap.BoundedCompactlySupported

--- a/Mathlib/Topology/ContinuousMap/Bounded/DomAct.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/DomAct.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 Ezequiel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ezequiel
+-/
+module
+
+public import Mathlib.GroupTheory.GroupAction.DomAct.Basic
+public import Mathlib.Topology.Algebra.Constructions.DomMulAct
+public import Mathlib.Topology.ContinuousMap.Bounded.Basic
+public import Mathlib.Topology.ContinuousMap.DomAct
+
+/-!
+# Action of `Mᵈᵐᵃ` on `α →ᵇ β`
+
+If `M` acts continuously on `α`, then `Mᵈᵐᵃ` acts on bounded continuous functions `α →ᵇ β` by
+`(c • f) a = f (mk.symm c • a)`.
+
+## Tags
+
+group action, bounded continuous map, domain action
+-/
+
+public section
+
+open BoundedContinuousFunction
+
+namespace DomMulAct
+
+variable {M α β : Type*}
+variable [TopologicalSpace α] [PseudoMetricSpace β]
+
+section SMul
+
+variable [SMul M α] [TopologicalSpace M] [ContinuousConstSMul M α]
+
+/-- The action of `Mᵈᵐᵃ` on `α →ᵇ β` induced by the action on `α`. -/
+noncomputable def smulBoundedContinuousFunction (c : Mᵈᵐᵃ) (f : α →ᵇ β) : α →ᵇ β :=
+  mkOfBound (c • f.toContinuousMap) (Classical.choose f.bounded)
+    fun x y => Classical.choose_spec f.bounded (mk.symm c • x) (mk.symm c • y)
+
+noncomputable instance instSMulBoundedContinuousFunction : SMul Mᵈᵐᵃ (α →ᵇ β) where
+  smul := smulBoundedContinuousFunction
+
+omit [TopologicalSpace M] in
+theorem smulBoundedContinuousFunction_apply (c : Mᵈᵐᵃ) (f : α →ᵇ β) (a : α) :
+    smulBoundedContinuousFunction c f a = f (mk.symm c • a) := by
+  simp only [smulBoundedContinuousFunction, mkOfBound_coe, smul_continuousMap_apply,
+    coe_toContinuousMap]
+
+omit [TopologicalSpace M] in
+theorem smul_boundedContinuousFunction_apply (c : Mᵈᵐᵃ) (f : α →ᵇ β) (a : α) :
+    (c • f) a = f (mk.symm c • a) :=
+  smulBoundedContinuousFunction_apply c f a
+
+omit [TopologicalSpace M] in
+@[simp]
+theorem coe_smul_boundedContinuousFunction (c : Mᵈᵐᵃ) (f : α →ᵇ β) :
+    ⇑(c • f) = c • ⇑f := by
+  funext a
+  rw [smul_boundedContinuousFunction_apply, DomMulAct.smul_apply]
+
+omit [TopologicalSpace M] in
+@[simp]
+theorem mk_smul_boundedContinuousFunction_apply (c : M) (f : α →ᵇ β) (a : α) :
+    (mk c • f) a = f (c • a) := by
+  simp [smul_boundedContinuousFunction_apply]
+
+end SMul
+
+section MulAction
+
+variable [Monoid M] [MulAction M α] [TopologicalSpace M] [ContinuousConstSMul M α]
+
+noncomputable instance instMulActionBoundedContinuousFunction : MulAction Mᵈᵐᵃ (α →ᵇ β) where
+  smul := (· • ·)
+  one_smul f := by ext; simp [smul_boundedContinuousFunction_apply]
+  mul_smul x y f := by ext; simp [smul_boundedContinuousFunction_apply, mul_smul]
+
+end MulAction
+
+end DomMulAct

--- a/Mathlib/Topology/ContinuousMap/DomAct.lean
+++ b/Mathlib/Topology/ContinuousMap/DomAct.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 Ezequiel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ezequiel
+-/
+module
+
+public import Mathlib.GroupTheory.GroupAction.DomAct.Basic
+public import Mathlib.Topology.Algebra.Constructions.DomMulAct
+public import Mathlib.Topology.Algebra.MulAction
+public import Mathlib.Topology.CompactOpen
+public import Mathlib.Topology.ContinuousMap.Algebra
+
+/-!
+# Action of `Mᵈᵐᵃ` on `C(α, β)`
+
+If `M` acts continuously on `α`, then `Mᵈᵐᵃ` acts on `C(α, β)` by
+`(c • f) a = f (mk.symm c • a)`.
+
+## Tags
+
+group action, continuous map, domain action
+-/
+
+public section
+
+open ContinuousMap
+
+namespace DomMulAct
+
+variable {M α β N : Type*}
+variable [TopologicalSpace α] [TopologicalSpace β]
+
+section SMul
+
+variable [SMul M α] [TopologicalSpace M] [ContinuousConstSMul M α]
+
+instance instSMulContinuousMap : SMul Mᵈᵐᵃ C(α, β) where
+  smul c f := ⟨c • (f : α → β), f.continuous.comp (continuous_const_smul (mk.symm c))⟩
+
+omit [TopologicalSpace M] in
+@[simp, norm_cast]
+theorem coe_smul_continuousMap (c : Mᵈᵐᵃ) (f : C(α, β)) : ⇑(c • f) = c • ⇑f :=
+  rfl
+
+omit [TopologicalSpace M] in
+theorem smul_continuousMap_apply (c : Mᵈᵐᵃ) (f : C(α, β)) (a : α) :
+    (c • f) a = f (mk.symm c • a) :=
+  rfl
+
+omit [TopologicalSpace M] in
+@[simp]
+theorem mk_smul_continuousMap_apply (c : M) (f : C(α, β)) (a : α) : (mk c • f) a = f (c • a) :=
+  rfl
+
+variable [SMul N β] [ContinuousConstSMul N β]
+
+instance instSMulCommClass_right : SMulCommClass Mᵈᵐᵃ N C(α, β) where
+  smul_comm _ _ _ := ext fun _ => rfl
+
+instance instSMulCommClass_left : SMulCommClass N Mᵈᵐᵃ C(α, β) where
+  smul_comm _ _ _ := ext fun _ => rfl
+
+variable [SMul N α] [SMulCommClass M N α] [ContinuousConstSMul N α]
+
+instance instSMulCommClass_dom : SMulCommClass Mᵈᵐᵃ Nᵈᵐᵃ C(α, β) where
+  smul_comm _ _ f := ext fun a => congr_arg f (smul_comm _ _ a).symm
+
+end SMul
+
+section MulAction
+
+variable [Monoid M] [MulAction M α] [TopologicalSpace M] [ContinuousConstSMul M α]
+
+instance instMulActionContinuousMap : MulAction Mᵈᵐᵃ C(α, β) where
+  smul := (· • ·)
+  one_smul f := by ext; simp [smul_continuousMap_apply]
+  mul_smul x y f := by ext; simp [smul_continuousMap_apply, mul_smul]
+
+end MulAction
+
+section ContinuousSMul
+
+variable [SMul M α] [TopologicalSpace M] [ContinuousSMul M α] [LocallyCompactSpace α]
+
+instance instContinuousSMulContinuousMap : ContinuousSMul Mᵈᵐᵃ C(α, β) where
+  continuous_smul := by
+    let h : C(Mᵈᵐᵃ, C(α, α)) :=
+      (ContinuousMap.mk (fun p : M × α => p.1 • p.2) continuous_smul).curry.comp (.mk mk.symm)
+    refine (continuous_comp'.comp <|
+      h.continuous.comp continuous_fst |>.prodMk continuous_snd).congr ?_
+    rintro ⟨c, f⟩
+    ext a
+    change f ((h c) a) = (c • f) a
+    rw [smul_continuousMap_apply, comp_apply]
+    congr 1
+
+end ContinuousSMul
+
+end DomMulAct


### PR DESCRIPTION
## Summary

- Define the action of `Mᵈᵐᵃ` on bounded continuous functions `α →ᵇ β`.
- Add basic instances and simp lemmas.

## Dependency

Depends on #41449. I will rebase onto `master` after that PR merges.

## Test plan

- [x] `lake build Mathlib.Topology.ContinuousMap.Bounded.DomAct`
- [x] `lake exe runLinter Mathlib.Topology.ContinuousMap.Bounded.DomAct`
