### PR TITLE
feat: use requireModuleSystem in mathlib

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -63,6 +63,7 @@ package mathlib where
   platformIndependent := true
   -- Mathlib currently expects artifacts to be in the build directory.
   restoreAllArtifacts := true
+  requiresModuleSystem := true
   -- These are additional settings which do not affect the lake hash,
   -- so they can be enabled in CI and disabled locally or vice versa.
   -- Warning: Do not put any options here that actually change the olean files,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -87,6 +87,7 @@ lean_lib Cache where
 lean_lib MathlibTest where
   globs := #[`MathlibTest.+]
   leanOptions := mathlibTestOptions
+  allowNonModules := true
 
 lean_lib Archive where
   leanOptions := mathlibLeanOptions


### PR DESCRIPTION
This option causes a warning in any project depending on a version of mathlib containing this PR that does not use the module system. The warning can be turned off using the `allowNonModules` option in the downstream project. (We do so for `MathlibTest`, because some tests intentionally use non-modules.)

For clarity, this does not immediately cause any breakage: it is giving advance notice of potential changes in the future, and provides further encouragement to use the module system.

The module system in Lean has been available for over 6 months. Adopting it brings significant benefits (on e.g. the amount of required RAM, or more fine-grained rebuilding), so encouraging it seems useful. At also signals an intent for mathlib to require the use of the module system: future versions of Mathlib might drop support for certain features that require non-module-system libraries.

For example, the simpNF linter currently does not assume the module system is enabled, in the future it might assume that and stop working in libraries that do not use the module system.

This PR has been [announced on Zulip](https://leanprover.zulipchat.com/#narrow/channel/113486-General-announcements/topic/Mathlib.20requiring.20the.20use.20of.20the.20module.20system/with/623623560) before.

------

- [x] depends on: #42010
- [x] depends on: #42242

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
