### PR TITLE
feat: add path length for paths in pseudo emetric spaces

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7932,6 +7932,7 @@ public import Mathlib.Topology.EMetricSpace.Diam
 public import Mathlib.Topology.EMetricSpace.Lipschitz
 public import Mathlib.Topology.EMetricSpace.PairReduction
 public import Mathlib.Topology.EMetricSpace.Paracompact
+public import Mathlib.Topology.EMetricSpace.PathLength
 public import Mathlib.Topology.EMetricSpace.Pi
 public import Mathlib.Topology.EMetricSpace.VariationOnFromTo
 public import Mathlib.Topology.EMetricSpace.Weak

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7961,6 +7961,7 @@ public import Mathlib.Topology.DenseEmbedding
 public import Mathlib.Topology.DerivedSet
 public import Mathlib.Topology.DiscreteQuotient
 public import Mathlib.Topology.DiscreteSubset
+public import Mathlib.Topology.EMetricSpace.ArcLength
 public import Mathlib.Topology.EMetricSpace.Basic
 public import Mathlib.Topology.EMetricSpace.BoundedVariation
 public import Mathlib.Topology.EMetricSpace.Defs

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7969,6 +7969,7 @@ public import Mathlib.Topology.EMetricSpace.Lipschitz
 public import Mathlib.Topology.EMetricSpace.MulOpposite
 public import Mathlib.Topology.EMetricSpace.PairReduction
 public import Mathlib.Topology.EMetricSpace.Paracompact
+public import Mathlib.Topology.EMetricSpace.PathLength
 public import Mathlib.Topology.EMetricSpace.Pi
 public import Mathlib.Topology.EMetricSpace.VariationOnFromTo
 public import Mathlib.Topology.EMetricSpace.Weak

--- a/Mathlib/Topology/EMetricSpace/ArcLength.lean
+++ b/Mathlib/Topology/EMetricSpace/ArcLength.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2023 Junyan Xu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junyan Xu, Success Moses, Zhenhua Wu
+-/
+module
+
+public import Mathlib.Topology.EMetricSpace.BoundedVariation
+
+/-!
+# Arc length of curves
+
+This file defines the arc length of a curve in a `WeakPseudoEMetricSpace` as the variation of the
+curve on an interval `Set.Icc a b`, and develops a basic API for this definition.
+
+## Main declarations
+
+* `arcLength`: the arc length of a curve (image of a linear order) on a closed interval.
+* `arcLength_eq_zero_of_le`: arc length vanishes on a reversed interval.
+* `arcLength_self`: arc length vanishes on a degenerate interval.
+* `edist_le_arcLength`: the endpoint distance is bounded above by the arc length.
+* `arcLength_add`: arc length is additive on adjacent intervals.
+* `arcLength_sum`: the arc lengths along a monotone subdivision sum to the whole arc length.
+* `arcLength_comp_eq_of_monotoneOn`: arc length is preserved by monotone reparametrizations.
+* `arcLength_comp_eq_of_antitoneOn`: arc length is preserved by antitone reparametrizations.
+-/
+
+open scoped ENNReal
+open Set
+
+@[expose] public noncomputable section
+
+variable {α E : Type*} [LinearOrder α] [TopologicalSpace E] [WeakPseudoEMetricSpace E]
+  (f : α → E) {a b c : α}
+
+/-- The arc length of `f` on `[a, b]` is the variation of `f` on the interval `Set.Icc a b`.
+This quantity is zero when `b ≤ a`. -/
+noncomputable def arcLength (a b : α) : ℝ≥0∞ :=
+  eVariationOn f (Set.Icc a b)
+
+/-- The arc length on `[a, b]` vanishes when `b ≤ a`. -/
+theorem arcLength_eq_zero_of_le (hba : b ≤ a) : arcLength f a b = 0 :=
+  eVariationOn.subsingleton f <| by simp [hba]
+
+/-- The arc length on the degenerate interval `[a, a]` is zero. -/
+theorem arcLength_self (a : α) : arcLength f a a = 0 := arcLength_eq_zero_of_le _ le_rfl
+
+/-- The endpoint distance on `[a, b]` is bounded above by the arc length. -/
+theorem edist_le_arcLength (hab : a ≤ b) : edist (f a) (f b) ≤ arcLength f a b := by
+  refine eVariationOn.edist_le f ?_ ?_ <;> simp [hab]
+
+/-- Arc length is additive on adjacent intervals. -/
+theorem arcLength_add (hab : a ≤ b) (hbc : b ≤ c) :
+    arcLength f a b + arcLength f b c = arcLength f a c := by
+  simp_rw [arcLength]
+  convert eVariationOn.Icc_add_Icc f (s := Set.univ) hab hbc (by simp) <;> simp
+
+/-- The arc length along a monotone finite subdivision equals the arc length of the whole
+interval. -/
+theorem arcLength_sum {n : ℕ} {u : ℕ → α} (hu : Monotone u) :
+    ∑ i ∈ Finset.range n, arcLength f (u i) (u (i + 1)) = arcLength f (u 0) (u n) := by
+  induction n with
+  | zero => rw [arcLength_self, Finset.sum_range_zero]
+  | succ k ih =>
+      rw [Finset.sum_range_succ, ih, arcLength_add f (hu (Nat.zero_le k)) (hu (Nat.le_succ k))]
+
+/-- Arc length is preserved by a monotone reparametrization whose image is exactly the target
+interval. -/
+theorem arcLength_comp_eq_of_monotoneOn {β : Type*} [LinearOrder β] {a b : β} (g : β → α)
+    (hg : MonotoneOn g (Set.Icc a b)) (himage : g '' Set.Icc a b = Set.Icc (g a) (g b)) :
+    arcLength (f ∘ g) a b = arcLength f (g a) (g b) := by
+  rw [arcLength, arcLength, eVariationOn.comp_eq_of_monotoneOn _ _ hg, himage]
+
+/-- Arc length is preserved by an antitone reparametrization whose image is exactly the target
+interval, with reversed endpoints. -/
+theorem arcLength_comp_eq_of_antitoneOn {β : Type*} [LinearOrder β] {a b : β} (g : β → α)
+    (hg : AntitoneOn g (Set.Icc a b)) (himage : g '' Set.Icc a b = Set.Icc (g b) (g a)) :
+    arcLength (f ∘ g) a b = arcLength f (g b) (g a) := by
+  rw [arcLength, arcLength, eVariationOn.comp_eq_of_antitoneOn _ _ hg, himage]
+
+end

--- a/Mathlib/Topology/EMetricSpace/ArcLength.lean
+++ b/Mathlib/Topology/EMetricSpace/ArcLength.lean
@@ -15,11 +15,6 @@ curve on an interval `Set.Icc a b`, and develops a basic API for this definition
 
 ## Main declarations
 
-* `arcLength`: the arc length of a curve (image of a linear order) on a closed interval.
-* `arcLength_eq_zero_of_le`: arc length vanishes on a reversed interval.
-* `arcLength_self`: arc length vanishes on a degenerate interval.
-* `edist_le_arcLength`: the endpoint distance is bounded above by the arc length.
-* `arcLength_add`: arc length is additive on adjacent intervals.
 * `arcLength_sum`: the arc lengths along a monotone subdivision sum to the whole arc length.
 * `arcLength_comp_eq_of_monotoneOn`: arc length is preserved by monotone reparametrizations.
 * `arcLength_comp_eq_of_antitoneOn`: arc length is preserved by antitone reparametrizations.
