### PR TITLE
[Merged by Bors] - chore: fix minor spacing issues

### DIFF
--- a/Archive/Wiedijk100Theorems/BuffonsNeedle.lean
+++ b/Archive/Wiedijk100Theorems/BuffonsNeedle.lean
@@ -195,13 +195,11 @@ lemma buffon_integral :
       ∫ (θ : ℝ) in Set.Icc 0 π,
       ∫ (_ : ℝ) in Set.Icc (-d / 2) (d / 2) ∩ Set.Icc (-θ.sin * l / 2) (θ.sin * l / 2), 1 := by
   simp_rw [N, Function.comp_apply]
-  rw [
-    ← MeasureTheory.integral_map hBₘ.aemeasurable
+  rw [← MeasureTheory.integral_map hBₘ.aemeasurable
       (stronglyMeasurable_needleCrossesIndicator l).aestronglyMeasurable,
     hB, ProbabilityTheory.cond, MeasureTheory.integral_smul_measure, volume_needleSpace d hd,
     ← ENNReal.ofReal_inv_of_pos (mul_pos hd Real.pi_pos),
-    ENNReal.toReal_ofReal (inv_nonneg.mpr (mul_nonneg hd.le Real.pi_pos.le)), smul_eq_mul,
-  ]
+    ENNReal.toReal_ofReal (inv_nonneg.mpr (mul_nonneg hd.le Real.pi_pos.le)), smul_eq_mul]
   refine mul_eq_mul_left_iff.mpr (Or.inl ?_)
   have : MeasureTheory.IntegrableOn (needleCrossesIndicator l)
       (Set.Icc (-d / 2) (d / 2) ×ˢ Set.Icc 0 π) := by

--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -183,7 +183,7 @@ def Pi.monoidHomMulEquiv {ι : Type*} [Fintype ι] [DecidableEq ι] (M : ι → 
   right_inv φ := by
     ext i m
     simp only [MonoidHom.coe_comp, Function.comp_apply, MonoidHom.mulSingle_apply,
-      MonoidHom.finsetProd_apply, evalMonoidHom_apply, ]
+      MonoidHom.finsetProd_apply, evalMonoidHom_apply]
     let φ' i : M i → M' := ⇑(φ i)
     conv =>
       enter [1, 2, j]

--- a/Mathlib/Algebra/Module/Presentation/Basic.lean
+++ b/Mathlib/Algebra/Module/Presentation/Basic.lean
@@ -473,7 +473,7 @@ lemma isPresentation_iff :
       Submodule.span A (Set.range solution.var) = ⊤ ∧
       LinearMap.ker solution.π = Submodule.span A (Set.range relations.relation) := by
   rw [← injective_fromQuotient_iff_ker_π_eq_span,
-    ← surjective_π_iff_span_eq_top, ← surjective_fromQuotient_iff_surjective_π, ]
+    ← surjective_π_iff_span_eq_top, ← surjective_fromQuotient_iff_surjective_π]
   exact ⟨fun h ↦ ⟨h.bijective.2, h.bijective.1⟩, fun h ↦ ⟨⟨h.2, h.1⟩⟩⟩
 
 lemma isPresentation_mk

--- a/Mathlib/AlgebraicGeometry/AffineSpace.lean
+++ b/Mathlib/AlgebraicGeometry/AffineSpace.lean
@@ -325,7 +325,7 @@ set_option backward.isDefEq.respectTransparency false in
 lemma isPullback_map {S T : Scheme.{u}} (f : S ⟶ T) :
     IsPullback (map n f) (𝔸(n; S) ↘ S) (𝔸(n; T) ↘ T) f := by
   refine (IsPullback.paste_horiz_iff (.flip <| .of_hasPullback _ _) (map_over f)).mp ?_
-  simp only [terminal.comp_from, ]
+  simp only [terminal.comp_from]
   convert! (IsPullback.of_hasPullback _ _).flip
   rw [← toSpecMvPoly, ← toSpecMvPoly, map_toSpecMvPoly]
 

--- a/Mathlib/AlgebraicTopology/ModelCategory/Opposite.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/Opposite.lean
@@ -49,7 +49,7 @@ instance [(trivialCofibrations C).HasFactorization (fibrations C)] :
 
 instance [(cofibrations C).HasFactorization (trivialFibrations C)] :
     (trivialCofibrations Cᵒᵖ).HasFactorization (fibrations Cᵒᵖ) := by
-  rw [trivialCofibrations_op, fibrations_op, ]
+  rw [trivialCofibrations_op, fibrations_op]
   infer_instance
 
 instance : ModelCategory Cᵒᵖ where

