### PR TITLE
[Merged by Bors] - chore(CategoryTheory/EssentiallySmall): lower priority of the Category (Shrink C) instance

### DIFF
--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -206,7 +206,10 @@ end ShrinkHoms
 
 namespace Shrink
 
-noncomputable instance [Small.{w} C] : Category.{v} (Shrink.{w} C) :=
+/- The priority is lower than that of `Preorder.smallCategory`: when `C` is a small preorder,
+`Shrink.{w} C` then gets its category structure from `Preorder (Shrink.{w} C)`
+(see `Mathlib/Order/Shrink.lean`), with morphisms in `Type w` rather than in `Type v`. -/
+noncomputable instance (priority := 50) [Small.{w} C] : Category.{v} (Shrink.{w} C) :=
   inferInstanceAs (Category (InducedCategory _ (equivShrink C).symm))
 
 /-- The categorical equivalence between `C` and `Shrink C`, when `C` is small. -/


### PR DESCRIPTION
Lower the priority of the induced Category (Shrink C) instance below Preorder.smallCategory, so a small preorder's Shrink gets its category structure from its preorder, with morphisms in Type w rather than Type v.


See #42925