### PR TITLE
[Merged by Bors] - feat: set `pp.mvars.anonymous false` for `MathlibTest`

### DIFF
--- a/MathlibTest/Algebra/MonoidAlgebra/Defs.lean
+++ b/MathlibTest/Algebra/MonoidAlgebra/Defs.lean
@@ -5,7 +5,6 @@ variable {R M A} [Semiring R] [Monoid M] [AddMonoid A]
 section Notation
 open scoped MonoidAlgebra AddMonoidAlgebra
 
-set_option pp.mvars.anonymous false
 -- TODO: could resolve ambiguity based on Monoid / AddMonoid
 /--
 error: Ambiguous term

--- a/MathlibTest/Attribute/ToAdditive/Basic.lean
+++ b/MathlibTest/Attribute/ToAdditive/Basic.lean
@@ -592,7 +592,7 @@ lemma one_eq_one'' {α : Type*} [One α] : (1 : α) = 1 := rfl
 
 /--
 error: `to_additive` validation failed: expected
-  ∀ {α : Type ?u.1} [inst : Zero α], 0 = 0
+  ∀ {α : Type _} [inst : Zero α], 0 = 0
 but 'Eq.trans' has type
   ∀ {α : Sort u} {a b c : α}, a = b → b = c → a = c
 -/

--- a/MathlibTest/Attribute/ToAdditive/Basic.lean
+++ b/MathlibTest/Attribute/ToAdditive/Basic.lean
@@ -98,7 +98,6 @@ instance : my_has_scalar Nat Nat := ⟨fun a b => a * b⟩
 
 set_option linter.translate.warnInvalid false in
 attribute [to_additive (reorder := α β) my_has_scalar] my_has_pow
-set_option pp.mvars.anonymous false in
 /--
 error: `to_additive` validation failed: expected
   {α : Type _} → {β : Type _} → [self : my_has_scalar β α] → α → β → α
@@ -107,7 +106,6 @@ but 'Test.my_has_scalar.smul' has type
 -/
 #guard_msgs in
 attribute [to_additive existing smul] my_has_pow.pow
-set_option pp.mvars.anonymous false in
 /--
 error: `to_additive` validation failed: expected
   {β : Type _} → {α : Type _} → [self : my_has_scalar β α] → α → β → α

--- a/MathlibTest/CategoryTheory/Bicategory/Basic.lean
+++ b/MathlibTest/CategoryTheory/Bicategory/Basic.lean
@@ -33,7 +33,6 @@ set_option backward.defeqAttrib.useBackward true in
 /-- error: expression contains metavariables:
 (F.map f ≫ η.app b) ≫ ?_ -/
 #guard_msgs in
