### PR TITLE
[Merged by Bors] - chore: add missing `to_additive` docstrings in category theory files

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Ulift.lean
+++ b/Mathlib/Algebra/Category/Grp/Ulift.lean
@@ -140,12 +140,12 @@ def uliftFunctorFullyFaithful : uliftFunctor.{u, v}.FullyFaithful where
   map_preimage _ := rfl
   preimage_map _ := rfl
 
--- The universe lift functor for commutative groups is faithful. -/
+/-- The universe lift functor for commutative groups is faithful. -/
 @[to_additive
   /-- The universe lift functor for commutative additive groups is faithful. -/]
 instance : uliftFunctor.{u, v}.Faithful := uliftFunctorFullyFaithful.faithful
 
--- The universe lift functor for commutative groups is full. -/
+/-- The universe lift functor for commutative groups is full. -/
 @[to_additive
   /-- The universe lift functor for commutative additive groups is full. -/]
 instance : uliftFunctor.{u, v}.Full := uliftFunctorFullyFaithful.full

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -504,7 +504,8 @@ instance CommMonCat.forget_reflects_isos : (forget CommMonCat.{u}).ReflectsIsomo
     exact e.toCommMonCatIso.isIso_hom
 
 /-- Ensure that `forget₂ CommMonCat MonCat` automatically reflects isomorphisms. -/
-@[to_additive]
+@[to_additive
+  /-- Ensure that `forget₂ AddCommMonCat AddMonCat` automatically reflects isomorphisms. -/]
 instance CommMonCat.forget₂_full : (forget₂ CommMonCat MonCat).Full where
   map_surjective f := ⟨ofHom f.hom, rfl⟩
 

--- a/Mathlib/Algebra/Category/Semigrp/Basic.lean
+++ b/Mathlib/Algebra/Category/Semigrp/Basic.lean
@@ -447,7 +447,8 @@ instance Semigrp.forgetReflectsIsos : (forget Semigrp.{u}).ReflectsIsomorphisms 
     exact e.toSemigrpIso.isIso_hom
 
 /-- Ensure that `forget₂ CommMonCat MonCat` automatically reflects isomorphisms. -/
-@[to_additive]
+@[to_additive /-- Ensure that `forget₂ AddCommMonCat AddMonCat` automatically reflects
+isomorphisms. -/]
 instance Semigrp.forget₂_full : (forget₂ Semigrp MagmaCat).Full where
   map_surjective f := ⟨ofHom f.hom, rfl⟩
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp.lean
@@ -187,7 +187,8 @@ lemma GrpObj.one_inv : η[G] ≫ ι = η := by simp [GrpObj.inv_eq_inv, GrpObj.c
 open scoped _root_.CategoryTheory.Obj in
 /-- If `G` is a group object and `F` is monoidal,
 then `Hom(X, G) → Hom(F X, F G)` preserves inverses. -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) /-- If `G` is an additive group object and `F` is monoidal,
+then `Hom(X, G) → Hom(F X, F G)` preserves negation. -/]
 lemma Functor.map_inv' {D : Type*} [Category* D] [CartesianMonoidalCategory D] (F : C ⥤ D)
     [F.Monoidal] {X G : C} (f : X ⟶ G) [GrpObj G] :
     F.map (f⁻¹) = (F.map f)⁻¹ := by
@@ -270,7 +271,8 @@ lemma hom_pow (f : G ⟶ H) (n : ℕ) : (f ^ n).hom = f.hom ^ n := by
 end Hom
 
 /-- A commutative group object is a group object in the category of group objects. -/
-@[to_additive]
+@[to_additive /-- A commutative additive group object is an additive group object in the category of
+additive group objects. -/]
 instance : GrpObj H where inv := Grp.homMk' { hom := ι[H.X] }
 
 namespace Hom
@@ -291,7 +293,8 @@ end Hom
 
 attribute [local simp] mul_eq_mul comp_mul mul_comm mul_div_mul_comm in
 /-- A commutative group object is a commutative group object in the category of group objects. -/
-@[to_additive]
+@[to_additive /-- A commutative additive group object is a commutative additive group object in the
+category of additive group objects. -/]
 instance : IsCommMonObj H where
 
 @[to_additive]
@@ -317,7 +320,8 @@ lemma GrpObj.conj_eq_snd_of_isCommMonObj [IsCommMonObj G] : conj G = snd G G := 
 open scoped IsMulCommutative in
 /-- `G` is a commutative group object if and only if the commutator map `(x, y) ↦ x * y * x⁻¹ * y⁻¹`
 is constant. -/
