### PR TITLE
[Merged by Bors] - feat: variations of Submodule.disjoint_map with weaker hypotheses

### DIFF
--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -452,8 +452,7 @@ end OrderIso
 --TODO(Mario): is there a way to prove this from order properties?
 theorem map_inf_eq_map_inf_comap [RingHomSurjective σ₁₂] {f : M →ₛₗ[σ₁₂] M₂} {p : Submodule R M}
     {p' : Submodule R₂ M₂} : map f p ⊓ p' = map f (p ⊓ comap f p') :=
-  le_antisymm (by rintro _ ⟨⟨x, h₁, rfl⟩, h₂⟩; exact ⟨_, ⟨h₁, h₂⟩, rfl⟩)
-    (le_inf (map_mono inf_le_left) (map_le_iff_le_comap.2 inf_le_right))
+  .symm <| SetLike.coe_injective <| image_inter_preimage _ _ _
 
 @[simp]
 theorem map_comap_subtype : map p.subtype (comap p.subtype p') = p ⊓ p' :=

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -643,6 +643,9 @@ variable [AddCommGroup M] [Module R M] [AddCommGroup M₂] [Module R₂ M₂]
 variable {τ₁₂ : R →+* R₂} [RingHomSurjective τ₁₂]
 variable {p p' : Submodule R M}
 
+/-- Let `f : M →ₗ N`. Assume that `p` and `q` are disjoint submodules of `M`,
+and that the kernel of `f` "decomposes well" wrt. `p` and `q`, in the sense that
+`f.ker = (f.ker ⊓ p) ⊔ (f.ker ⊓ q)`. Then `map f p` and `map f q` are disjoint. -/
 lemma disjoint_map_of_ker_le_inf_sup {f : M →ₛₗ[τ₁₂] M₂} {p q : Submodule R M}
     (hpq : Disjoint p q) (hker : f.ker ≤ (f.ker ⊓ p) ⊔ (f.ker ⊓ q)) :
     Disjoint (p.map f) (q.map f) := by

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -643,20 +643,6 @@ variable [AddCommGroup M] [Module R M] [AddCommGroup M₂] [Module R₂ M₂]
 variable {τ₁₂ : R →+* R₂} [RingHomSurjective τ₁₂]
 variable {p p' : Submodule R M}
 
-/-- Let `f : M →ₗ N`. Assume that `p` and `q` are disjoint submodules of `M`,
-and that the kernel of `f` "decomposes well" wrt. `p` and `q`, in the sense that
-`f.ker = (f.ker ⊓ p) ⊔ (f.ker ⊓ q)`. Then `map f p` and `map f q` are disjoint. -/
-lemma disjoint_map_of_ker_le_inf_sup {f : M →ₛₗ[τ₁₂] M₂} {p q : Submodule R M}
-    (hpq : Disjoint p q) (hker : f.ker ≤ (f.ker ⊓ p) ⊔ (f.ker ⊓ q)) :
-    Disjoint (p.map f) (q.map f) := by
-  replace hker : f.ker = (f.ker ⊓ p) ⊔ (f.ker ⊓ q) :=
-    le_antisymm hker (sup_le inf_le_left inf_le_left)
-  have : q ⊔ f.ker = q ⊔ (p ⊓ f.ker) := by
-    conv_lhs => rw [hker, inf_comm]; simp only [← sup_assoc, inf_left_le_sup_right, sup_of_le_left]
-  rw [disjoint_iff, map_inf_eq_map_inf_comap, comap_map_eq, eq_bot_iff, map_le_iff_le_comap,
-    comap_bot, this, ← inf_sup_assoc_of_le _ inf_le_left, hpq.eq_bot, bot_sup_eq]
-  exact inf_le_right
-
 theorem map_strict_mono_or_ker_sup_lt_ker_sup (f : M →ₛₗ[τ₁₂] M₂) (hab : p < p') :
     Submodule.map f p < Submodule.map f p' ∨ LinearMap.ker f ⊓ p < LinearMap.ker f ⊓ p' := by
   obtain (⟨h, -⟩ | ⟨-, h⟩) := Prod.mk_lt_mk.mp <| strictMono_inf_prod_sup (z := LinearMap.ker f) hab

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -561,6 +561,16 @@ theorem comap_map_sup_of_comap_le {f : M →ₛₗ[τ₁₂] M₂} {p : Submodul
   rw [add_comm, ← eq_sub_iff_add_eq, ← map_sub] at eq; subst eq
   simpa using p.add_mem (le hz) hy
 
+lemma disjoint_map_of_ker_le_right {f : M →ₛₗ[τ₁₂] M₂} {p q : Submodule R M}
+    (hpq : Disjoint p q) (hker : f.ker ≤ q) : Disjoint (p.map f) (q.map f) := by
+  rw [disjoint_iff, map_inf_eq_map_inf_comap, comap_map_eq, eq_bot_iff, map_le_iff_le_comap,
+    comap_bot, sup_eq_left.mpr hker, hpq.eq_bot]
+  exact bot_le
+
+lemma disjoint_map_of_ker_le_left {f : M →ₛₗ[τ₁₂] M₂} {p q : Submodule R M}
+    (hpq : Disjoint p q) (hker : f.ker ≤ p) : Disjoint (p.map f) (q.map f) :=
+  disjoint_map_of_ker_le_right hpq.symm hker |>.symm
+
 theorem isCoatom_comap_or_eq_top (f : M →ₛₗ[τ₁₂] M₂) {p : Submodule R₂ M₂} (hp : IsCoatom p) :
     IsCoatom (comap f p) ∨ comap f p = ⊤ :=
   or_iff_not_imp_right.mpr fun h ↦ ⟨h, fun q lt ↦ by
@@ -632,6 +642,17 @@ variable [Ring R] [Semiring R₂]
 variable [AddCommGroup M] [Module R M] [AddCommGroup M₂] [Module R₂ M₂]
 variable {τ₁₂ : R →+* R₂} [RingHomSurjective τ₁₂]
 variable {p p' : Submodule R M}
+
+lemma disjoint_map_of_ker_le_inf_sup {f : M →ₛₗ[τ₁₂] M₂} {p q : Submodule R M}
+    (hpq : Disjoint p q) (hker : f.ker ≤ (f.ker ⊓ p) ⊔ (f.ker ⊓ q)) :
+    Disjoint (p.map f) (q.map f) := by
+  replace hker : f.ker = (f.ker ⊓ p) ⊔ (f.ker ⊓ q) :=
+    le_antisymm hker (sup_le inf_le_left inf_le_left)
+  have : q ⊔ f.ker = q ⊔ (p ⊓ f.ker) := by
+    conv_lhs => rw [hker, inf_comm]; simp only [← sup_assoc, inf_left_le_sup_right, sup_of_le_left]
+  rw [disjoint_iff, map_inf_eq_map_inf_comap, comap_map_eq, eq_bot_iff, map_le_iff_le_comap,
+    comap_bot, this, ← inf_sup_assoc_of_le _ inf_le_left, hpq.eq_bot, bot_sup_eq]
+  exact inf_le_right
 
 theorem map_strict_mono_or_ker_sup_lt_ker_sup (f : M →ₛₗ[τ₁₂] M₂) (hab : p < p') :
     Submodule.map f p < Submodule.map f p' ∨ LinearMap.ker f ⊓ p < LinearMap.ker f ⊓ p' := by


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
