### PR TITLE
[Merged by Bors] - feat(RingTheory/Bialgebra): expose (Add)MonoidAlgebra.liftMulEquiv

### DIFF
--- a/Mathlib/RingTheory/Bialgebra/MonoidAlgebra.lean
+++ b/Mathlib/RingTheory/Bialgebra/MonoidAlgebra.lean
@@ -187,6 +187,7 @@ variable [Algebra R A] [Monoid M]
 
 variable (R M A) in
 /-- `MonoidAlgebra.lift` as a `MulEquiv`. -/
+@[expose, simps!]
 def liftMulEquiv : (M →* A) ≃* WithConv (R[M] →ₐ[R] A) where
   toEquiv := (lift R A M).trans (WithConv.equiv _).symm
   map_mul' f g := by ext; simp [AlgHom.convMul_apply]
@@ -381,6 +382,7 @@ variable [CommSemiring A] [Algebra R A] [AddMonoid M]
 
 variable (R M A) in
 /-- `AddMonoidAlgebra.lift` as a `MulEquiv`. -/
+@[expose, simps!]
 def liftMulEquiv : (Multiplicative M →* A) ≃* WithConv (R[M] →ₐ[R] A) where
   toEquiv := (lift R A M).trans (WithConv.equiv _).symm
   map_mul' f g := by ext; simp [AlgHom.convMul_apply]


### PR DESCRIPTION
This PR marks `MonoidAlgebra.liftMulEquiv` and `AddMonoidAlgebra.liftMulEquiv`
`@[expose, simps!]`, matching `mapDomainBialgHomMulEquiv` in the same file, which
is built the same way out of an equivalence composed with `WithConv.equiv` and
already carries both attributes. Without them the definitions are opaque
downstream: their bodies cannot be unfolded, and no lemma computes their
application or the application of their inverse, so `liftMulEquiv` cannot be
related to `lift` outside this file.

🤖 Prepared with Claude Code