### PR TITLE
[Merged by Bors] - ci: run lake cache shadow pipeline with patched lake version with latest features

### DIFF
--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -175,11 +175,16 @@ jobs:
           ./elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
-      # `elan which` below does not auto-install non-pinned toolchains.
+      # `elan which` below does not auto-install non-pinned toolchains. The
+      # uninstall forces a fresh download: pr-release tags are republished in
+      # place, and elan skips toolchains it already has, so a persistent
+      # runner would otherwise keep running a stale binary under that name.
       - name: Install override toolchain
         if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
         shell: bash -euo pipefail {0}
-        run: elan toolchain install "$TOOLCHAIN_OVERRIDE"
+        run: |
+          elan toolchain uninstall "$TOOLCHAIN_OVERRIDE" || true
+          elan toolchain install "$TOOLCHAIN_OVERRIDE"
 
       - name: set toolchain directory
         shell: bash -euo pipefail {0}

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -19,8 +19,9 @@ name: Lake cache shadow (master)
 #     # host than the S3 API endpoint; e.g. an R2 public r2.dev/custom domain).
 #     LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC    — e.g. https://pub-<hash>.r2.dev/<prefix>/artifacts
 #     LAKE_CACHE_REVISION_ENDPOINT_PUBLIC    — e.g. https://pub-<hash>.r2.dev/<prefix>/revisions
-#     # Optional. Default toolchain override for every run, incl. scheduled
-#     # ones (the dispatch input takes precedence). Unset for the stock pipeline.
+#     # Optional. Default toolchain override for every run, including
+#     # scheduled ones; the dispatch input takes precedence. Unset for the
+#     # stock pipeline.
 #     LAKE_SHADOW_TOOLCHAIN_OVERRIDE         — e.g. leanprover/lean4-pr-releases:pr-release-14301
 #
 # Jobs:
@@ -35,18 +36,19 @@ name: Lake cache shadow (master)
 #   report           Post a per-run summary to the `CI admins` Zulip
 #                    stream (topic `Lake cache shadow`).
 #
-# Toolchain override (input `toolchain_override`, else the
-# LAKE_SHADOW_TOOLCHAIN_OVERRIDE variable):
-#   Runs the whole pipeline on an alternate toolchain — e.g. a lean4
-#   pr-release cherry-picking a Lake change onto the pinned release's lineage
-#   (pr-release-14301 = v4.32.0-rc1 + lean4#14235). Its lean must be
-#   behaviorally compatible with the repo pin: mathlib sources build as-is.
+# Toolchain override:
+#   The `toolchain_override` input, or else the LAKE_SHADOW_TOOLCHAIN_OVERRIDE
+#   variable, runs the whole pipeline on an alternate toolchain — e.g. a lean4
+#   pr-release that cherry-picks a Lake change onto the pinned release's
+#   lineage, such as pr-release-14301 = v4.32.0-rc1 + lean4#14235. Its lean
+#   must be behaviorally compatible with the repo pin: mathlib sources build
+#   as-is.
 #
-#   The legacy cache is cold for a non-pinned toolchain (different lean
-#   githash), so hydration is skipped and the build warm-starts from the
-#   previous override run via `lake cache get`; the first run of a toolchain
+#   A non-pinned toolchain has a different lean githash, so the legacy cache
+#   is cold for it: hydration is skipped and the build warm-starts from the
+#   previous override run via `lake cache get`. The first run of a toolchain
 #   generation is a full source build. Override runs are isolated in the
-#   `mathlib4-master-shadow-lakeovr` scope + `analysis-lakeovr/` chain.
+#   `mathlib4-master-shadow-lakeovr` scope and `analysis-lakeovr/` chain.
 
 on:
   schedule:
@@ -73,7 +75,7 @@ on:
       toolchain_override:
         description: >-
           optional Lean toolchain to run the pipeline on instead of the repo
-          pin (see the "Toolchain override" note at the top of this file).
+          pin; see the "Toolchain override" note at the top of this file.
           Empty falls back to the LAKE_SHADOW_TOOLCHAIN_OVERRIDE repository
           variable; the stock pipeline runs when both are empty.
         required: false
@@ -93,8 +95,8 @@ defaults:
 
 env:
   # Effective toolchain override: dispatch input, else repository variable,
-  # else stock. (Workflow-level env can't self-reference, so the two derived
-  # values below repeat the fallback chain.)
+  # else stock. Workflow-level env can't self-reference, so the derived
+  # values below repeat the fallback chain.
   TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE || '' }}
   # Scope prefix for all puts and gets in this workflow. Override runs use an
   # isolated scope + analysis namespace so the stock chain stays clean.
@@ -108,7 +110,7 @@ jobs:
     name: Build + stage
     if: ${{ github.repository == 'leanprover-community/mathlib4' }}
     runs-on: pr
-    # 240 covers a full source build (first run of a toolchain generation).
+    # 240 covers the full source build of a toolchain generation's first run.
     timeout-minutes: ${{ (inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE) && 240 || 90 }}
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
@@ -164,9 +166,9 @@ jobs:
         shell: bash -euo pipefail {0}
         run: |
           mkdir -p pr-branch/.lake/
-          # The landrun ruleset mounts $HOME/.cache/mathlib read-only; landrun
-          # errors out if the path is missing (runs that skip legacy hydration
-          # reach the first landrun step with it absent).
+          # The landrun ruleset mounts $HOME/.cache/mathlib read-only and
+          # errors out if the path is missing. Runs that skip legacy hydration
+          # reach the first landrun step with it absent.
           mkdir -p "$HOME/.cache/mathlib/"
           mkdir -p _work
 
@@ -251,9 +253,10 @@ jobs:
           awk '/^package mathlib where/,/^$/' lakefile.lean
           echo "::endgroup::"
 
-      # Seed Lake's artifact cache from the previous override run (rev from
-      # the analysis chain's `_latest` pointer), so only the changed cone plus
-      # deps compiles. Best-effort: whatever it can't serve builds from source.
+      # Seed Lake's artifact cache from the previous override run, whose rev
+      # comes from the analysis chain's `_latest` pointer; only the changed
+      # cone plus deps compiles. Best-effort: whatever the cache can't serve
+      # builds from source.
       - name: Warm start from shadow scope (toolchain override)
         if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
         shell: bash -euo pipefail {0}

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -19,6 +19,9 @@ name: Lake cache shadow (master)
 #     # host than the S3 API endpoint; e.g. an R2 public r2.dev/custom domain).
 #     LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC    — e.g. https://pub-<hash>.r2.dev/<prefix>/artifacts
 #     LAKE_CACHE_REVISION_ENDPOINT_PUBLIC    — e.g. https://pub-<hash>.r2.dev/<prefix>/revisions
+#     # Optional. Default toolchain override for every run, incl. scheduled
+#     # ones (the dispatch input takes precedence). Unset for the stock pipeline.
+#     LAKE_SHADOW_TOOLCHAIN_OVERRIDE         — e.g. leanprover/lean4-pr-releases:pr-release-14301
 #
 # Jobs:
 #   build_and_stage  Build mathlib + deps with Lake's artifact cache
@@ -32,25 +35,18 @@ name: Lake cache shadow (master)
 #   report           Post a per-run summary to the `CI admins` Zulip
 #                    stream (topic `Lake cache shadow`).
 #
-# Toolchain override (`toolchain_override` input):
-#   Dispatching with `toolchain_override` runs the whole pipeline on that
-#   toolchain instead of the repo pin — e.g. a lean4 pr-release that
-#   cherry-picks a Lake change onto the pinned release's lineage (such as
-#   `leanprover/lean4-pr-releases:pr-release-14301` = v4.32.0-rc1 +
-#   leanprover/lean4#14235). The override toolchain's lean must be
-#   behaviorally compatible with the repo pin, since mathlib sources are
-#   built as-is.
+# Toolchain override (input `toolchain_override`, else the
+# LAKE_SHADOW_TOOLCHAIN_OVERRIDE variable):
+#   Runs the whole pipeline on an alternate toolchain — e.g. a lean4
+#   pr-release cherry-picking a Lake change onto the pinned release's lineage
+#   (pr-release-14301 = v4.32.0-rc1 + lean4#14235). Its lean must be
+#   behaviorally compatible with the repo pin: mathlib sources build as-is.
 #
