### PR TITLE
feat(RingTheory/ClassGroup): add mulEquiv_mk0

### DIFF
--- a/Mathlib/RingTheory/ClassGroup/Basic.lean
+++ b/Mathlib/RingTheory/ClassGroup/Basic.lean
@@ -466,4 +466,47 @@ noncomputable def ClassGroup.mulEquiv {R' : Type*} [CommRing R'] [IsDomain R'] (
         (FractionalIdeal.map_ringEquivOfRingEquiv_toPrincipalIdeal g)).trans
       (ClassGroup.equiv (FractionRing R')).symm)
 
+/-- The class-group equivalence induced by a ring equivalence sends the class of a nonzero ideal
+to the class of its image. -/
+@[simp 1100]
+theorem ClassGroup.mulEquiv_mk0 {S : Type*} [CommRing S] [IsDedekindDomain R]
+    [IsDedekindDomain S] (e : R ≃+* S) (I : (Ideal R)⁰) :
+    ClassGroup.mulEquiv e (ClassGroup.mk0 I) =
+      ClassGroup.mk0 ⟨I.1.map e,
+        by
+          rw [mem_nonZeroDivisors_iff_ne_zero]
+          exact (Ideal.map_eq_bot_iff_of_injective e.injective).not.mpr
+            (mem_nonZeroDivisors_iff_ne_zero.mp I.2)⟩ := by
+  letI : RingHomInvPair (e : R →+* S) e.symm :=
+    RingHomInvPair.of_ringEquiv e
+  letI : RingHomInvPair (e.symm : S →+* R) e :=
+    RingHomInvPair.of_ringEquiv_symm e
+  apply (ClassGroup.equiv (FractionRing S)).injective
+  simp only [ClassGroup.mulEquiv_apply, ClassGroup.equiv_mk0, QuotientGroup.mk'_apply,
+    QuotientGroup.congr_mk, MulEquiv.apply_symm_apply]
+  congr 1
+  ext x
+  change x ∈ Submodule.map
+      (IsFractionRing.semilinearEquivOfRingEquiv (FractionRing R) (FractionRing S) e).toLinearMap
+      (IsLocalization.coeSubmodule (FractionRing R) (I : Ideal R)) ↔
+    x ∈ IsLocalization.coeSubmodule (FractionRing S) (Ideal.map e (I : Ideal R))
+  rw [Submodule.mem_map, IsLocalization.mem_coeSubmodule]
+  constructor
+  · rintro ⟨z, hz, hzx⟩
+    obtain ⟨r, hr, hrz⟩ :=
+      (IsLocalization.mem_coeSubmodule (FractionRing R) (I : Ideal R)).mp hz
+    refine ⟨e r, (Ideal.mem_map_of_equiv e (e r)).mpr ⟨r, hr, rfl⟩, ?_⟩
+    rw [← hzx, ← hrz]
+    exact (IsFractionRing.semilinearEquivOfRingEquiv_algebraMap
+      (FractionRing R) (FractionRing S) e r).symm
+  · rintro ⟨s, hs, hsx⟩
+    obtain ⟨r, hr, hrs⟩ :=
+      (Ideal.mem_map_iff_of_surjective e e.surjective).mp hs
+    refine ⟨algebraMap R (FractionRing R) r,
+      (IsLocalization.mem_coeSubmodule (FractionRing R) (I : Ideal R)).mpr
+        ⟨r, hr, rfl⟩, ?_⟩
+    rw [← hsx, ← hrs]
+    exact IsFractionRing.semilinearEquivOfRingEquiv_algebraMap
+      (FractionRing R) (FractionRing S) e r
+
 end MulEquiv


### PR DESCRIPTION
Add `ClassGroup.mulEquiv_mk0`: the class-group isomorphism induced by a ring equivalence `e : R ≃+* S` sends `ClassGroup.mk0 I` to `ClassGroup.mk0 (I.map e)`.

`ClassGroup.mulEquiv` is currently only characterized through the `FractionRing` comparison equivalences, so any concrete computation has to unfold `ClassGroup.equiv` and chase fractional ideals through `IsFractionRing.semilinearEquivOfRingEquiv` by hand. This lemma states the expected behaviour on generators — classes of nonzero ideals — and is marked `@[simp 1100]` so that transporting class-group facts along a ring equivalence becomes a `simp` step.

**Downstream use.** This came out of a formalization of Riemann–Roch for algebraic function fields (announced in `#AI authored projects > Riemann–Roch for function fields`). There the group law on a Weierstrass elliptic curve is compared with the degree-zero class group, and the comparison is set up along a ring equivalence between two coordinate presentations; without this lemma the transport is several lines of manual fractional-ideal chasing at each use site.

The proof is by injectivity of `ClassGroup.equiv (FractionRing S)`, reducing to the statement that the semilinear equivalence maps `coeSubmodule` of `I` onto `coeSubmodule` of `I.map e`.

AI usage: LLM-generated, disclosed per the AI policy.
