### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Monoidal/Cartesian/Over): remove most backward options

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Products.lean
@@ -56,10 +56,9 @@ namespace CategoryTheory.Limits
 section Over
 variable {f : Y ⟶ X} {g : Z ⟶ X}
 
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 /-- Pullback cones to `X` are the same thing as binary fans in `Over X`. -/
-@[simps]
+@[implicit_reducible, simps]
 def pullbackConeEquivBinaryFan : PullbackCone f g ≌ BinaryFan (Over.mk f) (.mk g) where
   functor.obj c := .mk (Over.homMk (U := .mk (c.fst ≫ f)) (V := .mk f) c.fst rfl)
       (Over.homMk (U := .mk (c.fst ≫ f)) (V := .mk g) c.snd c.condition.symm)
@@ -94,9 +93,6 @@ def IsLimit.pullbackConeEquivBinaryFanFunctor {c : PullbackCone f g} (hc : IsLim
       · simpa using! congr(($e₁).left)
       · simpa using! congr(($e₂).left)
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency.types false in
 /-- A pullback cone to `X` is a limit if its corresponding binary fan in `Over X` is a limit. -/
 -- This could also be `(IsLimit.ofConeEquiv pullbackConeEquivBinaryFan.symm).symm hc`, but possibly
 -- bad defeqs?
@@ -186,7 +182,6 @@ variable {X : C} {Y Z : Over X}
 open Limits
 
 set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 lemma isPullback_of_binaryFan_isLimit (c : BinaryFan Y Z) (hc : IsLimit c) :
     IsPullback c.fst.left c.snd.left Y.hom Z.hom :=
   ⟨by simp, ⟨hc.pullbackConeEquivBinaryFanInverse⟩⟩

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -142,6 +142,7 @@ def limit (F : J ⥤ C) [HasLimit F] :=
   (limit.cone F).pt
 
 /-- The projection from the limit object to a value of the functor. -/
+@[implicit_reducible]
 def limit.π (F : J ⥤ C) [HasLimit F] (j : J) : limit F ⟶ F.obj j :=
   (limit.cone F).π.app j
 
@@ -704,6 +705,7 @@ def colimit (F : J ⥤ C) [HasColimit F] :=
   (colimit.cocone F).pt
 
 /-- The coprojection from a value of the functor to the colimit object. -/
+@[implicit_reducible]
 def colimit.ι (F : J ⥤ C) [HasColimit F] (j : J) : F.obj j ⟶ colimit F :=
   (colimit.cocone F).ι.app j
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Over.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Over.lean
@@ -29,8 +29,6 @@ open CategoryTheory.Functor Limits CartesianMonoidalCategory
 
 variable {C : Type*} [Category* C] [HasPullbacks C]
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 /-- A choice of finite products of `Over X` given by `Limits.pullback`. -/
 abbrev cartesianMonoidalCategory (X : C) : CartesianMonoidalCategory (Over X) :=
   .ofChosenFiniteProducts
@@ -41,7 +39,6 @@ abbrev cartesianMonoidalCategory (X : C) : CartesianMonoidalCategory (Over X) :=
 
 attribute [local instance] cartesianMonoidalCategory
 
-set_option backward.isDefEq.respectTransparency.types false in
 /-- `Over X` is braided w.r.t. the Cartesian monoidal structure given by `Limits.pullback`. -/
 abbrev braidedCategory (X : C) : BraidedCategory (Over X) :=
   .ofCartesianMonoidalCategory
@@ -52,200 +49,162 @@ open MonoidalCategory
 
 variable {X : C}
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[ext]
 lemma tensorObj_ext {R : C} {S T : Over X} (f₁ f₂ : R ⟶ (S ⊗ T).left)
     (e₁ : f₁ ≫ pullback.fst _ _ = f₂ ≫ pullback.fst _ _)
     (e₂ : f₁ ≫ pullback.snd _ _ = f₂ ≫ pullback.snd _ _) : f₁ = f₂ :=
   pullback.hom_ext e₁ e₂
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma tensorObj_left (R S : Over X) : (R ⊗ S).left = Limits.pullback R.hom S.hom := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma tensorObj_hom (R S : Over X) : (R ⊗ S).hom = pullback.fst R.hom S.hom ≫ R.hom := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma tensorUnit_left : (𝟙_ (Over X)).left = X := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma tensorUnit_hom : (𝟙_ (Over X)).hom = 𝟙 X := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma lift_left {R S T : Over X} (f : R ⟶ S) (g : R ⟶ T) :
     (lift f g).left = pullback.lift f.left g.left (f.w.trans g.w.symm) := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma fst_left {R S : Over X} : (fst R S).left = pullback.fst _ _ := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma snd_left {R S : Over X} : (snd R S).left = pullback.snd _ _ := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma toUnit_left {R : Over X} : (toUnit R).left = R.hom := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_hom_left_fst (R S T : Over X) :
     (α_ R S T).hom.left ≫ pullback.fst _ (pullback.fst _ _ ≫ _) =
       pullback.fst _ _ ≫ pullback.fst _ _ :=
   limit.lift_π _ _
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_hom_left_snd_fst (R S T : Over X) :
     (α_ R S T).hom.left ≫ pullback.snd _ (pullback.fst _ _ ≫ _) ≫ pullback.fst _ _ =
       pullback.fst _ _ ≫ pullback.snd _ _ :=
   (limit.lift_π_assoc _ _ _).trans (limit.lift_π _ _)
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_hom_left_snd_snd (R S T : Over X) :
     (α_ R S T).hom.left ≫ pullback.snd _ (pullback.fst _ _ ≫ _) ≫ pullback.snd _ _ =
       pullback.snd _ _ :=
   (limit.lift_π_assoc _ _ _).trans (limit.lift_π _ _)
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_inv_left_fst_fst (R S T : Over X) :
     (α_ R S T).inv.left ≫ pullback.fst (pullback.fst _ _ ≫ _) _ ≫ pullback.fst _ _ =
       pullback.fst _ _ :=
   (limit.lift_π_assoc _ _ _).trans (limit.lift_π _ _)
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_inv_left_fst_snd (R S T : Over X) :
     (α_ R S T).inv.left ≫ pullback.fst (pullback.fst _ _ ≫ _) _ ≫ pullback.snd _ _ =
       pullback.snd _ _ ≫ pullback.fst _ _ :=
   (limit.lift_π_assoc _ _ _).trans (limit.lift_π _ _)
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma associator_inv_left_snd (R S T : Over X) :
     (α_ R S T).inv.left ≫ pullback.snd (pullback.fst _ _ ≫ _) _ =
       pullback.snd _ _ ≫ pullback.snd _ _ :=
   limit.lift_π _ _
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma leftUnitor_hom_left (Y : Over X) :
     (λ_ Y).hom.left = pullback.snd _ _ := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma leftUnitor_inv_left_fst (Y : Over X) :
     (λ_ Y).inv.left ≫ pullback.fst (𝟙 X) _ = Y.hom :=
   limit.lift_π _ _
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma leftUnitor_inv_left_snd (Y : Over X) :
     (λ_ Y).inv.left ≫ pullback.snd (𝟙 X) _ = 𝟙 Y.left :=
   limit.lift_π _ _
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma rightUnitor_hom_left (Y : Over X) :
     (ρ_ Y).hom.left = pullback.fst _ (𝟙 X) := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma rightUnitor_inv_left_fst (Y : Over X) :
     (ρ_ Y).inv.left ≫ pullback.fst _ (𝟙 X) = 𝟙 _ :=
   limit.lift_π _ _
 
-#adaptation_note
-/-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma rightUnitor_inv_left_snd (Y : Over X) :
     (ρ_ Y).inv.left ≫ pullback.snd _ (𝟙 X) = Y.hom :=
   limit.lift_π _ _
 
-set_option backward.isDefEq.respectTransparency.types false in
 lemma whiskerLeft_left {R S T : Over X} (f : S ⟶ T) :
     (R ◁ f).left = pullback.map _ _ _ _ (𝟙 _) f.left (𝟙 _) (by simp) (by simp) := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma whiskerLeft_left_fst {R S T : Over X} (f : S ⟶ T) :
     (R ◁ f).left ≫ pullback.fst _ _ = pullback.fst _ _ :=
   (limit.lift_π _ _).trans (Category.comp_id _)
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma whiskerLeft_left_snd {R S T : Over X} (f : S ⟶ T) :
     (R ◁ f).left ≫ pullback.snd _ _ = pullback.snd _ _ ≫ f.left :=
   limit.lift_π _ _
 
-set_option backward.isDefEq.respectTransparency.types false in
 lemma whiskerRight_left {R S T : Over X} (f : S ⟶ T) :
     (f ▷ R).left = pullback.map _ _ _ _ f.left (𝟙 _) (𝟙 _) (by simp) (by simp) := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma whiskerRight_left_fst {R S T : Over X} (f : S ⟶ T) :
     (f ▷ R).left ≫ pullback.fst _ _ = pullback.fst _ _ ≫ f.left :=
   limit.lift_π _ _
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma whiskerRight_left_snd {R S T : Over X} (f : S ⟶ T) :
     (f ▷ R).left ≫ pullback.snd _ _ = pullback.snd _ _ :=
   (limit.lift_π _ _).trans (Category.comp_id _)
 
-set_option backward.isDefEq.respectTransparency.types false in
 lemma tensorHom_left {R S T U : Over X} (f : R ⟶ S) (g : T ⟶ U) :
     (f ⊗ₘ g).left = pullback.map _ _ _ _ f.left g.left (𝟙 _) (by simp) (by simp) := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma tensorHom_left_fst {S U : C} {R T : Over X} (fS : S ⟶ X) (fU : U ⟶ X)
     (f : R ⟶ mk fS) (g : T ⟶ mk fU) :
     (f ⊗ₘ g).left ≫ pullback.fst fS fU = pullback.fst R.hom T.hom ≫ f.left :=
   limit.lift_π _ _
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma tensorHom_left_snd {S U : C} {R T : Over X} (fS : S ⟶ X) (fU : U ⟶ X)
     (f : R ⟶ mk fS) (g : T ⟶ mk fU) :
     (f ⊗ₘ g).left ≫ pullback.snd fS fU = pullback.snd R.hom T.hom ≫ g.left :=
   limit.lift_π _ _
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma braiding_hom_left {R S : Over X} :
     (β_ R S).hom.left = (pullbackSymmetry _ _).hom := rfl
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma braiding_inv_left {R S : Over X} :
     (β_ R S).inv.left = (pullbackSymmetry _ _).hom := rfl
 
 variable {A B R S Y Z : C} {f : R ⟶ X} {g : S ⟶ X}
 
-set_option backward.isDefEq.respectTransparency.types false in
 instance : (Over.pullback f).Braided := .ofChosenFiniteProducts _
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma η_pullback_left : (OplaxMonoidal.η (Over.pullback f)).left = (pullback.snd (𝟙 _) f) := rfl
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma ε_pullback_left : (LaxMonoidal.ε (Over.pullback f)).left = inv (pullback.snd (𝟙 _) f) := by
   apply IsIso.eq_inv_of_hom_inv_id
   rw [← η_pullback_left, ← Over.comp_left, Monoidal.η_ε, Over.id_left]
 
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 lemma μ_pullback_left_fst_fst (R S : Over X) :
     (LaxMonoidal.μ (Over.pullback f) R S).left ≫
@@ -255,7 +214,6 @@ lemma μ_pullback_left_fst_fst (R S : Over X) :
     Iso.hom_inv_id]
   simp [CartesianMonoidalCategory.prodComparison, fst]
 
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 lemma μ_pullback_left_fst_snd (R S : Over X) :
     (LaxMonoidal.μ (Over.pullback f) R S).left ≫
