### PR TITLE
[Merged by Bors] - feat(fun_prop): discharge autoParams and optParams

### DIFF
--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -8,6 +8,7 @@ module
 public meta import Lean.Elab.Tactic.Config
 public import Mathlib.Tactic.FunProp.Core
 
+import Mathlib.Tactic.InferParam
 import Lean.Elab.InfoTree.Main
 
 /-!
@@ -62,7 +63,7 @@ syntax (name := funPropTacStx)
   "fun_prop" optConfig (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
 
 private def assumptionDischarge : Expr → MetaM (Option Expr) :=
-  fun e => do tacticToDischarge (← `(tactic| with_reducible assumption)) e
+  fun e => do tacticToDischarge (← `(tactic| first | with_reducible assumption | infer_param)) e
 
 /-- Tactic to prove function properties -/
 @[tactic funPropTacStx]
@@ -92,7 +93,8 @@ def funPropTac : Tactic
         | some d =>
           match d with
           | `(discharger| (discharger:=$tac)) =>
-            pure <| tacticToDischarge (← `(tactic| first | with_reducible assumption | ($tac)))
+            pure <| tacticToDischarge
+              (← `(tactic| first | with_reducible assumption | infer_param | ($tac)))
           | _ => pure assumptionDischarge
 
       let namesToUnfold ← show CoreM (Array Name) from


### PR DESCRIPTION
Currently, `fun_prop` only discharges assumptions from the local context. This means that `fun_prop` usually fails to deduce `Differentiable` from `ContDiff` because there will be no assumption in context to discharge the side goal. This change enables it to provide *light-weight* `autoParams` tactics that will discharge easy side goals (for instance positivity, or `grind` with a specialized set of lemmas).

Some amount of care has to be exercised here to not accidentally create `autoParam` loops.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
