### PR TITLE
feat(MeasureTheory): one-sided continuous functions are measurable

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -854,7 +854,8 @@ theorem MeasurableSet.of_mem_nhdsLT {s : Set α} (h : ∀ x ∈ s, s ∈ 𝓝[<]
 
 /-- A function which is right continuous at every point of a second-countable linear order is
 measurable. -/
-@[to_dual]
+@[to_dual /-- A function which is left continuous at every point of a second-countable linear order
+is measurable. -/]
 theorem measurable_of_continuousWithinAt_Ioi {f : α → β}
     (hf : ∀ x, ContinuousWithinAt f (Ioi x) x) : Measurable f :=
   measurable_of_isOpen fun _ hu ↦ .of_mem_nhdsGT fun x hx ↦ (hf x (hu.mem_nhds hx))

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -848,22 +848,16 @@ theorem MeasurableSet.of_mem_nhdsGT {s : Set α} (h : ∀ x ∈ s, s ∈ 𝓝[>]
     exact H
 
 /-- If a set is a left-neighborhood of all of its points, then it is measurable. -/
+@[to_dual existing]
 theorem MeasurableSet.of_mem_nhdsLT {s : Set α} (h : ∀ x ∈ s, s ∈ 𝓝[<] x) : MeasurableSet s :=
-  MeasurableSet.of_mem_nhdsGT (α := αᵒᵈ) h
+  of_mem_nhdsGT (α := αᵒᵈ) h
 
 /-- A function which is right continuous at every point of a second-countable linear order is
-measurable. The preimage of an open set is a right-neighborhood of each of its points, hence
-measurable by `MeasurableSet.of_mem_nhdsGT`. -/
-theorem measurable_of_continuousWithinAt_Ici {f : α → β}
-    (hf : ∀ x, ContinuousWithinAt f (Ici x) x) : Measurable f :=
-  measurable_of_isOpen fun _ hu ↦ .of_mem_nhdsGT fun x hx ↦
-    nhdsWithin_mono x Ioi_subset_Ici_self (hf x (hu.mem_nhds hx))
-
-/-- A function which is left continuous at every point of a second-countable linear order is
 measurable. -/
-theorem measurable_of_continuousWithinAt_Iic {f : α → β}
-    (hf : ∀ x, ContinuousWithinAt f (Iic x) x) : Measurable f :=
-  measurable_of_continuousWithinAt_Ici (α := αᵒᵈ) hf
+@[to_dual]
+theorem measurable_of_continuousWithinAt_Ioi {f : α → β}
+    (hf : ∀ x, ContinuousWithinAt f (Ioi x) x) : Measurable f :=
+  measurable_of_isOpen fun _ hu ↦ .of_mem_nhdsGT fun x hx ↦ (hf x (hu.mem_nhds hx))
 
 lemma measurableSet_bddAbove_range {ι} [Countable ι] {f : ι → δ → α} (hf : ∀ i, Measurable (f i)) :
     MeasurableSet {b | BddAbove (range (fun i ↦ f i b))} := by

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -847,6 +847,24 @@ theorem MeasurableSet.of_mem_nhdsGT {s : Set α} (h : ∀ x ∈ s, s ∈ 𝓝[>]
     push Not at H
     exact H
 
+/-- If a set is a left-neighborhood of all of its points, then it is measurable. -/
+theorem MeasurableSet.of_mem_nhdsLT {s : Set α} (h : ∀ x ∈ s, s ∈ 𝓝[<] x) : MeasurableSet s :=
+  MeasurableSet.of_mem_nhdsGT (α := αᵒᵈ) h
+
+/-- A function which is right continuous at every point of a second-countable linear order is
+measurable. The preimage of an open set is a right-neighborhood of each of its points, hence
+measurable by `MeasurableSet.of_mem_nhdsGT`. -/
+theorem measurable_of_continuousWithinAt_Ici {f : α → β}
+    (hf : ∀ x, ContinuousWithinAt f (Ici x) x) : Measurable f :=
+  measurable_of_isOpen fun _ hu ↦ .of_mem_nhdsGT fun x hx ↦
+    nhdsWithin_mono x Ioi_subset_Ici_self (hf x (hu.mem_nhds hx))
+
+/-- A function which is left continuous at every point of a second-countable linear order is
+measurable. -/
+theorem measurable_of_continuousWithinAt_Iic {f : α → β}
+    (hf : ∀ x, ContinuousWithinAt f (Iic x) x) : Measurable f :=
+  measurable_of_continuousWithinAt_Ici (α := αᵒᵈ) hf
+
 lemma measurableSet_bddAbove_range {ι} [Countable ι] {f : ι → δ → α} (hf : ∀ i, Measurable (f i)) :
     MeasurableSet {b | BddAbove (range (fun i ↦ f i b))} := by
   rcases isEmpty_or_nonempty α with hα | hα

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -726,6 +726,31 @@ theorem _root_.Continuous.stronglyMeasurable [MeasurableSpace α] [TopologicalSp
     exact isSeparable_range hf
   · exact hf.measurable.stronglyMeasurable
 
+/-- A function which is right continuous at every point of a second-countable linear order is
+strongly measurable.
+
+Unlike `Continuous.stronglyMeasurable`, no countability assumption is made on the target: right
+continuity forces the range of `f` to lie in the closure of the image of a countable set. -/
+theorem _root_.stronglyMeasurable_of_continuousWithinAt_Ici [MeasurableSpace α] [TopologicalSpace α]
+    [LinearOrder α] [OrderTopology α] [SecondCountableTopology α] [BorelSpace α]
+    [TopologicalSpace β] [PseudoMetrizableSpace β] {f : α → β}
+    (hf : ∀ x, ContinuousWithinAt f (Ici x) x) : StronglyMeasurable f := by
+  borelize β
+  obtain ⟨D, hDc, hD⟩ := exists_countable_mem_closure_inter_Ici (α := α)
+  refine stronglyMeasurable_iff_measurable_separable.2
+    ⟨measurable_of_continuousWithinAt_Ici hf, f '' D, hDc.image f, ?_⟩
+  rintro _ ⟨x, rfl⟩
+  exact closure_mono (image_mono inter_subset_left)
+    (((hf x).mono inter_subset_right).mem_closure_image (hD x))
+
+/-- A function which is left continuous at every point of a second-countable linear order is
+strongly measurable. -/
+theorem _root_.stronglyMeasurable_of_continuousWithinAt_Iic [MeasurableSpace α] [TopologicalSpace α]
+    [LinearOrder α] [OrderTopology α] [SecondCountableTopology α] [BorelSpace α]
+    [TopologicalSpace β] [PseudoMetrizableSpace β] {f : α → β}
+    (hf : ∀ x, ContinuousWithinAt f (Iic x) x) : StronglyMeasurable f :=
+  stronglyMeasurable_of_continuousWithinAt_Ici (α := αᵒᵈ) hf
+
 /-- A continuous function whose support is contained in a compact set is strongly measurable. -/
 @[to_additive /-- A continuous function whose support is contained in a compact set is strongly
 measurable. -/]

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -727,29 +727,17 @@ theorem _root_.Continuous.stronglyMeasurable [MeasurableSpace α] [TopologicalSp
   · exact hf.measurable.stronglyMeasurable
 
 /-- A function which is right continuous at every point of a second-countable linear order is
-strongly measurable.
-
-Unlike `Continuous.stronglyMeasurable`, no countability assumption is made on the target: right
-continuity forces the range of `f` to lie in the closure of the image of a countable set. -/
-theorem _root_.stronglyMeasurable_of_continuousWithinAt_Ici [MeasurableSpace α] [TopologicalSpace α]
-    [LinearOrder α] [OrderTopology α] [SecondCountableTopology α] [BorelSpace α]
-    [TopologicalSpace β] [PseudoMetrizableSpace β] {f : α → β}
-    (hf : ∀ x, ContinuousWithinAt f (Ici x) x) : StronglyMeasurable f := by
-  borelize β
-  obtain ⟨D, hDc, hD⟩ := exists_countable_mem_closure_inter_Ici (α := α)
-  refine stronglyMeasurable_iff_measurable_separable.2
-    ⟨measurable_of_continuousWithinAt_Ici hf, f '' D, hDc.image f, ?_⟩
-  rintro _ ⟨x, rfl⟩
-  exact closure_mono (image_mono inter_subset_left)
-    (((hf x).mono inter_subset_right).mem_closure_image (hD x))
-
-/-- A function which is left continuous at every point of a second-countable linear order is
 strongly measurable. -/
-theorem _root_.stronglyMeasurable_of_continuousWithinAt_Iic [MeasurableSpace α] [TopologicalSpace α]
+@[to_dual /-- A function which is left continuous at every point of a second-countable linear order
+is strongly measurable. -/]
+theorem _root_.stronglyMeasurable_of_continuousWithinAt_Ioi [MeasurableSpace α] [TopologicalSpace α]
     [LinearOrder α] [OrderTopology α] [SecondCountableTopology α] [BorelSpace α]
     [TopologicalSpace β] [PseudoMetrizableSpace β] {f : α → β}
-    (hf : ∀ x, ContinuousWithinAt f (Iic x) x) : StronglyMeasurable f :=
-  stronglyMeasurable_of_continuousWithinAt_Ici (α := αᵒᵈ) hf
+    (hf : ∀ x, ContinuousWithinAt f (Ioi x) x) : StronglyMeasurable f := by
+  borelize β
+  let := separableSpace_range_of_continuousWithinAt_Ioi hf
+  rw [stronglyMeasurable_iff_measurable_separable]
+  exact ⟨measurable_of_continuousWithinAt_Ioi hf, IsSeparable.of_subtype _⟩
 
 /-- A continuous function whose support is contained in a compact set is strongly measurable. -/
 @[to_additive /-- A continuous function whose support is contained in a compact set is strongly

--- a/Mathlib/Topology/Order/LeftRightNhds.lean
+++ b/Mathlib/Topology/Order/LeftRightNhds.lean
@@ -123,6 +123,33 @@ theorem countable_setOfPred_isolated_left [SecondCountableTopology α] :
 @[deprecated (since := "2026-07-09")]
 alias countable_setOf_isolated_left := countable_setOfPred_isolated_left
 
+/-- A second-countable linear order admits a countable set `D` which is dense *from the right*:
+every point lies in the closure of `D ∩ Set.Ici x`.
+
+A countable dense set does not suffice, since `D` must contain every point that is isolated on the
+right; but there are only countably many of those. -/
+theorem exists_countable_mem_closure_inter_Ici [SecondCountableTopology α] :
+    ∃ D : Set α, D.Countable ∧ ∀ x : α, x ∈ closure (D ∩ Ici x) := by
+  obtain ⟨D₀, hD₀c, hD₀⟩ := exists_countable_dense α
+  refine ⟨D₀ ∪ { x : α | 𝓝[>] x = ⊥ }, hD₀c.union countable_setOfPred_isolated_right, fun x ↦ ?_⟩
+  by_cases hx : 𝓝[>] x = ⊥
+  · exact subset_closure ⟨Or.inr hx, le_rfl⟩
+  · have : (𝓝[>] x).NeBot := neBot_iff.2 hx
+    refine mem_closure_iff.2 fun u hu hxu ↦ ?_
+    obtain ⟨d, hdD₀, hd⟩ := hD₀.exists_mem_open (hu.inter isOpen_Ioi)
+      (this.nonempty_of_mem (inter_mem (mem_nhdsWithin_of_mem_nhds (hu.mem_nhds hxu))
+        self_mem_nhdsWithin))
+    exact ⟨d, hd.1, Or.inl hdD₀, hd.2.le⟩
+
+/-- A second-countable linear order admits a countable set `D` which is dense *from the left*:
+every point lies in the closure of `D ∩ Set.Iic x`.
+
+A countable dense set does not suffice, since `D` must contain every point that is isolated on the
+left; but there are only countably many of those. -/
+theorem exists_countable_mem_closure_inter_Iic [SecondCountableTopology α] :
+    ∃ D : Set α, D.Countable ∧ ∀ x : α, x ∈ closure (D ∩ Iic x) :=
+  exists_countable_mem_closure_inter_Ici (α := αᵒᵈ)
+
 /-- The set of points in a set which are isolated on the right in this set is countable when the
 space is second-countable. -/
 theorem countable_setOfPred_isolated_right_within [SecondCountableTopology α] {s : Set α} :

--- a/Mathlib/Topology/Order/LeftRightNhds.lean
+++ b/Mathlib/Topology/Order/LeftRightNhds.lean
@@ -123,28 +123,6 @@ theorem countable_setOfPred_isolated_left [SecondCountableTopology α] :
 @[deprecated (since := "2026-07-09")]
 alias countable_setOf_isolated_left := countable_setOfPred_isolated_left
 
-/-- A second-countable linear order admits a countable set `D` such that each `x` lies in the
-closure of `D ∩ Ici x`. -/
-theorem exists_countable_mem_closure_inter_Ici [SecondCountableTopology α] :
-    ∃ D : Set α, D.Countable ∧ ∀ x, x ∈ closure (D ∩ Ici x) := by
-  obtain ⟨D₀, hD₀c, hD₀⟩ := exists_countable_dense α
-  refine ⟨D₀ ∪ {x | 𝓝[>] x = ⊥}, hD₀c.union countable_setOfPred_isolated_right,
-    fun x ↦ ?_⟩
-  by_cases hx : 𝓝[>] x = ⊥
-  · exact subset_closure ⟨Or.inr hx, le_rfl⟩
-  · have : (𝓝[>] x).NeBot := neBot_iff.2 hx
-    refine mem_closure_iff.2 fun u hu hxu ↦ ?_
-    obtain ⟨d, hdD₀, hd⟩ := hD₀.exists_mem_open (hu.inter isOpen_Ioi)
-      (this.nonempty_of_mem (inter_mem (mem_nhdsWithin_of_mem_nhds (hu.mem_nhds hxu))
-        self_mem_nhdsWithin))
-    exact ⟨d, hd.1, Or.inl hdD₀, hd.2.le⟩
-
-/-- A second-countable linear order admits a countable set `D` such that each `x` lies in the
-closure of `D ∩ Set.Iic x`. -/
-theorem exists_countable_mem_closure_inter_Iic [SecondCountableTopology α] :
-    ∃ D : Set α, D.Countable ∧ ∀ x, x ∈ closure (D ∩ Iic x) :=
-  exists_countable_mem_closure_inter_Ici (α := αᵒᵈ)
-
 /-- The set of points in a set which are isolated on the right in this set is countable when the
 space is second-countable. -/
 theorem countable_setOfPred_isolated_right_within [SecondCountableTopology α] {s : Set α} :

--- a/Mathlib/Topology/Order/LeftRightNhds.lean
+++ b/Mathlib/Topology/Order/LeftRightNhds.lean
@@ -182,11 +182,11 @@ theorem exists_countable_subset_mem_closure_inter_Ici [SecondCountableTopology �
   · exact (hdc.image _).union countable_setOfPred_isolated_right_within
   refine mem_closure_iff.2 fun u hu hxu ↦ ?_
   rcases (u ∩ (s ∩ Ioi x)).eq_empty_or_nonempty with h | ⟨y, hyu, hys, hyx⟩
-  · exact ⟨x, hxu, Or.inr ⟨hxs, empty_mem_iff_bot.1 <| h ▸ inter_mem
+  · exact ⟨x, hxu, .inr ⟨hxs, empty_mem_iff_bot.1 <| h ▸ inter_mem
       (mem_nhdsWithin_of_mem_nhds (hu.mem_nhds hxu)) self_mem_nhdsWithin⟩, le_rfl⟩
   · obtain ⟨z, hzd, hz⟩ := hd.exists_mem_open
       ((hu.inter isOpen_Ioi).preimage continuous_subtype_val) ⟨⟨y, hys⟩, hyu, hyx⟩
-    exact ⟨z, hz.1, Or.inl ⟨z, hzd, rfl⟩, hz.2.le⟩
+    exact ⟨z, hz.1, .inl ⟨z, hzd, rfl⟩, hz.2.le⟩
 
 @[to_dual existing]
 theorem exists_countable_subset_mem_closure_inter_Iic [SecondCountableTopology α] (s : Set α) :

--- a/Mathlib/Topology/Order/LeftRightNhds.lean
+++ b/Mathlib/Topology/Order/LeftRightNhds.lean
@@ -123,15 +123,13 @@ theorem countable_setOfPred_isolated_left [SecondCountableTopology α] :
 @[deprecated (since := "2026-07-09")]
 alias countable_setOf_isolated_left := countable_setOfPred_isolated_left
 
-/-- A second-countable linear order admits a countable set `D` which is dense *from the right*:
-every point lies in the closure of `D ∩ Set.Ici x`.
-
-A countable dense set does not suffice, since `D` must contain every point that is isolated on the
-right; but there are only countably many of those. -/
+/-- A second-countable linear order admits a countable set `D` such that each `x` lies in the
+closure of `D ∩ Ici x`. -/
 theorem exists_countable_mem_closure_inter_Ici [SecondCountableTopology α] :
-    ∃ D : Set α, D.Countable ∧ ∀ x : α, x ∈ closure (D ∩ Ici x) := by
+    ∃ D : Set α, D.Countable ∧ ∀ x, x ∈ closure (D ∩ Ici x) := by
   obtain ⟨D₀, hD₀c, hD₀⟩ := exists_countable_dense α
-  refine ⟨D₀ ∪ { x : α | 𝓝[>] x = ⊥ }, hD₀c.union countable_setOfPred_isolated_right, fun x ↦ ?_⟩
+  refine ⟨D₀ ∪ {x | 𝓝[>] x = ⊥}, hD₀c.union countable_setOfPred_isolated_right,
+    fun x ↦ ?_⟩
   by_cases hx : 𝓝[>] x = ⊥
   · exact subset_closure ⟨Or.inr hx, le_rfl⟩
   · have : (𝓝[>] x).NeBot := neBot_iff.2 hx
@@ -141,13 +139,10 @@ theorem exists_countable_mem_closure_inter_Ici [SecondCountableTopology α] :
         self_mem_nhdsWithin))
     exact ⟨d, hd.1, Or.inl hdD₀, hd.2.le⟩
 
-/-- A second-countable linear order admits a countable set `D` which is dense *from the left*:
-every point lies in the closure of `D ∩ Set.Iic x`.
-
-A countable dense set does not suffice, since `D` must contain every point that is isolated on the
-left; but there are only countably many of those. -/
+/-- A second-countable linear order admits a countable set `D` such that each `x` lies in the
+closure of `D ∩ Set.Iic x`. -/
 theorem exists_countable_mem_closure_inter_Iic [SecondCountableTopology α] :
-    ∃ D : Set α, D.Countable ∧ ∀ x : α, x ∈ closure (D ∩ Iic x) :=
+    ∃ D : Set α, D.Countable ∧ ∀ x, x ∈ closure (D ∩ Iic x) :=
   exists_countable_mem_closure_inter_Ici (α := αᵒᵈ)
 
 /-- The set of points in a set which are isolated on the right in this set is countable when the
@@ -201,6 +196,48 @@ theorem countable_setOfPred_isolated_left_within [SecondCountableTopology α] {s
 
 @[deprecated (since := "2026-07-09")]
 alias countable_setOf_isolated_left_within := countable_setOfPred_isolated_left_within
+
+theorem exists_countable_subset_mem_closure_inter_Ici [SecondCountableTopology α] (s : Set α) :
+    ∃ d, d ⊆ s ∧ d.Countable ∧ ∀ x ∈ s, x ∈ closure (d ∩ Ici x) := by
+  obtain ⟨d, hdc, hd⟩ := exists_countable_dense s
+  refine ⟨(↑) '' d ∪ {x ∈ s | 𝓝[s ∩ Ioi x] x = ⊥}, by grind, ?_, fun x hxs ↦ ?_⟩
+  · exact (hdc.image _).union countable_setOfPred_isolated_right_within
+  refine mem_closure_iff.2 fun u hu hxu ↦ ?_
+  rcases (u ∩ (s ∩ Ioi x)).eq_empty_or_nonempty with h | ⟨y, hyu, hys, hyx⟩
+  · exact ⟨x, hxu, Or.inr ⟨hxs, empty_mem_iff_bot.1 <| h ▸ inter_mem
+      (mem_nhdsWithin_of_mem_nhds (hu.mem_nhds hxu)) self_mem_nhdsWithin⟩, le_rfl⟩
+  · obtain ⟨z, hzd, hz⟩ := hd.exists_mem_open
+      ((hu.inter isOpen_Ioi).preimage continuous_subtype_val) ⟨⟨y, hys⟩, hyu, hyx⟩
+    exact ⟨z, hz.1, Or.inl ⟨z, hzd, rfl⟩, hz.2.le⟩
+
+@[to_dual existing]
+theorem exists_countable_subset_mem_closure_inter_Iic [SecondCountableTopology α] (s : Set α) :
+    ∃ d, d ⊆ s ∧ d.Countable ∧ ∀ x ∈ s, x ∈ closure (d ∩ Iic x) :=
+  exists_countable_subset_mem_closure_inter_Ici (α := αᵒᵈ) s
+
+/-- The image of a set of a second-countable linear order under a right-continuous function is a
+separable space. -/
+@[to_dual /-- The image of a set of a second-countable linear order under a left-continuous function
+is a separable space. -/]
+theorem separableSpace_image_of_continuousWithinAt_Ioi [SecondCountableTopology α] {s : Set α}
+    [TopologicalSpace β] {f : α → β} (hf : ∀ x ∈ s, ContinuousWithinAt f (s ∩ Ioi x) x) :
+    SeparableSpace (f '' s) := by
+  obtain ⟨d, hds, hdc, hd⟩ := exists_countable_subset_mem_closure_inter_Ici s
+  refine ⟨Subtype.val ⁻¹' (f '' d), (hdc.image _).preimage Subtype.val_injective, ?_⟩
+  rw [Subtype.dense_iff, Subtype.image_preimage_coe, inter_eq_self_of_subset_right (image_mono hds)]
+  rintro _ ⟨x, hxs, rfl⟩
+  refine closure_mono (s := f '' (d ∩ Ici x)) ?_ ?_
+  · exact image_mono inter_subset_left
+  · exact ((continuousWithinAt_inter_Ioi_iff_Ici.1 (hf x hxs)).mono fun _ hy ↦
+      ⟨hds hy.1, hy.2⟩).mem_closure_image (hd x hxs)
+
+/-- The range of a right-continuous function on a second-countable linear order is separable. -/
+@[to_dual /-- The range of a left-continuous function on a second-countable linear order is
+separable. -/]
+theorem separableSpace_range_of_continuousWithinAt_Ioi [SecondCountableTopology α]
+    [TopologicalSpace β] {f : α → β} (hf : ∀ x, ContinuousWithinAt f (Ioi x) x) :
+    SeparableSpace (range f) :=
+  image_univ ▸ separableSpace_image_of_continuousWithinAt_Ioi fun x _ ↦ by simpa using hf x
 
 /-- A set is a neighborhood of `a` within `(a, +∞)` if and only if it contains an interval `(a, u]`
 with `a < u`. -/


### PR DESCRIPTION
The following lemmas are proved in this PR:
- the image of a set of a second-countable linear order under a right-continuous function is a
separable space.
- a right continuous function is measurable.
- a right continuous function is strongly measurable.
The corresponding statements for left continuous functions are also included.

Note: the statement that a right continuous function is strongly measurable is actually true even in the case that the codomain is not assumed to be strongly measurable, and this can be proved through an explicit construction of an approximating sequence of simple functions. However, this proof is definitely more lengthy, and I believe in practice we only care about strongly measurable functions in the case of integrating banach space valued functions. This is why I decide to assume pseudometrizability so that a simpler proof is available through the use of [stronglyMeasurable_iff_measurable_separable](https://leanprover-community.github.io/mathlib4_docs/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.html#stronglyMeasurable_iff_measurable_separable).

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
