### PR TITLE
feat: support inferring a model with corners on Complex.UnitDisc

### DIFF
--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -394,6 +394,7 @@ partial def findModelInner (e : Expr) : TermElabM (Option FindModelResult) := do
   if let some m ← tryStrategy "RealInterval"        fromRealInterval    then return some m
   if let some m ← tryStrategy "EuclideanSpace"      fromEuclideanSpace  then return some m
   if let some m ← tryStrategy "UpperHalfPlane"      fromUpperHalfPlane  then return some m
+  if let some m ← tryStrategy "ComplexUnitDisc"     fromUnitDisc        then return some m
   if let some m ← tryStrategy "Units of algebra"    fromUnitsOfAlgebra  then return some m
   if let some m ← tryStrategy "Complex unit circle" fromCircle          then return some m
   if let some m ← tryStrategy "Sphere"              fromSphere          then return some m
@@ -526,21 +527,28 @@ where
         -- Euclidean space, a normed space or a normed field.
         if let some m ← tryFromEuclideanSpace H then
           return m
-        else
-          trace[Elab.DiffGeo.MDiff] "`{H}` is not a Euclidean space, half-space or quadrant"
-          let a ← findSomeLocalInstanceOf? ``NormedSpace fun inst type ↦ do
-            match_expr type with
-            | NormedSpace K E _ _ =>
-              if ← withReducible (pureIsDefEq E H) then return some (inst, K)
-              else return none
-            | _ => return none
-          if let some (inst, K) := a then
-            trace[Elab.DiffGeo.MDiff] "`{H}` is a normed space over the field `{K}`"
-            return ← mkAppOptM ``modelWithCornersSelf #[K, none, H, none, inst]
-          trace[Elab.DiffGeo.MDiff] "Couldn't find a normed space structure on {H}` either: \
-            assuming it is a non-trivially normed field"
-          -- Return the trivial model with corners: this will work if `H` is a normed field.
-          mkAppOptM ``modelWithCornersSelf #[H, none, H, none, none]
+        else if H.isConstOf `UpperHalfPlane || H.isConstOf `Complex.UnitDisc then
+          trace[Elab.DiffGeo.MDiff] "`{H}` is the complex upper half plane or the unit disc"
+          return ← mkAppOptM ``modelWithCornersSelf
+            #[mkConst `Complex, none, mkConst `Complex, none, none]
+        else if H.isConstOf `Circle then
+          trace[Elab.DiffGeo.MDiff] "`{H}` is the complex unit circle"
+          return ← mkAppOptM ``modelWithCornersSelf
+            #[mkConst `Real, none, ← mkAppM `EuclideanSpace #[q(ℝ), q(Fin 1)], none, none]
+        trace[Elab.DiffGeo.MDiff] "`{H}` is not a Euclidean space, half-space or quadrant"
+        let a ← findSomeLocalInstanceOf? ``NormedSpace fun inst type ↦ do
+          match_expr type with
+          | NormedSpace K E _ _ =>
+            if ← withReducible (pureIsDefEq E H) then return some (inst, K)
+            else return none
+          | _ => return none
+        if let some (inst, K) := a then
+          trace[Elab.DiffGeo.MDiff] "`{H}` is a normed space over the field `{K}`"
+          return ← mkAppOptM ``modelWithCornersSelf #[K, none, H, none, inst]
+        trace[Elab.DiffGeo.MDiff] "Couldn't find a normed space structure on {H}` either: \
+          assuming it is a non-trivially normed field"
+        -- Return the trivial model with corners: this will work if `H` is a normed field.
+        mkAppOptM ``modelWithCornersSelf #[H, none, H, none, none]
     return m
   /-- Attempt to find a model with corners on a space of continuous linear maps -/
   -- Note that (continuous) linear equivalences are not an abelian group, so are not a model with
@@ -556,6 +564,12 @@ where
   fromEuclideanSpace : TermElabM Expr := do
     if let some m ← tryFromEuclideanSpace e then return m else
     throwError "`{e}` is not a Euclidean space, half-space or quadrant"
