### PR TITLE
feat(Integral/Lebesgue): Uniform integrability for ENNReal-valued functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5526,6 +5526,7 @@ public import Mathlib.MeasureTheory.Integral.Lebesgue.Map
 public import Mathlib.MeasureTheory.Integral.Lebesgue.Markov
 public import Mathlib.MeasureTheory.Integral.Lebesgue.Norm
 public import Mathlib.MeasureTheory.Integral.Lebesgue.Sub
+public import Mathlib.MeasureTheory.Integral.Lebesgue.UniformIntegrable
 public import Mathlib.MeasureTheory.Integral.LebesgueNormedSpace
 public import Mathlib.MeasureTheory.Integral.Marginal
 public import Mathlib.MeasureTheory.Integral.MeanInequalities

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -363,6 +363,8 @@ theorem toReal_ofReal_eq_iff {a : ℝ} : (ENNReal.ofReal a).toReal = a ↔ 0 ≤
 
 @[simp] theorem top_ne_zero : ∞ ≠ 0 := top_ne_coe
 
+@[instance] theorem NeZero.top : NeZero ∞ := { out := top_ne_zero }
+
 @[simp, aesop (rule_sets := [finiteness]) safe apply] theorem one_ne_top : 1 ≠ ∞ := coe_ne_top
 
 @[simp] theorem top_ne_one : ∞ ≠ 1 := top_ne_coe

--- a/Mathlib/MeasureTheory/Function/Egorov.lean
+++ b/Mathlib/MeasureTheory/Function/Egorov.lean
@@ -45,7 +45,7 @@ This definition is useful for Egorov's theorem. -/
 def notConvergentSeq [Preorder ι] (f : ι → α → β) (g : α → β) (n : ℕ) (j : ι) : Set α :=
   ⋃ (k) (_ : j ≤ k), { x | (n : ℝ≥0∞)⁻¹ < edist (f k x) (g x) }
 
-variable {n : ℕ} {j : ι} {s : Set α} {ε : ℝ} {f : ι → α → β} {g : α → β}
+variable {n : ℕ} {j : ι} {s : Set α} {ε : ℝ≥0∞} {f : ι → α → β} {g : α → β}
 
 theorem mem_notConvergentSeq_iff [Preorder ι] {x : α} :
     x ∈ notConvergentSeq f g n j ↔ ∃ k ≥ j, (n : ℝ≥0∞)⁻¹ < edist (f k x) (g x) := by
@@ -94,10 +94,10 @@ theorem exists_notConvergentSeq_lt (hε : 0 < ε)
     (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) (n : ℕ) :
-    ∃ j : ι, μ (s ∩ notConvergentSeq f g n j) ≤ ENNReal.ofReal (ε * 2⁻¹ ^ n) := by
+    ∃ j : ι, μ (s ∩ notConvergentSeq f g n j) ≤ (ε * 2⁻¹ ^ n) := by
+  have h : 0 < ε * 2⁻¹ ^ n := ε.mul_pos hε.ne.symm (by simp)
   have ⟨N, hN⟩ := (ENNReal.tendsto_atTop ENNReal.zero_ne_top).1
-    (measure_notConvergentSeq_tendsto_zero hf hsm hs hfg n) (.ofReal (ε * 2⁻¹ ^ n))
-      (by positivity)
+    (measure_notConvergentSeq_tendsto_zero hf hsm hs hfg n) (ε * 2⁻¹ ^ n) h
   rw [zero_add] at hN
   exact ⟨N, (hN N le_rfl).2⟩
 
@@ -117,7 +117,7 @@ theorem notConvergentSeqLTIndex_spec (hε : 0 < ε)
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) (n : ℕ) :
     μ (s ∩ notConvergentSeq f g n (notConvergentSeqLTIndex hε hf hsm hs hfg n)) ≤
-      ENNReal.ofReal (ε * 2⁻¹ ^ n) :=
+      (ε * 2⁻¹ ^ n) :=
   Classical.choose_spec <| exists_notConvergentSeq_lt hε hf hsm hs hfg n
 
 /-- Given some `ε > 0`, `iUnionNotConvergentSeq` is the union of `notConvergentSeq` with
@@ -128,7 +128,7 @@ def iUnionNotConvergentSeq (hε : 0 < ε)
     (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) : Set α :=
