### PR TITLE
[Merged by Bors] - chore: add missing `to_additive` docstrings in MeasureTheory.Measure

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
@@ -633,7 +633,12 @@ to `QuotientGroup` (the next `instance`).
 TODO: typeclass inference should normally find this, but currently doesn't.
 E.g., `MeasurableSMul G (G ⧸ Γ)` fails to synthesize, even though `G ⧸ Γ` is the quotient
 of `G` by the action of `Γ`; it seems unable to pick up the `BorelSpace` instance. -/
-@[to_additive AddCosetSpace.borelSpace]
+@[to_additive AddCosetSpace.borelSpace
+  /-- When the additive subgroup `N < G` is not necessarily `Normal`, we have an `AddCosetSpace` as
+opposed to `QuotientAddGroup` (the next `instance`).
+TODO: typeclass inference should normally find this, but currently doesn't.
+E.g., `MeasurableVAdd G (G ⧸ Γ)` fails to synthesize, even though `G ⧸ Γ` is the quotient
+of `G` by the action of `Γ`; it seems unable to pick up the `BorelSpace` instance. -/]
 instance CosetSpace.borelSpace {G : Type*} [TopologicalSpace G] [PolishSpace G] [Group G]
     [MeasurableSpace G] [BorelSpace G] {N : Subgroup G} [T2Space (G ⧸ N)]
     [SecondCountableTopology (G ⧸ N)] : BorelSpace (G ⧸ N) := Quotient.borelSpace

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -726,7 +726,8 @@ theorem _root_.Continuous.stronglyMeasurable [MeasurableSpace α] [TopologicalSp
   · exact hf.measurable.stronglyMeasurable
 
 /-- A continuous function whose support is contained in a compact set is strongly measurable. -/
-@[to_additive]
+@[to_additive /-- A continuous function whose support is contained in a compact set is strongly
+measurable. -/]
 theorem _root_.Continuous.stronglyMeasurable_of_mulSupport_subset_isCompact
     [MeasurableSpace α] [TopologicalSpace α] [OpensMeasurableSpace α] [TopologicalSpace β]
     [PseudoMetrizableSpace β] [One β] {f : α → β} (hf : Continuous f) {k : Set α}
@@ -737,7 +738,7 @@ theorem _root_.Continuous.stronglyMeasurable_of_mulSupport_subset_isCompact
   exact ⟨hf.measurable, (isCompact_range_of_mulSupport_subset_isCompact hf hk h'f).isSeparable⟩
 
 /-- A continuous function with compact support is strongly measurable. -/
-@[to_additive]
+@[to_additive /-- A continuous function with compact support is strongly measurable. -/]
 theorem _root_.Continuous.stronglyMeasurable_of_hasCompactMulSupport
     [MeasurableSpace α] [TopologicalSpace α] [OpensMeasurableSpace α] [TopologicalSpace β]
     [PseudoMetrizableSpace β] [One β] {f : α → β} (hf : Continuous f)

--- a/Mathlib/MeasureTheory/Measure/EverywherePos.lean
+++ b/Mathlib/MeasureTheory/Measure/EverywherePos.lean
@@ -216,7 +216,11 @@ open scoped Pointwise
 topological group, then it is a Gδ set. This is nontrivial, as there is no second-countability or
 metrizability assumption in the statement, so a general compact closed set has no reason to be
 a countable intersection of open sets. -/
-@[to_additive]
+@[to_additive
+/-- If a compact closed set is everywhere positive with respect to a left-invariant measure on a
+topological additive group, then it is a Gδ set. This is nontrivial, as there is no
+second-countability or metrizability assumption in the statement, so a general compact closed set
+has no reason to be a countable intersection of open sets. -/]
 lemma IsEverywherePos.IsGdelta_of_isMulLeftInvariant
     {k : Set G} (h : μ.IsEverywherePos k) (hk : IsCompact k) (h'k : IsClosed k) :
     IsGδ k := by
@@ -275,7 +279,10 @@ lemma IsEverywherePos.IsGdelta_of_isMulLeftInvariant
 
 /-- **Halmos' theorem: Haar measure is completion regular.** More precisely, any finite measure
 set can be approximated from inside by a level set of a continuous function with compact support. -/
-@[to_additive innerRegularWRT_preimage_one_hasCompactSupport_measure_ne_top_of_addGroup]
+@[to_additive innerRegularWRT_preimage_one_hasCompactSupport_measure_ne_top_of_addGroup
+/-- **Halmos' theorem: Haar measure is completion regular.** More precisely, any finite measure
+set can be approximated from inside by a level set of a continuous function with compact
+support. -/]
 theorem innerRegularWRT_preimage_one_hasCompactSupport_measure_ne_top_of_group :
     InnerRegularWRT μ (fun s ↦ ∃ (f : G → ℝ), Continuous f ∧ HasCompactSupport f ∧ s = f ⁻¹' {1})
     (fun s ↦ MeasurableSet s ∧ μ s ≠ ∞) := by

--- a/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
@@ -673,7 +673,8 @@ theorem haarMeasure_unique (μ : Measure G) [SigmaFinite μ] [IsMulLeftInvariant
 
 /-- Let `μ` be a σ-finite left invariant measure on `G`. Then `μ` is equal to the Haar measure
 defined by `K₀` iff `μ K₀ = 1`. -/
-@[to_additive]
+@[to_additive /-- Let `μ` be a σ-finite left invariant measure on `G`. Then `μ` is equal to the
+additive Haar measure defined by `K₀` iff `μ K₀ = 1`. -/]
 theorem haarMeasure_eq_iff (K₀ : PositiveCompacts G) (μ : Measure G) [SigmaFinite μ]
     [IsMulLeftInvariant μ] :
     haarMeasure K₀ = μ ↔ μ K₀ = 1 :=

--- a/Mathlib/MeasureTheory/Measure/Haar/Quotient.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Quotient.lean
@@ -69,7 +69,9 @@ variable {G : Type*} [Group G] [MeasurableSpace G] (ν : Measure G) {Γ : Subgro
 /-- Given a subgroup `Γ` of a topological group `G` with measure `ν`, and a measure 'μ' on the
   quotient `G ⧸ Γ` satisfying `QuotientMeasureEqMeasurePreimage`, the restriction
   of `ν` to a fundamental domain is measure-preserving with respect to `μ`. -/
-@[to_additive]
+@[to_additive /-- Given a subgroup `Γ` of a topological additive group `G` with measure `ν`, and a
+  measure 'μ' on the quotient `G ⧸ Γ` satisfying `AddQuotientMeasureEqMeasurePreimage`, the
+  restriction of `ν` to a fundamental domain is measure-preserving with respect to `μ`. -/]
 theorem measurePreserving_quotientGroup_mk_of_QuotientMeasureEqMeasurePreimage
     {𝓕 : Set G} (h𝓕 : IsFundamentalDomain Γ.op 𝓕 ν) (μ : Measure (G ⧸ Γ))
     [QuotientMeasureEqMeasurePreimage ν μ] :
@@ -83,7 +85,8 @@ variable [TopologicalSpace G] [IsTopologicalGroup G] [BorelSpace G] [PolishSpace
 
 /-- If `μ` satisfies `QuotientMeasureEqMeasurePreimage` relative to a both left- and right-
   invariant measure `ν` on `G`, then it is a `G` invariant measure on `G ⧸ Γ`. -/
-@[to_additive]
+@[to_additive /-- If `μ` satisfies `AddQuotientMeasureEqMeasurePreimage` relative to a both left-
+  and right-invariant measure `ν` on `G`, then it is a `G` invariant measure on `G ⧸ Γ`. -/]
 lemma MeasureTheory.QuotientMeasureEqMeasurePreimage.smulInvariantMeasure_quotient
     [IsMulLeftInvariant ν] [hasFun : HasFundamentalDomain Γ.op G ν] :
     SMulInvariantMeasure G (G ⧸ Γ) μ where

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -74,7 +74,9 @@ namespace MeasureTheory
 /-- The parameterized integral `x ↦ ∫ y, g (y⁻¹ * x) ∂μ` depends continuously on `y` when `g` is a
 compactly supported continuous function on a topological group `G`, and `μ` is finite on compact
 sets. -/
-@[to_additive]
+@[to_additive /-- The parameterized integral `x ↦ ∫ y, g (-y + x) ∂μ` depends continuously on `y`
+when `g` is a compactly supported continuous function on a topological additive group `G`, and `μ`
+is finite on compact sets. -/]
 lemma continuous_integral_apply_inv_mul
     {G : Type*} [TopologicalSpace G] [LocallyCompactSpace G] [Group G] [IsTopologicalGroup G]
     [MeasurableSpace G] [BorelSpace G]
@@ -120,7 +122,10 @@ measures will give the same integral, up to some fixed scalar.
 integrals with respect to `μ` as integrals with respect to `ν` up to a constant scaling factor
 (given in the statement as `∫ x, g x ∂μ` where `g` is a fixed reference function) and an
 explicit density `y ↦ 1/∫ z, g (z⁻¹ * y) ∂ν`. -/
-@[to_additive]
+@[to_additive /-- In an additive group with a left invariant measure `μ` and a right invariant
+measure `ν`, one can express integrals with respect to `μ` as integrals with respect to `ν` up to a
+constant scaling factor (given in the statement as `∫ x, g x ∂μ` where `g` is a fixed reference
+function) and an explicit density `y ↦ 1/∫ z, g (-z + y) ∂ν`. -/]
 lemma integral_isMulLeftInvariant_isMulRightInvariant_combo
     {μ ν : Measure G} [IsFiniteMeasureOnCompacts μ] [IsFiniteMeasureOnCompacts ν]
     [IsMulLeftInvariant μ] [IsMulRightInvariant ν] [IsOpenPosMeasure ν]
@@ -214,7 +219,10 @@ lemma integral_isMulLeftInvariant_isMulRightInvariant_combo
 /-- Given two left-invariant measures which are finite on
 compacts, they coincide in the following sense: they give the same value to the integral of
 continuous compactly supported functions, up to a multiplicative constant. -/
-@[to_additive exists_integral_isAddLeftInvariant_eq_smul_of_hasCompactSupport]
+@[to_additive exists_integral_isAddLeftInvariant_eq_smul_of_hasCompactSupport
+/-- Given two left-invariant measures which are finite on
+compacts, they coincide in the following sense: they give the same value to the integral of
+continuous compactly supported functions, up to a multiplicative constant. -/]
 lemma exists_integral_isMulLeftInvariant_eq_smul_of_hasCompactSupport (μ' μ : Measure G)
     [IsHaarMeasure μ] [IsFiniteMeasureOnCompacts μ'] [IsMulLeftInvariant μ'] :
     ∃ (c : ℝ≥0), ∀ (f : G → ℝ), Continuous f → HasCompactSupport f →
@@ -409,7 +417,8 @@ lemma haarScalarFactor_map (μ' μ : Measure G) [IsHaarMeasure μ] [IsHaarMeasur
 
 /-- The scalar factor between two left-invariant measures is non-zero when both measures are
 positive on open sets. -/
-@[to_additive]
+@[to_additive /-- The scalar factor between two left-invariant measures is non-zero when both
+measures are positive on open sets. -/]
 lemma haarScalarFactor_pos_of_isHaarMeasure (μ' μ : Measure G) [IsHaarMeasure μ]
     [IsHaarMeasure μ'] : 0 < haarScalarFactor μ' μ :=
   pos_iff_ne_zero.2 (fun H ↦ by simpa [H] using haarScalarFactor_eq_mul μ' μ μ')
@@ -661,7 +670,9 @@ theorem measure_isMulInvariant_eq_smul_of_isCompact_closure [LocallyCompactSpace
 
 /-- **Uniqueness of Haar measures**:
 Two Haar measures on a compact group coincide up to a multiplicative factor. -/
-@[to_additive isAddInvariant_eq_smul_of_compactSpace]
+@[to_additive isAddInvariant_eq_smul_of_compactSpace
+/-- **Uniqueness of additive Haar measures**:
+Two additive Haar measures on a compact additive group coincide up to a multiplicative factor. -/]
 lemma isMulInvariant_eq_smul_of_compactSpace [CompactSpace G] (μ' μ : Measure G)
     [IsHaarMeasure μ] [IsMulLeftInvariant μ'] [IsFiniteMeasureOnCompacts μ'] :
     μ' = haarScalarFactor μ' μ • μ := by
@@ -684,7 +695,8 @@ instance (priority := 100) instRegularOfIsHaarMeasureOfCompactSpace
 
 /-- **Uniqueness of Haar measures**:
 Two Haar measures which are probability measures coincide. -/
-@[to_additive]
+@[to_additive /-- **Uniqueness of additive Haar measures**:
+Two additive Haar measures which are probability measures coincide. -/]
 lemma isHaarMeasure_eq_of_isProbabilityMeasure [LocallyCompactSpace G] (μ' μ : Measure G)
     [IsProbabilityMeasure μ] [IsProbabilityMeasure μ'] [IsHaarMeasure μ] [IsHaarMeasure μ'] :
     μ' = μ := by
@@ -828,7 +840,11 @@ Given two left-invariant measures which are finite on
 compacts and inner regular for finite measure sets with respect to compact sets,
 they coincide in the following sense: they give the same value to finite measure sets,
 up to a multiplicative constant. -/
-@[to_additive]
+@[to_additive /-- **Uniqueness of left-invariant measures**:
+Given two left-invariant measures which are finite on
+compacts and inner regular for finite measure sets with respect to compact sets,
+they coincide in the following sense: they give the same value to finite measure sets,
+up to a multiplicative constant. -/]
 lemma measure_isMulLeftInvariant_eq_smul_of_ne_top [LocallyCompactSpace G]
     (μ' μ : Measure G) [IsHaarMeasure μ] [IsFiniteMeasureOnCompacts μ'] [IsMulLeftInvariant μ']
     [InnerRegularCompactLTTop μ] [InnerRegularCompactLTTop μ'] {s : Set G}
@@ -866,7 +882,10 @@ lemma measure_isMulLeftInvariant_eq_smul_of_ne_top [LocallyCompactSpace G]
 /-- **Uniqueness of left-invariant measures**:
 Given two left-invariant measures which are finite
 on compacts and inner regular, they coincide up to a multiplicative constant. -/
-@[to_additive isAddLeftInvariant_eq_smul_of_innerRegular]
+@[to_additive isAddLeftInvariant_eq_smul_of_innerRegular
+/-- **Uniqueness of left-invariant measures**:
+Given two left-invariant measures which are finite
+on compacts and inner regular, they coincide up to a multiplicative constant. -/]
 lemma isMulLeftInvariant_eq_smul_of_innerRegular [LocallyCompactSpace G]
     (μ' μ : Measure G) [IsHaarMeasure μ] [IsFiniteMeasureOnCompacts μ'] [IsMulLeftInvariant μ']
     [InnerRegular μ] [InnerRegular μ'] :
@@ -880,7 +899,10 @@ lemma isMulLeftInvariant_eq_smul_of_innerRegular [LocallyCompactSpace G]
 /-- **Uniqueness of left-invariant measures**:
 Given two left-invariant measures which are finite
 on compacts and regular, they coincide up to a multiplicative constant. -/
-@[to_additive isAddLeftInvariant_eq_smul_of_regular]
+@[to_additive isAddLeftInvariant_eq_smul_of_regular
+/-- **Uniqueness of left-invariant measures**:
+Given two left-invariant measures which are finite
+on compacts and regular, they coincide up to a multiplicative constant. -/]
 lemma isMulLeftInvariant_eq_smul_of_regular [LocallyCompactSpace G]
     (μ' μ : Measure G) [IsHaarMeasure μ] [IsMulLeftInvariant μ'] [Regular μ] [Regular μ'] :
     μ' = haarScalarFactor μ' μ • μ := by
@@ -894,7 +916,9 @@ lemma isMulLeftInvariant_eq_smul_of_regular [LocallyCompactSpace G]
 
 /-- **Uniqueness of left-invariant measures**:
 Two Haar measures coincide up to a multiplicative constant in a second countable group. -/
-@[to_additive isAddLeftInvariant_eq_smul]
+@[to_additive isAddLeftInvariant_eq_smul
+/-- **Uniqueness of left-invariant measures**:
+Two additive Haar measures coincide up to a multiplicative constant in a second countable group. -/]
 lemma isMulLeftInvariant_eq_smul [LocallyCompactSpace G] [SecondCountableTopology G]
     (μ' μ : Measure G) [IsHaarMeasure μ] [IsFiniteMeasureOnCompacts μ'] [IsMulLeftInvariant μ'] :
     μ' = haarScalarFactor μ' μ • μ :=


### PR DESCRIPTION
Adds the missing additive doc-strings (multiplicative side has a hand-written doc-string, additive side did not) across 6 file(s) in **MeasureTheory.Measure**.

The additive doc-strings are simple-minded translations of the multiplicative ones, with referenced lemma names replaced by their `to_additive` counterparts. These gaps were found by an environment linter that pairs each declaration with its `to_additive` counterpart and checks that both or neither is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)