### PR TITLE
[Merged by Bors] - chore: tweak bench suite

### DIFF
--- a/scripts/bench/build/README.md
+++ b/scripts/bench/build/README.md
@@ -1,6 +1,6 @@
 # The `build` benchmark
 
-This benchmark executes a complete build of mathlib4 and collects global and per-module metrics.
+This benchmark executes a complete build and collects global and per-module metrics.
 
 The following metrics are collected by a wrapper around the entire build process:
 

--- a/scripts/bench/build/README.md
+++ b/scripts/bench/build/README.md
@@ -28,5 +28,5 @@ The following metrics are collected individually for each module:
 - `build/module/<name>//lines`
 - `build/module/<name>//instructions`
 
-If the file `build_upload_lakeprof_report` is present in the repo root,
-the lakeprof report will be uploaded once the benchmark run concludes.
+If the `LAKEPROF_UPLOAD_URL` environment variable is set,
+the lakeprof report will be uploaded to that URL prefix once the benchmark run concludes.

--- a/scripts/bench/build/lakeprof_report_upload.py
+++ b/scripts/bench/build/lakeprof_report_upload.py
@@ -12,10 +12,9 @@ if not upload_url:
 if upload_url.endswith("/"):
     upload_url = upload_url[:-1]
 
-# Determine paths relative to the current file.
-script_file = Path(__file__)
-template_file = script_file.parent / "lakeprof_report_template.html"
-root_dir = script_file.parent.parent.parent.parent
+# Determine paths
+template_file = Path(__file__).with_name("lakeprof_report_template.html")
+root_dir = Path(os.environ["ROOT_DIR"])
 
 
 def run_stdout(*command: str, cwd: Path | None = None) -> str:

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -14,5 +14,5 @@ LAKE_OVERRIDE_LEAN=true \
   lakeprof record lake build --no-cache
 
 # Analyze lakeprof data
-"$BENCH_DIR/build/lakeprof_measurements.py" measurements.jsonl
+"$BENCH_DIR/build/lakeprof_measurements.py" "$OUTPUT_FILE"
 python3 "$BENCH_DIR/build/lakeprof_report_upload.py"

--- a/scripts/bench/size/run
+++ b/scripts/bench/size/run
@@ -3,6 +3,7 @@
 import json
 import os
 from pathlib import Path
+from typing import Generator
 
 OUTFILE = Path(os.environ["OUTPUT_FILE"])
 
@@ -18,6 +19,16 @@ def output_result(
         data["unit"] = unit
     with open(OUTFILE, "a") as f:
         f.write(f"{json.dumps(data)}\n")
+
+
+def find_lean_files() -> Generator[Path, None, None]:
+    for p in Path().iterdir():
+        if p.name.startswith("."):
+            continue
+        elif p.is_dir():
+            yield from p.glob("**/*.lean")
+        elif p.name.endswith(".lean"):
+            yield p
 
 
 def measure_lines(topic: str, *paths: Path) -> None:
@@ -37,7 +48,7 @@ def measure_bytes(topic: str, *paths: Path) -> None:
 
 
 if __name__ == "__main__":
-    measure_lines("size/.lean", *Path().glob("Mathlib/**/*.lean"))
+    measure_lines("size/.lean", *find_lean_files())
     measure_bytes("size/.olean", *Path().glob(".lake/build/**/*.olean"))
     measure_bytes("size/.olean.server", *Path().glob(".lake/build/**/*.olean.server"))
     measure_bytes("size/.olean.private", *Path().glob(".lake/build/**/*.olean.private"))


### PR DESCRIPTION
This PR applies a few tweaks to bring the bench suite in-line with the other repos using a similar setup.

The only change that affects functionality is how `.lean` LoC are computed. Instead of looking only in `Mathlib`, now it searches the entire repo for `.lean` files.

Follow-up to #41587.