### PR TITLE
[Merged by Bors] - feat(Data/Real/ConjExponents): add toReal_of_ne_top

### DIFF
--- a/Mathlib/Data/Real/ConjExponents.lean
+++ b/Mathlib/Data/Real/ConjExponents.lean
@@ -507,6 +507,10 @@ lemma toReal (hp : 1 < p.toReal) [HolderConjugate p q] :
     p.toReal.HolderConjugate q.toReal :=
   toReal_iff hp |>.mpr ‹_›
 
+lemma toReal_of_ne_top (hp : p ≠ ∞) (hq : q ≠ ∞) [HolderConjugate p q] :
+    p.toReal.HolderConjugate q.toReal :=
+  toReal ((toReal_lt_toReal one_ne_top hp).mpr ((lt_top_iff_one_lt q p).mp hq.lt_top))
+
 lemma of_toNNReal (h : NNReal.HolderConjugate p.toNNReal q.toNNReal) :
     HolderConjugate p q :=
   .of_toReal <| by simpa only [coe_toNNReal_eq_toReal] using h.coe


### PR DESCRIPTION
From the Carleson project.

-------

**Upstreaming from Carleson: [/Carleson/ToMathlib/Data/Real/ConjExponents.lean](https://github.com/fpvandoorn/carleson/blob/0072b6e47ec58ac13be0a9f3b7c17e9f3bb1be2e/Carleson/ToMathlib/Data/Real/ConjExponents.lean)**

### Changes from carleson
- **refactored**
- **hypothesis `(h : p.HolderConjugate q)` => `[p.HolderConjugate q]`**
  For consistency with the neighbouring lemmas

### Signatures

```lean
-- CARLESON
ENNReal.HolderConjugate.toReal_of_ne_top {p q : ℝ≥0∞} (h : p.HolderConjugate q) (hp : p ≠ ∞) (hq : q ≠ ∞) : p.toReal.HolderConjugate q.toReal

-- MATHLIB
ENNReal.HolderConjugate.toReal_of_ne_top {p q : ℝ≥0∞} [p.HolderConjugate q] (hp : p ≠ ∞) (hq : q ≠ ∞) : p.toReal.HolderConjugate q.toReal
```
