### PR TITLE
[Merged by Bors] - chore(Data/List/ModifyLast): remove `import all`

### DIFF
--- a/Mathlib/Data/List/ModifyLast.lean
+++ b/Mathlib/Data/List/ModifyLast.lean
@@ -6,9 +6,7 @@ Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, M
 module
 
 public import Batteries.Data.List.Basic
-public import Batteries.Tactic.Alias
 public import Mathlib.Init
-import all Init.Data.Array.Basic
 
 /-! ### List.modifyLast -/
 
@@ -22,7 +20,7 @@ private theorem modifyLast.go_concat (f : α → α) (a : α) (tl : List α) (r 
     modifyLast.go f (tl ++ [a]) r = (r.toListAppend <| modifyLast.go f (tl ++ [a]) #[]) := by
   cases tl with
   | nil =>
-    simp only [nil_append, modifyLast.go]; rfl
+    simp only [nil_append, modifyLast.go]; simp
   | cons hd tl =>
     simp only [cons_append]
     rw [modifyLast.go, modifyLast.go]
@@ -50,7 +48,9 @@ theorem modifyLast_append_of_right_ne_nil (f : α → α) (l₁ l₂ : List α) 
   | nil => contradiction
   | cons hd tl =>
     cases tl with
-    | nil => exact modifyLast_concat _ hd _
+    | nil =>
+      simp only [modifyLast, modifyLast.go, Array.toListAppend_eq, nil_append]
+      exact modifyLast_concat _ hd _
     | cons hd' tl' =>
       rw [append_cons, ← nil_append (hd :: hd' :: tl'), append_cons [], nil_append,
         modifyLast_append_of_right_ne_nil _ (l₁ ++ [hd]) (hd' :: tl') _,


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
