### PR TITLE
[Merged by Bors] - fix: remove `DecidableEq Prop` instance

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -1029,7 +1029,7 @@ theorem prod_subsingleton [Subsingleton ι] (f : ι → M) (a : ι) : ∏ x : ι
   have : Unique ι := uniqueOfSubsingleton a
   rw [prod_unique f, Subsingleton.elim default a]
 
-@[to_additive] theorem prod_Prop (f : Prop → M) : ∏ p, f p = f True * f False := by simp
+@[to_additive] theorem prod_Prop (f : Prop → M) : ∏ p, f p = f True * f False := by classical simp
 
 @[to_additive]
 theorem prod_subtype_mul_prod_subtype (p : ι → Prop) (f : ι → M) [DecidablePred p] :

--- a/Mathlib/Data/Fintype/Sets.lean
+++ b/Mathlib/Data/Fintype/Sets.lean
@@ -257,7 +257,7 @@ instance Prop.fintype : Fintype Prop :=
   ⟨⟨{True, False}, by simp⟩, by simpa using em⟩
 
 @[simp]
-theorem Fintype.univ_Prop : (Finset.univ : Finset Prop) = {True, False} :=
+theorem Fintype.univ_Prop [DecidableEq Prop] : (Finset.univ : Finset Prop) = {True, False} :=
   Finset.eq_of_veq <| by simp; rfl
 
 instance Subtype.fintype (p : α → Prop) [DecidablePred p] [Fintype α] : Fintype { x // p x } :=

--- a/Mathlib/Data/Multiset/Filter.lean
+++ b/Mathlib/Data/Multiset/Filter.lean
@@ -412,8 +412,8 @@ See [here](https://github.com/leanprover-community/mathlib/pull/11306#discussion
 for more discussion.
 -/
 @[simp]
-theorem map_count_True_eq_filter_card (s : Multiset α) (p : α → Prop) [DecidablePred p] :
-    (s.map p).count True = card (s.filter p) := by
+theorem map_count_True_eq_filter_card (s : Multiset α) (p : α → Prop) [DecidablePred p]
+    [DecidableEq Prop] : (s.map p).count True = card (s.filter p) := by
   simp only [count_eq_card_filter_eq, eq_iff_iff, true_iff, filter_map, comp_apply, card_map]
 
 section Map

--- a/Mathlib/Data/Nat/Periodic.lean
+++ b/Mathlib/Data/Nat/Periodic.lean
@@ -44,6 +44,7 @@ open Multiset
 equal to the number naturals below `a` for which `p a` is true. -/
 theorem filter_multiset_Ico_card_eq_of_periodic (n a : ℕ) (p : ℕ → Prop) [DecidablePred p]
     (pp : Periodic p a) : card (filter p (Ico n (n + a))) = a.count p := by
+  classical
   rw [count_eq_card_filter_range, Finset.card, Finset.filter_val, Finset.range_val, ←
     multiset_Ico_map_mod n, ← map_count_True_eq_filter_card, ← map_count_True_eq_filter_card,
     map_map]

--- a/Mathlib/Order/CompleteLattice/Basic.lean
+++ b/Mathlib/Order/CompleteLattice/Basic.lean
@@ -811,7 +811,12 @@ instance Prop.instCompleteLattice : CompleteLattice Prop where
   sInf s := ∀ a ∈ s, a
   isGLB_sInf _ := ⟨fun a h p ↦ p a h, fun _ h p _ hb ↦ h hb p⟩
 
-noncomputable instance Prop.instCompleteLinearOrder : CompleteLinearOrder Prop where
+/-- The order on `Prop` is a `CompleteLinearOrder`.
+
+This is not an instance since `CompleteLinearOrder` includes decidability instances, which we want
+to avoid for `Prop`. -/
+@[expose, instance_reducible]
+noncomputable def Prop.completeLinearOrder : CompleteLinearOrder Prop where
   __ := Prop.instCompleteLattice
   __ := Prop.linearOrder
   __ := BooleanAlgebra.toBiheytingAlgebra

--- a/Mathlib/Order/PropInstances.lean
+++ b/Mathlib/Order/PropInstances.lean
@@ -47,7 +47,12 @@ theorem Prop.top_eq_true : (⊤ : Prop) = True :=
 instance Prop.le_total : @Std.Total Prop (· ≤ ·) :=
   ⟨fun p q => by by_cases h : q <;> simp [h]⟩
 
-noncomputable instance Prop.linearOrder : LinearOrder Prop := by
+/-- The order on `Prop` is a `LinearOrder`.
+
+This is not an instance since `LinearOrder` includes decidability instances, which we want to avoid
+for `Prop`. -/
+@[expose, instance_reducible]
+noncomputable def Prop.linearOrder : LinearOrder Prop := by
   classical
   exact Lattice.toLinearOrder Prop
 

--- a/Mathlib/RingTheory/Norm/Transitivity.lean
+++ b/Mathlib/RingTheory/Norm/Transitivity.lean
@@ -49,6 +49,7 @@ def auxMat : Matrix m m S :=
 /-- `aux M k` is lower triangular. -/
 lemma auxMat_blockTriangular : (auxMat M k).BlockTriangular (· ≠ k) :=
   fun i j lt ↦ by
+    let := Prop.linearOrder
     simp_rw [lt_iff_not_ge, le_Prop_eq, Classical.not_imp, not_not] at lt
     rw [auxMat, of_apply, if_pos lt.2, if_neg lt.1]
 
@@ -67,6 +68,7 @@ variable [Fintype m]
 /-- `M * aux M k` is upper triangular. -/
 lemma mul_auxMat_blockTriangular : (M * auxMat M k).BlockTriangular (· = k) :=
   fun i j lt ↦ by
+    let := Prop.linearOrder
     simp_rw [lt_iff_not_ge, le_Prop_eq, Classical.not_imp] at lt
     simp_rw [Matrix.mul_apply, auxMat, of_apply, if_neg lt.2, mul_ite, mul_neg, mul_zero]
     rw [Finset.sum_ite, Finset.filter_eq', if_pos (Finset.mem_univ _), Finset.sum_singleton,
@@ -88,6 +90,7 @@ scoped notation "mulAuxMatBlock" => (M * auxMat M k).toSquareBlock (· = k) Fals
 
 lemma det_mul_corner_pow :
     M.det * M k k ^ (Fintype.card m - 1) = M k k * (mulAuxMatBlock).det := by
+  let := Prop.linearOrder
   trans (M * auxMat M k).det
   · simp [det_mul, (auxMat_blockTriangular M k).det_fintype,
       auxMat_toSquareBlock_ne, auxMat_toSquareBlock_eq]
@@ -128,6 +131,7 @@ lemma eval_zero_comp_det :
 theorem comp_det_mul_pow :
     ((M.map f).comp m m n n R).det * (f (M k k)).det ^ (Fintype.card m - 1) =
       (f (M k k)).det * (((mulAuxMatBlock).map f).comp _ _ n n R).det := by
+  let := Prop.linearOrder
   trans (((M * auxMat M k).map f).comp m m n n R).det
   · simp_rw [← f.mapMatrix_apply, ← compRingEquiv_apply, map_mul, det_mul, f.mapMatrix_apply,
       compRingEquiv_apply, ((auxMat_blockTriangular M k).map f).comp.det_fintype, Fintype.prod_Prop,

--- a/Mathlib/Topology/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Topology/OmegaCompletePartialOrder.lean
@@ -54,6 +54,7 @@ def IsOpen (s : Set α) : Prop :=
 theorem isOpen_univ : IsOpen α univ := @CompleteLattice.ωScottContinuous.top α Prop _ _
 
 theorem IsOpen.inter (s t : Set α) : IsOpen α s → IsOpen α t → IsOpen α (s ∩ t) :=
+  let := Prop.completeLinearOrder
   CompleteLattice.ωScottContinuous.inf
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/Topology/Order/LowerUpperTopology.lean
+++ b/Mathlib/Topology/Order/LowerUpperTopology.lean
@@ -554,9 +554,9 @@ instance : IsUpper Prop where
     congr
     exact le_antisymm
       (fun h hs => by
-        simp only [compl_Iic, mem_ofPred_eq]
-        rw [← Ioi_True, ← Ioi_False] at hs
         rcases hs with (rfl | rfl)
         · use True
-        · use False)
+          simp
+        · use False
+          simp)
       (by rintro _ ⟨a, rfl⟩; by_cases a <;> aesop (add simp [Ioi, lt_iff_le_not_ge]))

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -311,6 +311,10 @@ instance [TopologicalSpace α] [IsUpper α] : IsScott α univ where
     rw [scott_eq_upper_of_completeLinearOrder]
     exact IsUpper.topology_eq α
 
+instance : IsScott Prop univ :=
+  let := Prop.completeLinearOrder
+  inferInstance
+
 end CompleteLinearOrder
 
 lemma isOpen_iff_scottContinuous_mem [Preorder α] {s : Set α} [TopologicalSpace α]

--- a/Mathlib/Topology/Separation/LinearUpperLowerSetTopology.lean
+++ b/Mathlib/Topology/Separation/LinearUpperLowerSetTopology.lean
@@ -35,4 +35,5 @@ instance (priority := low) {α : Type*}
   inferInstanceAs (CompletelyNormalSpace αᵒᵈ)
 
 instance : CompletelyNormalSpace Prop :=
+  let := Prop.linearOrder
   inferInstance

--- a/MathlibTest/Instances/DecidableEqProp.lean
+++ b/MathlibTest/Instances/DecidableEqProp.lean
@@ -1,0 +1,17 @@
+module -- shake: keep-all
+import Mathlib
+
+/-!
+# No decidable equality for `Prop`
+
+We import everything to verify that nothing exposes a `DecidableEq` instance for `Prop`.
+-/
+
+/--
+error: failed to synthesize
+  DecidableEq Prop
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+-/
+#guard_msgs in
+#synth DecidableEq Prop


### PR DESCRIPTION
Convert the `LinearOrder Prop` and `CompleteLinearOrder Prop` instances into `def`s, to avoid providing a global `DecidableEq Prop` instance.

We can convert them back when the decidability fields are removed from `LinearOrder`, but very few places need `LinearOrder Prop` so this seems like a good fix until that happens.

Note that the `DecidableEq Prop` instance causes diamonds with [`instDecidableEqOfIff`](https://leanprover-community.github.io/mathlib4_docs/Init/Core.html#instDecidableEqOfIff).

See [#mathlib4 > leaked &#96;DecidableEq Prop&#96;](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/leaked.20.60DecidableEq.20Prop.60/with/564769361)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
