### PR TITLE
feat(CategoryTheory/MorphismProperty): trivial bundles

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3201,6 +3201,7 @@ public import Mathlib.CategoryTheory.MorphismProperty.Representable
 public import Mathlib.CategoryTheory.MorphismProperty.Retract
 public import Mathlib.CategoryTheory.MorphismProperty.RetractArgument
 public import Mathlib.CategoryTheory.MorphismProperty.TransfiniteComposition
+public import Mathlib.CategoryTheory.MorphismProperty.TrivialBundles
 public import Mathlib.CategoryTheory.MorphismProperty.WeakFactorizationSystem
 public import Mathlib.CategoryTheory.NatIso
 public import Mathlib.CategoryTheory.NatTrans

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -275,8 +275,8 @@ instance types.finitaryExtensive : FinitaryExtensive (Type u) := by
       · rfl
     · intro s m e₁ e₂
       ext x
-      simp only [TypeCat.Fun.toFun_apply, Types.binaryCoproductCocone_pt, pair_obj_left,
-        Functor.const_obj_obj, pair_obj_right, ConcreteCategory.hom_ofHom, TypeCat.Fun.coe_mk]
+      simp only [TypeCat.Fun.toFun_apply, Types.binaryCoproductCocone_pt,
+        ConcreteCategory.hom_ofHom, TypeCat.Fun.coe_mk]
       split_ifs
       · rw [← e₁]
         rfl

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -184,11 +184,11 @@ abbrev BinaryFan (X Y : C) :=
   Cone (pair X Y)
 
 /-- The first projection of a binary fan. -/
-abbrev BinaryFan.fst {X Y : C} (s : BinaryFan X Y) :=
+abbrev BinaryFan.fst {X Y : C} (s : BinaryFan X Y) : s.pt ⟶ X :=
   s.π.app ⟨WalkingPair.left⟩
 
 /-- The second projection of a binary fan. -/
-abbrev BinaryFan.snd {X Y : C} (s : BinaryFan X Y) :=
+abbrev BinaryFan.snd {X Y : C} (s : BinaryFan X Y) : s.pt ⟶ Y :=
   s.π.app ⟨WalkingPair.right⟩
 
 -- Marking this `@[simp]` causes loops since `s.fst` is reducibly defeq to the LHS.
