### PR TITLE
chore(FieldTheory/IntermediateField/Adjoin): fix recursors

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -298,8 +298,8 @@ theorem fg_of_fg_toSubalgebra (S : IntermediateField F E) (h : S.toSubalgebra.FG
 theorem fg_of_noetherian (S : IntermediateField F E) [IsNoetherian F E] : S.FG :=
   S.fg_of_fg_toSubalgebra S.toSubalgebra.fg_of_noetherian
 
-theorem induction_on_adjoin [FiniteDimensional F E] (motive : IntermediateField F E → Prop)
-    (bot : motive ⊥)
+theorem induction_on_adjoin [FiniteDimensional F E]
+    {motive : IntermediateField F E → Prop} (bot : motive ⊥)
     (adjoin_simple : ∀ (K : IntermediateField F E) (x : E),
       motive K → motive (K⟮x⟯.restrictScalars F))
     (K : IntermediateField F E) : motive K :=

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -298,11 +298,13 @@ theorem fg_of_fg_toSubalgebra (S : IntermediateField F E) (h : S.toSubalgebra.FG
 theorem fg_of_noetherian (S : IntermediateField F E) [IsNoetherian F E] : S.FG :=
   S.fg_of_fg_toSubalgebra S.toSubalgebra.fg_of_noetherian
 
-theorem induction_on_adjoin [FiniteDimensional F E] (P : IntermediateField F E → Prop)
-    (base : P ⊥) (ih : ∀ (K : IntermediateField F E) (x : E), P K → P (K⟮x⟯.restrictScalars F))
-    (K : IntermediateField F E) : P K :=
+theorem induction_on_adjoin [FiniteDimensional F E] (motive : IntermediateField F E → Prop)
+    (bot : motive ⊥)
+    (adjoin_simple : ∀ (K : IntermediateField F E) (x : E),
+      motive K → motive (K⟮x⟯.restrictScalars F))
+    (K : IntermediateField F E) : motive K :=
   letI : IsNoetherian F E := IsNoetherian.iff_fg.2 inferInstance
-  induction_on_adjoin_fg P base ih K K.fg_of_noetherian
+  induction_on_adjoin_fg motive bot adjoin_simple K K.fg_of_noetherian
 
 end Induction
 

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -304,7 +304,7 @@ theorem induction_on_adjoin [FiniteDimensional F E]
       motive K → motive (K⟮x⟯.restrictScalars F))
     (K : IntermediateField F E) : motive K :=
   letI : IsNoetherian F E := IsNoetherian.iff_fg.2 inferInstance
-  induction_on_adjoin_fg motive bot adjoin_simple K K.fg_of_noetherian
+  induction_on_adjoin_fg bot adjoin_simple K K.fg_of_noetherian
 
 end Induction
 

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
@@ -684,7 +684,7 @@ theorem _root_.Field.fg_iff_fg_top_bot :
     ← toSubfield_inj, Subfield.algebraMap_ofSubfield, Subfield.closure_union]
 
 theorem induction_on_adjoin_finset (S : Finset E)
-    (motive : IntermediateField F E → Prop) (bot : motive ⊥)
+    {motive : IntermediateField F E → Prop} (bot : motive ⊥)
     (adjoin_simple : ∀ (K : IntermediateField F E),
       ∀ x ∈ S, motive K → motive (K⟮x⟯.restrictScalars F)) :
     motive (adjoin F S) := by
@@ -694,11 +694,11 @@ theorem induction_on_adjoin_finset (S : Finset E)
   · rw [Finset.coe_insert, Set.insert_eq, Set.union_comm, ← adjoin_adjoin_left]
     exact adjoin_simple (adjoin F _) _ ha h
 
-theorem induction_on_adjoin_fg (motive : IntermediateField F E → Prop) (base : motive ⊥)
+theorem induction_on_adjoin_fg {motive : IntermediateField F E → Prop} (base : motive ⊥)
     (ih : ∀ (K : IntermediateField F E) (x : E), motive K → motive (K⟮x⟯.restrictScalars F))
     (K : IntermediateField F E) (hK : K.FG) : motive K := by
   obtain ⟨S, rfl⟩ := hK
