### PR TITLE
[Merged by Bors] - chore(Analysis): missing normed/inner instances for closed submodules

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -1216,8 +1216,7 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
     rw [← sq_eq_sq₀ (norm_nonneg _) (norm_nonneg _), norm_sq_eq_add_norm_sq_projection x S]
     simp only [sq, Mx_decomp]
     rw [norm_add_sq_eq_norm_sq_add_norm_sq_of_inner_eq_zero (L (p1 x)) (L3 (p2 x)) Mx_orth]
-    simp only [p1, p2, LinearIsometry.norm_map,
-      ContinuousLinearMap.coe_coe, Submodule.coe_norm]
+    simp [p1, p2]
   exact
     { toLinearMap := M
       norm_map' := M_norm_map }

--- a/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
@@ -145,8 +145,8 @@ def quotientEquivOrthogonal : (E ⧸ K) ≃ₗᵢ[𝕜] ↥Kᗮ where
   __ := K.quotientEquivOfIsCompl Kᗮ K.isCompl_orthogonal
   norm_map' y := by
     set f := K.quotientEquivOfIsCompl Kᗮ K.isCompl_orthogonal
-    rw [coe_norm, ← norm_orthogonalProjectionOnto_apply Kᗮ (f y).2,
-      orthogonalProjectionOnto_orthogonal, coe_norm, starProjection_minimal, eq_comm]
+    rw [← norm_coe, ← norm_orthogonalProjectionOnto_apply Kᗮ (f y).2,
+      orthogonalProjectionOnto_orthogonal, ← norm_coe, starProjection_minimal, eq_comm]
     have h : ‖Quotient.mk (f y).val‖ = sInf ((fun (x : E) ↦ ‖(f y).val + x‖) '' K.toAddSubgroup) :=
       quotient_norm_mk_eq K.toAddSubgroup (f y).1
     convert! h using 2

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
@@ -649,7 +649,7 @@ lemma re_inner_starProjection_eq_normSq [K.HasOrthogonalProjection] (v : E) :
     re ⟪K.starProjection v, v⟫ = ‖K.orthogonalProjectionOnto v‖ ^ 2 := by
   rw [starProjection_apply,
     re_inner_eq_norm_mul_self_add_norm_mul_self_sub_norm_sub_mul_self_div_two,
-    div_eq_iff (NeZero.ne' 2).symm, pow_two, add_sub_assoc, ← eq_sub_iff_add_eq', coe_norm,
+    div_eq_iff (NeZero.ne' 2).symm, pow_two, add_sub_assoc, ← eq_sub_iff_add_eq', ← norm_coe,
     ← mul_sub_one, show (2 : ℝ) - 1 = 1 by norm_num, mul_one, sub_eq_iff_eq_add', norm_sub_rev]
   simpa [sq, add_comm] using K.norm_sq_eq_add_norm_sq_starProjection v
 

--- a/Mathlib/Analysis/InnerProductSpace/Subspace.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Subspace.lean
@@ -22,13 +22,13 @@ open RCLike Real Module
 
 open LinearMap (BilinForm)
 
+open scoped InnerProductSpace
+
 variable {𝕜 E F : Type*} [RCLike 𝕜]
 
 section Submodule
 
 variable [SeminormedAddCommGroup E] [InnerProductSpace 𝕜 E]
-
-local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
 
 /-! ### Inner product space structure on subspaces -/
 
@@ -38,7 +38,7 @@ instance Submodule.innerProductSpace (W : Submodule 𝕜 E) : InnerProductSpace 
 
 /-- The inner product on submodules is the same as on the ambient space. -/
 @[simp]
-theorem Submodule.coe_inner (W : Submodule 𝕜 E) (x y : W) : ⟪x, y⟫ = ⟪(x : E), ↑y⟫ :=
+theorem Submodule.coe_inner (W : Submodule 𝕜 E) (x y : W) : ⟪x, y⟫_𝕜 = ⟪(x : E), y⟫_𝕜 :=
   rfl
 
 theorem Orthonormal.codRestrict {ι : Type*} {v : ι → E} (hv : Orthonormal 𝕜 v) (s : Submodule 𝕜 E)
@@ -57,15 +57,13 @@ section ClosedSubmodule
 
 variable [SeminormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 
-local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
-
 /-- Induced inner product on a closed submodule. -/
 instance ClosedSubmodule.innerProductSpace (W : ClosedSubmodule 𝕜 E) : InnerProductSpace 𝕜 W :=
   fast_instance% W.toSubmodule.innerProductSpace
 
 /-- The inner product on closed submodules is the same as on the ambient space. -/
 @[simp]
-theorem ClosedSubmodule.coe_inner (W : Submodule 𝕜 E) (x y : W) : ⟪x, y⟫ = ⟪(x : E), ↑y⟫ :=
+theorem ClosedSubmodule.coe_inner (W : Submodule 𝕜 E) (x y : W) : ⟪x, y⟫_𝕜 = ⟪(x : E), y⟫_𝕜 :=
   rfl
 
 end ClosedSubmodule

--- a/Mathlib/Analysis/InnerProductSpace/Subspace.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Subspace.lean
@@ -53,6 +53,23 @@ theorem orthonormal_span {ι : Type*} {v : ι → E} (hv : Orthonormal 𝕜 v) :
 
 end Submodule
 
+section ClosedSubmodule
+
+variable [SeminormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
+
+/-- Induced inner product on a closed submodule. -/
+instance ClosedSubmodule.innerProductSpace (W : ClosedSubmodule 𝕜 E) : InnerProductSpace 𝕜 W :=
+  fast_instance% W.toSubmodule.innerProductSpace
+
+/-- The inner product on closed submodules is the same as on the ambient space. -/
+@[simp]
+theorem ClosedSubmodule.coe_inner (W : Submodule 𝕜 E) (x y : W) : ⟪x, y⟫ = ⟪(x : E), ↑y⟫ :=
+  rfl
+
+end ClosedSubmodule
+
 /-! ### Families of mutually-orthogonal subspaces of an inner product space -/
 
 section OrthogonalFamily_Seminormed

--- a/Mathlib/Analysis/Normed/Group/Submodule.lean
+++ b/Mathlib/Analysis/Normed/Group/Submodule.lean
@@ -25,16 +25,14 @@ instance seminormedAddCommGroup [Ring 𝕜] [SeminormedAddCommGroup E] [Module �
 
 /-- If `x` is an element of a submodule `s` of a normed group `E`, its norm in `s` is equal to its
 norm in `E`. -/
-@[simp, push_cast]
+@[deprecated "use `norm_coe`" (since := "2026-08-25")]
 theorem coe_norm [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
     (x : s) : ‖x‖ = ‖(x : E)‖ :=
   rfl
 
 /-- If `x` is an element of a submodule `s` of a normed group `E`, its norm in `E` is equal to its
-norm in `s`.
-
-This is a reversed version of the `simp` lemma `Submodule.coe_norm` for use by `norm_cast`. -/
-@[deprecated "use `coe_norm`" (since := "2026-08-25")]
+norm in `s`. -/
+@[simp ←, norm_cast]
 theorem norm_coe [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
     (x : s) : ‖(x : E)‖ = ‖x‖ :=
   rfl
@@ -57,9 +55,9 @@ instance seminormedAddCommGroup [Ring 𝕜] [SeminormedAddCommGroup E] [Module �
 
 /-- If `x` is an element of a closed submodule `s` of a normed group `E`, its norm in `s` is equal
 to its norm in `E`. -/
-@[simp, push_cast]
-theorem coe_norm [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
-    (x : s) : ‖x‖ = ‖(x : E)‖ :=
+@[simp ←, norm_cast]
+theorem norm_coe [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
+    (x : s) : ‖(x : E)‖ = ‖x‖ :=
   rfl
 
 /-- A closed submodule of a normed group is also a normed group, with the restriction of the norm.

--- a/Mathlib/Analysis/Normed/Group/Submodule.lean
+++ b/Mathlib/Analysis/Normed/Group/Submodule.lean
@@ -56,7 +56,7 @@ instance seminormedAddCommGroup [Ring 𝕜] [SeminormedAddCommGroup E] [Module �
 /-- If `x` is an element of a closed submodule `s` of a normed group `E`, its norm in `s` is equal
 to its norm in `E`. -/
 @[simp ←, norm_cast]
-theorem norm_coe [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
+theorem norm_coe [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : ClosedSubmodule 𝕜 E}
     (x : s) : ‖(x : E)‖ = ‖x‖ :=
   rfl
 

--- a/Mathlib/Analysis/Normed/Group/Submodule.lean
+++ b/Mathlib/Analysis/Normed/Group/Submodule.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Module.Submodule.LinearMap
 public import Mathlib.Analysis.Normed.Group.Basic
+public import Mathlib.Topology.Algebra.Module.ClosedSubmodule
 
 /-! # Submodules of normed groups -/
 
@@ -45,6 +46,38 @@ instance normedAddCommGroup [Ring 𝕜] [NormedAddCommGroup E] [Module 𝕜 E]
     eq_of_dist_eq_zero := eq_of_dist_eq_zero }
 
 end Submodule
+
+namespace ClosedSubmodule
+
+/-- A closed submodule of a seminormed group is also a seminormed group, with the restriction of the
+norm. -/
+instance seminormedAddCommGroup [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E]
+    (s : ClosedSubmodule 𝕜 E) : SeminormedAddCommGroup s :=
+  fast_instance% s.toSubmodule.seminormedAddCommGroup
+
+/-- If `x` is an element of a closed submodule `s` of a normed group `E`, its norm in `s` is equal
+to its norm in `E`. -/
+@[simp]
+theorem coe_norm [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
+    (x : s) : ‖x‖ = ‖(x : E)‖ :=
+  rfl
+
+/-- If `x` is an element of a closed submodule `s` of a normed group `E`, its norm in `E` is equal
+to its norm in `s`.
+
+This is a reversed version of the `simp` lemma `ClosedSubmodule.coe_norm` for use by `norm_cast`. -/
+@[norm_cast]
+theorem norm_coe [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
+    (x : s) : ‖(x : E)‖ = ‖x‖ :=
+  rfl
+
+/-- A closed submodule of a normed group is also a normed group, with the restriction of the norm.
+-/
+instance normedAddCommGroup [Ring 𝕜] [NormedAddCommGroup E] [Module 𝕜 E]
+    (s : ClosedSubmodule 𝕜 E) : NormedAddCommGroup s :=
+  fast_instance% s.toSubmodule.normedAddCommGroup
+
+end ClosedSubmodule
 
 @[continuity, fun_prop]
 theorem LinearMap.continuous_domRestrict {R R' M M' : Type*} [Semiring R] [Semiring R']

--- a/Mathlib/Analysis/Normed/Group/Submodule.lean
+++ b/Mathlib/Analysis/Normed/Group/Submodule.lean
@@ -25,7 +25,7 @@ instance seminormedAddCommGroup [Ring 𝕜] [SeminormedAddCommGroup E] [Module �
 
 /-- If `x` is an element of a submodule `s` of a normed group `E`, its norm in `s` is equal to its
 norm in `E`. -/
-@[simp]
+@[simp, push_cast]
 theorem coe_norm [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
     (x : s) : ‖x‖ = ‖(x : E)‖ :=
   rfl
@@ -34,7 +34,7 @@ theorem coe_norm [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Sub
 norm in `s`.
 
 This is a reversed version of the `simp` lemma `Submodule.coe_norm` for use by `norm_cast`. -/
-@[norm_cast]
+@[deprecated "use `coe_norm`" (since := "2026-08-25")]
 theorem norm_coe [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
     (x : s) : ‖(x : E)‖ = ‖x‖ :=
   rfl
@@ -57,18 +57,9 @@ instance seminormedAddCommGroup [Ring 𝕜] [SeminormedAddCommGroup E] [Module �
 
 /-- If `x` is an element of a closed submodule `s` of a normed group `E`, its norm in `s` is equal
 to its norm in `E`. -/
-@[simp]
+@[simp, push_cast]
 theorem coe_norm [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
     (x : s) : ‖x‖ = ‖(x : E)‖ :=
-  rfl
-
-/-- If `x` is an element of a closed submodule `s` of a normed group `E`, its norm in `E` is equal
-to its norm in `s`.
-
-This is a reversed version of the `simp` lemma `ClosedSubmodule.coe_norm` for use by `norm_cast`. -/
-@[norm_cast]
-theorem norm_coe [Ring 𝕜] [SeminormedAddCommGroup E] [Module 𝕜 E] {s : Submodule 𝕜 E}
-    (x : s) : ‖(x : E)‖ = ‖x‖ :=
   rfl
 
 /-- A closed submodule of a normed group is also a normed group, with the restriction of the norm.

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -170,6 +170,12 @@ instance Submodule.normedSpace {𝕜 R : Type*} [SMul 𝕜 R] [NormedField 𝕜]
     (s : Submodule R E) : NormedSpace 𝕜 s where
   norm_smul_le c x := norm_smul_le c (x : E)
 
+/-- A subspace of a normed space is also a normed space, with the restriction of the norm. -/
+instance ClosedSubmodule.normedSpace {𝕜 R : Type*} [SMul 𝕜 R] [NormedField 𝕜] [Ring R] {E : Type*}
+    [SeminormedAddCommGroup E] [NormedSpace 𝕜 E] [Module R E] [IsScalarTower 𝕜 R E]
+    (s : ClosedSubmodule R E) : NormedSpace 𝕜 s where
+  norm_smul_le c x := norm_smul_le c (x : E)
+
 variable {S 𝕜 R E : Type*} [SMul 𝕜 R] [NormedField 𝕜] [Ring R] [SeminormedAddCommGroup E]
 variable [NormedSpace 𝕜 E] [Module R E] [IsScalarTower 𝕜 R E] [SetLike S E] [AddSubgroupClass S E]
 variable [SMulMemClass S R E] (s : S)

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -164,13 +164,14 @@ instance SeparationQuotient.instNormedSpace : NormedSpace 𝕜 (SeparationQuotie
 instance MulOpposite.instNormedSpace : NormedSpace 𝕜 Eᵐᵒᵖ where
   norm_smul_le _ x := norm_smul_le _ x.unop
 
-/-- A subspace of a normed space is also a normed space, with the restriction of the norm. -/
+/-- A subspace of a normed space is also a normed space (with respect to the restricted norm). -/
 instance Submodule.normedSpace {𝕜 R : Type*} [SMul 𝕜 R] [NormedField 𝕜] [Ring R] {E : Type*}
     [SeminormedAddCommGroup E] [NormedSpace 𝕜 E] [Module R E] [IsScalarTower 𝕜 R E]
     (s : Submodule R E) : NormedSpace 𝕜 s where
   norm_smul_le c x := norm_smul_le c (x : E)
 
-/-- A subspace of a normed space is also a normed space, with the restriction of the norm. -/
+/-- A closed subspace of a normed space is also a normed space (with respect to the restricted
+norm). -/
 instance ClosedSubmodule.normedSpace {𝕜 R : Type*} [SMul 𝕜 R] [NormedField 𝕜] [Ring R] {E : Type*}
     [SeminormedAddCommGroup E] [NormedSpace 𝕜 E] [Module R E] [IsScalarTower 𝕜 R E]
     (s : ClosedSubmodule R E) : NormedSpace 𝕜 s where

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -201,7 +201,7 @@ theorem continuous_stereoInvFun (hv : ‖v‖ = 1) : Continuous (stereoInvFun hv
     ((contDiff_stereoInvFunAux (m := 0)).continuous.comp continuous_subtype_val)
 
 open scoped InnerProductSpace in
-attribute [-simp] AddSubgroupClass.coe_norm Submodule.coe_norm in
+attribute [-simp] AddSubgroupClass.coe_norm in
 theorem stereo_left_inv (hv : ‖v‖ = 1) {x : sphere (0 : E) 1} (hx : (x : E) ≠ v) :
     stereoInvFun hv (stereoToFun v x) = x := by
   ext
@@ -378,7 +378,7 @@ theorem stereographic'_symm_apply {n : ℕ} [Fact (finrank ℝ E = n + 1)] (v : 
         (OrthonormalBasis.fromOrthogonalSpanSingleton n (ne_zero_of_mem_unit_sphere v)).repr
       (‖(U.symm x : E)‖ ^ 2 + 4)⁻¹ • (4 : ℝ) • (U.symm x : E) +
         (‖(U.symm x : E)‖ ^ 2 + 4)⁻¹ • (‖(U.symm x : E)‖ ^ 2 - 4) • v.val := by
-  simp [stereographic, stereographic', ← Submodule.coe_norm]
+  simp [stereographic, stereographic', Submodule.norm_coe]
 
 /-! ### Analytic manifold structure on the sphere -/
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