-#   A non-pinned toolchain has a different lean githash, so both the legacy
-#   cache and the stock shadow scope are cold for it: the legacy hydration
-#   step is skipped and the build warm-starts from the *previous override
-#   run* via `lake cache get` (only the changed cone plus deps compiles).
-#   The first run of a new toolchain generation matches nothing and is a
-#   full source build.
-#
-#   Override runs upload under the isolated `mathlib4-master-shadow-lakeovr`
-#   scope and keep their carryover chain in `analysis-lakeovr/`, so they never
-#   pollute the stock daily chain (and vice versa).
+#   The legacy cache is cold for a non-pinned toolchain (different lean
+#   githash), so hydration is skipped and the build warm-starts from the
+#   previous override run via `lake cache get`; the first run of a toolchain
+#   generation is a full source build. Override runs are isolated in the
+#   `mathlib4-master-shadow-lakeovr` scope + `analysis-lakeovr/` chain.
 
 on:
   schedule:
@@ -77,9 +73,9 @@ on:
       toolchain_override:
         description: >-
           optional Lean toolchain to run the pipeline on instead of the repo
-          pin (see the "Toolchain override" note at the top of this file),
-          e.g. leanprover/lean4-pr-releases:pr-release-14301. Leave empty for
-          the stock pipeline.
+          pin (see the "Toolchain override" note at the top of this file).
+          Empty falls back to the LAKE_SHADOW_TOOLCHAIN_OVERRIDE repository
+          variable; the stock pipeline runs when both are empty.
         required: false
         type: string
         default: ''
@@ -96,11 +92,14 @@ defaults:
     shell: bash -euo pipefail {0}
 
 env:
-  # Scope prefix for all puts and gets in this workflow. Namespaces the
-  # workflow's artifacts within the cache bucket. Toolchain-override runs use
-  # an isolated scope + analysis namespace so the stock daily chain stays clean.
-  SHADOW_SCOPE: ${{ inputs.toolchain_override != '' && 'mathlib4-master-shadow-lakeovr' || 'mathlib4-master-shadow' }}
-  ANALYSIS_NS: ${{ inputs.toolchain_override != '' && 'analysis-lakeovr' || 'analysis' }}
+  # Effective toolchain override: dispatch input, else repository variable,
+  # else stock. (Workflow-level env can't self-reference, so the two derived
+  # values below repeat the fallback chain.)
+  TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE || '' }}
+  # Scope prefix for all puts and gets in this workflow. Override runs use an
+  # isolated scope + analysis namespace so the stock chain stays clean.
+  SHADOW_SCOPE: ${{ (inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE) && 'mathlib4-master-shadow-lakeovr' || 'mathlib4-master-shadow' }}
+  ANALYSIS_NS: ${{ (inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE) && 'analysis-lakeovr' || 'analysis' }}
   # NOTE: STAGE_TARGETS is set per-job (not here) from the `targets` input, so
   # it can be overridden per dispatch — see the `build_and_stage`/`consume` env.
 
@@ -109,9 +108,8 @@ jobs:
     name: Build + stage
     if: ${{ github.repository == 'leanprover-community/mathlib4' }}
     runs-on: pr
-    # A toolchain-override run compiles everything its warm start can't serve —
-    # up to a full source build on the first run of a new toolchain generation.
-    timeout-minutes: ${{ inputs.toolchain_override != '' && 240 || 90 }}
+    # 240 covers a full source build (first run of a toolchain generation).
+    timeout-minutes: ${{ (inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE) && 240 || 90 }}
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
       toolchain: ${{ steps.resolve.outputs.toolchain }}
@@ -146,10 +144,8 @@ jobs:
       # Before the resolve step, so the run's recorded toolchain is the one
       # actually used.
       - name: Apply toolchain override
-        if: ${{ inputs.toolchain_override != '' }}
+        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
         shell: bash -euo pipefail {0}
-        env:
-          TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override }}
         run: |
           printf '%s\n' "$TOOLCHAIN_OVERRIDE" > pr-branch/lean-toolchain
           echo "::notice::toolchain override: $TOOLCHAIN_OVERRIDE"
@@ -182,13 +178,10 @@ jobs:
           ./elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
-      # `elan which` below does not auto-install, so a non-pinned toolchain
-      # must be installed explicitly.
+      # `elan which` below does not auto-install non-pinned toolchains.
       - name: Install override toolchain
-        if: ${{ inputs.toolchain_override != '' }}
+        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
         shell: bash -euo pipefail {0}
-        env:
-          TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override }}
         run: elan toolchain install "$TOOLCHAIN_OVERRIDE"
 
       - name: set toolchain directory
@@ -224,11 +217,10 @@ jobs:
           cd pr-branch
           lake env
 
-      # The legacy cache is keyed to the repo's pinned toolchain, so it has
-      # nothing for an override toolchain — skip it there (the warm-start
-      # step below takes its place).
+      # The legacy cache is keyed to the repo's pinned toolchain — cold for an
+      # override toolchain, where the warm-start step below takes its place.
       - name: Hydrate .lake/build via legacy cache
-        if: ${{ inputs.toolchain_override == '' }}
+        if: ${{ env.TOOLCHAIN_OVERRIDE == '' }}
         shell: bash -euo pipefail {0}
         run: |
           cd pr-branch
@@ -259,14 +251,11 @@ jobs:
           awk '/^package mathlib where/,/^$/' lakefile.lean
           echo "::endgroup::"
 
-      # Warm start for override runs: seed Lake's artifact cache from the
-      # previous override run's revision manifest, so the build only compiles
-      # the changed cone (plus deps, which Lake never caches). The previous
-      # rev comes from the analysis chain's `_latest` pointer. Best-effort:
-      # with no prior run — or a fresh toolchain generation whose input
-      # hashes match nothing — the build falls back to compiling from source.
+      # Seed Lake's artifact cache from the previous override run (rev from
+      # the analysis chain's `_latest` pointer), so only the changed cone plus
+      # deps compiles. Best-effort: whatever it can't serve builds from source.
       - name: Warm start from shadow scope (toolchain override)
-        if: ${{ inputs.toolchain_override != '' }}
+        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
         shell: bash -euo pipefail {0}
         env:
           LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
@@ -499,9 +488,7 @@ jobs:
           fetch-depth: 1
 
       - name: Apply toolchain override
-        if: ${{ inputs.toolchain_override != '' }}
-        env:
-          TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override }}
+        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
         run: printf '%s\n' "$TOOLCHAIN_OVERRIDE" > pr-branch/lean-toolchain
 
       - name: install elan
@@ -512,9 +499,7 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - name: Install override toolchain
-        if: ${{ inputs.toolchain_override != '' }}
-        env:
-          TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override }}
+        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
         run: elan toolchain install "$TOOLCHAIN_OVERRIDE"
 
       - name: download dependencies
