### PR TITLE
[Merged by Bors] - feat(FreeGroup): `toWord` of multiplication by generators

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -598,6 +598,10 @@ theorem idxOf_getLast {l : List α} (hl : l ≠ []) (hl' : l.getLast hl ∉ l.dr
     contrapose hl'
     rwa [mem_dropLast_iff_idxOf_lt <| getLast_mem hl, ← Nat.not_le]
 
+theorem idxOf_tail_of_head_ne {a : α} (hl : l ≠ []) (ha : l.head hl ≠ a) :
+    l.tail.idxOf a = (l.idxOf a) - 1 := by
+  induction l <;> grind
+
 end IndexOf
 
 /-! ### nth element -/

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -599,8 +599,8 @@ theorem idxOf_getLast {l : List α} (hl : l ≠ []) (hl' : l.getLast hl ∉ l.dr
     rwa [mem_dropLast_iff_idxOf_lt <| getLast_mem hl, ← Nat.not_le]
 
 theorem idxOf_tail_of_head_ne {a : α} (hl : l ≠ []) (ha : l.head hl ≠ a) :
-    l.tail.idxOf a = (l.idxOf a) - 1 := by
-  induction l <;> grind
+    l.tail.idxOf a = l.idxOf a - 1 := by
+  induction l <;> simp_all
 
 end IndexOf
 

--- a/Mathlib/GroupTheory/FreeGroup/Reduce.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Reduce.lean
@@ -341,6 +341,64 @@ theorem isReduced_iff_reduce_eq : IsReduced L ↔ reduce L = L where
 theorem isReduced_toWord {x : FreeGroup α} : IsReduced x.toWord := by
   simp [isReduced_iff_reduce_eq]
 
+@[to_additive]
+theorem toWord_of_mul_eq (a : α) (x : FreeGroup α) :
+    (of a * x).toWord =
+      if x.toWord.head? = some ⟨a, false⟩ then x.toWord.tail else ⟨a, true⟩ :: x.toWord := by
+  simp [toWord_mul]
+  cases x.toWord
+  · simp
+  · grind
+
+@[to_additive]
+theorem toWord_inv_of_mul_eq (a : α) (x : FreeGroup α) :
+    ((of a)⁻¹ * x).toWord =
+      if x.toWord.head? = some ⟨a, true⟩ then x.toWord.tail else ⟨a, false⟩ :: x.toWord := by
+  simp [toWord_mul, invRev]
+  cases x.toWord
+  · simp
+  · grind [invRev]
+
+@[to_additive]
+theorem toWord_mul_of_eq (a : α) (x : FreeGroup α) :
+    (x * of a).toWord =
+      if x.toWord.getLast? = some ⟨a, false⟩ then x.toWord.dropLast
+      else x.toWord.concat ⟨a, true⟩ := by
+  rw [show x * of a = ((of a)⁻¹ * x⁻¹)⁻¹ by simp, toWord_inv, toWord_inv_of_mul_eq]
+  ext
+  simp [invRev]
+  split_ifs <;> simp <;> grind
+
+@[to_additive]
+theorem toWord_mul_of_inv_eq (a : α) (x : FreeGroup α) :
+    (x * (of a)⁻¹).toWord =
+      if x.toWord.getLast? = some ⟨a, true⟩ then x.toWord.dropLast
+      else x.toWord.concat ⟨a, false⟩ := by
+  rw [show x * (of a)⁻¹ = (of a * x⁻¹)⁻¹ by simp, toWord_inv, toWord_of_mul_eq]
+  ext
+  simp [invRev]
+  split_ifs <;> simp <;> grind
+
+@[to_additive]
+theorem idxOf_toWord_of_mul_eq {a : α} (x : FreeGroup α) {b : α × Bool} (hb₁ : b.1 ≠ a) :
+    (of a * x).toWord.idxOf b =
+      if x.toWord.head? = some (a, false) then x.toWord.idxOf b - 1 else x.toWord.idxOf b + 1 := by
+  rw [toWord_of_mul_eq]
+  split_ifs with h
+  · have : x.toWord ≠ [] := by grind
+    rw [List.head?_eq_some_head this, Option.some.injEq] at h
+    exact List.idxOf_tail_of_head_ne this (by simp [h, Prod.eq_iff_fst_eq_snd_eq, hb₁.symm])
+  · grind
+
+@[to_additive]
+theorem idxOf_toWord_mul_of_eq {a : α} (x : FreeGroup α) {b : α × Bool} (hb₁ : b.1 ≠ a)
+    (hb₂ : b ∈ x.toWord) : (x * of a).toWord.idxOf b = x.toWord.idxOf b := by
+  rw [toWord_mul_of_eq]
+  split_ifs
+  · refine List.IsPrefix.idxOf_eq_of_mem (List.dropLast_prefix _) ?_
+    exact List.mem_dropLast_of_mem_of_ne_getLast? hb₂ (by grind)
+  · grind
+
 end Reduce
 
 @[to_additive (attr := simp)]

--- a/Mathlib/GroupTheory/FreeGroup/Reduce.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Reduce.lean
@@ -342,48 +342,29 @@ theorem isReduced_toWord {x : FreeGroup α} : IsReduced x.toWord := by
   simp [isReduced_iff_reduce_eq]
 
 @[to_additive]
-theorem toWord_of_mul_eq (a : α) (x : FreeGroup α) :
-    (of a * x).toWord =
-      if x.toWord.head? = some ⟨a, false⟩ then x.toWord.tail else ⟨a, true⟩ :: x.toWord := by
+theorem toWord_mk_mul_eq (a : α) (b : Bool) (x : FreeGroup α) :
+    (mk [⟨a, b⟩] * x).toWord =
+      if x.toWord.head? = some ⟨a, !b⟩ then x.toWord.tail else ⟨a, b⟩ :: x.toWord := by
   simp [toWord_mul]
   cases x.toWord
   · simp
-  · grind
+  · simp [Prod.eq_iff_fst_eq_snd_eq]
+    grind
 
 @[to_additive]
-theorem toWord_inv_of_mul_eq (a : α) (x : FreeGroup α) :
-    ((of a)⁻¹ * x).toWord =
-      if x.toWord.head? = some ⟨a, true⟩ then x.toWord.tail else ⟨a, false⟩ :: x.toWord := by
-  simp [toWord_mul, invRev]
-  cases x.toWord
-  · simp
-  · grind [invRev]
-
-@[to_additive]
-theorem toWord_mul_of_eq (a : α) (x : FreeGroup α) :
-    (x * of a).toWord =
-      if x.toWord.getLast? = some ⟨a, false⟩ then x.toWord.dropLast
-      else x.toWord.concat ⟨a, true⟩ := by
-  rw [show x * of a = ((of a)⁻¹ * x⁻¹)⁻¹ by simp, toWord_inv, toWord_inv_of_mul_eq]
+theorem toWord_mul_mk_eq (a : α) (b : Bool) (x : FreeGroup α) :
+    (x * mk [⟨a, b⟩]).toWord =
+      if x.toWord.getLast? = some ⟨a, !b⟩ then x.toWord.dropLast else x.toWord.concat ⟨a, b⟩ := by
   ext
-  simp [invRev]
-  split_ifs <;> simp <;> grind
-
-@[to_additive]
-theorem toWord_mul_of_inv_eq (a : α) (x : FreeGroup α) :
-    (x * (of a)⁻¹).toWord =
-      if x.toWord.getLast? = some ⟨a, true⟩ then x.toWord.dropLast
-      else x.toWord.concat ⟨a, false⟩ := by
-  rw [show x * (of a)⁻¹ = (of a * x⁻¹)⁻¹ by simp, toWord_inv, toWord_of_mul_eq]
-  ext
-  simp [invRev]
+  rw [show x * mk [⟨a, b⟩] = ((mk [⟨a, b⟩])⁻¹ * x⁻¹)⁻¹ by simp, toWord_inv]
+  simp [invRev, toWord_mk_mul_eq]
   split_ifs <;> simp <;> grind
 
 @[to_additive]
 theorem idxOf_toWord_of_mul_eq {a : α} (x : FreeGroup α) {b : α × Bool} (hb₁ : b.1 ≠ a) :
     (of a * x).toWord.idxOf b =
       if x.toWord.head? = some (a, false) then x.toWord.idxOf b - 1 else x.toWord.idxOf b + 1 := by
-  rw [toWord_of_mul_eq]
+  rw [of, toWord_mk_mul_eq, Bool.not_true]
   split_ifs with h
   · have : x.toWord ≠ [] := by grind
     rw [List.head?_eq_some_head this, Option.some.injEq] at h
@@ -393,7 +374,7 @@ theorem idxOf_toWord_of_mul_eq {a : α} (x : FreeGroup α) {b : α × Bool} (hb�
 @[to_additive]
 theorem idxOf_toWord_mul_of_eq {a : α} (x : FreeGroup α) {b : α × Bool} (hb₁ : b.1 ≠ a)
     (hb₂ : b ∈ x.toWord) : (x * of a).toWord.idxOf b = x.toWord.idxOf b := by
-  rw [toWord_mul_of_eq]
+  rw [of, toWord_mul_mk_eq]
   split_ifs
   · refine List.IsPrefix.idxOf_eq_of_mem (List.dropLast_prefix _) ?_
     exact List.mem_dropLast_of_mem_of_ne_getLast? hb₂ (by grind)


### PR DESCRIPTION
Add lemmas unfolding how left-/right- multiplication by a generator behaves on the `toWord` representation of a FreeGroup element, and derive two lemmas about the position of an element inside a multiplied word that are used to derive a contradiction in #42677.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
