### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Triangulated): applying a homological functor to a spectral object

### DIFF
--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -40,8 +40,6 @@ TODO (@joelriou):
 
 -/
 
-set_option backward.defeqAttrib.useBackward true
-
 @[expose] public section
 
 /-!
@@ -127,7 +125,7 @@ namespace Mk₁
 variable (X₀ X₁ : C)
 
 /-- The map which sends `0 : Fin 2` to `X₀` and `1` to `X₁`. -/
-@[simp]
+@[implicit_reducible, simp]
 def obj : Fin 2 → C
   | ⟨0, _⟩ => X₀
   | ⟨1, _⟩  => X₁
@@ -136,7 +134,7 @@ variable {X₀ X₁}
 variable (f : X₀ ⟶ X₁)
 
 /-- The obvious map `obj X₀ X₁ i ⟶ obj X₀ X₁ j` whenever `i j : Fin 2` satisfy `i ≤ j`. -/
-@[simp]
+@[implicit_reducible, simp]
 def map : ∀ (i j : Fin 2) (_ : i ≤ j), obj X₀ X₁ i ⟶ obj X₀ X₁ j
   | ⟨0, _⟩, ⟨0, _⟩, _ => 𝟙 _
   | ⟨0, _⟩, ⟨1, _⟩, _ => f
@@ -156,7 +154,7 @@ lemma map_comp {i j k : Fin 2} (hij : i ≤ j) (hjk : j ≤ k) :
 end Mk₁
 
 /-- Constructor for `ComposableArrows C 1`. -/
-@[simps]
+@[implicit_reducible, simps]
 def mk₁ {X₀ X₁ : C} (f : X₀ ⟶ X₁) : ComposableArrows C 1 where
   obj := Mk₁.obj X₀ X₁
   map g := Mk₁.map f _ _ (leOfHom g)
@@ -166,7 +164,7 @@ def mk₁ {X₀ X₁ : C} (f : X₀ ⟶ X₁) : ComposableArrows C 1 where
 /-- Constructor for morphisms `F ⟶ G` in `ComposableArrows C n` which takes as inputs
 a family of morphisms `F.obj i ⟶ G.obj i` and the naturality condition only for the
 maps in `Fin (n + 1)` given by inequalities of the form `i ≤ i + 1`. -/
-@[simps]
+@[implicit_reducible, simps]
 def homMk {F G : ComposableArrows C n} (app : ∀ i, F.obj i ⟶ G.obj i)
     (w : ∀ (i : ℕ) (hi : i < n), F.map' i (i + 1) ≫ app _ = app _ ≫ G.map' i (i + 1)) :
     F ⟶ G where
@@ -194,7 +192,7 @@ def homMk {F G : ComposableArrows C n} (app : ∀ i, F.obj i ⟶ G.obj i)
 /-- Constructor for isomorphisms `F ≅ G` in `ComposableArrows C n` which takes as inputs
 a family of isomorphisms `F.obj i ≅ G.obj i` and the naturality condition only for the
 maps in `Fin (n + 1)` given by inequalities of the form `i ≤ i + 1`. -/
-@[simps]
+@[implicit_reducible, simps]
 def isoMk {F G : ComposableArrows C n} (app : ∀ i, F.obj i ≅ G.obj i)
     (w : ∀ (i : ℕ) (hi : i < n),
       F.map' i (i + 1) ≫ (app _).hom = (app _).hom ≫ G.map' i (i + 1)) :
@@ -211,7 +209,7 @@ lemma ext {F G : ComposableArrows C n} (h : ∀ i, F.obj i = G.obj i)
     (isoMk (fun i => eqToIso (h i)) (fun i hi => by simp [w i hi])) h
 
 /-- Constructor for morphisms in `ComposableArrows C 0`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def homMk₀ {F G : ComposableArrows C 0} (f : F.obj' 0 ⟶ G.obj' 0) : F ⟶ G :=
   homMk (fun i => match i with
     | ⟨0, _⟩ => f) (fun i hi => by simp at hi)
