### PR TITLE
[Merged by Bors] - chore(Util/CountHeartbeats): deprecate the global `#count_heartbeats` command

### DIFF
--- a/Mathlib/Util/CountHeartbeats.lean
+++ b/Mathlib/Util/CountHeartbeats.lean
@@ -242,6 +242,8 @@ it looks inside `set_option ... in`, but not, for instance, inside `mutual` bloc
 
 There is a convenience notation `#count_heartbeats` that simply sets the linter option to true.
 -/
+@[deprecated "use `#count_heartbeats in` or `set_option trace.profiler true` with \
+  `set_option trace.profiler.useHeartbeats true`" (since := "2026-07-30")]
 register_option linter.countHeartbeats : Bool := {
   defValue := false
   descr := "enable the countHeartbeats linter"
@@ -251,6 +253,8 @@ register_option linter.countHeartbeats : Bool := {
 An option used by the `countHeartbeats` linter: if set to `true`, then the countHeartbeats linter
 rounds down to the nearest 1000 the heartbeat count.
 -/
+@[deprecated "use `#count_heartbeats in` or `set_option trace.profiler true` with \
+  `set_option trace.profiler.useHeartbeats true`" (since := "2026-07-30")]
 register_option linter.countHeartbeatsApprox : Bool := {
   defValue := false
   descr := "if set to `true`, then the countHeartbeats linter rounds down \
@@ -259,7 +263,9 @@ register_option linter.countHeartbeatsApprox : Bool := {
 
 namespace CountHeartbeats
 
-@[inherit_doc Mathlib.Linter.linter.countHeartbeats]
+@[inherit_doc Mathlib.Linter.linter.countHeartbeats,
+deprecated "use `#count_heartbeats in` or `set_option trace.profiler true` with \
+  `set_option trace.profiler.useHeartbeats true`" (since := "2026-07-30")]
 def countHeartbeatsLinter : Linter where run := withSetOptionIn fun stx ↦ do
   unless getLinterValue linter.countHeartbeats (← getLinterOptions) do
     return
@@ -280,9 +286,12 @@ def countHeartbeatsLinter : Linter where run := withSetOptionIn fun stx ↦ do
     | none =>
       for msg in msgs do logInfoAt stx m!"{← msg.toString}"
 
+set_option linter.deprecated false in
 initialize addLinter countHeartbeatsLinter
 
-@[inherit_doc Mathlib.Linter.linter.countHeartbeats]
+@[inherit_doc Mathlib.Linter.linter.countHeartbeats,
+deprecated "use `#count_heartbeats in` or `set_option trace.profiler true` with \
+  `set_option trace.profiler.useHeartbeats true`" (since := "2026-07-30")]
 macro "#count_heartbeats" approx:(&" approximately")? : command => do
   let approx ←
     if approx.isSome then

--- a/Mathlib/Util/CountHeartbeats.lean
+++ b/Mathlib/Util/CountHeartbeats.lean
@@ -289,10 +289,8 @@ def countHeartbeatsLinter : Linter where run := withSetOptionIn fun stx ↦ do
 set_option linter.deprecated false in
 initialize addLinter countHeartbeatsLinter
 
-@[inherit_doc Mathlib.Linter.linter.countHeartbeats,
-deprecated "use `#count_heartbeats in` or `set_option trace.profiler true` with \
-  `set_option trace.profiler.useHeartbeats true`" (since := "2026-07-30")]
-macro "#count_heartbeats" approx:(&" approximately")? : command => do
+@[inherit_doc Mathlib.Linter.linter.countHeartbeats]
+macro (name := count_heartbeats) "#count_heartbeats" approx:(&" approximately")? : command => do
   let approx ←
     if approx.isSome then
       `(set_option linter.countHeartbeatsApprox true) else
@@ -301,6 +299,9 @@ macro "#count_heartbeats" approx:(&" approximately")? : command => do
     #[← `(command| set_option linter.countHeartbeats true),
       approx]⟩
 
+deprecated_syntax count_heartbeats "use `#count_heartbeats in` or \
+  `set_option trace.profiler true` with `set_option trace.profiler.useHeartbeats true`"
+  (since := "2026-07-30")
 
 end CountHeartbeats
 

--- a/Mathlib/Util/CountHeartbeats.lean
+++ b/Mathlib/Util/CountHeartbeats.lean
@@ -290,7 +290,7 @@ set_option linter.deprecated false in
 initialize addLinter countHeartbeatsLinter
 
 @[inherit_doc Mathlib.Linter.linter.countHeartbeats]
-macro (name := count_heartbeats) "#count_heartbeats" approx:(&" approximately")? : command => do
+macro (name := countHeartbeats) "#count_heartbeats" approx:(&" approximately")? : command => do
   let approx ←
     if approx.isSome then
       `(set_option linter.countHeartbeatsApprox true) else
@@ -299,7 +299,7 @@ macro (name := count_heartbeats) "#count_heartbeats" approx:(&" approximately")?
     #[← `(command| set_option linter.countHeartbeats true),
       approx]⟩
 
-deprecated_syntax count_heartbeats "use `#count_heartbeats in` or \
+deprecated_syntax countHeartbeats "use `#count_heartbeats in` or \
   `set_option trace.profiler true` with `set_option trace.profiler.useHeartbeats true`"
   (since := "2026-07-30")
 

--- a/MathlibTest/Util/CountHeartbeats.lean
+++ b/MathlibTest/Util/CountHeartbeats.lean
@@ -27,7 +27,7 @@ section using_count_heartbeats
 
 -- sets the `countHeartbeats` both linter option and the `approximate` option to `true`
 /--
-warning: syntax 'Mathlib.Linter.CountHeartbeats.count_heartbeats' has been deprecated: use `#count_heartbeats in` or `set_option trace.profiler true` with `set_option trace.profiler.useHeartbeats true`
+warning: syntax 'Mathlib.Linter.CountHeartbeats.countHeartbeats' has been deprecated: use `#count_heartbeats in` or `set_option trace.profiler true` with `set_option trace.profiler.useHeartbeats true`
 
 Note: This linter can be disabled with `set_option linter.deprecated.syntax false`
 -/

--- a/MathlibTest/Util/CountHeartbeats.lean
+++ b/MathlibTest/Util/CountHeartbeats.lean
@@ -26,6 +26,12 @@ example (a : Nat) : a = a := rfl
 section using_count_heartbeats
 
 -- sets the `countHeartbeats` both linter option and the `approximate` option to `true`
+/--
+warning: syntax 'Mathlib.Linter.CountHeartbeats.count_heartbeats' has been deprecated: use `#count_heartbeats in` or `set_option trace.profiler true` with `set_option trace.profiler.useHeartbeats true`
+
+Note: This linter can be disabled with `set_option linter.deprecated.syntax false`
+-/
+#guard_msgs in
 #count_heartbeats approximately
 
 mutual -- mutual declarations get ignored


### PR DESCRIPTION
This PR deprecates the global `#count_heartbeats` command. (Not to be confused with `#count_heartbeats in`, which we want to keep). The reason is that `#count_heartbeats` doesn't work in its current implementation.

A useful alternative is to use `set_option trace.profiler true` with `set_option trace.profiler.useHeartbeats` true.

As discussed in https://leanprover.zulipchat.com/#narrow/channel/263328-triage/topic/issue.20.214.2323905.3A.20linter.2EcountHeartbeats.20is.20broken/with/538006069

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
