### PR TITLE
fix(CategoryTheory/Monoidal/Cartesian/Over): add more adaptation notes

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Over.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Over.lean
@@ -92,6 +92,8 @@ set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma toUnit_left {R : Over X} : (toUnit R).left = R.hom := rfl
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_hom_left_fst (R S T : Over X) :
@@ -99,6 +101,8 @@ lemma associator_hom_left_fst (R S T : Over X) :
       pullback.fst _ _ ≫ pullback.fst _ _ :=
   limit.lift_π _ _
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_hom_left_snd_fst (R S T : Over X) :
@@ -106,6 +110,8 @@ lemma associator_hom_left_snd_fst (R S T : Over X) :
       pullback.fst _ _ ≫ pullback.snd _ _ :=
   (limit.lift_π_assoc _ _ _).trans (limit.lift_π _ _)
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_hom_left_snd_snd (R S T : Over X) :
@@ -113,6 +119,8 @@ lemma associator_hom_left_snd_snd (R S T : Over X) :
       pullback.snd _ _ :=
   (limit.lift_π_assoc _ _ _).trans (limit.lift_π _ _)
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_inv_left_fst_fst (R S T : Over X) :
@@ -120,6 +128,8 @@ lemma associator_inv_left_fst_fst (R S T : Over X) :
       pullback.fst _ _ :=
   (limit.lift_π_assoc _ _ _).trans (limit.lift_π _ _)
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_inv_left_fst_snd (R S T : Over X) :
@@ -127,6 +137,8 @@ lemma associator_inv_left_fst_snd (R S T : Over X) :
       pullback.snd _ _ ≫ pullback.fst _ _ :=
   (limit.lift_π_assoc _ _ _).trans (limit.lift_π _ _)
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_inv_left_snd (R S T : Over X) :
@@ -139,12 +151,16 @@ set_option backward.isDefEq.respectTransparency.types false in
 lemma leftUnitor_hom_left (Y : Over X) :
     (λ_ Y).hom.left = pullback.snd _ _ := rfl
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma leftUnitor_inv_left_fst (Y : Over X) :
     (λ_ Y).inv.left ≫ pullback.fst (𝟙 X) _ = Y.hom :=
   limit.lift_π _ _
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma leftUnitor_inv_left_snd (Y : Over X) :
@@ -156,6 +172,8 @@ set_option backward.isDefEq.respectTransparency.types false in
 lemma rightUnitor_hom_left (Y : Over X) :
     (ρ_ Y).hom.left = pullback.fst _ (𝟙 X) := rfl
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma rightUnitor_inv_left_fst (Y : Over X) :
@@ -174,12 +192,16 @@ set_option backward.isDefEq.respectTransparency.types false in
 lemma whiskerLeft_left {R S T : Over X} (f : S ⟶ T) :
     (R ◁ f).left = pullback.map _ _ _ _ (𝟙 _) f.left (𝟙 _) (by simp) (by simp) := rfl
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma whiskerLeft_left_fst {R S T : Over X} (f : S ⟶ T) :
     (R ◁ f).left ≫ pullback.fst _ _ = pullback.fst _ _ :=
   (limit.lift_π _ _).trans (Category.comp_id _)
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma whiskerLeft_left_snd {R S T : Over X} (f : S ⟶ T) :
@@ -190,12 +212,16 @@ set_option backward.isDefEq.respectTransparency.types false in
 lemma whiskerRight_left {R S T : Over X} (f : S ⟶ T) :
     (f ▷ R).left = pullback.map _ _ _ _ f.left (𝟙 _) (𝟙 _) (by simp) (by simp) := rfl
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma whiskerRight_left_fst {R S T : Over X} (f : S ⟶ T) :
     (f ▷ R).left ≫ pullback.fst _ _ = pullback.fst _ _ ≫ f.left :=
   limit.lift_π _ _
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma whiskerRight_left_snd {R S T : Over X} (f : S ⟶ T) :
@@ -206,6 +232,8 @@ set_option backward.isDefEq.respectTransparency.types false in
 lemma tensorHom_left {R S T U : Over X} (f : R ⟶ S) (g : T ⟶ U) :
     (f ⊗ₘ g).left = pullback.map _ _ _ _ f.left g.left (𝟙 _) (by simp) (by simp) := rfl
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma tensorHom_left_fst {S U : C} {R T : Over X} (fS : S ⟶ X) (fU : U ⟶ X)
@@ -213,6 +241,8 @@ lemma tensorHom_left_fst {S U : C} {R T : Over X} (fS : S ⟶ X) (fU : U ⟶ X)
     (f ⊗ₘ g).left ≫ pullback.fst fS fU = pullback.fst R.hom T.hom ≫ f.left :=
   limit.lift_π _ _
 
+#adaptation_note
+/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
 set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma tensorHom_left_snd {S U : C} {R T : Over X} (fS : S ⟶ X) (fU : U ⟶ X)


### PR DESCRIPTION
These lemmas all have their `_assoc` generated lemma type signatures change if the associated `set_option` is deleted. Add an `#adaptation_note` so these are not automatically deleted by `rm_set_option.py`.

This is a follow-up to #41837 and [this Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/4.2E33.2E0-rc1.20Multiple.20.60respectTransparency.60-related.20issues/near/611153200).


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
