### PR TITLE
feat(Topology): prove the Bing-Nagata-Smirnov metrization theorem

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7895,6 +7895,7 @@ public import Mathlib.Topology.Defs.Sequences
 public import Mathlib.Topology.Defs.Ultrafilter
 public import Mathlib.Topology.DenseEmbedding
 public import Mathlib.Topology.DerivedSet
+public import Mathlib.Topology.DiscreteFamily
 public import Mathlib.Topology.DiscreteQuotient
 public import Mathlib.Topology.DiscreteSubset
 public import Mathlib.Topology.EMetricSpace.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -8047,6 +8047,7 @@ public import Mathlib.Topology.MetricSpace.Ultra.Pi
 public import Mathlib.Topology.MetricSpace.Ultra.TotallySeparated
 public import Mathlib.Topology.MetricSpace.UniformConvergence
 public import Mathlib.Topology.Metrizable.Basic
+public import Mathlib.Topology.Metrizable.BingNagataSmirnov
 public import Mathlib.Topology.Metrizable.CompletelyMetrizable
 public import Mathlib.Topology.Metrizable.ContinuousMap
 public import Mathlib.Topology.Metrizable.Real

--- a/Mathlib/Topology/DiscreteFamily.lean
+++ b/Mathlib/Topology/DiscreteFamily.lean
@@ -1,0 +1,399 @@
+/-
+Copyright (c) 2026 Yongxi Lin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yongxi Lin
+-/
+module
+
+public import Mathlib.Topology.LocallyFinite
+public import Mathlib.Topology.Metrizable.Uniformity
+
+import Mathlib.Data.Nat.Pairing
+import Mathlib.SetTheory.Cardinal.Order
+import Mathlib.Tactic.GCongr
+
+/-!
+# Discrete and sigma-discrete families of sets
+
+A family of sets is discrete if every point has a neighborhood meeting at most one member of the
+family. A family is sigma-discrete if its index type is covered by countably many sets on each of
+which the restricted family is discrete. We also prove that every open cover of a
+pseudometrizable space has an open sigma-discrete refinement.
+-/
+
+@[expose] public section
+
+open ENNReal Filter Function Set TopologicalSpace Topology
+
+variable {ι ι' X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+  {f g : ι → Set X}
+
+/-- A family of sets is discrete if every point has a neighborhood meeting at most one member of
+the family. In particular, distinct members of a discrete family are disjoint. -/
+def DiscreteFamily (f : ι → Set X) : Prop :=
+  ∀ x, ∃ t ∈ 𝓝 x, {i | (f i ∩ t).Nonempty}.Subsingleton
+
+theorem discreteFamily_of_subsingleton [Subsingleton ι] (f : ι → Set X) : DiscreteFamily f :=
+  fun _ ↦ ⟨univ, univ_mem, Set.subsingleton_of_subsingleton⟩
+
+theorem discreteFamily_empty : DiscreteFamily (fun _ : ι ↦ (∅ : Set X)) := by
+  intro x
+  exact ⟨univ, univ_mem, by simp⟩
+
+namespace DiscreteFamily
+
+/-- A discrete family is locally finite. -/
+theorem locallyFinite (hf : DiscreteFamily f) : LocallyFinite f := fun x ↦ by
+  rcases hf x with ⟨t, htx, ht⟩
+  exact ⟨t, htx, ht.finite⟩
+
+/-- At most one member of a discrete family contains any given point. -/
+theorem point_subsingleton (hf : DiscreteFamily f) (x : X) :
+    {i | x ∈ f i}.Subsingleton := by
+  rcases hf x with ⟨t, htx, ht⟩
+  exact ht.anti fun _ hi ↦ ⟨x, hi, mem_of_mem_nhds htx⟩
+
+/-- Distinct members of a discrete family are disjoint. -/
+theorem pairwiseDisjoint (hf : DiscreteFamily f) : Pairwise (Disjoint on f) := by
+  rintro i j hij
+  change Disjoint (f i) (f j)
+  rw [Set.disjoint_left]
+  intro x hxi hxj
+  exact hij <| hf.point_subsingleton x hxi hxj
+
+/-- Replacing every member of a discrete family by a subset preserves discreteness. -/
+protected theorem subset (hf : DiscreteFamily f) (hg : ∀ i, g i ⊆ f i) :
+    DiscreteFamily g := fun x ↦ by
+  rcases hf x with ⟨t, htx, ht⟩
+  exact ⟨t, htx, ht.anti fun i hi ↦ hi.mono <| inter_subset_inter_left _ (hg i)⟩
+
+/-- Injectively reindexing a discrete family preserves discreteness. -/
+theorem comp_injective {g : ι' → ι} (hf : DiscreteFamily f) (hg : Injective g) :
+    DiscreteFamily (f ∘ g) := fun x ↦ by
+  rcases hf x with ⟨t, htx, ht⟩
+  refine ⟨t, htx, ?_⟩
+  intro i hi j hj
+  exact hg <| ht hi hj
+
+/-- A surjective reindexing detects whether a family is discrete. -/
+theorem of_comp_surjective {g : ι' → ι} (hg : Surjective g)
+    (hfg : DiscreteFamily (f ∘ g)) : DiscreteFamily f := by
+  simpa only [comp_def, surjInv_eq hg] using
+    hfg.comp_injective (injective_surjInv hg)
+
+/-- A family remains discrete when indexed by its range. -/
+theorem on_range (hf : DiscreteFamily f) : DiscreteFamily ((↑) : range f → Set X) :=
+  of_comp_surjective rangeFactorization_surjective hf
+
+/-- Continuous preimages of a discrete family form a discrete family. -/
+theorem preimage_continuous {g : Y → X} (hf : DiscreteFamily f) (hg : Continuous g) :
+    DiscreteFamily (g ⁻¹' f ·) := fun y ↦ by
+  rcases hf (g y) with ⟨t, hgy, ht⟩
+  exact ⟨g ⁻¹' t, hg.continuousAt hgy, ht.anti fun _ ⟨z, hz⟩ ↦ ⟨g z, hz⟩⟩
+
+/-- The closures of the members of a discrete family form a discrete family. -/
+protected theorem closure (hf : DiscreteFamily f) :
+    DiscreteFamily fun i ↦ closure (f i) := by
+  intro x
+  rcases hf x with ⟨s, hsx, hsf⟩
+  refine ⟨interior s, interior_mem_nhds.2 hsx, hsf.anti fun i hi ↦ ?_⟩
+  exact (hi.mono isOpen_interior.closure_inter).of_closure.mono
+    (inter_subset_inter_right _ interior_subset)
+
+theorem closure_iUnion (hf : DiscreteFamily f) : closure (⋃ i, f i) = ⋃ i, closure (f i) :=
+  hf.locallyFinite.closure_iUnion
+
+theorem isClosed_iUnion (hf : DiscreteFamily f) (hc : ∀ i, IsClosed (f i)) :
+    IsClosed (⋃ i, f i) :=
+  hf.locallyFinite.isClosed_iUnion hc
+
+end DiscreteFamily
+
+@[simp]
+theorem Equiv.discreteFamily_comp_iff (e : ι' ≃ ι) :
+    DiscreteFamily (f ∘ e) ↔ DiscreteFamily f :=
+  ⟨fun h ↦ by
+    simpa only [comp_def, e.apply_symm_apply] using h.comp_injective e.symm.injective,
+    fun h ↦ h.comp_injective e.injective⟩
+
+/-- A family is sigma-discrete if its index type is covered by countably many sets on each of
+which the restricted family is discrete. The sets of indices need not be pairwise disjoint. -/
+def SigmaDiscreteFamily (f : ι → Set X) : Prop :=
+  ∃ I : ℕ → Set ι, (⋃ n, I n) = univ ∧
+    ∀ n, DiscreteFamily fun i : I n ↦ f i
+
+namespace SigmaDiscreteFamily
+
+/-- A discrete family is sigma-discrete. -/
+theorem of_discreteFamily (hf : DiscreteFamily f) : SigmaDiscreteFamily f :=
+  ⟨fun _ ↦ univ, by ext; simp, fun _ ↦ hf.comp_injective Subtype.val_injective⟩
+
+/-- Replacing every member of a sigma-discrete family by a subset preserves sigma-discreteness. -/
+protected theorem subset (hf : SigmaDiscreteFamily f) (hg : ∀ i, g i ⊆ f i) :
+    SigmaDiscreteFamily g := by
+  rcases hf with ⟨I, hI, hdisc⟩
+  exact ⟨I, hI, fun n ↦ (hdisc n).subset fun i ↦ hg i⟩
+
+/-- Injectively reindexing a sigma-discrete family preserves sigma-discreteness. -/
+theorem comp_injective {g : ι' → ι} (hf : SigmaDiscreteFamily f) (hg : Injective g) :
+    SigmaDiscreteFamily (f ∘ g) := by
+  rcases hf with ⟨I, hI, hdisc⟩
+  refine ⟨fun n ↦ g ⁻¹' I n, ?_, fun n ↦ ?_⟩
+  · rw [← preimage_iUnion, hI, preimage_univ]
+  · let e : g ⁻¹' I n → I n := fun i ↦ ⟨g i, i.2⟩
+    exact (hdisc n).comp_injective fun (i j : g ⁻¹' I n) (h : e i = e j) ↦
+      Subtype.ext <| hg <| congrArg Subtype.val h
+
+/-- A surjective reindexing detects whether a family is sigma-discrete. -/
+theorem of_comp_surjective {g : ι' → ι} (hg : Surjective g)
+    (hfg : SigmaDiscreteFamily (f ∘ g)) : SigmaDiscreteFamily f := by
+  simpa only [comp_def, surjInv_eq hg] using
+    hfg.comp_injective (injective_surjInv hg)
+
+/-- A family remains sigma-discrete when indexed by its range. -/
+theorem on_range (hf : SigmaDiscreteFamily f) :
+    SigmaDiscreteFamily ((↑) : range f → Set X) :=
+  of_comp_surjective rangeFactorization_surjective hf
+
+/-- Continuous preimages of a sigma-discrete family form a sigma-discrete family. -/
+theorem preimage_continuous {g : Y → X} (hf : SigmaDiscreteFamily f) (hg : Continuous g) :
+    SigmaDiscreteFamily (g ⁻¹' f ·) := by
+  rcases hf with ⟨I, hI, hdisc⟩
+  exact ⟨I, hI, fun n ↦ (hdisc n).preimage_continuous hg⟩
+
+/-- Taking the closure of each member of a sigma-discrete family preserves sigma-discreteness. -/
+protected theorem closure (hf : SigmaDiscreteFamily f) :
+    SigmaDiscreteFamily fun i ↦ closure (f i) := by
+  rcases hf with ⟨I, hI, hdisc⟩
+  exact ⟨I, hI, fun n ↦ (hdisc n).closure⟩
+
+end SigmaDiscreteFamily
+
+@[simp]
+theorem Equiv.sigmaDiscreteFamily_comp_iff (e : ι' ≃ ι) :
+    SigmaDiscreteFamily (f ∘ e) ↔ SigmaDiscreteFamily f :=
+  ⟨fun h ↦ by
+    simpa only [comp_def, e.apply_symm_apply] using h.comp_injective e.symm.injective,
+    fun h ↦ h.comp_injective e.injective⟩
+
+section PseudoMetrizableSpace
+
+private theorem inv_two_pow_pos_aux (n : ℕ) : (0 : ℝ≥0∞) < 2⁻¹ ^ n :=
+  ENNReal.pow_pos (ENNReal.inv_pos.2 ENNReal.ofNat_ne_top) _
+
+private theorem inv_two_pow_le_aux {m n : ℕ} (h : m ≤ n) :
+    (2⁻¹ : ℝ≥0∞) ^ n ≤ 2⁻¹ ^ m :=
+  pow_le_pow_right_of_le_one' (ENNReal.inv_le_one.2 ENNReal.one_lt_two.le) h
+
+private theorem two_mul_inv_two_pow_succ_aux (n : ℕ) :
+    2 * (2⁻¹ : ℝ≥0∞) ^ (n + 1) = 2⁻¹ ^ n := by
+  simp [pow_succ', ← mul_assoc, ENNReal.mul_inv_cancel two_ne_zero ofNat_ne_top]
+
+section PseudoMetricSpace
+
+variable {Z : Type*} [PseudoMetricSpace Z] [LinearOrder ι] [WellFoundedLT ι]
+
+private noncomputable def sigmaDiscreteCoverIndex (u : ι → Set Z)
+    (hucov : ⋃ i, u i = univ) (x : Z) : ι :=
+  wellFounded_lt.min {i | x ∈ u i} (iUnion_eq_univ_iff.1 hucov x)
+
+omit [PseudoMetricSpace Z] in
+private theorem mem_sigmaDiscreteCoverIndex_aux (u : ι → Set Z)
+    (hucov : ⋃ i, u i = univ) (x : Z) : x ∈ u (sigmaDiscreteCoverIndex u hucov x) :=
+  wellFounded_lt.min_mem _ (iUnion_eq_univ_iff.1 hucov x)
+
+omit [PseudoMetricSpace Z] in
+private theorem not_mem_of_lt_sigmaDiscreteCoverIndex_aux (u : ι → Set Z)
+    (hucov : ⋃ i, u i = univ) {x : Z} {i : ι} (hi : i < sigmaDiscreteCoverIndex u hucov x) :
+    x ∉ u i := fun hxi ↦ wellFounded_lt.not_lt_min {i | x ∈ u i} hxi hi
+
+private noncomputable def sigmaDiscreteRefinement (u : ι → Set Z)
+    (hucov : ⋃ i, u i = univ) : ℕ → ι → Set Z :=
+  Nat.strongRec fun n v i ↦
+    ⋃ (x : Z) (_ : sigmaDiscreteCoverIndex u hucov x = i)
+      (_ : Metric.eball x (3 * 2⁻¹ ^ n) ⊆ u i)
+      (_ : ∀ (m : ℕ) (H : m < n), ∀ j, x ∉ v m H j), Metric.eball x (2⁻¹ ^ n)
+
+private theorem sigmaDiscreteRefinement_eq_aux (u : ι → Set Z)
+    (hucov : ⋃ i, u i = univ) (n : ℕ) (i : ι) :
+    sigmaDiscreteRefinement u hucov n i =
+      ⋃ (x : Z) (_ : sigmaDiscreteCoverIndex u hucov x = i)
+        (_ : Metric.eball x (3 * 2⁻¹ ^ n) ⊆ u i)
+        (_ : ∀ m < n, ∀ j, x ∉ sigmaDiscreteRefinement u hucov m j),
+        Metric.eball x (2⁻¹ ^ n) := by
+  rw [sigmaDiscreteRefinement, Nat.strongRec_eq]
+  rfl
+
+private theorem mem_sigmaDiscreteRefinement_aux (u : ι → Set Z)
+    (hucov : ⋃ i, u i = univ) {n : ℕ} {i : ι} {y : Z} :
+    y ∈ sigmaDiscreteRefinement u hucov n i ↔
+      ∃ x : Z, sigmaDiscreteCoverIndex u hucov x = i ∧
+        Metric.eball x (3 * 2⁻¹ ^ n) ⊆ u i ∧
+        (∀ m < n, ∀ j, x ∉ sigmaDiscreteRefinement u hucov m j) ∧
+        edist y x < 2⁻¹ ^ n := by
+  rw [sigmaDiscreteRefinement_eq_aux]
+  simp only [mem_iUnion, Metric.mem_eball, exists_prop]
+
+private theorem exists_mem_sigmaDiscreteRefinement_aux (u : ι → Set Z)
+    (huo : ∀ i, IsOpen (u i)) (hucov : ⋃ i, u i = univ) (x : Z) :
+    ∃ n i, x ∈ sigmaDiscreteRefinement u hucov n i := by
+  let ind := sigmaDiscreteCoverIndex u hucov
+  obtain ⟨n, hn⟩ : ∃ n : ℕ, Metric.eball x (3 * 2⁻¹ ^ n) ⊆ u (ind x) := by
+    rcases EMetric.isOpen_iff.1 (huo <| ind x) x
+      (mem_sigmaDiscreteCoverIndex_aux u hucov x) with ⟨ε, hε, hεu⟩
+    have hε3 : 0 < ε / 3 := ENNReal.div_pos_iff.2 ⟨hε.lt.ne', ENNReal.coe_ne_top⟩
+    obtain ⟨n, hn⟩ := ENNReal.exists_inv_two_pow_lt hε3.ne'
+    refine ⟨n, (Metric.eball_subset_eball ?_).trans hεu⟩
+    simpa only [div_eq_mul_inv, mul_comm] using (ENNReal.mul_lt_of_lt_div hn).le
+  by_contra! h
+  apply h n (ind x)
+  exact mem_sigmaDiscreteRefinement_aux u hucov |>.2
+    ⟨x, rfl, hn, fun _ _ _ ↦ h _ _, Metric.mem_eball_self (inv_two_pow_pos_aux _)⟩
+
+private theorem isOpen_sigmaDiscreteRefinement_aux (u : ι → Set Z)
+    (hucov : ⋃ i, u i = univ) (n : ℕ) (i : ι) :
+    IsOpen (sigmaDiscreteRefinement u hucov n i) := by
+  rw [sigmaDiscreteRefinement_eq_aux]
+  iterate 4 refine isOpen_iUnion fun _ ↦ ?_
+  exact Metric.isOpen_eball
+
+private theorem sigmaDiscreteRefinement_subset_aux (u : ι → Set Z)
+    (hucov : ⋃ i, u i = univ) (n : ℕ) (i : ι) :
+    sigmaDiscreteRefinement u hucov n i ⊆ u i := by
+  rintro x (hx : x ∈ sigmaDiscreteRefinement u hucov n i)
+  rcases (mem_sigmaDiscreteRefinement_aux u hucov).1 hx with ⟨y, rfl, hsub, -, hyx⟩
+  exact hsub (hyx.trans_le <| le_mul_of_one_le_left' <| by norm_num1)
+
+private theorem sigmaDiscreteRefinement_disjoint_eball_aux (u : ι → Set Z)
+    (hucov : ⋃ i, u i = univ) {n k p : ℕ} {i : ι} {x : Z}
+    (hk : Metric.eball x (2⁻¹ ^ k) ⊆ sigmaDiscreteRefinement u hucov n i)
+    (hp : n + k + 1 ≤ p) (j : ι) :
+    Disjoint (sigmaDiscreteRefinement u hucov p j)
+      (Metric.eball x (2⁻¹ ^ (n + k + 1))) := by
+  rw [Set.disjoint_left]
+  rintro y hyp hyx
+  rcases (mem_sigmaDiscreteRefinement_aux u hucov).1 hyp with ⟨z, rfl, -, hzv, hyz⟩
+  apply hzv n (by omega) i
+  apply hk
+  calc
+    edist z x ≤ edist y z + edist y x := edist_triangle_left _ _ _
+    _ < 2⁻¹ ^ p + 2⁻¹ ^ (n + k + 1) := ENNReal.add_lt_add hyz hyx
+    _ ≤ 2⁻¹ ^ (k + 1) + 2⁻¹ ^ (k + 1) :=
+      add_le_add (inv_two_pow_le_aux <| by omega) (inv_two_pow_le_aux <| by omega)
+    _ = 2⁻¹ ^ k := by rw [← two_mul, two_mul_inv_two_pow_succ_aux]
+
+private theorem sigmaDiscreteRefinement_inter_eball_subsingleton_aux (u : ι → Set Z)
+    (hucov : ⋃ i, u i = univ) {n k m : ℕ} {x : Z} (hm : m ≤ n + k) :
+    {j | (sigmaDiscreteRefinement u hucov m j ∩
+      Metric.eball x (2⁻¹ ^ (n + k + 1))).Nonempty}.Subsingleton := by
+  rintro j₁ ⟨y, hyD, hyB⟩ j₂ ⟨z, hzD, hzB⟩
+  by_contra hne : j₁ ≠ j₂
+  wlog hlt : j₁ < j₂ generalizing j₁ j₂ y z
+  · exact this z hzD hzB y hyD hyB hne.symm (hne.lt_or_gt.resolve_left hlt)
+  rcases (mem_sigmaDiscreteRefinement_aux u hucov).1 hyD with
+    ⟨y', rfl, hsuby, -, hdisty⟩
+  rcases (mem_sigmaDiscreteRefinement_aux u hucov).1 hzD with
+    ⟨z', rfl, -, -, hdistz⟩
+  apply not_mem_of_lt_sigmaDiscreteCoverIndex_aux u hucov hlt
+  apply hsuby
+  calc
+    edist z' y' ≤ edist z' x + edist x y' := edist_triangle _ _ _
+    _ ≤ edist z z' + edist z x + (edist y x + edist y y') :=
+      add_le_add (edist_triangle_left _ _ _) (edist_triangle_left _ _ _)
+    _ < 2⁻¹ ^ m + 2⁻¹ ^ (n + k + 1) + (2⁻¹ ^ (n + k + 1) + 2⁻¹ ^ m) := by
+      apply_rules [ENNReal.add_lt_add]
+    _ = 2 * (2⁻¹ ^ m + 2⁻¹ ^ (n + k + 1)) := by simp [two_mul, add_comm]
+    _ ≤ 2 * (2⁻¹ ^ m + 2⁻¹ ^ (m + 1)) := by
+      gcongr 2 * (_ + ?_)
+      exact inv_two_pow_le_aux (add_le_add hm le_rfl)
+    _ = 3 * 2⁻¹ ^ m := by
+      rw [mul_add, two_mul_inv_two_pow_succ_aux, ← two_add_one_eq_three, add_mul, one_mul]
+
+private theorem discreteFamily_sigmaDiscreteRefinement_aux (u : ι → Set Z)
+    (huo : ∀ i, IsOpen (u i)) (hucov : ⋃ i, u i = univ) (m : ℕ) :
+    DiscreteFamily (sigmaDiscreteRefinement u hucov m) := by
+  intro x
+  rcases exists_mem_sigmaDiscreteRefinement_aux u huo hucov x with ⟨n, i, hxn⟩
+  have hvn : sigmaDiscreteRefinement u hucov n i ∈ 𝓝 x :=
+    (isOpen_sigmaDiscreteRefinement_aux u hucov n i).mem_nhds hxn
+  rcases (nhds_basis_uniformity uniformity_basis_edist_inv_two_pow).mem_iff.1 hvn with
+    ⟨k, -, hk : Metric.eball x (2⁻¹ ^ k) ⊆ sigmaDiscreteRefinement u hucov n i⟩
+  let B := Metric.eball x (2⁻¹ ^ (n + k + 1))
+  refine ⟨B, Metric.eball_mem_nhds _ (inv_two_pow_pos_aux _), ?_⟩
+  by_cases hm : m ≤ n + k
+  · exact sigmaDiscreteRefinement_inter_eball_subsingleton_aux u hucov hm
+  · apply subsingleton_empty.anti
+    rintro j ⟨y, hyv, hyB⟩
+    exact Set.disjoint_left.1
+      (sigmaDiscreteRefinement_disjoint_eball_aux u hucov hk (by omega) j) hyv hyB
+
+end PseudoMetricSpace
+
+/-- Every open cover of a pseudometrizable space has an open sigma-discrete precise refinement. -/
+theorem exists_sigmaDiscrete_refinement [PseudoMetrizableSpace X] (u : ι → Set X)
+    (huo : ∀ i, IsOpen (u i)) (hucov : ⋃ i, u i = univ) :
+    ∃ v : ℕ → ι → Set X,
+      (∀ n i, IsOpen (v n i)) ∧
+      (⋃ n, ⋃ i, v n i) = univ ∧
+      (∀ n i, v n i ⊆ u i) ∧
+      ∀ n, DiscreteFamily (v n) := by
+  letI : PseudoMetricSpace X := pseudoMetrizableSpacePseudoMetric X
+  obtain ⟨_, _⟩ := exists_wellFoundedLT ι
+  let v := sigmaDiscreteRefinement u hucov
+  refine ⟨v, isOpen_sigmaDiscreteRefinement_aux u hucov, ?_,
+    sigmaDiscreteRefinement_subset_aux u hucov,
+    discreteFamily_sigmaDiscreteRefinement_aux u huo hucov⟩
+  apply iUnion_eq_univ_iff.2
+  intro x
+  rcases exists_mem_sigmaDiscreteRefinement_aux u huo hucov x with ⟨n, i, hxi⟩
+  exact ⟨n, mem_iUnion.2 ⟨i, hxi⟩⟩
+
+private theorem isTopologicalBasis_iUnion_range_aux {Z : Type*} [PseudoMetricSpace Z]
+    (v : ℕ → ℕ → Z → Set Z) (v_open : ∀ k n x, IsOpen (v k n x))
+    (v_cov : ∀ k, ⋃ n, ⋃ x, v k n x = univ)
+    (v_sub : ∀ k n x, v k n x ⊆ Metric.eball x (2⁻¹ ^ k)) :
+    IsTopologicalBasis
+      (⋃ p, range (v (Nat.pairEquiv.symm p).1 (Nat.pairEquiv.symm p).2)) := by
+  apply isTopologicalBasis_of_isOpen_of_nhds
+  · intro s hs
+    rcases mem_iUnion.1 hs with ⟨p, hp⟩
+    rcases hp with ⟨x, rfl⟩
+    exact v_open _ _ _
+  · intro x s hxs hs
+    rcases EMetric.isOpen_iff.1 hs x hxs with ⟨ε, hε, hεs⟩
+    have hε2 : 0 < ε / 2 := ENNReal.div_pos_iff.2 ⟨hε.lt.ne', ENNReal.coe_ne_top⟩
+    rcases ENNReal.exists_inv_two_pow_lt hε2.ne' with ⟨k, hk⟩
+    have h2k : 2 * (2⁻¹ : ℝ≥0∞) ^ k < ε := by
+      simpa only [div_eq_mul_inv, mul_comm] using ENNReal.mul_lt_of_lt_div hk
+    rcases iUnion_eq_univ_iff.1 (v_cov k) x with ⟨n, hxn⟩
+    rcases mem_iUnion.1 hxn with ⟨y, hxy⟩
+    refine ⟨v k n y, ?_, hxy, fun z hz ↦ hεs ?_⟩
+    · apply mem_iUnion.2
+      exact ⟨Nat.pairEquiv (k, n), ⟨y, by simp⟩⟩
+    · calc
+        edist z x ≤ edist z y + edist y x := edist_triangle _ _ _
+        _ < 2⁻¹ ^ k + 2⁻¹ ^ k := ENNReal.add_lt_add (v_sub k n y hz)
+          (by simpa only [Metric.mem_eball, edist_comm] using v_sub k n y hxy)
+        _ = 2 * 2⁻¹ ^ k := by rw [two_mul]
+        _ < ε := h2k
+
+/-- Every pseudometrizable space has a topological basis which is a countable union of discrete
+families. -/
+theorem exists_isTopologicalBasis_sigmaDiscrete [PseudoMetrizableSpace X] :
+    ∃ b : ℕ → Set (Set X),
+      IsTopologicalBasis (⋃ n, b n) ∧
+      ∀ n, DiscreteFamily ((↑) : b n → Set X) := by
+  letI : PseudoMetricSpace X := pseudoMetrizableSpacePseudoMetric X
+  let u : ℕ → X → Set X := fun k x ↦ Metric.eball x (2⁻¹ ^ k)
+  have u_open : ∀ k x, IsOpen (u k x) := fun _ _ ↦ Metric.isOpen_eball
+  have u_cov : ∀ k, ⋃ x, u k x = univ := fun k ↦ iUnion_eq_univ_iff.2 fun x ↦
+    ⟨x, Metric.mem_eball_self <| inv_two_pow_pos_aux k⟩
+  choose v v_open v_cov v_sub v_disc using
+    fun k ↦ exists_sigmaDiscrete_refinement (u k) (u_open k) (u_cov k)
+  let b : ℕ → Set (Set X) := fun p ↦
+    range (v (Nat.pairEquiv.symm p).1 (Nat.pairEquiv.symm p).2)
+  refine ⟨b, isTopologicalBasis_iUnion_range_aux v v_open v_cov ?_, fun p ↦ ?_⟩
+  · exact fun k n x ↦ v_sub k n x
+  · exact (v_disc (Nat.pairEquiv.symm p).1 (Nat.pairEquiv.symm p).2).on_range
+
+end PseudoMetrizableSpace

--- a/Mathlib/Topology/Metrizable/BingNagataSmirnov.lean
+++ b/Mathlib/Topology/Metrizable/BingNagataSmirnov.lean
@@ -1,0 +1,266 @@
+/-
+Copyright (c) 2026 Yongxi Lin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yongxi Lin
+-/
+module
+
+public import Mathlib.Topology.DiscreteFamily
+public import Mathlib.Topology.Metrizable.Urysohn
+
+/-!
+# The Bing--Nagata--Smirnov metrization theorem
+
+We prove that a regular topological space with a sigma-locally finite basis is pseudometrizable.
+Consequently, a T3 space is metrizable if and only if it has a sigma-locally finite basis, or,
+equivalently, a sigma-discrete basis.
+-/
+
+@[expose] public section
+
+open Filter Metric Set TopologicalSpace Topology
+open scoped BoundedContinuousFunction
+
+namespace TopologicalSpace
+
+variable {X : Type*} [TopologicalSpace X]
+
+private theorem hasSeparatingCover_of_sigmaLocallyFiniteBasis_aux [RegularSpace X]
+    (b : ℕ → Set (Set X)) (hb : IsTopologicalBasis (⋃ n, b n))
+    (hlf : ∀ n, LocallyFinite ((↑) : b n → Set X)) {s t : Set X} (ht : IsClosed t)
+    (hst : Disjoint s t) : HasSeparatingCover s t := by
+  let c (n : ℕ) := {U : b n // closure (U : Set X) ⊆ tᶜ}
+  let u (n : ℕ) := ⋃ U : c n, (U : Set X)
+  have hlfc (n : ℕ) : LocallyFinite ((↑) : c n → Set X) :=
+    (hlf n).comp_injective Subtype.val_injective
+  refine ⟨u, ?_, fun n ↦
+    ⟨isOpen_iUnion fun U ↦ hb.isOpen (mem_iUnion_of_mem n U.1.2), ?_⟩⟩
+  · intro x hxs
+    obtain ⟨U, hUb, hxU, hU⟩ := hb.exists_closure_subset (ht.isOpen_compl.mem_nhds <|
+      disjoint_left.1 hst hxs)
+    obtain ⟨n, hUbn⟩ := mem_iUnion.1 hUb
+    exact mem_iUnion_of_mem n <| mem_iUnion_of_mem ⟨⟨U, hUbn⟩, hU⟩ hxU
+  · rw [hlfc n |>.closure_iUnion]
+    exact disjoint_iUnion_left.2 fun U ↦ disjoint_left.2 fun _ hx ht ↦ U.2 hx ht
+
+/-- A regular space with a sigma-locally finite basis is normal. -/
+theorem NormalSpace.of_sigmaLocallyFiniteBasis [RegularSpace X]
+    (b : ℕ → Set (Set X)) (hb : IsTopologicalBasis (⋃ n, b n))
+    (hlf : ∀ n, LocallyFinite ((↑) : b n → Set X)) : NormalSpace X where
+  normal _s _t hs ht hst := hasSeparatingCovers_iff_separatedNhds.1
+    ⟨hasSeparatingCover_of_sigmaLocallyFiniteBasis_aux b hb hlf ht hst,
+      hasSeparatingCover_of_sigmaLocallyFiniteBasis_aux b hb hlf hs hst.symm⟩
+
+private abbrev sigmaLocallyFiniteBasisIndex_aux (b : ℕ → Set (Set X)) :=
+  Σ p : ℕ × ℕ, b p.1
+
+private instance instTopologicalSpaceSigmaLocallyFiniteBasisIndex_aux
+    (b : ℕ → Set (Set X)) : TopologicalSpace (sigmaLocallyFiniteBasisIndex_aux b) := ⊥
+
+private instance instDiscreteTopologySigmaLocallyFiniteBasisIndex_aux
+    (b : ℕ → Set (Set X)) : DiscreteTopology (sigmaLocallyFiniteBasisIndex_aux b) :=
+  ⟨rfl⟩
+
+private abbrev sigmaLocallyFiniteBasisInnerIndex_aux (b : ℕ → Set (Set X))
+    (q : sigmaLocallyFiniteBasisIndex_aux b) :=
+  {V : b q.1.2 // closure (V : Set X) ⊆ (q.2 : Set X)}
+
+private def sigmaLocallyFiniteBasisInnerUnion_aux (b : ℕ → Set (Set X))
+    (q : sigmaLocallyFiniteBasisIndex_aux b) : Set X :=
+  ⋃ V : sigmaLocallyFiniteBasisInnerIndex_aux b q, (V : Set X)
+
+private theorem closure_sigmaLocallyFiniteBasisInnerUnion_subset_aux
+    (b : ℕ → Set (Set X)) (hlf : ∀ n, LocallyFinite ((↑) : b n → Set X))
+    (q : sigmaLocallyFiniteBasisIndex_aux b) :
+    closure (sigmaLocallyFiniteBasisInnerUnion_aux b q) ⊆ (q.2 : Set X) := by
+  change closure (⋃ V, (Subtype.val ∘ Subtype.val) V) ⊆ _
+  rw [((hlf q.1.2).comp_injective Subtype.val_injective).closure_iUnion]
+  exact iUnion_subset fun V ↦ V.2
+
+private def sigmaLocallyFiniteBasisEmbedding_aux (b : ℕ → Set (Set X))
+    (f : sigmaLocallyFiniteBasisIndex_aux b → C(X, ℝ))
+    (hf : ∀ q x, f q x ∈ Icc (0 : ℝ) 1) :
+    X → (sigmaLocallyFiniteBasisIndex_aux b →ᵇ ℝ) := fun x =>
+  ⟨⟨fun q ↦ f q x, continuous_of_discreteTopology⟩, 1,
+    fun _ _ ↦ Real.dist_le_of_mem_Icc_01 (hf _ _) (hf _ _)⟩
+
+@[simp]
+private theorem sigmaLocallyFiniteBasisEmbedding_apply_aux (b : ℕ → Set (Set X))
+    (f : sigmaLocallyFiniteBasisIndex_aux b → C(X, ℝ))
+    (hf : ∀ q x, f q x ∈ Icc (0 : ℝ) 1) (x : X)
+    (q : sigmaLocallyFiniteBasisIndex_aux b) :
+    sigmaLocallyFiniteBasisEmbedding_aux b f hf x q = f q x :=
+  rfl
+
+private theorem nhds_le_comap_sigmaLocallyFiniteBasisEmbedding_aux
+    (b : ℕ → Set (Set X)) (hlf : ∀ n, LocallyFinite ((↑) : b n → Set X))
+    {ε : ℕ × ℕ → ℝ} (hε : Tendsto ε cofinite (nhds 0))
+    (f : sigmaLocallyFiniteBasisIndex_aux b → C(X, ℝ))
+    (hfε : ∀ q, EqOn (f q) (fun _ ↦ ε q.1) (q.2 : Set X)ᶜ)
+    (hf0ε : ∀ q x, f q x ∈ Icc 0 (ε q.1)) (hf01 : ∀ q x, f q x ∈ Icc 0 1)
+    (x : X) : nhds x ≤ comap (sigmaLocallyFiniteBasisEmbedding_aux b f hf01)
+      (nhds (sigmaLocallyFiniteBasisEmbedding_aux b f hf01 x)) := by
+  refine (nhds_basis_closedBall.comap _).ge_iff.2 fun δ hδ ↦ ?_
+  have hpfin : {p | δ ≤ ε p}.Finite := by
+    simpa only [← not_lt] using! hε (gt_mem_nhds hδ)
+  have hp (p : ℕ × ℕ) : ∀ᶠ y in nhds x, ∀ U : b p.1,
+      dist (f ⟨p, U⟩ y) (f ⟨p, U⟩ x) ≤ δ := by
+    rcases hlf p.1 x with ⟨t, htx, htfin⟩
+    have hevent : ∀ᶠ y in nhds x, ∀ U : b p.1, ((U : Set X) ∩ t).Nonempty →
+        dist (f ⟨p, U⟩ y) (f ⟨p, U⟩ x) ≤ δ := by
+      exact (eventually_all_finite htfin).2 fun U _ ↦
+        (f ⟨p, U⟩).continuous.tendsto x (closedBall_mem_nhds _ hδ)
+    filter_upwards [htx, hevent] with y hyt hy U
+    by_cases hU : ((U : Set X) ∩ t).Nonempty
+    · exact hy U hU
+    · have hyU : y ∉ (U : Set X) := fun hyU ↦ hU ⟨y, hyU, hyt⟩
+      have hxU : x ∉ (U : Set X) := fun hxU ↦ hU ⟨x, hxU, mem_of_mem_nhds htx⟩
+      simp only [hfε ⟨p, U⟩ hyU, hfε ⟨p, U⟩ hxU, dist_self, hδ.le]
+  have hlarge : ∀ᶠ y in nhds x, ∀ p, δ ≤ ε p → ∀ U : b p.1,
+      dist (f ⟨p, U⟩ y) (f ⟨p, U⟩ x) ≤ δ :=
+    (eventually_all_finite hpfin).2 fun p _ ↦ hp p
+  refine hlarge.mono fun y hy ↦ (BoundedContinuousFunction.dist_le hδ.le).2 fun q ↦ ?_
+  rcases le_total δ (ε q.1) with hle | hle
+  · exact hy q.1 hle q.2
+  · exact (Real.dist_le_of_mem_Icc (hf0ε q _) (hf0ε q _)).trans (by simpa using hle)
+
+private theorem comap_sigmaLocallyFiniteBasisEmbedding_le_nhds_aux [RegularSpace X]
+    (b : ℕ → Set (Set X)) (hb : IsTopologicalBasis (⋃ n, b n)) {ε : ℕ × ℕ → ℝ}
+    (hε0 : ∀ p, 0 < ε p) (f : sigmaLocallyFiniteBasisIndex_aux b → C(X, ℝ))
+    (hf0 : ∀ q, EqOn (f q) 0 (closure (sigmaLocallyFiniteBasisInnerUnion_aux b q)))
+    (hfε : ∀ q, EqOn (f q) (fun _ ↦ ε q.1) (q.2 : Set X)ᶜ)
+    (hf01 : ∀ q x, f q x ∈ Icc 0 1) (x : X) :
+    comap (sigmaLocallyFiniteBasisEmbedding_aux b f hf01)
+      (nhds (sigmaLocallyFiniteBasisEmbedding_aux b f hf01 x)) ≤ nhds x := by
+  refine ((nhds_basis_ball.comap _).le_basis_iff hb.nhds_hasBasis).2 ?_
+  rintro V ⟨hVb, hxV⟩
+  obtain ⟨U, hUb, hxU, hUV⟩ := hb.exists_closure_subset (hb.mem_nhds hVb hxV)
+  obtain ⟨m, hUm⟩ := mem_iUnion.1 hUb
+  obtain ⟨W, hWb, hxW, hWU⟩ := hb.exists_closure_subset (hb.mem_nhds hUb hxU)
+  obtain ⟨n, hWn⟩ := mem_iUnion.1 hWb
+  set q : sigmaLocallyFiniteBasisIndex_aux b := ⟨(m, n), ⟨U, hUm⟩⟩
+  have hxa : x ∈ sigmaLocallyFiniteBasisInnerUnion_aux b q :=
+    mem_iUnion_of_mem ⟨⟨W, hWn⟩, hWU⟩ hxW
+  refine ⟨ε q.1, hε0 q.1, fun y (hy : dist (sigmaLocallyFiniteBasisEmbedding_aux b f hf01 y)
+    (sigmaLocallyFiniteBasisEmbedding_aux b f hf01 x) < ε q.1) ↦ ?_⟩
+  have hyq : dist (f q y) (f q x) < ε q.1 :=
+    (BoundedContinuousFunction.dist_coe_le_dist q).trans_lt hy
+  contrapose! hyq
+  rw [hfε q (fun hyU ↦ hyq (hUV (subset_closure hyU))),
+    hf0 q (subset_closure hxa), Pi.zero_apply, dist_zero_right]
+  exact le_abs_self _
+
+private theorem exists_isInducing_of_sigmaLocallyFiniteBasis_aux [RegularSpace X]
+    (b : ℕ → Set (Set X)) (hb : IsTopologicalBasis (⋃ n, b n))
+    (hlf : ∀ n, LocallyFinite ((↑) : b n → Set X)) :
+    ∃ F : X → (sigmaLocallyFiniteBasisIndex_aux b →ᵇ ℝ), IsInducing F := by
+  letI : NormalSpace X := .of_sigmaLocallyFiniteBasis b hb hlf
+  obtain ⟨ε, ε01, hε⟩ : ∃ ε : ℕ × ℕ → ℝ,
+      (∀ p, ε p ∈ Ioc (0 : ℝ) 1) ∧ Tendsto ε cofinite (nhds 0) := by
+    rcases posSumOfEncodable zero_lt_one (ℕ × ℕ) with ⟨ε, hε0, C, hεC, hC⟩
+    refine ⟨ε, fun p ↦ ⟨hε0 p, ?_⟩, hεC.summable.tendsto_cofinite_zero⟩
+    exact (le_hasSum hεC p fun _ _ ↦ (hε0 _).le).trans hC
+  have hf : ∀ q : sigmaLocallyFiniteBasisIndex_aux b, ∃ f : C(X, ℝ),
+      EqOn f 0 (closure (sigmaLocallyFiniteBasisInnerUnion_aux b q)) ∧
+        EqOn f (fun _ ↦ ε q.1) (q.2 : Set X)ᶜ ∧
+        ∀ x, f x ∈ Icc 0 (ε q.1) := by
+    intro q
+    have hd : Disjoint (closure (sigmaLocallyFiniteBasisInnerUnion_aux b q))
+        (q.2 : Set X)ᶜ :=
+      (closure_sigmaLocallyFiniteBasisInnerUnion_subset_aux b hlf q).disjoint_compl_right
+    rcases exists_continuous_zero_one_of_isClosed isClosed_closure
+        (hb.isOpen (mem_iUnion_of_mem q.1.1 q.2.2)).isClosed_compl hd with
+      ⟨f, hf₀, hf₁, hf01⟩
+    exact ⟨ε q.1 • f, fun x hx ↦ by simp [hf₀ hx], fun x hx ↦ by simp [hf₁ hx],
+      fun x ↦ ⟨mul_nonneg (ε01 _).1.le (hf01 _).1,
+        mul_le_of_le_one_right (ε01 _).1.le (hf01 _).2⟩⟩
+  choose f hf0 hfε hf0ε using hf
+  have hf01 : ∀ q x, f q x ∈ Icc (0 : ℝ) 1 :=
+    fun q x ↦ Icc_subset_Icc_right (ε01 _).2 (hf0ε q x)
+  exact ⟨sigmaLocallyFiniteBasisEmbedding_aux b f hf01, isInducing_iff_nhds.2 fun x ↦
+    le_antisymm
+      (nhds_le_comap_sigmaLocallyFiniteBasisEmbedding_aux b hlf hε f hfε hf0ε hf01 x)
+      (comap_sigmaLocallyFiniteBasisEmbedding_le_nhds_aux b hb (fun p ↦ (ε01 p).1)
+        f hf0 hfε hf01 x)⟩
+
+/-- A regular space with a sigma-locally finite basis is pseudometrizable. -/
+theorem PseudoMetrizableSpace.of_sigmaLocallyFiniteBasis [RegularSpace X]
+    (b : ℕ → Set (Set X)) (hb : IsTopologicalBasis (⋃ n, b n))
+    (hlf : ∀ n, LocallyFinite ((↑) : b n → Set X)) : PseudoMetrizableSpace X :=
+  let ⟨_, hF⟩ := exists_isInducing_of_sigmaLocallyFiniteBasis_aux b hb hlf
+  hF.pseudoMetrizableSpace
+
+/-- A regular space with a sigma-discrete basis is pseudometrizable. -/
+theorem PseudoMetrizableSpace.of_sigmaDiscreteBasis [RegularSpace X]
+    (b : ℕ → Set (Set X)) (hb : IsTopologicalBasis (⋃ n, b n))
+    (hdisc : ∀ n, DiscreteFamily ((↑) : b n → Set X)) : PseudoMetrizableSpace X :=
+  .of_sigmaLocallyFiniteBasis b hb fun n ↦ (hdisc n).locallyFinite
+
+/-- A T3 space with a sigma-locally finite basis is metrizable. -/
+theorem MetrizableSpace.of_sigmaLocallyFiniteBasis [T3Space X]
+    (b : ℕ → Set (Set X)) (hb : IsTopologicalBasis (⋃ n, b n))
+    (hlf : ∀ n, LocallyFinite ((↑) : b n → Set X)) : MetrizableSpace X := by
+  letI : PseudoMetrizableSpace X := .of_sigmaLocallyFiniteBasis b hb hlf
+  infer_instance
+
+/-- A T3 space with a sigma-discrete basis is metrizable. -/
+theorem MetrizableSpace.of_sigmaDiscreteBasis [T3Space X]
+    (b : ℕ → Set (Set X)) (hb : IsTopologicalBasis (⋃ n, b n))
+    (hdisc : ∀ n, DiscreteFamily ((↑) : b n → Set X)) : MetrizableSpace X :=
+  .of_sigmaLocallyFiniteBasis b hb fun n ↦ (hdisc n).locallyFinite
+
+/-- The pseudometrizable version of the Bing--Nagata--Smirnov metrization theorem. -/
+theorem pseudoMetrizableSpace_iff_exists_sigmaLocallyFiniteBasis :
+    PseudoMetrizableSpace X ↔ RegularSpace X ∧
+      ∃ b : ℕ → Set (Set X), IsTopologicalBasis (⋃ n, b n) ∧
+        ∀ n, LocallyFinite ((↑) : b n → Set X) := by
+  constructor
+  · intro h
+    letI := h
+    obtain ⟨b, hb, hdisc⟩ := exists_isTopologicalBasis_sigmaDiscrete (X := X)
+    exact ⟨inferInstance, b, hb, fun n ↦ (hdisc n).locallyFinite⟩
+  · rintro ⟨hreg, b, hb, hlf⟩
+    letI := hreg
+    exact .of_sigmaLocallyFiniteBasis b hb hlf
+
+/-- A space is pseudometrizable if and only if it is regular and has a sigma-discrete basis. -/
+theorem pseudoMetrizableSpace_iff_exists_sigmaDiscreteBasis :
+    PseudoMetrizableSpace X ↔ RegularSpace X ∧
+      ∃ b : ℕ → Set (Set X), IsTopologicalBasis (⋃ n, b n) ∧
+        ∀ n, DiscreteFamily ((↑) : b n → Set X) := by
+  constructor
+  · intro h
+    letI := h
+    exact ⟨inferInstance, exists_isTopologicalBasis_sigmaDiscrete (X := X)⟩
+  · rintro ⟨hreg, b, hb, hdisc⟩
+    letI := hreg
+    exact .of_sigmaDiscreteBasis b hb hdisc
+
+/-- The Bing--Nagata--Smirnov metrization theorem, in terms of sigma-locally finite bases. -/
+theorem metrizableSpace_iff_exists_sigmaLocallyFiniteBasis :
+    MetrizableSpace X ↔ T3Space X ∧
+      ∃ b : ℕ → Set (Set X), IsTopologicalBasis (⋃ n, b n) ∧
+        ∀ n, LocallyFinite ((↑) : b n → Set X) := by
+  constructor
+  · intro h
+    letI := h
+    obtain ⟨b, hb, hdisc⟩ := exists_isTopologicalBasis_sigmaDiscrete (X := X)
+    exact ⟨inferInstance, b, hb, fun n ↦ (hdisc n).locallyFinite⟩
+  · rintro ⟨ht3, b, hb, hlf⟩
+    letI := ht3
+    exact .of_sigmaLocallyFiniteBasis b hb hlf
+
+/-- The Bing--Nagata--Smirnov metrization theorem, in terms of sigma-discrete bases. -/
+theorem metrizableSpace_iff_exists_sigmaDiscreteBasis :
+    MetrizableSpace X ↔ T3Space X ∧
+      ∃ b : ℕ → Set (Set X), IsTopologicalBasis (⋃ n, b n) ∧
+        ∀ n, DiscreteFamily ((↑) : b n → Set X) := by
+  constructor
+  · intro h
+    letI := h
+    exact ⟨inferInstance, exists_isTopologicalBasis_sigmaDiscrete (X := X)⟩
+  · rintro ⟨ht3, b, hb, hdisc⟩
+    letI := ht3
+    exact .of_sigmaDiscreteBasis b hb hdisc
+
+end TopologicalSpace

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -2245,6 +2245,9 @@ Q2607007:
 
 Q2621667:
   title: Nagata–Smirnov metrization theorem
+  decls:
+    - TopologicalSpace.metrizableSpace_iff_exists_sigmaLocallyFiniteBasis
+    - TopologicalSpace.metrizableSpace_iff_exists_sigmaDiscreteBasis
 
 Q2631152:
   title: Carathéodory's extension theorem


### PR DESCRIPTION
This PR proves that every regular space with a sigma-locally finite basis is normal and pseudometrizable. It also derives pseudometrizability from a sigma-discrete basis.

It gives the Bing-Nagata-Smirnov characterizations of pseudometrizable and metrizable spaces using sigma-locally finite and sigma-discrete bases. This PR depends on #41670.

Created with the help of codex.