### PR TITLE
ci: auto-stack module deprecation stub PRs

### DIFF
--- a/.github/workflows/auto_deprecate_modules.yml
+++ b/.github/workflows/auto_deprecate_modules.yml
@@ -4,27 +4,35 @@
 # When PR_summary detects that a PR removes or renames modules without
 # leaving `deprecated_module` stubs, it adds the `file-removed` label.
 # That label triggers this workflow, which generates the stub files on a
-# branch `deprecation-stubs/pr-<N>`, opens a PR for it, and chains it to
-# the parent with a `bors stack #<N>` comment. Bors then merges both PRs
-# atomically, parent first, so the old module names always resolve on
-# master.
+# branch `deprecation-stubs/pr-<N>` in the stub fork (mathlib4_copy, a
+# fork with CI disabled), opens a PR for it against this repository, and
+# chains it to the parent with a `bors stack #<N>` comment. Bors then
+# merges both PRs atomically, parent first, so the old module names
+# always resolve on master. Bors compares bundle members by commit SHA,
+# so the fork-hosted stub branch works.
 #
 # Later pushes to the parent regenerate the stub branch; closing the parent
 # without merging closes the stub PR. The `no-auto-stub` label on the
 # parent opts out.
 #
 # SECURITY: this workflow runs on pull_request_target and mints a token
-# that can push branches and open PRs. It must therefore never check out
-# or execute code from the parent PR. It always checks out `master`, and
-# the driver script assembles the stub commit with git plumbing, without a
-# working-tree checkout of the parent's head. Keep it that way: do not add
-# steps that run lake/lean or any other build tool here.
+# that can push branches to the stub fork and open PRs here. It must
+# therefore never check out or execute code from the parent PR. It always
+# checks out `master`, and the driver script assembles the stub commit
+# with git plumbing, without a working-tree checkout of the parent's head.
+# Keep it that way: do not add steps that run lake/lean or any other build
+# tool here.
 #
 # Requirements:
-#   * the GitHub App behind the minted token needs contents:write and
-#     pull_requests:write;
-#   * the app's user must have reviewer ("member") standing in bors,
-#     otherwise the `bors stack` comment is ignored.
+#   * the GitHub App behind the minted token needs pull_requests:write on
+#     this repository (open/close the stub PR, post the bors comment) and
+#     contents:write on the stub fork only — it can never push a branch
+#     to this repository;
+#   * the app's user must have member standing in bors (a manual add on
+#     the bors project settings page), otherwise the `bors stack` comment
+#     is ignored. Note: bors's "synchronize members with collaborators"
+#     option replaces the member list on every sync; it must stay off, or
+#     the manually added app user is removed again.
 
 name: Auto-stack module deprecation stubs
 
@@ -64,6 +72,7 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
       EVENT: ${{ github.event.action || 'dispatch' }}
+      STUB_REPO: leanprover-community/mathlib4_copy
 
     steps:
     - name: Check whether this event needs work
@@ -123,11 +132,13 @@ jobs:
         DRY_RUN: ${{ toJson(inputs.dry_run) }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
-        # Pushes authenticate through the remote URL; gh uses GH_TOKEN.
-        git remote set-url origin \
-          "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        # Stub-branch pushes go to the fork, authenticated through the
+        # remote URL; gh uses GH_TOKEN. Nothing pushes to this repository.
+        git remote add stubfork \
+          "https://x-access-token:${GH_TOKEN}@github.com/${STUB_REPO}.git"
 
-        args=(--pr "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --run-url "$RUN_URL")
+        args=(--pr "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --run-url "$RUN_URL"
+              --push-repo "$STUB_REPO" --push-remote stubfork)
         case "$EVENT" in
           closed)      args+=(--close) ;;
           synchronize) args+=(--only-if-exists) ;;

--- a/.github/workflows/auto_deprecate_modules.yml
+++ b/.github/workflows/auto_deprecate_modules.yml
@@ -1,0 +1,138 @@
+# Maintain a stacked "deprecated module stubs" PR for every PR that deletes
+# or renames library modules.
+#
+# When PR_summary detects that a PR removes or renames modules without
+# leaving `deprecated_module` stubs, it adds the `file-removed` label.
+# That label triggers this workflow, which generates the stub files on a
+# branch `deprecation-stubs/pr-<N>`, opens a PR for it, and chains it to
+# the parent with a `bors stack #<N>` comment. Bors then merges both PRs
+# atomically, parent first, so the old module names always resolve on
+# master.
+#
+# Later pushes to the parent regenerate the stub branch; closing the parent
+# without merging closes the stub PR. The `no-auto-stub` label on the
+# parent opts out.
+#
+# SECURITY: this workflow runs on pull_request_target and mints a token
+# that can push branches and open PRs. It must therefore never check out
+# or execute code from the parent PR. It always checks out `master`, and
+# the driver script assembles the stub commit with git plumbing, without a
+# working-tree checkout of the parent's head. Keep it that way: do not add
+# steps that run lake/lean or any other build tool here.
+#
+# Requirements:
+#   * the GitHub App behind the minted token needs contents:write and
+#     pull_requests:write;
+#   * the app's user must have reviewer ("member") standing in bors,
+#     otherwise the `bors stack` comment is ignored.
+
+name: Auto-stack module deprecation stubs
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize, closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'parent PR number to (re)generate deprecation stubs for'
+        required: true
+        type: string
+      dry_run:
+        description: 'if true, only log what would happen'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: auto-deprecate-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  stubs:
+    name: Maintain the stacked deprecation-stub PR
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'leanprover-community/mathlib4' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.action == 'synchronize' ||
+       github.event.action == 'closed' ||
+       (github.event.action == 'labeled' && github.event.label.name == 'file-removed'))
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+      EVENT: ${{ github.event.action || 'dispatch' }}
+
+    steps:
+    - name: Check whether this event needs work
+      id: precheck
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # `synchronize` fires for every push to every PR in the repository,
+        # and `closed` for every PR close. Those events only matter when a
+        # stub PR already exists, so gate them on one cheap API call before
+        # the (expensive) repository checkout. `labeled` and manual dispatch
+        # always proceed.
+        case "$EVENT" in
+          labeled|dispatch)
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            n="$(gh pr list --repo "$GITHUB_REPOSITORY" \
+              --head "deprecation-stubs/pr-${PR_NUMBER}" --state open \
+              --json number --jq 'length')"
+            if [ "$n" -gt 0 ]; then
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              echo "No open stub PR for #${PR_NUMBER}; nothing to do."
+            fi
+            ;;
+        esac
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      if: steps.precheck.outputs.proceed == 'true'
+      with:
+        # SECURITY: always check out master, never the (untrusted) PR head.
+        ref: master
+        # The driver needs commit history (merge base, deletion dates) but
+        # no file content beyond a handful of blobs it reads on demand.
+        fetch-depth: 0
+        filter: blob:none
+
+    - name: Generate app token
+      id: app-token
+      if: steps.precheck.outputs.proceed == 'true' && inputs.dry_run != true
+      uses: leanprover-community/mathlib-ci/.github/actions/azure-create-github-app-token@3bb576208589a435eeaeac9b144a1b7c3e948760
+      with:
+        app-id: ${{ secrets.MATHLIB_NOLINTS_APP_ID }}
+        key-vault-name: ${{ vars.MATHLIB_AZ_KEY_VAULT_NAME }}
+        key-name: mathlib-nolints-app-pk
+        azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID_PR_WRITERS }}
+        azure-tenant-id: ${{ secrets.LPC_AZ_TENANT_ID }}
+
+    # This token is masked by the token minting action and will not be
+    # logged accidentally.
+    - name: Maintain the stub PR
+      if: steps.precheck.outputs.proceed == 'true'
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        DRY_RUN: ${{ toJson(inputs.dry_run) }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        # Pushes authenticate through the remote URL; gh uses GH_TOKEN.
+        git remote set-url origin \
+          "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+        args=(--pr "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --run-url "$RUN_URL")
+        case "$EVENT" in
+          closed)      args+=(--close) ;;
+          synchronize) args+=(--only-if-exists) ;;
+        esac
+        if [ "$DRY_RUN" = "true" ]; then
+          args+=(--dry-run)
+        fi
+        ./scripts/auto_deprecate_modules.sh "${args[@]}"

