### PR TITLE
feat(NumberTheory/LSeries): conjugation symmetry for the completed Riemann zeta function

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
@@ -33,6 +33,7 @@ formula which is an important input in functional equations of (un-completed) Di
 
 open Filter Topology Asymptotics Real Set MeasureTheory
 open Complex
+open scoped ComplexConjugate
 
 namespace Complex
 
@@ -51,6 +52,19 @@ Note that this is not the same as `Complex.Gamma`. -/
 noncomputable def Gammaℂ (s : ℂ) := 2 * (2 * π) ^ (-s) * Gamma s
 
 lemma Gammaℂ_def (s : ℂ) : Gammaℂ s = 2 * (2 * π) ^ (-s) * Gamma s := rfl
+
+private lemma pi_cpow_conj (w : ℂ) : (π : ℂ) ^ conj w = conj ((π : ℂ) ^ w) := by
+  have harg : (π : ℂ).arg ≠ π := by
+    rw [arg_ofReal_of_nonneg pi_pos.le]
+    exact Ne.symm pi_ne_zero
+  rw [cpow_conj _ _ harg, conj_ofReal]
+
+/-- The Gamma factor `Gammaℝ` commutes with complex conjugation. -/
+@[simp]
+lemma Gammaℝ_conj (s : ℂ) : Gammaℝ (conj s) = conj (Gammaℝ s) := by
+  have hneg : -conj s / 2 = conj (-s / 2) := by rw [map_div₀, map_neg, map_ofNat]
+  have hhalf : conj s / 2 = conj (s / 2) := by rw [map_div₀, map_ofNat]
+  rw [Gammaℝ_def, Gammaℝ_def, map_mul, hneg, hhalf, pi_cpow_conj, Gamma_conj]
 
 lemma Gammaℝ_add_two {s : ℂ} (hs : s ≠ 0) : Gammaℝ (s + 2) = Gammaℝ s * s / 2 / π := by
   rw [Gammaℝ_def, Gammaℝ_def, neg_div, add_div, neg_add, div_self two_ne_zero,

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -9,8 +9,6 @@ public import Mathlib.NumberTheory.LSeries.Dirichlet
 public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 public import Mathlib.Analysis.Asymptotics.Lemmas
 
-import Mathlib.Analysis.Calculus.Deriv.Star
-import Mathlib.Analysis.Normed.Module.Connected
 
 /-!
 # Asymptotics of `ζ s` as `s → 1` or `s → 0`
@@ -451,35 +449,13 @@ lemma riemannZeta_one_ne_zero : riemannZeta 1 ≠ 0 := by
 
 /-- **Conjugation symmetry of the Riemann zeta function**: `ζ (conj s) = conj (ζ s)`.
 
-Since `ζ` has real Dirichlet coefficients, `conj (ζ (conj z)) = ζ z` holds termwise for
-`1 < re z`, and the identity principle propagates this to all `s ≠ 1`; the junk value `ζ 1` is
-real, so the identity also holds at `s = 1`. -/
+This holds for all `s`, including the pole `s = 1`, since the junk value `ζ 1` is real. -/
 @[simp]
 theorem riemannZeta_conj (s : ℂ) : riemannZeta (conj s) = conj (riemannZeta s) := by
-  rcases eq_or_ne s 1 with rfl | hs
-  · have h : riemannZeta 1 = ((γ - Real.log (4 * π)) / 2 : ℝ) := by
-      rw [riemannZeta_one, ofReal_div, ofReal_sub, ofReal_log (by positivity : (0 : ℝ) ≤ 4 * π)]
-      norm_cast
-    rw [map_one, h, conj_ofReal]
-  · -- `conj ∘ ζ ∘ conj` is analytic on `{1}ᶜ` and agrees with `ζ` termwise on `1 < re z`, so
-    -- the identity principle propagates the equality to the connected set `{1}ᶜ`.
-    have hg_an : AnalyticOnNhd ℂ (fun z ↦ conj (riemannZeta (conj z))) {1}ᶜ :=
-      DifferentiableOn.analyticOnNhd
-        (fun z hz ↦ (differentiableAt_conj_conj_iff.mpr <| differentiableAt_riemannZeta <|
-          (map_ne_one_iff _ (starRingEnd ℂ).injective).mpr hz).differentiableWithinAt)
-        isOpen_compl_singleton
-    have hgz (z : ℂ) (hz : 1 < z.re) : conj (riemannZeta (conj z)) = riemannZeta z := by
-      rw [zeta_eq_tsum_one_div_nat_cpow (by rwa [conj_re]), conj_tsum,
-        zeta_eq_tsum_one_div_nat_cpow hz]
-      exact tsum_congr fun n ↦ by
-        rw [map_div₀, map_one, ← conj_cpow _ _ (by rw [natCast_arg]; positivity), conj_natCast]
-    have heq : EqOn (fun z ↦ conj (riemannZeta (conj z))) riemannZeta {1}ᶜ :=
-      hg_an.eqOn_of_preconnected_of_eventuallyEq analyticOn_riemannZeta
-        (isConnected_compl_singleton_of_one_lt_rank (by simp) 1).isPreconnected
-        (by norm_num : (2 : ℂ) ∈ _)
-        (eventuallyEq_of_mem
-          ((isOpen_lt continuous_const continuous_re).mem_nhds (by norm_num)) hgz)
-    simpa using congrArg (starRingEnd ℂ) (heq hs)
+  rcases eq_or_ne s 0 with rfl | hs
+  · rw [map_zero, riemannZeta_zero, map_div₀, map_neg, map_one, map_ofNat]
+  · rw [riemannZeta_def_of_ne_zero (by simpa using hs), completedRiemannZeta_conj, Gammaℝ_conj,
+      riemannZeta_def_of_ne_zero hs, map_div₀]
 
 lemma riemannZeta_eventually_ne_zero_nhds_one : ∀ᶠ s in 𝓝 1, riemannZeta s ≠ 0 := by
   filter_upwards [eventually_nhdsWithin_iff.1 <| riemannZeta_residue_one.eventually_ne one_ne_zero]

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -5,6 +5,7 @@ Authors: David Loeffler
 -/
 module
 
+public import Mathlib.Analysis.Calculus.Deriv.Star
 public import Mathlib.NumberTheory.LSeries.HurwitzZeta
 public import Mathlib.Analysis.PSeriesComplex
 public import Mathlib.Tactic.CrossRefAttribute
@@ -34,6 +35,8 @@ Euler-Mascheroni constant will follow in a subsequent PR.
   `ζ(s) = ∑' (n : ℕ), 1 / (n + 1) ^ s`.
 * `completedRiemannZeta₀_one_sub`, `completedRiemannZeta_one_sub`, and `riemannZeta_one_sub` :
   functional equation relating values at `s` and `1 - s`
+* `completedRiemannZeta₀_conj` and `completedRiemannZeta_conj` : conjugation symmetry,
+  `Λ (conj s) = conj (Λ s)` and likewise for `Λ₀`
 
 For special-value formulae expressing `ζ (2 * k)` and `ζ (1 - 2 * k)` in terms of Bernoulli numbers
 see `Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean`. For computation of the constant term as
@@ -52,7 +55,7 @@ open CharZero Set Filter HurwitzZeta
 
 open Complex hiding exp continuous_exp
 
-open scoped Topology Real
+open scoped Topology Real ComplexConjugate
 
 noncomputable section
 
@@ -260,3 +263,72 @@ theorem tendsto_sub_mul_tsum_nat_rpow :
   apply (tendsto_sub_mul_tsum_nat_cpow.comp this).congr fun s ↦ ?_
   simp only [one_div, Function.comp_apply, ofReal_mul, ofReal_sub, ofReal_one, ofReal_tsum,
     ofReal_inv, ofReal_cpow (Nat.cast_nonneg _), ofReal_natCast]
+
+/-!
+## Conjugation symmetry
+
+The Dirichlet coefficients of `ζ` are real, so the completed zeta functions `Λ` and `Λ₀` commute
+with complex conjugation. We prove this on the halfplane `1 < re s` using the Dirichlet series,
+and propagate it to all of `ℂ` by the identity principle applied to the entire function `Λ₀`.
+
+No points need to be excluded in the final statements: at the poles `s = 0` and `s = 1` of `Λ`
+both sides take the same junk value, since `Λ` is defined from the entire function `Λ₀` by
+subtracting `1 / s + 1 / (1 - s)` and `1 / 0 = 0`.
+
+For the corresponding statement about `ζ` see `riemannZeta_conj`.
+-/
+
+private lemma natCast_cpow_conj (n : ℕ) (w : ℂ) : (n : ℂ) ^ conj w = conj ((n : ℂ) ^ w) := by
+  have harg : (n : ℂ).arg ≠ π := by
+    rw [natCast_arg]
+    exact Ne.symm Real.pi_ne_zero
+  rw [cpow_conj _ _ harg, conj_natCast]
+
+private lemma completedRiemannZeta_conj_of_one_lt_re {s : ℂ} (hs : 1 < re s) :
+    completedRiemannZeta (conj s) = conj (completedRiemannZeta s) := by
+  have hs' : 1 < re (conj s) := by rwa [conj_re]
+  rw [completedZeta_eq_tsum_of_one_lt_re hs', completedZeta_eq_tsum_of_one_lt_re hs,
+    ← Gammaℝ_def, ← Gammaℝ_def, map_mul, Gammaℝ_conj]
+  congr 1
+  calc ∑' n : ℕ, 1 / (n : ℂ) ^ conj s
+      = ∑' n : ℕ, conj (1 / (n : ℂ) ^ s) := by
+        refine tsum_congr fun n ↦ ?_
+        rw [natCast_cpow_conj, map_div₀, map_one]
+    _ = conj (∑' n : ℕ, 1 / (n : ℂ) ^ s) := (conj_tsum _).symm
+
+private lemma completedRiemannZeta₀_conj_of_one_lt_re {s : ℂ} (hs : 1 < re s) :
+    completedRiemannZeta₀ (conj s) = conj (completedRiemannZeta₀ s) := by
+  have e1 : completedRiemannZeta₀ (conj s)
+      = completedRiemannZeta (conj s) + 1 / conj s + 1 / (1 - conj s) := by
+    rw [completedRiemannZeta_eq (conj s)]; ring
+  have e2 : conj (completedRiemannZeta₀ s)
+      = conj (completedRiemannZeta s + 1 / s + 1 / (1 - s)) := by
+    congr 1
+    rw [completedRiemannZeta_eq s]; ring
+  rw [e1, completedRiemannZeta_conj_of_one_lt_re hs, e2]
+  simp only [map_add, map_sub, map_div₀, map_one]
+
+/-- The entire completed Riemann zeta function `Λ₀` commutes with complex conjugation. -/
+@[simp]
+theorem completedRiemannZeta₀_conj (s : ℂ) :
+    completedRiemannZeta₀ (conj s) = conj (completedRiemannZeta₀ s) := by
+  have hg_diff : Differentiable ℂ (conj ∘ completedRiemannZeta₀ ∘ (conj : ℂ → ℂ)) := fun z ↦ by
+    have h := (differentiable_completedZeta₀ (conj z)).conj_conj
+    rwa [Complex.conj_conj] at h
+  have heq : completedRiemannZeta₀ = conj ∘ completedRiemannZeta₀ ∘ (conj : ℂ → ℂ) := by
+    refine AnalyticOnNhd.eq_of_eventuallyEq
+      (differentiable_completedZeta₀.differentiableOn.analyticOnNhd isOpen_univ)
+      (hg_diff.differentiableOn.analyticOnNhd isOpen_univ) (z₀ := 2) ?_
+    have hopen : IsOpen {z : ℂ | 1 < re z} := isOpen_lt continuous_const continuous_re
+    have h2 : (2 : ℂ) ∈ {z : ℂ | 1 < re z} := by norm_num
+    filter_upwards [hopen.mem_nhds h2] with z hz
+    simp only [Function.comp_apply]
+    rw [completedRiemannZeta₀_conj_of_one_lt_re hz, Complex.conj_conj]
+  have h := congrArg conj (congrFun heq s)
+  simpa only [Function.comp_apply, Complex.conj_conj] using h.symm
+
+/-- The completed Riemann zeta function `Λ` commutes with complex conjugation. -/
+@[simp]
+theorem completedRiemannZeta_conj (s : ℂ) :
+    completedRiemannZeta (conj s) = conj (completedRiemannZeta s) := by
+  simp only [completedRiemannZeta_eq, completedRiemannZeta₀_conj, map_sub, map_div₀, map_one]


### PR DESCRIPTION
Adds conjugation symmetry for the completed Riemann zeta functions and for Deligne's archimedean
Gamma factor:

* `Complex.Gammaℝ_conj : Gammaℝ (conj s) = conj (Gammaℝ s)`
  (`Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean`)
* `completedRiemannZeta₀_conj : completedRiemannZeta₀ (conj s) = conj (completedRiemannZeta₀ s)`
* `completedRiemannZeta_conj : completedRiemannZeta (conj s) = conj (completedRiemannZeta s)`
  (both in `Mathlib/NumberTheory/LSeries/RiemannZeta.lean`)

All three hold for **every** `s : ℂ`, with no points excluded — in particular no exclusion of the
poles `s = 0, 1` of `Λ`, since `Λ` is built from the entire function `Λ₀` by subtracting
`1 / s + 1 / (1 - s)` and Mathlib's `1 / 0 = 0` convention makes both sides agree there. They are
tagged `@[simp]`, matching the existing `riemannZeta_conj`.

### Why

Conjugation symmetry is a basic structural fact about `ζ` that Mathlib already has
(`riemannZeta_conj`, in `Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean`), but the corresponding
statements for the completed functions `Λ`, `Λ₀` and for `Gammaℝ` were missing. The `Λ` version is
the one actually needed for work on the critical line: combined with the functional equation
`completedRiemannZeta_one_sub` it gives `conj (Λ ⟨1/2, t⟩) = Λ ⟨1/2, t⟩`, i.e. the Riemann
Ξ-function is real-valued on the critical line. It is also the natural form for completed
L-function arguments generally, where `Λ` rather than `ζ` is the object with the clean symmetry.

Note the `Λ` statements do **not** follow formally from `riemannZeta_conj`: the bridge
`riemannZeta_def_of_ne_zero` reads `ζ s = Λ s / Gammaℝ s`, and `Gammaℝ` vanishes at the trivial
zeros, so it cannot be inverted. The proof here instead runs the identity principle directly on the
entire function `Λ₀`.

### Proof

On the halfplane `1 < re s` the Dirichlet-series representation
`completedZeta_eq_tsum_of_one_lt_re` conjugates termwise (real coefficients), giving the result for
`Λ` and hence for `Λ₀` via `completedRiemannZeta_eq`. Since `Λ₀` is entire
(`differentiable_completedZeta₀`) and `conj ∘ Λ₀ ∘ conj` is entire by
`DifferentiableAt.conj_conj`, `AnalyticOnNhd.eq_of_eventuallyEq` propagates the identity from a
neighbourhood of `2` to all of `ℂ`. Transferring back through `completedRiemannZeta_eq` — which is
unconditional — yields `completedRiemannZeta_conj` with no side conditions.

### Drive-by

`riemannZeta_conj` in `Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean` is golfed from ~25 lines to 4
by deriving it from `completedRiemannZeta_conj` and `Gammaℝ_conj` (statement, name and `@[simp]`
attribute unchanged); its two now-unused private imports are dropped. It no longer depends on
anything in `ZetaAsymp`, so it could reasonably be relocated to `RiemannZeta.lean` alongside the new
lemmas — happy to do that in this PR if reviewers prefer.

`Mathlib/NumberTheory/LSeries/RiemannZeta.lean` gains one import,
`Mathlib.Analysis.Calculus.Deriv.Star` (2 extra modules in the transitive closure).

### Checks

Built locally against master (`v4.33.0-rc1`): full `lake build Mathlib` completes with zero errors
and zero warnings; `lake exe lint-style` is clean on all three touched files. No `sorry`, no new
axioms.

Parts of this contribution were developed with AI assistance (Claude). All statements are machine-checked by the Lean kernel; `#print axioms` on the new declarations reports only `[propext, Classical.choice, Quot.sound]`.

This PR is standalone and independent of my other open PRs (#42093, #42095, #42100).
