### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/InfiniteSum/NatInt): hasProd versions of ℕ+/ℕ transfer lemmas

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
@@ -542,8 +542,26 @@ lemma multipliable_pnat_iff_multipliable_nat [TopologicalSpace G] [IsTopological
   rw [multipliable_pnat_iff_multipliable_succ, multipliable_nat_add_iff]
 
 @[to_additive]
+theorem hasProd_pnat_iff_hasProd_succ {f : ℕ → M} :
+    HasProd (fun x : ℕ+ ↦ f x) m ↔ HasProd (fun x : ℕ ↦ f (x + 1)) m :=
+  Equiv.pnatEquivNat.symm.hasProd_iff.symm
+
+@[to_additive]
+theorem hasProd_pnat_iff [TopologicalSpace G] [IsTopologicalGroup G] {f : ℕ → G} {a : G} :
+    HasProd (fun x : ℕ+ ↦ f x) a ↔ HasProd f (a * f 0) := by
+  simp [hasProd_pnat_iff_hasProd_succ, hasProd_nat_add_iff]
+
+@[to_additive]
 theorem tprod_pnat_eq_tprod_succ {f : ℕ → M} : ∏' n : ℕ+, f n = ∏' n, f (n + 1) :=
   (Equiv.pnatEquivNat.symm.tprod_eq _).symm
+
+@[to_additive]
+theorem tprod_pnat_eq_tprod_of_eq_one {f : ℕ → M} (hf : f 0 = 1) :
+    ∏' n : ℕ+, f n = ∏' n : ℕ, f n :=
+  PNat.coe_injective.tprod_eq fun n hn ↦ by
+    rcases Nat.eq_zero_or_pos n with rfl | h
+    · exact absurd hf hn
+    · exact ⟨⟨n, h⟩, rfl⟩
 
 @[to_additive]
 lemma tprod_zero_pnat_eq_tprod_nat [TopologicalSpace G] [IsTopologicalGroup G] [T2Space G]


### PR DESCRIPTION
The `PNat` section of `Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean` provides `Multipliable` and `tprod` lemmas for transferring infinite products between `ℕ+` and `ℕ`, but not `HasProd` lemmas. This PR completes this gap with:

* `hasProd_pnat_iff_hasProd_succ`: `HasProd (fun n : ℕ+ ↦ f n) m ↔ HasProd (fun n : ℕ ↦ f (n + 1)) m`, the `HasProd` counterpart of the existing `multipliable_pnat_iff_multipliable_succ`
* `hasProd_pnat_iff`: in a topological group, `HasProd (fun n : ℕ+ ↦ f n) g ↔ HasProd f (g * f 0)`, the counterpart of `multipliable_pnat_iff_multipliable_nat`
* `tprod_pnat_eq_tprod_of_eq_one`: if `f 0 = 1`, then `∏' n : ℕ+, f n = ∏' n, f n`. Unlike `tprod_zero_pnat_eq_tprod_nat`, this requires no multipliability hypothesis (and no group structure or `T2Space`)

**Motivation**: the additive versions (`hasSum_pnat_iff`, `tsum_pnat_eq_tsum_of_eq_zero`, ...) replace
three private lemmas in the [FLT project](https://github.com/ImperialCollegeLondon/FLT) (`hasSum_nat_of_pnat_add`, `hasSum_pnat_of_nat`, `tsum_pnat_of_zero`), each of which becomes a one-line application, stated there for `ℂ` only.

**AI Disclosure**: original code in FLT was written by William Coram and Samuel Yin with the assistance of Claude. It was later cleaned up using Codex.

Co-authored-by: William Coram
Co-authored-by: Samuel Yin

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
