### PR TITLE
refactor: use `cmpLE` in `LinearOrder`

### DIFF
--- a/Mathlib/Data/Ordering/Basic.lean
+++ b/Mathlib/Data/Ordering/Basic.lean
@@ -7,8 +7,6 @@ module
 
 public import Mathlib.Init
 
-import Mathlib.Order.Defs.Unbundled
-
 /-!
 # Helper definitions and instances for `Ordering`
 -/

--- a/Mathlib/Data/Ordering/Basic.lean
+++ b/Mathlib/Data/Ordering/Basic.lean
@@ -1,11 +1,13 @@
 /-
 Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Leonardo de Moura
+Authors: Leonardo de Moura, Yuyang Zhao
 -/
 module
 
 public import Mathlib.Init
+
+import Mathlib.Order.Defs.Unbundled
 
 /-!
 # Helper definitions and instances for `Ordering`
@@ -15,9 +17,9 @@ public import Mathlib.Init
 
 universe u
 
-namespace Ordering
-
 variable {α : Type*}
+
+namespace Ordering
 
 /-- `Compares o a b` means that `a` and `b` have the ordering relation `o` between them, assuming
 that the relation `a < b` is defined. -/
@@ -45,12 +47,59 @@ end Ordering
 Lift a decidable relation to an `Ordering`,
 assuming that incomparable terms are `Ordering.eq`.
 -/
-def cmpUsing {α : Type u} (lt : α → α → Prop) [DecidableRel lt] (a b : α) : Ordering :=
+def cmpUsing (lt : α → α → Prop) [DecidableRel lt] (a b : α) : Ordering :=
   if lt a b then Ordering.lt else if lt b a then Ordering.gt else Ordering.eq
 
 /--
 Construct an `Ordering` from a type with a decidable `LT` instance,
 assuming that incomparable terms are `Ordering.eq`.
 -/
-def cmp {α : Type u} [LT α] [DecidableLT α] (a b : α) : Ordering :=
+def cmp [LT α] [DecidableLT α] (a b : α) : Ordering :=
   cmpUsing (· < ·) a b
