### PR TITLE
chore: remove or annotate `import all`s

### DIFF
--- a/Mathlib/Control/Monad/Cont.lean
+++ b/Mathlib/Control/Monad/Cont.lean
@@ -10,7 +10,6 @@ public import Mathlib.Control.Monad.Writer
 public import Mathlib.Control.Lawful
 public import Batteries.Tactic.Congr
 public import Batteries.Lean.Except
-import all Init.Control.Option  -- for unfolding `Option.lift`
 
 /-!
 # Continuation Monad

--- a/Mathlib/Data/Fintype/Parity.lean
+++ b/Mathlib/Data/Fintype/Parity.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Data.Fintype.Card
 public import Mathlib.Algebra.Group.Even
-import all Init.Data.Fin.Fold  -- for exposing `Fin.foldr`
 
 /-!
 # The cardinality of `Fin 2` is even.

--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -10,7 +10,6 @@ public import Mathlib.Data.Nat.Bitwise
 public import Mathlib.Data.Nat.Size
 public import Batteries.Data.Int
 import all Init.Data.Nat.Bitwise.Basic  -- for unfolding `Nat.bitwise`
-import all Init.Data.Int.Bitwise.Basic  -- for unfolding `Int.bitwise`
 
 /-!
 # Bitwise operations on integers

--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Encode.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Encode.lean
@@ -6,9 +6,7 @@ Authors: Jovan Gerbscheid
 module
 
 public import Mathlib.Lean.Meta.RefinedDiscrTree.Basic
-public import Lean.Meta.DiscrTree
 public import Lean.Meta.LazyDiscrTree
-import all Lean.Meta.DiscrTree
 
 /-!
 # Encoding an `Expr` as a sequence of `Key`s

--- a/Mathlib/Tactic/Cases.lean
+++ b/Mathlib/Tactic/Cases.lean
@@ -8,7 +8,7 @@ module
 public meta import Lean.Elab.Tactic.Induction
 public meta import Batteries.Data.List.Basic
 public meta import Batteries.Lean.Expr
-import all Lean.Elab.Tactic.Induction
+import all Lean.Elab.Tactic.Induction -- for `getElimNameInfo`
 public import Mathlib.Init
 
 /-!

--- a/Mathlib/Tactic/FieldSimp/Discharger.lean
+++ b/Mathlib/Tactic/FieldSimp/Discharger.lean
@@ -5,7 +5,7 @@ Authors: Sébastien Gouëzel, David Renshaw
 -/
 module
 
-import all Lean.Meta.Tactic.Simp.Rewrite
+import all Lean.Meta.Tactic.Simp.Rewrite -- for `Simp.dischargeUsingAssumption?`
 public import Mathlib.Tactic.Positivity.Core
 public import Mathlib.Util.DischargerAsTactic
 

--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -13,8 +13,6 @@ public import Mathlib.Order.Defs.Unbundled
 public import Mathlib.Tactic.Core
 public import Mathlib.Tactic.GCongr.ForwardAttr
 
-import all Lean.Meta.Tactic.Apply
-
 /-!
 # The `gcongr` ("generalized congruence") tactic
 

--- a/Mathlib/Tactic/PNatToNat.lean
+++ b/Mathlib/Tactic/PNatToNat.lean
@@ -5,10 +5,8 @@ Authors: Vasilii Nesterov
 -/
 module
 
-import all Lean.Elab.Tactic.Induction
 public import Mathlib.Data.PNat.Basic
 public meta import Mathlib.Tactic.ToAdditive
-
 
 /-!
 # `pnat_to_nat`

--- a/Mathlib/Tactic/WLOG.lean
+++ b/Mathlib/Tactic/WLOG.lean
@@ -6,7 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Johan Commelin, Reid Barton, Thomas Mu
 module
 
 public meta import Lean.Meta.Tactic.Cases
-import all Lean.MetavarContext
+import all Lean.MetavarContext -- for `mkAuxMVarType`
 public import Mathlib.Tactic.Core
 public import Mathlib.Tactic.Push
 


### PR DESCRIPTION
This PR removes immediately removable `import all` and adds a comment to un-annotated unremovable `import all`s explaining what they're for (except for `import all Mathlib.NumberTheory.Height.Basic` in `Mathlib.NumberTheory.Height.MvPolynomial`, which seems to depend on multiple parts of the private interface).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
