### PR TITLE
[Merged by Bors] - ci: publish the cache for off-master release tags

### DIFF
--- a/.github/actions/cache-trust-dispatch/action.yml
+++ b/.github/actions/cache-trust-dispatch/action.yml
@@ -1,4 +1,4 @@
-# Single source of truth mapping (repo, branch) → (upload container,
+# Single source of truth mapping (repo, ref) → (upload container,
 # read fallback chain) for Mathlib's multi-container cache.
 #
 # Called by build, upload_cache, and post_steps in build_template.yml so
@@ -14,7 +14,10 @@ inputs:
     description: GitHub repo full name (`owner/name`).
     required: true
   branch:
-    description: Branch name (`github.head_ref || github.ref_name`).
+    description: |
+      Branch name (`github.head_ref || github.ref_name`); on tag-triggered
+      runs this is the tag name, distinguished via `github.ref_type` inside
+      the dispatch step.
     required: true
   head-sha:
     description: |
@@ -55,6 +58,10 @@ runs:
         REPO="${{ inputs.repo }}"
         BRANCH="${{ inputs.branch }}"
         HEAD_SHA="${{ inputs.head-sha }}"
+        # Whether `branch` names a branch or a tag. Read from the run context
+        # rather than an input: unlike `repo`/`branch`, the value does not
+        # depend on which event shape (PR vs push) the caller handles.
+        REF_TYPE="${{ github.ref_type }}"
         PRIMARY=""
         READ_CHAIN=""
         REPO_SCOPE=""
@@ -80,30 +87,55 @@ runs:
         else
         case "$REPO" in
           "leanprover-community/mathlib4")
-            case "$BRANCH" in
-              "master"|"staging")
-                # Master / staging are the only writers that feed `master`
-                # (`staging` is bors's merge candidate, which fast-forwards to
-                # `master`). Read `master` only, not the default [master,
-                # legacy]: files the read chain serves are skipped at stage
-                # time, so keeping `legacy` would leave legacy-only files out of
-                # `master` for good. Reading `master` alone turns them into
-                # misses that get rebuilt and uploaded, so `master` fills itself
-                # into a standalone cache. (Only PRIMARY=master does this; other
-                # runs write to `forks` and keep the wider chain.)
-                PRIMARY="master"
-                READ_CHAIN="master"
-                ;;
-              *)
-                # `bors trying`, `ci-dev/*`, maintainer dev branches on the
-                # canonical repo: trust level is fork-equivalent (the OIDC
-                # token's RBAC scopes them to `forks`). Reads must widen
-                # past the default [master, legacy] so the post-build
-                # verification finds the just-uploaded fork-trust artifacts.
-                PRIMARY="forks"
-                READ_CHAIN="master,forks,legacy"
-                ;;
-            esac
+            if [ "$REF_TYPE" = "tag" ]; then
+              case "$BRANCH" in
+                v4.*)
+                  # `v4.*` release tags: release_cache.yml rebuilds off-master
+                  # release commits (patch releases, patched release
+                  # candidates) and publishes them into `master`, the container
+                  # canonical checkouts read. Tag creation is restricted to
+                  # release managers by a tag ruleset, and the
+                  # `cache-upload-master` environment admits `v4.*` tag refs,
+                  # so these builds carry master trust. Reads are `master`-only
+                  # for the same fill-in reason as the master/staging arm
+                  # below.
+                  PRIMARY="master"
+                  READ_CHAIN="master"
+                  ;;
+                *)
+                  # Other tags have no trust class of their own:
+                  # fork-equivalent, like the dev-branch arm below.
+                  PRIMARY="forks"
+                  READ_CHAIN="master,forks,legacy"
+                  ;;
+              esac
+            else
+              case "$BRANCH" in
+                "master"|"staging")
+                  # Master, staging, and `v4.*` release tags (above) are the
+                  # only writers that feed `master` (`staging` is bors's merge
+                  # candidate, which fast-forwards to `master`). Read `master`
+                  # only, not the default [master, legacy]: files the read
+                  # chain serves are skipped at stage time, so keeping `legacy`
+                  # would leave legacy-only files out of `master` for good.
+                  # Reading `master` alone turns them into misses that get
+                  # rebuilt and uploaded, so `master` fills itself into a
+                  # standalone cache. (Only PRIMARY=master does this; other
+                  # runs write to `forks` and keep the wider chain.)
+                  PRIMARY="master"
+                  READ_CHAIN="master"
+                  ;;
+                *)
+                  # `bors trying`, `ci-dev/*`, maintainer dev branches on the
+                  # canonical repo: trust level is fork-equivalent (the OIDC
+                  # token's RBAC scopes them to `forks`). Reads must widen
+                  # past the default [master, legacy] so the post-build
+                  # verification finds the just-uploaded fork-trust artifacts.
+                  PRIMARY="forks"
+                  READ_CHAIN="master,forks,legacy"
+                  ;;
+              esac
+            fi
             ;;
           "leanprover-community/mathlib4-nightly-testing")
             case "$BRANCH" in

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -1,4 +1,5 @@
-# Reusable workflow invoked by build.yml, bors.yml, build_fork.yml, and ci_dev.yml.
+# Reusable workflow invoked by build.yml, bors.yml, build_fork.yml, ci_dev.yml,
+# and release_cache.yml.
 
 on:
   workflow_call:

