### PR TITLE
chore(Analysis/SpecificLimits/Normed): remove newly-unused imports

### DIFF
--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -5,6 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 module
 
+public import Mathlib.Algebra.CharP.Defs
 public import Mathlib.Analysis.Analytic.Within
 public import Mathlib.Analysis.Calculus.FDeriv.Analytic
 public import Mathlib.Analysis.Calculus.ContDiff.FTaylorSeries

--- a/Mathlib/Analysis/SpecialFunctions/OrdinaryHypergeometric.lean
+++ b/Mathlib/Analysis/SpecialFunctions/OrdinaryHypergeometric.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Analytic.OfScalars
 public import Mathlib.Analysis.RCLike.Basic
+public import Mathlib.RingTheory.Polynomial.Pochhammer
 
 /-!
 # Ordinary hypergeometric function in a Banach algebra

--- a/Mathlib/Analysis/SpecialFunctions/Pochhammer.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pochhammer.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.BigOperators.Field
 public import Mathlib.Analysis.Convex.Deriv
 public import Mathlib.Analysis.Convex.Piecewise
 public import Mathlib.Analysis.Convex.Jensen
+public import Mathlib.RingTheory.Polynomial.Pochhammer
 
 /-!
 # Pochhammer polynomials

--- a/Mathlib/Analysis/SpecialFunctions/PolynomialExp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/PolynomialExp.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 module
 
+public import Mathlib.Algebra.Polynomial.Eval.Defs
 public import Mathlib.Analysis.SpecialFunctions.Exp
 
 /-!

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -11,6 +11,7 @@ public import Mathlib.Analysis.Calculus.FDeriv.Extend
 public import Mathlib.Analysis.Calculus.Deriv.Prod
 public import Mathlib.Analysis.SpecialFunctions.Log.Deriv
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
+public import Mathlib.RingTheory.Polynomial.Pochhammer
 
 import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Field.NegOnePow
 public import Mathlib.Algebra.Field.Periodic
+public import Mathlib.Algebra.Polynomial.Eval.Defs
 public import Mathlib.Algebra.QuadraticDiscriminant
 public import Mathlib.Analysis.SpecialFunctions.Exp
 

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -16,7 +16,6 @@ public import Mathlib.Analysis.SpecificLimits.Basic
 public import Mathlib.Combinatorics.Enumerative.Stirling
 public import Mathlib.Data.Nat.Choose.Bounds
 public import Mathlib.Order.Filter.AtTopBot.ModEq
-public import Mathlib.RingTheory.Polynomial.Pochhammer
 public import Mathlib.Tactic.NoncommRing
 
 /-!
@@ -478,13 +477,6 @@ lemma tsum_choose_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r�
     ∑' n, (n + k).choose k * r ^ n = 1 / (1 - r) ^ (k + 1) :=
   (hasSum_choose_mul_geometric_of_norm_lt_one k hr).tsum_eq
 
-lemma summable_descFactorial_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr : ‖r‖ < 1) :
-    Summable (fun n ↦ (n + k).descFactorial k * r ^ n) := by
-  convert! (summable_choose_mul_geometric_of_norm_lt_one k hr).mul_left (k.factorial : R) using
-    2 with n
-  simp [← mul_assoc, descFactorial_eq_factorial_mul_choose (n + k) k]
-
--- To-do: how to fix the fact that this has similar name to lemma above but diff summand
 -- To-do: generate tsum and un-primed statements
 theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {r : R} (h : ‖r‖ < 1) :
     HasSum (fun n : ℕ ↦ (n.descFactorial j : R) * r ^ n)
@@ -500,32 +492,9 @@ theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {r : R} (h 
   · exact sub_eq_self.2 <| Finset.sum_eq_zero fun i hi ↦ by
       simp [descFactorial_eq_zero_iff_lt.2 (Finset.mem_range.1 hi)]
 
-open Polynomial in
-theorem summable_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr : ‖r‖ < 1) :
-    Summable (fun n ↦ (n : R) ^ k * r ^ n : ℕ → R) := by
-  refine Nat.strong_induction_on k fun k hk => ?_
-  obtain ⟨a, ha⟩ : ∃ (a : ℕ → ℕ), ∀ n, (n + k).descFactorial k
-      = n ^ k + ∑ i ∈ range k, a i * n ^ i := by
-    let P : Polynomial ℕ := (ascPochhammer ℕ k).comp (Polynomial.X + C 1)
-    refine ⟨fun i ↦ P.coeff i, fun n ↦ ?_⟩
-    have mP : Monic P := Monic.comp_X_add_C (monic_ascPochhammer ℕ k) _
-    have dP : P.natDegree = k := by
-      simp only [P, natDegree_comp, ascPochhammer_natDegree, mul_one, natDegree_X_add_C]
-    have A : (n + k).descFactorial k = P.eval n := by
-      have : n + 1 + k - 1 = n + k := by lia
-      simp [P, ascPochhammer_nat_eq_descFactorial, this]
-    conv_lhs => rw [A, mP.as_sum, dP]
-    simp [eval_finsetSum]
-  have : Summable (fun n ↦ (n + k).descFactorial k * r ^ n
-      - ∑ i ∈ range k, a i * n ^ (i : ℕ) * r ^ n) := by
-    apply (summable_descFactorial_mul_geometric_of_norm_lt_one k hr).sub
-    apply summable_sum (fun i hi ↦ ?_)
-    simp_rw [mul_assoc]
-    simp only [Finset.mem_range] at hi
-    exact (hk _ hi).mul_left _
-  convert! this using 1
-  ext n
-  simp [ha n, add_mul, sum_mul]
+lemma summable_descFactorial_mul_geometric_of_norm_lt_one (j : ℕ) {r : R} (hr : ‖r‖ < 1) :
+    Summable (fun n : ℕ ↦ (n.descFactorial j : R) * r ^ n) :=
+  (hasSum_descFactorial_mul_geometric_of_norm_lt_one' j hr).summable
 
 /-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ k * r ^ n` is given by the finite sum
 `∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)`, where `S(k, j)` denotes the
@@ -549,6 +518,10 @@ theorem tsum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {r : R} (h : ‖r‖ < 
     ∑' n : ℕ, (n : R) ^ k * r ^ n = (∑ j ∈ Finset.range (k + 1),
       (stirlingSecond k j : R) * j.factorial * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)) :=
   (hasSum_pow_mul_geometric_of_norm_lt_one' k h).tsum_eq
+
+theorem summable_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr : ‖r‖ < 1) :
+    Summable (fun n ↦ (n : R) ^ k * r ^ n : ℕ → R) :=
+  (hasSum_pow_mul_geometric_of_norm_lt_one' k hr).summable
 
 /-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ k * r ^ n` is given by the finite sum
 `∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j / (1 - r) ^ (j + 1)`, where `S(k, j)` denotes the

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -536,14 +536,9 @@ theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {r : R} (h : ‖r‖ 
     HasSum (fun n : ℕ ↦ (n : R) ^ k * r ^ n)
       (∑ j ∈ Finset.range (k + 1),
         (stirlingSecond k j : R) * j.factorial * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)) := by
