### PR TITLE
feat(Order/Partition): complete lattice structure on partitions of frames

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6207,6 +6207,7 @@ public import Mathlib.Order.PartialSups
 public import Mathlib.Order.Partition.Basic
 public import Mathlib.Order.Partition.Equipartition
 public import Mathlib.Order.Partition.Finpartition
+public import Mathlib.Order.Partition.Set
 public import Mathlib.Order.PiLex
 public import Mathlib.Order.Preorder.Chain
 public import Mathlib.Order.Preorder.Finite

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6207,6 +6207,7 @@ public import Mathlib.Order.PartialSups
 public import Mathlib.Order.Partition.Basic
 public import Mathlib.Order.Partition.Equipartition
 public import Mathlib.Order.Partition.Finpartition
+public import Mathlib.Order.Partition.Lattice
 public import Mathlib.Order.Partition.Set
 public import Mathlib.Order.PiLex
 public import Mathlib.Order.Preorder.Chain

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -95,7 +95,6 @@ lemma pairwiseDisjoint : Set.PairwiseDisjoint (P : Set α) id :=
 lemma eq_or_disjoint (hx : x ∈ P) (hy : y ∈ P) : x = y ∨ Disjoint x y :=
   or_iff_not_imp_left.mpr (P.disjoint hx hy)
 
-@[grind →]
 lemma eq_of_not_disjoint (hx : x ∈ P) (hy : y ∈ P) (hxy : ¬ Disjoint x y) : x = y :=
   (P.eq_or_disjoint hx hy).resolve_right hxy
 
@@ -163,7 +162,7 @@ instance : PartialOrder (Partition α) where
   lt := _
   le_refl P x hx := ⟨x, hx, le_rfl⟩
   le_trans P Q R hPQ hQR x hxP := by grind
-  le_antisymm P Q hp hq := Partition.ext fun x ↦ by grind
+  le_antisymm P Q hp hq := Partition.ext fun x ↦ by grind [eq_of_not_disjoint]
 
 lemma le_def : P ≤ Q ↔ ∀ x ∈ P, ∃ y ∈ Q, x ≤ y := .rfl
 

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -32,10 +32,11 @@ of `Q`.
 * `Partition.instSemilatticeInf`: `Partition α` has finite meets `P ⊓ Q` when `α` is a frame,
   given by binding `P` with the induced partitions of `Q` on each part of `P`.
 
+See `Mathlib.Order.Partition.Lattice` for the complete lattice structure when `α` is a frame.
+
 ## TODO
 
 * Link this to `Finpartition`.
-* Show that when `α` is a frame `Partition α` also has finite joins, i.e. that it is a lattice.
 
 -/
 

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -210,6 +210,9 @@ lemma eq_bot (hP : P.supp = ⊥) : P = ⊥ := by
 lemma supp_eq_bot_iff : P.supp = ⊥ ↔ P = ⊥ :=
   ⟨eq_bot, (· ▸ supp_bot)⟩
 
+lemma notMem_of_bot (hP : P.supp = ⊥) (x : α) : x ∉ P :=
+  (eq_bot hP).symm ▸ notMem_bot
+
 /-- A partition has a part iff it is not the empty partition. -/
 @[simp]
 lemma parts_nonempty_iff (P : Partition α) : P.parts.Nonempty ↔ P ≠ ⊥ := by

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Peter Nelson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Peter Nelson
+Authors: Peter Nelson, Hyeokjun Kwon
 -/
 module
 
@@ -11,47 +11,26 @@ public import Mathlib.Order.SupIndep
 /-!
 # Partitions
 
-A `Partition` of an element `a` in a complete lattice is an independent family of nontrivial
-elements whose supremum is `a`.
+A `Partition` of a complete lattice `α` is an independent family of nontrivial elements.
+Its support `Partition.supp` is the supremum of its parts.
 
-An important special case is where `s : Set α`, where a `Partition s` corresponds to a partition
-of the elements of `s` into a family of nonempty sets.
-This is equivalent to a transitive and symmetric binary relation `r : α → α → Prop`
-where `s` is the set of all `x` for which `r x x`.
+An important special case is where `α` is `Set β`; see `Mathlib.Order.Partition.Set`.
 
 Partitions are ordered by refinement: `P ≤ Q` if every part of `P` is less than or equal to a part
 of `Q`.
 
 ## Main declarations
 
-* `Partition s`: For `[CompleteLattice α]` and `s : α`, a `Partition s` is an independent
-  collection of nontrivial elements whose supremum is `s`.
-* `Partition.removeBot`: A constructor for `Partition s` that removes `⊥` from a set of parts.
-* `Partition.instOrderTop`: `Partition s` has a top element, consisting of just `s` if `s ≠ ⊥` or
-  nothing otherwise.
-* `Partition.instSemilatticeInf`: `Partition s` has finite meets `P ⊓ Q` when `α` is a frame,
-  given by the collection of all non-bottom infima `p ⊓ q` of parts of the two partitions.
-* `Partition.Rel`: The partial equivalence relation induced by a partition of a set.
-* `Partition.IsRepFun`: A predicate characterizing a representative function for a partition.
-
-## Representative functions (`IsRepFun`)
-
-`IsRepFun P f` means that `f` sends each element of the support to a representative in its
-`Partition.Rel`-class, agrees on related elements, and is the identity outside the support.
-
-This is useful whenever a construction must pick one distinguished element per part of a partition.
-For example, in graph theory one may partition edges into parallel classes or vertices into
-connected components; a representative function can specify which edge remains when simplifying
-parallel edges, or how supervertices are labeled after contraction. Similar uses arise in matroid
-theory and in the definition of minors.
-
-Tempting alternatives are to use `Classical.choice` or fix a global well-order and take minimal
-representatives. However, these lead to issues with inconsistencies: independent choices need not
-respect relations between different instances (e.g. monotonicity of simplifications with respect
-to subgraph order), a global order can clash with structure already carried by the type, and maps
-between different types need not intertwine two separate canonical choices. Stating hypotheses with
-`IsRepFun` keeps the chosen representatives explicit; existence under suitable conditions can be
-proved separately.
+* `Partition α`: For `[CompleteLattice α]`, a `Partition α` is an independent collection of
+  nontrivial elements.
+* `Partition.supp`: The supremum of the parts of a partition.
+* `Partition.removeBot`: A constructor for `Partition α` that removes `⊥` from a set of parts.
+* `Partition.induce`: The partition obtained by meeting every part with a fixed element.
+* `Partition.bind`: Combine a partition with a family of partitions of its parts.
+* `Partition.instOrderTop`: `Partition α` has a top element, consisting of just `⊤`
+  if `⊤ ≠ ⊥` or nothing otherwise.
+* `Partition.instSemilatticeInf`: `Partition α` has finite meets `P ⊓ Q` when `α` is a frame,
+  given by binding `P` with the induced partitions of `Q` on each part of `P`.
 
 ## TODO
 
@@ -61,44 +40,47 @@ proved separately.
 -/
 
 @[expose] public section
-variable {α : Type*} {s t x y z : α} {S : Set α}
+variable {α : Type*} {s t x y z : α}
 
 open Set
 
-/-- A `Partition` of an element `s` of a `CompleteLattice` is a collection of
-independent nontrivial elements whose supremum is `s`. -/
-structure Partition [CompleteLattice α] (s : α) where
+/-- A `Partition` of a `CompleteLattice` is a collection of independent nontrivial elements.
+The support of the partition is the supremum of its parts. -/
+structure Partition (α : Type*) [CompleteLattice α] where
   /-- The collection of parts -/
   parts : Set α
   /-- The parts are `sSupIndep`. -/
   sSupIndep' : sSupIndep parts
   /-- The bottom element is not a part. -/
   bot_notMem' : ⊥ ∉ parts
-  /-- The supremum of all parts is `s`. -/
-  sSup_eq' : sSup parts = s
 
 namespace Partition
 
 section Basic
 
-variable [CompleteLattice α] {P Q : Partition s}
+variable [CompleteLattice α] {P Q : Partition α}
 
-instance {s : α} : SetLike (Partition s) α where
+/-- The support of a partition is the supremum of its parts. -/
+def supp (P : Partition α) : α := sSup P.parts
+
+instance : SetLike (Partition α) α where
   coe := Partition.parts
   coe_injective p p' h := by cases p; cases p'; simpa using h
 
 /-- See Note [custom simps projection]. -/
-def Simps.coe {s : α} (P : Partition s) : Set α := P
+def Simps.coe (P : Partition α) : Set α := P
 
 initialize_simps_projections Partition (parts → coe, as_prefix coe)
 
 @[simp] lemma coe_parts : P.parts = P := rfl
 
+lemma mem_parts : x ∈ P.parts ↔ x ∈ P := Iff.rfl
+
 @[ext] lemma ext (hP : ∀ x, x ∈ P ↔ x ∈ Q) : P = Q :=
   SetLike.ext hP
 
 @[simp]
-lemma sSupIndep (P : Partition s) : sSupIndep (P : Set α) :=
+lemma sSupIndep (P : Partition α) : sSupIndep (P : Set α) :=
   P.sSupIndep'
 
 lemma disjoint (hx : x ∈ P) (hy : y ∈ P) (hxy : x ≠ y) : Disjoint x y :=
@@ -110,86 +92,71 @@ lemma pairwiseDisjoint : Set.PairwiseDisjoint (P : Set α) id :=
 lemma eq_or_disjoint (hx : x ∈ P) (hy : y ∈ P) : x = y ∨ Disjoint x y :=
   or_iff_not_imp_left.mpr (P.disjoint hx hy)
 
+@[grind →]
 lemma eq_of_not_disjoint (hx : x ∈ P) (hy : y ∈ P) (hxy : ¬ Disjoint x y) : x = y :=
   (P.eq_or_disjoint hx hy).resolve_right hxy
 
 @[simp]
-lemma sSup_eq (P : Partition s) : sSup P = s :=
-  P.sSup_eq'
+lemma sSup_eq (P : Partition α) : sSup P = P.supp :=
+  rfl
+
+@[deprecated (since := "2026-07-28")] alias sSup_eq' := sSup_eq
 
 @[simp]
-lemma iSup_eq (P : Partition s) : ⨆ x ∈ P, x = s := by
+lemma iSup_eq (P : Partition α) : ⨆ x ∈ P, x = P.supp := by
   simp_rw [← P.sSup_eq, sSup_eq_iSup]
   rfl
 
-lemma le_of_mem (P : Partition s) (hx : x ∈ P) : x ≤ s :=
+@[grind →]
+lemma le_of_mem (P : Partition α) (hx : x ∈ P) : x ≤ P.supp :=
   (le_sSup hx).trans_eq P.sSup_eq
 
-lemma parts_nonempty (P : Partition s) (hs : s ≠ ⊥) : (P : Set α).Nonempty :=
+lemma parts_nonempty (P : Partition α) (hs : P.supp ≠ ⊥) : (P : Set α).Nonempty :=
   nonempty_iff_ne_empty.2 fun hP ↦ by simp [← P.sSup_eq, hP, sSup_empty] at hs
 
 @[simp]
-lemma bot_notMem (P : Partition s) : ⊥ ∉ P :=
+lemma bot_notMem (P : Partition α) : ⊥ ∉ P :=
   P.bot_notMem'
 
+@[grind →]
 lemma ne_bot_of_mem (hx : x ∈ P) : x ≠ ⊥ :=
   fun h ↦ P.bot_notMem <| h ▸ hx
 
 lemma bot_lt_of_mem (hx : x ∈ P) : ⊥ < x :=
   bot_lt_iff_ne_bot.2 <| P.ne_bot_of_mem hx
 
-/-- Convert a `Partition s` into a `Partition t` via an equality `s = t`. -/
+lemma supp_ne_bot_of_mem (hx : x ∈ P) : P.supp ≠ ⊥ := by
+  intro hP
+  exact P.ne_bot_of_mem hx <| le_bot_iff.mp <| (P.le_of_mem hx).trans_eq hP
+
+@[deprecated (since := "2026-07-28")] alias ne_bot_of_mem' := supp_ne_bot_of_mem
+
+/-- A constructor for `Partition α` that removes `⊥` from the set of parts. -/
 @[simps]
-protected def copy (P : Partition s) (hst : s = t) : Partition t where
-  parts := P
-  sSupIndep' := P.sSupIndep
-  bot_notMem' := P.bot_notMem
-  sSup_eq' := hst ▸ P.sSup_eq
-
-@[simp]
-lemma mem_copy_iff (hst : s = t) : x ∈ P.copy hst ↔ x ∈ P := Iff.rfl
-
-/-- The natural equivalence between the subtype of parts and the subtype of parts of a copy. -/
-@[simps!]
-def partscopyEquiv (P : Partition s) (hst : s = t) : ↥(P.copy hst) ≃ ↥P :=
-  Equiv.setCongr rfl
-
-/-- A constructor for `Partition s` that removes `⊥` from the set of parts. -/
-@[simps]
-def removeBot (P : Set α) (indep : _root_.sSupIndep P) (hsSup : sSup P = s) : Partition s where
+def removeBot (P : Set α) (indep : _root_.sSupIndep P) : Partition α where
   parts := P \ {⊥}
   sSupIndep' := indep.mono sdiff_subset
   bot_notMem' := by simp
-  sSup_eq' := by simp [← hsSup]
 
 @[simp]
-lemma mem_removeBot (P : Set α) (indep : _root_.sSupIndep P) (hsSup : sSup P = s) :
-    x ∈ removeBot P indep hsSup ↔ x ∈ P ∧ x ≠ ⊥ := Iff.rfl
+lemma mem_removeBot (P : Set α) (indep : _root_.sSupIndep P) :
+    x ∈ removeBot P indep ↔ x ∈ P ∧ x ≠ ⊥ := Iff.rfl
 
 @[simp]
-lemma notMem_of_bot (P : Partition (⊥ : α)) (x : α) : x ∉ P := by
-  rintro hxP
-  obtain rfl := le_bot_iff.mp <| P.le_of_mem hxP
-  exact P.bot_notMem hxP
-
-/-- There is a unique partition of `⊥`. -/
-instance : Unique (Partition (⊥ : α)) where
-  default := removeBot (∅ : Set α) sSupIndep_empty sSup_empty
-  uniq P := by ext; simp
-
-lemma ne_bot_of_mem' (hxP : x ∈ P) : s ≠ ⊥ := by
-  rintro rfl
-  exact P.notMem_of_bot _ hxP
+lemma supp_removeBot (P : Set α) (indep : _root_.sSupIndep P) :
+    (removeBot P indep).supp = sSup P := by
+  change sSup (P \ {⊥}) = sSup P
+  simp
 
 end Basic
 
 section Order
 
-variable [CompleteLattice α] {P Q : Partition s}
+variable [CompleteLattice α] {P Q : Partition α} {a : α}
 
-/-- Partitions on `s` are ordered by refinement: `P ≤ Q` if every part of `P` is contained in a part
+/-- Partitions are ordered by refinement: `P ≤ Q` if every part of `P` is contained in a part
 of `Q`. -/
-instance : PartialOrder (Partition s) where
+instance : PartialOrder (Partition α) where
   le P Q := ∀ ⦃x⦄, x ∈ P → ∃ y ∈ Q, x ≤ y
   lt := _
   le_refl P x hx := ⟨x, hx, le_rfl⟩
@@ -219,339 +186,254 @@ lemma existsUnique_of_mem_le (h : P ≤ Q) (hx : x ∈ P) : ∃! y ∈ Q, x ≤ 
   contrapose this
   exact le_bot_iff.mp (this hxz hxy)
 
