### PR TITLE
[Merged by Bors] - feat(CategoryTheory): add API for quadrifunctors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2726,6 +2726,7 @@ public import Mathlib.CategoryTheory.Functor.Basic
 public import Mathlib.CategoryTheory.Functor.Category
 public import Mathlib.CategoryTheory.Functor.Const
 public import Mathlib.CategoryTheory.Functor.Currying
+public import Mathlib.CategoryTheory.Functor.CurryingFour
 public import Mathlib.CategoryTheory.Functor.CurryingThree
 public import Mathlib.CategoryTheory.Functor.Derived.Adjunction
 public import Mathlib.CategoryTheory.Functor.Derived.LeftDerived
@@ -2749,6 +2750,7 @@ public import Mathlib.CategoryTheory.Functor.KanExtension.DenseAt
 public import Mathlib.CategoryTheory.Functor.KanExtension.Pointwise
 public import Mathlib.CategoryTheory.Functor.KanExtension.Preserves
 public import Mathlib.CategoryTheory.Functor.OfSequence
+public import Mathlib.CategoryTheory.Functor.Quadrifunctor
 public import Mathlib.CategoryTheory.Functor.ReflectsIso.Balanced
 public import Mathlib.CategoryTheory.Functor.ReflectsIso.Basic
 public import Mathlib.CategoryTheory.Functor.ReflectsIso.Exact

