### PR TITLE
[Merged by Bors] - chore(Analysis/Normed): move `normSeminorm` into new file

### DIFF
--- a/Counterexamples/SeminormLatticeNotDistrib.lean
+++ b/Counterexamples/SeminormLatticeNotDistrib.lean
@@ -5,7 +5,7 @@ Authors: Pierre-Alexandre Bazin
 -/
 module
 
-public import Mathlib.Analysis.Normed.Module.Seminorm.Basic
+public import Mathlib.Analysis.Normed.Module.Seminorm.Norm
 
 /-!
 # The lattice of seminorms is not distributive

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2240,6 +2240,7 @@ public import Mathlib.Analysis.Normed.Module.RCLike.Real
 public import Mathlib.Analysis.Normed.Module.Ray
 public import Mathlib.Analysis.Normed.Module.RieszLemma
 public import Mathlib.Analysis.Normed.Module.Seminorm.Basic
+public import Mathlib.Analysis.Normed.Module.Seminorm.Norm
 public import Mathlib.Analysis.Normed.Module.Shrink
 public import Mathlib.Analysis.Normed.Module.Span
 public import Mathlib.Analysis.Normed.Module.TransferInstance

--- a/Mathlib/Analysis/Calculus/TangentCone/ProperSpace.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/ProperSpace.lean
@@ -5,7 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 module
 
-public import Mathlib.Analysis.Normed.Module.Seminorm.Basic
+public import Mathlib.Analysis.Normed.Module.Seminorm.Norm
 public import Mathlib.Analysis.Calculus.TangentCone.Defs
 
 /-!

--- a/Mathlib/Analysis/Convex/EGauge.lean
+++ b/Mathlib/Analysis/Convex/EGauge.lean
@@ -5,7 +5,7 @@ Authors: Yury Kudryashov
 -/
 module
 
-public import Mathlib.Analysis.Normed.Module.Seminorm.Basic
+public import Mathlib.Analysis.Normed.Module.Seminorm.Norm
 public import Mathlib.GroupTheory.GroupAction.Pointwise
 
 /-!

--- a/Mathlib/Analysis/LocallyConvex/Bounded.lean
+++ b/Mathlib/Analysis/LocallyConvex/Bounded.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.GroupTheory.GroupAction.Pointwise
 public import Mathlib.Analysis.LocallyConvex.Basic
 public import Mathlib.Analysis.LocallyConvex.BalancedCoreHull
-public import Mathlib.Analysis.Normed.Module.Seminorm.Basic
+public import Mathlib.Analysis.Normed.Module.Seminorm.Norm
 public import Mathlib.Topology.Bornology.Basic
 public import Mathlib.Topology.Algebra.IsUniformGroup.Basic
 public import Mathlib.Topology.UniformSpace.Cauchy

--- a/Mathlib/Analysis/Normed/Group/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Group/Seminorm.lean
@@ -48,7 +48,7 @@ norm, seminorm
 
 @[expose] public section
 
-assert_not_exists Finset
+assert_not_exists Finset SeminormedGroup SeminormedAddGroup
 
 open Set
 

--- a/Mathlib/Analysis/Normed/Module/Seminorm/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Seminorm/Basic.lean
@@ -9,7 +9,6 @@ public import Mathlib.Algebra.Order.AddTorsor
 public import Mathlib.Algebra.Order.Pi
 public import Mathlib.Analysis.Convex.Function
 public import Mathlib.Analysis.LocallyConvex.Basic
-public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.Data.Real.Pointwise
 
 /-!