@@ -36,11 +31,16 @@ variable {α E : Type*} [LinearOrder α] [TopologicalSpace E] [WeakPseudoEMetric
 /-- The arc length of `f` on `[a, b]` is the variation of `f` on the interval `Set.Icc a b`.
 This quantity is zero when `b ≤ a`. -/
 noncomputable def arcLength (a b : α) : ℝ≥0∞ :=
-  eVariationOn f (Set.Icc a b)
+  eVariationOn f (Icc a b)
 
 /-- The arc length on `[a, b]` vanishes when `b ≤ a`. -/
 theorem arcLength_eq_zero_of_le (hba : b ≤ a) : arcLength f a b = 0 :=
   eVariationOn.subsingleton f <| by simp [hba]
+
+/-- The arc length on `[a, b]` vanishes if `f` is constant on this interval. -/
+theorem arcLength_eq_zero_of_constantOn (hf : (f '' Icc a b).Subsingleton) :
+    arcLength f a b = 0 :=
+  eVariationOn.constant_on hf
 
 /-- The arc length on the degenerate interval `[a, a]` is zero. -/
 theorem arcLength_self (a : α) : arcLength f a a = 0 := arcLength_eq_zero_of_le _ le_rfl
@@ -52,8 +52,8 @@ theorem edist_le_arcLength (hab : a ≤ b) : edist (f a) (f b) ≤ arcLength f a
 /-- Arc length is additive on adjacent intervals. -/
 theorem arcLength_add (hab : a ≤ b) (hbc : b ≤ c) :
     arcLength f a b + arcLength f b c = arcLength f a c := by
-  simp_rw [arcLength]
-  convert eVariationOn.Icc_add_Icc f (s := Set.univ) hab hbc (by simp) <;> simp
+  unfold arcLength
+  convert eVariationOn.Icc_add_Icc f (s := univ) hab hbc (mem_univ _) <;> simp
 
 /-- The arc length along a monotone finite subdivision equals the arc length of the whole
 interval. -/
@@ -67,14 +67,14 @@ theorem arcLength_sum {n : ℕ} {u : ℕ → α} (hu : Monotone u) :
 /-- Arc length is preserved by a monotone reparametrization whose image is exactly the target
 interval. -/
 theorem arcLength_comp_eq_of_monotoneOn {β : Type*} [LinearOrder β] {a b : β} (g : β → α)
-    (hg : MonotoneOn g (Set.Icc a b)) (himage : g '' Set.Icc a b = Set.Icc (g a) (g b)) :
+    (hg : MonotoneOn g (Icc a b)) (himage : g '' Icc a b = Icc (g a) (g b)) :
     arcLength (f ∘ g) a b = arcLength f (g a) (g b) := by
   rw [arcLength, arcLength, eVariationOn.comp_eq_of_monotoneOn _ _ hg, himage]
 
 /-- Arc length is preserved by an antitone reparametrization whose image is exactly the target
 interval, with reversed endpoints. -/
 theorem arcLength_comp_eq_of_antitoneOn {β : Type*} [LinearOrder β] {a b : β} (g : β → α)
-    (hg : AntitoneOn g (Set.Icc a b)) (himage : g '' Set.Icc a b = Set.Icc (g b) (g a)) :
+    (hg : AntitoneOn g (Icc a b)) (himage : g '' Icc a b = Icc (g b) (g a)) :
     arcLength (f ∘ g) a b = arcLength f (g b) (g a) := by
   rw [arcLength, arcLength, eVariationOn.comp_eq_of_antitoneOn _ _ hg, himage]
 

--- a/Mathlib/Topology/EMetricSpace/PathLength.lean
+++ b/Mathlib/Topology/EMetricSpace/PathLength.lean
@@ -82,13 +82,12 @@ theorem length_symm (γ : Path a b) :
     γ.symm.length = γ.length := by
   unfold length
   rw [symm_eq_comp γ]
-  have h :=
-    eVariationOn.comp_eq_of_antitoneOn (f := γ) (t := (Set.univ : Set I)) (φ := σ)
-      (by
-        intro x hx y hy hxy
-        change (σ y : ℝ) ≤ (σ x : ℝ)
-        rw [coe_symm_eq, coe_symm_eq]
-        linarith [show (x : ℝ) ≤ (y : ℝ) from hxy])
+  have h : eVariationOn (γ ∘ σ) (Set.univ : Set I) = eVariationOn γ (σ '' (Set.univ : Set I)) := by
+    apply eVariationOn.comp_eq_of_antitoneOn (f := γ) (t := (Set.univ : Set I)) (φ := σ)
+    intro x hx y hy hxy
+    change (σ y : ℝ) ≤ (σ x : ℝ)
+    rw [coe_symm_eq, coe_symm_eq]
+    linarith [show (x : ℝ) ≤ (y : ℝ) from hxy]
   rw [Set.image_univ, Set.range_eq_univ.2 unitInterval.symm_bijective.surjective] at h
   exact h
 
@@ -131,65 +130,59 @@ private lemma eVariationOn_symm_Icc_left_half (γ : Path a b) :
   rw [symm_eq_comp γ]
   calc
     _ = eVariationOn γ (σ '' Icc (0 : I) half) := by
-          apply eVariationOn.comp_eq_of_antitoneOn
-          intro x hx y hy hxy
-          change (σ y : ℝ) ≤ (σ x : ℝ)
-          rw [coe_symm_eq, coe_symm_eq]
-          linarith [show (x : ℝ) ≤ (y : ℝ) from hxy]
+        apply eVariationOn.comp_eq_of_antitoneOn
+        intro x hx y hy hxy
+        change (σ y : ℝ) ≤ (σ x : ℝ)
+        rw [coe_symm_eq, coe_symm_eq]
+        linarith [show (x : ℝ) ≤ (y : ℝ) from hxy]
     _ = eVariationOn γ (Icc half (1 : I)) := by
-          congr 1
-          ext x
+        congr 1
+        ext x
+        constructor
+        · rintro ⟨t, ht, rfl⟩
           constructor
-          · rintro ⟨t, ht, rfl⟩
-            constructor
-            · exact (half_le_symm_iff t).2 ht.2
-            · exact (σ t).2.2
-          · intro hx
-            refine ⟨σ x, ?_, ?_⟩
-            · constructor
-              · simp
-              · have : (1 / 2 : ℝ) ≤ (σ (σ x) : ℝ) := by
-                  rw [unitInterval.symm_symm]
-                  exact hx.1
-                exact (half_le_symm_iff (σ x)).1 this
+          · exact (half_le_symm_iff t).2 ht.2
+          · exact (σ t).2.2
+        · intro hx
+          refine ⟨σ x, ?_, ?_⟩
+          · constructor
             · simp
+            · have : (1 / 2 : ℝ) ≤ (σ (σ x) : ℝ) := by
+                rw [unitInterval.symm_symm]
+                exact hx.1
+              exact (half_le_symm_iff (σ x)).1 this
+          · simp
 
 /-! ## Length of concatenations -/
 
 /-- The variation of a concatenation on its left half is the variation of the first path. -/
 private lemma eVariationOn_trans_left (γ : Path a b) (η : Path b c) :
-    eVariationOn (γ.trans η) (Icc 0 half) = eVariationOn γ Set.univ := by
-  refine (eVariationOn.congr
-    (g := fun t : I ↦ γ.extend (2 * (t : ℝ)))
-    ?_).trans ?_
+    eVariationOn (γ.trans η) (Icc 0 half) = γ.length := by
+  refine (eVariationOn.congr (g := fun t : I ↦ γ.extend (2 * (t : ℝ))) ?_).trans ?_
   · intro t ht
     have hle : (t : ℝ) ≤ (1 / 2 : ℝ) := ht.2
-    rw [Path.trans_apply, dif_pos hle]
-    rw [← Path.extend_apply γ (by grind)]
-  · change eVariationOn (γ.extend ∘ fun t : I ↦ (2 : ℝ) * t) (Icc 0 half)
-        = eVariationOn γ Set.univ
+    rw [Path.trans_apply, dif_pos hle, ← Path.extend_apply γ (by grind)]
+  · change eVariationOn (γ.extend ∘ fun t : I ↦ (2 : ℝ) * t) (Icc 0 half) = eVariationOn γ Set.univ
     calc
       _ = eVariationOn γ.extend ((fun t : I ↦ (2 : ℝ) * t) '' Icc (0 : I) half) := by
-            apply eVariationOn.comp_eq_of_monotoneOn
-            intro x hx y hy hxy
-            exact mul_le_mul_of_nonneg_left hxy (by positivity)
+          apply eVariationOn.comp_eq_of_monotoneOn
+          intro x hx y hy hxy
+          exact mul_le_mul_of_nonneg_left hxy (by positivity)
       _ = eVariationOn γ.extend (Icc (0 : ℝ) 1) := by
-            rw [image_double_Icc_half]
+          rw [image_double_Icc_half]
       _ = γ.length := (length_eq_eVariationOn_extend γ).symm
-      _ = eVariationOn γ Set.univ := rfl
 
 /-- The variation of a concatenation on its right half is the variation of the second path. -/
 private lemma eVariationOn_trans_right (γ : Path a b) (η : Path b c) :
-    eVariationOn (γ.trans η) (Icc half 1) = eVariationOn η Set.univ := by
+    eVariationOn (γ.trans η) (Icc half 1) = η.length := by
   calc
     _ = eVariationOn (γ.trans η).symm (Icc 0 half) := by
-          exact (eVariationOn_symm_Icc_left_half (γ := γ.trans η)).symm
+        exact (eVariationOn_symm_Icc_left_half (γ := γ.trans η)).symm
     _ = eVariationOn η.symm Set.univ := by
-          rw [Path.trans_symm]
-          exact eVariationOn_trans_left (γ := η.symm) (η := γ.symm)
+        rw [Path.trans_symm]
+        exact eVariationOn_trans_left (γ := η.symm) (η := γ.symm)
     _ = eVariationOn η Set.univ := by
-          change η.symm.length = η.length
-          exact length_symm η
+        exact length_symm η
 
 /-- The length of a concatenation is the sum of the lengths of the two pieces. -/
 theorem length_trans (γ : Path a b) (η : Path b c) :
@@ -200,6 +193,7 @@ theorem length_trans (γ : Path a b) (η : Path b c) :
   simp only [Set.univ_inter] at h
   rw [← unitInterval.univ_eq_Icc] at h
   rw [← h, eVariationOn_trans_left, eVariationOn_trans_right]
+  rfl
 
 end
 

--- a/Mathlib/Topology/EMetricSpace/PathLength.lean
+++ b/Mathlib/Topology/EMetricSpace/PathLength.lean
@@ -1,0 +1,208 @@
+/-
+Copyright (c) 2026 Zhenhua Wu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhenhua Wu
+-/
+module
+
+public import Mathlib.Topology.EMetricSpace.BoundedVariation
+public import Mathlib.Topology.Path
+
+/-!
+# Length of paths
+
+This file defines the length of a path in a `PseudoEMetricSpace` as its variation on the unit
+interval. It also establishes the basic properties of path length that are needed in later files:
+the endpoint distance bound, invariance under reversal, and additivity under concatenation.
+
+## Main declarations
+
+- `Path.length`: the length of a path, defined as its variation on the unit interval.
+- `Path.edist_le_length`: the endpoint distance is bounded above by the length.
+- `Path.length_symm`: reversing a path does not change its length.
+- `Path.length_trans`: the length of a concatenation is the sum of the lengths.
+
+## TODO
+
+- Prove that path length is invariant under reparametrization.
+-/
+
+open scoped ENNReal
+open Set unitInterval
+
+namespace Path
+
+@[expose] public section
+
+noncomputable section
+
+variable {E : Type*} [PseudoEMetricSpace E] {a b c : E}
+
+local notation "half" => (⟨(1 / 2 : ℝ), by constructor <;> norm_num⟩ : I)
+
+private lemma zero_le_half : (0 : I) ≤ half := by
+  change (0 : ℝ) ≤ (1 / 2 : ℝ)
+  norm_num
+
+private lemma half_le_one : half ≤ (1 : I) := by
+  change (1 / 2 : ℝ) ≤ (1 : ℝ)
+  norm_num
+
+/-! ## Definition and basic properties -/
+
+/-- The length of a path is its variation on the unit interval. -/
+def length (γ : Path a b) : ℝ≥0∞ :=
+  eVariationOn γ Set.univ
+
+/-- The length of a path is nonnegative. -/
+theorem length_nonneg (γ : Path a b) :
+    0 ≤ γ.length := bot_le
+
+/-- The endpoint distance of a path is bounded above by its length. -/
+theorem edist_le_length (γ : Path a b) :
+    edist a b ≤ γ.length := by
+  unfold length
+  trans edist (γ 0) (γ 1)
+  · simp
+  · exact eVariationOn.edist_le γ (by simp) (by simp)
+
+/-- The constant path has zero length. -/
+@[simp]
+theorem length_refl (x : E) :
+    (Path.refl x).length = 0 := by
+  unfold length
+  apply eVariationOn.constant_on
+  simp
+
+private lemma symm_eq_comp (γ : Path a b) : ⇑γ.symm = ⇑γ ∘ σ := rfl
+
+/-- Reversing a path does not change its length. -/
+@[simp]
+theorem length_symm (γ : Path a b) :
+    γ.symm.length = γ.length := by
+  unfold length
+  rw [symm_eq_comp γ]
+  have h :=
+    eVariationOn.comp_eq_of_antitoneOn (f := γ) (t := (Set.univ : Set I)) (φ := σ)
+      (by
+        intro x hx y hy hxy
+        change (σ y : ℝ) ≤ (σ x : ℝ)
+        rw [coe_symm_eq, coe_symm_eq]
+        linarith [show (x : ℝ) ≤ (y : ℝ) from hxy])
+  rw [Set.image_univ, Set.range_eq_univ.2 unitInterval.symm_bijective.surjective] at h
+  exact h
+
+/-! ## Auxiliary lemmas for concatenation -/
+
+/-- The length of a path is the variation of its extension on `[0,1]`. -/
+lemma length_eq_eVariationOn_extend (γ : Path a b) :
+    γ.length = eVariationOn γ.extend (Icc (0 : ℝ) 1) := by
+  unfold length
+  have himage : ((↑) : I → ℝ) '' (Set.univ : Set I) = Icc (0 : ℝ) 1 := by
+    exact Subtype.coe_image_univ I
+  calc
+    _ = eVariationOn (γ.extend ∘ ((↑) : I → ℝ)) (Set.univ : Set I) := by
+      apply eVariationOn.congr
+      intro t ht
+      exact (Path.extend_extends' γ t).symm
+    _ = eVariationOn γ.extend (((↑) : I → ℝ) '' (Set.univ : Set I)) := by
+      apply eVariationOn.comp_eq_of_monotoneOn
+      intro x hx y hy hxy
+      exact hxy
+    _ = eVariationOn γ.extend (Icc (0 : ℝ) 1) := by
+      rw [himage]
+
+/-- Auxiliary lemma: the affine map `t ↦ 2t` sends the left half
+of the unit interval onto `[0,1]`. -/
+private lemma image_double_Icc_half :
+    (fun t : I ↦ (2 : ℝ) * t) '' Icc (0 : I) half = Icc (0 : ℝ) 1 := by
+  ext x
+  simp only [one_div, mem_image, mem_Icc, zero_le, true_and, Subtype.exists, Subtype.mk_le_mk,
+    exists_and_left, exists_prop]
+  constructor
+  · grind
+  · intros
+    exact ⟨2⁻¹ * x, by grind⟩
+
+/-- Auxiliary lemma: the variation of the left half of `γ.symm`
+is the variation of the right half of `γ`. -/
+private lemma eVariationOn_symm_Icc_left_half (γ : Path a b) :
+    eVariationOn γ.symm (Icc 0 half) = eVariationOn γ (Icc half 1) := by
+  rw [symm_eq_comp γ]
+  calc
+    _ = eVariationOn γ (σ '' Icc (0 : I) half) := by
+          apply eVariationOn.comp_eq_of_antitoneOn
+          intro x hx y hy hxy
+          change (σ y : ℝ) ≤ (σ x : ℝ)
+          rw [coe_symm_eq, coe_symm_eq]
+          linarith [show (x : ℝ) ≤ (y : ℝ) from hxy]
+    _ = eVariationOn γ (Icc half (1 : I)) := by
+          congr 1
+          ext x
+          constructor
+          · rintro ⟨t, ht, rfl⟩
+            constructor
+            · exact (half_le_symm_iff t).2 ht.2
+            · exact (σ t).2.2
+          · intro hx
+            refine ⟨σ x, ?_, ?_⟩
+            · constructor
+              · simp
+              · have : (1 / 2 : ℝ) ≤ (σ (σ x) : ℝ) := by
+                  rw [unitInterval.symm_symm]
+                  exact hx.1
+                exact (half_le_symm_iff (σ x)).1 this
+            · simp
+
+/-! ## Length of concatenations -/
+
+/-- The variation of a concatenation on its left half is the variation of the first path. -/
+private lemma eVariationOn_trans_left (γ : Path a b) (η : Path b c) :
+    eVariationOn (γ.trans η) (Icc 0 half) = eVariationOn γ Set.univ := by
+  refine (eVariationOn.congr
+    (g := fun t : I ↦ γ.extend (2 * (t : ℝ)))
+    ?_).trans ?_
+  · intro t ht
+    have hle : (t : ℝ) ≤ (1 / 2 : ℝ) := ht.2
+    rw [Path.trans_apply, dif_pos hle]
+    rw [← Path.extend_apply γ (by grind)]
+  · change eVariationOn (γ.extend ∘ fun t : I ↦ (2 : ℝ) * t) (Icc 0 half)
+        = eVariationOn γ Set.univ
+    calc
+      _ = eVariationOn γ.extend ((fun t : I ↦ (2 : ℝ) * t) '' Icc (0 : I) half) := by
+            apply eVariationOn.comp_eq_of_monotoneOn
+            intro x hx y hy hxy
+            exact mul_le_mul_of_nonneg_left hxy (by positivity)
+      _ = eVariationOn γ.extend (Icc (0 : ℝ) 1) := by
+            rw [image_double_Icc_half]
+      _ = γ.length := (length_eq_eVariationOn_extend γ).symm
+      _ = eVariationOn γ Set.univ := rfl
+
+/-- The variation of a concatenation on its right half is the variation of the second path. -/
+private lemma eVariationOn_trans_right (γ : Path a b) (η : Path b c) :
+    eVariationOn (γ.trans η) (Icc half 1) = eVariationOn η Set.univ := by
+  calc
+    _ = eVariationOn (γ.trans η).symm (Icc 0 half) := by
+          exact (eVariationOn_symm_Icc_left_half (γ := γ.trans η)).symm
+    _ = eVariationOn η.symm Set.univ := by
+          rw [Path.trans_symm]
+          exact eVariationOn_trans_left (γ := η.symm) (η := γ.symm)
+    _ = eVariationOn η Set.univ := by
+          change η.symm.length = η.length
+          exact length_symm η
+
+/-- The length of a concatenation is the sum of the lengths of the two pieces. -/
+theorem length_trans (γ : Path a b) (η : Path b c) :
+    (γ.trans η).length = γ.length + η.length := by
+  unfold length
+  have h := eVariationOn.Icc_add_Icc (f := γ.trans η) (s := Set.univ)
+    zero_le_half half_le_one (Set.mem_univ half)
+  simp only [Set.univ_inter] at h
+  rw [← unitInterval.univ_eq_Icc] at h
+  rw [← h, eVariationOn_trans_left, eVariationOn_trans_right]
+
+end
+
+end
+
+end Path

--- a/Mathlib/Topology/EMetricSpace/PathLength.lean
+++ b/Mathlib/Topology/EMetricSpace/PathLength.lean
@@ -5,18 +5,20 @@ Authors: Zhenhua Wu
 -/
 module
 
-public import Mathlib.Topology.EMetricSpace.BoundedVariation
+public import Mathlib.Topology.EMetricSpace.ArcLength
 public import Mathlib.Topology.Path
 
 /-!
 # Length of paths
 
-This file defines the length of a path in a `PseudoEMetricSpace` as its variation on the unit
-interval, and develops the basic API for this definition.
+This file defines the length of a path in a `WeakPseudoEMetricSpace` as the arc length of the
+underlying map on the unit interval, equivalently as its variation on `Set.univ`, and develops
+the basic API for this definition.
 
 ## Main declarations
 
-* `Path.length`: the length of a path, defined as its variation on the unit interval.
+* `Path.length`: the length of a path, defined as `arcLength γ 0 1`.
+* `Path.length_eq_eVariationOn`: `Path.length` agrees with `eVariationOn` on `Set.univ`.
 * `Path.edist_le_length`: the endpoint distance is bounded above by the length.
 * `Path.length_symm`: reversing a path does not change its length.
 * `Path.length_trans`: the length of a concatenation is the sum of the lengths.
@@ -33,7 +35,7 @@ namespace Path
 
 @[expose] public noncomputable section
 
-variable {E : Type*} [PseudoEMetricSpace E] {a b c : E}
+variable {E : Type*} [TopologicalSpace E] [WeakPseudoEMetricSpace E] {a b c : E}
 
 local notation "half" => (⟨1 / 2, by norm_num⟩ : I)
 
@@ -44,29 +46,36 @@ private lemma symm_half : σ half = half := by
 
 /-! ## Definition and basic properties -/
 
-/-- The length of a path is its variation on the unit interval. -/
+/-- The length of a path is the arc length of its underlying map on the unit interval. -/
 def length (γ : Path a b) : ℝ≥0∞ :=
-  eVariationOn γ Set.univ
+  arcLength γ 0 1
+
+/-- The length of a path agrees with the variation of its underlying map on `Set.univ`. -/
+theorem length_eq_eVariationOn (γ : Path a b) :
+    γ.length = eVariationOn γ Set.univ := by
+  rw [length, arcLength, ← unitInterval.univ_eq_Icc]
 
 /-- The endpoint distance of a path is bounded above by its length. -/
 theorem edist_le_length (γ : Path a b) :
-    edist a b ≤ γ.length := by
-  simp_rw [← γ.source, ← γ.target]
-  exact eVariationOn.edist_le γ (mem_univ 0) (mem_univ 1)
+    edist a b ≤ γ.length :=
+  calc
+    _ = edist (γ 0) (γ 1) := by rw [γ.source, γ.target]
+    _ ≤ arcLength γ 0 1 := edist_le_arcLength γ (a := 0) (b := 1) zero_le_one
+    _ = γ.length := by rw [length]
 
 /-- The constant path has zero length. -/
 @[simp]
 theorem length_refl (x : E) :
-    (Path.refl x).length = 0 := by
-  apply eVariationOn.constant_on
-  simp
+    (refl x).length = 0 := by
+  rw [length_eq_eVariationOn]
+  exact eVariationOn.constant_on (f := refl x) (s := Set.univ) (by simp)
 
 /-- Reversing a path does not change its length. -/
 @[simp]
 theorem length_symm (γ : Path a b) :
     γ.symm.length = γ.length := by
-  unfold length
-  rw [symm_eq_comp γ, eVariationOn.comp_eq_of_antitoneOn _ _
+  rw [length_eq_eVariationOn, length_eq_eVariationOn, symm_eq_comp γ,
+    eVariationOn.comp_eq_of_antitoneOn _ _
     (unitInterval.strictAnti_symm.antitone.antitoneOn univ),
     image_univ_of_surjective unitInterval.symm_bijective.surjective]
 
@@ -75,8 +84,7 @@ theorem length_symm (γ : Path a b) :
 /-- The length of a path is the variation of its extension on `[0,1]`. -/
 lemma length_eq_eVariationOn_extend (γ : Path a b) :
     γ.length = eVariationOn γ.extend (Icc (0 : ℝ) 1) := by
-  unfold length
-  rw [← restrict_extend γ, eVariationOn.comp_eq_of_monotoneOn _ _
+  rw [length_eq_eVariationOn, ← restrict_extend γ, eVariationOn.comp_eq_of_monotoneOn _ _
     ((Subtype.mono_coe _).monotoneOn univ), Subtype.coe_image_univ I]
 
 /-- Auxiliary lemma: the affine map `t ↦ 2t` sends the left half
@@ -107,11 +115,11 @@ private lemma eVariationOn_trans_left (γ : Path a b) (η : Path b c) :
     eVariationOn (γ.trans η) (Icc 0 half) = γ.length := by
   calc
     _ = eVariationOn (γ.extend ∘ fun t : I ↦ 2 * t) (Icc 0 half) := by
-      refine eVariationOn.congr fun t ht => ?_
-      rw [Function.comp_apply, ← Path.extend_apply, Path.extend_trans_of_le_half γ η ht.2]
+          refine eVariationOn.congr fun t ht => ?_
+          rw [Function.comp_apply, ← Path.extend_apply, Path.extend_trans_of_le_half γ η ht.2]
     _ = eVariationOn γ.extend (Icc 0 1) := by
-      rw [eVariationOn.comp_eq_of_monotoneOn _ _
-        (Subtype.mono_coe _ |>.const_mul zero_le_two |>.monotoneOn _), image_double_Icc_half]
+          rw [eVariationOn.comp_eq_of_monotoneOn _ _
+            ((Subtype.mono_coe _ |>.const_mul zero_le_two |>.monotoneOn _)), image_double_Icc_half]
     _ = γ.length := (length_eq_eVariationOn_extend γ).symm
 
 /-- Auxiliary lemma: the variation of a concatenation on its right half
@@ -128,8 +136,7 @@ private lemma eVariationOn_trans_right (γ : Path a b) (η : Path b c) :
 /-- The length of a concatenation is the sum of the lengths of the two pieces. -/
 theorem length_trans (γ : Path a b) (η : Path b c) :
     (γ.trans η).length = γ.length + η.length := by
-  change eVariationOn (γ.trans η) Set.univ = γ.length + η.length
-  rw [univ_eq_Icc, ← Icc_union_Icc_eq_Icc nonneg' le_one',
+  rw [length_eq_eVariationOn, univ_eq_Icc, ← Icc_union_Icc_eq_Icc nonneg' le_one',
     eVariationOn.union _ (isGreatest_Icc nonneg') (isLeast_Icc le_one'),
     eVariationOn_trans_left, eVariationOn_trans_right]
 

--- a/Mathlib/Topology/EMetricSpace/PathLength.lean
+++ b/Mathlib/Topology/EMetricSpace/PathLength.lean
@@ -12,19 +12,18 @@ public import Mathlib.Topology.Path
 # Length of paths
 
 This file defines the length of a path in a `PseudoEMetricSpace` as its variation on the unit
-interval. It also establishes the basic properties of path length that are needed in later files:
-the endpoint distance bound, invariance under reversal, and additivity under concatenation.
+interval, and develops the basic API for this definition.
 
 ## Main declarations
 
-- `Path.length`: the length of a path, defined as its variation on the unit interval.
-- `Path.edist_le_length`: the endpoint distance is bounded above by the length.
-- `Path.length_symm`: reversing a path does not change its length.
-- `Path.length_trans`: the length of a concatenation is the sum of the lengths.
+* `Path.length`: the length of a path, defined as its variation on the unit interval.
+* `Path.edist_le_length`: the endpoint distance is bounded above by the length.
+* `Path.length_symm`: reversing a path does not change its length.
+* `Path.length_trans`: the length of a concatenation is the sum of the lengths.
 
 ## TODO
 
-- Prove that path length is invariant under reparametrization.
+* Prove that path length is invariant under reparametrization. (@Zeta-Wu)
 -/
 
 open scoped ENNReal
@@ -32,21 +31,16 @@ open Set unitInterval
 
 namespace Path
 
-@[expose] public section
-
-noncomputable section
+@[expose] public noncomputable section
 
 variable {E : Type*} [PseudoEMetricSpace E] {a b c : E}
 
-local notation "half" => (⟨(1 / 2 : ℝ), by constructor <;> norm_num⟩ : I)
+local notation "half" => (⟨1 / 2, by norm_num⟩ : I)
 
-private lemma zero_le_half : (0 : I) ≤ half := by
-  change (0 : ℝ) ≤ (1 / 2 : ℝ)
-  norm_num
-
-private lemma half_le_one : half ≤ (1 : I) := by
-  change (1 / 2 : ℝ) ≤ (1 : ℝ)
-  norm_num
+/-- Auxiliary lemma: the symmetry of the unit interval fixes `half`. -/
+private lemma symm_half : σ half = half := by
+  ext
+  norm_num [unitInterval.symm]
 
 /-! ## Definition and basic properties -/
 
@@ -54,42 +48,27 @@ private lemma half_le_one : half ≤ (1 : I) := by
 def length (γ : Path a b) : ℝ≥0∞ :=
   eVariationOn γ Set.univ
 
-/-- The length of a path is nonnegative. -/
-theorem length_nonneg (γ : Path a b) :
-    0 ≤ γ.length := bot_le
-
 /-- The endpoint distance of a path is bounded above by its length. -/
 theorem edist_le_length (γ : Path a b) :
     edist a b ≤ γ.length := by
-  unfold length
-  trans edist (γ 0) (γ 1)
-  · simp
-  · exact eVariationOn.edist_le γ (by simp) (by simp)
+  simp_rw [← γ.source, ← γ.target]
+  exact eVariationOn.edist_le γ (mem_univ 0) (mem_univ 1)
 
 /-- The constant path has zero length. -/
 @[simp]
 theorem length_refl (x : E) :
     (Path.refl x).length = 0 := by
-  unfold length
   apply eVariationOn.constant_on
   simp
-
-private lemma symm_eq_comp (γ : Path a b) : ⇑γ.symm = ⇑γ ∘ σ := rfl
 
 /-- Reversing a path does not change its length. -/
 @[simp]
 theorem length_symm (γ : Path a b) :
     γ.symm.length = γ.length := by
   unfold length
-  rw [symm_eq_comp γ]
-  have h : eVariationOn (γ ∘ σ) (Set.univ : Set I) = eVariationOn γ (σ '' (Set.univ : Set I)) := by
-    apply eVariationOn.comp_eq_of_antitoneOn (f := γ) (t := (Set.univ : Set I)) (φ := σ)
-    intro x hx y hy hxy
-    change (σ y : ℝ) ≤ (σ x : ℝ)
-    rw [coe_symm_eq, coe_symm_eq]
-    linarith [show (x : ℝ) ≤ (y : ℝ) from hxy]
-  rw [Set.image_univ, Set.range_eq_univ.2 unitInterval.symm_bijective.surjective] at h
-  exact h
+  rw [symm_eq_comp γ, eVariationOn.comp_eq_of_antitoneOn _ _
+    (unitInterval.strictAnti_symm.antitone.antitoneOn univ),
+    image_univ_of_surjective unitInterval.symm_bijective.surjective]
 
 /-! ## Auxiliary lemmas for concatenation -/
 
@@ -97,31 +76,16 @@ theorem length_symm (γ : Path a b) :
 lemma length_eq_eVariationOn_extend (γ : Path a b) :
     γ.length = eVariationOn γ.extend (Icc (0 : ℝ) 1) := by
   unfold length
-  have himage : ((↑) : I → ℝ) '' (Set.univ : Set I) = Icc (0 : ℝ) 1 := by
-    exact Subtype.coe_image_univ I
-  calc
-    _ = eVariationOn (γ.extend ∘ ((↑) : I → ℝ)) (Set.univ : Set I) := by
-      apply eVariationOn.congr
-      intro t ht
-      exact (Path.extend_extends' γ t).symm
-    _ = eVariationOn γ.extend (((↑) : I → ℝ) '' (Set.univ : Set I)) := by
-      apply eVariationOn.comp_eq_of_monotoneOn
-      intro x hx y hy hxy
-      exact hxy
-    _ = eVariationOn γ.extend (Icc (0 : ℝ) 1) := by
-      rw [himage]
+  rw [← restrict_extend γ, eVariationOn.comp_eq_of_monotoneOn _ _
+    ((Subtype.mono_coe _).monotoneOn univ), Subtype.coe_image_univ I]
 
 /-- Auxiliary lemma: the affine map `t ↦ 2t` sends the left half
 of the unit interval onto `[0,1]`. -/
 private lemma image_double_Icc_half :
     (fun t : I ↦ (2 : ℝ) * t) '' Icc (0 : I) half = Icc (0 : ℝ) 1 := by
-  ext x
-  simp only [one_div, mem_image, mem_Icc, zero_le, true_and, Subtype.exists, Subtype.mk_le_mk,
-    exists_and_left, exists_prop]
-  constructor
-  · grind
-  · intros
-    exact ⟨2⁻¹ * x, by grind⟩
+  rw [ContinuousOn.image_Icc_of_monotoneOn nonneg' (by fun_prop)
+    (Subtype.mono_coe _ |>.const_mul zero_le_two |>.monotoneOn _)]
+  simp
 
 /-- Auxiliary lemma: the variation of the left half of `γ.symm`
 is the variation of the right half of `γ`. -/
@@ -129,73 +93,45 @@ private lemma eVariationOn_symm_Icc_left_half (γ : Path a b) :
     eVariationOn γ.symm (Icc 0 half) = eVariationOn γ (Icc half 1) := by
   rw [symm_eq_comp γ]
   calc
-    _ = eVariationOn γ (σ '' Icc (0 : I) half) := by
-        apply eVariationOn.comp_eq_of_antitoneOn
-        intro x hx y hy hxy
-        change (σ y : ℝ) ≤ (σ x : ℝ)
-        rw [coe_symm_eq, coe_symm_eq]
-        linarith [show (x : ℝ) ≤ (y : ℝ) from hxy]
-    _ = eVariationOn γ (Icc half (1 : I)) := by
-        congr 1
-        ext x
-        constructor
-        · rintro ⟨t, ht, rfl⟩
-          constructor
-          · exact (half_le_symm_iff t).2 ht.2
-          · exact (σ t).2.2
-        · intro hx
-          refine ⟨σ x, ?_, ?_⟩
-          · constructor
-            · simp
-            · have : (1 / 2 : ℝ) ≤ (σ (σ x) : ℝ) := by
-                rw [unitInterval.symm_symm]
-                exact hx.1
-              exact (half_le_symm_iff (σ x)).1 this
-          · simp
+    _ = eVariationOn γ (σ '' Icc (0 : I) half) :=
+        eVariationOn.comp_eq_of_antitoneOn γ σ fun _ _ _ _ hxy => symm_le_symm.mpr hxy
+    _ = eVariationOn γ (Icc half 1) := by
+        rw [ContinuousOn.image_Icc_of_antitoneOn nonneg'
+          ((unitInterval.continuous_symm.continuousOn : ContinuousOn σ (Icc 0 half)))
+          (strictAnti_symm.antitone.antitoneOn _), symm_half, symm_zero]
 
 /-! ## Length of concatenations -/
-
-/-- The variation of a concatenation on its left half is the variation of the first path. -/
+/-- Auxiliary lemma: the variation of a concatenation on its left half
+is the length of the first path. -/
 private lemma eVariationOn_trans_left (γ : Path a b) (η : Path b c) :
     eVariationOn (γ.trans η) (Icc 0 half) = γ.length := by
-  refine (eVariationOn.congr (g := fun t : I ↦ γ.extend (2 * (t : ℝ))) ?_).trans ?_
-  · intro t ht
-    have hle : (t : ℝ) ≤ (1 / 2 : ℝ) := ht.2
-    rw [Path.trans_apply, dif_pos hle, ← Path.extend_apply γ (by grind)]
-  · change eVariationOn (γ.extend ∘ fun t : I ↦ (2 : ℝ) * t) (Icc 0 half) = eVariationOn γ Set.univ
-    calc
-      _ = eVariationOn γ.extend ((fun t : I ↦ (2 : ℝ) * t) '' Icc (0 : I) half) := by
-          apply eVariationOn.comp_eq_of_monotoneOn
-          intro x hx y hy hxy
-          exact mul_le_mul_of_nonneg_left hxy (by positivity)
-      _ = eVariationOn γ.extend (Icc (0 : ℝ) 1) := by
-          rw [image_double_Icc_half]
-      _ = γ.length := (length_eq_eVariationOn_extend γ).symm
+  calc
+    _ = eVariationOn (γ.extend ∘ fun t : I ↦ 2 * t) (Icc 0 half) := by
+      refine eVariationOn.congr fun t ht => ?_
+      rw [Function.comp_apply, ← Path.extend_apply, Path.extend_trans_of_le_half γ η ht.2]
+    _ = eVariationOn γ.extend (Icc 0 1) := by
+      rw [eVariationOn.comp_eq_of_monotoneOn _ _
+        (Subtype.mono_coe _ |>.const_mul zero_le_two |>.monotoneOn _), image_double_Icc_half]
+    _ = γ.length := (length_eq_eVariationOn_extend γ).symm
 
-/-- The variation of a concatenation on its right half is the variation of the second path. -/
+/-- Auxiliary lemma: the variation of a concatenation on its right half
+is the length of the second path. -/
 private lemma eVariationOn_trans_right (γ : Path a b) (η : Path b c) :
     eVariationOn (γ.trans η) (Icc half 1) = η.length := by
   calc
-    _ = eVariationOn (γ.trans η).symm (Icc 0 half) := by
-        exact (eVariationOn_symm_Icc_left_half (γ := γ.trans η)).symm
-    _ = eVariationOn η.symm Set.univ := by
-        rw [Path.trans_symm]
-        exact eVariationOn_trans_left (γ := η.symm) (η := γ.symm)
-    _ = eVariationOn η Set.univ := by
-        exact length_symm η
+    _ = eVariationOn (γ.trans η).symm (Icc 0 half) :=
+      (eVariationOn_symm_Icc_left_half (γ.trans η)).symm
+    _ = η.length := by
+      rw [← length_symm, Path.trans_symm]
+      exact eVariationOn_trans_left η.symm γ.symm
 
 /-- The length of a concatenation is the sum of the lengths of the two pieces. -/
 theorem length_trans (γ : Path a b) (η : Path b c) :
     (γ.trans η).length = γ.length + η.length := by
-  unfold length
-  have h := eVariationOn.Icc_add_Icc (f := γ.trans η) (s := Set.univ)
-    zero_le_half half_le_one (Set.mem_univ half)
-  simp only [Set.univ_inter] at h
-  rw [← unitInterval.univ_eq_Icc] at h
-  rw [← h, eVariationOn_trans_left, eVariationOn_trans_right]
-  rfl
-
-end
+  change eVariationOn (γ.trans η) Set.univ = γ.length + η.length
+  rw [univ_eq_Icc, ← Icc_union_Icc_eq_Icc nonneg' le_one',
+    eVariationOn.union _ (isGreatest_Icc nonneg') (isLeast_Icc le_one'),
+    eVariationOn_trans_left, eVariationOn_trans_right]
 
 end
 

--- a/Mathlib/Topology/EMetricSpace/PathLength.lean
+++ b/Mathlib/Topology/EMetricSpace/PathLength.lean
@@ -37,13 +37,6 @@ namespace Path
 
 variable {E : Type*} [TopologicalSpace E] [WeakPseudoEMetricSpace E] {a b c : E}
 
-local notation "half" => (⟨1 / 2, by norm_num⟩ : I)
-
-/-- Auxiliary lemma: the symmetry of the unit interval fixes `half`. -/
-private lemma symm_half : σ half = half := by
-  ext
-  norm_num [unitInterval.symm]
-
 /-! ## Definition and basic properties -/
 
 /-- The length of a path is the arc length of its underlying map on the unit interval. -/
@@ -52,32 +45,33 @@ def length (γ : Path a b) : ℝ≥0∞ :=
 
 /-- The length of a path agrees with the variation of its underlying map on `Set.univ`. -/
 theorem length_eq_eVariationOn (γ : Path a b) :
-    γ.length = eVariationOn γ Set.univ := by
-  rw [length, arcLength, ← unitInterval.univ_eq_Icc]
+    γ.length = eVariationOn γ univ := by
+  rw [length, arcLength, ← univ_eq_Icc]
 
 /-- The endpoint distance of a path is bounded above by its length. -/
 theorem edist_le_length (γ : Path a b) :
-    edist a b ≤ γ.length :=
-  calc
-    _ = edist (γ 0) (γ 1) := by rw [γ.source, γ.target]
-    _ ≤ arcLength γ 0 1 := edist_le_arcLength γ (a := 0) (b := 1) zero_le_one
-    _ = γ.length := by rw [length]
+    edist a b ≤ γ.length := by
+    simp_rw [length, ← γ.source, ← γ.target]
+    exact edist_le_arcLength _ zero_le_one
 
 /-- The constant path has zero length. -/
 @[simp]
 theorem length_refl (x : E) :
-    (refl x).length = 0 := by
-  rw [length_eq_eVariationOn]
-  exact eVariationOn.constant_on (f := refl x) (s := Set.univ) (by simp)
+    (refl x).length = 0 :=
+  arcLength_eq_zero_of_constantOn (refl x) (a := 0) (b := 1) (by simp)
 
 /-- Reversing a path does not change its length. -/
 @[simp]
 theorem length_symm (γ : Path a b) :
     γ.symm.length = γ.length := by
-  rw [length_eq_eVariationOn, length_eq_eVariationOn, symm_eq_comp γ,
-    eVariationOn.comp_eq_of_antitoneOn _ _
-    (unitInterval.strictAnti_symm.antitone.antitoneOn univ),
-    image_univ_of_surjective unitInterval.symm_bijective.surjective]
+  rw [length, length, symm_eq_comp γ,
+    arcLength_comp_eq_of_antitoneOn _ _
+      (strictAnti_symm.antitone.antitoneOn (Icc (0 : I) 1))
+      (by
+        rw [ContinuousOn.image_Icc_of_antitoneOn nonneg'
+          (unitInterval.continuous_symm.continuousOn : ContinuousOn σ (Icc (0 : I) 1))
+          (strictAnti_symm.antitone.antitoneOn (Icc (0 : I) 1))]),
+    symm_one, symm_zero]
 
 /-! ## Auxiliary lemmas for concatenation -/
 
@@ -90,31 +84,37 @@ lemma length_eq_eVariationOn_extend (γ : Path a b) :
 /-- Auxiliary lemma: the affine map `t ↦ 2t` sends the left half
 of the unit interval onto `[0,1]`. -/
 private lemma image_double_Icc_half :
-    (fun t : I ↦ (2 : ℝ) * t) '' Icc (0 : I) half = Icc (0 : ℝ) 1 := by
+    (fun t : I ↦ (2 : ℝ) * t) '' Icc (0 : I) ((⟨(1 / 2 : ℝ), by norm_num⟩ : I))
+        = Icc (0 : ℝ) 1 := by
   rw [ContinuousOn.image_Icc_of_monotoneOn nonneg' (by fun_prop)
     (Subtype.mono_coe _ |>.const_mul zero_le_two |>.monotoneOn _)]
   simp
 
-/-- Auxiliary lemma: the variation of the left half of `γ.symm`
-is the variation of the right half of `γ`. -/
-private lemma eVariationOn_symm_Icc_left_half (γ : Path a b) :
-    eVariationOn γ.symm (Icc 0 half) = eVariationOn γ (Icc half 1) := by
-  rw [symm_eq_comp γ]
+/-- Auxiliary lemma: the arc length of the left half of `γ.symm`
+is the arc length of the right half of `γ`. -/
+private lemma arcLength_symm_left_half (γ : Path a b) :
+    arcLength γ.symm 0 ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) =
+      arcLength γ ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) 1 := by
+  rw [arcLength, symm_eq_comp γ]
   calc
-    _ = eVariationOn γ (σ '' Icc (0 : I) half) :=
+    _ = eVariationOn γ (σ '' Icc (0 : I) ((⟨(1 / 2 : ℝ), by norm_num⟩ : I))) :=
         eVariationOn.comp_eq_of_antitoneOn γ σ fun _ _ _ _ hxy => symm_le_symm.mpr hxy
-    _ = eVariationOn γ (Icc half 1) := by
+    _ = eVariationOn γ (Icc ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) 1) := by
         rw [ContinuousOn.image_Icc_of_antitoneOn nonneg'
-          ((unitInterval.continuous_symm.continuousOn : ContinuousOn σ (Icc 0 half)))
+          ((unitInterval.continuous_symm.continuousOn :
+            ContinuousOn σ (Icc 0 ((⟨(1 / 2 : ℝ), by norm_num⟩ : I))))
+          )
           (strictAnti_symm.antitone.antitoneOn _), symm_half, symm_zero]
+    _ = arcLength γ ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) 1 := by rw [arcLength]
 
 /-! ## Length of concatenations -/
-/-- Auxiliary lemma: the variation of a concatenation on its left half
+/-- Auxiliary lemma: the arc length of a concatenation on its left half
 is the length of the first path. -/
-private lemma eVariationOn_trans_left (γ : Path a b) (η : Path b c) :
-    eVariationOn (γ.trans η) (Icc 0 half) = γ.length := by
+private lemma arcLength_trans_left (γ : Path a b) (η : Path b c) :
+    arcLength (γ.trans η) 0 ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) = γ.length := by
   calc
-    _ = eVariationOn (γ.extend ∘ fun t : I ↦ 2 * t) (Icc 0 half) := by
+    _ = eVariationOn (γ.extend ∘ fun t : I ↦ 2 * t) (Icc 0 ((⟨(1 / 2 : ℝ), by norm_num⟩ : I))) := by
+          rw [arcLength]
           refine eVariationOn.congr fun t ht => ?_
           rw [Function.comp_apply, ← Path.extend_apply, Path.extend_trans_of_le_half γ η ht.2]
     _ = eVariationOn γ.extend (Icc 0 1) := by
@@ -122,23 +122,19 @@ private lemma eVariationOn_trans_left (γ : Path a b) (η : Path b c) :
             ((Subtype.mono_coe _ |>.const_mul zero_le_two |>.monotoneOn _)), image_double_Icc_half]
     _ = γ.length := (length_eq_eVariationOn_extend γ).symm
 
