### PR TITLE
doc(RingTheory/Extension/Generators): remove stale TODO and clarify docstring

### DIFF
--- a/Mathlib/RingTheory/Extension/Generators.lean
+++ b/Mathlib/RingTheory/Extension/Generators.lean
@@ -17,10 +17,10 @@ public import Mathlib.RingTheory.Extension.Basic
 
 ## Main definition
 
-- `Algebra.Generators`: A family of generators of an `R`-algebra `S` consists of
-  1. `ι`: The type of variables.
-  2. `val : ι → S`: The assignment of each variable to a value.
-  3. `σ`: A set-theoretic section of the induced `R`-algebra homomorphism `R[X] → S`, where we
+- `Algebra.Generators`: Given a type `ι` of variables, a family of generators of an `R`-algebra
+  `S` consists of
+  1. `val : ι → S`: The assignment of each variable to a value.
+  2. `σ`: A set-theoretic section of the induced `R`-algebra homomorphism `R[X] → S`, where we
      write `R[X]` for `R[ι]`.
 
 - `Algebra.Generators.Hom`: Given a commuting square
@@ -38,15 +38,6 @@ public import Mathlib.RingTheory.Extension.Basic
 - `Algebra.Generators.mvPolynomial`: The canonical `R`-generators of the polynomial algebra
   `MvPolynomial ι R`, indexed by `ι` via the variables `X`.
 
-## TODOs
-
-Currently, Lean does not see through the `ι` field of terms of `Generators R S` obtained
-from constructions, e.g. composition. This causes fragile and cumbersome proofs, because
-`simp` and `rw` often don't work properly. `Generators R S` (and `Presentation R S`, etc.) should
-be refactored in a way that makes these equalities reducibly def-eq, for example
-by unbundling the `ι` field or making the field globally reducible in constructions using
-unification hints.
-
 -/
 
 @[expose] public section
@@ -57,10 +48,9 @@ open TensorProduct MvPolynomial
 
 variable (R : Type u) (S : Type v) (ι : Type w) [CommRing R] [CommRing S] [Algebra R S]
 
-/-- A family of generators of an `R`-algebra `S` consists of
-1. `ι`: The type of variables.
-2. `val : ι → S`: The assignment of each variable to a value in `S`.
-3. `σ`: A section of `R[X] → S`. -/
+/-- Given a type `ι` of variables, a family of generators of an `R`-algebra `S` consists of
+1. `val : ι → S`: The assignment of each variable to a value in `S`.
+2. `σ`: A section of `R[X] → S`, where we write `R[X]` for `R[ι]`. -/
 structure Algebra.Generators where
   /-- The assignment of each variable to a value in `S`. -/
   val : ι → S


### PR DESCRIPTION
Update the docstring in light of #25085 refactoring the bundled type into an unbundled type. A fix to the docstring has been done in #39705.

The TODO still to be removed and the docstring is clarified a bit to be clear that the type iota is now unbundled.

---

Use of AI: Claude Fable was used to help me understand this API in light of me working on a similar API for `Group.Presentation` (#41936). It came to my attention that the docstring was outdated and I had Claude fetch the PR history. 

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
