### PR TITLE
feat(Analysis/Convex): the convex join of a compact and a closed bounded set is closed

### DIFF
--- a/Mathlib/Analysis/Convex/Join.lean
+++ b/Mathlib/Analysis/Convex/Join.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies
 module
 
 public import Mathlib.Analysis.Convex.Hull
+public import Mathlib.Analysis.LocallyConvex.Bounded
 
 /-!
 # Convex join
@@ -13,6 +14,15 @@ public import Mathlib.Analysis.Convex.Hull
 This file defines the convex join of two sets. The convex join of `s` and `t` is the union of the
 segments with one end in `s` and the other in `t`. This is notably a useful gadget to deal with
 convex hulls of finite sets.
+
+In a topological vector space we also show that the convex join of a compact closed set and a
+closed von Neumann bounded set is closed, and deduce that the convex hull of the union of a
+compact convex set and a closed bounded convex set is closed.
+
+## References
+
+* [C. D. Aliprantis and K. C. Border, *Infinite Dimensional Analysis*][aliprantis_border2006],
+  Lemma 5.37
 -/
 
 @[expose] public section
@@ -192,3 +202,70 @@ theorem convexJoin_singleton_segment (a b c : E) :
   rw [← segment_same 𝕜, convexJoin_segments, insert_idem]
 
 end LinearOrderedField
