### PR TITLE
[Merged by Bors] - chore(Topology/DiscreteSubset): fix typo eventualy -> eventually in lemma name

### DIFF
--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -375,7 +375,7 @@ lemma mem_codiscrete {S : Set X} :
     S ∈ codiscrete X ↔ ∀ x, Disjoint (𝓝[≠] x) (𝓟 Sᶜ) := by
   simp [codiscrete, mem_codiscreteWithin, compl_eq_univ_sdiff]
 
-lemma Disjoint.eventualy_nhdsWithin_specializes
+lemma Disjoint.eventually_nhdsWithin_specializes
     {p : X} {s : Set X} (hs : Disjoint (𝓝[s] p) cofinite) :
     ∀ᶠ x in 𝓝[s] p, x ⤳ p := by
   obtain ⟨t, h₁t, h₂t⟩ := disjoint_cofinite_right.mp hs
@@ -393,7 +393,7 @@ lemma Disjoint.nhdsWithin_eq_of_cofinite
     {p : X} {s : Set X} (hs : Disjoint (𝓝[s] p) cofinite) :
     𝓝[s] p = 𝓟 ({x | x ⤳ p} ∩ s) := by
   apply le_antisymm
-  · simpa using ⟨hs.eventualy_nhdsWithin_specializes, self_mem_nhdsWithin⟩
+  · simpa using ⟨hs.eventually_nhdsWithin_specializes, self_mem_nhdsWithin⟩
   · rw [← inf_principal, nhdsWithin]
     gcongr
     rw [Filter.principal_le_iff]


### PR DESCRIPTION
This PR renames `Disjoint.eventualy_nhdsWithin_specializes` to `Disjoint.eventually_nhdsWithin_specializes`, fixing the misspelling "eventualy", and update its single (internal) use site. The lemma was merged three days ago and has not been in any release, so no deprecated alias is added.

---

Follow-up to [#39353 (feat(Topology): Show existence of a neighbourhood around p which avoids all points in the support of a locally finsupp function except those which specialize to p)](https://github.com/leanprover-community/mathlib4/pull/39353).

🤖 Prepared with Claude Code
