### PR TITLE
feat(RingTheory): add nilpotence lemmas for zero sums

### DIFF
--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -224,20 +224,36 @@ variable [Semiring R] {x y : R}
 theorem sq_eq_sq_of_add_eq_zero (h : x + y = 0) : x ^ 2 = y ^ 2 := by
   simpa [h] using show x ^ 2 + (x + y) * y = x * (x + y) + y ^ 2 by grind
 
+theorem pow_even_eq_pow_even_of_add_eq_zero
+    (h : x + y = 0) (n : ℕ) : x ^ (2 * n) = y ^ (2 * n) := by
+  simp [pow_mul, sq_eq_sq_of_add_eq_zero h]
+
+theorem pow_odd_add_pow_odd_eq_zero_of_add_eq_zero
+    (h : x + y = 0) (n : ℕ) : x ^ (2 * n + 1) + y ^ (2 * n + 1) = 0 := by
+  simp_rw [pow_succ, pow_mul, sq_eq_sq_of_add_eq_zero h, ← mul_add, h, mul_zero]
+
+theorem pow_even_eq_pow_even_of_add_eq_zero_right
+    (h : x + y = 0) (n : ℕ) : y ^ (2 * n) = x ^ (2 * n) :=
+  (pow_even_eq_pow_even_of_add_eq_zero h n).symm
+
+theorem pow_odd_add_pow_odd_eq_zero_of_add_eq_zero_right
+    (h : x + y = 0) (n : ℕ) : y ^ (2 * n + 1) + x ^ (2 * n + 1) = 0 := by
+  rw [add_comm]
+  exact pow_odd_add_pow_odd_eq_zero_of_add_eq_zero h n
+
 /-- If two elements of a semiring sum to zero and a power of the right one vanishes,
 then the same power of the left one vanishes. -/
 theorem pow_eq_zero_of_add_eq_zero_left {n : ℕ} (h : x + y = 0) (hy : y ^ n = 0) :
     x ^ n = 0 := by
   obtain ⟨k, rfl | rfl⟩ := Nat.even_or_odd' n
-  · simpa [pow_mul, sq_eq_sq_of_add_eq_zero h] using hy
-  · have hpow : x ^ (2 * k + 1) + y ^ (2 * k + 1) = 0 := by
-      calc
-        x ^ (2 * k + 1) + y ^ (2 * k + 1) =
-            (x ^ 2) ^ k * x + (y ^ 2) ^ k * y := by rw [pow_add, pow_add, pow_mul, pow_mul,
-              pow_one, pow_one]
-        _ = (y ^ 2) ^ k * x + (y ^ 2) ^ k * y := by rw [sq_eq_sq_of_add_eq_zero h]
-        _ = 0 := by rw [← mul_add, h, mul_zero]
-    simpa [hy] using hpow
+  · rwa [pow_even_eq_pow_even_of_add_eq_zero h k]
+  · rwa [eq_zero_iff_eq_zero_of_add_eq_zero (pow_odd_add_pow_odd_eq_zero_of_add_eq_zero h k)]
+
+/-- If two elements of a semiring sum to zero and a power of the left one vanishes,
+then the same power of the right one vanishes. -/
+theorem pow_eq_zero_of_add_eq_zero_right {n : ℕ} (h : x + y = 0) (hx : x ^ n = 0) :
+    y ^ n = 0 :=
+  pow_eq_zero_of_add_eq_zero_left (add_eq_zero_comm.mp h) hx
 
 /-- If two elements of a semiring sum to zero and the right one is nilpotent,
 then so is the left one. -/
@@ -246,9 +262,15 @@ theorem IsNilpotent.of_add_eq_zero_left (h : x + y = 0) (hy : IsNilpotent y) :
   obtain ⟨n, hn⟩ := hy
   exact ⟨n, pow_eq_zero_of_add_eq_zero_left h hn⟩
 
+/-- If two elements of a semiring sum to zero and the left one is nilpotent,
+then so is the right one. -/
+theorem IsNilpotent.of_add_eq_zero_right (h : x + y = 0) (hx : IsNilpotent x) :
+    IsNilpotent y :=
+  .of_add_eq_zero_left (add_eq_zero_comm.mp h) hx
+
 theorem isNilpotent_iff_of_add_eq_zero (h : x + y = 0) :
     IsNilpotent x ↔ IsNilpotent y :=
-  ⟨.of_add_eq_zero_left (add_eq_zero_comm.mp h), .of_add_eq_zero_left h⟩
+  ⟨.of_add_eq_zero_right h, .of_add_eq_zero_left h⟩
 
 end Semiring
 

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -224,13 +224,27 @@ variable [Semiring R] {x y : R}
 theorem sq_eq_sq_of_add_eq_zero (h : x + y = 0) : x ^ 2 = y ^ 2 := by
   simpa [h] using show x ^ 2 + (x + y) * y = x * (x + y) + y ^ 2 by grind
 
