### PR TITLE
feat(Topology): add `Homeomorph.Set.iUnion`

### DIFF
--- a/Mathlib/Topology/Homeomorph/Lemmas.lean
+++ b/Mathlib/Topology/Homeomorph/Lemmas.lean
@@ -364,6 +364,39 @@ def Set.prod (s : Set X) (t : Set Y) : ↥(s ×ˢ t) ≃ₜ s × t where
   continuous_invFun :=
     (continuous_subtype_val.fst'.prodMk continuous_subtype_val.snd').subtype_mk _
 
+set_option backward.isDefEq.respectTransparency false in
+/-- The homeomorphism between a disjoint union of sets and a disjoint union of the corresponding
+subtypes when each set has a neighbourhood that is disjoint from all other sets.
+
+This condition is the precise condition needed for the bijection to be a homeomorphism:
+see `inducing_sigma`. A weaker condition like any two sets in the family having disjoint
+neighbourhoods is not enough, as the example of infinite collections of singletons in
+Hausdorff spaces shows. -/
+@[simps! symm_apply_coe]
+noncomputable def Set.iUnion {X : Type*} [TopologicalSpace X] {ι : Type*}
+    {s : ι → Set X} (hs : ∀ i, ∃ u ∈ 𝓝ˢ (s i), ∀ j ≠ i, Disjoint u (s j)) :
+    ⋃ i, s i ≃ₜ Σ i, s i := by
+  refine ((Set.unionEqSigmaOfDisjoint fun i j h ↦ ?_).symm.toHomeomorphOfIsInducing ?_).symm
+  · have ⟨u, hu, hu'⟩ := hs i
+    exact (hu' j h.symm).mono_left (subset_of_mem_nhdsSet hu)
+  · refine inducing_sigma.2 ⟨fun i ↦ ?_, fun i ↦ ?_⟩
+    · simp [Function.comp_def, ← IsInducing.subtypeVal.of_comp_iff, IsInducing.subtypeVal]
+    · have ⟨u, hu, hu'⟩ := hs i
+      have ⟨v, hvu, hv, hv'⟩ := mem_nhdsSet.1 hu
+      refine ⟨(↑) ⁻¹' v, hv.preimage_val, fun x ↦ ⟨fun h ↦ ?_, ?_⟩⟩
+      · simp only [Set.mem_preimage, Set.coe_unionEqSigmaOfDisjoint_symm_apply] at h
+        contrapose! h
+        exact Set.notMem_subset hvu <| (hu' _ h).notMem_of_mem_right x.snd.2
+      · intro rfl
+        simpa using hv' x.snd.2
+
+set_option backward.isDefEq.respectTransparency false in
+@[simp]
+lemma Set.iUnion_apply_snd_coe {X : Type*} [TopologicalSpace X] {ι : Type*}
+    {s : ι → Set X} (hs : ∀ i, ∃ u ∈ 𝓝ˢ (s i), ∀ j ≠ i, Disjoint u (s j)) {x : ⋃ i, s i} :
+    ((Homeomorph.Set.iUnion hs x).snd : X) = x := by
+  simp [Homeomorph.Set.iUnion]
+
 section
 
 variable {ι : Type*}

--- a/Mathlib/Topology/Homeomorph/Lemmas.lean
+++ b/Mathlib/Topology/Homeomorph/Lemmas.lean
@@ -372,27 +372,27 @@ see `inducing_sigma`. A weaker condition like any two sets in the family having 
 neighbourhoods is not enough, as the example of infinite collections of singletons in
 Hausdorff spaces shows. -/
 @[simps! symm_apply_coe]
-noncomputable def Set.iUnion {X : Type*} [TopologicalSpace X] {ι : Type*}
-    {s : ι → Set X} (hs : ∀ i, ∃ u ∈ 𝓝ˢ (s i), ∀ j ≠ i, Disjoint u (s j)) :
+noncomputable def Set.iUnion {ι : Type*} {s : ι → Set X}
+    (hs : ∀ i, ∃ u ∈ 𝓝ˢ (s i), ∀ j ≠ i, Disjoint u (s j)) :
     ⋃ i, s i ≃ₜ Σ i, s i := by
   haveI hs' : Pairwise (Disjoint on s) := fun i j h ↦ by
     have ⟨u, hu, hu'⟩ := hs i
     exact (hu' j h.symm).mono_left (subset_of_mem_nhdsSet hu)
-  refine ((Set.unionEqSigmaOfDisjoint hs').symm.toHomeomorphOfIsInducing ?_).symm
+  refine ((unionEqSigmaOfDisjoint hs').symm.toHomeomorphOfIsInducing ?_).symm
   refine inducing_sigma.2 ⟨fun i ↦ ?_, fun i ↦ ?_⟩
   · simp [Function.comp_def, ← IsInducing.subtypeVal.of_comp_iff, IsInducing.subtypeVal]
   · have ⟨u, hu, hu'⟩ := hs i
     have ⟨v, hvu, hv, hv'⟩ := mem_nhdsSet.1 hu
     refine ⟨(↑) ⁻¹' v, hv.preimage_val, fun x ↦ ⟨fun h ↦ ?_, ?_⟩⟩
-    · simp only [Set.mem_preimage, Set.coe_unionEqSigmaOfDisjoint_symm_apply] at h
+    · simp only [mem_preimage, coe_unionEqSigmaOfDisjoint_symm_apply] at h
       contrapose! h
-      exact Set.notMem_subset hvu <| (hu' _ h).notMem_of_mem_right x.snd.2
+      exact notMem_subset hvu <| (hu' _ h).notMem_of_mem_right x.snd.2
     · intro rfl
       simpa using hv' x.snd.2
 
 @[simp]
-lemma Set.iUnion_apply_snd_coe {X : Type*} [TopologicalSpace X] {ι : Type*}
-    {s : ι → Set X} (hs : ∀ i, ∃ u ∈ 𝓝ˢ (s i), ∀ j ≠ i, Disjoint u (s j)) {x : ⋃ i, s i} :
+lemma Set.iUnion_apply_snd_coe {ι : Type*} {s : ι → Set X}
+    (hs : ∀ i, ∃ u ∈ 𝓝ˢ (s i), ∀ j ≠ i, Disjoint u (s j)) {x : ⋃ i, s i} :
     ((Homeomorph.Set.iUnion hs x).snd : X) = x := by
   have hs' : Pairwise (Disjoint on s) := fun i j h ↦ by
     have ⟨u, hu, hu'⟩ := hs i

--- a/Mathlib/Topology/Homeomorph/Lemmas.lean
+++ b/Mathlib/Topology/Homeomorph/Lemmas.lean
@@ -364,7 +364,6 @@ def Set.prod (s : Set X) (t : Set Y) : ↥(s ×ˢ t) ≃ₜ s × t where
   continuous_invFun :=
     (continuous_subtype_val.fst'.prodMk continuous_subtype_val.snd').subtype_mk _
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The homeomorphism between a disjoint union of sets and a disjoint union of the corresponding
 subtypes when each set has a neighbourhood that is disjoint from all other sets.
 
@@ -376,26 +375,29 @@ Hausdorff spaces shows. -/
 noncomputable def Set.iUnion {X : Type*} [TopologicalSpace X] {ι : Type*}
     {s : ι → Set X} (hs : ∀ i, ∃ u ∈ 𝓝ˢ (s i), ∀ j ≠ i, Disjoint u (s j)) :
     ⋃ i, s i ≃ₜ Σ i, s i := by
-  refine ((Set.unionEqSigmaOfDisjoint fun i j h ↦ ?_).symm.toHomeomorphOfIsInducing ?_).symm
-  · have ⟨u, hu, hu'⟩ := hs i
+  haveI hs' : Pairwise (Disjoint on s) := fun i j h ↦ by
+    have ⟨u, hu, hu'⟩ := hs i
     exact (hu' j h.symm).mono_left (subset_of_mem_nhdsSet hu)
-  · refine inducing_sigma.2 ⟨fun i ↦ ?_, fun i ↦ ?_⟩
-    · simp [Function.comp_def, ← IsInducing.subtypeVal.of_comp_iff, IsInducing.subtypeVal]
-    · have ⟨u, hu, hu'⟩ := hs i
-      have ⟨v, hvu, hv, hv'⟩ := mem_nhdsSet.1 hu
-      refine ⟨(↑) ⁻¹' v, hv.preimage_val, fun x ↦ ⟨fun h ↦ ?_, ?_⟩⟩
-      · simp only [Set.mem_preimage, Set.coe_unionEqSigmaOfDisjoint_symm_apply] at h
-        contrapose! h
-        exact Set.notMem_subset hvu <| (hu' _ h).notMem_of_mem_right x.snd.2
-      · intro rfl
-        simpa using hv' x.snd.2
+  refine ((Set.unionEqSigmaOfDisjoint hs').symm.toHomeomorphOfIsInducing ?_).symm
+  refine inducing_sigma.2 ⟨fun i ↦ ?_, fun i ↦ ?_⟩
+  · simp [Function.comp_def, ← IsInducing.subtypeVal.of_comp_iff, IsInducing.subtypeVal]
+  · have ⟨u, hu, hu'⟩ := hs i
+    have ⟨v, hvu, hv, hv'⟩ := mem_nhdsSet.1 hu
+    refine ⟨(↑) ⁻¹' v, hv.preimage_val, fun x ↦ ⟨fun h ↦ ?_, ?_⟩⟩
+    · simp only [Set.mem_preimage, Set.coe_unionEqSigmaOfDisjoint_symm_apply] at h
+      contrapose! h
+      exact Set.notMem_subset hvu <| (hu' _ h).notMem_of_mem_right x.snd.2
+    · intro rfl
+      simpa using hv' x.snd.2
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma Set.iUnion_apply_snd_coe {X : Type*} [TopologicalSpace X] {ι : Type*}
     {s : ι → Set X} (hs : ∀ i, ∃ u ∈ 𝓝ˢ (s i), ∀ j ≠ i, Disjoint u (s j)) {x : ⋃ i, s i} :
     ((Homeomorph.Set.iUnion hs x).snd : X) = x := by
-  simp [Homeomorph.Set.iUnion]
+  have hs' : Pairwise (Disjoint on s) := fun i j h ↦ by
+    have ⟨u, hu, hu'⟩ := hs i
+    exact (hu' j h.symm).mono_left (subset_of_mem_nhdsSet hu)
+  simp [iUnion, coe_snd_unionEqSigmaOfDisjoint hs']
 
 section
 


### PR DESCRIPTION
Disjoint unions of families of sets are canonically isomorphic to disjoint unions of the corresponding subtypes, provided each set in the family can be separated from the others with an open neighbourhood. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The equivalence underlying this homeomorphism is already in mathlib as `Set.unionEqSigmaOfDisjoint`. I think that should be renamed to `Equiv.Set.iUnion` for several reasons, but doing so would touch 5 different files, so it's probably cleaner to do that in a separate PR.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
