### PR TITLE
chore: remove redudant haveI/letI in defs

### DIFF
--- a/Mathlib/Algebra/Algebra/RestrictScalars.lean
+++ b/Mathlib/Algebra/Algebra/RestrictScalars.lean
@@ -138,7 +138,6 @@ The preferred way of setting this up is
 `[Module Rᵐᵒᵖ M] [Module Sᵐᵒᵖ M] [IsScalarTower Rᵐᵒᵖ Sᵐᵒᵖ M]`.
 -/
 instance RestrictScalars.opModule [Module Sᵐᵒᵖ M] : Module Rᵐᵒᵖ (RestrictScalars R S M) :=
-  letI : Module Sᵐᵒᵖ (RestrictScalars R S M) := ‹Module Sᵐᵒᵖ M›
   Module.compHom M (RingHom.op <| algebraMap R S)
 
 instance RestrictScalars.isCentralScalar [Module S M] [Module Sᵐᵒᵖ M] [IsCentralScalar S M] :

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -403,7 +403,7 @@ theorem prod_eq_mul_of_mem {s : Finset ι} {f : ι → M} (a b : ι) (ha : a ∈
 theorem prod_eq_mul {s : Finset ι} {f : ι → M} (a b : ι) (hn : a ≠ b)
     (h₀ : ∀ c ∈ s, c ≠ a ∧ c ≠ b → f c = 1) (ha : a ∉ s → f a = 1) (hb : b ∉ s → f b = 1) :
     ∏ x ∈ s, f x = f a * f b := by
-  haveI := Classical.decEq ι; by_cases h₁ : a ∈ s <;> by_cases h₂ : b ∈ s
+  by_cases h₁ : a ∈ s <;> by_cases h₂ : b ∈ s
   · exact prod_eq_mul_of_mem a b h₁ h₂ hn h₀
   · rw [hb h₂, mul_one]
     apply prod_eq_single_of_mem a h₁

--- a/Mathlib/Algebra/Category/Grp/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/Grp/FilteredColimits.lean
@@ -142,7 +142,6 @@ noncomputable def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) :=
 noncomputable instance forget₂Mon_preservesFilteredColimits :
     PreservesFilteredColimits.{u} (forget₂ GrpCat.{u} MonCat.{u}) where
       preserves_filtered_colimits x hx1 _ :=
-      letI : Category.{u, u} x := hx1
       ⟨fun {F} => preservesColimit_of_preserves_colimit_cocone (colimitCoconeIsColimit.{u, u} F)
           (MonCat.FilteredColimits.colimitCoconeIsColimit.{u, u} _)⟩
 
@@ -203,7 +202,6 @@ noncomputable def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) :=
 noncomputable instance forget₂Group_preservesFilteredColimits :
     PreservesFilteredColimits (forget₂ CommGrpCat GrpCat.{u}) where
   preserves_filtered_colimits J hJ1 _ :=
