### PR TITLE
doc(Data/ENat,ENNReal): fix swapped docstring on mul_iInf_of_ne

### DIFF
--- a/Mathlib/Data/ENNReal/Inv.lean
+++ b/Mathlib/Data/ENNReal/Inv.lean
@@ -852,10 +852,10 @@ See `ENNReal.iInf_mul_of_ne` for the special case assuming `a ≠ 0` and `a ≠ 
 lemma iInf_mul' (hinfty : a = ∞ → ⨅ i, f i = 0 → ∃ i, f i = 0) (h₀ : a = 0 → Nonempty ι) :
     (⨅ i, f i) * a = ⨅ i, f i * a := by simpa only [mul_comm a] using mul_iInf' hinfty h₀
 
-/-- If `a ≠ 0` and `a ≠ ∞`, then right multiplication by `a` maps infimum to infimum.
+/-- If `a ≠ 0` and `a ≠ ∞`, then left multiplication by `a` maps infimum to infimum.
 
-See `ENNReal.mul_iInf'` for the general case, and `ENNReal.iInf_mul` for another special case that
-assumes `Nonempty ι` but does not require `a ≠ 0`, and `ENNReal`. -/
+See `ENNReal.mul_iInf'` for the general case, and `ENNReal.mul_iInf` for another special case that
+assumes `Nonempty ι` but does not require `a ≠ 0`. -/
 lemma mul_iInf_of_ne (ha₀ : a ≠ 0) (ha : a ≠ ∞) : a * ⨅ i, f i = ⨅ i, a * f i :=
   mul_iInf' (by simp [ha]) (by simp [ha₀])
 

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -190,8 +190,8 @@ lemma mul_iInf' (h₀ : a = 0 → Nonempty ι) : a * ⨅ i, f i = ⨅ i, a * f i
 lemma iInf_mul' (h₀ : a = 0 → Nonempty ι) : (⨅ i, f i) * a = ⨅ i, f i * a := by
   simp_rw [mul_comm, mul_iInf' h₀]
 
-/-- If `a ≠ 0`, then right multiplication by `a` maps infimum to infimum.
-See also `ENat.iInf_mul` that assumes `[Nonempty ι]` but does not require `a ≠ 0`. -/
+/-- If `a ≠ 0`, then left multiplication by `a` maps infimum to infimum.
+See also `ENat.mul_iInf` that assumes `[Nonempty ι]` but does not require `a ≠ 0`. -/
 lemma mul_iInf_of_ne (ha₀ : a ≠ 0) : a * ⨅ i, f i = ⨅ i, a * f i :=
   mul_iInf' <| by simp [ha₀]
 


### PR DESCRIPTION
Fixed left from right multiplication and "see-also" to point at mul_iInf

[Aristotle helped](https://github.com/attilavjda/formal-contributions/blob/main/mul_iInf_of_ne/PR3.lean) with finding the error, generating and verifying a solution by tests, and made a guide to the solution.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
