### PR TITLE
[Merged by Bors] - chore(Analysis/Calculus/FDeriv/Prod): deprecate differentiable*_finCons' as duplicates

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -598,18 +598,14 @@ theorem differentiableWithinAt_finCons :
   rw [differentiableWithinAt_pi, Fin.forall_fin_succ, differentiableWithinAt_pi]
   simp only [Fin.cons_zero, Fin.cons_succ]
 
-/-- A variant of `differentiableWithinAt_finCons` where the derivative variables are free on the RHS
-instead. -/
-theorem differentiableWithinAt_finCons' :
-    DifferentiableWithinAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) s x ↔
-      DifferentiableWithinAt 𝕜 φ s x ∧ DifferentiableWithinAt 𝕜 φs s x :=
-  differentiableWithinAt_finCons
+@[deprecated (since := "2026-08-08")]
+alias differentiableWithinAt_finCons' := differentiableWithinAt_finCons
 
 @[fun_prop]
 theorem DifferentiableWithinAt.finCons
     (h : DifferentiableWithinAt 𝕜 φ s x) (hs : DifferentiableWithinAt 𝕜 φs s x) :
     DifferentiableWithinAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) s x :=
-  differentiableWithinAt_finCons'.mpr ⟨h, hs⟩
+  differentiableWithinAt_finCons.mpr ⟨h, hs⟩
 
 theorem differentiableAt_finCons :
     DifferentiableAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) x ↔
@@ -617,18 +613,14 @@ theorem differentiableAt_finCons :
   rw [differentiableAt_pi, Fin.forall_fin_succ, differentiableAt_pi]
   simp only [Fin.cons_zero, Fin.cons_succ]
 
-/-- A variant of `differentiableAt_finCons` where the derivative variables are free on the RHS
-instead. -/
-theorem differentiableAt_finCons' :
-    DifferentiableAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) x ↔
-      DifferentiableAt 𝕜 φ x ∧ DifferentiableAt 𝕜 φs x :=
-  differentiableAt_finCons
+@[deprecated (since := "2026-08-08")]
+alias differentiableAt_finCons' := differentiableAt_finCons
 
 @[fun_prop]
 theorem DifferentiableAt.finCons
     (h : DifferentiableAt 𝕜 φ x) (hs : DifferentiableAt 𝕜 φs x) :
     DifferentiableAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) x :=
-  differentiableAt_finCons'.mpr ⟨h, hs⟩
+  differentiableAt_finCons.mpr ⟨h, hs⟩
 
 theorem differentiableOn_finCons :
     DifferentiableOn 𝕜 (fun x => Fin.cons (φ x) (φs x)) s ↔
@@ -636,18 +628,14 @@ theorem differentiableOn_finCons :
   rw [differentiableOn_pi, Fin.forall_fin_succ, differentiableOn_pi]
   simp only [Fin.cons_zero, Fin.cons_succ]
 
-/-- A variant of `differentiableOn_finCons` where the derivative variables are free on the RHS
-instead. -/
-theorem differentiableOn_finCons' :
-    DifferentiableOn 𝕜 (fun x => Fin.cons (φ x) (φs x)) s ↔
-      DifferentiableOn 𝕜 φ s ∧ DifferentiableOn 𝕜 φs s :=
-  differentiableOn_finCons
+@[deprecated (since := "2026-08-08")]
+alias differentiableOn_finCons' := differentiableOn_finCons
 
 @[fun_prop]
 theorem DifferentiableOn.finCons
     (h : DifferentiableOn 𝕜 φ s) (hs : DifferentiableOn 𝕜 φs s) :
     DifferentiableOn 𝕜 (fun x => Fin.cons (φ x) (φs x)) s :=
-  differentiableOn_finCons'.mpr ⟨h, hs⟩
+  differentiableOn_finCons.mpr ⟨h, hs⟩
 
 theorem differentiable_finCons :
     Differentiable 𝕜 (fun x => Fin.cons (φ x) (φs x)) ↔
@@ -655,18 +643,14 @@ theorem differentiable_finCons :
   rw [differentiable_pi, Fin.forall_fin_succ, differentiable_pi]
   simp only [Fin.cons_zero, Fin.cons_succ]
 
-/-- A variant of `differentiable_finCons` where the derivative variables are free on the RHS
-instead. -/
-theorem differentiable_finCons' :
-    Differentiable 𝕜 (fun x => Fin.cons (φ x) (φs x)) ↔
-      Differentiable 𝕜 φ ∧ Differentiable 𝕜 φs :=
-  differentiable_finCons
+@[deprecated (since := "2026-08-08")]
+alias differentiable_finCons' := differentiable_finCons
 
 @[fun_prop]
 theorem Differentiable.finCons
     (h : Differentiable 𝕜 φ) (hs : Differentiable 𝕜 φs) :
     Differentiable 𝕜 (fun x => Fin.cons (φ x) (φs x)) :=
