### PR TITLE
[Merged by Bors] - fix(cache): retry transport errors, improve transfer robustness

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -258,13 +258,15 @@ def validateCurl : IO Bool := do
           "-L", "-o", CURLBIN.toString]
         let _ ← runCmd "chmod" #["u+x", CURLBIN.toString]
         return true
-      -- The parallel download path passes `--retry-all-errors`, which
-      -- needs curl 7.71; an older curl rejects the whole command.
-      if version >= (7, 71) then
+      -- The parallel transfer paths pass `--retry-all-errors` (curl 7.71)
+      -- and read the `exitcode` and `errormsg` fields of the per-transfer
+      -- JSON report (curl 7.75); an older curl rejects the flag or omits
+      -- the fields.
+      if version >= (7, 75) then
         IO.println s!"Warning: recommended `curl` version ≥7.81. Found {v}"
         return true
       else
-        IO.println s!"Warning: recommended `curl` version ≥7.71. Found {v}. Can't use `--parallel`."
+        IO.println s!"Warning: recommended `curl` version ≥7.75. Found {v}. Can't use `--parallel`."
         return false
     | _ => throw <| IO.userError "Invalidly formatted version of `curl`"
   | _ => throw <| IO.userError "Invalidly formatted response from `curl --version`"

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -258,11 +258,13 @@ def validateCurl : IO Bool := do
           "-L", "-o", CURLBIN.toString]
         let _ ← runCmd "chmod" #["u+x", CURLBIN.toString]
         return true
-      if version >= (7, 70) then
+      -- The parallel download path passes `--retry-all-errors`, which
+      -- needs curl 7.71; an older curl rejects the whole command.
+      if version >= (7, 71) then
         IO.println s!"Warning: recommended `curl` version ≥7.81. Found {v}"
         return true
       else
-        IO.println s!"Warning: recommended `curl` version ≥7.70. Found {v}. Can't use `--parallel`."
+        IO.println s!"Warning: recommended `curl` version ≥7.71. Found {v}. Can't use `--parallel`."
         return false
     | _ => throw <| IO.userError "Invalidly formatted version of `curl`"
   | _ => throw <| IO.userError "Invalidly formatted response from `curl --version`"

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -225,16 +225,19 @@ where
       loop h (← processLine a line)
 
 /-- Runs a terminal command and retrieves its output -/
-def runCmd (cmd : String) (args : Array String) (throwFailure stderrAsErr := true) : IO String := do
+def runCmd (cmd : String) (args : Array String)
+    (throwFailure stderrAsErr showArgsOnError := true) : IO String := do
   let out ← IO.Process.output { cmd := cmd, args := args }
   if (out.exitCode != 0 || stderrAsErr && !out.stderr.isEmpty) && throwFailure then
-    throw <| IO.userError s!"failure in {cmd} {args}:\n{out.stderr}"
+    let invocation := if showArgsOnError then s!"{cmd} {args}" else cmd
+    throw <| IO.userError s!"failure in {invocation}:\n{out.stderr}"
   else if !out.stderr.isEmpty then
     IO.eprintln out.stderr
   return out.stdout
 
-def runCurl (args : Array String) (throwFailure stderrAsErr := true) : IO String := do
-  runCmd (← getCurl) (#["--no-progress-meter"] ++ args) throwFailure stderrAsErr
+def runCurl (args : Array String) (throwFailure stderrAsErr showArgsOnError := true) :
+    IO String := do
+  runCmd (← getCurl) (#["--no-progress-meter"] ++ args) throwFailure stderrAsErr showArgsOnError
 
 def validateCurl : IO Bool := do
   if (← CURLBIN.pathExists) then return true

--- a/Cache/Marker.lean
+++ b/Cache/Marker.lean
@@ -67,14 +67,16 @@ def uploadMarker (container : Container) (repo sha : String) (auth : UploadAuth)
   IO.FS.writeFile path s!"{sha}\n"
   let azureDateHeader ← getAzureDateHeader
   try
-    match auth with
-    | .azureSas token =>
-      let params := #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob"]
-      discard <| IO.runCurl <| params ++ #["-T", path.toString, s!"{url}?{token}"]
-    | .azureBearer token =>
-      let params := #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob", "-H",
-        azureBearerApiVersionHeader, "-H", azureDateHeader, "--oauth2-bearer", token]
-      discard <| IO.runCurl <| params ++ #["-T", path.toString, url]
+    let args := match auth with
+      | .azureSas token =>
+        #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob",
+          "-T", path.toString, s!"{url}?{token}"]
+      | .azureBearer token =>
+        #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob", "-H",
+          azureBearerApiVersionHeader, "-H", azureDateHeader, "--oauth2-bearer", token,
+          "-T", path.toString, url]
+    -- The argument list carries the credential; keep it out of the failure message.
+    discard <| IO.runCurl args (showArgsOnError := false)
   catch e =>
     IO.eprintln s!"warning: marker upload to {url} failed: {e}"
   IO.FS.removeFile path

--- a/Cache/Query.lean
+++ b/Cache/Query.lean
@@ -91,11 +91,11 @@ def probeContainerForSHA (container : Container) (repo sha : String) :
   let out ← IO.Process.output
     {cmd := (← IO.getCurl),
      args := #["-s", "-o", IO.nullDevice, "-w", "%{http_code}", "-I"] ++
-       -- `cache query` runs this probe without `validateCurl`, so it must
-       -- work on curls below 7.71.
-       curlFollowRedirectArgs ++ curlRetryArgs (supportLegacyCurl := true) ++
-       -- Time-bound each probe: the query walk makes up to 50 of them serially.
-       #["--connect-timeout", "10", "--max-time", "30", "--retry-max-time", "30", url],
+       -- No retry flags: the probe is diagnostic and a false negative is
+       -- cheap. The time bounds keep an unreachable endpoint from stalling
+       -- the up-to-50-probe `cache query` walk.
+       curlFollowRedirectArgs ++
+       #["--connect-timeout", "10", "--max-time", "30", url],
      cwd := "."}
   if out.exitCode != 0 then
     -- Network error; assume no cache at this SHA

