### PR TITLE
feat(NielsenSchreier): add `to_additive` to Nielsen-Schreier theorem

### DIFF
--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -1004,6 +1004,16 @@ instance [Unique α] : IsAddCyclic (FreeAddGroup α) :=
   ⟨FreeAddGroup.of default, fun x =>
   ⟨_root_.FreeAddGroup.addEquivIntOfUnique x, _root_.FreeAddGroup.addEquivIntOfUnique.left_inv x⟩⟩
 
+/-- Multiplicative free groups are isomorphic to `Multiplicative` additive free groups. -/
+def freeGroupEquivMultiplicative : FreeGroup α ≃* Multiplicative (FreeAddGroup α) :=
+  MonoidHom.toMulEquiv (FreeGroup.lift (Multiplicative.ofAdd .of))
+    (FreeAddGroup.lift (Additive.ofMul .of)).toMultiplicativeLeft (by ext; rfl) (by ext; rfl)
+
+/-- Additive free groups are isomorphic to `Additive` multiplicative free groups. -/
+def _root_.FreeAddGroup.freeAddGroupEquivAdditive : FreeAddGroup α ≃+ Additive (FreeGroup α) :=
+  AddMonoidHom.toAddEquiv (FreeAddGroup.lift (Additive.ofMul .of))
+    (FreeGroup.lift (Multiplicative.ofAdd .of)).toAdditiveLeft (by ext; rfl) (by ext; rfl)
+
 section Category
 
 variable {β : Type u}

--- a/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
+++ b/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
@@ -313,6 +313,19 @@ end IsFreeGroupoid
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The Nielsen-Schreier theorem: a subgroup of a free group is free. -/
-instance subgroupIsFreeOfIsFree {G : Type u} [Group G] [IsFreeGroup G] (H : Subgroup G) :
+instance subgroupIsFreeGroupOfIsFreeGroup {G : Type u} [Group G] [IsFreeGroup G] (H : Subgroup G) :
     IsFreeGroup H :=
   IsFreeGroup.ofMulEquiv (endMulEquivSubgroup H)
+
+@[deprecated (since := "2026-08-11")]
+alias subgroupIsFreeOfIsFree := subgroupIsFreeGroupOfIsFreeGroup
+
+/-- The Nielsen-Schreier theorem: an additive subgroup of an additive free group is free. -/
+instance addSubgroupIsFreeAddGroupOfIsFreeAddGroup {G : Type u} [AddGroup G] [IsFreeAddGroup G]
+    (H : AddSubgroup G) : IsFreeAddGroup H := by
+  obtain ⟨_, ⟨⟨f⟩⟩⟩ := ‹IsFreeAddGroup G›
+  have := IsFreeGroup.ofMulEquiv <| freeGroupEquivMultiplicative.trans f.toMultiplicative.symm
+  obtain ⟨β, ⟨⟨g⟩⟩⟩ := subgroupIsFreeGroupOfIsFreeGroup H.toSubgroup
+  exact ⟨β, ⟨⟨g.trans freeGroupEquivMultiplicative |>.toAdditiveLeft⟩⟩⟩
+
+attribute [to_additive existing] subgroupIsFreeGroupOfIsFreeGroup

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1560,7 +1560,7 @@ Q1249069:
 
 Q1259814:
   title: Nielsen–Schreier theorem
-  decl: subgroupIsFreeOfIsFree
+  decl: subgroupIsFreeGroupOfIsFreeGroup
 
 Q1276318:
   title: Schwartz kernel theorem


### PR DESCRIPTION
The proof of the Nielsen-Schreier theorem is not currently `to_additive`ized because it relies on category theory infrastructure like `End`/`IsFreeGroupoid`/`Quiver` that are not `to_additive` and don't appear to be very amenable to adding it.

Instead, `to_additive`ize Nielsen-Schreier by directly going across the isomorphism between `FreeGroup` and `Multiplicative (FreeAddGroup)`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
