### PR TITLE
feat(diffgeo): add Hom-bundle support and fix pullback base points in T% elaborator

### DIFF
--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -57,9 +57,10 @@ trivial model with corners on a product `E × F` and the product of the trivial 
 
 ## `T%`
 
-Secondly, this file adds an elaborator `T%` to ease working with sections in a fibre bundle,
-which converts a section `s : Π x : M, V x` to a non-dependent function into the total space of the
-bundle.
+Secondly, this file adds an elaborator `T%` to ease working with sections in a fibre bundle.
+which converts a section `s : Π x : M, V (b x)` to a non-dependent function into the total space of
+the bundle.
+
 ```lean
 -- omitted: let `V` be a fibre bundle over `M`
 
@@ -72,6 +73,19 @@ variable {σ : (x : E) → Trivial E E' x} in
 
 variable {s : E → E'} in
 #check T% s -- `(fun a ↦ TotalSpace.mk' E' a (s a)) : E → TotalSpace E' (Trivial E E')`
+
+-- omitted: let `E₁`, `E₂` be fibre bundles over `B` with model fibers `F₁`, `F₂`
+-- omitted: let `b : M → B`
+
+-- Pullback bundle (base space differs from the bundle's native base)
+variable {v : Π x : M, E₁ (b x)} in
+#check T% v -- `(fun x ↦ TotalSpace.mk' F₁ (b x) (v x)) : M → TotalSpace F₁ E₁`
+
+-- Hom-bundle (continuous linear maps between fibers over the same base point)
+variable {ϕ : ∀ x : M, (E₁ (b x) →L[𝕜] E₂ (b x))} in
+#check T% ϕ
+-- `(fun x ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ x)) :
+-- M → TotalSpace (F₁ →L[𝕜] F₂) (fun x ↦ E₁ x →L[𝕜] E₂ x)`
 ```
 
 ---
@@ -133,6 +147,9 @@ by searching in local context for either a `FiberBundle F E` or
 We could try a more systematic search of `TotalSpace F E` anywhere in the local context,
 but the current heuristic is faster and sufficient so far. -/
 private def findModelFiber? (V : Expr) : MetaM (Option Expr) := do
+  -- Intercept TangentSpace directly to bypass typeclass search
+  if V.isAppOf ``TangentSpace && V.getAppNumArgs >= 3 then
+    return some V.getAppArgs[2]!
   withTraceNode `Elab.DiffGeo.TotalSpaceMk
     (fun _ ↦ do return m!"Searching for a model fiber for {← ppExpr V}") do
   trace[Elab.DiffGeo.TotalSpaceMk] "Searching for relevant `FiberBundle` instance in context"
@@ -161,12 +178,13 @@ private def findModelFiber? (V : Expr) : MetaM (Option Expr) := do
         else return none
       | _ => return none
 /--
-Utility for sections in a fibre bundle: if an expression `e` is a section
-`s : Π x : M, V x` as a dependent function, convert it to a non-dependent function into the total
+Utility for sections in a fibre bundle: if an expression `e` is a section `s : Π x : M, V (b x)`
+as a dependent function, convert it to a non-dependent function into the total
 space. This handles the cases of
 - sections of a trivial bundle
 - vector fields on a manifold (i.e., sections of the tangent bundle)
-- sections of an explicit fibre bundle
+- sections of an explicit fibre bundle (including pullback bundles over `b x`)
+- sections of a Hom-bundle (i.e., `ContinuousLinearMap` between bundle fibers)
 - turning a bare function `E → E'` into a section of the trivial bundle `Bundle.Trivial E E'`
 
 This searches the local context for suitable hypotheses for the above cases by matching
@@ -198,13 +216,37 @@ def totalSpaceMk (e : Expr) : MetaM Expr := do
       trace[Elab.DiffGeo.TotalSpaceMk] "`{e}` is a vector field on `{M}`"
       let body ← mkAppM ``Bundle.TotalSpace.mk' #[E, x, (e.app x).headBeta]
       mkLambdaFVars #[x] body
-    | _ => match (← instantiateMVars tgt).cleanupAnnotations with
-      | .app V _ =>
+    | _ =>
+      let tgt_c := (← instantiateMVars tgt).cleanupAnnotations
+      -- 1. Try Hom-bundle intercept
+      if tgt_c.isAppOf ``ContinuousLinearMap && tgt_c.getAppNumArgs >= 9 then
+        let args := tgt_c.getAppArgs
+        let σ := args[4]!
+        let M₁ := args[5]!.headBeta
+        let M₂ := args[8]!.headBeta
+        if let (.app V₁ arg₁, .app V₂ arg₂) := (M₁, M₂) then
+          if ← isDefEq arg₁ arg₂ then
+            let F₁? ← findModelFiber? V₁
+            let F₂? ← findModelFiber? V₂
+            if let (some F₁, some F₂) := (F₁?, F₂?) then
+              trace[Elab.DiffGeo.TotalSpaceMk] "Section of a Hom-bundle"
+              let F_hom_base ← mkAppM ``ContinuousLinearMap #[σ, F₁, F₂]
+              let (mvars, _, _) ← forallMetaTelescope (← inferType F_hom_base)
+              let insts ← mvars.mapM fun mvar ↦ do synthInstance (← inferType mvar)
+              let F_hom := mkAppN F_hom_base insts
+              let B ← inferType arg₁
+              let E_body ← kabstract tgt_c arg₁
+              let E := Expr.lam `x B E_body default
+              let body ← mkAppOptM ``Bundle.TotalSpace.mk' #[B, E, F_hom, arg₁, (e.app x).headBeta]
+              return (← mkLambdaFVars #[x] body).headBeta
+      -- 2. Generic bundle logic
+      match tgt_c with
+      | .app V arg =>
         trace[Elab.DiffGeo.TotalSpaceMk] "Section of a bundle as a dependent function"
         match ← findModelFiber? V with
         | some F =>
-              let body ← mkAppM ``Bundle.TotalSpace.mk' #[F, x, (e.app x).headBeta]
-              return (← mkLambdaFVars #[x] body).headBeta
+          let body ← mkAppM ``Bundle.TotalSpace.mk' #[F, arg, (e.app x).headBeta]
+          return (← mkLambdaFVars #[x] body).headBeta
         | none =>
           -- future: special-case `Bundle.TotalSpace` for V;
           -- if so, say "there is no need to apply T% twice"
@@ -229,12 +271,13 @@ end Elab
 
 open Elab in
 /--
-Elaborator for sections in a fibre bundle: converts a section `s : Π x : M, V x` as a dependent
+Elaborator for sections in a fibre bundle: converts a section `s : Π x : M, V (b x)` as a dependent
 function to a non-dependent function into the total space. This handles the cases of
 - sections of a trivial bundle
 - vector fields on a manifold (i.e., sections of the tangent bundle)
-- sections of an explicit fibre bundle
+- sections of an explicit fibre bundle (including pullback bundles)
 - turning a bare function `E → E'` into a section of the trivial bundle `Bundle.Trivial E E'`
+- sections of a Hom-bundle (i.e., `ContinuousLinearMap` between bundle fibers)
 
 This elaborator searches the local context for suitable hypotheses for the above cases by matching
 on the expression structure, avoiding `isDefEq`. Therefore, it should be fast enough to always run.

--- a/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
@@ -297,9 +297,8 @@ One can apply `ϕ m` to `v m`, and the resulting map is `C^n`.
 
 We give here a version of this statement within a set at a point. -/
 lemma ContMDiffWithinAt.clm_bundle_apply
-    (hϕ : CMDiffAt[s] n
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) x)
-    (hv : CMDiffAt[s] n (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) x) :
+    (hϕ : CMDiffAt[s] n T% ϕ x)
+    (hv : CMDiffAt[s] n T% v x) :
     CMDiffAt[s] n (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) x := by
   simp only [contMDiffWithinAt_hom_bundle] at hϕ
   exact hϕ.2.clm_apply_of_inCoordinates hv hϕ.1
@@ -310,9 +309,8 @@ One can apply `ϕ m` to `v m`, and the resulting map is `C^n`.
 
 We give here a version of this statement at a point. -/
 lemma ContMDiffAt.clm_bundle_apply
-    (hϕ : CMDiffAt n
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) x)
-    (hv : CMDiffAt n (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) x) :
+    (hϕ : CMDiffAt n T% ϕ x)
+    (hv : CMDiffAt n T% v x) :
     CMDiffAt n (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) x :=
   ContMDiffWithinAt.clm_bundle_apply hϕ hv
 
@@ -322,9 +320,8 @@ One can apply `ϕ m` to `v m`, and the resulting map is `C^n`.
 
 We give here a version of this statement on a set. -/
 lemma ContMDiffOn.clm_bundle_apply
-    (hϕ : CMDiff[s] n
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)))
-    (hv : CMDiff[s] n (fun m ↦ TotalSpace.mk' F₁ (b m) (v m))) :
+    (hϕ : CMDiff[s] n T% ϕ)
+    (hv : CMDiff[s] n T% v) :
     CMDiff[s] n (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) :=
   fun x hx ↦ (hϕ x hx).clm_bundle_apply (hv x hx)
 
@@ -332,9 +329,8 @@ lemma ContMDiffOn.clm_bundle_apply
 linear maps `ϕ m : E₁ (b m) → E₂ (b m)` depending smoothly on `m`.
 One can apply `ϕ m` to `v m`, and the resulting map is `C^n`. -/
 lemma ContMDiff.clm_bundle_apply
-    (hϕ : CMDiff n
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)))
-    (hv : CMDiff n (fun m ↦ TotalSpace.mk' F₁ (b m) (v m))) :
+    (hϕ : CMDiff n T% ϕ)
+    (hv : CMDiff n T% v) :
     CMDiff n (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) :=
   fun x ↦ (hϕ x).clm_bundle_apply (hv x)
 
@@ -351,12 +347,12 @@ One can apply `ϕ m` to `v m`, and the resulting map is differentiable.
 
 We give here a version of this statement within a set at a point. -/
 lemma MDifferentiableWithinAt.clm_bundle_apply
-    (hϕ : MDiffAt[s]
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) x)
-    (hv : MDiffAt[s] (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) x) :
+    (hϕ : MDiffAt[s] T% ϕ x)
+    (hv : MDiffAt[s] T% v x) :
     MDiffAt[s] (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) x := by
   simp only [mdifferentiableWithinAt_hom_bundle] at hϕ
   exact hϕ.2.clm_apply_of_inCoordinates hv hϕ.1
+
 
 /-- Consider a differentiable map `v : M → E₁` to a vector bundle, over a base map `b : M → B`, and
 linear maps `ϕ m : E₁ (b m) → E₂ (b m)` depending smoothly on `m`.
@@ -364,9 +360,8 @@ One can apply `ϕ m` to `v m`, and the resulting map is differentiable.
 
 We give here a version of this statement at a point. -/
 lemma MDifferentiableAt.clm_bundle_apply
-    (hϕ : MDiffAt
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) x)
-    (hv : MDiffAt (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) x) :
+    (hϕ : MDiffAt T% ϕ x)
+    (hv : MDiffAt T% v x) :
     MDiffAt (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) x :=
   MDifferentiableWithinAt.clm_bundle_apply hϕ hv
 
@@ -376,9 +371,8 @@ One can apply `ϕ m` to `v m`, and the resulting map is differentiable.
 
 We give here a version of this statement on a set. -/
 lemma MDifferentiableOn.clm_bundle_apply
-    (hϕ : MDiff[s]
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)))
-    (hv : MDiff[s] (fun m ↦ TotalSpace.mk' F₁ (b m) (v m))) :
+    (hϕ : MDiff[s] T% ϕ)
+    (hv : MDiff[s] T% v) :
     MDiff[s] (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) :=
   fun x hx ↦ (hϕ x hx).clm_bundle_apply (hv x hx)
 
@@ -386,9 +380,8 @@ lemma MDifferentiableOn.clm_bundle_apply
 linear maps `ϕ m : E₁ (b m) → E₂ (b m)` depending smoothly on `m`.
 One can apply `ϕ m` to `v m`, and the resulting map is differentiable. -/
 lemma MDifferentiable.clm_bundle_apply
-    (hϕ : MDiff
-      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)))
-    (hv : MDiff (fun m ↦ TotalSpace.mk' F₁ (b m) (v m))) :
+    (hϕ : MDiff T% ϕ)
+    (hv : MDiff T% v) :
     MDiff (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) :=
   fun x ↦ (hϕ x).clm_bundle_apply (hv x)
 

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -56,6 +56,61 @@ variable (X : (m : M) → TangentSpace I m) [IsManifold I 1 M]
 #guard_msgs in
 #check T% X
 
+variable (F₂ : Type*) [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
+  -- `F₂` model fiber
+  (V₂ : M → Type*) [TopologicalSpace (TotalSpace F₂ V₂)]
+  [∀ x, AddCommGroup (V₂ x)] [∀ x, Module 𝕜 (V₂ x)]
+  [∀ x : M, TopologicalSpace (V₂ x)] [∀ x, IsTopologicalAddGroup (V₂ x)]
+  [∀ x, ContinuousSMul 𝕜 (V₂ x)]
+  [FiberBundle F₂ V₂] [VectorBundle 𝕜 F₂ V₂]
+  -- `V₂` vector bundle
+
+variable {ϕ : Π x : M, V x →L[𝕜] V₂ x}
+
+/-- info: (T% ϕ) : M → TotalSpace (F →L[𝕜] F₂) fun x ↦ V x →L[𝕜] V₂ x -/
+#guard_msgs in
+#check T% ϕ
+
+variable {ϕ_TM : Π x : M, TangentSpace I x →L[𝕜] V x} {ϕ_TM' : Π x : M, V x →L[𝕜] TangentSpace I x}
+
+/-- info: (T% ϕ_TM) : M → TotalSpace (E →L[𝕜] F) fun x ↦ TangentSpace I x →L[𝕜] V x -/
+#guard_msgs in
+#check T% ϕ_TM
+
+section Pullback
+
+/- Declare a manifold `B` (with model `IB : HB → EB`),
+and two vector bundles `E₁`, `E₂` and over `B` (with model fibers `F₁`, `F₂`).
+-/
+variable {B F₁ F₂ : Type*}
+  {E₁ : B → Type*} [∀ x, AddCommGroup (E₁ x)] [∀ x, Module 𝕜 (E₁ x)]
+  [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
+  [TopologicalSpace (TotalSpace F₁ E₁)] [∀ x, TopologicalSpace (E₁ x)]
+  {E₂ : B → Type*} [∀ x, AddCommGroup (E₂ x)] [∀ x, Module 𝕜 (E₂ x)]
+  [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
+  [TopologicalSpace (TotalSpace F₂ E₂)] [∀ x, TopologicalSpace (E₂ x)]
+  {EB : Type*}
+  [NormedAddCommGroup EB] [NormedSpace 𝕜 EB] {HB : Type*} [TopologicalSpace HB]
+  {IB : ModelWithCorners 𝕜 EB HB} [TopologicalSpace B] [ChartedSpace HB B]
+  [FiberBundle F₁ E₁] [VectorBundle 𝕜 F₁ E₁]
+  [FiberBundle F₂ E₂] [VectorBundle 𝕜 F₂ E₂]
+  {b : M → B}
+
+variable {v : ∀ x, E₁ (b x)}
+
+/-- info: (T% v) : M → TotalSpace F₁ E₁-/
+#guard_msgs in
+#check T% v
+
+variable [∀ x, IsTopologicalAddGroup (E₂ x)] [∀ x, ContinuousSMul 𝕜 (E₂ x)]
+  {ϕ : ∀ x, (E₁ (b x) →L[𝕜] E₂ (b x))}
+
+/-- info: (T% ϕ) : M → TotalSpace (F₁ →L[𝕜] F₂) fun x ↦ E₁ x →L[𝕜] E₂ x -/
+#guard_msgs in
+#check T% ϕ
+
+end Pullback
+
 variable {x : M}
 
 -- Testing precedence.


### PR DESCRIPTION
# Changes
## `Mathlib/Geometry/Manifold/Notation.lean`
* **Add support for pullback bundles:** Replaced the hardcoded bound variable `x` with the dynamically extracted argument `arg`, which allows for using elaborator `T%` with pullback bundles, where the base point lies in a different manifold, e.g. `v : Π (m : M), E₁ (b m)`, where `b : M → B`.
* **Add support for Hom-bundles:** The elaborator now supports sections of Hom-bundles (`ContinuousLinearMap` between two fiber bundles, e.g. `ϕ : ∀ x, (E₁ x →L[𝕜] E₂ x`). It also supports the case where the base point lies in a different manifold (e.g. `ϕ : ∀ x, (E₁ (b x) →L[𝕜] E₂ (b x))`)
* **Support nested `TangentSpace`:** Modified `findModelFiber?` to natively intercept `TangentSpace` applications and extract the model fiber at index 2. This prevents typeclass synthesis failures when `TangentSpace` is used inside a Hom-bundle.

## `MathlibTest/DifferentialGeometry/Notation/Basic.lean`
* **Added tests for all the new usecases** this includes pullback bundles, Hom-bundles, pullback Hom-bundles, and Hom-bundles where one of the fibers is a `TangentSpace`.

## `Mathlib/Geometry/Manifold/VectorBundle/Hom.lean`
* **Refactor `Hom.lean`:** Replaced verbose `TotalSpace.mk'` boilerplate in with the newly supported `T%` syntax (e.g. `MDiffAt[s] T% ϕ x` instead of  `MDiffAt[s] (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) x)`

# Use of AI
The help of AI was used in writing the code in  `Mathlib/Geometry/Manifold/Notation.lean`. It was hence manually edited to simplify the code as much as possible. While the author is not yet an expert in metaprogramming in Lean, he is willing to learn and receive feedback, and put all the effort to understand the presented code. The code was carefully tested with different parts of it changed and removed to make sure that every line serves a purpose to provide the expected functionality.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
