### PR TITLE
[Merged by Bors] - refactor: definition for `EventuallyConst` on `Set`

### DIFF
--- a/Mathlib/Dynamics/Ergodic/Action/Basic.lean
+++ b/Mathlib/Dynamics/Ergodic/Action/Basic.lean
@@ -31,7 +31,7 @@ then it is either null or conull.
 class ErgodicVAdd (G α : Type*) [VAdd G α] {_ : MeasurableSpace α} (μ : Measure α) : Prop
     extends VAddInvariantMeasure G α μ where
   aeconst_of_forall_preimage_vadd_ae_eq {s : Set α} : MeasurableSet s →
-    (∀ g : G, (g +ᵥ ·) ⁻¹' s =ᵐ[μ] s) → EventuallyConst s (ae μ)
+    (∀ g : G, (g +ᵥ ·) ⁻¹' s =ᵐ[μ] s) → EventuallyEmptyOrUniv s (ae μ)
 
 /--
 A group action of `G` on a space `α` with measure `μ` is called *ergodic*,
@@ -43,7 +43,7 @@ then it is either null or conull.
 class ErgodicSMul (G α : Type*) [SMul G α] {_ : MeasurableSpace α} (μ : Measure α) : Prop
     extends SMulInvariantMeasure G α μ where
   aeconst_of_forall_preimage_smul_ae_eq {s : Set α} : MeasurableSet s →
-    (∀ g : G, (g • ·) ⁻¹' s =ᵐ[μ] s) → EventuallyConst s (ae μ)
+    (∀ g : G, (g • ·) ⁻¹' s =ᵐ[μ] s) → EventuallyEmptyOrUniv s (ae μ)
 
 attribute [to_additive] ergodicSMul_iff
 
@@ -54,7 +54,7 @@ variable (G : Type*) {α : Type*} {m : MeasurableSpace α} {μ : Measure α}
 @[to_additive]
 theorem aeconst_of_forall_preimage_smul_ae_eq [SMul G α] [ErgodicSMul G α μ] {s : Set α}
     (hm : NullMeasurableSet s μ) (h : ∀ g : G, (g • ·) ⁻¹' s =ᵐ[μ] s) :
-    EventuallyConst s (ae μ) := by
+    EventuallyEmptyOrUniv s (ae μ) := by
   rcases hm with ⟨t, htm, hst⟩
   refine .congr ?_ hst.symm
   refine ErgodicSMul.aeconst_of_forall_preimage_smul_ae_eq htm fun g : G ↦ ?_
@@ -67,19 +67,19 @@ variable [Group G] [MulAction G α] [ErgodicSMul G α μ] {s : Set α}
 
 @[to_additive]
 theorem aeconst_of_forall_smul_ae_eq (hm : NullMeasurableSet s μ) (h : ∀ g : G, g • s =ᵐ[μ] s) :
-    EventuallyConst s (ae μ) :=
+    EventuallyEmptyOrUniv s (ae μ) :=
   aeconst_of_forall_preimage_smul_ae_eq G hm fun g ↦ by
     simpa only [preimage_smul] using h g⁻¹
 
 @[to_additive]
 theorem _root_.MulAction.aeconst_of_aestabilizer_eq_top
-    (hm : NullMeasurableSet s μ) (h : aestabilizer G μ s = ⊤) : EventuallyConst s (ae μ) :=
+    (hm : NullMeasurableSet s μ) (h : aestabilizer G μ s = ⊤) : EventuallyEmptyOrUniv s (ae μ) :=
   aeconst_of_forall_smul_ae_eq G hm <| (Subgroup.eq_top_iff' _).1 h
 
 end Group
 
 theorem _root_.ErgodicSMul.of_aestabilizer [Group G] [MulAction G α] [SMulInvariantMeasure G α μ]
-    (h : ∀ s, MeasurableSet s → aestabilizer G μ s = ⊤ → EventuallyConst s (ae μ)) :
+    (h : ∀ s, MeasurableSet s → aestabilizer G μ s = ⊤ → EventuallyEmptyOrUniv s (ae μ)) :
     ErgodicSMul G α μ :=
   ⟨fun hm hs ↦ h _ hm <| (Subgroup.eq_top_iff' _).2 fun g ↦ by
     simpa only [preimage_smul_inv] using! hs g⁻¹⟩

--- a/Mathlib/Dynamics/Ergodic/Action/OfMinimal.lean
+++ b/Mathlib/Dynamics/Ergodic/Action/OfMinimal.lean
@@ -53,7 +53,7 @@ If a null measurable set `s` is a.e. equal
 to its preimages under the action of a dense set of elements of `M`,
 then it is either null or conull. -/]
 theorem aeconst_of_dense_setOfPred_preimage_smul_ae (hsm : NullMeasurableSet s μ)
-    (hd : Dense {g : M | (g • ·) ⁻¹' s =ᵐ[μ] s}) : EventuallyConst s (ae μ) := by
+    (hd : Dense {g : M | (g • ·) ⁻¹' s =ᵐ[μ] s}) : EventuallyEmptyOrUniv s (ae μ) := by
   borelize M
   refine aeconst_of_forall_preimage_smul_ae_eq M hsm ?_
   rwa [dense_iff_closure_eq, IsClosed.closure_eq, eq_univ_iff_forall] at hd
@@ -69,7 +69,7 @@ alias aeconst_of_dense_setOf_preimage_vadd_ae := aeconst_of_dense_setOfPred_prei
 
 @[to_additive]
 theorem aeconst_of_dense_setOfPred_preimage_smul_eq (hsm : NullMeasurableSet s μ)
-    (hd : Dense {g : M | (g • ·) ⁻¹' s = s}) : EventuallyConst s (ae μ) :=
+    (hd : Dense {g : M | (g • ·) ⁻¹' s = s}) : EventuallyEmptyOrUniv s (ae μ) :=
   aeconst_of_dense_setOfPred_preimage_smul_ae hsm <| hd.mono fun _ h ↦ mem_ofPred.2 <| .of_eq h
 
 @[deprecated (since := "2026-07-09")]
@@ -132,7 +132,7 @@ variable {G : Type*} [Group G] [TopologicalSpace G] [ContinuousInv G]
 
 @[to_additive]
 theorem aeconst_of_dense_aestabilizer_smul (hsm : NullMeasurableSet s μ)
-    (hd : Dense (MulAction.aestabilizer G μ s : Set G)) : EventuallyConst s (ae μ) :=
+    (hd : Dense (MulAction.aestabilizer G μ s : Set G)) : EventuallyEmptyOrUniv s (ae μ) :=
   aeconst_of_dense_setOfPred_preimage_smul_ae hsm <|
     (hd.preimage (isOpenMap_inv _)).mono fun g hg ↦ by
     simpa only [preimage_smul] using! hg

--- a/Mathlib/Dynamics/Ergodic/Action/Regular.lean
+++ b/Mathlib/Dynamics/Ergodic/Action/Regular.lean
@@ -26,7 +26,7 @@ variable {G : Type*} [Group G] [MeasurableSpace G] [MeasurableMul₂ G] [Measura
 instance [μ.IsMulLeftInvariant] : ErgodicSMul G G μ := by
   refine ⟨fun {s} hsm hs ↦ ?_⟩
   suffices (∃ᵐ x ∂μ, x ∈ s) → ∀ᵐ x ∂μ, x ∈ s by
-    simp only [eventuallyConst_set, ← not_frequently]
+    simp only [eventuallyEmptyOrUniv_iff, ← not_frequently]
     exact or_not_of_imp this
   intro hμs
   obtain ⟨a, has, ha⟩ : ∃ a ∈ s, ∀ᵐ b ∂μ, (b * a ∈ s ↔ a ∈ s) := by
@@ -41,7 +41,7 @@ instance [μ.IsMulLeftInvariant] : ErgodicSMul G G μ := by
 instance [μ.IsMulRightInvariant] : ErgodicSMul Gᵐᵒᵖ G μ := by
   refine ⟨fun {s} hsm hs ↦ ?_⟩
   suffices (∃ᵐ x ∂μ, x ∈ s) → ∀ᵐ x ∂μ, x ∈ s by
-    simp only [eventuallyConst_set, ← not_frequently]
+    simp only [eventuallyEmptyOrUniv_iff, ← not_frequently]
     exact or_not_of_imp this
   intro hμs
   obtain ⟨a, has, ha⟩ : ∃ a ∈ s, ∀ᵐ b ∂μ, (a * b ∈ s ↔ a ∈ s) := by

--- a/Mathlib/Dynamics/Ergodic/AddCircle.lean
+++ b/Mathlib/Dynamics/Ergodic/AddCircle.lean
@@ -118,7 +118,7 @@ theorem ergodic_zsmul {n : ℤ} (hn : 1 < |n|) : Ergodic fun y : AddCircle T => 
         (vadd_eq_self_of_preimage_zsmul_eq_self hs' (hnu j)).eventuallyEq
       have hu₂ : Tendsto (fun j => addOrderOf <| u j) atTop atTop := by
         simp_rw [hu₀]; exact tendsto_pow_atTop_atTop_of_one_lt hn
-      rw [eventuallyConst_set']
+      rw [eventuallyEmptyOrUniv_iff']
       exact ae_empty_or_univ_of_forall_vadd_ae_eq_self hs.nullMeasurableSet hu₁ hu₂ }
 
 theorem ergodic_nsmul {n : ℕ} (hn : 1 < n) : Ergodic fun y : AddCircle T => n • y :=

--- a/Mathlib/Dynamics/Ergodic/Ergodic.lean
+++ b/Mathlib/Dynamics/Ergodic/Ergodic.lean
@@ -42,7 +42,7 @@ variable {α : Type*} {m : MeasurableSpace α} {s : Set α}
 /-- A map `f : α → α` is said to be pre-ergodic with respect to a measure `μ` if any measurable
 strictly invariant set is either almost empty or full. -/
 structure PreErgodic (f : α → α) (μ : Measure α := by volume_tac) : Prop where
-  aeconst_set ⦃s : Set α⦄ : MeasurableSet s → f ⁻¹' s = s → EventuallyConst s (ae μ)
+  aeconst_set ⦃s : Set α⦄ : MeasurableSet s → f ⁻¹' s = s → EventuallyEmptyOrUniv s (ae μ)
 
 /-- A map `f : α → α` is said to be ergodic with respect to a measure `μ` if it is measure
 preserving and pre-ergodic. -/
@@ -60,7 +60,7 @@ namespace PreErgodic
 
 theorem ae_empty_or_univ (hf : PreErgodic f μ) (hs : MeasurableSet s) (hfs : f ⁻¹' s = s) :
     s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ := by
-  simpa only [eventuallyConst_set'] using hf.aeconst_set hs hfs
+  simpa only [eventuallyEmptyOrUniv_iff'] using hf.aeconst_set hs hfs
 
 theorem measure_self_or_compl_eq_zero (hf : PreErgodic f μ) (hs : MeasurableSet s)
     (hs' : f ⁻¹' s = s) : μ s = 0 ∨ μ sᶜ = 0 := by
@@ -68,7 +68,7 @@ theorem measure_self_or_compl_eq_zero (hf : PreErgodic f μ) (hs : MeasurableSet
 
 theorem ae_mem_or_ae_notMem (hf : PreErgodic f μ) (hsm : MeasurableSet s) (hs : f ⁻¹' s = s) :
     (∀ᵐ x ∂μ, x ∈ s) ∨ ∀ᵐ x ∂μ, x ∉ s :=
-  eventuallyConst_set.1 <| hf.aeconst_set hsm hs
+  eventuallyEmptyOrUniv_iff.1 <| hf.aeconst_set hsm hs
 
 /-- On a probability space, the (pre)ergodicity condition is a zero-one law. -/
 theorem prob_eq_zero_or_one [IsProbabilityMeasure μ] (hf : PreErgodic f μ) (hs : MeasurableSet s)
@@ -83,7 +83,7 @@ theorem smul_measure {R : Type*} [SMul R ℝ≥0∞] [IsScalarTower R ℝ≥0∞
   aeconst_set _s hs hfs := (hf.aeconst_set hs hfs).anti <| ae_smul_measure_le _
 
 theorem zero_measure (f : α → α) : @PreErgodic α m f 0 where
-  aeconst_set _ _ _ := EventuallyConst.bot.anti ae_zero.le
+  aeconst_set _ _ _ := EventuallyEmptyOrUniv.bot.anti ae_zero.le
 
 end PreErgodic
 
@@ -123,7 +123,7 @@ end MeasureTheory.MeasurePreserving
 namespace QuasiErgodic
 
 theorem aeconst_set₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s μ) (hs : f ⁻¹' s =ᵐ[μ] s) :
-    EventuallyConst s (ae μ) :=
+    EventuallyEmptyOrUniv s (ae μ) :=
   let ⟨_t, h₀, h₁, h₂⟩ := hf.toQuasiMeasurePreserving.exists_preimage_eq_of_preimage_ae hsm hs
   (hf.aeconst_set h₀ h₂).congr h₁
 
@@ -132,14 +132,14 @@ still either almost empty or full. -/
 theorem ae_empty_or_univ₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s μ)
     (hs : f ⁻¹' s =ᵐ[μ] s) :
     s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ :=
-  eventuallyConst_set'.mp <| hf.aeconst_set₀ hsm hs
+  eventuallyEmptyOrUniv_iff'.mp <| hf.aeconst_set₀ hsm hs
 
 /-- For a quasi-ergodic map, sets that are almost invariant (rather than strictly invariant) are
 still either almost empty or full. -/
 theorem ae_mem_or_ae_notMem₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s μ)
     (hs : f ⁻¹' s =ᵐ[μ] s) :
     (∀ᵐ x ∂μ, x ∈ s) ∨ ∀ᵐ x ∂μ, x ∉ s :=
-  eventuallyConst_set.mp <| hf.aeconst_set₀ hsm hs
+  eventuallyEmptyOrUniv_iff.mp <| hf.aeconst_set₀ hsm hs
 
 theorem smul_measure {R : Type*} [SMul R ℝ≥0∞] [IsScalarTower R ℝ≥0∞ ℝ≥0∞]
     (hf : QuasiErgodic f μ) (c : R) : QuasiErgodic f (c • μ) :=

--- a/Mathlib/Dynamics/Ergodic/Extreme.lean
+++ b/Mathlib/Dynamics/Ergodic/Extreme.lean
@@ -49,7 +49,7 @@ theorem of_mem_extremePoints_measure_univ_eq {c : ℝ≥0∞} (hc : c ≠ ∞)
     intro s hsm hfs
     by_contra H
     obtain ⟨hs, hs'⟩ : μ s ≠ 0 ∧ μ sᶜ ≠ 0 := by
-      simpa [eventuallyConst_set, ae_iff, and_comm] using! H
+      simpa [eventuallyEmptyOrUniv_iff, ae_iff, and_comm] using! H
     have hcond : c • μ[|s] = μ := by
       apply h.2 (this hsm hfs hs) (this hsm.compl (by rw [preimage_compl, hfs]) hs')
       refine ⟨μ s / c, μ sᶜ / c, ENNReal.div_pos hs hc, ENNReal.div_pos hs' hc, ?_, ?_⟩

--- a/Mathlib/Dynamics/Ergodic/MeasurePreserving.lean
+++ b/Mathlib/Dynamics/Ergodic/MeasurePreserving.lean
@@ -174,7 +174,7 @@ theorem aeconst_comp [MeasurableSingletonClass γ] {f : α → β} (hf : Measure
 
 theorem aeconst_preimage {f : α → β} (hf : MeasurePreserving f μa μb) {s : Set β}
     (hs : NullMeasurableSet s μb) :
-    Filter.EventuallyConst (f ⁻¹' s) (ae μa) ↔ Filter.EventuallyConst s (ae μb) :=
+    (ae μa).EventuallyEmptyOrUniv (f ⁻¹' s) ↔ (ae μb).EventuallyEmptyOrUniv s :=
   aeconst_comp hf hs.mem
 
 theorem add_measure {f μa' μb'} (hf : MeasurePreserving f μa μb)

--- a/Mathlib/MeasureTheory/Group/AEStabilizer.lean
+++ b/Mathlib/MeasureTheory/Group/AEStabilizer.lean
@@ -72,9 +72,10 @@ lemma aestabilizer_congr (h : s =ᵐ[μ] t) : aestabilizer G μ s = aestabilizer
   ext g
   rw [mem_aestabilizer, mem_aestabilizer, h.congr_right, ((smul_set_ae_eq g).2 h).congr_left]
 
-lemma aestabilizer_of_aeconst (hs : EventuallyConst s (ae μ)) : aestabilizer G μ s = ⊤ := by
+lemma aestabilizer_of_eventuallyEmptyOrUniv (hs : EventuallyEmptyOrUniv s (ae μ)) :
+    aestabilizer G μ s = ⊤ := by
   refine top_unique fun g _ ↦ ?_
-  cases eventuallyConst_set'.mp hs with
+  cases eventuallyEmptyOrUniv_iff'.mp hs with
   | inl h => simp [aestabilizer_congr h]
   | inr h => simp [aestabilizer_congr h]
 

--- a/Mathlib/MeasureTheory/Group/Action.lean
+++ b/Mathlib/MeasureTheory/Group/Action.lean
@@ -154,9 +154,9 @@ theorem smul_ae (c : G) : c • ae μ = ae μ := by
   simp only [mem_smul_filter, preimage_smul, smul_mem_ae]
 
 @[to_additive (attr := simp)]
-theorem eventuallyConst_smul_set_ae (c : G) {s : Set α} :
-    EventuallyConst (c • s : Set α) (ae μ) ↔ EventuallyConst s (ae μ) := by
-  rw [← preimage_smul_inv, eventuallyConst_preimage, Filter.map_smul, smul_ae]
+theorem eventuallyEmptyOrUniv_smul_set_ae (c : G) {s : Set α} :
+    EventuallyEmptyOrUniv (c • s : Set α) (ae μ) ↔ EventuallyEmptyOrUniv s (ae μ) := by
+  rw [← preimage_smul_inv, eventuallyEmptyOrUniv_preimage, Filter.map_smul, smul_ae]
 
 @[to_additive (attr := simp)]
 theorem smul_set_ae_le (c : G) {s t : Set α} : c • s ≤ᵐ[μ] c • t ↔ s ≤ᵐ[μ] t := by

--- a/Mathlib/MeasureTheory/Group/Prod.lean
+++ b/Mathlib/MeasureTheory/Group/Prod.lean
@@ -166,9 +166,9 @@ theorem inv_ae : (ae μ)⁻¹ = ae μ := by
   exact Filter.map_mono (quasiMeasurePreserving_inv μ).tendsto_ae
 
 @[to_additive (attr := simp)]
-theorem eventuallyConst_inv_set_ae :
-    EventuallyConst (s⁻¹ : Set G) (ae μ) ↔ EventuallyConst s (ae μ) := by
-  rw [← inv_preimage, eventuallyConst_preimage, Filter.map_inv, inv_ae]
+theorem eventuallyEmptyOrUniv_inv_set_ae :
+    EventuallyEmptyOrUniv (s⁻¹ : Set G) (ae μ) ↔ EventuallyEmptyOrUniv s (ae μ) := by
+  rw [← inv_preimage, eventuallyEmptyOrUniv_preimage, Filter.map_inv, inv_ae]
 
 @[to_additive]
 theorem inv_absolutelyContinuous : μ.inv ≪ μ :=

--- a/Mathlib/Order/Filter/EventuallyConst.lean
+++ b/Mathlib/Order/Filter/EventuallyConst.lean
@@ -73,10 +73,8 @@ theorem eventuallyConst_pred {p : α → Prop} :
 /-- A set `s` is *eventually empty or eventually universal* along a filter `l` if it is eventually
 equal to `∅` or to `univ`.
 
-This is the specialization of `Filter.EventuallyConst` to `s : Set α`, defined as a separate
-definition (rather than used directly) so that lemmas about it do not need to unfold `Set α` to
-`α → Prop`. -/
-def EventuallyEmptyOrUniv (s : Set α) (l : Filter α) : Prop := EventuallyConst s l
+This is the specialization of `Filter.EventuallyConst` to `s : Set α`. -/
+def EventuallyEmptyOrUniv (s : Set α) (l : Filter α) : Prop := EventuallyConst (· ∈ s) l
 
 theorem eventuallyEmptyOrUniv_iff' {s : Set α} :
     EventuallyEmptyOrUniv s l ↔ (s =ᶠ[l] (∅ : Set α)) ∨ s =ᶠ[l] univ :=

--- a/Mathlib/Order/Filter/EventuallyConst.lean
+++ b/Mathlib/Order/Filter/EventuallyConst.lean
@@ -15,6 +15,9 @@ In this file we define a predicate `Filter.EventuallyConst f l` saying that a fu
 is eventually equal to a constant along a filter `l`. We also prove some basic properties of these
 functions.
 
+We also define `Filter.EventuallyEmptyOrUniv s l`, the specialization of `EventuallyConst` to a
+set `s : Set α`, saying that `s` is eventually empty or eventually equal to `univ` along `l`.
+
 ## Implementation notes
 
 A naive definition of `Filter.EventuallyConst f l` is `∃ y, ∀ᶠ x in l, f x = y`.
@@ -67,14 +70,37 @@ theorem eventuallyConst_pred {p : α → Prop} :
     EventuallyConst p l ↔ (∀ᶠ x in l, p x) ∨ (∀ᶠ x in l, ¬p x) := by
   simp [eventuallyConst_pred', or_comm, EventuallyEq]
 
+/-- A set `s` is *eventually empty or eventually universal* along a filter `l` if it is eventually
+equal to `∅` or to `univ`.
+
+This is the specialization of `Filter.EventuallyConst` to `s : Set α`, defined as a separate
+definition (rather than used directly) so that lemmas about it do not need to unfold `Set α` to
+`α → Prop`. -/
+def EventuallyEmptyOrUniv (s : Set α) (l : Filter α) : Prop := EventuallyConst s l
+
+theorem eventuallyEmptyOrUniv_iff' {s : Set α} :
+    EventuallyEmptyOrUniv s l ↔ (s =ᶠ[l] (∅ : Set α)) ∨ s =ᶠ[l] univ :=
+  eventuallyConst_pred'
+
+@[deprecated eventuallyEmptyOrUniv_iff' (since := "2026-08-25")]
 theorem eventuallyConst_set' {s : Set α} :
     EventuallyConst s l ↔ (s =ᶠ[l] (∅ : Set α)) ∨ s =ᶠ[l] univ :=
   eventuallyConst_pred'
 
+theorem eventuallyEmptyOrUniv_iff {s : Set α} :
+    EventuallyEmptyOrUniv s l ↔ (∀ᶠ x in l, x ∈ s) ∨ (∀ᶠ x in l, x ∉ s) :=
+  eventuallyConst_pred
+
+@[deprecated eventuallyEmptyOrUniv_iff (since := "2026-08-25")]
 theorem eventuallyConst_set {s : Set α} :
     EventuallyConst s l ↔ (∀ᶠ x in l, x ∈ s) ∨ (∀ᶠ x in l, x ∉ s) :=
   eventuallyConst_pred
 
+theorem eventuallyEmptyOrUniv_preimage {s : Set β} {f : α → β} :
+    EventuallyEmptyOrUniv (f ⁻¹' s) l ↔ EventuallyEmptyOrUniv s (map f l) :=
+  .rfl
+
+@[deprecated eventuallyEmptyOrUniv_preimage (since := "2026-08-25")]
 theorem eventuallyConst_preimage {s : Set β} {f : α → β} :
     EventuallyConst (f ⁻¹' s) l ↔ EventuallyConst s (map f l) :=
   .rfl
@@ -133,27 +159,72 @@ lemma mul [Mul β] {g : α → β} (hf : EventuallyConst f l) (hg : EventuallyCo
     EventuallyConst (f * g) l :=
   hf.comp₂ (· * ·) hg
 
+end EventuallyConst
+
+namespace EventuallyEmptyOrUniv
+
+@[simp] protected lemma bot {s : Set α} : EventuallyEmptyOrUniv s ⊥ :=
+  EventuallyConst.bot
+
+protected lemma congr {s t : Set α} (h : EventuallyEmptyOrUniv s l) (hst : s =ᶠ[l] t) :
+    EventuallyEmptyOrUniv t l :=
+  EventuallyConst.congr h hst
+
+lemma anti {s : Set α} {l'} (h : EventuallyEmptyOrUniv s l) (hl' : l' ≤ l) :
+    EventuallyEmptyOrUniv s l' :=
+  EventuallyConst.anti h hl'
+
 variable [One β] {s : Set α} {c : β}
 
 @[to_additive]
 lemma of_mulIndicator_const (h : EventuallyConst (s.mulIndicator fun _ ↦ c) l) (hc : c ≠ 1) :
-    EventuallyConst s l := by
+    EventuallyEmptyOrUniv s l := by
   simpa [Function.comp_def, hc, imp_false] using! h.comp (· = c)
 
 @[to_additive]
-theorem mulIndicator_const (h : EventuallyConst s l) (c : β) :
+theorem mulIndicator_const (h : EventuallyEmptyOrUniv s l) (c : β) :
     EventuallyConst (s.mulIndicator fun _ ↦ c) l := by
   classical exact h.comp (if · then c else 1)
 
 @[to_additive]
 theorem mulIndicator_const_iff_of_ne (hc : c ≠ 1) :
-    EventuallyConst (s.mulIndicator fun _ ↦ c) l ↔ EventuallyConst s l :=
+    EventuallyConst (s.mulIndicator fun _ ↦ c) l ↔ EventuallyEmptyOrUniv s l :=
   ⟨(of_mulIndicator_const · hc), (mulIndicator_const · c)⟩
 
 @[to_additive (attr := simp)]
 theorem mulIndicator_const_iff :
-    EventuallyConst (s.mulIndicator fun _ ↦ c) l ↔ c = 1 ∨ EventuallyConst s l := by
+    EventuallyConst (s.mulIndicator fun _ ↦ c) l ↔ c = 1 ∨ EventuallyEmptyOrUniv s l := by
   rcases eq_or_ne c 1 with rfl | hc <;> simp [mulIndicator_const_iff_of_ne, *]
+
+end EventuallyEmptyOrUniv
+
+namespace EventuallyConst
+
+variable [One β] {s : Set α} {c : β}
+
+@[to_additive (attr := deprecated EventuallyEmptyOrUniv.of_mulIndicator_const
+  (since := "2026-08-25"))]
+lemma of_mulIndicator_const (h : EventuallyConst (s.mulIndicator fun _ ↦ c) l) (hc : c ≠ 1) :
+    EventuallyConst s l :=
+  EventuallyEmptyOrUniv.of_mulIndicator_const h hc
+
+@[to_additive (attr := deprecated EventuallyEmptyOrUniv.mulIndicator_const
+  (since := "2026-08-25"))]
+theorem mulIndicator_const (h : EventuallyConst s l) (c : β) :
+    EventuallyConst (s.mulIndicator fun _ ↦ c) l :=
+  EventuallyEmptyOrUniv.mulIndicator_const h c
+
+@[to_additive (attr := deprecated EventuallyEmptyOrUniv.mulIndicator_const_iff_of_ne
+  (since := "2026-08-25"))]
+theorem mulIndicator_const_iff_of_ne (hc : c ≠ 1) :
+    EventuallyConst (s.mulIndicator fun _ ↦ c) l ↔ EventuallyConst s l :=
+  EventuallyEmptyOrUniv.mulIndicator_const_iff_of_ne hc
+
+@[to_additive (attr := deprecated EventuallyEmptyOrUniv.mulIndicator_const_iff
+  (since := "2026-08-25"))]
+theorem mulIndicator_const_iff :
+    EventuallyConst (s.mulIndicator fun _ ↦ c) l ↔ c = 1 ∨ EventuallyConst s l :=
+  EventuallyEmptyOrUniv.mulIndicator_const_iff
 
 end EventuallyConst
 


### PR DESCRIPTION
Introduce definition `EventuallyEmptyOrUniv` as the `Set` version of `EventuallyConst`.

In mathlib, we currently use `EventuallyConst` for sets, which abuses the `Set α := α → Prop` defeq and which will break once we make `Set` a one-field structure.

Generated by Claude Sonnet, reviewed line by line by myself.

Assisted-by: Claude Sonnet 5

---
- [x] depends on: #41533

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
