### PR TITLE
feat: add `List.Pairwise.orderedInsert'`, `List.sortedLE_orderedInsert_LT`, and `List.sortedGE_orderedInsert_GT`

### DIFF
--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -196,21 +196,27 @@ theorem Sublist.orderedInsert_sublist [IsTrans α r] {as bs} (x) (hs : as <+ bs)
       · simp_all
       · exact .cons_cons _ <| orderedInsert_sublist x ‹as <+ bs› hb.of_cons
 
+omit s in -- `s` has type `β → β → Prop`, but we need `α → α → Prop`
+omit [DecidableRel r] in
+/-- If a list `l` satisfies a pairwise relation `r`, then `List.orderedInsert l s a` will preserve
+that relation if `s` satisfies `∀ x y : α, (s y x → s x y) → r x y`. -/
+theorem Pairwise.orderedInsert'
+    {s : α → α → Prop}
+    [DecidableRel s] [IsTrans α r]
+    {l : List α} {a : α}
+    (h : ∀ x y : α, (s y x → s x y) → r x y) :
+    Pairwise r l ↔ Pairwise r (l.orderedInsert s a) := by
+  constructor
+  · intro h'
+    cases h' <;> grind [IsTrans, cons, mem_orderedInsert s, orderedInsert' h]
+  · exact sublist (sublist_orderedInsert a l)
+
 section TotalAndTransitive
 
 variable [Std.Total r] [IsTrans α r]
 
-theorem Pairwise.orderedInsert (a : α) : ∀ l, Pairwise r l → Pairwise r (orderedInsert r a l)
-  | [], _ => pairwise_singleton _ a
-  | b :: l, h => by
-    by_cases h' : a ≼ b
-    · grind
-    · suffices ∀ b' : α, b' ∈ List.orderedInsert r a l → r b b' by
-        simpa [orderedInsert_cons, h', h.of_cons.orderedInsert a l]
-      intro b' bm
-      rcases (mem_orderedInsert r).mp bm with rfl | bm
-      · exact (total_of r _ _).resolve_left h'
-      · exact rel_of_pairwise_cons h bm
+theorem Pairwise.orderedInsert (a : α) : ∀ l, Pairwise r l → Pairwise r (orderedInsert r a l) := by
+  grind [orderedInsert', total_of r]
 
 variable (r)
 
@@ -609,6 +615,20 @@ protected alias ⟨SortedGT.map_toDual, SortedLT.of_map_toDual⟩ := sortedGT_ma
 end ToDual
 
 end Dual
+
+section OrderedInsert
+
+variable [DecidableLT α] [@Std.Total α LE.le]
+
+theorem sortedLE_orderedInsert_LT {a : α} :
+    SortedLE l ↔ SortedLE (l.orderedInsert (· < ·) a) := by
+  grind [Pairwise.orderedInsert', lt_iff_le_not_ge, Std.Total]
+
+theorem sortedGE_orderedInsert_GT {a : α} :
+    SortedGE l ↔ SortedGE (l.orderedInsert (· > ·) a) := by
+  grind [Pairwise.orderedInsert', lt_iff_le_not_ge, Std.Total]
+
+end OrderedInsert
 
 end Preorder
 


### PR DESCRIPTION
Introduce a generalized `Pairwise.orderedInsert'` lemma to prove that `Pairwise r l` is maintained after performing an `orderedInsert` using a relation stronger than `r` under certain conditions. Prove `sortedLE_orderedInsert_LT`, showing that `l.orderedInsert (· < ·) a` preserves `SortedLE` for decidable total preorders (analogously for `sortedGE_orderedInsert_GT`). This is useful for inserting an element into a sorted list *behind* any other elements which compare equal.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I was hoping to avoid `omit`, but that would require moving all of `Pairwise.orderedInsert'`, `Pairwise.orderedInsert`, `pairwise_insertionSort`, `sublist_insertionSort'`, `pair_sublist_insertionSort'`, and `mergeSort_eq_insertionSort`  after `end sort` on line 365 and reintroducing all the section variables. I also considered moving `Pairwise.orderedInsert'` somewhere _before_ `variable {α β : Type*} (r : α → α → Prop) (s : β → β → Prop)` on line 30, but that would place it before `orderedInsert` is defined. "Omit" seemed like the least invasive approach.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
