### PR TITLE
refactor(NumberTheory/NumberField): transparent product instances for InfiniteAdeleRing

### DIFF
--- a/Mathlib/NumberTheory/NumberField/InfiniteAdeleRing.lean
+++ b/Mathlib/NumberTheory/NumberField/InfiniteAdeleRing.lean
@@ -48,13 +48,33 @@ infinite places. See `NumberField.InfinitePlace` for the definition of an infini
 `NumberField.InfinitePlace.Completion` for the associated completion.
 -/
 
-/-- The infinite adele ring of a number field. -/
+/-- The infinite adele ring of a number field.
+
+Kept as a semi-reducible `def` (not an `abbrev`) so the custom adelic product `Norm`
+below is not competed with by the pi/sup-norm hierarchy from `NormedField` on each
+completion. Algebraic and topological structure is still the underlying product: the
+instances use `show … from inferInstance` so they are definitionally the pi instances
+(needed at `instances` transparency since Lean v4.29). See #42057. -/
 def InfiniteAdeleRing (K : Type*) [Field K] := (v : InfinitePlace K) → v.Completion
-deriving CommRing, Inhabited, TopologicalSpace, IsTopologicalRing, Algebra K
 
 namespace InfiniteAdeleRing
 
 variable (K : Type*) [Field K]
+
+instance : CommRing (InfiniteAdeleRing K) :=
+  show CommRing ((v : InfinitePlace K) → v.Completion) from inferInstance
+
+instance : Inhabited (InfiniteAdeleRing K) :=
+  show Inhabited ((v : InfinitePlace K) → v.Completion) from inferInstance
+
+instance : TopologicalSpace (InfiniteAdeleRing K) :=
+  show TopologicalSpace ((v : InfinitePlace K) → v.Completion) from inferInstance
+
+instance : IsTopologicalRing (InfiniteAdeleRing K) :=
+  show IsTopologicalRing ((v : InfinitePlace K) → v.Completion) from inferInstance
+
+instance : Algebra K (InfiniteAdeleRing K) :=
+  show Algebra K ((v : InfinitePlace K) → v.Completion) from inferInstance
 
 instance [NumberField K] : Nontrivial (InfiniteAdeleRing K) :=
   (inferInstance : Nonempty (InfinitePlace K)).elim fun w => Pi.nontrivial_at w


### PR DESCRIPTION
Keep `InfiniteAdeleRing` as a semi-reducible `def`, but make its **algebraic and topological** instances definitionally the underlying pi instances.

Closes #42057.

## Why

With `deriving CommRing` on a `def` synonym, ring operations are packed behind machine-generated `_aux_*` fields that are opaque at `instances` transparency (default since Lean v4.29). Downstream code (e.g. ImperialCollegeLondon/FLT) then needs

```lean
set_option backward.isDefEq.respectTransparency false
```

for goals such as pointwise multiplication on the product.

### What we are *not* doing

| Approach | Problem |
|---|---|
| `abbrev InfiniteAdeleRing` | Exposes the full pi/`NormedField` hierarchy (sup norm). This file installs a **custom adelic product `Norm`** (`∏ v, ‖x v‖ ^ v.mult`); an `abbrev` creates a diamond between that norm and `Pi.normed*`. |
| `inferInstanceAs` alone | Still elaborates to `_aux_*` fields; MetaM canary stays red at `instances`. |
| Closed #42120 (same instance shape without this write-up) | Rejected as “leaky” without stating the **norm boundary** reason for keeping a `def`. |

### What we are doing

- Keep the **type** semi-reducible (`def`) so `Normed*` does not inherit through pi.
- Install only **selected** instances via `show … from inferInstance`:  
  `CommRing`, `Inhabited`, `TopologicalSpace`, `IsTopologicalRing`, `Algebra`.
- Leave the existing product `Norm` instance as the sole norm API.

## Change

`Mathlib/NumberTheory/NumberField/InfiniteAdeleRing.lean` only.

## Local verification

MetaM canary: `(f * g) i` vs `f i * g i` on `InfiniteAdeleRing ℚ`

| transparency | master (`def`+`deriving`) | this PR |
|---|---|---|
| reducible | false | false |
| **instances** | **false** | **true** |
| default | true | true |
| all | true | true |

- `#print instCommRing` → `have this := inferInstance; this` (no `_aux_*`)
- `‖x‖ = ∏ v, ‖x v‖ ^ v.mult` still holds (`norm_def`)
- `lake build Mathlib.NumberTheory.NumberField.InfiniteAdeleRing Mathlib.NumberTheory.NumberField.AdeleRing`: exit 0
- full matrix: remote CI

## Follow-up (not this PR)

After merge + FLT mathlib bump: drop infinite-adele / adele-product `set_option backward.isDefEq.respectTransparency false` sites that this unblocks. Other FLT hatches (Hecke, QHat, …) are separate roots.

---

### AI / tooling disclosure

- Experiments and patch: Grok (xAI), building on an earlier Claude FLT/mathlib session and review feedback on #42120 (Robin Carlier: type synonym / instance design; strong review: prefer opaque type + selected transparent algebraic instances over `abbrev`).
- Autoreview / local ClawSweeper: see review-history gist.

Review history gist: https://gist.github.com/0ff8fc1d7fc16828b04b942bdf121e84
