### PR TITLE
feat(fun_prop): add simp set to proprocess functions

### DIFF
--- a/Mathlib/Algebra/Notation/Pi/Defs.lean
+++ b/Mathlib/Algebra/Notation/Pi/Defs.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Notation.Defs
 public import Mathlib.Tactic.Push.Attr
+public import Mathlib.Tactic.Attr.Register
 public import Mathlib.Logic.Function.Defs
 public import Batteries.Tactic.Alias
 
@@ -48,7 +49,7 @@ instance instOne : One (∀ i, M i) where one _ := 1
 @[to_additive (attr := simp high)]
 lemma one_apply (i : ι) : (1 : ∀ i, M i) i = 1 := rfl
 
-@[to_additive (attr := push ← high)]
+@[to_additive (attr := push ← high, fun_cast)]
 lemma one_def : (1 : ∀ i, M i) = fun _ ↦ 1 := rfl
 
 variable {M : Type*} [One M]
@@ -69,7 +70,7 @@ instance instMul : Mul (∀ i, M i) where mul f g i := f i * g i
 @[to_additive (attr := simp)]
 lemma mul_apply (f g : ∀ i, M i) (i : ι) : (f * g) i = f i * g i := rfl
 
-@[to_additive (attr := push ←)]
+@[to_additive (attr := push ←, fun_cast)]
 lemma mul_def (f g : ∀ i, M i) : f * g = fun i ↦ f i * g i := rfl
 
 variable {M : Type*} [Mul M]
@@ -91,7 +92,7 @@ instance instInv : Inv (∀ i, G i) where inv f i := (f i)⁻¹
 @[to_additive (attr := simp)]
 lemma inv_apply (f : ∀ i, G i) (i : ι) : f⁻¹ i = (f i)⁻¹ := rfl
 
-@[to_additive (attr := push ←)]
+@[to_additive (attr := push ←, fun_cast)]
 lemma inv_def (f : ∀ i, G i) : f⁻¹ = fun i ↦ (f i)⁻¹ := rfl
 
 variable {G : Type*} [Inv G]
@@ -112,7 +113,7 @@ instance instDiv : Div (∀ i, G i) where div f g i := f i / g i
 @[to_additive (attr := simp)]
 lemma div_apply (f g : ∀ i, G i) (i : ι) : (f / g) i = f i / g i := rfl
 
-@[to_additive (attr := push ←)]
+@[to_additive (attr := push ←, fun_cast)]
 lemma div_def (f g : ∀ i, G i) : f / g = fun i ↦ f i / g i := rfl
 
 variable {G : Type*} [Div G]
@@ -135,7 +136,7 @@ instance instPow : Pow (∀ i, M i) α where pow f a i := f i ^ a
 @[to_additive (attr := simp, to_additive) (reorder := 5 6) smul_apply]
 lemma pow_apply (f : ∀ i, M i) (a : α) (i : ι) : (f ^ a) i = f i ^ a := rfl
 
-@[to_additive (attr := push ←, to_additive) (reorder := 5 6) smul_def]
+@[to_additive (attr := push ←, fun_cast, to_additive) (reorder := 5 6) smul_def]
 lemma pow_def (f : ∀ i, M i) (a : α) : f ^ a = fun i ↦ f i ^ a := rfl
 
 variable {M : Type*} [Pow M α]
@@ -157,7 +158,7 @@ instance : Star (∀ i, R i) where star x i := star (x i)
 @[simp]
 theorem star_apply (x : ∀ i, R i) (i : ι) : star x i = star (x i) := rfl
 
-@[push ←]
+@[push ←, fun_cast]
 theorem star_def (x : ∀ i, R i) : star x = fun i => star (x i) := rfl
 
 end Star

--- a/Mathlib/Analysis/CStarAlgebra/ApproximateUnit.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ApproximateUnit.lean
@@ -306,7 +306,7 @@ private lemma tendsto_mul_right_approximateUnit (m : A) :
           exact hm' y hy
         · exact div_le_one (by positivity) |>.mpr le_add_self
       _ = ε ^ 2 := mul_one _
