### PR TITLE
[Merged by Bors] - fix(Util/CountHeartbeats): count heartbeats spent in async theorem bodies

### DIFF
--- a/Mathlib/Util/CountHeartbeats.lean
+++ b/Mathlib/Util/CountHeartbeats.lean
@@ -131,11 +131,14 @@ As this is intended as a user command, we divide by 1000.
 The optional `approximately` keyword rounds down the heartbeats to the nearest thousand.
 This helps make the tests more stable to small changes in heartbeats.
 To use this functionality, use `#count_heartbeats approximately in cmd`.
+
+`cmd` is elaborated with `Elab.async` disabled: with async elaboration, theorem bodies are
+elaborated in a separate task, whose heartbeats would otherwise not be counted.
 -/
 elab "#count_heartbeats " approx:(&"approximately ")? "in" ppLine cmd:command : command => do
   let start ← IO.getNumHeartbeats
   try
-    elabCommand (← `(command| set_option maxHeartbeats 0 in $cmd))
+    elabCommand (← `(command| set_option Elab.async false in set_option maxHeartbeats 0 in $cmd))
   finally
     let finish ← IO.getNumHeartbeats
     let elapsed := (finish - start) / 1000
@@ -194,7 +197,7 @@ Run a command, optionally restoring the original state, and report just the numb
 def elabForHeartbeats (cmd : TSyntax `command) (revert : Bool := true) : CommandElabM Nat := do
   let start ← IO.getNumHeartbeats
   let s ← get
-  elabCommand (← `(command| set_option maxHeartbeats 0 in $cmd))
+  elabCommand (← `(command| set_option Elab.async false in set_option maxHeartbeats 0 in $cmd))
   if revert then set s
   return (← IO.getNumHeartbeats) - start
 

--- a/MathlibTest/Util/CountHeartbeats.lean
+++ b/MathlibTest/Util/CountHeartbeats.lean
@@ -30,3 +30,14 @@ set_option linter.unusedTactic false in
 example : True := by
   sleep_heartbeats 1000
   trivial
+
+-- With `Elab.async` (the default), `theorem` bodies are elaborated in a separate task, and their
+-- heartbeats were not counted; check they are. Note this needs a `theorem`, not an `example`:
+-- `example` and `def` bodies are elaborated synchronously and did not exhibit the bug.
+/-- info: Used approximately 5000 heartbeats, which is less than the current maximum of 200000. -/
+#guard_msgs in
+set_option linter.unusedTactic false in
+#count_heartbeats approximately in
+theorem countHeartbeatsCountsAsyncTheoremBody : True := by
+  sleep_heartbeats 5000
+  trivial


### PR DESCRIPTION
See [#mathlib4 > Behavior of count_heartbeats in](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Behavior.20of.20count_heartbeats.20in/with/619383102) Zulip thread for context.

MWE — each proof burns ~5000 user-facing heartbeats via `sleep_heartbeats`:

```lean
import Mathlib.Util.CountHeartbeats
import Mathlib.Util.SleepHeartbeats

#count_heartbeats in
theorem t1 : True := by
  sleep_heartbeats 5000
  trivial
```

| | before | after |
|---|---|---|
| `#count_heartbeats in theorem …` | `Used 2 heartbeats` | `Used 5005 heartbeats` |
| `#count_heartbeats! 3 in theorem …` (2000 hb) | `Min: 1 Max: 2` | `Min: 2005 Max: 2006` |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
