### PR TITLE
feat(Combinatorics/SimpleGraph/Connectivity): efficient decidability instances

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
@@ -11,16 +11,10 @@ public import Mathlib.Combinatorics.SimpleGraph.Walk.Counting
 public import Mathlib.Data.Set.Card
 
 /-!
-# Counting walks of a given length
+# Connectivity in a finite graph
 
-## Main definitions
-- `walkLengthTwoEquivCommonNeighbors`: bijective correspondence between walks of length two
-from `u` to `v` and common neighbours of `u` and `v`. Note that `u` and `v` may be the same.
-- `finsetWalkLength`: the `Finset` of length-`n` walks from `u` to `v`.
-This is used to give `{p : G.walk u v | p.length = n}` a `Fintype` instance, and it
-can also be useful as a recursive description of this set when `V` is finite.
-
-TODO: should this be extended further?
+This file provides efficient decidability instances for reachability and (pre)connectedness of
+finite graphs through a breadth-first search (BFS) algorithm.
 -/
 
 public section
@@ -33,11 +27,142 @@ universe u v w
 
 namespace SimpleGraph
 
-variable {V : Type u} (G : SimpleGraph V)
+variable {V : Type*} {G : SimpleGraph V}
 
 theorem ConnectedComponent.card_le_card_of_le [Finite V] {G G' : SimpleGraph V} (h : G ≤ G') :
     Nat.card G'.ConnectedComponent ≤ Nat.card G.ConnectedComponent :=
   Nat.card_le_card_of_surjective _ <| ConnectedComponent.surjective_map_ofLE h
