### PR TITLE
feat(Order/RelSeries): change `FiniteDimensional` to allow empty types

### DIFF
--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -700,7 +700,7 @@ lemma krullDim_le_one_iff_of_boundedOrder [BoundedOrder α] :
 
 end PartialOrder
 
-lemma krullDim_eq_length_of_finiteDimensionalOrder [FiniteDimensionalOrder α] :
+lemma krullDim_eq_length_of_finiteDimensionalOrder [FiniteDimensionalOrder α] [Nonempty α] :
     krullDim α = (LTSeries.longestOf α).length :=
   le_antisymm
     (iSup_le <| fun _ ↦ WithBot.coe_le_coe.mpr <| WithTop.coe_le_coe.mpr <|
@@ -776,7 +776,7 @@ lemma coheight_le_krullDim (a : α) : coheight a ≤ krullDim α := by
   simpa using! height_le_krullDim (α := αᵒᵈ) a
 
 @[simp]
-lemma _root_.LTSeries.height_last_longestOf [FiniteDimensionalOrder α] :
+lemma _root_.LTSeries.height_last_longestOf [FiniteDimensionalOrder α] [Nonempty α] :
     height (LTSeries.longestOf α).last = krullDim α := by
   refine le_antisymm (height_le_krullDim _) ?_
   rw [krullDim_eq_length_of_finiteDimensionalOrder, height]
@@ -901,18 +901,20 @@ section finiteDimensional
 variable {α : Type*} [Preorder α]
 
 lemma finiteDimensionalOrder_iff_krullDim_ne_bot_and_top :
-    FiniteDimensionalOrder α ↔ krullDim α ≠ ⊥ ∧ krullDim α ≠ ⊤ := by
+    Nonempty α ∧ FiniteDimensionalOrder α ↔ krullDim α ≠ ⊥ ∧ krullDim α ≠ ⊤ := by
   by_cases h : Nonempty α
-  · simp [← not_infiniteDimensionalOrder_iff, ← krullDim_eq_top_iff]
-  · constructor
-    · exact (fun h1 ↦ False.elim (h (LTSeries.nonempty_of_finiteDimensionalOrder α)))
-    · exact (fun h1 ↦ False.elim (h1.1 (krullDim_eq_bot_iff.mpr (not_nonempty_iff.mp h))))
+  · simp_rw [krullDim_ne_bot_iff, ne_eq, krullDim_eq_top_iff, not_infiniteDimensionalOrder_iff]
+  · refine ⟨fun ⟨hne, _⟩ ↦ absurd hne h, ?_⟩
+    exact (fun h1 ↦ False.elim (h1.1 (krullDim_eq_bot_iff.mpr (not_nonempty_iff.mp h))))
 
-lemma krullDim_ne_bot_of_finiteDimensionalOrder [FiniteDimensionalOrder α] : krullDim α ≠ ⊥ :=
-  (finiteDimensionalOrder_iff_krullDim_ne_bot_and_top.mp ‹_›).1
+lemma krullDim_ne_bot_of_nonempty [Nonempty α] : krullDim α ≠ ⊥ :=
+  krullDim_ne_bot_iff.mpr ‹_›
 
-lemma krullDim_ne_top_of_finiteDimensionalOrder [FiniteDimensionalOrder α] : krullDim α ≠ ⊤ :=
-  (finiteDimensionalOrder_iff_krullDim_ne_bot_and_top.mp ‹_›).2
+@[deprecated (since := "2026-08-21")]
+alias krullDim_ne_bot_of_finiteDimensionalOrder := krullDim_ne_bot_of_nonempty
+
+lemma krullDim_ne_top_of_finiteDimensionalOrder [FiniteDimensionalOrder α] : krullDim α ≠ ⊤ := by
+  rwa [ne_eq, krullDim_eq_top_iff, not_infiniteDimensionalOrder_iff]
 
 lemma coheight_lt_top [FiniteDimensionalOrder α] (x : α) : coheight x < ⊤ := by
   rw [← WithBot.coe_lt_coe]

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -146,7 +146,7 @@ namespace SetRel
 class FiniteDimensional : Prop where
   /-- A relation `r` is said to be finite dimensional iff there is a relation series of `r` with the
   maximum length. -/
-  exists_longest_relSeries : ∃ x : RelSeries r, ∀ y : RelSeries r, y.length ≤ x.length
+  exists_relSeries_length_le : ∃ n, ∀ x : RelSeries r, x.length ≤ n
 
 /-- A relation `r` is said to be infinite dimensional iff there exists relation series of arbitrary
   length. -/
@@ -156,15 +156,31 @@ class InfiniteDimensional : Prop where
   arbitrary length. -/
   exists_relSeries_with_length : ∀ n : ℕ, ∃ x : RelSeries r, x.length = n
 
+instance [IsEmpty α] : FiniteDimensional r where
+  exists_relSeries_length_le := ⟨0, (‹IsEmpty α›.elim <| · 0)⟩
+
+variable {r} in
+theorem finiteDimensional_iff_bddAbove :
+    r.FiniteDimensional ↔ BddAbove {(p.length) | (p : RelSeries r)} where
+  mp h := h.exists_relSeries_length_le.imp fun _ hn _ ⟨p, hp⟩ ↦ hn p |>.trans_eq' hp
+  mpr h := ⟨h.imp fun _ hn p ↦ hn ⟨p, rfl⟩⟩
+
+variable {r} in
+theorem FiniteDimensional.exists_longest_relSeries [r.FiniteDimensional] [Nonempty α] :
+    ∃ x : RelSeries r, ∀ y : RelSeries r, y.length ≤ x.length := by
+  have := finiteDimensional_iff_bddAbove.mp ‹_›
+  have ⟨m, hm⟩ := this.finite.exists_maximal ⟨0, .singleton r <| Classical.arbitrary α, by simp⟩
+  exact hm.prop.imp fun x hx y ↦ hm.le ⟨y, rfl⟩ |>.trans_eq hx.symm
+
 end SetRel
 
 namespace RelSeries
 
 /-- The longest relational series when a relation is finite dimensional -/
-protected noncomputable def longestOf [r.FiniteDimensional] : RelSeries r :=
+protected noncomputable def longestOf [r.FiniteDimensional] [Nonempty α] : RelSeries r :=
   SetRel.FiniteDimensional.exists_longest_relSeries.choose
 
-lemma length_le_length_longestOf [r.FiniteDimensional] (x : RelSeries r) :
+lemma length_le_length_longestOf [r.FiniteDimensional] [Nonempty α] (x : RelSeries r) :
     x.length ≤ (RelSeries.longestOf r).length :=
   SetRel.FiniteDimensional.exists_longest_relSeries.choose_spec _
 
@@ -183,9 +199,9 @@ variable {r} {s : RelSeries r} {x : α}
 lemma nonempty_of_infiniteDimensional [r.InfiniteDimensional] : Nonempty α :=
   ⟨RelSeries.withLength r 0 0⟩
 
-lemma nonempty_of_finiteDimensional [r.FiniteDimensional] : Nonempty α := by
-  obtain ⟨p, _⟩ := (r.finiteDimensional_iff).mp ‹_›
-  exact ⟨p 0⟩
+@[deprecated inferInstance (since := "2026-08-21")]
+lemma nonempty_of_finiteDimensional [r.FiniteDimensional] [Nonempty α] : Nonempty α :=
+  inferInstance
 
 instance membership : Membership α (RelSeries r) :=
   ⟨Function.swap (· ∈ Set.range ·)⟩
@@ -790,34 +806,24 @@ lemma last_drop (p : RelSeries r) (i : Fin (p.length + 1)) : (p.drop i).last = p
 end RelSeries
 
 variable {r} in
-lemma SetRel.not_finiteDimensional_iff [Nonempty α] :
-    ¬ r.FiniteDimensional ↔ r.InfiniteDimensional := by
+lemma SetRel.not_finiteDimensional_iff : ¬ r.FiniteDimensional ↔ r.InfiniteDimensional := by
   rw [finiteDimensional_iff, infiniteDimensional_iff]
   push Not
-  constructor
-  · intro H n
-    induction n with
-    | zero => refine ⟨⟨0, ![_root_.Nonempty.some ‹_›], by simp⟩, by simp⟩
-    | succ n IH =>
-      obtain ⟨l, hl⟩ := IH
-      obtain ⟨l', hl'⟩ := H l
-      exact ⟨l'.take ⟨n + 1, by simpa [hl] using hl'⟩, rfl⟩
-  · intro H l
-    obtain ⟨l', hl'⟩ := H (l.length + 1)
-    exact ⟨l', by simp [hl']⟩
+  refine ⟨fun h n ↦ ?_, fun h n ↦ h (n + 1) |>.imp fun x hx ↦ by simp [hx]⟩
+  have ⟨x, hx⟩ := h n
+  exact ⟨x.take ⟨n, by lia⟩, by simp⟩
 
 variable {r} in
