### PR TITLE
feat(LinearAlgebra/BilinearForm): totally isotropic subspaces have dimension at most half

### DIFF
--- a/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -289,6 +289,15 @@ lemma finrank_orthogonal (hB : B.Nondegenerate) (W : Submodule K V) :
   rw [hB.ker_eq_bot, inf_bot_eq, finrank_bot, add_zero] at this
   lia
 
+/-- A subspace contained in its own orthogonal complement — a totally isotropic subspace — has
+dimension at most half the dimension of the ambient space, provided `B` is nondegenerate. -/
+lemma two_mul_finrank_le_of_le_orthogonal (hB : B.Nondegenerate) {W : Submodule K V}
+    (hW : W ≤ B.orthogonal W) : 2 * finrank K W ≤ finrank K V := by
+  have := Submodule.finrank_mono hW
+  have := finrank_orthogonal hB W
+  have := Submodule.finrank_le W
+  lia
+
 lemma orthogonal_orthogonal (hB : B.Nondegenerate) (hB₀ : B.IsRefl) (W : Submodule K V) :
     B.orthogonal (B.orthogonal W) = W := by
   apply (eq_of_le_of_finrank_le (LinearMap.BilinForm.le_orthogonal_orthogonal hB₀) _).symm


### PR DESCRIPTION
Adds one lemma to `Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean`:

```lean
lemma two_mul_finrank_le_of_le_orthogonal (hB : B.Nondegenerate) {W : Submodule K V}
    (hW : W ≤ B.orthogonal W) : 2 * finrank K W ≤ finrank K V
```

A subspace contained in its own orthogonal complement — a *totally isotropic* subspace — has dimension at most half the dimension of the ambient space, when `B` is nondegenerate.

### Why

This is the standard dimension bound underlying the Witt decomposition, and it is the missing step in a number of applications: the Eventown theorem in extremal combinatorics, bounds on self-orthogonal linear codes, and dimension bounds for isotropic subspaces of quadratic forms. Searching for `totally isotropic` / `IsotropicSubmodule` / `isTotallyIsotropic` in Mathlib returns nothing, so as far as I can tell the bound is not currently available in any form.

The hypothesis is deliberately phrased as `W ≤ B.orthogonal W` rather than introducing a new `IsTotallyIsotropic` predicate, so that it composes directly with the existing `orthogonal` API and needs no new definitions.

### Proof

Three existing lemmas and arithmetic: `Submodule.finrank_mono` on the hypothesis, `finrank_orthogonal` (immediately above it in the same file), and `Submodule.finrank_le`. It sits directly after `finrank_orthogonal`, whose statement it consumes.

### Verification

Compiles against `master` with no errors or warnings. `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`. No new imports, no new definitions — `+9 -0` in a single file.

### Disclosure

Written with AI assistance (Claude Opus 5) and checked against the Lean kernel; I have read the statement and proof through before submitting. Happy to rename or restate as maintainers prefer — in particular if there is an appetite for an `IsTotallyIsotropic` predicate, I am glad to add one and state this in those terms instead.

### Related

Companion to #42718 (the linear algebra method and Oddtown), which will use this bound for the Eventown theorem, but the two are independent and this one stands alone.