--- a/Cache/Query.lean
+++ b/Cache/Query.lean
@@ -91,7 +91,9 @@ def probeContainerForSHA (container : Container) (repo sha : String) :
   let out ← IO.Process.output
     {cmd := (← IO.getCurl),
      args := #["-s", "-o", IO.nullDevice, "-w", "%{http_code}", "-I"] ++
-       curlFollowRedirectArgs ++ curlRetryArgs ++ #[url],
+       -- `cache query` runs this probe without `validateCurl`, so it must
+       -- work on curls below 7.71.
+       curlFollowRedirectArgs ++ curlRetryArgs (supportLegacyCurl := true) ++ #[url],
      cwd := "."}
   if out.exitCode != 0 then
     -- Network error; assume no cache at this SHA

--- a/Cache/Query.lean
+++ b/Cache/Query.lean
@@ -91,7 +91,7 @@ def probeContainerForSHA (container : Container) (repo sha : String) :
   let out ← IO.Process.output
     {cmd := (← IO.getCurl),
      args := #["-s", "-o", IO.nullDevice, "-w", "%{http_code}", "-I"] ++
-       curlFollowRedirectArgs ++ #[url],
+       curlFollowRedirectArgs ++ curlRetryArgs ++ #[url],
      cwd := "."}
   if out.exitCode != 0 then
     -- Network error; assume no cache at this SHA

--- a/Cache/Query.lean
+++ b/Cache/Query.lean
@@ -93,7 +93,9 @@ def probeContainerForSHA (container : Container) (repo sha : String) :
      args := #["-s", "-o", IO.nullDevice, "-w", "%{http_code}", "-I"] ++
        -- `cache query` runs this probe without `validateCurl`, so it must
        -- work on curls below 7.71.
-       curlFollowRedirectArgs ++ curlRetryArgs (supportLegacyCurl := true) ++ #[url],
+       curlFollowRedirectArgs ++ curlRetryArgs (supportLegacyCurl := true) ++
+       -- Time-bound each probe: the query walk makes up to 50 of them serially.
+       #["--connect-timeout", "10", "--max-time", "30", "--retry-max-time", "30", url],
      cwd := "."}
   if out.exitCode != 0 then
     -- Network error; assume no cache at this SHA

--- a/Cache/README.md
+++ b/Cache/README.md
@@ -287,7 +287,7 @@ Mathlib or `MathlibTest`. Exits 0 on success, non-zero on failure.
 
 The cache system automatically downloads and manages:
 
-- **curl** (>=7.71, preferably >=7.81) - for HTTP transfers
+- **curl** (>=7.75, preferably >=7.81) - for HTTP transfers
 - **leantar** - for `.ltar` compression/decompression
 
 If your system curl is too old, a static binary is downloaded automatically on Linux.

--- a/Cache/README.md
+++ b/Cache/README.md
@@ -287,7 +287,7 @@ Mathlib or `MathlibTest`. Exits 0 on success, non-zero on failure.
 
 The cache system automatically downloads and manages:
 
-- **curl** (>=7.70, preferably >=7.81) - for HTTP transfers
+- **curl** (>=7.71, preferably >=7.81) - for HTTP transfers
 - **leantar** - for `.ltar` compression/decompression
 
 If your system curl is too old, a static binary is downloaded automatically on Linux.

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -341,15 +341,15 @@ def curlFollowRedirectArgs : Array String :=
 
 /--
 `curl` retry flags for a cache transfer. `--retry` covers timeouts and
-408/429/5xx; `--retry-all-errors` adds transport errors, so a transfer that
-dies with its connection retries on a fresh one, with curl's exponential
-backoff. An HTTP 4xx is not a curl error, so a 404 miss never retries.
-`--retry-all-errors` needs curl >= 7.71, the `validateCurl` floor for
-parallel mode; the serial download path serves older curls and stays on
-plain `--retry`.
+408/429/5xx responses; every supported curl accepts it. With
+`supportLegacyCurl := false`, `--retry-all-errors` also retries transport
+errors: a transfer that dies with its connection retries on a fresh one,
+with exponential backoff. That flag needs curl 7.71, the `validateCurl`
+floor for parallel mode. Pass `supportLegacyCurl := true` on the paths that
+preserve compatibility with older versions of curl.
 -/
-def curlRetryArgs : Array String :=
-  #["--retry", "5", "--retry-all-errors"]
+def curlRetryArgs (supportLegacyCurl : Bool) : Array String :=
+  #["--retry", "5"] ++ (if supportLegacyCurl then #[] else #["--retry-all-errors"])
 
 /-- Authentication method used for cache upload operations. -/
 inductive UploadAuth where
