### PR TITLE
[Merged by Bors] - chore: fix argument names of `MonoidAlgebra.induction_on`

### DIFF
--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -443,10 +443,10 @@ lemma induction {motive : R[M] → Prop} (x : R[M])
     (by simpa using zero) (fun m r x ↦ single_add m r (ofCoeff x))
 
 @[to_additive (attr := elab_as_elim)]
-lemma induction_linear {p : R[M] → Prop} (x : R[M]) (zero : p 0)
-    (add : ∀ x y : R[M], p x → p y → p (x + y))
-    (single : ∀ m r, p (single m r)) : p x :=
-  Finsupp.induction_linear (motive := (p <| ofCoeff ·)) x.coeff zero (fun _ _ ↦ add _ _)
+lemma induction_linear {motive : R[M] → Prop} (x : R[M]) (zero : motive 0)
+    (add : ∀ x y : R[M], motive x → motive y → motive (x + y))
+    (single : ∀ m r, motive (single m r)) : motive x :=
+  Finsupp.induction_linear (motive := (motive <| ofCoeff ·)) x.coeff zero (fun _ _ ↦ add _ _)
     (fun _ _ ↦ single _ _)
 
 @[to_additive (attr := simp) addSubmonoidClosure_single]

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -730,12 +730,12 @@ lemma single_pow (m : M) (r : R) : ∀ n : ℕ, single m r ^ n = single (m ^ n) 
   | n + 1 => by simp [pow_succ, single_pow _ _ n]
 
 lemma induction_on {motive : R[M] → Prop} (x : R[M])
-    (of : ∀ m, motive (of R M m)) (add : ∀ x y : R[M], motive x → motive y → motive (x + y))
+    (of : ∀ m, motive (.of R M m)) (add : ∀ x y : R[M], motive x → motive y → motive (x + y))
     (smul : ∀ (r : R) (x), motive x → motive (r • x)) : motive x :=
   Finsupp.induction_linear (motive := fun x ↦ motive <| ofCoeff x) x.coeff
-    (by simpa using smul 0 (MonoidAlgebra.of R M 1) (of 1))
+    (by simpa using smul 0 (.of R M 1) (of 1))
     (fun x y hf hg ↦ add (ofCoeff x) (ofCoeff y) hf hg)
-    fun m r ↦ by simpa using smul r (MonoidAlgebra.of R M m) (of m)
+    fun m r ↦ by simpa using smul r (.of R M m) (of m)
 
 @[to_additive (dont_translate := R)]
 instance isLocalHom_singleOneRingHom : IsLocalHom (singleOneRingHom (R := R) (M := M)) where
@@ -1002,13 +1002,13 @@ def singleHom [AddZeroClass M] : R × Multiplicative M →* R[M] where
 
 set_option backward.isDefEq.respectTransparency false in
 theorem induction_on [AddMonoid M] {motive : R[M] → Prop} (x : R[M])
-    (of : ∀ m, motive (of R M <| .ofAdd m))
+    (of : ∀ m, motive (.of R M <| .ofAdd m))
     (add : ∀ x y : R[M], motive x → motive y → motive (x + y))
     (smul : ∀ (r : R) (x), motive x → motive (r • x)) : motive x :=
   Finsupp.induction_linear (motive := fun x ↦ motive (ofCoeff x)) x.coeff
-    (by simpa using smul 0 (AddMonoidAlgebra.of R M 1) (of 0))
+    (by simpa using smul 0 (.of R M 1) (of 0))
     (fun x y hf hg ↦ add (ofCoeff x) (ofCoeff y) hf hg)
-    fun m r ↦ by simpa using! smul r (AddMonoidAlgebra.of R M m) (of m)
+    fun m r ↦ by simpa using! smul r (.of R M m) (of m)
 
 /-- If two ring homomorphisms from `R[M]` are equal on all `single m 1`
 and `single 0 r`, then they are equal.

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -729,13 +729,13 @@ lemma single_pow (m : M) (r : R) : ∀ n : ℕ, single m r ^ n = single (m ^ n) 
   | 0 => by simp [one_def]
   | n + 1 => by simp [pow_succ, single_pow _ _ n]
 
