### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Bicategory): a retract of an equivalence is an equivalence

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2572,6 +2572,7 @@ public import Mathlib.CategoryTheory.Bicategory.NaturalTransformation.Oplax
 public import Mathlib.CategoryTheory.Bicategory.NaturalTransformation.Pseudo
 public import Mathlib.CategoryTheory.Bicategory.Opposites
 public import Mathlib.CategoryTheory.Bicategory.Product
+public import Mathlib.CategoryTheory.Bicategory.RetractArrow
 public import Mathlib.CategoryTheory.Bicategory.SingleObj
 public import Mathlib.CategoryTheory.Bicategory.Span.Basic
 public import Mathlib.CategoryTheory.Bicategory.Strict.Basic

--- a/Mathlib/CategoryTheory/Bicategory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction/Basic.lean
@@ -282,6 +282,14 @@ def mkOfAdjointifyCounit (η : 𝟙 a ≅ f ≫ g) (ε : g ≫ f ≅ 𝟙 b) : a
   counit := adjointifyCounit η ε
   left_triangle := adjointifyCounit_left_triangle η ε
 
+/-- The adjunction induced by an equivalence in a bicategory. -/
+@[implicit_reducible, simps]
+def toAdjunction (e : a ≌ b) : e.hom ⊣ e.inv where
+  unit := e.unit.hom
+  counit := e.counit.hom
+  left_triangle := e.left_triangle_hom
+  right_triangle := e.right_triangle_hom
+
 end Equivalence
 
 end

--- a/Mathlib/CategoryTheory/Bicategory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction/Basic.lean
@@ -284,7 +284,7 @@ def mkOfAdjointifyCounit (η : 𝟙 a ≅ f ≫ g) (ε : g ≫ f ≅ 𝟙 b) : a
 
 /-- The adjunction induced by an equivalence in a bicategory. -/
 @[implicit_reducible, simps]
-def toAdjunction (e : a ≌ b) : e.hom ⊣ e.inv where
+def adj (e : a ≌ b) : e.hom ⊣ e.inv where
   unit := e.unit.hom
   counit := e.counit.hom
   left_triangle := e.left_triangle_hom

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -125,7 +125,7 @@ corresponding locally discrete bicategories.
 
 This is just an abbreviation of `Functor.toPseudofunctor.toOplax`.
 -/
-@[simps! map]
+@[simps! -isSimp map]
 abbrev Functor.toOplaxFunctor : LocallyDiscrete C ⥤ᵒᵖᴸ (LocallyDiscrete D) :=
   F.toPseudofunctor.toOplax
 
@@ -155,7 +155,7 @@ def Functor.toPseudofunctor' : LocallyDiscrete I ⥤ᵖ B :=
 If `B` is a strict bicategory and `I` is a (1-)category, any functor (of 1-categories) `I ⥤ B` can
 be promoted to an oplax functor from `LocallyDiscrete I` to `B`.
 -/
-@[simps! map]
+@[simps! -isSimp map]
 abbrev Functor.toOplaxFunctor' : LocallyDiscrete I ⥤ᵒᵖᴸ B :=
   F.toPseudofunctor'.toOplax
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
@@ -115,7 +115,7 @@ attribute [nolint docBlame] CategoryTheory.Pseudofunctor.mapId
 variable (F : B ⥤ᵖ C)
 
 /-- The oplax functor associated with a pseudofunctor. -/
-@[simps]
+@[implicit_reducible, simps]
 def toOplax : B ⥤ᵒᵖᴸ C where
   toPrelaxFunctor := F.toPrelaxFunctor
   mapId := fun a => (F.mapId a).hom
@@ -125,7 +125,7 @@ instance hasCoeToOplax : Coe (B ⥤ᵖ C) (B ⥤ᵒᵖᴸ C) :=
   ⟨toOplax⟩
 
 /-- The lax functor associated with a pseudofunctor. -/
-@[simps]
+@[implicit_reducible, simps]
 def toLax : B ⥤ᴸ C where
   toPrelaxFunctor := F.toPrelaxFunctor
   mapId := fun a => (F.mapId a).inv