@@ -615,7 +600,6 @@ jobs:
           CACHE_HEALTH: ${{ needs.consume.outputs.cache_health }}
           SHA: ${{ needs.build_and_stage.outputs.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override }}
         run: |
           emoji() {
             case "$1" in

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -38,17 +38,19 @@ name: Lake cache shadow (master)
 #
 # Toolchain override:
 #   The `toolchain_override` input, or else the LAKE_SHADOW_TOOLCHAIN_OVERRIDE
-#   variable, runs the whole pipeline on an alternate toolchain — e.g. a lean4
+#   variable, swaps the toolchain the whole pipeline runs on — e.g. a lean4
 #   pr-release that cherry-picks a Lake change onto the pinned release's
 #   lineage, such as pr-release-14301 = v4.32.0-rc1 + lean4#14235. Its lean
 #   must be behaviorally compatible with the repo pin: mathlib sources build
 #   as-is.
 #
-#   A non-pinned toolchain has a different lean githash, so the legacy cache
-#   is cold for it: hydration is skipped and the build warm-starts from the
-#   previous override run via `lake cache get`. The first run of a toolchain
-#   generation is a full source build. Override runs are isolated in the
-#   `mathlib4-master-shadow-lakeovr` scope and `analysis-lakeovr/` chain.
+#   All runs share one scope and one carryover chain: module input hashes
+#   incorporate the toolchain, so runs on different toolchains never resolve
+#   each other's artifacts, and byte-identical content dedups. Every run
+#   warm-starts from the previous run via `lake cache get`; a toolchain
+#   switch misses everything and shows up once as a full-turnover source
+#   build. The legacy cache covers only the repo pin, so override runs skip
+#   hydration.
 
 on:
   schedule:
@@ -95,13 +97,11 @@ defaults:
 
 env:
   # Effective toolchain override: dispatch input, else repository variable,
-  # else stock. Workflow-level env can't self-reference, so the derived
-  # values below repeat the fallback chain.
+  # else stock.
   TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE || '' }}
-  # Scope prefix for all puts and gets in this workflow. Override runs use an
-  # isolated scope + analysis namespace so the stock chain stays clean.
-  SHADOW_SCOPE: ${{ (inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE) && 'mathlib4-master-shadow-lakeovr' || 'mathlib4-master-shadow' }}
-  ANALYSIS_NS: ${{ (inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE) && 'analysis-lakeovr' || 'analysis' }}
+  # Scope prefix for all puts and gets in this workflow. Namespaces the
+  # workflow's artifacts within the cache bucket.
+  SHADOW_SCOPE: mathlib4-master-shadow
   # NOTE: STAGE_TARGETS is set per-job (not here) from the `targets` input, so
   # it can be overridden per dispatch — see the `build_and_stage`/`consume` env.
 
@@ -253,25 +253,24 @@ jobs:
           awk '/^package mathlib where/,/^$/' lakefile.lean
           echo "::endgroup::"
 
-      # Seed Lake's artifact cache from the previous override run, whose rev
-      # comes from the analysis chain's `_latest` pointer; only the changed
-      # cone plus deps compiles. Best-effort: whatever the cache can't serve
-      # builds from source.
-      - name: Warm start from shadow scope (toolchain override)
-        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
+      # Seed Lake's artifact cache from the previous run, whose rev comes from
+      # the analysis chain's `_latest` pointer. Only content the cache can't
+      # serve is packed or built; a run on a different toolchain than the
+      # previous one misses everything and proceeds from source.
+      - name: Warm start from shadow scope
         shell: bash -euo pipefail {0}
         env:
           LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
         run: |
-          prev="$(curl -fsS "${LAKE_CACHE_ARTIFACT_ENDPOINT%/artifacts}/${ANALYSIS_NS}/_latest.txt" 2>/dev/null || true)"
+          prev="$(curl -fsS "${LAKE_CACHE_ARTIFACT_ENDPOINT%/artifacts}/analysis/_latest.txt" 2>/dev/null || true)"
           if [ -z "$prev" ]; then
-            echo "::notice::no prior override run recorded; building from source"
+            echo "::notice::no prior run recorded; proceeding without a warm start"
             exit 0
           fi
           cd pr-branch
           lake cache get --scope="$SHADOW_SCOPE" --rev="$prev" \
-            || echo "::warning::warm start from rev ${prev:0:12} failed; building from source"
+            || echo "::warning::warm start from rev ${prev:0:12} failed; proceeding without it"
 
       # Incremental build: with the legacy cache having hydrated .lake/build/
       # and the lakefile patched, Lake's pipeline runs to pack/cache any
@@ -406,7 +405,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          base="${AUTH%/artifacts}/${ANALYSIS_NS}"
+          base="${AUTH%/artifacts}/analysis"
           sha="${{ needs.build_and_stage.outputs.sha }}"
           sig=(--aws-sigv4 aws:amz:auto:s3 --user "$LAKE_CACHE_KEY")
           # grep exits 1 on no match (handled by the total==0 branch); tolerate it under pipefail.
@@ -616,7 +615,7 @@ jobs:
             echo "msg<<MSG_EOF"
             echo "**Lake cache shadow** ([run](${RUN_URL}), rev \`${SHA:0:12}\`)"
             if [ -n "${TOOLCHAIN_OVERRIDE:-}" ]; then
-              echo "🧪 toolchain override: \`${TOOLCHAIN_OVERRIDE}\` (scope \`${SHADOW_SCOPE}\`)"
+              echo "🧪 toolchain override: \`${TOOLCHAIN_OVERRIDE}\`"
             fi
             echo ""
             echo "- $(emoji "$BUILD") build_and_stage: \`$BUILD\`"

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -38,8 +38,10 @@ name: Lake cache shadow (master)
 #
 # Toolchain override:
 #   The `toolchain_override` input, or else the LAKE_SHADOW_TOOLCHAIN_OVERRIDE
-#   variable, swaps the toolchain the whole pipeline runs on. Its lean must be
-#   behaviorally compatible with the repo pin, e.g. a Lake change
+#   variable, swaps the toolchain the whole pipeline runs on: build_and_stage
+#   resolves it into its `toolchain` output, and the downstream jobs stamp
+#   that output into their checkouts, so every job runs the same lake. Its
+#   lean must be behaviorally compatible with the repo pin, e.g. a Lake change
 #   cherry-picked onto the pinned release's lineage as a lean4 pr-release.
 #   Input hashes incorporate the toolchain, so all runs safely share one
 #   scope and carryover chain; a toolchain switch misses the legacy cache and
@@ -343,12 +345,20 @@ jobs:
       LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
       LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
     steps:
-      - name: Checkout mathlib (for lean-toolchain pin)
+      - name: Checkout mathlib (workspace for put-staged)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.build_and_stage.outputs.sha }}
           path: pr-branch
           fetch-depth: 1
+
+      # Stamp the effective toolchain from build_and_stage's resolve step, so
+      # put-staged runs the same lake that produced the staging; the elan
+      # proxy auto-installs it on first use.
+      - name: Pin effective toolchain
+        env:
+          EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
+        run: printf '%s\n' "$EFFECTIVE_TOOLCHAIN" > pr-branch/lean-toolchain
 
       - name: install elan + matching lake
         run: |
@@ -482,9 +492,13 @@ jobs:
           path: pr-branch
           fetch-depth: 1
 
-      - name: Apply toolchain override
-        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
-        run: printf '%s\n' "$TOOLCHAIN_OVERRIDE" > pr-branch/lean-toolchain
+      # Stamp the effective toolchain from build_and_stage's resolve step, so
+      # the replay runs the same lake that built the artifacts; the elan
+      # proxy auto-installs it on first use.
+      - name: Pin effective toolchain
+        env:
+          EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
+        run: printf '%s\n' "$EFFECTIVE_TOOLCHAIN" > pr-branch/lean-toolchain
 
       - name: install elan
         run: |
@@ -492,10 +506,6 @@ jobs:
           chmod +x elan-init.sh
           ./elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
-
-      - name: Install override toolchain
-        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
-        run: elan toolchain install "$TOOLCHAIN_OVERRIDE"
 
       - name: download dependencies
         run: |

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -32,14 +32,22 @@ name: Lake cache shadow (master)
 #   report           Post a per-run summary to the `CI admins` Zulip
 #                    stream (topic `Lake cache shadow`).
 #
