### PR TITLE
[Merged by Bors] - feat(Algebra/Homology): homotopy equivalences satisfy the two out of three property

### DIFF
--- a/Mathlib/Algebra/Homology/Homotopy.lean
+++ b/Mathlib/Algebra/Homology/Homotopy.lean
@@ -714,9 +714,12 @@ def HomologicalComplex.homotopyEquivalences :
 
 namespace HomotopyEquiv
 
+variable {C D E : HomologicalComplex V c}
+
+variable (C) in
 /-- Any complex is homotopy equivalent to itself. -/
-@[refl]
-def refl (C : HomologicalComplex V c) : HomotopyEquiv C C where
+@[refl, simps]
+def refl : HomotopyEquiv C C where
   hom := 𝟙 C
   inv := 𝟙 C
   homotopyHomInvId := Homotopy.ofEq (by simp)
@@ -726,16 +729,16 @@ instance : Inhabited (HomotopyEquiv C C) :=
   ⟨refl C⟩
 
 /-- Being homotopy equivalent is a symmetric relation. -/
-@[symm]
-def symm {C D : HomologicalComplex V c} (f : HomotopyEquiv C D) : HomotopyEquiv D C where
+@[symm, simps]
+def symm (f : HomotopyEquiv C D) : HomotopyEquiv D C where
   hom := f.inv
   inv := f.hom
   homotopyHomInvId := f.homotopyInvHomId
   homotopyInvHomId := f.homotopyHomInvId
 
 /-- Homotopy equivalence is a transitive relation. -/
-@[trans]
-def trans {C D E : HomologicalComplex V c} (f : HomotopyEquiv C D) (g : HomotopyEquiv D E) :
+@[trans, simps]
+def trans (f : HomotopyEquiv C D) (g : HomotopyEquiv D E) :
     HomotopyEquiv C E where
   hom := f.hom ≫ g.hom
   inv := g.inv ≫ f.inv
@@ -749,7 +752,58 @@ def ofIso {ι : Type*} {V : Type u} [Category.{v} V] [Preadditive V] {c : Comple
     {C D : HomologicalComplex V c} (f : C ≅ D) : HomotopyEquiv C D :=
   ⟨f.hom, f.inv, Homotopy.ofEq f.3, Homotopy.ofEq f.4⟩
 
+lemma homotopyEquivalences_hom (f : HomotopyEquiv C D) :
+    homotopyEquivalences _ _ f.hom := ⟨f, rfl⟩
+
+lemma homotopyEquivalences_inv (f : HomotopyEquiv C D) :
+    homotopyEquivalences _ _ f.inv := f.symm.homotopyEquivalences_hom
+
+/-- If `f` if a homotopy equivalence and `h` is a homotopy from `f.hom` to
+a morphism `g`, then this is a homotopy equivalence whose `hom` field is `g`. -/
+@[simps hom inv]
+def copy (f : HomotopyEquiv C D) {g : C ⟶ D} (h : Homotopy f.hom g) :
+    HomotopyEquiv C D where
+  hom := g
+  inv := f.inv
+  homotopyHomInvId := (h.symm.compRight _).trans f.homotopyHomInvId
+  homotopyInvHomId := (h.symm.compLeft _).trans f.homotopyInvHomId
+
 end HomotopyEquiv
+
+namespace HomologicalComplex
+
+lemma homotopyEquivalences.of_isIso (f : C ⟶ D) [IsIso f] : homotopyEquivalences _ _ f :=
+  ⟨.ofIso (asIso f), rfl⟩
+
+lemma homotopyEquivalences.of_homotopy {f g : C ⟶ D} (h : homotopyEquivalences _ _ f)
+    (hfg : Homotopy f g) :
+    homotopyEquivalences _ _ g := by
+  obtain ⟨e, rfl⟩ := h
+  exact ⟨e.copy hfg, by simp⟩
+
+instance : (homotopyEquivalences V c).IsMultiplicative where
+  id_mem K := ⟨.refl _, rfl⟩
+  comp_mem f g := by
+    rintro ⟨f, rfl⟩ ⟨g, rfl⟩
+    exact ⟨f.trans g, rfl⟩
+
+instance : (homotopyEquivalences V c).HasTwoOutOfThreeProperty where
+  of_postcomp f _ := by
+    rintro ⟨g, rfl⟩ ⟨e, he⟩
+    refine (e.trans g.symm).homotopyEquivalences_hom.of_homotopy ?_
+    simp only [HomotopyEquiv.trans_hom, HomotopyEquiv.symm_hom, he, Category.assoc]
+    exact g.homotopyHomInvId.compLeftId f
+  of_precomp _ g := by
+    rintro ⟨f, rfl⟩ ⟨e, he⟩
+    refine (f.symm.trans e).homotopyEquivalences_hom.of_homotopy ?_
+    simp only [HomotopyEquiv.trans_hom, HomotopyEquiv.symm_hom, he, ← Category.assoc]
+    exact f.homotopyInvHomId.compRightId g
+
+instance : (homotopyEquivalences V c).RespectsIso :=
+  MorphismProperty.respectsIso_of_isStableUnderComposition
+    (fun _ _ _ _ ↦ .of_isIso _)
+
+end HomologicalComplex
 
 end
 


### PR DESCRIPTION


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
