### PR TITLE
[Merged by Bors] - chore(Data/List/Lookmap): remove `import all`

### DIFF
--- a/Mathlib/Data/List/Lookmap.lean
+++ b/Mathlib/Data/List/Lookmap.lean
@@ -28,7 +28,7 @@ private theorem lookmap.go_append (l : List α) (acc : Array α) :
     | none =>
       simp only [go_append tl _, Array.toListAppend_eq, append_assoc, Array.toList_push]
       rfl
-    | some a => simp only [Array.toListAppend_eq, nil_append]
+    | some a => simp
 
 @[simp, grind =]
 theorem lookmap_nil : [].lookmap f = [] :=

--- a/Mathlib/Data/List/Lookmap.lean
+++ b/Mathlib/Data/List/Lookmap.lean
@@ -5,10 +5,8 @@ Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, M
 -/
 module
 
-public import Batteries.Logic
 public import Batteries.Data.List.Basic
 public import Mathlib.Init
-import all Init.Data.Array.Basic
 
 /-! ### lookmap -/
 
@@ -30,7 +28,7 @@ private theorem lookmap.go_append (l : List α) (acc : Array α) :
     | none =>
       simp only [go_append tl _, Array.toListAppend_eq, append_assoc, Array.toList_push]
       rfl
-    | some a => rfl
+    | some a => simp only [Array.toListAppend_eq, nil_append]
 
 @[simp, grind =]
 theorem lookmap_nil : [].lookmap f = [] :=
@@ -40,7 +38,7 @@ theorem lookmap_nil : [].lookmap f = [] :=
 theorem lookmap_cons_none {a : α} (l : List α) (h : f a = none) :
     (a :: l).lookmap f = a :: l.lookmap f := by
   simp only [lookmap, lookmap.go, Array.toListAppend_eq, nil_append]
-  rw [lookmap.go_append, h]; rfl
+  rw [lookmap.go_append, lookmap, h]; simp
 
 @[simp]
 theorem lookmap_cons_some {a b : α} (l : List α) (h : f a = some b) :
@@ -57,11 +55,11 @@ theorem lookmap_cons {a : α} {l : List α} :
 
 theorem lookmap_some : ∀ l : List α, l.lookmap some = l
   | [] => rfl
-  | _ :: _ => rfl
+  | _ :: rest => lookmap_cons_some some rest rfl
 
 theorem lookmap_none : ∀ l : List α, (l.lookmap fun _ => none) = l
   | [] => rfl
-  | a :: l => (lookmap_cons_none _ l rfl).trans (congr_arg (cons a) (lookmap_none l))
+  | a :: l => (lookmap_cons_none _ l rfl).trans (congrArg (cons a) (lookmap_none l))
 
 theorem lookmap_congr {f g : α → Option α} :
     ∀ {l : List α}, (∀ a ∈ l, f a = g a) → l.lookmap f = l.lookmap g


### PR DESCRIPTION
This PR removes an unnecessary `import all` and further minimizes imports in `Mathlib.Data.List.Lookmap`. Found while exploring uses of `import all` in mathlib.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
