### PR TITLE
[Merged by Bors] - chore: remove all unused `let`

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
@@ -464,8 +464,6 @@ theorem second_derivative_symmetric_of_eventually [IsRCLikeNormedField 𝕜]
   let _ := IsRCLikeNormedField.rclike 𝕜
   let _ : NormedSpace ℝ E := NormedSpace.restrictScalars ℝ 𝕜 E
   let _ : NormedSpace ℝ F := NormedSpace.restrictScalars ℝ 𝕜 F
-  let _ : LinearMap.CompatibleSMul E F ℝ 𝕜 := LinearMap.IsScalarTower.compatibleSMul
-  let _ : LinearMap.CompatibleSMul E (E →L[𝕜] F) ℝ 𝕜 := LinearMap.IsScalarTower.compatibleSMul
   let f'R : E → E →L[ℝ] F := fun x ↦ (f' x).restrictScalars ℝ
   let f''R : E →L[ℝ] E →L[ℝ] F := f''.bilinearRestrictScalars ℝ
   have hfR : ∀ᶠ y in 𝓝 x, HasFDerivAt f (f'R y) y := by

--- a/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
@@ -68,7 +68,6 @@ lemma extensiveTopology.surjective_of_isLocallySurjective_sheaf_of_types [Finita
   rw [mem_sieves_iff_contains_colimit_cofan] at h
   obtain ⟨α, _, Y, π, h, h'⟩ := h
   let y : (a : α) → (F.obj ⟨Y a⟩) := fun a ↦ (h' a).choose
-  let _ : Fintype α := Fintype.ofFinite _
   let ht := (Types.productLimitCone (fun a ↦ F.obj ⟨Y a⟩)).isLimit
   let ht' := (Functor.Initial.isLimitWhiskerEquiv (Discrete.opposite α).inverse
     (Cocone.op (Cofan.mk X π))).symm h.some.op
@@ -116,7 +115,6 @@ lemma regularTopology.isLocallySurjective_sheaf_of_types [Preregular C] [Finitar
     obtain ⟨α, _, Z, π, h, h'⟩ := h
     rw [mem_sieves_iff_hasEffectiveEpi]
     let x : (a : α) → (F.obj ⟨Z a⟩) := fun a ↦ (h' a).choose
-    let _ : Fintype α := Fintype.ofFinite _
     let i' : ((a : α) → (F.obj ⟨Z a⟩)) ≅ (F.obj ⟨∐ Z⟩) := (Types.productIso _).symm ≪≫
       (PreservesProduct.iso F _).symm ≪≫ F.mapIso (opCoproductIsoProduct _).symm
     refine ⟨∐ Z, Sigma.desc π, inferInstance, i'.hom x, ?_⟩

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -259,7 +259,6 @@ theorem vecCons_const (a : α) : (vecCons a fun _ : Fin n => a) = fun _ => a :=
   funext <| Fin.forall_iff_succ.2 ⟨rfl, cons_val_succ _ _⟩
 
 theorem vec_single_eq_const (a : α) : ![a] = fun _ => a :=
-  let _ : Unique (Fin 1) := inferInstance
   funext <| Unique.forall_iff.2 rfl
 
 /-- `![a, b, ...] 1` is equal to `b`.

--- a/Mathlib/FieldTheory/CardinalEmb.lean
+++ b/Mathlib/FieldTheory/CardinalEmb.lean
@@ -128,7 +128,6 @@ def leastExt : ι → ι :=
       rw [adjoin_basis_eq_top, ← eq_top_iff] at this
       apply_fun Module.rank F at this
       refine ne_of_lt ?_ this
-      let _ : AddCommMonoid (⊤ : IntermediateField F E) := inferInstance
       conv_rhs => rw [topEquiv.toLinearEquiv.rank_eq]
       have := mk_Iio_lt i (by simp)
       rw [mk_toType, card_ord] at this

--- a/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
@@ -612,7 +612,6 @@ lemma adjoin_eq_of_isAlgebraic_of_isSeparable [Algebra.IsAlgebraic F E]
     have := Algebra.isSeparable_tower_top_of_isSeparable E L K
     let i : S →+* L := Subsemiring.inclusion fun x hx ↦ subset_adjoin E (S : Set K) hx
     let _ : Algebra S L := i.toAlgebra
-    let _ : SMul S L := Algebra.toSMul
     have : IsScalarTower S L K := IsScalarTower.of_algebraMap_eq (congrFun rfl)
     have := Algebra.IsAlgebraic.trans F E K
     have : IsPurelyInseparable S K := separableClosure.isPurelyInseparable F K

--- a/Mathlib/FieldTheory/Relrank.lean
+++ b/Mathlib/FieldTheory/Relrank.lean
@@ -124,7 +124,6 @@ theorem relfinrank_top_left : relfinrank ⊤ A = 1 := relfinrank_eq_one_of_le le
 
 @[simp]
 theorem relrank_top_right : relrank A ⊤ = Module.rank A E := by
-  let _ : AddCommMonoid (⊤ : IntermediateField A E) := inferInstance
   rw [relrank_eq_rank_of_le (show A ≤ ⊤ from le_top), extendScalars_top,
     IntermediateField.topEquiv.toLinearEquiv.rank_eq]
 

--- a/Mathlib/LinearAlgebra/RootSystem/BaseExists.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/BaseExists.lean
@@ -320,7 +320,6 @@ noncomputable def Base.mk' (s : Set ι)
 
 lemma nonempty_base : Nonempty P.Base := by
   let _i : Module ℚ M := Module.compHom M (algebraMap ℚ R)
-  let _i : Module ℚ N := Module.compHom N (algebraMap ℚ R)
   obtain ⟨f, hf⟩ : ∃ f : Dual ℚ M, ∀ i, f (P.root i) ≠ 0 :=
     exists_dual_forall_apply_ne_zero P.root <| by simp [P.ne_zero]
   letI := P.indexNeg

--- a/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
+++ b/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
@@ -832,7 +832,6 @@ lemma QuotientMeasureEqMeasurePreimage.sigmaFiniteQuotient
   · obtain ⟨s, fund_dom_s⟩ := i'
     have : π ⁻¹' π '' (A n) = _ := MulAction.quotient_preimage_image_eq_union_mul (A n) (G := G)
     have measπAn : MeasurableSet (π '' A n) := by
-      let _ : Setoid α := α_mod_G
       rw [measurableSet_quotient, Quotient.mk''_eq_mk, this]
       apply MeasurableSet.iUnion
       exact fun g ↦ MeasurableSet.const_smul (hA_meas n) g

--- a/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
@@ -159,7 +159,6 @@ lemma absNorm_eq_pow_inertiaDeg'_of_liesOver {S : Type*} [CommRing S] [IsDedekin
     (P : Ideal R) (p : Ideal S) [P.LiesOver p] (hp : p.IsPrime) (hp_ne_bot : p ≠ ⊥) :
     absNorm P = absNorm p ^ (p.inertiaDeg' P) := by
   have : p.IsMaximal := hp.isMaximal hp_ne_bot
-  let _ : Field (S ⧸ p) := Quotient.field p
   simpa [absNorm_apply, Submodule.cardQuot_apply] using Module.natCard_eq_pow_finrank (K := S ⧸ p)
 
 @[deprecated (since := "2026-07-03")] alias absNorm_eq_pow_inertiaDeg_of_liesOver :=

--- a/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -289,7 +289,6 @@ theorem exists_ideal_over_prime_of_isIntegral_of_isDomain [Algebra.IsIntegral R 
   letI : IsDomain (Localization (Algebra.algebraMapSubmonoid S P.primeCompl)) :=
     IsLocalization.isDomain_localization (le_nonZeroDivisors_of_noZeroDivisors hP0)
   obtain ⟨Qₚ : Ideal Sₚ, Qₚ_maximal⟩ := exists_maximal Sₚ
-  let _ : Algebra Rₚ Sₚ := localizationAlgebra P.primeCompl S
   have : Algebra.IsIntegral Rₚ Sₚ := ⟨isIntegral_localization⟩
   have Qₚ_max : IsMaximal (comap _ Qₚ) :=
     isMaximal_comap_of_isIntegral_of_isMaximal (R := Rₚ) (S := Sₚ) Qₚ

--- a/Mathlib/RingTheory/LittleWedderburn.lean
+++ b/Mathlib/RingTheory/LittleWedderburn.lean
@@ -173,5 +173,4 @@ theorem Finite.isDomain_to_isField (D : Type*) [Finite D] [Ring D] [IsDomain D] 
   classical
   cases nonempty_fintype D
   let _ := Fintype.divisionRingOfIsDomain D
-  let _ := littleWedderburn D
   exact Field.toIsField D

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/IsIntegral.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/IsIntegral.lean
@@ -236,7 +236,6 @@ theorem mem_adjoin_of_smul_prime_smul_of_minpoly_isEisensteinAt {B : PowerBasis 
   set P := minpoly R B.gen with hP
   obtain ⟨n, hn⟩ := Nat.exists_eq_succ_of_ne_zero B.dim_pos.ne'
   have : Module.IsTorsionFree R L := .trans_faithfulSMul R K L
-  let _ := P.map (algebraMap R L)
   -- There is a polynomial `Q` such that `p • z = aeval B.gen Q`. We can assume that
   -- `Q.degree < P.degree` and `Q ≠ 0`.
   rw [adjoin_singleton_eq_range_aeval] at hz

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -220,7 +220,6 @@ where
       let r : Q(decide ($na * $db ≤ $nb * $da) = true) := (q(Eq.refl true) : Expr)
       return (.isTrue q(isRat_le_true $pa $pb $r))
     else
-      let _i : Q(Nontrivial $α) := q(IsStrictOrderedRing.toNontrivial)
       let r : Q(decide ($nb * $da < $na * $db) = true) := (q(Eq.refl true) : Expr)
       return .isFalse q(isRat_le_false $pa $pb $r)
   match ra, rb with

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -220,6 +220,7 @@ where
       let r : Q(decide ($na * $db ≤ $nb * $da) = true) := (q(Eq.refl true) : Expr)
       return (.isTrue q(isRat_le_true $pa $pb $r))
     else
+      let _i : Q(Nontrivial $α) := q(IsStrictOrderedRing.toNontrivial)
       let r : Q(decide ($nb * $da < $na * $db) = true) := (q(Eq.refl true) : Expr)
       return .isFalse q(isRat_le_false $pa $pb $r)
   match ra, rb with

--- a/Mathlib/Topology/Category/Profinite/Extend.lean
+++ b/Mathlib/Topology/Category/Profinite/Extend.lean
@@ -42,7 +42,6 @@ the profinite set when written as a cofiltered limit of finite sets.
 -/
 lemma exists_hom (hc : IsLimit c) {X : FintypeCat} (f : c.pt ⟶ toProfinite.obj X) :
     ∃ (i : I) (g : F.obj i ⟶ X), f = c.π.app i ≫ toProfinite.map g := by
-  let _ : TopologicalSpace X := ⊥
   have : DiscreteTopology (toProfinite.obj X) := ⟨rfl⟩
   let f' : LocallyConstant c.pt (toProfinite.obj X) :=
     ⟨f, (IsLocallyConstant.iff_continuous _).mpr f.hom.hom.continuous⟩

--- a/Mathlib/Topology/Sheaves/Alexandrov.lean
+++ b/Mathlib/Topology/Sheaves/Alexandrov.lean
@@ -198,6 +198,5 @@ theorem Topology.IsUpperSet.isSheaf_of_isRightKanExtension
     @rightKanExtensionUnique _ _ _ _ _ _ _ _ _ _ (by assumption) _ _ (by assumption)
   change TopCat.Presheaf.IsSheaf (X := TopCat.of X) P
   rw [isSheaf_iso_iff this]
-  let _ : Preorder (TopCat.of X) := inferInstanceAs <| Preorder X
   have _ : Topology.IsUpperSet (TopCat.of X) := inferInstanceAs <| Topology.IsUpperSet X
   exact isSheaf_principalsKanExtension (X := TopCat.of X) F

--- a/Mathlib/Topology/UniformSpace/AbstractCompletion.lean
+++ b/Mathlib/Topology/UniformSpace/AbstractCompletion.lean
@@ -318,8 +318,6 @@ theorem compare_comp_eq_compare (γ : Type uγ) [TopologicalSpace γ]
     (∀ a : pkg.space,
       Filter.Tendsto f (Filter.comap pkg.coe (𝓝 a)) (𝓝 ((pkg.isDenseInducing.extend f) a))) →
       pkg.isDenseInducing.extend f ∘ pkg'.compare pkg = pkg'.isDenseInducing.extend f := by
-  let _ := pkg'.uniformStruct
-  let _ := pkg.uniformStruct
   intro h
   have (x : α) : (pkg.isDenseInducing.extend f ∘ pkg'.compare pkg) (pkg'.coe x) = f x := by
     simp only [Function.comp_apply, compare_coe, IsDenseInducing.extend_eq _ cont_f]

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -903,7 +903,6 @@ theorem uniformContinuous_sInf_dom₂ {α β γ} {f : α → β → γ} {uas : S
       haveI := sInf uas; haveI := sInf ubs
       exact @UniformContinuous _ _ _ uc fun p : α × β => f p.1 p.2 := by
   -- proof essentially copied from `continuous_sInf_dom`
-  let _ : UniformSpace (α × β) := instUniformSpaceProd
   have ha := uniformContinuous_sInf_dom ha uniformContinuous_id
   have hb := uniformContinuous_sInf_dom hb uniformContinuous_id
   have h_unif_cont_id := @UniformContinuous.prodMap _ _ _ _ (sInf uas) (sInf ubs) ua ub _ _ ha hb


### PR DESCRIPTION
This PR removes all unused/redundant `let`. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