-set_option pp.mvars false in
 example (η : F ⟶ G) {θ ι : G ⟶ H} (Γ : θ ⟶ ι) : η ≫ θ ⟶ η ≫ ι where
   as := {
     app a := η.app a ◁ Γ.as.app a

--- a/MathlibTest/CategoryTheory/CategoryStar.lean
+++ b/MathlibTest/CategoryTheory/CategoryStar.lean
@@ -4,8 +4,6 @@ import Mathlib.CategoryTheory.Functor.Category
 
 open CategoryTheory
 
-set_option pp.mvars.anonymous false
-
 section
 
 variable (C : Type*) [Category* C]

--- a/MathlibTest/CategoryTheory/Monoidal/Basic.lean
+++ b/MathlibTest/CategoryTheory/Monoidal/Basic.lean
@@ -30,7 +30,6 @@ example {V₁ V₂ V₃ : C} (R : ∀ V₁ V₂ : C, V₁ ⊗ V₂ ⟶ V₂ ⊗ 
 /-- error: expression contains metavariables:
 x ⊗ y ⊗ ?_ -/
 #guard_msgs in
-set_option pp.mvars false in
 example {x y z w : C} (f : x ⟶ y) (g : y ⟶ z) (h : x ⊗ y ⊗ w ⟶ y ⊗ z ⊗ w)
     (η : f ⊗ₘ (g ▷ w) = h) :
     (f ⊗ₘ g) ▷ w = 𝟙 _ ⊗≫ h ⊗≫ 𝟙 _ := by

--- a/MathlibTest/DefEqAbuse.lean
+++ b/MathlibTest/DefEqAbuse.lean
@@ -187,7 +187,7 @@ theorem zoC_eq_iff {α} [GrC α] (a : α) : NumC.fromNat 0 = a ↔ a = GrC.add a
 /--
 warning: #defeq_abuse: tactic fails with `backward.isDefEq.respectTransparency true` but succeeds with `false`.
 The following isDefEq checks are the root causes of the failure:
-  ❌️ @ZoC.zo Int instZoCInt =?= @ZoC.zo Int (@GrC.toZoC Int ?m.11)
+  ❌️ @ZoC.zo Int instZoCInt =?= @ZoC.zo Int (@GrC.toZoC Int ?_)
 -/
 #guard_msgs in
 example (a : Int) : NumC.fromNat 0 = a ↔ a = GrC.add a a := by

--- a/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
@@ -56,7 +56,6 @@ error: Could not find a model with corners for `TangentBundle (modelWithCornersS
 Hint: the expected type contains metavariables, maybe you need to provide an implicit argument
 -/
 #guard_msgs in
-set_option pp.mvars.anonymous false in
 lemma contMDiff_proj : CMDiff ∞ (proj) := by
   unfold proj
   exact contMDiff_snd_tangentBundle_modelSpace 𝕜 𝓘(𝕜)
@@ -419,7 +418,6 @@ error: Could not find a model with corners for `ContinuousLinearMap σ E'' E''''
 Hint: failures to find a model with corners can be debugged with the command `set_option trace.Elab.DiffGeo.MDiff true`.
 -/
 #guard_msgs in
-set_option pp.mvars.anonymous false in
 #check CMDiff 2 f
 
 variable {f : M → E'' →SL[σ] E''''} in
@@ -491,7 +489,6 @@ trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `M`
 -/
 #guard_msgs in
 set_option trace.Elab.DiffGeo.MDiff true in
-set_option pp.mvars.anonymous false in
 #check CMDiff 2 f
 
 end

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -565,7 +565,6 @@ error: Could not find a model with corners for `?_`.
 Hint: the expected type contains metavariables, maybe you need to provide an implicit argument
 -/
 #guard_msgs in
-set_option pp.mvars.anonymous false in
 #check UniqueMDiffAt[Set.univ] m
 
 variable {s : TopologicalSpace.Opens M}
@@ -589,7 +588,6 @@ in the application
   UniqueMDiffOn I s
 -/
 #guard_msgs in
-set_option pp.mvars.anonymous false in
 #check UniqueMDiffOn I s
 
 end UniqueMDiff

--- a/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
@@ -230,7 +230,6 @@ variable {g : E × E → E × E}
 #check MDifferentiable 𝓘(ℝ, E × E) ((𝓘(ℝ, E)).prod (𝓘(ℝ, E))) g
 
 -- This can yield rather confusing errors
-set_option pp.mvars.anonymous false in
 /--
 error: Tactic `apply` failed: could not unify the conclusion of `@mdifferentiable_id`
   MDiff id

--- a/MathlibTest/EuclideanSpace.lean
+++ b/MathlibTest/EuclideanSpace.lean
@@ -10,7 +10,6 @@ section delaborator
 #guard_msgs in
 #check !₂[1, 2, 3]
 
-set_option pp.mvars.anonymous false in
 /-- info: !₀[] : WithLp 0 (Fin 0 → ?_) -/
 #guard_msgs in
 #check !₀[]

--- a/MathlibTest/FinCoercions.lean
+++ b/MathlibTest/FinCoercions.lean
@@ -6,8 +6,6 @@
 module
 import Mathlib
 
-set_option pp.mvars.anonymous false
-
 -- We first verify that there is no global coercion from `Nat` to `Fin n`.
 -- Such a coercion would frequently introduce unexpected modular arithmetic.
 

--- a/MathlibTest/Tactic/Abel.lean
+++ b/MathlibTest/Tactic/Abel.lean
@@ -176,7 +176,6 @@ h : R (2 • myId x) (2 • myId x)
 ⊢ True
 -/
 #guard_msgs (trace) in
-set_option pp.mvars.anonymous false in
 example (x : ℤ) (R : ℤ → ℤ → Prop) [Std.Refl R] : True := by
   have h : R (myId x + x) (x + myId x) := refl _
   abel_nf at h

--- a/MathlibTest/Tactic/Check.lean
+++ b/MathlibTest/Tactic/Check.lean
@@ -1,6 +1,5 @@
 import Mathlib.Tactic.Check
 
-set_option pp.mvars.anonymous false
 set_option linter.unusedTactic false
 set_option linter.unusedVariables false
 

--- a/MathlibTest/Tactic/GRewrite.lean
+++ b/MathlibTest/Tactic/GRewrite.lean
@@ -114,7 +114,7 @@ example (h₁ : W ⊂ Y) (h₂ : X ⊂ (W ∪ Z)) : X ⊂ (Y ∪ Z) := by
 
 -- Binder names are preserved:
 /--
-trace: α : Type ?u.3
+trace: α : Type _
 X Y Z W : Set α
 a b : ℕ
 h : a < b
@@ -130,7 +130,7 @@ example {a b : Nat} (h : a < b) (f : Nat → Nat) (hf : ∀ i, 0 ≤ f i) :
   rfl
 
 /--
-trace: α : Type ?u.3
+trace: α : Type _
 X Y Z W : Set α
 ⊢ ∀ {α : Type u_1} [inst : LinearOrder α] (a b : α), max a b ≤ max a b
 -/

--- a/MathlibTest/Util/PrintSorries.lean
+++ b/MathlibTest/Util/PrintSorries.lean
@@ -1,7 +1,5 @@
 import Mathlib.Util.PrintSorries
 
-set_option pp.mvars.anonymous false
-
 /-!
 Direct use of `sorry`
 -/

--- a/MathlibTest/Widget/Conv.lean
+++ b/MathlibTest/Widget/Conv.lean
@@ -152,7 +152,6 @@ example : 1 = Nat.log2 4 → False := by
   test "/0/1/1"
   exact test_sorry
 
-set_option pp.mvars.anonymous false in
 /--
 info: `conv?` would output:
 conv =>

--- a/MathlibTest/superscript.lean
+++ b/MathlibTest/superscript.lean
@@ -194,7 +194,6 @@ open Nat' (γ) in
 #guard_msgs in #check testsub(ᵧ ₙ)
 
 /- The delaborator should reject metavariables. -/
-set_option pp.mvars.anonymous false in
 /-- info: checkSubscript ?_ : Unit -/
 #guard_msgs in #check checkSubscript ?_
 
@@ -229,7 +228,6 @@ open Nat' (γ) in
 #guard_msgs in #check testsup(ᵞ ⁿ)
 
 /- The delaborator should reject metavariables. -/
-set_option pp.mvars false in
 /-- info: checkSuperscript ?_ : Unit -/
 #guard_msgs in #check checkSuperscript ?_
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -39,13 +39,19 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
 ]
 
 /-- These options are passed as `leanOptions` to building mathlib, as well as the
-`Archive` and `Counterexamples`. (`tests` omits the first two options.) -/
+`Archive` and `Counterexamples`. -/
 abbrev mathlibLeanOptions := #[
     ⟨`pp.unicode.fun, true⟩, -- pretty-prints `fun a ↦ b`
     ⟨`autoImplicit, false⟩,
     ⟨`maxSynthPendingDepth, .ofNat 3⟩,
   ] ++ -- options that are used in `lake build`
     mathlibOnlyLinters.map fun s ↦ { s with name := `weak ++ s.name }
