### PR TITLE
[Merged by Bors] - chore: remove redundant `decreasing_by`

### DIFF
--- a/Mathlib/Combinatorics/Enumerative/Composition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Composition.lean
@@ -661,7 +661,6 @@ def recOnSingleAppend {motive : ∀ n, Composition n → Sort*} {n : ℕ} (c : C
     | (k + 1) :: l =>
       single_append k l.sum ⟨l, fun hi ↦ blocks_pos <| mem_cons_of_mem _ hi, rfl⟩ <|
         recOnSingleAppend _ zero single_append
-  decreasing_by simp
 
 /-- Induction (recursion) principle on `c : Composition _`
 that corresponds to the reverse induction on the list of blocks of `c`. -/

--- a/Mathlib/Data/List/PeriodicityLemma.lean
+++ b/Mathlib/Data/List/PeriodicityLemma.lean
@@ -229,8 +229,5 @@ theorem HasPeriod.gcd {w : List α} {p q : ℕ} (per_p : HasPeriod w p) (per_q :
       · rw [take_eq, take_append_drop q w]
       · exact (gcd_stable ▸ IH).take_append (p.gcd q) q (drop q w)
           (gcd_dvd_right p q) drop_len
-  termination_by (q, p)
-  decreasing_by
-    all_goals grind
 
 end List

--- a/Mathlib/Data/List/PeriodicityLemma.lean
+++ b/Mathlib/Data/List/PeriodicityLemma.lean
@@ -229,5 +229,8 @@ theorem HasPeriod.gcd {w : List α} {p q : ℕ} (per_p : HasPeriod w p) (per_q :
       · rw [take_eq, take_append_drop q w]
       · exact (gcd_stable ▸ IH).take_append (p.gcd q) q (drop q w)
           (gcd_dvd_right p q) drop_len
+  termination_by (q, p)
+  decreasing_by
+    all_goals grind
 
 end List

--- a/Mathlib/Data/Nat/BinaryRec.lean
+++ b/Mathlib/Data/Nat/BinaryRec.lean
@@ -91,7 +91,7 @@ def binaryRec {motive : Nat → Sort u} (zero : motive 0) (bit : ∀ b n, motive
   else
     let x := bit (1 &&& n != 0) (n >>> 1) (binaryRec zero bit (n >>> 1))
     congrArg motive n.bit_testBit_zero_shiftRight_one ▸ x
-termination_by if n = 0 then 0 else n.log2.succ
+termination_by if n = 0 then 0 else n.log2.succ -- redundant, but removing causes slowdown
 decreasing_by
   obtain _ | n := n; · exact (n0 rfl).elim
   obtain _ | n := n; · simp

--- a/Mathlib/Data/Nat/Fib/Zeckendorf.lean
+++ b/Mathlib/Data/Nat/Fib/Zeckendorf.lean
@@ -124,8 +124,6 @@ def zeckendorf : ℕ → List ℕ
   | m@(_ + 1) =>
     letI a := greatestFib m
     a :: zeckendorf (m - fib a)
-decreasing_by simp_wf; subst_vars; apply zeckendorf_aux (zero_lt_succ _)
-
 
 @[simp] lemma zeckendorf_zero : zeckendorf 0 = [] := zeckendorf.eq_1 ..
 


### PR DESCRIPTION
This PR removes all but one redundant `decreasing_by` blocks. The last one is in [Mathlib/Data/List/PeriodicityLemma.lean](https://github.com/leanprover-community/mathlib4/pull/41760/files/e8f86fa460b54f7f6ae80d1f05ae09b987cf7cdb#diff-36680f71f6eb8dcc91c5bf81a554bb9259650ee162a1944a3ecae5608ecbe198); removing that causes signifcant slowdown.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
