### PR TITLE
feat(MeasureTheory): the minimal 1-d Hausdorff measure is edist for pre-connected sets

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Hausdorff.lean
+++ b/Mathlib/MeasureTheory/Measure/Hausdorff.lean
@@ -990,6 +990,7 @@ instance isAddHaarMeasure_hausdorffMeasure {E : Type*}
     apply (e.isOpenMap U hU).measure_pos (μ := volume)
     simpa
 
+section MeasurePreserving
 variable (ι X)
 
 theorem hausdorffMeasure_measurePreserving_funUnique [Unique ι] (d : ℝ) :
@@ -1001,6 +1002,8 @@ theorem hausdorffMeasure_measurePreserving_piFinTwo (α : Fin 2 → Type*)
     [∀ i, SecondCountableTopology (α i)] (d : ℝ) :
     MeasurePreserving (MeasurableEquiv.piFinTwo α) μH[d] μH[d] :=
   (IsometryEquiv.piFinTwo α).measurePreserving_hausdorffMeasure _
+
+end MeasurePreserving
 
 /-- In the space `ℝ`, the Hausdorff measure coincides exactly with the Lebesgue measure. -/
 @[simp]
@@ -1122,5 +1125,51 @@ theorem hausdorffMeasure_orthogonalProjectionOnto_le [RCLike 𝕜]
   hausdorffMeasure_orthogonalProjectionOnto_le
 
 end Geometric
+
+/-! ### Bound of one-dimensional Hausdorff measure -/
+
+/-- On a connected set, the distance between two points is at most the one-dimensional Hausdorff
+measure of the set. Combining with `MeasureTheory.hausdorffMeasure_affineSegment`, this says the
+segment between two points is a set connecting them with the smallest one-dimensional Hausdorff
+measure. -/
+theorem edist_le_hausdorffMeasure {s : Set X} (hs : IsPreconnected s) {x y : X} (hx : x ∈ s)
+    (hy : y ∈ s) : edist x y ≤ μH[1] s := by
+  by_cases htop : μH[1] s = ∞
+  · simp [htop]
+  -- We'd like to use `LipschitzWith.hausdorffMeasure_image_le` with function
+  -- `fun z ↦ edist x z`. However, `ENNReal` is not a `EMetricSpace` so this doesn't apply directly.
+  -- As a work-around, we truncate this function by a constant larger than `μH[1] s`.
+  let f (z : X) : ℝ := (min (edist x z) (μH[1] s + 1)).toReal
+  have hftop (z : X) : min (edist x z) (μH[1] s + 1) ≠ ∞ := fun h ↦ by
+    have : μH[1] s + 1 = ∞ := (min_eq_top.mp h).2
+    simp [htop] at this
+  have hfle (p q : X) (hqp : edist q p ≠ ∞) : f p ≤ f q + (edist q p).toReal := by
+    rw [← ENNReal.toReal_add (hftop q) hqp]
+    apply ENNReal.toReal_mono (by simp [hftop q, hqp])
+    rw [min_add]
+    exact min_le_min (edist_triangle x q p) (by simp)
+  have hlip : LipschitzWith 1 f := by
+    refine LipschitzWith.of_edist_le fun p q ↦ ?_
+    by_cases h : edist p q = ∞
+    · simp [h]
+    rw [edist_dist, Real.dist_eq]
+    refine ENNReal.ofReal_le_of_le_toReal (abs_sub_le_iff.mpr ⟨?_, ?_⟩)
+    · exact sub_left_le_of_le_add <| edist_comm p q ▸ hfle p q (edist_comm p q ▸ h)
+    · exact sub_left_le_of_le_add <| hfle q p h
+  have hminle : min (edist x y) (μH[1] s + 1) ≤ μH[1] s := calc
+    min (edist x y) (μH[1] s + 1) = ENNReal.ofReal (f y) := by
+      simp [f, ENNReal.ofReal_toReal (hftop y)]
+    _ = volume (Icc 0 (f y)) := by simp
+    _ ≤ volume (f '' s) := by
+      refine measure_mono <| (hs.image f hlip.continuous.continuousOn).Icc_subset ?_ ?_
+      · exact ⟨x, hx, by simp [f]⟩
+      · exact ⟨y, hy, rfl⟩
+    _ = μH[1] (f '' s) := by rw [hausdorffMeasure_real]
+    _ ≤ μH[1] s := by simpa using hlip.hausdorffMeasure_image_le zero_le_one s
+  refine (min_le_iff.mp hminle).resolve_right (not_le_of_gt ?_)
+  exact ENNReal.lt_add_right htop (by simp)
+
+theorem ediam_le_hausdorffMeasure {s : Set X} (hs : IsPreconnected s) : ediam s ≤ μH[1] s :=
+  ediam_le_iff.mpr (fun _ hx _ hy ↦ edist_le_hausdorffMeasure hs hx hy)
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/Hausdorff.lean
+++ b/Mathlib/MeasureTheory/Measure/Hausdorff.lean
@@ -1140,14 +1140,12 @@ theorem edist_le_hausdorffMeasure {s : Set X} (hs : IsPreconnected s) {x y : X} 
   -- `fun z ↦ edist x z`. However, `ENNReal` is not a `EMetricSpace` so this doesn't apply directly.
   -- As a work-around, we truncate this function by a constant larger than `μH[1] s`.
   let f (z : X) : ℝ := (min (edist x z) (μH[1] s + 1)).toReal
