### PR TITLE
[Merged by Bors] - chore: generalize `NoZeroDivisors` to `IsReduced` when possible

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Indicator.lean
+++ b/Mathlib/Algebra/GroupWithZero/Indicator.lean
@@ -126,7 +126,7 @@ lemma support_mul_of_ne_zero_right (f : ι → M₀) {g : ι → M₀} (hg : ∀
 end MulZeroClass
 
 section MonoidWithZero
-variable [MonoidWithZero M₀] [NoZeroDivisors M₀] {n : ℕ}
+variable [MonoidWithZero M₀] [IsReduced M₀] {n : ℕ}
 
 @[simp] lemma support_pow (f : ι → M₀) (hn : n ≠ 0) : support (fun a ↦ f a ^ n) = support f := by
   ext; exact (pow_eq_zero_iff hn).not

--- a/Mathlib/Algebra/GroupWithZero/Torsion.lean
+++ b/Mathlib/Algebra/GroupWithZero/Torsion.lean
@@ -22,13 +22,12 @@ public section
 
 variable {M : Type*} [CommMonoidWithZero M]
 
-theorem IsMulTorsionFree.mk' [NoZeroDivisors M]
+theorem IsMulTorsionFree.mk' [IsReduced M]
     (ih : ∀ x ≠ 0, ∀ y ≠ 0, ∀ n ≠ 0, (x ^ n : M) = y ^ n → x = y) :
     IsMulTorsionFree M := by
   refine ⟨fun n hn x y hxy ↦ ?_⟩
   by_cases h : x ≠ 0 ∧ y ≠ 0
   · exact ih x h.1 y h.2 n hn hxy
-  have : IsReduced M := inferInstance
   grind [eq_zero_of_pow_eq_zero, zero_pow]
 
 variable [UniqueFactorizationMonoid M] [NormalizationMonoid M] [IsMulTorsionFree Mˣ]

--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -37,7 +37,7 @@ theorem isPrimePow_iff_pow_succ : IsPrimePow n ↔ ∃ (p : R) (k : ℕ), Prime 
     ⟨fun ⟨p, k, hp, hk, hn⟩ => ⟨p, k - 1, hp, by rwa [Nat.sub_add_cancel hk]⟩, fun ⟨_, _, hp, hn⟩ =>
       ⟨_, _, hp, Nat.succ_pos', hn⟩⟩
 
-theorem not_isPrimePow_zero [NoZeroDivisors R] : ¬IsPrimePow (0 : R) := by
+theorem not_isPrimePow_zero [IsReduced R] : ¬IsPrimePow (0 : R) := by
   simp only [isPrimePow_def, not_exists, not_and', and_imp]
   intro x n _hn hx
   rw [eq_zero_of_pow_eq_zero hx]
@@ -62,7 +62,7 @@ theorem IsPrimePow.pow {n : R} (hn : IsPrimePow n) {k : ℕ} (hk : k ≠ 0) : Is
   let ⟨p, k', hp, hk', hn⟩ := hn
   ⟨p, k * k', hp, mul_pos hk.bot_lt hk', by rw [pow_mul', hn]⟩
 
-theorem IsPrimePow.ne_zero [NoZeroDivisors R] {n : R} (h : IsPrimePow n) : n ≠ 0 := fun t =>
+theorem IsPrimePow.ne_zero [IsReduced R] {n : R} (h : IsPrimePow n) : n ≠ 0 := fun t =>
   not_isPrimePow_zero (t ▸ h)
 
 theorem IsPrimePow.ne_one {n : R} (h : IsPrimePow n) : n ≠ 1 := fun t =>

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -104,7 +104,7 @@ instance instLinearOrderedAddCommMonoidWithTopOrderDualAdditive :
   top_add' a := by ext; simp; simp [bot_eq_zero (α := α)]
   isAddLeftRegular_of_ne_top := by simp; simp +contextual [bot_eq_zero, IsRegular.of_ne_zero]
 
-variable [NoZeroDivisors α]
+variable [IsReduced α]
 
 lemma pow_pos_iff (hn : n ≠ 0) : 0 < a ^ n ↔ 0 < a := by
   simp_rw [pos_iff_ne_zero, pow_ne_zero_iff hn]

--- a/Mathlib/Algebra/Order/Ring/Canonical.lean
+++ b/Mathlib/Algebra/Order/Ring/Canonical.lean
@@ -68,7 +68,7 @@ protected theorem mul_pos [NoZeroDivisors R] {a b : R} :
     0 < a * b ↔ 0 < a ∧ 0 < b := by
   simp only [pos_iff_ne_zero, ne_eq, mul_eq_zero, not_or]
 
-lemma pow_pos [NoZeroDivisors R] {a : R} (ha : 0 < a) (n : ℕ) : 0 < a ^ n :=
+lemma pow_pos [IsReduced R] {a : R} (ha : 0 < a) (n : ℕ) : 0 < a ^ n :=
   pos_iff_ne_zero.2 <| pow_ne_zero _ ha.ne'
 
 protected lemma mul_lt_mul_of_lt_of_lt

--- a/Mathlib/Tactic/LinearCombinationPrime.lean
+++ b/Mathlib/Tactic/LinearCombinationPrime.lean
@@ -130,7 +130,7 @@ theorem eq_trans₃ (p : (a : α) = b) (p₁ : a = a') (p₂ : b = b') : a' = b'
 theorem eq_of_add [AddGroup α] (p : (a : α) = b) (H : (a' - b') - (a - b) = 0) : a' = b' := by
   rw [← sub_eq_zero] at p ⊢; rwa [sub_eq_zero, p] at H
 
-theorem eq_of_add_pow [Ring α] [NoZeroDivisors α] (n : ℕ) (p : (a : α) = b)
+theorem eq_of_add_pow [Ring α] [IsReduced α] (n : ℕ) (p : (a : α) = b)
     (H : (a' - b') ^ n - (a - b) = 0) : a' = b' := by
   rw [← sub_eq_zero] at p ⊢; apply eq_zero_of_pow_eq_zero (n := n); rwa [sub_eq_zero, p] at H
 


### PR DESCRIPTION
Follow-up to #33775.  In several places where `eq_zero_of_pow_eq_zero` or related lemmas are being used, we can generalize from `NoZeroDivisors` to `IsReduced` without changing anything else.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
