### PR TITLE
feat: add `fun_simp` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7411,6 +7411,9 @@ public import Mathlib.Tactic.FunProp.Mor
 public import Mathlib.Tactic.FunProp.Theorems
 public import Mathlib.Tactic.FunProp.ToBatteries
 public import Mathlib.Tactic.FunProp.Types
+public import Mathlib.Tactic.FunSimp
+public import Mathlib.Tactic.FunSimp.Attr
+public import Mathlib.Tactic.FunSimp.Simproc
 public import Mathlib.Tactic.GCongr
 public import Mathlib.Tactic.GCongr.Core
 public import Mathlib.Tactic.GCongr.CoreAttrs

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -143,6 +143,9 @@ public import Mathlib.Tactic.FunProp.Mor
 public import Mathlib.Tactic.FunProp.Theorems
 public import Mathlib.Tactic.FunProp.ToBatteries
 public import Mathlib.Tactic.FunProp.Types
+public import Mathlib.Tactic.FunSimp
+public import Mathlib.Tactic.FunSimp.Attr
+public import Mathlib.Tactic.FunSimp.Simproc
 public import Mathlib.Tactic.GCongr
 public import Mathlib.Tactic.GCongr.Core
 public import Mathlib.Tactic.GCongr.CoreAttrs

--- a/Mathlib/Tactic/FunSimp.lean
+++ b/Mathlib/Tactic/FunSimp.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 Attila Gáspár. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Attila Gáspár
+-/
+module
+
+public import Mathlib.Logic.Function.Basic
+public import Mathlib.Tactic.FunSimp.Attr
+public import Mathlib.Tactic.FunSimp.Simproc
+
+/-!
+# The `fun_simp` tactic
+
+The `fun_simp` tactic rewrites using lemmas tagged with the `@[fun_simp]` attribute. Its intended
+use is simplifying bundled morphisms, which are often wrappers around more basic functions.
+
+Unlike `simp`, this tactic can automatically eta-expand expressions when necessary. For example,
+assuming that a lemma `f x y = x + y` is tagged with `@[fun_simp]`, the expression `f x` is
+rewritten to `fun y => x + y`. Additionally, lemmas about the equality of bundled morphisms are used
+for rewriting when the morphism is coerced to a function.
+
+This tactic is also available in `conv` mode and as a `simp` set.
+-/
+
+public meta section
+
+open Function Lean.Parser.Tactic
+
+namespace Mathlib.Tactic.FunSimp
+
+/--
+The `fun_simp` tactic rewrites using lemmas tagged with the `@[fun_simp]` attribute. Its intended
+use is simplifying bundled morphisms, which are often wrappers around more basic functions.
+
+Unlike `simp`, this tactic can automatically eta-expand expressions when necessary. For example,
+assuming that a lemma `f x y = x + y` is tagged with `@[fun_simp]`, the expression `f x` is
+rewritten to `fun y => x + y`. Additionally, lemmas about the equality of bundled morphisms are used
+for rewriting when the morphism is coerced to a function.
+-/
+macro (name := funSimpStx) "fun_simp" loc:(location)? : tactic =>
+  `(tactic| simp only [fun_simp] $[$loc]?)
+
+@[inherit_doc funSimpStx]
+macro (name := convFunSimpStx) "fun_simp" : conv =>
+  `(conv| simp only [fun_simp])
+
+attribute [fun_simp] id curry uncurry const comp HasUncurry.uncurry
+
+end Mathlib.Tactic.FunSimp

