### PR TITLE
chore: add missing `to_additive` docstrings in Algebra/Group core and subobjects

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -639,12 +639,12 @@ theorem mul_eq_one_iff_inv_eq : a * b = 1 ↔ a⁻¹ = b := by
   rw [mul_eq_one_iff_eq_inv, inv_eq_iff_eq_inv]
 
 /-- Variant of `mul_eq_one_iff_eq_inv` with swapped equality. -/
-@[to_additive]
+@[to_additive /-- Variant of `add_eq_zero_iff_eq_neg` with swapped equality. -/]
 theorem mul_eq_one_iff_eq_inv' : a * b = 1 ↔ b = a⁻¹ := by
   rw [mul_eq_one_iff_inv_eq, eq_comm]
 
 /-- Variant of `mul_eq_one_iff_inv_eq` with swapped equality. -/
-@[to_additive]
+@[to_additive /-- Variant of `add_eq_zero_iff_neg_eq` with swapped equality. -/]
 theorem mul_eq_one_iff_inv_eq' : a * b = 1 ↔ b⁻¹ = a := by
   rw [mul_eq_one_iff_eq_inv, eq_comm]
 
@@ -1058,7 +1058,7 @@ alias multiplicative_of_isTotal := multiplicative_of_total
 end multiplicative
 
 /-- An auxiliary lemma that can be used to prove `⇑(f ^ n) = ⇑f^[n]`. -/
-@[to_additive]
+@[to_additive /-- An auxiliary lemma that can be used to prove `⇑(n • f) = ⇑f^[n]`. -/]
 lemma hom_coe_pow {F : Type*} [Monoid F] (c : F → M → M) (h1 : c 1 = id)
     (hmul : ∀ f g, c (f * g) = c f ∘ c g) (f : F) : ∀ n, c (f ^ n) = (c f)^[n]
   | 0 => by

--- a/Mathlib/Algebra/Group/Center.lean
+++ b/Mathlib/Algebra/Group/Center.lean
@@ -152,7 +152,9 @@ lemma centralizer_centralizer_comm_of_comm (h_comm : ∀ x ∈ S, ∀ y ∈ S, x
 theorem centralizer_empty : (∅ : Set M).centralizer = ⊤ := by simp [centralizer]
 
 /-- The centralizer of the product of non-empty sets is equal to the product of the centralizers. -/
-@[to_additive addCentralizer_prod]
+@[to_additive addCentralizer_prod
+/-- The additive centralizer of the product of non-empty sets is equal to the product of the
+additive centralizers. -/]
 theorem centralizer_prod {N : Type*} [Mul N] {S : Set M} {T : Set N}
     (hS : S.Nonempty) (hT : T.Nonempty) :
     (S ×ˢ T).centralizer = S.centralizer ×ˢ T.centralizer := by

--- a/Mathlib/Algebra/Group/Commute/Defs.lean
+++ b/Mathlib/Algebra/Group/Commute/Defs.lean
@@ -40,7 +40,9 @@ def Commute [Mul S] (a b : S) : Prop :=
 /--
 Two elements `a` and `b` commute if `a * b = b * a`.
 -/
-@[to_additive]
+@[to_additive /--
+Two elements `a` and `b` additively commute if `a + b = b + a`.
+-/]
 theorem commute_iff_eq [Mul S] (a b : S) : Commute a b ↔ a * b = b * a := Iff.rfl
 
 namespace Commute

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -713,7 +713,8 @@ lemma pow_one (a : M) : a ^ 1 = a := by rw [pow_succ, pow_zero, one_mul]
 lemma pow_mul_comm' (a : M) (n : ℕ) : a ^ n * a = a * a ^ n := by rw [← pow_succ, pow_succ']
 
 /-- Note that most of the lemmas about powers of two refer to it as `sq`. -/
-@[to_additive two_nsmul] lemma pow_two (a : M) : a ^ 2 = a * a := by rw [pow_succ, pow_one]
+@[to_additive two_nsmul /-- Note that most of the lemmas about multiples of two refer to it as
+`two_nsmul`. -/] lemma pow_two (a : M) : a ^ 2 = a * a := by rw [pow_succ, pow_one]
 
 -- TODO: Should `alias` automatically transfer `to_additive` statements?
 @[to_additive existing two_nsmul] alias sq := pow_two
