### PR TITLE
chore(Geometry): tidy markdown headers

### DIFF
--- a/Mathlib/Geometry/Convex/Cone/Face/Lattice.lean
+++ b/Mathlib/Geometry/Convex/Cone/Face/Lattice.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Geometry.Convex.Cone.Face.Basic
 
 /-!
-## Face
+# The face lattice of a pointed cone
 
 This file defines the concept of a face of a pointed cone. It also defines the complete lattice
 structure on the collection of all faces of such a cone.

--- a/Mathlib/Geometry/Manifold/Bordism.lean
+++ b/Mathlib/Geometry/Manifold/Bordism.lean
@@ -9,7 +9,7 @@ public import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
 public import Mathlib.Geometry.Manifold.IsManifold.InteriorBoundary
 
 /-!
-## (Unoriented) bordism theory
+# (Unoriented) bordism theory
 
 This file defines the beginnings of unoriented bordism theory. We define singular manifolds,
 the building blocks of unoriented bordism groups. Future pull requests will define bordisms

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Geometry.Manifold.ContMDiff.Defs
 
 /-!
-## Basic properties of `C^n` functions between manifolds
+# Basic properties of `C^n` functions between manifolds
 
 In this file, we show that standard operations on `C^n` maps between manifolds are `C^n` :
 * `ContMDiffOn.comp` gives the invariance of the `Cⁿ` property under composition

--- a/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Geometry.Manifold.ContMDiff.Basic
 
 /-!
-## Smoothness of standard maps associated to the product of manifolds
+# Smoothness of standard maps associated to the product of manifolds
 
 This file contains results about smoothness of standard maps associated to products and sums
 (disjoint unions) of smooth manifolds:

--- a/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Geometry.Manifold.ContMDiff.Constructions
 public import Mathlib.Analysis.Normed.Operator.Prod
 
-/-! ## Equivalence of smoothness with the basic definition for functions between vector spaces
+/-! # Equivalence of smoothness with the basic definition for functions between vector spaces
 
 * `contMDiff_iff_contDiff`: for functions between vector spaces,
   manifold-smoothness is equivalent to usual smoothness.

--- a/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
@@ -11,7 +11,7 @@ public import Mathlib.Geometry.Manifold.VectorBundle.Hom
 public import Mathlib.Geometry.Manifold.Notation
 
 /-!
-### Interactions between differentiability, smoothness and manifold derivatives
+# Interactions between differentiability, smoothness and manifold derivatives
 
 We give the relation between `MDifferentiable`, `ContMDiff`, `mfderiv`, `tangentMap`
 and related notions.

--- a/Mathlib/Geometry/Manifold/Instances/Quotient.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Quotient.lean
@@ -24,7 +24,8 @@ This file contains results about quotients of manifolds by group actions.
 * if `G` acts smoothly, the quotient is an `IsManifold I n` for a suitable `ModelWithCorners I`.
 * if `G` acts smoothly, the projection map is smooth
 
-## tags
+## Tags
+
 smooth manifold, smooth action, quotient manifold
 -/
 

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Basic.lean
@@ -40,7 +40,7 @@ junk.
 
 * Implement `IsMIntegralCurveWithinAt`.
 
-## Reference
+## References
 
 * [Lee, J. M. (2012). _Introduction to Smooth Manifolds_. Springer New York.][lee2012]
 

--- a/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
@@ -37,7 +37,7 @@ We state simpler versions of the theorem for boundaryless manifolds as corollari
 * The case where the integral curve may venture to the boundary of the manifold. See Theorem 9.34,
   Lee. May require submanifolds.
 
-## Reference
+## References
 
 * [Lee, J. M. (2012). _Introduction to Smooth Manifolds_. Springer New York.][lee2012]
 

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
@@ -15,7 +15,7 @@ curve.
 
 This file mirrors `Mathlib/Analysis/ODE/Transform`.
 
-## Reference
+## References
 
 * [Lee, J. M. (2012). _Introduction to Smooth Manifolds_. Springer New York.][lee2012]
 

--- a/Mathlib/Geometry/Manifold/IntegralCurve/UniformTime.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/UniformTime.lean
@@ -16,7 +16,7 @@ public import Mathlib.Geometry.Manifold.IntegralCurve.ExistUnique
   integral curve at each point `x : M` is defined at least on an open interval `Ioo (-ε) ε`, then
   every point on `M` has a global integral curve passing through it.
 
-## Reference
+## References
 
 * [Lee, J. M. (2012). _Introduction to Smooth Manifolds_. Springer New York.][lee2012]
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/FDeriv.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/FDeriv.lean
@@ -9,7 +9,7 @@ public import Mathlib.Geometry.Manifold.MFDeriv.Basic
 public import Mathlib.Geometry.Manifold.Notation
 
 /-!
-### Relations between vector space derivative and manifold derivative
+# Relations between vector space derivative and manifold derivative
 
 The manifold derivative `mfderiv`, when considered on the model vector space with its trivial
 manifold structure, coincides with the usual Fréchet derivative `fderiv`. In this section, we prove

--- a/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Metric.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Metric.lean
@@ -55,7 +55,7 @@ variable
   {V : M → Type*} [TopologicalSpace (TotalSpace F V)]
   [∀ x, NormedAddCommGroup (V x)] [∀ x, InnerProductSpace ℝ (V x)] [FiberBundle F V]
 
-/-! # Compatible connections
+/-! ### Compatible connections
 
 A connection on `V` is compatible with the metric on `V` iff `𝓛_X ⟨σ, τ⟩ = ⟨∇_X σ, τ⟩ + ⟨σ, ∇_X τ⟩`
 holds for all sufficiently nice vector fields `X` on `M` and sections `σ`, `τ` of `V`.


### PR DESCRIPTION
This PR:
- Ensures files in `Mathlib/Geometry` have one and only one H1 header,
- Standardizes some H2 headers,
both enforcing the style guide.

The new title for `Mathlib/Geometry/Convex/Cone/Face/Lattice.lean` was suggested by Claude Opus 5.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
