### PR TITLE
[Merged by Bors] - chore(RepresentationTheory/Rep/Res): fix malformed deprecation date

### DIFF
--- a/Mathlib/RepresentationTheory/Rep/Res.lean
+++ b/Mathlib/RepresentationTheory/Rep/Res.lean
@@ -55,7 +55,7 @@ lemma res_obj_V : (res f M).V = M.V := rfl
 lemma resMap_hom_toLinearMap {M N : Rep k G} (p : M ⟶ N) :
     (resMap f p).hom.toLinearMap = p.hom.toLinearMap := rfl
 
-@[deprecated (since := "26/06/2026")]
+@[deprecated (since := "2026-06-26")]
 alias res_map_hom_toLinearMap := resMap_hom_toLinearMap
 
 @[simp]


### PR DESCRIPTION
This PR fixes the malformed deprecation date `since := "26/06/2026"` on the `res_map_hom_toLinearMap` alias in `Mathlib/RepresentationTheory/Rep/Res.lean`, changing it to the standard `YYYY-MM-DD` form `"2026-06-26"`. It was the only deprecation date in Mathlib not in this format, which breaks date-based deprecation tooling.

Follow-up to [#41054 (refactor(RepresentationTheory/Rep/Res): refactor resFunctor)](https://github.com/leanprover-community/mathlib4/pull/41054).

🤖 Prepared with Claude Code
