### PR TITLE
feat(Algebra/MvPolynomial): compact only the right summand of a sum of variables

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Rename.lean
+++ b/Mathlib/Algebra/MvPolynomial/Rename.lean
@@ -332,29 +332,18 @@ theorem exists_finset_right_rename (p : MvPolynomial (σ ⊕ τ) R) :
     ∃ (t : Finset τ) (q : MvPolynomial (σ ⊕ { x // x ∈ t }) R),
       p = rename (Sum.map id (↑)) q := by
   classical
-  have hmap : ∀ (u v : Finset τ) (g : { x // x ∈ v } → τ) (f : { x // x ∈ u } → { x // x ∈ v }),
-      Sum.map (id : σ → σ) g ∘ Sum.map id f = Sum.map id (g ∘ f) := by
-    intro u v g f
-    funext x
-    obtain a | b := x <;> rfl
-  apply induction_on p
-  · intro r
-    exact ⟨∅, C r, by rw [rename_C]⟩
-  · rintro p q ⟨s, p, rfl⟩ ⟨t, q, rfl⟩
-    refine ⟨s ∪ t, ⟨?_, ?_⟩⟩
-    · refine rename (Sum.map id (Subtype.map id ?_)) p +
-        rename (Sum.map id (Subtype.map id ?_)) q <;>
-        simp +contextual only [id, true_or, or_true, Finset.mem_union, forall_true_iff]
-    · simp only [rename_rename, map_add, hmap]
-      rfl
-  · rintro p i ⟨t, p, rfl⟩
-    obtain a | b := i
-    · exact ⟨t, p * X (Sum.inl a), by simp only [map_mul, rename_X, Sum.map_inl, id_eq]⟩
-    · refine ⟨insert b t, ⟨?_, ?_⟩⟩
-      · refine rename (Sum.map id (Subtype.map id ?_)) p * X (Sum.inr ⟨b, t.mem_insert_self b⟩)
-        simp +contextual only [id, or_true, Finset.mem_insert, forall_true_iff]
-      · simp only [rename_rename, rename_X, map_mul, Sum.map_inr, hmap]
-        rfl
+  obtain ⟨s, q, rfl⟩ := exists_finset_rename p
+  let f : { x // x ∈ s } → σ ⊕ { x // x ∈ s.toRight } := fun x =>
+    match h : x.1 with
+    | .inl a => .inl a
+    | .inr b => .inr ⟨b, Finset.mem_toRight.mpr (h ▸ x.2)⟩
+  refine ⟨s.toRight, rename f q, ?_⟩
+  rw [rename_rename]
+  congr 2
+  funext x
+  rcases x with ⟨a | b, h⟩
+  · rfl
+  · simp [f]
 
 /-- Every polynomial in `σ ⊕ τ` is a polynomial in all of the variables from `σ` and finitely
 many of the variables from `τ`.

--- a/Mathlib/Algebra/MvPolynomial/Rename.lean
+++ b/Mathlib/Algebra/MvPolynomial/Rename.lean
@@ -323,6 +323,58 @@ theorem exists_fin_rename (p : MvPolynomial σ R) :
   rw [← rename_rename, rename_rename e]
   simp only [Function.comp_def, Equiv.symm_apply_apply, rename_rename]
 
+/-- Every polynomial in `σ ⊕ τ` is a polynomial in all of the variables from `σ` and finitely
+many of the variables from `τ`.
+
+Unlike `exists_finset_rename`, which compacts the whole variable type, the variables from `σ`
+are left untouched. -/
+theorem exists_finset_right_rename (p : MvPolynomial (σ ⊕ τ) R) :
+    ∃ (t : Finset τ) (q : MvPolynomial (σ ⊕ { x // x ∈ t }) R),
+      p = rename (Sum.map id (↑)) q := by
+  classical
+  have hmap : ∀ (u v : Finset τ) (g : { x // x ∈ v } → τ) (f : { x // x ∈ u } → { x // x ∈ v }),
+      Sum.map (id : σ → σ) g ∘ Sum.map id f = Sum.map id (g ∘ f) := by
+    intro u v g f
+    funext x
+    obtain a | b := x <;> rfl
+  apply induction_on p
+  · intro r
+    exact ⟨∅, C r, by rw [rename_C]⟩
+  · rintro p q ⟨s, p, rfl⟩ ⟨t, q, rfl⟩
+    refine ⟨s ∪ t, ⟨?_, ?_⟩⟩
+    · refine rename (Sum.map id (Subtype.map id ?_)) p +
+        rename (Sum.map id (Subtype.map id ?_)) q <;>
+        simp +contextual only [id, true_or, or_true, Finset.mem_union, forall_true_iff]
+    · simp only [rename_rename, map_add, hmap]
+      rfl
+  · rintro p i ⟨t, p, rfl⟩
+    obtain a | b := i
+    · exact ⟨t, p * X (Sum.inl a), by simp only [map_mul, rename_X, Sum.map_inl, id_eq]⟩
+    · refine ⟨insert b t, ⟨?_, ?_⟩⟩
+      · refine rename (Sum.map id (Subtype.map id ?_)) p * X (Sum.inr ⟨b, t.mem_insert_self b⟩)
+        simp +contextual only [id, or_true, Finset.mem_insert, forall_true_iff]
+      · simp only [rename_rename, rename_X, map_mul, Sum.map_inr, hmap]
+        rfl
+
+/-- Every polynomial in `σ ⊕ τ` is a polynomial in all of the variables from `σ` and finitely
+many of the variables from `τ`.
+
+Unlike `exists_fin_rename`, which reindexes the whole variable type along an injection
+`Fin n → σ ⊕ τ`, the variables from `σ` are left untouched: only the right summand is
+compacted. -/
+theorem exists_fin_right_rename (p : MvPolynomial (σ ⊕ τ) R) :
+    ∃ (n : ℕ) (f : Fin n → τ) (_hf : Injective f) (q : MvPolynomial (σ ⊕ Fin n) R),
+      p = rename (Sum.map id f) q := by
+  obtain ⟨t, q, rfl⟩ := exists_finset_right_rename p
+  let n := Fintype.card { x // x ∈ t }
+  let e := Fintype.equivFin { x // x ∈ t }
+  refine ⟨n, (↑) ∘ e.symm, Subtype.val_injective.comp e.symm.injective,
+    rename (Sum.map id e) q, ?_⟩
+  rw [rename_rename]
+  congr 1
+  ext x
+  obtain a | b := x <;> simp
+
 end Rename
 
 theorem eval₂_cast_comp (f : σ → τ) (c : ℤ →+* R) (g : τ → R) (p : MvPolynomial σ ℤ) :


### PR DESCRIPTION
Currently `exists_fin_rename` reindexes the entire variable type along an injection `Fin n → σ`. At `σ ⊕ τ` this renumbers the left-hand variables together with the right-hand ones, so it cannot be used when the left summand carries meaning that has to be preserved.

This PR adds two variants that leave the left summand alone, mirroring the existing `exists_finset_rename` / `exists_fin_rename` pair:

```lean
theorem exists_finset_right_rename (p : MvPolynomial (σ ⊕ τ) R) :
    ∃ (t : Finset τ) (q : MvPolynomial (σ ⊕ { x // x ∈ t }) R),
      p = rename (Sum.map id (↑)) q

theorem exists_fin_right_rename (p : MvPolynomial (σ ⊕ τ) R) :
    ∃ (n : ℕ) (f : Fin n → τ) (_hf : Injective f) (q : MvPolynomial (σ ⊕ Fin n) R),
      p = rename (Sum.map id f) q
```

The first of these factors `exists_finset_rename` through `Finset.toRight`: rename along the map that fixes the left-hand variables and sends each right-hand variable of the finset into `s.toRight`.

The second one then enumerates that right-hand finset with `Fintype.equivFin`, the same way that `exists_fin_rename` does.

Motivation: a Diophantine relation is presented as a polynomial in input variables along with existentially quantified witness variables, and the normal form wants inputs indexed by `Fin n` and witnesses compacted to `Fin m`. Only the witnesses may be reindexed; renumbering the inputs changes the relation being represented. This comes up in work I've been exploring towards Hilbert's tenth problem (the TODO in `Mathlib.NumberTheory.Dioph`), though the statement is independent of that.

🤖 These proofs were written with the assistance of Claude Opus 5 high and reviewed by GPT Sol 5.6 xhigh.