-  have hfun : (fun n : ℕ ↦ (n : R) ^ k * r ^ n) = fun n : ℕ ↦ ∑ j ∈ Finset.range (k + 1),
-      (stirlingSecond k j : R) * ((n.descFactorial j : R) * r ^ n) := by
-    funext n
-    rw [← Nat.cast_pow, Nat.pow_eq_sum_stirlingSecond_mul_descFactorial n k]
-    push_cast [Finset.sum_mul, mul_assoc]
-    rfl
-  simpa only [hfun, mul_assoc] using hasSum_sum fun j _ ↦
-    (hasSum_descFactorial_mul_geometric_of_norm_lt_one' j h).mul_left _
+  simpa only [← Nat.cast_pow, Nat.pow_eq_sum_stirlingSecond_mul_descFactorial, Nat.cast_sum,
+    Nat.cast_mul, Finset.sum_mul, mul_assoc] using
+    hasSum_sum fun j _ ↦ (hasSum_descFactorial_mul_geometric_of_norm_lt_one' j h).mul_left _
 
 /-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ k * r ^ n` is given by the finite sum
 `∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)`, where `S(k, j)` denotes the

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -15,6 +15,7 @@ public import Mathlib.Analysis.Normed.Order.Lattice
 public import Mathlib.Analysis.SpecificLimits.Basic
 public import Mathlib.Data.List.TFAE
 public import Mathlib.Data.Nat.Choose.Bounds
+public import Mathlib.Data.Nat.Choose.Cast
 public import Mathlib.Order.Filter.AtTopBot.ModEq
 public import Mathlib.RingTheory.Polynomial.Pochhammer
 public import Mathlib.Tactic.NoncommRing
@@ -547,6 +548,48 @@ theorem hasSum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
 theorem tsum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
     (∑' n : ℕ, n * r ^ n : 𝕜) = r / (1 - r) ^ 2 :=
   (hasSum_coe_mul_geometric_of_norm_lt_one hr).tsum_eq
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`, `HasSum` version in
+a general ring with summable geometric series. For a version in a field, using division instead
+of `Ring.inverse`, see `hasSum_sq_mul_geometric_of_norm_lt_one`. -/
+theorem hasSum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n : R) ^ 2 * x ^ n) (x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3) := by
+  have A : HasSum (fun n : ℕ ↦ ((n + 2).choose 2 : R) * x ^ n) ((1 - x)⁻¹ʳ ^ 3) :=
+    hasSum_choose_mul_geometric_of_norm_lt_one' 2 h
+  have B : HasSum (fun (n : ℕ) ↦ (n + 1) * x ^ n) ((1 - x)⁻¹ʳ ^ 2) := by
+    convert! hasSum_choose_mul_geometric_of_norm_lt_one' 1 h with n
+    simp
+  have C : HasSum (fun n ↦ n * x ^ n : ℕ → R) (x * (1 - x)⁻¹ʳ ^ 2) :=
+    hasSum_coe_mul_geometric_of_norm_lt_one' h
+  convert! ((A.mul_left 2).sub (B.mul_left 2)).sub C using 1
+  · ext n
+    rw [← mul_assoc, Nat.two_mul_cast_choose_two, pow_two, cast_add, cast_ofNat]
+    noncomm_ring
+  · symm
+    calc 2 * (1 - x)⁻¹ʳ ^ 3 - 2 * (1 - x)⁻¹ʳ ^ 2 - x * (1 - x)⁻¹ʳ ^ 2
+    _ = 2 * (1 - x)⁻¹ʳ ^ 3 - 2 * (((1 - x) * (1 - x)⁻¹ʳ) * (1 - x)⁻¹ʳ ^ 2)
+        - x * (((1 - x) * (1 - x)⁻¹ʳ) * (1 - x)⁻¹ʳ ^ 2) := by
+      simp [Ring.mul_inverse_cancel (1 - x) (isUnit_one_sub_of_norm_lt_one h)]
+    _ = x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3 := by noncomm_ring
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`, version in a general
+ring with summable geometric series. For a version in a field, using division instead of
+`Ring.inverse`, see `tsum_sq_mul_geometric_of_norm_lt_one`. -/
+theorem tsum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
+    ∑' n : ℕ, (n : R) ^ 2 * x ^ n = x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3 :=
+  (hasSum_sq_mul_geometric_of_norm_lt_one' h).tsum_eq
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`,
+`HasSum` version. -/
+theorem hasSum_sq_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n : 𝕜) ^ 2 * r ^ n) (r * (1 + r) / (1 - r) ^ 3) := by
+  convert! hasSum_sq_mul_geometric_of_norm_lt_one' hr using 1
+  simp [div_eq_mul_inv]
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`. -/
+theorem tsum_sq_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : 𝕜) ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3 :=
+  (hasSum_sq_mul_geometric_of_norm_lt_one hr).tsum_eq
 
 end MulGeometric
 

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -553,23 +553,16 @@ theorem tsum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
 theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {x : R} (h : ‖x‖ < 1) :
     HasSum (fun n : ℕ ↦ (n.descFactorial j : R) * x ^ n)
       ((j.factorial : R) * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
-  have hx : Commute (x ^ j) (((1 - x)⁻¹ʳ) ^ (j + 1)) := by
-    obtain ⟨u, hu⟩ := isUnit_one_sub_of_norm_lt_one h
-    have hxu : Commute x (u : R) := hu.symm ▸ (Commute.one_right x).sub_right (Commute.refl x)
-    simp [← hu, hxu.units_inv_right.pow_pow]
-  have A := ((hasSum_choose_mul_geometric_of_norm_lt_one' j h).mul_left
-    (j.factorial : R)).mul_right (x ^ j)
-  have Afun : (fun m : ℕ ↦ (j.factorial : R) * (((m + j).choose j : R) * x ^ m) * x ^ j)
-      = fun m : ℕ ↦ ((m + j).descFactorial j : R) * x ^ (m + j) := by
-    funext m
+  rw [← hasSum_nat_add_iff' j]
+  convert! (hasSum_choose_mul_geometric_of_norm_lt_one' j h).mul_left
+    ((j.factorial : R) * x ^ j) using 1
+  · funext n
+    symm
     push_cast [Nat.descFactorial_eq_factorial_mul_choose]
-    simp only [pow_add, mul_assoc]
-  rw [Afun] at A
-  have B := (hasSum_nat_add_iff (f := fun n : ℕ ↦ (n.descFactorial j : R) * x ^ n) j).mp A
-  have hzero : ∑ i ∈ Finset.range j, (i.descFactorial j : R) * x ^ i = 0 :=
-    Finset.sum_eq_zero fun i hi ↦ by
+    rw [mul_assoc, ((Nat.cast_commute ((n + j).choose j) (x ^ j)).symm).left_comm, ← pow_add,
+      add_comm j n, mul_assoc]
+  · exact sub_eq_self.2 <| Finset.sum_eq_zero fun i hi ↦ by
       simp [descFactorial_eq_zero_iff_lt.2 (Finset.mem_range.1 hi)]
-  simpa only [hzero, add_zero, mul_assoc, hx.symm.eq] using B
 
 /-- If `‖x‖ < 1`, then `∑' n : ℕ, n ^ k * x ^ n` is given by the finite sum
 `∑ j ∈ range (k + 1), S(k, j) * j ! * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)`,
@@ -581,16 +574,10 @@ theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ 
   have hfun : (fun n : ℕ ↦ (n : R) ^ k * x ^ n) = fun n : ℕ ↦ ∑ j ∈ Finset.range (k + 1),
       (stirlingSecond k j : R) * ((n.descFactorial j : R) * x ^ n) := by
     funext n
-    rw [← Nat.cast_pow, Nat.pow_eq_sum_stirlingSecond_mul_descFactorial n k, Nat.cast_sum,
-      Finset.sum_mul]
-    simp only [Nat.cast_mul, mul_assoc]
-  have hval : (∑ j ∈ Finset.range (k + 1),
-        (stirlingSecond k j : R) * j.factorial * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1))
-      = ∑ j ∈ Finset.range (k + 1), (stirlingSecond k j : R)
-        * ((j.factorial : R) * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
-    simp only [mul_assoc]
-  rw [hfun, hval]
-  exact hasSum_sum fun j _ ↦
+    rw [← Nat.cast_pow, Nat.pow_eq_sum_stirlingSecond_mul_descFactorial n k]
+    push_cast [Finset.sum_mul, mul_assoc]
+    rfl
+  simpa only [hfun, mul_assoc] using hasSum_sum fun j _ ↦
     (hasSum_descFactorial_mul_geometric_of_norm_lt_one' j h).mul_left _
 
 theorem tsum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ < 1) :
@@ -612,17 +599,12 @@ theorem tsum_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r‖
 
 theorem hasSum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : R) ^ 2 * x ^ n) (x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3) := by
