### PR TITLE
feat(ModelTheory/Basic): add characterization of languages with countably many symbols

### DIFF
--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -119,6 +119,21 @@ instance isEmpty_empty : IsEmpty Language.empty.Symbols := by
 instance Countable.countable_functions [h : Countable L.Symbols] : Countable (Σ l, L.Functions l) :=
   @Function.Injective.countable _ _ h _ Sum.inl_injective
 
+instance Countable.countable_relations [h : Countable L.Symbols] : Countable (Σ l, L.Relations l) :=
+  @Function.Injective.countable _ _ h _ Sum.inr_injective
+
+/-- A language has countably many symbols exactly when it has countably many function symbols and
+countably many relation symbols. -/
+theorem countable_symbols_iff :
+    Countable L.Symbols ↔ Countable (Σ l, L.Functions l) ∧ Countable (Σ l, L.Relations l) :=
+  ⟨fun _ => ⟨inferInstance, inferInstance⟩, fun ⟨_, _⟩ => inferInstance⟩
+
+/-- A language has cardinality at most `ℵ₀` exactly when both of its types of symbols are
+countable. -/
+theorem card_le_aleph0_iff_countable :
+    L.card ≤ ℵ₀ ↔ Countable (Σ l, L.Functions l) ∧ Countable (Σ l, L.Relations l) := by
+  rw [card, mk_le_aleph0_iff, countable_symbols_iff]
+
 @[simp]
 theorem card_functions_sum (i : ℕ) :
     #((L.sum L').Functions i)

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -134,6 +134,12 @@ theorem card_le_aleph0_iff_countable :
     L.card ≤ ℵ₀ ↔ Countable (Σ l, L.Functions l) ∧ Countable (Σ l, L.Relations l) := by
   rw [card, mk_le_aleph0_iff, countable_symbols_iff]
 