@@ -478,10 +478,9 @@ def downloadFile (container : Option Container) (repo containerURL : String)
   let out ← IO.Process.output
     { cmd := (← IO.getCurl),
       args := #[url, "--silent"] ++ curlFollowRedirectArgs ++
-        -- Plain `--retry` only: this path serves the curls below 7.71 that
-        -- `validateCurl` keeps out of parallel mode, and they reject
-        -- `curlRetryArgs`.
-        #["--retry", "5", "--write-out", "%{http_code}", "-o", partPath.toString] }
+        -- This path serves curls below 7.71, which reject `--retry-all-errors`.
+        curlRetryArgs (supportLegacyCurl := true) ++
+        #["--write-out", "%{http_code}", "-o", partPath.toString] }
   -- The status decides, as on the parallel path: only a 200/201 body is a
   -- cache file. On any other answer the part file holds an error body, if
   -- one exists at all. A connection error reports status `000`.
@@ -745,7 +744,9 @@ private def downloadFilesFromContainer
   if parallel then
     IO.FS.writeFile IO.CURLCFG (← mkGetConfigContent container repo containerURL hashMap scope?)
     let args := #["--request", "GET", "--parallel", "--silent"] ++
-      curlFollowRedirectArgs ++ curlRetryArgs ++
+      -- Avoid passing `--fail` here: it slows parallel transfers on curl
+      -- 8.13.0, and it makes `--retry-all-errors` retry every 404 miss.
+      curlFollowRedirectArgs ++ curlRetryArgs (supportLegacyCurl := false) ++
       #["--write-out", "%{json}\n", "--config", IO.CURLCFG.toString]
     -- `legacy` answers reads with 403 once its public access is revoked ahead
     -- of retirement; treat that as a miss so the chain stays quiet for clients
@@ -1146,7 +1147,8 @@ def putFilesAbsolute
     -- A retry after a PUT that landed is safe: a non-overwrite put answers
     -- it with 409/412, which `treatExistsAsSkip` excuses, and an overwrite
     -- put re-sends the same bytes.
-    let args := args ++ #["-X", "PUT", "--parallel"] ++ curlRetryArgs ++
+    let args := args ++ #["-X", "PUT", "--parallel"] ++
+      curlRetryArgs (supportLegacyCurl := false) ++
       #["--write-out", "%{json}\n", "--config", tempConfigFilePath.toString]
     let (s, _) ← monitorCurl args size "Uploaded" "speed_upload" (removeOnError := false)
       (decompConfig := none) (treatExistsAsSkip := !overwrite)

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -1285,20 +1285,22 @@ def commit (container : Option Container) (hashMap : IO.ModuleHashMap) (overwrit
   -- Commit files are never namespaced by repo (they always live at `/c/<hash>`),
   -- so we only need the URL from `effectiveUploadURL`, not the URL-shape container.
   let (_, uploadURL) ← effectiveUploadURL container
-  match auth with
-  | .azureSas token =>
-    let params := if overwrite
-      then #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob"]
-      else #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob", "-H", "If-None-Match: *"]
-    discard <| IO.runCurl <| params ++ #["-T", path.toString, s!"{uploadURL}/c/{hash}?{token}"]
-  | .azureBearer token =>
-    let params := if overwrite
-      then #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob", "-H", azureBearerApiVersionHeader,
-        "-H", azureDateHeader,
-        "--oauth2-bearer", token]
-      else #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob", "-H", "If-None-Match: *", "-H",
-        azureBearerApiVersionHeader, "-H", azureDateHeader, "--oauth2-bearer", token]
-    discard <| IO.runCurl <| params ++ #["-T", path.toString, s!"{uploadURL}/c/{hash}"]
+  let args := match auth with
+    | .azureSas token =>
+      let params := if overwrite
+        then #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob"]
+        else #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob", "-H", "If-None-Match: *"]
+      params ++ #["-T", path.toString, s!"{uploadURL}/c/{hash}?{token}"]
+    | .azureBearer token =>
+      let params := if overwrite
+        then #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob", "-H", azureBearerApiVersionHeader,
+          "-H", azureDateHeader,
+          "--oauth2-bearer", token]
+        else #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob", "-H", "If-None-Match: *", "-H",
+          azureBearerApiVersionHeader, "-H", azureDateHeader, "--oauth2-bearer", token]
+      params ++ #["-T", path.toString, s!"{uploadURL}/c/{hash}"]
+  -- The argument list carries the credential; keep it out of the failure message.
+  discard <| IO.runCurl args (showArgsOnError := false)
   IO.FS.removeFile path
 
 end Commit

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -341,12 +341,11 @@ def curlFollowRedirectArgs : Array String :=
 
 /--
 `curl` retry flags for a cache transfer. `--retry` covers timeouts and
-408/429/5xx responses; every supported curl accepts it. With
+408/429/5xx; every supported curl accepts it. With
 `supportLegacyCurl := false`, `--retry-all-errors` also retries transport
-errors: a transfer that dies with its connection retries on a fresh one,
-with exponential backoff. That flag needs curl 7.71, the `validateCurl`
-floor for parallel mode. Pass `supportLegacyCurl := true` on the paths that
-preserve compatibility with older versions of curl.
+errors on a fresh connection, with exponential backoff. That flag needs
+curl 7.71, the `validateCurl` floor for parallel mode; pass
+`supportLegacyCurl := true` on paths that must work on older curls.
 -/
 def curlRetryArgs (supportLegacyCurl : Bool) : Array String :=
   #["--retry", "5"] ++ (if supportLegacyCurl then #[] else #["--retry-all-errors"])
@@ -453,15 +452,63 @@ per-file transfer failure. Any other status is a real failure.
 def isCacheMissStatus (httpCode : Nat) (treatForbiddenAsMiss : Bool) : Bool :=
   httpCode == 404 || (httpCode == 403 && treatForbiddenAsMiss)
 
-/-- Outcome of a single serial download: the file arrived (`served`), the server
-returned a cache miss that should fall through to the next container (`miss`), or
-the transfer failed for another reason that should drive the exit code
-(`failed`). The parallel path draws the same distinction through
-`TransferState.failed` and `isCacheMissStatus`. -/
-inductive DownloadOutcome
-  | served
-  | miss
-  | failed
+/--
+Whether an HTTP status is the one Azure returns for a blob that already exists,
+which a non-overwrite `put` (`If-None-Match: *`) hits when it declines to
+overwrite. Azure reports it as 409 (the `BlobAlreadyExists` error, what it
+returns in practice) or 412 (the conditional-header spec's code for an unmet
+`If-None-Match`), so we accept both. Whether that's benign is the caller's call:
+the upload path skips it, reads don't.
+-/
+def isAlreadyPresentStatus (httpCode : Nat) : Bool :=
+  httpCode == 409 || httpCode == 412
+
+/-- Direction of a cache transfer. -/
+inductive TransferDirection where
+  | download
+  | upload
+  deriving Repr, DecidableEq
+
+/-- What one finished transfer amounts to. The index restricts each verdict to
+the direction where it has meaning. -/
+inductive TransferVerdict : TransferDirection → Type where
+  /-- The transfer completed in full. -/
+  | delivered {d : TransferDirection} : TransferVerdict d
+  /-- The server does not have the file; not an error. -/
+  | miss : TransferVerdict .download
+  /-- The server already has the file, so there is nothing to transfer; not an
+  error. -/
+  | skip : TransferVerdict .upload
+  /-- The transfer failed. -/
+  | failed {d : TransferDirection} : TransferVerdict d
+  deriving Repr, DecidableEq
+
+/--
+Classify one finished download; the parallel and serial paths share this
+table. A transfer delivers only when the status is 200/201 and curl exited
+cleanly: a nonzero exit code after a 200 means the body is truncated. The
+status alone decides a miss. `httpCode?` is `none` when there is no status
+to parse; `treatForbiddenAsMiss` is the `legacy` 403 policy.
+-/
+def classifyDownload (httpCode? : Option Nat) (exitCode : Nat)
+    (treatForbiddenAsMiss : Bool) : TransferVerdict .download :=
+  match httpCode? with
+  | some 200 | some 201 => if exitCode == 0 then .delivered else .failed
+  | some code => if isCacheMissStatus code treatForbiddenAsMiss then .miss else .failed
+  | none => .failed
+
+/--
+Classify one finished upload. A transfer delivers only on a clean 200/201,
+as in `classifyDownload`. With `treatExistsAsSkip` (a non-overwrite put), a
+409/412 is a skip: the blob is already on the server. Every other answer, a
+404 included, is a failure.
+-/
+def classifyUpload (httpCode? : Option Nat) (exitCode : Nat)
+    (treatExistsAsSkip : Bool) : TransferVerdict .upload :=
+  match httpCode? with
+  | some 200 | some 201 => if exitCode == 0 then .delivered else .failed
+  | some code => if treatExistsAsSkip && isAlreadyPresentStatus code then .skip else .failed
+  | none => .failed
 
 /-- Calls `curl` to download a single file from a specific container to `CACHEDIR`
 (`.cache`). `scope?` is the per-round SHA scope (see `mkGetConfigContent`).
