### PR TITLE
feat: add a wrapper around `fun_prop` that calls `simp` on the function

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7369,6 +7369,7 @@ public import Mathlib.Tactic.FunProp.Mor
 public import Mathlib.Tactic.FunProp.Theorems
 public import Mathlib.Tactic.FunProp.ToBatteries
 public import Mathlib.Tactic.FunProp.Types
+public import Mathlib.Tactic.FunPropSimp
 public import Mathlib.Tactic.GCongr
 public import Mathlib.Tactic.GCongr.Core
 public import Mathlib.Tactic.GCongr.CoreAttrs

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -137,6 +137,7 @@ public import Mathlib.Tactic.FunProp.Mor
 public import Mathlib.Tactic.FunProp.Theorems
 public import Mathlib.Tactic.FunProp.ToBatteries
 public import Mathlib.Tactic.FunProp.Types
+public import Mathlib.Tactic.FunPropSimp
 public import Mathlib.Tactic.GCongr
 public import Mathlib.Tactic.GCongr.Core
 public import Mathlib.Tactic.GCongr.CoreAttrs

--- a/Mathlib/Tactic/FunPropSimp.lean
+++ b/Mathlib/Tactic/FunPropSimp.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 Attila Gáspár. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Attila Gáspár
+-/
+module
+
+public import Mathlib.Tactic.Conv
+public import Mathlib.Tactic.DefEqTransformations
+public import Mathlib.Tactic.FunProp
+
+/-!
+# The `fun_prop_simp` tactic
+-/
+
+namespace Mathlib.Tactic
+
+open Lean Elab Tactic Syntax
+open Mathlib.Meta.FunProp (getFunPropDecl?)
+
+/-- `fun_prop_simp` is a wrapper around `fun_prop` that also tries calling `simp` on the function.
+It is intended to be used as an `autoParam` for proving properties of bundled morphisms. -/
+elab (name := funPropSimp) "fun_prop_simp" : tactic => do
+  let goalType ← instantiateMVars (← (← getMainGoal).getType)
+  let some funPropDecl ← getFunPropDecl? goalType | throwError "Not a `fun_prop` goal"
+  evalTactic <| ← `(tactic|
+    first
+    | fun_prop
+    | conv =>
+        arg @$(mkNatLit (funPropDecl.funArgId + 1))
+        with_reducible eta_expand
+        simp
+      fun_prop
+    | fail "`fun_prop_simp` failed"
+  )
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/FunPropSimp.lean
+++ b/Mathlib/Tactic/FunPropSimp.lean
@@ -15,13 +15,13 @@ public import Mathlib.Tactic.FunProp
 
 namespace Mathlib.Tactic
 
-open Lean Elab Tactic Syntax
+open Lean Elab Meta Tactic Syntax
 open Mathlib.Meta.FunProp (getFunPropDecl?)
 
 /-- `fun_prop_simp` is a wrapper around `fun_prop` that also tries calling `simp` on the function.
 It is intended to be used as an `autoParam` for proving properties of bundled morphisms. -/
 elab (name := funPropSimp) "fun_prop_simp" : tactic => do
-  let goalType ← instantiateMVars (← (← getMainGoal).getType)
+  let goalType ← whnfR (← (← getMainGoal).getType)
   let some funPropDecl ← getFunPropDecl? goalType | throwError "Not a `fun_prop` goal"
   evalTactic <| ← `(tactic|
     first

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -647,7 +647,6 @@ theorem nhds_one_symm' : map Inv.inv (𝓝 (1 : G)) = 𝓝 (1 : G) :=
 theorem inv_mem_nhds_one {S : Set G} (hS : S ∈ (𝓝 1 : Filter G)) : S⁻¹ ∈ 𝓝 (1 : G) := by
   rwa [← nhds_one_symm'] at hS
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The map `(x, y) ↦ (x, x * y)` as a homeomorphism. This is a shear mapping. -/
 @[to_additive /-- The map `(x, y) ↦ (x, x + y)` as a homeomorphism. This is a shear mapping. -/]
 protected def Homeomorph.shearMulRight : G × G ≃ₜ G × G :=

--- a/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Basic.lean
@@ -736,7 +736,6 @@ section ToSpanSingleton
 variable (R₁)
 variable [ContinuousSMul R₁ M₁]
 
-set_option backward.defeqAttrib.useBackward true in
 /-- Given an element `x` of a topological space `M` over a semiring `R`, the natural continuous
 linear map from `R` to `M` by taking multiples of `x`. -/
 def toSpanSingleton (x : M₁) : R₁ →L[R₁] M₁ where

--- a/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Basic.lean
@@ -61,8 +61,7 @@ ring `R`. -/
 structure ContinuousLinearMap {R : Type*} {S : Type*} [Semiring R] [Semiring S] (σ : R →+* S)
     (M : Type*) [TopologicalSpace M] [AddCommMonoid M] (M₂ : Type*) [TopologicalSpace M₂]
     [AddCommMonoid M₂] [Module R M] [Module S M₂] extends M →ₛₗ[σ] M₂ where
-  cont : Continuous toFun := by
-    first | fun_prop | eta_expand; dsimp; fun_prop | skip
+  cont : Continuous toFun := by fun_prop_simp
 
 attribute [inherit_doc ContinuousLinearMap] ContinuousLinearMap.cont
 

--- a/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/PiProd.lean
+++ b/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/PiProd.lean
@@ -81,7 +81,6 @@ variable
   {M₃ : Type*} [TopologicalSpace M₃] [AddCommMonoid M₃] [Module R M₃]
   {M₄ : Type*} [TopologicalSpace M₄] [AddCommMonoid M₄] [Module R M₄]
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The Cartesian product of two bounded linear maps, as a bounded linear map. -/
 protected def prod (f₁ : M₁ →L[R] M₂) (f₂ : M₁ →L[R] M₃) :
     M₁ →L[R] M₂ × M₃ where

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -958,10 +958,10 @@ variable [IsTopologicalAddGroup M₄]
   and `f` is a rectangular block below the diagonal. -/
 def skewProd (e : M ≃L[R] M₂) (e' : M₃ ≃L[R] M₄) (f : M →L[R] M₄) : (M × M₃) ≃L[R] M₂ × M₄ where
   __ := e.toLinearEquiv.skewProd e'.toLinearEquiv ↑f
-  continuous_invFun :=
-    (e.continuous_invFun.comp continuous_fst).prodMk
-      (e'.continuous_invFun.comp <|
-        continuous_snd.sub <| f.continuous.comp <| e.continuous_invFun.comp continuous_fst)
+  continuous_invFun := by
+    eta_expand
+    simp only [LinearEquiv.invFun_eq_symm, LinearEquiv.skewProd_symm_apply, coe_symm_toLinearEquiv]
+    fun_prop
 
 @[simp]
 theorem skewProd_apply (e : M ≃L[R] M₂) (e' : M₃ ≃L[R] M₄) (f : M →L[R] M₄) (x) :

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -959,6 +959,9 @@ variable [IsTopologicalAddGroup M₄]
 def skewProd (e : M ≃L[R] M₂) (e' : M₃ ≃L[R] M₄) (f : M →L[R] M₄) : (M × M₃) ≃L[R] M₂ × M₄ where
   __ := e.toLinearEquiv.skewProd e'.toLinearEquiv ↑f
   continuous_invFun := by
+    /- `fun_prop_simp` does not work here because `simp` results in subtraction on `M₃`. We cannot
+    use `ContinuousAddHom.isTopologicalAddGroup` to get `[IsTopologicalAddGroup M₃]` because it is
+    defined in a downstream file. -/
     eta_expand
     simp only [LinearEquiv.invFun_eq_symm, LinearEquiv.skewProd_symm_apply, coe_symm_toLinearEquiv]
     fun_prop

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -387,7 +387,6 @@ theorem prodCongr_symm [Module R₁ M₂] [Module R₁ M₃] [Module R₁ M₄] 
 
 variable (R₁ M₁ M₂)
 
-set_option backward.defeqAttrib.useBackward true in
 /-- Product of topological modules is commutative up to continuous linear isomorphism. -/
 @[simps! apply toLinearEquiv]
 def prodComm [Module R₁ M₂] : (M₁ × M₂) ≃L[R₁] M₂ × M₁ where
@@ -467,7 +466,6 @@ variable (R M N : Type*) [Semiring R]
   [TopologicalSpace M] [AddCommMonoid M] [TopologicalSpace N] [AddCommMonoid N]
   [Unique N] [Module R M] [Module R N]
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The natural equivalence `M × N ≃L[R] M` for any `Unique` type `N`.
 This is `Equiv.prodUnique` as a continuous linear equivalence. -/
 def prodUnique : (M × N) ≃L[R] M where
@@ -482,7 +480,6 @@ lemma prodUnique_apply (x : M × N) : prodUnique R M N x = x.1 := rfl
 @[simp]
 lemma prodUnique_symm_apply (x : M) : (prodUnique R M N).symm x = (x, default) := rfl
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The natural equivalence `N × M ≃L[R] M` for any `Unique` type `N`.
 This is `Equiv.uniqueProd` as a continuous linear equivalence. -/
 def uniqueProd : (N × M) ≃L[R] M where
@@ -927,7 +924,6 @@ variable {n : ℕ} {R : Type*} {M : Fin n.succ → Type*} {N : Type*}
 variable [Semiring R]
 variable [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)] [∀ i, TopologicalSpace (M i)]
 
-set_option backward.defeqAttrib.useBackward true in
 variable (R M) in
 /-- `Fin.consEquiv` as a continuous linear equivalence. -/
 @[simps!]
@@ -1040,7 +1036,6 @@ end Ring
 
 section RestrictScalars
 
-set_option backward.defeqAttrib.useBackward true in
 /-- If M is an `R`-module and `S`-module and `R`-module structure is defined by an action of `R` on
 `S` (formally, we have two scalar towers), then any `S`-linear equivalence on `M` is an `R`-linear
 equivalence. -/

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -51,8 +51,8 @@ structure ContinuousLinearEquiv {R : Type*} {S : Type*} [Semiring R] [Semiring S
     {σ' : S →+* R} [RingHomInvPair σ σ'] [RingHomInvPair σ' σ] (M : Type*) [TopologicalSpace M]
     [AddCommMonoid M] (M₂ : Type*) [TopologicalSpace M₂] [AddCommMonoid M₂] [Module R M]
     [Module S M₂] extends M ≃ₛₗ[σ] M₂ where
-  continuous_toFun : Continuous toFun := by first | fun_prop | eta_expand; dsimp; fun_prop | skip
-  continuous_invFun : Continuous invFun := by first | fun_prop | eta_expand; dsimp; fun_prop | skip
+  continuous_toFun : Continuous toFun := by fun_prop_simp
+  continuous_invFun : Continuous invFun := by fun_prop_simp
 
 attribute [inherit_doc ContinuousLinearEquiv] ContinuousLinearEquiv.continuous_toFun
 ContinuousLinearEquiv.continuous_invFun
@@ -958,6 +958,10 @@ variable [IsTopologicalAddGroup M₄]
   and `f` is a rectangular block below the diagonal. -/
 def skewProd (e : M ≃L[R] M₂) (e' : M₃ ≃L[R] M₄) (f : M →L[R] M₄) : (M × M₃) ≃L[R] M₂ × M₄ where
   __ := e.toLinearEquiv.skewProd e'.toLinearEquiv ↑f
+  continuous_invFun :=
+    (e.continuous_invFun.comp continuous_fst).prodMk
+      (e'.continuous_invFun.comp <|
+        continuous_snd.sub <| f.continuous.comp <| e.continuous_invFun.comp continuous_fst)
 
 @[simp]
 theorem skewProd_apply (e : M ≃L[R] M₂) (e' : M₃ ≃L[R] M₄) (f : M →L[R] M₄) (x) :

--- a/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
@@ -209,7 +209,6 @@ def applyAddHom (m : ∀ i, M₁ i) : ContinuousMultilinearMap R M₁ M₂ →+ 
 
 end ContinuousAdd
 
-set_option backward.defeqAttrib.useBackward true in
 /-- If `f` is a continuous multilinear map, then `f.toContinuousLinearMap m i` is the continuous
 linear map obtained by fixing all coordinates but `i` equal to those of `m`, and varying the
 `i`-th coordinate. -/

--- a/Mathlib/Topology/Algebra/Module/Star.lean
+++ b/Mathlib/Topology/Algebra/Module/Star.lean
@@ -28,7 +28,6 @@ section starL
 variable (R : Type*) {A : Type*} [CommSemiring R] [StarRing R] [AddCommMonoid A]
     [StarAddMonoid A] [Module R A] [StarModule R A] [TopologicalSpace A] [ContinuousStar A]
 
-set_option backward.defeqAttrib.useBackward true in
 /-- If `A` is a topological module over a commutative `R` with compatible actions,
 then `star` is a continuous semilinear equivalence. -/
 @[simps! apply]

--- a/Mathlib/Topology/Constructions/SumProd.lean
+++ b/Mathlib/Topology/Constructions/SumProd.lean
@@ -663,7 +663,6 @@ namespace Homeomorph
 
 variable {X' Y' : Type*} [TopologicalSpace X'] [TopologicalSpace Y']
 
-set_option backward.defeqAttrib.useBackward true in
 /-- Product of two homeomorphisms. -/
 def prodCongr (h₁ : X ≃ₜ X') (h₂ : Y ≃ₜ Y') : X × Y ≃ₜ X' × Y' where
   toEquiv := h₁.toEquiv.prodCongr h₂.toEquiv
@@ -881,7 +880,6 @@ namespace Homeomorph
 
 variable {X' Y' : Type*} [TopologicalSpace X'] [TopologicalSpace Y']
 
-set_option backward.defeqAttrib.useBackward true in
 /-- Sum of two homeomorphisms. -/
 def sumCongr (h₁ : X ≃ₜ X') (h₂ : Y ≃ₜ Y') : X ⊕ Y ≃ₜ X' ⊕ Y' where
   toEquiv := h₁.toEquiv.sumCongr h₂.toEquiv
@@ -931,7 +929,6 @@ def sumAssoc : (X ⊕ Y) ⊕ Z ≃ₜ X ⊕ Y ⊕ Z where
 @[simp]
 lemma sumAssoc_toEquiv : (sumAssoc X Y Z).toEquiv = Equiv.sumAssoc X Y Z := rfl
 
-set_option backward.defeqAttrib.useBackward true in
 /-- Four-way commutativity of the disjoint union. The name matches `add_add_add_comm`. -/
 def sumSumSumComm : (X ⊕ Y) ⊕ W ⊕ Z ≃ₜ (X ⊕ W) ⊕ Y ⊕ Z where
   toEquiv := Equiv.sumSumSumComm X Y W Z

--- a/Mathlib/Topology/Homeomorph/Defs.lean
+++ b/Mathlib/Topology/Homeomorph/Defs.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Topology.ContinuousMap.Defs
 public import Mathlib.Topology.Maps.OpenQuotient
+public import Mathlib.Tactic.FunPropSimp
 
 /-!
 # Homeomorphisms
@@ -43,11 +44,9 @@ variable {X Y W Z : Type*}
 structure Homeomorph (X : Type*) (Y : Type*) [TopologicalSpace X] [TopologicalSpace Y]
     extends X ≃ Y where
   /-- The forward map of a homeomorphism is a continuous function. -/
-  continuous_toFun : Continuous toFun := by
-    first | fun_prop | eta_expand; dsimp; fun_prop | skip
+  continuous_toFun : Continuous toFun := by fun_prop_simp
   /-- The inverse map of a homeomorphism is a continuous function. -/
-  continuous_invFun : Continuous invFun := by
-    first | fun_prop | eta_expand; dsimp; fun_prop | skip
+  continuous_invFun : Continuous invFun := by fun_prop_simp
 
 @[inherit_doc]
 infixl:25 " ≃ₜ " => Homeomorph

--- a/Mathlib/Topology/Homeomorph/Lemmas.lean
+++ b/Mathlib/Topology/Homeomorph/Lemmas.lean
@@ -154,7 +154,6 @@ theorem comp_continuousWithinAt_iff (h : X ≃ₜ Y) (f : Z → X) (s : Set Z) (
     ContinuousWithinAt f s z ↔ ContinuousWithinAt (h ∘ f) s z :=
   h.isInducing.continuousWithinAt_iff
 
-set_option backward.defeqAttrib.useBackward true in
 /-- A homeomorphism `h : X ≃ₜ Y` lifts to a homeomorphism between subtypes corresponding to
 predicates `p : X → Prop` and `q : Y → Prop` so long as `p = q ∘ h`. -/
 @[simps!]
@@ -172,8 +171,6 @@ whenever `h` maps `s` onto `t`. -/
 abbrev sets {s : Set X} {t : Set Y} (h : X ≃ₜ Y) (h_eq : s = h ⁻¹' t) : s ≃ₜ t :=
   h.subtype <| Set.ext_iff.mp h_eq
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 /-- If two sets are equal, then they are homeomorphic. -/
 def setCongr {s t : Set X} (h : s = t) : s ≃ₜ t where
   toEquiv := Equiv.setCongr h
@@ -247,7 +244,6 @@ lemma piCongrLeft_apply_apply {ι ι' : Type*} {Y : ι' → Type*} [∀ j, Topol
     (e : ι ≃ ι') (x : ∀ i, Y (e i)) (i : ι) : piCongrLeft e x (e i) = x i :=
   Equiv.piCongrLeft_apply_apply ..
 
-set_option backward.defeqAttrib.useBackward true in
 /-- `Equiv.piCongrRight` as a homeomorphism: this is the natural homeomorphism
 `Π i, Y₁ i ≃ₜ Π j, Y₂ i` obtained from homeomorphisms `Y₁ i ≃ₜ Y₂ i` for each `i`. -/
 @[simps! apply toEquiv]
@@ -325,7 +321,6 @@ def sigmaProdDistrib : (Σ i, X i) × Y ≃ₜ Σ i, X i × Y :=
 
 end Distrib
 
-set_option backward.defeqAttrib.useBackward true in
 /-- If `ι` has a unique element, then `ι → X` is homeomorphic to `X`. -/
 @[simps! -fullyApplied]
 def funUnique (ι X : Type*) [Unique ι] [TopologicalSpace X] : (ι → X) ≃ₜ X where


### PR DESCRIPTION
This new tactic is used for the `autoParam` tactics of `Homeomorph`, etc. These `autoParam`s currently use `dsimp`, which often requires the use of `backward.defeqAttrib.useBackward`, since `simps` tags lemmas with `@[backward_defeq]`. It also prevents the use of general lemmas such as `IsAddApply.add_apply`, which cannot hold definitionally.

This PR also removes the `backward.defeqAttrib.useBackward` options which become unnecessary as a result of this change.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
