### PR TITLE
[Merged by Bors] - feat(Algebra/Lie/Graded): add graded Lie modules

### DIFF
--- a/Mathlib/Algebra/Lie/Graded.lean
+++ b/Mathlib/Algebra/Lie/Graded.lean
@@ -16,8 +16,10 @@ algebras that are graded by a collection `ℒ` of submodules.
 
 ## Main definitions
 
-* `SetLike.GradedBracket`: A typeclass for a bracket to respect an additive grading.
-* `GradedLieAlgebra`: A typeclass for a Lie algebra to respect an additive grading.
+* `SetLike.GradedBracket`: A typeclass for a bracket to be compatible with a vector-additive
+  grading.
+* `GradedLieAlgebra`: A typeclass for a Lie algebra bracket to respect an additive grading.
+* `GradedLieModule`: A typeclass for a Lie module to be compatible with a vector-additive grading.
 * `LieDerivation.ofGradingSum`: A Lie derivation on the direct sum of graded pieces, that scalar-
   multiplies the pieces by an additive map applied to degree.
 * `LieDerivation.ofGrading`: A Lie derivation on a graded Lie algebra, that scalar-multiplies graded
@@ -35,20 +37,26 @@ and defining a new `GradedMonoid.GBracket` class to provide the data piecewise.
 
 open DirectSum
 
-variable {ι σ R L : Type*}
+variable {ι κ σ τ R L M : Type*}
 
 section SetLike
 
-/-- A class that ensures a bracket product preserves an additive grading. -/
-class SetLike.GradedBracket [SetLike σ L] [Bracket L L] [Add ι] (ℒ : ι → σ) : Prop where
+/-- A `graded bracket` class that ensures a bracket action preserves a vector-additive grading. -/
+class SetLike.GradedBracket [SetLike σ L] [SetLike τ M] [Bracket L M] [VAdd ι κ] (ℒ : ι → σ)
+    (ℳ : κ → τ) : Prop where
   /-- Bracket is homogeneous -/
-  bracket_mem : ∀ ⦃i j⦄ {gi gj}, gi ∈ ℒ i → gj ∈ ℒ j → ⁅gi, gj⁆ ∈ ℒ (i + j)
+  bracket_mem : ∀ ⦃i j⦄ {gi hj}, gi ∈ ℒ i → hj ∈ ℳ j → ⁅gi, hj⁆ ∈ ℳ (i +ᵥ j)
 
 variable [DecidableEq ι] [AddCommMonoid ι] [CommRing R] [LieRing L] [LieAlgebra R L]
-  (ℒ : ι → Submodule R L)
+  (ℒ : ι → Submodule R L) [DecidableEq κ] [VAdd ι κ] [AddCommGroup M] [Module R M]
+  [LieRingModule L M] [LieModule R L M] (ℳ : κ → Submodule R M)
 
 /-- A class that ensures a Lie algebra has a bracket that preserves a decomposition. -/
-class GradedLieAlgebra extends SetLike.GradedBracket ℒ, DirectSum.Decomposition ℒ
+class GradedLieAlgebra extends SetLike.GradedBracket ℒ ℒ, DirectSum.Decomposition ℒ
+
+/-- A class that ensures a Lie algebra has a bracket that preserves a decomposition. -/
+class GradedLieModule [GradedLieAlgebra ℒ] [DirectSum.Decomposition ℳ] extends
+    SetLike.GradedBracket ℒ ℳ
 
 end SetLike
 
@@ -65,28 +73,48 @@ instance : LieRing (⨁ i, ℒ i) where
   lie_self _ := by simp
   leibniz_lie _ _ _ := by simp
 
-lemma bracket_apply_apply (x y : ⨁ i, ℒ i) :
+lemma bracket_apply_apply_self (x y : ⨁ i, ℒ i) :
     ⁅x, y⁆ =
       decomposeLinearEquiv ℒ ⁅(decomposeLinearEquiv ℒ).symm x, (decomposeLinearEquiv ℒ).symm y⁆ :=
   rfl
 
+attribute [local simp] bracket_apply_apply_self
+
+variable [DecidableEq κ] [AddCommGroup M] [Module R M] [LieRingModule L M]
+  (ℳ : κ → Submodule R M) [DirectSum.Decomposition ℳ]
+
+instance : LieRingModule (⨁ i, ℒ i) (⨁ k, ℳ k) where
+  bracket x y := decomposeLinearEquiv ℳ
+    ⁅(decomposeLinearEquiv ℒ).symm x, (decomposeLinearEquiv ℳ).symm y⁆
+  add_lie _ _ _ := by simp
+  lie_add _ _ _ := by simp
+  leibniz_lie _ _ _ := by simp
+
+lemma bracket_apply_apply (x : ⨁ i, ℒ i) (y : ⨁ k, ℳ k) :
+    ⁅x, y⁆ =
+      decomposeLinearEquiv ℳ ⁅(decomposeLinearEquiv ℒ).symm x, (decomposeLinearEquiv ℳ).symm y⁆ :=
+  rfl
+
 attribute [local simp] bracket_apply_apply
 
