### PR TITLE
[Merged by Bors] - chore(Dynamics): fix defs with underscore

### DIFF
--- a/Mathlib/Dynamics/TopologicalEntropy/Subset.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/Subset.lean
@@ -196,7 +196,7 @@ lemma coverEntropy_biUnion_le (s : Set ι) (T : X → X) (F : ι → Set X) :
   iSup₂_le fun _ i_s ↦ coverEntropy_monotone T (subset_biUnion_of_mem i_s)
 
 /-- Topological entropy `CoverEntropy T` as a `SupBotHom` function of the subset. -/
-noncomputable def coverEntropy_supBotHom (T : X → X) :
+noncomputable def coverEntropySupBotHom (T : X → X) :
     SupBotHom (Set X) EReal where
   toFun := coverEntropy T
   map_sup' := fun _ _ ↦ coverEntropy_union
@@ -204,12 +204,12 @@ noncomputable def coverEntropy_supBotHom (T : X → X) :
 
 lemma coverEntropy_iUnion_of_finite [Finite ι] {T : X → X} {F : ι → Set X} :
     coverEntropy T (⋃ i : ι, F i) = ⨆ i : ι, coverEntropy T (F i) :=
-  map_finite_iSup (coverEntropy_supBotHom T) F
+  map_finite_iSup (coverEntropySupBotHom T) F
 
 lemma coverEntropy_biUnion_finset {T : X → X} {F : ι → Set X} {s : Finset ι} :
     coverEntropy T (⋃ i ∈ s, F i) = ⨆ i ∈ s, coverEntropy T (F i) := by
-  have := map_finset_sup (coverEntropy_supBotHom T) s F
-  rw [s.sup_set_eq_biUnion, s.sup_eq_iSup, coverEntropy_supBotHom, SupBotHom.coe_mk,
+  have := map_finset_sup (coverEntropySupBotHom T) s F
+  rw [s.sup_set_eq_biUnion, s.sup_eq_iSup, coverEntropySupBotHom, SupBotHom.coe_mk,
     SupHom.coe_mk] at this
   rw [this]
   congr

--- a/Mathlib/Dynamics/TopologicalEntropy/Subset.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/Subset.lean
@@ -202,6 +202,9 @@ noncomputable def coverEntropySupBotHom (T : X → X) :
   map_sup' := fun _ _ ↦ coverEntropy_union
   map_bot' := coverEntropy_empty
 
+@[deprecated (since := "2026-07-25")]
+alias coverEntropy_supBotHom := coverEntropySupBotHom
+
 lemma coverEntropy_iUnion_of_finite [Finite ι] {T : X → X} {F : ι → Set X} :
     coverEntropy T (⋃ i : ι, F i) = ⨆ i : ι, coverEntropy T (F i) :=
   map_finite_iSup (coverEntropySupBotHom T) F

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -122,6 +122,7 @@
  ["defsWithUnderscore", "DividedPowers.subDPIdeal_inf_of_quot"],
  ["defsWithUnderscore", "DomMulAct.stabilizerEquiv_invFun"],
  ["defsWithUnderscore", "DomMulAct.stabilizerEquiv_invFun_aux"],
+ ["defsWithUnderscore", "Dynamics.coverEntropy_supBotHom"],
  ["defsWithUnderscore", "EisensteinSeries.eisensteinSeries_SIF"],
  ["defsWithUnderscore", "EisensteinSeries.gammaSet_one_equiv"],
  ["defsWithUnderscore", "Equiv.removeNone_aux"],

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -122,7 +122,6 @@
  ["defsWithUnderscore", "DividedPowers.subDPIdeal_inf_of_quot"],
  ["defsWithUnderscore", "DomMulAct.stabilizerEquiv_invFun"],
  ["defsWithUnderscore", "DomMulAct.stabilizerEquiv_invFun_aux"],
- ["defsWithUnderscore", "Dynamics.coverEntropy_supBotHom"],
  ["defsWithUnderscore", "EisensteinSeries.eisensteinSeries_SIF"],
  ["defsWithUnderscore", "EisensteinSeries.gammaSet_one_equiv"],
  ["defsWithUnderscore", "Equiv.removeNone_aux"],


### PR DESCRIPTION
This PR deprecates all (1) defs with underscore in Dynamics and renames it according to the naming convention.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
