### PR TITLE
[Merged by Bors] - fix: increase priority of show elaboration

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -647,8 +647,10 @@ def elabShow (newType : Term) : TacticM Unit := do
         readability.\nHowever, this tactic invocation changed the goal. Please use `change` \
         instead for these purposes."
 
+-- `(priority := high)` is added to avoid the confusing message omission that can happen with synthetic
+-- `sorry` and multiple parses, see also `MathlibTest/Linter/Show.lean`
 @[tactic_alt Tactic.show]
-elab (name := «show») "show " newType:term : tactic => elabShow newType
+elab (name := «show») (priority := high) "show " newType:term : tactic => elabShow newType
 
 end Style
 

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -647,8 +647,8 @@ def elabShow (newType : Term) : TacticM Unit := do
         readability.\nHowever, this tactic invocation changed the goal. Please use `change` \
         instead for these purposes."
 
--- `(priority := high)` is added to avoid the confusing message omission that can happen with synthetic
--- `sorry` and multiple parses, see also `MathlibTest/Linter/Show.lean`
+-- `(priority := high)` ensures we avoid producing choice nodes, and thereby avoid unexpected 
+-- behavior arising from choice node elaboration
 @[tactic_alt Tactic.show]
 elab (name := «show») (priority := high) "show " newType:term : tactic => elabShow newType
 

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -647,7 +647,7 @@ def elabShow (newType : Term) : TacticM Unit := do
         readability.\nHowever, this tactic invocation changed the goal. Please use `change` \
         instead for these purposes."
 
--- `(priority := high)` ensures we avoid producing choice nodes, and thereby avoid unexpected 
+-- `(priority := high)` ensures we avoid producing choice nodes, and thereby avoid unexpected
 -- behavior arising from choice node elaboration
 @[tactic_alt Tactic.show]
 elab (name := «show») (priority := high) "show " newType:term : tactic => elabShow newType

--- a/MathlibTest/Linter/Show.lean
+++ b/MathlibTest/Linter/Show.lean
@@ -6,13 +6,13 @@ set_option linter.style.show true
 /-
 Check that logged messages appear when errors with synthetic `sorry` are thrown.
 
-If a choice node is produced, `evalChoice` (currently) resets the state, erasing logs, and 
-re-throwing the produced error. And if the error contains a synthetic sorry, Lean will not log it, 
-trusting that the (now-erased) logged errors that preceded it are sufficient. As such, a choice 
-node may ultimately produce a state with no visible errors at the tactic, since the logged ones 
+If a choice node is produced, `evalChoice` (currently) resets the state, erasing logs, and
+re-throwing the produced error. And if the error contains a synthetic sorry, Lean will not log it,
+trusting that the (now-erased) logged errors that preceded it are sufficient. As such, a choice
+node may ultimately produce a state with no visible errors at the tactic, since the logged ones
 have been erased and the thrown ones are not rendered in expectation of the logged ones appearing.
 
-This test fails correctly now because the parser avoids producing a choice node in the first place, 
+This test fails correctly now because the parser avoids producing a choice node in the first place,
 via `(priority := high)`.
 -/
 

--- a/MathlibTest/Linter/Show.lean
+++ b/MathlibTest/Linter/Show.lean
@@ -3,7 +3,18 @@ import Mathlib.Tactic.Linter.Style
 
 set_option linter.style.show true
 
--- Check that messages appear when errors with synthetic `sorry` occur
+/-
+Check that logged messages appear when errors with synthetic `sorry` are thrown.
+
+If a choice node is produced, `evalChoice` (currently) resets the state, erasing logs, and 
+re-throwing the produced error. And if the error contains a synthetic sorry, Lean will not log it, 
+trusting that the (now-erased) logged errors that preceded it are sufficient. As such, a choice 
+node may ultimately produce a state with no visible errors at the tactic, since the logged ones 
+have been erased and the thrown ones are not rendered in expectation of the logged ones appearing.
+
+This test fails correctly now because the parser avoids producing a choice node in the first place, 
+via `(priority := high)`.
+-/
 
 /-- error: Unknown identifier `arbitrary_ident` -/
 #guard_msgs in

--- a/MathlibTest/Linter/Show.lean
+++ b/MathlibTest/Linter/Show.lean
@@ -1,0 +1,10 @@
+module
+import Mathlib.Tactic.Linter.Style
+
+set_option linter.style.show true
+
+-- Check that messages appear when errors with synthetic `sorry` occur
+
+/-- error: Unknown identifier `arbitrary_ident` -/
+#guard_msgs in
+example : False := by show arbitrary_ident


### PR DESCRIPTION
See [this thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Performance.20cost.20of.20info.20tree.20traversal/with/610705175) for discussion. This prevents a confusing lack of messages for the `show` tactic introduced in #41761.

---

@JovanGerb or @thorimur might have better taste for wording the comments here.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
