### PR TITLE
feat(Logic/Relation): newman's lemma and unique normal forms

### DIFF
--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 module
 
+public import Mathlib.Logic.ExistsUnique
 public import Mathlib.Logic.Relator
 public import Mathlib.Tactic.Use
 public import Mathlib.Tactic.MkIffOfInductiveProp
@@ -47,6 +48,14 @@ the bundled version, see `Rel`.
   related by `r`.
 * `Relation.Join`: Join of a relation. For `r : α → α → Prop`, `Join r a b ↔ ∃ c, r a c ∧ r b c`. In
   terms of rewriting systems, this means that `a` and `b` can be rewritten to the same term.
+
+## Main results
+
+* `Relation.newman`: A terminating, locally confluent relation is confluent.
+* `Relation.normal_form_unique_of_confluent`: Normal forms reachable from a common element are
+  equal in a confluent rewriting system.
+* `Relation.exists_unique_normal_form`: Every element of a terminating, locally confluent
+  rewriting system reduces to a unique normal form.
 -/
 
 @[expose] public section
@@ -914,6 +923,60 @@ theorem church_rosser (h : ∀ a b c, r a b → r a c → ∃ d, ReflGen r b d �
     cases hba with
     | refl => exact ⟨b, hea, hcb⟩
     | single hba => exact ⟨a, hea, hcb.tail hba⟩
+
+/-- **Newman's lemma**: if the reverse of a relation is well-founded and every pair of one-step
+reductions is joinable, then any two finite reduction sequences from a common source are joinable.
+
+This neither implies nor is implied by `church_rosser`. That theorem assumes the one-step diamond
+condition `∀ a b c, r a b → r a c → ∃ d, ReflGen r b d ∧ ReflTransGen r c d` and makes no
+termination assumption, whereas this one assumes local confluence together with well-foundedness
+of the reverse relation. The two hypothesis sets are incomparable: the diamond condition does not
+imply termination, and termination together with local confluence does not imply the diamond
+condition. -/
+theorem newman {α : Type*} {r : α → α → Prop} (hwf : WellFounded (Function.swap r))
+    (hlocal : ∀ a b c, r a b → r a c → Join (ReflTransGen r) b c) {a b c : α}
+    (hab : ReflTransGen r a b) (hac : ReflTransGen r a c) : Join (ReflTransGen r) b c :=
+  (hwf.induction a (C := fun a ↦ ∀ b c, ReflTransGen r a b → ReflTransGen r a c →
+    Join (ReflTransGen r) b c) fun a ih b c hab hac ↦ by
+      rcases hab.cases_head with rfl | ⟨a₁, ha₁, h₁b⟩
+      · exact ⟨c, hac, .refl⟩
+      rcases hac.cases_head with rfl | ⟨a₂, ha₂, h₂c⟩
+      · exact ⟨b, .refl, hab⟩
+      obtain ⟨d, h₁d, h₂d⟩ := hlocal a a₁ a₂ ha₁ ha₂
+      obtain ⟨e, hbe, hde⟩ := ih a₁ ha₁ b d h₁b h₁d
+      obtain ⟨f, hcf, hef⟩ := ih a₂ ha₂ c e h₂c (h₂d.trans hde)
+      exact ⟨f, hbe.trans hef, hcf⟩) b c hab hac
+
+/-- Two normal forms reachable by finite reduction sequences from the same element are equal if
+the relation is confluent. -/
+theorem normal_form_unique_of_confluent {α : Type*} {r : α → α → Prop}
+    (hconfluent : ∀ a b c, ReflTransGen r a b → ReflTransGen r a c →
+      Join (ReflTransGen r) b c)
+    {a n₁ n₂ : α} (han₁ : ReflTransGen r a n₁) (hn₁ : ∀ b, ¬ r n₁ b)
+    (han₂ : ReflTransGen r a n₂) (hn₂ : ∀ b, ¬ r n₂ b) : n₁ = n₂ := by
+  obtain ⟨d, hn₁d, hn₂d⟩ := hconfluent a n₁ n₂ han₁ han₂
+  have h₁ : d = n₁ := (reflTransGen_iff_eq hn₁).mp hn₁d
+  have h₂ : d = n₂ := (reflTransGen_iff_eq hn₂).mp hn₂d
+  exact h₁.symm.trans h₂
+
+/-- Every element of a relation satisfying the hypotheses of Newman's lemma reduces to a unique
+normal form. -/
+theorem exists_unique_normal_form {α : Type*} {r : α → α → Prop}
+    (hwf : WellFounded (Function.swap r))
+    (hlocal : ∀ a b c, r a b → r a c → Join (ReflTransGen r) b c) (a : α) :
+    ∃! n, ReflTransGen r a n ∧ ∀ b, ¬ r n b := by
+  classical
+  have hexists : ∀ a, ∃ n, ReflTransGen r a n ∧ ∀ b, ¬ r n b := fun a ↦
+    hwf.induction a (C := fun a ↦ ∃ n, ReflTransGen r a n ∧ ∀ b, ¬ r n b) fun a ih ↦ by
+      by_cases h : ∃ b, r a b
+      · obtain ⟨b, hab⟩ := h
+        obtain ⟨n, hbn, hn⟩ := ih b hab
+        exact ⟨n, (ReflTransGen.single hab).trans hbn, hn⟩
+      · exact ⟨a, .refl, fun b hab ↦ h ⟨b, hab⟩⟩
+  obtain ⟨n, han, hn⟩ := hexists a
+  refine ⟨n, ⟨han, hn⟩, ?_⟩
+  rintro m ⟨ham, hm⟩
+  exact normal_form_unique_of_confluent (fun _ _ _ ↦ newman hwf hlocal) ham hm han hn
 
 theorem le_join_of_refl [Std.Refl r] : r ≤ Join r :=
   fun _ b hab ↦ ⟨b, hab, refl b⟩


### PR DESCRIPTION
Adds Newman's lemma for an arbitrary abstract rewriting relation, together with the two normal-form corollaries.

- `Relation.newman`: if `Function.swap r` is well-founded and every pair of one-step reductions is joinable, then `ReflTransGen r` is confluent.
- `Relation.normal_form_unique_of_confluent`: normal forms reachable from a common element in a confluent system are equal.
- `Relation.exists_unique_normal_form`: every element reduces to a unique normal form.

### Relation to `church_rosser`

`Relation.church_rosser` already lives in this file, but it assumes the one-step diamond condition `∀ a b c, r a b → r a c → ∃ d, ReflGen r b d ∧ ReflTransGen r c d` and makes no termination assumption. Newman's lemma instead assumes local confluence together with well-foundedness of the reverse relation. Neither hypothesis set implies the other, so this is not a duplicate; the `newman` docstring records the comparison.

I searched for an existing generic version under other names (`Newman`, `LocallyConfluent`, `locally_confluent`, local confluence) and found only `FreeGroup.Red.church_rosser`, which is a specialization to free-group word reduction.

### Placement

I put these in the `Join` section right after `church_rosser`, since they share its vocabulary (`Join`, `ReflTransGen`). This requires adding `public import Mathlib.Logic.ExistsUnique` for `exists_unique_normal_form`; that module only imports `Mathlib.Init`, so the cost is minimal. If maintainers would rather keep `Logic/Relation.lean` free of that import, I am happy to move the three results to a new `Mathlib/Logic/Relation/Confluence.lean` instead — just say which you prefer.

Hypotheses are stated inline rather than through new `LocallyConfluent` / `Confluent` predicates, matching how `church_rosser` states its own hypothesis. Introducing named predicates seemed better left until there is a concrete consumer.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/leanprover-community/mathlib4/tree/newman-lemma-confluence)


