### PR TITLE
feat: path length bounds for endpoints in metric spaces

### DIFF
--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -12,6 +12,7 @@ public import Mathlib.Topology.UniformSpace.UniformConvergenceTopology
 public import Mathlib.Topology.Instances.ENNReal.Lemmas
 public import Mathlib.Topology.Order.LeftRightLim
 public import Mathlib.Topology.Semicontinuity.Defs
+public import Mathlib.Topology.Path
 public import Mathlib.Tactic.Bound
 
 /-!
@@ -1272,3 +1273,34 @@ theorem LipschitzWith.locallyBoundedVariationOn {f : ℝ → E} {C : ℝ≥0} (h
   hf.lipschitzOnWith.locallyBoundedVariationOn
 
 end LipschitzOnWith
+
+/-- The edist between the endpoints of a path is bounded by its extended variation
+ (i.e. length) on [0, 1].
+
+TODO: Characterize shortest paths as straight line segments in strict convex spaces.
+-/
+lemma edist_le_length_of_path {E : Type*} [PseudoEMetricSpace E] {a b : E}
+    (γ : Path a b) : edist a b ≤ eVariationOn γ (Icc 0 1) := by
+  dsimp [eVariationOn]
+  let n : ℕ := 1
+  let u : ℕ → ↑unitInterval := fun i ↦ if i = 0 then ⟨0, by simp⟩ else ⟨1, by simp⟩
+  have hu : Monotone (fun i ↦ (u i : ℝ)) := by
+    apply monotone_nat_of_le_succ
+    intro i
+    dsimp [u]
+    split_ifs <;> simp
+  have us : ∀ i, (u i : ℝ) ∈ Icc (0 : ℝ) 1 := fun i ↦ (u i).property
+  apply le_iSup_of_le ⟨n, u, hu, us⟩
+  simp only
+  rw [Finset.sum_range_one,zero_add]
+  dsimp [u]
+  rw [γ.source, γ.target, edist_comm]
+
+/-- The distance between the endpoints of a path is bounded by its variation
+(i.e. length) on [0, 1]. This is a special case of the previous theorem in
+the metric space setting. -/
+lemma dist_le_length_of_path {E : Type*} [MetricSpace E] {a b : E}
+    (γ : Path a b) : ENNReal.ofReal (dist a b) ≤ eVariationOn γ.toFun (Icc 0 1) := by
+  have h := edist_le_length_of_path γ
+  rw [edist_dist] at h
+  exact h


### PR DESCRIPTION
Added lemmas relating the distance between endpoints of a path to its variation in both pseudo-emetric and metric spaces. This is a half of a theorem charactering shortest paths as straight line segments in strict convex spaces. Later I will do the other half which is harder.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
