### PR TITLE
Topology: pseudometrizable spaces are paracompact

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -8041,6 +8041,7 @@ public import Mathlib.Topology.MetricSpace.UniformConvergence
 public import Mathlib.Topology.Metrizable.Basic
 public import Mathlib.Topology.Metrizable.CompletelyMetrizable
 public import Mathlib.Topology.Metrizable.ContinuousMap
+public import Mathlib.Topology.Metrizable.Paracompact
 public import Mathlib.Topology.Metrizable.Real
 public import Mathlib.Topology.Metrizable.Uniformity
 public import Mathlib.Topology.Metrizable.Urysohn

--- a/Mathlib/Topology/Metrizable/Paracompact.lean
+++ b/Mathlib/Topology/Metrizable/Paracompact.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2026 Yongxi Lin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yongxi Lin
+-/
+module
+
+public import Mathlib.Topology.EMetricSpace.Paracompact
+public import Mathlib.Topology.Metrizable.Uniformity
+
+/-!
+# Paracompactness of pseudometrizable spaces
+
+This file proves Stone's theorem that every pseudometrizable space is paracompact. As a
+consequence, every metrizable space is a T4 space.
+-/
+
+public section
+
+namespace TopologicalSpace
+
+variable {X : Type*} [TopologicalSpace X]
+
+-- See note [lower instance priority]
+/-- **Stone's theorem**: every pseudometrizable space is paracompact. -/
+instance (priority := 100) PseudoMetrizableSpace.paracompactSpace
+    [PseudoMetrizableSpace X] : ParacompactSpace X := by
+  letI : PseudoMetricSpace X := pseudoMetrizableSpacePseudoMetric X
+  exact Metric.instParacompactSpace
+
+/-- Every metrizable space is a T4 space. -/
+theorem MetrizableSpace.t4Space [MetrizableSpace X] : T4Space X := inferInstance
+
+end TopologicalSpace


### PR DESCRIPTION
This PR proves Stone’s theorem that every pseudometrizable space is paracompact. It installs a compatible pseudometric using the existing PseudoMetrizableSpace API and transfers the established paracompactness theorem for pseudoemetric spaces.

It also records the resulting T4 theorem for metrizable spaces. This resolves the generalization TODO in Topology/EMetricSpace/Paracompact without changing its existing public API.

This is an independent metrizable-space PR associated with the Kupka--Prikry formalization project.

Checks:
- lake build
- lake exe lint-style Mathlib.Topology.Metrizable.Paracompact
- git diff --check upstream/master...HEAD