### PR TITLE
[Merged by Bors] - refactor(Topology/Algebra/ProperAction): weaken compactly generated hypothesis to compactly coherent

### DIFF
--- a/Mathlib/Topology/Algebra/ProperAction/CompactlyGenerated.lean
+++ b/Mathlib/Topology/Algebra/ProperAction/CompactlyGenerated.lean
@@ -6,7 +6,6 @@ Authors: Etienne Marion
 module
 
 public import Mathlib.Topology.Algebra.ProperAction.Basic
-public import Mathlib.Topology.Compactness.CompactlyCoherentSpace
 public import Mathlib.Topology.Maps.Proper.CompactlyGenerated
 
 /-!

--- a/Mathlib/Topology/Algebra/ProperAction/CompactlyGenerated.lean
+++ b/Mathlib/Topology/Algebra/ProperAction/CompactlyGenerated.lean
@@ -12,17 +12,17 @@ public import Mathlib.Topology.Maps.Proper.CompactlyGenerated
 # When a proper action is properly discontinuous
 
 This file proves that if a discrete group acts on a T2 space `X` such that `X × X` is compactly
-generated, and if the action is continuous in the second variable, then the action is properly
+coherent, and if the action is continuous in the second variable, then the action is properly
 discontinuous if and only if it is proper. This is in particular true if `X` is first-countable or
 weakly locally compact.
 
 ## Main statements
 
 * `properlyDiscontinuousSMul_iff_properSMul`: If a discrete group acts on a T2 space `X` such that
-  `X × X` is compactly generated, and if the action is continuous in the second variable,
+  `X × X` is compactly coherent, and if the action is continuous in the second variable,
   then the action is properly discontinuous if and only if it is proper.
 * `MulAction.properSMul_iff_isCompact_setOfPred_inter_nonempty`: if `G` is a topological group
-  acting continuously on a T2 space `X` such that `X × X` is compactly generated, then the action is
+  acting continuously on a T2 space `X` such that `X × X` is compactly coherent, then the action is
   proper iff, for each pair of compacts `U, V ⊆ X`, the set of `g : G` such that `g • U` intersects
   `V` is compact.
 
@@ -85,7 +85,7 @@ alias AddAction.properVAdd_iff_isCompact_setOf_inter_nonempty :=
   AddAction.properVAdd_iff_isCompact_setOfPred_inter_nonempty
 
 /-- If a discrete group acts on a T2 space `X` such that `X × X` is compactly
-generated, and if the action is continuous in the second variable, then the action is properly
+coherent, and if the action is continuous in the second variable, then the action is properly
 discontinuous if and only if it is proper. This is in particular true if `X` is first-countable or
 weakly locally compact. -/
 @[to_additive]

--- a/Mathlib/Topology/Algebra/ProperAction/CompactlyGenerated.lean
+++ b/Mathlib/Topology/Algebra/ProperAction/CompactlyGenerated.lean
@@ -39,7 +39,7 @@ open Prod Set
 public section
 
 variable {G X : Type*} [TopologicalSpace X] [Group G]
-  [TopologicalSpace G] [MulAction G X] [CompactlyGeneratedSpace (X × X)] [T2Space X]
+  [TopologicalSpace G] [MulAction G X] [CompactlyCoherentSpace (X × X)] [T2Space X]
 
 /-- The `G`-action on `X` is proper iff, for each pair of compacts `U, V` in `X`,
 the set of `g` such that `U` intersects `g • V` is compact.

--- a/Mathlib/Topology/Algebra/ProperAction/CompactlyGenerated.lean
+++ b/Mathlib/Topology/Algebra/ProperAction/CompactlyGenerated.lean
@@ -44,27 +44,21 @@ variable {G X : Type*} [TopologicalSpace X] [Group G]
 /-- The `G`-action on `X` is proper iff, for each pair of compacts `U, V` in `X`,
 the set of `g` such that `U` intersects `g • V` is compact.
 
-See `ProperSMul.isCompact_setOfPred_inter_nonempty`
-for a one-way implication with fewer conditions.
+See `ProperSMul.isCompact_setOfPred_inter_nonempty` for a one-way implication with fewer conditions.
 
-**Note**: We assume `CompactlyCoherentSpace (X × X)`
-as this is the minimal assumption needed to make the proof work;
-but this follows from various more familiar conditions,
-such as `FirstCountableTopology X`.
-Importing `Mathlib.Topology.Sequences` makes this implication available.
+**Note**: We assume `CompactlyCoherentSpace (X × X)` as this is the minimal assumption needed to
+make the proof work; but this follows from various more familiar conditions, such as
+`FirstCountableTopology X`. Importing `Mathlib.Topology.Sequences` makes this implication available.
 -/
 @[to_additive /--
 The `G`-action on `X` is proper iff, for each pair of compacts `U, V` in `X`,
 the set of `g` such that `U` intersects `g +ᵥ V` is compact.
 
-See `ProperVAdd.isCompact_setOfPred_inter_nonempty`
-for a one-way implication with fewer conditions.
+See `ProperVAdd.isCompact_setOfPred_inter_nonempty` for a one-way implication with fewer conditions.
 
-**Note**: We assume `CompactlyCoherentSpace (X × X)`
-as this is the minimal assumption needed to make the proof work;
-but this follows from various more familiar conditions,
-such as `FirstCountableTopology X`.
-Importing `Mathlib.Topology.Sequences` makes this implication available.
+**Note**: We assume `CompactlyCoherentSpace (X × X)` as this is the minimal assumption needed to
+make the proof work; but this follows from various more familiar conditions, such as
+`FirstCountableTopology X`. Importing `Mathlib.Topology.Sequences` makes this implication available.
 -/]
 lemma MulAction.properSMul_iff_isCompact_setOfPred_inter_nonempty [ContinuousSMul G X] :
     ProperSMul G X ↔

