### PR TITLE
[Merged by Bors] - doc: fix docstring of orthogonalProjectionOnto

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
@@ -109,7 +109,7 @@ section orthogonalProjection
 
 variable [K.HasOrthogonalProjection]
 
-/-- The orthogonal projection onto a complete subspace. -/
+/-- The orthogonal projection onto a subspace. -/
 def orthogonalProjectionOnto : E →L[𝕜] K := K.projectionOntoL Kᗮ K.isTopCompl_orthogonal
 
 /-- The orthogonal projection onto a subspace. -/


### PR DESCRIPTION
This PR fixes the docstring of `Submodule.orthogonalProjectionOnto`, which said "complete subspace" (a leftover from the removed `orthogonalProjectionFn` docstring), even though the hypothesis `[K.HasOrthogonalProjection]` is strictly weaker than completeness. Restore the pre-existing wording "The orthogonal projection onto a subspace.", matching the deprecated `orthogonalProjection` abbrev just below.

---

Follow-up to [#39041 (refactor: redefine orthogonalProjectionOnto via projectionOntoL)](https://github.com/leanprover-community/mathlib4/pull/39041).

🤖 Prepared with Claude Code
