### PR TITLE
[Merged by Bors] - feat(Algebra/Order/BigOperators): add `Finset.prod_le_prod_of_injOn`

### DIFF
--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -164,7 +164,7 @@ theorem prod_le_univ_prod_of_one_le' [MulLeftMono N] [Fintype ι] {s : Finset ι
 @[to_additive sum_le_sum_of_injOn]
 theorem prod_le_prod_of_injOn' [DecidableEq α] [MulLeftMono N]
     {g : α → N} {s : Finset ι} {t : Finset α} (e : ι → α) (he : Set.InjOn e s)
-    (ht : Finset.image e s ⊆ t) (h : ∀ i ∈ s, f i ≤ g (e i))
+    (ht : image e s ⊆ t) (h : ∀ i ∈ s, f i ≤ g (e i))
     (hg : ∀ a ∈ t, a ∉ image e s → 1 ≤ g a) :
     ∏ i ∈ s, f i ≤ ∏ a ∈ t, g a := by
   refine le_trans ?_ <| prod_le_prod_of_subset_of_one_le' ht hg

--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -161,6 +161,15 @@ theorem prod_le_univ_prod_of_one_le' [MulLeftMono N] [Fintype ι] {s : Finset ι
     ∏ x ∈ s, f x ≤ ∏ x, f x :=
   prod_le_prod_of_subset_of_one_le' (subset_univ s) fun a _ _ ↦ w a
 
+@[to_additive sum_le_sum_of_injOn]
+theorem prod_le_prod_of_injOn' [DecidableEq α] [MulLeftMono N]
+    {g : α → N} {s : Finset ι} {t : Finset α} (e : ι → α) (he : Set.InjOn e s)
+    (ht : Finset.image e s ⊆ t) (h : ∀ i ∈ s, f i ≤ g (e i))
+    (hg : ∀ a ∈ t, a ∉ image e s → 1 ≤ g a) :
+    ∏ i ∈ s, f i ≤ ∏ a ∈ t, g a := by
+  refine le_trans ?_ <| prod_le_prod_of_subset_of_one_le' ht hg
+  grw [prod_image he, prod_le_prod' h]
+
 @[to_additive sum_eq_zero_iff_of_nonneg]
 theorem prod_eq_one_iff_of_one_le' {ι : Type u_1} {N : Type u_5} [CommMonoid N] [PartialOrder N]
     {f : ι → N} {s : Finset ι} [MulLeftMono N] :

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Finset.lean
@@ -98,6 +98,14 @@ theorem prod_anti_set_of_le_one (hf0 : ∀ (x : ι), 0 ≤ f x) (hf : ∀ (x : �
     Antitone fun (s : Finset ι) => ∏ x ∈ s, f x :=
   fun _ _ hst ↦ prod_le_prod_of_subset_of_le_one hst (by grind) (by simp [hf])
 
+theorem prod_le_prod_of_injOn {α : Type*} [DecidableEq α]
+    {g : α → R} {s : Finset ι} {t : Finset α} (e : ι → α) (he : Set.InjOn e s)
+    (ht : Finset.image e s ⊆ t) (h : ∀ i ∈ s, f i ≤ g (e i))
+    (hf0 : ∀ i ∈ s, 0 ≤ f i) (hg : ∀ a ∈ t, a ∉ image e s → 1 ≤ g a) :
+    ∏ i ∈ s, f i ≤ ∏ a ∈ t, g a := by
+  refine le_trans ?_ (prod_le_prod_of_subset_of_one_le ht (by grind) hg)
+  grw [prod_image he, prod_le_prod hf0 h]
+
 end PosMulMono
 
 section PosMulStrictMono

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Finset.lean
@@ -100,7 +100,7 @@ theorem prod_anti_set_of_le_one (hf0 : ∀ (x : ι), 0 ≤ f x) (hf : ∀ (x : �
 
 theorem prod_le_prod_of_injOn {α : Type*} [DecidableEq α]
     {g : α → R} {s : Finset ι} {t : Finset α} (e : ι → α) (he : Set.InjOn e s)
-    (ht : Finset.image e s ⊆ t) (h : ∀ i ∈ s, f i ≤ g (e i))
+    (ht : image e s ⊆ t) (h : ∀ i ∈ s, f i ≤ g (e i))
     (hf0 : ∀ i ∈ s, 0 ≤ f i) (hg : ∀ a ∈ t, a ∉ image e s → 1 ≤ g a) :
     ∏ i ∈ s, f i ≤ ∏ a ∈ t, g a := by
   refine le_trans ?_ (prod_le_prod_of_subset_of_one_le ht (by grind) hg)


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