--- a/.github/workflows/auto_deprecate_modules.yml
+++ b/.github/workflows/auto_deprecate_modules.yml
@@ -24,15 +24,16 @@
 # tool here.
 #
 # Requirements:
-#   * the GitHub App behind the minted token needs pull_requests:write on
-#     this repository (open/close the stub PR, post the bors comment) and
-#     contents:write on the stub fork only — it can never push a branch
-#     to this repository;
-#   * the app's user must have member standing in bors (a manual add on
-#     the bors project settings page), otherwise the `bors stack` comment
-#     is ignored. Note: bors's "synchronize members with collaborators"
-#     option replaces the member list on every sync; it must stay off, or
-#     the manually added app user is removed again.
+#   * this reuses the splicebot app pair (see splice_bot_wf_run.yaml),
+#     which already has the needed scopes: the splicebot app acts on pull
+#     requests here (open/close the stub PR, post the bors comment) and
+#     the copy-splicebot app pushes branches to mathlib4_copy only —
+#     nothing can push a branch to this repository;
+#   * the mathlib-splicebot app user must have member standing in bors (a
+#     manual add on the bors project settings page), otherwise the
+#     `bors stack` comment is ignored. Note: bors's "synchronize members
+#     with collaborators" option replaces the member list on every sync;
+#     it must stay off, or the manually added app user is removed again.
 
 name: Auto-stack module deprecation stubs
 
@@ -54,6 +55,8 @@ on:
 concurrency:
   group: auto-deprecate-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   stubs:
@@ -112,30 +115,49 @@ jobs:
         fetch-depth: 0
         filter: blob:none
 
-    - name: Generate app token
-      id: app-token
+    - name: Mint splicebot token (PR actions on this repository)
+      id: pr-token
       if: steps.precheck.outputs.proceed == 'true' && inputs.dry_run != true
       uses: leanprover-community/mathlib-ci/.github/actions/azure-create-github-app-token@3bb576208589a435eeaeac9b144a1b7c3e948760
       with:
-        app-id: ${{ secrets.MATHLIB_NOLINTS_APP_ID }}
+        app-id: ${{ secrets.MATHLIB_SPLICEBOT_APP_ID }}
         key-vault-name: ${{ vars.MATHLIB_AZ_KEY_VAULT_NAME }}
-        key-name: mathlib-nolints-app-pk
-        azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID_PR_WRITERS }}
+        key-name: mathlib-splicebot-app-pk
+        azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID_SPLICEBOT }}
         azure-tenant-id: ${{ secrets.LPC_AZ_TENANT_ID }}
+        owner: leanprover-community
+
+    - name: Mint branch token (pushes to the stub fork)
+      id: branch-token
+      if: steps.precheck.outputs.proceed == 'true' && inputs.dry_run != true
+      uses: leanprover-community/mathlib-ci/.github/actions/azure-create-github-app-token@3bb576208589a435eeaeac9b144a1b7c3e948760
+      with:
+        app-id: ${{ secrets.MATHLIB_COPY_SPLICEBOT_APP_ID }}
+        key-vault-name: ${{ vars.MATHLIB_AZ_KEY_VAULT_NAME }}
+        key-name: mathlib-copy-splicebot-app-pk
+        azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID_SPLICEBOT }}
+        azure-tenant-id: ${{ secrets.LPC_AZ_TENANT_ID }}
+        owner: leanprover-community
 
     # This token is masked by the token minting action and will not be
     # logged accidentally.
     - name: Maintain the stub PR
       if: steps.precheck.outputs.proceed == 'true'
       env:
