### PR TITLE
[Merged by Bors] - chore(RingTheory/Ideal/Maximal): simplify proof

### DIFF
--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -243,10 +243,8 @@ theorem irreducible_of_isMaximal_of_eq_span_singleton_of_not_isIdempotentElem {a
   obtain ⟨d, rfl⟩ := show a ∣ v by simp [← Ideal.mem_span_singleton, hv₂]
   refine idem (a * (c * d)) ?_ ?_
   · apply le_antisymm <;> rw [span_singleton_le_span_singleton]
-    · convert dvd_mul_right (a * (c * d)) a
-      nth_rw 1 [ha]
-      ring
-    · simp
+    · exact (dvd_mul_right (a * (c * d)) a).trans (ha.trans (by ring)).symm.dvd
+    · apply dvd_mul_right
   · rw [isIdempotentElem_iff]
     nth_rw 3 [ha]
     ring

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -233,22 +233,23 @@ theorem irreducible_of_isMaximal_of_eq_span_singleton_of_not_isIdempotentElem {a
     (max : (Ideal.span {a}).IsMaximal)
     (idem : ∀ x, Ideal.span {a} = Ideal.span {x} → ¬IsIdempotentElem x) :
     Irreducible a := by
-  refine ⟨by grind [span_singleton_eq_top, max.ne_top], fun u v ha ↦ ?_⟩
-  by_contra! ⟨hu, hv⟩
-  have hu₂ : span {a} = span {u} :=
-    (max.eq_of_le (span_singleton_ne_top hu) (by simp [ha, Ideal.mem_span_singleton]))
-  have hv₂ : span {a} = span {v} :=
-    (max.eq_of_le (span_singleton_ne_top hv) (by simp [ha, Ideal.mem_span_singleton]))
-  obtain ⟨c, rfl⟩ : a ∣ u := by simp [← Ideal.mem_span_singleton, hu₂]
-  obtain ⟨d, rfl⟩ : a ∣ v := by simp [← Ideal.mem_span_singleton, hv₂]
-  refine idem (a * (c * d)) ?_ ?_
-  · apply le_antisymm <;> rw [span_singleton_le_span_singleton]
-    · convert dvd_mul_right (a * (c * d)) a
-      grind
-    · apply dvd_mul_right
-  · rw [isIdempotentElem_iff]
-    nth_rw 3 [ha]
-    ring
+  refine ⟨fun ha ↦ max.ne_top ?_, fun u v ha ↦ ?_⟩
+  · simpa using ha
+  · by_contra! ⟨hu, hv⟩
+    have hu₂ : span {a} = span {u} :=
+      (max.eq_of_le (span_singleton_ne_top hu) (by simp [ha, Ideal.mem_span_singleton]))
+    have hv₂ : span {a} = span {v} :=
+      (max.eq_of_le (span_singleton_ne_top hv) (by simp [ha, Ideal.mem_span_singleton]))
+    obtain ⟨c, rfl⟩ : a ∣ u := by simp [← Ideal.mem_span_singleton, hu₂]
+    obtain ⟨d, rfl⟩ : a ∣ v := by simp [← Ideal.mem_span_singleton, hv₂]
+    refine idem (a * (c * d)) ?_ ?_
+    · apply le_antisymm <;> rw [span_singleton_le_span_singleton]
+      · convert dvd_mul_right (a * (c * d)) a
+        grind
+      · apply dvd_mul_right
+    · rw [isIdempotentElem_iff]
+      nth_rw 3 [ha]
+      ring
 
 theorem irreducible_of_isMaximal_span_singleton [IsDomain α] {a : α}
     (ha : a ≠ 0) (max : (Ideal.span {a}).IsMaximal) :

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -243,7 +243,8 @@ theorem irreducible_of_isMaximal_of_eq_span_singleton_of_not_isIdempotentElem {a
   obtain ⟨d, rfl⟩ := show a ∣ v by simp [← Ideal.mem_span_singleton, hv₂]
   refine idem (a * (c * d)) ?_ ?_
   · apply le_antisymm <;> rw [span_singleton_le_span_singleton]
-    · exact (dvd_mul_right (a * (c * d)) a).trans (ha.trans (by ring)).symm.dvd
+    · convert dvd_mul_right (a * (c * d)) a
+      grind
     · apply dvd_mul_right
   · rw [isIdempotentElem_iff]
     nth_rw 3 [ha]

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -233,23 +233,22 @@ theorem irreducible_of_isMaximal_of_eq_span_singleton_of_not_isIdempotentElem {a
     (max : (Ideal.span {a}).IsMaximal)
     (idem : ∀ x, Ideal.span {a} = Ideal.span {x} → ¬IsIdempotentElem x) :
     Irreducible a := by
-  refine ⟨fun ha ↦ max.ne_top ?_, fun u v ha ↦ ?_⟩
-  · simpa using ha
-  · by_contra! ⟨hu, hv⟩
-    have hu₂ : span {a} = span {u} :=
-      (max.eq_of_le (span_singleton_ne_top hu) (by simp [ha, Ideal.mem_span_singleton]))
-    have hv₂ : span {a} = span {v} :=
-      (max.eq_of_le (span_singleton_ne_top hv) (by simp [ha, Ideal.mem_span_singleton]))
-    obtain ⟨c, rfl⟩ : a ∣ u := by simp [← Ideal.mem_span_singleton, hu₂]
-    obtain ⟨d, rfl⟩ : a ∣ v := by simp [← Ideal.mem_span_singleton, hv₂]
-    refine idem (a * (c * d)) ?_ ?_
-    · apply le_antisymm <;> rw [span_singleton_le_span_singleton]
-      · convert dvd_mul_right (a * (c * d)) a
-        grind
-      · apply dvd_mul_right
-    · rw [isIdempotentElem_iff]
-      nth_rw 3 [ha]
-      ring
+  refine ⟨fun _ ↦ max.ne_top (by simpa), fun u v ha ↦ ?_⟩
+  by_contra! ⟨hu, hv⟩
+  have hu₂ : span {a} = span {u} :=
+    (max.eq_of_le (span_singleton_ne_top hu) (by simp [ha, Ideal.mem_span_singleton]))
+  have hv₂ : span {a} = span {v} :=
+    (max.eq_of_le (span_singleton_ne_top hv) (by simp [ha, Ideal.mem_span_singleton]))
+  obtain ⟨c, rfl⟩ : a ∣ u := by simp [← Ideal.mem_span_singleton, hu₂]
+  obtain ⟨d, rfl⟩ : a ∣ v := by simp [← Ideal.mem_span_singleton, hv₂]
+  refine idem (a * (c * d)) ?_ ?_
+  · apply le_antisymm <;> rw [span_singleton_le_span_singleton]
+    · convert dvd_mul_right (a * (c * d)) a
+      grind
+    · apply dvd_mul_right
+  · rw [isIdempotentElem_iff]
+    nth_rw 3 [ha]
+    ring
 
 theorem irreducible_of_isMaximal_span_singleton [IsDomain α] {a : α}
     (ha : a ≠ 0) (max : (Ideal.span {a}).IsMaximal) :

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -233,28 +233,23 @@ theorem irreducible_of_isMaximal_of_eq_span_singleton_of_not_isIdempotentElem {a
     (max : (Ideal.span {a}).IsMaximal)
     (idem : ∀ x, Ideal.span {a} = Ideal.span {x} → ¬IsIdempotentElem x) :
     Irreducible a := by
-  constructor
-  · intro ha
-    apply max.ne_top
-    rw [span_singleton_eq_top.2 ha]
-  · intro u v ha
-    by_contra! huv
-    have hu : span {u} ≤ span {a} :=
-      (max.eq_of_le (span_singleton_ne_top huv.1)
-        (span_singleton_le_span_singleton.2 ((dvd_mul_right u v).trans ha.symm.dvd))).ge
-    have hv : span {v} ≤ span {a} :=
-      (max.eq_of_le (span_singleton_ne_top huv.2)
-        (span_singleton_le_span_singleton.2 ((dvd_mul_left v u).trans ha.symm.dvd))).ge
-    rw [span_singleton_le_span_singleton] at hu hv
-    obtain ⟨c, rfl⟩ := hu
-    obtain ⟨d, rfl⟩ := hv
-    refine idem (a * (c * d)) ?_ ?_
-    · apply le_antisymm <;> rw [span_singleton_le_span_singleton]
-      · exact (dvd_mul_right (a * (c * d)) a).trans (ha.trans (by ring)).symm.dvd
-      · apply dvd_mul_right
-    · rw [isIdempotentElem_iff]
-      refine Eq.trans ?_ (congrArg (· * (c * d)) ha.symm)
+  refine ⟨by grind [span_singleton_eq_top, max.ne_top], fun u v ha ↦ ?_⟩
+  by_contra! ⟨hu, hv⟩
+  have hu₂ : span {a} = span {u} :=
+    (max.eq_of_le (span_singleton_ne_top hu) (by simp [ha, Ideal.mem_span_singleton]))
+  have hv₂ : span {a} = span {v} :=
+    (max.eq_of_le (span_singleton_ne_top hv) (by simp [ha, Ideal.mem_span_singleton]))
+  obtain ⟨c, rfl⟩ := show a ∣ u by simp [← Ideal.mem_span_singleton, hu₂]
+  obtain ⟨d, rfl⟩ := show a ∣ v by simp [← Ideal.mem_span_singleton, hv₂]
+  refine idem (a * (c * d)) ?_ ?_
+  · apply le_antisymm <;> rw [span_singleton_le_span_singleton]
+    · convert dvd_mul_right (a * (c * d)) a
+      nth_rw 1 [ha]
       ring
+    · simp
+  · rw [isIdempotentElem_iff]
+    nth_rw 3 [ha]
+    ring
 
 theorem irreducible_of_isMaximal_span_singleton [IsDomain α] {a : α}
     (ha : a ≠ 0) (max : (Ideal.span {a}).IsMaximal) :

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -239,8 +239,8 @@ theorem irreducible_of_isMaximal_of_eq_span_singleton_of_not_isIdempotentElem {a
     (max.eq_of_le (span_singleton_ne_top hu) (by simp [ha, Ideal.mem_span_singleton]))
   have hv₂ : span {a} = span {v} :=
     (max.eq_of_le (span_singleton_ne_top hv) (by simp [ha, Ideal.mem_span_singleton]))
-  obtain ⟨c, rfl⟩ := show a ∣ u by simp [← Ideal.mem_span_singleton, hu₂]
-  obtain ⟨d, rfl⟩ := show a ∣ v by simp [← Ideal.mem_span_singleton, hv₂]
+  obtain ⟨c, rfl⟩ : a ∣ u := by simp [← Ideal.mem_span_singleton, hu₂]
+  obtain ⟨d, rfl⟩ : a ∣ v := by simp [← Ideal.mem_span_singleton, hv₂]
   refine idem (a * (c * d)) ?_ ?_
   · apply le_antisymm <;> rw [span_singleton_le_span_singleton]
     · convert dvd_mul_right (a * (c * d)) a


### PR DESCRIPTION
Refactor proof of `irreducible_of_isMaximal_of_eq_span_singleton_of_not_isIdempotentElem` for readability and robustness.

Follows #42332

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