@@ -225,7 +223,7 @@ lemma hom_ext₀ {F G : ComposableArrows C 0} {φ φ' : F ⟶ G}
   exact h
 
 /-- Constructor for isomorphisms in `ComposableArrows C 0`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def isoMk₀ {F G : ComposableArrows C 0} (e : F.obj' 0 ≅ G.obj' 0) : F ≅ G where
   hom := homMk₀ e.hom
   inv := homMk₀ e.inv
@@ -243,7 +241,7 @@ lemma mk₀_surjective (F : ComposableArrows C 0) : ∃ (X : C), F = mk₀ X :=
   ⟨F.obj' 0, ext₀ rfl⟩
 
 /-- Constructor for morphisms in `ComposableArrows C 1`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def homMk₁ {F G : ComposableArrows C 1}
     (left : F.obj' 0 ⟶ G.obj' 0) (right : F.obj' 1 ⟶ G.obj' 1)
     (w : F.map' 0 1 ≫ right = left ≫ G.map' 0 1 := by cat_disch) :
@@ -265,7 +263,7 @@ lemma hom_ext₁ {F G : ComposableArrows C 1} {φ φ' : F ⟶ G}
     | 1 => exact h₁
 
 /-- Constructor for isomorphisms in `ComposableArrows C 1`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def isoMk₁ {F G : ComposableArrows C 1}
     (left : F.obj' 0 ≅ G.obj' 0) (right : F.obj' 1 ≅ G.obj' 1)
     (w : F.map' 0 1 ≫ right.hom = left.hom ≫ G.map' 0 1 := by cat_disch) :
@@ -300,16 +298,12 @@ lemma mk₁_comp_eqToHom {X₀ X₁ X₁' : C} (f : X₀ ⟶ X₁) (h : X₁ = X
     ComposableArrows.mk₁ (f ≫ eqToHom h) = ComposableArrows.mk₁ f := by
   cat_disch
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 lemma mk₁_hom (X : ComposableArrows C 1) :
     mk₁ X.hom = X :=
   ext₁ rfl rfl (by simp)
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 /-- The bijection between `ComposableArrows C 1` and `Arrow C`. -/
-@[simps]
+@[implicit_reducible, simps]
 def arrowEquiv : ComposableArrows C 1 ≃ Arrow C where
   toFun F := Arrow.mk F.hom
   invFun f := mk₁ f.hom
@@ -324,6 +318,7 @@ variable (X : C)
 
 /-- The map `Fin (n + 1 + 1) → C` which "shifts" `F.obj'` to the right and inserts `X` in
 the zeroth position. -/
+@[implicit_reducible]
 def obj : Fin (n + 1 + 1) → C
   | ⟨0, _⟩ => X
   | ⟨i + 1, hi⟩ => F.obj' i
@@ -341,6 +336,7 @@ variable {X} (f : X ⟶ F.left)
 
 /-- Auxiliary definition for the action on maps of the functor `F.precomp f`.
 It sends `0 ≤ 1` to `f` and `i + 1 ≤ j + 1` to `F.map' i j`. -/
+@[implicit_reducible]
 def map : ∀ (i j : Fin (n + 1 + 1)) (_ : i ≤ j), obj F X i ⟶ obj F X j
   | ⟨0, _⟩, ⟨0, _⟩, _ => 𝟙 X
   | ⟨0, _⟩, ⟨1, _⟩, _ => f
@@ -383,8 +379,7 @@ lemma map_comp {i j k : Fin (n + 1 + 1)} (hij : i ≤ j) (hjk : j ≤ k) :
   obtain ⟨k, hk⟩ := k
   cases i
   · obtain _ | _ | j := j
-    · dsimp
-      rw [id_comp]
+    · simp
     · obtain _ | _ | k := k
       · simp at hjk
       · simp
@@ -404,7 +399,7 @@ lemma map_comp {i j k : Fin (n + 1 + 1)} (hij : i ≤ j) (hjk : j ≤ k) :
 end Precomp
 
 /-- "Precomposition" of `F : ComposableArrows C n` by a morphism `f : X ⟶ F.left`. -/
-@[simps]
+@[implicit_reducible, simps]
 def precomp {X : C} (f : X ⟶ F.left) : ComposableArrows C (n + 1) where
   obj := Precomp.obj F X
   map g := Precomp.map F f _ _ (leOfHom g)
@@ -437,35 +432,20 @@ variable {X₀ X₁ X₂ X₃ X₄ : C} (f : X₀ ⟶ X₁) (g : X₁ ⟶ X₂) 
 /-! These examples are meant to test the good definitional properties of `precomp`,
 and that `dsimp` can see through. -/
 
-set_option backward.isDefEq.respectTransparency.types false in
-set_option backward.defeqAttrib.useBackward true in
 example : map' (mk₂ f g) 0 1 = f := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₂ f g) 1 2 = g := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₂ f g) 0 2 = f ≫ g := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : (mk₂ f g).hom = f ≫ g := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₂ f g) 0 0 = 𝟙 _ := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₂ f g) 1 1 = 𝟙 _ := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₂ f g) 2 2 = 𝟙 _ := by dsimp
 
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₃ f g h) 0 1 = f := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₃ f g h) 1 2 = g := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₃ f g h) 2 3 = h := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₃ f g h) 0 3 = f ≫ g ≫ h := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : (mk₃ f g h).hom = f ≫ g ≫ h := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₃ f g h) 0 2 = f ≫ g := by dsimp
-set_option backward.isDefEq.respectTransparency.types false in
 example : map' (mk₃ f g h) 1 3 = g ≫ h := by dsimp
 
 end
