### PR TITLE
feat(Computability): characterize halted TM1 configurations

### DIFF
--- a/Mathlib/Computability/TuringMachine/PostTuringMachine.lean
+++ b/Mathlib/Computability/TuringMachine/PostTuringMachine.lean
@@ -350,6 +350,11 @@ def step [Inhabited Γ] (M : Λ → Stmt Γ Λ σ) : Cfg Γ Λ σ → Option (Cf
   | ⟨none, _, _⟩ => none
   | ⟨some l, v, T⟩ => some (stepAux (M l) v T)
 
+@[simp]
+theorem step_none_iff [Inhabited Γ] (M : Λ → Stmt Γ Λ σ) (c : Cfg Γ Λ σ) :
+    step M c = none ↔ c.l = none := by
+  rcases c with ⟨_ | l, v, T⟩ <;> simp [step]
+
 /-- A set `S` of labels supports the statement `q` if all the `goto`
   statements in `q` refer only to other functions in `S`. -/
 def SupportsStmt (S : Finset Λ) : Stmt Γ Λ σ → Prop


### PR DESCRIPTION
Adds `Turing.TM1.step_none_iff`, characterizing exactly when a single TM1 step returns `none`: iff the configuration's current label is already `none`. Tagged `@[simp]`.

Motivated by #35366.

### Validation
Built locally: `lake build Mathlib.Computability.TuringMachine.PostTuringMachine` — succeeds (688 jobs, cache-backed).

Closes #35366

### AI/LLM disclosure
AI coding tools were used to help draft this change and PR description. I reviewed the complete change, understand the reasoning, and verified the build locally before submitting.