### PR TITLE
[Merged by Bors] - chore(GroupTheory/FreeGroup): fix recursor argument name

### DIFF
--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -623,10 +623,10 @@ def of (x : α) : FreeGroup α :=
   mk [(x, true)]
 
 @[to_additive (attr := elab_as_elim, induction_eliminator)]
-protected lemma induction_on {C : FreeGroup α → Prop} (z : FreeGroup α) (C1 : C 1)
-    (of : ∀ x, C <| of x) (inv_of : ∀ x, C (.of x) → C (.of x)⁻¹)
-    (mul : ∀ x y, C x → C y → C (x * y)) : C z :=
-  Quot.inductionOn z fun L ↦ L.recOn C1 fun ⟨x, b⟩ _tl ih ↦
+protected lemma induction_on {motive : FreeGroup α → Prop} (z : FreeGroup α) (one : motive 1)
+    (of : ∀ x, motive <| of x) (inv_of : ∀ x, motive (.of x) → motive (.of x)⁻¹)
+    (mul : ∀ x y, motive x → motive y → motive (x * y)) : motive z :=
+  Quot.inductionOn z fun L ↦ L.recOn one fun ⟨x, b⟩ _tl ih ↦
     b.recOn (mul _ _ (inv_of _ <| of x) ih) (mul _ _ (of x) ih)
 
 /-- Two homomorphisms out of a free group are equal if they are equal on generators.
@@ -956,7 +956,7 @@ def equivIntOfUnique [Unique α] : FreeGroup α ≃ ℤ where
   invFun x := of default ^ x
   left_inv x := by
     induction x with
-    | C1 => simp
+    | one => simp
     | of x => simp [Unique.default_eq x]
     | inv_of x hx => simp [Unique.default_eq x]
     | mul x y hx hy => simp [zpow_add, hx, hy]
@@ -985,7 +985,7 @@ def _root_.FreeAddGroup.addEquivIntOfUnique [Unique α] : FreeAddGroup α ≃+ �
   invFun x := x • FreeAddGroup.of default
   left_inv x := by
     induction x with
-    | C1 => simp
+    | zero => simp
     | of x => simp [Unique.default_eq x]
     | neg_of x hx => simp [Unique.default_eq x]
     | add x y hx hy => simp [add_zsmul, hx, hy]


### PR DESCRIPTION
Fix the argument names to `FreeGroup.induction_on` and `FreeAddGroup.induction_on`. Name the motive `motive` and name the minor premises according to their contents.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
