### PR TITLE
[Merged by Bors] - perf(SimpleGraph/Walk/Operations): avoid costly `grind` in `drop_drop`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Operations.lean
@@ -699,7 +699,8 @@ lemma drop_support_eq_support_drop_min {u v} (p : G.Walk u v) (n : ℕ) :
 theorem drop_drop (p : G.Walk u v) (n m : ℕ) :
     (p.drop n).drop m = (p.drop (n + m)).copy (drop_getVert ..).symm rfl := by
   apply ext_support
-  grind [support_copy, drop_support_eq_support_drop_min, drop_length, List.drop_drop]
+  simp_rw [support_copy, drop_support_eq_support_drop_min, drop_length, List.drop_drop]
+  grind
 
 @[simp]
 theorem append_take_drop_eq (p : G.Walk u v) (n : ℕ) : (p.take n).append (p.drop n) = p := by


### PR DESCRIPTION
[#rss > Significant commits to mathlib4 @ 💬](https://leanprover.zulipchat.com/#narrow/channel/116290-rss/topic/Significant.20commits.20to.20mathlib4/near/614840976)

Something in v4.33.0 seems to have made this `grind` call ~25x slower, taking about 5 seconds now.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