@@ -469,7 +516,7 @@ inductive DownloadOutcome
 access revoked ahead of retirement) is a miss, not a failure. -/
 def downloadFile (container : Option Container) (repo containerURL : String)
     (hash : UInt64) (scope? : Option String) (treatForbiddenAsMiss : Bool := false) :
-    IO DownloadOutcome := do
+    IO (TransferVerdict .download) := do
   let fileName := hash.asLTar
   let url := mkFileURL container repo containerURL fileName scope?
   let path := IO.CACHEDIR / fileName
@@ -481,16 +528,14 @@ def downloadFile (container : Option Container) (repo containerURL : String)
         -- This path serves curls below 7.71, which reject `--retry-all-errors`.
         curlRetryArgs (supportLegacyCurl := true) ++
         #["--write-out", "%{http_code}", "-o", partPath.toString] }
-  -- The status decides, as on the parallel path: only a 200/201 body is a
-  -- cache file. On any other answer the part file holds an error body, if
-  -- one exists at all. A connection error reports status `000`.
-  let httpCode := out.stdout.trimAscii.toNat?.getD 0
-  if out.exitCode = 0 && (httpCode == 200 || httpCode == 201) then
+  -- Anything short of a delivery leaves at most an error body in the part file.
+  let verdict := classifyDownload out.stdout.trimAscii.toNat? out.exitCode.toNat
+    treatForbiddenAsMiss
+  if verdict matches .delivered then
     IO.FS.rename partPath path
-    return .served
-  if ← partPath.pathExists then
+  else if ← partPath.pathExists then
     IO.FS.removeFile partPath
-  return if isCacheMissStatus httpCode treatForbiddenAsMiss then .miss else .failed
+  return verdict
 
 /-- Extract hash from filename (e.g., "/path/to/.cache/00012345.ltar" → 0x12345).
     Handles a finished `<hash>.ltar`, an in-flight `<hash>.ltar<PARTSUFFIX>`, and a
@@ -591,23 +636,11 @@ def finalizeDecomp (state : DecompState) (config : DecompConfig) : IO (Nat × Na
       decompFailed := decompFailed + pending.size
   return (decompressed, decompFailed)
 
-/--
-Whether an HTTP status is the one Azure returns for a blob that already exists,
-which a non-overwrite `put` (`If-None-Match: *`) hits when it declines to
-overwrite. Azure reports it as 409 (the `BlobAlreadyExists` error, what it
-returns in practice) or 412 (the conditional-header spec's code for an unmet
-`If-None-Match`), so we accept both. Whether that's benign is the caller's call:
-the upload path skips it, reads don't.
--/
-def isAlreadyPresentStatus (httpCode : Nat) : Bool :=
-  httpCode == 409 || httpCode == 412
-
-def monitorCurl (args : Array String) (size : Nat)
-    (caption : String) (speedVar : String) (removeOnError := false)
+def monitorCurl {dir : TransferDirection} (args : Array String) (size : Nat)
+    (caption : String) (speedVar : String)
+    (classify : Option Nat → Nat → TransferVerdict dir) (removeOnError := false)
     (decompConfig : Option DecompConfig := none)
-    (decompState : DecompState := {})
-    (treatForbiddenAsMiss : Bool := false)
-    (treatExistsAsSkip : Bool := false) : IO (TransferState × Std.HashSet UInt64) := do
+    (decompState : DecompState := {}) : IO (TransferState × Std.HashSet UInt64) := do
   let useAnsi := (← IO.getEnv "TERM").isSome
   -- Hashes of the files this pass fetched, used to decide what the next
   -- container in the chain still needs to retry.
@@ -633,15 +666,19 @@ def monitorCurl (args : Array String) (size : Nat)
   let s ← IO.runCurlStreaming args init fun a line => do
     let mut {last, success, failed, done, speed, decomp} := a
     let mut {pending, currentTask, lastBatchSize, decompressed, decompFailed} := decomp
-    -- output errors other than 404 and remove corresponding partial downloads
+    -- Classify each finished transfer: rename a delivered part file, report a
+    -- failure, and remove the part file on any non-delivery.
     let line := line.trimAscii
     if !line.isEmpty then
       match Lean.Json.parse line.copy with
       | .ok result =>
-        match result.getObjValAs? Nat "http_code" with
-        | .ok 200
-        | .ok 201 =>
-          if let .ok fn := result.getObjValAs? String "filename_effective" then
+        let code? := result.getObjValAs? Nat "http_code"
+        let fn? := result.getObjValAs? String "filename_effective"
+        -- `exitcode` joined `%{json}` in curl 7.75; an absent field reads as 0.
+        let exitCode := (result.getObjValAs? Nat "exitcode").toOption.getD 0
+        let verdict := classify code?.toOption exitCode
+        if verdict matches .delivered then
+          if let .ok fn := fn? then
             -- Match this process's own suffix, not a bare `.part`: a concurrent run's
             -- in-flight file is not ours to rename, and curl only reports our transfers.
             if (← System.FilePath.pathExists fn) && fn.endsWith IO.PARTSUFFIX then
@@ -679,17 +716,8 @@ def monitorCurl (args : Array String) (size : Nat)
                   currentTask ← dispatchDecompBatch pending config
                   pending := #[]
           success := success + 1
-        -- A cache miss (404, or 403 from a retiring `legacy`) just falls through
-        -- to the next container; a blob already on the server (409/412 from a
-        -- non-overwrite put) is expected, not a failure; anything else fails.
-        | code? =>
-          let alreadyPresent := match code? with
-            | .ok c     => isAlreadyPresentStatus c
-            | .error _  => false
-          let isMiss := match code? with
-            | .ok c     => isCacheMissStatus c treatForbiddenAsMiss
-            | .error _  => false
-          unless isMiss || (treatExistsAsSkip && alreadyPresent) do
+        else
+          if verdict matches .failed then
             failed := failed + 1
             let mkFailureMsg code? fn? msg? : String := Id.run do
               let mut msg := "Transfer failed"
@@ -697,17 +725,20 @@ def monitorCurl (args : Array String) (size : Nat)
                 msg := s!"{fn}: {msg}"
               if let .ok code := code? then
                 msg := s!"{msg} (error code: {code})"
+              if exitCode != 0 then
+                msg := s!"{msg} (curl exit code: {exitCode})"
               if let .ok errMsg := msg? then
                 msg := s!"{msg}: {errMsg}"
               return msg
             let msg? := result.getObjValAs? String "errormsg"
-            let fn? :=  result.getObjValAs? String "filename_effective"
             IO.println (mkFailureMsg code? fn? msg?)
+          -- The part file holds a truncated body (failure) or an error body
+          -- (miss); remove it either way.
+          if removeOnError then
             if let .ok fn := fn? then
-              if removeOnError then
-                -- `curl --remove-on-error` can already do this, but only from 7.83 onwards
-                if (← System.FilePath.pathExists fn) then
-                  IO.FS.removeFile fn
+              -- `curl --remove-on-error` can already do this, but only from 7.83 onwards
+              if (← System.FilePath.pathExists fn) && fn.endsWith IO.PARTSUFFIX then
+                IO.FS.removeFile fn
         done := done + 1
         let now ← IO.monoMsNow
         if now - last ≥ 100 then -- max 10/s update rate
@@ -752,8 +783,9 @@ private def downloadFilesFromContainer
     -- of retirement; treat that as a miss so the chain stays quiet for clients
     -- whose chain still lists it.
     let treatForbiddenAsMiss := container == some Container.legacy
-    let (s, served) ← monitorCurl args size "Downloaded" "speed_download" (removeOnError := true)
-      decompConfig decompState (treatForbiddenAsMiss := treatForbiddenAsMiss)
+    let (s, served) ← monitorCurl args size "Downloaded" "speed_download"
+      (classifyDownload · · treatForbiddenAsMiss) (removeOnError := true)
+      decompConfig decompState
     IO.FS.removeFile IO.CURLCFG
     return (s, served)
   else
@@ -769,7 +801,7 @@ private def downloadFilesFromContainer
     let (served, failed) := r.foldl (init := ((∅ : Std.HashSet UInt64), 0))
       fun (served, failed) (hash, t) =>
         match t.get with
-        | .ok .served => (served.insert hash, failed)
+        | .ok .delivered => (served.insert hash, failed)
         | .ok .miss => (served, failed)
         | _ => (served, failed + 1)
     return ({ failed, decomp := decompState }, served)
@@ -1145,13 +1177,13 @@ def putFilesAbsolute
           #["-H", "x-ms-blob-type: BlockBlob", "-H", "If-None-Match: *", "-H",
             azureBearerApiVersionHeader, "-H", azureDateHeader, "--oauth2-bearer", token]
     -- A retry after a PUT that landed is safe: a non-overwrite put answers
