### PR TITLE
[Merged by Bors] - doc: fix docstrings still using the deprecated name CardinalFilteredPoset

### DIFF
--- a/Mathlib/CategoryTheory/Presentable/CardinalDirectedPoset.lean
+++ b/Mathlib/CategoryTheory/Presentable/CardinalDirectedPoset.lean
@@ -112,7 +112,7 @@ abbrev CardinalDirectedPoset.ι : CardinalDirectedPoset κ ⥤ PartOrdEmb :=
 
 namespace CardinalDirectedPoset
 
-/-- Constructor for objects in `CardinalFilteredPoset κ`. -/
+/-- Constructor for objects in `CardinalDirectedPoset κ`. -/
 abbrev of (J : PartOrdEmb.{u}) [IsCardinalFiltered J κ] : CardinalDirectedPoset κ where
   obj := J
   property := inferInstance
@@ -266,7 +266,7 @@ variable (J : CardinalDirectedPoset κ)
 
 -- `@[nolint unusedArguments]` allows to setup some instances which uses
 -- the fact that `κ'` is regular.
-/-- Given `J : CardinalFilteredPoset κ` and a regular cardinal `κ'`,
+/-- Given `J : CardinalDirectedPoset κ` and a regular cardinal `κ'`,
 this is the predicate on `Set J.withTop.obj` that is satisfied by
 subsets that are of cardinality `< κ'` and contain `⊤`. -/
 @[nolint unusedArguments]
@@ -314,7 +314,7 @@ lemma exists_mem_propSetWithTop (a : J.withTop.obj) :
   | some a => exact ⟨_, propSetWithTop_pair _ a, by aesop⟩
   | none => exact ⟨_, propSetWithTop_pair _ (Classical.arbitrary _), by aesop⟩
 
-/-- If `J : CardinalFilteredPoset κ` and `κ'` is any regular cardinal,
+/-- If `J : CardinalDirectedPoset κ` and `κ'` is any regular cardinal,
 this is a colimit cocone which exhibits `J.withTop` as the `κ'`-filtered
 colimit of its subsets that are of cardinality `< κ'` and contain `⊤`. -/
 abbrev coconeWithTop : Cocone (functorOfPredicateSet (J.PropSetWithTop κ')) :=


### PR DESCRIPTION
This PR updates the docstrings of `CardinalDirectedPoset.of`, `CardinalDirectedPoset.PropSetWithTop` and `CardinalDirectedPoset.coconeWithTop`, which still referred to the type by its deprecated name `CardinalFilteredPoset κ` after the rename to `CardinalDirectedPoset κ`. The intentional deprecated-alias block is left untouched.

Follow-up to [#40937 (feat(CategoryTheory/Presentable): sharply smaller regular cardinals)](https://github.com/leanprover-community/mathlib4/pull/40937).

🤖 Prepared with Claude Code