-        GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.pr-token.outputs.token || secrets.GITHUB_TOKEN }}
+        BRANCH_TOKEN: ${{ steps.branch-token.outputs.token }}
+        ADM_BRANCH_TOKEN: ${{ steps.branch-token.outputs.token }}
         DRY_RUN: ${{ toJson(inputs.dry_run) }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        ADM_GIT_NAME: 'mathlib-splicebot[bot]'
+        ADM_GIT_EMAIL: '261196803+mathlib-splicebot[bot]@users.noreply.github.com'
       run: |
-        # Stub-branch pushes go to the fork, authenticated through the
-        # remote URL; gh uses GH_TOKEN. Nothing pushes to this repository.
+        # Stub-branch pushes go to the fork, authenticated with the
+        # fork-scoped branch token through the remote URL; gh uses
+        # GH_TOKEN. Nothing pushes to this repository. (A dry run mints no
+        # tokens; the remote is then never used.)
         git remote add stubfork \
-          "https://x-access-token:${GH_TOKEN}@github.com/${STUB_REPO}.git"
+          "https://x-access-token:${BRANCH_TOKEN:-none}@github.com/${STUB_REPO}.git"
 
         args=(--pr "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --run-url "$RUN_URL"
               --push-repo "$STUB_REPO" --push-remote stubfork)

--- a/.github/workflows/auto_deprecate_modules.yml
+++ b/.github/workflows/auto_deprecate_modules.yml
@@ -29,11 +29,16 @@
 #     requests here (open/close the stub PR, post the bors comment) and
 #     the copy-splicebot app pushes branches to mathlib4_copy only —
 #     nothing can push a branch to this repository;
-#   * the mathlib-splicebot app user must have member standing in bors (a
-#     manual add on the bors project settings page), otherwise the
-#     `bors stack` comment is ignored. Note: bors's "synchronize members
-#     with collaborators" option replaces the member list on every sync;
-#     it must stay off, or the manually added app user is removed again.
+#   * the `bors stack` comment should be posted by a dedicated
+#     single-purpose app (see the commented-out "Mint stack token" step);
+#     its app user needs member standing in bors (a manual add on the
+#     bors project settings page), otherwise the comment is ignored.
+#     Keeping that identity separate from splicebot means no other
+#     automation can ever issue bors commands. Until the app exists, the
+#     comment falls back to the splicebot identity. Note: bors's
+#     "synchronize members with collaborators" option replaces the member
+#     list on every sync; it must stay off, or the manually added app
+#     user is removed again.
 
 name: Auto-stack module deprecation stubs
 
@@ -139,6 +144,21 @@ jobs:
         azure-tenant-id: ${{ secrets.LPC_AZ_TENANT_ID }}
         owner: leanprover-community
 
+    # TODO(provisioning): a dedicated app for the bors-privileged comment,
+    # so bors member standing never attaches to the splicebot identity.
+    # Uncomment once the app pair exists in the key vault.
+    # - name: Mint stack token (posts the bors stack comment)
+    #   id: stack-token
+    #   if: steps.precheck.outputs.proceed == 'true' && inputs.dry_run != true
+    #   uses: leanprover-community/mathlib-ci/.github/actions/azure-create-github-app-token@3bb576208589a435eeaeac9b144a1b7c3e948760
+    #   with:
+    #     app-id: ${{ secrets.MATHLIB_STACKER_APP_ID }}
+    #     key-vault-name: ${{ vars.MATHLIB_AZ_KEY_VAULT_NAME }}
+    #     key-name: mathlib-stacker-app-pk
+    #     azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID_SPLICEBOT }}
+    #     azure-tenant-id: ${{ secrets.LPC_AZ_TENANT_ID }}
+    #     owner: leanprover-community
+
     # This token is masked by the token minting action and will not be
     # logged accidentally.
     - name: Maintain the stub PR
@@ -147,6 +167,9 @@ jobs:
         GH_TOKEN: ${{ steps.pr-token.outputs.token || secrets.GITHUB_TOKEN }}
         BRANCH_TOKEN: ${{ steps.branch-token.outputs.token }}
         ADM_BRANCH_TOKEN: ${{ steps.branch-token.outputs.token }}
+        # Empty until the dedicated stack app exists; the driver then
+        # falls back to GH_TOKEN for the bors stack comment.
+        ADM_STACK_TOKEN: ${{ steps.stack-token.outputs.token }}
         DRY_RUN: ${{ toJson(inputs.dry_run) }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         ADM_GIT_NAME: 'mathlib-splicebot[bot]'

--- a/scripts/auto_deprecate_modules.sh
+++ b/scripts/auto_deprecate_modules.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+
+# auto_deprecate_modules.sh: maintain a stacked `deprecated_module` stub PR
+# for a parent PR that deletes or renames Lean modules.
+#
+# For parent PR #N, this script:
+#   * finds every `Mathlib/`, `Archive/` or `Counterexamples/` module that
+#     #N deletes or renames (vs the merge base with the target branch);
+#   * generates one `deprecated_module` stub per moved module, plus the
+#     matching `public import` lines in the root import files
+#     (`Mathlib.lean`, `Mathlib/Tactic.lean`, `Archive.lean`,
+#     `Counterexamples.lean`);
+#   * commits them on branch `deprecation-stubs/pr-N`, based on the head
+#     commit of #N;
+#   * opens (or refreshes) a PR for that branch against the target branch,
+#     and chains it to #N with a `bors stack #N` comment. Bors then merges
+#     both PRs atomically, parent first, so the old module names always
+#     resolve on the target branch.
+#
+# SECURITY: this script is meant to run in a privileged workflow
+# (pull_request_target) with a token that can push branches and open PRs.
+# It must never execute anything that comes from the parent PR. The stub
+# commit is assembled with git plumbing (read-tree/update-index/commit-tree);
+# file content is only read via `git cat-file` / `git show`. Do not add
+# steps that check out or build the parent PR's tree (lake, lean, ...).
+#
+# Stub generation mirrors scripts/create_deprecated_modules.lean:
+#   * a rename becomes a redirect stub (`public import <new module>`);
+#   * a deletion copies the deleted file's import block verbatim;
+#   * the `since` date is the date of the commit that removed the file.
+# The stub PR's own CI (`lake exe mk_all --check`, the header linter and a
+# full build) validates the generated files, so any drift between the two
+# generators is caught before the stubs can merge.
+#
+# Usage:
+#   auto_deprecate_modules.sh --pr N --repo OWNER/NAME [options]
+#
+# Options:
+#   --pr N              parent PR number (required)
+#   --repo OWNER/NAME   GitHub repository (required unless offline)
+#   --remote NAME       git remote to fetch from / push to (default: origin)
+#   --base BRANCH       target branch of the parent PR (default: master)
+#   --dry-run           log everything, push nothing, call no mutating API
+#   --close             close the stub PR (parent was closed without merge)
+#   --only-if-exists    exit quietly unless an open stub PR already exists;
+#                       used by the repo-wide `synchronize` trigger
+#   --run-url URL       workflow-run URL to link in the stub PR body
+#   --head-ref REF      TESTING: use a local ref as the parent head; skips
+#                       all gh calls and fetches, and requires --dry-run
+#   --base-ref REF      TESTING: use a local ref as the target branch
+#
+# Environment:
+#   GH_TOKEN            token for gh (pushes use the remote's configured auth)
+#   ADM_GIT_NAME/EMAIL  git identity for the stub commit
+#                       (default: mathlib-nolints[bot])
+
+set -euo pipefail
+export LC_ALL=C
+
+PR=""
+REPO=""
+REMOTE="origin"
+BASE="master"
+DRY_RUN=""
+CLOSE=""
+ONLY_IF_EXISTS=""
+RUN_URL=""
+HEAD_REF_OVERRIDE=""
+BASE_REF_OVERRIDE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pr) PR="$2"; shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --remote) REMOTE="$2"; shift 2 ;;
+    --base) BASE="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --close) CLOSE=1; shift ;;
+    --only-if-exists) ONLY_IF_EXISTS=1; shift ;;
+    --run-url) RUN_URL="$2"; shift 2 ;;
+    --head-ref) HEAD_REF_OVERRIDE="$2"; shift 2 ;;
+    --base-ref) BASE_REF_OVERRIDE="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$PR" ] || { echo "--pr is required" >&2; exit 2; }
+case "$PR" in *[!0-9]*|'') echo "--pr must be a number" >&2; exit 2 ;; esac
+
+OFFLINE=""
+if [ -n "$HEAD_REF_OVERRIDE" ]; then
+  OFFLINE=1
+  [ -n "$DRY_RUN" ] || { echo "--head-ref requires --dry-run" >&2; exit 2; }
+else
+  [ -n "$REPO" ] || { echo "--repo is required" >&2; exit 2; }
+fi
+
+STUB_BRANCH="deprecation-stubs/pr-${PR}"
+GIT_NAME="${ADM_GIT_NAME:-mathlib-nolints[bot]}"
+GIT_EMAIL="${ADM_GIT_EMAIL:-258989889+mathlib-nolints[bot]@users.noreply.github.com}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+TMP="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP"
+  git update-ref -d "refs/auto-deprecate/head-${PR}" 2>/dev/null || true
+  git update-ref -d "refs/auto-deprecate/base-${PR}" 2>/dev/null || true
+  git update-ref -d "refs/auto-deprecate/existing-${PR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+log() { printf '%s\n' "$*" >&2; }
+
+# find_stub_pr: print the number of the open stub PR, if any.
+find_stub_pr() {
+  gh pr list --repo "$REPO" --head "$STUB_BRANCH" --state open \
+    --json number --jq '.[0].number // empty'
+}
+
+close_stub_pr() {
+  local reason="$1" num
+  num="$(find_stub_pr)"
+  if [ -z "$num" ]; then
+    log "no open stub PR for ${STUB_BRANCH}; nothing to close"
+    return 0
+  fi
+  if [ -n "$DRY_RUN" ]; then
+    log "dry-run: would close stub PR #${num} (${reason}) and delete ${STUB_BRANCH}"
+    return 0
+  fi
+  gh pr close "$num" --repo "$REPO" --comment "$reason" --delete-branch
+  log "closed stub PR #${num} and deleted ${STUB_BRANCH}"
+}
+
+# --close: the parent PR was closed. Only clean up if it was not merged;
+# a merged parent means bors handled the bundle (or a human unstacked it),
+# and the stubs may still be needed.
+if [ -n "$CLOSE" ]; then
+  merged="$(gh api "repos/${REPO}/pulls/${PR}" --jq .merged)"
+  if [ "$merged" = "true" ]; then
+    log "parent #${PR} was merged; leaving the stub PR untouched"
+    exit 0
+  fi
+  close_stub_pr "Parent PR #${PR} was closed without merging, so these stubs are no longer needed."
+  exit 0
+fi
+
+if [ -n "$ONLY_IF_EXISTS" ] && [ -z "$OFFLINE" ]; then
+  if [ -z "$(find_stub_pr)" ]; then
+    log "no open stub PR for #${PR}; nothing to refresh"
+    exit 0
+  fi
+fi
+
+# Opt-out: the `no-auto-stub` label on the parent disables this automation.
+if [ -z "$OFFLINE" ]; then
+  IFS=$'\t' read -r state base_ref has_optout < <(gh api "repos/${REPO}/pulls/${PR}" \
+    --jq '[.state, .base.ref, (([.labels[].name] | contains(["no-auto-stub"])) | tostring)] | @tsv')
+  if [ "$state" != "open" ]; then
+    log "parent #${PR} is ${state}; nothing to do"
+    exit 0
+  fi
+  if [ "$base_ref" != "$BASE" ]; then
+    log "parent #${PR} targets '${base_ref}', not '${BASE}'; skipping"
+    exit 0
+  fi
+  if [ "$has_optout" = "true" ]; then
+    log "parent #${PR} carries the no-auto-stub label"
+    close_stub_pr "Parent PR #${PR} opted out of automatic deprecation stubs (label \`no-auto-stub\`)."
+    exit 0
+  fi
+  git fetch -q --no-tags "$REMOTE" \
+    "+refs/heads/${BASE}:refs/auto-deprecate/base-${PR}" \
+    "+refs/pull/${PR}/head:refs/auto-deprecate/head-${PR}"
+  BASE_SHA="$(git rev-parse "refs/auto-deprecate/base-${PR}")"
+  HEAD_SHA="$(git rev-parse "refs/auto-deprecate/head-${PR}")"
+else
+  BASE_SHA="$(git rev-parse "${BASE_REF_OVERRIDE:-$BASE}")"
+  HEAD_SHA="$(git rev-parse "$HEAD_REF_OVERRIDE")"
+fi
+
+MB="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+log "parent #${PR}: head ${HEAD_SHA}, merge base ${MB}"
+
+# mod_name Mathlib/Data/Nat/Basic.lean -> Mathlib.Data.Nat.Basic
+mod_name() {
+  local p="${1%.lean}"
+  printf '%s' "${p//\//.}"
+}
+
+# stub_date PATH: date (YYYY-MM-DD) of the commit that removed PATH,
+# searched from the parent head. Matches create_deprecated_modules.lean,
+# which uses the deletion commit's date for `since :=`.
+stub_date() {
+  local d
+  d="$(git log -1 --format=%cs "$HEAD_SHA" -- "$1" || true)"
+  if [ -z "$d" ]; then
+    log "warning: no history for $1 (shallow clone?); using today's date"
+    d="$(date -u +%Y-%m-%d)"
+  fi
+  printf '%s' "$d"
+}
+
+# Collect deletions and renames of library modules, excluding files that
+# were already deprecation stubs (removing an expired stub must not create
+# a fresh one; PR_summary flags those separately).
+STUBS_FILE="$TMP/stubs.tsv"    # kind<TAB>old<TAB>new
+: > "$STUBS_FILE"
+mkdir -p "$TMP/stubs"
+
+while IFS=$'\t' read -r status old new; do
+  case "$old" in
+    Mathlib/*.lean|Archive/*.lean|Counterexamples/*.lean) ;;
+    *) continue ;;
+  esac
+  if git show "${MB}:${old}" 2>/dev/null | grep -q '^deprecated_module'; then
+    log "skip ${old}: it is already a deprecation stub"
+    continue
+  fi
+  case "$status" in
+    D) printf 'D\t%s\t\n' "$old" >> "$STUBS_FILE" ;;
+    R*) printf 'R\t%s\t%s\n' "$old" "$new" >> "$STUBS_FILE" ;;
+  esac
+done < <(git diff -M --name-status --diff-filter=DR "$MB" "$HEAD_SHA")
+
+if [ ! -s "$STUBS_FILE" ]; then
+  log "parent #${PR} deletes or renames no library modules"
+  if [ -z "$OFFLINE" ]; then
+    close_stub_pr "Parent PR #${PR} no longer deletes or renames modules, so these stubs are no longer needed."
+  fi
+  exit 0
+fi
+
+# Generate one stub file per moved module.
+SUMMARY="$TMP/summary.md"
+: > "$SUMMARY"
+
+while IFS=$'\t' read -r kind old new; do
+  date="$(stub_date "$old")"
+  out="$TMP/stubs/${old}"
+  mkdir -p "$(dirname "$out")"
+  if [ "$kind" = "R" ]; then
+    {
+      printf 'module -- shake: keep-all\n\n'
+      printf 'public import %s\n\n' "$(mod_name "$new")"
+      printf 'deprecated_module "`%s` has been renamed to `%s`" (since := "%s")\n' \
+        "$(mod_name "$old")" "$(mod_name "$new")" "$date"
+    } > "$out"
+    printf -- '- `%s` → `%s` (renamed)\n' "$old" "$new" >> "$SUMMARY"
+  else
+    old_src="$(git show "${MB}:${old}")"
+    imports="$(grep -E '^((public|meta)[[:space:]]+)*import[[:space:]]' <<<"$old_src" || true)"
+    {
+      if grep -qE '^module([[:space:]]|$)' <<<"$old_src"; then
+        printf 'module -- shake: keep-all\n\n'
+      fi
+      if [ -n "$imports" ]; then
+        printf '%s\n\n' "$imports"
+      fi
+      printf 'deprecated_module (since := "%s")\n' "$date"
+    } > "$out"
+    printf -- '- `%s` (deleted)\n' "$old" >> "$SUMMARY"
+  fi
+  log "generated stub for ${old} (${kind}, since ${date})"
+done < "$STUBS_FILE"
+
+# roots_for PATH: the root import files that must list PATH's module.
+# Modules under Mathlib/Tactic/ are listed both in Mathlib.lean and in
+# Mathlib/Tactic.lean (mirroring `lake exe mk_all`).
+roots_for() {
+  case "$1" in
+    Mathlib/Tactic/*) printf 'Mathlib.lean\nMathlib/Tactic.lean\n' ;;
+    Mathlib/*)        printf 'Mathlib.lean\n' ;;
+    Archive/*)        printf 'Archive.lean\n' ;;
+    Counterexamples/*) printf 'Counterexamples.lean\n' ;;
+  esac
+}
+
+# prefix_for ROOT: the module-name prefix of the sorted import region that
+# ROOT owns. Insertion sorts only against lines with this prefix, because
+# root files also carry unrelated entries (e.g. `public import Std`).
+prefix_for() {
+  case "$1" in
+    Mathlib.lean)          printf 'Mathlib.' ;;
+    Mathlib/Tactic.lean)   printf 'Mathlib.Tactic.' ;;
+    Archive.lean)          printf 'Archive.' ;;
+    Counterexamples.lean)  printf 'Counterexamples.' ;;
+  esac
+}
+
+# insert_import FILE MOD PREFIX: insert `public import MOD` into FILE at
+# its sorted position among the `public import PREFIX*` lines. No-op when
+# the line is already present.
+insert_import() {
+  local file="$1" mod="$2" prefix="$3"
+  awk -v mod="$mod" -v prefix="$prefix" '
+    BEGIN { newline = "public import " mod; done = 0; inregion = 0 }
+    {
+      matches = (index($0, "public import " prefix) == 1)
+      if (!done && $0 == newline) { done = 1 }
+      else if (!done && matches) {
+        inregion = 1
+        cur = substr($0, 15)
+        if (cur > mod) { print newline; done = 1 }
+      }
+      else if (!done && inregion && !matches) { print newline; done = 1 }
+      print
+    }
+    END { if (!done) print newline }
+  ' "$file" > "${file}.new"
+  mv "${file}.new" "$file"
+}
+
+# Prepare updated root import files.
+mkdir -p "$TMP/roots"
+ROOTS_TOUCHED="$TMP/roots_touched"
+: > "$ROOTS_TOUCHED"
+
+while IFS=$'\t' read -r kind old new; do
+  while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    if ! git cat-file -e "${HEAD_SHA}:${root}" 2>/dev/null; then
+      log "warning: ${root} does not exist at the parent head; skipping"
+      continue
+    fi
+    rootcopy="$TMP/roots/${root//\//__}"
+    if [ ! -f "$rootcopy" ]; then
+      git cat-file blob "${HEAD_SHA}:${root}" > "$rootcopy"
+      printf '%s\n' "$root" >> "$ROOTS_TOUCHED"
+    fi
+    insert_import "$rootcopy" "$(mod_name "$old")" "$(prefix_for "$root")"
+  done < <(roots_for "$old")
+done < "$STUBS_FILE"
+
+# Assemble the stub commit with git plumbing; the parent PR's tree is never
+# checked out.
+export GIT_INDEX_FILE="$TMP/index"
+git read-tree "$HEAD_SHA"
+while IFS=$'\t' read -r kind old new; do
+  blob="$(git hash-object -w -- "$TMP/stubs/${old}")"
+  git update-index --add --cacheinfo "100644,${blob},${old}"
+done < "$STUBS_FILE"
+sort -u "$ROOTS_TOUCHED" | while IFS= read -r root; do
+  blob="$(git hash-object -w -- "$TMP/roots/${root//\//__}")"
+  git update-index --add --cacheinfo "100644,${blob},${root}"
+done
+TREE="$(git write-tree)"
+unset GIT_INDEX_FILE
+
+COMMIT_MSG="chore: module deprecation stubs for #${PR}"
+COMMIT="$(GIT_AUTHOR_NAME="$GIT_NAME" GIT_AUTHOR_EMAIL="$GIT_EMAIL" \
+  GIT_COMMITTER_NAME="$GIT_NAME" GIT_COMMITTER_EMAIL="$GIT_EMAIL" \
+  git commit-tree "$TREE" -p "$HEAD_SHA" -m "$COMMIT_MSG")"
+
+log "built stub commit ${COMMIT}"
+git --no-pager show --stat --format='%h %s' "$COMMIT" >&2
+
+if [ -n "$DRY_RUN" ]; then
+  log ""
+  log "dry-run: generated stubs:"
+  while IFS=$'\t' read -r kind old new; do
+    log ""
+    log "----- ${old} -----"
+    cat "$TMP/stubs/${old}" >&2
+  done < "$STUBS_FILE"
+  log ""
+  log "dry-run: would push ${COMMIT} to ${REMOTE}/${STUB_BRANCH}"
+  log "dry-run: would open or refresh the stub PR and comment 'bors stack #${PR}'"
+  exit 0
+fi
+
+# Idempotency: skip the push when the branch already holds this exact tree
+# on this exact parent.
+NEED_PUSH=1
+if git fetch -q --no-tags "$REMOTE" "+refs/heads/${STUB_BRANCH}:refs/auto-deprecate/existing-${PR}" 2>/dev/null; then
+  existing="$(git rev-parse "refs/auto-deprecate/existing-${PR}")"
+  if [ "$(git rev-parse "${existing}^{tree}")" = "$TREE" ] &&
+     [ "$(git rev-parse "${existing}^1" 2>/dev/null)" = "$HEAD_SHA" ]; then
+    log "branch ${STUB_BRANCH} is already up to date"
+    NEED_PUSH=""
+  fi
+  git update-ref -d "refs/auto-deprecate/existing-${PR}" || true
+fi
+if [ -n "$NEED_PUSH" ]; then
+  git push -q --force "$REMOTE" "${COMMIT}:refs/heads/${STUB_BRANCH}"
+  log "pushed ${STUB_BRANCH}"
+fi
+
+COMPARE_URL="https://github.com/${REPO}/compare/${HEAD_SHA}...${COMMIT}"
+BODY="$TMP/body.md"
+cat > "$BODY" <<EOF
+This PR adds \`deprecated_module\` stubs for the modules that #${PR} deletes or renames:
+
+$(cat "$SUMMARY")
+
+It is stacked on #${PR} with \`bors stack\`. Bors merges the two PRs in one batch, parent first. The old module names keep working on \`${BASE}\` at all times.
+
+Notes for the reviewer:
+
+- The diff on this page includes the changes of #${PR}, because this branch starts from its head commit. See the stubs alone here: ${COMPARE_URL}
+- Give each of the two PRs its own \`bors r+\`. Bors holds the first approval until the other PR is also approved.
+- Automation refreshes this branch each time #${PR} changes. Do not push commits to it.
+- If a stub needs a custom deprecation message, edit it after the merge, or replace this PR with a manual one and add the \`no-auto-stub\` label to #${PR}.
+
+---
+Auto-generated by \`scripts/auto_deprecate_modules.sh\`${RUN_URL:+ ([workflow run](${RUN_URL}))}
+EOF
+
+EXISTING_PR="$(find_stub_pr)"
+if [ -z "$EXISTING_PR" ]; then
+  url="$(gh pr create --repo "$REPO" --base "$BASE" --head "$STUB_BRANCH" \
+    --title "chore: module deprecation stubs for #${PR}" \
+    --body-file "$BODY")"
+  EXISTING_PR="${url##*/}"
+  log "opened stub PR #${EXISTING_PR}"
+  gh pr comment "$EXISTING_PR" --repo "$REPO" --body "bors stack #${PR}"
+  log "posted 'bors stack #${PR}' on #${EXISTING_PR}"
+else
+  gh pr edit "$EXISTING_PR" --repo "$REPO" --body-file "$BODY"
+  log "refreshed stub PR #${EXISTING_PR}"
+fi

