### PR TITLE
[Merged by Bors] - chore: add `shake: keep` to imports that `shake --fix` wrongly drops

### DIFF
--- a/Mathlib/Tactic/DuplicateDecls.lean
+++ b/Mathlib/Tactic/DuplicateDecls.lean
@@ -6,7 +6,7 @@ Authors: Jovan Gerbscheid
 module
 
 public import Mathlib.Init
-public import ImportGraph.Lean.Environment
+public import ImportGraph.Lean.Environment  -- shake: keep (Environment.getModuleFor? is used from public meta code), cf. lean#14427
 
 /-!
 # A tool for finding duplicate declarations

--- a/Mathlib/Tactic/NormDet.lean
+++ b/Mathlib/Tactic/NormDet.lean
@@ -5,8 +5,8 @@ Authors: Paul Cadman
 -/
 module
 
-public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
-public import Mathlib.LinearAlgebra.Matrix.Determinant.Bird.Correctness
+public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic  -- shake: keep (Matrix.det, Qq dependency)
+public import Mathlib.LinearAlgebra.Matrix.Determinant.Bird.Correctness  -- shake: keep (BirdDet.det_eq_birdDet, Qq dependency)
 public meta import Mathlib.Tactic.Determinant.Bird.Cert
 
 /-!


### PR DESCRIPTION
Found by examining the [latest build failure](https://github.com/leanprover-community/mathlib4/actions/runs/31334112781) for the automated shake --fix PR at #40343. Two fixes:

* `Mathlib/Tactic/DuplicateDecls.lean`: shake demotes `public import ImportGraph.Lean.Environment` to `meta import`, since `Environment.getModuleFor?` is only reached through the private meta helper `mkModuleKey!`, so no `metaPub` need is ever recorded for it. This is leanprover/lean4#14427.

* `Mathlib/Tactic/NormDet.lean`: shake drops the imports providing `Matrix.det` and `BirdDet.det_eq_birdDet`. Both are referenced only inside `q(...)`/`~q(...)` quotations and the `simproc_decl norm_det (Matrix.det _)` pattern, so they are invisible to `calcNeeds`, which only walks `Expr.foldConsts`.

Generated with Claude code

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
