### PR TITLE
[Merged by Bors] - feat(Probability/Kernel/Composition): kernel Radon-Nikodym derivative of composition products

### DIFF
--- a/Mathlib/Probability/Kernel/Composition/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/Composition/RadonNikodym.lean
@@ -6,8 +6,10 @@ Authors: Rémy Degenne
 module
 
 public import Mathlib.Probability.Kernel.Composition.MeasureCompProd
+public import Mathlib.Probability.Kernel.RadonNikodym
 
 import Mathlib.MeasureTheory.Measure.Decomposition.RadonNikodym
+import Mathlib.Probability.Kernel.CompProdEqIff
 
 /-!
 # Radon-Nikodym derivative of a composition product
@@ -16,6 +18,9 @@ We compute the Radon-Nikodym derivative of a composition product `μ ⊗ₘ κ` 
 composition product `ν ⊗ₘ η` in terms of the Radon-Nikodym derivatives `∂μ/∂ν` and
 `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)`.
 
+If `α` is countable or `β` is countably generated, the kernels have a Radon-Nikodym derivative
+`∂κ/∂η` and we give equivalent statements with `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)` replaced by `∂κ/∂η`.
+
 ## Main statements
 
 * `rnDeriv_compProd`: the Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(ν ⊗ₘ η)` equals the product of
@@ -23,10 +28,12 @@ composition product `ν ⊗ₘ η` in terms of the Radon-Nikodym derivatives `�
 * `rnDeriv_measure_compProd_left`: the Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(ν ⊗ₘ κ)`
   (with the same kernel) equals `∂μ/∂ν`.
 
-## TODO
+Under the assumption `CountableOrCountablyGenerated α β`:
 
-Under suitable assumptions to have Radon-Nikodym derivatives defined for kernels, we should give
-equivalent statements with `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)` replaced by `∂κ/∂η`.
+* `rnDeriv_measure_compProd_right`: the Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)`
+  (with the same measure) equals `∂κ/∂η`.
+* `rnDeriv_measure_compProd`: the Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(ν ⊗ₘ η)` equals the
+  product of `∂μ/∂ν` and `∂κ/∂η`.
 
 -/
 
@@ -103,7 +110,11 @@ lemma rnDeriv_measure_compProd_left (μ ν : Measure α) (κ : Kernel α β)
       (Measure.rnDeriv_withDensity ν (by fun_prop))
 
 /-- The Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(ν ⊗ₘ η)` equals the product of `∂μ/∂ν` and
-`∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)`. -/
+`∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)`.
+
+See `rnDeriv_measure_compProd` for a version that replaces `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)` by `∂κ/∂η`
+and does not require the absolute continuity hypothesis, assuming that `α` is countable or `β` is
+countably generated. -/
 lemma rnDeriv_compProd [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η]
     (h_ac : μ ⊗ₘ κ ≪ μ ⊗ₘ η) (ν : Measure α) [IsFiniteMeasure ν] :
     (μ ⊗ₘ κ).rnDeriv (ν ⊗ₘ η) =ᵐ[ν ⊗ₘ η]
