### PR TITLE
doc(100-yaml): claim #53 (Pi is Transcendental) via an external Lean 4 formalization

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -219,6 +219,10 @@
   authors: mathlib
 53:
   title  : Pi is Transcendental
+  authors: Trevor Morris
+  links  :
+    result: https://github.com/gotrevor/lean-formalizations/blob/main/src/LeanFormalizations/NumberTheory/Transcendence/PiTranscendental.lean
+  note   : "formalised outside mathlib, in Lean 4; the full Lindemann assembly (analytic engine over an arbitrary conjugate polynomial plus the symmetric-function algebraic part) is built on mathlib's `exp_polynomial_approx`"
 54:
   title  : Königsberg Bridges Problem
   decl   : Konigsberg.not_isEulerian


### PR DESCRIPTION
Adds `authors` + `links.result` to `docs/100.yaml` entry **53, "Pi is Transcendental"**, which
currently has a title and nothing else.

The formalization lives outside mathlib, in Lean 4:
[`PiTranscendental.lean`](https://github.com/gotrevor/lean-formalizations/blob/main/src/LeanFormalizations/NumberTheory/Transcendence/PiTranscendental.lean)
— `transcendental_pi_axiomClean : Transcendental ℚ Real.pi`, with
`#print axioms` = `[propext, Classical.choice, Quot.sound]` (re-verified 2026-08-25 against
mathlib v4.31.0). It builds the full Lindemann assembly on mathlib's own
`exp_polynomial_approx`: the analytic engine generalised to an arbitrary conjugate polynomial,
plus the algebraic half (symmetric functions over the Galois conjugates of `iπ`, via the
fundamental theorem of symmetric polynomials). `e_transcendental` is proved in the same chain.

No `decl` field, since that is for in-mathlib declarations and is existence-checked. `title` is
untouched. This follows the existing external-formalization entries: 8 (Compass), 24
(flypitch/CH), 31 (Ramsey), 36 (Brouwer), and 67 ("e is Transcendental").

`scripts/yaml_check.py docs/{100,1000,overview,undergrad}.yaml` exits 0.

### On #28013

[#28013](https://github.com/leanprover-community/mathlib4/pull/28013) (Lindemann–Weierstrass,
@astrainfinita) is open and active, and when it lands entry 53 should get a proper in-mathlib
`decl` — at which point this pointer has done its job and should be replaced or dropped. I am
not proposing this as an alternative to that work, and I would rather it landed than mine be
listed. This is only meant to record that a checkable Lean 4 proof exists in the meantime, which
is what `links.result` is for on the other five entries. Happy to close this if maintainers would
rather the entry stay empty until #28013 merges.

### Use of AI

The Lean development this points at was largely written by Claude working in long autonomous
sessions against a `lake build` + `#print axioms` gate, and two symmetric-function lemmas came
from Harmonic's Aristotle and were re-verified in the repository's own kernel; the repo's README
and commit history say so. This PR's four-line YAML diff was likewise drafted with Claude. I have
checked the axiom footprint myself and the linked file is machine-checked end to end.

