### PR TITLE
[Merged by Bors] - fix(LinearAlgebra/Matrix): make accidental private instance public

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Nonsingular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Nonsingular.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 
-import Mathlib.LinearAlgebra.InvariantBasisNumber
 import Mathlib.LinearAlgebra.Matrix.SemiringInverse
 import Mathlib.LinearAlgebra.Matrix.ToLin
 

--- a/Mathlib/LinearAlgebra/Matrix/Nonsingular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Nonsingular.lean
@@ -5,6 +5,7 @@ Authors: Junyan Xu, Aristotle AI
 -/
 module
 
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 
 import Mathlib.LinearAlgebra.InvariantBasisNumber

--- a/Mathlib/LinearAlgebra/Matrix/Nonsingular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Nonsingular.lean
@@ -33,12 +33,12 @@ a matrix is nonsingular if and only if its determinant is not a zero divisor).
   rank condition.
 -/
 
+public section
+
 variable {R m n : Type*} [CommSemiring R] [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n]
 variable {A : Matrix n n R}
 
 namespace Matrix
-
-public section
 
 lemma isDetpBalanced_iff_sub_mul_det_eq_zero {R : Type*} [CommRing R] {A : Matrix n n R} {a b : R} :
     A.IsDetpBalanced a b ↔ (a - b) * A.det = 0 := by
@@ -140,8 +140,6 @@ theorem linearIndependent_col_iff_row [Finite n] :
     LinearIndependent R A.col ↔ LinearIndependent R A.row := by
   have := Fintype.ofFinite
   classical rw [linearIndependent_col_iff, linearIndependent_row_iff]
-
-end
 
 end Matrix
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The `public section` declaration was put in the `Matrix` namespace in #39161, and got closed prematurely before the `CommSemiring.strongRankCondition_of_nontrivial` declaration, making the latter private. This fix moves `public section` to top level so everything in this file including `CommSemiring.strongRankCondition_of_nontrivial` is public. Also added public import for `StrongRankCondition`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
