### PR TITLE
[Merged by Bors] - fix(RepresentationTheory): move `Equiv.coe_invFun` to the correct symm notion to fit the statement as it suggests

### DIFF
--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -382,8 +382,6 @@ def refl : Equiv ρ ρ where
 
 @[simp] lemma coe_toLinearMap : ⇑φ.toLinearMap = φ := rfl
 
-lemma coe_invFun : φ.invFun = φ.symm := rfl
-
 theorem toLinearEquiv_toLinearMap :
   φ.toLinearEquiv.toLinearMap = φ.toIntertwiningMap.toLinearMap := rfl
 
@@ -410,6 +408,8 @@ lemma mk_symm {e : V ≃ₗ[A] W} (he : ∀ g, e ∘ₗ (ρ g) = (σ g) ∘ₗ e
     (mk e he).symm = mk e.symm (e.isIntertwining_symm_isIntertwining he) := rfl
 
 lemma toLinearMap_symm (φ : Equiv ρ σ) : (symm φ).toLinearMap = φ.toLinearEquiv.symm := rfl
+
+lemma coe_invFun : φ.invFun = φ.symm := rfl
 
 lemma coe_symm (φ : Equiv ρ σ) : ⇑φ.toLinearEquiv.symm = φ.symm := rfl
 


### PR DESCRIPTION
The current statement of `lemma coe_invFun : φ.invFun = φ.symm := rfl` actually reads `φ.symm` as`⇑φ.toLinearEquiv.symm`. However the context tends to make `Representation.Equiv` as the simp normal form, not `φ.toLinearEquiv`. We move it to where `Representation.Equiv.symm` has been defined so that the RHS has the correct form to get access to other API lemmas more directly.
