### PR TITLE
[Merged by Bors] - chore: fix more linter warnings encountered by `scripts/rm_set_option.py`

### DIFF
--- a/Mathlib/CategoryTheory/Limits/FormalCoproducts/Cech.lean
+++ b/Mathlib/CategoryTheory/Limits/FormalCoproducts/Cech.lean
@@ -186,7 +186,7 @@ variable [HasFiniteProducts C]
 
 /-- Given `U : FormalCoproduct C`, this is the simplicial object
 in `FormalCoproduct C` which sends `⦋n⦌` to `U.power (Fin (n + 1))`. -/
-@[simps]
+@[implicit_reducible, simps]
 noncomputable def cech (U : FormalCoproduct.{w} C) :
     SimplicialObject (FormalCoproduct.{w} C) where
   obj n := U.power (ToType n.unop)

--- a/Mathlib/CategoryTheory/Limits/FormalCoproducts/ExtraDegeneracy.lean
+++ b/Mathlib/CategoryTheory/Limits/FormalCoproducts/ExtraDegeneracy.lean
@@ -61,7 +61,6 @@ lemma cechIsoCechNerveApp_hom_π (n : SimplexCategoryᵒᵖ) (i : ToType n.unop)
       WidePullback.π (fun _ ↦ (isTerminalIncl T hT).from U) i = U.powerπ i :=
   IsLimit.conePointUniqueUpToIso_hom_comp _ _ _
 
-set_option backward.isDefEq.respectTransparency.types false in
 @[reassoc (attr := simp)]
 lemma cechIsoCechNerveApp_inv_π (n : SimplexCategoryᵒᵖ) (i : ToType n.unop) :
     (U.cechIsoCechNerveApp hT n).inv ≫ U.powerπ i =

--- a/Mathlib/Logic/Equiv/Option.lean
+++ b/Mathlib/Logic/Equiv/Option.lean
@@ -234,13 +234,10 @@ theorem optionSubtype_symm_apply_apply_none
     (e : α ≃ { y : β // y ≠ x }) : ((optionSubtype x).symm e : Option α ≃ β) none = x :=
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem optionSubtype_symm_apply_symm_apply [DecidableEq β] (x : β) (e : α ≃ { y : β // y ≠ x })
     (b : { y : β // y ≠ x }) : ((optionSubtype x).symm e : Option α ≃ β).symm b = e.symm b := by
-  simp only [optionSubtype, coe_fn_symm_mk, Subtype.coe_mk,
-             Subtype.coe_eta, dite_eq_ite, ite_eq_right_iff]
-  exact fun h => False.elim (b.property h)
+  simp [optionSubtype, b.property]
 
 variable [DecidableEq α] {a b : α}
 


### PR DESCRIPTION
This PR fixes two more linter warnings in order to make `scripts/rm_set_option.py` work:

- An unused simp argument
- `cechIsoCechNerveApp_inv_π_assoc` was getting the wrong type when removing the backwards option. This makes sense because the theorem is ill-typed at implicit transparency. To fix this, I marked `CategoryTheory.Limits.FormalCoproduct.cech` as `implicit_reducible`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
