### PR TITLE
[Merged by Bors] - chore: golf some proofs with `grw`

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Extend.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Extend.lean
@@ -84,7 +84,7 @@ theorem hasFDerivWithinAt_closure_of_tendsto_fderiv {f : E → F} {s : Set E} {x
   refine ContinuousWithinAt.closure_le uv_in ?_ ?_ key
   all_goals
     -- common start for both continuity proofs
-    have : (B ∩ s) ×ˢ (B ∩ s) ⊆ s ×ˢ s := by gcongr <;> exact inter_subset_right
+    have : (B ∩ s) ×ˢ (B ∩ s) ⊆ s ×ˢ s := by grw [inter_subset_right]
     obtain ⟨u_in, v_in⟩ : u ∈ closure s ∧ v ∈ closure s := by
       simpa [closure_prod_eq] using closure_mono this uv_in
     apply ContinuousWithinAt.mono _ this

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -545,8 +545,7 @@ lemma Subalgebra.frontier_subset_frontier :
     (spectrum.isClosed (x : A)).closure_eq]
   apply subset_inter (frontier_spectrum S x)
   rw [frontier_eq_closure_inter_closure]
-  exact inter_subset_right |>.trans <|
-    closure_mono <| compl_subset_compl.mpr <| spectrum.subset_subalgebra x
+  grw [inter_subset_right, spectrum.subset_subalgebra]
 
 open Set Notation
 
@@ -568,12 +567,8 @@ lemma Subalgebra.spectrum_sUnion_connectedComponentIn :
   suffices h_frontier : frontier (σ 𝕜 x \ σ 𝕜 (x : A)) ⊆ frontier (σ 𝕜 (x : A)) from
     disjoint_of_subset_left h_frontier <| disjoint_compl_right.frontier_left
       (spectrum.isClosed _).isOpen_compl
-  rw [sdiff_eq_compl_inter]
-  apply (frontier_inter_subset _ _).trans
-  rw [frontier_compl]
-  apply union_subset <| inter_subset_left
-  refine inter_subset_inter_right _ ?_ |>.trans <| inter_subset_right
-  exact frontier_subset_frontier S x
+  grw [sdiff_eq_compl_inter, frontier_inter_subset, inter_subset_left, inter_subset_right,
+    frontier_compl, frontier_subset_frontier, union_self]
 
 /-- Let `S` be a closed subalgebra of a Banach algebra `A`, and let `x : S`. If `z` is in the
 spectrum of `x`, then the connected component of `z` in the complement of the spectrum of `↑x : A`

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -369,17 +369,13 @@ theorem toReal_ofReal_eq_iff {a : ℝ} : (ENNReal.ofReal a).toReal = a ↔ 0 ≤
 
 @[simp] theorem zero_lt_top : 0 < ∞ := coe_lt_top
 
-@[simp, norm_cast] theorem coe_le_coe : (↑r : ℝ≥0∞) ≤ ↑q ↔ r ≤ q := WithTop.coe_le_coe
+@[simp, norm_cast, gcongr] theorem coe_le_coe : (↑r : ℝ≥0∞) ≤ ↑q ↔ r ≤ q := WithTop.coe_le_coe
 
-@[simp, norm_cast] theorem coe_lt_coe : (↑r : ℝ≥0∞) < ↑q ↔ r < q := WithTop.coe_lt_coe
+@[simp, norm_cast, gcongr] theorem coe_lt_coe : (↑r : ℝ≥0∞) < ↑q ↔ r < q := WithTop.coe_lt_coe
 
--- Needed until `@[gcongr]` accepts iff statements
-alias ⟨_, coe_le_coe_of_le⟩ := coe_le_coe
-attribute [gcongr] ENNReal.coe_le_coe_of_le
+@[deprecated (since := "2026-08-04")] alias ⟨_, coe_le_coe_of_le⟩ := coe_le_coe
 
--- Needed until `@[gcongr]` accepts iff statements
-alias ⟨_, coe_lt_coe_of_lt⟩ := coe_lt_coe
-attribute [gcongr] ENNReal.coe_lt_coe_of_lt
+@[deprecated (since := "2026-08-04")] alias ⟨_, coe_lt_coe_of_lt⟩ := coe_lt_coe
 
 theorem coe_mono : Monotone ofNNReal := fun _ _ => coe_le_coe.2
 

