### PR TITLE
feat(Probability/Decision): add data processing inequalities for minimax risk

### DIFF
--- a/Mathlib/Probability/Decision/Risk/Basic.lean
+++ b/Mathlib/Probability/Decision/Risk/Basic.lean
@@ -17,6 +17,9 @@ public import Mathlib.Probability.Kernel.Composition.MeasureComp
 * `bayesRisk_le_bayesRisk_comp`: data-processing inequality for the Bayes risk with respect to a
   prior: if we compose the data generating kernel `P` with a Markov kernel, then the Bayes risk
   increases.
+* `minimaxRisk_le_minimaxRisk_comp`, `minimaxRisk_le_minimaxRisk_map`,
+  `minimaxRisk_compProd_le_minimaxRisk`: analogous data-processing inequalities for the minimax
+  risk.
 * `bayesRisk_le_iInf`: for `P` a Markov kernel, the Bayes risk is less than `⨅ y, ∫⁻ θ, ℓ θ y ∂π`.
 
 In several cases, there is no information in the data about the parameter and the Bayes risk takes
@@ -256,6 +259,34 @@ lemma bayesRisk_compProd_le_bayesRisk (ℓ : Θ → 𝓨 → ℝ≥0∞) (P : Ke
     rw [Kernel.deterministic_comp_eq_map, ← Kernel.fst_eq, Kernel.fst_compProd]
   nth_rw 2 [this]
   exact bayesRisk_le_bayesRisk_comp _ _ _ _
+
+/-- **Data processing inequality** for the minimax risk: composition of the data generating
+kernel by a Markov kernel increases the risk. -/
+lemma minimaxRisk_le_minimaxRisk_comp (ℓ : Θ → 𝓨 → ℝ≥0∞) (P : Kernel Θ 𝓧)
+    (η : Kernel 𝓧 𝓧') [IsMarkovKernel η] :
+    minimaxRisk ℓ P ≤ minimaxRisk ℓ (η ∘ₖ P) := by
+  simp only [minimaxRisk, le_iInf_iff]
+  intro κ hκ
+  rw [← κ.comp_assoc η]
+  exact iInf_le_of_le (κ ∘ₖ η) (iInf_le_of_le inferInstance le_rfl)
+
+/-- **Data processing inequality** for the minimax risk: taking the map of the data generating
+kernel by a function increases the risk. -/
+lemma minimaxRisk_le_minimaxRisk_map (ℓ : Θ → 𝓨 → ℝ≥0∞) (P : Kernel Θ 𝓧)
+    {f : 𝓧 → 𝓧'} (hf : Measurable f) :
+    minimaxRisk ℓ P ≤ minimaxRisk ℓ (P.map f) := by
+  rw [← Kernel.deterministic_comp_eq_map hf]
+  exact minimaxRisk_le_minimaxRisk_comp _ _ _
+
+/-- Observing richer data cannot increase the minimax risk: the enriched experiment `P ⊗ₖ η` has
+minimax risk at most that of `P`. -/
+lemma minimaxRisk_compProd_le_minimaxRisk (ℓ : Θ → 𝓨 → ℝ≥0∞) (P : Kernel Θ 𝓧)
+    [IsSFiniteKernel P] (η : Kernel (Θ × 𝓧) 𝓧') [IsMarkovKernel η] :
+    minimaxRisk ℓ (P ⊗ₖ η) ≤ minimaxRisk ℓ P := by
+  have : P = (Kernel.deterministic Prod.fst (by fun_prop)) ∘ₖ (P ⊗ₖ η) := by
+    rw [Kernel.deterministic_comp_eq_map, ← Kernel.fst_eq, Kernel.fst_compProd]
+  nth_rw 2 [this]
+  exact minimaxRisk_le_minimaxRisk_comp _ _ _
 
 end Compositions
 


### PR DESCRIPTION
This PR adds the minimax analogs of the three data processing inequalities for the Bayes risk in Mathlib.Probability.Decision.Risk.Basic.
It is similar to the compositions section in PR #29143, but with minimax.

-----------

Claude Fable 5 wrote the code and GPT 5.6 Sol reviewed the code. This was written for a different project, and I identified this as a candidate for upstreaming into Mathlib.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
