### PR TITLE
[Merged by Bors] - fix(Topology/Metrizable/CompletelyMetrizable): make instances anonymous to avoid name collisions

### DIFF
--- a/Mathlib/Topology/Metrizable/CompletelyMetrizable.lean
+++ b/Mathlib/Topology/Metrizable/CompletelyMetrizable.lean
@@ -100,7 +100,7 @@ namespace IsCompletelyPseudoMetrizableSpace
 /-- Note: the priority is set to 90 to ensure that this instance is only applied after
 `PseudoEMetricSpace.pseudoMetrizableSpace`. This prevents unnecessary attempts to infer
 completeness. -/
-instance (priority := 90) PseudoMetrizableSpace [TopologicalSpace X]
+instance (priority := 90) [TopologicalSpace X]
     [IsCompletelyPseudoMetrizableSpace X] : PseudoMetrizableSpace X := by
   let := upgradeIsCompletelyPseudoMetrizable X
   infer_instance
@@ -211,7 +211,7 @@ namespace IsCompletelyMetrizableSpace
 
 /-- Note: the priority is set to 90 to ensure that this instance is only applied after
 `EMetricSpace.metrizableSpace`. This prevents unnecessary attempts to infer completeness. -/
-instance (priority := 90) MetrizableSpace [TopologicalSpace X] [IsCompletelyMetrizableSpace X] :
+instance (priority := 90) [TopologicalSpace X] [IsCompletelyMetrizableSpace X] :
     MetrizableSpace X := by
   let := upgradeIsCompletelyMetrizable X
   infer_instance


### PR DESCRIPTION
Drop instance names `TopologicalSpace.IsCompletelyPseudoMetrizableSpace.{Pseudo,}MetrizableSpace`. The current names violate naming convention, and can cause confusing errors (as this shadows the e.g. `MetrizableSpace` class).

--------

Why? As named, each instance shadows the class it produces --- any declaration in IsCompletelyMetrizableSpace resolves MetrizableSpace to the instance rather than the type, when the type is going to always be what is intended.

I discovered this while trying to add a proof that all CompletelyMetrizable subspaces of a Metrizable space are G\delta - the signature

theorem TopologicalSpace.IsCompletelyMetrizableSpace.isGδ
    {X : Type*} [TopologicalSpace X] [MetrizableSpace X] {s : Set X}
    (hs : IsCompletelyMetrizableSpace s) : IsGδ s
    
caused an error, because MetrizableSpace was interpreted as the instance (which takes no parameters) rather than the type MetrizableSpace.

The updated naming matches convention already used for other such instances as in Mathlib/Topology/Metrizable/Basic.lean