### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Matrix): diagonal matrices with nonnegative entries are totally nonnegative

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyNonneg.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyNonneg.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies
 module
 
 public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Finset
 
 /-!
 # Totally nonnegative matrices
@@ -24,6 +25,8 @@ This file defines totally nonnegative matrices and provides basic API for them.
 - `Matrix.IsTotallyNonneg.nonneg`: any entry of a totally nonnegative matrix is nonnegative.
 - `Matrix.IsTotallyNonneg.zero`: the zero matrix is totally nonnegative.
 - `Matrix.IsTotallyNonneg.one`: the identity matrix is totally nonnegative.
+- `Matrix.IsTotallyNonneg.diagonal`: a diagonal matrix with nonnegative diagonal entries is totally
+  nonnegative.
 - `Matrix.IsTotallyNonneg.smul`: a nonnegative scalar multiple of a totally nonnegative matrix
   is totally nonnegative.
 -/
@@ -52,19 +55,31 @@ lemma IsTotallyNonneg.nonneg (hM : M.IsTotallyNonneg) (i j : ι) : 0 ≤ M i j :
 variable [IsStrictOrderedRing R]
 
 @[simp] protected lemma IsTotallyNonneg.zero : (0 : Matrix ι ι R).IsTotallyNonneg
-  | 0 => by grind [det_fin_zero]
+  | 0 => by simp [det_fin_zero]
   | n + 1 => by simp
 
-@[simp] protected lemma IsTotallyNonneg.one [DecidableEq ι] :
-    (1 : Matrix ι ι R).IsTotallyNonneg := by
+/-- A diagonal matrix with nonnegative diagonal entries is totally nonnegative. -/
+protected lemma IsTotallyNonneg.diagonal [DecidableEq ι] {f : ι → R} (hf : 0 ≤ f) :
+    (diagonal f).IsTotallyNonneg := by
   intro n rows cols hrows hcols
   by_cases h_range : Set.range rows = Set.range cols
-  · simp [hrows.eq_of_range_eq hcols h_range, submatrix_one cols hcols.injective]
+  · rw [hrows.eq_of_range_eq hcols h_range, submatrix_diagonal _ _ hcols.injective,
+        det_diagonal]
+    exact Finset.prod_nonneg fun _ _ ↦ hf _
   · have : ¬(Set.range rows ⊆ Set.range cols) := by
       grind [hrows.injective.range_eq_range_iff_subset]
     obtain ⟨_, ⟨i, _⟩, _⟩ := Set.not_subset.mp this
     have : ∀ j, rows i ≠ cols j := by grind
     simp [det_eq_zero_of_row_eq_zero i, this]
+
+@[simp] protected lemma IsTotallyNonneg.one [DecidableEq ι] :
+    (1 : Matrix ι ι R).IsTotallyNonneg :=
+  IsTotallyNonneg.diagonal zero_le_one
+
+/-- A constant diagonal matrix with a nonnegative diagonal value is totally nonnegative. -/
+lemma IsTotallyNonneg.diagonal_const [DecidableEq ι] {c : R} (hc : 0 ≤ c) :
+    (diagonal (fun _ : ι ↦ c)).IsTotallyNonneg :=
+  IsTotallyNonneg.diagonal fun _ ↦ hc
 
 lemma IsTotallyNonneg.smul {M : Matrix ι ι R}
     (hM : M.IsTotallyNonneg) {c : R} (hc : 0 ≤ c) :

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyNonneg.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyNonneg.lean
@@ -52,10 +52,10 @@ lemma IsTotallyNonneg.nonneg (hM : M.IsTotallyNonneg) (i j : ι) : 0 ≤ M i j :
   have hcols : StrictMono ![j] := fun _ _ _ ↦ by lia
   grind [det_unique, submatrix_apply, const_fin1_eq, hM hrows hcols]
 
-variable [IsStrictOrderedRing R]
+variable [IsOrderedRing R]
 
 @[simp] protected lemma IsTotallyNonneg.zero : (0 : Matrix ι ι R).IsTotallyNonneg
-  | 0 => by simp [det_fin_zero]
+  | 0 => by simp
   | n + 1 => by simp
 
 /-- A diagonal matrix with nonnegative diagonal entries is totally nonnegative. -/
@@ -63,8 +63,7 @@ protected lemma IsTotallyNonneg.diagonal [DecidableEq ι] {f : ι → R} (hf : 0
     (diagonal f).IsTotallyNonneg := by
   intro n rows cols hrows hcols
   by_cases h_range : Set.range rows = Set.range cols
-  · rw [hrows.eq_of_range_eq hcols h_range, submatrix_diagonal _ _ hcols.injective,
-        det_diagonal]
+  · rw [hrows.eq_of_range_eq hcols h_range, submatrix_diagonal _ _ hcols.injective, det_diagonal]
     exact Finset.prod_nonneg fun _ _ ↦ hf _
   · have : ¬(Set.range rows ⊆ Set.range cols) := by
       grind [hrows.injective.range_eq_range_iff_subset]
@@ -72,14 +71,13 @@ protected lemma IsTotallyNonneg.diagonal [DecidableEq ι] {f : ι → R} (hf : 0
     have : ∀ j, rows i ≠ cols j := by grind
     simp [det_eq_zero_of_row_eq_zero i, this]
 
+@[simp] lemma isTotallyNonneg_diagonal_iff [DecidableEq ι] {f : ι → R} :
+    (diagonal f).IsTotallyNonneg ↔ 0 ≤ f :=
+  ⟨fun hM i ↦ by simpa using hM.nonneg i i, .diagonal⟩
+
 @[simp] protected lemma IsTotallyNonneg.one [DecidableEq ι] :
     (1 : Matrix ι ι R).IsTotallyNonneg :=
   IsTotallyNonneg.diagonal zero_le_one
-
-/-- A constant diagonal matrix with a nonnegative diagonal value is totally nonnegative. -/
-lemma IsTotallyNonneg.diagonal_const [DecidableEq ι] {c : R} (hc : 0 ≤ c) :
-    (diagonal (fun _ : ι ↦ c)).IsTotallyNonneg :=
-  IsTotallyNonneg.diagonal fun _ ↦ hc
 
 lemma IsTotallyNonneg.smul {M : Matrix ι ι R}
     (hM : M.IsTotallyNonneg) {c : R} (hc : 0 ≤ c) :


### PR DESCRIPTION
---
This follow-up PR was suggested by @Vierkantor in https://github.com/leanprover-community/mathlib4/pull/41813#discussion_r3602246957.

This contribution was created during "Formalizing Mathematics in Lean" held in Utrecht in August 2026.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
