### PR TITLE
[Merged by Bors] - feat(Analysis/CStarAlgebra/Matrix): add CStarAlgebra instance for matrices

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/Matrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Matrix.lean
@@ -289,6 +289,14 @@ lemma instCStarRing : CStarRing (Matrix n n 𝕜) where
 
 scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instCStarRing
 
+/-- The matrices Matrix n n ℂ with the L2 operator norm form a CStarAlgebra. -/
+
+@[reducible] noncomputable def instCStarAlgebra {n : Type*} [Fintype n] [DecidableEq n] :
+
+    CStarAlgebra (Matrix n n ℂ) := {}
+
+scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instCStarAlgebra
+
 end Matrix
 
 end L2OpNorm

--- a/Mathlib/Analysis/CStarAlgebra/Matrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Matrix.lean
@@ -5,6 +5,7 @@ Authors: Hans Parshall
 -/
 module
 
+public import Mathlib.Analysis.CStarAlgebra.Classes
 public import Mathlib.Analysis.InnerProductSpace.Adjoint
 public import Mathlib.Analysis.Matrix.Normed
 public import Mathlib.Analysis.RCLike.Basic
@@ -291,7 +292,7 @@ scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instCStarRing
 
 /-- The matrices Matrix n n ℂ with the L2 operator norm form a CStarAlgebra. -/
 
-@[reducible] noncomputable def instCStarAlgebra {n : Type*} [Fintype n] [DecidableEq n] :
+@[instance_reducible] noncomputable def instCStarAlgebra {n : Type*} [Fintype n] [DecidableEq n] :
 
     CStarAlgebra (Matrix n n ℂ) := {}
 

--- a/Mathlib/Analysis/CStarAlgebra/Matrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Matrix.lean
@@ -290,7 +290,7 @@ lemma instCStarRing : CStarRing (Matrix n n 𝕜) where
 
 scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instCStarRing
 
-/-- The matrices Matrix n n ℂ with the L2 operator norm form a CStarAlgebra. -/
+/-- The matrices `Matrix n n ℂ` with the L2 operator norm form a `CStarAlgebra`. -/
 @[instance_reducible] noncomputable def instCStarAlgebra {n : Type*} [Fintype n] [DecidableEq n] :
     CStarAlgebra (Matrix n n ℂ) where
 

--- a/Mathlib/Analysis/CStarAlgebra/Matrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Matrix.lean
@@ -292,7 +292,7 @@ scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instCStarRing
 
 /-- The matrices Matrix n n ℂ with the L2 operator norm form a CStarAlgebra. -/
 @[instance_reducible] noncomputable def instCStarAlgebra {n : Type*} [Fintype n] [DecidableEq n] :
-    CStarAlgebra (Matrix n n ℂ) := {}
+    CStarAlgebra (Matrix n n ℂ) where
 
 scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instCStarAlgebra
 

--- a/Mathlib/Analysis/CStarAlgebra/Matrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Matrix.lean
@@ -291,9 +291,7 @@ lemma instCStarRing : CStarRing (Matrix n n 𝕜) where
 scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instCStarRing
 
 /-- The matrices Matrix n n ℂ with the L2 operator norm form a CStarAlgebra. -/
-
 @[instance_reducible] noncomputable def instCStarAlgebra {n : Type*} [Fintype n] [DecidableEq n] :
-
     CStarAlgebra (Matrix n n ℂ) := {}
 
 scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instCStarAlgebra


### PR DESCRIPTION
Adds the bundled CStarAlgebra instance for Matrix n n ℂ in the L2 operator norm (Mathlib already has CStarRing scoped in Matrix.Norms.L2Operator, but not the bundled algebra). Composed from the existing scoped instances. Follow-up to #40900.