### PR TITLE
feat(SetTheory/Descriptive/Tree): add infinite branches and bodies

### DIFF
--- a/Mathlib/SetTheory/Descriptive/Tree.lean
+++ b/Mathlib/SetTheory/Descriptive/Tree.lean
@@ -5,17 +5,21 @@ Authors: Sven Manthe
 -/
 module
 
+public import Mathlib.Data.List.OfFn
 public import Mathlib.Order.CompleteLattice.SetLike
 
 /-!
 # Trees in the sense of descriptive set theory
 
 This file defines trees of depth `ω` in the sense of descriptive set theory as sets of finite
-sequences that are stable under taking prefixes.
+sequences that are stable under taking prefixes, together with their infinite branches and bodies.
 
 ## Main declarations
 
 * `tree A`: a (possibly infinite) tree of depth at most `ω` with nodes in `A`
+* `Tree.initialSegment`: the finite initial segment of an infinite sequence
+* `Tree.IsBranch`: the predicate that a sequence is an infinite branch through a tree
+* `Tree.body`: the set of infinite branches through a tree
 -/
 
 @[expose] public section
@@ -67,6 +71,43 @@ lemma take_mem {n : ℕ} (x : T) : x.val.take n ∈ T :=
 
 @[simp] lemma take_eq_take {x : T} {m n : ℕ} :
     take m x = take n x ↔ m ⊓ x.val.length = n ⊓ x.val.length := by simp [Subtype.ext_iff]
+
+-- ### Infinite branches
+
+/-- The list of the first `n` values of an infinite sequence. -/
+def initialSegment (x : ℕ → A) (n : ℕ) : List A :=
+  List.ofFn fun i : Fin n ↦ x i
+
+@[simp] lemma initialSegment_zero (x : ℕ → A) : initialSegment x 0 = [] := by
+  rfl
+
+@[simp] lemma length_initialSegment (x : ℕ → A) (n : ℕ) : (initialSegment x n).length = n := by
+  simp [initialSegment]
+
+/-- Passing from length `n` to length `n + 1` appends the next coordinate. -/
+lemma initialSegment_succ (x : ℕ → A) (n : ℕ) :
+    initialSegment x (n + 1) = initialSegment x n ++ [x n] := by
+  simpa [initialSegment] using List.ofFn_succ' (fun i : Fin (n + 1) ↦ x i)
+
+/-- An infinite sequence is a branch when every finite initial segment belongs to the tree. -/
+def IsBranch (T : tree A) (x : ℕ → A) : Prop :=
+  ∀ n, initialSegment x n ∈ T
+
+/-- The body of a tree is the set of all its infinite branches. -/
+def body (T : tree A) : Set (ℕ → A) :=
+  {x | IsBranch T x}
+
+@[simp] lemma mem_body {x : ℕ → A} : x ∈ body T ↔ ∀ n, initialSegment x n ∈ T :=
+  Iff.rfl
+
+/-- A branch forces the root to belong to the tree. -/
+lemma nil_mem_of_isBranch {x : ℕ → A} (hx : IsBranch T x) : [] ∈ T := by
+  simpa using hx 0
+
+/-- Inclusion of trees induces inclusion of their bodies. -/
+@[gcongr] lemma body_mono (h : S ≤ T) : body S ⊆ body T := by
+  intro x hx n
+  exact h (hx n)
 
 -- ### `subAt`
 


### PR DESCRIPTION
Motivation

The existing `tree A` API models trees as prefix-closed sets of finite
lists, together with some basic node operations (`take`, `subAt`,
`pullSub`). It had no notion of an infinite branch through such a
tree. Infinite branches and their collection, the body of a tree, are
basic vocabulary in descriptive set theory (e.g. to state that a tree
is well-founded iff its body is empty, or to talk about closed subsets
of Baire space as bodies of trees), so this is a natural extension of
the file.

Changes

* `initialSegment x n` is the list of the first `n` values of an
  infinite sequence `x : ℕ → A`, with lemmas relating its length and
  its behaviour when passing from `n` to `n + 1`.
* `IsBranch T x` says that `x : ℕ → A` is an infinite branch of `T`:
  every finite initial segment of `x` lies in `T`.
* `body T` is the set of infinite branches of `T`, defined via
  `IsBranch`.
* The auxiliary lemmas `nil_mem_of_isBranch` (a branch forces the root
  `[]` to lie in `T`) and `body_mono` (`body` is monotone in the tree,
  tagged `@[gcongr]`) round out the basic API.

Scope

This PR intentionally does not add closedness of `body T` (which
would require `A` to carry the discrete topology, so that `body T` is
closed in the product topology on `ℕ → A`), well-foundedness of trees
(which needs well-founded relations and descending chains), or rank
(which needs ordinal-valued rank API). These are left for follow-up
PRs, since each pulls in its own dependencies and deserves separate
review.


Verification

* `lake build Mathlib.SetTheory.Descriptive.Tree`
* `lake exe lint-style Mathlib.SetTheory.Descriptive.Tree`
* `lake build Mathlib`

AI use

I used Codex to help select this item from the
backlog, adapt the definitions to the existing `tree A` API and to the
`Descriptive.Tree` namespace and current module system (e.g. adding
the `public import` for `Mathlib.Data.List.OfFn`), draft the
implementation, and run the three verification commands above. I
checked every definition and lemma statement against its intended
mathematical meaning, and went through each proof term individually,
unfolding `initialSegment`, `IsBranch`, and `body` to confirm the
`simp`/`simpa` calls actually close the resulting goals rather than
just trusting that they compiled.