### PR TITLE
[Merged by Bors] - chore(Algebra/QuadraticAlgebra): rename map/mapEquiv to changeGenerator

### DIFF
--- a/Mathlib/Algebra/QuadraticAlgebra/Basic.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Basic.lean
@@ -21,8 +21,9 @@ Let `R` be a commutative ring. We define:
 
 * `QuadraticAlgebra.trace`: the trace, as an `R`-linear map
 
-* `QuadraticAlgebra.map` and `QuadraticAlgebra.mapEquiv`: the `R`-algebra map, respectively
-  isomorphism (when `u` is a unit), induced by the change of generator `ω ↦ u • ω + k`
+* `QuadraticAlgebra.changeGenerator` and `QuadraticAlgebra.changeGeneratorEquiv`: the `R`-algebra
+  map, respectively isomorphism (when `u` is a unit), induced by the change of generator
+  `ω ↦ u • ω + k`
 
 We prove:
 
@@ -380,54 +381,62 @@ theorem sq_eq_trace_smul_sub_norm :
 
 end trace
 
-section map
+section changeGenerator
 
 variable [CommRing R]
 
 -- The quadratic relation satisfied by the new generator `u • ω + k`; this is what makes
--- `map` well defined. Stated with `x * x` rather than `x ^ 2` to match the shape of the
--- subtype condition of `lift` (`{ u // u * u = a • 1 + b • u }`), so it feeds `map` verbatim.
-private theorem map_relation (a b u k : R) :
+-- `changeGenerator` well defined. Stated with `x * x` rather than `x ^ 2` to match the shape of
+-- the subtype condition of `lift` (`{ u // u * u = a • 1 + b • u }`), so it feeds
+-- `changeGenerator` verbatim.
+private theorem changeGenerator_relation (a b u k : R) :
     (u • ω + algebraMap R (QuadraticAlgebra R a b) k) *
         (u • ω + algebraMap R (QuadraticAlgebra R a b) k) =
       (u ^ 2 * a - u * b * k - k ^ 2) • 1 +
         (u * b + 2 * k) • (u • ω + algebraMap R (QuadraticAlgebra R a b) k) := by
   ext <;> simp <;> ring
 
-/-- The `R`-algebra map induced by the change of generator `ω ↦ u • ω + k`, see `map_omega`. -/
+/-- The `R`-algebra map induced by the change of generator `ω ↦ u • ω + k`, see
+`changeGenerator_omega`. -/
 @[simps!]
