### PR TITLE
feat(Combinatorics/SimpleGraph): the supersaturation theorem

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3669,6 +3669,7 @@ public import Mathlib.Combinatorics.SimpleGraph.Ends.Defs
 public import Mathlib.Combinatorics.SimpleGraph.Ends.Properties
 public import Mathlib.Combinatorics.SimpleGraph.Extremal.Basic
 public import Mathlib.Combinatorics.SimpleGraph.Extremal.ErdosStoneSimonovits
+public import Mathlib.Combinatorics.SimpleGraph.Extremal.Supersaturation
 public import Mathlib.Combinatorics.SimpleGraph.Extremal.Turan
 public import Mathlib.Combinatorics.SimpleGraph.Extremal.TuranDensity
 public import Mathlib.Combinatorics.SimpleGraph.Extremal.Zarankiewicz

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Order.Group.Nat
 public import Mathlib.Combinatorics.SimpleGraph.Subgraph
+public import Mathlib.Data.Fintype.CardEmbedding
 
 /-!
 # Containment of graphs
@@ -502,12 +503,20 @@ in `H`.
 -/
 
 section LabelledCopyCount
-variable [Fintype V] [Fintype W]
+
+variable [Fintype V] [Fintype W] [Fintype X]
 
 /-- `G.labelledCopyCount H` is the number of labelled copies of `H` in `G`, i.e. the number of graph
 embeddings from `H` to `G`. See `SimpleGraph.copyCount` for the number of unlabelled copies. -/
 noncomputable def labelledCopyCount (G : SimpleGraph V) (H : SimpleGraph W) : ℕ := by
   classical exact Fintype.card (Copy H G)
+
+/-- Swap the `classical` fintype instance in `labelledCopyCount` for an explicit fintype
+instance. -/
+theorem labelledCopyCount_eq_card_copy [Fintype (Copy H G)] :
+    G.labelledCopyCount H = card (Copy H G) := by
+  rw [labelledCopyCount]
+  convert rfl
 
 @[simp] lemma labelledCopyCount_of_isEmpty [IsEmpty W] (G : SimpleGraph V) (H : SimpleGraph W) :
     G.labelledCopyCount H = 1 := by
@@ -519,6 +528,60 @@ noncomputable def labelledCopyCount (G : SimpleGraph V) (H : SimpleGraph W) : �
 
 @[simp] lemma labelledCopyCount_pos : 0 < G.labelledCopyCount H ↔ H ⊑ G := by
   simp [labelledCopyCount, IsContained, Fintype.card_pos_iff]
