### PR TITLE
feat(AlgebraicTopology): natural transformation to nerve homotopy

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1607,6 +1607,7 @@ public import Mathlib.AlgebraicTopology.SimplicialSet.Nerve
 public import Mathlib.AlgebraicTopology.SimplicialSet.NerveAdjunction
 public import Mathlib.AlgebraicTopology.SimplicialSet.NerveCodiscrete
 public import Mathlib.AlgebraicTopology.SimplicialSet.NerveNondegenerate
+public import Mathlib.AlgebraicTopology.SimplicialSet.NerveProduct
 public import Mathlib.AlgebraicTopology.SimplicialSet.NonDegenerateSimplices
 public import Mathlib.AlgebraicTopology.SimplicialSet.NonDegenerateSimplicesColimit
 public import Mathlib.AlgebraicTopology.SimplicialSet.NonDegenerateSimplicesSubcomplex

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
@@ -6,7 +6,6 @@ Authors: Joël Riou
 module
 
 public import Mathlib.AlgebraicTopology.SimplicialSet.CompStruct
-public import Mathlib.AlgebraicTopology.SimplicialSet.Monoidal
 public import Mathlib.CategoryTheory.ComposableArrows.Basic
 
 /-!
@@ -25,7 +24,7 @@ which is the category `Fin (n + 1) ⥤ C`.
 
 @[expose] public section
 
-open CategoryTheory Category Simplicial Opposite MonoidalCategory
+open CategoryTheory Category Simplicial Opposite
 
 universe v u
 
@@ -261,59 +260,6 @@ lemma homEquiv_edgeMk_map_nerveMap {D : Type u} [Category.{v} D] {x y : C}
     (f : x ⟶ y) (F : C ⥤ D) :
     dsimp% homEquiv ((edgeMk f).map (nerveMap F)) = F.map f := by
   simp [homEquiv, nerveMap_app]
-
-end
-
-section
-variable (C₁ C₂ : Type u) [Category.{v} C₁] [Category.{v} C₂]
-
-/-- Map a nerve of a product category to product of the nerves. -/
-def nerveProdToProdNerve : nerve (C₁ × C₂) ⟶ (nerve C₁) ⊗ (nerve C₂) := by
-  let app (n : SimplexCategoryᵒᵖ) : (nerve (C₁ × C₂)).obj n ⟶ (nerve C₁ ⊗ nerve C₂).obj n := by
-    constructor
-    exact ⟨fun γ ↦ ⟨γ ⋙ (CategoryTheory.Prod.fst C₁ C₂), γ ⋙ (CategoryTheory.Prod.snd C₁ C₂)⟩⟩
-  constructor
-  · intro m n d
-    exact Eq.symm
-          (CartesianMonoidalCategory.hom_ext (app m ≫ ((nerve C₁).map d ⊗ₘ (nerve C₂).map d))
-            ((nerve (C₁ × C₂)).map d ≫ app n) rfl rfl)
-
-/-- Map a product of nerves to the nerve of the product category. -/
-def prodNerveToNerveProd : (nerve C₁) ⊗ (nerve C₂) ⟶ nerve (C₁ × C₂) := by
-  let app (n : SimplexCategoryᵒᵖ) : (nerve C₁ ⊗ nerve C₂).obj n ⟶ (nerve (C₁ × C₂)).obj n := by
-    constructor
-    exact ⟨fun ⟨γ₁,γ₂⟩ ↦ γ₁.prod' γ₂⟩
-  constructor
-  · intro m n f
-    exact Eq.symm (eq_of_comp_right_eq'
-                    (app m ≫ (nerve (C₁ × C₂)).map f)
-                    ((nerve C₁ ⊗ nerve C₂).map f ≫ app n)
-                    rfl)
-
-/-- nerve preserves products. -/
-def nerveOfProductIso : nerve (C₁ × C₂) ≅ (nerve C₁) ⊗ (nerve C₂) where
-  hom := nerveProdToProdNerve C₁ C₂
-  inv := prodNerveToNerveProd C₁ C₂
-
-end
-
-section
-variable {C₁ C₂ : Type u} [Category.{v} C₁] [Category.{v} C₂]
-variable {D₁ D₂ : Type u} [Category.{v} D₁] [Category.{v} D₂]
-
-/-- Convert a pair of functors to a map between products of nerves -/
-def nerveOfProdMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
-    (nerve C₁) ⊗ (nerve C₂) ⟶ (nerve D₁) ⊗ (nerve D₂) :=
-  prodNerveToNerveProd C₁ C₂ ≫ nerveMap (F₁.prod F₂) ≫ nerveProdToProdNerve D₁ D₂
-
-lemma nerveOfProdMap_prod_nerveMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
-    nerveOfProdMap F₁ F₂ = nerveMap F₁ ⊗ₘ nerveMap F₂ := rfl
-
-variable {E₁ E₂ : Type u} [Category.{v} E₁] [Category.{v} E₂]
-
-lemma nerve_of_product_interchange (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) (G₁ : D₁ ⥤ E₁) (G₂ : D₂ ⥤ E₂) :
-    (nerveOfProdMap F₁ F₂) ≫ (nerveOfProdMap G₁ G₂)
-    = nerveOfProdMap (F₁ ⋙ G₁) (F₂ ⋙ G₂) := rfl
 
 end
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
@@ -272,3 +272,57 @@ end CategoryTheory
 def PartOrd.nerveFunctor : PartOrd.{u} ⥤ SSet.{u} where
   obj X := nerve X
   map f := nerveMap f.hom.monotone.functor