-lemma induction_on {p : R[M] → Prop} (x : R[M])
-    (hM : ∀ m, p (of R M m)) (hadd : ∀ x y : R[M], p x → p y → p (x + y))
-    (hsmul : ∀ (r : R) (x), p x → p (r • x)) : p x :=
-  Finsupp.induction_linear (motive := fun x ↦ p <| ofCoeff x) x.coeff
-    (by simpa using hsmul 0 (of R M 1) (hM 1))
-    (fun x y hf hg ↦ hadd (ofCoeff x) (ofCoeff y) hf hg)
-    fun m r ↦ by simpa using hsmul r (of R M m) (hM m)
+lemma induction_on {motive : R[M] → Prop} (x : R[M])
+    (of : ∀ m, motive (of R M m)) (add : ∀ x y : R[M], motive x → motive y → motive (x + y))
+    (smul : ∀ (r : R) (x), motive x → motive (r • x)) : motive x :=
+  Finsupp.induction_linear (motive := fun x ↦ motive <| ofCoeff x) x.coeff
+    (by simpa using smul 0 (MonoidAlgebra.of R M 1) (of 1))
+    (fun x y hf hg ↦ add (ofCoeff x) (ofCoeff y) hf hg)
+    fun m r ↦ by simpa using smul r (MonoidAlgebra.of R M m) (of m)
 
 @[to_additive (dont_translate := R)]
 instance isLocalHom_singleOneRingHom : IsLocalHom (singleOneRingHom (R := R) (M := M)) where

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -1001,13 +1001,14 @@ def singleHom [AddZeroClass M] : R × Multiplicative M →* R[M] where
   map_mul' _a _b := (single_mul_single ..).symm
 
 set_option backward.isDefEq.respectTransparency false in