-  differentiable_finCons'.mpr ⟨h, hs⟩
+  differentiable_finCons.mpr ⟨h, hs⟩
 
 -- TODO: write the `Fin.cons` versions of `fderivWithin_pi` and `fderiv_pi`
 

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -375,13 +375,13 @@ theorem AntitoneOn.convex_gt (hf : AntitoneOn f s) (hs : Convex 𝕜 s) (r : β)
 theorem Monotone.convex_le (hf : Monotone f) (r : β) : Convex 𝕜 { x | f x ≤ r } :=
   Set.sep_univ.subst ((hf.monotoneOn univ).convex_le convex_univ r)
 
-theorem Monotone.convex_lt (hf : Monotone f) (r : β) : Convex 𝕜 { x | f x ≤ r } :=
+theorem Monotone.convex_lt (hf : Monotone f) (r : β) : Convex 𝕜 { x | f x < r } :=
   Set.sep_univ.subst ((hf.monotoneOn univ).convex_le convex_univ r)
 
 theorem Monotone.convex_ge (hf : Monotone f) (r : β) : Convex 𝕜 { x | r ≤ f x } :=
   Set.sep_univ.subst ((hf.monotoneOn univ).convex_ge convex_univ r)
 
-theorem Monotone.convex_gt (hf : Monotone f) (r : β) : Convex 𝕜 { x | f x ≤ r } :=
+theorem Monotone.convex_gt (hf : Monotone f) (r : β) : Convex 𝕜 { x | r < f x } :=
   Set.sep_univ.subst ((hf.monotoneOn univ).convex_le convex_univ r)
 
 theorem Antitone.convex_le (hf : Antitone f) (r : β) : Convex 𝕜 { x | f x ≤ r } :=

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -376,13 +376,13 @@ theorem Monotone.convex_le (hf : Monotone f) (r : β) : Convex 𝕜 { x | f x �
   Set.sep_univ.subst ((hf.monotoneOn univ).convex_le convex_univ r)
 
 theorem Monotone.convex_lt (hf : Monotone f) (r : β) : Convex 𝕜 { x | f x < r } :=
-  Set.sep_univ.subst ((hf.monotoneOn univ).convex_le convex_univ r)
+  Set.sep_univ.subst ((hf.monotoneOn univ).convex_lt convex_univ r)
 
 theorem Monotone.convex_ge (hf : Monotone f) (r : β) : Convex 𝕜 { x | r ≤ f x } :=
   Set.sep_univ.subst ((hf.monotoneOn univ).convex_ge convex_univ r)
 
 theorem Monotone.convex_gt (hf : Monotone f) (r : β) : Convex 𝕜 { x | r < f x } :=
-  Set.sep_univ.subst ((hf.monotoneOn univ).convex_le convex_univ r)
+  Set.sep_univ.subst ((hf.monotoneOn univ).convex_gt convex_univ r)
 
 theorem Antitone.convex_le (hf : Antitone f) (r : β) : Convex 𝕜 { x | f x ≤ r } :=
   Set.sep_univ.subst ((hf.antitoneOn univ).convex_le convex_univ r)

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -375,14 +375,14 @@ theorem AntitoneOn.convex_gt (hf : AntitoneOn f s) (hs : Convex 𝕜 s) (r : β)
 theorem Monotone.convex_le (hf : Monotone f) (r : β) : Convex 𝕜 { x | f x ≤ r } :=
   Set.sep_univ.subst ((hf.monotoneOn univ).convex_le convex_univ r)
 
-theorem Monotone.convex_lt (hf : Monotone f) (r : β) : Convex 𝕜 { x | f x < r } :=
-  Set.sep_univ.subst ((hf.monotoneOn univ).convex_lt convex_univ r)
+theorem Monotone.convex_lt (hf : Monotone f) (r : β) : Convex 𝕜 { x | f x ≤ r } :=
+  Set.sep_univ.subst ((hf.monotoneOn univ).convex_le convex_univ r)
 
 theorem Monotone.convex_ge (hf : Monotone f) (r : β) : Convex 𝕜 { x | r ≤ f x } :=
   Set.sep_univ.subst ((hf.monotoneOn univ).convex_ge convex_univ r)
 
-theorem Monotone.convex_gt (hf : Monotone f) (r : β) : Convex 𝕜 { x | r < f x } :=
-  Set.sep_univ.subst ((hf.monotoneOn univ).convex_gt convex_univ r)
+theorem Monotone.convex_gt (hf : Monotone f) (r : β) : Convex 𝕜 { x | f x ≤ r } :=
+  Set.sep_univ.subst ((hf.monotoneOn univ).convex_le convex_univ r)
 
 theorem Antitone.convex_le (hf : Antitone f) (r : β) : Convex 𝕜 { x | f x ≤ r } :=
   Set.sep_univ.subst ((hf.antitoneOn univ).convex_le convex_univ r)


### PR DESCRIPTION
The four primed `differentiable*_finCons'` lemmas are  exact copies of the unprimed ones (`@…' = @… := by with_reducible rfl`). Replaced by deprecated aliases, and repointed four in-file uses.

Aristotle found this duplication.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