-  have hftop (z : X) : min (edist x z) (μH[1] s + 1) ≠ ∞ := fun h ↦ by
-    have : μH[1] s + 1 = ∞ := (min_eq_top.mp h).2
-    simp [htop] at this
+  have hftop (z : X) : min (edist x z) (μH[1] s + 1) ≠ ∞ := min_eq_top.not.mpr (by simp [htop])
   have hfle (p q : X) (hqp : edist q p ≠ ∞) : f p ≤ f q + (edist q p).toReal := by
     rw [← ENNReal.toReal_add (hftop q) hqp]
     apply ENNReal.toReal_mono (by simp [hftop q, hqp])
     rw [min_add]
-    exact min_le_min (edist_triangle x q p) (by simp)
+    exact min_le_min (edist_triangle x q p) (self_le_add_right _ _)
   have hlip : LipschitzWith 1 f := by
     refine LipschitzWith.of_edist_le fun p q ↦ ?_
     by_cases h : edist p q = ∞
@@ -1161,9 +1159,8 @@ theorem edist_le_hausdorffMeasure {s : Set X} (hs : IsPreconnected s) {x y : X} 
       simp [f, ENNReal.ofReal_toReal (hftop y)]
     _ = volume (Icc 0 (f y)) := by simp
     _ ≤ volume (f '' s) := by
-      refine measure_mono <| (hs.image f hlip.continuous.continuousOn).Icc_subset ?_ ?_
-      · exact ⟨x, hx, by simp [f]⟩
-      · exact ⟨y, hy, rfl⟩
+      apply measure_mono
+      exact (hs.image f hlip.continuous.continuousOn).Icc_subset ⟨x, hx, by simp [f]⟩ ⟨y, hy, rfl⟩
     _ = μH[1] (f '' s) := by rw [hausdorffMeasure_real]
     _ ≤ μH[1] s := by simpa using hlip.hausdorffMeasure_image_le zero_le_one s
   refine (min_le_iff.mp hminle).resolve_right (not_le_of_gt ?_)


### PR DESCRIPTION
Stating that straight segment is the shortest using Hausdorff measure.

---

AI usage disclosure: the initial proof was drafted by Aristotle, then cleaned up by me.

This a lemma to build up to connecting 1-d Hausdorff measure with `eVariation`, and also probably useful in general

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
