### PR TITLE
chore(downstream_repos): add FormalSLT

### DIFF
--- a/scripts/downstream_repos.yml
+++ b/scripts/downstream_repos.yml
@@ -46,6 +46,12 @@
   default_branch: main
   name: Formal Conjectures
   zulip-contact: Eric Wieser
+- github: https://github.com/Robby955/FormalSLT
+  default_branch: main
+  name: FormalSLT - Formal Statistical Learning Theory
+  workflows:
+    build: ci.yml
+    docs: docs.yml
 - github: https://github.com/girving/series
   default_branch: main
   name: Power Series Arithmetic


### PR DESCRIPTION
## Summary

This adds [FormalSLT](https://github.com/Robby955/FormalSLT) to
`scripts/downstream_repos.yml`, and therefore to the Lean community's
[open-source projects page](https://leanprover-community.github.io/lean_projects.html).

FormalSLT is an MIT-licensed Lean 4/mathlib library for machine-checked
statistical learning theory. Its existing `main`-branch CI and documentation
workflow filenames are included for the downstream dashboard.

## Why it is a mathlib downstream

FormalSLT is built directly on mathlib rather than merely using Lean syntax.
Its theorem surface imports and extends mathlib's measure-theory and probability
APIs, finite product measures, PMFs and Markov kernels, filtrations,
martingales, conditional expectation and optional stopping, information-theoretic
KL divergence, real analysis, topology, and finite combinatorics.

The project pins compatible Lean and mathlib releases through Lake, and its
`main` CI builds the library and theorem checkers against that pin. Adding it to
the downstream dashboard gives mathlib a substantial probability/statistics
compatibility target.

## Use in accepted research

- [*From Agents to Axioms: Verifier-Gated Lean Formalization for Statistical
  Learning Theory*](https://openreview.net/forum?id=EsEqPLc0ef) ICML 2026 AI for Math workshop and uses FormalSLT as its checked artifact.
- *A Machine-Checked Anytime-Valid Confidence Sequence by the Method of
  Mixtures* [COPA 2026](https://copa-conference.com/). 
  its Lean result is implemented and audited in FormalSLT.

These are project research outputs that use FormalSLT, not claims of independent
third-party citation.

## Validation

- the YAML parses successfully;
- the FormalSLT entry is unique;
- the named `ci.yml` and `docs.yml` workflows exist on FormalSLT's default
  branch;
- `git diff --check` passes.

## AI usage

FormalSLT permits and uses LLM-assisted formalization as part of its development
workflow. All resulting Lean declarations are checked by the Lean kernel, and
the project treats machine-checkable verification rather than authorship method
as the correctness criterion. This PR itself only adds FormalSLT to the mathlib
downstream-project configuration.

## Relevant Zulip Topics

- [#mathlib4 > Villes Inequality](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Villes.20Inequality/with/599033270)