### PR TITLE
feat(Tactic/Linter): lint against exposed defs with `Classical.choose` (or equivalent) body

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7416,6 +7416,7 @@ public import Mathlib.Tactic.Linter.DocString
 public import Mathlib.Tactic.Linter.EmptyLine
 public import Mathlib.Tactic.Linter.FindDeprecations
 public import Mathlib.Tactic.Linter.FlexibleLinter
+public import Mathlib.Tactic.Linter.ForbiddenExposedHead
 public import Mathlib.Tactic.Linter.GlobalAttributeIn
 public import Mathlib.Tactic.Linter.HashCommandLinter
 public import Mathlib.Tactic.Linter.HaveLetLinter

--- a/Mathlib/Condensed/Light/Functors.lean
+++ b/Mathlib/Condensed/Light/Functors.lean
@@ -81,7 +81,7 @@ instance : PreservesFiniteLimits lightProfiniteToLightCondSet.{u} where
 The functor from `LightProfinite` to `LightCondSet` is monoidal with respect to the cartesian
 monoidal structure.
 -/
-noncomputable instance : lightProfiniteToLightCondSet.{u}.Monoidal :=
+@[no_expose] noncomputable instance : lightProfiniteToLightCondSet.{u}.Monoidal :=
   (Functor.Monoidal.nonempty_monoidal_iff_preservesFiniteProducts _).mpr inferInstance |>.some
 
 instance : PreservesFiniteCoproducts lightProfiniteToLightCondSet.{u} :=

--- a/Mathlib/Condensed/Light/Functors.lean
+++ b/Mathlib/Condensed/Light/Functors.lean
@@ -81,7 +81,7 @@ instance : PreservesFiniteLimits lightProfiniteToLightCondSet.{u} where
 The functor from `LightProfinite` to `LightCondSet` is monoidal with respect to the cartesian
 monoidal structure.
 -/
-@[no_expose] noncomputable instance : lightProfiniteToLightCondSet.{u}.Monoidal :=
+noncomputable instance : lightProfiniteToLightCondSet.{u}.Monoidal :=
   (Functor.Monoidal.nonempty_monoidal_iff_preservesFiniteProducts _).mpr inferInstance |>.some
 
 instance : PreservesFiniteCoproducts lightProfiniteToLightCondSet.{u} :=

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -26,6 +26,7 @@ public import Mathlib.Tactic.Linter.UnusedTactic
 public import Mathlib.Tactic.Linter.UnusedInstancesInType
 public import Mathlib.Tactic.Linter.Style
 public import Mathlib.Tactic.Linter.Whitespace
+public import Mathlib.Tactic.Linter.ForbiddenExposedHead
 public import Mathlib.Tactic.TacticAnalysis.Declarations
 public import Mathlib.Tactic.TypeStar
 -- This import makes the `#help` command available globally.

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -188,6 +188,7 @@ public import Mathlib.Tactic.Linter.DocString
 public import Mathlib.Tactic.Linter.EmptyLine
 public import Mathlib.Tactic.Linter.FindDeprecations
 public import Mathlib.Tactic.Linter.FlexibleLinter
+public import Mathlib.Tactic.Linter.ForbiddenExposedHead
 public import Mathlib.Tactic.Linter.GlobalAttributeIn
 public import Mathlib.Tactic.Linter.HashCommandLinter
 public import Mathlib.Tactic.Linter.HaveLetLinter

--- a/Mathlib/Tactic/Linter/ForbiddenExposedHead.lean
+++ b/Mathlib/Tactic/Linter/ForbiddenExposedHead.lean
@@ -40,13 +40,14 @@ constant (defined in the `forbiddenExposed.forbiddenHeads` array). -/
   test declName := do
     let env ← getEnv
     let c := (env.find? declName).get!
-    -- skip non-definitions, automatic declarations, and definition without an exposed body
+    -- skip non-definitions, automatic declarations, and definitions without an exposed body
     unless c.isDefinition && !(← isAutoDecl declName) && env.hasExposedBody declName do return none
     let some body := c.value? | return none
-    let h := body.getAppFn
-    if forbiddenExposed.forbiddenHeads.any (· == h.constName) then
+    let (_, _, b) ← lambdaMetaTelescope body
+    let n := b.getAppFn.constName
+    if forbiddenExposed.forbiddenHeads.any (· == n) then
       return m!"The definition `{declName}` is exposed and has
-        `{h.constName}` as head symbol of its body. \
+        `{n}` as head symbol of its body. \
         Please mark this definition with `@[no_expose]` or move it in a non-exposed section
         and provide specification lemmas for this definition."
     else return none

