### PR TITLE
[Merged by Bors] - chore: rename `IsPrimePow.not_unit` to `IsPrimePow.not_isUnit`

### DIFF
--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -43,11 +43,14 @@ theorem not_isPrimePow_zero [NoZeroDivisors R] : ¬IsPrimePow (0 : R) := by
   rw [eq_zero_of_pow_eq_zero hx]
   simp
 
-theorem IsPrimePow.not_unit {n : R} (h : IsPrimePow n) : ¬IsUnit n :=
+theorem IsPrimePow.not_isUnit {n : R} (h : IsPrimePow n) : ¬IsUnit n :=
   let ⟨_p, _k, hp, hk, hn⟩ := h
   hn ▸ (isUnit_pow_iff hk.ne').not.mpr hp.not_unit
 
-theorem IsUnit.not_isPrimePow {n : R} (h : IsUnit n) : ¬IsPrimePow n := fun h' => h'.not_unit h
+@[deprecated (since := "2026-08-02")]
+alias IsPrimePow.not_unit := IsPrimePow.not_isUnit
+
+theorem IsUnit.not_isPrimePow {n : R} (h : IsUnit n) : ¬IsPrimePow n := fun h' => h'.not_isUnit h
 
 theorem not_isPrimePow_one : ¬IsPrimePow (1 : R) :=
   isUnit_one.not_isPrimePow


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[#mathlib4 > &#96;not_unit&#96; vs &#96;not_isUnit&#96; naming convention](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60not_unit.60.20vs.20.60not_isUnit.60.20naming.20convention/with/612828605)