### PR TITLE
[Merged by Bors] - fix(Tactic/NormDet): make norm_det proofs compatible with modules

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Cartan.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Cartan.lean
@@ -10,6 +10,7 @@ public import Mathlib.LinearAlgebra.Matrix.Notation
 public import Mathlib.GroupTheory.Perm.Cycle.Concrete
 public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 public import Mathlib.LinearAlgebra.Matrix.Symmetric
+import Mathlib.Tactic.NormDet
 
 /-!
 # Cartan matrices
@@ -257,16 +258,16 @@ theorem G₂_det : G₂.det = 1 := by decide
 
 theorem F₄_det : F₄.det = 1 := by decide
 
-/-! The determinants of E₆, E₇, E₈ are 3, 2, 1 respectively.
-`decide` fails for these larger matrices without increasing the max recursion depth.
-We could write manual proofs (e.g., expanding via `det_succ_column_zero`),
-but prefer to wait for a more principled determinant tactic. -/
+/-! The determinants of E₆, E₇, E₈ are 3, 2, 1 respectively. -/
 
-proof_wanted E₆_det : E₆.det = 3
+theorem E₆_det : E₆.det = 3 := by
+  simp only [E₆, norm_det]
 
-proof_wanted E₇_det : E₇.det = 2
+theorem E₇_det : E₇.det = 2 := by
+  simp only [E₇, norm_det]
 
-proof_wanted E₈_det : E₈.det = 1
+theorem E₈_det : E₈.det = 1 := by
+  simp only [E₈, norm_det]
 
 /-- A Cartan matrix is simply laced if its off-diagonal entries are all `0` or `-1`. -/
 def _root_.Matrix.IsSimplyLaced {ι : Type*} (A : Matrix ι ι ℤ) : Prop :=

--- a/Mathlib/Tactic/Determinant/Bird/Cert.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Cert.lean
@@ -318,10 +318,12 @@ partial def certIterStepEntry (t i j : ℕ) : CertM rα (Cert rα) := do
       --   sumFrom n (i + 1) fun k => F_t i k * get n A k j
       let tailSumCert ← certTail t' i j (i + 1)
       let rhsCert ← certAdd diagProdCert tailSumCert
