### PR TITLE
[Merged by Bors] - chore(Tactic/Module): remove backward.isDefEq.respectTransparency

### DIFF
--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -56,7 +56,6 @@ variable {S : Type*} {R : Type*} {M : Type*}
 
 /-- Augment a `Module.NF R M` object `l`, i.e. a list of pairs in `R × M`, by prepending another
 pair `p : R × M`. -/
-@[match_pattern]
 def cons (p : R × M) (l : NF R M) : NF R M := p :: l
 
 @[inherit_doc cons] infixl:100 " ::ᵣ " => cons
@@ -257,7 +256,6 @@ def onScalar {u₁ u₂ : Level} {R₁ : Q(Type u₁)} {R₂ : Q(Type u₂)} (l 
     qNF R₂ M :=
   l.map fun ((a, x), k) ↦ ((q($f $a), x), k)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
 and a natural number), construct another such term `l`, which will have the property that in the
 `$R`-module `$M`, the sum of the "linear combinations" represented by `l₁` and `l₂` is the linear
@@ -273,15 +271,14 @@ appear in `l₁`, `l₂` respectively with the same `ℕ`-component `k`, then co
 meta def add (iR : Q(Semiring $R)) : qNF R M → qNF R M → qNF R M
   | [], l => l
   | l, [] => l
-  | ((a₁, x₁), k₁) ::ᵣ t₁, ((a₂, x₂), k₂) ::ᵣ t₂ =>
+  | ((a₁, x₁), k₁) :: t₁, ((a₂, x₂), k₂) :: t₂ =>
     if k₁ < k₂ then
-      ((a₁, x₁), k₁) ::ᵣ add iR t₁ (((a₂, x₂), k₂) ::ᵣ t₂)
+      ((a₁, x₁), k₁) :: add iR t₁ (((a₂, x₂), k₂) :: t₂)
     else if k₁ = k₂ then
-      ((q($a₁ + $a₂), x₁), k₁) ::ᵣ add iR t₁ t₂
+      ((q($a₁ + $a₂), x₁), k₁) :: add iR t₁ t₂
     else
-      ((a₂, x₂), k₂) ::ᵣ add iR (((a₁, x₁), k₁) ::ᵣ t₁) t₂
+      ((a₂, x₂), k₂) :: add iR (((a₁, x₁), k₁) :: t₁) t₂
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
 and a natural number), recursively construct a proof that in the `$R`-module `$M`, the sum of the
 "linear combinations" represented by `l₁` and `l₂` is the linear combination represented by
@@ -292,18 +289,17 @@ meta def mkAddProof {iR : Q(Semiring $R)} {iM : Q(AddCommMonoid $M)} (iRM : Q(Mo
   match l₁, l₂ with
   | [], l => (q(zero_add (NF.eval $(l.toNF))):)
   | l, [] => (q(add_zero (NF.eval $(l.toNF))):)
-  | ((a₁, x₁), k₁) ::ᵣ t₁, ((a₂, x₂), k₂) ::ᵣ t₂ =>
+  | ((a₁, x₁), k₁) :: t₁, ((a₂, x₂), k₂) :: t₂ =>
     if k₁ < k₂ then
-      let pf := mkAddProof iRM t₁ (((a₂, x₂), k₂) ::ᵣ t₂)
+      let pf := mkAddProof iRM t₁ (((a₂, x₂), k₂) :: t₂)
       (q(NF.add_eq_eval₁ ($a₁, $x₁) $pf):)
     else if k₁ = k₂ then
       let pf := mkAddProof iRM t₁ t₂
       (q(NF.add_eq_eval₂ $a₁ $a₂ $x₁ $pf):)
     else
-      let pf := mkAddProof iRM (((a₁, x₁), k₁) ::ᵣ t₁) t₂
+      let pf := mkAddProof iRM (((a₁, x₁), k₁) :: t₁) t₂
       (q(NF.add_eq_eval₃ ($a₂, $x₂) $pf):)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
 and a natural number), construct another such term `l`, which will have the property that in the
 `$R`-module `$M`, the difference of the "linear combinations" represented by `l₁` and `l₂` is the
@@ -320,15 +316,14 @@ that if pairs `(a₁, x₁)` and `(a₂, x₂)` appear in `l₁`, `l₂` respect
 def sub (iR : Q(Ring $R)) : qNF R M → qNF R M → qNF R M
   | [], l => l.onScalar q(Neg.neg)
   | l, [] => l
-  | ((a₁, x₁), k₁) ::ᵣ t₁, ((a₂, x₂), k₂) ::ᵣ t₂ =>
+  | ((a₁, x₁), k₁) :: t₁, ((a₂, x₂), k₂) :: t₂ =>
     if k₁ < k₂ then
-      ((a₁, x₁), k₁) ::ᵣ sub iR t₁ (((a₂, x₂), k₂) ::ᵣ t₂)
+      ((a₁, x₁), k₁) :: sub iR t₁ (((a₂, x₂), k₂) :: t₂)
     else if k₁ = k₂ then
-      ((q($a₁ - $a₂), x₁), k₁) ::ᵣ sub iR t₁ t₂
+      ((q($a₁ - $a₂), x₁), k₁) :: sub iR t₁ t₂
     else
-      ((q(-$a₂), x₂), k₂) ::ᵣ sub iR (((a₁, x₁), k₁) ::ᵣ t₁) t₂
+      ((q(-$a₂), x₂), k₂) :: sub iR (((a₁, x₁), k₁) :: t₁) t₂
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
 and a natural number), recursively construct a proof that in the `$R`-module `$M`, the difference
 of the "linear combinations" represented by `l₁` and `l₂` is the linear combination represented by
