### PR TITLE
[Merged by Bors] - feat(NumberTheory): define Carmichael numbers

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5736,6 +5736,7 @@ public import Mathlib.NumberTheory.Basic
 public import Mathlib.NumberTheory.Bernoulli
 public import Mathlib.NumberTheory.BernoulliPolynomials
 public import Mathlib.NumberTheory.Bertrand
+public import Mathlib.NumberTheory.CarmichaelNumber
 public import Mathlib.NumberTheory.Chebyshev
 public import Mathlib.NumberTheory.ClassNumber.AdmissibleAbs
 public import Mathlib.NumberTheory.ClassNumber.AdmissibleAbsoluteValue

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -520,8 +520,8 @@ theorem natCast_eq_zero_iff (a b : ℕ) : (a : ZMod b) = 0 ↔ b ∣ a := by
   rw [← Nat.cast_zero, ZMod.natCast_eq_natCast_iff, Nat.modEq_zero_iff_dvd]
 
 lemma neg_one_eq_one_iff {n : ℕ} : (-1 : ZMod n) = 1 ↔ n = 1 ∨ n = 2 := by
-  rw [neg_eq_iff_add_eq_zero, one_add_one_eq_two, show (2 : ZMod n) = (2 :) from rfl,
-    natCast_eq_zero_iff, Nat.dvd_prime Nat.prime_two]
+  rw [neg_eq_iff_add_eq_zero, one_add_one_eq_two, ← Nat.cast_ofNat, natCast_eq_zero_iff,
+    Nat.dvd_prime Nat.prime_two]
 
 set_option backward.isDefEq.respectTransparency false in
 theorem coe_intCast (a : ℤ) : cast (a : ZMod n) = a % n := by

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -519,6 +519,10 @@ theorem intCast_eq_intCast_iff_dvd_sub (a b : ℤ) (c : ℕ) : (a : ZMod c) = �
 theorem natCast_eq_zero_iff (a b : ℕ) : (a : ZMod b) = 0 ↔ b ∣ a := by
   rw [← Nat.cast_zero, ZMod.natCast_eq_natCast_iff, Nat.modEq_zero_iff_dvd]
 
+lemma neg_one_eq_one_iff {n : ℕ} : (-1 : ZMod n) = 1 ↔ n = 1 ∨ n = 2 := by
+  rw [neg_eq_iff_add_eq_zero, one_add_one_eq_two, show (2 : ZMod n) = (2 :) from rfl,
+    natCast_eq_zero_iff, Nat.dvd_prime Nat.prime_two]
+
 set_option backward.isDefEq.respectTransparency false in
 theorem coe_intCast (a : ℤ) : cast (a : ZMod n) = a % n := by
   cases n

