### PR TITLE
feat(RingTheory/Polynomial/Hermite): derivatives and the generating function

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7073,7 +7073,9 @@ public import Mathlib.RingTheory.Polynomial.Eisenstein.IsIntegral
 public import Mathlib.RingTheory.Polynomial.GaussLemma
 public import Mathlib.RingTheory.Polynomial.GaussNorm
 public import Mathlib.RingTheory.Polynomial.Hermite.Basic
+public import Mathlib.RingTheory.Polynomial.Hermite.Derivative
 public import Mathlib.RingTheory.Polynomial.Hermite.Gaussian
+public import Mathlib.RingTheory.Polynomial.Hermite.GeneratingFunction
 public import Mathlib.RingTheory.Polynomial.HilbertPoly
 public import Mathlib.RingTheory.Polynomial.Ideal
 public import Mathlib.RingTheory.Polynomial.IntegralNormalization

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6944,7 +6944,9 @@ public import Mathlib.RingTheory.Polynomial.Eisenstein.IsIntegral
 public import Mathlib.RingTheory.Polynomial.GaussLemma
 public import Mathlib.RingTheory.Polynomial.GaussNorm
 public import Mathlib.RingTheory.Polynomial.Hermite.Basic
+public import Mathlib.RingTheory.Polynomial.Hermite.Derivative
 public import Mathlib.RingTheory.Polynomial.Hermite.Gaussian
+public import Mathlib.RingTheory.Polynomial.Hermite.GeneratingFunction
 public import Mathlib.RingTheory.Polynomial.HilbertPoly
 public import Mathlib.RingTheory.Polynomial.Ideal
 public import Mathlib.RingTheory.Polynomial.IntegralNormalization

