### PR TITLE
feat(SpecialFunctions/Pow): versions of `le_rpow_inv_iff` for negative exponents

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -155,8 +155,9 @@ nonrec theorem NNReal.tendsto_rpow_atTop {y : ℝ} (hy : 0 < y) :
 theorem ENNReal.tendsto_rpow_at_top {y : ℝ} (hy : 0 < y) :
     Tendsto (fun x : ℝ≥0∞ ↦ x ^ y) (𝓝 ∞) (𝓝 ∞) := by
   rw [nhds_top_basis_Ici.tendsto_iff nhds_top_basis_Ici]
-  refine fun x hx ↦ ⟨x ^ y⁻¹, (rpow_lt_top_of_nonneg (inv_nonneg.2 hy.le) hx.ne), ?_⟩
-  exact fun z hz ↦ (rpow_inv_le_iff hy).1 hz
+  intro x hx
+  refine ⟨x ^ y⁻¹, (rpow_lt_top_of_nonneg (inv_nonneg.2 hy.le) hx.ne), ?_⟩
+  exact fun _ ↦ (rpow_inv_le_iff hy).1
 
 end Limits
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -153,19 +153,10 @@ nonrec theorem NNReal.tendsto_rpow_atTop {y : ℝ} (hy : 0 < y) :
   exact mod_cast hc a (Real.toNNReal_le_iff_le_coe.mp ha)
 
 theorem ENNReal.tendsto_rpow_at_top {y : ℝ} (hy : 0 < y) :