+      let hStep := q(BirdDet.stepEntry_eq $dimLit $A $(ctx.iterStepEntry t') $i $j)
+      let stepCert := rhsCert.chainProof hStep
       let hIter := q(Function.iterate_succ_apply'
         (BirdDet.stepEntry $dimLit $A) $t' (BirdDet.get $dimLit $A))
       let h := q(congrArg (fun F : ℕ → ℕ → $α ↦ F $i $j) $hIter)
-      pure (rhsCert.chainProof h)
+      pure (stepCert.chainProof h)
   modify fun s =>
     {s with iterStepEntryCache := s.iterStepEntryCache.insert (t, i, j) cert}
   return cert

--- a/Mathlib/Tactic/Determinant/Bird/Cert.lean
+++ b/Mathlib/Tactic/Determinant/Bird/Cert.lean
@@ -235,9 +235,11 @@ def certEntry (i j : ℕ) : CertM rα (Cert rα) := do
   let idx := dim * i + j
   let entry := arrayEntries.getD idx q(0)
   let ce ← certEval entry
-  have : $lhs =Q $entry := ⟨⟩
-  let h : Q($lhs = $entry) := q(rfl)
-  let cert := ce.chainProof h
+  let getD : Q($α) := q(Array.getD $A ($dimLit * $i + $j) 0)
+  let hGet : Q($lhs = $getD) := q(BirdDet.get_eq $dimLit $A $i $j)
+  have : $getD =Q $entry := ⟨⟩
+  let hGetD : Q($getD = $entry) := q(rfl)
+  let cert := ce.chainProof q(Eq.trans $hGet $hGetD)
   modify fun s => {s with entryCache := s.entryCache.insert (i, j) cert}
   return cert
 

--- a/Mathlib/Tactic/NormDet.lean
+++ b/Mathlib/Tactic/NormDet.lean
@@ -31,12 +31,16 @@ private def normalizeBirdDet (e : Expr) : MetaM Simp.Result := do
 private def normalizeDetFromEntries {u : Level} {α : Q(Type u)} {n : Q(ℕ)} (rα : Q(CommRing $α))
   (A : Q(Matrix (Fin $n) (Fin $n) $α)) (entries : Array Q($α)) :
     MetaM Simp.Result := do
-  let arrayExpr : Q(Array $α) ← mkArrayLit α entries.toList
-  let hA ← mkDecideProofQ q(Array.size $arrayExpr = $n * $n)
-  have : $arrayExpr =Q Array.ofFn fun k : Fin ($n * $n) ↦ $A k.divNat k.modNat := ⟨⟩
-  let ofArrayEqA := q(Matrix.ofArray_ofFn $A)
+  let xs : Q(List $α) ← mkListLit α entries.toList
+  let arrayExpr : Q(Array $α) := q(List.toArray $xs)
+  -- `List.ofFn` is exposed (unlike `Array.ofFn`) and so this reduction can be
+  -- checked by the kernel
+  have : (List.ofFn fun k : Fin ($n * $n) ↦ $A k.divNat k.modNat) =Q $xs := ⟨⟩
+  let hlist : Q(List.ofFn (fun k : Fin ($n * $n) ↦ $A k.divNat k.modNat) = $xs) := q(rfl)
+  let hArray := q($hlist ▸ List.toArray_ofFn)
   let birdDet := q(BirdDet.birdDet $n $arrayExpr)
-  let detEqBirdDet := q($ofArrayEqA ▸ BirdDet.det_eq_birdDet $arrayExpr $hA)
+  let detEqBirdDet := q($hArray ▸ Matrix.ofArray_ofFn $A ▸ BirdDet.det_eq_birdDet
+    (Array.ofFn fun k : Fin ($n * $n) ↦ $A k.divNat k.modNat) Array.size_ofFn)
   let birdDetNorm ← normalizeBirdDet birdDet
   let detEqBirdDetRes : Simp.Result := ⟨birdDet, some detEqBirdDet, true⟩
   detEqBirdDetRes.mkEqTrans birdDetNorm

--- a/Mathlib/Tactic/NormDet.lean
+++ b/Mathlib/Tactic/NormDet.lean
@@ -6,7 +6,7 @@ Authors: Paul Cadman
 module
 
 public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
-meta import Mathlib.LinearAlgebra.Matrix.Determinant.Bird.Correctness
+public import Mathlib.LinearAlgebra.Matrix.Determinant.Bird.Correctness
 public meta import Mathlib.Tactic.Determinant.Bird.Cert
 
 /-!

--- a/MathlibTest/matrix.lean
+++ b/MathlibTest/matrix.lean
@@ -1,7 +1,11 @@
+module
+
 /-
 manually ported from
 https://github.com/leanprover-community/mathlib/blob/4f4a1c875d0baa92ab5d92f3fb1bb258ad9f3e5b/test/matrix.lean
 -/
+
+public import Lean
 import Mathlib.GroupTheory.Perm.Fin
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.Determinant.Bird.Defs
@@ -9,11 +13,11 @@ import Mathlib.LinearAlgebra.Matrix.Notation
 import Mathlib.RingTheory.Polynomial.Basic
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.NormDet
-import Qq
+meta import Mathlib.Data.Fin.VecNotation
+meta import Mathlib.Data.Matrix.Basic
+meta import Qq
 
 open Qq
-
-variable {α β : Type} [Semiring α] [Ring β]
 
 namespace Matrix
 
@@ -113,6 +117,8 @@ section delaborators
 #guard_msgs in #check (!![] : Matrix (Fin 0) (Fin 0) ℕ)
 
 end delaborators
+
+variable {α β : Type} [Semiring α] [Ring β]
 
 example {a a' b b' c c' d d' : α} :
   !![a, b; c, d] + !![a', b'; c', d'] = !![a + a', b + b'; c + c', d + d'] := by


### PR DESCRIPTION
The proofs produced by the `norm_det` / `eval_det` simproc (added in #42059) could not be checked from within a `module` because the generated proofs depended on kernel checking of equalities for definitions (`Array.ofFn`, and `certEntry`, `certIterStepEntry` from the Bird determinant certificate evaluator) which are not exposed. The existing tests in `MathlibTest/matrix.lean` did not detect this issue because it was not a `module` itself.

This PR:

* Fixes the issues resulting from non-exposed definitions
* Makes the `MathlibTest/matrix.lean` file into a module
* Adds proofs for the determinants of Cartan matrices `LinearAlgebra/Matrix/Cartan` using `norm_det` - showing that the simrproc can be used in mathlib modules.

The function `normalizeDetFromEntries` generated a proof which related the matrix array literal to  `Array.ofFn fun k => A k.divNat k.modNat` by an unchecked `=Q` equality. This cannot be checked by the kernel because `Array.ofFn` is not exposed. The solution here is to use `List.ofFn` instead, which is exposed.

Similarly, the functions `certEntry` and `certIterStepEntry` in the Bird determinant certificate evaluator relied on definitional unfolding of `BirdDet.get` and `BirdDet.stepEntry` which are not exposed. The generated proofs now use the unfolding lemmas `BirdDet.get_eq` and `BirdDet.stepEntry_eq` instead.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
