### PR TITLE
[Merged by Bors] - fix(cache): carry decompression pipeline state across download rounds

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -500,18 +500,30 @@ structure DecompConfig where
   isMathlibRoot : Bool
   mathlibDepPath : FilePath
 
-private structure TransferState where
-  last : Nat
-  success : Nat
-  failed : Nat
-  done : Nat
-  speed : Nat
-  -- Decompression state (only used when decompConfig is set)
-  pending : Array (FilePath × Lean.Name)           -- files waiting to be decompressed
-  currentTask : Option (Task (Except IO.Error Unit))  -- current leantar task
-  lastBatchSize : Nat                              -- size of the last dispatched batch
-  decompressed : Nat                               -- total files decompressed
-  decompFailed : Nat                               -- total decompression failures
+/-- Decompression pipeline state, carried from each download round into the
+next. A round can end with downloads queued (`pending`) or in a running
+leantar batch (`currentTask`); `downloadFiles` hands each round's final state
+to the next, and `finalizeDecomp` drains what remains after the last round. -/
+structure DecompState where
+  /-- Downloaded files waiting to be dispatched in a leantar batch. -/
+  pending : Array (FilePath × Lean.Name) := #[]
+  /-- The in-flight leantar batch, if any. -/
+  currentTask : Option (Task (Except IO.Error Unit)) := none
+  /-- Size of the batch `currentTask` is processing. -/
+  lastBatchSize : Nat := 0
+  /-- Files decompressed, cumulative across rounds. -/
+  decompressed : Nat := 0
+  /-- Decompression failures, cumulative across rounds. -/
+  decompFailed : Nat := 0
+
+structure TransferState where
+  last : Nat := 0
+  success : Nat := 0
+  failed : Nat := 0
+  done : Nat := 0
+  speed : Nat := 0
+  /-- Decompression pipeline state; used only when a `DecompConfig` is set. -/
+  decomp : DecompState := {}
 
 /-- Harvest the result of a completed decompression task, updating counters.
     Returns `(successful, failed, error?)`. -/
