### PR TITLE
feat(ModelTheory/DirectLimit): bound cardinality of direct limits

### DIFF
--- a/Mathlib/ModelTheory/DirectLimit.lean
+++ b/Mathlib/ModelTheory/DirectLimit.lean
@@ -164,6 +164,33 @@ namespace DirectLimit
 
 variable [IsDirectedOrder ι] [DirectedSystem G fun i j h => f i j h]
 
+open scoped Cardinal
+
+/-- The cardinality of a direct limit is at most the cardinality of the sigma type of its
+components. -/
+theorem mk_le_mk_sigma :
+    #(DirectLimit G f) ≤ #(Σ i, G i) :=
+  Cardinal.mk_quotient_le
+
+/-- The cardinality of a direct limit is at most the cardinality of the index type times the
+supremum of the cardinalities of its components. -/
+theorem mk_le_lift_mk_mul_iSup_lift_mk :
+    #(DirectLimit G f) ≤
+      Cardinal.lift.{w} #ι * ⨆ i, Cardinal.lift.{v} #(G i) := by
+  apply (mk_le_mk_sigma G f).trans
+  rw [Cardinal.mk_sigma]
+  exact Cardinal.sum_le_lift_mk_mul_iSup_lift _
+
+/-- If the index type and all components have cardinality at most an infinite cardinal `κ`, then
+so does the direct limit. -/
+theorem mk_le_of_lift_mk_le {κ : Cardinal.{max v w}}
+    (hκ : ℵ₀ ≤ κ) (hι : Cardinal.lift.{w} #ι ≤ κ)
+    (hG : ∀ i, Cardinal.lift.{v} #(G i) ≤ κ) :
+    #(DirectLimit G f) ≤ κ := by
+  apply (mk_le_lift_mk_mul_iSup_lift_mk G f).trans
+  apply (mul_le_mul' hι (ciSup_le' hG)).trans
+  rw [Cardinal.mul_eq_self hκ]
+
 theorem equiv_iff {x y : Σˣ f} {i : ι} (hx : x.1 ≤ i) (hy : y.1 ≤ i) :
     x ≈ y ↔ (f x.1 i hx) x.2 = (f y.1 i hy) y.2 := by
   cases x


### PR DESCRIPTION
This PR adds cardinality bounds for direct limits in terms of their sigma type, index type, and component cardinalities.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
