### PR TITLE
[Merged by Bors] - chore: rename MvPolynomial.monomial_mul to monomial_mul_monomial

### DIFF
--- a/Counterexamples/CliffordAlgebraNotInjective.lean
+++ b/Counterexamples/CliffordAlgebraNotInjective.lean
@@ -51,8 +51,8 @@ theorem mem_kIdeal_iff (x : MvPolynomial (Fin 3) (ZMod 2)) :
     x ∈ kIdeal ↔ ∀ m : Fin 3 →₀ ℕ, m ∈ x.support → ∃ i, 2 ≤ m i := by
   have :
       kIdeal = Ideal.span ((monomial · (1 : ZMod 2)) '' Set.range (Finsupp.single · 2)) := by
-    simp_rw [kIdeal, MvPolynomial.X, monomial_mul_monomial, one_mul, ← Finsupp.single_add, ← Set.range_comp,
-      Function.comp_def]
+    simp_rw [kIdeal, MvPolynomial.X, monomial_mul_monomial, one_mul, ← Finsupp.single_add,
+      ← Set.range_comp, Function.comp_def]
   rw [this, mem_ideal_span_monomial_image]
   simp
 

--- a/Counterexamples/CliffordAlgebraNotInjective.lean
+++ b/Counterexamples/CliffordAlgebraNotInjective.lean
@@ -51,7 +51,7 @@ theorem mem_kIdeal_iff (x : MvPolynomial (Fin 3) (ZMod 2)) :
     x ∈ kIdeal ↔ ∀ m : Fin 3 →₀ ℕ, m ∈ x.support → ∃ i, 2 ≤ m i := by
   have :
       kIdeal = Ideal.span ((monomial · (1 : ZMod 2)) '' Set.range (Finsupp.single · 2)) := by
