### PR TITLE
chore: add missing `to_additive` docstrings in Algebra/Group actions and homs

### DIFF
--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -345,17 +345,23 @@ end SMul
 section
 
 /-- Note that the `SMulCommClass α β β` typeclass argument is usually satisfied by `Algebra α β`. -/
-@[to_additive]
+@[to_additive
+/-- Note that the `VAddCommClass α β β` typeclass argument is usually satisfied by `Algebra α β`.
+-/]
 lemma mul_smul_comm [Mul β] [SMul α β] [SMulCommClass α β β] (s : α) (x y : β) :
     x * s • y = s • (x * y) := (smul_comm s x y).symm
 
 /-- Note that the `IsScalarTower α β β` typeclass argument is usually satisfied by `Algebra α β`. -/
-@[to_additive]
+@[to_additive
+/-- Note that the `VAddAssocClass α β β` typeclass argument is usually satisfied by `Algebra α β`.
+-/]
 lemma smul_mul_assoc [Mul β] [SMul α β] [IsScalarTower α β β] (r : α) (x y : β) :
     r • x * y = r • (x * y) := smul_assoc r x y
 
 /-- Note that the `IsScalarTower α β β` typeclass argument is usually satisfied by `Algebra α β`. -/
-@[to_additive]
+@[to_additive
+/-- Note that the `VAddAssocClass α β β` typeclass argument is usually satisfied by `Algebra α β`.
+-/]
 lemma smul_div_assoc [DivInvMonoid β] [SMul α β] [IsScalarTower α β β] (r : α) (x y : β) :
     r • x / y = r • (x / y) := by simp [div_eq_mul_inv, smul_mul_assoc]
 
