### PR TITLE
[Merged by Bors] - refactor: definition and notation for `EventuallyEq` on `Set`

### DIFF
--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -524,7 +524,7 @@ theorem AnalyticWithinAt.mono_of_mem_nhdsWithin
 theorem AnalyticWithinAt.congr_set (h : AnalyticWithinAt 𝕜 f s x) (hst : s =ᶠ[𝓝 x] t) :
     AnalyticWithinAt 𝕜 f t x := by
   refine h.mono_of_mem_nhdsWithin ?_
-  simp [← nhdsWithin_eq_iff_eventuallyEq.mpr hst, self_mem_nhdsWithin]
+  simp [← nhdsWithin_eq_iff_eventuallyEqSet.mpr hst, self_mem_nhdsWithin]
 
 lemma AnalyticOn.mono {f : E → F} {s t : Set E} (h : AnalyticOn 𝕜 f t)
     (hs : s ⊆ t) : AnalyticOn 𝕜 f s :=

--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -303,7 +303,7 @@ theorem ContDiffWithinAt.congr_mono
 
 theorem ContDiffWithinAt.congr_set (h : ContDiffWithinAt 𝕜 n f s x) {t : Set E}
     (hst : s =ᶠ[𝓝 x] t) : ContDiffWithinAt 𝕜 n f t x := by
-  rw [← nhdsWithin_eq_iff_eventuallyEq] at hst
+  rw [← nhdsWithin_eq_iff_eventuallyEqSet] at hst
   apply h.mono_of_mem_nhdsWithin <| hst ▸ self_mem_nhdsWithin
 
 theorem contDiffWithinAt_congr_set {t : Set E} (hst : s =ᶠ[𝓝 x] t) :
@@ -312,7 +312,7 @@ theorem contDiffWithinAt_congr_set {t : Set E} (hst : s =ᶠ[𝓝 x] t) :
 
 theorem contDiffWithinAt_inter' (h : t ∈ 𝓝[s] x) :
     ContDiffWithinAt 𝕜 n f (s ∩ t) x ↔ ContDiffWithinAt 𝕜 n f s x :=
-  contDiffWithinAt_congr_set (mem_nhdsWithin_iff_eventuallyEq.1 h).symm
+  contDiffWithinAt_congr_set (mem_nhdsWithin_iff_eventuallyEqSet.1 h).symm
 
 theorem contDiffWithinAt_inter (h : t ∈ 𝓝 x) :
     ContDiffWithinAt 𝕜 n f (s ∩ t) x ↔ ContDiffWithinAt 𝕜 n f s x :=
@@ -794,7 +794,7 @@ theorem ContDiffWithinAt.differentiableWithinAt_iteratedFDerivWithin {m : ℕ}
     with ⟨u, uo, xu, hu⟩
   set t := insert x s ∩ u
   have A : t =ᶠ[𝓝[≠] x] s := by
