### PR TITLE
feat(GroupTheory): add the lattice of normal subgroups

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4839,6 +4839,8 @@ public import Mathlib.GroupTheory.MonoidLocalization.UniqueFactorization
 public import Mathlib.GroupTheory.Nilpotent
 public import Mathlib.GroupTheory.NoncommCoprod
 public import Mathlib.GroupTheory.NoncommPiCoprod
+public import Mathlib.GroupTheory.NormalSubgroup.Basic
+public import Mathlib.GroupTheory.NormalSubgroup.ModularLattice
 public import Mathlib.GroupTheory.Order.Min
 public import Mathlib.GroupTheory.OrderOfElement
 public import Mathlib.GroupTheory.OreLocalization.Basic

--- a/Mathlib/GroupTheory/NormalSubgroup/Basic.lean
+++ b/Mathlib/GroupTheory/NormalSubgroup/Basic.lean
@@ -19,12 +19,12 @@ structure inherited from `Subgroup`.
 /-- A normal subgroup of an arbitrary group. -/
 @[ext]
 structure NormalSubgroup (G : Type*) [Group G] extends Subgroup G where
-  isNormal' : toSubgroup.Normal := by infer_instance
+  normal : toSubgroup.Normal := by infer_instance
 
 /-- A normal additive subgroup of an arbitrary additive group. -/
 @[ext]
 structure NormalAddSubgroup (G : Type*) [AddGroup G] extends AddSubgroup G where
-  isNormal' : toAddSubgroup.Normal := by infer_instance
+  normal : toAddSubgroup.Normal := by infer_instance
 
 attribute [to_additive] NormalSubgroup
 
@@ -55,7 +55,7 @@ instance : Coe (NormalSubgroup G) (Subgroup G) where
   coe H := H.toSubgroup
 
 @[to_additive]
-instance (H : NormalSubgroup G) : H.toSubgroup.Normal := H.isNormal'
+instance (H : NormalSubgroup G) : H.toSubgroup.Normal := H.normal
 
 /-- Bundle a subgroup carrying a normality instance. -/
 @[to_additive /-- Bundle an additive subgroup carrying a normality instance. -/]

--- a/Mathlib/GroupTheory/NormalSubgroup/Basic.lean
+++ b/Mathlib/GroupTheory/NormalSubgroup/Basic.lean
@@ -6,7 +6,6 @@ Authors: Diwen Yu
 module
 
 public import Mathlib.Algebra.Group.Subgroup.Pointwise
-public import Mathlib.Order.Copy
 
 /-!
 # Normal subgroups as a complete lattice
@@ -34,12 +33,8 @@ namespace NormalSubgroup
 variable {G : Type*} [Group G]
 
 @[to_additive]
-theorem toSubgroup_injective : Function.Injective
-    (fun H ↦ H.toSubgroup : NormalSubgroup G → Subgroup G) :=
-  fun A B h ↦ by
-    ext
-    dsimp at h
-    rw [h]
+theorem toSubgroup_injective : Function.Injective (NormalSubgroup.toSubgroup (G := G)) :=
+  fun A B h ↦ NormalSubgroup.ext (by simp [h])
 
 @[to_additive]
 instance : SetLike (NormalSubgroup G) G where
@@ -52,7 +47,7 @@ instance : PartialOrder (NormalSubgroup G) := .ofSetLike (NormalSubgroup G) G
 @[to_additive]
 instance : SubgroupClass (NormalSubgroup G) G where
   mul_mem := Subsemigroup.mul_mem' _
-  one_mem H := H.toSubgroup.one_mem
+  one_mem H := H.one_mem'
   inv_mem := Subgroup.inv_mem' _
 
 @[to_additive]
@@ -72,6 +67,32 @@ theorem toSubgroup_ofSubgroup (H : Subgroup G) [H.Normal] :
     ((ofSubgroup H : NormalSubgroup G) : Subgroup G) = H :=
   rfl
 
