### PR TITLE
chore(Analysis/RCLike): move I_smul_of_mem_skewAdjoint out of IsSelfAdjoint namespace

### DIFF
--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -778,8 +778,11 @@ open RCLike
 lemma IsSelfAdjoint.I_smul_mem_skewAdjoint (h : IsSelfAdjoint a) :
     (I : K) • a ∈ skewAdjoint A := h.smul_mem_skewAdjoint I_mem_skewAdjoint
 
-lemma IsSelfAdjoint.I_smul_of_mem_skewAdjoint (h : a ∈ skewAdjoint A) :
+lemma isSelfAdjoint_I_smul_of_mem_skewAdjoint (h : a ∈ skewAdjoint A) :
     IsSelfAdjoint ((I : K) • a) := isSelfAdjoint_smul_of_mem_skewAdjoint I_mem_skewAdjoint h
+
+@[deprecated (since := "2026-07-10")]
+alias IsSelfAdjoint.I_smul_of_mem_skewAdjoint := isSelfAdjoint_I_smul_of_mem_skewAdjoint
 
 end
 


### PR DESCRIPTION
This PR renames `IsSelfAdjoint.I_smul_of_mem_skewAdjoint` to the root-namespace `isSelfAdjoint_I_smul_of_mem_skewAdjoint`, with a deprecated alias for the old name. The lemma's hypothesis is `a ∈ skewAdjoint A`, not `IsSelfAdjoint _`, so the `IsSelfAdjoint` namespace never enables dot notation; the new name mirrors `isSelfAdjoint_smul_of_mem_skewAdjoint`, the general lemma it is proved from, whose dot-notation sibling `IsSelfAdjoint.smul_mem_skewAdjoint` keeps the namespace for the same reason.

Follow-up to [#40684 (feat: some API for relating self-adjoint and skew-adjoints)](https://github.com/leanprover-community/mathlib4/pull/40684).

🤖 Prepared with Claude Code
