### PR TITLE
feat(Analysis/CStarAlgebra): spectral projections from clopen spectral sets

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1699,6 +1699,7 @@ public import Mathlib.Analysis.CStarAlgebra.CompletelyPositiveMap
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Commute
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Continuity
+public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Ideal
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Integral
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Isometric

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1710,6 +1710,7 @@ public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Pi
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Projection
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Range
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.RealImaginaryPart
+public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.SpectralProjection
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Restrict
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unique
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unital

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Ideal.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Ideal.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 Pablo Cohen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pablo Cohen
+-/
+module
+
+public import Mathlib.RingTheory.TwoSidedIdeal.Basic
+public import Mathlib.Analysis.CStarAlgebra.ApproximateUnit
+public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
+public import Mathlib.Topology.ContinuousMap.StoneWeierstrass
+
+/-!
+# The non-unital continuous functional calculus maps into closed two-sided ideals
+
+Let `A` be a non-unital C⋆-algebra, `I` a closed two-sided ideal of `A`, `a ∈ I`, and
+`f : ℝ → ℝ`. In this file we prove that `cfcₙ f a ∈ I`. Since `cfcₙ f a` takes the junk value
+`0 ∈ I` whenever `f` is not continuous on the quasispectrum, `f 0 ≠ 0`, or `a` is not selfadjoint,
+no hypotheses on `f` beyond `f : ℝ → ℝ` are required: the statement holds unconditionally.
+
+The proof spine is:
+
+* A closed two-sided ideal in a non-unital C⋆-algebra is closed under the scalar action
+  (`TwoSidedIdeal.smul_mem_of_isClosed`), proved using the canonical approximate unit
+  `CStarAlgebra.approximateUnit`: for `y ∈ I` and a scalar `r`, we have
+  `r • y = lim (r • (eₗ * y)) = lim ((r • eₗ) * y)`, and each `(r • eₗ) * y ∈ I`, so `r • y ∈ I`.
+* The set of elements `g : C(σₙ ℝ a, ℝ)₀` with `cfcₙHom ha g ∈ I` is closed (preimage of the
+  closed set `I` under the continuous map `cfcₙHom ha`), a non-unital `ℝ`-subalgebra containing
+  the identity (which maps to `a ∈ I`) and its star (which maps to `star a = a ∈ I`). By the
+  Weierstrass approximation theorem for `C(σₙ ℝ a, ℝ)₀`
+  (`ContinuousMapZero.induction_on_of_compact`), it is everything.
+
+## Main results
+
+* `TwoSidedIdeal.smul_mem_of_isClosed`: a closed two-sided ideal in a non-unital C⋆-algebra is
+  closed under the scalar action.
+* `TwoSidedIdeal.cfcₙHom_mem_of_isClosed`: for a selfadjoint `a` in a closed two-sided ideal `I`,
+  every value `cfcₙHom ha g` of the underlying homomorphism lies in `I`.
+* `TwoSidedIdeal.cfcₙ_mem_of_isClosed`: the main result, `cfcₙ f a ∈ I` for `a ∈ I` and
+  `I` closed.
+-/
+
+@[expose] public section
+
+open scoped ContinuousMapZero
+open Topology Filter CStarAlgebra
+
+namespace TwoSidedIdeal
+
+variable {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
+
+/-- A closed two-sided ideal in a non-unital C⋆-algebra is closed under the scalar action.
+
+This upgrades the purely ring-theoretic notion of a two-sided ideal to a submodule, using that a
+closed two-sided ideal in a C⋆-algebra is invariant under the canonical approximate unit. -/
+theorem smul_mem_of_isClosed {𝕜 : Type*} [SMul 𝕜 A] [ContinuousConstSMul 𝕜 A]
+    [IsScalarTower 𝕜 A A] {I : TwoSidedIdeal A} (hI : IsClosed (I : Set A)) {y : A}
+    (hy : y ∈ I) (r : 𝕜) : r • y ∈ I := by
+  haveI : (approximateUnit A).NeBot := (increasingApproximateUnit A).neBot
+  have h : Tendsto (fun x => r • (x * y)) (approximateUnit A) (𝓝 (r • y)) :=
+    ((increasingApproximateUnit A).tendsto_mul_right y).const_smul r
+  refine hI.mem_of_tendsto h (Eventually.of_forall fun x => ?_)
+  show r • (x * y) ∈ I
+  rw [← smul_mul_assoc]
+  exact I.mul_mem_left (r • x) y hy
+
+/-- For a selfadjoint element `a` of a closed two-sided ideal `I` in a non-unital C⋆-algebra, every
+value of the non-unital continuous functional calculus homomorphism `cfcₙHom` lies in `I`. -/
+theorem cfcₙHom_mem_of_isClosed {I : TwoSidedIdeal A} (hI : IsClosed (I : Set A)) {a : A}
+    (ha : a ∈ I) (ha' : IsSelfAdjoint a) (g : C(quasispectrum ℝ a, ℝ)₀) :
+    cfcₙHom ha' g ∈ I := by
+  have h0 : ((0 : quasispectrum ℝ a) : ℝ) = 0 := rfl
+  have hid : cfcₙHom ha' (ContinuousMapZero.id h0) = a := by
+    rw [show (ContinuousMapZero.id h0 : C(quasispectrum ℝ a, ℝ)₀) =
+        ⟨(ContinuousMap.id ℝ).restrict (quasispectrum ℝ a), rfl⟩ from rfl]
+    exact cfcₙHom_id ha'
+  induction g using ContinuousMapZero.induction_on_of_compact h0 with
+  | zero => simp only [map_zero]; exact I.zero_mem
+  | id => rw [hid]; exact ha
+  | star_id => rw [map_star, hid, ha'.star_eq]; exact ha
+  | add f g hf hg => rw [map_add]; exact I.add_mem hf hg
+  | mul f g hf hg => rw [map_mul]; exact I.mul_mem_left _ _ hg
+  | smul r f hf => rw [map_smul]; exact smul_mem_of_isClosed hI hf r
+  | frequently f h => exact h.mem_of_closed (hI.preimage (cfcₙHom_continuous ha'))
+
+/-- **The non-unital continuous functional calculus maps into closed two-sided ideals.** If `I` is a
+closed two-sided ideal of a non-unital C⋆-algebra `A`, `a ∈ I`, and `f : ℝ → ℝ`, then
+`cfcₙ f a ∈ I`.
+
+No continuity or `f 0 = 0` hypotheses are needed: in every case where `cfcₙ` would take its junk
+value, that value is `0 ∈ I`. -/
+theorem cfcₙ_mem_of_isClosed {I : TwoSidedIdeal A} (hI : IsClosed (I : Set A)) {a : A}
+    (ha : a ∈ I) (f : ℝ → ℝ) : cfcₙ f a ∈ I :=
+  cfcₙ_cases (· ∈ I) a f I.zero_mem fun _ _ ha' => cfcₙHom_mem_of_isClosed hI ha ha' _
+
+end TwoSidedIdeal
+

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Ideal.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Ideal.lean
@@ -94,4 +94,3 @@ theorem cfcₙ_mem_of_isClosed {I : TwoSidedIdeal A} (hI : IsClosed (I : Set A))
   cfcₙ_cases (· ∈ I) a f I.zero_mem fun _ _ ha' => cfcₙHom_mem_of_isClosed hI ha ha' _
 
 end TwoSidedIdeal
-

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Ideal.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Ideal.lean
@@ -60,7 +60,6 @@ theorem smul_mem_of_isClosed {𝕜 : Type*} [SMul 𝕜 A] [ContinuousConstSMul �
   have h : Tendsto (fun x => r • (x * y)) (approximateUnit A) (𝓝 (r • y)) :=
     ((increasingApproximateUnit A).tendsto_mul_right y).const_smul r
   refine hI.mem_of_tendsto h (Eventually.of_forall fun x => ?_)
-  show r • (x * y) ∈ I
   rw [← smul_mul_assoc]
   exact I.mul_mem_left (r • x) y hy
 
@@ -69,15 +68,10 @@ value of the non-unital continuous functional calculus homomorphism `cfcₙHom` 
 theorem cfcₙHom_mem_of_isClosed {I : TwoSidedIdeal A} (hI : IsClosed (I : Set A)) {a : A}
     (ha : a ∈ I) (ha' : IsSelfAdjoint a) (g : C(quasispectrum ℝ a, ℝ)₀) :
     cfcₙHom ha' g ∈ I := by
-  have h0 : ((0 : quasispectrum ℝ a) : ℝ) = 0 := rfl
-  have hid : cfcₙHom ha' (ContinuousMapZero.id h0) = a := by
-    rw [show (ContinuousMapZero.id h0 : C(quasispectrum ℝ a, ℝ)₀) =
-        ⟨(ContinuousMap.id ℝ).restrict (quasispectrum ℝ a), rfl⟩ from rfl]
-    exact cfcₙHom_id ha'
-  induction g using ContinuousMapZero.induction_on_of_compact h0 with
+  induction g using ContinuousMapZero.induction_on_of_compact with
   | zero => simp only [map_zero]; exact I.zero_mem
-  | id => rw [hid]; exact ha
-  | star_id => rw [map_star, hid, ha'.star_eq]; exact ha
+  | id => rw [cfcₙHom_id ha']; exact ha
+  | star_id => rw [map_star, cfcₙHom_id ha', ha'.star_eq]; exact ha
   | add f g hf hg => rw [map_add]; exact I.add_mem hf hg
   | mul f g hf hg => rw [map_mul]; exact I.mul_mem_left _ _ hg
   | smul r f hf => rw [map_smul]; exact smul_mem_of_isClosed hI hf r

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/SpectralProjection.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/SpectralProjection.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 Pablo Cohen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pablo Cohen
+-/
+module
+
+public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Ideal
+public import Mathlib.Topology.Algebra.Indicator
+public import Mathlib.Algebra.GroupWithZero.Indicator
+
+/-!
+# Spectral projections from clopen subsets of the quasispectrum
+
+Let `A` be a non-unital C⋆-algebra and `a : A` a selfadjoint element. If `U : Set ℝ` is clopen in
+the (non-unital) quasispectrum `σₙ ℝ a := quasispectrum ℝ a` and `0 ∉ U`, then the real-valued
+indicator function `U.indicator 1` is continuous on `σₙ ℝ a` and vanishes at `0`, so the non-unital
+continuous functional calculus produces an element
+
+  `spectralProjection a U := cfcₙ (U.indicator 1) a`.
+
+Because the indicator is idempotent and real-valued, this element is a *projection*: it is
+selfadjoint and idempotent. It is nonzero exactly when `U` meets the quasispectrum, and — crucially
+for the theory of ideals — it lies inside any closed two-sided ideal containing `a`
+(via `TwoSidedIdeal.cfcₙ_mem_of_isClosed`). Thus a clopen spectral set away from `0` manufactures a
+genuine projection inside a nonzero ideal.
+
+## Main definitions and results
+
+* `spectralProjection a U`: the value of the non-unital continuous functional calculus at the
+  indicator function of `U`.
+* `isSelfAdjoint_spectralProjection`: `spectralProjection a U` is selfadjoint.
+* `isIdempotentElem_spectralProjection`: for `U` clopen in `σₙ ℝ a` with `0 ∉ U`,
+  `spectralProjection a U` is idempotent.
+* `spectralProjection_mem`: if `a` belongs to a closed two-sided ideal `I`, then so does
+  `spectralProjection a U`.
+* `spectralProjection_eq_zero_iff` / `spectralProjection_ne_zero`: `spectralProjection a U`
+  vanishes iff `U` misses the quasispectrum, and is nonzero as soon as `U` meets it.
+* `spectralProjection_ne_zero_of_finite_quasispectrum`: when the quasispectrum is finite (e.g. in
+  AF/UHF or matrix C⋆-algebras) every point is isolated, so a nonzero selfadjoint element yields a
+  nonzero projection.
+-/
+
+@[expose] public section
+
+open Set
+open scoped ContinuousMapZero
+
+namespace CStarAlgebra
+
+variable {A : Type*} [NonUnitalCStarAlgebra A]
+
+/-- If `U : Set ℝ` is clopen in the quasispectrum of `a` (i.e. its preimage under the subtype
+coercion is clopen), then the real-valued indicator function `U.indicator 1` is continuous on the
+quasispectrum. -/
+theorem continuousOn_indicator_one_of_isClopen {a : A} {U : Set ℝ}
+    (hU : IsClopen (Subtype.val ⁻¹' U : Set (quasispectrum ℝ a))) :
+    ContinuousOn (U.indicator (1 : ℝ → ℝ)) (quasispectrum ℝ a) := by
+  rw [continuousOn_iff_continuous_domRestrict]
+  have h : (quasispectrum ℝ a).domRestrict (U.indicator (1 : ℝ → ℝ))
+      = (Subtype.val ⁻¹' U : Set (quasispectrum ℝ a)).indicator (fun _ => (1 : ℝ)) := by
+    ext x
+    rw [Set.domRestrict_apply]
+    by_cases hx : (x : ℝ) ∈ U
+    · rw [Set.indicator_of_mem hx, Set.indicator_of_mem (Set.mem_preimage.mpr hx)]; rfl
+    · rw [Set.indicator_of_notMem hx,
+        Set.indicator_of_notMem (fun h => hx (Set.mem_preimage.mp h))]
+  rw [h]
+  exact hU.continuous_indicator continuous_const
+
+/-- The **spectral projection** attached to a subset `U` of the reals: the value of the non-unital
+continuous functional calculus of `a` at the indicator function of `U`. When `U` is clopen in the
+quasispectrum of a selfadjoint `a` and `0 ∉ U`, this is a genuine projection
+(`isSelfAdjoint_spectralProjection`, `isIdempotentElem_spectralProjection`). -/
+noncomputable def spectralProjection (a : A) (U : Set ℝ) : A :=
+  cfcₙ (U.indicator (1 : ℝ → ℝ)) a
+
+/-- A spectral projection is selfadjoint. This needs no hypotheses: it is the defining predicate of
+the real non-unital continuous functional calculus, and holds even for the junk value `0`. -/
+theorem isSelfAdjoint_spectralProjection (a : A) (U : Set ℝ) :
+    IsSelfAdjoint (spectralProjection a U) :=
+  cfcₙ_predicate _ a
+
+/-- A spectral projection attached to a clopen set `U` away from `0` is idempotent, because the
+indicator function is idempotent pointwise. -/
+theorem isIdempotentElem_spectralProjection {a : A} {U : Set ℝ}
+    (hU : IsClopen (Subtype.val ⁻¹' U : Set (quasispectrum ℝ a))) (h0 : (0 : ℝ) ∉ U) :
+    IsIdempotentElem (spectralProjection a U) := by
+  have hcont : ContinuousOn (U.indicator (1 : ℝ → ℝ)) (quasispectrum ℝ a) :=
+    continuousOn_indicator_one_of_isClopen hU
+  have hzero : (U.indicator (1 : ℝ → ℝ)) 0 = 0 := Set.indicator_of_notMem h0 _
+  rw [IsIdempotentElem, spectralProjection, ← cfcₙ_mul _ _ a hcont hzero hcont hzero]
+  refine cfcₙ_congr (fun x _ => ?_)
+  by_cases hx : x ∈ U <;> simp [Set.indicator_of_mem, Set.indicator_of_notMem, hx]
+
+/-- If `a` lies in a closed two-sided ideal `I`, then so does every spectral projection of `a`.
+This is immediate from the fact that the non-unital continuous functional calculus maps into closed
+two-sided ideals. -/
+theorem spectralProjection_mem [PartialOrder A] [StarOrderedRing A] {I : TwoSidedIdeal A}
+    (hI : IsClosed (I : Set A)) {a : A} (ha : a ∈ I) (U : Set ℝ) : spectralProjection a U ∈ I :=
+  TwoSidedIdeal.cfcₙ_mem_of_isClosed hI ha _
+
+/-- A spectral projection vanishes exactly when `U` misses the quasispectrum. -/
+theorem spectralProjection_eq_zero_iff {a : A} (ha : IsSelfAdjoint a) {U : Set ℝ}
+    (hU : IsClopen (Subtype.val ⁻¹' U : Set (quasispectrum ℝ a))) (h0 : (0 : ℝ) ∉ U) :
+    spectralProjection a U = 0 ↔ ∀ x ∈ quasispectrum ℝ a, x ∉ U := by
+  have hcont : ContinuousOn (U.indicator (1 : ℝ → ℝ)) (quasispectrum ℝ a) :=
+    continuousOn_indicator_one_of_isClopen hU
+  have hzero : (U.indicator (1 : ℝ → ℝ)) 0 = 0 := Set.indicator_of_notMem h0 _
+  rw [spectralProjection, ← cfcₙ_zero ℝ a,
+    cfcₙ_eq_cfcₙ_iff_eqOn (f := U.indicator (1 : ℝ → ℝ)) (g := 0) (a := a) ha hcont hzero]
+  refine ⟨fun h x hx => ?_, fun h x hx => ?_⟩
+  · exact (Set.indicator_eq_zero_iff_notMem ℝ).mp (by simpa using h hx)
+  · simpa using (Set.indicator_eq_zero_iff_notMem ℝ).mpr (h x hx)
+
+/-- A spectral projection is nonzero as soon as `U` meets the quasispectrum. -/
+theorem spectralProjection_ne_zero {a : A} (ha : IsSelfAdjoint a) {U : Set ℝ}
+    (hU : IsClopen (Subtype.val ⁻¹' U : Set (quasispectrum ℝ a))) (h0 : (0 : ℝ) ∉ U)
+    (hne : (U ∩ quasispectrum ℝ a).Nonempty) : spectralProjection a U ≠ 0 := by
+  rw [Ne, spectralProjection_eq_zero_iff ha hU h0]
+  push Not
+  obtain ⟨x, hxU, hxσ⟩ := hne
+  exact ⟨x, hxσ, hxU⟩
+
+/-- When the quasispectrum of `a` is finite, the subspace topology on it is discrete, so *every*
+subset of the reals is clopen in the quasispectrum. This is the mechanism by which finite-spectrum
+C⋆-algebras (AF/UHF, matrix algebras) admit spectral projections onto arbitrary spectral values. -/
+theorem isClopen_of_finite_quasispectrum {a : A} [Finite (quasispectrum ℝ a)] (U : Set ℝ) :
+    IsClopen (Subtype.val ⁻¹' U : Set (quasispectrum ℝ a)) :=
+  isClopen_discrete _
+
+/-- **A nonzero selfadjoint element in a finite-quasispectrum C⋆-algebra admits a nonzero spectral
+projection.** If `σₙ ℝ a` is finite and contains a nonzero point `μ`, then the projection onto
+`{μ}` is nonzero (and, by `spectralProjection_mem`, lies in any closed two-sided ideal containing
+`a`). Finiteness of the quasispectrum holds for matrix and AF/UHF C⋆-algebras; it is what upgrades
+the mere existence of a nonzero spectral value to an *isolated* one. -/
+theorem spectralProjection_singleton_ne_zero {a : A} (ha : IsSelfAdjoint a)
+    [Finite (quasispectrum ℝ a)] {μ : ℝ} (hμ : μ ∈ quasispectrum ℝ a) (hμ0 : μ ≠ 0) :
+    spectralProjection a {μ} ≠ 0 :=
+  spectralProjection_ne_zero ha (isClopen_of_finite_quasispectrum {μ})
+    (by simpa using hμ0.symm) ⟨μ, rfl, hμ⟩
+
+end CStarAlgebra
+
+-- Axiom audit (to be removed before upstreaming)


### PR DESCRIPTION
## What

For `a` in a non-unital C*-algebra and `U : Set ℝ` clopen in the quasispectrum of `a`
with `0 ∉ U`, the indicator `U.indicator 1` is continuous on the quasispectrum and
vanishes at `0`, so `cfcₙ` applies. The resulting element

    CStarAlgebra.spectralProjection a U := cfcₙ (U.indicator 1) a

is a genuine projection: selfadjoint and idempotent. It is nonzero exactly when `U`
meets the quasispectrum, and it lies in any closed two-sided ideal containing `a`.
A corollary covers the finite-quasispectrum case: a nonzero selfadjoint element with
finite quasispectrum admits a nonzero spectral projection onto a nonzero spectral value.

## Why

The indicator of a clopen spectral set is the standard way to extract projections from a
disconnected spectrum. Combined with the `cfcₙ`-into-ideals result this produces
projections inside ideals, which is the basic move in the projection theory of non-unital
C*-algebras.

## Note

Parts of this contribution were developed with AI assistance (Claude). All statements are machine-checked by the Lean kernel; `#print axioms` on the new declarations reports only `[propext, Classical.choice, Quot.sound]`.


------

- [ ] depends on: #42095 (uses `TwoSidedIdeal.cfcₙ_mem_of_isClosed`)