+
+section Topology
+open Bornology Filter
+open scoped Pointwise Topology
+
+variable [NormedField 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [CompactIccSpace 𝕜]
+  [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E] [IsTopologicalAddGroup E]
+  [ContinuousSMul 𝕜 E] {s t : Set E}
+
+/-- The convex join of a compact closed set and a closed von Neumann bounded set is closed. -/
+theorem IsCompact.isClosed_convexJoin (hs : IsCompact s) (hs' : IsClosed s) (ht : IsClosed t)
+    (htb : IsVonNBounded 𝕜 t) : IsClosed (convexJoin 𝕜 s t) := by
+  rcases t.eq_empty_or_nonempty with rfl | ht₀
+  · simp
+  -- Parametrise the join by `Φ (θ, a, b) = (1 - θ) • a + θ • b` over `S = [0, 1] ×ˢ s ×ˢ t`.
+  set Φ : 𝕜 × E × E → E := fun p ↦ (1 - p.1) • p.2.1 + p.1 • p.2.2 with hΦ
+  set S : Set (𝕜 × E × E) := Icc 0 1 ×ˢ s ×ˢ t
+  have himg : convexJoin 𝕜 s t ⊆ Φ '' S := fun y hy ↦ by
+    obtain ⟨a, ha, b, hb, p, q, hp, hq, hpq, rfl⟩ := mem_convexJoin.1 hy
+    exact ⟨(q, a, b), ⟨⟨hq, by linarith⟩, ha, hb⟩, by simp [hΦ, show (1 : 𝕜) - q = p by linarith]⟩
+  rw [isClosed_iff_forall_filter]
+  intro x F hF hFs hFx
+  -- Lift a filter converging to `x` inside the join to an ultrafilter on the parameter space.
+  have : (comap Φ F ⊓ 𝓟 S).NeBot :=
+    comap_inf_principal_neBot_of_image_mem hF (mem_of_superset (le_principal_iff.1 hFs) himg)
+  obtain ⟨u, hu⟩ := Ultrafilter.exists_le (comap Φ F ⊓ 𝓟 S)
+  have hSu : S ∈ u := le_principal_iff.1 (hu.trans inf_le_right)
+  have hΦu : Tendsto Φ ↑u (𝓝 x) :=
+    ((map_mono (hu.trans inf_le_left)).trans map_comap_le).trans hFx
+  -- Compactness of `[0, 1]` and of `s` makes the first two parameters converge along `u`.
+  obtain ⟨θ, hθ, hθu⟩ : ∃ θ ∈ Icc (0 : 𝕜) 1, Tendsto (fun p : 𝕜 × E × E ↦ p.1) ↑u (𝓝 θ) :=
+    isCompact_Icc.ultrafilter_le_nhds' (u.map fun p : 𝕜 × E × E ↦ p.1)
+      (Ultrafilter.mem_map.2 <| by filter_upwards [hSu] with p hp using hp.1)
+  obtain ⟨a, ha, hau⟩ : ∃ a ∈ s, Tendsto (fun p : 𝕜 × E × E ↦ p.2.1) ↑u (𝓝 a) :=
+    hs.ultrafilter_le_nhds' (u.map fun p : 𝕜 × E × E ↦ p.2.1)
+      (Ultrafilter.mem_map.2 <| by filter_upwards [hSu] with p hp using hp.2.1)
+  rcases eq_or_ne θ 0 with rfl | hθ₀
+  · -- If `θ → 0`, boundedness crushes the third parameter and `x` is a limit of points of `s`.
+    have hbdd : Tendsto (fun p : 𝕜 × E × E ↦ p.1 • (p.2.2 - p.2.1)) ↑u (𝓝 0) :=
+      (htb.sub (hs.isVonNBounded 𝕜)).smul_tendsto_zero
+        (by filter_upwards [hSu] with p hp using sub_mem_sub hp.2.2 hp.2.1) hθu
+    have h : Tendsto (fun p : 𝕜 × E × E ↦ p.2.1) ↑u (𝓝 x) := sub_zero x ▸
+      (hΦu.sub hbdd).congr fun p ↦ by simp only [hΦ, sub_smul, smul_sub, one_smul]; abel
+    exact subset_convexJoin_left ht₀
+      (hs'.mem_of_tendsto h (by filter_upwards [hSu] with p hp using hp.2.1))
+  · -- Otherwise the third parameter converges to `θ⁻¹ • (x - (1 - θ) • a)`, which lies in `t`.
+    have hb : Tendsto (fun p : 𝕜 × E × E ↦ p.2.2) ↑u (𝓝 (θ⁻¹ • (x - (1 - θ) • a))) := by
+      refine Tendsto.congr' ?_
+        ((hθu.inv₀ hθ₀).smul (hΦu.sub ((tendsto_const_nhds.sub hθu).smul hau)))
+      filter_upwards [hθu.eventually_ne hθ₀] with p hp
+      simp [hΦ, inv_smul_smul₀ hp]
+    have hbt := ht.mem_of_tendsto hb (by filter_upwards [hSu] with p hp using hp.2.2)
+    rw [show x = (1 - θ) • a + θ • (θ⁻¹ • (x - (1 - θ) • a)) by rw [smul_inv_smul₀ hθ₀]; abel]
+    exact segment_subset_convexJoin ha hbt ⟨1 - θ, θ, sub_nonneg.2 hθ.2, hθ.1, by ring, rfl⟩
+
+/-- The convex hull of the union of a compact convex set and a closed von Neumann bounded convex
+set is closed. -/
+theorem IsCompact.isClosed_convexHull_union [T2Space E] (hs : IsCompact s) (hs' : Convex 𝕜 s)
+    (ht : IsClosed t) (ht' : Convex 𝕜 t) (htb : IsVonNBounded 𝕜 t) :
+    IsClosed (convexHull 𝕜 (s ∪ t)) := by
+  rcases s.eq_empty_or_nonempty with rfl | hs₀
+  · simpa [ht'.convexHull_eq] using ht
+  rcases t.eq_empty_or_nonempty with rfl | ht₀
+  · simpa [hs'.convexHull_eq] using hs.isClosed
+  exact hs'.convexHull_union ht' hs₀ ht₀ ▸ hs.isClosed_convexJoin hs.isClosed ht htb
+
+end Topology

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -138,6 +138,18 @@
   zbl           = {0248.46019}
 }
 
+@Book{            aliprantis_border2006,
+  author        = {Aliprantis, Charalambos D. and Border, Kim C.},
+  title         = {Infinite dimensional analysis. A hitchhiker's guide},
+  edition       = {3rd ed.},
+  isbn          = {978-3-540-29586-0},
+  year          = {2006},
+  publisher     = {Springer-Verlag, Berlin},
+  language      = {English},
+  doi           = {10.1007/3-540-29587-9},
+  url           = {https://doi.org/10.1007/3-540-29587-9}
+}
+
 @Book{            alfsenshultz2003,
   author        = {Erik M. {Alfsen} and Frederic W. {Shultz}},
   title         = {{Geometry of state spaces of operator algebras}},


### PR DESCRIPTION
In a topological vector space, `convexJoin 𝕜 s t` is closed as soon as `s` is compact and closed
and `t` is closed and von Neumann bounded. Neither set has to be convex, and neither has to be
nonempty.

The classical statement — [Aliprantis–Border, *Infinite Dimensional Analysis*][aliprantis_border2006],
Lemma 5.37: in a Hausdorff topological vector space, the convex hull of the union of a nonempty
compact convex set and a nonempty closed bounded convex set is closed — then follows via
`Convex.convexHull_union`.

Three hypotheses of Lemma 5.37 turn out to be unnecessary:

* **Convexity is never used for the join.** It only re-enters when rewriting
  `convexHull 𝕜 (s ∪ t)` as `convexJoin 𝕜 s t`, i.e. in the corollary.
* **Nonemptiness is not needed**, in either result. For the join, if either set is empty so is the
  join. For the convex hull, `convexHull 𝕜 (∅ ∪ t) = t` and `convexHull 𝕜 (s ∪ ∅) = s` by convexity,
  and both are closed; so `IsCompact.isClosed_convexHull_union` is stated without `s.Nonempty` and
  `t.Nonempty`, at the cost of two case splits.
* **Hausdorffness weakens to `IsClosed s`.** This one is sharp rather than cosmetic: in `ℝ²`
  topologised by the seminorm `|x₁|`, the set `s = {(0, 0)}` is compact but not closed,
  `t = {p | 1 ≤ p.1 ≤ 2}` is closed and bounded, and `convexJoin ℝ s t = {(0,0)} ∪ {p | 0 < p.1 ≤ 2}`
  is not closed. `[T2Space E]` is simply the cheapest way to supply closedness of `s`, and it is kept
  on the textbook corollary. Compare `IsCompact.isClosed_image_restrict` for the same
  `IsCompact` + `IsClosed` hypothesis pair.

The proof is phrased with filters and ultrafilters rather than nets: after parametrising the join as
the image of `Icc 0 1 ×ˢ s ×ˢ t` under `(θ, a, b) ↦ (1 - θ) • a + θ • b`, the given filter is lifted
through that map and refined to an ultrafilter, along which compactness of `Icc 0 1` and of `s` makes
the first two parameters converge. When the parameter `θ` tends to `0`, boundedness of `t` crushes
the third coordinate and the `s`-coordinate itself converges to the limit point; otherwise the
`t`-coordinate is recovered continuously as `θ⁻¹ • (x - (1 - θ) • a)`.

Boundedness is `Bornology.IsVonNBounded`, not `Bornology.IsBounded`: the ambient space is a bare
topological vector space with no metric, so it carries no `Bornology` instance and `IsBounded` is not
statable without adding `[SeminormedAddCommGroup E]`. In a normed space the two agree
(`NormedSpace.isVonNBounded_iff`), so normed-space users pay one rewrite.

The scalars are a general `𝕜` rather than `ℝ`, with the typeclass bundle
`[NormedField 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [CompactIccSpace 𝕜]` — the norm is what
`Bornology.IsVonNBounded` needs, the order is what `convexJoin` needs, and `CompactIccSpace` is what
makes the parameter `θ` converge. This mirrors `Set.Finite.isCompact_convexHull` in
`Mathlib/Analysis/Convex/Topology.lean`, which carries a comparable bundle. In fairness, a
conditionally complete linearly ordered field is `ℝ`, so the extra generality is a matter of not
hard-coding `ℝ` rather than of new instances.

Everything lives in `Mathlib/Analysis/Convex/Join.lean`. This adds a
`Mathlib.Analysis.LocallyConvex.Bounded` import there (+108 modules in the import closure, from 1566
to 1674); `Analysis.Convex.StoneSeparation` is the file's only direct dependent and still builds.
Happy to split this back out into a separate `Analysis/Convex/JoinTopology.lean` if reviewers would
rather keep `Join.lean` free of topology.

Also adds the Aliprantis–Border bibliography entry to `docs/references.bib`.

---

Opened as a draft for review of the statement shape — in particular whether the maintainers prefer
`IsCompact s` + `IsClosed s` on the main lemma (as here) or simply `[T2Space E]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)