+
+
+section
+variable (C₁ C₂ : Type u) [SmallCategory C₁] [SmallCategory C₂]
+
+/-- Map a nerve of a product category to product of the nerves. -/
+def nerveProdToProdNerve : nerve (C₁ × C₂) ⟶ (nerve C₁) ⊗ (nerve C₂) := by
+  let app (n : SimplexCategoryᵒᵖ) : (nerve (C₁ × C₂)).obj n ⟶ (nerve C₁ ⊗ nerve C₂).obj n := by
+    constructor
+    exact ⟨fun γ ↦ ⟨γ ⋙ (CategoryTheory.Prod.fst C₁ C₂), γ ⋙ (CategoryTheory.Prod.snd C₁ C₂)⟩⟩
+  constructor
+  · intro m n d
+    exact Eq.symm
+          (CartesianMonoidalCategory.hom_ext (app m ≫ ((nerve C₁).map d ⊗ₘ (nerve C₂).map d))
+            ((nerve (C₁ × C₂)).map d ≫ app n) rfl rfl)
+
+/-- Map a product of nerves to the nerve of the product category. -/
+def prodNerveToNerveProd : (nerve C₁) ⊗ (nerve C₂) ⟶ nerve (C₁ × C₂) := by
+  let app (n : SimplexCategoryᵒᵖ) : (nerve C₁ ⊗ nerve C₂).obj n ⟶ (nerve (C₁ × C₂)).obj n := by
+    constructor
+    exact ⟨fun ⟨γ₁,γ₂⟩ ↦ γ₁.prod' γ₂⟩
+  constructor
+  · intro m n f
+    exact Eq.symm (eq_of_comp_right_eq'
+                    (app m ≫ (nerve (C₁ × C₂)).map f)
+                    ((nerve C₁ ⊗ nerve C₂).map f ≫ app n)
+                    rfl)
+
+/-- nerve preserves products. -/
+def nerveOfProductIso : nerve (C₁ × C₂) ≅ (nerve C₁) ⊗ (nerve C₂) where
+  hom := nerveProdToProdNerve C₁ C₂
+  inv := prodNerveToNerveProd C₁ C₂
+
+end
+
+section
+variable {C₁ C₂ : Type u} [SmallCategory C₁] [SmallCategory C₂]
+variable {D₁ D₂ : Type u} [SmallCategory D₁] [SmallCategory D₂]
+
+/-- Convert a pair of functors to a map between products of nerves -/
+def nerveOfProdMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
+    (nerve C₁) ⊗ (nerve C₂) ⟶ (nerve D₁) ⊗ (nerve D₂) :=
+  prodNerveToNerveProd C₁ C₂ ≫ nerveMap (F₁.prod F₂) ≫ nerveProdToProdNerve D₁ D₂
+
+lemma nerveOfProdMap_prod_nerveMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
+    nerveOfProdMap F₁ F₂ = nerveMap F₁ ⊗ₘ nerveMap F₂ := rfl
+
+variable {E₁ E₂ : Type u} [SmallCategory E₁] [SmallCategory E₂]
+
+lemma nerve_of_product_interchange (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) (G₁ : D₁ ⥤ E₁) (G₂ : D₂ ⥤ E₂) :
+    (nerveOfProdMap F₁ F₂) ≫ (nerveOfProdMap G₁ G₂)
+    = nerveOfProdMap (F₁ ⋙ G₁) (F₂ ⋙ G₂) := rfl
+
+end

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
@@ -273,9 +273,8 @@ def PartOrd.nerveFunctor : PartOrd.{u} ⥤ SSet.{u} where
   obj X := nerve X
   map f := nerveMap f.hom.monotone.functor
 
-
 section
-variable (C₁ C₂ : Type u) [SmallCategory C₁] [SmallCategory C₂]
+variable (C₁ C₂ : Type u) [Category.{v} C₁] [Category.{v} C₂]
 
 /-- Map a nerve of a product category to product of the nerves. -/
 def nerveProdToProdNerve : nerve (C₁ × C₂) ⟶ (nerve C₁) ⊗ (nerve C₂) := by
@@ -308,8 +307,8 @@ def nerveOfProductIso : nerve (C₁ × C₂) ≅ (nerve C₁) ⊗ (nerve C₂) w
 end
 
 section
-variable {C₁ C₂ : Type u} [SmallCategory C₁] [SmallCategory C₂]
-variable {D₁ D₂ : Type u} [SmallCategory D₁] [SmallCategory D₂]
+variable {C₁ C₂ : Type u} [Category.{v} C₁] [Category.{v} C₂]
+variable {D₁ D₂ : Type u} [Category.{v} D₁] [Category.{v} D₂]
 
 /-- Convert a pair of functors to a map between products of nerves -/
 def nerveOfProdMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
@@ -319,7 +318,7 @@ def nerveOfProdMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
 lemma nerveOfProdMap_prod_nerveMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
     nerveOfProdMap F₁ F₂ = nerveMap F₁ ⊗ₘ nerveMap F₂ := rfl
 
-variable {E₁ E₂ : Type u} [SmallCategory E₁] [SmallCategory E₂]
+variable {E₁ E₂ : Type u} [Category.{v} E₁] [Category.{v} E₂]
 
 lemma nerve_of_product_interchange (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) (G₁ : D₁ ⥤ E₁) (G₂ : D₂ ⥤ E₂) :
     (nerveOfProdMap F₁ F₂) ≫ (nerveOfProdMap G₁ G₂)

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
@@ -6,6 +6,7 @@ Authors: Joël Riou
 module
 
 public import Mathlib.AlgebraicTopology.SimplicialSet.CompStruct
