### PR TITLE
[Merged by Bors] - feat: a bounded variation function is continuous off a countable set

### DIFF
--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -1012,7 +1012,7 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_zero_left
 small closed intervals to the right of this point tends to `0`. -/
 theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_zero_right
     [TopologicalSpace α] [OrderTopology α] {f : α → M} {s : Set α}
-    (hf : BoundedVariationOn f s) (x : α) (h : ContinuousWithinAt f (s ∩ Ici x) x) :
+    (hf : BoundedVariationOn f s) {x : α} (h : ContinuousWithinAt f (s ∩ Ici x) x) :
     Tendsto (fun y ↦ eVariationOn f (s ∩ Icc x y)) (𝓝[s] x) (𝓝 0) := by
   have : (fun y ↦ eVariationOn f (s ∩ Icc x y)) =
       (fun y ↦ eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s ∩ Icc (toDual y) (toDual x))) := by

--- a/Mathlib/Topology/EMetricSpace/VariationOnFromTo.lean
+++ b/Mathlib/Topology/EMetricSpace/VariationOnFromTo.lean
@@ -5,8 +5,8 @@ Authors: Sébastien Gouëzel
 -/
 module
 
+public import Mathlib.Analysis.Normed.Group.Real
 public import Mathlib.Topology.EMetricSpace.BoundedVariation
-public import Mathlib.Analysis.Normed.Group.Basic
 
 /-!
 # Signed variation
@@ -259,29 +259,121 @@ theorem rightLim_eq {E : Type*} [PseudoMetricSpace E] [CompleteSpace E]
   simp only [univ_inter] at this
   exact this (hf.tendsto_rightLim _)
 
+theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Ici
+    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
+    {a x : α} (as : a ∈ s) (xs : x ∈ s) (hx : ContinuousWithinAt g (s ∩ Ici x) x) :
+    ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Ici x) x := by
+  have H : ContinuousWithinAt (fun y ↦ (eVariationOn g (s ∩ Icc x y)).toReal) (s ∩ Ici x) x := by
+    simp only [ContinuousWithinAt, Icc_self]
+    rw [eVariationOn.subsingleton _ (by grind [Set.Subsingleton])]
+    apply (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp
+    apply Tendsto.mono_left (hg.tendsto_eVariationOn_Icc_zero_right hx)
+    exact nhdsWithin_mono _ inter_subset_left
+  apply (H.add (continuousWithinAt_const (b := variationOnFromTo g s a x))).congr_of_mem ?_
+    ⟨xs, le_rfl⟩
+  rintro y ⟨ys, hxy⟩
+  rw [← variationOnFromTo.add hg.locallyBoundedVariationOn as xs ys, add_comm]
+  simp only [Pi.add_apply, add_left_inj]
+  grind [variationOnFromTo]
+
+theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Ici_iff
+    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
+    {a x : α} (as : a ∈ s) (xs : x ∈ s) :
+    ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Ici x) x
+      ↔ ContinuousWithinAt g (s ∩ Ici x) x := by
+  refine ⟨fun h ↦ ?_, fun h ↦ hg.continuousWithinAt_variationOnFromTo_inter_Ici as xs h⟩
+  simp only [ContinuousWithinAt, tendsto_iff_edist_tendsto_0] at h ⊢
+  apply tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds h (by simp)
+  filter_upwards [self_mem_nhdsWithin] with y hy
+  rw [edist_eq_enorm_sub, variationOnFromTo.sub_right hg.locallyBoundedVariationOn as hy.1 xs,
+    variationOnFromTo.eq_of_le _ _ hy.2]
+  grw [eVariationOn.edist_le (s := s ∩ Icc x y) _ (by grind) (by grind)]
+  have : eVariationOn g (s ∩ Icc x y) ≠ ∞ := hg.mono inter_subset_left
+  simp [this]
+
 theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_Ici
     [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g univ) {a x : α}
     (hx : ContinuousWithinAt g (Ici x) x) :
     ContinuousWithinAt (variationOnFromTo g univ a) (Ici x) x := by
