### PR TITLE
feat(diffgeo): add Hom-bundle support and fix pullback base points in T% elaborator

### DIFF
--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -265,7 +265,8 @@ def totalSpaceMk (e : Expr) : MetaM Expr := do
             bound variable (`{x}` : `{base}`).\n\
             Hint: applying the `T%` elaborator twice makes no sense."
         let trivBundle ← mkAppOptM ``Bundle.Trivial #[some base, some tgt]
-        let body ← mkAppOptM ``Bundle.TotalSpace.mk' #[some base, some trivBundle, some tgt, some x, some (e.app x).headBeta]
+        let body ← mkAppOptM ``Bundle.TotalSpace.mk'
+          #[some base, some trivBundle, some tgt, some x,some (e.app x).headBeta]
         mkLambdaFVars #[x] body
   | _ => return e.headBeta
 

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -57,9 +57,10 @@ trivial model with corners on a product `E × F` and the product of the trivial 
 
 ## `T%`
 
-Secondly, this file adds an elaborator `T%` to ease working with sections in a fibre bundle,
-which converts a section `s : Π x : M, V x` to a non-dependent function into the total space of the
-bundle.
+Secondly, this file adds an elaborator `T%` to ease working with sections in a fibre bundle.
+which converts a section `s : Π x : M, V (b x)` to a non-dependent function into the total space of
+the bundle.
+
 ```lean
 -- omitted: let `V` be a fibre bundle over `M`
 
@@ -72,6 +73,20 @@ variable {σ : (x : E) → Trivial E E' x} in
 
 variable {s : E → E'} in
 #check T% s -- `(fun a ↦ TotalSpace.mk' E' a (s a)) : E → TotalSpace E' (Trivial E E')`
+
+-- Further examples with pullback bundles and Hom-bundles:
+-- omitted: let `V₁`, `V₂` be fibre bundles over `B` with model fibers `F₁`, `F₂`
+-- omitted: let `N` be a manifold with tangent model space `E_N` and index `I`
+-- omitted: let `b : N → B`
+
+-- Pullback bundle (base space differs from the bundle's native base)
+variable {v : Π x : N, V₁ (b x)} in
+#check T% v -- `(fun x ↦ TotalSpace.mk' F₁ (b x) (v x)) : N → TotalSpace F₁ (fun y ↦ V₁ y)`
+
+-- Hom-bundle (continuous linear maps between fibers over the same base point)
+variable {ϕ : Π x : N, V₁ (b x) →L[𝕜] V₂ (b x)} in
+#check T% ϕ -- `(fun x ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (b x) (ϕ x)) : N → TotalSpace (F₁ →L[𝕜] F₂)
+            -- (fun y ↦ V₁ y →L[𝕜] V₂ y)`
 ```
 
 ---
@@ -133,6 +148,9 @@ by searching in local context for either a `FiberBundle F E` or
 We could try a more systematic search of `TotalSpace F E` anywhere in the local context,
 but the current heuristic is faster and sufficient so far. -/
 private def findModelFiber? (V : Expr) : MetaM (Option Expr) := do
+  -- Intercept TangentSpace directly to bypass typeclass search
+  if V.isAppOf ``TangentSpace && V.getAppNumArgs >= 3 then
+    return some V.getAppArgs[2]!
   withTraceNode `Elab.DiffGeo.TotalSpaceMk
     (fun _ ↦ do return m!"Searching for a model fiber for {← ppExpr V}") do
   trace[Elab.DiffGeo.TotalSpaceMk] "Searching for relevant `FiberBundle` instance in context"
@@ -161,12 +179,13 @@ private def findModelFiber? (V : Expr) : MetaM (Option Expr) := do
         else return none
       | _ => return none
 /--
-Utility for sections in a fibre bundle: if an expression `e` is a section
-`s : Π x : M, V x` as a dependent function, convert it to a non-dependent function into the total
+Utility for sections in a fibre bundle: if an expression `e` is a section `s : Π x : M, V (b x)`
+as a dependent function, convert it to a non-dependent function into the total
 space. This handles the cases of
 - sections of a trivial bundle
 - vector fields on a manifold (i.e., sections of the tangent bundle)
-- sections of an explicit fibre bundle
+- sections of an explicit fibre bundle (including pullback bundles over `b x`)
+- sections of a Hom-bundle (i.e., `ContinuousLinearMap` between bundle fibers)
 - turning a bare function `E → E'` into a section of the trivial bundle `Bundle.Trivial E E'`
 
 This searches the local context for suitable hypotheses for the above cases by matching
@@ -198,20 +217,45 @@ def totalSpaceMk (e : Expr) : MetaM Expr := do
       trace[Elab.DiffGeo.TotalSpaceMk] "`{e}` is a vector field on `{M}`"
       let body ← mkAppM ``Bundle.TotalSpace.mk' #[E, x, (e.app x).headBeta]
       mkLambdaFVars #[x] body
-    | _ => match (← instantiateMVars tgt).cleanupAnnotations with
-      | .app V _ =>
+    | _ =>
+      let tgt_reduced := tgt.headBeta
+      let tgt_c := (← instantiateMVars tgt_reduced).cleanupAnnotations
+      -- 1. Try Hom-bundle intercept
+      if tgt_c.isAppOf ``ContinuousLinearMap && tgt_c.getAppNumArgs >= 9 then
+        let args := tgt_c.getAppArgs
+        let σ := args[4]!
+        let M₁ := args[5]!.headBeta
+        let M₂ := args[8]!.headBeta
+        if let .app V₁ arg₁ := M₁ then
+          if let .app V₂ arg₂ := M₂ then
+            if ← isDefEq arg₁ arg₂ then
+              if let some F₁ ← findModelFiber? V₁ then
+                if let some F₂ ← findModelFiber? V₂ then
+                  trace[Elab.DiffGeo.TotalSpaceMk] "Section of a Hom-bundle"
+                  let F_hom_base ← mkAppM ``ContinuousLinearMap #[σ, F₁, F₂]
+                  let (mvars, _, _) ← forallMetaTelescope (← inferType F_hom_base)
+                  for mvar in mvars do
+                    mvar.mvarId!.assign (← synthInstance (← inferType mvar))
+                  let F_hom ← instantiateMVars (mkAppN F_hom_base mvars)
+                  let B ← inferType arg₁
+                  let E_body ← kabstract tgt_reduced arg₁
+                  let E := Expr.lam `y B E_body BinderInfo.default
+                  let body ← mkAppOptM ``Bundle.TotalSpace.mk'
+                    #[some B, some E, some F_hom, some arg₁, some (e.app x).headBeta]
+                  return (← mkLambdaFVars #[x] body).headBeta
+      -- 2. Generic bundle logic
+      match tgt_c with
+      | .app V arg =>
         trace[Elab.DiffGeo.TotalSpaceMk] "Section of a bundle as a dependent function"
         match ← findModelFiber? V with
         | some F =>
-              let body ← mkAppM ``Bundle.TotalSpace.mk' #[F, x, (e.app x).headBeta]
-              return (← mkLambdaFVars #[x] body).headBeta
+          let body ← mkAppM ``Bundle.TotalSpace.mk' #[F, arg, (e.app x).headBeta]
+          return (← mkLambdaFVars #[x] body).headBeta
         | none =>
-          -- future: special-case `Bundle.TotalSpace` for V;
-          -- if so, say "there is no need to apply T% twice"
           throwError "could not find a `FiberBundle` instance on `{V}`:\n\
           `{e}` is a function into `{V}`\n\n\
           hint: you may be missing suitable typeclass assumptions"
-      | tgt =>
+      | _ =>
         trace[Elab.DiffGeo.TotalSpaceMk] "Section of a trivial bundle as a non-dependent function"
         -- TODO: can `tgt` depend on `x` in a way that is not a function application?
         -- Check that `x` is not a bound variable in `tgt`!
@@ -220,8 +264,8 @@ def totalSpaceMk (e : Expr) : MetaM Expr := do
             (`{e}` : `{etype}`) as a non-dependent function, but return type `{tgt}` depends on the
             bound variable (`{x}` : `{base}`).\n\
             Hint: applying the `T%` elaborator twice makes no sense."
-        let trivBundle ← mkAppOptM ``Bundle.Trivial #[base, tgt]
-        let body ← mkAppOptM ``Bundle.TotalSpace.mk' #[base, trivBundle, tgt, x, (e.app x).headBeta]
+        let trivBundle ← mkAppOptM ``Bundle.Trivial #[some base, some tgt]
+        let body ← mkAppOptM ``Bundle.TotalSpace.mk' #[some base, some trivBundle, some tgt, some x, some (e.app x).headBeta]
         mkLambdaFVars #[x] body
   | _ => return e.headBeta
 
@@ -229,12 +273,13 @@ end Elab
 
 open Elab in
 /--
-Elaborator for sections in a fibre bundle: converts a section `s : Π x : M, V x` as a dependent
+Elaborator for sections in a fibre bundle: converts a section `s : Π x : M, V (b x)` as a dependent
 function to a non-dependent function into the total space. This handles the cases of
 - sections of a trivial bundle
 - vector fields on a manifold (i.e., sections of the tangent bundle)
-- sections of an explicit fibre bundle
+- sections of an explicit fibre bundle (including pullback bundles)
 - turning a bare function `E → E'` into a section of the trivial bundle `Bundle.Trivial E E'`
+- sections of a Hom-bundle (i.e., `ContinuousLinearMap` between bundle fibers)
 
 This elaborator searches the local context for suitable hypotheses for the above cases by matching
 on the expression structure, avoiding `isDefEq`. Therefore, it should be fast enough to always run.

--- a/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Hom.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Hom.lean
@@ -1,0 +1,270 @@
+import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Basic
+import Mathlib.Geometry.Manifold.VectorField.LieBracket
+import Mathlib.Geometry.Manifold.VectorBundle.ContMDiffSection
+
+/-!
+# The induced connection on a Hom-bundle, and the covariant Hessian
+
+Given covariant derivatives `cov₁` on a vector bundle `V₁` and `cov₂` on a vector bundle `V₂`
+over the same manifold `M`, we build the induced covariant derivative on the bundle
+`Hom(V₁, V₂)`, characterized by the Leibniz rule
+
+`(∇_X σ)(s) = ∇₂_X (σ s) - σ (∇₁_X s)`.
+
+As an application we define the covariant Hessian `∇²σ` of a section `σ` of a vector bundle.
+
+## Notes on the formalization
+
+* The notions `TensorialAt`, `TensorialAt.mkHom`, `IsCovariantDerivativeOn` and
+  `CovariantDerivative` used here are provided by this project in
+  `RequestProject/Tensoriality.lean` and `RequestProject/CovariantDerivative.lean`.
+* The operation `s ↦ ∇₂_X (σ s) - σ (∇₁_X s)` is tensorial in `s` only when `σ` is a
+  differentiable section of the Hom-bundle: differentiability of `σ` is what makes
+  `∇₂_X (σ s)` meaningful (i.e. subject to the Leibniz rule) in the first place. Accordingly the
+  tensoriality statement below carries the hypothesis `HomSectionMDiffAt σ x`, and the pointwise
+  connection is defined by the usual junk-value pattern outside the differentiable case.
+* Rather than assuming abstract topological/fiber-bundle structures on the Hom-bundle, we use the
+  genuine Hom-bundle structure from Mathlib (`Bundle.ContinuousLinearMap`), which is what makes it
+  possible to relate differentiability of `σ` with differentiability of `y ↦ σ y (s y)`.
+-/
+
+open Bundle Filter Topology
+
+open scoped Manifold ContDiff
+
+noncomputable section
+
+section HomBundle
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+variable {E H : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [TopologicalSpace H]
+variable {I : ModelWithCorners 𝕜 E H} {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+
+/-! ### Vector Bundle Setup -/
+
+-- First vector bundle (Domain of the Hom-bundle)
+variable {F₁ : Type*} [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
+variable {V₁ : M → Type*} [TopologicalSpace (TotalSpace F₁ V₁)]
+variable [∀ x, AddCommGroup (V₁ x)] [∀ x, Module 𝕜 (V₁ x)] [∀ x, TopologicalSpace (V₁ x)]
+variable [∀ x, IsTopologicalAddGroup (V₁ x)] [∀ x, ContinuousSMul 𝕜 (V₁ x)]
+variable [FiberBundle F₁ V₁] [VectorBundle 𝕜 F₁ V₁] [ContMDiffVectorBundle 1 F₁ V₁ I]
+
+-- Second vector bundle (Codomain of the Hom-bundle)
+variable {F₂ : Type*} [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
+variable {V₂ : M → Type*} [TopologicalSpace (TotalSpace F₂ V₂)]
+variable [∀ x, AddCommGroup (V₂ x)] [∀ x, Module 𝕜 (V₂ x)] [∀ x, TopologicalSpace (V₂ x)]
+variable [∀ x, IsTopologicalAddGroup (V₂ x)] [∀ x, ContinuousSMul 𝕜 (V₂ x)]
+variable [FiberBundle F₂ V₂] [VectorBundle 𝕜 F₂ V₂] [ContMDiffVectorBundle 1 F₂ V₂ I]
+
+-- Require completeness and finite dimensions to use the `TensorialAt` machinery
+variable [CompleteSpace 𝕜] [FiniteDimensional 𝕜 F₁]
+
+-- Input covariant derivatives
+variable (cov₁ : CovariantDerivative I F₁ V₁)
+variable (cov₂ : CovariantDerivative I F₂ V₂)
+
+/-! ### Differentiable sections of the Hom-bundle -/
+
+omit [∀ (x : M), IsTopologicalAddGroup (V₁ x)] [∀ (x : M), ContinuousSMul 𝕜 (V₁ x)]
+  [ContMDiffVectorBundle 1 F₁ V₁ I] [ContMDiffVectorBundle 1 F₂ V₂ I] [CompleteSpace 𝕜]
+  [FiniteDimensional 𝕜 F₁] in
+/-- Applying a differentiable section of the Hom-bundle to a differentiable section of `V₁`
+yields a differentiable section of `V₂`. -/
+lemma mdifferentiableAt_hom_section_apply {σ : Π y : M, V₁ y →L[𝕜] V₂ y} {x : M}
+    (hσ : MDiffAt T% σ x)
+    {s : Π y : M, V₁ y} (hs : MDiffAt (T% s) x) :
+    MDiffAt (T% fun y ↦ σ y (s y)) x :=
+  MDifferentiableAt.clm_bundle_apply (b := id) hσ hs
+
+/-! ### Induced Hom-Bundle Connection -/
+
+/--
+The unbundled operator on global sections representing the Leibniz rule for the Hom-connection
+in the direction `X`. Mathematically, this computes `∇_X (σ(s₁)) - σ(∇_X s₁)`.
+-/
+def homBundleOp (σ : Π y : M, V₁ y →L[𝕜] V₂ y) (x : M) (X : TangentSpace I x) :
+    (Π y, V₁ y) → V₂ x :=
+  fun s₁ => cov₂ (fun y => σ y (s₁ y)) x X - σ x (cov₁ s₁ x X)
+
+/-
+The statement originally proposed for the tensoriality of `homBundleOp`:
+
+lemma homBundleOp_isTensorialAt (σ : Π y : M, V₁ y →L[𝕜] V₂ y) (x : M) (X : TangentSpace I x) :
+    TensorialAt I F₁ (homBundleOp cov₁ cov₂ σ x X) x
+
+This cannot be proved as stated: the cancellation of the derivative terms uses the Leibniz rule
+for `cov₂` applied to the section `y ↦ σ y (s₁ y)`, which requires `σ` to be a differentiable
+section of the Hom-bundle. The corrected statement below adds that hypothesis.
+-/
+
+omit [ContMDiffVectorBundle 1 F₁ V₁ I] [ContMDiffVectorBundle 1 F₂ V₂ I] [CompleteSpace 𝕜]
+  [FiniteDimensional 𝕜 F₁] in
+/--
+Proof that `homBundleOp` is tensorial at `x` with respect to the input section `s₁`, for `σ`
+a section of the Hom-bundle which is differentiable at `x`.
+Because the difference cancels the derivative of the section, this operator depends only
+on the pointwise value `s₁ x`, allowing us to project it down to the fiber.
+-/
+lemma homBundleOp_isTensorialAt (σ : Π y : M, V₁ y →L[𝕜] V₂ y) (x : M) (X : TangentSpace I x)
+    (hσ : MDiffAt T% σ x) :
+    TensorialAt I F₁ (homBundleOp cov₁ cov₂ σ x X) x := by
+  constructor
+  · intro f s hf hs
+    have hτ : MDiffAt (T% fun y ↦ σ y (s y)) x := mdifferentiableAt_hom_section_apply hσ hs
+    have hfs : (fun y ↦ σ y ((f • s) y)) = f • (fun y ↦ σ y (s y)) := by
+      funext y; simp
+    simp only [homBundleOp, hfs,
+      cov₂.isCovariantDerivativeOnUniv.leibniz hτ hf (Set.mem_univ x),
+      cov₁.isCovariantDerivativeOnUniv.leibniz hs hf (Set.mem_univ x)]
+    simp only [add_apply, ContinuousLinearMap.smulRight_apply,
+      smul_apply, map_add, map_smul, smul_sub]
+    abel
+  · intro s s' hs hs'
+    have hτ : MDiffAt (T% fun y ↦ σ y (s y)) x := mdifferentiableAt_hom_section_apply hσ hs
+    have hτ' : MDiffAt (T% fun y ↦ σ y (s' y)) x := mdifferentiableAt_hom_section_apply hσ hs'
+    have hadd : (fun y ↦ σ y ((s + s') y))
+        = (fun y ↦ σ y (s y)) + (fun y ↦ σ y (s' y)) := by
+      funext y; simp
+    simp only [homBundleOp, hadd,
+      cov₂.isCovariantDerivativeOnUniv.add hτ hτ' (Set.mem_univ x),
+      cov₁.isCovariantDerivativeOnUniv.add hs hs' (Set.mem_univ x)]
+    simp only [add_apply, map_add]
+    abel
+
+/-- The value of `homBundleOp` on the canonical extension of a vector `v` of the fibre `V₁ x`,
+packaged as a continuous linear map in the direction `X`. -/
+def homBundleFiberOp (σ : Π y : M, V₁ y →L[𝕜] V₂ y) (x : M) (v : V₁ x) :
+    TangentSpace I x →L[𝕜] V₂ x :=
+  cov₂ (fun y ↦ σ y (FiberBundle.extend F₁ v y)) x -
+    (σ x).comp (cov₁ (FiberBundle.extend F₁ v) x)
+
+omit [VectorBundle 𝕜 F₁ V₁] [ContMDiffVectorBundle 1 F₁ V₁ I] [VectorBundle 𝕜 F₂ V₂]
+  [ContMDiffVectorBundle 1 F₂ V₂ I] [CompleteSpace 𝕜] [FiniteDimensional 𝕜 F₁] in
+lemma homBundleOp_extend (σ : Π y : M, V₁ y →L[𝕜] V₂ y) (x : M) (X : TangentSpace I x)
+    (v : V₁ x) :
+    homBundleOp cov₁ cov₂ σ x X (FiberBundle.extend F₁ v) = homBundleFiberOp cov₁ cov₂ σ x v X :=
+  rfl
+
+/--
+The induced covariant derivative on the Hom-bundle, evaluated point-wise, for a section `σ` of
+the Hom-bundle which is differentiable at `x`.
+By using `TensorialAt.mkHom`, this projects the global differential operator down to a
+continuous linear map `V₁ x →L[𝕜] V₂ x`.
+-/
+def homBundlePointwiseAux (σ : Π y : M, V₁ y →L[𝕜] V₂ y) (x : M)
+    (hσ : MDiffAt T% σ x) :
+    TangentSpace I x →L[𝕜] (V₁ x →L[𝕜] V₂ x) where
+  toFun := fun X => TensorialAt.mkHom _ x (homBundleOp_isTensorialAt cov₁ cov₂ σ x X hσ)
+  map_add' X Y := by
+    ext v
+    simp only [add_apply, TensorialAt.mkHom_apply_eq_extend,
+      homBundleOp_extend, map_add]
+  map_smul' c X := by
+    ext v
+    simp only [RingHom.id_apply, smul_apply,
+      TensorialAt.mkHom_apply_eq_extend, homBundleOp_extend, map_smul]
+  cont := by
+    have he₁ : V₁ x ≃L[𝕜] F₁ := (trivializationAt F₁ V₁ x).continuousLinearEquivAt 𝕜 x
+      (FiberBundle.mem_baseSet_trivializationAt F₁ V₁ x)
+    have he₂ : V₂ x ≃L[𝕜] F₂ := (trivializationAt F₂ V₂ x).continuousLinearEquivAt 𝕜 x
+      (FiberBundle.mem_baseSet_trivializationAt F₂ V₂ x)
+    set Θ : (V₁ x →L[𝕜] V₂ x) ≃L[𝕜] (F₁ →L[𝕜] F₂) := he₁.arrowCongrSL he₂ with hΘ
+    change Continuous fun X ↦ TensorialAt.mkHom _ x (homBundleOp_isTensorialAt cov₁ cov₂ σ x X hσ)
+    rw [← Θ.toHomeomorph.comp_continuous_iff, continuous_clm_apply]
+    intro w
+    have key : ∀ X : TangentSpace I x,
+        (Θ.toHomeomorph ∘ fun X ↦ TensorialAt.mkHom (homBundleOp cov₁ cov₂ σ x X) x
+            (homBundleOp_isTensorialAt cov₁ cov₂ σ x X hσ)) X w
+          = he₂ (homBundleFiberOp cov₁ cov₂ σ x (he₁.symm w) X) := by
+      intro X
+      simp [hΘ, TensorialAt.mkHom_apply_eq_extend, homBundleOp_extend]
+    simp only [key]
+    exact he₂.continuous.comp (homBundleFiberOp cov₁ cov₂ σ x (he₁.symm w)).continuous
+
+open scoped Classical in
+/-- The induced covariant derivative on the Hom-bundle, evaluated point-wise; the junk value `0`
+is used at points where `σ` is not differentiable. -/
+def homBundlePointwise (σ : Π y : M, V₁ y →L[𝕜] V₂ y) (x : M) :
+    TangentSpace I x →L[𝕜] (V₁ x →L[𝕜] V₂ x) :=
+  if hσ : MDiffAt T% σ x then homBundlePointwiseAux cov₁ cov₂ σ x hσ else 0
+
+omit [ContMDiffVectorBundle 1 F₂ V₂ I] in
+/-- On the canonical extension of a vector of the fibre, the Hom-bundle connection is given by
+`homBundleFiberOp`. -/
+lemma homBundlePointwise_apply_extend {σ : Π y : M, V₁ y →L[𝕜] V₂ y} {x : M}
+    (hσ : MDiffAt T% σ x) (X : TangentSpace I x) (v : V₁ x) :
+    homBundlePointwise cov₁ cov₂ σ x X v = homBundleFiberOp cov₁ cov₂ σ x v X := by
+  rw [homBundlePointwise, dif_pos hσ]
+  rfl
+
+omit [ContMDiffVectorBundle 1 F₂ V₂ I] in
+/-- The defining property of the Hom-bundle connection. -/
+lemma homBundlePointwise_apply {σ : Π y : M, V₁ y →L[𝕜] V₂ y} {x : M}
+    (hσ : MDiffAt T% σ x) (X : TangentSpace I x)
+    {s : Π y : M, V₁ y} (hs : MDiffAt (T% s) x) :
+    homBundlePointwise cov₁ cov₂ σ x X (s x)
+      = cov₂ (fun y ↦ σ y (s y)) x X - σ x (cov₁ s x X) := by
+  rw [homBundlePointwise, dif_pos hσ]
+  exact TensorialAt.mkHom_apply (homBundleOp_isTensorialAt cov₁ cov₂ σ x X hσ) hs
+
+/-! ### Global Bundling of the Hom-Connection -/
+
+omit [ContMDiffVectorBundle 1 F₂ V₂ I] in
+/--
+Proof that the pointwise induced Hom-connection satisfies the unbundled local covariant
+derivative rules (additivity and the Leibniz rule over scalar multiplication).
+-/
+lemma isCovariantDerivativeOn_homBundle :
+    IsCovariantDerivativeOn (F₁ →L[𝕜] F₂) (homBundlePointwise cov₁ cov₂) Set.univ := by
+  constructor
+  · intro σ σ' x hσ hσ' _
+    ext X v
+    have hE : MDiffAt (T% (FiberBundle.extend F₁ v)) x :=
+      FiberBundle.mdifferentiableAt_extend I F₁ v
+    have hσσ' : MDiffAt T% (σ + σ') x :=
+      mdifferentiableAt_add_section hσ hσ'
+    rw [add_apply, add_apply,
+      homBundlePointwise_apply_extend cov₁ cov₂ hσσ',
+      homBundlePointwise_apply_extend cov₁ cov₂ hσ,
+      homBundlePointwise_apply_extend cov₁ cov₂ hσ']
+    have hsplit : (fun y ↦ (σ + σ') y (FiberBundle.extend F₁ v y))
+        = (fun y ↦ σ y (FiberBundle.extend F₁ v y))
+          + (fun y ↦ σ' y (FiberBundle.extend F₁ v y)) := by
+      funext y; simp
+    simp only [homBundleFiberOp, sub_apply, ContinuousLinearMap.coe_comp,
+      Function.comp_apply]
+    rw [hsplit, cov₂.isCovariantDerivativeOnUniv.add (mdifferentiableAt_hom_section_apply hσ hE)
+        (mdifferentiableAt_hom_section_apply hσ' hE) (Set.mem_univ x)]
+    simp only [add_apply, Pi.add_apply]
+    abel
+  · intro σ g x hσ hg _
+    ext X v
+    have hE : MDiffAt (T% (FiberBundle.extend F₁ v)) x :=
+      FiberBundle.mdifferentiableAt_extend I F₁ v
+    have hgσ : MDiffAt T% (g • σ) x := hg.smul_section hσ
+    rw [add_apply, smul_apply,
+      ContinuousLinearMap.smulRight_apply, add_apply,
+      smul_apply, smul_apply,
+      homBundlePointwise_apply_extend cov₁ cov₂ hgσ,
+      homBundlePointwise_apply_extend cov₁ cov₂ hσ]
+    have hsplit : (fun y ↦ (g • σ) y (FiberBundle.extend F₁ v y))
+        = g • (fun y ↦ σ y (FiberBundle.extend F₁ v y)) := by
+      funext y; simp
+    simp only [homBundleFiberOp, sub_apply, ContinuousLinearMap.coe_comp,
+      Function.comp_apply, hsplit,
+      cov₂.isCovariantDerivativeOnUniv.leibniz (mdifferentiableAt_hom_section_apply hσ hE) hg
+        (Set.mem_univ x),
+      add_apply, smul_apply,
+      ContinuousLinearMap.smulRight_apply, FiberBundle.extend_apply_self, smul_sub]
+    abel
+
+/--
+The globally bundled covariant derivative on the `Hom`-bundle.
+This provides the connection `∇^{Hom}` acting on sections of `Hom(V₁, V₂)`.
+-/
+def CovariantDerivative.homBundle :
+    CovariantDerivative I (F₁ →L[𝕜] F₂) (fun x ↦ V₁ x →L[𝕜] V₂ x) where
+  toFun := homBundlePointwise cov₁ cov₂
+  isCovariantDerivativeOnUniv := isCovariantDerivativeOn_homBundle cov₁ cov₂
+
+end HomBundle

--- a/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
@@ -297,9 +297,8 @@ One can apply `ϕ m` to `v m`, and the resulting map is `C^n`.
 
 We give here a version of this statement within a set at a point. -/
 lemma ContMDiffWithinAt.clm_bundle_apply
-    (hϕ : CMDiffAt[s] n
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) x)
-    (hv : CMDiffAt[s] n (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) x) :
+    (hϕ : CMDiffAt[s] n T% ϕ x)
+    (hv : CMDiffAt[s] n T% v x) :
     CMDiffAt[s] n (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) x := by
   simp only [contMDiffWithinAt_hom_bundle] at hϕ
   exact hϕ.2.clm_apply_of_inCoordinates hv hϕ.1
@@ -310,9 +309,8 @@ One can apply `ϕ m` to `v m`, and the resulting map is `C^n`.
 
 We give here a version of this statement at a point. -/
 lemma ContMDiffAt.clm_bundle_apply
-    (hϕ : CMDiffAt n
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) x)
-    (hv : CMDiffAt n (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) x) :
+    (hϕ : CMDiffAt n T% ϕ x)
+    (hv : CMDiffAt n T% v x) :
     CMDiffAt n (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) x :=
   ContMDiffWithinAt.clm_bundle_apply hϕ hv
 
@@ -322,9 +320,8 @@ One can apply `ϕ m` to `v m`, and the resulting map is `C^n`.
 
 We give here a version of this statement on a set. -/
 lemma ContMDiffOn.clm_bundle_apply
-    (hϕ : CMDiff[s] n
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)))
-    (hv : CMDiff[s] n (fun m ↦ TotalSpace.mk' F₁ (b m) (v m))) :
+    (hϕ : CMDiff[s] n T% ϕ)
+    (hv : CMDiff[s] n T% v) :
     CMDiff[s] n (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) :=
   fun x hx ↦ (hϕ x hx).clm_bundle_apply (hv x hx)
 
@@ -332,9 +329,8 @@ lemma ContMDiffOn.clm_bundle_apply
 linear maps `ϕ m : E₁ (b m) → E₂ (b m)` depending smoothly on `m`.
 One can apply `ϕ m` to `v m`, and the resulting map is `C^n`. -/
 lemma ContMDiff.clm_bundle_apply
-    (hϕ : CMDiff n
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)))
-    (hv : CMDiff n (fun m ↦ TotalSpace.mk' F₁ (b m) (v m))) :
+    (hϕ : CMDiff n T% ϕ)
+    (hv : CMDiff n T% v) :
     CMDiff n (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) :=
   fun x ↦ (hϕ x).clm_bundle_apply (hv x)
 
@@ -351,12 +347,12 @@ One can apply `ϕ m` to `v m`, and the resulting map is differentiable.
 
 We give here a version of this statement within a set at a point. -/
 lemma MDifferentiableWithinAt.clm_bundle_apply
-    (hϕ : MDiffAt[s]
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) x)
-    (hv : MDiffAt[s] (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) x) :
+    (hϕ : MDiffAt[s] T% ϕ x)
+    (hv : MDiffAt[s] T% v x) :
     MDiffAt[s] (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) x := by
   simp only [mdifferentiableWithinAt_hom_bundle] at hϕ
   exact hϕ.2.clm_apply_of_inCoordinates hv hϕ.1
+
 
 /-- Consider a differentiable map `v : M → E₁` to a vector bundle, over a base map `b : M → B`, and
 linear maps `ϕ m : E₁ (b m) → E₂ (b m)` depending smoothly on `m`.
@@ -364,9 +360,8 @@ One can apply `ϕ m` to `v m`, and the resulting map is differentiable.
 
 We give here a version of this statement at a point. -/
 lemma MDifferentiableAt.clm_bundle_apply
-    (hϕ : MDiffAt
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) x)
-    (hv : MDiffAt (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) x) :
+    (hϕ : MDiffAt T% ϕ x)
+    (hv : MDiffAt T% v x) :
     MDiffAt (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) x :=
   MDifferentiableWithinAt.clm_bundle_apply hϕ hv
 
@@ -376,9 +371,8 @@ One can apply `ϕ m` to `v m`, and the resulting map is differentiable.
 
 We give here a version of this statement on a set. -/
 lemma MDifferentiableOn.clm_bundle_apply
-    (hϕ : MDiff[s]
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)))
-    (hv : MDiff[s] (fun m ↦ TotalSpace.mk' F₁ (b m) (v m))) :
+    (hϕ : MDiff[s] T% ϕ)
+    (hv : MDiff[s] T% v) :
     MDiff[s] (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) :=
   fun x hx ↦ (hϕ x hx).clm_bundle_apply (hv x hx)
 
@@ -386,8 +380,7 @@ lemma MDifferentiableOn.clm_bundle_apply
 linear maps `ϕ m : E₁ (b m) → E₂ (b m)` depending smoothly on `m`.
 One can apply `ϕ m` to `v m`, and the resulting map is differentiable. -/
 lemma MDifferentiable.clm_bundle_apply
-    (hϕ : MDiff
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)))
+    (hϕ : MDiff T% ϕ)
     (hv : MDiff (fun m ↦ TotalSpace.mk' F₁ (b m) (v m))) :
     MDiff (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) :=
   fun x ↦ (hϕ x).clm_bundle_apply (hv x)

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -56,6 +56,44 @@ variable (X : (m : M) → TangentSpace I m) [IsManifold I 1 M]
 #guard_msgs in
 #check T% X
 
+section
+
+variable {F₁ F₂ : Type*} [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
+  [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
+  {B : Type*} [TopologicalSpace B]
+  (V₁ : B → Type*) [TopologicalSpace (TotalSpace F₁ V₁)]
+  [∀ x, AddCommGroup (V₁ x)] [∀ x, Module 𝕜 (V₁ x)]
+  [∀ x, TopologicalSpace (V₁ x)] [∀ x, IsTopologicalAddGroup (V₁ x)] [∀ x, ContinuousSMul 𝕜 (V₁ x)]
+  [FiberBundle F₁ V₁]
+  (V₂ : B → Type*) [TopologicalSpace (TotalSpace F₂ V₂)]
+  [∀ x, AddCommGroup (V₂ x)] [∀ x, Module 𝕜 (V₂ x)]
+  [∀ x, TopologicalSpace (V₂ x)] [∀ x, IsTopologicalAddGroup (V₂ x)] [∀ x, ContinuousSMul 𝕜 (V₂ x)]
+  [FiberBundle F₂ V₂]
+  (b : M → B)
+
+-- Pullback bundle
+variable {v₁ : Π x : M, V₁ (b x)}
+
+/-- info: (T% v₁) : M → TotalSpace F₁ V₁ -/
+#guard_msgs in
+#check T% v₁
+
+-- Hom-bundle
+variable {ϕ : Π x : M, V₁ (b x) →L[𝕜] V₂ (b x)}
+
+/-- info: (T% ϕ) : M → TotalSpace (F₁ →L[𝕜] F₂) fun y ↦ V₁ y →L[𝕜] V₂ y -/
+#guard_msgs in
+#check T% ϕ
+
+-- Hom-bundle with TangentSpace as domain (verifies TangentSpace intercept in `findModelFiber?`)
+variable {ϕ_TM : Π x : M, TangentSpace I x →L[𝕜] V₁ (b x)}
+
+/-- info: (T% ϕ_TM) : M → TotalSpace (E →L[𝕜] F₁) fun y ↦ TangentSpace I y →L[𝕜] V₁ (b y) -/
+#guard_msgs in
+#check T% ϕ_TM
+
+end
+
 variable {x : M}
 
 -- Testing precedence.


### PR DESCRIPTION
* **Add Hom-bundle intercept:** The elaborator now supports sections of Hom-bundles (`ContinuousLinearMap`). It extracts the domain and codomain fibers, verifies base point alignment, and constructs the `Hom` model fiber dynamically using `kabstract`.
* **Fix base point extraction for pullback bundles:** Replaced the hardcoded bound variable `x` with the dynamically extracted argument `arg`. Passed `arg` to `mkAppM` in the generic bundle branch, which correctly infers the base point and bundle family (avoiding eta-expanded `fun y ↦ V y` types) and resolves `⟨x, v x⟩` type mismatches.
* **Add `headBeta` reduction:** Applied `headBeta` to the return type `tgt` and Hom-bundle arguments before pattern matching. This evaluates lambda applications to extract the true base point without improperly unfolding reducible definitions like `TangentSpace`.
* **Support nested `TangentSpace`:** Modified `findModelFiber?` to natively intercept `TangentSpace` applications and extract the model fiber at index 2. This prevents typeclass synthesis failures when `TangentSpace` is used inside a Hom-bundle.
* **Refine elaborator logic and fallbacks:** Restored the dedicated `TangentSpace` match branch to preserve exact implicit parameter inference, preventing `I.tangent` from unfolding into `I.prod 𝓘(ℝ, E)`. Fixed the trivial bundle fallback by explicitly mapping arguments via `mkAppOptM`. Resolved variable shadowing.
* **Refactor `Hom.lean`:** Replaced verbose `TotalSpace.mk'` boilerplate in `Mathlib/Geometry/Manifold/VectorBundle/Hom.lean` with the newly supported `T%` syntax (e.g., `CMDiffAt[s] n T% ϕ x` instead of explicit lambdas).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
