### PR TITLE
[Merged by Bors] - chore(RingTheory/Ideal/Quotient): remove the Module.Finite instance for HasFiniteQuotients

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Basic.lean
@@ -10,6 +10,7 @@ public import Mathlib.Algebra.CharZero.AddMonoidHom
 public import Mathlib.Algebra.Ring.Int.Parity
 public import Mathlib.Algebra.Ring.Int.Units
 public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
+public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Basic
 public import Mathlib.Tactic.CrossRefAttribute
 
 /-!
@@ -318,6 +319,8 @@ instance : IsDedekindDomain (𝓞 K) :=
 
 instance : Free ℤ (𝓞 K) :=
   IsIntegralClosure.module_free ℤ ℚ K (𝓞 K)
+
+instance : Ring.HasFiniteQuotients (𝓞 K) := .of_moduleFinite_int
 
 instance : IsLocalization (Algebra.algebraMapSubmonoid (𝓞 K) ℤ⁰) K :=
   IsIntegralClosure.isLocalization_of_isSeparable ℤ ℚ K (𝓞 K)

--- a/Mathlib/NumberTheory/NumberField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Basic.lean
@@ -320,7 +320,7 @@ instance : IsDedekindDomain (𝓞 K) :=
 instance : Free ℤ (𝓞 K) :=
   IsIntegralClosure.module_free ℤ ℚ K (𝓞 K)
 
-instance : Ring.HasFiniteQuotients (𝓞 K) := .of_module_finite_int
+instance : Ring.HasFiniteQuotients (𝓞 K) := .of_module_finite ℤ _
 
 instance : IsLocalization (Algebra.algebraMapSubmonoid (𝓞 K) ℤ⁰) K :=
   IsIntegralClosure.isLocalization_of_isSeparable ℤ ℚ K (𝓞 K)

--- a/Mathlib/NumberTheory/NumberField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Basic.lean
@@ -320,7 +320,7 @@ instance : IsDedekindDomain (𝓞 K) :=
 instance : Free ℤ (𝓞 K) :=
   IsIntegralClosure.module_free ℤ ℚ K (𝓞 K)
 
