### PR TITLE
feat(NumberTheory/RamificationInertia/Unramified): generalize `IsUnramifiedAt.of_liesOver` to flat algebras

### DIFF
--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -5,6 +5,7 @@ Authors: Andrew Yang
 -/
 module
 
+public import Mathlib.RingTheory.Flat.TorsionFree
 public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Basic
 public import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 public import Mathlib.RingTheory.RamificationInertia.Ramification
@@ -38,6 +39,7 @@ lemma Ideal.ramificationIdx_eq_one_of_isUnramifiedAt
   p.ramificationIdx_eq_one R
 
 variable (R) in
+@[deprecated "Use `Algebra.IsUnramifiedAt.of_liesOver` instead." (since := "2026-08-18")]
 lemma IsUnramifiedAt.of_liesOver_of_ne_bot
     (p : Ideal S) (P : Ideal T) [P.LiesOver p] [p.IsPrime] [P.IsPrime]
     [IsUnramifiedAt R P] [EssFiniteType R S] [EssFiniteType R T]
@@ -76,17 +78,21 @@ section IsUnramifiedIn
 namespace Algebra
 
 variable (R) in
-/--
-Up to technical conditions, If `T/S/R` is a tower of algebras, `P` is a prime of `T` unramified
-in `R`, then `P ∩ S` (as a prime of `S`) is also unramified in `R`.
--/
 lemma IsUnramifiedAt.of_liesOver
     (p : Ideal S) (P : Ideal T) [P.LiesOver p] [p.IsPrime] [P.IsPrime]
     [IsUnramifiedAt R P] [EssFiniteType R S] [EssFiniteType R T]
-    [IsDedekindDomain S] [IsDomain T] [Module.IsTorsionFree S T] : IsUnramifiedAt R p :=
-  IsUnramifiedAt.of_liesOver_of_ne_bot R p P P.primeCompl_le_nonZeroDivisors
-    (Ideal.ne_bot_of_liesOver_of_ne_bot · P)
-
+    [Module.Flat S T] : IsUnramifiedAt R p := by
+  let p₀ : Ideal R := p.under R
+  let := Localization.AtPrime.algebraOfLiesOver p₀ p
+  let := Localization.AtPrime.algebraOfLiesOver p P
+  let := Localization.AtPrime.algebraOfLiesOver p₀ P
+  rw [isUnramifiedAt_iff_map_eq R p₀ p]
+  use isSeparable_tower_bot_of_isSeparable p₀.ResidueField p.ResidueField P.ResidueField
+  apply Ideal.map_injective_of_faithfullyFlat (B := Localization.AtPrime P)
+  apply le_antisymm
+  · grw [IsScalarTower.algebraMap_eq R S, ← Ideal.map_map, Ideal.map_comap_le,
+      Localization.AtPrime.map_eq_maximalIdeal]
+  · grw [map_maximalIdeal_le, Ideal.map_map, ← IsScalarTower.algebraMap_eq, IsUnramifiedAt.map_eq]
 
 /-- Let `R` be a domain of characteristic 0, finite rank over `ℤ`, `S` be a Dedekind domain
 that is a finite `R`-algebra. Let `p` be a prime of `S`, then `p` is unramified iff `e(p) = 1`. -/

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -5,7 +5,6 @@ Authors: Andrew Yang
 -/
 module
 
-public import Mathlib.RingTheory.Flat.TorsionFree
 public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Basic
 public import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 public import Mathlib.RingTheory.RamificationInertia.Ramification

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -77,6 +77,10 @@ section IsUnramifiedIn
 namespace Algebra
 
 variable (R) in
+/--
+Up to technical conditions, If `T/S/R` is a tower of algebras, `P` is a prime of `T` unramified
+in `R`, then `P ∩ S` (as a prime of `S`) is also unramified in `R`.
+-/
 lemma IsUnramifiedAt.of_liesOver
     (p : Ideal S) (P : Ideal T) [P.LiesOver p] [p.IsPrime] [P.IsPrime]
     [IsUnramifiedAt R P] [EssFiniteType R S] [EssFiniteType R T]

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
@@ -6,6 +6,7 @@ Authors: Christian Merten, Yi Song, Sihan Su
 module
 
 public import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
+public import Mathlib.RingTheory.Flat.Localization
 public import Mathlib.RingTheory.Ideal.GoingUp
 public import Mathlib.RingTheory.Spectrum.Prime.RingHom
 
@@ -67,6 +68,12 @@ lemma Module.FaithfullyFlat.of_flat_of_isLocalHom [IsLocalRing A] [IsLocalRing B
     ((IsLocalRing.local_hom_TFAE (algebraMap A B)).out 1 3).mp ‹_›
   rw [eqt, top_le_iff, Submodule.restrictScalars_eq_top_iff] at this
   exact Ideal.IsPrime.ne_top' this
+
+instance [Module.Flat A B] (p : Ideal A) (q : Ideal B) [p.IsPrime] [q.IsPrime] [q.LiesOver p]
+    [Algebra (Localization.AtPrime p) (Localization.AtPrime q)]
+    [Localization.AtPrime.IsLiesOverAlgebra p q] :
+    Module.FaithfullyFlat (Localization.AtPrime p) (Localization.AtPrime q) :=
+  Module.FaithfullyFlat.of_flat_of_isLocalHom
 
 instance Module.FaithfullyFlat.of_isIntegral_of_isDomain [IsDomain B] [Module.Flat A B]
     [Algebra.IsIntegral A B] [FaithfulSMul A B] :

--- a/Mathlib/RingTheory/Ideal/GoingDown.lean
+++ b/Mathlib/RingTheory/Ideal/GoingDown.lean
@@ -158,8 +158,6 @@ instance of_flat [Module.Flat R S] : Algebra.HasGoingDown R S := by
   have : IsLocalHom (algebraMap (Localization.AtPrime <| P.under R) (Localization.AtPrime P)) := by
     rw [RingHom.algebraMap_toAlgebra]
     exact Localization.isLocalHom_localRingHom (P.under R) P (algebraMap R S) Ideal.LiesOver.over
-  have : Module.FaithfullyFlat (Localization.AtPrime (P.under R)) (Localization.AtPrime P) :=
-    Module.FaithfullyFlat.of_flat_of_isLocalHom
   apply PrimeSpectrum.comap_surjective_of_faithfullyFlat
 
 end Algebra.HasGoingDown

--- a/Mathlib/RingTheory/Unramified/LocalRing.lean
+++ b/Mathlib/RingTheory/Unramified/LocalRing.lean
@@ -148,6 +148,10 @@ lemma isUnramifiedAt_iff_map_eq :
 instance [Algebra.IsUnramifiedAt R q] : Algebra.IsSeparable p.ResidueField q.ResidueField :=
   ((Algebra.isUnramifiedAt_iff_map_eq _ _ _).mp inferInstance).1
 
+lemma IsUnramifiedAt.map_eq [Algebra.IsUnramifiedAt R q] :
+    p.map (algebraMap R (Localization.AtPrime q)) = maximalIdeal _ :=
+  ((Algebra.isUnramifiedAt_iff_map_eq _ _ _).mp inferInstance).2
+
 instance [Algebra.IsUnramifiedAt R q] : Module.Finite p.ResidueField q.ResidueField :=
   Algebra.FormallyUnramified.finite_of_free _ _
 


### PR DESCRIPTION
This PR generalizes `IsUnramifiedAt.of_liesOver` to flat algebras and deprecates the technical auxiliary lemma `IsUnramifiedAt.of_liesOver_of_ne_bot` for the previous proof.

This also avoids the usage of the old `Ideal.ramificationIdx'`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