--- a/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
+++ b/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
@@ -85,7 +85,7 @@ def map {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow₁ f' f)
     have := congr_arg (fun f ↦ F.map₂ f) r.comm
     simp at this
     simp [← cancel_mono (F.map r.i₁ ◁ (F.mapComp r.r₁ f').inv),
-      ← cancel_mono ( (F.mapComp r.i₁ (r.r₁ ≫ f')).inv),
+      ← cancel_mono ((F.mapComp r.i₁ (r.r₁ ≫ f')).inv),
       this, dsimp% F.toLax.map₂_leftUnitor_assoc f']
 
 /-- In a bicategory, a `1`-morphism that is a retract

--- a/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
+++ b/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
@@ -128,7 +128,6 @@ def equivalence {f' : X' ⟶ Y'} {f : X ≌ Y} (r : RetractArrow₁ f' f.hom) :
       _ = _ := by
         simp [bicategoricalComp, r.comm'_assoc]
 
-
 end RetractArrow₁
 
 end Bicategory

--- a/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
+++ b/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
@@ -105,8 +105,6 @@ def adjunctionLeft {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow₁ f' f)
       _ = r.id₁.inv ▷ f' ⊗≫ ((r.i₁ ◁ adj.unit ⊗≫ r.commi.inv ▷ g) ▷ (r.r₁ ≫ f') ≫
           ((f' ≫ r.i₂) ≫ g) ◁ r.commr.inv) ⊗≫
           f' ◁ r.i₂ ◁ adj.counit ▷ r.r₂ ⊗≫ f' ◁ r.id₂.hom := by
-        simp only [whiskerRight_comp, Category.assoc, pentagon_hom_inv_inv_inv_inv_assoc,
-          whiskerLeft_comp, comp_whiskerLeft]
         bicategory
       _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
           (r.i₁ ◁ adj.unit) ▷ (f ≫ r.r₂) ⊗≫
@@ -125,7 +123,14 @@ def adjunctionLeft {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow₁ f' f)
         bicategory
       _ = _ := by
         simp [bicategoricalComp, r.comm'_assoc]
-  right_triangle := sorry
+  right_triangle := by
+    calc
+      _ = (r.i₂ ≫ g ≫ r.r₁) ◁ (r.id₁.inv ⊗≫ r.i₁ ◁ adj.unit ▷ r.r₁ ⊗≫
+          r.commi.inv ▷ (g ≫ r.r₁)) ⊗≫
+          (r.i₂ ◁ g ◁ r.commr.inv ⊗≫ r.i₂ ◁ adj.counit ▷ r.r₂ ⊗≫ r.id₂.hom) ▷
+            (r.i₂ ≫ g ≫ r.r₁) := by
+        bicategory
+      _ = _ := sorry
 
 /-- In a bicategory, a `1`-morphism that is a retract
 of an equivalence is an equivalence. -/

--- a/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
+++ b/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Bicategory.Adjunction.Basic
+
+/-!
+# Retracts of 1-morphisms in bicategories
+
+If `f : X ⟶ Y` and `f' : X' ⟶ Y'` are 1-morphisms in a bicategory,
+we introduce a structure `RetractArrow₁ f' f` expressing that
+`f'` is a retract of `f`, and we show that if `f` is an
+equivalence, then `f'` is also an equivalence.
+
+-/
+
+@[expose] public section
+
+universe w v u
+
+namespace CategoryTheory.Bicategory
+
+variable {C : Type u} [Bicategory.{w, v} C] {X Y X' Y' : C}
+
+/-- A structure expressing that a 1-morphism `f' : X' ⟶ Y`'
+in a bicategory is a retract of `f : X ⟶ Y`. -/
+structure RetractArrow₁ (f' : X' ⟶ Y') (f : X ⟶ Y) where
+  /-- the inclusion of the source object -/
+  i₁ : X' ⟶ X
+  /-- the retraction to the source object -/
+  r₁ : X ⟶ X'
+  /-- the inclusion of the target object -/
+  i₂ : Y' ⟶ Y
+  /-- the retraction to the target object -/
+  r₂ : Y ⟶ Y'
+  /-- the source of `f'` is a retract of the source of `f` -/
+  id₁ : i₁ ≫ r₁ ≅ 𝟙 X'
+  /-- the target of `f'` is a retract of the target of `f` -/
+  id₂ : i₂ ≫ r₂ ≅ 𝟙 Y'
+  /-- compatibility of the inclusions -/
+  commi : f' ≫ i₂ ≅ i₁ ≫ f
+  /-- compatibility of the retractions -/
+  commr : f ≫ r₂ ≅ r₁ ≫ f'
+  comm : commi.hom ▷ r₂ ≫ (α_ _ _ _).hom ≫ i₁ ◁ commr.hom =
+    (α_ _ _ _).hom ≫ f' ◁ id₂.hom ≫ (ρ_ _).hom ≫ (λ_ _).inv ≫
+      id₁.inv ▷ f' ≫ (α_ _ _ _).hom
+
+namespace RetractArrow₁
+
+attribute [reassoc] comm
+
+@[reassoc]
+lemma comm' {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow₁ f' f) :
+    r.i₁ ◁ r.commr.inv ≫ (α_ _ _ _).inv ≫ r.commi.inv ▷ r.r₂ =
+      (α_ _ _ _).inv ≫ r.id₁.hom ▷ f' ≫ (λ_ _).hom ≫ (ρ_ _).inv ≫
+        f' ◁ r.id₂.inv ≫ (α_ _ _ _).inv := by
+  rw [← cancel_epi (r.i₁ ◁ r.commr.hom),
+    ← cancel_epi (α_ _ _ _).hom,
+    ← cancel_epi (r.commi.hom ▷ r.r₂)]
+  nth_rw 2 [r.comm_assoc]
+  simp
+
+/-- In a bicategory, a `1`-morphism that is a retract
+of an equivalence is an equivalence. -/
+@[implicit_reducible, simps]
+def equivalence {f' : X' ⟶ Y'} {f : Equivalence X Y} (r : RetractArrow₁ f' f.hom) :
+    Equivalence X' Y' where
+  hom := f'
+  inv := r.i₂ ≫ f.inv ≫ r.r₁
+  unit :=
+    r.id₁.symm ≪≫ _ ◁ᵢ (λ_ _).symm ≪≫ r.i₁ ◁ᵢ f.unit ▷ᵢ r.r₁ ≪≫
+      _ ◁ᵢ (α_ _ _ _) ≪≫ (α_ _ _ _).symm ≪≫ (r.commi.symm ▷ᵢ (f.inv ≫ r.r₁)) ≪≫ α_ _ _ _
+  counit :=
+    α_ _ _ _ ≪≫ _ ◁ᵢ (α_ _ _ _ ≪≫ _ ◁ᵢ r.commr.symm ≪≫ (α_ _ _ _).symm) ≪≫
+      r.i₂ ◁ᵢ f.counit ▷ᵢ r.r₂ ≪≫ _ ◁ᵢ λ_ _ ≪≫ r.id₂
+  left_triangle := by
+    ext : 1
+    calc
+      _ = r.id₁.inv ▷ f' ⊗≫ ((r.i₁ ◁ f.unit.hom ⊗≫ r.commi.inv ▷ f.inv) ▷ (r.r₁ ≫ f') ≫
+          ((f' ≫ r.i₂) ≫ f.inv) ◁ r.commr.inv) ⊗≫
+          f' ◁ r.i₂ ◁ f.counit.hom ▷ r.r₂ ⊗≫ f' ◁ r.id₂.hom := by
+        simp only [leftZigzagIso_hom, Iso.trans_hom, Iso.symm_hom, whiskerLeftIso_hom,
+          whiskerRightIso_hom]
+        bicategory
+      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
+          (r.i₁ ◁ f.unit.hom) ▷ (f.hom ≫ r.r₂) ⊗≫
+          ((r.commi.inv ▷ (f.inv ≫ f.hom) ≫ ((f' ≫ r.i₂) ◁ f.counit.hom)) ▷ r.r₂) ⊗≫
+          f' ◁ r.id₂.hom := by
+        rw [← whisker_exchange]
+        bicategory
+      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
+          r.i₁ ◁ (leftZigzag f.unit.hom f.counit.hom) ▷ r.r₂ ⊗≫
+          (r.commi.inv ▷ r.r₂) ⊗≫ f' ◁ r.id₂.hom := by
+        rw [← whisker_exchange]
+        bicategory
+      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
+          (r.commi.inv ▷ r.r₂) ⊗≫ f' ◁ r.id₂.hom := by
+        rw [f.left_triangle_hom]
+        bicategory
+      _ = _ := by
+        simp [bicategoricalComp, r.comm'_assoc]
+
+end RetractArrow₁
+
+end CategoryTheory.Bicategory

--- a/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
+++ b/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
@@ -88,11 +88,50 @@ def map {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow₁ f' f)
       ← cancel_mono ( (F.mapComp r.i₁ (r.r₁ ≫ f')).inv),
       this, dsimp% F.toLax.map₂_leftUnitor_assoc f']
 
+/-- In a bicategory, if a `1`-morphism is a retract of a left adjoint,
+it is also a left adjoint. -/
+@[implicit_reducible, simps]
+def adjunctionLeft {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow₁ f' f)
+    {g : Y ⟶ X} (adj : Adjunction f g) :
+    Adjunction f' (r.i₂ ≫ g ≫ r.r₁) where
+  unit :=
+    r.id₁.inv ≫ _ ◁ (λ_ _).inv ≫ r.i₁ ◁ adj.unit ▷ r.r₁ ≫
+      _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv ≫ (r.commi.inv ▷ (g ≫ r.r₁)) ≫ (α_ _ _ _).hom
+  counit :=
+    (α_ _ _ _).hom ≫ _ ◁ ((α_ _ _ _).hom ≫ _ ◁ r.commr.inv ≫ (α_ _ _ _).inv) ≫
+      r.i₂ ◁ adj.counit ▷ r.r₂ ≫ _ ◁ (λ_ _).hom ≫ r.id₂.hom
+  left_triangle := by
+    calc
+      _ = r.id₁.inv ▷ f' ⊗≫ ((r.i₁ ◁ adj.unit ⊗≫ r.commi.inv ▷ g) ▷ (r.r₁ ≫ f') ≫
+          ((f' ≫ r.i₂) ≫ g) ◁ r.commr.inv) ⊗≫
+          f' ◁ r.i₂ ◁ adj.counit ▷ r.r₂ ⊗≫ f' ◁ r.id₂.hom := by
+        simp only [whiskerRight_comp, Category.assoc, pentagon_hom_inv_inv_inv_inv_assoc,
+          whiskerLeft_comp, comp_whiskerLeft]
+        bicategory
+      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
+          (r.i₁ ◁ adj.unit) ▷ (f ≫ r.r₂) ⊗≫
+          ((r.commi.inv ▷ (g ≫ f) ≫ ((f' ≫ r.i₂) ◁ adj.counit)) ▷ r.r₂) ⊗≫
+          f' ◁ r.id₂.hom := by
+        rw [← whisker_exchange]
+        bicategory
+      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
+          r.i₁ ◁ (leftZigzag adj.unit adj.counit) ▷ r.r₂ ⊗≫
+          (r.commi.inv ▷ r.r₂) ⊗≫ f' ◁ r.id₂.hom := by
+        rw [← whisker_exchange]
+        bicategory
+      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
+          (r.commi.inv ▷ r.r₂) ⊗≫ f' ◁ r.id₂.hom := by
+        rw [adj.left_triangle]
+        bicategory
+      _ = _ := by
+        simp [bicategoricalComp, r.comm'_assoc]
+  right_triangle := sorry
+
 /-- In a bicategory, a `1`-morphism that is a retract
 of an equivalence is an equivalence. -/
 @[implicit_reducible, simps]
-def equivalence {f' : X' ⟶ Y'} {f : Equivalence X Y} (r : RetractArrow₁ f' f.hom) :
-    Equivalence X' Y' where
+def equivalence {f' : X' ⟶ Y'} {f : X ≌ Y} (r : RetractArrow₁ f' f.hom) :
+    X' ≌ Y' where
   hom := f'
   inv := r.i₂ ≫ f.inv ≫ r.r₁
   unit :=
@@ -103,30 +142,7 @@ def equivalence {f' : X' ⟶ Y'} {f : Equivalence X Y} (r : RetractArrow₁ f' f
       r.i₂ ◁ᵢ f.counit ▷ᵢ r.r₂ ≪≫ _ ◁ᵢ λ_ _ ≪≫ r.id₂
   left_triangle := by
     ext : 1
-    calc
-      _ = r.id₁.inv ▷ f' ⊗≫ ((r.i₁ ◁ f.unit.hom ⊗≫ r.commi.inv ▷ f.inv) ▷ (r.r₁ ≫ f') ≫
-          ((f' ≫ r.i₂) ≫ f.inv) ◁ r.commr.inv) ⊗≫
-          f' ◁ r.i₂ ◁ f.counit.hom ▷ r.r₂ ⊗≫ f' ◁ r.id₂.hom := by
-        simp only [leftZigzagIso_hom, Iso.trans_hom, Iso.symm_hom, whiskerLeftIso_hom,
-          whiskerRightIso_hom]
-        bicategory
-      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
-          (r.i₁ ◁ f.unit.hom) ▷ (f.hom ≫ r.r₂) ⊗≫
-          ((r.commi.inv ▷ (f.inv ≫ f.hom) ≫ ((f' ≫ r.i₂) ◁ f.counit.hom)) ▷ r.r₂) ⊗≫
-          f' ◁ r.id₂.hom := by
-        rw [← whisker_exchange]
-        bicategory
-      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
-          r.i₁ ◁ (leftZigzag f.unit.hom f.counit.hom) ▷ r.r₂ ⊗≫
-          (r.commi.inv ▷ r.r₂) ⊗≫ f' ◁ r.id₂.hom := by
-        rw [← whisker_exchange]
-        bicategory
-      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
-          (r.commi.inv ▷ r.r₂) ⊗≫ f' ◁ r.id₂.hom := by
-        rw [f.left_triangle_hom]
-        bicategory
-      _ = _ := by
-        simp [bicategoricalComp, r.comm'_assoc]
+    exact (r.adjunctionLeft f.toAdjunction).left_triangle
 
 end RetractArrow₁
 
@@ -136,6 +152,7 @@ open Bicategory
 
 /-- A retract of morphisms in a category `C` induces a retract of
 `1`-morphisms in the bicategory `LocallyDiscrete C`. -/
+@[implicit_reducible, simps]
 def RetractArrow.toLoc {C : Type*} [Category* C] {X Y X' Y' : C}
     {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow f' f) :
     RetractArrow₁ (Quiver.Hom.toLoc f') (Quiver.Hom.toLoc f) where

--- a/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
+++ b/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
@@ -88,50 +88,6 @@ def map {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow₁ f' f)
       ← cancel_mono ( (F.mapComp r.i₁ (r.r₁ ≫ f')).inv),
       this, dsimp% F.toLax.map₂_leftUnitor_assoc f']
 
-/-- In a bicategory, if a `1`-morphism is a retract of a left adjoint,
-it is also a left adjoint. -/
-@[implicit_reducible, simps]
-def adjunctionLeft {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow₁ f' f)
-    {g : Y ⟶ X} (adj : Adjunction f g) :
-    Adjunction f' (r.i₂ ≫ g ≫ r.r₁) where
-  unit :=
-    r.id₁.inv ≫ _ ◁ (λ_ _).inv ≫ r.i₁ ◁ adj.unit ▷ r.r₁ ≫
-      _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv ≫ (r.commi.inv ▷ (g ≫ r.r₁)) ≫ (α_ _ _ _).hom
-  counit :=
-    (α_ _ _ _).hom ≫ _ ◁ ((α_ _ _ _).hom ≫ _ ◁ r.commr.inv ≫ (α_ _ _ _).inv) ≫
-      r.i₂ ◁ adj.counit ▷ r.r₂ ≫ _ ◁ (λ_ _).hom ≫ r.id₂.hom
-  left_triangle := by
-    calc
-      _ = r.id₁.inv ▷ f' ⊗≫ ((r.i₁ ◁ adj.unit ⊗≫ r.commi.inv ▷ g) ▷ (r.r₁ ≫ f') ≫
-          ((f' ≫ r.i₂) ≫ g) ◁ r.commr.inv) ⊗≫
-          f' ◁ r.i₂ ◁ adj.counit ▷ r.r₂ ⊗≫ f' ◁ r.id₂.hom := by
-        bicategory
-      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
-          (r.i₁ ◁ adj.unit) ▷ (f ≫ r.r₂) ⊗≫
-          ((r.commi.inv ▷ (g ≫ f) ≫ ((f' ≫ r.i₂) ◁ adj.counit)) ▷ r.r₂) ⊗≫
-          f' ◁ r.id₂.hom := by
-        rw [← whisker_exchange]
-        bicategory
-      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
-          r.i₁ ◁ (leftZigzag adj.unit adj.counit) ▷ r.r₂ ⊗≫
-          (r.commi.inv ▷ r.r₂) ⊗≫ f' ◁ r.id₂.hom := by
-        rw [← whisker_exchange]
-        bicategory
-      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
-          (r.commi.inv ▷ r.r₂) ⊗≫ f' ◁ r.id₂.hom := by
-        rw [adj.left_triangle]
-        bicategory
-      _ = _ := by
-        simp [bicategoricalComp, r.comm'_assoc]
-  right_triangle := by
-    calc
-      _ = (r.i₂ ≫ g ≫ r.r₁) ◁ (r.id₁.inv ⊗≫ r.i₁ ◁ adj.unit ▷ r.r₁ ⊗≫
-          r.commi.inv ▷ (g ≫ r.r₁)) ⊗≫
-          (r.i₂ ◁ g ◁ r.commr.inv ⊗≫ r.i₂ ◁ adj.counit ▷ r.r₂ ⊗≫ r.id₂.hom) ▷
-            (r.i₂ ≫ g ≫ r.r₁) := by
-        bicategory
-      _ = _ := sorry
-
 /-- In a bicategory, a `1`-morphism that is a retract
 of an equivalence is an equivalence. -/
 @[implicit_reducible, simps]
@@ -147,7 +103,31 @@ def equivalence {f' : X' ⟶ Y'} {f : X ≌ Y} (r : RetractArrow₁ f' f.hom) :
       r.i₂ ◁ᵢ f.counit ▷ᵢ r.r₂ ≪≫ _ ◁ᵢ λ_ _ ≪≫ r.id₂
   left_triangle := by
     ext : 1
-    exact (r.adjunctionLeft f.toAdjunction).left_triangle
+    calc
+      _ = r.id₁.inv ▷ f' ⊗≫ ((r.i₁ ◁ f.unit.hom ⊗≫ r.commi.inv ▷ f.inv) ▷ (r.r₁ ≫ f') ≫
+          ((f' ≫ r.i₂) ≫ f.inv) ◁ r.commr.inv) ⊗≫
+          f' ◁ r.i₂ ◁ f.counit.hom ▷ r.r₂ ⊗≫ f' ◁ r.id₂.hom := by
+        simp only [leftZigzagIso, leftZigzagIso_hom, Iso.trans_hom, Iso.symm_hom,
+          whiskerLeftIso_hom, whiskerRightIso_hom]
+        bicategory
+      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
+          (r.i₁ ◁ f.unit.hom) ▷ (f.hom ≫ r.r₂) ⊗≫
+          ((r.commi.inv ▷ (f.inv ≫ f.hom) ≫ (f' ≫ r.i₂) ◁ f.counit.hom) ▷ r.r₂) ⊗≫
+          f' ◁ r.id₂.hom := by
+        rw [← whisker_exchange]
+        bicategory
+      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
+          r.i₁ ◁ (leftZigzag f.unit.hom f.counit.hom) ▷ r.r₂ ⊗≫
+          (r.commi.inv ▷ r.r₂) ⊗≫ f' ◁ r.id₂.hom := by
+        rw [← whisker_exchange]
+        bicategory
+      _ = r.id₁.inv ▷ f' ⊗≫ r.i₁ ◁ r.commr.inv ⊗≫
+          (r.commi.inv ▷ r.r₂) ⊗≫ f' ◁ r.id₂.hom := by
+        rw [f.left_triangle_hom]
+        bicategory
+      _ = _ := by
+        simp [bicategoricalComp, r.comm'_assoc]
+
 
 end RetractArrow₁
 

--- a/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
+++ b/Mathlib/CategoryTheory/Bicategory/RetractArrow.lean
@@ -6,6 +6,8 @@ Authors: Joël Riou
 module
 
 public import Mathlib.CategoryTheory.Bicategory.Adjunction.Basic
+public import Mathlib.CategoryTheory.Bicategory.LocallyDiscrete
+public import Mathlib.CategoryTheory.Retract
 
 /-!
 # Retracts of 1-morphisms in bicategories
@@ -21,7 +23,9 @@ equivalence, then `f'` is also an equivalence.
 
 universe w v u
 
-namespace CategoryTheory.Bicategory
+namespace CategoryTheory
+
+namespace Bicategory
 
 variable {C : Type u} [Bicategory.{w, v} C] {X Y X' Y' : C}
 
@@ -46,7 +50,7 @@ structure RetractArrow₁ (f' : X' ⟶ Y') (f : X ⟶ Y) where
   commr : f ≫ r₂ ≅ r₁ ≫ f'
   comm : commi.hom ▷ r₂ ≫ (α_ _ _ _).hom ≫ i₁ ◁ commr.hom =
     (α_ _ _ _).hom ≫ f' ◁ id₂.hom ≫ (ρ_ _).hom ≫ (λ_ _).inv ≫
-      id₁.inv ▷ f' ≫ (α_ _ _ _).hom
+      id₁.inv ▷ f' ≫ (α_ _ _ _).hom := by cat_disch
 
 namespace RetractArrow₁
 
@@ -62,6 +66,27 @@ lemma comm' {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow₁ f' f) :
     ← cancel_epi (r.commi.hom ▷ r.r₂)]
   nth_rw 2 [r.comm_assoc]
   simp
+
+/-- If a `1`-morphism is a retract of another, it stays so
+after the applicaton of a pseudofunctor. -/
+@[implicit_reducible, simps]
+def map {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow₁ f' f)
+    {D : Type*} [Bicategory D] (F : C ⥤ᵖ D) :
+    RetractArrow₁ (F.map f') (F.map f) where
+  i₁ := F.map r.i₁
+  i₂ := F.map r.i₂
+  r₁ := F.map r.r₁
+  r₂ := F.map r.r₂
+  id₁ := (F.mapComp _ _).symm ≪≫ F.map₂Iso r.id₁ ≪≫ F.mapId _
+  id₂ := (F.mapComp _ _).symm ≪≫ F.map₂Iso r.id₂ ≪≫ F.mapId _
+  commi := (F.mapComp _ _).symm ≪≫ F.map₂Iso r.commi ≪≫ F.mapComp _ _
+  commr := (F.mapComp _ _).symm ≪≫ F.map₂Iso r.commr ≪≫ F.mapComp _ _
+  comm := by
+    have := congr_arg (fun f ↦ F.map₂ f) r.comm
+    simp at this
+    simp [← cancel_mono (F.map r.i₁ ◁ (F.mapComp r.r₁ f').inv),
+      ← cancel_mono ( (F.mapComp r.i₁ (r.r₁ ≫ f')).inv),
+      this, dsimp% F.toLax.map₂_leftUnitor_assoc f']
 
 /-- In a bicategory, a `1`-morphism that is a retract
 of an equivalence is an equivalence. -/
@@ -105,4 +130,22 @@ def equivalence {f' : X' ⟶ Y'} {f : Equivalence X Y} (r : RetractArrow₁ f' f
 
 end RetractArrow₁
 
-end CategoryTheory.Bicategory
+end Bicategory
+
+open Bicategory
+
+/-- A retract of morphisms in a category `C` induces a retract of
+`1`-morphisms in the bicategory `LocallyDiscrete C`. -/
+def RetractArrow.toLoc {C : Type*} [Category* C] {X Y X' Y' : C}
+    {f' : X' ⟶ Y'} {f : X ⟶ Y} (r : RetractArrow f' f) :
+    RetractArrow₁ (Quiver.Hom.toLoc f') (Quiver.Hom.toLoc f) where
+  i₁ := Quiver.Hom.toLoc r.i.left
+  i₂ := Quiver.Hom.toLoc r.i.right
+  r₁ := Quiver.Hom.toLoc r.r.left
+  r₂ := Quiver.Hom.toLoc r.r.right
+  id₁ := eqToIso (by simp [← Quiver.Hom.comp_toLoc])
+  id₂ := eqToIso (by simp [← Quiver.Hom.comp_toLoc])
+  commi := eqToIso (by simp [← Quiver.Hom.comp_toLoc])
+  commr := eqToIso (by simp [← Quiver.Hom.comp_toLoc])
+
+end CategoryTheory


### PR DESCRIPTION


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