-    -- it with 409/412, which `treatExistsAsSkip` excuses, and an overwrite
+    -- it with 409/412, which `classifyUpload` excuses, and an overwrite
     -- put re-sends the same bytes.
     let args := args ++ #["-X", "PUT", "--parallel"] ++
       curlRetryArgs (supportLegacyCurl := false) ++
       #["--write-out", "%{json}\n", "--config", tempConfigFilePath.toString]
-    let (s, _) ← monitorCurl args size "Uploaded" "speed_upload" (removeOnError := false)
-      (decompConfig := none) (treatExistsAsSkip := !overwrite)
+    let (s, _) ← monitorCurl args size "Uploaded" "speed_upload"
+      (classifyUpload · · !overwrite) (removeOnError := false) (decompConfig := none)
     IO.FS.removeFile tempConfigFilePath
     -- Surface genuine upload failures. Already-present blobs (409/412 on a
     -- non-overwrite put) are excused in `monitorCurl`, so this won't trip on a

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -344,7 +344,8 @@ def curlFollowRedirectArgs : Array String :=
 408/429/5xx; every supported curl accepts it. With
 `supportLegacyCurl := false`, `--retry-all-errors` also retries transport
 errors on a fresh connection, with exponential backoff. That flag needs
-curl 7.71, the `validateCurl` floor for parallel mode; pass
+curl 7.71; `validateCurl` gates parallel mode at 7.75, which also
+guarantees the per-transfer JSON report fields `monitorCurl` reads. Pass
 `supportLegacyCurl := true` on paths that must work on older curls.
 -/
 def curlRetryArgs (supportLegacyCurl : Bool) : Array String :=

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -469,6 +469,11 @@ inductive TransferDirection where
   | upload
   deriving Repr, DecidableEq
 
+instance : ToString TransferDirection where
+  toString
+    | .download => "download"
+    | .upload => "upload"
+
 /-- What one finished transfer amounts to. The index restricts each verdict to
 the direction where it has meaning. -/
 inductive TransferVerdict : TransferDirection → Type where
@@ -657,7 +662,7 @@ def monitorCurl {dir : TransferDirection} (args : Array String) (size : Nat)
       if s.decomp.decompFailed != 0 then
         msg := msg ++ s!" ({s.decomp.decompFailed} failed)"
     if s.failed != 0 then
-      msg := msg ++ s!", {s.failed} download failed"
+      msg := msg ++ s!", {s.failed} {dir} failed"
     -- Clear to end of line to avoid remnants from longer previous messages
     if useAnsi then
       msg := msg ++ "\x1b[K"
@@ -674,7 +679,8 @@ def monitorCurl {dir : TransferDirection} (args : Array String) (size : Nat)
       | .ok result =>
         let code? := result.getObjValAs? Nat "http_code"
         let fn? := result.getObjValAs? String "filename_effective"
-        -- `exitcode` joined `%{json}` in curl 7.75; an absent field reads as 0.
+        -- The per-transfer JSON report carries `exitcode` from curl 7.75 on;
+        -- an absent field reads as 0.
         let exitCode := (result.getObjValAs? Nat "exitcode").toOption.getD 0
         let verdict := classify code?.toOption exitCode
         if verdict matches .delivered then
@@ -731,7 +737,14 @@ def monitorCurl {dir : TransferDirection} (args : Array String) (size : Nat)
                 msg := s!"{msg}: {errMsg}"
               return msg
             let msg? := result.getObjValAs? String "errormsg"
