### PR TITLE
[Merged by Bors] - ci: keep the nightly toolchain when merging master into nightly-testing

### DIFF
--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -1,4 +1,5 @@
-# This job merges every commit to `master` into `nightly-testing`, resolving merge conflicts in favor of `master`.
+# This job merges every commit to `master` into `nightly-testing`, resolving merge conflicts in
+# favor of `master`, except in `lean-toolchain`, which always keeps the `nightly-testing` value.
 
 name: Merge master to nightly
 
@@ -60,6 +61,13 @@ jobs:
           # If the merge goes badly, we proceed anyway via '|| true'.
           # CI will report failures on the 'nightly-testing' branch direct to Zulip.
           git merge upstream/master --strategy-option theirs --no-commit --allow-unrelated-histories || true
+          # `lean-toolchain` is the one file where master must never win: whenever master
+          # bumps its toolchain, the merge above would replace the nightly with a stable
+          # release, and the whole point of `nightly-testing` is to build against a nightly.
+          # (`nightly_bump_and_merge.yml` in the mathlib4-nightly-testing repository puts
+          # this back a few hours later, but only after a wasted CI run and a Zulip report.)
+          # The merge is `--no-commit`, so `HEAD` is still the tip of `nightly-testing`.
+          git checkout HEAD -- lean-toolchain
           # We aggressively run `lake update`, to avoid having to do this by hand.
           # When Batteries changes break Mathlib, this will likely show up on nightly-testing first.
           lake update -v


### PR DESCRIPTION
This PR restores `lean-toolchain` from `nightly-testing` after the daily merge of `master`, so that a toolchain bump on `master` no longer drags `nightly-testing` onto a stable release.

Since #40257 the merge resolves conflicts in favour of `master`. That is the right call for source files, but `lean-toolchain` is the one file where `master` must never win: on every day that `master` bumps its toolchain the two sides conflict, and `nightly-testing` silently ends up on the release toolchain. It happened this morning, where the merge replaced `nightly-2026-08-10` with `v4.33.0` and the build then failed with `Unknown identifier ite_eq_right` and friends in `Mathlib/Data/Nat/BinaryRec.lean`:

https://github.com/leanprover-community/mathlib4-nightly-testing/actions/runs/31447213372

`nightly_bump_and_merge.yml` puts a nightly back within three hours, so the cost is a wasted CI run and a spurious failure report on Zulip rather than anything lasting, but there is no reason to pay it. The merge runs with `--no-commit`, so `HEAD` is still the tip of `nightly-testing` and `git checkout HEAD -- lean-toolchain` is enough; it runs before `lake update` so that the dependency resolution also happens against the nightly.

🤖 Prepared with Claude Code