### PR TITLE
[Merged by Bors] - feat: make `TFAE.out` 1-indexed

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRingsExact.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRingsExact.lean
@@ -39,12 +39,12 @@ lemma ModuleCat.restrictScalars_map_exact (S : ShortComplex (ModuleCat.{v} R')) 
   exact h
 
 instance : Limits.PreservesFiniteLimits (ModuleCat.restrictScalars.{v} f) := by
-  have := ((CategoryTheory.Functor.exact_tfae (ModuleCat.restrictScalars.{v} f)).out 1 3).mp
+  have := ((CategoryTheory.Functor.exact_tfae (ModuleCat.restrictScalars.{v} f)).out 2 4).mp
     (ModuleCat.restrictScalars_map_exact f)
   exact this.1
 
 instance : Limits.PreservesFiniteColimits (ModuleCat.restrictScalars.{v} f) := by
-  have := ((CategoryTheory.Functor.exact_tfae (ModuleCat.restrictScalars.{v} f)).out 1 3).mp
+  have := ((CategoryTheory.Functor.exact_tfae (ModuleCat.restrictScalars.{v} f)).out 2 4).mp
     (ModuleCat.restrictScalars_map_exact f)
   exact this.2
 

--- a/Mathlib/Algebra/Category/ModuleCat/Localization.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Localization.lean
@@ -93,12 +93,12 @@ lemma localizedModuleFunctor_map_exact [Small.{v} R] (S : Submonoid R)
 
 instance [Small.{v} R] (S : Submonoid R) :
     Limits.PreservesFiniteLimits (ModuleCat.localizedModuleFunctor.{v} S) := by
-  have := ((Functor.exact_tfae _).out 1 3).mp (ModuleCat.localizedModuleFunctor_map_exact S)
+  have := ((Functor.exact_tfae _).out 2 4).mp (ModuleCat.localizedModuleFunctor_map_exact S)
   exact this.1
 
 instance [Small.{v} R] (S : Submonoid R) :
     Limits.PreservesFiniteColimits (ModuleCat.localizedModuleFunctor.{v} S) := by
-  have := ((Functor.exact_tfae _).out 1 3).mp (ModuleCat.localizedModuleFunctor_map_exact S)
+  have := ((Functor.exact_tfae _).out 2 4).mp (ModuleCat.localizedModuleFunctor_map_exact S)
   exact this.2
 
 lemma isIso_of_isLocalizedModule_comp {S : Submonoid R} {M₁ M₂ M₃ : ModuleCat R} {f₁ : M₁ ⟶ M₂}

--- a/Mathlib/Algebra/Category/ModuleCat/Ulift.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Ulift.lean
@@ -85,7 +85,7 @@ lemma uliftFunctor_map_exact (S : ShortComplex (ModuleCat.{v} R)) (h : S.Exact) 
   cat_disch
 
 instance : Limits.PreservesFiniteColimits (uliftFunctor.{v', v} R) := by
-  have := ((CategoryTheory.Functor.exact_tfae (uliftFunctor.{v', v} R)).out 1 3).mp
+  have := ((CategoryTheory.Functor.exact_tfae (uliftFunctor.{v', v} R)).out 2 4).mp
     (uliftFunctor_map_exact R)
   exact this.2
 

--- a/Mathlib/Algebra/Homology/ShortComplex/ExactFunctor.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ExactFunctor.lean
@@ -151,7 +151,7 @@ lemma preservesFiniteLimits_tfae : List.TFAE
 lemma preservesFiniteLimits_iff_forall_exact_map_and_mono :
     PreservesFiniteLimits F ↔
       ∀ (S : ShortComplex C), S.ShortExact → (S.map F).Exact ∧ Mono (F.map S.f) :=
-  (Functor.preservesFiniteLimits_tfae F).out 3 0
+  (Functor.preservesFiniteLimits_tfae F).out 4 1
 
 /--
 If a functor `F : C ⥤ D` preserves exact sequences on the right-hand side (i.e.
@@ -227,10 +227,10 @@ lemma exact_tfae : List.TFAE
   tfae_have 1 → 3
   | hF => by
     refine ⟨fun {X Y} f ↦ ?_, fun {X Y} f ↦ ?_⟩
-    · have h := (preservesFiniteLimits_tfae F |>.out 0 2 |>.1 fun S hS ↦
+    · have h := (preservesFiniteLimits_tfae F |>.out 1 3 |>.1 fun S hS ↦
         And.intro (hF S hS).exact (hF S hS).mono_f)
       exact h f
-    · have h := (preservesFiniteColimits_tfae F |>.out 0 2 |>.1 fun S hS ↦
+    · have h := (preservesFiniteColimits_tfae F |>.out 1 3 |>.1 fun S hS ↦
         And.intro (hF S hS).exact (hF S hS).epi_g)
       exact h f
   tfae_have 2 → 1
@@ -250,7 +250,7 @@ lemma exact_tfae : List.TFAE
 lemma preservesFiniteColimits_iff_forall_exact_map_and_epi :
     PreservesFiniteColimits F ↔
       ∀ (S : ShortComplex C), S.ShortExact → (S.map F).Exact ∧ Epi (F.map S.g) :=
-  (Functor.preservesFiniteColimits_tfae F).out 3 0
+  (Functor.preservesFiniteColimits_tfae F).out 4 1
 
 end
 

--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -256,7 +256,7 @@ lemma Module.finitePresentation_of_split_exact
     Module.FinitePresentation R M := by
   have hg : Function.Surjective g := Function.LeftInverse.surjective (DFunLike.congr_fun hl)
   have := Module.Finite.of_surjective g hg
-  obtain ⟨e, rfl, rfl⟩ := ((Function.Exact.split_tfae' H).out 0 2 rfl rfl).mp
+  obtain ⟨e, rfl, rfl⟩ := ((Function.Exact.split_tfae' H).out 1 3 rfl rfl).mp
     ⟨hf, l, hl⟩
   refine Module.finitePresentation_of_surjective (LinearMap.fst _ _ _ ∘ₗ e.toLinearMap)
     (Prod.fst_surjective.comp e.surjective) ?_

--- a/Mathlib/Algebra/Order/ToIntervalMod.lean
+++ b/Mathlib/Algebra/Order/ToIntervalMod.lean
@@ -642,14 +642,14 @@ variable {a b}
 
 theorem modEq_iff_forall_notMem_Ioo_mod :
     a ≡ b [PMOD p] ↔ ∀ z : ℤ, b - z • p ∉ Set.Ioo a (a + p) :=
-  (tfae_modEq hp a b).out 0 1
+  (tfae_modEq hp a b).out 1 2
 
 theorem modEq_iff_toIcoMod_ne_toIocMod : a ≡ b [PMOD p] ↔ toIcoMod hp a b ≠ toIocMod hp a b :=
-  (tfae_modEq hp a b).out 0 2
+  (tfae_modEq hp a b).out 1 3
 
 theorem modEq_iff_toIcoMod_add_period_eq_toIocMod :
     a ≡ b [PMOD p] ↔ toIcoMod hp a b + p = toIocMod hp a b :=
-  (tfae_modEq hp a b).out 0 3
+  (tfae_modEq hp a b).out 1 4
 
 theorem not_modEq_iff_toIcoMod_eq_toIocMod : ¬a ≡ b [PMOD p] ↔ toIcoMod hp a b = toIocMod hp a b :=
   (modEq_iff_toIcoMod_ne_toIocMod _).not_left

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -200,7 +200,7 @@ lemma noZeroDivisors_tfae : List.TFAE
 
 /-- In a ring, `IsCancelMulZero` and `NoZeroDivisors` are equivalent. -/
 lemma isCancelMulZero_iff_noZeroDivisors : IsCancelMulZero R ↔ NoZeroDivisors R :=
-  noZeroDivisors_tfae.out 3 0
+  noZeroDivisors_tfae.out 4 1
 
 variable (R) in
 instance (priority := 100) NoZeroDivisors.to_isCancelMulZero

--- a/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
+++ b/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
@@ -163,10 +163,10 @@ theorem constFormalMultilinearSeries_radius {v : F} :
 for some `0 < a < 1`, `‖p n‖ rⁿ = o(aⁿ)`. -/
 theorem isLittleO_of_lt_radius (h : ↑r < p.radius) :
     ∃ a ∈ Ioo (0 : ℝ) 1, (fun n => ‖p n‖ * (r : ℝ) ^ n) =o[atTop] (a ^ ·) := by
-  have := (TFAE_exists_lt_isLittleO_pow (fun n => ‖p n‖ * (r : ℝ) ^ n) 1).out 1 4
+  have := (TFAE_exists_lt_isLittleO_pow (fun n => ‖p n‖ * (r : ℝ) ^ n) 1).out 2 5
   rw [this]
   -- Porting note: was
-  -- rw [(TFAE_exists_lt_isLittleO_pow (fun n => ‖p n‖ * (r : ℝ) ^ n) 1).out 1 4]
+  -- rw [(TFAE_exists_lt_isLittleO_pow (fun n => ‖p n‖ * (r : ℝ) ^ n) 1).out 2 5]
   simp only [radius, lt_iSup_iff] at h
   rcases h with ⟨t, C, hC, rt⟩
   rw [ENNReal.coe_lt_coe, ← NNReal.coe_lt_coe] at rt
@@ -188,7 +188,7 @@ theorem isLittleO_one_of_lt_radius (h : ↑r < p.radius) :
 for some `0 < a < 1` and `C > 0`, `‖p n‖ * r ^ n ≤ C * a ^ n`. -/
 theorem norm_mul_pow_le_mul_pow_of_lt_radius (h : ↑r < p.radius) :
     ∃ a ∈ Ioo (0 : ℝ) 1, ∃ C > 0, ∀ n, ‖p n‖ * (r : ℝ) ^ n ≤ C * a ^ n := by
-  have := ((TFAE_exists_lt_isLittleO_pow (fun n => ‖p n‖ * (r : ℝ) ^ n) 1).out 1 5).mp
+  have := ((TFAE_exists_lt_isLittleO_pow (fun n => ‖p n‖ * (r : ℝ) ^ n) 1).out 2 6).mp
     (p.isLittleO_of_lt_radius h)
   rcases this with ⟨a, ha, C, hC, H⟩
   exact ⟨a, ha, C, hC, fun n => (le_abs_self _).trans (H n)⟩
@@ -196,7 +196,7 @@ theorem norm_mul_pow_le_mul_pow_of_lt_radius (h : ↑r < p.radius) :
 /-- If `r ≠ 0` and `‖pₙ‖ rⁿ = O(aⁿ)` for some `-1 < a < 1`, then `r < p.radius`. -/
 theorem lt_radius_of_isBigO (h₀ : r ≠ 0) {a : ℝ} (ha : a ∈ Ioo (-1 : ℝ) 1)
     (hp : (fun n => ‖p n‖ * (r : ℝ) ^ n) =O[atTop] (a ^ ·)) : ↑r < p.radius := by
-  have := ((TFAE_exists_lt_isLittleO_pow (fun n => ‖p n‖ * (r : ℝ) ^ n) 1).out 2 5)
+  have := ((TFAE_exists_lt_isLittleO_pow (fun n => ‖p n‖ * (r : ℝ) ^ n) 1).out 3 6)
   rcases this.mp ⟨a, ha, hp⟩ with ⟨a, ha, C, hC, hp⟩
   rw [← pos_iff_ne_zero, ← NNReal.coe_pos] at h₀
   lift a to ℝ≥0 using ha.1.le

--- a/Mathlib/Analysis/Analytic/RadiusLiminf.lean
+++ b/Mathlib/Analysis/Analytic/RadiusLiminf.lean
@@ -47,7 +47,7 @@ theorem radius_eq_liminf :
         NNReal.one_rpow n⁻¹, NNReal.rpow_le_rpow_iff (inv_pos.2 this), mul_comm,
         NNReal.rpow_natCast]
   apply le_antisymm <;> refine ENNReal.le_of_forall_nnreal_lt fun r hr => ?_
-  · have := ((TFAE_exists_lt_isLittleO_pow (fun n => ‖p n‖ * r ^ n) 1).out 1 7).1
+  · have := ((TFAE_exists_lt_isLittleO_pow (fun n => ‖p n‖ * r ^ n) 1).out 2 8).1
       (p.isLittleO_of_lt_radius hr)
     obtain ⟨a, ha, H⟩ := this
     apply le_liminf_of_le

--- a/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
@@ -158,7 +158,7 @@ variable {I J}
 theorem coe_subset_coe : (I : Set (ι → ℝ)) ⊆ J ↔ I ≤ J := Iff.rfl
 
 theorem le_iff_bounds : I ≤ J ↔ J.lower ≤ I.lower ∧ I.upper ≤ J.upper :=
-  (le_TFAE I J).out 0 3
+  (le_TFAE I J).out 1 4
 
 theorem injective_coe : Injective ((↑) : Box ι → Set (ι → ℝ)) := by
   rintro ⟨l₁, u₁, h₁⟩ ⟨l₂, u₂, h₂⟩ h
@@ -182,7 +182,7 @@ instance : PartialOrder (Box ι) :=
 
 /-- Closed box corresponding to `I : BoxIntegral.Box ι`. -/
 protected def Icc : Box ι ↪o Set (ι → ℝ) :=
-  OrderEmbedding.ofMapLEIff (fun I : Box ι ↦ Icc I.lower I.upper) fun I J ↦ (le_TFAE I J).out 2 0
+  OrderEmbedding.ofMapLEIff (fun I : Box ι ↦ Icc I.lower I.upper) fun I J ↦ (le_TFAE I J).out 3 1
 
 theorem Icc_def : Box.Icc I = Icc I.lower I.upper := rfl
 
@@ -201,7 +201,7 @@ theorem Icc_eq_pi : Box.Icc I = pi univ fun i ↦ Icc (I.lower i) (I.upper i) :=
   (pi_univ_Icc _ _).symm
 
 theorem le_iff_Icc : I ≤ J ↔ Box.Icc I ⊆ Box.Icc J :=
-  (le_TFAE I J).out 0 2
+  (le_TFAE I J).out 1 3
 
 theorem antitone_lower : Antitone fun I : Box ι ↦ I.lower :=
   fun _ _ H ↦ (le_iff_bounds.1 H).1

--- a/Mathlib/Analysis/CStarAlgebra/Projection.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Projection.lean
@@ -107,19 +107,19 @@ lemma le_tfae (hp : IsStarProjection p) (hq : IsStarProjection q) :
 
 lemma le_iff_mul_eq_right (hp : IsStarProjection p) (hq : IsStarProjection q) :
     p ≤ q ↔ q * p = p :=
-  hp.le_tfae hq |>.out 0 1
+  hp.le_tfae hq |>.out 1 2
 
 lemma le_iff_mul_eq_left (hp : IsStarProjection p) (hq : IsStarProjection q) :
     p ≤ q ↔ p * q = p :=
-  hp.le_tfae hq |>.out 0 2
+  hp.le_tfae hq |>.out 1 3
 
 lemma le_iff_sub (hp : IsStarProjection p) (hq : IsStarProjection q) :
     p ≤ q ↔ IsStarProjection (q - p) :=
-  hp.le_tfae hq |>.out 0 3
+  hp.le_tfae hq |>.out 1 4
 
 lemma le_iff_idempotent_sub (hp : IsStarProjection p) (hq : IsStarProjection q) :
     p ≤ q ↔ IsIdempotentElem (q - p) :=
-  hp.le_tfae hq |>.out 0 4
+  hp.le_tfae hq |>.out 1 5
 
 lemma commute_of_le (hp : IsStarProjection p) (hq : IsStarProjection q) (h : p ≤ q) :
     Commute p q := by

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Measure.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Measure.lean
@@ -89,7 +89,7 @@ lemma volume_eq_lintegral (s : Set ℍ) :
 instance : SMulInvariantMeasure (GL (Fin 2) ℝ) ℍ volume := by
   -- It suffices to show `volume (g • s) = volume s` for measurable sets `s`. First
   -- we write this as a lintegral over subsets of `ℂ`.
-  refine ((smulInvariantMeasure_tfae _ _).out 2 0).mp fun g s hs ↦ ?_
+  refine ((smulInvariantMeasure_tfae _ _).out 3 1).mp fun g s hs ↦ ?_
   rw [volume_eq_lintegral, volume_eq_lintegral, ← Set.image_smul, Set.image_image]
   -- We want to apply the Jacobian change-of-variable formula.
   have hinj : Set.InjOn (fun z ↦ ↑(g • ofComplex z) : ℂ → ℂ) (UpperHalfPlane.coe '' s) :=

--- a/Mathlib/Analysis/Convex/Continuous.lean
+++ b/Mathlib/Analysis/Convex/Continuous.lean
@@ -174,7 +174,7 @@ lemma ConvexOn.locallyLipschitzOn_iff_continuousOn (hC : IsOpen C) (hf : ConvexO
     LocallyLipschitzOn C f ↔ ContinuousOn f C := by
   obtain rfl | hC' := C.eq_empty_or_nonempty
   · simp
-  · exact (hf.continuousOn_tfae hC hC').out 0 1
+  · exact (hf.continuousOn_tfae hC hC').out 1 2
 
 lemma ConcaveOn.locallyLipschitzOn_iff_continuousOn (hC : IsOpen C) (hf : ConcaveOn ℝ C f) :
     LocallyLipschitzOn C f ↔ ContinuousOn f C := by
@@ -187,7 +187,7 @@ protected lemma ConvexOn.locallyLipschitzOn (hC : IsOpen C) (hf : ConvexOn ℝ C
   obtain rfl | ⟨x₀, hx₀⟩ := C.eq_empty_or_nonempty
   · simp
   · obtain ⟨b, hx₀b, hbC⟩ := exists_mem_interior_convexHull_affineBasis (hC.mem_nhds hx₀)
-    refine ((hf.continuousOn_tfae hC ⟨x₀, hx₀⟩).out 3 0).mp ?_
+    refine ((hf.continuousOn_tfae hC ⟨x₀, hx₀⟩).out 4 1).mp ?_
     refine ⟨x₀, hx₀, BddAbove.isBoundedUnder (IsOpen.mem_nhds isOpen_interior hx₀b) ?_⟩
     exact (hf.bddAbove_convexHull ((subset_convexHull ..).trans hbC)
       ((finite_range _).image _).bddAbove).mono (by gcongr; exact interior_subset)

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -204,7 +204,7 @@ theorem real_inner_self_nonneg {x : F} : 0 ≤ ⟪x, x⟫_ℝ :=
   @inner_self_nonneg ℝ F _ _ _ x
 
 theorem inner_self_ofReal_re (x : E) : (re ⟪x, x⟫ : 𝕜) = ⟪x, x⟫ :=
-  ((RCLike.is_real_TFAE (⟪x, x⟫ : 𝕜)).out 2 3).2 (inner_self_im (𝕜 := 𝕜) x)
+  ((RCLike.is_real_TFAE (⟪x, x⟫ : 𝕜)).out 3 4).2 (inner_self_im (𝕜 := 𝕜) x)
 
 @[simp]
 theorem inner_self_eq_norm_sq_to_K (x : E) : ⟪x, x⟫ = (‖x‖ : 𝕜) ^ 2 := by
@@ -729,7 +729,7 @@ theorem norm_inner_eq_norm_iff {x y : E} (hx₀ : x ≠ 0) (hy₀ : y ≠ 0) :
     ‖⟪x, y⟫‖ = ‖x‖ * ‖y‖ ↔ ∃ r : 𝕜, r ≠ 0 ∧ y = r • x :=
   calc
     ‖⟪x, y⟫‖ = ‖x‖ * ‖y‖ ↔ x = 0 ∨ ∃ r : 𝕜, y = r • x :=
-      (norm_inner_eq_norm_tfae 𝕜 x y).out 0 2
+      (norm_inner_eq_norm_tfae 𝕜 x y).out 1 3
     _ ↔ ∃ r : 𝕜, y = r • x := or_iff_right hx₀
     _ ↔ ∃ r : 𝕜, r ≠ 0 ∧ y = r • x :=
       ⟨fun ⟨r, h⟩ => ⟨r, fun hr₀ => hy₀ <| h.symm ▸ smul_eq_zero.2 <| Or.inl hr₀, h⟩,
@@ -763,7 +763,7 @@ theorem inner_eq_norm_mul_iff_div {x y : E} (h₀ : x ≠ 0) :
   rw [← norm_ne_zero_iff, Ne, ← @ofReal_eq_zero 𝕜] at h₀'
   constructor <;> intro h
   · have : x = 0 ∨ y = (⟪x, y⟫ / ⟪x, x⟫ : 𝕜) • x :=
-      ((norm_inner_eq_norm_tfae 𝕜 x y).out 0 1).1 (by simp [h])
+      ((norm_inner_eq_norm_tfae 𝕜 x y).out 1 2).1 (by simp [h])
     rw [this.resolve_left h₀, h]
     simp [norm_smul, mul_div_cancel_right₀ _ h₀']
   · conv_lhs => rw [← h, inner_smul_right, inner_self_eq_norm_sq_to_K]

--- a/Mathlib/Analysis/InnerProductSpace/NormDet.lean
+++ b/Mathlib/Analysis/InnerProductSpace/NormDet.lean
@@ -157,7 +157,7 @@ theorem normDet_ne_zero_tfae (f : U →ₗ[𝕜] V) :
 private noncomputable def orthonormalBasis_range {ι : Type*} [Fintype ι] {f : U →ₗ[𝕜] V}
     (hf : f.ker = ⊥) (b : OrthonormalBasis ι 𝕜 U) : OrthonormalBasis ι 𝕜 f.range :=
   let h : Nonempty (OrthonormalBasis (Fin (finrank 𝕜 U)) 𝕜 f.range) :=
-    (f.normDet_ne_zero_tfae.out 1 3).mp hf
+    (f.normDet_ne_zero_tfae.out 2 4).mp hf
   h.some.reindex (Fintype.equivFinOfCardEq <| (Module.finrank_eq_card_basis b.toBasis).symm).symm
 
 theorem normDet_eq_zero_tfae (f : U →ₗ[𝕜] V) :
@@ -171,7 +171,7 @@ theorem normDet_eq_zero_tfae (f : U →ₗ[𝕜] V) :
   tfae_have 1 ↔ 3 := f.normDet_eq_zero_iff_rank_range_ne
   tfae_have 3 ↔ 4 := by simpa using finrank_range_le f
   tfae_have 3 ↔ 5 := by
-    have h := (f.normDet_ne_zero_tfae.out 2 3).not
+    have h := (f.normDet_ne_zero_tfae.out 3 4).not
     simpa using h
   tfae_have 2 ↔ 6 := ker_eq_bot.not
   tfae_finish
@@ -212,7 +212,7 @@ theorem normDet_eq_norm_det (f : U →ₗ[𝕜] U) : f.normDet = ‖f.det‖ := 
 -/
 @[simp]
 theorem _root_.LinearIsometry.normDet_eq_one (f : U →ₗᵢ[𝕜] V) : f.toLinearMap.normDet = 1 := by
-  obtain ⟨b⟩ := (f.normDet_ne_zero_tfae.out 4 3).mp f.injective
+  obtain ⟨b⟩ := (f.normDet_ne_zero_tfae.out 5 4).mp f.injective
   rw [normDet_eq_norm_det_toMatrix_rangeRestrict _ (stdOrthonormalBasis 𝕜 U) b]
   apply CStarRing.norm_of_mem_unitary
   exact Matrix.det_of_mem_unitary <| (f.equivRange).toMatrix_mem_unitaryGroup _ _
@@ -245,7 +245,7 @@ theorem normDet_smul (f : U →ₗ[𝕜] V) (c : 𝕜) :
   · nontriviality U
     simp [hc, zero_pow finrank_pos.ne.symm]
   by_cases h : f.ker = ⊥
-  · obtain ⟨bv⟩ := (f.normDet_ne_zero_tfae.out 1 3).mp h
+  · obtain ⟨bv⟩ := (f.normDet_ne_zero_tfae.out 2 4).mp h
     let bu : OrthonormalBasis (Fin (finrank 𝕜 U)) 𝕜 U := stdOrthonormalBasis 𝕜 U
     let bv' : OrthonormalBasis (Fin (finrank 𝕜 U)) 𝕜 (c • f).range := bv.map
       (LinearIsometryEquiv.ofEq _ _ (LinearMap.range_smul _ _ hc).symm)
@@ -272,7 +272,7 @@ theorem _root_.ContinuousLinearMap.normDet_sq [CompleteSpace V] (f : U →L[𝕜
   have : CompleteSpace f.range := FiniteDimensional.complete 𝕜 f.range
   let bu := stdOrthonormalBasis 𝕜 U
   by_cases h : f.ker = ⊥
-  · obtain ⟨b⟩ := (f.normDet_ne_zero_tfae.out 1 3).mp h
+  · obtain ⟨b⟩ := (f.normDet_ne_zero_tfae.out 2 4).mp h
     have hf : f = f.range.subtypeₗᵢ.toContinuousLinearMap ∘L f.rangeRestrict := rfl
     conv_rhs => rw [hf]
     rw [ContinuousLinearMap.adjoint_comp, ← ContinuousLinearMap.comp_assoc,
@@ -283,7 +283,7 @@ theorem _root_.ContinuousLinearMap.normDet_sq [CompleteSpace V] (f : U →L[𝕜
       toMatrix_adjoint, f.toLinearMap.normDet_eq_norm_det_toMatrix_rangeRestrict bu b]
     simp [RCLike.conj_mul]
   · trans 0
-    · simp [show f.normDet = 0 from (f.normDet_eq_zero_tfae.out 1 0).mp h]
+    · simp [show f.normDet = 0 from (f.normDet_eq_zero_tfae.out 2 1).mp h]
     symm
     rw [det_eq_zero_iff_ker_ne_bot, ContinuousLinearMap.ker_adjoint_comp_self]
     exact h
@@ -315,8 +315,8 @@ theorem normDet_sq_eq_det_gram {ι : Type*} [Fintype ι] [DecidableEq ι] (f : U
     ext i j
     simp [LinearMap.toMatrix_apply]
   · trans 0
-    · simp [show f.normDet = 0 from (f.normDet_eq_zero_tfae.out 1 0).mp h]
-    have hrank := (f.normDet_eq_zero_tfae.out 1 3).mp h
+    · simp [show f.normDet = 0 from (f.normDet_eq_zero_tfae.out 2 1).mp h]
+    have hrank := (f.normDet_eq_zero_tfae.out 2 4).mp h
     symm
     contrapose! hrank with h0
     rw [finrank_eq_card_basis b.toBasis]
@@ -326,9 +326,9 @@ theorem normDet_comp (f : U →ₗ[𝕜] V) (g : V →ₗ[𝕜] W) :
     (g ∘ₗ f).normDet = (g.domRestrict f.range).normDet * f.normDet := by
   by_cases hf : f.ker = ⊥
   · let bu : OrthonormalBasis (Fin (finrank 𝕜 U)) 𝕜 U := stdOrthonormalBasis 𝕜 U
-    obtain ⟨bv⟩ := (f.normDet_ne_zero_tfae.out 1 3).mp hf
+    obtain ⟨bv⟩ := (f.normDet_ne_zero_tfae.out 2 4).mp hf
     by_cases hgf : (g ∘ₗ f).ker = ⊥
-    · obtain ⟨bw⟩ := ((g ∘ₗ f).normDet_ne_zero_tfae.out 1 3).mp hgf
+    · obtain ⟨bw⟩ := ((g ∘ₗ f).normDet_ne_zero_tfae.out 2 4).mp hgf
       let bw' : OrthonormalBasis (Fin (finrank 𝕜 U)) 𝕜 (g.domRestrict f.range).range :=
         bw.map (LinearIsometryEquiv.ofEq _ _ (by simp [LinearMap.range_comp]))
       rw [(g ∘ₗ f).normDet_eq_norm_det_toMatrix_rangeRestrict bu bw,
@@ -398,8 +398,8 @@ theorem hausdorffMeasure_image [MeasurableSpace U] [BorelSpace U] [MeasurableSpa
     (f : U →ₗ[ℝ] V) (s : Set U) :
     μH[finrank ℝ U] (f '' s) = ENNReal.ofReal f.normDet * μH[finrank ℝ U] s := by
   by_cases h : f.ker = ⊥
-  · have hrank : finrank ℝ ↥f.range = finrank ℝ U := (f.normDet_ne_zero_tfae.out 1 2).mp h
-    obtain ⟨bv⟩ := (f.normDet_ne_zero_tfae.out 1 3).mp h
+  · have hrank : finrank ℝ ↥f.range = finrank ℝ U := (f.normDet_ne_zero_tfae.out 2 3).mp h
+    obtain ⟨bv⟩ := (f.normDet_ne_zero_tfae.out 2 4).mp h
     let g : U ≃ₗᵢ[ℝ] f.range := (stdOrthonormalBasis ℝ U).equiv bv (Equiv.refl _)
     suffices μH[finrank ℝ U] ((f.range.subtypeₗᵢ.comp g.toLinearIsometry) ''
         ((g.symm.toLinearIsometry.toLinearMap ∘ₗ f.rangeRestrict) '' s)) =
@@ -410,10 +410,10 @@ theorem hausdorffMeasure_image [MeasurableSpace U] [BorelSpace U] [MeasurableSpa
       normDet_comp_of_finrank_eq _ _ hrank.symm, g.symm.toLinearIsometry.normDet_eq_one]
     simp
   · suffices μH[finrank ℝ U] (f.range.subtypeₗᵢ '' (f.rangeRestrict '' s)) = 0 by
-      simpa [(f.normDet_eq_zero_tfae.out 1 0).mp h, Set.image_image]
+      simpa [(f.normDet_eq_zero_tfae.out 2 1).mp h, Set.image_image]
     rw [(LinearIsometry.isometry _).hausdorffMeasure_image (by simp)]
     have h : (finrank ℝ f.range : ℝ) < finrank ℝ U := by
-      exact_mod_cast (f.normDet_eq_zero_tfae.out 1 3).mp h
+      exact_mod_cast (f.normDet_eq_zero_tfae.out 2 4).mp h
     simp [Real.hausdorffMeasure_of_finrank_lt h]
 
 /--

--- a/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
@@ -219,9 +219,9 @@ theorem posSemidef_tfae : List.TFAE [K.PosSemidef, K.IsHermitian ∧ ∀ (f : X 
     ] := by
   have {h p1 p2 p3 : Prop} (htfae : h → List.TFAE [p1, p2, p3]) :
       List.TFAE [h ∧ p1, h ∧ p2, h ∧ p3] := by
-    tfae_have 1 → 2 := fun ⟨h, t⟩ ↦ ⟨h, ((htfae h).out 0 1).mp t⟩
-    tfae_have 2 → 3 := fun ⟨h, t⟩ ↦ ⟨h, ((htfae h).out 1 2).mp t⟩
-    tfae_have 3 → 1 := fun ⟨h, t⟩ ↦ ⟨h, ((htfae h).out 2 0).mp t⟩
+    tfae_have 1 → 2 := fun ⟨h, t⟩ ↦ ⟨h, ((htfae h).out 1 2).mp t⟩
+    tfae_have 2 → 3 := fun ⟨h, t⟩ ↦ ⟨h, ((htfae h).out 2 3).mp t⟩
+    tfae_have 3 → 1 := fun ⟨h, t⟩ ↦ ⟨h, ((htfae h).out 3 1).mp t⟩
     tfae_finish
   refine this fun hHerm ↦ ?_
   simp only [nonneg_iff_isPositive, isPositive_def', isSelfAdjoint_finsuppSum hHerm,
@@ -266,7 +266,7 @@ instance instPreInnerProductSpaceCoreH₀ : PreInnerProductSpace.Core 𝕜 (H₀
   smul_left _ _ _ := by
     rw [Finsupp.sum_smul_index] <;> simp [Finsupp.mul_sum, ← mul_assoc]
   re_inner_nonneg := by
-    have := (posSemidef_tfae.out 0 1).mp (Fact.out : K.PosSemidef)
+    have := (posSemidef_tfae.out 1 2).mp (Fact.out : K.PosSemidef)
     exact this.2
 
 instance instSeminormedAddCommGroupH₀ : SeminormedAddCommGroup (H₀ K) :=

--- a/Mathlib/Analysis/InnerProductSpace/SingularValues.lean
+++ b/Mathlib/Analysis/InnerProductSpace/SingularValues.lean
@@ -154,7 +154,7 @@ this.
 -/
 theorem injective_iff_forall_lt_finrank_singularValues_pos :
     Function.Injective T ↔ ∀ i < finrank 𝕜 E, 0 < T.singularValues i := by
-  have := (adjoint T ∘ₗ T).not_hasEigenvalue_zero_tfae.out 4 0
+  have := (adjoint T ∘ₗ T).not_hasEigenvalue_zero_tfae.out 5 1
   rw [← adjoint_comp_self_injective_iff, ← coe_comp, ← ker_eq_bot, ← not_iff_not, this.not_left]
   push Not
   constructor

--- a/Mathlib/Analysis/LocallyConvex/WithSeminorms.lean
+++ b/Mathlib/Analysis/LocallyConvex/WithSeminorms.lean
@@ -366,7 +366,7 @@ theorem WithSeminorms.T1_of_separating (hp : WithSeminorms p)
 /-- A family of seminorms inducing a T₁ topology is separating. -/
 theorem WithSeminorms.separating_of_T1 [T1Space E] (hp : WithSeminorms p) (x : E) (hx : x ≠ 0) :
     ∃ i, p i x ≠ 0 := by
-  have := ((t1Space_TFAE E).out 0 9).mp (inferInstance : T1Space E)
+  have := ((t1Space_TFAE E).out 1 10).mp (inferInstance : T1Space E)
   by_contra! h
   refine hx (this ?_)
   rw [hp.hasBasis_zero_ball.specializes_iff]
@@ -772,7 +772,7 @@ theorem uniformEquicontinuous_iff_exists_continuous_seminorm {κ : Type*}
     (f : κ → E →ₛₗ[σ₁₂] F) :
     UniformEquicontinuous ((↑) ∘ f) ↔
     ∀ i, ∃ p : Seminorm 𝕜 E, Continuous p ∧ ∀ k, (q i).comp (f k) ≤ p :=
-  (hq.equicontinuous_TFAE f).out 2 3
+  (hq.equicontinuous_TFAE f).out 3 4
 
 theorem uniformEquicontinuous_iff_bddAbove_and_continuous_iSup {κ : Type*}
     {q : SeminormFamily 𝕜₂ F ι'} [UniformSpace E] [IsUniformAddGroup E] [u : UniformSpace F]
@@ -781,7 +781,7 @@ theorem uniformEquicontinuous_iff_bddAbove_and_continuous_iSup {κ : Type*}
     UniformEquicontinuous ((↑) ∘ f) ↔ ∀ i,
     BddAbove (range fun k ↦ (q i).comp (f k)) ∧
       Continuous (⨆ k, (q i).comp (f k)) :=
-  (hq.equicontinuous_TFAE f).out 2 4
+  (hq.equicontinuous_TFAE f).out 3 5
 
 end WithSeminorms
 

--- a/Mathlib/Analysis/Normed/Operator/BanachSteinhaus.lean
+++ b/Mathlib/Analysis/Normed/Operator/BanachSteinhaus.lean
@@ -35,7 +35,7 @@ bounded, then the norms of these linear maps are uniformly bounded.
 See also `WithSeminorms.banach_steinhaus` for the general statement in barrelled spaces. -/
 theorem banach_steinhaus {ι : Type*} [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
     (h : ∀ x, ∃ C, ∀ i, ‖g i x‖ ≤ C) : ∃ C', ∀ i, ‖g i‖ ≤ C' := by
-  rw [show (∃ C, ∀ i, ‖g i‖ ≤ C) ↔ _ from (NormedSpace.equicontinuous_TFAE g).out 5 2]
+  rw [show (∃ C, ∀ i, ‖g i‖ ≤ C) ↔ _ from (NormedSpace.equicontinuous_TFAE g).out 6 3]
   refine (norm_withSeminorms 𝕜₂ F).banach_steinhaus (fun _ x ↦ ?_)
   simpa [bddAbove_def, forall_mem_range] using h x
 
@@ -45,6 +45,6 @@ open ENNReal
 for convenience. -/
 theorem banach_steinhaus_iSup_nnnorm {ι : Type*} [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
     (h : ∀ x, (⨆ i, ↑‖g i x‖₊) < ∞) : (⨆ i, ↑‖g i‖₊) < ∞ := by
-  rw [show ((⨆ i, ↑‖g i‖₊) < ∞) ↔ _ from (NormedSpace.equicontinuous_TFAE g).out 8 2]
+  rw [show ((⨆ i, ↑‖g i‖₊) < ∞) ↔ _ from (NormedSpace.equicontinuous_TFAE g).out 9 3]
   refine (norm_withSeminorms 𝕜₂ F).banach_steinhaus (fun _ x ↦ ?_)
   simpa [← NNReal.bddAbove_coe, ← Set.range_comp] using! ENNReal.iSup_coe_lt_top.1 (h x)

--- a/Mathlib/Analysis/Normed/Operator/Fredholm/Basic.lean
+++ b/Mathlib/Analysis/Normed/Operator/Fredholm/Basic.lean
@@ -354,11 +354,11 @@ theorem isFredholm_tfae (u : E →L[𝕜] F) :
 /-- If `u` has a Fredholm package, it is Fredholm. -/
 theorem FredholmPackage.isFredholm {u : E →L[𝕜] F} (pkg : FredholmPackage u) :
     IsFredholm u :=
-  isFredholm_tfae u |>.out 3 0 |>.mp (Nonempty.intro pkg)
+  isFredholm_tfae u |>.out 4 1 |>.mp (Nonempty.intro pkg)
 
 theorem isFredholm_iff_exists_isQuasiInverse {u : E →L[𝕜] F} :
     IsFredholm u ↔ ∃ v : F →L[𝕜] E, v.IsQuasiInverse u :=
-  isFredholm_tfae u |>.out 0 1
+  isFredholm_tfae u |>.out 1 2
 
 alias ⟨IsFredholm.exists_isQuasiInverse, _⟩ := isFredholm_iff_exists_isQuasiInverse
 

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -369,21 +369,21 @@ theorem is_real_TFAE (z : K) :
 set_option linter.style.whitespace false in -- manual alignment is not recognised
 theorem conj_eq_iff_real {z : K} : conj z = z ↔ ∃ r : ℝ, z = (r : K) :=
   calc
-    _ ↔ ∃ r : ℝ, (r : K) = z := (is_real_TFAE z).out 0 1
+    _ ↔ ∃ r : ℝ, (r : K) = z := (is_real_TFAE z).out 1 2
     _ ↔ _                    := by simp only [eq_comm]
 
 theorem conj_eq_iff_re {z : K} : conj z = z ↔ (re z : K) = z :=
-  (is_real_TFAE z).out 0 2
+  (is_real_TFAE z).out 1 3
 
 theorem conj_eq_iff_im {z : K} : conj z = z ↔ im z = 0 :=
-  (is_real_TFAE z).out 0 3
+  (is_real_TFAE z).out 1 4
 
 @[simp]
 theorem star_def : (Star.star : K → K) = conj :=
   rfl
 
 lemma im_eq_zero_iff_isSelfAdjoint {x : K} : im x = 0 ↔ IsSelfAdjoint x :=
-  is_real_TFAE x |>.out 3 4
+  is_real_TFAE x |>.out 4 5
 
 lemma re_eq_ofReal_of_isSelfAdjoint {x : K} {y : ℝ} (hx : IsSelfAdjoint x) :
     re x = y ↔ x = y := by
@@ -970,7 +970,7 @@ lemma toPosMulReflectLT : PosMulReflectLT K where
     rintro ⟨x, hx⟩ y z hyz
     dsimp at *
     rw [RCLike.le_iff_re_im, map_zero, map_zero, eq_comm] at hx
-    obtain ⟨r, rfl⟩ := ((is_real_TFAE x).out 3 1).1 hx.2
+    obtain ⟨r, rfl⟩ := ((is_real_TFAE x).out 4 2).1 hx.2
     simp only [RCLike.lt_iff_re_im (K := K), mul_re, ofReal_re, ofReal_im, zero_mul, sub_zero,
       mul_im, add_zero, mul_eq_mul_left_iff] at hyz ⊢
     refine ⟨lt_of_mul_lt_mul_of_nonneg_left hyz.1 <| by simpa using hx, hyz.2.resolve_right ?_⟩

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Basic.lean
@@ -373,17 +373,17 @@ theorem _root_.CStarAlgebra.nonneg_TFAE {a : A} :
   tfae_finish
 
 theorem _root_.CStarAlgebra.nonneg_iff_eq_sqrt_mul_sqrt {a : A} :
-    0 ≤ a ↔ a = sqrt a * sqrt a := CStarAlgebra.nonneg_TFAE.out 0 1
+    0 ≤ a ↔ a = sqrt a * sqrt a := CStarAlgebra.nonneg_TFAE.out 1 2
 theorem _root_.CStarAlgebra.nonneg_iff_exists_nonneg_and_eq_mul_self {a : A} :
-    0 ≤ a ↔ ∃ b, 0 ≤ b ∧ a = b * b := CStarAlgebra.nonneg_TFAE.out 0 2
+    0 ≤ a ↔ ∃ b, 0 ≤ b ∧ a = b * b := CStarAlgebra.nonneg_TFAE.out 1 3
 theorem _root_.CStarAlgebra.nonneg_iff_exists_isSelfAdjoint_and_eq_mul_self {a : A} :
-    0 ≤ a ↔ ∃ b, IsSelfAdjoint b ∧ a = b * b := CStarAlgebra.nonneg_TFAE.out 0 3
+    0 ≤ a ↔ ∃ b, IsSelfAdjoint b ∧ a = b * b := CStarAlgebra.nonneg_TFAE.out 1 4
 theorem _root_.CStarAlgebra.nonneg_iff_eq_star_mul_self {a : A} :
-    0 ≤ a ↔ ∃ b, a = star b * b := CStarAlgebra.nonneg_TFAE.out 0 4
+    0 ≤ a ↔ ∃ b, a = star b * b := CStarAlgebra.nonneg_TFAE.out 1 5
 theorem _root_.CStarAlgebra.nonneg_iff_eq_mul_star_self {a : A} :
-    0 ≤ a ↔ ∃ b, a = b * star b := CStarAlgebra.nonneg_TFAE.out 0 5
+    0 ≤ a ↔ ∃ b, a = b * star b := CStarAlgebra.nonneg_TFAE.out 1 6
 theorem _root_.CStarAlgebra.nonneg_iff_isSelfAdjoint_and_negPart_eq_zero {a : A} :
-    0 ≤ a ↔ IsSelfAdjoint a ∧ a⁻ = 0 := CStarAlgebra.nonneg_TFAE.out 0 7
+    0 ≤ a ↔ IsSelfAdjoint a ∧ a⁻ = 0 := CStarAlgebra.nonneg_TFAE.out 1 8
 
 end sqrt
 
@@ -838,25 +838,25 @@ theorem _root_.CStarAlgebra.isStrictlyPositive_TFAE {a : A} :
 
 theorem _root_.CStarAlgebra.isStrictlyPositive_iff_isStrictlyPositive_sqrt_and_eq_sqrt_mul_sqrt
     {a : A} : IsStrictlyPositive a ↔ IsStrictlyPositive (sqrt a) ∧ a = sqrt a * sqrt a :=
-  CStarAlgebra.isStrictlyPositive_TFAE.out 0 1
+  CStarAlgebra.isStrictlyPositive_TFAE.out 1 2
 theorem _root_.CStarAlgebra.isStrictlyPositive_iff_isUnit_sqrt_and_eq_sqrt_mul_sqrt
     {a : A} : IsStrictlyPositive a ↔ IsUnit (sqrt a) ∧ a = sqrt a * sqrt a :=
-  CStarAlgebra.isStrictlyPositive_TFAE.out 0 2
+  CStarAlgebra.isStrictlyPositive_TFAE.out 1 3
 theorem _root_.CStarAlgebra.isStrictlyPositive_iff_exists_isStrictlyPositive_and_eq_mul_self
     {a : A} : IsStrictlyPositive a ↔ ∃ b, IsStrictlyPositive b ∧ a = b * b :=
-  CStarAlgebra.isStrictlyPositive_TFAE.out 0 3
+  CStarAlgebra.isStrictlyPositive_TFAE.out 1 4
 theorem _root_.CStarAlgebra.isStrictlyPositive_iff_exists_isUnit_and_isSelfAdjoint_and_eq_mul_self
     {a : A} : IsStrictlyPositive a ↔ ∃ b, IsUnit b ∧ IsSelfAdjoint b ∧ a = b * b :=
-  CStarAlgebra.isStrictlyPositive_TFAE.out 0 4
+  CStarAlgebra.isStrictlyPositive_TFAE.out 1 5
 theorem _root_.CStarAlgebra.isStrictlyPositive_iff_eq_star_mul_self
     {a : A} : IsStrictlyPositive a ↔ ∃ b, IsUnit b ∧ a = star b * b :=
-  CStarAlgebra.isStrictlyPositive_TFAE.out 0 5
+  CStarAlgebra.isStrictlyPositive_TFAE.out 1 6
 theorem _root_.CStarAlgebra.isStrictlyPositive_iff_eq_mul_star_self
     {a : A} : IsStrictlyPositive a ↔ ∃ b, IsUnit b ∧ a = b * star b :=
-  CStarAlgebra.isStrictlyPositive_TFAE.out 0 6
+  CStarAlgebra.isStrictlyPositive_TFAE.out 1 7
 theorem _root_.CStarAlgebra.isStrictlyPositive_iff_isSelfAdjoint_and_spectrum_pos
     {a : A} : IsStrictlyPositive a ↔ IsSelfAdjoint a ∧ ∀ x ∈ spectrum ℝ a, 0 < x :=
-  CStarAlgebra.isStrictlyPositive_TFAE.out 0 8
+  CStarAlgebra.isStrictlyPositive_TFAE.out 1 9
 
 end unital_vs_nonunital
 

--- a/Mathlib/CategoryTheory/Abelian/Exact.lean
+++ b/Mathlib/CategoryTheory/Abelian/Exact.lean
@@ -250,16 +250,16 @@ set_option backward.defeqAttrib.useBackward true in
 /-- A functor which preserves exactness preserves monomorphisms. -/
 theorem preservesMonomorphisms_of_map_exact : L.PreservesMonomorphisms where
   preserves f hf := by
-    apply ((Abelian.tfae_mono (L.map f) (L.obj 0)).out 2 0).mp
-    refine ShortComplex.exact_of_iso ?_ (hL _ (((tfae_mono f 0).out 0 2).mp hf))
+    apply ((Abelian.tfae_mono (L.map f) (L.obj 0)).out 3 1).mp
+    refine ShortComplex.exact_of_iso ?_ (hL _ (((tfae_mono f 0).out 1 3).mp hf))
     exact ShortComplex.isoMk (Iso.refl _) (Iso.refl _) (Iso.refl _)
 
 set_option backward.defeqAttrib.useBackward true in
 /-- A functor which preserves exactness preserves epimorphisms. -/
 theorem preservesEpimorphisms_of_map_exact : L.PreservesEpimorphisms where
   preserves f hf := by
-    apply ((Abelian.tfae_epi (L.map f) (L.obj 0)).out 2 0).mp
-    refine ShortComplex.exact_of_iso ?_ (hL _ (((tfae_epi f 0).out 0 2).mp hf))
+    apply ((Abelian.tfae_epi (L.map f) (L.obj 0)).out 3 1).mp
+    refine ShortComplex.exact_of_iso ?_ (hL _ (((tfae_epi f 0).out 1 3).mp hf))
     exact ShortComplex.isoMk (Iso.refl _) (Iso.refl _) (Iso.refl _)
 
 set_option backward.defeqAttrib.useBackward true in

--- a/Mathlib/CategoryTheory/Abelian/SerreClass/Localization.lean
+++ b/Mathlib/CategoryTheory/Abelian/SerreClass/Localization.lean
@@ -181,7 +181,7 @@ lemma mono_map_tfae {X Y : C} (f : X ⟶ Y) :
 
 lemma mono_map_iff {X Y : C} (f : X ⟶ Y) :
     Mono (L.map f) ↔ P.monoModSerre f :=
-  (mono_map_tfae L P f).out 0 1
+  (mono_map_tfae L P f).out 1 2
 
 lemma epi_map_tfae {X Y : C} (f : X ⟶ Y) :
     List.TFAE [Epi (L.map f),
@@ -215,7 +215,7 @@ lemma epi_map_tfae {X Y : C} (f : X ⟶ Y) :
 
 lemma epi_map_iff {X Y : C} (f : X ⟶ Y) :
     Epi (L.map f) ↔ P.epiModSerre f :=
-  (epi_map_tfae L P f).out 0 1
+  (epi_map_tfae L P f).out 1 2
 
 lemma inverseImage_monomorphisms :
     (MorphismProperty.monomorphisms _).inverseImage L = P.monoModSerre := by
@@ -432,13 +432,13 @@ lemma hasZeroObject : HasZeroObject D :=
 
 lemma preservesFiniteLimits : PreservesFiniteLimits L := by
   let := abelian L P
-  rw [((Functor.preservesFiniteLimits_tfae L).out 3 2 :)]
+  rw [((Functor.preservesFiniteLimits_tfae L).out 4 3 :)]
   intro _ _ f
   exact preservesKernel L P f
 
 lemma preservesFiniteColimits : PreservesFiniteColimits L := by
   let := abelian L P
-  rw [((Functor.preservesFiniteColimits_tfae L).out 3 2 :)]
+  rw [((Functor.preservesFiniteColimits_tfae L).out 4 3 :)]
   intro _ _ f
   exact preservesCokernel L P f
 
@@ -462,7 +462,7 @@ lemma preservesFiniteLimits_comp_iff :
   refine ⟨fun _ ↦ ?_, fun _ ↦ comp_preservesFiniteLimits _ _⟩
   have := (Localization.functor_additive_iff L P.isoModSerre G).mpr
     (L ⋙ G).additive_of_preserves_binary_products
-  refine ((Functor.preservesFiniteLimits_tfae G).out 2 3).mp (fun _ _ f ↦ ?_)
+  refine ((Functor.preservesFiniteLimits_tfae G).out 3 4).mp (fun _ _ f ↦ ?_)
   obtain ⟨f', ⟨iso⟩⟩ :=
     (Localization.essSurj_mapArrow L P.isoModSerre).mem_essImage (Arrow.mk f)
   have : PreservesLimit (parallelPair (L.map f'.hom) 0) G :=
@@ -485,7 +485,7 @@ lemma preservesFiniteColimits_comp_iff :
   have := (Localization.functor_additive_iff L P.isoModSerre G).mpr (by
     have := preservesBinaryBiproducts_of_preservesBinaryCoproducts (L ⋙ G)
     exact Functor.additive_of_preservesBinaryBiproducts _)
-  refine ((Functor.preservesFiniteColimits_tfae G).out 2 3).mp (fun _ _ f ↦ ?_)
+  refine ((Functor.preservesFiniteColimits_tfae G).out 3 4).mp (fun _ _ f ↦ ?_)
   obtain ⟨f', ⟨iso⟩⟩ :=
     (Localization.essSurj_mapArrow L P.isoModSerre).mem_essImage (Arrow.mk f)
   have : PreservesColimit (parallelPair (L.map f'.hom) 0) G :=

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Reflection.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Reflection.lean
@@ -211,7 +211,7 @@ instance (d d' : D) : IsIso (L.map ((adj.unit.app d) ⊗ₘ (adj.unit.app d'))) 
 
 instance (c : C) (d : D) : IsIso (adj.unit.app ((ihom d).obj (R.obj c))) := by
   revert c d
-  rw [((isIso_tfae adj).out 0 3 :)]
+  rw [((isIso_tfae adj).out 1 4 :)]
   intro d d'
   infer_instance
 

--- a/Mathlib/Combinatorics/Matroid/Loop.lean
+++ b/Mathlib/Combinatorics/Matroid/Loop.lean
@@ -100,7 +100,7 @@ lemma isLoop_tfae (M : Matroid α) (e : α) : List.TFAE [
 
 @[simp]
 lemma singleton_dep : M.Dep {e} ↔ M.IsLoop e :=
-  (M.isLoop_tfae e).out 3 0
+  (M.isLoop_tfae e).out 4 1
 
 alias ⟨_, IsLoop.dep⟩ := singleton_dep
 
@@ -109,12 +109,12 @@ lemma singleton_not_indep (he : e ∈ M.E := by aesop_mat) : ¬ M.Indep {e} ↔ 
 
 @[simp]
 lemma singleton_isCircuit : M.IsCircuit {e} ↔ M.IsLoop e :=
-  (M.isLoop_tfae e).out 2 0
+  (M.isLoop_tfae e).out 3 1
 
 alias ⟨_, IsLoop.isCircuit⟩ := singleton_isCircuit
 
 lemma isLoop_iff_forall_mem_compl_isBase : M.IsLoop e ↔ ∀ B, M.IsBase B → e ∈ M.E \ B :=
-  (M.isLoop_tfae e).out 0 4
+  (M.isLoop_tfae e).out 1 5
 
 lemma isLoop_iff_forall_notMem_isBase (he : e ∈ M.E := by aesop_mat) :
     M.IsLoop e ↔ ∀ B, M.IsBase B → e ∉ B := by
@@ -541,7 +541,7 @@ lemma isColoop_tfae (M : Matroid α) (e : α) : List.TFAE [
   tfae_finish
 
 lemma isColoop_iff_forall_mem_isBase : M.IsColoop e ↔ ∀ ⦃B⦄, M.IsBase B → e ∈ B :=
-  (M.isColoop_tfae e).out 0 3
+  (M.isColoop_tfae e).out 1 4
 
 lemma IsBase.mem_of_isColoop (hB : M.IsBase B) (he : M.IsColoop e) : e ∈ B :=
   isColoop_iff_forall_mem_isBase.mp he hB
@@ -568,7 +568,7 @@ lemma IsCircuit.disjoint_coloops (hC : M.IsCircuit C) : Disjoint C M.coloops :=
 
 lemma isColoop_iff_forall_notMem_isCircuit (he : e ∈ M.E := by aesop_mat) :
     M.IsColoop e ↔ ∀ ⦃C⦄, M.IsCircuit C → e ∉ C := by
-  simp_rw [(M.isColoop_tfae e).out 0 4, and_iff_left he]
+  simp_rw [(M.isColoop_tfae e).out 1 5, and_iff_left he]
 
 lemma isColoop_iff_forall_mem_compl_isCircuit [RankPos M✶] :
     M.IsColoop e ↔ ∀ C, M.IsCircuit C → e ∈ M.E \ C := by
@@ -581,7 +581,7 @@ lemma IsCircuit.not_isColoop_of_mem (hC : M.IsCircuit C) (heC : e ∈ C) : ¬ M.
   fun h ↦ h.notMem_isCircuit hC heC
 
 lemma isColoop_iff_forall_mem_closure_iff_mem : M.IsColoop e ↔ (∀ X, e ∈ M.closure X ↔ e ∈ X) :=
-  (M.isColoop_tfae e).out 0 5
+  (M.isColoop_tfae e).out 1 6
 
 /-- A version of `Matroid.isColoop_iff_forall_mem_closure_iff_mem` where we only quantify
 over subsets of the ground set. -/
@@ -598,7 +598,7 @@ lemma IsColoop.mem_of_mem_closure (he : M.IsColoop e) (heX : e ∈ M.closure X) 
   he.mem_closure_iff_mem.1 heX
 
 lemma isColoop_iff_sdiff_not_spanning : M.IsColoop e ↔ ¬ M.Spanning (M.E \ {e}) :=
-  (M.isColoop_tfae e).out 0 6
+  (M.isColoop_tfae e).out 1 7
 
 @[deprecated (since := "2026-06-03")]
 alias isColoop_iff_diff_not_spanning := isColoop_iff_sdiff_not_spanning

--- a/Mathlib/Condensed/Discrete/Characterization.lean
+++ b/Mathlib/Condensed/Discrete/Characterization.lean
@@ -146,14 +146,14 @@ theorem isDiscrete_tfae (M : CondensedMod.{u} R) :
       CompHaus.isTerminalPUnit _).symm
   tfae_have 7 → 1 := by
     intro h
-    rw [isDiscrete_iff_isDiscrete_forget, ((CondensedSet.isDiscrete_tfae _).out 0 6 :)]
+    rw [isDiscrete_iff_isDiscrete_forget, ((CondensedSet.isDiscrete_tfae _).out 1 7 :)]
     intro S
     let : PreservesFilteredColimitsOfSize.{u, u} (forget (ModuleCat R)) :=
       preservesFilteredColimitsOfSize_shrink.{u, u + 1, u, u + 1} _
     exact ⟨isColimitOfPreserves (forget (ModuleCat R)) (h S).some⟩
   tfae_have 1 → 7 := by
     intro h S
-    rw [isDiscrete_iff_isDiscrete_forget, ((CondensedSet.isDiscrete_tfae _).out 0 6 :)] at h
+    rw [isDiscrete_iff_isDiscrete_forget, ((CondensedSet.isDiscrete_tfae _).out 1 7 :)] at h
     let : ReflectsFilteredColimitsOfSize.{u, u} (forget (ModuleCat R)) :=
       reflectsFilteredColimitsOfSize_shrink.{u, u + 1, u, u + 1} _
     exact ⟨isColimitOfReflects (forget (ModuleCat R)) (h S).some⟩
@@ -250,14 +250,14 @@ theorem isDiscrete_tfae (M : LightCondMod.{u} R) :
     Sheaf.isConstant_iff_isIso_counit_app' _ LightProfinite.isTerminalPUnit (adjunction R) _
   tfae_have 6 → 1 := by
     intro h
-    rw [isDiscrete_iff_isDiscrete_forget, ((LightCondSet.isDiscrete_tfae _).out 0 5 :)]
+    rw [isDiscrete_iff_isDiscrete_forget, ((LightCondSet.isDiscrete_tfae _).out 1 6 :)]
     intro S
     let : PreservesFilteredColimitsOfSize.{0, 0} (forget (ModuleCat R)) :=
       preservesFilteredColimitsOfSize_shrink.{0, u, 0, u} _
     exact ⟨isColimitOfPreserves (forget (ModuleCat R)) (h S).some⟩
   tfae_have 1 → 6 := by
     intro h S
-    rw [isDiscrete_iff_isDiscrete_forget, ((LightCondSet.isDiscrete_tfae _).out 0 5 :)] at h
+    rw [isDiscrete_iff_isDiscrete_forget, ((LightCondSet.isDiscrete_tfae _).out 1 6 :)] at h
     let : ReflectsFilteredColimitsOfSize.{0, 0} (forget (ModuleCat R)) :=
       reflectsFilteredColimitsOfSize_shrink.{0, u, 0, u} _
     exact ⟨isColimitOfReflects (forget (ModuleCat R)) (h S).some⟩

--- a/Mathlib/Condensed/Discrete/Colimit.lean
+++ b/Mathlib/Condensed/Discrete/Colimit.lean
@@ -175,7 +175,7 @@ def lanSheafProfinite (X : Type (u + 1)) :
     rw [Presheaf.isSheaf_of_iso_iff (lanPresheafNatIso
       fun _ ↦ isColimitLocallyConstantPresheafDiagram _ _)]
     exact ((CompHausLike.LocallyConstant.functor.{u, u + 1}
-      (hs := fun _ _ _ ↦ ((Profinite.effectiveEpi_tfae _).out 0 2).mp)).obj X).property
+      (hs := fun _ _ _ ↦ ((Profinite.effectiveEpi_tfae _).out 1 3).mp)).obj X).property
 
 /-- `lanPresheaf (locallyConstantPresheaf X)` as a condensed set. -/
 def lanCondensedSet (X : Type (u + 1)) : CondensedSet.{u} :=

--- a/Mathlib/Condensed/Discrete/LocallyConstant.lean
+++ b/Mathlib/Condensed/Discrete/LocallyConstant.lean
@@ -374,7 +374,7 @@ namespace CondensedSet.LocallyConstant
 /-- The functor from sets to condensed sets given by locally constant maps into the set. -/
 abbrev functor : Type (u + 1) ⥤ CondensedSet.{u} :=
   CompHausLike.LocallyConstant.functor.{u, u + 1} (P := fun _ ↦ True)
-    (hs := fun _ _ _ ↦ ((CompHaus.effectiveEpi_tfae _).out 0 2).mp)
+    (hs := fun _ _ _ ↦ ((CompHaus.effectiveEpi_tfae _).out 1 3).mp)
 
 /--
 `CondensedSet.LocallyConstant.functor` is isomorphic to `Condensed.discrete`

--- a/Mathlib/Condensed/Discrete/Module.lean
+++ b/Mathlib/Condensed/Discrete/Module.lean
@@ -73,7 +73,7 @@ abbrev functorToPresheaves : ModuleCat.{u + 1} R ⥤ (CompHaus.{u}ᵒᵖ ⥤ Mod
 /-- `functorToPresheaves` as a functor to condensed modules. -/
 abbrev functor : ModuleCat R ⥤ CondensedMod.{u} R :=
   CompHausLike.LocallyConstantModule.functor.{u + 1, u} R
-    (fun _ _ _ ↦ ((CompHaus.effectiveEpi_tfae _).out 0 2).mp)
+    (fun _ _ _ ↦ ((CompHaus.effectiveEpi_tfae _).out 1 3).mp)
 
 /-- Auxiliary definition for `functorIsoDiscrete`. -/
 noncomputable def functorIsoDiscreteAux₁ (M : ModuleCat.{u + 1} R) :

--- a/Mathlib/Condensed/Epi.lean
+++ b/Mathlib/Condensed/Epi.lean
@@ -46,7 +46,7 @@ lemma epi_iff_locallySurjective_on_compHaus : Epi f ↔
         f.hom.app ⟨S'⟩ x = Y.obj.map ⟨φ⟩ y) := by
   rw [← isLocallySurjective_iff_epi', coherentTopology.isLocallySurjective_iff,
     regularTopology.isLocallySurjective_iff]
-  simp_rw [((CompHaus.effectiveEpi_tfae _).out 0 2 :)]
+  simp_rw [((CompHaus.effectiveEpi_tfae _).out 1 3 :)]
 
 set_option Elab.async false in  -- TODO: universe levels from type are unified in proof
 variable

--- a/Mathlib/Condensed/Equivalence.lean
+++ b/Mathlib/Condensed/Equivalence.lean
@@ -58,11 +58,11 @@ namespace StoneanProfinite
 
 instance : Stonean.toProfinite.PreservesEffectiveEpis where
   preserves f h :=
-    ((Profinite.effectiveEpi_tfae _).out 0 2).mpr (((Stonean.effectiveEpi_tfae _).out 0 2).mp h)
+    ((Profinite.effectiveEpi_tfae _).out 1 3).mpr (((Stonean.effectiveEpi_tfae _).out 1 3).mp h)
 
 instance : Stonean.toProfinite.ReflectsEffectiveEpis where
   reflects f h :=
-    ((Stonean.effectiveEpi_tfae f).out 0 2).mpr (((Profinite.effectiveEpi_tfae _).out 0 2).mp h)
+    ((Stonean.effectiveEpi_tfae f).out 1 3).mpr (((Profinite.effectiveEpi_tfae _).out 1 3).mp h)
 
 /--
 An effective presentation of an `X : Profinite` with respect to the inclusion functor from `Stonean`
@@ -71,7 +71,7 @@ noncomputable def stoneanToProfiniteEffectivePresentation (X : Profinite) :
     Stonean.toProfinite.EffectivePresentation X where
   p := X.presentation
   f := Profinite.presentation.π X
-  effectiveEpi := ((Profinite.effectiveEpi_tfae _).out 0 1).mpr (inferInstance : Epi _)
+  effectiveEpi := ((Profinite.effectiveEpi_tfae _).out 1 2).mpr (inferInstance : Epi _)
 
 instance : Stonean.toProfinite.EffectivelyEnough where
   presentation X := ⟨stoneanToProfiniteEffectivePresentation X⟩

--- a/Mathlib/Condensed/TopComparison.lean
+++ b/Mathlib/Condensed/TopComparison.lean
@@ -138,10 +138,10 @@ Associate to a `(u + 1)`-small topological space the corresponding condensed set
 `yonedaPresheaf`.
 -/
 noncomputable abbrev TopCat.toCondensedSet (X : TopCat.{u + 1}) : CondensedSet.{u} :=
-  toSheafCompHausLike.{u + 1} _ X (fun _ _ _ ↦ ((CompHaus.effectiveEpi_tfae _).out 0 2).mp)
+  toSheafCompHausLike.{u + 1} _ X (fun _ _ _ ↦ ((CompHaus.effectiveEpi_tfae _).out 1 3).mp)
 
 /--
 `TopCat.toCondensedSet` yields a functor from `TopCat.{u + 1}` to `CondensedSet.{u}`.
 -/
 noncomputable abbrev topCatToCondensedSet : TopCat.{u + 1} ⥤ CondensedSet.{u} :=
-  topCatToSheafCompHausLike.{u + 1} _ (fun _ _ _ ↦ ((CompHaus.effectiveEpi_tfae _).out 0 2).mp)
+  topCatToSheafCompHausLike.{u + 1} _ (fun _ _ _ ↦ ((CompHaus.effectiveEpi_tfae _).out 1 3).mp)

--- a/Mathlib/Data/List/TFAE.lean
+++ b/Mathlib/Data/List/TFAE.lean
@@ -65,9 +65,14 @@ theorem tfae_of_cycle {a b} {l : List Prop} (h_chain : List.IsChain (· → ·) 
     have := IH ⟨bc, ch⟩ (ab ∘ h_last)
     exact ⟨⟨ab, h_last ∘ (this.2 c (.head _) _ getLastD_mem_cons).1 ∘ bc⟩, this⟩
 
-theorem TFAE.out {l} (h : TFAE l) (n₁ n₂ : Nat) {a b}
-    (h₁ : l[n₁]? = some a := by rfl)
-    (h₂ : l[n₂]? = some b := by rfl) :
+/-- `(TFAE [P₁, P₂, P₃, ...]).out i j`, where `i`, `j` are the **1-indexed** indices for TFAE
+statements, yields a proof of `Pᵢ ↔ Pⱼ`. Indices therefore must be greater than `0`. This
+convention matches the statement numbering in `tfae` tactics. -/
+theorem TFAE.out {l} (h : TFAE l) (i j : Nat) {a b}
+    (h₁ : l[i - 1]? = some a := by rfl)
+    (h₂ : l[j - 1]? = some b := by rfl)
+    (_ : i ≠ 0 := by first | decide +kernel | fail "TFAE indices start at 1.")
+    (_ : j ≠ 0 := by first | decide +kernel | fail "TFAE indices start at 1.") :
     a ↔ b :=
   h _ (List.mem_of_getElem? h₁) _ (List.mem_of_getElem? h₂)
 

--- a/Mathlib/FieldTheory/Differential/Liouville.lean
+++ b/Mathlib/FieldTheory/Differential/Liouville.lean
@@ -140,7 +140,7 @@ private local instance isLiouville_of_finiteDimensional_galois [FiniteDimensiona
       simp only [u₁, map_prod]
       apply Fintype.prod_equiv (Equiv.mulLeft e)
       simp
-    have ffb : fixedField ⊤ = ⊥ := (IsGalois.tfae.out 0 1).mp (inferInstance : IsGalois F K)
+    have ffb : fixedField ⊤ = ⊥ := (IsGalois.tfae.out 1 2).mp (inferInstance : IsGalois F K)
     simp_rw [ffb, IntermediateField.mem_bot, Set.mem_range] at this
     -- Therefore they are all in `F`. We use `choose` to get their values in `F`.
     choose u₀ hu₀ using this

--- a/Mathlib/FieldTheory/Galois/Infinite.lean
+++ b/Mathlib/FieldTheory/Galois/Infinite.lean
@@ -89,7 +89,7 @@ lemma fixedField_fixingSubgroup (L : IntermediateField k K) [IsGalois k K] :
     rw [IntermediateField.mem_fixedField_iff] at hx
     have mem : x ∈ (adjoin L {x}).1 := subset_adjoin _ _ rfl
     have : IntermediateField.fixedField (⊤ : Subgroup ((adjoin L {x}) ≃ₐ[L] (adjoin L {x}))) = ⊥ :=
-      (IsGalois.tfae.out 0 1).mp (by infer_instance)
+      (IsGalois.tfae.out 1 2).mp (by infer_instance)
     have : ⟨x, mem⟩ ∈ (⊥ : IntermediateField L (adjoin L {x})) := by
       rw [← this, IntermediateField.mem_fixedField_iff]
       intro f _

--- a/Mathlib/Geometry/Euclidean/SignedDist.lean
+++ b/Mathlib/Geometry/Euclidean/SignedDist.lean
@@ -176,7 +176,7 @@ lemma abs_signedDist_eq_dist_iff_vsub_mem_span :
   by_cases h : v = 0
   · simp [h, eq_comm (a := (0 : ℝ)), eq_comm (a := (0 : V))]
   rw [inv_mul_eq_iff_eq_mul₀ (by positivity)]
-  rw [← Real.norm_eq_abs, ((norm_inner_eq_norm_tfae ℝ v (q -ᵥ p)).out 0 2 :)]
+  rw [← Real.norm_eq_abs, ((norm_inner_eq_norm_tfae ℝ v (q -ᵥ p)).out 1 3 :)]
   simp [h, eq_comm]
 
 open NNReal in

--- a/Mathlib/GroupTheory/Frattini.lean
+++ b/Mathlib/GroupTheory/Frattini.lean
@@ -57,7 +57,7 @@ theorem frattini_nongenerating [IsCoatomic (Subgroup G)] {K : Subgroup G}
 /-- When `G` is finite, the Frattini subgroup is nilpotent. -/
 theorem frattini_nilpotent [Finite G] : Group.IsNilpotent (frattini G) := by
   -- We use the characterisation of nilpotency in terms of all Sylow subgroups being normal.
-  have q := (Group.isNilpotent_of_finite_tfae (G := frattini G)).out 0 3
+  have q := (Group.isNilpotent_of_finite_tfae (G := frattini G)).out 1 4
   rw [q]; clear q
   -- Consider each prime `p` and Sylow `p`-subgroup `P` of `frattini G`.
   intro p p_prime P

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -1255,7 +1255,7 @@ theorem Group.isNilpotent_of_finite_tfae :
   tfae_finish
 
 instance [IsNilpotent G] {p : ℕ} [Fact p.Prime] {P : Sylow p G} : P.Normal :=
-  isNilpotent_of_finite_tfae.out 0 3 rfl rfl |>.mp ‹_› p ‹_› P
+  isNilpotent_of_finite_tfae.out 1 4 rfl rfl |>.mp ‹_› p ‹_› P
 
 end WithFiniteGroup
 

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -127,7 +127,7 @@ open scoped IsMulCommutative in
 instance [Finite G] [IsZGroup G] [hG : Group.IsNilpotent G] : IsCyclic G := by
   have (p : { x // x ∈ (Nat.card G).primeFactors }) : Fact p.1.Prime :=
     ⟨Nat.prime_of_mem_primeFactors p.2⟩
-  obtain ⟨ϕ⟩ := ((Group.isNilpotent_of_finite_tfae (G := G)).out 0 4).mp hG
+  obtain ⟨ϕ⟩ := ((Group.isNilpotent_of_finite_tfae (G := G)).out 1 5).mp hG
   let _ : CommGroup G :=
     ⟨fun g h ↦ by rw [← ϕ.symm.injective.eq_iff, map_mul, mul_comm, ← map_mul]⟩
   exact IsCyclic.of_exponent_eq_card (exponent_eq_card G)

--- a/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
@@ -83,7 +83,7 @@ lemma charpoly_nilpotent_tfae [IsNoetherian R M] (φ : Module.End R M) :
 
 lemma charpoly_eq_X_pow_iff [IsNoetherian R M] (φ : Module.End R M) :
     φ.charpoly = X ^ finrank R M ↔ ∀ m : M, ∃ (n : ℕ), (φ ^ n) m = 0 :=
-  (charpoly_nilpotent_tfae φ).out 1 2
+  (charpoly_nilpotent_tfae φ).out 2 3
 
 open Module.Free in
 lemma hasEigenvalue_zero_tfae (φ : Module.End K M) :
@@ -119,7 +119,7 @@ lemma hasEigenvalue_zero_tfae (φ : Module.End K M) :
 
 lemma charpoly_constantCoeff_eq_zero_iff (φ : Module.End K M) :
     constantCoeff φ.charpoly = 0 ↔ ∃ (m : M), m ≠ 0 ∧ φ m = 0 :=
-  (hasEigenvalue_zero_tfae φ).out 2 5
+  (hasEigenvalue_zero_tfae φ).out 3 6
 
 open Module.Free in
 lemma not_hasEigenvalue_zero_tfae (φ : Module.End K M) :
@@ -178,7 +178,7 @@ lemma finrank_maxGenEigenspace_zero_eq (φ : Module.End K M) :
     natTrailingDegree_mul (charpoly_monic _).ne_zero (charpoly_monic _).ne_zero]
   have hG : natTrailingDegree (charpoly G) = 0 := by
     apply Polynomial.natTrailingDegree_eq_zero_of_constantCoeff_ne_zero
-    apply ((not_hasEigenvalue_zero_tfae G).out 2 5).mpr
+    apply ((not_hasEigenvalue_zero_tfae G).out 3 6).mpr
     intro x hx
     apply Subtype.ext
     suffices x.1 ∈ V ⊓ W by rwa [hVW.inf_eq_bot, Submodule.mem_bot] at this
@@ -188,7 +188,7 @@ lemma finrank_maxGenEigenspace_zero_eq (φ : Module.End K M) :
     rw [pow_one]
     rwa [Subtype.ext_iff] at hx
   rw [hG, add_zero, eq_comm]
-  apply ((charpoly_nilpotent_tfae F).out 2 3).mp
+  apply ((charpoly_nilpotent_tfae F).out 3 4).mp
   simp only [Subtype.forall, Module.End.mem_maxGenEigenspace, zero_smul, sub_zero, V, F]
   rintro x ⟨n, hx⟩
   use n

--- a/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
+++ b/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
@@ -272,10 +272,10 @@ lemma mutuallySingular_tfae : List.TFAE
   tfae_finish
 
 lemma mutuallySingular_iff_disjoint : μ ⟂ₘ ν ↔ Disjoint μ ν :=
-  mutuallySingular_tfae.out 0 1
+  mutuallySingular_tfae.out 1 2
 
 lemma mutuallySingular_iff_disjoint_ae : μ ⟂ₘ ν ↔ Disjoint (ae μ) (ae ν) :=
-  mutuallySingular_tfae.out 0 2
+  mutuallySingular_tfae.out 1 3
 
 end Measure
 

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -146,10 +146,10 @@ lemma fermatLastTheoremFor_iff_nat {n : ℕ} : FermatLastTheoremFor n ↔ Fermat
   Iff.rfl
 
 lemma fermatLastTheoremFor_iff_int {n : ℕ} : FermatLastTheoremFor n ↔ FermatLastTheoremWith ℤ n :=
-  (fermatLastTheoremWith_nat_int_rat_tfae n).out 0 1
+  (fermatLastTheoremWith_nat_int_rat_tfae n).out 1 2
 
 lemma fermatLastTheoremFor_iff_rat {n : ℕ} : FermatLastTheoremFor n ↔ FermatLastTheoremWith ℚ n :=
-  (fermatLastTheoremWith_nat_int_rat_tfae n).out 0 2
+  (fermatLastTheoremWith_nat_int_rat_tfae n).out 1 3
 
 /--
 A relaxed variant of Fermat's Last Theorem over a given commutative semiring with a specific

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -267,14 +267,14 @@ theorem wellFoundedGT_characterisations : List.TFAE
 
 theorem wellFoundedGT_iff_isSupFiniteCompact :
     WellFoundedGT α ↔ IsSupFiniteCompact α :=
-  (wellFoundedGT_characterisations α).out 0 1
+  (wellFoundedGT_characterisations α).out 1 2
 
 theorem isSupFiniteCompact_iff_isSupClosedCompact : IsSupFiniteCompact α ↔ IsSupClosedCompact α :=
-  (wellFoundedGT_characterisations α).out 1 2
+  (wellFoundedGT_characterisations α).out 2 3
 
 theorem isSupClosedCompact_iff_wellFoundedGT :
     IsSupClosedCompact α ↔ WellFoundedGT α :=
-  (wellFoundedGT_characterisations α).out 2 0
+  (wellFoundedGT_characterisations α).out 3 1
 
 alias ⟨_, IsSupFiniteCompact.wellFoundedGT⟩ := wellFoundedGT_iff_isSupFiniteCompact
 

--- a/Mathlib/RepresentationTheory/Homological/TateCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/Homological/TateCohomology/Basic.lean
@@ -184,12 +184,12 @@ instance : (tateComplexFunctor R G).Additive where
   `CochainComplex (ModuleCat R) ℤ`. -/
 instance preservesFiniteLimits_tateComplexFunctor :
     Limits.PreservesFiniteLimits (tateComplexFunctor R G) :=
-  (((tateComplexFunctor R G).exact_tfae.out 0 3 rfl rfl).mp
+  (((tateComplexFunctor R G).exact_tfae.out 1 4 rfl rfl).mp
     fun _ ↦ map_tateComplexFunctor_shortExact).1
 
 instance preservesFiniteColimits_tateComplexFunctor :
     Limits.PreservesFiniteColimits (tateComplexFunctor R G) :=
-  (((tateComplexFunctor R G).exact_tfae.out 0 3 rfl rfl).mp
+  (((tateComplexFunctor R G).exact_tfae.out 1 4 rfl rfl).mp
     fun _ ↦ map_tateComplexFunctor_shortExact).2
 
 end Exact

--- a/Mathlib/RingTheory/AdicCompletion/LocalRing.lean
+++ b/Mathlib/RingTheory/AdicCompletion/LocalRing.lean
@@ -110,7 +110,7 @@ lemma mem_maximalIdeal_iff_eval_one_eq_zero [IsNoetherianRing R] [IsLocalRing R]
 lemma algebraMap_isLocalHom_of_fg [IsLocalRing R] (fg : (maximalIdeal R).FG) :
     IsLocalHom (algebraMap R (AdicCompletion (maximalIdeal R) R)) := by
   have := AdicCompletion.isLocalRing_of_fg fg
-  apply ((IsLocalRing.local_hom_TFAE _).out 0 2).mpr
+  apply ((IsLocalRing.local_hom_TFAE _).out 1 3).mpr
   simp [AdicCompletion.maximalIdeal_eq_map_of_fg fg]
 
 instance [IsNoetherianRing R] [IsLocalRing R] :

--- a/Mathlib/RingTheory/DedekindDomain/Dvr.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Dvr.lean
@@ -117,7 +117,7 @@ theorem IsLocalization.AtPrime.isDiscreteValuationRing_of_dedekind_domain [IsDed
   let : IsLocalRing Aₘ := IsLocalization.AtPrime.isLocalRing Aₘ P
   have hnf := IsLocalization.AtPrime.not_isField A hP Aₘ
   exact
-    ((IsDiscreteValuationRing.TFAE Aₘ hnf).out 0 2).mpr
+    ((IsDiscreteValuationRing.TFAE Aₘ hnf).out 1 3).mpr
       (IsLocalization.AtPrime.isDedekindDomain A P _)
 
 end

--- a/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
@@ -174,7 +174,7 @@ theorem tfae_of_isNoetherianRing_of_isLocalRing_of_isDomain
         finrank (ResidueField R) (CotangentSpace R) ≤ 1,
         ∀ I ≠ ⊥, ∃ n : ℕ, I = maximalIdeal R ^ n] := by
   tfae_have 1 → 2 := fun _ ↦ inferInstance
-  tfae_have 2 → 1 := fun _ ↦ ((IsBezout.TFAE (R := R)).out 0 1).mp ‹_›
+  tfae_have 2 → 1 := fun _ ↦ ((IsBezout.TFAE (R := R)).out 1 2).mp ‹_›
   tfae_have 1 → 4
   | H => ⟨inferInstance, fun P hP hP' ↦ eq_maximalIdeal (hP'.isMaximal hP)⟩
   tfae_have 4 → 3 :=
@@ -232,7 +232,7 @@ lemma IsLocalRing.finrank_CotangentSpace_eq_one_iff [IsNoetherianRing R] [IsLoca
   · let := hR.toField
     simp only [finrank_cotangentSpace_eq_zero, zero_ne_one, false_iff]
     exact fun h ↦ h.3 maximalIdeal_eq_bot
-  · exact (IsDiscreteValuationRing.TFAE R hR).out 5 0
+  · exact (IsDiscreteValuationRing.TFAE R hR).out 6 1
 
 variable (R)
 
@@ -259,4 +259,4 @@ instance [IsDomain R] [IsDiscreteValuationRing R] : KrullDimLE 1 R :=
 
 instance (priority := 100) IsDedekindDomain.isPrincipalIdealRing
     [IsLocalRing R] [IsDedekindDomain R] : IsPrincipalIdealRing R :=
-  ((tfae_of_isNoetherianRing_of_isLocalRing_of_isDomain R).out 2 0).mp ‹_›
+  ((tfae_of_isNoetherianRing_of_isLocalRing_of_isDomain R).out 3 1).mp ‹_›

--- a/Mathlib/RingTheory/FiniteLength.lean
+++ b/Mathlib/RingTheory/FiniteLength.lean
@@ -106,7 +106,7 @@ theorem IsSemisimpleModule.finite_tfae [IsSemisimpleModule R M] :
   tfae_finish
 
 instance [IsSemisimpleModule R M] [Module.Finite R M] : IsArtinian R M :=
-  (IsSemisimpleModule.finite_tfae.out 0 2).mp ‹_›
+  (IsSemisimpleModule.finite_tfae.out 1 3).mp ‹_›
 
 variable {f : M →ₗ[R] N}
 

--- a/Mathlib/RingTheory/Flat/CategoryTheory.lean
+++ b/Mathlib/RingTheory/Flat/CategoryTheory.lean
@@ -73,7 +73,7 @@ open Limits
 lemma iff_preservesFiniteLimits_tensorLeft :
     Flat R M ↔ PreservesFiniteLimits (tensorLeft M) := by
   rw [Module.Flat.iff_lTensor_preserves_shortComplex_exact,
-    ((Functor.exact_tfae <| tensorLeft M).out 1 3 :)]
+    ((Functor.exact_tfae <| tensorLeft M).out 2 4 :)]
   simp [show PreservesFiniteColimits (tensorLeft M) from inferInstance]
 
 instance [Module.Flat R M] : PreservesFiniteLimits <| tensorLeft M := by

--- a/Mathlib/RingTheory/Flat/EquationalCriterion.lean
+++ b/Mathlib/RingTheory/Flat/EquationalCriterion.lean
@@ -168,7 +168,7 @@ a module $M$ is flat if and only if every relation $\sum_i f_i x_i = 0$ in $M$ i
 @[stacks 00HK]
 theorem iff_forall_isTrivialRelation : Flat R M ↔ ∀ {l : ℕ} {f : Fin l → R} {x : Fin l → M},
     ∑ i, f i • x i = 0 → IsTrivialRelation f x :=
-  (tfae_equational_criterion R M).out 0 3
+  (tfae_equational_criterion R M).out 1 4
 
 /-- **Equational criterion for flatness**, forward direction.
 
@@ -197,7 +197,7 @@ $y \colon R^k \to M$ such that $x = y \circ a$ and $a(f) = 0$. -/
 theorem iff_forall_exists_factorization : Flat R M ↔
     ∀ {l : ℕ} {f : Fin l →₀ R} {x : (Fin l →₀ R) →ₗ[R] M}, x f = 0 →
       ∃ (k : ℕ) (a : (Fin l →₀ R) →ₗ[R] (Fin k →₀ R)) (y : (Fin k →₀ R) →ₗ[R] M),
-        x = y ∘ₗ a ∧ a f = 0 := (tfae_equational_criterion R M).out 0 4
+        x = y ∘ₗ a ∧ a f = 0 := (tfae_equational_criterion R M).out 1 5
 
 /-- **Equational criterion for flatness**, backward direction, alternate form.
 

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
@@ -64,7 +64,7 @@ lemma Module.FaithfullyFlat.of_flat_of_isLocalHom [IsLocalRing A] [IsLocalRing B
   by_contra eqt
   have : Submodule.restrictScalars A (Ideal.map (algebraMap A B) (IsLocalRing.maximalIdeal A)) ≤
       Submodule.restrictScalars A (IsLocalRing.maximalIdeal B) :=
-    ((IsLocalRing.local_hom_TFAE (algebraMap A B)).out 0 2).mp ‹_›
+    ((IsLocalRing.local_hom_TFAE (algebraMap A B)).out 1 3).mp ‹_›
   rw [eqt, top_le_iff, Submodule.restrictScalars_eq_top_iff] at this
   exact Ideal.IsPrime.ne_top' this
 

--- a/Mathlib/RingTheory/Flat/Rank.lean
+++ b/Mathlib/RingTheory/Flat/Rank.lean
@@ -113,7 +113,7 @@ lemma Module.Flat.tfae_algebraMap_surjective :
 
 lemma Module.rankAtStalk_le_one_iff_surjective :
     (∀ p, Module.rankAtStalk (R := R) S p ≤ 1) ↔ Function.Surjective (algebraMap R S) :=
-  (Module.Flat.tfae_algebraMap_surjective R S).out 2 0
+  (Module.Flat.tfae_algebraMap_surjective R S).out 3 1
 
 /-- If `S` is a finite, flat `R`-algebra, `S` is of constant rank `1` if and only if
 `S` is isomorphic to `R`. -/

--- a/Mathlib/RingTheory/HopkinsLevitzki.lean
+++ b/Mathlib/RingTheory/HopkinsLevitzki.lean
@@ -83,7 +83,7 @@ private theorem finite_of_isNoetherian_or_isArtinian :
     Module.Finite R₀ M) (fun M _ _ _ _ _ hJ h ↦ ?_) (fun M _ _ _ _ hs hq h ↦ ?_)
   · let _ := hJ.module
     have := IsSemisimpleModule.finite_tfae (R := R) (M := M)
-    simp_rw [this.out 1 0, this.out 2 0, or_self,
+    simp_rw [this.out 2 1, this.out 3 1, or_self,
       hJ.semilinearMap.finite_iff_of_bijective Function.bijective_id] at h
     exact .trans (R ⧸ Ring.jacobson R) M
   · let N := (Ring.jacobson R • ⊤ : Submodule R M).restrictScalars R₀
@@ -103,7 +103,7 @@ variable {R M}
 
 theorem isNoetherian_iff_isArtinian : IsNoetherian R M ↔ IsArtinian R M :=
   IsSemiprimaryRing.induction R R M (P := fun M ↦ IsNoetherian R M ↔ IsArtinian R M)
-    (fun M _ _ _ _ _ _ ↦ IsSemisimpleModule.finite_tfae.out 1 2)
+    (fun M _ _ _ _ _ _ ↦ IsSemisimpleModule.finite_tfae.out 2 3)
     fun M _ _ _ _ h h' ↦ let N : Submodule R M := Ring.jacobson R • ⊤; by
       simp_rw [isNoetherian_iff_submodule_quotient N, isArtinian_iff_submodule_quotient N, N, h, h']
 
@@ -111,7 +111,7 @@ theorem isNoetherian_iff_finite_of_jacobson_fg (fg : (Ring.jacobson R).FG) :
     IsNoetherian R M ↔ Module.Finite R M :=
   ⟨fun _ ↦ inferInstance, IsSemiprimaryRing.induction R R M
     (P := fun M ↦ Module.Finite R M → IsNoetherian R M)
-    (fun M _ _ _ _ _ _ ↦ (IsSemisimpleModule.finite_tfae.out 0 1).mp)
+    (fun M _ _ _ _ _ _ ↦ (IsSemisimpleModule.finite_tfae.out 1 2).mp)
     fun M _ _ _ _ hs hq fin ↦ (isNoetherian_iff_submodule_quotient (Ring.jacobson R • ⊤)).mpr
       ⟨hs (.of_fg (.smul fg fin.1)), hq inferInstance⟩⟩
 
@@ -133,12 +133,12 @@ theorem IsArtinianRing.tfae [IsArtinianRing R] :
 
 @[stacks 00JB "A ring is Artinian if and only if it has finite length as a module over itself."]
 theorem isArtinianRing_iff_isFiniteLength : IsArtinianRing R ↔ IsFiniteLength R R :=
-  ⟨fun h ↦ ((IsArtinianRing.tfae R R).out 2 3).mp h,
+  ⟨fun h ↦ ((IsArtinianRing.tfae R R).out 3 4).mp h,
     fun h ↦ (isFiniteLength_iff_isNoetherian_isArtinian.mp h).2⟩
 
 @[stacks 00JB "A ring is Artinian if and only if it has finite length as a module over itself.
 **Any such ring is both Artinian and Noetherian.**"]
-instance [IsArtinianRing R] : IsNoetherianRing R := ((IsArtinianRing.tfae R R).out 2 1).mp ‹_›
+instance [IsArtinianRing R] : IsNoetherianRing R := ((IsArtinianRing.tfae R R).out 3 2).mp ‹_›
 
 /-- A finitely generated Artinian module over a commutative ring is Noetherian. This is not
 necessarily the case over a noncommutative ring, see https://mathoverflow.net/a/61700. -/
@@ -186,6 +186,6 @@ lemma isArtinianRing_iff_isNilpotent_maximalIdeal (R : Type*) [CommRing R] [IsNo
   rw [isArtinianRing_iff_krullDimLE_zero,
     Ideal.FG.isNilpotent_iff_le_nilradical (IsNoetherian.noetherian _),
     ← and_iff_left (a := Ring.KrullDimLE 0 R) ‹IsLocalRing R›,
-    (Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 0 3 rfl rfl,
+    (Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 1 4 rfl rfl,
     IsLocalRing.isMaximal_iff, le_antisymm_iff, and_iff_right]
   exact IsLocalRing.le_maximalIdeal (by simp [nilradical, Ideal.radical_eq_top])

--- a/Mathlib/RingTheory/Invariant/Galois.lean
+++ b/Mathlib/RingTheory/Invariant/Galois.lean
@@ -45,7 +45,7 @@ instance [Algebra.IsAlgebraic K L] : let := IsIntegralClosure.MulSemiringAction 
 theorem Algebra.isInvariant_of_isGalois [FiniteDimensional K L] [h : IsGalois K L] :
     letI := IsIntegralClosure.MulSemiringAction A K L B
     Algebra.IsInvariant A B Gal(L/K) := by
-  replace h := ((IsGalois.tfae (F := K) (E := L)).out 0 1).mp h
+  replace h := ((IsGalois.tfae (F := K) (E := L)).out 1 2).mp h
   let := IsIntegralClosure.MulSemiringAction A K L B
   refine ⟨fun b hb ↦ ?_⟩
   replace hb : algebraMap B L b ∈ IntermediateField.fixedField (⊤ : Subgroup Gal(L/K)) := by

--- a/Mathlib/RingTheory/Jacobson/Artinian.lean
+++ b/Mathlib/RingTheory/Jacobson/Artinian.lean
@@ -41,7 +41,7 @@ lemma Module.finite_of_isArtinianRing [IsJacobsonRing R] [IsArtinianRing A] :
 then `A` is finite over `R` if and only if `A` is an Artinian ring. -/
 lemma Module.finite_iff_isArtinianRing [IsArtinianRing R] :
     Module.Finite R A ↔ IsArtinianRing A :=
-  ⟨isArtinian_of_tower _ ∘ ((IsArtinianRing.tfae R A).out 0 2).mp,
+  ⟨isArtinian_of_tower _ ∘ ((IsArtinianRing.tfae R A).out 1 3).mp,
     fun _ ↦ finite_of_isArtinianRing R A⟩
 
 /-- If `A` is a finite type algebra over an Artinian ring `R`,

--- a/Mathlib/RingTheory/KrullDimension/Zero.lean
+++ b/Mathlib/RingTheory/KrullDimension/Zero.lean
@@ -111,18 +111,18 @@ lemma Ring.krullDimLE_zero_and_isLocalRing_tfae :
 @[simp]
 lemma le_isUnit_iff_zero_notMem [IsLocalRing R]
     {M : Submonoid R} : M ≤ IsUnit.submonoid R ↔ 0 ∉ M := by
-  have := ((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 0 2 rfl rfl).mp ⟨‹_›, ‹_›⟩
+  have := ((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 1 3 rfl rfl).mp ⟨‹_›, ‹_›⟩
   exact ⟨fun h₁ h₂ ↦ not_isUnit_zero (h₁ h₂),
     fun H x hx ↦ (this x).not_left.mp fun ⟨n, hn⟩ ↦ H (hn ▸ pow_mem hx n)⟩
 
 variable (R) in
 theorem Ring.KrullDimLE.existsUnique_isPrime [IsLocalRing R] :
     ∃! I : Ideal R, I.IsPrime :=
-  ((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 0 1 rfl rfl).mp ⟨‹_›, ‹_›⟩
+  ((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 1 2 rfl rfl).mp ⟨‹_›, ‹_›⟩
 
 theorem Ring.KrullDimLE.eq_maximalIdeal_of_isPrime [IsLocalRing R] (J : Ideal R) [J.IsPrime] :
     J = IsLocalRing.maximalIdeal R :=
-  (((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 0 1 rfl rfl).mp ⟨‹_›, ‹_›⟩).unique
+  (((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 1 2 rfl rfl).mp ⟨‹_›, ‹_›⟩).unique
     ‹_› inferInstance
 
 lemma Ring.KrullDimLE.radical_eq_maximalIdeal [IsLocalRing R] (I : Ideal R) (hI : I ≠ ⊤) :
@@ -141,7 +141,7 @@ theorem Ring.KrullDimLE.subsingleton_primeSpectrum [IsLocalRing R] :
 
 theorem Ring.KrullDimLE.isNilpotent_iff_mem_maximalIdeal [IsLocalRing R] {x} :
     IsNilpotent x ↔ x ∈ IsLocalRing.maximalIdeal R :=
-  ((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 0 2 rfl rfl).mp ⟨‹_›, ‹_›⟩ x
+  ((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 1 3 rfl rfl).mp ⟨‹_›, ‹_›⟩ x
 
 theorem Ring.KrullDimLE.isNilpotent_iff_mem_nonunits [IsLocalRing R] {x} :
     IsNilpotent x ↔ x ∈ nonunits R :=
@@ -156,13 +156,13 @@ omit [Ring.KrullDimLE 0 R] in
 variable (R) in
 theorem IsLocalRing.of_isMaximal_nilradical [(nilradical R).IsMaximal] :
     IsLocalRing R :=
-  (((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 3 0 rfl rfl).mp ‹_›).2
+  (((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 4 1 rfl rfl).mp ‹_›).2
 
 omit [Ring.KrullDimLE 0 R] in
 variable (R) in
 theorem Ring.KrullDimLE.of_isMaximal_nilradical [(nilradical R).IsMaximal] :
     Ring.KrullDimLE 0 R :=
-  (((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 3 0 rfl rfl).mp ‹_›).1
+  (((Ring.krullDimLE_zero_and_isLocalRing_tfae R).out 4 1 rfl rfl).mp ‹_›).1
 
 omit [Ring.KrullDimLE 0 R] in
 lemma Ring.KrullDimLE.of_isLocalization (p : Ideal R) (hp : p ∈ minimalPrimes R)

--- a/Mathlib/RingTheory/LocalRing/Module.lean
+++ b/Mathlib/RingTheory/LocalRing/Module.lean
@@ -346,7 +346,7 @@ theorem IsLocalRing.split_injective_iff_lTensor_residueField_injective [IsLocalR
     -- Hence `l(M)` is projective because `0 → l(M) → N → N ⧸ l(M) → 0` splits.
     have : Module.Projective R (LinearMap.range l) := by
       have := (Exact.split_tfae (LinearMap.exact_subtype_mkQ (LinearMap.range l))
-        Subtype.val_injective (Submodule.mkQ_surjective _)).out 0 1
+        Subtype.val_injective (Submodule.mkQ_surjective _)).out 1 2
       obtain ⟨l', hl'⟩ := this.mp
          (Module.projective_lifting_property _ _ (Submodule.mkQ_surjective _))
       exact Module.Projective.of_split _ _ hl'
@@ -356,7 +356,7 @@ theorem IsLocalRing.split_injective_iff_lTensor_residueField_injective [IsLocalR
           (l.codRestrict (LinearMap.range l) (LinearMap.mem_range_self l)) := by
         rw [LinearMap.exact_iff, LinearMap.ker_rangeRestrict, Submodule.range_subtype]
       have := (Exact.split_tfae this
-        Subtype.val_injective (fun ⟨x, y, e⟩ ↦ ⟨y, Subtype.ext e⟩)).out 0 1
+        Subtype.val_injective (fun ⟨x, y, e⟩ ↦ ⟨y, Subtype.ext e⟩)).out 1 2
       exact this.mp (Module.projective_lifting_property _ _ (fun ⟨x, y, e⟩ ↦ ⟨y, Subtype.ext e⟩))
     have : Module.Finite R (LinearMap.ker l) := by
       refine Module.Finite.of_surjective l' ?_
@@ -378,7 +378,7 @@ theorem IsLocalRing.split_injective_iff_lTensor_residueField_injective [IsLocalR
       rwa [← LinearMap.ker_eq_bot, ← Submodule.subsingleton_iff_eq_bot,
         ← IsLocalRing.subsingleton_tensorProduct (R := R)]
     -- Whence `M ≃ l(M)` is projective and the result follows.
-    have := (Exact.split_tfae l.exact_map_mkQ_range this (Submodule.mkQ_surjective _)).out 0 1
+    have := (Exact.split_tfae l.exact_map_mkQ_range this (Submodule.mkQ_surjective _)).out 1 2
     rw [← this]
     exact Module.projective_lifting_property _ _ (Submodule.mkQ_surjective _)
 

--- a/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
+++ b/Mathlib/RingTheory/LocalRing/NonLocalRing.lean
@@ -87,7 +87,7 @@ theorem exists_surjective_of_not_isLocalRing.{u} {R : Type u} [CommRing R] [Nont
     ∃ (K₁ K₂ : Type u) (_ : Field K₁) (_ : Field K₂) (f : R →+* K₁ × K₂),
       Function.Surjective f := by
   /- get two different maximal ideals and project on the product of quotients -/
-  obtain ⟨m₁, m₂, _, _, hm₁m₂⟩ := (not_isLocalRing_tfae.out 0 2).mp h
+  obtain ⟨m₁, m₂, _, _, hm₁m₂⟩ := (not_isLocalRing_tfae.out 1 3).mp h
   let e := Ideal.quotientInfEquivQuotientProd m₁ m₂ <| Ideal.isCoprime_of_isMaximal hm₁m₂
   let f := e.toRingHom.comp <| Ideal.Quotient.mk (m₁ ⊓ m₂)
   use R ⧸ m₁, R ⧸ m₂, Ideal.Quotient.field m₁, Ideal.Quotient.field m₂, f

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Basic.lean
@@ -182,7 +182,7 @@ section FiniteDimensional
 variable [Algebra R S] [IsLocalHom (algebraMap R S)]
 
 instance : (maximalIdeal S).LiesOver (maximalIdeal R) :=
-  ⟨(((local_hom_TFAE (algebraMap R S)).out 0 4 rfl rfl).mp inferInstance).symm⟩
+  ⟨(((local_hom_TFAE (algebraMap R S)).out 1 5 rfl rfl).mp inferInstance).symm⟩
 
 instance : Algebra (ResidueField R) (ResidueField S) :=
   Ideal.Quotient.algebraOfLiesOver _ _

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Fiber.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Fiber.lean
@@ -37,7 +37,7 @@ instance [IsLocalRing R] [IsLocalRing S] [IsLocalHom (algebraMap R S)] :
       ((TensorProduct.quotIdealMapEquivTensorQuot S (maximalIdeal R)).symm.restrictScalars _)
   have : Nontrivial (IsLocalRing.ResidueField R ⊗[R] S) := by
     rw [eSp.nontrivial_congr, Ideal.Quotient.nontrivial_iff]
-    exact ((((local_hom_TFAE (algebraMap R S)).out 0 2 rfl rfl).mp inferInstance).trans_lt
+    exact ((((local_hom_TFAE (algebraMap R S)).out 1 3 rfl rfl).mp inferInstance).trans_lt
       (inferInstance : (maximalIdeal S).IsMaximal).lt_top).ne
   .of_surjective' TensorProduct.includeRight.toRingHom
     (TensorProduct.mk_surjective _ _ _ residue_surjective)

--- a/Mathlib/RingTheory/LocalRing/RingHom/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/RingHom/Basic.lean
@@ -93,7 +93,7 @@ theorem local_hom_TFAE (f : R →+* S) :
   tfae_finish
 
 lemma maximalIdeal_comap (f : R →+* S) [IsLocalHom f] : (maximalIdeal S).comap f = maximalIdeal R :=
-  ((local_hom_TFAE _).out 0 4).mp ‹_›
+  ((local_hom_TFAE _).out 1 5).mp ‹_›
 
 theorem map_maximalIdeal_le (f : R →+* S) [IsLocalHom f] :
     (maximalIdeal R).map f ≤ maximalIdeal S := by
@@ -119,7 +119,7 @@ lemma _root_.IsLocalHom.of_surjective [CommRing R] [CommRing S] [Nontrivial S] [
     (f : R →+* S) (hf : Function.Surjective f) :
     IsLocalHom f := by
   have := IsLocalRing.of_surjective' f ‹_›
-  refine ((local_hom_TFAE f).out 3 0).mp ?_
+  refine ((local_hom_TFAE f).out 4 1).mp ?_
   have := Ideal.comap_isMaximal_of_surjective f hf (K := maximalIdeal S)
   exact ((maximal_ideal_unique R).unique (inferInstanceAs (maximalIdeal R).IsMaximal) this).le
 

--- a/Mathlib/RingTheory/Noetherian/Defs.lean
+++ b/Mathlib/RingTheory/Noetherian/Defs.lean
@@ -112,7 +112,7 @@ variable {R M P : Type*} {N : Type w} [Semiring R] [AddCommMonoid M] [Module R M
   [Module R N] [AddCommMonoid P] [Module R P]
 
 theorem isNoetherian_iff' : IsNoetherian R M ↔ WellFoundedGT (Submodule R M) := by
-  refine .trans ?_ ((CompleteLattice.wellFoundedGT_characterisations <| Submodule R M).out 0 3).symm
+  refine .trans ?_ ((CompleteLattice.wellFoundedGT_characterisations <| Submodule R M).out 1 4).symm
   exact
     ⟨fun ⟨h⟩ => fun k => (fg_iff_compact k).mp (h k), fun h =>
       ⟨fun k => (fg_iff_compact k).mpr (h k)⟩⟩

--- a/Mathlib/RingTheory/QuasiFinite/Basic.lean
+++ b/Mathlib/RingTheory/QuasiFinite/Basic.lean
@@ -474,7 +474,7 @@ lemma QuasiFiniteAt.isClopen_singleton
     [Algebra.QuasiFiniteAt R p.asIdeal] : IsClopen {p} := by
   have : IsJacobsonRing S := isJacobsonRing_of_finiteType (A := R)
   have : IsNoetherianRing S := Algebra.FiniteType.isNoetherianRing R S
-  refine ((PrimeSpectrum.isOpen_singleton_tfae_of_isNoetherian_of_isJacobsonRing p).out 0 1).mp ?_
+  refine ((PrimeSpectrum.isOpen_singleton_tfae_of_isNoetherian_of_isJacobsonRing p).out 1 2).mp ?_
   obtain ⟨f, hf, e⟩ := exists_basicOpen_eq_singleton (R := R) p.asIdeal
   exact e ▸ (PrimeSpectrum.basicOpen f).isOpen
 
@@ -484,7 +484,7 @@ lemma QuasiFiniteAt.of_isOpen_singleton
   have : IsNoetherianRing S := Algebra.FiniteType.isNoetherianRing R S
   have : IsJacobsonRing S := isJacobsonRing_of_finiteType (A := R)
   rw [(PrimeSpectrum.isOpen_singleton_tfae_of_isNoetherian_of_isJacobsonRing p).out
-    0 1 rfl rfl] at H
+    1 2 rfl rfl] at H
   obtain ⟨e, he, H⟩ := PrimeSpectrum.isClopen_iff.mp H
   have hep : e ∉ p.asIdeal := H.le rfl
   let f : Localization.Away e →ₐ[S] Localization.AtPrime p.asIdeal :=

--- a/Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean
+++ b/Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean
@@ -61,7 +61,7 @@ theorem IsSimpleRing.tfae [IsSimpleRing R] : List.TFAE
   tfae_finish
 
 theorem IsSimpleRing.isSemisimpleRing_iff_isArtinianRing [IsSimpleRing R] :
-    IsSemisimpleRing R ↔ IsArtinianRing R := tfae.out 0 1
+    IsSemisimpleRing R ↔ IsArtinianRing R := tfae.out 1 2
 
 theorem isSimpleRing_isArtinianRing_iff :
     IsSimpleRing R ∧ IsArtinianRing R ↔ IsSemisimpleRing R ∧ IsIsotypic R R ∧ Nontrivial R := by

--- a/Mathlib/RingTheory/Smooth/Basic.lean
+++ b/Mathlib/RingTheory/Smooth/Basic.lean
@@ -84,7 +84,7 @@ lemma FormallySmooth.comp_surjective [FormallySmooth R A] (I : Ideal B) (hI : I 
   have hP : Function.Injective P.toExtension.cotangentComplex := by
     rw [← LinearMap.ker_eq_bot, ← Submodule.subsingleton_iff_eq_bot]
     exact FormallySmooth.subsingleton_h1Cotangent
-  obtain ⟨l, hl⟩ := ((P.toExtension.exact_cotangentComplex_toKaehler.split_tfae'.out 0 1 rfl rfl).mp
+  obtain ⟨l, hl⟩ := ((P.toExtension.exact_cotangentComplex_toKaehler.split_tfae'.out 1 2 rfl rfl).mp
     ⟨P.toExtension.subsingleton_h1Cotangent.mp FormallySmooth.subsingleton_h1Cotangent,
       Module.projective_lifting_property _ _ P.toExtension.toKaehler_surjective⟩).2
   obtain ⟨g, hg⟩ := retractionKerCotangentToTensorEquivSection (R := R) P.algebraMap_surjective
@@ -297,7 +297,7 @@ theorem iff_split_injection
   convert!
     (((exact_kerCotangentToTensor_mapBaseChange R _ _ hf).split_tfae' (g :=
           (KaehlerDifferential.mapBaseChange R P A).restrictScalars P)).out
-      0 1) using 2
+      1 2) using 2
   · rw [← (LinearMap.extendScalarsOfSurjectiveEquiv hf).exists_congr_right]
     simp [LinearMap.ext_iff]
   · rw [and_iff_right (by exact mapBaseChange_surjective R P A hf)]

--- a/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
@@ -28,7 +28,7 @@ section IsNoetherianRing
 variable (R : Type u) [CommSemiring R] [IsNoetherianRing R]
 
 instance : NoetherianSpace (PrimeSpectrum R) :=
-  ((noetherianSpace_TFAE <| PrimeSpectrum R).out 0 1).mpr (closedsEmbedding R).dual.wellFoundedLT
+  ((noetherianSpace_TFAE <| PrimeSpectrum R).out 1 2).mpr (closedsEmbedding R).dual.wellFoundedLT
 
 lemma finite_setOfPred_isMin :
     {x : PrimeSpectrum R | IsMin x}.Finite := by

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -1314,7 +1314,7 @@ variable {R}
 theorem isLocalHom_iff_comap_closedPoint {S : Type v} [CommSemiring S] [IsLocalRing S]
     (f : R →+* S) : IsLocalHom f ↔ PrimeSpectrum.comap f (closedPoint S) = closedPoint R := by
   -- Porting note: inline `this` does **not** work
-  have := (local_hom_TFAE f).out 0 4
+  have := (local_hom_TFAE f).out 1 5
   rw [this, PrimeSpectrum.ext_iff]
   rfl
 

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -516,7 +516,7 @@ theorem traceForm_nondegenerate_tfae [FiniteDimensional K L] :
 
 theorem Algebra.trace_ne_zero [FiniteDimensional K L] [Algebra.IsSeparable K L] :
     Algebra.trace K L ≠ 0 :=
-  ((traceForm_nondegenerate_tfae K L).out 0 1).mp ‹_›
+  ((traceForm_nondegenerate_tfae K L).out 1 2).mp ‹_›
 
 theorem Algebra.trace_surjective [FiniteDimensional K L] [Algebra.IsSeparable K L] :
     Function.Surjective (Algebra.trace K L) := by

--- a/Mathlib/RingTheory/Unramified/Dedekind.lean
+++ b/Mathlib/RingTheory/Unramified/Dedekind.lean
@@ -27,7 +27,7 @@ theorem IsDedekindDomain.of_formallyUnramified : IsDedekindDomain B :=
     intro q hq hqp
     let q' := IsLocalRing.maximalIdeal (Localization.AtPrime q)
     suffices q'.IsPrincipal from ((IsDiscreteValuationRing.TFAE (Localization.AtPrime q)
-      (IsLocalization.AtPrime.not_isField B hq (Localization.AtPrime q))).out 4 0).mp this
+      (IsLocalization.AtPrime.not_isField B hq (Localization.AtPrime q))).out 5 1).mp this
     let p := q.under A
     let := Localization.AtPrime.algebraOfLiesOver p q
     have : p.IsMaximal := (hqp.under A).isMaximal (q.under_ne_bot A hq)

--- a/Mathlib/RingTheory/Unramified/LocalRing.lean
+++ b/Mathlib/RingTheory/Unramified/LocalRing.lean
@@ -68,7 +68,7 @@ set_option backward.inferInstanceAs.wrap.data false in
 lemma FormallyUnramified.isField_quotient_map_maximalIdeal [FormallyUnramified R S] :
     IsField (S ⧸ (maximalIdeal R).map (algebraMap R S)) := by
   let mR := (maximalIdeal R).map (algebraMap R S)
-  have hmR : mR ≤ maximalIdeal S := ((local_hom_TFAE (algebraMap R S)).out 0 2 rfl rfl).mp ‹_›
+  have hmR : mR ≤ maximalIdeal S := ((local_hom_TFAE (algebraMap R S)).out 1 3 rfl rfl).mp ‹_›
   let : Algebra (ResidueField R) (S ⧸ mR) := (inferInstanceAs <| Algebra (R ⧸ _) _)
   have : IsScalarTower R (ResidueField R) (S ⧸ mR) := (inferInstanceAs <| IsScalarTower R (R ⧸ _) _)
   have : FormallyUnramified (ResidueField R) (S ⧸ mR) := .of_restrictScalars R _ _

--- a/Mathlib/RingTheory/Valuation/Archimedean.lean
+++ b/Mathlib/RingTheory/Valuation/Archimedean.lean
@@ -76,7 +76,7 @@ lemma isPrincipalIdealRing_iff_not_denselyOrdered [MulArchimedean (MonoidHom.mra
     exact .of_surjective _ (RingEquiv.ofBijective _ this).symm.surjective
   have : IsDomain O := hv.hom_inj.isDomain
   have : ValuationRing O := ValuationRing.of_integers v hv
-  have := ((IsBezout.TFAE (R := O)).out 1 3)
+  have := ((IsBezout.TFAE (R := O)).out 2 4)
   rw [this, hv.wfDvdMonoid_iff_wellFounded_gt_on_v, hv.wellFounded_gt_on_v_iff_discrete_mrange,
     LinearOrderedCommGroupWithZero.discrete_iff_not_denselyOrdered]
   exact H

--- a/Mathlib/RingTheory/Valuation/LocalSubring.lean
+++ b/Mathlib/RingTheory/Valuation/LocalSubring.lean
@@ -55,7 +55,7 @@ lemma LocalSubring.map_maximalIdeal_eq_top_of_isMax {R : LocalSubring K}
   obtain ⟨M, h_is_max, h_incl⟩ := Ideal.exists_le_maximal _ h_is_not_top
   let fSₘ : LocalSubring K := LocalSubring.ofPrime S M
   have h_RleSₘ : R ≤ fSₘ := by
-    refine ⟨hS.le.trans (LocalSubring.le_ofPrime ..), ((local_hom_TFAE _).out 2 0).mp ?_⟩
+    refine ⟨hS.le.trans (LocalSubring.le_ofPrime ..), ((local_hom_TFAE _).out 3 1).mp ?_⟩
     conv_rhs => rw [← IsLocalization.AtPrime.map_eq_maximalIdeal M]
     refine .trans ?_ (Ideal.map_mono h_incl)
     rw [Ideal.map_map]; rfl
@@ -71,7 +71,7 @@ lemma LocalSubring.mem_of_isMax_of_isIntegral {R : LocalSubring K}
     (S := S) (maximalIdeal R.toSubring) (le_maximalIdeal (by simp))
   have : R = .ofPrime S.toSubring Q := by
     have hRS : R.toSubring ≤ S.toSubring := fun r hr ↦ algebraMap_mem S ⟨r, hr⟩
-    refine hR.eq_of_le ⟨hRS.trans (LocalSubring.le_ofPrime _ _), ((local_hom_TFAE _).out 2 0).mp ?_⟩
+    refine hR.eq_of_le ⟨hRS.trans (LocalSubring.le_ofPrime _ _), ((local_hom_TFAE _).out 3 1).mp ?_⟩
     conv_rhs => rw [← IsLocalization.AtPrime.map_eq_maximalIdeal Q]
     refine .trans ?_ (Ideal.map_mono <| Ideal.map_le_iff_le_comap.mpr e.ge)
     rw [Ideal.map_map]; rfl
@@ -149,7 +149,7 @@ lemma Ideal.image_subset_nonunits_valuationSubring {A : Subring K} (I : Ideal A)
   have ⟨V, hV⟩ := (LocalSubring.ofPrime A M).exists_le_valuationSubring
   refine ⟨V, (LocalSubring.le_ofPrime ..).trans hV.1, ?_⟩
   rw [← V.image_maximalIdeal]
-  refine .trans ?_ (Set.image_mono <| ((local_hom_TFAE _).out 0 2).mp hV.2)
+  refine .trans ?_ (Set.image_mono <| ((local_hom_TFAE _).out 1 3).mp hV.2)
   rw [← IsLocalization.AtPrime.map_eq_maximalIdeal M, map_map]
   refine .trans ?_ (Set.image_mono <| map_mono le)
   rintro _ ⟨a, ha, rfl⟩
@@ -190,7 +190,7 @@ open Polynomial Algebra in
       ⟨.C H.unit⁻¹.1 * p, by simp [Polynomial.Monic], by simpa using .inr hpx⟩
   have ⟨V, hV⟩ := Ideal.image_subset_nonunits_valuationSubring (A := B.toSubring) _ this
   refine ⟨V, ⟨fun r hr ↦ hV.1 (B.algebraMap_mem ⟨r, hr⟩),
-    ((local_hom_TFAE _).out 3 0).mp fun r hr ↦ ?_⟩, (V.inv_mem_nonunits_iff.mp <|
+    ((local_hom_TFAE _).out 4 1).mp fun r hr ↦ ?_⟩, (V.inv_mem_nonunits_iff.mp <|
       hV.2 ⟨_, le_add_self (α := Ideal B) (Ideal.subset_span rfl), rfl⟩).resolve_left hx0⟩
   rw [← V.image_maximalIdeal] at hV
   obtain ⟨⟨r, _⟩, hr, rfl⟩ := hV.2 ⟨_, le_self_add (α := Ideal B) (Ideal.mem_map_of_mem _ hr), rfl⟩

--- a/Mathlib/SetTheory/Ordinal/Topology.lean
+++ b/Mathlib/SetTheory/Ordinal/Topology.lean
@@ -78,7 +78,7 @@ theorem mem_closure_tfae (a : Ordinal.{u}) (s : Set Ordinal) :
 theorem mem_closure_iff_iSup :
     a ∈ closure s ↔
       ∃ (ι : Type u) (_ : Nonempty ι) (f : ι → Ordinal), (∀ i, f i ∈ s) ∧ ⨆ i, f i = a := by
-  apply ((mem_closure_tfae a s).out 0 4).trans
+  apply ((mem_closure_tfae a s).out 1 5).trans
   simp_rw [exists_prop]
 
 theorem mem_iff_iSup_of_isClosed (hs : IsClosed s) :

--- a/Mathlib/Topology/Algebra/Group/SubmonoidClosure.lean
+++ b/Mathlib/Topology/Algebra/Group/SubmonoidClosure.lean
@@ -80,7 +80,7 @@ theorem mapClusterPt_atTop_pow_tfae (x y : G) :
 @[to_additive]
 theorem mapClusterPt_atTop_pow_iff_mem_topologicalClosure_zpowers {x y : G} :
     MapClusterPt x atTop (y ^ · : ℕ → G) ↔ x ∈ (Subgroup.zpowers y).topologicalClosure :=
-  (mapClusterPt_atTop_pow_tfae x y).out 0 3
+  (mapClusterPt_atTop_pow_tfae x y).out 1 4
 
 @[to_additive (attr := simp)]
 theorem mapClusterPt_inv_atTop_pow {x y : G} :
@@ -91,7 +91,7 @@ theorem mapClusterPt_inv_atTop_pow {x y : G} :
 theorem closure_range_zpow_eq_pow (x : G) :
     closure (range (x ^ · : ℤ → G)) = closure (range (x ^ · : ℕ → G)) := by
   ext y
-  exact (mapClusterPt_atTop_pow_tfae y x).out 3 2
+  exact (mapClusterPt_atTop_pow_tfae y x).out 4 3
 
 @[to_additive]
 theorem denseRange_zpow_iff_pow {x : G} :

--- a/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
@@ -49,7 +49,7 @@ theorem effectiveEpi_tfae
   tfae_finish
 
 instance : Preregular CompHaus :=
-  preregular fun _ _ _ ↦ ((effectiveEpi_tfae _).out 0 2).mp
+  preregular fun _ _ _ ↦ ((effectiveEpi_tfae _).out 1 3).mp
 
 example : Precoherent CompHaus.{u} := inferInstance
 
@@ -66,7 +66,7 @@ theorem effectiveEpiFamily_tfae
     ] := by
   tfae_have 2 → 1
   | _ => by
-    simpa [← effectiveEpi_desc_iff_effectiveEpiFamily, (effectiveEpi_tfae (Sigma.desc π)).out 0 1]
+    simpa [← effectiveEpi_desc_iff_effectiveEpiFamily, (effectiveEpi_tfae (Sigma.desc π)).out 1 2]
   tfae_have 1 → 2
   | _ => inferInstance
   tfae_have 3 → 2
@@ -104,6 +104,6 @@ theorem effectiveEpiFamily_of_jointly_surjective
     (X : α → CompHaus.{u}) (π : (a : α) → (X a ⟶ B))
     (surj : ∀ b : B, ∃ (a : α) (x : X a), π a x = b) :
     EffectiveEpiFamily X π :=
-  ((effectiveEpiFamily_tfae X π).out 2 0).mp surj
+  ((effectiveEpiFamily_tfae X π).out 3 1).mp surj
 
 end CompHaus

--- a/Mathlib/Topology/Category/Profinite/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Profinite/EffectiveEpi.lean
@@ -46,11 +46,11 @@ theorem effectiveEpi_tfae
 
 instance : profiniteToCompHaus.PreservesEffectiveEpis where
   preserves f h :=
-    ((CompHaus.effectiveEpi_tfae _).out 0 2).mpr (((Profinite.effectiveEpi_tfae _).out 0 2).mp h)
+    ((CompHaus.effectiveEpi_tfae _).out 1 3).mpr (((Profinite.effectiveEpi_tfae _).out 1 3).mp h)
 
 instance : profiniteToCompHaus.ReflectsEffectiveEpis where
   reflects f h :=
-    ((Profinite.effectiveEpi_tfae f).out 0 2).mpr (((CompHaus.effectiveEpi_tfae _).out 0 2).mp h)
+    ((Profinite.effectiveEpi_tfae f).out 1 3).mpr (((CompHaus.effectiveEpi_tfae _).out 1 3).mp h)
 
 set_option backward.isDefEq.respectTransparency false in
 /--
@@ -60,7 +60,7 @@ noncomputable def profiniteToCompHausEffectivePresentation (X : CompHaus) :
     profiniteToCompHaus.EffectivePresentation X where
   p := Stonean.toProfinite.obj X.presentation
   f := CompHaus.presentation.π X
-  effectiveEpi := ((CompHaus.effectiveEpi_tfae _).out 0 1).mpr (inferInstance : Epi _)
+  effectiveEpi := ((CompHaus.effectiveEpi_tfae _).out 1 2).mpr (inferInstance : Epi _)
 
 instance : profiniteToCompHaus.EffectivelyEnough where
   presentation X := ⟨profiniteToCompHausEffectivePresentation X⟩
@@ -81,11 +81,11 @@ theorem effectiveEpiFamily_tfae
     ] := by
   tfae_have 2 → 1
   | _ => by
-    simpa [← effectiveEpi_desc_iff_effectiveEpiFamily, (effectiveEpi_tfae (Sigma.desc π)).out 0 1]
+    simpa [← effectiveEpi_desc_iff_effectiveEpiFamily, (effectiveEpi_tfae (Sigma.desc π)).out 1 2]
   tfae_have 1 → 2 := fun _ ↦ inferInstance
   tfae_have 3 ↔ 1 := by
     erw [((CompHaus.effectiveEpiFamily_tfae
-      (fun a ↦ profiniteToCompHaus.obj (X a)) (fun a ↦ profiniteToCompHaus.map (π a))).out 2 0 :)]
+      (fun a ↦ profiniteToCompHaus.obj (X a)) (fun a ↦ profiniteToCompHaus.map (π a))).out 3 1 :)]
     exact ⟨fun h ↦ profiniteToCompHaus.finite_effectiveEpiFamily_of_map _ _ h,
       fun _ ↦ inferInstance⟩
   tfae_finish
@@ -95,6 +95,6 @@ theorem effectiveEpiFamily_of_jointly_surjective
     (X : α → Profinite.{u}) (π : (a : α) → (X a ⟶ B))
     (surj : ∀ b : B, ∃ (a : α) (x : X a), π a x = b) :
     EffectiveEpiFamily X π :=
-  ((effectiveEpiFamily_tfae X π).out 2 0).mp surj
+  ((effectiveEpiFamily_tfae X π).out 3 1).mp surj
 
 end Profinite

--- a/Mathlib/Topology/Category/Profinite/Nobeling/Induction.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Induction.lean
@@ -127,7 +127,7 @@ theorem Nobeling.isClosedEmbedding : IsClosedEmbedding (Nobeling.ι S) := by
     refine continuous_pi ?_
     intro C
     rw [← IsLocallyConstant.iff_continuous]
-    refine ((IsLocallyConstant.tfae _).out 0 3).mpr ?_
+    refine ((IsLocallyConstant.tfae _).out 1 4).mpr ?_
     rintro ⟨⟩
     · refine IsClopen.isOpen (isClopen_compl_iff.mp ?_)
       convert! C.2

--- a/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
@@ -45,13 +45,13 @@ theorem effectiveEpi_tfae
 
 instance : Stonean.toCompHaus.PreservesEffectiveEpis where
   preserves f h :=
-    ((CompHaus.effectiveEpi_tfae (Stonean.toCompHaus.map f)).out 0 2).mpr
-      (((Stonean.effectiveEpi_tfae f).out 0 2).mp h)
+    ((CompHaus.effectiveEpi_tfae (Stonean.toCompHaus.map f)).out 1 3).mpr
+      (((Stonean.effectiveEpi_tfae f).out 1 3).mp h)
 
 instance : Stonean.toCompHaus.ReflectsEffectiveEpis where
   reflects f h :=
-    ((Stonean.effectiveEpi_tfae f).out 0 2).mpr
-      (((CompHaus.effectiveEpi_tfae (Stonean.toCompHaus.map f)).out 0 2).mp h)
+    ((Stonean.effectiveEpi_tfae f).out 1 3).mpr
+      (((CompHaus.effectiveEpi_tfae (Stonean.toCompHaus.map f)).out 1 3).mp h)
 
 /--
 An effective presentation of an `X : CompHaus` with respect to the inclusion functor from `Stonean`
@@ -60,7 +60,7 @@ noncomputable def stoneanToCompHausEffectivePresentation (X : CompHaus) :
     Stonean.toCompHaus.EffectivePresentation X where
   p := X.presentation
   f := CompHaus.presentation.π X
-  effectiveEpi := ((CompHaus.effectiveEpi_tfae _).out 0 1).mpr (inferInstance : Epi _)
+  effectiveEpi := ((CompHaus.effectiveEpi_tfae _).out 1 2).mpr (inferInstance : Epi _)
 
 instance : Stonean.toCompHaus.EffectivelyEnough where
   presentation X := ⟨stoneanToCompHausEffectivePresentation X⟩
@@ -81,11 +81,11 @@ theorem effectiveEpiFamily_tfae
     ] := by
   tfae_have 2 → 1
   | _ => by
-    simpa [← effectiveEpi_desc_iff_effectiveEpiFamily, (effectiveEpi_tfae (Sigma.desc π)).out 0 1]
+    simpa [← effectiveEpi_desc_iff_effectiveEpiFamily, (effectiveEpi_tfae (Sigma.desc π)).out 1 2]
   tfae_have 1 → 2 := fun _ ↦ inferInstance
   tfae_have 3 ↔ 1 := by
     erw [((CompHaus.effectiveEpiFamily_tfae
-      (fun a ↦ Stonean.toCompHaus.obj (X a)) (fun a ↦ Stonean.toCompHaus.map (π a))).out 2 0 :)]
+      (fun a ↦ Stonean.toCompHaus.obj (X a)) (fun a ↦ Stonean.toCompHaus.map (π a))).out 3 1 :)]
     exact ⟨fun h ↦ Stonean.toCompHaus.finite_effectiveEpiFamily_of_map _ _ h,
       fun _ ↦ inferInstance⟩
   tfae_finish
@@ -95,6 +95,6 @@ theorem effectiveEpiFamily_of_jointly_surjective
     (X : α → Stonean.{u}) (π : (a : α) → (X a ⟶ B))
     (surj : ∀ b : B, ∃ (a : α) (x : X a), π a x = b) :
     EffectiveEpiFamily X π :=
-  ((effectiveEpiFamily_tfae X π).out 2 0).mp surj
+  ((effectiveEpiFamily_tfae X π).out 3 1).mp surj
 
 end Stonean

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -81,7 +81,7 @@ theorem Specializes.not_disjoint (h : x ⤳ y) : ¬Disjoint (𝓝 x) (𝓝 y) :=
   absurd (hd.mono_right h) <| by simp [NeBot.ne']
 
 theorem specializes_iff_pure : x ⤳ y ↔ pure x ≤ 𝓝 y :=
-  (specializes_TFAE x y).out 0 1
+  (specializes_TFAE x y).out 1 2
 
 alias ⟨Specializes.nhds_le_nhds, _⟩ := specializes_iff_nhds
 
@@ -91,7 +91,7 @@ theorem ker_nhds_eq_specializes : (𝓝 x).ker = {y | y ⤳ x} := by
   ext; simp [specializes_iff_pure, le_def]
 
 theorem specializes_iff_forall_open : x ⤳ y ↔ ∀ s : Set X, IsOpen s → y ∈ s → x ∈ s :=
-  (specializes_TFAE x y).out 0 2
+  (specializes_TFAE x y).out 1 3
 
 omit [TopologicalSpace X] in
 theorem Tendsto.specializes {l : Filter X} {y : Y} (h : Tendsto g l (𝓝 y)) (hl : ∀ x, f x ⤳ g x) :
@@ -107,7 +107,7 @@ theorem IsOpen.not_specializes (hs : IsOpen s) (hx : x ∉ s) (hy : y ∈ s) : �
   hx <| h.mem_open hs hy
 
 theorem specializes_iff_forall_closed : x ⤳ y ↔ ∀ s : Set X, IsClosed s → x ∈ s → y ∈ s :=
-  (specializes_TFAE x y).out 0 3
+  (specializes_TFAE x y).out 1 4
 
 theorem Specializes.mem_closed (h : x ⤳ y) (hs : IsClosed s) (hx : x ∈ s) : y ∈ s :=
   specializes_iff_forall_closed.1 h s hs hx
@@ -116,17 +116,17 @@ theorem IsClosed.not_specializes (hs : IsClosed s) (hx : x ∈ s) (hy : y ∉ s)
   hy <| h.mem_closed hs hx
 
 theorem specializes_iff_mem_closure : x ⤳ y ↔ y ∈ closure ({x} : Set X) :=
-  (specializes_TFAE x y).out 0 4
+  (specializes_TFAE x y).out 1 5
 
 alias ⟨Specializes.mem_closure, _⟩ := specializes_iff_mem_closure
 
 theorem specializes_iff_closure_subset : x ⤳ y ↔ closure ({y} : Set X) ⊆ closure {x} :=
-  (specializes_TFAE x y).out 0 5
+  (specializes_TFAE x y).out 1 6
 
 alias ⟨Specializes.closure_subset, _⟩ := specializes_iff_closure_subset
 
 theorem specializes_iff_clusterPt : x ⤳ y ↔ ClusterPt y (pure x) :=
-  (specializes_TFAE x y).out 0 6
+  (specializes_TFAE x y).out 1 7
 
 theorem Filter.HasBasis.specializes_iff {ι} {p : ι → Prop} {s : ι → Set X}
     (h : (𝓝 y).HasBasis p s) : x ⤳ y ↔ ∀ i, p i → x ∈ s i :=

--- a/Mathlib/Topology/LocallyClosed.lean
+++ b/Mathlib/Topology/LocallyClosed.lean
@@ -187,10 +187,10 @@ lemma isLocallyClosed_tfae (s : Set X) :
   tfae_finish
 
 lemma isLocallyClosed_iff_isOpen_coborder : IsLocallyClosed s ↔ IsOpen (coborder s) :=
-  (isLocallyClosed_tfae s).out 0 1
+  (isLocallyClosed_tfae s).out 1 2
 
 alias ⟨IsLocallyClosed.isOpen_coborder, _⟩ := isLocallyClosed_iff_isOpen_coborder
 
 lemma IsLocallyClosed.isOpen_preimage_val_closure (hs : IsLocallyClosed s) :
     IsOpen (closure s ↓∩ s) :=
-  ((isLocallyClosed_tfae s).out 0 4).mp hs
+  ((isLocallyClosed_tfae s).out 1 5).mp hs

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -72,10 +72,10 @@ theorem isClopen_fiber {f : X → Y} (hf : IsLocallyConstant f) (y : Y) : IsClop
 
 theorem iff_exists_open (f : X → Y) :
     IsLocallyConstant f ↔ ∀ x, ∃ U : Set X, IsOpen U ∧ x ∈ U ∧ ∀ x' ∈ U, f x' = f x :=
-  (IsLocallyConstant.tfae f).out 0 4
+  (IsLocallyConstant.tfae f).out 1 5
 
 theorem iff_eventually_eq (f : X → Y) : IsLocallyConstant f ↔ ∀ x, ∀ᶠ y in 𝓝 x, f y = f x :=
-  (IsLocallyConstant.tfae f).out 0 1
+  (IsLocallyConstant.tfae f).out 1 2
 
 theorem exists_open {f : X → Y} (hf : IsLocallyConstant f) (x : X) :
     ∃ U : Set X, IsOpen U ∧ x ∈ U ∧ ∀ x' ∈ U, f x' = f x :=
@@ -86,10 +86,10 @@ protected theorem eventually_eq {f : X → Y} (hf : IsLocallyConstant f) (x : X)
   (iff_eventually_eq f).1 hf x
 
 theorem iff_isOpen_fiber_apply {f : X → Y} : IsLocallyConstant f ↔ ∀ x, IsOpen (f ⁻¹' {f x}) :=
-  (IsLocallyConstant.tfae f).out 0 2
+  (IsLocallyConstant.tfae f).out 1 3
 
 theorem iff_isOpen_fiber {f : X → Y} : IsLocallyConstant f ↔ ∀ y, IsOpen (f ⁻¹' {y}) :=
-  (IsLocallyConstant.tfae f).out 0 3
+  (IsLocallyConstant.tfae f).out 1 4
 
 protected theorem continuous [TopologicalSpace Y] {f : X → Y} (hf : IsLocallyConstant f) :
     Continuous f :=

--- a/Mathlib/Topology/NoetherianSpace.lean
+++ b/Mathlib/Topology/NoetherianSpace.lean
@@ -92,10 +92,10 @@ theorem noetherianSpace_TFAE :
   tfae_finish
 
 theorem noetherianSpace_iff_isCompact : NoetherianSpace α ↔ ∀ s : Set α, IsCompact s :=
-  (noetherianSpace_TFAE α).out 0 2
+  (noetherianSpace_TFAE α).out 1 3
 
 instance [NoetherianSpace α] : WellFoundedLT (Closeds α) :=
-  Iff.mp ((noetherianSpace_TFAE α).out 0 1) ‹_›
+  Iff.mp ((noetherianSpace_TFAE α).out 1 2) ‹_›
 
 instance {α} : NoetherianSpace (CofiniteTopology α) := by
   simp only [noetherianSpace_iff_isCompact, isCompact_iff_ultrafilter_le_nhds,

--- a/Mathlib/Topology/Order/LeftRightNhds.lean
+++ b/Mathlib/Topology/Order/LeftRightNhds.lean
@@ -63,13 +63,13 @@ theorem TFAE_mem_nhdsGT {a b : α} (hab : a < b) (s : Set α) :
 
 theorem mem_nhdsGT_iff_exists_mem_Ioc_Ioo_subset {a u' : α} {s : Set α} (hu' : a < u') :
     s ∈ 𝓝[>] a ↔ ∃ u ∈ Ioc a u', Ioo a u ⊆ s :=
-  (TFAE_mem_nhdsGT hu' s).out 0 3
+  (TFAE_mem_nhdsGT hu' s).out 1 4
 
 /-- A set is a neighborhood of `a` within `(a, +∞)` if and only if it contains an interval `(a, u)`
 with `a < u < u'`, provided `a` is not a top element. -/
 theorem mem_nhdsGT_iff_exists_Ioo_subset' {a u' : α} {s : Set α} (hu' : a < u') :
     s ∈ 𝓝[>] a ↔ ∃ u ∈ Ioi a, Ioo a u ⊆ s :=
-  (TFAE_mem_nhdsGT hu' s).out 0 4
+  (TFAE_mem_nhdsGT hu' s).out 1 5
 
 theorem nhdsGT_basis_of_exists_gt {a : α} (h : ∃ b, a < b) : (𝓝[>] a).HasBasis (a < ·) (Ioo a) :=
   let ⟨_, h⟩ := h
@@ -205,13 +205,13 @@ theorem TFAE_mem_nhdsLT {a b : α} (h : a < b) (s : Set α) :
 
 theorem mem_nhdsLT_iff_exists_mem_Ico_Ioo_subset {a l' : α} {s : Set α} (hl' : l' < a) :
     s ∈ 𝓝[<] a ↔ ∃ l ∈ Ico l' a, Ioo l a ⊆ s :=
-  (TFAE_mem_nhdsLT hl' s).out 0 3
+  (TFAE_mem_nhdsLT hl' s).out 1 4
 
 /-- A set is a neighborhood of `a` within `(-∞, a)` if and only if it contains an interval `(l, a)`
 with `l < a`, provided `a` is not a bottom element. -/
 theorem mem_nhdsLT_iff_exists_Ioo_subset' {a l' : α} {s : Set α} (hl' : l' < a) :
     s ∈ 𝓝[<] a ↔ ∃ l ∈ Iio a, Ioo l a ⊆ s :=
-  (TFAE_mem_nhdsLT hl' s).out 0 4
+  (TFAE_mem_nhdsLT hl' s).out 1 5
 
 /-- A set is a neighborhood of `a` within `(-∞, a)` if and only if it contains an interval `(l, a)`
 with `l < a`. -/
@@ -279,13 +279,13 @@ theorem TFAE_mem_nhdsGE {a b : α} (hab : a < b) (s : Set α) :
 
 theorem mem_nhdsGE_iff_exists_mem_Ioc_Ico_subset {a u' : α} {s : Set α} (hu' : a < u') :
     s ∈ 𝓝[≥] a ↔ ∃ u ∈ Ioc a u', Ico a u ⊆ s :=
-  (TFAE_mem_nhdsGE hu' s).out 0 3 (by simp) (by simp)
+  (TFAE_mem_nhdsGE hu' s).out 1 4 (by simp) (by simp)
 
 /-- A set is a neighborhood of `a` within `[a, +∞)` if and only if it contains an interval `[a, u)`
 with `a < u < u'`, provided `a` is not a top element. -/
 theorem mem_nhdsGE_iff_exists_Ico_subset' {a u' : α} {s : Set α} (hu' : a < u') :
     s ∈ 𝓝[≥] a ↔ ∃ u ∈ Ioi a, Ico a u ⊆ s :=
-  (TFAE_mem_nhdsGE hu' s).out 0 4 (by simp) (by simp)
+  (TFAE_mem_nhdsGE hu' s).out 1 5 (by simp) (by simp)
 
 /-- A set is a neighborhood of `a` within `[a, +∞)` if and only if it contains an interval `[a, u)`
 with `a < u`. -/
@@ -328,13 +328,13 @@ theorem TFAE_mem_nhdsLE {a b : α} (h : a < b) (s : Set α) :
 
 theorem mem_nhdsLE_iff_exists_mem_Ico_Ioc_subset {a l' : α} {s : Set α} (hl' : l' < a) :
     s ∈ 𝓝[≤] a ↔ ∃ l ∈ Ico l' a, Ioc l a ⊆ s :=
-  (TFAE_mem_nhdsLE hl' s).out 0 3 (by simp) (by simp)
+  (TFAE_mem_nhdsLE hl' s).out 1 4 (by simp) (by simp)
 
 /-- A set is a neighborhood of `a` within `(-∞, a]` if and only if it contains an interval `(l, a]`
 with `l < a`, provided `a` is not a bottom element. -/
 theorem mem_nhdsLE_iff_exists_Ioc_subset' {a l' : α} {s : Set α} (hl' : l' < a) :
     s ∈ 𝓝[≤] a ↔ ∃ l ∈ Iio a, Ioc l a ⊆ s :=
-  (TFAE_mem_nhdsLE hl' s).out 0 4 (by simp) (by simp)
+  (TFAE_mem_nhdsLE hl' s).out 1 5 (by simp) (by simp)
 
 /-- A set is a neighborhood of `a` within `(-∞, a]` if and only if it contains an interval `(l, a]`
 with `l < a`. -/

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -453,26 +453,26 @@ theorem t1Space_TFAE (X : Type u) [TopologicalSpace X] :
   tfae_finish
 
 theorem t1Space_iff_continuous_cofinite_of : T1Space X ↔ Continuous (@CofiniteTopology.of X) :=
-  (t1Space_TFAE X).out 0 3
+  (t1Space_TFAE X).out 1 4
 
 theorem CofiniteTopology.continuous_of [T1Space X] : Continuous (@CofiniteTopology.of X) :=
   t1Space_iff_continuous_cofinite_of.mp ‹_›
 
 theorem t1Space_iff_exists_open :
     T1Space X ↔ Pairwise fun x y => ∃ U : Set X, IsOpen U ∧ x ∈ U ∧ y ∉ U :=
-  (t1Space_TFAE X).out 0 6
+  (t1Space_TFAE X).out 1 7
 
 theorem t1Space_iff_disjoint_pure_nhds : T1Space X ↔ ∀ ⦃x y : X⦄, x ≠ y → Disjoint (pure x) (𝓝 y) :=
-  (t1Space_TFAE X).out 0 8
+  (t1Space_TFAE X).out 1 9
 
 theorem t1Space_iff_disjoint_nhds_pure : T1Space X ↔ ∀ ⦃x y : X⦄, x ≠ y → Disjoint (𝓝 x) (pure y) :=
-  (t1Space_TFAE X).out 0 7
+  (t1Space_TFAE X).out 1 8
 
 theorem t1Space_iff_specializes_imp_eq : T1Space X ↔ ∀ ⦃x y : X⦄, x ⤳ y → x = y :=
-  (t1Space_TFAE X).out 0 9
+  (t1Space_TFAE X).out 1 10
 
 theorem t1Space_iff_t0Space_and_r0Space : T1Space X ↔ T0Space X ∧ R0Space X :=
-  (t1Space_TFAE X).out 0 10
+  (t1Space_TFAE X).out 1 11
 
 theorem disjoint_pure_nhds [T1Space X] {x y : X} (h : x ≠ y) : Disjoint (pure x) (𝓝 y) :=
   t1Space_iff_disjoint_pure_nhds.mp ‹_› h
@@ -814,7 +814,7 @@ theorem Set.Finite.continuousOn [T1Space X] [TopologicalSpace Y] {s : Set X} (hs
   fun_prop
 
 theorem SeparationQuotient.t1Space_iff : T1Space (SeparationQuotient X) ↔ R0Space X := by
-  rw [r0Space_iff, ((t1Space_TFAE (SeparationQuotient X)).out 0 9 :)]
+  rw [r0Space_iff, ((t1Space_TFAE (SeparationQuotient X)).out 1 10 :)]
   refine ⟨fun h ↦ ⟨fun x y xspecy ↦ ?_⟩, ?_⟩
   · rw [← IsInducing.specializes_iff isInducing_mk, h xspecy] at *
   · -- TODO is there are better way to do this,

--- a/Mathlib/Topology/Separation/Connected.lean
+++ b/Mathlib/Topology/Separation/Connected.lean
@@ -22,7 +22,7 @@ open scoped Topology
 -- see Note [lower instance priority]
 instance (priority := 100) TotallyDisconnectedSpace.t1Space [h : TotallyDisconnectedSpace X] :
     T1Space X := by
-  rw [((t1Space_TFAE X).out 0 1 :)]
+  rw [((t1Space_TFAE X).out 1 2 :)]
   intro x
   rw [← totallyDisconnectedSpace_iff_connectedComponent_singleton.mp h x]
   exact isClosed_connectedComponent

--- a/Mathlib/Topology/Separation/Regular.lean
+++ b/Mathlib/Topology/Separation/Regular.lean
@@ -114,10 +114,10 @@ theorem regularSpace_TFAE (X : Type u) [TopologicalSpace X] :
 
 theorem RegularSpace.of_lift'_closure_le (h : ∀ x : X, (𝓝 x).lift' closure ≤ 𝓝 x) :
     RegularSpace X :=
-  Iff.mpr ((regularSpace_TFAE X).out 0 4) h
+  Iff.mpr ((regularSpace_TFAE X).out 1 5) h
 
 theorem RegularSpace.of_lift'_closure (h : ∀ x : X, (𝓝 x).lift' closure = 𝓝 x) : RegularSpace X :=
-  Iff.mpr ((regularSpace_TFAE X).out 0 5) h
+  Iff.mpr ((regularSpace_TFAE X).out 1 6) h
 
 theorem RegularSpace.of_hasBasis {ι : X → Sort*} {p : ∀ a, ι a → Prop} {s : ∀ a, ι a → Set X}
     (h₁ : ∀ a, (𝓝 a).HasBasis (p a) (s a)) (h₂ : ∀ a i, p a i → IsClosed (s a i)) :
@@ -126,7 +126,7 @@ theorem RegularSpace.of_hasBasis {ι : X → Sort*} {p : ∀ a, ι a → Prop} {
 
 theorem RegularSpace.of_exists_mem_nhds_isClosed_subset
     (h : ∀ (x : X), ∀ s ∈ 𝓝 x, ∃ t ∈ 𝓝 x, IsClosed t ∧ t ⊆ s) : RegularSpace X :=
-  Iff.mpr ((regularSpace_TFAE X).out 0 3) h
+  Iff.mpr ((regularSpace_TFAE X).out 1 4) h
 
 /-- A weakly locally compact R₁ space is regular. -/
 instance (priority := 100) [WeaklyLocallyCompactSpace X] [R1Space X] : RegularSpace X :=
@@ -155,7 +155,7 @@ section
 variable [RegularSpace X] {x : X} {s : Set X}
 
 theorem disjoint_nhdsSet_nhds : Disjoint (𝓝ˢ s) (𝓝 x) ↔ x ∉ closure s := by
-  have h := (regularSpace_TFAE X).out 0 2
+  have h := (regularSpace_TFAE X).out 1 3
   exact h.mp ‹_› _ _
 
 theorem disjoint_nhds_nhdsSet : Disjoint (𝓝 x) (𝓝ˢ s) ↔ x ∉ closure s :=
@@ -168,7 +168,7 @@ instance (priority := 100) : R1Space X where
 
 theorem exists_mem_nhds_isClosed_subset {x : X} {s : Set X} (h : s ∈ 𝓝 x) :
     ∃ t ∈ 𝓝 x, IsClosed t ∧ t ⊆ s := by
-  have h' := (regularSpace_TFAE X).out 0 3
+  have h' := (regularSpace_TFAE X).out 1 4
   exact h'.mp ‹_› _ _ h
 
 theorem closed_nhds_basis (x : X) : (𝓝 x).HasBasis (fun s : Set X => s ∈ 𝓝 x ∧ IsClosed s) id :=
@@ -276,7 +276,7 @@ lemma IsClosed.HasSeparatingCover {s t : Set X} [LindelofSpace X] [RegularSpace 
   have (a : X) : ∃ n : Set X, IsOpen n ∧ Disjoint (closure n) t ∧ (a ∈ s → a ∈ n) := by
     wlog ains : a ∈ s
     · exact ⟨∅, isOpen_empty, SeparatedNhds.empty_left t |>.disjoint_closure_left, fun a ↦ ains a⟩
-    obtain ⟨n, nna, ncl, nsubkc⟩ := ((regularSpace_TFAE X).out 0 3 :).mp ‹RegularSpace X› a tᶜ <|
+    obtain ⟨n, nna, ncl, nsubkc⟩ := ((regularSpace_TFAE X).out 1 4 :).mp ‹RegularSpace X› a tᶜ <|
       t_cl.compl_mem_nhds (disjoint_left.mp st_dis ains)
     exact
       ⟨interior n,
@@ -712,7 +712,7 @@ open SeparationQuotient
 /-- The `SeparationQuotient` of a completely normal R₀ space is a T₅ space. -/
 instance [CompletelyNormalSpace X] [R0Space X] : T5Space (SeparationQuotient X) where
   t1 := by
-    rwa [((t1Space_TFAE (SeparationQuotient X)).out 1 0 :), SeparationQuotient.t1Space_iff]
+    rwa [((t1Space_TFAE (SeparationQuotient X)).out 2 1 :), SeparationQuotient.t1Space_iff]
   completely_normal s t hd₁ hd₂ := by
     rw [← disjoint_comap_iff surjective_mk, comap_mk_nhdsSet, comap_mk_nhdsSet]
     apply completely_normal <;> rw [← preimage_mk_closure]

--- a/Mathlib/Topology/Sheaves/Abelian.lean
+++ b/Mathlib/Topology/Sheaves/Abelian.lean
@@ -74,9 +74,9 @@ variable {C : Type v} [Category.{u} C] [HasColimits C] [HasLimits C]
 
 instance : Limits.PreservesFiniteLimits (forget C X ⋙ stalkFunctor C p₀) :=
   have : (forget C X ⋙ stalkFunctor C p₀).PreservesHomology := by
-    simp only [(forget C X ⋙ stalkFunctor C p₀).exact_tfae.out 2 0]
+    simp only [(forget C X ⋙ stalkFunctor C p₀).exact_tfae.out 3 1]
     intro S h
-    have := ((forget C X ⋙ stalkFunctor C p₀).preservesFiniteColimits_tfae.out 3 0).mp
+    have := ((forget C X ⋙ stalkFunctor C p₀).preservesFiniteColimits_tfae.out 4 1).mp
       (inferInstance : (PreservesFiniteColimits _))
     refine ShortComplex.ShortExact.mk' (this S h).left ?_ (this S h).right
     have := h.2
@@ -104,7 +104,7 @@ theorem exact_iff_stalkFunctor_map_exact (S : ShortComplex (Sheaf C X)) :
     S.Exact ↔ ∀ x : X, (S.map (forget C X ⋙ stalkFunctor C x)).Exact := by
   constructor
   · intro h x
-    have := (forget C X ⋙ stalkFunctor C x).exact_tfae.out 2 1
+    have := (forget C X ⋙ stalkFunctor C x).exact_tfae.out 3 2
     exact this.mp inferInstance S h
   intro h
   simp_rw [ShortComplex.exact_iff_isZero_homology] at h

--- a/Mathlib/Topology/Sheaves/AddCommGrpCat.lean
+++ b/Mathlib/Topology/Sheaves/AddCommGrpCat.lean
@@ -33,7 +33,7 @@ theorem Presheaf.sections_exact_of_exact
     ∃ (t : S.X₁.obj (Opposite.op U)), S.f.app (Opposite.op U) t = s := by
   dsimp [Presheaf] at S
   let F := (evaluation (Opens X)ᵒᵖ AddCommGrpCat.{u}).obj (Opposite.op U)
-  exact (ShortComplex.ab_exact_iff (S.map F)).mp (((Functor.exact_tfae F).out 1 3 rfl rfl).mpr
+  exact (ShortComplex.ab_exact_iff (S.map F)).mp (((Functor.exact_tfae F).out 2 4 rfl rfl).mpr
     ⟨inferInstance, inferInstance⟩ S hS) _ h
 
 lemma Sheaf.sections_exact_of_left_exact {S : ShortComplex (TopCat.Sheaf AddCommGrpCat X)}
@@ -41,7 +41,7 @@ lemma Sheaf.sections_exact_of_left_exact {S : ShortComplex (TopCat.Sheaf AddComm
     (h : S.g.hom.app (Opposite.op U) s = 0) :
     ∃ (t : S.X₁.obj.obj (Opposite.op U)), S.f.hom.app (Opposite.op U) t = s :=
   Presheaf.sections_exact_of_exact
-    (((Functor.preservesFiniteLimits_tfae (Sheaf.forget ..)).out 1 3 rfl rfl).mpr
+    (((Functor.preservesFiniteLimits_tfae (Sheaf.forget ..)).out 2 4 rfl rfl).mpr
     inferInstance S ⟨hS, hf⟩).left h
 
 lemma Presheaf.restrict_sum {V : Opens X} {F : Presheaf AddCommGrpCat X} (h : V ≤ U)

--- a/Mathlib/Topology/UniformSpace/LocallyUniformConvergence.lean
+++ b/Mathlib/Topology/UniformSpace/LocallyUniformConvergence.lean
@@ -266,7 +266,7 @@ theorem tendstoLocallyUniformlyOn_TFAE [LocallyCompactSpace α] (G : ι → α �
 
 theorem tendstoLocallyUniformlyOn_iff_forall_isCompact [LocallyCompactSpace α] (hs : IsOpen s) :
     TendstoLocallyUniformlyOn F f p s ↔ ∀ K, K ⊆ s → IsCompact K → TendstoUniformlyOn F f p K :=
-  (tendstoLocallyUniformlyOn_TFAE F f p hs).out 0 1
+  (tendstoLocallyUniformlyOn_TFAE F f p hs).out 1 2
 
 lemma tendstoLocallyUniformly_iff_forall_isCompact [LocallyCompactSpace α] :
     TendstoLocallyUniformly F f p ↔ ∀ K : Set α, IsCompact K → TendstoUniformlyOn F f p K := by

--- a/MathlibTest/Tactic/TFAE.lean
+++ b/MathlibTest/Tactic/TFAE.lean
@@ -133,7 +133,7 @@ example : TFAE [P, Q] := by
   tfae_have 2 ← 1 := fun p => ?Qgoal
   case Qgoal => exact pq p
   refine ?a
-  fail_if_success (tfae_have 1 ← 2 := ((?a).out 1 2 sorry sorry).mpr)
+  fail_if_success (tfae_have 1 ← 2 := ((?a).out 2 3 sorry sorry).mpr)
   tfae_have 2 → 1 := qp
   tfae_finish
 


### PR DESCRIPTION
This PR makes `TFAE.out` take in 1-indexed arguments instead of 0-indexed arguments in order to match the convention of the `tfae` tactics.

Note: the indices must be provably greater than 0 in order to avoid confusing behavior due to `TFAE.out 0 _` succeeding.

Ideally, this is a stopgap measure to achieve consistency before moving to a proper elaborator.

This is discussed further [on zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Fix.20TFAE.20numbering/with/614435379).

Disclosure: this refactor was not performed directly with Claude, but was performed using an `awk` program written by Claude.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
