### PR TITLE
[Merged by Bors] - perf: restrict Subsingleton.eq_zero/eq_one simp arguments to their intended type

### DIFF
--- a/Mathlib/Algebra/Central/End.lean
+++ b/Mathlib/Algebra/Central/End.lean
@@ -60,7 +60,7 @@ public theorem LinearEquiv.conjAlgEquiv_ext_iff' {S M₂ : Type*} [CommRing S] [
     (f g : M ≃ₗ[R] M₂) : f.conjAlgEquiv S = g.conjAlgEquiv S ↔ ∃ α : Sˣ, f = α • g := by
   refine ⟨fun h ↦ ?_, fun ⟨y, h⟩ ↦ conjAlgEquiv_ext_iff.mpr ⟨(y : S), congr($h)⟩⟩
   by_cases! Subsingleton M
-  · exact ⟨1, by ext; simp [Subsingleton.eq_zero]⟩
+  · exact ⟨1, by ext; simp [Subsingleton.eq_zero (α := M)]⟩
   obtain ⟨α, hα⟩ := conjAlgEquiv_ext_iff.mp h
   obtain ⟨β, hβ⟩ := conjAlgEquiv_ext_iff.mp h.symm
   obtain ⟨x, hx⟩ := exists_ne (0 : M)

--- a/Mathlib/Algebra/MvPolynomial/NoZeroDivisors.lean
+++ b/Mathlib/Algebra/MvPolynomial/NoZeroDivisors.lean
@@ -50,7 +50,7 @@ lemma degreeOf_prod_eq {ι : Type*} (s : Finset ι) (f : ι → MvPolynomial σ 
     (h : ∀ i ∈ s, f i ≠ 0) :
     degreeOf n (∏ i ∈ s, f i) = ∑ i ∈ s, degreeOf n (f i) := by
   rcases subsingleton_or_nontrivial (MvPolynomial σ R) with nontrivial | nontrivial
-  · simp [Subsingleton.eq_zero]
+  · simp [Subsingleton.eq_zero (α := MvPolynomial σ R)]
   · classical
     induction s using Finset.induction_on with
     | empty => simp

--- a/Mathlib/Analysis/Normed/Operator/ContinuousAlgEquiv.lean
+++ b/Mathlib/Analysis/Normed/Operator/ContinuousAlgEquiv.lean
@@ -164,7 +164,8 @@ public theorem StarAlgEquiv.eq_linearIsometryEquivConjStarAlgEquiv
   -- Assume nontriviality of `V`.
   by_cases! Subsingleton V
   · by_cases! Subsingleton W
-    · use { toLinearEquiv := 0, norm_map' _ := by simp [Subsingleton.eq_zero] }
+    · use { toLinearEquiv := 0,
+            norm_map' _ := by simp [Subsingleton.eq_zero (α := V), Subsingleton.eq_zero (α := W)] }
       exact ext fun _ ↦ Subsingleton.allEq _ _
     simpa using congr(f $(Subsingleton.allEq 0 1))
   /- By `ContinuousAlgEquiv.eq_continuousLinearEquivConjContinuousAlgEquiv`,

--- a/Mathlib/Combinatorics/Enumerative/Partition/GenFun.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition/GenFun.lean
@@ -69,7 +69,7 @@ theorem tendsto_order_genFun_term_atTop_nhds_top (f : ℕ → ℕ → R) (i : �
   intro m hm
   grw [PowerSeries.smul_eq_C_mul, ← le_order_mul]
   refine lt_add_of_nonneg_of_lt (by simp) ?_
-  nontriviality R using Subsingleton.eq_zero
+  nontriviality R using Subsingleton.eq_zero (α := R⟦X⟧)
   rw [order_X_pow]
   norm_cast
   grind

--- a/Mathlib/Combinatorics/Enumerative/Partition/Glaisher.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition/Glaisher.lean
@@ -80,7 +80,7 @@ $$ -/
 theorem hasProd_powerSeriesMk_card_countRestricted {m : ℕ} (hm : 0 < m) :
     HasProd (fun i ↦ ∑ j ∈ range m, X ^ ((i + 1) * j))
     (PowerSeries.mk fun n ↦ (#(countRestricted n m) : R)) := by
-  nontriviality R using Subsingleton.eq_one
+  nontriviality R using Subsingleton.eq_one (α := R⟦X⟧)
   convert! hasProd_genFun (fun i c ↦ if c < m then (1 : R) else 0) using 1
   · ext1 i
     rw [sum_range_eq_add_Ico _ hm, sum_Ico_eq_sum_range]

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal/PowerSeries.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal/PowerSeries.lean
@@ -43,7 +43,7 @@ namespace Pentagonal
 theorem tendsto_order_pow_mul_prod_one_sub_pow (k : ℕ) :
     Tendsto (fun n ↦ (X ^ ((k + 1) * n) *
       ∏ i ∈ Finset.range (n + 1), (1 - X ^ (k + i + 1)) : R⟦X⟧).order) atTop (𝓝 ⊤) := by
-  nontriviality R using Subsingleton.eq_zero
+  nontriviality R using Subsingleton.eq_zero (α := R⟦X⟧)
   refine ENat.tendsto_nhds_top_iff_natCast_lt.mpr fun n ↦ eventually_atTop.mpr ⟨n + 1, ?_⟩
   intro m hm
   grw [← le_order_mul, order_X_pow]
@@ -53,7 +53,7 @@ theorem tendsto_order_pow_mul_prod_one_sub_pow (k : ℕ) :
 
 theorem tendsto_order_neg_X_pow (k : ℕ) :
     Tendsto (fun i ↦ (-(X : R⟦X⟧) ^ (i + k + 1)).order) atTop (𝓝 ⊤) := by
-  nontriviality R using Subsingleton.eq_zero
+  nontriviality R using Subsingleton.eq_zero (α := R⟦X⟧)
   simp_rw [order_neg, order_X_pow, add_assoc]
   exact ENat.tendsto_natCast_nhds_top.comp (tendsto_add_atTop_nat _)
 

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Defs.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Defs.lean
@@ -58,10 +58,10 @@ lemma gammaSet_one_const (a a' : Fin 2 → ZMod 1) : gammaSet 1 r a = gammaSet 1
 /-- For level `N = 1`, the gamma sets simplify to only a `gcd` condition. -/
 lemma gammaSet_one_eq (a : Fin 2 → ZMod 1) :
     gammaSet 1 r a = {v : Fin 2 → ℤ | (v 0).gcd (v 1) = r} := by
-  simp [gammaSet, Subsingleton.eq_zero]
+  simp [gammaSet, Subsingleton.eq_zero (α := Fin 2 → ZMod 1)]
 
 lemma gammaSet_one_mem_iff (v : Fin 2 → ℤ) : v ∈ gammaSet 1 r 0 ↔ (v 0).gcd (v 1) = r := by
-  simp [gammaSet, Subsingleton.eq_zero]
+  simp [gammaSet, Subsingleton.eq_zero (α := Fin 2 → ZMod 1)]
 
 /-- For level `N = 1`, the gamma sets are all equivalent; this is the equivalence. -/
 def gammaSet_one_equiv (a a' : Fin 2 → ZMod 1) : gammaSet 1 r a ≃ gammaSet 1 r a' :=

--- a/Mathlib/RingTheory/Polynomial/IntegralNormalization.lean
+++ b/Mathlib/RingTheory/Polynomial/IntegralNormalization.lean
@@ -185,7 +185,7 @@ variable [Semiring R] [IsCancelMulZero R]
 @[simp]
 theorem support_integralNormalization {f : R[X]} :
     (integralNormalization f).support = f.support := by
-  nontriviality R using Subsingleton.eq_zero
+  nontriviality R using Subsingleton.eq_zero (α := R[X])
   have : IsDomain R := {}
   by_cases hf : f = 0; · simp [hf]
   ext i


### PR DESCRIPTION
`Subsingleton.eq_zero` and `Subsingleton.eq_one` have a bare variable as their LHS, so as simp lemmas they are tried on every visited subterm, and each attempt runs a `Subsingleton` instance search. Pinning the type argument at the call site makes unification fail cheaply on all other subterms and confines the instance search to the type actually being collapsed.

Instruction counts for `lake env lean` on v4.33.0-rc1: `Mathlib.Algebra.Central.End` drops from 14.8G to 8.2G. The remaining call sites show the same pattern at smaller scale.

---

Found while investigating benchmark regressions under leanprover/lean4#14516, which widens simp's traversal and roughly doubles the number of subterms these lemmas are attempted on; the fix is independent of that change and pays off on the current toolchain as well.

AI usage: the profiling, analysis and edits in this PR were carried out with Claude Code (Claude Fable 5) under my direction; I have reviewed all changes, and the measurements were verified by rebuilding the affected files.