### PR TITLE
[Merged by Bors] - feat: add Measure.bind_comm

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Prod.lean
+++ b/Mathlib/MeasureTheory/Measure/Prod.lean
@@ -1073,6 +1073,32 @@ theorem lintegral_prod_mul {f : α → ℝ≥0∞} {g : β → ℝ≥0∞} (hf :
   rw [lintegral_prod _ (by fun_prop)]
   simp [lintegral_lintegral_mul hf hg]
 
+lemma _root_.Measurable.measurable_bind {f : α → β → Measure γ} (hf : Measurable f.uncurry) :
+    Measurable (fun a ↦ ν.bind (f a)) := by
+  refine measurable_measure.2 fun s hs ↦ ?_
+  simp_rw [ν.bind_apply hs hf.of_uncurry_left.aemeasurable]
+  apply Measurable.lintegral_prod_left
+  convert measurable_measure.1 (hf.comp measurable_swap) s hs
+  grind
+
+lemma _root_.Measurable.measurable_bind' [SFinite μ] {f : α → β → Measure γ}
+    (hf : Measurable f.uncurry) :
+    Measurable (fun b ↦ μ.bind (f · b)) := by
+  refine measurable_measure.2 fun s hs ↦ ?_
+  simp_rw [bind_apply hs hf.of_uncurry_right.aemeasurable]
+  apply Measurable.lintegral_prod_right
+  convert measurable_measure.1 (hf.comp measurable_swap) s hs
+  grind
+
+theorem Measure.bind_comm [SFinite μ] {f : α → β → Measure γ} (hf : Measurable f.uncurry) :
+    μ.bind (fun a ↦ ν.bind (f a)) = ν.bind (fun b ↦ μ.bind (f · b)) := by
+  ext s hs
+  simp_rw [bind_apply hs hf.measurable_bind.aemeasurable,
+    bind_apply hs hf.of_uncurry_left.aemeasurable, bind_apply hs hf.measurable_bind'.aemeasurable,
+    bind_apply hs hf.of_uncurry_right.aemeasurable]
+  rw [lintegral_lintegral_swap]
+  exact (measurable_measure.1 hf s hs).aemeasurable
+
 /-! ### Marginals of a measure defined on a product -/
 
 

--- a/Mathlib/MeasureTheory/Measure/Prod.lean
+++ b/Mathlib/MeasureTheory/Measure/Prod.lean
@@ -1073,7 +1073,7 @@ theorem lintegral_prod_mul {f : α → ℝ≥0∞} {g : β → ℝ≥0∞} (hf :
   rw [lintegral_prod _ (by fun_prop)]
   simp [lintegral_lintegral_mul hf hg]
 
-lemma _root_.Measurable.measurable_bind {f : α → β → Measure γ} (hf : Measurable f.uncurry) :
+lemma _root_.Measurable.measurable_bind_left {f : α → β → Measure γ} (hf : Measurable f.uncurry) :
     Measurable (fun a ↦ ν.bind (f a)) := by
   refine measurable_measure.2 fun s hs ↦ ?_
   simp_rw [ν.bind_apply hs hf.of_uncurry_left.aemeasurable]
@@ -1081,7 +1081,7 @@ lemma _root_.Measurable.measurable_bind {f : α → β → Measure γ} (hf : Mea
   convert measurable_measure.1 (hf.comp measurable_swap) s hs
   grind
 
-lemma _root_.Measurable.measurable_bind' [SFinite μ] {f : α → β → Measure γ}
+lemma _root_.Measurable.measurable_bind_right [SFinite μ] {f : α → β → Measure γ}
     (hf : Measurable f.uncurry) :
     Measurable (fun b ↦ μ.bind (f · b)) := by
   refine measurable_measure.2 fun s hs ↦ ?_
@@ -1093,8 +1093,9 @@ lemma _root_.Measurable.measurable_bind' [SFinite μ] {f : α → β → Measure
 theorem Measure.bind_comm [SFinite μ] {f : α → β → Measure γ} (hf : Measurable f.uncurry) :
     μ.bind (fun a ↦ ν.bind (f a)) = ν.bind (fun b ↦ μ.bind (f · b)) := by
   ext s hs
-  simp_rw [bind_apply hs hf.measurable_bind.aemeasurable,
-    bind_apply hs hf.of_uncurry_left.aemeasurable, bind_apply hs hf.measurable_bind'.aemeasurable,
+  simp_rw [bind_apply hs hf.measurable_bind_left.aemeasurable,
+    bind_apply hs hf.of_uncurry_left.aemeasurable,
+    bind_apply hs hf.measurable_bind_right.aemeasurable,
     bind_apply hs hf.of_uncurry_right.aemeasurable]
   rw [lintegral_lintegral_swap]
   exact (measurable_measure.1 hf s hs).aemeasurable


### PR DESCRIPTION
This lemma is primarily intended to replace `PMF.bind_comm` in #42821.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
