### PR TITLE
[Merged by Bors] - chore(Data/FunLike): tag `IsApply` lemmas as simp

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -178,15 +178,6 @@ open Complex
 
 variable {f g : ℂ → ℂ} {s : Set ℂ} {f' g' x c : ℂ}
 
-/-- A private lemma that rewrites the output of lemmas like `HasFDerivAt.cpow` to the form
-expected by lemmas like `HasDerivAt.cpow`. -/
-private theorem aux : ((g x * f x ^ (g x - 1)) • (1 : ℂ →L[ℂ] ℂ).smulRight f' +
-    (f x ^ g x * log (f x)) • (1 : ℂ →L[ℂ] ℂ).smulRight g') 1 =
-      g x * f x ^ (g x - 1) * f' + f x ^ g x * log (f x) * g' := by
-  simp only [smul_eq_mul, one_mul, one_apply_eq_self,
-    ContinuousLinearMap.smulRight_apply, add_apply, Pi.smul_apply,
-    FunLike.coe_smul']
-
 nonrec theorem HasStrictDerivAt.cpow (hf : HasStrictDerivAt f f' x) (hg : HasStrictDerivAt g g' x)
     (h0 : f x ∈ slitPlane) : HasStrictDerivAt (fun x => f x ^ g x)
       (g x * f x ^ (g x - 1) * f' + f x ^ g x * Complex.log (f x) * g') x := by
@@ -209,7 +200,7 @@ theorem HasStrictDerivAt.cpow_const (hf : HasStrictDerivAt f f' x)
 theorem HasDerivAt.cpow (hf : HasDerivAt f f' x) (hg : HasDerivAt g g' x)
     (h0 : f x ∈ slitPlane) : HasDerivAt (fun x => f x ^ g x)
       (g x * f x ^ (g x - 1) * f' + f x ^ g x * Complex.log (f x) * g') x := by
-  simpa [aux] using (hf.hasFDerivAt.cpow hg h0).hasDerivAt
+  simpa using (hf.hasFDerivAt.cpow hg h0).hasDerivAt
 
 theorem HasDerivAt.const_cpow (hf : HasDerivAt f f' x) (h0 : c ≠ 0 ∨ f x ≠ 0) :
     HasDerivAt (fun x => c ^ f x) (c ^ f x * Complex.log c * f') x :=
@@ -222,7 +213,7 @@ theorem HasDerivAt.cpow_const (hf : HasDerivAt f f' x) (h0 : f x ∈ slitPlane) 
 theorem HasDerivWithinAt.cpow (hf : HasDerivWithinAt f f' s x) (hg : HasDerivWithinAt g g' s x)
     (h0 : f x ∈ slitPlane) : HasDerivWithinAt (fun x => f x ^ g x)
       (g x * f x ^ (g x - 1) * f' + f x ^ g x * Complex.log (f x) * g') s x := by
-  simpa [aux] using (hf.hasFDerivWithinAt.cpow hg h0).hasDerivWithinAt
+  simpa using (hf.hasFDerivWithinAt.cpow hg h0).hasDerivWithinAt
 
 theorem HasDerivWithinAt.const_cpow (hf : HasDerivWithinAt f f' s x) (h0 : c ≠ 0 ∨ f x ≠ 0) :
     HasDerivWithinAt (fun x => c ^ f x) (c ^ f x * Complex.log c * f') s x :=

--- a/Mathlib/Data/FunLike/IsApply.lean
+++ b/Mathlib/Data/FunLike/IsApply.lean
@@ -232,8 +232,7 @@ theorem coe_smul [SMul M F] [SMul M β] [IsSMulApply M F α β] (n : M) (f : F) 
     ↑(n • f) = n • (f : α → β) := by
   ext; simp
 
--- `to_additive` on this creates a copy of `coe_smul` but with the arguments in the wrong order
-@[simp, norm_cast]
+@[simp, norm_cast, to_additive existing coe_smul]
 theorem coe_pow [Pow F M] [Pow β M] [IsPowApply M F α β] (f : F) (n : M) :
     ↑(f ^ n) = (f : α → β) ^ n := by
   ext; simp

--- a/Mathlib/Data/FunLike/IsApply.lean
+++ b/Mathlib/Data/FunLike/IsApply.lean
@@ -260,20 +260,25 @@ lemma coe_pow_eq_iterate [Monoid F'] [IsMulApplyEqComp F' α] [IsOneApplyEqSelf 
     (f : F') (n : ℕ) : ⇑(f ^ n) = f^[n] :=
   funext <| pow_apply_eq_iterate f n
 
--- these lemmas seem to be misnamed? the FunLike coercion isn't used in the statement!
+-- this lemma cannot be `simp` since this creates loops
 @[norm_cast]
-theorem coe_natCast [NatCast F'] [One F'] [SMul Nat α] [SMul Nat F'] [IsSMulApply Nat F' α α]
-    [IsNatCastApply F' α] [IsOneApplyEqSelf F' α] (n : Nat) :
+theorem natCast_eq_nsmul_one [NatCast F'] [One F'] [SMul Nat α] [SMul Nat F']
+    [IsSMulApply Nat F' α α] [IsNatCastApply F' α] [IsOneApplyEqSelf F' α] (n : ℕ) :
   (n : F') = n • (1 : F') := by
   apply DFunLike.ext
   simp
 
+@[deprecated (since := "2026-07-24")] alias coe_natCast := natCast_eq_nsmul_one
+
+-- this lemma cannot be `simp` since this creates loops
 @[norm_cast]
-theorem coe_intCast [IntCast F'] [One F'] [SMul Int α] [SMul Int F'] [IsSMulApply Int F' α α]
-    [IsIntCastApply F' α] [IsOneApplyEqSelf F' α] (n : Int) :
+theorem intCast_eq_zsmul_one [IntCast F'] [One F'] [SMul Int α] [SMul Int F']
+    [IsSMulApply Int F' α α] [IsIntCastApply F' α] [IsOneApplyEqSelf F' α] (n : ℤ) :
   (n : F') = n • (1 : F') := by
   apply DFunLike.ext
   simp
+
+@[deprecated (since := "2026-07-24")] alias coe_intCast := intCast_eq_zsmul_one
 
 end Coercion
 

--- a/Mathlib/Data/FunLike/IsApply.lean
+++ b/Mathlib/Data/FunLike/IsApply.lean
@@ -232,6 +232,8 @@ theorem coe_smul [SMul M F] [SMul M β] [IsSMulApply M F α β] (n : M) (f : F) 
     ↑(n • f) = n • (f : α → β) := by
   ext; simp
 
+@[deprecated (since := "2026-07-23")] alias coe_smul' := coe_smul
+
 @[simp, norm_cast, to_additive existing coe_smul]
 theorem coe_pow [Pow F M] [Pow β M] [IsPowApply M F α β] (f : F) (n : M) :
     ↑(f ^ n) = (f : α → β) ^ n := by

--- a/Mathlib/Data/FunLike/IsApply.lean
+++ b/Mathlib/Data/FunLike/IsApply.lean
@@ -204,7 +204,7 @@ variable {M M' F F' α β : Type*} [FunLike F α β] [FunLike F' α α]
 
 section Coercion
 
-@[to_additive (attr := norm_cast)]
+@[to_additive (attr := simp, norm_cast)]
 theorem coe_one [One F] [One β] [IsOneApply F α β] : ↑(1 : F) = (1 : α → β) := by ext; simp
 
 @[to_additive (attr := simp)]
@@ -213,53 +213,53 @@ theorem coe_one_iff [One F] [One β] [IsOneApply F α β] (f : F) : (f : α → 
   · intro h
     simp [DFunLike.ext_iff, h]
   · intro h
-    simp [funext_iff, h]
+    simp [h]
 
-@[to_additive (attr := norm_cast)]
+@[to_additive (attr := simp, norm_cast)]
 theorem coe_mul [Mul F] [Mul β] [IsMulApply F α β] (f g : F) : ↑(f * g) = (f : α → β) * g := by
   ext; simp
 
-@[to_additive (attr := norm_cast)]
+@[to_additive (attr := simp, norm_cast)]
 theorem coe_div [Div F] [Div β] [IsDivApply F α β] (f g : F) : ↑(f / g) = (f : α → β) / g := by
   ext; simp
 
-@[to_additive (attr := norm_cast)]
+@[to_additive (attr := simp, norm_cast)]
 theorem coe_inv [Inv F] [Inv β] [IsInvApply F α β] (f : F) : ↑(f⁻¹) = (f : α → β)⁻¹ := by
   ext; simp
 
-@[to_additive (attr := norm_cast)]
+@[to_additive (attr := simp, norm_cast)]
 theorem coe_smul [SMul M F] [SMul M β] [IsSMulApply M F α β] (n : M) (f : F) :
     ↑(n • f) = n • (f : α → β) := by
   ext; simp
 
-@[to_additive coe_smul']
+-- `to_additive` on this creates a copy of `coe_smul` but with the arguments in the wrong order
+@[simp, norm_cast]
 theorem coe_pow [Pow F M] [Pow β M] [IsPowApply M F α β] (f : F) (n : M) :
     ↑(f ^ n) = (f : α → β) ^ n := by
   ext; simp
 
-attribute [norm_cast] coe_pow
-
-@[norm_cast]
+@[simp, norm_cast]
 theorem coe_one_eq_id [One F'] [IsOneApplyEqSelf F' α] : ↑(1 : F') = id := by
   ext; simp
 
-@[simp]
+@[simp, norm_cast]
 theorem coe_one_eq_id_iff [One F'] [IsOneApplyEqSelf F' α] (f : F') : (f : α → α) = id ↔ f = 1 := by
   constructor
   · intro h
     simp [DFunLike.ext_iff, h]
   · intro h
-    simp [funext_iff, h]
+    simp [h]
 
-@[norm_cast]
+@[simp, norm_cast]
 theorem coe_mul_eq_comp [Mul F'] [IsMulApplyEqComp F' α] (f g : F') : ↑(f * g) = f ∘ g := by
   ext; simp
 
-@[norm_cast]
+@[simp, norm_cast]
 lemma coe_pow_eq_iterate [Monoid F'] [IsMulApplyEqComp F' α] [IsOneApplyEqSelf F' α]
     (f : F') (n : ℕ) : ⇑(f ^ n) = f^[n] :=
   funext <| pow_apply_eq_iterate f n
 
+-- these lemmas seem to be misnamed? the FunLike coercion isn't used in the statement!
 @[norm_cast]
 theorem coe_natCast [NatCast F'] [One F'] [SMul Nat α] [SMul Nat F'] [IsSMulApply Nat F' α α]
     [IsNatCastApply F' α] [IsOneApplyEqSelf F' α] (n : Nat) :

--- a/Mathlib/LinearAlgebra/Eigenspace/ContinuousLinearMap.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/ContinuousLinearMap.lean
@@ -26,8 +26,7 @@ variable {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M] [TopologicalSp
 open Module End
 
 instance isClosed_genEigenspace : IsClosed (genEigenspace (f : End R M) μ n : Set M) := by
-  rw [genEigenspace_nat, one_eq_id, ← coe_id, ← toLinearMap_smul, ← toLinearMap_sub, ← coe_pow]
-  apply isClosed_ker
+  simpa [genEigenspace_nat] using isClosed_ker ↑((f - μ • 1) ^ n)
 
 instance isClosed_eigenspace : IsClosed (eigenspace (f : End R M) μ : Set M) :=
   isClosed_genEigenspace f μ 1

--- a/Mathlib/MeasureTheory/VectorMeasure/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/SetIntegral.lean
@@ -252,7 +252,7 @@ theorem setIntegral_of_variation_apply_eq_zero (f : X → E) {s : Set X}
     rw [variation_restrict h's]
     apply Measure.restrict_eq_zero.2 hs
   have : μ.restrict s = 0 := variation_eq_zero.1 this
-  simpa [integral_eq_setToFun, this] using! setToFun_zero_left
+  simp [this]
 
 theorem setIntegral_dirac' {mX : MeasurableSpace X} [CompleteSpace G] {a : X} {v : F}
     (hf : StronglyMeasurable f) {s : Set X} (hs : MeasurableSet s) [Decidable (a ∈ s)] :

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/TwoVariable.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/TwoVariable.lean
@@ -182,10 +182,9 @@ lemma norm_jacobiTheta₂_term_fderiv_ge (n : ℤ) (z τ : ℂ) :
     refine (ContinuousLinearMap.le_opNorm _ _).trans ?_
     simp_rw [Prod.norm_def, norm_one, norm_zero, max_eq_right zero_le_one, mul_one, le_refl]
   refine le_trans ?_ this
-  simp_rw [jacobiTheta₂_term_fderiv, jacobiTheta₂_term, FunLike.coe_smul',
-    Pi.smul_apply, add_apply, FunLike.coe_smul',
-    ContinuousLinearMap.coe_fst', ContinuousLinearMap.coe_snd', Pi.smul_apply, smul_zero, zero_add,
-    smul_eq_mul, mul_one, mul_comm _ ‖cexp _‖, norm_mul]
+  simp_rw [jacobiTheta₂_term_fderiv, jacobiTheta₂_term, FunLike.coe_smul, Pi.smul_apply, add_apply,
+    FunLike.coe_smul, ContinuousLinearMap.coe_fst', ContinuousLinearMap.coe_snd', Pi.smul_apply,
+    smul_zero, zero_add, smul_eq_mul, mul_one, mul_comm _ ‖cexp _‖, norm_mul]
   refine mul_le_mul_of_nonneg_left (le_of_eq ?_) (norm_nonneg _)
   simp_rw [norm_real, norm_of_nonneg pi_pos.le, norm_I, mul_one,
     Int.cast_abs, ← norm_intCast, norm_pow]
@@ -346,11 +345,8 @@ lemma hasDerivAt_jacobiTheta₂_fst (z : ℂ) {τ : ℂ} (hτ : 0 < im τ) :
       ((jacobiTheta₂_fderiv z τ) (1, 0)) := by
     apply eval_fst_CLM.hasSum (hasSum_jacobiTheta₂_term_fderiv z hτ)
   have step2 (n : ℤ) : (jacobiTheta₂_term_fderiv n z τ) (1, 0) = jacobiTheta₂'_term n z τ := by
-    simp only [jacobiTheta₂_term_fderiv, smul_add, add_apply,
-      FunLike.coe_smul', ContinuousLinearMap.coe_fst', Pi.smul_apply, smul_eq_mul,
-      mul_one, ContinuousLinearMap.coe_snd', mul_zero, add_zero, jacobiTheta₂'_term,
-      jacobiTheta₂_term, mul_comm _ (cexp _)]
-  rw [funext step2] at step1
+    simp [jacobiTheta₂_term_fderiv, jacobiTheta₂'_term, jacobiTheta₂_term, mul_comm]
+  simp only [step2] at step1
   have step3 : HasDerivAt (fun x ↦ jacobiTheta₂ x τ) ((jacobiTheta₂_fderiv z τ) (1, 0)) z :=
     (((hasFDerivAt_jacobiTheta₂ z hτ).comp z (hasFDerivAt_prodMk_left z τ)).hasDerivAt :)
   rwa [← step1.tsum_eq] at step3

--- a/Mathlib/Probability/Distributions/Gaussian/Basic.lean
+++ b/Mathlib/Probability/Distributions/Gaussian/Basic.lean
@@ -51,8 +51,10 @@ instance IsGaussian.toIsProbabilityMeasure {E : Type*} [TopologicalSpace E] [Add
     [Module ℝ E] {mE : MeasurableSpace E} (μ : Measure E) [IsGaussian μ] :
     IsProbabilityMeasure μ where
   measure_univ := by
-    have : μ.map (0 : StrongDual ℝ E) Set.univ = 1 := by simp [IsGaussian.map_eq_gaussianReal]
-    simpa [Measure.map_apply (by fun_prop : Measurable (0 : StrongDual ℝ E)) .univ] using this
+    have : μ.map (0 : StrongDual ℝ E) Set.univ = 1 := by
+      simp [-FunLike.coe_zero, IsGaussian.map_eq_gaussianReal]
+    simpa [-FunLike.coe_zero,
+      Measure.map_apply (by fun_prop : Measurable (0 : StrongDual ℝ E)) .univ] using this
 
 /-- A real Gaussian measure is Gaussian. -/
 instance isGaussian_gaussianReal (m : ℝ) (v : ℝ≥0) : IsGaussian (gaussianReal m v) where
@@ -171,8 +173,7 @@ theorem isGaussian_iff_charFunDual_eq {μ : Measure E} [IsFiniteMeasure μ] :
   refine ⟨fun h ↦ h.charFunDual_eq, fun h ↦ ⟨fun L ↦ Measure.ext_of_charFun ?_⟩⟩
   ext u
   rw [charFun_map_eq_charFunDual_smul L u, h (u • L), charFun_gaussianReal]
-  simp only [FunLike.coe_smul', Pi.smul_apply, smul_eq_mul, ofReal_mul,
-    Real.coe_toNNReal']
+  simp only [FunLike.coe_smul, Pi.smul_apply, smul_eq_mul, ofReal_mul, Real.coe_toNNReal']
   congr
   · rw [integral_const_mul, integral_complex_ofReal]
   · rw [max_eq_left (variance_nonneg _ _), mul_comm, ← ofReal_pow, ← ofReal_mul,

--- a/Mathlib/Probability/Distributions/Gaussian/Basic.lean
+++ b/Mathlib/Probability/Distributions/Gaussian/Basic.lean
@@ -173,7 +173,7 @@ theorem isGaussian_iff_charFunDual_eq {μ : Measure E} [IsFiniteMeasure μ] :
   refine ⟨fun h ↦ h.charFunDual_eq, fun h ↦ ⟨fun L ↦ Measure.ext_of_charFun ?_⟩⟩
   ext u
   rw [charFun_map_eq_charFunDual_smul L u, h (u • L), charFun_gaussianReal]
-  simp only [FunLike.coe_smul, Pi.smul_apply, smul_eq_mul, ofReal_mul, Real.coe_toNNReal']
+  simp only [smul_apply, smul_eq_mul, ofReal_mul, Real.coe_toNNReal']
   congr
   · rw [integral_const_mul, integral_complex_ofReal]
   · rw [max_eq_left (variance_nonneg _ _), mul_comm, ← ofReal_pow, ← ofReal_mul,

--- a/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Basic.lean
@@ -589,13 +589,12 @@ theorem toLinearMap_mul (f g : M₁ →L[R₁] M₁) : (↑(f * g) : M₁ →ₗ
 instance monoidWithZero : MonoidWithZero (M₁ →L[R₁] M₁) :=
   fast_instance% FunLike.monoidWithZero
 
-@[simp, norm_cast]
-theorem coe_pow' (f : M₁ →L[R₁] M₁) (n : ℕ) : ⇑(f ^ n) = f^[n] :=
-  hom_coe_pow _ rfl (fun _ _ ↦ rfl) _ _
+@[deprecated (since := "2026-07-23")] alias coe_pow' := FunLike.coe_pow_eq_iterate
 
 @[simp, norm_cast]
 theorem coe_pow (f : M₁ →L[R₁] M₁) (n : ℕ) : (↑(f ^ n) : M₁ →ₗ[R₁] M₁) = f ^ n :=
-  DFunLike.ext' <| (coe_pow' f n).trans <| .symm <| hom_coe_pow _ rfl (fun _ _ ↦ rfl) _ _
+  DFunLike.ext' <| (FunLike.coe_pow_eq_iterate f n).trans
+    <| .symm <| hom_coe_pow _ rfl (fun _ _ ↦ rfl) _ _
 
 instance instNatCast [ContinuousAdd M₁] : NatCast (M₁ →L[R₁] M₁) where
   natCast n := n • (1 : M₁ →L[R₁] M₁)

--- a/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Basic.lean
@@ -592,9 +592,11 @@ instance monoidWithZero : MonoidWithZero (M₁ →L[R₁] M₁) :=
 @[deprecated (since := "2026-07-23")] alias coe_pow' := FunLike.coe_pow_eq_iterate
 
 @[simp, norm_cast]
-theorem coe_pow (f : M₁ →L[R₁] M₁) (n : ℕ) : (↑(f ^ n) : M₁ →ₗ[R₁] M₁) = f ^ n :=
+theorem toLinearMap_pow (f : M₁ →L[R₁] M₁) (n : ℕ) : (↑(f ^ n) : M₁ →ₗ[R₁] M₁) = f ^ n :=
   DFunLike.ext' <| (FunLike.coe_pow_eq_iterate f n).trans
     <| .symm <| hom_coe_pow _ rfl (fun _ _ ↦ rfl) _ _
+
+@[deprecated (since := "2026-07-24")] protected alias coe_pow := toLinearMap_pow
 
 instance instNatCast [ContinuousAdd M₁] : NatCast (M₁ →L[R₁] M₁) where
   natCast n := n • (1 : M₁ →L[R₁] M₁)


### PR DESCRIPTION
The new `IsApply` typeclasses allow many existing special-case `coe_xxx` lemmas to be unified; but the general lemmas currently do not have the simp tag. This tags them as simp. 

Other minor changes:
- There were two lemmas with statements identical up to argument order: `FunLike.coe_smul` (directly written) and `FunLike.coe_smul'` (auto-generated by `to_additive`). I unified these using `to_additive existing`, with a deprecation alias for `FunLike.coe_smul'`.
- Downstream code that uses `FunLike.coe_smul'` is adjusted appropriately (un-squeezing a couple of lengthy terminal `simp only`'s in the process).
- One more specific simp lemma downstream (`ContinuousLinearMap.coe_pow'`) is removed, because `simp` can now prove it using the `FunLike` simp lemmas. A misnamed lemma in this file, `ContinuousLinearMap.coe_pow`, was re-named to `ContinuousLinearMap.toLinearMap_pow`.
- There were just two simps (both in `Mathlib/Probability/Distributions/Gaussian/Basic.lean`) which broke, because they used an un-squeezed `simp` along with an additional explicitly provided lemma (not part of the default simp set) that conflicted with `FunLike.coe_zero`. These I fixed by explicitly removing `FunLike.coe_zero` from the simp set where necessary.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
