### PR TITLE
[Merged by Bors] - feat(Data/Nat/ModEq): add a new congruence to divisibility lemma

### DIFF
--- a/Mathlib/Data/Nat/ModEq.lean
+++ b/Mathlib/Data/Nat/ModEq.lean
@@ -118,6 +118,12 @@ alias ⟨ModEq.dvd, modEq_of_dvd⟩ := modEq_iff_dvd
 theorem modEq_iff_dvd' (h : a ≤ b) : a ≡ b [MOD n] ↔ n ∣ b - a := by
   rw [modEq_iff_dvd, ← Int.natCast_dvd_natCast, Int.ofNat_sub h]
 
+theorem ModEq.dvd' (h : a ≡ b [MOD n]) : n ∣ b - a := by
+  obtain h0 | h0 : a ≤ b ∨ b ≤ a := le_total a b
+  · exact (modEq_iff_dvd' h0).mp h
+  · rw [Nat.sub_eq_zero_of_le h0]
+    exact Nat.dvd_zero n
+
 theorem mod_modEq (a n) : a % n ≡ a [MOD n] :=
   mod_mod _ _
 

--- a/Mathlib/Data/Nat/ModEq.lean
+++ b/Mathlib/Data/Nat/ModEq.lean
@@ -118,6 +118,7 @@ alias ⟨ModEq.dvd, modEq_of_dvd⟩ := modEq_iff_dvd
 theorem modEq_iff_dvd' (h : a ≤ b) : a ≡ b [MOD n] ↔ n ∣ b - a := by
   rw [modEq_iff_dvd, ← Int.natCast_dvd_natCast, Int.ofNat_sub h]
 
+/-- The forward direction of `modEq_iff_dvd'`, which does not require the `a ≤ b` assumption. -/
 theorem ModEq.dvd' (h : a ≡ b [MOD n]) : n ∣ b - a := by
   obtain h0 | h0 : a ≤ b ∨ b ≤ a := le_total a b
   · exact (modEq_iff_dvd' h0).mp h

--- a/Mathlib/Data/Nat/ModEq.lean
+++ b/Mathlib/Data/Nat/ModEq.lean
@@ -125,6 +125,8 @@ theorem ModEq.dvd' (h : a ≡ b [MOD n]) : n ∣ b - a := by
   · rw [Nat.sub_eq_zero_of_le h0]
     exact Nat.dvd_zero n
 
+alias ⟨_, modEq_of_dvd'⟩ := modEq_iff_dvd'
+
 theorem mod_modEq (a n) : a % n ≡ a [MOD n] :=
   mod_mod _ _
 


### PR DESCRIPTION
Previously, we only have `modEq_iff_dvd'`  which assumes `a ≤ b`. However, the `→` direction does not need this assumption.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