@@ -274,7 +232,6 @@ lemma μ_pullback_left_snd (R S : Over X) :
     ← Over.comp_left_assoc, Iso.hom_inv_id]
   simp [CartesianMonoidalCategory.prodComparison]
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma μ_pullback_left_fst_fst' (g₁ : Y ⟶ X) (g₂ : Z ⟶ X) :
     (LaxMonoidal.μ (Over.pullback f) (.mk g₁) (.mk g₂)).left ≫
@@ -282,7 +239,6 @@ lemma μ_pullback_left_fst_fst' (g₁ : Y ⟶ X) (g₂ : Z ⟶ X) :
         pullback.fst _ _ ≫ pullback.fst _ _ :=
   μ_pullback_left_fst_fst ..
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma μ_pullback_left_fst_snd' (g₁ : Y ⟶ X) (g₂ : Z ⟶ X) :
     (LaxMonoidal.μ (Over.pullback f) (.mk g₁) (.mk g₂)).left ≫
@@ -290,21 +246,18 @@ lemma μ_pullback_left_fst_snd' (g₁ : Y ⟶ X) (g₂ : Z ⟶ X) :
         pullback.snd _ _ ≫ pullback.fst _ _ :=
   μ_pullback_left_fst_snd ..
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma μ_pullback_left_snd' (g₁ : Y ⟶ X) (g₂ : Z ⟶ X) :
     (LaxMonoidal.μ (Over.pullback f) (.mk g₁) (.mk g₂)).left ≫
       pullback.snd (pullback.fst g₁ g₂ ≫ g₁) f =
         pullback.snd _ _ ≫ pullback.snd _ _ := μ_pullback_left_snd ..
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma preservesTerminalIso_pullback (f : R ⟶ S) :
     preservesTerminalIso (Over.pullback f) =
       Over.isoMk (asIso (pullback.snd (𝟙 _) f)) (by simp) := by
   ext1; exact toUnit_unique _ _
 
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma prodComparisonIso_pullback_inv_left_fst_fst (f : X ⟶ Y) (A B : Over Y) :
@@ -315,7 +268,6 @@ lemma prodComparisonIso_pullback_inv_left_fst_fst (f : X ⟶ Y) (A B : Over Y) :
     Over.hom_left_inv_left_assoc]
   simp [CartesianMonoidalCategory.prodComparison, fst]
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 lemma prodComparisonIso_pullback_Spec_inv_left_fst_fst' (f : X ⟶ Y) (gA : A ⟶ Y) (gB : B ⟶ Y) :
     (prodComparisonIso (Over.pullback f) (.mk gA) (.mk gB)).inv.left ≫