-  have : variationOnFromTo g univ a =
-      fun y ↦ variationOnFromTo g univ a x + variationOnFromTo g univ x y := by
-    ext y
-    rw [variationOnFromTo.add hg.locallyBoundedVariationOn (mem_univ _) (mem_univ _) (mem_univ _)]
-  rw [this]
-  apply continuousWithinAt_const.add
-  suffices H : ContinuousWithinAt (fun y ↦ (eVariationOn g (univ ∩ Icc x y)).toReal) (Ici x) x from
-    H.congr_of_mem (fun y hy ↦ by grind [variationOnFromTo]) self_mem_Iic
-  simp only [ContinuousWithinAt, Icc_self]
-  rw [eVariationOn.subsingleton _ (by grind [Set.Subsingleton])]
-  apply (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp
-  apply Tendsto.mono_left _ (nhdsWithin_mono _ (subset_univ _))
-  exact hg.tendsto_eVariationOn_Icc_zero_right _ (by simpa using hx)
+  simpa using hg.continuousWithinAt_variationOnFromTo_inter_Ici (mem_univ a) (mem_univ x)
+    (hx.mono inter_subset_right)
 
 theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_rightLim_Ici
     [TopologicalSpace α] [OrderTopology α] [T3Space M] [CompleteSpace M]
     (hg : BoundedVariationOn g univ) {a x : α} :
     ContinuousWithinAt (variationOnFromTo g.rightLim univ a) (Ici x) x :=
   hg.rightLim.continuousWithinAt_variationOnFromTo_Ici hg.continuousWithinAt_rightLim
+
+theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Iic
+    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
+    {a x : α} (as : a ∈ s) (xs : x ∈ s) (hx : ContinuousWithinAt g (s ∩ Iic x) x) :
+    ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Iic x) x := by
+  have H : ContinuousWithinAt (fun y ↦ (eVariationOn g (s ∩ Icc y x)).toReal) (s ∩ Iic x) x := by
+    simp only [ContinuousWithinAt, Icc_self]
+    rw [eVariationOn.subsingleton _ (by grind [Set.Subsingleton])]
+    apply (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp
+    apply Tendsto.mono_left (hg.tendsto_eVariationOn_Icc_zero_left hx)
+    exact nhdsWithin_mono _ inter_subset_left
+  apply (H.neg.add (continuousWithinAt_const (b := variationOnFromTo g s a x))).congr_of_mem ?_
+    ⟨xs, le_rfl⟩
+  rintro y ⟨ys, hxy⟩
+  rw [← variationOnFromTo.add hg.locallyBoundedVariationOn as xs ys, add_comm]
+  simp only [Pi.add_apply, Pi.neg_apply, add_left_inj]
+  rw [variationOnFromTo.eq_neg_swap]
+  grind [variationOnFromTo]
+
+theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Iic_iff
+    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
+    {a x : α} (as : a ∈ s) (xs : x ∈ s) :
+    ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Iic x) x
+      ↔ ContinuousWithinAt g (s ∩ Iic x) x := by
+  refine ⟨fun h ↦ ?_, fun h ↦ hg.continuousWithinAt_variationOnFromTo_inter_Iic as xs h⟩
+  simp only [ContinuousWithinAt, tendsto_iff_edist_tendsto_0] at h ⊢
+  apply tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds h (by simp)
+  filter_upwards [self_mem_nhdsWithin] with y hy
+  rw [edist_eq_enorm_sub, variationOnFromTo.sub_right hg.locallyBoundedVariationOn as hy.1 xs,
+    variationOnFromTo.eq_of_ge _ _ hy.2, enorm_neg]
+  grw [eVariationOn.edist_le (s := s ∩ Icc y x) _ (by grind) (by grind)]
+  have : eVariationOn g (s ∩ Icc y x) ≠ ∞ := hg.mono inter_subset_left
+  simp [this]
+
+theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_Iic
+    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g univ) {a x : α}
+    (hx : ContinuousWithinAt g (Iic x) x) :
+    ContinuousWithinAt (variationOnFromTo g univ a) (Iic x) x := by
+  simpa using hg.continuousWithinAt_variationOnFromTo_inter_Iic (mem_univ a) (mem_univ x)
+    (hx.mono inter_subset_right)
+
+theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_leftLim_Iic
+    [TopologicalSpace α] [OrderTopology α] [T3Space M] [CompleteSpace M]
+    (hg : BoundedVariationOn g univ) {a x : α} :
+    ContinuousWithinAt (variationOnFromTo g.leftLim univ a) (Iic x) x :=
+  hg.leftLim.continuousWithinAt_variationOnFromTo_Iic hg.continuousWithinAt_leftLim
+
+theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_iff
+    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
+    {a x : α} (as : a ∈ s) (xs : x ∈ s) :
+    ContinuousWithinAt (variationOnFromTo g s a) s x ↔ ContinuousWithinAt g s x := by
+  rw [continuousWithinAt_iff_continuous_left_right,
+    hg.continuousWithinAt_variationOnFromTo_inter_Iic_iff as xs,
+    hg.continuousWithinAt_variationOnFromTo_inter_Ici_iff as xs,
+    ← continuousWithinAt_iff_continuous_left_right]
+
+theorem _root_.BoundedVariationOn.continuousAt_variationOnFromTo_iff
+    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g univ) (a x : α) :
+    ContinuousAt (variationOnFromTo g univ a) x ↔ ContinuousAt g x := by
+  simpa [← continuousWithinAt_univ] using
+    hg.continuousWithinAt_variationOnFromTo_iff (mem_univ a) (mem_univ x)
+
+theorem _root_.BoundedVariationOn.countable_not_continuousAt
+    [TopologicalSpace α] [OrderTopology α] (hf : BoundedVariationOn g univ) :
+    Set.Countable {x | ¬ ContinuousAt g x} := by
+  nontriviality α
+  inhabit α
+  simp only [← hf.continuousAt_variationOnFromTo_iff default]
+  apply Monotone.countable_not_continuousAt
+  rw [← monotoneOn_univ]
+  exact variationOnFromTo.monotoneOn hf.locallyBoundedVariationOn (mem_univ _)
 
 end variationOnFromTo
 

