### PR TITLE
[Merged by Bors] - fix(Translate): apply `(attr := ...)` attributes in order of application time

### DIFF
--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -1205,7 +1205,19 @@ partial def applyAttributes (t : TranslateData) (cfg : Config) (src tgt : Name) 
   let allDecls := #[src, tgt] ++ nestedDecls
   if attrs.size > 0 then
     trace[translate_detail] "Applying attributes {attrs.map (·.stx)} to {allDecls}"
+  -- Sort the attributes based on their application time.
+  let mut attrs₁ := #[]
+  let mut attrs₂ := #[]
+  let mut attrs₃ := #[]
   for attr in attrs do
+    match getAttributeImpl (← getEnv) attr.name with
+    | .error errMsg => throwError errMsg
+    | .ok attrImpl =>
+      match attrImpl.applicationTime with
+      | .beforeElaboration => attrs₁ := attrs₁.push attr
+      | .afterTypeChecking => attrs₂ := attrs₂.push attr
+      | .afterCompilation => attrs₃ := attrs₃.push attr
+  for attr in attrs₁ ++ attrs₂ ++ attrs₃ do
     if let some impl := (← generatingAttrs.get).find? attr.name then
       withRef attr.stx do withLogging do
         translateLemmas t allDecls "simps lemmas" cfg

--- a/MathlibTest/Attribute/ToDual.lean
+++ b/MathlibTest/Attribute/ToDual.lean
@@ -455,3 +455,20 @@ structure HasLimitsOfSize where
 @[to_dual]
 structure HasColimitsOfSize where
   cofoo : ∀ _ : Type u, True
+
+-- The `simps` attribute is applied after `implicit_reducible`,
+-- which allows the `simps` lemmas to be `@[defeq]`
+@[to_dual (attr := simps, implicit_reducible) MyLE']
+def MyLE : Preorder α where
+  le := (· ≤ ·)
+  lt := (· < ·)
+  le_refl := le_refl
+  le_trans _ _ _ := le_trans
+  lt_iff_le_not_ge _ _ := lt_iff_le_not_ge
+
+/--
+info: @[defeq] theorem MyLE_le : ∀ {α : Type} [inst : PartialOrder α] (x1 x2 : α), (x1 ≤ x2) = (x1 ≤ x2) :=
+fun {α} [PartialOrder α] x1 x2 => Eq.refl (x1 ≤ x2)
+-/
+#guard_msgs in
+#print MyLE_le


### PR DESCRIPTION
This PR sorts the `(attr := ...)` attributes in `to_additive`/`to_dual` so that they are applied in order of application time. This is consistent with the order in which attributes are applied by lean inside `@[...]` notation.

This is important because `simps` needs to run after `implicit_reducible`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
