### PR TITLE
feat(LinearAlgebra/Matrix): the transpose of a totally nonnegative matrix is totally nonnegative

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyNonneg.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyNonneg.lean
@@ -52,11 +52,11 @@ lemma IsTotallyNonneg.nonneg (hM : M.IsTotallyNonneg) (i j : ι) : 0 ≤ M i j :
   grind [det_unique, submatrix_apply, const_fin1_eq, hM hrows hcols]
 
 protected lemma IsTotallyNonneg.transpose (hM : M.IsTotallyNonneg) :
-    M.transpose.IsTotallyNonneg := fun _ _ _ hrows hcols ↦ by
-  simp [← transpose_submatrix, det_transpose, hM hcols hrows]
+    Mᵀ.IsTotallyNonneg := fun _ _ _ hrows hcols ↦ by
+  simp [← transpose_submatrix, hM hcols hrows]
 
 @[simp] theorem isTotallyNonneg_transpose_iff :
-    M.transpose.IsTotallyNonneg ↔ M.IsTotallyNonneg := ⟨(·.transpose), (·.transpose)⟩
+    Mᵀ.IsTotallyNonneg ↔ M.IsTotallyNonneg := ⟨(·.transpose), (·.transpose)⟩
 
 variable [IsStrictOrderedRing R]
 

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyNonneg.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyNonneg.lean
@@ -26,6 +26,8 @@ This file defines totally nonnegative matrices and provides basic API for them.
 - `Matrix.IsTotallyNonneg.one`: the identity matrix is totally nonnegative.
 - `Matrix.IsTotallyNonneg.smul`: a nonnegative scalar multiple of a totally nonnegative matrix
   is totally nonnegative.
+- `Matrix.IsTotallyNonneg.transpose`: the transpose of a totally nonnegative matrix is totally
+  nonnegative.
 -/
 public section
 
@@ -48,6 +50,13 @@ lemma IsTotallyNonneg.nonneg (hM : M.IsTotallyNonneg) (i j : ι) : 0 ≤ M i j :
   have hrows : StrictMono ![i] := fun _ _ _ ↦ by lia
   have hcols : StrictMono ![j] := fun _ _ _ ↦ by lia
   grind [det_unique, submatrix_apply, const_fin1_eq, hM hrows hcols]
+
+protected lemma IsTotallyNonneg.transpose (hM : M.IsTotallyNonneg) :
+    M.transpose.IsTotallyNonneg := fun _ _ _ hrows hcols ↦ by
+  simp [← transpose_submatrix, det_transpose, hM hcols hrows]
+
+@[simp] theorem isTotallyNonneg_transpose_iff :
+    M.transpose.IsTotallyNonneg ↔ M.IsTotallyNonneg := ⟨(·.transpose), (·.transpose)⟩
 
 variable [IsStrictOrderedRing R]
 


### PR DESCRIPTION

---
This PR continues the development of the basic API for totally nonnegative matrices (context: https://github.com/leanprover-community/mathlib4/pull/41813#discussion_r3602246957).

A matrix is totally nonnegative if all its finite minors have nonnegative determinant.

This contribution was created during "Formalizing Mathematics in Lean" held in Utrecht in August 2026.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
