### PR TITLE
feat(Combinatorics): define network flows

### DIFF
--- a/Mathlib/Combinatorics/Quiver/Flow.lean
+++ b/Mathlib/Combinatorics/Quiver/Flow.lean
@@ -1,0 +1,54 @@
+module
+
+/-
+Copyright (c) 2026 Felix Pernegger,. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Felix Pernegger
+-/
+public import Mathlib.Combinatorics.Quiver.Basic
+public import Mathlib.Data.EReal.Operations
+public import Mathlib.Topology.Algebra.InfiniteSum.Order
+public import Mathlib.Topology.Order.Real
+
+universe u v
+
+@[expose] public section
+
+open NNReal EReal
+
+namespace FlowNetwork
+
+structure PseudoFlow {V : Type u} (G : Quiver.{v} V) (u : {v : V} → {w : V} → G.Hom v w → ℝ≥0) where
+  flow : {v : V} → {w : V} → G.Hom v w → ℝ≥0
+  le_cap {v w : V} (e : G.Hom v w) : flow e ≤ u e
+
+variable {V : Type u} {G : Quiver.{v} V} {u : {v : V} → {w : V} → G.Hom v w → ℝ≥0}
+
+noncomputable def excessAt (N : PseudoFlow G u) (v : V) : EReal :=
+  ∑' w : V, ∑' e : G.Hom w v, (↑(N.flow e) : EReal) -
+    ∑' w : V, ∑' e : G.Hom v w, (↑(N.flow e) : EReal)
+
+structure Flow {V : Type u} {G : Quiver.{v} V} (s t : V) (u : {v : V} → {w : V} → G.Hom v w → ℝ≥0)
+    extends PseudoFlow G u where
+  excessAt_zero' (v : V) :
+    v ≠ s → v ≠ t → ∑' w : V, ∑' e : G.Hom v w, (↑(flow e) : EReal) =
+      ∑' w : V, ∑' e : G.Hom w v, (↑(flow e) : EReal)
+  excessAt_sink_noneg' :
+     ∑' v : V, ∑' e : G.Hom t v, ((flow e) : EReal) ≤
+      ∑' v : V, ∑' e : G.Hom v t, ((flow e) : EReal)
+
+noncomputable def Flow.val {V : Type u} {G : Quiver.{v} V} {s t : V}
+    {u : {v : V} → {w : V} → G.Hom v w → ℝ≥0} (N : Flow s t u) : ENNReal :=
+  (excessAt N.toPseudoFlow t).toENNReal
+
+variable {s t : V}
+
+example : (⊤ : EReal) - ⊤ = ⊥ := by simp only [sub_top]
+
+theorem Flow.excessAt_zero (N : Flow s t u) {v : V} (vs : v ≠ s) (vt : v ≠ t)
+    (hv : ∑' w : V, ∑' e : G.Hom w v, (↑(N.flow e) : EReal) ≠ ⊤) :
+    excessAt N.toPseudoFlow v = 0 := by
+  rw [excessAt, N.excessAt_zero' v vs vt]
+  exact EReal.sub_self hv (LT.lt.ne <| lt_of_lt_of_le bot_lt_zero (by positivity)).symm
+
+end FlowNetwork

--- a/Mathlib/Combinatorics/Quiver/Flow.lean
+++ b/Mathlib/Combinatorics/Quiver/Flow.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 Felix Pernegger,. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Felix Pernegger
 -/
+module
+
 public import Mathlib.Combinatorics.Quiver.Basic
 public import Mathlib.Data.EReal.Operations
 public import Mathlib.Topology.Algebra.InfiniteSum.Order


### PR DESCRIPTION
This PR defines network flows and basic definitions around them https://en.wikipedia.org/wiki/Flow_network

(while I know the basics, I am no expert on this topic and furthermore haven't done graph theory in Lean before, so please take everything with a grain of salt).

It is a tricky question how to define flows correctly and eager to hear suggestions.

I chose to work with quivers ineast of Digraph, since parallel edges are fine. Since min-cost flows dont necessarily need source and sink, I included "PseudoFlow"; only requiring that the flow at each edge is less than the capacity.

One question is, what values the capacities (and flow values) should live in. I dont think negative edge values are ever considered, so we can ignore that.
We could allow capacities (and maybe even flow values?) to be infinite. This is sometimes considered in the literature; but would make the formalisation a lot more messy with relatively little gain. So I put the capicites and edge flows in `NNReal` instead of `ENNReal`.

The excess function is defined with coercions to `EReal` and using `tsum`, to prevent unpleasant junk value surprises.
This is not a perfect solution however; mainly since in `EReal`, `0 \le a - b` is not equivalent to `b \le a` and so on. In particular, the sum of all excess values in a flow do not need to add up to 0. See i.e. `Flow.excessAt_zero`

However, all these issues only matter when we have infinite edges. This [has been considered](https://www.sciencedirect.com/science/article/pii/S0021980070800060), but is probably unimportant to any applications.

Maybe it is also worth to include the notion of a preflow between pseudoflows and (source-sink) flows?

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