-  have h1 : (∑ j ∈ Finset.range (2 + 1),
-        (stirlingSecond 2 j : R) * j.factorial * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1))
-      = x * ((1 - x)⁻¹ʳ) ^ 2 + 2 * (x ^ 2 * ((1 - x)⁻¹ʳ) ^ 3) := by
-    simp [Finset.sum_range_succ, stirlingSecond, Nat.factorial, mul_assoc]
-  have h2 : x * ((1 - x)⁻¹ʳ) ^ 2 + 2 * (x ^ 2 * ((1 - x)⁻¹ʳ) ^ 3)
-      = x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3 := by
-    calc x * ((1 - x)⁻¹ʳ) ^ 2 + 2 * (x ^ 2 * ((1 - x)⁻¹ʳ) ^ 3)
-        = x * (((1 - x) * (1 - x)⁻¹ʳ) * ((1 - x)⁻¹ʳ) ^ 2) + 2 * (x ^ 2 * ((1 - x)⁻¹ʳ) ^ 3) := by
-          grind [Ring.mul_inverse_cancel, isUnit_one_sub_of_norm_lt_one]
-      _ = x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3 := by grind
-  grind [hasSum_pow_mul_geometric_of_norm_lt_one']
+  have h1 : ((1 - x)⁻¹ʳ) ^ 2 = (1 - x) * ((1 - x)⁻¹ʳ) ^ 3 := by
+    rw [pow_succ' _ 2, ← mul_assoc,
+      Ring.mul_inverse_cancel _ (isUnit_one_sub_of_norm_lt_one h), one_mul]
+  convert! hasSum_pow_mul_geometric_of_norm_lt_one' 2 h using 1
+  simp [Finset.sum_range_succ, stirlingSecond, Nat.factorial, h1]
+  grind
 
 end MulGeometric
 

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -511,6 +511,9 @@ theorem summable_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr : ‖r�
   ext n
   simp [ha n, add_mul, sum_mul]
 
+
+-- Question: can't this be now proven more simply using the following generalization?
+-- in that case, is this result even needed?
 /-- If `‖r‖ < 1`, then `∑' n : ℕ, n * r ^ n = r / (1 - r) ^ 2`, `HasSum` version in a general ring
 with summable geometric series. For a version in a field, using division instead of `Ring.inverse`,
 see `hasSum_coe_mul_geometric_of_norm_lt_one`. -/
@@ -548,6 +551,9 @@ theorem tsum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
     (∑' n : ℕ, n * r ^ n : 𝕜) = r / (1 - r) ^ 2 :=
   (hasSum_coe_mul_geometric_of_norm_lt_one hr).tsum_eq
 
+--- new
+
+-- Question: does this belong here? is this the right name?
 theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {x : R} (h : ‖x‖ < 1) :
     HasSum (fun n : ℕ ↦ (n.descFactorial j : R) * x ^ n)
       ((j.factorial : R) * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
@@ -564,11 +570,17 @@ theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {x : R} (h 
 
 /-- If `‖x‖ < 1`, then `∑' n : ℕ, n ^ k * x ^ n` is given by the finite sum
 `∑ j ∈ range (k + 1), S(k, j) * j ! * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)`,
-where `S(k, j)` denotes the Stirling numbers of the second kind. -/
+where `S(k, j)` denotes the Stirling numbers of the second kind.
+
+Question: should you add here the note about genereal ring vs. field with division.
+Question: why isnt this named "coe" (hasSum_coe_pow_mul_geometric_of_norm_lt_one')
+as hasSum_coe_mul_geometric_of_norm_lt_one'
+-/
 theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : R) ^ k * x ^ n)
       (∑ j ∈ Finset.range (k + 1),
         (stirlingSecond k j : R) * j.factorial * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
+  -- Question: shouldn't this hfun be extracted as another lemma
   have hfun : (fun n : ℕ ↦ (n : R) ^ k * x ^ n) = fun n : ℕ ↦ ∑ j ∈ Finset.range (k + 1),
       (stirlingSecond k j : R) * ((n.descFactorial j : R) * x ^ n) := by
     funext n
@@ -578,11 +590,13 @@ theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ 
   simpa only [hfun, mul_assoc] using hasSum_sum fun j _ ↦
     (hasSum_descFactorial_mul_geometric_of_norm_lt_one' j h).mul_left _
 
+-- To-do: missing docstrings
 theorem tsum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ < 1) :
     ∑' n : ℕ, (n : R) ^ k * x ^ n = (∑ j ∈ Finset.range (k + 1),
       (stirlingSecond k j : R) * j.factorial * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) :=
   (hasSum_pow_mul_geometric_of_norm_lt_one' k h).tsum_eq
 
+-- To-do: missing docstrings
 theorem hasSum_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : 𝕜) ^ k * r ^ n)
       (∑ j ∈ Finset.range (k + 1),
@@ -590,11 +604,13 @@ theorem hasSum_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r�
   convert! hasSum_pow_mul_geometric_of_norm_lt_one' k hr using 1
   simp [div_eq_mul_inv]
 
+-- To-do: missing docstrings
 theorem tsum_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
     ∑' n : ℕ, (n : 𝕜) ^ k * r ^ n = (∑ j ∈ Finset.range (k + 1),
       stirlingSecond k j * j.factorial * r ^ j / (1 - r) ^ (j + 1)) :=
   (hasSum_pow_mul_geometric_of_norm_lt_one k hr).tsum_eq
 
+-- should this be deleted?
 theorem hasSum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : R) ^ 2 * x ^ n) (x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3) := by
   have h1 : ((1 - x)⁻¹ʳ) ^ 2 = (1 - x) * ((1 - x)⁻¹ʳ) ^ 3 := by
@@ -603,6 +619,8 @@ theorem hasSum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
   convert! hasSum_pow_mul_geometric_of_norm_lt_one' 2 h using 1
   simp [Finset.sum_range_succ, stirlingSecond, Nat.factorial, h1]
   grind
+
+-----
 
 end MulGeometric
 

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -14,9 +14,7 @@ public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.Analysis.Normed.Order.Lattice
 public import Mathlib.Analysis.SpecificLimits.Basic
 public import Mathlib.Combinatorics.Enumerative.Stirling
-public import Mathlib.Data.List.TFAE
 public import Mathlib.Data.Nat.Choose.Bounds
-public import Mathlib.Data.Nat.Choose.Cast
 public import Mathlib.Order.Filter.AtTopBot.ModEq
 public import Mathlib.RingTheory.Polynomial.Pochhammer
 public import Mathlib.Tactic.NoncommRing

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -485,16 +485,17 @@ lemma summable_descFactorial_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr 
   simp [← mul_assoc, descFactorial_eq_factorial_mul_choose (n + k) k]
 
 -- To-do: how to fix the fact that this has similar name to lemma above but diff summand
-theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {x : R} (h : ‖x‖ < 1) :
-    HasSum (fun n : ℕ ↦ (n.descFactorial j : R) * x ^ n)
-      ((j.factorial : R) * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
+-- To-do: generate tsum and un-primed statements
+theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {r : R} (h : ‖r‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n.descFactorial j : R) * r ^ n)
+      ((j.factorial : R) * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)) := by
   rw [← hasSum_nat_add_iff' j]
   convert! (hasSum_choose_mul_geometric_of_norm_lt_one' j h).mul_left
-    ((j.factorial : R) * x ^ j) using 1
+    ((j.factorial : R) * r ^ j) using 1
   · funext n
     symm
     push_cast [Nat.descFactorial_eq_factorial_mul_choose]
-    rw [mul_assoc, ((Nat.cast_commute ((n + j).choose j) (x ^ j)).symm).left_comm, ← pow_add,
+    rw [mul_assoc, ((Nat.cast_commute ((n + j).choose j) (r ^ j)).symm).left_comm, ← pow_add,
       add_comm j n, mul_assoc]
   · exact sub_eq_self.2 <| Finset.sum_eq_zero fun i hi ↦ by
       simp [descFactorial_eq_zero_iff_lt.2 (Finset.mem_range.1 hi)]
@@ -526,18 +527,18 @@ theorem summable_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr : ‖r�
   ext n
   simp [ha n, add_mul, sum_mul]
 
-/-- If `‖x‖ < 1`, then `∑' n : ℕ, n ^ k * x ^ n` is given by the finite sum
-`∑ j ∈ range (k + 1), S(k, j) * j ! * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)`,
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ k * r ^ n` is given by the finite sum
+`∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)`,
 where `S(k, j)` denotes the Stirling numbers of the second kind.
 To-do: add here the note about genereal ring vs. field with division.
 -/
-theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ < 1) :
-    HasSum (fun n : ℕ ↦ (n : R) ^ k * x ^ n)
+theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {r : R} (h : ‖r‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n : R) ^ k * r ^ n)
       (∑ j ∈ Finset.range (k + 1),
-        (stirlingSecond k j : R) * j.factorial * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
+        (stirlingSecond k j : R) * j.factorial * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)) := by
   -- Question: shouldn't this hfun be extracted as another lemma
-  have hfun : (fun n : ℕ ↦ (n : R) ^ k * x ^ n) = fun n : ℕ ↦ ∑ j ∈ Finset.range (k + 1),
-      (stirlingSecond k j : R) * ((n.descFactorial j : R) * x ^ n) := by
+  have hfun : (fun n : ℕ ↦ (n : R) ^ k * r ^ n) = fun n : ℕ ↦ ∑ j ∈ Finset.range (k + 1),
+      (stirlingSecond k j : R) * ((n.descFactorial j : R) * r ^ n) := by
     funext n
     rw [← Nat.cast_pow, Nat.pow_eq_sum_stirlingSecond_mul_descFactorial n k]
     push_cast [Finset.sum_mul, mul_assoc]
@@ -546,9 +547,9 @@ theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ 
     (hasSum_descFactorial_mul_geometric_of_norm_lt_one' j h).mul_left _
 
 -- To-do: missing docstrings
-theorem tsum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ < 1) :
-    ∑' n : ℕ, (n : R) ^ k * x ^ n = (∑ j ∈ Finset.range (k + 1),
-      (stirlingSecond k j : R) * j.factorial * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) :=
+theorem tsum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {r : R} (h : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : R) ^ k * r ^ n = (∑ j ∈ Finset.range (k + 1),
+      (stirlingSecond k j : R) * j.factorial * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)) :=
   (hasSum_pow_mul_geometric_of_norm_lt_one' k h).tsum_eq
 
 -- To-do: missing docstrings

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -530,8 +530,8 @@ theorem summable_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr : ‖r�
 /-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ k * r ^ n` is given by the finite sum
 `∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)`,
 where `S(k, j)` denotes the Stirling numbers of the second kind.
-To-do: add here the note about genereal ring vs. field with division.
--/
+`HasSum` version in a general ring with summable geometric series. For a version in a field,
+using division instead of `Ring.inverse`, see `hasSum_pow_mul_geometric_of_norm_lt_one`. -/
 theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {r : R} (h : ‖r‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : R) ^ k * r ^ n)
       (∑ j ∈ Finset.range (k + 1),

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -536,7 +536,6 @@ theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {r : R} (h : ‖r‖ 
     HasSum (fun n : ℕ ↦ (n : R) ^ k * r ^ n)
       (∑ j ∈ Finset.range (k + 1),
         (stirlingSecond k j : R) * j.factorial * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)) := by
-  -- Question: shouldn't this hfun be extracted as another lemma
   have hfun : (fun n : ℕ ↦ (n : R) ^ k * r ^ n) = fun n : ℕ ↦ ∑ j ∈ Finset.range (k + 1),
       (stirlingSecond k j : R) * ((n.descFactorial j : R) * r ^ n) := by
     funext n

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -477,7 +477,10 @@ lemma tsum_choose_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r�
     ∑' n, (n + k).choose k * r ^ n = 1 / (1 - r) ^ (k + 1) :=
   (hasSum_choose_mul_geometric_of_norm_lt_one k hr).tsum_eq
 
--- To-do: generate tsum and un-primed statements
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n.descFactorial j * r ^ n = j ! * r ^ j / (1 - r) ^ (j + 1)`,
+`HasSum` version in a general ring with summable geometric series. For a version in a field,
+using division instead of `Ring.inverse`, see
+`hasSum_descFactorial_mul_geometric_of_norm_lt_one`. -/
 theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {r : R} (h : ‖r‖ < 1) :
     HasSum (fun n : ℕ ↦ (n.descFactorial j : R) * r ^ n)
       ((j.factorial : R) * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)) := by
@@ -492,9 +495,30 @@ theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {r : R} (h 
   · exact sub_eq_self.2 <| Finset.sum_eq_zero fun i hi ↦ by
       simp [descFactorial_eq_zero_iff_lt.2 (Finset.mem_range.1 hi)]
 
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n.descFactorial j * r ^ n = j ! * r ^ j / (1 - r) ^ (j + 1)`,
+version in a general ring with summable geometric series. For a version in a field, using
+division instead of `Ring.inverse`, see `tsum_descFactorial_mul_geometric_of_norm_lt_one`. -/
+theorem tsum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {r : R} (h : ‖r‖ < 1) :
+    ∑' n : ℕ, (n.descFactorial j : R) * r ^ n
+      = (j.factorial : R) * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1) :=
+  (hasSum_descFactorial_mul_geometric_of_norm_lt_one' j h).tsum_eq
+
 lemma summable_descFactorial_mul_geometric_of_norm_lt_one (j : ℕ) {r : R} (hr : ‖r‖ < 1) :
     Summable (fun n : ℕ ↦ (n.descFactorial j : R) * r ^ n) :=
   (hasSum_descFactorial_mul_geometric_of_norm_lt_one' j hr).summable
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n.descFactorial j * r ^ n = j ! * r ^ j / (1 - r) ^ (j + 1)`,
+`HasSum` version. -/
+theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one (j : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n.descFactorial j : 𝕜) * r ^ n)
+      (j.factorial * r ^ j / (1 - r) ^ (j + 1)) := by
+  convert! hasSum_descFactorial_mul_geometric_of_norm_lt_one' j hr using 1
+  simp [div_eq_mul_inv]
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n.descFactorial j * r ^ n = j ! * r ^ j / (1 - r) ^ (j + 1)`. -/
+theorem tsum_descFactorial_mul_geometric_of_norm_lt_one (j : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, (n.descFactorial j : 𝕜) * r ^ n = j.factorial * r ^ j / (1 - r) ^ (j + 1) :=
+  (hasSum_descFactorial_mul_geometric_of_norm_lt_one j hr).tsum_eq
 
 /-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ k * r ^ n` is given by the finite sum
 `∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)`, where `S(k, j)` denotes the

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -484,6 +484,21 @@ lemma summable_descFactorial_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr 
     2 with n
   simp [← mul_assoc, descFactorial_eq_factorial_mul_choose (n + k) k]
 
+-- To-do: how to fix the fact that this has similar name to lemma above but diff summand
+theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {x : R} (h : ‖x‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n.descFactorial j : R) * x ^ n)
+      ((j.factorial : R) * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
+  rw [← hasSum_nat_add_iff' j]
+  convert! (hasSum_choose_mul_geometric_of_norm_lt_one' j h).mul_left
+    ((j.factorial : R) * x ^ j) using 1
+  · funext n
+    symm
+    push_cast [Nat.descFactorial_eq_factorial_mul_choose]
+    rw [mul_assoc, ((Nat.cast_commute ((n + j).choose j) (x ^ j)).symm).left_comm, ← pow_add,
+      add_comm j n, mul_assoc]
+  · exact sub_eq_self.2 <| Finset.sum_eq_zero fun i hi ↦ by
+      simp [descFactorial_eq_zero_iff_lt.2 (Finset.mem_range.1 hi)]
+
 open Polynomial in
 theorem summable_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr : ‖r‖ < 1) :
     Summable (fun n ↦ (n : R) ^ k * r ^ n : ℕ → R) := by
@@ -511,70 +526,10 @@ theorem summable_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr : ‖r�
   ext n
   simp [ha n, add_mul, sum_mul]
 
-
--- Question: can't this be now proven more simply using the following generalization?
--- in that case, is this result even needed?
-/-- If `‖r‖ < 1`, then `∑' n : ℕ, n * r ^ n = r / (1 - r) ^ 2`, `HasSum` version in a general ring
-with summable geometric series. For a version in a field, using division instead of `Ring.inverse`,
-see `hasSum_coe_mul_geometric_of_norm_lt_one`. -/
-theorem hasSum_coe_mul_geometric_of_norm_lt_one'
-    {x : R} (h : ‖x‖ < 1) :
-    HasSum (fun n ↦ n * x ^ n : ℕ → R) (x * ((1 - x)⁻¹ʳ) ^ 2) := by
-  have A : HasSum (fun (n : ℕ) ↦ (n + 1) * x ^ n) ((1 - x)⁻¹ʳ ^ 2) := by
-    convert! hasSum_choose_mul_geometric_of_norm_lt_one' 1 h with n
-    simp
-  have B : HasSum (fun (n : ℕ) ↦ x ^ n) ((1 - x)⁻¹ʳ) := hasSum_geom_series_inverse x h
-  convert! A.sub B using 1
-  · ext n
-    simp [add_mul]
-  · symm
-    calc (1 - x)⁻¹ʳ ^ 2 - (1 - x)⁻¹ʳ
-    _ = (1 - x)⁻¹ʳ ^ 2 - ((1 - x) * (1 - x)⁻¹ʳ) * (1 - x)⁻¹ʳ := by
-      simp [Ring.mul_inverse_cancel (1 - x) (isUnit_one_sub_of_norm_lt_one h)]
-    _ = x * (1 - x)⁻¹ʳ ^ 2 := by noncomm_ring
-
-/-- If `‖r‖ < 1`, then `∑' n : ℕ, n * r ^ n = r / (1 - r) ^ 2`, version in a general ring with
-summable geometric series. For a version in a field, using division instead of `Ring.inverse`,
-see `tsum_coe_mul_geometric_of_norm_lt_one`. -/
-theorem tsum_coe_mul_geometric_of_norm_lt_one'
-    {r : 𝕜} (hr : ‖r‖ < 1) : (∑' n : ℕ, n * r ^ n : 𝕜) = r * (1 - r)⁻¹ʳ ^ 2 :=
-  (hasSum_coe_mul_geometric_of_norm_lt_one' hr).tsum_eq
-
-/-- If `‖r‖ < 1`, then `∑' n : ℕ, n * r ^ n = r / (1 - r) ^ 2`, `HasSum` version. -/
-theorem hasSum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
-    HasSum (fun n ↦ n * r ^ n : ℕ → 𝕜) (r / (1 - r) ^ 2) := by
-  convert! hasSum_coe_mul_geometric_of_norm_lt_one' hr using 1
-  simp [div_eq_mul_inv]
-
-/-- If `‖r‖ < 1`, then `∑' n : ℕ, n * r ^ n = r / (1 - r) ^ 2`. -/
-theorem tsum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
-    (∑' n : ℕ, n * r ^ n : 𝕜) = r / (1 - r) ^ 2 :=
-  (hasSum_coe_mul_geometric_of_norm_lt_one hr).tsum_eq
-
---- new
-
--- Question: does this belong here? is this the right name?
-theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {x : R} (h : ‖x‖ < 1) :
-    HasSum (fun n : ℕ ↦ (n.descFactorial j : R) * x ^ n)
-      ((j.factorial : R) * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
-  rw [← hasSum_nat_add_iff' j]
-  convert! (hasSum_choose_mul_geometric_of_norm_lt_one' j h).mul_left
-    ((j.factorial : R) * x ^ j) using 1
-  · funext n
-    symm
-    push_cast [Nat.descFactorial_eq_factorial_mul_choose]
-    rw [mul_assoc, ((Nat.cast_commute ((n + j).choose j) (x ^ j)).symm).left_comm, ← pow_add,
-      add_comm j n, mul_assoc]
-  · exact sub_eq_self.2 <| Finset.sum_eq_zero fun i hi ↦ by
-      simp [descFactorial_eq_zero_iff_lt.2 (Finset.mem_range.1 hi)]
-
 /-- If `‖x‖ < 1`, then `∑' n : ℕ, n ^ k * x ^ n` is given by the finite sum
 `∑ j ∈ range (k + 1), S(k, j) * j ! * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)`,
 where `S(k, j)` denotes the Stirling numbers of the second kind.
-
-Question: should you add here the note about genereal ring vs. field with division.
-Question: why isnt this named "coe" (hasSum_coe_pow_mul_geometric_of_norm_lt_one')
-as hasSum_coe_mul_geometric_of_norm_lt_one'
+To-do: add here the note about genereal ring vs. field with division.
 -/
 theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : R) ^ k * x ^ n)
@@ -610,7 +565,45 @@ theorem tsum_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r‖
       stirlingSecond k j * j.factorial * r ^ j / (1 - r) ^ (j + 1)) :=
   (hasSum_pow_mul_geometric_of_norm_lt_one k hr).tsum_eq
 
--- should this be deleted?
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n * r ^ n = r / (1 - r) ^ 2`, `HasSum` version in a general ring
+with summable geometric series. For a version in a field, using division instead of `Ring.inverse`,
+see `hasSum_coe_mul_geometric_of_norm_lt_one`. -/
+theorem hasSum_coe_mul_geometric_of_norm_lt_one'
+    {x : R} (h : ‖x‖ < 1) :
+    HasSum (fun n ↦ n * x ^ n : ℕ → R) (x * ((1 - x)⁻¹ʳ) ^ 2) := by
+  -- To-do: prove this using only generalization
+  have A : HasSum (fun (n : ℕ) ↦ (n + 1) * x ^ n) ((1 - x)⁻¹ʳ ^ 2) := by
+    convert! hasSum_choose_mul_geometric_of_norm_lt_one' 1 h with n
+    simp
+  have B : HasSum (fun (n : ℕ) ↦ x ^ n) ((1 - x)⁻¹ʳ) := hasSum_geom_series_inverse x h
+  convert! A.sub B using 1
+  · ext n
+    simp [add_mul]
+  · symm
+    calc (1 - x)⁻¹ʳ ^ 2 - (1 - x)⁻¹ʳ
+    _ = (1 - x)⁻¹ʳ ^ 2 - ((1 - x) * (1 - x)⁻¹ʳ) * (1 - x)⁻¹ʳ := by
+      simp [Ring.mul_inverse_cancel (1 - x) (isUnit_one_sub_of_norm_lt_one h)]
+    _ = x * (1 - x)⁻¹ʳ ^ 2 := by noncomm_ring
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n * r ^ n = r / (1 - r) ^ 2`, version in a general ring with
+summable geometric series. For a version in a field, using division instead of `Ring.inverse`,
+see `tsum_coe_mul_geometric_of_norm_lt_one`. -/
+theorem tsum_coe_mul_geometric_of_norm_lt_one'
+    {r : 𝕜} (hr : ‖r‖ < 1) : (∑' n : ℕ, n * r ^ n : 𝕜) = r * (1 - r)⁻¹ʳ ^ 2 :=
+  (hasSum_coe_mul_geometric_of_norm_lt_one' hr).tsum_eq
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n * r ^ n = r / (1 - r) ^ 2`, `HasSum` version. -/
+theorem hasSum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
+    HasSum (fun n ↦ n * r ^ n : ℕ → 𝕜) (r / (1 - r) ^ 2) := by
+  convert! hasSum_coe_mul_geometric_of_norm_lt_one' hr using 1
+  simp [div_eq_mul_inv]
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n * r ^ n = r / (1 - r) ^ 2`. -/
+theorem tsum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
+    (∑' n : ℕ, n * r ^ n : 𝕜) = r / (1 - r) ^ 2 :=
+  (hasSum_coe_mul_geometric_of_norm_lt_one hr).tsum_eq
+
+-- To-do: add docstrings
 theorem hasSum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : R) ^ 2 * x ^ n) (x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3) := by
   have h1 : ((1 - x)⁻¹ʳ) ^ 2 = (1 - x) * ((1 - x)⁻¹ʳ) ^ 3 := by
@@ -620,7 +613,7 @@ theorem hasSum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
   simp [Finset.sum_range_succ, stirlingSecond, Nat.factorial, h1]
   grind
 
------
+-- To-do: add missing 3 statements
 
 end MulGeometric
 

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -13,6 +13,7 @@ public import Mathlib.Analysis.Normed.Ring.InfiniteSum
 public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.Analysis.Normed.Order.Lattice
 public import Mathlib.Analysis.SpecificLimits.Basic
+public import Mathlib.Combinatorics.Enumerative.Stirling
 public import Mathlib.Data.List.TFAE
 public import Mathlib.Data.Nat.Choose.Bounds
 public import Mathlib.Data.Nat.Choose.Cast
@@ -549,47 +550,79 @@ theorem tsum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
     (∑' n : ℕ, n * r ^ n : 𝕜) = r / (1 - r) ^ 2 :=
   (hasSum_coe_mul_geometric_of_norm_lt_one hr).tsum_eq
 
-/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`, `HasSum` version in
-a general ring with summable geometric series. For a version in a field, using division instead
-of `Ring.inverse`, see `hasSum_sq_mul_geometric_of_norm_lt_one`. -/
-theorem hasSum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
-    HasSum (fun n : ℕ ↦ (n : R) ^ 2 * x ^ n) (x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3) := by
-  have A : HasSum (fun n : ℕ ↦ ((n + 2).choose 2 : R) * x ^ n) ((1 - x)⁻¹ʳ ^ 3) :=
-    hasSum_choose_mul_geometric_of_norm_lt_one' 2 h
-  have B : HasSum (fun (n : ℕ) ↦ (n + 1) * x ^ n) ((1 - x)⁻¹ʳ ^ 2) := by
-    convert! hasSum_choose_mul_geometric_of_norm_lt_one' 1 h with n
-    simp
-  have C : HasSum (fun n ↦ n * x ^ n : ℕ → R) (x * (1 - x)⁻¹ʳ ^ 2) :=
-    hasSum_coe_mul_geometric_of_norm_lt_one' h
-  convert! ((A.mul_left 2).sub (B.mul_left 2)).sub C using 1
-  · ext n
-    rw [← mul_assoc, Nat.two_mul_cast_choose_two, pow_two, cast_add, cast_ofNat]
-    noncomm_ring
-  · symm
-    calc 2 * (1 - x)⁻¹ʳ ^ 3 - 2 * (1 - x)⁻¹ʳ ^ 2 - x * (1 - x)⁻¹ʳ ^ 2
-    _ = 2 * (1 - x)⁻¹ʳ ^ 3 - 2 * (((1 - x) * (1 - x)⁻¹ʳ) * (1 - x)⁻¹ʳ ^ 2)
-        - x * (((1 - x) * (1 - x)⁻¹ʳ) * (1 - x)⁻¹ʳ ^ 2) := by
-      simp [Ring.mul_inverse_cancel (1 - x) (isUnit_one_sub_of_norm_lt_one h)]
-    _ = x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3 := by noncomm_ring
+theorem hasSum_descFactorial_mul_geometric_of_norm_lt_one' (j : ℕ) {x : R} (h : ‖x‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n.descFactorial j : R) * x ^ n)
+      ((j.factorial : R) * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
+  have hx : Commute (x ^ j) (((1 - x)⁻¹ʳ) ^ (j + 1)) := by
+    obtain ⟨u, hu⟩ := isUnit_one_sub_of_norm_lt_one h
+    have hxu : Commute x (u : R) := hu.symm ▸ (Commute.one_right x).sub_right (Commute.refl x)
+    simp [← hu, hxu.units_inv_right.pow_pow]
+  have A := ((hasSum_choose_mul_geometric_of_norm_lt_one' j h).mul_left
+    (j.factorial : R)).mul_right (x ^ j)
+  have Afun : (fun m : ℕ ↦ (j.factorial : R) * (((m + j).choose j : R) * x ^ m) * x ^ j)
+      = fun m : ℕ ↦ ((m + j).descFactorial j : R) * x ^ (m + j) := by
+    funext m
+    push_cast [Nat.descFactorial_eq_factorial_mul_choose]
+    simp only [pow_add, mul_assoc]
+  rw [Afun] at A
+  have B := (hasSum_nat_add_iff (f := fun n : ℕ ↦ (n.descFactorial j : R) * x ^ n) j).mp A
+  have hzero : ∑ i ∈ Finset.range j, (i.descFactorial j : R) * x ^ i = 0 :=
+    Finset.sum_eq_zero fun i hi ↦ by
+      simp [descFactorial_eq_zero_iff_lt.2 (Finset.mem_range.1 hi)]
+  simpa only [hzero, add_zero, mul_assoc, hx.symm.eq] using B
 
-/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`, version in a general
-ring with summable geometric series. For a version in a field, using division instead of
-`Ring.inverse`, see `tsum_sq_mul_geometric_of_norm_lt_one`. -/
-theorem tsum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
-    ∑' n : ℕ, (n : R) ^ 2 * x ^ n = x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3 :=
-  (hasSum_sq_mul_geometric_of_norm_lt_one' h).tsum_eq
+/-- If `‖x‖ < 1`, then `∑' n : ℕ, n ^ k * x ^ n` is given by the finite sum
+`∑ j ∈ range (k + 1), S(k, j) * j ! * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)`,
+where `S(k, j)` denotes the Stirling numbers of the second kind. -/
+theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n : R) ^ k * x ^ n)
+      (∑ j ∈ Finset.range (k + 1),
+        (stirlingSecond k j : R) * j.factorial * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
+  have hfun : (fun n : ℕ ↦ (n : R) ^ k * x ^ n) = fun n : ℕ ↦ ∑ j ∈ Finset.range (k + 1),
+      (stirlingSecond k j : R) * ((n.descFactorial j : R) * x ^ n) := by
+    funext n
+    rw [← Nat.cast_pow, Nat.pow_eq_sum_stirlingSecond_mul_descFactorial n k, Nat.cast_sum,
+      Finset.sum_mul]
+    simp only [Nat.cast_mul, mul_assoc]
+  have hval : (∑ j ∈ Finset.range (k + 1),
+        (stirlingSecond k j : R) * j.factorial * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1))
+      = ∑ j ∈ Finset.range (k + 1), (stirlingSecond k j : R)
+        * ((j.factorial : R) * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) := by
+    simp only [mul_assoc]
+  rw [hfun, hval]
+  exact hasSum_sum fun j _ ↦
+    (hasSum_descFactorial_mul_geometric_of_norm_lt_one' j h).mul_left _
 
-/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`,
-`HasSum` version. -/
-theorem hasSum_sq_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
-    HasSum (fun n : ℕ ↦ (n : 𝕜) ^ 2 * r ^ n) (r * (1 + r) / (1 - r) ^ 3) := by
-  convert! hasSum_sq_mul_geometric_of_norm_lt_one' hr using 1
+theorem tsum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {x : R} (h : ‖x‖ < 1) :
+    ∑' n : ℕ, (n : R) ^ k * x ^ n = (∑ j ∈ Finset.range (k + 1),
+      (stirlingSecond k j : R) * j.factorial * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1)) :=
+  (hasSum_pow_mul_geometric_of_norm_lt_one' k h).tsum_eq
+
+theorem hasSum_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n : 𝕜) ^ k * r ^ n)
+      (∑ j ∈ Finset.range (k + 1),
+        stirlingSecond k j * j.factorial * r ^ j / (1 - r) ^ (j + 1)) := by
+  convert! hasSum_pow_mul_geometric_of_norm_lt_one' k hr using 1
   simp [div_eq_mul_inv]
 
-/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`. -/
-theorem tsum_sq_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
-    ∑' n : ℕ, (n : 𝕜) ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3 :=
-  (hasSum_sq_mul_geometric_of_norm_lt_one hr).tsum_eq
+theorem tsum_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : 𝕜) ^ k * r ^ n = (∑ j ∈ Finset.range (k + 1),
+      stirlingSecond k j * j.factorial * r ^ j / (1 - r) ^ (j + 1)) :=
+  (hasSum_pow_mul_geometric_of_norm_lt_one k hr).tsum_eq
+
+theorem hasSum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n : R) ^ 2 * x ^ n) (x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3) := by
+  have h1 : (∑ j ∈ Finset.range (2 + 1),
+        (stirlingSecond 2 j : R) * j.factorial * x ^ j * ((1 - x)⁻¹ʳ) ^ (j + 1))
+      = x * ((1 - x)⁻¹ʳ) ^ 2 + 2 * (x ^ 2 * ((1 - x)⁻¹ʳ) ^ 3) := by
+    simp [Finset.sum_range_succ, stirlingSecond, Nat.factorial, mul_assoc]
+  have h2 : x * ((1 - x)⁻¹ʳ) ^ 2 + 2 * (x ^ 2 * ((1 - x)⁻¹ʳ) ^ 3)
+      = x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3 := by
+    calc x * ((1 - x)⁻¹ʳ) ^ 2 + 2 * (x ^ 2 * ((1 - x)⁻¹ʳ) ^ 3)
+        = x * (((1 - x) * (1 - x)⁻¹ʳ) * ((1 - x)⁻¹ʳ) ^ 2) + 2 * (x ^ 2 * ((1 - x)⁻¹ʳ) ^ 3) := by
+          grind [Ring.mul_inverse_cancel, isUnit_one_sub_of_norm_lt_one]
+      _ = x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3 := by grind
+  grind [hasSum_pow_mul_geometric_of_norm_lt_one']
 
 end MulGeometric
 

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -7,17 +7,15 @@ module
 
 public import Mathlib.Algebra.BigOperators.Module
 public import Mathlib.Algebra.Order.Field.Power
-public import Mathlib.Algebra.Polynomial.Monic
 public import Mathlib.Analysis.Asymptotics.Lemmas
 public import Mathlib.Analysis.Normed.Ring.InfiniteSum
 public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.Analysis.Normed.Order.Lattice
 public import Mathlib.Analysis.SpecificLimits.Basic
-public import Mathlib.Data.List.TFAE
 public import Mathlib.Combinatorics.Enumerative.Stirling
 public import Mathlib.Data.Nat.Choose.Bounds
+public import Mathlib.Data.Nat.Choose.Sum
 public import Mathlib.Order.Filter.AtTopBot.ModEq
-public import Mathlib.RingTheory.Polynomial.Pochhammer
 public import Mathlib.Tactic.NoncommRing
 
 /-!

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -574,19 +574,9 @@ see `hasSum_coe_mul_geometric_of_norm_lt_one`. -/
 theorem hasSum_coe_mul_geometric_of_norm_lt_one'
     {x : R} (h : ‖x‖ < 1) :
     HasSum (fun n ↦ n * x ^ n : ℕ → R) (x * ((1 - x)⁻¹ʳ) ^ 2) := by
-  -- To-do: prove this using only generalization
-  have A : HasSum (fun (n : ℕ) ↦ (n + 1) * x ^ n) ((1 - x)⁻¹ʳ ^ 2) := by
-    convert! hasSum_choose_mul_geometric_of_norm_lt_one' 1 h with n
-    simp
-  have B : HasSum (fun (n : ℕ) ↦ x ^ n) ((1 - x)⁻¹ʳ) := hasSum_geom_series_inverse x h
-  convert! A.sub B using 1
-  · ext n
-    simp [add_mul]
-  · symm
-    calc (1 - x)⁻¹ʳ ^ 2 - (1 - x)⁻¹ʳ
-    _ = (1 - x)⁻¹ʳ ^ 2 - ((1 - x) * (1 - x)⁻¹ʳ) * (1 - x)⁻¹ʳ := by
-      simp [Ring.mul_inverse_cancel (1 - x) (isUnit_one_sub_of_norm_lt_one h)]
-    _ = x * (1 - x)⁻¹ʳ ^ 2 := by noncomm_ring
+  convert! hasSum_pow_mul_geometric_of_norm_lt_one' 1 h using 1
+  · simp
+  · simp [Finset.sum_range_succ, stirlingSecond_self]
 
 /-- If `‖r‖ < 1`, then `∑' n : ℕ, n * r ^ n = r / (1 - r) ^ 2`, version in a general ring with
 summable geometric series. For a version in a field, using division instead of `Ring.inverse`,

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -604,9 +604,12 @@ theorem hasSum_sq_mul_geometric_of_norm_lt_one' {r : R} (h : ‖r‖ < 1) :
   have h1 : ((1 - r)⁻¹ʳ) ^ 2 = (1 - r) * ((1 - r)⁻¹ʳ) ^ 3 := by
     rw [pow_succ' _ 2, ← mul_assoc,
       Ring.mul_inverse_cancel _ (isUnit_one_sub_of_norm_lt_one h), one_mul]
-  convert! hasSum_pow_mul_geometric_of_norm_lt_one' 2 h using 1
-  simp [Finset.sum_range_succ, stirlingSecond, Nat.factorial, h1]
-  grind
+  have h2 : r * (1 + r) * ((1 - r)⁻¹ʳ) ^ 3
+      = r * ((1 - r)⁻¹ʳ) ^ 2 + 2 * r ^ 2 * ((1 - r)⁻¹ʳ) ^ 3 := by
+    rw [h1]
+    noncomm_ring
+  simpa [h2, Finset.sum_range_succ, stirlingSecond_one_right, stirlingSecond_self] using
+    hasSum_pow_mul_geometric_of_norm_lt_one' 2 h
 
 /-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`, version in a
 general ring with summable geometric series. For a version in a field, using division instead

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -605,9 +605,9 @@ theorem tsum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
   (hasSum_coe_mul_geometric_of_norm_lt_one hr).tsum_eq
 
 -- To-do: add docstrings
-theorem hasSum_sq_mul_geometric_of_norm_lt_one' {x : R} (h : ‖x‖ < 1) :
-    HasSum (fun n : ℕ ↦ (n : R) ^ 2 * x ^ n) (x * (1 + x) * ((1 - x)⁻¹ʳ) ^ 3) := by
-  have h1 : ((1 - x)⁻¹ʳ) ^ 2 = (1 - x) * ((1 - x)⁻¹ʳ) ^ 3 := by
+theorem hasSum_sq_mul_geometric_of_norm_lt_one' {r : R} (h : ‖r‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n : R) ^ 2 * r ^ n) (r * (1 + r) * ((1 - r)⁻¹ʳ) ^ 3) := by
+  have h1 : ((1 - r)⁻¹ʳ) ^ 2 = (1 - r) * ((1 - r)⁻¹ʳ) ^ 3 := by
     rw [pow_succ' _ 2, ← mul_assoc,
       Ring.mul_inverse_cancel _ (isUnit_one_sub_of_norm_lt_one h), one_mul]
   convert! hasSum_pow_mul_geometric_of_norm_lt_one' 2 h using 1

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -545,13 +545,19 @@ theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {r : R} (h : ‖r‖ 
   simpa only [hfun, mul_assoc] using hasSum_sum fun j _ ↦
     (hasSum_descFactorial_mul_geometric_of_norm_lt_one' j h).mul_left _
 
--- To-do: missing docstrings
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ k * r ^ n` is given by the finite sum
+`∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)`, where `S(k, j)` denotes the
+Stirling numbers of the second kind. Version in a general ring with summable geometric series.
+For a version in a field, using division instead of `Ring.inverse`, see
+`tsum_pow_mul_geometric_of_norm_lt_one`. -/
 theorem tsum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {r : R} (h : ‖r‖ < 1) :
     ∑' n : ℕ, (n : R) ^ k * r ^ n = (∑ j ∈ Finset.range (k + 1),
       (stirlingSecond k j : R) * j.factorial * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)) :=
   (hasSum_pow_mul_geometric_of_norm_lt_one' k h).tsum_eq
 
--- To-do: missing docstrings
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ k * r ^ n` is given by the finite sum
+`∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j / (1 - r) ^ (j + 1)`, where `S(k, j)` denotes the
+Stirling numbers of the second kind. `HasSum` version. -/
 theorem hasSum_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : 𝕜) ^ k * r ^ n)
       (∑ j ∈ Finset.range (k + 1),
@@ -559,7 +565,9 @@ theorem hasSum_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r�
   convert! hasSum_pow_mul_geometric_of_norm_lt_one' k hr using 1
   simp [div_eq_mul_inv]
 
--- To-do: missing docstrings
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ k * r ^ n` is given by the finite sum
+`∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j / (1 - r) ^ (j + 1)`, where `S(k, j)` denotes the
+Stirling numbers of the second kind. -/
 theorem tsum_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
     ∑' n : ℕ, (n : 𝕜) ^ k * r ^ n = (∑ j ∈ Finset.range (k + 1),
       stirlingSecond k j * j.factorial * r ^ j / (1 - r) ^ (j + 1)) :=
@@ -603,7 +611,8 @@ theorem tsum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
     (∑' n : ℕ, n * r ^ n : 𝕜) = r / (1 - r) ^ 2 :=
   (hasSum_coe_mul_geometric_of_norm_lt_one hr).tsum_eq
 
--- To-do: add docstrings
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`, `HasSum` version
+in a general ring with summable geometric series, using `Ring.inverse` instead of division. -/
 theorem hasSum_sq_mul_geometric_of_norm_lt_one' {r : R} (h : ‖r‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : R) ^ 2 * r ^ n) (r * (1 + r) * ((1 - r)⁻¹ʳ) ^ 3) := by
   have h1 : ((1 - r)⁻¹ʳ) ^ 2 = (1 - r) * ((1 - r)⁻¹ʳ) ^ 3 := by

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -13,9 +13,11 @@ public import Mathlib.Analysis.Normed.Ring.InfiniteSum
 public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.Analysis.Normed.Order.Lattice
 public import Mathlib.Analysis.SpecificLimits.Basic
+public import Mathlib.Data.List.TFAE
 public import Mathlib.Combinatorics.Enumerative.Stirling
 public import Mathlib.Data.Nat.Choose.Bounds
 public import Mathlib.Order.Filter.AtTopBot.ModEq
+public import Mathlib.RingTheory.Polynomial.Pochhammer
 public import Mathlib.Tactic.NoncommRing
 
 /-!

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -528,10 +528,10 @@ theorem summable_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr : ‖r�
   simp [ha n, add_mul, sum_mul]
 
 /-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ k * r ^ n` is given by the finite sum
-`∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)`,
-where `S(k, j)` denotes the Stirling numbers of the second kind.
-`HasSum` version in a general ring with summable geometric series. For a version in a field,
-using division instead of `Ring.inverse`, see `hasSum_pow_mul_geometric_of_norm_lt_one`. -/
+`∑ j ∈ range (k + 1), S(k, j) * j ! * r ^ j * ((1 - r)⁻¹ʳ) ^ (j + 1)`, where `S(k, j)` denotes the
+Stirling numbers of the second kind. `HasSum` version in a general ring with summable geometric
+series. For a version in a field, using division instead of `Ring.inverse`, see
+`hasSum_pow_mul_geometric_of_norm_lt_one`. -/
 theorem hasSum_pow_mul_geometric_of_norm_lt_one' (k : ℕ) {r : R} (h : ‖r‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : R) ^ k * r ^ n)
       (∑ j ∈ Finset.range (k + 1),

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -597,7 +597,8 @@ theorem tsum_coe_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
   (hasSum_coe_mul_geometric_of_norm_lt_one hr).tsum_eq
 
 /-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`, `HasSum` version
-in a general ring with summable geometric series, using `Ring.inverse` instead of division. -/
+in a general ring with summable geometric series. For a version in a field, using division
+instead of `Ring.inverse`, see `hasSum_sq_mul_geometric_of_norm_lt_one`. -/
 theorem hasSum_sq_mul_geometric_of_norm_lt_one' {r : R} (h : ‖r‖ < 1) :
     HasSum (fun n : ℕ ↦ (n : R) ^ 2 * r ^ n) (r * (1 + r) * ((1 - r)⁻¹ʳ) ^ 3) := by
   have h1 : ((1 - r)⁻¹ʳ) ^ 2 = (1 - r) * ((1 - r)⁻¹ʳ) ^ 3 := by
@@ -607,7 +608,24 @@ theorem hasSum_sq_mul_geometric_of_norm_lt_one' {r : R} (h : ‖r‖ < 1) :
   simp [Finset.sum_range_succ, stirlingSecond, Nat.factorial, h1]
   grind
 
--- To-do: add missing 3 statements
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`, version in a
+general ring with summable geometric series. For a version in a field, using division instead
+of `Ring.inverse`, see `tsum_sq_mul_geometric_of_norm_lt_one`. -/
+theorem tsum_sq_mul_geometric_of_norm_lt_one' {r : R} (h : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : R) ^ 2 * r ^ n = r * (1 + r) * ((1 - r)⁻¹ʳ) ^ 3 :=
+  (hasSum_sq_mul_geometric_of_norm_lt_one' h).tsum_eq
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`,
+`HasSum` version. -/
+theorem hasSum_sq_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ ↦ (n : 𝕜) ^ 2 * r ^ n) (r * (1 + r) / (1 - r) ^ 3) := by
+  convert! hasSum_sq_mul_geometric_of_norm_lt_one' hr using 1
+  simp [div_eq_mul_inv]
+
+/-- If `‖r‖ < 1`, then `∑' n : ℕ, n ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3`. -/
+theorem tsum_sq_mul_geometric_of_norm_lt_one {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : 𝕜) ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3 :=
+  (hasSum_sq_mul_geometric_of_norm_lt_one hr).tsum_eq
 
 end MulGeometric
 

--- a/Mathlib/Combinatorics/Enumerative/Stirling.lean
+++ b/Mathlib/Combinatorics/Enumerative/Stirling.lean
@@ -34,6 +34,12 @@ The Stirling numbers of the second kind, represent the number of ways to partiti
 * `Nat.stirlingSecond`: the number of ways to partition `n` distinct elements into `k` non-empty
   subsets, defined by the recursive relationship it satisfies.
 
+## Main results
+
+* `Nat.pow_eq_sum_stirlingSecond_mul_descFactorial`: every power `n ^ k` is a linear combination
+  of the descending factorials `Nat.descFactorial` with the Stirling numbers of the second kind
+  as coefficients.
+
 ## References
 
 * [Knuth, *The Art of Computer Programming*, Volume 1, §1.2.6][knuth1997]
@@ -170,11 +176,8 @@ theorem stirlingSecond_succ_self_left (n : ℕ) :
     rw [stirlingSecond_succ_succ, ih, stirlingSecond_self, mul_one,
       Nat.choose_succ_succ (n + 1), Nat.choose_one_right]
 
-theorem descFactorial_mul_self (n j : ℕ) :
-    n.descFactorial j * n = n.descFactorial (j + 1) + j * n.descFactorial j := by
-  rcases le_or_gt j n with h | h <;>
-    grind [descFactorial_succ, add_mul, descFactorial_eq_zero_iff_lt]
-
+/-- Every power `n ^ k` is a linear combination of the descending factorials `n.descFactorial j`
+with the Stirling numbers of the second kind `stirlingSecond k j` as coefficients. -/
 theorem pow_eq_sum_stirlingSecond_mul_descFactorial (n k : ℕ) :
     n ^ k = ∑ j ∈ Finset.range (k + 1), stirlingSecond k j * n.descFactorial j := by
   induction k with
@@ -183,13 +186,15 @@ theorem pow_eq_sum_stirlingSecond_mul_descFactorial (n k : ℕ) :
     have : ∑ j ∈ Finset.range (k + 1), stirlingSecond k j * (j * n.descFactorial j)
         = ∑ j ∈ Finset.range (k + 1),
             (j + 1) * (stirlingSecond k (j + 1) * n.descFactorial (j + 1)) := by
-      grind [Finset.sum_range_succ' (fun j ↦ stirlingSecond k j * (j * n.descFactorial j)) k,
+      rw [Finset.sum_range_succ' (fun j ↦ stirlingSecond k j * (j * n.descFactorial j)) k,
         Finset.sum_range_succ (fun j ↦ (j + 1) * (stirlingSecond k (j + 1) *
-        n.descFactorial (j + 1))) k, stirlingSecond_eq_zero_of_lt k.lt_add_one]
+          n.descFactorial (j + 1))) k,
+        stirlingSecond_eq_zero_of_lt k.lt_add_one]
+      simp [mul_left_comm]
     rw [pow_succ, ih, Finset.sum_mul,
       Finset.sum_range_succ' (fun j ↦ stirlingSecond (k + 1) j * n.descFactorial j) (k + 1)]
     simp only [mul_assoc, descFactorial_mul_self, mul_add, Finset.sum_add_distrib, this,
       stirlingSecond_succ_succ, add_mul, stirlingSecond_succ_zero, zero_mul, add_zero]
-    grind
+    exact add_comm _ _
 
 end Nat

--- a/Mathlib/Combinatorics/Enumerative/Stirling.lean
+++ b/Mathlib/Combinatorics/Enumerative/Stirling.lean
@@ -5,6 +5,7 @@ Authors: Beibei Xiong, Yu Shao, Weijie Jiang, Zhengfeng Yang
 -/
 module
 
+public import Mathlib.Algebra.BigOperators.Ring.Finset
 public import Mathlib.Data.Nat.Factorial.Basic
 public import Mathlib.Data.Nat.Choose.Basic
 public import Mathlib.Tactic.NormNum.Inv
@@ -168,5 +169,27 @@ theorem stirlingSecond_succ_self_left (n : ℕ) :
   | succ n ih =>
     rw [stirlingSecond_succ_succ, ih, stirlingSecond_self, mul_one,
       Nat.choose_succ_succ (n + 1), Nat.choose_one_right]
+
+theorem descFactorial_mul_self (n j : ℕ) :
+    n.descFactorial j * n = n.descFactorial (j + 1) + j * n.descFactorial j := by
+  rcases le_or_gt j n with h | h <;>
+    grind [descFactorial_succ, add_mul, descFactorial_eq_zero_iff_lt]
+
+theorem pow_eq_sum_stirlingSecond_mul_descFactorial (n k : ℕ) :
+    n ^ k = ∑ j ∈ Finset.range (k + 1), stirlingSecond k j * n.descFactorial j := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have : ∑ j ∈ Finset.range (k + 1), stirlingSecond k j * (j * n.descFactorial j)
+        = ∑ j ∈ Finset.range (k + 1),
+            (j + 1) * (stirlingSecond k (j + 1) * n.descFactorial (j + 1)) := by
+      grind [Finset.sum_range_succ' (fun j ↦ stirlingSecond k j * (j * n.descFactorial j)) k,
+        Finset.sum_range_succ (fun j ↦ (j + 1) * (stirlingSecond k (j + 1) *
+        n.descFactorial (j + 1))) k, stirlingSecond_eq_zero_of_lt k.lt_add_one]
+    rw [pow_succ, ih, Finset.sum_mul,
+      Finset.sum_range_succ' (fun j ↦ stirlingSecond (k + 1) j * n.descFactorial j) (k + 1)]
+    simp only [mul_assoc, descFactorial_mul_self, mul_add, Finset.sum_add_distrib, this,
+      stirlingSecond_succ_succ, add_mul, stirlingSecond_succ_zero, zero_mul, add_zero]
+    grind
 
 end Nat

--- a/Mathlib/Data/Nat/Choose/Cast.lean
+++ b/Mathlib/Data/Nat/Choose/Cast.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.Nat.Factorial.Cast
 # Cast of binomial coefficients
 
 This file allows calculating the binomial coefficient `a.choose b` as an element of a division ring
-of characteristic `0`.
+of characteristic `0`, and provides a division-free variant of `a.choose 2` valid in any ring.
 -/
 
 public section
@@ -37,6 +37,15 @@ theorem cast_add_choose {a b : ℕ} : ((a + b).choose a : K) = (a + b)! / (a ! *
   rw [cast_choose K (le_add_right _ _), Nat.add_sub_cancel_left]
 
 end DivisionSemiring
+
+section Ring
+variable [Ring K]
+
+theorem two_mul_cast_choose_two (a : ℕ) : 2 * (a.choose 2 : K) = a * (a - 1) := by
+  rw [← cast_descFactorial_two, descFactorial_eq_factorial_mul_choose, factorial_two, cast_mul,
+    cast_ofNat]
+
+end Ring
 
 section DivisionRing
 variable [DivisionRing K] [NeZero (2 : K)]

--- a/Mathlib/Data/Nat/Choose/Cast.lean
+++ b/Mathlib/Data/Nat/Choose/Cast.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.Nat.Factorial.Cast
 # Cast of binomial coefficients
 
 This file allows calculating the binomial coefficient `a.choose b` as an element of a division ring
-of characteristic `0`, and provides a division-free variant of `a.choose 2` valid in any ring.
+of characteristic `0`.
 -/
 
 public section
@@ -37,15 +37,6 @@ theorem cast_add_choose {a b : ℕ} : ((a + b).choose a : K) = (a + b)! / (a ! *
   rw [cast_choose K (le_add_right _ _), Nat.add_sub_cancel_left]
 
 end DivisionSemiring
-
-section Ring
-variable [Ring K]
-
-theorem two_mul_cast_choose_two (a : ℕ) : 2 * (a.choose 2 : K) = a * (a - 1) := by
-  rw [← cast_descFactorial_two, descFactorial_eq_factorial_mul_choose, factorial_two, cast_mul,
-    cast_ofNat]
-
-end Ring
 
 section DivisionRing
 variable [DivisionRing K] [NeZero (2 : K)]

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -374,6 +374,12 @@ lemma descFactorial_pos {n k : ℕ} : 0 < n.descFactorial k ↔ k ≤ n := by si
 
 alias ⟨_, descFactorial_of_lt⟩ := descFactorial_eq_zero_iff_lt
 
+theorem descFactorial_mul_self (n j : ℕ) :
+    n.descFactorial j * n = n.descFactorial (j + 1) + j * n.descFactorial j := by
+  rcases le_or_gt j n with h | h
+  · rw [descFactorial_succ, ← Nat.add_mul, Nat.sub_add_cancel h, Nat.mul_comm]
+  · simp [descFactorial_of_lt h]
+
 theorem add_descFactorial_eq_ascFactorial (n : ℕ) : ∀ k : ℕ,
     (n + k).descFactorial k = (n + 1).ascFactorial k
   | 0 => by rw [ascFactorial_zero, descFactorial_zero]

--- a/Mathlib/InformationTheory/Coding/KraftMcMillan.lean
+++ b/Mathlib/InformationTheory/Coding/KraftMcMillan.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Data.List.Basic
 public import Mathlib.Data.Finset.Basic
 public import Mathlib.Data.Real.Basic
+public import Mathlib.Algebra.BigOperators.Fin
 public import Mathlib.Algebra.BigOperators.Pi
 public import Mathlib.Data.Fintype.Card
 public import Mathlib.Data.Fintype.BigOperators

--- a/Mathlib/Topology/Instances/CantorSet.lean
+++ b/Mathlib/Topology/Instances/CantorSet.lean
@@ -7,6 +7,7 @@ Filippo A. E. Nuccio
 -/
 module
 
+public import Mathlib.Algebra.CharP.Defs
 public import Mathlib.Analysis.Real.OfDigits
 public import Mathlib.Data.Stream.Init
 public import Mathlib.Topology.Algebra.GroupWithZero


### PR DESCRIPTION
#41498 deletes the `ascPochhammer`-based proof of `summable_pow_mul_geometric_of_norm_lt_one`, which was the last user of the `RingTheory.Polynomial.Pochhammer` and `Algebra.Polynomial.Monic` imports in `Analysis/SpecificLimits/Normed.lean`. This PR removes both imports.

A number of downstream files were using content from these imports transitively; they now import what they use directly (see changed files).

---

- [ ] depends on: #41498
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
