### PR TITLE
[Merged by Bors] - chore(Order/Defs/LinearOrder): move fundamental lemmas

### DIFF
--- a/Mathlib/Algebra/Polynomial/Reverse.lean
+++ b/Mathlib/Algebra/Polynomial/Reverse.lean
@@ -181,7 +181,7 @@ theorem reflect_mul (f g : R[X]) {F G : ℕ} (Ff : f.natDegree ≤ F) (Gg : g.na
 set_option backward.isDefEq.respectTransparency false in
 lemma natDegree_reflect_le {N : ℕ} {p : R[X]} :
     (p.reflect N).natDegree ≤ max N p.natDegree := by
-  simp +contextual [-le_sup_iff, natDegree_le_iff_coeff_eq_zero,
+  simp +contextual [-le_max_iff, natDegree_le_iff_coeff_eq_zero,
     revAt, not_le_of_gt, coeff_eq_zero_of_natDegree_lt]
 
 section Eval₂

--- a/Mathlib/Analysis/Normed/Module/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Multilinear/Basic.lean
@@ -263,7 +263,7 @@ theorem norm_image_sub_le_of_bound (f : MultilinearMap 𝕜 E G)
         rcases eq_or_ne j i with rfl | h
         · simp only [ite_true, Function.update_self]
           exact norm_le_pi_norm (m₁ - m₂) _
-        · simp [h, -le_sup_iff, -sup_le_iff, sup_le_sup, norm_le_pi_norm]
+        · simp [h, -le_max_iff, -sup_le_iff, sup_le_sup, norm_le_pi_norm]
       _ = ‖m₁ - m₂‖ * max ‖m₁‖ ‖m₂‖ ^ (Fintype.card ι - 1) := by
         rw [prod_update_of_mem (Finset.mem_univ _)]
         simp [card_univ_sdiff]

--- a/Mathlib/Data/List/Infix.lean
+++ b/Mathlib/Data/List/Infix.lean
@@ -56,7 +56,7 @@ lemma isPrefix_append_of_length (h : l₁.length ≤ l₂.length) : l₁ <+: l�
    fun h ↦ h.trans <| l₂.prefix_append l₃⟩
 
 @[simp] lemma take_isPrefix_take {m n : ℕ} : l.take m <+: l.take n ↔ m ≤ n ∨ l.length ≤ n := by
-  simp [prefix_take_iff, take_prefix]; omega
+  simp [prefix_take_iff, take_prefix]
 
 @[gcongr]
 protected theorem IsPrefix.flatten {l₁ l₂ : List (List α)} (h : l₁ <+: l₂) :

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -143,28 +143,30 @@ theorem max_ind {motive : α → Prop} (ha : b ≤ a → motive a) (hb : a ≤ b
   rw [max_def]; split_ifs with h
   exacts [hb h, ha (le_of_not_ge h)]
 
-@[to_dual existing max_def]
-theorem min_def' (a b : α) : min a b = if b ≤ a then b else a := by
-  obtain h | h | h := lt_trichotomy a b <;> simp [le_of_lt, not_le_of_gt, h, min_def]
+@[to_dual le_min_iff]
+theorem max_le_iff : max a b ≤ c ↔ a ≤ c ∧ b ≤ c :=
+  max_ind (iff_self_and.mpr <| le_trans ·) (iff_and_self.mpr <| le_trans ·)
 
-@[to_dual existing min_def]
-theorem max_def' (a b : α) : max a b = if b ≤ a then a else b := by
-  obtain h | h | h := lt_trichotomy a b <;> simp [le_of_lt, not_le_of_gt, h, max_def]
+@[to_dual (attr := simp) le_max_iff]
+theorem min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c :=
+  min_ind (iff_self_or.mpr <| le_trans ·) (iff_or_self.mpr <| le_trans ·)
+
+@[to_dual (attr := simp) lt_min_iff]
+theorem max_lt_iff : max a b < c ↔ a < c ∧ b < c :=
+  max_ind (iff_self_and.mpr <| lt_of_le_of_lt ·) (iff_and_self.mpr <| lt_of_le_of_lt ·)
+
+@[to_dual (attr := simp) lt_max_iff]
+theorem min_lt_iff : min a b < c ↔ a < c ∨ b < c :=
+  min_ind (iff_self_or.mpr <| lt_of_le_of_lt ·) (iff_or_self.mpr <| lt_of_le_of_lt ·)
 
 @[to_dual le_max_left]
-lemma min_le_left (a b : α) : min a b ≤ a := by
-  rw [min_def]
-  split_ifs with h <;> simp [h, le_of_not_ge]
+lemma min_le_left (a b : α) : min a b ≤ a := min_le_iff.mpr (.inl le_rfl)
 
 @[to_dual le_max_right]
-lemma min_le_right (a b : α) : min a b ≤ b := by
-  rw [min_def]
-  split_ifs with h <;> simp [h]
+lemma min_le_right (a b : α) : min a b ≤ b := min_le_iff.mpr (.inr le_rfl)
 
 @[to_dual max_le]
-lemma le_min (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := by
-  rw [min_def]
-  split_ifs <;> assumption
+lemma le_min (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := le_min_iff.mpr ⟨h₁, h₂⟩
 
 @[to_dual]
 lemma eq_min (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d ≤ b → d ≤ c) : c = min a b :=
@@ -174,13 +176,15 @@ lemma eq_min (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d �
 lemma min_comm (a b : α) : min a b = min b a :=
   eq_min (min_le_right a b) (min_le_left a b) fun h₁ h₂ => le_min h₂ h₁
 
+@[to_dual existing max_def]
+theorem min_def' (a b : α) : min a b = if b ≤ a then b else a := by rw [min_comm, min_def]
+
+@[to_dual existing min_def]
+theorem max_def' (a b : α) : max a b = if b ≤ a then a else b := by rw [max_comm, max_def]
+
 @[to_dual]
-lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) :=
-  eq_min
-    (le_trans (min_le_left ..) (min_le_left ..))
-    (le_min (le_trans (min_le_left ..) (min_le_right ..)) (min_le_right ..))
-    (fun h₁ h₂ ↦
-      le_min (le_min h₁ (le_trans h₂ (min_le_left ..))) (le_trans h₂ (min_le_right ..)))
+lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
+  apply le_antisymm <;> simp [min_le_iff, le_min_iff]
 
 @[to_dual]
 lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
@@ -198,8 +202,7 @@ lemma min_eq_right (h : b ≤ a) : min a b = b := min_comm b a ▸ min_eq_left h
 @[to_dual] lemma min_eq_right_of_lt (h : b < a) : min a b = b := min_eq_right (le_of_lt h)
 
 @[to_dual max_lt]
-lemma lt_min (h₁ : a < b) (h₂ : a < c) : a < min b c := by
-  cases le_total b c <;> simp [min_eq_left, min_eq_right, *]
+lemma lt_min (h₁ : a < b) (h₂ : a < c) : a < min b c := lt_min_iff.mpr ⟨h₁, h₂⟩
 
 section Ord
 

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -559,15 +559,15 @@ theorem sup_ind (a b : α) {p : α → Prop} (ha : p a) (hb : p b) : p (a ⊔ b)
   (Std.Total.total a b).elim (fun h : a ≤ b => by rwa [sup_eq_right.2 h]) fun h => by
   rwa [sup_eq_left.2 h]
 
-@[to_dual (attr := simp) inf_le_iff]
+@[to_dual inf_le_iff]
 theorem le_sup_iff : a ≤ b ⊔ c ↔ a ≤ b ∨ a ≤ c := by
   grind
 
-@[to_dual (attr := simp) inf_lt_iff]
+@[to_dual inf_lt_iff]
 theorem lt_sup_iff : a < b ⊔ c ↔ a < b ∨ a < c := by
   grind
 
-@[to_dual (attr := simp) lt_inf_iff]
+@[to_dual lt_inf_iff]
 theorem sup_lt_iff : b ⊔ c < a ↔ b < a ∧ c < a :=
   ⟨fun h => ⟨le_sup_left.trans_lt h, le_sup_right.trans_lt h⟩,
    fun h => sup_ind (p := (· < a)) b c h.1 h.2⟩

--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -29,27 +29,11 @@ section
 
 variable [LinearOrder α] [LinearOrder β] {f : α → β} {s : Set α} {a b c d : α}
 
--- translate from lattices to linear orders (sup → max, inf → min)
-@[to_dual max_le_iff]
-theorem le_min_iff : c ≤ min a b ↔ c ≤ a ∧ c ≤ b :=
-  le_inf_iff
-
-@[to_dual min_le_iff]
-theorem le_max_iff : a ≤ max b c ↔ a ≤ b ∨ a ≤ c :=
-  le_sup_iff
-
 @[to_dual]
 instance : Std.LawfulOrderSup α where
   max_le_iff _ _ _ := max_le_iff
 
-@[to_dual max_lt_iff]
-theorem lt_min_iff : a < min b c ↔ a < b ∧ a < c :=
-  lt_inf_iff
-
-@[to_dual min_lt_iff]
-theorem lt_max_iff : a < max b c ↔ a < b ∨ a < c :=
-  lt_sup_iff
-
+-- translate from lattices to linear orders (sup → max, inf → min)
 @[to_dual]
 theorem max_le_max : a ≤ c → b ≤ d → max a b ≤ max c d :=
   sup_le_sup

--- a/Mathlib/Tactic/Order/ToInt.lean
+++ b/Mathlib/Tactic/Order/ToInt.lean
@@ -89,11 +89,11 @@ theorem toInt_nlt_toInt : ¬toInt val i < toInt val j ↔ ¬val i < val j := by
 
 theorem toInt_sup_toInt_eq_toInt :
     toInt val i ⊔ toInt val j = toInt val k ↔ val i ⊔ val j = val k := by
-  simp [le_antisymm_iff, sup_le_iff, le_sup_iff, toInt_le_toInt]
+  simp [le_antisymm_iff, toInt_le_toInt]
 
 theorem toInt_inf_toInt_eq_toInt :
     toInt val i ⊓ toInt val j = toInt val k ↔ val i ⊓ val j = val k := by
-  simp [le_antisymm_iff, inf_le_iff, le_inf_iff, toInt_le_toInt]
+  simp [le_antisymm_iff, toInt_le_toInt]
 
 open Lean Meta Qq
 


### PR DESCRIPTION
Also simplifies the proofs of several lemmas.

This prepares for #35881.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