@@ -366,7 +372,9 @@ lemma smul_smul_smul_comm [SMul α β] [SMul α γ] [SMul β δ] [SMul α δ] [S
 
 /-- Note that the `IsScalarTower α β β` and `SMulCommClass α β β` typeclass arguments are usually
 satisfied by `Algebra α β`. -/
-@[to_additive]
+@[to_additive
+/-- Note that the `VAddAssocClass α β β` and `VAddCommClass α β β` typeclass arguments are usually
+satisfied by `Algebra α β`. -/]
 lemma smul_mul_smul_comm [Mul α] [Mul β] [SMul α β] [IsScalarTower α β β]
     [IsScalarTower α α β] [SMulCommClass α β β] (a : α) (b : β) (c : α) (d : β) :
     (a • b) * (c • d) = (a * c) • (b * d) := by
@@ -377,7 +385,9 @@ alias smul_mul_smul := smul_mul_smul_comm
 
 /-- Note that the `IsScalarTower α β β` and `SMulCommClass α β β` typeclass arguments are usually
 satisfied by `Algebra α β`. -/
-@[to_additive]
+@[to_additive
+/-- Note that the `VAddAssocClass α β β` and `VAddCommClass α β β` typeclass arguments are usually
+satisfied by `Algebra α β`. -/]
 lemma mul_smul_mul_comm [Mul α] [Mul β] [SMul α β] [IsScalarTower α β β]
     [IsScalarTower α α β] [SMulCommClass α β β] (a b : α) (c d : β) :
     (a * b) • (c * d) = (a • c) * (b • d) := smul_smul_smul_comm a b c d
@@ -589,7 +599,12 @@ lemma SMulCommClass.of_mul_smul_one {M N} [Monoid N] [SMul M N]
 Let `Q / P / N / M` be a tower. If `P / N / M`, `Q / P / M` and `Q / P / N` are
 scalar towers, then `Q / N / M` is also a scalar tower.
 -/
-@[to_additive] lemma IsScalarTower.to₁₂₄ (M N P Q)
+@[to_additive
+/--
+Let `Q / P / N / M` be a tower. If `P / N / M`, `Q / P / M` and `Q / P / N` are
+vector addition towers, then `Q / N / M` is also a vector addition tower.
+-/]
+lemma IsScalarTower.to₁₂₄ (M N P Q)
     [SMul M N] [SMul M P] [SMul M Q] [SMul N P] [SMul N Q] [Monoid P] [MulAction P Q]
     [IsScalarTower M N P] [IsScalarTower M P Q] [IsScalarTower N P Q] : IsScalarTower M N Q where
   smul_assoc m n q := by rw [← smul_one_smul P, smul_assoc m, smul_assoc, smul_one_smul]
@@ -598,7 +613,12 @@ scalar towers, then `Q / N / M` is also a scalar tower.
 Let `Q / P / N / M` be a tower. If `P / N / M`, `Q / N / M` and `Q / P / N` are
 scalar towers, then `Q / P / M` is also a scalar tower.
 -/
-@[to_additive] lemma IsScalarTower.to₁₃₄ (M N P Q)
+@[to_additive
+/--
+Let `Q / P / N / M` be a tower. If `P / N / M`, `Q / N / M` and `Q / P / N` are
+vector addition towers, then `Q / P / M` is also a vector addition tower.
+-/]
+lemma IsScalarTower.to₁₃₄ (M N P Q)
     [SMul M N] [SMul M P] [SMul M Q] [SMul P Q] [Monoid N] [MulAction N P] [MulAction N Q]
     [IsScalarTower M N P] [IsScalarTower M N Q] [IsScalarTower N P Q] : IsScalarTower M P Q where
   smul_assoc m p q := by rw [← smul_one_smul N m, smul_assoc, smul_one_smul]
@@ -607,7 +627,12 @@ scalar towers, then `Q / P / M` is also a scalar tower.
 Let `Q / P / N / M` be a tower. If `P / N / M`, `Q / N / M` and `Q / P / M` are
 scalar towers, then `Q / P / N` is also a scalar tower.
 -/
-@[to_additive] lemma IsScalarTower.to₂₃₄ (M N P Q)
+@[to_additive
+/--
+Let `Q / P / N / M` be a tower. If `P / N / M`, `Q / N / M` and `Q / P / M` are
+vector addition towers, then `Q / P / N` is also a vector addition tower.
+-/]
+lemma IsScalarTower.to₂₃₄ (M N P Q)
     [SMul M N] [SMul M P] [SMul M Q] [SMul P Q] [Monoid N] [MulAction N P] [MulAction N Q]
     [IsScalarTower M N P] [IsScalarTower M N Q] [IsScalarTower M P Q]
     (h : Function.Surjective fun m : M ↦ m • (1 : N)) : IsScalarTower N P Q where

--- a/Mathlib/Algebra/Group/Action/Faithful.lean
+++ b/Mathlib/Algebra/Group/Action/Faithful.lean
@@ -131,7 +131,10 @@ lemma FaithfulSMul.trans (R S T : Type*) [Monoid S] [MulOneClass T]
 Let `Q / P / N / M` be a tower. If `Q / N / M`, `Q / P / M` and `Q / P / N` are
 scalar towers, then `P / N / M` is also a scalar tower.
 -/
-@[to_additive] lemma IsScalarTower.to₁₂₃ (M N P Q)
+@[to_additive /--
+Let `Q / P / N / M` be a tower. If `Q / N / M`, `Q / P / M` and `Q / P / N` are
+vadd towers, then `P / N / M` is also a vadd tower.
+-/] lemma IsScalarTower.to₁₂₃ (M N P Q)
     [SMul M N] [SMul M P] [SMul M Q] [SMul N P] [SMul N Q] [SMul P Q] [FaithfulSMul P Q]
     [IsScalarTower M N Q] [IsScalarTower M P Q] [IsScalarTower N P Q] : IsScalarTower M N P where
   smul_assoc m n p := by simp_rw [← (smul_left_injective' (α := Q)).eq_iff, smul_assoc]

--- a/Mathlib/Algebra/Group/Action/Faithful.lean
+++ b/Mathlib/Algebra/Group/Action/Faithful.lean
@@ -133,7 +133,7 @@ scalar towers, then `P / N / M` is also a scalar tower.
 -/
 @[to_additive /--
 Let `Q / P / N / M` be a tower. If `Q / N / M`, `Q / P / M` and `Q / P / N` are
-vadd towers, then `P / N / M` is also a vadd tower.
+vector addition towers, then `P / N / M` is also a vector addition tower.
 -/]
 lemma IsScalarTower.to₁₂₃ (M N P Q)
     [SMul M N] [SMul M P] [SMul M Q] [SMul N P] [SMul N Q] [SMul P Q] [FaithfulSMul P Q]

--- a/Mathlib/Algebra/Group/Action/Faithful.lean
+++ b/Mathlib/Algebra/Group/Action/Faithful.lean
@@ -134,7 +134,8 @@ scalar towers, then `P / N / M` is also a scalar tower.
 @[to_additive /--
 Let `Q / P / N / M` be a tower. If `Q / N / M`, `Q / P / M` and `Q / P / N` are
 vadd towers, then `P / N / M` is also a vadd tower.
--/] lemma IsScalarTower.to₁₂₃ (M N P Q)
+-/]
+lemma IsScalarTower.to₁₂₃ (M N P Q)
     [SMul M N] [SMul M P] [SMul M Q] [SMul N P] [SMul N Q] [SMul P Q] [FaithfulSMul P Q]
     [IsScalarTower M N Q] [IsScalarTower M P Q] [IsScalarTower N P Q] : IsScalarTower M N P where
   smul_assoc m n p := by simp_rw [← (smul_left_injective' (α := Q)).eq_iff, smul_assoc]

--- a/Mathlib/Algebra/Group/Action/Hom.lean
+++ b/Mathlib/Algebra/Group/Action/Hom.lean
@@ -64,7 +64,9 @@ lemma compHom_smul_def
 
 /-- If an action is transitive, then composing this action with a surjective homomorphism gives
 again a transitive action. -/
-@[to_additive]
+@[to_additive
+/-- If an action is transitive, then composing this action with a surjective homomorphism gives
+again a transitive action. -/]
 lemma isPretransitive_compHom {E F G : Type*} [Monoid E] [Monoid F] [MulAction F G]
     [IsPretransitive F G] {f : E →* F} (hf : Surjective f) :
     letI : MulAction E G := MulAction.compHom _ f

--- a/Mathlib/Algebra/Group/Action/Units.lean
+++ b/Mathlib/Algebra/Group/Action/Units.lean
@@ -69,7 +69,9 @@ instance [Monoid M] [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
 
 /-- If an action `G` associates and commutes with multiplication on `M`, then it lifts to an
 action on `Mˣ`. Notably, this provides `MulAction Mˣ Nˣ` under suitable conditions. -/
-@[to_additive]
+@[to_additive /-- If an action `G` associates and commutes with addition on `M`, then it lifts to an
+action on `AddUnits M`. Notably, this provides `AddAction (AddUnits M) (AddUnits N)` under suitable
+conditions. -/]
 instance mulAction' [Group G] [Monoid M] [MulAction G M] [SMulCommClass G M M]
     [IsScalarTower G M M] : MulAction G Mˣ where
   smul g m :=
@@ -102,7 +104,8 @@ lemma val_smul [Group G] [Monoid M] [MulAction G M] [SMulCommClass G M M] [IsSca
     (g : G) (m : Mˣ) : ↑(g • m) = g • (m : M) := rfl
 
 /-- Note that this lemma exists more generally as the global `smul_inv` -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) /-- Note that this lemma exists more generally as the global
+`vadd_neg` -/]
 lemma smul_inv [Group G] [Monoid M] [MulAction G M] [SMulCommClass G M M] [IsScalarTower G M M]
     (g : G) (m : Mˣ) : (g • m)⁻¹ = g⁻¹ • m⁻¹ := ext rfl
 

--- a/Mathlib/Algebra/Group/Action/Units.lean
+++ b/Mathlib/Algebra/Group/Action/Units.lean
@@ -103,6 +103,7 @@ lemma smul_eq_mul {M} [CommMonoid M] (u₁ u₂ : Mˣ) :
 lemma val_smul [Group G] [Monoid M] [MulAction G M] [SMulCommClass G M M] [IsScalarTower G M M]
     (g : G) (m : Mˣ) : ↑(g • m) = g • (m : M) := rfl
 
+/-- Note that this lemma exists more generally as the global `smul_inv` -/
 @[to_additive (attr := simp)]
 lemma smul_inv [Group G] [Monoid M] [MulAction G M] [SMulCommClass G M M] [IsScalarTower G M M]
     (g : G) (m : Mˣ) : (g • m)⁻¹ = g⁻¹ • m⁻¹ := ext rfl

--- a/Mathlib/Algebra/Group/Action/Units.lean
+++ b/Mathlib/Algebra/Group/Action/Units.lean
@@ -103,9 +103,7 @@ lemma smul_eq_mul {M} [CommMonoid M] (u₁ u₂ : Mˣ) :
 lemma val_smul [Group G] [Monoid M] [MulAction G M] [SMulCommClass G M M] [IsScalarTower G M M]
     (g : G) (m : Mˣ) : ↑(g • m) = g • (m : M) := rfl
 
-/-- Note that this lemma exists more generally as the global `smul_inv` -/
-@[to_additive (attr := simp) /-- Note that this lemma exists more generally as the global
-`vadd_neg` -/]
+@[to_additive (attr := simp)]
 lemma smul_inv [Group G] [Monoid M] [MulAction G M] [SMulCommClass G M M] [IsScalarTower G M M]
     (g : G) (m : Mˣ) : (g • m)⁻¹ = g⁻¹ • m⁻¹ := ext rfl
 

--- a/Mathlib/Algebra/Group/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Group/Equiv/Defs.lean
@@ -203,7 +203,8 @@ theorem toEquiv_eq_coe (f : M ≃* N) : f.toEquiv = f :=
   rfl
 
 /-- The `simp`-normal form to turn something into a `MulHom` is via `MulHomClass.toMulHom`. -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) /-- The `simp`-normal form to turn something into an `AddHom` is via
+`AddHomClass.toAddHom`. -/]
 theorem toMulHom_eq_coe (f : M ≃* N) : f.toMulHom = ↑f :=
   rfl
 
@@ -211,7 +212,7 @@ theorem toMulHom_eq_coe (f : M ≃* N) : f.toMulHom = ↑f :=
 theorem toFun_eq_coe (f : M ≃* N) : f.toFun = f := rfl
 
 /-- `simp`-normal form of `toFun_eq_coe`. -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) /-- `simp`-normal form of `toFun_eq_coe`. -/]
 theorem coe_toEquiv (f : M ≃* N) : ⇑(f : M ≃ N) = f := rfl
 
 @[to_additive (attr := simp)]