-    letI : Category J := hJ1
     { preservesColimit := fun {F} =>
         preservesColimit_of_preserves_colimit_cocone (colimitCoconeIsColimit.{u, u} F)
           (GrpCat.FilteredColimits.colimitCoconeIsColimit.{u, u}

--- a/Mathlib/Algebra/Category/Grp/Images.lean
+++ b/Mathlib/Algebra/Category/Grp/Images.lean
@@ -60,14 +60,12 @@ noncomputable def image.lift (F' : MonoFactorisation f) : image f ⟶ F'.I :=
   ofHom
   { toFun := (fun x => F'.e (Classical.indefiniteDescription _ x.2).1 : image f → F'.I)
     map_zero' := by
-      haveI := F'.m_mono
       apply injective_of_mono F'.m
       change (F'.e ≫ F'.m) _ = _
       rw [F'.fac, map_zero]
       exact (Classical.indefiniteDescription (fun y => f y = 0) _).2
     map_add' := by
       intro x y
-      haveI := F'.m_mono
       apply injective_of_mono F'.m
       rw [map_add]
       change (F'.e ≫ F'.m) _ = (F'.e ≫ F'.m) _ + (F'.e ≫ F'.m) _

--- a/Mathlib/Algebra/Category/Grp/Limits.lean
+++ b/Mathlib/Algebra/Category/Grp/Limits.lean
@@ -86,8 +86,6 @@ reuse the existing limit. -/]
 noncomputable instance Forget₂.createsLimit :
     CreatesLimit F (forget₂ GrpCat.{u} MonCat.{u}) :=
   -- Porting note: need to add `forget₂ GrpCat MonCat` reflects isomorphism
-  letI : (forget₂ GrpCat.{u} MonCat.{u}).ReflectsIsomorphisms :=
-    CategoryTheory.reflectsIsomorphisms_forget₂ _ _
   createsLimitOfReflectsIso (K := F) (F := (forget₂ GrpCat.{u} MonCat.{u}))
     fun c' t =>
       have : Small.{u} (Functor.sections ((F ⋙ forget₂ GrpCat MonCat) ⋙ forget MonCat)) := by

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -801,7 +801,6 @@ def Unit.map {X : ModuleCat R} : X ⟶ (extendScalars f ⋙ restrictScalars f).o
   { toFun := fun x => (1 : S) ⊗ₜ[R,f] x
     map_add' := fun x x' => by dsimp; rw [TensorProduct.tmul_add]
     map_smul' := fun r x => by
-      letI m1 : Module R S := Module.compHom S f
       dsimp; rw [← TensorProduct.smul_tmul, TensorProduct.smul_tmul'] }
 
 /--

--- a/Mathlib/Algebra/Category/ModuleCat/Kernels.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Kernels.lean
@@ -64,8 +64,6 @@ def cokernelIsColimit : IsColimit (cokernelCocone f) :=
     (fun s => ofHom <| (LinearMap.range f.hom).liftQ (Cofork.π s).hom <|
       LinearMap.range_le_ker_iff.2 <| ModuleCat.hom_ext_iff.mp <| CokernelCofork.condition s)
     (fun s => hom_ext <| (LinearMap.range f.hom).liftQ_mkQ (Cofork.π s).hom _) fun s m h => by
-    haveI : Epi (ofHom f.hom.range.mkQ) :=
-      (epi_iff_range_eq_top _).mpr (Submodule.range_mkQ _)
     apply (cancel_epi (ofHom f.hom.range.mkQ)).1
     exact h
 

--- a/Mathlib/Algebra/Category/Ring/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/Ring/FilteredColimits.lean
@@ -180,7 +180,6 @@ def colimitCoconeIsColimit : IsColimit <| colimitCocone.{v, u} F where
 instance forget₂Mon_preservesFilteredColimits :
     PreservesFilteredColimits (forget₂ SemiRingCat MonCat.{u}) where
   preserves_filtered_colimits {J hJ1 _} :=
-    letI : Category J := hJ1
     { preservesColimit := fun {F} =>
         preservesColimit_of_preserves_colimit_cocone (colimitCoconeIsColimit.{u, u} F)
           (MonCat.FilteredColimits.colimitCoconeIsColimit (F ⋙ forget₂ SemiRingCat MonCat.{u})) }
@@ -235,7 +234,6 @@ def colimitCoconeIsColimit : IsColimit <| colimitCocone.{v, u} F :=
 instance forget₂SemiRing_preservesFilteredColimits :
     PreservesFilteredColimits (forget₂ CommSemiRingCat SemiRingCat.{u}) where
   preserves_filtered_colimits {J hJ1 _} :=
-    letI : Category J := hJ1
     { preservesColimit := fun {F} =>
         preservesColimit_of_preserves_colimit_cocone (colimitCoconeIsColimit.{u, u} F)
           (SemiRingCat.FilteredColimits.colimitCoconeIsColimit
@@ -292,7 +290,6 @@ def colimitCoconeIsColimit : IsColimit <| colimitCocone.{v, u} F :=
 instance forget₂SemiRing_preservesFilteredColimits :
     PreservesFilteredColimits (forget₂ RingCat SemiRingCat.{u}) where
   preserves_filtered_colimits {J hJ1 _} :=
-    letI : Category J := hJ1
     { preservesColimit := fun {F} =>
         preservesColimit_of_preserves_colimit_cocone (colimitCoconeIsColimit.{u, u} F)
           (SemiRingCat.FilteredColimits.colimitCoconeIsColimit
@@ -355,7 +352,6 @@ def colimitCoconeIsColimit : IsColimit <| colimitCocone.{v, u} F :=
 instance forget₂Ring_preservesFilteredColimits :
     PreservesFilteredColimits (forget₂ CommRingCat RingCat.{u}) where
   preserves_filtered_colimits {J hJ1 _} :=
-    letI : Category J := hJ1
     { preservesColimit := fun {F} =>
         preservesColimit_of_preserves_colimit_cocone (colimitCoconeIsColimit.{u, u} F)
           (RingCat.FilteredColimits.colimitCoconeIsColimit (F ⋙ forget₂ CommRingCat RingCat.{u})) }

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -388,7 +388,7 @@ noncomputable def ringExpChar : ℕ := max (ringChar R) 1
 
 lemma ringExpChar.eq (q : ℕ) [h : ExpChar R q] : ringExpChar R = q := by
   rcases h with _ | h
-  · haveI := CharP.ofCharZero R
+  ·
     rw [ringExpChar, ringChar.eq R 0]; rfl
   rw [ringExpChar, ringChar.eq R q]
   exact Nat.max_eq_left h.one_lt.le

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -211,7 +211,6 @@ theorem gcd_eq_gcd_ab (a b : R) : (gcd a b : R) = a * gcdA a b + b * gcdB a b :=
 
 -- see Note [lower instance priority]
 instance (priority := 70) (R : Type*) [e : EuclideanDomain R] : IsDomain R :=
-  haveI := Classical.decEq R
   have : NoZeroDivisors R :=
   { eq_zero_or_eq_zero_of_mul_eq_zero {a b} h :=
       or_iff_not_and_not.2 fun h0 ↦ h0.1 <| by rw [← mul_div_cancel_right₀ a h0.2, h, zero_div] }

--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -102,7 +102,7 @@ theorem CancelMonoid.toRightCancelMonoid_injective {M : Type u} :
     Function.Injective (@CancelMonoid.toRightCancelMonoid M) := by
   intro m₁ m₂ h
   apply CancelMonoid.ext
-  exact congrArg (fun m : Monoid M => (letI := m; HMul.hMul : M → M → M)) <|
+  exact congrArg (fun m : Monoid M => (HMul.hMul : M → M → M)) <|
     congrArg (@RightCancelMonoid.toMonoid M) h
 
 @[to_additive]

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -182,7 +182,6 @@ instance : LieRingModule L (shiftedGenWeightSpace R L M χ) where
     abel
 
 @[simp] lemma coe_lie_shiftedGenWeightSpace_apply (x : L) (m : shiftedGenWeightSpace R L M χ) :
-    letI : Bracket L (shiftedGenWeightSpace R L M χ) := LieRingModule.toBracket
     ⁅x, m⁆ = ⁅x, (m : M)⁆ - χ x • m :=
   rfl
 

--- a/Mathlib/Algebra/Polynomial/Expand.lean
+++ b/Mathlib/Algebra/Polynomial/Expand.lean
@@ -257,7 +257,7 @@ theorem expand_contract' [NoZeroDivisors R] {f : R[X]} (hf : Polynomial.derivati
     expand R p (contract p f) = f := by
   obtain _ | @⟨_, hprime, hchar⟩ := ‹ExpChar R p›
   · rw [expand_one, contract_one]
-  · haveI := Fact.mk hchar; exact expand_contract p hf hprime.ne_zero
+  · exact expand_contract p hf hprime.ne_zero
 
 theorem map_frobenius_expand (f : R[X]) : map (frobenius R p) (expand R p f) = f ^ p := by
   refine f.induction_on' (fun a b ha hb => ?_) fun n a => ?_

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -421,7 +421,6 @@ lemma isoSpec_inv_appTop :
 /-- The open immersion `Spec Γ(X, U) ⟶ X` for an affine `U`. -/
 def fromSpec :
     Spec Γ(X, U) ⟶ X :=
-  haveI : IsAffine U := hU
   hU.isoSpec.inv ≫ U.ι
 
 instance isOpenImmersion_fromSpec :

--- a/Mathlib/AlgebraicGeometry/Cover/Directed.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Directed.lean
@@ -290,7 +290,6 @@ variable {𝒰 : X.OpenCover} [Preorder 𝒰.I₀]
 
 include hle in
 lemma Cover.LocallyDirected.ofIsBasisOpensRange_le_iff (i j : 𝒰.I₀) :
-    letI := Cover.LocallyDirected.ofIsBasisOpensRange hle H
     i ≤ j ↔ (𝒰.f i).opensRange ≤ (𝒰.f j).opensRange := hle
 
 lemma Cover.LocallyDirected.ofIsBasisOpensRange_trans {i j : 𝒰.I₀} :

--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
@@ -575,7 +575,7 @@ noncomputable nonrec def vanishingIdeal (Z : Closeds X) : IdealSheafData X :=
           (Spec.map (X.presheaf.map (homOfLE _).op) x) ?_
         rwa [Set.mem_preimage, ← Scheme.Hom.comp_apply,
           IsAffineOpen.map_fromSpec _ (X.affineBasicOpen f).2]
-      · letI : Algebra Γ(X, U) Γ(X, X.affineBasicOpen f) := F.hom.toAlgebra
+      ·
         have : IsLocalization.Away f Γ(X, X.basicOpen f) :=
           U.2.isLocalization_of_eq_basicOpen _ _ rfl
         intro x hx

--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
@@ -575,8 +575,7 @@ noncomputable nonrec def vanishingIdeal (Z : Closeds X) : IdealSheafData X :=
           (Spec.map (X.presheaf.map (homOfLE _).op) x) ?_
         rwa [Set.mem_preimage, ← Scheme.Hom.comp_apply,
           IsAffineOpen.map_fromSpec _ (X.affineBasicOpen f).2]
-      ·
-        have : IsLocalization.Away f Γ(X, X.basicOpen f) :=
+      · have : IsLocalization.Away f Γ(X, X.basicOpen f) :=
           U.2.isLocalization_of_eq_basicOpen _ _ rfl
         intro x hx
         dsimp only at hx ⊢

--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
@@ -513,8 +513,6 @@ def radical (I : IdealSheafData X) : IdealSheafData X :=
   mkOfMemSupportIff
   (fun U ↦ (I.ideal U).radical)
   (fun U f ↦
-    letI : Algebra Γ(X, U) Γ(X, X.affineBasicOpen f) :=
-      (X.presheaf.map (homOfLE (X.basicOpen_le f)).op).hom.toAlgebra
     have : IsLocalization.Away f Γ(X, X.basicOpen f) := U.2.isLocalization_of_eq_basicOpen _ _ rfl
     (IsLocalization.map_radical (.powers f) Γ(X, X.basicOpen f) (I.ideal U)).trans
       congr($(I.map_ideal_basicOpen U f).radical))

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -260,7 +260,6 @@ noncomputable def Scheme.Modules.fromTildeΓ (M : (Spec (.of R)).Modules) :
         simp only [inducedFunctor_obj, Submonoid.powers_le, Submonoid.mem_comap]
         exact M.isUnit_algebraMap_end_of_le_basicOpen f.unop le_rfl
       naturality {f g : Rᵒᵖ} i := by
-        letI N := (modulesSpecToSheaf.obj M).presheaf.obj (.op ⊤)
         ext1
         apply IsLocalizedModule.ext (.powers (M := R) f.unop)
           (tilde.toOpen _ (PrimeSpectrum.basicOpen (R := R) f.unop)).hom

--- a/Mathlib/AlgebraicTopology/DoldKan/NReflectsIso.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/NReflectsIso.lean
@@ -43,7 +43,6 @@ instance : (N₁ : SimplicialObject C ⥤ Karoubi (ChainComplex C ℕ)).Reflects
     intro
     -- restating the result in a way that allows induction on the degree n
     suffices ∀ n : ℕ, IsIso (f.app (op ⦋n⦌)) by
-      haveI : ∀ Δ : SimplexCategoryᵒᵖ, IsIso (f.app Δ) := fun Δ => this Δ.unop.len
       apply NatIso.isIso_of_isIso_app
     -- restating the assumption in a more practical form
     have h₁ := HomologicalComplex.congr_hom (Karoubi.hom_ext_iff.mp (IsIso.hom_inv_id (N₁.map f)))

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -1192,8 +1192,6 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
         ((stdOrthonormalBasis 𝕜 LSᗮ).reindex <| finCongr dim_LS_perp).repr.symm
   let L3 := LSᗮ.subtypeₗᵢ.comp E.toLinearIsometry
   -- Project onto S and Sᗮ
-  haveI : CompleteSpace S := FiniteDimensional.complete 𝕜 S
-  haveI : CompleteSpace V := FiniteDimensional.complete 𝕜 V
   let p1 := S.orthogonalProjectionOnto.toLinearMap
   let p2 := Sᗮ.orthogonalProjectionOnto.toLinearMap
   -- Build a linear map from the isometries on S and Sᗮ

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -1191,7 +1191,6 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
       (stdOrthonormalBasis 𝕜 Sᗮ).repr.trans
         ((stdOrthonormalBasis 𝕜 LSᗮ).reindex <| finCongr dim_LS_perp).repr.symm
   let L3 := LSᗮ.subtypeₗᵢ.comp E.toLinearIsometry
-  -- Project onto S and Sᗮ
   let p1 := S.orthogonalProjectionOnto.toLinearMap
   let p2 := Sᗮ.orthogonalProjectionOnto.toLinearMap
   -- Build a linear map from the isometries on S and Sᗮ

--- a/Mathlib/Analysis/Normed/Module/Complemented.lean
+++ b/Mathlib/Analysis/Normed/Module/Complemented.lean
@@ -96,7 +96,7 @@ isomorphic to `E`. -/
 @[deprecated prodEquivOfIsTopCompl (since := "2026-06-07")]
 def prodEquivOfClosedCompl (h : IsCompl p q) (hp : IsClosed (p : Set E))
     (hq : IsClosed (q : Set E)) : (p × q) ≃L[𝕜] E := by
-  haveI := hp.completeSpace_coe;
+  haveI := hp.completeSpace_coe
   refine (p.prodEquivOfIsCompl q h).toContinuousLinearEquivOfContinuous ?_
   exact (p.subtypeL.coprod q.subtypeL).continuous
 

--- a/Mathlib/Analysis/Normed/Module/Complemented.lean
+++ b/Mathlib/Analysis/Normed/Module/Complemented.lean
@@ -81,7 +81,6 @@ variable [CompleteSpace E] {p q : Subspace 𝕜 E}
 
 theorem IsCompl.isTopCompl_of_isClosed (h : IsCompl p q) (hp : IsClosed (p : Set E))
     (hq : IsClosed (q : Set E)) : IsTopCompl p q := by
-  haveI := hp.completeSpace_coe; haveI := hq.completeSpace_coe
   rw [isTopCompl_iff_continuous_symm_prodEquivOfIsCompl h]
   exact (p.prodEquivOfIsCompl q h).continuous_symm (continuous_prodEquivOfIsCompl h)
 
@@ -97,7 +96,7 @@ isomorphic to `E`. -/
 @[deprecated prodEquivOfIsTopCompl (since := "2026-06-07")]
 def prodEquivOfClosedCompl (h : IsCompl p q) (hp : IsClosed (p : Set E))
     (hq : IsClosed (q : Set E)) : (p × q) ≃L[𝕜] E := by
-  haveI := hp.completeSpace_coe; haveI := hq.completeSpace_coe
+  haveI := hp.completeSpace_coe;
   refine (p.prodEquivOfIsCompl q h).toContinuousLinearEquivOfContinuous ?_
   exact (p.subtypeL.coprod q.subtypeL).continuous
 

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Basic.lean
@@ -388,12 +388,6 @@ instance preservesFiniteLimits_liftToFinset : PreservesFiniteLimits (liftToFinse
   preservesFiniteLimits_of_evaluation _ fun I =>
     letI : PreservesFiniteLimits (colim (J := Discrete I) (C := C)) :=
       preservesFiniteLimits_of_natIso HasBiproductsOfShape.colimIsoLim.symm
-    letI : PreservesFiniteLimits ((whiskeringLeft (Discrete I) (Discrete α) C).obj
-        (Discrete.functor fun x ↦ ↑x)) :=
-      ⟨fun J _ _ => whiskeringLeft_preservesLimitsOfShape J _⟩
-    letI : PreservesFiniteLimits ((whiskeringLeft (Discrete I) (Discrete α) C).obj
-        (Discrete.functor (·.val)) ⋙ colim) :=
-      comp_preservesFiniteLimits _ _
     preservesFiniteLimits_of_natIso (liftToFinsetEvaluationIso I).symm
 
 variable (J : Type*)
@@ -440,11 +434,6 @@ instance preservesFiniteColimits_liftToFinset : PreservesFiniteColimits (liftToF
   preservesFiniteColimits_of_evaluation _ fun ⟨I⟩ =>
     letI : PreservesFiniteColimits (lim (J := Discrete I) (C := C)) :=
       preservesFiniteColimits_of_natIso HasBiproductsOfShape.colimIsoLim
-    letI : PreservesFiniteColimits ((whiskeringLeft (Discrete I) (Discrete α) C).obj
-        (Discrete.functor fun x ↦ ↑x)) := ⟨fun _ _ _ => inferInstance⟩
-    letI : PreservesFiniteColimits ((whiskeringLeft (Discrete I) (Discrete α) C).obj
-        (Discrete.functor (·.val)) ⋙ lim) :=
-      comp_preservesFiniteColimits _ _
     preservesFiniteColimits_of_natIso (liftToFinsetEvaluationIso _ _ I).symm
 
 variable (J : Type*)

--- a/Mathlib/CategoryTheory/Abelian/NonPreadditive.lean
+++ b/Mathlib/CategoryTheory/Abelian/NonPreadditive.lean
@@ -232,7 +232,6 @@ instance mono_r {A : C} : Mono (r A) := by
   have hyy : y = 0 := by
     erw [← Category.comp_id y, ← Limits.prod.lift_snd (𝟙 A) (𝟙 A), ← Category.assoc, hy,
       Category.assoc, prod.lift_snd, HasZeroMorphisms.comp_zero]
-  haveI : Mono (prod.lift (𝟙 A) (0 : A ⟶ A)) := mono_of_mono_fac (prod.lift_fst _ _)
   apply (cancel_mono (prod.lift (𝟙 A) (0 : A ⟶ A))).1
   rw [← hy, hyy, zero_comp, zero_comp]
 
@@ -245,7 +244,6 @@ instance epi_r {A : C} : Epi (r A) := by
     · intro s
       apply Limits.prod.hom_ext <;> simp
     · intro s m h
-      haveI : Mono (prod.lift (𝟙 A) (0 : A ⟶ A)) := mono_of_mono_fac (prod.lift_fst _ _)
       apply (cancel_mono (prod.lift (𝟙 A) (0 : A ⟶ A))).1
       convert! h
       apply Limits.prod.hom_ext <;> simp

--- a/Mathlib/CategoryTheory/CatCommSq.lean
+++ b/Mathlib/CategoryTheory/CatCommSq.lean
@@ -78,8 +78,6 @@ def hComp (T₁ : C₁ ⥤ C₂) (T₂ : C₂ ⥤ C₃) (V₁ : C₁ ⥤ C₄) (
 abbrev hComp' {T₁ : C₁ ⥤ C₂} {T₂ : C₂ ⥤ C₃} {V₁ : C₁ ⥤ C₄} {V₂ : C₂ ⥤ C₅} {V₃ : C₃ ⥤ C₆}
     {B₁ : C₄ ⥤ C₅} {B₂ : C₅ ⥤ C₆} (S₁ : CatCommSq T₁ V₁ V₂ B₁) (S₂ : CatCommSq T₂ V₂ V₃ B₂) :
     CatCommSq (T₁ ⋙ T₂) V₁ V₃ (B₁ ⋙ B₂) :=
-  letI := S₁
-  letI := S₂
   hComp _ _ _ V₂ _ _ _
 
 /-- Vertical composition of 2-commutative squares -/
@@ -95,8 +93,6 @@ def vComp (L₁ : C₁ ⥤ C₂) (L₂ : C₂ ⥤ C₃) (H₁ : C₁ ⥤ C₄) (
 abbrev vComp' {L₁ : C₁ ⥤ C₂} {L₂ : C₂ ⥤ C₃} {H₁ : C₁ ⥤ C₄} {H₂ : C₂ ⥤ C₅} {H₃ : C₃ ⥤ C₆}
     {R₁ : C₄ ⥤ C₅} {R₂ : C₅ ⥤ C₆} (S₁ : CatCommSq H₁ L₁ R₁ H₂) (S₂ : CatCommSq H₂ L₂ R₂ H₃) :
     CatCommSq H₁ (L₁ ⋙ L₂) (R₁ ⋙ R₂) H₃ :=
-  letI := S₁
-  letI := S₂
   vComp _ _ _ H₂ _ _ _
 
 section

--- a/Mathlib/CategoryTheory/Category/Cat/Limit.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/Limit.lean
@@ -55,11 +55,9 @@ def homDiagram {F : J ⥤ Cat.{v, v}} (X Y : limit (F ⋙ Cat.objects.{v, v})) :
     · exact congr_hom (limit.w (F ⋙ Cat.objects) f) Y
   map_id X := by
     ext f
-    letI : Category (objects.obj (F.obj X)) := (inferInstance : Category (F.obj X))
     simp [Functor.congr_hom congr($(F.map_id X).toFunctor) f]
   map_comp {_ _ Z} f g := by
     ext h
-    letI : Category (objects.obj (F.obj Z)) := (inferInstance : Category (F.obj Z))
     simp [Functor.congr_hom congr($(F.map_comp f g).toFunctor) h, eqToHom_map]
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -332,8 +332,6 @@ noncomputable instance lan_preservesFiniteLimits_of_flat (F : C ⥤ D) [Represen
   intro J _ _
   apply preservesLimitsOfShape_of_evaluation (F.op.lan : (Cᵒᵖ ⥤ E) ⥤ Dᵒᵖ ⥤ E) J
   intro K
-  haveI : IsFiltered (CostructuredArrow F.op K) :=
-    IsFiltered.of_equivalence (structuredArrowOpEquivalence F (unop K))
   exact preservesLimitsOfShape_of_natIso (lanEvaluationIsoColim _ _ _).symm
 
 instance lan_flat_of_flat (F : C ⥤ D) [RepresentablyFlat F] :

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -130,8 +130,6 @@ lemma PreservesPointwiseLeftKanExtensionAt.mk' (c : C) {E : LeftExtension L F}
 instance hasLeftKanExtension_of_preserves [L.HasLeftKanExtension F]
     [PreservesLeftKanExtension G F L] : L.HasLeftKanExtension (F ⋙ G) :=
   @HasLeftKanExtension.mk _ _ _ _ _ _ _ _ _ _ <|
-    letI : (L.leftKanExtension F).IsLeftKanExtension <| L.leftKanExtensionUnit F := by
-      infer_instance
     PreservesLeftKanExtension.preserves (L.leftKanExtension F) (L.leftKanExtensionUnit F)
 
 instance hasPointwiseLeftKanExtension_of_preserves [L.HasPointwiseLeftKanExtension F]
@@ -390,8 +388,6 @@ lemma PreservesPointwiseRightKanExtensionAt.mk' (c : C) {E : RightExtension L F}
 instance hasRightKanExtension_of_preserves [L.HasRightKanExtension F]
     [PreservesRightKanExtension G F L] : L.HasRightKanExtension (F ⋙ G) :=
   @HasRightKanExtension.mk _ _ _ _ _ _ _ _ _ _ <|
-    letI : (L.rightKanExtension F).IsRightKanExtension <| L.rightKanExtensionCounit F := by
-      infer_instance
     PreservesRightKanExtension.preserves (L.rightKanExtension F) (L.rightKanExtensionCounit F)
 
 instance hasPointwiseRightKanExtension_of_preserves [L.HasPointwiseRightKanExtension F]

--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -156,8 +156,6 @@ instance {G : Type*} [Group G] [Finite G] :
 /-- Fiber functors reflect monomorphisms. -/
 instance : ReflectsMonomorphisms F := ReflectsMonomorphisms.mk <| by
   intro X Y f _
-  haveI : IsIso (pullback.fst (F.map f) (F.map f)) :=
-    isIso_fst_of_mono (F.map f)
   haveI : IsIso (F.map (pullback.fst f f)) := by
     rw [← PreservesPullback.iso_hom_fst]
     exact IsIso.comp_isIso

--- a/Mathlib/CategoryTheory/Galois/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Galois/Equivalence.lean
@@ -54,7 +54,6 @@ instance {F : C ⥤ FintypeCat.{u₁}} [FiberFunctor F] : (functorToContAction F
 
 instance : (functorToContAction F).EssSurj := by
   let F' : C ⥤ FintypeCat.{u₁} := F ⋙ FintypeCat.uSwitch.{w, u₁}
-  letI : FiberFunctor F' := FiberFunctor.comp_right _
   have : (functorToContAction F').EssSurj := inferInstance
   let f : Aut F ≃ₜ* Aut F' :=
     (autEquivAutWhiskerRight F (FintypeCat.uSwitchEquivalence.{w, u₁}).fullyFaithfulFunctor)

--- a/Mathlib/CategoryTheory/Galois/Examples.lean
+++ b/Mathlib/CategoryTheory/Galois/Examples.lean
@@ -32,7 +32,6 @@ namespace FintypeCat
 /-- Complement of the image of a morphism `f : X ⟶ Y` in `FintypeCat`. -/
 noncomputable def imageComplement {X Y : FintypeCat.{u}} (f : X ⟶ Y) :
     FintypeCat.{u} := by
-  haveI : Fintype (↑(Set.range f)ᶜ) := Fintype.ofFinite _
   exact FintypeCat.of (↑(Set.range f)ᶜ)
 
 /-- The inclusion from the complement of the image of `f : X ⟶ Y` into `Y`. -/
@@ -85,7 +84,6 @@ noncomputable instance : PreservesFiniteLimits (forget (Action FintypeCat G)) :=
 instance : PreGaloisCategory (Action FintypeCat G) where
   hasQuotientsByFiniteGroups _ _ _ := inferInstance
   monoInducesIsoOnDirectSummand {_ _} i _ :=
-    haveI : Mono ((forget (Action FintypeCat G)).map i) := map_mono (forget _) i
     ⟨Action.imageComplement G i, Action.imageComplementIncl G i,
      ⟨isColimitOfReflects (Action.forget _ _ ⋙ FintypeCat.incl) <|
       (isColimitMapCoconeBinaryCofanEquiv (forget _) i _).symm

--- a/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
+++ b/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
@@ -452,7 +452,6 @@ instance FiberFunctor.isPretransitive_of_isConnected (X : C) [IsConnected X] :
     MulAction.IsPretransitive (Aut F) (F.obj X) where
   exists_smul_eq x y := by
     let F' : C ⥤ FintypeCat.{u₂} := F ⋙ FintypeCat.uSwitch.{w, u₂}
-    letI : FiberFunctor F' := FiberFunctor.comp_right _
     let e (Y : C) : F'.obj Y ≃ F.obj Y := (F.obj Y).uSwitchEquiv
     set x' : F'.obj X := (e X).symm x with hx'
     set y' : F'.obj X := (e X).symm y with hy'

--- a/Mathlib/CategoryTheory/Generator/Basic.lean
+++ b/Mathlib/CategoryTheory/Generator/Basic.lean
@@ -663,7 +663,7 @@ theorem isSeparator_iff_epi (G : C) [∀ A : C, HasCoproduct fun _ : G ⟶ A => 
   rw [isSeparator_def]
   refine ⟨fun h A => ⟨fun u v huv => h _ _ fun i => ?_⟩, fun h X Y f g hh => ?_⟩
   · simpa using Sigma.ι _ i ≫= huv
-  · haveI := h X
+  ·
     refine (cancel_epi (Sigma.desc fun f : G ⟶ X => f)).1 (colimit.hom_ext fun j => ?_)
     simpa using hh j.as
 
@@ -673,7 +673,7 @@ theorem isCoseparator_iff_mono (G : C) [∀ A : C, HasProduct fun _ : A ⟶ G =>
   rw [isCoseparator_def]
   refine ⟨fun h A => ⟨fun u v huv => h _ _ fun i => ?_⟩, fun h X Y f g hh => ?_⟩
   · simpa using huv =≫ Pi.π _ i
-  · haveI := h Y
+  ·
     refine (cancel_mono (Pi.lift fun f : Y ⟶ G => f)).1 (limit.hom_ext fun j => ?_)
     simpa using hh j.as
 

--- a/Mathlib/CategoryTheory/Generator/Basic.lean
+++ b/Mathlib/CategoryTheory/Generator/Basic.lean
@@ -672,8 +672,7 @@ theorem isCoseparator_iff_mono (G : C) [∀ A : C, HasProduct fun _ : A ⟶ G =>
   rw [isCoseparator_def]
   refine ⟨fun h A => ⟨fun u v huv => h _ _ fun i => ?_⟩, fun h X Y f g hh => ?_⟩
   · simpa using huv =≫ Pi.π _ i
-  ·
-    refine (cancel_mono (Pi.lift fun f : Y ⟶ G => f)).1 (limit.hom_ext fun j => ?_)
+  · refine (cancel_mono (Pi.lift fun f : Y ⟶ G => f)).1 (limit.hom_ext fun j => ?_)
     simpa using hh j.as
 
 section ZeroMorphisms

--- a/Mathlib/CategoryTheory/Generator/Basic.lean
+++ b/Mathlib/CategoryTheory/Generator/Basic.lean
@@ -663,8 +663,7 @@ theorem isSeparator_iff_epi (G : C) [∀ A : C, HasCoproduct fun _ : G ⟶ A => 
   rw [isSeparator_def]
   refine ⟨fun h A => ⟨fun u v huv => h _ _ fun i => ?_⟩, fun h X Y f g hh => ?_⟩
   · simpa using Sigma.ι _ i ≫= huv
-  ·
-    refine (cancel_epi (Sigma.desc fun f : G ⟶ X => f)).1 (colimit.hom_ext fun j => ?_)
+  · refine (cancel_epi (Sigma.desc fun f : G ⟶ X => f)).1 (colimit.hom_ext fun j => ?_)
     simpa using hh j.as
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/CategoryTheory/Limits/Lattice.lean
+++ b/Mathlib/CategoryTheory/Limits/Lattice.lean
@@ -99,7 +99,6 @@ theorem finite_coproduct_eq_finset_sup [SemilatticeSup α] [OrderBot α] {ι : T
 -- see Note [lower instance priority]
 instance (priority := 100) [SemilatticeInf α] [OrderTop α] : HasBinaryProducts α := by
   have : ∀ x y : α, HasLimit (pair x y) := by
-    letI := hasFiniteLimits_of_hasFiniteLimits_of_size.{u} α
     infer_instance
   apply hasBinaryProducts_of_hasLimit_pair
 
@@ -118,7 +117,6 @@ theorem prod_eq_inf [SemilatticeInf α] [OrderTop α] (x y : α) : Limits.prod x
 -- see Note [lower instance priority]
 instance (priority := 100) [SemilatticeSup α] [OrderBot α] : HasBinaryCoproducts α := by
   have : ∀ x y : α, HasColimit (pair x y) := by
-    letI := hasFiniteColimits_of_hasFiniteColimits_of_size.{u} α
     infer_instance
   apply hasBinaryCoproducts_of_hasColimit_pair
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Equalizers.lean
@@ -189,8 +189,6 @@ instance : IsIso (coequalizerComparison f g G) := by
 instance map_π_epi : Epi (G.map (coequalizer.π f g)) :=
   ⟨fun {W} h k => by
     rw [← ι_comp_coequalizerComparison]
-    haveI : Epi (coequalizer.π (G.map f) (G.map g) ≫ coequalizerComparison f g G) := by
-      apply epi_comp
     apply (cancel_epi _).1⟩
 
 @[reassoc]

--- a/Mathlib/CategoryTheory/Localization/SmallHom.lean
+++ b/Mathlib/CategoryTheory/Localization/SmallHom.lean
@@ -110,7 +110,6 @@ that `HasSmallLocalizedHom.{w} W X Y` holds. -/
 noncomputable def equiv (L : C ⥤ D) [L.IsLocalization W] {X Y : C}
     [HasSmallLocalizedHom.{w} W X Y] :
     SmallHom.{w} W X Y ≃ (L.obj X ⟶ L.obj Y) :=
-  letI := small_of_hasSmallLocalizedHom.{w} W W.Q X Y
   (equivShrink _).symm.trans (homEquiv W W.Q L)
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/CategoryTheory/Monoidal/Closed/Ideal.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Closed/Ideal.lean
@@ -263,8 +263,6 @@ noncomputable def bijection (A B : C) (X : D) :
     _ ≃ (i.obj ((reflector i).obj A) ⊗ i.obj ((reflector i).obj B) ⟶ i.obj X) :=
       ((ihom.adjunction _).homEquiv _ _).symm
     _ ≃ (i.obj ((reflector i).obj A ⊗ (reflector i).obj B) ⟶ i.obj X) :=
-      haveI : Limits.PreservesLimits i := (reflectorAdjunction i).rightAdjoint_preservesLimits
-      haveI := Limits.preservesSmallestLimits_of_preservesLimits i
       Iso.homCongr (prodComparisonIso _ _ _).symm (Iso.refl (i.obj X))
     _ ≃ ((reflector i).obj A ⊗ (reflector i).obj B ⟶ X) :=
       i.fullyFaithfulOfReflective.homEquiv.symm

--- a/Mathlib/CategoryTheory/Monoidal/Closed/Zero.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Closed/Zero.lean
@@ -53,7 +53,6 @@ open scoped ZeroObject
 /-- If a Cartesian closed category has a zero object, each homset has exactly one element. -/
 @[instance_reducible]
 def uniqueHomsetOfZero [HasZeroObject C] (X Y : C) : Unique (X ⟶ Y) := by
-  haveI : HasInitial C := HasZeroObject.hasInitial
   apply uniqueHomsetOfInitialIsoUnit _ X Y
   refine ⟨default, (default : 𝟙_ C ⟶ 0) ≫ default, ?_, ?_⟩ <;> simp [eq_iff_true_of_subsingleton]
 

--- a/Mathlib/CategoryTheory/Monoidal/Mon.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon.lean
@@ -1175,7 +1175,6 @@ set_option backward.isDefEq.respectTransparency false in
 /-- Implementation of `AddMon.equivLaxMonoidalFunctorPUnit`. -/]
 def counitIso : monToLaxMonoidal.{w} C ⋙ laxMonoidalToMon C ≅ 𝟭 (Mon C) :=
   NatIso.ofComponents fun F ↦
-    letI : IsMonHom (counitIsoAux.{w} C F).hom := isMonHom_counitIsoAux C F
     mkIso (counitIsoAux.{w} C F)
 
 end EquivLaxMonoidalFunctorPUnit

--- a/Mathlib/CategoryTheory/MorphismProperty/OverAdjunction.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/OverAdjunction.lean
@@ -118,7 +118,6 @@ noncomputable def Over.pullbackComp (f : X ⟶ Y) (g : Y ⟶ Z)
     Over.pullback P Q fg ≅ Over.pullback P Q g ⋙ Over.pullback P Q f :=
   haveI : P.HasPullbacksAlong fg := by subst hfg; infer_instance
   NatIso.ofComponents fun X ↦
-    haveI : HasPullback X.hom fg := HasPullbacksAlong.hasPullback _ X.prop
     Over.isoMk (pullback.congrHom rfl hfg ≪≫ (pullbackLeftPullbackSndIso X.hom g f).symm) (by simp)
 
 set_option backward.defeqAttrib.useBackward true in
@@ -139,7 +138,6 @@ noncomputable def Over.pullbackCongr {f : X ⟶ Y} [P.HasPullbacksAlong f]
     Over.pullback P Q f ≅ Over.pullback P Q g :=
   haveI : P.HasPullbacksAlong g := by subst h; infer_instance
   NatIso.ofComponents fun X ↦
-    haveI : HasPullback X.hom g := HasPullbacksAlong.hasPullback _ X.prop
     Over.isoMk (pullback.congrHom rfl h)
 
 set_option backward.defeqAttrib.useBackward true in
@@ -298,7 +296,6 @@ noncomputable def Under.pushoutComp (f : X ⟶ Y) (g : Y ⟶ Z)
     Under.pushout P Q fg ≅ Under.pushout P Q f ⋙ Under.pushout P Q g :=
   haveI : P.HasPushoutsAlong fg := by subst hfg; infer_instance
   NatIso.ofComponents fun X ↦
-    haveI : HasPushout X.hom fg := HasPushoutsAlong.hasPushout _ X.prop
     Under.isoMk (pushout.congrHom rfl hfg ≪≫ (pushoutLeftPushoutInrIso X.hom f g).symm) (by simp)
 
 set_option backward.defeqAttrib.useBackward true in
@@ -311,7 +308,6 @@ noncomputable def Under.pushoutCongr {f : X ⟶ Y} [P.HasPushoutsAlong f]
     Under.pushout P Q f ≅ Under.pushout P Q g :=
   haveI : P.HasPushoutsAlong g := by subst h; infer_instance
   NatIso.ofComponents fun X ↦
-    haveI : HasPushout X.hom g := HasPushoutsAlong.hasPushout _ X.prop
     Under.isoMk (pushout.congrHom rfl h)
 
 set_option backward.defeqAttrib.useBackward true in

--- a/Mathlib/CategoryTheory/MorphismProperty/Representable.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Representable.lean
@@ -282,7 +282,7 @@ lemma of_isIso {X Y : D} (f : X ⟶ Y) [IsIso f] : F.relativelyRepresentable f :
   fun a g ↦ ⟨a, 𝟙 a, g ≫ CategoryTheory.inv f, IsPullback.of_vert_isIso ⟨by simp⟩⟩
 
 lemma isomorphisms_le : MorphismProperty.isomorphisms D ≤ F.relativelyRepresentable :=
-  fun _ _ f hf ↦ of_isIso F f
+  fun _ _ f hf ↦ letI : IsIso f := hf; of_isIso F f
 
 instance isMultiplicative : IsMultiplicative F.relativelyRepresentable where
   id_mem _ := of_isIso F _

--- a/Mathlib/CategoryTheory/MorphismProperty/Representable.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Representable.lean
@@ -282,7 +282,7 @@ lemma of_isIso {X Y : D} (f : X ⟶ Y) [IsIso f] : F.relativelyRepresentable f :
   fun a g ↦ ⟨a, 𝟙 a, g ≫ CategoryTheory.inv f, IsPullback.of_vert_isIso ⟨by simp⟩⟩
 
 lemma isomorphisms_le : MorphismProperty.isomorphisms D ≤ F.relativelyRepresentable :=
-  fun _ _ f hf ↦ letI : IsIso f := hf; of_isIso F f
+  fun _ _ f hf ↦ of_isIso F f
 
 instance isMultiplicative : IsMultiplicative F.relativelyRepresentable where
   id_mem _ := of_isIso F _

--- a/Mathlib/CategoryTheory/Sites/Subsheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Subsheaf.lean
@@ -292,7 +292,6 @@ noncomputable def imageFactorization {F F' : Sheaf J (Type (max v u))} (f : F �
   F := imageMonoFactorization f
   isImage :=
     { lift := fun I => by
-        haveI M := (Sheaf.Hom.mono_iff_presheaf_mono J (Type (max v u)) _).mp I.m_mono
         refine ⟨Subfunctor.homOfLe ?_ ≫ inv (Subfunctor.toRange I.m.1)⟩
         apply Subfunctor.sheafify_le
         · conv_lhs => rw [← I.fac]

--- a/Mathlib/CategoryTheory/Subobject/MonoOver.lean
+++ b/Mathlib/CategoryTheory/Subobject/MonoOver.lean
@@ -288,7 +288,6 @@ variable [HasPullbacks C]
 by pulling back a monomorphism along `f`. -/
 def pullback (f : X ⟶ Y) : MonoOver Y ⥤ MonoOver X :=
   MonoOver.lift (Over.pullback f) (fun g => by
-    haveI : Mono ((forget Y).obj g).hom := (inferInstance : Mono g.arrow)
     apply pullback.snd_of_mono)
 
 /-- pullback commutes with composition (up to a natural isomorphism) -/

--- a/Mathlib/Data/Analysis/Topology.lean
+++ b/Mathlib/Data/Analysis/Topology.lean
@@ -135,7 +135,7 @@ theorem isClosed_iff [TopologicalSpace α] (F : Realizer α) {s : Set α} :
     F.isOpen_iff.trans <|
       forall_congr' fun a ↦
         show (a ∉ s → ∃ b : F.σ, a ∈ F.F b ∧ ∀ z ∈ F.F b, z ∉ s) ↔ _ by
-          haveI := Classical.propDecidable; rw [not_imp_comm]
+          rw [not_imp_comm]
           simp [not_exists, not_and, not_forall, and_comm]
 
 theorem mem_interior_iff [TopologicalSpace α] (F : Realizer α) {s : Set α} {a : α} :

--- a/Mathlib/Data/Finite/Vector.lean
+++ b/Mathlib/Data/Finite/Vector.lean
@@ -16,10 +16,8 @@ public section
 variable {α : Type*}
 
 instance List.Vector.finite [Finite α] {n : ℕ} : Finite (Vector α n) := by
-  haveI := Fintype.ofFinite α
   infer_instance
 
 instance [Finite α] {n : ℕ} : Finite (Sym α n) := by
   classical
-  haveI := Fintype.ofFinite α
   infer_instance

--- a/Mathlib/Data/Sym/NatCard.lean
+++ b/Mathlib/Data/Sym/NatCard.lean
@@ -76,7 +76,7 @@ lemma ncard_diagSet_compl : (diagSetᶜ : Set (Sym2 α)).ncard = (Nat.card α).c
 /-- Type **stars and bars** for the case `n = 2`. -/
 protected theorem natCard : Nat.card (Sym2 α) = Nat.choose (Nat.card α + 1) 2 := by
   cases finite_or_infinite α
-  · obtain ⟨_⟩ := nonempty_fintype α; letI := Classical.decEq α
+  · obtain ⟨_⟩ := nonempty_fintype α;
     simp_rw [Nat.card_eq_fintype_card]
     exact Sym2.card
   · simp

--- a/Mathlib/Data/Sym/NatCard.lean
+++ b/Mathlib/Data/Sym/NatCard.lean
@@ -76,7 +76,7 @@ lemma ncard_diagSet_compl : (diagSetᶜ : Set (Sym2 α)).ncard = (Nat.card α).c
 /-- Type **stars and bars** for the case `n = 2`. -/
 protected theorem natCard : Nat.card (Sym2 α) = Nat.choose (Nat.card α + 1) 2 := by
   cases finite_or_infinite α
-  · obtain ⟨_⟩ := nonempty_fintype α;
+  · obtain ⟨_⟩ := nonempty_fintype α
     simp_rw [Nat.card_eq_fintype_card]
     exact Sym2.card
   · simp

--- a/Mathlib/FieldTheory/Finite/GaloisField.lean
+++ b/Mathlib/FieldTheory/Finite/GaloisField.lean
@@ -198,7 +198,6 @@ instance (priority := 100) {K K' : Type*} [Field K] [Field K'] [Finite K'] [Alge
     IsGalois K K' := by
   cases nonempty_fintype K'
   obtain ⟨p, hp⟩ := CharP.exists K
-  haveI : CharP K p := hp
   haveI : CharP K' p := charP_of_injective_algebraMap' K p
   exact IsGalois.of_separable_splitting_field
     (galois_poly_separable p (Fintype.card K')

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -490,7 +490,6 @@ variable (N : Subgroup G) [N.Normal] [IsGaloisGroup N F L]
 Galois group for `L/F`, then the quotient group `G ⧸ N` is a Galois group for `F/K`. -/
 instance [Finite G] [IsGaloisGroup G K L] : IsGaloisGroup (G ⧸ N) K F :=
   letI := smulOfNormal G F L N
-  haveI := smulDistribClass_smulOfNormal G F L N
   letI := mulSemiringActionOfSmulDistribClass F L G
   quotient G K F L N
 

--- a/Mathlib/FieldTheory/Galois/Profinite.lean
+++ b/Mathlib/FieldTheory/Galois/Profinite.lean
@@ -65,7 +65,6 @@ section Profinite
 `L : FiniteGaloisIntermediateField k K` `L`. -/
 def FiniteGaloisIntermediateField.finGaloisGroup (L : FiniteGaloisIntermediateField k K) :
     FiniteGrp :=
-  letI := AlgEquiv.fintype k L
   FiniteGrp.of Gal(L/k)
 
 /-- For `FiniteGaloisIntermediateField` s `L₁` and `L₂` with `L₂ ≤ L₁`

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -286,7 +286,6 @@ def Subalgebra.toIntermediateField' (S : Subalgebra K L) (hS : IsField S) : Inte
     by_cases hx0 : x = 0
     · rw [hx0, inv_zero]
       exact S.zero_mem
-    letI hS' := hS.toField
     obtain ⟨y, hy⟩ := hS.mul_inv_cancel (show (⟨x, hx⟩ : S) ≠ 0 from Subtype.coe_ne_coe.1 hx0)
     rw [Subtype.ext_iff, S.coe_mul, S.coe_one, Subtype.coe_mk, mul_eq_one_iff_inv_eq₀ hx0] at hy
     exact hy.symm ▸ y.2

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -346,7 +346,6 @@ private instance FractionRing.isAlgebraic :
     letI : IsDomain R := (FaithfulSMul.algebraMap_injective R S).isDomain _
     letI : Algebra (FractionRing R) (FractionRing S) := FractionRing.liftAlgebra R _
     Algebra.IsAlgebraic (FractionRing R) (FractionRing S) := by
-  letI : IsDomain R := (FaithfulSMul.algebraMap_injective R S).isDomain _
   letI : Algebra (FractionRing R) (FractionRing S) := FractionRing.liftAlgebra R _
   have := FractionRing.isScalarTower_liftAlgebra R (FractionRing S)
   have := (IsFractionRing.isAlgebraic_iff' R S (FractionRing S)).1 inferInstance

--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -253,7 +253,6 @@ def autAdjoinRootXPowSubCEquiv [NeZero n] :
     intro η
     have := Fact.mk H
     have : IsDomain K[n√a] := inferInstance
-    letI : Algebra K K[n√a] := inferInstance
     apply (rootsOfUnityEquivOfPrimitiveRoots (algebraMap K K[n√a]).injective hζ).injective
     ext
     simp only [AdjoinRoot.algebraMap_eq, OneHom.toFun_eq_coe, MonoidHom.toOneHom_coe,
@@ -268,7 +267,6 @@ def autAdjoinRootXPowSubCEquiv [NeZero n] :
   right_inv := by
     intro e
     have := Fact.mk H
-    letI : Algebra K K[n√a] := inferInstance
     apply AlgEquiv.coe_toAlgHom_injective
     apply AdjoinRoot.algHom_ext
     simp only [AdjoinRootXPowSubCEquivToRootsOfUnity, AdjoinRoot.algebraMap_eq, OneHom.toFun_eq_coe,

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -656,7 +656,6 @@ protected def openPartialHomeomorph (e : PartialEquiv M H) (he : e ∈ c.atlas) 
     open_source := by convert! c.open_source' he
     open_target := by convert! c.open_target he
     continuousOn_toFun := by
-      letI : TopologicalSpace M := c.toTopologicalSpace
       rw [continuousOn_open_iff (c.open_source' he)]
       intro s s_open
       rw [inter_comm]
@@ -664,7 +663,6 @@ protected def openPartialHomeomorph (e : PartialEquiv M H) (he : e ∈ c.atlas) 
       simp only [exists_prop, mem_iUnion, mem_singleton_iff]
       exact ⟨e, he, ⟨s, s_open, rfl⟩⟩
     continuousOn_invFun := by
-      letI : TopologicalSpace M := c.toTopologicalSpace
       apply continuousOn_isOpen_of_generateFrom
       intro t ht
       simp only [exists_prop, mem_iUnion, mem_singleton_iff] at ht

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace.lean
@@ -298,10 +298,6 @@ instance ofRestrict_mono {U : TopCat} (X : PresheafedSpace C) (f : U ⟶ X.1)
     have hV : (Opens.map (X.ofRestrict hf).base).obj (hf.functor.obj V) = V := by
       ext1
       exact Set.preimage_image_eq _ hf.injective
-    haveI :
-      IsIso (hf.isOpenMap.adjunction.counit.app (unop (op (hf.functor.obj V)))) :=
-        NatIso.isIso_app_of_isIso
-          (whiskerLeft hf.functor hf.isOpenMap.adjunction.counit) V
     have := PresheafedSpace.congr_app eq (op (hf.functor.obj V))
     rw [PresheafedSpace.comp_c_app, PresheafedSpace.comp_c_app,
       PresheafedSpace.ofRestrict_c_app, Category.assoc, cancel_epi] at this

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -163,7 +163,6 @@ def const (p : P2) : P1 →ᵃ[k] P2 where
   toFun := Function.const P1 p
   linear := 0
   map_vadd' _ _ :=
-    letI : AddAction V2 P2 := inferInstance
     by simp
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Basis/Submodule.lean
+++ b/Mathlib/LinearAlgebra/Basis/Submodule.lean
@@ -83,7 +83,6 @@ def Submodule.inductionOnRankAux (b : Basis ι R M) (P : Submodule R M → Sort*
     (n : ℕ) (N : Submodule R M)
     (rank_le : ∀ {m : ℕ} (v : Fin m → N), LinearIndependent R ((↑) ∘ v : Fin m → M) → m ≤ n) :
     P N := by
-  haveI : DecidableEq M := Classical.decEq M
   have Pbot : P ⊥ := by
     apply ih
     intro N _ x x_mem x_ortho

--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -332,12 +332,10 @@ variable {R}
 -- TODO: merge with the `Finrank` content
 /-- An `n`-dimensional `R`-vector space is equivalent to `Fin n → R`. -/
 def finDimVectorspaceEquiv (n : ℕ) (hn : Module.rank R M = n) : M ≃ₗ[R] Fin n → R := by
-  haveI := nontrivial_of_invariantBasisNumber R
   have : Cardinal.lift.{u} (n : Cardinal.{v}) = Cardinal.lift.{v} (n : Cardinal.{u}) := by simp
   have hn := Cardinal.lift_inj.{v, u}.2 hn
   rw [this] at hn
   rw [← @rank_fin_fun R _ _ n] at hn
-  haveI : Module.Free R (Fin n → R) := Module.Free.pi _ _
   exact Classical.choice (nonempty_linearEquiv_of_lift_rank_eq hn)
 
 end Pi

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -317,7 +317,7 @@ theorem maximal_linearIndependent_eq_infinite_basis {ι : Type w} (b : Basis ι 
     {κ : Type w} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) : #κ = #ι := by
   apply le_antisymm
   · exact linearIndependent_le_basis b v i
-  · haveI : Nontrivial R := nontrivial_of_invariantBasisNumber R
+  ·
     exact infinite_basis_le_maximal_linearIndependent b v i m
 
 theorem Module.Basis.mk_eq_rank'' {ι : Type v} (v : Basis ι R M) : #ι = Module.rank R M := by

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -317,8 +317,7 @@ theorem maximal_linearIndependent_eq_infinite_basis {ι : Type w} (b : Basis ι 
     {κ : Type w} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) : #κ = #ι := by
   apply le_antisymm
   · exact linearIndependent_le_basis b v i
-  ·
-    exact infinite_basis_le_maximal_linearIndependent b v i m
+  · exact infinite_basis_le_maximal_linearIndependent b v i m
 
 theorem Module.Basis.mk_eq_rank'' {ι : Type v} (v : Basis ι R M) : #ι = Module.rank R M := by
   haveI := nontrivial_of_invariantBasisNumber R

--- a/Mathlib/LinearAlgebra/Finsupp/Supported.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Supported.lean
@@ -267,8 +267,6 @@ end LMapDomain
 /-- An equivalence of sets induces a linear equivalence of `Finsupp`s supported on those sets. -/
 noncomputable def congr {α' : Type*} (s : Set α) (t : Set α') (e : s ≃ t) :
     supported M R s ≃ₗ[R] supported M R t := by
-  haveI := Classical.decPred fun x => x ∈ s
-  haveI := Classical.decPred fun x => x ∈ t
   exact Finsupp.supportedEquivFinsupp s ≪≫ₗ
     (Finsupp.domLCongr e ≪≫ₗ (Finsupp.supportedEquivFinsupp t).symm)
 

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
@@ -103,7 +103,6 @@ instance Module.Finite.addMonoidHom [Module.Finite ℤ N] : Module.Finite ℤ (M
   Module.Finite.equiv (addMonoidHomLequivInt ℤ).symm
 
 instance Module.Free.addMonoidHom [Module.Free ℤ N] : Module.Free ℤ (M →+ N) :=
-  letI : Module.Free ℤ (M →ₗ[ℤ] N) := Module.Free.linearMap _ _ _ _
   Module.Free.of_equiv (addMonoidHomLequivInt ℤ).symm
 
 end Integer

--- a/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
@@ -191,7 +191,6 @@ theorem IsPrimitive.isIrreducible
 /-- Reverse a path in `toQuiver A` to a path in `toQuiver Aᵀ`, swapping endpoints. -/
 def transposePath {i j : n} (p : @Quiver.Path n A.toQuiver i j) :
     @Quiver.Path n Aᵀ.toQuiver j i := by
-  letI : Quiver n := toQuiver A
   induction p with
   | nil =>
     exact (@Quiver.Path.nil _ (toQuiver Aᵀ) _)

--- a/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
@@ -1119,8 +1119,6 @@ variable [MeasurableSpace α] [MeasurableSpace β] [StandardBorelSpace α] [Stan
 then they are Borel isomorphic. -/
 noncomputable def borelSchroederBernstein {f : α → β} {g : β → α} (fmeas : Measurable f)
     (finj : Function.Injective f) (gmeas : Measurable g) (ginj : Function.Injective g) : α ≃ᵐ β :=
-  letI := upgradeStandardBorel α
-  letI := upgradeStandardBorel β
   (fmeas.measurableEmbedding finj).schroederBernstein (gmeas.measurableEmbedding ginj)
 
 /-- Any uncountable standard Borel space is Borel isomorphic to the Cantor space `ℕ → Bool`. -/

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -318,7 +318,7 @@ def extend [MeasurableSpace β] (f₁ : α →ₛ γ) (g : α → β) (hg : Meas
     (f₁.finite_range.union <| f₂.finite_range.subset (image_subset_range _ _)).subset
       (range_extend_subset _ _ _)
   measurableSet_fiber' := by
-    letI : MeasurableSpace γ := ⊤;
+    letI : MeasurableSpace γ := ⊤
     exact fun x => hg.measurable_extend f₁.measurable f₂.measurable (measurableSet_singleton _)
 
 @[simp]

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -318,7 +318,7 @@ def extend [MeasurableSpace β] (f₁ : α →ₛ γ) (g : α → β) (hg : Meas
     (f₁.finite_range.union <| f₂.finite_range.subset (image_subset_range _ _)).subset
       (range_extend_subset _ _ _)
   measurableSet_fiber' := by
-    letI : MeasurableSpace γ := ⊤; haveI : MeasurableSingletonClass γ := ⟨fun _ => trivial⟩
+    letI : MeasurableSpace γ := ⊤;
     exact fun x => hg.measurable_extend f₁.measurable f₂.measurable (measurableSet_singleton _)
 
 @[simp]

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -268,8 +268,7 @@ theorem finStronglyMeasurable_of_set_sigmaFinite [TopologicalSpace β] [Zero β]
     refine fun n => measure_biUnion_lt_top {y ∈ (fs n).range | y ≠ 0}.finite_toSet fun y hy => ?_
     rw [SimpleFunc.restrict_preimage_singleton _ ((hS_meas n).inter ht)]
     swap
-    ·
-      rw [Finset.mem_coe, Finset.mem_filter] at hy
+    · rw [Finset.mem_coe, Finset.mem_filter] at hy
       exact hy.2
     refine (measure_mono Set.inter_subset_left).trans_lt ?_
     have h_lt_top := measure_spanningSets_lt_top (μ.restrict t) n

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -268,7 +268,7 @@ theorem finStronglyMeasurable_of_set_sigmaFinite [TopologicalSpace β] [Zero β]
     refine fun n => measure_biUnion_lt_top {y ∈ (fs n).range | y ≠ 0}.finite_toSet fun y hy => ?_
     rw [SimpleFunc.restrict_preimage_singleton _ ((hS_meas n).inter ht)]
     swap
-    · letI : (y : β) → Decidable (y = 0) := fun y => Classical.propDecidable _
+    ·
       rw [Finset.mem_coe, Finset.mem_filter] at hy
       exact hy.2
     refine (measure_mono Set.inter_subset_left).trans_lt ?_

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -675,7 +675,6 @@ instance isCyclotomicExtension [NeZero (n : K)] :
     IsCyclotomicExtension {n} K (CyclotomicField n K) := by
   have : NeZero (n : CyclotomicField n K) :=
     NeZero.nat_of_injective (algebraMap K _).injective
-  letI := Classical.decEq (CyclotomicField n K)
   have := (degree_cyclotomic_pos n K (NeZero.pos n)).ne'
   obtain ⟨ζ, hζ⟩ :=
     Splits.exists_eval_eq_zero (SplittingField.splits (cyclotomic n K)) (by rwa [degree_map])
@@ -811,8 +810,6 @@ instance [IsFractionRing A K] [IsDomain A] [NeZero (n : A)] :
       obtain ⟨⟨z, w⟩, hw⟩ := this k
       refine ⟨⟨algebraMap A (CyclotomicRing n A K) z, algebraMap A (CyclotomicRing n A K) w,
         map_mem_nonZeroDivisors _ (algebraBase_injective n A K) w.2⟩, ?_⟩
-      letI : IsScalarTower A K (CyclotomicField n K) :=
-        IsScalarTower.of_algebraMap_eq (congr_fun rfl)
       rw [← IsScalarTower.algebraMap_apply, ← IsScalarTower.algebraMap_apply,
         @IsScalarTower.algebraMap_apply A K _ _ _ _ _ (_root_.CyclotomicField.algebra n K) _ _ w,
         ← map_mul, hw, ← IsScalarTower.algebraMap_apply]

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -472,7 +472,6 @@ theorem ofMapRelIff_coe (f : α → β) [Std.Antisymm r] [Std.Refl s]
   to show it is a relation embedding. -/
 def ofMonotone [Std.Trichotomous r] [Std.Asymm s] (f : α → β) (H : ∀ a b, r a b → s (f a) (f b)) :
     r ↪r s := by
-  haveI := @Std.Asymm.irrefl β s _
   refine ⟨⟨f, fun a b e => ?_⟩, @fun a b => ⟨fun h => ?_, H _ _⟩⟩
   · apply Std.Trichotomous.trichotomous (r := r) a b
     · exact fun h => irrefl (r := s) (f a) (by simpa [e] using H _ _ h)

--- a/Mathlib/RingTheory/AlgebraTower.lean
+++ b/Mathlib/RingTheory/AlgebraTower.lean
@@ -52,7 +52,6 @@ def Invertible.algebraTower (r : R) [Invertible (algebraMap R S r)] :
 when coerced to any `R`-algebra. -/
 @[implicit_reducible]
 def invertibleAlgebraCoeNat (n : ℕ) [inv : Invertible (n : R)] : Invertible (n : A) :=
-  haveI : Invertible (algebraMap ℕ R n) := inv
   fast_instance% Invertible.algebraTower ℕ R A n
 
 end Semiring

--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -199,7 +199,6 @@ instance self : FinitePresentation R R :=
 
 /-- `R[X]` is finitely presented as `R`-algebra. -/
 instance polynomial [FinitePresentation R A] : FinitePresentation R A[X] :=
-  letI := FinitePresentation.mvPolynomial R A Unit
   have := equiv (MvPolynomial.uniqueAlgEquiv.{_, 0} A PUnit)
   .trans _ A _
 

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -967,7 +967,6 @@ variable [NonUnitalNonAssocSemiring R]
 instance [IsCancelAdd R] [IsCancelMulZero R] : IsCancelMulZero R⟦Γ⟧ where
   -- TODO: This proof is painful because `coeff_mul` isn't stated in terms of `Finsupp.sum`.
   mul_left_cancel_of_ne_zero {x} hx y z hyz := by
-    letI : AddCancelCommMonoid R := ⟨⟩
     contrapose! hyz
     simp only [ne_eq, ← coeff_inj, funext_iff, not_forall] at ⊢ hyz
     have : Set.IsWF {a | y.coeff a ≠ z.coeff a} :=
@@ -989,7 +988,6 @@ instance [IsCancelAdd R] [IsCancelMulZero R] : IsCancelMulZero R⟦Γ⟧ where
     · simp +contextual [← and_or_left, ← or_and_right]
     · simp +contextual [← and_or_left, ← or_and_right]
   mul_right_cancel_of_ne_zero {x} hx y z hyz := by
-    letI : AddCancelCommMonoid R := ⟨⟩
     contrapose! hyz
     simp only [ne_eq, ← coeff_inj, funext_iff, not_forall] at ⊢ hyz
     have : Set.IsWF {a | y.coeff a ≠ z.coeff a} :=

--- a/Mathlib/RingTheory/Ideal/Quotient/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Basic.lean
@@ -93,8 +93,7 @@ instance isDomain [hI : I.IsPrime] : IsDomain (R ⧸ I) :=
 
 theorem isDomain_iff_prime : IsDomain (R ⧸ I) ↔ I.IsPrime := by
   refine ⟨fun H => ⟨zero_ne_one_iff.1 ?_, fun {x y} h => ?_⟩, fun h => inferInstance⟩
-  ·
-    exact zero_ne_one
+  · exact zero_ne_one
   · simp only [← eq_zero_iff_mem, (mk I).map_mul] at h ⊢
     haveI := @IsDomain.to_noZeroDivisors (R ⧸ I) _ H
     exact eq_zero_or_eq_zero_of_mul_eq_zero h

--- a/Mathlib/RingTheory/Ideal/Quotient/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Basic.lean
@@ -93,7 +93,7 @@ instance isDomain [hI : I.IsPrime] : IsDomain (R ⧸ I) :=
 
 theorem isDomain_iff_prime : IsDomain (R ⧸ I) ↔ I.IsPrime := by
   refine ⟨fun H => ⟨zero_ne_one_iff.1 ?_, fun {x y} h => ?_⟩, fun h => inferInstance⟩
-  · haveI : Nontrivial (R ⧸ I) := ⟨H.2.1⟩
+  ·
     exact zero_ne_one
   · simp only [← eq_zero_iff_mem, (mk I).map_mul] at h ⊢
     haveI := @IsDomain.to_noZeroDivisors (R ⧸ I) _ H

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -216,14 +216,7 @@ attribute [local instance] FractionRing.liftAlgebra FractionRing.isScalarTower_l
 noncomputable
 instance (priority := 900) [IsDomain A] [IsDomain B] [IsIntegrallyClosed B]
     [Module.Finite A B] [IsTorsionFree A B] : Fintype (B ≃ₐ[A] B) :=
-  haveI : IsIntegralClosure B A (FractionRing B) :=
-    IsIntegralClosure.of_isIntegrallyClosed _ _ _
   -- TODO: How is this even supposed to fire? `R` and `S` cannot be inferred.
-  haveI : Algebra.IsAlgebraic (FractionRing A) (FractionRing B) :=
-    isAlgebraic_of_isFractionRing A B ..
-  haveI : IsLocalization (Algebra.algebraMapSubmonoid B A⁰) (FractionRing B) :=
-    IsIntegralClosure.isLocalization _ (FractionRing A) _ _
-  haveI : FiniteDimensional (FractionRing A) (FractionRing B) := .of_isLocalization A B A⁰
   Fintype.ofEquiv _ (galRestrict A (FractionRing A) (FractionRing B) B).toEquiv
 
 variable {Aₘ Bₘ} [CommRing Aₘ] [CommRing Bₘ] [Algebra Aₘ Bₘ] [Algebra A Aₘ] [Algebra B Bₘ]

--- a/Mathlib/RingTheory/IsGaloisGroup/Basic.lean
+++ b/Mathlib/RingTheory/IsGaloisGroup/Basic.lean
@@ -250,9 +250,6 @@ variable {K L : Type*} [Field K] [Field L] [Algebra K L] [MulSemiringAction G L]
 variable (F : IntermediateField K L) (N : Subgroup G) [N.Normal] [IsGaloisGroup N F L]
 
 noncomputable instance : MulSemiringAction (G ⧸ N) F :=
-  letI := smulOfNormal G F L N
-  haveI := smulDistribClass_smulOfNormal G F L N
-  letI := mulSemiringActionOfSmulDistribClass F L G
   mulSemiringActionQuotient G F L N
 
 instance [SMulCommClass G K L] [MulSemiringAction G F] [SMulDistribClass G F L]

--- a/Mathlib/RingTheory/Norm/Transitivity.lean
+++ b/Mathlib/RingTheory/Norm/Transitivity.lean
@@ -266,7 +266,7 @@ theorem norm_eq_prod_embeddings [Algebra.IsSeparable K L] [IsAlgClosed E]
   rw [norm_eq_norm_adjoin K x, map_pow, ← adjoin.powerBasis_gen hx,
     norm_eq_prod_embeddings_gen E (adjoin.powerBasis hx) (IsAlgClosed.splits _)]
   · exact (prod_embeddings_eq_finrank_pow L (L := K⟮x⟯) E (adjoin.powerBasis hx)).symm
-  · haveI := Algebra.isSeparable_tower_bot_of_isSeparable K K⟮x⟯ L
+  ·
     exact Algebra.IsSeparable.isSeparable K _
 
 theorem norm_eq_prod_automorphisms [IsGalois K L] (x : L) :

--- a/Mathlib/RingTheory/Norm/Transitivity.lean
+++ b/Mathlib/RingTheory/Norm/Transitivity.lean
@@ -266,8 +266,7 @@ theorem norm_eq_prod_embeddings [Algebra.IsSeparable K L] [IsAlgClosed E]
   rw [norm_eq_norm_adjoin K x, map_pow, ← adjoin.powerBasis_gen hx,
     norm_eq_prod_embeddings_gen E (adjoin.powerBasis hx) (IsAlgClosed.splits _)]
   · exact (prod_embeddings_eq_finrank_pow L (L := K⟮x⟯) E (adjoin.powerBasis hx)).symm
-  ·
-    exact Algebra.IsSeparable.isSeparable K _
+  · exact Algebra.IsSeparable.isSeparable K _
 
 theorem norm_eq_prod_automorphisms [IsGalois K L] (x : L) :
     algebraMap K L (norm K x) = ∏ σ : Gal(L/K), σ x := by

--- a/Mathlib/RingTheory/Polynomial/UniqueFactorization.lean
+++ b/Mathlib/RingTheory/Polynomial/UniqueFactorization.lean
@@ -90,7 +90,6 @@ open UniqueFactorizationMonoid
 namespace Polynomial
 
 instance (priority := 100) uniqueFactorizationMonoid : UniqueFactorizationMonoid D[X] := by
-  letI := Classical.arbitrary (NormalizedGCDMonoid D)
   exact ufm_of_decomposition_of_wfDvdMonoid
 
 /-- If `D` is a unique factorization domain, `f` is a non-zero polynomial in `D[X]`, then `f` has

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -78,7 +78,6 @@ equal to the `S`-rank of `Ω[S/R]`
 (see `IsStandardSmoothOfRelativeDimension.rank_kaehlerDifferential`).
 -/
 noncomputable def IsStandardSmooth.relativeDimension [IsStandardSmooth R S] : ℕ :=
-  letI := ‹IsStandardSmooth R S›.out.choose_spec.choose_spec.choose
   ‹IsStandardSmooth R S›.out.choose_spec.choose_spec.choose_spec.2.some.dimension
 
 /--

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -499,7 +499,6 @@ abbrev rightAlgebra : Algebra B (A ⊗[R] B) :=
 attribute [local instance] TensorProduct.rightAlgebra
 
 lemma algebraMap_eq_includeRight :
-    letI := rightAlgebra (R := R) (A := A) (B := B)
     algebraMap B (A ⊗[R] B) = includeRight (R := R) (A := A) (B := B) := rfl
 
 instance right_isScalarTower : IsScalarTower R B (A ⊗[R] B) :=

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -257,7 +257,7 @@ theorem trace_eq_sum_embeddings [FiniteDimensional K L] [Algebra.IsSeparable K L
     trace_eq_sum_embeddings_gen E pb (IsAlgClosed.splits _), ← Algebra.smul_def,
     algebraMap_smul]
   · exact (sum_embeddings_eq_finrank_mul L E pb).symm
-  · haveI := Algebra.isSeparable_tower_bot_of_isSeparable K K⟮x⟯ L
+  ·
     exact Algebra.IsSeparable.isSeparable K _
 
 theorem trace_eq_sum_automorphisms (x : L) [FiniteDimensional K L] [IsGalois K L] :

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -257,8 +257,7 @@ theorem trace_eq_sum_embeddings [FiniteDimensional K L] [Algebra.IsSeparable K L
     trace_eq_sum_embeddings_gen E pb (IsAlgClosed.splits _), ← Algebra.smul_def,
     algebraMap_smul]
   · exact (sum_embeddings_eq_finrank_mul L E pb).symm
-  ·
-    exact Algebra.IsSeparable.isSeparable K _
+  · exact Algebra.IsSeparable.isSeparable K _
 
 theorem trace_eq_sum_automorphisms (x : L) [FiniteDimensional K L] [IsGalois K L] :
     algebraMap K L (Algebra.trace K L x) = ∑ σ : Gal(L/K), σ x := by

--- a/Mathlib/Topology/Algebra/FilterBasis.lean
+++ b/Mathlib/Topology/Algebra/FilterBasis.lean
@@ -267,7 +267,6 @@ instance (priority := 100) isTopologicalRing {R : Type u} [Ring R] (B : RingFilt
   letI := B'.topology
   have basis := B'.nhds_zero_hasBasis
   have basis' := basis.prod basis
-  haveI := B'.isTopologicalAddGroup
   apply IsTopologicalRing.of_addGroup_of_nhds_zero
   · rw [basis'.tendsto_iff basis]
     suffices ∀ U ∈ B', ∃ V W, (V ∈ B' ∧ W ∈ B') ∧ ∀ a b, a ∈ V → b ∈ W → a * b ∈ U by simpa

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -338,7 +338,6 @@ instance continuousSMul_quotient [TopologicalSpace R] [IsTopologicalAddGroup M]
 
 instance t3_quotient_of_isClosed [IsTopologicalAddGroup M] [IsClosed (S : Set M)] :
     T3Space (M ⧸ S) :=
-  letI : IsClosed (S.toAddSubgroup : Set M) := ‹_›
   QuotientAddGroup.instT3Space S.toAddSubgroup
 
 end Submodule

--- a/Mathlib/Topology/Algebra/Nonarchimedean/Bases.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/Bases.lean
@@ -313,7 +313,6 @@ def openAddSubgroup (i : ι) : @OpenAddSubgroup M _ hB.topology :=
   let _ := hB.topology
   { (B i).toAddSubgroup with
     isOpen' := by
-      letI := hB.topology
       rw [isOpen_iff_mem_nhds]
       intro a a_in
       rw [(hB.toModuleFilterBasis.toAddGroupFilterBasis.nhds_hasBasis a).mem_iff]

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -139,7 +139,6 @@ def mk' (v : Valuation R Γ₀) : Valued R Γ₀ :=
     toUniformSpace := @IsTopologicalAddGroup.rightUniformSpace R _ v.subgroups_basis.topology _
     toIsUniformAddGroup := @isUniformAddGroup_of_addCommGroup _ _ v.subgroups_basis.topology _
     is_topological_valuation := by
-      letI := @IsTopologicalAddGroup.rightUniformSpace R _ v.subgroups_basis.topology _
       intro s
       rw [Filter.hasBasis_iff.mp v.subgroups_basis.hasBasis_nhds_zero s]
       simp_rw [restrict_lt_iff_lt_embedding]

--- a/Mathlib/Topology/Category/Profinite/Nobeling/Span.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Span.lean
@@ -71,7 +71,6 @@ noncomputable
 def spanFinBasis (x : π C (· ∈ s)) : LocallyConstant (π C (· ∈ s)) ℤ where
   toFun := fun y ↦ if y = x then 1 else 0
   isLocallyConstant :=
-    haveI : DiscreteTopology (π C (· ∈ s)) := Finite.instDiscreteTopology
     IsLocallyConstant.of_discrete _
 
 theorem spanFinBasis.span : ⊤ ≤ Submodule.span ℤ (Set.range (spanFinBasis C s)) := by

--- a/Mathlib/Topology/Category/Stonean/Basic.lean
+++ b/Mathlib/Topology/Category/Stonean/Basic.lean
@@ -180,7 +180,6 @@ instance (X : Stonean) : Projective (toProfinite.obj X) where
 instance (X : Stonean) : Projective X where
   factors := by
     intro B C φ f _
-    haveI : ExtremallyDisconnected X.toTop := X.prop
     have hf : Function.Surjective f := by rwa [← Stonean.epi_iff_surjective]
     obtain ⟨f', h⟩ := CompactT2.ExtremallyDisconnected.projective φ.hom.hom.continuous
       f.hom.hom.continuous

--- a/Mathlib/Topology/Instances/Discrete.lean
+++ b/Mathlib/Topology/Instances/Discrete.lean
@@ -35,9 +35,6 @@ instance (priority := 100) DiscreteTopology.firstCountableTopology [DiscreteTopo
 
 instance (priority := 100) DiscreteTopology.secondCountableTopology_of_countable
     [hd : DiscreteTopology α] [Countable α] : SecondCountableTopology α :=
-  haveI : ∀ i : α, SecondCountableTopology (↥({i} : Set α)) := fun i =>
-    { is_open_generated_countable :=
-        ⟨{univ}, countable_singleton _, by simp only [eq_iff_true_of_subsingleton]⟩ }
   secondCountableTopology_of_countable_cover (fun _ ↦ isOpen_discrete _)
     (iUnion_of_singleton α)
 

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -405,7 +405,6 @@ where the distance is given by `dist x y = (1/2)^n`, where `n` is the smallest i
 @[implicit_reducible]
 protected def metricSpaceOfDiscreteUniformity {E : ℕ → Type*} [∀ n, UniformSpace (E n)]
     (h : ∀ n, uniformity (E n) = 𝓟 SetRel.id) : MetricSpace (∀ n, E n) :=
-  haveI : ∀ n, DiscreteTopology (E n) := fun n => discreteTopology_of_discrete_uniformity (h n)
   { dist_triangle := PiNat.dist_triangle
     dist_comm := PiNat.dist_comm
     dist_self := PiNat.dist_self

--- a/Mathlib/Topology/MetricSpace/Polish.lean
+++ b/Mathlib/Topology/MetricSpace/Polish.lean
@@ -65,7 +65,6 @@ class PolishSpace (α : Type*) [h : TopologicalSpace α] : Prop
 instance [TopologicalSpace α] [SeparableSpace α] [IsCompletelyMetrizableSpace α] :
     PolishSpace α := by
   letI := upgradeIsCompletelyMetrizable α
-  haveI := UniformSpace.secondCountable_of_separable α
   constructor
 
 namespace PolishSpace

--- a/Mathlib/Topology/Metrizable/Basic.lean
+++ b/Mathlib/Topology/Metrizable/Basic.lean
@@ -131,7 +131,6 @@ instance (priority := 100) PseudoMetrizableSpace.toMetrizableSpace
     [T0Space X] [h : PseudoMetrizableSpace X] : MetrizableSpace X where
 
 instance (priority := 100) t2Space_of_metrizableSpace [MetrizableSpace X] : T2Space X :=
-  letI : UniformSpace X := pseudoMetrizableSpaceUniformity X
   inferInstance
 
 instance metrizableSpace_prod [MetrizableSpace X] [MetrizableSpace Y] :

--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -279,7 +279,7 @@ theorem IndiscreteTopology.isOpen_iff [IndiscreteTopology α] (U : Set α) :
     exacts [@isOpen_empty _ ⊤, @isOpen_univ _ ⊤]
 
 theorem TopologicalSpace.isOpen_top_iff {α} (U : Set α) : IsOpen[⊤] U ↔ U = ∅ ∨ U = univ :=
-  letI : TopologicalSpace α := ⊤; IndiscreteTopology.isOpen_iff _
+  IndiscreteTopology.isOpen_iff _
 
 theorem IndiscreteTopology.isClosed_iff [IndiscreteTopology α] (C : Set α) :
     IsClosed C ↔ C = ∅ ∨ C = Set.univ := by

--- a/Mathlib/Topology/UniformSpace/AbstractCompletion.lean
+++ b/Mathlib/Topology/UniformSpace/AbstractCompletion.lean
@@ -313,8 +313,6 @@ the statement of `compare_comp_eq_compare` is the commutativity of the right tri
 -/
 theorem compare_comp_eq_compare (γ : Type uγ) [TopologicalSpace γ]
     [T3Space γ] {f : α → γ} (cont_f : Continuous f) :
-    letI := pkg.uniformStruct.toTopologicalSpace
-    letI := pkg'.uniformStruct.toTopologicalSpace
     (∀ a : pkg.space,
       Filter.Tendsto f (Filter.comap pkg.coe (𝓝 a)) (𝓝 ((pkg.isDenseInducing.extend f) a))) →
       pkg.isDenseInducing.extend f ∘ pkg'.compare pkg = pkg'.isDenseInducing.extend f := by


### PR DESCRIPTION
Like #41625, but for defs and instances. This is more risky, since it can in theory change a definition, But for this PR, all pretty printed version stay (or at least ought to stay) the same.

Together with #41625 this removes almost all redundant haveI/letI ´. Few (<2%) remain, but I was getting to a point of diminishing returns, so i let them be for now.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