---

### AI disclosure

Per the contribution guidelines, disclosing AI involvement in this PR.

**Tools used.** The Lean proofs were drafted with the OpenAI Codex CLI agent, orchestrated by Claude Code. I directed the work, set the constraints, and reviewed the output.

**What the AI produced.** The statements and proofs of the three theorems, and the port from a Lean 4.28 development to current master. The only adaptation the port required was `{α : Sort*}` → `{α : Type*}`, since `Relation.Join` and `ReflTransGen` are stated for `Type*` here.

**What was checked before submitting.**

- Three independent adversarial review passes (architecture / behaviour / verification strength), each run in isolation so they could not see each other's conclusions.
- Mutation testing: a four-element counter-model where the relation is locally confluent but not confluent, confirming the well-foundedness hypothesis is not redundant.
- The duplicate search was re-run against current master, not against a cached snapshot. `git grep` over `origin/master` for `newman`, `LocallyConfluent`, `locally_confluent` and local confluence returns only a historical mention of the name in `Mathlib/Geometry/Manifold/PoincareConjecture.lean` and the free-group specialization `FreeGroup.Red.church_rosser`.
- `lake build Mathlib.Logic.Relation`, `lake exe runLinter Mathlib.Logic.Relation` and `lake exe lint-style Mathlib.Logic.Relation` were re-run locally by hand, not taken on the agent's report.

I could not add the `LLM-generated` label myself (no permission as a new contributor) — could a maintainer add it?



**On the comprehension requirement.** I worked through the proofs with AI assistance and can
explain them unaided. Termination enters at exactly one point, the well-founded induction on the
source; the induction hypothesis is then applied twice rather than once, because the first
application joins `b` with the local-confluence witness at `e` and leaves `e` and `c` still
unjoined. It is not a redundant hypothesis: on the four-element relation with `b ← a → c` and `b`,
`c` rewriting to each other, local confluence holds but confluence fails. The one design choice
here was to state the hypotheses inline rather than introduce `LocallyConfluent` / `Confluent`
predicates, matching how `church_rosser` states its own; happy to add them if reviewers prefer.
