### PR TITLE
[Merged by Bors] - chore(Topology): tidy markdown headers

### DIFF
--- a/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
@@ -14,11 +14,11 @@ public import Mathlib.Topology.Algebra.Affine
 
 This file defines a type of bundled continuous affine maps.
 
-## Main definitions:
+## Main definitions
 
 * `ContinuousAffineMap`
 
-## Notation:
+## Notation
 
 We introduce the notation `P →ᴬ[R] Q` for `ContinuousAffineMap R P Q` (not to be confused with the
 notation `A →A[R] B` for `ContinuousAlgHom`). Note that this is parallel to the notation `E →L[R] F`

--- a/Mathlib/Topology/Algebra/Group/GroupTopology.lean
+++ b/Mathlib/Topology/Algebra/Group/GroupTopology.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Topology.Algebra.Group.Basic
 
 /-!
-### Lattice of group topologies
+# Lattice of group topologies
 
 We define a type class `GroupTopology α` which endows a group `α` with a topology such that all
 group operations are continuous.

--- a/Mathlib/Topology/Algebra/GroupCompletion.lean
+++ b/Mathlib/Topology/Algebra/GroupCompletion.lean
@@ -16,7 +16,7 @@ on the completion of an abelian group endowed with a compatible uniform structur
 Then the instance `UniformSpace.Completion.isUniformAddGroup` proves this group structure is
 compatible with the completed uniform structure. The compatibility condition is `IsUniformAddGroup`.
 
