### PR TITLE
refactor(RepresentationTheory): weaken condition of Schur's lemma

### DIFF
--- a/Mathlib/RepresentationTheory/AlgebraRepresentation/Basic.lean
+++ b/Mathlib/RepresentationTheory/AlgebraRepresentation/Basic.lean
@@ -5,8 +5,8 @@ Authors: Stepan Nesterov
 -/
 module
 
-public import Mathlib.Algebra.Lie.OfAssociative
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import Mathlib.RingTheory.SimpleModule.Basic
 
 /-!
 # Basic facts about algebra representations
@@ -21,21 +21,19 @@ public section
 
 variable {A V : Type*} (k : Type*) [Field k] [Ring A] [Algebra k A] [AddCommGroup V] [Module k V]
   [Module A V] [IsScalarTower k A V]
-  [IsSimpleModule A V] [FiniteDimensional k V] [IsAlgClosed k]
+  [IsSimpleModule A V] [FiniteDimensional k (Module.End A V)] [IsAlgClosed k]
 
-/-- Schur's Lemma: If `V` is a representation of an algebra `A` over an algebraically closed field
-`k`, then any endomorphism of `V` is scalar. -/
+/-- Schur's Lemma: If `V` is an irreducible representation of an algebra `A` over an algebraically
+closed field `k` with finite dimensional endomorphisms, then any endomorphism of `V` is scalar. -/
 theorem IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed :
     Function.Bijective (algebraMap k (Module.End A V)) := by
-  have : Module.Finite k (Module.End A V) := .of_injective (LinearMap.restrictScalarsₗ k A V V k) <|
-    LinearMap.restrictScalars_injective _
   classical exact IsAlgClosed.algebraMap_bijective_of_isIntegral (k := k)
 
 variable (A V)
 
 open scoped IsMulCommutative in
-/-- Any finite-dimensional irreducible representation of a commutative algebra over an algebraically
-closed field is one-dimensional. -/
+/-- Any irreducible representation of a commutative algebra with finite dimensional endomorphisms
+over an algebraically closed field is one-dimensional. -/
 theorem IsSimpleModule.finrank_eq_one_of_isMulCommutative [IsMulCommutative A] :
     Module.finrank k V = 1 := by
   have : Nontrivial V := IsSimpleModule.nontrivial A V

--- a/Mathlib/RepresentationTheory/Irreducible.lean
+++ b/Mathlib/RepresentationTheory/Irreducible.lean
@@ -57,6 +57,10 @@ theorem injective_or_eq_zero : Injective f ∨ f = 0 := by
   rw [← LinearEquiv.map_eq_zero_iff (equivLinearMapAsModule ρ σ)]
   exact LinearMap.injective_or_eq_zero (equivLinearMapAsModule ρ σ f)
 
+theorem surjective_or_eq_zero (g : IntertwiningMap σ ρ) : Surjective g ∨ g = 0 := by
+  rw [← LinearEquiv.map_eq_zero_iff (equivLinearMapAsModule σ ρ)]
+  exact LinearMap.surjective_or_eq_zero (equivLinearMapAsModule σ ρ g)
+
 theorem bijective_or_eq_zero [IsIrreducible σ] : Bijective f ∨ f = 0 := by
   rw [← LinearEquiv.map_eq_zero_iff (equivLinearMapAsModule ρ σ)]
   exact LinearMap.bijective_or_eq_zero (equivLinearMapAsModule ρ σ f)

--- a/Mathlib/RepresentationTheory/Irreducible.lean
+++ b/Mathlib/RepresentationTheory/Irreducible.lean
@@ -57,10 +57,6 @@ theorem injective_or_eq_zero : Injective f ∨ f = 0 := by
   rw [← LinearEquiv.map_eq_zero_iff (equivLinearMapAsModule ρ σ)]
   exact LinearMap.injective_or_eq_zero (equivLinearMapAsModule ρ σ f)
 
