### PR TITLE
chore(ci): cache dependencies in the lake cache shadow pipeline

### DIFF
--- a/.github/workflows/lake_cache_shadow.md
+++ b/.github/workflows/lake_cache_shadow.md
@@ -144,6 +144,16 @@ baseline.
 
 ## Scope qualifiers
 
+Lake requires `--scope` or `--repo` on every put and get against a custom
+endpoint; there is no unscoped form. A scope also bounds where a content hash
+is trusted, because Lake does not use cryptographically secure hashes and
+prefixes uploads to avoid clashes. Each package therefore gets its own
+namespace for its artifacts and its revision files, and the root scope stays
+for mathlib alone. `--repo=<owner>/<package>` would give a scope of that shape,
+and Lake would add the toolchain and the platform to it. It has no place for
+the pin hash, so the pipeline passes the whole string to `--scope`, which Lake
+uses verbatim.
+
 Two qualifiers extend a dependency scope, because the revision alone is not
 exact.
 

--- a/.github/workflows/lake_cache_shadow.md
+++ b/.github/workflows/lake_cache_shadow.md
@@ -8,7 +8,10 @@ no other consumer reads what it produces.
 The pipeline caches the root package, mathlib, and every git dependency in
 mathlib's manifest. In the examples below, `<DEP>` is one dependency, `<R-DEP>`
 is its revision from the manifest, and `<S-DEP>` is its scope,
-`mathlib4-master-shadow/deps/<toolchain-slug>/<pin-hash>/<DEP>`. A rendered
+`mathlib4-master-shadow/deps/<toolchain-slug>/<pin-hash>/<DEP>`. The pin hash
+is a short fingerprint of the revisions that mathlib's manifest pins, and the
+toolchain slug is the toolchain with its punctuation replaced. "Scope
+qualifiers" below covers both, and says why the scope carries them. A rendered
 scope reads
 `mathlib4-master-shadow/deps/leanprover-lean4-v4.34.0-rc2/2d10dd67/batteries`.
 

--- a/.github/workflows/lake_cache_shadow.md
+++ b/.github/workflows/lake_cache_shadow.md
@@ -172,6 +172,33 @@ exact.
 `build_and_stage` derives both and publishes them as job outputs. The `upload`
 and `consume` jobs read them from there.
 
+## What identifies a dependency entry
+
+A dependency's entry in the bucket is its revision file, at
+
+    revisions/<prefix>/deps/<toolchain-slug>/<pin-hash>/<DEP>/<R-DEP>.jsonl
+
+so four things identify it: the dependency, its revision, the toolchain, and
+the pin set of mathlib's manifest. A change to any one of them names a key that
+holds nothing, and the next run exports and uploads that dependency again.
+
+What that means in practice:
+
+- A mathlib commit changes nothing. No dependency entry mentions mathlib's sha,
+  so a run that only moves mathlib finds every dependency in place. This is the
+  steady state, and it uploads no dependency at all.
+- A toolchain bump changes the slug, so every dependency gets a new scope.
+- A dependency bump changes two things: the revision of that dependency, and
+  the pin hash. The pin hash covers the whole manifest, so a bump of one
+  dependency re-keys all of them, and the run rebuilds and re-uploads every
+  dependency. Only the bumped dependency, and any dependency that has it
+  upstream, holds different content. A hash over each dependency's own upstream
+  closure would re-key only those, and leave the rest in place.
+
+Every job runs on Linux, so the scope carries no platform segment. A pipeline
+that built on more than one platform would need one, because the artifacts of a
+package that is not platform-independent differ between them.
+
 ## What a full cache hit requires
 
 Four things are necessary. Without any one of them a fetch returns mappings

--- a/.github/workflows/lake_cache_shadow.md
+++ b/.github/workflows/lake_cache_shadow.md
@@ -1,0 +1,242 @@
+# Lake cache shadow pipeline
+
+`lake_cache_shadow.yml` exercises Lake's built-in artifact cache against the
+live mathlib4 master branch. It runs beside the regular master CI and stays
+independent of it. It writes to an isolated `mathlib4-master-shadow` scope, so
+no other consumer reads what it produces.
+
+The pipeline caches the root package, mathlib, and every git dependency in
+mathlib's manifest. In the examples below, `<DEP>` is one dependency, `<R-DEP>`
+is its revision from the manifest, and `<S-DEP>` is its scope,
+`mathlib4-master-shadow/deps/<toolchain-slug>/<pin-hash>/<DEP>`. A rendered
+scope reads
+`mathlib4-master-shadow/deps/leanprover-lean4-v4.34.0-rc2/2d10dd67/batteries`.
+
+## Jobs
+
+- `build_and_stage` builds mathlib and its dependencies with Lake's artifact
+  cache. It stages the outputs of the root package, and the mappings of each
+  dependency the bucket does not hold.
+- `upload` pushes the staged files to the bucket, once for the root scope and
+  then once per dependency scope. It records a manifest under
+  `analysis/<toolchain-slug>/` and reports the carryover.
+- `consume` fetches the root and dependency outputs into a fresh checkout,
+  builds against them, and verifies the result with `--rehash`.
+- `downstream` creates a small project that depends on mathlib, fetches
+  mathlib and every transitive dependency from the bucket, and requires zero
+  Mathlib rebuilds.
+- `report` posts a summary of the run to Zulip.
+
+## Cache service configuration
+
+Every `lake cache` call passes `--service=shadow`. Each job writes that service
+definition itself, into the file `LAKE_CONFIG` names, because each job runs on
+its own runner:
+
+    [[cache.service]]
+    name = "shadow"
+    type = "s3"
+    artifactEndpoint = "https://pub-<hash>.r2.dev/<prefix>/artifacts"
+    revisionEndpoint = "https://pub-<hash>.r2.dev/<prefix>/revisions"
+
+A job that fetches writes the public read endpoints, as above. The upload job
+writes the authenticated S3 endpoints, and `LAKE_CACHE_KEY` signs its requests.
+A services file is the supported way to configure a cache service, and Lake
+deprecates the endpoint environment variables.
+
+## Push, from a clean cache
+
+Lake's `-o` records the mappings of the workspace root only, so step 3 loads
+each dependency as its own root. Step 1 runs once, and steps 2 to 5 run once
+per dependency.
+
+1. `lake build Mathlib` builds mathlib and every dependency from source, and
+   writes the artifacts into the local Lake cache.
+2. Write `<DEP>-overrides.json`. A `jq` filter reads mathlib's
+   `lake-manifest.json`, drops the entry for `<DEP>` itself, and rewrites each
+   remaining package as a path entry into this checkout. It keeps the `name`,
+   `scope`, `configFile` and `inherited` fields, sets `type` to `path`, and
+   sets `dir` to `.lake/packages/<name>`. For aesop it renders:
+
+       {"version": "1.2.0",
+        "packages": [
+          {"name": "batteries", "scope": "leanprover-community",
+           "configFile": "lakefile.toml", "inherited": false, "type": "path",
+           "dir": "<checkout>/.lake/packages/batteries"},
+          ... one entry per other package ...
+        ]}
+
+   The file pins the dependencies of `<DEP>` to mathlib's. Without it Lake uses
+   the manifest of `<DEP>`, and the mappings never match this workspace's input
+   hashes.
+3. Export: `lake -d .lake/packages/<DEP> build
+   --packages=.lake/dep-plan/<DEP>-overrides.json -o
+   .lake/dep-outputs/<DEP>.jsonl`. This load replays instead of compiling,
+   because step 1 filled the local cache.
+4. Stage: `lake cache stage .lake/dep-outputs/<DEP>.jsonl
+   lake-cache-staging/deps/<DEP>`. Each dependency needs its own directory,
+   because `cache stage` writes one `outputs.jsonl` per directory. The staging
+   tree travels to the `upload` job as a GitHub artifact, because the build
+   runs in a sandbox without the credentials.
+5. Upload: `lake cache put-staged lake-cache-staging/deps/<DEP>
+   --service=shadow --scope=<S-DEP> --rev=<R-DEP>`. Lake PUTs the artifacts
+   first and the revision file last.
+
+## Pull
+
+The `consume` job builds mathlib from the bucket alone. It sets
+`LAKE_NO_CACHE`, so the bucket accounts for every replay.
+
+1. `lake cache get --service=shadow --scope=mathlib4-master-shadow
+   --rev=<mathlib-sha>`.
+2. `lake cache get --service=shadow --package=<DEP> --scope=<S-DEP>
+   --rev=<R-DEP>`, once per dependency, with the revisions from mathlib's
+   manifest.
+3. `lake build Mathlib` replays both.
+
+The `downstream` job runs the same pull for a small project that requires
+mathlib. In that project mathlib is a dependency, so it comes from the root
+scope under its sha. That job derives the scope qualifiers itself, because a
+real downstream project has no access to mathlib's CI outputs.
+
+## What a warm run adds
+
+Four optimizations decide how much a run compiles and uploads. None of them
+changes the keys or the content that a run writes.
+
+- The probe. Before the build, `curl -fsS -o /dev/null
+  "$REVISION_ENDPOINT/<S-DEP>/<R-DEP>.jsonl"` asks whether the bucket already
+  holds this dependency. If it does, steps 2 to 5 skip it. A revision, a
+  toolchain and a pin set determine the content, so a dependency uploads once.
+  Later runs skip it, until a manifest bump or a toolchain bump changes the
+  scope.
+- The root warm start. `lake cache get --service=shadow
+  --scope=mathlib4-master-shadow --rev=<previous-sha>` seeds the local cache
+  from the previous run on this toolchain, so step 1 compiles the churn since
+  that run only. `analysis/<toolchain-slug>/_latest.txt` holds the previous
+  sha.
+- The dependency warm start. `lake cache get --service=shadow --package=<DEP>
+  --scope=<S-DEP> --rev=<R-DEP>` for each dependency the probe found, so step 1
+  replays it instead of compiling it.
+- The legacy cache, for a cold analysis chain only, where no previous run
+  exists to warm start from.
+
+The `--rev` arguments are an optimization too. Without them Lake searches back
+through the ancestors of the checkout's HEAD.
+
+## Storage layout
+
+One bucket holds these keys:
+
+    revisions/mathlib4-master-shadow/<mathlib-sha>.jsonl
+    artifacts/mathlib4-master-shadow/<content-hash>.art
+    revisions/<S-DEP>/<R-DEP>.jsonl
+    artifacts/<S-DEP>/<content-hash>.art
+    analysis/leanprover-lean4-v4.34.0-rc2/_latest.txt
+    analysis/leanprover-lean4-v4.34.0-rc2/<mathlib-sha>.txt
+
+`lake cache get --scope=<SCOPE> --rev=<REV>` reads
+`revisions/<SCOPE>/<REV>.jsonl`, which maps input hashes to artifacts, and
+downloads the `artifacts/<SCOPE>/<content-hash>.art` files it names. Lake does
+not know the `analysis/` prefix; the workflow owns it. `_latest.txt` holds the
+sha the next run warm starts from, and `<mathlib-sha>.txt` holds its carryover
+baseline.
+
+## Scope qualifiers
+
+Two qualifiers extend a dependency scope, because the revision alone is not
+exact.
+
+- The toolchain slug separates the toolchains that build one long-lived
+  revision. It is the toolchain with each character outside `A-Za-z0-9._-`
+  replaced by `-`.
+- The pin hash separates the manifest generations. The input hashes of a
+  dependency cover the artifacts of its upstreams, so a bump of batteries alone
+  changes the correct mappings for aesop but not the revision of aesop. The
+  hash is 8 hex characters over the sorted `<name> <rev>` git entries of
+  mathlib's manifest.
+
+`build_and_stage` derives both and publishes them as job outputs. The `upload`
+and `consume` jobs read them from there.
+
+## What a full cache hit requires
+
+Four things are necessary. Without any one of them a fetch returns mappings
+that do not match, and the modules rebuild.
+
+- The lakefile patch, which lets the workspace write to Lake's artifact cache
+  at all. mathlib does not set `enableArtifactCache` itself yet, so the
+  pipeline injects it.
+- The export build of each dependency, with its `--packages` overrides.
+- The two scope qualifiers.
+- One `lake cache get`, `stage` and `put-staged` call per package. Lake has no
+  workspace-wide form of these against a custom endpoint.
+
+Everything in "What a warm run adds" is speed. A run without those parts writes
+the same keys with the same content, and takes longer.
+
+## Hydration and the legacy cache
+
+A pinned run hydrates from the shadow scope. The root package warm starts from
+the previous run on the toolchain's analysis chain, and each dependency warm
+starts from its own scope. The incremental build then compiles the churn since
+that run.
+
+The legacy cache is a bootstrap fallback. A run uses it only when the analysis
+chain holds no previous run, which happens on a fresh toolchain generation on
+the repo pin. An override run never uses it, because the legacy cache is keyed
+to the repo pin.
+
+## Toolchain override
+
+The `toolchain_override` input, or the `LAKE_SHADOW_TOOLCHAIN_OVERRIDE`
+variable, changes the toolchain of the whole pipeline. `build_and_stage`
+resolves it into its `toolchain` output, and the later jobs stamp that output
+into their checkouts, so every job runs the same lake.
+
+The lean of the override must behave like the repo pin. A Lake change,
+cherry-picked onto the lineage of the pinned release as a pr-release, is a
+valid example. Input hashes cover the toolchain, so all runs share one artifact
+scope safely.
+
+The analysis chain is per toolchain, under `analysis/<slug>/`. A pinned run and
+an override run therefore warm start from their own lineage, and compare
+against it.
+
+The first run on a toolchain misses the legacy cache and every prior root
+artifact, and costs one full source build of the root package. A republished
+pr-release tag costs the same. Dependencies already in the shadow scope for
+that toolchain still replay.
+
+## Dependency skip list
+
+`DEP_SKIP` excludes dependencies from caching, separated by spaces. It is
+empty: the pipeline caches all of them, proofwidgets included. proofwidgets
+commits its npm output and the Lake traces that guard the npm steps, so a build
+at a pinned revision never calls npm.
+
+Every per-dependency step tolerates failure. A miss, or a failed export, makes
+that dependency build from source, and the consume health line reports it. A
+toolchain older than v4.34.0-rc2 has no `cache get --package` and behaves the
+same way.
+
+## Required repository configuration
+
+Secrets:
+
+- `LAKE_CACHE_KEY` — SigV4 credential for the cache bucket, as
+  `<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>` (curl `--user`; region is `auto`).
+- `ZULIP_API_KEY` — Zulip bot key for the `report` job.
+
+Variables:
+
+- `LAKE_CACHE_ARTIFACT_ENDPOINT` and `LAKE_CACHE_REVISION_ENDPOINT` — the
+  authenticated S3 endpoints. The `upload` job PUTs to them. For example
+  `https://<acct>.r2.cloudflarestorage.com/<bucket>/<prefix>/artifacts`.
+- `LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC` and
+  `LAKE_CACHE_REVISION_ENDPOINT_PUBLIC` — the public read endpoints, for
+  anonymous GETs. On R2 these are a different host than the S3 API endpoints.
+  For example `https://pub-<hash>.r2.dev/<prefix>/artifacts`.
+- `LAKE_SHADOW_TOOLCHAIN_OVERRIDE` — optional. It sets the toolchain override
+  for every run. The dispatch input takes precedence. Leave it unset to run on
+  the repo pin.

--- a/.github/workflows/lake_cache_shadow.md
+++ b/.github/workflows/lake_cache_shadow.md
@@ -9,7 +9,8 @@ The pipeline caches the root package, mathlib, and every git dependency in
 mathlib's manifest. In the examples below, `<DEP>` is one dependency, `<R-DEP>`
 is its revision from the manifest, and `<S-DEP>` is its scope,
 `mathlib4-master-shadow/deps/<toolchain-slug>/<pin-hash>/<DEP>`. The pin hash
-is a short fingerprint of the revisions that mathlib's manifest pins, and the
+is a short fingerprint of the revisions that mathlib pins for that
+dependency's upstreams, and the
 toolchain slug is the toolchain with its punctuation replaced. "Scope
 qualifiers" below covers both, and says why the scope carries them. A rendered
 scope reads
@@ -163,11 +164,17 @@ exact.
 - The toolchain slug separates the toolchains that build one long-lived
   revision. It is the toolchain with each character outside `A-Za-z0-9._-`
   replaced by `-`.
-- The pin hash separates the manifest generations. The input hashes of a
-  dependency cover the artifacts of its upstreams, so a bump of batteries alone
-  changes the correct mappings for aesop but not the revision of aesop. The
-  hash is 8 hex characters over the sorted `<name> <rev>` git entries of
-  mathlib's manifest.
+- The pin hash separates the versions of the upstreams a dependency was built
+  against. The input hashes of a dependency cover the artifacts of its
+  upstreams, so a bump of batteries alone changes the correct mappings for
+  aesop but not the revision of aesop. The hash is 8 hex characters over the
+  sorted `<name> <rev>` entries of that dependency's transitive upstreams, as
+  mathlib's manifest pins them. A dependency with no upstream, which is six of
+  the eight today, gets the constant `noup` and never re-keys on another
+  dependency's bump. Where the closure is unknown, because a manifest is
+  missing or names a package this workspace does not pin, the whole manifest is
+  hashed instead: that over-keys, which costs an upload, where under-keying
+  would cost a silent miss.
 
 `build_and_stage` derives both and publishes them as job outputs. The `upload`
 and `consume` jobs read them from there.
@@ -188,12 +195,10 @@ What that means in practice:
   so a run that only moves mathlib finds every dependency in place. This is the
   steady state, and it uploads no dependency at all.
 - A toolchain bump changes the slug, so every dependency gets a new scope.
-- A dependency bump changes two things: the revision of that dependency, and
-  the pin hash. The pin hash covers the whole manifest, so a bump of one
-  dependency re-keys all of them, and the run rebuilds and re-uploads every
-  dependency. Only the bumped dependency, and any dependency that has it
-  upstream, holds different content. A hash over each dependency's own upstream
-  closure would re-key only those, and leave the rest in place.
+- A dependency bump changes the revision of that dependency, and the pin hash
+  of every dependency that has it upstream. A bump of batteries therefore
+  re-keys batteries, through its revision, and aesop, through its pin hash. The
+  other six keep their keys and their content in the bucket.
 
 Every job runs on Linux, so the scope carries no platform segment. A pipeline
 that built on more than one platform would need one, because the artifacts of a

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -39,6 +39,11 @@ name: Lake cache shadow (master)
 #                    from the cache bucket via `lake cache get` (+
 #                    `--package` for deps), run `lake build` against the
 #                    rehydrated cache, then verify with `--rehash`.
+#   downstream       Synthesize a minimal project that depends on mathlib at
+#                    the built rev, fetch mathlib + all transitive deps from
+#                    the bucket via `lake cache get --package`, and assert
+#                    zero Mathlib module rebuilds — validating that the
+#                    bucket can serve real downstream projects.
 #   report           Post a per-run summary to the `CI admins` Zulip
 #                    stream (topic `Lake cache shadow`).
 #
@@ -848,9 +853,120 @@ jobs:
           read -ra TARGETS <<< "$STAGE_TARGETS"
           lake build --no-build --rehash -v "${TARGETS[@]}"
 