--- a/Mathlib/Topology/EMetricSpace/VariationOnFromTo.lean
+++ b/Mathlib/Topology/EMetricSpace/VariationOnFromTo.lean
@@ -279,15 +279,15 @@ theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Ici
 theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Ici_iff
     [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
     {a x : α} (as : a ∈ s) (xs : x ∈ s) :
-    ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Ici x) x
-      ↔ ContinuousWithinAt g (s ∩ Ici x) x := by
+    ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Ici x) x ↔
+      ContinuousWithinAt g (s ∩ Ici x) x := by
   refine ⟨fun h ↦ ?_, fun h ↦ hg.continuousWithinAt_variationOnFromTo_inter_Ici as xs h⟩
   simp only [ContinuousWithinAt, tendsto_iff_edist_tendsto_0] at h ⊢
   apply tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds h (by simp)
   filter_upwards [self_mem_nhdsWithin] with y hy
-  rw [edist_eq_enorm_sub, variationOnFromTo.sub_right hg.locallyBoundedVariationOn as hy.1 xs,
-    variationOnFromTo.eq_of_le _ _ hy.2]
-  grw [eVariationOn.edist_le (s := s ∩ Icc x y) _ (by grind) (by grind)]
+  grw [edist_eq_enorm_sub, variationOnFromTo.sub_right hg.locallyBoundedVariationOn as hy.1 xs,
+    variationOnFromTo.eq_of_le _ _ hy.2,
+    eVariationOn.edist_le (s := s ∩ Icc x y) _ (by grind) (by grind)]
   have : eVariationOn g (s ∩ Icc x y) ≠ ∞ := hg.mono inter_subset_left
   simp [this]
 
@@ -325,15 +325,15 @@ theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Iic
 theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Iic_iff
     [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
     {a x : α} (as : a ∈ s) (xs : x ∈ s) :
-    ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Iic x) x
-      ↔ ContinuousWithinAt g (s ∩ Iic x) x := by
+    ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Iic x) x ↔
+      ContinuousWithinAt g (s ∩ Iic x) x := by
   refine ⟨fun h ↦ ?_, fun h ↦ hg.continuousWithinAt_variationOnFromTo_inter_Iic as xs h⟩
   simp only [ContinuousWithinAt, tendsto_iff_edist_tendsto_0] at h ⊢
   apply tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds h (by simp)
   filter_upwards [self_mem_nhdsWithin] with y hy
