### PR TITLE
[Merged by Bors] - chore(ci): wire MATHLIB_CACHE_BASE_URL from a repository variable

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -48,6 +48,7 @@ env:
   # are valid by-products of the Mathlib build. Build artifacts fetched from Lake's cache do
   # not necessarily satisfy this property.
   LAKE_NO_CACHE: true
+  MATHLIB_CACHE_BASE_URL: ${{ vars.MATHLIB_CACHE_BASE_URL }}
 
 jobs:
   build:

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -104,6 +104,7 @@ env:
   SHADOW_SCOPE: mathlib4-master-shadow
   # NOTE: STAGE_TARGETS is set per-job (not here) from the `targets` input, so
   # it can be overridden per dispatch — see the `build_and_stage`/`consume` env.
+  MATHLIB_CACHE_BASE_URL: ${{ vars.MATHLIB_CACHE_BASE_URL }}
 
 jobs:
   build_and_stage:

--- a/.github/workflows/olean_report.yaml
+++ b/.github/workflows/olean_report.yaml
@@ -20,6 +20,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  MATHLIB_CACHE_BASE_URL: ${{ vars.MATHLIB_CACHE_BASE_URL }}
+
 jobs:
   report:
     name: Prepare olean report

--- a/.github/workflows/remove_deprecated_decls.yml
+++ b/.github/workflows/remove_deprecated_decls.yml
@@ -21,6 +21,9 @@ on:
         default: false
         type: boolean
 
+env:
+  MATHLIB_CACHE_BASE_URL: ${{ vars.MATHLIB_CACHE_BASE_URL }}
+
 jobs:
   build:
     name: Remove outdated deprecated declarations


### PR DESCRIPTION
This PR passes the repository variable `MATHLIB_CACHE_BASE_URL` to every workflow that reads the mathlib cache: `build_template.yml` (which serves the build, fork, bors, ci_dev, and release_cache workflows), `olean_report.yaml`, `remove_deprecated_decls.yml`, and the warm-start `cache get` in `lake_cache_shadow.yml`. The variable is normally unset, so reads keep their current path to Azure. An operator sets the variable to move cache read traffic to another host, and clears it to move the traffic back. Both changes take effect on the next job, with no deploy and no code change.

The tool side is #42657: the cache tool reads `MATHLIB_CACHE_BASE_URL` and treats an empty value as unset, which is the state `${{ vars.MATHLIB_CACHE_BASE_URL }}` produces while the variable is undefined. The two PRs are safe in either merge order: before #42657 the tool ignores the variable, and after it the empty value keeps the default.

Out of scope: the `nightly-testing` repository has its own variable namespace, so a flip there is a separate switch. `publish_tools.yml` and `cache_test.yml` run no cache reads, so they stay unwired.