--- a/Mathlib/CategoryTheory/Functor/CurryingFour.lean
+++ b/Mathlib/CategoryTheory/Functor/CurryingFour.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 Dagur Asgeirsson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dagur Asgeirsson
+-/
+module
+
+public import Mathlib.CategoryTheory.Functor.CurryingThree
+public import Mathlib.CategoryTheory.Functor.Quadrifunctor
+public import Mathlib.CategoryTheory.Products.Associator
+
+/-!
+# Currying of functors in four variables
+
+We study the equivalence of categories
+`currying₄ : (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) ≌ C₁ × C₂ × C₃ × C₄ ⥤ E`.
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+namespace Functor
+
+variable {C₁ C₂ C₃ C₄ D₁ D₂ D₃ D₄ E : Type*}
+  [Category* C₁] [Category* C₂] [Category* C₃] [Category* C₄]
+  [Category* D₁] [Category* D₂] [Category* D₃] [Category* D₄] [Category* E]
+
+/-- The equivalence of categories `(C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) ≌ C₁ × C₂ × C₃ × C₄ ⥤ E`
+given by the curryfication of functors in four variables. -/
+def currying₄ : (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) ≌ C₁ × C₂ × C₃ × C₄ ⥤ E :=
+  currying.trans (currying.trans (currying.trans
+    (((prod.associativity (C₁ × C₂) C₃ C₄).trans
+      (prod.associativity C₁ C₂ (C₃ × C₄))).congrLeft)))
+
+/-- Uncurrying a functor in four variables. -/
+abbrev uncurry₄ : (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) ⥤ C₁ × C₂ × C₃ × C₄ ⥤ E :=
+  currying₄.functor
+
+/-- Currying a functor in four variables. -/
+abbrev curry₄ : (C₁ × C₂ × C₃ × C₄ ⥤ E) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E :=
+  currying₄.inverse
+
+/-- Uncurrying functors in four variables gives a fully faithful functor. -/
+def fullyFaithfulUncurry₄ :
+    (uncurry₄ : (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) ⥤ (C₁ × C₂ × C₃ × C₄ ⥤ E)).FullyFaithful :=
+  currying₄.fullyFaithfulFunctor
+
+/-- Currying functors in four variables gives a fully faithful functor. -/
+def fullyFaithfulCurry₄ :
+    (curry₄ : (C₁ × C₂ × C₃ × C₄ ⥤ E) ⥤ (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E)).FullyFaithful :=
+  currying₄.fullyFaithfulInverse
+
+instance : (uncurry₄ : (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) ⥤
+    C₁ × C₂ × C₃ × C₄ ⥤ E).Full :=
+  fullyFaithfulUncurry₄.full
+
+instance : (uncurry₄ : (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) ⥤
+    C₁ × C₂ × C₃ × C₄ ⥤ E).Faithful :=
+  fullyFaithfulUncurry₄.faithful
+
+instance : (curry₄ : (C₁ × C₂ × C₃ × C₄ ⥤ E) ⥤
+    C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E).Full :=
+  fullyFaithfulCurry₄.full
+
+instance : (curry₄ : (C₁ × C₂ × C₃ × C₄ ⥤ E) ⥤
+    C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E).Faithful :=
+  fullyFaithfulCurry₄.faithful
+
+@[simp]
+lemma curry₄_obj_map_app_app_app (F : C₁ × C₂ × C₃ × C₄ ⥤ E)
+    {X₁ Y₁ : C₁} (f : X₁ ⟶ Y₁) (X₂ : C₂) (X₃ : C₃) (X₄ : C₄) :
+    ((((curry₄.obj F).map f).app X₂).app X₃).app X₄ =
+      F.map ⟨f, 𝟙 X₂, 𝟙 X₃, 𝟙 X₄⟩ := rfl
+
+@[simp]
+lemma curry₄_obj_obj_map_app_app (F : C₁ × C₂ × C₃ × C₄ ⥤ E)
+    (X₁ : C₁) {X₂ Y₂ : C₂} (f : X₂ ⟶ Y₂) (X₃ : C₃) (X₄ : C₄) :
+    ((((curry₄.obj F).obj X₁).map f).app X₃).app X₄ =
+      F.map ⟨𝟙 X₁, f, 𝟙 X₃, 𝟙 X₄⟩ := rfl
+
+@[simp]
+lemma curry₄_obj_obj_obj_map_app (F : C₁ × C₂ × C₃ × C₄ ⥤ E)
+    (X₁ : C₁) (X₂ : C₂) {X₃ Y₃ : C₃} (f : X₃ ⟶ Y₃) (X₄ : C₄) :
+    ((((curry₄.obj F).obj X₁).obj X₂).map f).app X₄ =
+      F.map ⟨𝟙 X₁, 𝟙 X₂, f, 𝟙 X₄⟩ := rfl
+
+@[simp]
+lemma curry₄_obj_obj_obj_obj_map (F : C₁ × C₂ × C₃ × C₄ ⥤ E)
+    (X₁ : C₁) (X₂ : C₂) (X₃ : C₃) {X₄ Y₄ : C₄} (f : X₄ ⟶ Y₄) :
+    ((((curry₄.obj F).obj X₁).obj X₂).obj X₃).map f =
+      F.map ⟨𝟙 X₁, 𝟙 X₂, 𝟙 X₃, f⟩ := rfl
+
+@[simp]
+lemma curry₄_map_app_app_app_app {F G : C₁ × C₂ × C₃ × C₄ ⥤ E} (f : F ⟶ G)
+    (X₁ : C₁) (X₂ : C₂) (X₃ : C₃) (X₄ : C₄) :
+    ((((curry₄.map f).app X₁).app X₂).app X₃).app X₄ = f.app ⟨X₁, X₂, X₃, X₄⟩ := rfl
+
+set_option backward.isDefEq.respectTransparency.types false in
+set_option backward.defeqAttrib.useBackward true in
+@[simp]
+lemma currying₄_unitIso_hom_app_app_app_app_app (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E)
+    (X₁ : C₁) (X₂ : C₂) (X₃ : C₃) (X₄ : C₄) :
+    ((((currying₄.unitIso.hom.app F).app X₁).app X₂).app X₃).app X₄ = 𝟙 _ := by
+  simp [currying₄, Equivalence.unit]
+
+set_option backward.isDefEq.respectTransparency.types false in
+set_option backward.defeqAttrib.useBackward true in
+@[simp]
+lemma currying₄_unitIso_inv_app_app_app_app_app (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E)
+    (X₁ : C₁) (X₂ : C₂) (X₃ : C₃) (X₄ : C₄) :
+    ((((currying₄.unitIso.inv.app F).app X₁).app X₂).app X₃).app X₄ = 𝟙 _ := by
+  simp [currying₄, Equivalence.unitInv]
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+/-- Given functors `F₁ : C₁ ⥤ D₁`, `F₂ : C₂ ⥤ D₂`, `F₃ : C₃ ⥤ D₃`,
+`F₄ : C₄ ⥤ D₄` and `G : D₁ × D₂ × D₃ × D₄ ⥤ E`, this is the isomorphism between
+`curry₄.obj (F₁.prod (F₂.prod (F₃.prod F₄)) ⋙ G) : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E`
+and `F₁ ⋙ curry₄.obj G ⋙ ((((whiskeringLeft₃ E).obj F₂).obj F₃).obj F₄)`. -/
+@[simps!]
+def curry₄ObjProdComp (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) (F₃ : C₃ ⥤ D₃)
+    (F₄ : C₄ ⥤ D₄) (G : D₁ × D₂ × D₃ × D₄ ⥤ E) :
+    curry₄.obj (F₁.prod (F₂.prod (F₃.prod F₄)) ⋙ G) ≅
+      F₁ ⋙ curry₄.obj G ⋙ ((((whiskeringLeft₃ E).obj F₂).obj F₃).obj F₄) :=
+  NatIso.ofComponents
+    (fun X₁ ↦ NatIso.ofComponents
+      (fun X₂ ↦ NatIso.ofComponents
+        (fun X₃ ↦ NatIso.ofComponents (fun X₄ ↦ Iso.refl _))))
+
+end Functor
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/Quadrifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Quadrifunctor.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 Dagur Asgeirsson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dagur Asgeirsson
+-/
+module
+
+public import Mathlib.CategoryTheory.Functor.Trifunctor
+public import Mathlib.CategoryTheory.Whiskering
+/-!
+# Quadrifunctors obtained by composition of multifunctors
+
+Given a bifunctor `F : C₁ ⥤ C₂₃₄ ⥤ E` and a trifunctor
+`G : C₂ ⥤ C₃ ⥤ C₄ ⥤ C₂₃₄`, we define the quadrifunctor
+`trifunctorComp₂₃₄ F G : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E`.
+
+Similarly, given a trifunctor `F : C₁ ⥤ C₂ ⥤ C₃₄ ⥤ E` and a bifunctor
+`G : C₃ ⥤ C₄ ⥤ C₃₄`, we define the quadrifunctor
+`trifunctorComp₃₄ F G : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E`.
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+variable {C₁ C₂ C₃ C₄ C₂₃₄ C₃₄ E : Type*}
+  [Category* C₁] [Category* C₂] [Category* C₃] [Category* C₄]
+  [Category* C₂₃₄] [Category* C₃₄] [Category* E]
+
+section trifunctorComp₂₃₄Functor
+
+set_option backward.defeqAttrib.useBackward true in
+/-- Given a bifunctor `F : C₁ ⥤ C₂₃₄ ⥤ E` and a trifunctor
+`G : C₂ ⥤ C₃ ⥤ C₄ ⥤ C₂₃₄`, this is the quadrifunctor `C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E`
+obtained by composition. -/
+@[simps]
+def trifunctorComp₂₃₄ (F : C₁ ⥤ C₂₃₄ ⥤ E) (G : C₂ ⥤ C₃ ⥤ C₄ ⥤ C₂₃₄) :
+    C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E where
+  obj X₁ := (Functor.postcompose₃.obj (F.obj X₁)).obj G
+  map f := (Functor.postcompose₃.map (F.map f)).app G
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+/-- Auxiliary definition for `trifunctorComp₂₃₄Functor`. -/
+@[simps]
+def trifunctorComp₂₃₄FunctorObj (F : C₁ ⥤ C₂₃₄ ⥤ E) :
+    (C₂ ⥤ C₃ ⥤ C₄ ⥤ C₂₃₄) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E where
+  obj G := trifunctorComp₂₃₄ F G
+  map {G G'} τ :=
+    { app X₁ := (Functor.postcompose₃.obj (F.obj X₁)).map τ
+      naturality X₁ Y₁ f := by
+        ext X₂ X₃ X₄
+        change (F.map f).app (((G.obj X₂).obj X₃).obj X₄) ≫
+            (F.obj Y₁).map ((((τ.app X₂).app X₃).app X₄)) =
+          (F.obj X₁).map ((((τ.app X₂).app X₃).app X₄)) ≫
+            (F.map f).app (((G'.obj X₂).obj X₃).obj X₄)
+        exact ((F.map f).naturality _).symm }
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+/-- Auxiliary definition for `trifunctorComp₂₃₄Functor`. -/
+@[simps]
+def trifunctorComp₂₃₄FunctorMap {F F' : C₁ ⥤ C₂₃₄ ⥤ E} (τ : F ⟶ F') :
+    trifunctorComp₂₃₄FunctorObj (C₂ := C₂) (C₃ := C₃) (C₄ := C₄) F ⟶
+      trifunctorComp₂₃₄FunctorObj F' where
+  app G :=
+    { app X₁ := (Functor.postcompose₃.map (τ.app X₁)).app G
+      naturality X₁ Y₁ f := by
+        ext X₂ X₃ X₄
+        exact NatTrans.congr_app (τ.naturality f) (((G.obj X₂).obj X₃).obj X₄) }
+  naturality G G' σ := by
+    ext X₁ X₂ X₃ X₄
+    exact (τ.app X₁).naturality ((((σ.app X₂).app X₃).app X₄))
+
+/-- The functor
+`(C₁ ⥤ C₂₃₄ ⥤ E) ⥤ (C₂ ⥤ C₃ ⥤ C₄ ⥤ C₂₃₄) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E` which
+sends `F : C₁ ⥤ C₂₃₄ ⥤ E` and `G : C₂ ⥤ C₃ ⥤ C₄ ⥤ C₂₃₄` to
+`trifunctorComp₂₃₄ F G`. -/
+@[simps]
+def trifunctorComp₂₃₄Functor :
+    (C₁ ⥤ C₂₃₄ ⥤ E) ⥤ (C₂ ⥤ C₃ ⥤ C₄ ⥤ C₂₃₄) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E where
+  obj := trifunctorComp₂₃₄FunctorObj
+  map := trifunctorComp₂₃₄FunctorMap
+
+end trifunctorComp₂₃₄Functor
+
+section trifunctorComp₃₄Functor
+
+set_option backward.defeqAttrib.useBackward true in
+/-- Given a trifunctor `F : C₁ ⥤ C₂ ⥤ C₃₄ ⥤ E` and a bifunctor
+`G : C₃ ⥤ C₄ ⥤ C₃₄`, this is the quadrifunctor `C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E`
+obtained by composition. -/
+@[simps]
+def trifunctorComp₃₄ (F : C₁ ⥤ C₂ ⥤ C₃₄ ⥤ E) (G : C₃ ⥤ C₄ ⥤ C₃₄) :
+    C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E where
+  obj X₁ := bifunctorComp₂₃ (F.obj X₁) G
+  map f := (bifunctorComp₂₃Functor.map (F.map f)).app G
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+/-- Auxiliary definition for `trifunctorComp₃₄Functor`. -/
+@[simps]
+def trifunctorComp₃₄FunctorObj (F : C₁ ⥤ C₂ ⥤ C₃₄ ⥤ E) :
+    (C₃ ⥤ C₄ ⥤ C₃₄) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E where
+  obj G := trifunctorComp₃₄ F G
+  map {G G'} τ :=
+    { app X₁ := (bifunctorComp₂₃Functor.obj (F.obj X₁)).map τ
+      naturality X₁ Y₁ f := by
+        ext X₂ X₃ X₄
+        exact (((F.map f).app X₂).naturality (((τ.app X₃).app X₄))).symm }
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+/-- Auxiliary definition for `trifunctorComp₃₄Functor`. -/
+@[simps]
+def trifunctorComp₃₄FunctorMap {F F' : C₁ ⥤ C₂ ⥤ C₃₄ ⥤ E} (τ : F ⟶ F') :
+    trifunctorComp₃₄FunctorObj (C₃ := C₃) (C₄ := C₄) F ⟶
+      trifunctorComp₃₄FunctorObj F' where
+  app G :=
+    { app X₁ := (bifunctorComp₂₃Functor.map (τ.app X₁)).app G
+      naturality X₁ Y₁ f := by
+        ext X₂ X₃ X₄
+        exact NatTrans.congr_app (NatTrans.congr_app (τ.naturality f) X₂)
+          ((G.obj X₃).obj X₄) }
+  naturality G G' σ := by
+    ext X₁ X₂ X₃ X₄
+    exact ((τ.app X₁).app X₂).naturality (((σ.app X₃).app X₄))
+
+/-- The functor
+`(C₁ ⥤ C₂ ⥤ C₃₄ ⥤ E) ⥤ (C₃ ⥤ C₄ ⥤ C₃₄) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E` which
+sends `F : C₁ ⥤ C₂ ⥤ C₃₄ ⥤ E` and `G : C₃ ⥤ C₄ ⥤ C₃₄` to
+`trifunctorComp₃₄ F G`. -/
+@[simps]
+def trifunctorComp₃₄Functor :
+    (C₁ ⥤ C₂ ⥤ C₃₄ ⥤ E) ⥤ (C₃ ⥤ C₄ ⥤ C₃₄) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E where
+  obj := trifunctorComp₃₄FunctorObj
+  map := trifunctorComp₃₄FunctorMap
+
+end trifunctorComp₃₄Functor
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -377,8 +377,9 @@ theorem pentagon :
         (associator F (G ⋙ H) K).hom ≫ whiskerLeft F (associator G H K).hom =
       (associator (F ⋙ G) H K).hom ≫ (associator F G (H ⋙ K)).hom := by cat_disch
 
-variable {C₁ C₂ C₃ D₁ D₂ D₃ : Type*} [Category* C₁] [Category* C₂] [Category* C₃]
-  [Category* D₁] [Category* D₂] [Category* D₃] (E : Type*) [Category* E]
+variable {C₁ C₂ C₃ C₄ D₁ D₂ D₃ D₄ : Type*} [Category* C₁] [Category* C₂]
+  [Category* C₃] [Category* C₄] [Category* D₁] [Category* D₂] [Category* D₃]
+  [Category* D₄] (E : Type*) [Category* E]
 
 /-- The obvious functor `(C₁ ⥤ D₁) ⥤ (C₂ ⥤ D₂) ⥤ (D₁ ⥤ D₂ ⥤ E) ⥤ (C₁ ⥤ C₂ ⥤ E)`. -/
 @[simps!, implicit_reducible]
@@ -445,6 +446,87 @@ def whiskeringLeft₃ :
   obj F₁ := whiskeringLeft₃Obj C₂ C₃ D₂ D₃ E F₁
   map τ₁ := whiskeringLeft₃Map C₂ C₃ D₂ D₃ E τ₁
 
+/-- Auxiliary definition for `whiskeringLeft₄`. -/
+@[implicit_reducible, simps!]
+def whiskeringLeft₄ObjObjObjObj (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂)
+    (F₃ : C₃ ⥤ D₃) (F₄ : C₄ ⥤ D₄) :
+    (D₁ ⥤ D₂ ⥤ D₃ ⥤ D₄ ⥤ E) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E :=
+  (whiskeringRight _ _ _).obj ((((whiskeringLeft₃ E).obj F₂).obj F₃).obj F₄) ⋙
+    (whiskeringLeft C₁ D₁ _).obj F₁
+
+/-- Auxiliary definition for `whiskeringLeft₄`. -/
+@[implicit_reducible, simps]
+def whiskeringLeft₄ObjObjObjMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂)
+    (F₃ : C₃ ⥤ D₃) {F₄ F₄' : C₄ ⥤ D₄} (τ₄ : F₄ ⟶ F₄') :
+    whiskeringLeft₄ObjObjObjObj E F₁ F₂ F₃ F₄ ⟶
+      whiskeringLeft₄ObjObjObjObj E F₁ F₂ F₃ F₄' where
+  app F := whiskerLeft _ (whiskerLeft _ ((((whiskeringLeft₃ E).obj F₂).obj F₃).map τ₄))
+
+variable (C₄ D₄) in
+/-- Auxiliary definition for `whiskeringLeft₄`. -/
+@[implicit_reducible, simps]
+def whiskeringLeft₄ObjObjObj (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) (F₃ : C₃ ⥤ D₃) :
+    (C₄ ⥤ D₄) ⥤ (D₁ ⥤ D₂ ⥤ D₃ ⥤ D₄ ⥤ E) ⥤
+      (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) where
+  obj F₄ := whiskeringLeft₄ObjObjObjObj E F₁ F₂ F₃ F₄
+  map τ₄ := whiskeringLeft₄ObjObjObjMap E F₁ F₂ F₃ τ₄
+
+variable (C₄ D₄) in
+/-- Auxiliary definition for `whiskeringLeft₄`. -/
+@[implicit_reducible, simps]
+def whiskeringLeft₄ObjObjMap (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂)
+    {F₃ F₃' : C₃ ⥤ D₃} (τ₃ : F₃ ⟶ F₃') :
+    whiskeringLeft₄ObjObjObj C₄ D₄ E F₁ F₂ F₃ ⟶
+      whiskeringLeft₄ObjObjObj C₄ D₄ E F₁ F₂ F₃' where
+  app F₄ := whiskerRight
+    ((whiskeringRight _ _ _).map ((((whiskeringLeft₃ E).obj F₂).map τ₃).app F₄)) _
+
+variable (C₃ C₄ D₃ D₄) in
+/-- Auxiliary definition for `whiskeringLeft₄`. -/
+@[implicit_reducible, simps]
+def whiskeringLeft₄ObjObj (F₁ : C₁ ⥤ D₁) (F₂ : C₂ ⥤ D₂) :
+    (C₃ ⥤ D₃) ⥤ (C₄ ⥤ D₄) ⥤ (D₁ ⥤ D₂ ⥤ D₃ ⥤ D₄ ⥤ E) ⥤
+      (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) where
+  obj F₃ := whiskeringLeft₄ObjObjObj C₄ D₄ E F₁ F₂ F₃
+  map τ₃ := whiskeringLeft₄ObjObjMap C₄ D₄ E F₁ F₂ τ₃
+
+variable (C₃ C₄ D₃ D₄) in
+/-- Auxiliary definition for `whiskeringLeft₄`. -/
+@[implicit_reducible, simps]
+def whiskeringLeft₄ObjMap (F₁ : C₁ ⥤ D₁) {F₂ F₂' : C₂ ⥤ D₂} (τ₂ : F₂ ⟶ F₂') :
+    whiskeringLeft₄ObjObj C₃ C₄ D₃ D₄ E F₁ F₂ ⟶
+      whiskeringLeft₄ObjObj C₃ C₄ D₃ D₄ E F₁ F₂' where
+  app F₃ :=
+    { app F₄ := whiskerRight
+        ((whiskeringRight _ _ _).map ((((whiskeringLeft₃ E).map τ₂).app F₃).app F₄)) _ }
+
+variable (C₂ C₃ C₄ D₂ D₃ D₄) in
+/-- Auxiliary definition for `whiskeringLeft₄`. -/
+@[implicit_reducible, simps]
+def whiskeringLeft₄Obj (F₁ : C₁ ⥤ D₁) :
+    (C₂ ⥤ D₂) ⥤ (C₃ ⥤ D₃) ⥤ (C₄ ⥤ D₄) ⥤
+      (D₁ ⥤ D₂ ⥤ D₃ ⥤ D₄ ⥤ E) ⥤ (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) where
+  obj F₂ := whiskeringLeft₄ObjObj C₃ C₄ D₃ D₄ E F₁ F₂
+  map τ₂ := whiskeringLeft₄ObjMap C₃ C₄ D₃ D₄ E F₁ τ₂
+
+variable (C₂ C₃ C₄ D₂ D₃ D₄) in
+/-- Auxiliary definition for `whiskeringLeft₄`. -/
+@[implicit_reducible, simps]
+def whiskeringLeft₄Map {F₁ F₁' : C₁ ⥤ D₁} (τ₁ : F₁ ⟶ F₁') :
+    whiskeringLeft₄Obj C₂ C₃ C₄ D₂ D₃ D₄ E F₁ ⟶
+      whiskeringLeft₄Obj C₂ C₃ C₄ D₂ D₃ D₄ E F₁' where
+  app F₂ := { app F₃ := { app F₄ := whiskerLeft _ ((whiskeringLeft _ _ _).map τ₁) } }
+
+/-- The obvious functor
+`(C₁ ⥤ D₁) ⥤ (C₂ ⥤ D₂) ⥤ (C₃ ⥤ D₃) ⥤ (C₄ ⥤ D₄) ⥤`
+`(D₁ ⥤ D₂ ⥤ D₃ ⥤ D₄ ⥤ E) ⥤ (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E)`. -/
+@[simps!, implicit_reducible]
+def whiskeringLeft₄ :
+    (C₁ ⥤ D₁) ⥤ (C₂ ⥤ D₂) ⥤ (C₃ ⥤ D₃) ⥤ (C₄ ⥤ D₄) ⥤
+      (D₁ ⥤ D₂ ⥤ D₃ ⥤ D₄ ⥤ E) ⥤ (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) where
+  obj F₁ := whiskeringLeft₄Obj C₂ C₃ C₄ D₂ D₃ D₄ E F₁
+  map τ₁ := whiskeringLeft₄Map C₂ C₃ C₄ D₂ D₃ D₄ E τ₁
+
 variable {E}
 
 /-- The "postcomposition" with a functor `E ⥤ E'` gives a functor
@@ -460,6 +542,14 @@ def postcompose₂ {E' : Type*} [Category* E'] :
 def postcompose₃ {E' : Type*} [Category* E'] :
     (E ⥤ E') ⥤ (C₁ ⥤ C₂ ⥤ C₃ ⥤ E) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ E' :=
   whiskeringRight C₃ _ _ ⋙ whiskeringRight C₂ _ _ ⋙ whiskeringRight C₁ _ _
+
+/-- The "postcomposition" with a functor `E ⥤ E'` gives a functor
+`(E ⥤ E') ⥤ (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E'`. -/
+@[simps!, implicit_reducible]
+def postcompose₄ {E' : Type*} [Category* E'] :
+    (E ⥤ E') ⥤ (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ⥤ E' :=
+  whiskeringRight C₄ _ _ ⋙ whiskeringRight C₃ _ _ ⋙ whiskeringRight C₂ _ _ ⋙
+    whiskeringRight C₁ _ _
 
 end Functor
 


### PR DESCRIPTION
Adds currying and uncurrying for functors in four variables, together with simultaneous precomposition, postcomposition, and the composition functors needed to build quadrifunctors. The API follows the existing bifunctor and trifunctor conventions.

---

- [x] depends on: #43867
