### PR TITLE
[Merged by Bors] - feat(Analysis/BoxIntegral): minor API additions to BoxIntegral and BoxIntegral.BoxAdditiveMap

### DIFF
--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -76,11 +76,19 @@ local notation "ℝⁿ" => ι → ℝ
 ### Integral sum and its basic properties
 -/
 
-
 /-- The integral sum of `f : ℝⁿ → E` over a tagged prepartition `π` w.r.t. box-additive volume `vol`
 with codomain `E →L[ℝ] F` is the sum of `vol J (f (π.tag J))` over all boxes of `π`. -/
 def integralSum (f : ℝⁿ → E) (vol : ι →ᵇᵃ E →L[ℝ] F) (π : TaggedPrepartition I) : F :=
   ∑ J ∈ π.boxes, vol J (f (π.tag J))
+
+theorem integralSum_congr {f₁ f₂ : ℝⁿ → E} {vol₁ vol₂ : ι →ᵇᵃ E →L[ℝ] F}
+    (hf : EqOn f₁ f₂ I.Icc) (hvol : EqOn vol₁ vol₂ π.boxes) :
+    integralSum f₁ vol₁ π = integralSum f₂ vol₂ π := by
+  unfold integralSum
+  refine Finset.sum_congr rfl (fun J hJ ↦ ?_)
+  congr 1
+  · exact hvol hJ
+  exact hf (π.tag_mem_Icc J)
 
 theorem integralSum_biUnionTagged (f : ℝⁿ → E) (vol : ι →ᵇᵃ E →L[ℝ] F) (π : Prepartition I)
     (πi : ∀ J, TaggedPrepartition J) :
@@ -151,7 +159,6 @@ variable [Fintype ι]
 ### Basic integrability theory
 -/
 
-
 /-- The predicate `HasIntegral I l f vol y` says that `y` is the integral of `f` over `I` along `l`
 w.r.t. volume `vol`. This means that integral sums of `f` tend to `𝓝 y` along
 `BoxIntegral.IntegrationParams.toFilteriUnion I ⊤`. -/
@@ -169,6 +176,15 @@ open scoped Classical in
 Returns zero on non-integrable functions. -/
 def integral (I : Box ι) (l : IntegrationParams) (f : ℝⁿ → E) (vol : ι →ᵇᵃ E →L[ℝ] F) :=
   if h : Integrable I l f vol then h.choose else 0
