### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions/ImproperIntegrals): fix typo

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -301,7 +301,7 @@ theorem integrableOn_inv_div_log_sq_Ioi {c : ℝ} (hc : 1 < c) :
     positivity
 
 @[simp]
-theorem integral_inv_divlog_sq_Ioi {c : ℝ} (hc : 1 < c) :
+theorem integral_inv_div_log_sq_Ioi {c : ℝ} (hc : 1 < c) :
     ∫ (t : ℝ) in .Ioi c, t⁻¹ / (log t) ^ 2 = (log c)⁻¹ := by
   convert! integral_Ioi_of_hasDerivAt_of_tendsto' (m := 0) (f := fun t ↦ -(log t)⁻¹) ?_
     (integrableOn_inv_div_log_sq_Ioi hc) ?_ using 1


### PR DESCRIPTION
An underscore was left out of the name of a recently merged theorem by mistake; this PR restores that underscore.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
