### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Floor/Ring): `positivity` for `Int.fract`

### DIFF
--- a/Mathlib/Algebra/Order/Floor/Ring.lean
+++ b/Mathlib/Algebra/Order/Floor/Ring.lean
@@ -104,6 +104,18 @@ meta def evalIntCeil : PositivityExt where eval {u α} _zα pα? e :=
     | _ => pure .none
   | _, _, _ => throwError "failed to match on Int.ceil application"
 
+theorem int_fract_nonneg [Ring α] [LinearOrder α] [FloorRing α] [IsOrderedRing α] (a : α) :
+    0 ≤ Int.fract a :=
+  sub_nonneg.2 (Int.floor_le a)
+
+/-- Extension for the `positivity` tactic: `Int.fract` is always nonnegative. -/
+@[positivity Int.fract _]
+meta def evalIntFract : PositivityExt where eval {_u} (_α _zα pα?) e :=
+  match pα? with | none => pure .none | some pα' => do
+  let ~q(@Int.fract _ (_) (_) (_) $a) := e | throwError "not Int.fract"
+  let pa' ← mkAppM ``int_fract_nonneg #[a]
+  pure (.nonnegative (pα := pα') pa')
+
 end Mathlib.Meta.Positivity
 
 variable {F R S : Type*}

--- a/Mathlib/Algebra/Order/Floor/Ring.lean
+++ b/Mathlib/Algebra/Order/Floor/Ring.lean
@@ -104,18 +104,6 @@ meta def evalIntCeil : PositivityExt where eval {u α} _zα pα? e :=
     | _ => pure .none
   | _, _, _ => throwError "failed to match on Int.ceil application"
 
-theorem int_fract_nonneg [Ring α] [LinearOrder α] [FloorRing α] [IsOrderedRing α] (a : α) :
-    0 ≤ Int.fract a :=
-  sub_nonneg.2 (Int.floor_le a)
-
-/-- Extension for the `positivity` tactic: `Int.fract` is always nonnegative. -/
-@[positivity Int.fract _]
-meta def evalIntFract : PositivityExt where eval {_u} (_α _zα pα?) e :=
-  match pα? with | none => pure .none | some pα' => do
-  let ~q(@Int.fract _ (_) (_) (_) $a) := e | throwError "not Int.fract"
-  let pa' ← mkAppM ``int_fract_nonneg #[a]
-  pure (.nonnegative (pα := pα') pa')
-
 end Mathlib.Meta.Positivity
 
 variable {F R S : Type*}
@@ -922,3 +910,17 @@ theorem subsingleton_floorRing {R} [Ring R] [LinearOrder R] : Subsingleton (Floo
     funext fun a => (H₁.gc_coe_floor.u_unique H₂.gc_coe_floor) fun _ => rfl
   have : H₁.ceil = H₂.ceil := funext fun a => (H₁.gc_ceil_coe.l_unique H₂.gc_ceil_coe) fun _ => rfl
   cases H₁; cases H₂; congr
+
+namespace Mathlib.Meta.Positivity
+
+open Lean.Meta Qq
+
+/-- Extension for the `positivity` tactic: `Int.fract` is always nonnegative. -/
+@[positivity Int.fract _]
+meta def evalIntFract : PositivityExt where eval {_u} (_α _zα pα?) e :=
+  match pα? with | none => pure .none | some pα' => do
+  let ~q(@Int.fract _ (_) (_) (_) $a) := e | throwError "not Int.fract"
+  let pa' ← mkAppM ``Int.fract_nonneg #[a]
+  pure (.nonnegative (pα := pα') pa')
+
+end Mathlib.Meta.Positivity

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -399,6 +399,8 @@ example {a : ℝ} (ha : 0 < a) : 0 < ⌈a⌉₊ := by positivity
 example {a : ℝ} (ha : 0 < a) : 0 < ⌈a⌉ := by positivity
 example {a : ℝ} (ha : 0 ≤ a) : 0 ≤ ⌈a⌉ := by positivity
 
+example (a : ℝ) : 0 ≤ Int.fract a := by positivity
+
 end FloorCeil
 
 section Abs


### PR DESCRIPTION

This PR adds a positivity extension for `Int.fract`, which is always nonnegative.

I used Claude Code to prepare this PR.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