-    simp only [set_eventuallyEq_iff_inf_principal, ← nhdsWithin_inter']
+    simp only [eventuallyEqSet_iff_inf_principal, ← nhdsWithin_inter']
     rw [← inter_assoc, nhdsWithin_inter_of_mem', ← sdiff_eq_compl_inter, insert_sdiff_of_mem,
       sdiff_eq_compl_inter]
     exacts [rfl, mem_nhdsWithin_of_mem_nhds (uo.mem_nhds xu)]

--- a/Mathlib/Analysis/Calculus/ContDiff/FTaylorSeries.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FTaylorSeries.lean
@@ -621,7 +621,8 @@ theorem ftaylorSeriesWithin_insert :
 `s` with a neighborhood of `x` within `s`. -/
 theorem iteratedFDerivWithin_inter' {n : ℕ} (hu : u ∈ 𝓝[s] x) :
     iteratedFDerivWithin 𝕜 n f (s ∩ u) x = iteratedFDerivWithin 𝕜 n f s x :=
-  iteratedFDerivWithin_congr_set (nhdsWithin_eq_iff_eventuallyEq.1 <| nhdsWithin_inter_of_mem' hu) _
+  iteratedFDerivWithin_congr_set
+    (nhdsWithin_eq_iff_eventuallyEqSet.1 <| nhdsWithin_inter_of_mem' hu) _
 
 /-- The iterated differential within a set `s` at a point `x` is not modified if one intersects
 `s` with a neighborhood of `x`. -/
@@ -908,7 +909,7 @@ theorem iteratedFDerivWithin_of_isOpen (n : ℕ) (hs : IsOpen s) :
     EqOn (iteratedFDerivWithin 𝕜 n f s) (iteratedFDeriv 𝕜 n f) s := by
   intro x hx
   rw [← iteratedFDerivWithin_univ]
-  exact iteratedFDerivWithin_congr_set (Filter.eventuallyEq_univ.mpr <| hs.mem_nhds hx) n
+  exact iteratedFDerivWithin_congr_set (Filter.eventuallyEqSet_univ.mpr <| hs.mem_nhds hx) n
 
 theorem ftaylorSeriesWithin_univ : ftaylorSeriesWithin 𝕜 f univ = ftaylorSeries 𝕜 f := by
   ext1 x; ext1 n

--- a/Mathlib/Analysis/Calculus/ContDiff/Operations.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Operations.lean
@@ -212,7 +212,7 @@ The iterated derivative of the sum of two functions is the sum of the iterated d
   have hgt : ContDiffOn 𝕜 i g (s ∩ t) := fun a ha ↦ (h (by simp_all)).2.mono inter_subset_left
   have hut : UniqueDiffOn 𝕜 (s ∩ t) := hu.inter ht
   have H : ↑(s ∩ t) =ᶠ[𝓝 x] s :=
-    inter_eventuallyEq_left.mpr (eventually_of_mem (ht.mem_nhds hxt) (fun _ h _ ↦ h))
+    inter_eventuallyEqSet_left.mpr (eventually_of_mem (ht.mem_nhds hxt) (fun _ h _ ↦ h))
   rw [← iteratedFDerivWithin_congr_set H, ← iteratedFDerivWithin_congr_set H,
     ← iteratedFDerivWithin_congr_set H]
   exact .symm (((hft.ftaylorSeriesWithin hut).add

--- a/Mathlib/Analysis/Calculus/ContDiff/Operations.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Operations.lean
@@ -211,7 +211,7 @@ The iterated derivative of the sum of two functions is the sum of the iterated d
   have hft : ContDiffOn 𝕜 i f (s ∩ t) := fun a ha ↦ (h (by simp_all)).1.mono inter_subset_left
   have hgt : ContDiffOn 𝕜 i g (s ∩ t) := fun a ha ↦ (h (by simp_all)).2.mono inter_subset_left
   have hut : UniqueDiffOn 𝕜 (s ∩ t) := hu.inter ht
-  have H : ↑(s ∩ t) =ᶠ[𝓝 x] s :=
+  have H : s ∩ t =ᶠ[𝓝 x] s :=
     inter_eventuallyEqSet_left.mpr (eventually_of_mem (ht.mem_nhds hxt) (fun _ h _ ↦ h))
   rw [← iteratedFDerivWithin_congr_set H, ← iteratedFDerivWithin_congr_set H,
     ← iteratedFDerivWithin_congr_set H]

--- a/Mathlib/Analysis/Calculus/FDeriv/Congr.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Congr.lean
@@ -48,7 +48,7 @@ theorem hasFDerivWithinAt_congr_set_nhdsNE (h : s =ᶠ[𝓝[≠] x] t) :
       hasFDerivWithinAt_sdiff_singleton_self.symm
     _ ↔ HasFDerivWithinAt f f' (t \ {x}) x := by
       suffices 𝓝[s \ {x}] x = 𝓝[t \ {x}] x by simp only [HasFDerivWithinAt, this]
-      simpa only [set_eventuallyEq_iff_inf_principal, ← nhdsWithin_inter', sdiff_eq, inter_comm]
+      simpa only [eventuallyEqSet_iff_inf_principal, ← nhdsWithin_inter', sdiff_eq, inter_comm]
         using h
     _ ↔ HasFDerivWithinAt f f' t x := hasFDerivWithinAt_sdiff_singleton_self
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
@@ -117,18 +117,22 @@ lemma fderivWithin_fderivWithin_eq_of_mem_nhdsWithin (h : t ∈ 𝓝[s] x)
   exact (hf.fderivWithin_right (m := 1) ht le_rfl
     (mem_of_mem_nhdsWithin hx h)).differentiableWithinAt one_ne_zero
 
-lemma fderivWithin_fderivWithin_eq_of_eventuallyEq (h : s =ᶠ[𝓝 x] t) :
+lemma fderivWithin_fderivWithin_eq_of_eventuallyEqSet (h : s =ᶠ[𝓝 x] t) :
     fderivWithin 𝕜 (fderivWithin 𝕜 f s) s x = fderivWithin 𝕜 (fderivWithin 𝕜 f t) t x := calc
   fderivWithin 𝕜 (fderivWithin 𝕜 f s) s x
     = fderivWithin 𝕜 (fderivWithin 𝕜 f t) s x :=
       (fderivWithin_eventually_congr_set h).fderivWithin_eq_of_nhds
   _ = fderivWithin 𝕜 (fderivWithin 𝕜 f t) t x := fderivWithin_congr_set h
 
+@[deprecated (since := "2026-08-14")]
+alias fderivWithin_fderivWithin_eq_of_eventuallyEq :=
+  fderivWithin_fderivWithin_eq_of_eventuallyEqSet
+
 lemma fderivWithin_fderivWithin_eq_of_mem_nhds {f : E → F} {x : E} {s : Set E}
     (h : s ∈ 𝓝 x) :
     fderivWithin 𝕜 (fderivWithin 𝕜 f s) s x = fderiv 𝕜 (fderiv 𝕜 f) x := by
   simp only [← fderivWithin_univ]
-  apply fderivWithin_fderivWithin_eq_of_eventuallyEq
+  apply fderivWithin_fderivWithin_eq_of_eventuallyEqSet
   simp [h]
 
 @[simp] lemma isSymmSndFDerivWithinAt_univ :
@@ -146,7 +150,7 @@ theorem IsSymmSndFDerivWithinAt.mono_of_mem_nhdsWithin (h : IsSymmSndFDerivWithi
 theorem IsSymmSndFDerivWithinAt.congr_set (h : IsSymmSndFDerivWithinAt 𝕜 f s x)
     (hst : s =ᶠ[𝓝 x] t) : IsSymmSndFDerivWithinAt 𝕜 f t x := by
   intro v w
-  rw [fderivWithin_fderivWithin_eq_of_eventuallyEq hst.symm]
+  rw [fderivWithin_fderivWithin_eq_of_eventuallyEqSet hst.symm]
   exact h v w
 
 theorem isSymmSndFDerivWithinAt_congr_set (hst : s =ᶠ[𝓝 x] t) :
@@ -585,9 +589,8 @@ theorem ContDiffWithinAt.isSymmSndFDerivWithinAt {n : ℕ∞ω}
       (m := 0) le_rfl).continuousOn
     apply this.congr
     intro y hy
-    apply fderivWithin_fderivWithin_eq_of_eventuallyEq
+    apply fderivWithin_fderivWithin_eq_of_eventuallyEqSet
     filter_upwards [u_open.mem_nhds hy.2] with z hz
-    change (z ∈ s) = (z ∈ s ∩ u)
     simp_all
   have B : Tendsto (fun k ↦ fderivWithin 𝕜 (fderivWithin 𝕜 f s) s (y k)) atTop
       (𝓝 (fderivWithin 𝕜 (fderivWithin 𝕜 f s) s x)) := by

--- a/Mathlib/Analysis/Calculus/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/VectorField.lean
@@ -648,7 +648,7 @@ lemma pullbackWithin_lieBracketWithin_of_isSymmSndFDerivWithinAt
 second derivative. Version in a complete space. One could also give a version avoiding
 completeness but requiring that `f` is a local diffeomorphism. Variant where unique
 differentiability and the invariance property are only required in a smaller set `u`. -/
-lemma pullbackWithin_lieBracketWithin_of_isSymmSndFDerivWithinAt_of_eventuallyEq
+lemma pullbackWithin_lieBracketWithin_of_isSymmSndFDerivWithinAt_of_eventuallyEqSet
     {f : E → F} {V W : F → F} {x : E} {t : Set F} {u : Set E}
     (hf : IsSymmSndFDerivWithinAt 𝕜 f s x) (h'f : ContDiffWithinAt 𝕜 2 f s x)
     (hV : DifferentiableWithinAt 𝕜 V t (f x)) (hW : DifferentiableWithinAt 𝕜 W t (f x))
@@ -673,6 +673,10 @@ lemma pullbackWithin_lieBracketWithin_of_isSymmSndFDerivWithinAt_of_eventuallyEq
       simp [pullbackWithin, hy]
   _ = lieBracketWithin 𝕜 (pullbackWithin 𝕜 f V s) (pullbackWithin 𝕜 f W s) s x :=
     lieBracketWithin_congr_set hus
+
+@[deprecated (since := "2026-08-14")]
+alias pullbackWithin_lieBracketWithin_of_isSymmSndFDerivWithinAt_of_eventuallyEq :=
+  pullbackWithin_lieBracketWithin_of_isSymmSndFDerivWithinAt_of_eventuallyEqSet
 
 /-- The Lie bracket commutes with taking pullbacks. This requires the function to have symmetric
 second derivative. Version in a complete space. One could also give a version avoiding

--- a/Mathlib/Analysis/SpecialFunctions/NonIntegrable.lean
+++ b/Mathlib/Analysis/SpecialFunctions/NonIntegrable.lean
@@ -95,7 +95,7 @@ theorem not_integrableOn_of_tendsto_norm_atTop_of_deriv_isBigO_filter_aux
       setIntegral_mono_on hfi.norm.def' (hgi.mono_set hsub') measurableSet_uIoc hg
     _ ≤ ∫ x in k, C * ‖g x‖ := by
       apply setIntegral_mono_set hgi
-        (ae_of_all _ fun x => mul_nonneg hC₀ (norm_nonneg _)) hsub'.eventuallyLE
+        (ae_of_all _ fun x => mul_nonneg hC₀ (norm_nonneg _)) hsub'.eventuallySubset
 
 theorem not_integrableOn_of_tendsto_norm_atTop_of_deriv_isBigO_filter
     {f : ℝ → E} {g : ℝ → F}

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -189,7 +189,7 @@ lemma AntitoneOn.sum_Ico_le_integral {a b : ℕ} (anti : AntitoneOn f (Icc a b))
   by_cases! hab : b < a
   · simpa [Finset.Ico_eq_empty_of_le hab.le] using setIntegral_nonneg measurableSet_Ioi nonneg
   grw [anti.sum_le_integral_Ico hab, integral_of_le (mod_cast hab)]
-  apply setIntegral_mono_set integrable _ (Ioc_subset_Ioi_self.eventuallyLE)
+  apply setIntegral_mono_set integrable _ Ioc_subset_Ioi_self.eventuallySubset
   exact ae_restrict_of_forall_mem measurableSet_Ioi nonneg
 
 /-- The partial sums of a nonnegative function are bounded by the integral over `(0, ∞)`. -/

--- a/Mathlib/Analysis/SumIntegralExpDecay.lean
+++ b/Mathlib/Analysis/SumIntegralExpDecay.lean
@@ -31,7 +31,7 @@ lemma intervalIntegral_pow_mul_exp_neg_le {k : ℕ} {M c : ℝ} (hM : 0 ≤ M) (
     _ = ∫ x in Ioc (0 : ℝ) M, x ^ ((↑k + 1 : ℝ) - 1) * rexp (-(c * x)) := by
         simp [add_sub_cancel_right, rpow_natCast]
     _ ≤ ∫ x in Ioi (0 : ℝ), x ^ ((↑k + 1 : ℝ) - 1) * rexp (-(c * x)) := by
-        apply setIntegral_mono_set hint _ Ioc_subset_Ioi_self.eventuallyLE
+        apply setIntegral_mono_set hint _ Ioc_subset_Ioi_self.eventuallySubset
         filter_upwards [ae_restrict_mem measurableSet_Ioi] with x hx
         exact mul_nonneg (rpow_nonneg hx.le _) (exp_nonneg _)
     _ = k ! / c ^ (k + 1) := by

--- a/Mathlib/Dynamics/Ergodic/Conservative.lean
+++ b/Mathlib/Dynamics/Ergodic/Conservative.lean
@@ -165,8 +165,8 @@ theorem ae_mem_imp_frequently_image_mem (hf : Conservative f μ) (hs : NullMeasu
   simp
 
 theorem inter_frequently_image_mem_ae_eq (hf : Conservative f μ) (hs : NullMeasurableSet s μ) :
-    (s ∩ { x | ∃ᶠ n in atTop, f^[n] x ∈ s } : Set α) =ᵐ[μ] s :=
-  inter_eventuallyEq_left.2 <| hf.ae_mem_imp_frequently_image_mem hs
+    s ∩ { x | ∃ᶠ n in atTop, f^[n] x ∈ s } =ᵐ[μ] s :=
+  inter_eventuallyEqSet_left.2 <| hf.ae_mem_imp_frequently_image_mem hs
 
 theorem measure_inter_frequently_image_mem_eq (hf : Conservative f μ) (hs : NullMeasurableSet s μ) :
     μ (s ∩ { x | ∃ᶠ n in atTop, f^[n] x ∈ s }) = μ s :=

--- a/Mathlib/Dynamics/Ergodic/Ergodic.lean
+++ b/Mathlib/Dynamics/Ergodic/Ergodic.lean
@@ -176,7 +176,7 @@ theorem ae_empty_or_univ_of_ae_le_preimage' (hf : Ergodic f μ) (hs : NullMeasur
 theorem ae_empty_or_univ_of_image_ae_le' (hf : Ergodic f μ) (hs : NullMeasurableSet s μ)
     (hs' : f '' s ≤ᵐ[μ] s) (h_fin : μ s ≠ ∞) : s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ := by
   replace hs' : s ≤ᵐ[μ] f ⁻¹' s :=
-    (LE.le.eventuallyLE (subset_preimage_image f s)).trans
+    (subset_preimage_image f s).eventuallySubset.trans
       (hf.quasiMeasurePreserving.preimage_mono_ae hs')
   exact ae_empty_or_univ_of_ae_le_preimage' hf hs hs' h_fin
 

--- a/Mathlib/Dynamics/Ergodic/Ergodic.lean
+++ b/Mathlib/Dynamics/Ergodic/Ergodic.lean
@@ -59,7 +59,7 @@ variable {f : α → α} {μ : Measure α}
 namespace PreErgodic
 
 theorem ae_empty_or_univ (hf : PreErgodic f μ) (hs : MeasurableSet s) (hfs : f ⁻¹' s = s) :
-    s =ᵐ[μ] (∅ : Set α) ∨ s =ᵐ[μ] univ := by
+    s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ := by
   simpa only [eventuallyConst_set'] using hf.aeconst_set hs hfs
 
 theorem measure_self_or_compl_eq_zero (hf : PreErgodic f μ) (hs : MeasurableSet s)
@@ -131,7 +131,7 @@ theorem aeconst_set₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s μ) (
 still either almost empty or full. -/
 theorem ae_empty_or_univ₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s μ)
     (hs : f ⁻¹' s =ᵐ[μ] s) :
-    s =ᵐ[μ] (∅ : Set α) ∨ s =ᵐ[μ] univ :=
+    s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ :=
   eventuallyConst_set'.mp <| hf.aeconst_set₀ hsm hs
 
 /-- For a quasi-ergodic map, sets that are almost invariant (rather than strictly invariant) are
@@ -160,21 +160,21 @@ theorem quasiErgodic (hf : Ergodic f μ) : QuasiErgodic f μ :=
 
 /-- See also `Ergodic.ae_empty_or_univ_of_preimage_ae_le`. -/
 theorem ae_empty_or_univ_of_preimage_ae_le' (hf : Ergodic f μ) (hs : NullMeasurableSet s μ)
-    (hs' : f ⁻¹' s ≤ᵐ[μ] s) (h_fin : μ s ≠ ∞) : s =ᵐ[μ] (∅ : Set α) ∨ s =ᵐ[μ] univ := by
+    (hs' : f ⁻¹' s ≤ᵐ[μ] s) (h_fin : μ s ≠ ∞) : s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ := by
   refine hf.quasiErgodic.ae_empty_or_univ₀ hs ?_
   refine ae_eq_of_ae_subset_of_measure_ge hs' (hf.measure_preimage hs).ge ?_ h_fin
   exact hs.preimage hf.quasiMeasurePreserving
 
 /-- See also `Ergodic.ae_empty_or_univ_of_ae_le_preimage`. -/
 theorem ae_empty_or_univ_of_ae_le_preimage' (hf : Ergodic f μ) (hs : NullMeasurableSet s μ)
-    (hs' : s ≤ᵐ[μ] f ⁻¹' s) (h_fin : μ s ≠ ∞) : s =ᵐ[μ] (∅ : Set α) ∨ s =ᵐ[μ] univ := by
+    (hs' : s ≤ᵐ[μ] f ⁻¹' s) (h_fin : μ s ≠ ∞) : s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ := by
   replace h_fin : μ (f ⁻¹' s) ≠ ∞ := by rwa [hf.measure_preimage hs]
   refine hf.quasiErgodic.ae_empty_or_univ₀ hs ?_
   exact (ae_eq_of_ae_subset_of_measure_ge hs' (hf.measure_preimage hs).le hs h_fin).symm
 
 /-- See also `Ergodic.ae_empty_or_univ_of_image_ae_le`. -/
 theorem ae_empty_or_univ_of_image_ae_le' (hf : Ergodic f μ) (hs : NullMeasurableSet s μ)
-    (hs' : f '' s ≤ᵐ[μ] s) (h_fin : μ s ≠ ∞) : s =ᵐ[μ] (∅ : Set α) ∨ s =ᵐ[μ] univ := by
+    (hs' : f '' s ≤ᵐ[μ] s) (h_fin : μ s ≠ ∞) : s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ := by
   replace hs' : s ≤ᵐ[μ] f ⁻¹' s :=
     (LE.le.eventuallyLE (subset_preimage_image f s)).trans
       (hf.quasiMeasurePreserving.preimage_mono_ae hs')
@@ -202,15 +202,15 @@ section IsFiniteMeasure
 variable [IsFiniteMeasure μ]
 
 theorem ae_empty_or_univ_of_preimage_ae_le (hf : Ergodic f μ) (hs : NullMeasurableSet s μ)
-    (hs' : f ⁻¹' s ≤ᵐ[μ] s) : s =ᵐ[μ] (∅ : Set α) ∨ s =ᵐ[μ] univ :=
+    (hs' : f ⁻¹' s ≤ᵐ[μ] s) : s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ :=
   ae_empty_or_univ_of_preimage_ae_le' hf hs hs' <| measure_ne_top μ s
 
 theorem ae_empty_or_univ_of_ae_le_preimage (hf : Ergodic f μ) (hs : NullMeasurableSet s μ)
-    (hs' : s ≤ᵐ[μ] f ⁻¹' s) : s =ᵐ[μ] (∅ : Set α) ∨ s =ᵐ[μ] univ :=
+    (hs' : s ≤ᵐ[μ] f ⁻¹' s) : s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ :=
   ae_empty_or_univ_of_ae_le_preimage' hf hs hs' <| measure_ne_top μ s
 
 theorem ae_empty_or_univ_of_image_ae_le (hf : Ergodic f μ) (hs : NullMeasurableSet s μ)
-    (hs' : f '' s ≤ᵐ[μ] s) : s =ᵐ[μ] (∅ : Set α) ∨ s =ᵐ[μ] univ :=
+    (hs' : f '' s ≤ᵐ[μ] s) : s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ :=
   ae_empty_or_univ_of_image_ae_le' hf hs hs' <| measure_ne_top μ s
 
 end IsFiniteMeasure

--- a/Mathlib/Dynamics/Ergodic/RadonNikodym.lean
+++ b/Mathlib/Dynamics/Ergodic/RadonNikodym.lean
@@ -41,7 +41,7 @@ protected theorem singularPart [SigmaFinite ν] {f : X → X}
   rcases (μ.mutuallySingular_singularPart ν).symm with ⟨s, hsm, hνs, hμs⟩
   convert! hfμ.restrict_preimage hsm using 1
   · refine singularPart_eq_restrict ?_ (hfν.preimage_null hνs)
-    rw [← mem_ae_iff, ← Filter.eventuallyEq_univ,
+    rw [← mem_ae_iff, ← Filter.eventuallyEqSet_univ,
       ae_eq_univ_iff_measure_eq (hfμ.measurable hsm).nullMeasurableSet]
     calc
       μ.singularPart ν (f ⁻¹' s) = (ν.withDensity (μ.rnDeriv ν) + μ.singularPart ν) (f ⁻¹' s) := by

--- a/Mathlib/Geometry/Manifold/ContMDiff/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Atlas.lean
@@ -383,6 +383,6 @@ theorem OpenPartialHomeomorph.contMDiffOn_writtenInExtend_iff
   refine forall_mem_image.trans <| forall₂_congr fun x hx ↦ ?_
   refine (contMDiffWithinAt_congr_set ?_).trans
     (contMDiffWithinAt_writtenInExtend_iff hφ hψ (hs hx) (hmaps hx) hmaps)
-  rw [← nhdsWithin_eq_iff_eventuallyEq, ← φ.map_extend_nhdsWithin_eq_image_of_subset,
+  rw [← nhdsWithin_eq_iff_eventuallyEqSet, ← φ.map_extend_nhdsWithin_eq_image_of_subset,
     ← φ.map_extend_nhdsWithin]
   exacts [hs hx, hs hx, hs]

--- a/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
@@ -267,7 +267,7 @@ theorem contMDiffWithinAt_iff' :
           (extChartAt I x x) := by
   simp only [ContMDiffWithinAt, liftPropWithinAt_iff']
   exact and_congr_right fun hc => contDiffWithinAt_congr_set <|
-    hc.extChartAt_symm_preimage_inter_range_eventuallyEq
+    hc.extChartAt_symm_preimage_inter_range_eventuallyEqSet
 
 /-- One can reformulate being `Cⁿ` within a set at a point as continuity within this set at this
 point, and being `Cⁿ` in the corresponding extended chart in the target. -/
@@ -423,7 +423,7 @@ theorem contMDiffWithinAt_iff_image
           (e.extend I x) := by
   rw [contMDiffWithinAt_iff_of_mem_maximalAtlas he he' hx hy, and_congr_right_iff]
   refine fun _ => contDiffWithinAt_congr_set ?_
-  simp_rw [e.extend_symm_preimage_inter_range_eventuallyEq hs hx]
+  simp_rw [e.extend_symm_preimage_inter_range_eventuallyEqSet hs hx]
 
 theorem contMDiffAt_iff_of_mem_maximalAtlas {x : M} (he : e ∈ maximalAtlas I n M)
     (he' : e' ∈ maximalAtlas I' n M') (hx : x ∈ e.source) (hy : f x ∈ e'.source) :
@@ -458,7 +458,7 @@ theorem contMDiffWithinAt_iff_of_mem_source' [IsManifold I n M] [IsManifold I' n
   rw [and_congr_right_iff]
   set e := extChartAt I x; set e' := extChartAt I' (f x)
   refine fun hc => contDiffWithinAt_congr_set ?_
-  rw [← nhdsWithin_eq_iff_eventuallyEq, ← e.image_source_inter_eq',
+  rw [← nhdsWithin_eq_iff_eventuallyEqSet, ← e.image_source_inter_eq',
     ← map_extChartAt_nhdsWithin_eq_image' hx,
     ← map_extChartAt_nhdsWithin' hx, inter_comm, nhdsWithin_inter_of_mem]
   exact hc (extChartAt_source_mem_nhds' hy)
@@ -706,7 +706,7 @@ theorem contMDiffWithinAt_insert_self :
   simp only [contMDiffWithinAt_iff, continuousWithinAt_insert_self]
   refine Iff.rfl.and <| (contDiffWithinAt_congr_set ?_).trans contDiffWithinAt_insert_self
   simp only [← map_extChartAt_nhdsWithin, nhdsWithin_insert, Filter.map_sup, Filter.map_pure,
-    ← nhdsWithin_eq_iff_eventuallyEq]
+    ← nhdsWithin_eq_iff_eventuallyEqSet]
 
 alias ⟨ContMDiffWithinAt.of_insert, _⟩ := contMDiffWithinAt_insert_self
 
@@ -721,7 +721,7 @@ theorem contMDiffWithinAt_congr_set' (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
     ContMDiffWithinAt I I' n f s x ↔ ContMDiffWithinAt I I' n f t x := by
   have : T1Space M := I.t1Space M
   rw [← contMDiffWithinAt_insert_self (s := s), ← contMDiffWithinAt_insert_self (s := t)]
-  exact contMDiffWithinAt_congr_set (eventuallyEq_insert h)
+  exact contMDiffWithinAt_congr_set (eventuallyEqSet_insert h)
 
 protected theorem ContMDiffAt.contMDiffWithinAt (hf : ContMDiffAt I I' n f x) :
     ContMDiffWithinAt I I' n f s x :=
@@ -758,7 +758,7 @@ theorem contMDiffOn_iff_source_of_mem_maximalAtlas
   refine forall₂_congr fun x hx => ?_
   rw [contMDiffWithinAt_iff_source_of_mem_maximalAtlas he (hs hx)]
   apply contMDiffWithinAt_congr_set
-  simp_rw [e.extend_symm_preimage_inter_range_eventuallyEq hs (hs hx)]
+  simp_rw [e.extend_symm_preimage_inter_range_eventuallyEqSet hs (hs hx)]
 
 /-- A function is `C^n` within a set at a point, for `n : ℕ` or `n = ω`,
 if and only if it is `C^n` on a neighborhood of this point. -/

--- a/Mathlib/Geometry/Manifold/IsManifold/ExtChartAt.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/ExtChartAt.lean
@@ -184,9 +184,12 @@ theorem nhdsWithin_extend_target_eq {y : M} (hy : y ∈ f.source) :
   (nhdsWithin_mono _ (extend_target_subset_range _)).antisymm <|
     nhdsWithin_le_of_mem (extend_target_mem_nhdsWithin _ hy)
 
-theorem extend_target_eventuallyEq {y : M} (hy : y ∈ f.source) :
+theorem extend_target_eventuallyEqSet {y : M} (hy : y ∈ f.source) :
     (f.extend I).target =ᶠ[𝓝 (f.extend I y)] range I :=
-  nhdsWithin_eq_iff_eventuallyEq.1 (nhdsWithin_extend_target_eq _ hy)
+  nhdsWithin_eq_iff_eventuallyEqSet.1 (nhdsWithin_extend_target_eq _ hy)
+
+@[deprecated (since := "2026-08-14")]
+alias extend_target_eventuallyEq := extend_target_eventuallyEqSet
 
 theorem continuousAt_extend_symm' {x : E} (h : x ∈ (f.extend I).target) :
     ContinuousAt (f.extend I).symm x :=
@@ -275,7 +278,7 @@ theorem continuousOn_writtenInExtend_iff {f' : OpenPartialHomeomorph M' H'} {g :
   refine forall_mem_image.trans <| forall₂_congr fun x hx ↦ ?_
   refine (continuousWithinAt_congr_set ?_).trans
     (continuousWithinAt_writtenInExtend_iff _ (hs hx) (hmaps hx) hmaps)
-  rw [← nhdsWithin_eq_iff_eventuallyEq, ← map_extend_nhdsWithin_eq_image_of_subset,
+  rw [← nhdsWithin_eq_iff_eventuallyEqSet, ← map_extend_nhdsWithin_eq_image_of_subset,
     ← map_extend_nhdsWithin]
   exacts [hs hx, hs hx, hs]
 
@@ -303,11 +306,15 @@ theorem extend_preimage_inter_eq :
       (f.extend I).symm ⁻¹' s ∩ range I ∩ (f.extend I).symm ⁻¹' t := by
   mfld_set_tac
 
-theorem extend_symm_preimage_inter_range_eventuallyEq {s : Set M} {x : M} (hs : s ⊆ f.source)
+theorem extend_symm_preimage_inter_range_eventuallyEqSet {s : Set M} {x : M} (hs : s ⊆ f.source)
     (hx : x ∈ f.source) :
-    ((f.extend I).symm ⁻¹' s ∩ range I : Set _) =ᶠ[𝓝 (f.extend I x)] f.extend I '' s := by
-  rw [← nhdsWithin_eq_iff_eventuallyEq, ← map_extend_nhdsWithin _ hx,
+    (f.extend I).symm ⁻¹' s ∩ range I =ᶠ[𝓝 (f.extend I x)] f.extend I '' s := by
+  rw [← nhdsWithin_eq_iff_eventuallyEqSet, ← map_extend_nhdsWithin _ hx,
     map_extend_nhdsWithin_eq_image_of_subset _ hx hs]
+
+@[deprecated (since := "2026-08-14")]
+alias extend_symm_preimage_inter_range_eventuallyEq :=
+  extend_symm_preimage_inter_range_eventuallyEqSet
 
 lemma extend_prod (f' : OpenPartialHomeomorph M' H') :
     (f.prod f').extend (I.prod I') = (f.extend I).prod (f'.extend I') := by simp
@@ -601,19 +608,29 @@ theorem nhdsWithin_extChartAt_target_eq (x : M) :
 
 /-- Around the image of a point in the source, `(extChartAt I x).target` and `range I`
 coincide locally. -/
-theorem extChartAt_target_eventuallyEq' {x y : M} (hy : y ∈ (extChartAt I x).source) :
+theorem extChartAt_target_eventuallyEqSet' {x y : M} (hy : y ∈ (extChartAt I x).source) :
     (extChartAt I x).target =ᶠ[𝓝 (extChartAt I x y)] range I :=
-  nhdsWithin_eq_iff_eventuallyEq.1 (nhdsWithin_extChartAt_target_eq' hy)
+  nhdsWithin_eq_iff_eventuallyEqSet.1 (nhdsWithin_extChartAt_target_eq' hy)
+
+@[deprecated (since := "2026-08-14")]
+alias extChartAt_target_eventuallyEq' := extChartAt_target_eventuallyEqSet'
 
 /-- Around a point in the target, `(extChartAt I x).target` and `range I` coincide locally. -/
-theorem extChartAt_target_eventuallyEq_of_mem {x : M} {z : E} (hz : z ∈ (extChartAt I x).target) :
+theorem extChartAt_target_eventuallyEqSet_of_mem {x : M} {z : E}
+    (hz : z ∈ (extChartAt I x).target) :
     (extChartAt I x).target =ᶠ[𝓝 z] range I :=
-  nhdsWithin_eq_iff_eventuallyEq.1 (nhdsWithin_extChartAt_target_eq_of_mem hz)
+  nhdsWithin_eq_iff_eventuallyEqSet.1 (nhdsWithin_extChartAt_target_eq_of_mem hz)
+
+@[deprecated (since := "2026-08-14")]
+alias extChartAt_target_eventuallyEq_of_mem := extChartAt_target_eventuallyEqSet_of_mem
 
 /-- Around the image of the base point, `(extChartAt I x).target` and `range I` coincide locally. -/
-theorem extChartAt_target_eventuallyEq {x : M} :
+theorem extChartAt_target_eventuallyEqSet {x : M} :
     (extChartAt I x).target =ᶠ[𝓝 (extChartAt I x x)] range I :=
-  nhdsWithin_eq_iff_eventuallyEq.1 (nhdsWithin_extChartAt_target_eq x)
+  nhdsWithin_eq_iff_eventuallyEqSet.1 (nhdsWithin_extChartAt_target_eq x)
+
+@[deprecated (since := "2026-08-14")]
+alias extChartAt_target_eventuallyEq := extChartAt_target_eventuallyEqSet
 
 theorem continuousAt_extChartAt_symm'' {x : M} {y : E} (h : y ∈ (extChartAt I x).target) :
     ContinuousAt (extChartAt I x).symm y :=
@@ -645,7 +662,7 @@ lemma extChartAt_target_subset_closure_interior {x : M} :
     mem_closure_iff_nhds.1 B _ A
   refine ⟨z, ⟨tz, ?_⟩⟩
   have h''z : z ∈ (extChartAt I x).target := by simpa [interior_subset hz] using h'z
-  exact (extChartAt_target_eventuallyEq_of_mem h''z).symm.mem_interior hz
+  exact (extChartAt_target_eventuallyEqSet_of_mem h''z).symm.mem_interior hz
 
 variable (I) in
 theorem interior_extChartAt_target_nonempty (x : M) :
@@ -767,13 +784,17 @@ theorem ContinuousWithinAt.nhdsWithin_extChartAt_symm_preimage_inter_range
     ← map_extChartAt_nhdsWithin, nhdsWithin_inter_of_mem']
   exact hc (extChartAt_source_mem_nhds _)
 
-theorem ContinuousWithinAt.extChartAt_symm_preimage_inter_range_eventuallyEq
+theorem ContinuousWithinAt.extChartAt_symm_preimage_inter_range_eventuallyEqSet
     {f : M → M'} {x : M} (hc : ContinuousWithinAt f s x) :
-    ((extChartAt I x).symm ⁻¹' s ∩ range I : Set E) =ᶠ[𝓝 (extChartAt I x x)]
+    (extChartAt I x).symm ⁻¹' s ∩ range I =ᶠ[𝓝 (extChartAt I x x)]
       ((extChartAt I x).target ∩
         (extChartAt I x).symm ⁻¹' (s ∩ f ⁻¹' (extChartAt I' (f x)).source) : Set E) := by
-  rw [← nhdsWithin_eq_iff_eventuallyEq]
+  rw [← nhdsWithin_eq_iff_eventuallyEqSet]
   exact hc.nhdsWithin_extChartAt_symm_preimage_inter_range
+
+@[deprecated (since := "2026-08-14")]
+alias ContinuousWithinAt.extChartAt_symm_preimage_inter_range_eventuallyEq :=
+  ContinuousWithinAt.extChartAt_symm_preimage_inter_range_eventuallyEqSet
 
 /-! We use the name `ext_coord_change` for `(extChartAt I x').symm ≫ extChartAt I x`. -/
 

--- a/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
+++ b/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
@@ -85,7 +85,7 @@ theorem congr_set {s t : Set H} {x : H} {f : H → H'} (hu : s =ᶠ[𝓝 x] t) :
 
 theorem is_local_nhds {s u : Set H} {x : H} {f : H → H'} (hu : u ∈ 𝓝[s] x) :
     P f s x ↔ P f (s ∩ u) x :=
-  hG.congr_set <| mem_nhdsWithin_iff_eventuallyEq.mp hu
+  hG.congr_set <| mem_nhdsWithin_iff_eventuallyEqSet.mp hu
 
 theorem congr_iff_nhdsWithin {s : Set H} {x : H} {f g : H → H'} (h1 : f =ᶠ[𝓝[s] x] g)
     (h2 : f x = g x) : P f s x ↔ P g s x := by
@@ -138,9 +138,8 @@ theorem right_invariance {s : Set H} {x : H} {f : H → H'} {e : OpenPartialHome
   refine hG.congr ?_ ((hG.congr_set ?_).mp this)
   · refine eventually_of_mem (e.open_source.mem_nhds hxe) fun x' hx' ↦ ?_
     simp_rw [Function.comp_apply, e.left_inv hx']
-  · rw [eventuallyEq_set]
-    refine eventually_of_mem (e.open_source.mem_nhds hxe) fun x' hx' ↦ ?_
-    simp_rw [mem_preimage, e.left_inv hx']
+  · refine eventually_of_mem (e.open_source.mem_nhds hxe) fun x' hx' ↦ ?_
+    simp [e.left_inv hx']
 
 end LocalInvariantProp
 
@@ -241,7 +240,7 @@ theorem liftPropWithinAt_iff {f : M → M'} :
           (chartAt H x x) := by
   rw [liftPropWithinAt_iff']
   refine and_congr_right fun hf ↦ hG.congr_set ?_
-  exact OpenPartialHomeomorph.preimage_eventuallyEq_target_inter_preimage_inter hf
+  exact OpenPartialHomeomorph.preimage_eventuallyEqSet_target_inter_preimage_inter hf
     (mem_chart_source H x) (chart_source_mem_nhds H' (f x))
 
 theorem liftPropWithinAt_indep_chart_source_aux (g : M → H')
@@ -364,9 +363,9 @@ theorem liftPropOn_indep_chart (he : e ∈ G.maximalAtlas M)
 theorem liftPropWithinAt_inter' (ht : t ∈ 𝓝[s] x) :
     LiftPropWithinAt P g (s ∩ t) x ↔ LiftPropWithinAt P g s x := by
   rw [liftPropWithinAt_iff', liftPropWithinAt_iff', continuousWithinAt_inter' ht, hG.congr_set]
-  simp_rw [eventuallyEq_set, mem_preimage,
+  simp_rw [eventuallyEqSet_iff, mem_preimage,
     (chartAt _ x).eventually_nhds' (fun x ↦ x ∈ s ∩ t ↔ x ∈ s) (mem_chart_source _ x)]
-  exact (mem_nhdsWithin_iff_eventuallyEq.mp ht).symm.mem_iff
+  exact (mem_nhdsWithin_iff_eventuallyEqSet.mp ht).symm.mem_iff
 
 theorem liftPropWithinAt_inter (ht : t ∈ 𝓝 x) :
     LiftPropWithinAt P g (s ∩ t) x ↔ LiftPropWithinAt P g s x :=

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -291,7 +291,8 @@ theorem mdifferentiableWithinAt_iff_image {x : M} (he : e ∈ maximalAtlas I 1 M
           (e.extend I x) := by
   rw [mdifferentiableWithinAt_iff_of_mem_maximalAtlas he he' hx hy, and_congr_right_iff]
   refine fun _ => differentiableWithinAt_congr_nhds ?_
-  simp_rw [nhdsWithin_eq_iff_eventuallyEq, e.extend_symm_preimage_inter_range_eventuallyEq hs hx]
+  simp_rw [nhdsWithin_eq_iff_eventuallyEqSet,
+    e.extend_symm_preimage_inter_range_eventuallyEqSet hs hx]
 
 /-- One can reformulate smoothness within a set at a point as continuity within this set at this
 point, and smoothness in any chart containing that point. -/
@@ -841,8 +842,8 @@ lemma tangentMap_snd {X : TangentSpace% x} : (tangentMap% f X).2 = (mfderiv% f x
 
 /-- If two sets coincide locally around `x`, except maybe at a point `y`, then their
 preimage under `extChartAt x` coincide locally, except maybe at `extChartAt I x x`. -/
-theorem preimage_extChartAt_eventuallyEq_compl_singleton (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
-    ((extChartAt I x).symm ⁻¹' s ∩ range I : Set E) =ᶠ[𝓝[{extChartAt I x x}ᶜ] (extChartAt I x x)]
+theorem preimage_extChartAt_eventuallyEqSet_compl_singleton (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
+    (extChartAt I x).symm ⁻¹' s ∩ range I =ᶠ[𝓝[{extChartAt I x x}ᶜ] (extChartAt I x x)]
     ((extChartAt I x).symm ⁻¹' t ∩ range I : Set E) := by
   have : T1Space M := I.t1Space M
   obtain ⟨u, u_mem, hu⟩ : ∃ u ∈ 𝓝 x, u ∩ {x}ᶜ ⊆ {y | (y ∈ s) = (y ∈ t)} :=
@@ -855,7 +856,6 @@ theorem preimage_extChartAt_eventuallyEq_compl_singleton (y : M) (h : s =ᶠ[�
     ⟨_, Filter.inter_mem ((continuousAt_extChartAt_symm x).preimage_mem_nhds u_mem) B, ?_⟩
   rintro z ⟨hz, h'z⟩
   simp only [eq_iff_iff, mem_ofPred_eq]
-  change z ∈ (extChartAt I x).symm ⁻¹' s ∩ range I ↔ z ∈ (extChartAt I x).symm ⁻¹' t ∩ range I
   by_cases hIz : z ∈ range I
   · simp only [mem_inter_iff, mem_preimage, mem_union, mem_compl_iff, hIz, not_true_eq_false,
       or_false, and_true] at hz ⊢
@@ -865,6 +865,10 @@ theorem preimage_extChartAt_eventuallyEq_compl_singleton (y : M) (h : s =ᶠ[�
     rw [eq_comm, (extChartAt I x).eq_symm_apply (by simp) hz.2]
     exact Ne.symm h'z
   · simp [hIz]
+
+@[deprecated (since := "2026-08-14")]
+alias preimage_extChartAt_eventuallyEq_compl_singleton :=
+  preimage_extChartAt_eventuallyEqSet_compl_singleton
 
 /-! ### Congruence lemmas for derivatives on manifolds -/
 
@@ -877,7 +881,7 @@ theorem hasMFDerivWithinAt_congr_set' (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
   refine and_congr ?_ ?_
   · exact continuousWithinAt_congr_set' _ h
   · apply hasFDerivWithinAt_congr_set' (extChartAt I x x)
-    exact preimage_extChartAt_eventuallyEq_compl_singleton y h
+    exact preimage_extChartAt_eventuallyEqSet_compl_singleton y h
 
 theorem hasMFDerivWithinAt_congr_set (h : s =ᶠ[𝓝 x] t) :
     HasMFDerivAt[s] f x f' ↔ HasMFDerivAt[t] f x f' :=
@@ -901,7 +905,7 @@ theorem mfderivWithin_congr_set' (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
   by_cases hx : MDiffAt[s] f x
   · simp only [mfderivWithin, hx, (mdifferentiableWithinAt_congr_set' y h).1 hx, ↓reduceIte]
     apply fderivWithin_congr_set' (extChartAt I x x)
-    exact preimage_extChartAt_eventuallyEq_compl_singleton y h
+    exact preimage_extChartAt_eventuallyEqSet_compl_singleton y h
   · simp [mfderivWithin, hx, ← mdifferentiableWithinAt_congr_set' y h]
 
 /-- If two sets coincide locally, then derivatives within these sets

--- a/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
@@ -172,7 +172,7 @@ theorem mlieBracketWithin_congr_set' (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
     =ᶠ[𝓝[{(extChartAt I x) x}ᶜ] (extChartAt I x x)]
       ((extChartAt I x).symm ⁻¹' t ∩ range I : Set E) by
     apply lieBracketWithin_congr_set' _ A
-  exact preimage_extChartAt_eventuallyEq_compl_singleton y h
+  exact preimage_extChartAt_eventuallyEqSet_compl_singleton y h
 
 theorem mlieBracketWithin_congr_set (h : s =ᶠ[𝓝 x] t) :
     mlieBracketWithin I V W s x = mlieBracketWithin I V W t x :=
@@ -182,7 +182,6 @@ theorem mlieBracketWithin_inter (ht : t ∈ 𝓝 x) :
     mlieBracketWithin I V W (s ∩ t) x = mlieBracketWithin I V W s x := by
   apply mlieBracketWithin_congr_set
   filter_upwards [ht] with y hy
-  change (y ∈ s ∩ t) = (y ∈ s)
   simp_all
 
 theorem mlieBracketWithin_of_mem_nhds (h : s ∈ 𝓝 x) :
@@ -615,7 +614,7 @@ private lemma mpullbackWithin_mlieBracketWithin_aux [CompleteSpace E']
   simp only [mpullbackWithin_eq_pullbackWithin]
   -- finally, use the fact that for `C^2` maps between vector spaces with symmetric second
   -- derivative, the pullback and the Lie bracket commute.
-  rw [pullbackWithin_lieBracketWithin_of_isSymmSndFDerivWithinAt_of_eventuallyEq
+  rw [pullbackWithin_lieBracketWithin_of_isSymmSndFDerivWithinAt_of_eventuallyEqSet
       (u := (extChartAt I x₀).symm ⁻¹' s ∩ (extChartAt I x₀).target)]
   · exact hsymm
   · rw [hF, comp_assoc]
@@ -638,7 +637,7 @@ private lemma mpullbackWithin_mlieBracketWithin_aux [CompleteSpace E']
     refine ⟨?_, mem_range_self _⟩
     convert! hst hz.1
     exact PartialEquiv.left_inv (extChartAt I' (f x₀)) (ht (hst hz.1))
-  · rw [← nhdsWithin_eq_iff_eventuallyEq]
+  · rw [← nhdsWithin_eq_iff_eventuallyEqSet]
     apply le_antisymm
     · exact nhdsWithin_mono _ (inter_subset_inter_right _ (extChartAt_target_subset_range x₀))
     · rw [nhdsWithin_le_iff, nhdsWithin_inter]
@@ -694,8 +693,7 @@ lemma mpullbackWithin_mlieBracketWithin_of_isSymmSndFDerivWithinAt
   set s' := s ∩ u with hs'
   have s'_eq : s' =ᶠ[𝓝 x₀] s := by
     filter_upwards [u_mem] with y hy
-    change (y ∈ s ∩ u) = (y ∈ s)
-    simp [hy]
+    simp [hs', hy]
   set t' := t ∩ (extChartAt I' (f x₀)).source with ht'
   calc mpullbackWithin I I' f (mlieBracketWithin I' V W t) s x₀
   _ = mpullbackWithin I I' f (mlieBracketWithin I' V W t) s' x₀ := by
@@ -711,8 +709,6 @@ lemma mpullbackWithin_mlieBracketWithin_of_isSymmSndFDerivWithinAt
       apply (continuousAt_extChartAt_symm x₀).preimage_mem_nhds
       apply u_open.mem_nhds (by simpa using x₀u)
     filter_upwards [this] with y hy
-    change (y ∈ (extChartAt I x₀).symm ⁻¹' s ∩ range I) =
-      (y ∈ (extChartAt I x₀).symm ⁻¹' (s ∩ u) ∩ range I)
     simp [-extChartAt, hy]
   _ = mlieBracketWithin I (mpullbackWithin I I' f V s') (mpullbackWithin I I' f W s') s x₀ := by
     simp only [hs', mlieBracketWithin_inter u_mem]
@@ -747,12 +743,12 @@ lemma mpullbackWithin_mlieBracketWithin'
   have B : ContDiffWithinAt 𝕜 n ((extChartAt I' (f x₀)) ∘ f ∘ (extChartAt I x₀).symm)
       ((extChartAt I x₀).symm ⁻¹' u ∩ (extChartAt I x₀).target) (extChartAt I x₀ x₀) := by
     apply (contMDiffWithinAt_iff.1 hf).2.congr_set
-    exact EventuallyEq.inter (by rfl) extChartAt_target_eventuallyEq.symm
+    exact EventuallyEqSet.inter (by rfl) extChartAt_target_eventuallyEqSet.symm
   apply mpullbackWithin_mlieBracketWithin_of_isSymmSndFDerivWithinAt hV hW hs
     ((hf.mono hsu).of_le (le_minSmoothness.trans hn)) hx₀ hst
   have : ((extChartAt I x₀).symm ⁻¹' s ∩ (extChartAt I x₀).target : Set E)
-      =ᶠ[𝓝 (extChartAt I x₀ x₀)] ((extChartAt I x₀).symm ⁻¹' s ∩ range I : Set E) :=
-    EventuallyEq.inter (by rfl) extChartAt_target_eventuallyEq
+      =ᶠ[𝓝 (extChartAt I x₀ x₀)] (extChartAt I x₀).symm ⁻¹' s ∩ range I :=
+    EventuallyEqSet.inter (by rfl) extChartAt_target_eventuallyEqSet
   apply IsSymmSndFDerivWithinAt.congr_set _ this
   have : IsSymmSndFDerivWithinAt 𝕜 ((extChartAt I' (f x₀)) ∘ f ∘ (extChartAt I x₀).symm)
       ((extChartAt I x₀).symm ⁻¹' u ∩ (extChartAt I x₀).target) (extChartAt I x₀ x₀) := by

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -453,7 +453,7 @@ variable {α' : Type*} [TopologicalSpace α'] [MeasurableSpace α']
 
 theorem interior_ae_eq_of_null_frontier {μ : Measure α'} {s : Set α'} (h : μ (frontier s) = 0) :
     interior s =ᵐ[μ] s :=
-  interior_subset.eventuallyLE.antisymm <| subset_closure.eventuallyLE.trans (ae_le_set.2 h)
+  interior_subset.eventuallySubset.antisymm <| subset_closure.eventuallySubset.trans (ae_le_set.2 h)
 
 theorem measure_interior_of_null_frontier {μ : Measure α'} {s : Set α'} (h : μ (frontier s) = 0) :
     μ (interior s) = μ s :=
@@ -465,7 +465,8 @@ theorem nullMeasurableSet_of_null_frontier {s : Set α} {μ : Measure α} (h : �
 
 theorem closure_ae_eq_of_null_frontier {μ : Measure α'} {s : Set α'} (h : μ (frontier s) = 0) :
     closure s =ᵐ[μ] s :=
-  ((ae_le_set.2 h).trans interior_subset.eventuallyLE).antisymm <| subset_closure.eventuallyLE
+  ((ae_le_set.2 h).trans interior_subset.eventuallySubset).antisymm <|
+    subset_closure.eventuallySubset
 
 theorem measure_closure_of_null_frontier {μ : Measure α'} {s : Set α'} (h : μ (frontier s) = 0) :
     μ (closure s) = μ s :=

--- a/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
+++ b/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
@@ -229,9 +229,9 @@ theorem blimsup_cthickening_ae_eq_blimsup_thickening {p : ℕ → Prop} {s : ℕ
     (hr : Tendsto r atTop (𝓝 0)) (hr' : ∀ᶠ i in atTop, p i → 0 < r i) :
     (blimsup (fun i => cthickening (r i) (s i)) atTop p : Set α) =ᵐ[μ]
       (blimsup (fun i => thickening (r i) (s i)) atTop p : Set α) := by
-  refine eventuallySubset_antisymm_iff.mpr ⟨?_, .of_le ?_⟩
+  refine eventuallySubset_antisymm_iff.mpr ⟨?_, .of_subset ?_⟩
   · refine (blimsup_cthickening_mul_ae_eq μ p s (one_half_pos (α := ℝ)) r hr).superset.trans
-      (.of_le ?_)
+      (.of_subset ?_)
     refine mono_blimsup' (hr'.mono fun i hi pi => cthickening_subset_thickening' (hi pi) ?_ (s i))
     nlinarith [hi pi]
   · exact mono_blimsup fun i _ => thickening_subset_cthickening _ _

--- a/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
+++ b/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
@@ -198,7 +198,7 @@ theorem blimsup_cthickening_mul_ae_eq (p : ℕ → Prop) (s : ℕ → Set α) {M
     clear p hr r; intro p r hr
     have hr' : Tendsto (fun i => M * r i) atTop (𝓝[>] 0) := by
       convert! TendstoNhdsWithinIoi.const_mul hM hr <;> simp only [mul_zero]
-    refine eventuallyLE_antisymm_iff.mpr ⟨?_, ?_⟩
+    refine eventuallySubset_antisymm_iff.mpr ⟨?_, ?_⟩
     · exact blimsup_cthickening_ae_le_of_eventually_mul_le μ p (inv_pos.mpr hM) hr'
         (Eventually.of_forall fun i => by rw [inv_mul_cancel_left₀ hM.ne' (r i)])
     · exact blimsup_cthickening_ae_le_of_eventually_mul_le μ p hM hr
@@ -226,15 +226,13 @@ theorem blimsup_cthickening_mul_ae_eq (p : ℕ → Prop) (s : ℕ → Set α) {M
     blimsup_congr (Eventually.of_forall h₂)]
   exact ae_eq_set_union (this (fun i => p i ∧ 0 < r i) hr') (ae_eq_refl _)
 
-set_option backward.isDefEq.respectTransparency.types false in
 theorem blimsup_cthickening_ae_eq_blimsup_thickening {p : ℕ → Prop} {s : ℕ → Set α} {r : ℕ → ℝ}
     (hr : Tendsto r atTop (𝓝 0)) (hr' : ∀ᶠ i in atTop, p i → 0 < r i) :
     (blimsup (fun i => cthickening (r i) (s i)) atTop p : Set α) =ᵐ[μ]
       (blimsup (fun i => thickening (r i) (s i)) atTop p : Set α) := by
-  refine eventuallyLE_antisymm_iff.mpr ⟨?_, LE.le.eventuallyLE ?_⟩
-  · rw [eventuallyLE_congr (blimsup_cthickening_mul_ae_eq μ p s (one_half_pos (α := ℝ)) r hr).symm
-      EventuallyEq.rfl]
-    apply LE.le.eventuallyLE
+  refine eventuallySubset_antisymm_iff.mpr ⟨?_, .of_le ?_⟩
+  · refine (blimsup_cthickening_mul_ae_eq μ p s (one_half_pos (α := ℝ)) r hr).superset.trans
+      (.of_le ?_)
     refine mono_blimsup' (hr'.mono fun i hi pi => cthickening_subset_thickening' (hi pi) ?_ (s i))
     nlinarith [hi pi]
   · exact mono_blimsup fun i _ => thickening_subset_cthickening _ _

--- a/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
+++ b/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
@@ -168,8 +168,7 @@ theorem blimsup_cthickening_ae_le_of_eventually_mul_le (p : ℕ → Prop) {s : �
     exact max_le_max (le_refl 0) hi
   simp_rw [← cthickening_max_zero (r₁ _), ← cthickening_max_zero (r₂ _)]
   rcases le_or_gt 1 M with hM' | hM'
-  · apply LE.le.eventuallyLE
-    refine mono_blimsup' (hMr.mono fun i hi _ => cthickening_mono ?_ (s i))
+  · refine .of_subset <| mono_blimsup' <| hMr.mono fun i hi _ => cthickening_mono ?_ (s i)
     exact (le_mul_of_one_le_left (hRp i) hM').trans hi
   · simp only [← @cthickening_closure _ _ _ (s _)]
     have hs : ∀ i, IsClosed (closure (s i)) := fun i => isClosed_closure

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/AEMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/AEMeasurable.lean
@@ -423,7 +423,7 @@ theorem Lp.induction_stronglyMeasurable (hm : m ≤ m0) (hp_ne_top : p ≠ ∞) 
   let s_g : Set α := Function.support (hgm.mk g)
   have hs_g : MeasurableSet[m] s_g := hgm.stronglyMeasurable_mk.measurableSet_support
   have hs_g_eq : s_g =ᵐ[μ] Function.support g := hgm.ae_eq_mk.symm.support
-  have h_inter_empty : (s_f ∩ s_g : Set α) =ᵐ[μ] (∅ : Set α) := by
+  have h_inter_empty : s_f ∩ s_g =ᵐ[μ] ∅ := by
     refine (hs_f_eq.inter hs_g_eq).trans ?_
     suffices Function.support f ∩ Function.support g = ∅ by rw [this]
     exact Set.disjoint_iff_inter_eq_empty.mp h_disj
@@ -431,7 +431,7 @@ theorem Lp.induction_stronglyMeasurable (hm : m ≤ m0) (hp_ne_top : p ≠ ∞) 
   have hff' : f =ᵐ[μ] f' := by
     have : s_f \ s_g =ᵐ[μ] s_f := by
       rw [← Set.sdiff_inter_self_eq_sdiff, Set.inter_comm]
-      refine ((ae_eq_refl s_f).diff h_inter_empty).trans ?_
+      refine (EventuallyEqSet.rfl.diff h_inter_empty).trans ?_
       rw [Set.sdiff_empty]
     refine ((indicator_ae_eq_of_ae_eq_set this).trans ?_).symm
     rw [Set.indicator_support]
@@ -442,7 +442,7 @@ theorem Lp.induction_stronglyMeasurable (hm : m ≤ m0) (hp_ne_top : p ≠ ∞) 
   have hgg' : g =ᵐ[μ] g' := by
     have : s_g \ s_f =ᵐ[μ] s_g := by
       rw [← Set.sdiff_inter_self_eq_sdiff]
-      refine ((ae_eq_refl s_g).diff h_inter_empty).trans ?_
+      refine (EventuallyEqSet.rfl.diff h_inter_empty).trans ?_
       rw [Set.sdiff_empty]
     refine ((indicator_ae_eq_of_ae_eq_set this).trans ?_).symm
     rw [Set.indicator_support]

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -177,7 +177,6 @@ protected theorem congr' (h_left : ∀ᶠ i in l, f i =ᵐ[μ] f' i) (h_right : 
   refine measure_congr ?_
   filter_upwards [h_ae_eq, h_right] with x hxf hxg
   rw [eq_iff_iff]
-  change ε ≤ edist (f' i x) (g' x) ↔ ε ≤ edist (f i x) (g x)
   rw [hxg, hxf]
 
 protected theorem congr (h_left : ∀ i, f i =ᵐ[μ] f' i) (h_right : g =ᵐ[μ] g')

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
@@ -573,7 +573,6 @@ theorem nullMeasurableSet_eq_fun {E} [TopologicalSpace E] [MetrizableSpace E] {f
     (hf.stronglyMeasurable_mk.measurableSet_eq_fun
           hg.stronglyMeasurable_mk).nullMeasurableSet.congr
   filter_upwards [hf.ae_eq_mk, hg.ae_eq_mk] with x hfx hgx
-  change (hf.mk f x = hg.mk g x) = (f x = g x)
   simp only [hfx, hgx]
 
 @[to_additive]
@@ -587,7 +586,6 @@ theorem nullMeasurableSet_lt [Preorder β] [OrderClosedTopology β] [PseudoMetri
   apply
     (hf.stronglyMeasurable_mk.measurableSet_lt hg.stronglyMeasurable_mk).nullMeasurableSet.congr
   filter_upwards [hf.ae_eq_mk, hg.ae_eq_mk] with x hfx hgx
-  change (hf.mk f x < hg.mk g x) = (f x < g x)
   simp only [hfx, hgx]
 
 theorem nullMeasurableSet_le [Preorder β] [OrderClosedTopology β] [PseudoMetrizableSpace β]
@@ -596,7 +594,6 @@ theorem nullMeasurableSet_le [Preorder β] [OrderClosedTopology β] [PseudoMetri
   apply
     (hf.stronglyMeasurable_mk.measurableSet_le hg.stronglyMeasurable_mk).nullMeasurableSet.congr
   filter_upwards [hf.ae_eq_mk, hg.ae_eq_mk] with x hfx hgx
-  change (hf.mk f x ≤ hg.mk g x) = (f x ≤ g x)
   simp only [hfx, hgx]
 
 theorem _root_.aestronglyMeasurable_of_aestronglyMeasurable_trim {α} {m m0 : MeasurableSpace α}

--- a/Mathlib/MeasureTheory/Group/Action.lean
+++ b/Mathlib/MeasureTheory/Group/Action.lean
@@ -84,8 +84,7 @@ theorem measure_preimage_smul_of_nullMeasurableSet (hs : NullMeasurableSet s μ)
     μ ((c • ·) ⁻¹' s) = μ s := by
   rw [← measure_toMeasurable s,
     ← SMulInvariantMeasure.measure_preimage_smul c (measurableSet_toMeasurable μ s)]
-  exact measure_congr (s := (c • ·) ⁻¹' toMeasurable μ s) (t := (c • ·) ⁻¹' s)
-    (tendsto_smul_ae μ c hs.toMeasurable_ae_eq) |>.symm
+  exact measure_congr (tendsto_smul_ae μ c hs.toMeasurable_ae_eq) |>.symm
 
 end AE_smul
 

--- a/Mathlib/MeasureTheory/Group/Action.lean
+++ b/Mathlib/MeasureTheory/Group/Action.lean
@@ -84,7 +84,8 @@ theorem measure_preimage_smul_of_nullMeasurableSet (hs : NullMeasurableSet s μ)
     μ ((c • ·) ⁻¹' s) = μ s := by
   rw [← measure_toMeasurable s,
     ← SMulInvariantMeasure.measure_preimage_smul c (measurableSet_toMeasurable μ s)]
-  exact measure_congr (tendsto_smul_ae μ c hs.toMeasurable_ae_eq) |>.symm
+  exact measure_congr (s := (c • ·) ⁻¹' toMeasurable μ s) (t := (c • ·) ⁻¹' s)
+    (tendsto_smul_ae μ c hs.toMeasurable_ae_eq) |>.symm
 
 end AE_smul
 
@@ -165,7 +166,7 @@ theorem smul_set_ae_le (c : G) {s t : Set α} : c • s ≤ᵐ[μ] c • t ↔ s
 set_option backward.isDefEq.respectTransparency false in
 @[to_additive (attr := simp)]
 theorem smul_set_ae_eq (c : G) {s t : Set α} : c • s =ᵐ[μ] c • t ↔ s =ᵐ[μ] t := by
-  simp only [Filter.eventuallyLE_antisymm_iff, smul_set_ae_le]
+  simp only [Filter.eventuallySubset_antisymm_iff, smul_set_ae_le]
 
 end AE
 

--- a/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
+++ b/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
@@ -132,7 +132,7 @@ theorem mk_of_measure_univ_le [IsFiniteMeasure μ] [Countable G] (h_meas : NullM
 
 @[to_additive]
 theorem iUnion_smul_ae_eq (h : IsFundamentalDomain G s μ) : ⋃ g : G, g • s =ᵐ[μ] univ :=
-  eventuallyEq_univ.2 <| h.ae_covers.mono fun _ ⟨g, hg⟩ =>
+  eventuallyEqSet_univ.2 <| h.ae_covers.mono fun _ ⟨g, hg⟩ =>
     mem_iUnion.2 ⟨g⁻¹, _, hg, inv_smul_smul _ _⟩
 
 @[to_additive]
@@ -286,11 +286,10 @@ is determined by the measure of its intersection with a fundamental domain for t
   finite additive group `G`, the measure of any `G`-invariant set is determined by the measure of
   its intersection with a fundamental domain for the action of `G`. -/]
 theorem measure_eq_card_smul_of_smul_ae_eq_self [Finite G] (h : IsFundamentalDomain G s μ)
-    (t : Set α) (ht : ∀ g : G, (g • t : Set α) =ᵐ[μ] t) : μ t = Nat.card G • μ (t ∩ s) := by
+    (t : Set α) (ht : ∀ g : G, g • t =ᵐ[μ] t) : μ t = Nat.card G • μ (t ∩ s) := by
   have : Fintype G := Fintype.ofFinite G
   rw [h.measure_eq_tsum]
-  replace ht : ∀ g : G, (g • t ∩ s : Set α) =ᵐ[μ] (t ∩ s : Set α) := fun g =>
-    ae_eq_set_inter (ht g) (ae_eq_refl s)
+  replace ht (g : G) : g • t ∩ s =ᵐ[μ] t ∩ s := .inter (ht _) .rfl
   simp_rw [measure_congr (ht _), tsum_fintype, Finset.sum_const, Nat.card_eq_fintype_card,
     Finset.card_univ]
 

--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -423,7 +423,6 @@ theorem setIntegral_eq_of_subset_of_ae_sdiff_eq_zero_aux (hts : s ⊆ t)
     _ = ∫ x in s \ k, f x ∂μ := by
       apply setIntegral_congr_set
       filter_upwards [h't] with x hx
-      change (x ∈ t \ k) = (x ∈ s \ k)
       simp only [eq_iff_iff, and_congr_left_iff, Set.mem_sdiff]
       intro h'x
       by_cases xs : x ∈ s

--- a/Mathlib/MeasureTheory/Integral/CurveIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/CurveIntegral/Basic.lean
@@ -222,7 +222,7 @@ theorem curveIntegralFun_trans_of_lt_half (ω : E → E →L[𝕜] F) (γab : Pa
   have H₁ : (γab.trans γbc).extend =ᶠ[𝓝 t] (fun s ↦ γab.extend (2 * s)) :=
     (eventually_le_nhds ht).mono fun _ ↦ Path.extend_trans_of_le_half _ _
   have H₂ : (2 : ℝ) • I =ᶠ[𝓝 (2 * t)] I := by
-    rw [LinearOrderedField.smul_Icc two_pos, mul_zero, mul_one, ← nhdsWithin_eq_iff_eventuallyEq]
+    rw [LinearOrderedField.smul_Icc two_pos, mul_zero, mul_one, ← nhdsWithin_eq_iff_eventuallyEqSet]
     rcases lt_trichotomy t 0 with ht₀ | rfl | ht₀
     · rw [notMem_closure_iff_nhdsWithin_eq_bot.mp, notMem_closure_iff_nhdsWithin_eq_bot.mp] <;>
         simp_intro h <;> linarith

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -654,7 +654,7 @@ theorem IntegrableAtFilter.inf_ae_iff {l : Filter α} :
     IntegrableAtFilter f (l ⊓ ae μ) μ ↔ IntegrableAtFilter f l μ := by
   refine ⟨?_, fun h ↦ h.filter_mono inf_le_left⟩
   rintro ⟨s, ⟨t, ht, u, hu, rfl⟩, hf⟩
-  refine ⟨t, ht, hf.congr_set_ae <| eventuallyEq_set.2 ?_⟩
+  refine ⟨t, ht, hf.congr_set_ae <| eventuallyEqSet_iff.2 ?_⟩
   filter_upwards [hu] with x hx using (and_iff_left hx).symm
 
 alias ⟨IntegrableAtFilter.of_inf_ae, _⟩ := IntegrableAtFilter.inf_ae_iff

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -747,8 +747,7 @@ theorem tendsto_limUnder_of_hasDerivAt_of_integrableOn_Ioi [CompleteSpace E]
       apply setIntegral_mono_set
       · apply IntegrableOn.mono_set f'int.norm (Ici_subset_Ioi.2 h'N)
       · filter_upwards with x using norm_nonneg _
-      · have : Ioc (↑N) x ⊆ Ici ↑N := Ioc_subset_Ioi_self.trans Ioi_subset_Ici_self
-        exact this.eventuallyLE
+      · exact (Ioc_subset_Ioi_self.trans Ioi_subset_Ici_self).eventuallySubset
   _ < ε := hN
 
 open UniformSpace in

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -1408,7 +1408,7 @@ theorem integral_mono_interval {c d} (hca : c ≤ a) (hab : a ≤ b) (hbd : b �
     (hf : 0 ≤ᵐ[μ.restrict (Ioc c d)] f) (hfi : IntervalIntegrable f μ c d) :
     (∫ x in a..b, f x ∂μ) ≤ ∫ x in c..d, f x ∂μ := by
   rw [integral_of_le hab, integral_of_le (hca.trans (hab.trans hbd))]
-  exact setIntegral_mono_set hfi.1 hf (Ioc_subset_Ioc hca hbd).eventuallyLE
+  exact setIntegral_mono_set hfi.1 hf (Ioc_subset_Ioc hca hbd).eventuallySubset
 
 theorem abs_integral_mono_interval {c d} (h : Ι a b ⊆ Ι c d) (hf : 0 ≤ᵐ[μ.restrict (Ι c d)] f)
     (hfi : IntervalIntegrable f μ c d) : |∫ x in a..b, f x ∂μ| ≤ |∫ x in c..d, f x ∂μ| :=
@@ -1416,7 +1416,7 @@ theorem abs_integral_mono_interval {c d} (h : Ι a b ⊆ Ι c d) (hf : 0 ≤ᵐ[
   calc
     |∫ x in a..b, f x ∂μ| = |∫ x in Ι a b, f x ∂μ| := abs_integral_eq_abs_integral_uIoc f
     _ = ∫ x in Ι a b, f x ∂μ := abs_of_nonneg (MeasureTheory.integral_nonneg_of_ae hf')
-    _ ≤ ∫ x in Ι c d, f x ∂μ := setIntegral_mono_set hfi.def' hf h.eventuallyLE
+    _ ≤ ∫ x in Ι c d, f x ∂μ := setIntegral_mono_set hfi.def' hf h.eventuallySubset
     _ ≤ |∫ x in Ι c d, f x ∂μ| := le_abs_self _
     _ = |∫ x in c..d, f x ∂μ| := (abs_integral_eq_abs_integral_uIoc f).symm
 

--- a/Mathlib/MeasureTheory/Integral/Layercake.lean
+++ b/Mathlib/MeasureTheory/Integral/Layercake.lean
@@ -420,7 +420,7 @@ theorem lintegral_comp_eq_lintegral_meas_le_mul (μ : Measure α) (f_nn : 0 ≤�
     rw [ht]
     congr 1
     apply measure_congr
-    filter_upwards [f_eq_F] with a ha using by simp [Set.ofPred, ha]
+    filter_upwards [f_eq_F] with a ha using by simp [ha]
   have eq₂ : ∀ᵐ ω ∂μ,
       ENNReal.ofReal (∫ t in 0..f ω, g t) = ENNReal.ofReal (∫ t in 0..F ω, G t) := by
     filter_upwards [f_eq_F] with ω fω_nn

--- a/Mathlib/MeasureTheory/MeasurableSpace/EventuallyMeasurable.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/EventuallyMeasurable.lean
@@ -66,7 +66,7 @@ theorem le_eventuallyMeasurableSpace : m ≤ eventuallyMeasurableSpace m l :=
   fun _ hs => hs.eventuallyMeasurableSet
 
 theorem eventuallyMeasurableSet_of_mem_filter (hs : s ∈ l) : EventuallyMeasurableSet m l s :=
-  ⟨univ, MeasurableSet.univ, eventuallyEq_univ.mpr hs⟩
+  ⟨univ, MeasurableSet.univ, eventuallyEqSet_univ.mpr hs⟩
 
 /-- A set which is `EventuallyEq` to an `EventuallyMeasurableSet`
 is an `EventuallyMeasurableSet`. -/

--- a/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
+++ b/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
@@ -80,7 +80,7 @@ theorem mono_ae (h : AEDisjoint μ s t) (hu : u ≤ᵐ[μ] s) (hv : v ≤ᵐ[μ]
   measure_mono_null_ae (hu.inter hv) h
 
 protected theorem mono (h : AEDisjoint μ s t) (hu : u ⊆ s) (hv : v ⊆ t) : AEDisjoint μ u v :=
-  mono_ae h (LE.le.eventuallyLE hu) (LE.le.eventuallyLE hv)
+  mono_ae h hu.eventuallySubset hv.eventuallySubset
 
 protected theorem congr (h : AEDisjoint μ s t) (hu : u =ᵐ[μ] s) (hv : v =ᵐ[μ] t) :
     AEDisjoint μ u v :=

--- a/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
@@ -366,8 +366,7 @@ theorem MeasureTheory.Measure.restrict_map_of_aemeasurable {f : α → δ} (hf :
       apply congr_arg
       ext1 t ht
       simp only [ht, Measure.restrict_apply]
-      apply measure_congr
-      apply (EventuallyEq.refl _ _).inter (hf.ae_eq_mk.symm.preimage s)
+      exact measure_congr <| .inter .rfl (hf.ae_eq_mk.symm.preimage s)
 
 theorem MeasureTheory.Measure.map_mono_of_aemeasurable {f : α → δ} (h : μ ≤ ν)
     (hf : AEMeasurable f ν) : μ.map f ≤ ν.map f :=

--- a/Mathlib/MeasureTheory/Measure/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Basic.lean
@@ -310,21 +310,21 @@ lemma measure_inter_conull (ht : μ tᶜ = 0) : μ (s ∩ t) = μ s := by
   rw [← sdiff_compl, measure_sdiff_null ht]
 
 @[simp]
-theorem union_ae_eq_left_iff_ae_subset : (s ∪ t : Set α) =ᵐ[μ] s ↔ t ≤ᵐ[μ] s := by
+theorem union_ae_eq_left_iff_ae_subset : s ∪ t =ᵐ[μ] s ↔ t ≤ᵐ[μ] s := by
   rw [ae_le_set]
   refine
     ⟨fun h => by simpa only [union_sdiff_left] using (ae_eq_set.mp h).1, fun h =>
-      eventuallyLE_antisymm_iff.mpr
+      eventuallySubset_antisymm_iff.mpr
         ⟨by rwa [ae_le_set, union_sdiff_left],
-          LE.le.eventuallyLE subset_union_left⟩⟩
+          .of_subset subset_union_left⟩⟩
 
 @[simp]
-theorem union_ae_eq_right_iff_ae_subset : (s ∪ t : Set α) =ᵐ[μ] t ↔ s ≤ᵐ[μ] t := by
+theorem union_ae_eq_right_iff_ae_subset : s ∪ t =ᵐ[μ] t ↔ s ≤ᵐ[μ] t := by
   rw [union_comm, union_ae_eq_left_iff_ae_subset]
 
 theorem ae_eq_of_ae_subset_of_measure_ge (h₁ : s ≤ᵐ[μ] t) (h₂ : μ t ≤ μ s)
     (hsm : NullMeasurableSet s μ) (ht : μ t ≠ ∞) : s =ᵐ[μ] t := by
-  refine eventuallyLE_antisymm_iff.mpr ⟨h₁, ae_le_set.mpr ?_⟩
+  refine eventuallySubset_antisymm_iff.mpr ⟨h₁, ae_le_set.mpr ?_⟩
   replace h₂ : μ t = μ s := h₂.antisymm (measure_mono_ae h₁)
   replace ht : μ s ≠ ∞ := h₂ ▸ ht
   rw [measure_sdiff' t hsm ht, measure_congr (union_ae_eq_left_iff_ae_subset.mpr h₁), h₂, tsub_self]
@@ -344,7 +344,7 @@ theorem measure_iUnion_congr_of_subset {ι : Sort*} [Countable ι] {s : ι → S
       _ ≤ μ (s i) := hi ▸ h_le i
       _ ≤ μ (⋃ i, s i) := measure_mono <| subset_iUnion _ _
   set M := toMeasurable μ
-  have H : ∀ b, (M (t b) ∩ M (⋃ b, s b) : Set α) =ᵐ[μ] M (t b) := by
+  have H : ∀ b, M (t b) ∩ M (⋃ b, s b) =ᵐ[μ] M (t b) := by
     refine fun b => ae_eq_of_subset_of_measure_ge inter_subset_left ?_ ?_ ?_
     · calc
         μ (M (t b)) = μ (t b) := measure_toMeasurable _
@@ -359,7 +359,7 @@ theorem measure_iUnion_congr_of_subset {ι : Sort*} [Countable ι] {s : ι → S
   calc
     μ (⋃ b, t b) ≤ μ (⋃ b, M (t b)) := measure_mono (iUnion_mono fun b => subset_toMeasurable _ _)
     _ = μ (⋃ b, M (t b) ∩ M (⋃ b, s b)) :=
-      measure_congr (Filter.EventuallyEq.countable_iUnion H).symm
+      measure_congr (.symm <| .countable_iUnion H)
     _ ≤ μ (M (⋃ b, s b)) := measure_mono (iUnion_subset fun b => inter_subset_right)
     _ = μ (⋃ b, s b) := measure_toMeasurable _
 
@@ -462,7 +462,7 @@ theorem Measure.measure_inter_eq_of_measure_eq (hs : MeasurableSet s) (h : μ t 
 lemma Measure.measure_inter_eq_of_ae (h : ∀ᵐ a ∂μ, a ∈ t) :
     μ (t ∩ s) = μ s := by
   refine le_antisymm (measure_mono inter_subset_right) ?_
-  apply EventuallyLE.measure_le
+  apply EventuallySubset.measure_le
   filter_upwards [h] with x hx h'x using ⟨hx, h'x⟩
 
 /-- The measurable superset `toMeasurable μ t` of `t` (which has the same measure as `t`)

--- a/Mathlib/MeasureTheory/Measure/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Basic.lean
@@ -260,8 +260,7 @@ theorem measure_sdiff_le_iff_le_add (hs : NullMeasurableSet s μ) (hst : s ⊆ t
 alias measure_diff_le_iff_le_add := measure_sdiff_le_iff_le_add
 
 theorem measure_eq_measure_of_null_sdiff (hst : s ⊆ t) (h_nullsdiff : μ (t \ s) = 0) :
-    μ s = μ t := measure_congr <|
-      EventuallyLE.antisymm (LE.le.eventuallyLE hst) (ae_le_set.mpr h_nullsdiff)
+    μ s = μ t := measure_congr <| hst.eventuallySubset.antisymm (ae_le_set.mpr h_nullsdiff)
 
 @[deprecated (since := "2026-06-03")]
 alias measure_eq_measure_of_null_diff := measure_eq_measure_of_null_sdiff
@@ -332,7 +331,7 @@ theorem ae_eq_of_ae_subset_of_measure_ge (h₁ : s ≤ᵐ[μ] t) (h₂ : μ t �
 /-- If `s ⊆ t`, `μ t ≤ μ s`, `μ t ≠ ∞`, and `s` is measurable, then `s =ᵐ[μ] t`. -/
 theorem ae_eq_of_subset_of_measure_ge (h₁ : s ⊆ t) (h₂ : μ t ≤ μ s) (hsm : NullMeasurableSet s μ)
     (ht : μ t ≠ ∞) : s =ᵐ[μ] t :=
-  ae_eq_of_ae_subset_of_measure_ge h₁.eventuallyLE h₂ hsm ht
+  ae_eq_of_ae_subset_of_measure_ge h₁.eventuallySubset h₂ hsm ht
 
 theorem measure_iUnion_congr_of_subset {ι : Sort*} [Countable ι] {s : ι → Set α} {t : ι → Set α}
     (hsub : ∀ i, s i ⊆ t i) (h_le : ∀ i, μ (t i) ≤ μ (s i)) : μ (⋃ i, s i) = μ (⋃ i, t i) := by
@@ -359,7 +358,7 @@ theorem measure_iUnion_congr_of_subset {ι : Sort*} [Countable ι] {s : ι → S
   calc
     μ (⋃ b, t b) ≤ μ (⋃ b, M (t b)) := measure_mono (iUnion_mono fun b => subset_toMeasurable _ _)
     _ = μ (⋃ b, M (t b) ∩ M (⋃ b, s b)) :=
-      measure_congr (.symm <| .countable_iUnion H)
+      measure_congr <| .symm <| .countable_iUnion H
     _ ≤ μ (M (⋃ b, s b)) := measure_mono (iUnion_subset fun b => inter_subset_right)
     _ = μ (⋃ b, s b) := measure_toMeasurable _
 

--- a/Mathlib/MeasureTheory/Measure/Comap.lean
+++ b/Mathlib/MeasureTheory/Measure/Comap.lean
@@ -112,12 +112,12 @@ set_option backward.isDefEq.respectTransparency false in
 theorem ae_eq_image_of_ae_eq_comap (f : α → β) (μ : Measure β) (hfi : Injective f)
     (hf : ∀ s, MeasurableSet s → NullMeasurableSet (f '' s) μ)
     {s t : Set α} (hst : s =ᵐ[comap f μ] t) : f '' s =ᵐ[μ] f '' t := by
-  rw [EventuallyEq, ae_iff] at hst ⊢
-  have h_eq_α : { a : α | ¬s a = t a } = s \ t ∪ t \ s := by
+  rw [EventuallyEqSet, EventuallyEq, ae_iff] at hst ⊢
+  have h_eq_α : { a : α | ¬(a ∈ s) = (a ∈ t) } = s \ t ∪ t \ s := by
     ext1 x
     simp only [eq_iff_iff, mem_ofPred_eq, mem_union, Set.mem_sdiff]
     tauto
-  have h_eq_β : { a : β | ¬(f '' s) a = (f '' t) a } = f '' s \ f '' t ∪ f '' t \ f '' s := by
+  have h_eq_β : { a : β | ¬(a ∈ f '' s) = (a ∈ f '' t) } = f '' s \ f '' t ∪ f '' t \ f '' s := by
     ext1 x
     simp only [eq_iff_iff, mem_ofPred_eq, mem_union, Set.mem_sdiff]
     tauto

--- a/Mathlib/MeasureTheory/Measure/ContinuousPreimage.lean
+++ b/Mathlib/MeasureTheory/Measure/ContinuousPreimage.lean
@@ -120,7 +120,7 @@ theorem isClosed_setOfPred_preimage_ae_eq {f : Z → C(X, Y)} (hf : Continuous f
   filter_upwards [(tendsto_measure_symmDiff_preimage_nhds_zero (hf.tendsto z)
     (.of_forall hfm) (hfm z) htm ht).eventually hz] with w hw
   intro (hw' : f w ⁻¹' t =ᵐ[μ] s)
-  rw [measure_congr (hw'.symmDiff (ae_eq_refl _)), symmDiff_comm] at hw
+  rw [measure_congr (hw'.symmDiff .rfl), symmDiff_comm] at hw
   exact hw.false
 
 @[deprecated (since := "2026-07-09")]

--- a/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
@@ -366,7 +366,7 @@ lemma setIntegral_toReal_rnDeriv_le [SigmaFinite μ] {s : Set α} (hμs : μ s �
   have hμt : μ t ≠ ∞ := by rwa [ht, measure_toMeasurable s]
   calc ∫ x in s, (μ.rnDeriv ν x).toReal ∂ν
     ≤ ∫ x in t, (μ.rnDeriv ν x).toReal ∂ν := by
-        refine setIntegral_mono_set ?_ ?_ (LE.le.eventuallyLE (subset_toMeasurable _ _))
+        refine setIntegral_mono_set ?_ ?_ (subset_toMeasurable ..).eventuallySubset
         · exact integrableOn_toReal_rnDeriv hμt
         · exact ae_of_all _ (by simp)
   _ = (withDensity ν (rnDeriv μ ν)).real t := setIntegral_toReal_rnDeriv_eq_withDensity' ht_m

--- a/Mathlib/MeasureTheory/Measure/EverywherePos.lean
+++ b/Mathlib/MeasureTheory/Measure/EverywherePos.lean
@@ -147,8 +147,8 @@ lemma isEverywherePos_everywherePosSubset
   have A : 0 < μ (u ∩ s) := by
     have : u ∩ s ∈ 𝓝[s] x := by rw [inter_comm]; exact inter_mem_nhdsWithin s u_mem
     exact hx.2 _ this
-  have B : (u ∩ μ.everywherePosSubset s : Set α) =ᵐ[μ] (u ∩ s : Set α) :=
-    ae_eq_set_inter (ae_eq_refl _) (everywherePosSubset_ae_eq hs)
+  have B : u ∩ μ.everywherePosSubset s =ᵐ[μ] u ∩ s :=
+    .inter .rfl (everywherePosSubset_ae_eq hs)
   rw [← B.measure_eq] at A
   exact A.trans_le (measure_mono hu)
 
@@ -165,8 +165,8 @@ lemma isEverywherePos_everywherePosSubset_of_measure_ne_top
   have A : 0 < μ (u ∩ s) := by
     have : u ∩ s ∈ 𝓝[s] x := by rw [inter_comm]; exact inter_mem_nhdsWithin s u_mem
     exact hx.2 _ this
-  have B : (u ∩ μ.everywherePosSubset s : Set α) =ᵐ[μ] (u ∩ s : Set α) :=
-    ae_eq_set_inter (ae_eq_refl _) (everywherePosSubset_ae_eq_of_measure_ne_top hs h's)
+  have B : u ∩ μ.everywherePosSubset s =ᵐ[μ] u ∩ s :=
+    .inter .rfl (everywherePosSubset_ae_eq_of_measure_ne_top hs h's)
   rw [← B.measure_eq] at A
   exact A.trans_le (measure_mono hu)
 

--- a/Mathlib/MeasureTheory/Measure/Interval.lean
+++ b/Mathlib/MeasureTheory/Measure/Interval.lean
@@ -76,19 +76,19 @@ theorem Ioi_ae_eq_Ici' (ha : μ {a} = 0) : Ioi a =ᵐ[μ] Ici a :=
   Iio_ae_eq_Iic' (α := αᵒᵈ) ha
 
 theorem Ioo_ae_eq_Ioc' (hb : μ {b} = 0) : Ioo a b =ᵐ[μ] Ioc a b :=
-  (ae_eq_refl _).inter (Iio_ae_eq_Iic' hb)
+  .inter .rfl (Iio_ae_eq_Iic' hb)
 
 theorem Ioc_ae_eq_Icc' (ha : μ {a} = 0) : Ioc a b =ᵐ[μ] Icc a b :=
-  (Ioi_ae_eq_Ici' ha).inter (ae_eq_refl _)
+  (Ioi_ae_eq_Ici' ha).inter .rfl
 
 theorem Ioo_ae_eq_Ico' (ha : μ {a} = 0) : Ioo a b =ᵐ[μ] Ico a b :=
-  (Ioi_ae_eq_Ici' ha).inter (ae_eq_refl _)
+  (Ioi_ae_eq_Ici' ha).inter .rfl
 
 theorem Ioo_ae_eq_Icc' (ha : μ {a} = 0) (hb : μ {b} = 0) : Ioo a b =ᵐ[μ] Icc a b :=
   (Ioi_ae_eq_Ici' ha).inter (Iio_ae_eq_Iic' hb)
 
 theorem Ico_ae_eq_Icc' (hb : μ {b} = 0) : Ico a b =ᵐ[μ] Icc a b :=
-  (ae_eq_refl _).inter (Iio_ae_eq_Iic' hb)
+  .inter .rfl (Iio_ae_eq_Iic' hb)
 
 theorem Ico_ae_eq_Ioc' (ha : μ {a} = 0) (hb : μ {b} = 0) : Ico a b =ᵐ[μ] Ioc a b :=
   (Ioo_ae_eq_Ico' ha).symm.trans (Ioo_ae_eq_Ioc' hb)

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
@@ -537,10 +537,11 @@ theorem volume_regionBetween_eq_lintegral [SFinite μ] (hf : AEMeasurable f (μ.
       (μ.restrict s).prod volume
         (regionBetween (AEMeasurable.mk f hf) (AEMeasurable.mk g hg) s) := by
     apply measure_congr
-    apply EventuallyEq.rfl.inter
-    exact
-      ((quasiMeasurePreserving_fst.ae_eq_comp hf.ae_eq_mk).comp₂ _ EventuallyEq.rfl).inter
-        (EventuallyEq.rfl.comp₂ _ <| quasiMeasurePreserving_fst.ae_eq_comp hg.ae_eq_mk)
+    apply Filter.Eventually.set_eq
+    filter_upwards [quasiMeasurePreserving_fst.ae_eq_comp hf.ae_eq_mk,
+      quasiMeasurePreserving_fst.ae_eq_comp hg.ae_eq_mk] with p hp hq
+    simp only [Function.comp_apply] at hp hq
+    simp only [regionBetween, mem_ofPred_eq, hp, hq]
   rw [lintegral_congr_ae h₁, ←
     volume_regionBetween_eq_lintegral' hf.measurable_mk hg.measurable_mk hs]
   convert! h₂ using 1

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -334,7 +334,7 @@ theorem subset_toMeasurable (μ : Measure α) (s : Set α) : s ⊆ toMeasurable 
   exacts [hs.choose_spec.1, h's.choose_spec.1, (exists_measurable_superset μ s).choose_spec.1]
 
 theorem ae_le_toMeasurable : s ≤ᵐ[μ] toMeasurable μ s :=
-  LE.le.eventuallyLE (subset_toMeasurable _ _)
+  (subset_toMeasurable ..).eventuallySubset
 
 @[simp]
 theorem measurableSet_toMeasurable (μ : Measure α) (s : Set α) :

--- a/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
@@ -201,7 +201,7 @@ theorem exists_measurable_superset_ae_eq (h : NullMeasurableSet s μ) :
   rcases h with ⟨t, htm, hst⟩
   refine ⟨t ∪ toMeasurable μ (s \ t), ?_, htm.union (measurableSet_toMeasurable _ _), ?_⟩
   · exact sdiff_subset_iff.1 (subset_toMeasurable _ _)
-  · have : toMeasurable μ (s \ t) =ᵐ[μ] (∅ : Set α) := by simp [ae_le_set.1 hst.le]
+  · have : toMeasurable μ (s \ t) =ᵐ[μ] ∅ := by simp [ae_le_set.1 hst.le]
     simpa only [union_empty] using hst.symm.union this
 
 theorem toMeasurable_ae_eq (h : NullMeasurableSet s μ) : toMeasurable μ s =ᵐ[μ] s := by

--- a/Mathlib/MeasureTheory/Measure/Portmanteau.lean
+++ b/Mathlib/MeasureTheory/Measure/Portmanteau.lean
@@ -214,16 +214,16 @@ theorem tendsto_measure_of_le_liminf_measure_of_limsup_measure_le {ι : Type*} {
     (h_E₁ : (L.limsup fun i ↦ μs i E₁) ≤ μ E₁) : L.Tendsto (fun i ↦ μs i E) (𝓝 (μ E)) := by
   apply tendsto_of_le_liminf_of_limsup_le
   · have E₀_ae_eq_E : E₀ =ᵐ[μ] E :=
-      EventuallyLE.antisymm E₀_subset.eventuallyLE
-        (subset_E₁.eventuallyLE.trans (ae_le_set.mpr nulldiff))
+      E₀_subset.eventuallySubset.antisymm <|
+        subset_E₁.eventuallySubset.trans (ae_le_set.mpr nulldiff)
     calc
       μ E = μ E₀ := measure_congr E₀_ae_eq_E.symm
       _ ≤ L.liminf fun i ↦ μs i E₀ := h_E₀
       _ ≤ L.liminf fun i ↦ μs i E :=
         liminf_le_liminf (.of_forall fun _ ↦ measure_mono E₀_subset)
   · have E_ae_eq_E₁ : E =ᵐ[μ] E₁ :=
-      EventuallyLE.antisymm subset_E₁.eventuallyLE
-        ((ae_le_set.mpr nulldiff).trans E₀_subset.eventuallyLE)
+      EventuallyLE.antisymm subset_E₁.eventuallySubset <|
+        (ae_le_set.mpr nulldiff).trans E₀_subset.eventuallySubset
     calc
       (L.limsup fun i ↦ μs i E) ≤ L.limsup fun i ↦ μs i E₁ :=
         limsup_le_limsup (.of_forall fun _ ↦ measure_mono subset_E₁)

--- a/Mathlib/MeasureTheory/Measure/Regular.lean
+++ b/Mathlib/MeasureTheory/Measure/Regular.lean
@@ -967,7 +967,7 @@ protected theorem _root_.MeasureTheory.NullMeasurableSet.exists_isOpen_symmDiff_
   rcases hs with ⟨t, htm, hst⟩
   rcases htm.exists_isOpen_symmDiff_lt (by rwa [← measure_congr hst]) hε with ⟨U, hUo, hμU, hUs⟩
   refine ⟨U, hUo, hμU, ?_⟩
-  rwa [measure_congr <| (ae_eq_refl _).symmDiff hst]
+  rwa [measure_congr <| .symmDiff .rfl hst]
 
 instance smul [h : InnerRegularCompactLTTop μ] (c : ℝ≥0∞) : InnerRegularCompactLTTop (c • μ) := by
   by_cases hc : c = 0

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -136,7 +136,7 @@ theorem _root_.IsCountablySpanning.null_of_forall_restrict_null {C : Set (Set α
 theorem restrict_apply₀' (hs : NullMeasurableSet s μ) : μ.restrict s t = μ (t ∩ s) := by
   rw [← restrict_congr_set hs.toMeasurable_ae_eq,
     restrict_apply' (measurableSet_toMeasurable _ _),
-    measure_congr ((ae_eq_refl t).inter hs.toMeasurable_ae_eq)]
+    measure_congr (.inter .rfl hs.toMeasurable_ae_eq)]
 
 theorem restrict_le_self : μ.restrict s ≤ μ :=
   Measure.le_iff.2 fun t ht => calc
@@ -342,7 +342,7 @@ theorem restrict_toMeasurable (h : μ s ≠ ∞) : μ.restrict (toMeasurable μ 
 theorem restrict_eq_self_of_ae_mem {_m0 : MeasurableSpace α} ⦃s : Set α⦄ ⦃μ : Measure α⦄
     (hs : ∀ᵐ x ∂μ, x ∈ s) : μ.restrict s = μ :=
   calc
-    μ.restrict s = μ.restrict univ := restrict_congr_set (eventuallyEq_univ.mpr hs)
+    μ.restrict s = μ.restrict univ := restrict_congr_set (eventuallyEqSet_univ.mpr hs)
     _ = μ := restrict_univ
 
 theorem restrict_congr_meas (hs : MeasurableSet s) :
@@ -722,7 +722,7 @@ theorem self_mem_ae_restrict {s} (hs : MeasurableSet s) : s ∈ ae (μ.restrict 
 
 /-- If two measurable sets are `ae_eq` then any proposition that is almost everywhere true on one
 is almost everywhere true on the other -/
-theorem ae_restrict_of_ae_eq_of_ae_restrict {s t} (hst : s =ᵐ[μ] t) {p : α → Prop} :
+theorem ae_restrict_of_ae_eq_of_ae_restrict {s t : Set α} (hst : s =ᵐ[μ] t) {p : α → Prop} :
     (∀ᵐ x ∂μ.restrict s, p x) → ∀ᵐ x ∂μ.restrict t, p x := by simp [Measure.restrict_congr_set hst]
 
 /-- If two measurable sets are `ae_eq` then any proposition that is almost everywhere true on one
@@ -752,15 +752,14 @@ lemma nullMeasurableSet_restrict (hs : NullMeasurableSet s μ) {t : Set α} :
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · obtain ⟨t', -, ht', t't⟩ : ∃ t' ⊇ t, MeasurableSet t' ∧ t' =ᵐ[μ.restrict s] t :=
       h.exists_measurable_superset_ae_eq
-    have A : (t' ∩ s : Set α) =ᵐ[μ] (t ∩ s : Set α) := by
+    have A : t' ∩ s =ᵐ[μ] t ∩ s := by
       have : ∀ᵐ x ∂μ, x ∈ s → (x ∈ t') = (x ∈ t) :=
         (ae_restrict_iff'₀ hs).1 t't
       filter_upwards [this] with y hy
-      change (y ∈ t' ∩ s) = (y ∈ t ∩ s)
       simpa only [eq_iff_iff, mem_inter_iff, and_congr_left_iff] using hy
     obtain ⟨s', -, hs', s's⟩ : ∃ s' ⊇ s, MeasurableSet s' ∧ s' =ᵐ[μ] s :=
       hs.exists_measurable_superset_ae_eq
-    have B : (t' ∩ s' : Set α) =ᵐ[μ] (t' ∩ s : Set α) :=
+    have B : t' ∩ s' =ᵐ[μ] t' ∩ s :=
       ae_eq_set_inter (EventuallyEq.refl _ _) s's
     exact (ht'.inter hs').nullMeasurableSet.congr (B.trans A)
   · have A : NullMeasurableSet (t \ s) (μ.restrict s) := by
@@ -781,7 +780,6 @@ lemma nullMeasurableSet_restrict_of_subset {t : Set α} (ht : t ⊆ s) :
     filter_upwards [t't] with x hx using by simpa using! hx
   have : t' =ᵐ[μ] t := by
     filter_upwards [this] with x hx
-    change (x ∈ t') = (x ∈ t)
     simp only [eq_iff_iff]
     tauto
   exact ht'.nullMeasurableSet.congr this

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -181,7 +181,7 @@ theorem ae_eq_univ_iff_measure_eq [IsFiniteMeasure μ] (hs : NullMeasurableSet s
 
 theorem ae_iff_measure_eq [IsFiniteMeasure μ] {p : α → Prop}
     (hp : NullMeasurableSet { a | p a } μ) : (∀ᵐ a ∂μ, p a) ↔ μ { a | p a } = μ univ := by
-  rw [← ae_eq_univ_iff_measure_eq hp, eventuallyEq_univ, eventually_iff]
+  rw [← ae_eq_univ_iff_measure_eq hp, eventuallyEqSet_univ, eventually_iff]
 
 theorem ae_mem_iff_measure_eq [IsFiniteMeasure μ] {s : Set α} (hs : NullMeasurableSet s μ) :
     (∀ᵐ a ∂μ, a ∈ s) ↔ μ s = μ univ :=

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean
@@ -342,7 +342,7 @@ private lemma exists_ae_subset_biUnion_countable_of_isFiniteMeasure [IsFiniteMea
     exact measure_mono (fun x hx ↦ by simp at hx ⊢; grind)
   refine ⟨D, by grind, by grind, fun s hs ↦ union_ae_eq_right_iff_ae_subset.mp ?_⟩
   symm
-  apply ae_eq_of_ae_subset_of_measure_ge subset_union_right.eventuallyLE
+  apply ae_eq_of_ae_subset_of_measure_ge subset_union_right.eventuallySubset
   · rw [hD, show s ∪ ⋃₀ D = ⋃₀ (D ∪ {s}) by simp]
     apply le_biSup (f := fun D ↦ μ (⋃₀ D))
     simp [D_mem.2, insert_subset_iff, hs, D_mem.1]
@@ -364,7 +364,7 @@ lemma exists_ae_subset_biUnion_countable [SFinite μ]
   refine ⟨⋃ n, D n, by simp [DC], by simp [D_count], fun s hs ↦ ?_⟩
   rw [← sum_sfiniteSeq μ]
   apply ae_sum_iff.2 (fun n ↦ (hD n s hs).trans ?_)
-  exact LE.le.eventuallyLE (fun x hx ↦ by simp at hx ⊢; grind)
+  exact LE.le.eventuallySubset (fun x hx ↦ by simp at hx ⊢; grind)
 
 set_option backward.defeqAttrib.useBackward false in
 /-- If a measure `μ` is the sum of a countable family `mₙ`, and a set `t` has finite measure for

--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -81,47 +81,51 @@ open Lean Lean.PrettyPrinter.Delaborator
 
 /-- Delaborator printing `Filter.EventuallyEq (MeasureTheory.ae μ) f g` as `f =ᵐ[μ] g`. -/
 @[app_delab Filter.EventuallyEq]
-meta def delabAEEventuallyEq : Delab := whenPPOption Lean.getPPNotation do
-  let e ← SubExpr.getExpr
-  guard <| e.isAppOfArity ``Filter.EventuallyEq 5
-  guard <| (e.getArg! 2).isAppOfArity ``MeasureTheory.ae 5
-  let μ ← SubExpr.withNaryArg 2 <| SubExpr.withNaryArg 4 delab
-  let f ← SubExpr.withNaryArg 3 delab
-  let g ← SubExpr.withNaryArg 4 delab
-  `($f =ᵐ[$μ] $g)
+meta def delabAEEventuallyEq : Delab :=
+  whenNotPPOption getPPExplicit <| whenPPOption Lean.getPPNotation do
+    let e ← SubExpr.getExpr
+    guard <| e.isAppOfArity ``Filter.EventuallyEq 5
+    guard <| (e.getArg! 2).isAppOfArity ``MeasureTheory.ae 5
+    let μ ← SubExpr.withNaryArg 2 <| SubExpr.withNaryArg 4 delab
+    let f ← SubExpr.withNaryArg 3 delab
+    let g ← SubExpr.withNaryArg 4 delab
+    `($f =ᵐ[$μ] $g)
 
 /-- Delaborator printing `Filter.EventuallyEqSet (MeasureTheory.ae μ) s t` as `s =ᵐ[μ] t`. -/
 @[app_delab Filter.EventuallyEqSet]
-meta def delabAEEventuallyEqSet : Delab := whenPPOption Lean.getPPNotation do
-  let e ← SubExpr.getExpr
-  guard <| e.isAppOfArity ``Filter.EventuallyEqSet 4
-  guard <| (e.getArg! 1).isAppOfArity ``MeasureTheory.ae 5
-  let μ ← SubExpr.withNaryArg 1 <| SubExpr.withNaryArg 4 delab
-  let s ← SubExpr.withNaryArg 2 delab
-  let t ← SubExpr.withNaryArg 3 delab
-  `($s =ᵐ[$μ] $t)
+meta def delabAEEventuallyEqSet : Delab :=
+  whenNotPPOption getPPExplicit <| whenPPOption Lean.getPPNotation do
+    let e ← SubExpr.getExpr
+    guard <| e.isAppOfArity ``Filter.EventuallyEqSet 4
+    guard <| (e.getArg! 1).isAppOfArity ``MeasureTheory.ae 5
+    let μ ← SubExpr.withNaryArg 1 <| SubExpr.withNaryArg 4 delab
+    let s ← SubExpr.withNaryArg 2 delab
+    let t ← SubExpr.withNaryArg 3 delab
+    `($s =ᵐ[$μ] $t)
 
 /-- Delaborator printing `Filter.EventuallyLE (MeasureTheory.ae μ) f g` as `f ≤ᵐ[μ] g`. -/
 @[app_delab Filter.EventuallyLE]
-meta def delabAEEventuallyLE : Delab := whenPPOption Lean.getPPNotation do
-  let e ← SubExpr.getExpr
-  guard <| e.isAppOfArity ``Filter.EventuallyLE 6
-  guard <| (e.getArg! 3).isAppOfArity ``MeasureTheory.ae 5
-  let μ ← SubExpr.withNaryArg 3 <| SubExpr.withNaryArg 4 delab
-  let f ← SubExpr.withNaryArg 4 delab
-  let g ← SubExpr.withNaryArg 5 delab
-  `($f ≤ᵐ[$μ] $g)
+meta def delabAEEventuallyLE : Delab :=
+  whenNotPPOption getPPExplicit <| whenPPOption Lean.getPPNotation do
+    let e ← SubExpr.getExpr
+    guard <| e.isAppOfArity ``Filter.EventuallyLE 6
+    guard <| (e.getArg! 3).isAppOfArity ``MeasureTheory.ae 5
+    let μ ← SubExpr.withNaryArg 3 <| SubExpr.withNaryArg 4 delab
+    let f ← SubExpr.withNaryArg 4 delab
+    let g ← SubExpr.withNaryArg 5 delab
+    `($f ≤ᵐ[$μ] $g)
 
 /-- Delaborator printing `Filter.EventuallySubset (MeasureTheory.ae μ) s t` as `s ≤ᵐ[μ] t`. -/
 @[app_delab Filter.EventuallySubset]
-meta def delabAEEventuallySubset : Delab := whenPPOption Lean.getPPNotation do
-  let e ← SubExpr.getExpr
-  guard <| e.isAppOfArity ``Filter.EventuallySubset 4
-  guard <| (e.getArg! 1).isAppOfArity ``MeasureTheory.ae 5
-  let s ← SubExpr.withNaryArg 2 delab
-  let t ← SubExpr.withNaryArg 3 delab
-  let μ ← SubExpr.withNaryArg 1 <| SubExpr.withNaryArg 4 delab
-  `($s ≤ᵐ[$μ] $t)
+meta def delabAEEventuallySubset : Delab :=
+  whenNotPPOption getPPExplicit <| whenPPOption Lean.getPPNotation do
+    let e ← SubExpr.getExpr
+    guard <| e.isAppOfArity ``Filter.EventuallySubset 4
+    guard <| (e.getArg! 1).isAppOfArity ``MeasureTheory.ae 5
+    let μ ← SubExpr.withNaryArg 1 <| SubExpr.withNaryArg 4 delab
+    let s ← SubExpr.withNaryArg 2 delab
+    let t ← SubExpr.withNaryArg 3 delab
+    `($s ≤ᵐ[$μ] $t)
 
 end delaborators
 
@@ -211,12 +215,10 @@ theorem ae_le_set_union {s' t' : Set α} (h : s ≤ᵐ[μ] t) (h' : s' ≤ᵐ[μ
     s ∪ s' ≤ᵐ[μ] t ∪ t' :=
   h.union h'
 
-set_option backward.isDefEq.respectTransparency false in
 theorem union_ae_eq_right : s ∪ t =ᵐ[μ] t ↔ μ (s \ t) = 0 := by
   simp [eventuallySubset_antisymm_iff, ae_le_set, union_sdiff_right,
     sdiff_eq_empty.2 Set.subset_union_right]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem sdiff_ae_eq_self : s \ t =ᵐ[μ] s ↔ μ (s ∩ t) = 0 := by
   simp [eventuallySubset_antisymm_iff, ae_le_set]
 
@@ -227,7 +229,6 @@ theorem sdiff_null_ae_eq_self (ht : μ t = 0) : s \ t =ᵐ[μ] s :=
 
 @[deprecated (since := "2026-06-03")] alias diff_null_ae_eq_self := sdiff_null_ae_eq_self
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ae_eq_set {s t : Set α} : s =ᵐ[μ] t ↔ μ (s \ t) = 0 ∧ μ (t \ s) = 0 := by
   simp [eventuallySubset_antisymm_iff, ae_le_set]
 
@@ -236,12 +237,10 @@ open scoped symmDiff in
 theorem measure_symmDiff_eq_zero_iff {s t : Set α} : μ (s ∆ t) = 0 ↔ s =ᵐ[μ] t := by
   simp [ae_eq_set, symmDiff_def]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem ae_eq_set_compl_compl {s t : Set α} : sᶜ =ᵐ[μ] tᶜ ↔ s =ᵐ[μ] t := by
   simp only [← measure_symmDiff_eq_zero_iff, compl_symmDiff_compl]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ae_eq_set_compl {s t : Set α} : sᶜ =ᵐ[μ] t ↔ s =ᵐ[μ] tᶜ := by
   rw [← ae_eq_set_compl_compl, compl_compl]
 
@@ -264,32 +263,31 @@ theorem ae_eq_set_symmDiff {s' t' : Set α} (h : s =ᵐ[μ] t) (h' : s' =ᵐ[μ]
     s ∆ s' =ᵐ[μ] t ∆ t' :=
   h.symmDiff h'
 
-set_option backward.isDefEq.respectTransparency false in
 theorem union_ae_eq_univ_of_ae_eq_univ_left (h : s =ᵐ[μ] univ) : s ∪ t =ᵐ[μ] univ :=
-  (ae_eq_set_union h EventuallyEq.rfl).trans <| by rw [univ_union]
+  (ae_eq_set_union h .rfl).trans <| by rw [univ_union]
 
 theorem union_ae_eq_univ_of_ae_eq_univ_right (h : t =ᵐ[μ] univ) : s ∪ t =ᵐ[μ] univ :=
-  (ae_eq_set_union EventuallyEq.rfl h).trans <| by rw [union_univ]
+  (ae_eq_set_union .rfl h).trans <| by rw [union_univ]
 
 theorem union_ae_eq_right_of_ae_eq_empty (h : s =ᵐ[μ] ∅) : s ∪ t =ᵐ[μ] t :=
-  (ae_eq_set_union h EventuallyEq.rfl).trans <| by rw [empty_union]
+  (ae_eq_set_union h .rfl).trans <| by rw [empty_union]
 
 theorem union_ae_eq_left_of_ae_eq_empty (h : t =ᵐ[μ] ∅) : s ∪ t =ᵐ[μ] s :=
-  (ae_eq_set_union EventuallyEq.rfl h).trans <| by rw [union_empty]
+  (ae_eq_set_union .rfl h).trans <| by rw [union_empty]
 
 theorem inter_ae_eq_right_of_ae_eq_univ (h : s =ᵐ[μ] univ) : s ∩ t =ᵐ[μ] t :=
-  (ae_eq_set_inter h EventuallyEq.rfl).trans <| by rw [univ_inter]
+  (ae_eq_set_inter h .rfl).trans <| by rw [univ_inter]
 
 theorem inter_ae_eq_left_of_ae_eq_univ (h : t =ᵐ[μ] univ) : s ∩ t =ᵐ[μ] s :=
-  (ae_eq_set_inter EventuallyEq.rfl h).trans <| by rw [inter_univ]
+  (ae_eq_set_inter .rfl h).trans <| by rw [inter_univ]
 
 theorem inter_ae_eq_empty_of_ae_eq_empty_left (h : s =ᵐ[μ] ∅) :
     s ∩ t =ᵐ[μ] ∅ :=
-  (ae_eq_set_inter h EventuallyEq.rfl).trans <| by rw [empty_inter]
+  (ae_eq_set_inter h .rfl).trans <| by rw [empty_inter]
 
 theorem inter_ae_eq_empty_of_ae_eq_empty_right (h : t =ᵐ[μ] ∅) :
     s ∩ t =ᵐ[μ] ∅ :=
-  (ae_eq_set_inter EventuallyEq.rfl h).trans <| by rw [inter_empty]
+  (ae_eq_set_inter .rfl h).trans <| by rw [inter_empty]
 
 theorem ae_eq_set_biInter {s : Set β} (hs : s.Countable) {t t' : β → Set α}
     (h : ∀ b ∈ s, t b =ᵐ[μ] t' b) :

--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -82,7 +82,7 @@ open Lean Lean.PrettyPrinter.Delaborator
 /-- Delaborator printing `Filter.EventuallyEq (MeasureTheory.ae μ) f g` as `f =ᵐ[μ] g`. -/
 @[app_delab Filter.EventuallyEq]
 meta def delabAEEventuallyEq : Delab :=
-  whenNotPPOption getPPExplicit <| whenPPOption Lean.getPPNotation do
+  whenNotPPOption getPPExplicit <| whenPPOption getPPNotation do
     let e ← SubExpr.getExpr
     guard <| e.isAppOfArity ``Filter.EventuallyEq 5
     guard <| (e.getArg! 2).isAppOfArity ``MeasureTheory.ae 5
@@ -94,7 +94,7 @@ meta def delabAEEventuallyEq : Delab :=
 /-- Delaborator printing `Filter.EventuallyEqSet (MeasureTheory.ae μ) s t` as `s =ᵐ[μ] t`. -/
 @[app_delab Filter.EventuallyEqSet]
 meta def delabAEEventuallyEqSet : Delab :=
-  whenNotPPOption getPPExplicit <| whenPPOption Lean.getPPNotation do
+  whenNotPPOption getPPExplicit <| whenPPOption getPPNotation do
     let e ← SubExpr.getExpr
     guard <| e.isAppOfArity ``Filter.EventuallyEqSet 4
     guard <| (e.getArg! 1).isAppOfArity ``MeasureTheory.ae 5
@@ -106,7 +106,7 @@ meta def delabAEEventuallyEqSet : Delab :=
 /-- Delaborator printing `Filter.EventuallyLE (MeasureTheory.ae μ) f g` as `f ≤ᵐ[μ] g`. -/
 @[app_delab Filter.EventuallyLE]
 meta def delabAEEventuallyLE : Delab :=
-  whenNotPPOption getPPExplicit <| whenPPOption Lean.getPPNotation do
+  whenNotPPOption getPPExplicit <| whenPPOption getPPNotation do
     let e ← SubExpr.getExpr
     guard <| e.isAppOfArity ``Filter.EventuallyLE 6
     guard <| (e.getArg! 3).isAppOfArity ``MeasureTheory.ae 5
@@ -118,7 +118,7 @@ meta def delabAEEventuallyLE : Delab :=
 /-- Delaborator printing `Filter.EventuallySubset (MeasureTheory.ae μ) s t` as `s ≤ᵐ[μ] t`. -/
 @[app_delab Filter.EventuallySubset]
 meta def delabAEEventuallySubset : Delab :=
-  whenNotPPOption getPPExplicit <| whenPPOption Lean.getPPNotation do
+  whenNotPPOption getPPExplicit <| whenPPOption getPPNotation do
     let e ← SubExpr.getExpr
     guard <| e.isAppOfArity ``Filter.EventuallySubset 4
     guard <| (e.getArg! 1).isAppOfArity ``MeasureTheory.ae 5

--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -62,17 +62,68 @@ i.e. `p` holds on a set of positive measure.
 This is notation for `Filter.Frequently p (MeasureTheory.ae μ)`. -/
 notation3 "∃ᵐ "(...)" ∂"μ", "r:(scoped P => Filter.Frequently P <| MeasureTheory.ae μ) => r
 
-/-- `f =ᵐ[μ] g` means `f` and `g` are eventually equal along the a.e. filter,
-i.e. `f=g` away from a null set.
+/-- `x =ᵐ[μ] y` means that `x` and `y` are eventually equal along the a.e. filter,
+i.e. `x = y` away from a null set.
 
-This is notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
-notation3:50 f " =ᵐ[" μ:50 "] " g:50 => Filter.EventuallyEq (MeasureTheory.ae μ) f g
+This is `Filter.EventuallyEq (MeasureTheory.ae μ) x y` if `x` is a function and
+`Filter.EventuallyEqSet (MeasureTheory.ae μ) x y` if `x` is a set. -/
+notation:50 f " =ᵐ[" μ:50 "] " g:50 => f =ᶠ[MeasureTheory.ae μ] g
 
-/-- `f ≤ᵐ[μ] g` means `f` is eventually less than `g` along the a.e. filter,
-i.e. `f ≤ g` away from a null set.
+/-- `x ≤ᵐ[μ] y` means that `x` is eventually less than or equal to `y` along the a.e. filter,
+i.e. `x ≤ y` away from a null set.
 
-This is notation for `Filter.EventuallyLE (MeasureTheory.ae μ) f g`. -/
-notation3:50 f " ≤ᵐ[" μ:50 "] " g:50 => Filter.EventuallyLE (MeasureTheory.ae μ) f g
+This is `Filter.EventuallyLE (MeasureTheory.ae μ) x y` if `x` is a function and
+`Filter.EventuallySubset (MeasureTheory.ae μ) x y` if `x` is a set. -/
+notation:50 f " ≤ᵐ[" μ:50 "] " g:50 => f ≤ᶠ[MeasureTheory.ae μ] g
+
+section delaborators
+open Lean Lean.PrettyPrinter.Delaborator
+
+/-- Delaborator printing `Filter.EventuallyEq (MeasureTheory.ae μ) f g` as `f =ᵐ[μ] g`. -/
+@[app_delab Filter.EventuallyEq]
+meta def delabAEEventuallyEq : Delab := whenPPOption Lean.getPPNotation do
+  let e ← SubExpr.getExpr
+  guard <| e.isAppOfArity ``Filter.EventuallyEq 5
+  guard <| (e.getArg! 2).isAppOfArity ``MeasureTheory.ae 5
+  let μ ← SubExpr.withNaryArg 2 <| SubExpr.withNaryArg 4 delab
+  let f ← SubExpr.withNaryArg 3 delab
+  let g ← SubExpr.withNaryArg 4 delab
+  `($f =ᵐ[$μ] $g)
+
+/-- Delaborator printing `Filter.EventuallyEqSet (MeasureTheory.ae μ) s t` as `s =ᵐ[μ] t`. -/
+@[app_delab Filter.EventuallyEqSet]
+meta def delabAEEventuallyEqSet : Delab := whenPPOption Lean.getPPNotation do
+  let e ← SubExpr.getExpr
+  guard <| e.isAppOfArity ``Filter.EventuallyEqSet 4
+  guard <| (e.getArg! 1).isAppOfArity ``MeasureTheory.ae 5
+  let μ ← SubExpr.withNaryArg 1 <| SubExpr.withNaryArg 4 delab
+  let s ← SubExpr.withNaryArg 2 delab
+  let t ← SubExpr.withNaryArg 3 delab
+  `($s =ᵐ[$μ] $t)
+
+/-- Delaborator printing `Filter.EventuallyLE (MeasureTheory.ae μ) f g` as `f ≤ᵐ[μ] g`. -/
+@[app_delab Filter.EventuallyLE]
+meta def delabAEEventuallyLE : Delab := whenPPOption Lean.getPPNotation do
+  let e ← SubExpr.getExpr
+  guard <| e.isAppOfArity ``Filter.EventuallyLE 6
+  guard <| (e.getArg! 3).isAppOfArity ``MeasureTheory.ae 5
+  let μ ← SubExpr.withNaryArg 3 <| SubExpr.withNaryArg 4 delab
+  let f ← SubExpr.withNaryArg 4 delab
+  let g ← SubExpr.withNaryArg 5 delab
+  `($f ≤ᵐ[$μ] $g)
+
+/-- Delaborator printing `Filter.EventuallySubset (MeasureTheory.ae μ) s t` as `s ≤ᵐ[μ] t`. -/
+@[app_delab Filter.EventuallySubset]
+meta def delabAEEventuallySubset : Delab := whenPPOption Lean.getPPNotation do
+  let e ← SubExpr.getExpr
+  guard <| e.isAppOfArity ``Filter.EventuallySubset 4
+  guard <| (e.getArg! 1).isAppOfArity ``MeasureTheory.ae 5
+  let s ← SubExpr.withNaryArg 2 delab
+  let t ← SubExpr.withNaryArg 3 delab
+  let μ ← SubExpr.withNaryArg 1 <| SubExpr.withNaryArg 4 delab
+  `($s ≤ᵐ[$μ] $t)
+
+end delaborators
 
 theorem mem_ae_iff {s : Set α} : s ∈ ae μ ↔ μ sᶜ = 0 :=
   Iff.rfl
@@ -139,13 +190,13 @@ theorem ae_le_of_ae_lt {β : Type*} [Preorder β] {f g : α → β} (h : ∀ᵐ 
   h.mono fun _ ↦ le_of_lt
 
 @[simp]
-theorem ae_eq_empty : s =ᵐ[μ] (∅ : Set α) ↔ μ s = 0 :=
-  eventuallyEq_empty.trans <| by simp only [ae_iff, Classical.not_not, ofPred_mem_eq]
+theorem ae_eq_empty : s =ᵐ[μ] ∅ ↔ μ s = 0 :=
+  eventuallyEqSet_empty.trans <| by simp only [ae_iff, Classical.not_not, ofPred_mem_eq]
 
--- The priority should be higher than `eventuallyEq_univ`.
+-- The priority should be higher than `eventuallyEqSet_univ`.
 @[simp high]
-theorem ae_eq_univ : s =ᵐ[μ] (univ : Set α) ↔ μ sᶜ = 0 :=
-  eventuallyEq_univ
+theorem ae_eq_univ : s =ᵐ[μ] univ ↔ μ sᶜ = 0 :=
+  eventuallyEqSet_univ
 
 theorem ae_le_set : s ≤ᵐ[μ] t ↔ μ (s \ t) = 0 :=
   calc
@@ -153,32 +204,32 @@ theorem ae_le_set : s ≤ᵐ[μ] t ↔ μ (s \ t) = 0 :=
     _ ↔ μ (s \ t) = 0 := by simp [ae_iff]; rfl
 
 theorem ae_le_set_inter {s' t' : Set α} (h : s ≤ᵐ[μ] t) (h' : s' ≤ᵐ[μ] t') :
-    (s ∩ s' : Set α) ≤ᵐ[μ] (t ∩ t' : Set α) :=
+    s ∩ s' ≤ᵐ[μ] t ∩ t' :=
   h.inter h'
 
 theorem ae_le_set_union {s' t' : Set α} (h : s ≤ᵐ[μ] t) (h' : s' ≤ᵐ[μ] t') :
-    (s ∪ s' : Set α) ≤ᵐ[μ] (t ∪ t' : Set α) :=
+    s ∪ s' ≤ᵐ[μ] t ∪ t' :=
   h.union h'
 
 set_option backward.isDefEq.respectTransparency false in
-theorem union_ae_eq_right : (s ∪ t : Set α) =ᵐ[μ] t ↔ μ (s \ t) = 0 := by
-  simp [eventuallyLE_antisymm_iff, ae_le_set, union_sdiff_right,
+theorem union_ae_eq_right : s ∪ t =ᵐ[μ] t ↔ μ (s \ t) = 0 := by
+  simp [eventuallySubset_antisymm_iff, ae_le_set, union_sdiff_right,
     sdiff_eq_empty.2 Set.subset_union_right]
 
 set_option backward.isDefEq.respectTransparency false in
-theorem sdiff_ae_eq_self : (s \ t : Set α) =ᵐ[μ] s ↔ μ (s ∩ t) = 0 := by
-  simp [eventuallyLE_antisymm_iff, ae_le_set]
+theorem sdiff_ae_eq_self : s \ t =ᵐ[μ] s ↔ μ (s ∩ t) = 0 := by
+  simp [eventuallySubset_antisymm_iff, ae_le_set]
 
 @[deprecated (since := "2026-06-03")] alias diff_ae_eq_self := sdiff_ae_eq_self
 
-theorem sdiff_null_ae_eq_self (ht : μ t = 0) : (s \ t : Set α) =ᵐ[μ] s :=
+theorem sdiff_null_ae_eq_self (ht : μ t = 0) : s \ t =ᵐ[μ] s :=
   sdiff_ae_eq_self.mpr (measure_mono_null inter_subset_right ht)
 
 @[deprecated (since := "2026-06-03")] alias diff_null_ae_eq_self := sdiff_null_ae_eq_self
 
 set_option backward.isDefEq.respectTransparency false in
 theorem ae_eq_set {s t : Set α} : s =ᵐ[μ] t ↔ μ (s \ t) = 0 ∧ μ (t \ s) = 0 := by
-  simp [eventuallyLE_antisymm_iff, ae_le_set]
+  simp [eventuallySubset_antisymm_iff, ae_le_set]
 
 open scoped symmDiff in
 @[simp]
@@ -195,11 +246,11 @@ theorem ae_eq_set_compl {s t : Set α} : sᶜ =ᵐ[μ] t ↔ s =ᵐ[μ] tᶜ := 
   rw [← ae_eq_set_compl_compl, compl_compl]
 
 theorem ae_eq_set_inter {s' t' : Set α} (h : s =ᵐ[μ] t) (h' : s' =ᵐ[μ] t') :
-    (s ∩ s' : Set α) =ᵐ[μ] (t ∩ t' : Set α) :=
+    s ∩ s' =ᵐ[μ] t ∩ t' :=
   h.inter h'
 
 theorem ae_eq_set_union {s' t' : Set α} (h : s =ᵐ[μ] t) (h' : s' =ᵐ[μ] t') :
-    (s ∪ s' : Set α) =ᵐ[μ] (t ∪ t' : Set α) :=
+    s ∪ s' =ᵐ[μ] t ∪ t' :=
   h.union h'
 
 theorem ae_eq_set_sdiff {s' t' : Set α} (h : s =ᵐ[μ] t) (h' : s' =ᵐ[μ] t') :
@@ -214,47 +265,40 @@ theorem ae_eq_set_symmDiff {s' t' : Set α} (h : s =ᵐ[μ] t) (h' : s' =ᵐ[μ]
   h.symmDiff h'
 
 set_option backward.isDefEq.respectTransparency false in
-theorem union_ae_eq_univ_of_ae_eq_univ_left (h : s =ᵐ[μ] univ) : (s ∪ t : Set α) =ᵐ[μ] univ :=
-  (ae_eq_set_union h (ae_eq_refl t)).trans <| by rw [univ_union]
+theorem union_ae_eq_univ_of_ae_eq_univ_left (h : s =ᵐ[μ] univ) : s ∪ t =ᵐ[μ] univ :=
+  (ae_eq_set_union h EventuallyEq.rfl).trans <| by rw [univ_union]
 
-theorem union_ae_eq_univ_of_ae_eq_univ_right (h : t =ᵐ[μ] univ) : (s ∪ t : Set α) =ᵐ[μ] univ := by
-  convert! ae_eq_set_union (ae_eq_refl s) h
-  rw [union_univ]
+theorem union_ae_eq_univ_of_ae_eq_univ_right (h : t =ᵐ[μ] univ) : s ∪ t =ᵐ[μ] univ :=
+  (ae_eq_set_union EventuallyEq.rfl h).trans <| by rw [union_univ]
 
-theorem union_ae_eq_right_of_ae_eq_empty (h : s =ᵐ[μ] (∅ : Set α)) : (s ∪ t : Set α) =ᵐ[μ] t := by
-  convert! ae_eq_set_union h (ae_eq_refl t)
-  rw [empty_union]
+theorem union_ae_eq_right_of_ae_eq_empty (h : s =ᵐ[μ] ∅) : s ∪ t =ᵐ[μ] t :=
+  (ae_eq_set_union h EventuallyEq.rfl).trans <| by rw [empty_union]
 
-theorem union_ae_eq_left_of_ae_eq_empty (h : t =ᵐ[μ] (∅ : Set α)) : (s ∪ t : Set α) =ᵐ[μ] s := by
-  convert! ae_eq_set_union (ae_eq_refl s) h
-  rw [union_empty]
+theorem union_ae_eq_left_of_ae_eq_empty (h : t =ᵐ[μ] ∅) : s ∪ t =ᵐ[μ] s :=
+  (ae_eq_set_union EventuallyEq.rfl h).trans <| by rw [union_empty]
 
-theorem inter_ae_eq_right_of_ae_eq_univ (h : s =ᵐ[μ] univ) : (s ∩ t : Set α) =ᵐ[μ] t := by
-  convert! ae_eq_set_inter h (ae_eq_refl t)
-  rw [univ_inter]
+theorem inter_ae_eq_right_of_ae_eq_univ (h : s =ᵐ[μ] univ) : s ∩ t =ᵐ[μ] t :=
+  (ae_eq_set_inter h EventuallyEq.rfl).trans <| by rw [univ_inter]
 
-theorem inter_ae_eq_left_of_ae_eq_univ (h : t =ᵐ[μ] univ) : (s ∩ t : Set α) =ᵐ[μ] s := by
-  convert! ae_eq_set_inter (ae_eq_refl s) h
-  rw [inter_univ]
+theorem inter_ae_eq_left_of_ae_eq_univ (h : t =ᵐ[μ] univ) : s ∩ t =ᵐ[μ] s :=
+  (ae_eq_set_inter EventuallyEq.rfl h).trans <| by rw [inter_univ]
 
-theorem inter_ae_eq_empty_of_ae_eq_empty_left (h : s =ᵐ[μ] (∅ : Set α)) :
-    (s ∩ t : Set α) =ᵐ[μ] (∅ : Set α) := by
-  convert! ae_eq_set_inter h (ae_eq_refl t)
-  rw [empty_inter]
+theorem inter_ae_eq_empty_of_ae_eq_empty_left (h : s =ᵐ[μ] ∅) :
+    s ∩ t =ᵐ[μ] ∅ :=
+  (ae_eq_set_inter h EventuallyEq.rfl).trans <| by rw [empty_inter]
 
-theorem inter_ae_eq_empty_of_ae_eq_empty_right (h : t =ᵐ[μ] (∅ : Set α)) :
-    (s ∩ t : Set α) =ᵐ[μ] (∅ : Set α) := by
-  convert! ae_eq_set_inter (ae_eq_refl s) h
-  rw [inter_empty]
+theorem inter_ae_eq_empty_of_ae_eq_empty_right (h : t =ᵐ[μ] ∅) :
+    s ∩ t =ᵐ[μ] ∅ :=
+  (ae_eq_set_inter EventuallyEq.rfl h).trans <| by rw [inter_empty]
 
 theorem ae_eq_set_biInter {s : Set β} (hs : s.Countable) {t t' : β → Set α}
     (h : ∀ b ∈ s, t b =ᵐ[μ] t' b) :
-    (⋂ b ∈ s, t b : Set α) =ᵐ[μ] (⋂ b ∈ s, t' b : Set α) :=
+    ⋂ b ∈ s, t b =ᵐ[μ] ⋂ b ∈ s, t' b :=
   .countable_bInter hs h
 
 theorem ae_eq_set_biUnion {s : Set β} (hs : s.Countable) {t t' : β → Set α}
     (h : ∀ b ∈ s, t b =ᵐ[μ] t' b) :
-    (⋃ b ∈ s, t b : Set α) =ᵐ[μ] (⋃ b ∈ s, t' b : Set α) :=
+    ⋃ b ∈ s, t b =ᵐ[μ] ⋃ b ∈ s, t' b :=
   .countable_bUnion hs h
 
 set_option backward.isDefEq.respectTransparency false in
@@ -272,13 +316,19 @@ theorem measure_mono_ae (H : s ≤ᵐ[μ] t) : μ s ≤ μ t :=
     _ ≤ μ t + μ (s \ t) := measure_union_le _ _
     _ = μ t := by rw [ae_le_set.1 H, add_zero]
 
-alias _root_.Filter.EventuallyLE.measure_le := measure_mono_ae
+alias _root_.Filter.EventuallySubset.measure_le := measure_mono_ae
+
+@[deprecated (since := "2026-08-14")]
+alias _root_.Filter.EventuallyLE.measure_le := Filter.EventuallySubset.measure_le
 
 /-- If two sets are equal modulo a set of measure zero, then `μ s = μ t`. -/
 theorem measure_congr (H : s =ᵐ[μ] t) : μ s = μ t :=
-  le_antisymm H.le.measure_le H.symm.le.measure_le
+  le_antisymm H.subset.measure_le H.symm.subset.measure_le
 
-alias _root_.Filter.EventuallyEq.measure_eq := measure_congr
+alias _root_.Filter.EventuallyEqSet.measure_eq := measure_congr
+
+@[deprecated (since := "2026-08-14")]
+alias _root_.Filter.EventuallyEq.measure_eq := Filter.EventuallyEqSet.measure_eq
 
 theorem measure_mono_null_ae (H : s ≤ᵐ[μ] t) (ht : μ t = 0) : μ s = 0 :=
   nonpos_iff_eq_zero.1 <| ht ▸ H.measure_le

--- a/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
@@ -106,15 +106,15 @@ theorem measure_liminf_atTop_eq_zero {s : ℕ → Set α} (h : (∑' i, μ (s i)
 -- Need to specify `α := Set α` below because of diamond; see https://github.com/leanprover-community/mathlib4/pull/19041
 theorem limsup_ae_eq_of_forall_ae_eq (s : ℕ → Set α) {t : Set α}
     (h : ∀ n, s n =ᵐ[μ] t) : limsup (α := Set α) s atTop =ᵐ[μ] t := by
-  simp only [eventuallyEq_set, ← eventually_countable_forall] at h
-  refine eventuallyEq_set.2 <| h.mono fun x hx ↦ ?_
+  simp only [eventuallyEqSet_iff, ← eventually_countable_forall] at h
+  refine eventuallyEqSet_iff.2 <| h.mono fun x hx ↦ ?_
   simp [mem_limsup_iff_frequently_mem, hx]
 
 -- Need to specify `α := Set α` above because of diamond; see https://github.com/leanprover-community/mathlib4/pull/19041
 theorem liminf_ae_eq_of_forall_ae_eq (s : ℕ → Set α) {t : Set α}
     (h : ∀ n, s n =ᵐ[μ] t) : liminf (α := Set α) s atTop =ᵐ[μ] t := by
-  simp only [eventuallyEq_set, ← eventually_countable_forall] at h
-  refine eventuallyEq_set.2 <| h.mono fun x hx ↦ ?_
+  simp only [eventuallyEqSet_iff, ← eventually_countable_forall] at h
+  refine eventuallyEqSet_iff.2 <| h.mono fun x hx ↦ ?_
   simp only [mem_liminf_iff_eventually_mem, hx, eventually_const]
 
 end MeasureTheory

--- a/Mathlib/NumberTheory/AbelSummation.lean
+++ b/Mathlib/NumberTheory/AbelSummation.lean
@@ -359,7 +359,7 @@ private theorem summable_mul_of_bigO_atTop_aux (m : ℕ)
         simp
       · unfold C₂
         grw [setIntegral_mono_set ?_ (.of_forall fun _ ↦ norm_nonneg _)
-          Set.Ioc_subset_Ioi_self.eventuallyLE]
+          Set.Ioc_subset_Ioi_self.eventuallySubset]
         rw [← integrableOn_Ici_iff_integrableOn_Ioi, IntegrableOn,
           integrable_norm_iff (by fun_prop)]
         exact (locallyIntegrableOn_mul_sum_Icc _ m.cast_nonneg hf_int).integrableOn_of_isBigO_atTop

--- a/Mathlib/NumberTheory/LSeries/SumCoeff.lean
+++ b/Mathlib/NumberTheory/LSeries/SumCoeff.lean
@@ -245,7 +245,7 @@ private theorem LSeries_tendsto_sub_mul_nhds_one_of_tendsto_sum_div_aux₂ {s T 
     _ ≤ ε * ((s - 1) * ∫ (t : ℝ) in Set.Ioi 1, t ^ (-s)) := by
       rw [integral_const_mul, ← mul_assoc, ← mul_assoc, mul_comm ε]
       refine mul_le_mul_of_nonneg_left (setIntegral_mono_set ?_ ?_
-        (Set.Ioi_subset_Ioi hT₁).eventuallyLE) (mul_nonneg (sub_pos_of_lt hs).le hε.le)
+        (Set.Ioi_subset_Ioi hT₁).eventuallySubset) (mul_nonneg (sub_pos_of_lt hs).le hε.le)
       · exact integrableOn_Ioi_rpow_of_lt (neg_lt_neg_iff.mpr hs) zero_lt_one
       · exact (ae_restrict_iff' measurableSet_Ioi).mpr <| univ_mem' fun t ht ↦
         Real.rpow_nonneg (zero_le_one.trans ht.le) _

--- a/Mathlib/NumberTheory/WellApproximable.lean
+++ b/Mathlib/NumberTheory/WellApproximable.lean
@@ -244,11 +244,11 @@ theorem addWellApproximable_ae_empty_or_univ (δ : ℕ → ℝ) (hδ : Tendsto �
     congr
     ext n
     tauto
-  have hE₂ : ∀ p : Nat.Primes, A p =ᵐ[μ] (∅ : Set 𝕊) ∧ B p =ᵐ[μ] (∅ : Set 𝕊) → E =ᵐ[μ] C p := by
+  have hE₂ : ∀ p : Nat.Primes, A p =ᵐ[μ] ∅ ∧ B p =ᵐ[μ] ∅ → E =ᵐ[μ] C p := by
     rintro p ⟨hA, hB⟩
     rw [hE₁ p]
     exact union_ae_eq_right_of_ae_eq_empty ((union_ae_eq_right_of_ae_eq_empty hA).trans hB)
-  have hA : ∀ p : Nat.Primes, A p =ᵐ[μ] (∅ : Set 𝕊) ∨ A p =ᵐ[μ] univ := by
+  have hA : ∀ p : Nat.Primes, A p =ᵐ[μ] ∅ ∨ A p =ᵐ[μ] univ := by
     rintro ⟨p, hp⟩
     let f : 𝕊 → 𝕊 := fun y => (p : ℕ) • y
     suffices
@@ -260,7 +260,7 @@ theorem addWellApproximable_ae_empty_or_univ (δ : ℕ → ℝ) (hδ : Tendsto �
     refine (sSupHom.setImage f).apply_blimsup_le.trans (mono_blimsup fun n hn => ?_)
     replace hn := Nat.coprime_comm.mp (hp.coprime_iff_not_dvd.2 hn.2)
     exact approxAddOrderOf.image_nsmul_subset_of_coprime (δ n) hp.pos hn
-  have hB : ∀ p : Nat.Primes, B p =ᵐ[μ] (∅ : Set 𝕊) ∨ B p =ᵐ[μ] univ := by
+  have hB : ∀ p : Nat.Primes, B p =ᵐ[μ] ∅ ∨ B p =ᵐ[μ] univ := by
     rintro ⟨p, hp⟩
     let x := u ⟨p, hp⟩
     let f : 𝕊 → 𝕊 := fun y => p • y + x
@@ -289,7 +289,7 @@ theorem addWellApproximable_ae_empty_or_univ (δ : ℕ → ℝ) (hδ : Tendsto �
     convert! approxAddOrderOf.vadd_subset_of_coprime (p * δ n) h_cop
     rw [hu₀, Subtype.coe_mk, mul_comm p, h_div]
   change (∀ᵐ x, x ∉ E) ∨ E ∈ ae volume
-  rw [← eventuallyEq_empty, ← eventuallyEq_univ]
+  rw [← eventuallyEqSet_empty, ← eventuallyEqSet_univ]
   have hC : ∀ p : Nat.Primes, u p +ᵥ C p = C p := by
     intro p
     let e := (AddAction.toPerm (u p) : Equiv.Perm 𝕊).toOrderIsoSet
@@ -297,8 +297,8 @@ theorem addWellApproximable_ae_empty_or_univ (δ : ℕ → ℝ) (hδ : Tendsto �
     rw [OrderIso.apply_blimsup e, ← hu₀ p]
     exact blimsup_congr (Eventually.of_forall fun n hn =>
       approxAddOrderOf.vadd_eq_of_mul_dvd (δ n) hn.1 hn.2)
-  by_cases! +distrib h : ∀ p : Nat.Primes, A p =ᵐ[μ] (∅ : Set 𝕊) ∧ B p =ᵐ[μ] (∅ : Set 𝕊)
-  · replace h : ∀ p : Nat.Primes, (u p +ᵥ E : Set _) =ᵐ[μ] E := by
+  by_cases! +distrib h : ∀ p : Nat.Primes, A p =ᵐ[μ] ∅ ∧ B p =ᵐ[μ] ∅
+  · replace h : ∀ p : Nat.Primes, u p +ᵥ E =ᵐ[μ] E := by
       intro p
       replace hE₂ : E =ᵐ[μ] C p := hE₂ p (h p)
       have h_qmp : Measure.QuasiMeasurePreserving (-u p +ᵥ ·) μ μ :=

--- a/Mathlib/NumberTheory/WellApproximable.lean
+++ b/Mathlib/NumberTheory/WellApproximable.lean
@@ -254,7 +254,7 @@ theorem addWellApproximable_ae_empty_or_univ (δ : ℕ → ℝ) (hδ : Tendsto �
     suffices
       f '' A p ⊆ blimsup (fun n => approxAddOrderOf 𝕊 n (p * δ n)) atTop fun n => 0 < n ∧ p∤n by
       apply (ergodic_nsmul hp.one_lt).ae_empty_or_univ_of_image_ae_le (hA₀ p).nullMeasurableSet
-      apply (LE.le.eventuallyLE this).congr EventuallyEq.rfl
+      apply this.eventuallySubset.congr .rfl
       exact blimsup_thickening_mul_ae_eq μ (fun n => 0 < n ∧ p∤n) (fun n => {y | addOrderOf y = n})
         (Nat.cast_pos.mpr hp.pos) _ hδ
     refine (sSupHom.setImage f).apply_blimsup_le.trans (mono_blimsup fun n hn => ?_)
@@ -268,7 +268,7 @@ theorem addWellApproximable_ae_empty_or_univ (δ : ℕ → ℝ) (hδ : Tendsto �
       f '' B p ⊆ blimsup (fun n => approxAddOrderOf 𝕊 n (p * δ n)) atTop fun n => 0 < n ∧ p∣∣n by
       apply (ergodic_nsmul_add x hp.one_lt).ae_empty_or_univ_of_image_ae_le
         (hB₀ p).nullMeasurableSet
-      apply (LE.le.eventuallyLE this).congr EventuallyEq.rfl
+      apply this.eventuallySubset.congr .rfl
       exact blimsup_thickening_mul_ae_eq μ (fun n => 0 < n ∧ p∣∣n) (fun n => {y | addOrderOf y = n})
         (Nat.cast_pos.mpr hp.pos) _ hδ
     refine (sSupHom.setImage f).apply_blimsup_le.trans (mono_blimsup ?_)

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -939,6 +939,12 @@ theorem eventuallyEqSet_iff {s t : Set α} {l : Filter α} : s =ᶠ[l] t ↔ ∀
 
 alias ⟨EventuallyEqSet.mem_iff, Eventually.set_eq⟩ := eventuallyEqSet_iff
 
+theorem eventuallyEqSet_empty {s : Set α} {l : Filter α} :
+    s =ᶠ[l] ∅ ↔ ∀ᶠ x in l, x ∉ s := by
+  simp [EventuallyEqSet, EventuallyEq]
+
+@[deprecated (since := "2026-08-14")] alias eventuallyEq_empty := eventuallyEqSet_empty
+
 @[simp]
 theorem eventuallyEqSet_univ {s : Set α} {l : Filter α} : s =ᶠ[l] univ ↔ s ∈ l := by
   simp [eventuallyEqSet_iff]
@@ -1083,6 +1089,9 @@ lemma symm (h : s =ᶠ[l] t) : t =ᶠ[l] s := EventuallyEq.symm h
 @[trans]
 protected lemma trans (h : s =ᶠ[l] t) (h' : t =ᶠ[l] u) : s =ᶠ[l] u := EventuallyEq.trans h h'
 
+instance {l : Filter α} : IsTrans (Set α) (· =ᶠ[l] ·) where
+  trans _ _ _ := .trans
+
 lemma congr_left (h : s =ᶠ[l] t) : s =ᶠ[l] u ↔ t =ᶠ[l] u := ⟨h.symm.trans, h.trans⟩
 
 lemma congr_right (h : t =ᶠ[l] u) : s =ᶠ[l] t ↔ s =ᶠ[l] u := ⟨(·.trans h), (·.trans h.symm)⟩
@@ -1093,14 +1102,14 @@ lemma superset (h : s =ᶠ[l] t) : t ≤ᶠ[l] s := Eventually.mono h fun _ ↦ 
 
 @[gcongr]
 lemma inter (h : s =ᶠ[l] t) {s' t' : Set α} (h' : s' =ᶠ[l] t') : s ∩ s' =ᶠ[l] t ∩ t' :=
-  EventuallyEq.comp₂ h (· ∧ ·) h'
+  h.comp₂ (· ∧ ·) h'
 
 @[gcongr]
 lemma union (h : s =ᶠ[l] t) {s' t' : Set α} (h' : s' =ᶠ[l] t') : s ∪ s' =ᶠ[l] t ∪ t' :=
-  EventuallyEq.comp₂ h (· ∨ ·) h'
+  h.comp₂ (· ∨ ·) h'
 
 @[gcongr]
-lemma compl (h : s =ᶠ[l] t) : sᶜ =ᶠ[l] tᶜ := EventuallyEq.fun_comp h Not
+lemma compl (h : s =ᶠ[l] t) : sᶜ =ᶠ[l] tᶜ := h.fun_comp Not
 
 @[gcongr]
 lemma diff (h : s =ᶠ[l] t) {s' t' : Set α} (h' : s' =ᶠ[l] t') : s \ s' =ᶠ[l] t \ t' :=
@@ -1122,15 +1131,6 @@ end EventuallyEqSet
 
 lemma eventuallyEqSet_comm {s t : Set α} {l : Filter α} : s =ᶠ[l] t ↔ t =ᶠ[l] s :=
   ⟨.symm, .symm⟩
-
-instance {l : Filter α} : IsTrans (Set α) (· =ᶠ[l] ·) where
-  trans _ _ _ := .trans
-
-theorem eventuallyEqSet_empty {s : Set α} {l : Filter α} :
-    s =ᶠ[l] ∅ ↔ ∀ᶠ x in l, x ∉ s := by
-  simp [EventuallyEqSet, EventuallyEq]
-
-@[deprecated (since := "2026-08-14")] alias eventuallyEq_empty := eventuallyEqSet_empty
 
 theorem inter_eventuallyEqSet_left {s t : Set α} {l : Filter α} :
     s ∩ t =ᶠ[l] s ↔ ∀ᶠ x in l, x ∈ s → x ∈ t := by
@@ -1271,10 +1271,12 @@ protected lemma refl (l : Filter α) (s : Set α) : s ≤ᶠ[l] s := EventuallyL
 
 protected lemma rfl : s ≤ᶠ[l] s := .refl l s
 
-lemma of_subset (h : s ⊆ t) : s ≤ᶠ[l] t := Eventually.of_forall fun _ ↦ @h _
-
 @[trans]
 lemma trans (h : s ≤ᶠ[l] t) (h' : t ≤ᶠ[l] u) : s ≤ᶠ[l] u := EventuallyLE.trans h h'
+
+instance {l : Filter α} :
+    Trans ((· ≤ᶠ[l] ·) : Set α → Set α → Prop) (· ≤ᶠ[l] ·) (· ≤ᶠ[l] ·) where
+  trans := .trans
 
 lemma antisymm (h : s ≤ᶠ[l] t) (h' : t ≤ᶠ[l] s) : s =ᶠ[l] t := EventuallyLE.antisymm h h'
 
@@ -1315,15 +1317,10 @@ theorem eventuallySubset_iff_inf_principal_le {s t : Set α} {l : Filter α} :
 @[deprecated (since := "2026-08-14")]
 alias set_eventuallyLE_iff_inf_principal_le := eventuallySubset_iff_inf_principal_le
 
-instance {l : Filter α} :
-    Trans ((· ≤ᶠ[l] ·) : Set α → Set α → Prop) (· ≤ᶠ[l] ·) (· ≤ᶠ[l] ·) where
-  trans := EventuallySubset.trans
-
 theorem eventuallySubset_antisymm_iff {s t : Set α} {l : Filter α} :
     s =ᶠ[l] t ↔ s ≤ᶠ[l] t ∧ t ≤ᶠ[l] s :=
   eventuallyLE_antisymm_iff
 
-set_option backward.isDefEq.respectTransparency false in
 theorem eventuallyEqSet_iff_inf_principal {s t : Set α} {l : Filter α} :
     s =ᶠ[l] t ↔ l ⊓ 𝓟 s = l ⊓ 𝓟 t := by
   simp only [eventuallySubset_antisymm_iff, le_antisymm_iff, eventuallySubset_iff_inf_principal_le]
@@ -1370,10 +1367,12 @@ theorem Set.EqOn.eventuallyEq_of_mem {α β} {s : Set α} {l : Filter α} {f g :
 lemma LE.le.eventuallySubset {α} {l : Filter α} {s t : Set α} (h : s ⊆ t) : s ≤ᶠ[l] t :=
   .of_forall h
 
-theorem LE.le.eventuallyLE {α} {l : Filter α} {s t : Set α} (h : s ≤ t) : s ≤ᶠ[l] t :=
-  .of_forall h
+lemma LE.le.eventuallyLE {α β : Type*} [LE β] {l : Filter α} {f g : α → β} (h : f ≤ g) :
+    f ≤ᶠ[l] g := .of_forall h
 
-alias Filter.EventuallyLE.of_subset := LE.le.eventuallySubset
+@[deprecated (since := "2026-03-16")] alias HasSubset.Subset.eventuallyLE := LE.le.eventuallySubset
+
+alias Filter.EventuallySubset.of_subset := LE.le.eventuallySubset
 alias Filter.EventuallyLE.of_le := LE.le.eventuallyLE
 
 variable {α : Type*}

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -932,14 +932,18 @@ theorem EventuallyEq.rw {l : Filter α} {f g : α → β} (h : f =ᶠ[l] g) (p :
     (hf : ∀ᶠ x in l, p x (f x)) : ∀ᶠ x in l, p x (g x) :=
   hf.congr <| h.mono fun _ hx => hx ▸ Iff.rfl
 
-theorem eventuallyEq_set {s t : Set α} {l : Filter α} : s =ᶠ[l] t ↔ ∀ᶠ x in l, x ∈ s ↔ x ∈ t :=
+theorem eventuallyEqSet_iff {s t : Set α} {l : Filter α} : s =ᶠ[l] t ↔ ∀ᶠ x in l, x ∈ s ↔ x ∈ t :=
   eventually_congr <| Eventually.of_forall fun _ ↦ eq_iff_iff
 
-alias ⟨EventuallyEq.mem_iff, Eventually.set_eq⟩ := eventuallyEq_set
+@[deprecated (since := "2026-08-14")] alias eventuallyEq_set := eventuallyEqSet_iff
+
+alias ⟨EventuallyEqSet.mem_iff, Eventually.set_eq⟩ := eventuallyEqSet_iff
 
 @[simp]
-theorem eventuallyEq_univ {s : Set α} {l : Filter α} : s =ᶠ[l] univ ↔ s ∈ l := by
-  simp [eventuallyEq_set]
+theorem eventuallyEqSet_univ {s : Set α} {l : Filter α} : s =ᶠ[l] univ ↔ s ∈ l := by
+  simp [eventuallyEqSet_iff]
+
+@[deprecated (since := "2026-08-14")] alias eventuallyEq_univ := eventuallyEqSet_univ
 
 theorem EventuallyEq.exists_mem {l : Filter α} {f g : α → β} (h : f =ᶠ[l] g) :
     ∃ s ∈ l, EqOn f g s :=
@@ -1057,43 +1061,88 @@ theorem EventuallyEq.inf [Min β] {l : Filter α} {f f' g g' : α → β} (hf : 
 @[gcongr]
 theorem EventuallyEq.preimage {l : Filter α} {f g : α → β} (h : f =ᶠ[l] g) (s : Set β) :
     f ⁻¹' s =ᶠ[l] g ⁻¹' s :=
-  h.fun_comp s
+  h.fun_comp (· ∈ s)
+
+namespace EventuallyEqSet
+variable {s t u : Set α} {l l' : Filter α}
 
 @[gcongr]
-theorem EventuallyEq.inter {s t s' t' : Set α} {l : Filter α} (h : s =ᶠ[l] t) (h' : s' =ᶠ[l] t') :
-    (s ∩ s' : Set α) =ᶠ[l] (t ∩ t' : Set α) :=
-  h.comp₂ (· ∧ ·) h'
+lemma filter_mono (h : s =ᶠ[l] t) (hl : l' ≤ l) : s =ᶠ[l'] t :=
+  EventuallyEq.filter_mono h hl
+
+@[refl, simp]
+protected lemma refl (l : Filter α) (s : Set α) : s =ᶠ[l] s := EventuallyEq.refl l _
+
+protected lemma rfl : s =ᶠ[l] s := .refl l s
+
+lemma of_eq (h : s = t) : s =ᶠ[l] t := h ▸ .rfl
+
+@[symm]
+lemma symm (h : s =ᶠ[l] t) : t =ᶠ[l] s := EventuallyEq.symm h
+
+@[trans]
+protected lemma trans (h : s =ᶠ[l] t) (h' : t =ᶠ[l] u) : s =ᶠ[l] u := EventuallyEq.trans h h'
+
+lemma congr_left (h : s =ᶠ[l] t) : s =ᶠ[l] u ↔ t =ᶠ[l] u := ⟨h.symm.trans, h.trans⟩
+
+lemma congr_right (h : t =ᶠ[l] u) : s =ᶠ[l] t ↔ s =ᶠ[l] u := ⟨(·.trans h), (·.trans h.symm)⟩
+
+lemma subset (h : s =ᶠ[l] t) : s ≤ᶠ[l] t := Eventually.mono h fun _ ↦ le_of_eq
+
+lemma superset (h : s =ᶠ[l] t) : t ≤ᶠ[l] s := Eventually.mono h fun _ ↦ ge_of_eq
 
 @[gcongr]
-theorem EventuallyEq.union {s t s' t' : Set α} {l : Filter α} (h : s =ᶠ[l] t) (h' : s' =ᶠ[l] t') :
-    (s ∪ s' : Set α) =ᶠ[l] (t ∪ t' : Set α) :=
-  h.comp₂ (· ∨ ·) h'
+lemma inter (h : s =ᶠ[l] t) {s' t' : Set α} (h' : s' =ᶠ[l] t') : s ∩ s' =ᶠ[l] t ∩ t' :=
+  EventuallyEq.comp₂ h (· ∧ ·) h'
 
 @[gcongr]
-theorem EventuallyEq.compl {s t : Set α} {l : Filter α} (h : s =ᶠ[l] t) :
-    (sᶜ : Set α) =ᶠ[l] (tᶜ : Set α) :=
-  h.fun_comp Not
+lemma union (h : s =ᶠ[l] t) {s' t' : Set α} (h' : s' =ᶠ[l] t') : s ∪ s' =ᶠ[l] t ∪ t' :=
+  EventuallyEq.comp₂ h (· ∨ ·) h'
 
 @[gcongr]
-theorem EventuallyEq.diff {s t s' t' : Set α} {l : Filter α} (h : s =ᶠ[l] t) (h' : s' =ᶠ[l] t') :
-    (s \ s' : Set α) =ᶠ[l] (t \ t' : Set α) :=
+lemma compl (h : s =ᶠ[l] t) : sᶜ =ᶠ[l] tᶜ := EventuallyEq.fun_comp h Not
+
+@[gcongr]
+lemma diff (h : s =ᶠ[l] t) {s' t' : Set α} (h' : s' =ᶠ[l] t') : s \ s' =ᶠ[l] t \ t' :=
   h.inter h'.compl
 
 @[gcongr]
-protected theorem EventuallyEq.symmDiff {s t s' t' : Set α} {l : Filter α}
-    (h : s =ᶠ[l] t) (h' : s' =ᶠ[l] t') : (s ∆ s' : Set α) =ᶠ[l] (t ∆ t' : Set α) :=
+protected lemma symmDiff (h : s =ᶠ[l] t) {s' t' : Set α} (h' : s' =ᶠ[l] t') :
+    s ∆ s' =ᶠ[l] t ∆ t' :=
   (h.diff h').union (h'.diff h)
 
-theorem eventuallyEq_empty {s : Set α} {l : Filter α} : s =ᶠ[l] (∅ : Set α) ↔ ∀ᶠ x in l, x ∉ s :=
-  eventuallyEq_set.trans <| by simp
+end EventuallyEqSet
 
-theorem inter_eventuallyEq_left {s t : Set α} {l : Filter α} :
-    (s ∩ t : Set α) =ᶠ[l] s ↔ ∀ᶠ x in l, x ∈ s → x ∈ t := by
-  simp only [eventuallyEq_set, mem_inter_iff, and_iff_left_iff_imp]
+@[deprecated (since := "2026-08-14")] alias EventuallyEq.mem_iff := EventuallyEqSet.mem_iff
+@[deprecated (since := "2026-08-14")] alias EventuallyEq.inter := EventuallyEqSet.inter
+@[deprecated (since := "2026-08-14")] alias EventuallyEq.union := EventuallyEqSet.union
+@[deprecated (since := "2026-08-14")] alias EventuallyEq.compl := EventuallyEqSet.compl
+@[deprecated (since := "2026-08-14")] alias EventuallyEq.diff := EventuallyEqSet.diff
+@[deprecated (since := "2026-08-14")] alias EventuallyEq.symmDiff := EventuallyEqSet.symmDiff
 
-theorem inter_eventuallyEq_right {s t : Set α} {l : Filter α} :
-    (s ∩ t : Set α) =ᶠ[l] t ↔ ∀ᶠ x in l, x ∈ t → x ∈ s := by
-  rw [inter_comm, inter_eventuallyEq_left]
+lemma eventuallyEqSet_comm {s t : Set α} {l : Filter α} : s =ᶠ[l] t ↔ t =ᶠ[l] s :=
+  ⟨.symm, .symm⟩
+
+instance {l : Filter α} : IsTrans (Set α) (· =ᶠ[l] ·) where
+  trans _ _ _ := .trans
+
+theorem eventuallyEqSet_empty {s : Set α} {l : Filter α} :
+    s =ᶠ[l] ∅ ↔ ∀ᶠ x in l, x ∉ s := by
+  simp [EventuallyEqSet, EventuallyEq]
+
+@[deprecated (since := "2026-08-14")] alias eventuallyEq_empty := eventuallyEqSet_empty
+
+theorem inter_eventuallyEqSet_left {s t : Set α} {l : Filter α} :
+    s ∩ t =ᶠ[l] s ↔ ∀ᶠ x in l, x ∈ s → x ∈ t := by
+  simp [EventuallyEqSet, EventuallyEq]
+
+@[deprecated (since := "2026-08-14")] alias inter_eventuallyEq_left := inter_eventuallyEqSet_left
+
+theorem inter_eventuallyEqSet_right {s t : Set α} {l : Filter α} :
+    s ∩ t =ᶠ[l] t ↔ ∀ᶠ x in l, x ∈ t → x ∈ s := by
+  rw [inter_comm, inter_eventuallyEqSet_left]
+
+@[deprecated (since := "2026-08-14")] alias inter_eventuallyEq_right := inter_eventuallyEqSet_right
 
 @[simp]
 theorem eventuallyEq_principal {s : Set α} {f g : α → β} : f =ᶠ[𝓟 s] g ↔ EqOn f g s :=
@@ -1208,39 +1257,79 @@ theorem Eventually.lt_top_iff_ne_top [PartialOrder β] [OrderTop β] {l : Filter
     (∀ᶠ x in l, f x < ⊤) ↔ ∀ᶠ x in l, f x ≠ ⊤ :=
   ⟨Eventually.ne_of_lt, Eventually.lt_top_of_ne⟩
 
+namespace EventuallySubset
+variable {s t u : Set α} {l l' : Filter α}
+
+lemma eventually (h : s ≤ᶠ[l] t) : ∀ᶠ x in l, x ∈ s → x ∈ t := h
+
+@[gcongr]
+lemma filter_mono (h : s ≤ᶠ[l] t) (hl : l' ≤ l) : s ≤ᶠ[l'] t :=
+  Eventually.filter_mono hl h
+
+@[refl]
+protected lemma refl (l : Filter α) (s : Set α) : s ≤ᶠ[l] s := EventuallyLE.refl l _
+
+protected lemma rfl : s ≤ᶠ[l] s := .refl l s
+
+lemma of_subset (h : s ⊆ t) : s ≤ᶠ[l] t := Eventually.of_forall fun _ ↦ @h _
+
+@[trans]
+lemma trans (h : s ≤ᶠ[l] t) (h' : t ≤ᶠ[l] u) : s ≤ᶠ[l] u := EventuallyLE.trans h h'
+
+lemma antisymm (h : s ≤ᶠ[l] t) (h' : t ≤ᶠ[l] s) : s =ᶠ[l] t := EventuallyLE.antisymm h h'
+
 @[gcongr, mono]
-theorem EventuallyLE.inter {s t s' t' : Set α} {l : Filter α} (h : s ≤ᶠ[l] t) (h' : s' ≤ᶠ[l] t') :
-    (s ∩ s' : Set α) ≤ᶠ[l] (t ∩ t' : Set α) :=
+lemma inter (h : s ≤ᶠ[l] t) {s' t' : Set α} (h' : s' ≤ᶠ[l] t') : s ∩ s' ≤ᶠ[l] t ∩ t' :=
   h'.mp <| h.mono fun _ => And.imp
 
 @[gcongr, mono]
-theorem EventuallyLE.union {s t s' t' : Set α} {l : Filter α} (h : s ≤ᶠ[l] t) (h' : s' ≤ᶠ[l] t') :
-    (s ∪ s' : Set α) ≤ᶠ[l] (t ∪ t' : Set α) :=
+lemma union (h : s ≤ᶠ[l] t) {s' t' : Set α} (h' : s' ≤ᶠ[l] t') : s ∪ s' ≤ᶠ[l] t ∪ t' :=
   h'.mp <| h.mono fun _ => Or.imp
 
 @[gcongr, mono]
-theorem EventuallyLE.compl {s t : Set α} {l : Filter α} (h : s ≤ᶠ[l] t) :
-    (tᶜ : Set α) ≤ᶠ[l] (sᶜ : Set α) :=
-  h.mono fun _ => mt
+lemma compl (h : s ≤ᶠ[l] t) : tᶜ ≤ᶠ[l] sᶜ := h.mono fun _ => mt
 
 @[gcongr, mono]
-theorem EventuallyLE.diff {s t s' t' : Set α} {l : Filter α} (h : s ≤ᶠ[l] t) (h' : t' ≤ᶠ[l] s') :
-    (s \ s' : Set α) ≤ᶠ[l] (t \ t' : Set α) :=
+lemma diff (h : s ≤ᶠ[l] t) {s' t' : Set α} (h' : t' ≤ᶠ[l] s') : s \ s' ≤ᶠ[l] t \ t' :=
   h.inter h'.compl
 
-theorem set_eventuallyLE_iff_mem_inf_principal {s t : Set α} {l : Filter α} :
+end EventuallySubset
+
+@[deprecated (since := "2026-08-14")] alias EventuallyLE.inter := EventuallySubset.inter
+@[deprecated (since := "2026-08-14")] alias EventuallyLE.union := EventuallySubset.union
+@[deprecated (since := "2026-08-14")] alias EventuallyLE.compl := EventuallySubset.compl
+@[deprecated (since := "2026-08-14")] alias EventuallyLE.diff := EventuallySubset.diff
+
+theorem eventuallySubset_iff_mem_inf_principal {s t : Set α} {l : Filter α} :
     s ≤ᶠ[l] t ↔ t ∈ l ⊓ 𝓟 s :=
   eventually_inf_principal.symm
 
-theorem set_eventuallyLE_iff_inf_principal_le {s t : Set α} {l : Filter α} :
+@[deprecated (since := "2026-08-14")]
+alias set_eventuallyLE_iff_mem_inf_principal := eventuallySubset_iff_mem_inf_principal
+
+theorem eventuallySubset_iff_inf_principal_le {s t : Set α} {l : Filter α} :
     s ≤ᶠ[l] t ↔ l ⊓ 𝓟 s ≤ l ⊓ 𝓟 t :=
-  set_eventuallyLE_iff_mem_inf_principal.trans <| by
+  eventuallySubset_iff_mem_inf_principal.trans <| by
     simp only [le_inf_iff, inf_le_left, true_and, le_principal_iff]
 
+@[deprecated (since := "2026-08-14")]
+alias set_eventuallyLE_iff_inf_principal_le := eventuallySubset_iff_inf_principal_le
+
+instance {l : Filter α} :
+    Trans ((· ≤ᶠ[l] ·) : Set α → Set α → Prop) (· ≤ᶠ[l] ·) (· ≤ᶠ[l] ·) where
+  trans := EventuallySubset.trans
+
+theorem eventuallySubset_antisymm_iff {s t : Set α} {l : Filter α} :
+    s =ᶠ[l] t ↔ s ≤ᶠ[l] t ∧ t ≤ᶠ[l] s :=
+  eventuallyLE_antisymm_iff
+
 set_option backward.isDefEq.respectTransparency false in
-theorem set_eventuallyEq_iff_inf_principal {s t : Set α} {l : Filter α} :
+theorem eventuallyEqSet_iff_inf_principal {s t : Set α} {l : Filter α} :
     s =ᶠ[l] t ↔ l ⊓ 𝓟 s = l ⊓ 𝓟 t := by
-  simp only [eventuallyLE_antisymm_iff, le_antisymm_iff, set_eventuallyLE_iff_inf_principal_le]
+  simp only [eventuallySubset_antisymm_iff, le_antisymm_iff, eventuallySubset_iff_inf_principal_le]
+
+@[deprecated (since := "2026-08-14")]
+alias set_eventuallyEq_iff_inf_principal := eventuallyEqSet_iff_inf_principal
 
 @[to_dual (attr := gcongr)]
 theorem EventuallyLE.sup [SemilatticeSup β] {l : Filter α} {f₁ f₂ g₁ g₂ : α → β} (hf : f₁ ≤ᶠ[l] f₂)
@@ -1278,10 +1367,14 @@ theorem Set.EqOn.eventuallyEq_of_mem {α β} {s : Set α} {l : Filter α} {f g :
     (hl : s ∈ l) : f =ᶠ[l] g :=
   h.eventuallyEq.filter_mono <| Filter.le_principal_iff.2 hl
 
-theorem LE.le.eventuallyLE {α} {l : Filter α} {s t : Set α} (h : s ⊆ t) : s ≤ᶠ[l] t :=
-  Filter.Eventually.of_forall h
+lemma LE.le.eventuallySubset {α} {l : Filter α} {s t : Set α} (h : s ⊆ t) : s ≤ᶠ[l] t :=
+  .of_forall h
 
-@[deprecated (since := "2026-03-16")] alias HasSubset.Subset.eventuallyLE := LE.le.eventuallyLE
+theorem LE.le.eventuallyLE {α} {l : Filter α} {s t : Set α} (h : s ≤ t) : s ≤ᶠ[l] t :=
+  .of_forall h
+
+alias Filter.EventuallyLE.of_subset := LE.le.eventuallySubset
+alias Filter.EventuallyLE.of_le := LE.le.eventuallyLE
 
 variable {α : Type*}
 

--- a/Mathlib/Order/Filter/CardinalInter.lean
+++ b/Mathlib/Order/Filter/CardinalInter.lean
@@ -116,49 +116,66 @@ theorem eventually_cardinal_ball {S : Set ι} (hS : #S < c)
   simp only [Filter.Eventually, ofPred_forall]
   exact cardinal_bInter_mem hS
 
-theorem EventuallyLE.cardinal_iUnion {s t : ι → Set α} (hic : #ι < c)
+theorem EventuallySubset.cardinal_iUnion {s t : ι → Set α} (hic : #ι < c)
     (h : ∀ i, s i ≤ᶠ[l] t i) : ⋃ i, s i ≤ᶠ[l] ⋃ i, t i :=
   ((eventually_cardinal_forall hic).2 h).mono fun _ hst hs => mem_iUnion.2 <|
     (mem_iUnion.1 hs).imp hst
 
-theorem EventuallyEq.cardinal_iUnion {s t : ι → Set α} (hic : #ι < c)
+theorem EventuallyEqSet.cardinal_iUnion {s t : ι → Set α} (hic : #ι < c)
     (h : ∀ i, s i =ᶠ[l] t i) : ⋃ i, s i =ᶠ[l] ⋃ i, t i :=
-  (EventuallyLE.cardinal_iUnion hic fun i => (h i).le).antisymm
-    (EventuallyLE.cardinal_iUnion hic fun i => (h i).symm.le)
+  (EventuallySubset.cardinal_iUnion hic fun i => (h i).subset).antisymm
+    (EventuallySubset.cardinal_iUnion hic fun i => (h i).symm.subset)
 
-theorem EventuallyLE.cardinal_bUnion {S : Set ι} (hS : #S < c)
+theorem EventuallySubset.cardinal_bUnion {S : Set ι} (hS : #S < c)
     {s t : ∀ i ∈ S, Set α} (h : ∀ i hi, s i hi ≤ᶠ[l] t i hi) :
     ⋃ i ∈ S, s i ‹_› ≤ᶠ[l] ⋃ i ∈ S, t i ‹_› := by
   simp only [biUnion_eq_iUnion]
-  exact EventuallyLE.cardinal_iUnion hS fun i => h i i.2
+  exact EventuallySubset.cardinal_iUnion hS fun i => h i i.2
 
-theorem EventuallyEq.cardinal_bUnion {S : Set ι} (hS : #S < c)
+theorem EventuallyEqSet.cardinal_bUnion {S : Set ι} (hS : #S < c)
     {s t : ∀ i ∈ S, Set α} (h : ∀ i hi, s i hi =ᶠ[l] t i hi) :
     ⋃ i ∈ S, s i ‹_› =ᶠ[l] ⋃ i ∈ S, t i ‹_› :=
-  (EventuallyLE.cardinal_bUnion hS fun i hi => (h i hi).le).antisymm
-    (EventuallyLE.cardinal_bUnion hS fun i hi => (h i hi).symm.le)
+  (EventuallySubset.cardinal_bUnion hS fun i hi => (h i hi).subset).antisymm
+    (EventuallySubset.cardinal_bUnion hS fun i hi => (h i hi).symm.subset)
 
-theorem EventuallyLE.cardinal_iInter {s t : ι → Set α} (hic : #ι < c)
+theorem EventuallySubset.cardinal_iInter {s t : ι → Set α} (hic : #ι < c)
     (h : ∀ i, s i ≤ᶠ[l] t i) : ⋂ i, s i ≤ᶠ[l] ⋂ i, t i :=
   ((eventually_cardinal_forall hic).2 h).mono fun _ hst hs =>
     mem_iInter.2 fun i => hst _ (mem_iInter.1 hs i)
 
-theorem EventuallyEq.cardinal_iInter {s t : ι → Set α} (hic : #ι < c)
+theorem EventuallyEqSet.cardinal_iInter {s t : ι → Set α} (hic : #ι < c)
     (h : ∀ i, s i =ᶠ[l] t i) : ⋂ i, s i =ᶠ[l] ⋂ i, t i :=
-  (EventuallyLE.cardinal_iInter hic fun i => (h i).le).antisymm
-    (EventuallyLE.cardinal_iInter hic fun i => (h i).symm.le)
+  (EventuallySubset.cardinal_iInter hic fun i => (h i).subset).antisymm
+    (EventuallySubset.cardinal_iInter hic fun i => (h i).symm.subset)
 
-theorem EventuallyLE.cardinal_bInter {S : Set ι} (hS : #S < c)
+theorem EventuallySubset.cardinal_bInter {S : Set ι} (hS : #S < c)
     {s t : ∀ i ∈ S, Set α} (h : ∀ i hi, s i hi ≤ᶠ[l] t i hi) :
     ⋂ i ∈ S, s i ‹_› ≤ᶠ[l] ⋂ i ∈ S, t i ‹_› := by
   simp only [biInter_eq_iInter]
-  exact EventuallyLE.cardinal_iInter hS fun i => h i i.2
+  exact EventuallySubset.cardinal_iInter hS fun i => h i i.2
 
-theorem EventuallyEq.cardinal_bInter {S : Set ι} (hS : #S < c)
+theorem EventuallyEqSet.cardinal_bInter {S : Set ι} (hS : #S < c)
     {s t : ∀ i ∈ S, Set α} (h : ∀ i hi, s i hi =ᶠ[l] t i hi) :
     ⋂ i ∈ S, s i ‹_› =ᶠ[l] ⋂ i ∈ S, t i ‹_› :=
-  (EventuallyLE.cardinal_bInter hS fun i hi => (h i hi).le).antisymm
-    (EventuallyLE.cardinal_bInter hS fun i hi => (h i hi).symm.le)
+  (EventuallySubset.cardinal_bInter hS fun i hi => (h i hi).subset).antisymm
+    (EventuallySubset.cardinal_bInter hS fun i hi => (h i hi).symm.subset)
+
+@[deprecated (since := "2026-08-14")]
+alias EventuallyLE.cardinal_iUnion := EventuallySubset.cardinal_iUnion
+@[deprecated (since := "2026-08-14")]
+alias EventuallyEq.cardinal_iUnion := EventuallyEqSet.cardinal_iUnion
+@[deprecated (since := "2026-08-14")]
+alias EventuallyLE.cardinal_bUnion := EventuallySubset.cardinal_bUnion
+@[deprecated (since := "2026-08-14")]
+alias EventuallyEq.cardinal_bUnion := EventuallyEqSet.cardinal_bUnion
+@[deprecated (since := "2026-08-14")]
+alias EventuallyLE.cardinal_iInter := EventuallySubset.cardinal_iInter
+@[deprecated (since := "2026-08-14")]
+alias EventuallyEq.cardinal_iInter := EventuallyEqSet.cardinal_iInter
+@[deprecated (since := "2026-08-14")]
+alias EventuallyLE.cardinal_bInter := EventuallySubset.cardinal_bInter
+@[deprecated (since := "2026-08-14")]
+alias EventuallyEq.cardinal_bInter := EventuallyEqSet.cardinal_bInter
 
 /-- Construct a filter with cardinal `c` intersection property. This constructor deduces
 `Filter.univ_sets` and `Filter.inter_sets` from the cardinal `c` intersection property. -/
@@ -214,7 +231,7 @@ instance cardinalInter_ofCardinalUnion (l : Set (Set α)) (hc : 2 < c) (h₁ h�
 
 @[simp]
 theorem mem_ofCardinalUnion {l : Set (Set α)} (hc : 2 < c) {hunion hmono s} :
-    s ∈ ofCardinalUnion l hc hunion hmono ↔ l sᶜ :=
+    s ∈ ofCardinalUnion l hc hunion hmono ↔ sᶜ ∈ l :=
   Iff.rfl
 
 instance cardinalInterFilter_principal (s : Set α) : CardinalInterFilter (𝓟 s) c :=

--- a/Mathlib/Order/Filter/CountableInter.lean
+++ b/Mathlib/Order/Filter/CountableInter.lean
@@ -75,74 +75,91 @@ theorem eventually_finset_ball {ι : Type*} {S : Finset ι} {p : α → ∀ i �
 
 namespace Filter
 
-theorem EventuallyLE.countable_iUnion [Countable ι] {s t : ι → Set α} (h : ∀ i, s i ≤ᶠ[l] t i) :
+theorem EventuallySubset.countable_iUnion [Countable ι] {s t : ι → Set α} (h : ∀ i, s i ≤ᶠ[l] t i) :
     ⋃ i, s i ≤ᶠ[l] ⋃ i, t i :=
   (eventually_countable_forall.2 h).mono fun _ hst hs => mem_iUnion.2 <| (mem_iUnion.1 hs).imp hst
 
 @[deprecated (since := "2026-03-03")] alias _root_.EventuallyLE.countable_iUnion :=
-  EventuallyLE.countable_iUnion
+  EventuallySubset.countable_iUnion
 
-theorem EventuallyEq.countable_iUnion [Countable ι] {s t : ι → Set α} (h : ∀ i, s i =ᶠ[l] t i) :
+theorem EventuallyEqSet.countable_iUnion [Countable ι] {s t : ι → Set α} (h : ∀ i, s i =ᶠ[l] t i) :
     ⋃ i, s i =ᶠ[l] ⋃ i, t i :=
-  (EventuallyLE.countable_iUnion fun i => (h i).le).antisymm
-    (EventuallyLE.countable_iUnion fun i => (h i).symm.le)
+  (EventuallySubset.countable_iUnion fun i => (h i).subset).antisymm
+    (EventuallySubset.countable_iUnion fun i => (h i).symm.subset)
 
 @[deprecated (since := "2026-03-03")] alias _root_.EventuallyEq.countable_iUnion :=
-  EventuallyEq.countable_iUnion
+  EventuallyEqSet.countable_iUnion
 
-theorem EventuallyLE.countable_bUnion {ι : Type*} {S : Set ι} (hS : S.Countable)
+theorem EventuallySubset.countable_bUnion {ι : Type*} {S : Set ι} (hS : S.Countable)
     {s t : ∀ i ∈ S, Set α} (h : ∀ i hi, s i hi ≤ᶠ[l] t i hi) :
     ⋃ i ∈ S, s i ‹_› ≤ᶠ[l] ⋃ i ∈ S, t i ‹_› := by
   simp only [biUnion_eq_iUnion]
   have := hS.toEncodable
-  exact EventuallyLE.countable_iUnion fun i => h i i.2
+  exact EventuallySubset.countable_iUnion fun i => h i i.2
 
 @[deprecated (since := "2026-03-03")] alias _root_.EventuallyLE.countable_bUnion :=
-  EventuallyLE.countable_bUnion
+  EventuallySubset.countable_bUnion
 
-theorem EventuallyEq.countable_bUnion {ι : Type*} {S : Set ι} (hS : S.Countable)
+theorem EventuallyEqSet.countable_bUnion {ι : Type*} {S : Set ι} (hS : S.Countable)
     {s t : ∀ i ∈ S, Set α} (h : ∀ i hi, s i hi =ᶠ[l] t i hi) :
     ⋃ i ∈ S, s i ‹_› =ᶠ[l] ⋃ i ∈ S, t i ‹_› :=
-  (EventuallyLE.countable_bUnion hS fun i hi => (h i hi).le).antisymm
-    (EventuallyLE.countable_bUnion hS fun i hi => (h i hi).symm.le)
+  (EventuallySubset.countable_bUnion hS fun i hi => (h i hi).subset).antisymm
+    (EventuallySubset.countable_bUnion hS fun i hi => (h i hi).symm.subset)
 
 @[deprecated (since := "2026-03-03")] alias _root_.EventuallyEq.countable_bUnion :=
-  EventuallyEq.countable_bUnion
+  EventuallyEqSet.countable_bUnion
 
-theorem EventuallyLE.countable_iInter [Countable ι] {s t : ι → Set α} (h : ∀ i, s i ≤ᶠ[l] t i) :
+theorem EventuallySubset.countable_iInter [Countable ι] {s t : ι → Set α} (h : ∀ i, s i ≤ᶠ[l] t i) :
     ⋂ i, s i ≤ᶠ[l] ⋂ i, t i :=
   (eventually_countable_forall.2 h).mono fun _ hst hs =>
     mem_iInter.2 fun i => hst _ (mem_iInter.1 hs i)
 
 @[deprecated (since := "2026-03-03")] alias _root_.EventuallyLE.countable_iInter :=
-  EventuallyLE.countable_iInter
+  EventuallySubset.countable_iInter
 
-theorem EventuallyEq.countable_iInter [Countable ι] {s t : ι → Set α} (h : ∀ i, s i =ᶠ[l] t i) :
+theorem EventuallyEqSet.countable_iInter [Countable ι] {s t : ι → Set α} (h : ∀ i, s i =ᶠ[l] t i) :
     ⋂ i, s i =ᶠ[l] ⋂ i, t i :=
-  (EventuallyLE.countable_iInter fun i => (h i).le).antisymm
-    (EventuallyLE.countable_iInter fun i => (h i).symm.le)
+  (EventuallySubset.countable_iInter fun i => (h i).subset).antisymm
+    (EventuallySubset.countable_iInter fun i => (h i).symm.subset)
 
 @[deprecated (since := "2026-03-03")] alias _root_.EventuallyEq.countable_iInter :=
-  EventuallyEq.countable_iInter
+  EventuallyEqSet.countable_iInter
 
-theorem EventuallyLE.countable_bInter {ι : Type*} {S : Set ι} (hS : S.Countable)
+theorem EventuallySubset.countable_bInter {ι : Type*} {S : Set ι} (hS : S.Countable)
     {s t : ∀ i ∈ S, Set α} (h : ∀ i hi, s i hi ≤ᶠ[l] t i hi) :
     ⋂ i ∈ S, s i ‹_› ≤ᶠ[l] ⋂ i ∈ S, t i ‹_› := by
   simp only [biInter_eq_iInter]
   have := hS.toEncodable
-  exact EventuallyLE.countable_iInter fun i => h i i.2
+  exact EventuallySubset.countable_iInter fun i => h i i.2
 
 @[deprecated (since := "2026-03-03")] alias _root_.EventuallyLE.countable_bInter :=
-  EventuallyLE.countable_bInter
+  EventuallySubset.countable_bInter
 
-theorem EventuallyEq.countable_bInter {ι : Type*} {S : Set ι} (hS : S.Countable)
+theorem EventuallyEqSet.countable_bInter {ι : Type*} {S : Set ι} (hS : S.Countable)
     {s t : ∀ i ∈ S, Set α} (h : ∀ i hi, s i hi =ᶠ[l] t i hi) :
     ⋂ i ∈ S, s i ‹_› =ᶠ[l] ⋂ i ∈ S, t i ‹_› :=
-  (EventuallyLE.countable_bInter hS fun i hi => (h i hi).le).antisymm
-    (EventuallyLE.countable_bInter hS fun i hi => (h i hi).symm.le)
+  (EventuallySubset.countable_bInter hS fun i hi => (h i hi).subset).antisymm
+    (EventuallySubset.countable_bInter hS fun i hi => (h i hi).symm.subset)
 
 @[deprecated (since := "2026-03-03")] alias _root_.EventuallyEq.countable_bInter :=
-  EventuallyEq.countable_bInter
+  EventuallyEqSet.countable_bInter
+
+@[deprecated (since := "2026-08-14")]
+alias EventuallyLE.countable_iUnion := EventuallySubset.countable_iUnion
+@[deprecated (since := "2026-08-14")]
+alias EventuallyEq.countable_iUnion := EventuallyEqSet.countable_iUnion
+@[deprecated (since := "2026-08-14")]
+alias EventuallyLE.countable_bUnion := EventuallySubset.countable_bUnion
+@[deprecated (since := "2026-08-14")]
+alias EventuallyEq.countable_bUnion := EventuallyEqSet.countable_bUnion
+@[deprecated (since := "2026-08-14")]
+alias EventuallyLE.countable_iInter := EventuallySubset.countable_iInter
+@[deprecated (since := "2026-08-14")]
+alias EventuallyEq.countable_iInter := EventuallyEqSet.countable_iInter
+@[deprecated (since := "2026-08-14")]
+alias EventuallyLE.countable_bInter := EventuallySubset.countable_bInter
+@[deprecated (since := "2026-08-14")]
+alias EventuallyEq.countable_bInter := EventuallyEqSet.countable_bInter
 
 /-- Construct a filter with countable intersection property. This constructor deduces
 `Filter.univ_sets` and `Filter.inter_sets` from the countable intersection property. -/

--- a/Mathlib/Order/Filter/Defs.lean
+++ b/Mathlib/Order/Filter/Defs.lean
@@ -297,16 +297,118 @@ notation3 "∃ᶠ "(...)" in "f", "r:(scoped p => Filter.Frequently p f) => r
 def EventuallyEq (l : Filter α) (f g : α → β) : Prop :=
   ∀ᶠ x in l, f x = g x
 
-@[inherit_doc]
-notation:50 f " =ᶠ[" l:50 "] " g:50 => EventuallyEq l f g
-
 /-- A function `f` is eventually less than or equal to a function `g` at a filter `l`. -/
 @[to_dual self (reorder := f g)]
 def EventuallyLE [LE β] (l : Filter α) (f g : α → β) : Prop :=
   ∀ᶠ x in l, f x ≤ g x
 
-@[inherit_doc]
-notation:50 f " ≤ᶠ[" l:50 "] " g:50 => EventuallyLE l f g
+/-- Two sets `s` and `t` are *eventually equal* along a filter `l` if the set of `x` such that
+`x ∈ s ↔ x ∈ t` belongs to `l`.
+
+This is definitionally `(· ∈ s) =ᶠ[l] (· ∈ t)`, but it is a separate definition to avoid simp
+unfolding membership of concrete sets. -/
+def EventuallyEqSet (l : Filter α) (s t : Set α) : Prop :=
+  EventuallyEq l (fun x => x ∈ s) (fun x => x ∈ t)
+
+/-- A set `s` is *eventually contained* in a set `t` along a filter `l` if the set of `x` such that
+`x ∈ s → x ∈ t` belongs to `l`.
+
+This is definitionally `(· ∈ s) ≤ᶠ[l] (· ∈ t)`, but it is a separate definition to avoid simp
+unfolding membership of concrete sets. -/
+def EventuallySubset (l : Filter α) (s t : Set α) : Prop :=
+  EventuallyLE l (fun x => x ∈ s) (fun x => x ∈ t)
+
+/-- `x =ᶠ[l] y` means that `x` and `y` are *eventually equal* along the filter `l`.
+
+This is `Filter.EventuallyEq l x y` if `x` is a function or `Filter.EventuallyEqSet l x y` if `x`
+is a set. -/
+syntax:50 (name := eventuallyEqStx) term:51 " =ᶠ[" term "] " term:50 : term
+
+/-- `x ≤ᶠ[l] y` means that `x` is *eventually less than or equal to* `y` along the filter `l`.
+
+This is `Filter.EventuallyLE l x y` if `x` is a function and `Filter.EventuallySubset l x y` if `x`
+is a set. -/
+syntax:50 (name := eventuallyLEStx) term:51 " ≤ᶠ[" term "] " term:50 : term
+
+open Lean Elab Term Meta in
+/-- Elaborate the left-hand side `x` of an `x =ᶠ[l] y` / `x ≤ᶠ[l] y` on its own, dispatching on
+whether its type is a `Set`. If the type is not yet known (e.g. `x` is the `_` of a `calc` step),
+consult the right-hand side `y` instead. Returns the elaborated sides turned back into syntax
+together with whether they should be interpreted as sets. -/
+meta def elabEventuallyRelSides (x y : Term) : TermElabM (Term × Term × Bool) := do
+  -- Elaborate a side on its own, and return its type in whnf together with the elaborated term
+  -- turned back into syntax.
+  let elabSide (e : Term) : TermElabM (Expr × Term) := do
+    let e ← elabTerm e none
+    return (← whnfR (← instantiateMVars (← inferType e)), ← exprToSyntax e)
+  let (tyx, x) ← elabSide x
+  let mut y := y
+  let mut isSet := tyx.isAppOfArity ``Set 1
+  if !isSet && tyx.getAppFn.isMVar then
+    let (tyy, y') ← elabSide y
+    y := y'
+    isSet := tyy.isAppOfArity ``Set 1
+  return (x, y, isSet)
+
+open Lean Elab Term in
+/-- Elaborator for `x =ᶠ[l] y`, dispatching on the type of `x` (or of `y` if the type of `x` is not
+yet known): `Filter.EventuallyEqSet` for sets, `Filter.EventuallyEq` for functions. -/
+@[term_elab eventuallyEqStx]
+meta def elabEventuallyEq : TermElab := fun stx expectedType? => do
+  let `($x =ᶠ[$l] $y) := stx | throwUnsupportedSyntax
+  let (x, y, isSet) ← elabEventuallyRelSides x y
+  if isSet then
+    elabTerm (← `(Filter.EventuallyEqSet $l $x $y)) expectedType?
+  else
+    elabTerm (← `(Filter.EventuallyEq $l $x $y)) expectedType?
+
+open Lean Elab Term in
+/-- Elaborator for `x ≤ᶠ[l] y`, dispatching on the type of `x` (or of `y` if the type of `x` is not
+yet known): `Filter.EventuallySubset` for sets, `Filter.EventuallyLE` for functions. -/
+@[term_elab eventuallyLEStx]
+meta def elabEventuallyLE : TermElab := fun stx expectedType? => do
+  let `($x ≤ᶠ[$l] $y) := stx | throwUnsupportedSyntax
+  let (x, y, isSet) ← elabEventuallyRelSides x y
+  if isSet then
+    elabTerm (← `(Filter.EventuallySubset $l $x $y)) expectedType?
+  else
+    elabTerm (← `(Filter.EventuallyLE $l $x $y)) expectedType?
+
+open Lean.Elab Term.Quotation in
+/-- `quot_precheck` for the `=ᶠ[l]` notation, allowing it to appear inside other notations. -/
+@[quot_precheck Filter.eventuallyEqStx] meta def precheckEventuallyEq : Precheck
+  | `($x =ᶠ[$l] $y) => do precheck x; precheck l; precheck y
+  | _ => throwUnsupportedSyntax
+
+open Lean.Elab Term.Quotation in
+/-- `quot_precheck` for the `≤ᶠ[l]` notation, allowing it to appear inside other notations. -/
+@[quot_precheck Filter.eventuallyLEStx] meta def precheckEventuallyLE : Precheck
+  | `($x ≤ᶠ[$l] $y) => do precheck x; precheck l; precheck y
+  | _ => throwUnsupportedSyntax
+
+/-- Unexpander printing `Filter.EventuallyEq l f g` as `f =ᶠ[l] g`. -/
+@[app_unexpander Filter.EventuallyEq]
+meta def unexpandEventuallyEq : Lean.PrettyPrinter.Unexpander
+  | `($_ $l $f $g) => `($f =ᶠ[$l] $g)
+  | _ => throw ()
+
+/-- Unexpander printing `Filter.EventuallyEqSet l s t` as `s =ᶠ[l] t`. -/
+@[app_unexpander Filter.EventuallyEqSet]
+meta def unexpandEventuallyEqSet : Lean.PrettyPrinter.Unexpander
+  | `($_ $l $s $t) => `($s =ᶠ[$l] $t)
+  | _ => throw ()
+
+/-- Unexpander printing `Filter.EventuallyLE l f g` as `f ≤ᶠ[l] g`. -/
+@[app_unexpander Filter.EventuallyLE]
+meta def unexpandEventuallyLE : Lean.PrettyPrinter.Unexpander
+  | `($_ $l $f $g) => `($f ≤ᶠ[$l] $g)
+  | _ => throw ()
+
+/-- Unexpander printing `Filter.EventuallySubset l s t` as `s ≤ᶠ[l] t`. -/
+@[app_unexpander Filter.EventuallySubset]
+meta def unexpandEventuallySubset : Lean.PrettyPrinter.Unexpander
+  | `($_ $l $s $t) => `($s ≤ᶠ[$l] $t)
+  | _ => throw ()
 
 /-- The forward map of a filter -/
 def map (m : α → β) (f : Filter α) : Filter β where

--- a/Mathlib/Order/Filter/Defs.lean
+++ b/Mathlib/Order/Filter/Defs.lean
@@ -305,16 +305,16 @@ def EventuallyLE [LE β] (l : Filter α) (f g : α → β) : Prop :=
 /-- Two sets `s` and `t` are *eventually equal* along a filter `l` if the set of `x` such that
 `x ∈ s ↔ x ∈ t` belongs to `l`.
 
-This is definitionally `(· ∈ s) =ᶠ[l] (· ∈ t)`, but it is a separate definition to avoid simp
-unfolding membership of concrete sets. -/
+This is definitionally `(· ∈ s) =ᶠ[l] (· ∈ t)`, but it is a separate definition (rather than an
+abbreviation) to avoid simp unfolding membership of concrete sets. -/
 def EventuallyEqSet (l : Filter α) (s t : Set α) : Prop :=
   EventuallyEq l (fun x => x ∈ s) (fun x => x ∈ t)
 
 /-- A set `s` is *eventually contained* in a set `t` along a filter `l` if the set of `x` such that
 `x ∈ s → x ∈ t` belongs to `l`.
 
-This is definitionally `(· ∈ s) ≤ᶠ[l] (· ∈ t)`, but it is a separate definition to avoid simp
-unfolding membership of concrete sets. -/
+This is definitionally `(· ∈ s) ≤ᶠ[l] (· ∈ t)`, but it is a separate definition (rather than an
+abbreviation) to avoid simp unfolding membership of concrete sets. -/
 def EventuallySubset (l : Filter α) (s t : Set α) : Prop :=
   EventuallyLE l (fun x => x ∈ s) (fun x => x ∈ t)
 
@@ -334,7 +334,8 @@ open Lean Elab Term Meta in
 /-- Elaborate the left-hand side `x` of an `x =ᶠ[l] y` / `x ≤ᶠ[l] y` on its own, dispatching on
 whether its type is a `Set`. If the type is not yet known (e.g. `x` is the `_` of a `calc` step),
 consult the right-hand side `y` instead. Returns the elaborated sides turned back into syntax
-together with whether they should be interpreted as sets. -/
+together with whether they should be interpreted as sets. If `y` is not consulted, it is returned
+unelaborated. -/
 meta def elabEventuallyRelSides (x y : Term) : TermElabM (Term × Term × Bool) := do
   -- Elaborate a side on its own, and return its type in whnf together with the elaborated term
   -- turned back into syntax.
@@ -342,13 +343,11 @@ meta def elabEventuallyRelSides (x y : Term) : TermElabM (Term × Term × Bool) 
     let e ← elabTerm e none
     return (← whnfR (← instantiateMVars (← inferType e)), ← exprToSyntax e)
   let (tyx, x) ← elabSide x
-  let mut y := y
-  let mut isSet := tyx.isAppOfArity ``Set 1
-  if !isSet && tyx.getAppFn.isMVar then
-    let (tyy, y') ← elabSide y
-    y := y'
-    isSet := tyy.isAppOfArity ``Set 1
-  return (x, y, isSet)
+  if tyx.getAppFn.isMVar then
+    let (tyy, y) ← elabSide y
+    return (x, y, tyy.isAppOfArity ``Set 1)
+  else
+    return (x, y, tyx.isAppOfArity ``Set 1)
 
 open Lean Elab Term in
 /-- Elaborator for `x =ᶠ[l] y`, dispatching on the type of `x` (or of `y` if the type of `x` is not

--- a/Mathlib/Order/Filter/Finite.lean
+++ b/Mathlib/Order/Filter/Finite.lean
@@ -294,68 +294,101 @@ variable {l : Filter α} {f g : α → β}
 
 variable {l : Filter α}
 
-protected lemma EventuallyLE.iUnion [Finite ι] {s t : ι → Set α}
+protected lemma EventuallySubset.iUnion [Finite ι] {s t : ι → Set α}
     (h : ∀ i, s i ≤ᶠ[l] t i) : (⋃ i, s i) ≤ᶠ[l] ⋃ i, t i :=
   (eventually_all.2 h).mono fun _x hx hx' ↦
     let ⟨i, hi⟩ := mem_iUnion.1 hx'; mem_iUnion.2 ⟨i, hx i hi⟩
 
-protected lemma EventuallyEq.iUnion [Finite ι] {s t : ι → Set α}
+protected lemma EventuallyEqSet.iUnion [Finite ι] {s t : ι → Set α}
     (h : ∀ i, s i =ᶠ[l] t i) : (⋃ i, s i) =ᶠ[l] ⋃ i, t i :=
-  (EventuallyLE.iUnion fun i ↦ (h i).le).antisymm <| .iUnion fun i ↦ (h i).symm.le
+  (EventuallySubset.iUnion fun i ↦ (h i).subset).antisymm <| .iUnion fun i ↦ (h i).symm.subset
 
-protected lemma EventuallyLE.iInter [Finite ι] {s t : ι → Set α}
+protected lemma EventuallySubset.iInter [Finite ι] {s t : ι → Set α}
     (h : ∀ i, s i ≤ᶠ[l] t i) : (⋂ i, s i) ≤ᶠ[l] ⋂ i, t i :=
   (eventually_all.2 h).mono fun _x hx hx' ↦ mem_iInter.2 fun i ↦ hx i (mem_iInter.1 hx' i)
 
-protected lemma EventuallyEq.iInter [Finite ι] {s t : ι → Set α}
+protected lemma EventuallyEqSet.iInter [Finite ι] {s t : ι → Set α}
     (h : ∀ i, s i =ᶠ[l] t i) : (⋂ i, s i) =ᶠ[l] ⋂ i, t i :=
-  (EventuallyLE.iInter fun i ↦ (h i).le).antisymm <| .iInter fun i ↦ (h i).symm.le
+  (EventuallySubset.iInter fun i ↦ (h i).subset).antisymm <| .iInter fun i ↦ (h i).symm.subset
 
-lemma _root_.Set.Finite.eventuallyLE_iUnion {ι : Type*} {s : Set ι} (hs : s.Finite)
+lemma _root_.Set.Finite.eventuallySubset_iUnion {ι : Type*} {s : Set ι} (hs : s.Finite)
     {f g : ι → Set α} (hle : ∀ i ∈ s, f i ≤ᶠ[l] g i) : (⋃ i ∈ s, f i) ≤ᶠ[l] (⋃ i ∈ s, g i) := by
   have := hs.to_subtype
   rw [biUnion_eq_iUnion, biUnion_eq_iUnion]
   exact .iUnion fun i ↦ hle i.1 i.2
 
-alias EventuallyLE.biUnion := Set.Finite.eventuallyLE_iUnion
+alias EventuallySubset.biUnion := Set.Finite.eventuallySubset_iUnion
 
-lemma _root_.Set.Finite.eventuallyEq_iUnion {ι : Type*} {s : Set ι} (hs : s.Finite)
+@[deprecated (since := "2026-08-14")]
+alias _root_.Set.Finite.eventuallyLE_iUnion := Set.Finite.eventuallySubset_iUnion
+
+lemma _root_.Set.Finite.eventuallyEqSet_iUnion {ι : Type*} {s : Set ι} (hs : s.Finite)
     {f g : ι → Set α} (heq : ∀ i ∈ s, f i =ᶠ[l] g i) : (⋃ i ∈ s, f i) =ᶠ[l] (⋃ i ∈ s, g i) :=
-  (EventuallyLE.biUnion hs fun i hi ↦ (heq i hi).le).antisymm <|
-    .biUnion hs fun i hi ↦ (heq i hi).symm.le
+  (EventuallySubset.biUnion hs fun i hi ↦ (heq i hi).subset).antisymm <|
+    .biUnion hs fun i hi ↦ (heq i hi).symm.subset
 
-alias EventuallyEq.biUnion := Set.Finite.eventuallyEq_iUnion
+alias EventuallyEqSet.biUnion := Set.Finite.eventuallyEqSet_iUnion
 
-lemma _root_.Set.Finite.eventuallyLE_iInter {ι : Type*} {s : Set ι} (hs : s.Finite)
+@[deprecated (since := "2026-08-14")]
+alias _root_.Set.Finite.eventuallyEq_iUnion := Set.Finite.eventuallyEqSet_iUnion
+
+lemma _root_.Set.Finite.eventuallySubset_iInter {ι : Type*} {s : Set ι} (hs : s.Finite)
     {f g : ι → Set α} (hle : ∀ i ∈ s, f i ≤ᶠ[l] g i) : (⋂ i ∈ s, f i) ≤ᶠ[l] (⋂ i ∈ s, g i) := by
   have := hs.to_subtype
   rw [biInter_eq_iInter, biInter_eq_iInter]
   exact .iInter fun i ↦ hle i.1 i.2
 
-alias EventuallyLE.biInter := Set.Finite.eventuallyLE_iInter
+alias EventuallySubset.biInter := Set.Finite.eventuallySubset_iInter
 
-lemma _root_.Set.Finite.eventuallyEq_iInter {ι : Type*} {s : Set ι} (hs : s.Finite)
+@[deprecated (since := "2026-08-14")]
+alias _root_.Set.Finite.eventuallyLE_iInter := Set.Finite.eventuallySubset_iInter
+
+lemma _root_.Set.Finite.eventuallyEqSet_iInter {ι : Type*} {s : Set ι} (hs : s.Finite)
     {f g : ι → Set α} (heq : ∀ i ∈ s, f i =ᶠ[l] g i) : (⋂ i ∈ s, f i) =ᶠ[l] (⋂ i ∈ s, g i) :=
-  (EventuallyLE.biInter hs fun i hi ↦ (heq i hi).le).antisymm <|
-    .biInter hs fun i hi ↦ (heq i hi).symm.le
+  (EventuallySubset.biInter hs fun i hi ↦ (heq i hi).subset).antisymm <|
+    .biInter hs fun i hi ↦ (heq i hi).symm.subset
 
-alias EventuallyEq.biInter := Set.Finite.eventuallyEq_iInter
+alias EventuallyEqSet.biInter := Set.Finite.eventuallyEqSet_iInter
 
-lemma _root_.Finset.eventuallyLE_iUnion {ι : Type*} (s : Finset ι) {f g : ι → Set α}
+@[deprecated (since := "2026-08-14")]
+alias _root_.Set.Finite.eventuallyEq_iInter := Set.Finite.eventuallyEqSet_iInter
+
+lemma _root_.Finset.eventuallySubset_iUnion {ι : Type*} (s : Finset ι) {f g : ι → Set α}
     (hle : ∀ i ∈ s, f i ≤ᶠ[l] g i) : (⋃ i ∈ s, f i) ≤ᶠ[l] (⋃ i ∈ s, g i) :=
   .biUnion s.finite_toSet hle
 
-lemma _root_.Finset.eventuallyEq_iUnion {ι : Type*} (s : Finset ι) {f g : ι → Set α}
+@[deprecated (since := "2026-08-14")]
+alias _root_.Finset.eventuallyLE_iUnion := Finset.eventuallySubset_iUnion
+
+lemma _root_.Finset.eventuallyEqSet_iUnion {ι : Type*} (s : Finset ι) {f g : ι → Set α}
     (heq : ∀ i ∈ s, f i =ᶠ[l] g i) : (⋃ i ∈ s, f i) =ᶠ[l] (⋃ i ∈ s, g i) :=
   .biUnion s.finite_toSet heq
 
-lemma _root_.Finset.eventuallyLE_iInter {ι : Type*} (s : Finset ι) {f g : ι → Set α}
+@[deprecated (since := "2026-08-14")]
+alias _root_.Finset.eventuallyEq_iUnion := Finset.eventuallyEqSet_iUnion
+
+lemma _root_.Finset.eventuallySubset_iInter {ι : Type*} (s : Finset ι) {f g : ι → Set α}
     (hle : ∀ i ∈ s, f i ≤ᶠ[l] g i) : (⋂ i ∈ s, f i) ≤ᶠ[l] (⋂ i ∈ s, g i) :=
   .biInter s.finite_toSet hle
 
-lemma _root_.Finset.eventuallyEq_iInter {ι : Type*} (s : Finset ι) {f g : ι → Set α}
+@[deprecated (since := "2026-08-14")]
+alias _root_.Finset.eventuallyLE_iInter := Finset.eventuallySubset_iInter
+
+lemma _root_.Finset.eventuallyEqSet_iInter {ι : Type*} (s : Finset ι) {f g : ι → Set α}
     (heq : ∀ i ∈ s, f i =ᶠ[l] g i) : (⋂ i ∈ s, f i) =ᶠ[l] (⋂ i ∈ s, g i) :=
   .biInter s.finite_toSet heq
+
+@[deprecated (since := "2026-08-14")]
+alias _root_.Finset.eventuallyEq_iInter := Finset.eventuallyEqSet_iInter
+
+@[deprecated (since := "2026-08-14")] alias EventuallyLE.iUnion := EventuallySubset.iUnion
+@[deprecated (since := "2026-08-14")] alias EventuallyEq.iUnion := EventuallyEqSet.iUnion
+@[deprecated (since := "2026-08-14")] alias EventuallyLE.iInter := EventuallySubset.iInter
+@[deprecated (since := "2026-08-14")] alias EventuallyEq.iInter := EventuallyEqSet.iInter
+@[deprecated (since := "2026-08-14")] alias EventuallyLE.biUnion := EventuallySubset.biUnion
+@[deprecated (since := "2026-08-14")] alias EventuallyEq.biUnion := EventuallyEqSet.biUnion
+@[deprecated (since := "2026-08-14")] alias EventuallyLE.biInter := EventuallySubset.biInter
+@[deprecated (since := "2026-08-14")] alias EventuallyEq.biInter := EventuallyEqSet.biInter
 
 end EventuallyEq
 

--- a/Mathlib/Order/Filter/IndicatorFunction.lean
+++ b/Mathlib/Order/Filter/IndicatorFunction.lean
@@ -117,7 +117,7 @@ theorem Filter.EventuallyEq.mulIndicator_one [One β] {l : Filter α} {f : α �
   hf.mulIndicator.trans <| by rw [mulIndicator_one']
 
 @[to_additive]
-theorem Filter.EventuallyEq.of_mulIndicator [One β] {l : Filter α} {f : α → β}
+theorem Filter.EventuallyEqSet.of_mulIndicator [One β] {l : Filter α} {f : α → β}
     (hf : ∀ᶠ x in l, f x ≠ 1) {s t : Set α} (h : s.mulIndicator f =ᶠ[l] t.mulIndicator f) :
     s =ᶠ[l] t := by
   have : ∀ {s : Set α}, Function.mulSupport (s.mulIndicator f) =ᶠ[l] s := fun {s} ↦ by
@@ -125,10 +125,16 @@ theorem Filter.EventuallyEq.of_mulIndicator [One β] {l : Filter α} {f : α →
     exact (hf.mono fun x hx ↦ and_iff_left hx).set_eq
   exact this.symm.trans <| h.mulSupport.trans this
 
+@[to_additive (attr := deprecated (since := "2026-08-14"))]
+alias Filter.EventuallyEq.of_mulIndicator := Filter.EventuallyEqSet.of_mulIndicator
+
 @[to_additive]
-theorem Filter.EventuallyEq.of_mulIndicator_const [One β] {l : Filter α} {c : β} (hc : c ≠ 1)
+theorem Filter.EventuallyEqSet.of_mulIndicator_const [One β] {l : Filter α} {c : β} (hc : c ≠ 1)
     {s t : Set α} (h : s.mulIndicator (fun _ ↦ c) =ᶠ[l] t.mulIndicator fun _ ↦ c) : s =ᶠ[l] t :=
   .of_mulIndicator (Eventually.of_forall fun _ ↦ hc) h
+
+@[to_additive (attr := deprecated (since := "2026-08-14"))]
+alias Filter.EventuallyEq.of_mulIndicator_const := Filter.EventuallyEqSet.of_mulIndicator_const
 
 @[to_additive]
 theorem Filter.mulIndicator_const_eventuallyEq [One β] {l : Filter α} {c : β} (hc : c ≠ 1)

--- a/Mathlib/Probability/BorelCantelli.lean
+++ b/Mathlib/Probability/BorelCantelli.lean
@@ -69,8 +69,8 @@ open Filter
 theorem measure_limsup_eq_one {s : ℕ → Set Ω} (hsm : ∀ n, MeasurableSet (s n)) (hs : iIndepSet s μ)
     (hs' : (∑' n, μ (s n)) = ∞) : μ (limsup s atTop) = 1 := by
   have : IsProbabilityMeasure μ := hs.isProbabilityMeasure
-  rw [measure_congr (eventuallyEq_set.2 (ae_mem_limsup_atTop_iff μ <|
-    measurableSet_filtrationOfSet' hsm) : (limsup s atTop : Set Ω) =ᵐ[μ]
+  rw [measure_congr (eventuallyEqSet_iff.2 (ae_mem_limsup_atTop_iff μ <|
+    measurableSet_filtrationOfSet' hsm) : limsup s atTop =ᵐ[μ]
       {ω | Tendsto (fun n => ∑ k ∈ Finset.range n,
         (μ[(s (k + 1)).indicator (1 : Ω → ℝ)|filtrationOfSet hsm k]) ω) atTop atTop})]
   suffices {ω | Tendsto (fun n => ∑ k ∈ Finset.range n,

--- a/Mathlib/Probability/Process/LocalProperty.lean
+++ b/Mathlib/Probability/Process/LocalProperty.lean
@@ -279,10 +279,10 @@ private lemma isPreLocalizingSequence_of_isLocalizingSequence_aux
   obtain ⟨T, hT, h⟩ := isPreLocalizingSequence_of_isLocalizingSequence_aux' hτ hσ
   choose nk hnk using h
   refine ⟨mkStrictMonoAux nk, T, mkStrictMonoAux_strictMono nk, hT,
-    fun n ↦ le_trans (EventuallyLE.measure_le ?_) (hnk n)⟩
+    fun n ↦ le_trans (EventuallySubset.measure_le ?_) (hnk n)⟩
   filter_upwards [(hσ n).mono] with ω hω
   specialize hω (le_mkStrictMonoAux nk n)
-  simp [Set.ofPred]
+  simp
   grind
 
 lemma IsLocalizingSequence.isPrelocalizingSequence_inf_extraction

--- a/Mathlib/Topology/Baire/BaireMeasurable.lean
+++ b/Mathlib/Topology/Baire/BaireMeasurable.lean
@@ -36,7 +36,32 @@ open Topology
 /-- Notation for `=ᶠ[residual _]`. That is, eventual equality with respect to
 the filter of residual sets.
 In lemma names, this is called `residualEq`. -/
-scoped[Topology] notation:50 f " =ᵇ " g:50 => Filter.EventuallyEq (residual _) f g
+scoped[Topology] notation:50 f " =ᵇ " g:50 => f =ᶠ[residual _] g
+
+section delaborators
+open Lean Lean.PrettyPrinter.Delaborator
+
+/-- Delaborator printing `Filter.EventuallyEq (residual _) f g` as `f =ᵇ g`. -/
+@[app_delab Filter.EventuallyEq]
+meta def delabResidualEventuallyEq : Delab := whenPPOption Lean.getPPNotation do
+  let e ← SubExpr.getExpr
+  guard <| e.isAppOfArity ``Filter.EventuallyEq 5
+  guard <| (e.getArg! 2).isAppOfArity ``residual 2
+  let f ← SubExpr.withNaryArg 3 delab
+  let g ← SubExpr.withNaryArg 4 delab
+  `($f =ᵇ $g)
+
+/-- Delaborator printing `Filter.EventuallyEqSet (residual _) s t` as `s =ᵇ t`. -/
+@[app_delab Filter.EventuallyEqSet]
+meta def delabResidualEventuallyEqSet : Delab := whenPPOption Lean.getPPNotation do
+  let e ← SubExpr.getExpr
+  guard <| e.isAppOfArity ``Filter.EventuallyEqSet 4
+  guard <| (e.getArg! 1).isAppOfArity ``residual 2
+  let s ← SubExpr.withNaryArg 2 delab
+  let t ← SubExpr.withNaryArg 3 delab
+  `($s =ᵇ $t)
+
+end delaborators
 
 /-- Notation to say that a property of points in a topological space holds
 almost everywhere in the sense of Baire category. That is, on a residual set. -/
@@ -51,7 +76,7 @@ theorem coborder_mem_residual {s : Set α} (hs : IsLocallyClosed s) : coborder s
   residual_of_dense_open hs.isOpen_coborder dense_coborder
 
 theorem closure_residualEq {s : Set α} (hs : IsLocallyClosed s) : closure s =ᵇ s := by
-  rw [Filter.eventuallyEq_set]
+  rw [Filter.eventuallyEqSet_iff]
   filter_upwards [coborder_mem_residual hs] with x hx
   nth_rewrite 2 [← closure_inter_coborder (s := s)]
   simp [hx]

--- a/Mathlib/Topology/Baire/BaireMeasurable.lean
+++ b/Mathlib/Topology/Baire/BaireMeasurable.lean
@@ -43,23 +43,25 @@ open Lean Lean.PrettyPrinter.Delaborator
 
 /-- Delaborator printing `Filter.EventuallyEq (residual _) f g` as `f =ᵇ g`. -/
 @[app_delab Filter.EventuallyEq]
-meta def delabResidualEventuallyEq : Delab := whenPPOption Lean.getPPNotation do
-  let e ← SubExpr.getExpr
-  guard <| e.isAppOfArity ``Filter.EventuallyEq 5
-  guard <| (e.getArg! 2).isAppOfArity ``residual 2
-  let f ← SubExpr.withNaryArg 3 delab
-  let g ← SubExpr.withNaryArg 4 delab
-  `($f =ᵇ $g)
+meta def delabResidualEventuallyEq : Delab :=
+  whenNotPPOption getPPExplicit <| whenPPOption getPPNotation do
+    let e ← SubExpr.getExpr
+    guard <| e.isAppOfArity ``Filter.EventuallyEq 5
+    guard <| (e.getArg! 2).isAppOfArity ``residual 2
+    let f ← SubExpr.withNaryArg 3 delab
+    let g ← SubExpr.withNaryArg 4 delab
+    `($f =ᵇ $g)
 
 /-- Delaborator printing `Filter.EventuallyEqSet (residual _) s t` as `s =ᵇ t`. -/
 @[app_delab Filter.EventuallyEqSet]
-meta def delabResidualEventuallyEqSet : Delab := whenPPOption Lean.getPPNotation do
-  let e ← SubExpr.getExpr
-  guard <| e.isAppOfArity ``Filter.EventuallyEqSet 4
-  guard <| (e.getArg! 1).isAppOfArity ``residual 2
-  let s ← SubExpr.withNaryArg 2 delab
-  let t ← SubExpr.withNaryArg 3 delab
-  `($s =ᵇ $t)
+meta def delabResidualEventuallyEqSet : Delab :=
+  whenNotPPOption getPPExplicit <| whenPPOption getPPNotation do
+    let e ← SubExpr.getExpr
+    guard <| e.isAppOfArity ``Filter.EventuallyEqSet 4
+    guard <| (e.getArg! 1).isAppOfArity ``residual 2
+    let s ← SubExpr.withNaryArg 2 delab
+    let t ← SubExpr.withNaryArg 3 delab
+    `($s =ᵇ $t)
 
 end delaborators
 

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -246,7 +246,7 @@ equivalent. See also `continuousWithinAt_congr_set'` which requires that the set
 locally away from a point `y`, in a T1 space. -/
 theorem continuousWithinAt_congr_set (h : s =ᶠ[𝓝 x] t) :
     ContinuousWithinAt f s x ↔ ContinuousWithinAt f t x := by
-  simp only [ContinuousWithinAt, nhdsWithin_eq_iff_eventuallyEq.mpr h]
+  simp only [ContinuousWithinAt, nhdsWithin_eq_iff_eventuallyEqSet.mpr h]
 
 theorem ContinuousWithinAt.congr_set (hf : ContinuousWithinAt f s x) (h : s =ᶠ[𝓝 x] t) :
     ContinuousWithinAt f t x :=

--- a/Mathlib/Topology/NhdsWithin.lean
+++ b/Mathlib/Topology/NhdsWithin.lean
@@ -115,23 +115,29 @@ theorem mem_nhdsWithin_iff_eventually {s t : Set α} {x : α} :
     t ∈ 𝓝[s] x ↔ ∀ᶠ y in 𝓝 x, y ∈ s → y ∈ t :=
   eventually_inf_principal
 
-theorem mem_nhdsWithin_iff_eventuallyEq {s t : Set α} {x : α} :
-    t ∈ 𝓝[s] x ↔ s =ᶠ[𝓝 x] (s ∩ t : Set α) := by
-  simp_rw [mem_nhdsWithin_iff_eventually, eventuallyEq_set, mem_inter_iff, iff_self_and]
+theorem mem_nhdsWithin_iff_eventuallyEqSet {s t : Set α} {x : α} :
+    t ∈ 𝓝[s] x ↔ s =ᶠ[𝓝 x] s ∩ t := by
+  simp_rw [mem_nhdsWithin_iff_eventually, eventuallyEqSet_iff, mem_inter_iff, iff_self_and]
+
+@[deprecated (since := "2026-08-14")]
+alias mem_nhdsWithin_iff_eventuallyEq := mem_nhdsWithin_iff_eventuallyEqSet
 
 set_option backward.isDefEq.respectTransparency false in
 lemma mem_nhdsWithin_inter_self {s t : Set α} {x : α} : t ∈ 𝓝[s ∩ t] x :=
-  mem_nhdsWithin_iff_eventuallyEq.mpr <| by simp [inter_assoc]
+  mem_nhdsWithin_iff_eventuallyEqSet.mpr <| by simp [inter_assoc]
 
 set_option backward.isDefEq.respectTransparency false in
 lemma mem_nhdsWithin_self_inter {s t : Set α} {x : α} : s ∈ 𝓝[s ∩ t] x :=
-  mem_nhdsWithin_iff_eventuallyEq.mpr <| by simp [inter_comm s t, inter_assoc]
+  mem_nhdsWithin_iff_eventuallyEqSet.mpr <| by simp [inter_comm s t, inter_assoc]
 
-theorem nhdsWithin_eq_iff_eventuallyEq {s t : Set α} {x : α} : 𝓝[s] x = 𝓝[t] x ↔ s =ᶠ[𝓝 x] t :=
-  set_eventuallyEq_iff_inf_principal.symm
+theorem nhdsWithin_eq_iff_eventuallyEqSet {s t : Set α} {x : α} : 𝓝[s] x = 𝓝[t] x ↔ s =ᶠ[𝓝 x] t :=
+  eventuallyEqSet_iff_inf_principal.symm
+
+@[deprecated (since := "2026-08-14")]
+alias nhdsWithin_eq_iff_eventuallyEq := nhdsWithin_eq_iff_eventuallyEqSet
 
 theorem nhdsWithin_le_iff {s t : Set α} {x : α} : 𝓝[s] x ≤ 𝓝[t] x ↔ t ∈ 𝓝[s] x :=
-  set_eventuallyLE_iff_inf_principal_le.symm.trans set_eventuallyLE_iff_mem_inf_principal
+  eventuallySubset_iff_inf_principal_le.symm.trans eventuallySubset_iff_mem_inf_principal
 
 theorem preimage_nhdsWithin_coinduced' {X : α → β} {s : Set β} {t : Set α} {a : α} (h : a ∈ t)
     (hs : s ∈ @nhds β (.coinduced (fun x : t => X x) inferInstance) (X a)) :
@@ -308,14 +314,20 @@ theorem nhdsWithin_prod [TopologicalSpace β]
   rw [nhdsWithin_prod_eq]
   exact prod_mem_prod hu hv
 
-lemma Filter.EventuallyEq.mem_interior {x : α} {s t : Set α} (hst : s =ᶠ[𝓝 x] t)
+lemma Filter.EventuallyEqSet.mem_interior {x : α} {s t : Set α} (hst : s =ᶠ[𝓝 x] t)
     (h : x ∈ interior s) : x ∈ interior t := by
-  rw [← nhdsWithin_eq_iff_eventuallyEq] at hst
+  rw [← nhdsWithin_eq_iff_eventuallyEqSet] at hst
   simpa [mem_interior_iff_mem_nhds, ← nhdsWithin_eq_nhds, hst] using h
 
-lemma Filter.EventuallyEq.mem_interior_iff {x : α} {s t : Set α} (hst : s =ᶠ[𝓝 x] t) :
+lemma Filter.EventuallyEqSet.mem_interior_iff {x : α} {s t : Set α} (hst : s =ᶠ[𝓝 x] t) :
     x ∈ interior s ↔ x ∈ interior t :=
   ⟨fun h ↦ hst.mem_interior h, fun h ↦ hst.symm.mem_interior h⟩
+
+@[deprecated (since := "2026-08-14")]
+alias Filter.EventuallyEq.mem_interior := Filter.EventuallyEqSet.mem_interior
+
+@[deprecated (since := "2026-08-14")]
+alias Filter.EventuallyEq.mem_interior_iff := Filter.EventuallyEqSet.mem_interior_iff
 
 section Pi
 

--- a/Mathlib/Topology/NhdsWithin.lean
+++ b/Mathlib/Topology/NhdsWithin.lean
@@ -122,11 +122,9 @@ theorem mem_nhdsWithin_iff_eventuallyEqSet {s t : Set α} {x : α} :
 @[deprecated (since := "2026-08-14")]
 alias mem_nhdsWithin_iff_eventuallyEq := mem_nhdsWithin_iff_eventuallyEqSet
 
-set_option backward.isDefEq.respectTransparency false in
 lemma mem_nhdsWithin_inter_self {s t : Set α} {x : α} : t ∈ 𝓝[s ∩ t] x :=
   mem_nhdsWithin_iff_eventuallyEqSet.mpr <| by simp [inter_assoc]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma mem_nhdsWithin_self_inter {s t : Set α} {x : α} : s ∈ 𝓝[s ∩ t] x :=
   mem_nhdsWithin_iff_eventuallyEqSet.mpr <| by simp [inter_comm s t, inter_assoc]
 

--- a/Mathlib/Topology/OpenPartialHomeomorph/Continuity.lean
+++ b/Mathlib/Topology/OpenPartialHomeomorph/Continuity.lean
@@ -121,16 +121,20 @@ theorem eventually_nhdsWithin' {x : X} (p : X → Prop) {s : Set X}
 /-- This lemma is useful in the manifold library in the case that `e` is a chart. It states that
   locally around `e x` the set `e.symm ⁻¹' s` is the same as the set intersected with the target
   of `e` and some other neighborhood of `f x` (which will be the source of a chart on `Z`). -/
-theorem preimage_eventuallyEq_target_inter_preimage_inter {e : OpenPartialHomeomorph X Y}
+theorem preimage_eventuallyEqSet_target_inter_preimage_inter {e : OpenPartialHomeomorph X Y}
     {s : Set X} {t : Set Z} {x : X} {f : X → Z} (hf : ContinuousWithinAt f s x) (hxe : x ∈ e.source)
     (ht : t ∈ 𝓝 (f x)) :
-    e.symm ⁻¹' s =ᶠ[𝓝 (e x)] (e.target ∩ e.symm ⁻¹' (s ∩ f ⁻¹' t) : Set Y) := by
-  rw [eventuallyEq_set, e.eventually_nhds _ hxe]
+    e.symm ⁻¹' s =ᶠ[𝓝 (e x)] e.target ∩ e.symm ⁻¹' (s ∩ f ⁻¹' t) := by
+  rw [eventuallyEqSet_iff, e.eventually_nhds _ hxe]
   filter_upwards [e.open_source.mem_nhds hxe,
     mem_nhdsWithin_iff_eventually.mp (hf.preimage_mem_nhdsWithin ht)]
   intro y hy hyu
   simp_rw [mem_inter_iff, mem_preimage, mem_inter_iff, e.mapsTo hy, true_and, iff_self_and,
     e.left_inv hy, iff_true_intro hyu]
+
+@[deprecated (since := "2026-08-14")]
+alias preimage_eventuallyEq_target_inter_preimage_inter :=
+  preimage_eventuallyEqSet_target_inter_preimage_inter
 
 section Continuity
 

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -621,13 +621,15 @@ theorem insert_mem_nhdsWithin_of_subset_insert [T1Space X] {x y : X} {s t : Set 
   rw [nhdsWithin_insert_of_ne h]
   exact mem_of_superset self_mem_nhdsWithin (subset_insert x s)
 
-lemma eventuallyEq_insert [T1Space X] {s t : Set X} {x y : X} (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
-    (insert x s : Set X) =ᶠ[𝓝 x] (insert x t : Set X) := by
-  simp_rw [eventuallyEq_set] at h ⊢
+lemma eventuallyEqSet_insert [T1Space X] {s t : Set X} {x y : X} (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
+    insert x s =ᶠ[𝓝 x] insert x t := by
+  simp_rw [eventuallyEqSet_iff] at h ⊢
   simp_rw [← union_singleton, ← nhdsWithin_univ, ← compl_union_self {x},
     nhdsWithin_union, eventually_sup, nhdsWithin_singleton,
     eventually_pure, union_singleton, mem_insert_iff, true_or, and_true]
   filter_upwards [nhdsWithin_compl_singleton_le x y h] with y using or_congr (Iff.rfl)
+
+@[deprecated (since := "2026-08-14")] alias eventuallyEq_insert := eventuallyEqSet_insert
 
 @[simp]
 theorem ker_nhds [T1Space X] (x : X) : (𝓝 x).ker = {x} := by
@@ -758,7 +760,7 @@ theorem continuousWithinAt_congr_set' [TopologicalSpace Y] [T1Space X]
     {x : X} {s t : Set X} {f : X → Y} (y : X) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
     ContinuousWithinAt f s x ↔ ContinuousWithinAt f t x := by
   rw [← continuousWithinAt_insert_self (s := s), ← continuousWithinAt_insert_self (s := t)]
-  exact continuousWithinAt_congr_set (eventuallyEq_insert h)
+  exact continuousWithinAt_congr_set (eventuallyEqSet_insert h)
 
 theorem ContinuousWithinAt.eq_const_of_mem_closure [TopologicalSpace Y] [T1Space Y]
     {f : X → Y} {s : Set X} {x : X} {c : Y} (h : ContinuousWithinAt f s x) (hx : x ∈ closure s)


### PR DESCRIPTION
Introduce definitions `EventuallyEqSet`, `EventuallySubset` as the `Set` versions of `EventuallyEq` and `EventuallyLE`. Make the notations `x =ᶠ[l] y`, `x ≤ᶠ[l] y`  `x =ᵐ[μ] y`. elaborate to either the `Set` or functiion version depending on the expected type of the argument.

In mathlib, we currently use the function predicates for sets, which abuses the `Set α := α → Prop` defeq and which will break once we make `Set` a one-field structure.

Generated by Claude Opus, reviewed line by line by myself, with a large amount of manual edits and further Claude prompting to polish the angles.

Assisted-by: Claude Opus 4.8

---

~~Note that some simp lemmas aren't in simp normal form anymore because `(· ∈ someSetConstruction)` simplifies already. We might want to make the above into actual definitions instead of notation to avoid this.~~ EDIT: I have done so

We will want to do the same for `EventuallyConst`, but it is more subtle since it doesn't have notation we could hide the difference in, and I do not know what the correct name for the `Set` definition would be. EDIT: See #43114

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