+/-- The sum of two languages with countably many symbols has countably many symbols. -/
+instance Countable.countable_sum [Countable L.Symbols] [Countable L'.Symbols] :
+    Countable (L.sum L').Symbols := by
+  rw [countable_symbols_iff]
+  constructor <;> exact (Equiv.sigmaSumDistrib _ _).injective.countable
+
 @[simp]
 theorem card_functions_sum (i : ℕ) :
     #((L.sum L').Functions i)

--- a/Mathlib/ModelTheory/Encoding.lean
+++ b/Mathlib/ModelTheory/Encoding.lean
@@ -302,18 +302,6 @@ section Countable
 
 variable [Countable α] [Countable L.Symbols]
 
-instance : Countable (constantsOn α).Symbols := by
-  refine mk_le_aleph0_iff.mp ?_
-  change (constantsOn α).card ≤ ℵ₀
-  simpa only [card_constantsOn, mk_le_aleph0_iff]
-
-instance : Countable L[[α]].Symbols := by
-  simp only [← mk_le_aleph0_iff]
-  change L[[α]].card ≤ ℵ₀
-  simp only [withConstants, card_sum, add_le_aleph0, lift_le_aleph0]
-  simp only [card, mk_le_aleph0_iff]
-  constructor <;> infer_instance
-
 instance : Countable (Σ n, L.BoundedFormula α n) := by
   refine Cardinal.mk_le_aleph0_iff.mp (BoundedFormula.card_le.trans (max_le (le_refl _) ?_))
   simp only [card, add_le_aleph0, lift_le_aleph0, mk_le_aleph0_iff]

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -343,6 +343,12 @@ instance isRelational_constantsOn [_ie : IsEmpty α] : IsRelational (constantsOn
 theorem card_constantsOn : (constantsOn α).card = #α := by
   simp [card_eq_card_functions_add_card_relations, sum_nat_eq_add_sum_succ]
 
+/-- A language of constants indexed by a countable type has countably many symbols. -/
+instance Countable.countable_constantsOn [Countable α] : Countable (constantsOn α).Symbols := by
+  refine mk_le_aleph0_iff.mp ?_
+  change (constantsOn α).card ≤ ℵ₀
+  simpa only [card_constantsOn, mk_le_aleph0_iff]
+
 /-- Gives a `constantsOn α` structure to a type by assigning each constant a value. -/
 @[instance_reducible]
 def constantsOn.structure (f : α → M) : (constantsOn α).Structure M where
@@ -383,6 +389,12 @@ def withConstants : Language.{max u w', v} :=
 
 @[inherit_doc FirstOrder.Language.withConstants]
 scoped[FirstOrder] notation:max L "[[" α "]]" => Language.withConstants L α
+
+/-- Adding countably many constants to a language with countably many symbols preserves
+countability. -/
+instance Countable.countable_withConstants [Countable L.Symbols] [Countable α] :
+    Countable L[[α]].Symbols :=
+  inferInstanceAs (Countable (L.sum (constantsOn α)).Symbols)
 
 @[simp]
 theorem card_withConstants :


### PR DESCRIPTION
`Language.Countable.countable_functions` currently projects `Countable L.Symbols` onto the function symbols, but there is no counterpart for relations. This PR adds the missing instance; in doing so it relates the two ways that Mathlib already expresses "countable language": the bundled `Language.card ≤ ℵ₀` and the unbundled `Countable (Σ l, L.Functions l)` / `Countable (Σ l, L.Relations l)` hypotheses that model-theoretic statements tend to carry separately.

* `Countable.countable_relations`, `countable_symbols_iff`, and `card_le_aleph0_iff_countable` connect the bundled and unbundled formulations of symbol countability.

* `Countable.countable_sum`, `Countable.countable_constantsOn`, and `Countable.countable_withConstants` centralize countability instances for language constructors and remove the corresponding local instances from `Encoding.lean`.

## Motivation

Following review feedback from @NoneMore, this PR now also simplifies existing Mathlib code: generic countability instances for `Language.sum`, `constantsOn`, and `withConstants` live beside those constructors, so `Encoding.lean` no longer needs its own cardinal-arithmetic proofs for them.
 
The broader motivation comes from projects in infinitary model theory that build on Mathlib, in which one typically needs to carry around a hypothesis about countability of the set of symbols.

Specifically, in [cameronfreer/infinitary-logic](https://github.com/cameronfreer/infinitary-logic) the two sorts are carried unbundled and independently throughout; there are roughly 180 occurrences of the relation-symbol hypothesis and 24 of the function-symbol one. Here are a few examples:

* [`Methods/Henkin/ModelExistence.lean#L60`](https://github.com/cameronfreer/infinitary-logic/blob/1a478e80794080a536931c029281bb65266b3171/InfinitaryLogic/Methods/Henkin/ModelExistence.lean#L60): model existence, carrying both hypotheses side by side;
* [`Admissible/Compactness.lean#L90`](https://github.com/cameronfreer/infinitary-logic/blob/1a478e80794080a536931c029281bb65266b3171/InfinitaryLogic/Admissible/Compactness.lean#L90): Barwise completeness, likewise;
* [`Descriptive/Polish.lean#L46`](https://github.com/cameronfreer/infinitary-logic/blob/1a478e80794080a536931c029281bb65266b3171/InfinitaryLogic/Descriptive/Polish.lean#L46): a section variable assuming only the relation symbols are countable, which is where one notices the missing companion instance;
* [`Methods/LopezEscobar/CodeClass.lean#L29`](https://github.com/cameronfreer/infinitary-logic/blob/1a478e80794080a536931c029281bb65266b3171/InfinitaryLogic/Methods/LopezEscobar/CodeClass.lean#L29): a custom `Countable (Σ n, L.Functions n)` instance for relational languages, which is an example of the bookkeeping that arises from the two sorts not being related by a single lemma.

(Note that the `countable_functions` and `countable_relations` instances only project *out of* `Countable L.Symbols` into a summand; the converse direction is stated as a theorem rather than an instance, so there is no risk of an instance cycle.)

🤖 These proofs were written with the assistance of Claude Opus 5 high and reviewed by GPT Sol 5.6 xhigh.