+  /-- Attempt to find a model with corners on the complex unit disc -/
+  fromUnitDisc : TermElabM Expr := do
+    -- We don't use `match_expr` to avoid importing `UpperHalfPlane`.
+    if (← instantiateMVars e).cleanupAnnotations.isConstOf `Complex.UnitDisc then
+      mkAppOptM ``modelWithCornersSelf #[mkConst `Complex, none, mkConst `Complex, none, none]
+    else throwError "`{e}` is not the complex unit disc"
   /-- Attempt to find a model with corners on a closed interval of real numbers,
   or on the unit interval of real numbers -/
   fromRealInterval : TermElabM Expr := do

--- a/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Advanced.lean
@@ -1,3 +1,4 @@
+import Mathlib.Analysis.Complex.UnitDisc.Basic
 import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
 import Mathlib.Geometry.Manifold.Instances.Real
 import Mathlib.Geometry.Manifold.Instances.UnitsOfNormedAlgebra
@@ -366,6 +367,9 @@ trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `M`
 [Elab.DiffGeo.MDiff] 💥️ UpperHalfPlane
   [Elab.DiffGeo.MDiff] Failed with error:
       `ContinuousLinearMap id' E'' E'''` is not the complex upper half plane
+[Elab.DiffGeo.MDiff] 💥️ ComplexUnitDisc
+  [Elab.DiffGeo.MDiff] Failed with error:
+      `ContinuousLinearMap id' E'' E'''` is not the complex unit disc
 [Elab.DiffGeo.MDiff] 💥️ Units of algebra
   [Elab.DiffGeo.MDiff] Failed with error:
       `ContinuousLinearMap id' E'' E'''` is not a set of units, in particular not of a complete normed algebra
@@ -468,6 +472,9 @@ trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `M`
 [Elab.DiffGeo.MDiff] 💥️ UpperHalfPlane
   [Elab.DiffGeo.MDiff] Failed with error:
       `ContinuousLinearMap σ E'' E''''` is not the complex upper half plane
+[Elab.DiffGeo.MDiff] 💥️ ComplexUnitDisc
+  [Elab.DiffGeo.MDiff] Failed with error:
+      `ContinuousLinearMap σ E'' E''''` is not the complex unit disc
 [Elab.DiffGeo.MDiff] 💥️ Units of algebra
   [Elab.DiffGeo.MDiff] Failed with error:
       `ContinuousLinearMap σ E'' E''''` is not a set of units, in particular not of a complete normed algebra
@@ -672,6 +679,9 @@ trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `↑(Set.Icc x y)`
 [Elab.DiffGeo.MDiff] 💥️ UpperHalfPlane
   [Elab.DiffGeo.MDiff] Failed with error:
       `↑(Set.Icc x y)` is not the complex upper half plane
+[Elab.DiffGeo.MDiff] 💥️ ComplexUnitDisc
+  [Elab.DiffGeo.MDiff] Failed with error:
+      `↑(Set.Icc x y)` is not the complex unit disc
 [Elab.DiffGeo.MDiff] 💥️ Units of algebra
   [Elab.DiffGeo.MDiff] Failed with error:
       `↑(Set.Icc x y)` is not a set of units, in particular not of a complete normed algebra