-# Lake override (`lake_ref` input):
-#   Dispatching with `lake_ref` runs the whole pipeline with a patched `lake`
-#   built from that ref of marcelolynch/lean4 (src/lake must be a standalone
-#   Lake package pinned to this repo's toolchain, e.g. branch
-#   `lake-ltar-strip-rc1` = v4.32.0-rc1 + leanprover/lean4#14235). The
-#   override lake is compiled with the stock pinned toolchain, so module
-#   traces stay byte-compatible with the hydrated tree; `leantar` is upgraded
-#   to >= 0.1.20 via a shadow sysroot (lean4#14235 needs its `-s`/`-j` flags).
+# Toolchain override (`toolchain_override` input):
+#   Dispatching with `toolchain_override` runs the whole pipeline on that
+#   toolchain instead of the repo pin — e.g. a lean4 pr-release that
+#   cherry-picks a Lake change onto the pinned release's lineage (such as
+#   `leanprover/lean4-pr-releases:pr-release-14301` = v4.32.0-rc1 +
+#   leanprover/lean4#14235). The override toolchain's lean must be
+#   behaviorally compatible with the repo pin, since mathlib sources are
+#   built as-is.
+#
+#   A non-pinned toolchain has a different lean githash, so both the legacy
+#   cache and the stock shadow scope are cold for it: the legacy hydration
+#   step is skipped and the build warm-starts from the *previous override
+#   run* via `lake cache get` (only the changed cone plus deps compiles).
+#   The first run of a new toolchain generation matches nothing and is a
+#   full source build.
+#
 #   Override runs upload under the isolated `mathlib4-master-shadow-lakeovr`
 #   scope and keep their carryover chain in `analysis-lakeovr/`, so they never
 #   pollute the stock daily chain (and vice versa).
@@ -66,11 +74,12 @@ on:
         #   Mathlib.Topology.Basic Mathlib.Combinatorics.SimpleGraph.Basic Mathlib.RingTheory.Ideal.Basic
         # or add `Archive Counterexamples` to also shadow those libraries.
         default: Mathlib
-      lake_ref:
+      toolchain_override:
         description: >-
-          optional ref of marcelolynch/lean4 to build `lake` from (see the
-          "Lake override" note at the top of this file). Leave empty for the
-          stock pipeline.
+          optional Lean toolchain to run the pipeline on instead of the repo
+          pin (see the "Toolchain override" note at the top of this file),
+          e.g. leanprover/lean4-pr-releases:pr-release-14301. Leave empty for
+          the stock pipeline.
         required: false
         type: string
         default: ''
@@ -88,10 +97,10 @@ defaults:
 
 env:
   # Scope prefix for all puts and gets in this workflow. Namespaces the
-  # workflow's artifacts within the cache bucket. Lake-override runs use an
-  # isolated scope + analysis namespace so the stock daily chain stays clean.
-  SHADOW_SCOPE: ${{ inputs.lake_ref != '' && 'mathlib4-master-shadow-lakeovr' || 'mathlib4-master-shadow' }}
-  ANALYSIS_NS: ${{ inputs.lake_ref != '' && 'analysis-lakeovr' || 'analysis' }}
+  # workflow's artifacts within the cache bucket. Toolchain-override runs use
+  # an isolated scope + analysis namespace so the stock daily chain stays clean.
+  SHADOW_SCOPE: ${{ inputs.toolchain_override != '' && 'mathlib4-master-shadow-lakeovr' || 'mathlib4-master-shadow' }}
+  ANALYSIS_NS: ${{ inputs.toolchain_override != '' && 'analysis-lakeovr' || 'analysis' }}
   # NOTE: STAGE_TARGETS is set per-job (not here) from the `targets` input, so
   # it can be overridden per dispatch — see the `build_and_stage`/`consume` env.
 
@@ -100,7 +109,9 @@ jobs:
     name: Build + stage
     if: ${{ github.repository == 'leanprover-community/mathlib4' }}
     runs-on: pr
-    timeout-minutes: 90
+    # A toolchain-override run compiles everything its warm start can't serve —
+    # up to a full source build on the first run of a new toolchain generation.
+    timeout-minutes: ${{ inputs.toolchain_override != '' && 240 || 90 }}
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
       toolchain: ${{ steps.resolve.outputs.toolchain }}
@@ -132,6 +143,17 @@ jobs:
           fetch-depth: 2
           path: pr-branch
 
+      # Before the resolve step, so the run's recorded toolchain is the one
+      # actually used.
+      - name: Apply toolchain override
+        if: ${{ inputs.toolchain_override != '' }}
+        shell: bash -euo pipefail {0}
+        env:
+          TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override }}
+        run: |
+          printf '%s\n' "$TOOLCHAIN_OVERRIDE" > pr-branch/lean-toolchain
+          echo "::notice::toolchain override: $TOOLCHAIN_OVERRIDE"
+
       - name: Resolve sha & toolchain
         id: resolve
         shell: bash -euo pipefail {0}
@@ -156,6 +178,15 @@ jobs:
           chmod +x elan-init.sh
           ./elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      # `elan which` below does not auto-install, so a non-pinned toolchain
+      # must be installed explicitly.
+      - name: Install override toolchain
+        if: ${{ inputs.toolchain_override != '' }}
+        shell: bash -euo pipefail {0}
+        env:
+          TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override }}
+        run: elan toolchain install "$TOOLCHAIN_OVERRIDE"
 
       - name: set toolchain directory
         shell: bash -euo pipefail {0}
@@ -184,77 +215,17 @@ jobs:
           cd tools-branch
           lake build cache
 
