### PR TITLE
[Merged by Bors] - chore(Data): tidy markdown headers

### DIFF
--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -11,6 +11,8 @@ public import Mathlib.Data.List.ProdSigma
 public import Mathlib.Data.List.Pi
 
 /-!
+# Finitely enumerable types
+
 Type class for finitely enumerable types. The property is stronger
 than `Fintype` in that it assigns each element a rank in a finite
 enumeration.

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -15,10 +15,13 @@ public import Mathlib.Data.Fintype.Sum
 public import Mathlib.Data.Fintype.Vector
 
 /-!
+# Big operators over a fintype
+
 Results about "big operations" over a `Fintype`, and consequent
 results about cardinalities of certain types.
 
-## Implementation note
+## Implementation notes
+
 This content had previously been in `Data.Fintype.Basic`, but was moved here to avoid
 requiring `Algebra.BigOperators` (and hence many other imports) as a
 dependency of `Fintype`.

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -10,7 +10,7 @@ public import Mathlib.Data.Fintype.EquivFin
 public import Mathlib.Logic.Embedding.Set
 
 /-!
-## Instances
+# Fintypes and sum types
 
 We provide the `Fintype` instance for the sum of two fintypes.
 -/

--- a/Mathlib/Data/Int/ConditionallyCompleteOrder.lean
+++ b/Mathlib/Data/Int/ConditionallyCompleteOrder.lean
@@ -9,7 +9,7 @@ public import Mathlib.Data.Int.LeastGreatest
 public import Mathlib.Order.ConditionallyCompleteLattice.Defs
 
 /-!
-## `ℤ` forms a conditionally complete linear order
+# `ℤ` forms a conditionally complete linear order
 
 The integers form a conditionally complete linear order.
 -/

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -14,7 +14,7 @@ public import Batteries.Data.List.Basic
 public import Batteries.Logic
 
 /-!
-## Definitions on lists
+# Definitions on lists
 
 This file contains various definitions on lists. It does not contain
 proofs about these definitions, those are contained in other files in `Data.List`

--- a/Mathlib/Data/List/Induction.lean
+++ b/Mathlib/Data/List/Induction.lean
@@ -9,7 +9,7 @@ public import Mathlib.Tactic.Attr.Core
 public import Mathlib.Tactic.Common
 public import Mathlib.Util.CompileInductive
 
-/-! ### Induction principles for lists -/
+/-! # Induction principles for lists -/
 
 @[expose] public section
 

--- a/Mathlib/Data/List/Lookmap.lean
+++ b/Mathlib/Data/List/Lookmap.lean
@@ -8,7 +8,7 @@ module
 public import Batteries.Data.List.Basic
 public import Mathlib.Init
 
-/-! ### lookmap -/
+/-! # `List.lookmap` -/
 
 public section
 

--- a/Mathlib/Data/List/ModifyLast.lean
+++ b/Mathlib/Data/List/ModifyLast.lean
@@ -8,7 +8,7 @@ module
 public import Batteries.Data.List.Basic
 public import Mathlib.Init
 
-/-! ### List.modifyLast -/
+/-! # `List.modifyLast` -/
 
 public section
 

--- a/Mathlib/Data/List/TakeWhile.lean
+++ b/Mathlib/Data/List/TakeWhile.lean
@@ -9,7 +9,7 @@ public import Mathlib.Order.Basic
 public import Mathlib.Data.Nat.Basic
 public import Mathlib.Tactic.Set
 
-/-! ### List.takeWhile and List.dropWhile -/
+/-! # `List.takeWhile` and `List.dropWhile` -/
 
 public section
 

--- a/Mathlib/Data/Nat/Prime/Infinite.lean
+++ b/Mathlib/Data/Nat/Prime/Infinite.lean
@@ -10,7 +10,9 @@ public import Mathlib.Data.Nat.Prime.Defs
 public import Mathlib.Order.Bounds.Basic
 
 /-!
