### PR TITLE
[Merged by Bors] - chore: golf proof of smoothness of immersions and submersions

### DIFF
--- a/Mathlib/Geometry/Manifold/Immersion.lean
+++ b/Mathlib/Geometry/Manifold/Immersion.lean
@@ -425,12 +425,7 @@ theorem contMDiffOn (h : IsImmersionAtOfComplement F I J n f x) :
     h.codChart_mem_maximalAtlas le_rfl h.mapsto_domChart_source_codChart_source,
     ← h.domChart.extend_target_eq_image_source]
   have : CMDiff n (h.equiv ∘ fun x ↦ (x, 0)) := by
-    have : ContMDiff 𝓘(𝕜, E × F) 𝓘(𝕜, E'') n h.equiv := by
-      rw [contMDiff_iff_contDiff]
-      exact h.equiv.contDiff
-    apply this.comp
-    rw [contMDiff_iff_contDiff, contDiff_prod_iff]
-    exact ⟨contDiff_id, contDiff_const (c := (0 : F))⟩
+    rw [contMDiff_iff_contDiff]; fun_prop
   exact this.contMDiffOn.congr h.writtenInCharts
 
 /-- A `C^n` immersion at `x` is `C^n` at `x`. -/
@@ -475,10 +470,8 @@ private lemma aux {f : M → N} {φ : N → N'}
     rw [h.domChart.extend_target_eq_image_source]
     exact ⟨(f ∘ (extChartAt I x).symm) y, ht hy.1, by simp⟩
   -- Composing with a suitable projection to cancel the inclusion, we deduce that `f` is `C^n`.
-  have h'''' : ContDiffWithinAt 𝕜 n ((Prod.fst ∘ h.equiv.symm) ∘ f'') s x' := by
-    refine ContDiffWithinAt.comp x' ?_ h''' (mapsTo_univ _ _)
-    rw [contDiffWithinAt_univ]
-    exact contDiffAt_fst.comp _ h.equiv.symm.contDiff.contDiffAt
+  have h'''' : ContDiffWithinAt 𝕜 n ((Prod.fst ∘ h.equiv.symm) ∘ f'') s x' :=
+    ContDiffWithinAt.comp x' (by fun_prop) h''' (mapsTo_univ _ _)
   exact h''''.congr_of_mem (fun y hy ↦ by simp [f'']) hx'
 
 /-- A function `f : M → N` between `C^n` manifolds is `C^n` at `x` if and only if it is continuous

--- a/Mathlib/Geometry/Manifold/Submersion.lean
+++ b/Mathlib/Geometry/Manifold/Submersion.lean
@@ -368,16 +368,7 @@ theorem contMDiffOn (h : IsSubmersionAtOfComplement F I J n f x) :
   rw [← contMDiffOn_writtenInExtend_iff h.domChart_mem_maximalAtlas
     h.codChart_mem_maximalAtlas le_rfl h.mapsto_domChart_source_codChart_source,
     ← h.domChart.extend_target_eq_image_source]
-  have : CMDiff n (Prod.fst ∘ h.equiv) := by
-  -- Note that we cannot use `h₁.comp contMDiff_fst` since `h₁` and `contMDiff_fst` require
-  -- different models with corners on `E'' × F`. The former uses `𝓘(𝕜, E'' × F)` while the latter
-  -- uses `(𝓘(𝕜, E'')).prod (𝓘(𝕜, F)`.
-    have h₁ : ContMDiff 𝓘(𝕜, E) 𝓘(𝕜, E'' × F) n h.equiv := by
-      rw [contMDiff_iff_contDiff]
-      exact h.equiv.contDiff
-    apply ContMDiff.comp ?_ h₁
-    rw [contMDiff_iff_contDiff]
-    exact contDiff_fst
+  have : CMDiff n (Prod.fst ∘ h.equiv) := by rw [contMDiff_iff_contDiff]; fun_prop
   exact this.contMDiffOn.congr h.writtenInCharts
 
 /-- A `C^n` submersion at `x` is `C^n` at `x`. -/


### PR DESCRIPTION
The current proof of `Is{Immersion,Submersion}AtOfComplement.contMDiffOn` is slightly longer because two lemmas expect (mathematically equivalent, but incompatible) models with corners.
Side-step this by passing to the normed space setting at first, where this issue does not arise.
Pointed out by kim-em using Claude code.

While at it, also golf one proof using `fun_prop`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
