### PR TITLE
feat: generalize `OpenPartialHomeomorph/IsImage` to `PartialHomeomorph`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -8130,6 +8130,7 @@ public import Mathlib.Topology.Order.WithTop
 public import Mathlib.Topology.Partial
 public import Mathlib.Topology.PartialHomeomorph.Basic
 public import Mathlib.Topology.PartialHomeomorph.Defs
+public import Mathlib.Topology.PartialHomeomorph.IsImage
 public import Mathlib.Topology.PartitionOfUnity
 public import Mathlib.Topology.Path
 public import Mathlib.Topology.Perfect

--- a/Mathlib/Topology/OpenPartialHomeomorph/IsImage.lean
+++ b/Mathlib/Topology/OpenPartialHomeomorph/IsImage.lean
@@ -6,6 +6,7 @@ Authors: Sébastien Gouëzel
 module
 
 public import Mathlib.Topology.OpenPartialHomeomorph.Continuity
+public import Mathlib.Topology.PartialHomeomorph.IsImage
 /-!
 # Partial homeomorphisms: Images of sets
 
@@ -71,6 +72,9 @@ def IsImage (s : Set X) (t : Set Y) : Prop :=
 namespace IsImage
 
 variable {e} {s : Set X} {t : Set Y} {x : X} {y : Y}
+
+theorem toPartialHomeomorph (h : e.IsImage s t) : e.toPartialHomeomorph.IsImage s t :=
+  h
 
 theorem toPartialEquiv (h : e.IsImage s t) : e.toPartialEquiv.IsImage s t :=
   h
