### PR TITLE
[Merged by Bors] - chore: rename `Prime.not_unit` to `Prime.not_isUnit`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -73,7 +73,7 @@ theorem Associated.prod {M : Type*} [CommMonoid M] {ι : Type*} (s : Finset ι) 
 theorem exists_associated_mem_of_dvd_prod [CommMonoidWithZero M₀] [IsCancelMulZero M₀]
     {p : M₀} (hp : Prime p)
     {s : Multiset M₀} : (∀ r ∈ s, Prime r) → p ∣ s.prod → ∃ q ∈ s, p ~ᵤ q :=
-  Multiset.induction_on s (by simp [mt isUnit_iff_dvd_one.2 hp.not_unit]) fun a s ih hs hps => by
+  Multiset.induction_on s (by simp [mt isUnit_iff_dvd_one.2 hp.not_isUnit]) fun a s ih hs hps => by
     rw [Multiset.prod_cons] at hps
     rcases hp.dvd_or_dvd hps with h | h
     · have hap := hs a (Multiset.mem_cons.2 (Or.inl rfl))

--- a/Mathlib/Algebra/GroupWithZero/Associated.lean
+++ b/Mathlib/Algebra/GroupWithZero/Associated.lean
@@ -234,7 +234,7 @@ protected theorem Associated.prime [CommMonoidWithZero M] {p q : M} (h : p ~ᵤ 
     Prime q :=
   ⟨h.ne_zero_iff.1 hp.ne_zero,
     let ⟨u, hu⟩ := h
-    ⟨fun ⟨v, hv⟩ => hp.not_unit ⟨v * u⁻¹, by simp [hv, hu.symm]⟩, by
+    ⟨fun ⟨v, hv⟩ => hp.not_isUnit ⟨v * u⁻¹, by simp [hv, hu.symm]⟩, by
       rw [← hu]
       simp only [Units.isUnit, IsUnit.mul_right_dvd]
       intro a b

--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -45,7 +45,7 @@ theorem not_isPrimePow_zero [NoZeroDivisors R] : ¬IsPrimePow (0 : R) := by
 
 theorem IsPrimePow.not_unit {n : R} (h : IsPrimePow n) : ¬IsUnit n :=
   let ⟨_p, _k, hp, hk, hn⟩ := h
-  hn ▸ (isUnit_pow_iff hk.ne').not.mpr hp.not_unit
+  hn ▸ (isUnit_pow_iff hk.ne').not.mpr hp.not_isUnit
 
 theorem IsUnit.not_isPrimePow {n : R} (h : IsUnit n) : ¬IsPrimePow n := fun h' => h'.not_unit h
 

--- a/Mathlib/Algebra/Prime/Defs.lean
+++ b/Mathlib/Algebra/Prime/Defs.lean
@@ -51,11 +51,14 @@ include hp
 theorem ne_zero : p ≠ 0 :=
   hp.1
 
-theorem not_unit : ¬IsUnit p :=
+theorem not_isUnit : ¬IsUnit p :=
   hp.2.1
 
+@[deprecated (since := "2026-08-02")]
+alias not_unit := not_isUnit
+
 theorem not_dvd_one : ¬p ∣ 1 :=
-  mt (isUnit_of_dvd_one ·) hp.not_unit
+  mt (isUnit_of_dvd_one ·) hp.not_isUnit
 
 theorem ne_one : p ≠ 1 := fun h => hp.2.1 (h.symm ▸ isUnit_one)
 
@@ -76,7 +79,7 @@ theorem dvd_of_dvd_pow {a : M} {n : ℕ} (h : p ∣ a ^ n) : p ∣ a := by
   | zero =>
     rw [pow_zero] at h
     have := isUnit_of_dvd_one h
-    have := not_unit hp
+    have := not_isUnit hp
     contradiction
   | succ n ih =>
     rw [pow_succ'] at h
@@ -93,7 +96,7 @@ end Prime
 theorem not_prime_zero : ¬Prime (0 : M) := fun h => h.ne_zero rfl
 
 @[simp]
-theorem not_prime_one : ¬Prime (1 : M) := fun h => h.not_unit isUnit_one
+theorem not_prime_one : ¬Prime (1 : M) := fun h => h.not_isUnit isUnit_one
 
 end Prime
 
@@ -147,7 +150,7 @@ section CancelCommMonoidWithZero
 variable [CommMonoidWithZero M] [IsCancelMulZero M] {p : M}
 
 protected theorem Prime.irreducible (hp : Prime p) : Irreducible p :=
-  ⟨hp.not_unit, fun a b ↦ by
+  ⟨hp.not_isUnit, fun a b ↦ by
     rintro rfl
     exact (hp.dvd_or_dvd dvd_rfl).symm.imp
       (isUnit_of_dvd_one <| (mul_dvd_mul_iff_right <| right_ne_zero_of_mul hp.ne_zero).mp <|

--- a/Mathlib/Algebra/Squarefree/Basic.lean
+++ b/Mathlib/Algebra/Squarefree/Basic.lean
@@ -185,7 +185,7 @@ theorem pow_dvd_of_squarefree_of_pow_succ_dvd_mul_right {k : ℕ}
     p ^ k ∣ y := by
   by_cases hxp : p ∣ x
   · obtain ⟨x', rfl⟩ := hxp
-    have hx' : ¬ p ∣ x' := fun contra ↦ hp.not_unit <| hx p (mul_dvd_mul_left p contra)
+    have hx' : ¬ p ∣ x' := fun contra ↦ hp.not_isUnit <| hx p (mul_dvd_mul_left p contra)
     replace h : p ^ k ∣ x' * y := by
       rw [pow_succ', mul_assoc] at h
       exact (mul_dvd_mul_iff_left hp.ne_zero).mp h

--- a/Mathlib/Data/Nat/Multiplicity.lean
+++ b/Mathlib/Data/Nat/Multiplicity.lean
@@ -79,7 +79,7 @@ theorem emultiplicity_eq_card_pow_dvd {m n b : ℕ} (hm : m ≠ 1) (hn : 0 < n) 
 namespace Prime
 
 theorem emultiplicity_one {p : ℕ} (hp : p.Prime) : emultiplicity p 1 = 0 :=
-  emultiplicity_of_one_right hp.prime.not_unit
+  emultiplicity_of_one_right hp.prime.not_isUnit
 
 theorem emultiplicity_mul {p m n : ℕ} (hp : p.Prime) :
     emultiplicity p (m * n) = emultiplicity p m + emultiplicity p n :=
@@ -93,7 +93,7 @@ theorem emultiplicity_self {p : ℕ} (hp : p.Prime) : emultiplicity p p = 1 :=
   (Nat.finiteMultiplicity_iff.2 ⟨hp.ne_one, hp.pos⟩).emultiplicity_self
 
 theorem emultiplicity_pow_self {p n : ℕ} (hp : p.Prime) : emultiplicity p (p ^ n) = n :=
-  _root_.emultiplicity_pow_self hp.ne_zero hp.prime.not_unit n
+  _root_.emultiplicity_pow_self hp.ne_zero hp.prime.not_isUnit n
 
 /-- **Legendre's Theorem**
 

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -212,7 +212,7 @@ variable [NumberField K] [IsCyclotomicExtension {3} ℚ K]
 /-- For any `S' : Solution'`, the multiplicity of `λ` in `S'.c` is finite. -/
 lemma Solution'.multiplicity_lambda_c_finite :
     FiniteMultiplicity (hζ.toInteger - 1) S'.c :=
-  .of_not_isUnit hζ.zeta_sub_one_prime'.not_unit S'.hc
+  .of_not_isUnit hζ.zeta_sub_one_prime'.not_isUnit S'.hc
 
 /-- Given `S' : Solution'`, `S'.multiplicity` is the multiplicity of `λ` in `S'.c`, as a natural
 number. -/

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -75,7 +75,7 @@ theorem exists_chain_of_prime_pow {p : Associates M} {n : ℕ} (hn : n ≠ 0) (h
     exact Nat.lt_succ_of_le (Nat.one_le_iff_ne_zero.mpr hn)
   · exact Associates.dvdNotUnit_iff_lt.mp
         ⟨pow_ne_zero n hp.ne_zero, p ^ (m - n : ℕ),
-          not_isUnit_of_not_isUnit_dvd hp.not_unit (dvd_pow dvd_rfl (Nat.sub_pos_of_lt h).ne'),
+          not_isUnit_of_not_isUnit_dvd hp.not_isUnit (dvd_pow dvd_rfl (Nat.sub_pos_of_lt h).ne'),
           (pow_mul_pow_sub p h.le).symm⟩
   · obtain ⟨i, i_le, hi⟩ := (dvd_prime_pow hp n).1 h
     rw [associated_iff_eq] at hi
@@ -118,7 +118,7 @@ theorem eq_second_of_chain_of_prime_dvd {p q r : Associates M} {n : ℕ} (hn : n
   · rw [Fin.le_iff_val_le_val, Fin.val_one, Nat.succ_le_iff, ← Fin.val_zero (n.succ + 1), ←
       Fin.lt_def, Fin.pos_iff_ne_zero]
     rintro rfl
-    exact hp.not_unit (first_of_chain_isUnit h₁ @h₂)
+    exact hp.not_isUnit (first_of_chain_isUnit h₁ @h₂)
   obtain rfl | ⟨j, rfl⟩ := i.eq_zero_or_eq_succ
   · cases hi
   refine
@@ -289,7 +289,7 @@ theorem map_prime_of_factor_orderIso {m p : Associates M} {n : Associates N} (hn
   · rw [Ne, ← Associates.isUnit_iff_eq_bot, Associates.isUnit_iff_eq_one,
       coe_factor_orderIso_map_eq_one_iff _ d]
     rintro rfl
-    exact (prime_of_normalized_factor 1 hp).not_unit isUnit_one
+    exact (prime_of_normalized_factor 1 hp).not_isUnit isUnit_one
   · have : b ≤ n := le_trans (le_of_lt hb) (d ⟨p, dvd_of_mem_normalizedFactors hp⟩).prop
     obtain ⟨x, hx⟩ := d.surjective ⟨b, this⟩
     rw [← Subtype.coe_mk (p := (· ≤ n)) b this, ← hx] at hb

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -102,7 +102,7 @@ theorem isPrime_of_prime {P : Ideal A} (h : Prime P) : IsPrime P := by
   refine ⟨?_, fun hxy => ?_⟩
   · rintro rfl
     rw [← one_eq_top] at h
-    exact h.not_unit isUnit_one
+    exact h.not_isUnit isUnit_one
   · simp only [← dvd_span_singleton, ← span_singleton_mul_span_singleton] at hxy ⊢
     exact h.dvd_or_dvd hxy
 

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -706,13 +706,13 @@ theorem Finset.emultiplicity_prod {β : Type*} {p : α} (hp : Prime p) (s : Fins
   induction s using Finset.induction with
   | empty =>
     simp only [Finset.sum_empty, Finset.prod_empty]
-    exact emultiplicity_of_one_right hp.not_unit
+    exact emultiplicity_of_one_right hp.not_isUnit
   | insert a s has ih => simpa [has, ← ih] using emultiplicity_mul hp
 
 theorem emultiplicity_pow {p a : α} (hp : Prime p) {k : ℕ} :
     emultiplicity p (a ^ k) = k * emultiplicity p a := by
   induction k with
-  | zero => simp [emultiplicity_of_one_right hp.not_unit]
+  | zero => simp [emultiplicity_of_one_right hp.not_isUnit]
   | succ k hk => simp [pow_succ, emultiplicity_mul hp, hk, add_mul]
 
 protected theorem FiniteMultiplicity.multiplicity_pow {p a : α} (hp : Prime p)
@@ -733,11 +733,11 @@ theorem multiplicity_pow_self {p : α} (h0 : p ≠ 0) (hu : ¬IsUnit p) (n : ℕ
 
 theorem emultiplicity_pow_self_of_prime {p : α} (hp : Prime p) (n : ℕ) :
     emultiplicity p (p ^ n) = n :=
-  emultiplicity_pow_self hp.ne_zero hp.not_unit n
+  emultiplicity_pow_self hp.ne_zero hp.not_isUnit n
 
 theorem multiplicity_pow_self_of_prime {p : α} (hp : Prime p) (n : ℕ) :
     multiplicity p (p ^ n) = n :=
-  multiplicity_pow_self hp.ne_zero hp.not_unit n
+  multiplicity_pow_self hp.ne_zero hp.not_isUnit n
 
 end CancelCommMonoidWithZero
 

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Factorization.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Factorization.lean
@@ -159,7 +159,7 @@ theorem normalizedFactors_cyclotomic_card : (normalizedFactors (cyclotomic n K))
       (pos_of_ne_zero <| f_ne_zero hK) _ _).mp (hn.pow_left f))
         ((CharP.cast_eq_zero_iff K p _).mp H)
   have hP : P ∈ normalizedFactors (cyclotomic n K) := count_pos.mp (by lia)
-  refine (prime_of_normalized_factor _ hP).not_unit (squarefree_cyclotomic n K P ?_)
+  refine (prime_of_normalized_factor _ hP).not_isUnit (squarefree_cyclotomic n K P ?_)
   have : {P, P} ≤ normalizedFactors (cyclotomic n K) := by
     refine le_iff_count.mpr (fun Q ↦ ?_)
     by_cases hQ : Q = P

--- a/Mathlib/RingTheory/Polynomial/RationalRoot.lean
+++ b/Mathlib/RingTheory/Polynomial/RationalRoot.lean
@@ -74,7 +74,7 @@ theorem num_dvd_of_is_root {p : A[X]} {r : K} (hr : aeval r p = 0) : num A r ∣
     · simp_all [nonZeroDivisors.coe_ne_zero]
     · refine dvd_of_dvd_mul_left_of_no_prime_factors hr ?_ this
       intro q dvd_num dvd_denom_pow hq
-      apply hq.not_unit
+      apply hq.not_isUnit
       exact num_den_reduced A r dvd_num (hq.dvd_of_dvd_pow dvd_denom_pow)
   convert! dvd_term_of_isRoot_of_dvd_terms 0 (num_isRoot_scaleRoots_of_aeval_eq_zero hr) _
   · rw [pow_zero, mul_one]
@@ -93,7 +93,7 @@ theorem den_dvd_of_is_root {p : A[X]} {r : K} (hr : aeval r p = 0) :
       dvd_of_dvd_mul_left_of_no_prime_factors (mem_nonZeroDivisors_iff_ne_zero.mp (den A r).2) ?_
         this
     intro q dvd_den dvd_num_pow hq
-    apply hq.not_unit
+    apply hq.not_isUnit
     exact num_den_reduced A r (hq.dvd_of_dvd_pow dvd_num_pow) dvd_den
   rw [← coeff_scaleRoots_natDegree]
   apply dvd_term_of_isRoot_of_dvd_terms _ (num_isRoot_scaleRoots_of_aeval_eq_zero hr)

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -420,8 +420,9 @@ variable {R : Type*} [CommMonoidWithZero R] [UniqueFactorizationMonoid R]
 
 theorem isRelPrime_iff_no_prime_factors {a b : R} (ha : a ≠ 0) :
     IsRelPrime a b ↔ ∀ ⦃d⦄, d ∣ a → d ∣ b → ¬Prime d :=
-  ⟨fun h _ ha hb ↦ (·.not_isUnit <| h ha hb), fun h ↦ WfDvdMonoid.isRelPrime_of_no_irreducible_factors
-    (ha ·.1) fun _ irr ha hb ↦ h ha hb (UniqueFactorizationMonoid.irreducible_iff_prime.mp irr)⟩
+  ⟨fun h _ ha hb ↦ (·.not_isUnit <| h ha hb),
+    fun h ↦ WfDvdMonoid.isRelPrime_of_no_irreducible_factors
+      (ha ·.1) fun _ irr ha hb ↦ h ha hb (UniqueFactorizationMonoid.irreducible_iff_prime.mp irr)⟩
 
 /-- Euclid's lemma: if `a ∣ b * c` and `a` and `c` have no common prime factors, `a ∣ b`.
 Compare `IsCoprime.dvd_of_dvd_mul_left`. -/

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -80,7 +80,7 @@ theorem prime_factors_unique [CommMonoidWithZero α] [IsCancelMulZero α] :
     exact Multiset.rel_zero_left.2 <|
       Multiset.eq_zero_of_forall_notMem fun x hx =>
         have : IsUnit g.prod := by simpa [associated_one_iff_isUnit] using h.symm
-        (hg x hx).not_unit <|
+        (hg x hx).not_isUnit <|
           isUnit_iff_dvd_one.2 <| (Multiset.dvd_prod hx).trans (isUnit_iff_dvd_one.1 this)
   | cons p f ih =>
     intro g hf hg hfg
@@ -420,7 +420,7 @@ variable {R : Type*} [CommMonoidWithZero R] [UniqueFactorizationMonoid R]
 
 theorem isRelPrime_iff_no_prime_factors {a b : R} (ha : a ≠ 0) :
     IsRelPrime a b ↔ ∀ ⦃d⦄, d ∣ a → d ∣ b → ¬Prime d :=
-  ⟨fun h _ ha hb ↦ (·.not_unit <| h ha hb), fun h ↦ WfDvdMonoid.isRelPrime_of_no_irreducible_factors
+  ⟨fun h _ ha hb ↦ (·.not_isUnit <| h ha hb), fun h ↦ WfDvdMonoid.isRelPrime_of_no_irreducible_factors
     (ha ·.1) fun _ irr ha hb ↦ h ha hb (UniqueFactorizationMonoid.irreducible_iff_prime.mp irr)⟩
 
 /-- Euclid's lemma: if `a ∣ b * c` and `a` and `c` have no common prime factors, `a ∣ b`.

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
@@ -153,7 +153,7 @@ theorem exists_prime_factors (a : α) :
 
 lemma exists_prime_iff :
     (∃ (p : α), Prime p) ↔ ∃ (x : α), x ≠ 0 ∧ ¬ IsUnit x := by
-  refine ⟨fun ⟨p, hp⟩ ↦ ⟨p, hp.ne_zero, hp.not_unit⟩, fun ⟨x, hx₀, hxu⟩ ↦ ?_⟩
+  refine ⟨fun ⟨p, hp⟩ ↦ ⟨p, hp.ne_zero, hp.not_isUnit⟩, fun ⟨x, hx₀, hxu⟩ ↦ ?_⟩
   obtain ⟨f, hf, -⟩ := WfDvdMonoid.exists_irreducible_factor hxu hx₀
   exact ⟨f, UniqueFactorizationMonoid.irreducible_iff_prime.mp hf⟩
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
@@ -412,7 +412,7 @@ theorem coprime_iff_inf_one {a b : α} (ha0 : a ≠ 0) (hb0 : b ≠ 0) :
     Associates.mk a ⊓ Associates.mk b = 1 ↔ ∀ {d : α}, d ∣ a → d ∣ b → ¬Prime d := by
   constructor
   · intro hg p ha hb hp
-    refine (Associates.prime_mk.mpr hp).not_unit (isUnit_of_dvd_one ?_)
+    refine (Associates.prime_mk.mpr hp).not_isUnit (isUnit_of_dvd_one ?_)
     rw [← hg]
     exact le_inf (mk_le_mk_of_dvd ha) (mk_le_mk_of_dvd hb)
   · contrapose

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicity.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicity.lean
@@ -48,7 +48,7 @@ theorem FiniteMultiplicity.of_not_isUnit [CommMonoidWithZero α] [IsCancelMulZer
 
 theorem FiniteMultiplicity.of_prime_left [CommMonoidWithZero α] [IsCancelMulZero α] [WfDvdMonoid α]
     {a b : α} (ha : Prime a) (hb : b ≠ 0) : FiniteMultiplicity a b :=
-  .of_not_isUnit ha.not_unit hb
+  .of_not_isUnit ha.not_isUnit hb
 
 namespace UniqueFactorizationMonoid
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -252,7 +252,7 @@ theorem disjoint_normalizedFactors {a b : α} (hc : IsRelPrime a b) :
   intro x hxa hxb
   have x_dvd_a := dvd_of_mem_normalizedFactors hxa
   have x_dvd_b := dvd_of_mem_normalizedFactors hxb
-  exact (prime_of_normalized_factor x hxa).not_unit (hc x_dvd_a x_dvd_b)
+  exact (prime_of_normalized_factor x hxa).not_isUnit (hc x_dvd_a x_dvd_b)
 
 theorem exists_associated_prime_pow_of_unique_normalized_factor {p r : α}
     (h : ∀ {m}, m ∈ normalizedFactors r → m = p) (hr : r ≠ 0) : ∃ i : ℕ, Associated (p ^ i) r := by
@@ -283,7 +283,7 @@ theorem normalizedFactors_pos (x : α) (hx : x ≠ 0) : 0 < normalizedFactors x 
   · intro h hx
     obtain ⟨p, hp⟩ := Multiset.exists_mem_of_ne_zero h.ne'
     exact
-      (prime_of_normalized_factor _ hp).not_unit
+      (prime_of_normalized_factor _ hp).not_isUnit
         (isUnit_of_dvd_unit (dvd_of_mem_normalizedFactors hp) hx)
   · intro h
     obtain ⟨p, hp⟩ := exists_mem_normalizedFactors hx h

--- a/Mathlib/RingTheory/Unramified/LocalStructure.lean
+++ b/Mathlib/RingTheory/Unramified/LocalStructure.lean
@@ -196,7 +196,7 @@ private lemma exists_hasStandardEtaleSurjectionOn_of_exists_adjoin_singleton_eq_
       ring
     · rw [dvd_add_left (dvd_mul_of_dvd_right (dvd_pow (by simp [m, minpoly.dvd_iff]) (by simp)) _),
         ← isUnit_iff_dvd_one]
-      exact hm.not_unit
+      exact hm.not_isUnit
   have hm' : derivative m ≠ 0 :=
     (separable_iff_derivative_ne_zero hm.irreducible).mp (IsSeparable.isSeparable ..)
   suffices ¬m ∣ derivative (q.map (algebraMap R _)) by

--- a/Mathlib/RingTheory/Valuation/PrimeMultiplicity.lean
+++ b/Mathlib/RingTheory/Valuation/PrimeMultiplicity.lean
@@ -18,8 +18,9 @@ variable {R : Type*} [CommRing R] [IsDomain R] {p : R}
 
 /-- `multiplicity` of a prime in an integral domain as an additive valuation to `ℕ∞`. -/
 noncomputable def multiplicity_addValuation (hp : Prime p) : AddValuation R ℕ∞ :=
-  AddValuation.of (emultiplicity p) (emultiplicity_zero _) (emultiplicity_of_one_right hp.not_isUnit)
-    (fun _ _ => min_le_emultiplicity_add) fun _ _ => emultiplicity_mul hp
+  AddValuation.of (emultiplicity p) (emultiplicity_zero _)
+    (emultiplicity_of_one_right hp.not_isUnit)
+      (fun _ _ => min_le_emultiplicity_add) fun _ _ => emultiplicity_mul hp
 
 @[simp]
 theorem multiplicity_addValuation_apply {hp : Prime p} {r : R} :

--- a/Mathlib/RingTheory/Valuation/PrimeMultiplicity.lean
+++ b/Mathlib/RingTheory/Valuation/PrimeMultiplicity.lean
@@ -18,7 +18,7 @@ variable {R : Type*} [CommRing R] [IsDomain R] {p : R}
 
 /-- `multiplicity` of a prime in an integral domain as an additive valuation to `ℕ∞`. -/
 noncomputable def multiplicity_addValuation (hp : Prime p) : AddValuation R ℕ∞ :=
-  AddValuation.of (emultiplicity p) (emultiplicity_zero _) (emultiplicity_of_one_right hp.not_unit)
+  AddValuation.of (emultiplicity p) (emultiplicity_zero _) (emultiplicity_of_one_right hp.not_isUnit)
     (fun _ _ => min_le_emultiplicity_add) fun _ _ => emultiplicity_mul hp
 
 @[simp]


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[#mathlib4 > &#96;not_unit&#96; vs &#96;not_isUnit&#96; naming convention](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60not_unit.60.20vs.20.60not_isUnit.60.20naming.20convention/with/612828605)