### PR TITLE
feat(Order/KrullDimension): level sets of height are antichains

### DIFF
--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -285,6 +285,17 @@ private lemma height_add_const (a : α) (n : ℕ∞) :
   have := length_le_height_last (p := p.snoc y (by simp [*]))
   simpa using this
 
+/-- Elements of a common finite height are pairwise incomparable: the level sets of `height`
+are antichains. This is the combinatorial content of Mirsky's theorem, which partitions a
+finite-dimensional order into `krullDim + 1` antichains. -/
+lemma isAntichain_lt_height_preimage {n : ℕ∞} (hn : n ≠ ⊤) :
+    IsAntichain (· < ·) {x : α | height x = n} := by
+  rintro x (hx : height x = n) y (hy : height y = n) _ hlt
+  have hfin : height x < ⊤ := hx ▸ hn.lt_top
+  have hmono := height_strictMono hlt hfin
+  rw [hx, hy] at hmono
+  exact lt_irrefl n hmono
+
 lemma height_add_one_le {a b : α} (hab : a < b) : height a + 1 ≤ height b := by
   cases hfin : height a with
   | top =>


### PR DESCRIPTION
Adds one lemma to `Mathlib/Order/KrullDimension.lean`, directly after `height_strictMono`:

```lean
lemma isAntichain_lt_height_preimage {n : ℕ∞} (hn : n ≠ ⊤) :
    IsAntichain (· < ·) {x : α | height x = n}
```

Elements sharing a common *finite* height are pairwise incomparable — the level sets of `height` are antichains.

### Why

This is the combinatorial content of **Mirsky's theorem**, which partitions a finite-dimensional order into `krullDim + 1` antichains (and is the easy dual of Dilworth's theorem). Neither Mirsky nor Dilworth currently appears in Mathlib — both are on the tracked list in `docs/1000.yaml` without a `decl`, and searching for `Mirsky` and `Dilworth` returns nothing.

Rather than introduce the partition machinery up front, this contributes the underlying fact, which is what any route to Mirsky needs and is independently useful for reasoning about graded and finite-dimensional orders.

### Design

Stated with `(· < ·)` rather than `(· ≤ ·)` so that it lives in the existing `[Preorder α]` section and needs no antisymmetry; in a partial order the two coincide for distinct elements. The hypothesis is `n ≠ ⊤` rather than a finiteness typeclass, which keeps it usable without extra assumptions — `height_strictMono` needs exactly that much.

### Proof

Three lines on `height_strictMono`, immediately above it in the same file.

### Verification

Compiles against `master` with no errors or warnings. `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`. No new imports or definitions — `+11 -0` in one file.

### Disclosure

Written with AI assistance (Claude Opus 5) and checked against the Lean kernel; I have read the statement and proof before submitting. Happy to rename, or to restate as `IsAntichain (· ≤ ·)` in a `PartialOrder` section if that is preferred.
