### PR TITLE
[Merged by Bors] - fix(Algebra/GroupWithZero/Associated): de-`abbrev` `Associates`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Associated.lean
+++ b/Mathlib/Algebra/GroupWithZero/Associated.lean
@@ -390,7 +390,8 @@ end UniqueUnits₀
 /-- The quotient of a monoid by the `Associated` relation. Two elements `x` and `y`
   are associated iff there is a unit `u` such that `x * u = y`. There is a natural
   monoid structure on `Associates M`. -/
-abbrev Associates (M : Type*) [Monoid M] : Type _ :=
+@[implicit_reducible]
+def Associates (M : Type*) [Monoid M] : Type _ :=
   Quotient (Associated.setoid M)
 
 namespace Associates
@@ -398,25 +399,32 @@ namespace Associates
 open Associated
 
 /-- The canonical quotient map from a monoid `M` into the `Associates` of `M` -/
-protected abbrev mk {M : Type*} [Monoid M] (a : M) : Associates M :=
+@[implicit_reducible]
+protected def mk {M : Type*} [Monoid M] (a : M) : Associates M :=
   ⟦a⟧
 
 instance [Monoid M] : Inhabited (Associates M) :=
   ⟨⟦1⟧⟩
 
+@[simp]
 theorem mk_eq_mk_iff_associated [Monoid M] {a b : M} : Associates.mk a = Associates.mk b ↔ a ~ᵤ b :=
   Iff.intro Quotient.exact Quot.sound
 
+@[simp]
 theorem quotient_mk_eq_mk [Monoid M] (a : M) : ⟦a⟧ = Associates.mk a :=
   rfl
 
+@[simp]
 theorem quot_mk_eq_mk [Monoid M] (a : M) : Quot.mk Setoid.r a = Associates.mk a :=
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem quot_out [Monoid M] (a : Associates M) : Associates.mk (Quot.out a) = a := by
-  rw [← quot_mk_eq_mk, Quot.out_eq]
+theorem quotient_out [Monoid M] (a : Associates M) : Associates.mk (Quotient.out a) = a :=
+  Quotient.out_eq a
+
+@[simp]
+theorem quot_out [Monoid M] (a : Associates M) : Associates.mk (Quot.out a) = a :=
+  Quot.out_eq a
 
 theorem mk_quot_out [Monoid M] (a : M) : Quot.out (Associates.mk a) ~ᵤ a := by
   rw [← Associates.mk_eq_mk_iff_associated, Associates.quot_out]

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -412,10 +412,15 @@ theorem mk_mem_nonZeroDivisors_associates : Associates.mk a ∈ (Associates M₀
 of the non-zero divisors of `M₀` under the map `⟨⟦a⟧, _⟩ ↦ ⟦⟨a, _⟩⟧`. -/
 def associatesNonZeroDivisorsEquiv : (Associates M₀)⁰ ≃* Associates M₀⁰ where
   toEquiv := .subtypeQuotientEquivQuotientSubtype _ (s₂ := Associated.setoid _)
-    (· ∈ nonZeroDivisors _)
-    (by simp [mem_nonZeroDivisors_iff, Quotient.forall, Associates.mk_mul_mk])
+    (· ∈ nonZeroDivisors _ : Associates M₀ → Prop)
+    (by simp [mem_nonZeroDivisors_iff, Associates.forall_associated, Associates.mk_mul_mk])
     (by simp +instances [Associated.setoid])
-  map_mul' := by simp [Quotient.forall, Associates.mk_mul_mk]
+  map_mul' := by
+    simp_rw [Subtype.forall, Associates.forall_associated, Equiv.toFun_as_coe,
+      Submonoid.mk_mul_mk, Associates.mk_mul_mk, ← Associates.quotient_mk_eq_mk]
+    intros
+    repeat rw [Equiv.subtypeQuotientEquivQuotientSubtype_mk]
+    simp [Associates.mk_mul_mk]
 
 @[simp]
 lemma associatesNonZeroDivisorsEquiv_mk_mk (a : M₀) (ha) :

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -424,11 +424,13 @@ def associatesNonZeroDivisorsEquiv : (Associates M₀)⁰ ≃* Associates M₀�
 
 @[simp]
 lemma associatesNonZeroDivisorsEquiv_mk_mk (a : M₀) (ha) :
-    associatesNonZeroDivisorsEquiv ⟨⟦a⟧, ha⟩ = ⟦⟨a, mk_mem_nonZeroDivisors_associates.1 ha⟩⟧ := rfl
+    associatesNonZeroDivisorsEquiv ⟨.mk a, ha⟩ = .mk ⟨a, mk_mem_nonZeroDivisors_associates.1 ha⟩ :=
+  rfl
 
 @[simp]
 lemma associatesNonZeroDivisorsEquiv_symm_mk_mk (a : M₀) (ha) :
-    associatesNonZeroDivisorsEquiv.symm ⟦⟨a, ha⟩⟧ = ⟨⟦a⟧, mk_mem_nonZeroDivisors_associates.2 ha⟩ :=
+    associatesNonZeroDivisorsEquiv.symm (.mk ⟨a, ha⟩) =
+      ⟨.mk a, mk_mem_nonZeroDivisors_associates.2 ha⟩ :=
   rfl
 
 end CommMonoidWithZero

--- a/Mathlib/RingTheory/Ideal/IsPrincipal.lean
+++ b/Mathlib/RingTheory/Ideal/IsPrincipal.lean
@@ -73,7 +73,7 @@ noncomputable def associatesEquivIsPrincipal :
   invFun I := .mk I.2.generator
   left_inv := Quotient.ind fun _ ↦ by simpa [Quotient.eq] using!
     Ideal.span_singleton_eq_span_singleton.mp (@Ideal.span_singleton_generator _ _ _ ⟨_, rfl⟩)
-  right_inv I := by simp only [_root_.Quotient.lift_mk, span_singleton_generator, Subtype.coe_eta]
+  right_inv I := by simp [← Associates.quotient_mk_eq_mk]
 
 @[simp]
 theorem associatesEquivIsPrincipal_apply (x : R) :


### PR DESCRIPTION
`Associates` is an `abbrev` for `Quotient _`, but there are many `instance`s defined on it.
Some of them create diamonds with general `Quotient` instances: `Inhabited`, `Unique`, and most notably `Preorder`.

While `Associates` has a `Preorder` instance that uses the divisibility relation, any monoid with a `Preorder` will have its ordering lifted to the `Quotient`. So currently `Associates ℕ` has two different `LE` orders defined on it that disagree on `2 ≤ 3`.

This changes `Associates` to a `def` tagged with `@[implicit_reducible]`.

---
The `nonZeroDivisors` proof is now a bit awkward, since the `Equiv` works for `Quotient`s but `simp` refuses to evaluate the `Equiv` because `Associates` elements are multiplied but `Quotient` doesn't have that multiplication. Though `rw` works thanks to `@[implicit_reducible]`.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
