### PR TITLE
[Merged by Bors] - fix(Analysis): two lemmas are copies of the one above them

### DIFF
--- a/Mathlib/Analysis/Calculus/Darboux.lean
+++ b/Mathlib/Analysis/Calculus/Darboux.lean
@@ -130,10 +130,10 @@ theorem exists_hasDerivWithinAt_eq_of_ge_of_le (hab : a ≤ b)
 /-- **Darboux's theorem**: if `a ≤ b` and `f' b ≤ m ≤ f' a`, then `f' c = m` for some
 `c ∈ [a, b]`. -/
 theorem exists_hasDerivWithinAt_eq_of_le_of_ge (hab : a ≤ b)
-    (hf : ∀ x ∈ Icc a b, HasDerivWithinAt f (f' x) (Icc a b) x) {m : ℝ} (hma : f' a ≤ m)
-    (hmb : m ≤ f' b) : m ∈ f' '' Icc a b :=
-  (ordConnected_Icc.image_hasDerivWithinAt hf).out (mem_image_of_mem _ (left_mem_Icc.2 hab))
-    (mem_image_of_mem _ (right_mem_Icc.2 hab)) ⟨hma, hmb⟩
+    (hf : ∀ x ∈ Icc a b, HasDerivWithinAt f (f' x) (Icc a b) x) {m : ℝ} (hma : m ≤ f' a)
+    (hmb : f' b ≤ m) : m ∈ f' '' Icc a b :=
+  (ordConnected_Icc.image_hasDerivWithinAt hf).out (mem_image_of_mem _ (right_mem_Icc.2 hab))
+    (mem_image_of_mem _ (left_mem_Icc.2 hab)) ⟨hmb, hma⟩
 
 /-- If the derivative of a function is never equal to `m`, then either
 it is always greater than `m`, or it is always less than `m`. -/

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
@@ -195,8 +195,8 @@ theorem dist_le_iff_dist_coe_center_le :
   le_iff_le_of_cmp_eq_cmp (cmp_dist_eq_cmp_dist_coe_center z w r)
 
 theorem le_dist_iff_le_dist_coe_center :
-    r < dist z w ↔ w.im * Real.sinh r < dist (z : ℂ) (w.center r) :=
-  lt_iff_lt_of_cmp_eq_cmp (cmp_eq_cmp_symm.1 <| cmp_dist_eq_cmp_dist_coe_center z w r)
+    r ≤ dist z w ↔ w.im * Real.sinh r ≤ dist (z : ℂ) (w.center r) :=
+  le_iff_le_of_cmp_eq_cmp (cmp_eq_cmp_symm.1 <| cmp_dist_eq_cmp_dist_coe_center z w r)
 
 /-- For two points on the same vertical line, the distance is equal to the distance between the
 logarithms of their imaginary parts. -/


### PR DESCRIPTION
two lemmas are copies of the one above them 

Darboux's `_of_le_of_ge` (contradicts its docstring) and `le_dist_iff_le_dist_coe_center`. 

Used Aristotle AI to find this duplicate

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
