### PR TITLE
[Merged by Bors] - chore(NumberTheory/RamificationInertia/Inertia): deprecate `Ideal.inertiaDeg'`

### DIFF
--- a/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.RingTheory.Finiteness.Quotient
 public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
+public import Mathlib.RingTheory.RamificationInertia.Inertia
 
 /-!
 # Ramification index and inertia degree
@@ -32,6 +33,8 @@ We will try to relax the above hypotheses as much as possible.
 In this file, `f` stands for the inertia degree of `P` over `p`, leaving `p` and `P` implicit.
 
 -/
+
+deprecated_module "Use RingTheory.RamificationInertia.Inertia" (since := "2026-08-14")
 
 @[expose] public section
 
@@ -86,6 +89,13 @@ theorem inertiaDeg'_of_subsingleton [hp : p.IsMaximal] [hQ : Subsingleton (S ⧸
 theorem inertiaDeg'_algebraMap [P.LiesOver p] :
     inertiaDeg' p P = finrank (R ⧸ p) (S ⧸ P) := by
   rw [inertiaDeg', dite_eq_left (over_def P p).symm]
+
+@[deprecated "Use `inertiaDeg_eq_of_isMaximal` instead." (since := "2026-08-14")]
+theorem inertiaDeg'_eq_inertiaDeg [P.LiesOver p] [p.IsMaximal] [P.IsMaximal] :
+    p.inertiaDeg' P = P.inertiaDeg R := by
+  rw [inertiaDeg'_algebraMap, inertiaDeg_eq_of_isMaximal p P]
+
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_eq_inertiaDeg' := inertiaDeg'_eq_inertiaDeg
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_algebraMap := inertiaDeg'_algebraMap
 

--- a/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
@@ -89,7 +89,7 @@ theorem inertiaDeg'_algebraMap [P.LiesOver p] :
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_algebraMap := inertiaDeg'_algebraMap
 
-@[deprecated "Use `Ideal.inertiaDeg` instead." (since := "2026-08-14")]
+@[deprecated "Use `Ideal.inertiaDeg_pos` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_pos [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] : 0 < inertiaDeg' p P :=
   have : Nontrivial (S ⧸ P) := Quotient.nontrivial_of_liesOver_of_isPrime P p
   finrank_pos.trans_eq (inertiaDeg'_algebraMap p P).symm

--- a/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
@@ -34,8 +34,6 @@ In this file, `f` stands for the inertia degree of `P` over `p`, leaving `p` and
 
 -/
 
-deprecated_module "Use RingTheory.RamificationInertia.Inertia" (since := "2026-08-14")
-
 @[expose] public section
 
 

--- a/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
@@ -64,6 +64,7 @@ and there is an algebra structure `R / p → S / P`.
 
 Note: This definition of inertia degree will eventually be replaced by `Ideal.inertiaDeg`.
 -/
+@[deprecated "Use `Ideal.inertiaDeg` instead." (since := "2026-08-14")]
 noncomputable def inertiaDeg' : ℕ :=
   if hPp : comap f P = p then
     letI : Algebra (R ⧸ p) (S ⧸ P) := Quotient.algebraQuotientOfLEComap hPp.ge
@@ -71,7 +72,7 @@ noncomputable def inertiaDeg' : ℕ :=
   else 0
 
 -- Useful for the `nontriviality` tactic using `comap_eq_of_scalar_tower_quotient`.
-@[simp]
+@[simp, deprecated "Use `Ideal.inertiaDeg` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_of_subsingleton [hp : p.IsMaximal] [hQ : Subsingleton (S ⧸ P)] :
     inertiaDeg' p P = 0 := by
   have := Ideal.Quotient.subsingleton_iff.mp hQ
@@ -81,30 +82,34 @@ theorem inertiaDeg'_of_subsingleton [hp : p.IsMaximal] [hQ : Subsingleton (S ⧸
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_of_subsingleton :=
   inertiaDeg'_of_subsingleton
 
-@[simp]
+@[simp, deprecated "Use `Ideal.inertiaDeg_eq_of_isMaximal` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_algebraMap [P.LiesOver p] :
     inertiaDeg' p P = finrank (R ⧸ p) (S ⧸ P) := by
   rw [inertiaDeg', dite_eq_left (over_def P p).symm]
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_algebraMap := inertiaDeg'_algebraMap
 
+@[deprecated "Use `Ideal.inertiaDeg` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_pos [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] : 0 < inertiaDeg' p P :=
   have : Nontrivial (S ⧸ P) := Quotient.nontrivial_of_liesOver_of_isPrime P p
   finrank_pos.trans_eq (inertiaDeg'_algebraMap p P).symm
 
 /-- Variant with a weaker constraint, but on the prime upstairs instead. -/
+@[deprecated "Use `Ideal.inertiaDeg_pos` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_pos' [P.IsPrime] [Module.Finite R S] [P.LiesOver p] : 0 < inertiaDeg' p P :=
   have : p.IsPrime := Ideal.over_def P p ▸ inferInstance
   Module.finrank_pos.trans_eq (inertiaDeg'_algebraMap p P).symm
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_pos' := inertiaDeg'_pos'
 
+@[deprecated "Use `Ideal.inertiaDeg_pos` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_ne_zero [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] :
     inertiaDeg' p P ≠ 0 :=
   (Nat.ne_of_lt (inertiaDeg'_pos p P)).symm
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_ne_zero := inertiaDeg'_ne_zero
 
+@[deprecated "Use `Ideal.inertiaDeg` instead." (since := "2026-08-14")]
 lemma inertiaDeg'_comap_eq (e : S ≃ₐ[R] S₁) (P : Ideal S₁) :
     inertiaDeg' p (P.comap e) = inertiaDeg' p P := by
   have he : (P.comap e).comap (algebraMap R S) = p ↔ P.comap (algebraMap R S₁) = p := by
@@ -117,6 +122,7 @@ lemma inertiaDeg'_comap_eq (e : S ≃ₐ[R] S₁) (P : Ideal S₁) :
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_comap_eq := inertiaDeg'_comap_eq
 
+@[deprecated "Use `Ideal.inertiaDeg` instead." (since := "2026-08-14")]
 lemma inertiaDeg'_map_eq (P : Ideal S)
     {E : Type*} [EquivLike E S S₁] [AlgEquivClass E R S S₁] (e : E) :
     inertiaDeg' p (P.map e) = inertiaDeg' p P := by
@@ -125,6 +131,7 @@ lemma inertiaDeg'_map_eq (P : Ideal S)
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_map_eq := inertiaDeg'_map_eq
 
+@[deprecated "Use `Ideal.inertiaDeg` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_bot [Nontrivial R] [IsDomain S] [Algebra.IsIntegral R S]
     [hP : P.LiesOver (⊥ : Ideal R)] :
     (⊥ : Ideal R).inertiaDeg' P = finrank R S := by
@@ -136,6 +143,7 @@ theorem inertiaDeg'_bot [Nontrivial R] [IsDomain S] [Algebra.IsIntegral R S]
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_bot := inertiaDeg'_bot
 
+@[deprecated "Use `Ideal.inertiaDeg_above_le` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_le_inertiaDeg' {T : Type*} [CommRing T] [Algebra R T] [Algebra S T]
     [IsScalarTower R S T] [Module.Finite R T] (Q : Ideal T) [P.LiesOver p] [Q.LiesOver P]
     [p.IsPrime] : inertiaDeg' P Q ≤ inertiaDeg' p Q := by
@@ -152,6 +160,7 @@ end DecEq
 
 section absNorm
 
+@[deprecated "Use `Ideal.absNorm_pow_inertiaDeg` instead." (since := "2026-08-14")]
 lemma absNorm_eq_pow_inertiaDeg'_of_liesOver {S : Type*} [CommRing S] [IsDedekindDomain S]
     [Module.Free ℤ S] [IsDedekindDomain R] [Module.Free ℤ R] [Algebra S R] [Module.Finite S R]
     (P : Ideal R) (p : Ideal S) [P.LiesOver p] (hp : p.IsPrime) (hp_ne_bot : p ≠ ⊥) :
@@ -165,6 +174,7 @@ lemma absNorm_eq_pow_inertiaDeg'_of_liesOver {S : Type*} [CommRing S] [IsDedekin
 /-- The absolute norm of an ideal `P` above a rational prime `p` is
 `|p| ^ ((span {p}).inertiaDeg' P)`.
 See `absNorm_eq_pow_inertiaDeg'` for a version with `p` of type `ℕ`. -/
+@[deprecated "Use `Ideal.natAbs_pow_inertiaDeg` instead." (since := "2026-08-14")]
 lemma absNorm_eq_pow_inertiaDeg [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] {p : ℤ}
     (P : Ideal R) [P.LiesOver (span {p})] (hp : Prime p) :
     absNorm P = p.natAbs ^ ((span {p}).inertiaDeg' P) := by
@@ -174,6 +184,7 @@ lemma absNorm_eq_pow_inertiaDeg [IsDedekindDomain R] [Module.Free ℤ R] [Module
 /-- The absolute norm of an ideal `P` above a rational (positive) prime `p` is
 `p ^ ((span {p}).inertiaDeg' P)`.
 See `absNorm_eq_pow_inertiaDeg` for a version with `p` of type `ℤ`. -/
+@[deprecated "Use `Ideal.natAbs_pow_inertiaDeg` instead." (since := "2026-08-14")]
 lemma absNorm_eq_pow_inertiaDeg' [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] {p : ℕ}
     (P : Ideal R) [P.LiesOver (span {(p : ℤ)})] (hp : p.Prime) :
     absNorm P = p ^ ((span {(p : ℤ)}).inertiaDeg' P) :=
@@ -189,6 +200,7 @@ variable [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
 /-- Let `T / S / R` be a tower of algebras, `p, P, I` be ideals in `R, S, T`, respectively,
   and `p` and `P` are maximal. If `p = P ∩ S` and `P = I ∩ S`,
   then `f (I | p) = f (P | p) * f (I | P)`. -/
+@[deprecated "Use `Ideal.inertiaDeg_tower` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_algebra_tower (p : Ideal R) (P : Ideal S) (I : Ideal T) [p.IsMaximal]
     [P.IsMaximal] [P.LiesOver p] [I.LiesOver P] : inertiaDeg' p I =
     inertiaDeg' p P * inertiaDeg' P I := by

--- a/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Inertia.lean
@@ -90,14 +90,14 @@ theorem inertiaDeg'_algebraMap [P.LiesOver p] :
     inertiaDeg' p P = finrank (R ⧸ p) (S ⧸ P) := by
   rw [inertiaDeg', dite_eq_left (over_def P p).symm]
 
+@[deprecated (since := "2026-07-03")] alias inertiaDeg_algebraMap := inertiaDeg'_algebraMap
+
 @[deprecated "Use `inertiaDeg_eq_of_isMaximal` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_eq_inertiaDeg [P.LiesOver p] [p.IsMaximal] [P.IsMaximal] :
     p.inertiaDeg' P = P.inertiaDeg R := by
   rw [inertiaDeg'_algebraMap, inertiaDeg_eq_of_isMaximal p P]
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg_eq_inertiaDeg' := inertiaDeg'_eq_inertiaDeg
-
-@[deprecated (since := "2026-07-03")] alias inertiaDeg_algebraMap := inertiaDeg'_algebraMap
 
 @[deprecated "Use `Ideal.inertiaDeg_pos` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_pos [p.IsMaximal] [Module.Finite R S] [P.LiesOver p] : 0 < inertiaDeg' p P :=

--- a/Mathlib/RingTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Inertia.lean
@@ -5,7 +5,8 @@ Authors: Thomas Browning
 -/
 module
 
-public import Mathlib.NumberTheory.RamificationInertia.Inertia
+public import Mathlib.RingTheory.Finiteness.Quotient
+public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 public import Mathlib.RingTheory.QuasiFinite.Basic
 
 /-!
@@ -115,13 +116,6 @@ theorem inertiaDeg_eq_of_isMaximal [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
 
 @[deprecated (since := "2026-07-03")] alias inertiaDeg'_eq_of_isMaximal :=
   inertiaDeg_eq_of_isMaximal
-
-@[deprecated "Use `inertiaDeg_eq_of_isMaximal` instead." (since := "2026-08-14")]
-theorem inertiaDeg'_eq_inertiaDeg [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
-    p.inertiaDeg' q = q.inertiaDeg R := by
-  rw [inertiaDeg'_algebraMap, inertiaDeg_eq_of_isMaximal p q]
-
-@[deprecated (since := "2026-07-03")] alias inertiaDeg_eq_inertiaDeg' := inertiaDeg'_eq_inertiaDeg
 
 theorem inertiaDeg_tower [r.LiesOver q] :
     r.inertiaDeg R = q.inertiaDeg R * r.inertiaDeg S := by

--- a/Mathlib/RingTheory/RamificationInertia/Inertia.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Inertia.lean
@@ -116,6 +116,7 @@ theorem inertiaDeg_eq_of_isMaximal [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
 @[deprecated (since := "2026-07-03")] alias inertiaDeg'_eq_of_isMaximal :=
   inertiaDeg_eq_of_isMaximal
 
+@[deprecated "Use `inertiaDeg_eq_of_isMaximal` instead." (since := "2026-08-14")]
 theorem inertiaDeg'_eq_inertiaDeg [q.LiesOver p] [p.IsMaximal] [q.IsMaximal] :
     p.inertiaDeg' q = q.inertiaDeg R := by
   rw [inertiaDeg'_algebraMap, inertiaDeg_eq_of_isMaximal p q]
@@ -182,7 +183,7 @@ theorem inertiaDeg_smul {G : Type*} [Group G] [MulSemiringAction G S] [SMulCommC
 theorem cardQuot_pow_inertiaDeg [Module.Finite R S] [p.IsMaximal] [q.IsMaximal] [q.LiesOver p] :
     p.cardQuot ^ q.inertiaDeg R = q.cardQuot := by
   let _ : Field (R ⧸ p) := Quotient.field p
-  rw [← inertiaDeg'_eq_inertiaDeg p q, inertiaDeg'_algebraMap p q]
+  rw [inertiaDeg_eq_of_isMaximal p q]
   exact Module.natCard_eq_pow_finrank.symm
 
 @[deprecated (since := "2026-07-03")] alias cardQuot_pow_inertiaDeg' := cardQuot_pow_inertiaDeg


### PR DESCRIPTION
This PR deprecates `Ideal.inertiaDeg'` in favor of `Ideal.inertiaDeg`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