-@[simp]
-lemma decompose_bracket (x y : L) : decompose ℒ ⁅x, y⁆ = ⁅decompose ℒ x, decompose ℒ y⁆ := by
-  simp only [← decomposeLinearEquiv_apply]
+lemma decompose_bracket (x : L) (y : M) :
+    decompose ℳ ⁅x, y⁆ = ⁅decompose ℒ x, decompose ℳ y⁆ := by
+  simp only [← decomposeLinearEquiv_apply, bracket_apply_apply]
   simp
 
 @[simp]
-lemma decompose_symm_bracket (x y : ⨁ i, ℒ i) :
-    (decompose ℒ).symm ⁅x, y⁆ = ⁅(decompose ℒ).symm x, (decompose ℒ).symm y⁆ := by
-  simp only [← decomposeLinearEquiv_symm_apply]
+lemma decompose_symm_bracket (x : ⨁ i, ℒ i) (y : ⨁ k, ℳ k) :
+    (decompose ℳ).symm ⁅x, y⁆ = ⁅(decompose ℒ).symm x, (decompose ℳ).symm y⁆ := by
+  simp only [← decomposeLinearEquiv_symm_apply, bracket_apply_apply]
   simp
 
-set_option backward.isDefEq.respectTransparency false in
 instance : LieAlgebra R (⨁ i, ℒ i) where
   add_smul _ _ _ := by simp [add_smul]
   zero_smul _ := by simp
+  lie_smul _ _ _ := by simp
+
+instance [LieModule R L M] : LieModule R (⨁ i, ℒ i) (⨁ k, ℳ k) where
+  smul_lie _ _ _ := by simp
   lie_smul _ _ _ := by simp
 
 /-- If `L` is graded by `ι` with degree `i` component `ℒ i`, then it is isomorphic as
@@ -130,7 +158,8 @@ def ofGradingSum (φ : ι →+ R) : LieDerivation R (⨁ i, ℒ i) (⨁ i, ℒ i
             add_lie, smul_add, add_sub, ← sub_sub]
           congr 1
           have : (decompose ℒ).symm ⁅of (fun i ↦ ℒ i) i a, of (fun i ↦ ℒ i) k b⁆ ∈ ℒ (i + k) := by
-            simp [SetLike.GradedBracket.bracket_mem (Submodule.coe_mem a) (Submodule.coe_mem b)]
+            simp [← vadd_eq_add,
+              SetLike.GradedBracket.bracket_mem (Submodule.coe_mem a) (Submodule.coe_mem b)]
           rw [hM _ _ this, hM k (of (ℒ ·) k b) (by simp), ← lie_skew (of (ℒ ·) k b),
             add_sub_right_comm, add_right_cancel_iff, add_comm i k, map_add, add_smul,
             DirectSum.add_apply, Submodule.coe_add, sub_eq_add_neg, lie_smul, add_left_cancel_iff,
@@ -142,7 +171,6 @@ lemma ofGradingSum_of (φ : ι →+ R) (i : ι) (a : ℒ i) :
     ofGradingSum ℒ φ (of (ℒ ·) i a) = (φ i) • (of (ℒ ·) i a) := by
   simp [← lof_eq_of R, ofGradingSum]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The Lie derivation on a graded Lie algebra that scalar-multiplies by an additive function of
 the degree. -/
 def ofGrading (φ : ι →+ R) :
@@ -150,9 +178,11 @@ def ofGrading (φ : ι →+ R) :
   toFun x := (decomposeLinearEquiv ℒ).symm <| ofGradingSum ℒ φ <| decomposeLinearEquiv ℒ x
   map_add' _ _ := by simp
   map_smul' _ _ := by simp
-  leibniz' x y := by simp [decomposeLinearEquiv_apply, decomposeLinearEquiv_symm_apply]
+  leibniz' x y := by
+    simp [decomposeLinearEquiv_apply, decomposeLinearEquiv_symm_apply,
+      Equiv.symm_apply_eq (decompose ℒ)]
+    simp [decompose_bracket ℒ]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma ofGrading_apply_apply (φ : ι →+ R) {i : ι} {a : L} (ha : a ∈ ℒ i) :
     ofGrading ℒ φ a = φ i • a := by
   simp [ofGrading, decomposeLinearEquiv_apply, decompose_of_mem ℒ ha]


### PR DESCRIPTION
This PR defines graded Lie modules over graded Lie algebras. Some existing declarations are changed to be heterogeneous, so they apply to modules in addition to Lie algebras.

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