@@ -528,6 +540,26 @@ def dispatchDecompBatch (pending : Array (FilePath × Lean.Name)) (config : Deco
   let task ← IO.asTask (decompressBatch pending config.force config.isMathlibRoot config.mathlibDepPath)
   return some task
 
+/-- Drain the decompression pipeline after the last download round: harvest the
+in-flight leantar batch, then decompress the pending files. Returns the final
+`(decompressed, decompFailed)` counters. -/
+def finalizeDecomp (state : DecompState) (config : DecompConfig) : IO (Nat × Nat) := do
+  let mut {pending, currentTask, lastBatchSize, decompressed, decompFailed} := state
+  if let some task := currentTask then
+    let (d, f, err?) := harvestDecompTask task lastBatchSize decompressed decompFailed
+    decompressed := d
+    decompFailed := f
+    if let some e := err? then
+      IO.eprintln s!"Decompression error: {e}"
+  if !pending.isEmpty then
+    try
+      decompressBatch pending config.force config.isMathlibRoot config.mathlibDepPath
+      decompressed := decompressed + pending.size
+    catch e =>
+      IO.eprintln s!"Decompression error: {e}"
+      decompFailed := decompFailed + pending.size
+  return (decompressed, decompFailed)
+
 /--
 Whether an HTTP status is the one Azure returns for a blob that already exists,
 which a non-overwrite `put` (`If-None-Match: *`) hits when it declines to
@@ -542,6 +574,7 @@ def isAlreadyPresentStatus (httpCode : Nat) : Bool :=
 def monitorCurl (args : Array String) (size : Nat)
     (caption : String) (speedVar : String) (removeOnError := false)
     (decompConfig : Option DecompConfig := none)
+    (decompState : DecompState := {})
     (treatForbiddenAsMiss : Bool := false)
     (treatExistsAsSkip : Bool := false) : IO (TransferState × Std.HashSet UInt64) := do
   let useAnsi := (← IO.getEnv "TERM").isSome
@@ -556,18 +589,19 @@ def monitorCurl (args : Array String) (size : Nat)
     let mut msg := s!"\r{caption}: {s.success} file(s) [attempted {s.done}/{size} = {100*s.done/size}%{speedStr}]"
     -- Add decompression progress if enabled
     if decompConfig.isSome then
-      msg := msg ++ s!", Decompressed: {s.decompressed}"
-      if s.decompFailed != 0 then
-        msg := msg ++ s!" ({s.decompFailed} failed)"
+      msg := msg ++ s!", Decompressed: {s.decomp.decompressed}"
+      if s.decomp.decompFailed != 0 then
+        msg := msg ++ s!" ({s.decomp.decompFailed} failed)"
     if s.failed != 0 then
       msg := msg ++ s!", {s.failed} download failed"
     -- Clear to end of line to avoid remnants from longer previous messages
     if useAnsi then
       msg := msg ++ "\x1b[K"
     return msg
-  let init : TransferState := ⟨← IO.monoMsNow, 0, 0, 0, 0, #[], none, 0, 0, 0⟩
+  let init : TransferState := { last := (← IO.monoMsNow), decomp := decompState }
   let s ← IO.runCurlStreaming args init fun a line => do
-    let mut {last, success, failed, done, speed, pending, currentTask, lastBatchSize, decompressed, decompFailed} := a
+    let mut {last, success, failed, done, speed, decomp} := a
+    let mut {pending, currentTask, lastBatchSize, decompressed, decompFailed} := decomp
     -- output errors other than 404 and remove corresponding partial downloads
     let line := line.trimAscii
     if !line.isEmpty then
@@ -646,26 +680,32 @@ def monitorCurl (args : Array String) (size : Nat)
         if now - last ≥ 100 then -- max 10/s update rate
           speed := match result.getObjValAs? Nat speedVar with
             | .ok speed => speed | .error _ => speed
-          IO.eprint (mkStatus {last, success, failed, done, speed, pending, currentTask, lastBatchSize, decompressed, decompFailed})
+          let decompNow : DecompState :=
+            {pending, currentTask, lastBatchSize, decompressed, decompFailed}
+          IO.eprint (mkStatus {last, success, failed, done, speed, decomp := decompNow})
           last := now
        | .error e =>
         IO.println s!"Non-JSON output from curl:\n  {line}\n{e}"
-    pure {last, success, failed, done, speed, pending, currentTask, lastBatchSize, decompressed, decompFailed}
+    let decompNow : DecompState :=
+      {pending, currentTask, lastBatchSize, decompressed, decompFailed}
+    pure {last, success, failed, done, speed, decomp := decompNow}
   if s.done > 0 then
     -- to avoid confusingly moving on without finishing the count
     IO.eprintln (mkStatus s)
   return (s, ← servedRef.get)
 
 /-- Run one container's download pass for the given hash map. Returns the
-`TransferState` from `monitorCurl` (synthesized in serial mode, where it carries
-only the transfer-failure count) and the set of hashes it fetched, so the caller
-can carry the rest to the next container. Side effect: any files successfully
-fetched are written to `CACHEDIR` with their final names. -/
+`TransferState` from `monitorCurl` (synthesized in serial mode, where it
+carries only the transfer-failure count) and the set of hashes it fetched, so
+the caller can carry the rest to the next container. `decompState` is the
+previous round's decompression pipeline state; the returned state's `decomp`
+continues it. Serial mode never pipelines and passes it through untouched.
+Side effect: fetched files are written to `CACHEDIR` with their final names. -/
 private def downloadFilesFromContainer
     (container : Option Container) (repo containerURL : String)
     (hashMap : IO.ModuleHashMap)
     (parallel : Bool) (decompConfig : Option DecompConfig)
-    (scope? : Option String) :
+    (scope? : Option String) (decompState : DecompState) :
     IO (TransferState × Std.HashSet UInt64) := do
   let size := hashMap.size
   if parallel then
@@ -680,7 +720,7 @@ private def downloadFilesFromContainer
     -- whose chain still lists it.
     let treatForbiddenAsMiss := container == some Container.legacy
     let (s, served) ← monitorCurl args size "Downloaded" "speed_download" (removeOnError := true)
-      decompConfig (treatForbiddenAsMiss := treatForbiddenAsMiss)
+      decompConfig decompState (treatForbiddenAsMiss := treatForbiddenAsMiss)
     IO.FS.removeFile IO.CURLCFG
     return (s, served)
   else
@@ -699,7 +739,7 @@ private def downloadFilesFromContainer
         | .ok .served => (served.insert hash, failed)
         | .ok .miss => (served, failed)
         | _ => (served, failed + 1)
-    return (⟨0, 0, failed, 0, 0, #[], none, 0, 0, 0⟩, served)
+    return ({ failed, decomp := decompState }, served)
 
 /-- Expand the trust-ordered container list into the concrete download rounds to
 run, each carrying the SHA scope to read at. A round is
@@ -758,8 +798,8 @@ def downloadFiles
     IO.eprintln "No container URLs configured for download"
     return hashMap.size
 
-  -- Set up decompression config if enabled. We keep one config across all
-  -- container rounds so pipelined decompression continues across them.
+  -- Set up decompression config if enabled: one config shared by all container
+  -- rounds, with the pipeline state carried between them via `decompState`.
   let decompConfig ← if decompress then
     let hashToMod : Std.HashMap UInt64 Lean.Name := hashMap.fold (init := ∅) fun acc mod hash =>
       acc.insert hash mod
@@ -781,9 +821,13 @@ def downloadFiles
   let rounds := expandDownloadRounds containerURLs scope? unsafeScopes headScope?
   let unsafeMode := !unsafeScopes.isEmpty
   let mut remaining := hashMap
-  let mut finalState : TransferState := ⟨0, 0, 0, 0, 0, #[], none, 0, 0, 0⟩
+  -- Decompression pipeline state, carried from each round into the next (see
+  -- `DecompState`); `finalizeDecomp` below drains what the last round leaves.
+  let mut decompState : DecompState := {}
   -- Hard transfer failures (not 404 misses) drive the exit code; misses are
   -- normal and instead surface as the "not found" hint keyed on `remaining`.
+  -- Accumulated across rounds: a failure in an early container counts even
+  -- when a later round serves the file.
   let mut downloadFailed := 0
   -- For the `--unsafe` summary: how many files each scoped (forks) round supplied,
   -- attributed by the drop in `remaining` across that round.
@@ -793,13 +837,14 @@ def downloadFiles
     let scopeNote := match roundScope? with | some s => s!" (scope {s})" | none => ""
     IO.println s!"Attempting to download {remaining.size} file(s) from {repo} cache at {url}{scopeNote}"
     let before := remaining.size
-    let (s, served) ← downloadFilesFromContainer container? repo url remaining parallel decompConfig roundScope?
-    -- Keep the latest round's pipeline state and transfer-failure count for the
-    -- finalization and exit-code logic below. Drop the files this round served so
-    -- the next container only retries genuine misses, regardless of what is
-    -- already on disk.
-    finalState := s
-    downloadFailed := s.failed
+    let (s, served) ← downloadFilesFromContainer container? repo url remaining parallel
+      decompConfig roundScope? decompState
+    -- Carry the decompression pipeline into the next round and the drain
+    -- below: files left behind here are never decompressed. Drop the files
+    -- this round served so the next container only retries genuine misses,
+    -- regardless of what is already on disk.
+    decompState := s.decomp
+    downloadFailed := downloadFailed + s.failed
     remaining := remaining.filter fun _ hash => !served.contains hash
     if unsafeMode then
       if let some sha := roundScope? then
@@ -828,27 +873,9 @@ def downloadFiles
     IO.eprintln "  * If you have already opened a PR, this may mean"
     IO.eprintln "    the CI build has failed part-way through building."
 
-  -- Finalize decompression: wait for current task and process any remaining files
+  -- Drain the decompression pipeline accumulated across all rounds.
   if let some config := decompConfig then
-    let mut {pending, currentTask, lastBatchSize, decompressed, decompFailed, ..} := finalState
-
-    -- Wait for current task to complete if any
-    if let some task := currentTask then
-      let (d, f, err?) := harvestDecompTask task lastBatchSize decompressed decompFailed
-      decompressed := d
-      decompFailed := f
-      if let some e := err? then
-        IO.eprintln s!"Decompression error: {e}"
-
-    -- Process any remaining pending files
-    if !pending.isEmpty then
-      try
-        decompressBatch pending config.force config.isMathlibRoot config.mathlibDepPath
-        decompressed := decompressed + pending.size
-      catch e =>
-        IO.eprintln s!"Decompression error: {e}"
-        decompFailed := decompFailed + pending.size
-
+    let (decompressed, decompFailed) ← finalizeDecomp decompState config
     IO.println s!"Decompressed {decompressed} file(s)"
     if decompFailed > 0 then
       IO.println s!"{decompFailed} decompression(s) failed"

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -21,10 +21,14 @@ These tests cover the pure logic of the cache system, including:
 - CLI flag parsing (`--cache-from`, `--scope`, `--unsafe`, `--repo`, etc.)
 - `--unsafe` download-round expansion (`expandDownloadRounds`) and the
   non-default-scope security warning it triggers
+- Decompression-pipeline carry across download rounds (`DecompState`,
+  `finalizeDecomp`, `monitorCurl`)
 - Utility functions (URL extraction, filename hashing, etc.)
 
-Anything that touches `curl` or the network is left to CI, which exercises the
-`cache get`/`put` paths end-to-end on real containers.
+Anything that touches the network is left to CI, which exercises the
+`cache get`/`put` paths end-to-end on real containers. The unit tests spawn
+two local processes, `curl --version` and one leantar run on a nonexistent
+archive; neither makes a network request.
 
 ## Invariants these tests defend
 
@@ -40,6 +44,10 @@ Anything that touches `curl` or the network is left to CI, which exercises the
    collide.
 5. `legacy` stays readable with its mixed layout (flat for the canonical repo,
    prefixed for forks) so older clients keep working.
+6. Multi-round downloads decompress every file they fetch: the decompression
+   pipeline state is carried from each container round into the next and
+   drained after the last one, so a fork-PR `get` leaves no downloaded file
+   compressed on disk.
 
 ## Running the tests
 
@@ -974,6 +982,75 @@ def test_expandDownloadRounds : IO Unit := do
 
 end UnsafeRounds
 
+section DecompPipeline
+
+/-- Shared `DecompConfig` for the pipeline tests. `hashToMod` is unused here;
+`isMathlibRoot := true` makes `decompressBatch` treat pending paths as plain
+entries, so `mathlibDepPath` is unused too. -/
+private def testDecompConfig : DecompConfig :=
+  { hashToMod := ∅, force := false, isMathlibRoot := true, mathlibDepPath := "." }
+
+/-- `finalizeDecomp` drains the decompression pipeline after the last download
+round: it harvests the in-flight leantar batch, then decompresses the pending
+files. A pipeline dropped at a round boundary leaves downloaded files
+compressed on disk, forcing a rebuild. This test pins the harvest/counter
+logic and the pending-drain failure path; successful pending decompression
+needs real archives and is covered by CI. -/
+def test_finalizeDecomp : IO Unit := do
+  IO.println "finalizeDecomp:"
+  -- An empty pipeline passes the counters through unchanged.
+  let (d, f) ← withSuppressedOutput <|
+    finalizeDecomp { decompressed := 5, decompFailed := 2 } testDecompConfig
+  assert "empty pipeline passes counters through" (d == 5 && f == 2)
+
+  -- A finished successful batch is harvested into the success counter.
+  let okTask : Task (Except IO.Error Unit) := Task.pure (.ok ())
+  let (d, f) ← withSuppressedOutput <| finalizeDecomp
+    { currentTask := some okTask, lastBatchSize := 3, decompressed := 5 } testDecompConfig
+  assert "successful in-flight batch adds its size to decompressed" (d == 8 && f == 0)
+
+  -- A failed batch is harvested into the failure counter, not the success one.
+  let errTask : Task (Except IO.Error Unit) := Task.pure (.error (IO.userError "boom"))
+  let (d, f) ← withSuppressedOutput <| finalizeDecomp
+    { currentTask := some errTask, lastBatchSize := 4, decompressed := 5, decompFailed := 1 }
+    testDecompConfig
+  assert "failed in-flight batch adds its size to decompFailed" (d == 5 && f == 5)
+
+  -- Pending files are drained even with no in-flight task; a batch whose
+  -- leantar invocation fails lands in the failure counter.
+  let (d, f) ← withSuppressedOutput <| finalizeDecomp
+    { pending := #[(System.FilePath.mk "cache-test-missing-dir/bogus.ltar", `Mathlib.Bogus)]
+      decompressed := 5 } testDecompConfig
+  assert "failed pending drain adds its size to decompFailed" (d == 5 && f == 1)
+
+/-- A download round returns its decompression pipeline state in
+`TransferState.decomp` so `downloadFiles` can hand it to the next round and
+the final drain. A round in which curl transfers nothing, e.g. a container
+missing every requested file, must return the carried state intact; otherwise
+a prior round's queued files would be lost at the round boundary.
+`curl --version` drives `monitorCurl` through a real curl spawn with no
+downloads and no network. This pins `monitorCurl`'s half of the carry; the
+round loop's half is exercised by the CI integration tests. -/
+def test_monitorCurl_carries_decomp_state : IO Unit := do
+  IO.println "monitorCurl carries decompression state:"
+  let okTask : Task (Except IO.Error Unit) := Task.pure (.ok ())
+  let carried : DecompState := {
+    pending := #[(System.FilePath.mk "some/file.ltar", `Mathlib.SomeModule)]
+    currentTask := some okTask
+    lastBatchSize := 7
+    decompressed := 42
+    decompFailed := 1 }
+  let (s, served) ← withSuppressedOutput <|
+    monitorCurl #["--version"] 1 "Downloaded" "speed_download" (decompState := carried)
+  assert "no transfers → an empty served set" served.isEmpty
+  assert "pending files survive the round" (s.decomp.pending.size == 1)
+  assert "the in-flight task survives the round" s.decomp.currentTask.isSome
+  assert "the batch size survives the round" (s.decomp.lastBatchSize == 7)
+  assert "the decompressed counter survives the round" (s.decomp.decompressed == 42)
+  assert "the decompFailed counter survives the round" (s.decomp.decompFailed == 1)
+
+end DecompPipeline
+
 def runAll : IO Unit := do
   test_Container_name
   test_Container_parse
@@ -1002,6 +1079,8 @@ def runAll : IO Unit := do
   test_isCacheMissStatus
   test_isAlreadyPresentStatus
   test_expandDownloadRounds
+  test_finalizeDecomp
+  test_monitorCurl_carries_decomp_state
 
 end Cache.Test
 


### PR DESCRIPTION
`cache get` downloads files in multiple rounds (corresponding to azure containers, e.g. `master` then `forks` for a fork PR) and decompresses them in a pipeline while the download streams. 

Each round started from a fresh pipeline state and the round loop kept only the last round's state, so some files queued for decompression plus the in-flight leantar batch was dropped: the .ltars were on disk but never unpacked, and the next lake build recompiled those modules. 

The in-flight leantar was also never awaited, so it could still be writing build outputs while lake build read them.

Reported in https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/cache.20issues/with/609923362

The fix makes the pipeline state an explicit value threaded through the rounds: a DecompState structure (pending files, in-flight batch, counters) embedded in TransferState, and finalizeDecomp drain after the last round. 

Also adds related tests in Cache/Test.lean.