### PR TITLE
[Merged by Bors] - chore(Topology/MetricSpace/Closeds): rename lemmas about `MetricSpace (NonemptyCompacts α)`

### DIFF
--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -28,7 +28,7 @@ public section
 
 noncomputable section
 
-open Set Function TopologicalSpace Filter ENNReal
+open Set Function TopologicalSpace Filter ENNReal Metric
 
 open scoped Topology
 
@@ -81,8 +81,6 @@ protected abbrev _root_.PseudoEMetricSpace.hausdorff : PseudoEMetricSpace (Set �
 end Metric
 
 namespace TopologicalSpace
-
-open Metric
 
 variable {α β : Type*} [EMetricSpace α] [EMetricSpace β] {s : Set α}
 
@@ -286,25 +284,23 @@ end NonemptyCompacts
 
 end TopologicalSpace
 
-namespace Metric
-
-section
+namespace TopologicalSpace.NonemptyCompacts
 
 variable {α : Type*} [MetricSpace α]
 
 /-- `NonemptyCompacts α` inherits a metric space structure, as the Hausdorff
 edistance between two such sets is finite. -/
-instance NonemptyCompacts.instMetricSpace : MetricSpace (NonemptyCompacts α) :=
+instance : MetricSpace (NonemptyCompacts α) :=
   EMetricSpace.toMetricSpace fun x y =>
-    hausdorffEDist_ne_top_of_nonempty_of_bounded x.nonempty y.nonempty x.isCompact.isBounded
+    Metric.hausdorffEDist_ne_top_of_nonempty_of_bounded x.nonempty y.nonempty x.isCompact.isBounded
       y.isCompact.isBounded
 
 /-- The distance on `NonemptyCompacts α` is the Hausdorff distance, by construction -/
-theorem NonemptyCompacts.dist_eq {x y : NonemptyCompacts α} :
-    dist x y = hausdorffDist (x : Set α) y :=
+theorem dist_eq {x y : NonemptyCompacts α} : dist x y = hausdorffDist (x : Set α) y :=
   rfl
 
-theorem lipschitz_infDist_set (x : α) : LipschitzWith 1 fun s : NonemptyCompacts α => infDist x s :=
+theorem lipschitz_infDist_const (x : α) :
+    LipschitzWith 1 fun s : NonemptyCompacts α => infDist x s :=
   LipschitzWith.of_le_add fun s t => by
     rw [dist_comm]
     exact infDist_le_infDist_add_hausdorffDist (edist_ne_top t s)
@@ -312,12 +308,22 @@ theorem lipschitz_infDist_set (x : α) : LipschitzWith 1 fun s : NonemptyCompact
 theorem lipschitz_infDist : LipschitzWith 2 fun p : α × NonemptyCompacts α => infDist p.1 p.2 := by
   rw [← one_add_one_eq_two]
   exact LipschitzWith.uncurry
-    (fun s : NonemptyCompacts α => lipschitz_infDist_pt (s : Set α)) lipschitz_infDist_set
+    (fun s : NonemptyCompacts α => lipschitz_infDist_pt (s : Set α)) lipschitz_infDist_const
 
-theorem uniformContinuous_infDist_Hausdorff_dist :
+theorem uniformContinuous_infDist :
     UniformContinuous fun p : α × NonemptyCompacts α => infDist p.1 p.2 :=
   lipschitz_infDist.uniformContinuous
 
-end --section
+end TopologicalSpace.NonemptyCompacts
 
-end Metric --namespace
+@[deprecated (since := "2026-08-24")]
+alias Metric.NonemptyCompacts.dist_eq := NonemptyCompacts.dist_eq
+
+@[deprecated (since := "2026-08-24")]
+alias Metric.lipschitz_infDist_set := NonemptyCompacts.lipschitz_infDist_const
+
+@[deprecated (since := "2026-08-24")]
+alias Metric.lipschitz_infDist := NonemptyCompacts.lipschitz_infDist
+
+@[deprecated (since := "2026-08-24")]
+alias Metric.uniformContinuous_infDist_Hausdorff_dist := NonemptyCompacts.uniformContinuous_infDist


### PR DESCRIPTION
These lemmas are moved from the `Metric` namespace to `TopologicalSpace.NonemptyCompacts`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
