### PR TITLE
[Merged by Bors] - feat: a linear map which is a local embedding is an embedding

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7656,6 +7656,7 @@ public import Mathlib.Topology.Algebra.Module.ContinuousLinearMap.Quotient
 public import Mathlib.Topology.Algebra.Module.ContinuousLinearMap.Restrict
 public import Mathlib.Topology.Algebra.Module.ContinuousLinearMap.RestrictScalars
 public import Mathlib.Topology.Algebra.Module.Determinant
+public import Mathlib.Topology.Algebra.Module.EmbeddingOfLocal
 public import Mathlib.Topology.Algebra.Module.Equiv
 public import Mathlib.Topology.Algebra.Module.FiniteDimension
 public import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear

--- a/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
+++ b/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
@@ -52,7 +52,7 @@ sets being connected.
 Nevertheless, we are able to adapt their arguments to arbitrary nontrivially normed fields.
 The key argument, replacing the fact that a connected set cannot be covered nontrivially by
 disjoint open sets, is that a balanced set `W` cannot intersect nontrivially both `c • V`
-and `Vᶜ`, when `V` is a neighborhood of `0` and `0 < ‖c‖ < 1`. We refer to the (highly commented !)
+and `Vᶜ`, when `V` is a neighborhood of `0` and `0 < ‖c‖ < 1`. We refer to the (highly commented!)
 proof for more precision.
 
 ## References
