### PR TITLE
[Merged by Bors] - chore(Order/Interval): define `Unique (Iic 0)` directly, drop a defeq option in Traj

### DIFF
--- a/Mathlib/Order/Interval/Finset/Nat.lean
+++ b/Mathlib/Order/Interval/Finset/Nat.lean
@@ -41,9 +41,9 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder ℕ where
   finset_mem_Ioc a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; lia
   finset_mem_Ioo a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; lia
 
-instance : Unique (Iic 0) := by
-  rw [← Nat.bot_eq_zero]
-  infer_instance
+instance : Unique (Iic 0) where
+  default := ⟨0, by simp⟩
+  uniq a := Subtype.ext (Nat.le_zero.1 (mem_Iic.1 a.2))
 
 theorem Icc_eq_range' : Icc a b = ⟨List.range' a (b + 1 - a), List.nodup_range'⟩ :=
   rfl

--- a/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
@@ -766,7 +766,6 @@ def trajMeasure (μ₀ : Measure (X 0)) (κ : (n : ℕ) → Kernel (Π i : Iic n
 
 variable {μ₀ : Measure (X 0)} [IsProbabilityMeasure μ₀]
 
-set_option backward.isDefEq.respectTransparency false in
 instance : IsProbabilityMeasure (trajMeasure μ₀ κ) := by
   rw [trajMeasure]
   have : IsProbabilityMeasure (μ₀.map (MeasurableEquiv.piUnique ((fun i : Iic 0 ↦ X i))).symm) :=


### PR DESCRIPTION
The instance `Unique (Iic (0 : ℕ))` was defined by `rw [← Nat.bot_eq_zero]; infer_instance`, which hides `default` behind a cast, so `↑(default : Iic 0)` does not reduce to `0`. Defining the instance directly fixes this, and allows to remove the `set_option backward.isDefEq.respectTransparency` in `Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