-/-- The top partition of `s` is the partition with the single part `s`, or no parts if `s` is the
+/-- If the support of `Q` is contained in a part of `P`, then `Q` refines `P`. -/
+lemma le_of_supp_le_part (ha : a ∈ P) (hQa : Q.supp ≤ a) : Q ≤ P :=
+  fun _ hx ↦ ⟨a, ha, (Q.le_of_mem hx).trans hQa⟩
+
+/-- The empty partition, which is least in the refinement order. -/
+instance : OrderBot (Partition α) where
+  bot := { parts := ∅
+           sSupIndep' := by simp
+           bot_notMem' := by simp }
+  bot_le _ _ hs := hs.elim
+
+@[simp] lemma parts_bot : (⊥ : Partition α).parts = ∅ := rfl
+
+@[simp] lemma notMem_bot : x ∉ (⊥ : Partition α) := notMem_empty _
+
+@[simp] lemma coe_bot : ((⊥ : Partition α) : Set α) = ∅ := rfl
+
+/-- A partition is empty iff it is the bottom partition. -/
+@[simp]
+lemma coe_eq_empty_iff (P : Partition α) : (P : Set α) = ∅ ↔ P = ⊥ :=
+  ⟨fun h ↦ SetLike.coe_injective (h.trans coe_bot.symm), fun h ↦ h ▸ coe_bot⟩
+
+@[simp] lemma supp_bot : (⊥ : Partition α).supp = ⊥ := sSup_empty
+
+/-- A partition with bottom support is the empty partition. -/
+lemma eq_bot (hP : P.supp = ⊥) : P = ⊥ := by
+  ext x
+  have hsup := P.sSup_eq
+  simp only [sSup_eq_bot, SetLike.mem_coe, hP] at hsup
+  simp only [notMem_bot, iff_false]
+  exact fun hx ↦ P.ne_bot_of_mem hx <| hsup x hx
+
+/-- The support of a partition is bottom iff the partition is empty. -/
+@[simp]
+lemma supp_eq_bot_iff : P.supp = ⊥ ↔ P = ⊥ :=
+  ⟨eq_bot, fun h ↦ h ▸ supp_bot⟩
+
+/-- A partition has a part iff it is not the empty partition. -/
+@[simp]
+lemma parts_nonempty_iff (P : Partition α) : P.parts.Nonempty ↔ P ≠ ⊥ := by
+  refine ⟨?_, fun hP ↦ nonempty_iff_ne_empty.mpr <| mt (coe_eq_empty_iff P).mp hP⟩
+  rintro ⟨x, hx⟩ rfl
+  exact notMem_bot hx
+
+/-- On a subsingleton complete lattice there is a unique partition. -/
+instance {α : Type*} [CompleteLattice α] [Subsingleton α] : Unique (Partition α) where
+  default := ⊥
+  uniq P := eq_bot (by
+    simp only [← P.sSup_eq, sSup_eq_bot, SetLike.mem_coe]
+    exact fun a _ ↦ Subsingleton.elim _ _)
+
+/-- The top partition is the partition with the single part `⊤`, or no parts if `⊤` is the
 bottom element. -/
-instance instOrderTop : OrderTop (Partition s) where
-  top := removeBot {s} (sSupIndep_singleton s) sSup_singleton
-  le_top P x hxP := by simp [P.ne_bot_of_mem' hxP, P.le_of_mem hxP]
+instance instOrderTop : OrderTop (Partition α) where
+  top := removeBot {⊤} (sSupIndep_singleton ⊤)
+  le_top P x hxP := by
+    obtain (hs | hs) := eq_or_ne (⊤ : α) ⊥
+    · have : Subsingleton α := subsingleton_of_bot_eq_top hs.symm
+      exact (P.ne_bot_of_mem hxP (Subsingleton.elim _ _)).elim
+    exact ⟨⊤, by simp [hs], by simp⟩
 
-lemma top_def : (⊤ : Partition s) = removeBot {s} (sSupIndep_singleton s) sSup_singleton := rfl
+lemma top_def : (⊤ : Partition α) = removeBot {⊤} (sSupIndep_singleton ⊤) := rfl
 
-@[simp] lemma parts_top (hs : s ≠ ⊥) : ((⊤ : Partition s) : Set α) = {s} := by
-  simpa [top_def]
+@[simp] lemma supp_top : (⊤ : Partition α).supp = ⊤ := by
+  simp [top_def]
 
-@[simp] lemma mem_top_iff {a : α} : a ∈ (⊤ : Partition s) ↔ a = s ∧ a ≠ ⊥ := by
+@[simp] lemma parts_top [Nontrivial α] : ((⊤ : Partition α) : Set α) = {⊤} := by
+  change (removeBot {(⊤ : α)} _).parts = {⊤}
+  simp
+
+@[simp] lemma mem_top_iff {a : α} : a ∈ (⊤ : Partition α) ↔ a = ⊤ ∧ a ≠ ⊥ := by
   rw [top_def, mem_removeBot, mem_singleton_iff]
 
-lemma parts_top_subset : ((⊤ : Partition s) : Set α) ⊆ {s} := by simp
+lemma parts_top_subset : ((⊤ : Partition α) : Set α) ⊆ {⊤} :=
+  fun _ ha ↦ (mem_top_iff.mp ha).1 ▸ rfl
 
-/-- When `α` is a frame, the meet `P ⊓ Q` of two partitions is the partition consisting of all
-non-bottom meets `p ⊓ q` for `p ∈ P` and `q ∈ Q`.
+/-- Refinement of partitions implies inequality of supports. -/
+lemma supp_le_of_le {P Q : Partition α} (h : P ≤ Q) : P.supp ≤ Q.supp :=
+  sSup_le_sSup_of_isCofinalFor h
 
-Note that while finite meets of partitions can be constructed in this way, arbitrary meets generally
-do not exist: for example when `α` is the frame of open subsets of the Cantor space, `Partition α`
-has no bottom element. -/
-instance instSemilatticeInf {α : Type*} [Order.Frame α] (s : α) : SemilatticeInf (Partition s) where
-  inf P Q := removeBot {a | ∃ p ∈ P, ∃ q ∈ Q, a = p ⊓ q} (by
-      rw [sSupIndep_iff_pairwiseDisjoint]
-      intro a ha a' ha' h
-      grind [Partition.eq_or_disjoint, Disjoint.inf_left, Disjoint.inf_left'])
-    (by
-      suffices sSup {a | ∃ p ∈ P, ∃ q ∈ Q, a = p ⊓ q} = sSup P ⊓ sSup Q by simpa
-      rw [sSup_inf_sSup]
-      refine le_antisymm ?_ ?_
-      · exact sSup_le fun a ⟨p, hp, q, hq, ha⟩ ↦ le_iSup₂_of_le (p, q) ⟨hp, hq⟩ <| by grind
-      · exact iSup₂_le fun (p, q) ⟨hp, hq⟩ ↦ le_sSup_of_le ⟨p, hp, q, hq, rfl⟩ (by simp))
-  inf_le_left P Q a ha := by
-    obtain ⟨⟨p, hp, q, hq, rfl⟩, h⟩ := ha
-    grind [inf_le_left]
-  inf_le_right P Q a ha := by
-    obtain ⟨⟨p, hp, q, hq, rfl⟩, h⟩ := ha
-    grind [inf_le_right]
-  le_inf P Q R hQ hR a ha := by
-    have ⟨q, hq⟩ := hQ ha
-    have ⟨r, hr⟩ := hR ha
-    refine ⟨q ⊓ r, ⟨?_, ?_⟩, ?_⟩ <;> grind [le_inf_iff, P.ne_bot_of_mem ha]
+lemma supp_mono : Monotone (Partition.supp (α := α)) := fun _ _ ↦ supp_le_of_le
 
-@[simp]
-lemma mem_inf_iff {α : Type*} [Order.Frame α] {s a : α} {P Q : Partition s} :
-    a ∈ P ⊓ Q ↔ a ≠ ⊥ ∧ ∃ p ∈ P, ∃ q ∈ Q, a = p ⊓ q :=
-  and_comm
+/-- On a nontrivial complete lattice there are at least two partitions. -/
+instance [Nontrivial α] : Nontrivial (Partition α) :=
+  ⟨⊥, ⊤, mt (congrArg (·.parts)) <| by simp [parts_top]⟩
 
 end Order
 
-variable {S : Set (Set α)} {u s t : Set α} {a b c : α} {P Q : Partition u}
+section Induce
 
-section Set
+variable [CompleteLattice α] {P Q : Partition α} {a b : α}
 
-@[simp] protected lemma sUnion_eq (P : Partition s) : ⋃₀ P = s := P.sSup_eq
+/-- Meet every part of `P` with `a`, discarding bottom. -/
+@[simps!]
+protected def induce (P : Partition α) (a : α) : Partition α :=
+  removeBot ((a ⊓ ·) '' P.parts) <|
+    P.sSupIndep'.image_of_le_self fun _ _ ↦ inf_le_right
 
-lemma nonempty_of_mem (ht : t ∈ P) : t.Nonempty := notMem_singleton_empty.1 <| P.ne_bot_of_mem ht
+/-- Membership in an induced partition is equivalent to being a nontrivial meet of `a` with a
+part of `P`. -/
+@[simp]
+lemma mem_induce_iff : x ∈ P.induce a ↔ x ≠ ⊥ ∧ ∃ t ∈ P, a ⊓ t = x := by
+  simp [Partition.induce, and_comm]
 
-lemma empty_notMem : ∅ ∉ P := P.bot_notMem
+/-- The nontrivial meet of an element with a part belongs to the induced partition. -/
+lemma inf_mem_induce (h : x ∈ P) (hne : a ⊓ x ≠ ⊥) : a ⊓ x ∈ P.induce a :=
+  mem_induce_iff.mpr ⟨hne, x, h, rfl⟩
 
-lemma subset_of_mem (ht : t ∈ P) : t ⊆ u := P.le_of_mem ht
+/-- An induced partition always refines the original partition. -/
+@[simp]
+lemma induce_le : P.induce a ≤ P := by
+  intro T hT
+  obtain ⟨hne, t, htP, rfl⟩ := (by simpa only [mem_induce_iff] using hT); clear hT
+  exact ⟨t, htP, inf_le_right⟩
 
-lemma mem_iff_exists : x ∈ u ↔ ∃ t ∈ P, x ∈ t := by
-  refine ⟨fun hx ↦ ?_, fun ⟨t, htP, hxt⟩ ↦ subset_of_mem htP hxt⟩
-  rwa [← P.sUnion_eq, mem_sUnion] at hx
+/-- Inducing preserves refinement in the partition being induced. -/
+lemma induce_le_induce_left (hPQ : P ≤ Q) : P.induce a ≤ Q.induce a := by
+  intro t ht
+  simp_rw [mem_induce_iff] at ht ⊢
+  obtain ⟨hne, t', ht'Q, rfl⟩ := ht
+  obtain ⟨s, hsQ, ht's⟩ := hPQ ht'Q
+  have hsu := inf_le_inf_left a ht's
+  use a ⊓ s, ?_, hsu
+  use ne_bot_of_le_ne_bot hne hsu, s
 
-lemma eq_of_mem_inter (ht : t ∈ P) (hs : s ∈ P) (hx : x ∈ t ∩ s) : t = s :=
-  P.pairwiseDisjoint.elim ht hs fun (hdj : Disjoint t s) ↦ by simp [hdj.inter_eq] at hx
+end Induce
 
-lemma eq_of_mem_of_mem (ht : t ∈ P) (hus : s ∈ P) (hxt : x ∈ t) (hxs : x ∈ s) : t = s :=
-  eq_of_mem_inter ht hus ⟨hxt, hxs⟩
+section InduceFrame
 
-lemma mem_iff_unique : x ∈ u ↔ ∃! t, t ∈ P ∧ x ∈ t := by
-  refine ⟨fun hx ↦ ?_, fun ⟨_, ⟨htP, hxt⟩, _⟩ ↦ subset_of_mem htP hxt⟩
-  rw [← P.sUnion_eq, mem_sUnion] at hx
-  obtain ⟨t, ht, hxt⟩ := hx
-  exact ⟨t, ⟨ht, hxt⟩, fun s ⟨hsP, hxs⟩ ↦ P.eq_of_mem_of_mem hsP ht hxs hxt⟩
+variable [Order.Frame α] {P : Partition α} {a : α}
 
-lemma subset_sUnion_and_mem_iff_mem (hSP : S ⊆ P) : t ⊆ ⋃₀ S ∧ t ∈ P ↔ t ∈ S := by
-  refine ⟨fun ⟨htsu, htP⟩ ↦ ?_, fun htS ↦ ⟨subset_sUnion_of_mem htS, hSP htS⟩⟩
-  obtain ⟨x, hxt⟩ := nonempty_of_mem htP
-  obtain ⟨s, hsS, hxs⟩ := htsu hxt
-  exact eq_of_mem_of_mem htP (hSP hsS) hxt hxs ▸ hsS
+/-- In a frame, the support of an induced partition is the meet of the inducing element with the
+original support. -/
+@[simp]
+lemma supp_induce (P : Partition α) (a : α) : (P.induce a).supp = a ⊓ P.supp := by
+  change (removeBot ((a ⊓ ·) '' P.parts) _).supp = a ⊓ P.supp
+  rw [supp_removeBot, sSup_image, supp, inf_sSup_eq]
 
-lemma subset_sUnion_iff_mem (ht : t ∈ P) (hSP : S ⊆ P.parts) : t ⊆ ⋃₀ S ↔ t ∈ S := by
-  rw [← subset_sUnion_and_mem_iff_mem hSP]
-  simp [ht]
+end InduceFrame
 
-/-- Noncomputably choose a representative from an equivalence class. -/
-noncomputable def rep (P : Partition u) (ht : t ∈ P) : α := (P.nonempty_of_mem ht).some
+section Bind
 
-/-- The representative of a part belongs to that part. -/
-@[simp] lemma rep_mem (ht : t ∈ P) : P.rep ht ∈ t := (P.nonempty_of_mem ht).some_mem
+variable [Order.Frame α] {P Q : Partition α} {a : α} {Qs : ∀ a ∈ P, Partition α}
 
-/-- The representative of a part belongs to the underlying set. -/
-@[simp] lemma rep_mem_supp (ht : t ∈ P) : P.rep ht ∈ u := P.subset_of_mem ht <| rep_mem ht
+/-- Combine a partition with a family of partitions of (subparts of) its parts. -/
+@[simps] protected def bind (P : Partition α) (Qs : ∀ a ∈ P, Partition α)
+    (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) : Partition α where
+  parts := ⋃ a : P, (Qs a a.prop).parts
+  sSupIndep' := by
+    intro b hb
+    simp only [mem_iUnion, Subtype.exists] at hb
+    obtain ⟨a, haP, hba : b ∈ Qs a haP⟩ := hb
+    obtain hasupp := hQs a haP
+    have hdj1 := (Qs a haP).sSupIndep hba
+    have hdj2 := (P.sSupIndep haP).mono_left <| ((Qs a haP).le_of_mem hba).trans hasupp
+    refine (hdj1.sup_right hdj2).mono_right ?_
+    simp only [mem_iUnion, Subtype.exists, sSup_le_iff, mem_sdiff,
+      mem_singleton_iff, and_imp, forall_exists_index]
+    rintro t' x hx (ht' : t' ∈ Qs x hx) hne
+    obtain hxsupp := hQs x hx
+    obtain (rfl | hne) := eq_or_ne x a
+    · exact (le_sSup_of_le (show t' ∈ _ \ {b} from ⟨ht', hne⟩) rfl.le).trans le_sup_left
+    exact le_trans (le_sSup_of_le (mem_sdiff_of_mem hx hne) <|
+      (Qs x hx).le_of_mem ht' |>.trans hxsupp) le_sup_right
+  bot_notMem' := by
+    simp only [mem_iUnion, Subtype.exists, not_exists]
+    exact fun x hx ↦ (Qs x hx).bot_notMem
 
-end Set
+/-- Membership in a bind is equivalent to membership in one of the constituent partitions. -/
+@[simp] lemma mem_bind_iff (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) :
+    a ∈ P.bind Qs hQs ↔ ∃ (b : α) (hb : b ∈ P), a ∈ Qs b hb := by
+  change _ ∈ ⋃ _, _ ↔ _; simp
 
-/-! ### Induced relation -/
+/-- A bind refines `Q` iff every constituent partition refines `Q`. -/
+@[simp]
+lemma bind_le_iff (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) :
+    P.bind Qs hQs ≤ Q ↔ ∀ a, (h : a ∈ P) → (Qs a h) ≤ Q := by
+  simp_rw [le_def, mem_bind_iff hQs, forall_exists_index]
+  tauto
 
-section Rel
+/-- A bind always refines the original partition. -/
+lemma bind_le (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) : P.bind Qs hQs ≤ P := by
+  rw [bind_le_iff hQs]
+  exact fun a haP ↦ le_of_supp_le_part haP (hQs a haP)
 
-/-- Every partition of `s : Set α` induces a transitive, symmetric binary relation on `α`
-  whose equivalence classes are the parts of `P`. The relation is irreflexive outside `s`. -/
-def Rel (P : Partition s) (a b : α) : Prop :=
-  ∃ t ∈ P, a ∈ t ∧ b ∈ t
+/-- `Q` refines a bind of `P` iff `Q` refines `P` and, on each part of `P`, the induced partition
+of `Q` refines the corresponding constituent. -/
+@[simp]
+lemma le_bind_iff (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) :
+    Q ≤ P.bind Qs hQs ↔ Q ≤ P ∧ ∀ a, (h : a ∈ P) → Q.induce a ≤ Qs a h := by
+  refine ⟨fun h ↦ ⟨h.trans (bind_le hQs), fun a haP b hbQsa ↦ ?_⟩,
+    fun ⟨hQP, h⟩ a haQ ↦ ?_⟩
+  · obtain ⟨hcnea, c, hcQ, rfl⟩ := (by simpa using hbQsa); clear hbQsa
+    obtain ⟨d, hd, hcd⟩ := h hcQ
+    obtain ⟨e, heP, hdQse⟩ := (by simpa using hd); clear hd
+    have hne : ¬Disjoint a e := by
+      contrapose! hcnea
+      have hce := hcd.trans <| (le_of_mem _ hdQse).trans <| hQs e heP
+      exact disjoint_iff.mp (hcnea.mono_right hce)
+    obtain rfl := P.eq_of_not_disjoint haP heP hne
+    exact ⟨d, hdQse, inf_le_of_right_le hcd⟩
+  obtain ⟨p, hpP, hap⟩ := hQP haQ
+  obtain ⟨q, hqQsp, haq⟩ := h p hpP <| inf_mem_induce haQ <| by
+    simp [hap, Q.ne_bot_of_mem haQ]
+  simp only [hap, inf_of_le_right] at haq
+  exact ⟨q, (mem_bind_iff hQs).mpr ⟨p, hpP, hqQsp⟩, haq⟩
 
-lemma rel_le_iff_le : P.Rel ≤ Q.Rel ↔ P ≤ Q := by
-  refine ⟨fun h S hS ↦ ?_, fun h a b ⟨t, ht, ha, hb⟩ ↦ ?_⟩
-  · obtain ⟨x, hxS⟩ := nonempty_of_mem hS
-    obtain ⟨T, hT, hxT, -⟩ := h x x ⟨S, hS, hxS, hxS⟩
-    refine ⟨T, hT, fun a haS ↦ ?_⟩
-    obtain ⟨T', hT', haT', hxT'⟩ := h a x ⟨S, hS, haS, hxS⟩
-    exact eq_of_mem_of_mem hT hT' hxT hxT' ▸ haT'
-  obtain ⟨t', ht', htt'⟩ := h ht
-  use t', ht', htt' ha, htt' hb
+lemma supp_bind (P : Partition α) (Qs : ∀ a ∈ P, Partition α)
+    (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) :
+    (P.bind Qs hQs).supp = ⨆ a : P, (Qs a a.prop).supp := by
+  rw [← sSup_eq, coe_bind, sSup_iUnion]; rfl
 
-lemma Rel.exists (h : P.Rel x y) : ∃ t ∈ P, x ∈ t ∧ y ∈ t := h
+end Bind
 
-lemma Rel.forall (h : P.Rel x y) (ht : t ∈ P) : x ∈ t ↔ y ∈ t := by
-  obtain ⟨t, ht', hx, hy⟩ := h
-  exact ⟨fun h ↦ by rwa [P.eq_of_mem_of_mem ht ht' h hx],
-    fun h ↦ by rwa [P.eq_of_mem_of_mem ht ht' h hy]⟩
+section Inf
+
+variable [Order.Frame α] {P Q R : Partition α}
+
+/-- The meet of two partitions, obtained by binding `P` with the partitions induced by `Q`
+on each part of `P`. -/
+def inf (P Q : Partition α) : Partition α :=
+  P.bind (fun a _ ↦ Q.induce a) (by simp)
+
+/-- When `α` is a frame, partitions form a semilattice under refinement, with meet given by
+`Partition.inf`. -/
+instance instSemilatticeInf : SemilatticeInf (Partition α) where
+  inf := inf
+  inf_le_left P Q := bind_le (by simp)
+  inf_le_right P Q := by
+    rw [inf, bind_le_iff (by simp)]
+    exact fun _ _ ↦ induce_le
+  le_inf P Q R hPQ hPR := by
+    rw [inf, le_bind_iff (by simp)]
+    exact ⟨hPQ, fun a _ ↦ induce_le_induce_left hPR⟩
+
+/-- Membership in a meet is equivalent to being a nontrivial meet of parts from each
+partition. -/
+@[simp]
+lemma mem_inf_iff {a : α} :
+    a ∈ P ⊓ Q ↔ (∃ p ∈ P, ∃ q ∈ Q, p ⊓ q = a) ∧ a ≠ ⊥ := by
+  change a ∈ (P.bind _ _).parts ↔ _
+  simp [and_comm, eq_comm]
 
 @[simp]
-lemma rel_rfl_iff : P.Rel x x ↔ x ∈ u := by
-  refine ⟨fun ⟨t, ht, hxP, _⟩ ↦ subset_of_mem ht hxP, fun hx ↦ ?_⟩
-  obtain ⟨t, ⟨ht, hxt⟩, -⟩ := P.mem_iff_unique.mp hx
-  exact ⟨t, ht, hxt, hxt⟩
+lemma supp_inf (P Q : Partition α) : (P ⊓ Q).supp = P.supp ⊓ Q.supp := by
+  rw [show P ⊓ Q = P.bind (fun a _ ↦ Q.induce a) (by simp) from rfl, supp_bind]
+  simp only [supp_induce, iSup_subtype', ← iSup_inf_eq, ← P.iSup_eq]
 
-instance (P : Partition u) : Std.Symm P.Rel where
-  symm _ _ := fun ⟨t, ht, ha, hb⟩ ↦ ⟨t, ht, hb, ha⟩
+end Inf
 
-instance (P : Partition u) : IsTrans α P.Rel where
-  trans _ _ _ := fun ⟨t, ht, ha, hb⟩ ⟨t', ht', hb', hc⟩ ↦
-    ⟨t, ht, ha, by rwa [eq_of_mem_of_mem ht ht' hb hb']⟩
-
-@[symm] lemma Rel.symm (h : P.Rel x y) : P.Rel y x := symm_of P.Rel h
-
-lemma rel_comm : P.Rel x y ↔ P.Rel y x := ⟨Rel.symm, Rel.symm⟩
-
-lemma Rel.trans (hxy : P.Rel x y) (hyz : P.Rel y z) : P.Rel x z := trans_of P.Rel hxy hyz
-
-lemma Rel.left_mem (h : P.Rel x y) : x ∈ u := by
-  obtain ⟨t, htP, hxt, -⟩ := h
-  exact subset_of_mem htP hxt
-
-lemma Rel.right_mem (h : P.Rel x y) : y ∈ u := h.symm.left_mem
-
-/-- Any element of a part is related to the representative of that part. -/
-lemma rep_rel (ht : t ∈ P) (hx : x ∈ t) : P.Rel x (P.rep ht) := ⟨t, ht, hx, P.rep_mem ht⟩
-
-end Rel
-
-section partOf
-
-/-- The part of a partition containing a given element. If the element is not in the
-underlying set, this is empty. -/
-def partOf (P : Partition u) (a : α) : Set α := {b | P.Rel a b}
-
-lemma partOf_subset : P.partOf x ⊆ u := fun _ ⟨_, ht, _, hyt⟩ ↦ subset_of_mem ht hyt
-
-@[simp] lemma mem_partOf_iff : x ∈ P.partOf y ↔ P.Rel y x := Iff.rfl
-
-lemma eq_partOf_of_mem (ht : t ∈ P) (hxt : x ∈ t) : t = P.partOf x := by
-  ext y
-  exact ⟨(⟨t, ht, hxt, ·⟩), fun ⟨s, hsP, hxs, hys⟩ ↦ (P.eq_of_mem_of_mem ht hsP hxt hxs) ▸ hys⟩
-
-lemma mem_iff_mem_partOf_mem : x ∈ u ↔ x ∈ P.partOf x ∧ P.partOf x ∈ P := by
-  refine ⟨fun hx ↦ ?_, fun ⟨hx, hP⟩ ↦ subset_of_mem hP hx⟩
-  obtain ⟨t, htP, hxt⟩ := P.mem_iff_exists.mp hx
-  exact P.eq_partOf_of_mem htP hxt ▸ ⟨hxt, htP⟩
-
-lemma mem_partOf (hxu : x ∈ u) : x ∈ P.partOf x := (P.mem_iff_mem_partOf_mem.mp hxu).1
-
-lemma partOf_mem (hxu : x ∈ u) : P.partOf x ∈ P := (P.mem_iff_mem_partOf_mem.mp hxu).2
-
-@[simp]
-lemma partOf_rep (hs : s ∈ P) : P.partOf (P.rep hs) = s :=
-  eq_partOf_of_mem hs (rep_mem hs) |>.symm
-
-lemma mem_iff_exists_partOf : s ∈ P ↔ ∃ x ∈ u, partOf P x = s :=
-  ⟨fun hs ↦ ⟨P.rep hs, rep_mem_supp hs, partOf_rep hs⟩, fun ⟨_, hxu, h⟩ ↦ h ▸ partOf_mem hxu⟩
-
-lemma partOf_nonempty_iff : (P.partOf x).Nonempty ↔ x ∈ u := by
-  refine ⟨fun ⟨y, hy⟩ ↦ hy.left_mem, fun h ↦ ?_⟩
-  simpa [nonempty_iff_ne_empty] using P.ne_bot_of_mem (partOf_mem h)
-
-@[simp]
-lemma partOf_eq_empty_iff : P.partOf x = ∅ ↔ x ∉ u := by
-  rw [← partOf_nonempty_iff, not_nonempty_iff_eq_empty]
-
-lemma rel_iff_partOf_eq_partOf_of_mem (P : Partition u) (hx : x ∈ u) (hy : y ∈ u) :
-    P.Rel x y ↔ P.partOf x = P.partOf y := by
-  refine ⟨fun ⟨t, htP, hxt, hyt⟩ ↦ eq_partOf_of_mem (P.partOf_mem hx) ?_,
-    fun h ↦ ⟨P.partOf x, P.partOf_mem hx, P.mem_partOf hx, h ▸ mem_partOf hy⟩⟩
-  rwa [← eq_partOf_of_mem htP hxt]
-
-lemma rel_iff_partOf_eq_partOf (P : Partition u) :
-    P.Rel x y ↔ ∃ (_ : x ∈ u) (_ : y ∈ u), P.partOf x = P.partOf y := by
-  grind [rel_iff_partOf_eq_partOf_of_mem, Rel.left_mem, Rel.right_mem]
-
-end partOf
-
-/-! ### Representative functions
-
-See the module docstring for motivation (graph simplification, minors, and why we use an explicit
-`IsRepFun` hypothesis rather than a global choice of representatives).
--/
-
-section IsRepFun
-
-/-- A predicate characterizing when a function `f : α → α` is a representative function for a
-partition `P`. A representative function maps each element to a canonical representative in its
-equivalence class, is the identity outside the support, and maps related elements to the same
-representative. -/
-structure IsRepFun {u : Set α} (P : Partition u) (f : α → α) : Prop where
-  /-- The function is the identity outside the support. -/
-  apply_of_notMem : ∀ ⦃a⦄, a ∉ u → f a = a
-  /-- The function maps each element in the support to a related element. -/
-  rel_apply : ∀ ⦃a⦄, a ∈ u → P.Rel a (f a)
-  /-- The function maps related elements to the same representative. -/
-  apply_eq_apply : ∀ ⦃a b⦄, P.Rel a b → f a = f b
-
-namespace IsRepFun
-
-variable {u : Set α} {P : Partition u} {f g : α → α} {a b c : α}
-
-lemma apply_mem (hf : IsRepFun P f) (ha : a ∈ u) : f a ∈ u := (hf.rel_apply ha).right_mem
-
-lemma image_subset (hf : IsRepFun P f) (hs : u ⊆ s) : f '' s ⊆ s := by
-  rintro _ ⟨a, haS, rfl⟩
-  by_cases ha : a ∈ u
-  · exact hs <| hf.apply_mem ha
-  exact (hf.apply_of_notMem ha).symm ▸ haS
-
-lemma mapsTo (hf : IsRepFun P f) (hs : u ⊆ s) : Set.MapsTo f s s :=
-  fun x h ↦ hf.image_subset hs ⟨x, h, rfl⟩
-
-lemma mapsTo_of_disjoint (hf : IsRepFun P f) (hs : Disjoint u s) : Set.MapsTo f s s :=
-  fun _ h ↦ (hf.apply_of_notMem <| hs.notMem_of_mem_right h).symm ▸ h
-
-lemma apply_mem_iff (hf : IsRepFun P f) (hs : u ⊆ s) : f a ∈ s ↔ a ∈ s :=
-  hf.mapsTo hs |>.mem_iff <| mapsTo_of_disjoint hf hs.disjoint_compl_right
-
-lemma apply_eq_apply_iff_rel (hf : IsRepFun P f) (ha : a ∈ u) : f a = f b ↔ P.Rel a b := by
-  refine ⟨fun hab ↦ (hf.rel_apply ha).trans ?_, (hf.apply_eq_apply ·)⟩
-  rw [hab, P.rel_comm]
-  refine hf.rel_apply <| by_contra fun hb ↦ ?_
-  rw [hf.apply_of_notMem hb] at hab
-  exact hab ▸ hb <| hf.apply_mem ha
-
-lemma apply_eq_apply_iff (hf : IsRepFun P f) : f a = f b ↔ a = b ∨ P.Rel a b := by
-  simp only [or_iff_not_imp_left, ← ne_eq]
-  refine ⟨fun hab hne ↦ ?_, fun h ↦ ?_⟩
-  · obtain (ha | ha) := em (a ∈ u)
-    · exact hf.apply_eq_apply_iff_rel ha |>.mp hab
-    obtain (hb | hb) := em (b ∈ u)
-    · exact (hf.apply_eq_apply_iff_rel hb |>.mp hab.symm).symm
-    rw [hf.apply_of_notMem ha, hf.apply_of_notMem hb] at hab
-    contradiction
-  obtain rfl | hne := eq_or_ne a b
-  · rfl
-  exact hf.apply_eq_apply (h hne)
-
-lemma forall_apply_eq_apply_iff (hf : IsRepFun P f) (a) :
-    (∀ (x : α), f a = f x ↔ a = x) ∨ (∀ (x : α), f a = f x ↔ P.Rel a x) := by
-  refine (em (a ∈ u)).elim (fun ha ↦ Or.inr fun b ↦ ?_) (fun ha ↦ Or.inl fun b ↦ ?_)
-  · rw [hf.apply_eq_apply_iff_rel ha]
-  rw [hf.apply_of_notMem ha]
-  constructor <;> rintro rfl
-  · exact hf.apply_of_notMem <| hf.apply_mem_iff le_rfl |>.not.mp ha
-  exact hf.apply_of_notMem ha |>.symm
-
-lemma apply_eq_apply_iff' (hf : IsRepFun P f) :
-    f a = f b ↔ (a = b ∧ ∀ c, f a = f c ↔ a = c) ∨ P.Rel a b := by
-  obtain h1 | h2 := hf.forall_apply_eq_apply_iff a
-  · refine ⟨by grind, ?_⟩
-    rintro (h | h)
-    · exact congrArg _ h.1
-    exact hf.apply_eq_apply h
-  grind
-
-lemma idem (hf : IsRepFun P f) : f (f a) = f a := by
-  obtain (ha | ha) := em (a ∈ u)
-  · rw [eq_comm, hf.apply_eq_apply_iff_rel ha]
-    exact hf.rel_apply ha
-  simp_rw [hf.apply_of_notMem ha]
-
-theorem apply_apply (hf : IsRepFun P f) (hg : IsRepFun P g) (x : α) : f (g x) = f x := by
-  obtain (hx | hx) := em (x ∈ u)
-  · exact hf.apply_eq_apply (hg.rel_apply hx).symm
-  rw [hg.apply_of_notMem hx, hf.apply_of_notMem hx]
-
-/-- Any partially defined representative function extends to a complete one. -/
-lemma exists_extend_partial (P : Partition u) (f₀ : t → α)
-    (h_notMem : ∀ x : t, x.1 ∉ u → f₀ x = x) (h_mem : ∀ x : t, x.1 ∈ u → P.Rel x (f₀ x))
-    (h_eq : ∀ x y : t, P.Rel x y → f₀ x = f₀ y) : ∃ f, IsRepFun P f ∧ ∀ x : t, f x = f₀ x := by
-  classical
-  set f : α → α := fun a ↦ if ha : a ∈ u then
-    (if hb : ∃ b : t, P.Rel a b then f₀ hb.choose else P.rep (P.partOf_mem ha)) else a with hfdef
-  refine ⟨f, ⟨fun a ha ↦ by simp [hfdef, ha], fun a ha ↦ ?_, fun a b hab ↦ ?_⟩, fun a ↦ ?_⟩
-  · simp only [hfdef, ha, ↓reduceDIte]
-    split_ifs with h
-    · exact h.choose_spec.trans <| h_mem h.choose h.choose_spec.right_mem
-    push Not at h
-    exact P.rep_rel (P.partOf_mem ha) (P.mem_partOf ha)
-  · simp_rw [hfdef, dif_pos hab.left_mem, dif_pos hab.right_mem]
-    split_ifs with h₁ h₂ h₂
-    · exact h_eq _ _ <| (hab.symm.trans h₁.choose_spec).symm.trans h₂.choose_spec
-    · exact h₂ ⟨_, hab.symm.trans h₁.choose_spec⟩ |>.elim
-    · exact h₁ ⟨_, hab.trans h₂.choose_spec⟩ |>.elim
-    congr 1
-    rwa [← rel_iff_partOf_eq_partOf_of_mem _ hab.left_mem hab.right_mem]
-  obtain (ha | ha) := em (a.1 ∈ u) |>.symm
-  · simp [hfdef, ha, h_notMem _ ha]
-  simp only [hfdef, ha, ↓reduceDIte]
-  split_ifs with h
-  · exact h_eq _ _ h.choose_spec |>.symm
-  exact h ⟨a, rel_rfl_iff.mpr ha⟩ |>.elim
-
-/-- For any set `t` containing no two distinct related elements, there is a representative function
-equal to the identity on `t`. -/
-lemma exists_extend_partial' (P : Partition u)
-    (h : ∀ ⦃x y⦄, x ∈ t → y ∈ t → P.Rel x y → x = y) : ∃ f, IsRepFun P f ∧ EqOn f id t := by
-  simpa using! exists_extend_partial P (fun x : t ↦ x) (by simp) (by simp) (fun x y ↦ h x.2 y.2)
-
-/-- Every partition has a representative function. -/
-lemma nonempty (P : Partition u) : ∃ f, IsRepFun P f := by
-  obtain ⟨f, hf, -⟩ := exists_extend_partial' P (t := ∅) (by simp)
-  exact ⟨f, hf⟩
-
-end IsRepFun
-end Partition.IsRepFun
+end Partition

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -65,7 +65,10 @@ def supp (P : Partition α) : α := sSup P.parts
 
 instance : SetLike (Partition α) α where
   coe := Partition.parts
-  coe_injective p p' h := by cases p; cases p'; simpa using h
+  coe_injective p p' h := by
+    cases p
+    cases p'
+    simpa using h
 
 /-- See Note [custom simps projection]. -/
 def Simps.coe (P : Partition α) : Set α := P
@@ -125,9 +128,8 @@ lemma ne_bot_of_mem (hx : x ∈ P) : x ≠ ⊥ :=
 lemma bot_lt_of_mem (hx : x ∈ P) : ⊥ < x :=
   bot_lt_iff_ne_bot.2 <| P.ne_bot_of_mem hx
 
-lemma supp_ne_bot_of_mem (hx : x ∈ P) : P.supp ≠ ⊥ := by
-  intro hP
-  exact P.ne_bot_of_mem hx <| le_bot_iff.mp <| (P.le_of_mem hx).trans_eq hP
+lemma supp_ne_bot_of_mem (hx : x ∈ P) : P.supp ≠ ⊥ :=
+  fun hP ↦ P.ne_bot_of_mem hx <| le_bot_iff.mp <| (P.le_of_mem hx).trans_eq hP
 
 @[deprecated (since := "2026-07-28")] alias ne_bot_of_mem' := supp_ne_bot_of_mem
 
@@ -160,20 +162,8 @@ instance : PartialOrder (Partition α) where
   le P Q := ∀ ⦃x⦄, x ∈ P → ∃ y ∈ Q, x ≤ y
   lt := _
   le_refl P x hx := ⟨x, hx, le_rfl⟩
-  le_trans P Q R hPQ hQR x hxP := by
-    obtain ⟨y, hy, hxy⟩ := hPQ hxP
-    obtain ⟨z, hz, hyz⟩ := hQR hy
-    exact ⟨z, hz, hxy.trans hyz⟩
-  le_antisymm P Q hp hq := by
-    refine Partition.ext fun x ↦ ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-    · obtain ⟨y, hy, hxy⟩ := hp h
-      obtain ⟨x', hx', hyx'⟩ := hq hy
-      obtain rfl := P.pairwiseDisjoint.eq_of_le h hx' (P.ne_bot_of_mem h) (hxy.trans hyx')
-      rwa [hxy.antisymm hyx']
-    obtain ⟨y, hy, hxy⟩ := hq h
-    obtain ⟨x', hx', hyx'⟩ := hp hy
-    obtain rfl := Q.pairwiseDisjoint.eq_of_le h hx' (Q.ne_bot_of_mem h) (hxy.trans hyx')
-    rwa [hxy.antisymm hyx']
+  le_trans P Q R hPQ hQR x hxP := by grind
+  le_antisymm P Q hp hq := Partition.ext fun x ↦ by grind
 
 lemma le_def : P ≤ Q ↔ ∀ x ∈ P, ∃ y ∈ Q, x ≤ y := .rfl
 
@@ -181,10 +171,7 @@ lemma exists_le_of_mem_le (h : P ≤ Q) (hx : x ∈ P) : ∃ y ∈ Q, x ≤ y :=
 
 lemma existsUnique_of_mem_le (h : P ≤ Q) (hx : x ∈ P) : ∃! y ∈ Q, x ≤ y := by
   obtain ⟨y, hy, hxy⟩ := h hx
-  refine ⟨y, ⟨hy, hxy⟩, fun z ⟨hz, hxz⟩ ↦ Q.eq_of_not_disjoint hz hy ?_⟩
-  have := P.ne_bot_of_mem hx
-  contrapose this
-  exact le_bot_iff.mp (this hxz hxy)
+  exact ⟨y, ⟨hy, hxy⟩, fun z ⟨hz, hxz⟩ ↦ Q.eq_of_not_disjoint hz hy (by grind)⟩
 
 /-- If the support of `Q` is contained in a part of `P`, then `Q` refines `P`. -/
 lemma le_of_supp_le_part (ha : a ∈ P) (hQa : Q.supp ≤ a) : Q ≤ P :=
@@ -221,7 +208,7 @@ lemma eq_bot (hP : P.supp = ⊥) : P = ⊥ := by
 /-- The support of a partition is bottom iff the partition is empty. -/
 @[simp]
 lemma supp_eq_bot_iff : P.supp = ⊥ ↔ P = ⊥ :=
-  ⟨eq_bot, fun h ↦ h ▸ supp_bot⟩
+  ⟨eq_bot, (· ▸ supp_bot)⟩
 
 /-- A partition has a part iff it is not the empty partition. -/
 @[simp]
@@ -263,10 +250,10 @@ lemma parts_top_subset : ((⊤ : Partition α) : Set α) ⊆ {⊤} :=
   fun _ ha ↦ (mem_top_iff.mp ha).1 ▸ rfl
 
 /-- Refinement of partitions implies inequality of supports. -/
-lemma supp_le_of_le {P Q : Partition α} (h : P ≤ Q) : P.supp ≤ Q.supp :=
+lemma supp_mono {P Q : Partition α} (h : P ≤ Q) : P.supp ≤ Q.supp :=
   sSup_le_sSup_of_isCofinalFor h
 
-lemma supp_mono : Monotone (Partition.supp (α := α)) := fun _ _ ↦ supp_le_of_le
+lemma supp_monotone : Monotone (Partition.supp (α := α)) := fun _ _ ↦ supp_mono
 
 /-- On a nontrivial complete lattice there are at least two partitions. -/
 instance [Nontrivial α] : Nontrivial (Partition α) :=
@@ -281,8 +268,7 @@ variable [CompleteLattice α] {P Q : Partition α} {a b : α}
 /-- Meet every part of `P` with `a`, discarding bottom. -/
 @[simps!]
 protected def induce (P : Partition α) (a : α) : Partition α :=
-  removeBot ((a ⊓ ·) '' P.parts) <|
-    P.sSupIndep'.image_of_le_self fun _ _ ↦ inf_le_right
+  removeBot ((a ⊓ ·) '' P.parts) <| P.sSupIndep'.image_of_le_self fun _ _ ↦ inf_le_right
 
 /-- Membership in an induced partition is equivalent to being a nontrivial meet of `a` with a
 part of `P`. -/
@@ -298,7 +284,8 @@ lemma inf_mem_induce (h : x ∈ P) (hne : a ⊓ x ≠ ⊥) : a ⊓ x ∈ P.induc
 @[simp]
 lemma induce_le : P.induce a ≤ P := by
   intro T hT
-  obtain ⟨hne, t, htP, rfl⟩ := (by simpa only [mem_induce_iff] using hT); clear hT
+  rw [mem_induce_iff] at hT
+  obtain ⟨hne, t, htP, rfl⟩ := hT
   exact ⟨t, htP, inf_le_right⟩
 
 /-- Inducing preserves refinement in the partition being induced. -/
@@ -334,22 +321,18 @@ variable [Order.Frame α] {P Q : Partition α} {a : α} {Qs : ∀ a ∈ P, Parti
 @[simps] protected def bind (P : Partition α) (Qs : ∀ a ∈ P, Partition α)
     (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) : Partition α where
   parts := ⋃ a : P, (Qs a a.prop).parts
-  sSupIndep' := by
-    intro b hb
+  sSupIndep' b hb := by
     simp only [mem_iUnion, Subtype.exists] at hb
-    obtain ⟨a, haP, hba : b ∈ Qs a haP⟩ := hb
-    obtain hasupp := hQs a haP
-    have hdj1 := (Qs a haP).sSupIndep hba
-    have hdj2 := (P.sSupIndep haP).mono_left <| ((Qs a haP).le_of_mem hba).trans hasupp
-    refine (hdj1.sup_right hdj2).mono_right ?_
-    simp only [mem_iUnion, Subtype.exists, sSup_le_iff, mem_sdiff,
-      mem_singleton_iff, and_imp, forall_exists_index]
-    rintro t' x hx (ht' : t' ∈ Qs x hx) hne
-    obtain hxsupp := hQs x hx
-    obtain (rfl | hne) := eq_or_ne x a
+    obtain ⟨a, haP, hba⟩ := hb
+    refine (Qs a haP).sSupIndep hba |>.sup_right ((P.sSupIndep haP).mono_left
+      <| ((Qs a haP).le_of_mem hba).trans (hQs a haP)) |>.mono_right ?_
+    simp only [sSup_le_iff, mem_sdiff, mem_iUnion, Subtype.exists, mem_singleton_iff, and_imp,
+      forall_exists_index]
+    rintro t' x hx ht' hne
+    obtain rfl | hne := eq_or_ne x a
     · exact (le_sSup_of_le (show t' ∈ _ \ {b} from ⟨ht', hne⟩) rfl.le).trans le_sup_left
-    exact le_trans (le_sSup_of_le (mem_sdiff_of_mem hx hne) <|
-      (Qs x hx).le_of_mem ht' |>.trans hxsupp) le_sup_right
+    exact le_trans (le_sSup_of_le (mem_sdiff_of_mem hx hne) <| (Qs x hx).le_of_mem ht' |>.trans
+      <| hQs x hx) le_sup_right
   bot_notMem' := by
     simp only [mem_iUnion, Subtype.exists, not_exists]
     exact fun x hx ↦ (Qs x hx).bot_notMem
@@ -357,7 +340,8 @@ variable [Order.Frame α] {P Q : Partition α} {a : α} {Qs : ∀ a ∈ P, Parti
 /-- Membership in a bind is equivalent to membership in one of the constituent partitions. -/
 @[simp] lemma mem_bind_iff (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) :
     a ∈ P.bind Qs hQs ↔ ∃ (b : α) (hb : b ∈ P), a ∈ Qs b hb := by
-  change _ ∈ ⋃ _, _ ↔ _; simp
+  change _ ∈ ⋃ _, _ ↔ _
+  simp
 
 /-- A bind refines `Q` iff every constituent partition refines `Q`. -/
 @[simp]
@@ -388,15 +372,14 @@ lemma le_bind_iff (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) :
     obtain rfl := P.eq_of_not_disjoint haP heP hne
     exact ⟨d, hdQse, inf_le_of_right_le hcd⟩
   obtain ⟨p, hpP, hap⟩ := hQP haQ
-  obtain ⟨q, hqQsp, haq⟩ := h p hpP <| inf_mem_induce haQ <| by
-    simp [hap, Q.ne_bot_of_mem haQ]
+  obtain ⟨q, hqQsp, haq⟩ := h p hpP <| inf_mem_induce haQ <| by simp [hap, Q.ne_bot_of_mem haQ]
   simp only [hap, inf_of_le_right] at haq
   exact ⟨q, (mem_bind_iff hQs).mpr ⟨p, hpP, hqQsp⟩, haq⟩
 
-lemma supp_bind (P : Partition α) (Qs : ∀ a ∈ P, Partition α)
-    (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) :
+lemma supp_bind (hQs : ∀ a, (h : a ∈ P) → (Qs a h).supp ≤ a) :
     (P.bind Qs hQs).supp = ⨆ a : P, (Qs a a.prop).supp := by
-  rw [← sSup_eq, coe_bind, sSup_iUnion]; rfl
+  rw [← sSup_eq, coe_bind, sSup_iUnion]
+  rfl
 
 end Bind
 
@@ -419,8 +402,7 @@ instance instSemilatticeInf : SemilatticeInf (Partition α) where
 /-- Membership in a meet is equivalent to being a nontrivial meet of parts from each
 partition. -/
 @[simp]
-lemma mem_inf_iff {a : α} :
-    a ∈ P ⊓ Q ↔ (∃ p ∈ P, ∃ q ∈ Q, p ⊓ q = a) ∧ a ≠ ⊥ := by
+lemma mem_inf_iff {a : α} : a ∈ P ⊓ Q ↔ (∃ p ∈ P, ∃ q ∈ Q, p ⊓ q = a) ∧ a ≠ ⊥ := by
   change a ∈ (P.bind _ _).parts ↔ _
   simp [and_comm, eq_comm]
 

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -404,21 +404,16 @@ section Inf
 
 variable [Order.Frame α] {P Q R : Partition α}
 
-/-- The meet of two partitions, obtained by binding `P` with the partitions induced by `Q`
-on each part of `P`. -/
-def inf (P Q : Partition α) : Partition α :=
-  P.bind (fun a _ ↦ Q.induce a) (by simp)
-
 /-- When `α` is a frame, partitions form a semilattice under refinement, with meet given by
 `Partition.inf`. -/
 instance instSemilatticeInf : SemilatticeInf (Partition α) where
-  inf := inf
+  inf P Q := P.bind (fun a _ ↦ Q.induce a) (by simp)
   inf_le_left P Q := bind_le (by simp)
   inf_le_right P Q := by
-    rw [inf, bind_le_iff (by simp)]
+    rw [bind_le_iff (by simp)]
     exact fun _ _ ↦ induce_le
   le_inf P Q R hPQ hPR := by
-    rw [inf, le_bind_iff (by simp)]
+    rw [le_bind_iff (by simp)]
     exact ⟨hPQ, fun a _ ↦ induce_le_induce_left hPR⟩
 
 /-- Membership in a meet is equivalent to being a nontrivial meet of parts from each

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -214,7 +214,6 @@ lemma notMem_of_bot (hP : P.supp = ⊥) (x : α) : x ∉ P :=
   (eq_bot hP).symm ▸ notMem_bot
 
 /-- A partition has a part iff it is not the empty partition. -/
-@[simp]
 lemma parts_nonempty_iff (P : Partition α) : P.parts.Nonempty ↔ P ≠ ⊥ := by
   refine ⟨?_, fun hP ↦ nonempty_iff_ne_empty.mpr <| mt (coe_eq_empty_iff P).mp hP⟩
   rintro ⟨x, hx⟩ rfl

--- a/Mathlib/Order/Partition/Lattice.lean
+++ b/Mathlib/Order/Partition/Lattice.lean
@@ -59,12 +59,9 @@ lemma sUnion_nonDisjointComponents : ⋃₀ (nonDisjointComponents S : Set (Set 
   rw [nonDisjointComponents, supp_ofRel]
   ext a
   simp only [mem_ofPred, mem_sdiff, mem_singleton_iff]
-  constructor
-  · intro h
-    obtain ⟨b, hab, -⟩ := TransGen.head'_iff.mp h
-    exact ⟨hab.2.1, fun ha ↦ hab.1 (by simp [ha])⟩
-  · rintro ⟨haS, hane⟩
-    exact TransGen.single ⟨fun h ↦ hane (disjoint_self.1 h), haS, haS⟩
+  refine ⟨fun h ↦ ?_, fun ⟨haS, hane⟩ ↦ .single ⟨fun h ↦ hane (disjoint_self.1 h), haS, haS⟩⟩
+  obtain ⟨b, hab, -⟩ := TransGen.head'_iff.mp h
+  exact ⟨hab.2.1, fun ha ↦ hab.1 (by simp [ha])⟩
 
 /-- Every element of a non-disjointness component belongs to the original set. -/
 lemma mem_of_mem_nonDisjointComponents (ht : t ∈ nonDisjointComponents S) (ha : a ∈ t) : a ∈ S :=
@@ -104,25 +101,23 @@ lemma sSupIndep_iInf_image_pi (Ps : Set (Partition α)) :
   have hfg : f ≠ g := fun h ↦ hne (h ▸ rfl)
   contrapose! hfg
   ext p
-  refine (p : Partition α).eq_of_not_disjoint (hf p (mem_univ _)) (hg p (mem_univ _)) ?_
+  refine p.val.eq_of_not_disjoint (hf p (mem_univ _)) (hg p (mem_univ _)) ?_
   contrapose! hfg
   exact hfg.mono (iInf_le f p) (iInf_le g p)
 
 /-- Distinct non-disjointness components have disjoint suprema. -/
 lemma eq_of_not_disjoint_sSup_mem_nonDisjointComponents (hs : s ∈ nonDisjointComponents S)
     (ht : t ∈ nonDisjointComponents S) (h : ¬Disjoint (sSup s) (sSup t)) : s = t := by
-  have h1 : ∃ x ∈ s, ¬Disjoint x (sSup t) := by
+  obtain ⟨c, hcS, hct⟩ : ∃ x ∈ s, ¬Disjoint x (sSup t) := by
     contrapose! h
     rwa [sSup_disjoint_iff]
-  obtain ⟨c, hcS, hct⟩ := h1
-  have h2 : ∃ y ∈ t, ¬Disjoint c y := by
+  obtain ⟨d, hdT, hcd⟩ : ∃ y ∈ t, ¬Disjoint c y := by
     contrapose! hct
     rwa [disjoint_sSup_iff]
-  obtain ⟨d, hdT, hcd⟩ := h2
   have hrel : (nonDisjointComponents S).Rel c d := by
-    simpa [nonDisjointComponents, rel_ofRel_eq] using
-      TransGen.single ⟨hcd, mem_of_mem_nonDisjointComponents hs hcS,
-        mem_of_mem_nonDisjointComponents ht hdT⟩
+    rw [nonDisjointComponents, rel_ofRel_eq]
+    exact TransGen.single
+      ⟨hcd, mem_of_mem_nonDisjointComponents hs hcS, mem_of_mem_nonDisjointComponents ht hdT⟩
   exact eq_of_mem_of_mem hs ht hcS <| (Rel.forall hrel ht).mpr hdT
 
 /-- The join of a family of partitions: suprema of non-disjointness components of the union of
@@ -147,27 +142,6 @@ lemma mem_sSup_iff : a ∈ sSup Ps ↔
   change a ∈ SupSet.sSup '' (nonDisjointComponents (⋃ P ∈ Ps, (P : Set α)) : Set (Set α)) ↔ _
   simp [mem_image]
 
-/-- The constructed supremum of a family of partitions is its least upper bound. -/
-lemma isLUB_sSup (Ps : Set (Partition α)) : IsLUB Ps (sSup Ps) := by
-  refine ⟨fun P hP a haP ↦ ?_, fun P hP a ha ↦ ?_⟩
-  · have hane : a ≠ ⊥ := P.ne_bot_of_mem haP
-    have : a ∈ (⋃ Q ∈ Ps, (Q : Set α)) \ {⊥} := by
-      simp only [mem_sdiff, mem_iUnion, SetLike.mem_coe, mem_singleton_iff, hane,
-        not_false_eq_true, and_true]
-      exact ⟨P, hP, haP⟩
-    rw [← sUnion_nonDisjointComponents] at this
-    obtain ⟨s, hs, haS⟩ := this
-    exact ⟨SupSet.sSup s, mem_sSup_iff.mpr ⟨s, hs, rfl⟩, _root_.le_sSup haS⟩
-  obtain ⟨s, hs, rfl⟩ := mem_sSup_iff.mp ha
-  have hsne : s.Nonempty := nonempty_iff_ne_empty.mpr <|
-    (nonDisjointComponents _).ne_bot_of_mem hs
-  obtain ⟨x, hx⟩ := hsne
-  obtain ⟨Q, hQ, hxQ⟩ := mem_iUnion₂.mp (mem_of_mem_nonDisjointComponents hs hx)
-  obtain ⟨y, hyP, hxy⟩ := hP hQ hxQ
-  refine ⟨y, hyP, sSup_le_of_mem_nonDisjointComponents (fun z hz ↦ ?_) hs hx hyP hxy⟩
-  obtain ⟨R, hR, hzR⟩ := mem_iUnion₂.mp hz
-  exact hP hR hzR
-
 /-- When `α` is a frame, partitions form a complete lattice under refinement. -/
 instance instCompleteLattice : CompleteLattice (Partition α) where
   __ := (inferInstance : SemilatticeInf (Partition α))
@@ -188,7 +162,25 @@ instance instCompleteLattice : CompleteLattice (Partition α) where
         simpa [mem_pi] using fun (p : Ps) ↦ (hP p.property haP).choose_spec.1
       · exact ne_bot_of_le_ne_bot (P.ne_bot_of_mem haP) <|
           le_iInf fun (p : Ps) ↦ (hP p.property haP).choose_spec.2
-  __ := completeLatticeOfSup (Partition α) isLUB_sSup
+  __ := completeLatticeOfSup (Partition α) (fun Ps ↦ by
+    refine ⟨fun P hP a haP ↦ ?_, fun P hP a ha ↦ ?_⟩
+    · have hane : a ≠ ⊥ := P.ne_bot_of_mem haP
+      have : a ∈ (⋃ Q ∈ Ps, (Q : Set α)) \ {⊥} := by
+        simp only [mem_sdiff, mem_iUnion, SetLike.mem_coe, mem_singleton_iff, hane,
+          not_false_eq_true, and_true]
+        exact ⟨P, hP, haP⟩
+      rw [← sUnion_nonDisjointComponents] at this
+      obtain ⟨s, hs, haS⟩ := this
+      exact ⟨SupSet.sSup s, mem_sSup_iff.mpr ⟨s, hs, rfl⟩, _root_.le_sSup haS⟩
+    obtain ⟨s, hs, rfl⟩ := mem_sSup_iff.mp ha
+    have hsne : s.Nonempty := nonempty_iff_ne_empty.mpr <|
+      (nonDisjointComponents _).ne_bot_of_mem hs
+    obtain ⟨x, hx⟩ := hsne
+    obtain ⟨Q, hQ, hxQ⟩ := mem_iUnion₂.mp (mem_of_mem_nonDisjointComponents hs hx)
+    obtain ⟨y, hyP, hxy⟩ := hP hQ hxQ
+    refine ⟨y, hyP, sSup_le_of_mem_nonDisjointComponents (fun z hz ↦ ?_) hs hx hyP hxy⟩
+    obtain ⟨R, hR, hzR⟩ := mem_iUnion₂.mp hz
+    exact hP hR hzR)
 
 lemma mem_sup_iff : a ∈ P ⊔ Q ↔
     ∃ s ∈ nonDisjointComponents ((P : Set α) ∪ Q), SupSet.sSup s = a := by
@@ -204,19 +196,19 @@ lemma mem_iSup_iff : a ∈ ⨆ i, Pι i ↔
     ext x; simp [mem_iUnion, mem_range]]
 
 @[simp]
-lemma supp_sSup (Ps : Set (Partition α)) : (sSup Ps).supp = ⨆ P ∈ Ps, P.supp := by
+lemma supp_sSup : (sSup Ps).supp = ⨆ P ∈ Ps, P.supp := by
   change SupSet.sSup (SupSet.sSup '' _) = ⨆ P ∈ Ps, P.supp
   rw [sSup_image, ← sSup_sUnion, sUnion_nonDisjointComponents, sSup_sdiff_singleton_bot,
     ← sUnion_image, sSup_sUnion, iSup_image]
   simp only [sSup_eq]
 
 @[simp]
-lemma supp_iSup (Pι : ι → Partition α) : (⨆ i, Pι i).supp = ⨆ i, (Pι i).supp := by
+lemma supp_iSup : (⨆ i, Pι i).supp = ⨆ i, (Pι i).supp := by
   change (sSup (range Pι)).supp = _
   rw [supp_sSup, iSup_range]
 
 @[simp]
-lemma supp_sup (P Q : Partition α) : (P ⊔ Q).supp = P.supp ⊔ Q.supp := by
+lemma supp_sup : (P ⊔ Q).supp = P.supp ⊔ Q.supp := by
   change (sSup {P, Q}).supp = _
   rw [supp_sSup, iSup_pair]
 

--- a/Mathlib/Order/Partition/Lattice.lean
+++ b/Mathlib/Order/Partition/Lattice.lean
@@ -53,7 +53,6 @@ non-disjointness. -/
 def nonDisjointComponents (S : Set α) : Partition (Set α) :=
   ofRel (TransGen (NonDisjointOn S))
 
-@[simp]
 lemma sUnion_nonDisjointComponents : ⋃₀ (nonDisjointComponents S : Set (Set α)) = S \ {⊥} := by
   change (nonDisjointComponents S).supp = S \ {⊥}
   rw [nonDisjointComponents, supp_ofRel]

--- a/Mathlib/Order/Partition/Lattice.lean
+++ b/Mathlib/Order/Partition/Lattice.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2025 Peter Nelson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Peter Nelson, Hyeokjun Kwon
+-/
+module
+
+public import Mathlib.Logic.Relation
+public import Mathlib.Order.Partition.Set
+
+/-!
+# Complete lattice structure on partitions
+
+When `α` is a frame, `Partition α` is a complete lattice under refinement. Finite meets already
+exist via `Partition.instSemilatticeInf` in `Basic`; this file adds arbitrary meets and joins.
+
+Joins are constructed using `nonDisjointComponents`, the partition of a set of elements into
+connected components under non-disjointness, obtained as `ofRel` of the `TransGen` of that step
+relation.
+
+## Main declarations
+
+* `Partition.NonDisjointOn` / `Partition.nonDisjointComponents`
+* `Partition.instCompleteLattice`
+-/
+
+@[expose] public section
+variable {α : Type*}
+
+open Set Relation
+
+namespace Partition
+
+variable [Order.Frame α] {P Q R : Partition α} {S : Set α} {a b c : α} {s t : Set α}
+  {Ps : Set (Partition α)} {ι : Sort*} {Pι : ι → Partition α}
+
+/-- The relation of being non-disjoint elements of `S`. -/
+def NonDisjointOn (S : Set α) (a b : α) : Prop :=
+  ¬Disjoint a b ∧ a ∈ S ∧ b ∈ S
+
+instance (S : Set α) : Std.Symm (NonDisjointOn S) where
+  symm _ _ h := ⟨fun hdj ↦ h.1 hdj.symm, h.2.2, h.2.1⟩
+
+/-- Two parts are equal if they respectively contain non-disjoint elements. -/
+lemma eq_of_le_not_disjoint {x r : α} (hx : x ∈ R) (hxs : b ≤ x) (hr : r ∈ R) (hrs : c ≤ r)
+    (hndisj : ¬Disjoint b c) : r = x := by
+  refine R.eq_of_not_disjoint hr hx ?_
+  contrapose! hndisj
+  exact hndisj.symm.mono hxs hrs
+
+/-- The partition of the nontrivial elements of `S` into connected components under
+non-disjointness. -/
+def nonDisjointComponents (S : Set α) : Partition (Set α) :=
+  ofRel (TransGen (NonDisjointOn S))
+
+@[simp]
+lemma sUnion_nonDisjointComponents : ⋃₀ (nonDisjointComponents S : Set (Set α)) = S \ {⊥} := by
+  change (nonDisjointComponents S).supp = S \ {⊥}
+  rw [nonDisjointComponents, supp_ofRel]
+  ext a
+  simp only [mem_ofPred, mem_sdiff, mem_singleton_iff]
+  constructor
+  · intro h
+    obtain ⟨b, hab, -⟩ := TransGen.head'_iff.mp h
+    exact ⟨hab.2.1, fun ha ↦ hab.1 (by simp [ha])⟩
+  · rintro ⟨haS, hane⟩
+    exact TransGen.single ⟨fun h ↦ hane (disjoint_self.1 h), haS, haS⟩
+
+/-- Every element of a non-disjointness component belongs to the original set. -/
+lemma mem_of_mem_nonDisjointComponents (ht : t ∈ nonDisjointComponents S) (ha : a ∈ t) : a ∈ S :=
+  ((sUnion_nonDisjointComponents (S := S)).symm ▸ mem_sUnion_of_mem ha ht).1
+
+/-- Every element of a non-disjointness component is nontrivial. -/
+lemma ne_bot_of_mem_nonDisjointComponents (ht : t ∈ nonDisjointComponents S) (ha : a ∈ t) : a ≠ ⊥ :=
+  ((sUnion_nonDisjointComponents (S := S)).symm ▸ mem_sUnion_of_mem ha ht).2
+
+/-- The supremum of a non-disjointness component lies below any partition part containing one of
+its elements, provided every element of the original set lies below a partition part. -/
+lemma sSup_le_of_mem_nonDisjointComponents (h : ∀ s ∈ S, ∃ p ∈ P, s ≤ p)
+    (hs : s ∈ nonDisjointComponents S) (has : a ∈ s) (hbP : b ∈ P) (hab : a ≤ b) : sSup s ≤ b := by
+  have : ∀ c, TransGen (NonDisjointOn S) a c → c ≤ b := by
+    intro c hc
+    induction hc with
+    | single hstep =>
+      obtain ⟨p, hpP, hcp⟩ := h _ hstep.2.2
+      convert hcp
+      exact eq_of_le_not_disjoint hpP hcp hbP hab fun hd ↦ hstep.1 hd.symm
+    | tail _ hbc IH =>
+      obtain ⟨p, hpP, hcp⟩ := h _ hbc.2.2
+      convert hcp
+      exact eq_of_le_not_disjoint hpP hcp hbP IH fun hd ↦ hbc.1 hd.symm
+  rw [sSup_le_iff]
+  intro c hc
+  have hrel : (nonDisjointComponents S).Rel a c := ⟨s, hs, has, hc⟩
+  simp only [nonDisjointComponents, rel_ofRel_eq] at hrel
+  exact this c hrel
+
+/-- Choosing one part from each partition and taking their infimum gives an independent family. -/
+lemma sSupIndep_iInf_image_pi (Ps : Set (Partition α)) :
+    _root_.sSupIndep (iInf '' (pi univ fun p : Ps ↦ (p : Partition α).parts)) := by
+  rintro _ ⟨f, hf, rfl⟩
+  rw [disjoint_sSup_iff]
+  rintro _ ⟨⟨g, hg, rfl⟩, hne⟩
+  have hfg : f ≠ g := fun h ↦ hne (h ▸ rfl)
+  contrapose! hfg
+  ext p
+  refine (p : Partition α).eq_of_not_disjoint (hf p (mem_univ _)) (hg p (mem_univ _)) ?_
+  contrapose! hfg
+  exact hfg.mono (iInf_le f p) (iInf_le g p)
+
+/-- Distinct non-disjointness components have disjoint suprema. -/
+lemma eq_of_not_disjoint_sSup_mem_nonDisjointComponents (hs : s ∈ nonDisjointComponents S)
+    (ht : t ∈ nonDisjointComponents S) (h : ¬Disjoint (sSup s) (sSup t)) : s = t := by
+  have h1 : ∃ x ∈ s, ¬Disjoint x (sSup t) := by
+    contrapose! h
+    rwa [sSup_disjoint_iff]
+  obtain ⟨c, hcS, hct⟩ := h1
+  have h2 : ∃ y ∈ t, ¬Disjoint c y := by
+    contrapose! hct
+    rwa [disjoint_sSup_iff]
+  obtain ⟨d, hdT, hcd⟩ := h2
+  have hrel : (nonDisjointComponents S).Rel c d := by
+    simpa [nonDisjointComponents, rel_ofRel_eq] using
+      TransGen.single ⟨hcd, mem_of_mem_nonDisjointComponents hs hcS,
+        mem_of_mem_nonDisjointComponents ht hdT⟩
+  exact eq_of_mem_of_mem hs ht hcS <| (Rel.forall hrel ht).mpr hdT
+
+/-- The join of a family of partitions: suprema of non-disjointness components of the union of
+parts. -/
+instance instSupSet : SupSet (Partition α) where
+  sSup Ps := {
+    parts := SupSet.sSup '' (nonDisjointComponents (⋃ P ∈ Ps, (P : Set α)) : Set (Set α))
+    sSupIndep' := by
+      refine PairwiseDisjoint.sSupIndep ?_
+      rintro _ ⟨s, hs, rfl⟩ _ ⟨t, ht, rfl⟩ hne
+      exact not_not.mp fun h ↦ hne <|
+        congrArg SupSet.sSup <| eq_of_not_disjoint_sSup_mem_nonDisjointComponents hs ht h
+    bot_notMem' := by
+      rintro ⟨s, hs, heq⟩
+      have hsne : s.Nonempty := nonempty_iff_ne_empty.mpr <|
+        (nonDisjointComponents (⋃ P ∈ Ps, (P : Set α))).ne_bot_of_mem hs
+      exact (ne_bot_of_mem_nonDisjointComponents hs hsne.some_mem) <|
+        sSup_eq_bot.mp heq hsne.some hsne.some_mem}
+
+lemma mem_sSup_iff : a ∈ sSup Ps ↔
+    ∃ s ∈ nonDisjointComponents (⋃ P ∈ Ps, (P : Set α)), SupSet.sSup s = a := by
+  change a ∈ SupSet.sSup '' (nonDisjointComponents (⋃ P ∈ Ps, (P : Set α)) : Set (Set α)) ↔ _
+  simp [mem_image]
+
+/-- The constructed supremum of a family of partitions is its least upper bound. -/
+lemma isLUB_sSup (Ps : Set (Partition α)) : IsLUB Ps (sSup Ps) := by
+  refine ⟨fun P hP a haP ↦ ?_, fun P hP a ha ↦ ?_⟩
+  · have hane : a ≠ ⊥ := P.ne_bot_of_mem haP
+    have : a ∈ (⋃ Q ∈ Ps, (Q : Set α)) \ {⊥} := by
+      simp only [mem_sdiff, mem_iUnion, SetLike.mem_coe, mem_singleton_iff, hane,
+        not_false_eq_true, and_true]
+      exact ⟨P, hP, haP⟩
+    rw [← sUnion_nonDisjointComponents] at this
+    obtain ⟨s, hs, haS⟩ := this
+    exact ⟨SupSet.sSup s, mem_sSup_iff.mpr ⟨s, hs, rfl⟩, _root_.le_sSup haS⟩
+  obtain ⟨s, hs, rfl⟩ := mem_sSup_iff.mp ha
+  have hsne : s.Nonempty := nonempty_iff_ne_empty.mpr <|
+    (nonDisjointComponents _).ne_bot_of_mem hs
+  obtain ⟨x, hx⟩ := hsne
+  obtain ⟨Q, hQ, hxQ⟩ := mem_iUnion₂.mp (mem_of_mem_nonDisjointComponents hs hx)
+  obtain ⟨y, hyP, hxy⟩ := hP hQ hxQ
+  refine ⟨y, hyP, sSup_le_of_mem_nonDisjointComponents (fun z hz ↦ ?_) hs hx hyP hxy⟩
+  obtain ⟨R, hR, hzR⟩ := mem_iUnion₂.mp hz
+  exact hP hR hzR
+
+/-- When `α` is a frame, partitions form a complete lattice under refinement. -/
+instance instCompleteLattice : CompleteLattice (Partition α) where
+  __ := (inferInstance : SemilatticeInf (Partition α))
+  __ := (inferInstance : OrderBot (Partition α))
+  __ := (inferInstance : OrderTop (Partition α))
+  sInf Ps := removeBot (iInf '' (pi univ fun p : Ps ↦ (p : Partition α).parts))
+    (sSupIndep_iInf_image_pi Ps)
+  isGLB_sInf Ps := by
+    refine ⟨fun P hP a ha ↦ ?_, fun P hP a haP ↦ ?_⟩
+    · simp only [coe_parts, mem_removeBot, mem_image, mem_pi, mem_univ, SetLike.mem_coe,
+      forall_const, Subtype.forall, ne_eq] at ha
+      obtain ⟨⟨f, hf, rfl⟩, hne⟩ := ha
+      exact ⟨f ⟨P, hP⟩, hf P hP, iInf_le f _⟩
+    · refine ⟨iInf fun (p : Ps) ↦ (hP p.property haP).choose, ?_,
+        le_iInf fun (p : Ps) ↦ (hP p.property haP).choose_spec.2⟩
+      refine (mem_removeBot _ _).2 ⟨?_, ?_⟩
+      · refine mem_image_of_mem _ ?_
+        simpa [mem_pi] using fun (p : Ps) ↦ (hP p.property haP).choose_spec.1
+      · exact ne_bot_of_le_ne_bot (P.ne_bot_of_mem haP) <|
+          le_iInf fun (p : Ps) ↦ (hP p.property haP).choose_spec.2
+  __ := completeLatticeOfSup (Partition α) isLUB_sSup
+
+lemma mem_sup_iff : a ∈ P ⊔ Q ↔
+    ∃ s ∈ nonDisjointComponents ((P : Set α) ∪ Q), SupSet.sSup s = a := by
+  change a ∈ sSup {P, Q} ↔ _
+  simp only [mem_sSup_iff, biUnion_pair]
+
+lemma mem_iSup_iff : a ∈ ⨆ i, Pι i ↔
+    ∃ s ∈ nonDisjointComponents (⋃ i, (Pι i : Set α)), SupSet.sSup s = a := by
+  change a ∈ sSup (range Pι) ↔ _
+  simp only [mem_sSup_iff]
+  refine exists_congr fun s ↦ and_congr_left' ?_
+  rw [show (⋃ P ∈ range Pι, (P : Set α)) = ⋃ i, (Pι i : Set α) by
+    ext x; simp [mem_iUnion, mem_range]]
+
+@[simp]
+lemma supp_sSup (Ps : Set (Partition α)) : (sSup Ps).supp = ⨆ P ∈ Ps, P.supp := by
+  change SupSet.sSup (SupSet.sSup '' _) = ⨆ P ∈ Ps, P.supp
+  rw [sSup_image, ← sSup_sUnion, sUnion_nonDisjointComponents, sSup_sdiff_singleton_bot,
+    ← sUnion_image, sSup_sUnion, iSup_image]
+  simp only [sSup_eq]
+
+@[simp]
+lemma supp_iSup (Pι : ι → Partition α) : (⨆ i, Pι i).supp = ⨆ i, (Pι i).supp := by
+  change (sSup (range Pι)).supp = _
+  rw [supp_sSup, iSup_range]
+
+@[simp]
+lemma supp_sup (P Q : Partition α) : (P ⊔ Q).supp = P.supp ⊔ Q.supp := by
+  change (sSup {P, Q}).supp = _
+  rw [supp_sSup, iSup_pair]
+
+end Partition

--- a/Mathlib/Order/Partition/Set.lean
+++ b/Mathlib/Order/Partition/Set.lean
@@ -44,8 +44,7 @@ proved separately.
 -/
 
 @[expose] public section
-variable {α : Type*} {S : Set (Set α)} {s t : Set α} {a b c x y z : α}
-  {P Q : Partition (Set α)}
+variable {α : Type*} {S : Set (Set α)} {s t : Set α} {a b c x y z : α} {P Q : Partition (Set α)}
 
 open Set
 
@@ -271,23 +270,13 @@ lemma forall_apply_eq_apply_iff (hf : IsRepFun P f) (a) :
 
 lemma apply_eq_apply_iff' (hf : IsRepFun P f) :
     f a = f b ↔ (a = b ∧ ∀ c, f a = f c ↔ a = c) ∨ P.Rel a b := by
-  obtain h1 | h2 := hf.forall_apply_eq_apply_iff a
-  · refine ⟨by grind, ?_⟩
-    rintro (h | h)
-    · exact congrArg _ h.1
-    exact hf.apply_eq_apply h
-  grind
+  obtain h1 | h2 := hf.forall_apply_eq_apply_iff a <;> grind
 
 lemma idem (hf : IsRepFun P f) : f (f a) = f a := by
-  obtain (ha | ha) := em (a ∈ P.supp)
-  · rw [eq_comm, hf.apply_eq_apply_iff_rel ha]
-    exact hf.rel_apply ha
-  simp_rw [hf.apply_of_notMem ha]
+  obtain (ha | ha) := em (a ∈ P.supp) <;> grind
 
 theorem apply_apply (hf : IsRepFun P f) (hg : IsRepFun P g) (x : α) : f (g x) = f x := by
-  obtain (hx | hx) := em (x ∈ P.supp)
-  · exact hf.apply_eq_apply (hg.rel_apply hx).symm
-  rw [hg.apply_of_notMem hx, hf.apply_of_notMem hx]
+  obtain (hx | hx) := em (x ∈ P.supp) <;> grind
 
 /-- Any partially defined representative function extends to a complete one. -/
 lemma exists_extend_partial (P : Partition (Set α)) (f₀ : t → α)
@@ -303,12 +292,7 @@ lemma exists_extend_partial (P : Partition (Set α)) (f₀ : t → α)
     push Not at h
     exact P.rep_rel (P.partOf_mem ha) (P.mem_partOf ha)
   · simp_rw [hfdef, dif_pos hab.left_mem, dif_pos hab.right_mem]
-    split_ifs with h₁ h₂ h₂
-    · exact h_eq _ _ <| (hab.symm.trans h₁.choose_spec).symm.trans h₂.choose_spec
-    · exact h₂ ⟨_, hab.symm.trans h₁.choose_spec⟩ |>.elim
-    · exact h₁ ⟨_, hab.trans h₂.choose_spec⟩ |>.elim
-    congr 1
-    rwa [← rel_iff_partOf_eq_partOf_of_mem _ hab.left_mem hab.right_mem]
+    split_ifs with h₁ h₂ h₂ <;> grind
   obtain (ha | ha) := em (a.1 ∈ P.supp) |>.symm
   · simp [hfdef, ha, h_notMem _ ha]
   simp only [hfdef, ha, ↓reduceDIte]

--- a/Mathlib/Order/Partition/Set.lean
+++ b/Mathlib/Order/Partition/Set.lean
@@ -1,0 +1,332 @@
+/-
+Copyright (c) 2025 Peter Nelson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Peter Nelson, Hyeokjun Kwon
+-/
+module
+
+public import Mathlib.Order.Partition.Basic
+
+/-!
+# Partitions of sets
+
+This file specialises `Partition` to the complete lattice `Set α`. A `Partition (Set α)` is an
+independent family of nonempty sets; its support `Partition.supp` is their union.
+
+This is equivalent to a transitive and symmetric binary relation `r : α → α → Prop` where the
+support is the set of all `x` for which `r x x`.
+
+## Main declarations
+
+* `Partition.Rel`: The partial equivalence relation induced by a partition of a set.
+* `Partition.partOf`: The part of a partition containing a given element.
+* `Partition.IsRepFun`: A predicate characterizing a representative function for a partition.
+
+## Representative functions (`IsRepFun`)
+
+`IsRepFun P f` means that `f` sends each element of the support to a representative in its
+`Partition.Rel`-class, agrees on related elements, and is the identity outside the support.
+
+This is useful whenever a construction must pick one distinguished element per part of a partition.
+For example, in graph theory one may partition edges into parallel classes or vertices into
+connected components; a representative function can specify which edge remains when simplifying
+parallel edges, or how supervertices are labeled after contraction. Similar uses arise in matroid
+theory and in the definition of minors.
+
+Tempting alternatives are to use `Classical.choice` or fix a global well-order and take minimal
+representatives. However, these lead to issues with inconsistencies: independent choices need not
+respect relations between different instances (e.g. monotonicity of simplifications with respect
+to subgraph order), a global order can clash with structure already carried by the type, and maps
+between different types need not intertwine two separate canonical choices. Stating hypotheses with
+`IsRepFun` keeps the chosen representatives explicit; existence under suitable conditions can be
+proved separately.
+
+-/
+
+@[expose] public section
+variable {α : Type*} {S : Set (Set α)} {s t : Set α} {a b c x y z : α}
+  {P Q : Partition (Set α)}
+
+open Set
+
+namespace Partition
+
+section Set
+
+@[simp] protected lemma sUnion_eq (P : Partition (Set α)) : ⋃₀ P = P.supp := P.sSup_eq
+
+lemma nonempty_of_mem (ht : t ∈ P) : t.Nonempty := notMem_singleton_empty.1 <| P.ne_bot_of_mem ht
+
+lemma empty_notMem : ∅ ∉ P := P.bot_notMem
+
+lemma subset_of_mem (ht : t ∈ P) : t ⊆ P.supp := P.le_of_mem ht
+
+@[grind =]
+lemma mem_supp_iff : x ∈ P.supp ↔ ∃ t ∈ P, x ∈ t := by
+  refine ⟨fun hx ↦ ?_, fun ⟨t, htP, hxt⟩ ↦ subset_of_mem htP hxt⟩
+  rwa [← P.sUnion_eq, mem_sUnion] at hx
+
+@[deprecated (since := "2026-07-28")] alias mem_iff_exists := mem_supp_iff
+
+lemma eq_of_mem_inter (ht : t ∈ P) (hs : s ∈ P) (hx : x ∈ t ∩ s) : t = s :=
+  P.pairwiseDisjoint.elim ht hs fun (hdj : Disjoint t s) ↦ by simp [hdj.inter_eq] at hx
+
+@[grind →]
+lemma eq_of_mem_of_mem (ht : t ∈ P) (hus : s ∈ P) (hxt : x ∈ t) (hxs : x ∈ s) : t = s :=
+  eq_of_mem_inter ht hus ⟨hxt, hxs⟩
+
+lemma mem_supp_iff_unique : x ∈ P.supp ↔ ∃! t, t ∈ P ∧ x ∈ t := by
+  refine ⟨fun hx ↦ ?_, fun ⟨_, ⟨htP, hxt⟩, _⟩ ↦ subset_of_mem htP hxt⟩
+  rw [← P.sUnion_eq, mem_sUnion] at hx
+  obtain ⟨t, ht, hxt⟩ := hx
+  exact ⟨t, ⟨ht, hxt⟩, fun s ⟨hsP, hxs⟩ ↦ P.eq_of_mem_of_mem hsP ht hxs hxt⟩
+
+@[deprecated (since := "2026-07-28")] alias mem_iff_unique := mem_supp_iff_unique
+
+lemma subset_sUnion_and_mem_iff_mem (hSP : S ⊆ P) : t ⊆ ⋃₀ S ∧ t ∈ P ↔ t ∈ S := by
+  refine ⟨fun ⟨htsu, htP⟩ ↦ ?_, fun htS ↦ ⟨subset_sUnion_of_mem htS, hSP htS⟩⟩
+  obtain ⟨x, hxt⟩ := nonempty_of_mem htP
+  obtain ⟨s, hsS, hxs⟩ := htsu hxt
+  exact eq_of_mem_of_mem htP (hSP hsS) hxt hxs ▸ hsS
+
+lemma subset_sUnion_iff_mem (ht : t ∈ P) (hSP : S ⊆ P.parts) : t ⊆ ⋃₀ S ↔ t ∈ S := by
+  rw [← subset_sUnion_and_mem_iff_mem hSP]
+  simp [ht]
+
+/-- Noncomputably choose a representative from an equivalence class. -/
+noncomputable def rep (P : Partition (Set α)) (ht : t ∈ P) : α := (P.nonempty_of_mem ht).some
+
+/-- The representative of a part belongs to that part. -/
+@[simp] lemma rep_mem (ht : t ∈ P) : P.rep ht ∈ t := (P.nonempty_of_mem ht).some_mem
+
+/-- The representative of a part belongs to the underlying set. -/
+@[simp] lemma rep_mem_supp (ht : t ∈ P) : P.rep ht ∈ P.supp := P.subset_of_mem ht <| rep_mem ht
+
+end Set
+
+/-! ### Induced relation -/
+
+section Rel
+
+/-- Every partition of sets induces a transitive, symmetric binary relation on `α`
+  whose equivalence classes are the parts of `P`. The relation is irreflexive outside the
+  support. -/
+def Rel (P : Partition (Set α)) (a b : α) : Prop :=
+  ∃ t ∈ P, a ∈ t ∧ b ∈ t
+
+lemma rel_le_iff_le : P.Rel ≤ Q.Rel ↔ P ≤ Q := by
+  refine ⟨fun h S hS ↦ ?_, fun h a b ⟨t, ht, ha, hb⟩ ↦ ?_⟩
+  · obtain ⟨x, hxS⟩ := nonempty_of_mem hS
+    obtain ⟨T, hT, hxT, -⟩ := h x x ⟨S, hS, hxS, hxS⟩
+    refine ⟨T, hT, fun a haS ↦ ?_⟩
+    obtain ⟨T', hT', haT', hxT'⟩ := h a x ⟨S, hS, haS, hxS⟩
+    exact eq_of_mem_of_mem hT hT' hxT hxT' ▸ haT'
+  obtain ⟨t', ht', htt'⟩ := h ht
+  use t', ht', htt' ha, htt' hb
+
+lemma Rel.exists (h : P.Rel x y) : ∃ t ∈ P, x ∈ t ∧ y ∈ t := h
+
+lemma Rel.forall (h : P.Rel x y) (ht : t ∈ P) : x ∈ t ↔ y ∈ t := by
+  obtain ⟨t, ht', hx, hy⟩ := h
+  exact ⟨fun h ↦ by rwa [P.eq_of_mem_of_mem ht ht' h hx],
+    fun h ↦ by rwa [P.eq_of_mem_of_mem ht ht' h hy]⟩
+
+@[simp]
+lemma rel_rfl_iff : P.Rel x x ↔ x ∈ P.supp := by
+  refine ⟨fun ⟨t, ht, hxP, _⟩ ↦ subset_of_mem ht hxP, fun hx ↦ ?_⟩
+  obtain ⟨t, ⟨ht, hxt⟩, -⟩ := P.mem_supp_iff_unique.mp hx
+  exact ⟨t, ht, hxt, hxt⟩
+
+instance (P : Partition (Set α)) : Std.Symm P.Rel where
+  symm _ _ := fun ⟨t, ht, ha, hb⟩ ↦ ⟨t, ht, hb, ha⟩
+
+instance (P : Partition (Set α)) : IsTrans α P.Rel where
+  trans _ _ _ := fun ⟨t, ht, ha, hb⟩ ⟨t', ht', hb', hc⟩ ↦
+    ⟨t, ht, ha, by rwa [eq_of_mem_of_mem ht ht' hb hb']⟩
+
+@[symm, grind →] lemma Rel.symm (h : P.Rel x y) : P.Rel y x := symm_of P.Rel h
+
+lemma rel_comm : P.Rel x y ↔ P.Rel y x := ⟨Rel.symm, Rel.symm⟩
+
+@[grind →]
+lemma Rel.trans (hxy : P.Rel x y) (hyz : P.Rel y z) : P.Rel x z := trans_of P.Rel hxy hyz
+
+@[grind →]
+lemma Rel.left_mem (h : P.Rel x y) : x ∈ P.supp := by
+  obtain ⟨t, htP, hxt, -⟩ := h
+  exact subset_of_mem htP hxt
+
+@[grind →]
+lemma Rel.right_mem (h : P.Rel x y) : y ∈ P.supp := h.symm.left_mem
+
+/-- Any element of a part is related to the representative of that part. -/
+lemma rep_rel (ht : t ∈ P) (hx : x ∈ t) : P.Rel x (P.rep ht) := ⟨t, ht, hx, P.rep_mem ht⟩
+
+end Rel
+
+section partOf
+
+/-- The part of a partition containing a given element. If the element is not in the
+support, this is empty. -/
+def partOf (P : Partition (Set α)) (a : α) : Set α := {b | P.Rel a b}
+
+lemma partOf_subset : P.partOf x ⊆ P.supp := fun _ ⟨_, ht, _, hyt⟩ ↦ subset_of_mem ht hyt
+
+@[simp, grind =] lemma mem_partOf_iff : x ∈ P.partOf y ↔ P.Rel y x := Iff.rfl
+
+@[grind →]
+lemma eq_partOf_of_mem (ht : t ∈ P) (hxt : x ∈ t) : t = P.partOf x := by
+  ext y
+  exact ⟨(⟨t, ht, hxt, ·⟩), fun ⟨s, hsP, hxs, hys⟩ ↦ (P.eq_of_mem_of_mem ht hsP hxt hxs) ▸ hys⟩
+
+lemma mem_iff_mem_partOf_mem : x ∈ P.supp ↔ x ∈ P.partOf x ∧ P.partOf x ∈ P := by grind
+
+@[grind →]
+lemma mem_partOf (hxu : x ∈ P.supp) : x ∈ P.partOf x := (P.mem_iff_mem_partOf_mem.mp hxu).1
+
+@[grind →]
+lemma partOf_mem (hxu : x ∈ P.supp) : P.partOf x ∈ P := (P.mem_iff_mem_partOf_mem.mp hxu).2
+
+@[simp]
+lemma partOf_rep (hs : s ∈ P) : P.partOf (P.rep hs) = s :=
+  eq_partOf_of_mem hs (rep_mem hs) |>.symm
+
+lemma mem_iff_exists_partOf : s ∈ P ↔ ∃ x ∈ P.supp, partOf P x = s :=
+  ⟨fun hs ↦ ⟨P.rep hs, rep_mem_supp hs, partOf_rep hs⟩, fun ⟨_, hxu, h⟩ ↦ h ▸ partOf_mem hxu⟩
+
+lemma partOf_nonempty_iff : (P.partOf x).Nonempty ↔ x ∈ P.supp := by
+  refine ⟨fun ⟨y, hy⟩ ↦ hy.left_mem, fun h ↦ ?_⟩
+  simpa [nonempty_iff_ne_empty] using P.ne_bot_of_mem (partOf_mem h)
+
+@[simp]
+lemma partOf_eq_empty_iff : P.partOf x = ∅ ↔ x ∉ P.supp := by
+  rw [← partOf_nonempty_iff, not_nonempty_iff_eq_empty]
+
+lemma rel_iff_partOf_eq_partOf_of_mem (P : Partition (Set α)) (hx : x ∈ P.supp) (hy : y ∈ P.supp) :
+    P.Rel x y ↔ P.partOf x = P.partOf y := by
+  refine ⟨fun ⟨t, htP, hxt, hyt⟩ ↦ eq_partOf_of_mem (P.partOf_mem hx) ?_,
+    fun h ↦ ⟨P.partOf x, P.partOf_mem hx, P.mem_partOf hx, h ▸ mem_partOf hy⟩⟩
+  rwa [← eq_partOf_of_mem htP hxt]
+
+lemma rel_iff_partOf_eq_partOf (P : Partition (Set α)) :
+    P.Rel x y ↔ ∃ (_ : x ∈ P.supp) (_ : y ∈ P.supp), P.partOf x = P.partOf y := by
+  grind [rel_iff_partOf_eq_partOf_of_mem]
+
+end partOf
+
+/-! ### Representative functions
+
+See the module docstring for motivation (graph simplification, minors, and why we use an explicit
+`IsRepFun` hypothesis rather than a global choice of representatives).
+-/
+
+/-- A predicate characterizing when a function `f : α → α` is a representative function for a
+partition `P`. A representative function maps each element to a chosen representative in its
+equivalence class, is the identity outside the support, and maps related elements to the same
+representative. -/
+structure IsRepFun (P : Partition (Set α)) (f : α → α) : Prop where
+  /-- The function is the identity outside the support. -/
+  apply_of_notMem : ∀ ⦃a⦄, a ∉ P.supp → f a = a
+  /-- The function maps each element in the support to a related element. -/
+  rel_apply : ∀ ⦃a⦄, a ∈ P.supp → P.Rel a (f a)
+  /-- The function maps related elements to the same representative. -/
+  apply_eq_apply : ∀ ⦃a b⦄, P.Rel a b → f a = f b
+
+attribute [grind →] IsRepFun.apply_of_notMem IsRepFun.rel_apply IsRepFun.apply_eq_apply
+
+namespace IsRepFun
+
+variable {P : Partition (Set α)} {f g : α → α} {a b c : α}
+
+lemma apply_mem (hf : IsRepFun P f) (ha : a ∈ P.supp) : f a ∈ P.supp := (hf.rel_apply ha).right_mem
+
+lemma image_subset (hf : IsRepFun P f) (hs : P.supp ⊆ s) : f '' s ⊆ s := by
+  rintro _ ⟨a, haS, rfl⟩
+  by_cases ha : a ∈ P.supp
+  · exact hs <| hf.apply_mem ha
+  exact (hf.apply_of_notMem ha).symm ▸ haS
+
+lemma mapsTo (hf : IsRepFun P f) (hs : P.supp ⊆ s) : Set.MapsTo f s s :=
+  fun x h ↦ hf.image_subset hs ⟨x, h, rfl⟩
+
+lemma mapsTo_of_disjoint (hf : IsRepFun P f) (hs : Disjoint P.supp s) : Set.MapsTo f s s :=
+  fun _ h ↦ (hf.apply_of_notMem <| hs.notMem_of_mem_right h).symm ▸ h
+
+lemma apply_mem_iff (hf : IsRepFun P f) (hs : P.supp ⊆ s) : f a ∈ s ↔ a ∈ s :=
+  hf.mapsTo hs |>.mem_iff <| mapsTo_of_disjoint hf hs.disjoint_compl_right
+
+lemma apply_eq_apply_iff_rel (hf : IsRepFun P f) (ha : a ∈ P.supp) : f a = f b ↔ P.Rel a b :=
+  ⟨fun hab ↦ (hf.rel_apply ha).trans (by grind), (hf.apply_eq_apply ·)⟩
+
+lemma apply_eq_apply_iff (hf : IsRepFun P f) : f a = f b ↔ a = b ∨ P.Rel a b := by grind
+
+lemma forall_apply_eq_apply_iff (hf : IsRepFun P f) (a) :
+    (∀ (x : α), f a = f x ↔ a = x) ∨ (∀ (x : α), f a = f x ↔ P.Rel a x) := by
+  refine (em (a ∈ P.supp)).elim (fun ha ↦ Or.inr fun b ↦ ?_) (fun ha ↦ Or.inl fun b ↦ ?_)
+  · rw [hf.apply_eq_apply_iff_rel ha]
+  rw [hf.apply_of_notMem ha]
+  constructor <;> rintro rfl
+  · exact hf.apply_of_notMem <| hf.apply_mem_iff le_rfl |>.not.mp ha
+  exact hf.apply_of_notMem ha |>.symm
+
+lemma apply_eq_apply_iff' (hf : IsRepFun P f) :
+    f a = f b ↔ (a = b ∧ ∀ c, f a = f c ↔ a = c) ∨ P.Rel a b := by
+  obtain h1 | h2 := hf.forall_apply_eq_apply_iff a
+  · refine ⟨by grind, ?_⟩
+    rintro (h | h)
+    · exact congrArg _ h.1
+    exact hf.apply_eq_apply h
+  grind
+
+lemma idem (hf : IsRepFun P f) : f (f a) = f a := by
+  obtain (ha | ha) := em (a ∈ P.supp)
+  · rw [eq_comm, hf.apply_eq_apply_iff_rel ha]
+    exact hf.rel_apply ha
+  simp_rw [hf.apply_of_notMem ha]
+
+theorem apply_apply (hf : IsRepFun P f) (hg : IsRepFun P g) (x : α) : f (g x) = f x := by
+  obtain (hx | hx) := em (x ∈ P.supp)
+  · exact hf.apply_eq_apply (hg.rel_apply hx).symm
+  rw [hg.apply_of_notMem hx, hf.apply_of_notMem hx]
+
+/-- Any partially defined representative function extends to a complete one. -/
+lemma exists_extend_partial (P : Partition (Set α)) (f₀ : t → α)
+    (h_notMem : ∀ x : t, x.1 ∉ P.supp → f₀ x = x) (h_mem : ∀ x : t, x.1 ∈ P.supp → P.Rel x (f₀ x))
+    (h_eq : ∀ x y : t, P.Rel x y → f₀ x = f₀ y) : ∃ f, IsRepFun P f ∧ ∀ x : t, f x = f₀ x := by
+  classical
+  set f : α → α := fun a ↦ if ha : a ∈ P.supp then
+    (if hb : ∃ b : t, P.Rel a b then f₀ hb.choose else P.rep (P.partOf_mem ha)) else a with hfdef
+  refine ⟨f, ⟨fun a ha ↦ by simp [hfdef, ha], fun a ha ↦ ?_, fun a b hab ↦ ?_⟩, fun a ↦ ?_⟩
+  · simp only [hfdef, ha, ↓reduceDIte]
+    split_ifs with h
+    · exact h.choose_spec.trans <| h_mem h.choose h.choose_spec.right_mem
+    push Not at h
+    exact P.rep_rel (P.partOf_mem ha) (P.mem_partOf ha)
+  · simp_rw [hfdef, dif_pos hab.left_mem, dif_pos hab.right_mem]
+    split_ifs with h₁ h₂ h₂
+    · exact h_eq _ _ <| (hab.symm.trans h₁.choose_spec).symm.trans h₂.choose_spec
+    · exact h₂ ⟨_, hab.symm.trans h₁.choose_spec⟩ |>.elim
+    · exact h₁ ⟨_, hab.trans h₂.choose_spec⟩ |>.elim
+    congr 1
+    rwa [← rel_iff_partOf_eq_partOf_of_mem _ hab.left_mem hab.right_mem]
+  obtain (ha | ha) := em (a.1 ∈ P.supp) |>.symm
+  · simp [hfdef, ha, h_notMem _ ha]
+  simp only [hfdef, ha, ↓reduceDIte]
+  split_ifs with h
+  · exact h_eq _ _ h.choose_spec |>.symm
+  exact h ⟨a, rel_rfl_iff.mpr ha⟩ |>.elim
+
+/-- For any set `t` containing no two distinct related elements, there is a representative function
+equal to the identity on `t`. -/
+lemma exists_extend_partial' (P : Partition (Set α))
+    (h : ∀ ⦃x y⦄, x ∈ t → y ∈ t → P.Rel x y → x = y) : ∃ f, IsRepFun P f ∧ EqOn f id t := by
+  simpa using! exists_extend_partial P (fun x : t ↦ x) (by simp) (by simp) (fun x y ↦ h x.2 y.2)
+
+/-- Every partition has a representative function. -/
+lemma nonempty (P : Partition (Set α)) : ∃ f, IsRepFun P f := by
+  obtain ⟨f, hf, -⟩ := exists_extend_partial' P (t := ∅) (by simp)
+  exact ⟨f, hf⟩
+
+end IsRepFun
+
+end Partition

--- a/Mathlib/Order/Partition/Set.lean
+++ b/Mathlib/Order/Partition/Set.lean
@@ -19,6 +19,7 @@ support is the set of all `x` for which `r x x`.
 ## Main declarations
 
 * `Partition.Rel`: The partial equivalence relation induced by a partition of a set.
+* `Partition.ofRel`: Reconstruct a partition from a transitive, symmetric relation.
 * `Partition.partOf`: The part of a partition containing a given element.
 * `Partition.IsRepFun`: A predicate characterizing a representative function for a partition.
 
@@ -160,6 +161,54 @@ lemma Rel.right_mem (h : P.Rel x y) : y ∈ P.supp := h.symm.left_mem
 
 /-- Any element of a part is related to the representative of that part. -/
 lemma rep_rel (ht : t ∈ P) (hx : x ∈ t) : P.Rel x (P.rep ht) := ⟨t, ht, hx, P.rep_mem ht⟩
+
+/-- The relation induced by a partition determines the partition. -/
+lemma rel_injective : Function.Injective (Rel : Partition (Set α) → α → α → Prop) :=
+  fun _ _ h ↦ le_antisymm (rel_le_iff_le.1 h.le) (rel_le_iff_le.1 h.ge)
+
+@[simp]
+lemma rel_inj : P.Rel = Q.Rel ↔ P = Q := rel_injective.eq_iff
+
+/-- A transitive, symmetric relation induces a partition of its self-related elements.
+Parts are the sets `{y | r y x}` for each `x` satisfying `r x x`. -/
+def ofRel (r : α → α → Prop) [IsTrans α r] [Std.Symm r] : Partition (Set α) :=
+  removeBot ((fun x ↦ {y | r y x}) '' {x | r x x}) <| PairwiseDisjoint.sSupIndep <| by
+    rintro _ ⟨x, -, rfl⟩ _ ⟨y, -, rfl⟩ hne
+    rw [Function.onFun, disjoint_iff_inter_eq_empty]
+    ext z
+    simp only [id_eq, mem_inter_iff, mem_ofPred_eq, mem_empty_iff_false, iff_false, not_and]
+    intro hzx hzy
+    refine hne <| Set.ext fun w ↦ ?_
+    have hxy : r x y := trans_of r (symm_of r hzx) hzy
+    exact ⟨fun hwx ↦ trans_of r hwx hxy, fun hwy ↦ trans_of r hwy (symm_of r hxy)⟩
+
+@[simp]
+lemma mem_ofRel_iff (r : α → α → Prop) [IsTrans α r] [Std.Symm r] : s ∈ ofRel r ↔
+    ∃ x, r x x ∧ s = {y | r y x} := by
+  simp only [ofRel, mem_removeBot, mem_image, mem_ofPred, ne_eq, bot_eq_empty]
+  constructor
+  · rintro ⟨⟨x, hxx, rfl⟩, -⟩
+    exact ⟨x, hxx, rfl⟩
+  · rintro ⟨x, hxx, rfl⟩
+    exact ⟨⟨x, hxx, rfl⟩, nonempty_iff_ne_empty.mp ⟨x, hxx⟩⟩
+
+@[simp]
+lemma rel_ofRel_eq (r : α → α → Prop) [IsTrans α r] [Std.Symm r] : (ofRel r).Rel = r := by
+  ext a b
+  refine ⟨fun ⟨s, hs, ha, hb⟩ ↦ ?_, fun hab ↦ ⟨{y | r y b}, (mem_ofRel_iff r).mpr ⟨b,
+    trans_of r (symm_of r hab) hab, rfl⟩, hab, trans_of r (symm_of r hab) hab⟩⟩
+  obtain ⟨x, -, rfl, -⟩ := (mem_ofRel_iff r).1 hs
+  exact trans_of r ha (symm_of r hb)
+
+@[simp]
+lemma supp_ofRel (r : α → α → Prop) [IsTrans α r] [Std.Symm r] : (ofRel r).supp = {a | r a a} := by
+  ext a
+  rw [← rel_rfl_iff, rel_ofRel_eq]
+  rfl
+
+@[simp]
+lemma ofRel_rel_eq (P : Partition (Set α)) : ofRel P.Rel = P :=
+  rel_injective (by simp)
 
 end Rel
 

--- a/Mathlib/Order/Partition/Set.lean
+++ b/Mathlib/Order/Partition/Set.lean
@@ -70,7 +70,6 @@ lemma mem_supp_iff : x ∈ P.supp ↔ ∃ t ∈ P, x ∈ t := by
 lemma eq_of_mem_inter (ht : t ∈ P) (hs : s ∈ P) (hx : x ∈ t ∩ s) : t = s :=
   P.pairwiseDisjoint.elim ht hs fun (hdj : Disjoint t s) ↦ by simp [hdj.inter_eq] at hx
 
-@[grind →]
 lemma eq_of_mem_of_mem (ht : t ∈ P) (hus : s ∈ P) (hxt : x ∈ t) (hxs : x ∈ s) : t = s :=
   eq_of_mem_inter ht hus ⟨hxt, hxs⟩
 
@@ -130,7 +129,7 @@ lemma Rel.forall (h : P.Rel x y) (ht : t ∈ P) : x ∈ t ↔ y ∈ t := by
   exact ⟨fun h ↦ by rwa [P.eq_of_mem_of_mem ht ht' h hx],
     fun h ↦ by rwa [P.eq_of_mem_of_mem ht ht' h hy]⟩
 
-@[simp]
+@[simp, grind =]
 lemma rel_rfl_iff : P.Rel x x ↔ x ∈ P.supp := by
   refine ⟨fun ⟨t, ht, hxP, _⟩ ↦ subset_of_mem ht hxP, fun hx ↦ ?_⟩
   obtain ⟨t, ⟨ht, hxt⟩, -⟩ := P.mem_supp_iff_unique.mp hx
@@ -143,19 +142,16 @@ instance (P : Partition (Set α)) : IsTrans α P.Rel where
   trans _ _ _ := fun ⟨t, ht, ha, hb⟩ ⟨t', ht', hb', hc⟩ ↦
     ⟨t, ht, ha, by rwa [eq_of_mem_of_mem ht ht' hb hb']⟩
 
-@[symm, grind →] lemma Rel.symm (h : P.Rel x y) : P.Rel y x := symm_of P.Rel h
+@[symm] lemma Rel.symm (h : P.Rel x y) : P.Rel y x := symm_of P.Rel h
 
 lemma rel_comm : P.Rel x y ↔ P.Rel y x := ⟨Rel.symm, Rel.symm⟩
 
-@[grind →]
 lemma Rel.trans (hxy : P.Rel x y) (hyz : P.Rel y z) : P.Rel x z := trans_of P.Rel hxy hyz
 
-@[grind →]
 lemma Rel.left_mem (h : P.Rel x y) : x ∈ P.supp := by
   obtain ⟨t, htP, hxt, -⟩ := h
   exact subset_of_mem htP hxt
 
-@[grind →]
 lemma Rel.right_mem (h : P.Rel x y) : y ∈ P.supp := h.symm.left_mem
 
 /-- Any element of a part is related to the representative of that part. -/
@@ -173,17 +169,15 @@ lemma partOf_subset : P.partOf x ⊆ P.supp := fun _ ⟨_, ht, _, hyt⟩ ↦ sub
 
 @[simp, grind =] lemma mem_partOf_iff : x ∈ P.partOf y ↔ P.Rel y x := Iff.rfl
 
-@[grind →]
 lemma eq_partOf_of_mem (ht : t ∈ P) (hxt : x ∈ t) : t = P.partOf x := by
   ext y
   exact ⟨(⟨t, ht, hxt, ·⟩), fun ⟨s, hsP, hxs, hys⟩ ↦ (P.eq_of_mem_of_mem ht hsP hxt hxs) ▸ hys⟩
 
-lemma mem_iff_mem_partOf_mem : x ∈ P.supp ↔ x ∈ P.partOf x ∧ P.partOf x ∈ P := by grind
+lemma mem_iff_mem_partOf_mem : x ∈ P.supp ↔ x ∈ P.partOf x ∧ P.partOf x ∈ P := by
+  grind [eq_partOf_of_mem]
 
-@[grind →]
 lemma mem_partOf (hxu : x ∈ P.supp) : x ∈ P.partOf x := (P.mem_iff_mem_partOf_mem.mp hxu).1
 
-@[grind →]
 lemma partOf_mem (hxu : x ∈ P.supp) : P.partOf x ∈ P := (P.mem_iff_mem_partOf_mem.mp hxu).2
 
 @[simp]
@@ -197,10 +191,11 @@ lemma partOf_nonempty_iff : (P.partOf x).Nonempty ↔ x ∈ P.supp := by
   refine ⟨fun ⟨y, hy⟩ ↦ hy.left_mem, fun h ↦ ?_⟩
   simpa [nonempty_iff_ne_empty] using P.ne_bot_of_mem (partOf_mem h)
 
-@[simp]
+@[simp, grind =]
 lemma partOf_eq_empty_iff : P.partOf x = ∅ ↔ x ∉ P.supp := by
   rw [← partOf_nonempty_iff, not_nonempty_iff_eq_empty]
 
+@[grind =_]
 lemma rel_iff_partOf_eq_partOf_of_mem (P : Partition (Set α)) (hx : x ∈ P.supp) (hy : y ∈ P.supp) :
     P.Rel x y ↔ P.partOf x = P.partOf y := by
   refine ⟨fun ⟨t, htP, hxt, hyt⟩ ↦ eq_partOf_of_mem (P.partOf_mem hx) ?_,
@@ -209,7 +204,7 @@ lemma rel_iff_partOf_eq_partOf_of_mem (P : Partition (Set α)) (hx : x ∈ P.sup
 
 lemma rel_iff_partOf_eq_partOf (P : Partition (Set α)) :
     P.Rel x y ↔ ∃ (_ : x ∈ P.supp) (_ : y ∈ P.supp), P.partOf x = P.partOf y := by
-  grind [rel_iff_partOf_eq_partOf_of_mem]
+  grind [rel_iff_partOf_eq_partOf_of_mem, Rel.left_mem, Rel.right_mem]
 
 end partOf
 
@@ -230,8 +225,6 @@ structure IsRepFun (P : Partition (Set α)) (f : α → α) : Prop where
   rel_apply : ∀ ⦃a⦄, a ∈ P.supp → P.Rel a (f a)
   /-- The function maps related elements to the same representative. -/
   apply_eq_apply : ∀ ⦃a b⦄, P.Rel a b → f a = f b
-
-attribute [grind →] IsRepFun.apply_of_notMem IsRepFun.rel_apply IsRepFun.apply_eq_apply
 
 namespace IsRepFun
 
@@ -254,10 +247,23 @@ lemma mapsTo_of_disjoint (hf : IsRepFun P f) (hs : Disjoint P.supp s) : Set.Maps
 lemma apply_mem_iff (hf : IsRepFun P f) (hs : P.supp ⊆ s) : f a ∈ s ↔ a ∈ s :=
   hf.mapsTo hs |>.mem_iff <| mapsTo_of_disjoint hf hs.disjoint_compl_right
 
-lemma apply_eq_apply_iff_rel (hf : IsRepFun P f) (ha : a ∈ P.supp) : f a = f b ↔ P.Rel a b :=
-  ⟨fun hab ↦ (hf.rel_apply ha).trans (by grind), (hf.apply_eq_apply ·)⟩
+lemma apply_eq_apply_iff_rel (hf : IsRepFun P f) (ha : a ∈ P.supp) : f a = f b ↔ P.Rel a b := by
+  refine ⟨fun hab ↦ ?_, (hf.apply_eq_apply ·)⟩
+  by_cases hb : b ∈ P.supp
+  · exact (hf.rel_apply ha).trans <| by simpa [hab] using (hf.rel_apply hb).symm
+  simpa [hab.trans (hf.apply_of_notMem hb)] using hf.rel_apply ha
 
-lemma apply_eq_apply_iff (hf : IsRepFun P f) : f a = f b ↔ a = b ∨ P.Rel a b := by grind
+@[grind =>]
+lemma apply_eq_apply_iff (hf : IsRepFun P f) : f a = f b ↔ a = b ∨ P.Rel a b := by
+  refine ⟨fun hab ↦ ?_, ?_⟩
+  · by_cases ha : a ∈ P.supp
+    · exact Or.inr <| hf.apply_eq_apply_iff_rel ha |>.mp hab
+    by_cases hb : b ∈ P.supp
+    · exact (ha <| hf.apply_of_notMem ha ▸ hab.symm ▸ hf.apply_mem hb).elim
+    exact Or.inl <| (hf.apply_of_notMem ha).symm.trans <| hab.trans <| hf.apply_of_notMem hb
+  rintro (rfl | hab)
+  · rfl
+  exact hf.apply_eq_apply hab
 
 lemma forall_apply_eq_apply_iff (hf : IsRepFun P f) (a) :
     (∀ (x : α), f a = f x ↔ a = x) ∨ (∀ (x : α), f a = f x ↔ P.Rel a x) := by
@@ -270,13 +276,20 @@ lemma forall_apply_eq_apply_iff (hf : IsRepFun P f) (a) :
 
 lemma apply_eq_apply_iff' (hf : IsRepFun P f) :
     f a = f b ↔ (a = b ∧ ∀ c, f a = f c ↔ a = c) ∨ P.Rel a b := by
-  obtain h1 | h2 := hf.forall_apply_eq_apply_iff a <;> grind
+  refine ⟨fun hab ↦ by grind [hf.forall_apply_eq_apply_iff a], ?_⟩
+  rintro (⟨rfl, -⟩ | hab)
+  · rfl
+  exact hf.apply_eq_apply hab
 
 lemma idem (hf : IsRepFun P f) : f (f a) = f a := by
-  obtain (ha | ha) := em (a ∈ P.supp) <;> grind
+  by_cases ha : a ∈ P.supp
+  · exact (hf.apply_eq_apply <| hf.rel_apply ha).symm
+  simp only [hf.apply_of_notMem ha]
 
 theorem apply_apply (hf : IsRepFun P f) (hg : IsRepFun P g) (x : α) : f (g x) = f x := by
-  obtain (hx | hx) := em (x ∈ P.supp) <;> grind
+  by_cases hx : x ∈ P.supp
+  · exact (hf.apply_eq_apply <| hg.rel_apply hx).symm
+  rw [hg.apply_of_notMem hx]
 
 /-- Any partially defined representative function extends to a complete one. -/
 lemma exists_extend_partial (P : Partition (Set α)) (f₀ : t → α)
@@ -292,7 +305,12 @@ lemma exists_extend_partial (P : Partition (Set α)) (f₀ : t → α)
     push Not at h
     exact P.rep_rel (P.partOf_mem ha) (P.mem_partOf ha)
   · simp_rw [hfdef, dif_pos hab.left_mem, dif_pos hab.right_mem]
-    split_ifs with h₁ h₂ h₂ <;> grind
+    split_ifs with h₁ h₂ h₂
+    · exact h_eq _ _ <| (h₁.choose_spec.symm.trans hab).trans h₂.choose_spec
+    · exact (h₂ ⟨h₁.choose, hab.symm.trans h₁.choose_spec⟩).elim
+    · exact (h₁ ⟨h₂.choose, hab.trans h₂.choose_spec⟩).elim
+    congr 1
+    exact (P.rel_iff_partOf_eq_partOf_of_mem hab.left_mem hab.right_mem).mp hab
   obtain (ha | ha) := em (a.1 ∈ P.supp) |>.symm
   · simp [hfdef, ha, h_notMem _ ha]
   simp only [hfdef, ha, ↓reduceDIte]

--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -290,6 +290,15 @@ theorem sSupIndep.mono {t : Set α} (hst : t ⊆ s) : sSupIndep t := fun _ ha =>
   (hs (hst ha)).mono_right (sSup_le_sSup (sdiff_subset_sdiff_left hst))
 
 include hs in
+/-- The image of an independent set under a map satisfying `f i ≤ i` on `s` is independent. -/
+theorem sSupIndep.image_of_le_self {f : α → α} (hf : ∀ i ∈ s, f i ≤ i) : sSupIndep (f '' s) := by
+  rintro t ⟨x, hxS, rfl⟩
+  refine hs hxS |>.mono (hf x hxS) ?_
+  simp only [sSup_le_iff, mem_sdiff, mem_image, mem_singleton_iff, and_imp, forall_exists_index,
+    forall_apply_eq_imp_iff₂]
+  refine fun y hyS hne ↦ (hf y hyS).trans <| le_sSup <| by grind
+
+include hs in
 /-- If the elements of a set are independent, then any pair within that set is disjoint. -/
 theorem sSupIndep.pairwiseDisjoint : s.PairwiseDisjoint id := fun _ hx y hy h =>
   disjoint_sSup_right (hs hx) ((mem_sdiff y).mpr ⟨hy, h.symm⟩)


### PR DESCRIPTION
When `α` is a frame, this PR equips `Partition α` with a complete lattice structure under refinement.

Infima are constructed by choosing one part from each partition, taking their infimum, and removing `⊥`. Suprema are constructed by grouping the union of the parts into connected components under non-disjointness, then taking the supremum of each component.

This also adds:

* `Partition.ofRel`, which constructs a partition from a transitive symmetric relation, together with inverse lemmas for `Partition.Rel`;
* characterizations of membership in `sSup`, `iSup`, and binary suprema;
* simp lemmas computing the supports of these suprema.

This PR is partially generated by AI: Partition API written by myself in [Matroid repo](https://github.com/apnelson1/Matroid) has be adapted using codex and final checked by myself.

Co-authored-by: OpenAI Codex <codex@openai.com>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #42195

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