-theorem surjective_or_eq_zero (g : IntertwiningMap σ ρ) : Surjective g ∨ g = 0 := by
-  rw [← LinearEquiv.map_eq_zero_iff (equivLinearMapAsModule σ ρ)]
-  exact LinearMap.surjective_or_eq_zero (equivLinearMapAsModule σ ρ g)
-
 theorem bijective_or_eq_zero [IsIrreducible σ] : Bijective f ∨ f = 0 := by
   rw [← LinearEquiv.map_eq_zero_iff (equivLinearMapAsModule ρ σ)]
   exact LinearMap.bijective_or_eq_zero (equivLinearMapAsModule ρ σ f)

--- a/Mathlib/RepresentationTheory/Irreducible.lean
+++ b/Mathlib/RepresentationTheory/Irreducible.lean
@@ -5,9 +5,9 @@ Authors: Stepan Nesterov
 -/
 module
 
-public import Mathlib.RepresentationTheory.Subrepresentation
-public import Mathlib.RepresentationTheory.Intertwining
 public import Mathlib.RepresentationTheory.AlgebraRepresentation.Basic
+public import Mathlib.RepresentationTheory.Intertwining
+public import Mathlib.RepresentationTheory.Subrepresentation
 
 /-!
 # Irreducible representations
@@ -64,13 +64,15 @@ theorem bijective_or_eq_zero [IsIrreducible σ] : Bijective f ∨ f = 0 := by
 instance [IsIrreducible σ] [IsEmpty (Equiv ρ σ)] : Subsingleton (IntertwiningMap ρ σ) :=
   ⟨fun f g ↦ sub_eq_zero.mp <| (bijective_or_eq_zero _).resolve_left
     fun h ↦ isEmpty_iff.mp inferInstance <| (f - g).ofBijective h⟩
-variable [FiniteDimensional k V] [IsAlgClosed k]
 
-variable (f : IntertwiningMap ρ ρ) in
+variable [IsAlgClosed k] [FiniteDimensional k (IntertwiningMap ρ ρ)]
+
 theorem algebraMap_intertwiningMap_bijective_of_isAlgClosed :
     Bijective (algebraMap k (IntertwiningMap ρ ρ)) := by
-  have : Bijective (algebraMap k (Module.End k[G] ρ.asModule)) :=
-    IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed k
+  have : FiniteDimensional k (Module.End k[G] ρ.asModule) :=
+    (IntertwiningMap.equivLinearMapAsModule ρ ρ).finiteDimensional
+  have : Bijective (algebraMap k (Module.End k[G] ρ.asModule)) := by
+    classical exact IsAlgClosed.algebraMap_bijective_of_isIntegral (k := k)
   exact (Bijective.of_comp_iff' (IntertwiningMap.equivAlgEnd (ρ := ρ)).bijective _).1 this
 
 variable (ρ) in
@@ -83,6 +85,8 @@ open scoped IsMulCommutative in
 include ρ in
 variable (ρ) in
 theorem finrank_eq_one_of_isMulCommutative [IsMulCommutative G] : Module.finrank k V = 1 := by
+  have : FiniteDimensional k (Module.End k[G] ρ.asModule) :=
+    (IntertwiningMap.equivLinearMapAsModule ρ ρ).finiteDimensional
   exact IsSimpleModule.finrank_eq_one_of_isMulCommutative k[G] ρ.asModule k
 
 end IsIrreducible


### PR DESCRIPTION
Replace the condition `[FiniteDimensional k V]` of Schur's lemma by `[FiniteDimensional k (IntertwiningMap ρ ρ)]`. Note that the former will automatically give the latter by typeclass inference.

This has an immediate downstream application: irreducible admissible smooth representations (of e.g. GL2(Qp)) are usually not finite dimensional but the weaker condition`[FiniteDimensional k (IntertwiningMap ρ ρ)]` can be easily deduced from the definition of being "irreducible admissible smooth".