-lemma SetRel.not_infiniteDimensional_iff [Nonempty α] :
-    ¬ r.InfiniteDimensional ↔ r.FiniteDimensional := by
+lemma SetRel.not_infiniteDimensional_iff : ¬ r.InfiniteDimensional ↔ r.FiniteDimensional := by
   rw [← not_finiteDimensional_iff, not_not]
 
-lemma SetRel.finiteDimensional_or_infiniteDimensional [Nonempty α] :
+lemma SetRel.finiteDimensional_or_infiniteDimensional :
     r.FiniteDimensional ∨ r.InfiniteDimensional := by
   rw [← not_finiteDimensional_iff]
   exact em r.FiniteDimensional
 
 instance SetRel.FiniteDimensional.inv [FiniteDimensional r] : FiniteDimensional r.inv :=
-  ⟨.reverse (.longestOf r), fun s ↦ s.reverse.length_le_length_longestOf r⟩
+  ⟨FiniteDimensional.exists_relSeries_length_le (r := r) |>.imp fun _ h x ↦ h x.reverse⟩
 
 variable {r} in
 @[simp]
@@ -834,6 +840,8 @@ lemma SetRel.infiniteDimensional_inv : InfiniteDimensional r.inv ↔ InfiniteDim
 
 lemma SetRel.IsWellFounded.inv_of_finiteDimensional [r.FiniteDimensional] :
     r.inv.IsWellFounded := by
