### PR TITLE
chore(RingTheory/RamificationInertia/Ramification): reorganize proofs

### DIFF
--- a/Mathlib/RingTheory/RamificationInertia/Ramification.lean
+++ b/Mathlib/RingTheory/RamificationInertia/Ramification.lean
@@ -137,23 +137,57 @@ theorem ramificationIdx_eq [q.LiesOver p] [q.IsPrime] :
 
 @[deprecated (since := "2026-07-01")] alias ramificationIdx'_eq := ramificationIdx_eq
 
-open Localization IsLocalization.AtPrime in
-theorem ramificationIdx'_eq_ramificationIdx' [IsDedekindDomain S]
-    [q.LiesOver p] [hq : q.IsPrime] (hpS : p.map (algebraMap R S) ≠ ⊥) :
-    p.ramificationIdx' q = q.ramificationIdx R := by
-  have hq' : q ≠ ⊥ := ne_bot_of_le_ne_bot hpS (map_le_of_le_comap (q.over_def p).le)
-  have : q.IsMaximal := hq.isMaximal hq'
-  obtain ⟨I, hqI, h⟩ := Ideal.eq_prime_pow_mul_coprime hpS q
+namespace IsDedekindDomain
+
+open UniqueFactorizationMonoid IsLocalization.AtPrime
+
+theorem ramificationIdx_eq_of_map_eq_pow [IsDedekindDomain S]
+    [q.LiesOver p] [hq : q.IsPrime] (hq : q ≠ ⊥) (e : ℕ)
+    (hpS : p.map (algebraMap R (Localization.AtPrime q)) = IsLocalRing.maximalIdeal _ ^ e) :
+    q.ramificationIdx R = e := by
+  have hSq := isDiscreteValuationRing_of_dedekind_domain S hq (Localization.AtPrime q)
+  rw [ramificationIdx_eq p q, hpS, hSq.length_quotient_pow_maximalIdeal, ENat.toNat_natCast]
+
+theorem ramificationIdx_eq_normalizedFactors_count [IsDedekindDomain S]
+    [q.LiesOver p] (hp0 : p.map (algebraMap R S) ≠ ⊥) :
+    q.ramificationIdx R = (normalizedFactors (p.map (algebraMap R S))).count q := by
+  by_cases hq : q.IsPrime; swap
+  · rw [ramificationIdx_of_not_isPrime q R hq, eq_comm, Multiset.count_eq_zero]
+    contrapose! hq
+    exact isPrime_of_prime (prime_of_normalized_factor q hq)
+  have hq0 : q ≠ ⊥ := ne_bot_of_le_ne_bot hp0 (map_le_of_le_comap (q.over_def p).le)
+  have : q.IsMaximal := hq.isMaximal hq0
+  obtain ⟨I, hqI, h⟩ := Ideal.eq_prime_pow_mul_coprime hp0 q
   replace hqI : ¬ I ≤ q := by
     contrapose! hqI
     rw [sup_of_le_left hqI]
     exact hq.ne_top