+
+/-- These options are passed as `leanOptions` when building `MathlibTest`. We don't use the typical
+mathlib options in order to simulate the default downstream environment. -/
+abbrev mathlibTestOptions : Array LeanOption := #[
+    ⟨`pp.mvars.anonymous, false⟩ -- test stability: pretty-print `?m.37` as `?_`
+  ]
 
 package mathlib where
   testDriver := "MathlibTest"
@@ -79,6 +85,7 @@ lean_lib Cache where
 
 lean_lib MathlibTest where
   globs := #[`MathlibTest.+]
+  leanOptions := mathlibTestOptions
 
 lean_lib Archive where
   leanOptions := mathlibLeanOptions


### PR DESCRIPTION
This PR sets `pp.mvars.anonymous false` for `MathlibTest` in the lakefile, and removes the now-superfluous `set_option`s which did so in individual tests.

In tests, we always want to set this option (which pretty-prints autogenerated mvars such as `?m.37` as `?_`) to ensure that they are stable. Instead of looking for it during review, we can just have it always set to the correct value by default.

In fact, this PR also catches some unstable tests which slipped past during review.

It also documents the decision to not use the standard mathlib options, and removes stale documentation around `mathlibLeanOptions`. (Note: `mathlibLeanOptions` implicitly says that tests should use ``⟨`maxSynthPendingDepth, .ofNat 3⟩``, but we've been getting by just fine without that.)

So far this is the only option for `MathlibTest`, but we may as well still put it in an array to hold the documentation and not interrupt the flow of `lean_lib`s. (And maybe make it easier set other options for MathlibTest in the future if we find we need them.)


---

I'm not sure whether this is a chore or a feat! Since it's a lakefile change I erred on the side of "feat".

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
