### PR TITLE
[Merged by Bors] - chore(Tactic): mark two runtime-only imports as `shake: keep`

### DIFF
--- a/Mathlib/Tactic/AddGroup.lean
+++ b/Mathlib/Tactic/AddGroup.lean
@@ -5,7 +5,7 @@ Authors: Kevin Buzzard
 -/
 module
 
-public import Mathlib.Tactic.Group
+public import Mathlib.Tactic.Group  -- shake: keep (tactic dependency: `_zsmul_trick` lemmas)
 
 /-!
 # `add_group` tactic

--- a/Mathlib/Tactic/AddGroup.lean
+++ b/Mathlib/Tactic/AddGroup.lean
@@ -5,7 +5,8 @@ Authors: Kevin Buzzard
 -/
 module
 
-public import Mathlib.Tactic.Group  -- shake: keep (tactic dependency: `_zsmul_trick` lemmas)
+public import Mathlib.Tactic.Group  -- shake: keep
+-- tactic dependency: `addCommutatorElement_def`, `_zsmul_trick` lemmas
 
 /-!
 # `add_group` tactic

--- a/Mathlib/Tactic/Algebra/Basic.lean
+++ b/Mathlib/Tactic/Algebra/Basic.lean
@@ -7,7 +7,7 @@ module
 
 public meta import Lean.Meta.Tactic.NormCast
 public import Mathlib.Tactic.Algebra.Lemmas  -- shake: keep (Qq output dependency)
-public import Mathlib.Tactic.Ring.RingNF
+public import Mathlib.Tactic.Ring.RingNF  -- shake: keep (`initialize`s `Ring.ringCleanupRef`)
 
 /-!
 # The `algebra` tactic


### PR DESCRIPTION
`shake` cannot see either of these dependencies, and removed both in #40343, which broke `MathlibTest.Tactic.AddGroup` and `MathlibTest.Tactic.Algebra`:

* `Mathlib/Tactic/AddGroup.lean`: the `add_group` macro expands to a `simp only` naming `addCommutatorElement_def` and the `Mathlib.Tactic.Group._zsmul_trick*` lemmas, all of which come from `Mathlib.Tactic.Group`. Since the names occur inside a syntax quotation, no constant reference is left for `shake` to find.
* `Mathlib/Tactic/Algebra/Basic.lean`: `Ring.ringCleanupRef` is declared in `Mathlib.Tactic.Ring.Basic` but only populated by an `initialize` block in `Mathlib.Tactic.Ring.RingNF`, so without that import `algebra`'s error messages leak `Nat.rawCast` and friends.

Generated with Claude code

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