--- a/.github/workflows/release_cache.yml
+++ b/.github/workflows/release_cache.yml
@@ -1,0 +1,103 @@
+name: publish release cache
+
+# Publishes the Mathlib cache for release tags whose commits are not on
+# `master`.
+#
+# Patch releases (`v4.X.Y` with Y ≥ 1) and patched release candidates (e.g.
+# `v4.32.0-rc1-patch1`) are committed on `bump_to_*` branches that never merge
+# back into `master`, so the master push build never caches them; their branch
+# CI writes only the fork-trust container, which a canonical checkout at the
+# tag never reads. This workflow rebuilds the tagged commit and publishes the
+# result to the `master` container, where every consumer finds it. Tags that
+# point at commits on `master` (plain release candidates and `.0` releases)
+# are already cached by the master push build, so the gate job skips them.
+#
+# Trust model:
+#   - Creating a `v4.*` tag is restricted to release managers by a tag
+#     ruleset, so a tag push is a deliberate release-manager action — and the
+#     tagged tree is what runs here, including this workflow file. Tags cut
+#     from lineages predating this file simply never trigger it.
+#   - The upload job mints its OIDC token under the `cache-upload-master`
+#     environment (inside build_template.yml); the environment's deployment
+#     policy admits only `master`, `staging`, and `v4.*` tag refs.
+#
+# Retry: a spuriously failed run can simply be re-run ("Re-run failed jobs" /
+# `gh run rerun`) — same tag, same tree, no tag re-push involved. The
+# `workflow_dispatch` trigger covers what re-run cannot: a tag push that never
+# produced a run, or a re-run window that has expired. Dispatch it AT the tag
+# ref (`gh workflow run release_cache.yml --ref v4.X.Y`); the run then executes
+# the tag's own tree exactly as a tag push would.
+
+on:
+  push:
+    tags:
+      - 'v4.*'
+  # Manual fallback; see the retry note above. The `tags` filter does not
+  # apply to dispatches — the gate job's ref guards enforce it instead, so a
+  # dispatch on a branch ref skips cleanly.
+  workflow_dispatch:
+
+# `v4.*` tags are immutable (the tag ruleset blocks updates), so this group
+# only ever collides on re-runs of the same tag; keep those queued rather
+# than cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+# Read-only by default; the build job elevates for itself only.
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: skip tags already on master
+    # The ref guards double as the dispatch-path filter; on the push path the
+    # `tags` trigger filter has already enforced them.
+    if: ${{ github.repository == 'leanprover-community/mathlib4' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v4.') }}
+    runs-on: ubuntu-latest
+    outputs:
+      off_master: ${{ steps.check.outputs.off_master }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # `merge-base` needs history, so fetch all of it.
+          fetch-depth: 0
+
+      - name: check whether the tagged commit is on master
+        id: check
+        run: |
+          if git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
+            echo "Tag $GITHUB_REF_NAME points at a commit on master; the master push build covers its cache."
+            echo "off_master=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $GITHUB_REF_NAME is not on master; rebuilding it to publish its cache."
+            echo "off_master=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: ci
+    needs: gate
+    if: ${{ needs.gate.outputs.off_master == 'true' }}
+    # What build_template.yml needs, granted to this job only — the same set
+    # build.yml grants it on push events. In particular, the OIDC token for
+    # the cache upload can be minted here and nowhere else in this workflow.
+    permissions:
+      contents: read
+      id-token: write
+      actions: read  # Allow get-tools to download the prebuilt tools artifact from master's publish_tools runs
+      pull-requests: write  # Only allow PR comments/labels
+    uses: ./.github/workflows/build_template.yml
+    with:
+      concurrency_group: ${{ github.workflow }}-${{ github.ref }}
+      pr_branch_ref: ${{ github.sha }}
+      # Release tags publish to the `master` container under the master writer
+      # identity; see the trust note above and cache-trust-dispatch, which
+      # routes `v4.*` tag refs to that container.
+      cache_application_id: ${{ vars.CACHE_MASTER_WRITER_AZURE_APP_ID }}
+      cache_environment: cache-upload-master
+      # The cache-snapshot warming artifact exists to seed master and PR
+      # builds, which a release tag's snapshot cannot do.
+      publish_cache: false
+      # Skip the Post-CI job: it grooms PR labels, and a tag run has no PR.
+      run_post_ci: false
+      runs_on: pr
+    secrets: inherit

--- a/Cache/SECURITY.md
+++ b/Cache/SECURITY.md
@@ -21,7 +21,7 @@ CI job and assigned a trust level:
 
 | Container             | Who may write                                          | Trust  |
 |-----------------------|--------------------------------------------------------|--------|
-| `master`              | mathlib4 `master`/`staging`                            | high   |
+| `master`              | mathlib4 `master`/`staging`, `v4.*` release tags       | high   |
 | `forks`               | mathlib4 PR builds, non-master branches, `bors try`    | medium |
 | `nightly-testing`     | nightly-testing's trusted branches                     | medium |
 | `pr-toolchain-tests`  | nightly-testing's experimental toolchain branches      | low    |
@@ -148,5 +148,5 @@ The trust model does not attempt to defend against:
 | Trust property tests                           | [`Cache/Test.lean`](Test.lean)                                   |
 | User-facing CLI surface, env vars              | [`Cache/Main.lean`](Main.lean), [`Cache/README.md`](README.md)   |
 | OIDC mint + per-job dispatch                   | [`.github/workflows/build_template.yml`](../.github/workflows/build_template.yml) (`upload_cache` job) |
-| (repo, branch) → trust class policy table      | [`.github/actions/cache-trust-dispatch/action.yml`](../.github/actions/cache-trust-dispatch/action.yml) |
-| Caller `cache_application_id` ternaries        | [`.github/workflows/build.yml`](../.github/workflows/build.yml), [`bors.yml`](../.github/workflows/bors.yml), [`build_fork.yml`](../.github/workflows/build_fork.yml), [`ci_dev.yml`](../.github/workflows/ci_dev.yml) |
+| (repo, ref) → trust class policy table         | [`.github/actions/cache-trust-dispatch/action.yml`](../.github/actions/cache-trust-dispatch/action.yml) |
+| Caller `cache_application_id` wiring           | [`.github/workflows/build.yml`](../.github/workflows/build.yml), [`bors.yml`](../.github/workflows/bors.yml), [`build_fork.yml`](../.github/workflows/build_fork.yml), [`ci_dev.yml`](../.github/workflows/ci_dev.yml), [`release_cache.yml`](../.github/workflows/release_cache.yml) |


### PR DESCRIPTION
Patch releases (`v4.X.Y`, Y ≥ 1) and patched release candidates (e.g. `v4.32.0-rc1-patch1`) live on `bump_to_*` branches that are not ancestors of `master`, but we want their artifacts to land on the master cache once they are published.

Trust: creating `v4.*` tags is ruleset-restricted to release managers, so the tag push is already protected. The `cache-upload-master` environment's deployment policy (already updated) admits only `master`, `staging`, and `v4.*` tag refs. The workflow file that runs is the one at the tagged commit, so the whole stack is the tag's own tree (no version skew); tags from older lineages never trigger it, and coverage starts with the first `.0` release tagged after this lands.

