### PR TITLE
[Merged by Bors] - feat(FieldTheory): typeclass for field extension with finite transcendence degree

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4517,6 +4517,7 @@ public import Mathlib.FieldTheory.ChevalleyWarning
 public import Mathlib.FieldTheory.Differential.Basic
 public import Mathlib.FieldTheory.Differential.Liouville
 public import Mathlib.FieldTheory.Extension
+public import Mathlib.FieldTheory.FinTrdeg
 public import Mathlib.FieldTheory.Finite.Basic
 public import Mathlib.FieldTheory.Finite.Extension
 public import Mathlib.FieldTheory.Finite.GaloisField

--- a/Mathlib/FieldTheory/FinTrdeg.lean
+++ b/Mathlib/FieldTheory/FinTrdeg.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 Aaron Liu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Liu
+-/
+module
+
+public import Mathlib.RingTheory.AlgebraicIndependent.TranscendenceBasis
+public import Mathlib.FieldTheory.IntermediateField.Adjoin.Algebra
+public import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
+
+/-!
+# Extensions with Finite Transcendence Degree
+
+A field extension L/K has finite transcendence degree if
+the transcendence degree of L over K is finite.
+Equivalently, if L is an algebraic extension of a finitely generated field extension of K.
+-/
+
+public section
+
+variable {K L : Type*} [Field K] [Field L] [Algebra K L]
+
+open IntermediateField
+
+variable (K L) in
+/-- A field extension L/K is said to have finite transcendence degree if there is some
+intermediate extension L/E/K with E/K finitely generated and L/E algebraic. -/
+class FinTrdeg where
+  exists_fg_isAlgebraic : ∃ E : IntermediateField K L, E.FG ∧ Algebra.IsAlgebraic E L
+
+variable (K L) in
+instance [Algebra.IsAlgebraic K L] : FinTrdeg K L where
+  exists_fg_isAlgebraic := ⟨⊥, IntermediateField.fg_bot, inferInstance⟩
+
+variable (K L) in
+instance [Algebra.EssFiniteType K L] : FinTrdeg K L where
+  exists_fg_isAlgebraic := ⟨⊤, IntermediateField.fg_top_iff.mpr ‹_›, inferInstance⟩
+
+theorem finTrdeg_iff_trdeg : FinTrdeg K L ↔ Algebra.trdeg K L < .aleph0 := by
+  constructor
+  · intro ⟨E, fg, alg⟩
+    rw [← trdeg_add_eq K E, trdeg_eq_zero_iff.2 alg, add_zero]
+    rw [← essFiniteType_iff, Algebra.essFiniteType_iff_exists_subalgebra] at fg
+    obtain ⟨S₀, M, fin, islocal⟩ := fg
+    rw [← trdeg_add_eq K S₀, trdeg_eq_zero_iff.2 islocal.isAlgebraic, add_zero]
+    exact trdeg_lt_aleph0_of_finiteType
+  · intro h
+    obtain ⟨s, hs⟩ := exists_isTranscendenceBasis K L
+    have fin : s.Finite := Cardinal.lt_aleph0_iff_set_finite.1 (hs.cardinalMk_eq_trdeg.trans_lt h)
+    constructor
+    refine ⟨adjoin K s, fg_adjoin_of_finite fin, ?_⟩
+    have alg := hs.isAlgebraic_field
+    rwa [Subtype.range_coe] at alg
+
+alias ⟨_, FinTrdeg.of_trdeg⟩ := finTrdeg_iff_trdeg
+
+variable (K L) in
+theorem trdeg_lt_aleph0 [FinTrdeg K L] : Algebra.trdeg K L < .aleph0 :=
+  finTrdeg_iff_trdeg.mp ‹_›
+
+theorem FinTrdeg.trans (K E L : Type*) [Field K] [Field E] [Field L]
+    [Algebra K E] [Algebra K L] [Algebra E L] [IsScalarTower K E L]
+    [FinTrdeg K E] [FinTrdeg E L] : FinTrdeg K L := by
+  rw [finTrdeg_iff_trdeg, ← Cardinal.lift_lt_aleph0, ← lift_trdeg_add_eq K E L,
+    Cardinal.add_lt_aleph0_iff, Cardinal.lift_lt_aleph0, Cardinal.lift_lt_aleph0]
+  exact ⟨trdeg_lt_aleph0 K E, trdeg_lt_aleph0 E L⟩
+
+theorem finite_of_isTranscendenceBasis [FinTrdeg K L] {ι : Type*} {x : ι → L}
+    (hx : IsTranscendenceBasis K x) : Finite ι := by
+  rw [← Cardinal.mk_lt_aleph0_iff, ← Cardinal.lift_lt_aleph0,
+    hx.lift_cardinalMk_eq_trdeg, Cardinal.lift_lt_aleph0]
+  exact trdeg_lt_aleph0 K L
+
+theorem finite_of_algebraicIndependent [FinTrdeg K L] {ι : Type*} {x : ι → L}
+    (hx : AlgebraicIndependent K x) : Finite ι := by
+  rw [← Cardinal.mk_lt_aleph0_iff, ← Cardinal.lift_lt_aleph0]
+  exact hx.lift_cardinalMk_le_trdeg.trans_lt (Cardinal.lift_lt_aleph0.mpr (trdeg_lt_aleph0 K L))
+
+theorem FinTrdeg.of_isTranscendenceBasis {ι : Type*} [Finite ι] {x : ι → L}
+    (hx : IsTranscendenceBasis K x) : FinTrdeg K L := by
+  rw [finTrdeg_iff_trdeg, ← Cardinal.lift_lt_aleph0,
+    ← hx.lift_cardinalMk_eq_trdeg, Cardinal.lift_lt_aleph0]
+  exact Cardinal.mk_lt_aleph0
+
+theorem exists_finset_isTranscendenceBasis [FinTrdeg K L] :
+    ∃ s : Finset L, IsTranscendenceBasis K ((↑) : s → L) := by
+  obtain ⟨s, hs⟩ := exists_isTranscendenceBasis K L
+  obtain ⟨s, rfl⟩ := Finset.mem_range_coe_iff.2
+    (Set.finite_coe_iff.1 (finite_of_isTranscendenceBasis hs))
+  exact ⟨s, hs⟩

