### PR TITLE
[Merged by Bors] - chore(Geometry/Euclidean/Sphere): drop unneeded distinctness hypothesis

### DIFF
--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -604,16 +604,17 @@ lemma isDiameter_iff_mem_and_mem_and_wbtw :
   rw [mem_sphere.1 h₁, mem_sphere'.1 h₂, ← two_mul, eq_comm] at hd
   exact isDiameter_iff_mem_and_mem_and_dist.2 ⟨h₁, h₂, hd⟩
 
-/-- The center lies on the line through two distinct points of a sphere if and only if those
+/-- The center lies on the line through two points of a sphere if and only if those
 points are the endpoints of a diameter. -/
-theorem center_mem_affineSpan_pair_iff_isDiameter
-    (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) (hp₁p₂ : p₁ ≠ p₂) :
+theorem center_mem_affineSpan_pair_iff_isDiameter (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) :
     s.center ∈ line[ℝ, p₁, p₂] ↔ s.IsDiameter p₁ p₂ := by
-  rw [isDiameter_iff_mem_and_mem_and_wbtw]
-  refine ⟨fun h => ⟨hp₁, hp₂, ?_⟩, fun h => h.2.2.mem_affineSpan⟩
-  refine wbtw_of_collinear_of_dist_center_le_radius ?_ hp₁ ?_ hp₂ hp₁p₂
-  · rw [Set.insert_comm]; exact collinear_insert_of_mem_affineSpan_pair h
-  · simpa using radius_nonneg_of_mem hp₁
+  rcases eq_or_ne p₁ p₂ with rfl | hp₁p₂
+  · simp [isDiameter_iff_left_mem_and_midpoint_eq_center, hp₁, eq_comm]
+  · rw [isDiameter_iff_mem_and_mem_and_wbtw]
+    refine ⟨fun h => ⟨hp₁, hp₂, ?_⟩, fun h => h.2.2.mem_affineSpan⟩
+    refine wbtw_of_collinear_of_dist_center_le_radius ?_ hp₁ ?_ hp₂ hp₁p₂
+    · rw [Set.insert_comm]; exact collinear_insert_of_mem_affineSpan_pair h
+    · simpa using radius_nonneg_of_mem hp₁
 
 end Sphere
 


### PR DESCRIPTION
This PR removes the `p₁ ≠ p₂` hypothesis from `Sphere.center_mem_affineSpan_pair_iff_isDiameter`: the iff also holds when the points coincide (both sides then say `p₁ = s.center`), and the neighbouring `isDiameter_iff_*` lemmas carry no distinctness hypotheses. The degenerate case is handled by a one-line `simp`.

Follow-up to [#41143 (feat(Geometry/Euclidean/Sphere): lemmas about points on a sphere)](https://github.com/leanprover-community/mathlib4/pull/41143).

🤖 Prepared with Claude Code
