### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/LinearMapCompletion): `f.extend toComplL = f.fromCompletion`

### DIFF
--- a/Mathlib/Topology/Algebra/LinearMapCompletion.lean
+++ b/Mathlib/Topology/Algebra/LinearMapCompletion.lean
@@ -112,4 +112,4 @@ end UniformSpace.Completion
 open UniformSpace.Completion in
 @[simp] lemma ContinuousLinearMap.extend_completionToComplL [T0Space β] [CompleteSpace β]
     (f : α →SL[σ] β) : f.extend toComplL = f.fromCompletion :=
-  extend_unique _ (denseRange_coe) (isUniformInducing_coe α) _ (by ext; simp)
+  extend_unique _ denseRange_coe (isUniformInducing_coe α) _ (by ext; simp)

--- a/Mathlib/Topology/Algebra/LinearMapCompletion.lean
+++ b/Mathlib/Topology/Algebra/LinearMapCompletion.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Topology.Algebra.GroupCompletion
 public import Mathlib.Topology.Algebra.Module.ContinuousLinearMap.Basic
+public import Mathlib.Topology.Algebra.Module.ContinuousLinearMap.Extend
 
 /-!
 # Completion of continuous (semi-)linear maps:
@@ -107,3 +108,8 @@ def toComplL : α →L[S] Completion α where
 @[simp] lemma toAddMonoidHom_toComplL : ((toComplL : α →L[S] _) : α →+ _) = toCompl := rfl
 
 end UniformSpace.Completion
+
+open UniformSpace.Completion in
+@[simp] lemma ContinuousLinearMap.extend_completionToComplL [T0Space β] [CompleteSpace β]
+    (f : α →SL[σ] β) : f.extend toComplL = f.fromCompletion :=
+  extend_unique _ (denseRange_coe) (isUniformInducing_coe α) _ (by ext; simp)


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