@@ -323,7 +275,6 @@ lemma prodComparisonIso_pullback_Spec_inv_left_fst_fst' (f : X ⟶ Y) (gA : A �
         pullback.fst (pullback.snd gA f) (pullback.snd gB f) ≫ pullback.fst _ _ :=
   prodComparisonIso_pullback_inv_left_fst_fst ..
 
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma prodComparisonIso_pullback_inv_left_fst_snd' (f : X ⟶ Y) (gA : A ⟶ Y) (gB : B ⟶ Y) :
@@ -343,7 +294,6 @@ lemma prodComparisonIso_pullback_inv_left_snd' (f : X ⟶ Y) (gA : A ⟶ Y) (gB 
     Over.hom_left_inv_left_assoc]
   simp [CartesianMonoidalCategory.prodComparison]
 
-set_option backward.isDefEq.respectTransparency.types false in
 /-- The pullback of a monoid object is a monoid object. -/
 @[simps! -isSimp mul one]
 abbrev monObjMkPullbackSnd [MonObj (Over.mk f)] : MonObj (Over.mk <| pullback.snd f g) :=
@@ -351,12 +301,10 @@ abbrev monObjMkPullbackSnd [MonObj (Over.mk f)] : MonObj (Over.mk <| pullback.sn
 
 attribute [local instance] monObjMkPullbackSnd
 
-set_option backward.isDefEq.respectTransparency.types false in
 instance isCommMonObj_mk_pullbackSnd [MonObj (Over.mk f)] [IsCommMonObj (Over.mk f)] :
     IsCommMonObj (Over.mk <| pullback.snd f g) :=
   ((Over.pullback g).mapCommMon.obj <| .mk <| .mk f).comm
 
-set_option backward.isDefEq.respectTransparency.types false in
 /-- The pullback of a monoid object is a monoid object. -/
 @[simps! -isSimp mul one]
 abbrev grpObjMkPullbackSnd [GrpObj (Over.mk f)] : GrpObj (Over.mk (pullback.snd f g)) :=


### PR DESCRIPTION
This PR uses `implicit_reducible` to remove some backward options that currently block the use of `scripts/rm_set_option.py`.

---

This replaces #41996, see [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/4.2E33.2E0-rc1.20Multiple.20.60respectTransparency.60-related.20issues/near/613526582).