### PR TITLE
[Merged by Bors] - fix: update `scripts/rm_set_option.py` to ignore more comments

### DIFF
--- a/scripts/rm_set_option.py
+++ b/scripts/rm_set_option.py
@@ -29,6 +29,7 @@ try:
         DEFAULT_OPTIONS,
         PROJECT_DIR,
         commented_pattern,
+        is_annotated,
         lake_build_with_progress,
         lakefile_pattern,
         removable_pattern,
@@ -198,6 +199,8 @@ def scan_files(dag: DAG, options: list[str], value: str = "false") -> dict[str, 
         for i, line in enumerate(lines):
             if any(p.match(line) for p in commented_pats):
                 continue
+            if is_annotated(lines, i):
+                continue
             if any(p.match(line) for p in removable_pats):
                 removable.append(i)
         if removable:
@@ -206,11 +209,15 @@ def scan_files(dag: DAG, options: list[str], value: str = "false") -> dict[str, 
 
 
 def count_skipped(filepath: Path, options: list[str], value: str = "false") -> int:
-    """Count set_option lines with trailing comments."""
+    """Count set_option lines with trailing/preceding comments."""
     commented_pats = [commented_pattern(opt, value) for opt in options]
+    removable_pats = [removable_pattern(opt, value) for opt in options]
+    lines = filepath.read_text().splitlines()
     count = 0
-    for line in filepath.read_text().splitlines():
+    for i, line in enumerate(lines):
         if any(p.match(line) for p in commented_pats):
+            count += 1
+        elif any(p.match(line) for p in removable_pats) and is_annotated(lines, i):
             count += 1
     return count
 

--- a/scripts/set_option_utils.py
+++ b/scripts/set_option_utils.py
@@ -36,7 +36,7 @@ def commented_pattern(option: str, value: str = "false") -> re.Pattern:
 
 def is_annotated(lines: list[str], idx: int) -> bool:
     """Check whether line `idx` is immediately preceded by a `--` comment
-    or by a (possibly multi-line) `/-- ... -/` doc comment.
+    or by a (possibly multi-line) `/-- ... -/` doc comment or `/- ... -/` block comment.
     """
     if idx == 0:
         return False

--- a/scripts/set_option_utils.py
+++ b/scripts/set_option_utils.py
@@ -34,6 +34,20 @@ def commented_pattern(option: str, value: str = "false") -> re.Pattern:
     return re.compile(rf"^\s*set_option {escaped} {escaped_val} in\s+--")
 
 
+def is_annotated(lines: list[str], idx: int) -> bool:
+    """Check whether line `idx` is immediately preceded by a `--` comment
+    or by a (possibly multi-line) `/-- ... -/` doc comment.
+    """
+    if idx == 0:
+        return False
+    prev = lines[idx - 1]
+    if re.search(r"^\s*--", prev):
+        return True
+    if re.search(r"-/\s*$", prev):
+        return True
+    return False
+
+
 def lakefile_pattern(option: str, value: str = "false") -> re.Pattern:
     """Match lakefile entries for an option."""
     escaped = re.escape(option)


### PR DESCRIPTION
Currently `scripts/rm_set_option.py` will ignore any lines that look like `set_option ... in -- COMMENT`; however, the 4.33.0-rc1 bump introduced many `set_option`s that were unsafe to delete as indicated by a preceding `#adaptation_note`/comment.

This PR updates the script to ignore `--` and `/-- ... -/` comments before a set_option. This includes catching `#adaptation_note`s

Related [Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/4.2E33.2E0-rc1.20Multiple.20.60respectTransparency.60-related.20issues/near/611128727)

:robot: Prepared with Claude


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
