### PR TITLE
[Merged by Bors] - feat(Topology/InfiniteSum): applying the sum of functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7731,6 +7731,7 @@ public import Mathlib.Topology.Algebra.Indicator
 public import Mathlib.Topology.Algebra.InfiniteSum.Basic
 public import Mathlib.Topology.Algebra.InfiniteSum.ConditionalInt
 public import Mathlib.Topology.Algebra.InfiniteSum.Constructions
+public import Mathlib.Topology.Algebra.InfiniteSum.ContinuousMap
 public import Mathlib.Topology.Algebra.InfiniteSum.Defs
 public import Mathlib.Topology.Algebra.InfiniteSum.DiscreteConvolution
 public import Mathlib.Topology.Algebra.InfiniteSum.ENNReal

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7731,7 +7731,7 @@ public import Mathlib.Topology.Algebra.Indicator
 public import Mathlib.Topology.Algebra.InfiniteSum.Basic
 public import Mathlib.Topology.Algebra.InfiniteSum.ConditionalInt
 public import Mathlib.Topology.Algebra.InfiniteSum.Constructions
-public import Mathlib.Topology.Algebra.InfiniteSum.ContinuousMap
+public import Mathlib.Topology.Algebra.InfiniteSum.ContinuousEval
 public import Mathlib.Topology.Algebra.InfiniteSum.Defs
 public import Mathlib.Topology.Algebra.InfiniteSum.DiscreteConvolution
 public import Mathlib.Topology.Algebra.InfiniteSum.ENNReal

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
@@ -362,7 +362,7 @@ theorem Measurable.ennreal_tsum {ι} [Countable ι] {f : ι → α → ℝ≥0�
 theorem Measurable.ennreal_tsum' {ι} [Countable ι] {f : ι → α → ℝ≥0∞} (h : ∀ i, Measurable (f i)) :
     Measurable (∑' i, f i) := by
   convert! Measurable.ennreal_tsum h with x
-  exact tsum_apply (Pi.summable.2 fun _ => ENNReal.summable)
+  exact Pi.tsum_apply (Pi.summable.2 fun _ => ENNReal.summable)
 
 @[fun_prop, deprecated
   "Use `Measurable.tsum` from `Mathlib.MeasureTheory.Constructions.Polish.Basic` instead"

--- a/Mathlib/MeasureTheory/Measure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensity.lean
@@ -187,7 +187,7 @@ theorem withDensity_tsum {ι : Type*} [Countable ι] {f : ι → α → ℝ≥0�
   simp_rw [sum_apply _ hs, withDensity_apply _ hs]
   change ∫⁻ x in s, (∑' n, f n) x ∂μ = ∑' i, ∫⁻ x, f i x ∂μ.restrict s
   rw [← lintegral_tsum fun i => (h i).aemeasurable]
-  exact lintegral_congr fun x => tsum_apply (Pi.summable.2 fun _ => ENNReal.summable)
+  exact lintegral_congr fun x => Pi.tsum_apply (Pi.summable.2 fun _ => ENNReal.summable)
 
 theorem withDensity_indicator {s : Set α} (hs : MeasurableSet s) (f : α → ℝ≥0∞) :
     μ.withDensity (s.indicator f) = (μ.restrict s).withDensity f := by

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -165,13 +165,13 @@ theorem withDensity_tsum [Countable ι] (κ : Kernel α β) [IsSFiniteKernel κ]
   · have : Function.uncurry (∑' n, f n) = ∑' n, Function.uncurry (f n) := by
       ext1 p
       simp only [Function.uncurry_def]
-      rw [tsum_apply h_sum, tsum_apply (h_sum_a _), tsum_apply]
+      rw [Pi.tsum_apply h_sum, Pi.tsum_apply (h_sum_a _), Pi.tsum_apply]
       exact Pi.summable.mpr fun p => ENNReal.summable
     rw [this]
     fun_prop
   have : ∫⁻ b in s, (∑' n, f n) a b ∂κ a = ∫⁻ b in s, ∑' n, (fun b => f n a b) b ∂κ a := by
     congr with b
-    rw [tsum_apply h_sum, tsum_apply (h_sum_a a)]
+    rw [Pi.tsum_apply h_sum, Pi.tsum_apply (h_sum_a a)]
   rw [this, lintegral_tsum fun n => by fun_prop]
   congr with n
   rw [Kernel.withDensity_apply' _ (hf n) a s]
@@ -218,7 +218,7 @@ theorem isSFiniteKernel_withDensity_of_isFiniteKernel (κ : Kernel α β) [IsFin
     have h_sum_a : ∀ a, Summable fun n => fs n a :=
       fun _ => Pi.summable.mpr fun _ => ENNReal.summable
     ext a b : 2
-    rw [tsum_apply (Pi.summable.mpr h_sum_a), tsum_apply (h_sum_a a),
+    rw [Pi.tsum_apply (Pi.summable.mpr h_sum_a), Pi.tsum_apply (h_sum_a a),
       ENNReal.tsum_eq_liminf_sum_nat]
     have h_finsetSum : ∀ n, ∑ i ∈ Finset.range n, fs i a b = min (f a b) n := fun n ↦ by
       induction n with

--- a/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
@@ -270,18 +270,21 @@ section Pi
 variable {ι : Type*} {X : α → Type*} [∀ x, CommMonoid (X x)] [∀ x, TopologicalSpace (X x)]
   {L : SummationFilter ι}
 
-@[to_additive]
+/-- See also `hasProd_apply` for `FunLike` types. -/
+@[to_additive /-- See also `hasSum_apply` for `FunLike` types. -/]
 theorem Pi.hasProd {f : ι → ∀ x, X x} {g : ∀ x, X x} :
     HasProd f g L ↔ ∀ x, HasProd (fun i ↦ f i x) (g x) L := by
   simp only [HasProd, tendsto_pi_nhds, Finset.prod_apply]
 
-@[to_additive]
+/-- See also `multipliable_apply` for `FunLike` types. -/
+@[to_additive /-- See also `summable_apply` for `FunLike` types. -/]
 theorem Pi.multipliable {f : ι → ∀ x, X x} :
     Multipliable f L ↔ ∀ x, Multipliable (fun i ↦ f i x) L := by
   simp only [Multipliable, Pi.hasProd, Classical.skolem]
 
-@[to_additive]
-theorem tprod_apply [L.NeBot] [∀ x, T2Space (X x)] {f : ι → ∀ x, X x} {x : α}
+/-- See also `tprod_apply` for `FunLike` types. -/
+@[to_additive /-- See also `tsum_apply` for `FunLike` types. -/]
+theorem Pi.tprod_apply [L.NeBot] [∀ x, T2Space (X x)] {f : ι → ∀ x, X x} {x : α}
     (hf : Multipliable f L) : (∏'[L] i, f i) x = ∏'[L] i, f i x :=
   (Pi.hasProd.mp hf.hasProd x).tprod_eq.symm
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/ContinuousEval.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ContinuousEval.lean
@@ -10,7 +10,7 @@ public import Mathlib.Topology.Hom.ContinuousEval
 
 import Mathlib.Data.FunLike.Group
 
-/-! # Infinite sums with continuous maps
+/-! # Applying an infinite sum of functions
 
 This file provides lemmas for `(∏'[L] n, f n) x` and `(∑'[L] n, f n) x` where `f` is a family of
 functions. We state this for `FunLike` objects that are `ContinuousEvalConst`. This is applicable

--- a/Mathlib/Topology/Algebra/InfiniteSum/ContinuousMap.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ContinuousMap.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2026 Weiyi Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Weiyi Wang
+-/
+module
+
+public import Mathlib.Topology.Algebra.InfiniteSum.Basic
+public import Mathlib.Topology.Hom.ContinuousEval
+
+import Mathlib.Data.FunLike.Group
+
+/-! # Infinite sums with continuous maps
+
+This file provides lemmas for `(∏'[L] n, f n) x` and `(∑'[L] n, f n) x` where `f` is a family of
+functions. We state this for `FunLike` objects that are `ContinuousEvalConst`. This is applicable
+to e.g. `ContinuousLinearMap`.
+-/
+
+public section
+
+variable {α β γ F : Type*} [TopologicalSpace β] [CommMonoid β]
+  [FunLike F α β] [TopologicalSpace F] [CommMonoid F] [ContinuousEvalConst F α β]
+  [IsMulApply F α β] [IsOneApply F α β] {f : γ → F} {g : F} {L : SummationFilter γ}
+
+/-- See also `Pi.hasProd` for bare pi type. -/
+@[to_additive /-- See also `Pi.hasSum` for bare pi type. -/]
+theorem hasProd_apply (hf : HasProd f g L) (x : α) : HasProd (f · x) (g x) L :=
+  hf.map ((Pi.evalMonoidHom _ x).comp (FunLike.coeMonoidHom F α β)) (continuous_eval_const x)
+
+/-- See also `Pi.multipliable` for bare pi type. -/
+@[to_additive /-- See also `Pi.summable` for bare pi type. -/]
+theorem multipliable_apply (hf : Multipliable f L) (x : α) : Multipliable (f · x) L :=
+  hf.map ((Pi.evalMonoidHom _ x).comp (FunLike.coeMonoidHom F α β)) (continuous_eval_const x)
+
+/-- See also `Pi.tprod_apply` for bare pi type. -/
+@[to_additive /-- See also `Pi.tsum_apply` for bare pi type. -/]
+theorem tprod_apply [T2Space β] [L.NeBot] (hf : Multipliable f L) (x : α) :
+    (∏'[L] n, f n) x = ∏'[L] n, f n x :=
+  hf.map_tprod ((Pi.evalMonoidHom _ x).comp (FunLike.coeMonoidHom F α β)) (continuous_eval_const x)

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -241,7 +241,7 @@ theorem tendsto_tsum_compl_atTop_zero {α : Type*} {f : α → ℝ≥0∞} (hf :
 
 protected theorem tsum_apply {ι α : Type*} {f : ι → α → ℝ≥0∞} {x : α} :
     (∑' i, f i) x = ∑' i, f i x :=
-  tsum_apply <| Pi.summable.mpr fun _ => ENNReal.summable
+  Pi.tsum_apply <| Pi.summable.mpr fun _ => ENNReal.summable
 
 theorem tsum_sub {f : ℕ → ℝ≥0∞} {g : ℕ → ℝ≥0∞} (h₁ : ∑' i, g i ≠ ∞) (h₂ : g ≤ f) :
     ∑' i, (f i - g i) = ∑' i, f i - ∑' i, g i :=


### PR DESCRIPTION
These three one-liners are provided mostly for discoverability. Especially for `tsum_apply`: when one search for lemma in this shape, they will find the version for pi topology, which is not applicable for function spaces with other topology (e.g. `ContinuousLinearMap`). 

This PR comes with a breaking change: the original `tprod_apply` theorem is now moved to the `Pi` namespace, alone with existing `Pi.hasProd` and `Pi.multipliable`. The new `tprod_apply` is stated for all suitable FunLike objects.

---

As a side note, the new `tprod_apply` should apply to `ContinuousMap`, but doesn't as-is. This is because there isn't `IsMulApply` and `IsOneApply` instances for `ContinuousMap` yet. This can be in a separate PR. Once that's done, the existing `ContinuousMap.tprod_apply` can be deprecated.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