--- a/Mathlib/Topology/Algebra/ProperAction/CompactlyGenerated.lean
+++ b/Mathlib/Topology/Algebra/ProperAction/CompactlyGenerated.lean
@@ -6,7 +6,7 @@ Authors: Etienne Marion
 module
 
 public import Mathlib.Topology.Algebra.ProperAction.Basic
-public import Mathlib.Topology.Compactness.CompactlyGeneratedSpace
+public import Mathlib.Topology.Compactness.CompactlyCoherentSpace
 public import Mathlib.Topology.Maps.Proper.CompactlyGenerated
 
 /-!

--- a/Mathlib/Topology/Maps/Proper/CompactlyGenerated.lean
+++ b/Mathlib/Topology/Maps/Proper/CompactlyGenerated.lean
@@ -11,7 +11,7 @@ public import Mathlib.Topology.Maps.Proper.Basic
 /-!
 # A map is proper iff preimage of compact sets are compact
 
-This file proves that if `Y` is a Hausdorff and compactly generated space, a continuous map
+This file proves that if `Y` is a Hausdorff and compactly coherent space, a continuous map
 `f : X → Y` is proper if and only if preimage of compact sets are compact.
 -/
 
@@ -23,7 +23,7 @@ variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 variable [T2Space Y] [CompactlyCoherentSpace Y]
 variable {f : X → Y}
 
-/-- If `Y` is Hausdorff and compactly generated, then proper maps `X → Y` are exactly
+/-- If `Y` is Hausdorff and compactly coherent, then proper maps `X → Y` are exactly
 continuous maps such that the preimage of any compact set is compact. This is in particular true
 if `Y` is Hausdorff and sequential or locally compact. -/
 theorem isProperMap_iff_isCompact_preimage :

--- a/Mathlib/Topology/Maps/Proper/CompactlyGenerated.lean
+++ b/Mathlib/Topology/Maps/Proper/CompactlyGenerated.lean
@@ -25,10 +25,7 @@ variable {f : X → Y}
 
 /-- If `Y` is Hausdorff and compactly generated, then proper maps `X → Y` are exactly
 continuous maps such that the preimage of any compact set is compact. This is in particular true
-if `Y` is Hausdorff and sequential or locally compact.
-
-There was an older version of this theorem which was changed to this one to make use
-of the `CompactlyGeneratedSpace` typeclass. (since 2024-11-10) -/
+if `Y` is Hausdorff and sequential or locally compact. -/
 theorem isProperMap_iff_isCompact_preimage :
     IsProperMap f ↔ Continuous f ∧ ∀ ⦃K⦄, IsCompact K → IsCompact (f ⁻¹' K) where
   mp hf := ⟨hf.continuous, fun _ ↦ hf.isCompact_preimage⟩
@@ -37,10 +34,7 @@ theorem isProperMap_iff_isCompact_preimage :
         convert! (((h hK).inter_left hs).image hf).isClosed.preimage continuous_subtype_val using 1
         aesop, fun _ ↦ h isCompact_singleton⟩
 
-/-- Version of `isProperMap_iff_isCompact_preimage` in terms of `cocompact`.
-
-There was an older version of this theorem which was changed to this one to make use
-of the `CompactlyGeneratedSpace` typeclass. (since 2024-11-10) -/
+/-- Version of `isProperMap_iff_isCompact_preimage` in terms of `cocompact`. -/
 lemma isProperMap_iff_tendsto_cocompact :
     IsProperMap f ↔ Continuous f ∧ Tendsto f (cocompact X) (cocompact Y) := by
   simp_rw [isProperMap_iff_isCompact_preimage,


### PR DESCRIPTION
Weaken the `CompactlyGeneratedSpace (X × X)` assumption in `properSMul_iff_isCompact_setOfPred_inter_nonempty` to `CompactlyCoherentSpace (X × X)`. This matches the note in the result's docstring, which said `CompactlyCoherentSpace` was used as the minimal hypothesis.

Other related changes:
- Change the import from `Mathlib.Topology.Compactness.CompactlyGeneratedSpace` to `Mathlib.Topology.Compactness.CompactlyCoherentSpace`.
- Delete some unnecessary spaces that were making docstrings very long.
- In `Maps/Proper/CompactlyGenerated.lean`, delete some notes that were claiming results were written to make use of `CompactlyGeneratedSpace` typecass, as they no longer use it plus they now have uses in other places in the library. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
