### PR TITLE
feat(FreeGroup): basic center/centralizer properties

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4775,6 +4775,7 @@ public import Mathlib.GroupTheory.Focal
 public import Mathlib.GroupTheory.Frattini
 public import Mathlib.GroupTheory.FreeAbelianGroup
 public import Mathlib.GroupTheory.FreeGroup.Basic
+public import Mathlib.GroupTheory.FreeGroup.Center
 public import Mathlib.GroupTheory.FreeGroup.CyclicallyReduced
 public import Mathlib.GroupTheory.FreeGroup.GeneratorEquiv
 public import Mathlib.GroupTheory.FreeGroup.IsFreeGroup

--- a/Mathlib/GroupTheory/FreeGroup/Center.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Center.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 Vlad Tsyrklevich. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vlad Tsyrklevich
+-/
+module
+
+public import Mathlib.GroupTheory.FreeGroup.NielsenSchreier
+public import Mathlib.GroupTheory.FreeGroup.Reduce
+public import Mathlib.GroupTheory.SpecificGroups.Cyclic.Basic
+
+/-!
+# Center and centralizer of free groups
+
+This file develops the basic theory of center and the centralizer of a single element of a
+free group.
+
+## Main statements
+
+* `center_eq_top_of_subsingleton`/`center_eq_bot_of_nontrivial`: the center of a free group is
+  `⊤` or `⊥`, depending on the number of generators.
+* `isCyclic_centralizer`: the centralizer of a non-unit element is always a cyclic subgroup.
+-/
+
+@[expose] public section
+
+namespace FreeGroup
+
+variable {α : Type*}
+
+@[to_additive]
+theorem centralizer_of_eq_closure (a : α) :
+    Subgroup.centralizer { of a } = Subgroup.closure { of a } := by
+  classical
+  refine le_antisymm ?_ (by simp [Subgroup.mem_centralizer_singleton_iff])
+  by_contra! hh
+  obtain ⟨x, hx₁, hx₂⟩ := SetLike.not_le_iff_exists.mp hh
+  simp only [mem_closure_iff, not_forall] at hx₂
+  obtain ⟨n, hn, hx⟩ := hx₂
+  have : of a * x = x * of a := by simpa using hx₁ (of a) rfl
+  grind [idxOf_toWord_mul_of_eq x hx, idxOf_toWord_of_mul_eq x hx,
+    List.idxOf_eq_zero_iff_eq_nil_or_head_eq]
+
+@[to_additive]
+theorem center_eq_top_of_subsingleton [Subsingleton α] : Subgroup.center (FreeGroup α) = ⊤ :=
+  Subgroup.center_eq_top
+
+@[to_additive]
+theorem center_eq_bot_of_nontrivial [Nontrivial α] : Subgroup.center (FreeGroup α) = ⊥ := by
+  obtain ⟨a, b, hab⟩ := ‹_›
+  grw [eq_bot_iff, Subgroup.center_le_centralizer {of a, of b}]
+  have : Subgroup.centralizer { of a } ⊓ Subgroup.centralizer { of b } = ⊥ := by
+    ext x
+    refine ⟨fun ⟨ha, hb⟩ ↦ ?_, by simp +contextual⟩
+    rw [Subgroup.coe_toSubmonoid, SetLike.mem_coe, centralizer_of_eq_closure,
+      Subgroup.mem_closure_singleton] at ha hb
+    obtain ⟨n, hn⟩ := ha
+    obtain ⟨m, hm⟩ := hb
+    simpa [eq_of_of_zpow_eq_of_zpow hab (hm ▸ hn)] using hm.symm
+  grind [le_inf_iff, Subgroup.centralizer_le]
+
+@[to_additive]
+theorem isCyclic_centralizer (a : FreeGroup α) (ha : a ≠ 1) :
+    IsCyclic (Subgroup.centralizer { a }) := by
+  obtain ⟨β, ⟨⟨f⟩⟩⟩ := subgroupIsFreeGroupOfIsFreeGroup (Subgroup.centralizer { a })
+  rw [f.isCyclic, ← FreeGroup.subsingleton_iff_isCyclic]
+  have : Subgroup.center (Subgroup.centralizer { a }) ≠ ⊥ := by
+    refine Subgroup.ne_bot_iff_exists_ne_one.mpr ?_
+    refine ⟨⟨⟨a, Subgroup.mem_centralizer_singleton_iff.mpr rfl⟩, ?_⟩, ?_⟩
+    · simp [Subgroup.mem_center_iff, Subgroup.mem_centralizer_singleton_iff]
+    · simp [ha]
+  contrapose! this
+  simp [← Subgroup.map_center_of_mulEquiv f.symm, center_eq_bot_of_nontrivial]
+
+/-- Free groups are commutative-transitive. -/
+@[to_additive]
+theorem commute_of_commute {a b c : FreeGroup α} (h₁ : Commute a b)
+    (h₂ : Commute b c) (hb : b ≠ 1) : Commute a c := by
+  obtain ⟨x, hx⟩ := isCyclic_centralizer b hb
+  obtain ⟨y, hy⟩ := hx ⟨a, Subgroup.mem_centralizer_singleton_iff.mpr h₁.eq⟩
+  obtain ⟨z, hz⟩ := hx ⟨c, Subgroup.mem_centralizer_singleton_iff.mpr h₂.symm.eq⟩
+  simp [Subtype.ext_iff] at hy hz
+  simp [← hy, ← hz]
+
+end FreeGroup


### PR DESCRIPTION
Develop basic theory about the center/centralizer of a free group, in particular characterize when the center is trivial and that the centralizer of a single element always forms a cyclic subgroup of a free group. Use that to derive that free groups are commutative-transitive (e.g. if a,b commute and b,c commute, then so do a,c)


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #41988
- [ ] depends on: #42104
- [ ] depends on: #42106
- [ ] depends on: #42675

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
