### PR TITLE
chore: move simple_obj into Functor namespace, golf proofs, tidy docstring

### DIFF
--- a/Mathlib/CategoryTheory/Simple.lean
+++ b/Mathlib/CategoryTheory/Simple.lean
@@ -85,18 +85,16 @@ theorem Simple.of_iso {X Y : C} [Simple Y] (i : X ≅ Y) : Simple X :=
 theorem Simple.iff_of_iso {X Y : C} (i : X ≅ Y) : Simple X ↔ Simple Y :=
   ⟨fun _ => Simple.of_iso i.symm, fun _ => Simple.of_iso i⟩
 
-theorem simple_obj {D : Type*} [Category* D] [HasZeroMorphisms D] (F : C ⥤ D)
-    [F.IsEquivalence] (X : C) [Simple X] : Simple (F.obj X) := by
-  rw [← F.asEquivalence_functor]
-  have := F.asEquivalence.counitIso.app (F.asEquivalence.functor.obj X)
-  rw [Functor.comp_obj, Functor.id_obj] at this
-  have := Simple.of_iso <| Functor.preimageIso _ this
-  exact Functor.simple_of_simple_obj F.asEquivalence.inverse _
+theorem Functor.simple_obj {D : Type*} [Category* D] [HasZeroMorphisms D] (F : C ⥤ D)
+    [F.IsEquivalence] (X : C) [Simple X] : Simple (F.obj X) :=
+  have : Simple (F.asEquivalence.inverse.obj (F.obj X)) :=
+    (Simple.iff_of_iso (F.asEquivalence.unitIso.app X)).mp ‹Simple X›
+  Functor.simple_of_simple_obj F.asEquivalence.inverse (F.obj X)
 
-theorem simple_obj_iff {D : Type*} [Category* D] [HasZeroMorphisms D] (F : C ⥤ D)
+theorem Functor.simple_obj_iff {D : Type*} [Category* D] [HasZeroMorphisms D] (F : C ⥤ D)
     [F.IsEquivalence] (X : C) :
     Simple (F.obj X) ↔ Simple X :=
-  ⟨fun _ ↦ Functor.simple_of_simple_obj F X, fun _ ↦ simple_obj F X⟩
+  ⟨fun _ ↦ F.simple_of_simple_obj X, fun _ ↦ F.simple_obj X⟩
 
 theorem kernel_zero_of_nonzero_from_simple {X Y : C} [Simple X] {f : X ⟶ Y} [HasKernel f]
     (w : f ≠ 0) : kernel.ι f = 0 := by

--- a/Mathlib/RingTheory/SimpleRing/DivisionRing.lean
+++ b/Mathlib/RingTheory/SimpleRing/DivisionRing.lean
@@ -9,17 +9,17 @@ public import Mathlib.Algebra.Category.ModuleCat.Simple
 public import Mathlib.RingTheory.SimpleModule.Basic
 
 /-!
+# Simple modules over division rings
 
-## Simple modules over division rings
 This file contains some results about simple modules over division rings.
 
-# Main results
+## Main results
 
-* `DivisionRing.nonempty_linearEquiv_of_isSimpleModule` : There is an unique simple module over
+* `DivisionRing.nonempty_linearEquiv_of_isSimpleModule` : There is a unique simple module over
   a division ring, up to isomorphism.
 * `isSimpleModule_iff_eq_zero_or_injective` : A module is simple if and only if it is nontrivial
-  and every linear map from it is either zero or injective, this is the module analogue of
-  `RingHom.injective`
+  and every linear map from it is either zero or injective; this is the module analogue of
+  `RingHom.injective`.
 * `IsSimpleModule.obj_of_isEquivalence` : If `M` is a simple module over a ring `R`, and
   `e : ModuleCat R ⥤ ModuleCat S` is an equivalence of categories,
   then `e(M)` is a simple module over `S`.
@@ -35,7 +35,7 @@ universe u v
 
 open CategoryTheory
 
-variable (R S : Type*) [DivisionRing R] [DivisionRing S] (e : ModuleCat R ≌ ModuleCat S)
+variable (S : Type*) [DivisionRing S]
 
 lemma DivisionRing.nonempty_linearEquiv_of_isSimpleModule (N : Type*) [AddCommGroup N]
     [Module S N] [IsSimpleModule S N] : Nonempty (N ≃ₗ[S] S) := by
@@ -45,8 +45,7 @@ lemma DivisionRing.nonempty_linearEquiv_of_isSimpleModule (N : Type*) [AddCommGr
 lemma isSimpleModule_iff_eq_zero_or_injective (R : Type u) (M : Type v) [Ring R] [AddCommGroup M]
     [Module R M] : IsSimpleModule R M ↔ (Nontrivial M ∧ ∀ (N : Type v) [AddCommGroup N]
     [Module R N] (f : M →ₗ[R] N), f = 0 ∨ Function.Injective f) :=
-  ⟨fun hM ↦ ⟨Submodule.nontrivial_iff _|>.1 hM.1.1, fun N _ _ f ↦ hM.1.2 (LinearMap.ker f)|>.elim
-    (fun h ↦ Or.inr <| by rwa [LinearMap.ker_eq_bot] at h) (fun h ↦ Or.inl <|by simp_all)⟩,
+  ⟨fun _ ↦ ⟨IsSimpleModule.nontrivial R M, fun _ _ _ f ↦ f.injective_or_eq_zero.symm⟩,
   fun ⟨hM1, hM2⟩ ↦ isSimpleModule_iff R M|>.2 ⟨fun p ↦ (hM2 (M ⧸ p) p.mkQ).elim
   (fun h ↦ Or.inr <| by simpa [Submodule.ext_iff, LinearMap.ext_iff] using h)
   (fun h ↦ Or.inl <| eq_bot_iff.2 fun x hx ↦ h (by simp [hx]))⟩⟩
@@ -56,4 +55,4 @@ lemma IsSimpleModule.obj_of_isEquivalence
     [e.IsEquivalence] (M : ModuleCat R) [IsSimpleModule R M] :
     IsSimpleModule S (e.obj M) := by
   rw [← simple_iff_isSimpleModule'] at *
-  exact simple_obj e M
+  exact e.simple_obj M


### PR DESCRIPTION
This PR moves `CategoryTheory.simple_obj` and `CategoryTheory.simple_obj_iff` into the `Functor` namespace (matching their sibling `Functor.simple_of_simple_obj` and enabling dot notation), golf `Functor.simple_obj` and the forward direction of `isSimpleModule_iff_eq_zero_or_injective` via the existing `LinearMap.injective_or_eq_zero`, remove unused `variable` binders in `RingTheory/SimpleRing/DivisionRing.lean`, and fix inverted heading levels and an "an unique" typo in that file's module docstring. The one call site of the renamed lemmas is updated; no deprecated aliases are added since the declarations merged a week ago.

Follow-up to [#41233 (feat(SimpleRing/DivisionRing): simple module is preserved by ModuleCat equivs)](https://github.com/leanprover-community/mathlib4/pull/41233).

🤖 Prepared with Claude Code
