### PR TITLE
feat(NumberTheory/LSeries): define Hardy's Z function

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5820,6 +5820,7 @@ public import Mathlib.NumberTheory.LSeries.Convolution
 public import Mathlib.NumberTheory.LSeries.Deriv
 public import Mathlib.NumberTheory.LSeries.Dirichlet
 public import Mathlib.NumberTheory.LSeries.DirichletContinuation
+public import Mathlib.NumberTheory.LSeries.HardyZ
 public import Mathlib.NumberTheory.LSeries.HurwitzZeta
 public import Mathlib.NumberTheory.LSeries.HurwitzZetaEven
 public import Mathlib.NumberTheory.LSeries.HurwitzZetaOdd

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
@@ -33,6 +33,7 @@ formula which is an important input in functional equations of (un-completed) Di
 
 open Filter Topology Asymptotics Real Set MeasureTheory
 open Complex
+open scoped ComplexConjugate
 
 namespace Complex
 
@@ -72,6 +73,26 @@ lemma Gammaℝ_ne_zero_of_re_pos {s : ℂ} (hs : 0 < re s) : Gammaℝ s ≠ 0 :=
 
 lemma Gammaℝ_eq_zero_iff {s : ℂ} : Gammaℝ s = 0 ↔ ∃ n : ℕ, s = -(2 * n) := by
   simp [Gammaℝ_def, Complex.Gamma_eq_zero_iff, pi_ne_zero, div_eq_iff (two_ne_zero' ℂ), mul_comm]
+
+/-- The Gamma factor `Γ_ℝ` commutes with complex conjugation. -/
+lemma Gammaℝ_conj (s : ℂ) : Gammaℝ (conj s) = conj (Gammaℝ s) := by
+  have hpi : (π : ℂ).arg ≠ π := by
+    rw [arg_ofReal_of_nonneg pi_pos.le]
+    exact pi_pos.ne
+  have h := cpow_conj (π : ℂ) (-s / 2) hpi
+  rw [conj_ofReal] at h
+  rw [Gammaℝ_def, Gammaℝ_def, map_mul, ← Gamma_conj, ← h]
+  congr 2 <;> simp [map_div₀, map_neg, map_ofNat]
+
+/-- The Gamma factor `Γ_ℂ` commutes with complex conjugation. -/
+lemma Gammaℂ_conj (s : ℂ) : Gammaℂ (conj s) = conj (Gammaℂ s) := by
+  have h2pi : ((2 : ℂ) * π).arg ≠ π := by
+    rw [show (2 : ℂ) * π = ((2 * π : ℝ) : ℂ) by push_cast; ring,
+      arg_ofReal_of_nonneg (by positivity)]
+    exact pi_pos.ne
+  have h := cpow_conj ((2 : ℂ) * π) (-s) h2pi
+  rw [map_mul, conj_ofReal, map_ofNat] at h
+  rw [Gammaℂ_def, Gammaℂ_def, map_mul, map_mul, ← Gamma_conj, ← h, map_neg, map_ofNat]
 
 @[simp]
 lemma Gammaℝ_one : Gammaℝ 1 = 1 := by

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -481,6 +481,31 @@ theorem riemannZeta_conj (s : ℂ) : riemannZeta (conj s) = conj (riemannZeta s)
           ((isOpen_lt continuous_const continuous_re).mem_nhds (by norm_num)) hgz)
     simpa using congrArg (starRingEnd ℂ) (heq hs)
 
+/-- **Conjugation symmetry of the completed zeta function** for `0 < re s`, where the
+relation `Λ s = ζ s * Γ_ℝ s` is available. -/
+theorem completedRiemannZeta_conj_of_re_pos {s : ℂ} (hs : 0 < s.re) :
+    completedRiemannZeta (conj s) = conj (completedRiemannZeta s) := by
+  have hcs : 0 < (conj s).re := by rwa [conj_re]
+  have key {z : ℂ} (hz : 0 < z.re) : completedRiemannZeta z = riemannZeta z * Gammaℝ z := by
+    have hz0 : z ≠ 0 := fun h ↦ by simp [h] at hz
+    rw [riemannZeta_def_of_ne_zero hz0]
+    exact (div_mul_cancel₀ _ (Gammaℝ_ne_zero_of_re_pos hz)).symm
+  rw [key hcs, key hs, map_mul, riemannZeta_conj, Complex.Gammaℝ_conj]
+
+/-- **Conjugation symmetry of the completed zeta function**: `Λ (conj s) = conj (Λ s)`.
+
+For `0 < re s` this is `riemannZeta_conj` together with `Gammaℝ_conj`; the remaining
+half-plane follows from the functional equation `completedRiemannZeta_one_sub`. -/
+@[simp]
+theorem completedRiemannZeta_conj (s : ℂ) :
+    completedRiemannZeta (conj s) = conj (completedRiemannZeta s) := by
+  rcases lt_or_ge 0 s.re with hs | hs
+  · exact completedRiemannZeta_conj_of_re_pos hs
+  · have h1 : 0 < (1 - s).re := by simp only [sub_re, one_re]; linarith
+    have hcs : conj (1 - s) = 1 - conj s := by simp
+    have := completedRiemannZeta_conj_of_re_pos h1
+    rwa [hcs, completedRiemannZeta_one_sub, completedRiemannZeta_one_sub] at this
+
 lemma riemannZeta_eventually_ne_zero_nhds_one : ∀ᶠ s in 𝓝 1, riemannZeta s ≠ 0 := by
   filter_upwards [eventually_nhdsWithin_iff.1 <| riemannZeta_residue_one.eventually_ne one_ne_zero]
   grind [riemannZeta_one_ne_zero]

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -483,7 +483,7 @@ theorem riemannZeta_conj (s : ℂ) : riemannZeta (conj s) = conj (riemannZeta s)
 
 /-- **Conjugation symmetry of the completed zeta function** for `0 < re s`, where the
 relation `Λ s = ζ s * Γ_ℝ s` is available. -/
-theorem completedRiemannZeta_conj_of_re_pos {s : ℂ} (hs : 0 < s.re) :
+private theorem completedRiemannZeta_conj_of_re_pos {s : ℂ} (hs : 0 < s.re) :
     completedRiemannZeta (conj s) = conj (completedRiemannZeta s) := by
   have hcs : 0 < (conj s).re := by rwa [conj_re]
   have key {z : ℂ} (hz : 0 < z.re) : completedRiemannZeta z = riemannZeta z * Gammaℝ z := by

--- a/Mathlib/NumberTheory/LSeries/HardyZ.lean
+++ b/Mathlib/NumberTheory/LSeries/HardyZ.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 Thomas Lince. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Lince
+-/
+module
+
+public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
+
+/-!
+# Hardy's Z function
+
+Hardy's `Z` function is the real-valued function on `ℝ` whose zeros are exactly the heights of
+the zeros of `ζ` on the critical line. It is defined here by dividing the completed zeta
+function `Λ` on the critical line by the modulus of its archimedean factor:
+
+$$ Z(t) = \frac{\Lambda(1/2 + it)}{|\Gamma_{\mathbb{R}}(1/2 + it)|}. $$
+
+The numerator is real, by `completedRiemannZeta_conj` together with the functional equation
+`completedRiemannZeta_one_sub`, and the denominator is a positive real, so `Z` is real-valued.
+
+This definition avoids the Riemann–Siegel theta function `ϑ`. The textbook definition
+`Z t = exp (I * ϑ t) * ζ (1/2 + I * t)` requires a continuous branch of `log Γ` along the
+critical line, which Mathlib does not currently have.
+
+The two agree. Writing `Γ_ℝ(1/2 + it) = π ^ (-1/4) * π ^ (-it/2) * Γ(1/4 + it/2)`, the factor
+`π ^ (-1/4)` is a positive real and `|π ^ (-it/2)| = 1`, so dividing `Λ` by `|Γ_ℝ|` leaves
+
+$$ Z(t) = \pi^{-it/2} \frac{\Gamma(1/4 + it/2)}{|\Gamma(1/4 + it/2)|} \zeta(1/2 + it)
+        = e^{i \vartheta(t)} \zeta(1/2 + it), $$
+
+with `ϑ(t) = arg Γ(1/4 + it/2) - (t/2) * log π`, which is exactly the Riemann–Siegel theta
+function. Dividing by a modulus and multiplying by `exp (I * ϑ)` are the same normalisation;
+the first simply does not name a branch. Once `ϑ` is available this can be recorded as a lemma.
+
+### Main results
+
+* `hardyZ`: the definition, as a function `ℝ → ℝ`.
+* `abs_hardyZ`: `|Z t| = ‖ζ (1/2 + i t)‖`.
+* `hardyZ_neg`: `Z` is even.
+* `hardyZ_eq_zero_iff`: `Z t = 0 ↔ ζ (1/2 + i t) = 0`, the reason the definition exists.
+* `continuous_hardyZ`: `Z` is continuous, so the intermediate value theorem applies to it and
+  sign changes of `Z` locate zeros of `ζ` on the critical line.
+
+### References
+
+* E. C. Titchmarsh, *The theory of the Riemann zeta-function*, 2nd ed., Oxford, 1986, §4.17
+-/
+
+@[expose] public section
+
+open Complex Real Filter Topology
+open scoped ComplexConjugate
+
+private lemma half_add_mul_I_re (t : ℝ) : ((1 : ℂ) / 2 + t * I).re = 1 / 2 := by simp
+
+private lemma conj_half_add_mul_I (t : ℝ) :
+    conj ((1 : ℂ) / 2 + t * I) = 1 - (1 / 2 + t * I) := by
+  simp [Complex.ext_iff]; norm_num
+
+private lemma half_add_mul_I_ne_zero (t : ℝ) : (1 : ℂ) / 2 + t * I ≠ 0 := by
+  intro h
+  have hre : ((1 : ℂ) / 2 + t * I).re = 0 := by rw [h]; simp
+  rw [half_add_mul_I_re] at hre
+  norm_num at hre
+
+private lemma half_add_mul_I_ne_one (t : ℝ) : (1 : ℂ) / 2 + t * I ≠ 1 := by
+  intro h
+  have hre : ((1 : ℂ) / 2 + t * I).re = 1 := by rw [h]; simp
+  rw [half_add_mul_I_re] at hre
+  norm_num at hre
+
+private lemma continuous_half_add_mul_I : Continuous fun t : ℝ ↦ (1 : ℂ) / 2 + t * I :=
+  continuous_const.add (Complex.continuous_ofReal.mul continuous_const)
+
+/-- The completed zeta function is real on the critical line. -/
+theorem conj_completedRiemannZeta_half_add_mul_I (t : ℝ) :
+    conj (completedRiemannZeta (1 / 2 + t * I)) = completedRiemannZeta (1 / 2 + t * I) := by
+  rw [← completedRiemannZeta_conj, conj_half_add_mul_I, completedRiemannZeta_one_sub]
+
+theorem completedRiemannZeta_half_add_mul_I_im (t : ℝ) :
+    (completedRiemannZeta (1 / 2 + t * I)).im = 0 :=
+  Complex.conj_eq_iff_im.mp (conj_completedRiemannZeta_half_add_mul_I t)
+
+private theorem ofReal_completedRiemannZeta_half_add_mul_I_re (t : ℝ) :
+    ((completedRiemannZeta (1 / 2 + t * I)).re : ℂ) = completedRiemannZeta (1 / 2 + t * I) :=
+  Complex.conj_eq_iff_re.mp (conj_completedRiemannZeta_half_add_mul_I t)
+
+private theorem Gammaℝ_half_add_mul_I_ne_zero (t : ℝ) : Gammaℝ (1 / 2 + t * I) ≠ 0 :=
+  Gammaℝ_ne_zero_of_re_pos (by rw [half_add_mul_I_re]; norm_num)
+
+/-- **Hardy's Z function**: the real-valued function on `ℝ` obtained by dividing `Λ` on the
+critical line by the modulus of its archimedean factor. Its zeros are exactly the heights of
+the zeros of `ζ` on the critical line. -/
+noncomputable def hardyZ (t : ℝ) : ℝ :=
+  (completedRiemannZeta (1 / 2 + t * I)).re / ‖Gammaℝ (1 / 2 + t * I)‖
+
+theorem ofReal_hardyZ (t : ℝ) :
+    (hardyZ t : ℂ) =
+      completedRiemannZeta (1 / 2 + t * I) / (‖Gammaℝ (1 / 2 + t * I)‖ : ℝ) := by
+  rw [hardyZ, Complex.ofReal_div, ofReal_completedRiemannZeta_half_add_mul_I_re]
+
+/-- `Z` has the same modulus as `ζ` on the critical line. -/
+theorem abs_hardyZ (t : ℝ) : |hardyZ t| = ‖riemannZeta (1 / 2 + t * I)‖ := by
+  have hg := Gammaℝ_half_add_mul_I_ne_zero t
+  have hL : completedRiemannZeta (1 / 2 + t * I) =
+      riemannZeta (1 / 2 + t * I) * Gammaℝ (1 / 2 + t * I) := by
+    rw [riemannZeta_def_of_ne_zero (half_add_mul_I_ne_zero t)]
+    exact (div_mul_cancel₀ _ hg).symm
+  have h1 : |(completedRiemannZeta (1 / 2 + t * I)).re| =
+      ‖completedRiemannZeta (1 / 2 + t * I)‖ := by
+    rw [Complex.norm_def, Complex.normSq_apply, completedRiemannZeta_half_add_mul_I_im]
+    simp [Real.sqrt_mul_self_eq_abs]
+  rw [hardyZ, abs_div, h1, hL, norm_mul, abs_norm, mul_div_assoc,
+    div_self (norm_ne_zero_iff.mpr hg), mul_one]
+
+/-- `Z` is an even function. -/
+theorem hardyZ_neg (t : ℝ) : hardyZ (-t) = hardyZ t := by
+  have hnum : completedRiemannZeta (1 / 2 + (-t : ℝ) * I) =
+      completedRiemannZeta (1 / 2 + t * I) := by
+    have h : ((1 : ℂ) / 2 + (-t : ℝ) * I) = 1 - (1 / 2 + t * I) := by
+      simp [Complex.ext_iff]; norm_num
+    rw [h, completedRiemannZeta_one_sub]
+  have hden : ‖Gammaℝ (1 / 2 + (-t : ℝ) * I)‖ = ‖Gammaℝ (1 / 2 + t * I)‖ := by
+    have h : ((1 : ℂ) / 2 + (-t : ℝ) * I) = conj (1 / 2 + t * I) := by
+      simp [Complex.ext_iff]
+    rw [h, Complex.Gammaℝ_conj, Complex.norm_conj]
+  rw [hardyZ, hardyZ, hnum, hden]
+
+/-- The zeros of `Z` on `ℝ` are exactly the heights of the zeros of `ζ` on the critical line. -/
+theorem hardyZ_eq_zero_iff (t : ℝ) :
+    hardyZ t = 0 ↔ riemannZeta (1 / 2 + t * I) = 0 := by
+  rw [← abs_eq_zero (a := hardyZ t), abs_hardyZ, norm_eq_zero]
+
+/-- `Z` is continuous, so the intermediate value theorem applies to it. -/
+theorem continuous_hardyZ : Continuous hardyZ := by
+  have hnum : Continuous fun t : ℝ ↦ (completedRiemannZeta (1 / 2 + t * I)).re :=
+    Complex.continuous_re.comp (continuous_iff_continuousAt.mpr fun t ↦
+      ContinuousAt.comp (g := completedRiemannZeta) (f := fun t : ℝ ↦ (1 : ℂ) / 2 + t * I)
+        (x := t) (differentiableAt_completedZeta (half_add_mul_I_ne_zero t)
+          (half_add_mul_I_ne_one t)).continuousAt continuous_half_add_mul_I.continuousAt)
+  have hden : Continuous fun t : ℝ ↦ ‖Gammaℝ (1 / 2 + t * I)‖ := by
+    refine continuous_norm.comp (continuous_iff_continuousAt.mpr fun t ↦ ?_)
+    have hne : ∀ m : ℕ, ((1 : ℂ) / 2 + t * I) / 2 ≠ -m := by
+      intro m hm
+      have hre : (((1 : ℂ) / 2 + t * I) / 2).re = (-(m : ℂ)).re := by rw [hm]
+      rw [Complex.div_ofNat_re, half_add_mul_I_re] at hre
+      simp only [Complex.neg_re, Complex.natCast_re] at hre
+      have hm0 : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
+      linarith
+    have hG : ContinuousAt Gammaℝ (1 / 2 + t * I) := by
+      rw [continuousAt_congr (Filter.Eventually.of_forall Gammaℝ_def)]
+      refine ContinuousAt.mul ?_ ?_
+      · exact (continuousAt_const_cpow (by exact_mod_cast Real.pi_ne_zero)).comp
+          (continuousAt_id.neg.div_const 2)
+      · have h2 : ContinuousAt (fun z : ℂ ↦ z / 2) (1 / 2 + t * I) :=
+          continuousAt_id.div_const 2
+        exact ContinuousAt.comp (g := Complex.Gamma) (f := fun z : ℂ ↦ z / 2)
+          (x := 1 / 2 + t * I) (Complex.continuousAt_Gamma _ hne) h2
+    exact ContinuousAt.comp (g := Gammaℝ) (f := fun t : ℝ ↦ (1 : ℂ) / 2 + t * I) (x := t) hG
+      continuous_half_add_mul_I.continuousAt
+  exact hnum.div hden fun t ↦ norm_ne_zero_iff.mpr (Gammaℝ_half_add_mul_I_ne_zero t)


### PR DESCRIPTION
Add Hardy's Z function as a real-valued function on `ℝ`, with the two
conjugation lemmas its construction needs.

---

`Z` is the standard real-valued function on the critical line: it has the same
modulus as `ζ (1/2 + i t)`, so its sign changes locate zeros of `ζ` on the line.
It is a standard object for formulating and proving results about zeros on the
critical line, and Mathlib currently has no way to talk about such a zero
directly.

The `Critical line theorem` entry in `docs/1000.yaml` carries no `decl:`, so
this is an area the library has recorded as wanted. This PR is not that theorem;
it is foundational infrastructure toward it, and the dependency chain is what
gives the three commits their shape: a critical line theorem is naturally
formulated using `Z`, `Z` needs conjugation symmetry for the completed zeta
function, and that needs conjugation symmetry for the Deligne archimedean
factors. Hence, in order:

1. `Complex.Gammaℝ_conj`, `Complex.Gammaℂ_conj` in `Gamma/Deligne.lean`, which
   currently has no conjugation lemma for either Deligne factor.
2. `completedRiemannZeta_conj` in `ZetaAsymp.lean`, next to `riemannZeta_conj`.
   For `0 < re s` it follows from `riemannZeta_conj` and `Gammaℝ_conj`; the
   other half-plane follows from `completedRiemannZeta_one_sub` applied to
   `1 - s`, which also covers the junk values at `0` and `1`.
3. `Mathlib/NumberTheory/LSeries/HardyZ.lean`, the definition and its API:
   `abs_hardyZ`, `hardyZ_neg`, `hardyZ_eq_zero_iff`, `continuous_hardyZ`,
   `ofReal_hardyZ`.

**On the choice of definition.** The textbook definition is
`Z t = exp (I * ϑ t) * ζ (1/2 + i t)`, with `ϑ` the Riemann–Siegel theta
function. That needs a continuous branch of `log Γ` along the critical line,
which Mathlib does not have, and the branch bookkeeping is most of the work.
Dividing `Λ` by the modulus of its archimedean factor gives the same function
without mentioning a branch: `Λ (1/2 + i t)` is real by `completedRiemannZeta_conj`
and `completedRiemannZeta_one_sub`, and `‖Γ_ℝ (1/2 + i t)‖` is a positive real.
Since `Γ_ℝ (1/2 + it) = π ^ (-1/4) * π ^ (-it/2) * Γ (1/4 + it/2)`, where the
first factor is a positive real and the second has modulus `1`, the quotient is
exactly `exp (I * ϑ t) * ζ (1/2 + i t)`; the module docstring spells this out.
`ϑ` itself can follow later.

I chose `ℝ → ℝ` because it is what the literature means by `Z` and it makes the
intermediate value theorem directly applicable. I raised this signature question
on Zulip in `#mathlib4` on 6 August and would still welcome opinions on it.

## Use of AI

I used Claude (Anthropic), via Claude Code. The mathematical route, defining
`Z` from `Λ` rather than from `exp (I ϑ) ζ`, to avoid the logarithm branch, is
one I worked out in my own research repository before this Lean was written, and that earlier Lean was also AI-assisted. Claude wrote most of the
proofs from that plan for this PR and found that the divisor is exactly `‖Γ_ℝ (1/2 + i t)‖`
rather than the expanded `π ^ (-1/4) * ‖Γ (1/4 + i t / 2)‖`, split the two
general lemmas out into their proper files, and adapted everything to house
style. I set the goal and the design, chose the file layout and the names, and
reviewed the result.

Builds against master with no errors or warnings; `lake exe lint-style` is clean
and `#lint` reports no errors.