@@ -275,7 +276,9 @@ section symm
 /-- An alias for `h.symm.map_mul`. Introduced to fix the issue in
 https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.234183.20.60simps.60.20maximum.20recursion.20depth
 -/
-@[to_additive]
+@[to_additive /-- An alias for `h.symm.map_add`. Introduced to fix the issue in
+https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.234183.20.60simps.60.20maximum.20recursion.20depth
+-/]
 lemma symm_map_mul {M N : Type*} [Mul M] [Mul N] (h : M ≃* N) (x y : N) :
     h.symm (x * y) = h.symm x * h.symm y :=
   map_mul (h.toMulHom.inverse h.toEquiv.symm h.left_inv h.right_inv) x y
@@ -289,7 +292,7 @@ def symm {M N : Type*} [Mul M] [Mul N] (h : M ≃* N) : N ≃* M :=
 theorem invFun_eq_symm {f : M ≃* N} : f.invFun = f.symm := rfl
 
 /-- `simp`-normal form of `invFun_eq_symm`. -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) /-- `simp`-normal form of `invFun_eq_symm`. -/]
 theorem coe_toEquiv_symm (f : M ≃* N) : ((f : M ≃ N).symm : N → M) = f.symm := rfl
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -230,14 +230,15 @@ is the behavior we desire.
 variable [FunLike F M N]
 
 /-- See note [hom simp lemma priority] -/