--- a/Mathlib/NumberTheory/ArithmeticFunction/Carmichael.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction/Carmichael.lean
@@ -166,4 +166,18 @@ theorem carmichael_pow_of_prime_ne_two {p : ℕ} (n : ℕ) (hp : p.Prime) (hp₂
   rw [carmichael_eq_exponent', ← ZMod.card_units_eq_totient, Fintype.card_eq_nat_card]
   exact IsCyclic.iff_exponent_eq_card.mp <| ZMod.isCyclic_units_of_prime_pow p hp hp₂ n
 
+
+@[simp]
+theorem carmichael_one : carmichael 1 = 1 := by
+  rw [← pow_zero 2, carmichael_two_pow_of_le_two (zero_le 2), pow_zero]
+
+@[simp]
+theorem carmichael_two : carmichael 2 = 1 := by
+  rw [← pow_one 2, carmichael_two_pow_of_le_two one_le_two, tsub_self, pow_zero]
+
+theorem carmichael_of_prime {n : ℕ} (hn : n.Prime) : carmichael n = n - 1 := by
+  by_cases ne_two : n = 2
+  · simp [ne_two]
+  · rw [← Nat.totient_prime hn, ← pow_one n, ← carmichael_pow_of_prime_ne_two 1 hn ne_two]
+
 end ArithmeticFunction

--- a/Mathlib/NumberTheory/ArithmeticFunction/Carmichael.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction/Carmichael.lean
@@ -166,7 +166,6 @@ theorem carmichael_pow_of_prime_ne_two {p : ℕ} (n : ℕ) (hp : p.Prime) (hp₂
   rw [carmichael_eq_exponent', ← ZMod.card_units_eq_totient, Fintype.card_eq_nat_card]
   exact IsCyclic.iff_exponent_eq_card.mp <| ZMod.isCyclic_units_of_prime_pow p hp hp₂ n
 
-
 @[simp]
 theorem carmichael_one : carmichael 1 = 1 := by
   rw [← pow_zero 2, carmichael_two_pow_of_le_two (zero_le 2), pow_zero]

--- a/Mathlib/NumberTheory/CarmichaelNumber.lean
+++ b/Mathlib/NumberTheory/CarmichaelNumber.lean
@@ -69,25 +69,17 @@ theorem not_isCarmichael_one : ¬ IsCarmichael 1 := by
   intro h
   simpa using h.two_lt
 
--- TODO: move this to a more appropriate file
-lemma sub_one_pow_mod {n : ℕ} (hn : 2 ≤ n) (k : ℕ) :
-    (n - 1) ^ k % n = if Odd k then n - 1 else 1 := by
-  induction k with
-  | zero => simp [mod_eq_of_lt hn]
-  | succ k ih =>
-    simp only [pow_succ, mul_mod, ih, self_sub_mod, ite_mul, one_mul]
-    by_cases hk : Odd k
-    · simp only [hk, ↓reduceIte, not_odd_iff_even.mpr hk.add_one, mod_eq_iff]
-      refine Or.inr ⟨lt_of_succ_le hn, n - 2, ?_⟩
-      rw [Nat.mul_sub, Nat.mul_sub, mul_one, Nat.sub_mul, one_mul, Nat.sub_sub,
-        self_add_sub_one n, mul_comm 2, tsub_tsub_assoc (by gcongr)]
-      lia
-    · simp [hk, not_even_iff_odd.mpr (not_odd_iff_even.mp hk).add_one]
-
--- TODO: move this to a more appropriate file
-lemma pow_mod_succ {n : ℕ} (hn : n ≠ 0) (k : ℕ) :
-    n ^ k % (n + 1) = if Odd k then n else 1 :=
-  sub_one_pow_mod (n := n + 1) (by lia) k
+lemma IsCarmichael.zmod_unit_pow_sub_one (s : (ZMod n)ˣ) (hn : n.IsCarmichael) :
+  s ^ (n - 1) = 1 := by
+  have _ : NeZero n := ⟨by grind [hn.two_lt]⟩
+  have suf : (↑s : ZMod n).val ^ (n - 1) ≡ 1 [MOD n] := by
+    refine (probablePrime_iff_modEq n ?_).mp <|
+      hn.probablePrime_of_coprime (ZMod.val_coe_unit_coprime s)
+    rw [one_le_iff_ne_zero, Ne, ZMod.val_eq_zero]
+    have : Nontrivial (ZMod n) := ZMod.nontrivial_iff.mpr (by grind [hn.two_lt])
+    exact Units.ne_zero s
+  ext
+  simp [← cast_one (R := ZMod n), ← (ZMod.natCast_eq_natCast_iff ..).mpr suf]
 
 /-- A Carmichael number is odd. -/
 theorem IsCarmichael.odd (h : n.IsCarmichael) : Odd n := by
@@ -101,20 +93,6 @@ theorem IsCarmichael.odd (h : n.IsCarmichael) : Odd n := by
     rw [ite_eq_right H, Ne, Units.ext_iff, Units.val_one, Units.coe_neg_one,
       ZMod.neg_one_eq_one_iff]
     grind [h.two_lt]
-
-lemma IsCarmichael.zmod_unit_pow_sub_one (s : (ZMod n)ˣ) (hn : n.IsCarmichael) :
-  s ^ (n - 1) = 1 := by
-  have _ : NeZero n := ⟨by grind [hn.two_lt]⟩
-  have suf : (↑s : ZMod n).val ^ (n - 1) ≡ 1 [MOD n] := by
-    apply (probablePrime_iff_modEq n ?_).mp <|
-      hn.probablePrime_of_coprime (ZMod.val_coe_unit_coprime s)
-    rw [one_le_iff_ne_zero]
-    intro hs0
-    have h_coprime := ZMod.val_coe_unit_coprime s
-    rw [hs0, coprime_zero_left] at h_coprime
-    grind [hn.two_lt]
-  ext
-  simp [← cast_one (R := ZMod n), ← (ZMod.natCast_eq_natCast_iff ..).mpr suf]
 
 /-- A Carmichael number is squarefree. -/
 theorem IsCarmichael.squarefree (h : n.IsCarmichael) : Squarefree n := by
@@ -143,7 +121,7 @@ theorem IsCarmichael.carmichael_dvd_sub_one (h : n.IsCarmichael) : carmichael n 
 
 theorem IsCarmichael.prime_sub_one_dvd {p : ℕ} (h : n.IsCarmichael) (hp : p.Prime) (hpn : p ∣ n) :
     p - 1 ∣ n - 1 := by
-  refine dvd_trans ?_ h.carmichael_dvd_pred
+  refine dvd_trans ?_ h.carmichael_dvd_sub_one
   rw [← carmichael_of_prime hp]
   exact carmichael_dvd (by simpa using hpn)
 

--- a/Mathlib/NumberTheory/CarmichaelNumber.lean
+++ b/Mathlib/NumberTheory/CarmichaelNumber.lean
@@ -83,11 +83,10 @@ theorem IsCarmichael.odd (h : n.IsCarmichael) : Odd n := by
   match n with
   | 0 => exact (not_isCarmichael_zero h).elim
   | n + 1 =>
-    rw [odd_add_one, not_odd_iff_even]
     have H := h.zmod_unit_pow_sub_one (-1)
     rw [Nat.add_one_sub_one, neg_one_pow_eq_ite] at H
     contrapose! H
-    rw [ite_eq_right H, Ne, Units.ext_iff, Units.val_one, Units.coe_neg_one,
+    rw [ite_eq_right (by grind), ne_eq, Units.ext_iff, Units.val_one, Units.coe_neg_one,
       ZMod.neg_one_eq_one_iff]
     grind [h.two_lt]
 
@@ -97,19 +96,17 @@ theorem IsCarmichael.squarefree (h : n.IsCarmichael) : Squarefree n := by
   have : NeZero (p ^ 2) := ⟨pow_ne_zero 2 hp.ne_zero⟩
   have : NeZero n := ⟨by grind [h.two_lt]⟩
   have p_odd : Odd p := h.odd.of_dvd_nat <| dvd_trans (p.dvd_mul_left p) p_dvd
-  have h_cyclic : IsCyclic (ZMod (p ^ 2))ˣ :=
+  obtain ⟨r, hr⟩ := isCyclic_iff_exists_orderOf_eq_natCard.mp <|
     (ZMod.isCyclic_units_iff_of_odd p_odd.pow).mpr ⟨p, 2, hp, p_odd, rfl⟩
-  obtain ⟨r, hr⟩ := isCyclic_iff_exists_orderOf_eq_natCard.mp h_cyclic
   rw [card_eq_fintype_card, ZMod.card_units_eq_totient] at hr
   obtain ⟨s, hs⟩ := ZMod.unitsMap_surjective (pow_two p ▸ p_dvd) r
-  have r_pow : r ^ (n - 1) = 1 := by rw [← hs, ← map_pow, h.zmod_unit_pow_sub_one, map_one]
   have phi_dvd : φ (p ^ 2) ∣ n - 1 := by
-    rw [← hr]
-    exact orderOf_dvd_of_pow_eq_one r_pow
-  have p_dvd_sub : p ∣ n - 1 := dvd_trans (by simp [totient_prime_pow_succ hp 1]) phi_dvd
+    rw [← hr, ← hs]
+    apply orderOf_dvd_of_pow_eq_one
+    rw [← map_pow, h.zmod_unit_pow_sub_one, map_one]
   have p_dvd_n : p ∣ n := dvd_trans (dvd_mul_left p p) p_dvd
-  have := Nat.dvd_sub_iff_right (show 1 ≤ n by grind [h.two_lt]) p_dvd_n |>.mp p_dvd_sub
-  exact hp.not_dvd_one this
+  refine hp.not_dvd_one <| dvd_sub_iff_right (by grind [h.two_lt]) p_dvd_n |>.mp ?_
+  exact dvd_trans (by simp [totient_prime_pow_succ hp 1]) phi_dvd
 
 theorem IsCarmichael.carmichael_dvd_sub_one (h : n.IsCarmichael) : carmichael n ∣ n - 1 := by
   have : NeZero n := ⟨by grind [h.two_lt]⟩
@@ -129,10 +126,9 @@ theorem isCarmichael_iff_korselt :
     n.IsCarmichael ↔ 2 < n ∧ ¬n.Prime ∧ Squarefree n ∧ ∀ p, p.Prime → p ∣ n → p - 1 ∣ n - 1 := by
   refine ⟨fun h ↦ ⟨h.two_lt, h.not_prime, h.squarefree, fun _ ↦ h.prime_sub_one_dvd⟩, ?_⟩
   intro ⟨hn, hn_prime, hn_squarefree, h_dvd⟩
-  have : NeZero n := ⟨by lia⟩
   refine ⟨hn, hn_prime, fun b hb ↦ ?_⟩
   obtain ⟨d, hd⟩ : carmichael n ∣ n - 1 := by
-    rw [carmichael_factorization]
+    rw [@carmichael_factorization n ⟨by lia⟩]
     refine Finset.lcm_dvd fun p hp_mem ↦ ?_
     rw [mem_primeFactors] at hp_mem
     rw [factorization_eq_one_of_squarefree hn_squarefree hp_mem.1 hp_mem.2.1, pow_one,

--- a/Mathlib/NumberTheory/CarmichaelNumber.lean
+++ b/Mathlib/NumberTheory/CarmichaelNumber.lean
@@ -71,15 +71,12 @@ theorem not_isCarmichael_one : ¬ IsCarmichael 1 := by
 
 lemma IsCarmichael.zmod_unit_pow_sub_one (s : (ZMod n)ˣ) (hn : n.IsCarmichael) :
   s ^ (n - 1) = 1 := by
-  have _ : NeZero n := ⟨by grind [hn.two_lt]⟩
-  have suf : (↑s : ZMod n).val ^ (n - 1) ≡ 1 [MOD n] := by
-    refine (probablePrime_iff_modEq n ?_).mp <|
-      hn.probablePrime_of_coprime (ZMod.val_coe_unit_coprime s)
-    rw [one_le_iff_ne_zero, Ne, ZMod.val_eq_zero]
-    have : Nontrivial (ZMod n) := ZMod.nontrivial_iff.mpr (by grind [hn.two_lt])
-    exact Units.ne_zero s
+  have : Nontrivial (ZMod n) := ZMod.nontrivial_iff.mpr (by grind [hn.two_lt])
   ext
-  simp [← cast_one (R := ZMod n), ← (ZMod.natCast_eq_natCast_iff ..).mpr suf]
+  rw [Units.val_one, Units.val_pow_eq_pow_val,
+    ← @ZMod.natCast_zmod_val _ ⟨by grind [hn.two_lt]⟩ s.val,
+    ← probablePrime_iff_zmod_one n (by simp [Units.ne_zero s])]
+  exact hn.probablePrime_of_coprime <| ZMod.val_coe_unit_coprime s
 
 /-- A Carmichael number is odd. -/
 theorem IsCarmichael.odd (h : n.IsCarmichael) : Odd n := by
@@ -134,7 +131,6 @@ theorem isCarmichael_iff_korselt :
   intro ⟨hn, hn_prime, hn_squarefree, h_dvd⟩
   have : NeZero n := ⟨by lia⟩
   refine ⟨hn, hn_prime, fun b hb ↦ ?_⟩
-  rw [probablePrime_iff_modEq n (show 1 ≤ b by grind)]
   obtain ⟨d, hd⟩ : carmichael n ∣ n - 1 := by
     rw [carmichael_factorization]
     refine Finset.lcm_dvd fun p hp_mem ↦ ?_
@@ -142,12 +138,8 @@ theorem isCarmichael_iff_korselt :
     rw [factorization_eq_one_of_squarefree hn_squarefree hp_mem.1 hp_mem.2.1, pow_one,
       carmichael_of_prime hp_mem.1]
     exact h_dvd p hp_mem.1 hp_mem.2.1
-  have hb_pow : (ZMod.unitOfCoprime b hb) ^ (n - 1) = 1 := by
-    rw [hd, pow_mul, pow_carmichael, one_pow]
-  have h_cast : (b : ZMod n) ^ (n - 1) = 1 := by
-    simpa using congrArg Units.val hb_pow
-  apply (ZMod.natCast_eq_natCast_iff ..).mp
-  simp [h_cast]
+  rw [probablePrime_iff_zmod_one n (by grind), ← ZMod.coe_unitOfCoprime b hb,
+    ← Units.val_pow_eq_pow_val, hd, pow_mul, pow_carmichael, one_pow, Units.val_one]
 
 /-- **Korselt's criterion** stated in a form suitable for concrete calculations. -/
 theorem isCarmichael_iff_korselt_primeFactorsList :

--- a/Mathlib/NumberTheory/CarmichaelNumber.lean
+++ b/Mathlib/NumberTheory/CarmichaelNumber.lean
@@ -25,7 +25,8 @@ This file defines Carmichael numbers and proves Korselt's criterion about them.
 
 ## TODO
 
-* Prove (in computationally efficient manner) that there are no Carmichael numbers less than `561`.
+* Prove (in a computationally efficient manner) that there are no Carmichael numbers
+  less than `561`.
 
 ## References
 

--- a/Mathlib/NumberTheory/CarmichaelNumber.lean
+++ b/Mathlib/NumberTheory/CarmichaelNumber.lean
@@ -40,7 +40,7 @@ namespace Nat
 open ArithmeticFunction
 
 /-- We say a natural number `n` is a Carmichael number if it is greater than 2, composite and
-for all natural number `b` coprime to `n` we have `n ∣ b ^ (n - 1) - 1`. -/
+for all natural numbers `b` coprime to `n` we have `n ∣ b ^ (n - 1) - 1`. -/
 @[expose]
 def IsCarmichael (n : ℕ) : Prop :=
   2 < n ∧ ¬ n.Prime ∧ ∀ b, b.Coprime n → ProbablePrime n b
@@ -90,18 +90,16 @@ lemma pow_mod_succ {n : ℕ} (hn : n ≠ 0) (k : ℕ) :
 
 /-- A Carmichael number is odd. -/
 theorem IsCarmichael.odd (h : n.IsCarmichael) : Odd n := by
-  have : n.ProbablePrime (n - 1) := h.probablePrime_of_coprime (b := n - 1)
-    <| (coprime_self_sub_left (by grind [h.two_lt])).mpr (by simp)
-  rw [ProbablePrime, dvd_iff_mod_eq_zero, ← mod_sub_of_le] at this
-  · rw [sub_one_pow_mod h.two_lt.le] at this
-    contrapose! this
-    simp_rw [(odd_sub' (m := n) (n := 1) (by grind [h.two_lt.le])).mpr (by simp_all)]
-    exact Nat.sub_ne_zero_iff_lt.mpr <| lt_sub_of_add_lt h.two_lt
-  · rw [sub_one_pow_mod h.two_lt.le]
-    by_cases h0 : Odd (n - 1)
-    · simp [h0]
-      grind [h.two_lt]
-    · simp [h0]
+  match n with
+  | 0 => exact (not_isCarmichael_zero h).elim
+  | n + 1 =>
+    rw [odd_add_one, not_odd_iff_even]
+    have H := h.zmod_unit_pow_sub_one (-1)
+    rw [Nat.add_one_sub_one, neg_one_pow_eq_ite] at H
+    contrapose! H
+    rw [ite_eq_right H, Ne, Units.ext_iff, Units.val_one, Units.coe_neg_one,
+      ZMod.neg_one_eq_one_iff]
+    grind [h.two_lt]
 
 lemma IsCarmichael.zmod_unit_pow_sub_one (s : (ZMod n)ˣ) (hn : n.IsCarmichael) :
   s ^ (n - 1) = 1 := by
@@ -119,36 +117,28 @@ lemma IsCarmichael.zmod_unit_pow_sub_one (s : (ZMod n)ˣ) (hn : n.IsCarmichael) 
 
 /-- A Carmichael number is squarefree. -/
 theorem IsCarmichael.squarefree (h : n.IsCarmichael) : Squarefree n := by
-  intro k hk
-  rw [isUnit_iff_eq_one]
-  contrapose! hk
-  intro hn
-  obtain ⟨p, hp, pk⟩ := ne_one_iff_exists_prime_dvd.mp hk
+  refine squarefree_iff_prime_squarefree.mpr fun p hp p_dvd ↦ ?_
   have : NeZero (p ^ 2) := ⟨pow_ne_zero 2 hp.ne_zero⟩
   have : NeZero n := ⟨by grind [h.two_lt]⟩
-  have p_dvd : p * p ∣ n := dvd_trans (by gcongr) hn
   have p_odd : Odd p := h.odd.of_dvd_nat <| dvd_trans (p.dvd_mul_left p) p_dvd
   have h_cyclic : IsCyclic (ZMod (p ^ 2))ˣ :=
     (ZMod.isCyclic_units_iff_of_odd p_odd.pow).mpr ⟨p, 2, hp, p_odd, rfl⟩
   obtain ⟨r, hr⟩ := isCyclic_iff_exists_orderOf_eq_natCard.mp h_cyclic
   rw [card_eq_fintype_card, ZMod.card_units_eq_totient] at hr
-  have p_sq_dvd : p ^ 2 ∣ n := by simpa [pow_two] using p_dvd
-  obtain ⟨s, hs⟩ := ZMod.unitsMap_surjective p_sq_dvd r
+  obtain ⟨s, hs⟩ := ZMod.unitsMap_surjective (pow_two p ▸ p_dvd) r
   have r_pow : r ^ (n - 1) = 1 := by rw [← hs, ← map_pow, h.zmod_unit_pow_sub_one, map_one]
   have phi_dvd : φ (p ^ 2) ∣ n - 1 := by
     rw [← hr]
     exact orderOf_dvd_of_pow_eq_one r_pow
   have p_dvd_sub : p ∣ n - 1 := dvd_trans (by simp [totient_prime_pow_succ hp 1]) phi_dvd
-  apply hp.ne_one
-  exact eq_one_of_dvd_coprimes ((coprime_self_sub_left (by grind [h.two_lt])).mpr (by simp))
-    p_dvd_sub (dvd_trans (p.dvd_mul_right p) p_dvd)
+  have p_dvd_n : p ∣ n := dvd_trans (dvd_mul_left p p) p_dvd
+  have := Nat.dvd_sub_iff_right (show 1 ≤ n by grind [h.two_lt]) p_dvd_n |>.mp p_dvd_sub
+  exact hp.not_dvd_one this
 
-theorem IsCarmichael.carmichael_dvd_pred (h : n.IsCarmichael) : carmichael n ∣ n - 1 := by
+theorem IsCarmichael.carmichael_dvd_sub_one (h : n.IsCarmichael) : carmichael n ∣ n - 1 := by
   have : NeZero n := ⟨by grind [h.two_lt]⟩
   rw [carmichael_eq_exponent']
-  apply Monoid.exponent_dvd_of_forall_pow_eq_one
-  intro s
-  exact h.zmod_unit_pow_sub_one s
+  exact Monoid.exponent_dvd_of_forall_pow_eq_one h.zmod_unit_pow_sub_one
 
 theorem IsCarmichael.prime_sub_one_dvd {p : ℕ} (h : n.IsCarmichael) (hp : p.Prime) (hpn : p ∣ n) :
     p - 1 ∣ n - 1 := by
@@ -157,8 +147,8 @@ theorem IsCarmichael.prime_sub_one_dvd {p : ℕ} (h : n.IsCarmichael) (hp : p.Pr
   exact carmichael_dvd (by simpa using hpn)
 
 /-- **Korselt's criterion** for Carmichael numbers:
-`n` is a Carmichael number if and only if it is greater than two, composite, sqaurefree and for all
-of for each prime divisor `p`, we have `p - 1 ∣ n - 1`. -/
+`n` is a Carmichael number if and only if it is greater than two, composite, squarefree, and for
+each prime divisor `p` of `n`, we have `p - 1 ∣ n - 1`. -/
 theorem isCarmichael_iff_korselt :
     n.IsCarmichael ↔ 2 < n ∧ ¬n.Prime ∧ Squarefree n ∧ ∀ p, p.Prime → p ∣ n → p - 1 ∣ n - 1 := by
   refine ⟨fun h ↦ ⟨h.two_lt, h.not_prime, h.squarefree, fun _ ↦ h.prime_sub_one_dvd⟩, ?_⟩
@@ -166,15 +156,13 @@ theorem isCarmichael_iff_korselt :
   have : NeZero n := ⟨by lia⟩
   refine ⟨hn, hn_prime, fun b hb ↦ ?_⟩
   rw [probablePrime_iff_modEq n (show 1 ≤ b by grind)]
-  have carmichael_dvd : carmichael n ∣ n - 1 := by
+  obtain ⟨d, hd⟩ : carmichael n ∣ n - 1 := by
     rw [carmichael_factorization]
-    apply Finset.lcm_dvd
-    intro p hp_mem
+    refine Finset.lcm_dvd fun p hp_mem ↦ ?_
     rw [mem_primeFactors] at hp_mem
     rw [factorization_eq_one_of_squarefree hn_squarefree hp_mem.1 hp_mem.2.1, pow_one,
       carmichael_of_prime hp_mem.1]
     exact h_dvd p hp_mem.1 hp_mem.2.1
-  obtain ⟨d, hd⟩ := carmichael_dvd
   have hb_pow : (ZMod.unitOfCoprime b hb) ^ (n - 1) = 1 := by
     rw [hd, pow_mul, pow_carmichael, one_pow]
   have h_cast : (b : ZMod n) ^ (n - 1) = 1 := by

--- a/Mathlib/NumberTheory/CarmichaelNumber.lean
+++ b/Mathlib/NumberTheory/CarmichaelNumber.lean
@@ -94,12 +94,11 @@ theorem IsCarmichael.odd (h : n.IsCarmichael) : Odd n := by
 theorem IsCarmichael.squarefree (h : n.IsCarmichael) : Squarefree n := by
   refine squarefree_iff_prime_squarefree.mpr fun p hp p_dvd ↦ ?_
   have : NeZero (p ^ 2) := ⟨pow_ne_zero 2 hp.ne_zero⟩
-  have : NeZero n := ⟨by grind [h.two_lt]⟩
   have p_odd : Odd p := h.odd.of_dvd_nat <| dvd_trans (p.dvd_mul_left p) p_dvd
   obtain ⟨r, hr⟩ := isCyclic_iff_exists_orderOf_eq_natCard.mp <|
     (ZMod.isCyclic_units_iff_of_odd p_odd.pow).mpr ⟨p, 2, hp, p_odd, rfl⟩
   rw [card_eq_fintype_card, ZMod.card_units_eq_totient] at hr
-  obtain ⟨s, hs⟩ := ZMod.unitsMap_surjective (pow_two p ▸ p_dvd) r
+  obtain ⟨s, hs⟩ := @ZMod.unitsMap_surjective _ _ ⟨by grind [h.two_lt]⟩ (pow_two p ▸ p_dvd) r
   have phi_dvd : φ (p ^ 2) ∣ n - 1 := by
     rw [← hr, ← hs]
     apply orderOf_dvd_of_pow_eq_one
@@ -109,8 +108,7 @@ theorem IsCarmichael.squarefree (h : n.IsCarmichael) : Squarefree n := by
   exact dvd_trans (by simp [totient_prime_pow_succ hp 1]) phi_dvd
 
 theorem IsCarmichael.carmichael_dvd_sub_one (h : n.IsCarmichael) : carmichael n ∣ n - 1 := by
-  have : NeZero n := ⟨by grind [h.two_lt]⟩
-  rw [carmichael_eq_exponent']
+  rw [@carmichael_eq_exponent' n ⟨by grind [h.two_lt]⟩]
   exact Monoid.exponent_dvd_of_forall_pow_eq_one h.zmod_unit_pow_sub_one
 
 theorem IsCarmichael.prime_sub_one_dvd {p : ℕ} (h : n.IsCarmichael) (hp : p.Prime) (hpn : p ∣ n) :

--- a/Mathlib/NumberTheory/CarmichaelNumber.lean
+++ b/Mathlib/NumberTheory/CarmichaelNumber.lean
@@ -50,6 +50,9 @@ variable {n : ℕ}
 
 theorem IsCarmichael.two_lt (h : n.IsCarmichael) : 2 < n := h.1
 
+theorem IsCarmichael.neZero (h : n.IsCarmichael) : NeZero n :=
+  ⟨by grind [h.two_lt]⟩
+
 theorem IsCarmichael.not_prime (h : n.IsCarmichael) : ¬ n.Prime := h.2.1
 
 theorem IsCarmichael.probablePrime_of_coprime {b : ℕ} (h : n.IsCarmichael) (hb : b.Coprime n) :
@@ -73,8 +76,8 @@ lemma IsCarmichael.zmod_unit_pow_sub_one (s : (ZMod n)ˣ) (hn : n.IsCarmichael) 
   s ^ (n - 1) = 1 := by
   have : Nontrivial (ZMod n) := ZMod.nontrivial_iff.mpr (by grind [hn.two_lt])
   ext
-  rw [Units.val_one, Units.val_pow_eq_pow_val,
-    ← @ZMod.natCast_zmod_val _ ⟨by grind [hn.two_lt]⟩ s.val,
+  have : NeZero n := hn.neZero
+  rw [Units.val_one, Units.val_pow_eq_pow_val, ← ZMod.natCast_zmod_val s.val,
     ← probablePrime_iff_zmod_one n (by simp [Units.ne_zero s])]
   exact hn.probablePrime_of_coprime <| ZMod.val_coe_unit_coprime s
 
@@ -98,7 +101,8 @@ theorem IsCarmichael.squarefree (h : n.IsCarmichael) : Squarefree n := by
   obtain ⟨r, hr⟩ := isCyclic_iff_exists_orderOf_eq_natCard.mp <|
     (ZMod.isCyclic_units_iff_of_odd p_odd.pow).mpr ⟨p, 2, hp, p_odd, rfl⟩
   rw [card_eq_fintype_card, ZMod.card_units_eq_totient] at hr
-  obtain ⟨s, hs⟩ := @ZMod.unitsMap_surjective _ _ ⟨by grind [h.two_lt]⟩ (pow_two p ▸ p_dvd) r
+  have : NeZero n := h.neZero
+  obtain ⟨s, hs⟩ := ZMod.unitsMap_surjective (pow_two p ▸ p_dvd) r
   have phi_dvd : φ (p ^ 2) ∣ n - 1 := by
     rw [← hr, ← hs]
     apply orderOf_dvd_of_pow_eq_one
@@ -108,7 +112,7 @@ theorem IsCarmichael.squarefree (h : n.IsCarmichael) : Squarefree n := by
   exact dvd_trans (by simp [totient_prime_pow_succ hp 1]) phi_dvd
 
 theorem IsCarmichael.carmichael_dvd_sub_one (h : n.IsCarmichael) : carmichael n ∣ n - 1 := by
-  rw [@carmichael_eq_exponent' n ⟨by grind [h.two_lt]⟩]
+  rw [@carmichael_eq_exponent' n h.neZero]
   exact Monoid.exponent_dvd_of_forall_pow_eq_one h.zmod_unit_pow_sub_one
 
 theorem IsCarmichael.prime_sub_one_dvd {p : ℕ} (h : n.IsCarmichael) (hp : p.Prime) (hpn : p ∣ n) :

--- a/Mathlib/NumberTheory/CarmichaelNumber.lean
+++ b/Mathlib/NumberTheory/CarmichaelNumber.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2026 Felix Pernegger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Felix Pernegger
+-/
+module
+
+public import Mathlib.NumberTheory.ArithmeticFunction.Carmichael
+public import Mathlib.NumberTheory.FermatPsp
+public import Mathlib.Tactic.Simproc.Factors
+
+/-!
+# Carmichael numbers
+
+This file defines Carmichael numbers and proves Korselt's criterion about them.
+
+## Main definitions
+
+* `Nat.IsCarmichael`: a predicate for Carmicheal numbers
+
+## Main results
+
+* `Nat.IsCarmichael_iff_korselt`: Korselt's criterion for Carmichael numbers
+* `Nat.isCarmichael_561`: `561` is a Carmichael number
+
+## TODO
+
+* Prove (in computationally efficient manner) that there are no Carmichael numbers less than `561`.
+
+## References
+
+https://en.wikipedia.org/wiki/Carmichael_number
+
+-/
+
+public section
+
+namespace Nat
+
+open ArithmeticFunction
+
+/-- We say a natural number `n` is a Carmichael number if it is greater than 2, composite and
+for all natural number `b` coprime to `n` we have `n ∣ b ^ (n - 1) - 1`. -/
+@[expose]
+def IsCarmichael (n : ℕ) : Prop :=
+  2 < n ∧ ¬ n.Prime ∧ ∀ b, b.Coprime n → ProbablePrime n b
+
+variable {n : ℕ}
+
+theorem IsCarmichael.two_lt (h : n.IsCarmichael) : 2 < n := h.1
+
+theorem IsCarmichael.not_prime (h : n.IsCarmichael) : ¬ n.Prime := h.2.1
+
+theorem IsCarmichael.probablePrime_of_coprime {b : ℕ} (h : n.IsCarmichael) (hb : b.Coprime n) :
+    ProbablePrime n b := h.2.2 b hb
+
+theorem Prime.not_isCarmichael (hn : n.Prime) : ¬ n.IsCarmichael := by
+  contrapose hn
+  exact hn.not_prime
+
+@[simp]
+theorem not_isCarmichael_zero : ¬ IsCarmichael 0 := by
+  intro h
+  simpa using h.two_lt
+
+@[simp]
+theorem not_isCarmichael_one : ¬ IsCarmichael 1 := by
+  intro h
+  simpa using h.two_lt
+
+-- TODO: move this to a more appropriate file
+lemma sub_one_pow_mod {n : ℕ} (hn : 2 ≤ n) (k : ℕ) :
+    (n - 1) ^ k % n = if Odd k then n - 1 else 1 := by
+  induction k with
+  | zero => simp [mod_eq_of_lt hn]
+  | succ k ih =>
+    simp only [pow_succ, mul_mod, ih, self_sub_mod, ite_mul, one_mul]
+    by_cases hk : Odd k
+    · simp only [hk, ↓reduceIte, not_odd_iff_even.mpr hk.add_one, mod_eq_iff]
+      refine Or.inr ⟨lt_of_succ_le hn, n - 2, ?_⟩
+      rw [Nat.mul_sub, Nat.mul_sub, mul_one, Nat.sub_mul, one_mul, Nat.sub_sub,
+        self_add_sub_one n, mul_comm 2, tsub_tsub_assoc (by gcongr)]
+      lia
+    · simp [hk, not_even_iff_odd.mpr (not_odd_iff_even.mp hk).add_one]
+
+-- TODO: move this to a more appropriate file
+lemma pow_mod_succ {n : ℕ} (hn : n ≠ 0) (k : ℕ) :
+    n ^ k % (n + 1) = if Odd k then n else 1 :=
+  sub_one_pow_mod (n := n + 1) (by lia) k
+
+/-- A Carmichael number is odd. -/
+theorem IsCarmichael.odd (h : n.IsCarmichael) : Odd n := by
+  have : n.ProbablePrime (n - 1) := h.probablePrime_of_coprime (b := n - 1)
+    <| (coprime_self_sub_left (by grind [h.two_lt])).mpr (by simp)
+  rw [ProbablePrime, dvd_iff_mod_eq_zero, ← mod_sub_of_le] at this
+  · rw [sub_one_pow_mod h.two_lt.le] at this
+    contrapose! this
+    simp_rw [(odd_sub' (m := n) (n := 1) (by grind [h.two_lt.le])).mpr (by simp_all)]
+    exact Nat.sub_ne_zero_iff_lt.mpr <| lt_sub_of_add_lt h.two_lt
+  · rw [sub_one_pow_mod h.two_lt.le]
+    by_cases h0 : Odd (n - 1)
+    · simp [h0]
+      grind [h.two_lt]
+    · simp [h0]
+
+lemma IsCarmichael.zmod_unit_pow_sub_one (s : (ZMod n)ˣ) (hn : n.IsCarmichael) :
+  s ^ (n - 1) = 1 := by
+  have _ : NeZero n := ⟨by grind [hn.two_lt]⟩
+  have suf : (↑s : ZMod n).val ^ (n - 1) ≡ 1 [MOD n] := by
+    apply (probablePrime_iff_modEq n ?_).mp <|
+      hn.probablePrime_of_coprime (ZMod.val_coe_unit_coprime s)
+    rw [one_le_iff_ne_zero]
+    intro hs0
+    have h_coprime := ZMod.val_coe_unit_coprime s
+    rw [hs0, coprime_zero_left] at h_coprime
+    grind [hn.two_lt]
+  ext
+  simp [← cast_one (R := ZMod n), ← (ZMod.natCast_eq_natCast_iff ..).mpr suf]
+
+/-- A Carmichael number is squarefree. -/
+theorem IsCarmichael.squarefree (h : n.IsCarmichael) : Squarefree n := by
+  intro k hk
+  rw [isUnit_iff_eq_one]
+  contrapose! hk
+  intro hn
+  obtain ⟨p, hp, pk⟩ := ne_one_iff_exists_prime_dvd.mp hk
+  have : NeZero (p ^ 2) := ⟨pow_ne_zero 2 hp.ne_zero⟩
+  have : NeZero n := ⟨by grind [h.two_lt]⟩
+  have p_dvd : p * p ∣ n := dvd_trans (by gcongr) hn
+  have p_odd : Odd p := h.odd.of_dvd_nat <| dvd_trans (p.dvd_mul_left p) p_dvd
+  have h_cyclic : IsCyclic (ZMod (p ^ 2))ˣ :=
+    (ZMod.isCyclic_units_iff_of_odd p_odd.pow).mpr ⟨p, 2, hp, p_odd, rfl⟩
+  obtain ⟨r, hr⟩ := isCyclic_iff_exists_orderOf_eq_natCard.mp h_cyclic
+  rw [card_eq_fintype_card, ZMod.card_units_eq_totient] at hr
+  have p_sq_dvd : p ^ 2 ∣ n := by simpa [pow_two] using p_dvd
+  obtain ⟨s, hs⟩ := ZMod.unitsMap_surjective p_sq_dvd r
+  have r_pow : r ^ (n - 1) = 1 := by rw [← hs, ← map_pow, h.zmod_unit_pow_sub_one, map_one]
+  have phi_dvd : φ (p ^ 2) ∣ n - 1 := by
+    rw [← hr]
+    exact orderOf_dvd_of_pow_eq_one r_pow
+  have p_dvd_sub : p ∣ n - 1 := dvd_trans (by simp [totient_prime_pow_succ hp 1]) phi_dvd
+  apply hp.ne_one
+  exact eq_one_of_dvd_coprimes ((coprime_self_sub_left (by grind [h.two_lt])).mpr (by simp))
+    p_dvd_sub (dvd_trans (p.dvd_mul_right p) p_dvd)
+
+theorem IsCarmichael.carmichael_dvd_pred (h : n.IsCarmichael) : carmichael n ∣ n - 1 := by
+  let _ : NeZero n := ⟨by grind [h.two_lt]⟩
+  rw [carmichael_eq_exponent']
+  apply Monoid.exponent_dvd_of_forall_pow_eq_one
+  intro s
+  exact h.zmod_unit_pow_sub_one s
+
+theorem IsCarmichael.prime_sub_one_dvd {p : ℕ} (h : n.IsCarmichael) (hp : p.Prime) (hpn : p ∣ n) :
+    p - 1 ∣ n - 1 := by
+  refine dvd_trans ?_ h.carmichael_dvd_pred
+  rw [← carmichael_of_prime hp]
+  exact carmichael_dvd (by simpa using hpn)
+
+/-- **Korselt's criterion** for Carmichael numbers:
+`n` is a Carmichael number if and only if it is greater than two, composite, sqaurefree and for all
+of for each prime divisor `p`, we have `p - 1 ∣ n - 1`. -/
+theorem isCarmichael_iff_korselt :
+    n.IsCarmichael ↔ 2 < n ∧ ¬n.Prime ∧ Squarefree n ∧ ∀ p, p.Prime → p ∣ n → p - 1 ∣ n - 1 := by
+  refine ⟨fun h ↦ ⟨h.two_lt, h.not_prime, h.squarefree, fun _ ↦ h.prime_sub_one_dvd⟩, ?_⟩
+  intro ⟨hn, hn_prime, hn_squarefree, h_dvd⟩
+  let _ : NeZero n := ⟨by lia⟩
+  refine ⟨hn, hn_prime, fun b hb ↦ ?_⟩
+  rw [probablePrime_iff_modEq n (show 1 ≤ b by grind)]
+  have carmichael_dvd : carmichael n ∣ n - 1 := by
+    rw [carmichael_factorization]
+    apply Finset.lcm_dvd
+    intro p hp_mem
+    rw [mem_primeFactors] at hp_mem
+    rw [factorization_eq_one_of_squarefree hn_squarefree hp_mem.1 hp_mem.2.1, pow_one,
+      carmichael_of_prime hp_mem.1]
+    exact h_dvd p hp_mem.1 hp_mem.2.1
+  obtain ⟨d, hd⟩ := carmichael_dvd
+  have hb_pow : (ZMod.unitOfCoprime b hb) ^ (n - 1) = 1 := by
+    rw [hd, pow_mul, pow_carmichael, one_pow]
+  have h_cast : (b : ZMod n) ^ (n - 1) = 1 := by
+    simpa using congrArg Units.val hb_pow
+  apply (ZMod.natCast_eq_natCast_iff ..).mp
+  simp [h_cast]
+
+/-- **Korselt's criterion** stated in a form suitable for concrete calculations. -/
+theorem isCarmichael_iff_korselt_primeFactorsList :
+    n.IsCarmichael ↔
+      2 < n ∧ ¬n.Prime ∧ n.primeFactorsList.Nodup ∧ ∀ p ∈ n.primeFactorsList, p - 1 ∣ n - 1 := by
+  simp only [isCarmichael_iff_korselt, mem_primeFactorsList', ne_eq, and_imp, and_congr_right_iff]
+  intro hn
+  rw [squarefree_iff_nodup_primeFactorsList] <;> grind
+
+/-- 561 is a Carmichael number. -/
+theorem isCarmichael_561 : IsCarmichael 561 := by
+  simp [isCarmichael_iff_korselt_primeFactorsList]
+  norm_num
+
+/-- 1105 is a Carmichael number. -/
+theorem isCarmichael_1105 : IsCarmichael 1105 := by
+  simp [isCarmichael_iff_korselt_primeFactorsList]
+  norm_num
+
+end Nat

--- a/Mathlib/NumberTheory/CarmichaelNumber.lean
+++ b/Mathlib/NumberTheory/CarmichaelNumber.lean
@@ -144,7 +144,7 @@ theorem IsCarmichael.squarefree (h : n.IsCarmichael) : Squarefree n := by
     p_dvd_sub (dvd_trans (p.dvd_mul_right p) p_dvd)
 
 theorem IsCarmichael.carmichael_dvd_pred (h : n.IsCarmichael) : carmichael n ∣ n - 1 := by
-  let _ : NeZero n := ⟨by grind [h.two_lt]⟩
+  have : NeZero n := ⟨by grind [h.two_lt]⟩
   rw [carmichael_eq_exponent']
   apply Monoid.exponent_dvd_of_forall_pow_eq_one
   intro s
@@ -163,7 +163,7 @@ theorem isCarmichael_iff_korselt :
     n.IsCarmichael ↔ 2 < n ∧ ¬n.Prime ∧ Squarefree n ∧ ∀ p, p.Prime → p ∣ n → p - 1 ∣ n - 1 := by
   refine ⟨fun h ↦ ⟨h.two_lt, h.not_prime, h.squarefree, fun _ ↦ h.prime_sub_one_dvd⟩, ?_⟩
   intro ⟨hn, hn_prime, hn_squarefree, h_dvd⟩
-  let _ : NeZero n := ⟨by lia⟩
+  have : NeZero n := ⟨by lia⟩
   refine ⟨hn, hn_prime, fun b hb ↦ ?_⟩
   rw [probablePrime_iff_modEq n (show 1 ≤ b by grind)]
   have carmichael_dvd : carmichael n ∣ n - 1 := by

--- a/Mathlib/NumberTheory/FermatPsp.lean
+++ b/Mathlib/NumberTheory/FermatPsp.lean
@@ -55,6 +55,10 @@ probable primes to any base.
 def ProbablePrime (n b : ℕ) : Prop :=
   n ∣ b ^ (n - 1) - 1
 
+theorem probablePrime_iff_zmod_one (n : ℕ) {b : ℕ} (hb : b ≠ 0) :
+    n.ProbablePrime b ↔ (b : ZMod n) ^ (n - 1) = 1 := by
+  rw [ProbablePrime, ← ZMod.natCast_eq_zero_iff, cast_pred (by positivity), sub_eq_zero, cast_pow]
+
 /--
 `n` is a Fermat pseudoprime to base `b` if `n` is a probable prime to base `b` and is composite. By
 this definition, all composite natural numbers are pseudoprimes to base 0 and 1. This definition


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Carmichael_number
I.e. composite numbers that pass the Euler-Fermat test for all basis (not to be confused with the carmichael function, which is in mathlib and use in this file...)

We also prove Korselt's criterion, which gives a relatively fast test is a number is a Carmichael number.

A fun challenge would be to prove efficiently that 561 is the smallest Carmicheal number. The following code works but is way too slow for mathlib:

```
example (hn : n < 561) : ¬ IsCarmichael n := by
  rw [isCarmichael_iff_korselt_primeFactorsList] at ⊢
  simp only [not_and, not_forall]
  intro
  interval_cases n
  all_goals simp only [List.nodup_nil, not_true_eq_false, List.not_mem_nil, imp_false,
    Decidable.not_not, IsEmpty.forall_iff, List.nodup_cons, not_false_eq_true, and_self,
    Nat.add_one_sub_one, List.mem_cons, or_false, exists_prop, primeFactorsList_ofNat,
    exists_eq_left, dvd_refl, forall_const, reduceEqDiff, or_self, and_true, and_false,
    or_self_left, exists_eq_or_imp, isUnit_iff_eq_one, IsUnit.dvd, ↓existsAndEq, reduceDvd, or_true,
    implies_true]
  all_goals norm_num 
 ```
 
 Some of the proofs were originally made by Codex, but heavily golfed etc

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
