### PR TITLE
[Merged by Bors] - doc: remove dangling reference to deleted lemma in asymptotics docstring

### DIFF
--- a/Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean
@@ -212,12 +212,11 @@ section boundedRange
 /-!
 ## Bounded Range versus `IsBigO` Asymptotics
 
-For a continuous function `f` into a seminormed space, defined on an unbounded linear order whose
-order topology has compact intervals, having bounded range is equivalent to being `O(1)` along both
-`atTop` and `atBot` (`Continuous.isBounded_range_iff_isBigO_atTop_atBot`). For an even function a
-single `O(1)` bound along `atTop` already suffices
-(`Continuous.isBounded_range_iff_isBigO_atTop_of_even`), since `Function.Even` transports an `atTop`
-bound to an `atBot` bound (`Function.Even.isBigO_atTop_iff_isBigO_atBot`).
+For a continuous function `f` into a seminormed space, having bounded range is equivalent to being
+`O(1)` along the cocompact filter (`Continuous.isBounded_range_iff_isBigO`). On an unbounded linear
+order whose order topology has compact intervals, this means being `O(1)` along both `atTop` and
+`atBot` (`Continuous.isBounded_range_iff_isBigO_atTop_atBot`). For an even function a single `O(1)`
+bound along `atTop` already suffices (`Continuous.isBounded_range_iff_isBigO_atTop_of_even`).
 -/
 
 variable


### PR DESCRIPTION
This PR rewords the `Bounded Range versus IsBigO Asymptotics` section docstring in `Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean`, which referenced `Function.Even.isBigO_atTop_iff_isBigO_atBot`, a lemma deliberately removed during review and not present anywhere in Mathlib. The new text describes what the section actually contains, including the main general result `Continuous.isBounded_range_iff_isBigO` (previously unmentioned).

Follow-up to [#40664 (feat: Bounded Range versus `IsBigO` Asymptotics)](https://github.com/leanprover-community/mathlib4/pull/40664).

🤖 Prepared with Claude Code
