### PR TITLE
[Merged by Bors] - feat(Topology/Order): the bornology of an unbounded order is non-trivial

### DIFF
--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -260,6 +260,7 @@ theorem NeBot.ne {f : Filter α} (hf : NeBot f) : f ≠ ⊥ := hf.ne'
 @[simp, push]
 theorem not_neBot {f : Filter α} : ¬f.NeBot ↔ f = ⊥ := neBot_iff.not_left
 
+@[gcongr]
 theorem NeBot.mono {f g : Filter α} (hf : NeBot f) (hg : f ≤ g) : NeBot g :=
   ⟨ne_bot_of_le_ne_bot hf.1 hg⟩
 

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -269,6 +269,9 @@ theorem neBot_of_le {f g : Filter α} [hf : NeBot f] (hg : f ≤ g) : NeBot g :=
 @[simp] theorem sup_neBot {f g : Filter α} : NeBot (f ⊔ g) ↔ NeBot f ∨ NeBot g := by
   simp only [neBot_iff, not_and_or, Ne, sup_eq_bot_iff]
 
+instance neBot_sup_of_left {f g : Filter α} [f.NeBot] : NeBot (f ⊔ g) := by simp [*]
+instance neBot_sup_of_right {f g : Filter α} [g.NeBot] : NeBot (f ⊔ g) := by simp [*]
+
 theorem not_disjoint_self_iff : ¬Disjoint f f ↔ f.NeBot := by rw [disjoint_self, neBot_iff]
 
 theorem bot_sets_eq : (⊥ : Filter α).sets = univ := rfl

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -103,9 +103,11 @@ end Preorder
 
 section LinearOrder
 
-variable [Nonempty α] [LinearOrder α] [IsOrderBornology α]
+variable [LinearOrder α] [IsOrderBornology α]
 
 lemma IsOrderBornology.atTop_le_cobounded [NoMaxOrder α] : .atTop ≤ Bornology.cobounded α := by
+  cases isEmpty_or_nonempty α
+  · simp
   intro s
   rw [← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s,
     Filter.atTop_basis_Ioi.mem_iff]
@@ -118,8 +120,9 @@ lemma IsOrderBornology.atTop_le_cobounded [NoMaxOrder α] : .atTop ≤ Bornology
 lemma IsOrderBornology.atBot_le_cobounded [NoMinOrder α] : .atBot ≤ Bornology.cobounded α :=
   atTop_le_cobounded (α := αᵒᵈ)
 
-lemma IsOrderBornology.cobounded_le_atBot_sup_atTop :
-    cobounded α ≤ .atBot ⊔ .atTop := by
+lemma IsOrderBornology.cobounded_le_atBot_sup_atTop : cobounded α ≤ .atBot ⊔ .atTop := by
+  cases isEmpty_or_nonempty α
+  · simp
   intro s
   rw [Filter.mem_sup, Filter.atTop_basis.mem_iff, Filter.atBot_basis.mem_iff,
     ← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s]
@@ -149,21 +152,11 @@ lemma IsOrderBornology.cobounded_eq_atTop [NoMaxOrder α] [OrderBot α] :
 lemma IsOrderBornology.cobounded_eq_atBot [NoMinOrder α] [OrderTop α] :
     Bornology.cobounded α = .atBot := cobounded_eq_atTop (α := αᵒᵈ)
 
-instance IsOrderBornology.neBot_cobounded_of_noMinOrder [NoMinOrder α] : (cobounded α).NeBot := by
-  cases topOrderOrNoTopOrder α
-  · rw [cobounded_eq_atBot]
-    infer_instance
-  · have := NoTopOrder.to_noMaxOrder α
-    rw [cobounded_eq]
-    infer_instance
+instance IsOrderBornology.neBot_cobounded_of_noMinOrder [Nonempty α] [NoMinOrder α] :
+    (cobounded α).NeBot := by grw [← atBot_le_cobounded]; infer_instance
 
