### PR TITLE
[Merged by Bors] - chore: rename some lemmas containing `not_unit`

### DIFF
--- a/Mathlib/Algebra/Prime/Lemmas.lean
+++ b/Mathlib/Algebra/Prime/Lemmas.lean
@@ -161,9 +161,12 @@ theorem DvdNotUnit.isUnit_of_irreducible_right [CommMonoidWithZero M] {p q : M}
   obtain ⟨_, x, hx, hx'⟩ := h
   exact ((irreducible_iff.1 hq).right hx').resolve_right hx
 
-theorem not_irreducible_of_not_unit_dvdNotUnit [CommMonoidWithZero M] {p q : M} (hp : ¬IsUnit p)
+theorem not_irreducible_of_not_isUnit_dvdNotUnit [CommMonoidWithZero M] {p q : M} (hp : ¬IsUnit p)
     (h : DvdNotUnit p q) : ¬Irreducible q :=
   mt h.isUnit_of_irreducible_right hp
+
+@[deprecated (since := "2026-08-02")]
+alias not_irreducible_of_not_unit_dvdNotUnit := not_irreducible_of_not_isUnit_dvdNotUnit
 
 theorem DvdNotUnit.not_isUnit [CommMonoidWithZero M] {p q : M} (hp : DvdNotUnit p q) :
     ¬IsUnit q := by

--- a/Mathlib/Algebra/Prime/Lemmas.lean
+++ b/Mathlib/Algebra/Prime/Lemmas.lean
@@ -165,9 +165,13 @@ theorem not_irreducible_of_not_unit_dvdNotUnit [CommMonoidWithZero M] {p q : M} 
     (h : DvdNotUnit p q) : ¬Irreducible q :=
   mt h.isUnit_of_irreducible_right hp
 
-theorem DvdNotUnit.not_unit [CommMonoidWithZero M] {p q : M} (hp : DvdNotUnit p q) : ¬IsUnit q := by
+theorem DvdNotUnit.not_isUnit [CommMonoidWithZero M] {p q : M} (hp : DvdNotUnit p q) :
+    ¬IsUnit q := by
   obtain ⟨-, x, hx, rfl⟩ := hp
   exact fun hc => hx (isUnit_iff_dvd_one.mpr (dvd_of_mul_left_dvd (isUnit_iff_dvd_one.mp hc)))
+
+@[deprecated (since := "2026-08-02")]
+alias DvdNotUnit.not_unit := DvdNotUnit.not_isUnit
 
 end CommMonoidWithZero
 

--- a/Mathlib/Algebra/Prime/Lemmas.lean
+++ b/Mathlib/Algebra/Prime/Lemmas.lean
@@ -161,12 +161,12 @@ theorem DvdNotUnit.isUnit_of_irreducible_right [CommMonoidWithZero M] {p q : M}
   obtain ⟨_, x, hx, hx'⟩ := h
   exact ((irreducible_iff.1 hq).right hx').resolve_right hx
 
-theorem not_irreducible_of_not_isUnit_dvdNotUnit [CommMonoidWithZero M] {p q : M} (hp : ¬IsUnit p)
-    (h : DvdNotUnit p q) : ¬Irreducible q :=
+theorem not_irreducible_of_not_isUnit_of_dvdNotUnit [CommMonoidWithZero M] {p q : M}
+    (hp : ¬IsUnit p) (h : DvdNotUnit p q) : ¬Irreducible q :=
   mt h.isUnit_of_irreducible_right hp
 
 @[deprecated (since := "2026-08-02")]
-alias not_irreducible_of_not_unit_dvdNotUnit := not_irreducible_of_not_isUnit_dvdNotUnit
+alias not_irreducible_of_not_unit_dvdNotUnit := not_irreducible_of_not_isUnit_of_dvdNotUnit
 
 theorem DvdNotUnit.not_isUnit [CommMonoidWithZero M] {p q : M} (hp : DvdNotUnit p q) :
     ¬IsUnit q := by

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -85,7 +85,7 @@ theorem exists_chain_of_prime_pow {p : Associates M} {n : ℕ} (hn : n ≠ 0) (h
 
 theorem element_of_chain_not_isUnit_of_index_ne_zero {n : ℕ} {i : Fin (n + 1)} (i_pos : i ≠ 0)
     {c : Fin (n + 1) → Associates M} (h₁ : StrictMono c) : ¬IsUnit (c i) :=
-  DvdNotUnit.not_unit
+  DvdNotUnit.not_isUnit
     (Associates.dvdNotUnit_iff_lt.2
       (h₁ <| show (0 : Fin (n + 1)) < i from Fin.pos_iff_ne_zero.mpr i_pos))
 
@@ -123,7 +123,7 @@ theorem eq_second_of_chain_of_prime_dvd {p q r : Associates M} {n : ℕ} (hn : n
   · cases hi
   refine
     not_irreducible_of_not_unit_dvdNotUnit
-      (DvdNotUnit.not_unit
+      (DvdNotUnit.not_isUnit
         (Associates.dvdNotUnit_iff_lt.2 (h₁ (show (0 : Fin (n + 2)) < j.castSucc from ?_))))
       ?_ hp.irreducible
   · simpa using Fin.lt_def.mp hi

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -122,7 +122,7 @@ theorem eq_second_of_chain_of_prime_dvd {p q r : Associates M} {n : ℕ} (hn : n
   obtain rfl | ⟨j, rfl⟩ := i.eq_zero_or_eq_succ
   · cases hi
   refine
-    not_irreducible_of_not_unit_dvdNotUnit
+    not_irreducible_of_not_isUnit_dvdNotUnit
       (DvdNotUnit.not_isUnit
         (Associates.dvdNotUnit_iff_lt.2 (h₁ (show (0 : Fin (n + 2)) < j.castSucc from ?_))))
       ?_ hp.irreducible

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -122,7 +122,7 @@ theorem eq_second_of_chain_of_prime_dvd {p q r : Associates M} {n : ℕ} (hn : n
   obtain rfl | ⟨j, rfl⟩ := i.eq_zero_or_eq_succ
   · cases hi
   refine
-    not_irreducible_of_not_isUnit_dvdNotUnit
+    not_irreducible_of_not_isUnit_of_dvdNotUnit
       (DvdNotUnit.not_isUnit
         (Associates.dvdNotUnit_iff_lt.2 (h₁ (show (0 : Fin (n + 2)) < j.castSucc from ?_))))
       ?_ hp.irreducible


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[#mathlib4 > &#96;not_unit&#96; vs &#96;not_isUnit&#96; naming convention](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60not_unit.60.20vs.20.60not_isUnit.60.20naming.20convention/with/612828605)