### PR TITLE
[Merged by Bors] - chore(Order/Antidiag/Pi): review API and remove backward options

### DIFF
--- a/Mathlib/Algebra/Order/Antidiag/Pi.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Pi.lean
@@ -9,6 +9,7 @@ module
 public import Mathlib.Algebra.Group.Pointwise.Finset.Scalar
 public import Mathlib.Data.Fin.Tuple.NatAntidiagonal
 public import Mathlib.Data.Finset.Sym
+public import Mathlib.Algebra.Group.Pi.Lemmas
 
 /-!
 # Antidiagonal of functions as finsets
@@ -58,7 +59,6 @@ In this section, we define the antidiagonals in `Fin d → μ` by recursion on `
 computationally efficient, although probably not as efficient as `Finset.Nat.antidiagonalTuple`.
 -/
 
-set_option backward.isDefEq.respectTransparency.types false in
 /-- Auxiliary construction for `finAntidiagonal` that bundles a proof of lawfulness
 (`mem_finAntidiagonal`), as this is needed to invoke `disjiUnion`. Using `Finset.disjiUnion` makes
 this computationally much more efficient than using `Finset.biUnion`. -/
@@ -73,16 +73,10 @@ def finAntidiagonal.aux (d : ℕ) (n : μ) : {s : Finset (Fin d → μ) // ∀ f
     { val := (antidiagonal n).disjiUnion
         (fun ab => (aux d ab.2).1.map {
             toFun := Fin.cons (ab.1)
-            inj' := Fin.cons_right_injective _ })
-        (fun i _hi j _hj hij => Finset.disjoint_left.2 fun t hti htj => hij <| by
-          simp_rw [Finset.mem_map, Embedding.coeFn_mk] at hti htj
-          obtain ⟨ai, hai, hij'⟩ := hti
-          obtain ⟨aj, haj, rfl⟩ := htj
-          rw [Fin.cons_inj] at hij'
-          ext
-          · exact hij'.1
-          · obtain ⟨-, rfl⟩ := hij'
-            rw [← (aux d i.2).prop ai |>.mp hai, ← (aux d j.2).prop ai |>.mp haj])
+            inj' := Fin.cons_right_injective _ }) <| by
+        intro i _ j _ hij
+        simp only [Finset.disjoint_left, Finset.mem_map, Embedding.coeFn_mk]
+        grind [Fin.cons_inj]
       property := fun f => by
         simp_rw [mem_disjiUnion, mem_antidiagonal, mem_map, Embedding.coeFn_mk, Prod.exists,
           (aux d _).prop, Fin.sum_univ_succ]
@@ -92,7 +86,6 @@ def finAntidiagonal.aux (d : ℕ) (n : μ) : {s : Finset (Fin d → μ) // ∀ f
         · intro hf
           exact ⟨_, _, hf, _, rfl, Fin.cons_self_tail f⟩ }
 
-set_option backward.isDefEq.respectTransparency false in
 /-- `finAntidiagonal d n` is the type of `d`-tuples with sum `n`.
 
 TODO: deduplicate with the less general `Finset.Nat.antidiagonalTuple`. -/
@@ -109,13 +102,13 @@ choosing an identification `s ≃ Fin s.card` and proving that the end result do
 choice.
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The finset of functions `ι → μ` with support contained in `s` and sum `n`. -/
 def piAntidiag (s : Finset ι) (n : μ) : Finset (ι → μ) := by
   refine (Fintype.truncEquivFinOfCardEq <| Fintype.card_coe s).lift
     (fun e ↦ (finAntidiagonal s.card n).map ⟨fun f i ↦ if hi : i ∈ s then f (e ⟨i, hi⟩) else 0, ?_⟩)
     fun e₁ e₂ ↦ ?_
-  · rintro f g hfg
+  · rw [Injective]
+    rintro f g hfg
     ext i
     simpa using congr_fun hfg (e.symm i)
   · ext f
@@ -126,7 +119,6 @@ def piAntidiag (s : Finset ι) (n : μ) : Finset (ι → μ) := by
 
 variable {s : Finset ι} {n : μ} {f : ι → μ}
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp] lemma mem_piAntidiag : f ∈ piAntidiag s n ↔ s.sum f = n ∧ ∀ i, f i ≠ 0 → i ∈ s := by
   rw [piAntidiag]
   induction Fintype.truncEquivFinOfCardEq (Fintype.card_coe s) using Trunc.ind with | _ e
@@ -181,8 +173,7 @@ lemma piAntidiag_cons (hi : i ∉ s) (n : μ) :
   constructor
   · rintro ⟨hn, hf⟩
     refine ⟨_, _, hn, update f i 0, ⟨sum_update_of_notMem hi _ _, fun j ↦ ?_⟩, by aesop⟩
-    have := fun h₁ h₂ ↦ (hf j h₁).resolve_left h₂
-    aesop (add simp [update])
+    grind
   · rintro ⟨a, _, hn, g, ⟨rfl, hg⟩, rfl⟩
     have := hg i
     aesop (add simp [sum_add_distrib])
@@ -206,16 +197,14 @@ end CanonicallyOrderedAddCommMonoid
 section Nat
 variable [DecidableEq ι]
 
-/-- Local notation for the pointwise operation `n • s := {n • a | a ∈ s}` to avoid conflict with the
-pointwise operation `n • s := s + ... + s` (`n` times). -/
-local infixr:73 " •ℕ " => @SMul.smul _ _ Finset.smulFinset
+open Pointwise
 
 lemma piAntidiag_univ_fin_eq_antidiagonalTuple (n k : ℕ) :
     piAntidiag univ n = Nat.antidiagonalTuple k n := by
   ext; simp [Nat.mem_antidiagonalTuple]
 
 lemma nsmul_piAntidiag [DecidableEq (ι → ℕ)] (s : Finset ι) (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
-    n •ℕ piAntidiag s m = {f ∈ piAntidiag s (n * m) | ∀ i ∈ s, n ∣ f i} := by
+    n • piAntidiag s m = {f ∈ piAntidiag s (n * m) | ∀ i ∈ s, n ∣ f i} := by
   ext f
   refine mem_smul_finset.trans ?_
   simp only [mem_filter, mem_piAntidiag, and_assoc]
@@ -233,18 +222,16 @@ lemma nsmul_piAntidiag [DecidableEq (ι → ℕ)] (s : Finset ι) (m : ℕ) {n :
   grind
 
 lemma map_nsmul_piAntidiag (s : Finset ι) (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
-    (piAntidiag s m).map
-      ⟨(n • ·), fun _ _ h ↦ funext fun i ↦ mul_right_injective₀ hn (congr_fun h i)⟩ =
+    (piAntidiag s m).map ⟨(n • ·), nsmul_right_injective hn⟩ =
         {f ∈ piAntidiag s (n * m) | ∀ i ∈ s, n ∣ f i} := by
   classical rw [map_eq_image]; exact nsmul_piAntidiag _ _ hn
 
 lemma nsmul_piAntidiag_univ [Fintype ι] (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
-    n •ℕ (piAntidiag univ m) = {f ∈ piAntidiag (univ : Finset ι) (n * m) | ∀ i, n ∣ f i} := by
+    n • piAntidiag univ m = {f ∈ piAntidiag (univ : Finset ι) (n * m) | ∀ i, n ∣ f i} := by
   simpa using nsmul_piAntidiag (univ : Finset ι) m hn
 
 lemma map_nsmul_piAntidiag_univ [Fintype ι] (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
-    (piAntidiag (univ : Finset ι) m).map
-        ⟨(n • ·), fun _ _ h ↦ funext fun i ↦ mul_right_injective₀ hn (congr_fun h i)⟩ =
+    (piAntidiag (univ : Finset ι) m).map ⟨(n • ·), nsmul_right_injective hn⟩ =
       {f ∈ piAntidiag (univ : Finset ι) (n * m) | ∀ i, n ∣ f i} := by
   simpa using map_nsmul_piAntidiag (univ : Finset ι) m hn
 


### PR DESCRIPTION
This PR golfs some proofs, removes local notation (which means the theorem displays more nicely in Loogle + docs), and removes some `set_option backward.isDefEq.respectTransparency.types false in`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
