### PR TITLE
[Merged by Bors] - chore(RingTheory/Valuation/Basic): remove all `set_option`s in this file

### DIFF
--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -895,6 +895,10 @@ theorem orderMonoidIso_spec (h : v.IsEquiv w) (a : R) :
     simp [orderMonoidIso, valueGroup₀Fun_spec h (hs := ha),
       w.restrict_eq_mk ((eq_zero h.symm).ne.mpr ha)]
 
+lemma orderMonoidIso_spec₀ (h : v.IsEquiv w) (a : R) :
+    h.orderMonoidIso (restrict₀ (.ofClass v) a) = restrict₀ (.ofClass w) a :=
+  orderMonoidIso_spec h a
+
 theorem orderMonoidIso_symm (h : v.IsEquiv w) (h' : w.IsEquiv v) :
     h.orderMonoidIso.symm = h'.orderMonoidIso := by
   rfl

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -807,6 +807,7 @@ section LinearOrderedCommGroupWithZero
 
 variable [LinearOrderedCommGroupWithZero Γ₀] [LinearOrderedCommGroupWithZero Γ'₀]
   [LinearOrderedCommGroupWithZero Γ''₀]
+
 section Ring
 
 variable [Ring R] {v : Valuation R Γ₀} {w : Valuation R Γ'₀} {u : Valuation R Γ''₀}
@@ -891,32 +892,29 @@ theorem orderMonoidIso_spec (h : v.IsEquiv w) (a : R) :
   · rw [← restrict_eq_zero_iff] at ha
     rwa [ha, map_zero, Eq.comm, ← h_res.eq_zero]
   · rw [(v.restrict_eq_mk ha)]
-    convert! valueGroup₀Fun_spec (h := h) (hs := ha) (r := 1) (by simp)
-    exact w.restrict_eq_mk ((eq_zero h.symm).ne.mpr ha)
+    simp [orderMonoidIso, valueGroup₀Fun_spec h (hs := ha),
+      w.restrict_eq_mk ((eq_zero h.symm).ne.mpr ha)]
 
 theorem orderMonoidIso_symm (h : v.IsEquiv w) (h' : w.IsEquiv v) :
     h.orderMonoidIso.symm = h'.orderMonoidIso := by
   rfl
 
--- set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 theorem orderMonoidIso_eq_refl (h : v.IsEquiv v) :
     h.orderMonoidIso = .refl _ := by
   ext x
   obtain (rfl | ⟨x, y, _, _, rfl⟩) := x.zero_or_exists_mk
   · simp
-  · simp [orderMonoidIso]
-    sorry
+  · simp [orderMonoidIso, valueGroup₀Fun_spec h]
 
-#exit
-set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 theorem orderMonoidIso_trans (h : v.IsEquiv w) (h' : w.IsEquiv u) :
     h.orderMonoidIso.trans h'.orderMonoidIso = (h.trans h').orderMonoidIso := by
   ext x
   obtain (rfl | ⟨x, y, _, _, rfl⟩) := x.zero_or_exists_mk
   · simp
-  · simp [orderMonoidIso, valueGroup₀Fun_spec]
+  · simp [orderMonoidIso, valueGroup₀Fun_spec h, valueGroup₀Fun_spec h',
+      valueGroup₀Fun_spec (trans h h')]
 
 end IsEquiv
 

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -732,7 +732,7 @@ theorem eq_zero (h : v₁.IsEquiv v₂) {r : R} : v₁ r = 0 ↔ v₂ r = 0 := b
   have : v₁ r = v₁ 0 ↔ v₂ r = v₂ 0 := h.eq_iff
   rwa [v₁.map_zero, v₂.map_zero] at this
 
-lemma eq_zero_ofClass (h : v₁.IsEquiv v₂) {r : R} : (MonoidWithZeroHom.ofClass v₁) r = 0 ↔
+lemma ofClass_eq_zero (h : v₁.IsEquiv v₂) {r : R} : (MonoidWithZeroHom.ofClass v₁) r = 0 ↔
   (MonoidWithZeroHom.ofClass v₂) r = 0 := eq_zero h
 
 @[deprecated "use `(eq_zero _).ne` instead." (since := "2026-01-05")]

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -827,8 +827,8 @@ noncomputable def valueGroup₀Fun (h : v.IsEquiv w) (x : ValueGroup₀ (.ofClas
 
 theorem valueGroup₀Fun_spec (h : v.IsEquiv w) {r s : R} (hr : (MonoidWithZeroHom.ofClass v) r ≠ 0)
     (hs : (MonoidWithZeroHom.ofClass v) s ≠ 0)
-    (hr' : (MonoidWithZeroHom.ofClass w) r ≠ 0 := h.eq_zero_ofClass.ne.1 hr)
-    (hs' : (MonoidWithZeroHom.ofClass w) s ≠ 0 := h.eq_zero_ofClass.ne.1 hs) :
+    (hr' : (MonoidWithZeroHom.ofClass w) r ≠ 0 := h.ofClass_eq_zero.ne.1 hr)
+    (hs' : (MonoidWithZeroHom.ofClass w) s ≠ 0 := h.ofClass_eq_zero.ne.1 hs) :
     valueGroup₀Fun h (valueGroup.mk (.ofClass v) r s hr hs) =
       valueGroup.mk (.ofClass w) r s hr' hs' := by
   rw [valueGroup₀Fun, dif_neg (by simp)]

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -351,12 +351,17 @@ theorem map_one_sub_of_lt (h : v x < 1) : v (1 - x) = 1 := by
   rw [sub_eq_add_neg 1 x]
   simpa only [v.map_one, v.map_neg] using v.map_add_eq_of_lt_left h
 
-set_option backward.isDefEq.respectTransparency false in
+lemma OrderMonoidWithZeroHom.ofClass_monotone {F : Type u_1} {α : Type u_2} {β : Type u_3}
+    [LinearOrderedCommMonoidWithZero α] [LinearOrderedCommMonoidWithZero β] [FunLike F α β]
+    [MonoidWithZeroHomClass F α β] {f : F} (hf : Monotone f) :
+    Monotone (MonoidWithZeroHom.ofClass f) := hf
+
 /-- An ordered monoid isomorphism `Γ₀ ≃ Γ'₀` induces an equivalence
 `Valuation R Γ₀ ≃ Valuation R Γ'₀`. -/
 def congr (f : Γ₀ ≃*o Γ'₀) : Valuation R Γ₀ ≃ Valuation R Γ'₀ where
-  toFun := map (.ofClass f) f.toOrderIso.monotone
-  invFun := map (.ofClass f.symm) f.toOrderIso.symm.monotone
+  toFun := map (.ofClass f) (OrderMonoidWithZeroHom.ofClass_monotone f.toOrderIso.monotone)
+  invFun := map (.ofClass f.symm)
+    (OrderMonoidWithZeroHom.ofClass_monotone f.symm.toOrderIso.monotone)
   left_inv _ := by ext; simp
   right_inv _ := by ext; simp
 
@@ -457,47 +462,38 @@ lemma leAddSubgroup_monotone (v : Valuation R Γ₀) : Monotone v.leAddSubgroup 
 
 open MonoidWithZeroHom MonoidWithZeroHom.ValueGroup₀
 
-set_option backward.isDefEq.respectTransparency.types false in
 /-- The restriction of a valuation so that it takes values in its `valueGroup₀`. -/
 def restrict : Valuation R (ValueGroup₀ (.ofClass v)) where
   __ := restrict₀ (.ofClass v)
   map_add_le_max' x y := by
     by_cases H : v x ≠ 0 ∨ v y ≠ 0
-    · rcases H with h | h <;>
-      simp only [ZeroHom.toFun_eq_coe, toZeroHom_coe, restrict₀_apply, coe_ofClass, h,
-        reduceDIte, le_sup_iff] <;>
-      · split_ifs with H _ hy
-        all_goals simp [← Units.val_le_val]
-        simpa using map_add_le _ (by simp_all) (by simp_all)
+    · rcases H with h | h
+      all_goals simp only [ZeroHom.toFun_eq_coe, toZeroHom_coe, restrict₀_apply, coe_ofClass, h,
+        reduceDIte, le_sup_iff]
+      all_goals split_ifs with H
+      · simp [H]
+      · simp only [H, ↓reduceDIte, WithZero.coe_le_coe, Subtype.mk_le_mk, ← Units.val_le_val,
+          Units.val_mk0]
+        split_ifs with hy
+        · simpa [hy] using map_add_le _ (le_rfl (a := v x)) (hy ▸ zero_le)
+        · simp [hy, ← Units.val_le_val]
+      · simp [H]
+      · simp only [H, ↓reduceDIte, WithZero.coe_le_coe, Subtype.mk_le_mk]
+        split_ifs with hx
+        · simpa [hx, ← Units.val_le_val] using map_add_le _ (hx ▸ zero_le) (le_rfl (a := v y))
+        · simp [hx, ← Units.val_le_val]
     · simp only [ne_eq, not_or, Decidable.not_not] at H
-      simpa [restrict₀_apply, H] using map_add_le _ (le_of_eq H.1) (le_of_eq H.2)
+      simp only [ZeroHom.toFun_eq_coe, toZeroHom_coe, restrict₀_apply,
+        MonoidWithZeroHom.coe_ofClass, H, ↓reduceDIte, max_self, nonpos_iff_eq_zero]
+      replace H : v (x + y) = 0 :=
+        le_antisymm (map_add_le _ (le_of_eq H.1) (le_of_eq H.2)) zero_le
+      simp [H]
 
 lemma restrict_def (x : R) : v.restrict x = restrict₀ (.ofClass v) x := rfl
 
 @[simp]
 lemma embedding_restrict (x : R) : embedding (v.restrict x) = v x :=
   embedding_restrict₀ x
-
-set_option backward.isDefEq.respectTransparency false in
-lemma restrict_eq_mk {x : R} (hx : v x ≠ 0) : v.restrict x =
-    (valueGroup.mk (.ofClass v) 1 x (by simp) hx : ValueGroup₀ (.ofClass v)) := by
-  simp [restrict_def, restrict₀_apply, dif_neg hx, valueGroup.mk]
-
-@[simp]
-lemma restrict_pos_iff (x : R) : 0 < v.restrict x ↔ 0 < v x := by
-  simp only [restrict_def, restrict₀_apply]
-  split_ifs with h <;> simpa [zero_lt_iff]
-
-set_option backward.isDefEq.respectTransparency.types false in
-@[simp]
-lemma restrict_lt_iff {x y : R} : v.restrict x < v.restrict y ↔ v x < v y := by
-  simp [restrict_def, restrict₀_apply]
-  split_ifs with hx hy <;> simp_all [zero_lt_iff.mpr, ← Units.val_lt_val]
-
-set_option backward.isDefEq.respectTransparency.types false in
-theorem isEquiv_restrict : v.IsEquiv v.restrict := by
-  intro x y
-  aesop (add norm [restrict_def, restrict₀_apply])
 
 lemma restrict_lt_iff_lt_embedding {x : R} {g : ValueGroup₀ (.ofClass v)} :
     v.restrict x < g ↔ v x < embedding g :=
@@ -506,6 +502,29 @@ lemma restrict_lt_iff_lt_embedding {x : R} {g : ValueGroup₀ (.ofClass v)} :
 lemma restrict_le_iff_le_embedding {x : R} {g : ValueGroup₀ (.ofClass v)} :
     v.restrict x ≤ g ↔ v x ≤ embedding g :=
   embedding_strictMono.le_iff_le.symm.trans (by simp)
+
+lemma restrict_eq_mk {x : R} (hx : v x ≠ 0) : v.restrict x =
+    (valueGroup.mk (.ofClass v) 1 x (by simp) hx : ValueGroup₀ (.ofClass v)) := by
+  simp [restrict_def, restrict₀_apply, valueGroup.mk, hx]
+
+@[simp]
+lemma restrict_pos_iff (x : R) : 0 < v.restrict x ↔ 0 < v x := by
+  simp only [restrict_def, restrict₀_apply]
+  split_ifs with h <;> simpa [zero_lt_iff]
+
+@[simp]
+lemma restrict_lt_iff {x y : R} : v.restrict x < v.restrict y ↔ v x < v y := by
+  rw [restrict_lt_iff_lt_embedding, embedding_restrict]
+
+@[simp]
+lemma restrict_le_iff {x y : R} : v.restrict x ≤ v.restrict y ↔ v x ≤ v y := by
+  rw [restrict_le_iff_le_embedding, embedding_restrict]
+
+@[simp]
+lemma restrict_inj {x y : R} : v.restrict x = v.restrict y ↔ v x = v y :=
+  embedding_inj.symm.trans (by simp)
+
+theorem isEquiv_restrict : v.IsEquiv v.restrict := fun _ _ ↦ v.restrict_le_iff.symm
 
 @[simp]
 lemma restrict_lt_one_iff {x : R} : v.restrict x < 1 ↔ v x < 1 := by
@@ -522,18 +541,6 @@ lemma restrict_eq_zero_iff {x : R} : v.restrict x = 0 ↔ v x = 0 := by
 @[simp]
 lemma restrict_eq_one_iff {x : R} : v.restrict x = 1 ↔ v x = 1 := by
   simp [restrict_def, restrict₀_eq_one_iff]
-
-set_option backward.isDefEq.respectTransparency.types false in
-@[simp]
-lemma restrict_le_iff {x y : R} : v.restrict x ≤ v.restrict y ↔ v x ≤ v y := by
-  simp only [restrict_def, restrict₀_apply, MonoidWithZeroHom.coe_ofClass]
-  split_ifs with hx hy <;> simp_all [← Units.val_le_val]
-
-set_option backward.isDefEq.respectTransparency.types false in
-@[simp]
-lemma restrict_inj {x y : R} : v.restrict x = v.restrict y ↔ v x = v y := by
-  simp only [restrict_def, restrict₀_apply, MonoidWithZeroHom.coe_ofClass]
-  aesop
 
 lemma exists_div_eq_of_unit (γ : (ValueGroup₀ (.ofClass v))ˣ) :
     ∃ r s, 0 < v r ∧ 0 < v s ∧ v.restrict r / v.restrict s = γ.1 := by
@@ -725,6 +732,9 @@ theorem eq_zero (h : v₁.IsEquiv v₂) {r : R} : v₁ r = 0 ↔ v₂ r = 0 := b
   have : v₁ r = v₁ 0 ↔ v₂ r = v₂ 0 := h.eq_iff
   rwa [v₁.map_zero, v₂.map_zero] at this
 
+lemma eq_zero_ofClass (h : v₁.IsEquiv v₂) {r : R} : (MonoidWithZeroHom.ofClass v₁) r = 0 ↔
+  (MonoidWithZeroHom.ofClass v₂) r = 0 := eq_zero h
+
 @[deprecated "use `(eq_zero _).ne` instead." (since := "2026-01-05")]
 theorem ne_zero (h : v₁.IsEquiv v₂) {r : R} : v₁ r ≠ 0 ↔ v₂ r ≠ 0 :=
   (eq_zero h).ne
@@ -814,10 +824,12 @@ noncomputable def valueGroup₀Fun (h : v.IsEquiv w) (x : ValueGroup₀ (.ofClas
     haveI c := (x.zero_or_exists_mk'.resolve_left hx).choose
     valueGroup.mk (.ofClass w) c.1.1 c.1.2 (h.eq_zero.ne.mp c.2.1) (h.eq_zero.ne.mp c.2.2)
 
-set_option backward.isDefEq.respectTransparency.types false in
-theorem valueGroup₀Fun_spec (h : v.IsEquiv w) {r s : R} (hr : v r ≠ 0) (hs : v s ≠ 0) :
+theorem valueGroup₀Fun_spec (h : v.IsEquiv w) {r s : R} (hr : (MonoidWithZeroHom.ofClass v) r ≠ 0)
+    (hs : (MonoidWithZeroHom.ofClass v) s ≠ 0)
+    (hr' : (MonoidWithZeroHom.ofClass w) r ≠ 0 := h.eq_zero_ofClass.ne.1 hr)
+    (hs' : (MonoidWithZeroHom.ofClass w) s ≠ 0 := h.eq_zero_ofClass.ne.1 hs) :
     valueGroup₀Fun h (valueGroup.mk (.ofClass v) r s hr hs) =
-      valueGroup.mk (.ofClass w) r s (h.eq_zero.ne.mp hr) (h.eq_zero.ne.mp hs) := by
+      valueGroup.mk (.ofClass w) r s hr' hs' := by
   rw [valueGroup₀Fun, dif_neg (by simp)]
   generalize_proofs _ _ _ _ H _
   have c_spec := H.choose_spec
@@ -826,7 +838,6 @@ theorem valueGroup₀Fun_spec (h : v.IsEquiv w) {r s : R} (hr : v r ≠ 0) (hs :
 
 theorem valueGroup₀Fun_zero (h : v.IsEquiv w) : valueGroup₀Fun h 0 = 0 := by simp [valueGroup₀Fun]
 
-set_option backward.isDefEq.respectTransparency.types false in
 /-- The isomorphism between the `ValueGroup₀`'s of two equivalent valuations. -/
 noncomputable def orderMonoidIso (h : v.IsEquiv w) :
     ValueGroup₀ (.ofClass v) ≃*o ValueGroup₀ (.ofClass w) where
@@ -837,15 +848,15 @@ noncomputable def orderMonoidIso (h : v.IsEquiv w) :
     · simp_all [valueGroup₀Fun_zero]
     obtain _ | ⟨r₂, s₂, hr₂, hs₂, rfl⟩ := y.zero_or_exists_mk
     · simp_all [valueGroup₀Fun_zero]
-    simp [← WithZero.coe_mul, valueGroup.mk_mul, valueGroup₀Fun_spec]
+    simp [← WithZero.coe_mul, valueGroup.mk_mul, valueGroup₀Fun_spec h]
   left_inv x := by
     obtain _ | ⟨r₁, s₁, hr₁, hs₁, rfl⟩ := x.zero_or_exists_mk
     · simp_all [valueGroup₀Fun_zero]
-    simp [valueGroup₀Fun_spec]
+    rw [valueGroup₀Fun_spec h, valueGroup₀Fun_spec h.symm]
   right_inv x := by
     obtain _ | ⟨r₁, s₁, hr₁, hs₁, rfl⟩ := x.zero_or_exists_mk
     · simp_all [valueGroup₀Fun_zero]
-    simp [valueGroup₀Fun_spec]
+    rw [valueGroup₀Fun_spec h.symm, valueGroup₀Fun_spec h]
   map_le_map_iff' {x} {y} := by
     simp only [valueGroup₀Fun, ne_eq]
     split_ifs with hx0 hy0 hy0
@@ -887,16 +898,18 @@ theorem orderMonoidIso_symm (h : v.IsEquiv w) (h' : w.IsEquiv v) :
     h.orderMonoidIso.symm = h'.orderMonoidIso := by
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
+-- set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 theorem orderMonoidIso_eq_refl (h : v.IsEquiv v) :
     h.orderMonoidIso = .refl _ := by
   ext x
   obtain (rfl | ⟨x, y, _, _, rfl⟩) := x.zero_or_exists_mk
   · simp
-  · simp [orderMonoidIso, valueGroup₀Fun_spec]
+  · simp [orderMonoidIso]
+    sorry
 
-set_option backward.isDefEq.respectTransparency false in
+#exit
+set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
 theorem orderMonoidIso_trans (h : v.IsEquiv w) (h' : w.IsEquiv u) :
     h.orderMonoidIso.trans h'.orderMonoidIso = (h.trans h').orderMonoidIso := by

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -1149,7 +1149,7 @@ lemma embed_strictMono [v.Compatible] : StrictMono (embed v) := by
   · simp [restrict₀_apply, embed]
   · simp [restrict₀_apply, embed]
 
-set_option backward.isDefEq.respectTransparency false in
+-- set_option backward.isDefEq.respectTransparency false in
 /--
 When we have `h : w.IsEquiv v`, the image group (with zero) of `v` is
 isomorphic to that of `w` via `h.orderMonoidIso`. Then the following diagram is commutative:
@@ -1170,10 +1170,9 @@ theorem orderMonoidIso_embed [v.Compatible] {Γ' : Type*} [LinearOrderedCommGrou
     (w : Valuation R Γ') [w.Compatible] (x : ValueGroupWithZero R) (h : w.IsEquiv v) :
     h.orderMonoidIso
     (embed w x) = embed v x := by
-  simp only [embed, ← Valuation.restrict_def, coe_mk, ZeroHom.coe_mk]
+  simp only [embed, coe_mk, ZeroHom.coe_mk]
   induction x using ValueGroupWithZero.ind with
-  | mk r s =>
-    simp
+  | mk r s => simp [Valuation.IsEquiv.orderMonoidIso_spec₀]
 
 /-- If a valuation `v` is compatible with the valuative relation, then `ValueGroupWithZero R`
 is isomorphic to the image group (with zero) of `v` as an ordered group with zero. -/

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -1149,7 +1149,6 @@ lemma embed_strictMono [v.Compatible] : StrictMono (embed v) := by
   · simp [restrict₀_apply, embed]
   · simp [restrict₀_apply, embed]
 
--- set_option backward.isDefEq.respectTransparency false in
 /--
 When we have `h : w.IsEquiv v`, the image group (with zero) of `v` is
 isomorphic to that of `w` via `h.orderMonoidIso`. Then the following diagram is commutative:


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
