### PR TITLE
feat(ModelTheory): add counting formulas

### DIFF
--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -479,6 +479,22 @@ theorem exists_subset_encard_eq {k : ℕ∞} (hk : k ≤ s.encard) : ∃ t, t �
     exact ⟨insert x t₀, insert_subset hx.1 ht₀s, by rw [encard_insert_of_notMem hx.2, ht₀]⟩
   | top => rw [top_le_iff] at hk; exact ⟨s, Subset.rfl, hk⟩
 
+/-- An injection from `Fin n` into a set is equivalent to a lower bound of `n` on its extended
+cardinality. -/
+theorem le_encard_iff_exists_injection_fin (s : Set α) (n : ℕ) :
+    (n : ℕ∞) ≤ s.encard ↔ ∃ f : Fin n → α, (∀ i, f i ∈ s) ∧ Function.Injective f := by
+  constructor
+  · intro h
+    obtain ⟨t, hts, hte⟩ := exists_subset_encard_eq h
+    letI := (finite_of_encard_eq_coe hte).fintype
+    let e := Fintype.equivFinOfCardEq <| ENat.natCast_inj.mp <| (coe_fintypeCard t).trans hte
+    exact ⟨Subtype.val ∘ e.symm, fun i ↦ hts (e.symm i).2,
+      (Equiv.injective_comp e.symm Subtype.val).mpr Subtype.val_injective⟩
+  · rintro ⟨f, hf, hfi⟩
+    simpa only [ENat.card_eq_coe_fintype_card, Fintype.card_fin,
+      ENat.card_coe_set_eq] using ENat.card_le_card_of_injective
+        (f := fun i : Fin n ↦ ⟨f i, hf i⟩) (fun _ _ hi ↦ hfi (Subtype.ext_iff.mp hi))
+
 theorem exists_superset_subset_encard_eq {k : ℕ∞}
     (hst : s ⊆ t) (hsk : s.encard ≤ k) (hkt : k ≤ t.encard) :
     ∃ r, s ⊆ r ∧ r ⊆ t ∧ r.encard = k := by

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -6,8 +6,9 @@ Authors: Aaron Anderson, Jesse Michael Han, Floris van Doorn
 module
 
 public import Mathlib.Data.Finset.Basic
-public import Mathlib.ModelTheory.Syntax
 public import Mathlib.Data.List.ProdSigma
+public import Mathlib.Data.Set.Card
+public import Mathlib.ModelTheory.Syntax
 
 /-!
 # Basics on First-Order Semantics
