### PR TITLE
feat(NumberTheory): add bernoulli'_five, bernoulli'_six and riemannZeta_six

### DIFF
--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -124,18 +124,17 @@ theorem bernoulli'_one : bernoulli' 1 = 1 / 2 := by
 @[simp]
 theorem bernoulli'_two : bernoulli' 2 = 1 / 6 := by
   rw [bernoulli'_def]
-  norm_num [sum_range_succ, sum_range_succ, sum_range_zero]
+  norm_num [sum_range_succ]
 
 @[simp]
 theorem bernoulli'_three : bernoulli' 3 = 0 := by
   rw [bernoulli'_def]
-  norm_num [sum_range_succ, sum_range_succ, sum_range_zero]
+  norm_num [sum_range_succ]
 
 @[simp]
 theorem bernoulli'_four : bernoulli' 4 = -1 / 30 := by
-  have : Nat.choose 4 2 = 6 := by decide -- shrug
   rw [bernoulli'_def]
-  norm_num [sum_range_succ, sum_range_succ, sum_range_zero, this]
+  norm_num [sum_range_succ, Nat.choose]
 
 @[simp]
 theorem bernoulli'_five : bernoulli' 5 = 0 := by

--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -137,6 +137,16 @@ theorem bernoulli'_four : bernoulli' 4 = -1 / 30 := by
   rw [bernoulli'_def]
   norm_num [sum_range_succ, sum_range_succ, sum_range_zero, this]
 
+@[simp]
+theorem bernoulli'_five : bernoulli' 5 = 0 := by
+  rw [bernoulli'_def]
+  norm_num [sum_range_succ, Nat.choose]
+
+@[simp]
+theorem bernoulli'_six : bernoulli' 6 = 1 / 42 := by
+  rw [bernoulli'_def]
+  norm_num [sum_range_succ, Nat.choose]
+
 end Examples
 
 @[simp]

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
@@ -236,6 +236,11 @@ theorem riemannZeta_four : riemannZeta 4 = π ^ 4 / 90 := by
     simp only [push_cast]
   · norm_cast
 
+theorem riemannZeta_six : riemannZeta 6 = (π : ℂ) ^ 6 / 945 := by
+  linear_combination
+    (norm := (norm_num [bernoulli_eq_bernoulli'_of_ne_one, bernoulli'_six, Nat.factorial]; ring1))
+    riemannZeta_two_mul_nat (k := 3) three_ne_zero
+
 /-- Value of Riemann zeta at `-ℕ` in terms of `bernoulli'`. -/
 theorem riemannZeta_neg_nat_eq_bernoulli' (k : ℕ) :
     riemannZeta (-k) = -bernoulli' (k + 1) / (k + 1) := by


### PR DESCRIPTION
Add bernoulli'_five and bernoulli'_six as simp lemmas, continuing the
existing sequence of explicit values bernoulli'_zero through
bernoulli'_four, and use the latter to prove `riemannZeta 6 = π ^ 6 / 945`.

Along the way, golf the proofs of `bernoulli'_two`, `bernoulli'_three` and
`bernoulli'_four` .

These results are upstreamed from the FLT project (ImperialCollegeLondon/FLT#1069).

Co-authored-by: William Coram
Co-authored-by: Samuel Yin
Co-authored-by: Pepa Montero
Co-authored-by: Archie Browne

---


Original PR by William Coram and Samuel Yin, written with the assistance of Claude and
cleaned up by Codex and then by Pepa Montero).

I have done some further changes to fit Mathlib conventions and Claude was also used to help shorten the
proof of `riemannZeta_six` with an idea by Archie Browne.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