-  rw [cfc_mul _ _ m (continuousOn_id' _ |>.fun_mul hg') (continuousOn_id' _),
+  rw [cfc_mul _ _ m (continuousOn_id' _ |>.mul hg') (continuousOn_id' _),
     cfc_mul _ _ m (continuousOn_id' _) hg', cfc_id' .., hm₁.star_eq]
   congr
   rw [← cfc_one (R := ℝ≥0) m, ← cfc_comp_smul _ _ _ hg.continuousOn hm₁,

--- a/Mathlib/Analysis/Complex/JensenFormula.lean
+++ b/Mathlib/Analysis/Complex/JensenFormula.lean
@@ -49,7 +49,6 @@ private lemma continuousAt_herglotzLogIntegrand {w ρ z : ℂ} (hz_w : z ≠ w) 
     ContinuousAt (herglotzLogIntegrand w ρ) z := by
   have : ‖z - ρ‖ ≠ 0 := by simp_all [sub_eq_zero]
   simp only [herglotzLogIntegrand, herglotzRieszKernel_fun_def, sub_zero, smul_eq_mul]
-  dsimp [fun_cast]
   fun_prop (disch := grind)
 
 -- Auxiliary lemma for `circleAverage_re_herglotzRieszKernel_mul_log`. Continuity of the

--- a/Mathlib/Analysis/Complex/JensenFormula.lean
+++ b/Mathlib/Analysis/Complex/JensenFormula.lean
@@ -49,6 +49,7 @@ private lemma continuousAt_herglotzLogIntegrand {w ρ z : ℂ} (hz_w : z ≠ w) 
     ContinuousAt (herglotzLogIntegrand w ρ) z := by
   have : ‖z - ρ‖ ≠ 0 := by simp_all [sub_eq_zero]
   simp only [herglotzLogIntegrand, herglotzRieszKernel_fun_def, sub_zero, smul_eq_mul]
+  dsimp [fun_cast]
   fun_prop (disch := grind)
 
 -- Auxiliary lemma for `circleAverage_re_herglotzRieszKernel_mul_log`. Continuity of the

--- a/Mathlib/Analysis/Convex/Approximation.lean
+++ b/Mathlib/Analysis/Convex/Approximation.lean
@@ -10,6 +10,7 @@ public import Mathlib.Analysis.LocallyConvex.Separation
 import Mathlib.Analysis.InnerProductSpace.Basic
 import Mathlib.Analysis.Normed.Order.Lattice
 import Mathlib.Topology.Semicontinuity.Lindelof
+import Mathlib.Analysis.Convex.test
 
 /-!
 # Approximation to convex functions
@@ -142,7 +143,6 @@ theorem sSup_of_countable_affine_eq [HereditarilyLindelofSpace E] (hsc : IsClose
       obtain ⟨l, c, hlc⟩ := hf.2
       rw [hlc]
       apply Continuous.lowerSemicontinuous
-      try simp only [fun_cast]
       fun_prop
     obtain ⟨𝓕', h𝓕'⟩ := exists_countable_lowerSemicontinuous_isLUB hr hl
     refine ⟨𝓕', h𝓕'.2.1, h𝓕'.2.2.csSup_eq ?_, fun f hf => h𝓕'.1 hf⟩
@@ -213,7 +213,7 @@ theorem univ_sSup_of_countable_affine_eq [HereditarilyLindelofSpace E]
     · exact (bddAbove_def.2 ⟨φ, fun y hy => hy.1⟩)
   have hr (f) (hf : f ∈ 𝓕) : LowerSemicontinuous f := by
     obtain ⟨l, c, hlc⟩ := hf.2
-    exact Continuous.lowerSemicontinuous (by rw [hlc]; dsimp only [fun_cast]; fun_prop)
+    exact Continuous.lowerSemicontinuous (by rw [hlc]; fun_prop)
   obtain ⟨𝓕', h𝓕'⟩ := exists_countable_lowerSemicontinuous_isLUB hr hl
   refine ⟨𝓕', h𝓕'.2.1, h𝓕'.2.2.csSup_eq ?_, fun f hf => h𝓕'.1 hf⟩
   by_contra!

--- a/Mathlib/Analysis/Convex/Approximation.lean
+++ b/Mathlib/Analysis/Convex/Approximation.lean
@@ -140,7 +140,10 @@ theorem sSup_of_countable_affine_eq [HereditarilyLindelofSpace E] (hsc : IsClose
       · exact (bddAbove_def.2 ⟨φ ∘ Subtype.val, fun y hy => hy.1⟩)
     have hr (f) (hf : f ∈ 𝓕) : LowerSemicontinuous f := by
       obtain ⟨l, c, hlc⟩ := hf.2
-      exact Continuous.lowerSemicontinuous (hlc ▸ by fun_prop)
+      rw [hlc]
+      apply Continuous.lowerSemicontinuous
+      try simp only [fun_cast]
+      fun_prop
     obtain ⟨𝓕', h𝓕'⟩ := exists_countable_lowerSemicontinuous_isLUB hr hl
     refine ⟨𝓕', h𝓕'.2.1, h𝓕'.2.2.csSup_eq ?_, fun f hf => h𝓕'.1 hf⟩
     by_contra!
@@ -210,7 +213,7 @@ theorem univ_sSup_of_countable_affine_eq [HereditarilyLindelofSpace E]
     · exact (bddAbove_def.2 ⟨φ, fun y hy => hy.1⟩)
   have hr (f) (hf : f ∈ 𝓕) : LowerSemicontinuous f := by
     obtain ⟨l, c, hlc⟩ := hf.2
-    exact Continuous.lowerSemicontinuous (by rw [hlc]; fun_prop)
+    exact Continuous.lowerSemicontinuous (by rw [hlc]; dsimp only [fun_cast]; fun_prop)
   obtain ⟨𝓕', h𝓕'⟩ := exists_countable_lowerSemicontinuous_isLUB hr hl
   refine ⟨𝓕', h𝓕'.2.1, h𝓕'.2.2.csSup_eq ?_, fun f hf => h𝓕'.1 hf⟩
   by_contra!

--- a/Mathlib/Analysis/Quaternion.lean
+++ b/Mathlib/Analysis/Quaternion.lean
@@ -172,8 +172,8 @@ theorem continuous_coe : Continuous (coe : ℝ → ℍ) :=
 
 @[continuity]
 theorem continuous_normSq : Continuous (normSq : ℍ → ℝ) := by
-  simpa [← normSq_eq_norm_mul_self] using
-    (continuous_norm.fun_mul continuous_norm : Continuous fun q : ℍ => ‖q‖ * ‖q‖)
+  have : Continuous fun q : ℍ => ‖q‖ * ‖q‖ := by fun_prop
+  simpa [← normSq_eq_norm_mul_self]
 
 @[continuity]
 theorem continuous_re : Continuous fun q : ℍ => q.re :=

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -208,7 +208,7 @@ theorem partialGamma_add_one {s : ℂ} (hs : 0 < s.re) {X : ℝ} (hX : 0 ≤ X) 
     intervalIntegral.integral_neg, neg_add, neg_neg] at int_eval
   rw [eq_sub_of_add_eq int_eval, sub_neg_eq_add, neg_sub, add_comm, add_sub]
   have hn : s ≠ 0 := by contrapose! hs; rw [hs, zero_re]
-  simp only [Pi.mul_apply, Function.comp_apply, ofReal_zero, zero_cpow hn, mul_zero, add_zero,
+  simp only [Function.comp_apply, ofReal_zero, zero_cpow hn, mul_zero, add_zero,
     ← intervalIntegral.integral_const_mul]
   congr with x
   ring

--- a/Mathlib/Tactic/Attr/Core.lean
+++ b/Mathlib/Tactic/Attr/Core.lean
@@ -24,3 +24,5 @@ attribute [mfld_simps] id and_true true_and Function.comp_apply and_self eq_self
   true_or or_true heq_eq_eq forall_const and_imp
 
 attribute [nontriviality] eq_iff_true_of_subsingleton
+
+attribute [fun_cast] Function.comp_def Function.const id Function.uncurry

--- a/Mathlib/Tactic/Attr/Register.lean
+++ b/Mathlib/Tactic/Attr/Register.lean
@@ -94,6 +94,16 @@ register_simp_attr typevec
 /-- Simplification rules for ghost equations. -/
 register_simp_attr ghost_simps
 
+/-- The `@[fun_cast]` simp set is used as preprocessor by `fun_prop` to turn functions into a
+normal form so that not all defeq spellings have to be tagged with `@[fun_prop]`.
+
+For example `Continuous (f + g)` can be proved by `fun_prop` because `f + g` first gets expanded
+by `simp only [fun_cast]` into `fun x ↦ f x + g x` and `Continuous (fun x ↦ f x + g x)` is a
+`@[fun_prop]` lemma.
+
+Todo: add a linter for `fun_cast` normal forms in `@[fun_prop]` tagged lemmas. -/
+register_simp_attr fun_cast
+
 /-- The `@[nontriviality]` simp set is used by the `nontriviality` tactic to automatically
 discharge theorems about the trivial case (where we know `Subsingleton α` and many theorems
 in e.g. groups are trivially true). -/

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -60,9 +60,11 @@ example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x => x * (Real.log x) ^ 2 -
 -/
 syntax "fun_prop" optConfig (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
 
+/-- Tactic to prove function properties: do not use `fun_prop'`, but `fun_prop`. -/
 syntax (name := funPropTacStx')
   "fun_prop'" optConfig (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
 
+/-- Tactic to prove function properties -/
 macro_rules
   | `(tactic| fun_prop $cfg:optConfig $[$d]? $[[$names,*]]?) =>
     `(tactic| (

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -61,13 +61,20 @@ example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x => x * (Real.log x) ^ 2 -
 syntax (name := funPropTacStx)
   "fun_prop" optConfig (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
 
+syntax (name := funPropTacStx')
+  "fun_prop'" optConfig (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
+
+macro_rules
+  | `(tactic| fun_prop $cfg:optConfig $[$d]? $[[$names,*]]?) =>
+    `(tactic| try { dsimp only [fun_cast] }; fun_prop' $cfg $[$d]? $[[$names,*]]?)
+
 private def assumptionDischarge : Expr → MetaM (Option Expr) :=
   fun e => do tacticToDischarge (← `(tactic| with_reducible assumption)) e
 
 /-- Tactic to prove function properties -/
-@[tactic funPropTacStx]
+@[tactic funPropTacStx']
 def funPropTac : Tactic
-  | `(tactic| fun_prop $cfg:optConfig $[$d]? $[[$names,*]]?) => do
+  | `(tactic| fun_prop' $cfg:optConfig $[$d]? $[[$names,*]]?) => do
 
     let goal ← getMainGoal
     goal.withContext do
@@ -122,7 +129,6 @@ def funPropTac : Tactic
         throwError msg
 
   | _ => throwUnsupportedSyntax
-
 
 
 /-- Command that prints all function properties attached to a function.

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -58,15 +58,16 @@ example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x => x * (Real.log x) ^ 2 -
 ```
 
 -/
-syntax (name := funPropTacStx)
-  "fun_prop" optConfig (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
+syntax "fun_prop" optConfig (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
 
 syntax (name := funPropTacStx')
   "fun_prop'" optConfig (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
 
 macro_rules
   | `(tactic| fun_prop $cfg:optConfig $[$d]? $[[$names,*]]?) =>
-    `(tactic| try { dsimp only [fun_cast] }; fun_prop' $cfg $[$d]? $[[$names,*]]?)
+    `(tactic| (
+        try dsimp only [fun_cast]
+        fun_prop' $cfg $[$d]? $[[$names,*]]?))
 
 private def assumptionDischarge : Expr → MetaM (Option Expr) :=
   fun e => do tacticToDischarge (← `(tactic| with_reducible assumption)) e

--- a/Mathlib/Topology/Algebra/GroupCompletion.lean
+++ b/Mathlib/Topology/Algebra/GroupCompletion.lean
@@ -157,8 +157,8 @@ instance {M} [Monoid M] [DistribMulAction M α] [UniformContinuousConstSMul M α
     DistribMulAction M (Completion α) where
   smul_add r x y :=
     induction_on₂ x y
-      (isClosed_eq ((continuous_fst.fun_add continuous_snd).fun_const_smul _)
-        ((continuous_fst.fun_const_smul _).fun_add (continuous_snd.fun_const_smul _)))
+      (isClosed_eq ((continuous_fst.add continuous_snd).fun_const_smul _)
+        ((continuous_fst.fun_const_smul _).add (continuous_snd.fun_const_smul _)))
       fun a b ↦ by simp only [← coe_add, ← coe_smul, smul_add]
   smul_zero := fun r ↦ by rw [← coe_zero, ← coe_smul, smul_zero r]
 

--- a/Mathlib/Topology/Algebra/Monoid/Defs.lean
+++ b/Mathlib/Topology/Algebra/Monoid/Defs.lean
@@ -70,7 +70,7 @@ section ContinuousMul
 
 variable {M : Type*} [TopologicalSpace M] [Mul M] [ContinuousMul M]
 
-@[to_additive (attr := continuity, fun_prop)]
+@[to_additive (attr := continuity)]
 theorem continuous_mul : Continuous fun p : M × M => p.1 * p.2 :=
   ContinuousMul.continuous_mul
 
@@ -87,25 +87,37 @@ lemma Filter.tendsto_of_div_tendsto_one {α E : Type*} [CommGroup E] [Topologica
 
 variable {X : Type*} [TopologicalSpace X] {f g : X → M} {s : Set X} {x : X}
 
-@[to_fun (attr := to_additive (attr := continuity, fun_prop))]
+@[to_additive (attr := continuity, fun_prop)]
 theorem Continuous.mul (hf : Continuous f) (hg : Continuous g) :
-    Continuous (f * g) :=
+    Continuous (fun x ↦ f x * g x) :=
   continuous_mul.comp₂ hf hg
 
-@[to_fun (attr := to_additive (attr := fun_prop))]
+@[deprecated (since := "2026-08-07")] alias Continuous.fun_mul := Continuous.mul
+@[deprecated (since := "2026-08-07")] alias Continuous.fun_add := Continuous.add
+
+@[to_additive (attr := fun_prop)]
 theorem ContinuousWithinAt.mul (hf : ContinuousWithinAt f s x) (hg : ContinuousWithinAt g s x) :
-    ContinuousWithinAt (f * g) s x :=
+    ContinuousWithinAt (fun x ↦ f x * g x) s x :=
   Filter.Tendsto.mul hf hg
 
-@[to_fun (attr := to_additive (attr := fun_prop))]
+@[deprecated (since := "2026-08-07")] alias ContinuousWithinAt.fun_mul := ContinuousWithinAt.mul
+@[deprecated (since := "2026-08-07")] alias ContinuousWithinAt.fun_add := ContinuousWithinAt.add
+
+@[to_additive (attr := fun_prop)]
 theorem ContinuousAt.mul (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
-    ContinuousAt (f * g) x :=
+    ContinuousAt (fun x ↦ f x * g x) x :=
   Filter.Tendsto.mul hf hg
 
-@[to_fun (attr := to_additive (attr := fun_prop))]
+@[deprecated (since := "2026-08-07")] alias ContinuousAt.fun_mul := ContinuousAt.mul
+@[deprecated (since := "2026-08-07")] alias ContinuousAt.fun_add := ContinuousAt.add
+
+@[to_additive (attr := fun_prop)]
 theorem ContinuousOn.mul (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
-    ContinuousOn (f * g) s := fun x hx ↦
+    ContinuousOn (fun x ↦ f x * g x) s := fun x hx ↦
   (hf x hx).mul (hg x hx)
+
+@[deprecated (since := "2026-08-07")] alias ContinuousOn.fun_mul := ContinuousOn.mul
+@[deprecated (since := "2026-08-07")] alias ContinuousOn.fun_add := ContinuousOn.add
 
 end ContinuousMul
 


### PR DESCRIPTION
Adds a new attribute `fun_cast` that simplifies functions into some normal form for applications of `fun_prop`. This is to avoid tagging multiple defeq lemmas with `fun_prop`.

Currently, there are a lot of duplicated lemmas by using `@[to_fun]`, but this does not work for the case where a function might come as a bundled function and an unbundled function. The other option is to just use `dsimp; fun_prop` (as used by the `Homeomorph` auto parameters), but that performs more operations than we might want and a new attribute can be more tightly controlled.

---

The main conversion will be in a second PR, this one is to get a consensus on the design. A third PR will implement a linter that checks whether a `@[fun_prop]` tagged theorem is invariant under `dsimp only [fun_cast]` and otherwise flag the lemma (because it never applies).
Finally, some code in `fun_prop` itself can be simplified because we outsource the simplication to a macro, currently `fun_prop` does a similar thing already for a few hardcoded theorems.

As a design question: should the optional argument in square brackets be passed to `dsimp only [..]`? This would simplify the `fun_prop` implementation even further

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