+
+/-- `labelledCopyCount` is invariant under isomorphism of the host graph. -/
+theorem labelledCopyCount_congr_left (f : G ≃g H) :
+    G.labelledCopyCount I = H.labelledCopyCount I := by
+  classical simp_rw [labelledCopyCount_eq_card_copy, Fintype.card_eq]
+  exact ⟨⟨fun c ↦ f.toCopy.comp c, fun c ↦ f.symm.toCopy.comp c,
+    fun c ↦ by ext; simp, fun c ↦ by ext; simp⟩⟩
+
+/-- `labelledCopyCount` is invariant under isomorphism of the copied graph. -/
+theorem labelledCopyCount_congr_right (f : H ≃g I) :
+    G.labelledCopyCount H = G.labelledCopyCount I := by
+  classical simp_rw [labelledCopyCount_eq_card_copy, Fintype.card_eq]
+  exact ⟨⟨fun c ↦ c.comp f.symm.toCopy, fun c ↦ c.comp f.toCopy,
+    fun c ↦ by ext; simp, fun c ↦ by ext; simp⟩⟩
+
+/-- The number of labelled copies of `⊥` in `G` is the number of injections from `W` to the
+vertices of `G`. -/
+theorem labelledCopyCount_bot (G : SimpleGraph V) :
+    G.labelledCopyCount (⊥ : SimpleGraph W) = (card V).descFactorial (card W) := by classical
+  rw [labelledCopyCount_eq_card_copy, ← Fintype.card_embedding_eq]
+  exact Fintype.card_congr ⟨Copy.toEmbedding, Copy.bot, fun f ↦ Copy.ext fun w ↦ rfl, fun f ↦ rfl⟩
+
+variable [DecidableEq V] [Fintype (Copy H G)]
+
+omit [Fintype V] in
+/-- The number of copies of `H` in the induced subgraph of `G` by `s` is equal to the number of
+copies of `H` in `G` with vertices in `s`. -/
+theorem labelledCopyCount_induce_eq_card_filter_copy (s : Finset V) :
+    (G.induce s).labelledCopyCount H
+      = #{f : Copy H G | univ.map f.toEmbedding ⊆ s} := by classical
+  rw [labelledCopyCount_eq_card_copy]
+  refine card_bij' (fun f _ ↦ (Copy.induce G s).comp f)
+    (fun f hf ↦ ⟨⟨fun w ↦ ⟨f w, ((mem_filter_univ f).mp hf) <|
+        mem_map_of_mem f.toEmbedding (mem_univ w)⟩, f.toHom.map_adj⟩,
+      fun _ _ h ↦ f.injective (Subtype.val_inj.mpr h)⟩)
+    (fun u hu ↦ by simp [subset_iff, Copy.induce, Copy.toEmbedding])
+    (fun _ _ ↦ mem_univ _)
+    (fun u hu ↦ by simp [Copy.ext_iff, Copy.induce])
+    (fun u hu ↦ Copy.ext_iff.mpr (fun _ ↦ by rfl))
+
+omit [Fintype V] in
+/-- The number of copies of `H` in the induced subgraph of `G` by `s` is equal to the number of
+copies of `H` in `G` with vertices in `s`. -/
+theorem labelledCopyCount_induce_eq_card_subtype_copy (s : Finset V) :
+    (G.induce s).labelledCopyCount H
+      = card {f : Copy H G // univ.map f.toEmbedding ⊆ s} := by
+  rw [labelledCopyCount_induce_eq_card_filter_copy,
+    ← card_univ, ← subtype_univ, card_subtype]
+
+omit [DecidableEq V] [Fintype (Copy H G)] in
+theorem labelledCopyCount_induce_le (s : Finset V) :
+    (G.induce s).labelledCopyCount H ≤ G.labelledCopyCount H := by classical
+  rw [labelledCopyCount_induce_eq_card_subtype_copy, labelledCopyCount_eq_card_copy]
+  exact Fintype.card_subtype_le (fun f : Copy H G ↦ univ.map f.toEmbedding ⊆ s)
 
 end LabelledCopyCount
 

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Basic.lean
@@ -192,6 +192,11 @@ theorem card_edgeFinset_deleteIncidenceSet_le_extremalNumber
   contrapose h
   exact h.trans ⟨Copy.induce G {v}ᶜ⟩
 
+/-- The extremal number on `n` vertices is at most `n.choose 2`. -/
+theorem extremalNumber_le_choose_two : extremalNumber n H ≤ n.choose 2 := by
+  rw [← Fintype.card_fin n, extremalNumber_le_iff]
+  exact fun _ _ _ ↦ card_edgeFinset_le_card_choose_two
+
 end ExtremalNumber
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Supersaturation.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Supersaturation.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 Mitchell Horner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mitchell Horner
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Copy
+public import Mathlib.Combinatorics.SimpleGraph.Extremal.TuranDensity
+public import Mathlib.Combinatorics.SimpleGraph.Finite
+
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Data.Nat.Choose.Bounds
+
+/-!
+# Supersaturation
+
+This file proves the **supersaturation theorem** for simple graphs.
+
+## Main statements
+
+* `SimpleGraph.eventually_labelledCopyCount_ge_of_card_edgeFinset` is the **supersaturation
+  theorem**: if `ε > 0` and `H` is a simple graph, then for all sufficiently large `n`, every simple
+  graph `G` on `Fin n` with at least `(turanDensity H + ε) * n.choose 2` edges contains at least
+  `supersaturationConst H ε * n ^ v(H)` labelled copies of `H`, where `supersaturationConst H ε` is
+  an explicit positive constant depending only on `H` and `ε`.
+-/
+
+@[expose] public section
+
+
+open Filter Finset Fintype Function
+
+namespace SimpleGraph
+
+variable {W : Type*} {H : SimpleGraph W} {n : ℕ} {ε : ℝ}
+
+open scoped Classical in
+/-- `turanDenseGraphs n H ε` is the finset of simple graphs on `Fin n` having an edge density of at
+least `turanDensity H + ε`. -/
+noncomputable abbrev turanDenseGraphs (n : ℕ) (H : SimpleGraph W) (ε : ℝ) :
+    Finset (SimpleGraph (Fin n)) :=
+  { F : SimpleGraph (Fin n) | ∃ _ : DecidableRel F.Adj,
+    #F.edgeFinset ≥ (turanDensity H + ε) * n.choose 2 }
+
+lemma top_mem_turanDenseGraphs (h : H.turanDensity + ε ≤ 1) :
+    ⊤ ∈ turanDenseGraphs n H ε := by classical
+  refine (mem_filter_univ ⊤).mpr ⟨inferInstance, ?_⟩
+  rw [card_edgeFinset_top_eq_card_choose_two, Fintype.card_fin n, ge_iff_le]
+  exact mul_le_of_le_one_left (Nat.cast_nonneg _) h
+
+theorem turanDenseGraphs_nonempty (h : H.turanDensity + ε ≤ 1) :
+    (turanDenseGraphs n H ε).Nonempty :=
+  ⟨⊤, top_mem_turanDenseGraphs h⟩
+
+variable {G : SimpleGraph (Fin n)}
+
+/-- `turanDenseSubsets G k H ε` is the finset of `k`-sized finsets of vertices whose induced
+subgraphs `G.induce s` have an edge density of at least `turanDensity H + ε`. -/
+noncomputable abbrev turanDenseSubsets (G : SimpleGraph (Fin n)) [DecidableRel G.Adj]
+    (k : ℕ) (H : SimpleGraph W) (ε : ℝ) : Finset (Finset (Fin n)) :=
+  { s ∈ univ.powersetCard k | #(G.induce s).edgeFinset ≥ (turanDensity H + ε) * k.choose 2 }
+
+/-- The number of `k`-sized finsets of vertices in `turanDenseSubsets` is at least a positive
+proportion of all `k`-sized finsets of vertices. -/
+theorem le_card_turanDenseSubsets [DecidableRel G.Adj] {k : ℕ} (hk : 2 ≤ k) (hε_pos : 0 < ε)
+    (h : #G.edgeFinset ≥ (H.turanDensity + ε) * n.choose 2) :
+    ε / 2 * n.choose k ≤ #(turanDenseSubsets G k H (ε / 2)) := by
+  -- double count the `k`-sized sets with induced subgraphs that have sufficient edges
+  set S := turanDenseSubsets G k H (ε / 2)
+  have hS_subset : S ⊆ univ.powersetCard k := filter_subset _ _
+  have hS : #G.edgeFinset * (n - 2).choose (k - 2) ≤ #S * k.choose 2
+      + (n.choose k - #S) * (H.turanDensity + ε / 2) * k.choose 2 := by classical
+    -- double count `(s, e)` where `s` is a `k`-sized subset containing the vertices of `e`
+    let T := (univ.powersetCard k ×ˢ G.edgeFinset).filter fun (s, e) ↦ e.toFinset ⊆ s
+    trans (#T : ℝ)
+    · have he {e : G.edgeFinset} := hk.trans_eq' (card_toFinset_mem_edgeFinset e).symm
+      simp_rw [T, card_filter, sum_product_right, ← card_filter, ← sum_attach G.edgeFinset,
+        card_filter_powersetCard_subset _ _ _ (subset_univ _) he, card_univ,
+        card_toFinset_mem_edgeFinset, sum_const, smul_eq_mul, card_attach, Nat.cast_mul,
+        Fintype.card_fin, le_rfl]
+    · simp_rw [T, card_filter, sum_product, ← card_filter,
+        card_filter_edgeFinset_toFinset_subset, ← sum_inter_add_sum_sdiff (univ.powersetCard k) S,
+        inter_eq_right.mpr hS_subset, Nat.cast_add]
+      refine add_le_add ?_ ?_
+      · rw [← Nat.cast_mul, Nat.cast_le, ← smul_eq_mul]
+        exact sum_le_card_nsmul _ _ _ fun s hs ↦ card_edgeFinset_le_card_choose_two.trans_eq
+          (by rw [← Set.toFinset_card, toFinset_coe, mem_powersetCard_univ.mp (hS_subset hs)])
+      · push_cast
+        refine (sum_le_card_nsmul _ _ ((H.turanDensity + ε / 2) * k.choose 2)
+          fun s hs ↦ ?_).trans_eq ?_
+        · obtain ⟨hs, nhs⟩ := mem_sdiff.mp hs
+          rw [mem_filter, not_and, ge_iff_le, not_le] at nhs
+          exact (nhs hs).le
+        · rw [nsmul_eq_mul, card_sdiff_of_subset hS_subset,
+            Nat.cast_sub (card_le_card hS_subset), card_powersetCard, card_univ,
+            Fintype.card_fin, ← mul_assoc]
+  -- solve for `#S` using the bound on the number of edges of `G`
+  have h_choose_mul : (n.choose 2 : ℝ) * (n - 2).choose (k - 2) = (n.choose k : ℝ) * k.choose 2 :=
+    mod_cast (Nat.choose_mul hk).symm
+  have h_choose_pos : (0 : ℝ) < k.choose 2 := mod_cast Nat.choose_pos hk
+  replace hS : (H.turanDensity + ε) * ((n.choose k : ℝ) * k.choose 2)
+      ≤ #S * k.choose 2 + ((n.choose k : ℝ) - #S) * (H.turanDensity + ε / 2) * k.choose 2 := by
+    refine hS.trans' ?_
+    rw [← h_choose_mul, ← mul_assoc]
+    exact mul_le_mul_of_nonneg_right h (by positivity)
+  have h_nonneg : (0 : ℝ) ≤ #S * ((H.turanDensity + ε / 2) * k.choose 2) :=
+    mul_nonneg (Nat.cast_nonneg _)
+      (mul_nonneg (add_nonneg (turanDensity_nonneg H) (half_pos hε_pos).le) (Nat.cast_nonneg _))
+  nlinarith [hS, h_choose_pos, h_nonneg]
+
+variable [Fintype W]
+
+/-- `turanDenseGraphs.minLabelledCopyCount n H ε` is the minimum number of labelled copies of `H`
+in any simple graph in `turanDenseGraphs n H ε`.
+
+Note that this value is `0` if `turanDenseGraphs n H ε` is empty. -/
+noncomputable abbrev turanDenseGraphs.minLabelledCopyCount (n : ℕ) (H : SimpleGraph W) (ε : ℝ) :=
+  WithTop.untopD 0 <| (turanDenseGraphs n H ε).inf (labelledCopyCount · H)
+
+theorem turanDenseGraphs.minLabelledCopyCount_eq_inf' (h : H.turanDensity + ε ≤ 1) :
+    turanDenseGraphs.minLabelledCopyCount n H ε
+      = (turanDenseGraphs n H ε).inf' (turanDenseGraphs_nonempty h) (labelledCopyCount · H) :=
+  WithTop.untopD_eq_iff.mpr <| Or.inl <| Eq.symm <| coe_inf' (turanDenseGraphs_nonempty h) _
+
+/-- The minimum number of labelled copies of `H` in any simple graph in `turanDenseGraphs` is
+positive, given
+at least `turanDensityConst H ε` many vertices. -/
+theorem turanDenseGraphs.minLabelledCopyCount_pos (hε_pos : 0 < ε)
+    (h_verts : turanDensityConst H ε ≤ n) (h : H.turanDensity + ε ≤ 1) :
+    0 < turanDenseGraphs.minLabelledCopyCount n H ε := by
+  simp_rw [turanDenseGraphs.minLabelledCopyCount_eq_inf' h, lt_inf'_iff,
+    mem_filter_univ, forall_exists_index, labelledCopyCount_pos]
+  exact fun F _ hF ↦ isContained_of_card_edgeFinset H hε_pos
+    (by simpa using h_verts) F (by simpa using hF)
+
+/-- Each simple graph in `turanDenseSubsets` contains at least
+`turanDenseGraphs.minLabelledCopyCount k H ε` labelled copies of `H`, and each labelled copy of `H`
+in `G` lies in at most `(n - card W).choose (k - card W)` of the `k`-sized finsets of vertices. -/
+theorem turanDenseGraphs.minLabelledCopyCount_mul_card_turanDenseSubsets_le [DecidableRel G.Adj]
+    {k : ℕ} (hcard : card W ≤ k) (h : H.turanDensity + ε ≤ 1) :
+    turanDenseGraphs.minLabelledCopyCount k H ε * #(turanDenseSubsets G k H ε)
+      ≤ G.labelledCopyCount H * (n - card W).choose (k - card W) := by classical
+  -- double count `(s, f)` where `s` is a `k`-sized subset containing the image of `f`
+  let T := (univ.powersetCard k ×ˢ univ).filter fun (s, (f : Copy H G)) ↦ univ.map f.toEmbedding ⊆ s
+  trans #T
+  · simp_rw [T, card_filter, sum_product, mul_sum]
+    refine sum_le_sum (fun s hs ↦ ?_)
+    classical rw [← card_filter, mul_ite, mul_one, mul_zero,
+      ← labelledCopyCount_induce_eq_card_filter_copy s]
+    split_ifs with hcard_edges
+    · have : Nonempty (s ≃ Fin k) := by
+        simp_rw [← card_eq, card_coe, Fintype.card_fin, mem_powersetCard_univ.mp hs]
+      let f : s ≃ Fin k := Classical.arbitrary (s ≃ Fin k)
+      have hf : (G.induce s).map f.toEmbedding ∈ turanDenseGraphs k H ε := by
+        simp_rw [mem_filter_univ]
+        refine ⟨inferInstance, ?_⟩
+        rw [(G.induce s).card_edgeFinset_map f.toEmbedding, ge_iff_le]
+        exact hcard_edges.le.trans_eq (mod_cast by convert rfl)
+      simp_rw [turanDenseGraphs.minLabelledCopyCount_eq_inf' h, inf'_le_iff]
+      exact ⟨(G.induce s).map f, hf,
+        by rw [← labelledCopyCount_congr_left (Iso.map f _)]⟩
+    · exact Nat.zero_le _
+  · have hf {f : Copy H G} : #(univ.map f.toEmbedding) ≤ k := by
+      rwa [← card_univ, ← card_map f.toEmbedding] at hcard
+    classical simp_rw [T, card_filter, sum_product_right, ← card_filter,
+      card_filter_powersetCard_subset _ _ _ (subset_univ _) hf, card_map, card_univ,
+      Fintype.card_fin, sum_const, smul_eq_mul, card_univ, labelledCopyCount_eq_card_copy, le_rfl]
+
+/-- Simple graphs on sufficiently many vertices `n` having at least
+`(turanDensity H + ε) * n.choose 2` many edges contain at least
+`supersaturationConst H ε * n ^ (card W)` labelled copies of `H`.
+
+Note that this value is only defined for positive `ε` and `supersaturationConst H ε = 0` for non
+positive `ε`. -/
+noncomputable abbrev supersaturationConst (H : SimpleGraph W) (ε : ℝ) : ℝ :=
+  if ε > 0 then
+    turanDenseGraphs.minLabelledCopyCount (turanDensityConst H (ε / 2)) H (ε / 2) * (ε / 2)
+      / (turanDensityConst H (ε / 2)).choose (card W) / (2 ^ card W * (card W).factorial)
+  else 0
+
+/-- The supersaturation theorem constant is positive, for positive `ε` such that
+`turanDensity H + ε / 2 ≤ 1`. -/
+theorem supersaturationConst_pos (H : SimpleGraph W) {ε : ℝ} (hε_pos : 0 < ε)
+    (h : H.turanDensity + ε / 2 ≤ 1) : 0 < supersaturationConst H ε := by
+  simp_rw [supersaturationConst, if_pos hε_pos]
+  refine div_pos (div_pos (mul_pos ?_ (half_pos hε_pos)) ?_) (by positivity)
+  · exact_mod_cast turanDenseGraphs.minLabelledCopyCount_pos (half_pos hε_pos) le_rfl h
+  · exact_mod_cast Nat.choose_pos (card_le_turanDensityConst H (half_pos hε_pos) h)
+
+/-- If `G` has sufficiently many vertices `n` and at least `(turanDensity H + ε) * n.choose 2`
+many edges, then `G` contains at least `supersaturationConst H ε * n ^ v(H)` labelled copies of
+`H`.
+
+This is the **supersaturation theorem** for simple graphs. -/
+theorem eventually_labelledCopyCount_ge_of_card_edgeFinset {ε : ℝ} (hε_pos : 0 < ε) :
+    ∀ᶠ n in atTop, ∀ {G : SimpleGraph (Fin n)} [DecidableRel G.Adj],
+      #G.edgeFinset ≥ (turanDensity H + ε) * n.choose 2 →
+        G.labelledCopyCount H ≥ supersaturationConst H ε * n ^ card W := by
+  rcases lt_or_ge 1 (turanDensity H + ε) with hπH_ε | hπH_ε
+  -- if `turanDensity H + ε > 1` then no simple graph has sufficiently many edges
+  · refine eventually_atTop.mpr ⟨2, fun n hn {G} _ hcard_edges ↦ absurd hcard_edges ?_⟩
+    push Not
+    have h_le : #G.edgeFinset ≤ n.choose 2 := by
+      simpa using card_edgeFinset_le_card_choose_two (G := G)
+    exact lt_of_le_of_lt (mod_cast h_le) <| lt_mul_left (mod_cast Nat.choose_pos hn) hπH_ε
+  · have hπH_halfε : turanDensity H + ε / 2 < 1 := by linarith
+    simp_rw [supersaturationConst, if_pos hε_pos]
+    -- `k` is large enough that every `F ∈ turanDenseGraphs` contains `H`
+    set k := turanDensityConst H (ε / 2)
+    have hcardW_le_k : card W ≤ k := card_le_turanDensityConst H (half_pos hε_pos) hπH_halfε.le
+    set c := turanDenseGraphs.minLabelledCopyCount k H (ε / 2) with hc_def
+    set δ' := c * (ε / 2) / k.choose (card W) with hδ'_def
+    rcases lt_or_ge (card W) 2 with hcardW | hcardW
+    · -- if `card W ≤ 1` then `H` is the empty graph and copies are just vertex injections
+      have hH : H = ⊥ := by
+        have : Subsingleton W := Fintype.card_le_one_iff_subsingleton.mp (by omega)
+        ext a b
+        simpa using fun hab ↦ hab.ne (Subsingleton.elim a b)
+      -- the constant is at most `1`
+      have hc_le : c ≤ (card W).factorial * k.choose (card W) := by
+        rw [hc_def, turanDenseGraphs.minLabelledCopyCount_eq_inf' hπH_halfε.le,
+          ← Nat.descFactorial_eq_factorial_mul_choose]
+        apply le_of_le_of_eq <| inf'_le _ <| top_mem_turanDenseGraphs hπH_halfε.le
+        rw [hH, labelledCopyCount_bot, Fintype.card_fin]
+      have hδ'_le_one : δ' / (2 ^ card W * (card W).factorial) ≤ 1 := by
+        rw [hδ'_def, div_div,
+          div_le_one <| mul_pos (mod_cast Nat.choose_pos hcardW_le_k) (by positivity)]
+        have hc_le' : (c : ℝ) ≤ (card W).factorial * k.choose (card W) := mod_cast hc_le
+        have hε2 : ε / 2 ≤ 1 := by linarith [turanDensity_nonneg H]
+        have h2pow : (1 : ℝ) ≤ 2 ^ card W := one_le_pow₀ one_le_two
+        calc (c : ℝ) * (ε / 2)
+            ≤ ((card W).factorial * k.choose (card W) : ℝ) * 1 := by gcongr
+          _ = (k.choose (card W) : ℝ) * (1 * (card W).factorial) := by ring
+          _ ≤ (k.choose (card W) : ℝ) * (2 ^ card W * (card W).factorial) := by gcongr
+      refine Eventually.of_forall fun n G _ _ ↦ ?_
+      have hcount : (G.labelledCopyCount H : ℝ) = n ^ card W := by
+        rw [hH, labelledCopyCount_bot, Fintype.card_fin]
+        rcases (by omega : card W = 0 ∨ card W = 1) with h | h <;> simp [h]
+      rw [ge_iff_le, hcount]
+      exact mul_le_of_le_one_left (by positivity) hδ'_le_one
+    have hk_2 : 2 ≤ k := hcardW.trans hcardW_le_k
+    -- the minimum number of copies of `H` in any `F ∈ turanDenseGraphs` is positive
+    have hc_pos : 0 < c :=
+      turanDenseGraphs.minLabelledCopyCount_pos (half_pos hε_pos) le_rfl hπH_halfε.le
+    have hδ'_pos : 0 < δ' :=
+      div_pos (mul_pos (mod_cast hc_pos) (half_pos hε_pos)) (mod_cast Nat.choose_pos hcardW_le_k)
+    -- `n ^ card W / (2 ^ card W * (card W)!)` is less than `n.choose (card W)`
+    have hpow_le_choose : ∀ n : ℕ, 2 * card W ≤ n →
+        (n : ℝ) ^ card W / (2 ^ card W * (card W).factorial) ≤ n.choose (card W) := by
+      intro n hn
+      have hn' : (n : ℝ) / 2 ≤ ((n + 1 - card W : ℕ) : ℝ) := by
+        have : 2 * (card W : ℝ) ≤ n := by exact_mod_cast hn
+        rw [Nat.cast_sub (by omega)]
+        push_cast
+        linarith
+      calc (n : ℝ) ^ card W / (2 ^ card W * (card W).factorial)
+          = ((n : ℝ) / 2) ^ card W / (card W).factorial := by
+            rw [← div_div, ← div_pow]
+        _ ≤ ((n + 1 - card W : ℕ) : ℝ) ^ card W / (card W).factorial := by gcongr
+        _ ≤ n.choose (card W) := Nat.pow_le_choose (card W) n
+    refine eventually_atTop.mpr ⟨max k (2 * card W), fun n hn G _ hcard_edges ↦ ?_⟩
+    have hk_n : k ≤ n := (le_max_left k (2 * card W)).trans hn
+    -- there are at least `δ' * n.choose (card W)` copies of `H` in `G`
+    have h : δ' * n.choose (card W) ≤ G.labelledCopyCount H := by
+      have h_choose_mul : (n.choose (card W) : ℝ)
+          = n.choose k / (n - card W).choose (k - card W) * k.choose (card W) := by
+        rw [div_mul_eq_mul_div,
+          eq_div_iff_mul_eq (mod_cast Nat.choose_ne_zero (Nat.sub_le_sub_right hk_n (card W)))]
+        exact_mod_cast (Nat.choose_mul hcardW_le_k).symm
+      rw [h_choose_mul, mul_rotate', mul_div_cancel₀ _ (mod_cast Nat.choose_ne_zero hcardW_le_k),
+        div_mul_eq_mul_div, mul_comm,
+        div_le_iff₀ (mod_cast Nat.choose_pos (Nat.sub_le_sub_right hk_n (card W)))]
+      trans c * #(turanDenseSubsets G k H (ε / 2))
+      · rw [mul_assoc, mul_le_mul_iff_right₀ (mod_cast hc_pos)]
+        exact le_card_turanDenseSubsets hk_2 hε_pos hcard_edges
+      · norm_cast
+        exact turanDenseGraphs.minLabelledCopyCount_mul_card_turanDenseSubsets_le hcardW_le_k
+          hπH_halfε.le
+    rw [ge_iff_le, div_mul_eq_mul_div, mul_div_assoc]
+    exact h.trans' <| mul_le_mul_of_nonneg_left
+      (hpow_le_choose n <| hn.trans' <| le_max_right k (2 * card W)) hδ'_pos.le
+
+end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/TuranDensity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/TuranDensity.lean
@@ -97,6 +97,25 @@ theorem turanDensity_eq_csInf (H : SimpleGraph W) :
   have h := isGLB_turanDensity H
   (h.csInf_eq h.nonempty).symm
 
+theorem turanDensity_le_extremalNumber_div_choose_two (H : SimpleGraph W) {n : ℕ} (hn : n ≥ 2) :
+    turanDensity H ≤ extremalNumber n H / n.choose 2 := by
+  rw [turanDensity_eq_csInf H]
+  exact csInf_le (isGLB_turanDensity H).bddBelow ⟨n, hn, rfl⟩
+
+theorem turanDensity_nonneg (H : SimpleGraph W) : 0 ≤ turanDensity H := by
+  rw [turanDensity_eq_csInf]
+  refine le_csInf ?_ (fun x ⟨m, hm, hx⟩ ↦ ?_)
+  · rw [← Set.image, Set.image_nonempty]
+    exact Set.nonempty_Ici
+  · rw [← hx]
+    positivity
+
+theorem turanDensity_le_one (H : SimpleGraph W) : turanDensity H ≤ 1 := by
+  rw [turanDensity_eq_csInf]
+  apply csInf_le_of_le (isGLB_turanDensity H).bddBelow ⟨2, le_refl 2, rfl⟩
+  rw [div_le_iff₀ (mod_cast Nat.choose_pos le_rfl), one_mul, Nat.cast_le]
+  exact extremalNumber_le_choose_two
+
 /-- The **Turán density** of a simple graph `H` is well-defined. -/
 theorem tendsto_turanDensity (H : SimpleGraph W) :
     Tendsto (fun n ↦ (extremalNumber n H / n.choose 2 : ℝ)) atTop (𝓝 (turanDensity H)) := by
@@ -164,5 +183,18 @@ theorem isContained_of_card_edgeFinset (H : SimpleGraph W) {ε : ℝ} (hε_pos :
   rw [(G.overFinIso rfl).card_edgeFinset_eq, isContained_congr Iso.refl (G.overFinIso rfl)]
   apply Nat.find_spec <| eventually_atTop.mp <| eventually_isContained_of_card_edgeFinset H hε_pos
   simpa only [turanDensityConst, hε_pos, ↓reduceDIte] using h_verts
+
+/-- There are at least `card W` many vertices at `turanDensityConst`, since simple graphs on
+fewer vertices cannot contain `H`. -/
+theorem card_le_turanDensityConst [Fintype W] (H : SimpleGraph W) {ε : ℝ} (hε_pos : 0 < ε)
+    (h : H.turanDensity + ε ≤ 1) : card W ≤ turanDensityConst H ε := by classical
+  rw [turanDensityConst, dif_pos hε_pos, Nat.le_find_iff]
+  intro m hm hp
+  obtain ⟨f⟩ := by
+    apply hp m le_rfl (G := (⊤ : SimpleGraph (Fin m)))
+    rw [card_edgeFinset_top_eq_card_choose_two, Fintype.card_fin, ge_iff_le]
+    exact mul_le_of_le_one_left (Nat.cast_nonneg _) h
+  have : card W ≤ m := by simpa using Fintype.card_le_of_embedding f.toEmbedding
+  omega
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -680,19 +680,13 @@ theorem le_minDegree_induce_of_support_subset (h : G.support ⊆ s) :
   grw [G.minDegree_le_degree v, degree_induce_of_neighborSet_subset]
   grw [neighborSet_subset_support, h]
 
-end Support
-
-section InduceEdgeFinset
-
-variable [DecidableEq V] [Fintype V] [DecidableRel G.Adj]
-
-theorem filter_edgeFinset_toFinset_subset (s : Finset V) :
+theorem filter_edgeFinset_toFinset_subset [DecidableEq V] (s : Finset V) :
     {e ∈ G.edgeFinset | e.toFinset ⊆ s} = G.edgeFinset ∩ s.sym2 := by
   simp [subset_iff, ← mem_sym2_iff, filter_mem_eq_inter]
 
 /-- The edges whose vertices lie in `s` are in bijection with the edges of the induced
 subgraph `G.induce s`. -/
-theorem card_filter_edgeFinset_toFinset_subset (s : Finset V) :
+theorem card_filter_edgeFinset_toFinset_subset [DecidableEq V] (s : Finset V) :
     #{e ∈ G.edgeFinset | e.toFinset ⊆ s} = #(G.induce ↑s).edgeFinset := by
   have h := congrArg Finset.card (map_edgeFinset_induce (s := (↑s : Set V)) (G := G))
   rw [card_map, toFinset_coe] at h
@@ -700,7 +694,7 @@ theorem card_filter_edgeFinset_toFinset_subset (s : Finset V) :
   convert h.symm using 1
   congr!
 
-end InduceEdgeFinset
+end Support
 
 section Map
 

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -682,6 +682,26 @@ theorem le_minDegree_induce_of_support_subset (h : G.support ⊆ s) :
 
 end Support
 
+section InduceEdgeFinset
+
+variable [DecidableEq V] [Fintype V] [DecidableRel G.Adj]
+
+theorem filter_edgeFinset_toFinset_subset (s : Finset V) :
+    {e ∈ G.edgeFinset | e.toFinset ⊆ s} = G.edgeFinset ∩ s.sym2 := by
+  simp [subset_iff, ← mem_sym2_iff, filter_mem_eq_inter]
+
+/-- The edges whose vertices lie in `s` are in bijection with the edges of the induced
+subgraph `G.induce s`. -/
+theorem card_filter_edgeFinset_toFinset_subset (s : Finset V) :
+    #{e ∈ G.edgeFinset | e.toFinset ⊆ s} = #(G.induce ↑s).edgeFinset := by
+  have h := congrArg Finset.card (map_edgeFinset_induce (s := (↑s : Set V)) (G := G))
+  rw [card_map, toFinset_coe] at h
+  rw [filter_edgeFinset_toFinset_subset]
+  convert h.symm using 1
+  congr!
+
+end InduceEdgeFinset
+
 section Map
 
 variable [Fintype V] {W : Type*} [Fintype W] [DecidableEq W]


### PR DESCRIPTION
Prove the **supersaturation theorem** for simple graphs.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

There isn't really a well-known "supersaturation theorem", but I've seen this statement used without reference in proofs. It is also [listed on the forbidden subgraph problem Wikipedia page](https://en.wikipedia.org/wiki/Forbidden_subgraph_problem#Supersaturation_Theorem) for hypergraphs but proven here for simple graphs. It is probably one of the more general supersaturation-type statements. Nonetheless, I think it is a valuable addition for (1) its bound, (2) the intermediate definitions to prove it, and (3) as a template for other supersaturation-type proofs.

- [ ] depends on: #42135
- [ ] depends on: #42136
- [ ] depends on: #42137

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