-  exact induction_on_adjoin_finset S motive base fun K x _ hK => ih K x hK
+  exact induction_on_adjoin_finset S base fun K x _ hK => ih K x hK
 
 end Induction
 

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
@@ -478,13 +478,13 @@ theorem restrictScalars_adjoin_of_algEquiv
   simp [hi]
 
 @[elab_as_elim]
-theorem adjoin_induction {s : Set E} {p : ∀ x ∈ adjoin F s, Prop}
-    (mem : ∀ x hx, p x (subset_adjoin _ _ hx))
-    (algebraMap : ∀ x, p (algebraMap F E x) (algebraMap_mem _ _))
-    (add : ∀ x y hx hy, p x hx → p y hy → p (x + y) (add_mem hx hy))
-    (inv : ∀ x hx, p x hx → p x⁻¹ (inv_mem hx))
-    (mul : ∀ x y hx hy, p x hx → p y hy → p (x * y) (mul_mem hx hy))
-    {x} (h : x ∈ adjoin F s) : p x h :=
+theorem adjoin_induction {s : Set E} {motive : ∀ x ∈ adjoin F s, Prop}
+    (mem : ∀ x hx, motive x (subset_adjoin _ _ hx))
+    (algebraMap : ∀ x, motive (algebraMap F E x) (algebraMap_mem _ _))
+    (add : ∀ x y hx hy, motive x hx → motive y hy → motive (x + y) (add_mem hx hy))
+    (inv : ∀ x hx, motive x hx → motive x⁻¹ (inv_mem hx))
+    (mul : ∀ x y hx hy, motive x hx → motive y hy → motive (x * y) (mul_mem hx hy))
+    {x} (h : x ∈ adjoin F s) : motive x h :=
   Subfield.closure_induction
     (fun x hx ↦ Or.casesOn hx (fun ⟨x, hx⟩ ↦ hx ▸ algebraMap x) (mem x))
     (by simp_rw [← (Algebra.algebraMap F E).map_one]; exact algebraMap 1) add
@@ -683,20 +683,22 @@ theorem _root_.Field.fg_iff_fg_top_bot :
   simp [Field.fg_iff, fg_def, Set.exists_finite_iff_finset,
     ← toSubfield_inj, Subfield.algebraMap_ofSubfield, Subfield.closure_union]
 
-theorem induction_on_adjoin_finset (S : Finset E) (P : IntermediateField F E → Prop) (base : P ⊥)
-    (ih : ∀ (K : IntermediateField F E), ∀ x ∈ S, P K → P (K⟮x⟯.restrictScalars F)) :
-    P (adjoin F S) := by
+theorem induction_on_adjoin_finset (S : Finset E)
+    (motive : IntermediateField F E → Prop) (bot : motive ⊥)
+    (adjoin_simple : ∀ (K : IntermediateField F E),
+      ∀ x ∈ S, motive K → motive (K⟮x⟯.restrictScalars F)) :
+    motive (adjoin F S) := by
   classical
   refine Finset.induction_on' S ?_ (fun _ _ ha _ _ h => ?_)
-  · simp [base]
+  · simp [bot]
   · rw [Finset.coe_insert, Set.insert_eq, Set.union_comm, ← adjoin_adjoin_left]
-    exact ih (adjoin F _) _ ha h
+    exact adjoin_simple (adjoin F _) _ ha h
 
-theorem induction_on_adjoin_fg (P : IntermediateField F E → Prop) (base : P ⊥)
-    (ih : ∀ (K : IntermediateField F E) (x : E), P K → P (K⟮x⟯.restrictScalars F))
-    (K : IntermediateField F E) (hK : K.FG) : P K := by
+theorem induction_on_adjoin_fg (motive : IntermediateField F E → Prop) (base : motive ⊥)
+    (ih : ∀ (K : IntermediateField F E) (x : E), motive K → motive (K⟮x⟯.restrictScalars F))
+    (K : IntermediateField F E) (hK : K.FG) : motive K := by
   obtain ⟨S, rfl⟩ := hK
-  exact induction_on_adjoin_finset S P base fun K x _ hK => ih K x hK
+  exact induction_on_adjoin_finset S motive base fun K x _ hK => ih K x hK
 
 end Induction
 

