### PR TITLE
feat(NumberTheory/LegendreSymbol/QuadraticChar/Basic): characterize when products are squares

### DIFF
--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
@@ -241,6 +241,18 @@ theorem quadraticChar_sum_zero (hF : ringChar F ≠ 2) : ∑ a : F, quadraticCha
 
 end quadraticChar
 
+/-- In a finite field, a product of two nonzero elements is a square iff the factors are
+both squares or both nonsquares. -/
+theorem FiniteField.isSquare_mul_iff {F : Type*} [Field F] [Finite F] {a b : F}
+    (ha : a ≠ 0) (hb : b ≠ 0) : IsSquare (a * b) ↔ (IsSquare a ↔ IsSquare b) := by
+  cases nonempty_fintype F
+  classical
+  rw [← quadraticChar_one_iff_isSquare ha, ← quadraticChar_one_iff_isSquare hb,
+    ← quadraticChar_one_iff_isSquare (mul_ne_zero ha hb), map_mul]
+  rcases quadraticChar_dichotomy ha with h1 | h1 <;>
+    rcases quadraticChar_dichotomy hb with h2 | h2 <;>
+      rw [h1, h2] <;> norm_num
+
 /-!
 ### Special values of the quadratic character
 

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
@@ -253,6 +253,25 @@ theorem FiniteField.isSquare_mul_iff {F : Type*} [Field F] [Finite F] {a b : F}
     rcases quadraticChar_dichotomy hb with h2 | h2 <;>
       rw [h1, h2] <;> norm_num
 
+/-- In a finite field, the product of a nonzero square and a nonsquare is a nonsquare. -/
+theorem FiniteField.not_isSquare_mul_of_isSquare_of_not_isSquare {F : Type*} [Field F] [Finite F]
+    {a b : F} (ha : a ≠ 0) (ha' : IsSquare a) (hb : ¬IsSquare b) : ¬IsSquare (a * b) := by
+  have hb₀ : b ≠ 0 := fun h ↦ hb (h ▸ IsSquare.zero)
+  exact fun h ↦ hb (((isSquare_mul_iff ha hb₀).mp h).mp ha')
+
+/-- In a finite field, the product of a nonsquare and a nonzero square is a nonsquare. -/
+theorem FiniteField.not_isSquare_mul_of_not_isSquare_of_isSquare {F : Type*} [Field F] [Finite F]
+    {a b : F} (hb : b ≠ 0) (ha : ¬IsSquare a) (hb' : IsSquare b) : ¬IsSquare (a * b) := by
+  have ha₀ : a ≠ 0 := fun h ↦ ha (h ▸ IsSquare.zero)
+  exact fun h ↦ ha (((isSquare_mul_iff ha₀ hb).mp h).mpr hb')
+
+/-- In a finite field, the product of two nonsquares is a square. -/
+theorem FiniteField.isSquare_mul_of_not_isSquare_of_not_isSquare {F : Type*} [Field F] [Finite F]
+    {a b : F} (ha : ¬IsSquare a) (hb : ¬IsSquare b) : IsSquare (a * b) := by
+  have ha₀ : a ≠ 0 := fun h ↦ ha (h ▸ IsSquare.zero)
+  have hb₀ : b ≠ 0 := fun h ↦ hb (h ▸ IsSquare.zero)
+  exact (isSquare_mul_iff ha₀ hb₀).mpr (iff_of_false ha hb)
+
 /-!
 ### Special values of the quadratic character
 


### PR DESCRIPTION
## Motivation

This is a basic application of the quadratic character of a finite field that can be used in many instances, for example later to characterize squares in `ℤ_[p]`.

## Summary

`FiniteField.isSquare_mul_iff` characterizes when the product of two nonzero elements in a finite field is a square, using the quadratic character.

## Testing

- `lake build Mathlib.NumberTheory.LegendreSymbol.QuadraticChar.Basic -q --log-level=info`
- `lake exe lint-style Mathlib.NumberTheory.LegendreSymbol.QuadraticChar.Basic`
- `git diff --check upstream/master...HEAD`

## AI assistance

I was working with AI assistance (Claude Code, Codex) to formalize some fun number theory I like (Hilbert symbols, towards reciprocity laws) to help me learn Lean. I used AI assistance to highlight some small pieces that might be appropriate for mathlib, and to help me properly format these small items for mathlib.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
