### PR TITLE
chore(downstream_repos): add TorchLean

### DIFF
--- a/scripts/downstream_repos.yml
+++ b/scripts/downstream_repos.yml
@@ -118,6 +118,13 @@
   default_branch: master
   name: SciLean - Scientific Computing
   zulip-contact: Tomas Skrivan
+- github: https://github.com/lean-dojo/TorchLean
+  default_branch: main
+  name: TorchLean
+  zulip-contact: Robert Joseph George
+  workflows:
+    build: ci.yml
+    docs: blueprint.yml
 - github: https://github.com/teorth/analysis
   default_branch: main
   name: Tao's Analysis I


### PR DESCRIPTION
This PR adds [TorchLean](https://github.com/lean-dojo/TorchLean) to `scripts/downstream_repos.yml`!

TorchLean is the first unified Lean 4 framework for neural-network specification,
execution, training, and formal verification. It depends on Mathlib and maintains
build and documentation workflows on its default branch! Let me know if something else is needed:)