+/-- If two elements of a semiring sum to zero and a power of the right one vanishes,
+then the same power of the left one vanishes. -/
+theorem pow_eq_zero_of_add_eq_zero_left {n : ℕ} (h : x + y = 0) (hy : y ^ n = 0) :
+    x ^ n = 0 := by
+  obtain ⟨k, rfl | rfl⟩ := Nat.even_or_odd' n
+  · simpa [pow_mul, sq_eq_sq_of_add_eq_zero h] using hy
+  · have hpow : x ^ (2 * k + 1) + y ^ (2 * k + 1) = 0 := by
+      calc
+        x ^ (2 * k + 1) + y ^ (2 * k + 1) =
+            (x ^ 2) ^ k * x + (y ^ 2) ^ k * y := by rw [pow_add, pow_add, pow_mul, pow_mul,
+              pow_one, pow_one]
+        _ = (y ^ 2) ^ k * x + (y ^ 2) ^ k * y := by rw [sq_eq_sq_of_add_eq_zero h]
+        _ = 0 := by rw [← mul_add, h, mul_zero]
+    simpa [hy] using hpow
+
 /-- If two elements of a semiring sum to zero and the right one is nilpotent,
 then so is the left one. -/
 theorem IsNilpotent.of_add_eq_zero_left (h : x + y = 0) (hy : IsNilpotent y) :
     IsNilpotent x := by
   obtain ⟨n, hn⟩ := hy
-  use 2 * n
-  rw [pow_mul, sq_eq_sq_of_add_eq_zero h, pow_right_comm, hn, pow_two, mul_zero]
+  exact ⟨n, pow_eq_zero_of_add_eq_zero_left h hn⟩
 
 theorem isNilpotent_iff_of_add_eq_zero (h : x + y = 0) :
     IsNilpotent x ↔ IsNilpotent y :=

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -232,15 +232,6 @@ theorem pow_odd_add_pow_odd_eq_zero_of_add_eq_zero
     (h : x + y = 0) (n : ℕ) : x ^ (2 * n + 1) + y ^ (2 * n + 1) = 0 := by
   simp_rw [pow_succ, pow_mul, sq_eq_sq_of_add_eq_zero h, ← mul_add, h, mul_zero]
 
-theorem pow_even_eq_pow_even_of_add_eq_zero_right
-    (h : x + y = 0) (n : ℕ) : y ^ (2 * n) = x ^ (2 * n) :=
-  (pow_even_eq_pow_even_of_add_eq_zero h n).symm
-
-theorem pow_odd_add_pow_odd_eq_zero_of_add_eq_zero_right
-    (h : x + y = 0) (n : ℕ) : y ^ (2 * n + 1) + x ^ (2 * n + 1) = 0 := by
-  rw [add_comm]
-  exact pow_odd_add_pow_odd_eq_zero_of_add_eq_zero h n
-
 /-- If two elements of a semiring sum to zero and a power of the right one vanishes,
 then the same power of the left one vanishes. -/
 theorem pow_eq_zero_of_add_eq_zero_left {n : ℕ} (h : x + y = 0) (hy : y ^ n = 0) :

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -220,6 +220,35 @@ section CommSemiring
 
 variable [CommSemiring R] {x y : R}
 