@@ -33,6 +34,9 @@ in a style inspired by the [Flypitch project](https://flypitch.github.io/).
 - Several results in this file show that syntactic constructions such as `relabel`, `castLE`,
   `liftAt`, `subst`, and the actions of language maps commute with realization of terms, formulas,
   sentences, and theories.
+- `FirstOrder.Language.Formula.realize_iExsAtLeast`, `realize_iExsAtMost`, and
+  `realize_iExsExactly` characterize counting formulas using the extended cardinality of their
+  realization sets.
 
 ## Implementation Notes
 
@@ -941,6 +945,82 @@ theorem realize_iExsUnique [Finite γ] {φ : L.Formula (α ⊕ γ)} {v : α → 
 end BoundedFormula
 
 namespace Formula
+
+/-- Realization of `iExsAtLeast` is equivalent to the existence of an injective family of `n`
+pairwise distinct realizing assignments to the `β`-variables. -/
+theorem realize_iExsAtLeast_iff_exists_injective [Finite β]
+    (φ : L.Formula (α ⊕ β)) (v : α → M) (n : ℕ) :
+    (φ.iExsAtLeast β n).Realize v ↔
+      ∃ f : Fin n → (β → M), (∀ i, φ.Realize (Sum.elim v (f i))) ∧ Function.Injective f := by
+  simp only [iExsAtLeast, ne_eq, realize_iExs, realize_inf, realize_iInf, realize_relabel,
+    realize_not, realize_equal, Term.realize_var, Sum.elim_inr, not_forall, Subtype.forall,
+    Prod.forall]
+  refine (Equiv.curry (Fin n) β M).exists_congr fun u ↦ and_congr ?_ ?_
+  · refine forall_congr' fun i ↦ iff_of_eq <| congrArg φ.Realize ?_
+    funext x
+    cases x <;> rfl
+  · rw [Function.injective_iff_pairwise_ne]
+    simp [Pairwise, funext_iff, Function.onFun]
+
+/-- The formula `iExsAtLeast β n φ` is realized exactly when the realization set of `φ` has
+extended cardinality at least `n`. -/
+@[simp]
+theorem realize_iExsAtLeast [Finite β] (φ : L.Formula (α ⊕ β)) (v : α → M) (n : ℕ) :
+    (φ.iExsAtLeast β n).Realize v ↔
+      (n : ℕ∞) ≤ {x : β → M | φ.Realize (Sum.elim v x)}.encard := by
+  simp only [realize_iExsAtLeast_iff_exists_injective, Set.le_encard_iff_exists_injection_fin,
+    Set.mem_ofPred_eq]
+
+/-- The formula `iExsAtMost β n φ` is realized exactly when the realization set of `φ` has
+extended cardinality at most `n`. -/
+@[simp]
+theorem realize_iExsAtMost [Finite β] (φ : L.Formula (α ⊕ β)) (v : α → M) (n : ℕ) :
+    (φ.iExsAtMost β n).Realize v ↔
+      {x : β → M | φ.Realize (Sum.elim v x)}.encard ≤ n := by
+  simpa [iExsAtMost] using ENat.lt_natCast_add_one_iff
+
+/-- The formula `iExsExactly β n φ` is realized exactly when the realization set of `φ` has
+extended cardinality `n`. -/
+@[simp]
+theorem realize_iExsExactly [Finite β] (φ : L.Formula (α ⊕ β)) (v : α → M) (n : ℕ) :
+    (φ.iExsExactly β n).Realize v ↔
+      {x : β → M | φ.Realize (Sum.elim v x)}.encard = n := by
+  simpa [iExsExactly] using Iff.symm ge_antisymm_iff
+
+/-- Exact cardinality zero means there is no realizing assignment to the `β`-variables. -/
+theorem realize_iExsExactly_zero [Finite β] (φ : L.Formula (α ⊕ β)) (v : α → M) :
+    (φ.iExsExactly β 0).Realize v ↔ ¬∃ x : β → M, φ.Realize (Sum.elim v x) := by
+  simp only [realize_iExsExactly, Nat.cast_zero, Set.encard_eq_zero, not_exists]
+  exact Set.eq_empty_iff_forall_notMem
+
+/-- Exact cardinality one is semantically equivalent to unique existence. -/
+theorem realize_iExsExactly_one_iff_iExsUnique [Finite β]
+    (φ : L.Formula (α ⊕ β)) (v : α → M) :
+    (φ.iExsExactly β 1).Realize v ↔ (φ.iExsUnique β).Realize v := by
+  rw [realize_iExsExactly, Nat.cast_one, realize_iExsUnique, Set.encard_eq_one]
+  constructor
+  · rintro ⟨x, hx⟩
+    have hmem := Set.ext_iff.mp hx
+    exact ⟨x, (hmem x).2 rfl, fun y hy ↦ (hmem y).1 hy⟩
+  · rintro ⟨x, hx, hunique⟩
+    refine ⟨x, Set.ext fun y ↦ ?_⟩
+    simp only [Set.mem_ofPred_eq, Set.mem_singleton_iff]
+    exact ⟨hunique y, fun hy ↦ hy ▸ hx⟩
+
+/-- Having at most `n` realizations is the negation of having at least `n + 1` realizations. -/
+theorem realize_iExsAtMost_iff_not_iExsAtLeast_succ [Finite β]
+    (φ : L.Formula (α ⊕ β)) (v : α → M) (n : ℕ) :
+    (φ.iExsAtMost β n).Realize v ↔ ¬(φ.iExsAtLeast β (n + 1)).Realize v := by
+  simpa using Iff.symm ENat.lt_natCast_add_one_iff
+
+/-- Having at most `n` realizations rules out any injective family of `n + 1` realizations. -/
+theorem realize_iExsAtMost_iff_not_exists_injection [Finite β]
+    (φ : L.Formula (α ⊕ β)) (v : α → M) (n : ℕ) :
+    (φ.iExsAtMost β n).Realize v ↔
+      ¬∃ f : Fin (n + 1) → (β → M),
+        (∀ i, φ.Realize (Sum.elim v (f i))) ∧ Function.Injective f := by
+  simpa only [realize_iExsAtMost_iff_not_iExsAtLeast_succ] using
+    not_congr (realize_iExsAtLeast_iff_exists_injective φ v (n + 1))
 
 @[simp]
 theorem realize_exClosure [DecidableEq α] (φ : L.Formula α) :

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -22,6 +22,8 @@ This file defines first-order terms, formulas, sentences, and theories in a styl
   variables indexed by `α`.
 - A `FirstOrder.Language.Formula` is defined so that `L.Formula α` is the type of `L`-formulas with
   free variables indexed by `α`.
+- `FirstOrder.Language.Formula.iExsAtLeast`, `iExsAtMost`, and `iExsExactly` express finite
+  cardinality bounds on the set of realizations of a formula.
 - A `FirstOrder.Language.Sentence` is a formula with no free variables.
 - A `FirstOrder.Language.Theory` is a set of sentences.
 - The variables of terms and formulas can be relabelled with `FirstOrder.Language.Term.relabel`,
@@ -808,6 +810,32 @@ Note that this is an arbitrary formula defined using the axiom of choice. It is 
 to equivalence of formulas. -/
 noncomputable def iInf [Finite α] (f : α → L.Formula β) : L.Formula β :=
   BoundedFormula.iInf f
+
+variable (β) in
+/-- Asserts that `φ` has at least `n` pairwise distinct realizations as assignments to the
+`β`-variables. -/
+noncomputable def iExsAtLeast [Finite β] (n : ℕ) (φ : L.Formula (α ⊕ β)) : L.Formula α :=
+  let realizeAt (i : Fin n) : L.Formula (α ⊕ (Fin n × β)) :=
+    φ.relabel (Sum.map id fun b ↦ (i, b))
+  let tupleNe (i j : Fin n) : L.Formula (α ⊕ (Fin n × β)) :=
+    (iInf fun b : β ↦
+      (Term.var (Sum.inr (i, b))).equal (Term.var (Sum.inr (j, b)))).not
+  let NePair := {ij : Fin n × Fin n // ij.1 ≠ ij.2}
+  let witnessesRealize : L.Formula (α ⊕ (Fin n × β)) :=
+    iInf fun i : Fin n ↦ realizeAt i
+  let witnessesDistinct : L.Formula (α ⊕ (Fin n × β)) :=
+    iInf fun ij : NePair ↦ tupleNe ij.1.1 ij.1.2
+  (witnessesRealize ⊓ witnessesDistinct).iExs (Fin n × β)
+
+variable (β) in
+/-- Asserts that `φ` has at most `n` realizations as assignments to the `β`-variables. -/
+noncomputable def iExsAtMost [Finite β] (n : ℕ) (φ : L.Formula (α ⊕ β)) : L.Formula α :=
+  (φ.iExsAtLeast β (n + 1)).not
+
+variable (β) in
+/-- Asserts that `φ` has exactly `n` realizations as assignments to the `β`-variables. -/
+noncomputable def iExsExactly [Finite β] (n : ℕ) (φ : L.Formula (α ⊕ β)) : L.Formula α :=
+  φ.iExsAtLeast β n ⊓ φ.iExsAtMost β n
 
 /-- A bijection sending formulas to sentences with constants. -/
 def equivSentence : L.Formula α ≃ L[[α]].Sentence :=


### PR DESCRIPTION
Add formula constructors expressing at least, at most, and exactly finitely many realizations, together with their semantic characterizations.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #42024 

AI disclosure: I used Codex to generate the Lean declarations and documentation in this PR.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
