### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Chebyshev): the Cauchy–Schwarz inequality for multisets

### DIFF
--- a/Mathlib/Algebra/Order/Chebyshev.lean
+++ b/Mathlib/Algebra/Order/Chebyshev.lean
@@ -147,7 +147,7 @@ theorem _root_.Multiset.sq_sum_le_card_mul_sum_sq (m : Multiset α) :
     grind [m.map_toEnumFinset_fst, Multiset.map_map, Finset.sum_map_val]
   have := key id
   have := _root_.sq_sum_le_card_mul_sum_sq (s := m.toEnumFinset) (f := Prod.fst)
-  simp_all [sum_eq_sum_toEnumFinset m, key (· ^ 2)]
+  simp_all [key (· ^ 2)]
 
 variable [Fintype ι]
 

--- a/Mathlib/Algebra/Order/Chebyshev.lean
+++ b/Mathlib/Algebra/Order/Chebyshev.lean
@@ -10,6 +10,7 @@ public import Mathlib.Algebra.Order.Rearrangement
 public import Mathlib.GroupTheory.Perm.Cycle.Basic
 public import Mathlib.Tactic.GCongr
 public import Mathlib.Tactic.Positivity
+
 import Mathlib.Data.Multiset.Fintype
 
 /-!

--- a/Mathlib/Algebra/Order/Chebyshev.lean
+++ b/Mathlib/Algebra/Order/Chebyshev.lean
@@ -10,6 +10,7 @@ public import Mathlib.Algebra.Order.Rearrangement
 public import Mathlib.GroupTheory.Perm.Cycle.Basic
 public import Mathlib.Tactic.GCongr
 public import Mathlib.Tactic.Positivity
+import Mathlib.Data.Multiset.Fintype
 
 /-!
 # Chebyshev's sum inequality
@@ -136,6 +137,17 @@ of the sum is less than the size of the set times the sum of the squares. -/
 theorem sq_sum_le_card_mul_sum_sq : (∑ i ∈ s, f i) ^ 2 ≤ #s * ∑ i ∈ s, f i ^ 2 := by
   simp_rw [sq]
   exact (monovaryOn_self _ _).sum_mul_sum_le_card_mul_sum
+
+/-- Special case of **Chebyshev's Sum Inequality** or the **Cauchy-Schwarz Inequality** for a
+multiset: the square of the sum is at most the cardinality times the sum of the squares. -/
+theorem _root_.Multiset.sq_sum_le_card_mul_sum_sq (m : Multiset α) :
+    m.sum ^ 2 ≤ m.card * (m.map (· ^ 2)).sum := by
+  have key (g : α → α) : (m.map g).sum = ∑ i ∈ m.toEnumFinset, g i.1 := by
+    grind [m.map_toEnumFinset_fst, Multiset.map_map, Finset.sum_map_val]
+  have := key id
+  have := key (· ^ 2)
+  have := _root_.sq_sum_le_card_mul_sum_sq (s := m.toEnumFinset) (f := Prod.fst)
+  simp_all [Multiset.card_toEnumFinset]
 
 variable [Fintype ι]
 

--- a/Mathlib/Algebra/Order/Chebyshev.lean
+++ b/Mathlib/Algebra/Order/Chebyshev.lean
@@ -141,13 +141,11 @@ theorem sq_sum_le_card_mul_sum_sq : (∑ i ∈ s, f i) ^ 2 ≤ #s * ∑ i ∈ s,
 
 /-- Special case of **Chebyshev's Sum Inequality** or the **Cauchy-Schwarz Inequality** for a
 multiset: the square of the sum is at most the cardinality times the sum of the squares. -/
-theorem _root_.Multiset.sq_sum_le_card_mul_sum_sq (m : Multiset α) :
+theorem Multiset.sq_sum_le_card_mul_sum_sq (m : Multiset α) :
     m.sum ^ 2 ≤ m.card * (m.map (· ^ 2)).sum := by
-  have key (g : α → α) : (m.map g).sum = ∑ i ∈ m.toEnumFinset, g i.1 := by
-    grind [m.map_toEnumFinset_fst, Multiset.map_map, Finset.sum_map_val]
-  have := key id
-  have := _root_.sq_sum_le_card_mul_sum_sq (s := m.toEnumFinset) (f := Prod.fst)
-  simp_all [key (· ^ 2)]
+  have := m.sum_map_eq_sum_toEnumFinset id
+  have := _root_.sq_sum_le_card_mul_sum_sq (s := toEnumFinset m) (f := Prod.fst)
+  simp_all [m.sum_map_eq_sum_toEnumFinset (· ^ 2)]
 
 variable [Fintype ι]
 

--- a/Mathlib/Algebra/Order/Chebyshev.lean
+++ b/Mathlib/Algebra/Order/Chebyshev.lean
@@ -146,9 +146,8 @@ theorem _root_.Multiset.sq_sum_le_card_mul_sum_sq (m : Multiset α) :
   have key (g : α → α) : (m.map g).sum = ∑ i ∈ m.toEnumFinset, g i.1 := by
     grind [m.map_toEnumFinset_fst, Multiset.map_map, Finset.sum_map_val]
   have := key id
-  have := key (· ^ 2)
   have := _root_.sq_sum_le_card_mul_sum_sq (s := m.toEnumFinset) (f := Prod.fst)
-  simp_all [Multiset.card_toEnumFinset]
+  simp_all [sum_eq_sum_toEnumFinset m, key (· ^ 2)]
 
 variable [Fintype ι]
 

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -111,6 +111,11 @@ theorem mem_of_mem_toEnumFinset {p : α × ℕ} (h : p ∈ m.toEnumFinset) : p.1
 @[simp] lemma map_toEnumFinset_fst (m : Multiset α) : m.toEnumFinset.val.map Prod.fst = m := by
   ext a; simp [count_map, ← Finset.filter_val, eq_comm (a := a)]
 
+@[to_additive]
+theorem prod_map_eq_prod_toEnumFinset {M : Type*} [CommMonoid M] (m : Multiset α) (f : α → M) :
+    (m.map f).prod = ∏ i ∈ m.toEnumFinset, f i.1 := by
+  grind [m.map_toEnumFinset_fst, map_map, Finset.prod_map_val]
+
 @[simp] lemma image_toEnumFinset_fst (m : Multiset α) :
     m.toEnumFinset.image Prod.fst = m.toFinset := by
   rw [Finset.image, Multiset.map_toEnumFinset_fst]


### PR DESCRIPTION
Add `Multiset.sq_sum_le_card_mul_sum_sq`, the multiset analogue of the existing `sq_sum_le_card_mul_sum_sq`: `m.sum ^ 2 ≤ m.card * (m.map (· ^ 2)).sum`. It is derived from the `Finset` version via `Multiset.toEnumFinset`, combined with a new helper lemma `Multiset.sum_map_eq_sum_toEnumFinset` to convert between `Multiset.sum` and `Finset.sum` when a `Multiset.map` is involved.

---
The code here was prepared with AI assistance, but then golfed and reviewed by myself.  It will be used in a forthcoming PR on the Newton and Maclaurin inequalities.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
