### PR TITLE
feat: make `NegZeroClass` and `InvOneClass` mixins

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -336,6 +336,24 @@ theorem div_eq_mul_one_div (a b : G) : a / b = a * (1 / b) := by rw [div_eq_mul_
 
 end DivInvMonoid
 
+section InvOneClass
+
+variable [InvolutiveInv α] [One α] [InvOneClass α] {a : α}
+
+@[to_additive (attr := simp)]
+theorem inv_eq_one : a⁻¹ = 1 ↔ a = 1 :=
+  inv_injective.eq_iff' inv_one
+
+@[to_additive (attr := simp)]
+theorem one_eq_inv : 1 = a⁻¹ ↔ a = 1 :=
+  eq_comm.trans inv_eq_one
+
+@[to_additive]
+theorem inv_ne_one : a⁻¹ ≠ 1 ↔ a ≠ 1 :=
+  inv_eq_one.not
+
+end InvOneClass
+
 section DivInvOneMonoid
 
 variable [DivInvOneMonoid G]
@@ -445,18 +463,6 @@ lemma one_div_pow (a : α) (n : ℕ) : (1 / a) ^ n = 1 / a ^ n := by simp only [
 lemma one_div_zpow (a : α) (n : ℤ) : (1 / a) ^ n = 1 / a ^ n := by simp only [one_div, inv_zpow]
 
 variable {a b c}
-
-@[to_additive (attr := simp)]
-theorem inv_eq_one : a⁻¹ = 1 ↔ a = 1 :=
-  inv_injective.eq_iff' inv_one
-
-@[to_additive (attr := simp)]
-theorem one_eq_inv : 1 = a⁻¹ ↔ a = 1 :=
-  eq_comm.trans inv_eq_one
-
-@[to_additive]
-theorem inv_ne_one : a⁻¹ ≠ 1 ↔ a ≠ 1 :=
-  inv_eq_one.not
 
 @[to_additive]
 theorem eq_of_one_div_eq_one_div (h : 1 / a = 1 / b) : a = b := by

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -1135,7 +1135,7 @@ end DivInvMonoid
 section InvOneClass
 
 /-- Typeclass for expressing that `-0 = 0`. -/
-class NegZeroClass (G : Type*) extends Zero G, Neg G where
+class NegZeroClass (G : Type*) [Zero G] [Neg G] where
   protected neg_zero : -(0 : G) = 0
 
 /-- A `SubNegMonoid` where `-0 = 0`. -/
@@ -1143,14 +1143,14 @@ class SubNegZeroMonoid (G : Type*) extends SubNegMonoid G, NegZeroClass G
 
 /-- Typeclass for expressing that `1⁻¹ = 1`. -/
 @[to_additive]
-class InvOneClass (G : Type*) extends One G, Inv G where
+class InvOneClass (G : Type*) [One G] [Inv G] where
   protected inv_one : (1 : G)⁻¹ = 1
 
 /-- A `DivInvMonoid` where `1⁻¹ = 1`. -/
 @[to_additive]
 class DivInvOneMonoid (G : Type*) extends DivInvMonoid G, InvOneClass G
 
-variable [InvOneClass G]
+variable [One G] [Inv G] [InvOneClass G]
 
 @[to_additive (attr := simp)]
 theorem inv_one : (1 : G)⁻¹ = 1 :=

--- a/Mathlib/Algebra/Group/EvenFunction.lean
+++ b/Mathlib/Algebra/Group/EvenFunction.lean
@@ -47,7 +47,8 @@ lemma Even.zero [Zero β] : Function.Even (fun (_ : α) ↦ (0 : β)) := Even.co
 lemma Odd.eq [Neg β] {f : α → β} (hf : f.Odd) (x : α) : f (-x) = -f x := hf x
 
 /-- The zero function is odd. -/
-lemma Odd.zero [NegZeroClass β] : Function.Odd (fun (_ : α) ↦ (0 : β)) := fun _ ↦ neg_zero.symm
+lemma Odd.zero [Zero β] [Neg β] [NegZeroClass β] :
+    Function.Odd (fun (_ : α) ↦ (0 : β)) := fun _ ↦ neg_zero.symm
 
 section composition
 
@@ -161,7 +162,8 @@ lemma Odd.sum_eq_zero [Fintype α] [InvolutiveNeg α] {f : α → β} (hf : f.Od
   hf.finsetSum_eq_zero <| Finset.map_univ_equiv (Equiv.neg α)
 
 /-- An odd function vanishes at zero. -/
-lemma Odd.map_zero [NegZeroClass α] (hf : f.Odd) : f 0 = 0 := by simp [← neg_eq_self, ← hf 0]
+lemma Odd.map_zero [Zero α] [Neg α] [NegZeroClass α] (hf : f.Odd) :
+    f 0 = 0 := by simp [← neg_eq_self, ← hf 0]
 
 end torsionfree
 

--- a/Mathlib/Algebra/Group/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Finsupp.lean
@@ -414,15 +414,17 @@ lemma mapRange.addEquiv_toEquiv (e : M ≃+ N) :
 
 end AddCommMonoid
 
-instance instNeg [NegZeroClass G] : Neg (ι →₀ G) where neg := mapRange Neg.neg neg_zero
+instance instNeg [Zero G] [Neg G] [NegZeroClass G] : Neg (ι →₀ G) where
+  neg := mapRange Neg.neg neg_zero
 
-@[simp, norm_cast] lemma coe_neg [NegZeroClass G] (g : ι →₀ G) : ⇑(-g) = -g := rfl
+@[simp, norm_cast] lemma coe_neg [Zero G] [Neg G] [NegZeroClass G] (g : ι →₀ G) : ⇑(-g) = -g := rfl
 
-lemma neg_apply [NegZeroClass G] (g : ι →₀ G) (a : ι) : (-g) a = -g a :=
+lemma neg_apply [Zero G] [Neg G] [NegZeroClass G] (g : ι →₀ G) (a : ι) : (-g) a = -g a :=
   rfl
 
-lemma mapRange_neg [NegZeroClass G] [NegZeroClass H] {f : G → H} {hf : f 0 = 0}
-    (hf' : ∀ x, f (-x) = -f x) (v : ι →₀ G) : mapRange f hf (-v) = -mapRange f hf v :=
+lemma mapRange_neg [Zero G] [Neg G] [NegZeroClass G] [Zero H] [Neg H] [NegZeroClass H]
+    {f : G → H} {hf : f 0 = 0} (hf' : ∀ x, f (-x) = -f x) (v : ι →₀ G) :
+    mapRange f hf (-v) = -mapRange f hf v :=
   ext fun _ => by simp only [hf', neg_apply, mapRange_apply]
 
 instance instSub [SubNegZeroMonoid G] : Sub (ι →₀ G) :=

--- a/Mathlib/Algebra/Group/Hom/Basic.lean
+++ b/Mathlib/Algebra/Group/Hom/Basic.lean
@@ -101,20 +101,21 @@ theorem mul_comp [One M] [One N] [MulOneClass P] (g₁ g₂ : OneHom N P) (f : O
 `f⁻¹` is the one-preserving morphism sending `x` to `(f x)⁻¹`. -/
 @[to_additive /-- Given a zero-preserving morphism `f`,
 `-f` is the zero-preserving morphism sending `x` to `-f x`. -/]
-instance [One M] [InvOneClass N] : Inv (OneHom M N) where
+instance [One M] [One N] [Inv N] [InvOneClass N] : Inv (OneHom M N) where
   inv f :=
     { toFun m := (f m)⁻¹
       map_one' := by simp }
 
 @[to_additive (attr := norm_cast)]
-theorem coe_inv {M N} [One M] [InvOneClass N] (f : OneHom M N) : ⇑(f⁻¹) = (⇑f)⁻¹ := rfl
+theorem coe_inv {M N} [One M] [One N] [Inv N] [InvOneClass N] (f : OneHom M N) :
+    ⇑(f⁻¹) = (⇑f)⁻¹ := rfl
 
 @[to_additive (attr := simp)]
-theorem inv_apply {M N} [One M] [InvOneClass N] (f : OneHom M N) (x : M) :
+theorem inv_apply {M N} [One M] [One N] [Inv N] [InvOneClass N] (f : OneHom M N) (x : M) :
     f⁻¹ x = (f x)⁻¹ := rfl
 
 @[to_additive]
-theorem inv_comp [One M] [One N] [InvOneClass P] (g : OneHom N P) (f : OneHom M N) :
+theorem inv_comp [One M] [One N] [One P] [Inv P] [InvOneClass P] (g : OneHom N P) (f : OneHom M N) :
     (g⁻¹).comp f = (g.comp f)⁻¹ := rfl
 
 /-- Given two one-preserving morphisms `f`, `g`,

--- a/Mathlib/Algebra/Group/InjSurj.lean
+++ b/Mathlib/Algebra/Group/InjSurj.lean
@@ -205,8 +205,8 @@ preserves `1` and `⁻¹` to a `InvOneClass`.  See note [reducible non-instances
 @[to_additive
 /-- A type endowed with `0` and unary `-` is an `NegZeroClass`, if it admits an
 injective map that preserves `0` and unary `-` to an `NegZeroClass`. -/]
-protected abbrev invOneClass [InvOneClass M₂] (f : M₁ → M₂) (hf : Injective f) (one : f 1 = 1)
-    (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) : InvOneClass M₁ where
+protected abbrev invOneClass [One M₂] [Inv M₂] [InvOneClass M₂] (f : M₁ → M₂) (hf : Injective f)
+    (one : f 1 = 1) (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) : InvOneClass M₁ where
   inv_one := hf <| by rw [inv, one, inv_one]
 
 variable [Div M₁] [Pow M₁ ℤ]

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -65,7 +65,8 @@ instance mulOneClass [∀ i, MulOneClass (f i)] : MulOneClass (∀ i, f i) where
   mul_one := by intros; ext; exact mul_one _
 
 @[to_additive]
-instance invOneClass [∀ i, InvOneClass (f i)] : InvOneClass (∀ i, f i) where
+instance invOneClass [∀ i, One (f i)] [∀ i, Inv (f i)] [∀ i, InvOneClass (f i)] :
+    InvOneClass (∀ i, f i) where
   inv_one := by ext; exact inv_one
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -75,7 +75,7 @@ instance instInv [Inv α] : Inv (WithOne α) :=
 
 @[to_additive]
 instance instInvOneClass [Inv α] : InvOneClass (WithOne α) :=
-  { WithOne.instOne, WithOne.instInv with inv_one := rfl }
+  { inv_one := rfl }
 
 @[to_additive]
 instance inhabited : Inhabited (WithOne α) :=

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -218,7 +218,7 @@ instance inv : Inv (WithZero α) where inv a := Option.map (·⁻¹) a
 
 end Inv
 
-instance invOneClass [InvOneClass α] : InvOneClass (WithZero α) where
+instance invOneClass [One α] [Inv α] [InvOneClass α] : InvOneClass (WithZero α) where
   inv_one := show ((1⁻¹ : α) : WithZero α) = 1 by simp
 
 section Div

--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -177,10 +177,14 @@ lemma mabs_div_sup_mul_mabs_div_inf (a b c : α) :
     _ = |a / b|ₘ := by rw [sup_div_inf_eq_mabs_div]
 
 @[to_additive] lemma mabs_sup_div_sup_le_mabs (a b c : α) : |(a ⊔ c) / (b ⊔ c)|ₘ ≤ |a / b|ₘ := by
-  apply le_of_mul_le_of_one_le_left _ (one_le_mabs _); rw [mabs_div_sup_mul_mabs_div_inf]
+  apply le_of_mul_le_of_one_le_left
+  · rw [mabs_div_sup_mul_mabs_div_inf]
+  · apply one_le_mabs
 
 @[to_additive] lemma mabs_inf_div_inf_le_mabs (a b c : α) : |(a ⊓ c) / (b ⊓ c)|ₘ ≤ |a / b|ₘ := by
-  apply le_of_mul_le_of_one_le_right _ (one_le_mabs _); rw [mabs_div_sup_mul_mabs_div_inf]
+  apply le_of_mul_le_of_one_le_right
+  · rw [mabs_div_sup_mul_mabs_div_inf]
+  · apply one_le_mabs
 
 -- Commutative case, Zaanen, 3rd lecture
 -- For the non-commutative case, see Birkhoff Theorem 19 (27)

--- a/Mathlib/Algebra/QuadraticAlgebra/Defs.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Defs.lean
@@ -164,7 +164,8 @@ end Neg
 section AddGroup
 
 @[simp]
-theorem C_neg [NegZeroClass R] (x : R) : (.C (-x) : QuadraticAlgebra R a b) = -.C x := by
+theorem C_neg [Zero R] [Neg R] [NegZeroClass R] (x : R) :
+    (.C (-x) : QuadraticAlgebra R a b) = -.C x := by
   ext <;> simp
 
 instance [Sub R] : Sub (QuadraticAlgebra R a b) where

--- a/Mathlib/Algebra/Ring/Periodic.lean
+++ b/Mathlib/Algebra/Ring/Periodic.lean
@@ -307,7 +307,7 @@ theorem Antiperiodic.neg_eq [AddGroup α] [InvolutiveNeg β] (h : Antiperiodic f
     f (-c) = -f 0 := by
   simpa only [zero_add] using h.neg 0
 
-theorem Antiperiodic.nat_mul_eq_of_eq_zero [NonAssocSemiring α] [NegZeroClass β]
+theorem Antiperiodic.nat_mul_eq_of_eq_zero [NonAssocSemiring α] [Zero β] [Neg β] [NegZeroClass β]
     (h : Antiperiodic f c) (hi : f 0 = 0) : ∀ n : ℕ, f (n * c) = 0
   | 0 => by rwa [Nat.cast_zero, zero_mul]
   | n + 1 => by simp [add_mul, h _, Antiperiodic.nat_mul_eq_of_eq_zero h hi n]

--- a/Mathlib/Algebra/TrivSqZeroExt/Basic.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt/Basic.lean
@@ -312,7 +312,8 @@ theorem inl_add [Add R] [AddZeroClass M] (r₁ r₂ : R) :
   ext rfl (add_zero 0).symm
 
 @[simp]
-theorem inl_neg [Neg R] [NegZeroClass M] (r : R) : (inl (-r) : tsze R M) = -inl r :=
+theorem inl_neg [Neg R] [Zero M] [Neg M] [NegZeroClass M] (r : R) :
+    (inl (-r) : tsze R M) = -inl r :=
   ext rfl neg_zero.symm
 
 @[simp]
@@ -345,7 +346,8 @@ theorem inr_add [AddZeroClass R] [Add M] (m₁ m₂ : M) :
   ext (add_zero 0).symm rfl
 
 @[simp]
-theorem inr_neg [NegZeroClass R] [Neg M] (m : M) : (inr (-m) : tsze R M) = -inr m :=
+theorem inr_neg [Zero R] [Neg R] [NegZeroClass R] [Neg M] (m : M) :
+    (inr (-m) : tsze R M) = -inr m :=
   ext neg_zero.symm rfl
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -206,8 +206,8 @@ lemma tendsto_zpow_nhdsNE_zero_cobounded {m : ℤ} (hm : m < 0) :
     Tendsto (· ^ m) (𝓝[≠] 0) (cobounded α) := by
   obtain ⟨m, rfl⟩ := neg_surjective m
   lift m to ℕ using by lia
-  simpa [Function.comp_def] using
-    (tendsto_pow_cobounded_cobounded (by lia)).comp tendsto_inv₀_nhdsNE_zero
+  simp only [zpow_neg, zpow_natCast, ← inv_pow]
+  exact (tendsto_pow_cobounded_cobounded (by lia)).comp tendsto_inv₀_nhdsNE_zero
 
 end NormedDivisionRing
 

--- a/Mathlib/Data/ENNReal/Holder.lean
+++ b/Mathlib/Data/ENNReal/Holder.lean
@@ -149,10 +149,11 @@ lemma pos : 0 < p := zero_lt_one.trans_le (one_le p q)
 include q in
 lemma ne_zero : p ≠ 0 := pos p q |>.ne'
 
-lemma inv_add_inv_eq_one : p⁻¹ + q⁻¹ = 1 := @inv_one ℝ≥0∞ _ ▸ HolderTriple.inv_add_inv_eq_inv p q 1
+lemma inv_add_inv_eq_one : p⁻¹ + q⁻¹ = 1 :=
+  inv_one (G := ℝ≥0∞) ▸ HolderTriple.inv_add_inv_eq_inv p q 1
 
 lemma one_sub_inv : 1 - p⁻¹ = q⁻¹ :=
-  @inv_one ℝ≥0∞ _ ▸ HolderTriple.inv_sub_inv_eq_inv q p one_ne_zero
+  inv_one (G := ℝ≥0∞) ▸ HolderTriple.inv_sub_inv_eq_inv q p one_ne_zero
 
 lemma unique (q' : ℝ≥0∞) [hq' : HolderConjugate p q'] : q = q' :=
   HolderTriple.unique_of_ne_zero p q q' one_ne_zero

--- a/Mathlib/Data/ENNReal/Inv.lean
+++ b/Mathlib/Data/ENNReal/Inv.lean
@@ -193,7 +193,8 @@ instance : InvolutiveInv ℝ≥0∞ where
   inv_inv a := by
     by_cases a = 0 <;> cases a <;> simp_all [-coe_inv, (coe_inv _).symm]
 
-@[simp] protected lemma inv_eq_one : a⁻¹ = 1 ↔ a = 1 := by rw [← inv_inj, inv_inv, inv_one]
+@[deprecated _root_.inv_eq_one (since := "2026-07-19")]
+protected lemma inv_eq_one : a⁻¹ = 1 ↔ a = 1 := inv_eq_one
 
 @[simp] theorem inv_eq_top : a⁻¹ = ∞ ↔ a = 0 := inv_zero ▸ inv_inj
 

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -241,9 +241,8 @@ theorem neg_eq_top_iff {x : EReal} : -x = ⊤ ↔ x = ⊥ :=
 theorem neg_eq_bot_iff {x : EReal} : -x = ⊥ ↔ x = ⊤ :=
   neg_injective.eq_iff' rfl
 
-@[simp]
-theorem neg_eq_zero_iff {x : EReal} : -x = 0 ↔ x = 0 :=
-  neg_injective.eq_iff' neg_zero
+@[deprecated neg_eq_zero (since := "2026-07-18")]
+theorem neg_eq_zero_iff {x : EReal} : -x = 0 ↔ x = 0 := neg_eq_zero
 
 theorem neg_strictAnti : StrictAnti (- · : EReal → EReal) :=
   WithBot.strictAnti_iff.2 ⟨WithTop.strictAnti_iff.2

--- a/Mathlib/Data/FunLike/Group.lean
+++ b/Mathlib/Data/FunLike/Group.lean
@@ -217,8 +217,8 @@ protected abbrev involutiveInv [InvolutiveInv β] [IsInvApply F α β] : Involut
 /-- A `FunLike` type with `1` and inverse is an `InvOneClass` if `β` is an `InvOneClass`. -/
 @[to_additive /-- A `FunLike` type with `0` and negation is a `NegZeroClass` if `β` is a
 `NegZeroClass`. -/]
-protected abbrev invOneClass [InvOneClass β] [IsOneApply F α β] [IsInvApply F α β] :
-    InvOneClass F :=
+protected abbrev invOneClass [One β] [Inv β] [InvOneClass β] [IsOneApply F α β]
+    [IsInvApply F α β] : InvOneClass F :=
   DFunLike.coe_injective.invOneClass (fun (f : F) ↦ (f : α → β)) coe_one coe_inv
 
 variable [Div F] [Pow F ℤ]

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -127,7 +127,7 @@ theorem single_add [AddZeroClass α] (i : m) (j : n) (a b : α) :
   simp only [single, of_apply]
   split_ifs with h <;> simp [h]
 
-lemma single_neg [NegZeroClass α] (i j : n) (b : α) :
+lemma single_neg [Zero α] [Neg α] [NegZeroClass α] (i j : n) (b : α) :
     - single i j b = single i j (-b) :=
   neg_of _ |>.trans <| ext fun x y ↦ by simp [single, neg_ite]
 

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -105,7 +105,7 @@ theorem diagonal_smul [Zero α] [SMulZeroClass R α] (r : R) (d : n → α) :
   by_cases h : i = j <;> simp [h]
 
 @[simp]
-theorem diagonal_neg [NegZeroClass α] (d : n → α) :
+theorem diagonal_neg [Zero α] [Neg α] [NegZeroClass α] (d : n → α) :
     -diagonal d = diagonal fun i => -d i := by
   ext i j
   by_cases h : i = j <;>

--- a/Mathlib/Data/Sign/Defs.lean
+++ b/Mathlib/Data/Sign/Defs.lean
@@ -187,8 +187,8 @@ theorem self_eq_neg_iff {a : SignType} : a = -a ↔ a = 0 := by decide +revert
 @[simp]
 theorem neg_eq_self_iff {a : SignType} : -a = a ↔ a = 0 := by decide +revert
 
-@[simp]
-theorem neg_eq_zero_iff {a : SignType} : -a = 0 ↔ a = 0 := by decide +revert
+@[deprecated neg_eq_zero (since := "2026-07-18")]
+theorem neg_eq_zero_iff {a : SignType} : -a = 0 ↔ a = 0 := neg_eq_zero
 
 @[simp]
 theorem neg_one_lt_one : (-1 : SignType) < 1 :=

--- a/Mathlib/Geometry/Euclidean/Triangle.lean
+++ b/Mathlib/Geometry/Euclidean/Triangle.lean
@@ -217,8 +217,7 @@ theorem norm_eq_of_two_zsmul_oangle_sub_eq {x y : V}
     rw [ne_eq, ← o.oangle_eq_pi_iff_angle_eq_pi]
     exact hpi
   · rw [h, Real.Angle.sign_add_pi, SignType.neg_eq_self_iff, oangle_sign_sub_left_swap,
-      o.oangle_rev, Real.Angle.sign_neg, SignType.neg_eq_zero_iff,
-      Real.Angle.sign_eq_zero_iff] at hs
+      o.oangle_rev, Real.Angle.sign_neg, neg_eq_zero, Real.Angle.sign_eq_zero_iff] at hs
     simp [h0, hpi] at hs
 
 end Orientation

--- a/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
@@ -116,13 +116,14 @@ run_cmd
   for n in [`Mul, `One, `Inv, `Semigroup, `CommSemigroup, `LeftCancelSemigroup,
     `RightCancelSemigroup, `MulOneClass, `Monoid, `CommMonoid, `LeftCancelMonoid,
     `RightCancelMonoid, `CancelMonoid, `CancelCommMonoid, `InvolutiveInv, `DivInvMonoid,
-    `InvOneClass, `DivInvOneMonoid, `DivisionMonoid, `DivisionCommMonoid, `Group,
+    `DivInvOneMonoid, `DivisionMonoid, `DivisionCommMonoid, `Group,
     `CommGroup, `NonAssocSemiring, `NonUnitalSemiring, `Semiring,
     `Ring, `CommRing].map Lean.mkIdent do
   Lean.Elab.Command.elabCommand (← `(
     @[to_additive] instance [$n Mᵐᵒᵖ] : $n Mᵈᵐᵃ := ‹_›
   ))
 
+@[to_additive] instance [One Mᵐᵒᵖ] [Inv Mᵐᵒᵖ] [InvOneClass Mᵐᵒᵖ] : InvOneClass Mᵈᵐᵃ := ‹_›
 @[to_additive] instance [Mul Mᵐᵒᵖ] [IsLeftCancelMul Mᵐᵒᵖ] : IsLeftCancelMul Mᵈᵐᵃ := ‹_›
 @[to_additive] instance [Mul Mᵐᵒᵖ] [IsRightCancelMul Mᵐᵒᵖ] : IsRightCancelMul Mᵈᵐᵃ := ‹_›
 @[to_additive] instance [Mul Mᵐᵒᵖ] [IsCancelMul Mᵐᵒᵖ] : IsCancelMul Mᵈᵐᵃ := ‹_›

--- a/Mathlib/LinearAlgebra/Matrix/Block.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Block.lean
@@ -87,7 +87,7 @@ theorem blockTriangular_zero : BlockTriangular (0 : Matrix m m R) b := fun _ _ _
 
 end Zero
 
-protected theorem BlockTriangular.neg [NegZeroClass R] {M : Matrix m m R}
+protected theorem BlockTriangular.neg [Zero R] [Neg R] [NegZeroClass R] {M : Matrix m m R}
     (hM : BlockTriangular M b) : BlockTriangular (-M) b :=
   fun _ _ h => by rw [neg_apply, hM h, neg_zero]
 

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -503,7 +503,7 @@ theorem inv_zero : (0 : Matrix n n α)⁻¹ = 0 := by
     simp [det]
 
 noncomputable instance : InvOneClass (Matrix n n α) :=
-  { Matrix.one, Matrix.inv with inv_one := inv_eq_left_inv (by simp) }
+  { inv_one := inv_eq_left_inv (by simp) }
 
 theorem inv_smul (k : α) [Invertible k] (h : IsUnit A.det) : (k • A)⁻¹ = ⅟k • A⁻¹ :=
   inv_eq_left_inv (by simp [h, smul_smul])

--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -1413,13 +1413,13 @@ theorem toMeasureOfZeroLE_real_apply (hi : 0 ≤[i] s) (hi₁ : MeasurableSet i)
 provides the measure, mapping measurable sets `j` to `-s (i ∩ j)`. -/
 def toMeasureOfLEZero (s : SignedMeasure α) (i : Set α) (hi₁ : MeasurableSet i) (hi₂ : s ≤[i] 0) :
     Measure α :=
-  toMeasureOfZeroLE (-s) i hi₁ <| @neg_zero (VectorMeasure α ℝ) _ ▸ neg_le_neg _ _ hi₁ hi₂
+  toMeasureOfZeroLE (-s) i hi₁ <| neg_zero (G := VectorMeasure α ℝ) ▸ neg_le_neg _ _ hi₁ hi₂
 
 theorem toMeasureOfLEZero_apply (hi : s ≤[i] 0) (hi₁ : MeasurableSet i) (hj₁ : MeasurableSet j) :
     s.toMeasureOfLEZero i hi₁ hi j =
     ((↑) : ℝ≥0 → ℝ≥0∞) (NNReal.mk (-s (i ∩ j)) (neg_apply s (i ∩ j) ▸
       nonneg_of_zero_le_restrict _ (zero_le_restrict_subset _ hi₁ Set.inter_subset_left
-      (@neg_zero (VectorMeasure α ℝ) _ ▸ neg_le_neg _ _ hi₁ hi)))) := by
+      (neg_zero (G := VectorMeasure α ℝ) ▸ neg_le_neg _ _ hi₁ hi)))) := by
   simp [toMeasureOfLEZero, toMeasureOfZeroLE_apply _ _ _ hj₁]
 
 theorem toMeasureOfLEZero_real_apply (hi : s ≤[i] 0) (hi₁ : MeasurableSet i)

--- a/Mathlib/NumberTheory/ArithmeticFunction/Defs.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction/Defs.lean
@@ -200,7 +200,11 @@ instance [Zero R] [Neg R] [NegZeroClass R] : Neg (ArithmeticFunction R) where
   neg f := ⟨-f, by simp⟩
 
 instance [Zero R] [Neg R] [NegZeroClass R] : IsNegApply (ArithmeticFunction R) ℕ R where
-  neg_apply _ _ := by rfl
+  neg_apply _ _ := rfl
+
+@[deprecated _root_.neg_apply (since := "2026-07-18")]
+protected theorem neg_apply [Zero R] [Neg R] [NegZeroClass R] {f : ArithmeticFunction R} {n : ℕ} :
+    (-f) n = -f n := neg_apply f n
 
 instance [AddGroup R] : AddGroup (ArithmeticFunction R) where
   neg_add_cancel _ := ext fun _ ↦ neg_add_cancel _

--- a/Mathlib/NumberTheory/ArithmeticFunction/Defs.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction/Defs.lean
@@ -196,12 +196,11 @@ instance instAddMonoidWithOne [AddMonoidWithOne R] : AddMonoidWithOne (Arithmeti
 instance instAddCommMonoid [AddCommMonoid R] : AddCommMonoid (ArithmeticFunction R) where
   add_comm _ _ := ext fun _ ↦ add_comm _ _
 
-instance [NegZeroClass R] : Neg (ArithmeticFunction R) where
+instance [Zero R] [Neg R] [NegZeroClass R] : Neg (ArithmeticFunction R) where
   neg f := ⟨-f, by simp⟩
 
-@[simp]
-theorem neg_apply [NegZeroClass R] {f : ArithmeticFunction R} {n : ℕ} : (-f) n = -f n := by
-  rfl
+instance [Zero R] [Neg R] [NegZeroClass R] : IsNegApply (ArithmeticFunction R) ℕ R where
+  neg_apply _ _ := by rfl
 
 instance [AddGroup R] : AddGroup (ArithmeticFunction R) where
   neg_add_cancel _ := ext fun _ ↦ neg_add_cancel _

--- a/Mathlib/Order/Filter/Germ/Basic.lean
+++ b/Mathlib/Order/Filter/Germ/Basic.lean
@@ -485,7 +485,7 @@ instance instHasDistribNeg [Mul G] [HasDistribNeg G] : HasDistribNeg (Germ l G) 
     mul_neg := Quotient.ind₂' fun _ _ => congrArg ofFun <| mul_neg .. }
 
 @[to_additive]
-instance instInvOneClass [InvOneClass G] : InvOneClass (Germ l G) :=
+instance instInvOneClass [One G] [Inv G] [InvOneClass G] : InvOneClass (Germ l G) :=
   ⟨congr_arg ofFun inv_one⟩
 
 @[to_additive subNegMonoid]

--- a/Mathlib/RingTheory/DedekindDomain/Different.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Different.lean
@@ -543,6 +543,11 @@ theorem differentIdeal_ne_bot [Module.Finite A B]
   let K := FractionRing A
   let L := FractionRing B
   rw [ne_eq, ← FractionalIdeal.coeIdeal_inj (K := L), coeIdeal_differentIdeal (K := K)]
+  #adaptation_note /--
+  The `rw` was previously unnecessary but removing it causes failures due to
+  https://github.com/leanprover/lean4/issues/14447
+  -/
+  rw [FractionalIdeal.coeIdeal_bot, inv_eq_zero]
   simp
 
 lemma differentialIdeal_le_fractionalIdeal_iff

--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -328,7 +328,7 @@ end AddCommMonoid
 
 section NegZeroClass
 
-variable [NegZeroClass R]
+variable [Zero R] [Neg R] [NegZeroClass R]
 
 instance : Neg R⟦Γ⟧ where
   neg x := x.map (-ZeroHom.id _)

--- a/Mathlib/RingTheory/HahnSeries/Cardinal.lean
+++ b/Mathlib/RingTheory/HahnSeries/Cardinal.lean
@@ -77,7 +77,7 @@ theorem cardSupp_smul_le (s : S) (x : R⟦Γ⟧) [SMulZeroClass S R] : (s • x)
 
 end Zero
 
-theorem cardSupp_neg_le [NegZeroClass R] (x : R⟦Γ⟧) : (-x).cardSupp ≤ x.cardSupp :=
+theorem cardSupp_neg_le [Zero R] [Neg R] [NegZeroClass R] (x : R⟦Γ⟧) : (-x).cardSupp ≤ x.cardSupp :=
   cardSupp_mono <| support_neg_subset ..
 
 theorem cardSupp_add_le [AddMonoid R] (x y : R⟦Γ⟧) : (x + y).cardSupp ≤ x.cardSupp + y.cardSupp :=

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -390,7 +390,7 @@ theorem single_zpow (n : ℤ) :
   match n with
   | (n : ℕ) => apply single_one_eq_pow
   | -(n + 1 : ℕ) =>
-    rw [← Nat.cast_one, ← inv_one, ← HahnSeries.inv_single, zpow_neg,
+    rw [← Nat.cast_one, ← inv_one (G := F), ← HahnSeries.inv_single, zpow_neg,
       ← Nat.cast_one, Nat.cast_one,
       inv_inj, zpow_natCast, single_one_eq_pow, inv_one]
 

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -239,7 +239,7 @@ Interpret a negated expression in `abel`'s normal form.
 -/
 def evalNeg : NormalExpr → M (NormalExpr × Expr)
   | (zero _) => do
-    let p ← (← read).mkApp ``neg_zero ``NegZeroClass #[]
+    let p ← mkAppOptM ``neg_zero #[(← read).α, none, none, none]
     return (← zero', p)
   | (nterm _ n x a) => do
     let n' ← Mathlib.Meta.NormNum.eval (← mkAppM ``Neg.neg #[n.1])

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -156,7 +156,7 @@ def addNegEqProofsIdx : List (Expr × Nat) → MetaM (List (Expr × Nat))
     match iq with
     | Ineq.eq => do
       let nep :=
-        mkAppN (← mkAppM `Iff.mpr #[← mkAppOptM ``neg_eq_zero #[none, none, t]]) #[h]
+        mkAppN (← mkAppM `Iff.mpr #[← mkAppOptM ``neg_eq_zero #[none, none, none, none, t]]) #[h]
       let tl ← addNegEqProofsIdx tl
       return (h, i)::(nep, i)::tl
     | _ => return (h, i) :: (← addNegEqProofsIdx tl)

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
@@ -167,7 +167,7 @@ instance instInvolutiveInv [InvolutiveInv G] [ContinuousInv G] :
   surjective_mk.involutiveInv mk mk_inv
 
 @[to_additive]
-instance instInvOneClass [InvOneClass G] [ContinuousInv G] :
+instance instInvOneClass [One G] [Inv G] [InvOneClass G] [ContinuousInv G] :
     InvOneClass (SeparationQuotient G) where
   inv_one := congr_arg mk inv_one
 

--- a/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
@@ -229,10 +229,11 @@ instance instAdd [AddZeroClass R] [ContinuousAdd R] : Add C(X, R)₀ where
 
 @[simp] lemma coe_add [AddZeroClass R] [ContinuousAdd R] (f g : C(X, R)₀) : ⇑(f + g) = f + g := rfl
 
-instance instNeg [NegZeroClass R] [ContinuousNeg R] : Neg C(X, R)₀ where
+instance instNeg [Zero R] [Neg R] [NegZeroClass R] [ContinuousNeg R] : Neg C(X, R)₀ where
   neg f := ⟨- f, by simp⟩
 
-@[simp] lemma coe_neg [NegZeroClass R] [ContinuousNeg R] (f : C(X, R)₀) : ⇑(-f) = -f := rfl
+@[simp] lemma coe_neg [Zero R] [Neg R] [NegZeroClass R] [ContinuousNeg R] (f : C(X, R)₀) :
+    ⇑(-f) = -f := rfl
 
 instance instSub [SubNegZeroMonoid R] [ContinuousSub R] : Sub C(X, R)₀ where
   sub f g := ⟨f - g, by simp⟩


### PR DESCRIPTION
Most of the changes just add `[Zero α] [Neg α]` or `[One α] [Inv α]`, except:
- The change itself to `InvOneClass` / `NegZeroClass`
- Generalizing `neg_eq_zero` (and related theorems) to `InvolutiveNeg` + `NegZeroClass` and deprecating `EReal.neg_eq_zero_iff` / `ENNReal.inv_eq_zero_iff` / `SignType.neg_eq_zero_iff` which are no longer necessary
- Replacing occurrences of `@inv_one ty _` with `inv_one (G := ty)`
- Removing `one` and `inv` in some instance declarations of the form `:= { one, inv with inv_one := ... }`
- `mabs_sup_div_sup_le_mabs`, `mabs_inf_div_inf_le_mabs` and `tendsto_zpow_nhdsNE_zero_cobounded` needed adaptations; not sure why, something to do with unification?
- handling `InvOneClass` specially in `DomMulAct`
- replacing `neg_apply` in ``
- being more specific (i.e. `inv_one (G := F)` instead of `inv_one`) in the proof of `RatFunc.single_zpow`
- adding an `rw` in `differentIdeal_ne_bot` due to leanprover/lean4#14447
- replacing `ArithmeticFunction.neg_apply` with an `IsNegApply` instance
- adapting meta code by adding more implicit arguments (in the form of `none` arguments to `mkAppOptM`)

Zulip discussion at [#mathlib4 > Having both &#96;NegZeroClass&#96; and &#96;InvolutiveNeg&#96;](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Having.20both.20.60NegZeroClass.60.20and.20.60InvolutiveNeg.60/with/611441611)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
