### PR TITLE
doc: fix 'seperate' typos

### DIFF
--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -272,7 +272,7 @@ instance {α : Q(Type u)} {E : Q($α) → Type} {e : Q($α)} [Inhabited (Σ e, E
   let ⟨e', v⟩ : Σ e, E e := default; ⟨e', v, default⟩
 
 
-/-- Defines how comparisons and binary equality are computed in the base type. These are seperated
+/-- Defines how comparisons and binary equality are computed in the base type. These are separated
 from RingCompute because they can often be defined without using instance caches. -/
 structure RingCompare {u : Lean.Level} {α : Q(Type u)} (BaseType : Q($α) → Type) where
   /-- Returns whether two coefficients are equal -/

--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -71,7 +71,7 @@ together.
   below for a restriction on when we want to create aliases.
 * For types and definitions relevant to CW complexes like `cell`, `openCell`, `closedCell`,
   `cellFrontier`, `skeletonLT` and similar, we want there to exist only one actually used version,
-  namely the version in the `RelCWComplex` namespace (and thus no seperate definition in the
+  namely the version in the `RelCWComplex` namespace (and thus no separate definition in the
   `CWComplex` namespace.) This is to avoid unnecessary duplication of lemmas. To achieve this,
   definitions from the `RelCWComplex` namespace should be added to the `CWComplex` namespace with
   `export` intead of `alias_in`/`alias`. These will then apply to the absolute CW complex through


### PR DESCRIPTION
## Summary
- Correct "seperate" → "separate" in CWComplex and ring tactic module docs.

## Test plan
- [ ] Spelling only; no Lean changes

awaiting-review

Made with [Cursor](https://cursor.com)