+
+/-!
+### Deciding reachability by breadth-first search
+
+This section provides efficient decidability instances for reachability and (pre)connectedness of
+finite graphs through a breadth-first search (BFS) algorithm.
+
+The algorithm is as follows: we maintain a finset of visited vertices which we grow with all its
+neighbors at each round of breadth-first search at, stopping as soon as a round adds no new vertex:
+a search costs `O((diam G + 1) * (card V) ^ 2)` adjacency tests.
+
+Vertices `u` and `v` are then reachable if `v` lies in the BFS-constructed finset of vertices
+reachable from `u`, and a graph is (pre)connected iff it's non-empty and (/empty or) every vertex is
+lies in the reachability finset of an arbitrarily-chosen vertex.
+-/
+
+section BFS
+variable [Fintype V] [DecidableEq V] [DecidableRel G.Adj] {m n : ℕ} {s t : Finset V} {u v w : V}
+
+variable (G s) in
+/-- One round of breadth-first search: `G.bfsStep s` consists of the vertices of `s` together with
+their neighbours. -/
+def bfsStep : Finset V := {w | w ∈ s ∨ ∃ v ∈ s, G.Adj v w}
+
+@[simp, grind =]
+lemma mem_bfsStep : w ∈ G.bfsStep s ↔ w ∈ s ∨ ∃ v ∈ s, G.Adj v w := by simp [bfsStep]
+
+lemma subset_bfsStep : s ⊆ G.bfsStep s := fun _ hw ↦ G.mem_bfsStep.2 <| .inl hw
+
+@[gcongr] lemma bfsStep_mono (hst : s ⊆ t) : G.bfsStep s ⊆ G.bfsStep t := by grind
+
+@[gcongr]
+lemma iterate_bfsStep_mono (hst : s ⊆ t) : G.bfsStep^[n] s ⊆ G.bfsStep^[n] t := by
+  induction n generalizing s t with
+  | zero => exact hst
+  | succ n ih => simpa only [Function.iterate_succ_apply] using ih (G.bfsStep_mono hst)
+
+lemma subset_iterate_bfsStep : s ⊆ G.bfsStep^[n] s := by
+  induction n with
+  | zero => exact subset_rfl
+  | succ n ih => grw [Function.iterate_succ_apply', ih, ← G.subset_bfsStep]
+
+lemma iterate_bfsStep_subset_of_le (hmn : m ≤ n) : G.bfsStep^[m] s ⊆ G.bfsStep^[n] s := by
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hmn
+  rw [Function.iterate_add_apply]
+  exact G.iterate_bfsStep_mono G.subset_iterate_bfsStep
+
+lemma mem_iterate_bfsStep_of_walk (p : G.Walk u v) : v ∈ G.bfsStep^[p.length] {u} := by
+  induction p with
+  | nil => simp
+  | cons h p ih =>
+    rw [Walk.length_cons, Function.iterate_succ_apply]
+    exact G.iterate_bfsStep_mono (by simp [h]) ih
+
+lemma reachable_of_mem_iterate_bfsStep (hv : v ∈ G.bfsStep^[n] {u}) : G.Reachable u v := by
+  induction n generalizing v with
+  | zero =>
+    rw [Function.iterate_zero_apply, Finset.mem_singleton] at hv
+    exact hv ▸ Reachable.refl _
+  | succ n ih =>
+    rw [Function.iterate_succ_apply', mem_bfsStep] at hv
+    obtain hv | ⟨w, hw, hwv⟩ := hv
+    · exact ih hv
+    · exact (ih hw).trans hwv.reachable
+
+/-- Iterate `G.bfsStep` at most `n` times, stopping as soon as no new vertex shows up. -/
+def bfsIterate : ℕ → Finset V → Finset V
+  | 0, s => s
+  | n + 1, s => if (G.bfsStep s).card ≤ s.card then s else bfsIterate n (G.bfsStep s)
+
+lemma bfsIterate_eq_iterate_bfsStep (n : ℕ) (s : Finset V) :
+    G.bfsIterate n s = G.bfsStep^[n] s := by
+  induction n generalizing s with
+  | zero => rfl
+  | succ n ih =>
+    rw [bfsIterate]
+    split_ifs with h
+    · have hs : G.bfsStep s = s := (Finset.eq_of_subset_of_card_le G.subset_bfsStep h).symm
+      exact (Function.iterate_fixed hs _).symm
+    · rw [ih, ← Function.iterate_succ_apply]
+
+/-- The finset of vertices reachable from `u`, computed by breadth-first search. -/
+def reachableFinset (u : V) : Finset V := G.bfsIterate (Fintype.card V) {u}
+
+@[simp]
+lemma mem_reachableFinset : v ∈ G.reachableFinset u ↔ G.Reachable u v := by
+  rw [reachableFinset, bfsIterate_eq_iterate_bfsStep]
+  refine ⟨G.reachable_of_mem_iterate_bfsStep, fun h ↦ h.elim_path fun p ↦ ?_⟩
+  exact G.iterate_bfsStep_subset_of_le p.2.length_lt.le (G.mem_iterate_bfsStep_of_walk p.1)
+
+/-- Decides reachability of vertices `u` and `v` by performing a breadth-first search from `u`. -/
+instance decidableReachable : DecidableRel G.Reachable :=
+  fun _ _ ↦ decidable_of_iff _ G.mem_reachableFinset
+
+lemma preconnected_iff_forall_mem_reachableFinset (u : V) :
+    G.Preconnected ↔ ∀ v, v ∈ G.reachableFinset u := by
+  simp only [mem_reachableFinset]
+  exact ⟨fun h v ↦ h u v, fun h x y ↦ (h x).symm.trans (h y)⟩
+
+/-- Decides preconnectedness of `G` by checking whether the vertex set is empty and, if not,
+by performing a breadth-first search from an arbitrarily chosen vertex. -/
+instance decidablePreconnected : Decidable G.Preconnected :=
+  if h : Fintype.card V = 0 then
+    isTrue (by rw [Fintype.card_eq_zero_iff] at h; exact .of_subsingleton)
+  else
+    (truncOfCardPos <| by lia).lift
+      (fun u ↦ decidable_of_iff _ (G.preconnected_iff_forall_mem_reachableFinset u).symm)
+      fun _ _ ↦ Subsingleton.elim _ _
+
+lemma connected_iff_forall_mem_reachableFinset (u : V) :
+    G.Connected ↔ ∀ v, v ∈ G.reachableFinset u := by
+  rw [connected_iff, G.preconnected_iff_forall_mem_reachableFinset u, and_iff_left ⟨u⟩]
+
+/-- Decides preconnectedness of `G` by checking whether the vertex set is empty and, if not,
+by performing a breadth-first search from an arbitrarily chosen vertex. -/
+instance decidableConnected : Decidable G.Connected :=
+  if h : Fintype.card V = 0 then
+    isFalse fun hG ↦ (Fintype.card_eq_zero_iff.1 h).false hG.nonempty.some
+  else
+    (truncOfCardPos <| by lia).lift
+      (fun u ↦ decidable_of_iff _ (G.connected_iff_forall_mem_reachableFinset u).symm)
+      fun _ _ ↦ Subsingleton.elim ..
+
+instance : Fintype G.ConnectedComponent :=
+  fast_instance% @Quotient.fintype _ _ G.reachableSetoid (inferInstance : DecidableRel G.Reachable)
+
+instance instDecidableMemSupp (c : G.ConnectedComponent) (v : V) : Decidable (v ∈ c.supp) :=
+  c.recOn (fun w ↦ decidable_of_iff (G.Reachable v w) <| by simp)
+    (fun _ _ _ _ ↦ Subsingleton.elim _ _)
+
+end BFS
 
 section Fintype
 
@@ -53,25 +178,7 @@ theorem reachable_iff_exists_finsetWalkLength_nonempty (u v : V) :
   · rintro ⟨_, p, _⟩
     exact ⟨p⟩
 
-instance : DecidableRel G.Reachable := fun u v =>
-  decidable_of_iff' _ (reachable_iff_exists_finsetWalkLength_nonempty G u v)
-
-instance : Fintype G.ConnectedComponent :=
-  fast_instance% @Quotient.fintype _ _ G.reachableSetoid (inferInstance : DecidableRel G.Reachable)
-
-instance : Decidable G.Preconnected :=
-  inferInstanceAs <| Decidable (∀ u v, G.Reachable u v)
-
-instance : Decidable G.Connected :=
-  decidable_of_iff (G.Preconnected ∧ (Finset.univ : Finset V).Nonempty) <| by
-    rw [connected_iff, ← Finset.univ_nonempty_iff]
-
-instance instDecidableMemSupp (c : G.ConnectedComponent) (v : V) : Decidable (v ∈ c.supp) :=
-  c.recOn (fun w ↦ decidable_of_iff (G.Reachable v w) <| by simp)
-    (fun _ _ _ _ ↦ Subsingleton.elim _ _)
-
 set_option backward.isDefEq.respectTransparency.types false in
-variable {G} in
 lemma disjiUnion_supp_toFinset_eq_supp_toFinset {G' : SimpleGraph V} (h : G ≤ G')
     (c' : ConnectedComponent G') [Fintype c'.supp]
     [DecidablePred fun c : G.ConnectedComponent ↦ c.supp ⊆ c'.supp] :
@@ -118,7 +225,7 @@ lemma ncard_oddComponents_mono [Finite V] {G' : SimpleGraph V} (h : G ≤ G') :
       {c' : G.ConnectedComponent | Odd c'.supp.ncard ∧ c'.supp ⊆ c.supp}.Nonempty := by
     refine Set.nonempty_of_ncard_ne_zero fun h' ↦ Nat.not_odd_zero ?_
     rw [← h']
-    exact (c.odd_oddComponents_ncard_subset_supp _ h).2 hc
+    exact (c.odd_oddComponents_ncard_subset_supp h).2 hc
   let f : G'.oddComponents → G.oddComponents :=
     fun ⟨c, hc⟩ ↦ ⟨(aux c hc).choose, (aux c hc).choose_spec.1⟩
   refine Nat.card_le_card_of_injective f fun c c' fcc' ↦ ?_

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
@@ -11,16 +11,10 @@ public import Mathlib.Combinatorics.SimpleGraph.Walk.Counting
 public import Mathlib.Data.Set.Card
 
 /-!
-# Counting walks of a given length
+# Connectivity in a finite graph
 
-## Main definitions
-- `walkLengthTwoEquivCommonNeighbors`: bijective correspondence between walks of length two
-from `u` to `v` and common neighbours of `u` and `v`. Note that `u` and `v` may be the same.
-- `finsetWalkLength`: the `Finset` of length-`n` walks from `u` to `v`.
-This is used to give `{p : G.walk u v | p.length = n}` a `Fintype` instance, and it
-can also be useful as a recursive description of this set when `V` is finite.
-
-TODO: should this be extended further?
+This file provides efficient decidability instances for reachability and (pre)connectedness of
+finite graphs through a breadth-first search (BFS) algorithm.
 -/
 
 public section
@@ -33,11 +27,138 @@ universe u v w
 
 namespace SimpleGraph
 
-variable {V : Type u} (G : SimpleGraph V)
+variable {V : Type*} {G : SimpleGraph V}
 
 theorem ConnectedComponent.card_le_card_of_le [Finite V] {G G' : SimpleGraph V} (h : G ≤ G') :
     Nat.card G'.ConnectedComponent ≤ Nat.card G.ConnectedComponent :=
   Nat.card_le_card_of_surjective _ <| ConnectedComponent.surjective_map_ofLE h
+
+/-!
+### Deciding reachability by breadth-first search
+
+The instances below instead grow the set of visited vertices one round of breadth-first search at
+a time, stopping as soon as a round adds no new vertex: a search costs
+`O((diam G + 1) * (card V) ^ 2)` adjacency tests. Since reachability is symmetric and transitive,
+a single search, from any one vertex, settles `G.Preconnected` and `G.Connected` in both
+directions: `G` is preconnected iff that search visits every vertex.
+-/
+
+
+section BFS
+variable [Fintype V] [DecidableEq V] [DecidableRel G.Adj] {m n : ℕ} {s t : Finset V} {u v w : V}
+
+variable (G s) in
+/-- One round of breadth-first search: `G.bfsStep s` consists of the vertices of `s` together with
+their neighbours. -/
+def bfsStep : Finset V := {w | w ∈ s ∨ ∃ v ∈ s, G.Adj v w}
+
+@[simp, grind =]
+lemma mem_bfsStep : w ∈ G.bfsStep s ↔ w ∈ s ∨ ∃ v ∈ s, G.Adj v w := by simp [bfsStep]
+
+lemma subset_bfsStep : s ⊆ G.bfsStep s := fun _ hw ↦ G.mem_bfsStep.2 <| .inl hw
+
+@[gcongr] lemma bfsStep_mono (hst : s ⊆ t) : G.bfsStep s ⊆ G.bfsStep t := by grind
+
+@[gcongr]
+lemma iterate_bfsStep_mono (hst : s ⊆ t) : G.bfsStep^[n] s ⊆ G.bfsStep^[n] t := by
+  induction n generalizing s t with
+  | zero => exact hst
+  | succ n ih => simpa only [Function.iterate_succ_apply] using ih (G.bfsStep_mono hst)
+
+lemma subset_iterate_bfsStep : s ⊆ G.bfsStep^[n] s := by
+  induction n with
+  | zero => exact subset_rfl
+  | succ n ih => grw [Function.iterate_succ_apply', ih, ← G.subset_bfsStep]
+
+lemma iterate_bfsStep_subset_of_le (hmn : m ≤ n) : G.bfsStep^[m] s ⊆ G.bfsStep^[n] s := by
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hmn
+  rw [Function.iterate_add_apply]
+  exact G.iterate_bfsStep_mono G.subset_iterate_bfsStep
+
+lemma mem_iterate_bfsStep_of_walk (p : G.Walk u v) : v ∈ G.bfsStep^[p.length] {u} := by
+  induction p with
+  | nil => simp
+  | cons h p ih =>
+    rw [Walk.length_cons, Function.iterate_succ_apply]
+    exact G.iterate_bfsStep_mono (by simp [h]) ih
+
+lemma reachable_of_mem_iterate_bfsStep (hv : v ∈ G.bfsStep^[n] {u}) : G.Reachable u v := by
+  induction n generalizing v with
+  | zero =>
+    rw [Function.iterate_zero_apply, Finset.mem_singleton] at hv
+    exact hv ▸ Reachable.refl _
+  | succ n ih =>
+    rw [Function.iterate_succ_apply', mem_bfsStep] at hv
+    obtain hv | ⟨w, hw, hwv⟩ := hv
+    · exact ih hv
+    · exact (ih hw).trans hwv.reachable
+
+/-- Iterate `G.bfsStep` at most `n` times, stopping as soon as no new vertex shows up. -/
+def bfsIterate : ℕ → Finset V → Finset V
+  | 0, s => s
+  | n + 1, s => if (G.bfsStep s).card ≤ s.card then s else bfsIterate n (G.bfsStep s)
+
+lemma bfsIterate_eq_iterate_bfsStep (n : ℕ) (s : Finset V) :
+    G.bfsIterate n s = G.bfsStep^[n] s := by
+  induction n generalizing s with
+  | zero => rfl
+  | succ n ih =>
+    rw [bfsIterate]
+    split_ifs with h
+    · have hs : G.bfsStep s = s := (Finset.eq_of_subset_of_card_le G.subset_bfsStep h).symm
+      exact (Function.iterate_fixed hs _).symm
+    · rw [ih, ← Function.iterate_succ_apply]
+
+/-- The finset of vertices reachable from `u`, computed by breadth-first search. -/
+def reachableFinset (u : V) : Finset V := G.bfsIterate (Fintype.card V) {u}
+
+@[simp]
+lemma mem_reachableFinset : v ∈ G.reachableFinset u ↔ G.Reachable u v := by
+  rw [reachableFinset, bfsIterate_eq_iterate_bfsStep]
+  refine ⟨G.reachable_of_mem_iterate_bfsStep, fun h ↦ h.elim_path fun p ↦ ?_⟩
+  exact G.iterate_bfsStep_subset_of_le p.2.length_lt.le (G.mem_iterate_bfsStep_of_walk p.1)
+
+/-- Decides reachability of vertices `u` and `v` by performing a breadth-first search from `u`. -/
+instance decidableReachable : DecidableRel G.Reachable :=
+  fun _ _ ↦ decidable_of_iff _ G.mem_reachableFinset
+
+lemma preconnected_iff_forall_mem_reachableFinset (u : V) :
+    G.Preconnected ↔ ∀ v, v ∈ G.reachableFinset u := by
+  simp only [mem_reachableFinset]
+  exact ⟨fun h v ↦ h u v, fun h x y ↦ (h x).symm.trans (h y)⟩
+
+/-- Decides preconnectedness of `G` by checking whether the vertex set is empty and, if not,
+by performing a breadth-first search from an arbitrarily chosen vertex. -/
+instance decidablePreconnected : Decidable G.Preconnected :=
+  if h : Fintype.card V = 0 then
+    isTrue (by rw [Fintype.card_eq_zero_iff] at h; exact .of_subsingleton)
+  else
+    (truncOfCardPos <| by lia).lift
+      (fun u ↦ decidable_of_iff _ (G.preconnected_iff_forall_mem_reachableFinset u).symm)
+      fun _ _ ↦ Subsingleton.elim _ _
+
+lemma connected_iff_forall_mem_reachableFinset (u : V) :
+    G.Connected ↔ ∀ v, v ∈ G.reachableFinset u := by
+  rw [connected_iff, G.preconnected_iff_forall_mem_reachableFinset u, and_iff_left ⟨u⟩]
+
+/-- Decides preconnectedness of `G` by checking whether the vertex set is empty and, if not,
+by performing a breadth-first search from an arbitrarily chosen vertex. -/
+instance decidableConnected : Decidable G.Connected :=
+  if h : Fintype.card V = 0 then
+    isFalse fun hG ↦ (Fintype.card_eq_zero_iff.1 h).false hG.nonempty.some
+  else
+    (truncOfCardPos <| by lia).lift
+      (fun u ↦ decidable_of_iff _ (G.connected_iff_forall_mem_reachableFinset u).symm)
+      fun _ _ ↦ Subsingleton.elim ..
+
+instance : Fintype G.ConnectedComponent :=
+  fast_instance% @Quotient.fintype _ _ G.reachableSetoid (inferInstance : DecidableRel G.Reachable)
+
+instance instDecidableMemSupp (c : G.ConnectedComponent) (v : V) : Decidable (v ∈ c.supp) :=
+  c.recOn (fun w ↦ decidable_of_iff (G.Reachable v w) <| by simp)
+    (fun _ _ _ _ ↦ Subsingleton.elim _ _)
+
+end BFS
 
 section Fintype
 
@@ -53,25 +174,7 @@ theorem reachable_iff_exists_finsetWalkLength_nonempty (u v : V) :
   · rintro ⟨_, p, _⟩
     exact ⟨p⟩
 
-instance : DecidableRel G.Reachable := fun u v =>
-  decidable_of_iff' _ (reachable_iff_exists_finsetWalkLength_nonempty G u v)
-
-instance : Fintype G.ConnectedComponent :=
-  fast_instance% @Quotient.fintype _ _ G.reachableSetoid (inferInstance : DecidableRel G.Reachable)
-
-instance : Decidable G.Preconnected :=
-  inferInstanceAs <| Decidable (∀ u v, G.Reachable u v)
-
-instance : Decidable G.Connected :=
-  decidable_of_iff (G.Preconnected ∧ (Finset.univ : Finset V).Nonempty) <| by
-    rw [connected_iff, ← Finset.univ_nonempty_iff]
-
-instance instDecidableMemSupp (c : G.ConnectedComponent) (v : V) : Decidable (v ∈ c.supp) :=
-  c.recOn (fun w ↦ decidable_of_iff (G.Reachable v w) <| by simp)
-    (fun _ _ _ _ ↦ Subsingleton.elim _ _)
-
 set_option backward.isDefEq.respectTransparency.types false in
-variable {G} in
 lemma disjiUnion_supp_toFinset_eq_supp_toFinset {G' : SimpleGraph V} (h : G ≤ G')
     (c' : ConnectedComponent G') [Fintype c'.supp]
     [DecidablePred fun c : G.ConnectedComponent ↦ c.supp ⊆ c'.supp] :
@@ -118,7 +221,7 @@ lemma ncard_oddComponents_mono [Finite V] {G' : SimpleGraph V} (h : G ≤ G') :
       {c' : G.ConnectedComponent | Odd c'.supp.ncard ∧ c'.supp ⊆ c.supp}.Nonempty := by
     refine Set.nonempty_of_ncard_ne_zero fun h' ↦ Nat.not_odd_zero ?_
     rw [← h']
-    exact (c.odd_oddComponents_ncard_subset_supp _ h).2 hc
+    exact (c.odd_oddComponents_ncard_subset_supp h).2 hc
   let f : G'.oddComponents → G.oddComponents :=
     fun ⟨c, hc⟩ ↦ ⟨(aux c hc).choose, (aux c hc).choose_spec.1⟩
   refine Nat.card_le_card_of_injective f fun c c' fcc' ↦ ?_

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
@@ -36,13 +36,17 @@ theorem ConnectedComponent.card_le_card_of_le [Finite V] {G G' : SimpleGraph V} 
 /-!
 ### Deciding reachability by breadth-first search
 
-The instances below instead grow the set of visited vertices one round of breadth-first search at
-a time, stopping as soon as a round adds no new vertex: a search costs
-`O((diam G + 1) * (card V) ^ 2)` adjacency tests. Since reachability is symmetric and transitive,
-a single search, from any one vertex, settles `G.Preconnected` and `G.Connected` in both
-directions: `G` is preconnected iff that search visits every vertex.
--/
+This section provides efficient decidability instances for reachability and (pre)connectedness of
+finite graphs through a breadth-first search (BFS) algorithm.
 
+The algorithm is as follows: we maintain a finset of visited vertices which we grow with all its
+neighbors at each round of breadth-first search at, stopping as soon as a round adds no new vertex:
+a search costs `O((diam G + 1) * (card V) ^ 2)` adjacency tests.
+
+Vertices `u` and `v` are then reachable if `v` lies in the BFS-constructed finset of vertices
+reachable from `u`, and a graph is (pre)connected iff it's non-empty and (/empty or) every vertex is
+lies in the reachability finset of an arbitrarily-chosen vertex.
+-/
 
 section BFS
 variable [Fintype V] [DecidableEq V] [DecidableRel G.Adj] {m n : ℕ} {s t : Finset V} {u v w : V}

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
@@ -39,121 +39,162 @@ theorem ConnectedComponent.card_le_card_of_le [Finite V] {G G' : SimpleGraph V} 
 This section provides efficient decidability instances for reachability and (pre)connectedness of
 finite graphs through a breadth-first search (BFS) algorithm.
 
-The algorithm is as follows: we maintain a finset of visited vertices which we grow with all its
-neighbors at each round of breadth-first search at, stopping as soon as a round adds no new vertex:
-a search costs `O((diam G + 1) * (card V) ^ 2)` adjacency tests.
+The algorithm is as follows: we maintain the list of vertices visited so far along with the list of
+vertices remaining to be visited, and we repeatedly move to the former the vertices of the latter
+that are adjacent to the *frontier*, namely the vertices visited during the previous round. We stop
+as soon as a round visits no new vertex. Since a vertex enters the frontier at most once, a search
+costs `O(|V| ^ 2)` adjacency tests.
 
-Vertices `u` and `v` are then reachable if `v` lies in the BFS-constructed finset of vertices
-reachable from `u`, and a graph is (pre)connected iff it's non-empty and (/empty or) every vertex is
-lies in the reachability finset of an arbitrarily-chosen vertex.
+Vertices `u` and `v` are then reachable if `v` lies in the BFS-constructed list of vertices
+reachable from `u`, and a graph is (pre)connected iff it's non-empty and (/empty or) every vertex
+lies in the reachability list of an arbitrarily-chosen vertex.
 -/
 
 section BFS
-variable [Fintype V] [DecidableEq V] [DecidableRel G.Adj] {m n : ℕ} {s t : Finset V} {u v w : V}
+variable [DecidableRel G.Adj] {l s acc : List V} {n : ℕ} {u v w : V}
 
-variable (G s) in
-/-- One round of breadth-first search: `G.bfsStep s` consists of the vertices of `s` together with
-their neighbours. -/
-def bfsStep : Finset V := {w | w ∈ s ∨ ∃ v ∈ s, G.Adj v w}
+omit [DecidableRel G.Adj] in
+/-- A list of vertices closed under adjacency is closed under reachability. -/
+private lemma Reachable.mem_of_forall_adj_mem (huv : G.Reachable u v)
+    (hs : ∀ x ∈ s, ∀ y, G.Adj x y → y ∈ s) : u ∈ s → v ∈ s := by
+  obtain ⟨p⟩ := huv
+  induction p with
+  | nil => exact id
+  | cons hxy _ ih => exact fun hu ↦ ih (hs _ hu _ hxy)
+
+/-- One round of breadth-first search: `G.bfsStep s l acc` prepends to `acc` the vertices of the
+list `l` of vertices remaining to be visited that are adjacent to some vertex of the frontier `s`,
+namely the vertices getting visited during this round. -/
+def bfsStep (G : SimpleGraph V) [DecidableRel G.Adj] (s : List V) : List V → List V → List V
+  | [], acc => acc
+  | w :: l, acc => G.bfsStep s l (if s.any (G.Adj · w) then w :: acc else acc)
 
 @[simp, grind =]
-lemma mem_bfsStep : w ∈ G.bfsStep s ↔ w ∈ s ∨ ∃ v ∈ s, G.Adj v w := by simp [bfsStep]
+lemma mem_bfsStep : ∀ {l acc}, w ∈ G.bfsStep s l acc ↔ (w ∈ l ∧ ∃ v ∈ s, G.Adj v w) ∨ w ∈ acc
+  | [], acc => by simp [bfsStep]
+  | x :: l, acc => by rw [bfsStep, mem_bfsStep]; grind
 
-lemma subset_bfsStep : s ⊆ G.bfsStep s := fun _ hw ↦ G.mem_bfsStep.2 <| .inl hw
+/-- Iterate breadth-first search at most `n` times, stopping as soon as a round visits no new
+vertex.
 
-@[gcongr] lemma bfsStep_mono (hst : s ⊆ t) : G.bfsStep s ⊆ G.bfsStep t := by grind
+`G.bfsIterate n s l acc` is the list of visited vertices, where `s` is the current frontier, `l` the
+list of vertices remaining to be visited and `acc` the list of already visited vertices. -/
+def bfsIterate (G : SimpleGraph V) [DecidableRel G.Adj] :
+    ℕ → List V → List V → List V → List V
+  | 0, _, _, acc => acc
+  | n + 1, s, l, acc =>
+    let s' := G.bfsStep s l []
+    if s'.isEmpty then acc
+    else G.bfsIterate n s' (l.filter fun w ↦ !s.any (G.Adj · w)) (s' ++ acc)
 
-@[gcongr]
-lemma iterate_bfsStep_mono (hst : s ⊆ t) : G.bfsStep^[n] s ⊆ G.bfsStep^[n] t := by
-  induction n generalizing s t with
-  | zero => exact hst
-  | succ n ih => simpa only [Function.iterate_succ_apply] using ih (G.bfsStep_mono hst)
+/-- Breadth-first search only visits vertices reachable from `u`, assuming the frontier is made of
+visited vertices and that all visited vertices are reachable from `u`. -/
+lemma reachable_of_mem_bfsIterate (hs : ∀ x ∈ s, x ∈ acc) (hacc : ∀ x ∈ acc, G.Reachable u x)
+    (hv : v ∈ G.bfsIterate n s l acc) : G.Reachable u v := by
+  induction n generalizing s l acc with
+  | zero => exact hacc _ hv
+  | succ n ih =>
+  simp only [bfsIterate] at hv
+  split_ifs at hv with h
+  · exact hacc _ hv
+  refine ih (fun x hx ↦ List.mem_append_left _ hx) (fun x hx ↦ ?_) hv
+  rw [List.mem_append] at hx
+  obtain hx | hx := hx
+  · obtain ⟨-, y, hy, hyx⟩ | hx := mem_bfsStep.1 hx
+    · exact (hacc _ (hs _ hy)).trans hyx.reachable
+    · simp at hx
+  · exact hacc _ hx
 
-lemma subset_iterate_bfsStep : s ⊆ G.bfsStep^[n] s := by
-  induction n with
-  | zero => exact subset_rfl
-  | succ n ih => grw [Function.iterate_succ_apply', ih, ← G.subset_bfsStep]
-
-lemma iterate_bfsStep_subset_of_le (hmn : m ≤ n) : G.bfsStep^[m] s ⊆ G.bfsStep^[n] s := by
-  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hmn
-  rw [Function.iterate_add_apply]
-  exact G.iterate_bfsStep_mono G.subset_iterate_bfsStep
-
-lemma mem_iterate_bfsStep_of_walk (p : G.Walk u v) : v ∈ G.bfsStep^[p.length] {u} := by
-  induction p with
-  | nil => simp
-  | cons h p ih =>
-    rw [Walk.length_cons, Function.iterate_succ_apply]
-    exact G.iterate_bfsStep_mono (by simp [h]) ih
-
-lemma reachable_of_mem_iterate_bfsStep (hv : v ∈ G.bfsStep^[n] {u}) : G.Reachable u v := by
-  induction n generalizing v with
+/-- Breadth-first search visits all vertices reachable from `u`, assuming it is run for at least as
+many rounds as there are vertices remaining to be visited, that every vertex is either visited or
+remaining, that `u` is visited and that all neighbours of a visited vertex outside of the frontier
+are themselves visited. -/
+lemma mem_bfsIterate_of_reachable (hn : l.length ≤ n) (hu : u ∈ acc) (hl : ∀ x, x ∈ l ∨ x ∈ acc)
+    (hacc : ∀ x ∈ acc, x ∉ s → ∀ y, G.Adj x y → y ∈ acc) (hv : G.Reachable u v) :
+    v ∈ G.bfsIterate n s l acc := by
+  induction n generalizing s l acc with
   | zero =>
-    rw [Function.iterate_zero_apply, Finset.mem_singleton] at hv
-    exact hv ▸ Reachable.refl _
+    rw [Nat.le_zero, List.length_eq_zero_iff] at hn
+    subst hn
+    simpa only [bfsIterate] using (hl v).resolve_left (by simp)
   | succ n ih =>
-    rw [Function.iterate_succ_apply', mem_bfsStep] at hv
-    obtain hv | ⟨w, hw, hwv⟩ := hv
-    · exact ih hv
-    · exact (ih hw).trans hwv.reachable
+  simp only [bfsIterate]
+  split_ifs with h
+  · -- No new vertex got visited, hence the visited vertices are closed under adjacency.
+    rw [List.isEmpty_iff, List.eq_nil_iff_forall_not_mem] at h
+    refine hv.mem_of_forall_adj_mem (fun x hx y hxy ↦ ?_) hu
+    by_cases hxs : x ∈ s
+    · exact (hl y).resolve_left fun hy ↦ h y <| mem_bfsStep.2 <| .inl ⟨hy, x, hxs, hxy⟩
+    · exact hacc _ hx hxs _ hxy
+  -- Some new vertex got visited, hence there is one less vertex remaining to be visited.
+  rw [List.isEmpty_iff] at h
+  obtain ⟨w, hw⟩ := List.exists_mem_of_ne_nil _ h
+  obtain ⟨hwl, hws⟩ : w ∈ l ∧ ∃ z ∈ s, G.Adj z w := by simpa using hw
+  refine ih ?_ (List.mem_append_right _ hu) (fun x ↦ ?_) (fun x hx hxs y hxy ↦ ?_)
+  · have : (l.filter fun w ↦ !s.any (G.Adj · w)).length < l.length :=
+      List.length_filter_lt_length_iff_exists.2 ⟨w, hwl, by simpa using hws⟩
+    lia
+  · obtain hx | hx := hl x
+    · by_cases hxs : ∃ z ∈ s, G.Adj z x
+      · exact .inr <| List.mem_append_left _ <| mem_bfsStep.2 <| .inl ⟨hx, hxs⟩
+      · exact .inl <| List.mem_filter.2 ⟨hx, by simpa using hxs⟩
+    · exact .inr <| List.mem_append_right _ hx
+  · simp only [List.mem_append, hxs, false_or, mem_bfsStep, List.not_mem_nil, or_false] at hx ⊢
+    by_cases hxs' : x ∈ s
+    · obtain hy | hy := hl y
+      · exact .inl ⟨hy, x, hxs', hxy⟩
+      · exact .inr hy
+    · exact .inr <| hacc _ hx hxs' _ hxy
 
-/-- Iterate `G.bfsStep` at most `n` times, stopping as soon as no new vertex shows up. -/
-def bfsIterate : ℕ → Finset V → Finset V
-  | 0, s => s
-  | n + 1, s => if (G.bfsStep s).card ≤ s.card then s else bfsIterate n (G.bfsStep s)
+variable [DecidableEq V]
 
-lemma bfsIterate_eq_iterate_bfsStep (n : ℕ) (s : Finset V) :
-    G.bfsIterate n s = G.bfsStep^[n] s := by
-  induction n generalizing s with
-  | zero => rfl
-  | succ n ih =>
-    rw [bfsIterate]
-    split_ifs with h
-    · have hs : G.bfsStep s = s := (Finset.eq_of_subset_of_card_le G.subset_bfsStep h).symm
-      exact (Function.iterate_fixed hs _).symm
-    · rw [ih, ← Function.iterate_succ_apply]
+variable (G) in
+/-- The list of vertices reachable from `u`, computed by breadth-first search through the list `l`
+of all vertices. -/
+def bfsList (u : V) (l : List V) : List V := G.bfsIterate (l.length - 1) [u] (l.erase u) [u]
 
-/-- The finset of vertices reachable from `u`, computed by breadth-first search. -/
-def reachableFinset (u : V) : Finset V := G.bfsIterate (Fintype.card V) {u}
+lemma mem_bfsList (hl : ∀ w, w ∈ l) : v ∈ G.bfsList u l ↔ G.Reachable u v := by
+  refine ⟨reachable_of_mem_bfsIterate (fun x hx ↦ hx) (fun x hx ↦ ?_), fun hv ↦ ?_⟩
+  · rw [List.mem_singleton] at hx
+    exact hx ▸ .refl _
+  · refine mem_bfsIterate_of_reachable (by simp [hl]) (by simp) (fun x ↦ ?_) (by simp) hv
+    obtain rfl | hxu := eq_or_ne x u
+    · exact .inr (by simp)
+    · exact .inl <| (List.mem_erase_of_ne hxu).2 <| hl x
 
-@[simp]
-lemma mem_reachableFinset : v ∈ G.reachableFinset u ↔ G.Reachable u v := by
-  rw [reachableFinset, bfsIterate_eq_iterate_bfsStep]
-  refine ⟨G.reachable_of_mem_iterate_bfsStep, fun h ↦ h.elim_path fun p ↦ ?_⟩
-  exact G.iterate_bfsStep_subset_of_le p.2.length_lt.le (G.mem_iterate_bfsStep_of_walk p.1)
+lemma preconnected_iff_forall_mem_bfsList (hl : ∀ w, w ∈ l) (u : V) :
+    G.Preconnected ↔ ∀ v, v ∈ G.bfsList u l := by
+  simp only [mem_bfsList hl]
+  exact ⟨fun h v ↦ h u v, fun h x y ↦ (h x).symm.trans (h y)⟩
+
+lemma connected_iff_forall_mem_bfsList (hl : ∀ w, w ∈ l) (u : V) :
+    G.Connected ↔ ∀ v, v ∈ G.bfsList u l := by
+  rw [connected_iff, preconnected_iff_forall_mem_bfsList hl u, and_iff_left ⟨u⟩]
+
+variable [Fintype V]
 
 /-- Decides reachability of vertices `u` and `v` by performing a breadth-first search from `u`. -/
-instance decidableReachable : DecidableRel G.Reachable :=
-  fun _ _ ↦ decidable_of_iff _ G.mem_reachableFinset
-
-lemma preconnected_iff_forall_mem_reachableFinset (u : V) :
-    G.Preconnected ↔ ∀ v, v ∈ G.reachableFinset u := by
-  simp only [mem_reachableFinset]
-  exact ⟨fun h v ↦ h u v, fun h x y ↦ (h x).symm.trans (h y)⟩
+instance decidableReachable : DecidableRel G.Reachable := fun _u _v ↦
+  (Fintype.truncList V).lift (fun l ↦ decidable_of_iff _ (mem_bfsList l.2))
+    fun _ _ ↦ Subsingleton.elim ..
 
 /-- Decides preconnectedness of `G` by checking whether the vertex set is empty and, if not,
 by performing a breadth-first search from an arbitrarily chosen vertex. -/
 instance decidablePreconnected : Decidable G.Preconnected :=
-  if h : Fintype.card V = 0 then
-    isTrue (by rw [Fintype.card_eq_zero_iff] at h; exact .of_subsingleton)
-  else
-    (truncOfCardPos <| by lia).lift
-      (fun u ↦ decidable_of_iff _ (G.preconnected_iff_forall_mem_reachableFinset u).symm)
-      fun _ _ ↦ Subsingleton.elim _ _
+  (Fintype.truncList V).lift
+    (fun ⟨l, hl⟩ ↦ match l, hl with
+      | [], hl => isTrue fun x _ ↦ absurd (hl x) (by simp)
+      | u :: l, hl => decidable_of_iff _ (preconnected_iff_forall_mem_bfsList hl u).symm)
+    fun _ _ ↦ Subsingleton.elim ..
 
-lemma connected_iff_forall_mem_reachableFinset (u : V) :
-    G.Connected ↔ ∀ v, v ∈ G.reachableFinset u := by
-  rw [connected_iff, G.preconnected_iff_forall_mem_reachableFinset u, and_iff_left ⟨u⟩]
-
-/-- Decides preconnectedness of `G` by checking whether the vertex set is empty and, if not,
+/-- Decides connectedness of `G` by checking whether the vertex set is empty and, if not,
 by performing a breadth-first search from an arbitrarily chosen vertex. -/
 instance decidableConnected : Decidable G.Connected :=
-  if h : Fintype.card V = 0 then
-    isFalse fun hG ↦ (Fintype.card_eq_zero_iff.1 h).false hG.nonempty.some
-  else
-    (truncOfCardPos <| by lia).lift
-      (fun u ↦ decidable_of_iff _ (G.connected_iff_forall_mem_reachableFinset u).symm)
-      fun _ _ ↦ Subsingleton.elim ..
+  (Fintype.truncList V).lift
+    (fun ⟨l, hl⟩ ↦ match l, hl with
+      | [], hl => isFalse fun hG ↦ absurd (hl hG.nonempty.some) (by simp)
+      | u :: l, hl => decidable_of_iff _ (connected_iff_forall_mem_bfsList hl u).symm)
+    fun _ _ ↦ Subsingleton.elim ..
 
 instance : Fintype G.ConnectedComponent :=
   fast_instance% @Quotient.fintype _ _ G.reachableSetoid (inferInstance : DecidableRel G.Reachable)

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
@@ -66,7 +66,11 @@ private lemma Reachable.mem_of_forall_adj_mem (huv : G.Reachable u v)
 
 /-- One round of breadth-first search: `G.bfsStep s l acc` prepends to `acc` the vertices of the
 list `l` of vertices remaining to be visited that are adjacent to some vertex of the frontier `s`,
-namely the vertices getting visited during this round. -/
+namely the vertices getting visited during this round.
+
+This is intended to make proving reachability/connected in/of a concrete finite graph efficient
+using `decide`. In particular, it isn't designed to be efficient with `#eval`.
+-/
 def bfsStep (G : SimpleGraph V) [DecidableRel G.Adj] (s : List V) : List V → List V → List V
   | [], acc => acc
   | w :: l, acc => G.bfsStep s l (if s.any (G.Adj · w) then w :: acc else acc)
@@ -86,8 +90,8 @@ lemma bfsStep_eq_reverse_filter_append :
 lemma nodup_bfsStep_append (hl : l.Nodup) (hacc : acc.Nodup) (h : ∀ x ∈ l, x ∉ acc) :
     (G.bfsStep s l [] ++ acc).Nodup := by
   rw [bfsStep_eq_reverse_filter_append, List.append_nil]
-  exact List.Nodup.append (List.nodup_reverse.2 (hl.filter _)) hacc fun x hx hx' ↦
-    h x (List.mem_of_mem_filter (List.mem_reverse.1 hx)) hx'
+  exact (hl.filter _).reverse.append hacc fun x hx ↦
+    h x (List.mem_of_mem_filter (List.mem_reverse.1 hx))
 
 /-- Iterate breadth-first search at most `n` times, stopping as soon as a round visits no new
 vertex.

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
@@ -47,7 +47,9 @@ costs `O(|V| ^ 2)` adjacency tests.
 
 Vertices `u` and `v` are then reachable if `v` lies in the BFS-constructed list of vertices
 reachable from `u`, and a graph is (pre)connected iff it's non-empty and (/empty or) every vertex
-lies in the reachability list of an arbitrarily-chosen vertex.
+lies in the reachability list of an arbitrarily-chosen vertex. Since the search visits each vertex
+at most once, the latter is checked by comparing the length of the reachability list to the number
+of vertices, which is cheaper than testing membership of every vertex.
 -/
 
 section BFS
@@ -73,6 +75,19 @@ def bfsStep (G : SimpleGraph V) [DecidableRel G.Adj] (s : List V) : List V → L
 lemma mem_bfsStep : ∀ {l acc}, w ∈ G.bfsStep s l acc ↔ (w ∈ l ∧ ∃ v ∈ s, G.Adj v w) ∨ w ∈ acc
   | [], acc => by simp [bfsStep]
   | x :: l, acc => by rw [bfsStep, mem_bfsStep]; grind
+
+lemma bfsStep_eq_reverse_filter_append :
+    ∀ {l acc}, G.bfsStep s l acc = (l.filter fun w ↦ s.any (G.Adj · w)).reverse ++ acc
+  | [], acc => by simp [bfsStep]
+  | x :: l, acc => by
+    rw [bfsStep, bfsStep_eq_reverse_filter_append, List.filter_cons]
+    split <;> simp
+
+lemma nodup_bfsStep_append (hl : l.Nodup) (hacc : acc.Nodup) (h : ∀ x ∈ l, x ∉ acc) :
+    (G.bfsStep s l [] ++ acc).Nodup := by
+  rw [bfsStep_eq_reverse_filter_append, List.append_nil]
+  exact List.Nodup.append (List.nodup_reverse.2 (hl.filter _)) hacc fun x hx hx' ↦
+    h x (List.mem_of_mem_filter (List.mem_reverse.1 hx)) hx'
 
 /-- Iterate breadth-first search at most `n` times, stopping as soon as a round visits no new
 vertex.
@@ -146,12 +161,53 @@ lemma mem_bfsIterate_of_reachable (hn : l.length ≤ n) (hu : u ∈ acc) (hl : �
       · exact .inr hy
     · exact .inr <| hacc _ hx hxs' _ hxy
 
+/-- Breadth-first search only visits vertices that were remaining to be visited or already
+visited. -/
+lemma mem_or_mem_of_mem_bfsIterate (hv : v ∈ G.bfsIterate n s l acc) : v ∈ l ∨ v ∈ acc := by
+  induction n generalizing s l acc with
+  | zero => exact .inr hv
+  | succ n ih =>
+    simp only [bfsIterate] at hv
+    split_ifs at hv with h
+    · exact .inr hv
+    obtain hv | hv := ih hv
+    · exact .inl <| List.mem_of_mem_filter hv
+    · rw [List.mem_append] at hv
+      exact hv.imp (fun hv ↦ (mem_bfsStep.1 hv).elim And.left (by simp)) id
+
+/-- Breadth-first search visits no vertex twice, assuming the lists of remaining and of visited
+vertices are themselves duplicate-free and disjoint. -/
+lemma nodup_bfsIterate (hl : l.Nodup) (hacc : acc.Nodup) (h : ∀ x ∈ l, x ∉ acc) :
+    (G.bfsIterate n s l acc).Nodup := by
+  induction n generalizing s l acc with
+  | zero => exact hacc
+  | succ n ih =>
+    simp only [bfsIterate]
+    split_ifs with h'
+    · exact hacc
+    refine ih (hl.filter _) (nodup_bfsStep_append hl hacc h) fun x hx hx' ↦ ?_
+    rw [List.mem_filter] at hx
+    obtain hx' | hx' := List.mem_append.1 hx'
+    · simp only [mem_bfsStep, List.not_mem_nil, or_false] at hx'
+      simp only [Bool.not_eq_eq_eq_not, Bool.not_true, List.any_eq_false] at hx
+      exact absurd hx'.2 (by simpa using hx.2)
+    · exact h _ hx.1 hx'
+
 variable [DecidableEq V]
 
 variable (G) in
-/-- The list of vertices reachable from `u`, computed by breadth-first search through the list `l`
-of all vertices. -/
+/-- The list of vertices in `l` reachable from `u` via vertices of `l`, computed by breadth-first
+search through the list `l` of all vertices. -/
 def bfsList (u : V) (l : List V) : List V := G.bfsIterate (l.length - 1) [u] (l.erase u) [u]
+
+lemma mem_of_mem_bfsList (hu : u ∈ l) (hv : v ∈ G.bfsList u l) : v ∈ l := by
+  obtain hv | hv := mem_or_mem_of_mem_bfsIterate hv
+  · exact List.erase_subset hv
+  · rwa [List.mem_singleton.1 hv]
+
+lemma nodup_bfsList (hl : l.Nodup) : (G.bfsList u l).Nodup :=
+  nodup_bfsIterate (hl.erase _) (List.nodup_singleton _) fun x hx ↦ by
+    simp [(hl.mem_erase_iff.1 hx).1]
 
 lemma mem_bfsList (hl : ∀ w, w ∈ l) : v ∈ G.bfsList u l ↔ G.Reachable u v := by
   refine ⟨reachable_of_mem_bfsIterate (fun x hx ↦ hx) (fun x hx ↦ ?_), fun hv ↦ ?_⟩
@@ -171,11 +227,31 @@ lemma connected_iff_forall_mem_bfsList (hl : ∀ w, w ∈ l) (u : V) :
     G.Connected ↔ ∀ v, v ∈ G.bfsList u l := by
   rw [connected_iff, preconnected_iff_forall_mem_bfsList hl u, and_iff_left ⟨u⟩]
 
+/-- Breadth-first search from `u` visits every vertex iff it visits as many vertices as there are,
+since it visits each vertex at most once.
+
+Comparing lengths is faster than checking membership of every vertex, so this is the criterion used
+by the `SimpleGraph.decidablePreconnected` and `SimpleGraph.decidableConnected` instances. -/
+lemma length_bfsList_eq_iff (hl : l.Nodup) (hl' : ∀ w, w ∈ l) (u : V) :
+    (G.bfsList u l).length = l.length ↔ ∀ v, v ∈ G.bfsList u l := by
+  have hsub : List.Subperm (G.bfsList u l) l :=
+    (nodup_bfsList hl).subperm fun _ hv ↦ mem_of_mem_bfsList (hl' u) hv
+  exact ⟨fun h v ↦ (hsub.perm_of_length_le h.ge).mem_iff.2 (hl' v), fun h ↦
+    le_antisymm hsub.length_le (hl.subperm fun v _ ↦ h v).length_le⟩
+
+lemma preconnected_iff_length_bfsList (hl : l.Nodup) (hl' : ∀ w, w ∈ l) (u : V) :
+    G.Preconnected ↔ (G.bfsList u l).length = l.length := by
+  rw [preconnected_iff_forall_mem_bfsList hl' u, length_bfsList_eq_iff hl hl']
+
+lemma connected_iff_length_bfsList (hl : l.Nodup) (hl' : ∀ w, w ∈ l) (u : V) :
+    G.Connected ↔ (G.bfsList u l).length = l.length := by
+  rw [connected_iff_forall_mem_bfsList hl' u, length_bfsList_eq_iff hl hl']
+
 variable [Fintype V]
 
 /-- Decides reachability of vertices `u` and `v` by performing a breadth-first search from `u`. -/
 instance decidableReachable : DecidableRel G.Reachable := fun _u _v ↦
-  (Fintype.truncList V).lift (fun l ↦ decidable_of_iff _ (mem_bfsList l.2))
+  (Fintype.truncList V).lift (fun l ↦ decidable_of_iff _ (mem_bfsList l.2.2))
     fun _ _ ↦ Subsingleton.elim ..
 
 /-- Decides preconnectedness of `G` by checking whether the vertex set is empty and, if not,
@@ -183,8 +259,8 @@ by performing a breadth-first search from an arbitrarily chosen vertex. -/
 instance decidablePreconnected : Decidable G.Preconnected :=
   (Fintype.truncList V).lift
     (fun ⟨l, hl⟩ ↦ match l, hl with
-      | [], hl => isTrue fun x _ ↦ absurd (hl x) (by simp)
-      | u :: l, hl => decidable_of_iff _ (preconnected_iff_forall_mem_bfsList hl u).symm)
+      | [], hl => isTrue fun x _ ↦ absurd (hl.2 x) (by simp)
+      | u :: l, hl => decidable_of_iff _ (preconnected_iff_length_bfsList_eq hl.1 hl.2 u).symm)
     fun _ _ ↦ Subsingleton.elim ..
 
 /-- Decides connectedness of `G` by checking whether the vertex set is empty and, if not,
@@ -192,8 +268,8 @@ by performing a breadth-first search from an arbitrarily chosen vertex. -/
 instance decidableConnected : Decidable G.Connected :=
   (Fintype.truncList V).lift
     (fun ⟨l, hl⟩ ↦ match l, hl with
-      | [], hl => isFalse fun hG ↦ absurd (hl hG.nonempty.some) (by simp)
-      | u :: l, hl => decidable_of_iff _ (connected_iff_forall_mem_bfsList hl u).symm)
+      | [], hl => isFalse fun hG ↦ absurd (hl.2 hG.nonempty.some) (by simp)
+      | u :: l, hl => decidable_of_iff _ (connected_iff_length_bfsList_eq hl.1 hl.2 u).symm)
     fun _ _ ↦ Subsingleton.elim ..
 
 instance : Fintype G.ConnectedComponent :=

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Finite.lean
@@ -260,7 +260,7 @@ instance decidablePreconnected : Decidable G.Preconnected :=
   (Fintype.truncList V).lift
     (fun ⟨l, hl⟩ ↦ match l, hl with
       | [], hl => isTrue fun x _ ↦ absurd (hl.2 x) (by simp)
-      | u :: l, hl => decidable_of_iff _ (preconnected_iff_length_bfsList_eq hl.1 hl.2 u).symm)
+      | u :: l, hl => decidable_of_iff _ (preconnected_iff_length_bfsList hl.1 hl.2 u).symm)
     fun _ _ ↦ Subsingleton.elim ..
 
 /-- Decides connectedness of `G` by checking whether the vertex set is empty and, if not,
@@ -269,7 +269,7 @@ instance decidableConnected : Decidable G.Connected :=
   (Fintype.truncList V).lift
     (fun ⟨l, hl⟩ ↦ match l, hl with
       | [], hl => isFalse fun hG ↦ absurd (hl.2 hG.nonempty.some) (by simp)
-      | u :: l, hl => decidable_of_iff _ (connected_iff_length_bfsList_eq hl.1 hl.2 u).symm)
+      | u :: l, hl => decidable_of_iff _ (connected_iff_length_bfsList hl.1 hl.2 u).symm)
     fun _ _ ↦ Subsingleton.elim ..
 
 instance : Fintype G.ConnectedComponent :=

--- a/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
@@ -60,7 +60,7 @@ variable [Finite V]
 lemma IsTutteViolator.mono {u : Set V} (h : G ≤ G') (ht : G'.IsTutteViolator u) :
     G.IsTutteViolator u := by
   simp only [IsTutteViolator] at *
-  have := ncard_oddComponents_mono _ (Subgraph.deleteVerts_mono' (G := G) (G' := G') u h)
+  have := ncard_oddComponents_mono (Subgraph.deleteVerts_mono' (G := G) (G' := G') u h)
   simp only [oddComponents] at *
   #adaptation_note /-- Before https://github.com/leanprover/lean4/pull/13166
   (replacing grind's canonicalizer with a type-directed normalizer), `lia` closed this goal.
@@ -138,7 +138,7 @@ theorem Subgraph.IsPerfectMatching.exists_of_isClique_supp
 
 theorem IsTutteViolator.empty (hodd : Odd (Nat.card V)) : G.IsTutteViolator ∅ := by
   rw [IsTutteViolator, Set.ncard_empty]
-  exact ((odd_ncard_oddComponents _).mpr <| by simpa using hodd).pos
+  exact (odd_ncard_oddComponents.mpr <| by simpa using hodd).pos
 
 /-- Proves the necessity part of Tutte's theorem -/
 lemma not_isTutteViolator_of_isPerfectMatching {M : Subgraph G} (hM : M.IsPerfectMatching)

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -207,14 +207,15 @@ def truncOfMultisetExistsMem {α} (s : Multiset α) : (∃ x, x ∈ s) → Trunc
 def truncOfNonemptyFintype (α) [Nonempty α] [Fintype α] : Trunc α :=
   truncOfMultisetExistsMem Finset.univ.val (by simp)
 
-/-- A list of all the elements of a fintype.
+/-- A duplicate-free list of all the elements of a fintype.
 
 Since the order of the elements depends on the actual implementation of the `Fintype` instance, the
 list is wrapped in `Trunc` to preserve computability. -/
-def Fintype.truncList (α) [Fintype α] : Trunc {l : List α // ∀ a, a ∈ l} :=
+def Fintype.truncList (α) [Fintype α] : Trunc {l : List α // l.Nodup ∧ ∀ a, a ∈ l} :=
   Quotient.recOnSubsingleton
-    (motive := fun s : Multiset α ↦ (∀ a, a ∈ s) → Trunc {l : List α // ∀ a, a ∈ l})
-    Finset.univ.val (fun l hl ↦ Trunc.mk ⟨l, hl⟩) Finset.mem_univ_val
+    (motive := fun s : Multiset α ↦
+      s.Nodup → (∀ a, a ∈ s) → Trunc {l : List α // l.Nodup ∧ ∀ a, a ∈ l})
+    Finset.univ.val (fun l hl hl' ↦ Trunc.mk ⟨l, hl, hl'⟩) Finset.univ.nodup Finset.mem_univ_val
 
 /-- By iterating over the elements of a fintype, we can lift an existential statement `∃ a, P a`
 to `Trunc (Σ' a, P a)`, containing data.

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -207,6 +207,15 @@ def truncOfMultisetExistsMem {α} (s : Multiset α) : (∃ x, x ∈ s) → Trunc
 def truncOfNonemptyFintype (α) [Nonempty α] [Fintype α] : Trunc α :=
   truncOfMultisetExistsMem Finset.univ.val (by simp)
 
+/-- A list of all the elements of a fintype.
+
+Since the order of the elements depends on the actual implementation of the `Fintype` instance, the
+list is wrapped in `Trunc` to preserve computability. -/
+def Fintype.truncList (α) [Fintype α] : Trunc {l : List α // ∀ a, a ∈ l} :=
+  Quotient.recOnSubsingleton
+    (motive := fun s : Multiset α ↦ (∀ a, a ∈ s) → Trunc {l : List α // ∀ a, a ∈ l})
+    Finset.univ.val (fun l hl ↦ Trunc.mk ⟨l, hl⟩) Finset.mem_univ_val
+
 /-- By iterating over the elements of a fintype, we can lift an existential statement `∃ a, P a`
 to `Trunc (Σ' a, P a)`, containing data.
 -/

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -232,6 +232,8 @@ theorem Nodup.filter (p : α → Bool) {l} : Nodup l → Nodup (filter p l) := b
 theorem nodup_reverse {l : List α} : Nodup (reverse l) ↔ Nodup l :=
   pairwise_reverse.trans <| by simp only [Nodup, Ne, eq_comm]
 
+protected alias ⟨_, Nodup.reverse⟩ := nodup_reverse
+
 theorem nodup_concat (l : List α) (u : α) : (l.concat u).Nodup ↔ u ∉ l ∧ l.Nodup := by
   rw [← nodup_reverse]
   simp

--- a/MathlibTest/SimpleGraph.lean
+++ b/MathlibTest/SimpleGraph.lean
@@ -1,0 +1,53 @@
+import Mathlib.Combinatorics.SimpleGraph.Connectivity.Finite
+
+/-!
+# Tests for the breadth-first search decidability instances of a finite graph
+
+`SimpleGraph.decidableReachable`, `SimpleGraph.decidablePreconnected` and
+`SimpleGraph.decidableConnected` decide reachability and (pre)connectedness by running a breadth-
+first search, which costs `O(card V ^ 2)` adjacency tests. The `maxHeartbeats` bounds below guard
+against a regression to a super-polynomial algorithm.
+-/
+
+namespace SimpleGraph
+
+/-- The path graph on `{0, 1, 2, 3, 4}`, together with an isolated vertex `5`. -/
+def testPath : SimpleGraph (Fin 6) where
+  Adj i j := (i.val + 1 = j.val ∨ j.val + 1 = i.val) ∧ i.val < 5 ∧ j.val < 5
+  symm := ⟨by lia⟩
+  loopless := ⟨by lia⟩
+
+instance : DecidableRel testPath.Adj := fun _ _ ↦ inferInstanceAs (Decidable (_ ∧ _))
+
+/-- The cycle graph on `Fin 60`. -/
+def testCycle : SimpleGraph (Fin 60) where
+  Adj i j := (i.val + 1) % 60 = j.val ∨ (j.val + 1) % 60 = i.val
+  symm := ⟨by lia⟩
+  loopless := ⟨by lia⟩
+
+instance : DecidableRel testCycle.Adj := fun _ _ ↦ inferInstanceAs (Decidable (_ ∨ _))
+
+-- The vertices visited by the breadth-first search from `0`, most recently visited first.
+#guard testPath.bfsList 0 (List.finRange 6) = [4, 3, 2, 1, 0]
+
+example : testPath.Reachable 0 4 := by decide
+example : ¬ testPath.Reachable 0 5 := by decide
+example : ¬ testPath.Preconnected := by decide
+example : ¬ testPath.Connected := by decide
+
+example : (⊤ : SimpleGraph (Fin 5)).Connected := by decide
+example : ¬ (⊥ : SimpleGraph (Fin 2)).Connected := by decide
+example : (⊥ : SimpleGraph (Fin 1)).Connected := by decide
+
+-- The empty graph is preconnected, but not connected.
+example : (⊥ : SimpleGraph (Fin 0)).Preconnected := by decide
+example : ¬ (⊥ : SimpleGraph (Fin 0)).Connected := by decide
+
+-- These two take about 8000 and 12000 heartbeats respectively.
+set_option maxHeartbeats 50000 in
+example : testCycle.Reachable 0 30 := by decide
+
+set_option maxHeartbeats 50000 in
+example : testCycle.Connected := by decide
+
+end SimpleGraph

--- a/MathlibTest/SimpleGraph.lean
+++ b/MathlibTest/SimpleGraph.lean
@@ -30,6 +30,10 @@ instance : DecidableRel testCycle.Adj := fun _ _ ↦ inferInstanceAs (Decidable 
 -- The vertices visited by the breadth-first search from `0`, most recently visited first.
 #guard testPath.bfsList 0 (List.finRange 6) = [4, 3, 2, 1, 0]
 
+-- The isolated vertex `5` is not visited, so the search visits fewer vertices than there are.
+#guard (testPath.bfsList 0 (List.finRange 6)).length = 5
+#guard (testCycle.bfsList 0 (List.finRange 60)).length = 60
+
 example : testPath.Reachable 0 4 := by decide
 example : ¬ testPath.Reachable 0 5 := by decide
 example : ¬ testPath.Preconnected := by decide
@@ -43,11 +47,26 @@ example : (⊥ : SimpleGraph (Fin 1)).Connected := by decide
 example : (⊥ : SimpleGraph (Fin 0)).Preconnected := by decide
 example : ¬ (⊥ : SimpleGraph (Fin 0)).Connected := by decide
 
--- These two take about 8000 and 12000 heartbeats respectively.
+-- These two take about 8000 heartbeats each.
 set_option maxHeartbeats 50000 in
 example : testCycle.Reachable 0 30 := by decide
 
 set_option maxHeartbeats 50000 in
 example : testCycle.Connected := by decide
+
+/-!
+`SimpleGraph.decidablePreconnected` and `SimpleGraph.decidableConnected` check that the breadth-
+first search visited every vertex by comparing the *length* of the list of visited vertices to the
+number of vertices, rather than by checking that each vertex belongs to that list, which would cost
+a further `O(card V ^ 2)` equality tests.
+
+On a complete graph the search stops after a single round, so it only costs `O(card V)` adjacency
+tests and the difference is asymptotic: the example below takes about 1650 heartbeats, against
+about 42000 for the membership check. The `maxHeartbeats` bound guards against a regression to the
+latter.
+-/
+set_option maxRecDepth 4000 in
+set_option maxHeartbeats 5000 in
+example : (⊤ : SimpleGraph (Fin 200)).Connected := by decide
 
 end SimpleGraph


### PR DESCRIPTION
Currently, the `DecidableRel G.Reachable` instance provided by mathlib works by enumerating *all* walks from `u` to `v` of length less than `Fintype.card V`, which takes time exponential in the number of vertices. Currently also, the `Decidable G.Preconnected` and `Decidable G.Connected` instances build on the `DecidableRel G.Reachable` one and suffer from the same exponential slowdown.

This PR reworks those instances to use breadth-first search, which is polynomial in the number of vertices. Since the BFS doesn't depend on the starting vertex, we wrap it in `Trunc` to cut down an unnecessary factor of `Fintype.card V` (this makes a difference only if the graph is NOT preconnected).

This showed up in FormalConjectures because a contributor used `decide +native` to prove that some concrete graph on 11 vertices was connected. Their proof timed out while I was bumping the repo to v4.30.

Also make `G` implicit in a bunch of non-rewriting lemmas.

From FormalConjectures

Generated by Claude Opus following my idea, largely rewritten manually afterwards.

Assisted-by: Claude Opus 4.8


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
