### PR TITLE
[Merged by Bors] - perf(Geometry/Manifold/MFDeriv/SpecificFunctions): remove F₃/F₄ and scope F₁/F₂

### DIFF
--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -406,7 +406,7 @@ section prod_module
 -- `F₁` and `F₂` are normed spaces.
 variable {F₁ : Type*} [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
   {F₂ : Type*} [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
-variable {s : Set M} {x : M}
+  {s : Set M} {x : M}
 
 theorem mdifferentiableWithinAt_prod_module_iff (f : M → F₁ × F₂) :
     MDifferentiableWithinAt I 𝓘(𝕜, F₁ × F₂) f s x ↔

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -52,11 +52,6 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {F' : Type*}
   [NormedAddCommGroup F'] [NormedSpace 𝕜 F'] {G' : Type*} [TopologicalSpace G']
   {J' : ModelWithCorners 𝕜 F' G'} {N' : Type*} [TopologicalSpace N'] [ChartedSpace G' N']
-  -- F₁, F₂, F₃, F₄ are normed spaces
-  {F₁ : Type*}
-  [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁] {F₂ : Type*} [NormedAddCommGroup F₂]
-  [NormedSpace 𝕜 F₂] {F₃ : Type*} [NormedAddCommGroup F₃] [NormedSpace 𝕜 F₃] {F₄ : Type*}
-  [NormedAddCommGroup F₄] [NormedSpace 𝕜 F₄]
 
 namespace ContinuousLinearMap
 
@@ -406,6 +401,13 @@ theorem mdifferentiableWithinAt_prod_iff (f : M → M' × N') :
     MDiffAt[s] f x ↔ MDiffAt[s] (Prod.fst ∘ f) x ∧ MDiffAt[s] (Prod.snd ∘ f) x :=
   ⟨fun h ↦ ⟨h.fst, h.snd⟩, fun h ↦ h.1.prodMk h.2⟩
 
+section prod_module
+
+-- `F₁` and `F₂` are normed spaces.
+variable {F₁ : Type*} [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
+  {F₂ : Type*} [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
+variable {s : Set M} {x : M}
+
 theorem mdifferentiableWithinAt_prod_module_iff (f : M → F₁ × F₂) :
     MDifferentiableWithinAt I 𝓘(𝕜, F₁ × F₂) f s x ↔
       MDiffAt[s] (Prod.fst ∘ f) x ∧ MDiffAt[s] (Prod.snd ∘ f) x := by
@@ -441,6 +443,8 @@ theorem mdifferentiable_prod_module_iff (f : M → F₁ × F₂) :
     MDifferentiable I 𝓘(𝕜, F₁ × F₂) f ↔ MDiff (Prod.fst ∘ f) ∧ MDiff (Prod.snd ∘ f) := by
   rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
   exact mdifferentiable_prod_iff f
+
+end prod_module
 
 
 section prodMap


### PR DESCRIPTION
The section variable block of this file declares four normed spaces `F₁`–`F₄` with eight instance binders. No declaration uses `F₃` or `F₄`. Only the four `*_prod_module_iff` lemmas use `F₁` and `F₂`. The unused instance binders are candidates in every typeclass search in the file.

This PR deletes `F₃`/`F₄` and declares `F₁`/`F₂` in a section around their four users. The section redeclares `s`/`x` after `F₁`/`F₂`, so the binder order of every declaration is unchanged. A full dump of the module's constant types is identical before and after. Standalone elaboration of the file goes from 5.40 s to 5.09 s (medians of 5 interleaved runs, −6 %).

Same mechanism as #42214 and #42238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)