### PR TITLE
[Merged by Bors] - refactor(RepresentationTheory): move instance Abelian (Rep k G) to Rep.Basic

### DIFF
--- a/Mathlib/RepresentationTheory/Rep/Basic.lean
+++ b/Mathlib/RepresentationTheory/Rep/Basic.lean
@@ -571,6 +571,8 @@ instance : Limits.ReflectsLimitsOfSize.{w, w} (forget₂ (Rep.{w} k G) (ModuleCa
 instance : Limits.ReflectsColimitsOfSize.{w, w} (forget₂ (Rep.{w} k G) (ModuleCat k)) :=
   Limits.reflectsColimits_of_reflectsIsomorphisms
 
+instance : Abelian (Rep.{w} k G) := abelianOfEquivalence (RepToAction k G)
+
 variable {k G} in
 theorem epi_iff_surjective (f : A ⟶ B) : Epi f ↔ Function.Surjective f.hom :=
   ⟨fun _ => (ModuleCat.epi_iff_surjective ((forget₂ _ _).map f)).1 inferInstance,

--- a/Mathlib/RepresentationTheory/Rep/Iso.lean
+++ b/Mathlib/RepresentationTheory/Rep/Iso.lean
@@ -168,8 +168,6 @@ instance : (toModuleMonoidAlgebra.{w} (k := k) (G := G)).IsEquivalence :=
 instance : (ofModuleMonoidAlgebra (k := k) (G := G)).IsEquivalence :=
   (equivalenceModuleMonoidAlgebra (k := k) (G := G)).isEquivalence_inverse
 
-instance : Abelian (Rep.{w} k G) := abelianOfEquivalence toModuleMonoidAlgebra
-
 -- TODO Verify that the equivalence with `ModuleCat k[G]` is a monoidal functor.
 
 variable {k G : Type u} [CommRing k] [Monoid G] in


### PR DESCRIPTION
This instance removes the commutativity assumption on k in the current instance Abelian (Rep k G) in Rep.Iso.