### PR TITLE
[Merged by Bors] - chore: remove some unused instance arguments

### DIFF
--- a/Mathlib/Analysis/Convex/Birkhoff.lean
+++ b/Mathlib/Analysis/Convex/Birkhoff.lean
@@ -48,7 +48,7 @@ variable [Semifield R] [LinearOrder R] [IsStrictOrderedRing R] {M : Matrix n n R
 If M is a positive scalar multiple of a doubly stochastic matrix, then there is a permutation matrix
 whose support is contained in the support of M.
 -/
-private lemma exists_perm_eq_zero_implies_eq_zero [Nonempty n] {s : R} (hs : 0 < s)
+private lemma exists_perm_eq_zero_implies_eq_zero {s : R} (hs : 0 < s)
     (hM : ∃ M' ∈ doublyStochastic R n, M = s • M') :
     ∃ σ : Equiv.Perm n, ∀ i j, M i j = 0 → σ.permMatrix R i j = 0 := by
   rw [exists_mem_doublyStochastic_eq_smul_iff hs.le] at hM

--- a/Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean
+++ b/Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean
@@ -31,9 +31,8 @@ variable {ι : Type*}
 section prime
 variable {p : ℕ} [Fact p.Prime] {s : Finset ι}
 
-set_option linter.unusedVariables false in
 /-- The first multivariate polynomial used in the proof of Erdős–Ginzburg–Ziv. -/
-private noncomputable def f₁ (s : Finset ι) (a : ι → ZMod p) : MvPolynomial s (ZMod p) :=
+private noncomputable def f₁ (s : Finset ι) (_a : ι → ZMod p) : MvPolynomial s (ZMod p) :=
   ∑ i, X i ^ (p - 1)
 
 /-- The second multivariate polynomial used in the proof of Erdős–Ginzburg–Ziv. -/

--- a/Mathlib/Combinatorics/Nullstellensatz.lean
+++ b/Mathlib/Combinatorics/Nullstellensatz.lean
@@ -164,7 +164,7 @@ private theorem Alon.degree_P [Nontrivial R] (m : MonomialOrder σ) (S : Finset 
     exact isRegular_one
 
 /-- The leading coefficient of `Alon.P S i` is `1`. -/
-private theorem Alon.monic_P [Nontrivial R] (m : MonomialOrder σ) (S : Finset R) (i : σ) :
+private theorem Alon.monic_P (m : MonomialOrder σ) (S : Finset R) (i : σ) :
     m.Monic (P S i) :=
   Monic.prod (fun r _ ↦ m.monic_X_sub_C i r)
 

--- a/Mathlib/Data/W/Basic.lean
+++ b/Mathlib/Data/W/Basic.lean
@@ -129,8 +129,7 @@ We define an auxiliary type `WType' β n` of trees of depth at most `n`, and the
 induction on `n` that these are all encodable. These auxiliary constructions are not interesting in
 and of themselves, so we mark them as `private`.
 -/
-private abbrev WType' {α : Type*} (β : α → Type*) [∀ a : α, Fintype (β a)]
-    [∀ a : α, Encodable (β a)] (n : ℕ) :=
+private abbrev WType' {α : Type*} (β : α → Type*) [∀ a : α, Fintype (β a)] (n : ℕ) :=
   { t : WType β // t.depth ≤ n }
 
 variable [∀ a : α, Encodable (β a)]

--- a/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
@@ -29,8 +29,7 @@ namespace CommGroup
 
 open MonoidHom
 
-private
-lemma dvd_exponent {ι G : Type*} [Finite ι] [Monoid G] {n : ι → ℕ}
+private lemma dvd_exponent {ι G : Type*} [Monoid G] {n : ι → ℕ}
     (e : G ≃* ((i : ι) → Multiplicative (ZMod (n i)))) (i : ι) :
     n i ∣ Monoid.exponent G := by
   classical -- to get `DecidableEq ι`

--- a/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
+++ b/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
@@ -268,9 +268,7 @@ end SpanningTree
 
 set_option backward.privateInPublic true in
 /-- Another name for the identity function `G → G`, to help type checking. -/
-private def symgen {G : Type u} [Groupoid.{v} G] [IsFreeGroupoid G] :
-    G → Symmetrify (Generators G) :=
-  id
+private def symgen {G : Type u} [Groupoid.{v} G] : G → Symmetrify (Generators G) := id
 
 set_option backward.privateInPublic true in
 set_option backward.privateInPublic.warn false in

--- a/Mathlib/InformationTheory/Coding/KraftMcMillan.lean
+++ b/Mathlib/InformationTheory/Coding/KraftMcMillan.lean
@@ -65,8 +65,7 @@ private lemma concatFn_injective_of_uniquelyDecodable {S : Finset (List α)}
   have := List.ofFn_injective (h _ _ (by simp) (by simp) hflat)
   exact Subtype.ext (congrArg (fun f => f i) this)
 
-private lemma sum_pow_length_filter_eq_le_card_mul [Fintype α] [Nonempty α]
-    {T : Finset (List α)} {s : ℕ} :
+private lemma sum_pow_length_filter_eq_le_card_mul [Fintype α] {T : Finset (List α)} {s : ℕ} :
     (∑ x ∈ T.filter (fun x => x.length = s), (1 / (Fintype.card α : ℝ)) ^ x.length)
       ≤ ((Fintype.card α) ^ s) * (1 / Fintype.card α) ^ s := by
   calc

--- a/Mathlib/RingTheory/Etale/QuasiFinite.lean
+++ b/Mathlib/RingTheory/Etale/QuasiFinite.lean
@@ -447,9 +447,9 @@ attribute [local instance] Localization.AtPrime.algebraOfLiesOver
 
 /-- A key induction step of `exists_etale_completeOrthogonalIdempotents_forall_liesOver_eq`. -/
 private theorem Algebra.exists_etale_completeOrthogonalIdempotents_forall_liesOver_eq_aux
-    {R : Type u} {S : Type (max u v)} [CommRing R] [CommRing S] [Algebra R S] [Module.Finite R S]
-    (p : Ideal R) [p.IsPrime] (q : Ideal S) [q.IsPrime]
-    [q.LiesOver p] (R' : Type u) [CommRing R'] [Algebra R R'] [Algebra.Etale R R'] (P : Ideal R')
+    {R : Type u} {S : Type (max u v)} [CommRing R] [CommRing S] [Algebra R S]
+    (p : Ideal R) [p.IsPrime] (q : Ideal S)
+    (R' : Type u) [CommRing R'] [Algebra R R'] [Algebra.Etale R R'] (P : Ideal R')
     [P.IsPrime] [P.LiesOver p] (e : R' ⊗[R] S) (P' : Ideal (R' ⊗[R] S))
     [P'.IsPrime] [P'.LiesOver P]
     (hP'q : Ideal.comap Algebra.TensorProduct.includeRight.toRingHom P' = q)

--- a/Mathlib/RingTheory/Extension/Presentation/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Presentation/Basic.lean
@@ -341,10 +341,9 @@ assumption this span is the kernel of the evaluation map of `P`. For this, we us
 variable {ι' σ' T : Type*} [CommRing T] [Algebra S T]
 variable (Q : Presentation S T ι' σ') (P : Presentation R S ι σ)
 
-set_option linter.unusedVariables false in
 /-- The evaluation map `MvPolynomial (ι' ⊕ ι) →ₐ[R] T` factors via this map. For more
 details, see the module docstring at the beginning of the section. -/
-private noncomputable def aux (Q : Presentation S T ι' σ') (P : Presentation R S ι σ) :
+private noncomputable def aux (_Q : Presentation S T ι' σ') (P : Presentation R S ι σ) :
     MvPolynomial (ι' ⊕ ι) R →ₐ[R] MvPolynomial ι' S :=
   aeval (Sum.elim X (MvPolynomial.C ∘ P.val))
 

--- a/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
@@ -158,8 +158,7 @@ set_option backward.privateInPublic true in
 variable (R₀ R n e) in
 /-- The statement we induct on in the `C : R → R[X]` case of Chevalley's theorem with complexity
 bound. -/
-private def Statement [Algebra ℤ R] : Prop :=
-  ∀ f : R[X], ∃ T : ConstructibleSetData R,
+private def Statement : Prop := ∀ f : R[X], ∃ T : ConstructibleSetData R,
     comap Polynomial.C '' (zeroLocus (Set.range e) \ zeroLocus {f}) = T.toSet ∧
     ∀ C ∈ T, C.n ≤ e.degBound ∧ ∀ i, C.g i ∈ e.coeffSubmodule R₀ ^ e.powBound
 

--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -900,8 +900,7 @@ theorem mul_pow_mul {ea₁ b c₁ : ℕ} {xa₁ c₃ d : R} (_ : ea₁ * b = c�
   subst_vars; simp [_root_.mul_pow, pow_mul, Nat.rawCast]
 
 -- needed to lift from `OptionT CoreM` to `OptionT MetaM`
-private local instance {m m'} [Monad m] [Monad m'] [MonadLiftT m m'] :
-    MonadLiftT (OptionT m) (OptionT m') where
+private local instance {m m'} [MonadLiftT m m'] : MonadLiftT (OptionT m) (OptionT m') where
   monadLift x := OptionT.mk x.run
 
 /-- There are several special cases when exponentiating monomials:


### PR DESCRIPTION
Removes some unused instance arguments in private declarations. Found by leanprover-community/batteries#1831. Also uses `_` for intentionally unused arguments instead of setting the linter option, as this is respected by the `unusedArguments` linter as well.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