-/-- Auxiliary lemma: the variation of a concatenation on its right half
+/-- Auxiliary lemma: the arc length of a concatenation on its right half
 is the length of the second path. -/
-private lemma eVariationOn_trans_right (γ : Path a b) (η : Path b c) :
-    eVariationOn (γ.trans η) (Icc half 1) = η.length := by
-  calc
-    _ = eVariationOn (γ.trans η).symm (Icc 0 half) :=
-      (eVariationOn_symm_Icc_left_half (γ.trans η)).symm
-    _ = η.length := by
-      rw [← length_symm, Path.trans_symm]
-      exact eVariationOn_trans_left η.symm γ.symm
+private lemma arcLength_trans_right (γ : Path a b) (η : Path b c) :
+    arcLength (γ.trans η) ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) 1 = η.length := by
+  rw [← arcLength_symm_left_half (γ := γ.trans η), Path.trans_symm, ← length_symm]
+  exact arcLength_trans_left η.symm γ.symm
 
 /-- The length of a concatenation is the sum of the lengths of the two pieces. -/
 theorem length_trans (γ : Path a b) (η : Path b c) :
     (γ.trans η).length = γ.length + η.length := by
   rw [length_eq_eVariationOn, univ_eq_Icc, ← Icc_union_Icc_eq_Icc nonneg' le_one',
     eVariationOn.union _ (isGreatest_Icc nonneg') (isLeast_Icc le_one'),
-    eVariationOn_trans_left, eVariationOn_trans_right]
+    ← arcLength, arcLength_trans_left, ← arcLength, arcLength_trans_right]
 
 end
 

