### PR TITLE
feat(Combinatorics/SimpleGraph/Hamiltonian): the Bondy-Chvátal theorem

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Bhavik Mehta, Rishi Mehta, Linus Sommer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Bhavik Mehta, Rishi Mehta, Linus Sommer, Yue Sun
+Authors: Bhavik Mehta, Rishi Mehta, Linus Sommer, Yue Sun, Snir Broshi
 -/
 module
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -284,4 +284,102 @@ theorem IsBridge.not_isHamiltonian {e : Sym2 α} (he : G.IsBridge e) : ¬G.IsHam
     (fun huv ↦ he <| .trans ?_ huv) he (hp.isHamiltonian_tail.mem_support v)
   apply hp.isTrail.isEdgeReachable_two <;> simp
 
+-- #41721
+set_option warn.sorry false in set_option linter.style.longLine false in
+theorem isHamiltonian_sup_edge {V : Type*} [DecidableEq V] [Fintype V] {G : SimpleGraph V} {u v : V} : (G ⊔ edge u v).IsHamiltonian ↔ G.IsHamiltonian ∨ ∃ p : G.Walk u v, p.IsHamiltonian ∧ 2 ≤ p.length := sorry
+
+section
+variable {V : Type*} {G H : SimpleGraph V}
+
+/-- **Bondy-Chvátal theorem**: Adding an edge to a graph where the sum of the degrees of its
+endpoints is at least the number of vertices does not change whether the graph is Hamiltonian. -/
+@[wikidata Q60978620]
+theorem isHamiltonian_sup_edge_iff_of_card_le_degree_add_degree [DecidableEq V] [Fintype V]
+    [G.LocallyFinite] {u v : V} (hdeg : Fintype.card V ≤ G.degree u + G.degree v) :
+    (G ⊔ edge u v).IsHamiltonian ↔ G.IsHamiltonian := by
+  refine ⟨fun hsup ↦ ?_, .mono le_sup_left⟩
+  by_contra hG
+  have ⟨p, hp, hlen⟩ := isHamiltonian_sup_edge.mp hsup |>.resolve_left hG
+  -- `p` is Hamiltonian and so its support contains all the vertices exactly once.
+  -- Since `a` is not adjacent to itself, all of its neighbors appear from index `1` to `|V| - 2`.
+  -- Since `b` is not adjacent to itself, all of its neighbors appear from index `0` to `|V| - 1`.
+  classical
+  let sa := (Finset.range <| Fintype.card V - 1).filter (G.Adj u <| p.getVert <| · + 1)
+  let sb := (Finset.range <| Fintype.card V - 1).filter (G.Adj v <| p.getVert ·)
+  have ha : (G.neighborFinset u).card ≤ sa.card := by
+    refine sa.card_le_card_of_surjOn (p.getVert <| · + 1) fun w hw ↦ ⟨p.support.idxOf w - 1, ?_⟩
+    have hadj := G.mem_neighborFinset u w |>.mp hw
+    have : p.support.idxOf w ≠ 0 := by grind [p.support_getElem_zero, hadj.ne]
+    grind [hp.length_support, hp.mem_support, p.getVert_support_idxOf]
+  have hb : (G.neighborFinset v).card ≤ sb.card := by
+    refine sb.card_le_card_of_surjOn p.getVert fun w hw ↦ ⟨p.support.idxOf w, ?_⟩
+    have hadj := G.mem_neighborFinset v w |>.mp hw
+    have : p.support.idxOf w ≠ p.support.length - 1 := by grind [p.support_getElem_length, hadj.ne]
+    grind [hp.length_support, hp.mem_support, p.getVert_support_idxOf]
+  -- By assumption `|V| ≤ G.degree u + G.degree v`, and we distributed the neighbors into `|V| - 1`
+  -- boxes, so by the piegonhole principle there must exist some `0 ≤ i < |V| - 1` such that
+  -- `G.Adj u (p.getVert (i + 1))` and `G.Adj v (p.getVert i)`.
+  grw [← card_neighborFinset_eq_degree, ← card_neighborFinset_eq_degree, ha, hb] at hdeg
+  have : 0 < Fintype.card V := Fintype.card_pos_iff.mpr ⟨v⟩
+  have ⟨i, hi⟩ := Finset.inter_nonempty_of_card_lt_card_add_card (t := sa) (u := sb)
+    (Finset.filter_subset ..) (Finset.filter_subset ..) (by grind [Finset.card_range])
+  have hia := (Finset.mem_filter.mp <| sa.mem_of_mem_inter_left hi).right
+  have hib := (Finset.mem_filter.mp <| sa.mem_of_mem_inter_right hi).right
+  -- Using those two edges and `p` we can construct a Hamiltonian cycle without `(u, v)`,
+  refine hG fun _ ↦ ⟨v, p.take i |>.reverse.cons hib |>.append <| p.drop (i + 1) |>.cons hia, ?_⟩
+  -- and so `G` is Hamiltonian; contradiction!
+  rw [Walk.isHamiltonianCycle_iff_isCycle_and_length_eq, Walk.isCycle_iff_isPath_tail_and_le_length]
+  simp [Walk.isPath_def, Walk.support_append, List.nodup_append]
+  grind [Walk.support_take_append_support_drop, hp.length_eq, hp.isPath.support_nodup]
+
+open scoped Classical in
+/-- Two graphs `G`, `G'` are related by the Bondy-Chvátal relation if `G'` is the result of adding
+an edge to `G` where the sum of the degrees of its endpoints is at least the number of vertices. -/
+def BondyChvatalRel [Fintype V] (G G' : SimpleGraph V) : Prop :=
+  ∃ u v, G' = G ⊔ edge u v ∧ Fintype.card V ≤ G.degree u + G.degree v
+
+/-- **Bondy-Chvátal theorem**, spelled using a relation. -/
+@[wikidata Q60978620]
+theorem isHamiltonian_iff_of_eqvGen_bondyChvatalRel [DecidableEq V] [Fintype V]
+    (h : Relation.EqvGen BondyChvatalRel G H) : G.IsHamiltonian ↔ H.IsHamiltonian := by
+  suffices BondyChvatalRel (V := V) ≤ Iff.onFun SimpleGraph.IsHamiltonian by
+    simpa [Equivalence.of_isEquiv _ |>.eqvGen_eq] using Relation.EqvGen.mono this G H h
+  rintro G H ⟨u, v, rfl, hdeg⟩
+  classical
+  exact .symm <| isHamiltonian_sup_edge_iff_of_card_le_degree_add_degree hdeg
+
+-- #34799
+set_option warn.sorry false in set_option linter.style.longLine false in
+theorem isHamiltonian_top {V : Type*} [Fintype V] [DecidableEq V] (h : 2 < Fintype.card V) : (completeGraph V).IsHamiltonian := sorry
+
+/-- **Ore's theorem**: If the sum of the degrees of every pair of non-adjacent vertices is at least
+the number of vertices, then the graph is Hamiltonian. -/
+@[wikidata Q225973]
+theorem isHamiltonian_of_pairwise_not_adj_imp_card_le_degree_add_degree [DecidableEq V] [Fintype V]
+    [G.LocallyFinite] (h₃ : 3 ≤ Fintype.card V)
+    (h : Pairwise fun u v ↦ ¬G.Adj u v → Fintype.card V ≤ G.degree u + G.degree v) :
+    G.IsHamiltonian := by
+  -- If `G` isn't Hamiltonian, there's a maximal non-Hamiltonian graph `H` that contains it.
+  by_contra hG
+  obtain ⟨H, hle, ⟨hH, hmax⟩⟩ := Finite.exists_le_maximal (p := (¬IsHamiltonian ·)) hG
+  -- Since the complete graph is Hamiltonian, `H` must be missing some edge `(u, v)`,
+  have ⟨u, v, hne, hadj⟩ := H.ne_top_iff_exists_not_adj.mp <| by grind [isHamiltonian_top]
+  -- and by maximality adding it to `H` results in a Hamiltonian graph.
+  have : (H ⊔ edge u v).IsHamiltonian := by grind [le_sup_left, sup_le_iff, edge_le_iff]
+  -- By assumption we have `|V| ≤ G.degree u + G.degree v`, and the same for `H` since `G ≤ H`.
+  have : Fintype.card V ≤ G.degree u + G.degree v := h hne <| mt (le_iff_adj.mp hle u v) hadj
+  classical
+  grw [degree_le_of_le hle, degree_le_of_le hle] at this
+  -- This contradicts the Bondy-Chvátal theorem.
+  grind [isHamiltonian_sup_edge_iff_of_card_le_degree_add_degree]
+
+/-- **Dirac's theorem**: If the degree of every vertex is least half of the number of vertices,
+then the graph is Hamiltonian. -/
+theorem isHamiltonian_of_forall_card_le_two_mul_degree {V : Type*} [DecidableEq V] [Fintype V]
+    {G : SimpleGraph V} [G.LocallyFinite] (h₃ : 3 ≤ Fintype.card V)
+    (h : ∀ v, Fintype.card V ≤ 2 * G.degree v) : G.IsHamiltonian :=
+  isHamiltonian_of_pairwise_not_adj_imp_card_le_degree_add_degree h₃ <| by grind [Pairwise]
+
+end
+
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -300,9 +300,9 @@ theorem isHamiltonian_sup_edge_iff_of_card_le_degree_add_degree [DecidableEq V] 
   refine ⟨fun hsup ↦ ?_, .mono le_sup_left⟩
   by_contra hG
   have ⟨p, hp, hlen⟩ := isHamiltonian_sup_edge.mp hsup |>.resolve_left hG
-  -- `p` is Hamiltonian and so its support contains all the vertices exactly once.
-  -- Since `u` is not adjacent to itself, all of its neighbors appear from index `1` to `|V| - 2`.
-  -- Since `v` is not adjacent to itself, all of its neighbors appear from index `0` to `|V| - 1`.
+  -- `p` is Hamiltonian and so its support contains all `|V|` vertices exactly once.
+  -- Since `u` is not adjacent to itself, all of its neighbors appear from index `1` to `|V| - 1`.
+  -- Since `v` is not adjacent to itself, all of its neighbors appear from index `0` to `|V| - 2`.
   classical
   let su := (Finset.range <| Fintype.card V - 1).filter (G.Adj u <| p.getVert <| · + 1)
   let sv := (Finset.range <| Fintype.card V - 1).filter (G.Adj v <| p.getVert ·)

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -301,18 +301,18 @@ theorem isHamiltonian_sup_edge_iff_of_card_le_degree_add_degree [DecidableEq V] 
   by_contra hG
   have ⟨p, hp, hlen⟩ := isHamiltonian_sup_edge.mp hsup |>.resolve_left hG
   -- `p` is Hamiltonian and so its support contains all the vertices exactly once.
-  -- Since `a` is not adjacent to itself, all of its neighbors appear from index `1` to `|V| - 2`.
-  -- Since `b` is not adjacent to itself, all of its neighbors appear from index `0` to `|V| - 1`.
+  -- Since `u` is not adjacent to itself, all of its neighbors appear from index `1` to `|V| - 2`.
+  -- Since `v` is not adjacent to itself, all of its neighbors appear from index `0` to `|V| - 1`.
   classical
-  let sa := (Finset.range <| Fintype.card V - 1).filter (G.Adj u <| p.getVert <| · + 1)
-  let sb := (Finset.range <| Fintype.card V - 1).filter (G.Adj v <| p.getVert ·)
-  have ha : (G.neighborFinset u).card ≤ sa.card := by
-    refine sa.card_le_card_of_surjOn (p.getVert <| · + 1) fun w hw ↦ ⟨p.support.idxOf w - 1, ?_⟩
+  let su := (Finset.range <| Fintype.card V - 1).filter (G.Adj u <| p.getVert <| · + 1)
+  let sv := (Finset.range <| Fintype.card V - 1).filter (G.Adj v <| p.getVert ·)
+  have ha : (G.neighborFinset u).card ≤ su.card := by
+    refine su.card_le_card_of_surjOn (p.getVert <| · + 1) fun w hw ↦ ⟨p.support.idxOf w - 1, ?_⟩
     have hadj := G.mem_neighborFinset u w |>.mp hw
     have : p.support.idxOf w ≠ 0 := by grind [p.support_getElem_zero, hadj.ne]
     grind [hp.length_support, hp.mem_support, p.getVert_support_idxOf]
-  have hb : (G.neighborFinset v).card ≤ sb.card := by
-    refine sb.card_le_card_of_surjOn p.getVert fun w hw ↦ ⟨p.support.idxOf w, ?_⟩
+  have hb : (G.neighborFinset v).card ≤ sv.card := by
+    refine sv.card_le_card_of_surjOn p.getVert fun w hw ↦ ⟨p.support.idxOf w, ?_⟩
     have hadj := G.mem_neighborFinset v w |>.mp hw
     have : p.support.idxOf w ≠ p.support.length - 1 := by grind [p.support_getElem_length, hadj.ne]
     grind [hp.length_support, hp.mem_support, p.getVert_support_idxOf]
@@ -321,10 +321,10 @@ theorem isHamiltonian_sup_edge_iff_of_card_le_degree_add_degree [DecidableEq V] 
   -- `G.Adj u (p.getVert (i + 1))` and `G.Adj v (p.getVert i)`.
   grw [← card_neighborFinset_eq_degree, ← card_neighborFinset_eq_degree, ha, hb] at hdeg
   have : 0 < Fintype.card V := Fintype.card_pos_iff.mpr ⟨v⟩
-  have ⟨i, hi⟩ := Finset.inter_nonempty_of_card_lt_card_add_card (t := sa) (u := sb)
+  have ⟨i, hi⟩ := Finset.inter_nonempty_of_card_lt_card_add_card (t := su) (u := sv)
     (Finset.filter_subset ..) (Finset.filter_subset ..) (by grind [Finset.card_range])
-  have hia := (Finset.mem_filter.mp <| sa.mem_of_mem_inter_left hi).right
-  have hib := (Finset.mem_filter.mp <| sa.mem_of_mem_inter_right hi).right
+  have hia := (Finset.mem_filter.mp <| su.mem_of_mem_inter_left hi).right
+  have hib := (Finset.mem_filter.mp <| su.mem_of_mem_inter_right hi).right
   -- Using those two edges and `p` we can construct a Hamiltonian cycle without `(u, v)`,
   refine hG fun _ ↦ ⟨v, p.take i |>.reverse.cons hib |>.append <| p.drop (i + 1) |>.cons hia, ?_⟩
   -- and so `G` is Hamiltonian; contradiction!

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -297,10 +297,10 @@ endpoints is at least the number of vertices does not change whether the graph i
 theorem isHamiltonian_sup_edge_iff_of_card_le_degree_add_degree [DecidableEq V] [Fintype V]
     [G.LocallyFinite] {u v : V} (hdeg : Fintype.card V ≤ G.degree u + G.degree v) :
     (G ⊔ edge u v).IsHamiltonian ↔ G.IsHamiltonian := by
-  refine ⟨fun hsup ↦ ?_, .mono le_sup_left⟩
-  by_contra hG
-  have ⟨p, hp, hlen⟩ := isHamiltonian_sup_edge.mp hsup |>.resolve_left hG
-  -- `p` is Hamiltonian and so its support contains all `|V|` vertices exactly once.
+  -- The reverse implication is trivial. For the forward direction, since `G` with `(u, v)` is
+  -- Hamiltonian, `G` must either be Hamiltonian or have a Hamiltonian path `p` from `u` to `v`.
+  refine ⟨(isHamiltonian_sup_edge.mp · |>.elim id fun ⟨p, hp, hlen⟩ _ ↦ ?_), .mono le_sup_left⟩
+  -- `p` is a Hamiltonian path and so its support contains all `|V|` vertices exactly once.
   -- Since `u` is not adjacent to itself, all of its neighbors appear from index `1` to `|V| - 1`.
   -- Since `v` is not adjacent to itself, all of its neighbors appear from index `0` to `|V| - 2`.
   classical
@@ -326,8 +326,7 @@ theorem isHamiltonian_sup_edge_iff_of_card_le_degree_add_degree [DecidableEq V] 
   have hia := (Finset.mem_filter.mp <| su.mem_of_mem_inter_left hi).right
   have hib := (Finset.mem_filter.mp <| su.mem_of_mem_inter_right hi).right
   -- Using those two edges and `p` we can construct a Hamiltonian cycle without `(u, v)`,
-  refine hG fun _ ↦ ⟨v, p.take i |>.reverse.cons hib |>.append <| p.drop (i + 1) |>.cons hia, ?_⟩
-  -- and so `G` is Hamiltonian; contradiction!
+  refine ⟨v, p.take i |>.reverse.cons hib |>.append <| p.drop (i + 1) |>.cons hia, ?_⟩
   rw [Walk.isHamiltonianCycle_iff_isCycle_and_length_eq, Walk.isCycle_iff_isPath_tail_and_le_length]
   simp [Walk.isPath_def, Walk.support_append, List.nodup_append]
   grind [Walk.support_take_append_support_drop, hp.length_eq, hp.isPath.support_nodup]

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -291,7 +291,7 @@ theorem isHamiltonian_sup_edge {V : Type*} [DecidableEq V] [Fintype V] {G : Simp
 section
 variable {V : Type*} {G H : SimpleGraph V}
 
-/-- **Bondy-Chvátal theorem**: Adding an edge to a graph where the sum of the degrees of its
+/-- The **Bondy-Chvátal theorem**: Adding an edge to a graph where the sum of the degrees of its
 endpoints is at least the number of vertices does not change whether the graph is Hamiltonian. -/
 @[wikidata Q60978620]
 theorem isHamiltonian_sup_edge_iff_of_card_le_degree_add_degree [DecidableEq V] [Fintype V]
@@ -338,7 +338,7 @@ an edge to `G` where the sum of the degrees of its endpoints is at least the num
 def BondyChvatalRel [Fintype V] (G G' : SimpleGraph V) : Prop :=
   ∃ u v, G' = G ⊔ edge u v ∧ Fintype.card V ≤ G.degree u + G.degree v
 
-/-- **Bondy-Chvátal theorem**, spelled using a relation. -/
+/-- The **Bondy-Chvátal theorem**, spelled using a relation. -/
 @[wikidata Q60978620]
 theorem isHamiltonian_iff_of_eqvGen_bondyChvatalRel [DecidableEq V] [Fintype V]
     (h : Relation.EqvGen BondyChvatalRel G H) : G.IsHamiltonian ↔ H.IsHamiltonian := by

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Operations.lean
@@ -37,7 +37,7 @@ namespace SimpleGraph
 namespace Walk
 
 universe u
-variable {V : Type u} {G : SimpleGraph V} {u v w : V}
+variable {V : Type u} {G : SimpleGraph V} {u v w : V} {p : G.Walk u v}
 
 /-- Change the endpoints of a walk using equalities. This is helpful for relaxing
 definitional equality constraints and to be able to state otherwise difficult-to-state
@@ -679,6 +679,10 @@ lemma nil_drop_of_length_le {u v n} {p : G.Walk u v} (h : p.length ≤ n) :
 lemma drop_support_eq_support_drop_min {u v} (p : G.Walk u v) (n : ℕ) :
     (p.drop n).support = p.support.drop (n ⊓ p.length) := by
   induction p generalizing n <;> cases n <;> simp [*, drop]
+
+theorem support_take_append_support_drop {i : ℕ} (h : i < p.length) :
+    (p.take i).support ++ (p.drop (i + 1)).support = p.support := by
+  simp [support_take, drop_support_eq_support_drop_min, Nat.succ_le_of_lt h]
 
 @[simp]
 theorem append_take_drop_eq (p : G.Walk u v) (n : ℕ) : (p.take n).append (p.drop n) = p := by

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -238,6 +238,9 @@ Q220680:
 
 Q225973:
   title: Ore's theorem
+  decl: SimpleGraph.isHamiltonian_of_pairwise_not_adj_imp_card_le_degree_add_degree
+  authors: Snir Broshi
+  date: 2026-07
 
 Q226014:
   title: Poincaré recurrence theorem
@@ -309,6 +312,11 @@ Q268132:
 
 Q273037:
   title: Bondy–Chvátal theorem
+  decls:
+    - SimpleGraph.isHamiltonian_sup_edge_iff_of_card_le_degree_add_degree
+    - SimpleGraph.isHamiltonian_iff_of_eqvGen_bondyChvatalRel
+  authors: Snir Broshi
+  date: 2026-07
 
 Q276082:
   title: Wilson's theorem


### PR DESCRIPTION
Proves the Bondy-Chvátal theorem and its corollaries, Ore's theorem and Dirac's theorem.

[Wikipedia](https://en.wikipedia.org/wiki/Hamiltonian_path#Bondy%E2%80%93Chv%C3%A1tal_theorem)

---
The proof is detailed on the wiki page of [Ore's theorem](https://en.wikipedia.org/wiki/Ore's_theorem#Proof), with a nice illustration.

The wikidata item in `1000.yaml` points to [Hamiltonian path](https://www.wikidata.org/wiki/Q273037), but I found [one specifically about the theorem](https://www.wikidata.org/wiki/Q60978620).

I'm not sure about the `BondyChvatalRel` spelling, but it seems more faithful to the "Bondy-Chvátal closure" spelling (on Wikipedia and other places). We could also modify the def to remove self loops (by adding `G ≠ G' ∧ ...`, or more explicitly `u ≠ v ∧ ¬G.Adj u v`), prove it has no directed cycles and that it satisfies Church-Rosser, then define the closure of `G` as the (unique) normal form of it under this relation.

Wikipedia also mentions this theorem about Hamiltonian paths:
```lean
/-- **Rahman-Kaykobad theorem**: If for every pair of non-adjacent vertices the sum of their degrees
and the distance between them is greater than the number of vertices, then there exists a
Hamiltonian path. -/
theorem exists_isHamiltonian_of_pairwise_not_adj_imp_card_lt_degree_add_dist {V : Type*}
    [DecidableEq V] [Nonempty V] [Fintype V] {G : SimpleGraph V} [G.LocallyFinite]
    (h : Pairwise fun u v ↦ ¬G.Adj u v → Fintype.card V < G.degree u + G.degree v + G.dist u v) :
    ∃ (u v : V) (p : G.Walk u v), p.IsHamiltonian := by
  sorry
```
I'm not sure if it's a corollary of Bondy-Chvátal, but I think the proof is similar, so it's a good next target.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #41721
- [ ] depends on: #34799

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