+/-- In a commutative semiring, two elements whose sum is zero have equal squares. -/
+theorem sq_eq_sq_of_add_eq_zero (h : x + y = 0) : x ^ 2 = y ^ 2 := by
+  calc
+    x ^ 2 = x * x := pow_two x
+    _ = x * x + 0 := (add_zero _).symm
+    _ = x * x + (x + y) * y := by rw [h, zero_mul]
+    _ = (x * x + x * y) + y * y := by rw [add_mul, ← add_assoc]
+    _ = x * (x + y) + y * y := by rw [mul_add]
+    _ = 0 + y * y := by rw [h, mul_zero]
+    _ = y * y := zero_add _
+    _ = y ^ 2 := (pow_two y).symm
+
+/-- If two elements of a commutative semiring sum to zero and the right one is nilpotent,
+then so is the left one. -/
+theorem IsNilpotent.of_add_eq_zero_left (hy : IsNilpotent y) (h : x + y = 0) :
+    IsNilpotent x := by
+  obtain ⟨n, hn⟩ := hy
+  refine ⟨2 * n, ?_⟩
+  calc
+    x ^ (2 * n) = (x ^ 2) ^ n := pow_mul x 2 n
+    _ = (y ^ 2) ^ n := by rw [sq_eq_sq_of_add_eq_zero h]
+    _ = (y ^ n) ^ 2 := by rw [← pow_mul, mul_comm, pow_mul]
+    _ = 0 := by simp [hn]
+
+theorem isNilpotent_iff_of_add_eq_zero (h : x + y = 0) :
+    IsNilpotent x ↔ IsNilpotent y :=
+  ⟨fun hx ↦ hx.of_add_eq_zero_left (by simpa [add_comm] using h),
+    fun hy ↦ hy.of_add_eq_zero_left h⟩
+
 lemma isNilpotent_sum {ι : Type*} {s : Finset ι} {f : ι → R}
     (hnp : ∀ i ∈ s, IsNilpotent (f i)) :
     IsNilpotent (∑ i ∈ s, f i) :=

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -124,6 +124,7 @@ theorem zero_isRadical_iff [MonoidWithZero R] : IsRadical (0 : R) ↔ IsReduced 
 theorem isReduced_iff_pow_one_lt [MonoidWithZero R] (k : ℕ) (hk : 1 < k) :
     IsReduced R ↔ ∀ x : R, x ^ k = 0 → x = 0 := by
   simp_rw [← zero_isRadical_iff, isRadical_iff_pow_one_lt k hk, zero_dvd_iff]
+  exact forall_comm
 
 theorem IsRadical.of_dvd [CommMonoidWithZero R] [IsCancelMulZero R] {x y : R} (hy : IsRadical y)
     (h0 : y ≠ 0) (hxy : x ∣ y) : IsRadical x := (isRadical_iff_pow_one_lt 2 one_lt_two).2 <| by
@@ -222,15 +223,9 @@ variable [CommSemiring R] {x y : R}
 
 /-- In a commutative semiring, two elements whose sum is zero have equal squares. -/
 theorem sq_eq_sq_of_add_eq_zero (h : x + y = 0) : x ^ 2 = y ^ 2 := by
-  calc
-    x ^ 2 = x * x := pow_two x
-    _ = x * x + 0 := (add_zero _).symm
-    _ = x * x + (x + y) * y := by rw [h, zero_mul]
-    _ = (x * x + x * y) + y * y := by rw [add_mul, ← add_assoc]
-    _ = x * (x + y) + y * y := by rw [mul_add]
-    _ = 0 + y * y := by rw [h, mul_zero]
-    _ = y * y := zero_add _
-    _ = y ^ 2 := (pow_two y).symm
+  transitivity x * x + x * y + y * y
+  · rw [pow_two, add_assoc, ← add_mul, h, zero_mul, add_zero]
+  · rw [← mul_add, h, mul_zero, zero_add, pow_two]
 
 /-- If two elements of a commutative semiring sum to zero and the right one is nilpotent,
 then so is the left one. -/

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -216,28 +216,34 @@ end Ring
 
 end Commute
 
-section CommSemiring
+section Semiring
 
-variable [CommSemiring R] {x y : R}
+variable [Semiring R] {x y : R}
 
-/-- In a commutative semiring, two elements whose sum is zero have equal squares. -/
+/-- In a semiring, two elements whose sum is zero have equal squares. -/
 theorem sq_eq_sq_of_add_eq_zero (h : x + y = 0) : x ^ 2 = y ^ 2 := by
   transitivity x * x + x * y + y * y
   · rw [pow_two, add_assoc, ← add_mul, h, zero_mul, add_zero]
   · rw [← mul_add, h, mul_zero, zero_add, pow_two]
 
-/-- If two elements of a commutative semiring sum to zero and the right one is nilpotent,
+/-- If two elements of a semiring sum to zero and the right one is nilpotent,
 then so is the left one. -/
 theorem IsNilpotent.of_add_eq_zero_left (hy : IsNilpotent y) (h : x + y = 0) :
     IsNilpotent x := by
   obtain ⟨n, hn⟩ := hy
   refine ⟨2 * n, ?_⟩
-  rw [pow_mul, sq_eq_sq_of_add_eq_zero h, ← pow_mul, mul_comm, pow_mul, hn, pow_two, mul_zero]
+  rw [pow_mul, sq_eq_sq_of_add_eq_zero h, ← pow_mul, Nat.mul_comm, pow_mul, hn, pow_two, mul_zero]
 
 theorem isNilpotent_iff_of_add_eq_zero (h : x + y = 0) :
     IsNilpotent x ↔ IsNilpotent y :=
   ⟨fun hx ↦ hx.of_add_eq_zero_left (by simpa [add_comm] using h),
     fun hy ↦ hy.of_add_eq_zero_left h⟩