--- a/Mathlib/Topology/EMetricSpace/PathLength.lean
+++ b/Mathlib/Topology/EMetricSpace/PathLength.lean
@@ -44,33 +44,26 @@ def length (γ : Path a b) : ℝ≥0∞ :=
   arcLength γ 0 1
 
 /-- The length of a path agrees with the variation of its underlying map on `Set.univ`. -/
-theorem length_eq_eVariationOn (γ : Path a b) :
-    γ.length = eVariationOn γ univ := by
+theorem length_eq_eVariationOn (γ : Path a b) : γ.length = eVariationOn γ univ := by
   rw [length, arcLength, ← univ_eq_Icc]
 
 /-- The endpoint distance of a path is bounded above by its length. -/
-theorem edist_le_length (γ : Path a b) :
-    edist a b ≤ γ.length := by
+theorem edist_le_length (γ : Path a b) : edist a b ≤ γ.length := by
     simp_rw [length, ← γ.source, ← γ.target]
     exact edist_le_arcLength _ zero_le_one
 
 /-- The constant path has zero length. -/
 @[simp]
-theorem length_refl (x : E) :
-    (refl x).length = 0 :=
+theorem length_refl (x : E) : (refl x).length = 0 :=
   arcLength_eq_zero_of_constantOn (refl x) (a := 0) (b := 1) (by simp)
 
 /-- Reversing a path does not change its length. -/
 @[simp]
