### PR TITLE
chore: remove unused section variables (second pass)

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -90,7 +90,7 @@ open Function Set
 
 section sort
 
-variable {G M N : Type*} {α β ι : Sort*} [CommMonoid M] [CommMonoid N]
+variable {G M N : Type*} {α ι : Sort*} [CommMonoid M] [CommMonoid N]
 
 section
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean
@@ -16,7 +16,7 @@ This file proves lemmas on the sum and product of piecewise functions, including
 
 public section
 
-variable {ι κ M β γ : Type*} {s : Finset ι}
+variable {ι M γ : Type*} {s : Finset ι}
 
 namespace Finset
 

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -297,7 +297,7 @@ lemma range_lmap :
 end AddCommMonoid
 
 section AddCommGroup
-variable {R : Type u} {ι : Type v} {M : ι → Type w} {N : ι → Type*}
+variable {ι : Type v} {M : ι → Type w} {N : ι → Type*}
 
 lemma ker_map [∀ i, AddCommGroup (M i)] [∀ i, AddCommMonoid (N i)] (f : ∀ i, M i →+ N i) :
     (map f).ker =

--- a/Mathlib/Algebra/Homology/Bifunctor.lean
+++ b/Mathlib/Algebra/Homology/Bifunctor.lean
@@ -35,9 +35,9 @@ namespace CategoryTheory
 
 namespace Functor
 
-variable [HasZeroMorphisms C₁] [HasZeroMorphisms C₂] [HasZeroMorphisms D]
-  (F : C₁ ⥤ C₂ ⥤ D) {I₁ I₂ J : Type*} (c₁ : ComplexShape I₁) (c₂ : ComplexShape I₂)
-  [F.PreservesZeroMorphisms] [∀ X₁, (F.obj X₁).PreservesZeroMorphisms]
+variable [HasZeroMorphisms C₁] [HasZeroMorphisms C₂] [HasZeroMorphisms D] (F : C₁ ⥤ C₂ ⥤ D) {I₁ I₂
+  : Type*} (c₁ : ComplexShape I₁) (c₂ : ComplexShape I₂) [F.PreservesZeroMorphisms] [∀ X₁, (F.obj
+  X₁).PreservesZeroMorphisms]
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/Algebra/Module/LinearMap/FiniteRange.lean
+++ b/Mathlib/Algebra/Module/LinearMap/FiniteRange.lean
@@ -43,13 +43,11 @@ open LinearMap Submodule Module
 
 namespace LinearMap
 
-variable {K V V' V₂ V₂' V₃ : Type*}
+variable {K V V₂ V₃ : Type*}
 
 section Semiring
 
-variable [Semiring K]
-  [AddCommMonoid V] [Module K V]
-  [AddCommMonoid V₂] [Module K V₂]
+variable [Semiring K] [AddCommMonoid V] [Module K V] [AddCommMonoid V₂] [Module K V₂]
   [AddCommMonoid V₃] [Module K V₃]
 
 /-- A linear map **has Noetherian range** if its range is a Noetherian module. -/
@@ -111,10 +109,8 @@ end Semiring
 
 section Ring
 
-variable [Ring K]
-  [AddCommGroup V] [Module K V]
-  [AddCommGroup V₂] [Module K V₂]
-  [AddCommGroup V₃] [Module K V₃]
+variable [Ring K] [AddCommGroup V] [Module K V] [AddCommGroup V₂] [Module K V₂] [AddCommGroup V₃]
+  [Module K V₃]
 
 lemma HasFiniteRange.hasNoetherianRange [IsNoetherianRing K] {u : V →ₗ[K] V₂}
     (h : u.HasFiniteRange) : u.HasNoetherianRange := by
@@ -176,10 +172,8 @@ end Ring
 
 section CommRing
 
-variable [CommRing K]
-  [AddCommGroup V] [Module K V]
-  [AddCommGroup V₂] [Module K V₂]
-  [AddCommGroup V₃] [Module K V₃]
+variable [CommRing K] [AddCommGroup V] [Module K V] [AddCommGroup V₂] [Module K V₂] [AddCommGroup
+  V₃] [Module K V₃]
 
 @[simp] lemma HasNoetherianRange.smul {f : V →ₗ[K] V₂}
     (hf : f.HasNoetherianRange) (c : K) : (c • f).HasNoetherianRange :=
@@ -212,10 +206,8 @@ end CommRing
 
 section Setoid
 
-variable [CommRing K]
-  [AddCommGroup V] [Module K V]
-  [AddCommGroup V₂] [Module K V₂]
-  [AddCommGroup V₃] [Module K V₃]
+variable [CommRing K] [AddCommGroup V] [Module K V] [AddCommGroup V₂] [Module K V₂] [AddCommGroup
+  V₃] [Module K V₃]
 
 namespace FiniteRangeSetoid
 
@@ -299,10 +291,8 @@ end Setoid
 
 section QuasiInverse
 
-variable [CommRing K]
-  [AddCommGroup V] [Module K V]
-  [AddCommGroup V₂] [Module K V₂]
-  [AddCommGroup V₃] [Module K V₃]
+variable [CommRing K] [AddCommGroup V] [Module K V] [AddCommGroup V₂] [Module K V₂] [AddCommGroup
+  V₃] [Module K V₃]
 
 open scoped LinearMap.FiniteRangeSetoid
 

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -75,7 +75,7 @@ open scoped Pointwise
 
 universe u v w x
 
-variable {R : Type u} {S₁ : Type v} {S₂ : Type w} {S₃ : Type x}
+variable {R : Type u} {S₁ : Type v} {S₂ : Type w}
 
 /-- Multivariate polynomial, where `σ` is the index set of the variables and
   `R` is the coefficient ring -/
@@ -984,8 +984,8 @@ section coeffsIn
 variable {R S σ : Type*} [CommSemiring R] [CommSemiring S]
 
 section Module
-variable [Module R S] {M N : Submodule R S} {p : MvPolynomial σ S} {s : σ} {i : σ →₀ ℕ} {x : S}
-  {n : ℕ}
+variable [Module R S] {M N : Submodule R S} {p : MvPolynomial σ S} {s : σ} {i : σ →₀ ℕ} {x : S} {n
+  : ℕ}
 
 variable (σ M) in
 /-- The `R`-submodule of multivariate polynomials whose coefficients lie in an `R`-submodule `M`. -/

--- a/Mathlib/Algebra/MvPolynomial/CommRing.lean
+++ b/Mathlib/Algebra/MvPolynomial/CommRing.lean
@@ -47,7 +47,7 @@ variable {R : Type u} {S : Type v}
 
 namespace MvPolynomial
 
