### PR TITLE
feat(Order): add subset_Icc_iff and Set.OrdConnected.eq_Icc

### DIFF
--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -604,9 +604,11 @@ end
 theorem bddBelow_iff_subset_Ici : BddBelow s ↔ ∃ a, s ⊆ Ici a :=
   Iff.rfl
 
-theorem bddBelow_bddAbove_iff_subset_Icc : BddBelow s ∧ BddAbove s ↔ ∃ a b, s ⊆ Icc a b := by
-  simp [Ici_inter_Iic.symm, subset_inter_iff, bddBelow_iff_subset_Ici,
-    bddAbove_iff_subset_Iic, exists_and_left, exists_and_right]
+theorem subset_Icc_iff : s ⊆ Icc a b ↔ a ∈ lowerBounds s ∧ b ∈ upperBounds s :=
+  subset_inter_iff.trans (mem_lowerBounds_iff_subset_Ici.and mem_upperBounds_iff_subset_Iic)
+
+theorem bddBelow_bddAbove_iff_subset_Icc : BddBelow s ∧ BddAbove s ↔ ∃ a b, s ⊆ Icc a b :=
+  exists_and_exists_comm.trans <| exists₂_congr fun _ _ ↦ subset_Icc_iff.symm
 
 /-!
 #### Univ

--- a/Mathlib/Order/Interval/Set/OrdConnected.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnected.lean
@@ -64,6 +64,10 @@ protected theorem Icc_subset (s : Set α) [hs : OrdConnected s] {x y} (hx : x �
     Icc x y ⊆ s :=
   hs.out hx hy
 
+theorem OrdConnected.eq_Icc {a b : α} (hs : OrdConnected s) (ha : IsLeast s a)
+    (hb : IsGreatest s b) : s = Icc a b :=
+  Subset.antisymm (fun _ hx ↦ ⟨ha.2 hx, hb.2 hx⟩) (hs.out ha.1 hb.1)
+
 end Preorder
 
 end Set


### PR DESCRIPTION
Add two lemmas relating to closed bounded intervals in a preorder:

- `subset_Icc_iff : s ⊆ Icc a b ↔ a ∈ lowerBounds s ∧ b ∈ upperBounds s` in `Mathlib/Order/Bounds/Basic.lean` characterizes containment in a closed bounded interval. This is the version "with witnesses" of `bddBelow_bddAbove_iff_subset_Icc`, and we prove the latter as a corollary.
- `OrdConnected.eq_Icc (s : Set α) (hs : OrdConnected s) (ha : IsLeast s a) (hb : IsGreatest s b) : s = Icc a b` in `Mathlib/Order/Interval/Set/OrdConnected.lean` gives a sufficient condition to be a closed bounded interval.  It uses the previous lemma in its proof.

---

**Motivation:** I plan to use `OrdConnected.eq_Icc` to show that a set is closed when it is ordconnected and contains its infimum and supremum. This will allow to use the existing "continuous induction principle" `IsClosed.mem_of_ge_of_forall_exists_gt` to shorten the (compiling) proof in the draft PR #41552.