-theorem length_symm (γ : Path a b) :
-    γ.symm.length = γ.length := by
+theorem length_symm (γ : Path a b) : γ.symm.length = γ.length := by
   rw [length, length, symm_eq_comp γ,
     arcLength_comp_eq_of_antitoneOn _ _
       (strictAnti_symm.antitone.antitoneOn (Icc (0 : I) 1))
-      (by
-        rw [ContinuousOn.image_Icc_of_antitoneOn nonneg'
-          (unitInterval.continuous_symm.continuousOn : ContinuousOn σ (Icc (0 : I) 1))
-          (strictAnti_symm.antitone.antitoneOn (Icc (0 : I) 1))]),
+      (symm_image_Icc 0 1 nonneg'),
     symm_one, symm_zero]
 
 /-! ## Auxiliary lemmas for concatenation -/
@@ -78,7 +71,7 @@ theorem length_symm (γ : Path a b) :
 /-- The length of a path is the variation of its extension on `[0,1]`. -/
 lemma length_eq_eVariationOn_extend (γ : Path a b) :
     γ.length = eVariationOn γ.extend (Icc (0 : ℝ) 1) := by
-  rw [length_eq_eVariationOn, ← restrict_extend γ, eVariationOn.comp_eq_of_monotoneOn _ _
+  rw [length_eq_eVariationOn, ← extend_comp_subtype_val γ, eVariationOn.comp_eq_of_monotoneOn _ _
     ((Subtype.mono_coe _).monotoneOn univ), Subtype.coe_image_univ I]
 
 /-- Auxiliary lemma: the affine map `t ↦ 2t` sends the left half
@@ -86,28 +79,21 @@ of the unit interval onto `[0,1]`. -/
 private lemma image_double_Icc_half :
     (fun t : I ↦ (2 : ℝ) * t) '' Icc (0 : I) ((⟨(1 / 2 : ℝ), by norm_num⟩ : I))
         = Icc (0 : ℝ) 1 := by
-  rw [ContinuousOn.image_Icc_of_monotoneOn nonneg' (by fun_prop)
+  simp [ContinuousOn.image_Icc_of_monotoneOn nonneg' (by fun_prop)
     (Subtype.mono_coe _ |>.const_mul zero_le_two |>.monotoneOn _)]
-  simp
 
 /-- Auxiliary lemma: the arc length of the left half of `γ.symm`
 is the arc length of the right half of `γ`. -/
 private lemma arcLength_symm_left_half (γ : Path a b) :
     arcLength γ.symm 0 ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) =
       arcLength γ ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) 1 := by
-  rw [arcLength, symm_eq_comp γ]
-  calc
-    _ = eVariationOn γ (σ '' Icc (0 : I) ((⟨(1 / 2 : ℝ), by norm_num⟩ : I))) :=
-        eVariationOn.comp_eq_of_antitoneOn γ σ fun _ _ _ _ hxy => symm_le_symm.mpr hxy
-    _ = eVariationOn γ (Icc ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) 1) := by
-        rw [ContinuousOn.image_Icc_of_antitoneOn nonneg'
-          ((unitInterval.continuous_symm.continuousOn :
-            ContinuousOn σ (Icc 0 ((⟨(1 / 2 : ℝ), by norm_num⟩ : I))))
-          )
-          (strictAnti_symm.antitone.antitoneOn _), symm_half, symm_zero]
-    _ = arcLength γ ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) 1 := by rw [arcLength]
+  rw [arcLength, symm_eq_comp γ,
+    eVariationOn.comp_eq_of_antitoneOn γ σ fun _ _ _ _ hxy => symm_le_symm.mpr hxy,
+    symm_image_Icc 0 ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) nonneg', symm_half,
+    symm_zero, arcLength]
 
 /-! ## Length of concatenations -/
