### PR TITLE
chore(CategoryTheory): fix some `nolint simpNF`

### DIFF
--- a/Mathlib/CategoryTheory/Category/TwoP.lean
+++ b/Mathlib/CategoryTheory/Category/TwoP.lean
@@ -105,10 +105,10 @@ theorem swapEquiv_symm : swapEquiv.symm = swapEquiv :=
 
 end TwoP
 
-set_option backward.isDefEq.respectTransparency.types false in
-@[simp, nolint simpNF] -- mathlib builds without this simp attribute
+@[simp]
 theorem TwoP_swap_comp_forget_to_Bipointed :
-    TwoP.swap ⋙ forget₂ TwoP Bipointed = forget₂ TwoP Bipointed ⋙ Bipointed.swap :=
+    TwoP.swap ⋙ forget₂ TwoP Bipointed (CC := fun X ↦ X.X) =
+      forget₂ TwoP Bipointed ⋙ Bipointed.swap :=
   rfl
 
 /-- The functor from `Pointed` to `TwoP` which adds a second point. -/
@@ -137,16 +137,14 @@ theorem pointedToTwoPFst_comp_swap : pointedToTwoPFst ⋙ TwoP.swap = pointedToT
 theorem pointedToTwoPSnd_comp_swap : pointedToTwoPSnd ⋙ TwoP.swap = pointedToTwoPFst :=
   rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
-@[simp, nolint simpNF] -- mathlib builds without this simp attribute
+@[simp]
 theorem pointedToTwoPFst_comp_forget_to_bipointed :
-    pointedToTwoPFst ⋙ forget₂ TwoP Bipointed = pointedToBipointedFst :=
+    pointedToTwoPFst ⋙ forget₂ TwoP Bipointed (CC := fun X ↦ X.X) = pointedToBipointedFst :=
   rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
-@[simp, nolint simpNF] -- mathlib builds without this simp attribute
+@[simp]
 theorem pointedToTwoPSnd_comp_forget_to_bipointed :
-    pointedToTwoPSnd ⋙ forget₂ TwoP Bipointed = pointedToBipointedSnd :=
+    pointedToTwoPSnd ⋙ forget₂ TwoP Bipointed (CC := fun X ↦ X.X) = pointedToBipointedSnd :=
   rfl
 
 set_option backward.isDefEq.respectTransparency.types false in


### PR DESCRIPTION
By specifying an `outParam`.

Note: These are the only remaining `nolint simpNF` one can fix directly. All others are either an autogenerated lemma coming from tagging a definition with simp; a bug in the linter or in a docstring (which the tech debt counter on zulip seems to count accidentally).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
