### PR TITLE
feat(Combinatorics/SimpleGraph): `IsSubwalk` is a partial order and more relation properties

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -112,6 +112,12 @@ def SimpleGraph.mk' {V : Type u} :
     funext v w
     simpa [Bool.coe_iff_coe] using congr_fun₂ h v w
 
+instance {V : Type*} (G : SimpleGraph V) : Std.Symm G.Adj :=
+  G.symm
+
+instance {V : Type*} (G : SimpleGraph V) : Std.Irrefl G.Adj :=
+  G.loopless
+
 /-- We can enumerate simple graphs by enumerating all functions `V → V → Bool`
 and filtering on whether they are symmetric and irreflexive. -/
 instance {V : Type u} [Fintype V] [DecidableEq V] : Fintype (SimpleGraph V) where

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -161,8 +161,14 @@ lemma Reachable.mem_subgraphVerts {u v} {H : G.Subgraph} (hr : G.Reachable u v)
 
 variable (G)
 
+instance : IsEquiv V G.Reachable where
+  refl := .refl
+  symm _ _ := .symm
+  trans _ _ _ := .trans
+
+@[deprecated instIsEquivReachable (since := "2026-08-25")]
 theorem reachable_is_equivalence : Equivalence G.Reachable :=
-  Equivalence.mk (@Reachable.refl _ G) (@Reachable.symm _ G) (@Reachable.trans _ G)
+  .of_isEquiv G.Reachable
 
 /-- Distinct vertices are not reachable in the empty graph. -/
 @[simp]
@@ -222,7 +228,7 @@ lemma not_reachable_of_right_degree_zero {G : SimpleGraph V} {u v : V} [Fintype 
 
 /-- The equivalence relation on vertices given by `SimpleGraph.Reachable`. -/
 @[instance_reducible]
-def reachableSetoid : Setoid V := Setoid.mk _ G.reachable_is_equivalence
+def reachableSetoid : Setoid V := Setoid.mk _ <| .of_isEquiv G.Reachable
 
 /-- A graph is preconnected if every pair of vertices is reachable from one another. -/
 def Preconnected : Prop := ∀ u v : V, G.Reachable u v

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -166,7 +166,7 @@ instance : IsEquiv V G.Reachable where
   symm _ _ := .symm
   trans _ _ _ := .trans
 
-@[deprecated instIsEquivReachable (since := "2026-08-25")]
+@[deprecated Equivalence.of_isEquiv (since := "2026-09-09")]
 theorem reachable_is_equivalence : Equivalence G.Reachable :=
   .of_isEquiv G.Reachable
 

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -98,7 +98,10 @@ namespace Subgraph
 
 variable {G : SimpleGraph V} {G₁ G₂ : G.Subgraph} {a b : V}
 
-protected theorem loopless (G' : Subgraph G) : Std.Irrefl G'.Adj where
+instance (G' : Subgraph G) : Std.Symm G'.Adj :=
+  G'.symm
+
+protected instance loopless (G' : Subgraph G) : Std.Irrefl G'.Adj where
   irrefl _ hadj := G.irrefl <| G'.adj_sub hadj
 
 theorem adj_comm (G' : Subgraph G) (v w : V) : G'.Adj v w ↔ G'.Adj w v :=

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Subwalks.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Subwalks.lean
@@ -179,6 +179,11 @@ lemma isSubwalk_antisymm {u v} {p₁ p₂ : G.Walk u v} (h₁ : p₁.IsSubwalk p
   rw [isSubwalk_iff_support_isInfix] at h₁ h₂
   exact ext_support <| List.infix_antisymm h₁ h₂
 
+instance : IsPartialOrder (G.Walk u v) IsSubwalk where
+  refl := isSubwalk_rfl
+  trans _ _ _ := .trans
+  antisymm _ _ := isSubwalk_antisymm
+
 @[simp]
 theorem IsSubwalk.support_subset {u v u' v' : V} {p₁ : G.Walk u v} {p₂ : G.Walk u' v'}
     (h : p₂.IsSubwalk p₁) : p₂.support ⊆ p₁.support :=


### PR DESCRIPTION
---
The instances for `Symm` and `Irrefl` let us use `symm`/`irrefl` and any other mathlib theorems that expect these properties as typeclass arguments.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