+  # Downstream-consumer experiment: a minimal project that *depends on*
+  # mathlib fetches everything — mathlib itself plus the transitive deps —
+  # from the shadow bucket. The mappings were produced with mathlib as the
+  # workspace ROOT; here mathlib is a DEP, so zero rebuilt Mathlib modules
+  # proves the input hashes agree across the two workspace shapes, i.e. the
+  # bucket can serve real downstream projects.
+  downstream:
+    name: Downstream project fetch (mathlib-as-dep)
+    needs: [build_and_stage, upload]
+    # Only meaningful on full-Mathlib runs with dep caching on: the test
+    # imports Mathlib modules, so the bucket must hold the full root set.
+    if: ${{ github.repository == 'leanprover-community/mathlib4' && (inputs.targets || 'Mathlib') == 'Mathlib' && (github.event_name != 'workflow_dispatch' || inputs.cache_deps) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      health: ${{ steps.health.outputs.health }}
+    env:
+      LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+      LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+      # Disable barrel/build-cache auto-fetch so every replay in this job is
+      # attributable to the shadow bucket.
+      LAKE_NO_CACHE: true
+      EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
+      MATHLIB_SHA: ${{ needs.build_and_stage.outputs.sha }}
+    steps:
+      - name: install elan
+        run: |
+          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
+          chmod +x elan-init.sh
+          ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      # A minimal project depending on mathlib at the rev this run built.
+      # `lake update` materializes mathlib and inherits its manifest pins for
+      # the transitive deps, exactly as a real downstream would resolve them.
+      - name: Create downstream project
+        run: |
+          mkdir downstream && cd downstream
+          printf '%s\n' "$EFFECTIVE_TOOLCHAIN" > lean-toolchain
+          cat > lakefile.toml <<EOF
+          name = "downstream"
+          defaultTargets = ["Downstream"]
+
+          [[require]]
+          name = "mathlib"
+          git = "https://github.com/leanprover-community/mathlib4"
+          rev = "$MATHLIB_SHA"
+
+          [[lean_lib]]
+          name = "Downstream"
+          EOF
+          cat > Downstream.lean <<'EOF'
+          import Mathlib.Topology.Basic
+          import Mathlib.Tactic.Ring
+
+          example (x y : Nat) : (x + y)^2 = x^2 + 2*x*y + y^2 := by ring
+          EOF
+          lake update --keep-toolchain
+
+      # Hydrate: mathlib itself from the root scope, transitive deps from
+      # their per-dep scopes — every rev comes from the downstream's own
+      # manifest (mathlib's entry is the pinned sha; the rest are inherited
+      # pins). Misses degrade to source builds, reported below.
+      - name: lake cache get (mathlib + transitive deps)
+        run: |
+          cd downstream
+          # Must mirror the slug in build_and_stage's plan step.
+          tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
+          total=0 hits=0
+          while read -r name rev; do
+            if [[ " $DEP_SKIP " == *" $name "* ]]; then continue; fi
+            total=$((total+1))
+            if [ "$name" = mathlib ]; then
+              scope="$SHADOW_SCOPE"
+            else
+              scope="$SHADOW_SCOPE/deps/$tcslug/$name"
+            fi
+            if lake cache get --package="$name" --scope="$scope" --rev="$rev"; then
+              hits=$((hits+1))
+            else
+              echo "::warning::downstream cache miss for $name@${rev:0:12}; it will build from source"
+            fi
+          done < <(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json)
+          echo "PKG_TOTAL=$total" >> "$GITHUB_ENV"
+          echo "PKG_HITS=$hits" >> "$GITHUB_ENV"
+          echo "::notice::downstream cache: ${hits}/${total} packages fetched from shadow scope"
+
+      - name: lake build (downstream)
+        run: |
+          cd downstream
+          lake build 2>&1 | tee build.log
+
+      - name: Check downstream provenance
+        id: health
+        run: |
+          cd downstream
+          BUILT_TOTAL=$(grep -cE '^✔.*Built ' build.log || true)
+          BUILT_MATHLIB=$(grep -cE '^✔.*Built Mathlib([. ]|$)' build.log || true)
+          BUILT_SELF=$(grep -cE '^✔.*Built Downstream' build.log || true)
+          BUILT_OTHER=$((BUILT_TOTAL - BUILT_MATHLIB - BUILT_SELF))
+          if [ "$BUILT_MATHLIB" -ne 0 ]; then
+            health="❌ downstream: ${BUILT_MATHLIB} Mathlib module(s) rebuilt — as-dep input hashes diverge from as-root"
+            echo "health=${health}" >> "$GITHUB_OUTPUT"
+            echo "::error::${health}"
+            grep -E '^✔.*Built Mathlib([. ]|$)' build.log | head -20 || true
+            exit 1
+          fi
+          health="⬇️ downstream: ${PKG_HITS}/${PKG_TOTAL} pkgs fetched, 0 Mathlib modules rebuilt, ${BUILT_OTHER} other dep module(s) built (skip list: ${DEP_SKIP:-none})"
+          echo "health=${health}" >> "$GITHUB_OUTPUT"
+          echo "::notice::${health}"
+
   report:
     name: Post run summary to Zulip
-    needs: [build_and_stage, upload, consume]
+    needs: [build_and_stage, upload, consume, downstream]
     if: ${{ always() && github.repository == 'leanprover-community/mathlib4' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -861,6 +977,8 @@ jobs:
           BUILD: ${{ needs.build_and_stage.result }}
           UPLOAD: ${{ needs.upload.result }}
           CONSUME: ${{ needs.consume.result }}
+          DOWNSTREAM: ${{ needs.downstream.result }}
+          DOWNSTREAM_HEALTH: ${{ needs.downstream.outputs.health }}
           CARRYOVER: ${{ needs.upload.outputs.carryover }}
           NEW_CONTENT: ${{ needs.upload.outputs.new_content }}
           DEP_UPLOADS: ${{ needs.upload.outputs.dep_uploads }}
@@ -887,8 +1005,10 @@ jobs:
             echo "- $(emoji "$BUILD") build_and_stage: \`$BUILD\`"
             echo "- $(emoji "$UPLOAD") upload: \`$UPLOAD\`"
             echo "- $(emoji "$CONSUME") consume: \`$CONSUME\`"
+            echo "- $(emoji "$DOWNSTREAM") downstream: \`$DOWNSTREAM\`"
             echo "- ${CACHE_HEALTH:-❓ cache hits: n/a (consume skipped)}"
             echo "- ${DEP_HEALTH:-📚 deps: n/a (consume skipped)}"
+            echo "- ${DOWNSTREAM_HEALTH:-⬇️ downstream: n/a (skipped)}"
             echo "- 🔁 cache carryover: ${CARRYOVER:-n/a}"
             echo "- 📦 new content uploaded: ${NEW_CONTENT:-n/a}"
             echo "- 🗂️ dep uploads: ${DEP_UPLOADS:-n/a}"

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -47,6 +47,25 @@ name: Lake cache shadow (master)
 #   report           Post a per-run summary to the `CI admins` Zulip
 #                    stream (topic `Lake cache shadow`).
 #
+# Bucket layout:
+#   Everything the pipeline writes lives in one bucket, addressed by scope.
+#   For SHADOW_SCOPE=mathlib4-master-shadow, toolchain slug
+#   `leanprover-lean4-v4.34.0-rc2` and pin set `2d10dd67`, a run writes:
+#
+#     revisions/mathlib4-master-shadow/<mathlib-sha>.jsonl
+#     artifacts/mathlib4-master-shadow/<content-hash>.art
+#     revisions/mathlib4-master-shadow/deps/leanprover-lean4-v4.34.0-rc2/2d10dd67/batteries/<batteries-rev>.jsonl
+#     artifacts/mathlib4-master-shadow/deps/leanprover-lean4-v4.34.0-rc2/2d10dd67/batteries/<content-hash>.art
+#     analysis/leanprover-lean4-v4.34.0-rc2/_latest.txt
+#     analysis/leanprover-lean4-v4.34.0-rc2/<mathlib-sha>.txt
+#
+#   `lake cache get --scope=S --rev=R` reads `revisions/S/R.jsonl` (the
+#   input-hash-to-artifact mappings) and then the `artifacts/S/<hash>.art`
+#   files it names. The `analysis/` prefix is this workflow's own
+#   bookkeeping, invisible to Lake: `_latest.txt` holds the previous run's
+#   mathlib sha (the warm-start pointer) and `<sha>.txt` holds that run's
+#   uploaded artifact hashes (the carryover baseline).
+#
 # Dependency caching:
 #   Lake's `-o` records input-to-output mappings only for the workspace
 #   root, so each dependency's mappings are exported by loading the dep as
@@ -86,10 +105,21 @@ name: Lake cache shadow (master)
 #   never use it (it is keyed to the repo pin).
 #
 # Cache service configuration:
-#   Jobs consume the endpoint Variables below through a generated Lake
-#   services file (`LAKE_CONFIG` + `--service=shadow`), the supported
-#   mechanism; the raw LAKE_CACHE_*_ENDPOINT env vars are deprecated in
-#   Lake and only used here for plain-curl probes and analysis uploads.
+#   Jobs reach the bucket through a generated Lake services file
+#   (`LAKE_CONFIG` + `--service=shadow`), the supported mechanism; the raw
+#   LAKE_CACHE_*_ENDPOINT env vars are deprecated in Lake and used here only
+#   for plain-curl probes and the analysis uploads. Each job writes the file
+#   itself, since each runs on its own runner. Fetching jobs render the
+#   public read endpoints:
+#
+#     [[cache.service]]
+#     name = "shadow"
+#     type = "s3"
+#     artifactEndpoint = "https://pub-<hash>.r2.dev/<prefix>/artifacts"
+#     revisionEndpoint = "https://pub-<hash>.r2.dev/<prefix>/revisions"
+#
+#   and the upload job renders the same block with the authenticated S3
+#   endpoints, whose requests it signs with LAKE_CACHE_KEY.
 #
 # Toolchain override:
 #   The `toolchain_override` input, or else the LAKE_SHADOW_TOOLCHAIN_OVERRIDE
@@ -279,9 +309,10 @@ jobs:
           mkdir -p .lake/dep-plan
           : > .lake/dep-plan/stage.txt
           : > .lake/dep-plan/cached.txt
-          # Services file for the warm-start steps in this job (public
-          # endpoints; the upload job writes its own with the authenticated
-          # ones).
+          # Services file for the warm-start steps in this job. Renders the
+          # block shown under "Cache service configuration" at the top of this
+          # file, with the public read endpoints; the upload job writes its
+          # own with the authenticated ones.
           cat > .lake/shadow-services.toml <<EOF
           [[cache.service]]
           name = "shadow"
@@ -289,13 +320,21 @@ jobs:
           artifactEndpoint = "$LAKE_CACHE_ARTIFACT_ENDPOINT"
           revisionEndpoint = "$LAKE_CACHE_REVISION_ENDPOINT"
           EOF
-          # Must mirror the slug/hash in the warm-start/upload/consume/
-          # downstream steps.
+          # The two qualifiers that make a dep scope exact. Both are recomputed
+          # (identically) by the upload, consume and downstream jobs, which run
+          # on their own runners; a mismatch between any two would not fail
+          # anything, it would just turn every fetch into a silent miss.
+          #   tcslug: the toolchain, punctuation folded to '-'
+          #           "leanprover/lean4:v4.34.0-rc2" -> "leanprover-lean4-v4.34.0-rc2"
+          #   pins8:  8 hex chars over the manifest's sorted "<name> <rev>"
+          #           git entries, e.g. "2d10dd67" — see "Dependency caching".
           tcslug="$(printf %s "$(cat lean-toolchain)" | tr -c 'A-Za-z0-9._-' '-')"
           pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           echo "TCSLUG=$tcslug" >> "$GITHUB_ENV"
           echo "PINS8=$pins8" >> "$GITHUB_ENV"
-          # Root-chain probe: prev rev on this toolchain's analysis chain.
+          # Root-chain probe: `analysis/<tcslug>/_latest.txt` holds the mathlib
+          # sha of the previous run on this toolchain, or 404s on a chain that
+          # has never run. Absent (cold) means no warm start is possible.
           prev="$(curl -fsS "${LAKE_CACHE_ARTIFACT_ENDPOINT%/artifacts}/analysis/$tcslug/_latest.txt" 2>/dev/null || true)"
           if [ -n "$prev" ]; then
             echo "CHAIN_PREV=$prev" >> "$GITHUB_ENV"
@@ -310,6 +349,9 @@ jobs:
             echo "::notice::dependency caching disabled for this run (cache_deps input)"
             exit 0
           fi
+          # Sorts each dep into one of two plan files, both "<name> <rev>" per
+          # line: cached.txt (bucket already has it -> warm start from it) and
+          # stage.txt (missing -> build, export, upload it this run).
           while read -r name rev; do
             if [[ " $DEP_SKIP " == *" $name "* ]]; then
               echo "::notice::dep $name: on the skip list; not cached"
@@ -320,8 +362,21 @@ jobs:
               echo "$name $rev" >> .lake/dep-plan/cached.txt
             else
               echo "$name $rev" >> .lake/dep-plan/stage.txt
-              # Overrides for the dep-as-root export build: every other
-              # workspace package as a path entry into this checkout.
+              # Overrides for this dep's export build below. Rewrites every
+              # *other* workspace package as a path entry into this checkout,
+              # so that loading the dep standalone still resolves its
+              # upstreams to mathlib's pins rather than to its own manifest's
+              # (which would produce mappings this workspace never matches).
+              # `aesop-overrides.json` renders as:
+              #
+              #   {"version": "1.2.0",
+              #    "packages": [
+              #      {"name": "batteries", "scope": "leanprover-community",
+              #       "configFile": "lakefile.toml", "inherited": false,
+              #       "type": "path",
+              #       "dir": "/…/pr-branch/.lake/packages/batteries"},
+              #      … one entry per other package …
+              #    ]}
               jq --arg pfx "$PWD/.lake/packages" --arg self "$name" \
                 '{version, packages: [.packages[] | select(.name != $self)
                   | {name, scope, configFile, inherited, type: "path", dir: ($pfx + "/" + .name)}]}' \
@@ -462,6 +517,12 @@ jobs:
             echo "::notice::no cached deps to warm start"
             exit 0
           fi
+          # TCSLUG/PINS8 come from the plan step via $GITHUB_ENV, so this is
+          # the one dep fetch that does not recompute them. For batteries the
+          # scope below is
+          #   mathlib4-master-shadow/deps/leanprover-lean4-v4.34.0-rc2/2d10dd67/batteries
+          # and --rev is batteries' own manifest revision: an exact lookup, so
+          # a miss returns immediately instead of walking --max-revs ancestors.
           while read -r name rev; do
             lake cache get --service=shadow --package="$name" \
               --scope="$SHADOW_SCOPE/deps/$TCSLUG/$PINS8/$name" --rev="$rev" \
@@ -518,6 +579,16 @@ jobs:
             echo "no deps to export"
             exit 0
           fi
+          # `-o` writes the loaded workspace root's input-hash-to-artifact
+          # mappings as JSON Lines — a schema-version header, then one entry
+          # per module. `.lake/dep-outputs/batteries.jsonl` starts:
+          #
+          #   "2026-03-17"
+          #   ["40621d85d988875e","b219d1b135ae613c.ltar"]
+          #
+          # The upload job pushes this file to
+          # revisions/<dep scope>/<dep rev>.jsonl, and the .ltar files it
+          # names to artifacts/<dep scope>/.
           while read -r name rev; do
             echo "::group::export $name"
             if lake -d ".lake/packages/$name" build \
@@ -543,13 +614,28 @@ jobs:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --rw lake-cache-staging/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI --env LAKE_CACHE_DIR --env LAKE_NO_CACHE -- bash -euxo pipefail {0}
         run: |
           cd pr-branch
+          # Copies mappings + artifacts out of the local Lake cache into the
+          # tree the upload job consumes (it travels between jobs as a GitHub
+          # artifact). Each dep gets its own subdirectory because `cache stage`
+          # writes exactly one outputs.jsonl per directory. Result:
+          #
+          #   lake-cache-staging/
+          #     outputs.jsonl               root mappings
+          #     <content-hash>.ltar         root artifacts, flat
+          #     deps/cached.txt             "<name> <rev>" already in the bucket
+          #     deps/manifest.txt           "<name> <rev>" staged here now
+          #     deps/batteries/outputs.jsonl
+          #     deps/batteries/<content-hash>.ltar
+          #     deps/aesop/…
+          #
+          # The upload job reads deps/manifest.txt to know what to push and
+          # deps/cached.txt only to report how many it skipped.
           lake cache stage .lake/outputs.jsonl ../lake-cache-staging
-          # Stage each exported dep into its own subdirectory (`cache stage`
-          # writes one outputs.jsonl per directory) and record name+rev — and
-          # the already-cached set, for the upload summary — for the upload job.
           mkdir -p ../lake-cache-staging/deps
           cp .lake/dep-plan/cached.txt ../lake-cache-staging/deps/cached.txt
           while read -r name rev; do
+            # Deps whose export failed have no mappings file; plan.txt still
+            # lists them, so skip rather than staging a partial dep.
             [ -f ".lake/dep-outputs/$name.jsonl" ] || continue
             lake cache stage ".lake/dep-outputs/$name.jsonl" "../lake-cache-staging/deps/$name"
             echo "$name $rev" >> ../lake-cache-staging/deps/manifest.txt
@@ -605,6 +691,8 @@ jobs:
           ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
           REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
         run: |
+          # Renders the block shown under "Cache service configuration" at the
+          # top of this file.
           cat > "$LAKE_CONFIG" <<EOF
           [[cache.service]]
           name = "shadow"
@@ -674,13 +762,18 @@ jobs:
           EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
         run: |
           cd pr-branch
-          # Must mirror the slug/hash in build_and_stage's plan step.
+          # Recomputed here because this job runs on its own runner. Must
+          # match build_and_stage's plan step exactly (see the note there):
+          # drift produces no error, just a scope nothing was ever uploaded
+          # to, i.e. a silent 100% miss.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
           pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           skipped=0
           if [ -f ../lake-cache-staging/deps/cached.txt ]; then
             skipped=$(wc -l < ../lake-cache-staging/deps/cached.txt)
           fi
+          # No manifest.txt means the stage step staged no deps at all, which
+          # is the steady state: every dep was already in the bucket.
           if [ ! -f ../lake-cache-staging/deps/manifest.txt ]; then
             echo "summary=0 uploaded, ${skipped} already cached" >> "$GITHUB_OUTPUT"
             exit 0
@@ -700,8 +793,13 @@ jobs:
           done < ../lake-cache-staging/deps/manifest.txt
           arts=$(grep -c 'uploaded artifact' /tmp/dep-put.log || true)
           bytes=$(du -sb ../lake-cache-staging/deps | cut -f1)
+          # An `if` rather than `[ … ] && …`: `set -e` exempts the left side of
+          # an `&&`, so that idiom is safe here, but it silently fails the step
+          # if it ever ends up as the last command in the block.
           failnote=""
-          [ "$fail" -gt 0 ] && failnote=", ${fail} FAILED"
+          if [ "$fail" -gt 0 ]; then
+            failnote=", ${fail} FAILED"
+          fi
           summary="${ok} uploaded ($(numfmt --to=iec-i --suffix=B "$bytes") staged, ${arts} artifacts)${failnote}, ${skipped} already cached"
           echo "::notice::dep uploads: ${summary}"
           echo "summary=${summary}" >> "$GITHUB_OUTPUT"
@@ -723,7 +821,8 @@ jobs:
           REPO: ${{ github.repository }}
           EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
         run: |
-          # Must mirror the slug in build_and_stage's warm-start step.
+          # Only the toolchain slug here: the analysis chain is per
+          # toolchain, not per pin set. Must match the plan step's.
           slug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
           base="${AUTH%/artifacts}/analysis/$slug"
           sha="${{ needs.build_and_stage.outputs.sha }}"
@@ -779,7 +878,11 @@ jobs:
           echo "::notice::new content uploaded: ${new_content}"
           echo "summary=${summary}" >> "$GITHUB_OUTPUT"
           echo "new_content=${new_content}" >> "$GITHUB_OUTPUT"
-          # Persist this run's manifest + advance the pointer (best-effort).
+          # Persist this run's manifest and advance the pointer, both
+          # best-effort: losing them costs the next run its warm start and its
+          # carryover baseline, nothing more. `<sha>.txt` is one artifact hash
+          # per line; `_latest.txt` is a single sha with no trailing newline,
+          # which is what the next run's plan step curls.
           printf %s "$sha" > /tmp/latest.txt
           curl -fsS "${sig[@]}" -X PUT -T /tmp/today.txt  "$base/${sha}.txt"   >/dev/null || echo "::warning::failed to store analysis manifest"
           curl -fsS "${sig[@]}" -X PUT -T /tmp/latest.txt "$base/_latest.txt"  >/dev/null || echo "::warning::failed to advance analysis pointer"
@@ -810,6 +913,8 @@ jobs:
           ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
         run: |
+          # Renders the block shown under "Cache service configuration" at the
+          # top of this file.
           cat > "$LAKE_CONFIG" <<EOF
           [[cache.service]]
           name = "shadow"
@@ -881,7 +986,10 @@ jobs:
           EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
         run: |
           cd pr-branch
-          # Must mirror the slug/hash in build_and_stage's plan step.
+          # Recomputed here because this job runs on its own runner. Must
+          # match build_and_stage's plan step exactly (see the note there):
+          # drift produces no error, just a scope nothing was ever uploaded
+          # to, i.e. a silent 100% miss.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
           pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           total=0 hits=0
@@ -927,7 +1035,9 @@ jobs:
           BUILT_TOTAL=$(grep -cE '^✔.*Built ' "$log" || true)
           # The cache invariant: every root-package module must be a cache HIT
           # (no rebuild). Emit an explicit health line (consumed by the Zulip
-          # report) and fail the run if it's not a full hit.
+          # report) and fail the run if it's not a full hit. The alternation
+          # lists mathlib's four libraries — everything else that builds is a
+          # dependency.
           BUILT_ROOT=$(grep -cE '^✔.*Built (Mathlib|Archive|Counterexamples|Wanted)([. ]|$)' "$log" || true)
           # Dep rebuilds are reported, not fatal: they measure whether the
           # dep-as-root mappings actually match this workspace's input hashes
@@ -990,6 +1100,8 @@ jobs:
           ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
         run: |
+          # Renders the block shown under "Cache service configuration" at the
+          # top of this file.
           cat > "$LAKE_CONFIG" <<EOF
           [[cache.service]]
           name = "shadow"
@@ -1006,8 +1118,19 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       # A minimal project depending on mathlib at the rev this run built.
-      # `lake update` materializes mathlib and inherits its manifest pins for
-      # the transitive deps, exactly as a real downstream would resolve them.
+      # The three files below render as:
+      #
+      #   lean-toolchain   leanprover/lean4:v4.34.0-rc2
+      #   lakefile.toml    a [[require]] on mathlib's git URL, with
+      #                    rev = "<the sha build_and_stage staged>"
+      #   Downstream.lean  two Mathlib imports and one `ring` proof, chosen so
+      #                    the build pulls a real slice of Mathlib's closure
+      #                    rather than a leaf module
+      #
+      # `lake update` then materializes mathlib and writes a lake-manifest.json
+      # pinning it at that sha plus the 8 transitive deps at mathlib's own
+      # pins — the resolution a real downstream performs, and the manifest the
+      # fetch step below reads revisions from.
       - name: Create downstream project
         run: |
           mkdir downstream && cd downstream
@@ -1039,11 +1162,20 @@ jobs:
       - name: lake cache get (mathlib + transitive deps)
         run: |
           cd downstream
-          # Must mirror the slug/hash in build_and_stage's plan step. The
-          # pins hash comes from *mathlib's* manifest (inside this
-          # workspace), which is what a real downstream driver would read.
+          # Recomputed here because this job runs on its own runner. Must
+          # match build_and_stage's plan step exactly (see the note there):
+          # drift produces no error, just a scope nothing was ever uploaded
+          # to, i.e. a silent 100% miss.
+          # The pins hash comes from *mathlib's* manifest, vendored inside this
+          # workspace at .lake/packages/mathlib/ — a real downstream driver
+          # reads it from exactly there.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
           pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' .lake/packages/mathlib/lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
+          # Note the two manifests: the pins hash above comes from mathlib's,
+          # while the loop below iterates the *downstream's* — which lists
+          # mathlib itself plus the 8 deps it inherited. So mathlib is fetched
+          # from the root scope (keyed by its sha) and everything else from its
+          # dep scope, all revisions read from the downstream's own resolution.
           total=0 hits=0
           while read -r name rev; do
             if [[ " $DEP_SKIP " == *" $name "* ]]; then continue; fi

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -59,6 +59,25 @@ name: Lake cache shadow (master)
 #   `_latest.txt` holds the mathlib sha of the previous run on the toolchain,
 #   and `<sha>.txt` holds the artifact hashes that run uploaded.
 #
+# What a full cache hit requires:
+#   Four things are necessary. Without any one of them a fetch returns
+#   mappings that do not match, and the modules rebuild:
+#     * The lakefile patch, which lets the workspace write to Lake's artifact
+#       cache at all.
+#     * The export build of each dependency, with its `--packages` overrides.
+#       Lake's `-o` records the root package only, and the overrides make the
+#       exported input hashes match this workspace.
+#     * The two scope qualifiers, the toolchain slug and the pin hash.
+#       Without them one revision file holds the mappings of another
+#       toolchain or another pin set.
+#     * One `lake cache get`, `stage` and `put-staged` call per package.
+#       Lake has no workspace-wide form of these against a custom endpoint.
+#
+#   Everything else is speed. The probe and the plan files, the root and the
+#   dependency warm starts, the legacy fallback and the `--rev` arguments
+#   decide only how much this run compiles and uploads. A run without them
+#   writes the same keys with the same content, and takes longer.
+#
 # Dependency caching:
 #   Lake's `-o` records the mappings of the workspace root only. To obtain the
 #   mappings of a dependency, the pipeline loads that dependency as the root
@@ -282,7 +301,8 @@ jobs:
           rm -rf lake-cache-staging tools-branch
           echo "disk headroom: $(df -h --output=avail,pcent . | tail -1 | xargs) on $(hostname)"
 
-      # Plan the hydration and the dependency caching of this run:
+      # Plan the hydration and the dependency caching of this run. The plan
+      # is an optimization: it decides what this run can skip.
       #   * Write the Lake services file that the `lake cache get` steps read
       #     through LAKE_CONFIG.
       #   * Resolve the analysis-chain pointer of this toolchain. A warm chain
@@ -313,7 +333,8 @@ jobs:
           artifactEndpoint = "$LAKE_CACHE_ARTIFACT_ENDPOINT"
           revisionEndpoint = "$LAKE_CACHE_REVISION_ENDPOINT"
           EOF
-          # The two qualifiers that make a dependency scope exact. The upload,
+          # The two qualifiers that make a dependency scope exact. They are
+          # required for a hit. The upload,
           # consume and downstream jobs compute them again, because they run on
           # their own runners. A mismatch between two jobs fails nothing; it
           # makes every fetch a miss.
@@ -426,7 +447,8 @@ jobs:
           cd pr-branch
           lake env
 
-      # The bootstrap fallback. A pinned run normally hydrates from the shadow
+      # The bootstrap fallback, an optimization for a cold chain. A pinned run
+      # normally hydrates from the shadow
       # scope, in the warm-start steps below. The legacy cache covers the case
       # they cannot: a cold analysis chain, which is a fresh toolchain
       # generation on the repo pin. An override run never uses it, because the
@@ -477,7 +499,8 @@ jobs:
           awk '/^package mathlib where/,/^$/' lakefile.lean
           echo "::endgroup::"
 
-      # The primary root hydration. It seeds Lake's artifact cache from the
+      # The primary root hydration, an optimization. It seeds Lake's artifact
+      # cache from the
       # previous run on this toolchain, at the pointer the plan step resolved.
       # The incremental build below then compiles the churn since that run. On
       # a cold chain a pinned run uses the legacy fallback above, and an
@@ -495,8 +518,8 @@ jobs:
           lake cache get --service=shadow --scope="$SHADOW_SCOPE" --rev="$CHAIN_PREV" \
             || echo "::warning::warm start from rev ${CHAIN_PREV:0:12} failed; proceeding without it"
 
-      # The primary dependency hydration. It fetches the dependencies the
-      # bucket serves, and the main build replays them. The step is skipped
+      # The primary dependency hydration, an optimization. It fetches the
+      # dependencies the bucket serves, and the main build replays them. The step is skipped
       # only when the legacy fallback already hydrated everything, on a pinned
       # run with a cold chain. A dependency the plan step found missing builds
       # from source below, and the export step then records it.
@@ -547,8 +570,9 @@ jobs:
           echo "mappings entries: $(wc -l < .lake/outputs.jsonl)"
           head -3 .lake/outputs.jsonl
 
-      # Export the mappings of the dependencies the bucket does not hold. See
-      # "Dependency caching" at the top of this file. The incremental build
+      # Export the mappings of the dependencies the bucket does not hold. This
+      # step is required for a dependency to hit at all; see "What a full
+      # cache hit requires" at the top of this file. The incremental build
       # above put every dependency artifact in the shared local cache, so
       # these loads replay instead of compiling, as long as the input hashes
       # of the two workspace shapes agree. A disagreement appears as compile

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -51,9 +51,10 @@ name: Lake cache shadow (master)
 #     analysis/leanprover-lean4-v4.34.0-rc2/_latest.txt
 #     analysis/leanprover-lean4-v4.34.0-rc2/<mathlib-sha>.txt
 #
-#   `lake cache get --scope=S --rev=R` reads `revisions/S/R.jsonl`, which maps
-#   input hashes to artifacts. Lake then downloads the `artifacts/S/<hash>.art`
-#   files that the map names.
+#   `lake cache get --scope=<SCOPE> --rev=<REV>` reads
+#   `revisions/<SCOPE>/<REV>.jsonl`, which maps input hashes to artifacts.
+#   Lake then downloads the `artifacts/<SCOPE>/<content-hash>.art` files that
+#   the map names.
 #
 #   Lake does not know the `analysis/` prefix; this workflow owns it.
 #   `_latest.txt` holds the mathlib sha of the previous run on the toolchain,

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -5,157 +5,11 @@ name: Lake cache shadow (master)
 # of it. It writes to an isolated `mathlib4-master-shadow` scope, so no other
 # consumer reads what it produces.
 #
-# Required repository configuration:
-#   Secrets:
-#     LAKE_CACHE_KEY                         — SigV4 credential for the cache
-#                                              bucket, as `<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>`
-#                                              (curl `--user`; region is `auto`).
-#     ZULIP_API_KEY                          — Zulip bot key for the `report` job.
-#   Variables:
-#     # The authenticated S3 endpoint. The `upload` job PUTs to it.
-#     LAKE_CACHE_ARTIFACT_ENDPOINT           — e.g. https://<acct>.r2.cloudflarestorage.com/<bucket>/<prefix>/artifacts
-#     LAKE_CACHE_REVISION_ENDPOINT           — e.g. https://<acct>.r2.cloudflarestorage.com/<bucket>/<prefix>/revisions
-#     # The public read endpoint, for anonymous GETs. On R2 this is a
-#     # different host than the S3 API endpoint above.
-#     LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC    — e.g. https://pub-<hash>.r2.dev/<prefix>/artifacts
-#     LAKE_CACHE_REVISION_ENDPOINT_PUBLIC    — e.g. https://pub-<hash>.r2.dev/<prefix>/revisions
-#     # Optional. It sets the toolchain override for every run. The dispatch
-#     # input takes precedence. Leave it unset to run on the repo pin.
-#     LAKE_SHADOW_TOOLCHAIN_OVERRIDE         — e.g. leanprover/lean4-pr-releases:pr-release-14301
-#
-# Jobs:
-#   build_and_stage  Builds mathlib and its dependencies with Lake's artifact
-#                    cache. Stages the root package's outputs, and the
-#                    mappings of each dependency the bucket does not hold.
-#   upload           Pushes the staged files to the bucket with `lake cache
-#                    put-staged`: once for the root scope, then once per
-#                    dependency scope. Records a manifest under
-#                    analysis/<toolchain-slug>/ and reports the carryover.
-#   consume          Fetches the root and dependency outputs into a fresh
-#                    checkout with `lake cache get`, builds against them, and
-#                    verifies the result with `--rehash`.
-#   downstream       Creates a small project that depends on mathlib, fetches
-#                    mathlib and every transitive dependency from the bucket,
-#                    and requires zero Mathlib rebuilds.
-#   report           Posts a summary of the run to Zulip.
-#
-# Bucket layout:
-#   The pipeline writes everything to one bucket, addressed by scope. A run
-#   with SHADOW_SCOPE=mathlib4-master-shadow, toolchain slug
-#   `leanprover-lean4-v4.34.0-rc2` and pin hash `2d10dd67` writes these keys:
-#
-#     revisions/mathlib4-master-shadow/<mathlib-sha>.jsonl
-#     artifacts/mathlib4-master-shadow/<content-hash>.art
-#     revisions/mathlib4-master-shadow/deps/leanprover-lean4-v4.34.0-rc2/2d10dd67/batteries/<batteries-rev>.jsonl
-#     artifacts/mathlib4-master-shadow/deps/leanprover-lean4-v4.34.0-rc2/2d10dd67/batteries/<content-hash>.art
-#     analysis/leanprover-lean4-v4.34.0-rc2/_latest.txt
-#     analysis/leanprover-lean4-v4.34.0-rc2/<mathlib-sha>.txt
-#
-#   `lake cache get --scope=<SCOPE> --rev=<REV>` reads
-#   `revisions/<SCOPE>/<REV>.jsonl`, which maps input hashes to artifacts.
-#   Lake then downloads the `artifacts/<SCOPE>/<content-hash>.art` files that
-#   the map names.
-#
-#   Lake does not know the `analysis/` prefix; this workflow owns it.
-#   `_latest.txt` holds the mathlib sha of the previous run on the toolchain,
-#   and `<sha>.txt` holds the artifact hashes that run uploaded.
-#
-# What a full cache hit requires:
-#   Four things are necessary. Without any one of them a fetch returns
-#   mappings that do not match, and the modules rebuild:
-#     * The lakefile patch, which lets the workspace write to Lake's artifact
-#       cache at all.
-#     * The export build of each dependency, with its `--packages` overrides.
-#       Lake's `-o` records the root package only, and the overrides make the
-#       exported input hashes match this workspace.
-#     * The two scope qualifiers, the toolchain slug and the pin hash.
-#       Without them one revision file holds the mappings of another
-#       toolchain or another pin set.
-#     * One `lake cache get`, `stage` and `put-staged` call per package.
-#       Lake has no workspace-wide form of these against a custom endpoint.
-#
-#   Everything else is speed. The probe and the plan files, the root and the
-#   dependency warm starts, the legacy fallback and the `--rev` arguments
-#   decide only how much this run compiles and uploads. A run without them
-#   writes the same keys with the same content, and takes longer.
-#
-# Dependency caching:
-#   Lake's `-o` records the mappings of the workspace root only. To obtain the
-#   mappings of a dependency, the pipeline loads that dependency as the root
-#   of its own workspace: `lake -d .lake/packages/<dep> build -o`. The
-#   `--packages` overrides pin its own dependencies to this workspace's
-#   checkouts. Without them the dependency resolves the revisions in its own
-#   manifest, and the mappings never match this workspace's input hashes.
-#
-#   Each dependency uploads to the scope
-#     <SHADOW_SCOPE>/deps/<toolchain-slug>/<pins-hash>/<dep>
-#   under its own revision from lake-manifest.json. Two qualifiers extend the
-#   key, because the revision alone is not exact:
-#     toolchain slug  A dependency revision lives for months, so many
-#                     toolchains build it.
-#     pins hash       The input hashes of a dependency cover the artifacts of
-#                     its upstreams. A partial bump of the manifest, of
-#                     batteries alone for example, changes the correct
-#                     mappings for aesop but not the revision of aesop.
-#
-#   The plan step skips a dependency whose revision file is already in the
-#   bucket. Uploads therefore happen on a manifest bump or a toolchain bump,
-#   and both of those re-key every dependency. The `consume` job fetches each
-#   dependency with `lake cache get --package=<dep> --rev=<manifest-rev>`, and
-#   a run that skips legacy hydration warm starts with the same fetch.
-#
-#   DEP_SKIP excludes dependencies from all of this. Every per-dependency step
-#   tolerates failure. A miss, or a failed export, makes that dependency build
-#   from source, and the consume health line reports it. A toolchain older than
-#   v4.34.0-rc2 has no `cache get --package` and behaves the same way.
-#
-# Hydration and the legacy cache:
-#   A pinned run hydrates from the shadow scope. The root package warm starts
-#   from the previous run on the toolchain's analysis chain, and each
-#   dependency warm starts from its own scope. The incremental build then
-#   compiles the churn since that run.
-#
-#   The legacy cache is a bootstrap fallback. A run uses it only when the
-#   analysis chain holds no previous run, which happens on a fresh toolchain
-#   generation on the repo pin. An override run never uses it, because the
-#   legacy cache is keyed to the repo pin.
-#
-# Cache service configuration:
-#   Jobs reach the bucket through a generated Lake services file, with
-#   `LAKE_CONFIG` and `--service=shadow`. This is the supported mechanism.
-#   Lake deprecates the LAKE_CACHE_*_ENDPOINT variables, which this file uses
-#   only for plain curl probes and for the analysis uploads. Each job writes
-#   the services file itself, because each job runs on its own runner. A
-#   fetching job writes the public read endpoints:
-#
-#     [[cache.service]]
-#     name = "shadow"
-#     type = "s3"
-#     artifactEndpoint = "https://pub-<hash>.r2.dev/<prefix>/artifacts"
-#     revisionEndpoint = "https://pub-<hash>.r2.dev/<prefix>/revisions"
-#
-#   The upload job writes the same block with the authenticated S3 endpoints,
-#   and signs its requests with LAKE_CACHE_KEY.
-#
-# Toolchain override:
-#   The `toolchain_override` input, or the LAKE_SHADOW_TOOLCHAIN_OVERRIDE
-#   variable, changes the toolchain of the whole pipeline. build_and_stage
-#   resolves it into its `toolchain` output, and the later jobs stamp that
-#   output into their checkouts, so every job runs the same lake.
-#
-#   The lean of the override must behave like the repo pin. A Lake change,
-#   cherry-picked onto the lineage of the pinned release as a pr-release, is a
-#   valid example. Input hashes cover the toolchain, so all runs share one
-#   artifact scope safely.
-#
-#   The analysis chain is per toolchain, under analysis/<slug>/. A pinned run
-#   and an override run therefore warm start from their own lineage, and
-#   compare against it.
-#
-#   The first run on a toolchain misses the legacy cache and every prior root
-#   artifact, and costs one full source build of the root package. A
-#   republished pr-release tag costs the same. Dependencies already in the
-#   shadow scope for that toolchain still replay.
+# `lake_cache_shadow.md`, beside this file, documents the design: the cache
+# service configuration, the push and pull sequences, what a warm run adds,
+# the storage layout, the scope qualifiers, and what a full cache hit
+# requires. It also lists the secrets and variables the pipeline needs. The
+# comments below cover what each step does.
 
 on:
   schedule:
@@ -182,7 +36,7 @@ on:
       toolchain_override:
         description: >-
           optional Lean toolchain to run the pipeline on instead of the repo
-          pin; see the "Toolchain override" note at the top of this file.
+          pin; see the toolchain override notes in `lake_cache_shadow.md`.
           Empty falls back to the LAKE_SHADOW_TOOLCHAIN_OVERRIDE repository
           variable; the pipeline runs on the repo pin when both are empty.
         required: false
@@ -579,7 +433,7 @@ jobs:
 
       # Export the mappings of the dependencies the bucket does not hold. This
       # step is required for a dependency to hit at all; see "What a full
-      # cache hit requires" at the top of this file. The incremental build
+      # cache hit requires" in `lake_cache_shadow.md`. The incremental build
       # above put every dependency artifact in the shared local cache, so
       # these loads replay instead of compiling, as long as the input hashes
       # of the two workspace shapes agree. A disagreement appears as compile
@@ -712,7 +566,7 @@ jobs:
     env:
       # The uploads go through a generated Lake services file with the
       # authenticated S3 endpoints, and LAKE_CACHE_KEY signs them. See "Cache
-      # service configuration" above.
+      # service configuration" in `lake_cache_shadow.md`.
       LAKE_CONFIG: ${{ github.workspace }}/shadow-services.toml
     steps:
       - name: Write cache services config
@@ -720,8 +574,7 @@ jobs:
           ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
           REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
         run: |
-          # This renders the block under "Cache service configuration" at the
-          # top of this file.
+          # This renders the block documented in `lake_cache_shadow.md`.
           cat > "$LAKE_CONFIG" <<EOF
           [[cache.service]]
           name = "shadow"
@@ -778,7 +631,7 @@ jobs:
             --toolchain="${{ needs.build_and_stage.outputs.toolchain }}" 2>&1 | tee /tmp/put.log
 
       # Upload each staged dependency to its own scope, under its manifest
-      # revision. See "Dependency caching" at the top of this file. The plan
+      # revision. See `lake_cache_shadow.md`. The plan
       # step already removed the dependencies the bucket holds. The log is
       # separate from /tmp/put.log, so these artifacts stay out of the root
       # carryover analysis below.
@@ -935,8 +788,7 @@ jobs:
           ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
         run: |
-          # This renders the block under "Cache service configuration" at the
-          # top of this file.
+          # This renders the block documented in `lake_cache_shadow.md`.
           cat > "$LAKE_CONFIG" <<EOF
           [[cache.service]]
           name = "shadow"
@@ -1118,8 +970,7 @@ jobs:
           ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
         run: |
-          # This renders the block under "Cache service configuration" at the
-          # top of this file.
+          # This renders the block documented in `lake_cache_shadow.md`.
           cat > "$LAKE_CONFIG" <<EOF
           [[cache.service]]
           name = "shadow"

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -26,16 +26,43 @@ name: Lake cache shadow (master)
 #
 # Jobs:
 #   build_and_stage  Build mathlib + deps with Lake's artifact cache
-#                    enabled, then stage the resulting .ltar files.
+#                    enabled, then stage the resulting .ltar files — the
+#                    root package's and, for deps the bucket does not have
+#                    yet, per-dependency mappings exported via dep-as-root
+#                    builds (see "Dependency caching" below).
 #   upload           Push staged artifacts to the cache bucket via
-#                    `lake cache put-staged`, then record a per-run manifest
-#                    under cache/analysis/<toolchain-slug>/ and report
-#                    carryover vs the prior run on the same toolchain.
-#   consume          Fresh checkout, fetch from the cache bucket via
-#                    `lake cache get`, run `lake build` against the
+#                    `lake cache put-staged` (root scope + one scope per
+#                    staged dep), then record a per-run manifest under
+#                    cache/analysis/<toolchain-slug>/ and report carryover
+#                    vs the prior run on the same toolchain.
+#   consume          Fresh checkout, fetch root outputs and per-dep outputs
+#                    from the cache bucket via `lake cache get` (+
+#                    `--package` for deps), run `lake build` against the
 #                    rehydrated cache, then verify with `--rehash`.
 #   report           Post a per-run summary to the `CI admins` Zulip
 #                    stream (topic `Lake cache shadow`).
+#
+# Dependency caching:
+#   Lake's `-o` records input-to-output mappings only for the workspace
+#   root, so each dependency's mappings are exported by loading the dep as
+#   the root of its own workspace (`lake -d .lake/packages/<dep> build -o`),
+#   with `--packages` overrides pinning its dependency tree to this
+#   workspace's checkouts (a dep's own manifest can pin different revs,
+#   which would yield mappings this workspace's input hashes never match).
+#   Each dep is uploaded under scope
+#     <SHADOW_SCOPE>/deps/<toolchain-slug>/<dep>
+#   keyed by the dep's lake-manifest.json revision. The toolchain slug in
+#   the scope keeps toolchains from overwriting each other's <rev>.jsonl:
+#   dep revs are long-lived, unlike mathlib's. A dep whose <rev>.jsonl is
+#   already in the bucket is skipped end-to-end (dep uploads happen only on
+#   manifest bumps or new toolchains). `consume` fetches each dep with
+#   `lake cache get --package=<dep> --rev=<manifest-rev>`; the same fetch
+#   warm-starts override runs, which cannot use the legacy cache.
+#   Deps in DEP_SKIP are excluded (see the env note). Per-dep steps are
+#   failure-tolerant: a miss or export failure degrades that dep to a
+#   source build, reported in the consume health line, and a toolchain
+#   older than v4.34.0-rc2 (no `cache get --package`) degrades the same
+#   way rather than failing the pipeline.
 #
 # Toolchain override:
 #   The `toolchain_override` input, or else the LAKE_SHADOW_TOOLCHAIN_OVERRIDE
@@ -49,8 +76,9 @@ name: Lake cache shadow (master)
 #   manifests) is keyed per toolchain under analysis/<slug>/, so pinned and
 #   override runs each warm-start from and diff against their own lineage.
 #   A toolchain's first run — or a pr-release tag republished under the same
-#   name — misses the legacy cache and all prior artifacts, costing one
-#   full-turnover source build.
+#   name — misses the legacy cache and all prior root artifacts, costing one
+#   full-turnover source build of the root package; dependencies already in
+#   the shadow scope for that toolchain are warm-started and replay.
 
 on:
   schedule:
@@ -83,6 +111,15 @@ on:
         required: false
         type: string
         default: ''
+      cache_deps:
+        description: >-
+          also cache dependencies (see "Dependency caching" at the top of
+          this file). Disable for cheap experiments with a small `targets`
+          set: the dep export builds each dep's full default targets, which
+          a small main build may not have covered.
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -102,6 +139,14 @@ env:
   # Scope prefix for all puts and gets in this workflow. Namespaces the
   # workflow's artifacts within the cache bucket.
   SHADOW_SCOPE: mathlib4-master-shadow
+  # Space-separated deps excluded from shadow dependency caching.
+  # `proofwidgets` only builds from source with npm present; in `consume`
+  # its artifacts come from its own GitHub release fetch during the build,
+  # so caching it here buys nothing.
+  DEP_SKIP: proofwidgets
+  # Whether this run caches dependencies: always on schedule, else the
+  # `cache_deps` dispatch input.
+  CACHE_DEPS: ${{ (github.event_name != 'workflow_dispatch' || inputs.cache_deps) && 'true' || 'false' }}
   # NOTE: STAGE_TARGETS is set per-job (not here) from the `targets` input, so
   # it can be overridden per dispatch — see the `build_and_stage`/`consume` env.
   MATHLIB_CACHE_BASE_URL: ${{ vars.MATHLIB_CACHE_BASE_URL }}
@@ -172,6 +217,47 @@ jobs:
           # reach the first landrun step with it absent.
           mkdir -p "$HOME/.cache/mathlib/"
           mkdir -p _work
+
+      # Decide which deps to cache this run. A (dep, rev, toolchain) triple is
+      # deterministic, so a `<rev>.jsonl` already in the bucket means an
+      # earlier run uploaded that dep's mappings + artifacts and the whole
+      # export/stage/upload leg can be skipped. Also generate here (jq is not
+      # available inside landrun) the per-dep `--packages` overrides that pin
+      # each dep's dependency tree to this workspace's checkouts.
+      - name: Plan dependency caching
+        shell: bash -euo pipefail {0}
+        env:
+          LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: |
+          cd pr-branch
+          mkdir -p .lake/dep-plan
+          : > .lake/dep-plan/stage.txt
+          : > .lake/dep-plan/cached.txt
+          if [ "$CACHE_DEPS" != "true" ]; then
+            echo "::notice::dependency caching disabled for this run (cache_deps input)"
+            exit 0
+          fi
+          # Must mirror the slug in the warm-start/upload/consume dep steps.
+          tcslug="$(printf %s "$(cat lean-toolchain)" | tr -c 'A-Za-z0-9._-' '-')"
+          while read -r name rev; do
+            if [[ " $DEP_SKIP " == *" $name "* ]]; then
+              echo "::notice::dep $name: on the skip list; not cached"
+              continue
+            fi
+            url="$LAKE_CACHE_REVISION_ENDPOINT/$SHADOW_SCOPE/deps/$tcslug/$name/$rev.jsonl"
+            if curl -fsS -o /dev/null "$url" 2>/dev/null; then
+              echo "$name $rev" >> .lake/dep-plan/cached.txt
+            else
+              echo "$name $rev" >> .lake/dep-plan/stage.txt
+              # Overrides for the dep-as-root export build: every other
+              # workspace package as a path entry into this checkout.
+              jq --arg pfx "$PWD/.lake/packages" --arg self "$name" \
+                '{version, packages: [.packages[] | select(.name != $self)
+                  | {name, scope, configFile, inherited, type: "path", dir: ($pfx + "/" + .name)}]}' \
+                lake-manifest.json > ".lake/dep-plan/$name-overrides.json"
+            fi
+          done < <(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json)
+          echo "::notice::deps already cached: $(wc -l < .lake/dep-plan/cached.txt), to stage: $(wc -l < .lake/dep-plan/stage.txt)"
 
       - name: install elan
         shell: bash -euo pipefail {0}
