### PR TITLE
[Merged by Bors] - feat: linter for internal constructors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7459,6 +7459,7 @@ public import Mathlib.Tactic.Linter.HashCommandLinter
 public import Mathlib.Tactic.Linter.HaveILetI
 public import Mathlib.Tactic.Linter.HaveLetLinter
 public import Mathlib.Tactic.Linter.Header
+public import Mathlib.Tactic.Linter.InternalConstructor
 public import Mathlib.Tactic.Linter.Lint
 public import Mathlib.Tactic.Linter.MinImports
 public import Mathlib.Tactic.Linter.Multigoal

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -15,6 +15,7 @@ public import Mathlib.Tactic.Linter.GlobalAttributeIn
 public import Mathlib.Tactic.Linter.HashCommandLinter
 public import Mathlib.Tactic.Linter.HaveILetI
 public import Mathlib.Tactic.Linter.Header
+public import Mathlib.Tactic.Linter.InternalConstructor
 public import Mathlib.Tactic.Linter.FlexibleLinter
 public import Mathlib.Tactic.Linter.Multigoal
 public import Mathlib.Tactic.Linter.OldObtain

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -194,6 +194,7 @@ public import Mathlib.Tactic.Linter.HashCommandLinter
 public import Mathlib.Tactic.Linter.HaveILetI
 public import Mathlib.Tactic.Linter.HaveLetLinter
 public import Mathlib.Tactic.Linter.Header
+public import Mathlib.Tactic.Linter.InternalConstructor
 public import Mathlib.Tactic.Linter.Lint
 public import Mathlib.Tactic.Linter.MinImports
 public import Mathlib.Tactic.Linter.Multigoal

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -27,6 +27,11 @@ a reason, and lints against using them.
 - This linter could be accompanied by an environment linter to ensure that no forbidden constructor
   is used in final expressions. Currently this is an elaboration-time linter.
 - This linter could be generalized to allow forbidding other sorts of API besides constructors.
+- Performance. Currently, this linter has a small but non-negligible performance cost. Depending on
+  where exactly the performance cost is coming from, it might be useful to either:
+  - merge the `ContextInfo`s lazily (e.g. only when we need its `Environment`)
+  - run this linter in parallel alongside other similar infotree-traversing linters, within a single
+    infotree traversal
 -/
 
 open Lean Elab Command

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -35,16 +35,16 @@ namespace Mathlib.Tactic.Linter
 public meta section
 
 /--