+
+end Semiring
+
+section CommSemiring
+
+variable [CommSemiring R] {x y : R}
 
 lemma isNilpotent_sum {ι : Type*} {s : Finset ι} {f : ι → R}
     (hnp : ∀ i ∈ s, IsNilpotent (f i)) :

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -233,11 +233,7 @@ theorem IsNilpotent.of_add_eq_zero_left (hy : IsNilpotent y) (h : x + y = 0) :
     IsNilpotent x := by
   obtain ⟨n, hn⟩ := hy
   refine ⟨2 * n, ?_⟩
-  calc
-    x ^ (2 * n) = (x ^ 2) ^ n := pow_mul x 2 n
-    _ = (y ^ 2) ^ n := by rw [sq_eq_sq_of_add_eq_zero h]
-    _ = (y ^ n) ^ 2 := by rw [← pow_mul, mul_comm, pow_mul]
-    _ = 0 := by simp [hn]
+  rw [pow_mul, sq_eq_sq_of_add_eq_zero h, ← pow_mul, mul_comm, pow_mul, hn, pow_two, mul_zero]
 
 theorem isNilpotent_iff_of_add_eq_zero (h : x + y = 0) :
     IsNilpotent x ↔ IsNilpotent y :=

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -124,7 +124,6 @@ theorem zero_isRadical_iff [MonoidWithZero R] : IsRadical (0 : R) ↔ IsReduced 
 theorem isReduced_iff_pow_one_lt [MonoidWithZero R] (k : ℕ) (hk : 1 < k) :
     IsReduced R ↔ ∀ x : R, x ^ k = 0 → x = 0 := by
   simp_rw [← zero_isRadical_iff, isRadical_iff_pow_one_lt k hk, zero_dvd_iff]
-  exact forall_comm
 
 theorem IsRadical.of_dvd [CommMonoidWithZero R] [IsCancelMulZero R] {x y : R} (hy : IsRadical y)
     (h0 : y ≠ 0) (hxy : x ∣ y) : IsRadical x := (isRadical_iff_pow_one_lt 2 one_lt_two).2 <| by

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -222,22 +222,19 @@ variable [Semiring R] {x y : R}
 
 /-- In a semiring, two elements whose sum is zero have equal squares. -/
 theorem sq_eq_sq_of_add_eq_zero (h : x + y = 0) : x ^ 2 = y ^ 2 := by
-  transitivity x * x + x * y + y * y
-  · rw [pow_two, add_assoc, ← add_mul, h, zero_mul, add_zero]
-  · rw [← mul_add, h, mul_zero, zero_add, pow_two]
+  simpa [h] using show x ^ 2 + (x + y) * y = x * (x + y) + y ^ 2 by grind
 
 /-- If two elements of a semiring sum to zero and the right one is nilpotent,
 then so is the left one. -/
-theorem IsNilpotent.of_add_eq_zero_left (hy : IsNilpotent y) (h : x + y = 0) :
+theorem IsNilpotent.of_add_eq_zero_left (h : x + y = 0) (hy : IsNilpotent y) :
     IsNilpotent x := by
   obtain ⟨n, hn⟩ := hy
-  refine ⟨2 * n, ?_⟩
-  rw [pow_mul, sq_eq_sq_of_add_eq_zero h, ← pow_mul, Nat.mul_comm, pow_mul, hn, pow_two, mul_zero]
+  use 2 * n
+  rw [pow_mul, sq_eq_sq_of_add_eq_zero h, pow_right_comm, hn, pow_two, mul_zero]
 
 theorem isNilpotent_iff_of_add_eq_zero (h : x + y = 0) :
     IsNilpotent x ↔ IsNilpotent y :=
-  ⟨fun hx ↦ hx.of_add_eq_zero_left (by simpa [add_comm] using h),
-    fun hy ↦ hy.of_add_eq_zero_left h⟩
+  ⟨.of_add_eq_zero_left (add_eq_zero_comm.mp h), .of_add_eq_zero_left h⟩
 
 end Semiring
 


### PR DESCRIPTION
In a commutative semiring, adds:
- `sq_eq_sq_of_add_eq_zero`: if `x + y = 0` then `x^2 = y^2`
- `IsNilpotent.of_add_eq_zero_left`: if `x + y = 0` and `y` is nilpotent, so is `x`
- `isNilpotent_iff_of_add_eq_zero`: under `x + y = 0`, `x` is nilpotent iff `y` is

Motivated by #10539.

### Validation
Built locally: `lake build Mathlib.RingTheory.Nilpotent.Basic` — succeeds.

Closes #10539

### AI/LLM disclosure
AI coding tools were used to help draft this change and PR description. I reviewed the complete change, understand the reasoning, and verified the build locally before submitting.