--- a/Mathlib/Tactic/FunSimp/Attr.lean
+++ b/Mathlib/Tactic/FunSimp/Attr.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 Attila Gáspár. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Attila Gáspár
+-/
+module
+
+public import Mathlib.Tactic.Translate.Attributes
+
+/-!
+# Implementation of the `@[fun_simp]` attribute
+-/
+
+public meta section
+
+namespace Mathlib.Tactic.FunSimp
+
+open Lean Meta Elab Parser.Tactic Simp
+
+/-- Simp extension used by `fun_simp`. -/
+initialize simpExt : SimpExtension ← mkSimpExt `fun_simp
+initialize simpExtensionMapRef.modify fun map => map.insert `fun_simp simpExt
+
+/-- Simproc extension used by `fun_simp`. -/
+initialize simprocExt : SimprocExtension ← registerSimprocAttr `fun_simp_proc "fun_simp_proc" none
+@[nolint docBlame]
+syntax (name := Parser.Attr.fun_simp_proc)
+  "fun_simp_proc" (Parser.Tactic.simpPre <|> Parser.Tactic.simpPost)? : attr
+
+/-- Environment extension storing the mapping from lemmas to their preprocessed form. -/
+initialize auxThmExt : SimplePersistentEnvExtension (Name × Name) (NameMap Name) ←
+  registerSimplePersistentEnvExtension {
+    addEntryFn nameMap entry := nameMap.insert entry.1 entry.2
+    addImportedFn _ := {}
+  }
+
+initialize registerTraceClass `fun_simp.attr
+
+/-- Moves the free variables at the end of the LHS to the RHS, e.g. `f x y = x + y` becomes
+`f = fun x y => x + y`. Returns `some (type, proof)`, or `none` when no free variables can be moved.
+-/
+def removeArgs (type proof : Expr) : MetaM (Option (Expr × Expr)) := do
+  let mut proof := proof
+  let mut (_, lhs, rhs) := type.eq?.get!
+  let mut argRemoved := false
+  let mut ctx := (← getLCtx).getFVars
+  repeat
+    let .app f x := lhs | break
+    let some xId := x.fvarId? | break
+    unless (← xId.getBinderInfo).isExplicit do break
+    if f.containsFVar xId then break
+    if ← ctx.anyM (fun y => do return (← y.fvarId!.getType).containsFVar xId) then break
+    ctx := ctx.erase x
+    lhs := f
+    rhs := (← mkLambdaFVars #[x] rhs).eta
+    proof ← mkFunExt (← mkLambdaFVars #[x] proof)
+    argRemoved := true
+  if argRemoved then
+    return some (← mkForallFVars ctx (← mkEq lhs rhs), ← mkLambdaFVars ctx proof)
+  return none
+
+/-- Coerces both sides of an equality to functions. Returns `some (type, proof)`, or `none` if this
+is not possible. -/
+def applyCoeFun (type proof : Expr) : MetaM (Option (Expr × Expr)) := do
+  let (eqType, lhs, rhs) := type.eq?.get!
+  let u ← getLevel eqType
+  let v ← mkFreshLevelMVar
+  let γ ← mkFreshExprMVar (← mkArrow eqType (mkSort v))
+  let .some inst ← trySynthInstance (mkApp2 (.const ``CoeFun [u,v]) eqType γ)
+  | return none
+  let coe ← instantiateMVars (mkApp3 (.const ``CoeFun.coe [u,v]) eqType γ inst)
+  let (lhs, _) ← expandCoe (.app coe lhs)
+  let (rhs, _) ← expandCoe (.app coe rhs)
+  let ctx := (← getLCtx).getFVars
+  return some (← mkForallFVars ctx (← mkEq lhs rhs), ← mkLambdaFVars ctx (← mkCongrArg coe proof))
+
+/-- Applies preprocessing steps to an equality of functions. Returns `some (type, proof)`, or
+`none` if no preprocessing is needed. -/
+def preprocess (declName : Name) (inv : Bool) : MetaM (Option (Expr × Expr)) :=
+  withReducible do
+    let info ← getConstInfo declName
+    forallTelescopeReducing info.type fun args type => do
+      let mut type := type
+      let mut proof := mkAppN (← mkConstWithLevelParams declName) args
+      unless type.isEq do
+        throwError m!"The type of {.ofConstName declName} is not an equality"
+      if inv then
+        let (_, lhs, rhs) := type.eq?.get!
+        type ← mkEq rhs lhs
+        proof ← mkEqSymm proof
+      if let some res ← removeArgs type proof then return some res
+      if let some (.forallE .., _, _) := type.eq? then
+        return if inv then some (type, proof) else none
+      if let some res ← applyCoeFun type proof then return some res
+      throwError m!"The type of {.ofConstName declName} is not an equality of functions"
+
+/-- Preprocess and add a theorem tagged with `@[fun_simp]` to the simp set. Returns the list of
+auxiliary lemmas generated. -/
+partial def addThm (declName : Name) (post inv : Bool) (attrKind : AttributeKind) (prio : Nat) :
+    MetaM (Array Name) := do
+  if let some projInfo ← getProjectionFnInfo? declName then
+    if projInfo.fromClass then
+      -- Allow tagging class fields such as `HasUncurry.uncurry`
+      simpExt.add <| .toUnfold declName
+      return #[]
+  match ← getEqnsFor? declName with
+  | some eqns => eqns.flatMapM (addThm · post inv attrKind prio)
+  | none =>
+    let (simpThm, isAux) ←
+      match auxThmExt.getState (← getEnv) |>.get? declName with
+      | some auxThm =>
+        trace[fun_simp.attr]
+          m!"Auxiliary lemma {.ofConstName auxThm} for {.ofConstName declName} already generated"
+        pure (auxThm, true)
+      | none =>
+        let some (type, proof) ← preprocess declName inv |
+          trace[fun_simp.attr] m!"No preprocessing needed for {.ofConstName declName}"
+          pure (declName, false)
+        let auxThm ←
+          mkAuxLemma (← getConstInfo declName).levelParams type proof `_fun_simp
+        trace[fun_simp.attr]
+          m!"Generated auxiliary lemma {.ofConstName auxThm} for {.ofConstName declName}"
+        modifyEnv (auxThmExt.addEntry · (declName, auxThm))
+        pure (auxThm, true)
+    addSimpTheorem simpExt simpThm post (inv := false) attrKind prio
+    return if isAux then #[simpThm] else #[]
+
+/-- Elaboration of the `@[fun_simp]` attribute. Returns the list of auxiliary lemmas generated. -/
+def addAttr (declName : Name) (stx : Syntax) (attrKind : AttributeKind) : AttrM (Array Name) := do
+  let post := if stx[1].isNone then true else stx[1][0].getKind == ``Lean.Parser.Tactic.simpPost
+  let inv := !stx[2].isNone
+  let prio ← getAttrParamOptPrio stx[3]
+  MetaM.run' <| addThm declName post inv attrKind prio
+
+/-- Remove a theorem from the simp set. -/
+partial def eraseThm (declName : Name) : MetaM Unit := do
+  let isClassProj :=
+    match ← getProjectionFnInfo? declName with
+    | some projInfo => projInfo.fromClass
+    | none => false
+  let eqns ← if isClassProj then pure none else getEqnsFor? declName
+  match eqns with
+  | some eqns => eqns.forM eraseThm
+  | none =>
+    let auxThm := auxThmExt.getState (← getEnv) |>.getD declName declName
+    let s := simpExt.getState (← getEnv)
+    let s ← s.erase (.decl auxThm)
+    modifyEnv fun env => simpExt.modifyState env fun _ => s
+
+/--
+Attribute for tagging lemmas used by the `fun_simp` tactic. Has the same options as the `@[simp]`
+attribute.
+-/
+syntax (name := funSimpAttr)
+  "fun_simp" (simpPre <|> simpPost)? unicode("← ", "<- ")? (prio)? : attr
+
+initialize registerBuiltinAttribute {
+  name := `funSimpAttr
+  descr := "Attribute for tagging lemmas used by the `fun_simp` tactic."
+  add declName stx attrKind := discard <| addAttr declName stx attrKind
+  erase declName := MetaM.run' <| eraseThm declName
+}
+
+initialize registerGeneratingAttr `funSimpAttr addAttr
+
+end Mathlib.Tactic.FunSimp

--- a/Mathlib/Tactic/FunSimp/Simproc.lean
+++ b/Mathlib/Tactic/FunSimp/Simproc.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 Attila Gáspár. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Attila Gáspár
+-/
+module
+
+public import Mathlib.Tactic.FunSimp.Attr
+
+/-!
+# Simprocs for rewriting prefixes of applications
+
+These simprocs try to rewrite every prefix of an application. This is necessary because
+`@[fun_simp]` normalizes equalities into an unapplied form, e.g. `f (x + 1) y = x + y` becomes
+`f (x + 1) = fun y => x + y`.
+-/
+
+open Lean Meta.Simp
+
+public meta section
+
+namespace Mathlib.Tactic.FunSimp
+
+/-- Post-rewriting partial applications in `fun_simp`. -/
+simproc_decl partialAppPost (_) := fun e => do
+  let rec go (e : Expr) := do
+    let .app f x := e | return none
+    if let some r ← go f then
+      return some (← mkCongrFun r x)
+    let thms ← simpExt.getTheorems
+    rewrite? e thms.post thms.erased "fun_simp post" false
+  if let some res ← go e then
+    return .visit res
+  return .continue
+
+/-- Pre-rewriting partial applications in `fun_simp`. -/
+simproc_decl partialAppPre (_) := fun e => do
+  let rec go (e : Expr) := do
+    let .app f x := e | return none
+    let thms ← simpExt.getTheorems
+    if let some r ← rewrite? e thms.pre thms.erased "fun_simp pre" false then
+      return some r
+    (← go f).mapM (mkCongrFun · x)
+  if let some res ← go e then
+    return .visit res
+  return .continue
+
+attribute [fun_simp_proc↓] partialAppPre
+attribute [fun_simp_proc↑] partialAppPost
+
+end Mathlib.Tactic.FunSimp


### PR DESCRIPTION
This PR adds a tactic and simp set `fun_simp` for simplifying bundled morphisms. The main use case is simplifying functions before calling `fun_prop`. In the future, this tactic could be added to `fun_prop` itself as a preprocessing step.

---

The idea of this tactic is based on #42516 by @mcdoll. Unlike #42516, which simply uses a simp set, this implementation has a preprocessing step to allow using applied forms of lemmas without eta-expanding.

TODO: add tests

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
