### PR TITLE
feat(Tactic/FunProp): add validation for compositional form

### DIFF
--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -309,6 +309,19 @@ def FunctionData.decompositionOverArgs (fData : FunctionData) (args : Array Nat)
   catch _ =>
     return none
 
+def FunctionData.validateCompositionalForm (fData : FunctionData) : MetaM Bool :=
+  withLCtx fData.lctx fData.insts do
+    let x := fData.mainVar
+    let e := Mor.mkAppN fData.fn fData.args
+    return visit x false e
+where
+  visit (x : Expr) (xApplied : Bool) : Expr → Bool
+  | .app f a =>
+    let xApplied := xApplied || a == x
+    f.isFVar && f != x && xApplied || visit x xApplied f || visit x false a
+  | .lam _ _ body _ => visit x false body
+  | _ => false
+
 end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -342,6 +342,10 @@ def getTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : Me
     | .const funName _ =>
 
       let dec ← fData.decomposition
+      let form := dec.toTheoremForm
+      if form == .comp then
+        unless ← fData.validateCompositionalForm do
+          logWarning "invalid compositional form"
 
       return .function {
 -- funPropName funName fData.mainArgs fData.args.size thmForm
@@ -351,7 +355,7 @@ def getTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : Me
         mainArgs := fData.mainArgs
         appliedArgs := fData.args.size
         priority := prio
-        form := dec.toTheoremForm
+        form
       }
     | .fvar .. =>
       let (_,_,b') ← forallMetaTelescope info.type


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