-instance IsOrderBornology.neBot_cobounded_of_noMaxOrder [NoMaxOrder α] : (cobounded α).NeBot := by
-  cases botOrderOrNoBotOrder α
-  · rw [cobounded_eq_atTop]
-    infer_instance
-  · have := NoBotOrder.to_noMinOrder α
-    rw [cobounded_eq]
-    infer_instance
+instance IsOrderBornology.neBot_cobounded_of_noMaxOrder [Nonempty α] [NoMaxOrder α] :
+    (cobounded α).NeBot := by grw [← atTop_le_cobounded]; infer_instance
 
 end LinearOrder
 

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -145,8 +145,25 @@ lemma IsOrderBornology.cobounded_eq_atTop [NoMaxOrder α] [OrderBot α] :
 
 -- TODO (khw): Generate this in the future with `to_dual`
 -- See https://github.com/leanprover-community/mathlib4/pull/37738
+@[to_dual existing]
 lemma IsOrderBornology.cobounded_eq_atBot [NoMinOrder α] [OrderTop α] :
     Bornology.cobounded α = .atBot := cobounded_eq_atTop (α := αᵒᵈ)
+
+instance IsOrderBornology.neBot_cobounded_of_noMinOrder [NoMinOrder α] : (cobounded α).NeBot := by
+  cases topOrderOrNoTopOrder α
+  · rw [cobounded_eq_atBot]
+    infer_instance
+  · have := NoTopOrder.to_noMaxOrder α
+    rw [cobounded_eq]
+    infer_instance
+
+instance IsOrderBornology.neBot_cobounded_of_noMaxOrder [NoMaxOrder α] : (cobounded α).NeBot := by
+  cases botOrderOrNoBotOrder α
+  · rw [cobounded_eq_atTop]
+    infer_instance
+  · have := NoBotOrder.to_noMinOrder α
+    rw [cobounded_eq]
+    infer_instance
 
 end LinearOrder
 

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -99,11 +99,11 @@ instance Pi.instIsOrderBornology {ι : Type*} {α : ι → Type*} [∀ i, Preord
     simp_rw [← forall_isBounded_image_eval_iff, bddBelow_pi, bddAbove_pi, ← forall_and,
       isBounded_iff_bddBelow_bddAbove]
 
+variable (α) in
 lemma Nonempty.of_isOrderBornology : Nonempty α := Bornology.isBounded_empty.bddBelow.nonempty
 
 instance IsOrderBornology.neBot_cobounded_of_noBotOrder [NoBotOrder α] : (cobounded α).NeBot := by
-  rw [Filter.neBot_iff, Ne, cobounded_eq_bot_iff, ← isBounded_univ, isBounded_iff_bddBelow_bddAbove]
-  exact fun h ↦ not_bddBelow_univ h.1
+  simp [Filter.neBot_iff, cobounded_eq_bot_iff, ← isBounded_univ, isBounded_iff_bddBelow_bddAbove]
 
 instance IsOrderBornology.neBot_cobounded_of_noTopOrder [NoTopOrder α] : (cobounded α).NeBot :=
   neBot_cobounded_of_noBotOrder (α := αᵒᵈ)
@@ -129,8 +129,6 @@ section LinearOrder
 variable [LinearOrder α] [IsOrderBornology α]
 
 lemma IsOrderBornology.cobounded_le_atBot_sup_atTop : cobounded α ≤ .atBot ⊔ .atTop := by
-  cases isEmpty_or_nonempty α
-  · simp
   intro s
   rw [Filter.mem_sup, Filter.atTop_basis.mem_iff, Filter.atBot_basis.mem_iff,
     ← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s]

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -99,26 +99,36 @@ instance Pi.instIsOrderBornology {ι : Type*} {α : ι → Type*} [∀ i, Preord
     simp_rw [← forall_isBounded_image_eval_iff, bddBelow_pi, bddAbove_pi, ← forall_and,
       isBounded_iff_bddBelow_bddAbove]
 
-end Preorder
-
-section LinearOrder
-
-variable [LinearOrder α] [IsOrderBornology α]
-
 lemma IsOrderBornology.atTop_le_cobounded [NoMaxOrder α] : .atTop ≤ Bornology.cobounded α := by
-  cases isEmpty_or_nonempty α
-  · simp
-  intro s
-  rw [← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s,
-    Filter.atTop_basis_Ioi.mem_iff]
-  intro ⟨_, b, hb⟩
-  rw [mem_upperBounds_iff_subset_Iic, ← compl_compl (Iic b), compl_subset_compl, compl_Iic] at hb
-  use b
+  intro s hs
+  rw [← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove] at hs
+  obtain ⟨b, hb⟩ := hs.2
+  obtain ⟨c, hbc⟩ := exists_gt b
+  refine Filter.mem_of_superset (Filter.mem_atTop c) fun x hx ↦ ?_
+  by_contra hx'
+  exact hbc.not_ge <| hx.trans <| hb <| mem_compl hx'
 
 -- TODO (khw): Generate this in the future with `to_dual`
 -- See https://github.com/leanprover-community/mathlib4/pull/37738
 lemma IsOrderBornology.atBot_le_cobounded [NoMinOrder α] : .atBot ≤ Bornology.cobounded α :=
   atTop_le_cobounded (α := αᵒᵈ)
+
+instance IsOrderBornology.neBot_cobounded_of_noMinOrder [Nonempty α] [NoMinOrder α] :
+    (cobounded α).NeBot := by
+  rw [Filter.neBot_iff, Ne, cobounded_eq_bot_iff, ← isBounded_univ,
+    isBounded_iff_bddBelow_bddAbove]
+  rintro ⟨⟨a, ha⟩, -⟩
+  obtain ⟨b, hb⟩ := exists_lt a
+  exact hb.not_ge <| ha <| mem_univ _
+
+instance IsOrderBornology.neBot_cobounded_of_noMaxOrder [Nonempty α] [NoMaxOrder α] :
+    (cobounded α).NeBot := neBot_cobounded_of_noMinOrder (α := αᵒᵈ)
+
+end Preorder
+
+section LinearOrder
+
+variable [LinearOrder α] [IsOrderBornology α]
 
 lemma IsOrderBornology.cobounded_le_atBot_sup_atTop : cobounded α ≤ .atBot ⊔ .atTop := by
   cases isEmpty_or_nonempty α
@@ -151,12 +161,6 @@ lemma IsOrderBornology.cobounded_eq_atTop [NoMaxOrder α] [OrderBot α] :
 @[to_dual existing]
 lemma IsOrderBornology.cobounded_eq_atBot [NoMinOrder α] [OrderTop α] :
     Bornology.cobounded α = .atBot := cobounded_eq_atTop (α := αᵒᵈ)
-
-instance IsOrderBornology.neBot_cobounded_of_noMinOrder [Nonempty α] [NoMinOrder α] :
-    (cobounded α).NeBot := by grw [← atBot_le_cobounded]; infer_instance
-
-instance IsOrderBornology.neBot_cobounded_of_noMaxOrder [Nonempty α] [NoMaxOrder α] :
-    (cobounded α).NeBot := by grw [← atTop_le_cobounded]; infer_instance
 
 end LinearOrder
 

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -113,16 +113,14 @@ lemma IsOrderBornology.atTop_le_cobounded [NoMaxOrder α] : .atTop ≤ Bornology
 lemma IsOrderBornology.atBot_le_cobounded [NoMinOrder α] : .atBot ≤ Bornology.cobounded α :=
   atTop_le_cobounded (α := αᵒᵈ)
 
-instance IsOrderBornology.neBot_cobounded_of_noMinOrder [Nonempty α] [NoMinOrder α] :
+instance IsOrderBornology.neBot_cobounded_of_noBotOrder [NoBotOrder α] :
     (cobounded α).NeBot := by
   rw [Filter.neBot_iff, Ne, cobounded_eq_bot_iff, ← isBounded_univ,
     isBounded_iff_bddBelow_bddAbove]
-  rintro ⟨⟨a, ha⟩, -⟩
-  obtain ⟨b, hb⟩ := exists_lt a
-  exact hb.not_ge <| ha <| mem_univ _
+  exact fun h ↦ not_bddBelow_univ h.1
 
-instance IsOrderBornology.neBot_cobounded_of_noMaxOrder [Nonempty α] [NoMaxOrder α] :
-    (cobounded α).NeBot := neBot_cobounded_of_noMinOrder (α := αᵒᵈ)
+instance IsOrderBornology.neBot_cobounded_of_noTopOrder [NoTopOrder α] :
+    (cobounded α).NeBot := neBot_cobounded_of_noBotOrder (α := αᵒᵈ)
 
 end Preorder
 

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -129,6 +129,7 @@ section LinearOrder
 variable [LinearOrder α] [IsOrderBornology α]
 
 lemma IsOrderBornology.cobounded_le_atBot_sup_atTop : cobounded α ≤ .atBot ⊔ .atTop := by
+  have := Nonempty.of_isOrderBornology α
   intro s
   rw [Filter.mem_sup, Filter.atTop_basis.mem_iff, Filter.atBot_basis.mem_iff,
     ← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s]

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -99,6 +99,15 @@ instance Pi.instIsOrderBornology {ι : Type*} {α : ι → Type*} [∀ i, Preord
     simp_rw [← forall_isBounded_image_eval_iff, bddBelow_pi, bddAbove_pi, ← forall_and,
       isBounded_iff_bddBelow_bddAbove]
 
+lemma Nonempty.of_isOrderBornology : Nonempty α := Bornology.isBounded_empty.bddBelow.nonempty
+
+instance IsOrderBornology.neBot_cobounded_of_noBotOrder [NoBotOrder α] : (cobounded α).NeBot := by
+  rw [Filter.neBot_iff, Ne, cobounded_eq_bot_iff, ← isBounded_univ, isBounded_iff_bddBelow_bddAbove]
+  exact fun h ↦ not_bddBelow_univ h.1
+
+instance IsOrderBornology.neBot_cobounded_of_noTopOrder [NoTopOrder α] : (cobounded α).NeBot :=
+  neBot_cobounded_of_noBotOrder (α := αᵒᵈ)
+
 lemma IsOrderBornology.atTop_le_cobounded [NoMaxOrder α] : .atTop ≤ Bornology.cobounded α := by
   intro s hs
   rw [← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove] at hs
@@ -112,15 +121,6 @@ lemma IsOrderBornology.atTop_le_cobounded [NoMaxOrder α] : .atTop ≤ Bornology
 -- See https://github.com/leanprover-community/mathlib4/pull/37738
 lemma IsOrderBornology.atBot_le_cobounded [NoMinOrder α] : .atBot ≤ Bornology.cobounded α :=
   atTop_le_cobounded (α := αᵒᵈ)
-
-instance IsOrderBornology.neBot_cobounded_of_noBotOrder [NoBotOrder α] :
-    (cobounded α).NeBot := by
-  rw [Filter.neBot_iff, Ne, cobounded_eq_bot_iff, ← isBounded_univ,
-    isBounded_iff_bddBelow_bddAbove]
-  exact fun h ↦ not_bddBelow_univ h.1
-
-instance IsOrderBornology.neBot_cobounded_of_noTopOrder [NoTopOrder α] :
-    (cobounded α).NeBot := neBot_cobounded_of_noBotOrder (α := αᵒᵈ)
 
 end Preorder
 


### PR DESCRIPTION
Also generalise the fact that cobounded sets tend to top/bot from linear orders to preorders (without a max/min element).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
