### PR TITLE
feat(Combinatorics/Sperner): define facet incidence data

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3582,6 +3582,7 @@ public import Mathlib.Combinatorics.Enumerative.Catalan.Basic
 public import Mathlib.Combinatorics.Enumerative.Catalan.Tree
 public import Mathlib.Combinatorics.Enumerative.Composition
 public import Mathlib.Combinatorics.Enumerative.DoubleCounting
+public import Mathlib.Combinatorics.Sperner.Basic
 public import Mathlib.Combinatorics.Enumerative.DyckWord
 public import Mathlib.Combinatorics.Enumerative.IncidenceAlgebra
 public import Mathlib.Combinatorics.Enumerative.InclusionExclusion

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3582,7 +3582,6 @@ public import Mathlib.Combinatorics.Enumerative.Catalan.Basic
 public import Mathlib.Combinatorics.Enumerative.Catalan.Tree
 public import Mathlib.Combinatorics.Enumerative.Composition
 public import Mathlib.Combinatorics.Enumerative.DoubleCounting
-public import Mathlib.Combinatorics.Sperner.Basic
 public import Mathlib.Combinatorics.Enumerative.DyckWord
 public import Mathlib.Combinatorics.Enumerative.IncidenceAlgebra
 public import Mathlib.Combinatorics.Enumerative.InclusionExclusion
@@ -3745,6 +3744,7 @@ public import Mathlib.Combinatorics.SimpleGraph.Walks.Maps
 public import Mathlib.Combinatorics.SimpleGraph.Walks.Operations
 public import Mathlib.Combinatorics.SimpleGraph.Walks.Subwalks
 public import Mathlib.Combinatorics.SimpleGraph.Walks.Traversal
+public import Mathlib.Combinatorics.Sperner.Basic
 public import Mathlib.Combinatorics.Tiling.Tile
 public import Mathlib.Combinatorics.Young.SemistandardTableau
 public import Mathlib.Combinatorics.Young.YoungDiagram

