### PR TITLE
[Merged by Bors] - chore(Analysis/RCLike/Basic): state norm_I with positive polarity

### DIFF
--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -728,7 +728,7 @@ theorem norm_I_of_ne_zero (hI : (I : K) ≠ 0) : ‖(I : K)‖ = 1 := by
   rw [← mul_self_inj_of_nonneg (norm_nonneg I) zero_le_one, one_mul, ← norm_mul,
     I_mul_I_of_nonzero hI, norm_neg, norm_one]
 
-theorem norm_I : ‖(I : K)‖ = if (I : K) ≠ 0 then 1 else 0 := by
+theorem norm_I : ‖(I : K)‖ = if (I : K) = 0 then 0 else 1 := by
   grind [norm_I_of_ne_zero, norm_eq_zero]
 
 theorem re_eq_norm_of_mul_conj (x : K) : re (x * conj x) = ‖x * conj x‖ := by


### PR DESCRIPTION
This PR restates `RCLike.norm_I` with the `if` condition in positive polarity, changing the RHS from `if (I : K) ≠ 0 then 1 else 0` to `if (I : K) = 0 then 0 else 1`. The latter is the simp-normal form (`ne_eq` and `ite_not` rewrite the former to it) and matches every comparable `if _ = 0 then 0 else 1` statement in Mathlib; the negated form was the only one of its kind. The proof is unchanged and there are no downstream uses of the lemma yet.

Follow-up to [#41359 (feat(Analysis/RCLike/Basic): add norm_I)](https://github.com/leanprover-community/mathlib4/pull/41359).

🤖 Prepared with Claude Code
