### PR TITLE
perf(RingTheory/Ideal/Quotient): split HasFiniteQuotients to keep its dimension instances out of AbsNorm

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6741,6 +6741,7 @@ public import Mathlib.RingTheory.Ideal.Quotient.ChineseRemainder
 public import Mathlib.RingTheory.Ideal.Quotient.Defs
 public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients
 public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Basic
+public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Defs
 public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Norm
 public import Mathlib.RingTheory.Ideal.Quotient.Index
 public import Mathlib.RingTheory.Ideal.Quotient.Nilpotent

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -12,7 +12,7 @@ public import Mathlib.LinearAlgebra.FreeModule.Determinant
 public import Mathlib.LinearAlgebra.FreeModule.Finite.CardQuotient
 public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
 public import Mathlib.RingTheory.Ideal.Basis
-public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Basic
+public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Defs
 public import Mathlib.RingTheory.Norm.Basic
 public import Mathlib.RingTheory.UniqueFactorizationDomain.Multiplicative
 

--- a/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Basic.lean
@@ -5,51 +5,23 @@ Authors: Xavier Roblot
 -/
 module
 
-public import Mathlib.Data.ZMod.QuotientRing
-public import Mathlib.FieldTheory.Perfect
-public import Mathlib.RingTheory.DedekindDomain.Basic
-public import Mathlib.RingTheory.LocalRing.ResidueField.Ideal
+public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Defs
 
-/-! # Rings with finite quotients
+/-! # Basic result for rings with finite quotients
 
-A commutative ring is said to have finite quotients if, for any nonzero ideal `I` of `R`, the
-quotient `R ⧸ I` is finite.
+This file provides the basic results for a ring with finite quotients.
 
 ## Main results
 - `Ring.HasFiniteQuotients.instDimensionLEOne`: A ring with finite quotients has dimension `≤ 1`.
-- `Ring.HasFiniteQuotients.instIsNoetherianRing` : A ring with finite quotients is noetherian.
-- `Ring.HasFiniteQuotients.of_module_finite`: Assume that `R` has finite quotients and that `S` is
-  a domain and a finite `R`-module. Then `S` has finite quotients.
-- `Ring.HasFiniteQuotients.instOfIsDomainOfFG`: A domain that is also a finite `ℤ`-module
-  has finite quotients.
+- `Ring.HasFiniteQuotients.instIsNoetherianRing`: A ring with finite quotients is noetherian.
 
 -/
 
 public section
 
-/--
-A ring `R` has finite quotients if the quotient `R ⧸ I` is finite for all nonzero ideals of `R`.
--/
-class Ring.HasFiniteQuotients (R : Type*) [CommRing R] : Prop where
-  finiteQuotient {I : Ideal R} : I ≠ ⊥ → Finite (R ⧸ I)
-
 namespace Ring.HasFiniteQuotients
 
-variable {R : Type*} [CommRing R]
-
-/-- A finite ring has finite quotients. -/
-instance [Finite R] : Ring.HasFiniteQuotients R where
-  finiteQuotient := fun _ ↦ Quotient.finite _
-
-section properties
-
-variable [HasFiniteQuotients R]
-
-/-- A nonzero prime ideal of a ring with finite quotients is maximal. -/
-theorem maximalOfPrime {P : Ideal R} [P.IsPrime] (hp : P ≠ ⊥) :
-    P.IsMaximal :=
-  have : Finite (R ⧸ P) := finiteQuotient hp
-  Ideal.Quotient.maximal_of_isField P <| Finite.isField_of_domain (R ⧸ P)
+variable {R : Type*} [CommRing R] [HasFiniteQuotients R]
 
 /-- A ring with finite quotients has dimension `≤ 1`. -/
 instance : DimensionLEOne R where
@@ -66,42 +38,5 @@ instance : IsNoetherianRing R := by
     exact Submodule.FG.of_finite
   · rw [Submodule.ker_mkQ, inf_eq_right.mpr ((Ideal.span_singleton_le_iff_mem I).mpr hx₁)]
     exact Submodule.fg_span_singleton x
-
-instance [IsDomain R] [PerfectField (FractionRing R)] (P : Ideal R) [P.IsPrime] :
-    PerfectField P.ResidueField := by
-  rcases eq_or_ne P ⊥ with rfl | hP
-  · exact PerfectField.of_ringEquiv (FractionRing.algEquiv R _).toRingEquiv
-  · have : Finite (R ⧸ P) := Ring.HasFiniteQuotients.finiteQuotient hP
-    infer_instance
-
-variable (R) in
-/--
-Assume that `R` has finite quotients and that `S` is a domain and a finite `R`-module. Then
-`S` has finite quotients.
--/
-theorem of_module_finite (S : Type*) [CommRing S] [IsDomain S]
-    [Algebra R S] [Module.Finite R S] :
-    HasFiniteQuotients S where
-  finiteQuotient {I} hI := by
-    obtain hR | hR := subsingleton_or_nontrivial R
-    · have : Finite S := Module.finite_of_finite R
-      exact Quotient.finite _
-    let J : Ideal R := Ideal.under R I
-    have : Finite (R ⧸ J) := finiteQuotient <| Ideal.under_ne_bot R hI
-    have : Module.Finite (R ⧸ J) (S ⧸ I) := Module.Finite.of_restrictScalars_finite R _ _
-    exact Module.finite_of_finite (R ⧸ J)
-
-end properties
-
-/-- The ring `ℤ` has finite quotients. -/
-instance : HasFiniteQuotients ℤ where
-  finiteQuotient {I} hI := by
-    obtain ⟨n, rfl⟩ := Submodule.IsPrincipal.principal I
-    have : NeZero n := ⟨by simpa using hI⟩
-    exact inferInstanceAs <| Finite (ℤ ⧸ Ideal.span {n})
-
-/-- A domain that is finitely generated has finite quotients. -/
-instance [IsDomain R] [Module.Finite ℤ R] : HasFiniteQuotients R :=
-  .of_module_finite ℤ R
 
 end Ring.HasFiniteQuotients

