### PR TITLE
WIP: config option for expectedLicense

### DIFF
--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -175,11 +175,16 @@ The input is the copyright string, the output is an array of `Syntax × String` 
 The linter checks that
 * the first and last line of the copyright are a `("/-", "-/")` pair, each on its own line;
 * the first line is begins with `Copyright (c) 20` and ends with `. All rights reserved.`;
-* the second line is `Released under Apache 2.0 license as described in the file LICENSE.`;
+* the second line equals `expectedLicense` (which the linter reads from the
+  `linter.style.header.license` option, defaulting to
+  `Released under Apache 2.0 license as described in the file LICENSE.`);
 * the remainder of the string begins with `Authors: `, does not end with `.` and
   contains no ` and ` nor a double space, except possibly after a line break.
 -/
-public def copyrightHeaderChecks (copyright : String) : Array (Syntax × String) := Id.run do
+public def copyrightHeaderChecks (copyright : String)
+    (expectedLicense : String :=
+      "Released under Apache 2.0 license as described in the file LICENSE.") :
+    Array (Syntax × String) := Id.run do
   -- First, we merge lines ending in `,`: two spaces after the line-break are ok,
   -- but so is only one or none.  We take care of *not* adding more consecutive spaces, though.
   -- This is to allow the copyright or authors' lines to span several lines.
@@ -240,7 +245,6 @@ public def copyrightHeaderChecks (copyright : String) : Array (Syntax × String)
         "If an authors line spans multiple lines, \
         each line but the last must end with a trailing comma")
     output := output.append (authorsLineChecks authorsLine authorsStart)
-    let expectedLicense := "Released under Apache 2.0 license as described in the file LICENSE."
     if license != expectedLicense then
       output := output.push (toSyntax copyright license,
         s!"Second copyright line should be \"{expectedLicense}\"")
@@ -297,6 +301,11 @@ The linter allows `import`-only files and does not require a copyright statement
 public register_option linter.style.header : Bool := {
   defValue := false
   descr := "enable the header style linter"
+}
+
+public register_option linter.style.header.license : String := {
+  defValue := "Released under Apache 2.0 license as described in the file LICENSE."
+  descr := "The text required as the second line of the copyright header."
 }
 
 namespace Style.header
@@ -437,7 +446,7 @@ def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
     | _ => ""
   -- Report any errors about the copyright line.
   if mainModule != `Mathlib.Init && mainModule != `Mathlib.Tactic then
-    for (stx, m) in copyrightHeaderChecks copyright do
+    for (stx, m) in copyrightHeaderChecks copyright (linter.style.header.license.get (← getOptions)) do
       Linter.logLint linter.style.header stx m!"* '{stx.getAtomVal}':\n{m}\n"
   -- Report a missing module doc-string.
   match afterImports with

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -376,7 +376,7 @@ because they are files that test the linter.
 -/
 def headerTestFiles : NameSet := .ofList
   [`MathlibTest.Linter.Header.Basic, `MathlibTest.Linter.Header.Fail, `MathlibTest.Linter.Header.Verso,
-  `MathlibTest.DirectoryDependencyLinter.Test]
+  `MathlibTest.Linter.Header.License, `MathlibTest.DirectoryDependencyLinter.Test]
 
 @[inherit_doc Mathlib.Linter.linter.style.header]
 def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do

--- a/MathlibTest/Linter/Header/Basic.lean
+++ b/MathlibTest/Linter/Header/Basic.lean
@@ -65,6 +65,23 @@ elab "#check_copyright " copStx:str : command => do
            Range: {(rg.start, rg.stop)}\n\
            Message: '{replaceMultilineComments m}'"
 
+open Lean Elab Command in
+/--
+`#check_copyright_license lic cop` is like `#check_copyright cop`, but checks the second line against
+the custom expected license `lic`. This exercises the `expectedLicense` parameter of
+`copyrightHeaderChecks`, which `linter.style.header` reads from the `linter.style.header.license`
+option.
+-/
+elab "#check_copyright_license " licStx:str copStx:str : command => do
+  let cop := copStx.getString
+  let offset := copStx.raw.getPos?.get!.increaseBy 1
+  for (s, m) in Mathlib.Linter.copyrightHeaderChecks cop licStx.getString do
+    if let some rg := s.getRange? then
+      logInfoAt (.ofRange ({start := rg.start.offsetBy offset, stop := rg.stop.offsetBy offset}))
+        m!"Text: `{replaceMultilineComments s.getAtomVal}`\n\
+           Range: {(rg.start, rg.stop)}\n\
+           Message: '{replaceMultilineComments m}'"
+
 -- well-formed
 #check_copyright
 "/-
@@ -390,5 +407,37 @@ Authors: A
 Copyright (c) 2024 First Last Name jr.. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: A
+-/
+"
+
+/-!
+### The expected license line is configurable
+
+`copyrightHeaderChecks` takes the expected second line as a parameter (default: the Apache LICENSE
+line), which `linter.style.header` reads from the `linter.style.header.license` option.
+-/
+
+-- A header whose second line matches the custom license is accepted (no warnings).
+#guard_msgs in
+#check_copyright_license "Released under the Custom License."
+"/-
+Copyright (c) 2024 Damiano Testa. All rights reserved.
+Released under the Custom License.
+Authors: Name LastName
+-/
+"
+
+-- With a custom expected license, the old default second line is now flagged.
+/--
+info: Text: `Released under Apache 2.0 license as described in the file LICENSE.`
+Range: (58, 125)
+Message: 'Second copyright line should be "Released under the Custom License."'
+-/
+#guard_msgs in
+#check_copyright_license "Released under the Custom License."
+"/-
+Copyright (c) 2024 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Name LastName
 -/
 "

--- a/MathlibTest/Linter/Header/License.lean
+++ b/MathlibTest/Linter/Header/License.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 Oliver Butterley. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oliver Butterley
+-/
+
+import Mathlib.Tactic.Linter.Header
+
+/- Test that the expected copyright license line is configurable via `linter.style.header.license`
+(default: the Apache LICENSE line). We deliberately omit a module doc-string: the linter only checks
+the copyright for a command in the header region (before any module doc-string), so the first
+command below both triggers the copyright check and the incidental "missing module doc-string"
+warning. Setting a custom expected license flags this file's own (Apache default) second line. -/
+
+/--
+warning: * 'Released under Apache 2.0 license as described in the file LICENSE.':
+Second copyright line should be "Released under the Custom License."
+
+
+Note: This linter can be disabled with `set_option linter.style.header false`
+---
+warning: The module doc-string for a file should be the first command after the imports.
+Please, add a module doc-string before `def foo : Nat :=
+  37`.
+
+Note: This linter can be disabled with `set_option linter.style.header false`
+-/
+#guard_msgs in
+set_option linter.style.header.license "Released under the Custom License." in
+set_option linter.style.header true in
+def foo : Nat := 37


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
