### PR TITLE
feat(Topology/Algebra/Module/Spaces): add compact-open C-infinity topology

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7691,6 +7691,7 @@ public import Mathlib.Topology.Algebra.Module.PerfectSpace
 public import Mathlib.Topology.Algebra.Module.Simple
 public import Mathlib.Topology.Algebra.Module.Spaces.CharacterSpace
 public import Mathlib.Topology.Algebra.Module.Spaces.CompactConvergenceCLM
+public import Mathlib.Topology.Algebra.Module.Spaces.ContDiffMap
 public import Mathlib.Topology.Algebra.Module.Spaces.ContinuousLinearMap
 public import Mathlib.Topology.Algebra.Module.Spaces.PointwiseConvergenceCLM
 public import Mathlib.Topology.Algebra.Module.Spaces.UniformConvergenceCLM

--- a/Mathlib/Topology/Algebra/Module/Spaces/ContDiffMap.lean
+++ b/Mathlib/Topology/Algebra/Module/Spaces/ContDiffMap.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 Cameron Beeley. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Beeley
 -/
 module
 
@@ -23,7 +24,9 @@ part of this construction.
 open Set
 open scoped ContDiff
 
-namespace ContDiffMap
+@[expose] public section
+
+namespace SmoothMap
 
 noncomputable section
 
@@ -69,4 +72,4 @@ theorem jet_apply (f : ContDiffMap 𝕜 E F) (k : ℕ) :
   rfl
 
 end
-end ContDiffMap
+end SmoothMap

--- a/Mathlib/Topology/Algebra/Module/Spaces/ContDiffMap.lean
+++ b/Mathlib/Topology/Algebra/Module/Spaces/ContDiffMap.lean
@@ -26,8 +26,6 @@ open scoped ContDiff
 
 @[expose] public section
 
-namespace SmoothMap
-
 noncomputable section
 
 variable {𝕜 E F : Type*}
@@ -40,6 +38,8 @@ def ContDiffMap (𝕜 E F : Type*) [NontriviallyNormedField 𝕜]
     [NormedAddCommGroup E] [NormedSpace 𝕜 E]
     [NormedAddCommGroup F] [NormedSpace 𝕜 F] :=
   {f : E → F // ContDiff 𝕜 ∞ f}
+
+namespace ContDiffMap
 
 instance : FunLike (ContDiffMap 𝕜 E F) E F where
   coe f := f.1
@@ -71,5 +71,4 @@ theorem jet_apply (f : ContDiffMap 𝕜 E F) (k : ℕ) :
       iteratedFDeriv 𝕜 k f :=
   rfl
 
-end
-end SmoothMap
+end ContDiffMap

--- a/Mathlib/Topology/Algebra/Module/Spaces/ContDiffMap.lean
+++ b/Mathlib/Topology/Algebra/Module/Spaces/ContDiffMap.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 Cameron Beeley. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.ContDiff.Basic
+public import Mathlib.Topology.Algebra.Module.Multilinear.Topology
+public import Mathlib.Topology.UniformSpace.UniformConvergenceTopology
+
+/-!
+# The compact-open C-infinity topology on smooth maps
+
+For maps between normed spaces, the compact-open C-infinity topology is the
+initial topology for all iterated derivatives, where each derivative is given
+the topology of uniform convergence on compact subsets.
+
+This file defines the corresponding type of smooth maps and its topology.
+The manifold version requires additional chart-domain bookkeeping and is not
+part of this construction.
+-/
+
+open Set
+open scoped ContDiff
+
+namespace ContDiffMap
+
+noncomputable section
+
+variable {𝕜 E F : Type*}
+  [NontriviallyNormedField 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+
+/-- Smooth maps between normed spaces, bundled with their smoothness proof. -/
+def ContDiffMap (𝕜 E F : Type*) [NontriviallyNormedField 𝕜]
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    [NormedAddCommGroup F] [NormedSpace 𝕜 F] :=
+  {f : E → F // ContDiff 𝕜 ∞ f}
+
+instance : FunLike (ContDiffMap 𝕜 E F) E F where
+  coe f := f.1
+  coe_injective f g h := by exact Subtype.ext h
+
+/-- The family of compact subsets used by compact-open convergence. -/
+def compactSets (E : Type*) [TopologicalSpace E] : Set (Set E) :=
+  {K | IsCompact K}
+
+/-- The full iterated-derivative jet of a smooth map. -/
+def jet (f : ContDiffMap 𝕜 E F) :
+    ∀ k : ℕ, UniformOnFun E
+      (ContinuousMultilinearMap 𝕜 (fun _ : Fin k => E) F) (compactSets E) :=
+  fun k => UniformOnFun.ofFun (compactSets E) (iteratedFDeriv 𝕜 k f)
+
+/-- The compact-open C-infinity topology on smooth maps between normed spaces. -/
+@[instance_reducible]
+def topology : TopologicalSpace (ContDiffMap 𝕜 E F) :=
+  TopologicalSpace.induced jet
+    (inferInstance : TopologicalSpace
+      (∀ k : ℕ, UniformOnFun E
+        (ContinuousMultilinearMap 𝕜 (fun _ : Fin k => E) F) (compactSets E)))
+
+instance : TopologicalSpace (ContDiffMap 𝕜 E F) := topology
+
+@[simp]
+theorem jet_apply (f : ContDiffMap 𝕜 E F) (k : ℕ) :
+    (jet f k : E → ContinuousMultilinearMap 𝕜 (fun _ : Fin k => E) F) =
+      iteratedFDeriv 𝕜 k f :=
+  rfl
+
+end
+end ContDiffMap


### PR DESCRIPTION
This PR adds `ContDiffMap`, the type of `C-infinity` maps between normed spaces, together with the compact-open `C-infinity` topology.

The topology is induced by the full iterated-derivative jet. The component of order `k` uses `UniformOnFun` with the family of compact subsets of the domain, so convergence records uniform convergence on compact sets at every derivative order. The construction is deliberately limited to normed-space maps; manifold mapping spaces require separate chart-domain infrastructure.

--------

Validation on the current head `faf73609009edfc076b42d83047017c415a1a19d`:

* `lake -K jobs=1 --wfail build Mathlib.Topology.Algebra.Module.Spaces.ContDiffMap` — passed, 1,985 targets.
* `lake exe lint-style Mathlib/Topology/Algebra/Module/Spaces/ContDiffMap.lean` — passed.
* `git diff --check` — passed.
* `lake env lean /tmp/ContDiffMapUsage.lean` — passed; this imports the module, constructs a
  `ContDiffMap` from a smooth function, and resolves its topology instance.

Fresh after-fix transcript on `faf73609009edfc076b42d83047017c415a1a19d`:

```text
HEAD=faf73609009edfc076b42d83047017c415a1a19d
Build completed successfully (1985 jobs).
lake env lean /tmp/ContDiffMapUsage.lean: passed
lint-style: passed
git diff --check: passed
```

AI disclosure: the initial implementation and edits were produced with AI assistance (Codex and local review tooling). I reviewed the resulting Lean source, corrected the mathlib API and linter issues, and verified the current head with the commands above.

Review history: https://gist.github.com/anagnorisis2peripeteia/752e73fb9da140220b36a3ec6bbc8dc6