--- a/scripts/auto_deprecate_modules.sh
+++ b/scripts/auto_deprecate_modules.sh
@@ -11,14 +11,18 @@
 #     (`Mathlib.lean`, `Mathlib/Tactic.lean`, `Archive.lean`,
 #     `Counterexamples.lean`);
 #   * commits them on branch `deprecation-stubs/pr-N`, based on the head
-#     commit of #N;
+#     commit of #N. The branch lives in the repository given by --push-repo
+#     (a fork in the same fork network, e.g. mathlib4_copy), so the token
+#     never needs push access to the main repository;
 #   * opens (or refreshes) a PR for that branch against the target branch,
 #     and chains it to #N with a `bors stack #N` comment. Bors then merges
 #     both PRs atomically, parent first, so the old module names always
-#     resolve on the target branch.
+#     resolve on the target branch. Bors compares bundle members by commit
+#     SHA, so a fork-hosted stub branch works.
 #
 # SECURITY: this script is meant to run in a privileged workflow
-# (pull_request_target) with a token that can push branches and open PRs.
+# (pull_request_target) with a token that can push branches to the stub
+# fork and open PRs.
 # It must never execute anything that comes from the parent PR. The stub
 # commit is assembled with git plumbing (read-tree/update-index/commit-tree);
 # file content is only read via `git cat-file` / `git show`. Do not add
