### PR TITLE
feat(NumberTheory): the number-theoretic transform

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -244,6 +244,7 @@ public import Mathlib.Algebra.Category.Ring.Under.Basic
 public import Mathlib.Algebra.Category.Ring.Under.Limits
 public import Mathlib.Algebra.Category.Ring.Under.Property
 public import Mathlib.Algebra.Category.Semigrp.Basic
+public import Mathlib.Algebra.CayleyDickson
 public import Mathlib.Algebra.Central.Basic
 public import Mathlib.Algebra.Central.Defs
 public import Mathlib.Algebra.Central.End
@@ -914,6 +915,7 @@ public import Mathlib.Algebra.Notation.Pi.Basic
 public import Mathlib.Algebra.Notation.Pi.Defs
 public import Mathlib.Algebra.Notation.Prod
 public import Mathlib.Algebra.Notation.Support
+public import Mathlib.Algebra.Octonion
 public import Mathlib.Algebra.Opposites
 public import Mathlib.Algebra.Order.AbsoluteValue.Basic
 public import Mathlib.Algebra.Order.AbsoluteValue.Euclidean

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5893,6 +5893,7 @@ public import Mathlib.NumberTheory.NumberField.ProductFormula
 public import Mathlib.NumberTheory.NumberField.Units.Basic
 public import Mathlib.NumberTheory.NumberField.Units.DirichletTheorem
 public import Mathlib.NumberTheory.NumberField.Units.Regulator
+public import Mathlib.NumberTheory.NumberTheoreticTransform
 public import Mathlib.NumberTheory.Ostrowski
 public import Mathlib.NumberTheory.Padics.AddChar
 public import Mathlib.NumberTheory.Padics.Complex

--- a/Mathlib/Algebra/CayleyDickson.lean
+++ b/Mathlib/Algebra/CayleyDickson.lean
@@ -182,7 +182,7 @@ theorem mul_smul_comm' [Monoid S] [Star S] [TrivialStar S] [DistribMulAction S A
   ext <;> simp [hstar, smul_sub, smul_add, mul_smul_comm, smul_mul_assoc]
 
 /-- The self-action compatibility propagates up the Cayley–Dickson tower. -/
-instance [Monoid S] [Star S] [TrivialStar S] [DistribMulAction S A] [StarModule S A]
+instance [Monoid S] [DistribMulAction S A]
     [SMulCommClass S A A] [IsScalarTower S A A] :
     IsScalarTower S (CayleyDickson A) (CayleyDickson A) :=
   ⟨fun s x y => smul_mul_assoc' s x y⟩

