### PR TITLE
fix(Analysis/Matrix): anchor the elementwise matrix norm's topology to instTopologicalSpaceMatrix

### DIFF
--- a/Mathlib/Analysis/Matrix/Normed.lean
+++ b/Mathlib/Analysis/Matrix/Normed.lean
@@ -6,6 +6,7 @@ Authors: Heather Macbeth, Eric Wieser
 module
 
 public import Mathlib.Analysis.InnerProductSpace.PiL2
+public import Mathlib.Topology.Instances.Matrix
 
 /-!
 # Matrices as a normed space
@@ -74,10 +75,19 @@ variable [SeminormedAddCommGroup α] [SeminormedAddCommGroup β]
 
 /-- Seminormed group instance (using sup norm of sup norm) for matrices over a seminormed group. Not
 declared as an instance because there are several natural choices for defining the norm of a
-matrix. -/
+matrix.
+
+The topology field is anchored (via `PseudoMetricSpace.replaceTopology`) to the ambient matrix
+topology, i.e. the `Pi` topology, so that instance resolution can see the agreement at reducible
+transparency.  Without the anchor the two topologies are definitionally equal at default
+transparency but *not* at instance-resolution transparency, so e.g.
+`Norm (Matrix m n ℝ →L[ℝ] Matrix m n ℝ)` fails to synthesize for continuous linear maps formed
+with the ambient topology.  See `MathlibTest/MatrixNormTopology.lean`. -/
 @[instance_reducible]
 protected def seminormedAddCommGroup : SeminormedAddCommGroup (Matrix m n α) :=
-  fast_instance% Pi.seminormedAddCommGroup
+  letI I : SeminormedAddCommGroup (Matrix m n α) := fast_instance% Pi.seminormedAddCommGroup
+  { I with
+    toPseudoMetricSpace := I.toPseudoMetricSpace.replaceTopology rfl }
 
 attribute [local instance] Matrix.seminormedAddCommGroup
 
@@ -177,10 +187,15 @@ end SeminormedAddCommGroup
 
 /-- Normed group instance (using sup norm of sup norm) for matrices over a normed group.  Not
 declared as an instance because there are several natural choices for defining the norm of a
-matrix. -/
+matrix.
+
+The topology field is anchored to the ambient (`Pi`) matrix topology; see
+`Matrix.seminormedAddCommGroup` for why. -/
 @[instance_reducible]
 protected def normedAddCommGroup [NormedAddCommGroup α] : NormedAddCommGroup (Matrix m n α) :=
-  fast_instance% Pi.normedAddCommGroup
+  letI I : NormedAddCommGroup (Matrix m n α) := fast_instance% Pi.normedAddCommGroup
+  { I with
+    toMetricSpace := I.toMetricSpace.replaceTopology rfl }
 
 section NormedSpace
 

--- a/MathlibTest/MatrixNormTopology.lean
+++ b/MathlibTest/MatrixNormTopology.lean
@@ -1,0 +1,41 @@
+import Mathlib.Analysis.Matrix.Normed
+import Mathlib.Topology.Instances.Matrix
+
+/-! # Regression tests: elementwise matrix norm vs the ambient matrix topology
+
+The scoped elementwise matrix norm (`Matrix.seminormedAddCommGroup`, scope
+`Matrix.Norms.Elementwise`) induces a topology that is definitionally equal to
+the ambient `instTopologicalSpaceMatrix` (the `Pi` topology).  These tests pin
+down that the agreement is visible to *instance resolution*: without the
+`replaceTopology` anchor in `Matrix.seminormedAddCommGroup`, the `Norm`
+synthesis below fails even though the `rfl` example succeeds.
+-/
+
+open scoped Matrix.Norms.Elementwise
+
+variable {m n : Type*} [Fintype m] [Fintype n]
+
+-- The norm-induced topology is definitionally the ambient (`Pi`) topology.
+example :
+    (instTopologicalSpaceMatrix : TopologicalSpace (Matrix m n ℝ)) =
+      (Matrix.seminormedAddCommGroup :
+        SeminormedAddCommGroup (Matrix m n ℝ)).toPseudoMetricSpace.toUniformSpace.toTopologicalSpace :=
+  rfl
+
+-- ... and the same for the `NormedAddCommGroup` instance.
+example :
+    (instTopologicalSpaceMatrix : TopologicalSpace (Matrix m n ℝ)) =
+      (Matrix.normedAddCommGroup :
+        NormedAddCommGroup (Matrix m n ℝ)).toMetricSpace.toUniformSpace.toTopologicalSpace :=
+  rfl
+
+-- Operator-norm synthesis for continuous linear maps between matrix types
+-- (whose types are formed with the ambient topology).
+noncomputable example : Norm (Matrix m n ℝ →L[ℝ] Matrix m n ℝ) := inferInstance
+
+-- The operator norm is actually usable.
+noncomputable example (f : Matrix m n ℝ →L[ℝ] Matrix m n ℝ) : ℝ := ‖f‖
+
+-- Smul-continuity over the norm-induced topology unifies with the ambient
+-- `ContinuousConstSMul` instance from `Topology.Instances.Matrix`.
+example : ContinuousConstSMul ℝ (Matrix m n ℝ) := inferInstance


