### PR TITLE
[Merged by Bors] - chore(CategoryTheory): make more things implicit reducible

### DIFF
--- a/Mathlib/CategoryTheory/Functor/Category.lean
+++ b/Mathlib/CategoryTheory/Functor/Category.lean
@@ -150,7 +150,7 @@ end NatTrans
 namespace Functor
 
 /-- Flip the arguments of a bifunctor. See also `Currying.lean`. -/
-@[simps (attr := grind =) obj_obj obj_map]
+@[implicit_reducible, simps (attr := grind =) obj_obj obj_map]
 protected def flip (F : C ⥤ D ⥤ E) : D ⥤ C ⥤ E where
   obj k :=
     { obj := fun j => (F.obj j).obj k,
@@ -164,7 +164,7 @@ protected def flip (F : C ⥤ D ⥤ E) : D ⥤ C ⥤ E where
 
 /-- The left unitor, a natural isomorphism `((𝟭 _) ⋙ F) ≅ F`.
 -/
-@[simps]
+@[implicit_reducible, simps]
 def leftUnitor (F : C ⥤ D) :
     𝟭 C ⋙ F ≅ F where
   hom := { app := fun X => 𝟙 (F.obj X) }
@@ -172,7 +172,7 @@ def leftUnitor (F : C ⥤ D) :
 
 /-- The right unitor, a natural isomorphism `(F ⋙ (𝟭 B)) ≅ F`.
 -/
-@[simps]
+@[implicit_reducible, simps]
 def rightUnitor (F : C ⥤ D) :
     F ⋙ 𝟭 D ≅ F where
   hom := { app := fun X => 𝟙 (F.obj X) }
@@ -183,7 +183,7 @@ def rightUnitor (F : C ⥤ D) :
 (In fact, `iso.refl _` will work here, but it tends to make Lean slow later,
 and it's usually best to insert explicit associators.)
 -/
-@[simps]
+@[implicit_reducible, simps]
 def associator (F : C ⥤ D) (G : D ⥤ E) (H : E ⥤ E') :
     (F ⋙ G) ⋙ H ≅ F ⋙ G ⋙ H where
   hom := { app := fun _ => 𝟙 _ }
@@ -196,7 +196,7 @@ end Functor
 
 variable (C D E) in
 /-- The functor `(C ⥤ D ⥤ E) ⥤ D ⥤ C ⥤ E` which flips the variables. -/
-@[simps]
+@[implicit_reducible, simps]
 def flipFunctor : (C ⥤ D ⥤ E) ⥤ D ⥤ C ⥤ E where
   obj F := F.flip
   map {F₁ F₂} φ :=

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -54,6 +54,7 @@ def uncurry : (C ⥤ D ⥤ E) ⥤ C × D ⥤ E where
 
 /-- The object level part of the currying functor. (See `curry` for the functorial version.)
 -/
+@[implicit_reducible]
 def curryObj (F : C × D ⥤ E) : C ⥤ D ⥤ E where
   obj X :=
     { obj := fun Y => F.obj (X, Y)
@@ -68,7 +69,7 @@ def curryObj (F : C × D ⥤ E) : C ⥤ D ⥤ E where
 
 /-- The currying functor, taking a functor `(C × D) ⥤ E` and producing a functor `C ⥤ (D ⥤ E)`.
 -/
-@[simps! obj_obj_obj obj_obj_map obj_map_app map_app_app]
+@[implicit_reducible, simps! obj_obj_obj obj_obj_map obj_map_app map_app_app]
 def curry : (C × D ⥤ E) ⥤ C ⥤ D ⥤ E where
   obj F := curryObj F
   map T :=
@@ -86,7 +87,7 @@ set_option backward.defeqAttrib.useBackward true in
 -- create projection simp lemmas even though this isn't a `{ .. }`.
 /-- The equivalence of functor categories given by currying/uncurrying.
 -/
-@[simps!]
+@[implicit_reducible, simps!]
 def currying : C ⥤ D ⥤ E ≌ C × D ⥤ E where
   functor := uncurry
   inverse := curry
@@ -101,7 +102,7 @@ def currying : C ⥤ D ⥤ E ≌ C × D ⥤ E where
 set_option backward.isDefEq.respectTransparency.types false in
 set_option backward.defeqAttrib.useBackward true in
 /-- The equivalence of functor categories given by flipping. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def flipping : C ⥤ D ⥤ E ≌ D ⥤ C ⥤ E where
   functor := flipFunctor _ _ _
   inverse := flipFunctor _ _ _
@@ -233,7 +234,7 @@ lemma curry_obj_comp_flip (F : C × B ⥤ D) (G : D ⥤ E) :
       (curry.obj F).flip ⋙ (whiskeringRight _ _ _).obj G := rfl
 
 /-- The equivalence of types of bifunctors giving by flipping the arguments. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def flippingEquiv : C ⥤ D ⥤ E ≃ D ⥤ C ⥤ E where
   toFun F := F.flip
   invFun F := F.flip
@@ -241,7 +242,7 @@ def flippingEquiv : C ⥤ D ⥤ E ≃ D ⥤ C ⥤ E where
   right_inv _ := rfl
 
 /-- The equivalence of types of bifunctors given by currying. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E where
   toFun F := uncurry.obj F
   invFun G := curry.obj G
@@ -249,7 +250,7 @@ def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E where
   right_inv := uncurry_obj_curry_obj
 
 /-- The flipped equivalence of types of bifunctors given by currying. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def curryingFlipEquiv : D ⥤ C ⥤ E ≃ C × D ⥤ E :=
   flippingEquiv.trans curryingEquiv
 

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -82,8 +82,6 @@ def curry : (C × D ⥤ E) ⥤ C ⥤ D ⥤ E where
         ext; dsimp [curryObj]
         rw [NatTrans.naturality] }
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 -- create projection simp lemmas even though this isn't a `{ .. }`.
 /-- The equivalence of functor categories given by currying/uncurrying.
 -/
@@ -99,8 +97,6 @@ def currying : C ⥤ D ⥤ E ≌ C × D ⥤ E where
       dsimp at f₁ f₂ ⊢
       simp only [← F.map_comp, prod_comp, Category.comp_id, Category.id_comp]))
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 /-- The equivalence of functor categories given by flipping. -/
 @[implicit_reducible, simps!]
 def flipping : C ⥤ D ⥤ E ≌ D ⥤ C ⥤ E where
@@ -133,8 +129,6 @@ instance : (uncurry : (C ⥤ D ⥤ E) ⥤ C × D ⥤ E).Full :=
 instance : (uncurry : (C ⥤ D ⥤ E) ⥤ C × D ⥤ E).Faithful :=
   fullyFaithfulUncurry.faithful
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 /-- Given functors `F₁ : C ⥤ D`, `F₂ : C' ⥤ D'` and `G : D × D' ⥤ E`, this is the isomorphism
 between `curry.obj ((F₁.prod F₂).comp G)` and
 `F₁ ⋙ curry.obj G ⋙ (whiskeringLeft C' D' E).obj F₂` in the category `C ⥤ C' ⥤ E`. -/
@@ -145,37 +139,29 @@ def curryObjProdComp {C' D' : Type*} [Category* C'] [Category* D']
       F₁ ⋙ curry.obj G ⋙ (whiskeringLeft C' D' E).obj F₂ :=
   NatIso.ofComponents (fun X₁ ↦ NatIso.ofComponents (fun X₂ ↦ Iso.refl _))
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 /-- `F.flip` is isomorphic to uncurrying `F`, swapping the variables, and currying. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def flipIsoCurrySwapUncurry (F : C ⥤ D ⥤ E) : F.flip ≅ curry.obj (Prod.swap _ _ ⋙ uncurry.obj F) :=
   NatIso.ofComponents fun d => NatIso.ofComponents fun _ => Iso.refl _
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The uncurrying of `F.flip` is isomorphic to
 swapping the factors followed by the uncurrying of `F`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def uncurryObjFlip (F : C ⥤ D ⥤ E) : uncurry.obj F.flip ≅ Prod.swap _ _ ⋙ uncurry.obj F :=
   NatIso.ofComponents fun _ => Iso.refl _
 
 variable (B C D E)
 
-#adaptation_note
-/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
-set_option backward.isDefEq.respectTransparency.types false in
 /-- A version of `CategoryTheory.whiskeringRight` for bifunctors, obtained by uncurrying,
 applying `whiskeringRight` and currying back
 -/
-@[simps!]
+@[implicit_reducible, simps!]
 def whiskeringRight₂ : (C ⥤ D ⥤ E) ⥤ (B ⥤ C) ⥤ (B ⥤ D) ⥤ B ⥤ E :=
   uncurry ⋙
     whiskeringRight _ _ _ ⋙ (whiskeringLeft _ _ _).obj (prodFunctorToFunctorProd _ _ _) ⋙ curry
 
 variable {B C D E}
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 lemma uncurry_obj_curry_obj (F : B × C ⥤ D) : uncurry.obj (curry.obj F) = F :=
   Functor.ext (by simp) (fun ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ ⟨f₁, f₂⟩ => by
     dsimp
@@ -185,8 +171,6 @@ lemma curry_obj_injective {F₁ F₂ : C × D ⥤ E} (h : curry.obj F₁ = curry
     F₁ = F₂ := by
   rw [← uncurry_obj_curry_obj F₁, ← uncurry_obj_curry_obj F₂, h]
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 lemma curry_obj_uncurry_obj (F : B ⥤ C ⥤ D) : curry.obj (uncurry.obj F) = F :=
   Functor.ext (fun _ => Functor.ext (by simp) (by simp)) (by cat_disch)
 
@@ -200,16 +184,12 @@ lemma flip_injective {F₁ F₂ : B ⥤ C ⥤ D} (h : F₁.flip = F₂.flip) :
     F₁ = F₂ := by
   rw [← flip_flip F₁, ← flip_flip F₂, h]
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 lemma uncurry_obj_curry_obj_flip_flip (F₁ : B ⥤ C) (F₂ : D ⥤ E) (G : C × E ⥤ H) :
     uncurry.obj (F₂ ⋙ (F₁ ⋙ curry.obj G).flip).flip = (F₁.prod F₂) ⋙ G :=
   Functor.ext (by simp) (fun ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ ⟨f₁, f₂⟩ => by
     dsimp
     simp only [Category.id_comp, Category.comp_id, ← G.map_comp, prod_comp])
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 lemma uncurry_obj_curry_obj_flip_flip' (F₁ : B ⥤ C) (F₂ : D ⥤ E) (G : C × E ⥤ H) :
     uncurry.obj (F₁ ⋙ (F₂ ⋙ (curry.obj G).flip).flip) = (F₁.prod F₂) ⋙ G :=
   Functor.ext (by simp) (fun ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ ⟨f₁, f₂⟩ => by
@@ -217,7 +197,7 @@ lemma uncurry_obj_curry_obj_flip_flip' (F₁ : B ⥤ C) (F₂ : D ⥤ E) (G : C 
     simp only [Category.id_comp, Category.comp_id, ← G.map_comp, prod_comp])
 
 /-- Natural isomorphism witnessing `comp_flip_uncurry_eq`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def compFlipUncurryIso (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
     uncurry.obj (F ⋙ G).flip ≅ (𝟭 C).prod F ⋙ uncurry.obj G.flip := .refl _
 
@@ -225,7 +205,7 @@ lemma comp_flip_uncurry_eq (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
     uncurry.obj (F ⋙ G).flip = (𝟭 C).prod F ⋙ uncurry.obj G.flip := rfl
 
 /-- Natural isomorphism witnessing `comp_flip_curry_eq`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def curryObjCompIso (F : C × B ⥤ D) (G : D ⥤ E) :
     (curry.obj (F ⋙ G)).flip ≅ (curry.obj F).flip ⋙ (whiskeringRight _ _ _).obj G := .refl _
 

--- a/Mathlib/CategoryTheory/Iso.lean
+++ b/Mathlib/CategoryTheory/Iso.lean
@@ -83,7 +83,7 @@ theorem ext ⦃α β : X ≅ Y⦄ (w : α.hom = β.hom) : α = β :=
     _     = β.inv                 := by grind
 
 /-- Inverse isomorphism. -/
-@[symm]
+@[symm, implicit_reducible]
 def symm (I : X ≅ Y) : Y ≅ X where
   hom := I.inv
   inv := I.hom
@@ -112,7 +112,7 @@ theorem nonempty_iso_symm (X Y : C) : Nonempty (X ≅ Y) ↔ Nonempty (Y ≅ X) 
   ⟨fun h => ⟨h.some.symm⟩, fun h => ⟨h.some.symm⟩⟩
 
 /-- Identity isomorphism. -/
-@[refl, simps (attr := grind =)]
+@[refl, simps (attr := grind =), implicit_reducible]
 def refl (X : C) : X ≅ X where
   hom := 𝟙 X
   inv := 𝟙 X
@@ -127,7 +127,7 @@ theorem nonempty_iso_refl (X : C) : Nonempty (X ≅ X) := ⟨default⟩
 theorem refl_symm (X : C) : (Iso.refl X).symm = Iso.refl X := rfl
 
 /-- Composition of two isomorphisms -/
-@[simps (attr := grind =)]
+@[simps (attr := grind =), implicit_reducible]
 def trans (α : X ≅ Y) (β : Y ≅ Z) : X ≅ Z where
   hom := α.hom ≫ β.hom
   inv := β.inv ≫ α.inv
@@ -219,7 +219,7 @@ theorem hom_eq_inv (α : X ≅ Y) (β : Y ≅ X) : α.hom = β.inv ↔ β.hom = 
 attribute [local grind] Function.LeftInverse Function.RightInverse
 
 /-- The bijection `(Z ⟶ X) ≃ (Z ⟶ Y)` induced by `α : X ≅ Y`. -/
-@[to_dual (attr := simps) homFromEquiv
+@[implicit_reducible, to_dual (attr := simps) homFromEquiv
 /-- The bijection `(X ⟶ Z) ≃ (Y ⟶ Z)` induced by `α : X ≅ Y`. -/]
 def homToEquiv (α : X ≅ Y) {Z : C} : (Z ⟶ X) ≃ (Z ⟶ Y) where
   toFun f := f ≫ α.hom
@@ -469,7 +469,7 @@ variable {D : Type u₂}
 variable [Category.{v₂} D]
 
 /-- A functor `F : C ⥤ D` sends isomorphisms `i : X ≅ Y` to isomorphisms `F.obj X ≅ F.obj Y` -/
-@[simps]
+@[simps, implicit_reducible]
 def mapIso (F : C ⥤ D) {X Y : C} (i : X ≅ Y) : F.obj X ≅ F.obj Y where
   hom := F.map i.hom
   inv := F.map i.inv

--- a/Mathlib/CategoryTheory/NatIso.lean
+++ b/Mathlib/CategoryTheory/NatIso.lean
@@ -176,7 +176,7 @@ set_option linter.translate.warnInvalid false in
 /-- Construct a natural isomorphism between functors by giving object level isomorphisms,
 and checking naturality only in the forward direction.
 -/
-@[to_dual (attr := simps (attr := grind =)) ofComponents'
+@[implicit_reducible, to_dual (attr := simps (attr := grind =)) ofComponents'
 /-- The dual of `ofComponents` -/]
 def ofComponents (app : ∀ X : C, F.obj X ≅ G.obj X)
     (naturality : ∀ {X Y : C} (f : X ⟶ Y),

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -171,36 +171,34 @@ def sectR {C : Type u₁} [Category.{v₁} C] (Z : C) (D : Type u₂) [Category.
 variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 
 /-- `fst` is the functor `(X, Y) ↦ X`. -/
-@[simps]
+@[implicit_reducible, simps]
 def fst : C × D ⥤ C where
   obj X := X.1
   map f := f.1
 
 /-- `snd` is the functor `(X, Y) ↦ Y`. -/
-@[simps]
+@[implicit_reducible, simps]
 def snd : C × D ⥤ D where
   obj X := X.2
   map f := f.2
 
 /-- The functor swapping the factors of a Cartesian product of categories, `C × D ⥤ D × C`. -/
-@[simps]
+@[implicit_reducible, simps]
 def swap : C × D ⥤ D × C where
   obj X := (X.2, X.1)
   map f := f.2 ×ₘ f.1
 
-set_option backward.defeqAttrib.useBackward true in
 /-- Swapping the factors of a Cartesian product of categories twice is naturally isomorphic
 to the identity functor.
 -/
-@[simps]
+@[implicit_reducible, simps]
 def symmetry : swap C D ⋙ swap D C ≅ 𝟭 (C × D) where
   hom := { app := fun X => 𝟙 X }
   inv := { app := fun X => 𝟙 X }
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The equivalence, given by swapping factors, between `C × D` and `D × C`.
 -/
-@[simps]
+@[implicit_reducible, simps]
 def braiding : C × D ≌ D × C where
   functor := swap C D
   inverse := swap D C
@@ -243,16 +241,15 @@ def evaluation : C ⥤ (C ⥤ D) ⥤ D where
 /-- The "evaluation of `F` at `X`" functor,
 as a functor `C × (C ⥤ D) ⥤ D`.
 -/
-@[simps]
+@[implicit_reducible, simps]
 def evaluationUncurried : C × (C ⥤ D) ⥤ D where
   obj p := p.2.obj p.1
   map := fun {x} {y} f => x.2.map f.1 ≫ f.2.app y.1
 
 variable {C}
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The constant functor followed by the evaluation functor is just the identity. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def Functor.constCompEvaluationObj (X : C) : Functor.const C ⋙ (evaluation C D).obj X ≅ 𝟭 D :=
   NatIso.ofComponents fun _ => Iso.refl _
 
@@ -272,20 +269,18 @@ def prod (F : A ⥤ B) (G : C ⥤ D) : A × C ⥤ B × D where
 /- Because of limitations in Lean 3's handling of notations, we do not setup a notation `F × G`.
 You can use `F.prod G` as a "poor man's infix", or just write `functor.prod F G`. -/
 /-- Similar to `prod`, but both functors start from the same category `A` -/
-@[simps]
+@[implicit_reducible, simps]
 def prod' (F : A ⥤ B) (G : A ⥤ C) : A ⥤ B × C where
   obj a := (F.obj a, G.obj a)
   map f := F.map f ×ₘ G.map f
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The product `F.prod' G` followed by projection on the first component is isomorphic to `F` -/
-@[simps!]
+@[implicit_reducible, simps!]
 def prod'CompFst (F : A ⥤ B) (G : A ⥤ C) : F.prod' G ⋙ CategoryTheory.Prod.fst B C ≅ F :=
   NatIso.ofComponents fun _ => Iso.refl _
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The product `F.prod' G` followed by projection on the second component is isomorphic to `G` -/
-@[simps!]
+@[implicit_reducible, simps!]
 def prod'CompSnd (F : A ⥤ B) (G : A ⥤ C) : F.prod' G ⋙ CategoryTheory.Prod.snd B C ≅ G :=
   NatIso.ofComponents fun _ => Iso.refl _
 
@@ -294,7 +289,7 @@ section
 variable (C)
 
 /-- The diagonal functor. -/
-@[simps! obj map]
+@[implicit_reducible, simps! obj map]
 def diag : C ⥤ C × C :=
   (𝟭 C).prod' (𝟭 C)
 
@@ -304,36 +299,32 @@ end Functor
 
 namespace NatTrans
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The Cartesian product of two natural transformations. -/
-@[simps! app_fst app_snd]
+@[implicit_reducible, simps! app_fst app_snd]
 def prod {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) : F.prod H ⟶ G.prod I where
   app X := α.app X.1 ×ₘ β.app X.2
 
 /- Again, it is inadvisable in Lean 3 to setup a notation `α × β`;
 use instead `α.prod β` or `NatTrans.prod α β`. -/
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The Cartesian product of two natural transformations where both functors have the
 same source. -/
-@[simps! app_fst app_snd]
+@[implicit_reducible, simps! app_fst app_snd]
 def prod' {F G : A ⥤ B} {H K : A ⥤ C} (α : F ⟶ G) (β : H ⟶ K) : F.prod' H ⟶ G.prod' K where
   app X := α.app X ×ₘ β.app X
 
 end NatTrans
 
 /-- The Cartesian product functor between functor categories -/
-@[simps]
+@[implicit_reducible, simps]
 def prodFunctor : (A ⥤ B) × (C ⥤ D) ⥤ A × C ⥤ B × D where
   obj FG := FG.1.prod FG.2
   map nm := NatTrans.prod nm.1 nm.2
 
 namespace NatIso
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 /-- The Cartesian product of two natural isomorphisms. -/
-@[simps]
+@[implicit_reducible, simps]
 def prod {F F' : A ⥤ B} {G G' : C ⥤ D} (e₁ : F ≅ F') (e₂ : G ≅ G') :
     F.prod G ≅ F'.prod G' where
   hom := NatTrans.prod e₁.hom e₂.hom
@@ -343,10 +334,8 @@ end NatIso
 
 namespace Equivalence
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 /-- The Cartesian product of two equivalences of categories. -/
-@[simps]
+@[implicit_reducible, simps]
 def prod (E₁ : A ≌ B) (E₂ : C ≌ D) : A × C ≌ B × D where
   functor := E₁.functor.prod E₂.functor
   inverse := E₁.inverse.prod E₂.inverse
@@ -355,18 +344,16 @@ def prod (E₁ : A ≌ B) (E₂ : C ≌ D) : A × C ≌ B × D where
 
 end Equivalence
 
-set_option backward.defeqAttrib.useBackward true in
 /-- `F.flip` composed with evaluation is the same as evaluating `F`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def flipCompEvaluation (F : A ⥤ B ⥤ C) (a) : F.flip ⋙ (evaluation _ _).obj a ≅ F.obj a :=
   NatIso.ofComponents fun b => Iso.refl _
 
 theorem flip_comp_evaluation (F : A ⥤ B ⥤ C) (a) : F.flip ⋙ (evaluation _ _).obj a = F.obj a :=
   rfl
 
-set_option backward.defeqAttrib.useBackward true in
 /-- `F` composed with evaluation is the same as evaluating `F.flip`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def compEvaluation (F : A ⥤ B ⥤ C) (b) : F ⋙ (evaluation _ _).obj b ≅ F.flip.obj b :=
   NatIso.ofComponents fun a => Iso.refl _
 
@@ -374,7 +361,7 @@ theorem comp_evaluation (F : A ⥤ B ⥤ C) (b) : F ⋙ (evaluation _ _).obj b =
   rfl
 
 /-- Whiskering by `F` and then evaluating at `a` is the same as evaluating at `F.obj a`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def whiskeringLeftCompEvaluation (F : A ⥤ B) (a : A) :
     (whiskeringLeft A B C).obj F ⋙ (evaluation A C).obj a ≅ (evaluation B C).obj (F.obj a) :=
   Iso.refl _
@@ -387,7 +374,7 @@ theorem whiskeringLeft_comp_evaluation (F : A ⥤ B) (a : A) :
 
 /-- Whiskering by `F` and then evaluating at `a` is the same as evaluating at `F` and then
 applying `F`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def whiskeringRightCompEvaluation (F : B ⥤ C) (a : A) :
     (whiskeringRight A B C).obj F ⋙ (evaluation _ _).obj a ≅ (evaluation _ _).obj a ⋙ F :=
   Iso.refl _
@@ -402,39 +389,33 @@ theorem whiskeringRight_comp_evaluation (F : B ⥤ C) (a : A) :
 variable (A B C)
 
 /-- The forward direction for `functorProdFunctorEquiv` -/
-@[simps]
+@[implicit_reducible, simps]
 def prodFunctorToFunctorProd : (A ⥤ B) × (A ⥤ C) ⥤ A ⥤ B × C where
   obj F := F.1.prod' F.2
   map {F G} f := NatTrans.prod' f.1 f.2
 
 /-- The backward direction for `functorProdFunctorEquiv` -/
-@[simps]
+@[implicit_reducible, simps]
 def functorProdToProdFunctor : (A ⥤ B × C) ⥤ (A ⥤ B) × (A ⥤ C) where
   obj F := ⟨F ⋙ CategoryTheory.Prod.fst B C, F ⋙ CategoryTheory.Prod.snd B C⟩
   map α := whiskerRight α _ ×ₘ whiskerRight α _
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 /-- The unit isomorphism for `functorProdFunctorEquiv` -/
-@[simps!]
+@[implicit_reducible, simps!]
 def functorProdFunctorEquivUnitIso :
     𝟭 _ ≅ prodFunctorToFunctorProd A B C ⋙ functorProdToProdFunctor A B C :=
   NatIso.ofComponents (fun F =>
     Functor.prod'CompFst F.fst F.snd |>.prod (Functor.prod'CompSnd F.fst F.snd) |>.trans
       (prod.etaIso F) |>.symm)
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 /-- The counit isomorphism for `functorProdFunctorEquiv` -/
-@[simps!]
+@[implicit_reducible, simps!]
 def functorProdFunctorEquivCounitIso :
     functorProdToProdFunctor A B C ⋙ prodFunctorToFunctorProd A B C ≅ 𝟭 _ :=
   NatIso.ofComponents fun F => NatIso.ofComponents fun X => prod.etaIso (F.obj X)
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 /-- The equivalence of categories between `(A ⥤ B) × (A ⥤ C)` and `A ⥤ (B × C)` -/
-@[simps]
+@[implicit_reducible, simps]
 def functorProdFunctorEquiv : (A ⥤ B) × (A ⥤ C) ≌ A ⥤ B × C :=
   { functor := prodFunctorToFunctorProd A B C,
     inverse := functorProdToProdFunctor A B C,
@@ -446,7 +427,7 @@ section Opposite
 open Opposite
 
 /-- The equivalence between the opposite of a product and the product of the opposites. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def prodOpEquiv : (C × D)ᵒᵖ ≌ Cᵒᵖ × Dᵒᵖ where
   functor :=
     { obj := fun X ↦ ⟨op X.unop.1, op X.unop.2⟩,

--- a/Mathlib/CategoryTheory/ShrinkYoneda.lean
+++ b/Mathlib/CategoryTheory/ShrinkYoneda.lean
@@ -36,16 +36,15 @@ protected abbrev Small (F : C ⥤ Type w') := ∀ (X : C), _root_.Small.{w} (F.o
 
 /-- If a functor `F : C ⥤ Type w'` is `w`-small, this is the functor `C ⥤ Type w`
 obtained by shrinking `F.obj X` for all `X : C`. -/
-@[simps obj map, pp_with_univ]
+@[implicit_reducible, simps obj map, pp_with_univ]
 noncomputable def shrink (F : C ⥤ Type w') [FunctorToTypes.Small.{w} F] :
     C ⥤ Type w where
   obj X := Shrink.{w} (F.obj X)
   map f := ↾(equivShrink.{w} _ ∘ F.map f ∘ (equivShrink.{w} _).symm)
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The natural transformation `shrink.{w} F ⟶ shrink.{w} G` induces by a natural
 transformation `τ : F ⟶ G` between `w`-small functors to types. -/
-@[simps]
+@[implicit_reducible, simps]
 noncomputable def shrinkMap {F G : C ⥤ Type w'} (τ : F ⟶ G) [FunctorToTypes.Small.{w} F]
     [FunctorToTypes.Small.{w} G] :
     shrink.{w} F ⟶ shrink.{w} G where
@@ -75,7 +74,6 @@ set_option backward.defeqAttrib.useBackward true in
 instance (X : C) : FunctorToTypes.Small.{w} (yoneda.obj X) :=
   fun _ ↦ by dsimp; infer_instance
 
-set_option backward.isDefEq.respectTransparency.types false in
 /-- The Yoneda embedding `C ⥤ Cᵒᵖ ⥤ Type w` for a locally `w`-small category `C`. -/
 @[simps -isSimp obj map, pp_with_univ]
 noncomputable def shrinkYoneda :
@@ -385,7 +383,8 @@ noncomputable def fullyFaithfulShrinkCoyoneda :
   map_preimage f := by
     obtain ⟨f, rfl⟩ := shrinkCoyonedaEquiv.symm.surjective f
     cat_disch
-  preimage_map f := by simp [shrinkCoyonedaEquiv_shrinkCoyoneda_map]
+  preimage_map f := by
+    simp [shrinkCoyonedaEquiv_shrinkCoyoneda_map f]
 
 instance : (shrinkCoyoneda.{w} (C := C)).Faithful := (fullyFaithfulShrinkCoyoneda C).faithful
 

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -39,7 +39,7 @@ universe w v v₁ v₂ u₁ u₂
 variable {C : Type u₁} [Category.{v₁} C]
 
 /-- The Yoneda embedding, as a functor from `C` into presheaves on `C`. -/
-@[simps obj_obj obj_map map_app, stacks 001O]
+@[implicit_reducible, simps obj_obj obj_map map_app, stacks 001O]
 def yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁ where
   obj X :=
     { obj Y := (unop Y) ⟶ X
@@ -720,6 +720,7 @@ variable {C}
 /-- We have a type-level equivalence between natural transformations from the yoneda embedding
 and elements of `F.obj X`, without any universe switching.
 -/
+@[implicit_reducible]
 def yonedaEquiv {X : C} {F : Cᵒᵖ ⥤ Type v₁} : (yoneda.obj X ⟶ F) ≃ F.obj (op X) where
   toFun η := η.app (op X) (𝟙 X)
   invFun ξ := { app _ := ↾fun f ↦ F.map f.op ξ }
@@ -739,7 +740,7 @@ theorem yonedaEquiv_symm_app {X : C} {F : Cᵒᵖ ⥤ Type v₁} (x : F.obj (op 
   rfl
 
 theorem yonedaEquiv_symm_app_apply {X : C} {F : Cᵒᵖ ⥤ Type v₁} (x : F.obj (op X)) (Y : Cᵒᵖ)
-    (f : Y.unop ⟶ X) : (yonedaEquiv.symm x).app Y f = F.map f.op x :=
+    (f : Y.unop ⟶ X) : dsimp% (yonedaEquiv.symm x).app Y f = F.map f.op x :=
   rfl
 
 /-- See also `yonedaEquiv_naturality'` for a more general version. -/
@@ -1000,6 +1001,7 @@ variable {C}
 /-- We have a type-level equivalence between natural transformations from the coyoneda embedding
 and elements of `F.obj X.unop`, without any universe switching.
 -/
+@[implicit_reducible]
 def coyonedaEquiv {X : C} {F : C ⥤ Type v₁} : (coyoneda.obj (op X) ⟶ F) ≃ F.obj X where
   toFun η := η.app X (𝟙 X)
   invFun ξ := { app _ := ↾fun x ↦ F.map x ξ }
@@ -1014,7 +1016,7 @@ theorem coyonedaEquiv_apply {X : C} {F : C ⥤ Type v₁} (f : coyoneda.obj (op 
 
 @[simp]
 theorem coyonedaEquiv_symm_app_apply {X : C} {F : C ⥤ Type v₁} (x : F.obj X) (Y : C)
-    (f : X ⟶ Y) : (coyonedaEquiv.symm x).app Y f = F.map f x :=
+    (f : X ⟶ Y) : dsimp% (coyonedaEquiv.symm x).app Y f = F.map f x :=
   rfl
 
 lemma coyonedaEquiv_naturality {X Y : C} {F : C ⥤ Type v₁} (f : coyoneda.obj (op X) ⟶ F)

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -55,11 +55,11 @@ instance opposite {V} [Quiver V] : Quiver Vᵒᵖ :=
   ⟨fun a b => (unop b ⟶ unop a)ᵒᵖ⟩
 
 /-- The opposite of an arrow in `V`. -/
-@[to_dual self]
+@[implicit_reducible, to_dual self]
 def Hom.op {V} [Quiver V] {X Y : V} (f : X ⟶ Y) : op Y ⟶ op X := ⟨f⟩
 
 /-- Given an arrow in `Vᵒᵖ`, we can take the "unopposite" back in `V`. -/
-@[to_dual self]
+@[implicit_reducible, to_dual self]
 def Hom.unop {V} [Quiver V] {X Y : Vᵒᵖ} (f : X ⟶ Y) : unop Y ⟶ unop X := Opposite.unop f
 
 /-- The bijection `(X ⟶ Y) ≃ (op Y ⟶ op X)`. -/

--- a/MathlibTest/CategoryTheory/CheckDsimp.lean
+++ b/MathlibTest/CategoryTheory/CheckDsimp.lean
@@ -1,0 +1,85 @@
+import Mathlib.CategoryTheory.NatIso
+import Mathlib.CategoryTheory.Functor.Currying
+
+/-!
+# Testing the `@[defeq]` attribute on some important equalities in category theory
+
+Category theory in mathlib relies heavily on the `dsimp` tactic to simplify terms
+in dependent position. The `dsimp` tactic makes use of the `@[defeq]` attribute.
+In lean v4.31.0, automatic tagging for this attribute was restricted to theorems that are type-correct
+at `implicit_reducible` transparency.
+An attribute `@[backward_defeq]` was added for theorems that are definitional equalities
+but that do not type-check at `implicit_reducible` transparency.
+
+In practice, this means that many lemma generated `@[simps]` on semi-reducible `def`s
+are not seen by `dsimp`, unless the option `set_option backward.defeqAttrib.useBackward`
+is set to true. This is usually an indicator that the definition needs to be implicit-reducible.
+
+This test file ensures that some of the important "dsimplification" equalities in category
+theory are tagged with `@[defeq]`.
+
+You should feel free to add more here when tagging definitions with `@[implicit_reducible]`.
+-/
+
+/-- Throwaway command for this test: `#ensure_defeq foo` returns an error if
+the declaration `foo` does not have the `@[defeq]` tag (e.g., if it has
+the `@[backward_defeq]` tag instead). -/
+syntax (name := ensureDefeqCmd) "#ensure_defeq " ident : command
+
+open Lean in
+elab_rules : command
+  | `(command| #ensure_defeq $ident:ident) => do
+    let name := ident.getId
+    let env ← getEnv
+    match env.find? name with
+    | ConstantInfo.thmInfo _ =>
+      if defeqAttr.hasTag env name then
+        logInfo m!"`{.ofConstName name}` is tagged with @[defeq]"
+        return ()
+      else if backwardDefeqAttr.hasTag env name then
+        throwError "`{.ofConstName name}` is tagged with @[backward_defeq] instead of @[defeq]!"
+      else
+        throwError "`{.ofConstName name}` is not tagged @[defeq] nor @[backward_defeq]!"
+    | none => throwError "Unknown identifier `{.ofConstName name}`"
+    | _ => throwError "#ensure_defeq can only be run on equality theorems."
+
+-- intentional error to test the command
+/-- error: `CategoryTheory.Category.assoc` is not tagged @[defeq] nor @[backward_defeq]! -/
+#guard_msgs (error) in
+#ensure_defeq CategoryTheory.Category.assoc
+
+/-- info: `CategoryTheory.NatIso.ofComponents_hom_app` is tagged with @[defeq] -/
+#guard_msgs in
+#ensure_defeq CategoryTheory.NatIso.ofComponents_hom_app
+
+/-- info: `CategoryTheory.Iso.trans_hom` is tagged with @[defeq] -/
+#guard_msgs in
+#ensure_defeq CategoryTheory.Iso.trans_hom
+
+/-- info: `CategoryTheory.Functor.comp_map` is tagged with @[defeq] -/
+#guard_msgs in
+#ensure_defeq CategoryTheory.Functor.comp_map
+
+/-- info: `CategoryTheory.Functor.comp_obj` is tagged with @[defeq] -/
+#guard_msgs in
+#ensure_defeq CategoryTheory.Functor.comp_obj
+
+/-- info: `CategoryTheory.Functor.curry_obj_obj_obj` is tagged with @[defeq] -/
+#guard_msgs in
+#ensure_defeq CategoryTheory.Functor.curry_obj_obj_obj
+
+/-- info: `CategoryTheory.Functor.uncurry_obj_obj` is tagged with @[defeq] -/
+#guard_msgs in
+#ensure_defeq CategoryTheory.Functor.uncurry_obj_obj
+
+/-- info: `CategoryTheory.Functor.associator_hom_app` is tagged with @[defeq] -/
+#guard_msgs in
+#ensure_defeq CategoryTheory.Functor.associator_hom_app
+
+/-- info: `CategoryTheory.Functor.leftUnitor_hom_app` is tagged with @[defeq] -/
+#guard_msgs in
+#ensure_defeq CategoryTheory.Functor.leftUnitor_hom_app
+
+/-- info: `CategoryTheory.Functor.rightUnitor_hom_app` is tagged with @[defeq] -/
+#guard_msgs in
+#ensure_defeq CategoryTheory.Functor.rightUnitor_hom_app


### PR DESCRIPTION
A test file is added to ensure that certain "dsimplifying" equalites in category theory are tagged with `@[defeq]` instead of `@[backward_defeq]`, so that `dsimp` can use them without `set_option backward.defeqAttrib.useBackward true`.

To turn a `@[backward_defeq]` into a `@[defeq]`, definitions need to be made `implicit_reducible`. Now that `instance_reducible` is split off `implicit_reducible`, it is much safer to tag many declarations. There is still a ton of declarations that should be tagged, and I did not remove all `set_options` after this tagging (this should be an automated process), but we can already clear some.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
