### PR TITLE
[Merged by Bors] - fix(Algebra/FreeMonoid): fix recursor argument names

### DIFF
--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -232,16 +232,18 @@ end Mem
   /-- Recursor for `FreeAddMonoid` using `0` and
   `FreeAddMonoid.of x + xs` instead of `[]` and `x :: xs`. -/]
 -- Porting note: change from `List.recOn` to `List.rec` since only the latter is computable
-def recOn {C : FreeMonoid α → Sort*} (xs : FreeMonoid α) (h0 : C 1)
-    (ih : ∀ x xs, C xs → C (of x * xs)) : C xs := List.rec h0 ih xs
+def recOn {motive : FreeMonoid α → Sort*} (xs : FreeMonoid α) (one : motive 1)
+    (of_mul : ∀ x xs, motive xs → motive (of x * xs)) : motive xs := List.rec one of_mul xs
 
 @[to_additive (attr := simp)]
-theorem recOn_one {C : FreeMonoid α → Sort*} (h0 : C 1) (ih : ∀ x xs, C xs → C (of x * xs)) :
-    @recOn α C 1 h0 ih = h0 := rfl
+theorem recOn_one {motive : FreeMonoid α → Sort*} (one : motive 1)
+    (of_mul : ∀ x xs, motive xs → motive (of x * xs)) :
+    @recOn α motive 1 one of_mul = one := rfl
 
 @[to_additive (attr := simp)]
-theorem recOn_of_mul {C : FreeMonoid α → Sort*} (x : α) (xs : FreeMonoid α) (h0 : C 1)
-    (ih : ∀ x xs, C xs → C (of x * xs)) : @recOn α C (of x * xs) h0 ih = ih x xs (recOn xs h0 ih) :=
+theorem recOn_of_mul {motive : FreeMonoid α → Sort*} (x : α) (xs : FreeMonoid α) (one : motive 1)
+    (of_mul : ∀ x xs, motive xs → motive (of x * xs)) :
+    @recOn α motive (of x * xs) one of_mul = of_mul x xs (recOn xs one of_mul) :=
   rfl
 
 /-! ### Induction -/
@@ -251,18 +253,19 @@ section induction_principles
 /-- An induction principle on free monoids, with cases for `1`, `FreeMonoid.of` and `*`. -/
 @[to_additive (attr := elab_as_elim, induction_eliminator)
 /-- An induction principle on free monoids, with cases for `0`, `FreeAddMonoid.of` and `+`. -/]
-protected theorem inductionOn {C : FreeMonoid α → Prop} (z : FreeMonoid α) (one : C 1)
-    (of : ∀ (x : α), C (FreeMonoid.of x)) (mul : ∀ (x y : FreeMonoid α), C x → C y → C (x * y)) :
-    C z :=
-  List.rec one (fun _ _ ih => mul [_] _ (of _) ih) z
+protected theorem inductionOn {motive : FreeMonoid α → Prop} (z : FreeMonoid α) (one : motive 1)
+    (of : ∀ (x : α), motive (FreeMonoid.of x))
+    (mul : ∀ (x y : FreeMonoid α), motive x → motive y → motive (x * y)) :
+    motive z :=
+  recOn z one fun x xs ih => mul (.of x) xs (of x) ih
 
 /-- An induction principle for free monoids which mirrors induction on lists, with cases analogous
 to the empty list and cons -/
 @[to_additive (attr := elab_as_elim) /-- An induction principle for free monoids which mirrors
 induction on lists, with cases analogous to the empty list and cons -/]
-protected theorem inductionOn' {p : FreeMonoid α → Prop} (a : FreeMonoid α)
-    (one : p (1 : FreeMonoid α)) (mul_of : ∀ b a, p a → p (of b * a)) : p a :=
-  List.rec one (fun _ _ tail_ih => mul_of _ _ tail_ih) a
+protected theorem inductionOn' {motive : FreeMonoid α → Prop} (a : FreeMonoid α)
+    (one : motive (1 : FreeMonoid α)) (of_mul : ∀ b a, motive a → motive (of b * a)) : motive a :=
+  recOn a one of_mul
 
 end induction_principles
 
@@ -271,16 +274,18 @@ end induction_principles
 @[to_additive (attr := elab_as_elim, cases_eliminator)
   /-- A version of `List.casesOn` for `FreeAddMonoid` using `0` and
   `FreeAddMonoid.of x + xs` instead of `[]` and `x :: xs`. -/]
-def casesOn {C : FreeMonoid α → Sort*} (xs : FreeMonoid α) (h0 : C 1)
-    (ih : ∀ x xs, C (of x * xs)) : C xs := List.casesOn xs h0 ih
+def casesOn {motive : FreeMonoid α → Sort*} (xs : FreeMonoid α) (one : motive 1)
+    (of_mul : ∀ x xs, motive (of x * xs)) : motive xs := List.casesOn xs one of_mul
 
 @[to_additive (attr := simp)]