-## Main declarations:
+## Main declarations
 
 Beyond the instances explained above (that don't have to be explicitly invoked),
 the main constructions deal with continuous group morphisms.

--- a/Mathlib/Topology/Algebra/LinearMapCompletion.lean
+++ b/Mathlib/Topology/Algebra/LinearMapCompletion.lean
@@ -14,7 +14,7 @@ public import Mathlib.Topology.Algebra.Module.ContinuousLinearMap.Basic
 This file has a declaration that enables a continuous (semi-)linear map between modules to be
 lifted to a continuous semilinear map between the completions of those modules.
 
-## Main declarations:
+## Main declarations
 
 * `ContinuousLinearMap.completion`: promotes a continuous semilinear map
   from `α` to `β` to a continuous semilinear map from `Completion α` to `Completion β`.

--- a/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
@@ -32,7 +32,7 @@ continuous.
 
 When `E` is a normed space, this gets us the equivalence of norms in finite dimension.
 
-## Main results :
+## Main results
 
 * `LinearMap.continuous_iff_isClosed_ker` : a linear form is continuous if and only if its kernel
   is closed.

--- a/Mathlib/Topology/Algebra/UniformRing.lean
+++ b/Mathlib/Topology/Algebra/UniformRing.lean
@@ -24,7 +24,7 @@ Moreover, if a topological ring is an algebra over a commutative semiring, then 
 
 The last part of the file builds a ring structure on the biggest separated quotient of a ring.
 
-## Main declarations:
+## Main declarations
 
 Beyond the instances explained above (that don't have to be explicitly invoked),
 the main constructions deal with continuous ring morphisms.

--- a/Mathlib/Topology/Category/CompHaus/Frm.lean
+++ b/Mathlib/Topology/Category/CompHaus/Frm.lean
@@ -9,7 +9,7 @@ public import Mathlib.Order.Category.Frm
 public import Mathlib.Topology.Category.CompHaus.Basic
 public import Mathlib.Topology.Sets.Opens
 
-/-! The forgetful functor from `TopCatᵒᵖ` to `Frm`. -/
+/-! # The forgetful functor from `TopCatᵒᵖ` to `Frm` -/
 
 @[expose] public section
 

--- a/Mathlib/Topology/Category/Compactum.lean
+++ b/Mathlib/Topology/Category/Compactum.lean
@@ -30,7 +30,7 @@ https://ncatlab.org/nlab/show/monad
 This file proves the equivalence between the category of *compact Hausdorff topological spaces*
 and the category of algebras for the *ultrafilter monad*.
 
-## Notation:
+## Notation
 
 Here are the main objects introduced in this file.
 - `Compactum` is the type of compacta, which we define as algebras for the ultrafilter monad.

--- a/Mathlib/Topology/FiberPartition.lean
+++ b/Mathlib/Topology/FiberPartition.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Topology.LocallyConstant.Basic
 public import Mathlib.Logic.Function.FiberPartition
 /-!
+# Fiber partitions of a topological space
 
 This file provides some API surrounding `Function.Fiber` (see
 `Mathlib/Logic/Function/FiberPartition.lean`) in the presence of a topology on the domain of the

--- a/Mathlib/Topology/FiberPartition.lean
+++ b/Mathlib/Topology/FiberPartition.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Topology.LocallyConstant.Basic
 public import Mathlib.Logic.Function.FiberPartition
 /-!
-# Fiber partitions of a topological space
+# Fibers of a map from a topological space
 
 This file provides some API surrounding `Function.Fiber` (see
 `Mathlib/Logic/Function/FiberPartition.lean`) in the presence of a topology on the domain of the

--- a/Mathlib/Topology/Homotopy/HSpaces.lean
+++ b/Mathlib/Topology/Homotopy/HSpaces.lean
@@ -34,7 +34,8 @@ Some notable properties of `H-spaces` are
   definitionally equal to the product of `H-space` structures on `G` and `G'`.
 * The loop space based at every `x : X` carries a structure of an `H-space`.
 
-## To Do
+## TODO
+
 * Prove that for every `NormedAddTorsor Z` and every `z : Z`, the operation
   `fun x y ↦ midpoint x y` defines an `H-space` structure with `z` as a "neutral element".
 * Prove that `S^0`, `S^1`, `S^3` and `S^7` are the unique spheres that are `H-spaces`, where the

--- a/Mathlib/Topology/Homotopy/HomotopyGroup.lean
+++ b/Mathlib/Topology/Homotopy/HomotopyGroup.lean
@@ -23,7 +23,7 @@ We show that `π_0 X x` is equivalent to the path-connected components, and
 that `π_1 X x` is equivalent to the fundamental group at `x`.
 We provide a group instance using path composition and show commutativity when `n > 1`.
 
-## definitions
+## Definitions
 
 * `GenLoop N x` is the type of continuous functions `I^N → X` that send the boundary to `x`,
 * `HomotopyGroup.Pi n X x` denoted `π_ n X x` is the quotient of `GenLoop (Fin n) x` by
@@ -31,7 +31,8 @@ We provide a group instance using path composition and show commutativity when `
 * group instance `Group (π_(n+1) X x)`,
 * commutative group instance `CommGroup (π_(n+2) X x)`.
 
-TODO:
+## TODO
+
 * `Ω^M (Ω^N X) ≃ₜ Ω^(M⊕N) X`, and `Ω^M X ≃ₜ Ω^N X` when `M ≃ N`. Similarly for `π_`.
 * Examples with `𝕊^n`: `π_n (𝕊^n) = ℤ`, `π_m (𝕊^n)` trivial for `m < n`.
 * Actions of π_1 on π_n.

--- a/Mathlib/Topology/Instances/AddCircle/Defs.lean
+++ b/Mathlib/Topology/Instances/AddCircle/Defs.lean
@@ -24,7 +24,7 @@ We define the additive circle `AddCircle p` as the quotient `𝕜 ⧸ ℤ ∙ p`
 See also `Circle` and `Real.Angle`.  For the normed group structure on `AddCircle`, see
 `AddCircle.NormedAddCommGroup` in a later file.
 
-## Main definitions and results:
+## Main definitions and results
 
 * `AddCircle`: the additive circle `𝕜 ⧸ ℤ ∙ p` for some period `p : 𝕜`
 * `UnitAddCircle`: the special case `ℝ ⧸ ℤ`
@@ -39,7 +39,7 @@ See also `Circle` and `Real.Angle`.  For the normed group structure on `AddCircl
   and `f a = f (a + p)` for some `a`, then there is a continuous function `AddCircle p → B`
   which agrees with `f` on `Icc a (a + p)`.
 
-## Implementation notes:
+## Implementation notes
 
 Although the most important case is `𝕜 = ℝ` we wish to support other types of scalars, such as
 the rational circle `AddCircle (1 : ℚ)`, and so we set things up more generally.

--- a/Mathlib/Topology/Instances/Matrix.lean
+++ b/Mathlib/Topology/Instances/Matrix.lean
@@ -16,7 +16,7 @@ public import Mathlib.Topology.Algebra.Star
 
 This file is a place to collect topological results about matrices.
 
-## Main definitions:
+## Main definitions
 
 * `Matrix.topologicalRing`: square matrices form a topological ring
 

--- a/Mathlib/Topology/Instances/ZMultiples.lean
+++ b/Mathlib/Topology/Instances/ZMultiples.lean
@@ -12,6 +12,8 @@ public import Mathlib.Topology.Algebra.Ring.Real
 public import Mathlib.Topology.Metrizable.Basic
 
 /-!
+# Multiples of a real number form a discrete subgroup of `ℝ`
+
 The subgroup "multiples of `a`" (`zmultiples a`) is a discrete subgroup of `ℝ`, i.e. its
 intersection with compact sets is finite.
 -/

--- a/Mathlib/Topology/LocallyFinite.lean
+++ b/Mathlib/Topology/LocallyFinite.lean
@@ -9,7 +9,7 @@ public import Mathlib.Order.Filter.SmallSets
 public import Mathlib.Topology.ContinuousOn
 
 /-!
-### Locally finite families of sets
+# Locally finite families of sets
 
 We say that a family of sets in a topological space is *locally finite* if at every point `x : X`,
 there is a neighborhood of `x` which meets only finitely many sets in the family.

--- a/Mathlib/Topology/MetricSpace/Bounded.lean
+++ b/Mathlib/Topology/MetricSpace/Bounded.lean
@@ -13,7 +13,7 @@ public import Mathlib.Topology.MetricSpace.Basic
 public import Mathlib.Topology.EMetricSpace.Diam
 
 /-!
-## Boundedness in (pseudo)-metric spaces
+# Boundedness in (pseudo)-metric spaces
 
 This file contains one definition, and various results on boundedness in pseudo-metric spaces.
 * `Metric.diam s` : The `iSup` of the distances of members of `s`.

--- a/Mathlib/Topology/MetricSpace/Cauchy.lean
+++ b/Mathlib/Topology/MetricSpace/Cauchy.lean
@@ -9,7 +9,7 @@ public import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
 public import Mathlib.Topology.EMetricSpace.Basic
 
 /-!
-## Cauchy sequences in (pseudo-)metric spaces
+# Cauchy sequences in (pseudo-)metric spaces
 
 Various results on Cauchy sequences in (pseudo-)metric spaces, including
 

--- a/Mathlib/Topology/MetricSpace/ProperSpace.lean
+++ b/Mathlib/Topology/MetricSpace/ProperSpace.lean
@@ -10,7 +10,7 @@ public import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
 public import Mathlib.Topology.MetricSpace.Pseudo.Pi
 public import Mathlib.Topology.Order.IsLUB
 
-/-! ## Proper spaces
+/-! # Proper spaces
 
 ## Main definitions and results
 * `ProperSpace α`: a `PseudoMetricSpace` where all closed balls are compact

--- a/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
@@ -12,7 +12,7 @@ public import Mathlib.Topology.MetricSpace.Pseudo.Defs
 public import Mathlib.Topology.Metrizable.Basic
 
 /-!
-## Pseudo-metric spaces
+# Pseudo-metric spaces
 
 Further results about pseudo-metric spaces.
 

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -13,7 +13,7 @@ public import Mathlib.Topology.EMetricSpace.Defs
 public import Mathlib.Topology.UniformSpace.Basic
 
 /-!
-## Pseudo-metric spaces
+# Pseudo-metric spaces
 
 This file defines pseudo-metric spaces: these differ from metric spaces by not imposing the
 condition `dist x y = 0 → x = y`.

--- a/Mathlib/Topology/MetricSpace/Ultra/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Ultra/Basic.lean
@@ -9,7 +9,7 @@ public import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
 public import Mathlib.Topology.Clopen
 
 /-!
-## Ultrametric spaces
+# Ultrametric spaces
 
 This file defines ultrametric spaces, implemented as a mixin on the `Dist`,
 so that it can apply on pseudometric spaces as well.

--- a/Mathlib/Topology/Piecewise.lean
+++ b/Mathlib/Topology/Piecewise.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Topology.ContinuousOn
 
 /-!
-### Continuity of piecewise defined functions
+# Continuity of piecewise defined functions
 -/
 
 public section

--- a/Mathlib/Topology/Sheaves/Alexandrov.lean
+++ b/Mathlib/Topology/Sheaves/Alexandrov.lean
@@ -10,6 +10,7 @@ public import Mathlib.Topology.Order.UpperLowerSetTopology
 public import Mathlib.Topology.Sheaves.SheafCondition.OpensLeCover
 
 /-!
+# Sheaves on the Alexandrov topology of a preorder
 
 Let `X` be a preorder `≤`, and consider the associated Alexandrov topology on `X`.
 Given a functor `F : X ⥤ C` to a complete category, we can extend `F` to a


### PR DESCRIPTION
This PR:
- ensures all files in `Mathlib/Topology` have one and only one H1 header,
- Cleans up some non-standard H2 headers.

Some files were lacking an existing module header candidate. In those cases one was authored by Claude Opus 5.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