-      # --- Lake override (only when the `lake_ref` input is set) -------------
-      # Interposes a patched `lake` for every `lake` invocation below, via a
-      # PATH shim. The shim also points LEAN_SYSROOT at a shadow sysroot (the
-      # pinned toolchain with `leantar` upgraded), so no landrun --env plumbing
-      # changes are needed and scheduled stock runs are untouched.
-      - name: Checkout lake override source
-        if: ${{ inputs.lake_ref != '' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: marcelolynch/lean4
-          ref: ${{ inputs.lake_ref }}
-          path: lake-override
-          sparse-checkout: src/lake
-          fetch-depth: 1
-
-      - name: Build override lake + shadow sysroot
-        if: ${{ inputs.lake_ref != '' }}
-        shell: bash -euo pipefail {0}
-        env:
-          LEANTAR_VERSION: v0.1.20
-        run: |
-          # The override lake must be built with (and run against) the repo's
-          # pinned toolchain, or module traces would not match the tree the
-          # legacy cache hydrates.
-          PIN="$(tr -d '[:space:]' < pr-branch/lean-toolchain)"
-          OVR="$(tr -d '[:space:]' < lake-override/src/lake/lean-toolchain)"
-          if [ "$PIN" != "$OVR" ]; then
-            echo "::error::lake override pins toolchain '$OVR' but the repo pins '$PIN'"
-            exit 1
-          fi
-          (cd lake-override/src/lake && lake build)
-          LAKE_BIN="$PWD/lake-override/src/lake/.lake/build/bin/lake"
-          "$LAKE_BIN" --version
-          # Shadow sysroot: the pinned toolchain with only bin/leantar swapped.
-          # Lake resolves leantar from the *Lean* install, so the override
-          # binary sees the new leantar through LEAN_SYSROOT.
-          TOOLCHAIN_DIR="$(cd pr-branch && dirname "$(dirname "$(elan which lake)")")"
-          SHADOW="$PWD/shadow-sysroot"
-          mkdir -p "$SHADOW/bin"
-          for e in "$TOOLCHAIN_DIR"/*; do
-            [ "$(basename "$e")" = bin ] || ln -s "$e" "$SHADOW/$(basename "$e")"
-          done
-          for f in "$TOOLCHAIN_DIR"/bin/*; do
-            ln -s "$f" "$SHADOW/bin/$(basename "$f")"
-          done
-          rm "$SHADOW/bin/leantar"
-          case "$(uname -m)" in
-            x86_64) TRIPLE=x86_64-unknown-linux-musl ;;
-            aarch64) TRIPLE=aarch64-unknown-linux-musl ;;
-            *) echo "::error::unsupported arch $(uname -m)"; exit 1 ;;
-          esac
-          curl -sSfL -o /tmp/leantar.tar.gz \
-            "https://github.com/digama0/leangz/releases/download/${LEANTAR_VERSION}/leantar-${LEANTAR_VERSION}-${TRIPLE}.tar.gz"
-          tar -xzf /tmp/leantar.tar.gz -C /tmp
-          install -m755 "/tmp/leantar-${LEANTAR_VERSION}-${TRIPLE}/leantar" "$SHADOW/bin/leantar"
-          # PATH shim: `lake` resolves to the override binary, which detects
-          # the (non-collocated) Lean install through LEAN_SYSROOT.
-          SHIM="$PWD/lake-override-bin"
-          mkdir -p "$SHIM"
-          printf '#!/usr/bin/env bash\nexport LEAN_SYSROOT="%s"\nexec "%s" "$@"\n' "$SHADOW" "$LAKE_BIN" > "$SHIM/lake"
-          chmod +x "$SHIM/lake"
-          echo "$SHIM" >> "$GITHUB_PATH"
-          echo "::notice::lake override active: $("$LAKE_BIN" --version); leantar $("$SHADOW/bin/leantar" --version)"
-
       - name: download dependencies
         shell: landrun --unrestricted-network --rox /etc --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
         run: |
           cd pr-branch
           lake env
 
+      # The legacy cache is keyed to the repo's pinned toolchain, so it has
+      # nothing for an override toolchain — skip it there (the warm-start
+      # step below takes its place).
       - name: Hydrate .lake/build via legacy cache
+        if: ${{ inputs.toolchain_override == '' }}
         shell: bash -euo pipefail {0}
         run: |
           cd pr-branch
@@ -284,6 +255,28 @@ jobs:
           echo "::group::patched package block"
           awk '/^package mathlib where/,/^$/' lakefile.lean
           echo "::endgroup::"
+
+      # Warm start for override runs: seed Lake's artifact cache from the
+      # previous override run's revision manifest, so the build only compiles
+      # the changed cone (plus deps, which Lake never caches). The previous
+      # rev comes from the analysis chain's `_latest` pointer. Best-effort:
+      # with no prior run — or a fresh toolchain generation whose input
+      # hashes match nothing — the build falls back to compiling from source.
+      - name: Warm start from shadow scope (toolchain override)
+        if: ${{ inputs.toolchain_override != '' }}
+        shell: bash -euo pipefail {0}
+        env:
+          LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+          LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: |
+          prev="$(curl -fsS "${LAKE_CACHE_ARTIFACT_ENDPOINT%/artifacts}/${ANALYSIS_NS}/_latest.txt" 2>/dev/null || true)"
+          if [ -z "$prev" ]; then
+            echo "::notice::no prior override run recorded; building from source"
+            exit 0
+          fi
+          cd pr-branch
+          lake cache get --scope="$SHADOW_SCOPE" --rev="$prev" \
+            || echo "::warning::warm start from rev ${prev:0:12} failed; building from source"
 
       # Incremental build: with the legacy cache having hydrated .lake/build/
       # and the lakefile patched, Lake's pipeline runs to pack/cache any
@@ -482,8 +475,6 @@ jobs:
     needs: [build_and_stage, upload]
     if: ${{ github.repository == 'leanprover-community/mathlib4' }}
     runs-on: ubuntu-latest
-    # 90 rather than 60: a lake-override run spends ~10-15 extra minutes
-    # building the override lake before the consume proper starts.
     timeout-minutes: 90
     outputs:
       cache_health: ${{ steps.cachehealth.outputs.health }}
@@ -504,6 +495,12 @@ jobs:
           path: pr-branch
           fetch-depth: 1
 
+      - name: Apply toolchain override
+        if: ${{ inputs.toolchain_override != '' }}
+        env:
+          TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override }}
+        run: printf '%s\n' "$TOOLCHAIN_OVERRIDE" > pr-branch/lean-toolchain
+
       - name: install elan
         run: |
           curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
@@ -511,61 +508,11 @@ jobs:
           ./elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
-      # --- Lake override (only when the `lake_ref` input is set) -------------
-      # Same recipe as build_and_stage: the override binary is arch/glibc
-      # sensitive, so each job builds its own rather than sharing an artifact.
-      - name: Checkout lake override source
-        if: ${{ inputs.lake_ref != '' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: marcelolynch/lean4
-          ref: ${{ inputs.lake_ref }}
-          path: lake-override
-          sparse-checkout: src/lake
-          fetch-depth: 1
-
-      - name: Build override lake + shadow sysroot
-        if: ${{ inputs.lake_ref != '' }}
+      - name: Install override toolchain
+        if: ${{ inputs.toolchain_override != '' }}
         env:
-          LEANTAR_VERSION: v0.1.20
-        run: |
-          PIN="$(tr -d '[:space:]' < pr-branch/lean-toolchain)"
-          OVR="$(tr -d '[:space:]' < lake-override/src/lake/lean-toolchain)"
-          if [ "$PIN" != "$OVR" ]; then
-            echo "::error::lake override pins toolchain '$OVR' but the repo pins '$PIN'"
-            exit 1
-          fi
-          (cd lake-override/src/lake && lake build)
-          LAKE_BIN="$PWD/lake-override/src/lake/.lake/build/bin/lake"
-          "$LAKE_BIN" --version
-          TOOLCHAIN_DIR="$(cd pr-branch && dirname "$(dirname "$(elan which lake)")")"
-          SHADOW="$PWD/shadow-sysroot"
-          mkdir -p "$SHADOW/bin"
-          for e in "$TOOLCHAIN_DIR"/*; do
-            [ "$(basename "$e")" = bin ] || ln -s "$e" "$SHADOW/$(basename "$e")"
-          done
-          for f in "$TOOLCHAIN_DIR"/bin/*; do
-            ln -s "$f" "$SHADOW/bin/$(basename "$f")"
-          done
-          rm "$SHADOW/bin/leantar"
-          case "$(uname -m)" in
-            x86_64) TRIPLE=x86_64-unknown-linux-musl ;;
-            aarch64) TRIPLE=aarch64-unknown-linux-musl ;;
-            *) echo "::error::unsupported arch $(uname -m)"; exit 1 ;;
-          esac
-          curl -sSfL -o /tmp/leantar.tar.gz \
-            "https://github.com/digama0/leangz/releases/download/${LEANTAR_VERSION}/leantar-${LEANTAR_VERSION}-${TRIPLE}.tar.gz"
-          tar -xzf /tmp/leantar.tar.gz -C /tmp
-          install -m755 "/tmp/leantar-${LEANTAR_VERSION}-${TRIPLE}/leantar" "$SHADOW/bin/leantar"
-          SHIM="$PWD/lake-override-bin"
-          mkdir -p "$SHIM"
-          printf '#!/usr/bin/env bash\nexport LEAN_SYSROOT="%s"\nexec "%s" "$@"\n' "$SHADOW" "$LAKE_BIN" > "$SHIM/lake"
-          chmod +x "$SHIM/lake"
-          echo "$SHIM" >> "$GITHUB_PATH"
-          # The override lake is invoked directly (no elan shim), so it would
-          # not see the per-toolchain default cache dir; pin one explicitly.
-          echo "LAKE_CACHE_DIR=$HOME/.cache/lake-shadow" >> "$GITHUB_ENV"
-          echo "::notice::lake override active: $("$LAKE_BIN" --version); leantar $("$SHADOW/bin/leantar" --version)"
+          TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override }}
+        run: elan toolchain install "$TOOLCHAIN_OVERRIDE"
 
       - name: download dependencies
         run: |
@@ -598,10 +545,9 @@ jobs:
             --rev="${{ needs.build_and_stage.outputs.sha }}"
           # Artifacts fetched here = the root-package outputs served from cache
           # (a non-verbose build replays them silently). Hand the count to the
-          # provenance step. LAKE_CACHE_DIR is set only by a lake-override run;
-          # stock runs use Lake's per-toolchain default under ~/.elan.
+          # provenance step.
           # `|| true`: an informational count must not trip pipefail if find fails.
-          FETCHED=$(find "${LAKE_CACHE_DIR:-$HOME/.elan/toolchains}" -name '*.ltar' 2>/dev/null | wc -l || true)
+          FETCHED=$(find ~/.elan/toolchains -name '*.ltar' 2>/dev/null | wc -l || true)
           echo "ltar count after get: $FETCHED"
           echo "FETCHED_ARTIFACTS=$FETCHED" >> "$GITHUB_ENV"
 
@@ -666,7 +612,7 @@ jobs:
           CACHE_HEALTH: ${{ needs.consume.outputs.cache_health }}
           SHA: ${{ needs.build_and_stage.outputs.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          LAKE_REF: ${{ inputs.lake_ref }}
+          TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override }}
         run: |
           emoji() {
             case "$1" in
@@ -679,8 +625,8 @@ jobs:
           {
             echo "msg<<MSG_EOF"
             echo "**Lake cache shadow** ([run](${RUN_URL}), rev \`${SHA:0:12}\`)"
-            if [ -n "${LAKE_REF:-}" ]; then
-              echo "🧪 lake override: \`${LAKE_REF}\` (scope \`${SHADOW_SCOPE}\`)"
+            if [ -n "${TOOLCHAIN_OVERRIDE:-}" ]; then
+              echo "🧪 toolchain override: \`${TOOLCHAIN_OVERRIDE}\` (scope \`${SHADOW_SCOPE}\`)"
             fi
             echo ""
             echo "- $(emoji "$BUILD") build_and_stage: \`$BUILD\`"

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -29,7 +29,8 @@ name: Lake cache shadow (master)
 #                    enabled, then stage the resulting .ltar files.
 #   upload           Push staged artifacts to the cache bucket via
 #                    `lake cache put-staged`, then record a per-run manifest
-#                    under cache/analysis/ and report carryover vs the prior run.
+#                    under cache/analysis/<toolchain-slug>/ and report
+#                    carryover vs the prior run on the same toolchain.
 #   consume          Fresh checkout, fetch from the cache bucket via
 #                    `lake cache get`, run `lake build` against the
 #                    rehydrated cache, then verify with `--rehash`.
@@ -44,8 +45,12 @@ name: Lake cache shadow (master)
 #   lean must be behaviorally compatible with the repo pin, e.g. a Lake change
 #   cherry-picked onto the pinned release's lineage as a lean4 pr-release.
 #   Input hashes incorporate the toolchain, so all runs safely share one
-#   scope and carryover chain; a toolchain switch misses the legacy cache and
-#   all prior artifacts, costing one full-turnover source build.
+#   artifact scope. The analysis chain (warm-start pointer + carryover
+#   manifests) is keyed per toolchain under analysis/<slug>/, so pinned and
+#   override runs each warm-start from and diff against their own lineage.
+#   A toolchain's first run — or a pr-release tag republished under the same
+#   name — misses the legacy cache and all prior artifacts, costing one
+#   full-turnover source build.
 
 on:
   schedule:
@@ -253,19 +258,22 @@ jobs:
           awk '/^package mathlib where/,/^$/' lakefile.lean
           echo "::endgroup::"
 
-      # Seed Lake's artifact cache from the previous run, whose rev comes from
-      # the analysis chain's `_latest` pointer. Only content the cache can't
-      # serve is packed or built; a run on a different toolchain than the
-      # previous one misses everything and proceeds from source.
+      # Seed Lake's artifact cache from the previous run on the same
+      # toolchain, whose rev comes from that toolchain's analysis chain
+      # (`analysis/<slug>/_latest.txt`). Only content the cache can't serve
+      # is packed or built; a toolchain's first run has no chain yet and
+      # proceeds from source.
       - name: Warm start from shadow scope
         shell: bash -euo pipefail {0}
         env:
           LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
         run: |
-          prev="$(curl -fsS "${LAKE_CACHE_ARTIFACT_ENDPOINT%/artifacts}/analysis/_latest.txt" 2>/dev/null || true)"
+          # Must mirror the slug in the upload job's carryover step.
+          slug="$(printf %s "$(cat pr-branch/lean-toolchain)" | tr -c 'A-Za-z0-9._-' '-')"
+          prev="$(curl -fsS "${LAKE_CACHE_ARTIFACT_ENDPOINT%/artifacts}/analysis/$slug/_latest.txt" 2>/dev/null || true)"
           if [ -z "$prev" ]; then
-            echo "::notice::no prior run recorded; proceeding without a warm start"
+            echo "::notice::no prior run recorded for chain $slug; proceeding without a warm start"
             exit 0
           fi
           cd pr-branch
@@ -399,7 +407,8 @@ jobs:
             --toolchain="${{ needs.build_and_stage.outputs.toolchain }}" 2>&1 | tee /tmp/put.log
 
       # Cache carryover analysis: diff this run's uploaded artifact set against
-      # the previous run's, using a tiny per-run manifest kept in the bucket.
+      # the previous run's on the same toolchain, via tiny per-run manifests
+      # kept in the bucket under the toolchain's analysis/<slug>/ prefix.
       # Here:
       #   carryover = artifacts also present last run;
       #   new = this run's churn (≈ how much Mathlib changed since the last build).
@@ -412,8 +421,11 @@ jobs:
           AUTH: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
         run: |
-          base="${AUTH%/artifacts}/analysis"
+          # Must mirror the slug in build_and_stage's warm-start step.
+          slug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
+          base="${AUTH%/artifacts}/analysis/$slug"
           sha="${{ needs.build_and_stage.outputs.sha }}"
           sig=(--aws-sigv4 aws:amz:auto:s3 --user "$LAKE_CACHE_KEY")
           # grep exits 1 on no match (handled by the total==0 branch); tolerate it under pipefail.
@@ -460,7 +472,7 @@ jobs:
             new_content="$(numfmt --to=iec-i --suffix=B "$new_bytes") across ${new} new artifact(s) vs rev ${prev:0:12}${distnote}"
             pct=$(awk "BEGIN{printf \"%.1f\", ($total>0)?100*$carry/$total:0}")
             note=""
-            [ "$total" -gt 0 ] && [ "$new" -eq "$total" ] && note=" — full turnover, likely a toolchain/generation change, not source churn"
+            [ "$total" -gt 0 ] && [ "$new" -eq "$total" ] && note=" — full turnover, likely a republished toolchain binary, not source churn"
             summary="${carry}/${total} (${pct}%) carried over, ${new} new vs rev ${prev:0:12}${note}"
           fi
           echo "::notice::cache carryover: ${summary}"

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -38,19 +38,12 @@ name: Lake cache shadow (master)
 #
 # Toolchain override:
 #   The `toolchain_override` input, or else the LAKE_SHADOW_TOOLCHAIN_OVERRIDE
-#   variable, swaps the toolchain the whole pipeline runs on — e.g. a lean4
-#   pr-release that cherry-picks a Lake change onto the pinned release's
-#   lineage, such as pr-release-14301 = v4.32.0-rc1 + lean4#14235. Its lean
-#   must be behaviorally compatible with the repo pin: mathlib sources build
-#   as-is.
-#
-#   All runs share one scope and one carryover chain: module input hashes
-#   incorporate the toolchain, so runs on different toolchains never resolve
-#   each other's artifacts, and byte-identical content dedups. Every run
-#   warm-starts from the previous run via `lake cache get`; a toolchain
-#   switch misses everything and shows up once as a full-turnover source
-#   build. The legacy cache covers only the repo pin, so override runs skip
-#   hydration.
+#   variable, swaps the toolchain the whole pipeline runs on. Its lean must be
+#   behaviorally compatible with the repo pin, e.g. a Lake change
+#   cherry-picked onto the pinned release's lineage as a lean4 pr-release.
+#   Input hashes incorporate the toolchain, so all runs safely share one
+#   scope and carryover chain; a toolchain switch misses the legacy cache and
+#   all prior artifacts, costing one full-turnover source build.
 
 on:
   schedule:

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -168,7 +168,10 @@ jobs:
         shell: bash -euo pipefail {0}
         run: |
           mkdir -p pr-branch/.lake/
-          mkdir -p .cache/mathlib/
+          # The landrun ruleset mounts $HOME/.cache/mathlib read-only; landrun
+          # errors out if the path is missing (runs that skip legacy hydration
+          # reach the first landrun step with it absent).
+          mkdir -p "$HOME/.cache/mathlib/"
           mkdir -p _work
 
       - name: install elan

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -20,8 +20,8 @@ name: Lake cache shadow (master)
 #     LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC    — e.g. https://pub-<hash>.r2.dev/<prefix>/artifacts
 #     LAKE_CACHE_REVISION_ENDPOINT_PUBLIC    — e.g. https://pub-<hash>.r2.dev/<prefix>/revisions
 #     # Optional. Default toolchain override for every run, including
-#     # scheduled ones; the dispatch input takes precedence. Unset for the
-#     # stock pipeline.
+#     # scheduled ones; the dispatch input takes precedence. Unset to run
+#     # on the repo pin.
 #     LAKE_SHADOW_TOOLCHAIN_OVERRIDE         — e.g. leanprover/lean4-pr-releases:pr-release-14301
 #
 # Jobs:
@@ -79,7 +79,7 @@ on:
           optional Lean toolchain to run the pipeline on instead of the repo
           pin; see the "Toolchain override" note at the top of this file.
           Empty falls back to the LAKE_SHADOW_TOOLCHAIN_OVERRIDE repository
-          variable; the stock pipeline runs when both are empty.
+          variable; the pipeline runs on the repo pin when both are empty.
         required: false
         type: string
         default: ''
@@ -97,7 +97,7 @@ defaults:
 
 env:
   # Effective toolchain override: dispatch input, else repository variable,
-  # else stock.
+  # else the repo pin.
   TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE || '' }}
   # Scope prefix for all puts and gets in this workflow. Namespaces the
   # workflow's artifacts within the cache bucket.

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -31,6 +31,18 @@ name: Lake cache shadow (master)
 #                    rehydrated cache, then verify with `--rehash`.
 #   report           Post a per-run summary to the `CI admins` Zulip
 #                    stream (topic `Lake cache shadow`).
+#
+# Lake override (`lake_ref` input):
+#   Dispatching with `lake_ref` runs the whole pipeline with a patched `lake`
+#   built from that ref of marcelolynch/lean4 (src/lake must be a standalone
+#   Lake package pinned to this repo's toolchain, e.g. branch
+#   `lake-ltar-strip-rc1` = v4.32.0-rc1 + leanprover/lean4#14235). The
+#   override lake is compiled with the stock pinned toolchain, so module
+#   traces stay byte-compatible with the hydrated tree; `leantar` is upgraded
+#   to >= 0.1.20 via a shadow sysroot (lean4#14235 needs its `-s`/`-j` flags).
+#   Override runs upload under the isolated `mathlib4-master-shadow-lakeovr`
+#   scope and keep their carryover chain in `analysis-lakeovr/`, so they never
+#   pollute the stock daily chain (and vice versa).
 
 on:
   schedule:
@@ -54,6 +66,14 @@ on:
         #   Mathlib.Topology.Basic Mathlib.Combinatorics.SimpleGraph.Basic Mathlib.RingTheory.Ideal.Basic
         # or add `Archive Counterexamples` to also shadow those libraries.
         default: Mathlib
+      lake_ref:
+        description: >-
+          optional ref of marcelolynch/lean4 to build `lake` from (see the
+          "Lake override" note at the top of this file). Leave empty for the
+          stock pipeline.
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -68,8 +88,10 @@ defaults:
 
 env:
   # Scope prefix for all puts and gets in this workflow. Namespaces the
-  # workflow's artifacts within the cache bucket.
-  SHADOW_SCOPE: mathlib4-master-shadow
+  # workflow's artifacts within the cache bucket. Lake-override runs use an
+  # isolated scope + analysis namespace so the stock daily chain stays clean.
+  SHADOW_SCOPE: ${{ inputs.lake_ref != '' && 'mathlib4-master-shadow-lakeovr' || 'mathlib4-master-shadow' }}
+  ANALYSIS_NS: ${{ inputs.lake_ref != '' && 'analysis-lakeovr' || 'analysis' }}
   # NOTE: STAGE_TARGETS is set per-job (not here) from the `targets` input, so
   # it can be overridden per dispatch — see the `build_and_stage`/`consume` env.
 
@@ -161,6 +183,70 @@ jobs:
         run: |
           cd tools-branch
           lake build cache
+
+      # --- Lake override (only when the `lake_ref` input is set) -------------
+      # Interposes a patched `lake` for every `lake` invocation below, via a
+      # PATH shim. The shim also points LEAN_SYSROOT at a shadow sysroot (the
+      # pinned toolchain with `leantar` upgraded), so no landrun --env plumbing
+      # changes are needed and scheduled stock runs are untouched.
+      - name: Checkout lake override source
+        if: ${{ inputs.lake_ref != '' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: marcelolynch/lean4
+          ref: ${{ inputs.lake_ref }}
+          path: lake-override
+          sparse-checkout: src/lake
+          fetch-depth: 1
+
+      - name: Build override lake + shadow sysroot
+        if: ${{ inputs.lake_ref != '' }}
+        shell: bash -euo pipefail {0}
+        env:
+          LEANTAR_VERSION: v0.1.20
+        run: |
+          # The override lake must be built with (and run against) the repo's
+          # pinned toolchain, or module traces would not match the tree the
+          # legacy cache hydrates.
+          PIN="$(tr -d '[:space:]' < pr-branch/lean-toolchain)"
+          OVR="$(tr -d '[:space:]' < lake-override/src/lake/lean-toolchain)"
+          if [ "$PIN" != "$OVR" ]; then
+            echo "::error::lake override pins toolchain '$OVR' but the repo pins '$PIN'"
+            exit 1
+          fi
+          (cd lake-override/src/lake && lake build)
+          LAKE_BIN="$PWD/lake-override/src/lake/.lake/build/bin/lake"
+          "$LAKE_BIN" --version
+          # Shadow sysroot: the pinned toolchain with only bin/leantar swapped.
+          # Lake resolves leantar from the *Lean* install, so the override
+          # binary sees the new leantar through LEAN_SYSROOT.
+          TOOLCHAIN_DIR="$(cd pr-branch && dirname "$(dirname "$(elan which lake)")")"
+          SHADOW="$PWD/shadow-sysroot"
+          mkdir -p "$SHADOW/bin"
+          for e in "$TOOLCHAIN_DIR"/*; do
+            [ "$(basename "$e")" = bin ] || ln -s "$e" "$SHADOW/$(basename "$e")"
+          done
+          for f in "$TOOLCHAIN_DIR"/bin/*; do
+            ln -s "$f" "$SHADOW/bin/$(basename "$f")"
+          done
+          rm "$SHADOW/bin/leantar"
+          case "$(uname -m)" in
+            x86_64) TRIPLE=x86_64-unknown-linux-musl ;;
+            aarch64) TRIPLE=aarch64-unknown-linux-musl ;;
+            *) echo "::error::unsupported arch $(uname -m)"; exit 1 ;;
+          esac
+          curl -sSfL -o /tmp/leantar.tar.gz \
+            "https://github.com/digama0/leangz/releases/download/${LEANTAR_VERSION}/leantar-${LEANTAR_VERSION}-${TRIPLE}.tar.gz"
+          tar -xzf /tmp/leantar.tar.gz -C /tmp
+          install -m755 "/tmp/leantar-${LEANTAR_VERSION}-${TRIPLE}/leantar" "$SHADOW/bin/leantar"
+          # PATH shim: `lake` resolves to the override binary, which detects
+          # the (non-collocated) Lean install through LEAN_SYSROOT.
+          SHIM="$PWD/lake-override-bin"
+          mkdir -p "$SHIM"
+          printf '#!/usr/bin/env bash\nexport LEAN_SYSROOT="%s"\nexec "%s" "$@"\n' "$SHADOW" "$LAKE_BIN" > "$SHIM/lake"
+          chmod +x "$SHIM/lake"
+          echo "$SHIM" >> "$GITHUB_PATH"
+          echo "::notice::lake override active: $("$LAKE_BIN" --version); leantar $("$SHADOW/bin/leantar" --version)"
 
       - name: download dependencies
         shell: landrun --unrestricted-network --rox /etc --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
@@ -332,7 +418,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          base="${AUTH%/artifacts}/analysis"
+          base="${AUTH%/artifacts}/${ANALYSIS_NS}"
           sha="${{ needs.build_and_stage.outputs.sha }}"
           sig=(--aws-sigv4 aws:amz:auto:s3 --user "$LAKE_CACHE_KEY")
           # grep exits 1 on no match (handled by the total==0 branch); tolerate it under pipefail.
@@ -396,7 +482,9 @@ jobs:
     needs: [build_and_stage, upload]
     if: ${{ github.repository == 'leanprover-community/mathlib4' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 90 rather than 60: a lake-override run spends ~10-15 extra minutes
+    # building the override lake before the consume proper starts.
+    timeout-minutes: 90
     outputs:
       cache_health: ${{ steps.cachehealth.outputs.health }}
     env:
@@ -422,6 +510,62 @@ jobs:
           chmod +x elan-init.sh
           ./elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      # --- Lake override (only when the `lake_ref` input is set) -------------
+      # Same recipe as build_and_stage: the override binary is arch/glibc
+      # sensitive, so each job builds its own rather than sharing an artifact.
+      - name: Checkout lake override source
+        if: ${{ inputs.lake_ref != '' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: marcelolynch/lean4
+          ref: ${{ inputs.lake_ref }}
+          path: lake-override
+          sparse-checkout: src/lake
+          fetch-depth: 1
+
+      - name: Build override lake + shadow sysroot
+        if: ${{ inputs.lake_ref != '' }}
+        env:
+          LEANTAR_VERSION: v0.1.20
+        run: |
+          PIN="$(tr -d '[:space:]' < pr-branch/lean-toolchain)"
+          OVR="$(tr -d '[:space:]' < lake-override/src/lake/lean-toolchain)"
+          if [ "$PIN" != "$OVR" ]; then
+            echo "::error::lake override pins toolchain '$OVR' but the repo pins '$PIN'"
+            exit 1
+          fi
+          (cd lake-override/src/lake && lake build)
+          LAKE_BIN="$PWD/lake-override/src/lake/.lake/build/bin/lake"
+          "$LAKE_BIN" --version
+          TOOLCHAIN_DIR="$(cd pr-branch && dirname "$(dirname "$(elan which lake)")")"
+          SHADOW="$PWD/shadow-sysroot"
+          mkdir -p "$SHADOW/bin"
+          for e in "$TOOLCHAIN_DIR"/*; do
+            [ "$(basename "$e")" = bin ] || ln -s "$e" "$SHADOW/$(basename "$e")"
+          done
+          for f in "$TOOLCHAIN_DIR"/bin/*; do
+            ln -s "$f" "$SHADOW/bin/$(basename "$f")"
+          done
+          rm "$SHADOW/bin/leantar"
+          case "$(uname -m)" in
+            x86_64) TRIPLE=x86_64-unknown-linux-musl ;;
+            aarch64) TRIPLE=aarch64-unknown-linux-musl ;;
+            *) echo "::error::unsupported arch $(uname -m)"; exit 1 ;;
+          esac
+          curl -sSfL -o /tmp/leantar.tar.gz \
+            "https://github.com/digama0/leangz/releases/download/${LEANTAR_VERSION}/leantar-${LEANTAR_VERSION}-${TRIPLE}.tar.gz"
+          tar -xzf /tmp/leantar.tar.gz -C /tmp
+          install -m755 "/tmp/leantar-${LEANTAR_VERSION}-${TRIPLE}/leantar" "$SHADOW/bin/leantar"
+          SHIM="$PWD/lake-override-bin"
+          mkdir -p "$SHIM"
+          printf '#!/usr/bin/env bash\nexport LEAN_SYSROOT="%s"\nexec "%s" "$@"\n' "$SHADOW" "$LAKE_BIN" > "$SHIM/lake"
+          chmod +x "$SHIM/lake"
+          echo "$SHIM" >> "$GITHUB_PATH"
+          # The override lake is invoked directly (no elan shim), so it would
+          # not see the per-toolchain default cache dir; pin one explicitly.
+          echo "LAKE_CACHE_DIR=$HOME/.cache/lake-shadow" >> "$GITHUB_ENV"
+          echo "::notice::lake override active: $("$LAKE_BIN" --version); leantar $("$SHADOW/bin/leantar" --version)"
 
       - name: download dependencies
         run: |
@@ -454,9 +598,10 @@ jobs:
             --rev="${{ needs.build_and_stage.outputs.sha }}"
           # Artifacts fetched here = the root-package outputs served from cache
           # (a non-verbose build replays them silently). Hand the count to the
-          # provenance step.
+          # provenance step. LAKE_CACHE_DIR is set only by a lake-override run;
+          # stock runs use Lake's per-toolchain default under ~/.elan.
           # `|| true`: an informational count must not trip pipefail if find fails.
-          FETCHED=$(find ~/.elan/toolchains -name '*.ltar' 2>/dev/null | wc -l || true)
+          FETCHED=$(find "${LAKE_CACHE_DIR:-$HOME/.elan/toolchains}" -name '*.ltar' 2>/dev/null | wc -l || true)
           echo "ltar count after get: $FETCHED"
           echo "FETCHED_ARTIFACTS=$FETCHED" >> "$GITHUB_ENV"
 
@@ -521,6 +666,7 @@ jobs:
           CACHE_HEALTH: ${{ needs.consume.outputs.cache_health }}
           SHA: ${{ needs.build_and_stage.outputs.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LAKE_REF: ${{ inputs.lake_ref }}
         run: |
           emoji() {
             case "$1" in
@@ -533,6 +679,9 @@ jobs:
           {
             echo "msg<<MSG_EOF"
             echo "**Lake cache shadow** ([run](${RUN_URL}), rev \`${SHA:0:12}\`)"
+            if [ -n "${LAKE_REF:-}" ]; then
+              echo "🧪 lake override: \`${LAKE_REF}\` (scope \`${SHADOW_SCOPE}\`)"
+            fi
             echo ""
             echo "- $(emoji "$BUILD") build_and_stage: \`$BUILD\`"
             echo "- $(emoji "$UPLOAD") upload: \`$UPLOAD\`"


### PR DESCRIPTION
Use a variable to override the lean toolchain, so we can point to a custom lean toolchain to experiment / ingest some changes that are still unreleased

Note this pipeline is experimental and non-sensitive, so it's fine to be loose here.