### PR TITLE
feat(Tactic/Linter): add blanketSimpArgs linter

### DIFF
--- a/Counterexamples/DiscreteTopologyNonDiscreteUniformity.lean
+++ b/Counterexamples/DiscreteTopologyNonDiscreteUniformity.lean
@@ -180,7 +180,7 @@ lemma fundamentalEntourage_ext (t : ℕ) (T : Set (ℕ × ℕ)) : fundamentalEnt
 
 lemma mem_range_fundamentalEntourage (S : Set (ℕ × ℕ)) :
     S ∈ (range fundamentalEntourage) ↔ ∃ n, fundamentalEntourage n = S := by
-  simp only [Set.mem_range, Eq.symm]
+  simp only [Set.mem_range]
 
 lemma mem_fundamentalEntourage (n : ℕ) (P : ℕ × ℕ) : P ∈ fundamentalEntourage n ↔
     (n ≤ P.1 ∧ n ≤ P.2) ∨ (P.1 = P.2) := by

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7411,6 +7411,7 @@ public import Mathlib.Tactic.LinearCombination.Lemmas
 public import Mathlib.Tactic.LinearCombinationPrime
 public import Mathlib.Tactic.Linter
 public import Mathlib.Tactic.Linter.AuxLemma
+public import Mathlib.Tactic.Linter.BlanketSimpArgs
 public import Mathlib.Tactic.Linter.CommandRanges
 public import Mathlib.Tactic.Linter.CommandStart
 public import Mathlib.Tactic.Linter.DeprecatedModule

