### PR TITLE
[Merged by Bors] - feat(Kernel/Deterministic): any deterministic kernel is s-finite

### DIFF
--- a/Mathlib/Probability/Kernel/Deterministic.lean
+++ b/Mathlib/Probability/Kernel/Deterministic.lean
@@ -177,4 +177,24 @@ lemma comp_parallelComp_comp_copy {γ : Type*} [MeasurableSpace γ] {κ : Kernel
     _ = 0 := by
       rw [measure_compl hs (by simp), measure_univ h₁, h₁, tsub_self]
 
+open ENNReal
+
+instance (κ : Kernel α β) [IsDeterministic κ] : IsSFiniteKernel κ := by
+  by_contra
+  obtain ⟨a, ha⟩ : ∃ a, 0 < (κ a) univ := by
+    suffices ∀ C < ∞, ∃ a, C < (κ a) univ from this 0 (by simp)
+    by_contra! h
+    have : IsFiniteKernel κ := ⟨h⟩
+    have : IsSFiniteKernel κ := inferInstance
+    contradiction
+  have h := DFunLike.congr_fun κ.parallelComp_self_comp_copy a
+  simp_all only [not_false_eq_true, parallelComp_of_not_isSFiniteKernel_left, zero_comp, zero_apply]
+  replace h := DFunLike.congr_fun h Set.univ
+  rw [comp_apply'] at h
+  · simp_rw [copy_apply, Measure.dirac_apply' _ MeasurableSet.univ, indicator_univ] at h
+    simp only [Measure.coe_zero, Pi.zero_apply, Pi.one_apply, MeasureTheory.lintegral_const,
+      one_mul] at h
+    exact ha.ne h
+  exact MeasurableSet.univ
+
 end ProbabilityTheory.Kernel

--- a/Mathlib/Probability/Kernel/Deterministic.lean
+++ b/Mathlib/Probability/Kernel/Deterministic.lean
@@ -180,13 +180,11 @@ lemma comp_parallelComp_comp_copy {γ : Type*} [MeasurableSpace γ] {κ : Kernel
 open ENNReal
 
 instance (κ : Kernel α β) [IsDeterministic κ] : IsSFiniteKernel κ := by
-  by_contra
+  by_contra hκ
   obtain ⟨a, ha⟩ : ∃ a, 0 < (κ a) univ := by
-    suffices ∀ C < ∞, ∃ a, C < (κ a) univ from this 0 (by simp)
     by_contra! h
-    have : IsFiniteKernel κ := ⟨h⟩
-    have : IsSFiniteKernel κ := inferInstance
-    contradiction
+    let : IsFiniteKernel κ := ⟨⟨0, by simp, h⟩⟩
+    exact hκ inferInstance
   have h := DFunLike.congr_fun κ.parallelComp_self_comp_copy a
   simp_all only [not_false_eq_true, parallelComp_of_not_isSFiniteKernel_left, zero_comp, zero_apply]
   replace h := DFunLike.congr_fun h Set.univ

--- a/Mathlib/Probability/Kernel/Deterministic.lean
+++ b/Mathlib/Probability/Kernel/Deterministic.lean
@@ -185,14 +185,9 @@ instance (κ : Kernel α β) [IsDeterministic κ] : IsSFiniteKernel κ := by
     by_contra! h
     let : IsFiniteKernel κ := ⟨⟨0, by simp, h⟩⟩
     exact hκ inferInstance
-  have h := DFunLike.congr_fun κ.parallelComp_self_comp_copy a
-  simp_all only [not_false_eq_true, parallelComp_of_not_isSFiniteKernel_left, zero_comp, zero_apply]
-  replace h := DFunLike.congr_fun h Set.univ
-  rw [comp_apply'] at h
-  · simp_rw [copy_apply, Measure.dirac_apply' _ MeasurableSet.univ, indicator_univ] at h
-    simp only [Measure.coe_zero, Pi.zero_apply, Pi.one_apply, MeasureTheory.lintegral_const,
-      one_mul] at h
-    exact ha.ne h
-  exact MeasurableSet.univ
+  have h := DFunLike.congr_fun (DFunLike.congr_fun κ.parallelComp_self_comp_copy a) (univ ×ˢ univ)
+  simp only [parallelComp_of_not_isSFiniteKernel_left κ hκ, zero_comp, zero_apply,
+    copy_comp_apply_prod κ a .univ .univ, inter_self] at h
+  exact ha.ne h
 
 end ProbabilityTheory.Kernel

--- a/Mathlib/Probability/Kernel/Deterministic.lean
+++ b/Mathlib/Probability/Kernel/Deterministic.lean
@@ -177,8 +177,6 @@ lemma comp_parallelComp_comp_copy {γ : Type*} [MeasurableSpace γ] {κ : Kernel
     _ = 0 := by
       rw [measure_compl hs (by simp), measure_univ h₁, h₁, tsub_self]
 
-open ENNReal
-
 instance (κ : Kernel α β) [IsDeterministic κ] : IsSFiniteKernel κ := by
   by_contra hκ
   obtain ⟨a, ha⟩ : ∃ a, 0 < (κ a) univ := by


### PR DESCRIPTION
Any deterministic kernel is s-finite.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