+
 /-- Auxiliary lemma: the arc length of a concatenation on its left half
 is the length of the first path. -/
 private lemma arcLength_trans_left (γ : Path a b) (η : Path b c) :

--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -153,6 +153,9 @@ def symm (γ : Path x y) : Path y x where
   source' := by simp
   target' := by simp
 
+/-- The reversed path is obtained by composing the original path with unit-interval symmetry. -/
+theorem symm_eq_comp (γ : Path x y) : ⇑γ.symm = ⇑γ ∘ σ := rfl
+
 @[simp]
 theorem symm_symm (γ : Path x y) : γ.symm.symm = γ := by grind
 
@@ -221,6 +224,10 @@ theorem extend_one : γ.extend 1 = y := by simp
 
 theorem extend_extends' {a b : X} (γ : Path a b) (t : (Icc 0 1 : Set ℝ)) : γ.extend t = γ t :=
   IccExtend_val _ γ t
+
+/-- Restricting `Path.extend` to the unit interval recovers the original path. -/
+theorem restrict_extend {a b : X} (γ : Path a b) :
+    γ.extend ∘ ((↑) : I → ℝ) = γ := funext fun t => extend_extends' γ t
 
 @[simp]
 theorem extend_range {a b : X} (γ : Path a b) :

--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -154,7 +154,7 @@ def symm (γ : Path x y) : Path y x where
   target' := by simp
 
 /-- The reversed path is obtained by composing the original path with unit-interval symmetry. -/
