### PR TITLE
feat(CategoryTheory): pasting for kan extensions

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Extension.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Extension.lean
@@ -79,12 +79,7 @@ abbrev homMk (η : s.extension ⟶ t.extension) (w : s.unit ≫ f ◁ η = t.uni
 theorem w (η : s ⟶ t) : s.unit ≫ f ◁ η.right = t.unit :=
   StructuredArrow.w η
 
-@[reassoc (attr := simp)]
-theorem homMk_left (η : s.extension ⟶ t.extension) (w : s.unit ≫ f ◁ η = t.unit) :
-    (homMk η w).left = 𝟙 s.left :=
-  rfl
-
-@[reassoc (attr := simp)]
+@[simp]
 theorem homMk_right (η : s.extension ⟶ t.extension) (w : s.unit ≫ f ◁ η = t.unit) :
     (homMk η w).right = η :=
   rfl
@@ -281,12 +276,7 @@ abbrev homMk (η : s.lift ⟶ t.lift) (w : s.unit ≫ η ▷ f = t.unit := by ca
     s ⟶ t :=
   StructuredArrow.homMk η w
 
-@[reassoc (attr := simp)]
-theorem homMk_left (η : s.lift ⟶ t.lift) (w : s.unit ≫ η ▷ f = t.unit) :
-    (homMk η w).left = 𝟙 s.left :=
-  rfl
-
-@[reassoc (attr := simp)]
+@[simp]
 theorem homMk_right (η : s.lift ⟶ t.lift) (w : s.unit ≫ η ▷ f = t.unit) :
     (homMk η w).right = η :=
   rfl
@@ -493,14 +483,9 @@ abbrev homMk (η : s.extension ⟶ t.extension)
 theorem w (η : s ⟶ t) : f ◁ η.left ≫ t.counit = s.counit :=
   CostructuredArrow.w η
 
-@[reassoc (attr := simp)]
+@[simp]
 theorem homMk_left (η : s.extension ⟶ t.extension) (w : f ◁ η ≫ t.counit = s.counit) :
     (homMk η w).left = η :=
-  rfl
-
-@[reassoc (attr := simp)]
-theorem homMk_right (η : s.extension ⟶ t.extension) (w : f ◁ η ≫ t.counit = s.counit) :
-    (homMk η w).right = 𝟙 s.right :=
   rfl
 
 /-- The right extension along the identity. -/
@@ -700,14 +685,9 @@ abbrev homMk (η : s.lift ⟶ t.lift) (w : η ▷ f ≫ t.counit = s.counit := b
 theorem w (h : s ⟶ t) : h.left ▷ f ≫ t.counit = s.counit :=
   CostructuredArrow.w h
 
-@[reassoc (attr := simp)]
+@[simp]
 theorem homMk_left (η : s.lift ⟶ t.lift) (w : η ▷ f ≫ t.counit = s.counit) :
     (homMk η w).left = η :=
-  rfl
-
-@[reassoc (attr := simp)]
-theorem homMk_right (η : s.lift ⟶ t.lift) (w : η ▷ f ≫ t.counit = s.counit) :
-    (homMk η w).right = 𝟙 s.right :=
   rfl
 
 /-- The right lift along the identity. -/

--- a/Mathlib/CategoryTheory/Bicategory/Extension.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Extension.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.CategoryTheory.Bicategory.Basic
 public import Mathlib.CategoryTheory.Comma.StructuredArrow.Basic
+public import Mathlib.Tactic.CategoryTheory.Bicategory.Basic
 
 /-!
 # Extensions and lifts in bicategories
@@ -77,6 +78,16 @@ abbrev homMk (η : s.extension ⟶ t.extension) (w : s.unit ≫ f ◁ η = t.uni
 @[reassoc (attr := simp)]
 theorem w (η : s ⟶ t) : s.unit ≫ f ◁ η.right = t.unit :=
   StructuredArrow.w η
+
+@[reassoc (attr := simp)]
+theorem homMk_left (η : s.extension ⟶ t.extension) (w : s.unit ≫ f ◁ η = t.unit) :
+    (homMk η w).left = 𝟙 s.left :=
+  rfl
+
+@[reassoc (attr := simp)]
+theorem homMk_right (η : s.extension ⟶ t.extension) (w : s.unit ≫ f ◁ η = t.unit) :
+    (homMk η w).right = η :=
+  rfl
 
 /-- The left extension along the identity. -/
 def alongId (g : a ⟶ c) : LeftExtension (𝟙 a) g := .mk _ (λ_ g).inv
@@ -189,6 +200,50 @@ def whiskerOfIso (t : LeftExtension f g) {x : B} (h : c ⟶ x) :
 
 end OfIso
 
+section Paste
+
+variable {d : B} {f : a ⟶ b} {g : a ⟶ c} {h : b ⟶ d}
+
+/-- Given a left extension `t` of `g` along `f` and a left extension `s` of `t` along `h`, then we
+obtain a left extension `t.paste s` of `g` along `f ≫ h`.
+```
+  b                 d                    d
+  △ \               △ \                  △ \
+  |   \ t.ext       |   \ s.ext          |   \ paste.ext
+f |  ⇓  \         h |  ⇓  \        f ≫ h |  ⇓  \
+  |       ◿         |       ◿            |       ◿
+  a - - - ▷ c       b - - - ▷ c          a - - - ▷ c
+       g                t.ext                 g
+```
+-/
+def paste (t : LeftExtension f g) (s : LeftExtension h t.extension) : LeftExtension (f ≫ h) g :=
+  .mk s.extension (t.unit ≫ f ◁ s.unit ≫ (α_ f h s.extension).inv)
+
+variable {t : LeftExtension f g} {s : LeftExtension h t.extension}
+
+@[simp]
+theorem paste_extension : (t.paste s).extension = s.extension :=
+  rfl
+
+@[simp]
+theorem paste_unit :
+    (t.paste s).unit = t.unit ≫ f ◁ s.unit ≫ (α_ f h s.extension).inv :=
+  rfl
+
+/-- Whiskering a pasted left extension is isomorphic to pasting the whiskered left extensions. -/
+def pasteWhiskerIso (t : LeftExtension f g) (s : LeftExtension h t.extension) {x : B} (k : c ⟶ x) :
+    (t.paste s).whisker k ≅ (t.whisker k).paste (s.whisker k) :=
+  { hom := LeftExtension.homMk (𝟙 _) <| by
+      dsimp only [paste_extension, paste_unit, whisker_extension, whisker_unit]
+      bicategory
+    inv := LeftExtension.homMk (𝟙 _) <| by
+      dsimp only [paste_extension, paste_unit, whisker_extension, whisker_unit]
+      bicategory
+    hom_inv_id := by ext; simp
+    inv_hom_id := by ext; simp }
+
+end Paste
+
 end LeftExtension
 
 /-- Triangle diagrams for (left) lifts.
@@ -225,6 +280,16 @@ and to check that it is compatible with the units. -/
 abbrev homMk (η : s.lift ⟶ t.lift) (w : s.unit ≫ η ▷ f = t.unit := by cat_disch) :
     s ⟶ t :=
   StructuredArrow.homMk η w
+
+@[reassoc (attr := simp)]
+theorem homMk_left (η : s.lift ⟶ t.lift) (w : s.unit ≫ η ▷ f = t.unit) :
+    (homMk η w).left = 𝟙 s.left :=
+  rfl
+
+@[reassoc (attr := simp)]
+theorem homMk_right (η : s.lift ⟶ t.lift) (w : s.unit ≫ η ▷ f = t.unit) :
+    (homMk η w).right = η :=
+  rfl
 
 @[reassoc (attr := simp)]
 theorem w (h : s ⟶ t) : s.unit ≫ h.right ▷ f = t.unit :=
@@ -343,6 +408,50 @@ def whiskerOfIso (t : LeftLift f g) {x : B} (h : x ⟶ c) :
 
 end OfIso
 
+section Paste
+
+variable {d : B} {f : b ⟶ a} {g : d ⟶ a} {h : c ⟶ b}
+
+/-- Given a left lift `t` of `g` along `f` and a left lift `s` of `t` along `h`, then we obtain a
+left lift `t.paste s` of `g` along `f ≫ h`.
+```
+            b                 c                     c
+          ◹ |               ◹ |                   ◹ |
+ t.lift /   |      s.lift /   |      paste.lift /   |
+      /  ⇑  | f         /  ⇑  | h             /  ⇑  | f ≫ h
+    /       ▽         /       ▽             /       ▽
+  d - - - ▷ a       d - - - ▷ b           d - - - ▷ a
+       g              t.lift                   g
+```
+-/
+def paste (t : LeftLift f g) (s : LeftLift h t.lift) : LeftLift (h ≫ f) g :=
+  .mk s.lift (t.unit ≫ s.unit ▷ f ≫ (α_ s.lift h f).hom)
+
+variable {t : LeftLift f g} {s : LeftLift h t.lift}
+
+@[simp]
+theorem paste_lift : (t.paste s).lift = s.lift :=
+  rfl
+
+@[simp]
+theorem paste_unit :
+    (t.paste s).unit = t.unit ≫ s.unit ▷ f ≫ (α_ s.lift h f).hom :=
+  rfl
+
+/-- Whiskering a pasted left lift is isomorphic to pasting the whiskered left lifts. -/
+def pasteWhiskerIso (t : LeftLift f g) (s : LeftLift h t.lift) {x : B} (k : x ⟶ d) :
+    (t.paste s).whisker k ≅ (t.whisker k).paste (s.whisker k) :=
+  { hom := LeftLift.homMk (𝟙 _) <| by
+      dsimp only [paste_lift, paste_unit, whisker_lift, whisker_unit]
+      bicategory
+    inv := LeftLift.homMk (𝟙 _) <| by
+      dsimp only [paste_lift, paste_unit, whisker_lift, whisker_unit]
+      bicategory
+    hom_inv_id := by ext; simp
+    inv_hom_id := by ext; simp }
+
+end Paste
+
 end LeftLift
 
 /-- Triangle diagrams for (right) extensions.
@@ -383,6 +492,16 @@ abbrev homMk (η : s.extension ⟶ t.extension)
 @[reassoc (attr := simp)]
 theorem w (η : s ⟶ t) : f ◁ η.left ≫ t.counit = s.counit :=
   CostructuredArrow.w η
+
+@[reassoc (attr := simp)]
+theorem homMk_left (η : s.extension ⟶ t.extension) (w : f ◁ η ≫ t.counit = s.counit) :
+    (homMk η w).left = η :=
+  rfl
+
+@[reassoc (attr := simp)]
+theorem homMk_right (η : s.extension ⟶ t.extension) (w : f ◁ η ≫ t.counit = s.counit) :
+    (homMk η w).right = 𝟙 s.right :=
+  rfl
 
 /-- The right extension along the identity. -/
 def alongId (g : a ⟶ c) : RightExtension (𝟙 a) g := .mk _ (λ_ g).hom
@@ -495,6 +614,51 @@ def whiskerOfIso (t : RightExtension f g) {x : B} (h : c ⟶ x) :
 
 end OfIso
 
+section Paste
+
+variable {d : B} {f : a ⟶ b} {g : a ⟶ c} {h : b ⟶ d}
+
+/-- Given a right extension `t` of `g` along `f` and a right extension `s` of `t` along `h`, then we
+obtain a right extension `t.paste s` of `g` along `f ≫ h`.
+```
+  b                 d                    d
+  △ \               △ \                  △ \
+  |   \ t.ext       |   \ s.ext          |   \ paste.ext
+f |  ⇑  \         h |  ⇑  \        f ≫ h |  ⇑  \
+  |       ◿         |       ◿            |       ◿
+  a - - - ▷ c       b - - - ▷ c          a - - - ▷ c
+       g                t.ext                 g
+```
+-/
+def paste (t : RightExtension f g) (s : RightExtension h t.extension) : RightExtension (f ≫ h) g :=
+  .mk s.extension ((α_ f h s.extension).hom ≫ f ◁ s.counit ≫ t.counit)
+
+variable {t : RightExtension f g} {s : RightExtension h t.extension}
+
+@[simp]
+theorem paste_extension : (t.paste s).extension = s.extension :=
+  rfl
+
+@[simp]
+theorem paste_counit :
+    (t.paste s).counit = (α_ f h s.extension).hom ≫ f ◁ s.counit ≫ t.counit :=
+  rfl
+
+/-- Whiskering a pasted right extension is isomorphic to pasting the whiskered right extensions. -/
+def pasteWhiskerIso (t : RightExtension f g) (s : RightExtension h t.extension) {x : B}
+    (k : c ⟶ x) :
+    (t.paste s).whisker k ≅ (t.whisker k).paste (s.whisker k) :=
+  { hom := RightExtension.homMk (𝟙 _) <| by
+      dsimp only [paste_extension, paste_counit, whisker_extension, whisker_counit]
+      bicategory
+    inv := RightExtension.homMk (𝟙 _) <| by
+      dsimp only [paste_extension, paste_counit, whisker_extension, whisker_counit]
+      bicategory
+    hom_inv_id := by ext; simp
+    inv_hom_id := by ext; simp }
+
+end Paste
+
 end RightExtension
 
 /-- Triangle diagrams for (right) lifts.
@@ -535,6 +699,16 @@ abbrev homMk (η : s.lift ⟶ t.lift) (w : η ▷ f ≫ t.counit = s.counit := b
 @[reassoc (attr := simp)]
 theorem w (h : s ⟶ t) : h.left ▷ f ≫ t.counit = s.counit :=
   CostructuredArrow.w h
+
+@[reassoc (attr := simp)]
+theorem homMk_left (η : s.lift ⟶ t.lift) (w : η ▷ f ≫ t.counit = s.counit) :
+    (homMk η w).left = η :=
+  rfl
+
+@[reassoc (attr := simp)]
+theorem homMk_right (η : s.lift ⟶ t.lift) (w : η ▷ f ≫ t.counit = s.counit) :
+    (homMk η w).right = 𝟙 s.right :=
+  rfl
 
 /-- The right lift along the identity. -/
 def alongId (g : c ⟶ a) : RightLift (𝟙 a) g := .mk _ (ρ_ g).hom
@@ -649,6 +823,50 @@ def whiskerOfIso (t : RightLift f g) {x : B} (h : x ⟶ c) :
   CostructuredArrow.isoMk (Iso.refl _) <| by simp [postcomp]
 
 end OfIso
+
+section Paste
+
+variable {d : B} {f : b ⟶ a} {g : d ⟶ a} {h : c ⟶ b}
+
+/-- Given a right lift `t` of `g` along `f` and a right lift `s` of `t` along `h`, then we obtain a
+right lift `t.paste s` of `g` along `f ≫ h`.
+```
+            b                 c                     c
+          ◹ |               ◹ |                   ◹ |
+ t.lift /   |      s.lift /   |      paste.lift /   |
+      /  ⇓  | f         /  ⇓  | h             /  ⇓  | f ≫ h
+    /       ▽         /       ▽             /       ▽
+  d - - - ▷ a       d - - - ▷ b           d - - - ▷ a
+       g              t.lift                   g
+```
+-/
+def paste (t : RightLift f g) (s : RightLift h t.lift) : RightLift (h ≫ f) g :=
+  .mk s.lift ((α_ s.lift h f).inv ≫ s.counit ▷ f ≫ t.counit)
+
+variable {t : RightLift f g} {s : RightLift h t.lift}
+
+@[simp]
+theorem paste_lift : (t.paste s).lift = s.lift :=
+  rfl
+
+@[simp]
+theorem paste_counit :
+    (t.paste s).counit = (α_ s.lift h f).inv ≫ s.counit ▷ f ≫ t.counit :=
+  rfl
+
+/-- Whiskering a pasted right lift is isomorphic to pasting the whiskered right lifts. -/
+def pasteWhiskerIso (t : RightLift f g) (s : RightLift h t.lift) {x : B} (k : x ⟶ d) :
+    (t.paste s).whisker k ≅ (t.whisker k).paste (s.whisker k) :=
+  { hom := RightLift.homMk (𝟙 _) <| by
+      dsimp only [paste_lift, paste_counit, whisker_lift, whisker_counit]
+      bicategory
+    inv := RightLift.homMk (𝟙 _) <| by
+      dsimp only [paste_lift, paste_counit, whisker_lift, whisker_counit]
+      bicategory
+    hom_inv_id := by ext; simp
+    inv_hom_id := by ext; simp }
+
+end Paste
 
 end RightLift
 

--- a/Mathlib/CategoryTheory/Bicategory/Extension.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Extension.lean
@@ -158,6 +158,37 @@ set_option backward.defeqAttrib.useBackward true in
 def whiskerOfCompIdIsoSelf (t : LeftExtension f g) : (t.whisker (𝟙 c)).ofCompId ≅ t :=
   StructuredArrow.isoMk (ρ_ (t.extension))
 
+section OfIso
+
+variable {f f' : a ⟶ b} (ef : f ≅ f') {g g' : a ⟶ c} (eg : g ≅ g')
+
+/-- Given isomorphisms `ef : f ≅ f'` and `eg : g ≅ g'`, the induced equivalence between their
+categories of left extensions. -/
+def mapIso : LeftExtension f g ≌ LeftExtension f' g' :=
+  (StructuredArrow.mapNatIso ((precomposing a b c).mapIso ef)).trans (StructuredArrow.mapIso eg)
+
+/-- Given isomorphisms `ef : f ≅ f'` and `eg : g ≅ g'`, and a left extension
+`t : LeftExtension f g`, the induced left extension `t.ofIso : LeftExtension f' g'`. -/
+def ofIso (t : LeftExtension f g) : LeftExtension f' g' :=
+  (mapIso ef eg).functor.obj t
+
+@[simp]
+theorem ofIso_extension (t : LeftExtension f g) :
+    (t.ofIso ef eg).extension = t.extension :=
+  rfl
+
+@[simp]
+theorem ofIso_unit (t : LeftExtension f g) :
+    (t.ofIso ef eg).unit = eg.inv ≫ t.unit ≫ ef.hom ▷ t.extension :=
+  rfl
+
+/-- Whiskering commutes with `LeftExtension.ofIso`. -/
+def whiskerOfIso (t : LeftExtension f g) {x : B} (h : c ⟶ x) :
+    (t.whisker h).ofIso ef (whiskerRightIso eg h) ≅ (t.ofIso ef eg).whisker h :=
+  StructuredArrow.isoMk (Iso.refl _) <| by simp [precomp]
+
+end OfIso
+
 end LeftExtension
 
 /-- Triangle diagrams for (left) lifts.
@@ -281,6 +312,37 @@ set_option backward.defeqAttrib.useBackward true in
 def whiskerOfIdCompIsoSelf (t : LeftLift f g) : (t.whisker (𝟙 c)).ofIdComp ≅ t :=
   StructuredArrow.isoMk (λ_ (lift t))
 
+section OfIso
+
+variable {f f' : b ⟶ a} (ef : f ≅ f') {g g' : c ⟶ a} (eg : g ≅ g')
+
+/-- Given isomorphisms `ef : f ≅ f'` and `eg : g ≅ g'`, the induced equivalence between their
+categories of left lifts. -/
+def mapIso : LeftLift f g ≌ LeftLift f' g' :=
+  (StructuredArrow.mapNatIso ((postcomposing c b a).mapIso ef)).trans (StructuredArrow.mapIso eg)
+
+/-- Given isomorphisms `ef : f ≅ f'` and `eg : g ≅ g'`, and a left lift `t : LeftLift f g`, the
+induced left lift `t.ofIso : LeftLift f' g'`. -/
+def ofIso (t : LeftLift f g) : LeftLift f' g' :=
+  (mapIso ef eg).functor.obj t
+
+@[simp]
+theorem ofIso_lift (t : LeftLift f g) :
+    (t.ofIso ef eg).lift = t.lift :=
+  rfl
+
+@[simp]
+theorem ofIso_unit (t : LeftLift f g) :
+    (t.ofIso ef eg).unit = eg.inv ≫ t.unit ≫ t.lift ◁ ef.hom :=
+  rfl
+
+/-- Whiskering commutes with `LeftLift.ofIso`. -/
+def whiskerOfIso (t : LeftLift f g) {x : B} (h : x ⟶ c) :
+    (t.whisker h).ofIso ef (whiskerLeftIso h eg) ≅ (t.ofIso ef eg).whisker h :=
+  StructuredArrow.isoMk (Iso.refl _) <| by simp [postcomp]
+
+end OfIso
+
 end LeftLift
 
 /-- Triangle diagrams for (right) extensions.
@@ -310,21 +372,128 @@ abbrev counit (t : RightExtension f g) : f ≫ t.extension ⟶ g := t.hom
 abbrev mk (h : b ⟶ c) (counit : f ≫ h ⟶ g) : RightExtension f g :=
   CostructuredArrow.mk counit
 
+variable {s t : RightExtension f g}
+
 /-- To construct a morphism between right extensions, we need a 2-morphism between the extensions,
 and to check that it is compatible with the counits. -/
-abbrev homMk {s t : RightExtension f g} (η : s.extension ⟶ t.extension)
+abbrev homMk (η : s.extension ⟶ t.extension)
     (w : f ◁ η ≫ t.counit = s.counit := by cat_disch) : s ⟶ t :=
   CostructuredArrow.homMk η w
 
 @[reassoc (attr := simp)]
-theorem w {s t : RightExtension f g} (η : s ⟶ t) :
-    f ◁ η.left ≫ t.counit = s.counit :=
+theorem w (η : s ⟶ t) : f ◁ η.left ≫ t.counit = s.counit :=
   CostructuredArrow.w η
 
 /-- The right extension along the identity. -/
 def alongId (g : a ⟶ c) : RightExtension (𝟙 a) g := .mk _ (λ_ g).hom
 
 instance : Inhabited (RightExtension (𝟙 a) g) := ⟨alongId g⟩
+
+/-- Construct a right extension of `g : a ⟶ c` from a right extension of `g ≫ 𝟙 c`. -/
+@[simps!]
+def ofCompId (t : RightExtension f (g ≫ 𝟙 c)) : RightExtension f g :=
+  mk (extension t) (counit t ≫ (ρ_ g).hom)
+
+/-- Whisker a 1-morphism to an extension.
+```
+  b
+  △ \
+  |   \ extension  | counit
+f |     \          ▽
+  |       ◿
+  a - - - ▷ c - - - ▷ x
+      g         h
+```
+-/
+def whisker (t : RightExtension f g) {x : B} (h : c ⟶ x) : RightExtension f (g ≫ h) :=
+  .mk _ <| (α_ f t.extension h).inv ≫ t.counit ▷ h
+
+@[simp]
+theorem whisker_extension (t : RightExtension f g) {x : B} (h : c ⟶ x) :
+    (t.whisker h).extension = t.extension ≫ h :=
+  rfl
+
+@[simp]
+theorem whisker_counit (t : RightExtension f g) {x : B} (h : c ⟶ x) :
+    (t.whisker h).counit = (α_ f t.extension h).inv ≫ t.counit ▷ h :=
+  rfl
+
+/-- Whiskering a 1-morphism is a functor. -/
+@[simps]
+def whiskering {x : B} (h : c ⟶ x) : RightExtension f g ⥤ RightExtension f (g ≫ h) where
+  obj t := t.whisker h
+  map η := RightExtension.homMk (η.left ▷ h) <| by
+    simp [-RightExtension.w, ← RightExtension.w η]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Define a morphism between right extensions by cancelling the whiskered identities. -/
+@[simps! left]
+def whiskerIdCancel
+    (t : RightExtension f (g ≫ 𝟙 c)) {s : RightExtension f g} (τ : s.whisker (𝟙 c) ⟶ t) :
+    s ⟶ t.ofCompId :=
+  RightExtension.homMk ((ρ_ _).inv ≫ τ.left)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Construct a morphism between whiskered extensions. -/
+@[simps! left]
+def whiskerHom (i : s ⟶ t) {x : B} (h : c ⟶ x) :
+    s.whisker h ⟶ t.whisker h :=
+  CostructuredArrow.homMk (i.left ▷ h) <| by
+    rw [← cancel_epi (α_ f s.extension h).hom]
+    calc
+      _ = (f ◁ i.left ≫ t.counit) ▷ h := by simp [-RightExtension.w]
+      _ = s.counit ▷ h := congrArg (· ▷ h) (RightExtension.w i)
+      _ = _ := by simp
+
+/-- Construct an isomorphism between whiskered extensions. -/
+def whiskerIso (i : s ≅ t) {x : B} (h : c ⟶ x) :
+    s.whisker h ≅ t.whisker h :=
+  Iso.mk (whiskerHom i.hom h) (whiskerHom i.inv h)
+    (CostructuredArrow.hom_ext _ _ <|
+      calc
+        _ = (i.hom ≫ i.inv).left ▷ h := by simp [-Iso.hom_inv_id]
+        _ = 𝟙 _ := by simp [Iso.hom_inv_id])
+    (CostructuredArrow.hom_ext _ _ <|
+      calc
+        _ = (i.inv ≫ i.hom).left ▷ h := by simp [-Iso.inv_hom_id]
+        _ = 𝟙 _ := by simp [Iso.inv_hom_id])
+
+set_option backward.defeqAttrib.useBackward true in
+/-- The isomorphism between right extensions induced by a right unitor. -/
+@[simps! hom_left inv_left]
+def whiskerOfCompIdIsoSelf (t : RightExtension f g) : (t.whisker (𝟙 c)).ofCompId ≅ t :=
+  CostructuredArrow.isoMk (ρ_ (t.extension))
+
+section OfIso
+
+variable {f f' : a ⟶ b} (ef : f ≅ f') {g g' : a ⟶ c} (eg : g ≅ g')
+
+/-- Given isomorphisms `ef : f ≅ f'` and `eg : g ≅ g'`, the induced equivalence between their
+categories of right extensions. -/
+def mapIso : RightExtension f g ≌ RightExtension f' g' :=
+  (CostructuredArrow.mapNatIso ((precomposing a b c).mapIso ef)).trans (CostructuredArrow.mapIso eg)
+
+/-- Given isomorphisms `ef : f ≅ f'` and `eg : g ≅ g'`, and a right extension
+`t : RightExtension f g`, the induced right extension `t.ofIso : RightExtension f' g'`. -/
+def ofIso (t : RightExtension f g) : RightExtension f' g' :=
+  (mapIso ef eg).functor.obj t
+
+@[simp]
+theorem ofIso_extension (t : RightExtension f g) :
+    (t.ofIso ef eg).extension = t.extension :=
+  rfl
+
+@[simp]
+theorem ofIso_counit (t : RightExtension f g) :
+    (t.ofIso ef eg).counit = ef.inv ▷ t.extension ≫ t.counit ≫ eg.hom := by
+  rw [← Category.assoc]; rfl
+
+/-- Whiskering commutes with `RightExtension.ofIso`. -/
+def whiskerOfIso (t : RightExtension f g) {x : B} (h : c ⟶ x) :
+    (t.whisker h).ofIso ef (whiskerRightIso eg h) ≅ (t.ofIso ef eg).whisker h :=
+  CostructuredArrow.isoMk (Iso.refl _) <| by simp [precomp]
+
+end OfIso
 
 end RightExtension
 
@@ -448,6 +617,38 @@ set_option backward.defeqAttrib.useBackward true in
 @[simps! hom_left inv_left]
 def whiskerOfIdCompIsoSelf (t : RightLift f g) : (t.whisker (𝟙 c)).ofIdComp ≅ t :=
   CostructuredArrow.isoMk (λ_ (lift t))
+
+section OfIso
+
+variable {f f' : b ⟶ a} (ef : f ≅ f') {g g' : c ⟶ a} (eg : g ≅ g')
+
+/-- Given isomorphisms `ef : f ≅ f'` and `eg : g ≅ g'`, the induced equivalence between their
+categories of right lifts. -/
+def mapIso : RightLift f g ≌ RightLift f' g' :=
+  (CostructuredArrow.mapNatIso ((postcomposing c b a).mapIso ef)).trans
+    (CostructuredArrow.mapIso eg)
+
+/-- Given isomorphisms `ef : f ≅ f'` and `eg : g ≅ g'`, and a right lift `t : RightLift f g`, the
+induced right lift `t.ofIso : RightLift f' g'`. -/
+def ofIso (t : RightLift f g) : RightLift f' g' :=
+  (mapIso ef eg).functor.obj t
+
+@[simp]
+theorem ofIso_lift (t : RightLift f g) :
+    (t.ofIso ef eg).lift = t.lift :=
+  rfl
+
+@[simp]
+theorem ofIso_counit (t : RightLift f g) :
+    (t.ofIso ef eg).counit = t.lift ◁ ef.inv ≫ t.counit ≫ eg.hom := by
+  rw [← Category.assoc]; rfl
+
+/-- Whiskering commutes with `RightLift.ofIso`. -/
+def whiskerOfIso (t : RightLift f g) {x : B} (h : x ⟶ c) :
+    (t.whisker h).ofIso ef (whiskerLeftIso h eg) ≅ (t.ofIso ef eg).whisker h :=
+  CostructuredArrow.isoMk (Iso.refl _) <| by simp [postcomp]
+
+end OfIso
 
 end RightLift
 

--- a/Mathlib/CategoryTheory/Bicategory/Kan/IsKan.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/IsKan.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.CategoryTheory.Adjunction.Limits
 public import Mathlib.CategoryTheory.Bicategory.Extension
 public import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Terminal
+public import Mathlib.Tactic.CategoryTheory.Bicategory.Basic
 
 /-!
 # Kan extensions and Kan lifts in bicategories
@@ -48,7 +49,7 @@ namespace Bicategory
 
 universe w v u
 
-variable {B : Type u} [Bicategory.{w, v} B] {a b c : B}
+variable {B : Type u} [Bicategory.{w, v} B] {a b c d : B}
 
 namespace LeftExtension
 
@@ -151,6 +152,82 @@ noncomputable def ofIso {f' : a ⟶ b} {g' : a ⟶ c} (H : IsAbsKan t) (ef : f �
 
 end IsAbsKan
 
+section Paste
+
+variable {f : a ⟶ b} {g : a ⟶ c} {h : b ⟶ d}
+variable {t : LeftExtension f g} {s : LeftExtension h t.extension}
+
+/-- Given a left Kan extension `t` of `g` along `f`, a left extension `u` of `g` along `f ≫ h`
+induces, via the universal property of `t`, a left extension of `t.extension` along `h`. -/
+def IsKan.ofIsKanTop (Ht : IsKan t) (u : LeftExtension (f ≫ h) g) : LeftExtension h t.extension :=
+  .mk u.extension (Ht.desc (.mk (h ≫ u.extension) (u.unit ≫ (α_ f h u.extension).hom)))
+
+@[simp]
+theorem IsKan.ofIsKanTop_extension (Ht : IsKan t) (u : LeftExtension (f ≫ h) g) :
+    (Ht.ofIsKanTop u).extension = u.extension :=
+  rfl
+
+theorem IsKan.ofIsKanTop_fac (Ht : IsKan t) (u : LeftExtension (f ≫ h) g) :
+    t.unit ≫ f ◁ (Ht.ofIsKanTop u).unit = u.unit ≫ (α_ f h u.extension).hom := by
+  simpa [IsKan.ofIsKanTop] using
+    Ht.fac (.mk (h ≫ u.extension) (u.unit ≫ (α_ f h u.extension).hom))
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Pasting of left extensions preserves being Kan. -/
+def IsKan.paste (Ht : IsKan t) (Hs : IsKan s) : IsKan (t.paste s) :=
+  IsKan.mk
+    (fun u ↦
+      LeftExtension.homMk (Hs.desc (Ht.ofIsKanTop u)) <| by
+        rw [paste_unit, ← cancel_mono (α_ f h u.extension).hom, ← Ht.ofIsKanTop_fac,
+          ← Hs.fac (Ht.ofIsKanTop u)]
+        bicategory)
+    (fun u τ ↦ by
+      ext
+      apply Hs.hom_ext
+      apply Ht.hom_ext
+      rw [homMk_right, Hs.fac, Ht.ofIsKanTop_fac, ← LeftExtension.w τ, paste_unit]
+      bicategory)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Given a left extension `t` of `g` along `f` and a left extension `s` of `t` along `h`, if `t`
+and `t.paste s` are Kan, then so is `s`. -/
+def IsKan.ofPaste (Ht : IsKan t) (Hp : IsKan (t.paste s)) : IsKan s :=
+  IsKan.mk
+    (fun v ↦
+      LeftExtension.homMk (Hp.desc (t.paste v)) <| Ht.hom_ext <| by
+        rw [← cancel_mono (α_ f h v.extension).inv, Category.assoc, Category.assoc, ← paste_unit,
+          ← Hp.fac (t.paste v), paste_unit]
+        bicategory)
+    (fun v τ ↦ by
+      ext
+      apply Hp.hom_ext
+      rw [homMk_right, Hp.fac, paste_unit, paste_unit, ← LeftExtension.w τ]
+      bicategory)
+
+/-- Let `t` be a left Kan extension of `g` along `f` and `s` a left extension of `t` along `h`. Then
+`s` is Kan if and only if `t.paste s` is Kan. -/
+def isKanEquivIsKanPaste (Ht : IsKan t) : (IsKan s) ≃ (IsKan (t.paste s)) :=
+  equivOfSubsingletonOfSubsingleton Ht.paste Ht.ofPaste
+
+/-- Pasting of left extensions preserves being absolute Kan. -/
+noncomputable def IsAbsKan.paste (H : IsAbsKan t) (Hs : IsAbsKan s) :
+    IsAbsKan (t.paste s) :=
+  fun k ↦ ((H k).paste (Hs k)).ofIsoKan (pasteWhiskerIso t s k).symm
+
+/-- Given a left extension `t` of `g` along `f` and a left extension `s` of `t` along `h`, if `t`
+and `t.paste s` are absolute Kan, then so is `s`. -/
+noncomputable def IsAbsKan.ofPaste (H : IsAbsKan t) (Hp : IsAbsKan (t.paste s)) :
+    IsAbsKan s :=
+  fun k ↦ (H k).ofPaste ((Hp k).ofIsoKan (pasteWhiskerIso t s k))
+
+/-- Let `t` be an absolute left Kan extension of `g` along `f` and `s` a left extension of `t` along
+`h`. Then `s` is absolute Kan if and only if `t.paste s` is absolute Kan. -/
+noncomputable def isAbsKanEquivIsAbsKanPaste (H : IsAbsKan t) :
+    (IsAbsKan s) ≃ (IsAbsKan (t.paste s)) :=
+  equivOfSubsingletonOfSubsingleton H.paste H.ofPaste
+
+end Paste
+
 end LeftExtension
 
 namespace LeftLift
@@ -251,6 +328,82 @@ noncomputable def ofIso {f' : b ⟶ a} {g' : c ⟶ a} (H : IsAbsKan t) (ef : f �
   fun h ↦ ((H h).ofIso ef (whiskerLeftIso h eg)).ofIsoKan (whiskerOfIso ef eg t h)
 
 end IsAbsKan
+
+section Paste
+
+variable {f : b ⟶ a} {g : d ⟶ a} {h : c ⟶ b}
+variable {t : LeftLift f g} {s : LeftLift h t.lift}
+
+/-- Given a left Kan lift `t` of `g` along `f`, a left lift `u` of `g` along `h ≫ f` induces,
+via the universal property of `t`, a left lift of `t.lift` along `h`.
+-/
+def IsKan.ofIsKanTop (Ht : IsKan t) (u : LeftLift (h ≫ f) g) : LeftLift h t.lift :=
+  .mk u.lift (Ht.desc (.mk (u.lift ≫ h) (u.unit ≫ (α_ u.lift h f).inv)))
+
+@[simp]
+theorem IsKan.ofIsKanTop_lift (Ht : IsKan t) (u : LeftLift (h ≫ f) g) :
+    (Ht.ofIsKanTop u).lift = u.lift :=
+  rfl
+
+theorem IsKan.ofIsKanTop_fac (Ht : IsKan t) (u : LeftLift (h ≫ f) g) :
+    t.unit ≫ (Ht.ofIsKanTop u).unit ▷ f = u.unit ≫ (α_ u.lift h f).inv := by
+  simpa [IsKan.ofIsKanTop] using Ht.fac (.mk (u.lift ≫ h) (u.unit ≫ (α_ u.lift h f).inv))
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Pasting of left lifts preserves being Kan. -/
+def IsKan.paste (Ht : IsKan t) (Hs : IsKan s) : IsKan (t.paste s) :=
+  IsKan.mk
+    (fun u ↦
+      LeftLift.homMk (Hs.desc (Ht.ofIsKanTop u)) <| by
+        rw [paste_unit, ← cancel_mono (α_ u.lift h f).inv, ← Ht.ofIsKanTop_fac,
+          ← Hs.fac (Ht.ofIsKanTop u)]
+        bicategory)
+    (fun u τ ↦ by
+      ext
+      apply Hs.hom_ext
+      apply Ht.hom_ext
+      rw [homMk_right, Hs.fac, Ht.ofIsKanTop_fac, ← LeftLift.w τ, paste_unit]
+      bicategory)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Given a left lift `t` of `g` along `f` and a left lift `s` of `t` along `h`, if `t` and
+`t.paste s` are Kan, then so is `s`. -/
+def IsKan.ofPaste (Ht : IsKan t) (Hp : IsKan (t.paste s)) : IsKan s :=
+  IsKan.mk
+    (fun v ↦
+      LeftLift.homMk (Hp.desc (t.paste v)) <| Ht.hom_ext <| by
+        rw [← cancel_mono (α_ v.lift h f).hom, Category.assoc, Category.assoc, ← paste_unit,
+          ← Hp.fac (t.paste v), paste_unit]
+        bicategory)
+    (fun v τ ↦ by
+      ext
+      apply Hp.hom_ext
+      rw [homMk_right, Hp.fac, paste_unit, paste_unit, ← LeftLift.w τ]
+      bicategory)
+
+/-- Let `t` be a left Kan lift of `g` along `f` and `s` a left lift of `t` along `h`. Then `s` is
+Kan if and only if `t.paste s` is Kan. -/
+def isKanEquivIsKanPaste (Ht : IsKan t) : (IsKan s) ≃ (IsKan (t.paste s)) :=
+  equivOfSubsingletonOfSubsingleton Ht.paste Ht.ofPaste
+
+/-- Pasting of left lifts preserves being absolute Kan. -/
+noncomputable def IsAbsKan.paste (H : IsAbsKan t) (Hs : IsAbsKan s) :
+    IsAbsKan (t.paste s) :=
+  fun k ↦ ((H k).paste (Hs k)).ofIsoKan (pasteWhiskerIso t s k).symm
+
+/-- Given a left lift `t` of `g` along `f` and a left lift `s` of `t` along `h`, if `t` and
+`t.paste s` are absolute Kan, then so is `s`. -/
+noncomputable def IsAbsKan.ofPaste (H : IsAbsKan t) (Hp : IsAbsKan (t.paste s)) :
+    IsAbsKan s :=
+  fun k ↦ (H k).ofPaste ((Hp k).ofIsoKan (pasteWhiskerIso t s k))
+
+/-- Let `t` be an absolute left Kan lift of `g` along `f` and `s` a left lift of `t` along `h`. Then
+`s` is absolute Kan if and only if `t.paste s` is absolute Kan. -/
+noncomputable def isAbsKanEquivIsAbsKanPaste (H : IsAbsKan t) :
+    (IsAbsKan s) ≃ (IsAbsKan (t.paste s)) :=
+  equivOfSubsingletonOfSubsingleton H.paste H.ofPaste
+
+end Paste
 
 end LeftLift
 
@@ -355,6 +508,82 @@ noncomputable def ofIso {f' : a ⟶ b} {g' : a ⟶ c} (H : IsAbsKan t) (ef : f �
 
 end IsAbsKan
 
+section Paste
+
+variable {f : a ⟶ b} {g : a ⟶ c} {h : b ⟶ d}
+variable {t : RightExtension f g} {s : RightExtension h t.extension}
+
+/-- Given a right Kan extension `t` of `g` along `f`, a right extension `u` of `g` along `f ≫ h`
+induces, via the universal property of `t`, a right extension of `t.extension` along `h`. -/
+def IsKan.ofIsKanTop (Ht : IsKan t) (u : RightExtension (f ≫ h) g) : RightExtension h t.extension :=
+  .mk u.extension (Ht.desc (.mk (h ≫ u.extension) ((α_ f h u.extension).inv ≫ u.counit)))
+
+@[simp]
+theorem IsKan.ofIsKanTop_extension (Ht : IsKan t) (u : RightExtension (f ≫ h) g) :
+    (Ht.ofIsKanTop u).extension = u.extension :=
+  rfl
+
+theorem IsKan.ofIsKanTop_fac (Ht : IsKan t) (u : RightExtension (f ≫ h) g) :
+    f ◁ (Ht.ofIsKanTop u).counit ≫ t.counit = (α_ f h u.extension).inv ≫ u.counit := by
+  simpa [IsKan.ofIsKanTop] using
+    Ht.fac (.mk (h ≫ u.extension) ((α_ f h u.extension).inv ≫ u.counit))
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Pasting of right extensions preserves being Kan. -/
+def IsKan.paste (Ht : IsKan t) (Hs : IsKan s) : IsKan (t.paste s) :=
+  IsKan.mk
+    (fun u ↦
+      RightExtension.homMk (Hs.desc (Ht.ofIsKanTop u)) <| by
+        rw [paste_counit, ← cancel_epi (α_ f h u.extension).inv, ← Ht.ofIsKanTop_fac,
+          ← Hs.fac (Ht.ofIsKanTop u)]
+        bicategory)
+    (fun u τ ↦ by
+      ext
+      apply Hs.hom_ext
+      apply Ht.hom_ext
+      rw [homMk_left, Hs.fac, Ht.ofIsKanTop_fac, ← RightExtension.w τ, paste_counit]
+      bicategory)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Given a right extension `t` of `g` along `f` and a right extension `s` of `t` along `h`, if `t`
+and `t.paste s` are Kan, then so is `s`. -/
+def IsKan.ofPaste (Ht : IsKan t) (Hp : IsKan (t.paste s)) : IsKan s :=
+  IsKan.mk
+    (fun v ↦
+      RightExtension.homMk (Hp.desc (t.paste v)) <| Ht.hom_ext <| by
+        rw [← cancel_epi (α_ f h v.extension).hom, ← paste_counit, ← Hp.fac (t.paste v),
+          paste_counit]
+        bicategory)
+    (fun v τ ↦ by
+      ext
+      apply Hp.hom_ext
+      rw [homMk_left, Hp.fac, paste_counit, paste_counit, ← RightExtension.w τ]
+      bicategory)
+
+/-- Let `t` be a right Kan extension of `g` along `f` and `s` a right extension of `t` along `h`.
+Then `s` is Kan if and only if `t.paste s` is Kan. -/
+def isKanEquivIsKanPaste (Ht : IsKan t) : (IsKan s) ≃ (IsKan (t.paste s)) :=
+  equivOfSubsingletonOfSubsingleton Ht.paste Ht.ofPaste
+
+/-- Pasting of right extensions preserves being absolute Kan. -/
+noncomputable def IsAbsKan.paste (H : IsAbsKan t) (Hs : IsAbsKan s) :
+    IsAbsKan (t.paste s) :=
+  fun k ↦ ((H k).paste (Hs k)).ofIsoKan (pasteWhiskerIso t s k).symm
+
+/-- Given a right extension `t` of `g` along `f` and a right extension `s` of `t` along `h`, if `t`
+and `t.paste s` are absolute Kan, then so is `s`. -/
+noncomputable def IsAbsKan.ofPaste (H : IsAbsKan t) (Hp : IsAbsKan (t.paste s)) :
+    IsAbsKan s :=
+  fun k ↦ (H k).ofPaste ((Hp k).ofIsoKan (pasteWhiskerIso t s k))
+
+/-- Let `t` be an absolute right Kan extension of `g` along `f` and `s` a right extension of `t`
+along `h`. Then `s` is absolute Kan if and only if `t.paste s` is absolute Kan. -/
+noncomputable def isAbsKanEquivIsAbsKanPaste (H : IsAbsKan t) :
+    (IsAbsKan s) ≃ (IsAbsKan (t.paste s)) :=
+  equivOfSubsingletonOfSubsingleton H.paste H.ofPaste
+
+end Paste
+
 end RightExtension
 
 namespace RightLift
@@ -455,6 +684,80 @@ noncomputable def ofIso {f' : b ⟶ a} {g' : c ⟶ a} (H : IsAbsKan t) (ef : f �
   fun h ↦ ((H h).ofIso ef (whiskerLeftIso h eg)).ofIsoKan (whiskerOfIso ef eg t h)
 
 end IsAbsKan
+
+section Paste
+
+variable {f : b ⟶ a} {g : d ⟶ a} {h : c ⟶ b}
+variable {t : RightLift f g} {s : RightLift h t.lift}
+
+/-- Given a right Kan lift `t` of `g` along `f`, a right lift `u` of `g` along `h ≫ f` induces,
+via the universal property of `t`, a right lift of `t.lift` along `h`. -/
+def IsKan.ofIsKanTop (Ht : IsKan t) (u : RightLift (h ≫ f) g) : RightLift h t.lift :=
+  .mk u.lift (Ht.desc (.mk (u.lift ≫ h) ((α_ u.lift h f).hom ≫ u.counit)))
+
+@[simp]
+theorem IsKan.ofIsKanTop_lift (Ht : IsKan t) (u : RightLift (h ≫ f) g) :
+    (Ht.ofIsKanTop u).lift = u.lift :=
+  rfl
+
+theorem IsKan.ofIsKanTop_fac (Ht : IsKan t) (u : RightLift (h ≫ f) g) :
+    (Ht.ofIsKanTop u).counit ▷ f ≫ t.counit = (α_ u.lift h f).hom ≫ u.counit := by
+  simpa [IsKan.ofIsKanTop] using Ht.fac (.mk (u.lift ≫ h) ((α_ u.lift h f).hom ≫ u.counit))
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Pasting of right lifts preserves being Kan. -/
+def IsKan.paste (Ht : IsKan t) (Hs : IsKan s) : IsKan (t.paste s) :=
+  IsKan.mk
+    (fun u ↦
+      RightLift.homMk (Hs.desc (Ht.ofIsKanTop u)) <| by
+        rw [paste_counit, ← cancel_epi (α_ u.lift h f).hom, ← Ht.ofIsKanTop_fac,
+          ← Hs.fac (Ht.ofIsKanTop u)]
+        bicategory)
+    (fun u τ ↦ by
+      ext
+      apply Hs.hom_ext
+      apply Ht.hom_ext
+      rw [homMk_left, Hs.fac, Ht.ofIsKanTop_fac, ← RightLift.w τ, paste_counit]
+      bicategory)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Given a right lift `t` of `g` along `f` and a right lift `s` of `t` along `h`, if `t` and
+`t.paste s` are Kan, then so is `s`. -/
+def IsKan.ofPaste (Ht : IsKan t) (Hp : IsKan (t.paste s)) : IsKan s :=
+  IsKan.mk
+    (fun v ↦
+      RightLift.homMk (Hp.desc (t.paste v)) <| Ht.hom_ext <| by
+        rw [← cancel_epi (α_ v.lift h f).inv, ← paste_counit, ← Hp.fac (t.paste v), paste_counit]
+        bicategory)
+    (fun v τ ↦ by
+      ext
+      apply Hp.hom_ext
+      rw [homMk_left, Hp.fac, paste_counit, paste_counit, ← RightLift.w τ]
+      bicategory)
+
+/-- Let `t` be a right Kan lift of `g` along `f` and `s` a right lift of `t` along `h`. Then `s` is
+Kan if and only if `t.paste s` is Kan. -/
+def isKanEquivIsKanPaste (Ht : IsKan t) : (IsKan s) ≃ (IsKan (t.paste s)) :=
+  equivOfSubsingletonOfSubsingleton Ht.paste Ht.ofPaste
+
+/-- Pasting of right lifts preserves being absolute Kan. -/
+noncomputable def IsAbsKan.paste (H : IsAbsKan t) (Hs : IsAbsKan s) :
+    IsAbsKan (t.paste s) :=
+  fun k ↦ ((H k).paste (Hs k)).ofIsoKan (pasteWhiskerIso t s k).symm
+
+/-- Given a right lift `t` of `g` along `f` and a right lift `s` of `t` along `h`, if `t` and
+`t.paste s` are absolute Kan, then so is `s`. -/
+noncomputable def IsAbsKan.ofPaste (H : IsAbsKan t) (Hp : IsAbsKan (t.paste s)) :
+    IsAbsKan s :=
+  fun k ↦ (H k).ofPaste ((Hp k).ofIsoKan (pasteWhiskerIso t s k))
+
+/-- Let `t` be an absolute right Kan lift of `g` along `f` and `s` a right lift of `t` along `h`.
+Then `s` is absolute Kan if and only if `t.paste s` is absolute Kan. -/
+noncomputable def isAbsKanEquivIsAbsKanPaste (H : IsAbsKan t) :
+    (IsAbsKan s) ≃ (IsAbsKan (t.paste s)) :=
+  equivOfSubsingletonOfSubsingleton H.paste H.ofPaste
+
+end Paste
 
 end RightLift
 

--- a/Mathlib/CategoryTheory/Bicategory/Kan/IsKan.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/IsKan.lean
@@ -5,7 +5,9 @@ Authors: Yuma Mizuno
 -/
 module
 
+public import Mathlib.CategoryTheory.Adjunction.Limits
 public import Mathlib.CategoryTheory.Bicategory.Extension
+public import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Terminal
 
 /-!
 # Kan extensions and Kan lifts in bicategories
@@ -209,6 +211,12 @@ def whiskerOfCommute (s t : LeftLift f g) (i : s ≅ t) {x : B} (h : x ⟶ c)
     IsKan (t.whisker h) :=
   P.ofIsoKan <| whiskerIso i h
 
+/-- `LeftLift.ofIso` preserves Kan lifts: being a left Kan lift is invariant under transporting
+the boundary 1-cells along isomorphisms. -/
+noncomputable def ofIso {f' : b ⟶ a} {g' : c ⟶ a} (H : IsKan t) (ef : f ≅ f') (eg : g ≅ g') :
+    IsKan (t.ofIso ef eg) :=
+  Limits.IsInitial.isInitialObj (LeftLift.mapIso ef eg).functor t H
+
 end IsKan
 
 namespace IsAbsKan
@@ -227,6 +235,11 @@ def isKan (H : IsAbsKan t) : IsKan t :=
 /-- Transport evidence that a left lift is a Kan lift across an isomorphism of lifts. -/
 def ofIsoAbsKan (P : IsAbsKan s) (i : s ≅ t) : IsAbsKan t :=
   fun h ↦ (P h).ofIsoKan (whiskerIso i h)
+
+/-- `LeftLift.ofIso` preserves absolute left Kan lifts. -/
+noncomputable def ofIso {f' : b ⟶ a} {g' : c ⟶ a} (H : IsAbsKan t) (ef : f ≅ f') (eg : g ≅ g') :
+    IsAbsKan (t.ofIso ef eg) :=
+  fun h ↦ ((H h).ofIso ef (whiskerLeftIso h eg)).ofIsoKan (whiskerOfIso ef eg t h)
 
 end IsAbsKan
 

--- a/Mathlib/CategoryTheory/Bicategory/Kan/IsKan.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/IsKan.lean
@@ -119,6 +119,11 @@ def whiskerOfCommute (s t : LeftExtension f g) (i : s ≅ t) {x : B} (h : c ⟶ 
     IsKan (t.whisker h) :=
   P.ofIsoKan <| whiskerIso i h
 
+/-- `LeftExtension.ofIso` preserves Kan extensions. -/
+noncomputable def ofIso {f' : a ⟶ b} {g' : a ⟶ c} (H : IsKan t) (ef : f ≅ f') (eg : g ≅ g') :
+    IsKan (t.ofIso ef eg) :=
+  Limits.IsInitial.isInitialObj (LeftExtension.mapIso ef eg).functor t H
+
 end IsKan
 
 namespace IsAbsKan
@@ -138,6 +143,11 @@ def isKan (H : IsAbsKan t) : IsKan t :=
 of extensions. -/
 def ofIsoAbsKan (P : IsAbsKan s) (i : s ≅ t) : IsAbsKan t :=
   fun h ↦ (P h).ofIsoKan (whiskerIso i h)
+
+/-- `LeftExtension.ofIso` preserves absolute left Kan extensions. -/
+noncomputable def ofIso {f' : a ⟶ b} {g' : a ⟶ c} (H : IsAbsKan t) (ef : f ≅ f') (eg : g ≅ g') :
+    IsAbsKan (t.ofIso ef eg) :=
+  fun h ↦ ((H h).ofIso ef (whiskerRightIso eg h)).ofIsoKan (whiskerOfIso ef eg t h)
 
 end IsAbsKan
 
@@ -211,8 +221,7 @@ def whiskerOfCommute (s t : LeftLift f g) (i : s ≅ t) {x : B} (h : x ⟶ c)
     IsKan (t.whisker h) :=
   P.ofIsoKan <| whiskerIso i h
 
-/-- `LeftLift.ofIso` preserves Kan lifts: being a left Kan lift is invariant under transporting
-the boundary 1-cells along isomorphisms. -/
+/-- `LeftLift.ofIso` preserves Kan lifts. -/
 noncomputable def ofIso {f' : b ⟶ a} {g' : c ⟶ a} (H : IsKan t) (ef : f ≅ f') (eg : g ≅ g') :
     IsKan (t.ofIso ef eg) :=
   Limits.IsInitial.isInitialObj (LeftLift.mapIso ef eg).functor t H
@@ -251,6 +260,100 @@ variable {f : a ⟶ b} {g : a ⟶ c}
 
 /-- A right Kan extension of `g` along `f` is a terminal object in `RightExtension f g`. -/
 abbrev IsKan (t : RightExtension f g) := t.IsUniversal
+
+/-- An absolute right Kan extension is a Kan extension that commutes with any 1-morphism. -/
+abbrev IsAbsKan (t : RightExtension f g) :=
+  ∀ {x : B} (h : c ⟶ x), IsKan (t.whisker h)
+
+namespace IsKan
+
+variable {s t : RightExtension f g}
+
+/-- To show that a right extension `t` is a Kan extension, we need to show that for every right
+extension `s` there is a unique morphism `s ⟶ t`. -/
+abbrev mk (desc : ∀ s, s ⟶ t) (w : ∀ s τ, τ = desc s) :
+    IsKan t :=
+  .ofUniqueHom desc w
+
+/-- The family of 2-morphisms into a right Kan extension. -/
+abbrev desc (H : IsKan t) (s : RightExtension f g) : s.extension ⟶ t.extension :=
+  CostructuredArrow.IsUniversal.lift H s
+
+@[reassoc (attr := simp)]
+theorem fac (H : IsKan t) (s : RightExtension f g) :
+    f ◁ H.desc s ≫ t.counit = s.counit :=
+  CostructuredArrow.IsUniversal.fac H s
+
+/-- Two 2-morphisms into a right Kan extension are equal if their compositions with
+each triangle 2-morphism are equal. -/
+theorem hom_ext (H : IsKan t) {k : b ⟶ c} {τ τ' : k ⟶ t.extension}
+    (w : f ◁ τ ≫ t.counit = f ◁ τ' ≫ t.counit) : τ = τ' :=
+  CostructuredArrow.IsUniversal.hom_ext H w
+
+/-- Kan extensions on `g` along `f` are unique up to isomorphism. -/
+def uniqueUpToIso (P : IsKan s) (Q : IsKan t) : s ≅ t :=
+  Limits.IsTerminal.uniqueUpToIso P Q
+
+@[simp]
+theorem uniqueUpToIso_hom_left (P : IsKan s) (Q : IsKan t) :
+    (uniqueUpToIso P Q).hom.left = Q.desc s := rfl
+
+@[simp]
+theorem uniqueUpToIso_inv_left (P : IsKan s) (Q : IsKan t) :
+    (uniqueUpToIso P Q).inv.left = P.desc t := rfl
+
+/-- Transport evidence that a right extension is a Kan extension across an isomorphism
+of extensions. -/
+def ofIsoKan (P : IsKan s) (i : s ≅ t) : IsKan t :=
+  Limits.IsTerminal.ofIso P i
+
+set_option backward.isDefEq.respectTransparency false in
+/-- If `t : RightExtension f (g ≫ 𝟙 c)` is a Kan extension, then `t.ofCompId : RightExtension f g`
+is also a Kan extension. -/
+def ofCompId (t : RightExtension f (g ≫ 𝟙 c)) (P : IsKan t) : IsKan t.ofCompId :=
+  .mk (fun s ↦ t.whiskerIdCancel <| P.from (s.whisker (𝟙 c))) <| by
+    intro s τ
+    ext
+    apply P.hom_ext
+    simp [← RightExtension.w τ]
+
+/-- If `s ≅ t` and `IsKan (s.whisker h)`, then `IsKan (t.whisker h)`. -/
+def whiskerOfCommute (s t : RightExtension f g) (i : s ≅ t) {x : B} (h : c ⟶ x)
+    (P : IsKan (s.whisker h)) :
+    IsKan (t.whisker h) :=
+  P.ofIsoKan <| whiskerIso i h
+
+/-- `RightExtension.ofIso` preserves Kan extensions. -/
+noncomputable def ofIso {f' : a ⟶ b} {g' : a ⟶ c} (H : IsKan t) (ef : f ≅ f') (eg : g ≅ g') :
+    IsKan (t.ofIso ef eg) :=
+  Limits.IsTerminal.isTerminalObj (RightExtension.mapIso ef eg).functor t H
+
+end IsKan
+
+namespace IsAbsKan
+
+variable {s t : RightExtension f g}
+
+/-- The family of 2-morphisms into an absolute right Kan extension. -/
+abbrev desc (H : IsAbsKan t) {x : B} {h : c ⟶ x} (s : RightExtension f (g ≫ h)) :
+    s.extension ⟶ t.extension ≫ h :=
+  (H h).desc s
+
+/-- An absolute right Kan extension is a right Kan extension. -/
+def isKan (H : IsAbsKan t) : IsKan t :=
+  ((H (𝟙 c)).ofCompId _).ofIsoKan <| whiskerOfCompIdIsoSelf t
+
+/-- Transport evidence that a right extension is a Kan extension across an isomorphism
+of extensions. -/
+def ofIsoAbsKan (P : IsAbsKan s) (i : s ≅ t) : IsAbsKan t :=
+  fun h ↦ (P h).ofIsoKan (whiskerIso i h)
+
+/-- `RightExtension.ofIso` preserves absolute right Kan extensions. -/
+noncomputable def ofIso {f' : a ⟶ b} {g' : a ⟶ c} (H : IsAbsKan t) (ef : f ≅ f') (eg : g ≅ g') :
+    IsAbsKan (t.ofIso ef eg) :=
+  fun h ↦ ((H h).ofIso ef (whiskerRightIso eg h)).ofIsoKan (whiskerOfIso ef eg t h)
+
+end IsAbsKan
 
 end RightExtension
 
@@ -322,6 +425,11 @@ def whiskerOfCommute (s t : RightLift f g) (i : s ≅ t) {x : B} (h : x ⟶ c)
     IsKan (t.whisker h) :=
   P.ofIsoKan <| whiskerIso i h
 
+/-- `RightLift.ofIso` preserves Kan lifts. -/
+noncomputable def ofIso {f' : b ⟶ a} {g' : c ⟶ a} (H : IsKan t) (ef : f ≅ f') (eg : g ≅ g') :
+    IsKan (t.ofIso ef eg) :=
+  Limits.IsTerminal.isTerminalObj (RightLift.mapIso ef eg).functor t H
+
 end IsKan
 
 namespace IsAbsKan
@@ -340,6 +448,11 @@ def isKan (H : IsAbsKan t) : IsKan t :=
 /-- Transport evidence that a right lift is a Kan lift across an isomorphism of lifts. -/
 def ofIsoAbsKan (P : IsAbsKan s) (i : s ≅ t) : IsAbsKan t :=
   fun h ↦ (P h).ofIsoKan (whiskerIso i h)
+
+/-- `RightLift.ofIso` preserves absolute right Kan lifts. -/
+noncomputable def ofIso {f' : b ⟶ a} {g' : c ⟶ a} (H : IsAbsKan t) (ef : f ≅ f') (eg : g ≅ g') :
+    IsAbsKan (t.ofIso ef eg) :=
+  fun h ↦ ((H h).ofIso ef (whiskerLeftIso h eg)).ofIsoKan (whiskerOfIso ef eg t h)
 
 end IsAbsKan
 


### PR DESCRIPTION
This PR constructs pasting for left lifts and shows the pasting lemma for (abs) left kan lifts. This is done for all four notions of left/right lifts/extensions.

This is needed for the oo-cosmos project.

- [ ] depends on: #41484

-----

AI disclosure. Claude was used in defining the API for the left lift case. After manually fixing its bad proofs/definitions/docstrings, Claude was later asked to replicate this for the other three cases, which I again finetuned.