@@ -173,11 +177,9 @@ theorem isOpen_iff (h : e.IsImage s t) : IsOpen (e.source ∩ s) ↔ IsOpen (e.t
 /-- Restrict an `OpenPartialHomeomorph` to a pair of corresponding open sets. -/
 @[simps! -fullyApplied apply symm_apply toPartialHomeomorph]
 def restr (h : e.IsImage s t) (hs : IsOpen (e.source ∩ s)) : OpenPartialHomeomorph X Y where
-  toPartialEquiv := h.toPartialEquiv.restr
+  toPartialHomeomorph := h.toPartialHomeomorph.restr
   open_source := hs
   open_target := h.isOpen_iff.1 hs
-  continuousOn_toFun := e.continuousOn.mono inter_subset_left
-  continuousOn_invFun := e.symm.continuousOn.mono inter_subset_left
 
 end IsImage
 
@@ -222,6 +224,11 @@ theorem restrOpen_toPartialEquiv (s : Set X) (hs : IsOpen s) :
     (e.restrOpen s hs).toPartialEquiv = e.toPartialEquiv.restr s :=
   rfl
 
+@[simp, mfld_simps]
+theorem restrOpen_toPartialHomeomorph (s : Set X) (hs : IsOpen s) :
+    (e.restrOpen s hs).toPartialHomeomorph = e.toPartialHomeomorph.restr s :=
+  rfl
+
 -- Already simp via `PartialEquiv`
 theorem restrOpen_source (s : Set X) (hs : IsOpen s) : (e.restrOpen s hs).source = e.source ∩ s :=
   rfl
@@ -254,7 +261,7 @@ theorem restr_toPartialEquiv' (s : Set X) (hs : IsOpen s) :
 
 theorem restr_eq_of_source_subset {e : OpenPartialHomeomorph X Y} {s : Set X} (h : e.source ⊆ s) :
     e.restr s = e :=
-  toPartialEquiv_injective <| PartialEquiv.restr_eq_of_source_subset <|
+  toPartialHomeomorph_injective <| PartialHomeomorph.restr_eq_of_source_subset <|
     interior_maximal h e.open_source
 
 @[simp, mfld_simps]
@@ -280,11 +287,13 @@ variable {s : Set X} (hs : IsOpen s)
 /-- The identity partial equivalence on a set `s` -/
 @[simps! (attr := mfld_simps) -fullyApplied apply, simps! -isSimp source target]
 def ofSet (s : Set X) (hs : IsOpen s) : OpenPartialHomeomorph X X where
-  toPartialEquiv := PartialEquiv.ofSet s
+  toPartialHomeomorph := PartialHomeomorph.ofSet s
   open_source := hs
   open_target := hs
-  continuousOn_toFun := continuous_id.continuousOn
-  continuousOn_invFun := continuous_id.continuousOn
+
+@[simp]
+theorem ofSet_toPartialHomeomorph : (ofSet s hs).toPartialHomeomorph = PartialHomeomorph.ofSet s :=
+  rfl
 
 @[simp, mfld_simps]
 theorem ofSet_toPartialEquiv : (ofSet s hs).toPartialEquiv = PartialEquiv.ofSet s :=
@@ -313,10 +322,13 @@ theorem eqOnSource_iff (e e' : OpenPartialHomeomorph X Y) :
     EqOnSource e e' ↔ PartialEquiv.EqOnSource e.toPartialEquiv e'.toPartialEquiv :=
   Iff.rfl
 
+theorem eqOnSource_iff_partialHomeomorph (e e' : OpenPartialHomeomorph X Y) :
+    EqOnSource e e' ↔ PartialHomeomorph.EqOnSource e.toPartialHomeomorph e'.toPartialHomeomorph :=
+  Iff.rfl
+
 /-- `EqOnSource` is an equivalence relation. -/
 instance eqOnSourceSetoid : Setoid (OpenPartialHomeomorph X Y) :=
-  { PartialEquiv.eqOnSourceSetoid.comap
-    (fun x ↦ (toPartialHomeomorph x).toPartialEquiv) with r := EqOnSource }
+  { PartialHomeomorph.eqOnSourceSetoid.comap toPartialHomeomorph with r := EqOnSource }
 
 theorem eqOnSource_refl : e ≈ e := Setoid.refl _
 
@@ -352,8 +364,7 @@ theorem EqOnSource.restr {e e' : OpenPartialHomeomorph X Y} (he : e ≈ e') (s :
 theorem Set.EqOn.restr_eqOn_source {e e' : OpenPartialHomeomorph X Y}
     (h : EqOn e e' (e.source ∩ e'.source)) : e.restr e'.source ≈ e'.restr e.source := by
   constructor
-  · rw [e'.restr_source' _ e.open_source]
-    rw [e.restr_source' _ e'.open_source]
+  · rw [e'.restr_source' _ e.open_source, e.restr_source' _ e'.open_source]
     exact Set.inter_comm _ _
   · rw [e.restr_source' _ e'.open_source]
     refine (EqOn.trans ?_ h).trans ?_ <;> simp only [mfld_simps, eqOn_refl]

--- a/Mathlib/Topology/OpenPartialHomeomorph/IsImage.lean
+++ b/Mathlib/Topology/OpenPartialHomeomorph/IsImage.lean
@@ -22,6 +22,9 @@ public import Mathlib.Topology.PartialHomeomorph.IsImage
 Most statements are copied from their `PartialEquiv` versions, although some care is required
 especially when restricting to subsets, as these should be open subsets.
 
+See `Mathlib/Topology/PartialHomeomorph/IsImage.lean` for a version of this file for general
+partial homeomorphisms (without the requirement that source and target are open).
+
 For design notes, see `PartialEquiv.lean`.
 
 ### Local coding conventions
@@ -177,7 +180,7 @@ theorem isOpen_iff (h : e.IsImage s t) : IsOpen (e.source ∩ s) ↔ IsOpen (e.t
 /-- Restrict an `OpenPartialHomeomorph` to a pair of corresponding open sets. -/
 @[simps! -fullyApplied apply symm_apply toPartialHomeomorph]
 def restr (h : e.IsImage s t) (hs : IsOpen (e.source ∩ s)) : OpenPartialHomeomorph X Y where
-  toPartialHomeomorph := h.toPartialHomeomorph.restr
+  toPartialHomeomorph := PartialHomeomorph.IsImage.restr h
   open_source := hs
   open_target := h.isOpen_iff.1 hs
 
@@ -323,7 +326,7 @@ theorem eqOnSource_iff (e e' : OpenPartialHomeomorph X Y) :
   Iff.rfl
 
 theorem eqOnSource_iff_partialHomeomorph (e e' : OpenPartialHomeomorph X Y) :
-    EqOnSource e e' ↔ PartialHomeomorph.EqOnSource e.toPartialHomeomorph e'.toPartialHomeomorph :=
+    EqOnSource e e' ↔ e.toPartialHomeomorph.EqOnSource e'.toPartialEquiv :=
   Iff.rfl
 
 /-- `EqOnSource` is an equivalence relation. -/

--- a/Mathlib/Topology/PartialHomeomorph/IsImage.lean
+++ b/Mathlib/Topology/PartialHomeomorph/IsImage.lean
@@ -180,7 +180,7 @@ section restr
 This is sometimes hard to use, but it has the advantage that when it can be used then its
 `PartialEquiv` is defeq to `PartialEquiv.restr`. -/
 @[simps! -fullyApplied apply symm_apply,
-  simps!? (attr := grind =) -isSimp source target]
+  simps! (attr := grind =) -isSimp source target]
 protected def restr (s : Set X) : PartialHomeomorph X Y :=
   (@IsImage.of_symm_preimage_eq X Y _ _ e s (e.symm ⁻¹' s) rfl).restr
 

--- a/Mathlib/Topology/PartialHomeomorph/IsImage.lean
+++ b/Mathlib/Topology/PartialHomeomorph/IsImage.lean
@@ -1,0 +1,335 @@
+/-
+Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+module
+
+public import Mathlib.Topology.PartialHomeomorph.Basic
+/-!
+# Partial homeomorphisms: Images of sets
+
+## Main definitions
+
+* `PartialHomeomorph.IsImage`: predicate for when one set is an image of another
+* `PartialHomeomorph.ofSet`: the identity on a set `s`
+* `PartialHomeomorph.EqOnSource`: equivalence relation describing the "right" notion of equality
+  for partial homeomorphisms
+
+## Implementation notes
+
+Most statements are copied from their `PartialEquiv` versions, although some care is required.
+
+For design notes, see `PartialEquiv.lean`.
+
+### Local coding conventions
+
+If a lemma deals with the intersection of a set with either source or target of a `PartialEquiv`,
+then it should use `e.source ∩ s` or `e.target ∩ t`, not `s ∩ e.source` or `t ∩ e.target`.
+-/
+
+@[expose] public section
+
+open Function Set Filter Topology
+
+variable {X X' : Type*} {Y Y' : Type*} {Z Z' : Type*}
+  [TopologicalSpace X] [TopologicalSpace X'] [TopologicalSpace Y] [TopologicalSpace Y']
+  [TopologicalSpace Z] [TopologicalSpace Z']
+
+namespace PartialHomeomorph
+
+variable (e : PartialHomeomorph X Y)
+
+section IsImage
+
+/-!
+## `PartialHomeomorph.IsImage` relation
+
+We say that `t : Set Y` is an image of `s : Set X` under a partial homeomorphism `e` if any of
+the following equivalent conditions hold:
+
+* `e '' (e.source ∩ s) = e.target ∩ t`;
+* `e.source ∩ e ⁻¹ t = e.source ∩ s`;
+* `∀ x ∈ e.source, e x ∈ t ↔ x ∈ s` (this one is used in the definition).
+
+This definition is a restatement of `PartialEquiv.IsImage` for partial homeomorphisms.
+In this section we transfer API about `PartialEquiv.IsImage` to partial homeomorphisms.
+-/
+
+/-- We say that `t : Set Y` is an image of `s : Set X` under a partial homeomorphism `e`
+if any of the following equivalent conditions hold:
+
+* `e '' (e.source ∩ s) = e.target ∩ t`;
+* `e.source ∩ e ⁻¹ t = e.source ∩ s`;
+* `∀ x ∈ e.source, e x ∈ t ↔ x ∈ s` (this one is used in the definition).
+-/
+def IsImage (s : Set X) (t : Set Y) : Prop :=
+  ∀ ⦃x⦄, x ∈ e.source → (e x ∈ t ↔ x ∈ s)
+
+namespace IsImage
+
+variable {e} {s : Set X} {t : Set Y} {x : X} {y : Y}
+
+theorem toPartialEquiv (h : e.IsImage s t) : e.toPartialEquiv.IsImage s t :=
+  h
+
+theorem apply_mem_iff (h : e.IsImage s t) (hx : x ∈ e.source) : e x ∈ t ↔ x ∈ s :=
+  h hx
+
+protected theorem symm (h : e.IsImage s t) : e.symm.IsImage t s :=
+  h.toPartialEquiv.symm
+
+theorem symm_apply_mem_iff (h : e.IsImage s t) (hy : y ∈ e.target) : e.symm y ∈ s ↔ y ∈ t :=
+  h.symm hy
+
+@[simp]
+theorem symm_iff : e.symm.IsImage t s ↔ e.IsImage s t :=
+  ⟨fun h => h.symm, fun h => h.symm⟩
+
+protected theorem mapsTo (h : e.IsImage s t) : MapsTo e (e.source ∩ s) (e.target ∩ t) :=
+  h.toPartialEquiv.mapsTo
+
+theorem symm_mapsTo (h : e.IsImage s t) : MapsTo e.symm (e.target ∩ t) (e.source ∩ s) :=
+  h.symm.mapsTo
+
+theorem image_eq (h : e.IsImage s t) : e '' (e.source ∩ s) = e.target ∩ t :=
+  h.toPartialEquiv.image_eq
+
+theorem symm_image_eq (h : e.IsImage s t) : e.symm '' (e.target ∩ t) = e.source ∩ s :=
+  h.symm.image_eq
+
+theorem iff_preimage_eq : e.IsImage s t ↔ e.source ∩ e ⁻¹' t = e.source ∩ s :=
+  PartialEquiv.IsImage.iff_preimage_eq
+
+alias ⟨preimage_eq, of_preimage_eq⟩ := iff_preimage_eq
+
+theorem iff_symm_preimage_eq : e.IsImage s t ↔ e.target ∩ e.symm ⁻¹' s = e.target ∩ t :=
+  symm_iff.symm.trans iff_preimage_eq
+
+alias ⟨symm_preimage_eq, of_symm_preimage_eq⟩ := iff_symm_preimage_eq
+
+theorem iff_symm_preimage_eq' :
+    e.IsImage s t ↔ e.target ∩ e.symm ⁻¹' (e.source ∩ s) = e.target ∩ t := by
+  rw [iff_symm_preimage_eq, ← image_source_inter_eq, ← image_source_inter_eq']
+
+alias ⟨symm_preimage_eq', of_symm_preimage_eq'⟩ := iff_symm_preimage_eq'
+
+theorem iff_preimage_eq' : e.IsImage s t ↔ e.source ∩ e ⁻¹' (e.target ∩ t) = e.source ∩ s :=
+  symm_iff.symm.trans iff_symm_preimage_eq'
+
+alias ⟨preimage_eq', of_preimage_eq'⟩ := iff_preimage_eq'
+
+theorem of_image_eq (h : e '' (e.source ∩ s) = e.target ∩ t) : e.IsImage s t :=
+  PartialEquiv.IsImage.of_image_eq h
+
+theorem of_symm_image_eq (h : e.symm '' (e.target ∩ t) = e.source ∩ s) : e.IsImage s t :=
+  PartialEquiv.IsImage.of_symm_image_eq h
+
+protected theorem compl (h : e.IsImage s t) : e.IsImage sᶜ tᶜ := fun _ hx => (h hx).not
+
+protected theorem inter {s' t'} (h : e.IsImage s t) (h' : e.IsImage s' t') :
+    e.IsImage (s ∩ s') (t ∩ t') := fun _ hx => (h hx).and (h' hx)
+
+protected theorem union {s' t'} (h : e.IsImage s t) (h' : e.IsImage s' t') :
+    e.IsImage (s ∪ s') (t ∪ t') := fun _ hx => (h hx).or (h' hx)
+
+protected theorem diff {s' t'} (h : e.IsImage s t) (h' : e.IsImage s' t') :
+    e.IsImage (s \ s') (t \ t') :=
+  h.inter h'.compl
+
+theorem leftInvOn_piecewise {e' : PartialHomeomorph X Y} [∀ i, Decidable (i ∈ s)]
+    [∀ i, Decidable (i ∈ t)] (h : e.IsImage s t) (h' : e'.IsImage s t) :
+    LeftInvOn (t.piecewise e.symm e'.symm) (s.piecewise e e') (s.ite e.source e'.source) :=
+  h.toPartialEquiv.leftInvOn_piecewise h'
+
+theorem inter_eq_of_inter_eq_of_eqOn {e' : PartialHomeomorph X Y} (h : e.IsImage s t)
+    (h' : e'.IsImage s t) (hs : e.source ∩ s = e'.source ∩ s) (Heq : EqOn e e' (e.source ∩ s)) :
+    e.target ∩ t = e'.target ∩ t :=
+  h.toPartialEquiv.inter_eq_of_inter_eq_of_eqOn h' hs Heq
+
+theorem symm_eqOn_of_inter_eq_of_eqOn {e' : PartialHomeomorph X Y} (h : e.IsImage s t)
+    (hs : e.source ∩ s = e'.source ∩ s) (Heq : EqOn e e' (e.source ∩ s)) :
+    EqOn e.symm e'.symm (e.target ∩ t) :=
+  h.toPartialEquiv.symm_eq_on_of_inter_eq_of_eqOn hs Heq
+
+/-- Restrict an `PartialHomeomorph` to a pair of corresponding sets. -/
+@[simps! -fullyApplied apply symm_apply toPartialEquiv]
+def restr (h : e.IsImage s t) : PartialHomeomorph X Y where
+  toPartialEquiv := h.toPartialEquiv.restr
+  continuousOn_toFun := e.continuousOn.mono inter_subset_left
+  continuousOn_invFun := e.symm.continuousOn.mono inter_subset_left
+
+end IsImage
+
+theorem isImage_source_target : e.IsImage e.source e.target :=
+  e.toPartialEquiv.isImage_source_target
+
+theorem isImage_source_target_of_disjoint (e' : PartialHomeomorph X Y)
+    (hs : Disjoint e.source e'.source) (ht : Disjoint e.target e'.target) :
+    e.IsImage e'.source e'.target :=
+  e.toPartialEquiv.isImage_source_target_of_disjoint e'.toPartialEquiv hs ht
+
+end IsImage
+
+section restr
+/-!
+## Restriction
+-/
+
+/-- Restricting a partial homeomorphism `e` to `e.source ∩ s`.
+This is sometimes hard to use, but it has the advantage that when it can be used then its
+`PartialEquiv` is defeq to `PartialEquiv.restr`. -/
+@[simps! -fullyApplied apply symm_apply,
+  simps!? (attr := grind =) -isSimp source target]
+protected def restr (s : Set X) : PartialHomeomorph X Y :=
+  (@IsImage.of_symm_preimage_eq X Y _ _ e s (e.symm ⁻¹' s) rfl).restr
+
+@[simp] theorem coe_restr {s : Set X} : ⇑(e.restr s) = e := rfl
+
+@[simp]
+theorem coe_restr_symm {s : Set X} : ⇑(e.restr s).symm = e.symm := rfl
+
+@[simp]
+theorem restr_toPartialEquiv (s : Set X) :
+    (e.restr s).toPartialEquiv = e.toPartialEquiv.restr s :=
+  rfl
+
+theorem restr_eq_of_source_subset {e : PartialHomeomorph X Y} {s : Set X} (h : e.source ⊆ s) :
+    e.restr s = e :=
+  toPartialEquiv_injective <| PartialEquiv.restr_eq_of_source_subset <| h
+
+@[simp, mfld_simps]
+theorem restr_univ {e : PartialHomeomorph X Y} : e.restr univ = e :=
+  restr_eq_of_source_subset (subset_univ _)
+
+@[simp, grind =]
+theorem restr_source_inter (s : Set X) : e.restr (e.source ∩ s) = e.restr s := by
+  refine PartialHomeomorph.ext _ _ (fun x => rfl) (fun x => rfl) ?_
+  simp [← inter_assoc]
+
+end restr
+
+/-!
+## ofSet
+
+The identity on a set `s`
+-/
+section ofSet
+
+variable {s : Set X}
+
+/-- The identity partial equivalence on a set `s` -/
+@[simps! -fullyApplied apply, simps! -isSimp source target]
+def ofSet (s : Set X) : PartialHomeomorph X X where
+  toPartialEquiv := PartialEquiv.ofSet s
+  continuousOn_toFun := continuous_id.continuousOn
+  continuousOn_invFun := continuous_id.continuousOn
+
+@[simp]
+theorem ofSet_toPartialEquiv : (ofSet s).toPartialEquiv = PartialEquiv.ofSet s :=
+  rfl
+
+@[simp]
+theorem ofSet_symm : (ofSet s).symm = ofSet s :=
+  rfl
+
+@[simp]
+theorem ofSet_univ_eq_refl : ofSet univ = PartialHomeomorph.refl X := by
+  ext <;> simp
+
+end ofSet
+
+
+/-! `EqOnSource`: equivalence on their source -/
+section EqOnSource
+
+/-- `EqOnSource e e'` means that `e` and `e'` have the same source, and coincide there. They
+should really be considered the same partial equivalence. -/
+def EqOnSource (e e' : PartialHomeomorph X Y) : Prop :=
+  e.source = e'.source ∧ EqOn e e' e.source
+
+theorem eqOnSource_iff (e e' : PartialHomeomorph X Y) :
+    EqOnSource e e' ↔ PartialEquiv.EqOnSource e.toPartialEquiv e'.toPartialEquiv :=
+  Iff.rfl
+
+/-- `EqOnSource` is an equivalence relation. -/
+instance eqOnSourceSetoid : Setoid (PartialHomeomorph X Y) :=
+  { PartialEquiv.eqOnSourceSetoid.comap toPartialEquiv with r := EqOnSource }
+
+theorem eqOnSource_refl : e ≈ e := Setoid.refl _
+
+/-- If two partial homeomorphisms are equivalent, so are their inverses. -/
+theorem EqOnSource.symm' {e e' : PartialHomeomorph X Y} (h : e ≈ e') : e.symm ≈ e'.symm :=
+  PartialEquiv.EqOnSource.symm' h
+
+/-- Two equivalent partial homeomorphisms have the same source. -/
+theorem EqOnSource.source_eq {e e' : PartialHomeomorph X Y} (h : e ≈ e') :
+    e.source = e'.source :=
+  h.1
+
+/-- Two equivalent partial homeomorphisms have the same target. -/
+theorem EqOnSource.target_eq {e e' : PartialHomeomorph X Y} (h : e ≈ e') :
+    e.target = e'.target :=
+  h.symm'.1
+
+/-- Two equivalent partial homeomorphisms have coinciding `toFun` on the source -/
+theorem EqOnSource.eqOn {e e' : PartialHomeomorph X Y} (h : e ≈ e') : EqOn e e' e.source :=
+  h.2
+
+/-- Two equivalent partial homeomorphisms have coinciding `invFun` on the target -/
+theorem EqOnSource.symm_eqOn_target {e e' : PartialHomeomorph X Y} (h : e ≈ e') :
+    EqOn e.symm e'.symm e.target :=
+  h.symm'.2
+
+/-- Restriction of partial homeomorphisms respects equivalence -/
+theorem EqOnSource.restr {e e' : PartialHomeomorph X Y} (he : e ≈ e') (s : Set X) :
+    e.restr s ≈ e'.restr s :=
+  PartialEquiv.EqOnSource.restr he _
+
+/-- Two equivalent partial homeomorphisms are equal when the source and target are `univ`. -/
+theorem Set.EqOn.restr_eqOn_source {e e' : PartialHomeomorph X Y}
+    (h : EqOn e e' (e.source ∩ e'.source)) : e.restr e'.source ≈ e'.restr e.source := by
+  constructor
+  · rw [restr_source, restr_source]
+    exact Set.inter_comm _ _
+  · rw [restr_source]
+    refine (EqOn.trans ?_ h).trans ?_ <;> simp only [coe_restr, eqOn_refl]
+
+theorem eq_of_eqOnSource_univ {e e' : PartialHomeomorph X Y} (h : e ≈ e') (s : e.source = univ)
+    (t : e.target = univ) : e = e' :=
+  toPartialEquiv_injective <| PartialEquiv.eq_of_eqOnSource_univ _ _ h s t
+
+variable {s : Set X}
+
+lemma restr_eqOnSource_restr {s' : Set X}
+    (hss' : e.source ∩ s = e.source ∩ s') :
+    e.restr s ≈ e.restr s' := by
+  constructor
+  · simpa [e.restr_source]
+  · simp [Set.eqOn_refl]
+
+lemma restr_inter_source : e.restr (e.source ∩ s) ≈ e.restr s :=
+  e.restr_eqOnSource_restr (by simp)
+
+
+end EqOnSource
+
+end PartialHomeomorph
+
+namespace Homeomorph
+
+variable (e : X ≃ₜ Y) (e' : Y ≃ₜ Z)
+
+/- Register as simp lemmas that the fields of a partial homeomorphism built from a
+homeomorphism correspond to the fields of the original homeomorphism. -/
+@[simp]
+theorem refl_toPartialHomeomorph :
+    (Homeomorph.refl X).toPartialHomeomorph = PartialHomeomorph.refl X :=
+  rfl
+
+@[simp]
+theorem symm_toPartialHomeomorph :
+    e.symm.toPartialHomeomorph = e.toPartialHomeomorph.symm :=
+  rfl
+
+end Homeomorph

--- a/Mathlib/Topology/PartialHomeomorph/IsImage.lean
+++ b/Mathlib/Topology/PartialHomeomorph/IsImage.lean
@@ -75,7 +75,6 @@ protected theorem symm (h : e.IsImage s t) : e.symm.IsImage t s :=
 theorem symm_apply_mem_iff (h : e.IsImage s t) (hy : y ∈ e.target) : e.symm y ∈ s ↔ y ∈ t :=
   h.symm hy
 
-@[simp]
 theorem symm_iff : e.symm.IsImage t s ↔ e.IsImage s t :=
   ⟨fun h => h.symm, fun h => h.symm⟩
 

--- a/Mathlib/Topology/PartialHomeomorph/IsImage.lean
+++ b/Mathlib/Topology/PartialHomeomorph/IsImage.lean
@@ -146,7 +146,7 @@ theorem symm_eqOn_of_inter_eq_of_eqOn {e' : PartialHomeomorph X Y} (h : e.IsImag
   h.symm_eq_on_of_inter_eq_of_eqOn hs Heq
 
 /-- Restrict an `PartialHomeomorph` to a pair of corresponding sets. -/
-@[simps! -fullyApplied apply symm_apply toPartialEquiv]
+@[simps! -fullyApplied apply symm_apply toPartialEquiv, reducible]
 def restr (h : e.IsImage s t) : PartialHomeomorph X Y where
   toPartialEquiv := h.restr
   continuousOn_toFun := e.continuousOn.mono inter_subset_left

--- a/Mathlib/Topology/PartialHomeomorph/IsImage.lean
+++ b/Mathlib/Topology/PartialHomeomorph/IsImage.lean
@@ -11,16 +11,21 @@ public import Mathlib.Topology.PartialHomeomorph.Basic
 
 ## Main definitions
 
-* `PartialHomeomorph.IsImage`: predicate for when one set is an image of another
 * `PartialHomeomorph.ofSet`: the identity on a set `s`
-* `PartialHomeomorph.EqOnSource`: equivalence relation describing the "right" notion of equality
-  for partial homeomorphisms
 
 ## Implementation notes
 
-Most statements are copied from their `PartialEquiv` versions, although some care is required.
+Most statements are copied from their `PartialEquiv` and `OpenPartialHomeomorph` versions, although
+some care is required.
+
+See `Mathlib/Topology/OpenPartialHomeomorph/IsImage.lean` for a version of this file for
+partial homeomorphisms with open source and target.
 
 For design notes, see `PartialEquiv.lean`.
+
+We use the definitions `PartialEquiv.IsImage` and `PartialEquiv.EqOnSource` also for partial
+homeomorphisms. We do however transfer API about them to partial homeomorphisms to
+avoid defeq abuse.
 
 ### Local coding conventions
 
@@ -52,32 +57,20 @@ the following equivalent conditions hold:
 * `e.source ∩ e ⁻¹ t = e.source ∩ s`;
 * `∀ x ∈ e.source, e x ∈ t ↔ x ∈ s` (this one is used in the definition).
 
-This definition is a restatement of `PartialEquiv.IsImage` for partial homeomorphisms.
-In this section we transfer API about `PartialEquiv.IsImage` to partial homeomorphisms.
+We use the definition `PartialEquiv.IsImage` also for partial homeomorphisms.
+In this section we transfer API about `PartialEquiv.IsImage` to partial homeomorphisms to
+avoid defeq abuse.
 -/
-
-/-- We say that `t : Set Y` is an image of `s : Set X` under a partial homeomorphism `e`
-if any of the following equivalent conditions hold:
-
-* `e '' (e.source ∩ s) = e.target ∩ t`;
-* `e.source ∩ e ⁻¹ t = e.source ∩ s`;
-* `∀ x ∈ e.source, e x ∈ t ↔ x ∈ s` (this one is used in the definition).
--/
-def IsImage (s : Set X) (t : Set Y) : Prop :=
-  ∀ ⦃x⦄, x ∈ e.source → (e x ∈ t ↔ x ∈ s)
 
 namespace IsImage
 
 variable {e} {s : Set X} {t : Set Y} {x : X} {y : Y}
 
-theorem toPartialEquiv (h : e.IsImage s t) : e.toPartialEquiv.IsImage s t :=
-  h
-
 theorem apply_mem_iff (h : e.IsImage s t) (hx : x ∈ e.source) : e x ∈ t ↔ x ∈ s :=
   h hx
 
 protected theorem symm (h : e.IsImage s t) : e.symm.IsImage t s :=
-  h.toPartialEquiv.symm
+  h.symm
 
 theorem symm_apply_mem_iff (h : e.IsImage s t) (hy : y ∈ e.target) : e.symm y ∈ s ↔ y ∈ t :=
   h.symm hy
@@ -87,13 +80,13 @@ theorem symm_iff : e.symm.IsImage t s ↔ e.IsImage s t :=
   ⟨fun h => h.symm, fun h => h.symm⟩
 
 protected theorem mapsTo (h : e.IsImage s t) : MapsTo e (e.source ∩ s) (e.target ∩ t) :=
-  h.toPartialEquiv.mapsTo
+  h.mapsTo
 
 theorem symm_mapsTo (h : e.IsImage s t) : MapsTo e.symm (e.target ∩ t) (e.source ∩ s) :=
   h.symm.mapsTo
 
 theorem image_eq (h : e.IsImage s t) : e '' (e.source ∩ s) = e.target ∩ t :=
-  h.toPartialEquiv.image_eq
+  h.image_eq
 
 theorem symm_image_eq (h : e.IsImage s t) : e.symm '' (e.target ∩ t) = e.source ∩ s :=
   h.symm.image_eq
@@ -140,22 +133,22 @@ protected theorem diff {s' t'} (h : e.IsImage s t) (h' : e.IsImage s' t') :
 theorem leftInvOn_piecewise {e' : PartialHomeomorph X Y} [∀ i, Decidable (i ∈ s)]
     [∀ i, Decidable (i ∈ t)] (h : e.IsImage s t) (h' : e'.IsImage s t) :
     LeftInvOn (t.piecewise e.symm e'.symm) (s.piecewise e e') (s.ite e.source e'.source) :=
-  h.toPartialEquiv.leftInvOn_piecewise h'
+  h.leftInvOn_piecewise h'
 
 theorem inter_eq_of_inter_eq_of_eqOn {e' : PartialHomeomorph X Y} (h : e.IsImage s t)
     (h' : e'.IsImage s t) (hs : e.source ∩ s = e'.source ∩ s) (Heq : EqOn e e' (e.source ∩ s)) :
     e.target ∩ t = e'.target ∩ t :=
-  h.toPartialEquiv.inter_eq_of_inter_eq_of_eqOn h' hs Heq
+  h.inter_eq_of_inter_eq_of_eqOn h' hs Heq
 
 theorem symm_eqOn_of_inter_eq_of_eqOn {e' : PartialHomeomorph X Y} (h : e.IsImage s t)
     (hs : e.source ∩ s = e'.source ∩ s) (Heq : EqOn e e' (e.source ∩ s)) :
     EqOn e.symm e'.symm (e.target ∩ t) :=
-  h.toPartialEquiv.symm_eq_on_of_inter_eq_of_eqOn hs Heq
+  h.symm_eq_on_of_inter_eq_of_eqOn hs Heq
 
 /-- Restrict an `PartialHomeomorph` to a pair of corresponding sets. -/
 @[simps! -fullyApplied apply symm_apply toPartialEquiv]
 def restr (h : e.IsImage s t) : PartialHomeomorph X Y where
-  toPartialEquiv := h.toPartialEquiv.restr
+  toPartialEquiv := h.restr
   continuousOn_toFun := e.continuousOn.mono inter_subset_left
   continuousOn_invFun := e.symm.continuousOn.mono inter_subset_left
 
@@ -182,7 +175,7 @@ This is sometimes hard to use, but it has the advantage that when it can be used
 @[simps! -fullyApplied apply symm_apply,
   simps! (attr := grind =) -isSimp source target]
 protected def restr (s : Set X) : PartialHomeomorph X Y :=
-  (@IsImage.of_symm_preimage_eq X Y _ _ e s (e.symm ⁻¹' s) rfl).restr
+  PartialHomeomorph.IsImage.restr (@IsImage.of_symm_preimage_eq X Y _ _ e s (e.symm ⁻¹' s) rfl)
 
 @[simp] theorem coe_restr {s : Set X} : ⇑(e.restr s) = e := rfl
 
@@ -222,8 +215,8 @@ variable {s : Set X}
 @[simps! -fullyApplied apply, simps! -isSimp source target]
 def ofSet (s : Set X) : PartialHomeomorph X X where
   toPartialEquiv := PartialEquiv.ofSet s
-  continuousOn_toFun := continuous_id.continuousOn
-  continuousOn_invFun := continuous_id.continuousOn
+  continuousOn_toFun := continuousOn_id
+  continuousOn_invFun := continuousOn_id
 
 @[simp]
 theorem ofSet_toPartialEquiv : (ofSet s).toPartialEquiv = PartialEquiv.ofSet s :=
@@ -239,22 +232,23 @@ theorem ofSet_univ_eq_refl : ofSet univ = PartialHomeomorph.refl X := by
 
 end ofSet
 
+/-!
+## `EqOnSource` relation
 
-/-! `EqOnSource`: equivalence on their source -/
+Equivalence of partial homeomorphisms on their source.
+
+We use the definition `PartialEquiv.EqOnSource` also for partial homeomorphisms.
+In this section we transfer API about `PartialEquiv.EqOnSource` to partial homeomorphisms to
+avoid defeq abuse.
+-/
 section EqOnSource
 
-/-- `EqOnSource e e'` means that `e` and `e'` have the same source, and coincide there. They
-should really be considered the same partial equivalence. -/
-def EqOnSource (e e' : PartialHomeomorph X Y) : Prop :=
-  e.source = e'.source ∧ EqOn e e' e.source
-
-theorem eqOnSource_iff (e e' : PartialHomeomorph X Y) :
-    EqOnSource e e' ↔ PartialEquiv.EqOnSource e.toPartialEquiv e'.toPartialEquiv :=
-  Iff.rfl
+open PartialEquiv
 
 /-- `EqOnSource` is an equivalence relation. -/
 instance eqOnSourceSetoid : Setoid (PartialHomeomorph X Y) :=
-  { PartialEquiv.eqOnSourceSetoid.comap toPartialEquiv with r := EqOnSource }
+  { PartialEquiv.eqOnSourceSetoid.comap toPartialEquiv with
+    r := fun e e' ↦ e.EqOnSource e'.toPartialEquiv}
 
 theorem eqOnSource_refl : e ≈ e := Setoid.refl _
 
@@ -293,7 +287,8 @@ theorem Set.EqOn.restr_eqOn_source {e e' : PartialHomeomorph X Y}
   · rw [restr_source, restr_source]
     exact Set.inter_comm _ _
   · rw [restr_source]
-    refine (EqOn.trans ?_ h).trans ?_ <;> simp only [coe_restr, eqOn_refl]
+    refine (EqOn.trans ?_ h).trans ?_ <;> simp only [restr_toPartialEquiv, restr_coe, toFun_eq_coe,
+      eqOn_refl]
 
 theorem eq_of_eqOnSource_univ {e e' : PartialHomeomorph X Y} (h : e ≈ e') (s : e.source = univ)
     (t : e.target = univ) : e = e' :=


### PR DESCRIPTION
This is a continuation of #41045.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
