### PR TITLE
feat(Computability/Reduce): the halting problem is many-one complete

### DIFF
--- a/Mathlib/Computability/Reduce.lean
+++ b/Mathlib/Computability/Reduce.lean
@@ -279,9 +279,7 @@ theorem disjoin_le {α β γ} [Primcodable α] [Primcodable β] [Primcodable γ]
 
 /-! ### Many-one completeness of the halting problem
 
-`ComputablePred.halting_problem_re` and `ComputablePred.halting_problem` show that the halting
-problem is recursively enumerable and not computable. Here we show that it is *complete* for
-recursively enumerable predicates under many-one reducibility.
+The halting problem is complete for recursively enumerable predicates under many-one reducibility.
 -/
 
 section HaltingProblem
@@ -289,11 +287,7 @@ section HaltingProblem
 open Nat.Partrec (Code)
 
 /-- Every recursively enumerable predicate on `ℕ` many-one reduces to the halting problem on any
-fixed input `n`.
-
-Given a code `c` for a partial recursive function whose domain is the predicate, the reduction
-sends `a` to `c.comp (Code.const a)`, a program that halts on every input exactly when `c` halts
-on `a`; in particular the input `n` plays no role. -/
+fixed input. -/
 theorem REPred.manyOneReducible_halting_problem {R : ℕ → Prop} (h : REPred R) (n : ℕ) :
     R ≤₀ fun c : Code => (Code.eval c n).Dom := by
   obtain ⟨c, hc⟩ := Code.exists_code.mp <| Partrec.nat_iff.mp <|
