### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Matrix): add echelon form decomposition certificate structure

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5138,6 +5138,7 @@ public import Mathlib.LinearAlgebra.Matrix.DotProduct
 public import Mathlib.LinearAlgebra.Matrix.Dual
 public import Mathlib.LinearAlgebra.Matrix.DualNumber
 public import Mathlib.LinearAlgebra.Matrix.Echelon.Basic
+public import Mathlib.LinearAlgebra.Matrix.Echelon.Decomposition
 public import Mathlib.LinearAlgebra.Matrix.Echelon.Pivot
 public import Mathlib.LinearAlgebra.Matrix.FiniteDimensional
 public import Mathlib.LinearAlgebra.Matrix.FixedDetMatrices

--- a/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
@@ -25,18 +25,16 @@ public import Mathlib.LinearAlgebra.Matrix.Echelon.Pivot
 matrix, echelon form
 -/
 
-@[expose] public section
+public section
 
-universe v
-
-variable {m n : ℕ}
-variable {R : Type v} {A : Matrix (Fin m) (Fin n) R}
+variable
+  {m : Type*} [Fintype m] [LinearOrder m]
+  {n : Type*} [Fintype n] [LinearOrder n]
+  {R : Type*} [CommRing R] [IsDomain R]
 
 namespace Echelon
 
-open Finset
-
-variable [CommRing R] [IsDomain R]
+open scoped Finset
 
 /-- A certificate of an echelon form decomposition of `A`, certifying that
 `L * (A.submatrix σ id)` is in echelon form by providing a pivot, where `L`

--- a/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
@@ -55,8 +55,8 @@ structure Decomposition (A : Matrix (Fin m) (Fin n) R) where
 
 theorem Decomposition.rank_eq (cert : Decomposition A) :
     A.rank = #{i | cert.pivot i ≠ ⊤} := by
-  have hr : (A.submatrix cert.σ id).rank = A.rank := A.rank_submatrix cert.σ (Equiv.refl (Fin n))
-  rw [← hr, ← Matrix.rank_mul_eq_right_of_isLowerTriangular cert.L _ cert.L_lowerTriangular
-    cert.L_diag_ne_zero, cert.isPivotedBy.rank_eq]
+  rw [← cert.isPivotedBy.rank_eq,
+    cert.L.rank_mul_eq_right_of_isLowerTriangular _ cert.L_lowerTriangular cert.L_diag_ne_zero]
+  exact (A.rank_submatrix cert.σ (.refl _)).symm
 
 end Echelon

--- a/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 Rao Xiaojia. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rao Xiaojia
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.Echelon.Pivot
+
+/-!
+# Echelon decomposition certificates
+
+`Echelon.Decomposition` certifies an echelon decomposition of a matrix `A`: pivots for
+`L * (A.submatrix σ id)` with `L` lower triangular with nonzero diagonal and `σ` a row
+permutation. The certificate records the decomposed form rather than a computation trace,
+so a producer is free to choose how to find it.
+
+## Main definitions
+
+- `Echelon.Decomposition`: the certificate structure.
+
+## Main results
+
+- `Echelon.Decomposition.rank_eq`: `A.rank` is the pivot count of any certificate for `A`.
+
+## Tags
+
+matrix, echelon form
+-/
+
+@[expose] public section
+
+universe v
+
+variable {m n : ℕ}
+variable {R : Type v} {A : Matrix (Fin m) (Fin n) R}
+
+namespace Echelon
+
+open Finset
+
+variable [CommRing R] [IsDomain R]
+
+/-- A certificate of an echelon decomposition of `A`: pivots for
+`L * (A.submatrix σ id)`, with `L` lower triangular with nonzero diagonal and `σ` a
+row permutation. -/
+structure Decomposition (A : Matrix (Fin m) (Fin n) R) where
+  /-- The lower-triangular transform. -/
+  L : Matrix (Fin m) (Fin m) R
+  /-- The row permutation. -/
+  σ : Equiv.Perm (Fin m)
+  /-- The pivot column of each row of the final echelon form. -/
+  pivot : Fin m → WithTop (Fin n)
+  isPivotedBy : (L * (A.submatrix σ id)).IsPivotedBy pivot
+  L_lowerTriangular : L.IsLowerTriangular
+  L_diag_ne_zero (i : Fin m) : L.diag i ≠ 0
+
+theorem Decomposition.rank_eq (cert : Decomposition A) :
+    A.rank = #{i | cert.pivot i ≠ ⊤} := by
+  have hr : (A.submatrix cert.σ id).rank = A.rank := A.rank_submatrix cert.σ (Equiv.refl (Fin n))
+  rw [← hr, ← Matrix.rank_mul_eq_right_of_isLowerTriangular cert.L _ cert.L_lowerTriangular
+    cert.L_diag_ne_zero, cert.isPivotedBy.rank_eq]
+
+end Echelon