@@ -767,14 +768,18 @@ variable (M)
 namespace IsDedekindFiniteMonoid
 
 /-- A monoid is Dedekind-finite if every element with a left inverse also has a right inverse. -/
-@[to_additive] lemma of_exists_self_mul_eq_one (ex : ∀ x y : M, x * y = 1 → ∃ z, y * z = 1) :
+@[to_additive /-- An additive monoid is Dedekind-finite if every element with a left negation also
+has a right negation. -/]
+lemma of_exists_self_mul_eq_one (ex : ∀ x y : M, x * y = 1 → ∃ z, y * z = 1) :
     IsDedekindFiniteMonoid M where
   mul_eq_one_symm {x y} h := by
     have ⟨z, hz⟩ := ex x y h
     rwa [show x = z by simpa [← mul_assoc, h] using congr_arg (x * ·) hz.symm]
 
 /-- A monoid is Dedekind-finite if every element with a right inverse also has a left inverse. -/
-@[to_additive] lemma of_exists_mul_self_eq_one (ex : ∀ x y : M, x * y = 1 → ∃ z, z * x = 1) :
+@[to_additive /-- An additive monoid is Dedekind-finite if every element with a right negation also
+has a left negation. -/]
+lemma of_exists_mul_self_eq_one (ex : ∀ x y : M, x * y = 1 → ∃ z, z * x = 1) :
     IsDedekindFiniteMonoid M where
   mul_eq_one_symm {x y} h := by
     have ⟨z, hz⟩ := ex x y h
@@ -809,7 +814,12 @@ class CommMonoid (M : Type u) extends Monoid M, CommSemigroup M
 This is assigned default rather than low priority because it gives the most common examples
 of Dedekind-finite monoids and is used the most often. Benchmark results indicate default
 priority performs better than low or high priority. -/
-@[to_additive] instance (M) [CommMonoid M] : IsDedekindFiniteMonoid M := inferInstance
+@[to_additive /-- Shortcut instance for `IsCommutativeHAdd M → IsDedekindFiniteAddMonoid M`.
+
+This is assigned default rather than low priority because it gives the most common examples
+of Dedekind-finite additive monoids and is used the most often. Benchmark results indicate default
+priority performs better than low or high priority. -/]
+instance (M) [CommMonoid M] : IsDedekindFiniteMonoid M := inferInstance
 
 section LeftCancelMonoid
 
@@ -1036,11 +1046,15 @@ explanations on this.
 -/
 class SubNegMonoid (G : Type u) extends AddMonoid G, Neg G, Sub G, ZSMul G where
   protected sub := SubNegMonoid.sub'
+  /-- `a - b := a + -b` -/
   protected sub_eq_add_neg : ∀ a b : G, a - b = a + -b := by intros; rfl
+  /-- `0 • a = 0` -/
   protected zsmul_zero' (a : G) : (0 : ℤ) • a = 0 := by intros; rfl
+  /-- `(n + 1) • a = n • a + a` -/
   protected zsmul_succ' (n : ℕ) (a : G) :
       (n.succ : ℤ) • a = (n : ℤ) • a + a := by
     intros; rfl
+  /-- `-(n + 1) • a = -((n + 1) • a)` -/
   protected zsmul_neg' (n : ℕ) (a : G) : (Int.negSucc n) • a = -((n.succ : ℤ) • a) := by
     intros; rfl
 

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -714,7 +714,8 @@ lemma pow_mul_comm' (a : M) (n : ℕ) : a ^ n * a = a * a ^ n := by rw [← pow_
 
 /-- Note that most of the lemmas about powers of two refer to it as `sq`. -/
 @[to_additive two_nsmul /-- Note that most of the lemmas about multiples of two refer to it as
-`two_nsmul`. -/] lemma pow_two (a : M) : a ^ 2 = a * a := by rw [pow_succ, pow_one]
+`two_nsmul`. -/]
+lemma pow_two (a : M) : a ^ 2 = a * a := by rw [pow_succ, pow_one]
 
 -- TODO: Should `alias` automatically transfer `to_additive` statements?
 @[to_additive existing two_nsmul] alias sq := pow_two