--- a/Mathlib/Algebra/CayleyDickson.lean
+++ b/Mathlib/Algebra/CayleyDickson.lean
@@ -1,0 +1,252 @@
+/-
+Copyright (c) 2026 Junji Hashimoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junji Hashimoto
+-/
+module
+
+public import Mathlib.Algebra.Quaternion
+public import Mathlib.RingTheory.Finiteness.Prod
+
+/-!
+# The Cayley–Dickson construction
+
+Given a (possibly non-associative) ring `A` with a star operation, the Cayley–Dickson
+construction produces the algebra `CayleyDickson A` of pairs of elements of `A`,
+multiplied by
+
+`⟨a, b⟩ * ⟨c, d⟩ = ⟨a * c - star d * b, d * a + b * star c⟩`,
+
+with the star operation `star ⟨a, b⟩ = ⟨star a, -b⟩`. Iterating the construction starting
+from the quaternions produces the octonions, the sedenions, the trigintaduonions, and so
+on; see `Mathlib/Algebra/Octonion.lean`.
+
+The construction preserves `NonAssocRing` and `StarRing`, but not associativity, so the
+tower can be iterated indefinitely inside these classes.
+
+The doubling unit `ℓ = ⟨0, 1⟩` satisfies `ℓ * ℓ = -1` and, crucially,
+`ℓ * (ℓ * x) = -x` (`CayleyDickson.unit_mul_unit_mul`) *at every level of the tower* —
+the proof only uses that `star` is an involution on `A`. Consequently left multiplication
+by `ℓ` is a complex structure on every Cayley–Dickson algebra (even the non-alternative
+ones with zero divisors, such as the sedenions), which is what the hypercomplex
+(octonion, sedenion, …) Fourier transform needs; this is used in a follow-up PR to derive
+Plancherel's theorem for these transforms from the vector-valued `L²` Fourier theory.
+
+## Main definitions
+
+* `CayleyDickson A`: the Cayley–Dickson double of `A`.
+* `CayleyDickson.unit`: the doubling unit `ℓ`.
+
+## TODO
+
+* alternativity of the double of an associative star ring, the multiplicative norm for
+  composition algebras.
+
+## References
+
+* J. C. Baez, *The octonions*, Bull. Amer. Math. Soc. 39 (2002)
+
+-/
+
+@[expose] public section
+
+/-- The Cayley–Dickson double of `A`: pairs of elements of `A` with the multiplication
+`⟨a, b⟩ * ⟨c, d⟩ = ⟨a * c - star d * b, d * a + b * star c⟩`. -/
+@[ext]
+structure CayleyDickson (A : Type*) where
+  /-- The first component. -/
+  fst : A
+  /-- The second component. -/
+  snd : A
+
+namespace CayleyDickson
+
+variable {A S : Type*}
+
+/-! ### The additive and module structure, componentwise -/
+
+section AddGroup
+
+variable [AddCommGroup A]
+
+instance : Zero (CayleyDickson A) := ⟨⟨0, 0⟩⟩
+instance : Add (CayleyDickson A) := ⟨fun x y => ⟨x.fst + y.fst, x.snd + y.snd⟩⟩
+instance : Neg (CayleyDickson A) := ⟨fun x => ⟨-x.fst, -x.snd⟩⟩
+instance : Sub (CayleyDickson A) := ⟨fun x y => ⟨x.fst - y.fst, x.snd - y.snd⟩⟩
+instance [SMul S A] : SMul S (CayleyDickson A) :=
+  ⟨fun s x => ⟨s • x.fst, s • x.snd⟩⟩
+
+@[simp] theorem zero_fst : (0 : CayleyDickson A).fst = 0 := rfl
+@[simp] theorem zero_snd : (0 : CayleyDickson A).snd = 0 := rfl
+@[simp] theorem add_fst (x y : CayleyDickson A) : (x + y).fst = x.fst + y.fst := rfl
+@[simp] theorem add_snd (x y : CayleyDickson A) : (x + y).snd = x.snd + y.snd := rfl
+@[simp] theorem neg_fst (x : CayleyDickson A) : (-x).fst = -x.fst := rfl
+@[simp] theorem neg_snd (x : CayleyDickson A) : (-x).snd = -x.snd := rfl
+@[simp] theorem sub_fst (x y : CayleyDickson A) : (x - y).fst = x.fst - y.fst := rfl
+@[simp] theorem sub_snd (x y : CayleyDickson A) : (x - y).snd = x.snd - y.snd := rfl
+omit [AddCommGroup A] in
+@[simp] theorem smul_fst [SMul S A] (s : S) (x : CayleyDickson A) :
+    (s • x).fst = s • x.fst := rfl
+
+omit [AddCommGroup A] in
+@[simp] theorem smul_snd [SMul S A] (s : S) (x : CayleyDickson A) :
+    (s • x).snd = s • x.snd := rfl
+
+/-- The underlying pair of a Cayley–Dickson number. -/
+def toProd (x : CayleyDickson A) : A × A := (x.fst, x.snd)
+
+omit [AddCommGroup A] in
+theorem toProd_injective : Function.Injective (toProd (A := A)) := fun x y h => by
+  cases x
+  cases y
+  simpa [toProd, Prod.ext_iff] using h
+
+instance : AddCommGroup (CayleyDickson A) :=
+  toProd_injective.addCommGroup toProd rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl)
+
+/-- `toProd` as an additive monoid homomorphism. -/
+def toProdHom : CayleyDickson A →+ A × A where
+  toFun := toProd
+  map_zero' := rfl
+  map_add' _ _ := rfl
+
+instance instModule [Semiring S] [Module S A] : Module S (CayleyDickson A) :=
+  toProd_injective.module S toProdHom fun _ _ => rfl
+
+variable (S) in
+/-- `toProd` as a linear equivalence. -/
+@[simps apply]
+def toProdLinearEquiv [Semiring S] [Module S A] : CayleyDickson A ≃ₗ[S] A × A where
+  toFun := toProd
+  invFun p := ⟨p.1, p.2⟩
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+instance [Semiring S] [Module S A] [Module.Finite S A] :
+    Module.Finite S (CayleyDickson A) :=
+  Module.Finite.equiv (toProdLinearEquiv S).symm
+
+end AddGroup
+
+/-! ### The multiplicative and star structure -/
+
+section Ring
+
+variable [NonUnitalNonAssocRing A] [StarRing A]
+
+instance : Mul (CayleyDickson A) :=
+  ⟨fun x y => ⟨x.fst * y.fst - star y.snd * x.snd, y.snd * x.fst + x.snd * star y.fst⟩⟩
+
+theorem mul_def (x y : CayleyDickson A) :
+    x * y = ⟨x.fst * y.fst - star y.snd * x.snd, y.snd * x.fst + x.snd * star y.fst⟩ :=
+  rfl
+
+@[simp] theorem mul_fst (x y : CayleyDickson A) :
+    (x * y).fst = x.fst * y.fst - star y.snd * x.snd := rfl
+@[simp] theorem mul_snd (x y : CayleyDickson A) :
+    (x * y).snd = y.snd * x.fst + x.snd * star y.fst := rfl
+
+instance : NonUnitalNonAssocRing (CayleyDickson A) where
+  left_distrib _ _ _ := by
+    ext <;> simp [mul_add, add_mul, star_add, sub_eq_add_neg] <;> abel
+  right_distrib _ _ _ := by
+    ext <;> simp [mul_add, add_mul, sub_eq_add_neg] <;> abel
+  zero_mul _ := by ext <;> simp
+  mul_zero _ := by ext <;> simp
+
+instance : Star (CayleyDickson A) := ⟨fun x => ⟨star x.fst, -x.snd⟩⟩
+
+@[simp] theorem star_fst (x : CayleyDickson A) : (star x).fst = star x.fst := rfl
+@[simp] theorem star_snd (x : CayleyDickson A) : (star x).snd = -x.snd := rfl
+
+instance : StarRing (CayleyDickson A) where
+  star_involutive _ := by ext <;> simp
+  star_add _ _ := by ext <;> simp [add_comm]
+  star_mul _ _ := by ext <;> simp [star_mul, sub_eq_add_neg]
+
+instance [Monoid S] [DistribMulAction S A] [Star S] [TrivialStar S] [StarModule S A] :
+    StarModule S (CayleyDickson A) :=
+  ⟨fun s x => by ext <;> simp [star_smul, star_trivial, smul_neg]⟩
+
+theorem smul_mul_assoc' [Monoid S] [DistribMulAction S A] [SMulCommClass S A A]
+    [IsScalarTower S A A] (s : S) (x y : CayleyDickson A) :
+    (s • x) * y = s • (x * y) := by
+  ext <;> simp [smul_sub, smul_add, mul_smul_comm, smul_mul_assoc]
+
+theorem mul_smul_comm' [Monoid S] [Star S] [TrivialStar S] [DistribMulAction S A]
+    [StarModule S A] [SMulCommClass S A A] [IsScalarTower S A A] (s : S)
+    (x y : CayleyDickson A) : x * (s • y) = s • (x * y) := by
+  have hstar : ∀ a : A, star (s • a) = s • star a := fun a => by
+    rw [star_smul, star_trivial]
+  ext <;> simp [hstar, smul_sub, smul_add, mul_smul_comm, smul_mul_assoc]
+
+/-- The self-action compatibility propagates up the Cayley–Dickson tower. -/
+instance [Monoid S] [Star S] [TrivialStar S] [DistribMulAction S A] [StarModule S A]
+    [SMulCommClass S A A] [IsScalarTower S A A] :
+    IsScalarTower S (CayleyDickson A) (CayleyDickson A) :=
+  ⟨fun s x y => smul_mul_assoc' s x y⟩
+
+/-- The self-action compatibility propagates up the Cayley–Dickson tower. -/
+instance [Monoid S] [Star S] [TrivialStar S] [DistribMulAction S A] [StarModule S A]
+    [SMulCommClass S A A] [IsScalarTower S A A] :
+    SMulCommClass S (CayleyDickson A) (CayleyDickson A) :=
+  ⟨fun s x y => (mul_smul_comm' s x y).symm⟩
+
+end Ring
+
+section Unital
+
+variable [NonAssocRing A]
+
+instance : One (CayleyDickson A) := ⟨⟨1, 0⟩⟩
+
+@[simp] theorem one_fst : (1 : CayleyDickson A).fst = 1 := rfl
+@[simp] theorem one_snd : (1 : CayleyDickson A).snd = 0 := rfl
+
+instance : NatCast (CayleyDickson A) := ⟨fun n => ⟨n, 0⟩⟩
+instance : IntCast (CayleyDickson A) := ⟨fun n => ⟨n, 0⟩⟩
+
+@[simp] theorem natCast_fst (n : ℕ) : (n : CayleyDickson A).fst = n := rfl
+@[simp] theorem natCast_snd (n : ℕ) : (n : CayleyDickson A).snd = 0 := rfl
+@[simp] theorem intCast_fst (n : ℤ) : (n : CayleyDickson A).fst = n := rfl
+@[simp] theorem intCast_snd (n : ℤ) : (n : CayleyDickson A).snd = 0 := rfl
+
+variable [StarRing A]
+
+instance : NonAssocRing (CayleyDickson A) where
+  one_mul _ := by ext <;> simp
+  mul_one _ := by ext <;> simp
+  natCast_zero := by ext <;> simp
+  natCast_succ _ := by ext <;> simp
+  intCast_ofNat _ := by ext <;> simp
+  intCast_negSucc _ := by ext <;> simp [Int.negSucc_eq]
+
+/-! ### The doubling unit -/
+
+variable (A) in
+/-- The Cayley–Dickson doubling unit `ℓ = ⟨0, 1⟩`. -/
+def unit : CayleyDickson A := ⟨0, 1⟩
+
+omit [StarRing A] in
+@[simp] theorem unit_fst : (unit A).fst = 0 := rfl
+
+omit [StarRing A] in
+@[simp] theorem unit_snd : (unit A).snd = 1 := rfl
+
+@[simp] theorem unit_mul_unit : unit A * unit A = -1 := by
+  ext <;> simp
+
+theorem unit_mul (x : CayleyDickson A) : unit A * x = ⟨-star x.snd, star x.fst⟩ := by
+  ext <;> simp
+
+/-- The left alternative law at the doubling unit: `ℓ * (ℓ * x) = (ℓ * ℓ) * x = -x`.
+This holds at *every* level of the Cayley–Dickson tower — the proof uses only that
+`star` is an involution — even when the algebra is not alternative (e.g. the
+sedenions). Left multiplication by `ℓ` is therefore always a complex structure. -/
+@[simp] theorem unit_mul_unit_mul (x : CayleyDickson A) : unit A * (unit A * x) = -x := by
+  ext <;> simp
+
+end Unital
+
+end CayleyDickson

--- a/Mathlib/Algebra/Octonion.lean
+++ b/Mathlib/Algebra/Octonion.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 Junji Hashimoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junji Hashimoto
+-/
+module
+
+public import Mathlib.Algebra.CayleyDickson
+
+/-!
+# Octonions, sedenions, and the Cayley–Dickson tower over the quaternions
+
+The octonions are the Cayley–Dickson double of the quaternions, the sedenions the double
+of the octonions. Both are *not associative* (`NonAssocRing`); the sedenions are not even
+alternative and have zero divisors. All the structure comes from the generic construction
+in `Mathlib/Algebra/CayleyDickson.lean`; this file only fixes the base of the tower by
+providing the `StarModule` instance for the quaternions.
+
+## Main definitions
+
+* `Octonion R`: the octonions over `R`.
+* `Sedenion R`: the sedenions over `R`.
+
+## References
+
+* J. C. Baez, *The octonions*, Bull. Amer. Math. Soc. 39 (2002)
+
+-/
+
+@[expose] public section
+
+open Quaternion
+
+/-- Scalars with a trivial star act star-equivariantly on the quaternions. -/
+instance Quaternion.instStarModule {R S : Type*} [CommRing R] [Monoid S]
+    [DistribMulAction S R] [Star S] [TrivialStar S] : StarModule S ℍ[R] :=
+  ⟨fun s a => by rw [star_trivial s, Quaternion.star_smul]⟩
+
+/-- The octonions over a commutative ring `R`: the Cayley–Dickson double of the
+quaternions. -/
+abbrev Octonion (R : Type*) [CommRing R] := CayleyDickson ℍ[R]
+
+/-- The sedenions over a commutative ring `R`: the Cayley–Dickson double of the
+octonions. The sedenions are not alternative and have zero divisors, but the doubling
+unit still satisfies `ℓ * (ℓ * x) = -x` (`CayleyDickson.unit_mul_unit_mul`). -/
+abbrev Sedenion (R : Type*) [CommRing R] := CayleyDickson (Octonion R)
+
+/-- The trigintaduonions (32-ons) over a commutative ring `R`. -/
+abbrev Trigintaduonion (R : Type*) [CommRing R] := CayleyDickson (Sedenion R)
+
+namespace Octonion
+
+variable {R : Type*} [CommRing R]
+
+example : NonAssocRing (Octonion R) := inferInstance
+example : StarRing (Octonion R) := inferInstance
+example : NonAssocRing (Sedenion R) := inferInstance
+example : StarRing (Sedenion R) := inferInstance
+example : Module.Finite R (Sedenion R) := inferInstance
+
+end Octonion

--- a/Mathlib/NumberTheory/NumberTheoreticTransform.lean
+++ b/Mathlib/NumberTheory/NumberTheoreticTransform.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 Junji Hashimoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junji Hashimoto
+-/
+module
+
+public import Mathlib.NumberTheory.LegendreSymbol.AddCharacter
+public import Mathlib.Algebra.Octonion
+
+/-!
+# The number-theoretic transform
+
+The number-theoretic transform (NTT) is the discrete Fourier transform of functions
+`ZMod N → M`, where `M` is a module over a commutative domain `R` containing a primitive
+`N`-th root of unity `ζ` — e.g. `R = ZMod p` with `N ∣ p - 1`:
+
+`ntt hζ f k = ∑ j, ζ ^ (j * k) • f j`.
+
+There is no norm or complex conjugation over a general `R`, so Plancherel's theorem takes
+the form of the *bilinear* Parseval identity `sum_bilin_ntt_ntt_neg`, and the Fourier
+inversion formula `nttInv_ntt` holds after multiplication by `N` (so the transform is
+bijective whenever `N` is invertible in `R`; over `ZMod p` this is `p ∤ N`).
+
+The module `M` can be any `R`-module: taking `M` to be a hypercomplex algebra over `R`
+(for instance the octonions or sedenions over `ZMod p`, with the `R`-scalar action) yields
+hypercomplex number-theoretic transforms; see the example at the end of the file.
+
+## Main definitions
+
+* `ZMod.ntt`: the number-theoretic transform.
+* `ZMod.nttInv`: the inverse transform (up to the factor `N`).
+
+## Main statements
+
+* `ZMod.sum_zmodChar_mul`: orthogonality of the characters `j ↦ ζ ^ (s * j)`.
+* `ZMod.nttInv_ntt`, `ZMod.ntt_nttInv`: the Fourier inversion formula.
+* `ZMod.sum_bilin_ntt_ntt_neg`: the bilinear Parseval identity.
+
+## References
+
+* J. M. Pollard, *The fast Fourier transform in a finite field*, Math. Comp. 25 (1971)
+
+-/
+
+@[expose] public section
+
+open Finset AddChar
+
+namespace ZMod
+
+variable {N : ℕ} [NeZero N] {R : Type*} [CommRing R] [IsDomain R] {ζ : R}
+  {M : Type*} [AddCommGroup M] [Module R M]
+
+/-- The number-theoretic transform of `f : ZMod N → M` with respect to an `N`-th root of
+unity `ζ`: `ntt hζ f k = ∑ j, ζ ^ (j * k) • f j`. -/
+def ntt (hζ : ζ ^ N = 1) (f : ZMod N → M) (k : ZMod N) : M :=
+  ∑ j : ZMod N, zmodChar N hζ (j * k) • f j
+
+/-- The inverse number-theoretic transform, up to the factor `N`:
+`nttInv hζ f k = ∑ j, ζ ^ (-(j * k)) • f j`. -/
+def nttInv (hζ : ζ ^ N = 1) (f : ZMod N → M) (k : ZMod N) : M :=
+  ∑ j : ZMod N, zmodChar N hζ (-(j * k)) • f j
+
+/-- Orthogonality of the characters of `ZMod N` obtained from a primitive `N`-th root of
+unity. -/
+theorem sum_zmodChar_mul (hζ : IsPrimitiveRoot ζ N) (s : ZMod N) :
+    ∑ j : ZMod N, zmodChar N hζ.pow_eq_one (s * j) = if s = 0 then (N : R) else 0 := by
+  classical
+  split_ifs with hs
+  · simp [hs, card_univ, ZMod.card]
+  · have hprim := zmodChar_primitive_of_primitive_root N hζ
+    have h := sum_eq_ite ((zmodChar N hζ.pow_eq_one).mulShift s)
+    rw [if_neg (show (zmodChar N hζ.pow_eq_one).mulShift s ≠ 0 from fun h => hprim hs h)] at h
+    simpa only [mulShift_apply] using h
+
+/-- The **Fourier inversion formula** for the number-theoretic transform. -/
+theorem nttInv_ntt (hζ : IsPrimitiveRoot ζ N) (f : ZMod N → M) (k : ZMod N) :
+    nttInv hζ.pow_eq_one (ntt hζ.pow_eq_one f) k = (N : R) • f k := by
+  classical
+  simp only [nttInv, ntt, smul_sum, smul_smul, ← map_add_eq_mul]
+  rw [sum_comm]
+  simp only [show ∀ i j : ZMod N, -(j * k) + i * j = (i - k) * j from fun i j => by ring]
+  have horth : ∀ i : ZMod N,
+      (∑ j : ZMod N, zmodChar N hζ.pow_eq_one ((i - k) * j) • f i)
+        = (if i - k = 0 then (N : R) else 0) • f i := fun i => by
+    rw [← sum_smul, sum_zmodChar_mul hζ]
+  simp only [horth, sub_eq_zero, ite_smul, zero_smul]
+  rw [Finset.sum_ite_eq' Finset.univ k, if_pos (mem_univ k)]
+
+/-- The **Fourier inversion formula** for the number-theoretic transform, the other
+composition. -/
+theorem ntt_nttInv (hζ : IsPrimitiveRoot ζ N) (f : ZMod N → M) (k : ZMod N) :
+    ntt hζ.pow_eq_one (nttInv hζ.pow_eq_one f) k = (N : R) • f k := by
+  classical
+  simp only [ntt, nttInv, smul_sum, smul_smul, ← map_add_eq_mul]
+  rw [sum_comm]
+  simp only [show ∀ i j : ZMod N, j * k + -(i * j) = (k - i) * j from fun i j => by ring]
+  have horth : ∀ i : ZMod N,
+      (∑ j : ZMod N, zmodChar N hζ.pow_eq_one ((k - i) * j) • f i)
+        = (if k - i = 0 then (N : R) else 0) • f i := fun i => by
+    rw [← sum_smul, sum_zmodChar_mul hζ]
+  simp only [horth, sub_eq_zero, ite_smul, zero_smul]
+  rw [Finset.sum_ite_eq Finset.univ k, if_pos (mem_univ k)]
+
+/-- Summing the transform against the character recovers `N` times the original function:
+a reformulation of the inversion formula used for the Parseval identity. -/
+theorem sum_zmodChar_smul_ntt_neg (hζ : IsPrimitiveRoot ζ N) (g : ZMod N → M) (i : ZMod N) :
+    (∑ k : ZMod N, zmodChar N hζ.pow_eq_one (i * k) • ntt hζ.pow_eq_one g (-k))
+      = (N : R) • g i := by
+  rw [← nttInv_ntt hζ g i, nttInv]
+  exact Fintype.sum_equiv (Equiv.neg (ZMod N)) _ _ fun k => by
+    rw [Equiv.neg_apply, show (-(-k * i) : ZMod N) = i * k from by ring]
+
+/-- The **bilinear Parseval identity** for the number-theoretic transform: over a general
+coefficient ring there is no norm or conjugation, and Plancherel's theorem takes this
+bilinear form. -/
+theorem sum_bilin_ntt_ntt_neg {M' P : Type*} [AddCommGroup M'] [Module R M']
+    [AddCommGroup P] [Module R P] (hζ : IsPrimitiveRoot ζ N)
+    (B : M →ₗ[R] M' →ₗ[R] P) (f : ZMod N → M) (g : ZMod N → M') :
+    ∑ k : ZMod N, B (ntt hζ.pow_eq_one f k) (ntt hζ.pow_eq_one g (-k))
+      = (N : R) • ∑ x : ZMod N, B (f x) (g x) := by
+  classical
+  have hexp : ∀ (k : ZMod N) (y : M'), B (ntt hζ.pow_eq_one f k) y
+      = ∑ i : ZMod N, zmodChar N hζ.pow_eq_one (i * k) • (B (f i)) y := fun k y => by
+    rw [ntt, map_sum, LinearMap.sum_apply]
+    exact Finset.sum_congr rfl fun d _ => by rw [B.map_smul, LinearMap.smul_apply]
+  simp only [hexp]
+  rw [sum_comm]
+  have hinner : ∀ i : ZMod N,
+      (∑ k : ZMod N,
+          zmodChar N hζ.pow_eq_one (i * k) • (B (f i)) (ntt hζ.pow_eq_one g (-k)))
+        = (N : R) • (B (f i)) (g i) := fun i => by
+    have h1 : (B (f i)) (∑ k : ZMod N,
+        zmodChar N hζ.pow_eq_one (i * k) • ntt hζ.pow_eq_one g (-k))
+        = ∑ k : ZMod N,
+            zmodChar N hζ.pow_eq_one (i * k) • (B (f i)) (ntt hζ.pow_eq_one g (-k)) := by
+      rw [map_sum]
+      exact Finset.sum_congr rfl fun k _ => (B (f i)).map_smul _ _
+    rw [← h1, sum_zmodChar_smul_ntt_neg hζ g i]
+    exact (B (f i)).map_smul _ _
+  simp only [hinner]
+  rw [← smul_sum]
+
+/-- A hypercomplex number-theoretic transform: the octonions over `ZMod p` are a module
+over `ZMod p`, so the inversion formula applies to octonion-valued NTTs (and similarly at
+every level of the Cayley–Dickson tower). -/
+example {p : ℕ} [Fact p.Prime] {ζ : ZMod p} (hζ : IsPrimitiveRoot ζ N)
+    (f : ZMod N → CayleyDickson (Quaternion (ZMod p))) (k : ZMod N) :
+    nttInv hζ.pow_eq_one (ntt hζ.pow_eq_one f) k = (N : ZMod p) • f k :=
+  nttInv_ntt hζ f k
+
+end ZMod


### PR DESCRIPTION
The number-theoretic transform is the discrete Fourier transform of functions `ZMod N → M`, where `M` is a module over a commutative domain `R` containing a primitive `N`-th root of unity `ζ` (e.g. `R = ZMod p` with `N ∣ p - 1`):

`ntt hζ f k = ∑ j, ζ ^ (j * k) • f j`.

We prove the character orthogonality relation (`sum_zmodChar_mul`, from `AddChar.sum_eq_ite`), the **Fourier inversion formula** `nttInv_ntt` / `ntt_nttInv` (so the transform is bijective whenever `N` is invertible in `R`), and the **bilinear Parseval identity** `sum_bilin_ntt_ntt_neg` — over a general coefficient ring there is no norm or conjugation, and this is the correct finite-field replacement for Plancherel's theorem.

The module `M` is arbitrary; taking `M` to be a hypercomplex algebra over `R` (e.g. the octonions or sedenions over `ZMod p` from #41919, whence the dependency) yields hypercomplex number-theoretic transforms, recorded as an example. This is the finite-field counterpart of the archimedean theory in #41921/#41922.

The NTT is the transform underlying polynomial multiplication in lattice-based cryptography (e.g. ML-KEM/Kyber), so this also provides groundwork for formalizing those schemes.

- [ ] depends on: #41919
