### PR TITLE
feat(FieldTheory): reduce Frobenius powers modulo the extension degree

### DIFF
--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -489,8 +489,7 @@ theorem iterateFrobenius_mod {p : ℕ} [Fact p.Prime] [CharP K p] {n : ℕ}
     (hcard : Fintype.card K = p ^ n) (m : ℕ) (x : K) :
     iterateFrobenius K p m x =
       iterateFrobenius K p (m % n) x := by
-  rw [iterateFrobenius_eq_pow, iterateFrobenius_eq_pow,
-    frobenius_pow_eq_pow_mod hcard m]
+  rw [iterateFrobenius_eq_pow, iterateFrobenius_eq_pow, frobenius_pow_eq_pow_mod hcard m]
 
 open Polynomial
 

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -487,8 +487,7 @@ theorem frobenius_pow_eq_pow_mod {p : ℕ} [Fact p.Prime] [CharP K p] {n : ℕ}
 /-- Pointwise form of `frobenius_pow_eq_pow_mod`. -/
 theorem iterateFrobenius_mod {p : ℕ} [Fact p.Prime] [CharP K p] {n : ℕ}
     (hcard : Fintype.card K = p ^ n) (m : ℕ) (x : K) :
-    iterateFrobenius K p m x =
-      iterateFrobenius K p (m % n) x := by
+    iterateFrobenius K p m x = iterateFrobenius K p (m % n) x := by
   rw [iterateFrobenius_eq_pow, iterateFrobenius_eq_pow, frobenius_pow_eq_pow_mod hcard m]
 
 open Polynomial

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -479,13 +479,13 @@ theorem frobenius_pow {p : ℕ} [Fact p.Prime] [CharP K p] {n : ℕ} (hcard : q 
     rw [pow_succ', pow_succ, pow_mul, RingHom.mul_def, RingHom.comp_apply, frobenius_def, hn]
 
 /-- Powers of Frobenius may be reduced modulo the extension degree. -/
-theorem frobenius_pow_eq_pow_mod
+theorem frobenius_pow_eq_pow_mod {p : ℕ} [Fact p.Prime] [CharP K p] {n : ℕ}
     (hcard : Fintype.card K = p ^ n) (m : ℕ) :
     frobenius K p ^ m = frobenius K p ^ (m % n) :=
   pow_eq_pow_mod m (frobenius_pow hcard)
 
 /-- Pointwise form of `frobenius_pow_eq_pow_mod`. -/
-theorem iterateFrobenius_mod
+theorem iterateFrobenius_mod {p : ℕ} [Fact p.Prime] [CharP K p] {n : ℕ}
     (hcard : Fintype.card K = p ^ n) (m : ℕ) (x : K) :
     iterateFrobenius K p m x =
       iterateFrobenius K p (m % n) x := by

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -478,6 +478,20 @@ theorem frobenius_pow {p : ℕ} [Fact p.Prime] [CharP K p] {n : ℕ} (hcard : q 
   | succ n hn =>
     rw [pow_succ', pow_succ, pow_mul, RingHom.mul_def, RingHom.comp_apply, frobenius_def, hn]
 
+/-- Powers of Frobenius may be reduced modulo the extension degree. -/
+theorem frobenius_pow_eq_pow_mod
+    (hcard : Fintype.card K = p ^ n) (m : ℕ) :
+    frobenius K p ^ m = frobenius K p ^ (m % n) :=
+  pow_eq_pow_mod m (frobenius_pow hcard)
+
+/-- Pointwise form of `frobenius_pow_eq_pow_mod`. -/
+theorem iterateFrobenius_mod
+    (hcard : Fintype.card K = p ^ n) (m : ℕ) (x : K) :
+    iterateFrobenius K p m x =
+      iterateFrobenius K p (m % n) x := by
+  rw [iterateFrobenius_eq_pow, iterateFrobenius_eq_pow,
+    frobenius_pow_eq_pow_mod hcard m]
+
 open Polynomial
 
 theorem expand_card (f : K[X]) : expand K q f = f ^ q := by


### PR DESCRIPTION
Adds ring-hom and pointwise lemmas reducing powers of Frobenius modulo the extension degree of a finite field.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