+  cases isEmpty_or_nonempty α
+  · apply wellFounded_of_isEmpty
   rw [IsWellFounded, wellFounded_iff_isEmpty_descending_chain]
   refine ⟨fun ⟨f, hf⟩ ↦ ?_⟩
   let s := RelSeries.mk (r := r) ((RelSeries.longestOf r).length + 1) (f ·) (hf ·)
@@ -848,7 +856,7 @@ abbrev FiniteDimensionalOrder (γ : Type*) [Preorder γ] :=
 
 instance FiniteDimensionalOrder.ofUnique (γ : Type*) [Preorder γ] [Unique γ] :
     FiniteDimensionalOrder γ where
-  exists_longest_relSeries := ⟨.singleton _ default, fun x ↦ by
+  exists_relSeries_length_le := ⟨1, fun x ↦ by
     by_contra! r
     exact (x.step ⟨0, by lia⟩).ne <| Subsingleton.elim _ _⟩
 
@@ -867,7 +875,7 @@ abbrev LTSeries := RelSeries {(a, b) : α × α | a < b}
 namespace LTSeries
 
 /-- The longest `<`-series when a type is finite dimensional -/
-protected noncomputable def longestOf [FiniteDimensionalOrder α] : LTSeries α :=
+protected noncomputable def longestOf [FiniteDimensionalOrder α] [Nonempty α] : LTSeries α :=
   RelSeries.longestOf _
 
 /-- A `<`-series with length `n` if the relation is infinite dimensional -/
