### PR TITLE
[Merged by Bors] - refactor: allow non-unital normed rings in `HasSummableGeomSeries`

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -198,6 +198,14 @@ lemma mul_left_iterate_apply (a b : M) : (a * ·)^[n] b = a ^ n * b := by simp
 lemma mul_right_iterate_apply (a b : M) : (· * a)^[n] b = b * a ^ n := by simp
 
 @[to_additive]
+lemma mul_left_iterate_apply_self (a : M) (n : ℕ) : (a * ·)^[n] a = a ^ (n + 1) := by
+  rw [pow_succ, mul_left_iterate_apply]
+
+@[to_additive]
+lemma mul_right_iterate_apply_self (a : M) (n : ℕ) : (· * a)^[n] a = a ^ (n + 1) := by
+  rw [pow_succ', mul_right_iterate_apply]
+
+@[to_additive]
 lemma mul_left_iterate_apply_one (a : M) : (a * ·)^[n] 1 = a ^ n := by simp
 
 @[to_additive]

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -292,7 +292,7 @@ section NonUnitalNormedRing
 variable {R : Type*} [NonUnitalNormedRing R]
 
 -- this lemma should be removed (and unnecessary) once we have a `Pow G ℕ+` instance for semigroups
-private lemma _root_.norm_iterate_mul_le {R : Type*} [NonUnitalNormedRing R] (x : R) (n : ℕ) :
+private lemma _root_.norm_iterate_mul_le (x : R) (n : ℕ) :
     ‖(· * x)^[n] x‖ ≤ ‖x‖ ^ (n + 1) := by
   induction n with
   | zero => simp
@@ -311,7 +311,7 @@ instance [CompleteSpace R] : HasSummableGeomSeries R where
 protected theorem Summable.add_geom_series_mul_self {x : R} (h : Summable ((· * x)^[·] x)) :
     x + (∑' i : ℕ, (· * x)^[i] x) * x = (∑' i : ℕ, (· * x)^[i] x) := by
   rw [← h.tsum_mul_right, h.tsum_eq_zero_add]
-  simp [Function.iterate_succ_apply']
+  simp [iterate_succ_apply']
 
 protected theorem Summable.add_self_mul_geom_series {x : R} (h : Summable ((· * x)^[·] x)) :
     x + x * (∑' i : ℕ, (· * x)^[i] x) = (∑' i : ℕ, (· * x)^[i] x) := by
@@ -393,7 +393,7 @@ alias ⟨_, HasSummableGeomSeries.of_summable_pow⟩ := hasSummableGeomSeries_if
 
 /-- If `‖x‖ < 1` and `x` lies in a normed ring, then `∑' n : ℕ, x ^ n` is summable
 if and only if `1 - x` is invertible. -/
-theorem hasSummableGeomSeries_iff_isUnit {R : Type*} [NormedRing R] :
+theorem hasSummableGeomSeries_iff_isUnit :
     HasSummableGeomSeries R ↔ ∀ ⦃x : R⦄, ‖x‖ < 1 → IsUnit (1 - x) := by
   rw [neg_involutive.surjective.forall]
   simp_rw [norm_neg, sub_neg_eq_add, hasSummableGeomSeries_iff_isQuasiregular,

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -298,7 +298,7 @@ private lemma _root_.norm_iterate_mul_le (x : R) (n : ℕ) :
   | zero => simp
   | succ n ih => grw [iterate_succ_apply', norm_mul_le, ih, ← pow_succ]
 
-lemma summable_geometric_iterate_of_norm_lt_one [HasSummableGeomSeries R] {x : R} (h : ‖x‖ < 1) :
+lemma summable_iterate_mul_of_norm_lt_one [HasSummableGeomSeries R] {x : R} (h : ‖x‖ < 1) :
     Summable ((· * x)^[·] x) :=
   HasSummableGeomSeries.summable_geometric_of_norm_lt_one x h
 
@@ -372,11 +372,11 @@ variable [HasSummableGeomSeries R]
 
 theorem add_geom_series_mul_self {x : R} (hx : ‖x‖ < 1) :
     x + (∑' i : ℕ, (· * x)^[i] x) * x = (∑' i : ℕ, (· * x)^[i] x) :=
-  summable_geometric_iterate_of_norm_lt_one hx |>.add_geom_series_mul_self
+  summable_iterate_mul_of_norm_lt_one hx |>.add_geom_series_mul_self
 
 theorem add_self_mul_geom_series {x : R} (hx : ‖x‖ < 1) :
     x + x * (∑' i : ℕ, (· * x)^[i] x) = (∑' i : ℕ, (· * x)^[i] x) :=
-  summable_geometric_iterate_of_norm_lt_one hx |>.add_self_mul_geom_series
+  summable_iterate_mul_of_norm_lt_one hx |>.add_self_mul_geom_series
 
 end NonUnitalNormedRing
 

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -368,6 +368,10 @@ theorem hasSummableGeomSeries_iff_isQuasiregular :
   congr!
   exact summable_iterate_mul_iff_isQuasiregular ‹_›
 
+lemma IsQuasiregular.of_norm_lt_one [HasSummableGeomSeries R]
+    {x : R} (h : ‖x‖ < 1) : IsQuasiregular x :=
+  hasSummableGeomSeries_iff_isQuasiregular.mp inferInstance h
+
 variable [HasSummableGeomSeries R]
 
 theorem add_geom_series_mul_self {x : R} (hx : ‖x‖ < 1) :

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -339,19 +339,15 @@ theorem summable_iterate_mul_iff_isQuasiregular {x : R} (h : ‖x‖ < 1) :
   rw [isQuasiregular_iff]
   refine ⟨fun h ↦ ?_, ?_⟩
   · refine ⟨∑' i : ℕ, (· * x)^[i] x, ?_, ?_⟩
-    · simpa [← sub_eq_add_neg, sub_sub] using sub_eq_zero.mpr h.add_self_mul_geom_series.symm
+    · simpa [← sub_eq_add_neg, sub_sub, sub_eq_zero] using h.add_self_mul_geom_series.symm
     · rw [mul_neg]
       convert sub_eq_zero.mpr h.add_geom_series_mul_self.symm
       abel
   · rintro ⟨s, hs, hs'⟩
     rw [neg_mul] at hs
     have hxy : x * s = s - x := by grind
-    have hnorm (n : ℕ) : ‖(· * x)^[n] x‖ ≤ ‖x‖ ^ (n + 1) := by
-      induction n with
-      | zero => simp
-      | succ n ih => grw [iterate_succ_apply', pow_succ, norm_mul_le, ih]
     have hsum : Summable (‖(· * x)^[·] x‖) :=
-      .of_nonneg_of_le (by intro; positivity) hnorm <| by
+      .of_nonneg_of_le (by intro; positivity) (norm_iterate_mul_le x) <| by
         simpa [pow_succ] using (summable_geometric_of_lt_one (norm_nonneg x) h).mul_right ‖x‖
     apply HasSum.summable (a := s)
     rw [hasSum_iff_tendsto_nat_of_summable_norm hsum, ← tendsto_sub_nhds_zero_iff]

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -5,6 +5,7 @@ Authors: Anatole Dedecker, Sébastien Gouëzel, Yury Kudryashov, Dylan MacKenzie
 -/
 module
 
+public import Mathlib.Algebra.Algebra.Spectrum.Quasispectrum
 public import Mathlib.Algebra.BigOperators.Module
 public import Mathlib.Algebra.Order.Field.Power
 public import Mathlib.Analysis.Asymptotics.Lemmas
@@ -267,22 +268,126 @@ theorem AbsoluteValue.tendsto_div_one_add_pow_nhds_zero {v : AbsoluteValue R S} 
 
 /-! ### Geometric series -/
 
-/-- A normed ring has summable geometric series if, for all `ξ` of norm `< 1`, the geometric series
-`∑ ξ ^ n` converges. This holds both in complete normed rings and in normed fields, providing a
-convenient abstraction of these two classes to avoid repeating the same proofs. -/
-class HasSummableGeomSeries (K : Type*) [NormedRing K] : Prop where
-  summable_geometric_of_norm_lt_one : ∀ (ξ : K), ‖ξ‖ < 1 → Summable (fun n ↦ ξ ^ n)
+/-- A non-unital normed ring has summable geometric series if, for all `ξ` of norm `< 1`, the
+geometric series `∑' n, ξ ^ (n + 1)` converges. This holds both in non-unital complete normed rings
+and in normed fields, providing a convenient abstraction of these two classes to avoid repeating
+the same proofs. -/
+@[mk_iff hasSummableGeomSeries_iff_summable_iterate_mul]
+class HasSummableGeomSeries (K : Type*) [NonUnitalNormedRing K] : Prop where
+  summable_geometric_of_norm_lt_one : ∀ (ξ : K), ‖ξ‖ < 1 → Summable (fun n ↦ (· * ξ)^[n] ξ)
+  --summable_geometric_of_norm_lt_one : ∀ (ξ : K), ‖ξ‖ < 1 → Summable (fun n ↦ ξ ^ n)
+
+private lemma _root_.pow_succ_eq_iterate_mul {M : Type*} [Monoid M] (x : M) (n : ℕ) :
+    x ^ (n + 1) = (· * x)^[n] x := by
+  induction n <;> simp [_root_.pow_succ', mul_assoc]
+
+private lemma _root_.iterate_mul_succ' {G : Type*} [Semigroup G] (x : G)
+    (n : ℕ) : (· * x)^[n + 1] x = x * (· * x)^[n] x := by
+  induction n with
+  | zero => simp
+  | succ n ih => rw [iterate_succ_apply' _ n, ← mul_assoc, ← ih, iterate_succ_apply']
+
+lemma summable_geometric_iterate_of_norm_lt_one {K : Type*} [NonUnitalNormedRing K]
+    [HasSummableGeomSeries K] {x : K} (h : ‖x‖ < 1) :
+    Summable (fun n ↦ (· * x)^[n] x) :=
+  HasSummableGeomSeries.summable_geometric_of_norm_lt_one x h
+
+lemma hasSummableGeomSeries_iff_summable_pow {K : Type*} [NormedRing K] :
+    HasSummableGeomSeries K ↔ ∀ (ξ : K), ‖ξ‖ < 1 → Summable (fun n ↦ ξ ^ n) := by
+  simp only [hasSummableGeomSeries_iff_summable_iterate_mul, ← pow_succ_eq_iterate_mul,
+    summable_nat_add_iff 1]
+
+alias ⟨_, HasSummableGeomSeries.of_summable_pow⟩ := hasSummableGeomSeries_iff_summable_pow
 
 lemma summable_geometric_of_norm_lt_one {K : Type*} [NormedRing K] [HasSummableGeomSeries K]
     {x : K} (h : ‖x‖ < 1) : Summable (fun n ↦ x ^ n) :=
-  HasSummableGeomSeries.summable_geometric_of_norm_lt_one x h
+  hasSummableGeomSeries_iff_summable_pow.mp inferInstance _ h
 
 instance {R : Type*} [NormedRing R] [CompleteSpace R] : HasSummableGeomSeries R := by
-  constructor
-  intro x hx
+  refine .of_summable_pow fun x hx ↦ ?_
   have h1 : Summable fun n : ℕ ↦ ‖x‖ ^ n := summable_geometric_of_lt_one (norm_nonneg _) hx
   exact h1.of_norm_bounded_eventually_nat (eventually_norm_pow_le x)
 
+section NonUnitalNormedRing
+
+variable {R : Type*} [NonUnitalNormedRing R]
+
+protected theorem Summable.add_geom_series_mul_self {x : R}
+    (h : Summable (fun n ↦ (· * x)^[n] x)) :
+    x + (∑' i : ℕ, (· * x)^[i] x) * x = (∑' i : ℕ, (· * x)^[i] x) := by
+  rw [← h.tsum_mul_right, h.tsum_eq_zero_add]
+  simp [Function.iterate_succ_apply']
+
+protected theorem Summable.add_self_mul_geom_series {x : R}
+    (h : Summable (fun n ↦ (· * x)^[n] x)) :
+    x + x * (∑' i : ℕ, (· * x)^[i] x) = (∑' i : ℕ, (· * x)^[i] x) := by
+  rw [← h.tsum_mul_left, h.tsum_eq_zero_add]
+  simp [iterate_mul_succ']
+
+theorem summable_iterate_mul_iff_isQuasiregular {x : R} (h : ‖x‖ < 1) :
+    Summable (fun n ↦ (· * x)^[n] x) ↔ IsQuasiregular (-x) := by
+  rw [isQuasiregular_iff]
+  refine ⟨fun h ↦ ?_, ?_⟩
+  · refine ⟨∑' i : ℕ, (· * x)^[i] x, ?_, ?_⟩
+    · simpa [← sub_eq_add_neg, sub_sub] using sub_eq_zero.mpr h.add_self_mul_geom_series.symm
+    · rw [mul_neg]
+      convert sub_eq_zero.mpr h.add_geom_series_mul_self.symm
+      abel
+  · rintro ⟨s, hs, hs'⟩
+    rw [neg_mul] at hs
+    have hxy : x * s = s - x := by grind
+    have hnorm (n : ℕ) : ‖(· * x)^[n] x‖ ≤ ‖x‖ ^ (n + 1) := by
+      induction n with
+      | zero => simp
+      | succ n ih => grw [iterate_succ_apply', pow_succ, norm_mul_le, ih]
+    have hsum : Summable (‖(· * x)^[·] x‖) :=
+      .of_nonneg_of_le (by intro; positivity) hnorm <| by
+        simpa [pow_succ] using (summable_geometric_of_lt_one (norm_nonneg x) h).mul_right ‖x‖
+    apply HasSum.summable (a := s)
+    rw [hasSum_iff_tendsto_nat_of_summable_norm hsum, ← tendsto_sub_nhds_zero_iff]
+    have key (n : ℕ) :
+        (∑ i ∈ range (n + 1), (· * x)^[i] x) - s = x * ((∑ i ∈ range n, (· * x)^[i] x) - s) := by
+      rw [sum_range_succ', mul_sub, hxy, mul_sum]
+      simp only [iterate_mul_succ', iterate_zero_apply, sub_sub_eq_add_sub]
+    suffices ∀ n : ℕ, ‖(∑ i ∈ range n, (· * x)^[i] x) - s‖ ≤ ‖x‖ ^ n * ‖s‖ from
+      squeeze_zero_norm this <| by
+        simpa using (tendsto_pow_atTop_nhds_zero_of_lt_one (norm_nonneg x) h).mul_const ‖s‖
+    intro n
+    induction n with
+    | zero => simp
+    | succ n ih =>
+      rw [key n, pow_succ, mul_comm (‖x‖ ^ n), mul_assoc]
+      exact (norm_mul_le _ _).trans (by gcongr)
+
+theorem hasSummableGeomSeries_iff_isQuasiregular :
+    HasSummableGeomSeries R ↔ ∀ ⦃x : R⦄, ‖x‖ < 1 → IsQuasiregular (-x) := by
+  rw [hasSummableGeomSeries_iff_summable_iterate_mul]
+  congr!
+  exact summable_iterate_mul_iff_isQuasiregular ‹_›
+
+theorem hasSummableGeomSeries_iff_isUnit {R : Type*} [NormedRing R] :
+    HasSummableGeomSeries R ↔ ∀ ⦃x : R⦄, ‖x‖ < 1 → IsUnit (1 - x) := by
+  simp_rw [hasSummableGeomSeries_iff_isQuasiregular, isQuasiregular_iff_isUnit, sub_eq_add_neg]
+
+ #exit
+
+theorem mul_neg_geom_series (x : R) (h : ‖x‖ < 1) : (1 - x) * ∑' i : ℕ, x ^ i = 1 :=
+  (summable_geometric_of_norm_lt_one h).one_sub_mul_tsum_pow
+
+theorem geom_series_succ (x : R) (h : ‖x‖ < 1) : ∑' i : ℕ, x ^ (i + 1) = ∑' i : ℕ, x ^ i - 1 := by
+  rw [eq_sub_iff_add_eq, (summable_geometric_of_norm_lt_one h).tsum_eq_zero_add,
+    pow_zero, add_comm]
+
+theorem geom_series_mul_shift (x : R) (h : ‖x‖ < 1) :
+    x * ∑' i : ℕ, x ^ i = ∑' i : ℕ, x ^ (i + 1) := by
+  simp_rw [← (summable_geometric_of_norm_lt_one h).tsum_mul_left, ← _root_.pow_succ']
+
+theorem geom_series_mul_one_add (x : R) (h : ‖x‖ < 1) :
+    (1 + x) * ∑' i : ℕ, x ^ i = 2 * ∑' i : ℕ, x ^ i - 1 := by
+  rw [add_mul, one_mul, geom_series_mul_shift x h, geom_series_succ x h, two_mul, add_sub_assoc]
+
+end NonUnitalNormedRing
+#exit
 section HasSummableGeometricSeries
 
 variable {R : Type*} [NormedRing R]

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -418,6 +418,11 @@ theorem tsum_geometric_le_of_norm_lt_one (x : R) (h : ‖x‖ < 1) :
 
 variable [HasSummableGeomSeries R]
 
+/-- The element `1 - x` also available bundled as a term of `Rˣ` with inverse `∑' n : ℕ, x ^ n`
+in `Units.oneSub`. -/
+theorem IsUnit.one_sub_of_norm_lt_one {x : R} (hx : ‖x‖ < 1) : IsUnit (1 - x) :=
+  hasSummableGeomSeries_iff_isUnit.mp inferInstance hx
+
 lemma summable_geometric_of_norm_lt_one {x : R} (h : ‖x‖ < 1) : Summable (fun n ↦ x ^ n) :=
   hasSummableGeomSeries_iff_summable_pow.mp inferInstance h
 

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -271,11 +271,14 @@ theorem AbsoluteValue.tendsto_div_one_add_pow_nhds_zero {v : AbsoluteValue R S} 
 /-- A non-unital normed ring has summable geometric series if, for all `ξ` of norm `< 1`, the
 geometric series `∑' n, ξ ^ (n + 1)` converges. This holds both in non-unital complete normed rings
 and in normed fields, providing a convenient abstraction of these two classes to avoid repeating
-the same proofs. -/
+the same proofs.
+
+Due to the fact that Mathlib has no `Pow G ℕ+` instance for semigroups, this is currently stated
+using iterated multiplication. Once semigroups implement this bundled `Pow` instance, then we can
+switch the statements to use that instead, and improve the proofs. -/
 @[mk_iff hasSummableGeomSeries_iff_summable_iterate_mul]
 class HasSummableGeomSeries (K : Type*) [NonUnitalNormedRing K] : Prop where
-  summable_geometric_of_norm_lt_one : ∀ (ξ : K), ‖ξ‖ < 1 → Summable (fun n ↦ (· * ξ)^[n] ξ)
-  --summable_geometric_of_norm_lt_one : ∀ (ξ : K), ‖ξ‖ < 1 → Summable (fun n ↦ ξ ^ n)
+  summable_geometric_of_norm_lt_one : ∀ (ξ : K), ‖ξ‖ < 1 → Summable ((· * ξ)^[·] ξ)
 
 private lemma _root_.pow_succ_eq_iterate_mul {M : Type*} [Monoid M] (x : M) (n : ℕ) :
     x ^ (n + 1) = (· * x)^[n] x := by
@@ -287,45 +290,52 @@ private lemma _root_.iterate_mul_succ' {G : Type*} [Semigroup G] (x : G)
   | zero => simp
   | succ n ih => rw [iterate_succ_apply' _ n, ← mul_assoc, ← ih, iterate_succ_apply']
 
-lemma summable_geometric_iterate_of_norm_lt_one {K : Type*} [NonUnitalNormedRing K]
-    [HasSummableGeomSeries K] {x : K} (h : ‖x‖ < 1) :
-    Summable (fun n ↦ (· * x)^[n] x) :=
-  HasSummableGeomSeries.summable_geometric_of_norm_lt_one x h
-
-lemma hasSummableGeomSeries_iff_summable_pow {K : Type*} [NormedRing K] :
-    HasSummableGeomSeries K ↔ ∀ (ξ : K), ‖ξ‖ < 1 → Summable (fun n ↦ ξ ^ n) := by
-  simp only [hasSummableGeomSeries_iff_summable_iterate_mul, ← pow_succ_eq_iterate_mul,
-    summable_nat_add_iff 1]
-
-alias ⟨_, HasSummableGeomSeries.of_summable_pow⟩ := hasSummableGeomSeries_iff_summable_pow
-
-lemma summable_geometric_of_norm_lt_one {K : Type*} [NormedRing K] [HasSummableGeomSeries K]
-    {x : K} (h : ‖x‖ < 1) : Summable (fun n ↦ x ^ n) :=
-  hasSummableGeomSeries_iff_summable_pow.mp inferInstance _ h
-
-instance {R : Type*} [NormedRing R] [CompleteSpace R] : HasSummableGeomSeries R := by
-  refine .of_summable_pow fun x hx ↦ ?_
-  have h1 : Summable fun n : ℕ ↦ ‖x‖ ^ n := summable_geometric_of_lt_one (norm_nonneg _) hx
-  exact h1.of_norm_bounded_eventually_nat (eventually_norm_pow_le x)
-
 section NonUnitalNormedRing
 
 variable {R : Type*} [NonUnitalNormedRing R]
 
-protected theorem Summable.add_geom_series_mul_self {x : R}
-    (h : Summable (fun n ↦ (· * x)^[n] x)) :
+private lemma _root_.norm_iterate_mul_le {R : Type*} [NonUnitalNormedRing R] (x : R) (n : ℕ) :
+    ‖(· * x)^[n] x‖ ≤ ‖x‖ ^ (n + 1) := by
+  induction n with
+  | zero => simp
+  | succ n ih => grw [iterate_succ_apply', norm_mul_le, ih, ← pow_succ]
+
+lemma summable_geometric_iterate_of_norm_lt_one [HasSummableGeomSeries R] {x : R} (h : ‖x‖ < 1) :
+    Summable ((· * x)^[·] x) :=
+  HasSummableGeomSeries.summable_geometric_of_norm_lt_one x h
+
+instance [CompleteSpace R] : HasSummableGeomSeries R where
+  summable_geometric_of_norm_lt_one x hx := by
+    have h1 : Summable fun n : ℕ ↦ ‖x‖ ^ (n + 1) :=
+      summable_nat_add_iff 1 |>.mpr <| summable_geometric_of_lt_one (norm_nonneg _) hx
+    refine h1.of_norm_bounded_eventually_nat <| .of_forall <| norm_iterate_mul_le x
+
+protected theorem Summable.add_geom_series_mul_self {x : R} (h : Summable ((· * x)^[·] x)) :
     x + (∑' i : ℕ, (· * x)^[i] x) * x = (∑' i : ℕ, (· * x)^[i] x) := by
   rw [← h.tsum_mul_right, h.tsum_eq_zero_add]
   simp [Function.iterate_succ_apply']
 
-protected theorem Summable.add_self_mul_geom_series {x : R}
-    (h : Summable (fun n ↦ (· * x)^[n] x)) :
+protected theorem Summable.add_self_mul_geom_series {x : R} (h : Summable ((· * x)^[·] x)) :
     x + x * (∑' i : ℕ, (· * x)^[i] x) = (∑' i : ℕ, (· * x)^[i] x) := by
   rw [← h.tsum_mul_left, h.tsum_eq_zero_add]
   simp [iterate_mul_succ']
 
+/-- Bound for the sum of a geometric series in a normed ring. This formula does not assume that the
+normed ring satisfies the axiom `‖1‖ = 1`. -/
+theorem tsum_iterate_mul_le_of_norm_lt_one (x : R) (h : ‖x‖ < 1) :
+    ‖∑' n : ℕ, (· * x)^[n] x‖ ≤ ‖x‖ / (1 - ‖x‖) := by
+  by_cases hx : Summable ((· * x)^[·] x)
+  · refine tsum_of_norm_bounded (g := ((· * ‖x‖)^[·] ‖x‖)) ?_ ?_
+    · simp_rw [← pow_succ_eq_iterate_mul, _root_.pow_succ']
+      simpa [div_eq_mul_inv] using (hasSum_geometric_of_lt_one (norm_nonneg x) h).mul_left ‖x‖
+    · simpa [← pow_succ_eq_iterate_mul] using norm_iterate_mul_le x
+  · simp only [tsum_eq_zero_of_not_summable hx, norm_zero]
+    positivity [sub_pos.mpr h]
+
+/-- If `‖x‖ < 1` and `x` lies in a non-unital normed ring, then `∑' n : ℕ, x ^ (n + 1)` is summable
+if and only if `-x` is quasiregular. -/
 theorem summable_iterate_mul_iff_isQuasiregular {x : R} (h : ‖x‖ < 1) :
-    Summable (fun n ↦ (· * x)^[n] x) ↔ IsQuasiregular (-x) := by
+    Summable ((· * x)^[·] x) ↔ IsQuasiregular (-x) := by
   rw [isQuasiregular_iff]
   refine ⟨fun h ↦ ?_, ?_⟩
   · refine ⟨∑' i : ℕ, (· * x)^[i] x, ?_, ?_⟩
@@ -359,58 +369,62 @@ theorem summable_iterate_mul_iff_isQuasiregular {x : R} (h : ‖x‖ < 1) :
       rw [key n, pow_succ, mul_comm (‖x‖ ^ n), mul_assoc]
       exact (norm_mul_le _ _).trans (by gcongr)
 
+/-- A non-unital normed ring `R` has summable geometric series if and only if every element of
+in the unit ball is quasiregular. -/
 theorem hasSummableGeomSeries_iff_isQuasiregular :
-    HasSummableGeomSeries R ↔ ∀ ⦃x : R⦄, ‖x‖ < 1 → IsQuasiregular (-x) := by
-  rw [hasSummableGeomSeries_iff_summable_iterate_mul]
+    HasSummableGeomSeries R ↔ ∀ ⦃x : R⦄, ‖x‖ < 1 → IsQuasiregular x := by
+  rw [neg_involutive.surjective.forall, hasSummableGeomSeries_iff_summable_iterate_mul]
+  simp only [norm_neg]
   congr!
   exact summable_iterate_mul_iff_isQuasiregular ‹_›
 
-theorem hasSummableGeomSeries_iff_isUnit {R : Type*} [NormedRing R] :
-    HasSummableGeomSeries R ↔ ∀ ⦃x : R⦄, ‖x‖ < 1 → IsUnit (1 - x) := by
-  simp_rw [hasSummableGeomSeries_iff_isQuasiregular, isQuasiregular_iff_isUnit, sub_eq_add_neg]
+variable [HasSummableGeomSeries R]
 
- #exit
+theorem add_geom_series_mul_self {x : R} (hx : ‖x‖ < 1) :
+    x + (∑' i : ℕ, (· * x)^[i] x) * x = (∑' i : ℕ, (· * x)^[i] x) :=
+  summable_geometric_iterate_of_norm_lt_one hx |>.add_geom_series_mul_self
 
-theorem mul_neg_geom_series (x : R) (h : ‖x‖ < 1) : (1 - x) * ∑' i : ℕ, x ^ i = 1 :=
-  (summable_geometric_of_norm_lt_one h).one_sub_mul_tsum_pow
-
-theorem geom_series_succ (x : R) (h : ‖x‖ < 1) : ∑' i : ℕ, x ^ (i + 1) = ∑' i : ℕ, x ^ i - 1 := by
-  rw [eq_sub_iff_add_eq, (summable_geometric_of_norm_lt_one h).tsum_eq_zero_add,
-    pow_zero, add_comm]
-
-theorem geom_series_mul_shift (x : R) (h : ‖x‖ < 1) :
-    x * ∑' i : ℕ, x ^ i = ∑' i : ℕ, x ^ (i + 1) := by
-  simp_rw [← (summable_geometric_of_norm_lt_one h).tsum_mul_left, ← _root_.pow_succ']
-
-theorem geom_series_mul_one_add (x : R) (h : ‖x‖ < 1) :
-    (1 + x) * ∑' i : ℕ, x ^ i = 2 * ∑' i : ℕ, x ^ i - 1 := by
-  rw [add_mul, one_mul, geom_series_mul_shift x h, geom_series_succ x h, two_mul, add_sub_assoc]
+theorem add_self_mul_geom_series {x : R} (hx : ‖x‖ < 1) :
+    x + x * (∑' i : ℕ, (· * x)^[i] x) = (∑' i : ℕ, (· * x)^[i] x) :=
+  summable_geometric_iterate_of_norm_lt_one hx |>.add_self_mul_geom_series
 
 end NonUnitalNormedRing
-#exit
-section HasSummableGeometricSeries
+
+section NormedRing
 
 variable {R : Type*} [NormedRing R]
+
+lemma hasSummableGeomSeries_iff_summable_pow :
+    HasSummableGeomSeries R ↔ ∀ ⦃ξ : R⦄, ‖ξ‖ < 1 → Summable (fun n ↦ ξ ^ n) := by
+  simp only [hasSummableGeomSeries_iff_summable_iterate_mul, ← pow_succ_eq_iterate_mul,
+    summable_nat_add_iff 1]
+
+alias ⟨_, HasSummableGeomSeries.of_summable_pow⟩ := hasSummableGeomSeries_iff_summable_pow
+
+/-- If `‖x‖ < 1` and `x` lies in a non-unital normed ring, then `∑' n : ℕ, x ^ n` is summable
+if and only if `1 - x` is invertible. -/
+theorem hasSummableGeomSeries_iff_isUnit {R : Type*} [NormedRing R] :
+    HasSummableGeomSeries R ↔ ∀ ⦃x : R⦄, ‖x‖ < 1 → IsUnit (1 - x) := by
+  rw [neg_involutive.surjective.forall]
+  simp_rw [norm_neg, sub_neg_eq_add, hasSummableGeomSeries_iff_isQuasiregular,
+    isQuasiregular_iff_isUnit]
 
 /-- Bound for the sum of a geometric series in a normed ring. This formula does not assume that the
 normed ring satisfies the axiom `‖1‖ = 1`. -/
 theorem tsum_geometric_le_of_norm_lt_one (x : R) (h : ‖x‖ < 1) :
     ‖∑' n : ℕ, x ^ n‖ ≤ ‖(1 : R)‖ - 1 + (1 - ‖x‖)⁻¹ := by
+  have := by simpa only [← pow_succ_eq_iterate_mul] using tsum_iterate_mul_le_of_norm_lt_one x h
   by_cases hx : Summable (fun n ↦ x ^ n)
-  · rw [hx.tsum_eq_zero_add]
-    simp only [_root_.pow_zero]
-    refine le_trans (norm_add_le _ _) ?_
-    have : ‖∑' b : ℕ, (fun n ↦ x ^ (n + 1)) b‖ ≤ (1 - ‖x‖)⁻¹ - 1 := by
-      refine tsum_of_norm_bounded ?_ fun b ↦ norm_pow_le' _ (Nat.succ_pos b)
-      simpa using (hasSum_nat_add_iff' 1).mpr (hasSum_geometric_of_lt_one (norm_nonneg x) h)
-    linarith
+  · grw [hx.tsum_eq_zero_add, norm_add_le, this]
+    grind
   · simp only [tsum_eq_zero_of_not_summable hx, norm_zero]
     nontriviality R
-    have : 1 ≤ ‖(1 : R)‖ := one_le_norm_one R
-    have : 0 ≤ (1 - ‖x‖)⁻¹ := inv_nonneg.2 (by linarith)
-    linarith
+    positivity [sub_pos.mpr h, one_le_norm_one R]
 
 variable [HasSummableGeomSeries R]
+
+lemma summable_geometric_of_norm_lt_one {x : R} (h : ‖x‖ < 1) : Summable (fun n ↦ x ^ n) :=
+  hasSummableGeomSeries_iff_summable_pow.mp inferInstance h
 
 theorem geom_series_mul_neg (x : R) (h : ‖x‖ < 1) : (∑' i : ℕ, x ^ i) * (1 - x) = 1 :=
   (summable_geometric_of_norm_lt_one h).tsum_pow_mul_one_sub
@@ -453,7 +467,7 @@ theorem hasSum_geom_series_inverse (x : R) (h : ‖x‖ < 1) :
 lemma isUnit_one_sub_of_norm_lt_one {x : R} (h : ‖x‖ < 1) : IsUnit (1 - x) :=
   ⟨Units.oneSub x h, rfl⟩
 
-end HasSummableGeometricSeries
+end NormedRing
 
 section Geometric
 
@@ -470,7 +484,7 @@ theorem hasSum_geometric_of_norm_lt_one (h : ‖ξ‖ < 1) : HasSum (fun n : ℕ
   · simp [norm_pow, summable_geometric_of_lt_one (norm_nonneg _) h]
 
 instance : HasSummableGeomSeries K :=
-  ⟨fun _ h ↦ (hasSum_geometric_of_norm_lt_one h).summable⟩
+  .of_summable_pow fun _ h ↦ (hasSum_geometric_of_norm_lt_one h).summable
 
 theorem tsum_geometric_of_norm_lt_one (h : ‖ξ‖ < 1) : ∑' n : ℕ, ξ ^ n = (1 - ξ)⁻¹ :=
   (hasSum_geometric_of_norm_lt_one h).tsum_eq

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -282,7 +282,7 @@ class HasSummableGeomSeries (K : Type*) [NonUnitalNormedRing K] : Prop where
 
 private lemma _root_.pow_succ_eq_iterate_mul {M : Type*} [Monoid M] (x : M) (n : ℕ) :
     x ^ (n + 1) = (· * x)^[n] x := by
-  induction n <;> simp [_root_.pow_succ', mul_assoc]
+  simp [add_comm n, pow_add]
 
 private lemma _root_.iterate_mul_succ' {G : Type*} [Semigroup G] (x : G)
     (n : ℕ) : (· * x)^[n + 1] x = x * (· * x)^[n] x := by
@@ -324,13 +324,9 @@ protected theorem Summable.add_self_mul_geom_series {x : R} (h : Summable ((· *
 normed ring satisfies the axiom `‖1‖ = 1`. -/
 theorem tsum_iterate_mul_le_of_norm_lt_one (x : R) (h : ‖x‖ < 1) :
     ‖∑' n : ℕ, (· * x)^[n] x‖ ≤ ‖x‖ / (1 - ‖x‖) := by
-  by_cases hx : Summable ((· * x)^[·] x)
-  · refine tsum_of_norm_bounded (g := ((· * ‖x‖)^[·] ‖x‖)) ?_ ?_
-    · simp_rw [← pow_succ_eq_iterate_mul, _root_.pow_succ']
-      simpa [div_eq_mul_inv] using (hasSum_geometric_of_lt_one (norm_nonneg x) h).mul_left ‖x‖
-    · simpa [← pow_succ_eq_iterate_mul] using norm_iterate_mul_le x
-  · simp only [tsum_eq_zero_of_not_summable hx, norm_zero]
-    positivity [sub_pos.mpr h]
+  refine tsum_of_norm_bounded ?_ (norm_iterate_mul_le x)
+  simpa [_root_.pow_succ', div_eq_mul_inv] using
+    (hasSum_geometric_of_lt_one (norm_nonneg x) h).mul_left _
 
 /-- If `‖x‖ < 1` and `x` lies in a non-unital normed ring, then `∑' n : ℕ, x ^ (n + 1)` is summable
 if and only if `-x` is quasiregular. -/
@@ -366,7 +362,7 @@ theorem summable_iterate_mul_iff_isQuasiregular {x : R} (h : ‖x‖ < 1) :
       exact (norm_mul_le _ _).trans (by gcongr)
 
 /-- A non-unital normed ring `R` has summable geometric series if and only if every element of
-in the unit ball is quasiregular. -/
+in the open unit ball is quasiregular. -/
 theorem hasSummableGeomSeries_iff_isQuasiregular :
     HasSummableGeomSeries R ↔ ∀ ⦃x : R⦄, ‖x‖ < 1 → IsQuasiregular x := by
   rw [neg_involutive.surjective.forall, hasSummableGeomSeries_iff_summable_iterate_mul]
@@ -397,7 +393,7 @@ lemma hasSummableGeomSeries_iff_summable_pow :
 
 alias ⟨_, HasSummableGeomSeries.of_summable_pow⟩ := hasSummableGeomSeries_iff_summable_pow
 
-/-- If `‖x‖ < 1` and `x` lies in a non-unital normed ring, then `∑' n : ℕ, x ^ n` is summable
+/-- If `‖x‖ < 1` and `x` lies in a normed ring, then `∑' n : ℕ, x ^ n` is summable
 if and only if `1 - x` is invertible. -/
 theorem hasSummableGeomSeries_iff_isUnit {R : Type*} [NormedRing R] :
     HasSummableGeomSeries R ↔ ∀ ⦃x : R⦄, ‖x‖ < 1 → IsUnit (1 - x) := by

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -280,10 +280,7 @@ switch the statements to use that instead, and improve the proofs. -/
 class HasSummableGeomSeries (K : Type*) [NonUnitalNormedRing K] : Prop where
   summable_geometric_of_norm_lt_one : ∀ (ξ : K), ‖ξ‖ < 1 → Summable ((· * ξ)^[·] ξ)
 
-private lemma _root_.pow_succ_eq_iterate_mul {M : Type*} [Monoid M] (x : M) (n : ℕ) :
-    x ^ (n + 1) = (· * x)^[n] x := by
-  induction n <;> simp [_root_.pow_succ', mul_assoc]
-
+-- this lemma should be removed (and unnecessary) once we have a `Pow G ℕ+` instance for semigroups
 private lemma _root_.iterate_mul_succ' {G : Type*} [Semigroup G] (x : G)
     (n : ℕ) : (· * x)^[n + 1] x = x * (· * x)^[n] x := by
   induction n with
@@ -294,6 +291,7 @@ section NonUnitalNormedRing
 
 variable {R : Type*} [NonUnitalNormedRing R]
 
+-- this lemma should be removed (and unnecessary) once we have a `Pow G ℕ+` instance for semigroups
 private lemma _root_.norm_iterate_mul_le {R : Type*} [NonUnitalNormedRing R] (x : R) (n : ℕ) :
     ‖(· * x)^[n] x‖ ≤ ‖x‖ ^ (n + 1) := by
   induction n with
@@ -326,9 +324,9 @@ theorem tsum_iterate_mul_le_of_norm_lt_one (x : R) (h : ‖x‖ < 1) :
     ‖∑' n : ℕ, (· * x)^[n] x‖ ≤ ‖x‖ / (1 - ‖x‖) := by
   by_cases hx : Summable ((· * x)^[·] x)
   · refine tsum_of_norm_bounded (g := ((· * ‖x‖)^[·] ‖x‖)) ?_ ?_
-    · simp_rw [← pow_succ_eq_iterate_mul, _root_.pow_succ']
+    · simp_rw [mul_right_iterate_apply]
       simpa [div_eq_mul_inv] using (hasSum_geometric_of_lt_one (norm_nonneg x) h).mul_left ‖x‖
-    · simpa [← pow_succ_eq_iterate_mul] using norm_iterate_mul_le x
+    · simpa [← _root_.mul_right_iterate_apply_self] using norm_iterate_mul_le x
   · simp only [tsum_eq_zero_of_not_summable hx, norm_zero]
     positivity [sub_pos.mpr h]
 
@@ -392,7 +390,7 @@ variable {R : Type*} [NormedRing R]
 
 lemma hasSummableGeomSeries_iff_summable_pow :
     HasSummableGeomSeries R ↔ ∀ ⦃ξ : R⦄, ‖ξ‖ < 1 → Summable (fun n ↦ ξ ^ n) := by
-  simp only [hasSummableGeomSeries_iff_summable_iterate_mul, ← pow_succ_eq_iterate_mul,
+  simp only [hasSummableGeomSeries_iff_summable_iterate_mul, mul_right_iterate_apply_self,
     summable_nat_add_iff 1]
 
 alias ⟨_, HasSummableGeomSeries.of_summable_pow⟩ := hasSummableGeomSeries_iff_summable_pow
@@ -409,7 +407,8 @@ theorem hasSummableGeomSeries_iff_isUnit {R : Type*} [NormedRing R] :
 normed ring satisfies the axiom `‖1‖ = 1`. -/
 theorem tsum_geometric_le_of_norm_lt_one (x : R) (h : ‖x‖ < 1) :
     ‖∑' n : ℕ, x ^ n‖ ≤ ‖(1 : R)‖ - 1 + (1 - ‖x‖)⁻¹ := by
-  have := by simpa only [← pow_succ_eq_iterate_mul] using tsum_iterate_mul_le_of_norm_lt_one x h
+  have := by simpa only [mul_right_iterate_apply_self]
+    using tsum_iterate_mul_le_of_norm_lt_one x h
   by_cases hx : Summable (fun n ↦ x ^ n)
   · grw [hx.tsum_eq_zero_add, norm_add_le, this]
     grind


### PR DESCRIPTION
This PR changes the field of `HasSummableGeomSeries` to a version which is equivalent for `NormedRing`s, but which also makes sense and is useful in `NonUnitalNormedRing`s. In particular, the previous definition was, for `x : R` and `‖x‖ < 1`: `Summable (fun n : ℕ ↦ x ^ n)`, which doesn't work for non-unital rings since there is no `Pow R ℕ` instance. We change the field to `Summable (fun n : ℕ ↦ (· * x)^[n] x)` (i.e., `fun n ↦ x ^ (n + 1)`).

We are forced to use iterated multiplication because Mathlib currently doesn't define any `Pow G ℕ+` instance for semigroups `G`, however, when it eventually does, we can switch this definition easily to make use of that instead.

In addition to this change, we show the `HasSummableGeomSeries` is equivalent (in non-unital normed rings) to every element of the open unit ball being quasiregular, and consequently (in normed rings) to every element `x` of the open unit ball satisfying `IsUnit (1 - x)`.

These changes are used in other PRs (see #42779 and #42782):

1. to show that `HasSummableGeomSeries` is preserved under `A ↦ WithLp 1 (Unitization 𝕜 A)`
2. to provide some mild generalization of results on the quasispectrum in non-unital Banach algebras
3. remove some `NormOneClass` assumptions for some results on the spectrum in unital Banach algebras 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