--- a/Mathlib/Algebra/DirectSum/Basic.lean
+++ b/Mathlib/Algebra/DirectSum/Basic.lean
@@ -299,7 +299,7 @@ protected def id (M : Type v) (ι : Type* := PUnit) [AddCommMonoid M] [Unique ι
 @[simp] lemma id_apply {M : Type v} {ι : Type*} [AddCommMonoid M] [Unique ι] (x : ⨁ _ : ι, M) :
     DirectSum.id M ι x = x default := by
   rw [← AddEquiv.eq_symm_apply, id_symm_apply, eq_comm]
-  induction x using DirectSum.induction_on <;> simp [Unique.eq_default, *]
+  induction x using DirectSum.induction_on <;> simp [Unique.eq_default (α := ι), *]
 
 section CongrLeft
 

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -755,7 +755,7 @@ def uniqueRingEquiv [Subsingleton M] : R[M] ≃+* R where
   map_mul' x y := by
     let : Unique M := ⟨⟨1⟩, fun _ ↦ Subsingleton.elim ..⟩
     refine (coeff_mul ..).trans ?_
-    simp [Finsupp.sum_unique, Unique.eq_default]
+    simp [Finsupp.sum_unique, Unique.eq_default (α := M)]
 
 set_option backward.isDefEq.respectTransparency.types false in
 variable (M) in

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -1347,7 +1347,7 @@ theorem toBasis_orthonormalBasisSingleton :
 theorem orthonormalBasisSingleton_repr_apply (w : E) :
     (orthonormalBasisSingleton ι 𝕜 h v hv).repr w = .single default ⟪v, w⟫ := by
   ext
-  simp [OrthonormalBasis.repr_apply_apply, Unique.eq_default]
+  simp [OrthonormalBasis.repr_apply_apply, Unique.eq_default (α := ι)]
 
 theorem range_orthonormalBasisSingleton :
     Set.range (orthonormalBasisSingleton ι 𝕜 h v hv) = {v} := by

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -1150,8 +1150,8 @@ def withLpProdUnique [Unique β] : WithLp p (α × β) ≃ᵢ α where
   isometry_toFun x y : edist x.fst y.fst = edist x y := by
     rcases p.trichotomy with rfl | rfl | hp
     · absurd hp.elim; simp
-    · simp_rw [WithLp.prod_edist_eq_sup, Unique.eq_default, edist_self, max_zero]
-    · simp_rw [WithLp.prod_edist_eq_add hp, Unique.eq_default, edist_self,
+    · simp_rw [WithLp.prod_edist_eq_sup, Unique.eq_default (α := β), edist_self, max_zero]
+    · simp_rw [WithLp.prod_edist_eq_add hp, Unique.eq_default (α := β), edist_self,
         ENNReal.zero_rpow_of_pos hp, add_zero, one_div, ENNReal.rpow_rpow_inv hp.ne']
 
 theorem coe_withLpProdUnique [Unique β] : ⇑(withLpProdUnique p α β) = WithLp.fst :=

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -6,6 +6,7 @@ public import Mathlib.Lean.Linter -- linter utilities; will be transitively impo
 public import Mathlib.Tactic.AdaptationNote -- make #adaptation_note available everywhere
 public import Mathlib.Tactic.Lemma
 public import Mathlib.Tactic.Linter.AuxLemma
+public import Mathlib.Tactic.Linter.BlanketSimpArgs
 public import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 public import Mathlib.Tactic.Linter.DirectoryDependency
 public import Mathlib.Tactic.Linter.DocPrime
@@ -85,6 +86,7 @@ register_linter_set linter.mathlibStandardSet :=
   -- linter.allScriptsDocumented -- disabled, let's not impose this requirement downstream.
   -- linter.checkInitImports -- disabled, not relevant downstream.
   linter.auxLemma
+  linter.blanketSimpArgs
   linter.flexible
   linter.hashCommand
   linter.oldObtain

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -261,7 +261,7 @@ def oneEmbeddingEquiv {one α : Type*} [Unique one] : (one ↪ α) ≃ α where
   invFun a := {
     toFun := fun _ ↦ a
     inj' x y h := by simp [Unique.uniq inferInstance] }
-  left_inv f := by ext; simp [Unique.uniq]
+  left_inv f := by ext x; exact congrArg f (Unique.eq_default x).symm
 
 /-- Fixing an element `b : β` gives an embedding `α ↪ α × β`. -/
 @[simps]

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Definability.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Definability.lean
@@ -143,7 +143,8 @@ lemma isSemilinearSet_formula_realize_semilinear (φ : presburger[[A]].Formula �
   ext x
   simp only [mem_ofPred_eq, mem_image]
   rw [(e.arrowCongr (.refl ℕ)).exists_congr_left]
-  simp [Formula.Realize, Unique.eq_default, Function.comp_def, LinearMap.funLeft, e]
+  simp [Formula.Realize, Unique.eq_default (α := Fin 0 → ℕ), Function.comp_def,
+    LinearMap.funLeft, e]
 
 /-- A set is Presburger definable in `ℕ` if and only if it is semilinear. -/
 theorem definable_iff_isSemilinearSet {s : Set (α → ℕ)} :

--- a/Mathlib/RepresentationTheory/Homological/TateCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/Homological/TateCohomology/Basic.lean
@@ -66,7 +66,7 @@ def Rep.tateNorm : (inhomogeneousChains M).X 0 ⟶ (inhomogeneousCochains M).X 0
 lemma Rep.tateNorm_eq :
     M.tateNorm = ModuleCat.ofHom (Finsupp.lsum R fun _ ↦ LinearMap.pi fun _ ↦ M.ρ.norm) := by
   ext
-  simp_all [tateNorm, chainsIso₀, cochainsIso₀, Unique.eq_default]
+  simp_all [tateNorm, chainsIso₀, cochainsIso₀, Unique.eq_default (α := Fin 0 → G)]
 
 @[reassoc (attr := simp), elementwise]
 lemma Rep.norm_comp_d_eq_zero : M.norm.toModuleCatHom ≫ d₀₁ M = 0 := by

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -179,6 +179,7 @@ public import Mathlib.Tactic.LinearCombination.Lemmas
 public import Mathlib.Tactic.LinearCombinationPrime
 public import Mathlib.Tactic.Linter
 public import Mathlib.Tactic.Linter.AuxLemma
+public import Mathlib.Tactic.Linter.BlanketSimpArgs
 public import Mathlib.Tactic.Linter.CommandRanges
 public import Mathlib.Tactic.Linter.CommandStart
 public import Mathlib.Tactic.Linter.DeprecatedModule

--- a/Mathlib/Tactic/Linter/BlanketSimpArgs.lean
+++ b/Mathlib/Tactic/Linter/BlanketSimpArgs.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 Sebastian Graf. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+public meta import Lean.Elab.Command
+-- Import this linter explicitly to ensure that
+-- this file has a valid copyright header and module docstring.
+public meta import Mathlib.Tactic.Linter.Header  -- shake: keep
+
+/-!
+# The `blanketSimpArgs` linter
+
+The `blanketSimpArgs` linter flags simp arguments such as `simp [Subsingleton.eq_zero]`
+whose rewrite source is a bare variable and whose remaining hypotheses `simp` must
+discharge at every match.
+
+## Example
+
+```
+example {M : Type} [Zero M] [Subsingleton M] (x : M) : x = 0 := by
+  simp [Subsingleton.eq_zero]     -- linted against
+```
+
+## Why is this bad?
+
+A lemma like `Subsingleton.eq_zero : ∀ {α} [Zero α] [Subsingleton α] (a : α), a = 0`
+rewrites the bare variable `a`. Its discrimination tree key is `*`, so `simp` retrieves
+and tries it at every visited subterm, and each attempted match triggers instance
+searches for `Zero α` and `Subsingleton α`. Under binders these searches miss the
+instance cache, so a single such simp argument can dominate the elaboration time of
+a proof.
+
+The fix is to determine the side conditions once, at elaboration time of the simp
+argument: apply the lemma to a term, as in `simp [Subsingleton.eq_zero x]`, or fix
+its implicit arguments, as in `simp [Subsingleton.eq_zero (α := M)]`.
+-/
+
+meta section
+
+open Lean Elab Command Linter Meta
+
+namespace Mathlib.Linter
+
+/-- The `blanketSimpArgs` linter flags simp arguments whose rewrite source is a bare
+variable and whose remaining hypotheses `simp` must discharge at every match. -/
+public register_option linter.blanketSimpArgs : Bool := {
+  defValue := false
+  descr := "enable the blanketSimpArgs linter"
+}
+
+namespace BlanketSimpArgs
+
+/-- The source term that using `declName` as a simp lemma rewrites, i.e. the left-hand
+side of its conclusion, or the right-hand side when the lemma is used with `←`. -/
+private def rewriteSource? (concl : Expr) (rev : Bool) : Option Expr :=
+  if let some (_, lhs, rhs) := concl.eq? then
+    some (if rev then rhs else lhs)
+  else if let some (lhs, rhs) := concl.iff? then
+    some (if rev then rhs else lhs)
+  else if let some (_, lhs, _, rhs) := concl.heq? then
+    some (if rev then rhs else lhs)
+  else
+    none
+
+/-- Whether using `declName` as a simp lemma rewrites a bare variable of variable type,
+leaving side conditions for `simp` to discharge at every match. `rev` is `true` for `←`. -/
+def isBlanketRewrite (declName : Name) (rev : Bool) : MetaM Bool := do
+  let ci ← getConstInfo declName
+  unless ← isProp ci.type do return false
+  forallTelescope ci.type fun xs concl => do
+    let some src := rewriteSource? concl rev | return false
+    unless src.isFVar && xs.contains src do return false
+    let srcType ← src.fvarId!.getType
+    unless srcType.isSort || (srcType.isFVar && xs.contains srcType) do return false
+    xs.anyM fun x => do
+      if x == src then return false
+      let fvarId := x.fvarId!
+      return (← fvarId.getBinderInfo) == .instImplicit || (← isProp (← fvarId.getType))
+
+/-- The syntax kind of the `simp_rw` tactic, whose module cannot be imported here.
+`MathlibTest.Linter.BlanketSimpArgs` checks this against the kind `simp_rw` actually parses to. -/
+public def simpRwKind : SyntaxNodeKind := `Mathlib.Tactic.tacticSimp_rw___
+
+mutual
+
+/-- The simp argument terms underneath `stx`, each paired with whether it is reversed
+by `←`: the `simpLemma` nodes of the `simp`-like tactics, including `simpa`, `simp_all`,
+`norm_num` and `nontriviality _ using`, and the rewrite rules of `simp_rw`. -/
+partial def simpArgTerms (stx : Syntax) (inSimpRw : Bool := false)
+    (acc : Array (Syntax × Bool) := #[]) : Array (Syntax × Bool) :=
+  match stx with
+  | .node _ kind args =>
+    let inSimpRw := inSimpRw || kind == simpRwKind
+    let acc :=
+      if kind == ``Lean.Parser.Tactic.simpLemma then
+        acc.push (stx[2], !stx[1].isNone)
+      else if inSimpRw && kind == ``Lean.Parser.Tactic.rwRule then
+        acc.push (stx[1], !stx[0].isNone)
+      else
+        acc
+    simpArgTermsAux args 0 inSimpRw acc
+  | _ => acc
+
+/-- Accumulate the simp argument terms of `args[i:]` into `acc`. -/
+partial def simpArgTermsAux (args : Array Syntax) (i : Nat) (inSimpRw : Bool)
+    (acc : Array (Syntax × Bool)) : Array (Syntax × Bool) :=
+  if h : i < args.size then
+    simpArgTermsAux args (i + 1) inSimpRw (simpArgTerms args[i] inSimpRw acc)
+  else
+    acc
+
+end
+
+@[inherit_doc Mathlib.Linter.linter.blanketSimpArgs]
+def blanketSimpArgsLinter : Linter where run := withSetOptionIn fun stx => do
+  unless getLinterValue linter.blanketSimpArgs (← getLinterOptions) do
+    return
+  if (← MonadState.get).messages.hasErrors then
+    return
+  for (term, rev) in simpArgTerms stx do
+    unless term.isIdent do continue
+    let some declName ← liftCoreM <|
+        try some <$> realizeGlobalConstNoOverload term catch _ => pure none
+      | continue
+    if ← liftTermElabM (isBlanketRewrite declName rev) then
+      logLint linter.blanketSimpArgs term
+        m!"`{.ofConstName declName}` rewrites a bare variable, so `simp` tries it at every \
+        subterm and attempts to discharge its side conditions at each match, which can \
+        dominate the elaboration time of a proof.\n\
+        Determine the side conditions at this use site instead, by applying the lemma to a \
+        term or by fixing its implicit arguments with named arguments, as in \
+        `Subsingleton.eq_zero (α := M)`."
+
+initialize addLinter blanketSimpArgsLinter
+
+end BlanketSimpArgs
+
+end Mathlib.Linter

--- a/MathlibTest/Linter/BlanketSimpArgs.lean
+++ b/MathlibTest/Linter/BlanketSimpArgs.lean
@@ -1,0 +1,110 @@
+import Mathlib.Tactic.Linter.BlanketSimpArgs
+import Mathlib.Tactic.Nontriviality
+import Mathlib.Tactic.SimpRw
+import Mathlib.Algebra.Notation.Defs
+import Mathlib.Logic.Unique
+
+/-! Tests for the `blanketSimpArgs` linter. -/
+
+set_option linter.blanketSimpArgs true
+
+variable {M : Type} [Zero M] [One M] [Subsingleton M]
+
+-- The bare lemma is linted against.
+
+/--
+warning: `Subsingleton.eq_zero` rewrites a bare variable, so `simp` tries it at every subterm and attempts to discharge its side conditions at each match, which can dominate the elaboration time of a proof.
+Determine the side conditions at this use site instead, by applying the lemma to a term or by fixing its implicit arguments with named arguments, as in `Subsingleton.eq_zero (α := M)`.
+
+Note: This linter can be disabled with `set_option linter.blanketSimpArgs false`
+-/
+#guard_msgs in
+example (x : M) : x = 0 := by simp [Subsingleton.eq_zero]
+
+-- The check is not tied to `Subsingleton.eq_zero`: any lemma of the same shape is flagged.
+
+/--
+warning: `Subsingleton.eq_one` rewrites a bare variable, so `simp` tries it at every subterm and attempts to discharge its side conditions at each match, which can dominate the elaboration time of a proof.
+Determine the side conditions at this use site instead, by applying the lemma to a term or by fixing its implicit arguments with named arguments, as in `Subsingleton.eq_zero (α := M)`.
+
+Note: This linter can be disabled with `set_option linter.blanketSimpArgs false`
+-/
+#guard_msgs in
+example (x : M) : x = 1 := by simp [Subsingleton.eq_one]
+
+-- All `simp`-like tactics are covered, including the `using` clause of `nontriviality`.
+
+-- The linter names the `simp_rw` syntax kind literally, because importing its module there
+-- would be circular. Check that name against the kind `simp_rw` actually parses to.
+open Lean Mathlib.Linter.BlanketSimpArgs in
+run_meta do
+  let stx ← `(tactic| simp_rw [id_eq])
+  unless stx.raw.getKind == simpRwKind do
+    throwError "`simpRwKind` is stale: `simp_rw` parses to `{stx.raw.getKind}`"
+
+/--
+warning: `Subsingleton.eq_zero` rewrites a bare variable, so `simp` tries it at every subterm and attempts to discharge its side conditions at each match, which can dominate the elaboration time of a proof.
+Determine the side conditions at this use site instead, by applying the lemma to a term or by fixing its implicit arguments with named arguments, as in `Subsingleton.eq_zero (α := M)`.
+
+Note: This linter can be disabled with `set_option linter.blanketSimpArgs false`
+-/
+#guard_msgs in
+example (x : M) : x = 0 := by simp_rw [Subsingleton.eq_zero]
+
+/--
+warning: `Subsingleton.eq_zero` rewrites a bare variable, so `simp` tries it at every subterm and attempts to discharge its side conditions at each match, which can dominate the elaboration time of a proof.
+Determine the side conditions at this use site instead, by applying the lemma to a term or by fixing its implicit arguments with named arguments, as in `Subsingleton.eq_zero (α := M)`.
+
+Note: This linter can be disabled with `set_option linter.blanketSimpArgs false`
+-/
+#guard_msgs in
+example {R : Type} [Zero R] (r : R) : r = r := by
+  nontriviality R using Subsingleton.eq_zero
+  rfl
+
+-- Fixing the implicit arguments determines the side conditions; this is not linted.
+
+#guard_msgs in
+example (x : M) : x = 0 := by simp [Subsingleton.eq_zero (α := M)]
+
+-- Applying the lemma to a term determines the side conditions; this is not linted.
+
+#guard_msgs in
+example (x : M) : x = 0 := by simp [Subsingleton.eq_zero x]
+
+-- Ordinary simp lemmas with a proper head pattern are not linted.
+
+#guard_msgs in
+example (n : Nat) : id n = n := by simp [id_eq]
+
+-- Local hypotheses are not linted.
+
+#guard_msgs in
+example (x : M) (h : ∀ y : M, y = 0) : x = 0 := by simp [h]
+
+-- Unfolding a definition is not linted.
+
+private def myId (n : Nat) : Nat := n
+
+#guard_msgs in
+example (n : Nat) : myId n = n := by simp [myId]
+
+-- Unfolding a definition whose result type is a type variable with instance
+-- arguments is not linted either: the constant is not a proof, so it cannot be
+-- a rewrite with side conditions.
+
+private def fallback {α : Type} [Inhabited α] (_ : Nat) : α := default
+
+#guard_msgs in
+example : fallback 3 = (default : Nat) := by simp [fallback]
+
+-- A variable rewrite source whose type is fixed only matches subterms of that type
+-- family, so it is not linted.
+
+private theorem eq_nil_of_isEmpty {α : Type} [IsEmpty α] (l : List α) : l = [] := by
+  cases l with
+  | nil => rfl
+  | cons a _ => exact (IsEmpty.false a).elim
+
+#guard_msgs in
+example {β : Type} [IsEmpty β] (l : List β) : l = [] := by simp [eq_nil_of_isEmpty]


### PR DESCRIPTION
The `blanketSimpArgs` linter flags simp arguments such as `simp [Subsingleton.eq_zero]` whose rewrite source is a bare variable and whose side conditions `simp` must discharge at every match. Such an argument is retrieved at every visited subterm (its discrimination tree key is `*`), and each attempted match triggers instance searches that miss the cache under binders; #42053 measured a single such argument dominating the elaboration time of a file. The linter suggests determining the side conditions at the use site, by applying the lemma to a term or by fixing its implicit arguments, as in `Subsingleton.eq_zero (α := M)`.

The check is semantic, so it covers `Subsingleton.eq_one`, `Unique.eq_default` and any other lemma of the same shape. It walks the `simpLemma` argument nodes shared by the `simp`-like tactics, including the `using` clause of `nontriviality`, and the rewrite rules of `simp_rw`.

The first commit pins the remaining such simp arguments in Mathlib, all of them uses of `Unique.eq_default`, so that the library is clean under the new linter.

---

- [x] depends on: #42053

AI usage: the linter, its tests and the call-site fixes were written with Claude Code (Claude Fable 5) under my direction; I have reviewed all of it, and the tests and affected files were verified by building them locally.