### PR TITLE
feat: diffeomorphisms are smooth embeddings

### DIFF
--- a/Mathlib/Geometry/Manifold/Immersion.lean
+++ b/Mathlib/Geometry/Manifold/Immersion.lean
@@ -64,6 +64,7 @@ This shortens the overall argument, as the definition of submersions has the sam
 * `ContMDiffAt.iff_comp_isImmersionAt` and `ContMDiff.iff_comp_isImmersion`: a function `f : M → N`
   is `C^n` (at `x`) if and only if it is continuous (at `x`) and its composition `φ ∘ f` with a
   `C^n` immersion `φ : N → P` (at `f x`) is `C^n`.
+* `Diffeomorph.isImmersion`: a diffeomorphism (between the same model with corners) is an immersion
 
 ## Implementation notes
 
@@ -94,7 +95,6 @@ This shortens the overall argument, as the definition of submersions has the sam
   implies `f` is an immersion at `x`.
 * `IsLocalDiffeomorphAt.isImmersionAt` and `IsLocalDiffeomorph.isImmersion`:
   a local diffeomorphism (at `x`) is an immersion (at `x`)
-* `Diffeomorph.isImmersion`: in particular, a diffeomorphism is an immersion
 
 ## References
 
@@ -808,6 +808,16 @@ protected lemma id [IsManifold I n M] : IsImmersionOfComplement PUnit I I n (@id
     rw [(chartAt H x).right_inv (by simp_all), I.right_inv (by simp_all)]
   simpa
 
+/-- A diffeomorphism for the same model with corners is an immersion (with trivial complement). -/
+-- This also holds for local diffeomorphisms (with a more cumbersome proof),
+-- and for arbitrary diffeomorphisms under mild additional hypotheses.
+lemma _root_.Diffeomorph.isImmersionOfComplement
+    {N' : Type*} [TopologicalSpace N'] [ChartedSpace G N'] [IsManifold J n N] [IsManifold J n N']
+    (Φ : Diffeomorph J J N N' n) :
+    IsImmersionOfComplement Unit J J n Φ := by
+  suffices IsImmersionOfComplement Unit J J n (Φ ∘ id) from this.congr (by simp)
+  exact fun x ↦ IsImmersionAtOfComplement.comp_diffeomorph (IsImmersionOfComplement.id x) _
+
 /- The inclusion of an open subset `s` of a smooth manifold `M` is an immersion. -/
 lemma of_opens [IsManifold I n M] (s : TopologicalSpace.Opens M) :
     IsImmersionOfComplement PUnit I I n (Subtype.val : s → M) :=
@@ -945,6 +955,14 @@ lemma comp_diffeomorph {N' : Type*} [TopologicalSpace N'] [ChartedSpace G N'] [I
     IsImmersion I J n (Φ ∘ f) := by
   use h.complement, by infer_instance, by infer_instance
   exact h.isImmersionOfComplement_complement.comp_diffeomorph Φ
+
+/-- A diffeomorphism for the same model with corners is an immersion. -/
+-- This also holds for local diffeomorphisms (with a more cumbersome proof),
+-- and for arbitrary diffeomorphisms under mild additional hypotheses.
+lemma _root_.Diffeomorph.isImmersion
+    {N' : Type*} [TopologicalSpace N'] [ChartedSpace G N'] [IsManifold J n N] [IsManifold J n N']
+    (Φ : Diffeomorph J J N N' n) : IsImmersion J J n Φ :=
+    Φ.isImmersionOfComplement.isImmersion
 
 end IsImmersion
 

--- a/Mathlib/Geometry/Manifold/SmoothEmbedding.lean
+++ b/Mathlib/Geometry/Manifold/SmoothEmbedding.lean
@@ -26,6 +26,8 @@ This will be useful to define embedded submanifolds.
   `Sum.inl : M → M ⊕ N` and `Sum.inr : N → M ⊕ N` are `C^n` embeddings
 * `IsSmoothEmbedding.contMDiff`: if `f` is a `C^n` embedding, it is automatically `C^n`
   in the sense of `ContMDiff`.
+* `Diffeomorph.isSmoothEmbedding`: a diffeomorphism for the same model with corners is a smooth
+  embedding
 
 ## Implementation notes
 
@@ -39,8 +41,9 @@ This will be useful to define embedded submanifolds.
 ## TODO
 * `IsSmoothEmbedding.comp`: the composition of smooth embeddings (between Banach manifolds)
   is a smooth embedding
-* `IsLocalDiffeomorph.isSmoothEmbedding`, `Diffeomorph.isSmoothEmbedding`:
-  a local diffeomorphism (and in particular, a diffeomorphism) is a smooth embedding
+* generalize `Diffeomorph.isSmoothEmbedding` to different models,
+  under good conditions (so we can use `IsDiffImmersionAt`)
+* `IsLocalDiffeomorph.isSmoothEmbedding`: an injective local diffeomorphism is a smooth embedding
 
 -/
 
@@ -113,6 +116,14 @@ lemma sumInr {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M']
 lemma contMDiff (hf : IsSmoothEmbedding I J n f) :
     ContMDiff I J n f :=
   hf.isImmersion.contMDiff
+
+/-- A diffeomorphism for the same model with corners is a smooth embedding. -/
+-- This also holds for injective local diffeomorphisms (with a more cumbersome proof),
+-- and for arbitrary diffeomorphisms under mild additional hypotheses.
+lemma _root_.Diffeomorph.isSmoothEmbedding
+    {N' : Type*} [TopologicalSpace N'] [ChartedSpace G N'] [IsManifold J n N] [IsManifold J n N']
+    (Φ : Diffeomorph J J N N' n) : IsSmoothEmbedding J J n Φ :=
+  ⟨Φ.isImmersion, Φ.toHomeomorph.isEmbedding⟩
 
 end IsSmoothEmbedding
 


### PR DESCRIPTION
This is a direct corollary of a previous PR, so let's include it.

This PR assumes matching models with corners (as the general case is not obviously true).
Using the inverse function theorem instead allows any models, but requires Banach manifolds and conditions on boundary behaviour. This will be added in the future, once the relevant version of the inverse function theorem is merged to mathlib.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