-theorem symm_eq_comp (γ : Path x y) : ⇑γ.symm = ⇑γ ∘ σ := rfl
+theorem symm_eq_comp (γ : Path x y) : γ.symm = γ ∘ σ := rfl
 
 @[simp]
 theorem symm_symm (γ : Path x y) : γ.symm.symm = γ := by grind
@@ -226,7 +226,7 @@ theorem extend_extends' {a b : X} (γ : Path a b) (t : (Icc 0 1 : Set ℝ)) : γ
   IccExtend_val _ γ t
 
 /-- Restricting `Path.extend` to the unit interval recovers the original path. -/
-theorem restrict_extend {a b : X} (γ : Path a b) :
+theorem extend_comp_subtype_val {a b : X} (γ : Path a b) :
     γ.extend ∘ ((↑) : I → ℝ) = γ := funext fun t => extend_extends' γ t
 
 @[simp]

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -87,7 +87,6 @@ theorem symm_one : σ 1 = 0 :=
 
 @[grind =]
 theorem symm_half : σ ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) = ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) := by
-  ext
   norm_num [symm]
 
 @[simp, grind =]
@@ -131,6 +130,10 @@ def symmHomeomorph : I ≃ₜ I where
 
 theorem strictAnti_symm : StrictAnti σ := fun _ _ h ↦ sub_lt_sub_left (α := ℝ) h _
 