--- a/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Defs.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 Xavier Roblot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Roblot
+-/
+module
+
+public import Mathlib.Data.ZMod.QuotientRing
+public import Mathlib.FieldTheory.Perfect
+public import Mathlib.RingTheory.DedekindDomain.Basic
+public import Mathlib.RingTheory.LocalRing.ResidueField.Ideal
+
+/-! # Rings with finite quotients
+
+A commutative ring is said to have finite quotients if, for any nonzero ideal `I` of `R`, the
+quotient `R ⧸ I` is finite.
+
+This file defines the class `Ring.HasFiniteQuotients` and its basic API.
+
+## Main results
+- `Ring.HasFiniteQuotients.of_module_finite`: Assume that `R` has finite quotients and that `S` is
+  a domain and a finite `R`-module. Then `S` has finite quotients.
+- `Ring.HasFiniteQuotients.instOfIsDomainOfFG`: A domain that is also a finite `ℤ`-module
+  has finite quotients.
+
+-/
+
+public section
+
+/--
+A ring `R` has finite quotients if the quotient `R ⧸ I` is finite for all nonzero ideals of `R`.
+-/
+class Ring.HasFiniteQuotients (R : Type*) [CommRing R] : Prop where
+  finiteQuotient {I : Ideal R} : I ≠ ⊥ → Finite (R ⧸ I)
+
+namespace Ring.HasFiniteQuotients
+
+variable {R : Type*} [CommRing R]
+
+/-- A finite ring has finite quotients. -/
+instance [Finite R] : Ring.HasFiniteQuotients R where
+  finiteQuotient := fun _ ↦ Quotient.finite _
+
+section properties
+
+variable [HasFiniteQuotients R]
+
+/-- A nonzero prime ideal of a ring with finite quotients is maximal. -/
+theorem maximalOfPrime {P : Ideal R} [P.IsPrime] (hp : P ≠ ⊥) :
+    P.IsMaximal :=
+  have : Finite (R ⧸ P) := finiteQuotient hp
+  Ideal.Quotient.maximal_of_isField P <| Finite.isField_of_domain (R ⧸ P)
+
+instance [IsDomain R] [PerfectField (FractionRing R)] (P : Ideal R) [P.IsPrime] :
+    PerfectField P.ResidueField := by
+  rcases eq_or_ne P ⊥ with rfl | hP
+  · exact PerfectField.of_ringEquiv (FractionRing.algEquiv R _).toRingEquiv
+  · have : Finite (R ⧸ P) := Ring.HasFiniteQuotients.finiteQuotient hP
+    infer_instance
+
+variable (R) in
+/--
+Assume that `R` has finite quotients and that `S` is a domain and a finite `R`-module. Then
+`S` has finite quotients.
+-/
+theorem of_module_finite (S : Type*) [CommRing S] [IsDomain S]
+    [Algebra R S] [Module.Finite R S] :
+    HasFiniteQuotients S where
+  finiteQuotient {I} hI := by
+    obtain hR | hR := subsingleton_or_nontrivial R
+    · have : Finite S := Module.finite_of_finite R
+      exact Quotient.finite _
+    let J : Ideal R := Ideal.under R I
+    have : Finite (R ⧸ J) := finiteQuotient <| Ideal.under_ne_bot R hI
+    have : Module.Finite (R ⧸ J) (S ⧸ I) := Module.Finite.of_restrictScalars_finite R _ _
+    exact Module.finite_of_finite (R ⧸ J)
+
+end properties
+
+/-- The ring `ℤ` has finite quotients. -/
+instance : HasFiniteQuotients ℤ where
+  finiteQuotient {I} hI := by
+    obtain ⟨n, rfl⟩ := Submodule.IsPrincipal.principal I
+    have : NeZero n := ⟨by simpa using hI⟩
+    exact inferInstanceAs <| Finite (ℤ ⧸ Ideal.span {n})
+
+/-- A domain that is finitely generated has finite quotients. -/
+instance [IsDomain R] [Module.Finite ℤ R] : HasFiniteQuotients R :=
+  .of_module_finite ℤ R
+
+end Ring.HasFiniteQuotients


### PR DESCRIPTION
#42784 made `AbsNorm` publicly import `HasFiniteQuotients.Basic`, which registers two global instances:  `DimensionLEOne` and `IsNoetherianRing` derived from `Ring.HasFiniteQuotients`. It seems that those two classes are searched constantly and propagating them downstream of `AbsNorm` caused large instruction regressions.

This PR splits `HasFiniteQuotients/Basic.lean` into `Defs.lean` (the class and its basic API, which is all `AbsNorm` needs) and `Basic.lean` (which imports `Defs` and adds the two instances). `AbsNorm` now imports `Defs`, so the instances no longer reach its downstream modules.

Prepared with Claude Code 🤖

---