--- a/Mathlib/Combinatorics/Sperner/Basic.lean
+++ b/Mathlib/Combinatorics/Sperner/Basic.lean
@@ -32,16 +32,19 @@ structure FacetIncidence (Facet Ridge : Type*) [DecidableEq Facet] [DecidableEq 
   ridges : Finset Ridge
   /-- Facet-ridge incidence. -/
   incident : Facet → Ridge → Prop
-  incident_decidable : DecidableRel incident
-  ridge_nonempty : ∀ ridge ∈ ridges, (facets.bipartiteBelow incident ridge).Nonempty
-  ridge_card_le_two : ∀ ridge ∈ ridges, (facets.bipartiteBelow incident ridge).card ≤ 2
+  /-- A decision procedure for facet-ridge incidence. -/
+  incidentDecidable : DecidableRel incident
+  /-- Every ridge is incident to at least one facet. -/
+  ridgeNonempty : ∀ ridge ∈ ridges, (facets.bipartiteBelow incident ridge).Nonempty
+  /-- Every ridge is incident to at most two facets. -/
+  ridgeCardLeTwo : ∀ ridge ∈ ridges, (facets.bipartiteBelow incident ridge).card ≤ 2
 
 namespace FacetIncidence
 
 variable {Facet Ridge : Type*} [DecidableEq Facet] [DecidableEq Ridge]
   (I : FacetIncidence Facet Ridge)
 
-instance : DecidableRel I.incident := I.incident_decidable
+instance : DecidableRel I.incident := I.incidentDecidable
 
 /-- The facets incident to a ridge. -/
 def cofacets (I : FacetIncidence Facet Ridge) (ridge : Ridge) : Finset Facet :=
@@ -64,8 +67,8 @@ def IsInteriorRidge (I : FacetIncidence Facet Ridge) (ridge : Ridge) : Prop :=
 /-- Every ridge is either a boundary ridge or an interior ridge. -/
 theorem isBoundaryRidge_or_isInteriorRidge {ridge : Ridge} (hridge : ridge ∈ I.ridges) :
     I.IsBoundaryRidge ridge ∨ I.IsInteriorRidge ridge := by
-  have hpos : 0 < (I.cofacets ridge).card := Finset.card_pos.mpr (I.ridge_nonempty ridge hridge)
-  have hle : (I.cofacets ridge).card ≤ 2 := I.ridge_card_le_two ridge hridge
+  have hpos : 0 < (I.cofacets ridge).card := Finset.card_pos.mpr (I.ridgeNonempty ridge hridge)
+  have hle : (I.cofacets ridge).card ≤ 2 := I.ridgeCardLeTwo ridge hridge
   simp only [IsBoundaryRidge, IsInteriorRidge]
   omega
 

--- a/Mathlib/Combinatorics/Sperner/Basic.lean
+++ b/Mathlib/Combinatorics/Sperner/Basic.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 Andrey Lukin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrey Lukin
+-/
+module
+
+public import Mathlib.Combinatorics.Enumerative.DoubleCounting
+
+/-!
+# Facet incidence data
+
+This file defines finite codimension-one incidence data whose ridges have one or two cofacets.
+It is intended as the combinatorial input for a future formalization of Sperner's lemma: a ridge
+with one cofacet is a boundary ridge, while a ridge with two cofacets is an interior ridge.
+-/
+
+@[expose] public section
+
+namespace Combinatorics
+namespace Sperner
+
+/-- Finite facet-ridge incidence data in which every ridge has either one or two cofacets.
+
+For a simplicial complex, the facets are its top-dimensional faces and the ridges are their
+codimension-one faces. The one-or-two cofacet condition is the pseudomanifold-with-boundary
+property needed by the usual incidence proof of Sperner's lemma. -/
+structure FacetIncidence (Facet Ridge : Type*) [DecidableEq Facet] [DecidableEq Ridge] where
+  /-- The top-dimensional faces. -/
+  facets : Finset Facet
+  /-- The codimension-one faces. -/
+  ridges : Finset Ridge
+  /-- Facet-ridge incidence. -/
+  incident : Facet → Ridge → Prop
+  incident_decidable : DecidableRel incident
+  ridge_nonempty : ∀ ridge ∈ ridges, (facets.bipartiteBelow incident ridge).Nonempty
+  ridge_card_le_two : ∀ ridge ∈ ridges, (facets.bipartiteBelow incident ridge).card ≤ 2
+
+namespace FacetIncidence
+
+variable {Facet Ridge : Type*} [DecidableEq Facet] [DecidableEq Ridge]
+  (I : FacetIncidence Facet Ridge)
+
+instance : DecidableRel I.incident := I.incident_decidable
+
+/-- The facets incident to a ridge. -/
+def cofacets (I : FacetIncidence Facet Ridge) (ridge : Ridge) : Finset Facet :=
+  I.facets.bipartiteBelow I.incident ridge
+
+@[simp]
+theorem mem_cofacets {facet : Facet} {ridge : Ridge} :
+    facet ∈ I.cofacets ridge ↔ facet ∈ I.facets ∧ I.incident facet ridge := by
+  simpa only [cofacets] using
+    (Finset.mem_bipartiteBelow (r := I.incident) (s := I.facets) (b := ridge) (a := facet))
+
+/-- A ridge with exactly one cofacet. -/
+def IsBoundaryRidge (I : FacetIncidence Facet Ridge) (ridge : Ridge) : Prop :=
+  (I.cofacets ridge).card = 1
+
+/-- A ridge with exactly two cofacets. -/
+def IsInteriorRidge (I : FacetIncidence Facet Ridge) (ridge : Ridge) : Prop :=
+  (I.cofacets ridge).card = 2
+
+/-- Every ridge is either a boundary ridge or an interior ridge. -/
+theorem isBoundaryRidge_or_isInteriorRidge {ridge : Ridge} (hridge : ridge ∈ I.ridges) :
+    I.IsBoundaryRidge ridge ∨ I.IsInteriorRidge ridge := by
+  have hpos : 0 < (I.cofacets ridge).card := Finset.card_pos.mpr (I.ridge_nonempty ridge hridge)
+  have hle : (I.cofacets ridge).card ≤ 2 := I.ridge_card_le_two ridge hridge
+  simp only [IsBoundaryRidge, IsInteriorRidge]
+  omega
+
+/-- The boundary ridges. -/
+def boundaryRidges (I : FacetIncidence Facet Ridge) : Finset Ridge :=
+  I.ridges.filter fun ridge ↦ (I.cofacets ridge).card = 1
+
+@[simp]
+theorem mem_boundaryRidges {ridge : Ridge} :
+    ridge ∈ I.boundaryRidges ↔ ridge ∈ I.ridges ∧ I.IsBoundaryRidge ridge :=
+  Finset.mem_filter
+
+/-- The interior ridges. -/
+def interiorRidges (I : FacetIncidence Facet Ridge) : Finset Ridge :=
+  I.ridges.filter fun ridge ↦ (I.cofacets ridge).card = 2
+
+@[simp]
+theorem mem_interiorRidges {ridge : Ridge} :
+    ridge ∈ I.interiorRidges ↔ ridge ∈ I.ridges ∧ I.IsInteriorRidge ridge :=
+  Finset.mem_filter
+
+/-- Boundary and interior ridges partition the ridges. -/
+theorem boundaryRidges_union_interiorRidges : I.boundaryRidges ∪ I.interiorRidges = I.ridges := by
+  ext ridge
+  simp only [Finset.mem_union, mem_boundaryRidges, mem_interiorRidges]
+  constructor
+  · rintro (⟨hridge, -⟩ | ⟨hridge, -⟩)
+    · exact hridge
+    · exact hridge
+  · intro hridge
+    rcases I.isBoundaryRidge_or_isInteriorRidge hridge with hboundary | hinterior
+    · exact Or.inl ⟨hridge, hboundary⟩
+    · exact Or.inr ⟨hridge, hinterior⟩
+
+/-- No ridge is both boundary and interior. -/
+theorem disjoint_boundaryRidges_interiorRidges : Disjoint I.boundaryRidges I.interiorRidges := by
+  refine Finset.disjoint_left.mpr fun ridge hboundary hinterior => ?_
+  have hboundary' := (I.mem_boundaryRidges.mp hboundary).2
+  have hinterior' := (I.mem_interiorRidges.mp hinterior).2
+  simp only [IsBoundaryRidge, IsInteriorRidge] at hboundary' hinterior'
+  omega
+
+end FacetIncidence
+end Sperner
+end Combinatorics


### PR DESCRIPTION
## Summary

Adds a small finite facet-ridge incidence interface intended as a prerequisite for the general Sperner lemma (#25231).

- defines finite facets, ridges, and their incidence relation;
- assumes every ridge has one or two cofacets;
- defines boundary and interior ridges and proves that they are disjoint and partition the ridges.

This deliberately does not claim the geometric Sperner theorem. A future development must connect finite triangulations of the standard simplex to this incidence interface and establish the required coface-count property.

## Validation

- `lake build Mathlib.Combinatorics.Sperner.Basic`
- `lake env lean -DwarningAsError=false Mathlib.lean`

Towards #25231