+theorem symm_image_Icc (a b : I) (h : a ≤ b) : σ '' Icc a b = Icc (σ b) (σ a) :=
+  ContinuousOn.image_Icc_of_antitoneOn h
+    (continuous_symm.continuousOn : ContinuousOn σ (Icc a b))
+    (strictAnti_symm.antitone.antitoneOn (Icc a b))
 
 @[simp]
 theorem symm_inj {i j : I} : σ i = σ j ↔ i = j := symm_bijective.injective.eq_iff

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -85,6 +85,11 @@ theorem symm_zero : σ 0 = 1 :=
 theorem symm_one : σ 1 = 0 :=
   Subtype.ext <| by simp [symm]
 
+@[grind =]
+theorem symm_half : σ ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) = ((⟨(1 / 2 : ℝ), by norm_num⟩ : I)) := by
+  ext
+  norm_num [symm]
+
 @[simp, grind =]
 theorem symm_symm (x : I) : σ (σ x) = x :=
   Subtype.ext <| by simp [symm]


### PR DESCRIPTION
This PR defines the length of a path in a `PseudoEMetricSpace` as its variation on the unit interval.

It proves the basic properties of path length:
- the endpoint distance is bounded by the length;
- the constant path has length zero;
- reversing a path preserves its length;
- concatenating two paths adds their lengths.

Main declarations:
- `Path.length`
- `Path.edist_le_length`
- `Path.length_refl`
- `Path.length_symm`
- `Path.length_trans`

This is intended as a first step toward a broader theory of rectifiable paths, including later results on invariance of length under monotone reparametrization, and shortest paths are line segments up to monotone reparametrization in strict convex spaces.

This PR was discussed on Zulip [here](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/PR.20.2342110.3A.20Path.2Elength.20in.20PseudoEMetricSpace).

AI disclosure: I used an agent called ReasLingo to generate those codes. After the codes are generated I read them line by line and ask the agent to rewrite some proofs when I think it is a bad code. For design decisions, I asked the agent to give me several versions, and I manually picked one of them to make sure it fits human understanding.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
