### PR TITLE
chore(Algebra/*/NonUnital*): split nonassoc and assoc nonunital `center` instances

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -1094,8 +1094,10 @@ theorem coe_center : (center R A : Set A) = Set.center A :=
   rfl
 
 /-- The center of a non-unital algebra is commutative and associative -/
-instance center.instNonUnitalCommSemiring : NonUnitalCommSemiring (center R A) :=
-  inferInstanceAs <| NonUnitalCommSemiring (NonUnitalSubsemiring.center A)
+instance (priority := 75) center.instNonUnitalCommSemiring :
+    NonUnitalCommSemiring (center R A) where
+  mul_assoc := Subsemigroup.center.commSemigroup.mul_assoc
+  mul_comm := Subsemigroup.center.commSemigroup.mul_comm
 
 instance center.instNonUnitalCommRing {A : Type*} [NonUnitalNonAssocRing A] [Module R A]
     [IsScalarTower R A A] [SMulCommClass R A A] : NonUnitalCommRing (center R A) :=
@@ -1121,8 +1123,15 @@ end NonUnitalNonAssocSemiring
 variable (R A : Type*) [CommSemiring R] [NonUnitalSemiring A] [Module R A] [IsScalarTower R A A]
   [SMulCommClass R A A]
 
--- no instance diamond, as the `npow` field isn't present in the non-unital case.
-example : center.instNonUnitalCommSemiring.toNonUnitalSemiring =
+/-- When the ambient algebra is associative, use the inherited subsemiring structure so that
+positive powers agree definitionally with the ambient powers. -/
+instance center.instNonUnitalCommSemiringOfNonUnitalSemiring :
+    NonUnitalCommSemiring (center R A) where
+  __ := NonUnitalSubsemiringClass.toNonUnitalSemiring (center R A)
+  mul_comm := Subsemigroup.center.commSemigroup.mul_comm
+
+-- no instance diamond
+example : (inferInstance : NonUnitalCommSemiring (center R A)).toNonUnitalSemiring =
     NonUnitalSubsemiringClass.toNonUnitalSemiring (center R A) := by
   with_reducible_and_instances rfl
 

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -1134,42 +1134,79 @@ end iSupLift
 
 section Center
 
-variable (R A)
-variable [IsScalarTower R A A] [SMulCommClass R A A]
+section NonUnitalNonAssocSemiring
+
+variable {R₀ A₀ : Type*}
+variable [CommSemiring R₀] [NonUnitalNonAssocSemiring A₀] [StarRing A₀] [Module R₀ A₀]
+variable (R₀ A₀)
+variable [IsScalarTower R₀ A₀ A₀] [SMulCommClass R₀ A₀ A₀]
 
 /-- The center of a non-unital star algebra is the set of elements which commute with every element.
 They form a non-unital star subalgebra. -/
-def center : NonUnitalStarSubalgebra R A where
-  toNonUnitalSubalgebra := NonUnitalSubalgebra.center R A
+def center : NonUnitalStarSubalgebra R₀ A₀ where
+  toNonUnitalSubalgebra := NonUnitalSubalgebra.center R₀ A₀
   star_mem' := Set.star_mem_center
 
 @[norm_cast]
-theorem coe_center : (center R A : Set A) = Set.center A :=
+theorem coe_center : (center R₀ A₀ : Set A₀) = Set.center A₀ :=
   rfl
 
 @[simp]
 theorem center_toNonUnitalSubalgebra :
-    (center R A).toNonUnitalSubalgebra = NonUnitalSubalgebra.center R A :=
+    (center R₀ A₀).toNonUnitalSubalgebra = NonUnitalSubalgebra.center R₀ A₀ :=
   rfl
 
+variable {R₀ A₀}
+
+instance (priority := 75) instNonUnitalCommSemiring : NonUnitalCommSemiring (center R₀ A₀) where
+  __ := NonUnitalSubsemiringClass.toNonUnitalNonAssocSemiring (center R₀ A₀)
+  __ := Subsemigroup.center.commSemigroup.toCommMagma
+  mul_assoc := Subsemigroup.center.commSemigroup.mul_assoc
+
+end NonUnitalNonAssocSemiring
+
+section NonUnitalSemiring
+
+variable {R₀ A₀ : Type*}
+variable [CommSemiring R₀] [NonUnitalSemiring A₀] [StarRing A₀] [Module R₀ A₀]
+variable [IsScalarTower R₀ A₀ A₀] [SMulCommClass R₀ A₀ A₀]
+
+instance instNonUnitalCommSemiringOfNonUnitalSemiring : NonUnitalCommSemiring (center R₀ A₀) where
+  __ := NonUnitalSubsemiringClass.toNonUnitalSemiring (center R₀ A₀)
+  mul_comm := Subsemigroup.center.commSemigroup.mul_comm
+
 @[simp]
-theorem center_eq_top (A : Type*) [StarRing R] [NonUnitalCommSemiring A] [StarRing A] [Module R A]
-    [IsScalarTower R A A] [SMulCommClass R A A] [StarModule R A] : center R A = ⊤ :=
-  SetLike.coe_injective (Set.center_eq_univ A)
+theorem center_eq_top (A₀ : Type*) [StarRing R₀] [NonUnitalCommSemiring A₀] [StarRing A₀]
+    [Module R₀ A₀] [IsScalarTower R₀ A₀ A₀] [SMulCommClass R₀ A₀ A₀]
+    [StarModule R₀ A₀] : center R₀ A₀ = ⊤ :=
+  SetLike.coe_injective (Set.center_eq_univ A₀)
 
-variable {R A}
-
-instance instNonUnitalCommSemiring : NonUnitalCommSemiring (center R A) :=
-  fast_instance% NonUnitalSubalgebra.center.instNonUnitalCommSemiring
-
-instance instNonUnitalCommRing {A : Type*} [NonUnitalRing A] [StarRing A] [Module R A]
-    [IsScalarTower R A A] [SMulCommClass R A A] : NonUnitalCommRing (center R A) :=
-  fast_instance% NonUnitalSubalgebra.center.instNonUnitalCommRing
-
-theorem mem_center_iff {a : A} : a ∈ center R A ↔ ∀ b : A, b * a = a * b :=
+theorem mem_center_iff {a : A₀} : a ∈ center R₀ A₀ ↔ ∀ b : A₀, b * a = a * b :=
   Subsemigroup.mem_center_iff
 
-protected theorem center_prod [IsScalarTower R B B] [SMulCommClass R B B] :
+end NonUnitalSemiring
+
+section NonUnitalRing
+
+variable {R₀ A₀ : Type*}
+variable [CommSemiring R₀] [NonUnitalRing A₀] [StarRing A₀] [Module R₀ A₀]
+variable [IsScalarTower R₀ A₀ A₀] [SMulCommClass R₀ A₀ A₀]
+
+instance instNonUnitalCommRing : NonUnitalCommRing (center R₀ A₀) where
+  __ := NonUnitalSubsemiringClass.toNonUnitalSemiring (center R₀ A₀)
+  __ := NonUnitalSubalgebra.center.instNonUnitalCommRing.toNonUnitalRing
+  mul_comm := Subsemigroup.center.commSemigroup.mul_comm
+
+-- no instance diamond
+example :
+    ((inferInstance : NonUnitalCommRing (center R₀ A₀)).toNonUnitalSemiring) =
+      (NonUnitalSubsemiringClass.toNonUnitalSemiring (center R₀ A₀)) := by
+  with_reducible_and_instances rfl
+
+end NonUnitalRing
+
+protected theorem center_prod [IsScalarTower R A A] [SMulCommClass R A A]
+  [IsScalarTower R B B] [SMulCommClass R B B] :
     center R (A × B) = prod (center R A) (center R B) :=
   SetLike.coe_injective Set.center_prod
 

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -356,10 +356,9 @@ theorem center_toNonUnitalSubsemiring :
   rfl
 
 /-- The center is commutative and associative. -/
-instance center.instNonUnitalCommRing : NonUnitalCommRing (center R) where
-  __ : NonUnitalCommSemiring (center R) :=
-    inferInstanceAs <| NonUnitalCommSemiring (NonUnitalSubsemiring.center R)
-  __ := (inferInstance : NonUnitalNonAssocRing (center R))
+instance (priority := 75) center.instNonUnitalCommRing : NonUnitalCommRing (center R) where
+  mul_assoc := Subsemigroup.center.commSemigroup.mul_assoc
+  mul_comm := Subsemigroup.center.commSemigroup.mul_comm
 
 variable {R}
 
@@ -377,8 +376,14 @@ end NonUnitalNonAssocRing
 section NonUnitalRing
 variable [NonUnitalRing R]
 
+/-- When the ambient ring is associative, use the inherited subring structure so that positive
+powers agree definitionally with the ambient powers. -/
+instance center.instNonUnitalCommRingOfNonUnitalRing : NonUnitalCommRing (center R) where
+  __ := NonUnitalSubringClass.toNonUnitalRing (center R)
+  mul_comm := Subsemigroup.center.commSemigroup.mul_comm
+
 -- no instance diamond, unlike the unital version
-example : (center.instNonUnitalCommRing _).toNonUnitalRing =
+example : ((inferInstance : NonUnitalCommRing (center R)).toNonUnitalRing) =
       NonUnitalSubringClass.toNonUnitalRing (center R) := by
   with_reducible_and_instances rfl
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -237,9 +237,10 @@ theorem center_toSubsemigroup :
   rfl
 
 /-- The center is commutative and associative. -/
-instance center.instNonUnitalCommSemiring : NonUnitalCommSemiring (center R) :=
-  { Subsemigroup.center.commSemigroup,
-    NonUnitalSubsemiringClass.toNonUnitalNonAssocSemiring (center R) with }
+instance (priority := 75) center.instNonUnitalCommSemiring : NonUnitalCommSemiring (center R) where
+  __ := NonUnitalSubsemiringClass.toNonUnitalNonAssocSemiring (center R)
+  __ := Subsemigroup.center.commSemigroup.toCommMagma
+  mul_assoc := Subsemigroup.center.commSemigroup.mul_assoc
 
 /-- A point-free means of proving membership in the center, for a non-associative ring.
 
@@ -269,10 +270,18 @@ end NonUnitalNonAssocSemiring
 
 section NonUnitalSemiring
 
-set_option backward.isDefEq.respectTransparency false in
+variable {R : Type*} [NonUnitalSemiring R]
+
+/-- When the ambient semiring is associative, use the inherited subsemiring structure so that
+positive powers agree definitionally with the ambient powers. -/
+instance center.instNonUnitalCommSemiringOfNonUnitalSemiring :
+    NonUnitalCommSemiring (center R) where
+  __ := NonUnitalSubsemiringClass.toNonUnitalSemiring (center R)
+  mul_comm := Subsemigroup.center.commSemigroup.mul_comm
+
 -- no instance diamond, unlike the unital version
 example {R} [NonUnitalSemiring R] :
-    (center.instNonUnitalCommSemiring _).toNonUnitalSemiring =
+    (inferInstance : NonUnitalCommSemiring (center R)).toNonUnitalSemiring =
       NonUnitalSubsemiringClass.toNonUnitalSemiring (center R) := by
   with_reducible_and_instances rfl
 


### PR DESCRIPTION
There is a diamond from how Subsemigroup.center defines mul and implies associativity and commutativity. So over a non-assoc parent type, the instance one gets differs than if you already had associativity. When/if we set up positive nat powers, there will be a diamond.

So at least prepare for that world by having the overriding instances in the "happy path" case.

---



---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Discovered while working on https://github.com/leanprover-community/mathlib4/pull/40785.
Used GPT 5.6 Terra to classify hunks from the originating PR and do the cherry-pick operations.