### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Dimension/Torsion/Finite): a torsion module has rank zero

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Torsion/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Torsion/Finite.lean
@@ -15,14 +15,26 @@ public import Mathlib.LinearAlgebra.Dimension.Finite
 
 public section
 
+/-- A torsion module has rank zero. -/
+theorem Module.IsTorsion.rank_eq_zero {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
+    [Nontrivial R] (h : IsTorsion R M) : Module.rank R M = 0 := by
+  by_contra! h'
+  obtain ⟨f, hf⟩ := by rwa [← Cardinal.one_le_iff_ne_zero, one_le_rank_iff] at h'
+  simpa [← map_smul, zero_notMem_nonZeroDivisors, hf] using @h (f 1)
+
+theorem Module.IsTorsion.finrank_eq_zero {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
+    [Nontrivial R] (h : IsTorsion R M) : finrank R M = 0 :=
+  finrank_eq_zero_of_rank_eq_zero h.rank_eq_zero
+
 variable {R M : Type*} [CommRing R] [IsDomain R] [AddCommGroup M] [Module R M]
 
-lemma rank_eq_zero_iff_isTorsion : Module.rank R M = 0 ↔ Module.IsTorsion R M := by
-  rw [Module.IsTorsion, rank_eq_zero_iff]
-  simp [mem_nonZeroDivisors_iff_ne_zero]
+lemma Module.rank_eq_zero_iff_isTorsion : Module.rank R M = 0 ↔ Module.IsTorsion R M := by
+  simp [IsTorsion, rank_eq_zero_iff]
+
+@[deprecated (since := "2026-07-14")] alias
+rank_eq_zero_iff_isTorsion := Module.rank_eq_zero_iff_isTorsion
 
 /-- The `StrongRankCondition` is automatic. See `commRing_strongRankCondition`. -/
 theorem Module.finrank_eq_zero_iff_isTorsion [StrongRankCondition R] [Module.Finite R M] :
     finrank R M = 0 ↔ Module.IsTorsion R M := by
-  rw [← rank_eq_zero_iff_isTorsion (R := R), ← finrank_eq_rank]
-  norm_cast
+  simp [← rank_eq_zero_iff_isTorsion (R := R), ← finrank_eq_rank]


### PR DESCRIPTION
Also put `rank_eq_zero_iff_isTorsion` in the `Module` namespace.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

follow up on #41697

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
