### PR TITLE
feat(RingTheory/MvPolynomial/MonomialOrder): add primed versions of lemmas

### DIFF
--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -367,14 +367,24 @@ theorem degree_add_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degr
     simp only [degree_zero, map_zero]
     apply bot_le
 
-theorem degree_add_eq_right_of_lt {f g : MvPolynomial σ R} (h : m.degree f ≺[m] m.degree g) :
+/-- A version of `degree_add_of_lt` where the right polynomial has larger degree. -/
+theorem degree_add_of_lt' {f g : MvPolynomial σ R} (h : m.degree f ≺[m] m.degree g) :
     m.degree (f + g) = m.degree g := by
   rw [add_comm]
   exact degree_add_of_lt h
 
+@[deprecated (since := "2026-08-16")]
+alias degree_add_eq_right_of_lt := degree_add_of_lt'
+
 theorem leadingCoeff_add_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degree f) :
     m.leadingCoeff (f + g) = m.leadingCoeff f := by
   simp only [leadingCoeff, m.degree_add_of_lt h, coeff_add, coeff_eq_zero_of_lt h, add_zero]
+
+/-- A version of `leadingCoeff_add_of_lt` where the right polynomial has larger degree. -/
+theorem leadingCoeff_add_of_lt' {f g : MvPolynomial σ R} (h : m.degree f ≺[m] m.degree g) :
+    m.leadingCoeff (f + g) = m.leadingCoeff g := by
+  rw [add_comm]
+  exact leadingCoeff_add_of_lt h
 
 theorem Monic.add_of_lt {f g : MvPolynomial σ R} (hf : m.Monic f) (h : m.degree g ≺[m] m.degree f) :
     m.Monic (f + g) := by
@@ -922,6 +932,12 @@ theorem leadingTerm_add_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m
     m.leadingTerm (f + g) = m.leadingTerm f := by
   simp [leadingTerm, h, degree_add_of_lt, leadingCoeff_add_of_lt]
 
+/-- A version of `leadingTerm_add_of_lt` where the right polynomial has larger degree. -/
+theorem leadingTerm_add_of_lt' {f g : MvPolynomial σ R} (h : m.degree f ≺[m] m.degree g) :
+    m.leadingTerm (f + g) = m.leadingTerm g := by
+  rw [add_comm]
+  exact leadingTerm_add_of_lt h
+
 @[simp, nontriviality]
 lemma monic_of_subsingleton [Subsingleton R] (p : MvPolynomial σ R) :
     m.Monic p := by
@@ -1219,6 +1235,24 @@ theorem leadingCoeff_sub_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] 
 theorem leadingTerm_sub_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degree f) :
     m.leadingTerm (f - g) = m.leadingTerm f := by
   simp [leadingTerm, h, degree_sub_of_lt, leadingCoeff_sub_of_lt]
+
+/-- A version of `degree_sub_of_lt` where the right polynomial has larger degree. -/
+theorem degree_sub_of_lt' {f g : MvPolynomial σ R} (h : m.degree f ≺[m] m.degree g) :
+    m.degree (f - g) = m.degree g := by
+  rw [← degree_neg, neg_sub]
+  exact degree_sub_of_lt h
+
+/-- A version of `leadingCoeff_sub_of_lt` where the right polynomial has larger degree. -/
+theorem leadingCoeff_sub_of_lt' {f g : MvPolynomial σ R} (h : m.degree f ≺[m] m.degree g) :
+    m.leadingCoeff (f - g) = m.leadingCoeff (-g) := by
+  rw [sub_eq_add_neg]
+  apply leadingCoeff_add_of_lt'
+  simp only [degree_neg, h]
+
+/-- A version of `leadingTerm_sub_of_lt` where the right polynomial has larger degree. -/
+theorem leadingTerm_sub_of_lt' {f g : MvPolynomial σ R} (h : m.degree f ≺[m] m.degree g) :
+    m.leadingTerm (f - g) = m.leadingTerm (-g) := by
+  simp [leadingTerm, h, degree_sub_of_lt', leadingCoeff_sub_of_lt']
 
 theorem degree_sub_leadingTerm_le (f : MvPolynomial σ R) :
     m.degree (f - m.leadingTerm f) ≼[m] m.degree f := by


### PR DESCRIPTION
In https://github.com/leanprover-community/mathlib4/pull/39736#discussion_r3786537308, it was suggested to add primed versions of `leadingTerm_add_of_lt` and `leadingTerm_sub_of_lt`.  In the primed versions, the other polynomial has the larger degree.  Also add versions for `degree` and `leadingCoeff`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
