### PR TITLE
[Merged by Bors] - feat(Data/ZMod): add `Unique (ZMod 2)ˣ` instance

### DIFF
--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -935,8 +935,9 @@ lemma subsingleton_iff {n : ℕ} : Subsingleton (ZMod n) ↔ n = 1 := by
 lemma nontrivial_iff {n : ℕ} : Nontrivial (ZMod n) ↔ n ≠ 1 := by
   rw [← not_subsingleton_iff_nontrivial, subsingleton_iff]
 
--- todo: this can be made a `Unique` instance.
-instance instSubsingletonUnits : Subsingleton (ZMod 2)ˣ := ⟨by decide⟩
+instance : Unique (ZMod 2)ˣ where
+  default := 1
+  uniq := by decide
 
 @[simp]
 theorem add_self_eq_zero_iff_eq_zero {n : ℕ} (hn : Odd n) {a : ZMod n} :


### PR DESCRIPTION
Strengthen the existing `Subsingleton (ZMod 2)ˣ` instance to a `Unique (ZMod 2)ˣ` instance, resolving the in-source `todo`. The old `Subsingleton` instance is dropped since it derives from `Unique`.

---

**AI disclosure.** I used Claude (via the Claude Code CLI) while preparing this PR: it flagged the in-source `todo` and proposed the `Unique (ZMod 2)ˣ` instance in its idiomatic form (`default := 1`, `uniq := by decide`). I reviewed the change and verified it locally before pushing — built the file, ran `runLinter`, and ran a full downstream `lake build` — and I understand the change and can justify it to reviewers.