--- a/Mathlib/Data/Set/NAry.lean
+++ b/Mathlib/Data/Set/NAry.lean
@@ -316,21 +316,16 @@ lemma image2_right_identity {f : α → β → α} {b : β} (h : ∀ a, f a b = 
 theorem image2_inter_union_subset_union :
     image2 f (s ∩ s') (t ∪ t') ⊆ image2 f s t ∪ image2 f s' t' := by
   rw [image2_union_right]
-  exact
-    union_subset_union (image2_subset_right inter_subset_left)
-      (image2_subset_right inter_subset_right)
+  nth_grw 1 [inter_subset_left, inter_subset_right]
 
 theorem image2_union_inter_subset_union :
     image2 f (s ∪ s') (t ∩ t') ⊆ image2 f s t ∪ image2 f s' t' := by
   rw [image2_union_left]
-  exact
-    union_subset_union (image2_subset_left inter_subset_left)
-      (image2_subset_left inter_subset_right)
+  nth_grw 1 [inter_subset_left, inter_subset_right]
 
 theorem image2_inter_union_subset {f : α → α → β} {s t : Set α} (hf : ∀ a b, f a b = f b a) :
     image2 f (s ∩ t) (s ∪ t) ⊆ image2 f s t := by
-  rw [inter_comm]
-  exact image2_inter_union_subset_union.trans (union_subset (image2_comm hf).subset Subset.rfl)
+  grw [inter_comm, image2_inter_union_subset_union, image2_comm hf, union_self]
 
 theorem image2_union_inter_subset {f : α → α → β} {s t : Set α} (hf : ∀ a b, f a b = f b a) :
     image2 f (s ∪ t) (s ∩ t) ⊆ image2 f s t := by

--- a/Mathlib/Dynamics/OmegaLimit.lean
+++ b/Mathlib/Dynamics/OmegaLimit.lean
@@ -291,9 +291,7 @@ theorem nonempty_omegaLimit_of_isCompact_absorbing [NeBot f] {c : Set β} (hc₁
     exact hn.mono subset_closure
   · intro
     apply hc₁.of_isClosed_subset isClosed_closure
-    calc
-      _ ⊆ closure (image2 ϕ v s) := closure_mono (image2_subset inter_subset_right Subset.rfl)
-      _ ⊆ c := hv₂
+    grw [inter_subset_right, hv₂]
   · exact fun _ ↦ isClosed_closure
 
 theorem nonempty_omegaLimit [CompactSpace β] [NeBot f] (hs : s.Nonempty) : (ω f ϕ s).Nonempty :=

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -276,8 +276,9 @@ theorem ChartedSpace.locallyPathConnectedSpace [LocallyPathConnectedSpace H] :
     apply e.symm.image_mem_nhds (by simp [e])
     exact pathComponentIn_mem_nhds <| e.image_mem_nhds (mem_chart_source _ _) ht
   · refine (isPathConnected_pathComponentIn <| mem_image_of_mem e (mem_of_mem_nhds ht)).image' ?_
-    refine e.continuousOn_symm.mono <| subset_trans ?_ e.image_source_subset
-    exact (pathComponentIn_mono <| image_mono inter_subset_right).trans pathComponentIn_subset
+    refine e.continuousOn_symm.mono ?_
+    unfold t
+    grw [pathComponentIn_subset, inter_subset_right, e.image_source_subset]
   · exact (image_mono pathComponentIn_subset).trans
       (PartialEquiv.symm_image_image_of_subset_source _ inter_subset_right).subset
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -689,7 +689,7 @@ theorem eLpNorm_one_smul_measure {f : α → ε} (c : ℝ≥0∞) :
 theorem eLpNorm_le_of_measure_le_smul {c : ℝ≥0∞}
     {μ μ' : Measure α} (h : μ' ≤ c • μ) {f : α → ε} {p : ℝ≥0∞} :
     eLpNorm f p μ' ≤ c ^ (1 / p).toReal • eLpNorm f p μ := by
-  grw [eLpNorm_mono_measure f h, eLpNorm_smul_measure_le]
+  grw [h, eLpNorm_smul_measure_le]
 
 theorem MemLp.of_measure_le_smul {μ' : Measure α} {c : ℝ≥0∞} (hc : c ≠ ∞)
     (hμ'_le : μ' ≤ c • μ) {f : α → ε} (hf : MemLp f p μ) : MemLp f p μ' := by
@@ -708,12 +708,12 @@ theorem eLpNorm_one_add_measure (f : α → ε) (μ ν : Measure α) :
   rw [lintegral_add_measure _ μ ν]
 
 theorem eLpNorm_le_add_measure_right (f : α → ε) (μ ν : Measure α) {p : ℝ≥0∞} :
-    eLpNorm f p μ ≤ eLpNorm f p (μ + ν) :=
-  eLpNorm_mono_measure f <| Measure.le_add_right <| le_refl _
+    eLpNorm f p μ ≤ eLpNorm f p (μ + ν) := by
+  grw [← Measure.le_add_right le_rfl]
 
 theorem eLpNorm_le_add_measure_left (f : α → ε) (μ ν : Measure α) {p : ℝ≥0∞} :
-    eLpNorm f p ν ≤ eLpNorm f p (μ + ν) :=
-  eLpNorm_mono_measure f <| Measure.le_add_left <| le_refl _
+    eLpNorm f p ν ≤ eLpNorm f p (μ + ν) := by
+  grw [← Measure.le_add_left le_rfl]
 
 variable {ε : Type*} [ENorm ε] in
 lemma eLpNormEssSup_eq_iSup (hμ : ∀ a, μ {a} ≠ 0) (f : α → ε) : eLpNormEssSup f μ = ⨆ a, ‖f a‖ₑ :=

--- a/Mathlib/MeasureTheory/Measure/Stieltjes.lean
+++ b/Mathlib/MeasureTheory/Measure/Stieltjes.lean
@@ -131,6 +131,7 @@ initialize_simps_projections StieltjesFunction (toFun → apply)
 
 variable (f : StieltjesFunction R)
 
+@[gcongr]
 theorem mono : Monotone f :=
   f.mono'
 
@@ -296,13 +297,14 @@ theorem length_Ioc (a b : R) : f.length (Ioc a b) = ofReal (f b - f a) := by
     apply zero_le
   simp only [Ioc_sdiff_botSet] at h
   obtain ⟨h₁, h₂⟩ := (Ioc_subset_Ioc_iff ab).1 h
-  exact Real.toNNReal_le_toNNReal (sub_le_sub (f.mono h₁) (f.mono h₂))
+  grw [h₁, h₂]
 
+@[gcongr]
 theorem length_mono {s₁ s₂ : Set R} (h : s₁ ⊆ s₂) : f.length s₁ ≤ f.length s₂ := by
   rcases isEmpty_or_nonempty R with hR | hR
   · simp [length_eq_of_isEmpty]
   simp only [length_eq]
-  exact iInf_mono fun a => biInf_mono fun b h' => (sdiff_subset_sdiff_left h).trans h'
+  exact iInf_mono fun a => biInf_mono fun b => by gcongr
 
 theorem length_sdiff_botSet {s : Set R} : f.length (s \ botSet) = f.length s := by
   rcases isEmpty_or_nonempty R with hR | hR
@@ -355,9 +357,8 @@ theorem length_subadditive_Icc_Ioo {a b : R} {c d : ℕ → R} (ss : Icc a b ⊆
   rw [Finset.sum_insert (Finset.notMem_erase _ _)]
   replace bcd : b ∈ Ioc (c i) (d i) := Iotop_subset_Ioc bcd
   grw [← IH _ (Finset.erase_ssubset is) (c i), ← ENNReal.ofReal_add_le]
-  · gcongr
-    rw [sub_add_sub_cancel]
-    exact sub_le_sub_right (f.mono bcd.2) _
+  · rw [sub_add_sub_cancel]
+    grw [bcd.2]
   · rintro x ⟨h₁, h₂⟩
     apply (cv ⟨h₁, le_trans h₂ (le_of_lt bcd.1)⟩).resolve_left (fun h ↦ ?_)
     order [(Iotop_subset_Ioc h).1]
@@ -450,10 +451,7 @@ theorem measurableSet_Ioi {c : R} : MeasurableSet[f.outer.caratheodory] (Ioi c) 
   simp only [← length_eq]
   rw [← length_sdiff_botSet, inter_sdiff_right_comm, ← length_sdiff_botSet (s := t \ Ioi c),
     sdiff_sdiff_comm]
-  refine
-    le_trans
-      (add_le_add (f.length_mono <| inter_subset_inter_left _ h)
-        (f.length_mono <| sdiff_subset_sdiff_left h)) ?_
+  grw [h]
   rcases le_total a c with hac | hac <;> rcases le_total b c with hbc | hbc
   · simp only [Ioc_inter_Ioi, f.length_Ioc, hac, hbc, le_refl, Ioc_eq_empty,
       max_eq_right, min_eq_left, Ioc_sdiff_Ioi, f.length_empty, zero_add, not_lt]

--- a/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
@@ -211,6 +211,7 @@ lemma variation_transpose_eq_smul [Nontrivial E] {C : ℝ≥0}
       simp only [flip_apply, hB] at this
       rw [mul_right_comm, mul_le_mul_iff_left₀ (by simpa), ← le_div_iff₀' (by positivity),
         div_eq_inv_mul] at this
+      change ENNReal.ofNNReal _ ≤ ENNReal.ofNNReal _
       gcongr
     grw [this, enorm_measure_le_variation, Measure.smul_apply]
 

--- a/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
@@ -211,7 +211,7 @@ lemma variation_transpose_eq_smul [Nontrivial E] {C : ℝ≥0}
       simp only [flip_apply, hB] at this
       rw [mul_right_comm, mul_le_mul_iff_left₀ (by simpa), ← le_div_iff₀' (by positivity),
         div_eq_inv_mul] at this
-      exact ENNReal.coe_le_coe_of_le this
+      gcongr
     grw [this, enorm_measure_le_variation, Measure.smul_apply]
 
 lemma variation_transpose_eq [Nontrivial E] (hB : ∀ x y, ‖B x y‖₊ = ‖x‖₊ * ‖y‖₊) :


### PR DESCRIPTION
Use `grw`/`gcongr` to golf some proofs. Additionally, deprecate `ENNReal.coe_le_coe_of_le`/`ENNReal.coe_lt_coe_of_lt`, as `gcongr` can now be used on iff lemmas.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