-  rw [edist_eq_enorm_sub, variationOnFromTo.sub_right hg.locallyBoundedVariationOn as hy.1 xs,
-    variationOnFromTo.eq_of_ge _ _ hy.2, enorm_neg]
-  grw [eVariationOn.edist_le (s := s ∩ Icc y x) _ (by grind) (by grind)]
+  grw [edist_eq_enorm_sub, variationOnFromTo.sub_right hg.locallyBoundedVariationOn as hy.1 xs,
+    variationOnFromTo.eq_of_ge _ _ hy.2, enorm_neg,
+    eVariationOn.edist_le (s := s ∩ Icc y x) _ (by grind) (by grind)]
   have : eVariationOn g (s ∩ Icc y x) ≠ ∞ := hg.mono inter_subset_left
   simp [this]
 
@@ -362,7 +362,7 @@ theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_iff
 theorem _root_.BoundedVariationOn.continuousAt_variationOnFromTo_iff
     [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g univ) (a x : α) :
     ContinuousAt (variationOnFromTo g univ a) x ↔ ContinuousAt g x := by
-  simpa [← continuousWithinAt_univ] using
+  simpa [continuousWithinAt_univ] using
     hg.continuousWithinAt_variationOnFromTo_iff (mem_univ a) (mem_univ x)
 
 theorem _root_.BoundedVariationOn.countable_not_continuousAt

--- a/Mathlib/Topology/EMetricSpace/VariationOnFromTo.lean
+++ b/Mathlib/Topology/EMetricSpace/VariationOnFromTo.lean
@@ -33,7 +33,7 @@ noncomputable def variationOnFromTo (f : α → E) (s : Set α) (a b : α) : ℝ
 
 namespace variationOnFromTo
 
-variable (f : α → E) (s : Set α) {g : α → M}
+variable (f : α → E) (s : Set α)
 
 protected theorem self (a : α) : variationOnFromTo f s a a = 0 := by
   dsimp only [variationOnFromTo]
@@ -259,8 +259,13 @@ theorem rightLim_eq {E : Type*} [PseudoMetricSpace E] [CompleteSpace E]
   simp only [univ_inter] at this
   exact this (hf.tendsto_rightLim _)
 
-theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Ici
-    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
+end variationOnFromTo
+
+namespace BoundedVariationOn
+
+variable [TopologicalSpace α] [OrderTopology α] {s : Set α} {g : α → M}
+
+theorem continuousWithinAt_variationOnFromTo_inter_Ici (hg : BoundedVariationOn g s)
     {a x : α} (as : a ∈ s) (xs : x ∈ s) (hx : ContinuousWithinAt g (s ∩ Ici x) x) :
     ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Ici x) x := by
   have H : ContinuousWithinAt (fun y ↦ (eVariationOn g (s ∩ Icc x y)).toReal) (s ∩ Ici x) x := by
@@ -276,8 +281,7 @@ theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Ici
   simp only [Pi.add_apply, add_left_inj]
   grind [variationOnFromTo]
 
-theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Ici_iff
-    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
+theorem continuousWithinAt_variationOnFromTo_inter_Ici_iff (hg : BoundedVariationOn g s)
     {a x : α} (as : a ∈ s) (xs : x ∈ s) :
     ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Ici x) x ↔
       ContinuousWithinAt g (s ∩ Ici x) x := by
@@ -291,21 +295,18 @@ theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Ici
   have : eVariationOn g (s ∩ Icc x y) ≠ ∞ := hg.mono inter_subset_left
   simp [this]
 
-theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_Ici
-    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g univ) {a x : α}
+theorem continuousWithinAt_variationOnFromTo_Ici (hg : BoundedVariationOn g univ) {a x : α}
     (hx : ContinuousWithinAt g (Ici x) x) :
     ContinuousWithinAt (variationOnFromTo g univ a) (Ici x) x := by
   simpa using hg.continuousWithinAt_variationOnFromTo_inter_Ici (mem_univ a) (mem_univ x)
     (hx.mono inter_subset_right)
 
-theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_rightLim_Ici
-    [TopologicalSpace α] [OrderTopology α] [T3Space M] [CompleteSpace M]
+theorem continuousWithinAt_variationOnFromTo_rightLim_Ici [T3Space M] [CompleteSpace M]
     (hg : BoundedVariationOn g univ) {a x : α} :
     ContinuousWithinAt (variationOnFromTo g.rightLim univ a) (Ici x) x :=
   hg.rightLim.continuousWithinAt_variationOnFromTo_Ici hg.continuousWithinAt_rightLim
 
-theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Iic
-    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
+theorem continuousWithinAt_variationOnFromTo_inter_Iic (hg : BoundedVariationOn g s)
     {a x : α} (as : a ∈ s) (xs : x ∈ s) (hx : ContinuousWithinAt g (s ∩ Iic x) x) :
     ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Iic x) x := by
   have H : ContinuousWithinAt (fun y ↦ (eVariationOn g (s ∩ Icc y x)).toReal) (s ∩ Iic x) x := by
@@ -322,8 +323,7 @@ theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Iic
   rw [variationOnFromTo.eq_neg_swap]
   grind [variationOnFromTo]
 
-theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Iic_iff
-    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
+theorem continuousWithinAt_variationOnFromTo_inter_Iic_iff (hg : BoundedVariationOn g s)
     {a x : α} (as : a ∈ s) (xs : x ∈ s) :
     ContinuousWithinAt (variationOnFromTo g s a) (s ∩ Iic x) x ↔
       ContinuousWithinAt g (s ∩ Iic x) x := by
@@ -337,21 +337,18 @@ theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_inter_Iic
   have : eVariationOn g (s ∩ Icc y x) ≠ ∞ := hg.mono inter_subset_left
   simp [this]
 
-theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_Iic
-    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g univ) {a x : α}
+theorem continuousWithinAt_variationOnFromTo_Iic (hg : BoundedVariationOn g univ) {a x : α}
     (hx : ContinuousWithinAt g (Iic x) x) :
     ContinuousWithinAt (variationOnFromTo g univ a) (Iic x) x := by
   simpa using hg.continuousWithinAt_variationOnFromTo_inter_Iic (mem_univ a) (mem_univ x)
     (hx.mono inter_subset_right)
 
-theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_leftLim_Iic
-    [TopologicalSpace α] [OrderTopology α] [T3Space M] [CompleteSpace M]
+theorem continuousWithinAt_variationOnFromTo_leftLim_Iic [T3Space M] [CompleteSpace M]
     (hg : BoundedVariationOn g univ) {a x : α} :
     ContinuousWithinAt (variationOnFromTo g.leftLim univ a) (Iic x) x :=
   hg.leftLim.continuousWithinAt_variationOnFromTo_Iic hg.continuousWithinAt_leftLim
 
-theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_iff
-    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g s)
+theorem continuousWithinAt_variationOnFromTo_iff (hg : BoundedVariationOn g s)
     {a x : α} (as : a ∈ s) (xs : x ∈ s) :
     ContinuousWithinAt (variationOnFromTo g s a) s x ↔ ContinuousWithinAt g s x := by
   rw [continuousWithinAt_iff_continuous_left_right,
@@ -359,14 +356,12 @@ theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_iff
     hg.continuousWithinAt_variationOnFromTo_inter_Ici_iff as xs,
     ← continuousWithinAt_iff_continuous_left_right]
 
-theorem _root_.BoundedVariationOn.continuousAt_variationOnFromTo_iff
-    [TopologicalSpace α] [OrderTopology α] (hg : BoundedVariationOn g univ) (a x : α) :
+theorem continuousAt_variationOnFromTo_iff (hg : BoundedVariationOn g univ) (a x : α) :
     ContinuousAt (variationOnFromTo g univ a) x ↔ ContinuousAt g x := by
   simpa [continuousWithinAt_univ] using
     hg.continuousWithinAt_variationOnFromTo_iff (mem_univ a) (mem_univ x)
 
-theorem _root_.BoundedVariationOn.countable_not_continuousAt
-    [TopologicalSpace α] [OrderTopology α] (hf : BoundedVariationOn g univ) :
+theorem countable_not_continuousAt (hf : BoundedVariationOn g univ) :
     Set.Countable {x | ¬ ContinuousAt g x} := by
   nontriviality α
   inhabit α
@@ -375,7 +370,7 @@ theorem _root_.BoundedVariationOn.countable_not_continuousAt
   rw [← monotoneOn_univ]
   exact variationOnFromTo.monotoneOn hf.locallyBoundedVariationOn (mem_univ _)
 
-end variationOnFromTo
+end BoundedVariationOn
 
 /-- If a real-valued function has bounded variation on a set, then it is a difference of monotone
 functions there. Moreover, one can make sure that the two monotone functions add up to the


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
