### PR TITLE
[Merged by Bors] - chore(Data/Finset/Prod): state `singleton_product`/`product_singleton` via `sectR`/`sectL`

### DIFF
--- a/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
@@ -745,7 +745,7 @@ lemma pow_mul_norm_iteratedFDeriv_fourier_le
     rwa [pow_two, mul_pow, mul_assoc] at this
   rcases eq_or_ne n 0 with rfl | hn
   · simp only [pow_zero, one_mul, mul_one, zero_add, Finset.range_one, Finset.product_singleton,
-      Finset.sum_map, Function.Embedding.coeFn_mk, norm_iteratedFDeriv_zero] at Z ⊢
+      Finset.sum_map, Function.Embedding.sectL_apply] at Z ⊢
     apply Z.trans
     conv_rhs => rw [← mul_one π]
     gcongr

--- a/Mathlib/Data/Finset/Prod.lean
+++ b/Mathlib/Data/Finset/Prod.lean
@@ -201,19 +201,16 @@ theorem product_eq_empty {s : Finset α} {t : Finset β} : s ×ˢ t = ∅ ↔ s 
   contrapose!; exact nonempty_product
 
 @[simp]
-theorem singleton_product {a : α} :
-    ({a} : Finset α) ×ˢ t = t.map ⟨Prod.mk a, Prod.mk_right_injective _⟩ := by
+theorem singleton_product {a : α} : ({a} : Finset α) ×ˢ t = t.map (.sectR a _) := by
   ext ⟨x, y⟩
   simp [and_left_comm, eq_comm]
 
 @[simp]
-lemma product_singleton : s ×ˢ {b} = s.map ⟨fun i => (i, b), Prod.mk_left_injective _⟩ := by
+lemma product_singleton : s ×ˢ {b} = s.map (.sectL _ b) := by
   ext ⟨x, y⟩
   simp [and_left_comm, eq_comm]
 
-theorem singleton_product_singleton {a : α} {b : β} :
-    ({a} ×ˢ {b} : Finset _) = {(a, b)} := by
-  simp only [product_singleton, Function.Embedding.coeFn_mk, map_singleton]
+theorem singleton_product_singleton {a : α} {b : β} : ({a} ×ˢ {b} : Finset _) = {(a, b)} := rfl
 
 @[simp]
 theorem union_product [DecidableEq α] [DecidableEq β] : (s ∪ s') ×ˢ t = s ×ˢ t ∪ s' ×ˢ t := by grind

--- a/Mathlib/Topology/EMetricSpace/PairReduction.lean
+++ b/Mathlib/Topology/EMetricSpace/PairReduction.lean
@@ -387,7 +387,7 @@ lemma edist_le_of_mem_pairSet (ha : 1 < a) (hJ_card : #J ≤ a ^ n) {s t : T}
     have ⟨hs, ht⟩ := Finset.mem_product.mp (pairSet_subset h)
     exact Finset.card_le_one_iff.mp hJ_card hs ht
   simp only [pairSetSeq, hJ, ↓reduceDIte, logSizeBallStruct.ball, Finset.product_eq_sprod,
-    Finset.singleton_product, Finset.mem_map, Finset.mem_filter, Function.Embedding.coeFn_mk,
+    Finset.singleton_product, Finset.mem_map, Finset.mem_filter, Function.Embedding.sectR_apply,
     Prod.mk.injEq, exists_eq_right_right] at h'
   obtain ⟨⟨ht, hdist⟩, rfl⟩ := h'
   grw [hdist, radius_logSizeBallSeq_le hJ ha hn hJ_card i]


### PR DESCRIPTION
The embeddings in the statements of `Finset.singleton_product` and `Finset.product_singleton` are `Function.Embedding.sectR`/`sectL` written out as anonymous constructors. Restate them via the named embeddings (the statements are definitionally unchanged), so call sites can rewrite with the `sectR_apply`/`sectL_apply` simp lemmas instead of `Embedding.coeFn_mk`. Update the two call sites that did the latter, and golf `singleton_product_singleton`, which is now `rfl`.

Preparation for a follow-up PR replacing the `aesop` proofs of the `{Icc,Ico,Ioc,Ioo,uIcc}_map_{sectL,sectR}` lemmas in `Order/Interval/Finset/Basic`.