-  ⋃ n, s ∩ notConvergentSeq f g n (notConvergentSeqLTIndex (half_pos hε) hf hsm hs hfg n)
+  ⋃ n, s ∩ notConvergentSeq f g n (notConvergentSeqLTIndex (ε.half_pos hε.ne.symm) hf hsm hs hfg n)
 
 theorem iUnionNotConvergentSeq_measurableSet (hε : 0 < ε)
     (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
@@ -141,15 +141,11 @@ theorem measure_iUnionNotConvergentSeq (hε : 0 < ε)
     (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) :
-    μ (iUnionNotConvergentSeq hε hf hsm hs hfg) ≤ ENNReal.ofReal ε := by
-  refine le_trans (measure_iUnion_le _) (le_trans
-    (ENNReal.tsum_le_tsum <| notConvergentSeqLTIndex_spec (half_pos hε) hf hsm hs hfg) ?_)
-  simp_rw [ENNReal.ofReal_mul (half_pos hε).le]
-  rw [ENNReal.tsum_mul_left, ← ENNReal.ofReal_tsum_of_nonneg, inv_eq_one_div, tsum_geometric_two,
-    ← ENNReal.ofReal_mul (half_pos hε).le, div_mul_cancel₀ ε two_ne_zero]
-  · intro n; positivity
-  · rw [inv_eq_one_div]
-    exact summable_geometric_two
+    μ (iUnionNotConvergentSeq hε hf hsm hs hfg) ≤ ε := by
+  refine (measure_iUnion_le _).trans (le_trans
+    (ENNReal.tsum_le_tsum <| notConvergentSeqLTIndex_spec (ε.half_pos hε.ne.symm) hf hsm hs hfg) ?_)
+  rw [ENNReal.tsum_mul_left, ENNReal.tsum_geometric_two, mul_comm]
+  exact ENNReal.mul_div_le
 
 theorem iUnionNotConvergentSeq_subset (hε : 0 < ε)
     (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
@@ -193,8 +189,8 @@ an arbitrarily small set. -/
 theorem tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist
     (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
-    (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ} (hε : 0 < ε) :
-    ∃ t ⊆ s, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop (s \ t) :=
+    (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ t ⊆ s, MeasurableSet t ∧ μ t ≤ ε ∧ TendstoUniformlyOn f g atTop (s \ t) :=
   ⟨Egorov.iUnionNotConvergentSeq hε hf hsm hs hfg,
     Egorov.iUnionNotConvergentSeq_subset hε hf hsm hs hfg,
     Egorov.iUnionNotConvergentSeq_measurableSet hε hf hsm hs hfg,
@@ -219,8 +215,8 @@ theorem tendstoUniformlyOn_of_ae_tendsto (hf : ∀ n, StronglyMeasurable (f n))
 Version with measurable distances. -/
 theorem tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist' [IsFiniteMeasure μ]
     (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
-    (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ} (hε : 0 < ε) :
-    ∃ t, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop tᶜ := by
+    (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ t, MeasurableSet t ∧ μ t ≤ ε ∧ TendstoUniformlyOn f g atTop tᶜ := by
   have ⟨t, _, ht, htendsto⟩ :=
     tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist hf MeasurableSet.univ
     (measure_ne_top μ Set.univ) (by filter_upwards [hfg] with _ htendsto _ using htendsto) hε
@@ -229,9 +225,9 @@ theorem tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist' [IsFiniteMeasure �
 
 /-- Egorov's theorem for finite measure spaces. -/
 theorem tendstoUniformlyOn_of_ae_tendsto' [IsFiniteMeasure μ] (hf : ∀ n, StronglyMeasurable (f n))
-    (hg : StronglyMeasurable g) (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ}
-    (hε : 0 < ε) :
-    ∃ t, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop tᶜ :=
+    (hg : StronglyMeasurable g) (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x)))
+    {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ t, MeasurableSet t ∧ μ t ≤ ε ∧ TendstoUniformlyOn f g atTop tᶜ :=
   tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist' (fun n ↦ ((hf n).edist hg).measurable)
     hfg hε
 

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -48,13 +48,14 @@ uniformly integrable, uniformly absolutely continuous integral, Vitali convergen
 
 noncomputable section
 
-open scoped MeasureTheory NNReal ENNReal Topology
+open scoped ENNReal MeasureTheory NNReal Topology
 
 namespace MeasureTheory
 
-open Set Filter TopologicalSpace
+open Filter TopologicalSpace Set
 
 variable {α β ι : Type*} {m : MeasurableSpace α} {μ : Measure α} [NormedAddCommGroup β]
+  {f g : ι → α → β} {p : ℝ≥0∞}
 
 /-- Uniform integrability in the measure theory sense.
 
@@ -64,8 +65,9 @@ restricted to `s` is less than `ε`.
 
 Uniform integrability is also known as uniformly absolutely continuous integrals. -/
 def UnifIntegrable {_ : MeasurableSpace α} (f : ι → α → β) (p : ℝ≥0∞) (μ : Measure α) : Prop :=
-  ∀ ⦃ε : ℝ⦄ (_ : 0 < ε), ∃ (δ : ℝ) (_ : 0 < δ), ∀ i s,
-    MeasurableSet s → μ s ≤ ENNReal.ofReal δ → eLpNorm (s.indicator (f i)) p μ ≤ ENNReal.ofReal ε
+  Tendsto (fun ε ↦ ⨆ (i : ι) (s : Set α) (_ : μ s ≤ ε), eLpNorm (s.indicator (f i)) p μ) (𝓝 0) (𝓝 0)
+ -- ∀ ⦃ε : ℝ⦄ (_ : 0 < ε), ∃ (δ : ℝ) (_ : 0 < δ), ∀ i s,
+  --  MeasurableSet s → μ s ≤ ENNReal.ofReal δ → eLpNorm (s.indicator (f i)) p μ ≤ ENNReal.ofReal ε
 
 /-- In probability theory, a family of measurable functions is uniformly integrable if it is
 uniformly integrable in the measure theory sense and is uniformly bounded. -/
@@ -74,15 +76,15 @@ def UniformIntegrable {_ : MeasurableSpace α} (f : ι → α → β) (p : ℝ�
 
 namespace UniformIntegrable
 
-protected theorem aestronglyMeasurable {f : ι → α → β} {p : ℝ≥0∞} (hf : UniformIntegrable f p μ)
-    (i : ι) : AEStronglyMeasurable (f i) μ :=
+protected theorem aestronglyMeasurable (hf : UniformIntegrable f p μ) (i : ι) :
+    AEStronglyMeasurable (f i) μ :=
   hf.1 i
 
-protected theorem unifIntegrable {f : ι → α → β} {p : ℝ≥0∞} (hf : UniformIntegrable f p μ) :
+protected theorem unifIntegrable (hf : UniformIntegrable f p μ) :
     UnifIntegrable f p μ :=
   hf.2.1
 
-protected theorem memLp {f : ι → α → β} {p : ℝ≥0∞} (hf : UniformIntegrable f p μ) (i : ι) :
+protected theorem memLp (hf : UniformIntegrable f p μ) (i : ι) :
     MemLp (f i) p μ :=
   ⟨hf.1 i,
     let ⟨_, _, hC⟩ := hf.2
@@ -99,23 +101,36 @@ This section deals with uniform integrability in the measure theory sense. -/
 
 namespace UnifIntegrable
 
-variable {f g : ι → α → β} {p : ℝ≥0∞}
+-- Put in Mathlib.MeasureTheory.Function.LpSeminorm.Indicator
+theorem _root_.MeasureTheory.eLpnorm_indicator_mono_set {α ε : Type*} {m : MeasurableSpace α}
+    {p : ℝ≥0∞} {μ : Measure α} [TopologicalSpace ε] [ESeminormedAddMonoid ε] {s t : Set α}
+    {f : α → ε} (h : s ⊆ t) :
+    eLpNorm (s.indicator f) p μ ≤ eLpNorm (t.indicator f) p μ :=
+  eLpNorm_mono_enorm_ae (Eventually.of_forall fun x ↦ enorm_indicator_le_of_subset h f x)
+
+protected theorem mk :
+    UnifIntegrable f p μ ↔ Tendsto (fun ε ↦ ⨆ (i : ι) (s : Set α) (_ : MeasurableSet s)
+      (_ : μ s ≤ ε), eLpNorm (s.indicator (f i)) p μ) (𝓝 0) (𝓝 0) := by
+  rw [UnifIntegrable, iff_iff_eq]; congr 2; ext ε
+  refine iSup_congr fun i ↦ le_antisymm (iSup₂_le fun s hsμ ↦ ?_) (iSup_mono fun s ↦ by simp)
+  obtain ⟨t, hst, ht, htμ⟩ := exists_measurable_superset μ s
+  rw [← htμ] at hsμ
+  apply (le_iSup _ t).trans'
+  apply (le_iSup _ ht).trans'
+  apply (le_iSup _ hsμ).trans'
+  exact eLpnorm_indicator_mono_set hst
 
 protected theorem add (hf : UnifIntegrable f p μ) (hg : UnifIntegrable g p μ) (hp : 1 ≤ p)
     (hf_meas : ∀ i, AEStronglyMeasurable (f i) μ) (hg_meas : ∀ i, AEStronglyMeasurable (g i) μ) :
     UnifIntegrable (f + g) p μ := by
-  intro ε hε
-  have hε2 : 0 < ε / 2 := half_pos hε
-  obtain ⟨δ₁, hδ₁_pos, hfδ₁⟩ := hf hε2
-  obtain ⟨δ₂, hδ₂_pos, hgδ₂⟩ := hg hε2
-  refine ⟨min δ₁ δ₂, lt_min hδ₁_pos hδ₂_pos, fun i s hs hμs => ?_⟩
-  simp_rw [Pi.add_apply, Set.indicator_add']
-  refine (eLpNorm_add_le ((hf_meas i).indicator hs) ((hg_meas i).indicator hs) hp).trans ?_
-  have hε_halves : ENNReal.ofReal ε = ENNReal.ofReal (ε / 2) + ENNReal.ofReal (ε / 2) := by
-    rw [← ENNReal.ofReal_add hε2.le hε2.le, add_halves]
-  rw [hε_halves]
-  exact add_le_add (hfδ₁ i s hs (hμs.trans (ENNReal.ofReal_le_ofReal (min_le_left _ _))))
-    (hgδ₂ i s hs (hμs.trans (ENNReal.ofReal_le_ofReal (min_le_right _ _))))
+  rw [UnifIntegrable.mk]
+  refine ENNReal.tendsto_nhds_zero.2 fun ε hε ↦ ?_
+  filter_upwards [ENNReal.tendsto_nhds_zero.1 hf (ε / 2) (ε.half_pos hε.ne.symm),
+    ENNReal.tendsto_nhds_zero.1 hg (ε / 2) (ε.half_pos hε.ne.symm)] with δ hδf hδg
+  simp only [iSup_le_iff, Pi.add_apply, indicator_add'] at hδf hδg ⊢
+  intro i s hs hsμ
+  apply (eLpNorm_add_le ((hf_meas i).indicator hs) ((hg_meas i).indicator hs) hp).trans
+  exact (add_le_add (hδf i s hsμ) (hδg i s hsμ)).trans_eq ε.add_halves
 
 protected theorem neg (hf : UnifIntegrable f p μ) : UnifIntegrable (-f) p μ := by
   simp_rw [UnifIntegrable, Pi.neg_apply, Set.indicator_neg', eLpNorm_neg]
@@ -127,51 +142,57 @@ protected theorem sub (hf : UnifIntegrable f p μ) (hg : UnifIntegrable g p μ) 
   rw [sub_eq_add_neg]
   exact hf.add hg.neg hp hf_meas fun i => (hg_meas i).neg
 
-protected theorem ae_eq (hf : UnifIntegrable f p μ) (hfg : ∀ n, f n =ᵐ[μ] g n) :
+protected theorem ae_mono (hg : UnifIntegrable g p μ) (hfg : ∀ i, (‖f i ·‖ₑ) ≤ᵐ[μ] (‖g i ·‖ₑ)) :
+    UnifIntegrable f p μ := by
+  refine tendsto_nhds_bot_mono hg (Eventually.of_forall fun ε ↦ ?_)
+  apply iSup_mono fun i ↦ iSup_mono fun s ↦ iSup_mono fun _ ↦  eLpNorm_mono_enorm_ae ?_
+  filter_upwards [hfg i] with x hx
+  simp only [enorm_indicator_eq_indicator_enorm]
+  exact indicator_le_indicator hx
+
+protected theorem ae_eq (hf : UnifIntegrable f p μ) (hfg : ∀ i, f i =ᵐ[μ] g i) :
     UnifIntegrable g p μ := by
-  classical
-  intro ε hε
-  obtain ⟨δ, hδ_pos, hfδ⟩ := hf hε
-  refine ⟨δ, hδ_pos, fun n s hs hμs => (le_of_eq <| eLpNorm_congr_ae ?_).trans (hfδ n s hs hμs)⟩
-  filter_upwards [hfg n] with x hx
-  simp_rw [Set.indicator_apply, hx]
+  apply hf.ae_mono fun i ↦ ?_
+  filter_upwards [hfg i] with x hx
+  rw [hx]
 
 /-- Uniform integrability is preserved by restriction of the functions to a set. -/
-protected theorem indicator (hf : UnifIntegrable f p μ) (E : Set α) :
-    UnifIntegrable (fun i => E.indicator (f i)) p μ := fun ε hε ↦ by
-  obtain ⟨δ, hδ_pos, hε⟩ := hf hε
-  refine ⟨δ, hδ_pos, fun i s hs hμs ↦ ?_⟩
-  calc
-    eLpNorm (s.indicator (E.indicator (f i))) p μ
-      = eLpNorm (E.indicator (s.indicator (f i))) p μ := by
-      simp only [indicator_indicator, inter_comm]
-    _ ≤ eLpNorm (s.indicator (f i)) p μ := eLpNorm_indicator_le _
-    _ ≤ ENNReal.ofReal ε := hε _ _ hs hμs
+protected theorem indicator (hf : UnifIntegrable f p μ) (s : Set α) :
+    UnifIntegrable (fun i ↦ s.indicator (f i)) p μ := by
+  apply hf.ae_mono fun i ↦ Eventually.of_forall fun x ↦ ?_
+  simp only [enorm_indicator_eq_indicator_enorm]
+  exact indicator_enorm_le_enorm_self (f i) x
 
 /-- Uniform integrability is preserved by restriction of the measure to a set. -/
-protected theorem restrict (hf : UnifIntegrable f p μ) (E : Set α) :
-    UnifIntegrable f p (μ.restrict E) := fun ε hε ↦ by
-  obtain ⟨δ, hδ_pos, hδε⟩ := hf hε
-  refine ⟨δ, hδ_pos, fun i s hs hμs ↦ ?_⟩
-  rw [μ.restrict_apply hs, ← measure_toMeasurable] at hμs
-  calc
-    eLpNorm (indicator s (f i)) p (μ.restrict E) = eLpNorm (f i) p (μ.restrict (s ∩ E)) := by
-      rw [eLpNorm_indicator_eq_eLpNorm_restrict hs, μ.restrict_restrict hs]
-    _ ≤ eLpNorm (f i) p (μ.restrict (toMeasurable μ (s ∩ E))) :=
-      eLpNorm_mono_measure _ <| Measure.restrict_mono (subset_toMeasurable _ _) le_rfl
-    _ = eLpNorm (indicator (toMeasurable μ (s ∩ E)) (f i)) p μ :=
-      (eLpNorm_indicator_eq_eLpNorm_restrict (measurableSet_toMeasurable _ _)).symm
-    _ ≤ ENNReal.ofReal ε := hδε i _ (measurableSet_toMeasurable _ _) hμs
+protected theorem restrict (hf : UnifIntegrable f p μ) (s : Set α) :
+    UnifIntegrable f p (μ.restrict s) := by
+  rw [UnifIntegrable.mk]
+  apply tendsto_nhds_bot_mono hf (ENNReal.nhds_zero_basis.eventually_iff.2 ?_)
+  refine ⟨∞, ENNReal.zero_lt_top, fun ε hε ↦ iSup_mono fun i ↦ ?_⟩
+  simp only [iSup_le_iff]
+  intro t ht htμ
+  rw [Measure.restrict_apply ht] at htμ
+  have htμ' : μ (toMeasurable μ (t ∩ s)) ≤ ε := by rwa [measure_toMeasurable]
+  apply (le_iSup _ (toMeasurable μ (t ∩ s))).trans'
+  apply (le_iSup _ htμ').trans_eq'
+  rw [eLpNorm_indicator_eq_eLpNorm_restrict ht, μ.restrict_restrict ht,
+    eLpNorm_indicator_eq_eLpNorm_restrict (measurableSet_toMeasurable _ _)]
+  congr 1
+  exact μ.restrict_toMeasurable (htμ.trans_lt (mem_Iio.1 hε)).ne
 
 end UnifIntegrable
 
-theorem unifIntegrable_zero_meas [MeasurableSpace α] {p : ℝ≥0∞} {f : ι → α → β} :
-    UnifIntegrable f p (0 : Measure α) :=
-  fun ε _ => ⟨1, one_pos, fun i s _ _ => by simp⟩
 
-theorem unifIntegrable_congr_ae {p : ℝ≥0∞} {f g : ι → α → β} (hfg : ∀ n, f n =ᵐ[μ] g n) :
+
+theorem unifIntegrable_congr_ae (hfg : ∀ i, f i =ᵐ[μ] g i) :
     UnifIntegrable f p μ ↔ UnifIntegrable g p μ :=
-  ⟨fun hf => hf.ae_eq hfg, fun hg => hg.ae_eq fun n => (hfg n).symm⟩
+  ⟨fun hf ↦ hf.ae_eq hfg, fun hg ↦ hg.ae_eq fun n => (hfg n).symm⟩
+
+theorem unifIntegrable_empty [IsEmpty ι] : UnifIntegrable f p μ := by simp [UnifIntegrable]
+
+theorem unifIntegrable_zero_meas [MeasurableSpace α] {p : ℝ≥0∞} {f : ι → α → β} :
+    UnifIntegrable f p (0 : Measure α) := by
+  simp [UnifIntegrable]
 
 theorem tendsto_indicator_ge (f : α → β) (x : α) :
     Tendsto (fun M : ℕ => { x | (M : ℝ) ≤ ‖f x‖₊ }.indicator f x) atTop (𝓝 0) := by
@@ -191,8 +212,8 @@ variable {f : α → β}
 /-- This lemma is weaker than `MeasureTheory.MemLp.integral_indicator_norm_ge_nonneg_le`
 as the latter provides `0 ≤ M` and does not require the measurability of `f`. -/
 theorem MemLp.integral_indicator_norm_ge_le (hf : MemLp f 1 μ) (hmeas : StronglyMeasurable f)
-    {ε : ℝ} (hε : 0 < ε) :
-    ∃ M : ℝ, (∫⁻ x, ‖{ x | M ≤ ‖f x‖₊ }.indicator f x‖₊ ∂μ) ≤ ENNReal.ofReal ε := by
+    {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ M : ℝ, (∫⁻ x, ‖{ x | M ≤ ‖f x‖₊ }.indicator f x‖₊ ∂μ) ≤ ε := by
   have htendsto :
       ∀ᵐ x ∂μ, Tendsto (fun M : ℕ => { x | (M : ℝ) ≤ ‖f x‖₊ }.indicator f x) atTop (𝓝 0) :=
     univ_mem' (id fun x => tendsto_indicator_ge f x)
@@ -207,16 +228,9 @@ theorem MemLp.integral_indicator_norm_ge_le (hf : MemLp f 1 μ) (hmeas : Strongl
   have : Tendsto (fun n : ℕ ↦ ∫⁻ a, ENNReal.ofReal ‖{ x | n ≤ ‖f x‖₊ }.indicator f a - 0‖ ∂μ)
       atTop (𝓝 0) := by
     refine tendsto_lintegral_norm_of_dominated_convergence hmeas hbound ?_ htendsto
-    refine fun n => univ_mem' (id fun x => ?_)
-    by_cases hx : (n : ℝ) ≤ ‖f x‖
-    · dsimp
-      rwa [Set.indicator_of_mem]
-    · dsimp
-      rw [Set.indicator_of_notMem, norm_zero]
-      · exact norm_nonneg _
-      · assumption
+    exact fun n ↦ Eventually.of_forall (fun x ↦ norm_indicator_le_norm_self f x)
   rw [ENNReal.tendsto_atTop_zero] at this
-  obtain ⟨M, hM⟩ := this (ENNReal.ofReal ε) (ENNReal.ofReal_pos.2 hε)
+  obtain ⟨M, hM⟩ := this ε hε
   simp only [sub_zero] at hM
   refine ⟨M, ?_⟩
   convert! hM M le_rfl
@@ -226,13 +240,13 @@ theorem MemLp.integral_indicator_norm_ge_le (hf : MemLp f 1 μ) (hmeas : Strongl
 /-- This lemma is superseded by `MeasureTheory.MemLp.integral_indicator_norm_ge_nonneg_le`
 which does not require measurability. -/
 theorem MemLp.integral_indicator_norm_ge_nonneg_le_of_meas (hf : MemLp f 1 μ)
-    (hmeas : StronglyMeasurable f) {ε : ℝ} (hε : 0 < ε) :
-    ∃ M : ℝ, 0 ≤ M ∧ (∫⁻ x, ‖{ x | M ≤ ‖f x‖₊ }.indicator f x‖ₑ ∂μ) ≤ ENNReal.ofReal ε :=
+    (hmeas : StronglyMeasurable f) {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ M : ℝ, 0 ≤ M ∧ (∫⁻ x, ‖{ x | M ≤ ‖f x‖₊ }.indicator f x‖ₑ ∂μ) ≤ ε :=
   let ⟨M, hM⟩ := hf.integral_indicator_norm_ge_le hmeas hε
   ⟨max M 0, le_max_right _ _, by simpa⟩
 
-theorem MemLp.integral_indicator_norm_ge_nonneg_le (hf : MemLp f 1 μ) {ε : ℝ} (hε : 0 < ε) :
-    ∃ M : ℝ, 0 ≤ M ∧ (∫⁻ x, ‖{ x | M ≤ ‖f x‖₊ }.indicator f x‖ₑ ∂μ) ≤ ENNReal.ofReal ε := by
+theorem MemLp.integral_indicator_norm_ge_nonneg_le (hf : MemLp f 1 μ) {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ M : ℝ, 0 ≤ M ∧ (∫⁻ x, ‖{ x | M ≤ ‖f x‖₊ }.indicator f x‖ₑ ∂μ) ≤ ε := by
   have hf_mk : MemLp (hf.1.mk f) 1 μ := (memLp_congr_ae hf.1.ae_eq_mk).mp hf
   obtain ⟨M, hM_pos, hfM⟩ :=
     hf_mk.integral_indicator_norm_ge_nonneg_le_of_meas hf.1.stronglyMeasurable_mk hε
@@ -255,7 +269,7 @@ theorem MemLp.eLpNormEssSup_indicator_norm_ge_eq_zero (hf : MemLp f ∞ μ)
         rw [Set.mem_ofPred_eq, ← ENNReal.toReal_lt_toReal hbdd.ne ENNReal.coe_lt_top.ne,
           ENNReal.coe_toReal, coe_nnnorm]
         refine lt_of_lt_of_le ?_ hx
-        rw [ENNReal.toReal_lt_toReal hbdd.ne]
+        rw [ENNReal.toReal_lt_toReal hbdd.ne _]
         · exact ENNReal.lt_add_right hbdd.ne one_ne_zero
         · finiteness
       rw [← nonpos_iff_eq_zero]
@@ -268,44 +282,42 @@ theorem MemLp.eLpNormEssSup_indicator_norm_ge_eq_zero (hf : MemLp f ∞ μ)
 
 /-- This lemma is slightly weaker than `MeasureTheory.MemLp.eLpNorm_indicator_norm_ge_pos_le` as the
 latter provides `0 < M`. -/
-theorem MemLp.eLpNorm_indicator_norm_ge_le (hf : MemLp f p μ) (hmeas : StronglyMeasurable f) {ε : ℝ}
-    (hε : 0 < ε) : ∃ M : ℝ, eLpNorm ({ x | M ≤ ‖f x‖₊ }.indicator f) p μ ≤ ENNReal.ofReal ε := by
+theorem MemLp.eLpNorm_indicator_norm_ge_le (hf : MemLp f p μ) (hmeas : StronglyMeasurable f)
+    {ε : ℝ≥0∞} (hε : 0 < ε) : ∃ M : ℝ, eLpNorm ({ x | M ≤ ‖f x‖₊ }.indicator f) p μ ≤ ε := by
   by_cases hp_ne_zero : p = 0
   · exact ⟨1, by simp [hp_ne_zero]⟩
-  by_cases hp_ne_top : p = ∞
-  · subst hp_ne_top
-    obtain ⟨M, hM⟩ := hf.eLpNormEssSup_indicator_norm_ge_eq_zero hmeas
+  rcases eq_top_or_lt_top p with rfl | hp_top
+  · obtain ⟨M, hM⟩ := hf.eLpNormEssSup_indicator_norm_ge_eq_zero hmeas
     refine ⟨M, ?_⟩
     simp only [eLpNorm_exponent_top, hM, zero_le]
   obtain ⟨M, hM', hM⟩ := MemLp.integral_indicator_norm_ge_nonneg_le
-    (μ := μ) (hf.norm_rpow hp_ne_zero hp_ne_top) (Real.rpow_pos_of_pos hε p.toReal)
+    (μ := μ) (hf.norm_rpow hp_ne_zero hp_top.ne) (ENNReal.rpow_pos_of_nonneg hε p.toReal_nonneg)
   refine ⟨M ^ (1 / p.toReal), ?_⟩
-  rw [eLpNorm_eq_lintegral_rpow_enorm_toReal hp_ne_zero hp_ne_top, ← ENNReal.rpow_one (.ofReal ε)]
-  conv_rhs => rw [← mul_one_div_cancel (ENNReal.toReal_pos hp_ne_zero hp_ne_top).ne.symm]
+  rw [eLpNorm_eq_lintegral_rpow_enorm_toReal hp_ne_zero hp_top.ne, ← ε.rpow_one]
+  conv_rhs => rw [← mul_one_div_cancel (ENNReal.toReal_pos hp_ne_zero hp_top.ne).ne.symm]
   rw [ENNReal.rpow_mul]
   gcongr
-  rw [ENNReal.ofReal_rpow_of_pos hε]
   convert! hM using 3 with x
   rw [enorm_indicator_eq_indicator_enorm, enorm_indicator_eq_indicator_enorm]
   have hiff : M ^ (1 / p.toReal) ≤ ‖f x‖₊ ↔ M ≤ ‖‖f x‖ ^ p.toReal‖₊ := by
     rw [coe_nnnorm, coe_nnnorm, Real.norm_rpow_of_nonneg (norm_nonneg _), norm_norm,
       ← Real.rpow_le_rpow_iff hM' (by positivity)
-        (one_div_pos.2 <| ENNReal.toReal_pos hp_ne_zero hp_ne_top), ← Real.rpow_mul (norm_nonneg _),
-      mul_one_div_cancel (ENNReal.toReal_pos hp_ne_zero hp_ne_top).ne.symm, Real.rpow_one]
+        (one_div_pos.2 <| ENNReal.toReal_pos hp_ne_zero hp_top.ne), ← Real.rpow_mul (norm_nonneg _),
+      mul_one_div_cancel (ENNReal.toReal_pos hp_ne_zero hp_top.ne).ne.symm, Real.rpow_one]
   by_cases hx : x ∈ { x : α | M ^ (1 / p.toReal) ≤ ‖f x‖₊ }
-  · rw [Set.indicator_of_mem hx, Set.indicator_of_mem, Real.enorm_of_nonneg (by positivity),
+  · rw [indicator_of_mem hx, indicator_of_mem, Real.enorm_of_nonneg (by positivity),
       ← ENNReal.ofReal_rpow_of_nonneg (norm_nonneg _) ENNReal.toReal_nonneg, ofReal_norm]
-    rw [Set.mem_ofPred_eq]
-    rwa [← hiff]
+    rw [Set.mem_ofPred_eq] at hx ⊢
+    exact hiff.1 hx
   · rw [Set.indicator_of_notMem hx, Set.indicator_of_notMem]
-    · simp [ENNReal.toReal_pos hp_ne_zero hp_ne_top]
+    · simp [ENNReal.toReal_pos hp_ne_zero hp_top.ne]
     · rw [Set.mem_ofPred_eq]
       rwa [← hiff]
 
 /-- This lemma implies that a single function is uniformly integrable (in the probability sense). -/
 theorem MemLp.eLpNorm_indicator_norm_ge_pos_le (hf : MemLp f p μ) (hmeas : StronglyMeasurable f)
-    {ε : ℝ} (hε : 0 < ε) :
-    ∃ M : ℝ, 0 < M ∧ eLpNorm ({ x | M ≤ ‖f x‖₊ }.indicator f) p μ ≤ ENNReal.ofReal ε := by
+    {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ M : ℝ, 0 < M ∧ eLpNorm ({ x | M ≤ ‖f x‖₊ }.indicator f) p μ ≤ ε := by
   obtain ⟨M, hM⟩ := hf.eLpNorm_indicator_norm_ge_le hmeas hε
   refine
     ⟨max M 1, lt_of_lt_of_le zero_lt_one (le_max_right _ _), le_trans (eLpNorm_mono fun x => ?_) hM⟩
@@ -314,10 +326,9 @@ theorem MemLp.eLpNorm_indicator_norm_ge_pos_le (hf : MemLp f p μ) (hmeas : Stro
 
 end
 
-theorem eLpNorm_indicator_le_of_bound {f : α → β} (hp_top : p ≠ ∞) {ε : ℝ} (hε : 0 < ε) {M : ℝ}
+theorem eLpNorm_indicator_le_of_bound {f : α → β} (hp_top : p ≠ ∞) {ε : ℝ≥0∞} (hε : 0 < ε) {M : ℝ}
     (hf : ∀ x, ‖f x‖ < M) :
-    ∃ (δ : ℝ) (_ : 0 < δ), ∀ s, MeasurableSet s →
-      μ s ≤ ENNReal.ofReal δ → eLpNorm (s.indicator f) p μ ≤ ENNReal.ofReal ε := by
+    ∃ δ > 0, ∀ s, MeasurableSet s → μ s ≤ δ → eLpNorm (s.indicator f) p μ ≤ ε := by
   by_cases! hM : M ≤ 0
   · refine ⟨1, zero_lt_one, fun s _ _ => ?_⟩
     rw [(_ : f = 0)]
@@ -325,21 +336,17 @@ theorem eLpNorm_indicator_le_of_bound {f : α → β} (hp_top : p ≠ ∞) {ε :
     · ext x
       rw [Pi.zero_apply, ← norm_le_zero_iff]
       exact (lt_of_lt_of_le (hf x) hM).le
-  refine ⟨(ε / M) ^ p.toReal, Real.rpow_pos_of_pos (div_pos hε hM) _, fun s hs hμ => ?_⟩
+  refine ⟨(ε / .ofReal M) ^ p.toReal,
+    (ENNReal.rpow_pos_of_nonneg (ε.div_pos hε.ne.symm ENNReal.coe_ne_top) p.toReal_nonneg),
+    fun s hs hμ ↦ ?_⟩
   by_cases hp : p = 0
   · simp [hp]
   rw [eLpNorm_indicator_eq_eLpNorm_restrict hs]
-  have haebdd : ∀ᵐ x ∂μ.restrict s, ‖f x‖ ≤ M := by
-    filter_upwards
-    exact fun x => (hf x).le
-  refine le_trans (eLpNorm_le_of_ae_bound haebdd) ?_
+  have haebdd : ∀ᵐ x ∂μ.restrict s, ‖f x‖ ≤ M := Eventually.of_forall fun x ↦ (hf x).le
+  refine (eLpNorm_le_of_ae_bound haebdd).trans ?_
   rw [Measure.restrict_apply MeasurableSet.univ, Set.univ_inter,
-    ← ENNReal.le_div_iff_mul_le (Or.inl _) (Or.inl ENNReal.ofReal_ne_top)]
-  · rw [ENNReal.rpow_inv_le_iff (ENNReal.toReal_pos hp hp_top)]
-    refine le_trans hμ ?_
-    rw [← ENNReal.ofReal_rpow_of_pos (div_pos hε hM)]
-    gcongr
-    rw [ENNReal.ofReal_div_of_pos hM]
+    ← ENNReal.le_div_iff_mul_le (Or.inl _) (.inl ENNReal.ofReal_ne_top)]
+  · rwa [ENNReal.rpow_inv_le_iff (ENNReal.toReal_pos hp hp_top)]
   · simpa only [ENNReal.ofReal_eq_zero, not_le, Ne]
 
 section
@@ -348,9 +355,8 @@ variable {f : α → β}
 
 /-- Auxiliary lemma for `MeasureTheory.MemLp.eLpNorm_indicator_le`. -/
 theorem MemLp.eLpNorm_indicator_le' (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) (hf : MemLp f p μ)
-    (hmeas : StronglyMeasurable f) {ε : ℝ} (hε : 0 < ε) :
-    ∃ (δ : ℝ) (_ : 0 < δ), ∀ s, MeasurableSet s → μ s ≤ ENNReal.ofReal δ →
-      eLpNorm (s.indicator f) p μ ≤ 2 * ENNReal.ofReal ε := by
+    (hmeas : StronglyMeasurable f) {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ δ > 0, ∀ s, MeasurableSet s → μ s ≤ δ → eLpNorm (s.indicator f) p μ ≤ 2 * ε := by
   obtain ⟨M, hMpos, hM⟩ := hf.eLpNorm_indicator_norm_ge_pos_le hmeas hε
   obtain ⟨δ, hδpos, hδ⟩ :=
     eLpNorm_indicator_le_of_bound (f := { x | ‖f x‖ < M }.indicator f) hp_top hε (by
@@ -379,76 +385,60 @@ theorem MemLp.eLpNorm_indicator_le' (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) (hf 
 /-- This lemma is superseded by `MeasureTheory.MemLp.eLpNorm_indicator_le` which does not require
 measurability on `f`. -/
 theorem MemLp.eLpNorm_indicator_le_of_meas (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) (hf : MemLp f p μ)
-    (hmeas : StronglyMeasurable f) {ε : ℝ} (hε : 0 < ε) :
-    ∃ (δ : ℝ) (_ : 0 < δ), ∀ s, MeasurableSet s → μ s ≤ ENNReal.ofReal δ →
-      eLpNorm (s.indicator f) p μ ≤ ENNReal.ofReal ε := by
-  obtain ⟨δ, hδpos, hδ⟩ := hf.eLpNorm_indicator_le' hp_one hp_top hmeas (half_pos hε)
-  refine ⟨δ, hδpos, fun s hs hμs => le_trans (hδ s hs hμs) ?_⟩
-  rw [ENNReal.ofReal_div_of_pos zero_lt_two, (by simp : ENNReal.ofReal 2 = 2),
-      ENNReal.mul_div_cancel] <;>
-    norm_num
+    (hmeas : StronglyMeasurable f) {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ δ > 0, ∀ s, MeasurableSet s → μ s ≤ δ → eLpNorm (s.indicator f) p μ ≤ ε := by
+  obtain ⟨δ, hδpos, hδ⟩ := hf.eLpNorm_indicator_le' hp_one hp_top hmeas (ε.half_pos hε.ne.symm)
+  exact ⟨δ, hδpos, fun s hs hμs ↦ (hδ s hs hμs).trans ENNReal.mul_div_le⟩
 
-theorem MemLp.eLpNorm_indicator_le (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) (hf : MemLp f p μ) {ε : ℝ}
+theorem MemLp.eLpNorm_indicator_le (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) (hf : MemLp f p μ) {ε : ℝ≥0∞}
     (hε : 0 < ε) :
-    ∃ (δ : ℝ) (_ : 0 < δ), ∀ s, MeasurableSet s → μ s ≤ ENNReal.ofReal δ →
-      eLpNorm (s.indicator f) p μ ≤ ENNReal.ofReal ε := by
+    ∃ δ > 0, ∀ s, MeasurableSet s → μ s ≤ δ → eLpNorm (s.indicator f) p μ ≤ ε := by
   have hℒp := hf
   obtain ⟨⟨f', hf', heq⟩, _⟩ := hf
   obtain ⟨δ, hδpos, hδ⟩ := (hℒp.ae_eq heq).eLpNorm_indicator_le_of_meas hp_one hp_top hf' hε
-  refine ⟨δ, hδpos, fun s hs hμs => ?_⟩
+  refine ⟨δ, hδpos, fun s hs hμs ↦ ?_⟩
   convert! hδ s hs hμs using 1
   rw [eLpNorm_indicator_eq_eLpNorm_restrict hs, eLpNorm_indicator_eq_eLpNorm_restrict hs]
   exact eLpNorm_congr_ae heq.restrict
 
+theorem MemLp.tendsto_eLpNorm_indicator_zero (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) (hf : MemLp f p μ) :
+    Tendsto (fun ε ↦ ⨆ (s : Set α) (_ : MeasurableSet s) (_ : μ s ≤ ε),
+      eLpNorm (s.indicator f) p μ) (𝓝 0) (𝓝 0) := by
+  refine ENNReal.tendsto_nhds_zero.2 fun ε hε ↦ ENNReal.nhds_zero_basis.eventually_iff.2 ?_
+  obtain ⟨δ, hδ, hδf⟩ := hf.eLpNorm_indicator_le hp_one hp_top hε
+  simp only [mem_Iio, iSup_le_iff]
+  exact ⟨δ, hδ, fun a ha s hs hsμ ↦ hδf s hs (hsμ.trans ha.le)⟩
+
 /-- A constant function is uniformly integrable. -/
-theorem unifIntegrable_const {g : α → β} (hp : 1 ≤ p) (hp_ne_top : p ≠ ∞) (hg : MemLp g p μ) :
-    UnifIntegrable (fun _ : ι => g) p μ := by
-  intro ε hε
-  obtain ⟨δ, hδ_pos, hgδ⟩ := hg.eLpNorm_indicator_le hp hp_ne_top hε
-  exact ⟨δ, hδ_pos, fun _ => hgδ⟩
+theorem unifIntegrable_const {f : α → β} (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) (hf : MemLp f p μ) :
+    UnifIntegrable (fun _ : ι ↦ f) p μ := by
+  rcases isEmpty_or_nonempty ι with _ | _
+  · exact unifIntegrable_empty
+  rw [UnifIntegrable.mk]
+  simp only [ciSup_const]
+  exact hf.tendsto_eLpNorm_indicator_zero hp_one hp_top
 
 /-- A single function is uniformly integrable. -/
 theorem unifIntegrable_subsingleton [Subsingleton ι] (hp_one : 1 ≤ p) (hp_top : p ≠ ∞)
     {f : ι → α → β} (hf : ∀ i, MemLp (f i) p μ) : UnifIntegrable f p μ := by
-  intro ε hε
-  by_cases hι : Nonempty ι
-  · obtain ⟨i⟩ := hι
-    obtain ⟨δ, hδpos, hδ⟩ := (hf i).eLpNorm_indicator_le hp_one hp_top hε
-    refine ⟨δ, hδpos, fun j s hs hμs => ?_⟩
-    convert! hδ s hs hμs
-  · exact ⟨1, zero_lt_one, fun i => False.elim <| hι <| Nonempty.intro i⟩
-
-/-- This lemma is less general than `MeasureTheory.unifIntegrable_finite` which applies to
-all sequences indexed by a finite type. -/
-theorem unifIntegrable_fin (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) {n : ℕ} {f : Fin n → α → β}
-    (hf : ∀ i, MemLp (f i) p μ) : UnifIntegrable f p μ := by
-  revert f
-  induction n with
-  | zero => exact fun {f} hf ↦ unifIntegrable_subsingleton hp_one hp_top hf
-  | succ n h =>
-    intro f hfLp ε hε
-    let g : Fin n → α → β := fun k => f k.castSucc
-    have hgLp : ∀ i, MemLp (g i) p μ := fun i => hfLp i.castSucc
-    obtain ⟨δ₁, hδ₁pos, hδ₁⟩ := h hgLp hε
-    obtain ⟨δ₂, hδ₂pos, hδ₂⟩ := (hfLp (Fin.last n)).eLpNorm_indicator_le hp_one hp_top hε
-    refine ⟨min δ₁ δ₂, lt_min hδ₁pos hδ₂pos, fun i s hs hμs => ?_⟩
-    by_cases! hi : i.val < n
-    · rw [(_ : f i = g ⟨i.val, hi⟩)]
-      · exact hδ₁ _ s hs (le_trans hμs <| ENNReal.ofReal_le_ofReal <| min_le_left _ _)
-      · simp [g]
-    · obtain rfl : i = Fin.last n := Fin.ext (le_antisymm (Fin.is_le i) hi)
-      exact hδ₂ _ hs (le_trans hμs <| ENNReal.ofReal_le_ofReal <| min_le_right _ _)
+  rcases isEmpty_or_nonempty ι with _ | hι
+  · exact unifIntegrable_empty
+  rw [UnifIntegrable.mk]
+  obtain ⟨i⟩ := hι
+  simp only [ciSup_subsingleton i]
+  exact (hf i).tendsto_eLpNorm_indicator_zero hp_one hp_top
 
 /-- A finite sequence of Lp functions is uniformly integrable. -/
 theorem unifIntegrable_finite [Finite ι] (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) {f : ι → α → β}
     (hf : ∀ i, MemLp (f i) p μ) : UnifIntegrable f p μ := by
-  obtain ⟨n, hn⟩ := Finite.exists_equiv_fin ι
-  intro ε hε
-  let g : Fin n → α → β := f ∘ hn.some.symm
-  have hg : ∀ i, MemLp (g i) p μ := fun _ => hf _
-  obtain ⟨δ, hδpos, hδ⟩ := unifIntegrable_fin hp_one hp_top hg hε
-  refine ⟨δ, hδpos, fun i s hs hμs => ?_⟩
-  simpa [g] using hδ (hn.some i) s hs hμs
+  rw [UnifIntegrable.mk]
+  refine ENNReal.tendsto_nhds_zero.2 fun ε hε ↦ ?_
+  have key := fun i ↦ (hf i).tendsto_eLpNorm_indicator_zero hp_one hp_top
+  simp only [ENNReal.tendsto_nhds_zero] at key
+  filter_upwards [eventually_all.2 (fun i ↦ key i ε hε)] with a ha
+  exact iSup_le ha
+
+@[deprecated (since := "2026-07-23")] alias unifIntegrable_fin := unifIntegrable_finite
 
 end
 
@@ -456,20 +446,20 @@ end
 theorem tendsto_Lp_finite_of_tendsto_ae_of_meas [IsFiniteMeasure μ] (hp : 1 ≤ p) (hp' : p ≠ ∞)
     {f : ℕ → α → β} {g : α → β} (hf : ∀ n, StronglyMeasurable (f n)) (hg : StronglyMeasurable g)
     (hg' : MemLp g p μ) (hui : UnifIntegrable f p μ)
-    (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) :
-    Tendsto (fun n => eLpNorm (f n - g) p μ) atTop (𝓝 0) := by
+    (hfg : ∀ᵐ x ∂μ, Tendsto (fun n ↦ f n x) atTop (𝓝 (g x))) :
+    Tendsto (fun n ↦ eLpNorm (f n - g) p μ) atTop (𝓝 0) := by
   rw [ENNReal.tendsto_atTop_zero]
   intro ε hε
-  by_cases! h : ∞ ≤ ε
-  · rw [top_le_iff] at h
-    exact ⟨0, fun n _ => by simp [h]⟩
+  rcases eq_top_or_lt_top ε with rfl | h
+  · simp
   by_cases hμ : μ = 0
   · exact ⟨0, fun n _ => by simp [hμ]⟩
-  have hε' : 0 < ε.toReal / 3 := div_pos (ENNReal.toReal_pos hε.ne' h.ne) (by simp)
+  have hε' : 0 < ε / 3 := ENNReal.div_pos hε.ne.symm ENNReal.ofNat_ne_top
   have hdivp : 0 ≤ 1 / p.toReal := by positivity
   have hpow : 0 < measureUnivNNReal μ ^ (1 / p.toReal) :=
     Real.rpow_pos_of_pos (measureUnivNNReal_pos hμ) _
-  obtain ⟨δ₁, hδ₁, heLpNorm₁⟩ := hui hε'
+  obtain ⟨δ₁, hδ₁, heLpNorm₁⟩ := ENNReal.nhds_zero_basis.eventually_iff.1
+    (ENNReal.tendsto_nhds_zero.1 hui (ε / 3) hε')
   obtain ⟨δ₂, hδ₂, heLpNorm₂⟩ := hg'.eLpNorm_indicator_le hp hp' hε'
   obtain ⟨t, htm, ht₁, ht₂⟩ := tendstoUniformlyOn_of_ae_tendsto' hf hg hfg (lt_min hδ₁ hδ₂)
   rw [Metric.tendstoUniformlyOn_iff] at ht₂
@@ -536,16 +526,17 @@ theorem tendsto_Lp_finite_of_tendsto_ae [IsFiniteMeasure μ] (hp : 1 ≤ p) (hp'
 variable {f : ℕ → α → β} {g : α → β}
 
 theorem unifIntegrable_of_tendsto_Lp_zero (hp : 1 ≤ p) (hp' : p ≠ ∞) (hf : ∀ n, MemLp (f n) p μ)
-    (hf_tendsto : Tendsto (fun n => eLpNorm (f n) p μ) atTop (𝓝 0)) : UnifIntegrable f p μ := by
-  intro ε hε
-  rw [ENNReal.tendsto_atTop_zero] at hf_tendsto
-  obtain ⟨N, hN⟩ := hf_tendsto (ENNReal.ofReal ε) (by simpa)
-  let F : Fin N → α → β := fun n => f n
-  have hF : ∀ n, MemLp (F n) p μ := fun n => hf n
-  obtain ⟨δ₁, hδpos₁, hδ₁⟩ := unifIntegrable_fin hp hp' hF hε
-  refine ⟨δ₁, hδpos₁, fun n s hs hμs => ?_⟩
+    (hf_tendsto : Tendsto (fun n ↦ eLpNorm (f n) p μ) atTop (𝓝 0)) : UnifIntegrable f p μ := by
+  rw [UnifIntegrable.mk]
+  refine ENNReal.tendsto_nhds_zero.2 fun ε hε ↦ ?_
+  obtain ⟨N, hN⟩ := (ENNReal.tendsto_atTop_zero.1 hf_tendsto) ε hε
+  let F : Fin N → α → β := fun n ↦ f n
+  have hF : ∀ n, MemLp (F n) p μ := fun n ↦ hf n
+  filter_upwards [ENNReal.tendsto_nhds_zero.1 (unifIntegrable_finite hp hp' hF) ε hε] with δ hδ
+  simp only [iSup_le_iff]at hδ ⊢
+  intro n s _ hsμ
   by_cases! hn : n < N
-  · exact hδ₁ ⟨n, hn⟩ s hs hμs
+  · exact hδ ⟨n, hn⟩ s hsμ
   · exact (eLpNorm_indicator_le _).trans (hN n hn)
 
 /-- Convergence in Lp implies uniform integrability. -/
@@ -587,18 +578,24 @@ theorem tendstoInMeasure_iff_tendsto_Lp_finite [IsFiniteMeasure μ] (hp : 1 ≤ 
 /-- This lemma is superseded by `unifIntegrable_of` which do not require `C` to be positive. -/
 theorem unifIntegrable_of' (hp : 1 ≤ p) (hp' : p ≠ ∞) {f : ι → α → β}
     (hf : ∀ i, StronglyMeasurable (f i))
-    (h : ∀ ε : ℝ, 0 < ε → ∃ C : ℝ≥0, 0 < C ∧
-      ∀ i, eLpNorm ({ x | C ≤ ‖f i x‖₊ }.indicator (f i)) p μ ≤ ENNReal.ofReal ε) :
+    (h : ∀ ε > 0, ∃ C : ℝ≥0, 0 < C ∧
+      ∀ i, eLpNorm ({ x | C ≤ ‖f i x‖₊ }.indicator (f i)) p μ ≤ ε) :
     UnifIntegrable f p μ := by
   have hpzero := (lt_of_lt_of_le zero_lt_one hp).ne.symm
   by_cases hμ : μ Set.univ = 0
   · rw [Measure.measure_univ_eq_zero] at hμ
     exact hμ.symm ▸ unifIntegrable_zero_meas
-  intro ε hε
-  obtain ⟨C, hCpos, hC⟩ := h (ε / 2) (half_pos hε)
-  refine ⟨(ε / (2 * C)) ^ ENNReal.toReal p,
-    Real.rpow_pos_of_pos (div_pos hε (mul_pos two_pos (NNReal.coe_pos.2 hCpos))) _,
-    fun i s hs hμs => ?_⟩
+  rw [UnifIntegrable.mk]
+  refine ENNReal.tendsto_nhds_zero.2 fun ε hε ↦ ENNReal.nhds_zero_basis.eventually_iff.2 ?_
+  obtain ⟨C, hCpos, hC⟩ := h (ε / 2) (ε.half_pos hε.ne.symm)
+  refine ⟨(ε / (2 * C)) ^ p.toReal, ENNReal.rpow_pos_of_nonneg ?_ ENNReal.toReal_nonneg,
+    fun δ hδ ↦ ?_⟩
+  · apply ENNReal.div_pos hε.ne.symm
+    sorry
+  simp only [iSup_le_iff]
+  intro i s hs hsμ
+    --Real.rpow_pos_of_pos (div_pos hε (mul_pos two_pos (NNReal.coe_pos.2 hCpos))) _,
+    --fun i s hs hμs => ?_⟩
   by_cases hμs' : μ s = 0
   · rw [(eLpNorm_eq_zero_iff ((hf i).indicator hs).aestronglyMeasurable hpzero).2
         (indicator_meas_zero hμs')]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -259,19 +259,6 @@ theorem setLIntegral_le_lintegral (s : Set α) (f : α → ℝ≥0∞) :
     ∫⁻ x in s, f x ∂μ ≤ ∫⁻ x, f x ∂μ :=
   lintegral_mono' Measure.restrict_le_self le_rfl
 
-lemma iInf_mul_le_setLIntegral (f : α → ℝ≥0∞) {s : Set α} (hs : MeasurableSet s) :
-    (⨅ x ∈ s, f x) * μ s ≤ ∫⁻ x in s, f x ∂μ := by
-  calc (⨅ x ∈ s, f x) * μ s
-  _ = ∫⁻ y in s, ⨅ x ∈ s, f x ∂μ := by simp
-  _ ≤ ∫⁻ x in s, f x ∂μ := setLIntegral_mono' hs fun x hx ↦ iInf₂_le x hx
-
-lemma setLIntegral_le_iSup_mul (f : α → ℝ≥0∞) {s : Set α} (hs : MeasurableSet s) :
-    ∫⁻ x in s, f x ∂μ ≤ (⨆ x ∈ s, f x) * μ s := by
-  calc ∫⁻ x in s, f x ∂μ
-  _ ≤ ∫⁻ y in s, ⨆ x ∈ s, f x ∂μ :=
-    setLIntegral_mono' hs fun x hx ↦ le_iSup₂ (f := fun x _ ↦ f x) x hx
-  _ = (⨆ x ∈ s, f x) * μ s := by simp
-
 theorem lintegral_congr_ae {f g : α → ℝ≥0∞} (h : f =ᵐ[μ] g) : ∫⁻ a, f a ∂μ = ∫⁻ a, g a ∂μ :=
   le_antisymm (lintegral_mono_ae <| h.le) (lintegral_mono_ae <| h.symm.le)
 
@@ -290,6 +277,31 @@ theorem setLIntegral_congr_fun_ae {f g : α → ℝ≥0∞} {s : Set α} (hs : M
 theorem setLIntegral_congr_fun {f g : α → ℝ≥0∞} {s : Set α} (hs : MeasurableSet s)
     (hfg : EqOn f g s) : ∫⁻ x in s, f x ∂μ = ∫⁻ x in s, g x ∂μ :=
   setLIntegral_congr_fun_ae hs <| Eventually.of_forall hfg
+
+lemma iInf_mul_le_setLIntegral (f : α → ℝ≥0∞) {s : Set α} (hs : MeasurableSet s) :
+    (⨅ x ∈ s, f x) * μ s ≤ ∫⁻ x in s, f x ∂μ := by
+  calc (⨅ x ∈ s, f x) * μ s
+  _ = ∫⁻ y in s, ⨅ x ∈ s, f x ∂μ := by simp
+  _ ≤ ∫⁻ x in s, f x ∂μ := setLIntegral_mono' hs fun x hx ↦ iInf₂_le x hx
+
+lemma iInf_mul_le_setLIntegral₀ (f : α → ℝ≥0∞) {s : Set α} (hs : NullMeasurableSet s μ) :
+    (⨅ x ∈ s, f x) * μ s ≤ ∫⁻ x in s, f x ∂μ := by
+  obtain ⟨t, hst, ht, htμ⟩ := hs.exists_measurable_subset_ae_eq
+  rw [← setLIntegral_congr htμ, ← measure_congr htμ]
+  exact (mul_le_mul_left (iInf_le_iInf_of_subset hst) (μ t)).trans (iInf_mul_le_setLIntegral f ht)
+
+lemma setLIntegral_le_iSup_mul (f : α → ℝ≥0∞) {s : Set α} (hs : MeasurableSet s) :
+    ∫⁻ x in s, f x ∂μ ≤ (⨆ x ∈ s, f x) * μ s := by
+  calc ∫⁻ x in s, f x ∂μ
+  _ ≤ ∫⁻ y in s, ⨆ x ∈ s, f x ∂μ :=
+    setLIntegral_mono' hs fun x hx ↦ le_iSup₂ (f := fun x _ ↦ f x) x hx
+  _ = (⨆ x ∈ s, f x) * μ s := by simp
+
+lemma setLIntegral_le_iSup_mul₀ (f : α → ℝ≥0∞) {s : Set α} (hs : NullMeasurableSet s μ) :
+    ∫⁻ x in s, f x ∂μ ≤ (⨆ x ∈ s, f x) * μ s := by
+  obtain ⟨t, hst, ht, htμ⟩ := hs.exists_measurable_subset_ae_eq
+  rw [← setLIntegral_congr htμ, ← measure_congr htμ]
+  apply (setLIntegral_le_iSup_mul f ht).trans (mul_le_mul_left (iSup_le_iSup_of_subset hst) (μ t))
 
 lemma setLIntegral_eq_zero {f : α → ℝ≥0∞} {s : Set α} (hs : MeasurableSet s) (h's : EqOn f 0 s) :
     ∫⁻ x in s, f x ∂μ = 0 := by

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/UniformIntegrable.lean
@@ -1,0 +1,372 @@
+/-
+Copyright (c) 2026 Damien Thomine. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damien Thomine
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.Lebesgue.Markov
+
+/-!
+# Hitting time and hitting map in measured dynamical systems
+In this file, we define first hitting maps in measured dynamical systems.
+
+## Main definitions
+- `HitTime`: given a map `f : α → α` and a set `s`, the first positive time at which an iteration of
+  `f` hits `s`. Its value is `0` if no iteration hits `s`.
+- `HitMap`: given a map `f : α → α` and a set `s`, the point at which an iteration of `f` first hits
+  `s`.
+- `ExcursionSum` : given a map `f : α → α` a set `s` and an `ℝ≥0∞`-valued function `w` on `α`, the
+  sum of `w` on an orbit until this orbit first hits `s`.
+
+## Implementation notes
+The hitting time of a set `s` for a point `x` under a transformation `f` is defined as the `sInf`
+of all positive times `n` such that `f^[n] x ∈ s`. By default, `sInf ∅ = 0`. Hence, if the orbit
+starting from `x` never returns to `s`, then `HitTime f s x = 0`. This convention differs from the
+usual convention on the subject, for which `HitTime f s x = +∞` if the orbit starting from `x`
+never returns to `s`. The convention adopted therein has some upsides (e.g. `HitMap` is defined
+everywhere, `s` is stable under `HitMap`), but also some limitations one should keep in mind
+(e.g. `HitTime f s` is not antitone in `s`).
+
+## TODO
+Prove:
+- That `HitMap f s` is measure-preserving if `f` is measure-preserving and `s` recurrent.
+- If possible, remove the hypothesis that `s` has finite measure in the previous theorem.
+- Kac's lemma (or rather, its generalization for nonnegative functions): if `f` is
+measure-preserving and `s` recurrent, then
+`∫⁻ x in (⋃ n, f^[n] ⁻¹' s), w x ∂μ = ∫⁻ x in s, ExcursionSum f s x ∂μ`.
+
+## Tags
+hitting time, hitting map, induction, recurrent set
+-/
+
+public section
+
+noncomputable section
+
+namespace MeasureTheory
+
+open ENNReal Filter Function Measure Set Topology
+
+@[instance] theorem _root_.ENNReal.NeZero.top : NeZero ∞ := { out := zero_ne_top.symm }
+
+variable {α ι : Type*} [MeasurableSpace α] {F G : ι → α → ℝ≥0∞} {μ : Measure α}
+
+/-! ### Uniform integrability -/
+
+def UnifLIntegrable (F : ι → α → ℝ≥0∞) (μ : Measure α) :=
+  Tendsto (fun ε ↦ ⨆ (i : ι) (A : Set α) (_ : μ A ≤ ε), ∫⁻ x in A, F i x ∂μ) (𝓝 0) (𝓝 0)
+
+lemma unifLIntegrable_def :
+    UnifLIntegrable F μ ↔ Tendsto (fun ε ↦ ⨆ (i : ι) (A : Set α) (_ : μ A ≤ ε),
+    ∫⁻ x in A, F i x ∂μ) (𝓝 0) (𝓝 0) := by rfl
+
+lemma unifLIntegrable_mk :
+    UnifLIntegrable F μ ↔ Tendsto (fun ε ↦ ⨆ (i : ι) (A : Set α) (_ : MeasurableSet A)
+    (_ : μ A ≤ ε), ∫⁻ x in A, F i x ∂μ) (𝓝 0) (𝓝 0) := by
+  rw [unifLIntegrable_def, iff_iff_eq]; congr 2; ext ε
+  refine iSup_congr fun i ↦ le_antisymm (iSup₂_le fun A hAμ ↦ ?_) (iSup_mono fun A ↦ by simp)
+  obtain ⟨B, hAB, hB, hBμ⟩ := exists_measurable_superset μ A
+  rw [← hBμ] at hAμ
+  apply (le_iSup _ B).trans'
+  apply (le_iSup _ hB).trans'
+  apply (le_iSup _ hAμ).trans'
+  exact lintegral_mono_set hAB
+
+lemma UnifLIntegrable.mono_ae (hG : UnifLIntegrable G μ) (h : ∀ i, F i ≤ᵐ[μ] G i) :
+    UnifLIntegrable F μ := by
+  rw [unifLIntegrable_mk] at hG ⊢
+  refine tendsto_nhds_bot_mono hG (Eventually.of_forall fun a ↦ ?_)
+  apply iSup_mono fun i ↦ iSup_mono fun A ↦ iSup_mono fun hA ↦ iSup_mono fun hAμ ↦ ?_
+  exact lintegral_mono_ae (Eventually.filter_mono ae_restrict_le (h i))
+
+lemma unifLIntegrable_congr_ae (h : ∀ i, F i =ᵐ[μ] G i) :
+    UnifLIntegrable F μ ↔ UnifLIntegrable G μ :=
+  ⟨fun h' ↦ h'.mono_ae fun i ↦ (h i).symm.le, fun h' ↦ h'.mono_ae fun i ↦ (h i).le⟩
+
+lemma UnifLIntegrable.restrict (s : Set α) (h : UnifLIntegrable F μ) :
+    UnifLIntegrable F (μ.restrict s) := by
+  rw [unifLIntegrable_mk] at ⊢
+  refine tendsto_nhds_bot_mono h (Eventually.of_forall fun a ↦ iSup_mono fun i ↦ ?_)
+  simp only [iSup_le_iff]
+  intro A hA hAμ
+  rw [Measure.restrict_apply hA] at hAμ
+  apply (le_iSup _ (A ∩ s)).trans_eq'
+  rw [iSup_pos hAμ]
+  simp [hA]
+
+lemma UnifLIntegrable.tendsto_comp_set {A : ι → Set α} {l : Filter ι} (h : UnifLIntegrable F μ)
+    (h' : Tendsto (μ ∘ A) l (𝓝 0)) :
+    Tendsto (fun i ↦ ∫⁻ x in A i, F i x ∂μ) l (𝓝 0) := by
+  have key := h.comp h'
+  rw [← bot_eq_zero] at key ⊢
+  refine tendsto_nhds_bot_mono' key (fun i ↦ ?_)
+  simp only [comp_apply]
+  apply (le_iSup _ i).trans'
+  apply (le_iSup _ (A i)).trans'
+  simp
+
+lemma tendsto_iSup_setLIntegral_zero {f : α → ℝ≥0∞} (h : ∫⁻ x, f x ∂μ ≠ ∞) :
+    Tendsto (fun ε ↦ ⨆ (A : Set α) (_ : μ A ≤ ε), ∫⁻ x in A, f x ∂μ) (𝓝 0) (𝓝 0) := by
+  refine ENNReal.tendsto_nhds_zero.2 fun ε hε ↦ ?_
+  rw [nhds_zero_basis.eventually_iff]
+  obtain ⟨δ, hδ, hfδ⟩ := exists_pos_setLIntegral_lt_of_measure_lt h hε.ne.symm
+  refine ⟨δ, hδ, fun a ha ↦ ?_⟩
+  simp only [iSup_le_iff]
+  exact fun s hs ↦ (hfδ s (hs.trans_lt (mem_Iio.1 ha))).le
+
+lemma unifLIntegrable_empty [IsEmpty ι] : UnifLIntegrable F μ := by simp [UnifLIntegrable]
+
+lemma unifLIntegrable_const {f : α → ℝ≥0∞} (h : ∀ i, F i = f) (h' : ∫⁻ x, f x ∂μ ≠ ∞) :
+    UnifLIntegrable F μ := by
+  rcases isEmpty_or_nonempty ι with _ | _
+  · exact unifLIntegrable_empty
+  simp only [unifLIntegrable_def, h, ciSup_const]
+  exact tendsto_iSup_setLIntegral_zero h'
+
+lemma unifLIntegrable_of_finite [Finite ι] (h : ∀ i, ∫⁻ x, F i x ∂μ ≠ ∞) :
+    UnifLIntegrable F μ := by
+  refine ENNReal.tendsto_nhds_zero.2 fun ε hε ↦ ?_
+  have key := fun i ↦ tendsto_iSup_setLIntegral_zero (h i)
+  simp only [ENNReal.tendsto_nhds_zero] at key
+  filter_upwards [eventually_all.2 (fun i ↦ key i ε hε)] with a ha
+  exact iSup_le ha
+
+lemma UnifLIntegrable.add (h : ∀ i, AEMeasurable (G i) μ) (hF : UnifLIntegrable F μ)
+    (hG : UnifLIntegrable G μ) :
+    UnifLIntegrable (F + G) μ := by
+  rw [unifLIntegrable_mk]
+  refine ENNReal.tendsto_nhds_zero.2 fun ε hε ↦ ?_
+  filter_upwards [ENNReal.tendsto_nhds_zero.1 hF (ε / 2) (ε.half_pos hε.ne.symm),
+    ENNReal.tendsto_nhds_zero.1 hG (ε / 2) (ε.half_pos hε.ne.symm)] with a haF haG
+  simp only [iSup_le_iff, Pi.add_apply] at haF haG ⊢
+  intro i A hA hAμ
+  rw [← lintegral_indicator hA, indicator_add, lintegral_add_right' _ ((h i).indicator hA),
+    lintegral_indicator hA, lintegral_indicator hA, ← ε.add_halves]
+  exact add_le_add (haF i A hAμ) (haG i A hAμ)
+
+/-! ### Uniform tails -/
+
+def UniformTail (F : ι → α → ℝ≥0∞) (μ : Measure α) :=
+  Tendsto (fun a ↦ ⨆ i, μ (F i ⁻¹' Ici a)) (𝓝 ∞) (𝓝 0)
+
+lemma uniformTail_def :
+    UniformTail F μ
+      ↔ Tendsto (fun a ↦ ⨆ i, μ (F i ⁻¹' Ici a)) (𝓝 ∞) (𝓝 0) := by rfl
+
+lemma UniformTail.mono_ae (h : ∀ i, F i ≤ᵐ[μ] G i) (h' : UniformTail G μ) :
+    UniformTail F μ := by
+  refine tendsto_nhds_bot_mono h' (Eventually.of_forall fun a ↦ ?_)
+  refine iSup_mono fun i ↦ measure_mono_ae ?_
+  filter_upwards [h i] with x hx hxF
+  exact mem_Ici.2 ((mem_Ici.1 hxF).trans hx)
+
+lemma uniformTail_congr_ae (h : ∀ i, F i =ᵐ[μ] G i) :
+    UniformTail F μ ↔ UniformTail G μ :=
+  ⟨fun h' ↦ h'.mono_ae fun i ↦ (h i).symm.le, fun h' ↦ h'.mono_ae fun i ↦ (h i).le⟩
+
+lemma UniformTail.restrict (s : Set α) (h : UniformTail F μ) :
+    UniformTail F (μ.restrict s) :=
+  tendsto_nhds_bot_mono h (Eventually.of_forall fun _ ↦ iSup_mono fun _ ↦ μ.restrict_apply_le s _)
+
+lemma uniformTail_of_lintegral_lt_top (h : ∀ i, AEMeasurable (F i) μ)
+    (h' : ⨆ i, ∫⁻ x, F i x ∂μ ≠ ∞) :
+    UniformTail F μ := by
+  apply tendsto_nhds_bot_mono (f := fun a ↦ (⨆ i, ∫⁻ x, F i x ∂μ) / a)
+  · have := Tendsto.const_div (a := ⨆ i, ∫⁻ x, F i x ∂μ) (b := ∞) tendsto_id (.inr h')
+    simp only [id_eq, div_top] at this
+    rwa [ENNReal.bot_eq_zero]
+  · refine (eventually_gt_nhds zero_lt_top).mono fun a ha₀ ↦ ?_
+    simp only [ENNReal.iSup_div]
+    refine iSup_mono fun i ↦ ?_
+    rcases eq_or_ne a ⊤ with rfl | ha
+    · simp only [Ici_top, div_top, nonpos_iff_eq_zero]
+      exact measure_eq_top_of_lintegral_ne_top (h i) ((le_iSup _ i).trans_lt h'.lt_top).ne
+    · exact meas_ge_le_lintegral_div (h i) ha₀.ne.symm ha
+
+lemma uniformTail_empty [IsEmpty ι] : UniformTail F μ := by simp [UniformTail]
+
+lemma uniformTail_const {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) (hf' : ∫⁻ x, f x ∂μ ≠ ∞)
+    (h : ∀ i, F i = f) :
+    UniformTail F μ := by
+  rcases isEmpty_or_nonempty ι with _ | _
+  · exact uniformTail_empty
+  · exact uniformTail_of_lintegral_lt_top (fun i ↦ (h i) ▸ hf) (by simpa [h])
+
+lemma tendsto_measure_preimage_zero {f : α → ℝ≥0∞} (h : AEMeasurable f μ) (h' : ∫⁻ x, f x ∂μ ≠ ∞) :
+    Tendsto (fun a ↦ μ (f ⁻¹' Ici a)) (𝓝 ∞) (𝓝 0) := by
+  suffices hF : UniformTail (ι := {g // g = f}) (fun g x ↦ g.1 x) μ by
+    simp only [UniformTail, ciSup_unique] at hF
+    exact hF
+  exact uniformTail_const h h' (by simp)
+
+lemma uniformTail_of_finite [Finite ι] (h : ∀ i, AEMeasurable (F i) μ)
+    (h' : ∀ i, ∫⁻ x, F i x ∂μ ≠ ∞) :
+    UniformTail F μ := by
+  refine ENNReal.tendsto_nhds_zero.2 fun ε hε ↦ ?_
+  have key := fun i ↦ tendsto_measure_preimage_zero (h i) (h' i)
+  simp only [ENNReal.tendsto_nhds_zero] at key
+  filter_upwards [eventually_all.2 (fun i ↦ key i ε hε)] with a ha
+  exact iSup_le ha
+
+lemma UniformTail.add (hF : UniformTail F μ) (hG : UniformTail G μ) :
+    UniformTail (F + G) μ := by
+  -- If `c ≤ F i + G i`, then either `c / 2 ≤ F i` or `c / 2 ≤ G i`.
+  -- By this observation, `{c ≤ F i + G i} ⊆ {c / 2 ≤ F i} ∪ {c / 2 ≤ G i}`,
+  -- and we can control the measure of the latter set.
+  rw [UniformTail, ENNReal.tendsto_nhds_zero] at hF hG ⊢
+  intro ε hε
+  obtain ⟨a, ha, haμ⟩ := _root_.nhds_top_basis.eventually_iff.1 (hF (ε / 2) (ε.half_pos hε.ne.symm))
+  obtain ⟨b, hb, hbμ⟩ := _root_.nhds_top_basis.eventually_iff.1 (hG (ε / 2) (ε.half_pos hε.ne.symm))
+  refine _root_.nhds_top_basis.eventually_iff.2 ⟨max (2 * a) (2 * b), ?_, fun c hc ↦ ?_⟩
+  · exact (max_ne_top (mul_ne_top ofNat_ne_top ha.ne) (mul_ne_top ofNat_ne_top hb.ne)).lt_top
+  simp only [mem_Ioi, sup_lt_iff, iSup_le_iff, Pi.add_apply] at hc haμ hbμ ⊢
+  intro i
+  apply le_trans (b := μ ((F i ⁻¹' Ici (c / 2)) ∪ G i ⁻¹' Ici (c / 2)))
+  · refine measure_mono fun x ↦ ?_
+    contrapose
+    simp only [mem_union, mem_preimage, mem_Ici, not_or, not_le, Pi.add_apply, and_imp]
+    exact fun hFx hGx ↦ (ENNReal.add_lt_add hFx hGx).trans_eq c.add_halves
+  · rw [mul_comm 2 _, ← ENNReal.lt_div_iff_mul_lt (.inl two_ne_zero) (.inl ofNat_ne_top),
+      mul_comm 2 _, ← ENNReal.lt_div_iff_mul_lt (.inl two_ne_zero) (.inl ofNat_ne_top)] at hc
+    apply (measure_union_le _ _).trans
+    exact (add_le_add (haμ hc.1 i) (hbμ hc.2 i)).trans_eq ε.add_halves
+
+/-! ### Equi-integrability -/
+
+def UniformLIntegrable (F : ι → α → ℝ≥0∞) (μ : Measure α) :=
+  Tendsto (fun a ↦ ⨆ i, ∫⁻ x in F i ⁻¹' Ici a, F i x ∂μ) (𝓝 ∞) (𝓝 0)
+
+lemma uniformLIntegrable_def :
+    UniformLIntegrable F μ
+      ↔ Tendsto (fun a ↦ ⨆ i, ∫⁻ x in F i ⁻¹' Ici a, F i x ∂μ) (𝓝 ∞) (𝓝 0) := by rfl
+
+lemma UniformLIntegrable.mono_ae (hG : UniformLIntegrable G μ) (h : ∀ i, F i ≤ᵐ[μ] G i) :
+    UniformLIntegrable F μ := by
+  refine tendsto_nhds_bot_mono hG (Eventually.of_forall fun a ↦ iSup_mono fun i ↦ ?_)
+  apply le_trans (b :=  ∫⁻ (x : α) in G i ⁻¹' Ici a, F i x ∂μ)
+  · apply lintegral_mono_set'
+    filter_upwards [h i] with x hx hxF
+    exact mem_Ici.2 ((mem_Ici.1 hxF).trans hx)
+  · exact lintegral_mono_ae (Eventually.filter_mono ae_restrict_le (h i))
+
+lemma uniforLIntegrable_congr_ae (h : ∀ i, F i =ᵐ[μ] G i) :
+    UniformLIntegrable F μ ↔ UniformLIntegrable G μ :=
+  ⟨fun p ↦ p.mono_ae (fun i ↦ (h i).symm.le), fun p ↦ p.mono_ae (fun i ↦ (h i).le)⟩
+
+lemma UniformLIntegrable.restrict (s : Set α) (h : UniformLIntegrable F μ) :
+    UniformLIntegrable F (μ.restrict s) := by
+  refine tendsto_nhds_bot_mono h (Eventually.of_forall fun a ↦ iSup_mono fun i ↦ ?_)
+  exact lintegral_mono' (Measure.restrict_mono_measure μ.restrict_le_self _) (le_refl _)
+
+-- Auxiliary lemma to prove that `UniformLIntegrable` families are `UnifLIntegrable`.
+private lemma setLIntegral_le_add_lintegral (f : α → ℝ≥0∞) (A : Set α) (a : ℝ≥0∞) :
+    ∫⁻ x in A, f x ∂μ ≤ a * μ A + ∫⁻ x in f ⁻¹' Ici a, f x ∂μ := by
+  -- Without loss of generality, `A` can be assumed measurable.
+  obtain ⟨B, hAB, hB, hBμ⟩ := exists_measurable_superset μ A
+  apply (lintegral_mono_set hAB).trans
+  rw [← hBμ]; clear hBμ hAB A
+  -- We replace `f` by a measurable approximation `g` of `f`.
+  obtain ⟨g, hg, hfg, hgμ⟩ := exists_measurable_le_lintegral_eq (μ.restrict B) f
+  rw [hgμ]
+  apply le_trans (b := a * μ B + ∫⁻ x in g ⁻¹' Ici a, g x ∂μ)
+  -- Main argument : on `(g ⁻¹' Ici a)ᶜ`, the function `g` is bounded by `a`.
+  · rw [← lintegral_inter_add_sdiff g B (.preimage (measurableSet_Ici (a := a)) hg), add_comm]
+    apply add_le_add _ (lintegral_mono_set inter_subset_right)
+    rw [← setLIntegral_const]
+    apply (setLIntegral_mono (measurable_const (a := a)) (by grind)).trans
+    exact lintegral_mono_set sdiff_subset
+  -- We finally relate bound `∫⁻ x in g ⁻¹' Ici a, g x ∂μ` with `∫⁻ x in f ⁻¹' Ici a, f x ∂μ`.
+  · apply add_le_add_right
+    exact (lintegral_mono hfg).trans (lintegral_mono_set fun x hx ↦ hx.trans (Pi.le_def.1 hfg x))
+
+lemma UniformLIntegrable.unifLIntegrable (h : UniformLIntegrable F μ) : UnifLIntegrable F μ := by
+  -- The key is Lemma `setLIntegral_le_add_lintegral`.
+  -- Choose `a` large enough that `∫⁻ x in f ⁻¹' Ici a, f x ∂μ` is small.
+  -- Then, choose `μ A` small enough that `a * μ A` is also small.
+  refine ENNReal.tendsto_nhds_zero.2 fun ε hε ↦ nhds_zero_basis.eventually_iff.2 ?_
+  obtain ⟨δ, hδ, hδε⟩ := exists_between hε
+  obtain ⟨a, ha, haF⟩ :=
+    ENNReal.nhds_top_basis.eventually_iff.1 (ENNReal.tendsto_nhds_zero.1 h δ hδ)
+  obtain ⟨b, hab, hb⟩ := exists_between ha
+  have hδε' : ε - δ ≠ 0 := fun p ↦ hδε.not_ge (tsub_eq_zero_iff_le.1 p)
+  obtain ⟨κ, hκ, hκb⟩ := ENNReal.exists_pos_mul_lt hb.ne hδε'
+  refine ⟨κ, hκ, fun γ hγ ↦ ?_⟩
+  specialize haF (mem_Ioi.2 hab)
+  simp only [iSup_le_iff] at haF ⊢
+  intro i A hAμ
+  apply (setLIntegral_le_add_lintegral (F i) A b).trans
+  rw [← tsub_add_cancel_of_le hδε.le, mul_comm (a := b)]
+  apply add_le_add (hκb.le.trans' _) (haF i)
+  exact mul_le_mul_left (hAμ.trans (mem_Iio.1 hγ).le) b
+
+lemma UniformLIntegrable.uniformTail (h : ∀ i, AEMeasurable (F i) μ) (h' : UniformLIntegrable F μ) :
+    UniformTail F μ := by
+  apply tendsto_nhds_bot_mono (f := fun a ↦ 1 / a)
+  · have := Tendsto.const_div (a := 1) (b := ∞) tendsto_id (.inr one_ne_top)
+    simp only [id_eq, div_top] at this
+    exact this
+  · filter_upwards [ENNReal.tendsto_nhds_zero.1 h' 1 zero_lt_one] with a ha
+    simp only [iSup_le_iff, one_div, le_inv_iff_mul_le] at ha ⊢
+    refine fun i ↦ (ha i).trans' ?_
+    apply (iInf_mul_le_setLIntegral₀ _ ((h i).nullMeasurableSet_preimage (by measurability))).trans'
+    rw [mul_comm]
+    apply mul_le_mul_left
+    simp
+
+lemma UnifLIntegrable.uniformLIntegrable (h : UnifLIntegrable F μ) (h' : UniformTail F μ) :
+    UniformLIntegrable F μ := by
+  refine tendsto_nhds_bot_mono' (h.comp h') fun a ↦ ?_
+  simp only [comp_apply, iSup_le_iff]
+  intro i
+  apply (le_iSup _ i).trans'
+  apply (le_iSup _ ((F i) ⁻¹' Ici a)).trans'
+  rw [iSup_pos]
+  exact le_iSup (α := ℝ≥0∞) _ i
+
+lemma uniformLIntegrable_iff_unifLIntegrable_uniformTail (h : ∀ i, AEMeasurable (F i) μ) :
+    UniformLIntegrable F μ ↔ UnifLIntegrable F μ ∧ UniformTail F μ :=
+  ⟨fun h' ↦ ⟨h'.unifLIntegrable, h'.uniformTail h⟩, fun h' ↦ h'.1.uniformLIntegrable h'.2⟩
+
+lemma UniformLIntegrable.lintegral_lt_top_of_isFinite (h : IsFiniteMeasure μ)
+    (hF : UniformLIntegrable F μ) :
+    ⨆ i, ∫⁻ x, F i x ∂μ < ∞ := by
+  have key := (ENNReal.tendsto_nhds_zero.1 hF 1 zero_lt_one).and_frequently (frequently_lt_nhds ∞)
+  obtain ⟨a, ha, a_top⟩ := key.exists
+  apply lt_of_le_of_lt (b := a * μ univ + 1)
+  · simp only [iSup_le_iff] at ha ⊢
+    intro i
+    rw [← setLIntegral_univ (F i)]
+    apply (setLIntegral_le_add_lintegral (F i) univ a).trans
+    exact add_le_add_right (ha i) (a * μ univ)
+  · exact add_lt_top.2 ⟨mul_lt_top a_top ((isFiniteMeasure_iff μ).1 h), one_lt_top⟩
+
+lemma uniformLIntegrable_empty [IsEmpty ι] : UniformLIntegrable F μ := by simp [UniformLIntegrable]
+
+lemma uniformLIntegrable_const {f : α → ℝ≥0∞} (h : ∀ i, F i = f) (hf : AEMeasurable f μ)
+    (hf' : ∫⁻ x, f x ∂μ ≠ ∞) :
+    UniformLIntegrable F μ :=
+  (unifLIntegrable_const h hf').uniformLIntegrable (uniformTail_const hf hf' h)
+
+lemma tendsto_setLIntegral_preimage_zero {f : α → ℝ≥0∞} (h : AEMeasurable f μ)
+    (h' : ∫⁻ x, f x ∂μ ≠ ∞) :
+    Tendsto (fun a ↦ ∫⁻ x in f ⁻¹' Ici a, f x ∂μ) (𝓝 ∞) (𝓝 0) := by
+  suffices hF : UniformLIntegrable (ι := {g // g = f}) (fun g x ↦ g.1 x) μ by
+    simp only [UniformLIntegrable, ciSup_unique] at hF
+    exact hF
+  exact uniformLIntegrable_const (by simp) h h'
+
+lemma _root_.Finite.uniformLIntegrable [Finite ι] (h : ∀ i, AEMeasurable (F i) μ)
+    (h' : ∀ i, ∫⁻ x, F i x ∂μ ≠ ∞) :
+    UniformLIntegrable F μ := by
+  apply (uniformLIntegrable_iff_unifLIntegrable_uniformTail h).2
+  exact ⟨unifLIntegrable_of_finite h', uniformTail_of_finite h h'⟩
+
+lemma UniformLIntegrable.add (hF : ∀ i, AEMeasurable (F i) μ) (hG : ∀ i, AEMeasurable (G i) μ)
+    (hF' : UniformLIntegrable F μ) (hG' : UniformLIntegrable G μ) :
+    UniformLIntegrable (F + G) μ := by
+  rw [uniformLIntegrable_iff_unifLIntegrable_uniformTail (by simp [fun i ↦ (hF i).add (hG i)])]
+  refine ⟨hF'.unifLIntegrable.add hG hG'.unifLIntegrable, ?_⟩
+  exact (hF'.uniformTail hF).add (hG'.uniformTail hG)
+
+end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/UniformIntegrable.lean
@@ -255,7 +255,7 @@ lemma UniformLIntegrable.restrict (s : Set α) (h : UniformLIntegrable F μ) :
 -- Auxiliary lemma to prove that `UniformLIntegrable` families are `UnifLIntegrable`.
 private lemma setLIntegral_le_add_lintegral (f : α → ℝ≥0∞) (A : Set α) (a : ℝ≥0∞) :
     ∫⁻ x in A, f x ∂μ ≤ a * μ A + ∫⁻ x in f ⁻¹' Ici a, f x ∂μ := by
-  -- Without loss of generality, `A` can be assumed measurable.
+  -- Without loss of generality, `A` can be assumed measurable.
   obtain ⟨B, hAB, hB, hBμ⟩ := exists_measurable_superset μ A
   apply (lintegral_mono_set hAB).trans
   rw [← hBμ]; clear hBμ hAB A

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/UniformIntegrable.lean
@@ -18,10 +18,10 @@ This file contains the definitions for uniform integrability of `ℝ≥0∞`-val
   A family of functions `F` is uniformly integrable if for all `ε > 0`, there
   exists some `δ > 0` such that for all sets `s` of smaller measure than `δ`, for all `i`,
   the integral of `F i` restricted to `s` is smaller than `ε`.
-* `MeasureTheory.UniformLIntegrable`: a sequence of measurable functions `F` is uniformly
-  integrable in this sense if the integrals `∫⁻ x in F i ⁻¹' Ici a, F i x ∂μ` decay to `0` as `a`
+* `MeasureTheory.UniformLIntegrable`: a family of functions `F` is uniformly integrable
+  in this sense if the integrals `∫⁻ x in F i ⁻¹' Ici a, F i x ∂μ` decay to `0` as `a`
   tends to `∞`, uniformly in `i`.
-* `MeasureTheory.UniformTail`: a sequence of measurable functions `F` has uniform tails
+* `MeasureTheory.UniformTail`: a family of functions `F` has uniform tails
   if the tails `μ (F i ⁻¹' Ici a)` decay to `0` as `a` tends to `∞`, uniformly in `i`. This notion
   is useful to relate precisely `UnifLIntegrable` and `UniformLIntegrable`.
 
@@ -47,6 +47,9 @@ variable {α ι : Type*} [MeasurableSpace α] {F G : ι → α → ℝ≥0∞} {
 
 /-! ### Uniform integrability -/
 
+/-- A family of functions `F` is `UnifLIntegrable` if for all `ε > 0`, there
+  exists some `δ > 0` such that for all sets `s` of smaller measure than `δ`, for all `i`,
+  the integral of `F i` restricted to `s` is smaller than `ε`. -/
 def UnifLIntegrable (F : ι → α → ℝ≥0∞) (μ : Measure α) :=
   Tendsto (fun ε ↦ ⨆ (i : ι) (A : Set α) (_ : μ A ≤ ε), ∫⁻ x in A, F i x ∂μ) (𝓝 0) (𝓝 0)
 
@@ -68,9 +71,9 @@ lemma unifLIntegrable_mk :
 
 lemma UnifLIntegrable.mono_ae (hG : UnifLIntegrable G μ) (h : ∀ i, F i ≤ᵐ[μ] G i) :
     UnifLIntegrable F μ := by
-  rw [unifLIntegrable_mk] at hG ⊢
+  rw [unifLIntegrable_def] at hG ⊢
   refine tendsto_nhds_bot_mono hG (Eventually.of_forall fun a ↦ ?_)
-  apply iSup_mono fun i ↦ iSup_mono fun A ↦ iSup_mono fun hA ↦ iSup_mono fun hAμ ↦ ?_
+  apply iSup_mono fun i ↦ iSup_mono fun A ↦ iSup_mono fun _ ↦ ?_
   exact lintegral_mono_ae (Eventually.filter_mono ae_restrict_le (h i))
 
 lemma unifLIntegrable_congr_ae (h : ∀ i, F i =ᵐ[μ] G i) :
@@ -140,6 +143,8 @@ lemma UnifLIntegrable.add (h : ∀ i, AEMeasurable (G i) μ) (hF : UnifLIntegrab
 
 /-! ### Uniform tails -/
 
+/-- A family of functions `F` has uniform tails if the tails `μ (F i ⁻¹' Ici a)` decay to `0`
+  as `a` tends to `∞`, uniformly in `i`. -/
 def UniformTail (F : ι → α → ℝ≥0∞) (μ : Measure α) :=
   Tendsto (fun a ↦ ⨆ i, μ (F i ⁻¹' Ici a)) (𝓝 ∞) (𝓝 0)
 
@@ -227,6 +232,8 @@ lemma UniformTail.add (hF : UniformTail F μ) (hG : UniformTail G μ) :
 
 /-! ### Equi-integrability -/
 
+/-- A family of functions `F` is `UniformLIntegrable` if the integrals
+  `∫⁻ x in F i ⁻¹' Ici a, F i x ∂μ` decay to `0` as `a` tends to `∞`, uniformly in `i`. -/
 def UniformLIntegrable (F : ι → α → ℝ≥0∞) (μ : Measure α) :=
   Tendsto (fun a ↦ ⨆ i, ∫⁻ x in F i ⁻¹' Ici a, F i x ∂μ) (𝓝 ∞) (𝓝 0)
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/UniformIntegrable.lean
@@ -8,36 +8,31 @@ module
 public import Mathlib.MeasureTheory.Integral.Lebesgue.Markov
 
 /-!
-# Hitting time and hitting map in measured dynamical systems
-In this file, we define first hitting maps in measured dynamical systems.
+# Uniform integrability
+
+This file contains the definitions for uniform integrability of `ℝ≥0∞`-valued functions.
 
 ## Main definitions
-- `HitTime`: given a map `f : α → α` and a set `s`, the first positive time at which an iteration of
-  `f` hits `s`. Its value is `0` if no iteration hits `s`.
-- `HitMap`: given a map `f : α → α` and a set `s`, the point at which an iteration of `f` first hits
-  `s`.
-- `ExcursionSum` : given a map `f : α → α` a set `s` and an `ℝ≥0∞`-valued function `w` on `α`, the
-  sum of `w` on an orbit until this orbit first hits `s`.
 
-## Implementation notes
-The hitting time of a set `s` for a point `x` under a transformation `f` is defined as the `sInf`
-of all positive times `n` such that `f^[n] x ∈ s`. By default, `sInf ∅ = 0`. Hence, if the orbit
-starting from `x` never returns to `s`, then `HitTime f s x = 0`. This convention differs from the
-usual convention on the subject, for which `HitTime f s x = +∞` if the orbit starting from `x`
-never returns to `s`. The convention adopted therein has some upsides (e.g. `HitMap` is defined
-everywhere, `s` is stable under `HitMap`), but also some limitations one should keep in mind
-(e.g. `HitTime f s` is not antitone in `s`).
+* `MeasureTheory.UnifLIntegrable`: uniform integrability in the measure theory sense.
+  A family of functions `F` is uniformly integrable if for all `ε > 0`, there
+  exists some `δ > 0` such that for all sets `s` of smaller measure than `δ`, for all `i`,
+  the integral of `F i` restricted to `s` is smaller than `ε`.
+* `MeasureTheory.UniformLIntegrable`: a sequence of measurable functions `F` is uniformly
+  integrable in this sense if the integrals `∫⁻ x in F i ⁻¹' Ici a, F i x ∂μ` decay to `0` as `a`
+  tends to `∞`, uniformly in `i`.
+* `MeasureTheory.UniformTail`: a sequence of measurable functions `F` has uniform tails
+  if the tails `μ (F i ⁻¹' Ici a)` decay to `0` as `a` tends to `∞`, uniformly in `i`. This notion
+  is useful to relate precisely `UnifLIntegrable` and `UniformLIntegrable`.
 
-## TODO
-Prove:
-- That `HitMap f s` is measure-preserving if `f` is measure-preserving and `s` recurrent.
-- If possible, remove the hypothesis that `s` has finite measure in the previous theorem.
-- Kac's lemma (or rather, its generalization for nonnegative functions): if `f` is
-measure-preserving and `s` recurrent, then
-`∫⁻ x in (⋃ n, f^[n] ⁻¹' s), w x ∂μ = ∫⁻ x in s, ExcursionSum f s x ∂μ`.
+## Main results
+
+* `MeasureTheory.uniformLIntegrable_iff_unifLIntegrable_uniformTail`: the equivalence between
+  `UniformLIntegrable` on the one hand, and `UnifLIntegrable` together with `UniformTail` on the
+  other hand.
 
 ## Tags
-hitting time, hitting map, induction, recurrent set
+uniformly integrable, equi-integrable, Lebesgue integral
 -/
 
 public section
@@ -46,9 +41,7 @@ noncomputable section
 
 namespace MeasureTheory
 
-open ENNReal Filter Function Measure Set Topology
-
-@[instance] theorem _root_.ENNReal.NeZero.top : NeZero ∞ := { out := zero_ne_top.symm }
+open ENNReal Filter Set Topology
 
 variable {α ι : Type*} [MeasurableSpace α] {F G : ι → α → ℝ≥0∞} {μ : Measure α}
 
@@ -101,7 +94,7 @@ lemma UnifLIntegrable.tendsto_comp_set {A : ι → Set α} {l : Filter ι} (h : 
   have key := h.comp h'
   rw [← bot_eq_zero] at key ⊢
   refine tendsto_nhds_bot_mono' key (fun i ↦ ?_)
-  simp only [comp_apply]
+  simp only [Function.comp_apply]
   apply (le_iSup _ i).trans'
   apply (le_iSup _ (A i)).trans'
   simp
@@ -317,13 +310,15 @@ lemma UniformLIntegrable.uniformTail (h : ∀ i, AEMeasurable (F i) μ) (h' : Un
 lemma UnifLIntegrable.uniformLIntegrable (h : UnifLIntegrable F μ) (h' : UniformTail F μ) :
     UniformLIntegrable F μ := by
   refine tendsto_nhds_bot_mono' (h.comp h') fun a ↦ ?_
-  simp only [comp_apply, iSup_le_iff]
+  simp only [Function.comp_apply, iSup_le_iff]
   intro i
   apply (le_iSup _ i).trans'
   apply (le_iSup _ ((F i) ⁻¹' Ici a)).trans'
   rw [iSup_pos]
   exact le_iSup (α := ℝ≥0∞) _ i
 
+/-- Equivalence between `UniformLIntegrable` on the one hand, and `UnifLIntegrable` together with
+  `UniformTail` on the other hand. -/
 lemma uniformLIntegrable_iff_unifLIntegrable_uniformTail (h : ∀ i, AEMeasurable (F i) μ) :
     UniformLIntegrable F μ ↔ UnifLIntegrable F μ ∧ UniformTail F μ :=
   ⟨fun h' ↦ ⟨h'.unifLIntegrable, h'.uniformTail h⟩, fun h' ↦ h'.1.uniformLIntegrable h'.2⟩

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/UniformIntegrable.lean
@@ -7,6 +7,10 @@ module
 
 public import Mathlib.MeasureTheory.Integral.Lebesgue.Markov
 
+
+
+
+
 /-!
 # Uniform integrability
 
@@ -71,7 +75,6 @@ lemma unifLIntegrable_mk :
 
 lemma UnifLIntegrable.mono_ae (hG : UnifLIntegrable G μ) (h : ∀ i, F i ≤ᵐ[μ] G i) :
     UnifLIntegrable F μ := by
-  rw [unifLIntegrable_def] at hG ⊢
   refine tendsto_nhds_bot_mono hG (Eventually.of_forall fun a ↦ ?_)
   apply iSup_mono fun i ↦ iSup_mono fun A ↦ iSup_mono fun _ ↦ ?_
   exact lintegral_mono_ae (Eventually.filter_mono ae_restrict_le (h i))
@@ -82,7 +85,7 @@ lemma unifLIntegrable_congr_ae (h : ∀ i, F i =ᵐ[μ] G i) :
 
 lemma UnifLIntegrable.restrict (s : Set α) (h : UnifLIntegrable F μ) :
     UnifLIntegrable F (μ.restrict s) := by
-  rw [unifLIntegrable_mk] at ⊢
+  rw [unifLIntegrable_mk]
   refine tendsto_nhds_bot_mono h (Eventually.of_forall fun a ↦ iSup_mono fun i ↦ ?_)
   simp only [iSup_le_iff]
   intro A hA hAμ


### PR DESCRIPTION
A version of `Mathlib.MeasureTheory.Function.UniformIntegrable` for `ENNReal`-valued function. Needed for a project in dynamics (Kac's lemma). I may also rewrite `Mathlib.MeasureTheory.Function.UniformIntegrable` to use this file as a foundation.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