+@[to_additive]
+instance : OrderTop (NormalSubgroup G) where
+  top := { toSubgroup := ⊤ }
+  le_top H := show H.toSubgroup ≤ ⊤ from le_top
+
+@[to_additive]
+instance : OrderBot (NormalSubgroup G) where
+  bot := { toSubgroup := ⊥ }
+  bot_le H := show (⊥ : Subgroup G) ≤ H.toSubgroup from bot_le
+
+@[to_additive]
+instance : SemilatticeSup (NormalSubgroup G) where
+  sup H K := { toSubgroup := H.toSubgroup ⊔ K.toSubgroup }
+  le_sup_left H K := show H.toSubgroup ≤ H.toSubgroup ⊔ K.toSubgroup from le_sup_left
+  le_sup_right H K := show K.toSubgroup ≤ H.toSubgroup ⊔ K.toSubgroup from le_sup_right
+  sup_le H K L hH hK :=
+    show H.toSubgroup ⊔ K.toSubgroup ≤ L.toSubgroup from sup_le hH hK
+
+@[to_additive]
+instance : SemilatticeInf (NormalSubgroup G) where
+  inf H K := { toSubgroup := H.toSubgroup ⊓ K.toSubgroup }
+  inf_le_left H K := show H.toSubgroup ⊓ K.toSubgroup ≤ H.toSubgroup from inf_le_left
+  inf_le_right H K := show H.toSubgroup ⊓ K.toSubgroup ≤ K.toSubgroup from inf_le_right
+  le_inf H K L hK hL :=
+    show H.toSubgroup ≤ K.toSubgroup ⊓ L.toSubgroup from le_inf hK hL
+
 variable (G) in
 /-- `normalClosure` forms a Galois insertion with the coercion to subgroups. -/
 @[to_additive /-- `normalClosure` forms a Galois insertion with the coercion to additive
@@ -85,20 +106,12 @@ protected def gi :
   choice_eq _ _ := rfl
 
 @[to_additive]
-instance : CompleteLattice (NormalSubgroup G) :=
-  fast_instance% CompleteLattice.copy
-    (GaloisInsertion.liftCompleteLattice (NormalSubgroup.gi G))
-    _ rfl
-    { toSubgroup := ⊤ } (toSubgroup_injective <| (Subgroup.normalClosure_eq_self _).symm)
-    { toSubgroup := ⊥ } (toSubgroup_injective <| (Subgroup.normalClosure_eq_self _).symm)
-    (fun H K ↦ { toSubgroup := H.toSubgroup ⊔ K.toSubgroup })
-      (funext fun H ↦ funext fun K ↦
-        toSubgroup_injective <| (Subgroup.normalClosure_eq_self _).symm)
-    (fun H K ↦ { toSubgroup := H.toSubgroup ⊓ K.toSubgroup })
-      (funext fun H ↦ funext fun K ↦
-        toSubgroup_injective <| (Subgroup.normalClosure_eq_self _).symm)
-    _ rfl
-    _ rfl
+instance : CompleteLattice (NormalSubgroup G) where
+  __ := (inferInstance : OrderTop (NormalSubgroup G))
+  __ := (inferInstance : OrderBot (NormalSubgroup G))
+  __ := (inferInstance : SemilatticeSup (NormalSubgroup G))
+  __ := (inferInstance : SemilatticeInf (NormalSubgroup G))
+  __ := (NormalSubgroup.gi G).liftCompleteLattice
 
 @[to_additive (attr := simp)]
 theorem toSubgroup_top : ((⊤ : NormalSubgroup G) : Subgroup G) = ⊤ := rfl

--- a/Mathlib/GroupTheory/NormalSubgroup/Basic.lean
+++ b/Mathlib/GroupTheory/NormalSubgroup/Basic.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Diwen Yu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Diwen Yu
+-/
+module
+
+public import Mathlib.Algebra.Group.Subgroup.Pointwise
+
+/-!
+# Normal subgroups as a complete lattice
+
+This file bundles normal subgroups of an arbitrary group and equips them with the complete lattice
+structure inherited from `Subgroup`.
+-/
+
+@[expose] public section
+
+/-- A normal subgroup of an arbitrary group. -/
+@[ext]
+structure NormalSubgroup (G : Type*) [Group G] extends Subgroup G where
+  isNormal' : toSubgroup.Normal := by infer_instance
+
+/-- A normal additive subgroup of an arbitrary additive group. -/
+@[ext]
+structure NormalAddSubgroup (G : Type*) [AddGroup G] extends AddSubgroup G where
+  isNormal' : toAddSubgroup.Normal := by infer_instance
+
+attribute [to_additive] NormalSubgroup
+
+namespace NormalSubgroup
+
+variable {G : Type*} [Group G]
+
+@[to_additive]
+theorem toSubgroup_injective : Function.Injective
+    (fun H ↦ H.toSubgroup : NormalSubgroup G → Subgroup G) :=
+  fun A B h ↦ by
+    ext
+    dsimp at h
+    rw [h]
+
+@[to_additive]
+instance : SetLike (NormalSubgroup G) G where
+  coe H := H.toSubgroup
+  coe_injective _ _ h := toSubgroup_injective <| SetLike.ext' h
+
+@[to_additive]
+instance : PartialOrder (NormalSubgroup G) := .ofSetLike (NormalSubgroup G) G
+
+@[to_additive]
+instance : SubgroupClass (NormalSubgroup G) G where
+  mul_mem := Subsemigroup.mul_mem' _
+  one_mem H := H.toSubgroup.one_mem
+  inv_mem := Subgroup.inv_mem' _
+
+@[to_additive]
+instance : Coe (NormalSubgroup G) (Subgroup G) where
+  coe H := H.toSubgroup
+
+@[to_additive]
+instance (H : NormalSubgroup G) : H.toSubgroup.Normal := H.isNormal'
+
+/-- Bundle a subgroup carrying a normality instance. -/
+@[to_additive /-- Bundle an additive subgroup carrying a normality instance. -/]
+def ofSubgroup (H : Subgroup G) [H.Normal] : NormalSubgroup G :=
+  { toSubgroup := H }
+
+@[to_additive (attr := simp)]
+theorem toSubgroup_ofSubgroup (H : Subgroup G) [H.Normal] :
+    ((ofSubgroup H : NormalSubgroup G) : Subgroup G) = H :=
+  rfl
+
+@[to_additive]
+instance : Top (NormalSubgroup G) :=
+  ⟨{ toSubgroup := ⊤ }⟩
+
+@[to_additive]
+instance : Bot (NormalSubgroup G) :=
+  ⟨{ toSubgroup := ⊥ }⟩
+
+@[to_additive]
+instance : Max (NormalSubgroup G) :=
+  ⟨fun H K ↦ { toSubgroup := H.toSubgroup ⊔ K.toSubgroup }⟩
+
+@[to_additive]
+instance : Min (NormalSubgroup G) :=
+  ⟨fun H K ↦ { toSubgroup := H.toSubgroup ⊓ K.toSubgroup }⟩
+
+@[to_additive]
+instance : SupSet (NormalSubgroup G) :=
+  ⟨fun s ↦ { toSubgroup := ⨆ H, ⨆ (_ : H ∈ s), H.toSubgroup }⟩
+
+@[to_additive]
+instance : InfSet (NormalSubgroup G) :=
+  ⟨fun s ↦ {
+    toSubgroup := ⨅ H, ⨅ (_ : H ∈ s), H.toSubgroup
+    isNormal' := Subgroup.normal_iInf_normal fun H ↦
+      Subgroup.normal_iInf_normal fun _ ↦ H.isNormal'
+  }⟩
+
+@[to_additive (attr := simp)]
+theorem toSubgroup_top : ((⊤ : NormalSubgroup G) : Subgroup G) = ⊤ := rfl
+
+@[to_additive (attr := simp)]
+theorem toSubgroup_bot : ((⊥ : NormalSubgroup G) : Subgroup G) = ⊥ := rfl
+
+@[to_additive (attr := simp)]
+theorem toSubgroup_sup (H K : NormalSubgroup G) :
+    ((H ⊔ K : NormalSubgroup G) : Subgroup G) = H.toSubgroup ⊔ K.toSubgroup :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem toSubgroup_inf (H K : NormalSubgroup G) :
+    ((H ⊓ K : NormalSubgroup G) : Subgroup G) = H.toSubgroup ⊓ K.toSubgroup :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem toSubgroup_sSup (s : Set (NormalSubgroup G)) :
+    ((sSup s : NormalSubgroup G) : Subgroup G) = ⨆ H, ⨆ (_ : H ∈ s), H.toSubgroup :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem toSubgroup_sInf (s : Set (NormalSubgroup G)) :
+    ((sInf s : NormalSubgroup G) : Subgroup G) = ⨅ H, ⨅ (_ : H ∈ s), H.toSubgroup :=
+  rfl
+
+@[to_additive]
+instance : CompleteLattice (NormalSubgroup G) :=
+  toSubgroup_injective.completeLattice _ .rfl .rfl toSubgroup_sup toSubgroup_inf
+    toSubgroup_sSup toSubgroup_sInf toSubgroup_top toSubgroup_bot
+
+@[to_additive (attr := simp)]
+theorem mem_toSubgroup_iff {H : NormalSubgroup G} {g : G} : g ∈ H.toSubgroup ↔ g ∈ H :=
+  .rfl
+
+end NormalSubgroup

--- a/Mathlib/GroupTheory/NormalSubgroup/Basic.lean
+++ b/Mathlib/GroupTheory/NormalSubgroup/Basic.lean
@@ -6,6 +6,7 @@ Authors: Diwen Yu
 module
 
 public import Mathlib.Algebra.Group.Subgroup.Pointwise
+public import Mathlib.Order.Copy
 
 /-!
 # Normal subgroups as a complete lattice
@@ -71,33 +72,33 @@ theorem toSubgroup_ofSubgroup (H : Subgroup G) [H.Normal] :
     ((ofSubgroup H : NormalSubgroup G) : Subgroup G) = H :=
   rfl
 
-@[to_additive]
-instance : Top (NormalSubgroup G) :=
-  ⟨{ toSubgroup := ⊤ }⟩
+variable (G) in
+/-- `normalClosure` forms a Galois insertion with the coercion to subgroups. -/
+@[to_additive /-- `normalClosure` forms a Galois insertion with the coercion to additive
+subgroups. -/]
+protected def gi :
+    GaloisInsertion (fun H : Subgroup G ↦ ofSubgroup (Subgroup.normalClosure H))
+      ((↑) : NormalSubgroup G → Subgroup G) where
+  choice H _ := ofSubgroup (Subgroup.normalClosure H)
+  gc _ _ := Subgroup.normalClosure_subset_iff.symm
+  le_l_u _ := Subgroup.le_normalClosure
+  choice_eq _ _ := rfl
 
 @[to_additive]
-instance : Bot (NormalSubgroup G) :=
-  ⟨{ toSubgroup := ⊥ }⟩
-
-@[to_additive]
-instance : Max (NormalSubgroup G) :=
-  ⟨fun H K ↦ { toSubgroup := H.toSubgroup ⊔ K.toSubgroup }⟩
-
-@[to_additive]
-instance : Min (NormalSubgroup G) :=
-  ⟨fun H K ↦ { toSubgroup := H.toSubgroup ⊓ K.toSubgroup }⟩
-
-@[to_additive]
-instance : SupSet (NormalSubgroup G) :=
-  ⟨fun s ↦ { toSubgroup := ⨆ H, ⨆ (_ : H ∈ s), H.toSubgroup }⟩
-
-@[to_additive]
-instance : InfSet (NormalSubgroup G) :=
-  ⟨fun s ↦ {
-    toSubgroup := ⨅ H, ⨅ (_ : H ∈ s), H.toSubgroup
-    isNormal' := Subgroup.normal_iInf_normal fun H ↦
-      Subgroup.normal_iInf_normal fun _ ↦ H.isNormal'
-  }⟩
+instance : CompleteLattice (NormalSubgroup G) :=
+  fast_instance% CompleteLattice.copy
+    (GaloisInsertion.liftCompleteLattice (NormalSubgroup.gi G))
+    _ rfl
+    { toSubgroup := ⊤ } (toSubgroup_injective <| (Subgroup.normalClosure_eq_self _).symm)
+    { toSubgroup := ⊥ } (toSubgroup_injective <| (Subgroup.normalClosure_eq_self _).symm)
+    (fun H K ↦ { toSubgroup := H.toSubgroup ⊔ K.toSubgroup })
+      (funext fun H ↦ funext fun K ↦
+        toSubgroup_injective <| (Subgroup.normalClosure_eq_self _).symm)
+    (fun H K ↦ { toSubgroup := H.toSubgroup ⊓ K.toSubgroup })
+      (funext fun H ↦ funext fun K ↦
+        toSubgroup_injective <| (Subgroup.normalClosure_eq_self _).symm)
+    _ rfl
+    _ rfl
 
 @[to_additive (attr := simp)]
 theorem toSubgroup_top : ((⊤ : NormalSubgroup G) : Subgroup G) = ⊤ := rfl
@@ -114,21 +115,6 @@ theorem toSubgroup_sup (H K : NormalSubgroup G) :
 theorem toSubgroup_inf (H K : NormalSubgroup G) :
     ((H ⊓ K : NormalSubgroup G) : Subgroup G) = H.toSubgroup ⊓ K.toSubgroup :=
   rfl
-
-@[to_additive (attr := simp)]
-theorem toSubgroup_sSup (s : Set (NormalSubgroup G)) :
-    ((sSup s : NormalSubgroup G) : Subgroup G) = ⨆ H, ⨆ (_ : H ∈ s), H.toSubgroup :=
-  rfl
-
-@[to_additive (attr := simp)]
-theorem toSubgroup_sInf (s : Set (NormalSubgroup G)) :
-    ((sInf s : NormalSubgroup G) : Subgroup G) = ⨅ H, ⨅ (_ : H ∈ s), H.toSubgroup :=
-  rfl
-
-@[to_additive]
-instance : CompleteLattice (NormalSubgroup G) :=
-  toSubgroup_injective.completeLattice _ .rfl .rfl toSubgroup_sup toSubgroup_inf
-    toSubgroup_sSup toSubgroup_sInf toSubgroup_top toSubgroup_bot
 
 @[to_additive (attr := simp)]
 theorem mem_toSubgroup_iff {H : NormalSubgroup G} {g : G} : g ∈ H.toSubgroup ↔ g ∈ H :=

--- a/Mathlib/GroupTheory/NormalSubgroup/ModularLattice.lean
+++ b/Mathlib/GroupTheory/NormalSubgroup/ModularLattice.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 Diwen Yu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Diwen Yu
+-/
+module
+
+public import Mathlib.GroupTheory.NormalSubgroup.Basic
+public import Mathlib.Order.JordanHolder
+
+/-!
+# Modular lattice of normal subgroups
+
+This file proves the modular law for the complete lattice of normal subgroups of an arbitrary
+group. Mathlib's abstract construction then supplies its `JordanHolderLattice` instance.
+-/
+
+@[expose] public section
+
+namespace NormalSubgroup
+
+variable {G : Type*} [Group G]
+
+/-- The normal subgroups of an arbitrary group form a modular lattice. -/
+@[to_additive /-- The normal additive subgroups of an arbitrary additive group form a modular
+lattice. -/]
+instance instIsModularLatticeNormalSubgroup : IsModularLattice (NormalSubgroup G) where
+  sup_inf_le_assoc_of_le := by
+    intro x y z h g hg
+    change g ∈ (x.toSubgroup ⊔ y.toSubgroup) ⊓ z.toSubgroup at hg
+    change g ∈ x.toSubgroup ⊔ (y.toSubgroup ⊓ z.toSubgroup)
+    rw [← SetLike.mem_coe, Subgroup.normal_mul]
+    rw [Subgroup.mul_inf_assoc _ _ _ h]
+    change g ∈ (x.toSubgroup ⊔ y.toSubgroup) ∧ g ∈ z.toSubgroup at hg
+    rw [← SetLike.mem_coe, Subgroup.normal_mul] at hg
+    exact hg
+
+end NormalSubgroup

--- a/Mathlib/GroupTheory/NormalSubgroup/ModularLattice.lean
+++ b/Mathlib/GroupTheory/NormalSubgroup/ModularLattice.lean
@@ -26,13 +26,11 @@ variable {G : Type*} [Group G]
 lattice. -/]
 instance : IsModularLattice (NormalSubgroup G) where
   sup_inf_le_assoc_of_le := by
