### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions/ImproperIntegrals): add not_integrableOn_Ioi_rpow_of_neg_one_le

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -166,6 +166,12 @@ theorem not_integrableOn_Ioi_rpow (s : ℝ) : ¬ IntegrableOn (fun x ↦ x ^ s) 
     rw [integrableOn_Ioi_rpow_iff zero_lt_one] at this
     exact hs.not_gt this
 
+theorem not_integrableOn_Ioi_rpow' {a s : ℝ} (ha : 0 ≤ a) (hs : -1 ≤ s) :
+    ¬IntegrableOn (fun (x : ℝ) ↦ x ^ s) (Ioi a) volume := by
+  rcases ha.eq_or_lt with rfl | ha
+  · exact not_integrableOn_Ioi_rpow s
+  · rwa [integrableOn_Ioi_rpow_iff ha, not_lt]
+
 theorem setIntegral_Ioi_zero_rpow (s : ℝ) : ∫ x in Ioi (0 : ℝ), x ^ s = 0 :=
   MeasureTheory.integral_undef (not_integrableOn_Ioi_rpow s)
 

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -166,11 +166,12 @@ theorem not_integrableOn_Ioi_rpow (s : ℝ) : ¬ IntegrableOn (fun x ↦ x ^ s) 
     rw [integrableOn_Ioi_rpow_iff zero_lt_one] at this
     exact hs.not_gt this
 
-theorem not_integrableOn_Ioi_rpow' {a s : ℝ} (ha : 0 ≤ a) (hs : -1 ≤ s) :
+theorem not_integrableOn_Ioi_rpow_of_neg_one_le {a s : ℝ} (hs : -1 ≤ s) :
     ¬IntegrableOn (fun (x : ℝ) ↦ x ^ s) (Ioi a) volume := by
-  rcases ha.eq_or_lt with rfl | ha
-  · exact not_integrableOn_Ioi_rpow s
-  · rwa [integrableOn_Ioi_rpow_iff ha, not_lt]
+  have hpos : (0 : ℝ) < max a 1 := by simp
+  refine fun h ↦ not_lt.mpr hs ?_
+  rw [← integrableOn_Ioi_rpow_iff hpos]
+  exact h.mono_set (Ioi_subset_Ioi (le_max_left a 1))
 
 theorem setIntegral_Ioi_zero_rpow (s : ℝ) : ∫ x in Ioi (0 : ℝ), x ^ s = 0 :=
   MeasureTheory.integral_undef (not_integrableOn_Ioi_rpow s)

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -168,10 +168,9 @@ theorem not_integrableOn_Ioi_rpow (s : ℝ) : ¬ IntegrableOn (fun x ↦ x ^ s) 
 
 theorem not_integrableOn_Ioi_rpow_of_neg_one_le {a s : ℝ} (hs : -1 ≤ s) :
     ¬IntegrableOn (fun (x : ℝ) ↦ x ^ s) (Ioi a) volume := by
-  have hpos : (0 : ℝ) < max a 1 := by simp
   refine fun h ↦ not_lt.mpr hs ?_
-  rw [← integrableOn_Ioi_rpow_iff hpos]
-  exact h.mono_set (Ioi_subset_Ioi (le_max_left a 1))
+  rw [← integrableAtFilter_rpow_atTop_iff]
+  exact ⟨Ioi a, Ioi_mem_atTop a, h⟩
 
 theorem setIntegral_Ioi_zero_rpow (s : ℝ) : ∫ x in Ioi (0 : ℝ), x ^ s = 0 :=
   MeasureTheory.integral_undef (not_integrableOn_Ioi_rpow s)

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -167,7 +167,7 @@ theorem not_integrableOn_Ioi_rpow (s : ℝ) : ¬ IntegrableOn (fun x ↦ x ^ s) 
     exact hs.not_gt this
 
 theorem not_integrableOn_Ioi_rpow_of_neg_one_le {a s : ℝ} (hs : -1 ≤ s) :
-    ¬IntegrableOn (fun x ↦ x ^ s) (Ioi a) := by
+    ¬ IntegrableOn (fun x ↦ x ^ s) (Ioi a) := by
   refine fun h ↦ not_lt.mpr hs ?_
   rw [← integrableAtFilter_rpow_atTop_iff]
   exact ⟨Ioi a, Ioi_mem_atTop a, h⟩

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -167,7 +167,7 @@ theorem not_integrableOn_Ioi_rpow (s : ℝ) : ¬ IntegrableOn (fun x ↦ x ^ s) 
     exact hs.not_gt this
 
 theorem not_integrableOn_Ioi_rpow_of_neg_one_le {a s : ℝ} (hs : -1 ≤ s) :
-    ¬IntegrableOn (fun (x : ℝ) ↦ x ^ s) (Ioi a) volume := by
+    ¬IntegrableOn (fun x ↦ x ^ s) (Ioi a) := by
   refine fun h ↦ not_lt.mpr hs ?_
   rw [← integrableAtFilter_rpow_atTop_iff]
   exact ⟨Ioi a, Ioi_mem_atTop a, h⟩


### PR DESCRIPTION
From the Carleson project.

-------

**Upstreaming from Carleson: [/Carleson/ToMathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean](https://github.com/fpvandoorn/carleson/blob/0072b6e47ec58ac13be0a9f3b7c17e9f3bb1be2e/Carleson/ToMathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean)**

### Changes from carleson

- **generalized**
  Removed `(ha : 0 ≤ a)` hypothesis
- **renamed from `theorem not_integrableOn_Ioi_rpow'` to `theorem not_integrableOn_Ioi_rpow_of_neg_one_le`**
  A more descriptive name
  
### Signatures

```lean
-- CARLESON
not_integrableOn_Ioi_rpow' {a s : ℝ} (ha : 0 ≤ a) (hs : -1 ≤ s) : ¬IntegrableOn (fun x ↦ x ^ s) (Ioi a) volume
-- MATHLIB
not_integrableOn_Ioi_rpow_of_neg_one_le {a s : ℝ} (hs : -1 ≤ s) : ¬IntegrableOn (fun x ↦ x ^ s) (Ioi a) volume
```