### PR TITLE
[Merged by Bors] - chore: rename `QuotientAddGroup.mk_out_eq_mul` to `mk_out_eq_add`

### DIFF
--- a/Mathlib/GroupTheory/Coset/Defs.lean
+++ b/Mathlib/GroupTheory/Coset/Defs.lean
@@ -209,7 +209,7 @@ variable (s)
 /-- It can be useful to write `obtain ⟨h, H⟩ := mk_out_eq_mul ...`, and then `rw [H]` or
 `simp_rw [H]` or `simp only [H]`. In order for `simp_rw` and `simp only` to work, this lemma is
 stated in terms of an arbitrary `h : s`, rather than the specific `h = g⁻¹ * (mk g).out`. -/
-@[to_additive QuotientAddGroup.mk_out_eq_add]
+@[to_additive]
 theorem mk_out_eq_mul (g : α) : ∃ h : s, (mk g : α ⧸ s).out = g * h :=
   ⟨⟨g⁻¹ * (mk g).out, QuotientGroup.eq.mp (mk g).out_eq'.symm⟩, by rw [mul_inv_cancel_left]⟩
 

--- a/Mathlib/GroupTheory/Coset/Defs.lean
+++ b/Mathlib/GroupTheory/Coset/Defs.lean
@@ -209,7 +209,7 @@ variable (s)
 /-- It can be useful to write `obtain ⟨h, H⟩ := mk_out_eq_mul ...`, and then `rw [H]` or
 `simp_rw [H]` or `simp only [H]`. In order for `simp_rw` and `simp only` to work, this lemma is
 stated in terms of an arbitrary `h : s`, rather than the specific `h = g⁻¹ * (mk g).out`. -/
-@[to_additive QuotientAddGroup.mk_out_eq_mul]
+@[to_additive QuotientAddGroup.mk_out_eq_add]
 theorem mk_out_eq_mul (g : α) : ∃ h : s, (mk g : α ⧸ s).out = g * h :=
   ⟨⟨g⁻¹ * (mk g).out, QuotientGroup.eq.mp (mk g).out_eq'.symm⟩, by rw [mul_inv_cancel_left]⟩
 
@@ -248,6 +248,9 @@ theorem preimage_mk_one (N : Subgroup α) :
   simp
 
 end QuotientGroup
+
+@[deprecated (since := "2026-07-12")]
+alias QuotientAddGroup.mk_out_eq_mul := QuotientAddGroup.mk_out_eq_add
 
 namespace Subgroup
 


### PR DESCRIPTION
The additive lemma states `(mk g).out = g + h`, so by the `to_additive` naming convention its name should end in `add`, not `mul`. Rename it to `QuotientAddGroup.mk_out_eq_add` (a copy-paste error inherited from mathlib3) and deprecate the old name.