### PR TITLE
[Merged by Bors] - feat(FreeGroup): `zpow` lemmas

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -444,6 +444,10 @@ lemma one_div_pow (a : α) (n : ℕ) : (1 / a) ^ n = 1 / a ^ n := by simp only [
 @[to_additive zsmul_zero_sub]
 lemma one_div_zpow (a : α) (n : ℤ) : (1 / a) ^ n = 1 / a ^ n := by simp only [one_div, inv_zpow]
 
+@[to_additive]
+theorem zpow_eq_inv_pow_natAbs (a : α) {n : ℤ} (hn : n ≤ 0) : a ^ n = a⁻¹ ^ n.natAbs := by
+  rw [← zpow_natCast, inv_zpow', Int.ofNat_natAbs_of_nonpos hn, Int.neg_neg]
+
 variable {a b c}
 
 @[to_additive (attr := simp)]

--- a/Mathlib/GroupTheory/FreeGroup/Reduce.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Reduce.lean
@@ -252,6 +252,29 @@ theorem toWord_inv (x : FreeGroup α) : x⁻¹.toWord = invRev x.toWord := by
   rcases x with ⟨L⟩
   rw [quot_mk_eq_mk, inv_mk, toWord_mk, toWord_mk, reduce_invRev]
 
+@[to_additive (attr := simp)]
+theorem toWord_of_zpow (a : α) (n : ℤ) :
+    (of a ^ n).toWord = List.replicate n.natAbs (a, decide (0 ≤ n)) := by
+  by_cases! hn : 0 ≤ n
+  · lift n to ℕ using hn
+    simp
+  · rw [zpow_eq_inv_pow_natAbs _ (le_of_lt hn)]
+    simp [FreeGroup.invRev, hn]
+
+omit [DecidableEq α] in
+@[to_additive]
+theorem eq_of_of_zpow_eq_of_zpow {a b : α} (hab : a ≠ b) {n m : ℤ} (h : of a ^ n = of b ^ m) :
+    n = 0 ∧ m = 0 := by
+  classical
+  simp [← toWord_inj, hab, toWord_of_zpow] at h
+  lia
+
+omit [DecidableEq α] in
+@[to_additive]
+theorem eq_of_of_pow_eq_of_pow {a b : α} (hab : a ≠ b) {n m : ℕ} (h : of a ^ n = of b ^ m) :
+    n = 0 ∧ m = 0 := by
+  simpa [← Int.natCast_eq_zero] using eq_of_of_zpow_eq_of_zpow hab h
+
 @[to_additive]
 theorem reduce_append_reduce_reduce : reduce (reduce L₁ ++ reduce L₂) = reduce (L₁ ++ L₂) := by
   rw [← toWord_mk (L₁ := L₁ ++ L₂), ← mul_mk, toWord_mul, toWord_mk, toWord_mk]
@@ -393,6 +416,10 @@ theorem norm_mul_le (x y : FreeGroup α) : norm (x * y) ≤ norm x + norm y :=
 @[to_additive (attr := simp)]
 theorem norm_of_pow (a : α) (n : ℕ) : norm (of a ^ n) = n := by
   rw [norm, toWord_of_pow, List.length_replicate]
+
+@[to_additive (attr := simp)]
+theorem norm_of_zpow (a : α) (n : ℤ) : norm (of a ^ n) = n.natAbs := by
+  rw [norm, toWord_of_zpow, List.length_replicate]
 
 @[to_additive]
 theorem norm_surjective [Nonempty α] : Function.Surjective (norm (α := α)) := by

--- a/Mathlib/GroupTheory/FreeGroup/Reduce.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Reduce.lean
@@ -231,11 +231,6 @@ theorem toWord_pow (x : FreeGroup α) (n : ℕ) :
   simp
 
 @[to_additive (attr := simp)]
-theorem toWord_of_pow (a : α) (n : ℕ) : (of a ^ n).toWord = List.replicate n (a, true) := by
-  rw [of, pow_mk, List.flatten_replicate_singleton, toWord]
-  exact reduce_replicate _ _
-
-@[to_additive (attr := simp)]
 theorem toWord_eq_nil_iff {x : FreeGroup α} : x.toWord = [] ↔ x = 1 :=
   toWord_injective.eq_iff' toWord_one
 
@@ -253,6 +248,11 @@ theorem toWord_inv (x : FreeGroup α) : x⁻¹.toWord = invRev x.toWord := by
   rw [quot_mk_eq_mk, inv_mk, toWord_mk, toWord_mk, reduce_invRev]
 
 @[to_additive (attr := simp)]
+theorem toWord_of_pow (a : α) (n : ℕ) : (of a ^ n).toWord = List.replicate n (a, true) := by
+  rw [of, pow_mk, List.flatten_replicate_singleton, toWord]
+  exact reduce_replicate _ _
+
+@[to_additive (attr := simp)]
 theorem toWord_of_zpow (a : α) (n : ℤ) :
     (of a ^ n).toWord = List.replicate n.natAbs (a, decide (0 ≤ n)) := by
   by_cases! hn : 0 ≤ n
@@ -260,20 +260,6 @@ theorem toWord_of_zpow (a : α) (n : ℤ) :
     simp
   · rw [zpow_eq_inv_pow_natAbs _ (le_of_lt hn)]
     simp [FreeGroup.invRev, hn]
-
-omit [DecidableEq α] in
-@[to_additive]
-theorem eq_of_of_zpow_eq_of_zpow {a b : α} (hab : a ≠ b) {n m : ℤ} (h : of a ^ n = of b ^ m) :
-    n = 0 ∧ m = 0 := by
-  classical
-  simp [← toWord_inj, hab, toWord_of_zpow] at h
-  lia
-
-omit [DecidableEq α] in
-@[to_additive]
-theorem eq_of_of_pow_eq_of_pow {a b : α} (hab : a ≠ b) {n m : ℕ} (h : of a ^ n = of b ^ m) :
-    n = 0 ∧ m = 0 := by
-  simpa [← Int.natCast_eq_zero] using eq_of_of_zpow_eq_of_zpow hab h
 
 @[to_additive]
 theorem reduce_append_reduce_reduce : reduce (reduce L₁ ++ reduce L₂) = reduce (L₁ ++ L₂) := by
@@ -365,6 +351,18 @@ theorem isReduced_toWord {x : FreeGroup α} : IsReduced x.toWord := by
   simp [isReduced_iff_reduce_eq]
 
 end Reduce
+
+@[to_additive]
+theorem eq_of_of_zpow_eq_of_zpow {a b : α} (hab : a ≠ b) {n m : ℤ} (h : of a ^ n = of b ^ m) :
+    n = 0 ∧ m = 0 := by
+  classical
+  simp [← toWord_inj, hab] at h
+  lia
+
+@[to_additive]
+theorem eq_of_of_pow_eq_of_pow {a b : α} (hab : a ≠ b) {n m : ℕ} (h : of a ^ n = of b ^ m) :
+    n = 0 ∧ m = 0 := by
+  simpa [← Int.natCast_eq_zero] using eq_of_of_zpow_eq_of_zpow hab h
 
 @[to_additive (attr := simp)]
 theorem one_ne_of (a : α) : 1 ≠ of a :=


### PR DESCRIPTION
We already have some lemmas for working with `Nat`-valued powers of FreeGroup elements, add some matching lemmas for working with `Int`-valued powers.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