@@ -111,5 +122,50 @@ lemma rnDeriv_compProd [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel 
   refine Filter.EventuallyEq.trans (Measure.rnDeriv_mul_rnDeriv h_ac).symm ?_
   filter_upwards [rnDeriv_measure_compProd_left μ ν η] with p hp
   rw [Pi.mul_apply, hp, mul_comm]
+
+section CountableOrCountablyGenerated
+
+variable [MeasurableSpace.CountableOrCountablyGenerated α β]
+
+/-- The Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)` (with the same measure)
+equals `∂κ/∂η`. -/
+lemma rnDeriv_measure_compProd_right (μ : Measure α) (κ η : Kernel α β)
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η] :
+    (μ ⊗ₘ κ).rnDeriv (μ ⊗ₘ η) =ᵐ[μ ⊗ₘ η] fun p ↦ κ.rnDeriv η p.1 p.2 := by
+  refine (Measure.eq_rnDeriv (Kernel.measurable_rnDeriv κ η)
+    (Measure.MutuallySingular.compProd_of_right μ μ
+      (.of_forall <| Kernel.mutuallySingular_singularPart κ η)) ?_).symm
+  rw [← Measure.compProd_withDensity (Kernel.measurable_rnDeriv κ η),
+    ← Measure.compProd_add_right, add_comm, Kernel.rnDeriv_add_singularPart]
+
+/-- The Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(ν ⊗ₘ η)` equals the product of `∂μ/∂ν` and
+`∂κ/∂η`. -/
+lemma rnDeriv_measure_compProd (μ ν : Measure α) (κ η : Kernel α β)
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν] [IsFiniteKernel κ] [IsFiniteKernel η] :
+    (μ ⊗ₘ κ).rnDeriv (ν ⊗ₘ η) =ᵐ[ν ⊗ₘ η] fun p ↦ μ.rnDeriv ν p.1 * κ.rnDeriv η p.1 p.2 := by
+  have h_add : μ ⊗ₘ κ = μ ⊗ₘ κ.singularPart η + μ ⊗ₘ η.withDensity (κ.rnDeriv η) := by
+    conv_lhs => rw [← Kernel.rnDeriv_add_singularPart κ η]
+    rw [Measure.compProd_add_right, add_comm]
+  have h_sing : (μ ⊗ₘ κ.singularPart η).rnDeriv (ν ⊗ₘ η) =ᵐ[ν ⊗ₘ η] 0 :=
+    Measure.rnDeriv_eq_zero_of_mutuallySingular
+      (Measure.MutuallySingular.compProd_of_right μ ν
+        (.of_forall <| Kernel.mutuallySingular_singularPart κ η))
+      Measure.AbsolutelyContinuous.rfl
+  have h_ne_top : ∀ᵐ p ∂(μ ⊗ₘ η), κ.rnDeriv η p.1 p.2 ≠ ∞ := by
+    refine Measure.ae_compProd_of_ae_ae (p := fun p ↦ κ.rnDeriv η p.1 p.2 ≠ ∞)
+      (Kernel.measurable_rnDeriv κ η (measurableSet_singleton ∞)).compl ?_
+    exact ae_of_all _ fun _ ↦ Kernel.rnDeriv_ne_top κ η
+  have h_wd : (μ ⊗ₘ η.withDensity (κ.rnDeriv η)).rnDeriv (ν ⊗ₘ η)
+      =ᵐ[ν ⊗ₘ η] fun p ↦ κ.rnDeriv η p.1 p.2 * (μ ⊗ₘ η).rnDeriv (ν ⊗ₘ η) p := by
+    rw [Measure.compProd_withDensity (Kernel.measurable_rnDeriv κ η)]
+    exact Measure.rnDeriv_withDensity_left (Kernel.measurable_rnDeriv κ η).aemeasurable h_ne_top
+  rw [h_add]
+  have h_add' := Measure.rnDeriv_add' (μ ⊗ₘ κ.singularPart η)
+    (μ ⊗ₘ η.withDensity (κ.rnDeriv η)) (ν ⊗ₘ η)
+  filter_upwards [h_add', h_sing, h_wd, rnDeriv_measure_compProd_left μ ν η]
+    with p h1 h2 h3 h4
+  rw [h1, Pi.add_apply, h2, Pi.zero_apply, zero_add, h3, h4, mul_comm]
+
+end CountableOrCountablyGenerated
 
 end ProbabilityTheory

--- a/Mathlib/Probability/Kernel/Composition/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/Composition/RadonNikodym.lean
@@ -18,7 +18,7 @@ composition product `ν ⊗ₘ η` in terms of the Radon-Nikodym derivatives `�
 `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)`.
 
 If `α` is countable or `β` is countably generated, the kernels have a Radon-Nikodym derivative
-`∂κ/∂η` and we give equivalent statements with `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)` replaced by `∂κ/∂η`.
+`∂κ/∂η` and we give statements in terms of `∂κ/∂η`.
 
 ## Main statements
 

--- a/Mathlib/Probability/Kernel/Composition/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/Composition/RadonNikodym.lean
@@ -26,13 +26,10 @@ If `α` is countable or `β` is countably generated, the kernels have a Radon-Ni
   `∂μ/∂ν` and `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)`.
 * `rnDeriv_measure_compProd_left`: the Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(ν ⊗ₘ κ)`
   (with the same kernel) equals `∂μ/∂ν`.
-
-Under the assumption `CountableOrCountablyGenerated α β`:
-
-* `rnDeriv_measure_compProd_right`: the Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)`
-  (with the same measure) equals `∂κ/∂η`.
 * `rnDeriv_measure_compProd`: the Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(ν ⊗ₘ η)` equals the
   product of `∂μ/∂ν` and `∂κ/∂η`.
