### PR TITLE
[Merged by Bors] - feat(Order/SupClosed): a lower directed set is sup-closed

### DIFF
--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -72,6 +72,13 @@ lemma SupClosed.directedOn (hs : SupClosed s) : DirectedOn (· ≤ ·) s :=
 lemma IsUpperSet.supClosed (hs : IsUpperSet s) : SupClosed s := fun _a _ _b ↦ hs le_sup_right
 
 @[to_dual]
+theorem IsLowerSet.supClosed_of_directedOn (hl : IsLowerSet s) (hd : DirectedOn (· ≤ ·) s) :
+    SupClosed s := by
+  intro a ha b hb
+  have ⟨c, hcs, hac, hbc⟩ := hd a ha b hb
+  exact hl (sup_le hac hbc) hcs
+
+@[to_dual]
 lemma SupClosed.preimage [FunLike F β α] [SupHomClass F β α] (hs : SupClosed s) (f : F) :
     SupClosed (f ⁻¹' s) :=
   fun a ha b hb ↦ by simpa [map_sup] using hs ha hb

--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -69,11 +69,14 @@ lemma SupClosed.directedOn (hs : SupClosed s) : DirectedOn (· ≤ ·) s :=
   fun _a ha _b hb ↦ ⟨_, hs ha hb, le_sup_left, le_sup_right⟩
 
 @[to_dual]
-theorem DirectedOn.supClosed_of_isLowerSet (hd : DirectedOn (· ≤ ·) s) (hl : IsLowerSet s) :
-    SupClosed s := by
-  intro a ha b hb
+theorem IsLowerSet.supClosed_iff_directedOn (h : IsLowerSet s) :
+    SupClosed s ↔ DirectedOn (· ≤ ·) s := by
+  refine ⟨SupClosed.directedOn, fun hd a ha b hb ↦ ?_⟩
   have ⟨c, hcs, hac, hbc⟩ := hd a ha b hb
-  exact hl (sup_le hac hbc) hcs
+  exact h (sup_le hac hbc) hcs
+
+@[to_dual]
+alias ⟨_, DirectedOn.supClosed_of_isLowerSet⟩ := IsLowerSet.supClosed_iff_directedOn
 
 @[to_dual]
 lemma IsUpperSet.supClosed (hs : IsUpperSet s) : SupClosed s := fun _a _ _b ↦ hs le_sup_right

--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -69,7 +69,7 @@ lemma SupClosed.directedOn (hs : SupClosed s) : DirectedOn (· ≤ ·) s :=
   fun _a ha _b hb ↦ ⟨_, hs ha hb, le_sup_left, le_sup_right⟩
 
 @[to_dual]
-theorem IsLowerSet.supClosed_of_directedOn (hl : IsLowerSet s) (hd : DirectedOn (· ≤ ·) s) :
+theorem DirectedOn.supClosed_of_isLowerSet (hd : DirectedOn (· ≤ ·) s) (hl : IsLowerSet s) :
     SupClosed s := by
   intro a ha b hb
   have ⟨c, hcs, hac, hbc⟩ := hd a ha b hb

--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -69,14 +69,14 @@ lemma SupClosed.directedOn (hs : SupClosed s) : DirectedOn (· ≤ ·) s :=
   fun _a ha _b hb ↦ ⟨_, hs ha hb, le_sup_left, le_sup_right⟩
 
 @[to_dual]
-lemma IsUpperSet.supClosed (hs : IsUpperSet s) : SupClosed s := fun _a _ _b ↦ hs le_sup_right
-
-@[to_dual]
 theorem IsLowerSet.supClosed_of_directedOn (hl : IsLowerSet s) (hd : DirectedOn (· ≤ ·) s) :
     SupClosed s := by
   intro a ha b hb
   have ⟨c, hcs, hac, hbc⟩ := hd a ha b hb
   exact hl (sup_le hac hbc) hcs
+
+@[to_dual]
+lemma IsUpperSet.supClosed (hs : IsUpperSet s) : SupClosed s := fun _a _ _b ↦ hs le_sup_right
 
 @[to_dual]
 lemma SupClosed.preimage [FunLike F β α] [SupHomClass F β α] (hs : SupClosed s) (f : F) :


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