-theorem casesOn_one {C : FreeMonoid α → Sort*} (h0 : C 1) (ih : ∀ x xs, C (of x * xs)) :
-    @casesOn α C 1 h0 ih = h0 := rfl
+theorem casesOn_one {motive : FreeMonoid α → Sort*} (one : motive 1)
+    (of_mul : ∀ x xs, motive (of x * xs)) :
+    @casesOn α motive 1 one of_mul = one := rfl
 
 @[to_additive (attr := simp)]
-theorem casesOn_of_mul {C : FreeMonoid α → Sort*} (x : α) (xs : FreeMonoid α) (h0 : C 1)
-    (ih : ∀ x xs, C (of x * xs)) : @casesOn α C (of x * xs) h0 ih = ih x xs := rfl
+theorem casesOn_of_mul {motive : FreeMonoid α → Sort*} (x : α) (xs : FreeMonoid α) (one : motive 1)
+    (of_mul : ∀ x xs, motive (of x * xs)) :
+    @casesOn α motive (of x * xs) one of_mul = of_mul x xs := rfl
 
 @[to_additive (attr := ext)]
 theorem hom_eq ⦃f g : FreeMonoid α →* M⦄ (h : ∀ x, f (of x) = g (of x)) : f = g :=
@@ -427,7 +432,7 @@ theorem map_surjective {f : α → β} : Function.Surjective (map f) ↔ Functio
     | one =>
       have H := congr_arg length hb
       simp only [length_one, length_of, Nat.zero_ne_one, map_one] at H
-    | mul_of head _ _ =>
+    | of_mul head _ _ =>
       simp only [map_mul, map_of] at hb
       use head
       have H := congr_arg length hb
@@ -437,7 +442,7 @@ theorem map_surjective {f : α → β} : Function.Surjective (map f) ↔ Functio
   intro fs d
   induction d using FreeMonoid.inductionOn' with
   | one => use 1; rfl
-  | mul_of head tail ih =>
+  | of_mul head tail ih =>
     specialize fs head
     rcases fs with ⟨a, rfl⟩
     rcases ih with ⟨b, rfl⟩

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -277,7 +277,7 @@ theorem closure_induction_left
   obtain ⟨l, rfl⟩ := h
   induction l using FreeMonoid.inductionOn' with
   | one => exact one
-  | mul_of x y ih =>
+  | of_mul x y ih =>
     simp only [map_mul, FreeMonoid.lift_eval_of]
     refine mul_left _ x.prop (FreeMonoid.lift Subtype.val y) _ (ih ?_)
     simp only [closure_eq_mrange, mem_mrange, exists_apply_eq_apply]

--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -200,7 +200,7 @@ theorem induction_on' {C : M ∗ N → Prop} (m : M ∗ N)
   rcases mk_surjective m with ⟨x, rfl⟩
   induction x using FreeMonoid.inductionOn' with
   | one => exact one
-  | mul_of x xs ih =>
+  | of_mul x xs ih =>
     cases x with
     | inl m => simpa using inl_mul m _ ih
     | inr n => simpa using inr_mul n _ ih
@@ -581,7 +581,7 @@ theorem con_inv_mul_cancel (x : FreeMonoid (G ⊕ H)) :
   rw [← mk_eq_mk, map_mul, map_one]
   induction x using FreeMonoid.inductionOn' with
   | one => simp
-  | mul_of x xs ihx =>
+  | of_mul x xs ihx =>
     simp only [toList_of_mul, map_cons, reverse_cons, ofList_append, map_mul, ofList_singleton]
     rwa [mul_assoc, ← mul_assoc (mk (of _)), mk_of_inv_mul, one_mul]
 

--- a/Mathlib/LinearAlgebra/PiTensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct/Basic.lean
@@ -301,7 +301,7 @@ lemma _root_.FreeAddMonoid.toPiTensorProduct (p : FreeAddMonoid (R × Π i, s i)
     List.sum (List.map (fun x ↦ x.1 • ⨂ₜ[R] i, x.2 i) p.toList) := by
   induction p using FreeAddMonoid.inductionOn' with
   | zero => rfl
-  | add_of b a ih =>
+  | of_add b a ih =>
     rw [FreeAddMonoid.toList_of_add, List.map_cons, List.sum_cons, ← ih, ← tprodCoeff_eq_smul_tprod]
     rfl
 


### PR DESCRIPTION
Fix the argument names of `FreeMonoid.recOn`, `FreeMonoid.inductionOn`, and `FreeMonoid.inductionOn'`. Name the motive `motive` and name the minor premises according to their contents.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