-Allow internal constructors (e.g. `_mkInternal`) to be referenced during elaboration. By
-default, this is `false`, and disallows references arising from notation as well (including e.g.
+Forbid internal constructors (e.g. `_mkInternal`) from being referenced during elaboration. By
+default, this is `true`, and disallows references arising from notation as well (including e.g.
 anonymous constructor notation).
 
 Internal constructors may be used freely in the module in which they were defined.
 -/
-register_option linter.allowInternalConstructors : Bool := {
-  -- Note: unlike style linters which are turned on in `Mathlib.Init`, we make this false
+register_option linter.internalConstructors : Bool := {
+  -- Note: unlike style linters which are turned on in `Mathlib.Init`, we make this true
   -- everywhere so that downstream libraries do not accidentally use Mathlib internal constructors.
-  defValue := false
+  defValue := true
   descr := "allow internal constructors to be referenced downstream."
 }
 
@@ -65,15 +65,14 @@ private partial def logInternalConstructors (t : InfoTree) (ctx? : Option Contex
         then
           -- Use `withRef` to fall back to outer ref if `t.stx` has no position info
           withRef t.stx do
-            logLintErrorSuggestingTrue linter.allowInternalConstructors (← getRef)
+            logLintError linter.internalConstructors (← getRef)
               m!"`{.ofConstName n}` is an internal constructor and should not be used directly."
       | _ => pure ()
     withRef t.stx do ch.forM (logInternalConstructors · ctx?)
 where
-  /-- We inline some of `logLint` so that we can (1) log an error (2) adjust the suggested
-  option value from `false` to `true`. -/
-  logLintErrorSuggestingTrue (linterOption) (stx) (msg) := do
-    let disable := .note m!"This linter can be disabled with `set_option {linterOption.name} true`"
+  /-- We inline some of `logLint` so that we can log an error instead of a warning. -/
+  logLintError (linterOption) (stx) (msg) := do
+    let disable := .note m!"This linter can be disabled with `set_option {linterOption.name} false`"
     logErrorAt stx <|
       .ofOriginatingSyntax stx  <|
       .tagged linterOption.name <|
@@ -82,7 +81,7 @@ where
 /-- Lints against using constructors with internal names during elaboration. -/
 def internalConstructor : Linter where
   run := withSetOptionIn fun _ => do
-    if Linter.getLinterValue linter.allowInternalConstructors (← Linter.getLinterOptions) then
+    unless Linter.getLinterValue linter.internalConstructors (← Linter.getLinterOptions) do
       return
     for t in ← getInfoTrees do
       logInternalConstructors t

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -30,7 +30,7 @@ a reason, and lints against using them.
 
 open Lean Elab Command
 
-namespace Mathlib.Tactic
+namespace Mathlib.Tactic.Linter
 
 public meta section
 

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -58,7 +58,7 @@ def internalConstructor : Linter where
       t.foldInfoM (init := ()) fun ctx info _ => do
         match info with
         | .ofTermInfo i =>
-          let .const n _ := i.expr | pure ()
+          let .const n _ := i.expr.cleanupAnnotations | pure ()
           if
             n.isInternal && !isPrivateName n && ctx.env.isImportedConst n && ctx.env.isConstructor n
           then

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -60,6 +60,7 @@ def internalConstructor : Linter where
         | .ofTermInfo i =>
           let .const n _ := i.expr.cleanupAnnotations | pure ()
           if
+            -- Putting the conjuncts in this order provides a performance benefit.
             n.isInternal && !isPrivateName n && ctx.env.isImportedConst n && ctx.env.isConstructor n
           then
             -- Use `withRef` to fall back to outer ref if `info.stx` has no position info

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -60,8 +60,7 @@ def internalConstructor : Linter where
         | .ofTermInfo i =>
           let .const n _ := i.expr.cleanupAnnotations | pure ()
           if
-            ctx.env.isImportedConst n && !isPrivateName n &&
-            n.isInternal && ctx.env.isConstructor n
+            n.isInternal && !isPrivateName n && ctx.env.isImportedConst n && ctx.env.isConstructor n
           then
             -- Use `withRef` to fall back to outer ref if `info.stx` has no position info
             withRef info.stx do

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -19,7 +19,7 @@ access by the user. However, even internal names (e.g. `_mkInternal`) can be use
 anonymous constructor notation `⟨...⟩`. This linter assumes internal constructors are internal for
 a reason, and lints against using them.
 
-## TODO
+## Future work
 
 - This linter could be extensible in multiple ways:
   - Custom predicates (e.g. the ability to register non-internal constructors as forbidden)

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -58,7 +58,7 @@ def internalConstructor : Linter where
       t.foldInfoM (init := ()) fun ctx info _ => do
         match info with
         | .ofTermInfo i =>
-          let .const n _ := i.expr.cleanupAnnotations | pure ()
+          let .const n _ := i.expr | pure ()
           if
             n.isInternal && !isPrivateName n && ctx.env.isImportedConst n && ctx.env.isConstructor n
           then

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -79,7 +79,7 @@ where
       .tagged linterOption.name <|
       .tagged Linter.linterMessageTag m!"{msg}{disable}"
 
-
+/-- Lints against using constructors with internal during elaboration. -/
 def internalConstructor : Linter where
   run := withSetOptionIn fun _ => do
     if Linter.getLinterValue linter.allowInternalConstructors (← Linter.getLinterOptions) then

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Thomas R. Murrills. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas R. Murrills
+-/
+module
+
+public meta import Lean.Linter.Basic
+-- Import this linter explicitly to ensure that
+-- this file has a valid copyright header and module docstring.
+public meta import Mathlib.Tactic.Linter.Header  -- shake: keep
+
+/-!
+# Linting against internal constructors
+
+Sometimes, we want a constructor to be public for definitional equality reasons, but to discourage
+access by the user. However, even internal names (e.g. `_mkInternal`) can be used without error via
+anonymous constructor notation `⟨...⟩`. This linter assumes internal constructors are internal for
+a reason, and lints against using them.
+
+## TODO
+
+- This linter could be extensible in multiple ways:
+  - Custom predicates (e.g. the ability to register non-internal constructors as forbidden)
+  - Custom lint messages (e.g. saying "please use `fooMk` instead")
+- This linter could be accompanied by an environment linter to ensure that no forbidden constructor
+  is used in final expressions. Currently this is an elaboration-time linter.
+- This linter could be generalized to allow forbidding other sorts of API besides constructors.
+-/
+
+open Lean Elab Command
+
+namespace Mathlib.Tactic
+
+public meta section
+
+/--
+Allow internal constructors (e.g. `_mkInternal`) to be referenced during elaboration. By
+default, this is `false`, and disallows references arising from notation as well (including e.g.
+anonymous constructor notation).
+
+Internal constructors may be used freely in the module in which they were defined.
+-/
+register_option linter.allowInternalConstructors : Bool := {
+  -- Note: unlike style linters which are turned on in `Mathlib.Init`, we make this false
+  -- everywhere so that downstream libraries do not accidentally use Mathlib internal constructors.
+  defValue := false
+  descr := "allow internal constructors to be referenced downstream."
+}
+
+private partial def logInternalConstructors (t : InfoTree) (ctx? : Option ContextInfo := none) :
+    CommandElabM Unit :=
+  match t with
+  | .context ctx t =>
+    logInternalConstructors t <| ctx.mergeIntoOuter? ctx?
+  | .hole _ => return
+  | .node t ch => do
+    if let some ctx := ctx? then
+      match t with
+      | .ofTermInfo i =>
+        let .const n _ := i.expr.cleanupAnnotations | pure ()
+        if
+          ctx.env.isImportedConst n && !isPrivateName n &&
+          n.isInternal && ctx.env.isConstructor n
+        then
+          -- Use `withRef` to fall back to outer ref if `t.stx` has no position info
+          withRef t.stx do
+            logLintErrorSuggestingTrue linter.allowInternalConstructors (← getRef)
+              m!"`{.ofConstName n}` is an internal constructor and should not be used directly."
+      | _ => pure ()
+    withRef t.stx do ch.forM (logInternalConstructors · ctx?)
+where
+  /-- We inline some of `logLint` so that we can (1) log an error (2) adjust the suggested
+  option value from `false` to `true`. -/
+  logLintErrorSuggestingTrue (linterOption) (stx) (msg) := do
+    let disable := .note m!"This linter can be disabled with `set_option {linterOption.name} true`"
+    logErrorAt stx <|
+      .ofOriginatingSyntax stx  <|
+      .tagged linterOption.name <|
+      .tagged Linter.linterMessageTag m!"{msg}{disable}"
+
+
+def internalConstructor : Linter where
+  run := withSetOptionIn fun _ => do
+    if Linter.getLinterValue linter.allowInternalConstructors (← Linter.getLinterOptions) then
+      return
+    for t in ← getInfoTrees do
+      logInternalConstructors t
+
+initialize addLinter internalConstructor

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -79,7 +79,7 @@ where
       .tagged linterOption.name <|
       .tagged Linter.linterMessageTag m!"{msg}{disable}"
 
-/-- Lints against using constructors with internal during elaboration. -/
+/-- Lints against using constructors with internal names during elaboration. -/
 def internalConstructor : Linter where
   run := withSetOptionIn fun _ => do
     if Linter.getLinterValue linter.allowInternalConstructors (← Linter.getLinterOptions) then

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -6,6 +6,7 @@ Authors: Thomas R. Murrills
 module
 
 public meta import Lean.Linter.Basic
+public meta import Lean.Server.InfoUtils
 -- Import this linter explicitly to ensure that
 -- this file has a valid copyright header and module docstring.
 public meta import Mathlib.Tactic.Linter.Header  -- shake: keep
@@ -45,30 +46,28 @@ register_option linter.internalConstructors : Bool := {
   -- Note: unlike style linters which are turned on in `Mathlib.Init`, we make this true
   -- everywhere so that downstream libraries do not accidentally use Mathlib internal constructors.
   defValue := true
-  descr := "allow internal constructors to be referenced downstream."
+  descr := "forbid internal constructors from being referenced during elaboration."
 }
 
-private partial def logInternalConstructors (t : InfoTree) (ctx? : Option ContextInfo := none) :
-    CommandElabM Unit :=
-  match t with
-  | .context ctx t =>
-    logInternalConstructors t <| ctx.mergeIntoOuter? ctx?
-  | .hole _ => return
-  | .node t ch => do
-    if let some ctx := ctx? then
-      match t with
-      | .ofTermInfo i =>
-        let .const n _ := i.expr.cleanupAnnotations | pure ()
-        if
-          ctx.env.isImportedConst n && !isPrivateName n &&
-          n.isInternal && ctx.env.isConstructor n
-        then
-          -- Use `withRef` to fall back to outer ref if `t.stx` has no position info
-          withRef t.stx do
-            logLintError linter.internalConstructors (← getRef)
-              m!"`{.ofConstName n}` is an internal constructor and should not be used directly."
-      | _ => pure ()
-    withRef t.stx do ch.forM (logInternalConstructors · ctx?)
+/-- Lints against using constructors with internal names during elaboration. -/
+def internalConstructor : Linter where
+  run := withSetOptionIn fun _ => do
+    unless Linter.getLinterValue linter.internalConstructors (← Linter.getLinterOptions) do
+      return
+    for t in ← getInfoTrees do
+      t.foldInfoM (init := ()) fun ctx info _ => do
+        match info with
+        | .ofTermInfo i =>
+          let .const n _ := i.expr.cleanupAnnotations | pure ()
+          if
+            ctx.env.isImportedConst n && !isPrivateName n &&
+            n.isInternal && ctx.env.isConstructor n
+          then
+            -- Use `withRef` to fall back to outer ref if `info.stx` has no position info
+            withRef info.stx do
+              logLintError linter.internalConstructors (← getRef)
+                m!"`{.ofConstName n}` is an internal constructor and should not be used directly."
+        | _ => pure ()
 where
   /-- We inline some of `logLint` so that we can log an error instead of a warning. -/
   logLintError (linterOption) (stx) (msg) := do
@@ -77,13 +76,5 @@ where
       .ofOriginatingSyntax stx  <|
       .tagged linterOption.name <|
       .tagged Linter.linterMessageTag m!"{msg}{disable}"
-
-/-- Lints against using constructors with internal names during elaboration. -/
-def internalConstructor : Linter where
-  run := withSetOptionIn fun _ => do
-    unless Linter.getLinterValue linter.internalConstructors (← Linter.getLinterOptions) do
-      return
-    for t in ← getInfoTrees do
-      logInternalConstructors t
 
 initialize addLinter internalConstructor

--- a/MathlibTest/Linter/InternalConstructor/Source.lean
+++ b/MathlibTest/Linter/InternalConstructor/Source.lean
@@ -1,0 +1,10 @@
+module
+
+import Mathlib.Init
+
+public section
+
+structure Foo where _mkInternal :: x : Nat
+
+-- We can use internal constructors in the module we defined them in
+def e : Foo := ⟨4⟩

--- a/MathlibTest/Linter/InternalConstructor/Target.lean
+++ b/MathlibTest/Linter/InternalConstructor/Target.lean
@@ -7,7 +7,7 @@ import MathlibTest.Linter.InternalConstructor.Source
 @ +1:16...19
 error: `Foo._mkInternal` is an internal constructor and should not be used directly.
 
-Note: This linter can be disabled with `set_option linter.allowInternalConstructors true`
+Note: This linter can be disabled with `set_option linter.internalConstructors false`
 -/
 #guard_msgs (positions := true) in
 def e₁ : Foo := ⟨4⟩
@@ -16,7 +16,7 @@ def e₁ : Foo := ⟨4⟩
 @ +1:16...31
 error: `Foo._mkInternal` is an internal constructor and should not be used directly.
 
-Note: This linter can be disabled with `set_option linter.allowInternalConstructors true`
+Note: This linter can be disabled with `set_option linter.internalConstructors false`
 -/
 #guard_msgs (positions := true) in
 def e₂ : Foo := Foo._mkInternal 4

--- a/MathlibTest/Linter/InternalConstructor/Target.lean
+++ b/MathlibTest/Linter/InternalConstructor/Target.lean
@@ -1,0 +1,22 @@
+module
+
+import Mathlib.Init
+import MathlibTest.Linter.InternalConstructor.Source
+
+/--
+@ +1:16...19
+error: `Foo._mkInternal` is an internal constructor and should not be used directly.
+
+Note: This linter can be disabled with `set_option linter.allowInternalConstructors true`
+-/
+#guard_msgs (positions := true) in
+def e₁ : Foo := ⟨4⟩
+
+/--
+@ +1:16...31
+error: `Foo._mkInternal` is an internal constructor and should not be used directly.
+
+Note: This linter can be disabled with `set_option linter.allowInternalConstructors true`
+-/
+#guard_msgs (positions := true) in
+def e₂ : Foo := Foo._mkInternal 4


### PR DESCRIPTION
This PR lints against using internal constructors during elaboration (i.e. those with a name component that starts with `_`, e.g. `_mkInternal`).

This allows us to preserve defeq properties (such as in category theory) and avoid `set_option backward.privateInPublic false` while still preventing uses downstream through `⟨_⟩`.

This linter does not fire in the file in which the internal constructor is defined.

---

*Should* it fire in the file in which the internal constructor is defined, demanding a loud `set_option linter.allowInternalConstructors true`? This just means removing `ctx.env.isImportedConst n`.

Also, should the name of the option be different, so that `false` turns off the linter? Maybe just `linter.internalConstructors`?

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
