### PR TITLE
[Merged by Bors] - chore(Order/ConditionallyCompleteLattice/Basic): use `to_dual` for `WellFoundedLT` theorems

### DIFF
--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -445,19 +445,24 @@ open Function
 
 variable [WellFoundedLT α]
 
+@[to_dual]
 theorem sInf_eq_argmin_on (hs : s.Nonempty) : sInf s = argminOn id s hs :=
   IsLeast.csInf_eq ⟨argminOn_mem _ _ _, fun _ ha => argminOn_le id _ ha⟩
 
+@[to_dual]
 theorem isLeast_csInf (hs : s.Nonempty) : IsLeast s (sInf s) := by
   rw [sInf_eq_argmin_on hs]
   exact ⟨argminOn_mem _ _ _, fun a ha => argminOn_le id _ ha⟩
 
-theorem le_csInf_iff' (hs : s.Nonempty) : b ≤ sInf s ↔ b ∈ lowerBounds s :=
+@[to_dual csSup_le_iff_of_wellFoundedGT]
+theorem le_csInf_iff_of_wellFoundedLT (hs : s.Nonempty) : b ≤ sInf s ↔ b ∈ lowerBounds s :=
   le_isGLB_iff (isLeast_csInf hs).isGLB
 
+@[to_dual]
 theorem csInf_mem (hs : s.Nonempty) : sInf s ∈ s :=
   (isLeast_csInf hs).1
 
+@[to_dual]
 lemma csInf_eq_iff (hs : s.Nonempty) (n : α) :
      sInf s = n ↔ n ∈ s ∧ ∀ a ∈ s, n ≤ a := by
   have : OrderBot α := WellFoundedLT.toOrderBot α
@@ -467,10 +472,12 @@ lemma csInf_eq_iff (hs : s.Nonempty) (n : α) :
   · intro ⟨hn, hle⟩
     exact le_antisymm (csInf_le (OrderBot.bddBelow s) hn) (le_csInf hs hle)
 
+@[to_dual]
 theorem MonotoneOn.map_csInf {β : Type*} [ConditionallyCompleteLattice β] {f : α → β}
     (hf : MonotoneOn f s) (hs : s.Nonempty) : f (sInf s) = sInf (f '' s) :=
   (hf.map_isLeast (isLeast_csInf hs)).csInf_eq.symm
 
+@[to_dual]
 theorem Monotone.map_csInf {β : Type*} [ConditionallyCompleteLattice β] {f : α → β}
     (hf : Monotone f) (hs : s.Nonempty) : f (sInf s) = sInf (f '' s) :=
   (hf.map_isLeast (isLeast_csInf hs)).csInf_eq.symm
@@ -518,9 +525,11 @@ theorem le_csSup_iff' {s : Set α} {a : α} (h : BddAbove s) :
     a ≤ sSup s ↔ ∀ b, b ∈ upperBounds s → a ≤ b :=
   ⟨fun h _ hb => le_trans h (csSup_le' hb), fun hb => hb _ fun _ => le_csSup h⟩
 
-theorem le_csInf_iff'' {s : Set α} {a : α} (ne : s.Nonempty) :
+theorem le_csInf_iff' {s : Set α} {a : α} (ne : s.Nonempty) :
     a ≤ sInf s ↔ ∀ b : α, b ∈ s → a ≤ b :=
   le_csInf_iff (OrderBot.bddBelow _) ne
+
+@[deprecated (since := "2026-08-25")] alias le_csInf_iff'' := le_csInf_iff'
 
 theorem csInf_le' (h : a ∈ s) : sInf s ≤ a := csInf_le (OrderBot.bddBelow _) h
 


### PR DESCRIPTION
The double primed `le_csInf_iff''` lemma for `ConditionallyCompleteLinearOrderBot` took the place of the single primed `le_csInf_iff'` which was previously a `WellFoundedLT` lemma.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