@@ -303,12 +297,8 @@ theorem REPred.manyOneReducible_halting_problem {R : ℕ → Prop} (h : REPred R
   simp [Code.eval, hc, Part.assert]
 
 set_option backward.isDefEq.respectTransparency false in
-/-- The halting problem on a fixed input and the two-argument halting problem are many-one
-equivalent.
-
-Left to right pairs the code with the fixed input; right to left specializes the input into the
-code, sending `p` to `p.1.comp (Code.const p.2)`. The individual reductions are the two
-projections. -/
+/-- The fixed-input and two-argument formulations of the halting problem are many-one
+equivalent. -/
 theorem halting_problem_manyOneEquiv_halting_problem₂ (n : ℕ) :
     ManyOneEquiv (fun c : Code => (Code.eval c n).Dom)
       (fun p : Code × ℕ => (Code.eval p.1 p.2).Dom) := by
@@ -318,8 +308,8 @@ theorem halting_problem_manyOneEquiv_halting_problem₂ (n : ℕ) :
     fun p => ?_⟩
   simp [Code.eval]
 
-/-- Every recursively enumerable predicate on `ℕ` many-one reduces to the halting problem in its
-two-argument form. -/
+/-- Every recursively enumerable predicate on `ℕ` many-one reduces to the two-argument halting
+problem. -/
 theorem REPred.manyOneReducible_halting_problem₂ {R : ℕ → Prop} (h : REPred R) :
     R ≤₀ fun p : Code × ℕ => (Code.eval p.1 p.2).Dom :=
   (h.manyOneReducible_halting_problem 0).trans (halting_problem_manyOneEquiv_halting_problem₂ 0).1

--- a/Mathlib/Computability/Reduce.lean
+++ b/Mathlib/Computability/Reduce.lean
@@ -302,26 +302,27 @@ theorem REPred.manyOneReducible_halting_problem {R : ℕ → Prop} (h : REPred R
     (Code.primrec₂_comp.comp (Primrec.const c) Code.primrec_const).to_comp, fun a => ?_⟩
   simp [Code.eval, hc, Part.assert]
 
-/-- The halting problem on a fixed input reduces to the two-argument halting problem. -/
-theorem halting_problem_manyOneReducible_halting_problem₂ (n : ℕ) :
-    (fun c : Code => (Code.eval c n).Dom) ≤₀ fun p : Code × ℕ => (Code.eval p.1 p.2).Dom :=
-  ⟨fun c => (c, n), Computable.id.pair (Computable.const n), fun _ => Iff.rfl⟩
+set_option backward.isDefEq.respectTransparency false in
+/-- The halting problem on a fixed input and the two-argument halting problem are many-one
+equivalent.
+
+Left to right pairs the code with the fixed input; right to left specializes the input into the
+code, sending `p` to `p.1.comp (Code.const p.2)`. The individual reductions are the two
+projections. -/
+theorem halting_problem_manyOneEquiv_halting_problem₂ (n : ℕ) :
+    ManyOneEquiv (fun c : Code => (Code.eval c n).Dom)
+      (fun p : Code × ℕ => (Code.eval p.1 p.2).Dom) := by
+  refine ⟨⟨fun c => (c, n), Computable.id.pair (Computable.const n), fun _ => Iff.rfl⟩, ?_⟩
+  refine ⟨fun p => p.1.comp (Code.const p.2),
+    (Code.primrec₂_comp.comp Primrec.fst (Code.primrec_const.comp Primrec.snd)).to_comp,
+    fun p => ?_⟩
+  simp [Code.eval]
 
 /-- Every recursively enumerable predicate on `ℕ` many-one reduces to the halting problem in its
 two-argument form. -/
 theorem REPred.manyOneReducible_halting_problem₂ {R : ℕ → Prop} (h : REPred R) :
     R ≤₀ fun p : Code × ℕ => (Code.eval p.1 p.2).Dom :=
-  (h.manyOneReducible_halting_problem 0).trans (halting_problem_manyOneReducible_halting_problem₂ 0)
-
-set_option backward.isDefEq.respectTransparency false in
-/-- The two-argument halting problem reduces to the halting problem on any fixed input, by
-specializing the input into the code. -/
-theorem halting_problem₂_manyOneReducible_halting_problem (n : ℕ) :
-    (fun p : Code × ℕ => (Code.eval p.1 p.2).Dom) ≤₀ fun c : Code => (Code.eval c n).Dom := by
-  refine ⟨fun p => p.1.comp (Code.const p.2),
-    (Code.primrec₂_comp.comp Primrec.fst (Code.primrec_const.comp Primrec.snd)).to_comp,
-    fun p => ?_⟩
-  simp [Code.eval]
+  (h.manyOneReducible_halting_problem 0).trans (halting_problem_manyOneEquiv_halting_problem₂ 0).1
 
 end HaltingProblem
 

--- a/Mathlib/Computability/Reduce.lean
+++ b/Mathlib/Computability/Reduce.lean
@@ -296,34 +296,24 @@ sends `a` to `c.comp (Code.const a)`, a program that halts on every input exactl
 on `a`; in particular the input `n` plays no role. -/
 theorem REPred.manyOneReducible_halting_problem {R : ℕ → Prop} (h : REPred R) (n : ℕ) :
     R ≤₀ fun c : Code => (Code.eval c n).Dom := by
-  have hf : Partrec fun a : ℕ => (Part.assert (R a) fun _ => Part.some ()).map fun _ => (0 : ℕ) :=
+  obtain ⟨c, hc⟩ := Code.exists_code.mp <| Partrec.nat_iff.mp <|
     h.map (Computable.const (0 : ℕ)).to₂
-  set f : ℕ →. ℕ := fun a => (Part.assert (R a) fun _ => Part.some ()).map fun _ => (0 : ℕ)
-    with hf_def
-  have hdom : ∀ a, (f a).Dom ↔ R a := by
-    intro a
-    simp [hf_def, Part.assert]
-  obtain ⟨c, hc⟩ := Code.exists_code.mp (Partrec.nat_iff.mp hf)
   refine ⟨fun a => c.comp (Code.const a),
     (Code.primrec₂_comp.comp (Primrec.const c) Code.primrec_const).to_comp, fun a => ?_⟩
-  change R a ↔ (Code.eval (c.comp (Code.const a)) n).Dom
-  rw [show Code.eval (c.comp (Code.const a)) n = f a by
-    simp only [Code.eval, Code.eval_const, hc]
-    exact Part.bind_some a f]
-  exact (hdom a).symm
-
-/-- Every recursively enumerable predicate on `ℕ` many-one reduces to the halting problem in its
-two-argument form. -/
-theorem REPred.manyOneReducible_halting_problem₂ {R : ℕ → Prop} (h : REPred R) :
-    R ≤₀ fun p : Code × ℕ => (Code.eval p.1 p.2).Dom := by
-  obtain ⟨g, hg, hgR⟩ := h.manyOneReducible_halting_problem 0
-  exact ⟨fun a => (g a, 0), hg.pair (Computable.const 0), hgR⟩
+  simp [Code.eval, hc, Part.assert]
 
 /-- The halting problem on a fixed input reduces to the two-argument halting problem. -/
 theorem halting_problem_manyOneReducible_halting_problem₂ (n : ℕ) :
     (fun c : Code => (Code.eval c n).Dom) ≤₀ fun p : Code × ℕ => (Code.eval p.1 p.2).Dom :=
   ⟨fun c => (c, n), Computable.id.pair (Computable.const n), fun _ => Iff.rfl⟩
 
+/-- Every recursively enumerable predicate on `ℕ` many-one reduces to the halting problem in its
+two-argument form. -/
+theorem REPred.manyOneReducible_halting_problem₂ {R : ℕ → Prop} (h : REPred R) :
+    R ≤₀ fun p : Code × ℕ => (Code.eval p.1 p.2).Dom :=
+  (h.manyOneReducible_halting_problem 0).trans (halting_problem_manyOneReducible_halting_problem₂ 0)
+
+set_option backward.isDefEq.respectTransparency false in
 /-- The two-argument halting problem reduces to the halting problem on any fixed input, by
 specializing the input into the code. -/
 theorem halting_problem₂_manyOneReducible_halting_problem (n : ℕ) :
@@ -331,10 +321,7 @@ theorem halting_problem₂_manyOneReducible_halting_problem (n : ℕ) :
   refine ⟨fun p => p.1.comp (Code.const p.2),
     (Code.primrec₂_comp.comp Primrec.fst (Code.primrec_const.comp Primrec.snd)).to_comp,
     fun p => ?_⟩
-  change (Code.eval p.1 p.2).Dom ↔ (Code.eval (p.1.comp (Code.const p.2)) n).Dom
-  rw [show Code.eval (p.1.comp (Code.const p.2)) n = Code.eval p.1 p.2 by
-    simp only [Code.eval, Code.eval_const]
-    exact Part.bind_some p.2 (Code.eval p.1)]
+  simp [Code.eval]
 
 end HaltingProblem
 

--- a/Mathlib/Computability/Reduce.lean
+++ b/Mathlib/Computability/Reduce.lean
@@ -279,7 +279,9 @@ theorem disjoin_le {α β γ} [Primcodable α] [Primcodable β] [Primcodable γ]
 
 /-! ### Many-one completeness of the halting problem
 
-The halting problem is complete for recursively enumerable predicates under many-one reducibility.
+The halting problem is complete for recursively enumerable predicates under many-one reducibility;
+see `ComputablePred.halting_problem_re` and `ComputablePred.halting_problem` for the other basic
+facts.
 -/
 
 section HaltingProblem

--- a/Mathlib/Computability/Reduce.lean
+++ b/Mathlib/Computability/Reduce.lean
@@ -277,6 +277,67 @@ theorem disjoin_le {α β γ} [Primcodable α] [Primcodable β] [Primcodable γ]
       OneOneReducible.disjoin_right.to_many_one.trans h⟩,
     fun ⟨h₁, h₂⟩ => disjoin_manyOneReducible h₁ h₂⟩
 
+/-! ### Many-one completeness of the halting problem
+
+`ComputablePred.halting_problem_re` and `ComputablePred.halting_problem` show that the halting
+problem is recursively enumerable and not computable. Here we show that it is *complete* for
+recursively enumerable predicates under many-one reducibility.
+-/
+
+section HaltingProblem
+
+open Nat.Partrec (Code)
+
+/-- Every recursively enumerable predicate on `ℕ` many-one reduces to the halting problem on any
+fixed input `n`.
+
+Given a code `c` for a partial recursive function whose domain is the predicate, the reduction
+sends `a` to `c.comp (Code.const a)`, a program that halts on every input exactly when `c` halts
+on `a`; in particular the input `n` plays no role. -/
+theorem REPred.manyOneReducible_halting_problem {R : ℕ → Prop} (h : REPred R) (n : ℕ) :
+    R ≤₀ fun c : Code => (Code.eval c n).Dom := by
+  have hf : Partrec fun a : ℕ => (Part.assert (R a) fun _ => Part.some ()).map fun _ => (0 : ℕ) :=
+    h.map (Computable.const (0 : ℕ)).to₂
+  set f : ℕ →. ℕ := fun a => (Part.assert (R a) fun _ => Part.some ()).map fun _ => (0 : ℕ)
+    with hf_def
+  have hdom : ∀ a, (f a).Dom ↔ R a := by
+    intro a
+    simp [hf_def, Part.assert]
+  obtain ⟨c, hc⟩ := Code.exists_code.mp (Partrec.nat_iff.mp hf)
+  refine ⟨fun a => c.comp (Code.const a),
+    (Code.primrec₂_comp.comp (Primrec.const c) Code.primrec_const).to_comp, fun a => ?_⟩
+  change R a ↔ (Code.eval (c.comp (Code.const a)) n).Dom
+  rw [show Code.eval (c.comp (Code.const a)) n = f a by
+    simp only [Code.eval, Code.eval_const, hc]
+    exact Part.bind_some a f]
+  exact (hdom a).symm
+
+/-- Every recursively enumerable predicate on `ℕ` many-one reduces to the halting problem in its
+two-argument form. -/
+theorem REPred.manyOneReducible_halting_problem₂ {R : ℕ → Prop} (h : REPred R) :
+    R ≤₀ fun p : Code × ℕ => (Code.eval p.1 p.2).Dom := by
+  obtain ⟨g, hg, hgR⟩ := h.manyOneReducible_halting_problem 0
+  exact ⟨fun a => (g a, 0), hg.pair (Computable.const 0), hgR⟩
+
+/-- The halting problem on a fixed input reduces to the two-argument halting problem. -/
+theorem halting_problem_manyOneReducible_halting_problem₂ (n : ℕ) :
+    (fun c : Code => (Code.eval c n).Dom) ≤₀ fun p : Code × ℕ => (Code.eval p.1 p.2).Dom :=
+  ⟨fun c => (c, n), Computable.id.pair (Computable.const n), fun _ => Iff.rfl⟩
+
+/-- The two-argument halting problem reduces to the halting problem on any fixed input, by
+specializing the input into the code. -/
+theorem halting_problem₂_manyOneReducible_halting_problem (n : ℕ) :
+    (fun p : Code × ℕ => (Code.eval p.1 p.2).Dom) ≤₀ fun c : Code => (Code.eval c n).Dom := by
+  refine ⟨fun p => p.1.comp (Code.const p.2),
+    (Code.primrec₂_comp.comp Primrec.fst (Code.primrec_const.comp Primrec.snd)).to_comp,
+    fun p => ?_⟩
+  change (Code.eval p.1 p.2).Dom ↔ (Code.eval (p.1.comp (Code.const p.2)) n).Dom
+  rw [show Code.eval (p.1.comp (Code.const p.2)) n = Code.eval p.1 p.2 by
+    simp only [Code.eval, Code.eval_const]
+    exact Part.bind_some p.2 (Code.eval p.1)]
+
+end HaltingProblem
+
 variable {α : Type u} [Primcodable α] [Inhabited α] {β : Type v} [Primcodable β] [Inhabited β]
 
 /-- Computable and injective mapping of predicates to sets of natural numbers.

--- a/Mathlib/Computability/Reduce.lean
+++ b/Mathlib/Computability/Reduce.lean
@@ -279,9 +279,9 @@ theorem disjoin_le {α β γ} [Primcodable α] [Primcodable β] [Primcodable γ]
 
 /-! ### Many-one completeness of the halting problem
 
-The halting problem is complete for recursively enumerable predicates under many-one reducibility;
-see `ComputablePred.halting_problem_re` and `ComputablePred.halting_problem` for the other basic
-facts.
+The halting problem is complete for recursively enumerable predicates under many-one reducibility.
+See `ComputablePred.halting_problem_re` and `ComputablePred.halting_problem` for recursive
+enumerability and noncomputability, respectively.
 -/
 
 section HaltingProblem


### PR DESCRIPTION
`Mathlib/Computability/Halting.lean` proves that the halting problem is recursively enumerable (`ComputablePred.halting_problem_re`) and not computable (`ComputablePred.halting_problem`), but not that it is complete: there is no `REPred R → R ≤₀ K`, and neither `Halting.lean` nor `RE.lean` mentions `≤₀`.

This PR adds three results:

```lean
theorem REPred.manyOneReducible_halting_problem {R : ℕ → Prop} (h : REPred R) (n : ℕ) :
    R ≤₀ fun c : Code => (Code.eval c n).Dom

theorem halting_problem_manyOneEquiv_halting_problem₂ (n : ℕ) :
    ManyOneEquiv (fun c : Code => (Code.eval c n).Dom)
      (fun p : Code × ℕ => (Code.eval p.1 p.2).Dom)

theorem REPred.manyOneReducible_halting_problem₂ {R : ℕ → Prop} (h : REPred R) :
    R ≤₀ fun p : Code × ℕ => (Code.eval p.1 p.2).Dom
```

(I've stated the results in `Reduce.lean` rather than alongside the other halting-problem results because `≤₀` is defined here, and `Reduce` imports `Halting` rather than the other way around.)

🤖 These proofs were written with the assistance of Claude Opus 5 high and reviewed by GPT Sol 5.6 xhigh.