@@ -37,9 +41,21 @@
 #
 # Options:
 #   --pr N              parent PR number (required)
-#   --repo OWNER/NAME   GitHub repository (required unless offline)
-#   --remote NAME       git remote to fetch from / push to (default: origin)
+#   --repo OWNER/NAME   GitHub repository of the parent PR (required unless
+#                       offline)
+#   --remote NAME       git remote to fetch the parent from (default: origin)
+#   --push-repo O/N     repository that hosts the stub branches (default:
+#                       --repo). Must be in the same fork network. PRs still
+#                       open on --repo.
+#   --push-remote R     git remote or URL to push the stub branch to
+#                       (default: --remote when --push-repo equals --repo,
+#                       otherwise https://github.com/<push-repo>.git)
 #   --base BRANCH       target branch of the parent PR (default: master)
+#   --bors-login NAME   GitHub login of the bors bot (default: mathlib-bors).
+#                       Used to tell a bors merge apart from an abandoned
+#                       parent: in squash mode bors closes pull requests
+#                       instead of merging them through GitHub, so `.merged`
+#                       stays false and only the closing actor differs.
 #   --dry-run           log everything, push nothing, call no mutating API
 #   --close             close the stub PR (parent was closed without merge)
 #   --only-if-exists    exit quietly unless an open stub PR already exists;
@@ -60,7 +76,10 @@ export LC_ALL=C
 PR=""
 REPO=""
 REMOTE="origin"
+PUSH_REPO=""
+PUSH_REMOTE=""
 BASE="master"
+BORS_LOGIN="mathlib-bors"
 DRY_RUN=""
 CLOSE=""
 ONLY_IF_EXISTS=""
@@ -73,7 +92,10 @@ while [ $# -gt 0 ]; do
     --pr) PR="$2"; shift 2 ;;
     --repo) REPO="$2"; shift 2 ;;
     --remote) REMOTE="$2"; shift 2 ;;
+    --push-repo) PUSH_REPO="$2"; shift 2 ;;
+    --push-remote) PUSH_REMOTE="$2"; shift 2 ;;
     --base) BASE="$2"; shift 2 ;;
+    --bors-login) BORS_LOGIN="$2"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     --close) CLOSE=1; shift ;;
     --only-if-exists) ONLY_IF_EXISTS=1; shift ;;
@@ -95,6 +117,17 @@ else
   [ -n "$REPO" ] || { echo "--repo is required" >&2; exit 2; }
 fi
 
+PUSH_REPO="${PUSH_REPO:-$REPO}"
+PUSH_OWNER="${PUSH_REPO%%/*}"
+PUSH_REPO_NAME="${PUSH_REPO##*/}"
+if [ -z "$PUSH_REMOTE" ]; then
+  if [ "$PUSH_REPO" = "$REPO" ]; then
+    PUSH_REMOTE="$REMOTE"
+  else
+    PUSH_REMOTE="https://github.com/${PUSH_REPO}.git"
+  fi
+fi
+
 STUB_BRANCH="deprecation-stubs/pr-${PR}"
 GIT_NAME="${ADM_GIT_NAME:-mathlib-nolints[bot]}"
 GIT_EMAIL="${ADM_GIT_EMAIL:-258989889+mathlib-nolints[bot]@users.noreply.github.com}"