-@[to_additive]
+@[to_additive /-- `G` is a commutative additive group object if and only if the commutator map
+`(x, y) ↦ x + y + (-x) + (-y)` is constant. -/]
 lemma isCommMonObj_iff_commutator_eq_toUnit_η :
     IsCommMonObj G ↔ GrpObj.commutator G = toUnit _ ≫ η := by
   rw [isCommMonObj_iff_isMulCommutative]

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon.lean
@@ -468,7 +468,9 @@ end Hom
 
 open scoped IsMulCommutative in
 /-- A monoid object `M` is commutative if and only if `X ⟶ M` is commutative for all `X`. -/
-@[to_additive]
+@[to_additive
+/-- An additive monoid object `M` is commutative if and only if `X ⟶ M` is commutative for all
+`X`. -/]
 lemma isCommMonObj_iff_isMulCommutative (M : C) [MonObj M] [BraidedCategory C] :
     IsCommMonObj M ↔ ∀ (X : C), IsMulCommutative (X ⟶ M) := by
   exact ⟨fun h X ↦ ⟨⟨by simp [mul_comm]⟩⟩, fun h ↦ ⟨by simp [mul_eq_mul, comp_mul, mul_comm]⟩⟩

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Normal.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Normal.lean
@@ -78,7 +78,8 @@ lemma isNormalHom_iff [IsMonHom φ] [Mono φ] : Normal φ ↔ ∃ ψ : G ⊗ H �
 
 /-- If `φ` is mono, it is a normal group homomorphism if and only if for all `X` the image of
 `H(X)` in `G(X)` is a normal subgroup. -/
-@[to_additive]
+@[to_additive /-- If `φ` is mono, it is a normal additive group homomorphism if and only if for all
+`X` the image of `H(X)` in `G(X)` is a normal additive subgroup. -/]
 theorem normal_iff_normal_monoidHom [IsMonHom φ] [Mono φ] :
     Normal φ ↔ ∀ (X : C), (monoidHom φ X).range.Normal := by
   rw [isNormalHom_iff]

--- a/Mathlib/CategoryTheory/Monoidal/Grp.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Grp.lean
@@ -286,7 +286,11 @@ lemma mulRight_one (A : C) [GrpObj A] : mulRight η[A] = Iso.refl A := by
 In fact, any monoid object whose associativity diagram is Cartesian can be made into a group object
 (we do not prove this in this file), so we should expect that many properties of group objects
 follow from this result. -/
-@[to_additive]
+@[to_additive /-- The associativity diagram of an additive group object is Cartesian.
+
+In fact, any additive monoid object whose associativity diagram is Cartesian can be made into an
+additive group object (we do not prove this in this file), so we should expect that many properties
+of additive group objects follow from this result. -/]
 theorem isPullback (A : C) [GrpObj A] :
     IsPullback (μ ▷ A) ((α_ A A A).hom ≫ (A ◁ μ)) μ μ where
   w := by simp

--- a/Mathlib/CategoryTheory/Monoidal/Mod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mod.lean
@@ -108,7 +108,8 @@ lemma smul_eq_mul (M : C) [MonObj M] : γ[M,M] = μ[M] := rfl
 
 /-- If `C` acts monoidally on `D`, then every object of `D` is canonically a
 module over the trivial monoid. -/
-@[to_additive (attr := simps)]
+@[to_additive (attr := simps) /-- If `C` acts monoidally on `D`, then every object of `D` is
+canonically an additive module over the trivial additive monoid. -/]
 instance (X : D) : ModObj (𝟙_ C) X where
   smul := (λₗ _).hom
 

--- a/Mathlib/CategoryTheory/Monoidal/Mon.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon.lean
@@ -606,7 +606,8 @@ instance {A B : Mon C} (f : A ⟶ B) [e : IsIso ((forget C).map f)] : IsIso f.ho
   e
 
 /-- The forgetful functor from monoid objects to the ambient category reflects isomorphisms. -/
-@[to_additive]
+@[to_additive /-- The forgetful functor from additive monoid objects to the ambient category
+reflects isomorphisms. -/]
 instance : (forget C).ReflectsIsomorphisms where
   reflects f e := ⟨⟨.mk' (inv f.hom), by cat_disch⟩⟩
 
@@ -726,7 +727,7 @@ variable (C)
 
 set_option backward.defeqAttrib.useBackward true in
 /-- The forgetful functor from `Mon C` to `C` is monoidal when `C` is monoidal. -/
-@[to_additive]
+@[to_additive /-- The forgetful functor from `AddMon C` to `C` is monoidal when `C` is monoidal. -/]
 instance : (forget C).Monoidal :=
   Functor.CoreMonoidal.toMonoidal
     { εIso := Iso.refl _


### PR DESCRIPTION
Adds the missing additive doc-strings (multiplicative side has a hand-written doc-string, additive side did not) across 9 file(s) in **category theory files**.

The additive doc-strings are simple-minded translations of the multiplicative ones, with referenced lemma names replaced by their `to_additive` counterparts. These gaps were found by an environment linter that pairs each declaration with its `to_additive` counterpart and checks that both or neither is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)