--- a/Mathlib/FieldTheory/PrimitiveElement.lean
+++ b/Mathlib/FieldTheory/PrimitiveElement.lean
@@ -208,16 +208,14 @@ variable [FiniteDimensional F E] [Algebra.IsSeparable F E]
 @[stacks 030N "The moreover part"]
 theorem exists_primitive_element : ∃ α : E, F⟮α⟯ = ⊤ := by
   rcases isEmpty_or_nonempty (Fintype F) with (F_inf | ⟨⟨F_finite⟩⟩)
-  · let P : IntermediateField F E → Prop := fun K => ∃ α : E, F⟮α⟯ = K
-    have base : P ⊥ := ⟨0, adjoin_zero⟩
-    have ih : ∀ (K : IntermediateField F E) (x : E), P K → P (K⟮x⟯.restrictScalars F) := by
-      intro K β hK
+  · induction (⊤ : IntermediateField F E) using induction_on_adjoin with
+    | bot => exact ⟨0, adjoin_zero⟩
+    | adjoin_simple K β hK =>
       obtain ⟨α, hK⟩ := hK
       rw [← hK, adjoin_simple_adjoin_simple]
       have : Infinite F := isEmpty_fintype.mp F_inf
       obtain ⟨γ, hγ⟩ := primitive_element_inf_aux F α β
       exact ⟨γ, hγ.symm⟩
-    exact induction_on_adjoin P base ih ⊤
   · exact exists_primitive_element_of_finite_bot F E
 
 /-- Alternative phrasing of primitive element theorem:
@@ -289,10 +287,12 @@ theorem exists_primitive_element_of_finite_intermediateField
   rcases finite_or_infinite F with (_ | _)
   · obtain ⟨α, h⟩ := exists_primitive_element_of_finite_bot F K
     exact ⟨α, by simpa only [lift_adjoin_simple, lift_top] using congr_arg lift h⟩
-  · apply induction_on_adjoin (fun K ↦ ∃ α : E, F⟮α⟯ = K) ⟨0, adjoin_zero⟩
-    rintro K β ⟨α, rfl⟩
-    simp_rw [adjoin_simple_adjoin_simple, eq_comm]
-    exact primitive_element_inf_aux_of_finite_intermediateField F α β
+  · induction K using induction_on_adjoin with
+    | bot => exact ⟨0, adjoin_zero⟩
+    | adjoin_simple K β ih =>
+      obtain ⟨α, rfl⟩ := ih
+      simp_rw [adjoin_simple_adjoin_simple, eq_comm]
+      exact primitive_element_inf_aux_of_finite_intermediateField F α β
 
 theorem FiniteDimensional.of_exists_primitive_element [Algebra.IsAlgebraic F E]
     (h : ∃ α : E, F⟮α⟯ = ⊤) : FiniteDimensional F E := by

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -728,8 +728,7 @@ namespace Field
 /-- The separable degree of any field extension `E / F` divides the degree of `E / F`. -/
 theorem finSepDegree_dvd_finrank : finSepDegree F E ∣ finrank F E := by
   by_cases hfd : FiniteDimensional F E