@@ -112,10 +145,13 @@ trap cleanup EXIT
 
 log() { printf '%s\n' "$*" >&2; }
 
-# find_stub_pr: print the number of the open stub PR, if any.
+# find_stub_pr: print the number of the open stub PR, if any. The head
+# filter takes the branch label (`owner:branch`); for a same-org fork the
+# label matches either hosting repository, which is fine because only the
+# automation creates this branch name.
 find_stub_pr() {
-  gh pr list --repo "$REPO" --head "$STUB_BRANCH" --state open \
-    --json number --jq '.[0].number // empty'
+  gh api "repos/${REPO}/pulls?state=open&head=${PUSH_OWNER}:${STUB_BRANCH}" \
+    --jq '.[0].number // empty'
 }
 
 close_stub_pr() {
@@ -126,20 +162,44 @@ close_stub_pr() {
     return 0
   fi
   if [ -n "$DRY_RUN" ]; then
-    log "dry-run: would close stub PR #${num} (${reason}) and delete ${STUB_BRANCH}"
+    log "dry-run: would close stub PR #${num} (${reason}) and delete ${PUSH_REPO}:${STUB_BRANCH}"
     return 0
   fi
-  gh pr close "$num" --repo "$REPO" --comment "$reason" --delete-branch
-  log "closed stub PR #${num} and deleted ${STUB_BRANCH}"
+  gh pr close "$num" --repo "$REPO" --comment "$reason"
+  gh api -X DELETE "repos/${PUSH_REPO}/git/refs/heads/${STUB_BRANCH}" 2>/dev/null ||
+    log "note: branch ${STUB_BRANCH} was already gone from ${PUSH_REPO}"
+  log "closed stub PR #${num} and deleted ${PUSH_REPO}:${STUB_BRANCH}"
 }
 
-# --close: the parent PR was closed. Only clean up if it was not merged;
-# a merged parent means bors handled the bundle (or a human unstacked it),
-# and the stubs may still be needed.
+# gc_stub_branch: delete the stub branch once its PR is no longer open.
+# Needed because bors's delete_merged_branches cannot delete a branch that
+# lives in the stub fork.
+gc_stub_branch() {
+  if [ -n "$(find_stub_pr)" ]; then
+    log "parent #${PR} was merged but the stub PR is still open; leaving it untouched"
+  elif [ -n "$DRY_RUN" ]; then
+    log "dry-run: would delete ${PUSH_REPO}:${STUB_BRANCH} if it still exists"
+  elif gh api -X DELETE "repos/${PUSH_REPO}/git/refs/heads/${STUB_BRANCH}" 2>/dev/null; then
+    log "deleted merged stub branch ${PUSH_REPO}:${STUB_BRANCH}"
+  else
+    log "no stub branch to clean up"
+  fi
+}
+
+# --close: the parent PR was closed.
+# Merged by bors or through GitHub: never touch an open stub PR; only
+# garbage-collect the stub branch once its PR is no longer open. In squash
+# mode bors closes pull requests instead of merging them through GitHub, so
+# `.merged` stays false there and the closing actor is the signal.
+# Closed by a person without a merge: the stubs are no longer needed, so
+# close the stub PR.
 if [ -n "$CLOSE" ]; then
   merged="$(gh api "repos/${REPO}/pulls/${PR}" --jq .merged)"
-  if [ "$merged" = "true" ]; then
-    log "parent #${PR} was merged; leaving the stub PR untouched"
+  closer="$(gh api "repos/${REPO}/issues/${PR}" --jq '.closed_by.login // empty')"
+  # closed_by reports the app-suffixed login (`name[bot]`) while comments
+  # use the plain login; compare with the suffix stripped.
+  if [ "$merged" = "true" ] || [ "${closer%\[bot\]}" = "${BORS_LOGIN%\[bot\]}" ]; then
+    gc_stub_branch
     exit 0
   fi
   close_stub_pr "Parent PR #${PR} was closed without merging, so these stubs are no longer needed."
@@ -365,7 +425,7 @@ if [ -n "$DRY_RUN" ]; then
     cat "$TMP/stubs/${old}" >&2
   done < "$STUBS_FILE"
   log ""
-  log "dry-run: would push ${COMMIT} to ${REMOTE}/${STUB_BRANCH}"
+  log "dry-run: would push ${COMMIT} to ${PUSH_REPO}:${STUB_BRANCH}"
   log "dry-run: would open or refresh the stub PR and comment 'bors stack #${PR}'"
   exit 0
 fi
@@ -373,7 +433,7 @@ fi
 # Idempotency: skip the push when the branch already holds this exact tree
 # on this exact parent.
 NEED_PUSH=1
-if git fetch -q --no-tags "$REMOTE" "+refs/heads/${STUB_BRANCH}:refs/auto-deprecate/existing-${PR}" 2>/dev/null; then
+if git fetch -q --no-tags "$PUSH_REMOTE" "+refs/heads/${STUB_BRANCH}:refs/auto-deprecate/existing-${PR}" 2>/dev/null; then
   existing="$(git rev-parse "refs/auto-deprecate/existing-${PR}")"
   if [ "$(git rev-parse "${existing}^{tree}")" = "$TREE" ] &&
      [ "$(git rev-parse "${existing}^1" 2>/dev/null)" = "$HEAD_SHA" ]; then
@@ -383,8 +443,8 @@ if git fetch -q --no-tags "$REMOTE" "+refs/heads/${STUB_BRANCH}:refs/auto-deprec
   git update-ref -d "refs/auto-deprecate/existing-${PR}" || true
 fi
 if [ -n "$NEED_PUSH" ]; then
-  git push -q --force "$REMOTE" "${COMMIT}:refs/heads/${STUB_BRANCH}"
-  log "pushed ${STUB_BRANCH}"
+  git push -q --force "$PUSH_REMOTE" "${COMMIT}:refs/heads/${STUB_BRANCH}"
+  log "pushed ${PUSH_REPO}:${STUB_BRANCH}"
 fi
 
 COMPARE_URL="https://github.com/${REPO}/compare/${HEAD_SHA}...${COMMIT}"
@@ -409,10 +469,22 @@ EOF
 
 EXISTING_PR="$(find_stub_pr)"
 if [ -z "$EXISTING_PR" ]; then
-  url="$(gh pr create --repo "$REPO" --base "$BASE" --head "$STUB_BRANCH" \
-    --title "chore: module deprecation stubs for #${PR}" \
-    --body-file "$BODY")"
-  EXISTING_PR="${url##*/}"
+  if [ "$PUSH_REPO" = "$REPO" ]; then
+    url="$(gh pr create --repo "$REPO" --base "$BASE" --head "$STUB_BRANCH" \
+      --title "chore: module deprecation stubs for #${PR}" \
+      --body-file "$BODY")"
+    EXISTING_PR="${url##*/}"
+  else
+    # Cross-repo head. `head_repo` disambiguates when the fork and the main
+    # repository share an owner (`owner:branch` alone is ambiguous then).
+    EXISTING_PR="$(gh api "repos/${REPO}/pulls" \
+      -f title="chore: module deprecation stubs for #${PR}" \
+      -f head="${PUSH_OWNER}:${STUB_BRANCH}" \
+      -f head_repo="${PUSH_REPO_NAME}" \
+      -f base="$BASE" \
+      -F body=@"$BODY" \
+      --jq '.number')"
+  fi
   log "opened stub PR #${EXISTING_PR}"
   gh pr comment "$EXISTING_PR" --repo "$REPO" --body "bors stack #${PR}"
   log "posted 'bors stack #${PR}' on #${EXISTING_PR}"

--- a/scripts/auto_deprecate_modules.sh
+++ b/scripts/auto_deprecate_modules.sh
@@ -67,8 +67,11 @@
 #
 # Environment:
 #   GH_TOKEN            token for gh (pushes use the remote's configured auth)
+#   ADM_BRANCH_TOKEN    optional token for REST calls against --push-repo
+#                       (branch deletion); needed when GH_TOKEN has no
+#                       contents:write there. Defaults to gh's normal auth.
 #   ADM_GIT_NAME/EMAIL  git identity for the stub commit
