### PR TITLE
feat(order): add ciSup₂ diagonal lemmas

### DIFF
--- a/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
@@ -617,8 +617,8 @@ theorem ciSup₂_eq_ciSup_diagonal' {α : Type*} {ι : Sort*}
         obtain ⟨k, hik⟩ := h i j
         exact hik.trans (hb' ⟨k, rfl⟩)⟩
   apply le_antisymm
-  · exact ciSup_le' fun i ↦ ciSup_mono_of_forall_exists' hb (h i)
-  · exact ciSup_mono_of_forall_exists' hfi fun k ↦
+  · exact ciSup_le' fun i ↦ ciSup_mono' hb (h i)
+  · exact ciSup_mono' hfi fun k ↦
       ⟨k, le_ciSup (hf k) k⟩
 
 theorem ciSup_exists {p : ι → Prop} {f : Exists p → α} : ⨆ ih, f ih = ⨆ (i) (h), f ⟨i, h⟩ := by

--- a/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
@@ -233,7 +233,7 @@ theorem ciSup₂_eq_ciSup_diagonal {α : Type*} {ι : Sort*}
   · exact ciSup_le fun i ↦ ciSup_mono_of_forall_exists hb (h i)
   · exact ciSup_mono_of_forall_exists hfi fun k ↦
       ⟨k, le_ciSup (hf k) k⟩
-      
+
 /-- If the set of all `f i j` is bounded below, then so is the set of the infimums of every row -/
 theorem BddBelow.range_iInf_of_iUnion_range {κ : ι → Sort*} {f : ∀ i, κ i → α}
     (H : BddBelow <| ⋃ i, range (f i)) : BddBelow <| range fun i ↦ ⨅ j, f i j := by

--- a/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
@@ -168,6 +168,32 @@ theorem ciSup_mono {f g : ι → α} (B : BddAbove (range g)) (H : ∀ x, f x �
   · rw [iSup_of_empty', iSup_of_empty']
   · exact ciSup_le fun x => le_ciSup_of_le B x (H x)
 
+/-- A doubly indexed conditionally complete supremum equals the supremum along its diagonal when
+that diagonal is cofinal. Boundedness of the diagonal bounds the entire double family. -/
+theorem ciSup₂_eq_ciSup_diagonal {α : Type*} {ι : Sort*}
+    [ConditionallyCompleteLattice α] [Nonempty ι]
+    (f : ι → ι → α)
+    (h : ∀ i j, ∃ k, f i j ≤ f k k)
+    (hb : BddAbove (Set.range fun k ↦ f k k)) :
+    (⨆ i, ⨆ j, f i j) = ⨆ k, f k k := by
+  let b := Classical.choose hb
+  have hb' := Classical.choose_spec hb
+  have hf : ∀ i, BddAbove (range (f i)) := fun i ↦
+    ⟨b, by
+      rintro _ ⟨j, rfl⟩
+      obtain ⟨k, hik⟩ := h i j
+      exact hik.trans (hb' ⟨k, rfl⟩)⟩
+  have hfi : BddAbove (range fun i ↦ ⨆ j, f i j) :=
+    ⟨b, by
+      rintro _ ⟨i, rfl⟩
+      exact ciSup_le fun j ↦ by
+        obtain ⟨k, hik⟩ := h i j
+        exact hik.trans (hb' ⟨k, rfl⟩)⟩
+  apply le_antisymm
+  · exact ciSup_le fun i ↦ ciSup_mono_of_forall_exists hb (h i)
+  · exact ciSup_mono_of_forall_exists hfi fun k ↦
+      ⟨k, le_ciSup (hf k) k⟩
+
 theorem ciSup_sup_eq {f g : ι → α} (Hf : BddAbove <| range f) (Hg : BddAbove <| range g) :
     ⨆ x, f x ⊔ g x = (⨆ x, f x) ⊔ (⨆ x, g x) := by
   cases isEmpty_or_nonempty ι
@@ -568,6 +594,32 @@ theorem ciSup_mono_of_forall_exists' {ι'} {f : ι → α} {g : ι' → α} (hg 
   ciSup_le' fun i ↦ h i |>.elim <| le_ciSup_of_le hg
 
 @[deprecated (since := "2026-05-03")] alias ciSup_mono' := ciSup_mono_of_forall_exists'
+
+/-- The bottomed linear-order version of `ciSup₂_eq_ciSup_diagonal`. No `Nonempty ι` assumption is
+needed because an empty indexed supremum is `⊥`. -/
+theorem ciSup₂_eq_ciSup_diagonal' {α : Type*} {ι : Sort*}
+    [ConditionallyCompleteLinearOrderBot α]
+    (f : ι → ι → α)
+    (h : ∀ i j, ∃ k, f i j ≤ f k k)
+    (hb : BddAbove (Set.range fun k ↦ f k k)) :
+    (⨆ i, ⨆ j, f i j) = ⨆ k, f k k := by
+  let b := Classical.choose hb
+  have hb' := Classical.choose_spec hb
+  have hf : ∀ i, BddAbove (range (f i)) := fun i ↦
+    ⟨b, by
+      rintro _ ⟨j, rfl⟩
+      obtain ⟨k, hik⟩ := h i j
+      exact hik.trans (hb' ⟨k, rfl⟩)⟩
+  have hfi : BddAbove (range fun i ↦ ⨆ j, f i j) :=
+    ⟨b, by
+      rintro _ ⟨i, rfl⟩
+      exact ciSup_le' fun j ↦ by
+        obtain ⟨k, hik⟩ := h i j
+        exact hik.trans (hb' ⟨k, rfl⟩)⟩
+  apply le_antisymm
+  · exact ciSup_le' fun i ↦ ciSup_mono_of_forall_exists' hb (h i)
+  · exact ciSup_mono_of_forall_exists' hfi fun k ↦
+      ⟨k, le_ciSup (hf k) k⟩
 
 theorem ciSup_exists {p : ι → Prop} {f : Exists p → α} : ⨆ ih, f ih = ⨆ (i) (h), f ⟨i, h⟩ := by
   refine le_antisymm ciSup_exists_le <| ciSup_le' fun i ↦ ciSup_le' fun hi ↦ ?_

--- a/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
@@ -168,32 +168,6 @@ theorem ciSup_mono {f g : ι → α} (B : BddAbove (range g)) (H : ∀ x, f x �
   · rw [iSup_of_empty', iSup_of_empty']
   · exact ciSup_le fun x => le_ciSup_of_le B x (H x)
 
-/-- A doubly indexed conditionally complete supremum equals the supremum along its diagonal when
-that diagonal is cofinal. Boundedness of the diagonal bounds the entire double family. -/
-theorem ciSup₂_eq_ciSup_diagonal {α : Type*} {ι : Sort*}
-    [ConditionallyCompleteLattice α] [Nonempty ι]
-    (f : ι → ι → α)
-    (h : ∀ i j, ∃ k, f i j ≤ f k k)
-    (hb : BddAbove (Set.range fun k ↦ f k k)) :
-    (⨆ i, ⨆ j, f i j) = ⨆ k, f k k := by
-  let b := Classical.choose hb
-  have hb' := Classical.choose_spec hb
-  have hf : ∀ i, BddAbove (range (f i)) := fun i ↦
-    ⟨b, by
-      rintro _ ⟨j, rfl⟩
-      obtain ⟨k, hik⟩ := h i j
-      exact hik.trans (hb' ⟨k, rfl⟩)⟩
-  have hfi : BddAbove (range fun i ↦ ⨆ j, f i j) :=
-    ⟨b, by
-      rintro _ ⟨i, rfl⟩
-      exact ciSup_le fun j ↦ by
-        obtain ⟨k, hik⟩ := h i j
-        exact hik.trans (hb' ⟨k, rfl⟩)⟩
-  apply le_antisymm
-  · exact ciSup_le fun i ↦ ciSup_mono_of_forall_exists hb (h i)
-  · exact ciSup_mono_of_forall_exists hfi fun k ↦
-      ⟨k, le_ciSup (hf k) k⟩
-
 theorem ciSup_sup_eq {f g : ι → α} (Hf : BddAbove <| range f) (Hg : BddAbove <| range g) :
     ⨆ x, f x ⊔ g x = (⨆ x, f x) ⊔ (⨆ x, g x) := by
   cases isEmpty_or_nonempty ι
@@ -234,6 +208,32 @@ theorem ciInf_mono_of_forall_exists {ι'} [Nonempty ι'] {f : ι → α} {g : ι
     (hf : BddBelow <| range f) (h : ∀ i', ∃ i, f i ≤ g i') : ⨅ i, f i ≤ ⨅ i', g i' :=
   ciSup_mono_of_forall_exists (α := αᵒᵈ) hf h
 
+/-- A doubly indexed conditionally complete supremum equals the supremum along its diagonal when
+that diagonal is cofinal. Boundedness of the diagonal bounds the entire double family. -/
+theorem ciSup₂_eq_ciSup_diagonal {α : Type*} {ι : Sort*}
+    [ConditionallyCompleteLattice α] [Nonempty ι]
+    (f : ι → ι → α)
+    (h : ∀ i j, ∃ k, f i j ≤ f k k)
+    (hb : BddAbove (Set.range fun k ↦ f k k)) :
+    (⨆ i, ⨆ j, f i j) = ⨆ k, f k k := by
+  let b := Classical.choose hb
+  have hb' := Classical.choose_spec hb
+  have hf : ∀ i, BddAbove (range (f i)) := fun i ↦
+    ⟨b, by
+      rintro _ ⟨j, rfl⟩
+      obtain ⟨k, hik⟩ := h i j
+      exact hik.trans (hb' ⟨k, rfl⟩)⟩
+  have hfi : BddAbove (range fun i ↦ ⨆ j, f i j) :=
+    ⟨b, by
+      rintro _ ⟨i, rfl⟩
+      exact ciSup_le fun j ↦ by
+        obtain ⟨k, hik⟩ := h i j
+        exact hik.trans (hb' ⟨k, rfl⟩)⟩
+  apply le_antisymm
+  · exact ciSup_le fun i ↦ ciSup_mono_of_forall_exists hb (h i)
+  · exact ciSup_mono_of_forall_exists hfi fun k ↦
+      ⟨k, le_ciSup (hf k) k⟩
+      
 /-- If the set of all `f i j` is bounded below, then so is the set of the infimums of every row -/
 theorem BddBelow.range_iInf_of_iUnion_range {κ : ι → Sort*} {f : ∀ i, κ i → α}
     (H : BddBelow <| ⋃ i, range (f i)) : BddBelow <| range fun i ↦ ⨅ j, f i j := by

--- a/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
@@ -617,8 +617,8 @@ theorem ciSup₂_eq_ciSup_diagonal' {α : Type*} {ι : Sort*}
         obtain ⟨k, hik⟩ := h i j
         exact hik.trans (hb' ⟨k, rfl⟩)⟩
   apply le_antisymm
-  · exact ciSup_le' fun i ↦ ciSup_mono' hb (h i)
-  · exact ciSup_mono' hfi fun k ↦
+  · exact ciSup_le' fun i ↦ ciSup_mono_of_forall_exists' hb (h i)
+  · exact ciSup_mono_of_forall_exists' hfi fun k ↦
       ⟨k, le_ciSup (hf k) k⟩
 
 theorem ciSup_exists {p : ι → Prop} {f : Exists p → α} : ⨆ ih, f ih = ⨆ (i) (h), f ⟨i, h⟩ := by

--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -398,6 +398,21 @@ protected theorem ciSup_add_ciSup (hf : BddAbove (range f)) (g : ι' → Cardina
     (⨆ i, f i) + (⨆ j, g j) = ⨆ (i) (j), f i + g j := by
   simp_rw [Cardinal.ciSup_add f hf, Cardinal.add_ciSup g hg]
 
+/-- A diagonal strengthening of `Cardinal.ciSup_add_ciSup`: if the diagonal sums are cofinal among
+all pairwise sums, its double supremum collapses to the diagonal. -/
+protected theorem ciSup_add_ciSup_diagonal {ι : Type*} [Nonempty ι]
+    (f g : ι → Cardinal)
+    (hf : BddAbove (range f)) (hg : BddAbove (range g))
+    (h : ∀ i j, ∃ k, f i + g j ≤ f k + g k) :
+    (⨆ i, f i) + (⨆ j, g j) = ⨆ k, f k + g k := by
+  rw [Cardinal.ciSup_add_ciSup f hf g hg]
+  apply ciSup₂_eq_ciSup_diagonal' (fun i j ↦ f i + g j) h
+  obtain ⟨bf, hbf⟩ := hf
+  obtain ⟨bg, hbg⟩ := hg
+  exact ⟨bf + bg, by
+    rintro _ ⟨k, rfl⟩
+    exact add_le_add (hbf ⟨k, rfl⟩) (hbg ⟨k, rfl⟩)⟩
+
 end add
 
 protected theorem ciSup_mul (c : Cardinal.{v}) : (⨆ i, f i) * c = ⨆ i, f i * c := by


### PR DESCRIPTION
Add ciSup₂_eq_ciSup_diagonal and its bounded-below variant ciSup₂_eq_ciSup_diagonal' to the conditionally complete indexed-supremum API. 

Add Cardinal.ciSup_add_ciSup_diagonal as a concrete application, collapsing the double supremum in Cardinal.ciSup_add_ciSup to a cofinal diagonal.

Aristotle helped

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