+
+theorem hasIntegral_congr (I : Box ι) (l : IntegrationParams) {f₁ f₂ : ℝⁿ → E}
+    {vol₁ vol₂ : ι →ᵇᵃ E →L[ℝ] F}
+    (hf : EqOn f₁ f₂ I.Icc) (hvol : EqOn vol₁ vol₂ (Set.Iic I)) (y : F) :
+    HasIntegral I l f₁ vol₁ y ↔ HasIntegral I l f₂ vol₂ y := by
+  unfold HasIntegral
+  refine Filter.tendsto_congr (fun π ↦ integralSum_congr hf (hvol.mono ?_))
+  intro J hJ
+  simp [π.le_of_mem' J hJ]
 
 -- Porting note: using the above notation ℝⁿ here causes the theorem below to be silently ignored
 -- see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Lean.204.20doesn't.20add.20lemma.20to.20the.20environment/near/363764522
@@ -389,7 +405,6 @@ The proof is mostly based on
 [Russel A. Gordon, *The integrals of Lebesgue, Denjoy, Perron, and Henstock*][Gordon55].
 
 -/
-
 namespace Integrable
 
 /-- If `ε > 0`, then `BoxIntegral.Integrable.convergenceR` is a function `r : ℝ≥0 → ℝⁿ → (0, ∞)`

--- a/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
@@ -63,6 +63,8 @@ open Box Prepartition Finset
 variable {N : Type*} [AddCommMonoid M] [AddCommMonoid N] {I₀ : WithTop (Box ι)} {I : Box ι}
   {i : ι}
 
+/-! ### Coercion, extensionality, and the defining property -/
+
 instance : FunLike (ι →ᵇᵃ[I₀] M) (Box ι) M where
   coe := toFun
   coe_injective f g h := by cases f; cases g; congr
@@ -77,9 +79,15 @@ theorem coe_injective : Injective fun (f : ι →ᵇᵃ[I₀] M) x => f x :=
 
 theorem coe_inj {f g : ι →ᵇᵃ[I₀] M} : (f : Box ι → M) = g ↔ f = g := DFunLike.coe_fn_eq
 
+@[ext]
+theorem ext {f g : ι →ᵇᵃ[I₀] M} (h : ∀ J, f J = g J) : f = g :=
+  DFunLike.ext _ _ h
+
 theorem sum_partition_boxes (f : ι →ᵇᵃ[I₀] M) (hI : ↑I ≤ I₀) {π : Prepartition I}
     (h : π.IsPartition) : ∑ J ∈ π.boxes, f J = f I :=
   f.sum_partition_boxes' I hI π h
+
+/-! ### Additive monoid structure -/
 
 @[simps -fullyApplied]
 instance : Zero (ι →ᵇᵃ[I₀] M) :=
@@ -100,6 +108,15 @@ instance {R} [Monoid R] [DistribMulAction R M] : SMul R (ι →ᵇᵃ[I₀] M) :
 
 instance : AddCommMonoid (ι →ᵇᵃ[I₀] M) :=
   Function.Injective.addCommMonoid _ coe_injective rfl (fun _ _ => rfl) fun _ _ => rfl
+
+@[simp]
+lemma add_apply (f g : ι →ᵇᵃ[I₀] M) (J : Box ι) : (f + g) J = f J + g J := rfl
+
+@[simp]
+lemma smul_apply {R : Type*} [Monoid R] [DistribMulAction R M]
+    (c : R) (f : ι →ᵇᵃ[I₀] M) (J : Box ι) : (c • f) J = c • (f J) := rfl
+
+/-! ### Constructions and combinators -/
 
 @[simp]
 theorem map_split_add (f : ι →ᵇᵃ[I₀] M) (hI : ↑I ≤ I₀) (i : ι) (x : ℝ) :
@@ -163,7 +180,38 @@ theorem sum_boxes_congr [Finite ι] (f : ι →ᵇᵃ[I₀] M) (hI : ↑I ≤ I�
   exacts [(WithTop.coe_le_coe.2 <| π₁.le_of_mem hJ).trans hI,
     (WithTop.coe_le_coe.2 <| π₂.le_of_mem hJ).trans hI]
 
+section AddCommGroup
+
+/-! ### Additive group structure -/
+
+variable {M : Type*} [AddCommGroup M]
+
+instance : Neg (ι →ᵇᵃ[I₀] M) :=
+  ⟨fun f ↦
+    ⟨-(f : Box ι → M), fun I hI π hπ ↦ by
+      simp only [Pi.neg_apply, Finset.sum_neg_distrib, sum_partition_boxes _ hI hπ]⟩⟩
+
+instance : Sub (ι →ᵇᵃ[I₀] M) :=
+  ⟨fun f g ↦
+    ⟨(f : Box ι → M) - g, fun I hI π hπ ↦ by
+      simp only [Pi.sub_apply, Finset.sum_sub_distrib, sum_partition_boxes _ hI hπ]⟩⟩
+
+instance : AddCommGroup (ι →ᵇᵃ[I₀] M) :=
+  Function.Injective.addCommGroup _ DFunLike.coe_injective
+    rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
+    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+@[simp]
+lemma neg_apply (f : ι →ᵇᵃ[I₀] M) (J : Box ι) : (-f) J = -(f J) := rfl
+
+@[simp]
+lemma sub_apply (f g : ι →ᵇᵃ[I₀] M) (J : Box ι) : (f - g) J = f J - g J := rfl
+
+end AddCommGroup
+
 section ToSMul
+
+/-! ### Scalar multiplication on a normed space -/
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
@@ -176,6 +224,8 @@ def toSMul (f : ι →ᵇᵃ[I₀] ℝ) : ι →ᵇᵃ[I₀] E →L[ℝ] E :=
 theorem toSMul_apply (f : ι →ᵇᵃ[I₀] ℝ) (I : Box ι) (x : E) : f.toSMul I x = f I • x := rfl
 
 end ToSMul
+
+/-! ### Difference along an axis: `upper − lower` over faces -/
 
 /-- Given a box `I₀` in `ℝⁿ⁺¹`, `f x : Box (Fin n) → G` is a family of functions indexed by a real
 `x` and for `x ∈ [I₀.lower i, I₀.upper i]`, `f x` is box-additive on subboxes of the `i`-th face of


### PR DESCRIPTION
Thjs PR records some minor API additions to `Analysis.BoxIntegral` and `Analysis.BoxIntegral.BoxAdditiveMap` that arose as part of the ICERM Riemann-Stieltjes integration project, but are of general utility beyond that project.

---

The additions are:

- Congruence lemmas for `BoxIntegral.integralSum` and `BoxIntegral.HasIntegral`
- an `ext` lemma and `AddCommGroup` structure for `BoxIntegral.BoxAdditiveMap`, with the standard `apply` lemmas
- some docstring sectioning

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