-            IO.println (mkFailureMsg code? fn? msg?)
+            -- A download is named by its part file, an upload by its URL —
+            -- query-stripped: a SAS put carries its token there.
+            let src? : Except String String := match dir with
+              | .download => fn?
+              | .upload =>
+                (result.getObjValAs? String "url_effective").map
+                  fun url => (url.splitOn "?").headD url
+            IO.println (mkFailureMsg code? src? msg?)
           -- The part file holds a truncated body (failure) or an error body
           -- (miss); remove it either way.
           if removeOnError then
@@ -1143,7 +1156,10 @@ def mkPutConfigContent (container : Option Container) (repo uploadURL : String)
     | .azureSas token => s!"?{token}"
     | _ => ""
   let l ← files.toList.mapM fun file : FilePath => do
-    pure s!"-T {file.toString}\nurl = {mkFileURL container repo uploadURL file.fileName.get! scope?}{token}"
+    -- The response body goes to the null device: stdout must carry only the
+    -- per-transfer JSON reports that `monitorCurl` parses.
+    pure s!"-T {file.toString}\nurl = {mkFileURL container repo uploadURL file.fileName.get! scope?}{token}\n\
+      -o {IO.nullDevice}"
   return "\n".intercalate l
 
 /-- Calls `curl` to send a set of files to the server. The destination container
@@ -1181,7 +1197,10 @@ def putFilesAbsolute
     -- put re-sends the same bytes.
     let args := args ++ #["-X", "PUT", "--parallel"] ++
       curlRetryArgs (supportLegacyCurl := false) ++
-      #["--write-out", "%{json}\n", "--config", tempConfigFilePath.toString]
+      -- `%{json}` prints a JSON report for each finished transfer. The
+      -- leading newline keeps each report on its own line even if something
+      -- else reaches stdout ahead of it.
+      #["--write-out", "\n%{json}\n", "--config", tempConfigFilePath.toString]
     let (s, _) ← monitorCurl args size "Uploaded" "speed_upload"
       (classifyUpload · · !overwrite) (removeOnError := false) (decompConfig := none)
     IO.FS.removeFile tempConfigFilePath

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -339,6 +339,18 @@ plaintext protocol or through a long chain of hops.
 def curlFollowRedirectArgs : Array String :=
   #["--location", "--proto-redir", "=https", "--max-redirs", "5"]
 
+/--
+`curl` retry flags for a cache transfer. `--retry` covers timeouts and
+408/429/5xx; `--retry-all-errors` adds transport errors, so a transfer that
+dies with its connection retries on a fresh one, with curl's exponential
+backoff. An HTTP 4xx is not a curl error, so a 404 miss never retries.
+`--retry-all-errors` needs curl >= 7.71, the `validateCurl` floor for
+parallel mode; the serial download path serves older curls and stays on
+plain `--retry`.
+-/
+def curlRetryArgs : Array String :=
+  #["--retry", "5", "--retry-all-errors"]
+
 /-- Authentication method used for cache upload operations. -/
 inductive UploadAuth where
   | azureSas (token : String)
@@ -465,15 +477,20 @@ def downloadFile (container : Option Container) (repo containerURL : String)
   let partPath := IO.CACHEDIR / partFileName
   let out ← IO.Process.output
     { cmd := (← IO.getCurl),
-      args := #[url, "--fail", "--silent"] ++ curlFollowRedirectArgs ++
-        #["--write-out", "%{http_code}", "-o", partPath.toString] }
-  if out.exitCode = 0 then
+      args := #[url, "--silent"] ++ curlFollowRedirectArgs ++
+        -- Plain `--retry` only: this path serves the curls below 7.71 that
+        -- `validateCurl` keeps out of parallel mode, and they reject
+        -- `curlRetryArgs`.
+        #["--retry", "5", "--write-out", "%{http_code}", "-o", partPath.toString] }
+  -- The status decides, as on the parallel path: only a 200/201 body is a
+  -- cache file. On any other answer the part file holds an error body, if
+  -- one exists at all. A connection error reports status `000`.
+  let httpCode := out.stdout.trimAscii.toNat?.getD 0
+  if out.exitCode = 0 && (httpCode == 200 || httpCode == 201) then
     IO.FS.rename partPath path
     return .served
-  IO.FS.removeFile partPath
-  -- `--fail` exits nonzero on any HTTP error; the written-out status tells a 404
-  -- miss apart from a real transfer failure (a connection error reports `000`).
-  let httpCode := out.stdout.trimAscii.toNat?.getD 0
+  if ← partPath.pathExists then
+    IO.FS.removeFile partPath
   return if isCacheMissStatus httpCode treatForbiddenAsMiss then .miss else .failed
 
 /-- Extract hash from filename (e.g., "/path/to/.cache/00012345.ltar" → 0x12345).
@@ -727,11 +744,9 @@ private def downloadFilesFromContainer
   let size := hashMap.size
   if parallel then
     IO.FS.writeFile IO.CURLCFG (← mkGetConfigContent container repo containerURL hashMap scope?)
-    let args := #["--request", "GET", "--parallel",
-        -- commented as this creates a big slowdown on curl 8.13.0: "--fail",
-        "--silent"] ++ curlFollowRedirectArgs ++
-      #["--retry", "5", -- there seem to be some intermittent failures
-        "--write-out", "%{json}\n", "--config", IO.CURLCFG.toString]
+    let args := #["--request", "GET", "--parallel", "--silent"] ++
+      curlFollowRedirectArgs ++ curlRetryArgs ++
+      #["--write-out", "%{json}\n", "--config", IO.CURLCFG.toString]
     -- `legacy` answers reads with 403 once its public access is revoked ahead
     -- of retirement; treat that as a miss so the chain stays quiet for clients
     -- whose chain still lists it.
@@ -1128,10 +1143,11 @@ def putFilesAbsolute
         else
           #["-H", "x-ms-blob-type: BlockBlob", "-H", "If-None-Match: *", "-H",
             azureBearerApiVersionHeader, "-H", azureDateHeader, "--oauth2-bearer", token]
