### PR TITLE
[Merged by Bors] - chore: remove unused `have`/`let`

### DIFF
--- a/Mathlib/AlgebraicGeometry/Modules/Sheaf.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Sheaf.lean
@@ -476,9 +476,6 @@ set_option backward.isDefEq.respectTransparency.types false in
 set_option backward.defeqAttrib.useBackward true in
 /-- Restriction along the composition is isomorphic to the composition of restrictions. -/
 def restrictFunctorComp : restrictFunctor (f ≫ g) ≅ restrictFunctor g ⋙ restrictFunctor f :=
-  have : (f.opensFunctor ⋙ g.opensFunctor).IsContinuous
-      (Opens.grothendieckTopology X) (Opens.grothendieckTopology Z) :=
-    Functor.isContinuous_comp _ _ _ (Opens.grothendieckTopology _) _
   SheafOfModules.pushforwardNatIso _ (NatIso.ofComponents fun _ ↦ eqToIso (by simp)) ≪≫
     SheafOfModules.pushforwardCongr (by ext : 3; simp [← Functor.map_comp, SheafedSpace.sheaf]) ≪≫
     (SheafOfModules.pushforwardComp _ _).symm

--- a/Mathlib/CategoryTheory/Limits/Types/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Products.lean
@@ -229,7 +229,6 @@ noncomputable def productLimitCone :
       π := Discrete.natTrans (fun ⟨j⟩ =>
         ↾fun f => (equivShrink (∀ j, F j)).symm f j) }
   isLimit :=
-    have : Small.{u} (∀ j, F j) := inferInstance
     { lift := fun s => ↾fun x => (equivShrink _) (fun j => s.π.app ⟨j⟩ x)
       uniq := fun s m w => ConcreteCategory.hom_ext _ _ fun x => Shrink.ext (funext fun j => by
         simpa using! ConcreteCategory.congr_hom (w ⟨j⟩) x) }

--- a/Mathlib/CategoryTheory/Sites/CoproductSheafCondition.lean
+++ b/Mathlib/CategoryTheory/Sites/CoproductSheafCondition.lean
@@ -45,9 +45,6 @@ def PreZeroHypercover.isLimitSigmaOfIsColimitEquiv (E : PreZeroHypercover.{w} S)
     [PreservesLimit (Discrete.functor fun i ↦ op (E.toPreOneHypercover.Y' i)) F] :
     IsLimit ((E.sigmaOfIsColimit hc).toPreOneHypercover.multifork F) ≃
       IsLimit (E.toPreOneHypercover.multifork F) := by
-  have : HasPullback (Cofan.IsColimit.desc hc E.f) (Cofan.IsColimit.desc hc E.f) :=
-    inferInstanceAs <| HasPullback
-      ((E.sigmaOfIsColimit hc).f ⟨⟩) ((E.sigmaOfIsColimit hc).f ⟨⟩)
   let c' : Cofan E.toPreOneHypercover.Y' :=
     Cofan.mk
       ((E.sigmaOfIsColimit hc).toPreOneHypercover.Y (i₁ := ⟨⟩) (i₂ := ⟨⟩) ⟨⟩)

--- a/Mathlib/CategoryTheory/Sites/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Sites/LeftExact.lean
@@ -135,7 +135,6 @@ def liftToPlusObjLimitObj {K : Type s} [SmallCategory K] [FinCategory K]
     [ReflectsLimitsOfShape K (forget D)] (F : K ⥤ Cᵒᵖ ⥤ D) (X : C)
     (S : Cone (F ⋙ J.plusFunctor D ⋙ (evaluation Cᵒᵖ D).obj (op X))) :
     S.pt ⟶ (J.plusObj (limit F)).obj (op X) :=
-  let x := (J.Cover X)ᵒᵖ
   let F' := F ⋙ J.diagramFunctor D X
   let e := colimitLimitIso (F ⋙ J.diagramFunctor D X)
   let t : J.diagram (limit F) X ≅ limit (F ⋙ J.diagramFunctor D X) :=

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -197,7 +197,6 @@ dsimproc cons_val (Matrix.vecCons _ _ _) := fun e => do
     if let Expr.lit (.natVal length) := etailn_whnf then
       pure (length, false, q(OfNat.ofNat $etailn_whnf))
     else if let some ((base : Q(ℕ)), offset) ← (Meta.isOffset? etailn_whnf).run then
-      let offset_e : Q(ℕ) := mkNatLit offset
       pure (offset, true, q($base + $offset))
     else
       pure (0, true, etailn)

--- a/Mathlib/LinearAlgebra/FreeModule/ModN.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/ModN.lean
@@ -63,7 +63,6 @@ set_option backward.isDefEq.respectTransparency false in
 /-- Given a free module `G` over `ℤ`, construct the corresponding basis
 of `G / ⟨n⟩` over `ℤ / nℤ`. -/
 noncomputable def basis {ι : Type*} (b : Basis ι ℤ G) : Basis ι (ZMod n) (ModN G n) := by
-  set ψ : G →+ G := zsmulAddGroupHom n
   set nG := LinearMap.range (LinearMap.lsmul ℤ G n)
   set H := G ⧸ nG
   set φ : G →ₗ[ℤ] H := nG.mkQ

--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -481,7 +481,6 @@ section
 
 /-- Get the leading coefficient of an `ExProd`. -/
 def ExProd.coeff {e : Q($α)} :
-    have : Inhabited <| Σ c, bt c := ⟨default, default⟩
   ExProd bt sα e → Σ c, bt c
   | .const q => ⟨_, q⟩
   | .mul _ _ v => v.coeff


### PR DESCRIPTION
This PR removes some unused `have`/`let` that have been caught using the `unusedHavesSuffices` linter from batteries.

Unfortunately, the linter has quite a few false positives as well. See also https://github.com/leanprover-community/batteries/pull/1932

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
