### PR TITLE
[Merged by Bors] - feat(IsMulCommutative): generalize lemma from MulHom to MulHomClass

### DIFF
--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -937,9 +937,9 @@ theorem Function.Surjective.isMulCommutative [Mul M] [Mul N] [FunLike F M N] [Mu
     simp [← ha', ← hb', ← map_mul, mul_comm']
 
 @[deprecated (since := "2026-08-11")]
-alias Function.Surjective.mul_comm := Function.Surjective.isMulCommutative
-@[deprecated (since := "2026-08-11")]
 alias Function.Surjective.add_comm := Function.Surjective.isAddCommutative
+@[to_additive existing, deprecated (since := "2026-08-11")]
+alias Function.Surjective.mul_comm := Function.Surjective.isMulCommutative
 
 /-- The inverse of a bijective `MonoidHom` is a `MonoidHom`. -/
 @[to_additive (attr := simps)

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -923,17 +923,23 @@ def MulHom.inverse [Mul M] [Mul N] (f : M →ₙ* N) (g : N → M)
       _ = g (f (g x * g y)) := by rw [f.map_mul]
       _ = g x * g y := h₁ _
 
-/-- If `M` and `N` have multiplications, `f : M →ₙ* N` is a surjective multiplicative map,
+/-- If `M` and `N` have multiplications, `f` is a surjective multiplicative map,
 and `M` is commutative, then `N` is commutative. -/
 @[to_additive
-/-- If `M` and `N` have additions, `f : M →ₙ+ N` is a surjective additive map,
+/-- If `M` and `N` have additions, `f` is a surjective additive map,
 and `M` is commutative, then `N` is commutative. -/]
-theorem Function.Surjective.mul_comm [Mul M] [Mul N] {f : M →ₙ* N} (is_surj : Function.Surjective f)
-    (is_comm : IsMulCommutative M) : IsMulCommutative N where
+theorem Function.Surjective.isMulCommutative [Mul M] [Mul N] [FunLike F M N] [MulHomClass F M N]
+    {f : F} (is_surj : Function.Surjective f) (is_comm : IsMulCommutative M) :
+    IsMulCommutative N where
   is_comm.comm a b := by
     have ⟨a', ha'⟩ := is_surj a
     have ⟨b', hb'⟩ := is_surj b
     simp [← ha', ← hb', ← map_mul, mul_comm']
+
+@[deprecated (since := "2026-08-11")]
+alias Function.Surjective.mul_comm := Function.Surjective.isMulCommutative
+@[deprecated (since := "2026-08-11")]
+alias Function.Surjective.add_comm := Function.Surjective.isAddCommutative
 
 /-- The inverse of a bijective `MonoidHom` is a `MonoidHom`. -/
 @[to_additive (attr := simps)

--- a/Mathlib/GroupTheory/Commutator/Basic.lean
+++ b/Mathlib/GroupTheory/Commutator/Basic.lean
@@ -519,7 +519,7 @@ theorem Subgroup.Normal.commutator_le_of_self_sup_commutative_eq_top {N : Subgro
   -- Q is a quotient of H
   let φ : H →ₙ* G ⧸ N := MonoidHom.comp (QuotientGroup.mk' N) (Subgroup.subtype H)
   -- It is enough to prove that φ is surjective
-  apply Function.Surjective.mul_comm (f := φ) _ hH
+  apply Function.Surjective.isMulCommutative (f := φ) _ hH
   -- We have to prove that `MonoidHom.range φ = ⊤`
   have : Subgroup.map (QuotientGroup.mk' N) ⊤ = ⊤ := by
     rw [← MonoidHom.range_eq_map, MonoidHom.range_eq_top]


### PR DESCRIPTION
---

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
