### PR TITLE
[Merged by Bors] - chore(Topology/Separation): generalize theorems on `IndiscreteTopology`

### DIFF
--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -159,18 +159,11 @@ theorem inseparable_iff : Inseparable x y ↔ edist x y = 0 := by
 
 alias ⟨_root_.Inseparable.edist_eq_zero, _⟩ := EMetric.inseparable_iff
 
-theorem nontrivial_iff_nontrivialTopology {α} [EMetricSpace α] :
-    Nontrivial α ↔ NontrivialTopology α := by
-  simp_rw [nontrivial_iff, TopologicalSpace.nontrivial_iff_exists_not_inseparable,
-    EMetric.inseparable_iff, edist_eq_zero]
+@[deprecated (since := "2026-07-31")]
+alias nontrivial_iff_nontrivialTopology := nontrivial_iff_nontrivialTopology
 
-theorem subsingleton_iff_indiscreteTopology {α} [EMetricSpace α] :
-    Subsingleton α ↔ IndiscreteTopology α := by
-  simpa [not_nontrivial_iff_subsingleton] using nontrivial_iff_nontrivialTopology (α := α).not
-
-/-- In an (e)metric space, every nontrivial type has a nontrivial topology. -/
-instance (priority := 100) {α} [EMetricSpace α] [Nontrivial α] : NontrivialTopology α :=
-  nontrivial_iff_nontrivialTopology.1 ‹_›
+@[deprecated (since := "2026-07-31")]
+alias subsingleton_iff_indiscreteTopology := subsingleton_iff_indiscreteTopology
 
 /-- In a pseudoemetric space, Cauchy sequences are characterized by the fact that, eventually,
 the pseudoedistance between its elements is arbitrarily small -/

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -258,6 +258,25 @@ theorem T0Space.of_open_cover (h : ∀ x, ∃ s : Set X, x ∈ s ∧ IsOpen s �
     let ⟨s, hxs, hso, hs⟩ := h x
     ⟨s, hxs, (hxy.mem_open_iff hso).1 hxs, hs⟩
 
+variable (X) in
+instance [T0Space X] [Nontrivial X] : NontrivialTopology X := by
+  rw [← not_indiscrete_iff]
+  intro
+  obtain ⟨a, b, hab⟩ := exists_pair_ne X
+  apply hab
+  exact (Inseparable.all a b).eq
+
+theorem subsingleton_iff_indiscreteTopology [T0Space X] :
+    Subsingleton X ↔ IndiscreteTopology X := by
+  refine ⟨?_, Function.mtr ?_⟩
+  · intro; infer_instance
+  · rw [not_subsingleton_iff_nontrivial, not_indiscrete_iff]
+    intro; infer_instance
+
+theorem nontrivial_iff_nontrivialTopology [T0Space X] : Nontrivial X ↔ NontrivialTopology X := by
+  rw [← not_subsingleton_iff_nontrivial, ← not_indiscrete_iff, not_iff_not]
+  exact subsingleton_iff_indiscreteTopology
+
 /-- A topological space is called an R₀ space, if `Specializes` relation is symmetric.
 
 In other words, given two points `x y : X`,
@@ -806,6 +825,10 @@ instance Finite.instDiscreteTopology [T1Space X] [Finite X] : DiscreteTopology X
 
 lemma Set.Finite.isDiscrete [T1Space X] {s : Set X} (hs : s.Finite) : IsDiscrete s :=
   ⟨@Finite.instDiscreteTopology _ _ _ hs.to_subtype⟩
+
+theorem subsingleton_iff_discrete_and_indiscrete :
+    Subsingleton X ↔ DiscreteTopology X ∧ IndiscreteTopology X :=
+  ⟨fun _ ↦ ⟨inferInstance, inferInstance⟩, fun ⟨_, _⟩ ↦ subsingleton_iff_indiscreteTopology.2 ‹_›⟩
 
 theorem Set.Finite.continuousOn [T1Space X] [TopologicalSpace Y] {s : Set X} (hs : s.Finite)
     (f : X → Y) : ContinuousOn f s := by

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -260,11 +260,8 @@ theorem T0Space.of_open_cover (h : ∀ x, ∃ s : Set X, x ∈ s ∧ IsOpen s �
 
 variable (X) in
 instance [T0Space X] [Nontrivial X] : NontrivialTopology X := by
-  rw [← not_indiscrete_iff]
-  intro
   obtain ⟨a, b, hab⟩ := exists_pair_ne X
-  apply hab
-  exact (Inseparable.all a b).eq
+  exact nontrivial_iff_exists_not_inseparable.mpr ⟨a, b, mt Inseparable.eq hab⟩
 
 theorem subsingleton_iff_indiscreteTopology [T0Space X] :
     Subsingleton X ↔ IndiscreteTopology X := by

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -259,6 +259,8 @@ theorem T0Space.of_open_cover (h : ∀ x, ∃ s : Set X, x ∈ s ∧ IsOpen s �
     ⟨s, hxs, (hxy.mem_open_iff hso).1 hxs, hs⟩
 
 variable (X) in
+-- since this instance is usually the desired instance, its priority is not lowered
+-- see Note [lower instance priority]
 instance [T0Space X] [Nontrivial X] : NontrivialTopology X := by
   obtain ⟨a, b, hab⟩ := exists_pair_ne X
   exact nontrivial_iff_exists_not_inseparable.mpr ⟨a, b, mt Inseparable.eq hab⟩

--- a/Mathlib/Topology/Separation/Connected.lean
+++ b/Mathlib/Topology/Separation/Connected.lean
@@ -42,10 +42,6 @@ theorem IsPreconnected.infinite_of_nontrivial [T1Space X] {s : Set X} (h : IsPre
 theorem PreconnectedSpace.infinite [PreconnectedSpace X] [Nontrivial X] [T1Space X] : Infinite X :=
   infinite_univ_iff.mp <| isPreconnected_univ.infinite_of_nontrivial nontrivial_univ
 
-theorem subsingleton_iff_discrete_and_indiscrete :
-    Subsingleton X ↔ DiscreteTopology X ∧ IndiscreteTopology X :=
-  ⟨fun _ ↦ ⟨inferInstance, inferInstance⟩, fun ⟨_, _⟩ ↦ PreconnectedSpace.trivial_of_discrete⟩
-
 /-- A non-trivial connected T1 space has no isolated points. -/
 instance (priority := 100) ConnectedSpace.neBot_nhdsWithin_compl_of_nontrivial_of_t1space
     [ConnectedSpace X] [Nontrivial X] [T1Space X] (x : X) :


### PR DESCRIPTION
Generalize some theorems on `IndiscreteTopology` from `EMetricSpace` to `T0Space`. Also move `subsingleton_iff_discrete_and_indiscrete` to an earlier file because it has an easier proof.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
