### PR TITLE
perf(IntermediateField/Basic): algebra instance for IntermediateField.restrictScalars

### DIFF
--- a/Mathlib/FieldTheory/Extension.lean
+++ b/Mathlib/FieldTheory/Extension.lean
@@ -210,13 +210,11 @@ theorem exists_lift_of_splits' (x : Lifts F E K) {s : E} (h1 : IsIntegral x.carr
   have I2 := (minpoly.degree_pos h1).ne'
   letI : Algebra x.carrier K := x.emb.toRingHom.toAlgebra
   let carrier := x.carrier⟮s⟯.restrictScalars F
-  letI : Algebra x.carrier carrier := x.carrier⟮s⟯.toSubalgebra.algebra
   let φ : carrier →ₐ[x.carrier] K := ((algHomAdjoinIntegralEquiv x.carrier h1).symm
     ⟨rootOfSplits h2 (by rwa [degree_map]), by
       rw [mem_aroots, and_iff_right (minpoly.ne_zero h1)]
       exact (eval_map _ _).symm.trans (eval_rootOfSplits _ _)⟩)
-  ⟨⟨carrier, (@algHomEquivSigma F x.carrier carrier K _ _ _ _ _ _ _ _
-      (IsScalarTower.of_algebraMap_eq fun _ ↦ rfl)).symm ⟨x.emb, φ⟩⟩,
+  ⟨⟨carrier, algHomEquivSigma.symm ⟨x.emb, φ⟩⟩,
     ⟨fun z hz ↦ algebraMap_mem x.carrier⟮s⟯ ⟨z, hz⟩, φ.commutes⟩,
     mem_adjoin_simple_self x.carrier s⟩
 

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -737,6 +737,9 @@ instance (E : IntermediateField L' L) : Algebra L' (E.restrictScalars K) := E.al
 instance (E : IntermediateField L' L) : IsScalarTower L' (E.restrictScalars K) L :=
   E.isScalarTower_mid'
 
+instance (E : IntermediateField L' L) : IsScalarTower K L' (E.restrictScalars K) :=
+  E.isScalarTower
+
 end RestrictScalars
 
 /-- This was formerly an instance called `lift2_alg`, but an instance above already provides it. -/

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -732,6 +732,11 @@ theorem restrictScalars_inj {E E' : IntermediateField L' L} :
     E.restrictScalars K = E'.restrictScalars K ↔ E = E' :=
   (restrictScalars_injective K).eq_iff
 
+instance (E : IntermediateField L' L) : Algebra L' (E.restrictScalars K) := E.algebra
+
+instance (E : IntermediateField L' L) : IsScalarTower L' (E.restrictScalars K) L :=
+  E.isScalarTower_mid'
+
 end RestrictScalars
 
 /-- This was formerly an instance called `lift2_alg`, but an instance above already provides it. -/

--- a/Mathlib/NumberTheory/FunctionField.lean
+++ b/Mathlib/NumberTheory/FunctionField.lean
@@ -233,13 +233,6 @@ lemma finiteDimensional_of_adjoin_transcendental (hy : Transcendental F y) :
   let x := algebraMap _ K (X : F⟮X⟯)
   let Fyx := restrictScalars F F⟮y⟯⟮x⟯
   let Fxy := restrictScalars F F⟮x⟯⟮y⟯
-  -- Recalling instance to speed up search
-  let : Algebra F⟮y⟯ Fyx := F⟮y⟯⟮x⟯.algebra
-  let : Module F⟮y⟯ Fyx := Algebra.toModule
-  let : SMul F⟮y⟯ Fyx := Algebra.toSMul
-  let : Algebra F⟮x⟯ Fxy := F⟮x⟯⟮y⟯.algebra
-  let : Module F⟮x⟯ Fxy := Algebra.toModule
-  let : SMul F⟮x⟯ Fxy := Algebra.toSMul
   have : FiniteDimensional F⟮y⟯ Fyx :=
     adjoin.finiteDimensional
       (isAlgebraic_iff_isIntegral.mp (isAlgebraic_X_over_adjoin_transcendental hy))
@@ -247,9 +240,7 @@ lemma finiteDimensional_of_adjoin_transcendental (hy : Transcendental F y) :
     have := FiniteDimensional.adjoin_algebraMap_X (F := F) (K := K)
     unfold Fyx
     rw [adjoin_simple_comm]
-    have : IsScalarTower F⟮x⟯ Fxy K := isScalarTower_mid' F⟮x⟯⟮y⟯
     exact .right F⟮x⟯ Fxy K
-  have : IsScalarTower F⟮y⟯ Fyx K := isScalarTower_mid' F⟮y⟯⟮x⟯
   .trans F⟮y⟯ Fyx K
 
 end AdjoinTranscendental


### PR DESCRIPTION
Add `Algebra` / `IsScalarTower` instance for `IntermediateField.restrictScalars`.
This simplifies a proof in `FunctionField.lean`.

I also tried to hunt for another similar application and found one in `Mathlib.FieldTheory.Extension`.

AI disclaimer: I asked an AI assistant to suggest an improvement to the proof in the FunctionField.lean file. This PR is the result of this discussion. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
