### PR TITLE
feat(NumberTheory): conjugation symmetry of the completed Riemann zeta function

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
@@ -33,6 +33,7 @@ formula which is an important input in functional equations of (un-completed) Di
 
 open Filter Topology Asymptotics Real Set MeasureTheory
 open Complex
+open scoped ComplexConjugate
 
 namespace Complex
 
@@ -72,6 +73,19 @@ lemma Gammaℝ_ne_zero_of_re_pos {s : ℂ} (hs : 0 < re s) : Gammaℝ s ≠ 0 :=
 
 lemma Gammaℝ_eq_zero_iff {s : ℂ} : Gammaℝ s = 0 ↔ ∃ n : ℕ, s = -(2 * n) := by
   simp [Gammaℝ_def, Complex.Gamma_eq_zero_iff, pi_ne_zero, div_eq_iff (two_ne_zero' ℂ), mul_comm]
+
+/-- The archimedean Gamma factor `Γ_ℝ` commutes with complex conjugation:
+`Γ_ℝ (conj s) = conj (Γ_ℝ s)`. -/
+lemma Gammaℝ_conj (s : ℂ) : Gammaℝ (conj s) = conj (Gammaℝ s) := by
+  rw [Gammaℝ_def, Gammaℝ_def, map_mul]
+  have harg : (π : ℂ).arg ≠ π := by
+    rw [arg_ofReal_of_nonneg Real.pi_pos.le]; exact Real.pi_pos.ne
+  have hΓ : Gamma (conj s / 2) = conj (Gamma (s / 2)) := by
+    rw [← Gamma_conj, map_div₀, map_ofNat]
+  have hpow : (π : ℂ) ^ (-conj s / 2) = conj ((π : ℂ) ^ (-s / 2)) := by
+    rw [show (-conj s / 2 : ℂ) = conj (-s / 2) by rw [map_div₀, map_neg, map_ofNat],
+      cpow_conj _ _ harg, conj_ofReal]
+  rw [hpow, hΓ]
 
 @[simp]
 lemma Gammaℝ_one : Gammaℝ 1 = 1 := by

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -481,6 +481,50 @@ theorem riemannZeta_conj (s : ℂ) : riemannZeta (conj s) = conj (riemannZeta s)
           ((isOpen_lt continuous_const continuous_re).mem_nhds (by norm_num)) hgz)
     simpa using congrArg (starRingEnd ℂ) (heq hs)
 
+/-- **Conjugation symmetry of the entire completed zeta function**: `Λ₀ (conj s) = conj (Λ₀ s)`.
+
+Both `conj ∘ Λ₀ ∘ conj` and `Λ₀` are entire, and they agree on the half-plane `1 < re s`, where
+`Λ = Γ_ℝ · ζ` and both factors satisfy conjugation symmetry (`Complex.Gammaℝ_conj` and
+`riemannZeta_conj`); the identity principle then propagates the equality to all of `ℂ`. -/
+@[simp]
+theorem completedRiemannZeta₀_conj (s : ℂ) :
+    completedRiemannZeta₀ (conj s) = conj (completedRiemannZeta₀ s) := by
+  have hg_an : AnalyticOnNhd ℂ (fun z ↦ conj (completedRiemannZeta₀ (conj z))) univ :=
+    analyticOnNhd_univ_iff_differentiable.mpr fun z ↦
+      differentiableAt_conj_conj_iff.mpr (differentiable_completedZeta₀ (conj z))
+  have hgz (z : ℂ) (hz : 1 < z.re) :
+      conj (completedRiemannZeta₀ (conj z)) = completedRiemannZeta₀ z := by
+    have hpos : 0 < z.re := one_pos.trans hz
+    have hz0 : z ≠ 0 := fun h ↦ by simp [h] at hpos
+    have hcz0 : conj z ≠ 0 := by
+      rw [ne_eq, ← map_zero (starRingEnd ℂ), (starRingEnd ℂ).injective.eq_iff]; exact hz0
+    -- `Λ = Γ_ℝ · ζ` on the region where `Γ_ℝ` is non-vanishing
+    have hΛ : ∀ w : ℂ, w ≠ 0 → 0 < w.re →
+        completedRiemannZeta w = Gammaℝ w * riemannZeta w := fun w hw hw' ↦ by
+      rw [riemannZeta_def_of_ne_zero hw, mul_comm, div_mul_cancel₀ _ (Gammaℝ_ne_zero_of_re_pos hw')]
+    have hΛ₀ : ∀ w : ℂ,
+        completedRiemannZeta₀ w = completedRiemannZeta w + 1 / w + 1 / (1 - w) := fun w ↦ by
+      linear_combination -(completedRiemannZeta_eq w)
+    rw [hΛ₀ (conj z), hΛ₀ z, hΛ (conj z) hcz0 (by rwa [conj_re]), hΛ z hz0 hpos]
+    simp only [map_add, map_mul, map_div₀, map_one, map_sub, Complex.Gammaℝ_conj, riemannZeta_conj,
+      Complex.conj_conj]
+  simpa [Complex.conj_conj] using congrArg (starRingEnd ℂ)
+    (congrFun (hg_an.eq_of_eventuallyEq
+      (analyticOnNhd_univ_iff_differentiable.mpr differentiable_completedZeta₀)
+      (eventuallyEq_of_mem
+        ((isOpen_lt continuous_const continuous_re).mem_nhds (by norm_num : (1 : ℝ) < (2 : ℂ).re))
+        hgz)) s)
+
+/-- **Conjugation symmetry of the completed Riemann zeta function**: `Λ (conj s) = conj (Λ s)`.
+
+Obtained from `completedRiemannZeta₀_conj` by subtracting the conjugation-symmetric poles `1 / s`
+and `1 / (1 - s)`. -/
+@[simp]
+theorem completedRiemannZeta_conj (s : ℂ) :
+    completedRiemannZeta (conj s) = conj (completedRiemannZeta s) := by
+  rw [completedRiemannZeta_eq, completedRiemannZeta_eq, map_sub, map_sub,
+    completedRiemannZeta₀_conj, map_div₀, map_div₀, map_one, map_sub, map_one]
+
 lemma riemannZeta_eventually_ne_zero_nhds_one : ∀ᶠ s in 𝓝 1, riemannZeta s ≠ 0 := by
   filter_upwards [eventually_nhdsWithin_iff.1 <| riemannZeta_residue_one.eventually_ne one_ne_zero]
   grind [riemannZeta_one_ne_zero]


### PR DESCRIPTION
This PR adds the conjugation-symmetry lemmas for Deligne's archimedean Gamma factor `Γ_ℝ` and for
the completed Riemann zeta function `Λ` / `Λ₀`, complementing the existing `riemannZeta_conj`.

## What is added

* `Complex.Gammaℝ_conj` (in `Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean`):
  ```
  lemma Gammaℝ_conj (s : ℂ) : Gammaℝ (conj s) = conj (Gammaℝ s)
  ```
* `completedRiemannZeta₀_conj` and `completedRiemannZeta_conj`
  (in `Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean`, next to the existing `riemannZeta_conj`):
  ```
  @[simp] theorem completedRiemannZeta₀_conj (s : ℂ) :
      completedRiemannZeta₀ (conj s) = conj (completedRiemannZeta₀ s)

  @[simp] theorem completedRiemannZeta_conj (s : ℂ) :
      completedRiemannZeta (conj s) = conj (completedRiemannZeta s)
  ```

## Why these are missing

Mathlib already has `Complex.Gamma_conj` (for `Complex.Gamma`), the Jacobi-theta conjugation
lemmas, and `riemannZeta_conj` (the un-completed zeta, added in `ZetaAsymp.lean`). But there was no
conjugation lemma for Deligne's `Γ_ℝ` factor, nor for the *completed* zeta `Λ = Γ_ℝ · ζ` or its
entire cousin `Λ₀`. These are basic reality/symmetry facts about `Λ` — for instance they give,
in one line, that `Λ` is real on the critical line `re s = 1/2` (combine with the functional
equation `completedRiemannZeta_one_sub`), which is a standard ingredient when locating zeros of `ζ`.

## Proof technique

* `Gammaℝ_conj`: unfold `Γ_ℝ(s) = π^(-s/2) · Γ(s/2)` and push conjugation through each factor,
  using `Complex.Gamma_conj` for the Gamma factor and `Complex.cpow_conj` for the `π`-power (whose
  hypothesis `(π : ℂ).arg ≠ π` holds since `π > 0`).
* `completedRiemannZeta₀_conj`: the identity principle. Both `conj ∘ Λ₀ ∘ conj` (analytic via
  `differentiableAt_conj_conj_iff`) and `Λ₀` are entire, and they agree on the open half-plane
  `1 < re s`: there `Λ = Γ_ℝ · ζ` (as `Γ_ℝ` is non-vanishing) and both factors satisfy conjugation
  symmetry (`Gammaℝ_conj`, `riemannZeta_conj`), while the poles `1/s + 1/(1-s)` are conjugation
  symmetric. `AnalyticOnNhd.eq_of_eventuallyEq` then propagates the identity to all of `ℂ`.
* `completedRiemannZeta_conj`: subtract the conjugation-symmetric poles `1/s`, `1/(1-s)` from
  `completedRiemannZeta₀_conj` via `completedRiemannZeta_eq`.

## Notes

* No new imports are introduced; the lemmas sit in the files where the corresponding objects and
  the neighbouring `riemannZeta_conj` already live.
* `Gammaℝ_conj` is left un-`@[simp]` to mirror `Complex.Gamma_conj`; the two completed-zeta lemmas
  are tagged `@[simp]` to mirror the existing `@[simp] riemannZeta_conj`.

## Formalization use-case

These lemmas were extracted from a formalization that certifies the first non-trivial zero of `ζ`
on the critical line: reality of `Λ` on `re s = 1/2` (via `completedRiemannZeta_conj` and the
functional equation) reduces a sign-change / intermediate-value argument for the real-valued
`Λ(1/2 + it)` to two certified numerical signs. The conjugation lemmas themselves are of general
interest and independent of that application.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyynZSLYoSAaXyzUCTfahZ
