### PR TITLE
chore(Algebra/Order/Hom/Basic): split file by imports

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1028,10 +1028,12 @@ public import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Defs
 public import Mathlib.Algebra.Order.GroupWithZero.Unbundled.OrderIso
 public import Mathlib.Algebra.Order.GroupWithZero.WithZero
 public import Mathlib.Algebra.Order.Hom.Basic
+public import Mathlib.Algebra.Order.Hom.GroupNormClass
 public import Mathlib.Algebra.Order.Hom.Lattice
 public import Mathlib.Algebra.Order.Hom.Monoid
 public import Mathlib.Algebra.Order.Hom.MonoidWithZero
 public import Mathlib.Algebra.Order.Hom.Ring
+public import Mathlib.Algebra.Order.Hom.RingNormClass
 public import Mathlib.Algebra.Order.Hom.Submonoid
 public import Mathlib.Algebra.Order.Hom.TypeTags
 public import Mathlib.Algebra.Order.Hom.Units

--- a/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Algebra.GroupWithZero.Regular
 public import Mathlib.Algebra.GroupWithZero.Units.Lemmas
-public import Mathlib.Algebra.Order.Hom.Basic
+public import Mathlib.Algebra.Order.Hom.RingNormClass
 public import Mathlib.Algebra.Order.Ring.Abs
 public import Mathlib.Tactic.Positivity.Core
 

--- a/Mathlib/Algebra/Order/Hom/Basic.lean
+++ b/Mathlib/Algebra/Order/Hom/Basic.lean
@@ -5,9 +5,9 @@ Authors: Yaël Dillies
 -/
 module
 
-public import Mathlib.Algebra.GroupWithZero.Hom
-public import Mathlib.Algebra.Order.Group.Abs
-public import Mathlib.Algebra.Ring.Defs
+public import Mathlib.Algebra.Group.Basic
+public import Mathlib.Algebra.Group.Hom.Defs
+public import Mathlib.Order.Lattice
 
 /-!
 # Algebraic order homomorphism classes
@@ -23,19 +23,6 @@ Basic typeclasses
 * `MulLEAddHomClass`: `∀ f a b, f (a * b) ≤ f a + f b`
 * `NonarchimedeanHomClass`: `∀ a b, f (a + b) ≤ max (f a) (f b)`
 
-Group norms
-* `AddGroupSeminormClass`: Homs are nonnegative, subadditive, even and preserve zero.
-* `GroupSeminormClass`: Homs are nonnegative, respect `f (a * b) ≤ f a + f b`, `f a⁻¹ = f a` and
-  preserve zero.
-* `AddGroupNormClass`: Homs are seminorms such that `f x = 0 → x = 0` for all `x`.
-* `GroupNormClass`: Homs are seminorms such that `f x = 0 → x = 1` for all `x`.
-
-Ring norms
-* `RingSeminormClass`: Homs are submultiplicative group norms.
-* `RingNormClass`: Homs are ring seminorms that are also additive group norms.
-* `MulRingSeminormClass`: Homs are ring seminorms that are multiplicative.
-* `MulRingNormClass`: Homs are ring norms that are multiplicative.
-
 ## Notes
 
 Typeclasses for seminorms are defined here while types of seminorms are defined in
@@ -49,7 +36,7 @@ Finitary versions of the current lemmas.
 
 public section
 
-assert_not_exists Field
+assert_not_exists Ring
 
 library_note «out-param inheritance» /--
 Diamond inheritance cannot depend on `outParam`s in the following circumstances:
@@ -147,182 +134,3 @@ theorem le_map_div_mul_map_div [Group α] [Mul β] [LE β] [SubmultiplicativeHom
 theorem le_map_div_add_map_div [Group α] [Add β] [LE β] [MulLEAddHomClass F α β]
     (f : F) (a b c : α) : f (a / c) ≤ f (a / b) + f (b / c) := by
     simpa only [div_mul_div_cancel] using map_mul_le_add f (a / b) (b / c)
-
-/-! ### Group (semi)norms -/
-
-
-/-- `AddGroupSeminormClass F α` states that `F` is a type of `β`-valued seminorms on the additive
-group `α`.
-
-You should extend this class when you extend `AddGroupSeminorm`. -/
-class AddGroupSeminormClass (F : Type*) (α β : outParam Type*)
-    [AddGroup α] [AddCommMonoid β] [PartialOrder β] [FunLike F α β] : Prop
-  extends SubadditiveHomClass F α β where
-  /-- The image of zero is zero. -/
-  map_zero (f : F) : f 0 = 0
-  /-- The map is invariant under negation of its argument. -/
-  map_neg_eq_map (f : F) (a : α) : f (-a) = f a
-
-/-- `GroupSeminormClass F α` states that `F` is a type of `β`-valued seminorms on the group `α`.
-
-You should extend this class when you extend `GroupSeminorm`. -/
-@[to_additive]
-class GroupSeminormClass (F : Type*) (α β : outParam Type*)
-    [Group α] [AddCommMonoid β] [PartialOrder β] [FunLike F α β] : Prop
-  extends MulLEAddHomClass F α β where
-  /-- The image of one is zero. -/
-  map_one_eq_zero (f : F) : f 1 = 0
-  /-- The map is invariant under inversion of its argument. -/
-  map_inv_eq_map (f : F) (a : α) : f a⁻¹ = f a
-
-/-- `AddGroupNormClass F α` states that `F` is a type of `β`-valued norms on the additive group
-`α`.
-
-You should extend this class when you extend `AddGroupNorm`. -/
-class AddGroupNormClass (F : Type*) (α β : outParam Type*)
-    [AddGroup α] [AddCommMonoid β] [PartialOrder β] [FunLike F α β] : Prop
-  extends AddGroupSeminormClass F α β where
-  /-- The argument is zero if its image under the map is zero. -/
-  eq_zero_of_map_eq_zero (f : F) {a : α} : f a = 0 → a = 0
-
-/-- `GroupNormClass F α` states that `F` is a type of `β`-valued norms on the group `α`.
-
-You should extend this class when you extend `GroupNorm`. -/
-@[to_additive]
-class GroupNormClass (F : Type*) (α β : outParam Type*)
-    [Group α] [AddCommMonoid β] [PartialOrder β] [FunLike F α β] : Prop
-  extends GroupSeminormClass F α β where
-  /-- The argument is one if its image under the map is zero. -/
-  eq_one_of_map_eq_zero (f : F) {a : α} : f a = 0 → a = 1
-
-export AddGroupSeminormClass (map_neg_eq_map)
-
-export GroupSeminormClass (map_one_eq_zero map_inv_eq_map)
-
-export AddGroupNormClass (eq_zero_of_map_eq_zero)
-
-export GroupNormClass (eq_one_of_map_eq_zero)
-
-attribute [simp] map_one_eq_zero map_neg_eq_map map_inv_eq_map
-
--- See note [lower instance priority]
-instance (priority := 100) AddGroupSeminormClass.toZeroHomClass [AddGroup α]
-    [AddCommMonoid β] [PartialOrder β] [AddGroupSeminormClass F α β] : ZeroHomClass F α β :=
-  { ‹AddGroupSeminormClass F α β› with }
-
-section GroupSeminormClass
-
-variable [Group α] [AddCommMonoid β] [PartialOrder β] [GroupSeminormClass F α β] (f : F) (x y : α)
-
-@[to_additive]
-theorem map_div_le_add : f (x / y) ≤ f x + f y := by
-  rw [div_eq_mul_inv, ← map_inv_eq_map f y]
-  exact map_mul_le_add _ _ _
-
-@[to_additive]
-theorem map_div_rev : f (x / y) = f (y / x) := by rw [← inv_div, map_inv_eq_map]
-
-@[to_additive]
-theorem map_inv_mul {α : Type*} [FunLike F α β] [CommGroup α] [GroupSeminormClass F α β] (x y : α) :
-    f (x⁻¹ * y) = f (x * y⁻¹) := by
-  rw [← map_inv_eq_map, inv_mul', inv_inv, div_eq_mul_inv]
-
-@[to_additive]
-theorem le_map_add_map_div' : f x ≤ f y + f (y / x) := by
-  simpa only [add_comm, map_div_rev, div_mul_cancel] using map_mul_le_add f (x / y) y
-
-end GroupSeminormClass
-
-@[to_additive]
-theorem abs_sub_map_le_div [Group α] [AddCommGroup β] [LinearOrder β] [IsOrderedAddMonoid β]
-    [GroupSeminormClass F α β]
-    (f : F) (x y : α) : |f x - f y| ≤ f (x / y) := by
-  rw [abs_sub_le_iff, sub_le_iff_le_add', sub_le_iff_le_add']
-  exact ⟨le_map_add_map_div _ _ _, le_map_add_map_div' _ _ _⟩
-
--- See note [lower instance priority]
-@[to_additive]
-instance (priority := 100) GroupSeminormClass.toNonnegHomClass [Group α]
-    [AddCommMonoid β] [LinearOrder β] [IsOrderedAddMonoid β] [GroupSeminormClass F α β] :
-    NonnegHomClass F α β :=
-  { ‹GroupSeminormClass F α β› with
-    apply_nonneg := fun f a =>
-      (nsmul_nonneg_iff two_ne_zero).1 <| by
-        rw [two_nsmul, ← map_one_eq_zero f, ← div_self' a]
-        exact map_div_le_add _ _ _ }
-
-section GroupNormClass
-
-variable [Group α] [AddCommMonoid β] [PartialOrder β] [GroupNormClass F α β] (f : F) {x : α}
-
-@[to_additive]
-theorem map_eq_zero_iff_eq_one : f x = 0 ↔ x = 1 :=
-  ⟨eq_one_of_map_eq_zero _, by
-    rintro rfl
-    exact map_one_eq_zero _⟩
-
-@[to_additive]
-theorem map_ne_zero_iff_ne_one : f x ≠ 0 ↔ x ≠ 1 :=
-  (map_eq_zero_iff_eq_one _).not
-
-end GroupNormClass
-
-@[to_additive]
-theorem map_pos_of_ne_one [Group α] [AddCommMonoid β] [LinearOrder β] [IsOrderedAddMonoid β]
-    [GroupNormClass F α β] (f : F)
-    {x : α} (hx : x ≠ 1) : 0 < f x :=
-  (apply_nonneg _ _).lt_of_ne <| ((map_ne_zero_iff_ne_one _).2 hx).symm
-
-/-! ### Ring (semi)norms -/
-
-
-/-- `RingSeminormClass F α` states that `F` is a type of `β`-valued seminorms on the ring `α`.
-
-You should extend this class when you extend `RingSeminorm`. -/
-class RingSeminormClass (F : Type*) (α β : outParam Type*)
-    [NonUnitalNonAssocRing α] [Semiring β] [PartialOrder β] [FunLike F α β] : Prop
-  extends AddGroupSeminormClass F α β, SubmultiplicativeHomClass F α β
-
-/-- `RingNormClass F α` states that `F` is a type of `β`-valued norms on the ring `α`.
-
-You should extend this class when you extend `RingNorm`. -/
-class RingNormClass (F : Type*) (α β : outParam Type*)
-    [NonUnitalNonAssocRing α] [Semiring β] [PartialOrder β] [FunLike F α β] : Prop
-  extends RingSeminormClass F α β, AddGroupNormClass F α β
-
-/-- `MulRingSeminormClass F α` states that `F` is a type of `β`-valued multiplicative seminorms
-on the ring `α`.
-
-You should extend this class when you extend `MulRingSeminorm`. -/
-class MulRingSeminormClass (F : Type*) (α β : outParam Type*)
-    [NonAssocRing α] [Semiring β] [PartialOrder β] [FunLike F α β] : Prop
-  extends AddGroupSeminormClass F α β, MonoidWithZeroHomClass F α β
-
--- Lower the priority of these instances since they require synthesizing an order structure.
-attribute [instance 50]
-  MulRingSeminormClass.toMonoidHomClass MulRingSeminormClass.toMonoidWithZeroHomClass
-
-/-- `MulRingNormClass F α` states that `F` is a type of `β`-valued multiplicative norms on the
-ring `α`.
-
-You should extend this class when you extend `MulRingNorm`. -/
-class MulRingNormClass (F : Type*) (α β : outParam Type*)
-    [NonAssocRing α] [Semiring β] [PartialOrder β] [FunLike F α β] : Prop
-  extends MulRingSeminormClass F α β, AddGroupNormClass F α β
-
--- See note [out-param inheritance]
--- See note [lower instance priority]
-instance (priority := 100) RingSeminormClass.toNonnegHomClass [NonUnitalNonAssocRing α]
-    [Semiring β] [LinearOrder β] [IsOrderedAddMonoid β] [RingSeminormClass F α β] :
-    NonnegHomClass F α β :=
-  AddGroupSeminormClass.toNonnegHomClass
-
--- See note [lower instance priority]
-instance (priority := 100) MulRingSeminormClass.toRingSeminormClass [NonAssocRing α]
-    [Semiring β] [PartialOrder β] [MulRingSeminormClass F α β] : RingSeminormClass F α β :=
-  { ‹MulRingSeminormClass F α β› with map_mul_le_mul := fun _ _ _ => (map_mul _ _ _).le }
-
--- See note [lower instance priority]
-instance (priority := 100) MulRingNormClass.toRingNormClass [NonAssocRing α]
-    [Semiring β] [PartialOrder β] [MulRingNormClass F α β] : RingNormClass F α β :=
-  { ‹MulRingNormClass F α β›, MulRingSeminormClass.toRingSeminormClass with }

--- a/Mathlib/Algebra/Order/Hom/GroupNormClass.lean
+++ b/Mathlib/Algebra/Order/Hom/GroupNormClass.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+module
+
+public import Mathlib.Algebra.Order.Group.Abs
+public import Mathlib.Algebra.Order.Hom.Basic
+
+/-!
+# Algebraic order homomorphism classes
+
+This file defines hom classes for common properties at the intersection of order theory and algebra.
+
+## Typeclasses
+
+Group norms
+* `AddGroupSeminormClass`: Homs are nonnegative, subadditive, even and preserve zero.
+* `GroupSeminormClass`: Homs are nonnegative, respect `f (a * b) ≤ f a + f b`, `f a⁻¹ = f a` and
+  preserve zero.
+* `AddGroupNormClass`: Homs are seminorms such that `f x = 0 → x = 0` for all `x`.
+* `GroupNormClass`: Homs are seminorms such that `f x = 0 → x = 1` for all `x`.
+
+## Notes
+
+Typeclasses for seminorms are defined here while types of seminorms are defined in
+`Analysis.Normed.Group.Seminorm` and `Analysis.Normed.Ring.Seminorm` because absolute values are
+multiplicative ring norms but outside of this use we only consider real-valued seminorms.
+
+## TODO
+
+Finitary versions of the current lemmas.
+-/
+
+public section
+
+assert_not_exists Ring
+
+variable {F α β : Type*} [FunLike F α β]
+
+/-! ### Group (semi)norms -/
+
+/-- `AddGroupSeminormClass F α` states that `F` is a type of `β`-valued seminorms on the additive
+group `α`.
+
+You should extend this class when you extend `AddGroupSeminorm`. -/
+class AddGroupSeminormClass (F : Type*) (α β : outParam Type*)
+    [AddGroup α] [AddCommMonoid β] [PartialOrder β] [FunLike F α β] : Prop
+  extends SubadditiveHomClass F α β where
+  /-- The image of zero is zero. -/
+  map_zero (f : F) : f 0 = 0
+  /-- The map is invariant under negation of its argument. -/
+  map_neg_eq_map (f : F) (a : α) : f (-a) = f a
+
+/-- `GroupSeminormClass F α` states that `F` is a type of `β`-valued seminorms on the group `α`.
+
+You should extend this class when you extend `GroupSeminorm`. -/
+@[to_additive]
+class GroupSeminormClass (F : Type*) (α β : outParam Type*)
+    [Group α] [AddCommMonoid β] [PartialOrder β] [FunLike F α β] : Prop
+  extends MulLEAddHomClass F α β where
+  /-- The image of one is zero. -/
+  map_one_eq_zero (f : F) : f 1 = 0
+  /-- The map is invariant under inversion of its argument. -/
+  map_inv_eq_map (f : F) (a : α) : f a⁻¹ = f a
+
+/-- `AddGroupNormClass F α` states that `F` is a type of `β`-valued norms on the additive group
+`α`.
+
+You should extend this class when you extend `AddGroupNorm`. -/
+class AddGroupNormClass (F : Type*) (α β : outParam Type*)
+    [AddGroup α] [AddCommMonoid β] [PartialOrder β] [FunLike F α β] : Prop
+  extends AddGroupSeminormClass F α β where
+  /-- The argument is zero if its image under the map is zero. -/
+  eq_zero_of_map_eq_zero (f : F) {a : α} : f a = 0 → a = 0
+
+/-- `GroupNormClass F α` states that `F` is a type of `β`-valued norms on the group `α`.
+
+You should extend this class when you extend `GroupNorm`. -/
+@[to_additive]
+class GroupNormClass (F : Type*) (α β : outParam Type*)
+    [Group α] [AddCommMonoid β] [PartialOrder β] [FunLike F α β] : Prop
+  extends GroupSeminormClass F α β where
+  /-- The argument is one if its image under the map is zero. -/
+  eq_one_of_map_eq_zero (f : F) {a : α} : f a = 0 → a = 1
+
+export AddGroupSeminormClass (map_neg_eq_map)
+
+export GroupSeminormClass (map_one_eq_zero map_inv_eq_map)
+
+export AddGroupNormClass (eq_zero_of_map_eq_zero)
+
+export GroupNormClass (eq_one_of_map_eq_zero)
+
+attribute [simp] map_one_eq_zero map_neg_eq_map map_inv_eq_map
+
+-- See note [lower instance priority]
+instance (priority := 100) AddGroupSeminormClass.toZeroHomClass [AddGroup α]
+    [AddCommMonoid β] [PartialOrder β] [AddGroupSeminormClass F α β] : ZeroHomClass F α β :=
+  { ‹AddGroupSeminormClass F α β› with }
+
+section GroupSeminormClass
+
+variable [Group α] [AddCommMonoid β] [PartialOrder β] [GroupSeminormClass F α β] (f : F) (x y : α)
+
+@[to_additive]
+theorem map_div_le_add : f (x / y) ≤ f x + f y := by
+  rw [div_eq_mul_inv, ← map_inv_eq_map f y]
+  exact map_mul_le_add _ _ _
+
+@[to_additive]
+theorem map_div_rev : f (x / y) = f (y / x) := by rw [← inv_div, map_inv_eq_map]
+
+@[to_additive]
+theorem map_inv_mul {α : Type*} [FunLike F α β] [CommGroup α] [GroupSeminormClass F α β] (x y : α) :
+    f (x⁻¹ * y) = f (x * y⁻¹) := by
+  rw [← map_inv_eq_map, inv_mul', inv_inv, div_eq_mul_inv]
+
+@[to_additive]
+theorem le_map_add_map_div' : f x ≤ f y + f (y / x) := by
+  simpa only [add_comm, map_div_rev, div_mul_cancel] using map_mul_le_add f (x / y) y
+
+end GroupSeminormClass
+
+@[to_additive]
+theorem abs_sub_map_le_div [Group α] [AddCommGroup β] [LinearOrder β] [IsOrderedAddMonoid β]
+    [GroupSeminormClass F α β]
+    (f : F) (x y : α) : |f x - f y| ≤ f (x / y) := by
+  rw [abs_sub_le_iff, sub_le_iff_le_add', sub_le_iff_le_add']
+  exact ⟨le_map_add_map_div _ _ _, le_map_add_map_div' _ _ _⟩
+
+-- See note [lower instance priority]
+@[to_additive]
+instance (priority := 100) GroupSeminormClass.toNonnegHomClass [Group α]
+    [AddCommMonoid β] [LinearOrder β] [IsOrderedAddMonoid β] [GroupSeminormClass F α β] :
+    NonnegHomClass F α β :=
+  { ‹GroupSeminormClass F α β› with
+    apply_nonneg := fun f a =>
+      (nsmul_nonneg_iff (Nat.succ_ne_zero 1)).1 <| by
+        rw [two_nsmul, ← map_one_eq_zero f, ← div_self' a]
+        exact map_div_le_add _ _ _ }
+
+section GroupNormClass
+
+variable [Group α] [AddCommMonoid β] [PartialOrder β] [GroupNormClass F α β] (f : F) {x : α}
+
+@[to_additive]
+theorem map_eq_zero_iff_eq_one : f x = 0 ↔ x = 1 :=
+  ⟨eq_one_of_map_eq_zero _, by
+    rintro rfl
+    exact map_one_eq_zero _⟩
+
+@[to_additive]
+theorem map_ne_zero_iff_ne_one : f x ≠ 0 ↔ x ≠ 1 :=
+  (map_eq_zero_iff_eq_one _).not
+
+end GroupNormClass
+
+@[to_additive]
+theorem map_pos_of_ne_one [Group α] [AddCommMonoid β] [LinearOrder β] [IsOrderedAddMonoid β]
+    [GroupNormClass F α β] (f : F)
+    {x : α} (hx : x ≠ 1) : 0 < f x :=
+  (apply_nonneg _ _).lt_of_ne <| ((map_ne_zero_iff_ne_one _).2 hx).symm

--- a/Mathlib/Algebra/Order/Hom/RingNormClass.lean
+++ b/Mathlib/Algebra/Order/Hom/RingNormClass.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+module
+
+public import Mathlib.Algebra.GroupWithZero.Hom
+public import Mathlib.Algebra.Order.Hom.GroupNormClass
+public import Mathlib.Algebra.Ring.Defs
+
+
+/-!
+# Algebraic order homomorphism classes
+
+This file defines hom classes for common properties at the intersection of order theory and algebra.
+
+## Typeclasses
+
+Ring norms
+* `RingSeminormClass`: Homs are submultiplicative group norms.
+* `RingNormClass`: Homs are ring seminorms that are also additive group norms.
+* `MulRingSeminormClass`: Homs are ring seminorms that are multiplicative.
+* `MulRingNormClass`: Homs are ring norms that are multiplicative.
+
+## Notes
+
+Typeclasses for seminorms are defined here while types of seminorms are defined in
+`Analysis.Normed.Group.Seminorm` and `Analysis.Normed.Ring.Seminorm` because absolute values are
+multiplicative ring norms but outside of this use we only consider real-valued seminorms.
+
+## TODO
+
+Finitary versions of the current lemmas.
+-/
+
+public section
+
+assert_not_exists Field
+
+variable {F α β : Type*}
+
+variable [FunLike F α β]
+
+/-! ### Ring (semi)norms -/
+
+/-- `RingSeminormClass F α` states that `F` is a type of `β`-valued seminorms on the ring `α`.
+
+You should extend this class when you extend `RingSeminorm`. -/
+class RingSeminormClass (F : Type*) (α β : outParam Type*)
+    [NonUnitalNonAssocRing α] [Semiring β] [PartialOrder β] [FunLike F α β] : Prop
+  extends AddGroupSeminormClass F α β, SubmultiplicativeHomClass F α β
+
+/-- `RingNormClass F α` states that `F` is a type of `β`-valued norms on the ring `α`.
+
+You should extend this class when you extend `RingNorm`. -/
+class RingNormClass (F : Type*) (α β : outParam Type*)
+    [NonUnitalNonAssocRing α] [Semiring β] [PartialOrder β] [FunLike F α β] : Prop
+  extends RingSeminormClass F α β, AddGroupNormClass F α β
+
+/-- `MulRingSeminormClass F α` states that `F` is a type of `β`-valued multiplicative seminorms
+on the ring `α`.
+
+You should extend this class when you extend `MulRingSeminorm`. -/
+class MulRingSeminormClass (F : Type*) (α β : outParam Type*)
+    [NonAssocRing α] [Semiring β] [PartialOrder β] [FunLike F α β] : Prop
+  extends AddGroupSeminormClass F α β, MonoidWithZeroHomClass F α β
+
+-- Lower the priority of these instances since they require synthesizing an order structure.
+attribute [instance 50]
+  MulRingSeminormClass.toMonoidHomClass MulRingSeminormClass.toMonoidWithZeroHomClass
+
+/-- `MulRingNormClass F α` states that `F` is a type of `β`-valued multiplicative norms on the
+ring `α`.
+
+You should extend this class when you extend `MulRingNorm`. -/
+class MulRingNormClass (F : Type*) (α β : outParam Type*)
+    [NonAssocRing α] [Semiring β] [PartialOrder β] [FunLike F α β] : Prop
+  extends MulRingSeminormClass F α β, AddGroupNormClass F α β
+
+-- See note [out-param inheritance]
+-- See note [lower instance priority]
+instance (priority := 100) RingSeminormClass.toNonnegHomClass [NonUnitalNonAssocRing α]
+    [Semiring β] [LinearOrder β] [IsOrderedAddMonoid β] [RingSeminormClass F α β] :
+    NonnegHomClass F α β :=
+  AddGroupSeminormClass.toNonnegHomClass
+
+-- See note [lower instance priority]
+instance (priority := 100) MulRingSeminormClass.toRingSeminormClass [NonAssocRing α]
+    [Semiring β] [PartialOrder β] [MulRingSeminormClass F α β] : RingSeminormClass F α β :=
+  { ‹MulRingSeminormClass F α β› with map_mul_le_mul := fun _ _ _ => (map_mul _ _ _).le }
+
+-- See note [lower instance priority]
+instance (priority := 100) MulRingNormClass.toRingNormClass [NonAssocRing α]
+    [Semiring β] [PartialOrder β] [MulRingNormClass F α β] : RingNormClass F α β :=
+  { ‹MulRingNormClass F α β›, MulRingSeminormClass.toRingSeminormClass with }

--- a/Mathlib/Analysis/Normed/Order/Hom/Basic.lean
+++ b/Mathlib/Analysis/Normed/Order/Hom/Basic.lean
@@ -5,7 +5,7 @@ Authors: Yakov Pechersky
 -/
 module
 
-public import Mathlib.Algebra.Order.Hom.Basic
+public import Mathlib.Algebra.Order.Hom.GroupNormClass
 public import Mathlib.Analysis.Normed.Group.Basic
 
 /-!


### PR DESCRIPTION
I ran intro trouble importing `Algebra/Order/Hom/Basic` into `Algebra/Order/BigOperators/Group/Finset` (which has `assert_not_exists Ring`) in order to prove subadditivity for finite sums.

The file `Algebra/Order/Hom/Basic` is already organized into a basic section, a group norms section, and a ring norms section, so splitting the file along those divisions seemed simplest.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
