### PR TITLE
perf(NumberTheory/NumberField): use show/from inferInstance for InfiniteAdeleRing instances

### DIFF
--- a/Mathlib/NumberTheory/NumberField/InfiniteAdeleRing.lean
+++ b/Mathlib/NumberTheory/NumberField/InfiniteAdeleRing.lean
@@ -50,11 +50,34 @@ infinite places. See `NumberField.InfinitePlace` for the definition of an infini
 
 /-- The infinite adele ring of a number field. -/
 def InfiniteAdeleRing (K : Type*) [Field K] := (v : InfinitePlace K) → v.Completion
-deriving CommRing, Inhabited, TopologicalSpace, IsTopologicalRing, Algebra K
 
 namespace InfiniteAdeleRing
 
 variable (K : Type*) [Field K]
+
+/- The algebraic and topological instances are given by `show … from inferInstance` on the
+underlying pi type rather than `deriving` or `inferInstanceAs`.
+`deriving` and `inferInstanceAs` both emit machine-generated `_aux_*` field definitions that
+are opaque to instance-implicit unification at `instances` transparency, forcing downstream
+`set_option backward.isDefEq.respectTransparency false` workarounds.
+With `show CommRing ((v : InfinitePlace K) → v.Completion) from inferInstance` the instance
+body is definitionally the pi instance (no structure re-packing), so operations unfold at
+`instances` transparency. See #42057. -/
+
+instance : CommRing (InfiniteAdeleRing K) :=
+  show CommRing ((v : InfinitePlace K) → v.Completion) from inferInstance
+
+instance : Inhabited (InfiniteAdeleRing K) :=
+  show Inhabited ((v : InfinitePlace K) → v.Completion) from inferInstance
+
+instance : TopologicalSpace (InfiniteAdeleRing K) :=
+  show TopologicalSpace ((v : InfinitePlace K) → v.Completion) from inferInstance
+
+instance : IsTopologicalRing (InfiniteAdeleRing K) :=
+  show IsTopologicalRing ((v : InfinitePlace K) → v.Completion) from inferInstance
+
+instance : Algebra K (InfiniteAdeleRing K) :=
+  show Algebra K ((v : InfinitePlace K) → v.Completion) from inferInstance
 
 instance [NumberField K] : Nontrivial (InfiniteAdeleRing K) :=
   (inferInstance : Nonempty (InfinitePlace K)).elim fun w => Pi.nontrivial_at w


### PR DESCRIPTION
Replace `deriving CommRing, …` on `InfiniteAdeleRing` with explicit
`show … from inferInstance` instances over the underlying pi type.

Closes #42057.

## Why

`deriving` on this def-synonym emits machine-generated `_aux_*` field
definitions that are opaque to instance-implicit unification at `instances`
transparency (the default since Lean v4.29). Downstream (FLT) then needs

```
set_option backward.isDefEq.respectTransparency false
```

to prove goals like `f i * g i =?= instCommRingInfiniteAdeleRing._aux_13 K f g i`.
Tagging individual `_aux_*` defs `@[implicit_reducible]` is not viable: the
names are unstable and fixing one only shifts the failure to the next.

`inferInstanceAs` alone is also insufficient: it still elaborates through
generated field helpers that stay opaque at `instances` transparency.
With `show CommRing ((v : InfinitePlace K) → v.Completion) from inferInstance`,
the instance body is definitionally the pi instance (no structure re-packing),
so operations unfold at `instances` transparency. Existing `rfl` lemmas in the
same file (e.g. `algebraMap_apply`) remain a canary that defeq is preserved.

## Change

In `Mathlib/NumberTheory/NumberField/InfiniteAdeleRing.lean`:

- drop `deriving CommRing, Inhabited, TopologicalSpace, IsTopologicalRing, Algebra K`
- add five explicit instances via `show … from inferInstance` on the pi type

Blast radius is two modules: `InfiniteAdeleRing` and its sole importer `AdeleRing`.

## Local verification

- `lake exe lint-style` on the touched file: exit 0
- scoped `lake build Mathlib.NumberTheory.NumberField.InfiniteAdeleRing Mathlib.NumberTheory.NumberField.AdeleRing`: exit 0
- MetaM defeq canary for pointwise multiplication
  `(f * g) i` vs `f i * g i` on `InfiniteAdeleRing ℚ`:

  | transparency | base (`deriving`, origin/master) | HEAD (`show … from inferInstance`) |
  |---|---|---|
  | reducible | false | false |
  | **instances** | **false** | **true** |
  | default | true | true |
  | all | true | true |

  Full mathlib matrix left to remote CI (`build_fork.yml`).

---

### AI / tooling disclosure

- Diagnosis of the `_aux_*` opacity and the instance-fix shape: Claude
  (Claude Code session) + downstream FLT evidence
  (ImperialCollegeLondon/FLT#1132 / #889).
- Patch drafting (`inferInstanceAs` then `show … from inferInstance` after
  canary showed the former insufficient), gate loop, rebase onto current
  `master`, PR body assembly: Grok (xAI) after Claude hit weekly quota mid-gate.
- Autoreview / strong review engines: per the review-history gist below
  (cascade + local_clawsweeper).
- No LLM-written GitHub/Zulip comments beyond this PR description (mathlib policy).

Review history gist: https://gist.github.com/anagnorisis2peripeteia/69bc525a6ffeeac48be3215677aa72b0