-    intro x y z h g hg
-    change g ∈ (x.toSubgroup ⊔ y.toSubgroup) ⊓ z.toSubgroup at hg
-    change g ∈ x.toSubgroup ⊔ (y.toSubgroup ⊓ z.toSubgroup)
-    rw [← SetLike.mem_coe, Subgroup.normal_mul]
-    rw [Subgroup.mul_inf_assoc _ _ _ h]
-    change g ∈ (x.toSubgroup ⊔ y.toSubgroup) ∧ g ∈ z.toSubgroup at hg
-    rw [← SetLike.mem_coe, Subgroup.normal_mul] at hg
-    exact hg
+    intro x y z h
+    apply le_of_eq
+    apply toSubgroup_injective
+    apply SetLike.coe_injective
+    simp only [toSubgroup_inf, toSubgroup_sup, Subgroup.coe_inf, Subgroup.normal_mul]
+    exact (Subgroup.mul_inf_assoc _ _ _ h).symm
 
 end NormalSubgroup

--- a/Mathlib/GroupTheory/NormalSubgroup/ModularLattice.lean
+++ b/Mathlib/GroupTheory/NormalSubgroup/ModularLattice.lean
@@ -6,13 +6,13 @@ Authors: Diwen Yu
 module
 
 public import Mathlib.GroupTheory.NormalSubgroup.Basic
