### PR TITLE
[Merged by Bors] - perf(LinearAlgebra/TensorProduct/Tower): remove unused P' instance binders

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -68,8 +68,8 @@ variable [AddCommMonoid N] [Module R N]
 variable [AddCommMonoid P] [Module R P] [Module A P]
 variable [IsScalarTower R A P]
 variable [AddCommMonoid Q] [Module R Q]
-variable [AddCommMonoid P'] [Module R P'] [Module A P'] [Module B P']
-variable [IsScalarTower R A P'] [IsScalarTower R B P'] [SMulCommClass A B P']
+variable [AddCommMonoid P'] [Module R P'] [Module A P']
+variable [IsScalarTower R A P']
 variable [AddCommMonoid Q'] [Module R Q']
 
 theorem smul_eq_lsmul_rTensor (a : A) (x : M ⊗[R] N) : a • x = (lsmul R R M a).rTensor N x :=


### PR DESCRIPTION
The Semiring section of this file declares `[Module B P']`, `[IsScalarTower R B P']`, and `[SMulCommClass A B P']`. The three declarations that use `P'` (`map_comp`, `rTensor_comp`, `congr_trans`) need only the `R`/`A`-side instances. No other declaration mentions `P'`. The unused binders are candidates in every `IsScalarTower` and `SMulCommClass` search in the section.

This PR removes the three unused instance binders. No signature changes: a full dump of the module's constant types is identical before and after. Standalone elaboration of the file goes from 5.47 s to 5.15 s (medians of 6 interleaved runs, −6 %).

Same mechanism as #42214 and #42238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)