### PR DESCRIPTION
With `open scoped Matrix.Norms.Elementwise`,

```lean
noncomputable example {m n : Type*} [Fintype m] [Fintype n] :
    Norm (Matrix m n ℝ →L[ℝ] Matrix m n ℝ) := inferInstance
```

fails to synthesize, even though the norm-induced topology on `Matrix m n ℝ` is definitionally equal to the ambient `instTopologicalSpaceMatrix` (`rfl` proves the equality).

What goes wrong: the `→L[ℝ]` type is elaborated with the *direct* instance `instTopologicalSpaceMatrix`, while `ContinuousLinearMap.hasOpNorm`'s conclusion carries topologies that are *projections* of its `SeminormedAddCommGroup` arguments. During resolution, pending synthesis does find `Matrix.seminormedAddCommGroup`, but the projected topology then has to unify with `instTopologicalSpaceMatrix`, and the projection chain through `fast_instance% Pi.seminormedAddCommGroup` does not reduce to the same term. (Types like `ℝ` or `EuclideanSpace` don't hit this because they have no direct `TopologicalSpace` instance competing with the projection path — matrices do.)

**Fix**: anchor the topology field of `Matrix.seminormedAddCommGroup` / `Matrix.normedAddCommGroup` to `instTopologicalSpaceMatrix` via `PseudoMetricSpace.replaceTopology` / `MetricSpace.replaceTopology` with `rfl` proofs — the standard forgetful-inheritance pattern; the Frobenius family in the same file already achieves this through `PiLp.seminormedAddCommGroupToPi`. Anchoring to a freshly-elaborated `inferInstanceAs <| TopologicalSpace (m → n → α)` is *not* sufficient — the anchor must be the same instance term that appears in elaborated goal types, which is why this also adds `public import Mathlib.Topology.Instances.Matrix` (no cycle; that file only imports `LinearAlgebra.Matrix.*` and `Topology.Algebra.*`).

`norm`, `dist`, and the uniformity are untouched — only the packaging of the topology field changes, in the direction of the canonical instance. The fix works at Lean's default `maxSynthPendingDepth`. It also unblocks smul-continuity resolution in Fréchet-derivative developments over matrix codomains (`HasFDerivAt.const_smul` sites), where the goal's topology argument is the same non-reducing projection.

Motivation: hit in a downstream project (~4300 build jobs of matrix-valued Fréchet calculus) where ten files currently need local high-priority compat instances to work around this. A downstream repair cannot be shipped safely: boosting a repaired `SeminormedAddCommGroup`'s priority steals `‖·‖` resolution from files mixing norm scopes (e.g. `Matrix.Norms.L2Operator` sections of a Davis–Kahan development silently re-resolve to the elementwise norm). The fix has to live in the instance definitions.

Validation: full `lake build Mathlib` passes with the change (8666 jobs), plus new regression tests in `MathlibTest/MatrixNormTopology.lean` (both `rfl` agreements, the `Norm` synthesis above, `‖f‖` usage, `ContinuousConstSMul` unification).

Open questions for reviewers:
- Should the `linftyOp*` family get the same anchor for uniformity of design?
- Is `letI I := fast_instance% …; { I with … }` the preferred spelling here?
- Is the added import acceptable, or should the anchored instances move to a file that already sees `Topology.Instances.Matrix`?

Disclosure: this PR was prepared with AI assistance (Claude); the diagnosis and fix were validated by the full mathlib build and the included regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
