### PR TITLE
[Merged by Bors] - fix(Tactic/DepRewrite): `rw!` produces type incorrect terms

### DIFF
--- a/Mathlib/Tactic/DepRewrite.lean
+++ b/Mathlib/Tactic/DepRewrite.lean
@@ -23,9 +23,12 @@ theorem dcongrArg.{u, v} {α : Sort u} {a a' : α} {β : (a' : α) → a = a' �
     f a rfl = Eq.rec (motive := fun x h' ↦ β x (h.trans h')) (f a' h) h.symm := by
   cases h; rfl
 
-theorem nddcongrArg.{u, v} {α : Sort u} {a a' : α} {β : Sort v}
-    (h : a = a') (f : (a' : α) → (h : a = a') → β) :
-    f a rfl = f a' h := by
+theorem hdcongrArg.{u, v} {α : Sort u} {a a' : α} {β : (a' : α) → a = a' → Sort v}
+    (h : a = a') (f : (a' : α) → (h : a = a') → β a' h) :
+    f a rfl ≍ f a' h := by
+  cases h; rfl
+
+theorem eq_of_heq.{u} {α : Sort u} {a a' : α} (h : a ≍ a') : a = a' := by
   cases h; rfl
 
 theorem heqL.{u} {α β : Sort u} {a : α} {b : β} (h : HEq a b) :
@@ -467,20 +470,21 @@ def _root_.Lean.MVarId.depRewrite (mvarId : MVarId) (e : Expr) (heq : Expr)
           -- `eqPrf : eAbst lhs rfl = eNew`
           -- `eAbst lhs rfl ≡ e`
           let (eNew, eqPrf) ← do
-            if isDep then
-              lambdaBoundedTelescope eAbst 2 fun xs eBody => do
-                let #[x, h] := xs | throwError
-                  "internal error: expected 2 arguments in{indentExpr eAbst}"
-                let eBodyTp ← inferType eBody
-                checkCastAllowed eBody eBodyTp config.castMode
-                let some eBody ← castBack? eBody eBodyTp x h ∅ ∅ | throwError
+            lambdaBoundedTelescope eAbst 2 fun xs eBody => do
+              let #[x, h] := xs | throwError
+                "internal error: expected 2 arguments in{indentExpr eAbst}"
+              let eBodyTyp ← inferType eBody
+              let motive ← mkLambdaFVars xs eBodyTyp
+              if isDep then
+                checkCastAllowed eBody eBodyTyp config.castMode
+                let some eBody ← castBack? eBody eBodyTyp x h ∅ ∅ | throwError
                   "internal error: body{indentExpr eBody}\nshould mention '{x}' or '{h}'"
-                let motive ← mkLambdaFVars xs eBodyTp
                 pure (
                   eBody.replaceFVars #[x, h] #[rhs, heq],
                   mkApp6 (.const ``dcongrArg [u1, u2]) α lhs rhs motive heq eAbst)
-            else
-              pure (eNew, mkApp6 (.const ``nddcongrArg [u1, u2]) α lhs rhs eType heq eAbst)
+              else
+                let heqPrf := mkApp6 (.const ``hdcongrArg [u1, u2]) α lhs rhs motive heq eAbst
+                pure (eNew, mkApp4 (.const ``eq_of_heq [u2]) eType e eNew heqPrf)
           postprocessAppMVars `depRewrite mvarId newMVars binderInfos
             (synthAssignedInstances := !tactic.skipAssignedInstances.get (← getOptions))
           let newMVarIds ← newMVars.map Expr.mvarId! |>.filterM fun mvarId =>

--- a/MathlibTest/depRewrite.lean
+++ b/MathlibTest/depRewrite.lean
@@ -525,3 +525,18 @@ example {ι : Type*} {X : ι → Sort*} (f : ∀ i, X i) (i : ι) (y : X i) :
   conv => lhs; rw! [h]; trace_state
   trace_state
   exact test_sorry
+
+def PropOrBool (x : Bool) : Type :=
+  bif x then Prop else Bool
+
+def boolToPropOrBool (x y : Bool) : PropOrBool x :=
+  match x with
+  | true => y = true
+  | false => y
+
+theorem foo : let t := true; boolToPropOrBool t t := by
+  intro t
+  have h : t = true := rfl
+  rw! [h]
+  guard_target =ₛ boolToPropOrBool true true
+  rfl

--- a/MathlibTest/depRewrite.lean
+++ b/MathlibTest/depRewrite.lean
@@ -493,3 +493,35 @@ example (f : Nat → ∀ c, Fin (c + n)) : P (f (f (f m n) (f n m)) n).1 := by
   rw! (castMode := .all) [eq, ← eq]
   guard_target =ₛ P ((f (f (f n n) (f n n))) n).1
   exact test_sorry
+
+-- https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/conv-mode.20rw.21.20can.20produce.20type-incorrect.20term/near/609501125
+/--
+trace: n m : Nat
+eq : n = m
+B : Nat → Type
+ι : Type u_1
+X : ι → Sort u_2
+f : (i : ι) → X i
+i : ι
+y : X i
+h : (i, 1).fst = i
+| f i
+---
+trace: n m : Nat
+eq : n = m
+B : Nat → Type
+ι : Type u_1
+X : ι → Sort u_2
+f : (i : ι) → X i
+i : ι
+y : X i
+h : (i, 1).fst = i
+⊢ f i = y
+-/
+#guard_msgs in
+example {ι : Type*} {X : ι → Sort*} (f : ∀ i, X i) (i : ι) (y : X i) :
+    f (i, 1).1 = y := by
+  have h : (i, 1).1 = i := rfl
+  conv => lhs; rw! [h]; trace_state
+  trace_state
+  exact test_sorry

--- a/MathlibTest/depRewrite.lean
+++ b/MathlibTest/depRewrite.lean
@@ -534,9 +534,16 @@ def boolToPropOrBool (x y : Bool) : PropOrBool x :=
   | true => y = true
   | false => y
 
-theorem foo : let t := true; boolToPropOrBool t t := by
+example : let t := true; boolToPropOrBool t t := by
   intro t
   have h : t = true := rfl
   rw! [h]
   guard_target =ₛ boolToPropOrBool true true
   rfl
+
+example : let t := true; boolToPropOrBool (t || true) t := by
+  intro t
+  have h : t = false := test_sorry
+  rw! [h]
+  guard_target =ₛ boolToPropOrBool (false || true) false
+  contradiction


### PR DESCRIPTION
Fix bug where `rw!` can produce type-incorrect terms when the motive is dependent but the rewritten term is definitionally equal to the original term. See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/conv-mode.20rw.21.20can.20produce.20type-incorrect.20term/near/609501125).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
