### PR TITLE
feat: `IsMulApplyEqComp` instances for `RelHom`/`RelEmbedding`/`RelIso` and `MulAction (α →o α) α`

### DIFF
--- a/Mathlib/Algebra/Order/Group/Action/End.lean
+++ b/Mathlib/Algebra/Order/Group/Action/End.lean
@@ -61,3 +61,19 @@ instance applyMulAction : MulAction (r ≃r r) α where
 instance apply_faithfulSMul : FaithfulSMul (r ≃r r) α where eq_of_smul_eq_smul h := RelIso.ext h
 
 end RelIso
+
+namespace OrderHom
+variable {α : Type*} [Preorder α]
+
+/-- The tautological action by `α →o α` on `α`. -/
+instance applyMulAction : MulAction (α →o α) α where
+  smul := (⇑)
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+
+@[simp] lemma smul_def (f : α →o α) (a : α) : f • a = f a := rfl
+
+instance apply_faithfulSMul : FaithfulSMul (α →o α) α where
+  eq_of_smul_eq_smul h := ext _ _ (funext h)
+
+end OrderHom

--- a/Mathlib/Algebra/Order/Group/End.lean
+++ b/Mathlib/Algebra/Order/Group/End.lean
@@ -20,7 +20,6 @@ is an abbreviation for `RelIso`, there is no need for an additional instance.
 ## TODO
 
 + Rename the `mul_def`/`one_def` lemmas to `mul_eq_comp`/`one_eq_id`.
-+ Use the `IsMulApplyEqComp` and `IsOneApplyEqSelf` classes for `RelHom` and `RelIso`.
 -/
 
 @[expose] public section
@@ -37,6 +36,9 @@ instance : Monoid (r →r r) where
   mul_assoc _ _ _ := rfl
   one_mul _ := rfl
   mul_one _ := rfl
+
+instance : IsMulApplyEqComp (r →r r) α where mul_apply_eq_comp _ _ _ := rfl
+instance : IsOneApplyEqSelf (r →r r) α where one_apply_eq_self _ := rfl
 
 lemma one_def : (1 : r →r r) = .id r := rfl
 lemma mul_def (f g : r →r r) : (f * g) = f.comp g := rfl
@@ -57,6 +59,9 @@ instance : Monoid (r ↪r r) where
   mul_assoc _ _ _ := rfl
   one_mul _ := rfl
   mul_one _ := rfl
+
+instance : IsMulApplyEqComp (r ↪r r) α where mul_apply_eq_comp _ _ _ := rfl
+instance : IsOneApplyEqSelf (r ↪r r) α where one_apply_eq_self _ := rfl
 
 lemma one_def : (1 : r ↪r r) = .refl r := rfl
 lemma mul_def (f g : r ↪r r) : (f * g) = g.trans f := rfl
@@ -79,6 +84,9 @@ instance : Group (r ≃r r) where
   one_mul _ := ext fun _ => rfl
   mul_one _ := ext fun _ => rfl
   inv_mul_cancel f := ext f.symm_apply_apply
+
+instance : IsMulApplyEqComp (r ≃r r) α where mul_apply_eq_comp _ _ _ := rfl
+instance : IsOneApplyEqSelf (r ≃r r) α where one_apply_eq_self _ := rfl
 
 lemma one_def : (1 : r ≃r r) = .refl r := rfl
 lemma mul_def (f g : r ≃r r) : (f * g) = g.trans f := rfl


### PR DESCRIPTION
This PR adds `IsMulApplyEqComp`/`IsOneApplyEqSelf` instances for `RelHom`, `RelEmbedding` and `RelIso` (fulfilling a TODO recorded in `Mathlib/Algebra/Order/Group/End.lean`, so these types get the generic `pow_apply_eq_iterate`/`coe_pow_eq_iterate` lemmas), and add the tautological `MulAction (α →o α) α` instance together with `smul_def` and `FaithfulSMul` in `Mathlib/Algebra/Order/Group/Action/End.lean` (requested in review; it cannot live in `End.lean` because of `assert_not_exists MulAction`), matching the existing `RelHom`/`RelEmbedding`/`RelIso` instances in that file.

Follow-up to [#40515 (feat: Monoid and Group instances for OrderHom and OrderIso)](https://github.com/leanprover-community/mathlib4/pull/40515).

🤖 Prepared with Claude Code