--- a/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
@@ -10,10 +10,7 @@ public import Mathlib.LinearAlgebra.Matrix.Echelon.Pivot
 /-!
 # Echelon decomposition certificates
 
-`Echelon.Decomposition` certifies an echelon decomposition of a matrix `A`: pivots for
-`L * (A.submatrix σ id)` with `L` lower triangular with nonzero diagonal and `σ` a row
-permutation. The certificate records the decomposed form rather than a computation trace,
-so a producer is free to choose how to find it.
+`Echelon.Decomposition A` certifies an echelon decomposition of the matrix `A`.
 
 ## Main definitions
 
@@ -41,15 +38,16 @@ open Finset
 
 variable [CommRing R] [IsDomain R]
 
-/-- A certificate of an echelon decomposition of `A`: pivots for
-`L * (A.submatrix σ id)`, with `L` lower triangular with nonzero diagonal and `σ` a
-row permutation. -/
+/-- A certificate of an echelon form decomposition of `A`, certifying that
+`L * (A.submatrix σ id)` is in echelon form by providing a pivot, where `L`
+is lower triangular with nonzero diagonal, and `σ` the permutation on the rows
+of `A`.
+This version does not store the final echelon form itself as it can be computed
+by the data enclosed.
+-/
 structure Decomposition (A : Matrix (Fin m) (Fin n) R) where
-  /-- The lower-triangular transform. -/
   L : Matrix (Fin m) (Fin m) R
-  /-- The row permutation. -/
   σ : Equiv.Perm (Fin m)
-  /-- The pivot column of each row of the final echelon form. -/
   pivot : Fin m → WithTop (Fin n)
   isPivotedBy : (L * (A.submatrix σ id)).IsPivotedBy pivot
   L_lowerTriangular : L.IsLowerTriangular

--- a/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
@@ -46,8 +46,11 @@ This version does not store the final echelon form itself as it can be computed
 by the data enclosed.
 -/
 structure Decomposition (A : Matrix (Fin m) (Fin n) R) where
+  /-- The transformation matrix. -/
   L : Matrix (Fin m) (Fin m) R
+  /-- The row permutation on the rows of `A`. -/
   σ : Equiv.Perm (Fin m)
+  /-- The pivot of the resulting echelon form. -/
   pivot : Fin m → WithTop (Fin n)
   isPivotedBy : (L * (A.submatrix σ id)).IsPivotedBy pivot
   L_lowerTriangular : L.IsLowerTriangular

--- a/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean
@@ -43,18 +43,18 @@ of `A`.
 This version does not store the final echelon form itself as it can be computed
 by the data enclosed.
 -/
-structure Decomposition (A : Matrix (Fin m) (Fin n) R) where
+structure Decomposition (A : Matrix m n R) where
   /-- The transformation matrix. -/
-  L : Matrix (Fin m) (Fin m) R
+  L : Matrix m m R
   /-- The row permutation on the rows of `A`. -/
-  σ : Equiv.Perm (Fin m)
+  σ : Equiv.Perm m
   /-- The pivot of the resulting echelon form. -/
-  pivot : Fin m → WithTop (Fin n)
+  pivot : m → WithTop n
   isPivotedBy : (L * (A.submatrix σ id)).IsPivotedBy pivot
   L_lowerTriangular : L.IsLowerTriangular
-  L_diag_ne_zero (i : Fin m) : L.diag i ≠ 0
+  L_diag_ne_zero (i : m) : L.diag i ≠ 0
 
-theorem Decomposition.rank_eq (cert : Decomposition A) :
+theorem Decomposition.rank_eq {A : Matrix m n R} (cert : Decomposition A) :
     A.rank = #{i | cert.pivot i ≠ ⊤} := by
   rw [← cert.isPivotedBy.rank_eq,
     cert.L.rank_mul_eq_right_of_isLowerTriangular _ cert.L_lowerTriangular cert.L_diag_ne_zero]


### PR DESCRIPTION
This PR adds the structure of the echelon form decomposition certificate and provides one lemma that derives the rank of a matrix from the pivot.

---

This follows #42236, and is separated from the WIP tactic [PR](https://github.com/raoxiaojia/mathlib4/pull/2) that implements a tactic for evaluating the rank of matrix, based on a core tactic that derives an echelon form decomposition using Bareiss decomposition (echelon form with exact division only). The link is updated from the previous PR since a new parametric structure is used.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
