### PR TITLE
feat(Order/Partition): converting a `Finpartition` into a `Partition`

### DIFF
--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -5,8 +5,7 @@ Authors: Peter Nelson
 -/
 module
 
-public import Mathlib.Data.SetLike.Basic
-public import Mathlib.Order.SupIndep
+public import Mathlib.Order.Partition.Finpartition
 
 /-!
 # Partitions
@@ -55,7 +54,6 @@ proved separately.
 
 ## TODO
 
-* Link this to `Finpartition`.
 * Show that when `α` is a frame `Partition α` also has finite joins, i.e. that it is a lattice.
 
 -/
@@ -555,3 +553,51 @@ lemma nonempty (P : Partition u) : ∃ f, IsRepFun P f := by
 
 end IsRepFun
 end Partition.IsRepFun
+
+namespace Finpartition
+
+section CompleteLattice
+
+variable [CompleteLattice α]
+
+/-- Converts a `Finpartition` into a `Partition`. -/
+def toPartition : Finpartition x ↪o Partition x where
+  toFun P :=
+    { parts := P.parts
+      sSupIndep' := P.supIndep.sSupIndep
+      bot_notMem' := P.bot_notMem
+      sSup_eq' := by rw [← Finset.sup_id_eq_sSup, P.sup_parts] }
+  inj' :=
+    .of_comp (f := SetLike.coe) <| (SetLike.coe_injective (A := Finset α)).comp <|
+      fun _ _ => Finpartition.ext
+  map_rel_iff' := .rfl
+
+@[simp]
+theorem coe_toPartition (P : Finpartition x) : (P.toPartition : Set α) = P.parts :=
+  rfl
+
+@[simp]
+theorem mem_toPartition (P : Finpartition x) {y : α} : y ∈ P.toPartition ↔ y ∈ P.parts :=
+  .rfl
+
+instance : CanLift (Partition x) (Finpartition x) toPartition (fun P => (P : Set α).Finite) where
+  prf := by
+    rintro ⟨s, hs₁, hs₂, rfl⟩ h
+    lift s to Finset α using h
+    exact ⟨⟨s, hs₁.supIndep, s.sup_id_eq_sSup, hs₂⟩, rfl⟩
+
+@[simp]
+theorem toPartition_top [Decidable (x = ⊥)] : (⊤ : Finpartition x).toPartition = ⊤ := by
+  ext
+  rw [mem_toPartition, mem_parts_top, Partition.mem_top_iff]
+
+end CompleteLattice
+
+theorem toPartition_inf [Order.Frame α] [DecidableEq α] {x : α} {P Q : Finpartition x} :
+    (P ⊓ Q).toPartition = P.toPartition ⊓ Q.toPartition := by
+  ext b
+  simp_rw [Partition.mem_inf_iff, mem_toPartition, parts_inf, Finset.mem_erase, Finset.mem_image,
+    Finset.mem_product, Prod.exists]
+  grind only
+
+end Finpartition

--- a/Mathlib/Order/Partition/Finpartition.lean
+++ b/Mathlib/Order/Partition/Finpartition.lean
@@ -296,6 +296,11 @@ instance [Decidable (a = ⊥)] : OrderTop (Finpartition a) where
       simpa [h, P.ne_bot hx] using P.le hx
     · exact fun b hb ↦ ⟨a, mem_singleton_self _, P.le hb⟩
 
+theorem mem_parts_top {b : α} [Decidable (a = ⊥)] :
+    b ∈ (⊤ : Finpartition a).parts ↔ b = a ∧ b ≠ ⊥ := by
+  simp only [Top.top]
+  split_ifs <;> simp +contextual [*]
+
 theorem parts_top_subset (a : α) [Decidable (a = ⊥)] : (⊤ : Finpartition a).parts ⊆ {a} := by
   intro b hb
   have hb : b ∈ Finpartition.parts (dite _ _ _) := hb

--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -545,6 +545,12 @@ lemma iSupIndep.mem_of_biSup_eq_top {f : ι → α} {s : Set ι}
   replace h₁ : Disjoint (f i) (⨆ i ∈ s, f i) := (h₁ i).mono_right <| biSup_mono <| by aesop
   aesop
 
+theorem Finset.sSupIndep_coe_iff {s : Finset α} : sSupIndep (s : Set α) ↔ s.SupIndep id := by
+  rw [sSupIndep_iff, ← iSupIndep_comp_coe_iff_supIndep, id_comp]
+  rfl -- This is needed because the LHS has `↥(s : Set α)`, while the RHS has `↥s`.
+
+alias ⟨sSupIndep.supIndep, Finset.SupIndep.sSupIndep⟩ := Finset.sSupIndep_coe_iff
+
 end CompleteLattice
 
 section Frame


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