--- a/Mathlib/FieldTheory/FinTrdeg.lean
+++ b/Mathlib/FieldTheory/FinTrdeg.lean
@@ -83,6 +83,7 @@ theorem FinTrdeg.of_isTranscendenceBasis {ι : Type*} [Finite ι] {x : ι → L}
     ← hx.lift_cardinalMk_eq_trdeg, Cardinal.lift_lt_aleph0]
   exact Cardinal.mk_lt_aleph0
 
+variable (K L) in
 theorem exists_finset_isTranscendenceBasis [FinTrdeg K L] :
     ∃ s : Finset L, IsTranscendenceBasis K ((↑) : s → L) := by
   obtain ⟨s, hs⟩ := exists_isTranscendenceBasis K L

--- a/Mathlib/FieldTheory/FinTrdeg.lean
+++ b/Mathlib/FieldTheory/FinTrdeg.lean
@@ -19,15 +19,14 @@ Equivalently, if L is an algebraic extension of a finitely generated field exten
 
 public section
 
-variable {K L : Type*} [Field K] [Field L] [Algebra K L]
-
 open IntermediateField
 
-variable (K L) in
 /-- A field extension L/K is said to have finite transcendence degree if there is some
 intermediate extension L/E/K with E/K finitely generated and L/E algebraic. -/
-class FinTrdeg where
-  exists_fg_isAlgebraic : ∃ E : IntermediateField K L, E.FG ∧ Algebra.IsAlgebraic E L
+class FinTrdeg (K L : Type*) [Field K] [Field L] [Algebra K L] where
+  exists_fg_isAlgebraic (K L) : ∃ E : IntermediateField K L, E.FG ∧ Algebra.IsAlgebraic E L
+
+variable {K L : Type*} [Field K] [Field L] [Algebra K L]
 
 variable (K L) in
 instance [Algebra.IsAlgebraic K L] : FinTrdeg K L where

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -554,6 +554,18 @@ theorem _root_.Polynomial.Irreducible.natDegree_dvd_finrank {f : K[X]} (hi : Irr
   contrapose hi
   rwa [hi, mul_zero] at key
 
+instance : Algebra.IsAlgebraic K (⊥ : IntermediateField K L) where
+  isAlgebraic := by
+    intro ⟨x, hx⟩
+    obtain ⟨c, rfl⟩ := hx
+    exact isAlgebraic_algebraMap c
+
+instance : Algebra.IsAlgebraic (⊤ : IntermediateField K L) L where
+  isAlgebraic := by
+    intro x
+    let xt : (⊤ : IntermediateField K L) := ⟨x, mem_top⟩
+    exact isAlgebraic_algebraMap xt
+
 -- TODO: generalize to `Sort`
 /-- A compositum of algebraic extensions is algebraic -/
 theorem isAlgebraic_iSup {ι : Type*} {t : ι → IntermediateField K L}

--- a/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
@@ -451,7 +451,7 @@ theorem Polynomial.trdeg_of_isDomain [IsDomain R] : trdeg R (Polynomial R) = 1 :
   simpa using (IsTranscendenceBasis.polynomial Unit R).lift_cardinalMk_eq_trdeg.symm
 
 -- TODO: generalize to Nontrivial S
-theorem trdeg_lt_aleph0 [IsDomain R] [fin : FiniteType R S] : trdeg R S < ℵ₀ :=
+theorem trdeg_lt_aleph0_of_finiteType [IsDomain R] [fin : FiniteType R S] : trdeg R S < ℵ₀ :=
   have ⟨n, f, surj⟩ := FiniteType.iff_quotient_mvPolynomial''.mp fin
   lift_lt.mp <| (lift_trdeg_le_of_surjective f surj).trans_lt <| by simp
 


### PR DESCRIPTION
Make a new typeclass for field extensions with finite transcendence degree. See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/typeclass.20for.20finite.20transcendence.20basis/near/612845827).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
