### PR TITLE
feat(RingTheory/RootsOfUnity/Complex): add Fintype instance for complex roots of unity

### DIFF
--- a/Mathlib/RingTheory/RootsOfUnity/Complex.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Complex.lean
@@ -213,3 +213,11 @@ theorem Complex.conj_rootsOfUnity {ζ : ℂˣ} {n : ℕ} [NeZero n] (hζ : ζ �
     (starRingEnd ℂ) ζ = ζ⁻¹ := by
   rw [← Units.mul_eq_one_iff_eq_inv, conj_mul', norm_eq_one_of_mem_rootsOfUnity hζ, ofReal_one,
     one_pow]
+
+noncomputable instance {n : ℕ} [NeZero n] : Fintype (rootsOfUnity n ℂ) where
+  elems := Finset.univ.image fun (i : Fin n) =>
+    ⟨Units.mk0 _ (Complex.exp_ne_zero _), (Complex.mem_rootsOfUnity n _).mpr ⟨i, i.isLt, rfl⟩⟩
+  complete := by
+    rintro ⟨x, hx⟩
+    obtain ⟨i, hi, h_eq⟩ := (Complex.mem_rootsOfUnity n x).mp hx
+    exact Finset.mem_image.mpr ⟨⟨i, hi⟩, Finset.mem_univ _, by ext; exact h_eq⟩


### PR DESCRIPTION



---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