@@ -803,7 +813,7 @@ info: ContMDiff ((modelWithCornersEuclideanHalfSpace 2).prod (modelWithCornersEu
 
 end EuclideanSpace
 
-/-! Inferring a model with corners when the model is a variable in the local context, but
+/-! Inferring a model with corners when the model is a not variable in the local context, but
 a specific model: basic versions (such as `𝓘(𝕜, E)`) are tested in `Basic.lean`; this also works
 for Euclidean space, half-space or quadrants.
 -/
@@ -837,6 +847,29 @@ variable [ChartedSpace ℝ X] [ChartedSpace (EuclideanQuadrant n) Y] in
 info: MDifferentiable (modelWithCornersSelf Real Real) (modelWithCornersEuclideanQuadrant n) f : Prop
 -/
 #guard_msgs in
+#check MDiff f
+
+-- TODO: the `[ChartedSpace ℂ Y]` is necessary for TC synthesis, but not the elaborators
+variable [ChartedSpace ℂ X] [ChartedSpace (UpperHalfPlane) Y] [ChartedSpace ℂ Y] in
+/--
+info: MDifferentiable (modelWithCornersSelf Complex Complex) (modelWithCornersSelf Complex Complex) f : Prop
+-/
+#guard_msgs in
+#check MDiff f
+
+-- TODO: the `[ChartedSpace ℂ Y]` is necessary for TC synthesis, but not the elaborators
+variable [ChartedSpace ℂ X] [ChartedSpace (Complex.UnitDisc) Y] [ChartedSpace ℂ Y] in
+/--
+info: MDifferentiable (modelWithCornersSelf Complex Complex) (modelWithCornersSelf Complex Complex) f : Prop
+-/
+#guard_msgs in
+#check MDiff f
+
+-- TODO: the last `ChartedSpace` hypothesis is necessary for TC synthesis (but not the elaborators)
+set_option trace.Elab.DiffGeo.MDiff true in
+variable [ChartedSpace ℝ X] [ChartedSpace Circle Y] [ChartedSpace (EuclideanSpace Real (Fin 1)) Y] in
+/-- `Circle` is the complex unit circle -/
+#guard_msgs (substring := true) in
 #check MDiff f
 
 end
@@ -877,6 +910,58 @@ info: MDifferentiableAt (modelWithCornersSelf Complex Complex) (modelWithCorners
 #check MDiffAt k y
 
 end UpperHalfPlane
+
+section ComplexUnitDisc
+
+-- Make a new complex manifold N with model J.
+-- TODO: change this line to modify M and E instead (thus testing if everything
+-- still works in the presence of two instances over different fields).
+variable {E'' : Type*} [NormedAddCommGroup E''] [NormedSpace ℂ E''] {J : ModelWithCorners ℂ E'' H}
+  {N : Type} [TopologicalSpace N] [ChartedSpace H N] [IsManifold J 2 N]
+open Complex
+open scoped Complex.UnitDisc
+
+-- TODO: upstream the next four declarations! added just so the test is more meaningful
+lemma Complex.UnitDisc.range_coe : Set.range UnitDisc.coe = Metric.ball (0 : ℂ) 1 := by
+  ext x
+  sorry
+
+theorem isOpenEmbedding_coe : Topology.IsOpenEmbedding ((↑) : 𝔻 → ℂ) := by
+  refine ⟨UnitDisc.isEmbedding_coe, ?_⟩
+  rw [Complex.UnitDisc.range_coe]
+  exact Metric.isOpen_ball
+
+noncomputable instance : ChartedSpace ℂ UnitDisc :=
+  isOpenEmbedding_coe.singletonChartedSpace
+
+open scoped ContDiff
+instance : IsManifold 𝓘(ℝ, ℂ) ω 𝔻 :=
+  isOpenEmbedding_coe.isManifold_singleton
+
+variable {g : UnitDisc → N} {h : E'' → UnitDisc} {k : UnitDisc → ℂ} {y : UnitDisc}
+
+/-- info: ContMDiff (modelWithCornersSelf Complex Complex) J 2 g : Prop -/
+#guard_msgs in
+variable {g : UnitDisc → M} in
+#check CMDiff 2 g
+
+/-- info: ContMDiff (modelWithCornersSelf Complex Complex) J 2 g : Prop -/
+#guard_msgs in
+#check CMDiff 2 g
+
+/--
+info: MDifferentiableAt (modelWithCornersSelf Complex E'') (modelWithCornersSelf Complex Complex) h : E'' → Prop
+-/
+#guard_msgs in
+#check MDiffAt h
+
+/--
+info: MDifferentiableAt (modelWithCornersSelf Complex Complex) (modelWithCornersSelf Complex Complex) k y : Prop
+-/
+#guard_msgs in
+#check MDiffAt k y
+
+end ComplexUnitDisc
 
 section units
 

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -1486,6 +1486,9 @@ trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `Unit`
 [Elab.DiffGeo.MDiff] 💥️ UpperHalfPlane
   [Elab.DiffGeo.MDiff] Failed with error:
       `Unit` is not the complex upper half plane
+[Elab.DiffGeo.MDiff] 💥️ ComplexUnitDisc
+  [Elab.DiffGeo.MDiff] Failed with error:
+      `Unit` is not the complex unit disc
 [Elab.DiffGeo.MDiff] 💥️ Units of algebra
   [Elab.DiffGeo.MDiff] Failed with error:
       `Unit` is not a set of units, in particular not of a complete normed algebra

--- a/MathlibTest/DifferentialGeometry/Notation/Sphere.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Sphere.lean
@@ -213,6 +213,9 @@ trace: [Elab.DiffGeo.MDiff] Finding a model with corners for: `↑(Metric.sphere
 [Elab.DiffGeo.MDiff] 💥️ UpperHalfPlane
   [Elab.DiffGeo.MDiff] Failed with error:
       `↑(Metric.sphere 0 1)` is not the complex upper half plane
+[Elab.DiffGeo.MDiff] 💥️ ComplexUnitDisc
+  [Elab.DiffGeo.MDiff] Failed with error:
+      `↑(Metric.sphere 0 1)` is not the complex unit disc
 [Elab.DiffGeo.MDiff] 💥️ Units of algebra
   [Elab.DiffGeo.MDiff] Failed with error:
       `↑(Metric.sphere 0 1)` is not a set of units, in particular not of a complete normed algebra


### PR DESCRIPTION
- add missing instances to this effect (partially WIP)
- extend the model finding to them
- also supporting finding a `ChartedSpace` instance for them: for some reason, this does not work as well as for Euclidean spaces. I still need to understand why; this code is all for hypothetical use cases anyway.

---

This requires a preliminary PR adding the ChartedSpace instance: as this may fall out of Théo Tyburn's master thesis, I'm not cleaning up that code at the moment (but will leave it to them).

- [x] depends on: #42250
- [x] depends on: #42491

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