-    let args := args ++ #[
-      "-X", "PUT", "--parallel",
-      "--retry", "5", -- there seem to be some intermittent failures
-      "--write-out", "%{json}\n", "--config", tempConfigFilePath.toString]
+    -- A retry after a PUT that landed is safe: a non-overwrite put answers
+    -- it with 409/412, which `treatExistsAsSkip` excuses, and an overwrite
+    -- put re-sends the same bytes.
+    let args := args ++ #["-X", "PUT", "--parallel"] ++ curlRetryArgs ++
+      #["--write-out", "%{json}\n", "--config", tempConfigFilePath.toString]
     let (s, _) ← monitorCurl args size "Uploaded" "speed_upload" (removeOnError := false)
       (decompConfig := none) (treatExistsAsSkip := !overwrite)
     IO.FS.removeFile tempConfigFilePath

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -1129,6 +1129,16 @@ def test_classifyDownload : IO Unit := do
   assertTrue "no status fails"
     (classifyDownload none 0 false matches .failed)
 
+/-- The put config discards every response body: stdout must carry only the
+per-transfer JSON reports (`--write-out '%{json}'`) that `monitorCurl`
+parses. -/
+def test_mkPutConfigContent : IO Unit := do
+  IO.println "mkPutConfigContent:"
+  let cfg ← mkPutConfigContent (some .master) MATHLIBREPO "https://example.invalid"
+    #["/tmp/00000000deadbeef.ltar"] (.azureSas "tok")
+  assertTrue "uploads the file" ((cfg.splitOn "-T /tmp/00000000deadbeef.ltar").length == 2)
+  assertTrue "discards the response body" ((cfg.splitOn s!"-o {IO.nullDevice}").length == 2)
+
 /-- `classifyUpload`: a clean 200/201 delivers, a 409/412 skips for a
 non-overwrite put, and every other answer — a 404 included — is a failure. -/
 def test_classifyUpload : IO Unit := do
@@ -1312,6 +1322,7 @@ def runAll : IO Unit := do
   test_isAlreadyPresentStatus
   test_classifyDownload
   test_classifyUpload
+  test_mkPutConfigContent
   test_expandDownloadRounds
   test_finalizeDecomp
   test_monitorCurl_carries_decomp_state

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -1040,8 +1040,8 @@ end ReadRedirects
 section RetryFlags
 
 /-- Only a path with a curl 7.71 floor may pass `--retry-all-errors`; an older
-curl rejects the whole command. The legacy tier serves the serial download path
-and the marker probe, so it must stay free of that flag. -/
+curl rejects the whole command. The legacy tier serves the serial download
+path, so it must stay free of that flag. -/
 def test_curlRetryArgs : IO Unit := do
   IO.println "curlRetryArgs:"
   assertEq "legacy tier" "--retry 5"

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -23,6 +23,9 @@ These tests cover the pure logic of the cache system, including:
   non-default-scope security warning it triggers
 - Decompression-pipeline carry across download rounds (`DecompState`,
   `finalizeDecomp`, `monitorCurl`)
+- Transfer classification (`classifyDownload`/`classifyUpload`): delivered,
+  miss, skip, or failed, per HTTP status and curl exit code
+- The two retry-flag tiers (`curlRetryArgs`)
 - Utility functions (URL extraction, filename hashing, etc.)
 
 Anything that touches the network is left to CI, which exercises the
@@ -1034,6 +1037,20 @@ def test_curlFollowRedirectArgs : IO Unit := do
 
 end ReadRedirects
 
+section RetryFlags
+
+/-- Only a path with a curl 7.71 floor may pass `--retry-all-errors`; an older
+curl rejects the whole command. The legacy tier serves the serial download path
+and the marker probe, so it must stay free of that flag. -/
+def test_curlRetryArgs : IO Unit := do
+  IO.println "curlRetryArgs:"
+  assertEq "legacy tier" "--retry 5"
+    (" ".intercalate (curlRetryArgs (supportLegacyCurl := true)).toList)
+  assertEq "full tier" "--retry 5 --retry-all-errors"
+    (" ".intercalate (curlRetryArgs (supportLegacyCurl := false)).toList)
+
+end RetryFlags
+
 section CacheMissStatus
 
 /-- `isCacheMissStatus` decides whether a read's HTTP status is a benign miss
@@ -1076,6 +1093,62 @@ def test_isAlreadyPresentStatus : IO Unit := do
   assertTrue "500 is not already-present" (!isAlreadyPresentStatus 500)
 
 end AlreadyPresentStatus
+
+section TransferClassification
+
+/-- `classifyDownload` is the decision table shared by the parallel and serial
+download paths. The clean-exit rows guard against renaming a truncated body: a
+transport error that outlives the retries reports `http_code: 200` with a
+nonzero `exitcode`. -/
+def test_classifyDownload : IO Unit := do
+  IO.println "classifyDownload:"
+  -- A clean 200/201 delivers.
+  assertTrue "200 + exit 0 delivers"
+    (classifyDownload (some 200) 0 false matches .delivered)
+  assertTrue "201 + exit 0 delivers"
+    (classifyDownload (some 201) 0 false matches .delivered)
+  -- A 200 with a nonzero exit code carries a truncated body.
+  assertTrue "200 + exit 18 fails"
+    (classifyDownload (some 200) 18 false matches .failed)
+  assertTrue "201 + exit 18 fails"
+    (classifyDownload (some 201) 18 false matches .failed)
+  -- The status alone decides a miss.
+  assertTrue "404 is a miss"
+    (classifyDownload (some 404) 0 false matches .miss)
+  assertTrue "404 + nonzero exit is still a miss"
+    (classifyDownload (some 404) 18 false matches .miss)
+  assertTrue "403 is a miss with treatForbiddenAsMiss"
+    (classifyDownload (some 403) 0 true matches .miss)
+  assertTrue "403 fails otherwise"
+    (classifyDownload (some 403) 0 false matches .failed)
+  assertTrue "409 fails on a read"
+    (classifyDownload (some 409) 0 false matches .failed)
+  -- No usable status is a failure (a connection error reports `000`).
+  assertTrue "status 0 fails"
+    (classifyDownload (some 0) 0 false matches .failed)
+  assertTrue "no status fails"
+    (classifyDownload none 0 false matches .failed)
+
+/-- `classifyUpload`: a clean 200/201 delivers, a 409/412 skips for a
+non-overwrite put, and every other answer — a 404 included — is a failure. -/
+def test_classifyUpload : IO Unit := do
+  IO.println "classifyUpload:"
+  assertTrue "201 + exit 0 delivers"
+    (classifyUpload (some 201) 0 false matches .delivered)
+  assertTrue "201 + exit 18 fails"
+    (classifyUpload (some 201) 18 false matches .failed)
+  assertTrue "409 skips on a non-overwrite put"
+    (classifyUpload (some 409) 0 true matches .skip)
+  assertTrue "412 skips on a non-overwrite put"
+    (classifyUpload (some 412) 0 true matches .skip)
+  assertTrue "409 fails on an overwrite put"
+    (classifyUpload (some 409) 0 false matches .failed)
+  assertTrue "404 fails"
+    (classifyUpload (some 404) 0 true matches .failed)
+  assertTrue "no status fails"
+    (classifyUpload none 0 true matches .failed)
+
+end TransferClassification
 
 section UnsafeRounds
 