@@ -281,14 +367,38 @@ jobs:
           lake cache get --scope="$SHADOW_SCOPE" --rev="$prev" \
             || echo "::warning::warm start from rev ${prev:0:12} failed; proceeding without it"
 
+      # On an override toolchain the legacy cache is skipped, so fetch the
+      # deps the bucket already serves (keyed by manifest rev); the main
+      # build then replays them instead of compiling from source. Pinned
+      # runs skip this: legacy hydration has already provided dep builds,
+      # and these downloads would be redundant bytes.
+      - name: Warm start dependencies from shadow scope
+        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
+        shell: bash -euo pipefail {0}
+        env:
+          LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+          LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: |
+          cd pr-branch
+          if [ ! -s .lake/dep-plan/cached.txt ]; then
+            echo "::notice::no cached deps to warm start"
+            exit 0
+          fi
+          tcslug="$(printf %s "$(cat lean-toolchain)" | tr -c 'A-Za-z0-9._-' '-')"
+          while read -r name rev; do
+            lake cache get --package="$name" \
+              --scope="$SHADOW_SCOPE/deps/$tcslug/$name" --rev="$rev" \
+              || echo "::warning::dep warm start failed for $name@${rev:0:12}; it will build from source"
+          done < .lake/dep-plan/cached.txt
+
       # Incremental build: with the legacy cache having hydrated .lake/build/
       # and the lakefile patched, Lake's pipeline runs to pack/cache any
       # modules whose .ltar+mapping aren't yet in Lake's cache. Module
       # source compilation is skipped where per-module traces match (which
       # they do for the 3 knobs we set), so the "work" here is bounded to
