### PR TITLE
[Merged by Bors] - chore(GroupTheory): tidy markdown headers

### DIFF
--- a/Mathlib/GroupTheory/Commutator/Finite.lean
+++ b/Mathlib/GroupTheory/Commutator/Finite.lean
@@ -11,6 +11,8 @@ public import Mathlib.GroupTheory.Rank
 public import Mathlib.GroupTheory.Index
 
 /-!
+# Commutators of finite direct products
+
 The commutator of a finite direct product is contained in the direct product of the commutators.
 -/
 

--- a/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
+++ b/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
@@ -11,6 +11,8 @@ public import Mathlib.GroupTheory.FreeGroup.Reduce
 public import Mathlib.Tactic.Group
 
 /-!
+# Cyclically reduced words in free groups
+
 This file defines some extra lemmas for free groups, in particular about cyclically reduced words.
 We show that free groups are (strongly) torsion-free in the sense of `IsMulTorsionFree`, i.e.,
 taking powers by every non-zero element `n : ℕ` is injective.

--- a/Mathlib/GroupTheory/FreeGroup/Orbit.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Orbit.lean
@@ -9,6 +9,8 @@ public import Mathlib.GroupTheory.FreeGroup.Reduce
 public import Mathlib.GroupTheory.GroupAction.Defs
 
 /-!
+# Orbits of `FreeGroup.startsWith`
+
 For any `w : α × Bool`, `FreeGroup.startsWith w` is the set of all elements of `FreeGroup α` that
 start with `w`.
 

--- a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
+++ b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
@@ -33,7 +33,7 @@ public import Mathlib.SetTheory.Cardinal.Arithmetic
   If an action is `n`-pretransitive, then it is `m`-pretransitive for all `m ≤ n`,
   provided `α` has at least `n` elements.
 
-## Results for `SubMulAction`.
+## Results for `SubMulAction`
 
 * `SubMulAction.ofStabilizer.isPretransitive_iff_conj` shows
   that for `a`, `b` and `g` such that `g • a = b`, the actions

--- a/Mathlib/GroupTheory/HNNExtension.lean
+++ b/Mathlib/GroupTheory/HNNExtension.lean
@@ -11,8 +11,7 @@ public import Mathlib.GroupTheory.Coprod.Basic
 public import Mathlib.GroupTheory.Complement
 
 /-!
-
-## HNN Extensions of Groups
+# HNN Extensions of Groups
 
 This file defines the HNN extension of a group `G`, `HNNExtension G A B φ`. Given a group `G`,
 subgroups `A` and `B` and an isomorphism `φ` of `A` and `B`, we adjoin a letter `t` to `G`, such

--- a/Mathlib/GroupTheory/NoncommCoprod.lean
+++ b/Mathlib/GroupTheory/NoncommCoprod.lean
@@ -23,7 +23,7 @@ and whose composition with `inr M N` coincides with `g`.
 
 There is an analogue `MulHom.noncommCoprod` when `f` and `g` are only `MulHom`s.
 
-## Main theorems:
+## Main statements
 
 * `noncommCoprod_comp_inr` and `noncommCoprod_comp_inl` prove that the compositions
   of `MonoidHom.noncommCoprod f g _` with `inl M N` and `inr M N` coincide with `f` and `g`.

--- a/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
@@ -28,7 +28,7 @@ public import Mathlib.GroupTheory.GroupAction.SubMulAction.OfFixingSubgroup
   * Formalize the other cases of the classification.
     The next one should be the *imprimitive case*.
 
-## Reference
+## References
 
 The argument is taken from [M. Liebeck, C. Praeger, J. Saxl,
 *A classification of the maximal subgroups of the finite

--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -10,8 +10,7 @@ public import Mathlib.GroupTheory.Coprod.Basic
 public import Mathlib.GroupTheory.Complement
 
 /-!
-
-## Pushouts of Monoids and Groups
+# Pushouts of Monoids and Groups
 
 This file defines wide pushouts of monoids and groups and proves some properties
 of the amalgamated product of groups (i.e. the special case where all the maps

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/KleinFour.lean
@@ -44,7 +44,7 @@ Since all 2-sylow subgroups are conjugate, we conclude
 that there is only one 2-sylow subgroup and that it is normal,
 and then characteristic.
 
-## TODO :
+## TODO
 
 Prove `alternatingGroup.kleinFour α = commutator (alternatingGroup α)`
 without any assumption on `Nat.card α`.

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/MaximalSubgroups.lean
@@ -28,7 +28,7 @@ Compare with `Equiv.Perm.isCoatom_stabilizer` for the case of the permutation gr
   * Formalize the other cases of the classification.
     The next one should be the *imprimitive case*.
 
-## Reference
+## References
 
 The argument is taken from [M. Liebeck, C. Praeger, J. Saxl,
 *A classification of the maximal subgroups of the finite


### PR DESCRIPTION
This PR:
- Ensures all files in `Mathlib/GroupTheory` have one and only one H1 header.
- Aligns some H2 headers with the style guide

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
