### PR TITLE
test: move IsModularLattice earlier

### DIFF
--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -34,6 +34,8 @@ of `sup` over `inf`, on the left or on the right.
   commutative, associative and satisfy a pair of "absorption laws".
 
 * `DistribLattice`: a type class for distributive lattices.
+* `IsModularLattice`: Modular lattices. Lattices where `a ≤ c → (a ⊔ b) ⊓ c = a ⊔ (b ⊓ c)`. We
+  only require an inequality because the other direction holds in all lattices.
 
 ## Notation
 
@@ -481,6 +483,11 @@ class DistribLattice (α) extends Lattice α where
   /-- The infimum distributes over the supremum -/
   protected le_sup_inf : ∀ x y z : α, (x ⊔ y) ⊓ (x ⊔ z) ≤ x ⊔ y ⊓ z
 
+/-- A modular lattice is one with a limited associativity between `⊓` and `⊔`. -/
+class IsModularLattice (α : Type*) [Lattice α] : Prop where
+/-- Whenever `x ≤ z`, then for any `y`, `(x ⊔ y) ⊓ z ≤ x ⊔ (y ⊓ z)` -/
+  sup_inf_le_assoc_of_le : ∀ {x : α} (y : α) {z : α}, x ≤ z → (x ⊔ y) ⊓ z ≤ x ⊔ y ⊓ z
+
 section DistribLattice
 
 variable [DistribLattice α] {x y z : α}
@@ -538,6 +545,67 @@ abbrev DistribLattice.ofInfSupLe
     [Lattice α] (inf_sup_le : ∀ a b c : α, a ⊓ (b ⊔ c) ≤ a ⊓ b ⊔ a ⊓ c) : DistribLattice α where
   le_sup_inf := (@OrderDual.instDistribLattice αᵒᵈ { (inferInstance : Lattice αᵒᵈ) with
       le_sup_inf := inf_sup_le }).le_sup_inf
+
+/-- A lattice satisfying the (self-dual, ostensibly weaker) law `(x ⊔ y) ⊓ z ≤ x ⊔ (y ⊓ z)`
+is distributive. -/
+abbrev DistribLattice.ofSupInfLeAssoc [Lattice α] (h : ∀ x y z : α, (x ⊔ y) ⊓ z ≤ x ⊔ y ⊓ z) :
+    DistribLattice α where
+  le_sup_inf x y z := (h x y (x ⊔ z)).trans <|
+    (sup_le_sup_left ((inf_comm ..).trans_le (h x z y)) _).trans <| by
+    rw [inf_comm, ← sup_assoc, sup_idem]
+
+section IsModularLattice
+
+variable [Lattice α] [IsModularLattice α]
+
+theorem sup_inf_le_assoc_of_le {x z : α} (y : α) : x ≤ z → (x ⊔ y) ⊓ z ≤ x ⊔ y ⊓ z :=
+  IsModularLattice.sup_inf_le_assoc_of_le y
+
+@[to_dual existing]
+theorem inf_sup_le_assoc_of_le {x z : α} (y : α) : z ≤ x → x ⊓ (y ⊔ z) ≤ x ⊓ y ⊔ z := by
+  simp_rw [inf_comm x, sup_comm _ z]
+  exact sup_inf_le_assoc_of_le y
+
+@[to_dual]
+theorem sup_inf_assoc_of_le {x : α} (y : α) {z : α} (h : x ≤ z) : (x ⊔ y) ⊓ z = x ⊔ y ⊓ z :=
+  le_antisymm (sup_inf_le_assoc_of_le y h)
+    (le_inf (sup_le_sup_left inf_le_left _) (sup_le h inf_le_right))
+
+@[to_dual]
+theorem IsModularLattice.inf_sup_inf_assoc {x y z : α} : x ⊓ z ⊔ y ⊓ z = (x ⊓ z ⊔ y) ⊓ z :=
+  (sup_inf_assoc_of_le y inf_le_right).symm
+
+instance : IsModularLattice αᵒᵈ :=
+  ⟨fun y z xz =>
+    le_of_eq
+      (by
+        rw [inf_comm, sup_comm, eq_comm, inf_comm, sup_comm]
+        exact @sup_inf_assoc_of_le α _ _ _ y _ xz)⟩
+
+variable {x y z : α}
+
+@[to_dual]
+theorem eq_of_le_of_inf_le_of_le_sup (hxy : x ≤ y) (hinf : y ⊓ z ≤ x) (hsup : y ≤ x ⊔ z) :
+    x = y := by
+  refine hxy.antisymm ?_
+  rw [← inf_eq_right, sup_inf_assoc_of_le _ hxy] at hsup
+  rwa [← hsup, sup_le_iff, and_iff_right rfl.le, inf_comm]
+
+@[to_dual]
+theorem eq_of_le_of_inf_le_of_sup_le (hxy : x ≤ y) (hinf : y ⊓ z ≤ x ⊓ z) (hsup : y ⊔ z ≤ x ⊔ z) :
+    x = y :=
+  eq_of_le_of_inf_le_of_le_sup hxy (hinf.trans inf_le_left) (le_sup_left.trans hsup)
+
+@[to_dual]
+theorem sup_lt_sup_of_lt_of_inf_le_inf (hxy : y < x) (hinf : x ⊓ z ≤ y ⊓ z) : y ⊔ z < x ⊔ z :=
+  lt_of_le_of_ne (sup_le_sup_right (le_of_lt hxy) _) fun hsup =>
+    ne_of_lt hxy <| eq_of_le_of_inf_le_of_sup_le (le_of_lt hxy) hinf (le_of_eq hsup.symm)
+
+theorem strictMono_inf_prod_sup : StrictMono fun x ↦ (x ⊓ z, x ⊔ z) := fun _x _y hxy ↦
+  ⟨⟨inf_le_inf_right _ hxy.le, sup_le_sup_right hxy.le _⟩,
+    fun ⟨inf_le, sup_le⟩ ↦ (sup_lt_sup_of_lt_of_inf_le_inf hxy inf_le).not_ge sup_le⟩
+
+end IsModularLattice
 
 /-!
 ### Lattices derived from linear orders

