### PR TITLE
[Merged by Bors] - feat(Algebra/GroupWithZero): prove that `Is{Left,Right}CancelMulZero` is Dedekind-finite

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -327,16 +327,16 @@ theorem eq_zero_of_mul_eq_self_left [IsRightCancelMulZero M₀] (h₁ : b ≠ 1)
 
 variable {M₀ : Type*} [MonoidWithZero M₀]
 
-instance [IsLeftCancelMulZero M₀] : IsDedekindFiniteMonoid M₀ where
+instance (priority := 100) [IsLeftCancelMulZero M₀] : IsDedekindFiniteMonoid M₀ where
   mul_eq_one_symm h := by
-    rcases subsingleton_or_nontrivial M₀ with hM | hM
+    cases subsingleton_or_nontrivial M₀
     · exact Subsingleton.elim _ _
     exact (IsLeftCancelMulZero.mul_left_cancel_of_ne_zero
       (left_ne_zero_of_mul_eq_one h)).mul_eq_one_symm h
 
-instance [IsRightCancelMulZero M₀] : IsDedekindFiniteMonoid M₀ where
+instance (priority := 100) [IsRightCancelMulZero M₀] : IsDedekindFiniteMonoid M₀ where
   mul_eq_one_symm h := by
-    rcases subsingleton_or_nontrivial M₀ with hM | hM
+    cases subsingleton_or_nontrivial M₀
     · exact Subsingleton.elim _ _
     exact (IsRightCancelMulZero.mul_right_cancel_of_ne_zero
       (right_ne_zero_of_mul_eq_one h)).mul_eq_one_symm h

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -325,6 +325,22 @@ theorem eq_zero_of_mul_eq_self_left [IsRightCancelMulZero M₀] (h₁ : b ≠ 1)
     a = 0 :=
   Classical.byContradiction fun ha => h₁ <| mul_right_cancel₀ ha <| h₂.symm ▸ (one_mul a).symm
 
+variable {M₀ : Type*} [MonoidWithZero M₀]
+
+instance [IsLeftCancelMulZero M₀] : IsDedekindFiniteMonoid M₀ where
+  mul_eq_one_symm h := by
+    rcases subsingleton_or_nontrivial M₀ with hM | hM
+    · exact Subsingleton.elim _ _
+    exact (IsLeftCancelMulZero.mul_left_cancel_of_ne_zero
+      (left_ne_zero_of_mul_eq_one h)).mul_eq_one_symm h
+
+instance [IsRightCancelMulZero M₀] : IsDedekindFiniteMonoid M₀ where
+  mul_eq_one_symm h := by
+    rcases subsingleton_or_nontrivial M₀ with hM | hM
+    · exact Subsingleton.elim _ _
+    exact (IsRightCancelMulZero.mul_right_cancel_of_ne_zero
+      (right_ne_zero_of_mul_eq_one h)).mul_eq_one_symm h
+
 end CancelMonoidWithZero
 
 section GroupWithZero


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