+* `rnDeriv_measure_compProd_right`: the Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)`
+  (with the same measure) equals `∂κ/∂η`.
 
 -/
 
@@ -126,17 +123,6 @@ section CountableOrCountablyGenerated
 
 variable [MeasurableSpace.CountableOrCountablyGenerated α β]
 
-/-- The Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)` (with the same measure)
-equals `∂κ/∂η`. -/
-lemma rnDeriv_measure_compProd_right (μ : Measure α) (κ η : Kernel α β)
-    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η] :
-    (μ ⊗ₘ κ).rnDeriv (μ ⊗ₘ η) =ᵐ[μ ⊗ₘ η] fun p ↦ κ.rnDeriv η p.1 p.2 := by
-  refine (Measure.eq_rnDeriv (Kernel.measurable_rnDeriv κ η)
-    (Measure.MutuallySingular.compProd_of_right μ μ
-      (.of_forall <| Kernel.mutuallySingular_singularPart κ η)) ?_).symm
-  rw [← Measure.compProd_withDensity (Kernel.measurable_rnDeriv κ η),
-    ← Measure.compProd_add_right, add_comm, Kernel.rnDeriv_add_singularPart]
-
 /-- The Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(ν ⊗ₘ η)` equals the product of `∂μ/∂ν` and
 `∂κ/∂η`. -/
 lemma rnDeriv_measure_compProd (μ ν : Measure α) (κ η : Kernel α β)
@@ -163,6 +149,15 @@ lemma rnDeriv_measure_compProd (μ ν : Measure α) (κ η : Kernel α β)
   filter_upwards [h_add', h_sing, h_wd, rnDeriv_measure_compProd_left μ ν η]
     with p h1 h2 h3 h4
   rw [h1, Pi.add_apply, h2, Pi.zero_apply, zero_add, h3, h4, mul_comm]
+
+/-- The Radon-Nikodym derivative `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)` (with the same measure)
+equals `∂κ/∂η`. -/
+lemma rnDeriv_measure_compProd_right (μ : Measure α) (κ η : Kernel α β)
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η] :
+    (μ ⊗ₘ κ).rnDeriv (μ ⊗ₘ η) =ᵐ[μ ⊗ₘ η] fun p ↦ κ.rnDeriv η p.1 p.2 := by
+  filter_upwards [Measure.ae_compProd_of_ae_fst η (by measurability) μ.rnDeriv_self,
+    rnDeriv_measure_compProd μ μ κ η]
+  simp_all
 
 end CountableOrCountablyGenerated
 

--- a/Mathlib/Probability/Kernel/Composition/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/Composition/RadonNikodym.lean
@@ -148,8 +148,7 @@ lemma rnDeriv_measure_compProd (μ ν : Measure α) (κ η : Kernel α β)
   have h_sing : (μ ⊗ₘ κ.singularPart η).rnDeriv (ν ⊗ₘ η) =ᵐ[ν ⊗ₘ η] 0 :=
     Measure.rnDeriv_eq_zero_of_mutuallySingular
       (Measure.MutuallySingular.compProd_of_right μ ν
-        (.of_forall <| Kernel.mutuallySingular_singularPart κ η))
-      Measure.AbsolutelyContinuous.rfl
+        (.of_forall <| Kernel.mutuallySingular_singularPart κ η)) .rfl
   have h_ne_top : ∀ᵐ p ∂(μ ⊗ₘ η), κ.rnDeriv η p.1 p.2 ≠ ∞ := by
     refine Measure.ae_compProd_of_ae_ae (p := fun p ↦ κ.rnDeriv η p.1 p.2 ≠ ∞)
       (Kernel.measurable_rnDeriv κ η (measurableSet_singleton ∞)).compl ?_

--- a/Mathlib/Probability/Kernel/Composition/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/Composition/RadonNikodym.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Probability.Kernel.Composition.MeasureCompProd
 public import Mathlib.Probability.Kernel.RadonNikodym
 
-import Mathlib.MeasureTheory.Measure.Decomposition.RadonNikodym
 import Mathlib.Probability.Kernel.CompProdEqIff
 
 /-!


### PR DESCRIPTION
This PR resolves the TODO in this file by adding `rnDeriv_measure_compProd_right` and `rnDeriv_measure_compProd`, which replace `∂(μ ⊗ₘ κ)/∂(μ ⊗ₘ η)` by `∂κ/∂η` under the suitable assumptions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