-#                       (default: mathlib-nolints[bot])
+#                       (default: mathlib-splicebot[bot])
 
 set -euo pipefail
 export LC_ALL=C
@@ -129,8 +132,8 @@ if [ -z "$PUSH_REMOTE" ]; then
 fi
 
 STUB_BRANCH="deprecation-stubs/pr-${PR}"
-GIT_NAME="${ADM_GIT_NAME:-mathlib-nolints[bot]}"
-GIT_EMAIL="${ADM_GIT_EMAIL:-258989889+mathlib-nolints[bot]@users.noreply.github.com}"
+GIT_NAME="${ADM_GIT_NAME:-mathlib-splicebot[bot]}"
+GIT_EMAIL="${ADM_GIT_EMAIL:-261196803+mathlib-splicebot[bot]@users.noreply.github.com}"
 
 cd "$(git rev-parse --show-toplevel)"
 
@@ -144,6 +147,17 @@ cleanup() {
 trap cleanup EXIT
 
 log() { printf '%s\n' "$*" >&2; }
+
+# delete_stub_branch: delete the stub branch from the push repository,
+# using the branch-scoped token when one is provided.
+delete_stub_branch() {
+  if [ -n "${ADM_BRANCH_TOKEN:-}" ]; then
+    GH_TOKEN="$ADM_BRANCH_TOKEN" gh api -X DELETE \
+      "repos/${PUSH_REPO}/git/refs/heads/${STUB_BRANCH}" 2>/dev/null
+  else
+    gh api -X DELETE "repos/${PUSH_REPO}/git/refs/heads/${STUB_BRANCH}" 2>/dev/null
+  fi
+}
 
 # find_stub_pr: print the number of the open stub PR, if any. The head
 # filter takes the branch label (`owner:branch`); for a same-org fork the
@@ -166,7 +180,7 @@ close_stub_pr() {
     return 0
   fi
   gh pr close "$num" --repo "$REPO" --comment "$reason"
-  gh api -X DELETE "repos/${PUSH_REPO}/git/refs/heads/${STUB_BRANCH}" 2>/dev/null ||
+  delete_stub_branch ||
     log "note: branch ${STUB_BRANCH} was already gone from ${PUSH_REPO}"
   log "closed stub PR #${num} and deleted ${PUSH_REPO}:${STUB_BRANCH}"
 }
@@ -179,7 +193,7 @@ gc_stub_branch() {
     log "parent #${PR} was merged but the stub PR is still open; leaving it untouched"
   elif [ -n "$DRY_RUN" ]; then
     log "dry-run: would delete ${PUSH_REPO}:${STUB_BRANCH} if it still exists"
-  elif gh api -X DELETE "repos/${PUSH_REPO}/git/refs/heads/${STUB_BRANCH}" 2>/dev/null; then
+  elif delete_stub_branch; then
     log "deleted merged stub branch ${PUSH_REPO}:${STUB_BRANCH}"
   else
     log "no stub branch to clean up"
@@ -300,19 +314,31 @@ while IFS=$'\t' read -r kind old new; do
   date="$(stub_date "$old")"
   out="$TMP/stubs/${old}"
   mkdir -p "$(dirname "$out")"
+  # Emit module-system syntax only when the old file used it. Mathlib is
+  # fully migrated, but Archive/ and Counterexamples/ still use plain
+  # imports. (create_deprecated_modules.lean hardcodes the module form for
+  # renames; this detection is deliberately more careful.)
+  old_src="$(git show "${MB}:${old}")"
+  is_module=""
+  if grep -qE '^module([[:space:]]|$)' <<<"$old_src"; then
+    is_module=1
+  fi
   if [ "$kind" = "R" ]; then
     {
-      printf 'module -- shake: keep-all\n\n'
-      printf 'public import %s\n\n' "$(mod_name "$new")"
+      if [ -n "$is_module" ]; then
+        printf 'module -- shake: keep-all\n\n'
+        printf 'public import %s\n\n' "$(mod_name "$new")"
+      else
+        printf 'import %s\n\n' "$(mod_name "$new")"
+      fi
       printf 'deprecated_module "`%s` has been renamed to `%s`" (since := "%s")\n' \
         "$(mod_name "$old")" "$(mod_name "$new")" "$date"
     } > "$out"
     printf -- '- `%s` → `%s` (renamed)\n' "$old" "$new" >> "$SUMMARY"
   else
-    old_src="$(git show "${MB}:${old}")"
     imports="$(grep -E '^((public|meta)[[:space:]]+)*import[[:space:]]' <<<"$old_src" || true)"
     {
-      if grep -qE '^module([[:space:]]|$)' <<<"$old_src"; then
+      if [ -n "$is_module" ]; then
         printf 'module -- shake: keep-all\n\n'
       fi
       if [ -n "$imports" ]; then
@@ -349,19 +375,30 @@ prefix_for() {
   esac
 }
 
-# insert_import FILE MOD PREFIX: insert `public import MOD` into FILE at
-# its sorted position among the `public import PREFIX*` lines. No-op when
-# the line is already present.
+# import_keyword FILE: the import style FILE uses — `public import` for
+# module-system roots (Mathlib.lean, Mathlib/Tactic.lean), plain `import`
+# otherwise (Archive.lean, Counterexamples.lean).
+import_keyword() {
+  if grep -q '^public import ' "$1"; then
+    printf 'public import'
+  else
+    printf 'import'
+  fi
+}
+
+# insert_import FILE MOD PREFIX KW: insert `KW MOD` into FILE at its sorted
+# position among the `KW PREFIX*` lines. No-op when the line is already
+# present.
 insert_import() {
-  local file="$1" mod="$2" prefix="$3"
-  awk -v mod="$mod" -v prefix="$prefix" '
-    BEGIN { newline = "public import " mod; done = 0; inregion = 0 }
+  local file="$1" mod="$2" prefix="$3" kw="$4"
+  awk -v mod="$mod" -v prefix="$prefix" -v kw="$kw" '
+    BEGIN { newline = kw " " mod; done = 0; inregion = 0; modstart = length(kw) + 2 }
     {
-      matches = (index($0, "public import " prefix) == 1)
+      matches = (index($0, kw " " prefix) == 1)
       if (!done && $0 == newline) { done = 1 }
       else if (!done && matches) {
         inregion = 1
-        cur = substr($0, 15)
+        cur = substr($0, modstart)
         if (cur > mod) { print newline; done = 1 }
       }
       else if (!done && inregion && !matches) { print newline; done = 1 }
@@ -389,7 +426,8 @@ while IFS=$'\t' read -r kind old new; do
       git cat-file blob "${HEAD_SHA}:${root}" > "$rootcopy"
       printf '%s\n' "$root" >> "$ROOTS_TOUCHED"
     fi
-    insert_import "$rootcopy" "$(mod_name "$old")" "$(prefix_for "$root")"
+    insert_import "$rootcopy" "$(mod_name "$old")" "$(prefix_for "$root")" \
+      "$(import_keyword "$rootcopy")"
   done < <(roots_for "$old")
 done < "$STUBS_FILE"
 
@@ -397,14 +435,16 @@ done < "$STUBS_FILE"
 # checked out.
 export GIT_INDEX_FILE="$TMP/index"
 git read-tree "$HEAD_SHA"
+# --index-info takes `<mode> SP <sha> SP <stage> TAB <path>`, which keeps
+# the path clear of the comma-separated --cacheinfo syntax.
 while IFS=$'\t' read -r kind old new; do
   blob="$(git hash-object -w -- "$TMP/stubs/${old}")"
-  git update-index --add --cacheinfo "100644,${blob},${old}"
-done < "$STUBS_FILE"
+  printf '100644 %s 0\t%s\n' "$blob" "$old"
+done < "$STUBS_FILE" | git update-index --add --index-info
 sort -u "$ROOTS_TOUCHED" | while IFS= read -r root; do
   blob="$(git hash-object -w -- "$TMP/roots/${root//\//__}")"
-  git update-index --add --cacheinfo "100644,${blob},${root}"
-done
+  printf '100644 %s 0\t%s\n' "$blob" "$root"
+done | git update-index --add --index-info
 TREE="$(git write-tree)"
 unset GIT_INDEX_FILE
 
@@ -425,7 +465,7 @@ if [ -n "$DRY_RUN" ]; then
     cat "$TMP/stubs/${old}" >&2
   done < "$STUBS_FILE"
   log ""
-  log "dry-run: would push ${COMMIT} to ${PUSH_REPO}:${STUB_BRANCH}"
+  log "dry-run: would push ${COMMIT} to ${PUSH_REPO:-$PUSH_REMOTE}:${STUB_BRANCH}"
   log "dry-run: would open or refresh the stub PR and comment 'bors stack #${PR}'"
   exit 0
 fi
@@ -490,5 +530,15 @@ if [ -z "$EXISTING_PR" ]; then
   log "posted 'bors stack #${PR}' on #${EXISTING_PR}"
 else
   gh pr edit "$EXISTING_PR" --repo "$REPO" --body-file "$BODY"
+  # Self-heal: an earlier run can be canceled between PR creation and the
+  # stack comment, which would leave the stub PR unbundled forever. Only
+  # post when no `bors stack` command was ever issued on this PR, so a
+  # deliberate `bors unlink` by a person is not overridden.
+  n_stack="$(gh api "repos/${REPO}/issues/${EXISTING_PR}/comments?per_page=100" \
+    --jq '[.[] | select(.body | startswith("bors stack"))] | length')"
+  if [ "$n_stack" = "0" ]; then
+    gh pr comment "$EXISTING_PR" --repo "$REPO" --body "bors stack #${PR}"
+    log "posted missing 'bors stack #${PR}' on #${EXISTING_PR}"
+  fi
   log "refreshed stub PR #${EXISTING_PR}"
 fi

--- a/scripts/auto_deprecate_modules.sh
+++ b/scripts/auto_deprecate_modules.sh
@@ -70,6 +70,10 @@
 #   ADM_BRANCH_TOKEN    optional token for REST calls against --push-repo
 #                       (branch deletion); needed when GH_TOKEN has no
 #                       contents:write there. Defaults to gh's normal auth.
+#   ADM_STACK_TOKEN     optional token used only to post the `bors stack`
+#                       comment. Lets the bors-privileged identity be a
+#                       separate, single-purpose app instead of the PR
+#                       token's identity. Defaults to gh's normal auth.
 #   ADM_GIT_NAME/EMAIL  git identity for the stub commit
 #                       (default: mathlib-splicebot[bot])
 
@@ -147,6 +151,16 @@ cleanup() {
 trap cleanup EXIT
 
 log() { printf '%s\n' "$*" >&2; }
+
+# post_stack_comment PR_NUMBER: post `bors stack #<parent>` on the stub PR,
+# as the dedicated bors-privileged identity when one is provided.
+post_stack_comment() {
+  if [ -n "${ADM_STACK_TOKEN:-}" ]; then
+    GH_TOKEN="$ADM_STACK_TOKEN" gh pr comment "$1" --repo "$REPO" --body "bors stack #${PR}"
+  else
+    gh pr comment "$1" --repo "$REPO" --body "bors stack #${PR}"
+  fi
+}
 
 # delete_stub_branch: delete the stub branch from the push repository,
 # using the branch-scoped token when one is provided.
@@ -526,7 +540,7 @@ if [ -z "$EXISTING_PR" ]; then
       --jq '.number')"
   fi
   log "opened stub PR #${EXISTING_PR}"
-  gh pr comment "$EXISTING_PR" --repo "$REPO" --body "bors stack #${PR}"
+  post_stack_comment "$EXISTING_PR"
   log "posted 'bors stack #${PR}' on #${EXISTING_PR}"
 else
   gh pr edit "$EXISTING_PR" --repo "$REPO" --body-file "$BODY"
@@ -537,7 +551,7 @@ else
   n_stack="$(gh api "repos/${REPO}/issues/${EXISTING_PR}/comments?per_page=100" \
     --jq '[.[] | select(.body | startswith("bors stack"))] | length')"
   if [ "$n_stack" = "0" ]; then
-    gh pr comment "$EXISTING_PR" --repo "$REPO" --body "bors stack #${PR}"
+    post_stack_comment "$EXISTING_PR"
     log "posted missing 'bors stack #${PR}' on #${EXISTING_PR}"
   fi
   log "refreshed stub PR #${EXISTING_PR}"


### PR DESCRIPTION
When a PR deletes or renames library modules, CI adds the `file-removed` label. The `deprecated_module` stubs must then come in a follow-up PR. Today a contributor opens that follow-up by hand, and between the two merges the old module names do not resolve on `master`.

This PR automates the follow-up with a new workflow and a driver script.

Mechanism:

- The `file-removed` label triggers the workflow.
- The script computes the deleted and renamed modules against the merge base with `master`.
- It generates one stub per module. A rename becomes a redirect stub that imports the new module. A deletion copies the import block of the old file. The stub uses the module system only when the old file did: Mathlib is migrated, `Archive/` and `Counterexamples/` are not. The `since` date is the date of the commit that removed the file.
- It inserts the module names into the root import files, in sorted position and in each file's own import style (`Mathlib.lean`, `Mathlib/Tactic.lean`, `Archive.lean`, `Counterexamples.lean`).
- It commits the files to the branch `deprecation-stubs/pr-N` in `mathlib4_copy` (the org fork with CI disabled), based on the head commit of the parent PR, and opens a PR against `master` here. Bors compares bundle members by commit SHA, so the fork-hosted branch works. PR creation uses the API's `head_repo` parameter, because `owner:branch` is ambiguous for a same-org fork.
- It comments `bors stack #N` on the new PR. Bors merges the two PRs in one batch, parent first. The old module names resolve on `master` at all times. Each PR still needs its own `bors r+`.

Token scope: the workflow reuses the splicebot app pair (see `splice_bot_wf_run.yaml`). The splicebot app acts on pull requests in this repository; the copy-splicebot app pushes branches to `mathlib4_copy` only. The workflow can never push a branch to this repository. The `bors stack` comment — the only action that needs bors standing — goes through a third, dedicated single-purpose app, so that standing never attaches to the splicebot identity, which other automations can trigger. Until that app is provisioned, the comment falls back to the splicebot token.

Lifecycle:

- A push to the parent PR regenerates the stub branch.
- If a person closes the parent PR without a merge, the workflow closes the stub PR. If bors merged the parent, the workflow only deletes the stub branch from the fork. In squash mode bors closes pull requests instead of merging them through GitHub, so the workflow identifies a bors merge by the closing actor, not by the merged flag.
- The `no-auto-stub` label on the parent PR turns the automation off for that PR.
- The removal of an already-expired stub does not create a new stub.

Security: the workflow runs on `pull_request_target` with the tokens above. It therefore never executes code from the parent PR. It checks out `master` only, reads file content with `git show`, and assembles the stub commit with git plumbing. No Lean or Lake runs at generation time. The stub PR's own CI (`lake exe mk_all --check`, the header linter, a full build) validates the generated files. For this reason the generator mirrors `scripts/create_deprecated_modules.lean` in bash instead of calling it.

Testing: the generator was checked against synthetic parent commits in all three trees (deletion, rename, expired-stub removal, sorted root-file inserts, plain-import Archive/Counterexamples cases). The full flow ran twice live on `leanprover-community/bors-sandbox`, once with an in-repo stub branch and once with a fork-hosted stub branch: the driver opened and stacked the stub PR, bors held the first approval until the second, merged the bundle atomically parent first in squash mode, and the driver cleaned up the fork branch afterwards. An independent adversarial review ran over the branch; its findings (Archive/Counterexamples import style, a canceled-run race that could leave the stub PR unstacked) are fixed.

Draft until the prerequisites are in place:

- [ ] provision the dedicated stack-comment app (`MATHLIB_STACKER_APP_ID` / `mathlib-stacker-app-pk`; the mint step ships commented out) and give its app user member standing in bors (a manual add on the project settings page); without it, bors ignores the `bors stack` comment. The bors option "synchronize members with collaborators" must stay off for the project, or the sync removes the manual add again. Member standing allows `stack`/`link` only; the bot can never approve or merge.
- [ ] a pilot run via `workflow_dispatch` (the workflow supports `dry_run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKC7AboHauCypP6jvxfgYh
