### PR TITLE
[Merged by Bors] - feat(Analysis): generalise `eVariationOn` to `WeakPseudoEMetricSpace`

### DIFF
--- a/Mathlib/Analysis/ConstantSpeed.lean
+++ b/Mathlib/Analysis/ConstantSpeed.lean
@@ -47,7 +47,7 @@ open scoped NNReal ENNReal
 
 open Set
 
-variable {α : Type*} [LinearOrder α] {E : Type*} [PseudoEMetricSpace E]
+variable {α : Type*} [LinearOrder α] {E : Type*} [TopologicalSpace E] [WeakPseudoEMetricSpace E]
 variable (f : ℝ → E) (s : Set ℝ) (l : ℝ≥0)
 
 /-- `f` has constant speed `l` on `s` if the variation of `f` on `s ∩ Icc x y` is equal to
@@ -115,7 +115,7 @@ theorem HasConstantSpeedOnWith.union {t : Set ℝ} (hfs : HasConstantSpeedOnWith
         exacts [Or.inl ⟨ws, zw, hs.2 ws⟩, Or.inr ⟨wt, ht.2 wt, wy⟩]
       · rintro (⟨ws, zw, wx⟩ | ⟨wt, xw, wy⟩)
         exacts [⟨Or.inl ws, zw, wx.trans (ht.2 yt)⟩, ⟨Or.inr wt, (hs.2 zs).trans xw, wy⟩]
-    rw [this, @eVariationOn.union _ _ _ _ f _ _ x, hfs zs hs.1 (hs.2 zs), hft ht.1 yt (ht.2 yt)]
+    rw [this, @eVariationOn.union _ _ _ _ _ f _ _ x, hfs zs hs.1 (hs.2 zs), hft ht.1 yt (ht.2 yt)]
     · have q := ENNReal.ofReal_add (mul_nonneg l.prop (sub_nonneg.mpr (hs.2 zs)))
         (mul_nonneg l.prop (sub_nonneg.mpr (ht.2 yt)))
       simp only [NNReal.val_eq_coe] at q
@@ -253,7 +253,7 @@ theorem has_unit_speed_naturalParameterization (f : α → E) {s : Set α}
     rw [←
       eVariationOn.comp_inter_Icc_eq_of_monotoneOn (naturalParameterization f s a) _
         (variationOnFromTo.monotoneOn hf as) bs cs]
-    rw [@eVariationOn.eq_of_edist_zero_on _ _ _ _ _ f]
+    rw [@eVariationOn.eq_of_edist_zero_on _ _ _ _ _ _ f]
     · rw [variationOnFromTo.eq_of_le _ _ bc, ENNReal.ofReal_toReal (hf b c bs cs)]
     · rintro x ⟨xs, _, _⟩
       exact edist_naturalParameterization_eq_zero hf as xs

--- a/Mathlib/Analysis/ConstantSpeed.lean
+++ b/Mathlib/Analysis/ConstantSpeed.lean
@@ -115,7 +115,7 @@ theorem HasConstantSpeedOnWith.union {t : Set ℝ} (hfs : HasConstantSpeedOnWith
         exacts [Or.inl ⟨ws, zw, hs.2 ws⟩, Or.inr ⟨wt, ht.2 wt, wy⟩]
       · rintro (⟨ws, zw, wx⟩ | ⟨wt, xw, wy⟩)
         exacts [⟨Or.inl ws, zw, wx.trans (ht.2 yt)⟩, ⟨Or.inr wt, (hs.2 zs).trans xw, wy⟩]
-    rw [this, @eVariationOn.union _ _ _ _ _ f _ _ x, hfs zs hs.1 (hs.2 zs), hft ht.1 yt (ht.2 yt)]
+    rw [this, eVariationOn.union (f := f) (x := x), hfs zs hs.1 (hs.2 zs), hft ht.1 yt (ht.2 yt)]
     · have q := ENNReal.ofReal_add (mul_nonneg l.prop (sub_nonneg.mpr (hs.2 zs)))
         (mul_nonneg l.prop (sub_nonneg.mpr (ht.2 yt)))
       simp only [NNReal.val_eq_coe] at q
@@ -253,7 +253,7 @@ theorem has_unit_speed_naturalParameterization (f : α → E) {s : Set α}
     rw [←
       eVariationOn.comp_inter_Icc_eq_of_monotoneOn (naturalParameterization f s a) _
         (variationOnFromTo.monotoneOn hf as) bs cs]
-    rw [@eVariationOn.eq_of_edist_zero_on _ _ _ _ _ _ f]
+    rw [eVariationOn.eq_of_edist_zero_on (f' := f)]
     · rw [variationOnFromTo.eq_of_le _ _ bc, ENNReal.ofReal_toReal (hf b c bs cs)]
     · rintro x ⟨xs, _, _⟩
       exact edist_naturalParameterization_eq_zero hf as xs

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -52,7 +52,8 @@ that the sets one uses are nonempty and bounded above as these are only conditio
 open scoped NNReal ENNReal Topology UniformConvergence
 open Set Filter OrderDual
 
-variable {α : Type*} [LinearOrder α] {E : Type*} [PseudoEMetricSpace E]
+variable {α : Type*} [LinearOrder α] {E M : Type*} [TopologicalSpace E] [WeakPseudoEMetricSpace E]
+  [PseudoEMetricSpace M]
 
 /-- The (extended-real-valued) variation of a function `f` on a set `s` inside a linear order is
 the supremum of the sum of `edist (f (u (i+1))) (f (u i))` over all finite increasing
@@ -225,7 +226,7 @@ theorem _root_.BoundedVariationOn.of_subsingleton {f : α → E} {s : Set α} (h
     BoundedVariationOn f s := by
   simp [BoundedVariationOn, hs]
 
-theorem lowerSemicontinuous_aux {ι : Type*} {F : ι → α → E} {p : Filter ι} {f : α → E} {s : Set α}
+theorem lowerSemicontinuous_aux {ι : Type*} {F : ι → α → M} {p : Filter ι} {f : α → M} {s : Set α}
     (Ffs : ∀ x ∈ s, Tendsto (fun i => F i x) p (𝓝 (f x))) {v : ℝ≥0∞} (hv : v < eVariationOn f s) :
     ∀ᶠ n : ι in p, v < eVariationOn (F n) s := by
   obtain ⟨⟨n, ⟨u, um, us⟩⟩, hlt⟩ :
@@ -243,16 +244,16 @@ Pointwise convergence on `s` is encoded here as uniform convergence on the famil
 singletons of elements of `s`.
 -/
 protected theorem lowerSemicontinuous (s : Set α) :
-    LowerSemicontinuous fun f : α →ᵤ[s.image singleton] E => eVariationOn f s := fun f ↦ by
-  apply @lowerSemicontinuous_aux _ _ _ _ (UniformOnFun α E (s.image singleton)) id (𝓝 f) f s _
+    LowerSemicontinuous fun f : α →ᵤ[s.image singleton] M => eVariationOn f s := fun f ↦ by
+  apply @lowerSemicontinuous_aux _ _ _ _ (UniformOnFun α M (s.image singleton)) id (𝓝 f) f s _
   simpa only [UniformOnFun.tendsto_iff_tendstoUniformlyOn, mem_image, forall_exists_index, and_imp,
     forall_apply_eq_imp_iff₂, tendstoUniformlyOn_singleton_iff_tendsto] using! @tendsto_id _ (𝓝 f)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The map `(eVariationOn · s)` is lower semicontinuous for uniform convergence on `s`. -/
 theorem lowerSemicontinuous_uniformOn (s : Set α) :
-    LowerSemicontinuous fun f : α →ᵤ[{s}] E => eVariationOn f s := fun f ↦ by
-  apply @lowerSemicontinuous_aux _ _ _ _ (UniformOnFun α E {s}) id (𝓝 f) f s _
+    LowerSemicontinuous fun f : α →ᵤ[{s}] M => eVariationOn f s := fun f ↦ by
+  apply @lowerSemicontinuous_aux _ _ _ _ (UniformOnFun α M {s}) id (𝓝 f) f s _
   have := @tendsto_id _ (𝓝 f)
   rw [UniformOnFun.tendsto_iff_tendstoUniformlyOn] at this
   simp_rw [← tendstoUniformlyOn_singleton_iff_tendsto]
@@ -598,7 +599,7 @@ end Monotone
 contribution of `a`, i.e., the distance between the left limit and the value at `a`.
 We give a version relative to a set `s`. -/
 theorem eVariationOn_on_inter_Iic_eq_Iio_add_edist
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {a : α} {l : E}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α} {a : α} {l : M}
     (h : (𝓝[s ∩ Iio a] a).NeBot) (ha : a ∈ s)
     (h'f : Tendsto f (𝓝[s ∩ Iio a] a) (𝓝 l)) :
     eVariationOn f (s ∩ Iic a) = eVariationOn f (s ∩ Iio a) + edist (f a) l := by
@@ -664,7 +665,7 @@ theorem eVariationOn_on_inter_Iic_eq_Iio_add_edist
 contribution of `a`, i.e., the distance between the right limit and the value at `a`.
 We give a version relative to a set `s`. -/
 theorem eVariationOn_on_inter_Ici_eq_Ioi_add_edist
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {a : α} {l : E}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α} {a : α} {l : M}
     (h : (𝓝[s ∩ Ioi a] a).NeBot) (ha : a ∈ s)
     (h'f : Tendsto f (𝓝[s ∩ Ioi a] a) (𝓝 l)) :
     eVariationOn f (s ∩ Ici a) = eVariationOn f (s ∩ Ioi a) + edist (f a) l := by
@@ -674,7 +675,7 @@ theorem eVariationOn_on_inter_Ici_eq_Ioi_add_edist
 /-- If a function is continuous on the left at a point `a`, then its variations on `Iio a` and
 on `Iic a` coincide. We give a version relative to a set `s`. -/
 lemma eVariationOn_inter_Iio_eq_inter_Iic_of_continuousWithinAt
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {a : α}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α} {a : α}
     (h : (𝓝[s ∩ Iio a] a).NeBot) (h' : ContinuousWithinAt f (s ∩ Iic a) a) :
     eVariationOn f (s ∩ Iio a) = eVariationOn f (s ∩ Iic a) := by
   by_cases ha : a ∈ s
@@ -686,14 +687,14 @@ lemma eVariationOn_inter_Iio_eq_inter_Iic_of_continuousWithinAt
 /-- If a function is continuous on the right at a point `a`, then its variations on `Ioi a` and
 on `Ici a` coincide. We give a version relative to a set `s`. -/
 lemma eVariationOn_inter_Ioi_eq_inter_Ici_of_continuousWithinAt
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {a : α}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α} {a : α}
     (h : (𝓝[s ∩ Ioi a] a).NeBot) (h' : ContinuousWithinAt f (s ∩ Ici a) a) :
     eVariationOn f (s ∩ Ioi a) = eVariationOn f (s ∩ Ici a) := by
   rw [← comp_ofDual f, ← comp_ofDual f]
   exact eVariationOn_inter_Iio_eq_inter_Iic_of_continuousWithinAt h h'
 
 lemma eVariationOn_Ioc_eq_Icc_of_continuousWithinAt'
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {a b : α}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {a b : α}
     [h : (𝓝[>] a).NeBot] (h' : ContinuousWithinAt f (Ici a) a) :
     eVariationOn f (Ioc a b) = eVariationOn f (Icc a b) := by
   rcases le_or_gt b a with hab | hab
@@ -705,7 +706,7 @@ lemma eVariationOn_Ioc_eq_Icc_of_continuousWithinAt'
     (h'.mono inter_subset_right) <;> grind
 
 lemma eVariationOn_Ioc_eq_Icc_of_continuousWithinAt
-    [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α] {f : α → E} {a b : α}
+    [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α] {f : α → M} {a b : α}
     (h' : ContinuousWithinAt f (Ici a) a) :
     eVariationOn f (Ioc a b) = eVariationOn f (Icc a b) := by
   rcases le_or_gt b a with hab | hab
@@ -714,14 +715,14 @@ lemma eVariationOn_Ioc_eq_Icc_of_continuousWithinAt
   exact eVariationOn_Ioc_eq_Icc_of_continuousWithinAt' h'
 
 lemma eVariationOn_Ico_eq_Icc_of_continuousWithinAt'
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {a b : α}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {a b : α}
     [h : (𝓝[<] a).NeBot] (h' : ContinuousWithinAt f (Iic a) a) :
     eVariationOn f (Ico b a) = eVariationOn f (Icc b a) := by
   rw [← comp_ofDual f, ← comp_ofDual f, ← Ioc_toDual, ← Icc_toDual]
   exact eVariationOn_Ioc_eq_Icc_of_continuousWithinAt' h'
 
 lemma eVariationOn_Ico_eq_Icc_of_continuousWithinAt
-    [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α] {f : α → E} {a b : α}
+    [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α] {f : α → M} {a b : α}
     (h' : ContinuousWithinAt f (Iic a) a) :
     eVariationOn f (Ico b a) = eVariationOn f (Icc b a) := by
   rw [← comp_ofDual f, ← comp_ofDual f, ← Ioc_toDual, ← Icc_toDual]
@@ -805,8 +806,8 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ici_zero_of_filter
 
 /-- A bounded variation function has a limit on its left within a set. Version with a general
 filter, covering both left neighborhoods of points and `atTop`. -/
-theorem _root_.BoundedVariationOn.exists_tendsto_left_of_filter [CompleteSpace E]
-    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s)
+theorem _root_.BoundedVariationOn.exists_tendsto_left_of_filter [CompleteSpace M]
+    {f : α → M} {s : Set α} (hf : BoundedVariationOn f s)
     (L : Filter α) (hL : ∀ y ∈ s, s ∩ Ici y ∈ L) (hs : s.Nonempty) :
     ∃ l, Tendsto f L (𝓝 l) := by
   rcases hs with ⟨x₀, hx₀⟩
@@ -855,8 +856,8 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ioc_zero [TopologicalSpac
   exact hf.ofDual.tendsto_eVariationOn_Ico_zero (toDual x)
 
 /-- A bounded variation function has a limit on its left within a set. -/
-theorem _root_.BoundedVariationOn.exists_tendsto_left [CompleteSpace E] [TopologicalSpace α]
-    [OrderTopology α] {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
+theorem _root_.BoundedVariationOn.exists_tendsto_left [CompleteSpace M] [TopologicalSpace α]
+    [OrderTopology α] {f : α → M} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
     ∃ l, Tendsto f (𝓝[s ∩ Iio x] x) (𝓝 l) := by
   rcases eq_empty_or_nonempty (s ∩ Iio x) with hs | hs
   · simp only [hs, nhdsWithin_empty, tendsto_bot, exists_const_iff, and_true]
@@ -865,27 +866,27 @@ theorem _root_.BoundedVariationOn.exists_tendsto_left [CompleteSpace E] [Topolog
     (hf.mono inter_subset_left) _ (fun y hy ↦ inter_mem_nhdsWithin _ (Ici_mem_nhds hy.2)) hs
 
 /-- A bounded variation function has a limit on its right within a set. -/
-theorem _root_.BoundedVariationOn.exists_tendsto_right [CompleteSpace E] [TopologicalSpace α]
-    [OrderTopology α] {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
+theorem _root_.BoundedVariationOn.exists_tendsto_right [CompleteSpace M] [TopologicalSpace α]
+    [OrderTopology α] {f : α → M} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
     ∃ l, Tendsto f (𝓝[s ∩ Ioi x] x) (𝓝 l) :=
   hf.ofDual.exists_tendsto_left (toDual x)
 
 /-- A bounded variation function tends to its left-limit on its left. -/
-theorem _root_.BoundedVariationOn.tendsto_leftLim [CompleteSpace E] [TopologicalSpace α]
-    [OrderTopology α] {f : α → E} (hf : BoundedVariationOn f univ) (x : α) :
+theorem _root_.BoundedVariationOn.tendsto_leftLim [CompleteSpace M] [TopologicalSpace α]
+    [OrderTopology α] {f : α → M} (hf : BoundedVariationOn f univ) (x : α) :
     Tendsto f (𝓝[<] x) (𝓝 (f.leftLim x)) := by
   apply tendsto_leftLim_of_tendsto
   convert! hf.exists_tendsto_left x
   simp
 
 /-- A bounded variation function tends to its right-limit on its right. -/
-theorem _root_.BoundedVariationOn.tendsto_rightLim [CompleteSpace E] [TopologicalSpace α]
-    [OrderTopology α] {f : α → E} (hf : BoundedVariationOn f univ) (x : α) :
+theorem _root_.BoundedVariationOn.tendsto_rightLim [CompleteSpace M] [TopologicalSpace α]
+    [OrderTopology α] {f : α → M} (hf : BoundedVariationOn f univ) (x : α) :
     Tendsto f (𝓝[>] x) (𝓝 (f.rightLim x)) :=
   hf.ofDual.tendsto_leftLim x
 
-theorem _root_.BoundedVariationOn.eVariationOn_Iic_eq_Iio_add_edist [CompleteSpace E]
-    [DenselyOrdered α] {f : α → E} {a : α} (hf : BoundedVariationOn f univ) :
+theorem _root_.BoundedVariationOn.eVariationOn_Iic_eq_Iio_add_edist [CompleteSpace M]
+    [DenselyOrdered α] {f : α → M} {a : α} (hf : BoundedVariationOn f univ) :
     eVariationOn f (Iic a) = eVariationOn f (Iio a) + edist (f a) (f.leftLim a) := by
   let : TopologicalSpace α := Preorder.topology α
   have : OrderTopology α := ⟨rfl⟩
@@ -900,8 +901,8 @@ theorem _root_.BoundedVariationOn.eVariationOn_Iic_eq_Iio_add_edist [CompleteSpa
     simpa only [univ_inter] using hf.tendsto_leftLim _
   simpa using this
 
-theorem _root_.BoundedVariationOn.eVariationOn_Ici_eq_Ioi_add_edist [CompleteSpace E]
-    [DenselyOrdered α] {f : α → E} {a : α} (hf : BoundedVariationOn f univ) :
+theorem _root_.BoundedVariationOn.eVariationOn_Ici_eq_Ioi_add_edist [CompleteSpace M]
+    [DenselyOrdered α] {f : α → M} {a : α} (hf : BoundedVariationOn f univ) :
     eVariationOn f (Ici a) = eVariationOn f (Ioi a) + edist (f a) (f.rightLim a) := by
   rw [← eVariationOn.comp_ofDual f, ← eVariationOn.comp_ofDual f]
   exact hf.ofDual.eVariationOn_Iic_eq_Iio_add_edist (a := toDual a)
@@ -910,7 +911,7 @@ theorem _root_.BoundedVariationOn.eVariationOn_Ici_eq_Ioi_add_edist [CompleteSpa
 small closed intervals to the left of this point tends to the contribution of the point, i.e.,
 the distance between the left limit and the value at the point -/
 theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_left
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {l : E}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α} {l : M}
     (hf : BoundedVariationOn f s) {x : α} (h'f : Tendsto f (𝓝[s ∩ Iio x] x) (𝓝 l)) (hx : x ∈ s) :
     Tendsto (fun y ↦ eVariationOn f (s ∩ Icc y x)) (𝓝[s ∩ Iio x] x) (𝓝 (edist (f x) l)) := by
   rcases eq_or_neBot (𝓝[s ∩ Iio x] x) with h | h
@@ -936,7 +937,7 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_left
 small closed intervals to the right of this point tends to the contribution of the point, i.e.,
 the distance between the right limit and the value at the point -/
 theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_right
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {l : E}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α} {l : M}
     (hf : BoundedVariationOn f s) {x : α} (h'f : Tendsto f (𝓝[s ∩ Ioi x] x) (𝓝 l)) (hx : x ∈ s) :
     Tendsto (fun y ↦ eVariationOn f (s ∩ Icc x y)) (𝓝[s ∩ Ioi x] x) (𝓝 (edist (f x) l)) := by
   have : (fun y ↦ eVariationOn f (s ∩ Icc x y)) =
@@ -950,7 +951,7 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_right
 small closed intervals to the left of this point tends to the contribution of the point, i.e.,
 the distance between the left limit and the value at the point -/
 theorem _root_.LocallyBoundedVariationOn.tendsto_eVariationOn_Icc_left
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {l : E}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α} {l : M}
     (hf : LocallyBoundedVariationOn f s) {x : α}
     (h'f : Tendsto f (𝓝[s ∩ Iio x] x) (𝓝 l)) (hx : x ∈ s) :
     Tendsto (fun y ↦ eVariationOn f (s ∩ Icc y x)) (𝓝[s ∩ Iio x] x) (𝓝 (edist (f x) l)) := by
@@ -971,7 +972,7 @@ theorem _root_.LocallyBoundedVariationOn.tendsto_eVariationOn_Icc_left
 small closed intervals to the right of this point tends to the contribution of the point, i.e.,
 the distance between the right limit and the value at the point -/
 theorem _root_.LocallyBoundedVariationOn.tendsto_eVariationOn_Icc_right
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {l : E}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α} {l : M}
     (hf : LocallyBoundedVariationOn f s) {x : α}
     (h'f : Tendsto f (𝓝[s ∩ Ioi x] x) (𝓝 l)) (hx : x ∈ s) :
     Tendsto (fun y ↦ eVariationOn f (s ∩ Icc x y)) (𝓝[s ∩ Ioi x] x) (𝓝 (edist (f x) l)) := by
@@ -985,7 +986,7 @@ theorem _root_.LocallyBoundedVariationOn.tendsto_eVariationOn_Icc_right
 /-- If a function has bounded variation and is left-continuous at a point, then the variation on
 small closed intervals to the left of this point tends to `0`. -/
 theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_zero_left
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α}
     (hf : BoundedVariationOn f s) {x : α} (h : ContinuousWithinAt f (s ∩ Iic x) x) :
     Tendsto (fun y ↦ eVariationOn f (s ∩ Icc y x)) (𝓝[s] x) (𝓝 0) := by
   rcases eq_or_neBot (𝓝[s ∩ Iio x] x) with h' | h'
@@ -1010,7 +1011,7 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_zero_left
 /-- If a function has bounded variation and is right-continuous at a point, then the variation on
 small closed intervals to the right of this point tends to `0`. -/
 theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_zero_right
-    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α}
+    [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α}
     (hf : BoundedVariationOn f s) (x : α) (h : ContinuousWithinAt f (s ∩ Ici x) x) :
     Tendsto (fun y ↦ eVariationOn f (s ∩ Icc x y)) (𝓝[s] x) (𝓝 0) := by
   have : (fun y ↦ eVariationOn f (s ∩ Icc x y)) =
@@ -1024,7 +1025,7 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_zero_right
 generally a cluster point of the values of `f` around `x`) then the variation of `g` is bounded
 by that of `f`. -/
 private lemma eVariationOn_le_of_mapClusterPt
-    [TopologicalSpace α] [OrderTopology α] {f g : α → E}
+    [TopologicalSpace α] [OrderTopology α] {f g : α → M}
     {s : Set α} (hg : ∀ x ∈ s, MapClusterPt (g x) (𝓝[s] x) f) :
     eVariationOn g s ≤ eVariationOn f s := by
   rw [eVariationOn_eq_strictMonoOn]
@@ -1033,14 +1034,14 @@ private lemma eVariationOn_le_of_mapClusterPt
   simp only
   have : Nonempty α := ⟨u 0⟩
   apply le_of_forall_lt (fun c hc ↦ ?_)
-  have : ∀ᶠ (b : ℕ → E) in 𝓝 (fun i ↦ g (u i)),
+  have : ∀ᶠ (b : ℕ → M) in 𝓝 (fun i ↦ g (u i)),
       c < ∑ i ∈ Finset.range n, edist (b (i + 1)) (b i) := by
-    have : Continuous (fun (v : ℕ → E) ↦ ∑ i ∈ Finset.range n, edist (v (i + 1)) (v i)) := by
+    have : Continuous (fun (v : ℕ → M) ↦ ∑ i ∈ Finset.range n, edist (v (i + 1)) (v i)) := by
       fun_prop
     exact (tendsto_order.1 (this.continuousAt (x := fun i ↦ g (u i))).tendsto).1 c hc
   rw [nhds_pi] at this
   obtain ⟨I, I_fin, t, t_mem, ht⟩ : ∃ (I : Set ℕ), I.Finite ∧ ∃ t, (∀ (i : ℕ), t i ∈ 𝓝 (g (u i))) ∧
-      I.pi t ⊆ {b : ℕ → E | c < ∑ i ∈ Finset.range n, edist (b (i + 1)) (b i)} := mem_pi.1 this
+      I.pi t ⊆ {b : ℕ → M | c < ∑ i ∈ Finset.range n, edist (b (i + 1)) (b i)} := mem_pi.1 this
   have : ∀ᶠ b in 𝓝 u, ∀ i ∈ ((Finset.Iic n) ×ˢ (Finset.Iic n)).filter
       (fun i ↦ i.1 < i.2), b i.1 < b i.2 := by
     rw [Filter.eventually_all_finset]
@@ -1073,37 +1074,37 @@ private lemma eVariationOn_le_of_mapClusterPt
     grind
   exact sum_le_of_monotoneOn_Iic v_mono.monotoneOn (by grind)
 
-lemma eVariationOn_leftLim_le [TopologicalSpace α] [OrderTopology α] {f : α → E}
+lemma eVariationOn_leftLim_le [TopologicalSpace α] [OrderTopology α] {f : α → M}
     {s : Set α} (hs : IsOpen s) :
     eVariationOn f.leftLim s ≤ eVariationOn f s := by
   apply eVariationOn_le_of_mapClusterPt (fun x hx ↦ ?_)
   rw [IsOpen.nhdsWithin_eq hs hx]
   exact (mapClusterPt_leftLim f x).mono nhdsWithin_le_nhds
 
-lemma eVariationOn_rightLim_le [TopologicalSpace α] [OrderTopology α] {f : α → E}
+lemma eVariationOn_rightLim_le [TopologicalSpace α] [OrderTopology α] {f : α → M}
     {s : Set α} (hs : IsOpen s) :
     eVariationOn f.rightLim s ≤ eVariationOn f s := by
   apply eVariationOn_le_of_mapClusterPt (fun x hx ↦ ?_)
   rw [IsOpen.nhdsWithin_eq hs hx]
   exact (mapClusterPt_rightLim f x).mono nhdsWithin_le_nhds
 
-lemma _root_.BoundedVariationOn.leftLim [TopologicalSpace α] [OrderTopology α] {f : α → E}
+lemma _root_.BoundedVariationOn.leftLim [TopologicalSpace α] [OrderTopology α] {f : α → M}
     (hf : BoundedVariationOn f univ) : BoundedVariationOn f.leftLim univ :=
   ((eVariationOn_leftLim_le isOpen_univ).trans_lt hf.lt_top).ne
 
-lemma _root_.BoundedVariationOn.rightLim [TopologicalSpace α] [OrderTopology α] {f : α → E}
+lemma _root_.BoundedVariationOn.rightLim [TopologicalSpace α] [OrderTopology α] {f : α → M}
     (hf : BoundedVariationOn f univ) : BoundedVariationOn f.rightLim univ :=
   ((eVariationOn_rightLim_le isOpen_univ).trans_lt hf.lt_top).ne
 
 lemma _root_.BoundedVariationOn.continuousWithinAt_leftLim [TopologicalSpace α] [OrderTopology α]
-    [CompleteSpace E] [T3Space E] {f : α → E} (hf : BoundedVariationOn f univ) {x : α} :
+    [CompleteSpace M] [T3Space M] {f : α → M} (hf : BoundedVariationOn f univ) {x : α} :
     ContinuousWithinAt f.leftLim (Iic x) x := by
   have : Tendsto f.leftLim (𝓝[<] x) (𝓝 (f.leftLim.leftLim x)) := hf.leftLim.tendsto_leftLim x
   rw [leftLim_leftLim (hf.tendsto_leftLim x)] at this
   exact continuousWithinAt_Iio_iff_Iic.1 this
 
 lemma _root_.BoundedVariationOn.continuousWithinAt_rightLim [TopologicalSpace α] [OrderTopology α]
-    [CompleteSpace E] [T3Space E] {f : α → E} (hf : BoundedVariationOn f univ) {x : α} :
+    [CompleteSpace M] [T3Space M] {f : α → M} (hf : BoundedVariationOn f univ) {x : α} :
     ContinuousWithinAt f.rightLim (Ici x) x :=
   BoundedVariationOn.continuousWithinAt_leftLim hf.ofDual
 
@@ -1130,8 +1131,8 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Iic_zero
   exact hf.ofDual.tendsto_eVariationOn_Ici_zero
 
 /-- A bounded variation function has a limit at `+∞`. -/
-theorem _root_.BoundedVariationOn.exists_tendsto_atTop [CompleteSpace E] [hE : Nonempty E]
-    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
+theorem _root_.BoundedVariationOn.exists_tendsto_atTop [CompleteSpace M] [hM : Nonempty M]
+    {f : α → M} {s : Set α} (hf : BoundedVariationOn f s) :
     ∃ l, Tendsto f (𝓟 s ⊓ atTop) (𝓝 l) := by
   rcases eq_empty_or_nonempty s with rfl | hs
   · simp
@@ -1139,18 +1140,18 @@ theorem _root_.BoundedVariationOn.exists_tendsto_atTop [CompleteSpace E] [hE : N
       (fun y hy ↦ inter_mem_inf (mem_principal_self s) (Ici_mem_atTop _)) hs
 
 /-- A bounded variation function has a limit at `-∞`. -/
-theorem _root_.BoundedVariationOn.exists_tendsto_atBot [CompleteSpace E] [hE : Nonempty E]
-    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
+theorem _root_.BoundedVariationOn.exists_tendsto_atBot [CompleteSpace M] [hM : Nonempty M]
+    {f : α → M} {s : Set α} (hf : BoundedVariationOn f s) :
     ∃ l, Tendsto f (𝓟 s ⊓ atBot) (𝓝 l) :=
   hf.ofDual.exists_tendsto_atTop
 
-theorem _root_.BoundedVariationOn.tendsto_atTop_limUnder [CompleteSpace E] [hE : Nonempty E]
-    {f : α → E} (hf : BoundedVariationOn f univ) :
+theorem _root_.BoundedVariationOn.tendsto_atTop_limUnder [CompleteSpace M] [hM : Nonempty M]
+    {f : α → M} (hf : BoundedVariationOn f univ) :
     Tendsto f atTop (𝓝 (limUnder atTop f)) :=
   tendsto_nhds_limUnder (by simpa using hf.exists_tendsto_atTop)
 
-theorem _root_.BoundedVariationOn.tendsto_atBot_limUnder [CompleteSpace E] [hE : Nonempty E]
-    {f : α → E} (hf : BoundedVariationOn f univ) :
+theorem _root_.BoundedVariationOn.tendsto_atBot_limUnder [CompleteSpace M] [hM : Nonempty M]
+    {f : α → M} (hf : BoundedVariationOn f univ) :
     Tendsto f atBot (𝓝 (limUnder atBot f)) :=
   tendsto_nhds_limUnder (by simpa using hf.exists_tendsto_atBot)
 
@@ -1230,8 +1231,8 @@ section LipschitzOnWith
 
 variable {F : Type*} [PseudoEMetricSpace F]
 
-theorem LipschitzOnWith.comp_eVariationOn_le {f : E → F} {C : ℝ≥0} {t : Set E}
-    (h : LipschitzOnWith C f t) {g : α → E} {s : Set α} (hg : MapsTo g s t) :
+theorem LipschitzOnWith.comp_eVariationOn_le {f : M → F} {C : ℝ≥0} {t : Set M}
+    (h : LipschitzOnWith C f t) {g : α → M} {s : Set α} (hg : MapsTo g s t) :
     eVariationOn (f ∘ g) s ≤ C * eVariationOn g s := by
   apply iSup_le _
   rintro ⟨n, ⟨u, hu, us⟩⟩
@@ -1242,32 +1243,32 @@ theorem LipschitzOnWith.comp_eVariationOn_le {f : E → F} {C : ℝ≥0} {t : Se
     _ = C * ∑ i ∈ Finset.range n, edist (g (u (i + 1))) (g (u i)) := by rw [Finset.mul_sum]
     _ ≤ C * eVariationOn g s := by grw [eVariationOn.sum_le hu us]
 
-theorem LipschitzOnWith.comp_boundedVariationOn {f : E → F} {C : ℝ≥0} {t : Set E}
-    (hf : LipschitzOnWith C f t) {g : α → E} {s : Set α} (hg : MapsTo g s t)
+theorem LipschitzOnWith.comp_boundedVariationOn {f : M → F} {C : ℝ≥0} {t : Set M}
+    (hf : LipschitzOnWith C f t) {g : α → M} {s : Set α} (hg : MapsTo g s t)
     (h : BoundedVariationOn g s) : BoundedVariationOn (f ∘ g) s :=
   ne_top_of_le_ne_top (by finiteness) (hf.comp_eVariationOn_le hg)
 
-theorem LipschitzOnWith.comp_locallyBoundedVariationOn {f : E → F} {C : ℝ≥0} {t : Set E}
-    (hf : LipschitzOnWith C f t) {g : α → E} {s : Set α} (hg : MapsTo g s t)
+theorem LipschitzOnWith.comp_locallyBoundedVariationOn {f : M → F} {C : ℝ≥0} {t : Set M}
+    (hf : LipschitzOnWith C f t) {g : α → M} {s : Set α} (hg : MapsTo g s t)
     (h : LocallyBoundedVariationOn g s) : LocallyBoundedVariationOn (f ∘ g) s :=
   fun x y xs ys =>
   hf.comp_boundedVariationOn (hg.mono_left inter_subset_left) (h x y xs ys)
 
-theorem LipschitzWith.comp_boundedVariationOn {f : E → F} {C : ℝ≥0} (hf : LipschitzWith C f)
-    {g : α → E} {s : Set α} (h : BoundedVariationOn g s) : BoundedVariationOn (f ∘ g) s :=
+theorem LipschitzWith.comp_boundedVariationOn {f : M → F} {C : ℝ≥0} (hf : LipschitzWith C f)
+    {g : α → M} {s : Set α} (h : BoundedVariationOn g s) : BoundedVariationOn (f ∘ g) s :=
   hf.lipschitzOnWith.comp_boundedVariationOn (mapsTo_univ _ _) h
 
-theorem LipschitzWith.comp_locallyBoundedVariationOn {f : E → F} {C : ℝ≥0}
-    (hf : LipschitzWith C f) {g : α → E} {s : Set α} (h : LocallyBoundedVariationOn g s) :
+theorem LipschitzWith.comp_locallyBoundedVariationOn {f : M → F} {C : ℝ≥0}
+    (hf : LipschitzWith C f) {g : α → M} {s : Set α} (h : LocallyBoundedVariationOn g s) :
     LocallyBoundedVariationOn (f ∘ g) s :=
   hf.lipschitzOnWith.comp_locallyBoundedVariationOn (mapsTo_univ _ _) h
 
-theorem LipschitzOnWith.locallyBoundedVariationOn {f : ℝ → E} {C : ℝ≥0} {s : Set ℝ}
+theorem LipschitzOnWith.locallyBoundedVariationOn {f : ℝ → M} {C : ℝ≥0} {s : Set ℝ}
     (hf : LipschitzOnWith C f s) : LocallyBoundedVariationOn f s :=
   hf.comp_locallyBoundedVariationOn (mapsTo_id _)
     (@monotoneOn_id ℝ _ s).locallyBoundedVariationOn
 
-theorem LipschitzWith.locallyBoundedVariationOn {f : ℝ → E} {C : ℝ≥0} (hf : LipschitzWith C f)
+theorem LipschitzWith.locallyBoundedVariationOn {f : ℝ → M} {C : ℝ≥0} (hf : LipschitzWith C f)
     (s : Set ℝ) : LocallyBoundedVariationOn f s :=
   hf.lipschitzOnWith.locallyBoundedVariationOn
 

--- a/Mathlib/Topology/EMetricSpace/VariationOnFromTo.lean
+++ b/Mathlib/Topology/EMetricSpace/VariationOnFromTo.lean
@@ -22,7 +22,8 @@ functions.
 open scoped ENNReal Topology
 open Set Filter
 
-variable {α : Type*} [LinearOrder α] {E : Type*} [PseudoEMetricSpace E]
+variable {α : Type*} [LinearOrder α] {E M : Type*} [TopologicalSpace E] [WeakPseudoEMetricSpace E]
+  [PseudoEMetricSpace M]
 
 /-- The **signed** variation of `f` on the interval `Icc a b` intersected with the set `s`,
 squashed to a real (therefore only really meaningful if the variation is finite)
@@ -32,7 +33,7 @@ noncomputable def variationOnFromTo (f : α → E) (s : Set α) (a b : α) : ℝ
 
 namespace variationOnFromTo
 
-variable (f : α → E) (s : Set α)
+variable (f : α → E) (s : Set α) {g : α → M}
 
 protected theorem self (a : α) : variationOnFromTo f s a a = 0 := by
   dsimp only [variationOnFromTo]
@@ -259,28 +260,28 @@ theorem rightLim_eq {E : Type*} [PseudoMetricSpace E] [CompleteSpace E]
   exact this (hf.tendsto_rightLim _)
 
 theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_Ici
-    [TopologicalSpace α] [OrderTopology α] (hf : BoundedVariationOn f univ) {a x : α}
-    (hx : ContinuousWithinAt f (Ici x) x) :
-    ContinuousWithinAt (variationOnFromTo f univ a) (Ici x) x := by
-  have : variationOnFromTo f univ a =
-      fun y ↦ variationOnFromTo f univ a x + variationOnFromTo f univ x y := by
+    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g univ) {a x : α}
+    (hx : ContinuousWithinAt g (Ici x) x) :
+    ContinuousWithinAt (variationOnFromTo g univ a) (Ici x) x := by
+  have : variationOnFromTo g univ a =
+      fun y ↦ variationOnFromTo g univ a x + variationOnFromTo g univ x y := by
     ext y
-    rw [variationOnFromTo.add hf.locallyBoundedVariationOn (mem_univ _) (mem_univ _) (mem_univ _)]
+    rw [variationOnFromTo.add hg.locallyBoundedVariationOn (mem_univ _) (mem_univ _) (mem_univ _)]
   rw [this]
   apply continuousWithinAt_const.add
-  suffices H : ContinuousWithinAt (fun y ↦ (eVariationOn f (univ ∩ Icc x y)).toReal) (Ici x) x from
+  suffices H : ContinuousWithinAt (fun y ↦ (eVariationOn g (univ ∩ Icc x y)).toReal) (Ici x) x from
     H.congr_of_mem (fun y hy ↦ by grind [variationOnFromTo]) self_mem_Iic
   simp only [ContinuousWithinAt, Icc_self]
   rw [eVariationOn.subsingleton _ (by grind [Set.Subsingleton])]
   apply (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp
   apply Tendsto.mono_left _ (nhdsWithin_mono _ (subset_univ _))
-  exact hf.tendsto_eVariationOn_Icc_zero_right _ (by simpa using hx)
+  exact hg.tendsto_eVariationOn_Icc_zero_right _ (by simpa using hx)
 
 theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_rightLim_Ici
-    [TopologicalSpace α] [OrderTopology α] [T3Space E] [CompleteSpace E]
-    (hf : BoundedVariationOn f univ) {a x : α} :
-    ContinuousWithinAt (variationOnFromTo f.rightLim univ a) (Ici x) x :=
-  hf.rightLim.continuousWithinAt_variationOnFromTo_Ici hf.continuousWithinAt_rightLim
+    [TopologicalSpace α] [OrderTopology α] [T3Space M] [CompleteSpace M]
+    (hg : BoundedVariationOn g univ) {a x : α} :
+    ContinuousWithinAt (variationOnFromTo g.rightLim univ a) (Ici x) x :=
+  hg.rightLim.continuousWithinAt_variationOnFromTo_Ici hg.continuousWithinAt_rightLim
 
 end variationOnFromTo
 


### PR DESCRIPTION
Generalize the definition of `eVariationOn` for the underlying space `E` to be a `WeakPseudoEMetricSpace` (as well as theorems about/using the variation). In particular, now `E` can be `ENNReal` for example.

Some theorems can not be generalised from `PseudoEMetricSpace` to `WeakPseudoEMetricSpace` of course. Most of them seem to be related to convergence and continuity. This is not surprising, since for instance `EMetric.tendsto_nhds` does not hold for `WeakPseudoEMetricSpace` (again think of `ENNReal`).
Maybe with some effort more can be generalized, but I havent looked into that. I used the letter `M`(etric) instead of `E` for those who couldnt be generalized, as `F` was already used in the main file....

(The main changes live in Mathlib/Topology, but `eVariationOn` arguably belongs more to Analysis, which is why I added it in the PR title, maybe the file should even be moved)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