@@ -1318,83 +1317,3 @@ lemma bddAbove_of_absorbent {ι : Sort*} {p : ι → Seminorm 𝕜 E} {s : Set E
 end NontriviallyNormedField
 
 end Seminorm
-
-/-! ### The norm as a seminorm -/
-
-
-section normSeminorm
-
-variable (𝕜) (E) [NormedField 𝕜] [SeminormedAddCommGroup E] [NormedSpace 𝕜 E] {r : ℝ}
-
-/-- The norm of a seminormed group as a seminorm. -/
-def normSeminorm : Seminorm 𝕜 E :=
-  { normAddGroupSeminorm E with smul' := norm_smul }
-
-@[simp]
-theorem coe_normSeminorm : ⇑(normSeminorm 𝕜 E) = norm :=
-  rfl
-
-@[simp]
-theorem ball_normSeminorm : (normSeminorm 𝕜 E).ball = Metric.ball := by
-  ext x r y
-  simp only [Seminorm.mem_ball, Metric.mem_ball, coe_normSeminorm, dist_eq_norm]
-
-@[simp]
-theorem closedBall_normSeminorm : (normSeminorm 𝕜 E).closedBall = Metric.closedBall := by
-  ext x r y
-  simp only [Seminorm.mem_closedBall, Metric.mem_closedBall, coe_normSeminorm, dist_eq_norm]
-
-variable {𝕜 E} {x : E}
-
-/-- Balls at the origin are absorbent. -/
-theorem absorbent_ball_zero (hr : 0 < r) : Absorbent 𝕜 (Metric.ball (0 : E) r) := by
-  rw [← ball_normSeminorm 𝕜]
-  exact (normSeminorm 𝕜 _).absorbent_ball_zero hr
-
-/-- Balls containing the origin are absorbent. -/
-theorem absorbent_ball (hx : ‖x‖ < r) : Absorbent 𝕜 (Metric.ball x r) := by
-  rw [← ball_normSeminorm 𝕜]
-  exact (normSeminorm 𝕜 _).absorbent_ball hx
-
-/-- Balls at the origin are balanced. -/
-theorem balanced_ball_zero : Balanced 𝕜 (Metric.ball (0 : E) r) := by
-  rw [← ball_normSeminorm 𝕜]
-  exact (normSeminorm _ _).balanced_ball_zero r
-
-/-- Closed balls at the origin are balanced. -/
-theorem balanced_closedBall_zero : Balanced 𝕜 (Metric.closedBall (0 : E) r) := by
-  rw [← closedBall_normSeminorm 𝕜]
-  exact (normSeminorm _ _).balanced_closedBall_zero r
-
-/-- If there is a scalar `c` with `‖c‖>1`, then any element with nonzero norm can be
-moved by scalar multiplication to any shell of width `‖c‖`. Also recap information on the norm of
-the rescaling element that shows up in applications. -/
-lemma rescale_to_shell_semi_normed_zpow {c : 𝕜} (hc : 1 < ‖c‖) {ε : ℝ} (εpos : 0 < ε) {x : E}
-    (hx : ‖x‖ ≠ 0) :
-    ∃ n : ℤ, c ^ n ≠ 0 ∧ ‖c ^ n • x‖ < ε ∧ (ε / ‖c‖ ≤ ‖c ^ n • x‖) ∧
-      (‖c ^ n‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
-  (normSeminorm 𝕜 E).rescale_to_shell_zpow hc εpos hx
-
-/-- If there is a scalar `c` with `‖c‖>1`, then any element with nonzero norm can be
-moved by scalar multiplication to any shell of width `‖c‖`. Also recap information on the norm of
-the rescaling element that shows up in applications. -/
-lemma rescale_to_shell_semi_normed {c : 𝕜} (hc : 1 < ‖c‖) {ε : ℝ} (εpos : 0 < ε)
-    {x : E} (hx : ‖x‖ ≠ 0) :
-    ∃ d : 𝕜, d ≠ 0 ∧ ‖d • x‖ < ε ∧ (ε / ‖c‖ ≤ ‖d • x‖) ∧ (‖d‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
-  (normSeminorm 𝕜 E).rescale_to_shell hc εpos hx
-
-lemma rescale_to_shell_zpow [NormedAddCommGroup F] [NormedSpace 𝕜 F] {c : 𝕜} (hc : 1 < ‖c‖)
-    {ε : ℝ} (εpos : 0 < ε) {x : F} (hx : x ≠ 0) :
-    ∃ n : ℤ, c ^ n ≠ 0 ∧ ‖c ^ n • x‖ < ε ∧ (ε / ‖c‖ ≤ ‖c ^ n • x‖) ∧
-      (‖c ^ n‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
-  rescale_to_shell_semi_normed_zpow hc εpos (norm_ne_zero_iff.mpr hx)
-
-/-- If there is a scalar `c` with `‖c‖>1`, then any element can be moved by scalar multiplication to
-any shell of width `‖c‖`. Also recap information on the norm of the rescaling element that shows
-up in applications. -/
-lemma rescale_to_shell [NormedAddCommGroup F] [NormedSpace 𝕜 F] {c : 𝕜} (hc : 1 < ‖c‖)
-    {ε : ℝ} (εpos : 0 < ε) {x : F} (hx : x ≠ 0) :
-    ∃ d : 𝕜, d ≠ 0 ∧ ‖d • x‖ < ε ∧ (ε / ‖c‖ ≤ ‖d • x‖) ∧ (‖d‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
-  rescale_to_shell_semi_normed hc εpos (norm_ne_zero_iff.mpr hx)
-
-end normSeminorm

--- a/Mathlib/Analysis/Normed/Module/Seminorm/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Seminorm/Basic.lean
@@ -38,7 +38,7 @@ seminorm, locally convex, LCTVS
 
 @[expose] public section
 
-assert_not_exists balancedCore
+assert_not_exists balancedCore NormedSpace
 
 open NormedField Set Filter
 

--- a/Mathlib/Analysis/Normed/Module/Seminorm/Norm.lean
+++ b/Mathlib/Analysis/Normed/Module/Seminorm/Norm.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Anatole Dedecker
+-/
+
+module
+
+public import Mathlib.Analysis.Normed.Module.Basic
+public import Mathlib.Analysis.Normed.Module.Seminorm.Basic
+
+/-! # The norm as a seminorm
+
+In this file, we define the norm of a normed space as a bundled seminorm.
+
+-/
+
+public section
+
+variable {𝕜 E F : Type}
+
+variable [NormedField 𝕜]
+
+section Seminormed
+
+variable [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable {r : ℝ} {x : E} {c : 𝕜} {ε : ℝ}
+
+variable (𝕜 E)
+
+/-- The norm of a seminormed space as a seminorm. -/
+def normSeminorm : Seminorm 𝕜 E :=
+  { normAddGroupSeminorm E with smul' := norm_smul }
+
+@[simp]
+theorem coe_normSeminorm : ⇑(normSeminorm 𝕜 E) = norm := by rfl
+
+@[simp]
+theorem ball_normSeminorm : (normSeminorm 𝕜 E).ball = Metric.ball := by
+  ext x r y
+  simp only [Seminorm.mem_ball, Metric.mem_ball, coe_normSeminorm, dist_eq_norm]
+
+@[simp]
+theorem closedBall_normSeminorm : (normSeminorm 𝕜 E).closedBall = Metric.closedBall := by
+  ext x r y
+  simp only [Seminorm.mem_closedBall, Metric.mem_closedBall, coe_normSeminorm, dist_eq_norm]
+
+variable {𝕜 E}
+
+/-- Balls at the origin are absorbent. -/
+theorem absorbent_ball_zero (hr : 0 < r) : Absorbent 𝕜 (Metric.ball (0 : E) r) := by
+  rw [← ball_normSeminorm 𝕜]
+  exact (normSeminorm 𝕜 _).absorbent_ball_zero hr
+
+/-- Balls containing the origin are absorbent. -/
+theorem absorbent_ball (hx : ‖x‖ < r) : Absorbent 𝕜 (Metric.ball x r) := by
+  rw [← ball_normSeminorm 𝕜]
+  exact (normSeminorm 𝕜 _).absorbent_ball hx
+
+/-- Balls at the origin are balanced. -/
+theorem balanced_ball_zero : Balanced 𝕜 (Metric.ball (0 : E) r) := by
+  rw [← ball_normSeminorm 𝕜]
+  exact (normSeminorm _ _).balanced_ball_zero r
+
+/-- Closed balls at the origin are balanced. -/
+theorem balanced_closedBall_zero : Balanced 𝕜 (Metric.closedBall (0 : E) r) := by
+  rw [← closedBall_normSeminorm 𝕜]
+  exact (normSeminorm _ _).balanced_closedBall_zero r
+
+/-- If there is a scalar `c` with `‖c‖ > 1`, then any element with nonzero norm can be
+moved by scalar multiplication to any shell of width `‖c‖`. Also recap information on the norm of
+the rescaling element that shows up in applications. -/
+lemma rescale_to_shell_semi_normed_zpow (hc : 1 < ‖c‖) (εpos : 0 < ε) (hx : ‖x‖ ≠ 0) :
+    ∃ n : ℤ, c ^ n ≠ 0 ∧ ‖c ^ n • x‖ < ε ∧ (ε / ‖c‖ ≤ ‖c ^ n • x‖) ∧
+      (‖c ^ n‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
+  (normSeminorm 𝕜 E).rescale_to_shell_zpow hc εpos hx
+
+/-- If there is a scalar `c` with `‖c‖ > 1`, then any element with nonzero norm can be
+moved by scalar multiplication to any shell of width `‖c‖`. Also recap information on the norm of
+the rescaling element that shows up in applications. -/
+lemma rescale_to_shell_semi_normed (hc : 1 < ‖c‖) (εpos : 0 < ε) (hx : ‖x‖ ≠ 0) :
+    ∃ d : 𝕜, d ≠ 0 ∧ ‖d • x‖ < ε ∧ (ε / ‖c‖ ≤ ‖d • x‖) ∧ (‖d‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
+  (normSeminorm 𝕜 E).rescale_to_shell hc εpos hx
+
+end Seminormed
+
+section Normed
+
+variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable {r : ℝ} {x : E} {c : 𝕜} {ε : ℝ}
+
+lemma rescale_to_shell_zpow (hc : 1 < ‖c‖) (εpos : 0 < ε) (hx : x ≠ 0) :
+    ∃ n : ℤ, c ^ n ≠ 0 ∧ ‖c ^ n • x‖ < ε ∧ (ε / ‖c‖ ≤ ‖c ^ n • x‖) ∧
+      (‖c ^ n‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
+  rescale_to_shell_semi_normed_zpow hc εpos (norm_ne_zero_iff.mpr hx)
+
+/-- If there is a scalar `c` with `‖c‖ > 1`, then any element can be moved by scalar multiplication
+to any shell of width `‖c‖`. Also recap information on the norm of the rescaling element that shows
+up in applications. -/
+lemma rescale_to_shell (hc : 1 < ‖c‖) (εpos : 0 < ε) (hx : x ≠ 0) :
+    ∃ d : 𝕜, d ≠ 0 ∧ ‖d • x‖ < ε ∧ (ε / ‖c‖ ≤ ‖d • x‖) ∧ (‖d‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
+  rescale_to_shell_semi_normed hc εpos (norm_ne_zero_iff.mpr hx)
+
+end Normed

--- a/Mathlib/Analysis/Normed/Module/Seminorm/Norm.lean
+++ b/Mathlib/Analysis/Normed/Module/Seminorm/Norm.lean
@@ -17,7 +17,7 @@ In this file, we define the norm of a normed space as a bundled seminorm.
 
 public section
 
-variable {𝕜 E F : Type}
+variable {𝕜 E F : Type*}
 
 variable [NormedField 𝕜]
 
@@ -29,8 +29,10 @@ variable {r : ℝ} {x : E} {c : 𝕜} {ε : ℝ}
 variable (𝕜 E)
 
 /-- The norm of a seminormed space as a seminorm. -/
-def normSeminorm : Seminorm 𝕜 E :=
+@[expose] def normSeminorm : Seminorm 𝕜 E :=
   { normAddGroupSeminorm E with smul' := norm_smul }
+
+-- Todo: exposing this definition is questionable, but unexposing needs some work
 
 @[simp]
 theorem coe_normSeminorm : ⇑(normSeminorm 𝕜 E) = norm := by rfl


### PR DESCRIPTION
Aims to untangle `NormedSpace` and `Seminorm`.

We also add checks for `GroupSeminorm` not importing `SeminormedGroup` and `Seminorm` not importing `NormedSpace`.

Copyright goes to Yael for [#11487](https://github.com/leanprover-community/mathlib3/pull/11487) (mathlib3) and Anatole for #5501.

---

Future plans: move last section of `EGauge` into the new file and untangle `WithSeminorms`

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