-## Notable Theorems
+# Infinitude of the primes
+
+## Main statements
 
 - `Nat.exists_infinite_primes`: Euclid's theorem that there exist infinitely many prime numbers.
   This also appears as `Nat.not_bddAbove_setOfPred_prime` and `Nat.infinite_setOfPred_prime`

--- a/Mathlib/Data/Nat/Set.lean
+++ b/Mathlib/Data/Nat/Set.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Data.Set.Image
 
 /-!
-### Recursion on the natural numbers and `Set.range`
+# Recursion on the natural numbers and `Set.range`
 -/
 
 public section

--- a/Mathlib/Data/Nat/Size.lean
+++ b/Mathlib/Data/Nat/Size.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Data.Nat.Bits
 
-/-! Lemmas about `size`. -/
+/-! # Lemmas about `Nat.size`, `Nat.shiftLeft` and `Nat.shiftRight` -/
 
 public section
 

--- a/Mathlib/Data/Prod/Lex.lean
+++ b/Mathlib/Data/Prod/Lex.lean
@@ -34,7 +34,7 @@ Related files are:
 * `Data.PSigma.Order`: Lexicographic order on `Σ' i, α i`.
 * `Data.Sigma.Order`: Lexicographic order on `Σ i, α i`.
 
-# TODO
+## TODO
 
 Some lemmas could be automatically generated with `to_dual`.
 See [https://github.com/leanprover-community/mathlib4/pull/37939#discussion_r3367855484]

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Prj.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Prj.lean
@@ -9,6 +9,8 @@ public import Mathlib.Control.Functor.Multivariate
 public import Mathlib.Data.QPF.Multivariate.Basic
 
 /-!
+# Projection functors as QPFs
+
 Projection functors are QPFs. The `n`-ary projection functors on `i` is an `n`-ary
 functor `F` such that `F (α₀..αᵢ₋₁, αᵢ, αᵢ₊₁..αₙ₋₁) = αᵢ`
 -/

--- a/Mathlib/Data/Rat/Cast/OfScientific.lean
+++ b/Mathlib/Data/Rat/Cast/OfScientific.lean
@@ -9,6 +9,8 @@ public import Mathlib.Data.Rat.Cast.CharZero
 public import Mathlib.Data.Rat.Cast.Lemmas
 
 /-!
+# Scientific notation for characteristic-zero fields
+
 The `OfScientific` instance for any characteristic zero field
 is well-behaved with respect to the field operations.
 

--- a/Mathlib/Data/Rat/NatSqrt/Defs.lean
+++ b/Mathlib/Data/Rat/NatSqrt/Defs.lean
@@ -9,6 +9,8 @@ public import Mathlib.Tactic.Positivity
 public import Mathlib.Algebra.Order.Field.Basic
 
 /-!
+# Rational approximations to square roots of naturals
+
 Rational approximation of the square root of a natural number.
 
 See also `Mathlib.Analysis.Rat.NatSqrt.Real` for comparisons with the real square root.

--- a/Mathlib/Data/Vector/Defs.lean
+++ b/Mathlib/Data/Vector/Defs.lean
@@ -9,6 +9,8 @@ public import Mathlib.Data.List.Defs
 public import Mathlib.Tactic.Common
 
 /-!
+# The type `List.Vector`
+
 The type `List.Vector` represents lists with fixed length.
 
 TODO: The API of `List.Vector` is quite incomplete relative to `Vector`,

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -9,6 +9,8 @@ public import Mathlib.Data.Vector.Basic
 public import Mathlib.Data.Vector.Snoc
 
 /-!
+# Normalization lemmas for `map` and `mapAccumr` on vectors
+
   This file establishes a set of normalization lemmas for `map`/`mapAccumr` operations on vectors
 -/
 

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Data.Vector.Basic
 
 /-!
+# Appending to the back of a vector
+
   This file establishes a `snoc : Vector α n → α → Vector α (n+1)` operation, that appends a single
   element to the back of a vector.
 


### PR DESCRIPTION
We ensure files in `Mathlib/Data` have one and only one H1 header, thus enforcing the style guide.

New headers are authored by Claude Opus 5.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