-instance : Ring.HasFiniteQuotients (𝓞 K) := .of_moduleFinite_int
+instance : Ring.HasFiniteQuotients (𝓞 K) := .of_module_finite_int
 
 instance : IsLocalization (Algebra.algebraMapSubmonoid (𝓞 K) ℤ⁰) K :=
   IsIntegralClosure.isLocalization_of_isSeparable ℤ ℚ K (𝓞 K)

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Galois.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Galois.lean
@@ -116,6 +116,7 @@ theorem mem_zpowers_galEquivZMod_of_mem_stabilizer {σ : Gal(K/ℚ)} (hσ : σ �
   let τ := IsFractionRing.stabilizerHom Gal(K/ℚ) (Ideal.span {(p : ℤ)}) P
      (ℤ ⧸ span {(p : ℤ)}) (𝓞 K ⧸ P) ⟨σ, hσ⟩
   have : CharP (ℤ ⧸ span {(p : ℤ)}) p := ringChar.of_eq <| Int.ringChar_idealQuot p
+  have : Ring.HasFiniteQuotients (𝓞 K) := .of_moduleFinite_int
   have : Finite (𝓞 K ⧸ P) := Ring.HasFiniteQuotients.finiteQuotient (NeZero.ne P)
   obtain ⟨i, hi⟩ := FiniteField.exists_forall_apply_eq_pow (ℤ ⧸ span {(p : ℤ)}) p (𝓞 K ⧸ P) τ
   refine ⟨i, ?_⟩

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Galois.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Galois.lean
@@ -116,7 +116,6 @@ theorem mem_zpowers_galEquivZMod_of_mem_stabilizer {σ : Gal(K/ℚ)} (hσ : σ �
   let τ := IsFractionRing.stabilizerHom Gal(K/ℚ) (Ideal.span {(p : ℤ)}) P
      (ℤ ⧸ span {(p : ℤ)}) (𝓞 K ⧸ P) ⟨σ, hσ⟩
   have : CharP (ℤ ⧸ span {(p : ℤ)}) p := ringChar.of_eq <| Int.ringChar_idealQuot p
-  have : Ring.HasFiniteQuotients (𝓞 K) := .of_moduleFinite_int
   have : Finite (𝓞 K ⧸ P) := Ring.HasFiniteQuotients.finiteQuotient (NeZero.ne P)
   obtain ⟨i, hi⟩ := FiniteField.exists_forall_apply_eq_pow (ℤ ⧸ span {(p : ℤ)}) p (𝓞 K ⧸ P) τ
   refine ⟨i, ?_⟩

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -95,7 +95,7 @@ lemma isUnramifiedAt_iff_of_isDedekindDomain
     {p : Ideal S} [p.IsPrime] [EssFiniteType R S] [IsDomain R]
     [Module.Finite ℤ R] [CharZero R] [Algebra.IsIntegral R S] :
     Algebra.IsUnramifiedAt R p ↔ e(p|R) = 1 := by
-  have : Ring.HasFiniteQuotients R := .of_module_finite_int
+  have : Ring.HasFiniteQuotients R := .of_module_finite ℤ _
   exact Ideal.ramificationIdx'_eq_one_iff.symm
 
 /-- In characteristic zero the generic point is unramified: if `S` is a domain that is integral
@@ -153,7 +153,7 @@ theorem IsUnramifiedIn.ramificationIdx_eq_one [IsDomain R]
     [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedIn S 𝔭) {𝔓 : Ideal S}
     [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx 𝔓 R = 1 := by
-  have : Ring.HasFiniteQuotients R := .of_module_finite_int
+  have : Ring.HasFiniteQuotients R := .of_module_finite ℤ _
   exact Ideal.ramificationIdx_eq_one_iff.mpr (hunr 𝔓 inferInstance hP)
 
 /-- A nonzero ideal of `R` is unramified in `S` if and only if every prime ideal of `S` lying
@@ -163,7 +163,7 @@ theorem isUnramifiedIn_iff_forall_ramificationIdx_eq_one [IsDomain R]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} :
     IsUnramifiedIn S 𝔭 ↔
       ∀ (𝔓 : Ideal S) [𝔓.IsPrime], 𝔓.LiesOver 𝔭 → Ideal.ramificationIdx 𝔓 R = 1 := by
-  have : Ring.HasFiniteQuotients R := .of_module_finite_int
+  have : Ring.HasFiniteQuotients R := .of_module_finite ℤ _
   refine ⟨fun hunr 𝔓 _ hP ↦ hunr.ramificationIdx_eq_one hP, fun h 𝔓 _ hP ↦ ?_⟩
   rw [← Ideal.ramificationIdx_eq_one_iff]
   exact h 𝔓 hP

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -94,8 +94,9 @@ that is a finite `R`-algebra. Let `p` be a prime of `S`, then `p` is unramified 
 lemma isUnramifiedAt_iff_of_isDedekindDomain
     {p : Ideal S} [p.IsPrime] [EssFiniteType R S] [IsDomain R]
     [Module.Finite ℤ R] [CharZero R] [Algebra.IsIntegral R S] :
-    Algebra.IsUnramifiedAt R p ↔ e(p|R) = 1 :=
-  Ideal.ramificationIdx'_eq_one_iff.symm
+    Algebra.IsUnramifiedAt R p ↔ e(p|R) = 1 := by
+  have : Ring.HasFiniteQuotients R := .of_moduleFinite_int
+  exact Ideal.ramificationIdx'_eq_one_iff.symm
 
 /-- In characteristic zero the generic point is unramified: if `S` is a domain that is integral
 over a characteristic-zero domain `R` and `R → S` is injective, then `S` is unramified at the zero
@@ -151,9 +152,9 @@ theorem isUnramifiedIn_iff_forall_of_isDedekindDomain [IsDomain R] [IsDedekindDo
 theorem IsUnramifiedIn.ramificationIdx_eq_one [IsDomain R]
     [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedIn S 𝔭) {𝔓 : Ideal S}
-    [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx 𝔓 R = 1 :=
-  Ideal.ramificationIdx_eq_one_iff.mpr
-    (hunr 𝔓 inferInstance hP)
+    [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx 𝔓 R = 1 := by
+  have : Ring.HasFiniteQuotients R := .of_moduleFinite_int
+  exact Ideal.ramificationIdx_eq_one_iff.mpr (hunr 𝔓 inferInstance hP)
 
 /-- A nonzero ideal of `R` is unramified in `S` if and only if every prime ideal of `S` lying
 over it has ramification index `1`. -/
@@ -162,6 +163,7 @@ theorem isUnramifiedIn_iff_forall_ramificationIdx_eq_one [IsDomain R]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} :
     IsUnramifiedIn S 𝔭 ↔
       ∀ (𝔓 : Ideal S) [𝔓.IsPrime], 𝔓.LiesOver 𝔭 → Ideal.ramificationIdx 𝔓 R = 1 := by
+  have : Ring.HasFiniteQuotients R := .of_moduleFinite_int
   refine ⟨fun hunr 𝔓 _ hP ↦ hunr.ramificationIdx_eq_one hP, fun h 𝔓 _ hP ↦ ?_⟩
   rw [← Ideal.ramificationIdx_eq_one_iff]
   exact h 𝔓 hP

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -95,7 +95,7 @@ lemma isUnramifiedAt_iff_of_isDedekindDomain
     {p : Ideal S} [p.IsPrime] [EssFiniteType R S] [IsDomain R]
     [Module.Finite ℤ R] [CharZero R] [Algebra.IsIntegral R S] :
     Algebra.IsUnramifiedAt R p ↔ e(p|R) = 1 := by
-  have : Ring.HasFiniteQuotients R := .of_moduleFinite_int
+  have : Ring.HasFiniteQuotients R := .of_module_finite_int
   exact Ideal.ramificationIdx'_eq_one_iff.symm
 
 /-- In characteristic zero the generic point is unramified: if `S` is a domain that is integral
@@ -153,7 +153,7 @@ theorem IsUnramifiedIn.ramificationIdx_eq_one [IsDomain R]
     [Module.Finite ℤ R] [CharZero R] [EssFiniteType R S]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} (hunr : IsUnramifiedIn S 𝔭) {𝔓 : Ideal S}
     [𝔓.IsPrime] (hP : 𝔓.LiesOver 𝔭) : Ideal.ramificationIdx 𝔓 R = 1 := by
-  have : Ring.HasFiniteQuotients R := .of_moduleFinite_int
+  have : Ring.HasFiniteQuotients R := .of_module_finite_int
   exact Ideal.ramificationIdx_eq_one_iff.mpr (hunr 𝔓 inferInstance hP)
 
 /-- A nonzero ideal of `R` is unramified in `S` if and only if every prime ideal of `S` lying
@@ -163,7 +163,7 @@ theorem isUnramifiedIn_iff_forall_ramificationIdx_eq_one [IsDomain R]
     [Algebra.IsIntegral R S] {𝔭 : Ideal R} :
     IsUnramifiedIn S 𝔭 ↔
       ∀ (𝔓 : Ideal S) [𝔓.IsPrime], 𝔓.LiesOver 𝔭 → Ideal.ramificationIdx 𝔓 R = 1 := by
-  have : Ring.HasFiniteQuotients R := .of_moduleFinite_int
+  have : Ring.HasFiniteQuotients R := .of_module_finite_int
   refine ⟨fun hunr 𝔓 _ hP ↦ hunr.ramificationIdx_eq_one hP, fun h 𝔓 _ hP ↦ ?_⟩
   rw [← Ideal.ramificationIdx_eq_one_iff]
   exact h 𝔓 hP

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -493,7 +493,7 @@ lemma exists_isMaximal_dvd_of_dvd_absNorm'
 
 theorem finite_setOfPred_absNorm_le (n : ℕ) :
     {I : Ideal S | Ideal.absNorm I ≤ n}.Finite := by
-  have : Ring.HasFiniteQuotients S := .of_module_finite_int
+  have : Ring.HasFiniteQuotients S := .of_module_finite ℤ _
   simpa [absNorm_apply] using Ring.HasFiniteQuotients.finite_cardQuot_le (S := S) n
 
 @[deprecated (since := "2026-07-09")] alias finite_setOf_absNorm_le := finite_setOfPred_absNorm_le

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -493,7 +493,7 @@ lemma exists_isMaximal_dvd_of_dvd_absNorm'
 
 theorem finite_setOfPred_absNorm_le (n : ℕ) :
     {I : Ideal S | Ideal.absNorm I ≤ n}.Finite := by
-  have : Ring.HasFiniteQuotients S := .of_moduleFinite_int
+  have : Ring.HasFiniteQuotients S := .of_module_finite_int
   simpa [absNorm_apply] using Ring.HasFiniteQuotients.finite_cardQuot_le (S := S) n
 
 @[deprecated (since := "2026-07-09")] alias finite_setOf_absNorm_le := finite_setOfPred_absNorm_le

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -493,6 +493,7 @@ lemma exists_isMaximal_dvd_of_dvd_absNorm'
 
 theorem finite_setOfPred_absNorm_le (n : ℕ) :
     {I : Ideal S | Ideal.absNorm I ≤ n}.Finite := by
+  have : Ring.HasFiniteQuotients S := .of_moduleFinite_int
   simpa [absNorm_apply] using Ring.HasFiniteQuotients.finite_cardQuot_le (S := S) n
 
 @[deprecated (since := "2026-07-09")] alias finite_setOf_absNorm_le := finite_setOfPred_absNorm_le

--- a/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Basic.lean
@@ -20,8 +20,6 @@ quotient `R ⧸ I` is finite.
 - `Ring.HasFiniteQuotients.instIsNoetherianRing` : A ring with finite quotients is noetherian.
 - `Ring.HasFiniteQuotients.of_module_finite`: Assume that `R` has finite quotients and that `S` is
   a domain and a finite `R`-module. Then `S` has finite quotients.
-- `Ring.HasFiniteQuotients.of_module_finite_int`: A domain that is a finite `ℤ`-module has finite
-  quotients.
 
 -/
 
@@ -99,10 +97,5 @@ instance : HasFiniteQuotients ℤ where
     obtain ⟨n, rfl⟩ := Submodule.IsPrincipal.principal I
     have : NeZero n := ⟨by simpa using hI⟩
     exact inferInstanceAs <| Finite (ℤ ⧸ Ideal.span {n})
-
-/-- A domain that is a finite `ℤ`-module has finite quotients.
-This cannot be an instance since it is very slow to fail. -/
-theorem of_module_finite_int [IsDomain R] [Module.Finite ℤ R] : HasFiniteQuotients R :=
-  .of_module_finite ℤ R
 
 end Ring.HasFiniteQuotients

--- a/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Basic.lean
@@ -20,7 +20,7 @@ quotient `R ⧸ I` is finite.
 - `Ring.HasFiniteQuotients.instIsNoetherianRing` : A ring with finite quotients is noetherian.
 - `Ring.HasFiniteQuotients.of_module_finite`: Assume that `R` has finite quotients and that `S` is
   a domain and a finite `R`-module. Then `S` has finite quotients.
-- `Ring.HasFiniteQuotients.of_moduleFinite_int`: A domain that is a finite `ℤ`-module has finite
+- `Ring.HasFiniteQuotients.of_module_finite_int`: A domain that is a finite `ℤ`-module has finite
   quotients.
 
 -/
@@ -102,7 +102,7 @@ instance : HasFiniteQuotients ℤ where
 
 /-- A domain that is a finite `ℤ`-module has finite quotients.
 This cannot be an instance since it is very slow to fail. -/
-theorem of_moduleFinite_int [IsDomain R] [Module.Finite ℤ R] : HasFiniteQuotients R :=
+theorem of_module_finite_int [IsDomain R] [Module.Finite ℤ R] : HasFiniteQuotients R :=
   .of_module_finite ℤ R
 
 end Ring.HasFiniteQuotients

--- a/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Basic.lean
@@ -21,7 +21,7 @@ quotient `R ⧸ I` is finite.
 - `Ring.HasFiniteQuotients.of_module_finite`: Assume that `R` has finite quotients and that `S` is
   a domain and a finite `R`-module. Then `S` has finite quotients.
 - `Ring.HasFiniteQuotients.of_moduleFinite_int`: A domain that is a finite `ℤ`-module has finite
-  quotients (a lemma, not an instance: see its docstring).
+  quotients.
 
 -/
 
@@ -101,10 +101,7 @@ instance : HasFiniteQuotients ℤ where
     exact inferInstanceAs <| Finite (ℤ ⧸ Ideal.span {n})
 
 /-- A domain that is a finite `ℤ`-module has finite quotients.
-
-Not an instance: `Module.Finite ℤ R` is expensive to *refute*, so a global instance keyed on it
-makes every failing `HasFiniteQuotients R` search slow. Provide it explicitly (as an instance or a
-`have`/`letI`) for the rings that need it. -/
+This cannot be an instance since it is very slow to fail. -/
 theorem of_moduleFinite_int [IsDomain R] [Module.Finite ℤ R] : HasFiniteQuotients R :=
   .of_module_finite ℤ R
 

--- a/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients/Basic.lean
@@ -20,8 +20,8 @@ quotient `R ⧸ I` is finite.
 - `Ring.HasFiniteQuotients.instIsNoetherianRing` : A ring with finite quotients is noetherian.
 - `Ring.HasFiniteQuotients.of_module_finite`: Assume that `R` has finite quotients and that `S` is
   a domain and a finite `R`-module. Then `S` has finite quotients.
-- `Ring.HasFiniteQuotients.instOfIsDomainOfFG`: A domain that is also a finite `ℤ`-module
-  has finite quotients.
+- `Ring.HasFiniteQuotients.of_moduleFinite_int`: A domain that is a finite `ℤ`-module has finite
+  quotients (a lemma, not an instance: see its docstring).
 
 -/
 
@@ -100,8 +100,12 @@ instance : HasFiniteQuotients ℤ where
     have : NeZero n := ⟨by simpa using hI⟩
     exact inferInstanceAs <| Finite (ℤ ⧸ Ideal.span {n})
 
-/-- A domain that is finitely generated has finite quotients. -/
-instance [IsDomain R] [Module.Finite ℤ R] : HasFiniteQuotients R :=
+/-- A domain that is a finite `ℤ`-module has finite quotients.
+
+Not an instance: `Module.Finite ℤ R` is expensive to *refute*, so a global instance keyed on it
+makes every failing `HasFiniteQuotients R` search slow. Provide it explicitly (as an instance or a
+`have`/`letI`) for the rings that need it. -/
+theorem of_moduleFinite_int [IsDomain R] [Module.Finite ℤ R] : HasFiniteQuotients R :=
   .of_module_finite ℤ R
 
 end Ring.HasFiniteQuotients


### PR DESCRIPTION
The instance `[IsDomain R] [Module.Finite ℤ R] → Ring.HasFiniteQuotients R` is expensive to *refute*: whenever `HasFiniteQuotients R` is searched for a ring that is not a finite `ℤ`-module, Lean tries this instance and pays a slow failing `Module.Finite ℤ R` search. This caused the regressions after #42784.

This removes the instance, so it is no longer tried during instance search. The few proofs that relied on inferring `HasFiniteQuotients` from `[Module.Finite ℤ R]` now derive it locally.

A concrete `Ring.HasFiniteQuotients (𝓞 K)` instance is also added for the ring of integers of a number field.

Prepared with Claude Code 🤖

---