--- a/Mathlib/Algebra/Group/Subgroup/Actions.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Actions.lean
@@ -50,7 +50,8 @@ instance smulCommClass_right [SMul α β] [MulAction G β] [SMulCommClass α G �
   S.toSubmonoid.smulCommClass_right
 
 /-- Note that this provides `IsScalarTower S G G` which is needed by `smul_mul_assoc`. -/
-@[to_additive]
+@[to_additive
+/-- Note that this provides `VAddAssocClass S G G` which is needed by `vadd_add_assoc`. -/]
 instance [SMul α β] [MulAction G α] [MulAction G β] [IsScalarTower G α β] (S : Subgroup G) :
     IsScalarTower S α β :=
   inferInstanceAs (IsScalarTower S.toSubmonoid α β)

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -648,12 +648,14 @@ theorem normalClosure_closure_eq_normalClosure {s : Set G} :
   le_antisymm (normalClosure_le_normal closure_le_normalClosure) (normalClosure_mono subset_closure)
 
 /-- The normal closure of an empty set is the trivial subgroup. -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp)
+  /-- The normal closure of an empty set is the trivial additive subgroup. -/]
 lemma normalClosure_empty : normalClosure (∅ : Set G) = (⊥ : Subgroup G) := by
   rw [← normalClosure_closure_eq_normalClosure, closure_empty, normalClosure_eq_self]
 
 /-- The normal closure of the union of sets is the join of the normal closures of each set. -/
-@[to_additive]
+@[to_additive /-- The normal closure of the union of sets is the join of the normal closures
+of each set. -/]
 theorem normalClosure_union {G : Type*} [Group G] (s t : Set G) :
     normalClosure (s ∪ t) = normalClosure s ⊔ normalClosure t := by
   simp_rw [normalClosure, Group.conjugatesOfSet_union, closure_union]

--- a/Mathlib/Algebra/Group/Subgroup/Ker.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Ker.lean
@@ -317,19 +317,22 @@ theorem ker_eq_bot (f : G →* M) (hf : Function.Injective f) : f.ker = ⊥ :=
 
 /-- The kernel of a homomorphism composed with an isomorphism is equal to the kernel of
 the homomorphism mapped by the inverse isomorphism. -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) /-- The kernel of a homomorphism composed with an isomorphism is equal
+to the kernel of the homomorphism mapped by the inverse isomorphism. -/]
 lemma ker_comp_mulEquiv {P : Type*} [MulOneClass P] (g : N →* P) (iso : G ≃* N) :
     (g.comp iso).ker = map (iso.symm : N →* G) g.ker := by
   rw [← comap_ker, comap_equiv_eq_map_symm]
 
 /-- Composing with an injective homomorphism on the codomain does not change the kernel. -/
-@[to_additive]
+@[to_additive /-- Composing with an injective homomorphism on the codomain does not change the
+kernel. -/]
 lemma ker_comp_of_injective {P : Type*} [MulOneClass P] (f : G →* N) (g : N →* P)
     (hg : Function.Injective g) : (g.comp f).ker = f.ker := by
   rw [← comap_ker, g.ker_eq_bot hg, comap_bot]
 
 /-- Composing with an isomorphism on the codomain does not change the kernel. -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) /-- Composing with an isomorphism on the codomain does not change the
+kernel. -/]
 lemma ker_mulEquiv_comp {P : Type*} [MulOneClass P] (f : G →* N) (iso : N ≃* P) :
     ((iso : N →* P).comp f).ker = f.ker :=
   ker_comp_of_injective f iso.toMonoidHom iso.injective