-def map (a b u k : R) {a' b' : R} (ha : a' = u ^ 2 * a - u * b * k - k ^ 2)
+def changeGenerator (a b u k : R) {a' b' : R} (ha : a' = u ^ 2 * a - u * b * k - k ^ 2)
     (hb : b' = u * b + 2 * k) :
     QuadraticAlgebra R a' b' →ₐ[R] QuadraticAlgebra R a b :=
-  lift ⟨u • ω + algebraMap R _ k, by rw [ha, hb]; exact map_relation a b u k⟩
+  lift ⟨u • ω + algebraMap R _ k, by rw [ha, hb]; exact changeGenerator_relation a b u k⟩
 
 @[simp]
-theorem map_omega (a b u k : R) {a' b' : R} (ha : a' = u ^ 2 * a - u * b * k - k ^ 2)
+theorem changeGenerator_omega (a b u k : R) {a' b' : R} (ha : a' = u ^ 2 * a - u * b * k - k ^ 2)
     (hb : b' = u * b + 2 * k) :
-    map a b u k ha hb ω = u • ω + algebraMap R (QuadraticAlgebra R a b) k := by
+    changeGenerator a b u k ha hb ω = u • ω + algebraMap R (QuadraticAlgebra R a b) k := by
   ext <;> simp
 
-theorem map_injective (a b u k : R) {a' b' : R} (ha : a' = u ^ 2 * a - u * b * k - k ^ 2)
+theorem changeGenerator_injective (a b u k : R) {a' b' : R}
+    (ha : a' = u ^ 2 * a - u * b * k - k ^ 2)
     (hb : b' = u * b + 2 * k) (hu : IsRegular u) :
-    Function.Injective (map a b u k ha hb) := by
+    Function.Injective (changeGenerator a b u k ha hb) := by
   intro z w h
   have hy : z.im = w.im := hu.right <| by simpa using congr_arg im h
   exact QuadraticAlgebra.ext (by simpa [hy] using congr_arg re h) hy
 
-/-- `map` along a unit `u`, as an isomorphism. -/
+/-- `changeGenerator` along a unit `u`, as an isomorphism. -/
 @[simps! apply symm_apply]
-def mapEquiv (a b : R) (u : Rˣ) (k : R) {a' b' : R}
+def changeGeneratorEquiv (a b : R) (u : Rˣ) (k : R) {a' b' : R}
     (ha : a' = (u : R) ^ 2 * a - (u : R) * b * k - k ^ 2)
     (hb : b' = (u : R) * b + 2 * k) :
     QuadraticAlgebra R a' b' ≃ₐ[R] QuadraticAlgebra R a b where
-  __ := map a b u k ha hb
-  invFun := map a' b' (u⁻¹ : Rˣ) (-(u⁻¹ : Rˣ) * k)
+  __ := changeGenerator a b u k ha hb
+  invFun := changeGenerator a' b' (u⁻¹ : Rˣ) (-(u⁻¹ : Rˣ) * k)
     (by grind [sq, mul_assoc, Units.inv_mul_cancel_left])
     (by grind [Units.inv_mul_cancel_left])
   left_inv _ := by ext <;> simp [mul_assoc]
   right_inv _ := by ext <;> simp [mul_assoc]
 
-end map
+@[deprecated (since := "2026-08-14")] alias map := changeGenerator
+@[deprecated (since := "2026-08-14")] alias map_omega := changeGenerator_omega
+@[deprecated (since := "2026-08-14")] alias map_injective := changeGenerator_injective
+@[deprecated (since := "2026-08-14")] alias mapEquiv := changeGeneratorEquiv
+
+end changeGenerator
 
 section field
 

--- a/Mathlib/Algebra/QuadraticAlgebra/Discr.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Discr.lean
@@ -20,8 +20,8 @@ over a field, a criterion for `QuadraticAlgebra K a b` to be a field.
 
 ## Main results
 
-* `QuadraticAlgebra.discr_map`: the discriminant scales by `u ^ 2` under the change of
-  generator `ω ↦ u • ω + k`.
+* `QuadraticAlgebra.discr_changeGenerator`: the discriminant scales by `u ^ 2` under the change
+  of generator `ω ↦ u • ω + k`.
 * `QuadraticAlgebra.exists_sq_eq_iff_isSquare_discr`: over a ring with `2` invertible,
   `X ^ 2 - b * X - a` has a root iff `discr a b` is a square.
 * `QuadraticAlgebra.isField_iff_not_isSquare_discr`: over a field with `2 ≠ 0`,
@@ -42,11 +42,13 @@ def discr [CommSemiring R] (a b : R) : R := b ^ 2 + 4 * a
 
 theorem discr_def [CommSemiring R] (a b : R) : discr a b = b ^ 2 + 4 * a := rfl
 
-/-- Under the change of generator `ω ↦ u • ω + k` (see `QuadraticAlgebra.map`), the
+/-- Under the change of generator `ω ↦ u • ω + k` (see `QuadraticAlgebra.changeGenerator`), the
 discriminant is multiplied by `u ^ 2`. -/
-theorem discr_map [CommRing R] (a b u k : R) :
+theorem discr_changeGenerator [CommRing R] (a b u k : R) :
     discr (u ^ 2 * a - u * b * k - k ^ 2) (u * b + 2 * k) = u ^ 2 * discr a b := by
   rw [discr_def, discr_def]; ring
+
+@[deprecated (since := "2026-08-14")] alias discr_map := discr_changeGenerator
 
 /-- The discriminant is the square of the different `ω - star ω`. -/
 theorem algebraMap_discr [CommRing R] (a b : R) :


### PR DESCRIPTION
Turns out `map` was a bad choice, being too general. `changeGenerator` says what the construction actually does. Renames it accordingly.

Prepared with Claude Code 🤖

---