### PR TITLE
[Merged by Bors] - chore: remove AI tools from Authors lines

### DIFF
--- a/Mathlib/Analysis/Complex/Harmonic/Poisson.lean
+++ b/Mathlib/Analysis/Complex/Harmonic/Poisson.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Stefan Kebekus. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mihai Iancu, Stefan Kebekus, Sebastian Schleissinger, Aristotle AI
+Authors: Mihai Iancu, Stefan Kebekus, Sebastian Schleissinger
 -/
 module
 

--- a/Mathlib/Analysis/Complex/Poisson.lean
+++ b/Mathlib/Analysis/Complex/Poisson.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Stefan Kebekus. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mihai Iancu, Stefan Kebekus, Sebastian Schleissinger, Aristotle AI
+Authors: Mihai Iancu, Stefan Kebekus, Sebastian Schleissinger
 -/
 module
 

--- a/Mathlib/Analysis/Complex/Polynomial/GaussLucas.lean
+++ b/Mathlib/Analysis/Complex/Polynomial/GaussLucas.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yury Kudryashov, Aristotle AI
+Authors: Yury Kudryashov
 -/
 module
 

--- a/Mathlib/Analysis/Meromorphic/LogDeriv.lean
+++ b/Mathlib/Analysis/Meromorphic/LogDeriv.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Stefan Kebekus. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Stefan Kebekus using Claude Code
+Authors: Stefan Kebekus
 -/
 module
 

--- a/Mathlib/LinearAlgebra/Matrix/Nonsingular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Nonsingular.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Junyan Xu. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Junyan Xu, Aristotle AI
+Authors: Junyan Xu
 -/
 module
 

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/E2/MDifferentiable.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/E2/MDifferentiable.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chris Birkbeck, Gauss AI (Math Inc)
+Authors: Chris Birkbeck
 -/
 
 module

--- a/Mathlib/Topology/WithTopology.lean
+++ b/Mathlib/Topology/WithTopology.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yury Kudryashov, Gemini CLI
+Authors: Yury Kudryashov
 -/
 module
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1186,7 +1186,7 @@ Q1008566:
   decls:
     - Polynomial.rootSet_derivative_subset_convexHull_rootSet
     - Polynomial.eq_centerMass_of_eval_derivative_eq_zero
-  authors: Yury Kudryashov, Aristotle AI
+  authors: Yury Kudryashov
 
 Q1032886:
   title: Hales–Jewett theorem


### PR DESCRIPTION
This PR removes AI tools and services from the `Authors:` lines of copyright headers, and from the one corresponding `docs/1000.yaml` entry.

The [style guide](https://leanprover-community.github.io/contribute/style.html) describes the `Authors` line as listing "the people ... we would reach out to if we had questions about the design or development of the Lean code". An AI tool cannot answer those questions; the human who ran it can, and remains the person accountable for the code. Disclosure of AI use belongs in the PR description, which the [use of AI](https://leanprover-community.github.io/contribute/index.html#use-of-ai) guidelines already require, and each of these PRs did that.

The lines changed are `Stefan Kebekus using Claude Code`, `Aristotle AI` (four files), `Gauss AI (Math Inc)`, and `Gemini CLI`. No human author is removed anywhere.

🤖 Prepared with Claude Code