--- a/Mathlib/Algebra/Group/Subgroup/MulOppositeLemmas.lean
+++ b/Mathlib/Algebra/Group/Subgroup/MulOppositeLemmas.lean
@@ -33,7 +33,12 @@ namespace Subgroup
   (Subgroup (MulOpposite _) _) _ (@Subgroup.op _ _ _))) _`
 compared to the keys for `Submonoid.smul`
 `SMul (@Subtype _ (@Membership.mem _ (Submonoid _ _) _ _)) _` -/
-@[to_additive] instance instSMul (H : Subgroup G) : SMul H.op G := Submonoid.smul ..
+@[to_additive /-- We redeclare this instance to get keys
+`VAdd (@Subtype (AddOpposite _) (@Membership.mem (AddOpposite _)
+  (AddSubgroup (AddOpposite _) _) _ (@AddSubgroup.op _ _ _))) _`
+compared to the keys for `AddSubmonoid.vadd`
+`VAdd (@Subtype _ (@Membership.mem _ (AddSubmonoid _ _) _ _)) _` -/]
+instance instSMul (H : Subgroup G) : SMul H.op G := Submonoid.smul ..
 
 /-! ### Lattice results -/
 

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -213,7 +213,8 @@ open Fintype
 
 /-- curly brackets `{}` are used here instead of instance brackets `[]` because
 the instance in a goal is often not the same as the one inferred by type class inference. -/
-@[to_additive]
+@[to_additive /-- curly brackets `{}` are used here instead of instance brackets `[]` because
+the instance in a goal is often not the same as the one inferred by type class inference. -/]
 theorem card_bot {_ : Fintype (⊥ : Submonoid M)} : card (⊥ : Submonoid M) = 1 :=
   card_eq_one_iff.2
     ⟨⟨(1 : M), Set.mem_singleton 1⟩, fun ⟨_y, hy⟩ => Subtype.ext <| mem_bot.1 hy⟩

--- a/Mathlib/Algebra/Group/Submonoid/MulAction.lean
+++ b/Mathlib/Algebra/Group/Submonoid/MulAction.lean
@@ -88,9 +88,9 @@ instance smulCommClass_right [SMul α β] [SMul M' β] [SMulCommClass α M' β]
     (S : Submonoid M') : SMulCommClass α S β :=
   inferInstance
 
-/-- Note that this provides `IsScalarTower S M' M'` which is needed by `SMulMulAssoc`. -/
+/-- Note that this provides `IsScalarTower S M' M'` which is needed by `smul_mul_assoc`. -/
 @[to_additive /-- Note that this provides `VAddAssocClass S M' M'` which is needed by
-`VAddAddAssoc`. -/]
+`vadd_add_assoc`. -/]
 instance isScalarTower [SMul α β] [SMul M' α] [SMul M' β] [IsScalarTower M' α β]
       (S : Submonoid M') :
     IsScalarTower S α β :=

--- a/Mathlib/Algebra/Group/Submonoid/MulAction.lean
+++ b/Mathlib/Algebra/Group/Submonoid/MulAction.lean
@@ -89,7 +89,8 @@ instance smulCommClass_right [SMul α β] [SMul M' β] [SMulCommClass α M' β]
   inferInstance
 
 /-- Note that this provides `IsScalarTower S M' M'` which is needed by `SMulMulAssoc`. -/
-@[to_additive]
+@[to_additive /-- Note that this provides `VAddAssocClass S M' M'` which is needed by
+`VAddAddAssoc`. -/]
 instance isScalarTower [SMul α β] [SMul M' α] [SMul M' β] [IsScalarTower M' α β]
       (S : Submonoid M') :
     IsScalarTower S α β :=

--- a/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
@@ -80,7 +80,9 @@ theorem coe_iSup_of_directed {S : ι → Subsemigroup M} (hS : Directed (· ≤ 
   Set.ext fun x => by simp [mem_iSup_of_directed hS]
 
 /-- The supremum of a directed family of commutative subsemigroups is commutative. -/
-@[to_additive]
+@[to_additive
+  /-- The supremum of a directed family of additively commutative additive subsemigroups is
+  additively commutative. -/]
 theorem isMulCommutative_iSup {S : ι → Subsemigroup M}
     [hS : ∀ i, IsMulCommutative (S i)] (dir : Directed (· ≤ ·) S) :
     IsMulCommutative (⨆ i, S i : Subsemigroup M) := by
@@ -92,7 +94,9 @@ theorem isMulCommutative_iSup {S : ι → Subsemigroup M}
   exact setLike_mul_comm (hik ha) (hjk hb)
 
 /-- The supremum of a directed family of commutative subsemigroups is commutative. -/
-@[to_additive]
+@[to_additive
+  /-- The supremum of a directed family of additively commutative additive subsemigroups is
+  additively commutative. -/]
 instance instIsMulCommutative_iSup {ι : Type*} [Preorder ι] [IsDirectedOrder ι]
     (S : ι →o Subsemigroup M) [hS : ∀ i, IsMulCommutative (S i)] :
     IsMulCommutative (⨆ i, S i : Subsemigroup M) :=

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -52,7 +52,8 @@ lemma pow_eq_one_iff : a ^ n = 1 ↔ a = 1 ∨ n = 0 := by
 lemma pow_eq_one_iff_right (ha : a ≠ 1) : a ^ n = 1 ↔ n = 0 := by simp [*]
 
 /-- See `sq_eq_one_iff` for a version that holds in rings. -/
-@[to_additive two_nsmul_eq_zero]
+@[to_additive two_nsmul_eq_zero
+  /-- See `sq_eq_one_iff` for a version that holds in rings. -/]
 lemma sq_eq_one : a ^ 2 = 1 ↔ a = 1 := pow_eq_one_iff_left (by lia)
 
 end Monoid

--- a/Mathlib/Algebra/Group/UniqueProds/Basic.lean
+++ b/Mathlib/Algebra/Group/UniqueProds/Basic.lean
@@ -360,7 +360,12 @@ open MulOpposite in
   a group, then we only need to check this when `A = B`.
   Here we generalize the result to cancellative semigroups.
   Non-cancellative counterexample: the AddMonoid `{0,1}` with 1+1=1. -/
-@[to_additive] theorem of_same {G} [Semigroup G] [IsCancelMul G]
+@[to_additive /-- `UniqueSums G` says that for any two nonempty `Finset`s `A` and `B` in `G`,
+  `A × B` contains a unique pair with the `UniqueAdd` property. Strojnowski showed that if `G` is
+  an additive group, then we only need to check this when `A = B`.
+  Here we generalize the result to cancellative additive semigroups.
+  Non-cancellative counterexample: the AddMonoid `{0,1}` with 1+1=1. -/]
+theorem of_same {G} [Semigroup G] [IsCancelMul G]
     (h : ∀ {A : Finset G}, A.Nonempty → ∃ a1 ∈ A, ∃ a2 ∈ A, UniqueMul A A a1 a2) :
     UniqueProds G where
   uniqueMul_of_nonempty {A B} hA hB := by
@@ -377,7 +382,11 @@ open MulOpposite in
   For an example of a semigroup `G` embeddable into a group that has `UniqueProds`
   but not `TwoUniqueProds`, see Example 10.13 in
   [J. Okniński, *Semigroup Algebras*][Okninski1991]. -/
-@[to_additive] theorem toTwoUniqueProds_of_group {G}
+@[to_additive /-- If an additive group has `UniqueSums`, then it actually has `TwoUniqueSums`.
+  For an example of an additive semigroup `G` embeddable into an additive group that has
+  `UniqueSums` but not `TwoUniqueSums`, see Example 10.13 in
+  [J. Okniński, *Semigroup Algebras*][Okninski1991]. -/]
+theorem toTwoUniqueProds_of_group {G}
     [Group G] [UniqueProds G] : TwoUniqueProds G where
   uniqueMul_of_one_lt_card {A B} hc := by
     simp_rw [Nat.one_lt_mul_iff, card_pos] at hc


### PR DESCRIPTION
Adds the missing additive doc-strings (multiplicative side has a hand-written doc-string, additive side did not) across 13 file(s) in **Algebra/Group core and subobjects**.

The additive doc-strings are simple-minded translations of the multiplicative ones, with referenced lemma names replaced by their `to_additive` counterparts. These gaps were found by an environment linter that pairs each declaration with its `to_additive` counterpart and checks that both or neither is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)