### PR TITLE
[Merged by Bors] - fix(Translate): support structures where a universe level doesn't appear in the type

### DIFF
--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -1004,10 +1004,15 @@ partial def checkExistingType (t : TranslateData) (src tgt : Name) (cfg : Config
       type{indentExpr tgtType}"
   -- Process any remaining universe contraints, to assign all universe metavariables.
   discard <| processPostponed (mayPostpone := false) (exceptionOnFailure := true)
-  let params ← levels.mapM fun level ↦ do match ← instantiateLevelMVars level with
+  let tgtParams := tgtDecl.levelParams.toArray
+  let params ← levels.mapIdxM fun i level ↦ do
+    match ← instantiateLevelMVars level with
     | .param u => return u
-    | _ => throwError "inferred universe `{level}` in `{srcType}` is not a parameter."
-  let some univReorder := getPermutation params.toArray tgtDecl.levelParams.toArray |
+    | _ =>
+      -- For example in `HasLimitsOfSize`, not all universe levels appear in the type.
+      -- In that case, default to not permuting the universe levels.
+      return tgtParams[i]!
+  let some univReorder := getPermutation params.toArray tgtParams |
     throwError "inferred universe parameters {params} \
       are not a reordering of {srcDecl.levelParams}."
   return ({ univReorder, reorder }, ← getRelevantArg t cfg relevantArg? src lint)

--- a/MathlibTest/Attribute/ToDual.lean
+++ b/MathlibTest/Attribute/ToDual.lean
@@ -447,3 +447,11 @@ to_dual_name_hint Left Right, Epi Mono
 /-- info: "right_epi" -/
 #guard_msgs in
 #eval return GuessName.guessName (data.guessNameExt.getState (← getEnv)) "left_mono"
+
+-- A structure with a universe not appearing in its type
+structure HasLimitsOfSize where
+  foo : ∀ _ : Type u, True
+
+@[to_dual]
+structure HasColimitsOfSize where
+  cofoo : ∀ _ : Type u, True


### PR DESCRIPTION
This PR fixes a bug in `to_dual`/`to_additive` that makes it impossible to use it on a structure where a universe level doesn't appear in its type.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
