### PR TITLE
test: lint against `variable` whose type has universe metavariables

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -20,6 +20,7 @@ public import Mathlib.Tactic.Linter.OldObtain
 public import Mathlib.Tactic.Linter.OverlappingInstances
 public import Mathlib.Tactic.Linter.PrivateModule
 public import Mathlib.Tactic.Linter.TacticDocumentation
+public import Mathlib.Tactic.Linter.UniverseMVar
 -- The following import contains the environment extension for the unused tactic linter.
 public import Mathlib.Tactic.Linter.UnusedTacticExtension
 public import Mathlib.Tactic.Linter.UnusedTactic

--- a/Mathlib/Tactic/Linter/UniverseMVar.lean
+++ b/Mathlib/Tactic/Linter/UniverseMVar.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+module
+
+public meta import Lean.Elab.Command
+-- Import this linter explicitly to ensure that
+-- this file has a valid copyright header and module docstring.
+public meta import Mathlib.Tactic.Linter.Header  -- shake: keep
+public import Lean.Message
+
+meta section
+
+open Lean Elab Command Linter
+
+namespace Mathlib.Linter
+
+/-- Lint on `variable (foo : Bar)`, and emits a warning if Bar has
+universe metavariables in its type. -/
+public register_option linter.universeMVarInVariable : Bool := {
+  defValue := false
+  descr := "enable the universeMVarInVariable linter"
+}
+
+namespace universeMVarInVariableLinter
+
+open Term in
+def universeMVarInVariable : Linter where run := withSetOptionIn fun stx => do match stx with
+  | `(variable $[$x:bracketedBinder]*) =>
+    runTermElabM <| fun fvars ↦ elabBinders x fun s => do
+      for x in s do
+        let v ← Meta.inferType x
+        if v.hasLevelMVar then
+          Linter.logLint linter.universeMVarInVariable stx
+            m!"Type has universe level metavariable! {v}"
+  | _ => return
+
+initialize addLinter universeMVarInVariable
+
+end universeMVarInVariableLinter
+
+end Mathlib.Linter

--- a/Mathlib/Tactic/Linter/UniverseMVar.lean
+++ b/Mathlib/Tactic/Linter/UniverseMVar.lean
@@ -5,7 +5,6 @@ Authors: Robin Carlier
 -/
 module
 
-meta import all Lean.Elab.BuiltinCommand
 meta import Lean.Elab.Command
 -- Import this linter explicitly to ensure that
 -- this file has a valid copyright header and module docstring.
@@ -27,6 +26,21 @@ public register_option linter.universeMVarInVariable : Bool :=
 namespace universeMVarInVariableLinter
 
 open Meta Term Parser.Term
+
+-- Copied from Core
+
+private def typelessBinder? : Syntax → Option (Array (TSyntax [`ident, `Lean.Parser.Term.hole]) × BinderInfo)
+  | `(bracketedBinderF|($ids*))     => some (ids, .default)
+  | `(bracketedBinderF|{$ids*})     => some (ids, .implicit)
+  | `(bracketedBinderF|⦃$ids*⦄)     => some (ids, .strictImplicit)
+  | `(bracketedBinderF|[$id:ident]) => some (#[id], .instImplicit)
+  | _                               => none
+
+-- Copied from Core
+
+/--  If `id` is an identifier, return true if `ids` contains `id`. -/
+private def containsId (ids : Array (TSyntax [`ident, ``Parser.Term.hole])) (id : TSyntax [`ident, ``Parser.Term.hole]) : Bool :=
+  id.raw.isIdent && ids.any fun id' => id'.raw.getId == id.raw.getId
 
 /-- Open scopes and remove the binders that are binder updates. -/
 private def pruneUpdate (binder : TSyntax ``Parser.Term.bracketedBinder) :

--- a/Mathlib/Tactic/Linter/UniverseMVar.lean
+++ b/Mathlib/Tactic/Linter/UniverseMVar.lean
@@ -27,11 +27,12 @@ public register_option linter.universeMVarInVariable : Bool := {
 namespace universeMVarInVariableLinter
 
 open Term in
-def universeMVarInVariable : Linter where run := withSetOptionIn fun stx => do match stx with
+def universeMVarInVariable : Linter where run := withSetOptionIn fun stx => do
+  match stx with
   | `(variable $[$x:bracketedBinder]*) =>
     runTermElabM <| fun fvars ↦ elabBinders x fun s => do
       for x in s do
-        let v ← Meta.inferType x
+        let v ← instantiateMVars <| ← Meta.inferType x
         if v.hasLevelMVar then
           Linter.logLint linter.universeMVarInVariable stx
             m!"Type has universe level metavariable! {v}"

--- a/Mathlib/Tactic/Linter/UniverseMVar.lean
+++ b/Mathlib/Tactic/Linter/UniverseMVar.lean
@@ -26,6 +26,8 @@ public register_option linter.universeMVarInVariable : Bool :=
 namespace universeMVarInVariableLinter
 
 open Meta Term in
+/-- Lint on `variable (foo : Bar)`, and emits a warning if `Bar` has
+universe metavariables in its type. -/
 def universeMVarInVariable : Linter where run := withSetOptionIn fun stx => do
   match stx with
   | `(variable $[$x:bracketedBinder]*)

--- a/Mathlib/Tactic/Linter/UniverseMVar.lean
+++ b/Mathlib/Tactic/Linter/UniverseMVar.lean
@@ -5,11 +5,11 @@ Authors: Robin Carlier
 -/
 module
 
-public meta import Lean.Elab.Command
+meta import Lean.Elab.Command
 -- Import this linter explicitly to ensure that
 -- this file has a valid copyright header and module docstring.
 public meta import Mathlib.Tactic.Linter.Header  -- shake: keep
-public import Lean.Message
+import Lean.Message
 
 meta section
 
@@ -19,23 +19,23 @@ namespace Mathlib.Linter
 
 /-- Lint on `variable (foo : Bar)`, and emits a warning if Bar has
 universe metavariables in its type. -/
-public register_option linter.universeMVarInVariable : Bool := {
-  defValue := false
-  descr := "enable the universeMVarInVariable linter"
-}
+public register_option linter.universeMVarInVariable : Bool :=
+  { defValue := true
+    descr := "enable the universeMVarInVariable linter" }
 
 namespace universeMVarInVariableLinter
 
-open Term in
+open Meta Term Linter in
 def universeMVarInVariable : Linter where run := withSetOptionIn fun stx => do
   match stx with
-  | `(variable $[$x:bracketedBinder]*) =>
+  | `(variable $[$x:bracketedBinder]*)
+  | `(variable $[$x:bracketedBinder]* in $t) =>
     runTermElabM <| fun fvars ↦ elabBinders x fun s => do
       for x in s do
-        let v ← instantiateMVars <| ← Meta.inferType x
+        let v ← instantiateMVars <| ← inferType x
         if v.hasLevelMVar then
-          Linter.logLint linter.universeMVarInVariable stx
-            m!"Type has universe level metavariable! {v}"
+          logLint linter.universeMVarInVariable stx
+            m!"type of variable contains universe metavariable! {v}"
   | _ => return
 
 initialize addLinter universeMVarInVariable

--- a/Mathlib/Tactic/Linter/UniverseMVar.lean
+++ b/Mathlib/Tactic/Linter/UniverseMVar.lean
@@ -66,7 +66,7 @@ private def pruneUpdate (binder : TSyntax ``Parser.Term.bracketedBinder) :
       | .default => `(bracketedBinderF| ($binderId))
       | .implicit => `(bracketedBinderF| {$binderId})
       | .strictImplicit => `(bracketedBinderF| {{$binderId}})
-      | .instImplicit => throwUnsupportedSyntax
+      | .instImplicit => `(bracketedBinderF| [$(⟨binderId⟩)])
 
 open Meta Term in
 /-- Lint on `variable (foo : Bar)`, and emits a warning if `Bar` has

--- a/Mathlib/Tactic/Linter/UniverseMVar.lean
+++ b/Mathlib/Tactic/Linter/UniverseMVar.lean
@@ -17,7 +17,7 @@ open Lean Elab Command Linter
 
 namespace Mathlib.Linter
 
-/-- Lint on `variable (foo : Bar)`, and emits a warning if Bar has
+/-- Lint on `variable (foo : Bar)`, and emits a warning if `Bar` has
 universe metavariables in its type. -/
 public register_option linter.universeMVarInVariable : Bool :=
   { defValue := true
@@ -25,12 +25,12 @@ public register_option linter.universeMVarInVariable : Bool :=
 
 namespace universeMVarInVariableLinter
 
-open Meta Term Linter in
+open Meta Term in
 def universeMVarInVariable : Linter where run := withSetOptionIn fun stx => do
   match stx with
   | `(variable $[$x:bracketedBinder]*)
   | `(variable $[$x:bracketedBinder]* in $t) =>
-    runTermElabM <| fun fvars ↦ elabBinders x fun s => do
+    runTermElabM <| fun _ ↦ elabBinders x fun s => do
       for x in s do
         let v ← instantiateMVars <| ← inferType x
         if v.hasLevelMVar then

--- a/Mathlib/Tactic/Linter/UniverseMVar.lean
+++ b/Mathlib/Tactic/Linter/UniverseMVar.lean
@@ -5,6 +5,7 @@ Authors: Robin Carlier
 -/
 module
 
+meta import all Lean.Elab.BuiltinCommand
 meta import Lean.Elab.Command
 -- Import this linter explicitly to ensure that
 -- this file has a valid copyright header and module docstring.
@@ -25,15 +26,29 @@ public register_option linter.universeMVarInVariable : Bool :=
 
 namespace universeMVarInVariableLinter
 
-open Parser.Term in
-/- Returns `True` if the binder has no type annotation (this happens e.g when
-updating a binder annotation) -/
-private def isTypelessBinder : TSyntax ``Parser.Term.bracketedBinder → Bool
-  | `(bracketedBinderF|($_*))
-  | `(bracketedBinderF|{$_*})
-  | `(bracketedBinderF|⦃$_*⦄)
-  | `(bracketedBinderF|[$_]) => False
-  | _ => True
+open Meta Term Parser.Term
+
+/-- Open scopes and remove the binders that are binder updates. -/
+private def pruneUpdate (binder : TSyntax ``Parser.Term.bracketedBinder) :
+    CommandElabM (Array (TSyntax ``Parser.Term.bracketedBinder)) := do
+  let some (binderIds, binderInfo) := typelessBinder? binder | return #[binder]
+  let varDecls := (← getScope).varDecls
+  let mut binderIds := binderIds
+  -- Go through declarations in reverse to respect shadowing
+  for varDecl in varDecls.reverse do
+    let ids ← match varDecl with
+      | `(bracketedBinderF|($ids* $[: $_]? $(_)?)) => pure ids
+      | `(bracketedBinderF|{$ids* $[: $_]?}) => pure ids
+      | `(bracketedBinderF|⦃$ids* $[: $_]?⦄) => pure ids
+      | `(bracketedBinderF|[$id : $_]) => pure #[⟨id⟩]
+      | _ => continue
+    binderIds := binderIds.filter fun id' => ¬ containsId ids id'
+  binderIds.mapM fun binderId =>
+    match binderInfo with
+      | .default => `(bracketedBinderF| ($binderId))
+      | .implicit => `(bracketedBinderF| {$binderId})
+      | .strictImplicit => `(bracketedBinderF| {{$binderId}})
+      | .instImplicit => throwUnsupportedSyntax
 
 open Meta Term in
 /-- Lint on `variable (foo : Bar)`, and emits a warning if `Bar` has
@@ -42,13 +57,13 @@ def universeMVarInVariable : Linter where run := withSetOptionIn fun stx => do
   match stx with
   | `(variable $[$x:bracketedBinder]*)
   | `(variable $[$x:bracketedBinder]* in $t) =>
-    for binder in x do
-      if !(isTypelessBinder binder) then
-      runTermElabM <| fun f ↦ elabBinder binder fun s => do
-        let v ← instantiateMVars <| ← inferType s
-        if v.hasLevelMVar then
-          logLint linter.universeMVarInVariable binder
-            m!"type of variable contains universe metavariable! {v}"
+    let y ← x.flatMapM pruneUpdate
+    runTermElabM <| fun f ↦ elabBindersEx y fun b => do
+      for (stx, e) in b do
+      let v ← instantiateMVars <| ← inferType e
+      if v.hasLevelMVar then
+        logLint linter.universeMVarInVariable stx
+          m!"type of variable contains universe metavariable! {v}"
   | _ => return
 
 initialize addLinter universeMVarInVariable

--- a/Mathlib/Tactic/Linter/UniverseMVar.lean
+++ b/Mathlib/Tactic/Linter/UniverseMVar.lean
@@ -25,6 +25,16 @@ public register_option linter.universeMVarInVariable : Bool :=
 
 namespace universeMVarInVariableLinter
 
+open Parser.Term in
+/- Returns `True` if the binder has no type annotation (this happens e.g when
+updating a binder annotation) -/
+private def isTypelessBinder : TSyntax ``Parser.Term.bracketedBinder → Bool
+  | `(bracketedBinderF|($_*))
+  | `(bracketedBinderF|{$_*})
+  | `(bracketedBinderF|⦃$_*⦄)
+  | `(bracketedBinderF|[$_]) => False
+  | _ => True
+
 open Meta Term in
 /-- Lint on `variable (foo : Bar)`, and emits a warning if `Bar` has
 universe metavariables in its type. -/
@@ -32,11 +42,12 @@ def universeMVarInVariable : Linter where run := withSetOptionIn fun stx => do
   match stx with
   | `(variable $[$x:bracketedBinder]*)
   | `(variable $[$x:bracketedBinder]* in $t) =>
-    runTermElabM <| fun _ ↦ elabBinders x fun s => do
-      for x in s do
-        let v ← instantiateMVars <| ← inferType x
+    for binder in x do
+      if !(isTypelessBinder binder) then
+      runTermElabM <| fun f ↦ elabBinder binder fun s => do
+        let v ← instantiateMVars <| ← inferType s
         if v.hasLevelMVar then
-          logLint linter.universeMVarInVariable stx
+          logLint linter.universeMVarInVariable binder
             m!"type of variable contains universe metavariable! {v}"
   | _ => return
 

--- a/Mathlib/Tactic/Linter/UniverseMVar.lean
+++ b/Mathlib/Tactic/Linter/UniverseMVar.lean
@@ -27,7 +27,13 @@ namespace universeMVarInVariableLinter
 
 open Meta Term Parser.Term
 
--- Copied from Core
+/- (Probably) because of lean4#14574, trying to `import all` the next two definitions from
+`Lean.Elab.BuiltinCommand` causes
+interpreter crash. We copy their code instead.
+Original license header for `typelessBinder?` and `containsId`:
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura -/
 
 private def typelessBinder? : Syntax → Option (Array (TSyntax [`ident, `Lean.Parser.Term.hole]) × BinderInfo)
   | `(bracketedBinderF|($ids*))     => some (ids, .default)
@@ -35,8 +41,6 @@ private def typelessBinder? : Syntax → Option (Array (TSyntax [`ident, `Lean.P
   | `(bracketedBinderF|⦃$ids*⦄)     => some (ids, .strictImplicit)
   | `(bracketedBinderF|[$id:ident]) => some (#[id], .instImplicit)
   | _                               => none
-
--- Copied from Core
 
 /--  If `id` is an identifier, return true if `ids` contains `id`. -/
 private def containsId (ids : Array (TSyntax [`ident, ``Parser.Term.hole])) (id : TSyntax [`ident, ``Parser.Term.hole]) : Bool :=

--- a/MathlibTest/Linter/UniverseMVarInVariable.lean
+++ b/MathlibTest/Linter/UniverseMVarInVariable.lean
@@ -1,7 +1,6 @@
 import Mathlib.Tactic.Linter.UniverseMVar
 import Mathlib.Tactic.TypeStar
-
-set_option linter.universeMVarInVariable true
+import Mathlib.Algebra.Group.Action.Defs
 
 universe v u
 
@@ -18,6 +17,47 @@ Note: This linter can be disabled with `set_option linter.universeMVarInVariable
 -/
 #guard_msgs in
 variable [Foo C]
+end
+
+section
+/--
+warning: type of variable contains universe metavariable! Foo C
+
+Note: This linter can be disabled with `set_option linter.universeMVarInVariable false`
+-/
+#guard_msgs in
+variable {h0 : Foo C}
+
+/--
+warning: type of variable contains universe metavariable! Foo C
+
+Note: This linter can be disabled with `set_option linter.universeMVarInVariable false`
+-/
+#guard_msgs in
+variable ⦃h1 : Foo C⦄
+
+/--
+warning: type of variable contains universe metavariable! Foo C
+
+Note: This linter can be disabled with `set_option linter.universeMVarInVariable false`
+-/
+#guard_msgs in
+variable [h2 : Foo C]
+
+/--
+warning: type of variable contains universe metavariable! Foo C
+
+Note: This linter can be disabled with `set_option linter.universeMVarInVariable false`
+-/
+#guard_msgs in
+variable (h3 : Foo C)
+end
+
+section
+variable {h0 : Foo.{v} C}
+variable ⦃h1 : Foo.{v} C⦄
+variable [h2 : Foo.{v} C]
+variable (h3 : Foo.{v} C)
 end
 
 section
@@ -45,4 +85,12 @@ Note: This linter can be disabled with `set_option linter.universeMVarInVariable
 -/
 #guard_msgs in
 variable {D} [Foo D]
+end
+
+variable {D} (D) {D} (D)
+
+variable {α β : Type*}
+section
+variable [DecidableEq β] [Group α] [MulAction α β]
+example (a : α) (b : β) : a • b = a • b := rfl
 end

--- a/MathlibTest/Linter/UniverseMVarInVariable.lean
+++ b/MathlibTest/Linter/UniverseMVarInVariable.lean
@@ -8,6 +8,28 @@ universe v u
 
 open CategoryTheory
 
-variable (n m : Nat) (m : Nat) (C : Type*)
+#guard_msgs in
+variable (n m : Nat) (m : Nat) (C : Type*) (D : Type*)
+
+/--
+warning: type of variable contains universe metavariable! Category.{_, u_1} C
+
+Note: This linter can be disabled with `set_option linter.universeMVarInVariable false`
+---
+warning: type of variable contains universe metavariable! Category.{_, u_2} D
+
+Note: This linter can be disabled with `set_option linter.universeMVarInVariable false`
+-/
+#guard_msgs in
+variable [Category C] [Category D]
+
+#guard_msgs in
 variable [Category* C]
 
+/--
+warning: type of variable contains universe metavariable! Category.{_, u_1} C
+
+Note: This linter can be disabled with `set_option linter.universeMVarInVariable false`
+-/
+#guard_msgs in
+variable [Category C] in example (c : C) : C := c

--- a/MathlibTest/Linter/UniverseMVarInVariable.lean
+++ b/MathlibTest/Linter/UniverseMVarInVariable.lean
@@ -1,35 +1,48 @@
 import Mathlib.Tactic.Linter.UniverseMVar
-import Mathlib.CategoryTheory.Yoneda
-import Mathlib.Tactic.CategoryTheory.CategoryStar
+import Mathlib.Tactic.TypeStar
 
 set_option linter.universeMVarInVariable true
 
 universe v u
 
-open CategoryTheory
+variable (C : Type*) (D : Type u)
 
-#guard_msgs in
-variable (n m : Nat) (m : Nat) (C : Type*) (D : Type*)
+class Foo (X : Type u) where
+  P : Type v
 
+section
 /--
-warning: type of variable contains universe metavariable! Category.{_, u_1} C
-
-Note: This linter can be disabled with `set_option linter.universeMVarInVariable false`
----
-warning: type of variable contains universe metavariable! Category.{_, u_2} D
+warning: type of variable contains universe metavariable! Foo C
 
 Note: This linter can be disabled with `set_option linter.universeMVarInVariable false`
 -/
 #guard_msgs in
-variable [Category C] [Category D]
+variable [Foo C]
+end
 
-#guard_msgs in
-variable [Category* C]
+section
+variable [Foo.{v} C]
+end
 
+section
+variable {D} [Foo.{v} C]
+end
+
+section
+variable {D}
+variable [Foo.{v} D]
+end
+
+section
+variable {D} [Foo.{v} D]
+end
+
+section
 /--
-warning: type of variable contains universe metavariable! Category.{_, u_1} C
+warning: type of variable contains universe metavariable! Foo D
 
 Note: This linter can be disabled with `set_option linter.universeMVarInVariable false`
 -/
 #guard_msgs in
-variable [Category C] in example (c : C) : C := c
+variable {D} [Foo D]
+end

--- a/MathlibTest/Linter/UniverseMVarInVariable.lean
+++ b/MathlibTest/Linter/UniverseMVarInVariable.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic.Linter.UniverseMVar
 import Mathlib.CategoryTheory.Yoneda
+import Mathlib.Tactic.CategoryTheory.CategoryStar
 
 set_option linter.universeMVarInVariable true
 

--- a/MathlibTest/Linter/UniverseMVarInVariable.lean
+++ b/MathlibTest/Linter/UniverseMVarInVariable.lean
@@ -1,0 +1,12 @@
+import Mathlib.Tactic.Linter.UniverseMVar
+import Mathlib.CategoryTheory.Yoneda
+
+set_option linter.universeMVarInVariable true
+
+universe v u
+
+open CategoryTheory
+
+variable (n m : Nat) (m : Nat) (C : Type*)
+variable [Category* C]
+


### PR DESCRIPTION
In the past, universe metavariables in binders in the `variable` command have caused performance issues.
They are also at risk of getting involuntarily unified later on.

This PR adds a linter (currently emitting a lot of warnings throughout the library) against `variable (foo : Foo)` (or `variable (foo : Foo) in` where the type `Foo` contains universe MVars.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I mostly wanted an excuse to learn a bit more about linters.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