-    simp_rw [kIdeal, MvPolynomial.X, monomial_mul, one_mul, ← Finsupp.single_add, ← Set.range_comp,
+    simp_rw [kIdeal, MvPolynomial.X, monomial_mul_monomial, one_mul, ← Finsupp.single_add, ← Set.range_comp,
       Function.comp_def]
   rw [this, mem_ideal_span_monomial_image]
   simp
@@ -80,7 +80,7 @@ theorem mul_self_mem_kIdeal_of_X_Y_Z_mul_mem {x : MvPolynomial (Fin 3) (ZMod 2)}
     norm_num at hi
   rw [as_sum x, CharTwo.sum_mul_self]
   refine sum_mem fun m hm => ?_
-  rw [mem_kIdeal_iff, monomial_mul]
+  rw [mem_kIdeal_iff, monomial_mul_monomial]
   intro m' hm'
   obtain rfl := Finset.mem_singleton.1 (support_monomial_subset hm')
   rw [mem_ideal_span_X_image] at this

--- a/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
@@ -133,7 +133,7 @@ lemma toMvPolynomial_mul (M : Matrix m n R) (N : Matrix n o R) (i : m) :
   simp only [toMvPolynomial, mul_apply, map_sum, Finset.sum_comm (γ := o), bind₁, aeval,
     AlgHom.coe_mk, coe_eval₂Hom, eval₂_monomial, algebraMap_apply, Algebra.algebraMap_self,
     RingHom.id_apply, C_apply, pow_zero, Finsupp.prod_single_index, pow_one, Finset.mul_sum,
-    monomial_mul, zero_add]
+    monomial_mul_monomial, zero_add]
 
 end Matrix
 

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -229,9 +229,11 @@ theorem monomial_pow : monomial s a ^ e = monomial (e • s) (a ^ e) :=
   AddMonoidAlgebra.single_pow ..
 
 @[simp]
-theorem monomial_mul {s s' : σ →₀ ℕ} {a b : R} :
+theorem monomial_mul_monomial {s s' : σ →₀ ℕ} {a b : R} :
     monomial s a * monomial s' b = monomial (s + s') (a * b) :=
   AddMonoidAlgebra.single_mul_single ..
+
+@[deprecated (since := "2026-08-08")] alias monomial_mul := monomial_mul_monomial
 
 variable (σ R)
 
@@ -249,10 +251,10 @@ theorem X_pow_eq_monomial : X n ^ e = monomial (Finsupp.single n e) (1 : R) := b
   simp [X, monomial_pow]
 
 theorem monomial_add_single : monomial (s + Finsupp.single n e) a = monomial s a * X n ^ e := by
-  rw [X_pow_eq_monomial, monomial_mul, mul_one]
+  rw [X_pow_eq_monomial, monomial_mul_monomial, mul_one]
 
 theorem monomial_single_add : monomial (Finsupp.single n e + s) a = X n ^ e * monomial s a := by
-  rw [X_pow_eq_monomial, monomial_mul, one_mul]
+  rw [X_pow_eq_monomial, monomial_mul_monomial, one_mul]
 
 theorem C_mul_X_pow_eq_monomial {s : σ} {a : R} {n : ℕ} :
     C a * X s ^ n = monomial (Finsupp.single s n) a := by
@@ -1066,7 +1068,7 @@ lemma coeffsIn_mul (M N : Submodule R S) : coeffsIn σ (M * N) = coeffsIn σ M *
   · intro r hr s
     induction hr using Submodule.mul_induction_on' with
     | mem_mul_mem m hm n hn =>
-      rw [← add_zero s, ← monomial_mul]
+      rw [← add_zero s, ← monomial_mul_monomial]
       apply Submodule.mul_mem_mul <;> simpa
     | add x _ y _ hx hy =>
       simpa [map_add] using add_mem hx hy

--- a/Mathlib/Algebra/MvPolynomial/Derivation.lean
+++ b/Mathlib/Algebra/MvPolynomial/Derivation.lean
@@ -114,14 +114,14 @@ def mkDerivation (f : σ → A) : Derivation R (MvPolynomial σ R) A where
   map_one_eq_zero' := mkDerivationₗ_C _ 1
   leibniz' :=
     (leibniz_iff_X (mkDerivationₗ R f) (mkDerivationₗ_C _ 1)).2 fun s i => by
-      simp only [mkDerivationₗ_monomial, X, monomial_mul, one_smul, one_mul]
+      simp only [mkDerivationₗ_monomial, X, monomial_mul_monomial, one_smul, one_mul]
       rw [Finsupp.sum_add_index'] <;>
         [skip; simp; (intros; simp only [Nat.cast_add, (monomial _).map_add, add_smul])]
       rw [Finsupp.sum_single_index, Finsupp.sum_single_index] <;> [skip; simp; simp]
       rw [tsub_self, add_tsub_cancel_right, Nat.cast_one, ← C_apply, C_1, one_smul, add_comm,
         Finsupp.smul_sum]
       refine congr_arg₂ (· + ·) rfl (Finset.sum_congr rfl fun j hj => ?_); dsimp only
-      rw [smul_smul, monomial_mul, one_mul, add_comm s, add_tsub_assoc_of_le]
+      rw [smul_smul, monomial_mul_monomial, one_mul, add_comm s, add_tsub_assoc_of_le]
       rwa [Finsupp.single_le_iff, Nat.succ_le_iff, pos_iff_ne_zero, ← Finsupp.mem_support_iff]
 
 @[simp]

--- a/Mathlib/Algebra/MvPolynomial/Division.lean
+++ b/Mathlib/Algebra/MvPolynomial/Division.lean
@@ -200,7 +200,7 @@ theorem monomial_dvd_monomial {r s : R} {i j : σ →₀ ℕ} :
   · rintro ⟨h | hij, d, rfl⟩
     · simp_rw [h, monomial_zero, dvd_zero]
     · refine ⟨monomial (j - i) d, ?_⟩
-      rw [monomial_mul, add_tsub_cancel_of_le hij]
+      rw [monomial_mul_monomial, add_tsub_cancel_of_le hij]
 
 @[simp]
 theorem monomial_one_dvd_monomial_one [Nontrivial R] {i j : σ →₀ ℕ} :
@@ -369,7 +369,7 @@ theorem dvd_monomial_mul_iff_exists [IsCancelMulZero R] {n : σ →₀ ℕ} :
         use m + Finsupp.single i 1, r, ?_, hr
         · simp [monomial_add_single, pow_one, mul_comm _ (X i), mul_assoc, ← hp]
         · simpa [← hn'] using hm
-    · rw [hp, ← add_tsub_cancel_of_le hmn, ← mul_one 1, ← monomial_mul, mul_one, mul_assoc]
+    · rw [hp, ← add_tsub_cancel_of_le hmn, ← mul_one 1, ← monomial_mul_monomial, mul_one, mul_assoc]
       apply mul_dvd_mul dvd_rfl
       apply dvd_mul_of_dvd_right hrq
 

--- a/Mathlib/Algebra/MvPolynomial/PDeriv.lean
+++ b/Mathlib/Algebra/MvPolynomial/PDeriv.lean
@@ -78,7 +78,7 @@ theorem pderiv_monomial {i : σ} :
 
 lemma X_mul_pderiv_monomial {i : σ} {m : σ →₀ ℕ} {r : R} :
     X i * pderiv i (monomial m r) = m i • monomial m r := by
-  rw [pderiv_monomial, X, monomial_mul, smul_monomial]
+  rw [pderiv_monomial, X, monomial_mul_monomial, smul_monomial]
   by_cases h : m i = 0
   · simp_rw [h, Nat.cast_zero, mul_zero, zero_smul, monomial_zero]
   rw [one_mul, mul_comm, nsmul_eq_mul, add_comm, sub_add_single_one_cancel h]

--- a/Mathlib/RingTheory/Extension/Generators.lean
+++ b/Mathlib/RingTheory/Extension/Generators.lean
@@ -692,7 +692,7 @@ lemma map_toComp_ker (Q : Generators S T ι') (P : Generators R S ι) :
         toComp_toAlgHom_monomial ..
       simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe,
           this]
-      rw [monomial_mul, ← map_add, Prod.mk_add_mk, add_zero, zero_add, one_mul]
+      rw [monomial_mul_monomial, ← map_add, Prod.mk_add_mk, add_zero, zero_add, one_mul]
     · apply Ideal.mul_mem_left
       refine Ideal.mem_map_of_mem _ ?_
       simp only [ker_eq_ker_aeval_val, AddEquiv.toEquiv_eq_coe, RingHom.mem_ker, map_sum]

--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -251,7 +251,7 @@ lemma δAux_mul (x y) :
   | monomial n r =>
     induction y using MvPolynomial.induction_on' with
     | monomial m s =>
-      simp only [monomial_mul, δAux_monomial, Derivation.leibniz, tmul_add, tmul_smul,
+      simp only [monomial_mul_monomial, δAux_monomial, Derivation.leibniz, tmul_add, tmul_smul,
         smul_tmul', Algebra.smul_def, algebraMap_apply, aeval_monomial, mul_assoc]
       rw [mul_comm (m.prod _) (n.prod _)]
       simp only [pow_zero, implies_true, pow_add, Finsupp.prod_add_index']

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -119,7 +119,7 @@ lemma restrictSupport_add (s t : Set (σ →₀ ℕ)) :
   apply le_antisymm
   · rw [restrictSupport_eq_span, Submodule.span_le, Set.image_subset_iff, Set.add_subset_iff]
     intro x hx y hy
-    simp [show monomial (x + y) (1 : R) = monomial x 1 * monomial y 1 by simp, -monomial_mul,
+    simp [show monomial (x + y) (1 : R) = monomial x 1 * monomial y 1 by simp, -monomial_mul_monomial,
       *, Submodule.mul_mem_mul]
   · rw [restrictSupport_eq_span, restrictSupport_eq_span, Submodule.span_mul_span,
       Submodule.span_le, Set.mul_subset_iff]

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -119,8 +119,8 @@ lemma restrictSupport_add (s t : Set (σ →₀ ℕ)) :
   apply le_antisymm
   · rw [restrictSupport_eq_span, Submodule.span_le, Set.image_subset_iff, Set.add_subset_iff]
     intro x hx y hy
-    simp [show monomial (x + y) (1 : R) = monomial x 1 * monomial y 1 by simp, -monomial_mul_monomial,
-      *, Submodule.mul_mem_mul]
+    simp [show monomial (x + y) (1 : R) = monomial x 1 * monomial y 1 by simp,
+      -monomial_mul_monomial, *, Submodule.mul_mem_mul]
   · rw [restrictSupport_eq_span, restrictSupport_eq_span, Submodule.span_mul_span,
       Submodule.span_le, Set.mul_subset_iff]
     simp +contextual [Set.add_mem_add]

--- a/Mathlib/RingTheory/MvPolynomial/IrreducibleQuadratic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/IrreducibleQuadratic.lean
@@ -213,7 +213,7 @@ theorem irreducible_sumSMulXSMulY [IsDomain R]
      fun i j ↦ by simp +contextual [Finsupp.ext_iff, Finsupp.single_apply, ite_eq_iff']⟩
   have aux : sumSMulXSMulY c = .ofCoeff (c.embDomain ι) := by
     rw [← Finsupp.sum_single (Finsupp.embDomain _ _)]
-    simp [Finsupp.sum_embDomain, sumSMulXSMulY, X, monomial_mul,
+    simp [Finsupp.sum_embDomain, sumSMulXSMulY, X, monomial_mul_monomial,
       Finsupp.linearCombination_apply, smul_monomial, ι]
     rfl
   have hcoeff (i : n) : coeff (ι i) (sumSMulXSMulY c) = c i := by

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -1209,7 +1209,7 @@ lemma sPolynomial_monomial_mul [NoZeroDivisors R] (p₁ p₂ : MvPolynomial σ R
   have hm1 := (monomial_eq_zero (s := d₁)).not.mpr hc1
   have hm2 := (monomial_eq_zero (s := d₂)).not.mpr hc2
   simp_rw [m.degree_mul hm1 hp1, m.degree_mul hm2 hp2,
-    mul_sub, ← mul_assoc _ _ p₁, ← mul_assoc _ _ p₂, monomial_mul,
+    mul_sub, ← mul_assoc _ _ p₁, ← mul_assoc _ _ p₂, monomial_mul_monomial,
     m.leadingCoeff_mul, m.leadingCoeff_monomial,
     degree_monomial, hc1, hc2, reduceIte, mul_right_comm, mul_comm c₂ c₁]
   rw [tsub_add_tsub_cancel (sup_le_sup (self_le_add_left _ _) (self_le_add_left _ _)) (by simp),

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric/FundamentalTheorem.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric/FundamentalTheorem.lean
@@ -167,7 +167,7 @@ lemma esymmAlgHomMonomial_single_one :
 
 lemma esymmAlgHomMonomial_add {t s : Fin n →₀ ℕ} :
     esymmAlgHomMonomial σ (t + s) r = esymmAlgHomMonomial σ t r * esymmAlgHomMonomial σ s 1 := by
-  simp_rw [esymmAlgHomMonomial, esymmAlgHom_apply, ← map_mul, monomial_mul, mul_one]
+  simp_rw [esymmAlgHomMonomial, esymmAlgHom_apply, ← map_mul, monomial_mul_monomial, mul_one]
 
 lemma esymmAlgHom_zero : esymmAlgHomMonomial σ (0 : Fin n →₀ ℕ) r = C r := by
   rw [esymmAlgHomMonomial, monomial_zero', esymmAlgHom_apply, aeval_C, algebraMap_eq]


### PR DESCRIPTION
Rename MvPolynomial.monomial_mul to monomial_mul_monomial for consistency with analogous theorems. For example, Polynomial.monomial_mul_monomial.

Deprecated aliases are added for backwards compatibility.

Addresses item in https://github.com/leanprover-community/mathlib4/issues/21584.