@@ -882,17 +890,17 @@ protected noncomputable def withLength [InfiniteDimensionalOrder α] (n : ℕ) :
 lemma nonempty_of_infiniteDimensionalOrder [InfiniteDimensionalOrder α] : Nonempty α :=
   ⟨LTSeries.withLength α 0 0⟩
 
-lemma nonempty_of_finiteDimensionalOrder [FiniteDimensionalOrder α] : Nonempty α := by
-  obtain ⟨p, _⟩ := (SetRel.finiteDimensional_iff _).mp ‹_›
-  exact ⟨p 0⟩
+@[deprecated inferInstance (since := "2026-08-21")]
+lemma nonempty_of_finiteDimensionalOrder [FiniteDimensionalOrder α] [Nonempty α] : Nonempty α :=
+  inferInstance
 
 variable {α}
 
-lemma longestOf_is_longest [FiniteDimensionalOrder α] (x : LTSeries α) :
+lemma longestOf_is_longest [FiniteDimensionalOrder α] [Nonempty α] (x : LTSeries α) :
     x.length ≤ (LTSeries.longestOf α).length :=
   RelSeries.length_le_length_longestOf _ _
 
-lemma longestOf_len_unique [FiniteDimensionalOrder α] (p : LTSeries α)
+lemma longestOf_len_unique [FiniteDimensionalOrder α] [Nonempty α] (p : LTSeries α)
     (is_longest : ∀ (q : LTSeries α), q.length ≤ p.length) :
     p.length = (LTSeries.longestOf α).length :=
   le_antisymm (longestOf_is_longest _) (is_longest _)
@@ -1094,16 +1102,16 @@ end LTSeries
 
 end LTSeries
 
-lemma not_finiteDimensionalOrder_iff [Preorder α] [Nonempty α] :
+lemma not_finiteDimensionalOrder_iff [Preorder α] :
     ¬ FiniteDimensionalOrder α ↔ InfiniteDimensionalOrder α :=
   SetRel.not_finiteDimensional_iff
 
-lemma not_infiniteDimensionalOrder_iff [Preorder α] [Nonempty α] :
+lemma not_infiniteDimensionalOrder_iff [Preorder α] :
     ¬ InfiniteDimensionalOrder α ↔ FiniteDimensionalOrder α :=
   SetRel.not_infiniteDimensional_iff
 
 variable (α) in
-lemma finiteDimensionalOrder_or_infiniteDimensionalOrder [Preorder α] [Nonempty α] :
+lemma finiteDimensionalOrder_or_infiniteDimensionalOrder [Preorder α] :
     FiniteDimensionalOrder α ∨ InfiniteDimensionalOrder α :=
   SetRel.finiteDimensional_or_infiniteDimensional _
 

--- a/Mathlib/RingTheory/Ideal/Height.lean
+++ b/Mathlib/RingTheory/Ideal/Height.lean
@@ -186,7 +186,7 @@ lemma Ideal.height_le_ringKrullDim_of_ne_top {I : Ideal R} (h : I ≠ ⊤) :
   refine (WithBot.coe_le_coe.mpr (iInf₂_le _ hP)).trans P.height_le_ringKrullDim_of_isPrime
 
 /-- If `R` has finite Krull dimension, there exists a maximal ideal `m` with `ht m = dim R`. -/
-lemma Ideal.exists_isMaximal_height [FiniteRingKrullDim R] :
+lemma Ideal.exists_isMaximal_height [Nontrivial R] [FiniteRingKrullDim R] :
     ∃ (p : Ideal R), p.IsMaximal ∧ p.height = ringKrullDim R := by
   let l := LTSeries.longestOf (PrimeSpectrum R)
   obtain ⟨m, hm, hle⟩ := l.last.asIdeal.exists_le_maximal IsPrime.ne_top'