@@ -339,15 +334,15 @@ def mkSubProof (iR : Q(Ring $R)) (iM : Q(AddCommGroup $M)) (iRM : Q(Module $R $M
   match l₁, l₂ with
   | [], l => (q(NF.zero_sub_eq_eval $(l.toNF)):)
   | l, [] => (q(sub_zero (NF.eval $(l.toNF))):)
-  | ((a₁, x₁), k₁) ::ᵣ t₁, ((a₂, x₂), k₂) ::ᵣ t₂ =>
+  | ((a₁, x₁), k₁) :: t₁, ((a₂, x₂), k₂) :: t₂ =>
     if k₁ < k₂ then
-      let pf := mkSubProof iR iM iRM t₁ (((a₂, x₂), k₂) ::ᵣ t₂)
+      let pf := mkSubProof iR iM iRM t₁ (((a₂, x₂), k₂) :: t₂)
       (q(NF.sub_eq_eval₁ ($a₁, $x₁) $pf):)
     else if k₁ = k₂ then
       let pf := mkSubProof iR iM iRM t₁ t₂
       (q(NF.sub_eq_eval₂ $a₁ $a₂ $x₁ $pf):)
     else
-      let pf := mkSubProof iR iM iRM (((a₁, x₁), k₁) ::ᵣ t₁) t₂
+      let pf := mkSubProof iR iM iRM (((a₁, x₁), k₁) :: t₁) t₂
       (q(NF.sub_eq_eval₃ ($a₂, $x₂) $pf):)
 
 variable {iM : Q(AddCommMonoid $M)}
@@ -496,18 +491,18 @@ partial def reduceCoefficientwise {R : Q(Type u)} {_ : Q(AddCommMonoid $M)} {_ :
   /- if one of the lists is empty and the other one is not, recurse down the nonempty one,
     forming goals that each of the listed coefficients is equal to
     zero -/
-  | [], ((a, x), _) ::ᵣ L =>
+  | [], ((a, x), _) :: L =>
     let mvar : Q((0:$R) = $a) ← mkFreshExprMVar q((0:$R) = $a)
     let (mvars, pf) ← reduceCoefficientwise iRM [] L
     pure (mvar.mvarId! :: mvars, (q(NF.eq_const_cons $x $mvar $pf):))
-  | ((a, x), _) ::ᵣ L, [] =>
+  | ((a, x), _) :: L, [] =>
     let mvar : Q($a = (0:$R)) ← mkFreshExprMVar q($a = (0:$R))
     let (mvars, pf) ← reduceCoefficientwise iRM L []
     pure (mvar.mvarId! :: mvars, (q(NF.eq_cons_const $x $mvar $pf):))
   /- if both lists are nonempty, then deal with the numerically-smallest term in either list,
     forming a goal that it is equal to zero (if it appears in only one list) or that its
     coefficients in the two lists are the same (if it appears in both lists); then recurse -/
-  | ((a₁, x₁), k₁) ::ᵣ L₁, ((a₂, x₂), k₂) ::ᵣ L₂ =>
+  | ((a₁, x₁), k₁) :: L₁, ((a₂, x₂), k₂) :: L₂ =>
     if k₁ < k₂ then
       let mvar : Q($a₁ = (0:$R)) ← mkFreshExprMVar q($a₁ = (0:$R))
       let (mvars, pf) ← reduceCoefficientwise iRM L₁ l₂

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -60,6 +60,13 @@ def cons (p : R × M) (l : NF R M) : NF R M := p :: l
 
 @[inherit_doc cons] infixl:100 " ::ᵣ " => cons
 
+/-- An induction principle for `NF` which mirrors induction on lists, with cases
+for `[]` and `NF.cons` -/
+@[elab_as_elim, induction_eliminator]
+protected theorem inductionOn {motive : NF R M → Prop} (l : NF R M) (nil : motive [])
+    (cons : ∀ (p : R × M) (l : NF R M), motive l → motive (p ::ᵣ l)) : motive l :=
+  List.rec nil cons l
+
 /-- Evaluate a `Module.NF R M` object `l`, i.e. a list of pairs in `R × M`, to an element of `M`, by
 forming the "linear combination" it specifies: scalar-multiply each `R` term to the corresponding
 `M` term, then add them all up. -/
@@ -137,12 +144,12 @@ theorem sub_eq_eval {R₁ R₂ S₁ S₂ : Type*} [AddCommGroup M] [Ring R] [Mod
 instance [Neg R] : Neg (NF R M) where
   neg l := l.map fun (a, x) ↦ (-a, x)
 
-set_option backward.isDefEq.respectTransparency false in
+theorem neg_cons [Neg R] (p : R × M) (l : NF R M) : -(p ::ᵣ l) = (-p.1, p.2) ::ᵣ (-l) := rfl
+
 theorem eval_neg [AddCommGroup M] [Ring R] [Module R M] (l : NF R M) : (-l).eval = - l.eval := by
-  simp +instances only [NF.eval, List.map_map, List.sum_neg, NF.instNeg]
-  congr
-  ext p
-  simp
+  induction l with
+  | nil => exact neg_zero.symm
+  | cons p l ih => simp only [eval_cons, neg_add, neg_cons, ih, neg_smul]
 
 theorem zero_sub_eq_eval [AddCommGroup M] [Ring R] [Module R M] (l : NF R M) :
     0 - l.eval = (-l).eval := by
@@ -159,14 +166,15 @@ instance [Mul R] : SMul R (NF R M) where
 @[simp] theorem smul_apply [Mul R] (r : R) (l : NF R M) : r • l = l.map fun (a, x) ↦ (r * a, x) :=
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
+theorem smul_cons [Mul R] (r : R) (p : R × M) (l : NF R M) :
+    r • (p ::ᵣ l) = (r * p.1, p.2) ::ᵣ (r • l) := rfl
+
 theorem eval_smul [AddCommMonoid M] [Semiring R] [Module R M] {l : NF R M} {x : M} (h : x = l.eval)
     (r : R) : (r • l).eval = r • x := by
-  unfold NF.eval at h ⊢
-  simp only [h, smul_sum, map_map, NF.smul_apply]
-  congr
-  ext p
-  simp [mul_smul]
+  subst h
+  induction l with
+  | nil => exact (smul_zero r).symm
+  | cons p l ih => simp only [smul_cons, eval_cons, ih, smul_add, mul_smul]
 
 theorem smul_eq_eval {R₀ : Type*} [AddCommMonoid M] [Semiring R] [Module R M] [Semiring R₀]
     [Module R₀ M] [Semiring S] [Module S M] {l : NF R M} {l₀ : NF R₀ M} {s : S} {r : R}
@@ -205,14 +213,15 @@ commutative semiring, by applying to each `S`-component the algebra-map from `S`
 def algebraMap [CommSemiring S] [Semiring R] [Algebra S R] (l : NF S M) : NF R M :=
   l.map (fun ⟨s, x⟩ ↦ (Algebra.algebraMap S R s, x))
 
-set_option backward.isDefEq.respectTransparency false in
+theorem algebraMap_cons [CommSemiring S] [Semiring R] [Algebra S R] (p : S × M) (l : NF S M) :
+    (p ::ᵣ l).algebraMap R = (Algebra.algebraMap S R p.1, p.2) ::ᵣ (l.algebraMap R) := rfl
+
 theorem eval_algebraMap [CommSemiring S] [Semiring R] [Algebra S R] [AddMonoid M] [SMul S M]
     [MulAction R M] [IsScalarTower S R M] (l : NF S M) :
     (l.algebraMap R).eval = l.eval := by
-  simp only [NF.eval, algebraMap, map_map]
-  congr
-  ext
-  simp [IsScalarTower.algebraMap_smul]
+  induction l with
+  | nil => rfl
+  | cons p l ih => simp only [algebraMap_cons, eval_cons, ih, IsScalarTower.algebraMap_smul]
 
 end NF
 end


### PR DESCRIPTION
remove all `set_option backward.isDefEq.respectTransparency false` flags from `Tactic/Module` that were added in the v4.33.0-rc1 bump (#41779) by making the `NF / List` type synonym boundary explicit.

* The transparency changes meant that lean cannot automatically infer termination for `qNF` using `::ᵣ` (notation for `NF.cons`). This is fixed by matching on plain `::` instead. I also define `reduceCoefficientwise` using plain `::` for consistency, even though it is marked `partial` so didn't have this problem.
* I remove the now unused `@[match_pattern]` on `NF.cons`
* The proofs of the three `NF.eval_*` theorems fail after the transparency changes because they unfold `NF.eval` into terms involving `List.map` over lists using the `NF` alias and `simp` has to unify the `List` and `NF` types. This worked before because `isDefEq` bumped this type of unification to `.default` transparency. These are now proved by induction by a new `induction_eliminator` in a similar way to `FreeMonoid.inductionOn`) and three `rfl` lemmas for `NF.cons`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
