### PR TITLE
[Merged by Bors] - chore: deprecate `Mathlib.Data.Finite.Vector`

### DIFF
--- a/Mathlib/Data/Finite/Vector.lean
+++ b/Mathlib/Data/Finite/Vector.lean
@@ -3,22 +3,8 @@ Copyright (c) 2022 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-module
+module -- shake: keep-all
 
 public import Mathlib.Data.Fintype.Vector
 
-/-!
-# Finiteness of vector types
--/
-
-public section
-
-variable {α : Type*}
-
-instance List.Vector.finite [Finite α] {n : ℕ} : Finite (Vector α n) := by
-  have := Fintype.ofFinite α
-  infer_instance
-
-instance [Finite α] {n : ℕ} : Finite (Sym α n) := by
-  have := Fintype.ofFinite α
-  infer_instance
+deprecated_module (since := "2026-08-21")

--- a/Mathlib/Data/Set/Finite/List.lean
+++ b/Mathlib/Data/Set/Finite/List.lean
@@ -27,7 +27,7 @@ namespace List
 variable (α : Type*) [Finite α] (n : ℕ)
 
 lemma finite_length_eq : {l : List α | l.length = n}.Finite :=
-  inferInstanceAs <| Finite <| Vector α n
+  inferInstanceAs <| Finite (Vector α n)
 
 lemma finite_length_lt : {l : List α | l.length < n}.Finite := by
   convert! (Finset.range n).finite_toSet.biUnion fun i _ ↦ finite_length_eq α i; ext; simp

--- a/Mathlib/Data/Set/Finite/List.lean
+++ b/Mathlib/Data/Set/Finite/List.lean
@@ -9,7 +9,7 @@ public import Mathlib.Data.Set.Finite.Basic
 public import Mathlib.Data.Set.Finite.Lattice
 public import Mathlib.Data.Set.Finite.Range
 public import Mathlib.Data.Set.Lattice
-public import Mathlib.Data.Finite.Vector
+public import Mathlib.Data.Fintype.Vector
 
 /-!
 # Finiteness of sets of lists
@@ -26,7 +26,8 @@ assert_not_exists IsOrderedRing MonoidWithZero
 namespace List
 variable (α : Type*) [Finite α] (n : ℕ)
 
-lemma finite_length_eq : {l : List α | l.length = n}.Finite := List.Vector.finite
+lemma finite_length_eq : {l : List α | l.length = n}.Finite :=
+  inferInstanceAs <| Finite <| Vector α n
 
 lemma finite_length_lt : {l : List α | l.length < n}.Finite := by
   convert! (Finset.range n).finite_toSet.biUnion fun i _ ↦ finite_length_eq α i; ext; simp


### PR DESCRIPTION
since #38743 merged it into `Mathlib.Data.Fintype.Vector`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