-@[to_additive (attr := simp mid, grind =)]
+@[to_additive (attr := simp mid, grind =) /-- See note [hom simp lemma priority] -/]
 theorem map_one [OneHomClass F M N] (f : F) : f 1 = 1 :=
   OneHomClass.map_one f
 
 @[to_additive] lemma map_comp_one [OneHomClass F M N] (f : F) : f ∘ (1 : ι → M) = 1 := by simp
 
 /-- In principle this could be an instance, but in practice it causes performance issues. -/
-@[to_additive]
+@[to_additive
+  /-- In principle this could be an instance, but in practice it causes performance issues. -/]
 theorem Subsingleton.of_oneHomClass [Subsingleton M] [OneHomClass F M N] :
     Subsingleton F where
   allEq f g := DFunLike.ext _ _ fun x ↦ by simp [Subsingleton.elim x 1]
@@ -322,7 +323,7 @@ instance MulHom.mulHomClass : MulHomClass (M →ₙ* N) M N where
 variable [FunLike F M N]
 
 /-- See note [hom simp lemma priority] -/
-@[to_additive (attr := simp mid, grind =)]
+@[to_additive (attr := simp mid, grind =) /-- See note [hom simp lemma priority] -/]
 theorem map_mul [MulHomClass F M N] (f : F) (x y : M) : f (x * y) = f x * f y :=
   MulHomClass.map_mul f x y
 