+
+variable [LE α] [DecidableLE α]
+
+/-- Like `cmp`, but uses a `≤` on the type instead of `<`. Given two elements `x` and `y`, returns a
+three-way comparison result `Ordering`. -/
+def cmpLE (x y : α) : Ordering :=
+  if x ≤ y then if y ≤ x then Ordering.eq else Ordering.lt else Ordering.gt
+
+theorem cmpLE_swap [Std.Total (α := α) (· ≤ ·)] (x y : α) :
+    (cmpLE x y).swap = cmpLE y x := by
+  by_cases xy : x ≤ y <;> by_cases yx : y ≤ x <;> simp [cmpLE, *, Ordering.swap]
+  cases not_or_intro xy yx (Std.Total.total _ _)
+
+theorem isLE_cmpLE {x y : α} :
+    (cmpLE x y).isLE ↔ x ≤ y := by
+  rw [cmpLE]
+  (repeat' split) <;> simpa
+
+theorem isGE_cmpLE [Std.Total (α := α) (· ≤ ·)] {x y : α} :
+    (cmpLE x y).isGE ↔ y ≤ x := by
+  rw [← Ordering.isLE_swap, cmpLE_swap, isLE_cmpLE]
+
+@[simp]
+theorem cmpLE_eq_lt [LT α] [Std.LawfulOrderLT α] {x y : α} :
+    cmpLE x y = .lt ↔ x < y := by
+  rw [Std.LawfulOrderLT.lt_iff, cmpLE]
+  (repeat' split) <;> simp [*]
+
+@[simp]
+theorem cmpLE_eq_gt [LT α] [Std.LawfulOrderLT α] [Std.Total (α := α) (· ≤ ·)] {x y : α} :
+    cmpLE x y = .gt ↔ y < x := by
+  rw [Std.LawfulOrderLT.lt_iff, ← isGE_cmpLE, ← isLE_cmpLE]
+  cases cmpLE x y <;> decide
+
+@[simp]
+theorem cmpLE_eq_eq [Std.Refl (α := α) (· ≤ ·)] [Std.Antisymm (α := α) (· ≤ ·)] {x y : α} :
+    cmpLE x y = .eq ↔ x = y := by
+  refine Iff.trans ?_ (antisymm_iff (r := (· ≤ ·)))
+  rw [cmpLE]
+  (repeat' split) <;> simp [*]
+
+theorem compareOfLessAndEq_eq_cmpLE [LT α] [DecidableLT α] [DecidableEq α] [Std.LawfulOrderLT α]
+    [Std.Total (α := α) (· ≤ ·)] [Std.Antisymm (α := α) (· ≤ ·)] (x y : α) :
+    compareOfLessAndEq x y = cmpLE x y := by
+  rw [eq_comm, compareOfLessAndEq]
+  simp only [← cmpLE_eq_lt, ← cmpLE_eq_eq (α := α)]
+  cases cmpLE x y <;> decide

--- a/Mathlib/Data/Ordering/Basic.lean
+++ b/Mathlib/Data/Ordering/Basic.lean
@@ -91,7 +91,7 @@ theorem cmpLE_eq_gt [LT α] [Std.LawfulOrderLT α] [Std.Total (α := α) (· ≤
 @[simp]
 theorem cmpLE_eq_eq [Std.Refl (α := α) (· ≤ ·)] [Std.Antisymm (α := α) (· ≤ ·)] {x y : α} :
     cmpLE x y = .eq ↔ x = y := by
-  refine Iff.trans ?_ (antisymm_iff (r := (· ≤ ·)))
+  refine Iff.trans ?_ Std.le_antisymm_iff
   rw [cmpLE]
   (repeat' split) <;> simp [*]
 

--- a/Mathlib/Data/Prod/Lex.lean
+++ b/Mathlib/Data/Prod/Lex.lean
@@ -193,14 +193,11 @@ instance instLinearOrder (α β : Type*) [LinearOrder α] [LinearOrder β] : Lin
   toDecidableLE := Prod.Lex.decidable _ _
   toDecidableLT := Prod.Lex.decidable _ _
   toDecidableEq := instDecidableEqLex _
-  compare_eq_compareOfLessAndEq := fun a b => by
-    have : DecidableLT (α ×ₗ β) := Prod.Lex.decidable _ _
-    have : Std.LawfulBEqOrd (α ×ₗ β) := ⟨by
-      simp [compare_def, compareLex, compareOn, Ordering.then_eq_eq]⟩
-    have : Std.LawfulLTOrd (α ×ₗ β) := ⟨by
-      simp [compare_def, compareLex, compareOn, Ordering.then_eq_lt, toLex_lt_toLex,
-        compare_lt_iff_lt]⟩
-    convert! Std.LawfulLTCmp.eq_compareOfLessAndEq (cmp := compare) a b
+  compare_eq_cmpLE := fun a b => by
+    have : Std.LawfulLEOrd (α ×ₗ β) := ⟨by
+      simp [compare_def, compareLex, compareOn, Ordering.isLE_then_iff_or, toLex_le_toLex,
+        compare_lt_iff_lt, compare_le_iff_le]⟩
+    convert! Std.LawfulLECmp.eq_cmpLE (cmp := compare) a b
 
 @[to_dual]
 instance orderBot [PartialOrder α] [Preorder β] [OrderBot α] [OrderBot β] : OrderBot (α ×ₗ β) where

--- a/Mathlib/Data/String/Basic.lean
+++ b/Mathlib/Data/String/Basic.lean
@@ -153,7 +153,6 @@ instance : LinearOrder String where
   toDecidableLE := inferInstance
   toDecidableEq := inferInstance
   toDecidableLT := String.decidableLT
-  compare_eq_compareOfLessAndEq a b := by simp [Ord.compare, String.compare]
 
 theorem ofList_eq {l : List Char} {s : String} : ofList l = s ↔ l = s.toList := by
   simp [← toList_inj]

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -462,11 +462,11 @@ lemma LinearOrder.toPartialOrder_injective : Function.Injective (@LinearOrder.to
   | { le := A_le, lt := A_lt,
       toDecidableLE := A_decidableLE, toDecidableEq := A_decidableEq, toDecidableLT := A_decidableLT
       min := A_min, max := A_max, min_def := A_min_def, max_def := A_max_def,
-      compare := A_compare, compare_eq_compareOfLessAndEq := A_compare_canonical, .. },
+      compare := A_compare, compare_eq_cmpLE := A_compare_canonical, .. },
     { le := B_le, lt := B_lt,
       toDecidableLE := B_decidableLE, toDecidableEq := B_decidableEq, toDecidableLT := B_decidableLT
       min := B_min, max := B_max, min_def := B_min_def, max_def := B_max_def,
-      compare := B_compare, compare_eq_compareOfLessAndEq := B_compare_canonical, .. } => by
+      compare := B_compare, compare_eq_cmpLE := B_compare_canonical, .. } => by
     rintro ⟨⟩
     obtain rfl : A_decidableLE = B_decidableLE := Subsingleton.elim _ _
     obtain rfl : A_decidableEq = B_decidableEq := Subsingleton.elim _ _
@@ -703,9 +703,9 @@ abbrev Function.Injective.linearOrder [LinearOrder β] [LE α] [LT α] [Max α] 
   le_total _ _ := by simp only [← le, le_total]
   min_def _ _ := by simp_rw [← hf.eq_iff, ← le, apply_ite f, ← min_def, min]
   max_def _ _ := by simp_rw [← hf.eq_iff, ← le, apply_ite f, ← max_def, max]
-  compare_eq_compareOfLessAndEq _ _ := by
-    simp_rw [← compare, LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq, ← lt,
-      hf.eq_iff]
+  compare_eq_cmpLE _ _ := by
+    simp_rw [← compare, LinearOrder.compare_eq_cmpLE, cmpLE]
+    congr! <;> exact le
 
 /-!
 ### Lifts of order instances
@@ -740,7 +740,7 @@ theorem compare_of_injective_eq_compareOfLessAndEq (a b : α) [LinearOrder β]
     [Decidable (LT.lt (self := PartialOrder.lift f inj |>.toLT) a b)] :
     compare (f a) (f b) =
       @compareOfLessAndEq _ a b (PartialOrder.lift f inj |>.toLT) _ _ := by
-  have h := LinearOrder.compare_eq_compareOfLessAndEq (f a) (f b)
+  have h := compare_eq_compareOfLessAndEq (f a) (f b)
   simp only [h, compareOfLessAndEq]
   split_ifs <;> try (first | rfl | contradiction)
   · have : ¬ f a = f b := by rename_i h; exact inj.ne h

--- a/Mathlib/Order/Compare.lean
+++ b/Mathlib/Order/Compare.lean
@@ -27,15 +27,10 @@ This file provides basic results about orderings and comparison in linear orders
 
 variable {α β : Type*}
 
-/-- Like `cmp`, but uses a `≤` on the type instead of `<`. Given two elements `x` and `y`, returns a
-three-way comparison result `Ordering`. -/
-def cmpLE {α} [LE α] [DecidableLE α] (x y : α) : Ordering :=
-  if x ≤ y then if y ≤ x then Ordering.eq else Ordering.lt else Ordering.gt
-
-theorem cmpLE_swap {α} [LE α] [@Std.Total α (· ≤ ·)] [DecidableLE α] (x y : α) :
-    (cmpLE x y).swap = cmpLE y x := by
-  by_cases xy : x ≤ y <;> by_cases yx : y ≤ x <;> simp [cmpLE, *, Ordering.swap]
-  cases not_or_intro xy yx (total_of _ _ _)
+theorem Std.LawfulLECmp.eq_cmpLE {cmp} [LE α] [DecidableLE α] [LawfulLECmp cmp] (x y : α) :
+    cmp x y = cmpLE x y := by
+  simp_rw [cmpLE, ← isLE_iff_le (cmp := cmp) (x := x), ← isGE_iff_ge (cmp := cmp)]
+  cases cmp x y <;> decide
 
 theorem cmpLE_eq_cmp {α} [Preorder α] [@Std.Total α (· ≤ ·)] [DecidableLE α] [DecidableLT α]
     (x y : α) : cmpLE x y = cmp x y := by

--- a/Mathlib/Order/CompleteLattice/Defs.lean
+++ b/Mathlib/Order/CompleteLattice/Defs.lean
@@ -251,10 +251,10 @@ class CompleteLinearOrder (α : Type*) extends CompleteLattice α, BiheytingAlge
   toDecidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ toDecidableLE
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
   toDecidableLT : DecidableLT α := @decidableLTOfDecidableLE _ _ toDecidableLE
-  compare a b := compareOfLessAndEq a b
+  compare a b := cmpLE a b
   /-- Comparison via `compare` is equal to the canonical comparison given decidable `<` and `=`. -/
-  compare_eq_compareOfLessAndEq : ∀ a b, compare a b = compareOfLessAndEq a b := by
-    compareOfLessAndEq_rfl
+  compare_eq_cmpLE : ∀ a b, compare a b = cmpLE a b := by
+    cmpLE_rfl
 
 instance CompleteLinearOrder.toLinearOrder [i : CompleteLinearOrder α] : LinearOrder α where
   __ := i

--- a/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
@@ -76,10 +76,10 @@ class ConditionallyCompleteLinearOrder (α : Type*)
   csSup_of_not_bddAbove : ∀ s, ¬BddAbove s → sSup s = sSup (∅ : Set α)
   /-- If a set is not bounded below, its infimum is by convention `sInf ∅`. -/
   csInf_of_not_bddBelow : ∀ s, ¬BddBelow s → sInf s = sInf (∅ : Set α)
-  compare a b := compareOfLessAndEq a b
+  compare a b := cmpLE a b
   /-- Comparison via `compare` is equal to the canonical comparison given decidable `<` and `=`. -/
-  compare_eq_compareOfLessAndEq : ∀ a b, compare a b = compareOfLessAndEq a b := by
-    compareOfLessAndEq_rfl
+  compare_eq_cmpLE : ∀ a b, compare a b = cmpLE a b := by
+    cmpLE_rfl
 
 /-- A conditionally complete linear order with `Bot` is a linear order with least element, in which
 every nonempty subset which is bounded above has a supremum, and every nonempty subset (necessarily

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -41,19 +41,19 @@ def maxDefault [LE α] [DecidableLE α] (a b : α) :=
 def minDefault [LE α] [DecidableLE α] (a b : α) :=
   if a ≤ b then a else b
 
-/-- This attempts to prove that a given instance of `compare` is equal to `compareOfLessAndEq` by
+/-- This attempts to prove that a given instance of `compare` is equal to `cmpLE` by
 introducing the arguments and trying the following approaches in order:
 
 1. seeing if `rfl` works
-2. seeing if the `compare` at hand is nonetheless essentially `compareOfLessAndEq`, but, because of
-   implicit arguments, requires us to unfold the defs and split the `if`s in the definition of
-   `compareOfLessAndEq`
+2. seeing if the `compare` at hand is nonetheless essentially `cmpLE`, but, because of implicit
+   arguments, requires us to unfold the defs and split the `if`s in the definition of `cmpLE`
 3. seeing if we can split by cases on the arguments, then see if the defs work themselves out
    (useful when `compare` is defined via a `match` statement, as it is for `Bool`)
 -/
-macro "compareOfLessAndEq_rfl" : tactic =>
+macro "cmpLE_rfl" : tactic =>
   `(tactic| (intro a b; first | rfl |
-    (simp only [compare, compareOfLessAndEq]; split_ifs <;> rfl) |
+    (exact compareOfLessAndEq_eq_cmpLE a b) |
+    (simp only [compare, cmpLE]; split_ifs <;> rfl) |
     (induction a <;> induction b <;> simp +decide only)))
 
 /-- A linear order is reflexive, transitive, antisymmetric and total relation `≤`.
@@ -73,10 +73,10 @@ class LinearOrder (α : Type*) extends PartialOrder α, Min α, Max α, Ord α w
   protected min_def : ∀ a b, min a b = if a ≤ b then a else b := by intros; rfl
   /-- The minimum function is equivalent to the one you get from `maxOfLe`. -/
   protected max_def : ∀ a b, max a b = if a ≤ b then b else a := by intros; rfl
-  compare a b := compareOfLessAndEq a b
+  compare a b := cmpLE a b
   /-- Comparison via `compare` is equal to the canonical comparison given decidable `<` and `=`. -/
-  compare_eq_compareOfLessAndEq : ∀ a b, compare a b = compareOfLessAndEq a b := by
-    compareOfLessAndEq_rfl
+  compare_eq_cmpLE : ∀ a b, compare a b = cmpLE a b := by
+    cmpLE_rfl
 
 attribute [to_dual existing] LinearOrder.toMax
 
@@ -119,8 +119,7 @@ lemma ne_iff_lt_or_gt : a ≠ b ↔ a < b ∨ b < a := ⟨lt_or_gt_of_ne, (Or.el
 @[simp, push, to_dual self] lemma not_le : ¬a ≤ b ↔ b < a := lt_iff_not_ge.symm
 
 @[to_dual eq_or_lt_of_not_gt]
-lemma eq_or_gt_of_not_lt (h : ¬a < b) : a = b ∨ b < a :=
-  if h₁ : a = b then Or.inl h₁ else Or.inr (lt_of_not_ge fun hge => h (lt_of_le_of_ne hge h₁))
+lemma eq_or_gt_of_not_lt (h : ¬a < b) : a = b ∨ b < a := (lt_trichotomy a b).resolve_left h
 
 @[to_dual self]
 theorem le_imp_le_of_lt_imp_lt {α β} [Preorder α] [LinearOrder β] {a b : α} {c d : β}
@@ -204,26 +203,19 @@ lemma lt_min (h₁ : a < b) (h₂ : a < c) : a < min b c := by
 section Ord
 
 lemma compare_lt_iff_lt : compare a b = .lt ↔ a < b := by
-  rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq_eq_lt]
+  rw [LinearOrder.compare_eq_cmpLE, cmpLE_eq_lt]
 
 lemma compare_eq_iff_eq : compare a b = .eq ↔ a = b := by
-  rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq_eq_eq le_refl not_le]
+  rw [LinearOrder.compare_eq_cmpLE, cmpLE_eq_eq]
 
 lemma compare_gt_iff_gt : compare a b = .gt ↔ b < a := by
-  rw [LinearOrder.compare_eq_compareOfLessAndEq,
-    compareOfLessAndEq_eq_gt le_antisymm le_total not_le]
+  rw [LinearOrder.compare_eq_cmpLE, cmpLE_eq_gt]
 
-lemma compare_le_iff_le : compare a b ≠ .gt ↔ a ≤ b := by
-  cases h : compare a b
-  · simpa using le_of_lt <| compare_lt_iff_lt.1 h
-  · simpa using le_of_eq <| compare_eq_iff_eq.1 h
-  · simpa using compare_gt_iff_gt.1 h
+lemma compare_le_iff_le : (compare a b).isLE ↔ a ≤ b := by
+  rw [LinearOrder.compare_eq_cmpLE, isLE_cmpLE]
 
-lemma compare_ge_iff_ge : compare a b ≠ .lt ↔ b ≤ a := by
-  cases h : compare a b
-  · simpa using compare_lt_iff_lt.1 h
-  · simpa using le_of_eq <| (·.symm) <| compare_eq_iff_eq.1 h
-  · simpa using le_of_lt <| compare_gt_iff_gt.1 h
+lemma compare_ge_iff_ge : (compare a b).isGE ↔ b ≤ a := by
+  rw [LinearOrder.compare_eq_cmpLE, isGE_cmpLE]
 
 lemma compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ o.Compares a b := by
   cases o <;> simp only [Ordering.Compares]
@@ -238,19 +230,28 @@ theorem cmp_eq_compare (a b : α) : cmp a b = compare a b := by
   · exact h2
   · exact le_antisymm (not_lt.1 h2) (not_lt.1 h1)
 
-theorem cmp_eq_compareOfLessAndEq (a b : α) : cmp a b = compareOfLessAndEq a b :=
-  (cmp_eq_compare ..).trans (LinearOrder.compare_eq_compareOfLessAndEq ..)
+theorem compare_eq_compareOfLessAndEq (a b : α) :
+    compare a b = compareOfLessAndEq a b := by
+  rw [compare_iff, compareOfLessAndEq]
+  split_ifs with h1 h2
+  · exact h1
+  · exact h2
+  · exact (lt_or_gt_of_ne h2).resolve_left h1
+
+theorem cmp_eq_compareOfLessAndEq (a b : α) :
+    cmp a b = compareOfLessAndEq a b := by
+  rw [cmp_eq_compare, compare_eq_compareOfLessAndEq]
 
 instance : Std.LawfulBCmp (compare (α := α)) where
   eq_swap {a b} := by
     cases _ : compare b a <;>
       simp_all [Ordering.swap, compare_eq_iff_eq, compare_lt_iff_lt, compare_gt_iff_gt]
   isLE_trans h₁ h₂ := by
-    simp only [← Ordering.ne_gt_iff_isLE, compare_le_iff_le] at *
+    simp only [compare_le_iff_le] at *
     exact le_trans h₁ h₂
   compare_eq_iff_beq := by simp [compare_eq_iff_eq]
   eq_lt_iff_lt := by simp [compare_lt_iff_lt]
-  isLE_iff_le := by simp [← Ordering.ne_gt_iff_isLE, compare_le_iff_le]
+  isLE_iff_le := by simp [compare_le_iff_le]
 
 end Ord
 

--- a/Mathlib/Order/OrderDual.lean
+++ b/Mathlib/Order/OrderDual.lean
@@ -93,8 +93,8 @@ instance (α : Type*) [LinearOrder α] : LinearOrder αᵒᵈ where
   toDecidableLE := inferInstance
   toDecidableLT := inferInstance
   toDecidableEq := inferInstance
-  compare_eq_compareOfLessAndEq a b := by
-    simp only [compare, LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq, eq_comm]
+  compare_eq_cmpLE a b := by
+    simp only [compare, LinearOrder.compare_eq_cmpLE]
     rfl
 
 set_option linter.style.setOption false in

--- a/Mathlib/Order/Std.lean
+++ b/Mathlib/Order/Std.lean
@@ -278,10 +278,12 @@ def LinearOrder.ofStd (α : Type*) (args : OfStdArgs α := by exact {}) : Linear
         · rfl
       case _ h => rw [if_pos (Std.le_of_lt (Std.not_le.mp h))]
     toOrd := args.ord
-    compare_eq_compareOfLessAndEq a b := by
+    compare_eq_cmpLE a b := by
       let := args.ord
       have := args.lawfulOrderOrd
-      rw [compareOfLessAndEq]
+      let := args.decidableLT
+      let := args.decidableEq
+      rw [← compareOfLessAndEq_eq_cmpLE, compareOfLessAndEq]
       split_ifs
       case _ => rwa [Std.compare_eq_lt]
       case _ => rwa [Std.compare_eq_iff_eq]

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -30,7 +30,7 @@
  ["defsWithUnderscore",
   "singularChainComplexFunctor_mapHomotopy_of_simplicialHomotopy"],
  ["defsWithUnderscore", "spectralAlgNorm_of_finiteDimensional_normal"],
- ["defsWithUnderscore", "tacticCompareOfLessAndEq_rfl"],
+ ["defsWithUnderscore", "tacticCmpLE_rfl"],
  ["defsWithUnderscore", "tacticUse_finite_instance"],
  ["defsWithUnderscore", "toAddUnits_homeomorph"],
  ["defsWithUnderscore", "toUnits_homeomorph"],


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