-    Tendsto (fun x : ℝ≥0∞ => x ^ y) (𝓝 ⊤) (𝓝 ⊤) := by
-  rw [ENNReal.tendsto_nhds_top_iff_nnreal]
-  intro x
-  obtain ⟨c, _, hc⟩ :=
-    (atTop_basis_Ioi.tendsto_iff atTop_basis_Ioi).mp (NNReal.tendsto_rpow_atTop hy) x trivial
-  have hc' : Set.Ioi ↑c ∈ 𝓝 (⊤ : ℝ≥0∞) := Ioi_mem_nhds ENNReal.coe_lt_top
-  filter_upwards [hc'] with a ha
-  by_cases ha' : a = ⊤
-  · simp [ha', hy]
-  lift a to ℝ≥0 using ha'
-  simp only [Set.mem_Ioi, coe_lt_coe] at ha hc
-  rw [← ENNReal.coe_rpow_of_nonneg _ hy.le]
-  exact mod_cast hc a ha
+    Tendsto (fun x : ℝ≥0∞ ↦ x ^ y) (𝓝 ∞) (𝓝 ∞) := by
+  rw [nhds_top_basis_Ici.tendsto_iff nhds_top_basis_Ici]
+  refine fun x hx ↦ ⟨x ^ y⁻¹, (rpow_lt_top_of_nonneg (inv_nonneg.2 hy.le) hx.ne), ?_⟩
+  exact fun z hz ↦ (rpow_inv_le_iff hy).1 hz
 
 end Limits
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -813,27 +813,30 @@ lemma max_rpow {x y : ℝ≥0∞} {p : ℝ} (hp : 0 ≤ p) : max x y ^ p = max (
   · rw [max_eq_left hxy, max_eq_left (rpow_le_rpow hxy hp)]
 
 theorem le_rpow_inv_iff {x y : ℝ≥0∞} {z : ℝ} (hz : 0 < z) : x ≤ y ^ z⁻¹ ↔ x ^ z ≤ y := by
-  nth_rw 1 [← rpow_one x, ← mul_inv_cancel₀ hz.ne']
-  rw [rpow_mul, rpow_le_rpow_iff (inv_pos_of_pos hz)]
-
-theorem rpow_inv_lt_iff {x y : ℝ≥0∞} {z : ℝ} (hz : 0 < z) : x ^ z⁻¹ < y ↔ x < y ^ z := by
-  simp only [← not_le, le_rpow_inv_iff hz]
-
-theorem lt_rpow_inv_iff {x y : ℝ≥0∞} {z : ℝ} (hz : 0 < z) : x < y ^ z⁻¹ ↔ x ^ z < y := by
-  nth_rw 1 [← rpow_one x, ← mul_inv_cancel₀ hz.ne']
-  rw [rpow_mul, rpow_lt_rpow_iff (inv_pos_of_pos hz)]
+  nth_rw 1 [← rpow_one x, ← mul_inv_cancel₀ hz.ne', rpow_mul, rpow_le_rpow_iff (inv_pos_of_pos hz)]
 
 theorem rpow_inv_le_iff {x y : ℝ≥0∞} {z : ℝ} (hz : 0 < z) : x ^ z⁻¹ ≤ y ↔ x ≤ y ^ z := by
-  nth_rw 1 [← rpow_one y, ← mul_inv_cancel₀ hz.ne']
-  rw [rpow_mul, rpow_le_rpow_iff (inv_pos.2 hz)]
+  nth_rw 1 [← rpow_one y, ← mul_inv_cancel₀ hz.ne', rpow_mul, rpow_le_rpow_iff (inv_pos.2 hz)]
+
+theorem le_rpow_inv_iff_of_neg {x y : ℝ≥0∞} {z : ℝ} (hz : z < 0) : x ≤ y ^ z⁻¹ ↔ y ≤ x ^ z := by
+  nth_rw 1 [← neg_neg z, inv_neg, rpow_neg, le_inv_iff_le_inv, rpow_inv_le_iff (neg_pos.2 hz),
+    inv_rpow, ← rpow_neg, neg_neg]
 
 theorem rpow_inv_le_iff_of_neg {x y : ℝ≥0∞} {z : ℝ} (hz : z < 0) : x ^ z⁻¹ ≤ y ↔ y ^ z ≤ x := by
   nth_rw 1 [← neg_neg z, inv_neg, rpow_neg, inv_le_iff_inv_le, le_rpow_inv_iff (neg_pos.2 hz),
     inv_rpow, ← rpow_neg, neg_neg]
 
-theorem le_rpow_inv_iff_of_neg {x y : ℝ≥0∞} {z : ℝ} (hz : z < 0) : x ≤ y ^ z⁻¹ ↔ y ≤ x ^ z := by
-  nth_rw 1 [← neg_neg z, inv_neg, rpow_neg, le_inv_iff_le_inv, rpow_inv_le_iff (neg_pos.2 hz),
-    inv_rpow, ← rpow_neg, neg_neg]
+theorem lt_rpow_inv_iff {x y : ℝ≥0∞} {z : ℝ} (hz : 0 < z) : x < y ^ z⁻¹ ↔ x ^ z < y := by
+  simp only [← not_le, rpow_inv_le_iff hz]
+
+theorem rpow_inv_lt_iff {x y : ℝ≥0∞} {z : ℝ} (hz : 0 < z) : x ^ z⁻¹ < y ↔ x < y ^ z := by
+  simp only [← not_le, le_rpow_inv_iff hz]
+
+theorem lt_rpow_inv_iff_of_neg {x y : ℝ≥0∞} {z : ℝ} (hz : z < 0) : x < y ^ z⁻¹ ↔ y < x ^ z := by
+  simp only [← not_le, rpow_inv_le_iff_of_neg hz]
+
+theorem rpow_inv_lt_iff_of_neg {x y : ℝ≥0∞} {z : ℝ} (hz : z < 0) : x ^ z⁻¹ < y ↔ y ^ z < x := by
+  simp only [← not_le, le_rpow_inv_iff_of_neg hz]
 
 @[gcongr]
 theorem rpow_lt_rpow_of_exponent_lt {x : ℝ≥0∞} {y z : ℝ} (hx : 1 < x) (hx' : x ≠ ⊤) (hyz : y < z) :

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -813,22 +813,27 @@ lemma max_rpow {x y : ℝ≥0∞} {p : ℝ} (hp : 0 ≤ p) : max x y ^ p = max (
   · rw [max_eq_left hxy, max_eq_left (rpow_le_rpow hxy hp)]
 
 theorem le_rpow_inv_iff {x y : ℝ≥0∞} {z : ℝ} (hz : 0 < z) : x ≤ y ^ z⁻¹ ↔ x ^ z ≤ y := by
-  nth_rw 1 [← rpow_one x]
-  nth_rw 1 [← @mul_inv_cancel₀ _ _ z hz.ne']
-  rw [rpow_mul, @rpow_le_rpow_iff _ _ z⁻¹ (by simp [hz])]
+  nth_rw 1 [← rpow_one x, ← mul_inv_cancel₀ hz.ne']
+  rw [rpow_mul, rpow_le_rpow_iff (inv_pos_of_pos hz)]
 
 theorem rpow_inv_lt_iff {x y : ℝ≥0∞} {z : ℝ} (hz : 0 < z) : x ^ z⁻¹ < y ↔ x < y ^ z := by
   simp only [← not_le, le_rpow_inv_iff hz]
 
 theorem lt_rpow_inv_iff {x y : ℝ≥0∞} {z : ℝ} (hz : 0 < z) : x < y ^ z⁻¹ ↔ x ^ z < y := by
-  nth_rw 1 [← rpow_one x]
-  nth_rw 1 [← @mul_inv_cancel₀ _ _ z (ne_of_lt hz).symm]
-  rw [rpow_mul, @rpow_lt_rpow_iff _ _ z⁻¹ (by simp [hz])]
+  nth_rw 1 [← rpow_one x, ← mul_inv_cancel₀ hz.ne']
+  rw [rpow_mul, rpow_lt_rpow_iff (inv_pos_of_pos hz)]
 
 theorem rpow_inv_le_iff {x y : ℝ≥0∞} {z : ℝ} (hz : 0 < z) : x ^ z⁻¹ ≤ y ↔ x ≤ y ^ z := by
-  nth_rw 1 [← ENNReal.rpow_one y]
-  nth_rw 1 [← @mul_inv_cancel₀ _ _ z hz.ne.symm]
-  rw [ENNReal.rpow_mul, ENNReal.rpow_le_rpow_iff (inv_pos.2 hz)]
+  nth_rw 1 [← rpow_one y, ← mul_inv_cancel₀ hz.ne']
+  rw [rpow_mul, rpow_le_rpow_iff (inv_pos.2 hz)]
+
+theorem rpow_inv_le_iff_of_neg {x y : ℝ≥0∞} {z : ℝ} (hz : z < 0) : x ^ z⁻¹ ≤ y ↔ y ^ z ≤ x := by
+  nth_rw 1 [← neg_neg z, inv_neg, rpow_neg, inv_le_iff_inv_le, le_rpow_inv_iff (neg_pos.2 hz),
+    inv_rpow, ← rpow_neg, neg_neg]
+
+theorem le_rpow_inv_iff_of_neg {x y : ℝ≥0∞} {z : ℝ} (hz : z < 0) : x ≤ y ^ z⁻¹ ↔ y ≤ x ^ z := by
+  nth_rw 1 [← neg_neg z, inv_neg, rpow_neg, le_inv_iff_le_inv, rpow_inv_le_iff (neg_pos.2 hz),
+    inv_rpow, ← rpow_neg, neg_neg]
 
 @[gcongr]
 theorem rpow_lt_rpow_of_exponent_lt {x : ℝ≥0∞} {y z : ℝ} (hx : 1 < x) (hx' : x ≠ ⊤) (hyz : y < z) :


### PR DESCRIPTION
This PR introduces negative exponent versions of `le_rpow_inv_iff` and `rpow_le_inv_iff`, and golfs a few adjacent lemmas.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