@@ -92,12 +92,10 @@ lemma ContinuousSMul.topology_eq_of_nhds_inf_principal_eq (t₁ t₂ : Topologic
   suffices V ∈ 𝓕₂ by simpa [H]
   -- Hence, let us show that `V ∈ 𝓕₂`. Fix a scalar `c` with `0 < ‖c‖ < 1`.
   obtain ⟨c, hc₀, hc₁⟩ := NormedField.exists_norm_lt_one 𝕜₁
-  have c_ne : c ≠ 0 := fun h ↦ by simp [h] at hc₀
+  have c_ne : c ≠ 0 := norm_pos_iff.mp hc₀ 
   -- We know that `c • V ∈ 𝓕₁ = 𝓕₂ ⊓ 𝓟 V`.
   have cV_mem : c • V ∈ 𝓕₂ ⊓ 𝓟 V := by
-    rw [← H]
-    let := t₁
-    simpa [𝓕₁, set_smul_mem_nhds_zero_iff c_ne]
+    simpa [← H, 𝓕₁, set_smul_mem_nhds_zero_iff c_ne]
   -- Furthermore, we know that `𝓕₂` has a basis of balanced sets
   have basis_𝓕₂ : HasBasis 𝓕₂ (fun (s : Set E) ↦ s ∈ 𝓕₂ ∧ Balanced 𝕜₁ s) id :=
     let := t₂; nhds_basis_balanced 𝕜₁ E
@@ -119,7 +117,7 @@ lemma ContinuousSMul.topology_eq_of_nhds_inf_principal_eq (t₁ t₂ : Topologic
   have k₀_spec : c ^ k₀ • w ∈ V := Nat.find_spec exists_scale
   -- Note that `1 ≤ k₀` since `w ∉ V`
   have k₀_pos : 0 < k₀ := pos_iff_ne_zero.mpr fun h ↦ by simp [h, w_notin_V] at k₀_spec
-  -- By definition, `c ^ k₀ • w ∈ V`, and becaus `W` is balanced `c ^ k₀ • w ∈ W`.
+  -- By definition, `c ^ k₀ • w ∈ V`, and because `W` is balanced `c ^ k₀ • w ∈ W`.
   -- Thus, `c ^ k₀ • w ∈ V ∩ W ⊆ c • V`.
   have : c ^ k₀ • w ∈ c • V :=
     hW ⟨W_bal.smul_mem (by simpa using pow_le_one₀ hc₀.le hc₁.le) w_in_W, k₀_spec⟩
@@ -144,7 +142,7 @@ lemma ContinuousSMul.topology_eq_of_induced_eq (t₁ t₂ : TopologicalSpace E)
   apply topology_eq_of_nhds_inf_principal_eq 𝕜₁ t₁ t₂ V_mem
   set o : V := ⟨0, letI := t₁; mem_of_mem_nhds V_mem⟩
   simp_rw [← map_comap_setCoe_val, show 0 = (o : E) from rfl, ← nhds_induced]
-  congr
+  rw [H]
 
 variable [TopologicalSpace E] [TopologicalSpace F]
   [IsTopologicalAddGroup E] [IsTopologicalAddGroup F]
@@ -161,7 +159,7 @@ lemma LinearMap.isInducing_of_restrict_nhds_zero {V : Set E}
 lemma LinearMap.isEmbedding_of_restrict_nhds_zero {V : Set E}
     (V_mem : V ∈ 𝓝 0) (H : IsEmbedding (Set.domRestrict V f)) : IsEmbedding f := by
   refine ⟨isInducing_of_restrict_nhds_zero V_mem H.isInducing, ?_⟩
-  have f_injOn : InjOn f V := by simpa [injOn_iff_injective] using H.injective
+  have f_injOn : InjOn f V := injOn_iff_injective.2 H.injective
   rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
   intro x hx
   obtain ⟨c, hc, c_ne : c ≠ 0⟩ := absorbent_nhds_zero (𝕜 := 𝕜₁) V_mem

--- a/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
+++ b/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
@@ -146,8 +146,12 @@ variable [TopologicalSpace E] [TopologicalSpace F]
 lemma LinearMap.isInducing_of_restrict_nhds_zero {V : Set E}
     (V_mem : V ∈ 𝓝 0) (H : IsInducing (Set.domRestrict V f)) : IsInducing f := by
   rw [isInducing_iff]
+  -- Call `t₁` the original topology on `E`, and `t₂` the topology induced by `f`. Because
+  -- `f` is linear, `t₂` is also a vector space topology.
   have := topologicalAddGroup_induced f
   have := continuousSMul_inducedₛₗ f σ.isometry.continuous
+  -- Because `Set.domRestrict V f` is an inducing, `t₁` and `t₂` induce the same topology
+  -- on `V`, so we get `t₁ = t₂` from the lemmas above.
   apply ContinuousSMul.topology_eq_of_induced_eq 𝕜₁ _ (.induced f _) V_mem
   rw [induced_compose, ← domRestrict_eq, ← H.eq_induced, ← IsInducing.subtypeVal.eq_induced]
 

--- a/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
+++ b/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
@@ -92,7 +92,7 @@ lemma ContinuousSMul.topology_eq_of_nhds_inf_principal_eq (t₁ t₂ : Topologic
   suffices V ∈ 𝓕₂ by simpa [H]
   -- Hence, let us show that `V ∈ 𝓕₂`. Fix a scalar `c` with `0 < ‖c‖ < 1`.
   obtain ⟨c, hc₀, hc₁⟩ := NormedField.exists_norm_lt_one 𝕜₁
-  have c_ne : c ≠ 0 := norm_pos_iff.mp hc₀ 
+  have c_ne : c ≠ 0 := norm_pos_iff.mp hc₀
   -- We know that `c • V ∈ 𝓕₁ = 𝓕₂ ⊓ 𝓟 V`.
   have cV_mem : c • V ∈ 𝓕₂ ⊓ 𝓟 V := by
     simpa [← H, 𝓕₁, set_smul_mem_nhds_zero_iff c_ne]
@@ -108,10 +108,10 @@ lemma ContinuousSMul.topology_eq_of_nhds_inf_principal_eq (t₁ t₂ : Topologic
   by_contra! w_notin_V
   -- Now, because `V` is absorbent, there exists a natural `k` such that `c ^ k • w ∈ V`.
   have exists_scale : ∃ k : ℕ, c ^ k • w ∈ V := by
-    have V_abs : Absorbent 𝕜₁ V := let := t₁; absorbent_nhds_zero V_mem
-    have : Tendsto (fun k : ℕ ↦ c ^ k) atTop (𝓝[≠] 0) := by
-      simp [tendsto_nhdsWithin_iff, c_ne, tendsto_pow_atTop_nhds_zero_iff_norm_lt_one, hc₁]
-    exact this.eventually (V_abs.eventually_nhdsNE_zero w) |>.exists
+    let := t₁
+    have : Tendsto (fun k : ℕ ↦ c ^ k • w) atTop (𝓝 0) :=
+      zero_smul 𝕜₁ w ▸ (tendsto_pow_atTop_nhds_zero_of_norm_lt_one hc₁).smul_const w
+    exact this.eventually_mem V_mem |>.exists
   -- Denote by `k₀` the *smallest* such `k`.
   set k₀ := Nat.find exists_scale
   have k₀_spec : c ^ k₀ • w ∈ V := Nat.find_spec exists_scale

--- a/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
+++ b/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
@@ -86,7 +86,7 @@ lemma ContinuousSMul.topology_eq_of_nhds_inf_principal_eq (t₁ t₂ : Topologic
   set 𝓕₂ := @nhds E t₂ 0
   -- Note that, because `V ∈ 𝓕₁`, `H` may be rewritten as `𝓕₁ = 𝓕₂ ⊓ 𝓟 V`.
   replace H : 𝓕₁ = 𝓕₂ ⊓ 𝓟 V := by simpa [← H]
-  -- Because both `t₁` and `t₂` are additive group topologies, we have to show `𝓕₁ = 𝓕₂`.
+  -- Because both `t₁` and `t₂` are additive group topologies, it is enough to show `𝓕₁ = 𝓕₂`.
   suffices 𝓕₁ = 𝓕₂ by rwa [IsTopologicalAddGroup.ext_iff] <;> infer_instance
   -- If we can show that `V ∈ 𝓕₂` we are done, because then `𝓕₁ = 𝓕₂ ⊓ 𝓟 V = 𝓕₂`.
   suffices V ∈ 𝓕₂ by simpa [H]

--- a/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
+++ b/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
@@ -53,7 +53,7 @@ Nevertheless, we are able to adapt their proof to arbitrary nontrivially normed 
 The key argument, replacing the fact that a connected set cannot be covered nontrivially by
 disjoint open sets, is that a balanced set `W` cannot intersect nontrivially both `c • V`
 and `Vᶜ`, when `V` is a neighborhood of `0` and `0 < ‖c‖ < 1`. We refer to the (highly commented!)
-proof for more precision.
+proof for more details.
 
 ## References
 

--- a/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
+++ b/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
@@ -111,20 +111,16 @@ lemma ContinuousSMul.topology_eq_of_nhds_inf_principal_eq (t₁ t₂ : Topologic
     have : Tendsto (fun k : ℕ ↦ c ^ k • w) atTop (𝓝 0) :=
       zero_smul 𝕜₁ w ▸ (tendsto_pow_atTop_nhds_zero_of_norm_lt_one hc₁).smul_const w
     exact this.eventually_mem V_mem |>.exists
-  -- Observe that the inclusion `W ∩ V ⊆ c • V` has the following consequence:
-  -- for any `x ∈ W`, if `c • x ∈ V`, then because `W` is balanced
-  -- we have `c • x ∈ W ∩ V ⊆ c • V`, hence in fact `x ∈ V`.
-  replace key : ∀ x ∈ W, c • x ∈ V → x ∈ V := fun x x_in_W cx_in_V ↦
-    smul_mem_smul_set_iff₀ c_ne V x |>.mp <| hW ⟨W_bal.smul_mem hc₁.le x_in_W, cx_in_V⟩
-  -- Using this observation repeatedly on `c ^ n • w ∈ W`, which is legal because `c ^ k • w ∈ W`
-  -- for every `k : ℕ`, we obtain that in fact `c ^ 0 • w ∈ V`.
-  have : c ^ 0 • w ∈ V := by
-    apply Nat.decreasingInduction (motive := fun (k : ℕ) _ ↦ c^k • w ∈ V) ?_ hn n.zero_le
-    intro k _
-    rw [pow_add, pow_one, mul_comm, mul_smul]
-    exact key _ <| W_bal.smul_mem (by grw [norm_pow, hc₁.le, one_pow]) w_in_W
-  -- Hence `w ∈ V` as we claimed.
-  simpa using this
+  -- We will conclude by reducing `c ^ n • w ∈ V` to `w = c ^ 0 • w ∈ V` inductively.
+  suffices c ^ 0 • w ∈ V by simpa
+  apply Nat.decreasingInduction (motive := fun (k : ℕ) _ ↦ c^k • w ∈ V) ?_ hn n.zero_le
+  -- To do so, we show that if `k : ℕ` is such that `c ^ (k + 1) • w ∈ V` then `c ^ k • w ∈ V`.
+  intro k _ (hk : c ^ (k + 1) • w ∈ V)
+  -- Indeed, because `W` is balanced, we have `c ^ (k + 1) • w ∈ W ∩ V ⊆ c • V`
+  have : c ^ (k + 1) • w ∈ c • V :=
+    hW ⟨W_bal.smul_mem (by grw [norm_pow, hc₁.le, one_pow]) w_in_W, hk⟩
+  -- Cancelling `c`, we get `c ^ k • w ∈ V` as we claimed.
+  rwa [pow_add, pow_one, mul_comm, mul_smul, smul_mem_smul_set_iff₀ c_ne V] at this
 
 variable (𝕜₁) in
 /-- Consider a vector space `E` over a `NontriviallyNormedField` `𝕜`, and `t₁`, `t₂` two topologies

--- a/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
+++ b/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
@@ -70,8 +70,8 @@ variable {𝕜₁ 𝕜₂ E F : Type*} [NontriviallyNormedField 𝕜₁] [Nontri
   [AddCommGroup E] [AddCommGroup F] [Module 𝕜₁ E] [Module 𝕜₂ F] {σ : 𝕜₁ →+* 𝕜₂} {f : E →ₛₗ[σ] F}
 
 variable (𝕜₁) in
-/-- Consider a vector space `E` over a `NontriviallyNormedField` `𝕜`, and `t₁`, `t₂` two topologies
-on `E` which are compatible with the vector space structure.
+/-- Consider a vector space `E` over a `NontriviallyNormedField` `𝕜`, and `t₁`, `t₂` two
+vector space topologies on `E`.
 
 Assume that there is a `t₁`-neighborhood of zero `V` such that the two topogies induce the
 same filter of neighborhoods of `0` *in the subspace `V`*. Then `t₁ = t₂`. -/
@@ -103,29 +103,28 @@ lemma ContinuousSMul.topology_eq_of_nhds_inf_principal_eq (t₁ t₂ : Topologic
   obtain ⟨W, ⟨W_mem_𝓕₂, W_bal⟩, hW⟩ := basis_𝓕₂.inf_principal V |>.mem_iff.mp cV_mem
   -- We claim that `W ⊆ V`. This will conclude the proof, since `W ∈ 𝓕₂`.
   suffices W ⊆ V from mem_of_superset W_mem_𝓕₂ this
-  -- By contradiction, assume that we have a point `w ∈ W \ V`
+  -- Let `w ∈ W` be arbitrary.
   intro w w_in_W
-  by_contra! w_notin_V
-  -- Now, because `V` is absorbent, there exists a natural `k` such that `c ^ k • w ∈ V`.
-  have exists_scale : ∃ k : ℕ, c ^ k • w ∈ V := by
+  -- Because `V` is a `t₁`-neighborhood of `0`, we have `c ^ n • w ∈ V` for some natural number `n`.
+  obtain ⟨n, hn⟩ : ∃ n : ℕ, c ^ n • w ∈ V := by
     let := t₁
     have : Tendsto (fun k : ℕ ↦ c ^ k • w) atTop (𝓝 0) :=
       zero_smul 𝕜₁ w ▸ (tendsto_pow_atTop_nhds_zero_of_norm_lt_one hc₁).smul_const w
     exact this.eventually_mem V_mem |>.exists
-  -- Denote by `k₀` the *smallest* such `k`.
-  set k₀ := Nat.find exists_scale
-  have k₀_spec : c ^ k₀ • w ∈ V := Nat.find_spec exists_scale
-  -- Note that `1 ≤ k₀` since `w ∉ V`
-  have k₀_pos : 0 < k₀ := pos_iff_ne_zero.mpr fun h ↦ by simp [h, w_notin_V] at k₀_spec
-  -- By definition, `c ^ k₀ • w ∈ V`, and because `W` is balanced `c ^ k₀ • w ∈ W`.
-  -- Thus, `c ^ k₀ • w ∈ V ∩ W ⊆ c • V`.
-  have : c ^ k₀ • w ∈ c • V :=
-    hW ⟨W_bal.smul_mem (by simpa using pow_le_one₀ hc₀.le hc₁.le) w_in_W, k₀_spec⟩
-  -- But then, we have `c ^ (k₀ - 1) • w ∈ V`.
-  have : c ^ (k₀ - 1) • w ∈ V := by
-    rwa [pow_sub₀ c c_ne k₀_pos, pow_one, mul_comm, mul_smul, ← mem_smul_set_iff_inv_smul_mem₀ c_ne]
-  -- This contradicts the minimality of `k₀`.
-  exact Nat.find_min exists_scale (tsub_lt_self k₀_pos one_pos) this
+  -- Observe that the inclusion `W ∩ V ⊆ c • V` has the following consequence:
+  -- for any `x ∈ W`, if `c • x ∈ V`, then because `W` is balanced
+  -- we have `c • x ∈ W ∩ V ⊆ c • V`, hence in fact `x ∈ V`.
+  replace key : ∀ x ∈ W, c • x ∈ V → x ∈ V := fun x x_in_W cx_in_V ↦
+    smul_mem_smul_set_iff₀ c_ne V x |>.mp <| hW ⟨W_bal.smul_mem hc₁.le x_in_W, cx_in_V⟩
+  -- Using this observation repeatedly on `c ^ n • w ∈ W`, which is legal because `c ^ k • w ∈ W`
+  -- for every `k : ℕ`, we obtain that in fact `c ^ 0 • w ∈ V`.
+  have : c ^ 0 • w ∈ V := by
+    apply Nat.decreasingInduction (motive := fun (k : ℕ) _ ↦ c^k • w ∈ V) ?_ hn n.zero_le
+    intro k _
+    rw [pow_add, pow_one, mul_comm, mul_smul]
+    exact key _ <| W_bal.smul_mem (by grw [norm_pow, hc₁.le, one_pow]) w_in_W
+  -- Hence `w ∈ V` as we claimed.
+  simpa using this
 
 variable (𝕜₁) in
 /-- Consider a vector space `E` over a `NontriviallyNormedField` `𝕜`, and `t₁`, `t₂` two topologies

--- a/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
+++ b/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
@@ -92,7 +92,7 @@ lemma ContinuousSMul.topology_eq_of_nhds_inf_principal_eq (t₁ t₂ : Topologic
   suffices V ∈ 𝓕₂ by simpa [H]
   -- Hence, let us show that `V ∈ 𝓕₂`. Fix a scalar `c` with `0 < ‖c‖ < 1`.
   obtain ⟨c, hc₀, hc₁⟩ := NormedField.exists_norm_lt_one 𝕜₁
-  have c_ne : c ≠ 0 := norm_pos_iff.mp hc₀ 
+  have c_ne : c ≠ 0 := norm_pos_iff.mp hc₀
   -- We know that `c • V ∈ 𝓕₁ = 𝓕₂ ⊓ 𝓟 V`.
   have cV_mem : c • V ∈ 𝓕₂ ⊓ 𝓟 V := by
     simpa [← H, 𝓕₁, set_smul_mem_nhds_zero_iff c_ne]

--- a/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
+++ b/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 Anatole Dedecker. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anatole Dedecker
+-/
+module
+
+public import Mathlib.Analysis.LocallyConvex.BalancedCoreHull
+public import Mathlib.Analysis.SpecificLimits.Normed
+
+/-!
+# A linear map which is locally an embedding is an embedding
+
+Fix `𝕜` a `NontriviallyNormedField`, `E`, `F` two topological vector spaces over `𝕜`, and
+`f : E → F` a `𝕜`-linear map. We show that, if there is a neighborhood `V` of `0 : E`
+such that the restriction `V → F` is an embedding, then `f` itself is an embedding.
+
+Note that this result is false for topological groups, as shown by the following counterexamples:
+* first, in the group setting, there are local embeddings (even local homeomorphisms) which
+  are not globally injective; an example is the quotient map `ℝ → 𝕋 := ℝ ⧸ ℤ`;
+* even if assume that `f` is globally injective, the theorem still fails. Consider for example
+  `f : ℝ → 𝕋 × 𝕋` given by `x ↦ ([x], [α * x])`, with `α` irrational. `f` is injective, and locally
+  an embedding by the inverse function theorem, yet it is not globally an embedding: any
+  neighborhood of `f(0) = (0, 0)` contains infinitely many points `f(n)`, `n ∈ ℤ`, since
+  `α * n` gets arbitrarily close to being an integer infinitely many times.
+
+## Main results
+
+* `ContinuousSMul.topology_eq_of_induced_eq`: let `t₁`, `t₂` be two vector space
+  topologies on `E`, and assume that there is a `t₁`-neighborhood of 0 `V` in restriction to
+  which the two topologies coincide. Then `t₁ = t₂`.
+* `LinearMap.isInducing_of_restrict_nhds_zero`: consider a linear map `f : E → F`, and assume
+  there is a neighborhood of 0 `V` in `E` such that `V.domRestrict f : V → F` satisfies
+  `Topology.IsInducing`. Then `f` satisfies `Topology.IsInducing`.
+* `LinearMap.isEmbedding_of_restrict_nhds_zero`: consider a linear map `f : E → F`, and assume
+  there is a neighborhood of 0 `V` in `E` such that `V.domRestrict f : V → F` is a topological
+  embedding. Then `f` is a topological embedding.
+
+## TODO
+
+We will also need the fact that if the restriction `V → F` is a *closed* embedding, then
+`f : E → F` is a *closed* embedding. This will follow from the fact that a subgroup which is
+locally closed at `0` is in fact closed, which we don't have yet
+
+## Implementation details
+
+The content of this file is essentially (variations of)
+[N. Bourbaki, *Théories Spectrales*, Chapitre III, § 5, n° 1, lemme 1][bourbaki2023], except
+Bourbaki's proof is very specific to `𝕜 = ℝ` or `𝕜 = ℂ`, since it relies crucially on balanced
+sets being connected.
+
+Nevertheless, we are able to adapt their arguments to arbitrary nontrivially normed fields.
+The key argument, replacing the fact that a connected set cannot be covered nontrivially by
+disjoint open sets, is that a balanced set `W` cannot intersect nontrivially both `c • V`
+and `Vᶜ`, when `V` is a neighborhood of `0` and `0 < ‖c‖ < 1`. We refer to the (highly commented !)
+proof for more precision.
+
+## References
+
+* [N. Bourbaki, *Théories Spectrales*, Chapitre III, § 5, n° 1, lemme 1][bourbaki2023]
+
+-/
+
+@[expose] public section
+
+open Topology Filter Bornology Set
+open scoped Pointwise Set.Notation
+
+variable {𝕜₁ 𝕜₂ E F : Type*} [NontriviallyNormedField 𝕜₁] [NontriviallyNormedField 𝕜₂]
+  [AddCommGroup E] [AddCommGroup F] [Module 𝕜₁ E] [Module 𝕜₂ F] {σ : 𝕜₁ →+* 𝕜₂} {f : E →ₛₗ[σ] F}
+
+variable (𝕜₁) in
+/-- Consider a vector space `E` over a `NontriviallyNormedField` `𝕜`, and `t₁`, `t₂` two topologies
+on `E` which are compatible with the vector space structure.
+
+Assume that there is a `t₁`-neighborhood of zero `V` such that the two topogies induce the
+same filter of neighborhoods of `0` *in the subspace `V`*. Then `t₁ = t₂`. -/
+lemma ContinuousSMul.topology_eq_of_nhds_inf_principal_eq (t₁ t₂ : TopologicalSpace E)
+    [@IsTopologicalAddGroup E t₁ _] [@IsTopologicalAddGroup E t₂ _]
+    [@ContinuousSMul 𝕜₁ E _ _ t₁] [@ContinuousSMul 𝕜₁ E _ _ t₂]
+    {V : Set E} (V_mem : V ∈ @nhds E t₁ 0) (H : @nhds E t₁ 0 ⊓ 𝓟 V = @nhds E t₂ 0 ⊓ 𝓟 V) :
+    t₁ = t₂ := by
+  classical
+  -- For `i = 1, 2`, denote by `𝓕ᵢ` the filter of neighborhoods of `0` for the topology `tᵢ`.
+  set 𝓕₁ := @nhds E t₁ 0
+  set 𝓕₂ := @nhds E t₂ 0
+  -- Note that, because `V ∈ 𝓕₁`, `H` may be rewritten as `𝓕₁ = 𝓕₂ ⊓ 𝓟 V`.
+  replace H : 𝓕₁ = 𝓕₂ ⊓ 𝓟 V := by simpa [← H]
+  -- Because both `t₁` and `t₂` are additive group topologies, we have to show `𝓕₁ = 𝓕₂`.
+  suffices 𝓕₁ = 𝓕₂ by rwa [IsTopologicalAddGroup.ext_iff] <;> infer_instance
+  -- If we can show that `V ∈ 𝓕₂` we are done, because then `𝓕₁ = 𝓕₂ ⊓ 𝓟 V = 𝓕₂`.
+  suffices V ∈ 𝓕₂ by simpa [H]
+  -- Hence, let us show that `V ∈ 𝓕₂`. Fix a scalar `c` with `0 < ‖c‖ < 1`.
+  obtain ⟨c, hc₀, hc₁⟩ := NormedField.exists_norm_lt_one 𝕜₁
+  have c_ne : c ≠ 0 := fun h ↦ by simp [h] at hc₀
+  -- We know that `c • V ∈ 𝓕₁ = 𝓕₂ ⊓ 𝓟 V`.
+  have cV_mem : c • V ∈ 𝓕₂ ⊓ 𝓟 V := by
+    rw [← H]
+    let := t₁
+    simpa [𝓕₁, set_smul_mem_nhds_zero_iff c_ne]
+  -- Furthermore, we know that `𝓕₂` has a basis of balanced sets
+  have basis_𝓕₂ : HasBasis 𝓕₂ (fun (s : Set E) ↦ s ∈ 𝓕₂ ∧ Balanced 𝕜₁ s) id :=
+    let := t₂; nhds_basis_balanced 𝕜₁ E
+  -- Hence, we get a balanced set `W ∈ 𝓕₂` such that `W ∩ V ⊆ c • V`.
+  obtain ⟨W, ⟨W_mem_𝓕₂, W_bal⟩, hW⟩ := basis_𝓕₂.inf_principal V |>.mem_iff.mp cV_mem
+  -- We claim that `W ⊆ V`. This will conclude the proof, since `W ∈ 𝓕₂`.
+  suffices W ⊆ V from mem_of_superset W_mem_𝓕₂ this
+  -- By contradiction, assume that we have a point `w ∈ W \ V`
+  intro w w_in_W
+  by_contra! w_notin_V
+  -- Now, because `V` is absorbent, there exists a natural `k` such that `c ^ k • w ∈ V`.
+  have exists_scale : ∃ k : ℕ, c ^ k • w ∈ V := by
+    have V_abs : Absorbent 𝕜₁ V := let := t₁; absorbent_nhds_zero V_mem
+    have : Tendsto (fun k : ℕ ↦ c ^ k) atTop (𝓝[≠] 0) := by
+      simp [tendsto_nhdsWithin_iff, c_ne, tendsto_pow_atTop_nhds_zero_iff_norm_lt_one, hc₁]
+    exact this.eventually (V_abs.eventually_nhdsNE_zero w) |>.exists
+  -- Denote by `k₀` the *smallest* such `k`.
+  set k₀ := Nat.find exists_scale
+  have k₀_spec : c ^ k₀ • w ∈ V := Nat.find_spec exists_scale
+  -- Note that `1 ≤ k₀` since `w ∉ V`
+  have k₀_pos : 0 < k₀ := pos_iff_ne_zero.mpr fun h ↦ by simp [h, w_notin_V] at k₀_spec
+  -- By definition, `c ^ k₀ • w ∈ V`, and becaus `W` is balanced `c ^ k₀ • w ∈ W`.
+  -- Thus, `c ^ k₀ • w ∈ V ∩ W ⊆ c • V`.
+  have : c ^ k₀ • w ∈ c • V :=
+    hW ⟨W_bal.smul_mem (by simpa using pow_le_one₀ hc₀.le hc₁.le) w_in_W, k₀_spec⟩
+  -- But then, we have `c ^ (k₀ - 1) • w ∈ V`.
+  have : c ^ (k₀ - 1) • w ∈ V := by
+    rwa [pow_sub₀ c c_ne k₀_pos, pow_one, mul_comm, mul_smul, ← mem_smul_set_iff_inv_smul_mem₀ c_ne]
+  -- This contradicts the minimality of `k₀`.
+  exact Nat.find_min exists_scale (tsub_lt_self k₀_pos one_pos) this
+
+variable (𝕜₁) in
+/-- Consider a vector space `E` over a `NontriviallyNormedField` `𝕜`, and `t₁`, `t₂` two topologies
+on `E` which are compatible with the vector space structure.
+
+Assume that there is a `t₁`-neighborhood of zero `V` such that the two topogies induce the
+same topology *on the subspace `V`*. Then `t₁ = t₂`. -/
+lemma ContinuousSMul.topology_eq_of_induced_eq (t₁ t₂ : TopologicalSpace E)
+    [@IsTopologicalAddGroup E t₁ _] [@IsTopologicalAddGroup E t₂ _]
+    [@ContinuousSMul 𝕜₁ E _ _ t₁] [@ContinuousSMul 𝕜₁ E _ _ t₂]
+    {V : Set E} (V_mem : V ∈ @nhds E t₁ 0)
+    (H : t₁.induced ((↑) : V → E) = t₂.induced ((↑) : V → E)) :
+    t₁ = t₂ := by
+  apply topology_eq_of_nhds_inf_principal_eq 𝕜₁ t₁ t₂ V_mem
+  set o : V := ⟨0, letI := t₁; mem_of_mem_nhds V_mem⟩
+  simp_rw [← map_comap_setCoe_val, show 0 = (o : E) from rfl, ← nhds_induced]
+  congr
+
+variable [TopologicalSpace E] [TopologicalSpace F]
+  [IsTopologicalAddGroup E] [IsTopologicalAddGroup F]
+  [ContinuousSMul 𝕜₁ E] [ContinuousSMul 𝕜₂ F] [RingHomIsometric σ]
+
+lemma LinearMap.isInducing_of_restrict_nhds_zero {V : Set E}
+    (V_mem : V ∈ 𝓝 0) (H : IsInducing (Set.domRestrict V f)) : IsInducing f := by
+  rw [isInducing_iff]
+  have := topologicalAddGroup_induced f
+  have := continuousSMul_inducedₛₗ f σ.isometry.continuous
+  apply ContinuousSMul.topology_eq_of_induced_eq 𝕜₁ _ (.induced f _) V_mem
+  rw [induced_compose, ← domRestrict_eq, ← H.eq_induced, ← IsInducing.subtypeVal.eq_induced]
+
+lemma LinearMap.isEmbedding_of_restrict_nhds_zero {V : Set E}
+    (V_mem : V ∈ 𝓝 0) (H : IsEmbedding (Set.domRestrict V f)) : IsEmbedding f := by
+  refine ⟨isInducing_of_restrict_nhds_zero V_mem H.isInducing, ?_⟩
+  have f_injOn : InjOn f V := by simpa [injOn_iff_injective] using H.injective
+  rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
+  intro x hx
+  obtain ⟨c, hc, c_ne : c ≠ 0⟩ := absorbent_nhds_zero (𝕜 := 𝕜₁) V_mem
+    |>.eventually_nhdsNE_zero x |>.and eventually_mem_nhdsWithin |>.exists
+  rw [← smul_eq_zero_iff_right c_ne, ← f_injOn.eq_iff hc (mem_of_mem_nhds V_mem), map_zero,
+    map_smulₛₗ, hx, smul_zero]

--- a/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
+++ b/Mathlib/Topology/Algebra/Module/EmbeddingOfLocal.lean
@@ -49,7 +49,7 @@ The content of this file is essentially (variations of)
 Bourbaki's proof is very specific to `𝕜 = ℝ` or `𝕜 = ℂ`, since it relies crucially on balanced
 sets being connected.
 
-Nevertheless, we are able to adapt their arguments to arbitrary nontrivially normed fields.
+Nevertheless, we are able to adapt their proof to arbitrary nontrivially normed fields.
 The key argument, replacing the fact that a connected set cannot be covered nontrivially by
 disjoint open sets, is that a balanced set `W` cannot intersect nontrivially both `c • V`
 and `Vᶜ`, when `V` is a neighborhood of `0` and `0 < ‖c‖ < 1`. We refer to the (highly commented!)


### PR DESCRIPTION
This is a nice intermediate result that will ultimately be used to show that Fredholm operators are stable under compact perturbation.

Note that Bourbaki gives a proof which is very specific to R and C. After writing down multiple completely different proofs for the general result over the last few days, I eventually realised that their proof could just be tweaked slightly to work over a nontrivially normed field. I think it gives a really nice argument, so it's fully commented.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