--- a/Mathlib/Analysis/Complex/JensenFormula.lean
+++ b/Mathlib/Analysis/Complex/JensenFormula.lean
@@ -71,7 +71,7 @@ private lemma const_mul_norm_sub_circleMap_le_norm_sub_circleMap {r₀ r R : ℝ
     sqrt (r₀ / R) * ‖circleMap 0 R θ - ρ‖ ≤ ‖circleMap 0 r θ - ρ‖ := by
   have h_cos_law (r₁ : ℝ) :
       ‖circleMap 0 r₁ θ - ρ‖ ^ 2 = r₁ ^ 2 + R ^ 2 - 2 * r₁ * R * Real.cos (θ - Complex.arg ρ) := by
-    rw [← ofReal_inj, ← normSq_eq_norm_sq, normSq_sub ]
+    rw [← ofReal_inj, ← normSq_eq_norm_sq, normSq_sub]
     suffices (circleMap 0 r₁ θ * (conj) ρ).re = r₁ * ‖ρ‖ * Real.cos (θ - ρ.arg) by
       simp [normSq_eq_norm_sq, hρ, -mul_re, this, mul_assoc]
     conv_lhs => rw [← norm_mul_exp_arg_mul_I ρ, ← circleMap_zero, conj_circleMap_zero,

--- a/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
@@ -215,8 +215,7 @@ private lemma isSelfAdjoint_finsuppSum (h : K.IsHermitian) (f : X →₀ V →L[
 theorem posSemidef_tfae : List.TFAE [K.PosSemidef, K.IsHermitian ∧ ∀ (f : X × V →₀ 𝕜),
     0 ≤ RCLike.re (f.sum fun xv z ↦ f.sum fun xv' w ↦ conj z * w * ⟪K xv'.1 xv.1 xv.2, xv'.2⟫_𝕜),
     K.IsHermitian ∧ ∀ (vv : X →₀ V),
-    0 ≤ RCLike.re (vv.sum fun x w ↦ vv.sum fun x' w' ↦ ⟪K x' x w, w'⟫_𝕜),
-    ] := by
+    0 ≤ RCLike.re (vv.sum fun x w ↦ vv.sum fun x' w' ↦ ⟪K x' x w, w'⟫_𝕜)] := by
   have {h p1 p2 p3 : Prop} (htfae : h → List.TFAE [p1, p2, p3]) :
       List.TFAE [h ∧ p1, h ∧ p2, h ∧ p3] := by
     tfae_have 1 → 2 := fun ⟨h, t⟩ ↦ ⟨h, ((htfae h).out 0 1).mp t⟩

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -151,7 +151,7 @@ noncomputable def constructLeftAdjointEquiv (h : ∀ X : B, RegularEpi (adj₁.c
         comp_id, Functor.comp_map, ← U.map_comp, assoc]
       dsimp
       rw [← adj₁.counit_naturality]
-      simp [dsimp% adj₂.homEquiv_unit _ _ f ]
+      simp [dsimp% adj₂.homEquiv_unit _ _ f]
     _ ≃ { z : F.obj (U.obj X) ⟶ R.obj Y // _ } := by
       apply (adj₁.homEquiv _ _).symm.subtypeEquiv
       intro g

--- a/Mathlib/CategoryTheory/Monad/Basic.lean
+++ b/Mathlib/CategoryTheory/Monad/Basic.lean
@@ -312,7 +312,7 @@ def transport {F : C ⥤ C} (T : Monad C) (i : (T : C ⥤ C) ≅ F) : Monad C wh
   left_unit X := by
     simp only [Functor.id_obj, NatTrans.comp_app, comp_obj, NatTrans.hcomp_app, Category.assoc,
       hom_inv_id_app_assoc]
-    slice_lhs 1 2 => rw [← T.η.naturality (i.inv.app X), ]
+    slice_lhs 1 2 => rw [← T.η.naturality (i.inv.app X)]
     simp
   right_unit X := by
     simp only [NatTrans.comp_app, Functor.map_comp, comp_obj, NatTrans.hcomp_app,

--- a/Mathlib/MeasureTheory/VectorMeasure/WithDensityVec.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/WithDensityVec.lean
@@ -91,7 +91,7 @@ lemma variation_WithDensity_le :
   · apply variation_le_of_forall_enorm_le (fun s hs ↦ ?_)
     rw [withDensity_apply hf, MeasureTheory.withDensity_apply _ hs]
     apply enorm_setIntegral_le_lintegral_enorm_transpose
-  · simp [withDensity, hf, Measure.zero_le ]
+  · simp [withDensity, hf, Measure.zero_le]
 
 set_option backward.isDefEq.respectTransparency.types false in
 /-- If `‖B x y‖ = ‖B · y‖ * ‖x‖` for all `x, y`, then the variation of a vector measure with

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -885,7 +885,7 @@ lemma height_eq_krullDim_Iic (x : α) : (height x : ℕ∞) = krullDim (Set.Iic 
     exact le_iSup (fun p ↦ (p.length : ℕ∞)) q
   · apply iSup_le; intro p; apply iSup_le; intro _
     have mono : StrictMono (fun (y : Set.Iic x) ↦ y.1) := fun _ _ h ↦ h
-    rw [← LTSeries.map_length p (fun x ↦ x.1) mono, ]
+    rw [← LTSeries.map_length p (fun x ↦ x.1) mono]
     refine le_iSup₂ (f := fun p hp ↦ (p.length : ℕ∞)) (p.map (fun x ↦ x.1) mono) ?_
     exact (p.toFun (Fin.last p.length)).2
 

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -101,7 +101,7 @@ instance : Zero (IntertwiningMap ρ σ) := ⟨⟨0, by simp⟩⟩
 
 instance : Add (IntertwiningMap ρ σ) :=
   ⟨fun f g ↦ ⟨f.toLinearMap + g.toLinearMap, by
-    simp [LinearMap.add_comp, LinearMap.comp_add, f.2, g.2,]⟩⟩
+    simp [LinearMap.add_comp, LinearMap.comp_add, f.2, g.2]⟩⟩
 
 @[simp] lemma coe_add (f g : IntertwiningMap ρ σ) :
     ((f + g : IntertwiningMap ρ σ) : V → W) = f + g := rfl

--- a/Mathlib/RingTheory/Smooth/Basic.lean
+++ b/Mathlib/RingTheory/Smooth/Basic.lean
@@ -93,7 +93,7 @@ lemma FormallySmooth.comp_surjective [FormallySmooth R A] (I : Ideal B) (hI : I 
   let σ := Function.surjInv (f := algebraMap B (B ⧸ I)) Ideal.Quotient.mk_surjective
   have H (x : P.Ring) : ↑(aeval (σ ∘ f) x) = f (algebraMap _ A x) := by
     rw [← Ideal.Quotient.algebraMap_eq, ← aeval_algebraMap_apply, P.algebraMap_eq,
-      AlgHom.coe_toRingHom, comp_aeval_apply, ← Function.comp_assoc, Function.comp_surjInv,]
+      AlgHom.coe_toRingHom, comp_aeval_apply, ← Function.comp_assoc, Function.comp_surjInv]
     simp [P]
   let l : P.Ring ⧸ (RingHom.ker (algebraMap P.Ring A)) ^ 2 →ₐ[R] B :=
     Ideal.Quotient.liftₐ _ (aeval (σ ∘ f)) <|

--- a/Mathlib/Tactic/FieldSimp/Lemmas.lean
+++ b/Mathlib/Tactic/FieldSimp/Lemmas.lean
@@ -91,7 +91,7 @@ lemma zpow'_mul (a : α) (m n : ℤ) : zpow' a (m * n) = zpow' (zpow' a m) n := 
   · simp [ha]
   by_cases hn : n = 0
   · rw [hn]
-    simp [zpow', ha, zpow_ne_zero ]
+    simp [zpow', ha, zpow_ne_zero]
   by_cases hm : m = 0
   · rw [hm]
     simp [zpow', ha]

--- a/Mathlib/Topology/Algebra/Group/SubmonoidClosure.lean
+++ b/Mathlib/Topology/Algebra/Group/SubmonoidClosure.lean
@@ -63,8 +63,7 @@ theorem mapClusterPt_atTop_pow_tfae (x y : G) :
       MapClusterPt x atTop (y ^ · : ℕ → G),
       MapClusterPt x atTop (y ^ · : ℤ → G),
       x ∈ closure (range (y ^ · : ℕ → G)),
-      x ∈ closure (range (y ^ · : ℤ → G)),
-    ] := by
+      x ∈ closure (range (y ^ · : ℤ → G))] := by
   tfae_have 2 ↔ 1 := mapClusterPt_atTop_zpow_iff_pow
   tfae_have 3 → 4 := by
     refine fun h ↦ closure_mono (range_subset_iff.2 fun n ↦ ?_) h

--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -562,7 +562,7 @@ instance subsingleton [PreconnectedSpace α] : Subsingleton (ConnectedComponents
   refine ⟨fun x y ↦ ?_⟩
   obtain ⟨x, rfl⟩ := surjective_coe x
   obtain ⟨y, rfl⟩ := surjective_coe y
-  simp_rw [coe_eq_coe, PreconnectedSpace.connectedComponent_eq_univ, ]
+  simp_rw [coe_eq_coe, PreconnectedSpace.connectedComponent_eq_univ]
 
 section
 


### PR DESCRIPTION
Done via regex. Replaces `\w ]` with `\w]` basically.

---

I have previously been adviced against PRs like this due to a future autoformatter, but:

- This PR is very easy to review

- It is not clear to me at all an autoformatter would include this


<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
