### PR TITLE
feat(Analysis/Fourier): the Plancherel theorem for hypercomplex Fourier transforms

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -244,6 +244,7 @@ public import Mathlib.Algebra.Category.Ring.Under.Basic
 public import Mathlib.Algebra.Category.Ring.Under.Limits
 public import Mathlib.Algebra.Category.Ring.Under.Property
 public import Mathlib.Algebra.Category.Semigrp.Basic
+public import Mathlib.Algebra.CayleyDickson
 public import Mathlib.Algebra.Central.Basic
 public import Mathlib.Algebra.Central.Defs
 public import Mathlib.Algebra.Central.End
@@ -914,6 +915,7 @@ public import Mathlib.Algebra.Notation.Pi.Basic
 public import Mathlib.Algebra.Notation.Pi.Defs
 public import Mathlib.Algebra.Notation.Prod
 public import Mathlib.Algebra.Notation.Support
+public import Mathlib.Algebra.Octonion
 public import Mathlib.Algebra.Opposites
 public import Mathlib.Algebra.Order.AbsoluteValue.Basic
 public import Mathlib.Algebra.Order.AbsoluteValue.Euclidean

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2016,6 +2016,7 @@ public import Mathlib.Analysis.Distribution.TestFunction
 public import Mathlib.Analysis.Fourier.AddCircle
 public import Mathlib.Analysis.Fourier.AddCircleMulti
 public import Mathlib.Analysis.Fourier.BoundedContinuousFunctionChar
+public import Mathlib.Analysis.Fourier.CayleyDicksonPlancherel
 public import Mathlib.Analysis.Fourier.Convolution
 public import Mathlib.Analysis.Fourier.FiniteAbelian.Orthogonality
 public import Mathlib.Analysis.Fourier.FiniteAbelian.PontryaginDuality

--- a/Mathlib/Algebra/CayleyDickson.lean
+++ b/Mathlib/Algebra/CayleyDickson.lean
@@ -182,7 +182,7 @@ theorem mul_smul_comm' [Monoid S] [Star S] [TrivialStar S] [DistribMulAction S A
   ext <;> simp [hstar, smul_sub, smul_add, mul_smul_comm, smul_mul_assoc]
 
 /-- The self-action compatibility propagates up the Cayley–Dickson tower. -/
-instance [Monoid S] [Star S] [TrivialStar S] [DistribMulAction S A] [StarModule S A]
+instance [Monoid S] [DistribMulAction S A]
     [SMulCommClass S A A] [IsScalarTower S A A] :
     IsScalarTower S (CayleyDickson A) (CayleyDickson A) :=
   ⟨fun s x y => smul_mul_assoc' s x y⟩

