### PR TITLE
[Merged by Bors] - feat(Combinatorics/Quiver/Path): add `Quiver.Reachable`

### DIFF
--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -336,6 +336,10 @@ protected theorem Reachable.rfl : Reachable a a := Reachable.refl _
 protected theorem Reachable.trans (hab : Reachable a b) (hbc : Reachable b c) : Reachable a c :=
   hab.elim fun p => hbc.elim fun q => ⟨p.comp q⟩
 
+instance : IsPreorder V Reachable where
+  refl := Reachable.refl
+  trans _ _ _ := Reachable.trans
+
 /-- A path witnesses that its target is reachable from its source. -/
 protected theorem Path.reachable (p : Path a b) : Reachable a b := ⟨p⟩
 

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -327,18 +327,18 @@ protected theorem Reachable.elim {p : Prop} (h : Reachable a b) (hp : Path a b �
   Nonempty.elim h hp
 
 @[refl]
-protected theorem Reachable.refl (a : V) : Reachable a a := ⟨Path.nil⟩
+protected theorem Reachable.refl (a : V) : Reachable a a := ⟨.nil⟩
 
 @[simp]
-protected theorem Reachable.rfl : Reachable a a := Reachable.refl _
+protected theorem Reachable.rfl : Reachable a a := .refl _
 
 @[trans]
 protected theorem Reachable.trans (hab : Reachable a b) (hbc : Reachable b c) : Reachable a c :=
   hab.elim fun p => hbc.elim fun q => ⟨p.comp q⟩
 
 instance : IsPreorder V Reachable where
-  refl := Reachable.refl
-  trans _ _ _ := Reachable.trans
+  refl := .refl
+  trans _ _ _ := .trans
 
 /-- A path witnesses that its target is reachable from its source. -/
 protected theorem Path.reachable (p : Path a b) : Reachable a b := ⟨p⟩

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -324,7 +324,7 @@ def Reachable (a b : V) : Prop := Nonempty (Path a b)
 variable {a b c : V}
 
 protected theorem Reachable.elim {p : Prop} (h : Reachable a b) (hp : Path a b → p) : p :=
-  h.elim hp
+  Nonempty.elim h hp
 
 @[refl]
 protected theorem Reachable.refl (a : V) : Reachable a a := ⟨.nil⟩

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 David Wärn,. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: David Wärn, Kim Morrison, Matteo Cipollina
+Authors: David Wärn, Kim Morrison, Matteo Cipollina, Runtian Zhou
 -/
 module
 
@@ -14,6 +14,8 @@ public import Batteries.Data.List.Basic
 
 Given a quiver `V`, we define the type of paths from `a : V` to `b : V` as an inductive
 family. We define composition of paths and the action of prefunctors on paths.
+
+We also define `Quiver.Reachable a b`, the existence of a directed path from `a` to `b`.
 -/
 
 @[expose] public section
@@ -308,6 +310,39 @@ instance instDecidableEq [DecidableEq V] [∀ (v w : V), DecidableEq (v ⟶ w)] 
 end BoundedPath
 
 end Path
+
+section Reachable
+
+variable {V : Type u} [Quiver V]
+
+/-- `Reachable a b` holds when there is a directed path from `a` to `b`.
+
+This is a preorder rather than an equivalence, since quiver paths are directed (compare the
+symmetric `SimpleGraph.Reachable`). -/
+def Reachable (a b : V) : Prop := Nonempty (Path a b)
+
+variable {a b c : V}
+
+protected theorem Reachable.elim {p : Prop} (h : Reachable a b) (hp : Path a b → p) : p :=
+  Nonempty.elim h hp
+
+@[refl]
+protected theorem Reachable.refl (a : V) : Reachable a a := ⟨Path.nil⟩
+
+@[simp]
+protected theorem Reachable.rfl : Reachable a a := Reachable.refl _
+
+@[trans]
+protected theorem Reachable.trans (hab : Reachable a b) (hbc : Reachable b c) : Reachable a c :=
+  hab.elim fun p => hbc.elim fun q => ⟨p.comp q⟩
+
+/-- A path witnesses that its target is reachable from its source. -/
+protected theorem Path.reachable (p : Path a b) : Reachable a b := ⟨p⟩
+
+/-- An arrow witnesses that its target is reachable from its source. -/
+protected theorem Hom.reachable (e : a ⟶ b) : Reachable a b := ⟨e.toPath⟩
+
+end Reachable
 
 end Quiver
 

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -324,7 +324,7 @@ def Reachable (a b : V) : Prop := Nonempty (Path a b)
 variable {a b c : V}
 
 protected theorem Reachable.elim {p : Prop} (h : Reachable a b) (hp : Path a b → p) : p :=
-  Nonempty.elim h hp
+  h.elim hp
 
 @[refl]
 protected theorem Reachable.refl (a : V) : Reachable a a := ⟨.nil⟩


### PR DESCRIPTION
Add `Quiver.Reachable a b`, the existence of a directed path from `a` to `b`, together with its basic preorder API (`@[refl]`/`@[trans]`) and `Path.reachable`/`Hom.reachable`.

Unlike `SimpleGraph.Reachable`, this is only a preorder, not an equivalence, since quiver paths are directed; the symmetric notion is reachability in `Symmetrify V`.

---

This will be used by #38310 (where it was suggested in review).

This PR was written with AI assistance (Claude). The code has been reviewed by the author.
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