--- a/Mathlib/Tactic/Linter/ForbiddenExposedHead.lean
+++ b/Mathlib/Tactic/Linter/ForbiddenExposedHead.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+module
+
+-- Import this linter explicitly to ensure that
+-- this file has a valid copyright header and module docstring.
+public meta import Mathlib.Tactic.Linter.Header  -- shake: keep
+public import Batteries.Tactic.Lint.Basic
+
+/-!
+## The Forbidden Exposed Head Linter
+
+This file defines a linter that checks every definitions against a list of head symbols
+(mostly non-constructive data producer such as `Classical.choose`, `Exist.choose`, `Nonempty.some`, etc.),
+and ensure that definitions with this head symbol are not exposed. -/
+
+
+meta section
+
+namespace Mathlib.Linter
+
+open Lean Parser Elab Command Meta Linter
+
+/-- The list of forbidden head names for the `forbiddenExposed` linter. -/
+public def forbiddenExposed.forbiddenHeads : Array Name := #[
+  `Classical.choose,
+  `Classical.choice,
+  `Exists.choose,
+  `Nonempty.some ]
+
+open Batteries.Tactic.Lint in
+/-- Linter that checks if definitions are exposed `def`s with a known forbidden-for-exposure head
+constant (defined in the `forbiddenExposed.forbiddenHeads` array). -/
+@[env_linter] public def forbiddenExposed : Batteries.Tactic.Lint.Linter where
+  noErrorsFound := "no exposed definitions with a forbidden head symbol."
+  errorsFound := "FOUND exposed definitions with a forbidden head symbol"
+  test declName := do
+    let env ← getEnv
+    let c := (env.find? declName).get!
+    -- skip non-definitions, automatic declarations, and definition without an exposed body
+    unless c.isDefinition && !(← isAutoDecl declName) && env.hasExposedBody declName do return none
+    let some body := c.value? | return none
+    let h := body.getAppFn
+    if forbiddenExposed.forbiddenHeads.any (· == h.constName) then
+      return m!"The definition `{declName}` is exposed and has
+        `{h.constName}` as head symbol of its body. \
+        Please mark this definition with `@[no_expose]` or move it in a non-exposed section
+        and provide specification lemmas for this definition."
+    else return none

--- a/Mathlib/Tactic/Linter/ForbiddenExposedHead.lean
+++ b/Mathlib/Tactic/Linter/ForbiddenExposedHead.lean
@@ -39,7 +39,7 @@ constant (defined in the `forbiddenExposed.forbiddenHeads` array). -/
   errorsFound := "FOUND exposed definitions with a forbidden head symbol"
   test declName := do
     let env ← getEnv
-    let c := (env.find? declName).get!
+    let c ← getConstInfo declName
     -- skip non-definitions, automatic declarations, and definitions without an exposed body
     unless c.isDefinition && !(← isAutoDecl declName) && env.hasExposedBody declName do return none
     let some body := c.value? | return none

--- a/Mathlib/Tactic/Linter/ForbiddenExposedHead.lean
+++ b/Mathlib/Tactic/Linter/ForbiddenExposedHead.lean
@@ -38,10 +38,9 @@ constant (defined in the `forbiddenExposed.forbiddenHeads` array). -/
   noErrorsFound := "no exposed definitions with a forbidden head symbol."
   errorsFound := "FOUND exposed definitions with a forbidden head symbol"
   test declName := do
-    let env ← getEnv
     let c ← getConstInfo declName
     -- skip non-definitions, automatic declarations, and definitions without an exposed body
-    unless c.isDefinition && !(← isAutoDecl declName) && env.hasExposedBody declName do return none
+    unless c.isDefinition && !(← isAutoDecl declName) && (← getEnv).hasExposedBody declName do return none
     let some body := c.value? | return none
     let (_, _, b) ← lambdaMetaTelescope body
     let n := b.getAppFn.constName

--- a/MathlibTest/Linter/ForbiddenExposedHead.lean
+++ b/MathlibTest/Linter/ForbiddenExposedHead.lean
@@ -1,0 +1,34 @@
+module
+public import Mathlib.Tactic.Linter.ForbiddenExposedHead
+public import Batteries.Tactic.Lint.Frontend
+public import Mathlib.Logic.Nonempty
+
+/-- A docstring -/
+@[expose] public noncomputable def anExposedDef : Nat := Classical.choice inferInstance
+/-- A docstring -/
+public noncomputable def aNonExposedDef : Nat := Classical.choice inferInstance
+/-- A docstring -/
+noncomputable def aPrivateNonExposedDef : Nat := Classical.choice inferInstance
+
+@[expose] public noncomputable def anotherExposedDef : Nat := Nonempty.some inferInstance
+
+/--
+error: -- Found 3 errors in 3 declarations (plus 2 automatically generated ones) in the current file with 14 linters
+
+/- The `docBlame` linter reports:
+DEFINITIONS ARE MISSING DOCUMENTATION STRINGS:
+This linter can be disabled with `@[nolint docBlame]`. -/
+#check anotherExposedDef /- definition missing documentation string -/
+
+/- The `forbiddenExposed` linter reports:
+FOUND exposed definitions with a forbidden head symbol
+This linter can be disabled with `@[nolint forbiddenExposed]`. -/
+#check anExposedDef /- The definition `anExposedDef` is exposed and has
+        `Classical.choice` as head symbol of its body. Please mark this definition with `@[no_expose]` or move it in a non-exposed section
+        and provide specification lemmas for this definition. -/
+#check anotherExposedDef /- The definition `anotherExposedDef` is exposed and has
+        `Nonempty.some` as head symbol of its body. Please mark this definition with `@[no_expose]` or move it in a non-exposed section
+        and provide specification lemmas for this definition. -/
+-/
+#guard_msgs in
+#lint


### PR DESCRIPTION
Definitional properties of definitions made through `Classical.choice` (or `Classical.choose`, or `Nonempty.some`, etc.) should not matter. Hence, it makes sense to systematically `no_expose` such definitions. This PR adds an environment linter that checks definitions with an exposed body and tests their body against a known list of "forbidden" head constants. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Currently, the linter is very simple and it does not try recursing into structures. For instance, if `Foo` is a one-field structure (such as `Inhabited`), this linter will not fire on something defined as `mk (Classical.choose _)` while it arguably should. (Do we want this for multi-fields structures? I can see some issues if we want to keep defeqs of certain fields but not for the others, e.g. for some functors in category theory).
Happy to try to implement this if asked to.

It seems the current implementation is broken.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