-public import Mathlib.Order.JordanHolder
+public import Mathlib.Order.ModularLattice
 
 /-!
 # Modular lattice of normal subgroups
 
 This file proves the modular law for the complete lattice of normal subgroups of an arbitrary
-group. Mathlib's abstract construction then supplies its `JordanHolderLattice` instance.
+group. This is the lattice-theoretic input for mathlib's abstract Jordan–Hölder construction.
 -/
 
 @[expose] public section
@@ -24,7 +24,7 @@ variable {G : Type*} [Group G]
 /-- The normal subgroups of an arbitrary group form a modular lattice. -/
 @[to_additive /-- The normal additive subgroups of an arbitrary additive group form a modular
 lattice. -/]
-instance instIsModularLatticeNormalSubgroup : IsModularLattice (NormalSubgroup G) where
+instance : IsModularLattice (NormalSubgroup G) where
   sup_inf_le_assoc_of_le := by
     intro x y z h g hg
     change g ∈ (x.toSubgroup ⊔ y.toSubgroup) ⊓ z.toSubgroup at hg


### PR DESCRIPTION
Defines `NormalSubgroup` and its complete lattice and modular lattice structures. This will be used later to define classical composition series and chief series of groups and the Jordan–Hölder theorem/uniqueness. The proposal to `NormalSubgroup` was discussed on  [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Jordan.E2.80.93H.C3.B6lder.20theorem.20for.20groups/with/613459805).

Generated by Codex. Then I carefully reviewed the entire code line by line and made some modifications.
Co-Authored-By: ChatGPT-5.6 Sol