@@ -1191,7 +1264,8 @@ def test_monitorCurl_carries_decomp_state : IO Unit := do
     decompressed := 42
     decompFailed := 1 }
   let (s, served) ← withSuppressedOutput <|
-    monitorCurl #["--version"] 1 "Downloaded" "speed_download" (decompState := carried)
+    monitorCurl #["--version"] 1 "Downloaded" "speed_download"
+      (classifyDownload · · false) (decompState := carried)
   assertTrue "no transfers → an empty served set" served.isEmpty
   assertTrue "pending files survive the round" (s.decomp.pending.size == 1)
   assertTrue "the in-flight task survives the round" s.decomp.currentTask.isSome
@@ -1233,8 +1307,11 @@ def runAll : IO Unit := do
   test_parseNamedOpt
   test_parseFlagOpt
   test_curlFollowRedirectArgs
+  test_curlRetryArgs
   test_isCacheMissStatus
   test_isAlreadyPresentStatus
+  test_classifyDownload
+  test_classifyUpload
   test_expandDownloadRounds
   test_finalizeDecomp
   test_monitorCurl_carries_decomp_state

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -1051,6 +1051,29 @@ def test_curlRetryArgs : IO Unit := do
 
 end RetryFlags
 
+section RunCmdErrors
+
+/-- With `showArgsOnError := false` a failing command's error names only the
+command: the argument list can carry a credential (the marker uploads pass
+`--oauth2-bearer` and SAS-tokened URLs). The default keeps the argument list
+in the message. -/
+def test_runCmd_showArgsOnError : IO Unit := do
+  IO.println "runCmd showArgsOnError:"
+  let secret := "hunter2-credential"
+  let hidden ← try
+      discard <| IO.runCmd "curl" #["--not-a-curl-flag", secret] (showArgsOnError := false)
+      pure "no failure"
+    catch e => pure (toString e)
+  assertTrue "the failure throws" (hidden != "no failure")
+  assertTrue "the message hides the arguments" ((hidden.splitOn secret).length == 1)
+  let shown ← try
+      discard <| IO.runCmd "curl" #["--not-a-curl-flag", secret]
+      pure "no failure"
+    catch e => pure (toString e)
+  assertTrue "the default shows the arguments" ((shown.splitOn secret).length == 2)
+
+end RunCmdErrors
+
 section CacheMissStatus
 
 /-- `isCacheMissStatus` decides whether a read's HTTP status is a benign miss
@@ -1318,6 +1341,7 @@ def runAll : IO Unit := do
   test_parseFlagOpt
   test_curlFollowRedirectArgs
   test_curlRetryArgs
+  test_runCmd_showArgsOnError
   test_isCacheMissStatus
   test_isAlreadyPresentStatus
   test_classifyDownload


### PR DESCRIPTION
Since CI cache reads moved to `cache.mathlib.org` (#42777), the transport is HTTP/2: one connection carries many parallel transfers, and a dropped connection fails them all at once with `Send failure: Broken pipe`. curl's `--retry` does not cover transport errors, so a short network fault fails the job. Seven bors runs failed this way in six days ([example](https://github.com/leanprover-community/mathlib4/actions/runs/32578053250/job/97043588851): 14 of 8750 files, one connection); the same step failed zero times in the previous four weeks (429 runs).

Fix: `--retry 5 --retry-all-errors` on the parallel download path and the upload path (`curlRetryArgs`). curl retries a failed transfer on a fresh connection, with exponential backoff. An HTTP 4xx is not a curl error on these paths, so a 404 miss never retries and the container fallback works as before.

- The serial download path keeps plain `--retry 5`: it serves curls below 7.71, which reject `--retry-all-errors`. It now drops `--fail` and decides by the written-out status, like the parallel path, so no download path treats a miss as an error.
- The marker probe keeps no retry flags: it is diagnostic, a false negative is cheap, and retry backoff would stall the up-to-50-probe `cache query` walk against an unreachable endpoint. It adds `--connect-timeout 10 --max-time 30` as time bounds.
- A retried PUT is safe: a non-overwrite put sends `If-None-Match: *`, and a duplicate answers 409/412, which the upload path already excuses.
- `validateCurl` raises the parallel-mode floor to curl 7.75: `--retry-all-errors` needs 7.71, and the per-transfer JSON report carries `exitcode` and `errormsg` from 7.75 on. CI runners have 8.5; old Linux curls already fetch a static 7.88.1.

An outage that outlives the five retries still fails the step.

This PR also fixes five pre-existing bugs in these paths:

- A transfer can die after the 200 status arrives: curl reports `http_code: 200` with a nonzero exit code, but the code matched the status alone and renamed the truncated part file into the cache, where only a manual clean removed it. A transfer now counts as delivered only when curl also exits cleanly. The verdict is a pure table with unit tests (`classifyDownload` / `classifyUpload`).
- An error answer to a PUT carries a body, which landed on stdout and glued to curl's per-transfer JSON report. The report did not parse, so a 409 did not count as a skip and a 403/404/500 did not count as a failure — the upload step passed either way. The put config now discards each response body, so stdout carries only the reports.
- On a miss, the parallel path left the error body behind as a `.part` file. It now removes the file, like the serial path.
- A 404 answer to a PUT was excused as a cache miss. It now counts as an upload failure.
- The marker PUTs carry their credential in the curl argument list, and a failure message echoed that list. Their failure messages now name the command, its exit state, and stderr only. (In CI the token is also masked in logs; this guards local runs and transformed output.)

Tested with `lake build cache`, the `cache-test` suite, and a forced re-download of 64 files through `cache.mathlib.org`. Against a local server that truncates every body, all 64 transfers fail and no truncated or partial file stays in the cache; against a server that answers 404, misses stay quiet and leave no partial files. For uploads, a put against a local server that answers 409 with an error body skips and exits 0; against a 404 server it reports the failed blob by URL and exits 1. Two `ci_dev` runs built the branch's cache tool in CI: the download path served through `cache.mathlib.org`, and the upload job wrote 3 files to the forks container over OIDC.