-theorem induction_on [AddMonoid M] {p : R[M] → Prop} (x : R[M])
-    (hM : ∀ m, p (of R M <| .ofAdd m)) (hadd : ∀ x y : R[M], p x → p y → p (x + y))
-    (hsmul : ∀ (r : R) (x), p x → p (r • x)) : p x :=
-  Finsupp.induction_linear (motive := fun x ↦ p (ofCoeff x)) x.coeff
-    (by simpa using hsmul 0 (of R M 1) (hM 0))
-    (fun x y hf hg ↦ hadd (ofCoeff x) (ofCoeff y) hf hg)
-    fun m r ↦ by simpa using! hsmul r (of R M m) (hM m)
+theorem induction_on [AddMonoid M] {motive : R[M] → Prop} (x : R[M])
+    (of : ∀ m, motive (of R M <| .ofAdd m))
+    (add : ∀ x y : R[M], motive x → motive y → motive (x + y))
+    (smul : ∀ (r : R) (x), motive x → motive (r • x)) : motive x :=
+  Finsupp.induction_linear (motive := fun x ↦ motive (ofCoeff x)) x.coeff
+    (by simpa using smul 0 (AddMonoidAlgebra.of R M 1) (of 0))
+    (fun x y hf hg ↦ add (ofCoeff x) (ofCoeff y) hf hg)
+    fun m r ↦ by simpa using! smul r (AddMonoidAlgebra.of R M m) (of m)
 
 /-- If two ring homomorphisms from `R[M]` are equal on all `single m 1`
 and `single 0 r`, then they are equal.

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -497,9 +497,9 @@ variable {k G V : Type*} [CommSemiring k] [Group G] [AddCommMonoid V] [Module k 
 lemma asAlgebraHom_ofMulAction_smul_eq_mul (x y : k[G]) :
     (ofMulAction k G G).asAlgebraHom x y = x * y := by
   induction x using induction_on with
-  | hM g => ext; simp [MonoidAlgebra.coeff_single_mul_apply]
-  | hadd x y hx hy => simp [hx, hy, add_mul]
-  | hsmul r x hx => simp [← hx]
+  | of g => ext; simp [MonoidAlgebra.coeff_single_mul_apply]
+  | add x y hx hy => simp [hx, hy, add_mul]
+  | smul r x hx => simp [← hx]
 
 @[deprecated (since := "2026-06-18")]
 alias ofMulAction_self_smul_eq_mul := asAlgebraHom_ofMulAction_smul_eq_mul

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -382,7 +382,7 @@ theorem mvPolynomial_aeval_of_surjective_of_closure [AddCommMonoid M] [CommSemir
       (MvPolynomial.aeval fun s : S => of' R M ↑s : MvPolynomial S R → R[M]) := by
   intro f
   induction f using induction_on with
-  | hM m =>
+  | of m =>
     have : m ∈ closure S := hS.symm ▸ mem_top _
     refine AddSubmonoid.closure_induction (fun m hm => ?_) ?_ ?_ this
     · exact ⟨MvPolynomial.X ⟨m, hm⟩, MvPolynomial.aeval_X _ _⟩
@@ -392,11 +392,11 @@ theorem mvPolynomial_aeval_of_surjective_of_closure [AddCommMonoid M] [CommSemir
         ⟨P₁ * P₂, by
           rw [map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single,
             one_mul]; rfl⟩
-  | hadd f g ihf ihg =>
+  | add f g ihf ihg =>
     rcases ihf with ⟨P, rfl⟩
     rcases ihg with ⟨Q, rfl⟩
     exact ⟨P + Q, map_add _ _ _⟩
-  | hsmul r f ih =>
+  | smul r f ih =>
     rcases ih with ⟨P, rfl⟩
     exact ⟨r • P, map_smul _ _ _⟩
 
@@ -410,7 +410,7 @@ theorem freeAlgebra_lift_of_surjective_of_closure [CommSemiring R] {S : Set M}
       (FreeAlgebra.lift R fun s : S => of' R M ↑s : FreeAlgebra R S → R[M]) := by
   intro f
   induction f using induction_on with
-  | hM m =>
+  | of m =>
     have : m ∈ closure S := hS.symm ▸ mem_top _
     refine AddSubmonoid.closure_induction (fun m hm => ?_) ?_ ?_ this
     · exact ⟨FreeAlgebra.ι R ⟨m, hm⟩, FreeAlgebra.lift_ι_apply _ _⟩
@@ -420,11 +420,11 @@ theorem freeAlgebra_lift_of_surjective_of_closure [CommSemiring R] {S : Set M}
         ⟨P₁ * P₂, by
           rw [map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single,
             one_mul]; rfl⟩
-  | hadd f g ihf ihg =>
+  | add f g ihf ihg =>
     rcases ihf with ⟨P, rfl⟩
     rcases ihg with ⟨Q, rfl⟩
     exact ⟨P + Q, map_add _ _ _⟩
-  | hsmul r f ih =>
+  | smul r f ih =>
     rcases ih with ⟨P, rfl⟩
     exact ⟨r • P, map_smul _ _ _⟩
 
@@ -531,7 +531,7 @@ theorem mvPolynomial_aeval_of_surjective_of_closure [CommMonoid M] [CommSemiring
       (MvPolynomial.aeval fun s : S => of R M ↑s : MvPolynomial S R → R[M]) := by
   intro f
   induction f using induction_on with
-  | hM m =>
+  | of m =>
     have : m ∈ closure S := hS.symm ▸ mem_top _
     refine Submonoid.closure_induction (fun m hm => ?_) ?_ ?_ this
     · exact ⟨MvPolynomial.X ⟨m, hm⟩, MvPolynomial.aeval_X _ _⟩
@@ -540,10 +540,10 @@ theorem mvPolynomial_aeval_of_surjective_of_closure [CommMonoid M] [CommSemiring
       exact
         ⟨P₁ * P₂, by
           rw [map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single, one_mul]⟩
-  | hadd f g ihf ihg =>
+  | add f g ihf ihg =>
     rcases ihf with ⟨P, rfl⟩; rcases ihg with ⟨Q, rfl⟩
     exact ⟨P + Q, map_add _ _ _⟩
-  | hsmul r f ih =>
+  | smul r f ih =>
     rcases ih with ⟨P, rfl⟩
     exact ⟨r • P, map_smul _ _ _⟩
 
@@ -558,7 +558,7 @@ theorem freeAlgebra_lift_of_surjective_of_closure [CommSemiring R] {S : Set M}
       (FreeAlgebra.lift R fun s : S => of R M ↑s : FreeAlgebra R S → R[M]) := by
   intro f
   induction f using induction_on with
-  | hM m =>
+  | of m =>
     have : m ∈ closure S := hS.symm ▸ mem_top _
     refine Submonoid.closure_induction (fun m hm => ?_) ?_ ?_ this
     · exact ⟨FreeAlgebra.ι R ⟨m, hm⟩, FreeAlgebra.lift_ι_apply _ _⟩
@@ -567,11 +567,11 @@ theorem freeAlgebra_lift_of_surjective_of_closure [CommSemiring R] {S : Set M}
       exact
         ⟨P₁ * P₂, by
           rw [map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single, one_mul]⟩
-  | hadd f g ihf ihg =>
+  | add f g ihf ihg =>
     rcases ihf with ⟨P, rfl⟩
     rcases ihg with ⟨Q, rfl⟩
     exact ⟨P + Q, map_add _ _ _⟩
-  | hsmul r f ih =>
+  | smul r f ih =>
     rcases ih with ⟨P, rfl⟩
     exact ⟨r • P, map_smul _ _ _⟩
 


### PR DESCRIPTION
Fix argument names for `MonoidAlgebra.induction_on` and `AddMonoidAlgebra.induction_on` and `MonoidAlgebra.induction_linear`. Name the motive `motive` and name the minor premises according to their contents.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
