### PR TITLE
[Merged by Bors] - chore: add `to_fun` tag to theorems on logarithmic derivations

### DIFF
--- a/Mathlib/Analysis/Calculus/LogDeriv.lean
+++ b/Mathlib/Analysis/Calculus/LogDeriv.lean
@@ -81,14 +81,16 @@ theorem logDeriv_const (a : 𝕜') : logDeriv (fun _ : 𝕜 ↦ a) = 0 := by
   ext
   simp [logDeriv_apply]
 
+@[to_fun logDeriv_fun_mul]
 theorem logDeriv_mul {f g : 𝕜 → 𝕜'} (x : 𝕜) (hf : f x ≠ 0) (hg : g x ≠ 0)
     (hdf : DifferentiableAt 𝕜 f x) (hdg : DifferentiableAt 𝕜 g x) :
-      logDeriv (fun z => f z * g z) x = logDeriv f x + logDeriv g x := by
+      logDeriv (f * g) x = logDeriv f x + logDeriv g x := by
   simp [field, logDeriv_apply, *]
 
+@[to_fun logDeriv_fun_div]
 theorem logDeriv_div {f g : 𝕜 → 𝕜'} (x : 𝕜) (hf : f x ≠ 0) (hg : g x ≠ 0)
     (hdf : DifferentiableAt 𝕜 f x) (hdg : DifferentiableAt 𝕜 g x) :
-    logDeriv (fun z => f z / g z) x = logDeriv f x - logDeriv g x := by
+    logDeriv (f / g) x = logDeriv f x - logDeriv g x := by
   simp [field, logDeriv_apply, *]
 
 theorem logDeriv_mul_const {f : 𝕜 → 𝕜'} (x : 𝕜) (a : 𝕜') (ha : a ≠ 0) :
@@ -100,19 +102,19 @@ theorem logDeriv_const_mul {f : 𝕜 → 𝕜'} (x : 𝕜) (a : 𝕜') (ha : a �
   simp only [logDeriv_apply, deriv_const_mul_field, mul_div_mul_left _ _ ha]
 
 /-- The logarithmic derivative of a finite product is the sum of the logarithmic derivatives. -/
+@[to_fun logDeriv_fun_prod]
 theorem logDeriv_prod {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → 𝕜'} {x : 𝕜} (hf : ∀ i ∈ s, f i x ≠ 0)
     (hd : ∀ i ∈ s, DifferentiableAt 𝕜 (f i) x) :
-    logDeriv (∏ i ∈ s, f i ·) x = ∑ i ∈ s, logDeriv (f i) x := by
+    logDeriv (∏ i ∈ s, f i) x = ∑ i ∈ s, logDeriv (f i) x := by
   induction s using Finset.cons_induction with
-  | empty => simp
+  | empty => simp [Pi.one_def]
   | cons a s ha ih =>
     rw [Finset.forall_mem_cons] at hf hd
-    simp_rw [Finset.prod_cons, Finset.sum_cons]
-    rw [logDeriv_mul, ih hf.2 hd.2]
+    rw [Finset.prod_cons, Finset.sum_cons, logDeriv_mul, ih hf.2 hd.2]
     · exact hf.1
     · simpa [Finset.prod_eq_zero_iff] using hf.2
     · exact hd.1
-    · exact .fun_finsetProd hd.2
+    · exact .finsetProd hd.2
 
 lemma logDeriv_fun_zpow {f : 𝕜 → 𝕜'} {x : 𝕜} (hdf : DifferentiableAt 𝕜 f x) (n : ℤ) :
     logDeriv (f · ^ n) x = n * logDeriv f x := by

--- a/Mathlib/Analysis/Calculus/LogDerivUniformlyOn.lean
+++ b/Mathlib/Analysis/Calculus/LogDerivUniformlyOn.lean
@@ -29,4 +29,4 @@ theorem logDeriv_tprod_eq_tsum {ι : Type*} {s : Set ℂ} (hs : IsOpen s) {x : �
   rw [Eq.comm, ← hm.hasSum_iff]
   refine logDeriv_tendsto hs hx htend.hasProdLocallyUniformlyOn (.of_forall <| by fun_prop) hnez
     |>.congr fun b ↦ ?_
-  rw [logDeriv_prod (fun i _ ↦ hf i) (fun i _ ↦ (hd i x hx).differentiableAt (hs.mem_nhds hx))]
+  rw [logDeriv_fun_prod (fun i _ ↦ hf i) (fun i _ ↦ (hd i x hx).differentiableAt (hs.mem_nhds hx))]

--- a/Mathlib/Analysis/Meromorphic/LogDeriv.lean
+++ b/Mathlib/Analysis/Meromorphic/LogDeriv.lean
@@ -42,7 +42,7 @@ theorem MeromorphicOn.logDeriv_mul_eventuallyEq (hf : MeromorphicOn f U) (hg : M
     hf.eventually_codiscreteWithin_apply_ne_zero h'f,
     hg.eventually_codiscreteWithin_apply_ne_zero h'g]
     with y h₁y h₂y h₃y h₄y
-  rw [Pi.add_apply, Pi.mul_def]
+  rw [Pi.add_apply]
   exact logDeriv_mul y h₃y h₄y h₁y.differentiableAt h₂y.differentiableAt
 
 /--
@@ -73,7 +73,7 @@ theorem MeromorphicOn.logDeriv_prod_eventuallyEq {ι : Type*} {s : Finset ι} {F
     (eventually_all_finset s).2 fun i hi ↦ (h i hi).eventually_codiscreteWithin_apply_ne_zero
       (h' i hi)
   filter_upwards [hA, hN] with y h₁y h₂y
-  rw [Finset.sum_apply, Finset.prod_fn]
+  rw [Finset.sum_apply]
   exact logDeriv_prod h₂y fun i hi ↦ (h₁y i hi).differentiableAt
 
 /--
@@ -158,7 +158,7 @@ theorem MeromorphicOn.logDeriv_finprod_zpow_eventuallyEq {ι : Type*} {F : ι �
   have hsub : support (fun i ↦ d i • logDeriv (F i) y) ⊆ hd.toFinset := by
     simp +contextual [-support_mul, -mul_eq_zero, Set.subset_def, not_imp_not]
   calc logDeriv (∏ᶠ i, F i ^ d i) y
-      = logDeriv (fun z ↦ ∏ i ∈ hd.toFinset, (F i ^ d i) z) y := by rw [h₀, Finset.prod_fn]
+      = logDeriv (∏ i ∈ hd.toFinset, F i ^ d i) y := by rw [h₀]
     _ = ∑ i ∈ hd.toFinset, logDeriv (F i ^ d i) y :=
         logDeriv_prod (fun i hi ↦ zpow_ne_zero _ (h₂y i hi))
           (fun i hi ↦ ((h₁y i hi).zpow (h₂y i hi)).differentiableAt)

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Cotangent.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Cotangent.lean
@@ -160,7 +160,7 @@ lemma logDeriv_sin_div_eq_cot (hz : x ∈ ℂ_ℤ) :
     logDeriv (fun t ↦ (Complex.sin (π * t) / (π * t))) x = π * cot (π * x) - 1 / x := by
   have : (fun t ↦ (Complex.sin (π * t) / (π * t))) = fun z ↦
     (Complex.sin ∘ fun t ↦ π * t) z / (π * z) := by simp
-  rw [this, logDeriv_div _ (by apply sin_pi_mul_ne_zero hz) ?_
+  rw [this, logDeriv_fun_div _ (by apply sin_pi_mul_ne_zero hz) ?_
     (DifferentiableAt.comp _ (Complex.differentiableAt_sin) (by fun_prop)) (by fun_prop),
     logDeriv_comp (Complex.differentiableAt_sin) (by fun_prop), Complex.logDeriv_sin,
     deriv_const_mul_id, logDeriv_const_mul, logDeriv_id']
@@ -189,7 +189,7 @@ lemma logDeriv_sineTerm_eq_cotTerm (hx : x ∈ ℂ_ℤ) (i : ℕ) :
 lemma logDeriv_prod_sineTerm_eq_sum_cotTerm (hx : x ∈ ℂ_ℤ) (n : ℕ) :
     logDeriv (fun (z : ℂ) ↦ ∏ j ∈ Finset.range n, (1 + sineTerm z j)) x =
     ∑ j ∈ Finset.range n, cotTerm x j := by
-  rw [logDeriv_prod]
+  rw [logDeriv_fun_prod]
   · simp_rw [logDeriv_sineTerm_eq_cotTerm hx]
   · exact fun i _ ↦ sineTerm_ne_zero hx i
   · fun_prop

--- a/Mathlib/NumberTheory/ModularForms/DedekindEta.lean
+++ b/Mathlib/NumberTheory/ModularForms/DedekindEta.lean
@@ -168,7 +168,7 @@ lemma summable_logDeriv_one_sub_eta_q {z : ℂ} (hz : z ∈ ℍₒ) :
 open EisensteinSeries in
 lemma logDeriv_eta_eq_E2 (z : ℍ) : logDeriv eta z = (π * I / 12) * E2 z := by
   unfold eta
-  rw [logDeriv_mul _ (Periodic.qParam_ne_zero _) (eta_tprod_ne_zero z.2) (by fun_prop)
+  rw [logDeriv_fun_mul _ (Periodic.qParam_ne_zero _) (eta_tprod_ne_zero z.2) (by fun_prop)
     (differentiableAt_eta_tprod z.2)]
   have HG := logDeriv_tprod_eq_tsum isOpen_upperHalfPlaneSet z.2
     (one_sub_eta_q_ne_zero · z.2) (by fun_prop) (summable_logDeriv_one_sub_eta_q z.2)

--- a/Mathlib/NumberTheory/ModularForms/Discriminant.lean
+++ b/Mathlib/NumberTheory/ModularForms/Discriminant.lean
@@ -74,7 +74,7 @@ lemma logDeriv_eta_comp_div_eq (z : ℍ) :
 open EisensteinSeries in
 lemma logDeriv_eta_comp_eq_logDeriv_csqrt_eta (z : ℍ) :
     logDeriv (η ∘ (-1 / ·)) z = logDeriv (sqrt * η) z := by
-  rw [logDeriv_eta_comp_div_eq z, Pi.mul_def,
+  rw [logDeriv_eta_comp_div_eq z,
       logDeriv_mul _ (by simp [sqrt, ne_zero z]) (eta_ne_zero z.2)
       (differentiableAt_sqrt (mem_slitPlane z))
       (differentiableAt_eta_of_mem_upperHalfPlaneSet z.2), logDeriv_apply sqrt]


### PR DESCRIPTION
Following a discussion with @j-loreaux, add `to_fun` tag to theorems on logarithmic derivations.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
