### PR TITLE
chore(GroupTheory/Index): don't import `MonoidWithZero`

### DIFF
--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -5,11 +5,7 @@ Authors: Thomas Browning
 -/
 module
 
-public import Mathlib.Algebra.BigOperators.GroupWithZero.Finset
-public import Mathlib.Algebra.Group.Subgroup.ZPowers.Basic
 public import Mathlib.Algebra.GroupWithZero.Subgroup
-public import Mathlib.Data.Finite.Prod
-public import Mathlib.Data.Set.Card
 public import Mathlib.GroupTheory.Coset.Card
 public import Mathlib.GroupTheory.GroupAction.Quotient
 public import Mathlib.GroupTheory.QuotientGroup.Basic
@@ -41,7 +37,7 @@ Several theorems proved in this file are known as Lagrange's theorem.
 
 @[expose] public section
 
-assert_not_exists Field
+assert_not_exists MonoidWithZero
 
 open scoped Pointwise
 
@@ -434,20 +430,22 @@ theorem index_inf_le : (H ⊓ K).index ≤ H.index * K.index := by
 
 @[to_additive]
 theorem relIndex_iInf_ne_zero {ι : Type*} [_hι : Finite ι] {f : ι → Subgroup G}
-    (hf : ∀ i, (f i).relIndex L ≠ 0) : (⨅ i, f i).relIndex L ≠ 0 :=
-  haveI := Fintype.ofFinite ι
-  (Finset.prod_ne_zero_iff.mpr fun i _hi => hf i) ∘
-    Nat.card_pi.symm.trans ∘
-      Finite.card_eq_zero_of_embedding (quotientiInfSubgroupOfEmbedding f L)
+    (hf : ∀ i, (f i).relIndex L ≠ 0) : (⨅ i, f i).relIndex L ≠ 0 := by
+  classical
+  cases nonempty_fintype ι
+  suffices ∀ s : Finset ι, (⨅ i ∈ s, f i).relIndex L ≠ 0 by simpa using this Finset.univ
+  refine Finset.induction (by simp) fun i s his h ↦ ?_
+  rw [Finset.iInf_insert]
+  exact relIndex_inf_ne_zero (hf i) h
 
 @[to_additive]
 theorem relIndex_iInf_le {ι : Type*} [Fintype ι] (f : ι → Subgroup G) :
-    (⨅ i, f i).relIndex L ≤ ∏ i, (f i).relIndex L :=
-  le_of_le_of_eq
-    (Finite.card_le_of_embedding' (quotientiInfSubgroupOfEmbedding f L) fun h =>
-      let ⟨i, _hi, h⟩ := Finset.prod_eq_zero_iff.mp (Nat.card_pi.symm.trans h)
-      relIndex_eq_zero_of_le_left (iInf_le f i) h)
-    Nat.card_pi
+    (⨅ i, f i).relIndex L ≤ ∏ i, (f i).relIndex L := by
+  classical
+  suffices ∀ s : Finset ι, (⨅ i ∈ s, f i).relIndex L ≤ ∏ i ∈ s, (f i).relIndex L by
+    simpa using this Finset.univ
+  refine Finset.induction (by simp) fun i s his h ↦ ?_
+  grw [Finset.iInf_insert, Finset.prod_insert his, relIndex_inf_le, h]
 
 @[to_additive]
 theorem index_iInf_ne_zero {ι : Type*} [Finite ι] {f : ι → Subgroup G}


### PR DESCRIPTION
`GroupTheory/Index` is a basic workhorse file in the group theory library. It shouldn't need to import `MonoidWithZero`.

Zulip thread: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/What.20is.20.60assert_not_exists.20MonoidWithZero.60/with/619226720

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