--- a/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
+++ b/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
@@ -274,7 +274,7 @@ instance Ideal.finiteHeight_of_isNoetherianRing (I : Ideal R) :
   fun h ↦ Or.inr <| (I.height_le_spanFinrank h).trans_lt (ENat.natCast_lt_top _)
 
 instance [IsLocalRing R] : FiniteRingKrullDim R := by
-  apply finiteRingKrullDim_iff_ne_bot_and_top.mpr
+  refine finiteRingKrullDim_iff_ne_bot_and_top.mpr ?_ |>.right
   rw [← IsLocalRing.maximalIdeal_height_eq_ringKrullDim]
   constructor
   · exact WithBot.coe_ne_bot

--- a/Mathlib/RingTheory/KrullDimension/Basic.lean
+++ b/Mathlib/RingTheory/KrullDimension/Basic.lean
@@ -75,8 +75,7 @@ theorem ringKrullDim_eq_of_ringEquiv (e : R ≃+* S) :
 
 alias RingEquiv.ringKrullDim := ringKrullDim_eq_of_ringEquiv
 
-/-- A ring has finite Krull dimension if its `PrimeSpectrum` is
-finite-dimensional (and non-empty). -/
+/-- A ring has finite Krull dimension if its `PrimeSpectrum` is finite-dimensional. -/
 abbrev FiniteRingKrullDim (R : Type*) [CommSemiring R] :=
   FiniteDimensionalOrder (PrimeSpectrum R)
 
@@ -86,16 +85,19 @@ lemma ringKrullDim_ne_top [FiniteRingKrullDim R] :
 lemma ringKrullDim_lt_top [FiniteRingKrullDim R] :
     ringKrullDim R < ⊤ := ringKrullDim_ne_top.lt_top
 
-lemma ringKrullDim_ne_bot [FiniteRingKrullDim R] :
-    ringKrullDim R ≠ ⊥ := krullDim_ne_bot_of_finiteDimensionalOrder
+lemma ringKrullDim_ne_bot [Nontrivial R] :
+    ringKrullDim R ≠ ⊥ := krullDim_ne_bot_of_nonempty
 
 lemma finiteRingKrullDim_iff_ne_bot_and_top :
-    FiniteRingKrullDim R ↔ (ringKrullDim R ≠ ⊥ ∧ ringKrullDim R ≠ ⊤) :=
-  (Order.finiteDimensionalOrder_iff_krullDim_ne_bot_and_top (α := PrimeSpectrum R))
-
-lemma Nontrivial.of_finiteRingKrullDim [FiniteRingKrullDim R] : Nontrivial R := by
+    Nontrivial R ∧ FiniteRingKrullDim R ↔ ringKrullDim R ≠ ⊥ ∧ ringKrullDim R ≠ ⊤ := by
   rw [← PrimeSpectrum.nonempty_iff_nontrivial]
-  exact LTSeries.nonempty_of_finiteDimensionalOrder _
+  exact finiteDimensionalOrder_iff_krullDim_ne_bot_and_top
+
+lemma Nontrivial.of_nonempty_primeSpectrum [Nonempty (PrimeSpectrum R)] : Nontrivial R :=
+  PrimeSpectrum.nonempty_iff_nontrivial.mp ‹_›
+
+@[deprecated (since := "2026-08-21")]
+alias Nontrivial.of_finiteRingKrullDim := Nontrivial.of_nonempty_primeSpectrum
 
 section Zero
 


### PR DESCRIPTION
This also means that the zero ring is now `FiniteRingKrullDim`, and that `Empty` is `FiniteDimensionalOrder`.

[#mathlib4 > Should zero ring be finite-dimensional?](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Should.20zero.20ring.20be.20finite-dimensional.3F/with/495871110)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