-variable {σ : Type*} {a a' a₁ a₂ : R} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
+variable {σ : Type*} {a a' : R} {n m : σ}
 
 section CommRing
 

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -62,7 +62,7 @@ variable {R : Type u} {S : Type v}
 
 namespace MvPolynomial
 
-variable {σ τ : Type*} {r : R} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
+variable {σ τ : Type*} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
 
 section CommSemiring
 

--- a/Mathlib/Algebra/MvPolynomial/Equiv.lean
+++ b/Mathlib/Algebra/MvPolynomial/Equiv.lean
@@ -56,7 +56,7 @@ variable {R : Type u} {S₁ : Type v} {S₂ : Type w} {S₃ : Type x}
 
 namespace MvPolynomial
 
-variable {σ : Type*} {a a' a₁ a₂ : R} {e : ℕ} {s : σ →₀ ℕ}
+variable {σ : Type*} {a : R} {e : ℕ} {s : σ →₀ ℕ}
 
 section Equiv
 

--- a/Mathlib/Algebra/MvPolynomial/PDeriv.lean
+++ b/Mathlib/Algebra/MvPolynomial/PDeriv.lean
@@ -51,7 +51,7 @@ namespace MvPolynomial
 
 open Set Function Finsupp
 
-variable {R : Type u} {σ : Type v} {a a' a₁ a₂ : R} {s : σ →₀ ℕ}
+variable {R : Type u} {σ : Type v} {a : R} {s : σ →₀ ℕ}
 
 section PDeriv
 

--- a/Mathlib/Algebra/MvPolynomial/Rename.lean
+++ b/Mathlib/Algebra/MvPolynomial/Rename.lean
@@ -123,7 +123,7 @@ theorem rename_surjective (f : σ → τ) (hf : Function.Surjective f) :
 
 section
 
-variable {f : σ → τ} (hf : Function.Injective f) {p q : MvPolynomial τ R}
+variable {f : σ → τ} (hf : Function.Injective f) {p : MvPolynomial τ R}
 
 open scoped Classical in
 /-- Given a function between sets of variables `f : σ → τ` that is injective with proof `hf`,

--- a/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
@@ -28,7 +28,7 @@ This file defines a bundled type of absolute values `AbsoluteValue R S`.
 
 @[expose] public section
 
-variable {ι α R S : Type*}
+variable {α R S : Type*}
 
 /-- `AbsoluteValue R S` is the type of absolute values on `R` mapping to `S`:
 the maps that preserve `*`, are nonnegative, positive definite and satisfy
@@ -201,8 +201,8 @@ section OrderedRing
 
 section Ring
 
-variable {R S : Type*} [Ring R] [Ring S] [PartialOrder S] [IsOrderedRing S]
-  (abv : AbsoluteValue R S)
+variable {R S : Type*} [Ring R] [Ring S] [PartialOrder S] [IsOrderedRing S] (abv : AbsoluteValue R
+  S)
 
 @[bound]
 protected theorem le_sub (a b : R) : abv a - abv b ≤ abv (a - b) :=
@@ -214,8 +214,8 @@ end OrderedRing
 
 section OrderedCommRing
 
-variable [CommRing S] [PartialOrder S] [IsOrderedRing S] [Ring R]
-  (abv : AbsoluteValue R S) [NoZeroDivisors S]
+variable [CommRing S] [PartialOrder S] [IsOrderedRing S] [Ring R] (abv : AbsoluteValue R S)
+  [NoZeroDivisors S]
 
 protected theorem map_neg (a : R) : abv (-a) = abv a := by
   by_cases ha : a = 0; · simp [ha]
@@ -262,8 +262,7 @@ end OrderedCommRing
 
 section LinearOrderedRing
 
-variable {R S : Type*} [Semiring R] [Ring S] [LinearOrder S] [IsStrictOrderedRing S]
-  (abv : AbsoluteValue R S)
+variable {S : Type*} [Ring S] [LinearOrder S] [IsStrictOrderedRing S]
 
 /-- `AbsoluteValue.abs` is `abs` as a bundled `AbsoluteValue`. -/
 @[simps]
@@ -281,8 +280,8 @@ end LinearOrderedRing
 
 section LinearOrderedCommRing
 
-variable {R S : Type*} [Ring R] [CommRing S] [LinearOrder S] [IsStrictOrderedRing S]
-  (abv : AbsoluteValue R S)
+variable {R S : Type*} [Ring R] [CommRing S] [LinearOrder S] [IsStrictOrderedRing S] (abv :
+  AbsoluteValue R S)
 
 @[bound]
 theorem abs_abv_sub_le_abv_sub (a b : R) : abs (abv a - abv b) ≤ abv (a - b) :=
@@ -363,8 +362,8 @@ end OrderedSemiring
 
 section LinearOrderedSemifield
 
-variable [Field R] [Semifield S] [LinearOrder S] [IsStrictOrderedRing S] [ExistsAddOfLE S]
-  {v : AbsoluteValue R S}
+variable [Field R] [Semifield S] [LinearOrder S] [IsStrictOrderedRing S] [ExistsAddOfLE S] {v :
+  AbsoluteValue R S}
 
 lemma IsNontrivial.exists_abv_gt_one (h : v.IsNontrivial) : ∃ x, 1 < v x := by
   obtain ⟨x, hx₀, hx₁⟩ := h
@@ -500,8 +499,8 @@ end Ring
 end OrderedRing
 
 section OrderedCommRing
-variable [CommRing S] [PartialOrder S] [IsOrderedRing S] [NoZeroDivisors S] [Ring R]
-  (abv : R → S) [IsAbsoluteValue abv]
+variable [CommRing S] [PartialOrder S] [IsOrderedRing S] [NoZeroDivisors S] [Ring R] (abv : R → S)
+  [IsAbsoluteValue abv]
 
 theorem abv_neg (a : R) : abv (-a) = abv a :=
   (toAbsoluteValue abv).map_neg a

--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -27,7 +27,7 @@ assert_not_exists Ring
 
 open Function
 
-variable {ι α β M N G k R : Type*}
+variable {ι α β M N G k : Type*}
 
 namespace Finset
 
@@ -288,8 +288,8 @@ end OrderedCommMonoid
 
 section ProdSum
 
-variable [CommMonoid α] [AddCommMonoid β] [Preorder β] [AddLeftMono β]
-  (s : Finset ι) {f : ι → α} (g : α → β)
+variable [CommMonoid α] [AddCommMonoid β] [Preorder β] [AddLeftMono β] (s : Finset ι) {f : ι → α}
+  (g : α → β)
 
 theorem apply_prod_le_sum_apply (h_one : g 1 ≤ 0) (h_mul : ∀ (a b : α), g (a * b) ≤ g a + g b) :
     g (∏ x ∈ s, f x) ≤ ∑ x ∈ s, g (f x) := by
@@ -602,7 +602,7 @@ end OrderedCancelCommMonoid
 
 section LinearOrderedCancelCommMonoid
 
-variable [CommMonoid M] [LinearOrder M] {f g : ι → M} {s t : Finset ι}
+variable [CommMonoid M] [LinearOrder M] {f g : ι → M} {s : Finset ι}
 
 @[to_additive exists_lt_of_sum_lt]
 theorem exists_lt_of_prod_lt' [MulLeftMono M] (Hlt : ∏ i ∈ s, f i < ∏ i ∈ s, g i) :

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -112,7 +112,7 @@ lemma pow_pos_iff (hn : n ≠ 0) : 0 < a ^ n ↔ 0 < a := by
 end LinearOrderedCommMonoidWithZero
 
 section LinearOrderedCommGroupWithZero
-variable [LinearOrderedCommGroupWithZero α] {a b c d : α} {m n : ℕ}
+variable [LinearOrderedCommGroupWithZero α] {a b c d : α} {n : ℕ}
 
 @[simp]
 theorem Units.zero_lt (u : αˣ) : (0 : α) < u :=
@@ -614,7 +614,7 @@ end LE
 
 section LT
 
-variable [LT α] {x y : WithZero α} {a b : α}
+variable [LT α] {x : WithZero α} {a b : α}
 
 lemma lt_unzeroD_iff (hx : x ≠ 0) : b < x.unzeroD a ↔ b < x := by
   lift x to α using hx; simp
@@ -626,7 +626,7 @@ end LT
 
 section Preorder
 
-variable [Preorder α] {x y : WithZero α} {a b : α}
+variable [Preorder α] {x : WithZero α} {b : α}
 
 theorem le_coe_unzeroD (x : WithZero α) (b : α) : x ≤ x.unzeroD b := by cases x <;> simp
 
@@ -634,7 +634,7 @@ end Preorder
 
 section PartialOrder
 
-variable [PartialOrder α] {x y : WithZero α} {a b : α}
+variable [PartialOrder α] {y : WithZero α} {a b : α}
 
 lemma le_unzeroD (hy : b ≤ y) : b ≤ y.unzeroD a := by
   have hne : y ≠ 0 := ne_bot_of_le_ne_bot WithZero.coe_ne_zero hy

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
@@ -30,7 +30,7 @@ assert_not_exists IsOrderedMonoid Field Finset Set.Icc GaloisConnection
 
 namespace Rat
 
-variable {a b c p q : ℚ}
+variable {a b c q : ℚ}
 
 @[simp] lemma mkRat_nonneg {a : ℤ} (ha : 0 ≤ a) (b : ℕ) : 0 ≤ mkRat a b := by
   simpa using divInt_nonneg ha (Int.natCast_nonneg _)

--- a/Mathlib/Algebra/Order/Round.lean
+++ b/Mathlib/Algebra/Order/Round.lean
@@ -223,7 +223,7 @@ namespace Int
 
 variable [Field α] [LinearOrder α] [IsStrictOrderedRing α]
   [Field β] [LinearOrder β] [IsStrictOrderedRing β] [FloorRing α] [FloorRing β]
-variable [FunLike F α β] [RingHomClass F α β] {a : α} {b : β}
+variable [FunLike F α β] [RingHomClass F α β] {a : α}
 
 theorem map_round (f : F) (hf : StrictMono f) (a : α) : round (f a) = round a := by
   simp_rw [round_eq, ← map_floor _ hf, map_add, one_div, map_inv₀, map_ofNat]

--- a/Mathlib/Algebra/Polynomial/Degree/Operations.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Operations.lean
@@ -30,11 +30,11 @@ namespace Polynomial
 
 universe u v
 
-variable {R : Type u} {S : Type v} {a b c d : R} {n m : ℕ}
+variable {R : Type u} {S : Type v} {a b c : R} {n m : ℕ}
 
 section Semiring
 
-variable [Semiring R] [Semiring S] {p q r : R[X]}
+variable [Semiring R] [Semiring S] {p q : R[X]}
 
 theorem supDegree_eq_degree (p : R[X]) : p.toFinsupp.supDegree WithBot.some = p.degree :=
   max_eq_sup_coe
@@ -130,7 +130,7 @@ end Ring
 
 section Semiring
 
-variable [Semiring R] {p q : R[X]} {ι : Type*}
+variable [Semiring R] {p q : R[X]}
 
 theorem coeff_natDegree_eq_zero_of_degree_lt (h : degree p < degree q) :
     coeff p (natDegree q) = 0 :=
@@ -509,7 +509,7 @@ end Semiring
 
 section NontrivialSemiring
 
-variable [Semiring R] [Nontrivial R] {p q : R[X]} (n : ℕ)
+variable [Semiring R] [Nontrivial R] {p : R[X]} (n : ℕ)
 
 @[simp] lemma natDegree_mul_X (hp : p ≠ 0) : natDegree (p * X) = natDegree p + 1 := by
   rw [natDegree_mul' (by simpa), natDegree_X]
@@ -726,7 +726,7 @@ lemma degree_le_mul_left (p : R[X]) (hq : q ≠ 0) : degree p ≤ degree (p * q)
 end Semiring
 
 section CommSemiring
-variable [CommSemiring R] {a p : R[X]} (hp : p.Monic)
+variable [CommSemiring R] {p : R[X]} (hp : p.Monic)
 include hp
 
 lemma Monic.natDegree_pos : 0 < natDegree p ↔ p ≠ 1 :=

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -34,7 +34,7 @@ namespace Polynomial
 
 universe u v w y z
 
-variable {R : Type u} {S : Type v} {T : Type w} {ι : Type y} {A : Type z} {a b : R} {n : ℕ}
+variable {R : Type u} {S : Type v} {T : Type w} {ι : Type y} {a b : R} {n : ℕ}
 
 section Derivative
 

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -31,7 +31,7 @@ namespace Polynomial
 
 universe u v w z
 
-variable {R : Type u} {S : Type v} {T : Type w} {A : Type z} {a b : R} {n : ℕ}
+variable {R : Type u} {S : Type v} {a b : R} {n : ℕ}
 
 section Semiring
 

--- a/Mathlib/Algebra/Polynomial/Eval/Degree.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Degree.lean
@@ -29,7 +29,7 @@ namespace Polynomial
 
 universe u v w y
 
-variable {R : Type u} {S : Type v} {T : Type w} {ι : Type y} {a b : R} {m n : ℕ}
+variable {R : Type u} {S : Type v} {a b : R} {m n : ℕ}
 
 section Semiring
 
@@ -216,7 +216,7 @@ end
 
 section
 
-variable [CommSemiring R] {p q : R[X]} {x : R} [CommSemiring S] (f : R →+* S)
+variable [CommSemiring R] {p q : R[X]} {x : R} [CommSemiring S]
 
 @[simp]
 theorem iterate_comp_eval :

--- a/Mathlib/Algebra/Polynomial/FieldDivision.lean
+++ b/Mathlib/Algebra/Polynomial/FieldDivision.lean
@@ -253,7 +253,7 @@ end IsDomain
 
 section DivisionRing
 
-variable [DivisionRing R] {p q : R[X]}
+variable [DivisionRing R] {p : R[X]}
 
 theorem degree_pos_of_ne_zero_of_nonunit (hp0 : p ≠ 0) (hp : ¬IsUnit p) : 0 < degree p :=
   lt_of_not_ge fun h => by
@@ -264,7 +264,7 @@ end DivisionRing
 
 section SimpleRing
 
-variable [Ring R] [IsSimpleRing R] [Semiring S] [Nontrivial S] {p q : R[X]}
+variable [Ring R] [IsSimpleRing R] [Semiring S] [Nontrivial S] {p : R[X]}
 
 @[simp]
 protected theorem map_eq_zero (f : R →+* S) : p.map f = 0 ↔ p = 0 :=

--- a/Mathlib/Algebra/Polynomial/Mirror.lean
+++ b/Mathlib/Algebra/Polynomial/Mirror.lean
@@ -179,7 +179,7 @@ end Semiring
 
 section Ring
 
-variable {R : Type*} [Ring R] (p q : R[X])
+variable {R : Type*} [Ring R] (p : R[X])
 
 theorem mirror_neg : (-p).mirror = -p.mirror := by
   rw [mirror, mirror, reverse_neg, natTrailingDegree_neg, neg_mul_eq_neg_mul]

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -31,7 +31,7 @@ namespace Polynomial
 
 universe u v w z
 
-variable {R : Type u} {S : Type v} {T : Type w} {a b : R} {n : ℕ}
+variable {R : Type u} {S : Type v} {a b : R} {n : ℕ}
 
 section CommRing
 

--- a/Mathlib/Algebra/Ring/Parity.lean
+++ b/Mathlib/Algebra/Ring/Parity.lean
@@ -73,7 +73,7 @@ variable [Add α] [Mul α] {a : α}
 end Distrib
 
 section Semiring
-variable [Semiring α] [Semiring β] {a b : α} {m n : ℕ}
+variable [Semiring α] [Semiring β] {a b : α} {n : ℕ}
 
 lemma even_iff_exists_two_mul : Even a ↔ ∃ b, a = 2 * b := by simp [even_iff_exists_two_nsmul]
 
@@ -195,7 +195,7 @@ lemma Odd.neg_pow : Odd n → ∀ a : α, (-a) ^ n = -a ^ n := by
 end Monoid
 
 section Ring
-variable [Ring α] {a b : α} {n : ℕ}
+variable [Ring α] {a b : α}
 
 lemma even_neg_two : Even (-2 : α) := by simp only [even_neg, even_two]
 

--- a/Mathlib/Algebra/SkewPolynomial/Basic.lean
+++ b/Mathlib/Algebra/SkewPolynomial/Basic.lean
@@ -104,7 +104,7 @@ variable [Semiring R] {p q : SkewPolynomial R}
 
 lemma zero_def : (0 : SkewPolynomial R) = (0 : SkewMonoidAlgebra R (Multiplicative ℕ)) := rfl
 
-variable {S S₁ S₂ : Type*}
+variable {S : Type*}
 
 /--
 The set of all `n` such that `X^n` has a non-zero coefficient.

--- a/Mathlib/Analysis/Analytic/CPolynomial.lean
+++ b/Mathlib/Analysis/Analytic/CPolynomial.lean
@@ -26,7 +26,7 @@ variable {𝕜 E F G : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup
 open scoped Topology
 open Set Filter Asymptotics NNReal ENNReal
 
-variable {f g : E → F} {p pf pg : FormalMultilinearSeries 𝕜 E F} {x : E} {r r' : ℝ≥0∞} {n m : ℕ}
+variable {f g : E → F} {p pf pg : FormalMultilinearSeries 𝕜 E F} {x : E} {r : ℝ≥0∞} {n m : ℕ}
 
 theorem hasFiniteFPowerSeriesOnBall_const {c : F} {e : E} :
     HasFiniteFPowerSeriesOnBall (fun _ => c) (constFormalMultilinearSeries 𝕜 E c) e 1 ⊤ :=
@@ -147,8 +147,8 @@ We show that a continuous linear map into continuous multilinear maps is continu
 namespace ContinuousLinearMap
 
 variable {ι : Type*} {Em : ι → Type*} [∀ i, NormedAddCommGroup (Em i)] [∀ i, NormedSpace 𝕜 (Em i)]
-  [Fintype ι] (f : G →L[𝕜] ContinuousMultilinearMap 𝕜 Em F)
-  {s : Set (G × (Π i, Em i))} {x : G × (Π i, Em i)}
+  [Fintype ι] (f : G →L[𝕜] ContinuousMultilinearMap 𝕜 Em F) {s : Set (G × (Π i, Em i))} {x : G ×
+  (Π i, Em i)}
 
 /-- Formal multilinear series associated to a linear map into multilinear maps. -/
 noncomputable def toFormalMultilinearSeriesOfMultilinear :
@@ -197,11 +197,9 @@ end ContinuousLinearMap
 
 namespace ContinuousMultilinearMap
 
-variable {ι : Type*} {Em Fm : ι → Type*}
-  [∀ i, NormedAddCommGroup (Em i)] [∀ i, NormedSpace 𝕜 (Em i)]
-  [∀ i, NormedAddCommGroup (Fm i)] [∀ i, NormedSpace 𝕜 (Fm i)]
-  [Fintype ι] (f : ContinuousMultilinearMap 𝕜 Em (G →L[𝕜] F))
-  {s : Set ((Π i, Em i) × G)} {x : (Π i, Em i) × G}
+variable {ι : Type*} {Em Fm : ι → Type*} [∀ i, NormedAddCommGroup (Em i)] [∀ i, NormedSpace 𝕜 (Em
+  i)] [∀ i, NormedAddCommGroup (Fm i)] [∀ i, NormedSpace 𝕜 (Fm i)] [Fintype ι] (f :
+  ContinuousMultilinearMap 𝕜 Em (G →L[𝕜] F)) {s : Set ((Π i, Em i) × G)} {x : (Π i, Em i) × G}
 
 lemma cpolynomialAt_uncurry_of_linear :
     CPolynomialAt 𝕜 (fun (p : (Π i, Em i) × G) ↦ f p.1 p.2) x := by
@@ -228,8 +226,8 @@ lemma analyticWithinAt_uncurry_of_linear :
     AnalyticWithinAt 𝕜 (fun (p : (Π i, Em i) × G) ↦ f p.1 p.2) s x :=
   f.analyticAt_uncurry_of_linear.analyticWithinAt
 
-variable {t : Set ((Π i, Fm i →L[𝕜] Em i) × (ContinuousMultilinearMap 𝕜 Em G))}
-  {q : (Π i, Fm i →L[𝕜] Em i) × (ContinuousMultilinearMap 𝕜 Em G)}
+variable {t : Set ((Π i, Fm i →L[𝕜] Em i) × (ContinuousMultilinearMap 𝕜 Em G))} {q : (Π i, Fm i
+  →L[𝕜] Em i) × (ContinuousMultilinearMap 𝕜 Em G)}
 
 lemma cpolynomialAt_uncurry_compContinuousLinearMap :
     CPolynomialAt 𝕜 (fun (p : (Π i, Fm i →L[𝕜] Em i) × (ContinuousMultilinearMap 𝕜 Em G))

--- a/Mathlib/Analysis/BoxIntegral/Partition/Tagged.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Tagged.lean
@@ -47,7 +47,7 @@ structure TaggedPrepartition (I : Box ι) extends Prepartition I where
 
 namespace TaggedPrepartition
 
-variable {I J J₁ J₂ : Box ι} (π : TaggedPrepartition I) {x : ι → ℝ}
+variable {I J : Box ι} (π : TaggedPrepartition I) {x : ι → ℝ}
 
 instance : Membership (Box ι) (TaggedPrepartition I) :=
   ⟨fun π J => J ∈ π.boxes⟩

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -560,8 +560,7 @@ end fderiv
 
 section deriv
 
-variable {p : FormalMultilinearSeries 𝕜 𝕜 F} {r : ℝ≥0∞}
-variable {f : 𝕜 → F} {x : 𝕜} {s : Set 𝕜}
+variable {f : 𝕜 → F} {s : Set 𝕜}
 
 /-- If a function is polynomial on a set `s`, so is its derivative. -/
 protected theorem CPolynomialOn.deriv (h : CPolynomialOn 𝕜 f s) : CPolynomialOn 𝕜 (deriv f) s :=

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -181,8 +181,8 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 variable {E : Type*} [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E]
 variable {F : Type*} [AddCommGroup F] [Module 𝕜 F] [TopologicalSpace F]
 
-variable {f f₀ f₁ g : E → F}
-variable {f' f₀' f₁' g' : E →L[𝕜] F}
+variable {f : E → F}
+variable {f' : E →L[𝕜] F}
 variable {x : E}
 variable {s t : Set E}
 variable {L L₁ L₂ : Filter (E × E)}
@@ -736,7 +736,7 @@ variable {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 
 variable {f : E → F}
 variable {f' : E →L[𝕜] F}
-variable {x x₀ : E}
+variable {x : E}
 variable {s : Set E}
 variable {L : Filter (E × E)}
 

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -520,7 +520,7 @@ theorem AffineBasis.convexHull_eq_nonneg_coord {ι : Type*} (b : AffineBasis ι 
     rw [b.coord_apply_combination_of_mem hi hw₁] at hx
     exact hx
 
-variable {s t t₁ t₂ : Finset E}
+variable {s t₁ t₂ : Finset E}
 
 /-- Two simplices glue nicely if the union of their vertices is affine independent. -/
 lemma AffineIndependent.convexHull_inter (hs : AffineIndependent R ((↑) : s → E))

--- a/Mathlib/Analysis/InnerProductSpace/Subspace.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Subspace.lean
@@ -247,7 +247,7 @@ variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 
 local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
 
-variable {ι : Type*} {G : ι → Type*}
+variable {ι : Type*}
 
 /-- An orthogonal family forms an independent family of subspaces; that is, any collection of
 elements each from a different subspace in the family is linearly independent. In particular, the

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -849,7 +849,7 @@ instance normedSpace [NormedField 𝕜] [∀ i, SeminormedAddCommGroup (β i)]
 
 variable {𝕜 p α}
 variable [Semiring 𝕜] [∀ i, SeminormedAddCommGroup (α i)] [∀ i, SeminormedAddCommGroup (β i)]
-variable [∀ i, Module 𝕜 (α i)] [∀ i, Module 𝕜 (β i)] (c : 𝕜)
+variable [∀ i, Module 𝕜 (α i)] [∀ i, Module 𝕜 (β i)]
 
 /-- The canonical map `WithLp.equiv` between `PiLp ∞ β` and `Π i, β i` as a linear isometric
 equivalence. -/
@@ -949,9 +949,8 @@ end piLpCongrRight
 
 section piLpCurry
 
-variable {ι : Type*} {κ : ι → Type*} (p : ℝ≥0∞) [Fact (1 ≤ p)]
-  [Fintype ι] [∀ i, Fintype (κ i)]
-  (α : ∀ i, κ i → Type*) [∀ i k, SeminormedAddCommGroup (α i k)] [∀ i k, Module 𝕜 (α i k)]
+variable {ι : Type*} {κ : ι → Type*} (p : ℝ≥0∞) [Fact (1 ≤ p)] [Fintype ι] [∀ i, Fintype (κ i)] (α
+  : ∀ i, κ i → Type*) [∀ i k, SeminormedAddCommGroup (α i k)] [∀ i k, Module 𝕜 (α i k)]
 
 variable (𝕜) in
 /-- `LinearEquiv.piCurry` for `PiLp`, as an isometry. -/

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -1254,7 +1254,7 @@ end OfLE
 
 section Eval
 
-variable [NormedRing 𝕜] [∀ i, Module 𝕜 (E i)] [∀ i, IsBoundedSMul 𝕜 (E i)] {p q r : ℝ≥0∞}
+variable [NormedRing 𝕜] [∀ i, Module 𝕜 (E i)] [∀ i, IsBoundedSMul 𝕜 (E i)] {p : ℝ≥0∞}
 
 variable (E p) in
 /-- Evaluation at a single coordinate, as a linear map on `lp E p`. -/

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -151,7 +151,7 @@ theorem eq_zero_of_abs_deriv_le_mul_abs_self_of_eq_zero_right {f f' : ℝ → E}
       norm_le_gronwallBound_of_norm_deriv_right_le hf hf' (by simp [ha]) (by simpa using bound) _ hx
     _ = 0 := by rw [gronwallBound_ε0_δ0]
 
-variable {v : ℝ → E → E} {s : ℝ → Set E} {K : ℝ≥0} {f g f' g' : ℝ → E} {a b t₀ : ℝ} {εf εg δ : ℝ}
+variable {v : ℝ → E → E} {s : ℝ → Set E} {K : ℝ≥0} {f g f' g' : ℝ → E} {a b : ℝ} {εf εg δ : ℝ}
 
 /-- If `f` and `g` are two approximate solutions of the same ODE, then the distance between them
 can't grow faster than exponentially. This is a simple corollary of Grönwall's inequality, and some

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -977,7 +977,7 @@ end Complex
 
 namespace Real
 
-variable {z x y : ℝ}
+variable {x : ℝ}
 
 section Sqrt
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -1023,7 +1023,6 @@ end FiniteBiproducts
 
 variable {J : Type w}
 variable {C : Type u} [Category.{v} C] [HasZeroMorphisms C]
-variable {D : Type uD} [Category.{uD'} D] [HasZeroMorphisms D]
 
 instance biproduct.ι_mono (f : J → C) [HasBiproduct f] (b : J) : IsSplitMono (biproduct.ι f b) :=
   (biproduct.bicone f).instIsSplitMonoι b

--- a/Mathlib/CategoryTheory/Monoidal/Mon.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon.lean
@@ -145,8 +145,8 @@ end MonObj
 open scoped MonObj
 
 namespace Mathlib.Tactic.MonTauto
-variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory C]
-  {M W X X₁ X₂ X₃ Y Y₁ Y₂ Y₃ Z Z₁ Z₂ : C} [MonObj M]
+variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory C] {M W X X₁ X₂ Y Y₁ Y₂ Z Z₁ Z₂ : C}
+  [MonObj M]
 
 attribute [mon_tauto] Category.id_comp Category.comp_id Category.assoc
   id_tensorHom_id tensorμ tensorδ

--- a/Mathlib/Combinatorics/Enumerative/IncidenceAlgebra.lean
+++ b/Mathlib/Combinatorics/Enumerative/IncidenceAlgebra.lean
@@ -73,7 +73,7 @@ Here are some additions to this file that could be made in the future:
 
 open Finset OrderDual
 
-variable {F 𝕜 𝕝 𝕞 α β : Type*}
+variable {𝕜 𝕝 𝕞 α β : Type*}
 
 /-- The `𝕜`-incidence algebra over `α`. -/
 structure IncidenceAlgebra (𝕜 α : Type*) [Zero 𝕜] [LE α] where
@@ -638,8 +638,8 @@ end CommRing
 end Preorder
 
 section PartialOrder
-variable (𝕜) [Ring 𝕜] [PartialOrder α] [PartialOrder β] [LocallyFiniteOrder α]
-  [LocallyFiniteOrder β] [DecidableEq α] [DecidableEq β] [DecidableLE α] [DecidableLE β]
+variable (𝕜) [Ring 𝕜] [PartialOrder α] [PartialOrder β] [LocallyFiniteOrder α] [LocallyFiniteOrder
+  β] [DecidableEq α] [DecidableEq β] [DecidableLE α] [DecidableLE β]
 
 /-- The Möbius function on a product order. Based on lemma 2.1.13 of Incidence Algebras by Spiegel
 and O'Donnell. -/

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -51,7 +51,7 @@ assert_not_exists Finset.prod Submonoid
 
 universe u u₁ u₂ v v₁ v₂ v₃ w x y l
 
-variable {ι : Type u} {γ : Type w} {β : ι → Type v} {β₁ : ι → Type v₁} {β₂ : ι → Type v₂}
+variable {ι : Type u} {β : ι → Type v} {β₁ : ι → Type v₁} {β₂ : ι → Type v₂}
 
 variable (β) in
 /-- A dependent function `Π i, β i` with finite support, with notation `Π₀ i, β i`.

--- a/Mathlib/Data/DFinsupp/Sigma.lean
+++ b/Mathlib/Data/DFinsupp/Sigma.lean
@@ -27,7 +27,7 @@ public import Mathlib.Data.Fintype.Quotient
 
 universe u u₁ u₂ v v₁ v₂ v₃ w x y l
 
-variable {ι : Type u} {γ : Type w} {β : ι → Type v} {β₁ : ι → Type v₁} {β₂ : ι → Type v₂}
+variable {ι : Type u} {γ : Type w}
 
 namespace DFinsupp
 
@@ -35,7 +35,6 @@ section Equiv
 
 open Finset
 
-variable {κ : Type*}
 
 section SigmaCurry
 

--- a/Mathlib/Data/Finsupp/Single.lean
+++ b/Mathlib/Data/Finsupp/Single.lean
@@ -33,7 +33,7 @@ noncomputable section
 
 open Finset Function
 
-variable {α β γ ι M M' N P G H R S : Type*}
+variable {α β ι M N P H : Type*}
 
 namespace Finsupp
 

--- a/Mathlib/Data/Finsupp/Weight.lean
+++ b/Mathlib/Data/Finsupp/Weight.lean
@@ -145,8 +145,6 @@ theorem le_weight (w : σ → ℕ) {s : σ} (hs : w s ≠ 0) (f : σ →₀ ℕ)
     apply zero_le
 
 variable [AddCommMonoid M] [PartialOrder M] [IsOrderedAddMonoid M] (w : σ → M)
-  {R : Type*} [CommSemiring R] [PartialOrder R] [IsOrderedRing R]
-  [CanonicallyOrderedAdd R] [NoZeroDivisors R] [Module R M]
 
 variable {w} in
 theorem le_weight_of_ne_zero (hw : ∀ s, 0 ≤ w s) {s : σ} {f : σ →₀ ℕ} (hs : f s ≠ 0) :

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -25,7 +25,7 @@ public section
 open Nat
 
 namespace Int
-variable {a b c d m n : ℤ}
+variable {a b c m n : ℤ}
 
 attribute [gcongr] ofNat_le
 

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -19,7 +19,7 @@ at position `(i, j)`, and zeroes elsewhere.
 assert_not_exists Matrix.trace
 
 variable {l m n o : Type*}
-variable {R S α β γ : Type*}
+variable {R S α β : Type*}
 
 namespace Matrix
 

--- a/Mathlib/Data/Matrix/Block.lean
+++ b/Mathlib/Data/Matrix/Block.lean
@@ -28,7 +28,7 @@ public import Mathlib.LinearAlgebra.Matrix.ConjTranspose
 @[expose] public section
 
 variable {l m n o p q : Type*} {m' n' p' : o → Type*}
-variable {R : Type*} {S : Type*} {α : Type*} {β : Type*}
+variable {R : Type*} {α : Type*} {β : Type*}
 
 open Matrix
 

--- a/Mathlib/Data/Multiset/AddSub.lean
+++ b/Mathlib/Data/Multiset/AddSub.lean
@@ -35,7 +35,7 @@ universe v
 
 open List Subtype Nat Function
 
-variable {α : Type*} {β : Type v} {γ : Type*}
+variable {α : Type*} {β : Type v}
 
 namespace Multiset
 
@@ -367,7 +367,7 @@ end sub
 
 section Rel
 
-variable {δ : Type*} {r : α → β → Prop} {p : γ → δ → Prop}
+variable {r : α → β → Prop}
 
 theorem Rel.add {s t u v} (hst : Rel r s t) (huv : Rel r u v) : Rel r (s + u) (t + v) := by
   induction hst with

--- a/Mathlib/Data/Multiset/Filter.lean
+++ b/Mathlib/Data/Multiset/Filter.lean
@@ -299,7 +299,7 @@ end
 
 section
 
-variable [DecidableEq α] {s t u : Multiset α}
+variable [DecidableEq α] {s : Multiset α}
 
 @[simp]
 theorem count_filter_of_pos {p} [DecidablePred p] {a} {s : Multiset α} (h : p a) :
@@ -357,7 +357,7 @@ end
 /-! ### Subtraction -/
 
 section sub
-variable [DecidableEq α] {s t u : Multiset α} {a : α}
+variable [DecidableEq α] {s t : Multiset α} {a : α}
 
 @[simp]
 lemma filter_sub (p : α → Prop) [DecidablePred p] (s t : Multiset α) :

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -57,7 +57,7 @@ assert_not_exists Monoid
 open Function
 
 namespace Nat
-variable {a b c d e m n k : ℕ} {p : ℕ → Prop}
+variable {a b m n k : ℕ} {p : ℕ → Prop}
 
 /-! ### `succ`, `pred` -/
 

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -26,7 +26,7 @@ This file contains basic results on the following predicates of functions and se
 
 @[expose] public section
 
-variable {α β γ δ : Type*} {ι : Sort*} {π : α → Type*}
+variable {α β γ δ : Type*} {ι : Sort*}
 
 open Equiv Equiv.Perm Function
 
@@ -105,8 +105,8 @@ alias ⟨EqOn.comp_eq, _⟩ := eqOn_range
 
 end equality
 
-variable {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {p : Set γ} {f f₁ f₂ : α → β} {g g₁ g₂ : β → γ}
-  {f' f₁' f₂' : β → α} {g' : γ → β} {a : α} {b : β}
+variable {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {p : Set γ} {f f₁ f₂ : α → β} {g g₁ g₂ : β → γ} {f'
+  f₁' f₂' : β → α} {g' : γ → β} {a : α} {b : β}
 
 section MapsTo
 
@@ -1262,8 +1262,8 @@ namespace Set
 
 section Prod
 
-variable {α β₁ β₂ : Type*} {s : Set α} {t₁ : Set β₁} {t₂ : Set β₂}
-  {f₁ : α → β₁} {f₂ : α → β₂} {g₁ : β₁ → α} {g₂ : β₂ → α}
+variable {α β₁ β₂ : Type*} {s : Set α} {t₁ : Set β₁} {t₂ : Set β₂} {f₁ : α → β₁} {f₂ : α → β₂} {g₁
+  : β₁ → α} {g₂ : β₂ → α}
 
 lemma InjOn.left_prodMk (h₁ : s.InjOn f₁) : s.InjOn fun x ↦ (f₁ x, f₂ x) :=
   fun _ hx _ hy h => h₁ hx hy (Prod.ext_iff.1 h).1
@@ -1296,8 +1296,8 @@ end Prod
 
 section ProdMap
 
-variable {α₁ α₂ β₁ β₂ : Type*} {s₁ : Set α₁} {s₂ : Set α₂} {t₁ : Set β₁} {t₂ : Set β₂}
-  {f₁ : α₁ → β₁} {f₂ : α₂ → β₂} {g₁ : β₁ → α₁} {g₂ : β₂ → α₂}
+variable {α₁ α₂ β₁ β₂ : Type*} {s₁ : Set α₁} {s₂ : Set α₂} {t₁ : Set β₁} {t₂ : Set β₂} {f₁ : α₁ →
+  β₁} {f₂ : α₂ → β₂} {g₁ : β₁ → α₁} {g₂ : β₂ → α₂}
 
 lemma InjOn.prodMap (h₁ : s₁.InjOn f₁) (h₂ : s₂.InjOn f₂) :
     (s₁ ×ˢ s₂).InjOn fun x ↦ (f₁ x.1, f₂ x.2) :=

--- a/Mathlib/Data/Set/Piecewise.lean
+++ b/Mathlib/Data/Set/Piecewise.lean
@@ -15,7 +15,7 @@ This file contains basic results on piecewise defined functions.
 
 public section
 
-variable {α β γ δ : Type*} {ι : Sort*} {π : α → Type*}
+variable {α β γ δ : Type*} {ι : Sort*}
 
 open Equiv Equiv.Perm Function
 

--- a/Mathlib/Data/Set/Restrict.lean
+++ b/Mathlib/Data/Set/Restrict.lean
@@ -18,7 +18,7 @@ public import Mathlib.Data.Set.Image
 
 @[expose] public section
 
-variable {α β γ δ : Type*} {ι : Sort*} {π : α → Type*}
+variable {α β γ : Type*} {ι : Sort*} {π : α → Type*}
 
 open Equiv Equiv.Perm Function
 
@@ -212,8 +212,7 @@ alias restrict_eq_restrict_iff := domRestrict_eq_domRestrict_iff
 
 end domRestrict
 
-variable {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {p : Set γ} {f f₁ f₂ : α → β} {g g₁ g₂ : β → γ}
-  {f' f₁' f₂' : β → α} {g' : γ → β} {a : α} {b : β}
+variable {s : Set α} {t : Set β} {p : Set γ} {f : α → β} {g : β → γ} {a : α} {b : β}
 
 section MapsTo
 

--- a/Mathlib/Dynamics/PeriodicPts/Defs.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Defs.lean
@@ -495,7 +495,7 @@ namespace Function
 
 section Prod
 
-variable {α β : Type*} {f : α → α} {g : β → β} {x : α × β} {a : α} {b : β} {m n : ℕ}
+variable {α β : Type*} {f : α → α} {g : β → β} {x : α × β} {a : α} {b : β} {n : ℕ}
 
 @[simp]
 theorem isFixedPt_prodMap (x : α × β) :

--- a/Mathlib/FieldTheory/RatFunc/Valuation.lean
+++ b/Mathlib/FieldTheory/RatFunc/Valuation.lean
@@ -35,7 +35,7 @@ public noncomputable section
 
 namespace RatFunc
 
-variable (F K : Type*) [Field F] [Field K]
+variable (F : Type*) [Field F]
 
 /-! ### The place at infinity on F(t) -/
 

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -760,8 +760,8 @@ end AlgEquiv
 
 section CardAlgHom
 
-variable {R S T : Type*} [CommRing S]
-variable {K L F : Type*} [Field K] [Field L] [Field F]
+variable {S : Type*} [CommRing S]
+variable {K L : Type*} [Field K] [Field L]
 variable [Algebra K S] [Algebra K L]
 
 theorem AlgHom.natCard_of_powerBasis (pb : PowerBasis K S) (h_sep : IsSeparable K pb.gen)

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -36,11 +36,11 @@ noncomputable section
 
 universe u v w
 
-variable {F : Type u} {K : Type v} {L : Type w}
+variable {K : Type v} {L : Type w}
 
 namespace Polynomial
 
-variable [Field K] [Field L] [Field F]
+variable [Field K] [Field L]
 
 open Polynomial
 

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -120,7 +120,7 @@ open TopologicalSpace Topology
 
 universe u
 
-variable {H : Type u} {H' : Type*} {M : Type*} {M' : Type*} {M'' : Type*}
+variable {H : Type u} {H' : Type*} {M : Type*} {M' : Type*}
 
 open Set OpenPartialHomeomorph Manifold
 
@@ -494,8 +494,8 @@ end Products
 
 section sum
 
-variable [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M']
-    [cm : ChartedSpace H M] [cm' : ChartedSpace H M']
+variable [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M'] [cm : ChartedSpace H M]
+  [cm' : ChartedSpace H M']
 
 /-- The disjoint union of two charted spaces modelled on a non-empty space `H`
 is a charted space over `H`. -/

--- a/Mathlib/Geometry/Manifold/IntegralCurve/UniformTime.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/UniformTime.lean
@@ -31,11 +31,9 @@ open scoped Topology
 
 open Function Manifold Set
 
-variable
-  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
-  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 1 M]
-  [T2Space M] {γ γ' : ℝ → M} {v : (x : M) → TangentSpace I x} {s s' : Set ℝ} {t₀ : ℝ}
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {H : Type*} [TopologicalSpace H] {I
+  : ModelWithCorners ℝ E H} {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 1 M]
+  [T2Space M] {γ γ' : ℝ → M} {v : (x : M) → TangentSpace I x} {s : Set ℝ} {t₀ : ℝ}
 
 /-- This is the uniqueness theorem of integral curves applied to a real-indexed family of integral
 curves with the same starting point. -/

--- a/Mathlib/Geometry/Manifold/IsManifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/InteriorBoundary.lean
@@ -485,11 +485,8 @@ end opens
 /-! Interior and boundary of the product of two manifolds. -/
 section prod
 
-variable
-  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
-  {H' : Type*} [TopologicalSpace H']
-  {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
-  {J : ModelWithCorners 𝕜 E' H'} {x : M} {y : N}
+variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace
+  H'] {N : Type*} [TopologicalSpace N] [ChartedSpace H' N] {J : ModelWithCorners 𝕜 E' H'}
 
 /-- The interior of `M × N` is the product of the interiors of `M` and `N`. -/
 lemma interior_prod :
@@ -545,7 +542,7 @@ end prod
 /-! Interior and boundary of the disjoint union of two manifolds. -/
 section disjointUnion
 
-variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M'] {n : WithTop ℕ∞}
+variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M']
 
 open Topology
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -679,7 +679,7 @@ theorem mfderiv_sumSwap :
     mfderiv% (@Sum.swap M M') p = ContinuousLinearMap.id 𝕜 (TangentSpace% p) := by
   simpa [mfderivWithin_univ] using (mfderivWithin_sumSwap (uniqueMDiffWithinAt_univ I))
 
-variable {f : M → N} (g : M' → N') {q : M} {q' : M'}
+variable {f : M → N} {q : M} {q' : M'}
 
 lemma writtenInExtChartAt_sumInl_eventuallyEq_id :
     (writtenInExtChartAt I I q (@Sum.inl M M')) =ᶠ[𝓝[Set.range I] (extChartAt I q q)] id := by
@@ -1049,8 +1049,8 @@ end AlgebraOverCommRing
 section DivisionRing
 open scoped RightActions
 
-variable {z : M} {F' : Type*} [NormedDivisionRing F'] [NormedAlgebra 𝕜 F'] {p q : M → F'}
-  {p' q' : TangentSpace% z →L[𝕜] F'}
+variable {z : M} {F' : Type*} [NormedDivisionRing F'] [NormedAlgebra 𝕜 F'] {p q : M → F'} {p' :
+  TangentSpace% z →L[𝕜] F'}
 
 lemma HasMFDerivWithinAt.inv' (hp : HasMFDerivWithinAt I 𝓘(𝕜, F') p s z p') (hp_ne : p z ≠ 0) :
     HasMFDerivWithinAt I 𝓘(𝕜, F') (p⁻¹) s z (-((p z)⁻¹ •> p' <• (p z)⁻¹) : E →L[𝕜] F') :=

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -23,15 +23,13 @@ open scoped Manifold Topology
 section
 
 
-variable {𝕜 B B' F M : Type*} {E : B → Type*}
+variable {𝕜 B F M : Type*} {E : B → Type*}
 
-variable [NontriviallyNormedField 𝕜] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-  [TopologicalSpace (TotalSpace F E)] [∀ x, TopologicalSpace (E x)] {EB : Type*}
-  [NormedAddCommGroup EB] [NormedSpace 𝕜 EB] {HB : Type*} [TopologicalSpace HB]
-  (IB : ModelWithCorners 𝕜 EB HB) (E' : B → Type*) [∀ x, Zero (E' x)] {EM : Type*}
-  [NormedAddCommGroup EM] [NormedSpace 𝕜 EM] {HM : Type*} [TopologicalSpace HM]
-  {IM : ModelWithCorners 𝕜 EM HM} [TopologicalSpace M] [ChartedSpace HM M]
-  {n : ℕ∞}
+variable [NontriviallyNormedField 𝕜] [NormedAddCommGroup F] [NormedSpace 𝕜 F] [TopologicalSpace
+  (TotalSpace F E)] [∀ x, TopologicalSpace (E x)] {EB : Type*} [NormedAddCommGroup EB]
+  [NormedSpace 𝕜 EB] {HB : Type*} [TopologicalSpace HB] (IB : ModelWithCorners 𝕜 EB HB) (E' : B →
+  Type*) [∀ x, Zero (E' x)] {EM : Type*} [NormedAddCommGroup EM] [NormedSpace 𝕜 EM] {HM : Type*}
+  [TopologicalSpace HM] {IM : ModelWithCorners 𝕜 EM HM} [TopologicalSpace M] [ChartedSpace HM M]
 
 variable [TopologicalSpace B] [ChartedSpace HB B] [FiberBundle F E]
 
@@ -221,8 +219,8 @@ protected theorem MDifferentiable.coordChange
 
 end coordChange
 
-variable [(x : B) → AddCommMonoid (E x)] [(x : B) → Module 𝕜 (E x)]
-  [VectorBundle 𝕜 F E] [ContMDiffVectorBundle 1 F E IB]
+variable [(x : B) → AddCommMonoid (E x)] [(x : B) → Module 𝕜 (E x)] [VectorBundle 𝕜 F E]
+  [ContMDiffVectorBundle 1 F E IB]
 
 lemma MDifferentiableWithinAt.change_section_trivialization
     {e : Trivialization F TotalSpace.proj} [MemTrivializationAtlas e]
@@ -329,12 +327,11 @@ theorem mdifferentiableOn_section_baseSet_iff {s : ∀ x, E x}
 
 section
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
-  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
-  (Z : M → Type*) [TopologicalSpace (TotalSpace F Z)] [∀ b, TopologicalSpace (Z b)]
-  [FiberBundle F Z] [∀ b, AddCommMonoid (Z b)] [∀ b, Module 𝕜 (Z b)] [VectorBundle 𝕜 F Z]
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H] {I
+  : ModelWithCorners 𝕜 E H} {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {M : Type*}
+  [TopologicalSpace M] [ChartedSpace H M] (Z : M → Type*) [TopologicalSpace (TotalSpace F Z)] [∀
+  b, TopologicalSpace (Z b)] [FiberBundle F Z] [∀ b, AddCommMonoid (Z b)] [∀ b, Module 𝕜 (Z b)]
+  [VectorBundle 𝕜 F Z]
 
 theorem mdifferentiable [ContMDiffVectorBundle 1 F Z I]
     (e : Trivialization F (π F Z)) [MemTrivializationAtlas e] :
@@ -352,7 +349,7 @@ end
 
 section operations
 
-variable {𝕜 B B' F M : Type*} {E : B → Type*}
+variable {𝕜 B F M : Type*} {E : B → Type*}
 
 variable
   -- Let `E` be a fiber bundle with base `B` and fiber `F` (a vector space over `𝕜`)
@@ -615,21 +612,16 @@ Also a third manifold `M`, which will be the source of all our maps.
 variable {𝕜 F₁ F₂ B₁ B₂ M : Type*} {E₁ : B₁ → Type*} {E₂ : B₂ → Type*} [NontriviallyNormedField 𝕜]
   [∀ x, AddCommGroup (E₁ x)] [∀ x, Module 𝕜 (E₁ x)] [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
   [TopologicalSpace (TotalSpace F₁ E₁)] [∀ x, TopologicalSpace (E₁ x)] [∀ x, AddCommGroup (E₂ x)]
-  [∀ x, Module 𝕜 (E₂ x)] [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
-  [TopologicalSpace (TotalSpace F₂ E₂)] [∀ x, TopologicalSpace (E₂ x)]
-  {EB₁ : Type*}
-  [NormedAddCommGroup EB₁] [NormedSpace 𝕜 EB₁] {HB₁ : Type*} [TopologicalSpace HB₁]
-  {IB₁ : ModelWithCorners 𝕜 EB₁ HB₁} [TopologicalSpace B₁] [ChartedSpace HB₁ B₁]
-  {EB₂ : Type*}
-  [NormedAddCommGroup EB₂] [NormedSpace 𝕜 EB₂] {HB₂ : Type*} [TopologicalSpace HB₂]
-  {IB₂ : ModelWithCorners 𝕜 EB₂ HB₂} [TopologicalSpace B₂] [ChartedSpace HB₂ B₂]
-  {EM : Type*}
-  [NormedAddCommGroup EM] [NormedSpace 𝕜 EM] {HM : Type*} [TopologicalSpace HM]
-  {IM : ModelWithCorners 𝕜 EM HM} [TopologicalSpace M] [ChartedSpace HM M]
-  {n : ℕ∞} [FiberBundle F₁ E₁] [VectorBundle 𝕜 F₁ E₁]
-  [FiberBundle F₂ E₂] [VectorBundle 𝕜 F₂ E₂]
-  {b₁ : M → B₁} {b₂ : M → B₂} {m₀ : M}
-  {ϕ : Π (m : M), E₁ (b₁ m) →L[𝕜] E₂ (b₂ m)} {v : Π (m : M), E₁ (b₁ m)} {s : Set M}
+  [∀ x, Module 𝕜 (E₂ x)] [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂] [TopologicalSpace (TotalSpace
+  F₂ E₂)] [∀ x, TopologicalSpace (E₂ x)] {EB₁ : Type*} [NormedAddCommGroup EB₁] [NormedSpace 𝕜
+  EB₁] {HB₁ : Type*} [TopologicalSpace HB₁] {IB₁ : ModelWithCorners 𝕜 EB₁ HB₁} [TopologicalSpace
+  B₁] [ChartedSpace HB₁ B₁] {EB₂ : Type*} [NormedAddCommGroup EB₂] [NormedSpace 𝕜 EB₂] {HB₂ :
+  Type*} [TopologicalSpace HB₂] {IB₂ : ModelWithCorners 𝕜 EB₂ HB₂} [TopologicalSpace B₂]
+  [ChartedSpace HB₂ B₂] {EM : Type*} [NormedAddCommGroup EM] [NormedSpace 𝕜 EM] {HM : Type*}
+  [TopologicalSpace HM] {IM : ModelWithCorners 𝕜 EM HM} [TopologicalSpace M] [ChartedSpace HM M]
+  [FiberBundle F₁ E₁] [VectorBundle 𝕜 F₁ E₁] [FiberBundle F₂ E₂] [VectorBundle 𝕜 F₂ E₂] {b₁ : M →
+  B₁} {b₂ : M → B₂} {m₀ : M} {ϕ : Π (m : M), E₁ (b₁ m) →L[𝕜] E₂ (b₂ m)} {v : Π (m : M), E₁ (b₁ m)}
+  {s : Set M}
 
 /-- Consider a differentiable map `v : M → E₁` to a vector bundle, over a basemap `b₁ : M → B₁`, and
 another basemap `b₂ : M → B₂`. Given linear maps `ϕ m : E₁ (b₁ m) → E₂ (b₂ m)` depending

--- a/Mathlib/GroupTheory/Divisible.lean
+++ b/Mathlib/GroupTheory/Divisible.lean
@@ -262,7 +262,7 @@ end Hom
 
 section Quotient
 
-variable (α : Type*) {A : Type*} [CommGroup A] (B : Subgroup A)
+variable {A : Type*} [CommGroup A] (B : Subgroup A)
 
 /-- Any quotient group of a rootable group is rootable. -/
 @[to_additive /-- Any quotient group of a divisible group is divisible -/]

--- a/Mathlib/GroupTheory/Perm/Centralizer.lean
+++ b/Mathlib/GroupTheory/Perm/Centralizer.lean
@@ -596,8 +596,8 @@ section Sign
 
 open Function
 
-variable {a : Type*} (g : Perm α) (k : Perm (fixedPoints g))
-    (v : (c : g.cycleFactorsFinset) → Subgroup.zpowers (c : Perm α))
+variable (g : Perm α) (k : Perm (fixedPoints g)) (v : (c : g.cycleFactorsFinset) →
+  Subgroup.zpowers (c : Perm α))
 
 set_option backward.isDefEq.respectTransparency false in
 theorem sign_kerParam_apply_apply :

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -652,7 +652,7 @@ end Conjugation
 
 section IsCycleOn
 
-variable {f g : Perm α} {s t : Set α} {a b x y : α}
+variable {f g : Perm α} {s : Set α} {a b x y : α}
 
 /-- A permutation is a cycle on `s` when any two points of `s` are related by repeated application
 of the permutation. Note that this means the identity is a cycle of subsingleton sets. -/

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -25,7 +25,7 @@ Let `β` be a `Fintype` and `f : Equiv.Perm β`.
 
 open Equiv Function Finset
 
-variable {ι α β : Type*}
+variable {α β : Type*}
 
 namespace Equiv.Perm
 

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -474,7 +474,7 @@ instance [Fintype G] : Fintype (vectorsProdEqOne G n) :=
 theorem card [Fintype G] : Fintype.card (vectorsProdEqOne G n) = Fintype.card G ^ (n - 1) :=
   (Fintype.card_congr (equivVector G n)).trans (card_vector (n - 1))
 
-variable {G n} {g : G}
+variable {G n}
 variable (v : vectorsProdEqOne G n) (j k : ℕ)
 
 /-- Rotate a vector whose product is 1. -/

--- a/Mathlib/LinearAlgebra/Basis/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basis/Basic.lean
@@ -35,12 +35,12 @@ universe u
 
 open Function Set Submodule Finsupp
 
-variable {ι : Type*} {ι' : Type*} {R : Type*} {R₂ : Type*} {M : Type*} {M' : Type*}
+variable {ι : Type*} {R : Type*} {R₂ : Type*} {M : Type*} {M' : Type*}
 
 namespace Module.Basis
 
-variable [Semiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid M'] [Module R M']
-  (b : Basis ι R M)
+variable [Semiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid M'] [Module R M'] (b : Basis ι
+  R M)
 
 section Properties
 

--- a/Mathlib/LinearAlgebra/Dual/Basis.lean
+++ b/Mathlib/LinearAlgebra/Dual/Basis.lean
@@ -41,7 +41,7 @@ noncomputable section
 namespace Module.Basis
 
 universe u v w uR uM uK uV uι
-variable {R : Type uR} {M : Type uM} {K : Type uK} {V : Type uV} {ι : Type uι}
+variable {R : Type uR} {M : Type uM} {V : Type uV} {ι : Type uι}
 
 section CommSemiring
 

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -50,8 +50,7 @@ variable {K : Type u} {V : Type v}
 
 namespace FiniteDimensional
 section DivisionRing
-variable [DivisionRing K] [AddCommGroup V] [Module K V] {V₂ : Type v'} [AddCommGroup V₂]
-  [Module K V₂]
+variable [DivisionRing K] [AddCommGroup V] [Module K V]
 
 theorem finrank_le_iff_rank_le [FiniteDimensional K V] {n : ℕ} :
     finrank K V ≤ n ↔ Module.rank K V ≤ n := by

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Lemmas.lean
@@ -229,8 +229,7 @@ namespace Submodule
 
 section DivisionRing
 
-variable [DivisionRing K] [AddCommGroup V] [Module K V] {V₂ : Type v'} [AddCommGroup V₂]
-  [Module K V₂]
+variable [DivisionRing K] [AddCommGroup V] [Module K V]
 
 theorem finrank_lt_finrank_of_lt {s t : Submodule K V} [FiniteDimensional K t] (hst : s < t) :
     finrank K s < finrank K t :=

--- a/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -39,10 +39,8 @@ open Set LinearMap Submodule
 
 namespace Finsupp
 
-variable {α : Type*} {M : Type*} {N : Type*} {P : Type*} {R : Type*} {S : Type*}
+variable {α : Type*} {M : Type*} {R : Type*} {S : Type*}
 variable [Semiring R] [Semiring S] [AddCommMonoid M] [Module R M]
-variable [AddCommMonoid N] [Module R N]
-variable [AddCommMonoid P] [Module R P]
 
 section LinearCombination
 

--- a/Mathlib/LinearAlgebra/Finsupp/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/VectorSpace.lean
@@ -236,7 +236,7 @@ instance : Module.Free R S[M] := .of_equiv (coeffLinearEquiv _).symm
 end MonoidAlgebra
 
 namespace Polynomial
-variable {R S : Type*} [Semiring R] [Semiring S] [Module R S] [Module.Free R S]
+variable {R : Type*} [Semiring R]
 
 instance : Module.Free R R[X] := .of_equiv (Polynomial.toFinsuppIsoLinear _).symm
 

--- a/Mathlib/LinearAlgebra/FreeModule/Norm.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Norm.lean
@@ -22,7 +22,6 @@ variable {R S ι : Type*} [CommRing R] [IsDomain R] [IsPrincipalIdealRing R] [Co
 
 section CommRing
 
-variable (F : Type*)
 
 /-- For a nonzero element `f` in an algebra `S` over a principal ideal domain `R` that is finite and
 free as an `R`-module, the norm of `f` relative to `R` is associated to the product of the Smith

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -908,7 +908,7 @@ These can be considered generalizations of properties of linear independence in 
 section Module
 
 variable [DivisionRing K] [AddCommGroup V] [Module K V]
-variable {v : ι → V} {s t : Set ι} {x y : V}
+variable {v : ι → V} {s : Set ι}
 
 open Submodule
 

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -47,8 +47,8 @@ open Finset Matrix Polynomial
 open scoped Ring
 
 variable {R : Type u} [CommRing R]
-variable {n G : Type v} [DecidableEq n] [Fintype n]
-variable {α β : Type v} [DecidableEq α]
+variable {n : Type v} [DecidableEq n] [Fintype n]
+variable {α : Type v} [DecidableEq α]
 variable {M : Matrix n n R}
 
 namespace Matrix

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -558,7 +558,6 @@ end SpecialLinearGroup
 
 namespace TransvectionStruct
 
-variable {n R : Type*} [Fintype n] [DecidableEq n] [CommRing R]
 
 /-- Any transvection structure can be converted to a special linear matrix. -/
 def toSpecialLinearGroup (t : TransvectionStruct ι F) :

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -82,7 +82,7 @@ The definitions in this section are stated with two extra rings, to allow for no
 -/
 
 section Bilinear
-variable {l m n R S A : Type*}
+variable {m n R S A : Type*}
 variable [Semiring R] [Semiring S] [NonUnitalNonAssocSemiring A]
 variable [Module R A] [Module S A]
 variable [SMulCommClass S R A] [SMulCommClass S A A] [IsScalarTower R A A]
@@ -699,7 +699,7 @@ theorem LinearMap.toMatrix_smulBasis_right {G} [Group G] [DistribMulAction G M�
       LinearMap.toMatrix v₁ v₂ (DistribSMul.toLinearMap _ _ g⁻¹ ∘ₗ f) := by
   rfl
 
-variable {M₃ : Type*} [AddCommMonoid M₃] [Module R M₃] (v₃ : Basis l R M₃)
+variable {M₃ : Type*} [AddCommMonoid M₃] [Module R M₃]
 
 theorem LinearMap.toMatrix_map_left (f : M₃ →ₗ[R] M₂) (g : M₁ ≃ₗ[R] M₃) :
     f.toMatrix (v₁.map g) v₂ = (f ∘ₗ g.toLinearMap).toMatrix v₁ v₂ := by
@@ -1046,11 +1046,8 @@ end Algebra
 
 section
 
-variable {R S : Type*} [CommSemiring R] {n : Type*} [DecidableEq n]
-variable {M M₁ M₂ : Type*} [AddCommMonoid M] [Module R M]
-variable [AddCommMonoid M₁] [Module R M₁] [AddCommMonoid M₂] [Module R M₂]
-variable [Semiring S] [Module S M₁] [Module S M₂] [SMulCommClass S R M₁] [SMulCommClass S R M₂]
-variable [SMul R S] [IsScalarTower R S M₁] [IsScalarTower R S M₂]
+variable {R : Type*} [CommSemiring R] {n : Type*} [DecidableEq n]
+variable {M : Type*} [AddCommMonoid M] [Module R M]
 
 /-- The natural equivalence between linear endomorphisms of finite free modules and square matrices
 is compatible with the algebra structures. -/

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -39,8 +39,8 @@ It contains theorems relating these to each other, as well as to `LinearMap.ker`
 
 universe u v w x y z u' v' w' x' y'
 
-variable {R : Type u} {K : Type u'} {M : Type v} {V : Type v'} {M₂ : Type w} {V₂ : Type w'}
-variable {M₃ : Type y} {V₃ : Type y'} {M₄ : Type z} {ι : Type x} {ι' : Type x'}
+variable {R : Type u} {M : Type v} {M₂ : Type w}
+variable {M₃ : Type y} {ι : Type x} {ι' : Type x'}
 
 open Function Submodule
 
@@ -48,8 +48,8 @@ namespace LinearMap
 
 universe i
 
-variable [Semiring R] [AddCommMonoid M₂] [Module R M₂] [AddCommMonoid M₃] [Module R M₃]
-  {φ : ι → Type i} [(i : ι) → AddCommMonoid (φ i)] [(i : ι) → Module R (φ i)]
+variable [Semiring R] [AddCommMonoid M₂] [Module R M₂] [AddCommMonoid M₃] [Module R M₃] {φ : ι →
+  Type i} [(i : ι) → AddCommMonoid (φ i)] [(i : ι) → Module R (φ i)]
 
 /-- `pi` construction for linear functions. From a family of linear functions it produces a linear
 function into a family of modules. -/
@@ -535,8 +535,8 @@ def piOptionEquivProd {ι : Type*} {M : Option ι → Type*} [(i : Option ι) �
     map_add' := by simp [funext_iff]
     map_smul' := by simp [funext_iff] }
 
-variable (ι M) (S : Type*) [Fintype ι] [DecidableEq ι] [Semiring S] [AddCommMonoid M]
-  [Module R M] [Module S M] [SMulCommClass R S M]
+variable (ι M) (S : Type*) [Fintype ι] [DecidableEq ι] [Semiring S] [AddCommMonoid M] [Module R M]
+  [Module S M] [SMulCommClass R S M]
 
 /-- Linear equivalence between linear functions `Rⁿ → M` and `Mⁿ`. The spaces `Rⁿ` and `Mⁿ`
 are represented as `ι → R` and `ι → M`, respectively, where `ι` is a finite type.

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -34,7 +34,7 @@ universe u v w z
 open Function
 
 -- Unless required to be `Type*`, all variables in this file are `Sort*`
-variable {α α₁ α₂ β β₁ β₂ γ δ : Sort*}
+variable {α α₁ α₂ β β₁ β₂ γ : Sort*}
 
 namespace Equiv
 
@@ -183,7 +183,7 @@ end
 
 section prodCongr
 
-variable {α₁ α₂ β₁ β₂ : Type*} (e : α₁ → β₁ ≃ β₂)
+variable (e : α₁ → β₁ ≃ β₂)
 
 -- See also `Equiv.ofPreimageEquiv`.
 /-- A family of equivalences between fibers gives an equivalence between domains. -/

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -159,7 +159,7 @@ end Preorder
 
 section PartialOrder
 
-variable [PartialOrder α] [OrderClosedTopology α] [SecondCountableTopology α] {a b : α}
+variable [PartialOrder α] [OrderClosedTopology α] [SecondCountableTopology α] {a : α}
 
 theorem measurableSet_le' : MeasurableSet { p : α × α | p.1 ≤ p.2 } :=
   OrderClosedTopology.isClosed_le'.measurableSet

--- a/Mathlib/MeasureTheory/Function/AEMeasurableSequence.lean
+++ b/Mathlib/MeasureTheory/Function/AEMeasurableSequence.lean
@@ -26,8 +26,8 @@ and a measurable set `aeSeqSet hf p`, such that
 
 open MeasureTheory
 
-variable {ι : Sort*} {α β γ : Type*} [MeasurableSpace α] [MeasurableSpace β] {f : ι → α → β}
-  {μ : Measure α} {p : α → (ι → β) → Prop}
+variable {ι : Sort*} {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] {f : ι → α → β} {μ :
+  Measure α} {p : α → (ι → β) → Prop}
 
 /-- If we have the additional hypothesis `∀ᵐ x ∂μ, p x (fun n ↦ f n x)`, this is a measurable set
 whose complement has measure 0 such that for all `x ∈ aeSeqSet`, `f i x` is equal to

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -44,9 +44,9 @@ open EMetric ENNReal Filter MeasureTheory NNReal Set TopologicalSpace
 
 open scoped Topology
 
-variable {α β γ δ ε ε' ε'' : Type*} {m : MeasurableSpace α} {μ ν : Measure α} [MeasurableSpace δ]
-variable [NormedAddCommGroup β] [NormedAddCommGroup γ]
-  [TopologicalSpace ε] [ContinuousENorm ε] [TopologicalSpace ε'] [ContinuousENorm ε'] [ENorm ε'']
+variable {α β γ δ ε ε' : Type*} {m : MeasurableSpace α} {μ ν : Measure α} [MeasurableSpace δ]
+variable [NormedAddCommGroup β] [NormedAddCommGroup γ] [TopologicalSpace ε] [ContinuousENorm ε]
+  [TopologicalSpace ε'] [ContinuousENorm ε']
 
 namespace MeasureTheory
 
@@ -957,8 +957,7 @@ end PosPart
 
 section IsBoundedSMul
 
-variable {𝕜 : Type*}
-  {ε : Type*} [TopologicalSpace ε] [ESeminormedAddMonoid ε]
+variable {𝕜 : Type*} {ε : Type*} [TopologicalSpace ε] [ESeminormedAddMonoid ε]
 
 @[to_fun (attr := fun_prop)]
 theorem Integrable.smul [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 β] [IsBoundedSMul 𝕜 β] (c : 𝕜)
@@ -1147,8 +1146,7 @@ end Trim
 
 section SigmaFinite
 
-variable {E : Type*} {m0 : MeasurableSpace α} [NormedAddCommGroup E]
-  {ε : Type*} [TopologicalSpace ε] [ContinuousENorm ε]
+variable {m0 : MeasurableSpace α} {ε : Type*} [TopologicalSpace ε] [ContinuousENorm ε]
 
 theorem integrable_of_forall_fin_meas_le' {μ : Measure α} (hm : m ≤ m0) [SigmaFinite (μ.trim hm)]
     (C : ℝ≥0∞) (hC : C < ∞) {f : α → ε} (hf_meas : AEStronglyMeasurable f μ)
@@ -1180,12 +1178,11 @@ section ContinuousLinearMap
 
 open MeasureTheory
 
-variable {E H : Type*} [NormedAddCommGroup E] [NormedAddCommGroup H]
-  {𝕜 𝕜' : Type*} [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜']
-  [NormedSpace 𝕜' E] [NormedSpace 𝕜 H]
+variable {E H : Type*} [NormedAddCommGroup E] [NormedAddCommGroup H] {𝕜 𝕜' : Type*}
+  [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜'] [NormedSpace 𝕜' E] [NormedSpace 𝕜 H]
 
-variable {σ : 𝕜 →+* 𝕜'} {σ' : 𝕜' →+* 𝕜} [RingHomIsometric σ] [RingHomIsometric σ']
-  [RingHomInvPair σ σ'] [RingHomInvPair σ' σ]
+variable {σ : 𝕜 →+* 𝕜'} {σ' : 𝕜' →+* 𝕜} [RingHomIsometric σ] [RingHomIsometric σ'] [RingHomInvPair
+  σ σ'] [RingHomInvPair σ' σ]
 
 @[fun_prop]
 theorem ContinuousLinearMap.integrable_comp {φ : α → H} (L : H →SL[σ] E) (φ_int : Integrable φ μ) :
@@ -1213,8 +1210,8 @@ end ContinuousLinearMap
 
 namespace MeasureTheory
 
-variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-  [NormedAddCommGroup F] [NormedSpace ℝ F]
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [NormedAddCommGroup F]
+  [NormedSpace ℝ F]
 
 @[fun_prop]
 lemma Integrable.fst {f : α → E × F} (hf : Integrable f μ) : Integrable (fun x ↦ (f x).1) μ :=

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/LpNorm.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/LpNorm.lean
@@ -23,8 +23,8 @@ open scoped BigOperators ComplexConjugate ENNReal NNReal
 public section
 
 namespace MeasureTheory
-variable {α E : Type*} {m : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ} {μ ν : Measure α}
-  [NormedAddCommGroup E] {f g h : α → E}
+variable {α E : Type*} {m : MeasurableSpace α} {p : ℝ≥0∞} {μ : Measure α} [NormedAddCommGroup E]
+  {f g h : α → E}
 
 lemma toReal_eLpNorm (hf : AEStronglyMeasurable f μ) : (eLpNorm f p μ).toReal = lpNorm f p μ := by
   rw [lpNorm, if_pos hf]

--- a/Mathlib/MeasureTheory/Integral/Prod.lean
+++ b/Mathlib/MeasureTheory/Integral/Prod.lean
@@ -556,10 +556,9 @@ theorem integral_fun_fst (f : α → E) : ∫ z, f z.1 ∂μ.prod ν = ν.real u
 section ContinuousLinearMap
 
 variable {E F G : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {mE : MeasurableSpace E}
-  [NormedAddCommGroup F] [NormedSpace ℝ F] {mF : MeasurableSpace F}
-  [NormedAddCommGroup G] [NormedSpace ℝ G] {mG : MeasurableSpace G}
-  {μ : Measure E} [IsProbabilityMeasure μ] {ν : Measure F} [IsProbabilityMeasure ν]
-  {L : E × F →L[ℝ] G}
+  [NormedAddCommGroup F] [NormedSpace ℝ F] {mF : MeasurableSpace F} [NormedAddCommGroup G]
+  [NormedSpace ℝ G] {μ : Measure E} [IsProbabilityMeasure μ] {ν : Measure F} [IsProbabilityMeasure
+  ν] {L : E × F →L[ℝ] G}
 
 lemma integrable_continuousLinearMap_prod'
     (hLμ : Integrable (L.comp (.inl ℝ E F)) μ) (hLν : Integrable (L.comp (.inr ℝ E F)) ν) :

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -91,13 +91,13 @@ open Filter hiding map
 open Function MeasurableSpace Topology Filter ENNReal NNReal Interval MeasureTheory
 open scoped symmDiff
 
-variable {α β γ δ ι R R' : Type*}
+variable {α β γ ι R R' : Type*}
 
 namespace MeasureTheory
 
 section
 
-variable {m : MeasurableSpace α} {μ μ₁ μ₂ : Measure α} {s s₁ s₂ t : Set α}
+variable {m : MeasurableSpace α} {μ : Measure α} {s s₁ s₂ t : Set α}
 
 instance ae_isMeasurablyGenerated : IsMeasurablyGenerated (ae μ) :=
   ⟨fun _s hs =>
@@ -820,7 +820,7 @@ end OuterMeasure
 section
 
 variable {m0 : MeasurableSpace α} {mβ : MeasurableSpace β} [MeasurableSpace γ]
-variable {μ μ₁ μ₂ μ₃ ν ν' ν₁ ν₂ : Measure α} {s s' t : Set α}
+variable {μ μ₁ μ₂ ν ν' : Measure α} {s t : Set α}
 namespace Measure
 
 /-- If `u` is a superset of `t` with the same (finite) measure (both sets possibly non-measurable),

--- a/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
@@ -423,7 +423,7 @@ section IsComplete
 class Measure.IsComplete {_ : MeasurableSpace α} (μ : Measure α) : Prop where
   out' : ∀ s, μ s = 0 → MeasurableSet s
 
-variable {m0 : MeasurableSpace α} {μ : Measure α} {s t : Set α}
+variable {m0 : MeasurableSpace α} {μ : Measure α} {s : Set α}
 
 theorem Measure.isComplete_iff : μ.IsComplete ↔ ∀ s, μ s = 0 → MeasurableSet s :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -25,12 +25,12 @@ pullback under `Subtype.val`) and the restriction to a set as above.
 open scoped ENNReal NNReal Topology
 open Set MeasureTheory Measure Filter MeasurableSpace ENNReal Function
 
-variable {R α β δ γ ι : Type*}
+variable {R α β δ ι : Type*}
 
 namespace MeasureTheory
 
-variable {m0 : MeasurableSpace α} [MeasurableSpace β] [MeasurableSpace γ]
-variable {μ μ₁ μ₂ μ₃ ν ν' ν₁ ν₂ : Measure α} {s s' t : Set α}
+variable {m0 : MeasurableSpace α} [MeasurableSpace β]
+variable {μ ν : Measure α} {s s' t : Set α}
 
 namespace Measure
 

--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -1081,7 +1081,7 @@ end
 section
 
 variable {M : Type*} [TopologicalSpace M] [AddCommMonoid M] [PartialOrder M]
-variable (v w : VectorMeasure α M) {i j : Set α}
+variable (v : VectorMeasure α M) {i j : Set α}
 
 theorem nonneg_of_zero_le_restrict (hi₂ : 0 ≤[i] v) : 0 ≤ v i := by
   by_cases hi₁ : MeasurableSet i
@@ -1118,7 +1118,7 @@ end
 section
 
 variable {M : Type*} [TopologicalSpace M] [AddCommMonoid M] [LinearOrder M]
-variable (v w : VectorMeasure α M) {i j : Set α}
+variable (v : VectorMeasure α M) {i j : Set α}
 
 theorem exists_pos_measure_of_not_restrict_le_zero (hi : ¬v ≤[i] 0) :
     ∃ j : Set α, MeasurableSet j ∧ j ⊆ i ∧ 0 < v j := by

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -1275,7 +1275,7 @@ instance isCoatomistic [∀ i, CompleteLattice (π i)] [∀ i, IsCoatomistic (π
 end Pi
 
 section BooleanAlgebra
-variable [BooleanAlgebra α] {a b : α}
+variable [BooleanAlgebra α] {a : α}
 
 @[simp] lemma isAtom_compl : IsAtom aᶜ ↔ IsCoatom a := isCompl_compl.symm.isAtom_iff_isCoatom
 @[simp] lemma isCoatom_compl : IsCoatom aᶜ ↔ IsAtom a := isCompl_compl.symm.isCoatom_iff_isAtom

--- a/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
@@ -32,7 +32,7 @@ with an additional assumption that `s` is bounded below.
 
 open Set
 
-variable {α β γ : Type*} {ι : Sort*}
+variable {α : Type*}
 
 /-- A conditionally complete lattice is a lattice in which
 every nonempty subset which is bounded above has a supremum, and

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1279,7 +1279,7 @@ theorem LE.le.eventuallyLE {α} {l : Filter α} {s t : Set α} (h : s ⊆ t) : s
 
 @[deprecated (since := "2026-03-16")] alias HasSubset.Subset.eventuallyLE := LE.le.eventuallyLE
 
-variable {α β : Type*} {F : Filter α} {G : Filter β}
+variable {α : Type*}
 
 namespace Filter
 

--- a/Mathlib/Order/Filter/Finite.lean
+++ b/Mathlib/Order/Filter/Finite.lean
@@ -24,7 +24,7 @@ universe u v w x y
 
 namespace Filter
 
-variable {α : Type u} {f g : Filter α} {s t : Set α}
+variable {α : Type u} {f : Filter α} {s : Set α}
 
 @[simp]
 theorem biInter_mem {β : Type v} {s : β → Set α} {is : Set β} (hf : is.Finite) :
@@ -53,7 +53,7 @@ end Filter
 
 namespace Filter
 
-variable {α : Type u} {β : Type v} {γ : Type w} {δ : Type*} {ι : Sort x}
+variable {α : Type u} {β : Type v} {ι : Sort x}
 
 section Lattice
 

--- a/Mathlib/Order/Interval/Basic.lean
+++ b/Mathlib/Order/Interval/Basic.lean
@@ -567,7 +567,7 @@ namespace NonemptyInterval
 
 section Preorder
 
-variable [Preorder α] {s t : NonemptyInterval α} {a : α}
+variable [Preorder α] {s : NonemptyInterval α} {a : α}
 
 @[simp, norm_cast]
 theorem coe_pure_interval (a : α) : (pure a : Interval α) = Interval.pure a :=

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -388,7 +388,7 @@ end Subset
 
 section Set
 
-variable {s t : Set α}
+variable {s : Set α}
 section Preorder
 
 variable [Preorder α]

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -97,7 +97,7 @@ instance [Inhabited α] : Inhabited (Chain α) :=
 instance : Membership α (Chain α) where
   mem c a := ∃ i, a = c i
 
-variable (c c' : Chain α)
+variable (c : Chain α)
 variable (f : α →o β)
 variable (g : β →o γ)
 

--- a/Mathlib/Order/Preorder/Chain.lean
+++ b/Mathlib/Order/Preorder/Chain.lean
@@ -58,7 +58,7 @@ def SuperChain (s t : Set α) : Prop :=
 def IsMaxChain (s : Set α) : Prop :=
   IsChain r s ∧ ∀ ⦃t⦄, IsChain r t → s ⊆ t → s = t
 
-variable {r} {c c₁ c₂ s t : Set α} {a b x y : α}
+variable {r} {c s t : Set α} {a b x y : α}
 
 @[simp] lemma IsChain.empty : IsChain r ∅ := pairwise_empty _
 @[simp] lemma IsChain.singleton : IsChain r {a} := pairwise_singleton ..

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -627,7 +627,7 @@ theorem succ_eq_csInf [ConditionallyCompleteLattice α] [SuccOrder α] [NoMaxOrd
 
 section Preorder
 
-variable [Preorder α] [PredOrder α] {a b : α}
+variable [Preorder α] [PredOrder α] {a : α}
 
 -- TODO: auto-generate all of these through `to_dual`
 

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -220,7 +220,7 @@ end LT
 
 section Preorder
 
-variable [Preorder α] {s t : Set α} {a : α}
+variable [Preorder α] {s t : Set α}
 
 protected nonrec theorem IsWF.union (hs : IsWF s) (ht : IsWF t) : IsWF (s ∪ t) := hs.union ht
 
@@ -230,7 +230,7 @@ end Preorder
 
 section Preorder
 
-variable [Preorder α] {s t : Set α} {a : α}
+variable [Preorder α] {s : Set α}
 
 theorem isWF_iff_no_descending_seq :
     IsWF s ↔ ∀ f : ℕ → α, StrictAnti f → ¬∀ n, f n ∈ s :=

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -990,8 +990,8 @@ theorem quotEquivQuotMap_symm_apply_mk (f g : R[X]) (I : Ideal R) :
 end
 
 section TensorProduct
-variable {R S T U : Type*} [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T]
-  [CommRing U] [Algebra R U] {p : Polynomial S}
+variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T] {p :
+  Polynomial S}
 
 open Algebra TensorProduct
 

--- a/Mathlib/RingTheory/Coalgebra/CoassocSimps.lean
+++ b/Mathlib/RingTheory/Coalgebra/CoassocSimps.lean
@@ -48,14 +48,12 @@ open Coalgebra
 open Qq
 namespace CoassocSimps
 
-variable {R A M N P M' N' P' Q Q' M₁ M₂ M₃ N₁ N₂ N₃ : Type*}
-    [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A]
-    [AddCommMonoid M] [Module R M] [AddCommMonoid N] [Module R N] [AddCommMonoid P] [Module R P]
-    [AddCommMonoid M'] [Module R M'] [AddCommMonoid N'] [Module R N']
-    [AddCommMonoid P'] [Module R P'] [AddCommMonoid Q] [Module R Q] [AddCommMonoid Q'] [Module R Q']
-    [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
-    [AddCommMonoid N₁] [AddCommMonoid N₂] [AddCommMonoid N₃]
-    [Module R M₁] [Module R M₂] [Module R M₃] [Module R N₁] [Module R N₂] [Module R N₃]
+variable {R A M N P M' N' P' Q M₁ M₂ M₃ N₁ N₂ N₃ : Type*} [CommSemiring R] [AddCommMonoid A]
+  [Module R A] [Coalgebra R A] [AddCommMonoid M] [Module R M] [AddCommMonoid N] [Module R N]
+  [AddCommMonoid P] [Module R P] [AddCommMonoid M'] [Module R M'] [AddCommMonoid N'] [Module R N']
+  [AddCommMonoid P'] [Module R P'] [AddCommMonoid Q] [Module R Q] [AddCommMonoid M₁]
+  [AddCommMonoid M₂] [AddCommMonoid M₃] [AddCommMonoid N₁] [AddCommMonoid N₂] [AddCommMonoid N₃]
+  [Module R M₁] [Module R M₂] [Module R M₃] [Module R N₁] [Module R N₂] [Module R N₃]
 
 local notation3 "α" => (TensorProduct.assoc R _ _ _).toLinearMap
 local notation3 "α⁻¹" => (TensorProduct.assoc R _ _ _).symm.toLinearMap

--- a/Mathlib/RingTheory/FreeCommRing.lean
+++ b/Mathlib/RingTheory/FreeCommRing.lean
@@ -228,7 +228,7 @@ def restriction (s : Set α) [DecidablePred (· ∈ s)] : FreeCommRing α →+* 
 
 section Restriction
 
-variable (s : Set α) [DecidablePred (· ∈ s)] (x y : FreeCommRing α)
+variable (s : Set α) [DecidablePred (· ∈ s)]
 
 @[simp]
 theorem restriction_of (p) : restriction s (of p) = if H : p ∈ s then of ⟨p, H⟩ else 0 :=

--- a/Mathlib/RingTheory/Ideal/Quotient/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Basic.lean
@@ -30,7 +30,7 @@ See `RingCon.Quotient` for quotients of (possibly non-commutative) semirings.
 
 open Set
 
-variable {ι ι' R S : Type*} [Ring R] (I J : Ideal R) {a b : R}
+variable {ι ι' R : Type*} [Ring R] (I J : Ideal R) {a b : R}
 
 namespace Ideal.Quotient
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -363,7 +363,7 @@ namespace RatFunc
 
 open scoped LaurentSeries
 
-variable {F : Type u} [Field F] (p q : F[X]) (f g : RatFunc F)
+variable {F : Type u} [Field F] (p q : F[X])
 
 instance : FaithfulSMul F[X] F⸨X⸩ := by
   refine (faithfulSMul_iff_algebraMap_injective F[X] F⸨X⸩).mpr ?_

--- a/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
@@ -390,7 +390,7 @@ def weightedHomogeneousComponent (w : σ → M) (n : M) : MvPolynomial σ R →�
 
 section WeightedHomogeneousComponent
 
-variable {w : σ → M} (n : M) (φ ψ : MvPolynomial σ R)
+variable {w : σ → M} (n : M) (φ : MvPolynomial σ R)
 
 set_option backward.isDefEq.respectTransparency false in
 theorem coeff_weightedHomogeneousComponent [DecidableEq M] (d : σ →₀ ℕ) :
@@ -624,8 +624,7 @@ end OrderedAddCommMonoid
 
 section LinearOrderedAddCommMonoid
 
-variable [AddCommMonoid M] [LinearOrder M] [OrderBot M] [CanonicallyOrderedAdd M]
-  {w : σ → M} (φ : MvPolynomial σ R)
+variable [AddCommMonoid M] [LinearOrder M] [OrderBot M] [CanonicallyOrderedAdd M] {w : σ → M}
 
 /-- A multivariate polynomial is weighted homogeneous of weighted degree zero if and only if
   its weighted total degree is equal to zero. -/

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -218,7 +218,7 @@ end Commute
 
 section CommSemiring
 
-variable [CommSemiring R] {x y : R}
+variable [CommSemiring R]
 
 lemma isNilpotent_sum {ι : Type*} {s : Finset ι} {f : ι → R}
     (hnp : ∀ i ∈ s, IsNilpotent (f i)) :

--- a/Mathlib/RingTheory/Polynomial/IntegralNormalization.lean
+++ b/Mathlib/RingTheory/Polynomial/IntegralNormalization.lean
@@ -23,7 +23,7 @@ namespace Polynomial
 
 universe u v y
 
-variable {R : Type u} {S : Type v} {a b : R} {m n : ℕ} {ι : Type y}
+variable {R : Type u} {S : Type v} {a : R} {m n : ℕ}
 
 section IntegralNormalization
 

--- a/Mathlib/RingTheory/PowerBasis.lean
+++ b/Mathlib/RingTheory/PowerBasis.lean
@@ -46,7 +46,7 @@ power basis, powerbasis
 
 open Finsupp Module Polynomial
 
-variable {R S T : Type*} [CommRing R] [Ring S] [Algebra R S]
+variable {R S : Type*} [CommRing R] [Ring S] [Algebra R S]
 variable {A B : Type*} [CommRing A] [CommRing B] [Algebra A B]
 variable {K : Type*} [Field K]
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -860,7 +860,7 @@ end Semiring
 
 section CommSemiring
 
-variable {R : Type*} [CommSemiring R] (φ ψ : R[X])
+variable {R : Type*} [CommSemiring R] (φ : R[X])
 
 theorem _root_.MvPolynomial.toMvPowerSeries_pUnitAlgEquiv {f : MvPolynomial PUnit R} :
     (f.toMvPowerSeries : PowerSeries R) =

--- a/Mathlib/RingTheory/PowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/PowerSeries/Substitution.lean
@@ -373,8 +373,7 @@ theorem HasSubst.comp
     HasSubst (substAlgHom hb a) :=
   MvPowerSeries.IsNilpotent_substAlgHom hb.const ha
 
-variable {a : PowerSeries S} {b : MvPowerSeries υ T} {a' : MvPowerSeries τ S}
-  {b' : τ → MvPowerSeries υ T} [IsScalarTower R S T]
+variable {a : PowerSeries S} {b : MvPowerSeries υ T} [IsScalarTower R S T]
 
 theorem substAlgHom_comp_substAlgHom (ha : HasSubst a) (hb : HasSubst b) :
     ((substAlgHom hb).restrictScalars R).comp (substAlgHom ha) = substAlgHom (ha.comp hb) :=
@@ -602,8 +601,8 @@ section
 
 attribute [local instance] DiscreteTopology.instContinuousSMul
 
-variable {x : ℕ → PowerSeries R} {a : MvPowerSeries τ S}
-  [UniformSpace R] [DiscreteUniformity R] [UniformSpace S] [DiscreteUniformity S]
+variable {x : ℕ → PowerSeries R} {a : MvPowerSeries τ S} [UniformSpace R] [DiscreteUniformity R]
+  [UniformSpace S] [DiscreteUniformity S]
 
 lemma subst_tsum (hx : Summable x) (ha : HasSubst a) :
     (∑' i, x i).subst a = ∑' i, ((x i).subst a) := by

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -50,8 +50,8 @@ the roots of the minimal polynomial of `s` over `R`.
 
 universe u v w z
 
-variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
-variable [Algebra R S] [Algebra R T]
+variable {R S : Type*} [CommRing R] [CommRing S]
+variable [Algebra R S]
 variable {K L : Type*} [Field K] [Field L] [Algebra K L]
 variable {ι κ : Type w}
 
@@ -439,7 +439,7 @@ section Field
 variable (K) (E : Type z) [Field E]
 variable [Algebra K E]
 variable [Module.Finite K L] [Algebra.IsSeparable K L] [IsAlgClosed E]
-variable (b : κ → L) (pb : PowerBasis K L)
+variable (b : κ → L)
 
 theorem traceMatrix_eq_embeddingsMatrix_mul_trans : (traceMatrix K b).map (algebraMap K E) =
     embeddingsMatrix K E b * (embeddingsMatrix K E b)ᵀ := by
@@ -544,8 +544,8 @@ section Basis
 
 open Algebra
 
-variable [FiniteDimensional K L] [Algebra.IsSeparable K L] [Finite ι] [DecidableEq ι]
-  (b : Basis ι K L)
+variable [FiniteDimensional K L] [Algebra.IsSeparable K L] [Finite ι] [DecidableEq ι] (b : Basis ι
+  K L)
 
 /--
 The dual basis of a basis under the trace form in a finite separable extension.

--- a/Mathlib/SetTheory/Cardinal/NatCard.lean
+++ b/Mathlib/SetTheory/Cardinal/NatCard.lean
@@ -33,7 +33,7 @@ assert_not_exists Field
 
 noncomputable section
 
-variable {α β γ : Type*}
+variable {α β : Type*}
 
 /-- There is (noncomputably) an equivalence between a finite type `α` and `Fin (Nat.card α)`. -/
 def Finite.equivFin (α : Type*) [Finite α] : α ≃ Fin (Nat.card α) := by

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -28,7 +28,6 @@ noncomputable section
 
 namespace TopCat
 
-variable {J : Type v} [Category.{w} J]
 
 /-- The projection from the product as a bundled continuous map. -/
 abbrev piπ {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : TopCat.of (∀ i, α i) ⟶ α i :=

--- a/Mathlib/Topology/Compactification/OnePoint/ProjectiveLine.lean
+++ b/Mathlib/Topology/Compactification/OnePoint/ProjectiveLine.lean
@@ -38,7 +38,7 @@ open Projectivization Matrix Polynomial OnePoint
 
 section MatrixProdAction
 
-variable {R n : Type*} [Semiring R] [Fintype n] [DecidableEq n]
+variable {R : Type*} [Semiring R]
 
 @[simp] lemma Matrix.mulVec_fin_two (m : Matrix (Fin 2) (Fin 2) R) (v : Fin 2 → R) :
     m *ᵥ v = ![m 0 0 * v 0 + m 0 1 * v 1, m 1 0 * v 0 + m 1 1 * v 1] := by

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -48,7 +48,7 @@ open scoped Set.Notation
 
 universe u v u' v'
 
-variable {X : Type u} {Y : Type v} {Z W ε ζ : Type*}
+variable {X : Type u} {Y : Type v} {Z : Type*}
 
 section Constructions
 
@@ -758,8 +758,8 @@ end Quotient
 
 section Pi
 
-variable {ι : Type*} {A B : ι → Type*} {κ : Type*} [TopologicalSpace X]
-  [T : ∀ i, TopologicalSpace (A i)] [∀ i, TopologicalSpace (B i)] {f : X → ∀ i : ι, A i}
+variable {ι : Type*} {A B : ι → Type*} {κ : Type*} [TopologicalSpace X] [T : ∀ i, TopologicalSpace
+  (A i)] [∀ i, TopologicalSpace (B i)] {f : X → ∀ i : ι, A i}
 
 theorem continuous_pi_iff : Continuous f ↔ ∀ i, Continuous fun a => f a i := by
   simp only [continuous_iInf_rng, continuous_induced_rng, comp_def]
@@ -1222,8 +1222,8 @@ end Pi
 
 section Sigma
 
-variable {ι κ : Type*} {σ : ι → Type*} {τ : κ → Type*} [∀ i, TopologicalSpace (σ i)]
-  [∀ k, TopologicalSpace (τ k)] [TopologicalSpace X]
+variable {ι κ : Type*} {σ : ι → Type*} {τ : κ → Type*} [∀ i, TopologicalSpace (σ i)] [∀ k,
+  TopologicalSpace (τ k)] [TopologicalSpace X]
 
 @[continuity, fun_prop]
 theorem continuous_sigmaMk {i : ι} : Continuous (@Sigma.mk ι σ i) :=
@@ -1417,8 +1417,7 @@ theorem IsClosed.trans (ht : IsClosed t) (hs : IsClosed s) : IsClosed (t : Set X
 end Monad
 
 section NhdsSet
-variable [TopologicalSpace X] [TopologicalSpace Y]
-  {s : Set X} {t : Set Y}
+variable [TopologicalSpace X] [TopologicalSpace Y] {s : Set X} {t : Set Y}
 
 /-- The product of a neighborhood of `s` and a neighborhood of `t` is a neighborhood of `s ×ˢ t`,
 formulated in terms of a filter inequality. -/

--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -206,7 +206,7 @@ glues only along the basepoints, putting them at distance 1. We give a direct de
 the distance, without `iInf`, as it is easier to use in applications, and show that it is equal to
 the gluing distance defined above to take advantage of the lemmas we have already proved.
 -/
-variable {X : Type u} {Y : Type v} {Z : Type w}
+variable {X : Type u} {Y : Type v}
 variable [MetricSpace X] [MetricSpace Y]
 
 /-- Distance on a disjoint union. There are many (noncanonical) ways to put a distance compatible
@@ -462,7 +462,6 @@ section Gluing
 -- Exact gluing of two metric spaces along isometric subsets.
 variable {X : Type u} {Y : Type v} {Z : Type w}
 variable [Nonempty Z] [MetricSpace Z] [MetricSpace X] [MetricSpace Y] {Φ : Z → X} {Ψ : Z → Y}
-  {ε : ℝ}
 
 set_option backward.privateInPublic true in
 set_option backward.privateInPublic.warn false in

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -789,7 +789,7 @@ namespace PiCountable
 variable {ι : Type*} [Encodable ι] {F : ι → Type*}
 
 section EDist
-variable [∀ i, EDist (F i)] {x y : ∀ i, F i} {i : ι} {r : ℝ≥0∞}
+variable [∀ i, EDist (F i)] {x y : ∀ i, F i} {i : ι}
 
 /-- Given a countable family of extended metric spaces,
 one may put an extended distance on their product `Π i, E i`.
@@ -1141,7 +1141,6 @@ lemma injective_distDenseSeq (x y : X) (hxy : x ≠ y) :
   obtain ⟨n, hn⟩ := separation ((isOpen_compl_singleton (x := y)).mem_nhds hxy)
   exact ⟨n, fun e ↦ by simp +contextual [e, ← exists_prop, mem_of_mem_nhds] at hn⟩
 
-variable (A : Type*) [TopologicalSpace A]
 
 lemma continuous_distDenseSeq_inv :
     Continuous (ofPiNat : PiNatEmbed X (fun _ => I) (distDenseSeq X) → X) := by

--- a/Mathlib/Topology/MetricSpace/ProperSpace.lean
+++ b/Mathlib/Topology/MetricSpace/ProperSpace.lean
@@ -29,7 +29,7 @@ open Set Filter
 
 universe u v w
 
-variable {α : Type u} {β : Type v} {X ι : Type*}
+variable {α : Type u} {β : Type v} {X : Type*}
 
 section ProperSpace
 

--- a/Mathlib/Topology/Order/Compact.lean
+++ b/Mathlib/Topology/Order/Compact.lean
@@ -142,8 +142,7 @@ end openIntervals
 
 section LinearOrder
 
-variable {α β γ : Type*} [LinearOrder α] [TopologicalSpace α]
-  [TopologicalSpace β] [TopologicalSpace γ]
+variable {α β : Type*} [LinearOrder α] [TopologicalSpace α] [TopologicalSpace β]
 
 theorem IsCompact.exists_isLeast [ClosedIicTopology α] {s : Set α} (hs : IsCompact s)
     (ne_s : s.Nonempty) : ∃ x, IsLeast s x := by
@@ -351,8 +350,8 @@ end LinearOrder
 
 section ConditionallyCompleteLinearOrder
 
-variable {α β γ : Type*} [ConditionallyCompleteLinearOrder α] [TopologicalSpace α]
-  [TopologicalSpace β] [TopologicalSpace γ]
+variable {α β : Type*} [ConditionallyCompleteLinearOrder α] [TopologicalSpace α] [TopologicalSpace
+  β]
 
 theorem IsCompact.sSup_lt_iff_of_continuous [ClosedIciTopology α] {f : β → α} {K : Set β}
     (hK : IsCompact K) (h0K : K.Nonempty) (hf : ContinuousOn f K) (y : α) :

--- a/Mathlib/Topology/UniformSpace/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Completion.lean
@@ -65,8 +65,8 @@ namespace CauchyFilter
 section
 
 variable {α : Type u} [UniformSpace α]
-variable {β : Type v} {γ : Type w}
-variable [UniformSpace β] [UniformSpace γ]
+variable {β : Type v}
+variable [UniformSpace β]
 
 instance (f : CauchyFilter α) : NeBot f.1 := f.2.1
 


### PR DESCRIPTION
This PR removes a further ~330 unused `variable` binders across 118 files. It recovers the findings that #42214 dropped conservatively: files with comments inside `variable` statements, which the first edit pass could not handle, and files whose sources had diverged from the validation branch.

The `unusedVariableCommand` linter (#42216) found the binders, in its refined form with syntactic usage marking, so the known false-positive classes of the first pass do not apply. Every edited file was verified to compile against the validation sources. 117 of the 118 files then transferred to current master through fuzzy patching, so CI is the final gate for the transfer step.

The benchmark of #42214 showed that removals of this kind concentrate real elaboration savings in typeclass-heavy files (up to -29% instructions per module). This pass draws from the same population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)