--- a/Mathlib/RingTheory/Polynomial/Hermite/Derivative.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Derivative.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+public import Mathlib.Algebra.Polynomial.AlgebraMap
+public import Mathlib.RingTheory.Polynomial.Hermite.Basic
+
+/-!
+# Derivatives, recurrence, and parity of the Hermite polynomials
+
+`Mathlib/RingTheory/Polynomial/Hermite/Basic.lean` defines the probabilists' Hermite polynomials
+by the recursion `hermite (n + 1) = X * hermite n - derivative (hermite n)` and develops their
+coefficient API. This file records the classical closed form of their derivatives, and its
+consequences:
+
+* `Polynomial.derivative_hermite`: the lowering identity `H'ₙ = n • Hₙ₋₁`;
+* `Polynomial.iterate_derivative_hermite`: its iterated form
+  `derivative^[k] (hermite n) = n.descFactorial k • hermite (n - k)`;
+* `Polynomial.hermite_add_two`: the three-term recurrence `Hₙ₊₂ = X * Hₙ₊₁ - (n + 1) • Hₙ`,
+  obtained by eliminating the derivative from the defining recursion;
+* `Polynomial.hermite_aeval_neg`: the parity `Hₙ(-x) = (-1)ⁿ * Hₙ(x)` in any commutative ring.
+
+## References
+
+* [Hermite Polynomials](https://en.wikipedia.org/wiki/Hermite_polynomials)
+-/
+
+public section
+
+namespace Polynomial
+
+/-- **Lowering (derivative) identity for the Hermite polynomials.** Differentiating the
+`(n + 1)`-st probabilists' Hermite polynomial lowers the index: `H'ₙ₊₁ = (n + 1) • Hₙ`.
+
+This is not a `simp` lemma because its left-hand side is already reduced by the `n`-indexed
+form `Polynomial.derivative_hermite`. -/
+theorem derivative_hermite_succ (n : ℕ) :
+    derivative (hermite (n + 1)) = (n + 1) • hermite n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    calc
+      derivative (hermite (n + 1 + 1))
+          = derivative (X * hermite (n + 1) - derivative (hermite (n + 1))) := by
+            rw [hermite_succ]
+      _ = hermite (n + 1) + X * ((n + 1) • hermite n) -
+            derivative ((n + 1) • hermite n) := by
+            simp only [derivative_sub, derivative_mul, derivative_X, one_mul, ih, derivative_smul]
+      _ = (n + 1 + 1) • hermite (n + 1) := by
+            rw [hermite_succ n]
+            simp only [derivative_smul]
+            ring_nf
+
+/-- The Hermite derivative identity at index `n`: `H'ₙ = n • Hₙ₋₁`. For `n = 0` both sides
+vanish, since `H₀ = 1`. -/
+@[simp]
+theorem derivative_hermite (n : ℕ) :
+    derivative (hermite n) = n • hermite (n - 1) := by
+  cases n with
+  | zero => simp [hermite_zero]
+  | succ n => simpa using derivative_hermite_succ n
+
+/-- Iterating the lowering identity: the `k`-th derivative of `Hₙ` is the descending factorial
+`n * (n - 1) * ⋯ * (n - k + 1)` times `Hₙ₋ₖ`. For `k > n` the descending factorial is `0` and
+both sides vanish. -/
+@[simp]
+theorem iterate_derivative_hermite (n k : ℕ) :
+    derivative^[k] (hermite n) = n.descFactorial k • hermite (n - k) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    rw [Function.iterate_succ_apply', ih, derivative_smul, derivative_hermite, smul_smul,
+      Nat.descFactorial_succ, Nat.sub_sub, mul_comm]
+
+/-- **Three-term recurrence for the Hermite polynomials.** Eliminating the derivative from the
+defining recursion `Polynomial.hermite_succ` gives the classical relation
+`Hₙ₊₂ = X * Hₙ₊₁ - (n + 1) • Hₙ`. -/
+theorem hermite_add_two (n : ℕ) :
+    hermite (n + 2) = X * hermite (n + 1) - (n + 1) • hermite n := by
+  rw [hermite_succ (n + 1), derivative_hermite_succ]
+
+/-- **Parity of the Hermite polynomials**: `Hₙ(-x) = (-1)ⁿ * Hₙ(x)` in any commutative ring.
+A coefficient of `hermite n` in degree `k` can be nonzero only when `n + k` is even
+(`Polynomial.coeff_hermite_of_odd_add`), so `k` and `n` share parity and `(-x)ᵏ = (-1)ⁿ * xᵏ`
+on every surviving monomial. -/
+@[simp]
+theorem hermite_aeval_neg {R : Type*} [CommRing R] (n : ℕ) (x : R) :
+    aeval (-x) (hermite n) = (-1) ^ n * aeval x (hermite n) := by
+  rw [aeval_eq_sum_range, aeval_eq_sum_range, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k _
+  by_cases hodd : Odd (n + k)
+  · rw [coeff_hermite_of_odd_add hodd]; simp
+  · rw [Nat.not_odd_iff_even] at hodd
+    rw [zsmul_eq_mul, zsmul_eq_mul]
+    have hpow : (-x) ^ k = (-1) ^ n * x ^ k := by
+      rcases Nat.even_or_odd n with hn | hn
+      · rw [Even.neg_pow ((Nat.even_add.mp hodd).mp hn), Even.neg_one_pow hn, one_mul]
+      · have hk : Odd k := Nat.not_even_iff_odd.mp fun hke =>
+          (Nat.not_even_iff_odd.mpr hn) ((Nat.even_add.mp hodd).mpr hke)
+        rw [Odd.neg_pow hk, Odd.neg_one_pow hn]; ring
+    rw [hpow]; ring
+
+end Polynomial

--- a/Mathlib/RingTheory/Polynomial/Hermite/Derivative.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Derivative.lean
@@ -16,12 +16,15 @@ by the recursion `hermite (n + 1) = X * hermite n - derivative (hermite n)` and 
 coefficient API. This file records the classical closed form of their derivatives, and its
 consequences:
 
+## Main results
+
 * `Polynomial.derivative_hermite`: the lowering identity `H'ₙ = n • Hₙ₋₁`;
 * `Polynomial.iterate_derivative_hermite`: its iterated form
   `derivative^[k] (hermite n) = n.descFactorial k • hermite (n - k)`;
 * `Polynomial.hermite_add_two`: the three-term recurrence `Hₙ₊₂ = X * Hₙ₊₁ - (n + 1) • Hₙ`,
   obtained by eliminating the derivative from the defining recursion;
-* `Polynomial.hermite_aeval_neg`: the parity `Hₙ(-x) = (-1)ⁿ * Hₙ(x)` in any commutative ring.
+* `Polynomial.hermite_comp_neg_X` and `Polynomial.hermite_aeval_neg`: the parity identity, as a
+  polynomial identity and after evaluation in any commutative ring.
 
 ## References
 
@@ -33,30 +36,18 @@ public section
 namespace Polynomial
 
 /-- **Lowering (derivative) identity for the Hermite polynomials.** Differentiating the
-`(n + 1)`-st probabilists' Hermite polynomial lowers the index: `H'ₙ₊₁ = (n + 1) • Hₙ`.
-
-This is not a `simp` lemma because its left-hand side is already reduced by the `n`-indexed
-form `Polynomial.derivative_hermite`. -/
+`(n + 1)`-st probabilists' Hermite polynomial lowers the index: `H'ₙ₊₁ = (n + 1) • Hₙ`. -/
 theorem derivative_hermite_succ (n : ℕ) :
     derivative (hermite (n + 1)) = (n + 1) • hermite n := by
   induction n with
   | zero => simp
   | succ n ih =>
-    calc
-      derivative (hermite (n + 1 + 1))
-          = derivative (X * hermite (n + 1) - derivative (hermite (n + 1))) := by
-            rw [hermite_succ]
-      _ = hermite (n + 1) + X * ((n + 1) • hermite n) -
-            derivative ((n + 1) • hermite n) := by
-            simp only [derivative_sub, derivative_mul, derivative_X, one_mul, ih, derivative_smul]
-      _ = (n + 1 + 1) • hermite (n + 1) := by
-            rw [hermite_succ n]
-            simp only [derivative_smul]
-            ring_nf
+    rw [hermite_succ (n + 1), derivative_sub, derivative_mul, derivative_X, one_mul, ih,
+      derivative_smul, hermite_succ n]
+    ring
 
 /-- The Hermite derivative identity at index `n`: `H'ₙ = n • Hₙ₋₁`. For `n = 0` both sides
 vanish, since `H₀ = 1`. -/
-@[simp]
 theorem derivative_hermite (n : ℕ) :
     derivative (hermite n) = n • hermite (n - 1) := by
   cases n with
@@ -66,7 +57,6 @@ theorem derivative_hermite (n : ℕ) :
 /-- Iterating the lowering identity: the `k`-th derivative of `Hₙ` is the descending factorial
 `n * (n - 1) * ⋯ * (n - k + 1)` times `Hₙ₋ₖ`. For `k > n` the descending factorial is `0` and
 both sides vanish. -/
-@[simp]
 theorem iterate_derivative_hermite (n k : ℕ) :
     derivative^[k] (hermite n) = n.descFactorial k • hermite (n - k) := by
   induction k with
@@ -82,26 +72,23 @@ theorem hermite_add_two (n : ℕ) :
     hermite (n + 2) = X * hermite (n + 1) - (n + 1) • hermite n := by
   rw [hermite_succ (n + 1), derivative_hermite_succ]
 
-/-- **Parity of the Hermite polynomials**: `Hₙ(-x) = (-1)ⁿ * Hₙ(x)` in any commutative ring.
-A coefficient of `hermite n` in degree `k` can be nonzero only when `n + k` is even
-(`Polynomial.coeff_hermite_of_odd_add`), so `k` and `n` share parity and `(-x)ᵏ = (-1)ⁿ * xᵏ`
-on every surviving monomial. -/
+/-- The parity identity for the Hermite polynomials, as a polynomial identity. -/
+theorem hermite_comp_neg_X (n : ℕ) : (hermite n).comp (-X) = (-1) ^ n * hermite n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    have h := congrArg derivative ih
+    rw [derivative_comp, derivative_neg, derivative_X, derivative_mul, derivative_pow] at h
+    simp only [derivative_neg, derivative_one, neg_mul, one_mul, zero_mul,
+      mul_zero, zero_add, neg_zero] at h
+    rw [hermite_succ, sub_comp, mul_comp, X_comp, ih, neg_eq_iff_eq_neg.mp h]
+    ring
+
+/-- **Parity of the Hermite polynomials**: `Hₙ(-x) = (-1)ⁿ * Hₙ(x)` in any commutative ring. -/
 @[simp]
 theorem hermite_aeval_neg {R : Type*} [CommRing R] (n : ℕ) (x : R) :
     aeval (-x) (hermite n) = (-1) ^ n * aeval x (hermite n) := by
-  rw [aeval_eq_sum_range, aeval_eq_sum_range, Finset.mul_sum]
-  apply Finset.sum_congr rfl
-  intro k _
-  by_cases hodd : Odd (n + k)
-  · rw [coeff_hermite_of_odd_add hodd]; simp
-  · rw [Nat.not_odd_iff_even] at hodd
-    rw [zsmul_eq_mul, zsmul_eq_mul]
-    have hpow : (-x) ^ k = (-1) ^ n * x ^ k := by
-      rcases Nat.even_or_odd n with hn | hn
-      · rw [Even.neg_pow ((Nat.even_add.mp hodd).mp hn), Even.neg_one_pow hn, one_mul]
-      · have hk : Odd k := Nat.not_even_iff_odd.mp fun hke =>
-          (Nat.not_even_iff_odd.mpr hn) ((Nat.even_add.mp hodd).mpr hke)
-        rw [Odd.neg_pow hk, Odd.neg_one_pow hn]; ring
-    rw [hpow]; ring
+  rw [show (-x) = aeval x (-X : ℤ[X]) by simp, ← aeval_comp, hermite_comp_neg_X]
+  simp
 
 end Polynomial

--- a/Mathlib/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Polynomial
+public import Mathlib.Analysis.Complex.TaylorSeries
+public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+public import Mathlib.RingTheory.Polynomial.Hermite.Basic
+
+/-!
+# The exponential generating function of the Hermite polynomials
+
+This file proves the classical exponential generating function of the probabilists' Hermite
+polynomials,
+
+  `∑' n, Hₙ(x) * tⁿ / n ! = exp (x * t - t ^ 2 / 2)`.
+
+## Main results
+
+* `Polynomial.hasSum_hermite_generating_function`: the complex `HasSum` form, which carries the
+  summability of the series and holds for all complex `x` and `t`.
+* `Polynomial.hermite_generating_function`: the real `tsum` form, obtained from the complex
+  statement by casting.
+
+## Proof outline
+
+Fix `x : ℂ` and consider the entire function `f z = exp (x * z - z ^ 2 / 2)`. A short induction
+on `n`, using only the chain rule and the defining recursion
+`hermite (n + 1) = X * hermite n - derivative (hermite n)`, evaluates its iterated derivatives
+in closed form,
+
+  `iteratedDeriv n f z = Hₙ(x - z) * f z`,
+
+so at the base point `z = 0` (where `f 0 = 1`) we get `iteratedDeriv n f 0 = Hₙ(x)`. Since `f`
+is complex differentiable everywhere, `Complex.hasSum_taylorSeries_of_entire` says `f` equals
+its Taylor series about `0` at every point, which is exactly the generating function identity
+at an arbitrary complex `t`.
+
+## References
+
+* [Hermite Polynomials](https://en.wikipedia.org/wiki/Hermite_polynomials)
+-/
+
+public section
+
+namespace Polynomial
+
+open Complex
+
+/-- Derivative of the entire function `z ↦ exp (x * z - z ^ 2 / 2)`: its value at `z` times
+`x - z`. -/
+private theorem hasDerivAt_cexp_quadratic (x z : ℂ) :
+    HasDerivAt (fun w : ℂ => Complex.exp (x * w - w ^ 2 / 2))
+      (Complex.exp (x * z - z ^ 2 / 2) * (x - z)) z := by
+  have hu : HasDerivAt (fun w : ℂ => x * w - w ^ 2 / 2) (x - z) z := by
+    have h1 : HasDerivAt (fun w : ℂ => x * w) (x * 1) z :=
+      (hasDerivAt_id z).const_mul _
+    have h2 := (hasDerivAt_pow 2 z).div_const (2 : ℂ)
+    have hv : x * 1 - ((2 : ℕ) : ℂ) * z ^ (2 - 1) / 2 = x - z := by
+      have he : (2 : ℕ) - 1 = 1 := rfl
+      rw [he, pow_one]
+      push_cast
+      ring
+    have h3 := h1.sub h2
+    rw [hv] at h3
+    exact h3
+  exact hu.cexp
+
+/-- Closed form for the iterated derivatives of `z ↦ exp (x * z - z ^ 2 / 2)`: the `n`-th
+derivative at `z` is `Hₙ(x - z)` times the function value, proved by induction on `n` from the
+defining recursion `hermite (n + 1) = X * hermite n - derivative (hermite n)`. -/
+private theorem iteratedDeriv_cexp_quadratic (x : ℂ) (n : ℕ) (z : ℂ) :
+    iteratedDeriv n (fun w : ℂ => Complex.exp (x * w - w ^ 2 / 2)) z
+      = aeval (x - z) (hermite n) * Complex.exp (x * z - z ^ 2 / 2) := by
+  induction n generalizing z with
+  | zero => simp [iteratedDeriv_zero, hermite_zero]
+  | succ n ih =>
+    have hfun : iteratedDeriv n (fun w : ℂ => Complex.exp (x * w - w ^ 2 / 2))
+        = fun z : ℂ => aeval (x - z) (hermite n) * Complex.exp (x * z - z ^ 2 / 2) :=
+      _root_.funext ih
+    have hP : HasDerivAt (fun z : ℂ => aeval (x - z) (hermite n))
+        (-aeval (x - z) (derivative (hermite n))) z := by
+      have h1 : HasDerivAt (fun w : ℂ => x - w) (-1) z := by
+        simpa using (hasDerivAt_id z).const_sub x
+      have h3 := ((hermite n).hasDerivAt_aeval (x - z)).comp z h1
+      simpa [Function.comp_def, mul_neg_one] using h3
+    have hHD : HasDerivAt (iteratedDeriv n (fun w : ℂ => Complex.exp (x * w - w ^ 2 / 2)))
+        (-aeval (x - z) (derivative (hermite n)) * Complex.exp (x * z - z ^ 2 / 2)
+          + aeval (x - z) (hermite n) * (Complex.exp (x * z - z ^ 2 / 2) * (x - z))) z := by
+      rw [hfun]
+      exact hP.mul (hasDerivAt_cexp_quadratic x z)
+    rw [iteratedDeriv_succ, hHD.deriv, hermite_succ]
+    simp only [map_sub, map_mul, aeval_X]
+    ring
+
+/-- **Exponential generating function of the probabilists' Hermite polynomials**, summable form:
+for all complex `x` and `t`, the family `Hₙ(x) * tⁿ / n !` is summable with sum
+`exp (x * t - t ^ 2 / 2)`, where `Hₙ = Polynomial.hermite n`.
+
+This form carries the summability that the `tsum` form
+`Polynomial.hermite_generating_function` discards, and it holds over all of `ℂ`. -/
+theorem hasSum_hermite_generating_function (x t : ℂ) :
+    HasSum (fun n : ℕ => aeval x (hermite n) * t ^ n / (n.factorial : ℂ))
+      (Complex.exp (x * t - t ^ 2 / 2)) := by
+  -- The entire function `f z = exp (x * z - z ^ 2 / 2)` on the complex plane.
+  set f : ℂ → ℂ := fun z => Complex.exp (x * z - z ^ 2 / 2) with hf_def
+  have hf_diff : Differentiable ℂ f := by
+    rw [hf_def]
+    exact fun z => (hasDerivAt_cexp_quadratic x z).differentiableAt
+  -- Evaluating the iterated-derivative closed form at `z = 0` gives
+  -- `iteratedDeriv n f 0 = Hₙ(x)`.
+  have hval : ∀ n : ℕ, iteratedDeriv n f 0 = aeval x (hermite n) := by
+    intro n
+    rw [hf_def, iteratedDeriv_cexp_quadratic]
+    simp
+  -- `f` equals its Taylor series about `0`; specialize at `t`.
+  have htaylor := hasSum_taylorSeries_of_entire hf_diff 0 t
+  -- Rewrite the Taylor terms into the generating-function terms.
+  have hfun_eq :
+      (fun n : ℕ => (n.factorial : ℂ)⁻¹ • (t - 0) ^ n • iteratedDeriv n f 0)
+        = fun n : ℕ => aeval x (hermite n) * t ^ n / (n.factorial : ℂ) := by
+    funext n
+    rw [hval n]
+    simp only [sub_zero, smul_eq_mul]
+    ring
+  -- The value of `f` at `t` is the exponential on the right-hand side.
+  have hft : f t = Complex.exp (x * t - t ^ 2 / 2) := by rw [hf_def]
+  rw [hfun_eq, hft] at htaylor
+  exact htaylor
+
+/-- **Exponential generating function of the probabilists' Hermite polynomials**: for all real
+`x` and `t`,
+
+  `∑' n, Hₙ(x) * tⁿ / n ! = exp (x * t - t ^ 2 / 2)`,
+
+where `Hₙ = Polynomial.hermite n`. This is the real specialization of
+`Polynomial.hasSum_hermite_generating_function`. -/
+theorem hermite_generating_function (x t : ℝ) :
+    ∑' n : ℕ, aeval x (hermite n) * t ^ n / (n.factorial : ℝ)
+      = Real.exp (x * t - t ^ 2 / 2) := by
+  -- Compatibility of `aeval` with the coercion `ℝ → ℂ`.
+  have hcast_aeval : ∀ n : ℕ, ((aeval x (hermite n) : ℝ) : ℂ) = aeval (x : ℂ) (hermite n) := by
+    intro n
+    have h : (algebraMap ℤ ℂ).comp (RingHom.id ℤ) = (algebraMap ℝ ℂ).comp (algebraMap ℤ ℝ) := by
+      ext k; simp
+    simpa [Polynomial.map_id, Complex.coe_algebraMap] using
+      map_aeval_eq_aeval_map h (hermite n) x
+  -- Cast the complex `HasSum` down to `ℝ`, then read off the `tsum`.
+  have hsum : HasSum (fun n : ℕ => aeval x (hermite n) * t ^ n / (n.factorial : ℝ))
+      (Real.exp (x * t - t ^ 2 / 2)) := by
+    rw [← Complex.hasSum_ofReal]
+    have hterm : ∀ n : ℕ,
+        ((aeval x (hermite n) * t ^ n / (n.factorial : ℝ) : ℝ) : ℂ)
+          = aeval (x : ℂ) (hermite n) * (t : ℂ) ^ n / (n.factorial : ℂ) := by
+      intro n
+      rw [← hcast_aeval n]
+      push_cast
+      ring
+    have hexp : ((Real.exp (x * t - t ^ 2 / 2) : ℝ) : ℂ)
+        = Complex.exp ((x : ℂ) * (t : ℂ) - (t : ℂ) ^ 2 / 2) := by
+      rw [Complex.ofReal_exp]
+      congr 1
+      push_cast
+      ring
+    simp only [hterm, hexp]
+    exact hasSum_hermite_generating_function (x : ℂ) (t : ℂ)
+  exact hsum.tsum_eq
+
+end Polynomial

--- a/Mathlib/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Analysis.Calculus.Deriv.Polynomial
 public import Mathlib.Analysis.Complex.TaylorSeries
-public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 public import Mathlib.RingTheory.Polynomial.Hermite.Basic
 
 /-!
@@ -22,8 +21,9 @@ polynomials,
 
 * `Polynomial.hasSum_hermite_generating_function`: the complex `HasSum` form, which carries the
   summability of the series and holds for all complex `x` and `t`.
-* `Polynomial.hermite_generating_function`: the real `tsum` form, obtained from the complex
-  statement by casting.
+* `Polynomial.hasSum_hermite_generating_function_real` and
+  `Polynomial.hermite_generating_function`: the real `HasSum` and `tsum` forms, obtained from the
+  complex statement by casting.
 
 ## Proof outline
 
@@ -48,7 +48,7 @@ public section
 
 namespace Polynomial
 
-open Complex
+open Complex Nat
 
 /-- Derivative of the entire function `z ↦ exp (x * z - z ^ 2 / 2)`: its value at `z` times
 `x - z`. -/
@@ -56,17 +56,7 @@ private theorem hasDerivAt_cexp_quadratic (x z : ℂ) :
     HasDerivAt (fun w : ℂ => Complex.exp (x * w - w ^ 2 / 2))
       (Complex.exp (x * z - z ^ 2 / 2) * (x - z)) z := by
   have hu : HasDerivAt (fun w : ℂ => x * w - w ^ 2 / 2) (x - z) z := by
-    have h1 : HasDerivAt (fun w : ℂ => x * w) (x * 1) z :=
-      (hasDerivAt_id z).const_mul _
-    have h2 := (hasDerivAt_pow 2 z).div_const (2 : ℂ)
-    have hv : x * 1 - ((2 : ℕ) : ℂ) * z ^ (2 - 1) / 2 = x - z := by
-      have he : (2 : ℕ) - 1 = 1 := rfl
-      rw [he, pow_one]
-      push_cast
-      ring
-    have h3 := h1.sub h2
-    rw [hv] at h3
-    exact h3
+    simpa using ((hasDerivAt_id z).const_mul x).fun_sub ((hasDerivAt_pow 2 z).div_const 2)
   exact hu.cexp
 
 /-- Closed form for the iterated derivatives of `z ↦ exp (x * z - z ^ 2 / 2)`: the `n`-th
@@ -100,10 +90,9 @@ private theorem iteratedDeriv_cexp_quadratic (x : ℂ) (n : ℕ) (z : ℂ) :
 for all complex `x` and `t`, the family `Hₙ(x) * tⁿ / n !` is summable with sum
 `exp (x * t - t ^ 2 / 2)`, where `Hₙ = Polynomial.hermite n`.
 
-This form carries the summability that the `tsum` form
-`Polynomial.hermite_generating_function` discards, and it holds over all of `ℂ`. -/
+This form carries the summability that a `tsum` equality discards, and it holds over all of `ℂ`. -/
 theorem hasSum_hermite_generating_function (x t : ℂ) :
-    HasSum (fun n : ℕ => aeval x (hermite n) * t ^ n / (n.factorial : ℂ))
+    HasSum (fun n : ℕ => aeval x (hermite n) * t ^ n / (n ! : ℂ))
       (Complex.exp (x * t - t ^ 2 / 2)) := by
   -- The entire function `f z = exp (x * z - z ^ 2 / 2)` on the complex plane.
   set f : ℂ → ℂ := fun z => Complex.exp (x * z - z ^ 2 / 2) with hf_def
@@ -120,8 +109,8 @@ theorem hasSum_hermite_generating_function (x t : ℂ) :
   have htaylor := hasSum_taylorSeries_of_entire hf_diff 0 t
   -- Rewrite the Taylor terms into the generating-function terms.
   have hfun_eq :
-      (fun n : ℕ => (n.factorial : ℂ)⁻¹ • (t - 0) ^ n • iteratedDeriv n f 0)
-        = fun n : ℕ => aeval x (hermite n) * t ^ n / (n.factorial : ℂ) := by
+      (fun n : ℕ => (n ! : ℂ)⁻¹ • (t - 0) ^ n • iteratedDeriv n f 0)
+        = fun n : ℕ => aeval x (hermite n) * t ^ n / (n ! : ℂ) := by
     funext n
     rw [hval n]
     simp only [sub_zero, smul_eq_mul]
@@ -131,6 +120,34 @@ theorem hasSum_hermite_generating_function (x t : ℂ) :
   rw [hfun_eq, hft] at htaylor
   exact htaylor
 
+/-- **Exponential generating function of the probabilists' Hermite polynomials**, real summable
+form: for all real `x` and `t`, the family `Hₙ(x) * tⁿ / n !` is summable with sum
+`exp (x * t - t ^ 2 / 2)`. -/
+theorem hasSum_hermite_generating_function_real (x t : ℝ) :
+    HasSum (fun n : ℕ => aeval x (hermite n) * t ^ n / (n ! : ℝ))
+      (Real.exp (x * t - t ^ 2 / 2)) := by
+  -- Compatibility of `aeval` with the coercion `ℝ → ℂ`.
+  have hcast_aeval : ∀ n : ℕ, ((aeval x (hermite n) : ℝ) : ℂ) = aeval (x : ℂ) (hermite n) := by
+    intro n
+    exact (aeval_algHom_apply Complex.ofRealHom.toIntAlgHom x (hermite n)).symm
+  -- Cast the complex `HasSum` down to `ℝ`.
+  rw [← Complex.hasSum_ofReal]
+  have hterm : ∀ n : ℕ,
+      ((aeval x (hermite n) * t ^ n / (n ! : ℝ) : ℝ) : ℂ)
+        = aeval (x : ℂ) (hermite n) * (t : ℂ) ^ n / (n ! : ℂ) := by
+    intro n
+    rw [← hcast_aeval n]
+    push_cast
+    ring
+  have hexp : ((Real.exp (x * t - t ^ 2 / 2) : ℝ) : ℂ)
+      = Complex.exp ((x : ℂ) * (t : ℂ) - (t : ℂ) ^ 2 / 2) := by
+    rw [Complex.ofReal_exp]
+    congr 1
+    push_cast
+    ring
+  simp only [hterm, hexp]
+  exact hasSum_hermite_generating_function (x : ℂ) (t : ℂ)
+
 /-- **Exponential generating function of the probabilists' Hermite polynomials**: for all real
 `x` and `t`,
 
@@ -139,34 +156,8 @@ theorem hasSum_hermite_generating_function (x t : ℂ) :
 where `Hₙ = Polynomial.hermite n`. This is the real specialization of
 `Polynomial.hasSum_hermite_generating_function`. -/
 theorem hermite_generating_function (x t : ℝ) :
-    ∑' n : ℕ, aeval x (hermite n) * t ^ n / (n.factorial : ℝ)
+    ∑' n : ℕ, aeval x (hermite n) * t ^ n / (n ! : ℝ)
       = Real.exp (x * t - t ^ 2 / 2) := by
-  -- Compatibility of `aeval` with the coercion `ℝ → ℂ`.
-  have hcast_aeval : ∀ n : ℕ, ((aeval x (hermite n) : ℝ) : ℂ) = aeval (x : ℂ) (hermite n) := by
-    intro n
-    have h : (algebraMap ℤ ℂ).comp (RingHom.id ℤ) = (algebraMap ℝ ℂ).comp (algebraMap ℤ ℝ) := by
-      ext k; simp
-    simpa [Polynomial.map_id, Complex.coe_algebraMap] using
-      map_aeval_eq_aeval_map h (hermite n) x
-  -- Cast the complex `HasSum` down to `ℝ`, then read off the `tsum`.
-  have hsum : HasSum (fun n : ℕ => aeval x (hermite n) * t ^ n / (n.factorial : ℝ))
-      (Real.exp (x * t - t ^ 2 / 2)) := by
-    rw [← Complex.hasSum_ofReal]
-    have hterm : ∀ n : ℕ,
-        ((aeval x (hermite n) * t ^ n / (n.factorial : ℝ) : ℝ) : ℂ)
-          = aeval (x : ℂ) (hermite n) * (t : ℂ) ^ n / (n.factorial : ℂ) := by
-      intro n
-      rw [← hcast_aeval n]
-      push_cast
-      ring
-    have hexp : ((Real.exp (x * t - t ^ 2 / 2) : ℝ) : ℂ)
-        = Complex.exp ((x : ℂ) * (t : ℂ) - (t : ℂ) ^ 2 / 2) := by
-      rw [Complex.ofReal_exp]
-      congr 1
-      push_cast
-      ring
-    simp only [hterm, hexp]
-    exact hasSum_hermite_generating_function (x : ℂ) (t : ℂ)
-  exact hsum.tsum_eq
+  exact (hasSum_hermite_generating_function_real x t).tsum_eq
 
 end Polynomial


### PR DESCRIPTION
This PR adds the classical derivative identities, three-term recurrence, parity, and exponential generating function for the probabilists' Hermite polynomials. The algebraic results include `derivative_hermite`, `iterate_derivative_hermite`, `hermite_add_two`, and polynomial and evaluated forms of parity; the analytic results prove `∑' n, Hₙ(x) * tⁿ / n! = exp (x * t - t² / 2)` in complex and real `HasSum` forms, with a real `tsum` corollary. The algebraic and analytic developments live in separate files.

This contribution originated in the [Tau Ceti project](https://github.com/TauCetiProject/TauCeti), an AI-written mathematics repository; it was adapted for Mathlib with Claude Code and reviewed with OpenAI Codex, supervised by Kim Morrison.

:robot: Prepared with OpenAI Codex