-  · rw [← finSepDegree_top F, ← finrank_top F E]
-    change finSepDegree F (⊤ : IntermediateField F E) ∣ finrank F (⊤ : IntermediateField F E)
+  · rw [← finSepDegree_top F, ← finrank_top']
     induction (⊤ : IntermediateField F E) using induction_on_adjoin with
     | bot => simp_rw [finSepDegree_bot, IntermediateField.finrank_bot, one_dvd]
     | adjoin_simple L x h =>
@@ -758,8 +757,7 @@ theorem finSepDegree_eq_finrank_of_isSeparable [Algebra.IsSeparable F E] :
     by_cases hd' : finSepDegree L E = 0
     · rw [← hd, hd', mul_zero]
     linarith only [h', hd, Nat.le_mul_of_pos_right (finrank F L) (Nat.pos_of_ne_zero hd')]
-  rw [← finSepDegree_top F, ← finrank_top F E]
-  change finSepDegree F (⊤ : IntermediateField F E) = finrank F (⊤ : IntermediateField F E)
+  rw [← finSepDegree_top F, ← finrank_top']
   induction (⊤ : IntermediateField F E) using induction_on_adjoin with
   | bot => simp_rw [finSepDegree_bot, IntermediateField.finrank_bot]
   | adjoin_simple L x h =>

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -729,12 +729,14 @@ namespace Field
 theorem finSepDegree_dvd_finrank : finSepDegree F E ∣ finrank F E := by
   by_cases hfd : FiniteDimensional F E
   · rw [← finSepDegree_top F, ← finrank_top F E]
-    refine induction_on_adjoin (fun K : IntermediateField F E ↦ finSepDegree F K ∣ finrank F K)
-      (by simp_rw [finSepDegree_bot, IntermediateField.finrank_bot, one_dvd]) (fun L x h ↦ ?_) ⊤
-    have hdvd := mul_dvd_mul h <| finSepDegree_adjoin_simple_dvd_finrank L E x
-    set M := L⟮x⟯
-    rwa [finSepDegree_mul_finSepDegree_of_isAlgebraic F L M,
-      Module.finrank_mul_finrank F L M] at hdvd
+    change finSepDegree F (⊤ : IntermediateField F E) ∣ finrank F (⊤ : IntermediateField F E)
+    induction (⊤ : IntermediateField F E) using induction_on_adjoin with
+    | bot => simp_rw [finSepDegree_bot, IntermediateField.finrank_bot, one_dvd]
+    | adjoin_simple L x h =>
+      have hdvd := mul_dvd_mul h <| finSepDegree_adjoin_simple_dvd_finrank L E x
+      set M := L⟮x⟯
+      rwa [finSepDegree_mul_finSepDegree_of_isAlgebraic F L M,
+        Module.finrank_mul_finrank F L M] at hdvd
   rw [finrank_of_infinite_dimensional hfd]
   exact dvd_zero _
 
@@ -757,14 +759,16 @@ theorem finSepDegree_eq_finrank_of_isSeparable [Algebra.IsSeparable F E] :
     · rw [← hd, hd', mul_zero]
     linarith only [h', hd, Nat.le_mul_of_pos_right (finrank F L) (Nat.pos_of_ne_zero hd')]
   rw [← finSepDegree_top F, ← finrank_top F E]
-  refine induction_on_adjoin (fun K : IntermediateField F E ↦ finSepDegree F K = finrank F K)
-    (by simp_rw [finSepDegree_bot, IntermediateField.finrank_bot]) (fun L x h ↦ ?_) ⊤
-  have heq : _ * _ = _ * _ := congr_arg₂ (· * ·) h <|
-    (finSepDegree_adjoin_simple_eq_finrank_iff L E x (IsAlgebraic.of_finite L x)).2 <|
-      IsSeparable.tower_top L (Algebra.IsSeparable.isSeparable F x)
-  set M := L⟮x⟯
-  rwa [finSepDegree_mul_finSepDegree_of_isAlgebraic F L M,
-    Module.finrank_mul_finrank F L M] at heq
+  change finSepDegree F (⊤ : IntermediateField F E) = finrank F (⊤ : IntermediateField F E)
+  induction (⊤ : IntermediateField F E) using induction_on_adjoin with
+  | bot => simp_rw [finSepDegree_bot, IntermediateField.finrank_bot]
+  | adjoin_simple L x h =>
+    have heq : _ * _ = _ * _ := congr_arg₂ (· * ·) h <|
+      (finSepDegree_adjoin_simple_eq_finrank_iff L E x (IsAlgebraic.of_finite L x)).2 <|
+        IsSeparable.tower_top L (Algebra.IsSeparable.isSeparable F x)
+    set M := L⟮x⟯
+    rwa [finSepDegree_mul_finSepDegree_of_isAlgebraic F L M,
+      Module.finrank_mul_finrank F L M] at heq
 
 alias Algebra.IsSeparable.finSepDegree_eq := finSepDegree_eq_finrank_of_isSeparable
 


### PR DESCRIPTION
Name the motive `motive` and name the minor premises according to their contents. Also make the motive implicit.

---

The motivation for naming the motive `motive` is to make it consistent across all the recursors, and to give it a more descriptive name, and to make it easier to find recursors by a text search. The motivation for renaming the minor premise arguments is to give them more descriptive names, since they are used as the names of `induction` arms and `cases` arms. The motivation for making the motive implicit is that you usually don't want to fill this in yourself, but rather let `induction` or `cases` or `@[elab_as_elim]` fill it in for you. The motive can still be specified explicitly by writing `(motive := ...)`.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