-  rw [← IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count hpS hq hq'] at h
-  apply_fun (map (algebraMap S (Localization.AtPrime q))) at h
-  rw [map_map, ← IsScalarTower.algebraMap_eq, Ideal.map_mul, Ideal.map_pow,
-    map_eq_top_of_not_le (Localization.AtPrime q) hqI, mul_top, AtPrime.map_eq_maximalIdeal] at h
-  have hSq := isDiscreteValuationRing_of_dedekind_domain S hq' (Localization.AtPrime q)
-  rw [ramificationIdx_eq p q, h, hSq.length_quotient_pow_maximalIdeal, ENat.toNat_natCast]
+  apply ramificationIdx_eq_of_map_eq_pow p q hq0
+  rw [IsScalarTower.algebraMap_eq R S, ← map_map, h, Ideal.map_mul, Ideal.map_pow, ← h,
+    map_eq_maximalIdeal, map_eq_top_of_not_le (Localization.AtPrime q) hqI, mul_top]
+
+theorem ramificationIdx_eq_factors_count [IsDedekindDomain S]
+    [q.LiesOver p] (hp0 : p.map (algebraMap R S) ≠ ⊥) :
+    q.ramificationIdx R = (factors (p.map (algebraMap R S))).count q := by
+  rw [factors_eq_normalizedFactors, ← ramificationIdx_eq_normalizedFactors_count p q hp0]
+
+open UniqueFactorizationMonoid in
+theorem ramificationIdx_eq_multiplicity [IsDedekindDomain S]
+    [q.IsPrime] [q.LiesOver p] (hp : p.map (algebraMap R S) ≠ ⊥) :
+    q.ramificationIdx R = multiplicity q (p.map (algebraMap R S)) := by
+  have hq : q ≠ ⊥ := ne_bot_of_le_ne_bot hp (map_le_of_le_comap (q.over_def p).le)
+  rw [ramificationIdx_eq_normalizedFactors_count p q hp,
+    multiplicity_eq_of_emultiplicity_eq_some (emultiplicity_eq_count_normalizedFactors
+      (prime_of_isPrime hq inferInstance).irreducible hp), normalize_eq]
+
+end IsDedekindDomain
+
+theorem ramificationIdx'_eq_ramificationIdx' [IsDedekindDomain S]
+    [q.LiesOver p] [hq : q.IsPrime] (hpS : p.map (algebraMap R S) ≠ ⊥) :
+    p.ramificationIdx' q = q.ramificationIdx R := by
+  have hq' : q ≠ ⊥ := ne_bot_of_le_ne_bot hpS (map_le_of_le_comap (q.over_def p).le)
+  rw [IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count hpS hq hq',
+    IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count p q hpS]
 
 @[deprecated (since := "2026-07-01")] alias ramificationIdx_eq_ramificationIdx'' :=
   ramificationIdx'_eq_ramificationIdx'
@@ -166,37 +200,6 @@ theorem ramificationIdx'_eq_ramificationIdx [IsDomain R] [IsDedekindDomain S]
 
 @[deprecated (since := "2026-07-01")] alias ramificationIdx_eq_ramificationIdx' :=
   ramificationIdx'_eq_ramificationIdx
-
-namespace IsDedekindDomain
-
-open UniqueFactorizationMonoid
-
-theorem ramificationIdx_eq_factors_count [IsDedekindDomain S]
-    [q.LiesOver p] (hp0 : p.map (algebraMap R S) ≠ ⊥) :
-    q.ramificationIdx R = (factors (p.map (algebraMap R S))).count q := by
-  by_cases hq : q.IsPrime; swap
-  · rw [ramificationIdx_of_not_isPrime q R hq, eq_comm, Multiset.count_eq_zero]
-    contrapose! hq
-    exact isPrime_of_prime (prime_of_factor q hq)
-  have hq0 : q ≠ ⊥ := ne_bot_of_le_ne_bot hp0 (map_le_of_le_comap (q.over_def p).le)
-  rw [← ramificationIdx'_eq_ramificationIdx' p q hp0, ramificationIdx'_eq_factors_count hp0 ‹_› hq0]
-
-open UniqueFactorizationMonoid in
-theorem ramificationIdx_eq_normalizedFactors_count [IsDedekindDomain S]
-    [q.LiesOver p] (hp0 : p.map (algebraMap R S) ≠ ⊥) :
-    q.ramificationIdx R = (normalizedFactors (p.map (algebraMap R S))).count q := by
-  rw [← factors_eq_normalizedFactors, ← ramificationIdx_eq_factors_count p q hp0]
-
-open UniqueFactorizationMonoid in
-theorem ramificationIdx_eq_multiplicity [IsDedekindDomain S]
-    [q.IsPrime] [q.LiesOver p] (hp : p.map (algebraMap R S) ≠ ⊥) :
-    q.ramificationIdx R = multiplicity q (p.map (algebraMap R S)) := by
-  have hq : q ≠ ⊥ := ne_bot_of_le_ne_bot hp (map_le_of_le_comap (q.over_def p).le)
-  rw [ramificationIdx_eq_normalizedFactors_count p q hp,
-    multiplicity_eq_of_emultiplicity_eq_some (emultiplicity_eq_count_normalizedFactors
-      (prime_of_isPrime hq inferInstance).irreducible hp), normalize_eq]
-
-end IsDedekindDomain
 
 /-- See `ramificationIdx_tower` for a version that does not assume primality. -/
 theorem ramificationIdx_tower' [q.IsPrime] [r.IsPrime] [r.LiesOver q]


### PR DESCRIPTION
This PR reorganizes the proofs in `RingTheory/RamificationInertia/Ramification.lean` so that `ramificationIdx_eq_normalizedFactors_count` is proved directly rather than relying on `IsDedekindDomain.ramificationIdx'_eq_normalizedFactors_count` which will soon be deprecated.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
