### PR TITLE
chore(Analysis/SpecialFunctions/Pow/Real): deprecate six misnamed duplicate log/rpow lemmas

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -829,16 +829,9 @@ lemma le_log_of_pow_le (hx : 0 < x) (h : x ^ n ≤ y) : n * log x ≤ log y :=
 lemma le_log_of_zpow_le {n : ℤ} (hx : 0 < x) (h : x ^ n ≤ y) : n * log x ≤ log y :=
   le_log_of_rpow_le hx (rpow_intCast _ _ ▸ h)
 
-lemma rpow_le_of_le_log (hy : 0 < y) (h : log x ≤ z * log y) : x ≤ y ^ z := by
-  obtain hx | hx := le_or_gt x 0
-  · exact hx.trans (rpow_pos_of_pos hy _).le
-  · exact (le_rpow_iff_log_le hx hy).2 h
-
-lemma pow_le_of_le_log (hy : 0 < y) (h : log x ≤ n * log y) : x ≤ y ^ n :=
-  rpow_natCast _ _ ▸ rpow_le_of_le_log hy h
-
-lemma zpow_le_of_le_log {n : ℤ} (hy : 0 < y) (h : log x ≤ n * log y) : x ≤ y ^ n :=
-  rpow_intCast _ _ ▸ rpow_le_of_le_log hy h
+@[deprecated (since := "2026-08-07")] alias rpow_le_of_le_log := le_rpow_of_log_le
+@[deprecated (since := "2026-08-07")] alias pow_le_of_le_log := le_pow_of_log_le
+@[deprecated (since := "2026-08-07")] alias zpow_le_of_le_log := le_zpow_of_log_le
 
 lemma rpow_lt_iff_lt_log (hx : 0 < x) (hy : 0 < y) : x ^ z < y ↔ z * log x < log y := by
   rw [← log_lt_log_iff (rpow_pos_of_pos hx _) hy, log_rpow hx]
@@ -858,16 +851,9 @@ lemma lt_log_of_pow_lt (hx : 0 < x) (h : x ^ n < y) : n * log x < log y :=
 lemma lt_log_of_zpow_lt {n : ℤ} (hx : 0 < x) (h : x ^ n < y) : n * log x < log y :=
   lt_log_of_rpow_lt hx (rpow_intCast _ _ ▸ h)
 
-lemma rpow_lt_of_lt_log (hy : 0 < y) (h : log x < z * log y) : x < y ^ z := by
-  obtain hx | hx := le_or_gt x 0
-  · exact hx.trans_lt (rpow_pos_of_pos hy _)
-  · exact (lt_rpow_iff_log_lt hx hy).2 h
-
-lemma pow_lt_of_lt_log (hy : 0 < y) (h : log x < n * log y) : x < y ^ n :=
-  rpow_natCast _ _ ▸ rpow_lt_of_lt_log hy h
-
-lemma zpow_lt_of_lt_log {n : ℤ} (hy : 0 < y) (h : log x < n * log y) : x < y ^ n :=
-  rpow_intCast _ _ ▸ rpow_lt_of_lt_log hy h
+@[deprecated (since := "2026-08-06")] alias rpow_lt_of_lt_log := lt_rpow_of_log_lt
+@[deprecated (since := "2026-08-06")] alias pow_lt_of_lt_log := lt_pow_of_log_lt
+@[deprecated (since := "2026-08-06")] alias zpow_lt_of_lt_log := lt_zpow_of_log_lt
 
 theorem rpow_le_one_iff_of_pos (hx : 0 < x) : x ^ y ≤ 1 ↔ 1 ≤ x ∧ y ≤ 0 ∨ x ≤ 1 ∧ 0 ≤ y := by
   rw [rpow_def_of_pos hx, exp_le_one_iff, mul_nonpos_iff, log_nonneg_iff hx, log_nonpos_iff hx.le]

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -851,9 +851,9 @@ lemma lt_log_of_pow_lt (hx : 0 < x) (h : x ^ n < y) : n * log x < log y :=
 lemma lt_log_of_zpow_lt {n : ℤ} (hx : 0 < x) (h : x ^ n < y) : n * log x < log y :=
   lt_log_of_rpow_lt hx (rpow_intCast _ _ ▸ h)
 
-@[deprecated (since := "2026-08-06")] alias rpow_lt_of_lt_log := lt_rpow_of_log_lt
-@[deprecated (since := "2026-08-06")] alias pow_lt_of_lt_log := lt_pow_of_log_lt
-@[deprecated (since := "2026-08-06")] alias zpow_lt_of_lt_log := lt_zpow_of_log_lt
+@[deprecated (since := "2026-08-07")] alias rpow_lt_of_lt_log := lt_rpow_of_log_lt
+@[deprecated (since := "2026-08-07")] alias pow_lt_of_lt_log := lt_pow_of_log_lt
+@[deprecated (since := "2026-08-07")] alias zpow_lt_of_lt_log := lt_zpow_of_log_lt
 
 theorem rpow_le_one_iff_of_pos (hx : 0 < x) : x ^ y ≤ 1 ↔ 1 ≤ x ∧ y ≤ 0 ∨ x ≤ 1 ∧ 0 ≤ y := by
   rw [rpow_def_of_pos hx, exp_le_one_iff, mul_nonpos_iff, log_nonneg_iff hx, log_nonpos_iff hx.le]


### PR DESCRIPTION
6 `Pow/Real.lean` lemmas duplicate with misleading names, replace by deprecated aliases

Some of these deprecated lemmas names, or their intended proofs seem mixed up too, which could be updated perhaps after the deprecation period?

[Used Aristotle in making this PR. It found the duplicates, generated guidance, example code, and verifications.](https://github.com/attilavjda/formal-contributions/blob/main/analysis-rpow-dedup/RpowLogDedup.lean)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