@@ -466,7 +467,8 @@ lemma map_comp_div [Group G] [DivisionMonoid H] [MonoidHomClass F G H] (f : F) (
     f ∘ (g / h) = f ∘ g / f ∘ h := by ext; simp
 
 /-- See note [hom simp lemma priority] -/
-@[to_additive (attr := simp mid, grind =) (reorder := a n)]
+@[to_additive (attr := simp mid, grind =) (reorder := a n)
+  /-- See note [hom simp lemma priority] -/]
 theorem map_pow [Monoid G] [Monoid H] [MonoidHomClass F G H] (f : F) (a : G) :
     ∀ n : ℕ, f (a ^ n) = f a ^ n
   | 0 => by rw [pow_zero, pow_zero, map_one]

--- a/Mathlib/Algebra/Group/Units/Hom.lean
+++ b/Mathlib/Algebra/Group/Units/Hom.lean
@@ -223,9 +223,9 @@ theorem of_leftInverse [MonoidHomClass G N M] {f : F} {x : M} (g : G)
     (hfg : Function.LeftInverse g f) (h : IsUnit (f x)) : IsUnit x := by
   simpa only [hfg x] using h.map g
 
-/-- Prefer `IsLocalHom.of_leftInverse`, but we can't get rid of this because of `ToAdditive`. -/
+/-- Prefer `isLocalHom_of_leftInverse`, but we can't get rid of this because of `ToAdditive`. -/
 @[to_additive
-  /-- Prefer `IsLocalHom.of_leftInverse`, but we can't get rid of this because of `ToAdditive`. -/]
+  /-- Prefer `isLocalHom_of_leftInverse`, but we can't get rid of this because of `ToAdditive`. -/]
 theorem _root_.isUnit_map_of_leftInverse [MonoidHomClass F M N] [MonoidHomClass G N M]
     {f : F} {x : M} (g : G) (hfg : Function.LeftInverse g f) :
     IsUnit (f x) ↔ IsUnit x := ⟨of_leftInverse g hfg, map _⟩

--- a/Mathlib/Algebra/Group/Units/Hom.lean
+++ b/Mathlib/Algebra/Group/Units/Hom.lean
@@ -224,7 +224,8 @@ theorem of_leftInverse [MonoidHomClass G N M] {f : F} {x : M} (g : G)
   simpa only [hfg x] using h.map g
 
 /-- Prefer `IsLocalHom.of_leftInverse`, but we can't get rid of this because of `ToAdditive`. -/
-@[to_additive]
+@[to_additive
+  /-- Prefer `IsLocalHom.of_leftInverse`, but we can't get rid of this because of `ToAdditive`. -/]
 theorem _root_.isUnit_map_of_leftInverse [MonoidHomClass F M N] [MonoidHomClass G N M]
     {f : F} {x : M} (g : G) (hfg : Function.LeftInverse g f) :
     IsUnit (f x) ↔ IsUnit x := ⟨of_leftInverse g hfg, map _⟩


### PR DESCRIPTION
Adds the missing additive doc-strings (multiplicative side has a hand-written doc-string, additive side did not) across 7 file(s) in **Algebra/Group actions and homs**.

The additive doc-strings are simple-minded translations of the multiplicative ones, with referenced lemma names replaced by their `to_additive` counterparts. These gaps were found by an environment linter that pairs each declaration with its `to_additive` counterpart and checks that both or neither is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)