+public import Mathlib.AlgebraicTopology.SimplicialSet.Monoidal
 public import Mathlib.CategoryTheory.ComposableArrows.Basic
 
 /-!
@@ -24,7 +25,7 @@ which is the category `Fin (n + 1) ⥤ C`.
 
 @[expose] public section
 
-open CategoryTheory Category Simplicial Opposite
+open CategoryTheory Category Simplicial Opposite MonoidalCategory
 
 universe v u
 
@@ -263,16 +264,6 @@ lemma homEquiv_edgeMk_map_nerveMap {D : Type u} [Category.{v} D] {x y : C}
 
 end
 
-end nerve
-
-end CategoryTheory
-
-/-- The functor `PartOrd ⥤ SSet` which sends a partially ordered type to its nerve. -/
-@[simps]
-def PartOrd.nerveFunctor : PartOrd.{u} ⥤ SSet.{u} where
-  obj X := nerve X
-  map f := nerveMap f.hom.monotone.functor
-
 section
 variable (C₁ C₂ : Type u) [Category.{v} C₁] [Category.{v} C₂]
 
@@ -325,3 +316,13 @@ lemma nerve_of_product_interchange (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂)
     = nerveOfProdMap (F₁ ⋙ G₁) (F₂ ⋙ G₂) := rfl
 
 end
