### PR TITLE
[Merged by Bors] - feat(SetTheory/Cardinal/ToNat): `Cardinal.toNat` version of `eq_of_forall_le_iff`

### DIFF
--- a/Mathlib/SetTheory/Cardinal/ToNat.lean
+++ b/Mathlib/SetTheory/Cardinal/ToNat.lean
@@ -170,4 +170,16 @@ lemma toNat_eq_iff_of_lt_aleph0 {a : Cardinal.{u}} (n : ℕ) (lt : a < Cardinal.
   nth_rw 2 [← Cardinal.cast_toNat_of_lt_aleph0 lt]
   exact Nat.cast_inj.symm
 
+/-- A `Cardinal.toNat` version of `eq_of_forall_le_iff`.
+This is useful for proving equality of `Module.finrank`. -/
+theorem toNat_eq_of_forall_le_iff {c : Cardinal.{u}} {d : Cardinal.{v}}
+    (h : ∀ n : ℕ, n ≤ c ↔ n ≤ d) : c.toNat = d.toNat := by
+  have h' := forall_congr' h
+  rw [← Cardinal.aleph0_le, ← Cardinal.aleph0_le] at h'
+  rcases iff_iff_and_or_not_and_not.mp h' with ⟨hc, hd⟩ | ⟨hc, hd⟩
+  · simp [Cardinal.toNat_apply_of_aleph0_le, hc, hd]
+  · apply eq_of_forall_le_iff
+    rw [← cast_toNat_of_lt_aleph0 (not_le.mp hc), ← cast_toNat_of_lt_aleph0 (not_le.mp hd)] at h
+    simpa using h
+
 end Cardinal


### PR DESCRIPTION
This PR adds a `Cardinal.toNat` version of `eq_of_forall_le_iff`. This is useful for proving equality of `Module.finrank`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
