### PR TITLE
doc: fix TFAE list rendering in Rees theorem module docstring

### DIFF
--- a/Mathlib/RingTheory/Depth/Rees.lean
+++ b/Mathlib/RingTheory/Depth/Rees.lean
@@ -24,11 +24,12 @@ certain `Ext` groups and the length of a maximal regular sequence in a certain i
 * `ModuleCat.exists_isRegular_tfae` (Rees theorem) : For any `n : ℕ`, Noetherian ring `R`,
   `I : Ideal R`, and finitely generated and nontrivial `R`-module `M` satisfying `IM < M`,
   the following are equivalent:
-  · for any `N : ModuleCat R` finitely generated such that `Supp N ⊆ V(I)`, `∀ i < n, Ext N M i = 0`
-  · `∀ i < n, Ext (R ⧸ I) M i = 0`
-  · there exists a `N : ModuleCat R` finitely generated and nontrivial with `Supp N = V(I)`
+  * for any `N : ModuleCat R` finitely generated and nontrivial such that `Supp N ⊆ V(I)`,
+    `∀ i < n, Ext N M i = 0`
+  * `∀ i < n, Ext (R ⧸ I) M i = 0`
+  * there exists a `N : ModuleCat R` finitely generated and nontrivial with `Supp N = V(I)`
     such that `∀ i < n, Ext N M i = 0`
-  · there exists a `M`-regular sequence of length `n` with every element in `I`
+  * there exists a `M`-regular sequence of length `n` with every element in `I`
 
 ## References
 
@@ -99,7 +100,7 @@ module over Noetherian ring `R` and ideal `I` satisfying `IM < M` and `Supp N �
 if there is an `M`-regular sequence `rs` contained in `I`,
 then `Ext N M i = 0` for all `i < rs.length`. -/
 lemma subsingleton_ext_of_exists_isRegular [Small.{v} R] [IsNoetherianRing R] (I : Ideal R)
-    (N : ModuleCat.{v} R) [Nfin : Module.Finite R N]
+    (N : ModuleCat.{v} R) [Module.Finite R N]
     (Nsupp : Module.support R N ⊆ PrimeSpectrum.zeroLocus I)
     (M : ModuleCat.{v} R) [Module.Finite R M] (smul_lt : I • (⊤ : Submodule R M) < ⊤)
     (rs : List R) (mem : ∀ r ∈ rs, r ∈ I) (reg : IsRegular M rs) :


### PR DESCRIPTION
This PR fixes the module docstring of `Mathlib/RingTheory/Depth/Rees.lean`: the four TFAE items used `·`, which is not a markdown list marker, so they rendered as a single run-on paragraph on doc-gen. Replace them with proper `*` sub-list items, add the missing "and nontrivial" to the first item to match the Lean statement, and drop the unused binder name `Nfin` in `subsingleton_ext_of_exists_isRegular`.

Follow-up to [#26212 (feat(Algebra): the Rees theorem for depth)](https://github.com/leanprover-community/mathlib4/pull/26212), where the reviewer deferred checking the rendered docs to after the merge.

🤖 Prepared with Claude Code
