### PR TITLE
feat(CountablyGenerated): add measurableSet_graph

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
@@ -455,14 +455,14 @@ theorem measurableSingletonClass_of_countablySeparated
 
 /-- A measurable function into a countably separated space has a measurable graph. -/
 @[measurability]
-theorem _root_.Measurable.measurableSet_graph {X Y : Type*}
-    [MeasurableSpace X]
-    [MeasurableSpace Y] [cs : MeasurableSpace.CountablySeparated Y]
-    {f : X → Y} (measf : Measurable f) :
-    MeasurableSet { (x, y) : X × Y | y = f x } := by
+theorem _root_.Measurable.measurableSet_graph
+    [MeasurableSpace α]
+    [MeasurableSpace β] [cs : CountablySeparated β]
+    {f : α → β} (measf : Measurable f) :
+    MeasurableSet { (x, y) : α × β | y = f x } := by
   let ⟨V, Vctbl, Vmeas, Vsep⟩ := cs.countably_separated
-  let A : Set (Set (X × Y)) := (fun v => { (x, y) : X × Y | x ∈ f ⁻¹' v ↔ y ∈ v }) '' V
-  have : { (x, y) : X × Y | y = f x } = ⋂₀ A := by
+  let A : Set (Set (α × β)) := (fun v => { (x, y) : α × β | x ∈ f ⁻¹' v ↔ y ∈ v }) '' V
+  have : { (x, y) : α × β | y = f x } = ⋂₀ A := by
     ext x
     have := Vsep (f x.1) (Set.mem_univ _) x.2 (Set.mem_univ _)
     simp [A]; grind

--- a/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
@@ -453,6 +453,25 @@ theorem measurableSingletonClass_of_countablySeparated
   rw [← finj.preimage_image {x}, image_singleton]
   exact fmeas <| MeasurableSet.singleton _
 
+/-- A measurable function into a countably separated space has a measurable graph. -/
+@[measurability]
+theorem _root_.Measurable.measurableSet_graph {X Y : Type*}
+    [MeasurableSpace X]
+    [MeasurableSpace Y] [cs : MeasurableSpace.CountablySeparated Y]
+    {f : X → Y} (measf : Measurable f) :
+    MeasurableSet { (x, y) : X × Y | y = f x } := by
+  let ⟨V, Vctbl, Vmeas, Vsep⟩ := cs.countably_separated
+  let A : Set (Set (X × Y)) := (fun v => { (x, y) : X × Y | x ∈ f ⁻¹' v ↔ y ∈ v }) '' V
+  have : { (x, y) : X × Y | y = f x } = ⋂₀ A := by
+    ext x
+    have := Vsep (f x.1) (Set.mem_univ _) x.2 (Set.mem_univ _)
+    simp [A]; grind
+  rw [this]
+  apply MeasurableSet.sInter (Vctbl.image _)
+  simp only [Set.mem_preimage, Set.mem_image, forall_exists_index, and_imp,
+    forall_apply_eq_imp_iff₂, measurableSet_setOfPred]
+  fun_prop (disch := measurability)
+
 end SeparatesPoints
 
 section MeasurableMemPartition

--- a/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
@@ -472,6 +472,9 @@ theorem _root_.Measurable.measurableSet_graph
     forall_apply_eq_imp_iff₂, measurableSet_setOfPred]
   fun_prop (disch := measurability)
 
+instance [MeasurableSpace β] [CountablySeparated β] : MeasurableEq β :=
+⟨measurable_swap measurable_id.measurableSet_graph⟩
+
 end SeparatesPoints
 
 section MeasurableMemPartition

--- a/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
@@ -459,10 +459,10 @@ theorem _root_.Measurable.measurableSet_graph
     [MeasurableSpace α]
     [MeasurableSpace β] [cs : CountablySeparated β]
     {f : α → β} (measf : Measurable f) :
-    MeasurableSet { (x, y) : α × β | y = f x } := by
+    MeasurableSet { p : α × β | p.2 = f p.1 } := by
   let ⟨V, Vctbl, Vmeas, Vsep⟩ := cs.countably_separated
-  let A : Set (Set (α × β)) := (fun v => { (x, y) : α × β | x ∈ f ⁻¹' v ↔ y ∈ v }) '' V
-  have : { (x, y) : α × β | y = f x } = ⋂₀ A := by
+  let A : Set (Set (α × β)) := (fun v => { p : α × β | p.1 ∈ f ⁻¹' v ↔ p.2 ∈ v }) '' V
+  have : { p : α × β | p.2 = f p.1 } = ⋂₀ A := by
     ext x
     have := Vsep (f x.1) (Set.mem_univ _) x.2 (Set.mem_univ _)
     simp [A]; grind

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
@@ -503,10 +503,16 @@ theorem measurableSet_region_between_cc (hf : Measurable f) (hg : Measurable g)
         (measurableSet_le measurable_snd (hg.comp measurable_fst)))
   exact measurable_fst hs
 
-/-- The graph of a measurable function is a measurable set. -/
-theorem measurableSet_graph (hf : Measurable f) :
+/-- The graph of a measurable function into ℝ is a measurable set. -/
+theorem measurableSet_graph_real (hf : Measurable f) :
     MeasurableSet { p : α × ℝ | p.snd = f p.fst } := by
   simpa using measurableSet_region_between_cc hf hf MeasurableSet.univ
+
+@[deprecated measurableSet_graph_real "See also Measurable.measurableSet_graph."
+  (since := "2026-07-19")]
+theorem measurableSet_graph (hf : Measurable f) :
+    MeasurableSet { p : α × ℝ | p.snd = f p.fst } :=
+  measurableSet_graph_real hf
 
 theorem volume_regionBetween_eq_lintegral' (hf : Measurable f) (hg : Measurable g)
     (hs : MeasurableSet s) :

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
@@ -510,9 +510,7 @@ theorem measurableSet_graph_real (hf : Measurable f) :
 
 @[deprecated measurableSet_graph_real "See also Measurable.measurableSet_graph."
   (since := "2026-07-19")]
-theorem measurableSet_graph (hf : Measurable f) :
-    MeasurableSet { p : α × ℝ | p.snd = f p.fst } :=
-  measurableSet_graph_real hf
+alias measurableSet_graph := measurableSet_graph_real
 
 theorem volume_regionBetween_eq_lintegral' (hf : Measurable f) (hg : Measurable g)
     (hs : MeasurableSet s) :


### PR DESCRIPTION
This PR proves that the graph of a measurable function into a countably separated space is measurable. It also renames the currently proven special case `measurableSet_graph` to `measurableSet_graph_real`, deprecating the current name.

Supported by NSF grant DMS 2425401.

Co-authored-by: Wojciech Nawrocki <wjn@lean-fro.org>

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
