### PR TITLE
[Merged by Bors] - chore(MulLECancellable): rename lemmas

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -1400,24 +1400,40 @@ theorem mulLECancellable_one [MulOneClass α] [LE α] : MulLECancellable (1 : α
 namespace MulLECancellable
 
 @[to_additive]
-protected theorem Injective [Mul α] [PartialOrder α] {a : α} (ha : MulLECancellable a) :
-    Injective (a * ·) :=
-  fun _ _ h => le_antisymm (ha h.le) (ha h.ge)
+protected theorem injective_right [Mul α] [PartialOrder α] {a : α} (ha : MulLECancellable a) :
+    Injective (a * ·) := fun _ _ h => le_antisymm (ha h.le) (ha h.ge)
+
+@[deprecated (since := "2026-07-07")]
+protected alias _root_.MulLECancellable.Injective := MulLECancellable.injective_right
+
+@[deprecated (since := "2026-07-07")]
+protected alias _root_.AddLECancellable.Injective := AddLECancellable.injective_right
 
 @[to_additive]
 protected theorem isLeftRegular [Mul α] [PartialOrder α] {a : α}
     (ha : MulLECancellable a) : IsLeftRegular a :=
-  ha.Injective
+  ha.injective_right
 
 @[to_additive]
-protected theorem inj [Mul α] [PartialOrder α] {a b c : α} (ha : MulLECancellable a) :
+protected theorem inj_right [Mul α] [PartialOrder α] {a b c : α} (ha : MulLECancellable a) :
     a * b = a * c ↔ b = c :=
-  ha.Injective.eq_iff
+  ha.injective_right.eq_iff
+
+@[deprecated (since := "2026-07-07")]
+protected alias _root_.MulLECancellable.inj := MulLECancellable.inj_right
+
+@[deprecated (since := "2026-07-07")]
+protected alias _root_.AddLECancellable.inj := AddLECancellable.inj_right
 
 @[to_additive]
 protected theorem injective_left [Mul α] [IsMulCommutative α] [PartialOrder α] {a : α}
     (ha : MulLECancellable a) : Injective (· * a) :=
-  fun b c h ↦ ha.Injective <| by dsimp; rwa [mul_comm' a, mul_comm' a]
+  fun b c h ↦ ha.injective_right <| by dsimp; rwa [mul_comm' a, mul_comm' a]
+
+@[to_additive]
+protected theorem isRightRegular [Mul α] [IsMulCommutative α] [PartialOrder α] {a : α}
+    (ha : MulLECancellable a) : IsRightRegular a :=
+  ha.injective_left
 
 @[to_additive]
 protected theorem inj_left [Mul α] [IsMulCommutative α] [PartialOrder α] {a b c : α}

--- a/Mathlib/Algebra/Order/Sub/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Sub/Unbundled/Basic.lean
@@ -131,7 +131,7 @@ protected theorem lt_tsub_iff_left_of_le (hc : AddLECancellable c) (h : c ≤ b)
 
 protected theorem tsub_inj_right (hab : AddLECancellable (a - b)) (h₁ : b ≤ a) (h₂ : c ≤ a)
     (h₃ : a - b = a - c) : b = c := by
-  rw [← hab.inj]
+  rw [← hab.inj_right]
   rw [tsub_add_cancel_of_le h₁, h₃, tsub_add_cancel_of_le h₂]
 
 protected theorem lt_of_tsub_lt_tsub_left_of_le [AddLeftReflectLT α]

--- a/Mathlib/Data/ENNReal/Operations.lean
+++ b/Mathlib/Data/ENNReal/Operations.lean
@@ -267,7 +267,7 @@ theorem cancel_coe {a : ℝ≥0} : AddLECancellable (a : ℝ≥0∞) :=
   cancel_of_ne coe_ne_top
 
 theorem add_right_inj (h : a ≠ ∞) : a + b = a + c ↔ b = c :=
-  (cancel_of_ne h).inj
+  (cancel_of_ne h).inj_right
 
 theorem add_left_inj (h : a ≠ ∞) : b + a = c + a ↔ b = c :=
   (cancel_of_ne h).inj_left


### PR DESCRIPTION
Right now MulLECancellable has dual `Injective/inj` and `injective_left/inj_left` lemmas. Rename the first pair to `injective_right/inj_right` to match and add a `IsRightRegular` lemma to match the `IsLeftRegular` one.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