--- a/Mathlib/Algebra/CayleyDickson.lean
+++ b/Mathlib/Algebra/CayleyDickson.lean
@@ -1,0 +1,252 @@
+/-
+Copyright (c) 2026 Junji Hashimoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junji Hashimoto
+-/
+module
+
+public import Mathlib.Algebra.Quaternion
+public import Mathlib.RingTheory.Finiteness.Prod
+
+/-!
+# The Cayley–Dickson construction
+
+Given a (possibly non-associative) ring `A` with a star operation, the Cayley–Dickson
+construction produces the algebra `CayleyDickson A` of pairs of elements of `A`,
+multiplied by
+
+`⟨a, b⟩ * ⟨c, d⟩ = ⟨a * c - star d * b, d * a + b * star c⟩`,
+
+with the star operation `star ⟨a, b⟩ = ⟨star a, -b⟩`. Iterating the construction starting
+from the quaternions produces the octonions, the sedenions, the trigintaduonions, and so
+on; see `Mathlib/Algebra/Octonion.lean`.
+
+The construction preserves `NonAssocRing` and `StarRing`, but not associativity, so the
+tower can be iterated indefinitely inside these classes.
+
+The doubling unit `ℓ = ⟨0, 1⟩` satisfies `ℓ * ℓ = -1` and, crucially,
+`ℓ * (ℓ * x) = -x` (`CayleyDickson.unit_mul_unit_mul`) *at every level of the tower* —
+the proof only uses that `star` is an involution on `A`. Consequently left multiplication
+by `ℓ` is a complex structure on every Cayley–Dickson algebra (even the non-alternative
+ones with zero divisors, such as the sedenions), which is what the hypercomplex
+(octonion, sedenion, …) Fourier transform needs; this is used in a follow-up PR to derive
+Plancherel's theorem for these transforms from the vector-valued `L²` Fourier theory.
+
+## Main definitions
+
+* `CayleyDickson A`: the Cayley–Dickson double of `A`.
+* `CayleyDickson.unit`: the doubling unit `ℓ`.
+
+## TODO
+
+* alternativity of the double of an associative star ring, the multiplicative norm for
+  composition algebras.
+
+## References
+
+* J. C. Baez, *The octonions*, Bull. Amer. Math. Soc. 39 (2002)
+
+-/
+
+@[expose] public section
+
+/-- The Cayley–Dickson double of `A`: pairs of elements of `A` with the multiplication
+`⟨a, b⟩ * ⟨c, d⟩ = ⟨a * c - star d * b, d * a + b * star c⟩`. -/
+@[ext]
+structure CayleyDickson (A : Type*) where
+  /-- The first component. -/
+  fst : A
+  /-- The second component. -/
+  snd : A
+
+namespace CayleyDickson
+
+variable {A S : Type*}
+
+/-! ### The additive and module structure, componentwise -/
+
+section AddGroup
+
+variable [AddCommGroup A]
+
+instance : Zero (CayleyDickson A) := ⟨⟨0, 0⟩⟩
+instance : Add (CayleyDickson A) := ⟨fun x y => ⟨x.fst + y.fst, x.snd + y.snd⟩⟩
+instance : Neg (CayleyDickson A) := ⟨fun x => ⟨-x.fst, -x.snd⟩⟩
+instance : Sub (CayleyDickson A) := ⟨fun x y => ⟨x.fst - y.fst, x.snd - y.snd⟩⟩
+instance [SMul S A] : SMul S (CayleyDickson A) :=
+  ⟨fun s x => ⟨s • x.fst, s • x.snd⟩⟩
+
+@[simp] theorem zero_fst : (0 : CayleyDickson A).fst = 0 := rfl
+@[simp] theorem zero_snd : (0 : CayleyDickson A).snd = 0 := rfl
+@[simp] theorem add_fst (x y : CayleyDickson A) : (x + y).fst = x.fst + y.fst := rfl
+@[simp] theorem add_snd (x y : CayleyDickson A) : (x + y).snd = x.snd + y.snd := rfl
+@[simp] theorem neg_fst (x : CayleyDickson A) : (-x).fst = -x.fst := rfl
+@[simp] theorem neg_snd (x : CayleyDickson A) : (-x).snd = -x.snd := rfl
+@[simp] theorem sub_fst (x y : CayleyDickson A) : (x - y).fst = x.fst - y.fst := rfl
+@[simp] theorem sub_snd (x y : CayleyDickson A) : (x - y).snd = x.snd - y.snd := rfl
+omit [AddCommGroup A] in
+@[simp] theorem smul_fst [SMul S A] (s : S) (x : CayleyDickson A) :
+    (s • x).fst = s • x.fst := rfl
+
+omit [AddCommGroup A] in
+@[simp] theorem smul_snd [SMul S A] (s : S) (x : CayleyDickson A) :
+    (s • x).snd = s • x.snd := rfl
+
+/-- The underlying pair of a Cayley–Dickson number. -/
+def toProd (x : CayleyDickson A) : A × A := (x.fst, x.snd)
+
+omit [AddCommGroup A] in
+theorem toProd_injective : Function.Injective (toProd (A := A)) := fun x y h => by
+  cases x
+  cases y
+  simpa [toProd, Prod.ext_iff] using h
+
+instance : AddCommGroup (CayleyDickson A) :=
+  toProd_injective.addCommGroup toProd rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl)
+
+/-- `toProd` as an additive monoid homomorphism. -/
+def toProdHom : CayleyDickson A →+ A × A where
+  toFun := toProd
+  map_zero' := rfl
+  map_add' _ _ := rfl
+
+instance instModule [Semiring S] [Module S A] : Module S (CayleyDickson A) :=
+  toProd_injective.module S toProdHom fun _ _ => rfl
+
+variable (S) in
+/-- `toProd` as a linear equivalence. -/
+@[simps apply]
+def toProdLinearEquiv [Semiring S] [Module S A] : CayleyDickson A ≃ₗ[S] A × A where
+  toFun := toProd
+  invFun p := ⟨p.1, p.2⟩
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+instance [Semiring S] [Module S A] [Module.Finite S A] :
+    Module.Finite S (CayleyDickson A) :=
+  Module.Finite.equiv (toProdLinearEquiv S).symm
+
+end AddGroup
+
+/-! ### The multiplicative and star structure -/
+
+section Ring
+
+variable [NonUnitalNonAssocRing A] [StarRing A]
+
+instance : Mul (CayleyDickson A) :=
+  ⟨fun x y => ⟨x.fst * y.fst - star y.snd * x.snd, y.snd * x.fst + x.snd * star y.fst⟩⟩
+
+theorem mul_def (x y : CayleyDickson A) :
+    x * y = ⟨x.fst * y.fst - star y.snd * x.snd, y.snd * x.fst + x.snd * star y.fst⟩ :=
+  rfl
+
+@[simp] theorem mul_fst (x y : CayleyDickson A) :
+    (x * y).fst = x.fst * y.fst - star y.snd * x.snd := rfl
+@[simp] theorem mul_snd (x y : CayleyDickson A) :
+    (x * y).snd = y.snd * x.fst + x.snd * star y.fst := rfl
+
+instance : NonUnitalNonAssocRing (CayleyDickson A) where
+  left_distrib _ _ _ := by
+    ext <;> simp [mul_add, add_mul, star_add, sub_eq_add_neg] <;> abel
+  right_distrib _ _ _ := by
+    ext <;> simp [mul_add, add_mul, sub_eq_add_neg] <;> abel
+  zero_mul _ := by ext <;> simp
+  mul_zero _ := by ext <;> simp
+
+instance : Star (CayleyDickson A) := ⟨fun x => ⟨star x.fst, -x.snd⟩⟩
+
+@[simp] theorem star_fst (x : CayleyDickson A) : (star x).fst = star x.fst := rfl
+@[simp] theorem star_snd (x : CayleyDickson A) : (star x).snd = -x.snd := rfl
+
+instance : StarRing (CayleyDickson A) where
+  star_involutive _ := by ext <;> simp
+  star_add _ _ := by ext <;> simp [add_comm]
+  star_mul _ _ := by ext <;> simp [star_mul, sub_eq_add_neg]
+
+instance [Monoid S] [DistribMulAction S A] [Star S] [TrivialStar S] [StarModule S A] :
+    StarModule S (CayleyDickson A) :=
+  ⟨fun s x => by ext <;> simp [star_smul, star_trivial, smul_neg]⟩
+
+theorem smul_mul_assoc' [Monoid S] [DistribMulAction S A] [SMulCommClass S A A]
+    [IsScalarTower S A A] (s : S) (x y : CayleyDickson A) :
+    (s • x) * y = s • (x * y) := by
+  ext <;> simp [smul_sub, smul_add, mul_smul_comm, smul_mul_assoc]
+
+theorem mul_smul_comm' [Monoid S] [Star S] [TrivialStar S] [DistribMulAction S A]
+    [StarModule S A] [SMulCommClass S A A] [IsScalarTower S A A] (s : S)
+    (x y : CayleyDickson A) : x * (s • y) = s • (x * y) := by
+  have hstar : ∀ a : A, star (s • a) = s • star a := fun a => by
+    rw [star_smul, star_trivial]
+  ext <;> simp [hstar, smul_sub, smul_add, mul_smul_comm, smul_mul_assoc]
+
+/-- The self-action compatibility propagates up the Cayley–Dickson tower. -/
+instance [Monoid S] [Star S] [TrivialStar S] [DistribMulAction S A] [StarModule S A]
+    [SMulCommClass S A A] [IsScalarTower S A A] :
+    IsScalarTower S (CayleyDickson A) (CayleyDickson A) :=
+  ⟨fun s x y => smul_mul_assoc' s x y⟩
+
+/-- The self-action compatibility propagates up the Cayley–Dickson tower. -/
+instance [Monoid S] [Star S] [TrivialStar S] [DistribMulAction S A] [StarModule S A]
+    [SMulCommClass S A A] [IsScalarTower S A A] :
+    SMulCommClass S (CayleyDickson A) (CayleyDickson A) :=
+  ⟨fun s x y => (mul_smul_comm' s x y).symm⟩
+
+end Ring
+
+section Unital
+
+variable [NonAssocRing A]
+
+instance : One (CayleyDickson A) := ⟨⟨1, 0⟩⟩
+
+@[simp] theorem one_fst : (1 : CayleyDickson A).fst = 1 := rfl
+@[simp] theorem one_snd : (1 : CayleyDickson A).snd = 0 := rfl
+
+instance : NatCast (CayleyDickson A) := ⟨fun n => ⟨n, 0⟩⟩
+instance : IntCast (CayleyDickson A) := ⟨fun n => ⟨n, 0⟩⟩
+
+@[simp] theorem natCast_fst (n : ℕ) : (n : CayleyDickson A).fst = n := rfl
+@[simp] theorem natCast_snd (n : ℕ) : (n : CayleyDickson A).snd = 0 := rfl
+@[simp] theorem intCast_fst (n : ℤ) : (n : CayleyDickson A).fst = n := rfl
+@[simp] theorem intCast_snd (n : ℤ) : (n : CayleyDickson A).snd = 0 := rfl
+
+variable [StarRing A]
+
+instance : NonAssocRing (CayleyDickson A) where
+  one_mul _ := by ext <;> simp
+  mul_one _ := by ext <;> simp
+  natCast_zero := by ext <;> simp
+  natCast_succ _ := by ext <;> simp
+  intCast_ofNat _ := by ext <;> simp
+  intCast_negSucc _ := by ext <;> simp [Int.negSucc_eq]
+
+/-! ### The doubling unit -/
+
+variable (A) in
+/-- The Cayley–Dickson doubling unit `ℓ = ⟨0, 1⟩`. -/
+def unit : CayleyDickson A := ⟨0, 1⟩
+
+omit [StarRing A] in
+@[simp] theorem unit_fst : (unit A).fst = 0 := rfl
+
+omit [StarRing A] in
+@[simp] theorem unit_snd : (unit A).snd = 1 := rfl
+
+@[simp] theorem unit_mul_unit : unit A * unit A = -1 := by
+  ext <;> simp
+
+theorem unit_mul (x : CayleyDickson A) : unit A * x = ⟨-star x.snd, star x.fst⟩ := by
+  ext <;> simp
+
+/-- The left alternative law at the doubling unit: `ℓ * (ℓ * x) = (ℓ * ℓ) * x = -x`.
+This holds at *every* level of the Cayley–Dickson tower — the proof uses only that
+`star` is an involution — even when the algebra is not alternative (e.g. the
+sedenions). Left multiplication by `ℓ` is therefore always a complex structure. -/
+@[simp] theorem unit_mul_unit_mul (x : CayleyDickson A) : unit A * (unit A * x) = -x := by
+  ext <;> simp
+
+end Unital
+
+end CayleyDickson

--- a/Mathlib/Algebra/Octonion.lean
+++ b/Mathlib/Algebra/Octonion.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 Junji Hashimoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junji Hashimoto
+-/
+module
+
+public import Mathlib.Algebra.CayleyDickson
+
+/-!
+# Octonions, sedenions, and the Cayley–Dickson tower over the quaternions
+
+The octonions are the Cayley–Dickson double of the quaternions, the sedenions the double
+of the octonions. Both are *not associative* (`NonAssocRing`); the sedenions are not even
+alternative and have zero divisors. All the structure comes from the generic construction
+in `Mathlib/Algebra/CayleyDickson.lean`; this file only fixes the base of the tower by
+providing the `StarModule` instance for the quaternions.
+
+## Main definitions
+
+* `Octonion R`: the octonions over `R`.
+* `Sedenion R`: the sedenions over `R`.
+
+## References
+
+* J. C. Baez, *The octonions*, Bull. Amer. Math. Soc. 39 (2002)
+
+-/
+
+@[expose] public section
+
+open Quaternion
+
+/-- Scalars with a trivial star act star-equivariantly on the quaternions. -/
+instance Quaternion.instStarModule {R S : Type*} [CommRing R] [Monoid S]
+    [DistribMulAction S R] [Star S] [TrivialStar S] : StarModule S ℍ[R] :=
+  ⟨fun s a => by rw [star_trivial s, Quaternion.star_smul]⟩
+
+/-- The octonions over a commutative ring `R`: the Cayley–Dickson double of the
+quaternions. -/
+abbrev Octonion (R : Type*) [CommRing R] := CayleyDickson ℍ[R]
+
+/-- The sedenions over a commutative ring `R`: the Cayley–Dickson double of the
+octonions. The sedenions are not alternative and have zero divisors, but the doubling
+unit still satisfies `ℓ * (ℓ * x) = -x` (`CayleyDickson.unit_mul_unit_mul`). -/
+abbrev Sedenion (R : Type*) [CommRing R] := CayleyDickson (Octonion R)
+
+/-- The trigintaduonions (32-ons) over a commutative ring `R`. -/
+abbrev Trigintaduonion (R : Type*) [CommRing R] := CayleyDickson (Sedenion R)
+
+namespace Octonion
+
+variable {R : Type*} [CommRing R]
+
+example : NonAssocRing (Octonion R) := inferInstance
+example : StarRing (Octonion R) := inferInstance
+example : NonAssocRing (Sedenion R) := inferInstance
+example : StarRing (Sedenion R) := inferInstance
+example : Module.Finite R (Sedenion R) := inferInstance
+
+end Octonion

--- a/Mathlib/Analysis/Fourier/CayleyDicksonPlancherel.lean
+++ b/Mathlib/Analysis/Fourier/CayleyDicksonPlancherel.lean
@@ -1,0 +1,298 @@
+/-
+Copyright (c) 2026 Junji Hashimoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junji Hashimoto
+-/
+module
+
+public import Mathlib.Algebra.Octonion
+public import Mathlib.Analysis.Fourier.LpSpace
+
+/-!
+# Plancherel's theorem for hypercomplex Fourier transforms on the Cayley–Dickson tower
+
+The (left-sided) hypercomplex Fourier transform of a function `f : V → CayleyDickson A`
+on a finite-dimensional real inner product space `V` replaces the imaginary unit in the
+Fourier kernel by the Cayley–Dickson doubling unit `ℓ`:
+
+`ℱ f ξ = ∫ x, exp (-2π ⟪x, ξ⟫ ℓ) * f x
+       = ∫ x, (cos (2π ⟪x, ξ⟫) - sin (2π ⟪x, ξ⟫) ℓ) * f x`.
+
+Cayley–Dickson algebras beyond the quaternions are not associative — the sedenions are
+not even alternative and have zero divisors — but the Fourier theory only needs a complex
+*module* structure on the codomain. Left multiplication by `ℓ` squares to `-1` at every
+level of the tower (`CayleyDickson.unit_mul_unit_mul`), so `Complex.liftAux` into
+`Module.End ℝ (CayleyDickson A)` — where associativity lives — makes every Cayley–Dickson
+algebra a complex vector space. Equipping it with a compatible complex Hilbert space
+structure, Plancherel's theorem and the Fourier inversion formula are inherited from the
+vector-valued case.
+
+Taking `A = ℍ[ℝ]` gives the octonion Fourier transform (Hahn–Snopek, Błaszczyk),
+`A = Octonion ℝ` the sedenion one, and so on up the tower.
+
+## Main definitions
+
+* `CayleyDickson.fourierIntegral`: the hypercomplex Fourier transform, defined by the
+  real cos/sin kernel above.
+* `CayleyDickson.fourierInvIntegral`: its inverse.
+* `CayleyDickson.fourierL2`: the hypercomplex Fourier transform as a linear isometry
+  equivalence of `L²(V, CayleyDickson A)`.
+
+## Main statements
+
+* `CayleyDickson.fourierIntegral_eq_fourier`: the hypercomplex Fourier transform is the
+  Fourier transform for the `ℓ`-complex structure.
+* `CayleyDickson.integral_norm_sq_fourierIntegral`: Plancherel's theorem for Schwartz
+  functions.
+* `CayleyDickson.fourierInvIntegral_fourierIntegral`: the Fourier inversion formula for
+  Schwartz functions.
+
+## References
+
+* S. L. Hahn, K. M. Snopek, *The unified theory of n-dimensional complex and
+  hypercomplex analytic signals*, Bull. Polish Ac. Sci. 59 (2011)
+* Ł. Błaszczyk, *Octonion Fourier transform of real-valued functions of three
+  variables*, J. Fourier Anal. Appl. 26 (2020)
+
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Quaternion MeasureTheory SchwartzMap Real
+open scoped FourierTransform RealInnerProductSpace
+
+namespace CayleyDickson
+
+variable {A : Type*} [NonAssocRing A] [StarRing A] [Module ℝ A] [StarModule ℝ A]
+  [SMulCommClass ℝ A A] [IsScalarTower ℝ A A]
+
+/-! ### The complex structure -/
+
+/-- Left multiplication by the doubling unit `ℓ`, as a real-linear endomorphism. -/
+def unitMulHom : Module.End ℝ (CayleyDickson A) where
+  toFun x := unit A * x
+  map_add' := mul_add _
+  map_smul' r x := mul_smul_comm' r _ x
+
+@[simp] theorem unitMulHom_apply (x : CayleyDickson A) : unitMulHom x = unit A * x := rfl
+
+theorem unitMulHom_mul_unitMulHom :
+    unitMulHom * unitMulHom = (-1 : Module.End ℝ (CayleyDickson A)) := by
+  ext x : 1
+  simp [Module.End.mul_apply]
+
+/-- The real-algebra morphism `ℂ →ₐ[ℝ] Module.End ℝ (CayleyDickson A)` sending `I` to
+left multiplication by the doubling unit. The endomorphism algebra is associative even
+when the Cayley–Dickson algebra is not, which is all `Complex.liftAux` needs. -/
+def complexLift : ℂ →ₐ[ℝ] Module.End ℝ (CayleyDickson A) :=
+  Complex.liftAux unitMulHom unitMulHom_mul_unitMulHom
+
+/-- Every Cayley–Dickson algebra is a complex vector space, `I` acting by left
+multiplication by the doubling unit `ℓ`. It is in general *not* a complex algebra: `ℓ`
+is not central, but a module structure needs no commutation.
+
+This is a scoped instance since it involves the choice of an imaginary unit. -/
+scoped instance instModuleComplex : Module ℂ (CayleyDickson A) :=
+  Module.compHom _ (complexLift (A := A)).toRingHom
+
+theorem complex_smul_def (z : ℂ) (x : CayleyDickson A) : z • x = complexLift z x := rfl
+
+/-- The complex scalar action, componentwise. -/
+theorem complex_smul_mk (z : ℂ) (x : CayleyDickson A) :
+    z • x = ⟨z.re • x.fst - z.im • star x.snd, z.re • x.snd + z.im • star x.fst⟩ := by
+  rw [complex_smul_def, complexLift, Complex.liftAux_apply]
+  ext <;>
+    simp [Module.algebraMap_end_apply, unit_mul, sub_eq_add_neg]
+
+scoped instance : IsScalarTower ℝ ℂ (CayleyDickson A) :=
+  ⟨fun r z x => by
+    rw [complex_smul_def, complex_smul_def, map_smul, LinearMap.smul_apply]⟩
+
+scoped instance : SMulCommClass ℂ ℂ (CayleyDickson A) :=
+  ⟨fun z w x => by
+    rw [complex_smul_def, complex_smul_def, complex_smul_def, complex_smul_def,
+      ← Module.End.mul_apply, ← Module.End.mul_apply, ← map_mul, ← map_mul, mul_comm z w]⟩
+
+instance [Module.Finite ℝ A] : Module.Finite ℂ (CayleyDickson A) := by
+  -- pin the native real module structure (rather than the one restricted from `ℂ`)
+  letI : Module ℝ (CayleyDickson A) := CayleyDickson.instModule
+  exact Module.Finite.of_restrictScalars_finite ℝ ℂ _
+
+/-! ### The Hilbert space structure -/
+
+variable [Module.Finite ℝ A]
+
+/-- A `ℂ`-linear equivalence with a complex Euclidean space, fixing a Hilbert space
+structure. (Plancherel's theorem below holds for any choice.) -/
+def toEuclidean :
+    CayleyDickson A ≃ₗ[ℂ]
+      EuclideanSpace ℂ (Fin (Module.finrank ℂ (CayleyDickson A))) :=
+  (Module.finBasis ℂ _).equivFun.trans (WithLp.linearEquiv 2 ℂ _).symm
+
+scoped instance instNormedAddCommGroup : NormedAddCommGroup (CayleyDickson A) :=
+  NormedAddCommGroup.induced _ _ (toEuclidean (A := A)).toLinearMap
+    (toEuclidean (A := A)).injective
+
+scoped instance instInnerProductSpace : InnerProductSpace ℂ (CayleyDickson A) :=
+  InnerProductSpace.induced (toEuclidean (A := A)).toLinearMap
+
+scoped instance instCompleteSpace : CompleteSpace (CayleyDickson A) :=
+  FiniteDimensional.complete ℂ _
+
+/-! ### The hypercomplex Fourier transform -/
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
+  [MeasurableSpace V] [BorelSpace V]
+
+omit [Module.Finite ℝ A] [FiniteDimensional ℝ V] [MeasurableSpace V] [BorelSpace V] in
+/-- The hypercomplex Fourier kernel
+`exp (-2π ⟪x, ξ⟫ ℓ) = cos (2π ⟪x, ξ⟫) - sin (2π ⟪x, ξ⟫) ℓ`, componentwise. -/
+def fourierKernel (x ξ : V) : CayleyDickson A :=
+  ⟨Real.cos (2 * π * ⟪x, ξ⟫) • 1, -(Real.sin (2 * π * ⟪x, ξ⟫) • 1)⟩
+
+omit [Module.Finite ℝ A] [FiniteDimensional ℝ V] [MeasurableSpace V] [BorelSpace V] in
+/-- The inverse hypercomplex Fourier kernel `exp (2π ⟪x, ξ⟫ ℓ)`. -/
+def fourierInvKernel (x ξ : V) : CayleyDickson A :=
+  ⟨Real.cos (2 * π * ⟪x, ξ⟫) • 1, Real.sin (2 * π * ⟪x, ξ⟫) • 1⟩
+
+/-- The (left-sided) hypercomplex Fourier transform. -/
+def fourierIntegral (f : V → CayleyDickson A) (ξ : V) : CayleyDickson A :=
+  ∫ x, fourierKernel x ξ * f x
+
+/-- The inverse hypercomplex Fourier transform. -/
+def fourierInvIntegral (f : V → CayleyDickson A) (ξ : V) : CayleyDickson A :=
+  ∫ x, fourierInvKernel x ξ * f x
+
+omit [Module.Finite ℝ A] [FiniteDimensional ℝ V] [MeasurableSpace V] [BorelSpace V] in
+/-- The scalar action of the Fourier character is left multiplication by the
+hypercomplex Fourier kernel. -/
+theorem exp_smul_eq_fourierKernel_mul (x ξ : V) (a : CayleyDickson A) :
+    Complex.exp (((-(2 * π * ⟪x, ξ⟫) : ℝ) : ℂ) * Complex.I) • a
+      = fourierKernel x ξ * a := by
+  rw [complex_smul_mk, Complex.exp_ofReal_mul_I_re, Complex.exp_ofReal_mul_I_im,
+    Real.cos_neg, Real.sin_neg]
+  ext <;>
+    simp [fourierKernel, smul_mul_assoc, mul_smul_comm, sub_eq_add_neg]
+
+omit [Module.Finite ℝ A] [FiniteDimensional ℝ V] [MeasurableSpace V] [BorelSpace V] in
+/-- The scalar action of the inverse Fourier character is left multiplication by the
+inverse hypercomplex Fourier kernel. -/
+theorem exp_smul_eq_fourierInvKernel_mul (x ξ : V) (a : CayleyDickson A) :
+    Complex.exp (((2 * π * ⟪x, ξ⟫ : ℝ) : ℂ) * Complex.I) • a
+      = fourierInvKernel x ξ * a := by
+  rw [complex_smul_mk, Complex.exp_ofReal_mul_I_re, Complex.exp_ofReal_mul_I_im]
+  ext <;>
+    simp [fourierInvKernel, smul_mul_assoc, mul_smul_comm, sub_eq_add_neg]
+
+/-- The hypercomplex Fourier transform is the Fourier transform of a vector-valued
+function, for the complex structure given by the doubling unit. -/
+theorem fourierIntegral_eq_fourier (f : V → CayleyDickson A) (ξ : V) :
+    fourierIntegral f ξ = 𝓕 f ξ := by
+  rw [Real.fourier_eq', fourierIntegral]
+  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+  change fourierKernel x ξ * f x
+    = Complex.exp (((-2 * π * ⟪x, ξ⟫ : ℝ) : ℂ) * Complex.I) • f x
+  rw [show ((-2 * π * ⟪x, ξ⟫ : ℝ) : ℂ) * Complex.I
+        = ((-(2 * π * ⟪x, ξ⟫) : ℝ) : ℂ) * Complex.I by norm_num,
+    exp_smul_eq_fourierKernel_mul]
+
+/-- The inverse hypercomplex Fourier transform is the inverse Fourier transform of a
+vector-valued function, for the complex structure given by the doubling unit. -/
+theorem fourierInvIntegral_eq_fourierInv (f : V → CayleyDickson A) (ξ : V) :
+    fourierInvIntegral f ξ = 𝓕⁻ f ξ := by
+  rw [Real.fourierInv_eq', fourierInvIntegral]
+  refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+  change fourierInvKernel x ξ * f x
+    = Complex.exp (((2 * π * ⟪x, ξ⟫ : ℝ) : ℂ) * Complex.I) • f x
+  rw [exp_smul_eq_fourierInvKernel_mul]
+
+/-! ### Plancherel's theorem and inversion -/
+
+theorem fourierIntegral_coe (f : 𝓢(V, CayleyDickson A)) (ξ : V) :
+    fourierIntegral (⇑f) ξ = 𝓕 f ξ := by
+  rw [fourierIntegral_eq_fourier, fourier_coe]
+
+/-- **Plancherel's theorem** for the hypercomplex Fourier transform of Schwartz
+functions, inner product version. -/
+theorem integral_inner_fourierIntegral_fourierIntegral (f g : 𝓢(V, CayleyDickson A)) :
+    ∫ ξ, inner ℂ (fourierIntegral (⇑f) ξ) (fourierIntegral (⇑g) ξ)
+      = ∫ x, inner ℂ (f x) (g x) := by
+  simp_rw [fourierIntegral_coe]
+  exact integral_inner_fourier_fourier f g
+
+/-- **Plancherel's theorem** for the hypercomplex Fourier transform of Schwartz
+functions: the transform preserves the `L²` norm. -/
+theorem integral_norm_sq_fourierIntegral (f : 𝓢(V, CayleyDickson A)) :
+    ∫ ξ, ‖fourierIntegral (⇑f) ξ‖ ^ 2 = ∫ x, ‖f x‖ ^ 2 := by
+  simp_rw [fourierIntegral_coe]
+  exact integral_norm_sq_fourier f
+
+/-- **Fourier inversion** for the hypercomplex Fourier transform of Schwartz
+functions. -/
+theorem fourierInvIntegral_fourierIntegral (f : 𝓢(V, CayleyDickson A)) (x : V) :
+    fourierInvIntegral (fourierIntegral (⇑f)) x = f x := by
+  have h : fourierIntegral (⇑f) = 𝓕 (⇑f) :=
+    funext fun ξ => fourierIntegral_eq_fourier _ ξ
+  rw [h, fourierInvIntegral_eq_fourierInv, ← fourier_coe, ← fourierInv_coe,
+    FourierPair.fourierInv_fourier_eq f]
+
+/-- **Fourier inversion** for the hypercomplex Fourier transform of Schwartz
+functions, the other composition. -/
+theorem fourierIntegral_fourierInvIntegral (f : 𝓢(V, CayleyDickson A)) (x : V) :
+    fourierIntegral (fourierInvIntegral (⇑f)) x = f x := by
+  have h : fourierInvIntegral (⇑f) = 𝓕⁻ (⇑f) :=
+    funext fun ξ => fourierInvIntegral_eq_fourierInv _ ξ
+  rw [h, fourierIntegral_eq_fourier, ← fourierInv_coe, ← fourier_coe,
+    FourierInvPair.fourier_fourierInv_eq f]
+
+/-! ### `L²` theory -/
+
+variable (A V) in
+/-- The hypercomplex Fourier transform as a linear isometry equivalence of
+`L²(V, CayleyDickson A)` — the `L²` form of **Plancherel's theorem**. -/
+def fourierL2 :
+    Lp (α := V) (CayleyDickson A) 2 ≃ₗᵢ[ℂ] Lp (α := V) (CayleyDickson A) 2 :=
+  Lp.fourierTransformₗᵢ _ _
+
+@[simp] theorem norm_fourierL2_eq (f : Lp (α := V) (CayleyDickson A) 2) :
+    ‖fourierL2 A V f‖ = ‖f‖ :=
+  (fourierL2 A V).norm_map f
+
+end CayleyDickson
+
+/-! ### The octonion and sedenion Fourier transforms
+
+The hypothesis chain of the generic results is satisfied at every level of the
+Cayley–Dickson tower over the quaternions, so Plancherel's theorem specializes to the
+octonion Fourier transform, the sedenion one, and so on. We record the sedenion case —
+an algebra with zero divisors that is not even alternative — explicitly. -/
+
+section Instances
+
+open CayleyDickson in
+example (V : Type*) [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
+    [MeasurableSpace V] [BorelSpace V] (f : 𝓢(V, Octonion ℝ)) :
+    ∫ ξ, ‖fourierIntegral (⇑f) ξ‖ ^ 2 = ∫ x, ‖f x‖ ^ 2 :=
+  integral_norm_sq_fourierIntegral f
+
+open CayleyDickson in
+/-- **Plancherel's theorem for the sedenion Fourier transform.** The sedenions have zero
+divisors and are not alternative, but the doubling unit is still a square root of `-1`
+by direct computation, which is all the Fourier theory needs. -/
+theorem Sedenion.integral_norm_sq_fourierIntegral (V : Type*) [NormedAddCommGroup V]
+    [InnerProductSpace ℝ V] [FiniteDimensional ℝ V] [MeasurableSpace V] [BorelSpace V]
+    (f : 𝓢(V, Sedenion ℝ)) :
+    ∫ ξ, ‖fourierIntegral (⇑f) ξ‖ ^ 2 = ∫ x, ‖f x‖ ^ 2 :=
+  CayleyDickson.integral_norm_sq_fourierIntegral f
+
+open CayleyDickson in
+/-- **Fourier inversion for the sedenion Fourier transform.** -/
+theorem Sedenion.fourierInvIntegral_fourierIntegral (V : Type*) [NormedAddCommGroup V]
+    [InnerProductSpace ℝ V] [FiniteDimensional ℝ V] [MeasurableSpace V] [BorelSpace V]
+    (f : 𝓢(V, Sedenion ℝ)) (x : V) :
+    fourierInvIntegral (fourierIntegral (⇑f)) x = f x :=
+  CayleyDickson.fourierInvIntegral_fourierIntegral f x
+
+end Instances

--- a/Mathlib/Analysis/Fourier/CayleyDicksonPlancherel.lean
+++ b/Mathlib/Analysis/Fourier/CayleyDicksonPlancherel.lean
@@ -131,10 +131,13 @@ def toEuclidean :
       EuclideanSpace ℂ (Fin (Module.finrank ℂ (CayleyDickson A))) :=
   (Module.finBasis ℂ _).equivFun.trans (WithLp.linearEquiv 2 ℂ _).symm
 
+/-- The norm induced by the fixed complex Hilbert space structure (`toEuclidean`). -/
 scoped instance instNormedAddCommGroup : NormedAddCommGroup (CayleyDickson A) :=
   NormedAddCommGroup.induced _ _ (toEuclidean (A := A)).toLinearMap
     (toEuclidean (A := A)).injective
 
+/-- The complex inner product induced by the fixed complex Hilbert space structure
+(`toEuclidean`). -/
 scoped instance instInnerProductSpace : InnerProductSpace ℂ (CayleyDickson A) :=
   InnerProductSpace.induced (toEuclidean (A := A)).toLinearMap
 

--- a/Mathlib/Analysis/Fourier/CayleyDicksonPlancherel.lean
+++ b/Mathlib/Analysis/Fourier/CayleyDicksonPlancherel.lean
@@ -256,7 +256,7 @@ def fourierL2 :
     Lp (α := V) (CayleyDickson A) 2 ≃ₗᵢ[ℂ] Lp (α := V) (CayleyDickson A) 2 :=
   Lp.fourierTransformₗᵢ _ _
 
-@[simp] theorem norm_fourierL2_eq (f : Lp (α := V) (CayleyDickson A) 2) :
+theorem norm_fourierL2_eq (f : Lp (α := V) (CayleyDickson A) 2) :
     ‖fourierL2 A V f‖ = ‖f‖ :=
   (fourierL2 A V).norm_map f
 


### PR DESCRIPTION
The (left-sided) hypercomplex Fourier transform of `f : V → CayleyDickson A` replaces the imaginary unit in the Fourier kernel by the Cayley–Dickson doubling unit `ℓ`:

`ℱ f ξ = ∫ x, (cos (2π ⟪x, ξ⟫) - sin (2π ⟪x, ξ⟫) ℓ) * f x`.

Cayley–Dickson algebras beyond the quaternions are not associative — the sedenions are not even alternative and have zero divisors — but the Fourier theory only needs a complex *module* structure on the codomain: `ℓ * (ℓ * x) = -x` holds at every level of the tower, so `Complex.liftAux` into `Module.End ℝ (CayleyDickson A)` (where associativity lives) makes every Cayley–Dickson algebra a complex vector space. Equipping it with a compatible complex Hilbert space structure, Plancherel's theorem (`CayleyDickson.integral_norm_sq_fourierIntegral`) and the Fourier inversion formula (`CayleyDickson.fourierInvIntegral_fourierIntegral`) are inherited from the vector-valued `L²` Fourier theory (#24063-style `Lp.fourierTransformₗᵢ`), on any finite-dimensional real inner product space domain.

Taking `A = ℍ[ℝ]` gives the octonion Fourier transform (Hahn–Snopek; Błaszczyk, *J. Fourier Anal. Appl.* 2020); `A = Octonion ℝ` gives the sedenion one, recorded explicitly as `Sedenion.integral_norm_sq_fourierIntegral`.

- [ ] depends on: #41919
