### PR TITLE
[Merged by Bors] - feat(Analysis/InnerProductSpace/Adjoint): characterize least-squares minimizers

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -202,6 +202,20 @@ theorem orthogonal_range (T : E →L[𝕜] F) : T.rangeᗮ = T†.ker := by
   rw [← T†.ker.orthogonal_orthogonal, T†.orthogonal_ker]
   simp
 
+/-- The fitted value `A x` minimizes the distance to `y` among points in `A.range`
+if and only if the adjoint of `A` sends the residual `y - A x` to zero. -/
+theorem norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero
+    (A : E →L[𝕜] F) (y : F) (x : E) :
+    (‖y - A x‖ = ⨅ z : A.range, ‖y - z‖) ↔ (A†) (y - A x) = 0 := by
+  -- The fitted value belongs to the range of `A`, with preimage `x`.
+  have hx : A x ∈ A.range := ⟨x, rfl⟩
+  -- Rewrite minimization as orthogonality, then as membership in the kernel
+  -- of the adjoint, and finally as the adjoint sending the residual to zero.
+  rw [A.range.norm_eq_iInf_iff_inner_eq_zero hx,
+    ← Submodule.mem_orthogonal', A.orthogonal_range, LinearMap.mem_ker]
+  -- These expressions differ only by the coercion to an underlying linear map.
+  rfl
+
 omit [CompleteSpace E] in
 theorem ker_le_ker_iff_range_le_range [FiniteDimensional 𝕜 E] {T U : E →L[𝕜] E}
     (hT : T.IsSymmetric) (hU : U.IsSymmetric) :

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -204,8 +204,7 @@ theorem orthogonal_range (T : E →L[𝕜] F) : T.rangeᗮ = T†.ker := by
 
 /-- The fitted value `A x` minimizes the distance to `y` among points in `A.range`
 if and only if the adjoint of `A` sends the residual `y - A x` to zero. -/
-theorem norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero
-    (A : E →L[𝕜] F) (y : F) (x : E) :
+theorem norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero (A : E →L[𝕜] F) (y : F) (x : E) :
     (‖y - A x‖ = ⨅ z : A.range, ‖y - z‖) ↔ (A†) (y - A x) = 0 := by
   rw [A.range.norm_eq_iInf_iff_inner_eq_zero (by simp),
     ← Submodule.mem_orthogonal', A.orthogonal_range, LinearMap.mem_ker, coe_coe, map_sub]

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -214,18 +214,11 @@ the adjoint of `A` sends the residual `y - A x` to zero. -/
 theorem forall_norm_sub_apply_le_iff_adjoint_apply_sub_eq_zero
     (A : E →L[𝕜] F) (y : F) (x : E) :
     (∀ z : E, ‖y - A x‖ ≤ ‖y - A z‖) ↔ (A†) (y - A x) = 0 := by
-  have residual_norms_bddBelow : BddBelow (Set.range fun w : A.range => ‖y - w‖) :=
+  have hb : BddBelow (Set.range fun w : A.range => ‖y - w‖) :=
     ⟨0, Set.forall_mem_range.mpr fun _ => norm_nonneg _⟩
-  rw [← A.norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero y x]
-  constructor
-  · intro h
-    apply le_antisymm
-    · apply le_ciInf
-      simpa
-    · exact ciInf_le residual_norms_bddBelow ⟨A x, ⟨x, rfl⟩⟩
-  · intro h z
-    rw [h]
-    exact ciInf_le residual_norms_bddBelow ⟨A z, ⟨z, rfl⟩⟩
+  rw [← A.norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero y x, le_antisymm_iff,
+    and_iff_left (ciInf_le hb ⟨A x, x, rfl⟩), le_ciInf_iff hb]
+  simp
 
 omit [CompleteSpace E] in
 theorem ker_le_ker_iff_range_le_range [FiniteDimensional 𝕜 E] {T U : E →L[𝕜] E}

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -207,44 +207,24 @@ if and only if the adjoint of `A` sends the residual `y - A x` to zero. -/
 theorem norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero
     (A : E →L[𝕜] F) (y : F) (x : E) :
     (‖y - A x‖ = ⨅ z : A.range, ‖y - z‖) ↔ (A†) (y - A x) = 0 := by
-  -- The fitted value belongs to the range of `A`, with preimage `x`.
-  have hx : A x ∈ A.range := ⟨x, rfl⟩
-  -- Rewrite minimization as orthogonality, then as membership in the kernel
-  -- of the adjoint, and finally as the adjoint sending the residual to zero.
-  rw [A.range.norm_eq_iInf_iff_inner_eq_zero hx,
-    ← Submodule.mem_orthogonal', A.orthogonal_range, LinearMap.mem_ker]
-  -- These expressions differ only by the coercion to an underlying linear map.
-  rfl
+  rw [A.range.norm_eq_iInf_iff_inner_eq_zero (by simp),
+    ← Submodule.mem_orthogonal', A.orthogonal_range, LinearMap.mem_ker, coe_coe, map_sub]
 
 /-- The residual norm at `x` is minimal among all points of `E` if and only if
 the adjoint of `A` sends the residual `y - A x` to zero. -/
 theorem forall_norm_sub_apply_le_iff_adjoint_apply_sub_eq_zero
     (A : E →L[𝕜] F) (y : F) (x : E) :
     (∀ z : E, ‖y - A x‖ ≤ ‖y - A z‖) ↔ (A†) (y - A x) = 0 := by
-  -- Residual norms are bounded below by zero. This fact lets us compare their
-  -- conditional infimum with any particular residual norm.
-  have residual_norms_bddBelow :
-      BddBelow (Set.range fun w : A.range => ‖y - w‖) :=
+  have residual_norms_bddBelow : BddBelow (Set.range fun w : A.range => ‖y - w‖) :=
     ⟨0, Set.forall_mem_range.mpr fun _ => norm_nonneg _⟩
-  -- Rewrite the adjoint equation as minimization over `A.range`.
   rw [← A.norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero y x]
   constructor
   · intro h
     apply le_antisymm
-    · -- The hypothesis makes the residual at `x` a lower bound for all
-      -- residuals coming from points in `A.range`.
-      apply le_ciInf
-      intro w
-      -- Since `w` belongs to `A.range`, it equals `A z` for some `z : E`.
-      obtain ⟨z, hz⟩ := w.property
-      rw [← hz]
-      exact h z
-    · -- The infimum is at most the residual at the particular range point
-      -- `A x`.
-      exact ciInf_le residual_norms_bddBelow ⟨A x, ⟨x, rfl⟩⟩
+    · apply le_ciInf
+      simpa
+    · exact ciInf_le residual_norms_bddBelow ⟨A x, ⟨x, rfl⟩⟩
   · intro h z
-    -- The fitted value `A z` is an admissible point of `A.range`, so its
-    -- residual norm is at least the infimum.
     rw [h]
     exact ciInf_le residual_norms_bddBelow ⟨A z, ⟨z, rfl⟩⟩
 

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -207,7 +207,7 @@ if and only if the adjoint of `A` sends the residual `y - A x` to zero. -/
 theorem norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero (A : E →L[𝕜] F) (y : F) (x : E) :
     (‖y - A x‖ = ⨅ z : A.range, ‖y - z‖) ↔ (A†) (y - A x) = 0 := by
   rw [A.range.norm_eq_iInf_iff_inner_eq_zero (by simp),
-    ← Submodule.mem_orthogonal', A.orthogonal_range, LinearMap.mem_ker, coe_coe, map_sub]
+    ← Submodule.mem_orthogonal', A.orthogonal_range, LinearMap.mem_ker, coe_coe]
 
 /-- The residual norm at `x` is minimal among all points of `E` if and only if
 the adjoint of `A` sends the residual `y - A x` to zero. -/

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -216,6 +216,38 @@ theorem norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero
   -- These expressions differ only by the coercion to an underlying linear map.
   rfl
 
+/-- The residual norm at `x` is minimal among all points of `E` if and only if
+the adjoint of `A` sends the residual `y - A x` to zero. -/
+theorem forall_norm_sub_apply_le_iff_adjoint_apply_sub_eq_zero
+    (A : E →L[𝕜] F) (y : F) (x : E) :
+    (∀ z : E, ‖y - A x‖ ≤ ‖y - A z‖) ↔ (A†) (y - A x) = 0 := by
+  -- Residual norms are bounded below by zero. This fact lets us compare their
+  -- conditional infimum with any particular residual norm.
+  have residual_norms_bddBelow :
+      BddBelow (Set.range fun w : A.range => ‖y - w‖) :=
+    ⟨0, Set.forall_mem_range.mpr fun _ => norm_nonneg _⟩
+  -- Rewrite the adjoint equation as minimization over `A.range`.
+  rw [← A.norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero y x]
+  constructor
+  · intro h
+    apply le_antisymm
+    · -- The hypothesis makes the residual at `x` a lower bound for all
+      -- residuals coming from points in `A.range`.
+      apply le_ciInf
+      intro w
+      -- Since `w` belongs to `A.range`, it equals `A z` for some `z : E`.
+      obtain ⟨z, hz⟩ := w.property
+      rw [← hz]
+      exact h z
+    · -- The infimum is at most the residual at the particular range point
+      -- `A x`.
+      exact ciInf_le residual_norms_bddBelow ⟨A x, ⟨x, rfl⟩⟩
+  · intro h z
+    -- The fitted value `A z` is an admissible point of `A.range`, so its
+    -- residual norm is at least the infimum.
+    rw [h]
+    exact ciInf_le residual_norms_bddBelow ⟨A z, ⟨z, rfl⟩⟩
+
 omit [CompleteSpace E] in
 theorem ker_le_ker_iff_range_le_range [FiniteDimensional 𝕜 E] {T U : E →L[𝕜] E}
     (hT : T.IsSymmetric) (hU : U.IsSymmetric) :

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -204,7 +204,7 @@ theorem orthogonal_range (T : E →L[𝕜] F) : T.rangeᗮ = T†.ker := by
 
 /-- The fitted value `A x` minimizes the distance to `y` among points in `A.range`
 if and only if the adjoint of `A` sends the residual `y - A x` to zero. -/
-theorem norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero (A : E →L[𝕜] F) (y : F) (x : E) :
+theorem norm_eq_iInf_range_iff_adjoint_apply_eq_zero (A : E →L[𝕜] F) (y : F) (x : E) :
     (‖y - A x‖ = ⨅ z : A.range, ‖y - z‖) ↔ (A†) (y - A x) = 0 := by
   rw [A.range.norm_eq_iInf_iff_inner_eq_zero (by simp),
     ← Submodule.mem_orthogonal', A.orthogonal_range, LinearMap.mem_ker, coe_coe]
@@ -214,9 +214,8 @@ the adjoint of `A` sends the residual `y - A x` to zero. -/
 theorem forall_norm_sub_apply_le_iff_adjoint_apply_sub_eq_zero
     (A : E →L[𝕜] F) (y : F) (x : E) :
     (∀ z : E, ‖y - A x‖ ≤ ‖y - A z‖) ↔ (A†) (y - A x) = 0 := by
-  have hb : BddBelow (Set.range fun w : A.range => ‖y - w‖) :=
-    ⟨0, Set.forall_mem_range.mpr fun _ => norm_nonneg _⟩
-  rw [← A.norm_sub_apply_eq_iInf_iff_adjoint_apply_sub_eq_zero y x, le_antisymm_iff,
+  have hb : BddBelow (Set.range fun w : A.range => ‖y - w‖) := ⟨0, by rintro - ⟨_, rfl⟩; positivity⟩
+  rw [← A.norm_eq_iInf_range_iff_adjoint_apply_eq_zero y x, le_antisymm_iff,
     and_iff_left (ciInf_le hb ⟨A x, x, rfl⟩), le_ciInf_iff hb]
   simp
 


### PR DESCRIPTION
This PR adds two theorems about least-squares minimizers for a continuous linear map `A`. 

The first theorem states that the fitted value `A x` minimizes the distance to `y` over `A.range` if and only if the adjoint maps the residual `y - A x` to zero. 

The second theorem restates the result in coefficient-space. That is, `x` minimizes `‖y - A z‖` over all `z : E` if and only if the same adjoint condition holds. This result is useful because it makes the range-level characterization applicable for least-squares problems (which are often stated in terms of coefficients).

These results provide a characterization of least-squares minimizers. The theorems use the existing APIs for range, orthogonal-complement, and adjoints. The PR adds them to `Mathlib/Analysis/InnerProductSpace/Adjoint.lean`. 

These results were added to `Mathlib/Analysis/InnerProductSpace/Adjoint.lean` because a least-squares residual is orthogonal to `A.range`, while the orthogonal complement of `A.range` is the kernel of the adjoint.

---

### Motivation

These lemmas are an early step toward implementing theory of least squares in mathlib. Least squares is a foundational, workhorse method in statistics that underlies linear regression. For example, least squares is used to estimate coefficients from noisy data. These lemmas connect the least square optimization problem to mathlib’s Hilbert-space geometry. This provides a foundation for later results. 

### LLM disclosure

For theorem planning and Lean implementation, I used OpenAI Codex substantially. I also used it for suggestions around naming and documentation, for iterating on the proofs, and for validating my commits locally. 

I manually searched for the best locations and earlier results to build upon. I personally reviewed both the mathematical statements and Lean code (line-by-line), as well as the suggestions around naming and API choices. I also reviewed and confirmed that I can explain each step of the two theorems' proofs.

To validate the change, I directly compiled the modified file and ran a targeted build of `Mathlib.Analysis.InnerProductSpace.Adjoint`. Then I ran the style linter, and completed a full `lake build` and a full `lake test`.

Please note: This is my first Mathlib contribution. I welcome corrections or suggestions about all aspects of this PR. I'm prepared to revise it as necessary, and to learn from the review. 