-      # cache population, not lean recompilation. Deps build transitively
-      # but their mappings don't end up in the bundle (Lake's `-o` only
-      # writes root-package outputs).
+      # cache population, not lean recompilation. Deps build transitively;
+      # their mappings don't land in `-o` (root-only) and are instead
+      # exported by the dep-as-root step below.
       - name: Incremental build (populate Lake's cache)
         run: |
           cd pr-branch
@@ -307,6 +417,45 @@ jobs:
           echo "mappings entries: $(wc -l < .lake/outputs.jsonl)"
           head -3 .lake/outputs.jsonl
 
+      # Export input-to-output mappings for the deps the bucket is missing
+      # (see "Dependency caching" at the top of this file). After the
+      # incremental build above, every dep artifact is already in the shared
+      # local cache, so these dep-as-root loads replay rather than compile —
+      # provided input hashes agree between the two workspace shapes.
+      # Divergence shows up as compile time here and as dep rebuilds in
+      # `consume`; both are part of what this shadow measures.
+      # LAKE_ARTIFACT_CACHE=true makes the dep-as-root workspaces
+      # cache-writable — the lakefile patch only covers the mathlib
+      # workspace. Per-dep failures are tolerated: that dep is just not
+      # cached this run.
+      - name: Export dependency mappings
+        # Override default landrun shell to pass LAKE_ARTIFACT_CACHE.
+        shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI --env LAKE_CACHE_DIR --env LAKE_NO_CACHE --env LAKE_ARTIFACT_CACHE -- bash -euxo pipefail {0}
+        env:
+          LAKE_ARTIFACT_CACHE: true
+        run: |
+          cd pr-branch
+          # The dep-as-root loads run with other workspace directories, so the
+          # cache dir must not be CWD-relative.
+          export LAKE_CACHE_DIR="$PWD/.lake/cache"
+          mkdir -p .lake/dep-outputs
+          if [ ! -s .lake/dep-plan/stage.txt ]; then
+            echo "no deps to export"
+            exit 0
+          fi
+          while read -r name rev; do
+            echo "::group::export $name"
+            if lake -d ".lake/packages/$name" build \
+                --packages="$PWD/.lake/dep-plan/$name-overrides.json" \
+                -o "$PWD/.lake/dep-outputs/$name.jsonl"; then
+              echo "exported $name: $(wc -l < ".lake/dep-outputs/$name.jsonl") mapping lines"
+            else
+              echo "::warning::failed to export mappings for dep $name; it will not be cached this run"
+              rm -f ".lake/dep-outputs/$name.jsonl"
+            fi
+            echo "::endgroup::"
+          done < .lake/dep-plan/stage.txt
+
       # Pre-create the staging dir outside landrun so the stage step can
       # write to it. Same pattern as build_template.yml uses for the legacy
       # cache-staging dir.
@@ -320,21 +469,35 @@ jobs:
         run: |
           cd pr-branch
           lake cache stage .lake/outputs.jsonl ../lake-cache-staging
+          # Stage each exported dep into its own subdirectory (`cache stage`
+          # writes one outputs.jsonl per directory) and record name+rev — and
+          # the already-cached set, for the upload summary — for the upload job.
+          mkdir -p ../lake-cache-staging/deps
+          cp .lake/dep-plan/cached.txt ../lake-cache-staging/deps/cached.txt
+          while read -r name rev; do
+            [ -f ".lake/dep-outputs/$name.jsonl" ] || continue
+            lake cache stage ".lake/dep-outputs/$name.jsonl" "../lake-cache-staging/deps/$name"
+            echo "$name $rev" >> ../lake-cache-staging/deps/manifest.txt
+          done < .lake/dep-plan/stage.txt
           du -sh ../lake-cache-staging | awk '{print "staging total:", $1}'
+          du -sh ../lake-cache-staging/deps | awk '{print "deps staging total:", $1}'
           echo "ltar count: $(find ../lake-cache-staging -name '*.ltar' | wc -l)"
 
       # Safety valve: the staged bytes are what gets uploaded (GH artifact → R2).
       # Bail before any upload if it would exceed the cap, to protect the R2
       # free-tier / lifecycle budget. Logs the size first, so a trip still tells
       # us how big the build got.
-      - name: Guard upload size (bail if staging > 1 GB)
+      - name: Guard upload size (bail if staging > 2 GB)
         shell: bash -euo pipefail {0}
         run: |
-          MAX=$((1 * 1000 * 1000 * 1000))   # 1 GB — ~2.5x the measured ~389 MB full build (runaway guard)
+          # 2 GB — headroom over the measured ~389 MB root build plus a
+          # first-run upload of every dep (deps re-stage only on manifest
+          # bumps or new toolchains, so steady-state stays near the root size).
+          MAX=$((2 * 1000 * 1000 * 1000))
           BYTES=$(du -sb lake-cache-staging | cut -f1)
-          echo "staging size: $(du -sh lake-cache-staging | cut -f1) (${BYTES} bytes); cap: 1 GB (${MAX} bytes)"
+          echo "staging size: $(du -sh lake-cache-staging | cut -f1) (${BYTES} bytes); cap: 2 GB (${MAX} bytes)"
           if [ "$BYTES" -gt "$MAX" ]; then
-            echo "::error::staging is over 1 GB — bailing before upload to protect the R2 free-tier / lifecycle budget"
+            echo "::error::staging is over 2 GB — bailing before upload to protect the R2 free-tier / lifecycle budget"
             exit 1
           fi
 
@@ -351,10 +514,12 @@ jobs:
     needs: build_and_stage
     if: ${{ github.repository == 'leanprover-community/mathlib4' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45 covers a first-run upload of every dep on top of the root set.
+    timeout-minutes: 45
     outputs:
       carryover: ${{ steps.carryover.outputs.summary }}
       new_content: ${{ steps.carryover.outputs.new_content }}
+      dep_uploads: ${{ steps.depupload.outputs.summary }}
     env:
       LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
       LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
@@ -406,6 +571,48 @@ jobs:
             --scope="${{ env.SHADOW_SCOPE }}" \
             --rev="${{ needs.build_and_stage.outputs.sha }}" \
             --toolchain="${{ needs.build_and_stage.outputs.toolchain }}" 2>&1 | tee /tmp/put.log
+
+      # Upload each staged dep under its toolchain-qualified scope, keyed by
+      # the dep's manifest revision (see "Dependency caching" at the top of
+      # this file). Deps already in the bucket were filtered out by the build
+      # job's plan step. Logged separately from /tmp/put.log so dep artifacts
+      # do not skew the root carryover analysis below.
+      - name: Upload dependency caches
+        id: depupload
+        continue-on-error: true
+        env:
+          EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
+        run: |
+          cd pr-branch
+          # Must mirror the slug in build_and_stage's plan step.
+          tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
+          skipped=0
+          if [ -f ../lake-cache-staging/deps/cached.txt ]; then
+            skipped=$(wc -l < ../lake-cache-staging/deps/cached.txt)
+          fi
+          if [ ! -f ../lake-cache-staging/deps/manifest.txt ]; then
+            echo "summary=0 uploaded, ${skipped} already cached" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ok=0 fail=0
+          : > /tmp/dep-put.log
+          while read -r name rev; do
+            if lake cache put-staged "../lake-cache-staging/deps/$name" \
+                --scope="$SHADOW_SCOPE/deps/$tcslug/$name" \
+                --rev="$rev" 2>&1 | tee -a /tmp/dep-put.log; then
+              ok=$((ok+1))
+            else
+              fail=$((fail+1))
+              echo "::warning::dep upload failed for $name@${rev:0:12}"
+            fi
+          done < ../lake-cache-staging/deps/manifest.txt
+          arts=$(grep -c 'uploaded artifact' /tmp/dep-put.log || true)
+          bytes=$(du -sb ../lake-cache-staging/deps | cut -f1)
+          failnote=""
+          [ "$fail" -gt 0 ] && failnote=", ${fail} FAILED"
+          summary="${ok} uploaded ($(numfmt --to=iec-i --suffix=B "$bytes") staged, ${arts} artifacts)${failnote}, ${skipped} already cached"
+          echo "::notice::dep uploads: ${summary}"
+          echo "summary=${summary}" >> "$GITHUB_OUTPUT"
 
       # Cache carryover analysis: diff this run's uploaded artifact set against
       # the previous run's on the same toolchain, via tiny per-run manifests
@@ -493,6 +700,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       cache_health: ${{ steps.cachehealth.outputs.health }}
+      dep_health: ${{ steps.cachehealth.outputs.dep_health }}
     env:
       # Must match the targets staged/uploaded by build_and_stage.
       STAGE_TARGETS: ${{ inputs.targets || 'Mathlib' }}
@@ -554,17 +762,45 @@ jobs:
           lake cache get \
             --scope="$SHADOW_SCOPE" \
             --rev="${{ needs.build_and_stage.outputs.sha }}"
-          # Artifacts fetched here = the root-package outputs served from cache
-          # (a non-verbose build replays them silently). Hand the count to the
-          # provenance step.
-          # `|| true`: an informational count must not trip pipefail if find fails.
-          FETCHED=$(find ~/.elan/toolchains -name '*.ltar' 2>/dev/null | wc -l || true)
-          echo "ltar count after get: $FETCHED"
-          echo "FETCHED_ARTIFACTS=$FETCHED" >> "$GITHUB_ENV"
+
+      # Fetch each dep's outputs from its toolchain-qualified shadow scope,
+      # keyed by the dep's manifest rev (exact lookup, no history walk). A
+      # miss degrades that dep to a source build; the provenance step reports
+      # the counts.
+      - name: lake cache get dependencies
+        if: ${{ env.CACHE_DEPS == 'true' }}
+        env:
+          EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
+        run: |
+          cd pr-branch
+          # Must mirror the slug in build_and_stage's plan step.
+          tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
+          total=0 hits=0
+          while read -r name rev; do
+            if [[ " $DEP_SKIP " == *" $name "* ]]; then continue; fi
+            total=$((total+1))
+            if lake cache get --package="$name" \
+                --scope="$SHADOW_SCOPE/deps/$tcslug/$name" --rev="$rev"; then
+              hits=$((hits+1))
+            else
+              echo "::warning::dep cache miss for $name@${rev:0:12}; it will build from source"
+            fi
+          done < <(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json)
+          echo "DEP_TOTAL=$total" >> "$GITHUB_ENV"
+          echo "DEP_HITS=$hits" >> "$GITHUB_ENV"
+          echo "::notice::dep cache: ${hits}/${total} fetched from shadow scope"
 
       - name: lake build
         run: |
           cd pr-branch
+          # Artifacts fetched = root + dep outputs the `cache get` steps
+          # served (a non-verbose build replays them silently). Count before
+          # the build, which can add ltars of its own; hand the count to the
+          # provenance step.
+          # `|| true`: an informational count must not trip pipefail if find fails.
+          FETCHED=$(find ~/.elan/toolchains -name '*.ltar' 2>/dev/null | wc -l || true)
+          echo "ltar count after gets: $FETCHED"
+          echo "FETCHED_ARTIFACTS=$FETCHED" >> "$GITHUB_ENV"
           read -ra TARGETS <<< "$STAGE_TARGETS"
           lake build "${TARGETS[@]}" 2>&1 | tee .lake/consume-build.log
 
@@ -573,17 +809,24 @@ jobs:
         run: |
           cd pr-branch
           log=.lake/consume-build.log
-          # "Served from cache" = the artifacts `lake cache get` fetched (replayed
-          # silently by a non-verbose build). "Built" = dependencies, which Lake
-          # never caches (`-o` records only `pkg.isRoot` outputs; only the root
-          # `mathlib` package sets `enableArtifactCache`) and always rebuilds.
+          # "Served from cache" = the artifacts the `lake cache get` steps
+          # fetched (replayed silently by a non-verbose build). "Built" =
+          # modules the pipeline ran for: with dep caching, only skip-list
+          # deps (whose artifacts come from their own release archives) and
+          # deps that missed the shadow scope should appear here.
           echo "Served from cache (fetched): ${FETCHED_ARTIFACTS}"
-          echo "Built from source (deps, expected): $(grep -cE '^✔.*Built ' "$log" || true)"
+          BUILT_TOTAL=$(grep -cE '^✔.*Built ' "$log" || true)
           # The cache invariant: every root-package module must be a cache HIT
-          # (no rebuild). Deps building is expected and excluded from the grep.
-          # Emit an explicit health line (consumed by the Zulip report) and fail
-          # the run if it's not a full hit.
+          # (no rebuild). Emit an explicit health line (consumed by the Zulip
+          # report) and fail the run if it's not a full hit.
           BUILT_ROOT=$(grep -cE '^✔.*Built (Mathlib|Archive|Counterexamples|Wanted)([. ]|$)' "$log" || true)
+          # Dep rebuilds are reported, not fatal: they measure whether the
+          # dep-as-root mappings actually match this workspace's input hashes
+          # (plus skip-list deps and shadow-scope misses, which always build).
+          BUILT_DEP=$((BUILT_TOTAL - BUILT_ROOT))
+          dep_health="📚 deps: ${DEP_HITS:-0}/${DEP_TOTAL:-0} fetched from shadow scope, ${BUILT_DEP} dep module(s) rebuilt (skip list: ${DEP_SKIP:-none})"
+          echo "dep_health=${dep_health}" >> "$GITHUB_OUTPUT"
+          echo "::notice::${dep_health}"
           if [ "$BUILT_ROOT" -ne 0 ]; then
             health="❌ NOT full cache hits — ${BUILT_ROOT} root-package module(s) rebuilt"
             echo "health=${health}" >> "$GITHUB_OUTPUT"
@@ -620,7 +863,9 @@ jobs:
           CONSUME: ${{ needs.consume.result }}
           CARRYOVER: ${{ needs.upload.outputs.carryover }}
           NEW_CONTENT: ${{ needs.upload.outputs.new_content }}
+          DEP_UPLOADS: ${{ needs.upload.outputs.dep_uploads }}
           CACHE_HEALTH: ${{ needs.consume.outputs.cache_health }}
+          DEP_HEALTH: ${{ needs.consume.outputs.dep_health }}
           SHA: ${{ needs.build_and_stage.outputs.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -643,8 +888,10 @@ jobs:
             echo "- $(emoji "$UPLOAD") upload: \`$UPLOAD\`"
             echo "- $(emoji "$CONSUME") consume: \`$CONSUME\`"
             echo "- ${CACHE_HEALTH:-❓ cache hits: n/a (consume skipped)}"
+            echo "- ${DEP_HEALTH:-📚 deps: n/a (consume skipped)}"
             echo "- 🔁 cache carryover: ${CARRYOVER:-n/a}"
             echo "- 📦 new content uploaded: ${NEW_CONTENT:-n/a}"
+            echo "- 🗂️ dep uploads: ${DEP_UPLOADS:-n/a}"
             echo "MSG_EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -160,8 +160,57 @@ jobs:
           rm -rf lake-cache-staging tools-branch
           echo "disk headroom: $(df -h --output=avail,pcent . | tail -1 | xargs) on $(hostname)"
 
+      - name: install elan
+        shell: bash -euo pipefail {0}
+        run: |
+          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
+          chmod +x elan-init.sh
+          ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      # `elan which` below does not install a toolchain the repo does not pin.
+      # The uninstall forces a fresh download: elan skips a toolchain that is
+      # already present, and a pr-release tag is republished under the same
+      # name.
+      - name: Install override toolchain
+        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
+        shell: bash -euo pipefail {0}
+        run: |
+          elan toolchain uninstall "$TOOLCHAIN_OVERRIDE" || true
+          elan toolchain install "$TOOLCHAIN_OVERRIDE"
+
+      - name: set toolchain directory
+        shell: bash -euo pipefail {0}
+        run: |
+          cd pr-branch
+          LAKE_PATH=$(elan which lake)
+          TOOLCHAIN_DIR=$(dirname "$(dirname "$LAKE_PATH")")
+          echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> "$GITHUB_ENV"
+
+      - name: set LEAN_SRC_PATH
+        shell: bash -euo pipefail {0}
+        run: |
+          cd pr-branch
+          LEAN_SRC_PATH=".:$TOOLCHAIN_DIR/src/lean/lake"
+          PACKAGE_NAMES=$(jq -r '.packages[].name' lake-manifest.json)
+          for pkg in $PACKAGE_NAMES; do
+            if [[ "$pkg" =~ ^[A-Za-z0-9_-]+$ ]]; then
+              LEAN_SRC_PATH="$LEAN_SRC_PATH:.lake/packages/$pkg"
+            fi
+          done
+          echo "LEAN_SRC_PATH=$LEAN_SRC_PATH" >> "$GITHUB_ENV"
+
+      - name: download dependencies
+        shell: landrun --unrestricted-network --rox /etc --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
+        run: |
+          cd pr-branch
+          lake env
+
       # Plan the hydration and the dependency caching of this run. The plan
-      # is an optimization: it decides what this run can skip.
+      # itself is an optimization: it decides what this run can skip. It has to
+      # run after `lake env`, because it reads the manifest of each dependency
+      # to derive that dependency's upstream closure, and `lake env` is what
+      # materializes the dependency checkouts.
       #   * Write the Lake services file that the `lake cache get` steps read
       #     through LAKE_CONFIG.
       #   * Resolve the analysis-chain pointer of this toolchain. A warm chain
@@ -245,6 +294,8 @@ jobs:
                           queue.append(d)
               if not known:
                   out[name] = whole
+                  print(f"::warning::{name}: upstream closure unknown; "
+                        "keyed by the whole manifest", file=sys.stderr)
               elif closure:
                   out[name] = h(f"{d} {pins[d]}" for d in closure)
               else:
@@ -311,52 +362,6 @@ jobs:
             fi
           done < <(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json)
           echo "::notice::deps already cached: $(wc -l < .lake/dep-plan/cached.txt), to stage: $(wc -l < .lake/dep-plan/stage.txt)"
-
-      - name: install elan
-        shell: bash -euo pipefail {0}
-        run: |
-          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
-          chmod +x elan-init.sh
-          ./elan-init.sh -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
-
-      # `elan which` below does not install a toolchain the repo does not pin.
-      # The uninstall forces a fresh download: elan skips a toolchain that is
-      # already present, and a pr-release tag is republished under the same
-      # name.
-      - name: Install override toolchain
-        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
-        shell: bash -euo pipefail {0}
-        run: |
-          elan toolchain uninstall "$TOOLCHAIN_OVERRIDE" || true
-          elan toolchain install "$TOOLCHAIN_OVERRIDE"
-
-      - name: set toolchain directory
-        shell: bash -euo pipefail {0}
-        run: |
-          cd pr-branch
-          LAKE_PATH=$(elan which lake)
-          TOOLCHAIN_DIR=$(dirname "$(dirname "$LAKE_PATH")")
-          echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> "$GITHUB_ENV"
-
-      - name: set LEAN_SRC_PATH
-        shell: bash -euo pipefail {0}
-        run: |
-          cd pr-branch
-          LEAN_SRC_PATH=".:$TOOLCHAIN_DIR/src/lean/lake"
-          PACKAGE_NAMES=$(jq -r '.packages[].name' lake-manifest.json)
-          for pkg in $PACKAGE_NAMES; do
-            if [[ "$pkg" =~ ^[A-Za-z0-9_-]+$ ]]; then
-              LEAN_SRC_PATH="$LEAN_SRC_PATH:.lake/packages/$pkg"
-            fi
-          done
-          echo "LEAN_SRC_PATH=$LEAN_SRC_PATH" >> "$GITHUB_ENV"
-
-      - name: download dependencies
-        shell: landrun --unrestricted-network --rox /etc --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
-        run: |
-          cd pr-branch
-          lake env
 
       # The bootstrap fallback, an optimization for a cold chain. A pinned run
       # normally hydrates from the shadow
@@ -1126,6 +1131,8 @@ jobs:
                           queue.append(d)
               if not known:
                   out[name] = whole
+                  print(f"::warning::{name}: upstream closure unknown; "
+                        "keyed by the whole manifest", file=sys.stderr)
               elif closure:
                   out[name] = h(f"{d} {pins[d]}" for d in closure)
               else:

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -55,19 +55,41 @@ name: Lake cache shadow (master)
 #   workspace's checkouts (a dep's own manifest can pin different revs,
 #   which would yield mappings this workspace's input hashes never match).
 #   Each dep is uploaded under scope
-#     <SHADOW_SCOPE>/deps/<toolchain-slug>/<dep>
-#   keyed by the dep's lake-manifest.json revision. The toolchain slug in
-#   the scope keeps toolchains from overwriting each other's <rev>.jsonl:
-#   dep revs are long-lived, unlike mathlib's. A dep whose <rev>.jsonl is
-#   already in the bucket is skipped end-to-end (dep uploads happen only on
-#   manifest bumps or new toolchains). `consume` fetches each dep with
+#     <SHADOW_SCOPE>/deps/<toolchain-slug>/<pins-hash>/<dep>
+#   keyed by the dep's lake-manifest.json revision. The two scope
+#   qualifiers make the key exact where a bare dep rev is not:
+#     * toolchain slug — dep revs are long-lived, unlike mathlib's, so one
+#       rev is built under many toolchains over its lifetime;
+#     * pins hash (8 hex chars over the manifest's sorted name+rev pairs) —
+#       a dep's input hashes incorporate its *upstreams'* artifacts, so a
+#       partial manifest bump (say batteries only) changes the correct
+#       mappings for aesop without changing aesop's rev. This mirrors the
+#       legacy cache's root hash, which covers the whole manifest.
+#   A dep whose <rev>.jsonl is already in the bucket is skipped end-to-end
+#   (dep uploads happen only on manifest or toolchain bumps, which re-key
+#   and re-upload every dep). `consume` fetches each dep with
 #   `lake cache get --package=<dep> --rev=<manifest-rev>`; the same fetch
-#   warm-starts override runs, which cannot use the legacy cache.
-#   Deps in DEP_SKIP are excluded (see the env note). Per-dep steps are
+#   warm-starts runs that skip legacy hydration. Deps in DEP_SKIP are
+#   excluded (empty by default; see the env note). Per-dep steps are
 #   failure-tolerant: a miss or export failure degrades that dep to a
 #   source build, reported in the consume health line, and a toolchain
 #   older than v4.34.0-rc2 (no `cache get --package`) degrades the same
 #   way rather than failing the pipeline.
+#
+# Hydration & the legacy cache:
+#   Pinned runs hydrate from the shadow scope itself: the root package warm
+#   starts from the previous run on this toolchain's analysis chain, deps
+#   from their per-dep scopes, and the incremental build compiles only the
+#   churn since — i.e. the steady state a migrated CI would run. The legacy
+#   cache is a bootstrap fallback only, used when the analysis chain has no
+#   prior run (a fresh toolchain generation on the repo pin). Override runs
+#   never use it (it is keyed to the repo pin).
+#
+# Cache service configuration:
+#   Jobs consume the endpoint Variables below through a generated Lake
+#   services file (`LAKE_CONFIG` + `--service=shadow`), the supported
+#   mechanism; the raw LAKE_CACHE_*_ENDPOINT env vars are deprecated in
+#   Lake and only used here for plain-curl probes and analysis uploads.
 #
 # Toolchain override:
 #   The `toolchain_override` input, or else the LAKE_SHADOW_TOOLCHAIN_OVERRIDE
@@ -119,9 +141,9 @@ on:
       cache_deps:
         description: >-
           also cache dependencies (see "Dependency caching" at the top of
-          this file). Disable for cheap experiments with a small `targets`
-          set: the dep export builds each dep's full default targets, which
-          a small main build may not have covered.
+          this file). Disabling skips the dep export/upload/fetch legs; note
+          that on a warm chain the deps then build from source in
+          build_and_stage (the legacy cache only runs on a cold chain).
         required: false
         type: boolean
         default: true
@@ -144,11 +166,12 @@ env:
   # Scope prefix for all puts and gets in this workflow. Namespaces the
   # workflow's artifacts within the cache bucket.
   SHADOW_SCOPE: mathlib4-master-shadow
-  # Space-separated deps excluded from shadow dependency caching.
-  # `proofwidgets` only builds from source with npm present; in `consume`
-  # its artifacts come from its own GitHub release fetch during the build,
-  # so caching it here buys nothing.
-  DEP_SKIP: proofwidgets
+  # Space-separated deps excluded from shadow dependency caching — an escape
+  # hatch, empty by default (everything is cached). Even proofwidgets caches
+  # cleanly: its npm-built JS and the Lake traces guarding the npm steps are
+  # committed to its repo, so builds at pinned revs never invoke npm and its
+  # Lean modules cache like any other dep's.
+  DEP_SKIP: ''
   # Whether this run caches dependencies: always on schedule, else the
   # `cache_deps` dispatch input.
   CACHE_DEPS: ${{ (github.event_name != 'workflow_dispatch' || inputs.cache_deps) && 'true' || 'false' }}
@@ -161,8 +184,11 @@ jobs:
     name: Build + stage
     if: ${{ github.repository == 'leanprover-community/mathlib4' }}
     runs-on: pr
-    # 240 covers the full source build of a toolchain generation's first run.
-    timeout-minutes: ${{ (inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE) && 240 || 90 }}
+    # Pinned runs warm-start from the shadow scope and compile the churn since
+    # the previous run from source (plus a full dep build on manifest-bump
+    # days); 150 covers that. 240 covers the full source build of an override
+    # toolchain generation's first run.
+    timeout-minutes: ${{ (inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE) && 240 || 150 }}
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
       toolchain: ${{ steps.resolve.outputs.toolchain }}
@@ -180,12 +206,6 @@ jobs:
 
       - name: Setup jq
         uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
-
-      - name: Checkout tools branch
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: master
-          path: tools-branch
 
       - name: Checkout mathlib (pr-branch)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -223,33 +243,67 @@ jobs:
           mkdir -p "$HOME/.cache/mathlib/"
           mkdir -p _work
 
-      # Decide which deps to cache this run. A (dep, rev, toolchain) triple is
-      # deterministic, so a `<rev>.jsonl` already in the bucket means an
-      # earlier run uploaded that dep's mappings + artifacts and the whole
-      # export/stage/upload leg can be skipped. Also generate here (jq is not
-      # available inside landrun) the per-dep `--packages` overrides that pin
-      # each dep's dependency tree to this workspace's checkouts.
-      - name: Plan dependency caching
+      # Plan this run's hydration and dep caching:
+      #   * generate the Lake cache-services file (public read endpoints)
+      #     that later `lake cache get` steps use via LAKE_CONFIG;
+      #   * resolve this toolchain's analysis-chain pointer — a warm chain
+      #     means the shadow scope itself hydrates the root and the legacy
+      #     cache stays unused (bootstrap fallback only);
+      #   * decide which deps to stage: a (dep rev, toolchain, pins-hash)
+      #     triple is deterministic, so a `<rev>.jsonl` already in the
+      #     bucket means the whole export/stage/upload leg can be skipped.
+      #     On a manifest bump the pins hash re-keys every dep, so all of
+      #     them re-stage and the deps build from source once.
+      #   Also generate here (jq is not available inside landrun) the
+      #   per-dep `--packages` overrides that pin each dep's dependency
+      #   tree to this workspace's checkouts.
+      - name: Plan hydration & dependency caching
         shell: bash -euo pipefail {0}
         env:
+          LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
         run: |
           cd pr-branch
           mkdir -p .lake/dep-plan
           : > .lake/dep-plan/stage.txt
           : > .lake/dep-plan/cached.txt
+          # Services file for the warm-start steps in this job (public
+          # endpoints; the upload job writes its own with the authenticated
+          # ones).
+          cat > .lake/shadow-services.toml <<EOF
+          [[cache.service]]
+          name = "shadow"
+          type = "s3"
+          artifactEndpoint = "$LAKE_CACHE_ARTIFACT_ENDPOINT"
+          revisionEndpoint = "$LAKE_CACHE_REVISION_ENDPOINT"
+          EOF
+          # Must mirror the slug/hash in the warm-start/upload/consume/
+          # downstream steps.
+          tcslug="$(printf %s "$(cat lean-toolchain)" | tr -c 'A-Za-z0-9._-' '-')"
+          pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
+          echo "TCSLUG=$tcslug" >> "$GITHUB_ENV"
+          echo "PINS8=$pins8" >> "$GITHUB_ENV"
+          # Root-chain probe: prev rev on this toolchain's analysis chain.
+          prev="$(curl -fsS "${LAKE_CACHE_ARTIFACT_ENDPOINT%/artifacts}/analysis/$tcslug/_latest.txt" 2>/dev/null || true)"
+          if [ -n "$prev" ]; then
+            echo "CHAIN_PREV=$prev" >> "$GITHUB_ENV"
+            echo "CHAIN_COLD=false" >> "$GITHUB_ENV"
+            echo "::notice::warm chain for $tcslug: prev rev ${prev:0:12}"
+          else
+            echo "CHAIN_PREV=" >> "$GITHUB_ENV"
+            echo "CHAIN_COLD=true" >> "$GITHUB_ENV"
+            echo "::notice::cold chain for $tcslug; pinned runs fall back to legacy hydration"
+          fi
           if [ "$CACHE_DEPS" != "true" ]; then
             echo "::notice::dependency caching disabled for this run (cache_deps input)"
             exit 0
           fi
-          # Must mirror the slug in the warm-start/upload/consume dep steps.
-          tcslug="$(printf %s "$(cat lean-toolchain)" | tr -c 'A-Za-z0-9._-' '-')"
           while read -r name rev; do
             if [[ " $DEP_SKIP " == *" $name "* ]]; then
               echo "::notice::dep $name: on the skip list; not cached"
               continue
             fi
-            url="$LAKE_CACHE_REVISION_ENDPOINT/$SHADOW_SCOPE/deps/$tcslug/$name/$rev.jsonl"
+            url="$LAKE_CACHE_REVISION_ENDPOINT/$SHADOW_SCOPE/deps/$tcslug/$pins8/$name/$rev.jsonl"
             if curl -fsS -o /dev/null "$url" 2>/dev/null; then
               echo "$name $rev" >> .lake/dep-plan/cached.txt
             else
@@ -304,22 +358,33 @@ jobs:
           done
           echo "LEAN_SRC_PATH=$LEAN_SRC_PATH" >> "$GITHUB_ENV"
 
-      - name: build tools-branch tools
-        shell: bash -euo pipefail {0}
-        run: |
-          cd tools-branch
-          lake build cache
-
       - name: download dependencies
         shell: landrun --unrestricted-network --rox /etc --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
         run: |
           cd pr-branch
           lake env
 
-      # The legacy cache is keyed to the repo's pinned toolchain — cold for an
-      # override toolchain, where the warm-start step below takes its place.
-      - name: Hydrate .lake/build via legacy cache
-        if: ${{ env.TOOLCHAIN_OVERRIDE == '' }}
+      # Bootstrap fallback only: pinned runs normally hydrate from the shadow
+      # scope (warm-start steps below); the legacy cache covers the one case
+      # they cannot — a cold analysis chain, i.e. a fresh toolchain
+      # generation on the repo pin. It is keyed to the repo pin, so override
+      # runs never use it.
+      - name: Checkout tools branch (legacy-cache fallback)
+        if: ${{ env.TOOLCHAIN_OVERRIDE == '' && env.CHAIN_COLD == 'true' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: master
+          path: tools-branch
+
+      - name: build tools-branch tools (legacy-cache fallback)
+        if: ${{ env.TOOLCHAIN_OVERRIDE == '' && env.CHAIN_COLD == 'true' }}
+        shell: bash -euo pipefail {0}
+        run: |
+          cd tools-branch
+          lake build cache
+
+      - name: Hydrate .lake/build via legacy cache (bootstrap fallback)
+        if: ${{ env.TOOLCHAIN_OVERRIDE == '' && env.CHAIN_COLD == 'true' }}
         shell: bash -euo pipefail {0}
         run: |
           cd pr-branch
@@ -350,68 +415,61 @@ jobs:
           awk '/^package mathlib where/,/^$/' lakefile.lean
           echo "::endgroup::"
 
-      # Seed Lake's artifact cache from the previous run on the same
-      # toolchain, whose rev comes from that toolchain's analysis chain
-      # (`analysis/<slug>/_latest.txt`). Only content the cache can't serve
-      # is packed or built; a toolchain's first run has no chain yet and
-      # proceeds from source.
+      # Primary root hydration: seed Lake's artifact cache from the previous
+      # run on the same toolchain (the chain pointer resolved by the plan
+      # step); the incremental build below then compiles only the churn
+      # since. A cold chain proceeds from the legacy fallback above (pinned)
+      # or from source (override).
       - name: Warm start from shadow scope
         shell: bash -euo pipefail {0}
         env:
-          LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
-          LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+          LAKE_CONFIG: .lake/shadow-services.toml
         run: |
-          # Must mirror the slug in the upload job's carryover step.
-          slug="$(printf %s "$(cat pr-branch/lean-toolchain)" | tr -c 'A-Za-z0-9._-' '-')"
-          prev="$(curl -fsS "${LAKE_CACHE_ARTIFACT_ENDPOINT%/artifacts}/analysis/$slug/_latest.txt" 2>/dev/null || true)"
-          if [ -z "$prev" ]; then
-            echo "::notice::no prior run recorded for chain $slug; proceeding without a warm start"
+          if [ -z "${CHAIN_PREV:-}" ]; then
+            echo "::notice::cold chain; proceeding without a root warm start"
             exit 0
           fi
           cd pr-branch
-          lake cache get --scope="$SHADOW_SCOPE" --rev="$prev" \
-            || echo "::warning::warm start from rev ${prev:0:12} failed; proceeding without it"
+          lake cache get --service=shadow --scope="$SHADOW_SCOPE" --rev="$CHAIN_PREV" \
+            || echo "::warning::warm start from rev ${CHAIN_PREV:0:12} failed; proceeding without it"
 
-      # On an override toolchain the legacy cache is skipped, so fetch the
-      # deps the bucket already serves (keyed by manifest rev); the main
-      # build then replays them instead of compiling from source. Pinned
-      # runs skip this: legacy hydration has already provided dep builds,
-      # and these downloads would be redundant bytes.
+      # Primary dep hydration: fetch the deps the bucket already serves
+      # (keyed by manifest rev); the main build then replays them instead of
+      # compiling from source. Skipped only when the legacy fallback already
+      # hydrated everything (pinned run on a cold chain). Deps the plan step
+      # found missing (first run after a manifest or toolchain bump) build
+      # from source in the incremental build and are exported below.
       - name: Warm start dependencies from shadow scope
-        if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
+        if: ${{ env.TOOLCHAIN_OVERRIDE != '' || env.CHAIN_COLD == 'false' }}
         shell: bash -euo pipefail {0}
         env:
-          LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
-          LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+          LAKE_CONFIG: .lake/shadow-services.toml
         run: |
           cd pr-branch
           if [ ! -s .lake/dep-plan/cached.txt ]; then
             echo "::notice::no cached deps to warm start"
             exit 0
           fi
-          tcslug="$(printf %s "$(cat lean-toolchain)" | tr -c 'A-Za-z0-9._-' '-')"
           while read -r name rev; do
-            lake cache get --package="$name" \
-              --scope="$SHADOW_SCOPE/deps/$tcslug/$name" --rev="$rev" \
+            lake cache get --service=shadow --package="$name" \
+              --scope="$SHADOW_SCOPE/deps/$TCSLUG/$PINS8/$name" --rev="$rev" \
               || echo "::warning::dep warm start failed for $name@${rev:0:12}; it will build from source"
           done < .lake/dep-plan/cached.txt
 
-      # Incremental build: with the legacy cache having hydrated .lake/build/
-      # and the lakefile patched, Lake's pipeline runs to pack/cache any
-      # modules whose .ltar+mapping aren't yet in Lake's cache. Module
-      # source compilation is skipped where per-module traces match (which
-      # they do for the 3 knobs we set), so the "work" here is bounded to
-      # cache population, not lean recompilation. Deps build transitively;
-      # their mappings don't land in `-o` (root-only) and are instead
-      # exported by the dep-as-root step below.
+      # Incremental build: with the warm start (or legacy fallback) having
+      # hydrated the artifact cache and the lakefile patched, this compiles
+      # the churn since the previous run — root modules changed since the
+      # chain's prev rev, plus any deps the bucket was missing — and
+      # packs/caches everything `-o` will record. Dep mappings don't land in
+      # `-o` (root-only); the dep-as-root step below exports them.
       - name: Incremental build (populate Lake's cache)
         run: |
           cd pr-branch
           lake build $STAGE_TARGETS 2>&1 | tee .lake/lake-build.log
           echo "::group::build summary"
           # Replays aren't counted: a non-verbose `lake build` restores cached
-          # outputs silently (no "Replayed" lines to grep). 0 built is the
-          # healthy case here — legacy hydration already populated .lake/build.
+          # outputs silently (no "Replayed" lines to grep). The count here is
+          # the day's churn — plus full dep builds on bump days.
           echo "Built (pipeline ran):    $(grep -cE '^✔.*Built '    .lake/lake-build.log || true)"
           echo "::endgroup::"
 
@@ -526,9 +584,23 @@ jobs:
       new_content: ${{ steps.carryover.outputs.new_content }}
       dep_uploads: ${{ steps.depupload.outputs.summary }}
     env:
-      LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
-      LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
+      # Uploads go through a generated Lake services file (authenticated S3
+      # endpoints) + LAKE_CACHE_KEY; see "Cache service configuration" above.
+      LAKE_CONFIG: ${{ github.workspace }}/shadow-services.toml
     steps:
+      - name: Write cache services config
+        env:
+          ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
+          REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
+        run: |
+          cat > "$LAKE_CONFIG" <<EOF
+          [[cache.service]]
+          name = "shadow"
+          type = "s3"
+          artifactEndpoint = "$ARTIFACT_ENDPOINT"
+          revisionEndpoint = "$REVISION_ENDPOINT"
+          EOF
+
       - name: Checkout mathlib (workspace for put-staged)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -573,6 +645,7 @@ jobs:
           # wired so the eventual migration to `--repo=` is a one-line
           # change rather than re-plumbing outputs.
           lake cache put-staged ../lake-cache-staging \
+            --service=shadow \
             --scope="${{ env.SHADOW_SCOPE }}" \
             --rev="${{ needs.build_and_stage.outputs.sha }}" \
             --toolchain="${{ needs.build_and_stage.outputs.toolchain }}" 2>&1 | tee /tmp/put.log
@@ -589,8 +662,9 @@ jobs:
           EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
         run: |
           cd pr-branch
-          # Must mirror the slug in build_and_stage's plan step.
+          # Must mirror the slug/hash in build_and_stage's plan step.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
+          pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           skipped=0
           if [ -f ../lake-cache-staging/deps/cached.txt ]; then
             skipped=$(wc -l < ../lake-cache-staging/deps/cached.txt)
@@ -603,7 +677,8 @@ jobs:
           : > /tmp/dep-put.log
           while read -r name rev; do
             if lake cache put-staged "../lake-cache-staging/deps/$name" \
-                --scope="$SHADOW_SCOPE/deps/$tcslug/$name" \
+                --service=shadow \
+                --scope="$SHADOW_SCOPE/deps/$tcslug/$pins8/$name" \
                 --rev="$rev" 2>&1 | tee -a /tmp/dep-put.log; then
               ok=$((ok+1))
             else
@@ -709,13 +784,28 @@ jobs:
     env:
       # Must match the targets staged/uploaded by build_and_stage.
       STAGE_TARGETS: ${{ inputs.targets || 'Mathlib' }}
-      # `lake cache get` issues unauthenticated GETs, so this job must read
-      # from a publicly-readable host. On R2 that is the bucket's public
-      # r2.dev (or custom-domain) URL, which is a different host than the
-      # authenticated S3 API endpoint used by the `upload` job's PUTs.
-      LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
-      LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+      # `lake cache get` issues unauthenticated GETs, so this job reads from
+      # a publicly-readable host (on R2, the bucket's public r2.dev or
+      # custom-domain URL — a different host than the authenticated S3 API
+      # endpoint the `upload` job PUTs to), via a generated services file.
+      LAKE_CONFIG: ${{ github.workspace }}/shadow-services.toml
+      # Disable barrel/build-cache auto-fetch: every replay in this job must
+      # be attributable to the shadow bucket.
+      LAKE_NO_CACHE: true
     steps:
+      - name: Write cache services config
+        env:
+          ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+          REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: |
+          cat > "$LAKE_CONFIG" <<EOF
+          [[cache.service]]
+          name = "shadow"
+          type = "s3"
+          artifactEndpoint = "$ARTIFACT_ENDPOINT"
+          revisionEndpoint = "$REVISION_ENDPOINT"
+          EOF
+
       - name: Checkout mathlib
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -765,6 +855,7 @@ jobs:
         run: |
           cd pr-branch
           lake cache get \
+            --service=shadow \
             --scope="$SHADOW_SCOPE" \
             --rev="${{ needs.build_and_stage.outputs.sha }}"
 
@@ -778,14 +869,15 @@ jobs:
           EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
         run: |
           cd pr-branch
-          # Must mirror the slug in build_and_stage's plan step.
+          # Must mirror the slug/hash in build_and_stage's plan step.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
+          pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           total=0 hits=0
           while read -r name rev; do
             if [[ " $DEP_SKIP " == *" $name "* ]]; then continue; fi
             total=$((total+1))
-            if lake cache get --package="$name" \
-                --scope="$SHADOW_SCOPE/deps/$tcslug/$name" --rev="$rev"; then
+            if lake cache get --service=shadow --package="$name" \
+                --scope="$SHADOW_SCOPE/deps/$tcslug/$pins8/$name" --rev="$rev"; then
               hits=$((hits+1))
             else
               echo "::warning::dep cache miss for $name@${rev:0:12}; it will build from source"
@@ -816,9 +908,9 @@ jobs:
           log=.lake/consume-build.log
           # "Served from cache" = the artifacts the `lake cache get` steps
           # fetched (replayed silently by a non-verbose build). "Built" =
-          # modules the pipeline ran for: with dep caching, only skip-list
-          # deps (whose artifacts come from their own release archives) and
-          # deps that missed the shadow scope should appear here.
+          # modules the pipeline ran for: only deps that missed the shadow
+          # scope (or skip-listed ones, if any) should appear here; the
+          # expected steady state is zero.
           echo "Served from cache (fetched): ${FETCHED_ARTIFACTS}"
           BUILT_TOTAL=$(grep -cE '^✔.*Built ' "$log" || true)
           # The cache invariant: every root-package module must be a cache HIT
@@ -870,14 +962,26 @@ jobs:
     outputs:
       health: ${{ steps.health.outputs.health }}
     env:
-      LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
-      LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+      LAKE_CONFIG: ${{ github.workspace }}/shadow-services.toml
       # Disable barrel/build-cache auto-fetch so every replay in this job is
       # attributable to the shadow bucket.
       LAKE_NO_CACHE: true
       EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
       MATHLIB_SHA: ${{ needs.build_and_stage.outputs.sha }}
     steps:
+      - name: Write cache services config
+        env:
+          ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+          REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: |
+          cat > "$LAKE_CONFIG" <<EOF
+          [[cache.service]]
+          name = "shadow"
+          type = "s3"
+          artifactEndpoint = "$ARTIFACT_ENDPOINT"
+          revisionEndpoint = "$REVISION_ENDPOINT"
+          EOF
+
       - name: install elan
         run: |
           curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
@@ -919,8 +1023,11 @@ jobs:
       - name: lake cache get (mathlib + transitive deps)
         run: |
           cd downstream
-          # Must mirror the slug in build_and_stage's plan step.
+          # Must mirror the slug/hash in build_and_stage's plan step. The
+          # pins hash comes from *mathlib's* manifest (inside this
+          # workspace), which is what a real downstream driver would read.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
+          pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' .lake/packages/mathlib/lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           total=0 hits=0
           while read -r name rev; do
             if [[ " $DEP_SKIP " == *" $name "* ]]; then continue; fi
@@ -928,9 +1035,9 @@ jobs:
             if [ "$name" = mathlib ]; then
               scope="$SHADOW_SCOPE"
             else
-              scope="$SHADOW_SCOPE/deps/$tcslug/$name"
+              scope="$SHADOW_SCOPE/deps/$tcslug/$pins8/$name"
             fi
-            if lake cache get --package="$name" --scope="$scope" --rev="$rev"; then
+            if lake cache get --service=shadow --package="$name" --scope="$scope" --rev="$rev"; then
               hits=$((hits+1))
             else
               echo "::warning::downstream cache miss for $name@${rev:0:12}; it will build from source"

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -243,6 +243,18 @@ jobs:
           mkdir -p "$HOME/.cache/mathlib/"
           mkdir -p _work
 
+      # The runners are ephemeral, so this is defensive hygiene rather than a
+      # leak fix (these paths live outside the pr-branch checkout, beyond
+      # `git clean`'s reach, so they would go stale if a workspace were ever
+      # reused). The `df` line is the useful part: the run needs a few GB of
+      # headroom (build dirs + artifact cache + ~1 GB staging), and some
+      # runner hosts carry a lot of baseline disk usage.
+      - name: Clean workspace leftovers & log disk headroom
+        shell: bash -euo pipefail {0}
+        run: |
+          rm -rf lake-cache-staging tools-branch
+          echo "disk headroom: $(df -h --output=avail,pcent . | tail -1 | xargs) on $(hostname)"
+
       # Plan this run's hydration and dep caching:
       #   * generate the Lake cache-services file (public read endpoints)
       #     that later `lake cache get` steps use via LAKE_CONFIG;

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -966,6 +966,10 @@ jobs:
       # Disable barrel/build-cache auto-fetch so every replay in this job is
       # attributable to the shadow bucket.
       LAKE_NO_CACHE: true
+      # Skip mathlib's post-update hook: it runs the legacy `cache get` when
+      # mathlib is updated as a dependency, which would hydrate the build
+      # dirs from the legacy cache and mask what the shadow bucket serves.
+      MATHLIB_NO_CACHE_ON_UPDATE: "1"
       EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
       MATHLIB_SHA: ${{ needs.build_and_stage.outputs.sha }}
     steps:

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -97,7 +97,7 @@ jobs:
       # The scope qualifiers, so the later jobs use these values and do not
       # derive them again.
       tcslug: ${{ steps.plan.outputs.tcslug }}
-      pins8: ${{ steps.plan.outputs.pins8 }}
+      pins: ${{ steps.plan.outputs.pins }}
     env:
       LAKE_CACHE_DIR: .lake/cache
       LAKE_NO_CACHE: true
@@ -200,14 +200,62 @@ jobs:
           #   tcslug  The toolchain, with each character outside A-Za-z0-9._-
           #           replaced by '-'. "leanprover/lean4:v4.34.0-rc2" becomes
           #           "leanprover-lean4-v4.34.0-rc2".
-          #   pins8   8 hex characters over the sorted "<name> <rev>" git
-          #           entries of the manifest, for example "2d10dd67".
+          #   pins    One hash per dependency, over the pins of that
+          #           dependency's transitive upstreams. A dependency with no
+          #           upstream gets the constant "noup".
           tcslug="$(printf %s "$(cat lean-toolchain)" | tr -c 'A-Za-z0-9._-' '-')"
-          pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
+          # The input hashes of a dependency cover the artifacts of its
+          # upstreams, so its scope must change when an upstream pin changes.
+          # A hash of the whole manifest would do that, but it would also
+          # re-key every dependency whose upstreams did not move, and mathlib
+          # bumps a dependency about every other day. This hashes the upstream
+          # closure of each dependency instead. Where the closure is unknown,
+          # because a manifest is missing or names a package this workspace
+          # does not pin, the whole manifest is hashed for that dependency:
+          # that over-keys, which costs an upload, where under-keying would
+          # cost a silent miss.
+          pins="$(python3 - <<'PY'
+          import hashlib, json, pathlib, sys
+          root = sys.argv[1] if len(sys.argv) > 1 else "lake-manifest.json"
+          pins = {q["name"]: q["rev"] for q in json.load(open(root))["packages"]
+                  if q.get("type") == "git"}
+          def h(lines):
+              return hashlib.sha256("\n".join(sorted(lines)).encode()).hexdigest()[:8]
+          whole = h(f"{n} {r}" for n, r in pins.items())
+          def direct(name):
+              mf = pathlib.Path(".lake/packages") / name / "lake-manifest.json"
+              if not mf.exists():
+                  return None
+              return [q["name"] for q in json.load(open(mf)).get("packages", [])
+                      if q.get("type") == "git"]
+          out = {}
+          for name in pins:
+              closure, queue, known = set(), [name], True
+              while queue and known:
+                  ds = direct(queue.pop())
+                  if ds is None:
+                      known = False
+                      break
+                  for d in ds:
+                      if d not in pins:
+                          known = False
+                          break
+                      if d not in closure:
+                          closure.add(d)
+                          queue.append(d)
+              if not known:
+                  out[name] = whole
+              elif closure:
+                  out[name] = h(f"{d} {pins[d]}" for d in closure)
+              else:
+                  out[name] = "noup"
+          print(json.dumps(out, sort_keys=True, separators=(",", ":")))
+          PY
+          )"
           echo "TCSLUG=$tcslug" >> "$GITHUB_ENV"
-          echo "PINS8=$pins8" >> "$GITHUB_ENV"
           echo "tcslug=$tcslug" >> "$GITHUB_OUTPUT"
-          echo "pins8=$pins8" >> "$GITHUB_OUTPUT"
+          echo "pins=$pins" >> "$GITHUB_OUTPUT"
+          echo "::notice::upstream pin hashes: $pins"
           # `analysis/<tcslug>/_latest.txt` holds the mathlib sha of the
           # previous run on this toolchain. It returns 404 on a chain that has
           # never run, and that run has no warm start.
@@ -226,19 +274,21 @@ jobs:
             exit 0
           fi
           # Each dependency goes into one of two plan files, which both hold
-          # "<name> <rev>" per line. cached.txt lists what the bucket serves,
-          # and the warm start reads it. stage.txt lists what this run must
-          # build, export and upload.
+          # "<name> <rev> <pin-hash>" per line. cached.txt lists what the
+          # bucket serves, and the warm start reads it. stage.txt lists what
+          # this run must build, export and upload. The hash travels with the
+          # name, so the later steps and the upload job do not derive it again.
           while read -r name rev; do
             if [[ " $DEP_SKIP " == *" $name "* ]]; then
               echo "::notice::dep $name: on the skip list; not cached"
               continue
             fi
-            url="$LAKE_CACHE_REVISION_ENDPOINT/$SHADOW_SCOPE/deps/$tcslug/$pins8/$name/$rev.jsonl"
+            ph="$(jq -r --arg d "$name" '.[$d]' <<< "$pins")"
+            url="$LAKE_CACHE_REVISION_ENDPOINT/$SHADOW_SCOPE/deps/$tcslug/$ph/$name/$rev.jsonl"
             if curl -fsS -o /dev/null "$url" 2>/dev/null; then
-              echo "$name $rev" >> .lake/dep-plan/cached.txt
+              echo "$name $rev $ph" >> .lake/dep-plan/cached.txt
             else
-              echo "$name $rev" >> .lake/dep-plan/stage.txt
+              echo "$name $rev $ph" >> .lake/dep-plan/stage.txt
               # The overrides for the export build of this dependency. They
               # rewrite every other workspace package as a path entry into this
               # checkout, so the standalone load resolves the upstreams to
@@ -395,15 +445,16 @@ jobs:
             echo "::notice::no cached deps to warm start"
             exit 0
           fi
-          # TCSLUG and PINS8 arrive from the plan step through $GITHUB_ENV.
+          # TCSLUG arrives from the plan step through $GITHUB_ENV, and the
+          # third column of cached.txt is that dependency's upstream pin hash.
           # For batteries the scope below is
           #   mathlib4-master-shadow/deps/leanprover-lean4-v4.34.0-rc2/2d10dd67/batteries
           # and `--rev` is the manifest revision of batteries. The lookup is
           # exact, so a miss returns at once and does not walk `--max-revs`
           # ancestors.
-          while read -r name rev; do
+          while read -r name rev ph; do
             lake cache get --service=shadow --package="$name" \
-              --scope="$SHADOW_SCOPE/deps/$TCSLUG/$PINS8/$name" --rev="$rev" \
+              --scope="$SHADOW_SCOPE/deps/$TCSLUG/$ph/$name" --rev="$rev" \
               || echo "::warning::dep warm start failed for $name@${rev:0:12}; it will build from source"
           done < .lake/dep-plan/cached.txt
 
@@ -467,7 +518,7 @@ jobs:
           # The upload job pushes this file to
           # revisions/<dep scope>/<dep rev>.jsonl, and the .ltar files it
           # names to artifacts/<dep scope>/.
-          while read -r name rev; do
+          while read -r name _ _; do
             echo "::group::export $name"
             if lake -d ".lake/packages/$name" build \
                 --packages="$PWD/.lake/dep-plan/$name-overrides.json" \
@@ -513,13 +564,13 @@ jobs:
           lake cache stage .lake/outputs.jsonl ../lake-cache-staging
           mkdir -p ../lake-cache-staging/deps
           cp .lake/dep-plan/cached.txt ../lake-cache-staging/deps/cached.txt
-          while read -r name rev; do
+          while read -r name rev ph; do
             # A dependency whose export failed has no mappings file, but
             # stage.txt still lists it. Skip it instead of staging a part of
             # it.
             [ -f ".lake/dep-outputs/$name.jsonl" ] || continue
             lake cache stage ".lake/dep-outputs/$name.jsonl" "../lake-cache-staging/deps/$name"
-            echo "$name $rev" >> ../lake-cache-staging/deps/manifest.txt
+            echo "$name $rev $ph" >> ../lake-cache-staging/deps/manifest.txt
           done < .lake/dep-plan/stage.txt
           du -sh ../lake-cache-staging | awk '{print "staging total:", $1}'
           du -sh ../lake-cache-staging/deps | awk '{print "deps staging total:", $1}'
@@ -644,7 +695,6 @@ jobs:
         continue-on-error: true
         env:
           TCSLUG: ${{ needs.build_and_stage.outputs.tcslug }}
-          PINS8: ${{ needs.build_and_stage.outputs.pins8 }}
         run: |
           cd pr-branch
           skipped=0
@@ -659,10 +709,11 @@ jobs:
           fi
           ok=0 fail=0
           : > /tmp/dep-put.log
-          while read -r name rev; do
+          # The third column is the upstream pin hash the plan step derived.
+          while read -r name rev ph; do
             if lake cache put-staged "../lake-cache-staging/deps/$name" \
                 --service=shadow \
-                --scope="$SHADOW_SCOPE/deps/$TCSLUG/$PINS8/$name" \
+                --scope="$SHADOW_SCOPE/deps/$TCSLUG/$ph/$name" \
                 --rev="$rev" 2>&1 | tee -a /tmp/dep-put.log; then
               ok=$((ok+1))
             else
@@ -858,15 +909,18 @@ jobs:
         if: ${{ env.CACHE_DEPS == 'true' }}
         env:
           TCSLUG: ${{ needs.build_and_stage.outputs.tcslug }}
-          PINS8: ${{ needs.build_and_stage.outputs.pins8 }}
+          PINS: ${{ needs.build_and_stage.outputs.pins }}
         run: |
           cd pr-branch
+          # PINS maps each dependency to the hash of its upstream pins, as the
+          # plan step derived it.
           total=0 hits=0
           while read -r name rev; do
             if [[ " $DEP_SKIP " == *" $name "* ]]; then continue; fi
             total=$((total+1))
+            ph="$(jq -r --arg d "$name" '.[$d]' <<< "$PINS")"
             if lake cache get --service=shadow --package="$name" \
-                --scope="$SHADOW_SCOPE/deps/$TCSLUG/$PINS8/$name" --rev="$rev"; then
+                --scope="$SHADOW_SCOPE/deps/$TCSLUG/$ph/$name" --rev="$rev"; then
               hits=$((hits+1))
             else
               echo "::warning::dep cache miss for $name@${rev:0:12}; it will build from source"
@@ -1035,11 +1089,50 @@ jobs:
           # This job derives the qualifiers itself, where the other jobs read
           # them from build_and_stage. That is the point of the job: a real
           # downstream project has no access to mathlib's CI outputs, and must
-          # arrive at the same scope from what it holds locally. The pin hash
-          # therefore comes from mathlib's manifest, which this workspace holds
-          # at .lake/packages/mathlib/.
+          # arrive at the same scope from what it holds locally. The derivation
+          # below is therefore a copy of the plan step's, rooted at mathlib's
+          # manifest, which this workspace holds at .lake/packages/mathlib/.
+          # The dependency manifests sit at .lake/packages/<name>/ in both
+          # workspaces, so the rest of the computation is identical.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
-          pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' .lake/packages/mathlib/lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
+          pins="$(python3 - .lake/packages/mathlib/lake-manifest.json <<'PY'
+          import hashlib, json, pathlib, sys
+          root = sys.argv[1] if len(sys.argv) > 1 else "lake-manifest.json"
+          pins = {q["name"]: q["rev"] for q in json.load(open(root))["packages"]
+                  if q.get("type") == "git"}
+          def h(lines):
+              return hashlib.sha256("\n".join(sorted(lines)).encode()).hexdigest()[:8]
+          whole = h(f"{n} {r}" for n, r in pins.items())
+          def direct(name):
+              mf = pathlib.Path(".lake/packages") / name / "lake-manifest.json"
+              if not mf.exists():
+                  return None
+              return [q["name"] for q in json.load(open(mf)).get("packages", [])
+                      if q.get("type") == "git"]
+          out = {}
+          for name in pins:
+              closure, queue, known = set(), [name], True
+              while queue and known:
+                  ds = direct(queue.pop())
+                  if ds is None:
+                      known = False
+                      break
+                  for d in ds:
+                      if d not in pins:
+                          known = False
+                          break
+                      if d not in closure:
+                          closure.add(d)
+                          queue.append(d)
+              if not known:
+                  out[name] = whole
+              elif closure:
+                  out[name] = h(f"{d} {pins[d]}" for d in closure)
+              else:
+                  out[name] = "noup"
+          print(json.dumps(out, sort_keys=True, separators=(",", ":")))
+          PY
+          )"
           # Two manifests are in play. The pin hash above comes from
           # mathlib's, and the loop below reads the downstream project's, which
           # lists mathlib and the 8 dependencies it inherited. mathlib
@@ -1052,7 +1145,7 @@ jobs:
             if [ "$name" = mathlib ]; then
               scope="$SHADOW_SCOPE"
             else
-              scope="$SHADOW_SCOPE/deps/$tcslug/$pins8/$name"
+              scope="$SHADOW_SCOPE/deps/$tcslug/$(jq -r --arg d "$name" '.[$d]' <<< "$pins")/$name"
             fi
             if lake cache get --service=shadow --package="$name" --scope="$scope" --rev="$rev"; then
               hits=$((hits+1))

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -1,56 +1,48 @@
 name: Lake cache shadow (master)
 
-# Shadow pipeline that exercises Lake's built-in artifact cache against
-# the live mathlib4 master branch, alongside (and independent of) the
-# regular master CI. Uploads to an isolated `mathlib4-master-shadow`
-# scope so no other consumer reads from it.
+# A shadow pipeline for Lake's built-in artifact cache. It runs against the
+# live mathlib4 master branch, beside the regular master CI and independent
+# of it. It writes to an isolated `mathlib4-master-shadow` scope, so no other
+# consumer reads what it produces.
 #
 # Required repository configuration:
 #   Secrets:
 #     LAKE_CACHE_KEY                         — SigV4 credential for the cache
 #                                              bucket, as `<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>`
 #                                              (curl `--user`; region is `auto`).
-#     ZULIP_API_KEY                          — Zulip bot key, used by the `report` job.
+#     ZULIP_API_KEY                          — Zulip bot key for the `report` job.
 #   Variables:
-#     # Authenticated S3 endpoint, used by `upload` for PUTs.
+#     # The authenticated S3 endpoint. The `upload` job PUTs to it.
 #     LAKE_CACHE_ARTIFACT_ENDPOINT           — e.g. https://<acct>.r2.cloudflarestorage.com/<bucket>/<prefix>/artifacts
 #     LAKE_CACHE_REVISION_ENDPOINT           — e.g. https://<acct>.r2.cloudflarestorage.com/<bucket>/<prefix>/revisions
-#     # Public read endpoint, used by `consume` for anonymous GETs (different
-#     # host than the S3 API endpoint; e.g. an R2 public r2.dev/custom domain).
+#     # The public read endpoint, for anonymous GETs. On R2 this is a
+#     # different host than the S3 API endpoint above.
 #     LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC    — e.g. https://pub-<hash>.r2.dev/<prefix>/artifacts
 #     LAKE_CACHE_REVISION_ENDPOINT_PUBLIC    — e.g. https://pub-<hash>.r2.dev/<prefix>/revisions
-#     # Optional. Default toolchain override for every run, including
-#     # scheduled ones; the dispatch input takes precedence. Unset to run
-#     # on the repo pin.
+#     # Optional. It sets the toolchain override for every run. The dispatch
+#     # input takes precedence. Leave it unset to run on the repo pin.
 #     LAKE_SHADOW_TOOLCHAIN_OVERRIDE         — e.g. leanprover/lean4-pr-releases:pr-release-14301
 #
 # Jobs:
-#   build_and_stage  Build mathlib + deps with Lake's artifact cache
-#                    enabled, then stage the resulting .ltar files — the
-#                    root package's and, for deps the bucket does not have
-#                    yet, per-dependency mappings exported via dep-as-root
-#                    builds (see "Dependency caching" below).
-#   upload           Push staged artifacts to the cache bucket via
-#                    `lake cache put-staged` (root scope + one scope per
-#                    staged dep), then record a per-run manifest under
-#                    cache/analysis/<toolchain-slug>/ and report carryover
-#                    vs the prior run on the same toolchain.
-#   consume          Fresh checkout, fetch root outputs and per-dep outputs
-#                    from the cache bucket via `lake cache get` (+
-#                    `--package` for deps), run `lake build` against the
-#                    rehydrated cache, then verify with `--rehash`.
-#   downstream       Synthesize a minimal project that depends on mathlib at
-#                    the built rev, fetch mathlib + all transitive deps from
-#                    the bucket via `lake cache get --package`, and assert
-#                    zero Mathlib module rebuilds — validating that the
-#                    bucket can serve real downstream projects.
-#   report           Post a per-run summary to the `CI admins` Zulip
-#                    stream (topic `Lake cache shadow`).
+#   build_and_stage  Builds mathlib and its dependencies with Lake's artifact
+#                    cache. Stages the root package's outputs, and the
+#                    mappings of each dependency the bucket does not hold.
+#   upload           Pushes the staged files to the bucket with `lake cache
+#                    put-staged`: once for the root scope, then once per
+#                    dependency scope. Records a manifest under
+#                    analysis/<toolchain-slug>/ and reports the carryover.
+#   consume          Fetches the root and dependency outputs into a fresh
+#                    checkout with `lake cache get`, builds against them, and
+#                    verifies the result with `--rehash`.
+#   downstream       Creates a small project that depends on mathlib, fetches
+#                    mathlib and every transitive dependency from the bucket,
+#                    and requires zero Mathlib rebuilds.
+#   report           Posts a summary of the run to Zulip.
 #
 # Bucket layout:
-#   Everything the pipeline writes lives in one bucket, addressed by scope.
-#   For SHADOW_SCOPE=mathlib4-master-shadow, toolchain slug
-#   `leanprover-lean4-v4.34.0-rc2` and pin set `2d10dd67`, a run writes:
+#   The pipeline writes everything to one bucket, addressed by scope. A run
+#   with SHADOW_SCOPE=mathlib4-master-shadow, toolchain slug
+#   `leanprover-lean4-v4.34.0-rc2` and pin hash `2d10dd67` writes these keys:
 #
 #     revisions/mathlib4-master-shadow/<mathlib-sha>.jsonl
 #     artifacts/mathlib4-master-shadow/<content-hash>.art
@@ -59,58 +51,62 @@ name: Lake cache shadow (master)
 #     analysis/leanprover-lean4-v4.34.0-rc2/_latest.txt
 #     analysis/leanprover-lean4-v4.34.0-rc2/<mathlib-sha>.txt
 #
-#   `lake cache get --scope=S --rev=R` reads `revisions/S/R.jsonl` (the
-#   input-hash-to-artifact mappings) and then the `artifacts/S/<hash>.art`
-#   files it names. The `analysis/` prefix is this workflow's own
-#   bookkeeping, invisible to Lake: `_latest.txt` holds the previous run's
-#   mathlib sha (the warm-start pointer) and `<sha>.txt` holds that run's
-#   uploaded artifact hashes (the carryover baseline).
+#   `lake cache get --scope=S --rev=R` reads `revisions/S/R.jsonl`, which maps
+#   input hashes to artifacts. Lake then downloads the `artifacts/S/<hash>.art`
+#   files that the map names.
+#
+#   Lake does not know the `analysis/` prefix; this workflow owns it.
+#   `_latest.txt` holds the mathlib sha of the previous run on the toolchain,
+#   and `<sha>.txt` holds the artifact hashes that run uploaded.
 #
 # Dependency caching:
-#   Lake's `-o` records input-to-output mappings only for the workspace
-#   root, so each dependency's mappings are exported by loading the dep as
-#   the root of its own workspace (`lake -d .lake/packages/<dep> build -o`),
-#   with `--packages` overrides pinning its dependency tree to this
-#   workspace's checkouts (a dep's own manifest can pin different revs,
-#   which would yield mappings this workspace's input hashes never match).
-#   Each dep is uploaded under scope
-#     <SHADOW_SCOPE>/deps/<toolchain-slug>/<pins-hash>/<dep>
-#   keyed by the dep's lake-manifest.json revision. The two scope
-#   qualifiers make the key exact where a bare dep rev is not:
-#     * toolchain slug — dep revs are long-lived, unlike mathlib's, so one
-#       rev is built under many toolchains over its lifetime;
-#     * pins hash (8 hex chars over the manifest's sorted name+rev pairs) —
-#       a dep's input hashes incorporate its *upstreams'* artifacts, so a
-#       partial manifest bump (say batteries only) changes the correct
-#       mappings for aesop without changing aesop's rev. This mirrors the
-#       legacy cache's root hash, which covers the whole manifest.
-#   A dep whose <rev>.jsonl is already in the bucket is skipped end-to-end
-#   (dep uploads happen only on manifest or toolchain bumps, which re-key
-#   and re-upload every dep). `consume` fetches each dep with
-#   `lake cache get --package=<dep> --rev=<manifest-rev>`; the same fetch
-#   warm-starts runs that skip legacy hydration. Deps in DEP_SKIP are
-#   excluded (empty by default; see the env note). Per-dep steps are
-#   failure-tolerant: a miss or export failure degrades that dep to a
-#   source build, reported in the consume health line, and a toolchain
-#   older than v4.34.0-rc2 (no `cache get --package`) degrades the same
-#   way rather than failing the pipeline.
+#   Lake's `-o` records the mappings of the workspace root only. To obtain the
+#   mappings of a dependency, the pipeline loads that dependency as the root
+#   of its own workspace: `lake -d .lake/packages/<dep> build -o`. The
+#   `--packages` overrides pin its own dependencies to this workspace's
+#   checkouts. Without them the dependency resolves the revisions in its own
+#   manifest, and the mappings never match this workspace's input hashes.
 #
-# Hydration & the legacy cache:
-#   Pinned runs hydrate from the shadow scope itself: the root package warm
-#   starts from the previous run on this toolchain's analysis chain, deps
-#   from their per-dep scopes, and the incremental build compiles only the
-#   churn since — i.e. the steady state a migrated CI would run. The legacy
-#   cache is a bootstrap fallback only, used when the analysis chain has no
-#   prior run (a fresh toolchain generation on the repo pin). Override runs
-#   never use it (it is keyed to the repo pin).
+#   Each dependency uploads to the scope
+#     <SHADOW_SCOPE>/deps/<toolchain-slug>/<pins-hash>/<dep>
+#   under its own revision from lake-manifest.json. Two qualifiers extend the
+#   key, because the revision alone is not exact:
+#     toolchain slug  A dependency revision lives for months, so many
+#                     toolchains build it.
+#     pins hash       The input hashes of a dependency cover the artifacts of
+#                     its upstreams. A partial bump of the manifest, of
+#                     batteries alone for example, changes the correct
+#                     mappings for aesop but not the revision of aesop.
+#
+#   The plan step skips a dependency whose revision file is already in the
+#   bucket. Uploads therefore happen on a manifest bump or a toolchain bump,
+#   and both of those re-key every dependency. The `consume` job fetches each
+#   dependency with `lake cache get --package=<dep> --rev=<manifest-rev>`, and
+#   a run that skips legacy hydration warm starts with the same fetch.
+#
+#   DEP_SKIP excludes dependencies from all of this. Every per-dependency step
+#   tolerates failure. A miss, or a failed export, makes that dependency build
+#   from source, and the consume health line reports it. A toolchain older than
+#   v4.34.0-rc2 has no `cache get --package` and behaves the same way.
+#
+# Hydration and the legacy cache:
+#   A pinned run hydrates from the shadow scope. The root package warm starts
+#   from the previous run on the toolchain's analysis chain, and each
+#   dependency warm starts from its own scope. The incremental build then
+#   compiles the churn since that run.
+#
+#   The legacy cache is a bootstrap fallback. A run uses it only when the
+#   analysis chain holds no previous run, which happens on a fresh toolchain
+#   generation on the repo pin. An override run never uses it, because the
+#   legacy cache is keyed to the repo pin.
 #
 # Cache service configuration:
-#   Jobs reach the bucket through a generated Lake services file
-#   (`LAKE_CONFIG` + `--service=shadow`), the supported mechanism; the raw
-#   LAKE_CACHE_*_ENDPOINT env vars are deprecated in Lake and used here only
-#   for plain-curl probes and the analysis uploads. Each job writes the file
-#   itself, since each runs on its own runner. Fetching jobs render the
-#   public read endpoints:
+#   Jobs reach the bucket through a generated Lake services file, with
+#   `LAKE_CONFIG` and `--service=shadow`. This is the supported mechanism.
+#   Lake deprecates the LAKE_CACHE_*_ENDPOINT variables, which this file uses
+#   only for plain curl probes and for the analysis uploads. Each job writes
+#   the services file itself, because each job runs on its own runner. A
+#   fetching job writes the public read endpoints:
 #
 #     [[cache.service]]
 #     name = "shadow"
@@ -118,24 +114,28 @@ name: Lake cache shadow (master)
 #     artifactEndpoint = "https://pub-<hash>.r2.dev/<prefix>/artifacts"
 #     revisionEndpoint = "https://pub-<hash>.r2.dev/<prefix>/revisions"
 #
-#   and the upload job renders the same block with the authenticated S3
-#   endpoints, whose requests it signs with LAKE_CACHE_KEY.
+#   The upload job writes the same block with the authenticated S3 endpoints,
+#   and signs its requests with LAKE_CACHE_KEY.
 #
 # Toolchain override:
-#   The `toolchain_override` input, or else the LAKE_SHADOW_TOOLCHAIN_OVERRIDE
-#   variable, swaps the toolchain the whole pipeline runs on: build_and_stage
-#   resolves it into its `toolchain` output, and the downstream jobs stamp
-#   that output into their checkouts, so every job runs the same lake. Its
-#   lean must be behaviorally compatible with the repo pin, e.g. a Lake change
-#   cherry-picked onto the pinned release's lineage as a lean4 pr-release.
-#   Input hashes incorporate the toolchain, so all runs safely share one
-#   artifact scope. The analysis chain (warm-start pointer + carryover
-#   manifests) is keyed per toolchain under analysis/<slug>/, so pinned and
-#   override runs each warm-start from and diff against their own lineage.
-#   A toolchain's first run — or a pr-release tag republished under the same
-#   name — misses the legacy cache and all prior root artifacts, costing one
-#   full-turnover source build of the root package; dependencies already in
-#   the shadow scope for that toolchain are warm-started and replay.
+#   The `toolchain_override` input, or the LAKE_SHADOW_TOOLCHAIN_OVERRIDE
+#   variable, changes the toolchain of the whole pipeline. build_and_stage
+#   resolves it into its `toolchain` output, and the later jobs stamp that
+#   output into their checkouts, so every job runs the same lake.
+#
+#   The lean of the override must behave like the repo pin. A Lake change,
+#   cherry-picked onto the lineage of the pinned release as a pr-release, is a
+#   valid example. Input hashes cover the toolchain, so all runs share one
+#   artifact scope safely.
+#
+#   The analysis chain is per toolchain, under analysis/<slug>/. A pinned run
+#   and an override run therefore warm start from their own lineage, and
+#   compare against it.
+#
+#   The first run on a toolchain misses the legacy cache and every prior root
+#   artifact, and costs one full source build of the root package. A
+#   republished pr-release tag costs the same. Dependencies already in the
+#   shadow scope for that toolchain still replay.
 
 on:
   schedule:
@@ -154,10 +154,10 @@ on:
           experiments.
         required: false
         type: string
-        # Default: the full `Mathlib` library — the representative master shadow.
-        # For a cheaper experiment, pass a smaller set, e.g.
-        #   Mathlib.Topology.Basic Mathlib.Combinatorics.SimpleGraph.Basic Mathlib.RingTheory.Ideal.Basic
-        # or add `Archive Counterexamples Wanted` to also shadow those libraries.
+        # The default builds the whole `Mathlib` library, the representative
+        # master shadow. For a cheaper experiment, pass a smaller set:
+        #   Mathlib.Topology.Basic Mathlib.Combinatorics.SimpleGraph.Basic
+        # Add `Archive Counterexamples Wanted` to shadow those libraries too.
         default: Mathlib
       toolchain_override:
         description: >-
@@ -190,23 +190,22 @@ defaults:
     shell: bash -euo pipefail {0}
 
 env:
-  # Effective toolchain override: dispatch input, else repository variable,
-  # else the repo pin.
+  # The effective toolchain override. The dispatch input wins, then the
+  # repository variable, then the repo pin.
   TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE || '' }}
-  # Scope prefix for all puts and gets in this workflow. Namespaces the
-  # workflow's artifacts within the cache bucket.
+  # The scope prefix for every put and get in this workflow. It keeps these
+  # artifacts apart from the rest of the bucket.
   SHADOW_SCOPE: mathlib4-master-shadow
-  # Space-separated deps excluded from shadow dependency caching — an escape
-  # hatch, empty by default (everything is cached). Even proofwidgets caches
-  # cleanly: its npm-built JS and the Lake traces guarding the npm steps are
-  # committed to its repo, so builds at pinned revs never invoke npm and its
-  # Lean modules cache like any other dep's.
+  # Dependencies to exclude from caching, separated by spaces. It is empty:
+  # the pipeline caches all of them, proofwidgets included. proofwidgets
+  # commits its npm output and the Lake traces that guard the npm steps, so a
+  # build at a pinned revision never calls npm.
   DEP_SKIP: ''
-  # Whether this run caches dependencies: always on schedule, else the
-  # `cache_deps` dispatch input.
+  # Whether this run caches dependencies. A scheduled run always does. A
+  # dispatched run follows the `cache_deps` input.
   CACHE_DEPS: ${{ (github.event_name != 'workflow_dispatch' || inputs.cache_deps) && 'true' || 'false' }}
-  # NOTE: STAGE_TARGETS is set per-job (not here) from the `targets` input, so
-  # it can be overridden per dispatch — see the `build_and_stage`/`consume` env.
+  # STAGE_TARGETS is set per job, not here, from the `targets` input. See the
+  # env of `build_and_stage` and `consume`.
   MATHLIB_CACHE_BASE_URL: ${{ vars.MATHLIB_CACHE_BASE_URL }}
 
 jobs:
@@ -214,10 +213,9 @@ jobs:
     name: Build + stage
     if: ${{ github.repository == 'leanprover-community/mathlib4' }}
     runs-on: pr
-    # Pinned runs warm-start from the shadow scope and compile the churn since
-    # the previous run from source (plus a full dep build on manifest-bump
-    # days); 150 covers that. 240 covers the full source build of an override
-    # toolchain generation's first run.
+    # A pinned run compiles the churn since the previous run, and on a bump
+    # day it also builds every dependency. 150 minutes covers that. 240 covers
+    # the full source build of a new toolchain generation.
     timeout-minutes: ${{ (inputs.toolchain_override || vars.LAKE_SHADOW_TOOLCHAIN_OVERRIDE) && 240 || 150 }}
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
@@ -244,8 +242,8 @@ jobs:
           fetch-depth: 2
           path: pr-branch
 
-      # Before the resolve step, so the run's recorded toolchain is the one
-      # actually used.
+      # This runs before the resolve step, so the recorded toolchain is the
+      # one the run uses.
       - name: Apply toolchain override
         if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
         shell: bash -euo pipefail {0}
@@ -267,38 +265,34 @@ jobs:
         shell: bash -euo pipefail {0}
         run: |
           mkdir -p pr-branch/.lake/
-          # The landrun ruleset mounts $HOME/.cache/mathlib read-only and
-          # errors out if the path is missing. Runs that skip legacy hydration
-          # reach the first landrun step with it absent.
+          # The landrun ruleset mounts $HOME/.cache/mathlib read-only, and
+          # landrun fails if that path does not exist. A run that skips legacy
+          # hydration never creates it, so this step does.
           mkdir -p "$HOME/.cache/mathlib/"
           mkdir -p _work
 
-      # The runners are ephemeral, so this is defensive hygiene rather than a
-      # leak fix (these paths live outside the pr-branch checkout, beyond
-      # `git clean`'s reach, so they would go stale if a workspace were ever
-      # reused). The `df` line is the useful part: the run needs a few GB of
-      # headroom (build dirs + artifact cache + ~1 GB staging), and some
-      # runner hosts carry a lot of baseline disk usage.
+      # These paths sit outside the pr-branch checkout, where `git clean` does
+      # not reach. The runners are ephemeral, so the removal only guards a
+      # reused workspace. The `df` line reports the headroom: the run needs a
+      # few GB for the build directories, the artifact cache and about 1 GB of
+      # staging, and some hosts carry a large baseline.
       - name: Clean workspace leftovers & log disk headroom
         shell: bash -euo pipefail {0}
         run: |
           rm -rf lake-cache-staging tools-branch
           echo "disk headroom: $(df -h --output=avail,pcent . | tail -1 | xargs) on $(hostname)"
 
-      # Plan this run's hydration and dep caching:
-      #   * generate the Lake cache-services file (public read endpoints)
-      #     that later `lake cache get` steps use via LAKE_CONFIG;
-      #   * resolve this toolchain's analysis-chain pointer — a warm chain
-      #     means the shadow scope itself hydrates the root and the legacy
-      #     cache stays unused (bootstrap fallback only);
-      #   * decide which deps to stage: a (dep rev, toolchain, pins-hash)
-      #     triple is deterministic, so a `<rev>.jsonl` already in the
-      #     bucket means the whole export/stage/upload leg can be skipped.
-      #     On a manifest bump the pins hash re-keys every dep, so all of
-      #     them re-stage and the deps build from source once.
-      #   Also generate here (jq is not available inside landrun) the
-      #   per-dep `--packages` overrides that pin each dep's dependency
-      #   tree to this workspace's checkouts.
+      # Plan the hydration and the dependency caching of this run:
+      #   * Write the Lake services file that the `lake cache get` steps read
+      #     through LAKE_CONFIG.
+      #   * Resolve the analysis-chain pointer of this toolchain. A warm chain
+      #     hydrates the root package from the shadow scope, and the legacy
+      #     cache stays unused.
+      #   * Decide which dependencies to stage. A revision file that is
+      #     already in the bucket ends the work for that dependency.
+      #   * Write the `--packages` overrides for the export builds.
+      # This step writes the overrides because jq is not available inside
+      # landrun.
       - name: Plan hydration & dependency caching
         shell: bash -euo pipefail {0}
         env:
@@ -309,10 +303,9 @@ jobs:
           mkdir -p .lake/dep-plan
           : > .lake/dep-plan/stage.txt
           : > .lake/dep-plan/cached.txt
-          # Services file for the warm-start steps in this job. Renders the
-          # block shown under "Cache service configuration" at the top of this
-          # file, with the public read endpoints; the upload job writes its
-          # own with the authenticated ones.
+          # The services file for the warm-start steps of this job. It renders
+          # the block under "Cache service configuration" at the top of this
+          # file, with the public read endpoints.
           cat > .lake/shadow-services.toml <<EOF
           [[cache.service]]
           name = "shadow"
@@ -320,21 +313,22 @@ jobs:
           artifactEndpoint = "$LAKE_CACHE_ARTIFACT_ENDPOINT"
           revisionEndpoint = "$LAKE_CACHE_REVISION_ENDPOINT"
           EOF
-          # The two qualifiers that make a dep scope exact. Both are recomputed
-          # (identically) by the upload, consume and downstream jobs, which run
-          # on their own runners; a mismatch between any two would not fail
-          # anything, it would just turn every fetch into a silent miss.
-          #   tcslug: the toolchain, punctuation folded to '-'
-          #           "leanprover/lean4:v4.34.0-rc2" -> "leanprover-lean4-v4.34.0-rc2"
-          #   pins8:  8 hex chars over the manifest's sorted "<name> <rev>"
-          #           git entries, e.g. "2d10dd67" — see "Dependency caching".
+          # The two qualifiers that make a dependency scope exact. The upload,
+          # consume and downstream jobs compute them again, because they run on
+          # their own runners. A mismatch between two jobs fails nothing; it
+          # makes every fetch a miss.
+          #   tcslug  The toolchain, with each character outside A-Za-z0-9._-
+          #           replaced by '-'. "leanprover/lean4:v4.34.0-rc2" becomes
+          #           "leanprover-lean4-v4.34.0-rc2".
+          #   pins8   8 hex characters over the sorted "<name> <rev>" git
+          #           entries of the manifest, for example "2d10dd67".
           tcslug="$(printf %s "$(cat lean-toolchain)" | tr -c 'A-Za-z0-9._-' '-')"
           pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           echo "TCSLUG=$tcslug" >> "$GITHUB_ENV"
           echo "PINS8=$pins8" >> "$GITHUB_ENV"
-          # Root-chain probe: `analysis/<tcslug>/_latest.txt` holds the mathlib
-          # sha of the previous run on this toolchain, or 404s on a chain that
-          # has never run. Absent (cold) means no warm start is possible.
+          # `analysis/<tcslug>/_latest.txt` holds the mathlib sha of the
+          # previous run on this toolchain. It returns 404 on a chain that has
+          # never run, and that run has no warm start.
           prev="$(curl -fsS "${LAKE_CACHE_ARTIFACT_ENDPOINT%/artifacts}/analysis/$tcslug/_latest.txt" 2>/dev/null || true)"
           if [ -n "$prev" ]; then
             echo "CHAIN_PREV=$prev" >> "$GITHUB_ENV"
@@ -349,9 +343,10 @@ jobs:
             echo "::notice::dependency caching disabled for this run (cache_deps input)"
             exit 0
           fi
-          # Sorts each dep into one of two plan files, both "<name> <rev>" per
-          # line: cached.txt (bucket already has it -> warm start from it) and
-          # stage.txt (missing -> build, export, upload it this run).
+          # Each dependency goes into one of two plan files, which both hold
+          # "<name> <rev>" per line. cached.txt lists what the bucket serves,
+          # and the warm start reads it. stage.txt lists what this run must
+          # build, export and upload.
           while read -r name rev; do
             if [[ " $DEP_SKIP " == *" $name "* ]]; then
               echo "::notice::dep $name: on the skip list; not cached"
@@ -362,11 +357,11 @@ jobs:
               echo "$name $rev" >> .lake/dep-plan/cached.txt
             else
               echo "$name $rev" >> .lake/dep-plan/stage.txt
-              # Overrides for this dep's export build below. Rewrites every
-              # *other* workspace package as a path entry into this checkout,
-              # so that loading the dep standalone still resolves its
-              # upstreams to mathlib's pins rather than to its own manifest's
-              # (which would produce mappings this workspace never matches).
+              # The overrides for the export build of this dependency. They
+              # rewrite every other workspace package as a path entry into this
+              # checkout, so the standalone load resolves the upstreams to
+              # mathlib's pins. The manifest of the dependency pins other
+              # revisions, which produce mappings this workspace never matches.
               # `aesop-overrides.json` renders as:
               #
               #   {"version": "1.2.0",
@@ -393,10 +388,10 @@ jobs:
           ./elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
-      # `elan which` below does not auto-install non-pinned toolchains. The
-      # uninstall forces a fresh download: pr-release tags are republished in
-      # place, and elan skips toolchains it already has, so a persistent
-      # runner would otherwise keep running a stale binary under that name.
+      # `elan which` below does not install a toolchain the repo does not pin.
+      # The uninstall forces a fresh download: elan skips a toolchain that is
+      # already present, and a pr-release tag is republished under the same
+      # name.
       - name: Install override toolchain
         if: ${{ env.TOOLCHAIN_OVERRIDE != '' }}
         shell: bash -euo pipefail {0}
@@ -431,11 +426,11 @@ jobs:
           cd pr-branch
           lake env
 
-      # Bootstrap fallback only: pinned runs normally hydrate from the shadow
-      # scope (warm-start steps below); the legacy cache covers the one case
-      # they cannot — a cold analysis chain, i.e. a fresh toolchain
-      # generation on the repo pin. It is keyed to the repo pin, so override
-      # runs never use it.
+      # The bootstrap fallback. A pinned run normally hydrates from the shadow
+      # scope, in the warm-start steps below. The legacy cache covers the case
+      # they cannot: a cold analysis chain, which is a fresh toolchain
+      # generation on the repo pin. An override run never uses it, because the
+      # legacy cache is keyed to the repo pin.
       - name: Checkout tools branch (legacy-cache fallback)
         if: ${{ env.TOOLCHAIN_OVERRIDE == '' && env.CHAIN_COLD == 'true' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -482,11 +477,11 @@ jobs:
           awk '/^package mathlib where/,/^$/' lakefile.lean
           echo "::endgroup::"
 
-      # Primary root hydration: seed Lake's artifact cache from the previous
-      # run on the same toolchain (the chain pointer resolved by the plan
-      # step); the incremental build below then compiles only the churn
-      # since. A cold chain proceeds from the legacy fallback above (pinned)
-      # or from source (override).
+      # The primary root hydration. It seeds Lake's artifact cache from the
+      # previous run on this toolchain, at the pointer the plan step resolved.
+      # The incremental build below then compiles the churn since that run. On
+      # a cold chain a pinned run uses the legacy fallback above, and an
+      # override run builds from source.
       - name: Warm start from shadow scope
         shell: bash -euo pipefail {0}
         env:
@@ -500,12 +495,11 @@ jobs:
           lake cache get --service=shadow --scope="$SHADOW_SCOPE" --rev="$CHAIN_PREV" \
             || echo "::warning::warm start from rev ${CHAIN_PREV:0:12} failed; proceeding without it"
 
-      # Primary dep hydration: fetch the deps the bucket already serves
-      # (keyed by manifest rev); the main build then replays them instead of
-      # compiling from source. Skipped only when the legacy fallback already
-      # hydrated everything (pinned run on a cold chain). Deps the plan step
-      # found missing (first run after a manifest or toolchain bump) build
-      # from source in the incremental build and are exported below.
+      # The primary dependency hydration. It fetches the dependencies the
+      # bucket serves, and the main build replays them. The step is skipped
+      # only when the legacy fallback already hydrated everything, on a pinned
+      # run with a cold chain. A dependency the plan step found missing builds
+      # from source below, and the export step then records it.
       - name: Warm start dependencies from shadow scope
         if: ${{ env.TOOLCHAIN_OVERRIDE != '' || env.CHAIN_COLD == 'false' }}
         shell: bash -euo pipefail {0}
@@ -517,32 +511,32 @@ jobs:
             echo "::notice::no cached deps to warm start"
             exit 0
           fi
-          # TCSLUG/PINS8 come from the plan step via $GITHUB_ENV, so this is
-          # the one dep fetch that does not recompute them. For batteries the
-          # scope below is
+          # TCSLUG and PINS8 arrive from the plan step through $GITHUB_ENV.
+          # For batteries the scope below is
           #   mathlib4-master-shadow/deps/leanprover-lean4-v4.34.0-rc2/2d10dd67/batteries
-          # and --rev is batteries' own manifest revision: an exact lookup, so
-          # a miss returns immediately instead of walking --max-revs ancestors.
+          # and `--rev` is the manifest revision of batteries. The lookup is
+          # exact, so a miss returns at once and does not walk `--max-revs`
+          # ancestors.
           while read -r name rev; do
             lake cache get --service=shadow --package="$name" \
               --scope="$SHADOW_SCOPE/deps/$TCSLUG/$PINS8/$name" --rev="$rev" \
               || echo "::warning::dep warm start failed for $name@${rev:0:12}; it will build from source"
           done < .lake/dep-plan/cached.txt
 
-      # Incremental build: with the warm start (or legacy fallback) having
-      # hydrated the artifact cache and the lakefile patched, this compiles
-      # the churn since the previous run — root modules changed since the
-      # chain's prev rev, plus any deps the bucket was missing — and
-      # packs/caches everything `-o` will record. Dep mappings don't land in
-      # `-o` (root-only); the dep-as-root step below exports them.
+      # The incremental build. The warm start, or the legacy fallback, has
+      # hydrated the artifact cache, and the lakefile patch enables it. This
+      # step compiles the churn since the previous run: the root modules that
+      # changed, and any dependency the bucket did not hold. It also packs and
+      # caches everything `-o` records. Dependency mappings do not reach `-o`,
+      # which covers the root only; the export step below writes them.
       - name: Incremental build (populate Lake's cache)
         run: |
           cd pr-branch
           lake build $STAGE_TARGETS 2>&1 | tee .lake/lake-build.log
           echo "::group::build summary"
-          # Replays aren't counted: a non-verbose `lake build` restores cached
-          # outputs silently (no "Replayed" lines to grep). The count here is
-          # the day's churn — plus full dep builds on bump days.
+          # A non-verbose `lake build` replays a cached output in silence, so
+          # no line counts it. The count below is the churn of the day, plus
+          # the dependency builds on a bump day.
           echo "Built (pipeline ran):    $(grep -cE '^✔.*Built '    .lake/lake-build.log || true)"
           echo "::endgroup::"
 
@@ -553,35 +547,34 @@ jobs:
           echo "mappings entries: $(wc -l < .lake/outputs.jsonl)"
           head -3 .lake/outputs.jsonl
 
-      # Export input-to-output mappings for the deps the bucket is missing
-      # (see "Dependency caching" at the top of this file). After the
-      # incremental build above, every dep artifact is already in the shared
-      # local cache, so these dep-as-root loads replay rather than compile —
-      # provided input hashes agree between the two workspace shapes.
-      # Divergence shows up as compile time here and as dep rebuilds in
-      # `consume`; both are part of what this shadow measures.
-      # LAKE_ARTIFACT_CACHE=true makes the dep-as-root workspaces
-      # cache-writable — the lakefile patch only covers the mathlib
-      # workspace. Per-dep failures are tolerated: that dep is just not
-      # cached this run.
+      # Export the mappings of the dependencies the bucket does not hold. See
+      # "Dependency caching" at the top of this file. The incremental build
+      # above put every dependency artifact in the shared local cache, so
+      # these loads replay instead of compiling, as long as the input hashes
+      # of the two workspace shapes agree. A disagreement appears as compile
+      # time here, and as dependency rebuilds in `consume`.
+      #
+      # LAKE_ARTIFACT_CACHE=true makes these workspaces cache-writable,
+      # because the lakefile patch covers the mathlib workspace only. A
+      # failure leaves that one dependency uncached for this run.
       - name: Export dependency mappings
-        # Override default landrun shell to pass LAKE_ARTIFACT_CACHE.
+        # This overrides the default landrun shell, to pass LAKE_ARTIFACT_CACHE.
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI --env LAKE_CACHE_DIR --env LAKE_NO_CACHE --env LAKE_ARTIFACT_CACHE -- bash -euxo pipefail {0}
         env:
           LAKE_ARTIFACT_CACHE: true
         run: |
           cd pr-branch
-          # The dep-as-root loads run with other workspace directories, so the
-          # cache dir must not be CWD-relative.
+          # These loads run in other workspace directories, so the cache
+          # directory must not be relative to the working directory.
           export LAKE_CACHE_DIR="$PWD/.lake/cache"
           mkdir -p .lake/dep-outputs
           if [ ! -s .lake/dep-plan/stage.txt ]; then
             echo "no deps to export"
             exit 0
           fi
-          # `-o` writes the loaded workspace root's input-hash-to-artifact
-          # mappings as JSON Lines — a schema-version header, then one entry
-          # per module. `.lake/dep-outputs/batteries.jsonl` starts:
+          # `-o` writes the mappings of the loaded workspace root as JSON
+          # Lines: a schema version, then one entry per module.
+          # `.lake/dep-outputs/batteries.jsonl` starts:
           #
           #   "2026-03-17"
           #   ["40621d85d988875e","b219d1b135ae613c.ltar"]
@@ -602,22 +595,24 @@ jobs:
             echo "::endgroup::"
           done < .lake/dep-plan/stage.txt
 
-      # Pre-create the staging dir outside landrun so the stage step can
-      # write to it. Same pattern as build_template.yml uses for the legacy
-      # cache-staging dir.
+      # The staging directory is created outside landrun, so the step below
+      # can write to it. build_template.yml uses the same pattern for the
+      # legacy staging directory.
       - name: Create staging directory
         shell: bash -euo pipefail {0}
         run: mkdir -p lake-cache-staging
 
       - name: Stage cache for upload
-        # Override default landrun shell to add the staging dir as writable.
+        # This overrides the default landrun shell, to make the staging
+        # directory writable.
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --rw lake-cache-staging/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI --env LAKE_CACHE_DIR --env LAKE_NO_CACHE -- bash -euxo pipefail {0}
         run: |
           cd pr-branch
-          # Copies mappings + artifacts out of the local Lake cache into the
-          # tree the upload job consumes (it travels between jobs as a GitHub
-          # artifact). Each dep gets its own subdirectory because `cache stage`
-          # writes exactly one outputs.jsonl per directory. Result:
+          # This copies the mappings and the artifacts out of the local Lake
+          # cache, into the tree the upload job consumes. The tree travels
+          # between the jobs as a GitHub artifact. Each dependency gets its own
+          # subdirectory, because `cache stage` writes one outputs.jsonl per
+          # directory. The result:
           #
           #   lake-cache-staging/
           #     outputs.jsonl               root mappings
@@ -628,14 +623,15 @@ jobs:
           #     deps/batteries/<content-hash>.ltar
           #     deps/aesop/…
           #
-          # The upload job reads deps/manifest.txt to know what to push and
-          # deps/cached.txt only to report how many it skipped.
+          # The upload job reads deps/manifest.txt for the list to push, and
+          # deps/cached.txt for the count it reports as skipped.
           lake cache stage .lake/outputs.jsonl ../lake-cache-staging
           mkdir -p ../lake-cache-staging/deps
           cp .lake/dep-plan/cached.txt ../lake-cache-staging/deps/cached.txt
           while read -r name rev; do
-            # Deps whose export failed have no mappings file; plan.txt still
-            # lists them, so skip rather than staging a partial dep.
+            # A dependency whose export failed has no mappings file, but
+            # stage.txt still lists it. Skip it instead of staging a part of
+            # it.
             [ -f ".lake/dep-outputs/$name.jsonl" ] || continue
             lake cache stage ".lake/dep-outputs/$name.jsonl" "../lake-cache-staging/deps/$name"
             echo "$name $rev" >> ../lake-cache-staging/deps/manifest.txt
@@ -644,16 +640,17 @@ jobs:
           du -sh ../lake-cache-staging/deps | awk '{print "deps staging total:", $1}'
           echo "ltar count: $(find ../lake-cache-staging -name '*.ltar' | wc -l)"
 
-      # Safety valve: the staged bytes are what gets uploaded (GH artifact → R2).
-      # Bail before any upload if it would exceed the cap, to protect the R2
-      # free-tier / lifecycle budget. Logs the size first, so a trip still tells
-      # us how big the build got.
+      # The safety valve. The staged bytes are the bytes that reach R2, so this
+      # stops a run that exceeds the cap before it uploads. It protects the R2
+      # free tier and the lifecycle budget. It logs the size first, so a trip
+      # still reports how large the build got.
       - name: Guard upload size (bail if staging > 2 GB)
         shell: bash -euo pipefail {0}
         run: |
-          # 2 GB — headroom over the measured ~389 MB root build plus a
-          # first-run upload of every dep (deps re-stage only on manifest
-          # bumps or new toolchains, so steady-state stays near the root size).
+          # 2 GB gives headroom over the root build, about 400 MB, plus one
+          # upload of every dependency. Dependencies stage again on a manifest
+          # bump or a toolchain bump only, so the steady state stays near the
+          # root size.
           MAX=$((2 * 1000 * 1000 * 1000))
           BYTES=$(du -sb lake-cache-staging | cut -f1)
           echo "staging size: $(du -sh lake-cache-staging | cut -f1) (${BYTES} bytes); cap: 2 GB (${MAX} bytes)"
@@ -675,15 +672,16 @@ jobs:
     needs: build_and_stage
     if: ${{ github.repository == 'leanprover-community/mathlib4' }}
     runs-on: ubuntu-latest
-    # 45 covers a first-run upload of every dep on top of the root set.
+    # 45 minutes covers an upload of every dependency on top of the root set.
     timeout-minutes: 45
     outputs:
       carryover: ${{ steps.carryover.outputs.summary }}
       new_content: ${{ steps.carryover.outputs.new_content }}
       dep_uploads: ${{ steps.depupload.outputs.summary }}
     env:
-      # Uploads go through a generated Lake services file (authenticated S3
-      # endpoints) + LAKE_CACHE_KEY; see "Cache service configuration" above.
+      # The uploads go through a generated Lake services file with the
+      # authenticated S3 endpoints, and LAKE_CACHE_KEY signs them. See "Cache
+      # service configuration" above.
       LAKE_CONFIG: ${{ github.workspace }}/shadow-services.toml
     steps:
       - name: Write cache services config
@@ -691,7 +689,7 @@ jobs:
           ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
           REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
         run: |
-          # Renders the block shown under "Cache service configuration" at the
+          # This renders the block under "Cache service configuration" at the
           # top of this file.
           cat > "$LAKE_CONFIG" <<EOF
           [[cache.service]]
@@ -708,9 +706,9 @@ jobs:
           path: pr-branch
           fetch-depth: 1
 
-      # Stamp the effective toolchain from build_and_stage's resolve step, so
-      # put-staged runs the same lake that produced the staging; the elan
-      # proxy auto-installs it on first use.
+      # Stamp the toolchain that build_and_stage resolved, so put-staged runs
+      # the same lake that produced the staging. The elan proxy installs it on
+      # first use.
       - name: Pin effective toolchain
         env:
           EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
@@ -740,21 +738,19 @@ jobs:
       - name: lake cache put-staged
         run: |
           cd pr-branch
-          # --toolchain is a no-op with the current `--scope=<string>` form
-          # (Lake's revisionUrl ignores it for `.str` scopes), but stays
-          # wired so the eventual migration to `--repo=` is a one-line
-          # change rather than re-plumbing outputs.
+          # `--toolchain` has no effect with a string scope: Lake's revision
+          # URL ignores it there. It applies to the `--repo` form of a scope.
           lake cache put-staged ../lake-cache-staging \
             --service=shadow \
             --scope="${{ env.SHADOW_SCOPE }}" \
             --rev="${{ needs.build_and_stage.outputs.sha }}" \
             --toolchain="${{ needs.build_and_stage.outputs.toolchain }}" 2>&1 | tee /tmp/put.log
 
-      # Upload each staged dep under its toolchain-qualified scope, keyed by
-      # the dep's manifest revision (see "Dependency caching" at the top of
-      # this file). Deps already in the bucket were filtered out by the build
-      # job's plan step. Logged separately from /tmp/put.log so dep artifacts
-      # do not skew the root carryover analysis below.
+      # Upload each staged dependency to its own scope, under its manifest
+      # revision. See "Dependency caching" at the top of this file. The plan
+      # step already removed the dependencies the bucket holds. The log is
+      # separate from /tmp/put.log, so these artifacts stay out of the root
+      # carryover analysis below.
       - name: Upload dependency caches
         id: depupload
         continue-on-error: true
@@ -762,18 +758,17 @@ jobs:
           EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
         run: |
           cd pr-branch
-          # Recomputed here because this job runs on its own runner. Must
-          # match build_and_stage's plan step exactly (see the note there):
-          # drift produces no error, just a scope nothing was ever uploaded
-          # to, i.e. a silent 100% miss.
+          # Computed again here, because this job runs on its own runner. It
+          # must match the plan step of build_and_stage. Drift raises no error;
+          # it points at a scope nothing was uploaded to.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
           pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           skipped=0
           if [ -f ../lake-cache-staging/deps/cached.txt ]; then
             skipped=$(wc -l < ../lake-cache-staging/deps/cached.txt)
           fi
-          # No manifest.txt means the stage step staged no deps at all, which
-          # is the steady state: every dep was already in the bucket.
+          # No manifest.txt means the stage step staged nothing, which is the
+          # steady state: the bucket already holds every dependency.
           if [ ! -f ../lake-cache-staging/deps/manifest.txt ]; then
             echo "summary=0 uploaded, ${skipped} already cached" >> "$GITHUB_OUTPUT"
             exit 0
@@ -793,9 +788,6 @@ jobs:
           done < ../lake-cache-staging/deps/manifest.txt
           arts=$(grep -c 'uploaded artifact' /tmp/dep-put.log || true)
           bytes=$(du -sb ../lake-cache-staging/deps | cut -f1)
-          # An `if` rather than `[ … ] && …`: `set -e` exempts the left side of
-          # an `&&`, so that idiom is safe here, but it silently fails the step
-          # if it ever ends up as the last command in the block.
           failnote=""
           if [ "$fail" -gt 0 ]; then
             failnote=", ${fail} FAILED"
@@ -804,14 +796,13 @@ jobs:
           echo "::notice::dep uploads: ${summary}"
           echo "summary=${summary}" >> "$GITHUB_OUTPUT"
 
-      # Cache carryover analysis: diff this run's uploaded artifact set against
-      # the previous run's on the same toolchain, via tiny per-run manifests
-      # kept in the bucket under the toolchain's analysis/<slug>/ prefix.
-      # Here:
-      #   carryover = artifacts also present last run;
-      #   new = this run's churn (≈ how much Mathlib changed since the last build).
-      # We also size the new artifacts (bytes of fresh content pushed to the
-      # bucket this run) by mapping each new content-hash back to its staged file.
+      # The carryover analysis. It compares the artifacts this run uploaded
+      # against those of the previous run on the same toolchain, through the
+      # small manifests under the analysis/<slug>/ prefix. Carryover counts the
+      # artifacts the previous run also held. New counts this run's churn,
+      # which tracks how much mathlib changed since that build. The step also
+      # sizes the new artifacts: it maps each new content hash back to its
+      # staged file.
       - name: Cache carryover analysis
         id: carryover
         continue-on-error: true
@@ -821,13 +812,14 @@ jobs:
           REPO: ${{ github.repository }}
           EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
         run: |
-          # Only the toolchain slug here: the analysis chain is per
-          # toolchain, not per pin set. Must match the plan step's.
+          # The slug alone here: the analysis chain is per toolchain, not per
+          # pin set. It must match the one the plan step computes.
           slug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
           base="${AUTH%/artifacts}/analysis/$slug"
           sha="${{ needs.build_and_stage.outputs.sha }}"
           sig=(--aws-sigv4 aws:amz:auto:s3 --user "$LAKE_CACHE_KEY")
-          # grep exits 1 on no match (handled by the total==0 branch); tolerate it under pipefail.
+          # grep exits 1 when it matches nothing, which pipefail would treat as
+          # a failure. The total==0 branch below handles that case.
           grep -oE 'uploaded artifact [0-9a-f]+' /tmp/put.log | awk '{print $3}' | sort -u > /tmp/today.txt || true
           total=$(wc -l < /tmp/today.txt)
           if [ "$total" -eq 0 ]; then
@@ -836,9 +828,9 @@ jobs:
             echo "new_content=n/a (no artifacts uploaded)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Map staged artifact content-hash -> file size in bytes. Staging files
-          # are flat `<hash>.<ext>` (see Lake's `artifactPath`); the lone
-          # `outputs.jsonl` keys to "outputs" and never matches a hash.
+          # Map each staged content hash to a file size in bytes. The staged
+          # files are flat, as `<hash>.<ext>`; see Lake's `artifactPath`. The
+          # single `outputs.jsonl` keys to "outputs" and matches no hash.
           declare -A SZ
           while read -r fname fsize; do
             SZ[${fname%%.*}]=$fsize
@@ -849,7 +841,7 @@ jobs:
             echo "$tot"
           }
           summary="n/a (baseline — no prior manifest)"
-          # Baseline: with no prior manifest, every uploaded artifact is "new".
+          # Without a previous manifest, every uploaded artifact counts as new.
           new_bytes=$(sum_bytes /tmp/today.txt)
           new_content="$(numfmt --to=iec-i --suffix=B "$new_bytes") across ${total} new artifact(s) (baseline — all new)"
           prev="$(curl -fsS "${sig[@]}" "$base/_latest.txt" 2>/dev/null || true)"
@@ -858,9 +850,9 @@ jobs:
             comm -23 /tmp/today.txt /tmp/prev.txt > /tmp/new.txt
             new=$(wc -l < /tmp/new.txt)
             new_bytes=$(sum_bytes /tmp/new.txt)
-            # Commit distance prev..sha on master, via the GitHub compare API
-            # (`.ahead_by`) — avoids deepening the shallow checkout across what
-            # can be hundreds of commits between daily runs.
+            # The commit distance from prev to sha on master, from the GitHub
+            # compare API. This avoids a deeper checkout, which daily runs can
+            # put hundreds of commits apart.
             dist=$(curl -fsS \
               -H "Authorization: Bearer ${GH_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
@@ -878,11 +870,11 @@ jobs:
           echo "::notice::new content uploaded: ${new_content}"
           echo "summary=${summary}" >> "$GITHUB_OUTPUT"
           echo "new_content=${new_content}" >> "$GITHUB_OUTPUT"
-          # Persist this run's manifest and advance the pointer, both
-          # best-effort: losing them costs the next run its warm start and its
-          # carryover baseline, nothing more. `<sha>.txt` is one artifact hash
-          # per line; `_latest.txt` is a single sha with no trailing newline,
-          # which is what the next run's plan step curls.
+          # Store this run's manifest and advance the pointer. Both are
+          # best-effort: a loss costs the next run its warm start and its
+          # carryover baseline, and nothing else. `<sha>.txt` holds one
+          # artifact hash per line. `_latest.txt` holds a single sha with no
+          # trailing newline, which the next plan step reads.
           printf %s "$sha" > /tmp/latest.txt
           curl -fsS "${sig[@]}" -X PUT -T /tmp/today.txt  "$base/${sha}.txt"   >/dev/null || echo "::warning::failed to store analysis manifest"
           curl -fsS "${sig[@]}" -X PUT -T /tmp/latest.txt "$base/_latest.txt"  >/dev/null || echo "::warning::failed to advance analysis pointer"
@@ -899,13 +891,13 @@ jobs:
     env:
       # Must match the targets staged/uploaded by build_and_stage.
       STAGE_TARGETS: ${{ inputs.targets || 'Mathlib' }}
-      # `lake cache get` issues unauthenticated GETs, so this job reads from
-      # a publicly-readable host (on R2, the bucket's public r2.dev or
-      # custom-domain URL — a different host than the authenticated S3 API
-      # endpoint the `upload` job PUTs to), via a generated services file.
+      # `lake cache get` sends unauthenticated GETs, so this job reads from a
+      # public host through a generated services file. On R2 that host is the
+      # public r2.dev or custom-domain URL, which differs from the
+      # authenticated S3 endpoint the `upload` job PUTs to.
       LAKE_CONFIG: ${{ github.workspace }}/shadow-services.toml
-      # Disable barrel/build-cache auto-fetch: every replay in this job must
-      # be attributable to the shadow bucket.
+      # Disable the barrel and build-cache auto-fetch, so the shadow bucket
+      # accounts for every replay in this job.
       LAKE_NO_CACHE: true
     steps:
       - name: Write cache services config
@@ -913,7 +905,7 @@ jobs:
           ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
         run: |
-          # Renders the block shown under "Cache service configuration" at the
+          # This renders the block under "Cache service configuration" at the
           # top of this file.
           cat > "$LAKE_CONFIG" <<EOF
           [[cache.service]]
@@ -930,9 +922,9 @@ jobs:
           path: pr-branch
           fetch-depth: 1
 
-      # Stamp the effective toolchain from build_and_stage's resolve step, so
-      # the replay runs the same lake that built the artifacts; the elan
-      # proxy auto-installs it on first use.
+      # Stamp the toolchain that build_and_stage resolved, so the replay runs
+      # the same lake that built the artifacts. The elan proxy installs it on
+      # first use.
       - name: Pin effective toolchain
         env:
           EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
@@ -976,9 +968,9 @@ jobs:
             --scope="$SHADOW_SCOPE" \
             --rev="${{ needs.build_and_stage.outputs.sha }}"
 
-      # Fetch each dep's outputs from its toolchain-qualified shadow scope,
-      # keyed by the dep's manifest rev (exact lookup, no history walk). A
-      # miss degrades that dep to a source build; the provenance step reports
+      # Fetch the outputs of each dependency from its own scope, under its
+      # manifest revision. The lookup is exact and walks no history. A miss
+      # builds that dependency from source, and the provenance step reports
       # the counts.
       - name: lake cache get dependencies
         if: ${{ env.CACHE_DEPS == 'true' }}
@@ -986,10 +978,9 @@ jobs:
           EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
         run: |
           cd pr-branch
-          # Recomputed here because this job runs on its own runner. Must
-          # match build_and_stage's plan step exactly (see the note there):
-          # drift produces no error, just a scope nothing was ever uploaded
-          # to, i.e. a silent 100% miss.
+          # Computed again here, because this job runs on its own runner. It
+          # must match the plan step of build_and_stage. Drift raises no error;
+          # it points at a scope nothing was uploaded to.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
           pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           total=0 hits=0
@@ -1010,11 +1001,11 @@ jobs:
       - name: lake build
         run: |
           cd pr-branch
-          # Artifacts fetched = root + dep outputs the `cache get` steps
-          # served (a non-verbose build replays them silently). Count before
-          # the build, which can add ltars of its own; hand the count to the
-          # provenance step.
-          # `|| true`: an informational count must not trip pipefail if find fails.
+          # The fetched artifacts are the root and dependency outputs the
+          # `cache get` steps served, which the build replays in silence. Count
+          # them before the build, which adds ltars of its own, and pass the
+          # count to the provenance step. `|| true` keeps this count from
+          # failing the step if find errors.
           FETCHED=$(find ~/.elan/toolchains -name '*.ltar' 2>/dev/null | wc -l || true)
           echo "ltar count after gets: $FETCHED"
           echo "FETCHED_ARTIFACTS=$FETCHED" >> "$GITHUB_ENV"
@@ -1026,22 +1017,22 @@ jobs:
         run: |
           cd pr-branch
           log=.lake/consume-build.log
-          # "Served from cache" = the artifacts the `lake cache get` steps
-          # fetched (replayed silently by a non-verbose build). "Built" =
-          # modules the pipeline ran for: only deps that missed the shadow
-          # scope (or skip-listed ones, if any) should appear here; the
-          # expected steady state is zero.
+          # "Served from cache" counts the artifacts the `lake cache get` steps
+          # fetched, which the build replays in silence. "Built" counts the
+          # modules the pipeline ran for. Only a dependency that missed the
+          # bucket, or one on the skip list, belongs there; the steady state is
+          # zero.
           echo "Served from cache (fetched): ${FETCHED_ARTIFACTS}"
           BUILT_TOTAL=$(grep -cE '^✔.*Built ' "$log" || true)
-          # The cache invariant: every root-package module must be a cache HIT
-          # (no rebuild). Emit an explicit health line (consumed by the Zulip
-          # report) and fail the run if it's not a full hit. The alternation
-          # lists mathlib's four libraries — everything else that builds is a
-          # dependency.
+          # The cache invariant: every root-package module must be a hit. The
+          # step emits a health line for the Zulip report, and fails the run on
+          # anything less. The alternation lists mathlib's four libraries;
+          # everything else that builds is a dependency.
           BUILT_ROOT=$(grep -cE '^✔.*Built (Mathlib|Archive|Counterexamples|Wanted)([. ]|$)' "$log" || true)
-          # Dep rebuilds are reported, not fatal: they measure whether the
-          # dep-as-root mappings actually match this workspace's input hashes
-          # (plus skip-list deps and shadow-scope misses, which always build).
+          # A dependency rebuild is reported, not fatal. The count measures
+          # whether the exported mappings match this workspace's input hashes.
+          # A skip-list dependency and a bucket miss also build, and count
+          # here.
           BUILT_DEP=$((BUILT_TOTAL - BUILT_ROOT))
           dep_health="📚 deps: ${DEP_HITS:-0}/${DEP_TOTAL:-0} fetched from shadow scope, ${BUILT_DEP} dep module(s) rebuilt (skip list: ${DEP_SKIP:-none})"
           echo "dep_health=${dep_health}" >> "$GITHUB_OUTPUT"
@@ -1057,27 +1048,28 @@ jobs:
           echo "health=${health}" >> "$GITHUB_OUTPUT"
           echo "::notice::${health}"
 
-      # Integrity check (not a cache-provenance check): re-derives artifact
-      # hashes from disk for the targets and confirms nothing is stale. Runs
-      # after the build, so dependency artifacts are already present; the
-      # cache-provenance assertion lives in the `lake build` step above.
+      # An integrity check, not a provenance check. It derives the artifact
+      # hashes of the targets from disk again, and confirms that none is stale.
+      # It runs after the build, so the dependency artifacts are present. The
+      # provenance assertion lives in the step above.
       - name: Verify with --rehash
         run: |
           cd pr-branch
           read -ra TARGETS <<< "$STAGE_TARGETS"
           lake build --no-build --rehash -v "${TARGETS[@]}"
 
-  # Downstream-consumer experiment: a minimal project that *depends on*
-  # mathlib fetches everything — mathlib itself plus the transitive deps —
-  # from the shadow bucket. The mappings were produced with mathlib as the
-  # workspace ROOT; here mathlib is a DEP, so zero rebuilt Mathlib modules
-  # proves the input hashes agree across the two workspace shapes, i.e. the
-  # bucket can serve real downstream projects.
+  # The downstream-consumer check. A small project that depends on mathlib
+  # fetches mathlib and every transitive dependency from the bucket. The
+  # pipeline produced those mappings with mathlib as the workspace root, and
+  # this project builds mathlib as a dependency. Zero rebuilt Mathlib modules
+  # therefore show that the input hashes agree across the two workspace
+  # shapes, and that the bucket can serve a real downstream project.
   downstream:
     name: Downstream project fetch (mathlib-as-dep)
     needs: [build_and_stage, upload]
-    # Only meaningful on full-Mathlib runs with dep caching on: the test
-    # imports Mathlib modules, so the bucket must hold the full root set.
+    # This job needs a full-Mathlib run with dependency caching on, because
+    # the project imports Mathlib modules and the bucket must hold the whole
+    # root set.
     if: ${{ github.repository == 'leanprover-community/mathlib4' && (inputs.targets || 'Mathlib') == 'Mathlib' && (github.event_name != 'workflow_dispatch' || inputs.cache_deps) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -1085,12 +1077,12 @@ jobs:
       health: ${{ steps.health.outputs.health }}
     env:
       LAKE_CONFIG: ${{ github.workspace }}/shadow-services.toml
-      # Disable barrel/build-cache auto-fetch so every replay in this job is
-      # attributable to the shadow bucket.
+      # Disable the barrel and build-cache auto-fetch, so the shadow bucket
+      # accounts for every replay in this job.
       LAKE_NO_CACHE: true
-      # Skip mathlib's post-update hook: it runs the legacy `cache get` when
-      # mathlib is updated as a dependency, which would hydrate the build
-      # dirs from the legacy cache and mask what the shadow bucket serves.
+      # Skip mathlib's post-update hook. It runs the legacy `cache get` when a
+      # workspace updates mathlib as a dependency. That would hydrate the build
+      # directories from the legacy cache, and hide what the bucket serves.
       MATHLIB_NO_CACHE_ON_UPDATE: "1"
       EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
       MATHLIB_SHA: ${{ needs.build_and_stage.outputs.sha }}
@@ -1100,7 +1092,7 @@ jobs:
           ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
         run: |
-          # Renders the block shown under "Cache service configuration" at the
+          # This renders the block under "Cache service configuration" at the
           # top of this file.
           cat > "$LAKE_CONFIG" <<EOF
           [[cache.service]]
@@ -1117,8 +1109,8 @@ jobs:
           ./elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
-      # A minimal project depending on mathlib at the rev this run built.
-      # The three files below render as:
+      # A small project that depends on mathlib at the revision this run
+      # built. The three files below render as:
       #
       #   lean-toolchain   leanprover/lean4:v4.34.0-rc2
       #   lakefile.toml    a [[require]] on mathlib's git URL, with
@@ -1127,10 +1119,10 @@ jobs:
       #                    the build pulls a real slice of Mathlib's closure
       #                    rather than a leaf module
       #
-      # `lake update` then materializes mathlib and writes a lake-manifest.json
-      # pinning it at that sha plus the 8 transitive deps at mathlib's own
-      # pins — the resolution a real downstream performs, and the manifest the
-      # fetch step below reads revisions from.
+      # `lake update` then materializes mathlib and writes a lake-manifest.json.
+      # That manifest pins mathlib at the sha, and the 8 transitive
+      # dependencies at mathlib's own pins. A real downstream project resolves
+      # the same way, and the fetch step below reads its revisions.
       - name: Create downstream project
         run: |
           mkdir downstream && cd downstream
@@ -1155,27 +1147,27 @@ jobs:
           EOF
           lake update --keep-toolchain
 
-      # Hydrate: mathlib itself from the root scope, transitive deps from
-      # their per-dep scopes — every rev comes from the downstream's own
-      # manifest (mathlib's entry is the pinned sha; the rest are inherited
-      # pins). Misses degrade to source builds, reported below.
+      # Hydrate mathlib from the root scope, and each transitive dependency
+      # from its own scope. Every revision comes from the manifest of the
+      # downstream project: the mathlib entry holds the pinned sha, and the
+      # rest hold the inherited pins. A miss builds from source, and the step
+      # below reports it.
       - name: lake cache get (mathlib + transitive deps)
         run: |
           cd downstream
-          # Recomputed here because this job runs on its own runner. Must
-          # match build_and_stage's plan step exactly (see the note there):
-          # drift produces no error, just a scope nothing was ever uploaded
-          # to, i.e. a silent 100% miss.
-          # The pins hash comes from *mathlib's* manifest, vendored inside this
-          # workspace at .lake/packages/mathlib/ — a real downstream driver
-          # reads it from exactly there.
+          # Computed again here, because this job runs on its own runner. It
+          # must match the plan step of build_and_stage. Drift raises no error;
+          # it points at a scope nothing was uploaded to.
+          # The pin hash comes from mathlib's manifest, which this workspace
+          # holds at .lake/packages/mathlib/. A real downstream cache driver
+          # reads it from the same place.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
           pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' .lake/packages/mathlib/lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
-          # Note the two manifests: the pins hash above comes from mathlib's,
-          # while the loop below iterates the *downstream's* — which lists
-          # mathlib itself plus the 8 deps it inherited. So mathlib is fetched
-          # from the root scope (keyed by its sha) and everything else from its
-          # dep scope, all revisions read from the downstream's own resolution.
+          # Two manifests are in play. The pin hash above comes from
+          # mathlib's, and the loop below reads the downstream project's, which
+          # lists mathlib and the 8 dependencies it inherited. mathlib
+          # therefore comes from the root scope, under its sha, and every other
+          # package from its own dependency scope.
           total=0 hits=0
           while read -r name rev; do
             if [[ " $DEP_SKIP " == *" $name "* ]]; then continue; fi

--- a/.github/workflows/lake_cache_shadow.yml
+++ b/.github/workflows/lake_cache_shadow.yml
@@ -240,6 +240,10 @@ jobs:
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
       toolchain: ${{ steps.resolve.outputs.toolchain }}
+      # The scope qualifiers, so the later jobs use these values and do not
+      # derive them again.
+      tcslug: ${{ steps.plan.outputs.tcslug }}
+      pins8: ${{ steps.plan.outputs.pins8 }}
     env:
       LAKE_CACHE_DIR: .lake/cache
       LAKE_NO_CACHE: true
@@ -315,6 +319,7 @@ jobs:
       # This step writes the overrides because jq is not available inside
       # landrun.
       - name: Plan hydration & dependency caching
+        id: plan
         shell: bash -euo pipefail {0}
         env:
           LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
@@ -335,10 +340,9 @@ jobs:
           revisionEndpoint = "$LAKE_CACHE_REVISION_ENDPOINT"
           EOF
           # The two qualifiers that make a dependency scope exact. They are
-          # required for a hit. The upload,
-          # consume and downstream jobs compute them again, because they run on
-          # their own runners. A mismatch between two jobs fails nothing; it
-          # makes every fetch a miss.
+          # required for a hit. This step is the only place that derives them:
+          # the upload and consume jobs read them from this job's outputs, so
+          # the two cannot drift apart.
           #   tcslug  The toolchain, with each character outside A-Za-z0-9._-
           #           replaced by '-'. "leanprover/lean4:v4.34.0-rc2" becomes
           #           "leanprover-lean4-v4.34.0-rc2".
@@ -348,6 +352,8 @@ jobs:
           pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           echo "TCSLUG=$tcslug" >> "$GITHUB_ENV"
           echo "PINS8=$pins8" >> "$GITHUB_ENV"
+          echo "tcslug=$tcslug" >> "$GITHUB_OUTPUT"
+          echo "pins8=$pins8" >> "$GITHUB_OUTPUT"
           # `analysis/<tcslug>/_latest.txt` holds the mathlib sha of the
           # previous run on this toolchain. It returns 404 on a chain that has
           # never run, and that run has no warm start.
@@ -776,18 +782,18 @@ jobs:
       # step already removed the dependencies the bucket holds. The log is
       # separate from /tmp/put.log, so these artifacts stay out of the root
       # carryover analysis below.
+      # `continue-on-error` keeps a failed dependency upload from failing the
+      # run: the root upload has already succeeded, and the run still carries
+      # useful data. The summary reports the count as FAILED, and the consume
+      # job then reports the miss and the rebuild.
       - name: Upload dependency caches
         id: depupload
         continue-on-error: true
         env:
-          EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
+          TCSLUG: ${{ needs.build_and_stage.outputs.tcslug }}
+          PINS8: ${{ needs.build_and_stage.outputs.pins8 }}
         run: |
           cd pr-branch
-          # Computed again here, because this job runs on its own runner. It
-          # must match the plan step of build_and_stage. Drift raises no error;
-          # it points at a scope nothing was uploaded to.
-          tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
-          pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           skipped=0
           if [ -f ../lake-cache-staging/deps/cached.txt ]; then
             skipped=$(wc -l < ../lake-cache-staging/deps/cached.txt)
@@ -803,7 +809,7 @@ jobs:
           while read -r name rev; do
             if lake cache put-staged "../lake-cache-staging/deps/$name" \
                 --service=shadow \
-                --scope="$SHADOW_SCOPE/deps/$tcslug/$pins8/$name" \
+                --scope="$SHADOW_SCOPE/deps/$TCSLUG/$PINS8/$name" \
                 --rev="$rev" 2>&1 | tee -a /tmp/dep-put.log; then
               ok=$((ok+1))
             else
@@ -835,12 +841,11 @@ jobs:
           AUTH: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
+          TCSLUG: ${{ needs.build_and_stage.outputs.tcslug }}
         run: |
-          # The slug alone here: the analysis chain is per toolchain, not per
-          # pin set. It must match the one the plan step computes.
-          slug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
-          base="${AUTH%/artifacts}/analysis/$slug"
+          # The slug alone keys the analysis chain, which is per toolchain and
+          # not per pin set.
+          base="${AUTH%/artifacts}/analysis/$TCSLUG"
           sha="${{ needs.build_and_stage.outputs.sha }}"
           sig=(--aws-sigv4 aws:amz:auto:s3 --user "$LAKE_CACHE_KEY")
           # grep exits 1 when it matches nothing, which pipefail would treat as
@@ -1000,20 +1005,16 @@ jobs:
       - name: lake cache get dependencies
         if: ${{ env.CACHE_DEPS == 'true' }}
         env:
-          EFFECTIVE_TOOLCHAIN: ${{ needs.build_and_stage.outputs.toolchain }}
+          TCSLUG: ${{ needs.build_and_stage.outputs.tcslug }}
+          PINS8: ${{ needs.build_and_stage.outputs.pins8 }}
         run: |
           cd pr-branch
-          # Computed again here, because this job runs on its own runner. It
-          # must match the plan step of build_and_stage. Drift raises no error;
-          # it points at a scope nothing was uploaded to.
-          tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
-          pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           total=0 hits=0
           while read -r name rev; do
             if [[ " $DEP_SKIP " == *" $name "* ]]; then continue; fi
             total=$((total+1))
             if lake cache get --service=shadow --package="$name" \
-                --scope="$SHADOW_SCOPE/deps/$tcslug/$pins8/$name" --rev="$rev"; then
+                --scope="$SHADOW_SCOPE/deps/$TCSLUG/$PINS8/$name" --rev="$rev"; then
               hits=$((hits+1))
             else
               echo "::warning::dep cache miss for $name@${rev:0:12}; it will build from source"
@@ -1180,12 +1181,12 @@ jobs:
       - name: lake cache get (mathlib + transitive deps)
         run: |
           cd downstream
-          # Computed again here, because this job runs on its own runner. It
-          # must match the plan step of build_and_stage. Drift raises no error;
-          # it points at a scope nothing was uploaded to.
-          # The pin hash comes from mathlib's manifest, which this workspace
-          # holds at .lake/packages/mathlib/. A real downstream cache driver
-          # reads it from the same place.
+          # This job derives the qualifiers itself, where the other jobs read
+          # them from build_and_stage. That is the point of the job: a real
+          # downstream project has no access to mathlib's CI outputs, and must
+          # arrive at the same scope from what it holds locally. The pin hash
+          # therefore comes from mathlib's manifest, which this workspace holds
+          # at .lake/packages/mathlib/.
           tcslug="$(printf %s "$EFFECTIVE_TOOLCHAIN" | tr -c 'A-Za-z0-9._-' '-')"
           pins8="$(jq -r '.packages[] | select(.type == "git") | "\(.name) \(.rev)"' .lake/packages/mathlib/lake-manifest.json | LC_ALL=C sort | sha256sum | cut -c1-8)"
           # Two manifests are in play. The pin hash above comes from


### PR DESCRIPTION
This PR makes the lake cache shadow pipeline cache dependencies. The pipeline cached the root package only, and used the legacy cache for the dependencies.

The placeholders below are: `<SCOPE>`, the scope string this pipeline passes to every put and get, which is `mathlib4-master-shadow`; `<mathlib-sha>`, the mathlib commit a run builds; `<DEP>`, a dependency's package name, such as `batteries`; and `<targets>`, the Lake targets to build, from the `targets` dispatch input, which defaults to `Mathlib`.

### One revision for every package

mathlib and its 8 git dependencies all publish under the same revision, the mathlib commit:

    revisions/<SCOPE>/<mathlib-sha>.jsonl           mathlib
    revisions/<SCOPE>/<DEP>/<mathlib-sha>.jsonl     each dependency
    artifacts/<SCOPE>/<content-hash>.art            no sha, shared across commits
    artifacts/<SCOPE>/<DEP>/<content-hash>.art

A dependency's own revision leaves open which upstreams it was built against, and a mathlib commit that bumps one dependency changes the correct mappings for every dependency below it. The mathlib commit determines the whole set, through its manifest, so it is the revision that identifies a dependency's outputs.

Lake accepts this because `GitRepo.resolveRevision` returns a full SHA-1 unchanged, without looking it up, and `cache put-staged` loads no workspace and resolves nothing. So a dependency's revision file lands under the mathlib commit even though that commit belongs to another repository. The revision reaches only the revision file's name, so artifacts stay shared.

One mathlib commit therefore names one complete set of packages, and a consumer needs that sha and its own manifest.

### Push

1. `lake build <targets> -o .lake/outputs.jsonl` builds mathlib and every dependency, writes the artifacts into the local Lake cache, and records mathlib's own mappings.
2. `lake build @<DEP> --package=<DEP> -o .lake/dep-outputs/<DEP>.jsonl`, once per dependency. `--package` points `-o` at a dependency, so the export runs in mathlib's own workspace and replays what step 1 produced.
3. `lake cache stage`, once per package, each into its own directory.
4. `lake cache put-staged`, once per package, all with `--rev=<mathlib-sha>`. mathlib passes `--scope=<SCOPE>` and each dependency `--scope=<SCOPE>/<DEP>`.

### Pull

One `lake cache get` per package, with the same scope and revision arguments, then `lake build <targets>` to replay. The `downstream` job runs the same sequence for a small project that requires mathlib, from mathlib's sha and its own manifest alone.

`.github/workflows/lake_cache_shadow.md`, which this PR adds, covers the rest: the cache service, hydration, the storage layout, the override lane, the skip list, and the secrets and variables the pipeline needs.

Every cache operation is now a Lake one. The pipeline no longer builds mathlib's `cache` tool to hydrate a cold chain, so the first run on a toolchain builds mathlib and its dependencies from source, as an override run already did.

### Validation

[Run 35631186158](https://github.com/leanprover-community/mathlib4/actions/runs/35631186158) and [run 35635772741](https://github.com/leanprover-community/mathlib4/actions/runs/35635772741) cover the work end to end on master's toolchain. Each exported and uploaded all 8 dependencies, 497 MiB across 455 artifacts. `consume` fetched 8 of 8 with zero dependency rebuilds and zero root-package rebuilds, and `--rehash` passed. `downstream` fetched 9 of 9 packages with zero Mathlib rebuilds and zero other dependency modules built. The second run rebuilt the same commit as the first and uploaded zero new artifacts.

Those two runs keyed the dependencies through a per-run revision endpoint. A further run validates the present form, which keys them by the mathlib commit instead.

A run fails if a root-package module rebuilds, so the daily run guards against a regression.

The pipeline needs `lake build --package`, which master's toolchain pin v4.35.0-rc2 provides. An older toolchain override builds from source and warns.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
