### PR TITLE
[Merged by Bors] - feat: add formula for the `j`-invariant of an elliptic curve

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -379,9 +379,6 @@ discriminant `Δ` of it as a Weierstrass curve. -/
 lemma coe_Δ' : W.Δ' = W.Δ :=
   rfl
 
-theorem j_eq : W.j = W.Δ⁻¹ * W.c₄ ^ 3 := by
-  rw [WeierstrassCurve.j, Units.val_inv_eq_inv_val, WeierstrassCurve.coe_Δ']
-
 /-- The j-invariant `j` of an elliptic curve, which is invariant under isomorphisms over `R`.
 Note that to prove two equal elliptic curves have the same `j`, you need to use `simp_rw`,
 as `rw` cannot transfer instance `WeierstrassCurve.IsElliptic` automatically. -/
@@ -397,6 +394,10 @@ lemma j_eq_zero (h : W.c₄ = 0) : W.j = 0 := by
 
 lemma j_eq_zero_iff [IsReduced R] : W.j = 0 ↔ W.c₄ = 0 := by
   rw [j_eq_zero_iff', pow_eq_zero_iff three_ne_zero]
+
+theorem j_eq {K : Type*} [Field K] (W : WeierstrassCurve K) [W.IsElliptic] :
+    W.j = W.Δ⁻¹ * W.c₄ ^ 3 := by
+  rw [WeierstrassCurve.j, Units.val_inv_eq_inv_val, WeierstrassCurve.coe_Δ']
 
 section CharTwo
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -379,8 +379,7 @@ discriminant `Δ` of it as a Weierstrass curve. -/
 lemma coe_Δ' : W.Δ' = W.Δ :=
   rfl
 
-theorem j_eq {K : Type*} [Field K] (E : WeierstrassCurve K) [E.IsElliptic] :
-    E.j = E.Δ⁻¹ * E.c₄ ^ 3 := by
+theorem j_eq : W.j = W.Δ⁻¹ * W.c₄ ^ 3 := by
   rw [WeierstrassCurve.j, Units.val_inv_eq_inv_val, WeierstrassCurve.coe_Δ']
 
 /-- The j-invariant `j` of an elliptic curve, which is invariant under isomorphisms over `R`.

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -379,6 +379,10 @@ discriminant `Δ` of it as a Weierstrass curve. -/
 lemma coe_Δ' : W.Δ' = W.Δ :=
   rfl
 
+theorem j_eq {K : Type*} [Field K] (E : WeierstrassCurve K) [E.IsElliptic] :
+    E.j = E.Δ⁻¹ * E.c₄ ^ 3 := by
+  rw [WeierstrassCurve.j, Units.val_inv_eq_inv_val, WeierstrassCurve.coe_Δ']
+
 /-- The j-invariant `j` of an elliptic curve, which is invariant under isomorphisms over `R`.
 Note that to prove two equal elliptic curves have the same `j`, you need to use `simp_rw`,
 as `rw` cannot transfer instance `WeierstrassCurve.IsElliptic` automatically. -/


### PR DESCRIPTION
This doesn't seem to be in Mathlib yet (?).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