+
+end nerve
+
+end CategoryTheory
+
+/-- The functor `PartOrd ⥤ SSet` which sends a partially ordered type to its nerve. -/
+@[simps]
+def PartOrd.nerveFunctor : PartOrd.{u} ⥤ SSet.{u} where
+  obj X := nerve X
+  map f := nerveMap f.hom.monotone.functor

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
@@ -33,7 +33,7 @@ def nerveProdToProdNerve : nerve (C₁ × C₂) ⟶ (nerve C₁) ⊗ (nerve C₂
 def prodNerveToNerveProd : (nerve C₁) ⊗ (nerve C₂) ⟶ nerve (C₁ × C₂) where
   app n := ↾(ComposableArrows.prodEquivalence C₁ C₂ n.unop.len).inverse.obj
 
-/-- nerve preserves products. -/
+/-- `nerve` preserves products. -/
 def nerveOfProductIso : nerve (C₁ × C₂) ≅ (nerve C₁) ⊗ (nerve C₂) where
   hom := nerveProdToProdNerve C₁ C₂
   inv := prodNerveToNerveProd C₁ C₂

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
@@ -7,6 +7,9 @@ module
 
 public import Mathlib.AlgebraicTopology.SimplicialSet.Nerve
 public import Mathlib.AlgebraicTopology.SimplicialSet.Monoidal
+public import Mathlib.CategoryTheory.Monoidal.Category
+public import Mathlib.CategoryTheory.Monoidal.Functor
+public import Mathlib.CategoryTheory.Monoidal.Cartesian.Cat
 
 /-!
 # The nerve of a product category
@@ -25,37 +28,50 @@ namespace CategoryTheory.nerve
 section
 variable (C₁ C₂ : Type u) [Category.{v} C₁] [Category.{v} C₂]
 
+/-- `nerve` preserves products. -/
+def nerveProdIso : nerve (C₁ × C₂) ≅ nerve C₁ ⊗ nerve C₂ := by
+  let app (n : SimplexCategoryᵒᵖ) := (ComposableArrows.prodEquiv C₁ C₂ n.unop.len).toIso
+  exact NatIso.ofComponents app
+
 /-- Map a nerve of a product category to product of the nerves. -/
-def nerveProdToProdNerve : nerve (C₁ × C₂) ⟶ (nerve C₁) ⊗ (nerve C₂) where
-  app n := ↾(ComposableArrows.prodEquivalence C₁ C₂ n.unop.len).functor.obj
+def nerveProdToProdNerve : nerve (C₁ × C₂) ⟶ nerve C₁ ⊗ nerve C₂ := (nerveProdIso C₁ C₂).hom
 
 /-- Map a product of nerves to the nerve of the product category. -/
-def prodNerveToNerveProd : (nerve C₁) ⊗ (nerve C₂) ⟶ nerve (C₁ × C₂) where
-  app n := ↾(ComposableArrows.prodEquivalence C₁ C₂ n.unop.len).inverse.obj
+def prodNerveToNerveProd : nerve C₁ ⊗ nerve C₂ ⟶ nerve (C₁ × C₂) := (nerveProdIso C₁ C₂).inv
 
-/-- `nerve` preserves products. -/
-def nerveOfProductIso : nerve (C₁ × C₂) ≅ (nerve C₁) ⊗ (nerve C₂) where
-  hom := nerveProdToProdNerve C₁ C₂
-  inv := prodNerveToNerveProd C₁ C₂
 end
 
 section
 variable {C₁ C₂ : Type u} [Category.{v} C₁] [Category.{v} C₂]
 variable {D₁ D₂ : Type u} [Category.{v} D₁] [Category.{v} D₂]
 
-/-- Convert a pair of functors to a map between products of nerves -/
-def nerveOfProdMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
-    (nerve C₁) ⊗ (nerve C₂) ⟶ (nerve D₁) ⊗ (nerve D₂) :=
-  prodNerveToNerveProd C₁ C₂ ≫ nerveMap (F₁.prod F₂) ≫ nerveProdToProdNerve D₁ D₂
-
 lemma nerveOfProdMap_prod_nerveMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
-    nerveOfProdMap F₁ F₂ = nerveMap F₁ ⊗ₘ nerveMap F₂ := rfl
+    prodNerveToNerveProd C₁ C₂ ≫ nerveMap (F₁.prod F₂) ≫ nerveProdToProdNerve D₁ D₂
+    = nerveMap F₁ ⊗ₘ nerveMap F₂ := rfl
 
 variable {E₁ E₂ : Type u} [Category.{v} E₁] [Category.{v} E₂]
 
 lemma nerve_of_product_interchange (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) (G₁ : D₁ ⥤ E₁) (G₂ : D₂ ⥤ E₂) :
-    (nerveOfProdMap F₁ F₂) ≫ (nerveOfProdMap G₁ G₂)
-    = nerveOfProdMap (F₁ ⋙ G₁) (F₂ ⋙ G₂) := rfl
+    (nerveMap F₁ ⊗ₘ nerveMap F₂) ≫ (nerveMap G₁ ⊗ₘ nerveMap G₂)
+    = nerveMap (F₁ ⋙ G₁) ⊗ₘ nerveMap (F₂ ⋙ G₂) := rfl
 end
+
+def nerveOfTerminal : nerve (𝟙_ Cat.{v,u}) ≅ 𝟙_ SSet where
+  hom := SemiCartesianMonoidalCategory.toUnit _
+  inv := {
+    app n := by
+      repeat constructor
+      intro _
+      exact {
+        obj _ := by repeat constructor
+        map _ := by repeat constructor
+      }
+  }
+
+instance : Functor.Monoidal nerveFunctor where
+  ε := nerveOfTerminal.inv
+  μ C₁ C₂ := prodNerveToNerveProd C₁ C₂
+  η := nerveOfTerminal.hom
+  δ C₁ C₂ := nerveProdToProdNerve C₁ C₂
 
 end CategoryTheory.nerve

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 Dennis Sweeney. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dennis Sweeney
+-/
+module
+
+public import Mathlib.AlgebraicTopology.SimplicialSet.Nerve
+public import Mathlib.AlgebraicTopology.SimplicialSet.Monoidal
+
+/-!
+# The nerve of a product category
+
+The nerve of a product category can be identified with the product of the nerves.
+-/
+
+@[expose] public section
+
+open CategoryTheory MonoidalCategory
+
+universe v u
+
+namespace CategoryTheory.nerve
+
+section
+variable (C₁ C₂ : Type u) [Category.{v} C₁] [Category.{v} C₂]
+
+/-- Map a nerve of a product category to product of the nerves. -/
+def nerveProdToProdNerve : nerve (C₁ × C₂) ⟶ (nerve C₁) ⊗ (nerve C₂) := by
+  let app (n : SimplexCategoryᵒᵖ) : (nerve (C₁ × C₂)).obj n ⟶ (nerve C₁ ⊗ nerve C₂).obj n := by
+    constructor
+    exact ⟨fun γ ↦ ⟨γ ⋙ (CategoryTheory.Prod.fst C₁ C₂), γ ⋙ (CategoryTheory.Prod.snd C₁ C₂)⟩⟩
+  constructor
+  · intro m n d
+    exact Eq.symm
+          (CartesianMonoidalCategory.hom_ext (app m ≫ ((nerve C₁).map d ⊗ₘ (nerve C₂).map d))
+            ((nerve (C₁ × C₂)).map d ≫ app n) rfl rfl)
+
+/-- Map a product of nerves to the nerve of the product category. -/
+def prodNerveToNerveProd : (nerve C₁) ⊗ (nerve C₂) ⟶ nerve (C₁ × C₂) := by
+  let app (n : SimplexCategoryᵒᵖ) : (nerve C₁ ⊗ nerve C₂).obj n ⟶ (nerve (C₁ × C₂)).obj n := by
+    constructor
+    exact ⟨fun ⟨γ₁,γ₂⟩ ↦ γ₁.prod' γ₂⟩
+  constructor
+  · intro m n f
+    exact Eq.symm (eq_of_comp_right_eq'
+                    (app m ≫ (nerve (C₁ × C₂)).map f)
+                    ((nerve C₁ ⊗ nerve C₂).map f ≫ app n)
+                    rfl)
+
+/-- nerve preserves products. -/
+def nerveOfProductIso : nerve (C₁ × C₂) ≅ (nerve C₁) ⊗ (nerve C₂) where
+  hom := nerveProdToProdNerve C₁ C₂
+  inv := prodNerveToNerveProd C₁ C₂
+end
+
+section
+variable {C₁ C₂ : Type u} [Category.{v} C₁] [Category.{v} C₂]
+variable {D₁ D₂ : Type u} [Category.{v} D₁] [Category.{v} D₂]
+
+/-- Convert a pair of functors to a map between products of nerves -/
+def nerveOfProdMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
+    (nerve C₁) ⊗ (nerve C₂) ⟶ (nerve D₁) ⊗ (nerve D₂) :=
+  prodNerveToNerveProd C₁ C₂ ≫ nerveMap (F₁.prod F₂) ≫ nerveProdToProdNerve D₁ D₂
+
+lemma nerveOfProdMap_prod_nerveMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
+    nerveOfProdMap F₁ F₂ = nerveMap F₁ ⊗ₘ nerveMap F₂ := rfl
+
+variable {E₁ E₂ : Type u} [Category.{v} E₁] [Category.{v} E₂]
+
+lemma nerve_of_product_interchange (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) (G₁ : D₁ ⥤ E₁) (G₂ : D₂ ⥤ E₂) :
+    (nerveOfProdMap F₁ F₂) ≫ (nerveOfProdMap G₁ G₂)
+    = nerveOfProdMap (F₁ ⋙ G₁) (F₂ ⋙ G₂) := rfl
+end
+
+end CategoryTheory.nerve

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
@@ -26,27 +26,12 @@ section
 variable (C₁ C₂ : Type u) [Category.{v} C₁] [Category.{v} C₂]
 
 /-- Map a nerve of a product category to product of the nerves. -/
-def nerveProdToProdNerve : nerve (C₁ × C₂) ⟶ (nerve C₁) ⊗ (nerve C₂) := by
-  let app (n : SimplexCategoryᵒᵖ) : (nerve (C₁ × C₂)).obj n ⟶ (nerve C₁ ⊗ nerve C₂).obj n := by
-    constructor
-    exact ⟨fun γ ↦ ⟨γ ⋙ (CategoryTheory.Prod.fst C₁ C₂), γ ⋙ (CategoryTheory.Prod.snd C₁ C₂)⟩⟩
-  constructor
-  · intro m n d
-    exact Eq.symm
-          (CartesianMonoidalCategory.hom_ext (app m ≫ ((nerve C₁).map d ⊗ₘ (nerve C₂).map d))
-            ((nerve (C₁ × C₂)).map d ≫ app n) rfl rfl)
+def nerveProdToProdNerve : nerve (C₁ × C₂) ⟶ (nerve C₁) ⊗ (nerve C₂) where
+  app n := ↾(ComposableArrows.prodEquivalence C₁ C₂ n.unop.len).functor.obj
 
 /-- Map a product of nerves to the nerve of the product category. -/
-def prodNerveToNerveProd : (nerve C₁) ⊗ (nerve C₂) ⟶ nerve (C₁ × C₂) := by
-  let app (n : SimplexCategoryᵒᵖ) : (nerve C₁ ⊗ nerve C₂).obj n ⟶ (nerve (C₁ × C₂)).obj n := by
-    constructor
-    exact ⟨fun ⟨γ₁,γ₂⟩ ↦ γ₁.prod' γ₂⟩
-  constructor
-  · intro m n f
-    exact Eq.symm (eq_of_comp_right_eq'
-                    (app m ≫ (nerve (C₁ × C₂)).map f)
-                    ((nerve C₁ ⊗ nerve C₂).map f ≫ app n)
-                    rfl)
+def prodNerveToNerveProd : (nerve C₁) ⊗ (nerve C₂) ⟶ nerve (C₁ × C₂) where
+  app n := ↾(ComposableArrows.prodEquivalence C₁ C₂ n.unop.len).inverse.obj
 
 /-- nerve preserves products. -/
 def nerveOfProductIso : nerve (C₁ × C₂) ≅ (nerve C₁) ⊗ (nerve C₂) where

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
@@ -56,6 +56,7 @@ lemma nerve_of_product_interchange (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂)
     = nerveMap (F₁ ⋙ G₁) ⊗ₘ nerveMap (F₂ ⋙ G₂) := rfl
 end
 
+/-- The nerve of the terminal category is the terminal simplicial set. -/
 def nerveOfTerminal : nerve (𝟙_ Cat.{v,u}) ≅ 𝟙_ SSet where
   hom := SemiCartesianMonoidalCategory.toUnit _
   inv := {

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
@@ -25,54 +25,33 @@ universe v u
 
 namespace CategoryTheory.nerve
 
-section
-variable (C₁ C₂ : Type u) [Category.{v} C₁] [Category.{v} C₂]
-
 /-- `nerve` preserves products. -/
-def nerveProdIso : nerve (C₁ × C₂) ≅ nerve C₁ ⊗ nerve C₂ := by
-  let app (n : SimplexCategoryᵒᵖ) := (ComposableArrows.prodEquiv C₁ C₂ n.unop.len).toIso
-  exact NatIso.ofComponents app
-
-/-- Map a nerve of a product category to product of the nerves. -/
-def nerveProdToProdNerve : nerve (C₁ × C₂) ⟶ nerve C₁ ⊗ nerve C₂ := (nerveProdIso C₁ C₂).hom
-
-/-- Map a product of nerves to the nerve of the product category. -/
-def prodNerveToNerveProd : nerve C₁ ⊗ nerve C₂ ⟶ nerve (C₁ × C₂) := (nerveProdIso C₁ C₂).inv
-
-end
+def nerveProdIso (C₁ C₂ : Type u) [Category.{v} C₁] [Category.{v} C₂] :
+    nerve (C₁ × C₂) ≅ nerve C₁ ⊗ nerve C₂ :=
+  NatIso.ofComponents (fun n ↦ (ComposableArrows.prodEquiv C₁ C₂ n.unop.len).toIso)
 
 section
 variable {C₁ C₂ : Type u} [Category.{v} C₁] [Category.{v} C₂]
 variable {D₁ D₂ : Type u} [Category.{v} D₁] [Category.{v} D₂]
 
 lemma nerveOfProdMap_prod_nerveMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
-    prodNerveToNerveProd C₁ C₂ ≫ nerveMap (F₁.prod F₂) ≫ nerveProdToProdNerve D₁ D₂
-    = nerveMap F₁ ⊗ₘ nerveMap F₂ := rfl
+    (nerveProdIso C₁ C₂).inv ≫ nerveMap (F₁.prod F₂) ≫ (nerveProdIso D₁ D₂).hom =
+      nerveMap F₁ ⊗ₘ nerveMap F₂ := rfl
 
 variable {E₁ E₂ : Type u} [Category.{v} E₁] [Category.{v} E₂]
 
 lemma nerve_of_product_interchange (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) (G₁ : D₁ ⥤ E₁) (G₂ : D₂ ⥤ E₂) :
-    (nerveMap F₁ ⊗ₘ nerveMap F₂) ≫ (nerveMap G₁ ⊗ₘ nerveMap G₂)
-    = nerveMap (F₁ ⋙ G₁) ⊗ₘ nerveMap (F₂ ⋙ G₂) := rfl
+    (nerveMap F₁ ⊗ₘ nerveMap F₂) ≫ (nerveMap G₁ ⊗ₘ nerveMap G₂) =
+      nerveMap (F₁ ⋙ G₁) ⊗ₘ nerveMap (F₂ ⋙ G₂) := rfl
+
 end
 
-/-- The nerve of the terminal category is the terminal simplicial set. -/
-def nerveOfTerminal : nerve (𝟙_ Cat.{v,u}) ≅ 𝟙_ SSet where
-  hom := SemiCartesianMonoidalCategory.toUnit _
-  inv := {
-    app n := by
-      repeat constructor
-      intro _
-      exact {
-        obj _ := by repeat constructor
-        map _ := by repeat constructor
-      }
-  }
-
 instance : Functor.Monoidal nerveFunctor where
-  ε := nerveOfTerminal.inv
-  μ C₁ C₂ := prodNerveToNerveProd C₁ C₂
-  η := nerveOfTerminal.hom
-  δ C₁ C₂ := nerveProdToProdNerve C₁ C₂
+  δ C₁ C₂ := (nerveProdIso C₁ C₂).hom
+  μ C₁ C₂ := (nerveProdIso C₁ C₂).inv
+  η := SemiCartesianMonoidalCategory.toUnit _
+  ε.app _ := TypeCat.ofHom fun _ ↦
+    { obj _ := ⟨⟨⟨⟩⟩⟩
+      map _ := ⟨⟨⟨rfl⟩⟩⟩ }
 
 end CategoryTheory.nerve

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
@@ -6,20 +6,22 @@ Authors: Dennis Sweeney
 module
 
 public import Mathlib.AlgebraicTopology.SimplicialSet.Nerve
-public import Mathlib.AlgebraicTopology.SimplicialSet.Monoidal
-public import Mathlib.CategoryTheory.Monoidal.Category
-public import Mathlib.CategoryTheory.Monoidal.Functor
+public import Mathlib.AlgebraicTopology.SimplicialSet.Homotopy
+public import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplex
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Cat
+public import Mathlib.CategoryTheory.Functor.Currying
 
 /-!
 # The nerve of a product category
 
-The nerve of a product category can be identified with the product of the nerves.
+The nerve of a product category can be identified with the product of the nerves. This leads
+to a proof that a natural transformation between functors induces a homotopy between their
+`nerveMap`s.
 -/
 
 @[expose] public section
 
-open CategoryTheory MonoidalCategory
+open CategoryTheory MonoidalCategory SSet Functor
 
 universe v u
 
@@ -30,12 +32,47 @@ def nerveProdIso (C₁ C₂ : Type u) [Category.{v} C₁] [Category.{v} C₂] :
     nerve (C₁ × C₂) ≅ nerve C₁ ⊗ nerve C₂ :=
   NatIso.ofComponents (fun n ↦ (ComposableArrows.prodEquiv C₁ C₂ n.unop.len).toIso)
 
-instance : Functor.Monoidal nerveFunctor where
+instance : Monoidal nerveFunctor where
   δ C₁ C₂ := (nerveProdIso C₁ C₂).hom
   μ C₁ C₂ := (nerveProdIso C₁ C₂).inv
   η := SemiCartesianMonoidalCategory.toUnit _
   ε.app _ := TypeCat.ofHom fun _ ↦
     { obj _ := ⟨⟨⟨⟩⟩⟩
       map _ := ⟨⟨⟨rfl⟩⟩⟩ }
+
+section
+variable {C D : Type u} [SmallCategory C] [SmallCategory D]
+variable {F₀ F₁ : C ⥤ D}
+
+/-- Convert a natural transformation between functors into a homotopy between their `nerveMap`s. -/
+def homotopyOfNatTrans (η : F₀ ⟶ F₁) : Homotopy (nerveMap F₀) (nerveMap F₁) where
+  h := nerve C ◁ (stdSimplex.isoNerve 1).hom ≫
+    (nerveProdIso C (ULift (Fin 2))).inv ≫
+    nerveMap ((𝟭 C).prod ( { obj i := i.down,
+                             map ij := ⟨⟨ij.down.down⟩⟩} : ULift (Fin 2) ⥤ Fin 2) ⋙
+              Prod.swap C (Fin 2) ⋙
+              uncurry.obj (ComposableArrows.mk₁ η))
+  h₀ := by
+    let G₀ : C ⥤ Fin 2 × C := { obj c := ⟨0, c⟩, map f := ⟨𝟙 0, f⟩ }
+    change nerveMap (G₀ ⋙ uncurry.obj (ComposableArrows.mk₁ η)) = nerveMap F₀
+    apply congrArg nerveMap
+    apply CategoryTheory.Functor.mk.congr_simp
+    ext x y f
+    apply Category.id_comp
+  h₁ := by
+    let G₁ : C ⥤ Fin 2 × C := { obj c := ⟨1, c⟩, map f := ⟨𝟙 1, f⟩ }
+    change nerveMap (G₁ ⋙ uncurry.obj (ComposableArrows.mk₁ η)) = nerveMap F₁
+    apply congrArg nerveMap
+    apply CategoryTheory.Functor.mk.congr_simp
+    ext x y f
+    apply Category.id_comp
+  rel := by
+    ext n e_σ
+    refine IsEmpty.elim' ?_ e_σ
+    constructor
+    intro ⟨⟨e, he⟩, _⟩
+    simp at he
+
+end
 
 end CategoryTheory.nerve

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveProduct.lean
@@ -30,22 +30,6 @@ def nerveProdIso (C₁ C₂ : Type u) [Category.{v} C₁] [Category.{v} C₂] :
     nerve (C₁ × C₂) ≅ nerve C₁ ⊗ nerve C₂ :=
   NatIso.ofComponents (fun n ↦ (ComposableArrows.prodEquiv C₁ C₂ n.unop.len).toIso)
 
-section
-variable {C₁ C₂ : Type u} [Category.{v} C₁] [Category.{v} C₂]
-variable {D₁ D₂ : Type u} [Category.{v} D₁] [Category.{v} D₂]
-
-lemma nerveOfProdMap_prod_nerveMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
-    (nerveProdIso C₁ C₂).inv ≫ nerveMap (F₁.prod F₂) ≫ (nerveProdIso D₁ D₂).hom =
-      nerveMap F₁ ⊗ₘ nerveMap F₂ := rfl
-
-variable {E₁ E₂ : Type u} [Category.{v} E₁] [Category.{v} E₂]
-
-lemma nerve_of_product_interchange (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) (G₁ : D₁ ⥤ E₁) (G₂ : D₂ ⥤ E₂) :
-    (nerveMap F₁ ⊗ₘ nerveMap F₂) ≫ (nerveMap G₁ ⊗ₘ nerveMap G₂) =
-      nerveMap (F₁ ⋙ G₁) ⊗ₘ nerveMap (F₂ ⋙ G₂) := rfl
-
-end
-
 instance : Functor.Monoidal nerveFunctor where
   δ C₁ C₂ := (nerveProdIso C₁ C₂).hom
   μ C₁ C₂ := (nerveProdIso C₁ C₂).inv

--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -1065,6 +1065,11 @@ def prodIsoCat : IsoCat (ComposableArrows (C × D) n)
   unit_eq := rfl
   counit_eq := rfl
 
+/-- `ComposableArrows` preserves products, up to bijection. -/
+def prodEquiv : ComposableArrows (C × D) n ≃ ComposableArrows C n × ComposableArrows D n where
+  toFun := (prodEquivalence C D n).functor.obj
+  invFun := (prodEquivalence C D n).inverse.obj
+
 end
 
 end ComposableArrows

--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -1053,9 +1053,11 @@ namespace ComposableArrows
 section
 variable (D : Type*) [Category* D] (n : ℕ)
 
+/-- `ComposableArrows` preserves products, up to equivalence of categories. -/
 def prodEquivalence : ComposableArrows (C × D) n ≌ ComposableArrows C n × ComposableArrows D n :=
   (functorProdFunctorEquiv (Fin (n + 1)) C D).symm
 
+/-- `ComposableArrows` preserves products, up to isomorphism of categories. -/
 def prodIsoCat : IsoCat (ComposableArrows (C × D) n)
                         (ComposableArrows C n × ComposableArrows D n) where
   functor := (prodEquivalence C D n).functor

--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Group.Nat.Defs
 public import Mathlib.CategoryTheory.Category.Preorder
 public import Mathlib.CategoryTheory.Comma.Arrow
+public import Mathlib.CategoryTheory.IsoCat
 public import Mathlib.Data.Fintype.Basic
 public import Mathlib.Tactic.FinCases
 public import Mathlib.Tactic.SuppressCompilation
@@ -1046,5 +1047,24 @@ def Functor.mapComposableArrowsOpIso :
   Iso.refl _
 
 end
+
+namespace ComposableArrows
+
+section
+variable (D : Type*) [Category* D] (n : ℕ)
+
+def prodEquivalence : ComposableArrows (C × D) n ≌ ComposableArrows C n × ComposableArrows D n :=
+  (functorProdFunctorEquiv (Fin (n + 1)) C D).symm
+
+def prodIsoCat : IsoCat (ComposableArrows (C × D) n)
+                        (ComposableArrows C n × ComposableArrows D n) where
+  functor := (prodEquivalence C D n).functor
+  inverse := (prodEquivalence C D n).inverse
+  unit_eq := rfl
+  counit_eq := rfl
+
+end
+
+end ComposableArrows
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.Group.Nat.Defs
 public import Mathlib.CategoryTheory.Category.Preorder
 public import Mathlib.CategoryTheory.Comma.Arrow
 public import Mathlib.CategoryTheory.IsoCat
+public import Mathlib.CategoryTheory.Products.Basic
 public import Mathlib.Data.Fintype.Basic
 public import Mathlib.Tactic.FinCases
 public import Mathlib.Tactic.SuppressCompilation
@@ -1054,19 +1055,16 @@ section
 variable (D : Type*) [Category* D] (n : ℕ)
 
 /-- `ComposableArrows` preserves products, up to equivalence of categories. -/
-def prodEquivalence : ComposableArrows (C × D) n ≌ ComposableArrows C n × ComposableArrows D n :=
+abbrev prodEquivalence : ComposableArrows (C × D) n ≌ ComposableArrows C n × ComposableArrows D n :=
   (functorProdFunctorEquiv (Fin (n + 1)) C D).symm
 
 /-- `ComposableArrows` preserves products, up to isomorphism of categories. -/
-def prodIsoCat : IsoCat (ComposableArrows (C × D) n)
-                        (ComposableArrows C n × ComposableArrows D n) where
-  functor := (prodEquivalence C D n).functor
-  inverse := (prodEquivalence C D n).inverse
-  unit_eq := rfl
-  counit_eq := rfl
+abbrev prodIsoCat : IsoCat (ComposableArrows (C × D) n)
+                           (ComposableArrows C n × ComposableArrows D n) :=
+  (functorProdFunctorIsoCat (Fin (n + 1)) C D).symm
 
 /-- `ComposableArrows` preserves products, up to bijection. -/
-def prodEquiv : ComposableArrows (C × D) n ≃ ComposableArrows C n × ComposableArrows D n :=
+abbrev prodEquiv : ComposableArrows (C × D) n ≃ ComposableArrows C n × ComposableArrows D n :=
   IsoCat.objEquiv (prodIsoCat C D n)
 
 end

--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -1066,9 +1066,8 @@ def prodIsoCat : IsoCat (ComposableArrows (C × D) n)
   counit_eq := rfl
 
 /-- `ComposableArrows` preserves products, up to bijection. -/
-def prodEquiv : ComposableArrows (C × D) n ≃ ComposableArrows C n × ComposableArrows D n where
-  toFun := (prodEquivalence C D n).functor.obj
-  invFun := (prodEquivalence C D n).inverse.obj
+def prodEquiv : ComposableArrows (C × D) n ≃ ComposableArrows C n × ComposableArrows D n :=
+  IsoCat.objEquiv (prodIsoCat C D n)
 
 end
 

--- a/Mathlib/CategoryTheory/IsoCat.lean
+++ b/Mathlib/CategoryTheory/IsoCat.lean
@@ -171,6 +171,7 @@ instance IsoCat.isIso_functor (e : IsoCat C D) : e.functor.IsIso where
       Functor.congr_obj e.counit_eq⟩
 
 /-- Convert an isomorphism of categories into a bijection on objects. -/
+@[implicit_reducible, simps]
 def IsoCat.objEquiv (e : IsoCat C D) : C ≃ D where
   toFun := e.functor.obj
   invFun := e.inverse.obj

--- a/Mathlib/CategoryTheory/IsoCat.lean
+++ b/Mathlib/CategoryTheory/IsoCat.lean
@@ -170,6 +170,13 @@ instance IsoCat.isIso_functor (e : IsoCat C D) : e.functor.IsIso where
     ⟨e.inverse.obj, fun X => (Functor.congr_obj e.unit_eq X).symm,
       Functor.congr_obj e.counit_eq⟩
 
+/-- Convert an isomorphism of categories into a bijection on objects. -/
+def IsoCat.objEquiv (e : IsoCat C D) : C ≃ D where
+  toFun := e.functor.obj
+  invFun := e.inverse.obj
+  left_inv c : (e.functor ⋙ e.inverse).obj c = (𝟭 C).obj c := by rw [e.unit_eq]
+  right_inv d : (e.inverse ⋙ e.functor).obj d = (𝟭 D).obj d := by rw [e.counit_eq]
+
 instance (e : IsoCat C D) : e.inverse.IsIso := e.symm.isIso_functor
 
 instance [F.IsIso] : F.strictInv.IsIso := F.asIsomorphism.symm.isIso_functor

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.CategoryTheory.EqToHom
 public import Mathlib.CategoryTheory.Functor.Const
+public import Mathlib.CategoryTheory.IsoCat
 public import Mathlib.CategoryTheory.Opposites
 public import Mathlib.Data.Prod.Basic
 
@@ -440,6 +441,13 @@ def functorProdFunctorEquiv : (A ⥤ B) × (A ⥤ C) ≌ A ⥤ B × C :=
     inverse := functorProdToProdFunctor A B C,
     unitIso := functorProdFunctorEquivUnitIso A B C,
     counitIso := functorProdFunctorEquivCounitIso A B C, }
+
+/-- The isomorphism of categories between `(A ⥤ B) × (A ⥤ C)` and `A ⥤ (B × C)` -/
+def functorProdFunctorIsoCat : IsoCat ((A ⥤ B) × (A ⥤ C)) (A ⥤ B × C) where
+  functor := prodFunctorToFunctorProd A B C
+  inverse := functorProdToProdFunctor A B C
+  unit_eq := rfl
+  counit_eq := rfl
 
 section Opposite
 


### PR DESCRIPTION
Given a natural transformation between two functors, we produce a homotopy between the maps they induce on nerve simplicial sets.

---

Using `SmallCategory` instances made the proof easier--I had trouble with the universe levels involved when trying to use `Category.{v} C` instead. One could use [CategoryTheory.AsSmall](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Category/ULift.html#CategoryTheory.AsSmall) to convert to a small category first.

- [ ] depends on: #41963

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