@@ -234,10 +234,10 @@ theorem BinaryFan.IsLimit.hom_ext {W X Y : C} {s : BinaryFan X Y} (h : IsLimit s
 abbrev BinaryCofan (X Y : C) := Cocone (pair X Y)
 
 /-- The first inclusion of a binary cofan. -/
-abbrev BinaryCofan.inl {X Y : C} (s : BinaryCofan X Y) := s.ι.app ⟨WalkingPair.left⟩
+abbrev BinaryCofan.inl {X Y : C} (s : BinaryCofan X Y) : X ⟶ s.pt := s.ι.app ⟨WalkingPair.left⟩
 
 /-- The second inclusion of a binary cofan. -/
-abbrev BinaryCofan.inr {X Y : C} (s : BinaryCofan X Y) := s.ι.app ⟨WalkingPair.right⟩
+abbrev BinaryCofan.inr {X Y : C} (s : BinaryCofan X Y) : Y ⟶ s.pt := s.ι.app ⟨WalkingPair.right⟩
 
 /-- Constructs an isomorphism of `BinaryCofan`s out of an isomorphism of the tips that commutes with
 the injections. -/
@@ -381,6 +381,12 @@ lemma BinaryFan.IsLimit.lift_snd {W : C} {s : BinaryFan X Y} (h : IsLimit s)
     lift h f g ≫ s.snd = g :=
   h.fac (BinaryFan.mk f g) _
 
+lemma BinaryFan.IsLimit.exists_lift
+    {X Y : C} {s : BinaryFan X Y} (h : IsLimit s)
+    {W : C} (f₁ : W ⟶ X) (f₂ : W ⟶ Y) :
+    ∃ (φ : W ⟶ s.pt), φ ≫ s.fst = f₁ ∧ φ ≫ s.snd = f₂ :=
+  ⟨lift h f₁ f₂, by simp, by simp⟩
+
 /-- If `s` is a limit binary fan over `X` and `Y`, then every pair of morphisms `f : W ⟶ X` and
 `g : W ⟶ Y` induces a morphism `l : W ⟶ s.pt` satisfying `l ≫ s.fst = f` and `l ≫ s.snd = g`.
 -/
@@ -409,6 +415,12 @@ lemma BinaryCofan.IsColimit.inr_desc {W : C} {s : BinaryCofan X Y} (h : IsColimi
     s.inr ≫ desc h f g = g :=
   h.fac (BinaryCofan.mk f g) _
 
+lemma BinaryCofan.IsColimit.exists_desc
+    {X Y : C} {s : BinaryCofan X Y} (h : IsColimit s)
+    {W : C} (f₁ : X ⟶ W) (f₂ : Y ⟶ W) :
+    ∃ (φ : s.pt ⟶ W), s.inl ≫ φ = f₁ ∧ s.inr ≫ φ = f₂ :=
+  ⟨desc h f₁ f₂, by simp, by simp⟩
+
 /-- If `s` is a colimit binary cofan over `X` and `Y`, then every pair of morphisms `f : X ⟶ W` and
 `g : Y ⟶ W` induces a morphism `l : s.pt ⟶ W` satisfying `s.inl ≫ l = f` and `s.inr ≫ l = g`.
 -/
@@ -426,7 +438,6 @@ def BinaryFan.isLimitFlip {X Y : C} {c : BinaryFan X Y} (hc : IsLimit c) :
       (e₂.trans (hc.fac (BinaryFan.mk s.snd s.fst) ⟨WalkingPair.left⟩).symm)
       (e₁.trans (hc.fac (BinaryFan.mk s.snd s.fst) ⟨WalkingPair.right⟩).symm)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem BinaryFan.isLimit_iff_isIso_fst {X Y : C} (h : IsTerminal Y) (c : BinaryFan X Y) :
     Nonempty (IsLimit c) ↔ IsIso c.fst := by
   constructor
@@ -449,7 +460,6 @@ theorem BinaryFan.isLimit_iff_isIso_snd {X Y : C} (h : IsTerminal X) (c : Binary
     ⟨fun h => ⟨BinaryFan.isLimitFlip h.some⟩, fun h =>
       ⟨(BinaryFan.isLimitFlip h.some).ofIsoLimit (isoBinaryFanMk c).symm⟩⟩
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If `X' ≅ X`, then `X × Y` also is the product of `X'` and `Y`. -/
 noncomputable def BinaryFan.isLimitCompLeftIso {X Y X' : C} (c : BinaryFan X Y) (f : X ⟶ X')
     [IsIso f] (h : IsLimit c) : IsLimit (BinaryFan.mk (c.fst ≫ f) c.snd) := by
@@ -476,7 +486,6 @@ def BinaryCofan.isColimitFlip {X Y : C} {c : BinaryCofan X Y} (hc : IsColimit c)
       (e₂.trans (hc.fac (BinaryCofan.mk s.inr s.inl) ⟨WalkingPair.left⟩).symm)
       (e₁.trans (hc.fac (BinaryCofan.mk s.inr s.inl) ⟨WalkingPair.right⟩).symm)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem BinaryCofan.isColimit_iff_isIso_inl {X Y : C} (h : IsInitial Y) (c : BinaryCofan X Y) :
     Nonempty (IsColimit c) ↔ IsIso c.inl := by
   constructor
@@ -499,7 +508,6 @@ theorem BinaryCofan.isColimit_iff_isIso_inr {X Y : C} (h : IsInitial X) (c : Bin
     ⟨fun h => ⟨BinaryCofan.isColimitFlip h.some⟩, fun h =>
       ⟨(BinaryCofan.isColimitFlip h.some).ofIsoColimit (isoBinaryCofanMk c).symm⟩⟩
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If `X' ≅ X`, then `X ⨿ Y` also is the coproduct of `X'` and `Y`. -/
 noncomputable def BinaryCofan.isColimitCompLeftIso {X Y X' : C} (c : BinaryCofan X Y) (f : X' ⟶ X)
     [IsIso f] (h : IsColimit c) : IsColimit (BinaryCofan.mk (f ≫ c.inl) c.inr) := by

--- a/Mathlib/CategoryTheory/Limits/Shapes/CombinedProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/CombinedProducts.lean
@@ -44,6 +44,7 @@ abbrev combPairHoms : (i : ι₁ ⊕ ι₂) → bc.pt ⟶ Sum.elim f₁ f₂ i
 
 variable {c₁ c₂ bc}
 
+set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 /-- If `c₁` and `c₂` are limit fans and `bc` is a limit binary fan on their cone
 points, then the fan constructed from `combPairHoms` is a limit cone. -/
@@ -53,15 +54,11 @@ def combPairIsLimit : IsLimit (Fan.mk bc.pt (combPairHoms c₁ c₂ bc)) :=
       cases i
       · exact Fan.IsLimit.lift h₁ (fun a ↦ s.proj (.inl a))
       · exact Fan.IsLimit.lift h₂ (fun a ↦ s.proj (.inr a)))
-    (fun s w ↦ by
-      cases w <;>
-      · simp only [fan_mk_proj, combPairHoms]
-        erw [← Category.assoc, h.fac]
-        simp only [pair_obj_left, mk_π_app, IsLimit.fac])
+    (fun s w ↦ by cases w <;> exact (h.fac_assoc ..).trans (by simp))
     (fun s m hm ↦ Fan.IsLimit.hom_ext h _ _ <| fun w ↦ by
       cases w
-      · refine Fan.IsLimit.hom_ext h₁ _ _ (fun a ↦ by aesop)
-      · refine Fan.IsLimit.hom_ext h₂ _ _ (fun a ↦ by aesop))
+      · exact Fan.IsLimit.hom_ext h₁ _ _ (fun a ↦ by aesop)
+      · exact Fan.IsLimit.hom_ext h₂ _ _ (fun a ↦ by aesop))
 
 end Fan
 

--- a/Mathlib/CategoryTheory/Limits/Types/Coproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Coproducts.lean
@@ -319,8 +319,8 @@ theorem binaryCofan_isColimit_iff {X Y : Type u} (c : BinaryCofan X Y) :
         exact this.elim
       · rintro T _ _ m rfl rfl
         ext x
-        simp only [TypeCat.Fun.toFun_apply, Functor.const_obj_obj, pair_obj_left, Set.mem_range,
-          comp_apply, pair_obj_right, ConcreteCategory.hom_ofHom, TypeCat.Fun.coe_mk]
+        simp only [TypeCat.Fun.toFun_apply, Set.mem_range, comp_apply,
+          ConcreteCategory.hom_ofHom, TypeCat.Fun.coe_mk]
         split_ifs <;> exact congr_arg _ (Equiv.apply_ofInjective_symm _ ⟨_, _⟩).symm
 
 /-- Any monomorphism in `Type` is a coproduct injection. -/

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -574,11 +574,10 @@ theorem isUniversalColimit_extendCofan {n : ℕ} (f : Fin (n + 1) → C)
     dsimp
     simp only [limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, Cofan.inj]
   · intro j
-    simp only [pair_obj_right, Functor.const_obj_obj, Discrete.functor_obj,
+    simp only [Functor.const_obj_obj, Discrete.functor_obj,
       Cofan.mk_pt, Cofan.mk_ι_app, Discrete.natTrans_app]
     refine IsPullback.of_right ?_ ?_ (IsPullback.of_hasPullback (BinaryCofan.inr c₂) i).flip
-    · simp only [Functor.const_obj_obj, pair_obj_right, limit.lift_π,
-        PullbackCone.mk_pt, PullbackCone.mk_π_app]
+    · simp only [limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app]
       exact H _
     · simp only [limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, Cofan.inj]
   obtain ⟨H₁⟩ := t₁'
@@ -590,12 +589,8 @@ theorem isUniversalColimit_extendCofan {n : ℕ} (f : Fin (n + 1) → C)
     · simpa [mapPair] using! congr_app e ⟨0⟩
     · simpa using! pullback.condition
   · rintro ⟨⟨⟩⟩
-    · simp only [pair_obj_right, Functor.const_obj_obj, pair_obj_left, BinaryCofan.mk_pt,
-        BinaryCofan.ι_app_left, BinaryCofan.mk_inl, mapPair_left]
-      exact H ⟨0⟩
-    · simp only [pair_obj_right, Functor.const_obj_obj, BinaryCofan.mk_pt, BinaryCofan.ι_app_right,
-        BinaryCofan.mk_inr, mapPair_right]
-      exact (IsPullback.of_hasPullback (BinaryCofan.inr c₂) i).flip
+    · simpa using H ⟨0⟩
+    · simpa using (IsPullback.of_hasPullback (BinaryCofan.inr c₂) i).flip
   obtain ⟨H₂⟩ := t₂'
   clear_value F'
   subst this
@@ -644,19 +639,11 @@ theorem isVanKampenColimit_extendCofan {n : ℕ} (f : Fin (n + 1) → C)
     subst this
     apply BinaryCofan.IsColimit.mk _ (fun {T} f₁ f₂ ↦ Hc.desc (Cofan.mk T (Fin.cases f₁
       (fun i ↦ Sigma.ι (fun (j : Fin n) ↦ (Discrete.functor F').obj ⟨j.succ⟩) _ ≫ f₂))))
-    · intro T f₁ f₂
-      simp only [Discrete.functor_obj, pair_obj_left, BinaryCofan.mk_pt, Functor.const_obj_obj,
-        BinaryCofan.mk_inl, IsColimit.fac, Cofan.mk_pt, Cofan.mk_ι_app,
-        Fin.cases_zero]
-    · intro T f₁ f₂
-      simp only [Discrete.functor_obj, pair_obj_right, BinaryCofan.mk_pt, Functor.const_obj_obj,
-        BinaryCofan.mk_inr]
-      ext j
-      simp only [colimit.ι_desc_assoc, Discrete.functor_obj, Cofan.mk_pt,
-        Cofan.mk_ι_app, IsColimit.fac, Fin.cases_succ]
+    · simp
+    · cat_disch
     · intro T f₁ f₂ f₃ m₁ m₂
-      simp only [Discrete.functor_obj_eq_as, pair_obj_left, BinaryCofan.mk_pt, const_obj_obj,
-        BinaryCofan.mk_inl, pair_obj_right, BinaryCofan.mk_inr] at m₁ m₂ ⊢
+      simp only [Discrete.functor_obj_eq_as, pair_obj_left,
+        BinaryCofan.mk_inl, BinaryCofan.mk_inr] at m₁ m₂ ⊢
       refine Hc.uniq (Cofan.mk T (Fin.cases f₁
         (fun i ↦ Sigma.ι (fun (j : Fin n) ↦ (Discrete.functor F').obj ⟨j.succ⟩) _ ≫ f₂))) _ ?_
       intro ⟨j⟩

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -642,7 +642,7 @@ theorem isVanKampenColimit_extendCofan {n : ℕ} (f : Fin (n + 1) → C)
     · simp
     · cat_disch
     · intro T f₁ f₂ f₃ m₁ m₂
-      simp only [Discrete.functor_obj_eq_as, pair_obj_left,
+      simp only [Discrete.functor_obj_eq_as,
         BinaryCofan.mk_inl, BinaryCofan.mk_inr] at m₁ m₂ ⊢
       refine Hc.uniq (Cofan.mk T (Fin.cases f₁
         (fun i ↦ Sigma.ι (fun (j : Fin n) ↦ (Discrete.functor F').obj ⟨j.succ⟩) _ ≫ f₂))) _ ?_

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -196,6 +196,13 @@ lemma IsStableUnderBaseChange.of_forall_exists_isPullback {P : MorphismProperty 
   obtain ⟨T, fst, snd, h, hfst⟩ := H f g hg
   rwa [← h.isoPullback_inv_fst, P.cancel_left_of_respectsIso]
 
+instance {ι : Type*} (W : ι → MorphismProperty C) [∀ i, (W i).IsStableUnderBaseChange] :
+    (⨆ i, W i).IsStableUnderBaseChange where
+  of_isPullback sq h := by
+    simp only [iSup_iff] at h ⊢
+    obtain ⟨_, h⟩ := h
+    exact ⟨_, of_isPullback sq h⟩
+
 variable (C)
 
 instance IsStableUnderBaseChange.isomorphisms :
@@ -323,6 +330,13 @@ lemma IsStableUnderCobaseChange.of_forall_exists_isPullback {P : MorphismPropert
   refine .mk' fun X Y S f g _ hg ↦ ?_
   obtain ⟨T, inl, inr, h, hinl⟩ := H f g hg
   rwa [← h.inr_isoPushout_hom, P.cancel_right_of_respectsIso]
+
+instance {ι : Type*} (W : ι → MorphismProperty C) [∀ i, (W i).IsStableUnderCobaseChange] :
+    (⨆ i, W i).IsStableUnderCobaseChange where
+  of_isPushout sq h := by
+    simp only [iSup_iff] at h ⊢
+    obtain ⟨_, h⟩ := h
+    exact ⟨_, of_isPushout sq h⟩
 
 instance IsStableUnderCobaseChange.isomorphisms :
     (isomorphisms C).IsStableUnderCobaseChange where

--- a/Mathlib/CategoryTheory/MorphismProperty/TrivialBundles.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/TrivialBundles.lean
@@ -11,6 +11,11 @@ public import Mathlib.CategoryTheory.Limits.Preserves.Shapes.BinaryProducts
 /-!
 # Trivial bundles
 
+Let `p : E ⟶ B` be a morphism in a category `C` and `F : C`. We introduce
+a structure `TrivialBundleWithFiber F p` which contains the data
+of a morphism `r : E ⟶ F` such `(p, r)` makes `E` the binary product of `B` and `F`.
+The corresponding property of morphisms in `C` is `trivialBundleWithFiber F`.
+
 -/
 
 @[expose] public section

--- a/Mathlib/CategoryTheory/MorphismProperty/TrivialBundles.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/TrivialBundles.lean
@@ -1,0 +1,234 @@
+/-
+Copyright (c) 2026 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.MorphismProperty.Limits
+public import Mathlib.CategoryTheory.Limits.Preserves.Shapes.BinaryProducts
+
+/-!
+# Trivial bundles
+
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+open Limits
+
+variable {C D : Type*} [Category* C] [Category* D]
+
+namespace MorphismProperty
+
+/-- Given `F : C`, we say that `p : E ⟶ B` is a trivial bundle with fiber `F`
+if we have a morphism `r : E ⟶ F` such `(p, r)` identify `E` to the binary
+product of `B` and `F`. -/
+structure TrivialBundleWithFiber (F : C) {E B : C} (p : E ⟶ B) where
+  /-- the projection to the fiber -/
+  r : E ⟶ F
+  /-- `E` identifies to the binary product of `B` and `F`. -/
+  isLimit : IsLimit (BinaryFan.mk p r)
+
+initialize_simps_projections TrivialBundleWithFiber (-isLimit)
+
+namespace TrivialBundleWithFiber
+
+variable {F E B : C} {p : E ⟶ B} (h : TrivialBundleWithFiber F p)
+
+lemma ext_iff {h₁ h₂ : TrivialBundleWithFiber F p} :
+    h₁ = h₂ ↔ h₁.r = h₂.r := by
+  constructor
+  · rintro rfl
+    rfl
+  · obtain ⟨r₁, h₁⟩ := h₁
+    obtain ⟨r₂, h₂⟩ := h₂
+    rintro rfl
+    obtain rfl : h₁ = h₂ := by subsingleton
+    rfl
+
+@[ext]
+lemma ext {h₁ h₂ : TrivialBundleWithFiber F p} (eq : h₁.r = h₂.r) : h₁ = h₂ := by
+  rwa [ext_iff]
+
+set_option backward.defeqAttrib.useBackward true in
+/-- If `p : E ⟶ B` is a trivial bundle with fiber `F`, and `F' ≅ F`,
+then `p` is also a trivial bundle with fiber `F'`. -/
+@[simps]
+def chgFiber {F' : C} (e : F' ≅ F) : TrivialBundleWithFiber F' p where
+  r := h.r ≫ e.inv
+  isLimit := by
+    let e' : pair B F' ≅ pair B F := mapPairIso (Iso.refl _) e
+    refine (IsLimit.equivOfNatIsoOfIso e' _ _ ?_).2 h.isLimit
+    refine BinaryFan.ext (Iso.refl _) ?_ ?_
+    all_goals simp [BinaryFan.fst, BinaryFan.snd, e']
+
+set_option backward.defeqAttrib.useBackward true in
+/-- If `p : E ⟶ B` is a trivial bundle with fiber `F`, then so is any pullback of `p`. -/
+@[simps]
+noncomputable def pullback {E' B' : C} {p' : E' ⟶ B'} {f : B' ⟶ B} {f' : E' ⟶ E}
+    (sq : IsPullback f' p' p f) :
+    TrivialBundleWithFiber F p' where
+  r := f' ≫ h.r
+  isLimit :=
+    BinaryFan.isLimitMk
+      (fun s ↦ sq.lift (BinaryFan.IsLimit.lift' h.isLimit (s.fst ≫ f) s.snd).val s.fst
+        (BinaryFan.IsLimit.lift' _ _ _).2.1)
+      (fun s ↦ by simp)
+      (fun s ↦ by simpa using (BinaryFan.IsLimit.lift' h.isLimit (s.fst ≫ f) s.snd).2.2)
+      (fun s m hm₁ hm₂ ↦ by
+        apply sq.hom_ext
+        · apply BinaryFan.IsLimit.hom_ext h.isLimit
+          · dsimp
+            rw [Category.assoc, IsPullback.lift_fst, sq.w, reassoc_of% hm₁]
+            exact (BinaryFan.IsLimit.lift' h.isLimit (s.fst ≫ f) s.snd).2.1.symm
+          · dsimp
+            rw [Category.assoc, IsPullback.lift_fst, hm₂]
+            exact (BinaryFan.IsLimit.lift' h.isLimit (s.fst ≫ f) s.snd).2.2.symm
+        · simp [hm₁])
+
+variable (p) in
+/-- If `p : E ⟶ B` is a morphism with `B` a terminal object, then `p` is a trivial
+bundle with fiber `E`. -/
+@[simps]
+def ofIsTerminal (hB : IsTerminal B) : TrivialBundleWithFiber E p where
+  r := 𝟙 E
+  isLimit :=
+    BinaryFan.isLimitMk (fun s ↦ s.snd) (fun s ↦ hB.hom_ext _ _)
+      (fun s ↦ by simp)
+      (fun s m _ hm ↦ by simpa using hm)
+
+set_option backward.defeqAttrib.useBackward true in
+/-- If `p : E ⟶ B` is a trivial bundle with fiber `F` and `B` is a terminal object,
+then `E` is isomorphic to `F`. -/
+@[simps hom]
+def isoOfIsTerminal (h : TrivialBundleWithFiber F p) (hB : IsTerminal B) : E ≅ F where
+  hom := h.r
+  inv := (BinaryFan.IsLimit.lift' h.isLimit (hB.from _) (𝟙 _)).1
+  hom_inv_id := by
+    apply BinaryFan.IsLimit.hom_ext h.isLimit
+    · apply hB.hom_ext
+    · simp [dsimp% (BinaryFan.IsLimit.lift' h.isLimit (hB.from _) (𝟙 _)).2.2]
+  inv_hom_id := (BinaryFan.IsLimit.lift' h.isLimit (hB.from _) (𝟙 _)).2.2
+
+lemma isPullback_of_isTerminal {T : C} (hT : IsTerminal T) :
+    IsPullback h.r p (hT.from _) (hT.from _) where
+  w := by simp
+  isLimit' :=
+    ⟨PullbackCone.IsLimit.mk _
+      (fun s ↦ (BinaryFan.IsLimit.lift' h.isLimit s.snd s.fst).1)
+      (fun s ↦ (BinaryFan.IsLimit.lift' h.isLimit s.snd s.fst).2.2)
+      (fun s ↦ (BinaryFan.IsLimit.lift' h.isLimit s.snd s.fst).2.1)
+      (fun s m hm₁ hm₂ ↦ by
+        apply BinaryFan.IsLimit.hom_ext h.isLimit
+        · exact hm₂.trans (BinaryFan.IsLimit.lift' h.isLimit s.snd s.fst).2.1.symm
+        · exact hm₁.trans (BinaryFan.IsLimit.lift' h.isLimit s.snd s.fst).2.2.symm)⟩
+
+set_option backward.defeqAttrib.useBackward true in
+/-- Two trivial bundles with the same fiber `F` are isomorphic. -/
+lemma exists_iso {E' : C} {p' : E' ⟶ B} (h' : TrivialBundleWithFiber F p') :
+    ∃ (e : E ≅ E'), e.hom ≫ p' = p ∧ e.hom ≫ h'.r = h.r := by
+  obtain ⟨hom, h₁, h₂⟩ := BinaryFan.IsLimit.exists_lift h'.isLimit p h.r
+  obtain ⟨inv, h₃, h₄⟩ := BinaryFan.IsLimit.exists_lift h.isLimit p' h'.r
+  dsimp at h₁ h₂ h₃ h₄
+  refine ⟨
+    { hom := hom
+      inv := inv
+      hom_inv_id := ?_
+      inv_hom_id := ?_ }, ?_, ?_⟩
+  · apply BinaryFan.IsLimit.hom_ext h.isLimit <;> cat_disch
+  · apply BinaryFan.IsLimit.hom_ext h'.isLimit <;> cat_disch
+  · cat_disch
+  · cat_disch
+
+/-- If two morphism `p : E ⟶ B` and `p' : E' ⟶ B` are isomorphic over `B`,
+and `p` is a trivial bundle with fiber `F`, then so is `p'`. -/
+@[simps]
+def ofIso {E' : C} (e : E' ≅ E) {p' : E' ⟶ B} (hp' : e.hom ≫ p = p') :
+    TrivialBundleWithFiber F p' where
+  r := e.hom ≫ h.r
+  isLimit := IsLimit.ofIsoLimit h.isLimit (BinaryFan.ext e (by cat_disch) (by cat_disch)).symm
+
+set_option backward.defeqAttrib.useBackward true in
+lemma isPullback {E' B' : C} {p' : E' ⟶ B'} (h' : TrivialBundleWithFiber F p')
+    (t : E' ⟶ E) (b : B' ⟶ B) (h₁ : t ≫ p = p' ≫ b) (h₂ : t ≫ h.r = h'.r) :
+    IsPullback t p' p b where
+  isLimit' :=
+    ⟨Limits.PullbackCone.IsLimit.mk _
+      (fun s ↦ BinaryFan.IsLimit.lift h'.isLimit s.snd (s.fst ≫ h.r))
+      (fun s ↦ by
+        have h₃ := BinaryFan.IsLimit.lift_fst h'.isLimit s.snd (s.fst ≫ h.r)
+        have h₄ := BinaryFan.IsLimit.lift_snd h'.isLimit s.snd (s.fst ≫ h.r)
+        dsimp at h₃ h₄
+        apply BinaryFan.IsLimit.hom_ext h.isLimit
+        · simp [h₁, reassoc_of% h₃, s.condition]
+        · simp [h₂, h₄])
+      (fun s ↦ BinaryFan.IsLimit.lift_fst h'.isLimit s.snd (s.fst ≫ h.r))
+      (fun s m hm₁ hm₂ ↦ by
+        have h₃ := BinaryFan.IsLimit.lift_fst h'.isLimit s.snd (s.fst ≫ h.r)
+        have h₄ := BinaryFan.IsLimit.lift_snd h'.isLimit s.snd (s.fst ≫ h.r)
+        dsimp at h₃ h₄
+        apply BinaryFan.IsLimit.hom_ext h'.isLimit
+        · dsimp
+          rw [hm₂, h₃]
+        · dsimp
+          rw [h₄, ← h₂, reassoc_of% hm₁])⟩
+
+/-- If `p : E ⟶ B` is a trivial bundle with fiber `F` in a category `C`,
+then `G.map p` is a trivial bundle with fiber `G.obj F` in the category `D`
+if `G : C ⥤ D` is a functor which commutes with the binary product of `B` and `F`. -/
+@[simps]
+noncomputable def map (G : C ⥤ D) [PreservesLimit (pair B F) G] :
+    TrivialBundleWithFiber (G.obj F) (G.map p) where
+  r := G.map h.r
+  isLimit := mapIsLimitOfPreservesOfIsLimit _ _ _ h.isLimit
+
+end TrivialBundleWithFiber
+
+/-- Given `F : C`, this is the property of morphisms `p : E ⟶ B`
+such that there exists a structure `TrivialBundleWithFiber F p`,
+i.e. `E` identifies to the binary product of `B` and `F`. -/
+def trivialBundlesWithFiber (F : C) : MorphismProperty C :=
+  fun _ _ p ↦ Nonempty (TrivialBundleWithFiber F p)
+
+instance (F : C) : (trivialBundlesWithFiber F).IsStableUnderBaseChange where
+  of_isPullback sq h := ⟨h.some.pullback sq⟩
+
+/-- In a category `C`, this is the property of morphisms which identify to
+the projection from a binary product. -/
+def trivialBundles : MorphismProperty C :=
+  ⨆ F, trivialBundlesWithFiber F
+deriving IsStableUnderBaseChange
+
+lemma trivialBundlesWithFiber_le_trivialBundles (F : C) :
+    trivialBundlesWithFiber F ≤ trivialBundles :=
+  le_iSup _ _
+
+lemma mem_trivialBundles_iff {X Y : C} (p : X ⟶ Y) :
+    trivialBundles p ↔ ∃ F, Nonempty (TrivialBundleWithFiber F p) := by
+  simp [trivialBundles]
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+lemma trivialBundles.of_isPullback_of_fac {E E' B B' : C} {p' : E' ⟶ B'} {p : E ⟶ B}
+    {f : B' ⟶ B} {f' : E' ⟶ E} (sq : IsPullback f' p' p f)
+    {T : C} (hT : IsTerminal T) (a : B' ⟶ T) (b : T ⟶ B) (fac : a ≫ b = f)
+    [HasPullback p b] :
+    trivialBundles p' := by
+  have sq :
+      IsPullback (pullback.lift f' (p' ≫ a) (by simp [fac, sq.w])) p' (pullback.snd p b) a :=
+    .of_right (by simpa [fac]) (by simp) (.of_hasPullback p b)
+  refine MorphismProperty.of_isPullback sq ?_
+  simp only [mem_trivialBundles_iff]
+  exact ⟨_, ⟨TrivialBundleWithFiber.ofIsTerminal (pullback.snd p b) hT⟩⟩
+
+instance (F : C) : (trivialBundlesWithFiber F).IsStableUnderBaseChange where
+  of_isPullback {X₁ X₂ X₃ X₄ t f' f b} sq := by
+    rintro ⟨hf⟩
+    exact ⟨hf.pullback sq⟩
+
+end MorphismProperty
+
+end CategoryTheory

--- a/Mathlib/Condensed/Light/Sequence.lean
+++ b/Mathlib/Condensed/Light/Sequence.lean
@@ -234,10 +234,9 @@ noncomputable def cocone {X : LightCondMod R} {S T : LightProfinite} (π : T ⟶
           ((pullback.snd _ _) ≫ LightProfinite.fibreIncl _ _)
           (by simp [pullback.condition]))).val := rfl
     -- simp? [this, ← Functor.map_comp] says:
-    simp only [this, pair_obj_left, pair_obj_right, BinaryCofan.IsColimit.desc'_coe,
+    simp only [this, pair_obj_right, BinaryCofan.IsColimit.desc'_coe,
       IsColimit.fac, BinaryCofan.mk_inr, ← Functor.map_comp,
-      pullback.lift_fst, IsColimit.fac_assoc, assoc,
-      pullback.lift_snd]
+      pullback.lift_fst, IsColimit.fac_assoc, assoc, pullback.lift_snd]
     -- simp? [-Functor.map_comp, ← assoc, hr] says:
     simp only [← assoc, hr, id_comp, sub_self, zero_add]
     simp [pullback.condition]


### PR DESCRIPTION
In a category `C`, we introduce a structure `TrivialBundleWithFiber p F` which records the fact that for `p : E ⟶ B`, there is a morphism `r : E ⟶ F` which allows to identify `E` to the binary product of `B` and `F`. The corresponding property of morphisms is `trivialBundlesWithFiber F`.

(In a certain distant future, in the case of a suitable convenient category of topological spaces, this will be used as part of the formalization of the model category structure on simplicial sets.)

From https://github.com/joelriou/topcat-model-category

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
