### PR TITLE
chore(Probability/ProbabilityMassFunction): remove defeq option in Monad

### DIFF
--- a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
@@ -243,7 +243,6 @@ theorem pure_bindOnSupport (a : α) (f : ∀ (a' : α) (_ : a' ∈ (pure a).supp
 theorem bindOnSupport_pure (p : PMF α) : (p.bindOnSupport fun a _ => pure a) = p := by
   simp only [PMF.bind_pure, PMF.bindOnSupport_eq_bind]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem bindOnSupport_bindOnSupport (p : PMF α) (f : ∀ a ∈ p.support, PMF β)
     (g : ∀ b ∈ (p.bindOnSupport f).support, PMF γ) :
@@ -255,13 +254,25 @@ theorem bindOnSupport_bindOnSupport (p : PMF α) (f : ∀ a ∈ p.support, PMF �
   dsimp only [bindOnSupport_apply]
   simp only [← tsum_dite_right, ENNReal.tsum_mul_left.symm, ENNReal.tsum_mul_right.symm]
   classical
-  simp only [ENNReal.tsum_eq_zero]
   refine ENNReal.tsum_comm.trans (tsum_congr fun a' => tsum_congr fun b => ?_)
-  split_ifs with h _ h_1 H h_2
+  split_ifs with h _ h_1
   any_goals ring1
-  · absurd H
-    simpa [h] using h_1 a'
-  · simp [h_2]
+  · have hf0 := ENNReal.tsum_eq_zero.mp h_1 a'
+    rw [dite_eq_right h, mul_eq_zero, or_iff_right h] at hf0
+    trans (0 : ℝ≥0∞)
+    · exact mul_eq_zero_of_right _ (dite_eq_left h_1)
+    · exact (mul_eq_zero_of_right _ (mul_eq_zero_of_left hf0 _)).symm
+  · rcases eq_or_ne (f a' h b) 0 with hf0 | hf0
+    · trans (0 : ℝ≥0∞)
+      · exact mul_eq_zero_of_left (mul_eq_zero_of_right _ hf0) _
+      · exact (mul_eq_zero_of_right _ (mul_eq_zero_of_left hf0 _)).symm
+    · have hD₁ : (if h : (∑' (a : α), p a * if h : p a = 0 then 0 else f a h b) = 0 then 0
+          else g b h a) = g b h_1 a := dite_eq_right h_1
+      have hD₂ : (if h2 : f a' h b = 0 then 0
+          else g b ((mem_support_bindOnSupport_iff f b).mpr ⟨a', h, h2⟩) a) = g b h_1 a :=
+        dite_eq_right hf0
+      refine (congrArg (p a' * f a' h b * ·) hD₁).trans ((mul_assoc _ _ _).trans ?_)
+      exact congrArg (p a' * ·) (congrArg (f a' h b * ·) hD₂.symm)
 
 theorem bindOnSupport_comm (p : PMF α) (q : PMF β) (f : ∀ a ∈ p.support, ∀ b ∈ q.support, PMF γ) :
     (p.bindOnSupport fun a ha => q.bindOnSupport (f a ha)) =


### PR DESCRIPTION
Remove the `set_option backward.isDefEq.respectTransparency` false in `Mathlib/Probability/ProbabilityMassFunction/Monad.lean`, on `bindOnSupport_bindOnSupport`. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