@@ -513,7 +493,7 @@ lemma natAddLEFunctor_app' {n k l i : ℕ} (h : k + l ≤ n) {R₁ R₂ : Compos
 
 /-- The functor `ComposableArrows C (n + 1) ⥤ ComposableArrows C n` which forgets
 the first arrow. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def δ₀Functor : ComposableArrows C (n + 1) ⥤ ComposableArrows C n :=
   whiskerLeftFunctor (Fin.succFunctor (n + 1))
 
@@ -542,10 +522,10 @@ section
 
 variable {F G : ComposableArrows C (n + 1)}
 
-
 /-- Inductive construction of morphisms in `ComposableArrows C (n + 1)`: in order to construct
 a morphism `F ⟶ G`, it suffices to provide `α : F.obj' 0 ⟶ G.obj' 0` and `β : F.δ₀ ⟶ G.δ₀`
 such that `F.map' 0 1 ≫ app' β 0 = α ≫ G.map' 0 1`. -/
+@[implicit_reducible]
 def homMkSucc (α : F.obj' 0 ⟶ G.obj' 0) (β : F.δ₀ ⟶ G.δ₀)
     (w : F.map' 0 1 ≫ app' β 0 = α ≫ G.map' 0 1) : F ⟶ G :=
   homMk
@@ -579,6 +559,7 @@ lemma hom_ext_succ {F G : ComposableArrows C (n + 1)} {f g : F ⟶ G}
   · exact congr_app h₁ ⟨i, by valid⟩
 
 set_option backward.isDefEq.respectTransparency false in
+set_option backward.defeqAttrib.useBackward true in
 /-- Inductive construction of isomorphisms in `ComposableArrows C (n + 1)`: in order to
 construct an isomorphism `F ≅ G`, it suffices to provide `α : F.obj' 0 ≅ G.obj' 0` and
 `β : F.δ₀ ≅ G.δ₀` such that `F.map' 0 1 ≫ app' β.hom 0 = α.hom ≫ G.map' 0 1`. -/
@@ -587,9 +568,7 @@ def isoMkSucc {F G : ComposableArrows C (n + 1)} (α : F.obj' 0 ≅ G.obj' 0)
     (β : F.δ₀ ≅ G.δ₀) (w : F.map' 0 1 ≫ app' β.hom 0 = α.hom ≫ G.map' 0 1) : F ≅ G where
   hom := homMkSucc α.hom β.hom w
   inv := homMkSucc α.inv β.inv (by
-    rw [← cancel_epi α.hom, ← reassoc_of% w, α.hom_inv_id_assoc, β.hom_inv_id_app]
-    dsimp
-    rw [comp_id])
+    simp [← cancel_epi α.hom, ← reassoc_of% w, α.hom_inv_id_assoc, β.hom_inv_id_app])
   hom_inv_id := by
     apply hom_ext_succ
     · simp
@@ -681,7 +660,6 @@ lemma ext₂ {f g : ComposableArrows C 2}
     (w₁ : f.map' 1 2 = eqToHom h₁ ≫ g.map' 1 2 ≫ eqToHom h₂.symm) : f = g :=
   ext_succ h₀ (ext₁ h₁ h₂ w₁) w₀
 
-set_option backward.isDefEq.respectTransparency.types false in
 lemma mk₂_surjective (X : ComposableArrows C 2) :
     ∃ (X₀ X₁ X₂ : C) (f₀ : X₀ ⟶ X₁) (f₁ : X₁ ⟶ X₂), X = mk₂ f₀ f₁ :=
   ⟨_, _, _, X.map' 0 1, X.map' 1 2, ext₂ rfl rfl rfl (by simp) (by simp)⟩
@@ -764,7 +742,6 @@ lemma ext₃ {f g : ComposableArrows C 3}
     (w₂ : f.map' 2 3 = eqToHom h₂ ≫ g.map' 2 3 ≫ eqToHom h₃.symm) : f = g :=
   ext_succ h₀ (ext₂ h₁ h₂ h₃ w₁ w₂) w₀
 
-set_option backward.isDefEq.respectTransparency.types false in
 lemma mk₃_surjective (X : ComposableArrows C 3) :
     ∃ (X₀ X₁ X₂ X₃ : C) (f₀ : X₀ ⟶ X₁) (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃), X = mk₃ f₀ f₁ f₂ :=
   ⟨_, _, _, _, X.map' 0 1, X.map' 1 2, X.map' 2 3,
@@ -850,7 +827,6 @@ lemma ext₄ {f g : ComposableArrows C 4}
     f = g :=
   ext_succ h₀ (ext₃ h₁ h₂ h₃ h₄ w₁ w₂ w₃) w₀
 
-set_option backward.isDefEq.respectTransparency.types false in
 lemma mk₄_surjective (X : ComposableArrows C 4) :
     ∃ (X₀ X₁ X₂ X₃ X₄ : C) (f₀ : X₀ ⟶ X₁) (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃) (f₃ : X₃ ⟶ X₄),
       X = mk₄ f₀ f₁ f₂ f₃ :=
@@ -940,7 +916,6 @@ lemma ext₅ {f g : ComposableArrows C 5}
     f = g :=
   ext_succ h₀ (ext₄ h₁ h₂ h₃ h₄ h₅ w₁ w₂ w₃ w₄) w₀
 
-set_option backward.isDefEq.respectTransparency.types false in
 lemma mk₅_surjective (X : ComposableArrows C 5) :
     ∃ (X₀ X₁ X₂ X₃ X₄ X₅ : C) (f₀ : X₀ ⟶ X₁) (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃)
       (f₃ : X₃ ⟶ X₄) (f₄ : X₄ ⟶ X₅), X = mk₅ f₀ f₁ f₂ f₃ f₄ :=
@@ -1015,22 +990,24 @@ variable {C} {D : Type*} [Category* D] (G : C ⥤ D) (n : ℕ)
 
 /-- The functor `ComposableArrows C n ⥤ ComposableArrows D n` obtained by postcomposition
 with a functor `C ⥤ D`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def Functor.mapComposableArrows :
     ComposableArrows C n ⥤ ComposableArrows D n :=
   (whiskeringRight _ _ _).obj G
 
+set_option backward.defeqAttrib.useBackward true in
 /-- The isomorphism between `(G.mapComposableArrows 1).obj (.mk₁ f)` and
 `.mk₁ (G.map f)`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def Functor.mapComposableArrowsObjMk₁Iso {X Y : C} (f : X ⟶ Y) :
     (G.mapComposableArrows 1).obj (.mk₁ f) ≅ .mk₁ (G.map f) :=
   isoMk₁ (Iso.refl _) (Iso.refl _)
 
+set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency.types false in
 /-- The isomorphism between `(G.mapComposableArrows 2).obj (.mk₂ f g)` and
 `.mk₂ (G.map f) (G.map g)`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def Functor.mapComposableArrowsObjMk₂Iso {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
     (G.mapComposableArrows 2).obj (.mk₂ f g) ≅ .mk₂ (G.map f) (G.map g) :=
   isoMk₂ (Iso.refl _) (Iso.refl _) (Iso.refl _)

--- a/Mathlib/CategoryTheory/ComposableArrows/One.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/One.lean
@@ -25,7 +25,7 @@ variable (C : Type u) [Category.{v} C]
 /-- The functor `ComposableArrows C n ⥤ ComposableArrows C 1`
 which sends `S` to `mk₁ (S.map' i j)` when `i`, `j` and `n`
 are such that `i ≤ j` and `j ≤ n`. -/
-@[simps]
+@[implicit_reducible, simps]
 def functorArrows (i j n : ℕ) (hij : i ≤ j := by lia) (hj : j ≤ n := by lia) :
     ComposableArrows C n ⥤ ComposableArrows C 1 where
   obj S := mk₁ (S.map' i j)

--- a/Mathlib/CategoryTheory/ComposableArrows/Two.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Two.lean
@@ -33,13 +33,13 @@ variable {C : Type*} [Category* C]
 
 set_option backward.defeqAttrib.useBackward true in
 /-- The morphism `mk₁ f ⟶ mk₁ fg` when `f ≫ g = fg` for some morphism `g`. -/
-def twoδ₂Toδ₁ (h : f ≫ g = fg := by cat_disch) :
+abbrev twoδ₂Toδ₁ (h : f ≫ g = fg := by cat_disch) :
     mk₁ f ⟶ mk₁ fg :=
   homMk₁ (𝟙 _) g
 
 set_option backward.defeqAttrib.useBackward true in
 /-- The morphism `mk₁ fg ⟶ mk₁ g` when `f ≫ g = fg` for some morphism `f`. -/
-def twoδ₁Toδ₀ (h : f ≫ g = fg := by cat_disch) :
+abbrev twoδ₁Toδ₀ (h : f ≫ g = fg := by cat_disch) :
     mk₁ fg ⟶ mk₁ g :=
   homMk₁ f (𝟙 _)
 

--- a/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
@@ -176,17 +176,14 @@ noncomputable def homologySequenceδ
     (F.shift n₀).obj T.obj₃ ⟶ (F.shift n₁).obj T.obj₁ :=
   F.shiftMap T.mor₃ n₀ n₁ (by rw [add_comm 1, h])
 
-variable {T T'}
-
 @[reassoc]
 lemma homologySequenceδ_naturality
-    [F.ShiftSequence ℤ] (T T' : Triangle C) (φ : T ⟶ T') (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) :
+    [F.ShiftSequence ℤ] {T T' : Triangle C} (φ : T ⟶ T') (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) :
     (F.shift n₀).map φ.hom₃ ≫ F.homologySequenceδ T' n₀ n₁ h =
       F.homologySequenceδ T n₀ n₁ h ≫ (F.shift n₁).map φ.hom₁ := by
   dsimp only [homologySequenceδ]
   rw [← shiftMap_comp', ← φ.comm₃, shiftMap_comp]
 
-variable (T)
 variable [HasZeroObject C] [Preadditive C] [∀ (n : ℤ), (CategoryTheory.shiftFunctor C n).Additive]
   [Pretriangulated C] [Abelian A] [F.IsHomological]
 variable [F.ShiftSequence ℤ] (T : Triangle C) (hT : T ∈ distTriang C)

--- a/Mathlib/CategoryTheory/Triangulated/SpectralObject.lean
+++ b/Mathlib/CategoryTheory/Triangulated/SpectralObject.lean
@@ -77,6 +77,17 @@ are composable. -/
 def δ : X.ω₁.obj (mk₁ g) ⟶ (X.ω₁.obj (mk₁ f))⟦(1 : ℤ)⟧ :=
   X.δ'.app (mk₂ f g)
 
+@[reassoc]
+lemma δ_naturality {i' j' k' : ι} (f' : i' ⟶ j') (g' : j' ⟶ k')
+    (α : mk₁ f ⟶ mk₁ f') (β : mk₁ g ⟶ mk₁ g') (hαβ : α.app 1 = β.app 0) :
+    X.ω₁.map β ≫ X.δ f' g' = X.δ f g ≫ (X.ω₁.map α)⟦(1 : ℤ)⟧' := by
+  let φ : mk₂ f g ⟶ mk₂ f' g' := homMk₂ (α.app 0) (α.app 1) (β.app 1) (naturality' α 0 1)
+    (by simp [Precomp.map, hαβ, dsimp% naturality' β 0 1] )
+  have h := X.δ'.naturality φ
+  dsimp at h
+  simp only [φ, hαβ] at h
+  convert! h <;> cat_disch
+
 /-- The distinguished triangle attached to a spectral object `E : SpectralObject C ι`
 and composable morphisms `f : i ⟶ j` and `g : j ⟶ k` in `ι`. -/
 @[implicit_reducible, simps!]
@@ -102,24 +113,19 @@ noncomputable def mapTriangle (φ : mk₂ f g ⟶ mk₂ f' g') :
   hom₃ := X.ω₁.map ((functorArrows ι 1 2 2).map φ)
   comm₁ := by
     dsimp
-    sorry
-    --simp only [← X.ω₁.map_comp]
-    --congr 1
-    --ext
-    --· simp
-    --· exact naturality' φ 1 2
+    simp only [← X.ω₁.map_comp]
+    congr 1
+    ext
+    · simp
+    · exact naturality' φ 1 2
   comm₂ := by
-    sorry
-    --simp only [← X.ω₁.map_comp]
-    --congr 1
-    --ext
-    --· exact naturality' φ 0 1
-    --· simp
-  comm₃ := by
-    sorry
-    --symm
-    --apply X.δ_naturality
-    --rfl
+    dsimp
+    simp only [← X.ω₁.map_comp]
+    congr 1
+    ext
+    · exact naturality' φ 0 1
+    · simp
+  comm₃ := (X.δ_naturality _ _ _ _ _ _ rfl).symm
 
 end
 
@@ -179,16 +185,17 @@ variable (F : C ⥤ D) [F.CommShift ℤ] [F.IsTriangulated]
 
 /-- The image of a spectral object by a triangulated functor. -/
 @[simps]
-def mapTriangulatedFunctor :
-    SpectralObject D ι where
+def mapTriangulatedFunctor : SpectralObject D ι where
   ω₁ := X.ω₁ ⋙ F
   δ' := Functor.whiskerRight X.δ' F ≫
       Functor.whiskerLeft (functorArrows ι 0 1 2 ⋙ X.ω₁) (F.commShiftIso (1 : ℤ)).hom
   distinguished' D := F.map_distinguished _ (X.distinguished' D)
 
+
 @[simp]
 lemma mapTriangulatedFunctor_δ {i j k : ι} (f : i ⟶ j) (g : j ⟶ k) :
-    (X.mapTriangulatedFunctor F).δ f g = F.map (X.δ f g) ≫ (F.commShiftIso 1).hom.app _ := rfl
+    (X.mapTriangulatedFunctor F).δ f g = F.map (X.δ f g) ≫ (F.commShiftIso 1).hom.app _ :=
+  rfl
 
 end
 
@@ -202,11 +209,11 @@ structure Hom (Y : SpectralObject C ι) where
 
 attribute [reassoc (attr := simp)] Hom.comm
 
+@[simps id_hom comp_hom]
 instance : Category (SpectralObject C ι) where
   Hom := Hom
   id X := { hom := 𝟙 _ }
-  comp f g :=
-    { hom := f.hom ≫ g.hom }
+  comp f g := { hom := f.hom ≫ g.hom }
 
 section
 
@@ -215,13 +222,7 @@ variable {X} {Y Z : SpectralObject C ι}
 @[ext]
 lemma hom_ext {α β : X ⟶ Y} (h : α.hom = β.hom) : α = β := Hom.ext h
 
-variable (X) in
-@[simp]
-lemma id_hom : Hom.hom (𝟙 X) = 𝟙 _ := rfl
-
-@[simp, reassoc]
-lemma comp_hom (α : X ⟶ Y) (β : Y ⟶ Z) :
-    (α ≫ β).hom = α.hom ≫ β.hom := rfl
+attribute [reassoc] comp_hom
 
 end
 
@@ -299,6 +300,7 @@ variable {C}
 set_option backward.defeqAttrib.useBackward true in
 /-- The functor between categories of spectral objects that is induced by
 a triangulated functor. -/
+@[implicit_reducible, simps]
 def mapTriangulatedSpectralObject (F : C ⥤ D) [F.CommShift ℤ] [F.IsTriangulated]
     (ι : Type*) [Category* ι] :
     Triangulated.SpectralObject C ι ⥤ Triangulated.SpectralObject D ι where

--- a/Mathlib/CategoryTheory/Triangulated/SpectralObject.lean
+++ b/Mathlib/CategoryTheory/Triangulated/SpectralObject.lean
@@ -194,8 +194,7 @@ def mapTriangulatedFunctor : SpectralObject D ι where
 
 @[simp]
 lemma mapTriangulatedFunctor_δ {i j k : ι} (f : i ⟶ j) (g : j ⟶ k) :
-    (X.mapTriangulatedFunctor F).δ f g = F.map (X.δ f g) ≫ (F.commShiftIso 1).hom.app _ :=
-  rfl
+    (X.mapTriangulatedFunctor F).δ f g = F.map (X.δ f g) ≫ (F.commShiftIso 1).hom.app _ := rfl
 
 end
 

--- a/Mathlib/CategoryTheory/Triangulated/SpectralObject.lean
+++ b/Mathlib/CategoryTheory/Triangulated/SpectralObject.lean
@@ -184,7 +184,7 @@ section
 variable (F : C ⥤ D) [F.CommShift ℤ] [F.IsTriangulated]
 
 /-- The image of a spectral object by a triangulated functor. -/
-@[simps]
+@[implicit_reducible, simps]
 def mapTriangulatedFunctor : SpectralObject D ι where
   ω₁ := X.ω₁ ⋙ F
   δ' := Functor.whiskerRight X.δ' F ≫

--- a/Mathlib/CategoryTheory/Triangulated/SpectralObject.lean
+++ b/Mathlib/CategoryTheory/Triangulated/SpectralObject.lean
@@ -7,7 +7,8 @@ module
 
 public import Mathlib.CategoryTheory.ComposableArrows.One
 public import Mathlib.CategoryTheory.ComposableArrows.Two
-public import Mathlib.CategoryTheory.Triangulated.Functor
+public import Mathlib.CategoryTheory.Triangulated.HomologicalFunctor
+public import Mathlib.Algebra.Homology.SpectralObject.Basic
 
 /-!
 # Spectral objects in triangulated categories
@@ -16,12 +17,8 @@ In this file, we introduce the category `SpectralObject C ι` of spectral
 objects in a pretriangulated category `C` indexed by the category `ι`.
 
 ## TODO (@joelriou)
-* construct the spectral object indexed by `WithTop (WithBot ℤ)` consisting
-  of all truncations of an object of a triangulated category equipped with a t-structure
-* define a similar notion of spectral objects in abelian categories, show that
-  by applying a homological functor `C ⥤ A` to a spectral object in the
-  triangulated category `C`, we obtain a spectral object in the abelian category `A`
 * construct the spectral sequence attached to a spectral object in an abelian category
+ (the spectral sequence is already constructed: it remains to study convergence)
 
 ## References
 * [Jean-Louis Verdier, *Des catégories dérivées des catégories abéliennes*, II.4][verdier1996]
@@ -82,13 +79,49 @@ def δ : X.ω₁.obj (mk₁ g) ⟶ (X.ω₁.obj (mk₁ f))⟦(1 : ℤ)⟧ :=
 
 /-- The distinguished triangle attached to a spectral object `E : SpectralObject C ι`
 and composable morphisms `f : i ⟶ j` and `g : j ⟶ k` in `ι`. -/
-@[simps!]
+@[implicit_reducible, simps!]
 def triangle : Triangle C :=
   Triangle.mk (X.ω₁.map (twoδ₂Toδ₁ f g _ rfl))
     (X.ω₁.map (twoδ₁Toδ₀ f g _ rfl)) (X.δ f g)
 
 lemma triangle_distinguished : X.triangle f g ∈ distTriang C :=
   X.ω₂_obj_distinguished (mk₂ f g)
+
+section
+
+variable {f g} {i' j' k' : ι} {f' : i' ⟶ j'} {g' : j' ⟶ k'}
+
+/-- Given a spectral object `X` indexed by `ι` in a triangulated category,
+this is the morphisms of distinguished triangles `X.triangle f g ⟶ X.triangle f' g'`
+induced by a morphism `mk₂ f g ⟶ mk₂ f' g'` in `ComposableArrows ι 2`. -/
+@[simps]
+noncomputable def mapTriangle (φ : mk₂ f g ⟶ mk₂ f' g') :
+    X.triangle f g ⟶ X.triangle f' g' where
+  hom₁ := X.ω₁.map ((functorArrows ι 0 1 2).map φ)
+  hom₂ := X.ω₁.map ((functorArrows ι 0 2 2).map φ)
+  hom₃ := X.ω₁.map ((functorArrows ι 1 2 2).map φ)
+  comm₁ := by
+    dsimp
+    sorry
+    --simp only [← X.ω₁.map_comp]
+    --congr 1
+    --ext
+    --· simp
+    --· exact naturality' φ 1 2
+  comm₂ := by
+    sorry
+    --simp only [← X.ω₁.map_comp]
+    --congr 1
+    --ext
+    --· exact naturality' φ 0 1
+    --· simp
+  comm₃ := by
+    sorry
+    --symm
+    --apply X.δ_naturality
+    --rfl
+
+end
 
 end
 
@@ -144,7 +177,7 @@ section
 
 variable (F : C ⥤ D) [F.CommShift ℤ] [F.IsTriangulated]
 
-/-- The image of a spectral by a triangulated functor. -/
+/-- The image of a spectral object by a triangulated functor. -/
 @[simps]
 def mapTriangulatedFunctor :
     SpectralObject D ι where
@@ -189,6 +222,69 @@ lemma id_hom : Hom.hom (𝟙 X) = 𝟙 _ := rfl
 @[simp, reassoc]
 lemma comp_hom (α : X ⟶ Y) (β : Y ⟶ Z) :
     (α ≫ β).hom = α.hom ≫ β.hom := rfl
+
+end
+
+variable {X} in
+/-- If `φ : X ⟶ Y` is a morphism of spectral objects indexed by `ι`
+in a triangulated category, this is the induced morphism of distinguished
+triangles `X.triangle f g ⟶ Y.triangle f g` associated to two composable
+morphisms `f` and `g` in `ι`. -/
+@[simps]
+def triangleMap {Y : SpectralObject C ι} (φ : X ⟶ Y)
+    {i j k : ι} (f : i ⟶ j) (g : j ⟶ k) :
+    X.triangle f g ⟶ Y.triangle f g where
+  hom₁ := φ.hom.app _
+  hom₂ := φ.hom.app _
+  hom₃ := φ.hom.app _
+
+section
+
+variable {A : Type*} [Category* A] [Abelian A]
+
+/-- If `X` is a spectral object indexed by `ι` in a triangulated category `C`, and
+`F : C ⥤ A` is a homological functor, this is the spectral object in the
+abelian category `A` that is obtained by applying `F` to `X`. -/
+@[implicit_reducible, simps H]
+noncomputable def mapHomologicalFunctor (F : C ⥤ A) [F.IsHomological] [F.ShiftSequence ℤ] :
+    Abelian.SpectralObject A ι where
+  H n := X.ω₁ ⋙ F.shift n
+  δ' n₀ n₁ h :=
+    { app D := F.homologySequenceδ (X.triangle (D.map' 0 1) (D.map' 1 2)) n₀ n₁ h
+      naturality D₁ D₂ φ := by
+        obtain ⟨_, _, _, f, g, rfl⟩ := mk₂_surjective D₁
+        obtain ⟨_, _, _, f', g', rfl⟩ := mk₂_surjective D₂
+        exact F.homologySequenceδ_naturality (X.mapTriangle φ) n₀ n₁ h }
+  exact₁' n₀ n₁ h D := by
+    obtain ⟨_, _, _, f, g, rfl⟩ := mk₂_surjective D
+    exact (F.homologySequence_exact₁ _
+      (X.triangle_distinguished f g) n₀ n₁ h).exact_toComposableArrows
+  exact₂' n D := by
+    obtain ⟨_, _, _, f, g, rfl⟩ := mk₂_surjective D
+    exact (F.homologySequence_exact₂ _ (X.triangle_distinguished f g) n).exact_toComposableArrows
+  exact₃' n₀ n₁ h D := by
+    obtain ⟨_, _, _, f, g, rfl⟩ := mk₂_surjective D
+    exact (F.homologySequence_exact₃ _
+      (X.triangle_distinguished f g) n₀ n₁ h).exact_toComposableArrows
+
+@[simp]
+lemma mapHomologicalFunctor_δ (F : C ⥤ A) [F.IsHomological] [F.ShiftSequence ℤ]
+    {i j k : ι} (f : i ⟶ j) (g : j ⟶ k) (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁ := by lia) :
+    (X.mapHomologicalFunctor F).δ f g n₀ n₁ h =
+      F.homologySequenceδ (X.triangle f g) n₀ n₁ h := rfl
+
+/-- Given a homological functor `F : C ⥤ A`, this is the functor which sends
+a spectral object `X : SpectralObject C ι` in the triangulated category `C`
+to the spectral object `X.mapHomologicalFunctor F` in the abelian category `A`. -/
+@[implicit_reducible, simps]
+noncomputable def mapHomologicalFunctorFunctor
+    (F : C ⥤ A) [F.IsHomological] [F.ShiftSequence ℤ] (ι : Type*) [Category* ι] :
+    SpectralObject C ι ⥤ Abelian.SpectralObject A ι where
+  obj X := X.mapHomologicalFunctor F
+  map φ :=
+    { hom n := Functor.whiskerRight φ.hom _
+      comm n₀ n₁ h _ _ _ f g :=
+        (F.homologySequenceδ_naturality (triangleMap φ f g) n₀ n₁ h).symm }
 
 end
 


### PR DESCRIPTION
In this file, we show that one may obtain a spectral object in an abelian category by applying a homological functor to a triangulated spectral object.
We also fix some (not all) transparency issues with `ComposableArrows`.

---

I think that the `large-import` label can be ignored here.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
