### PR TITLE
[Merged by Bors] - feat(Data/Finset/Powerset): `powersetCard_inter` and `disjoint_powersetCard_powersetCard`

### DIFF
--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -202,7 +202,7 @@ def powersetCard (n : ℕ) (s : Finset α) : Finset (Finset α) :=
 @[simp, grind =] lemma mem_powersetCard : s ∈ powersetCard n t ↔ s ⊆ t ∧ card s = n := by
   cases s; simp [powersetCard, val_le_iff.symm]
 
-@[simp]
+@[simp, gcongr]
 theorem powersetCard_mono {n} {s t : Finset α} (h : s ⊆ t) : powersetCard n s ⊆ powersetCard n t :=
   fun _u h' => mem_powersetCard.2 <|
     And.imp (fun h₂ => Subset.trans h₂ h) id (mem_powersetCard.1 h')
@@ -268,6 +268,14 @@ lemma powersetCard_eq_empty : powersetCard n s = ∅ ↔ s.card < n := by
 
 @[simp] lemma powersetCard_card_add (s : Finset α) (hn : 0 < n) :
     s.powersetCard (s.card + n) = ∅ := by simpa
+
+lemma powersetCard_inter [DecidableEq α] (s t : Finset α) (n : ℕ) :
+    powersetCard n (s ∩ t) = powersetCard n s ∩ powersetCard n t := by
+  ext; simpa [subset_inter_iff] using and_and_right
+
+@[simp] lemma disjoint_powersetCard_powersetCard [DecidableEq α] (s t : Finset α) (n : ℕ) :
+    Disjoint (powersetCard n s) (powersetCard n t) ↔ #(s ∩ t) < n := by
+  simp [disjoint_iff_inter_eq_empty, ← powersetCard_inter]
 
 theorem powersetCard_eq_filter {n} {s : Finset α} :
     powersetCard n s = (powerset s).filter fun x => x.card = n := by


### PR DESCRIPTION
Add `Finset.powersetCard_inter` and `Finset.disjoint_powersetCard_powersetCard`, and tag `Finset.powersetCard_mono` with `@[gcongr]`.

Ported from Formal Conjecture's ForMathlib, original PR is https://github.com/google-deepmind/formal-conjectures/pull/1428.

Co-authored-by: Yaël Dillies <yael.dillies@gmail.com>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