--- a/Mathlib/Order/ModularLattice.lean
+++ b/Mathlib/Order/ModularLattice.lean
@@ -29,8 +29,6 @@ We define (semi)modularity typeclasses as Prop-valued mixins.
   covers `a ⊓ b`.
 * `IsLowerModularLattice`: Lower modular lattices. Lattices where `a` covers `a ⊓ b` if `a ⊔ b`
   covers `b`.
-- `IsModularLattice`: Modular lattices. Lattices where `a ≤ c → (a ⊔ b) ⊓ c = a ⊔ (b ⊓ c)`. We
-  only require an inequality because the other direction holds in all lattices.
 
 ## Main Definitions
 
@@ -86,11 +84,6 @@ either `a` or `b`. -/
 class IsLowerModularLattice (α : Type*) [Lattice α] : Prop where
 /-- `a` and `b` both cover `a ⊓ b` if `a ⊔ b` covers either `a` or `b` -/
   inf_covBy_of_covBy_sup {a b : α} : a ⋖ a ⊔ b → a ⊓ b ⋖ b
-
-/-- A modular lattice is one with a limited associativity between `⊓` and `⊔`. -/
-class IsModularLattice (α : Type*) [Lattice α] : Prop where
-/-- Whenever `x ≤ z`, then for any `y`, `(x ⊔ y) ⊓ z ≤ x ⊔ (y ⊓ z)` -/
-  sup_inf_le_assoc_of_le : ∀ {x : α} (y : α) {z : α}, x ≤ z → (x ⊔ y) ⊓ z ≤ x ⊔ y ⊓ z
 
 section WeakUpperModular
 
@@ -151,53 +144,6 @@ end UpperModular
 section IsModularLattice
 
 variable [Lattice α] [IsModularLattice α]
-
-theorem sup_inf_le_assoc_of_le {x z : α} (y : α) : x ≤ z → (x ⊔ y) ⊓ z ≤ x ⊔ y ⊓ z :=
-  IsModularLattice.sup_inf_le_assoc_of_le y
-
-@[to_dual existing]
-theorem inf_sup_le_assoc_of_le {x z : α} (y : α) : z ≤ x → x ⊓ (y ⊔ z) ≤ x ⊓ y ⊔ z := by
-  simp_rw [inf_comm x, sup_comm _ z]
-  exact sup_inf_le_assoc_of_le y
-
-@[to_dual]
-theorem sup_inf_assoc_of_le {x : α} (y : α) {z : α} (h : x ≤ z) : (x ⊔ y) ⊓ z = x ⊔ y ⊓ z :=
-  le_antisymm (sup_inf_le_assoc_of_le y h)
-    (le_inf (sup_le_sup_left inf_le_left _) (sup_le h inf_le_right))
-
-@[to_dual]
-theorem IsModularLattice.inf_sup_inf_assoc {x y z : α} : x ⊓ z ⊔ y ⊓ z = (x ⊓ z ⊔ y) ⊓ z :=
-  (sup_inf_assoc_of_le y inf_le_right).symm
-
-instance : IsModularLattice αᵒᵈ :=
-  ⟨fun y z xz =>
-    le_of_eq
-      (by
-        rw [inf_comm, sup_comm, eq_comm, inf_comm, sup_comm]
-        exact @sup_inf_assoc_of_le α _ _ _ y _ xz)⟩
-
-variable {x y z : α}
-
-@[to_dual]
-theorem eq_of_le_of_inf_le_of_le_sup (hxy : x ≤ y) (hinf : y ⊓ z ≤ x) (hsup : y ≤ x ⊔ z) :
-    x = y := by
-  refine hxy.antisymm ?_
-  rw [← inf_eq_right, sup_inf_assoc_of_le _ hxy] at hsup
-  rwa [← hsup, sup_le_iff, and_iff_right rfl.le, inf_comm]
-
-@[to_dual]
-theorem eq_of_le_of_inf_le_of_sup_le (hxy : x ≤ y) (hinf : y ⊓ z ≤ x ⊓ z) (hsup : y ⊔ z ≤ x ⊔ z) :
-    x = y :=
-  eq_of_le_of_inf_le_of_le_sup hxy (hinf.trans inf_le_left) (le_sup_left.trans hsup)
-
-@[to_dual]
-theorem sup_lt_sup_of_lt_of_inf_le_inf (hxy : y < x) (hinf : x ⊓ z ≤ y ⊓ z) : y ⊔ z < x ⊔ z :=
-  lt_of_le_of_ne (sup_le_sup_right (le_of_lt hxy) _) fun hsup =>
-    ne_of_lt hxy <| eq_of_le_of_inf_le_of_sup_le (le_of_lt hxy) hinf (le_of_eq hsup.symm)
-
-theorem strictMono_inf_prod_sup : StrictMono fun x ↦ (x ⊓ z, x ⊔ z) := fun _x _y hxy ↦
-  ⟨⟨inf_le_inf_right _ hxy.le, sup_le_sup_right hxy.le _⟩,
-    fun ⟨inf_le, sup_le⟩ ↦ (sup_lt_sup_of_lt_of_inf_le_inf hxy inf_le).not_ge sup_le⟩
 
 /-- A generalization of the theorem that if `N` is a submodule of `M` and
   `N` and `M / N` are both Artinian, then `M` is Artinian. -/


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
