### PR TITLE
feat(GroupTheory): add Hecke double coset API

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5836,6 +5836,10 @@ public import Mathlib.NumberTheory.Harmonic.GammaDeriv
 public import Mathlib.NumberTheory.Harmonic.Int
 public import Mathlib.NumberTheory.Harmonic.ZetaAsymp
 public import Mathlib.NumberTheory.HeckeRing.Defs
+public import Mathlib.NumberTheory.HeckeRing.HeckeCoset.Basic
+public import Mathlib.NumberTheory.HeckeRing.HeckeCoset.DecompQuotient
+public import Mathlib.NumberTheory.HeckeRing.HeckeCoset.Multiplicity
+public import Mathlib.NumberTheory.HeckeRing.HeckeCoset.Unimodular
 public import Mathlib.NumberTheory.Height.Basic
 public import Mathlib.NumberTheory.Height.EllipticCurve
 public import Mathlib.NumberTheory.Height.MvPolynomial

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -570,5 +570,10 @@ lemma conjAct_pointwise_smul_eq_self {H : Subgroup G} {g : G} (hg : g ∈ normal
     ConjAct.toConjAct g • H = H :=
   conjAct_pointwise_smul_iff.2 hg
 
+lemma mem_conjAct_pointwise_smul_iff {H : Subgroup G} {g x : G} :
+    x ∈ ConjAct.toConjAct g • H ↔ g⁻¹ * x * g ∈ H := by
+  rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv, ConjAct.smul_def,
+    ConjAct.ofConjAct_toConjAct, inv_inv]
+
 end Group
 end Subgroup

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Basic.lean
@@ -5,7 +5,7 @@ Authors: Chris Birkbeck, Jiaxi Mo
 -/
 module
 
-public import Mathlib.RepresentationTheory.HeckeCoset.DecompQuotient
+public import Mathlib.NumberTheory.HeckeRing.HeckeCoset.DecompQuotient
 
 /-!
 # Hecke Double Cosets

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Basic.lean
@@ -22,7 +22,7 @@ section triple
 
 open DoubleCoset
 
-/-- tbd -/
+/-- `(H₁, H₂, g)` is a Hecke triple if `H₁ ⧸ (H₁ ∩ gH₂g⁻¹)` is finite. -/
 @[mk_iff] class IsHeckeTriple : Prop where
   degreeNeZero : (DoubleCoset.mk H₁ H₂ g).degree ≠ 0
 
@@ -59,7 +59,7 @@ instance instIsHeckeTriple_diag_mul (H : Subgroup G) (g g' : G)
 
 end triple
 
-/-- tbd -/
+/-- The collection of double cosets admitting finite decomposition into left cosets. -/
 @[implicit_reducible]
 def HeckeCoset := {x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G) // x.degree ≠ 0}
 
@@ -69,12 +69,13 @@ namespace HeckeCoset
 
 variable {H₁ H₂ H₃}
 
-/-- tbd -/
+/-- A representative of the underlying double coset in the ambient group. -/
 noncomputable def rep (x : HeckeCoset H₁ H₂) : G := x.val.out
 
 lemma rep_eq_out (x : HeckeCoset H₁ H₂) : x.rep = x.val.out := rfl
 
-/-- tbd -/
+/-- The cardinality of `H₁ ⧸ (H₁ ∩ gH₂g⁻¹)` where `g` is a representative of the underlying double
+coset. -/
 noncomputable abbrev degree (x : HeckeCoset H₁ H₂) : ℕ := x.val.degree
 
 @[simp]
@@ -88,7 +89,7 @@ lemma degree_eq_rep (x : HeckeCoset H₁ H₂) :
 instance (x : HeckeCoset H₁ H₂) : IsHeckeTriple H₁ H₂ x.rep := by
   simp [isHeckeTriple_iff, rep_eq_out, DoubleCoset.mk_degree, ← DoubleCoset.degree_eq_out]
 
-/-- tbd -/
+/-- The Hecke double coset represented by `g`. -/
 abbrev mk (H₁ H₂ : Subgroup G) (g : G) [IsHeckeTriple H₁ H₂ g] :
     HeckeCoset H₁ H₂ := ⟨DoubleCoset.mk H₁ H₂ g, IsHeckeTriple.degreeNeZero⟩
 

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Basic.lean
@@ -61,43 +61,44 @@ end triple
 
 /-- The collection of double cosets admitting finite decomposition into left cosets. -/
 @[implicit_reducible]
-def HeckeCoset := {x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G) // x.degree ≠ 0}
+def DoubleCoset₀ := {x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G) // x.degree ≠ 0}
 
-instance : Coe (HeckeCoset H₁ H₂) (DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)) := ⟨Subtype.val⟩
+instance : Coe (DoubleCoset₀ H₁ H₂) (DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)) :=
+  ⟨Subtype.val⟩
 
-namespace HeckeCoset
+namespace DoubleCoset₀
 
 variable {H₁ H₂ H₃}
 
 /-- A representative of the underlying double coset in the ambient group. -/
-noncomputable def rep (x : HeckeCoset H₁ H₂) : G := x.val.out
+noncomputable def rep (x : DoubleCoset₀ H₁ H₂) : G := x.val.out
 
-lemma rep_eq_out (x : HeckeCoset H₁ H₂) : x.rep = x.val.out := rfl
+lemma rep_eq_out (x : DoubleCoset₀ H₁ H₂) : x.rep = x.val.out := rfl
 
 /-- The cardinality of `H₁ ⧸ (H₁ ∩ gH₂g⁻¹)` where `g` is a representative of the underlying double
 coset. -/
-noncomputable abbrev degree (x : HeckeCoset H₁ H₂) : ℕ := x.val.degree
+noncomputable abbrev degree (x : DoubleCoset₀ H₁ H₂) : ℕ := x.val.degree
 
 @[simp]
-lemma degree_ne_zero (x : HeckeCoset H₁ H₂) :
+lemma degree_ne_zero (x : DoubleCoset₀ H₁ H₂) :
     x.degree ≠ 0 := x.prop
 
-lemma degree_eq_rep (x : HeckeCoset H₁ H₂) :
+lemma degree_eq_rep (x : DoubleCoset₀ H₁ H₂) :
     x.degree = Nat.card (DoubleCoset.DecompQuotient H₁ H₂ x.rep) := by
   simp [degree, rep_eq_out, ← DoubleCoset.degree_eq_out]
 
-instance (x : HeckeCoset H₁ H₂) : IsHeckeTriple H₁ H₂ x.rep := by
+instance (x : DoubleCoset₀ H₁ H₂) : IsHeckeTriple H₁ H₂ x.rep := by
   simp [isHeckeTriple_iff, rep_eq_out, DoubleCoset.mk_degree, ← DoubleCoset.degree_eq_out]
 
 /-- The Hecke double coset represented by `g`. -/
 abbrev mk (H₁ H₂ : Subgroup G) (g : G) [IsHeckeTriple H₁ H₂ g] :
-    HeckeCoset H₁ H₂ := ⟨DoubleCoset.mk H₁ H₂ g, IsHeckeTriple.degreeNeZero⟩
+    DoubleCoset₀ H₁ H₂ := ⟨DoubleCoset.mk H₁ H₂ g, IsHeckeTriple.degreeNeZero⟩
 
 lemma coe_mk (g : G) [IsHeckeTriple H₁ H₂ g] :
     mk H₁ H₂ g = DoubleCoset.mk H₁ H₂ g := rfl
 
 @[simp]
-lemma mk_rep (x : HeckeCoset H₁ H₂) :
+lemma mk_rep (x : DoubleCoset₀ H₁ H₂) :
     mk H₁ H₂ x.rep = x := by
   simp [mk, rep_eq_out, DoubleCoset.out_eq']
 
@@ -111,8 +112,7 @@ lemma mk_eq_iff {g g' : G} [IsHeckeTriple H₁ H₂ g] [IsHeckeTriple H₁ H₂ 
 
 @[simp]
 lemma diag_mk_one_rep_mem (H : Subgroup G) : (mk H H 1).rep ∈ H := by
-  obtain ⟨_, h₁, _, h₂, heq⟩ :=
-    HeckeCoset.mk_eq_iff.mp (show mk H H 1 = mk H H (mk H H 1).rep from by simp)
+  obtain ⟨_, h₁, _, h₂, heq⟩ := mk_eq_iff.mp (show mk H H 1 = mk H H (mk H H 1).rep from by simp)
   simp [heq, H.mul_mem h₁ h₂]
 
 @[simp]
@@ -120,10 +120,10 @@ lemma diag_one_degree_eq_one (H : Subgroup G) : (mk H H 1).degree = 1 := by
   rw [mk_degree, DoubleCoset.DecompQuotient.nat_card_eq_relIndex]
   simp
 
-lemma induction_on (x : HeckeCoset H₁ H₂) {p : HeckeCoset H₁ H₂ → Prop}
+lemma induction_on (x : DoubleCoset₀ H₁ H₂) {p : DoubleCoset₀ H₁ H₂ → Prop}
     (h : ∀ (g : G) [IsHeckeTriple H₁ H₂ g], p (mk H₁ H₂ g)) :
     p x := by
   rw [← mk_rep x]
   exact h x.rep
 
-end HeckeCoset
+end DoubleCoset₀

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Basic.lean
@@ -23,39 +23,39 @@ section triple
 open DoubleCoset
 
 /-- `(H₁, H₂, g)` is a Hecke triple if `H₁ ⧸ (H₁ ∩ gH₂g⁻¹)` is finite. -/
-@[mk_iff] class IsHeckeTriple : Prop where
+@[mk_iff] class IsHeckeFinite : Prop where
   degreeNeZero : (DoubleCoset.mk H₁ H₂ g).degree ≠ 0
 
-noncomputable instance [IsHeckeTriple H₁ H₂ g] : Fintype (DecompQuotient H₁ H₂ g) :=
-  Subgroup.fintypeOfIndexNeZero IsHeckeTriple.degreeNeZero
+noncomputable instance [IsHeckeFinite H₁ H₂ g] : Fintype (DecompQuotient H₁ H₂ g) :=
+  Subgroup.fintypeOfIndexNeZero IsHeckeFinite.degreeNeZero
 
-instance instIsHeckeTriple_diag_one (H : Subgroup G) : IsHeckeTriple H H 1 := ⟨by simp⟩
+instance instIsHeckeFinite_diag_one (H : Subgroup G) : IsHeckeFinite H H 1 := ⟨by simp⟩
 
-instance instIsHeckeTriple_mulLeft [IsHeckeTriple H₁ H₂ g] (h₁ : H₁) :
-    IsHeckeTriple H₁ H₂ (h₁ * g) := by
+instance instIsHeckeFinite_mulLeft [IsHeckeFinite H₁ H₂ g] (h₁ : H₁) :
+    IsHeckeFinite H₁ H₂ (h₁ * g) := by
   have := (DoubleCoset.eq H₁ H₂ (h₁ * g) g).mpr ⟨h₁⁻¹, H₁.inv_mem h₁.prop, 1, H₂.one_mem, by simp⟩
-  simp [isHeckeTriple_iff, this, mk_degree]
+  simp [isHeckeFinite_iff, this, mk_degree]
 
-instance instIsHeckeTriple_mulRight [IsHeckeTriple H₁ H₂ g] (h₂ : H₂) :
-    IsHeckeTriple H₁ H₂ (g * h₂) := by
+instance instIsHeckeFinite_mulRight [IsHeckeFinite H₁ H₂ g] (h₂ : H₂) :
+    IsHeckeFinite H₁ H₂ (g * h₂) := by
   have := (DoubleCoset.eq H₁ H₂ (g * h₂) g).mpr ⟨1, H₁.one_mem, h₂⁻¹, H₂.inv_mem h₂.prop, by simp⟩
-  simp [isHeckeTriple_iff, this, mk_degree]
+  simp [isHeckeFinite_iff, this, mk_degree]
 
-lemma isHeckeTriple_trans [IsHeckeTriple H₁ H₂ g] [IsHeckeTriple H₂ H₃ g'] :
-    IsHeckeTriple H₁ H₃ (g * g') := by
+lemma isHeckeFinite_trans [IsHeckeFinite H₁ H₂ g] [IsHeckeFinite H₂ H₃ g'] :
+    IsHeckeFinite H₁ H₃ (g * g') := by
   have h₂₃ : ((ConjAct.toConjAct g) • ((ConjAct.toConjAct g') • H₃)).relIndex
       ((ConjAct.toConjAct g) • H₂) ≠ 0 := by
     simp [Subgroup.relIndex_pointwise_smul, ← DecompQuotient.nat_card_eq_relIndex]
-  simpa [isHeckeTriple_iff, DecompQuotient.nat_card_eq_relIndex, mul_smul, mk_degree] using
-    Subgroup.relIndex_ne_zero_trans h₂₃ IsHeckeTriple.degreeNeZero
+  simpa [isHeckeFinite_iff, DecompQuotient.nat_card_eq_relIndex, mul_smul, mk_degree] using
+    Subgroup.relIndex_ne_zero_trans h₂₃ IsHeckeFinite.degreeNeZero
 
-instance instIsHeckeTriple_trans [IsHeckeTriple H₁ H₂ g]
-    [IsHeckeTriple H₂ H₃ g'] (h₂ : H₂) : IsHeckeTriple H₁ H₃ (g * h₂ * g') :=
-  isHeckeTriple_trans H₁ H₂ H₃ (g * h₂) g'
+instance instIsHeckeFinite_trans [IsHeckeFinite H₁ H₂ g]
+    [IsHeckeFinite H₂ H₃ g'] (h₂ : H₂) : IsHeckeFinite H₁ H₃ (g * h₂ * g') :=
+  isHeckeFinite_trans H₁ H₂ H₃ (g * h₂) g'
 
-instance instIsHeckeTriple_diag_mul (H : Subgroup G) (g g' : G)
-    [IsHeckeTriple H H g] [IsHeckeTriple H H g'] : IsHeckeTriple H H (g * g') := by
-  simpa using isHeckeTriple_trans H H H g g'
+instance instIsHeckeFinite_diag_mul (H : Subgroup G) (g g' : G)
+    [IsHeckeFinite H H g] [IsHeckeFinite H H g'] : IsHeckeFinite H H (g * g') := by
+  simpa using isHeckeFinite_trans H H H g g'
 
 end triple
 
@@ -87,14 +87,14 @@ lemma degree_eq_rep (x : DoubleCoset₀ H₁ H₂) :
     x.degree = Nat.card (DoubleCoset.DecompQuotient H₁ H₂ x.rep) := by
   simp [degree, rep_eq_out, ← DoubleCoset.degree_eq_out]
 
-instance (x : DoubleCoset₀ H₁ H₂) : IsHeckeTriple H₁ H₂ x.rep := by
-  simp [isHeckeTriple_iff, rep_eq_out, DoubleCoset.mk_degree, ← DoubleCoset.degree_eq_out]
+instance (x : DoubleCoset₀ H₁ H₂) : IsHeckeFinite H₁ H₂ x.rep := by
+  simp [isHeckeFinite_iff, rep_eq_out, DoubleCoset.mk_degree, ← DoubleCoset.degree_eq_out]
 
 /-- The Hecke double coset represented by `g`. -/
-abbrev mk (H₁ H₂ : Subgroup G) (g : G) [IsHeckeTriple H₁ H₂ g] :
-    DoubleCoset₀ H₁ H₂ := ⟨DoubleCoset.mk H₁ H₂ g, IsHeckeTriple.degreeNeZero⟩
+abbrev mk (H₁ H₂ : Subgroup G) (g : G) [IsHeckeFinite H₁ H₂ g] :
+    DoubleCoset₀ H₁ H₂ := ⟨DoubleCoset.mk H₁ H₂ g, IsHeckeFinite.degreeNeZero⟩
 
-lemma coe_mk (g : G) [IsHeckeTriple H₁ H₂ g] :
+lemma coe_mk (g : G) [IsHeckeFinite H₁ H₂ g] :
     mk H₁ H₂ g = DoubleCoset.mk H₁ H₂ g := rfl
 
 @[simp]
@@ -102,11 +102,11 @@ lemma mk_rep (x : DoubleCoset₀ H₁ H₂) :
     mk H₁ H₂ x.rep = x := by
   simp [mk, rep_eq_out, DoubleCoset.out_eq']
 
-lemma mk_degree [IsHeckeTriple H₁ H₂ g] :
+lemma mk_degree [IsHeckeFinite H₁ H₂ g] :
     (mk H₁ H₂ g).degree = Nat.card (DoubleCoset.DecompQuotient H₁ H₂ g) := by
   simp [degree, DoubleCoset.mk_degree]
 
-lemma mk_eq_iff {g g' : G} [IsHeckeTriple H₁ H₂ g] [IsHeckeTriple H₁ H₂ g'] :
+lemma mk_eq_iff {g g' : G} [IsHeckeFinite H₁ H₂ g] [IsHeckeFinite H₁ H₂ g'] :
     mk H₁ H₂ g = mk H₁ H₂ g' ↔ ∃ h₁ ∈ H₁, ∃ h₂ ∈ H₂, g' = h₁ * g * h₂ := by
   rw [Subtype.ext_iff, DoubleCoset.eq]
 
@@ -121,7 +121,7 @@ lemma diag_one_degree_eq_one (H : Subgroup G) : (mk H H 1).degree = 1 := by
   simp
 
 lemma induction_on (x : DoubleCoset₀ H₁ H₂) {p : DoubleCoset₀ H₁ H₂ → Prop}
-    (h : ∀ (g : G) [IsHeckeTriple H₁ H₂ g], p (mk H₁ H₂ g)) :
+    (h : ∀ (g : G) [IsHeckeFinite H₁ H₂ g], p (mk H₁ H₂ g)) :
     p x := by
   rw [← mk_rep x]
   exact h x.rep

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Basic.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Basic.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, Jiaxi Mo
+-/
+module
+
+public import Mathlib.RepresentationTheory.HeckeCoset.DecompQuotient
+
+/-!
+# Hecke Double Cosets
+
+-/
+
+@[expose] public section
+
+variable {G : Type*} [Group G] (H₁ H₂ H₃ : Subgroup G) (g g' : G)
+
+open Pointwise
+
+section triple
+
+open DoubleCoset
+
+/-- tbd -/
+@[mk_iff] class IsHeckeTriple : Prop where
+  degreeNeZero : (DoubleCoset.mk H₁ H₂ g).degree ≠ 0
+
+noncomputable instance [IsHeckeTriple H₁ H₂ g] : Fintype (DecompQuotient H₁ H₂ g) :=
+  Subgroup.fintypeOfIndexNeZero IsHeckeTriple.degreeNeZero
+
+instance instIsHeckeTriple_diag_one (H : Subgroup G) : IsHeckeTriple H H 1 := ⟨by simp⟩
+
+instance instIsHeckeTriple_mulLeft [IsHeckeTriple H₁ H₂ g] (h₁ : H₁) :
+    IsHeckeTriple H₁ H₂ (h₁ * g) := by
+  have := (DoubleCoset.eq H₁ H₂ (h₁ * g) g).mpr ⟨h₁⁻¹, H₁.inv_mem h₁.prop, 1, H₂.one_mem, by simp⟩
+  simp [isHeckeTriple_iff, this, mk_degree]
+
+instance instIsHeckeTriple_mulRight [IsHeckeTriple H₁ H₂ g] (h₂ : H₂) :
+    IsHeckeTriple H₁ H₂ (g * h₂) := by
+  have := (DoubleCoset.eq H₁ H₂ (g * h₂) g).mpr ⟨1, H₁.one_mem, h₂⁻¹, H₂.inv_mem h₂.prop, by simp⟩
+  simp [isHeckeTriple_iff, this, mk_degree]
+
+lemma isHeckeTriple_trans [IsHeckeTriple H₁ H₂ g] [IsHeckeTriple H₂ H₃ g'] :
+    IsHeckeTriple H₁ H₃ (g * g') := by
+  have h₂₃ : ((ConjAct.toConjAct g) • ((ConjAct.toConjAct g') • H₃)).relIndex
+      ((ConjAct.toConjAct g) • H₂) ≠ 0 := by
+    simp [Subgroup.relIndex_pointwise_smul, ← DecompQuotient.nat_card_eq_relIndex]
+  simpa [isHeckeTriple_iff, DecompQuotient.nat_card_eq_relIndex, mul_smul, mk_degree] using
+    Subgroup.relIndex_ne_zero_trans h₂₃ IsHeckeTriple.degreeNeZero
+
+instance instIsHeckeTriple_trans [IsHeckeTriple H₁ H₂ g]
+    [IsHeckeTriple H₂ H₃ g'] (h₂ : H₂) : IsHeckeTriple H₁ H₃ (g * h₂ * g') :=
+  isHeckeTriple_trans H₁ H₂ H₃ (g * h₂) g'
+
+instance instIsHeckeTriple_diag_mul (H : Subgroup G) (g g' : G)
+    [IsHeckeTriple H H g] [IsHeckeTriple H H g'] : IsHeckeTriple H H (g * g') := by
+  simpa using isHeckeTriple_trans H H H g g'
+
+end triple
+
+/-- tbd -/
+@[implicit_reducible]
+def HeckeCoset := {x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G) // x.degree ≠ 0}
+
+instance : Coe (HeckeCoset H₁ H₂) (DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)) := ⟨Subtype.val⟩
+
+namespace HeckeCoset
+
+variable {H₁ H₂ H₃}
+
+/-- tbd -/
+noncomputable def rep (x : HeckeCoset H₁ H₂) : G := x.val.out
+
+lemma rep_eq_out (x : HeckeCoset H₁ H₂) : x.rep = x.val.out := rfl
+
+/-- tbd -/
+noncomputable abbrev degree (x : HeckeCoset H₁ H₂) : ℕ := x.val.degree
+
+@[simp]
+lemma degree_ne_zero (x : HeckeCoset H₁ H₂) :
+    x.degree ≠ 0 := x.prop
+
+lemma degree_eq_rep (x : HeckeCoset H₁ H₂) :
+    x.degree = Nat.card (DoubleCoset.DecompQuotient H₁ H₂ x.rep) := by
+  simp [degree, rep_eq_out, ← DoubleCoset.degree_eq_out]
+
+instance (x : HeckeCoset H₁ H₂) : IsHeckeTriple H₁ H₂ x.rep := by
+  simp [isHeckeTriple_iff, rep_eq_out, DoubleCoset.mk_degree, ← DoubleCoset.degree_eq_out]
+
+/-- tbd -/
+abbrev mk (H₁ H₂ : Subgroup G) (g : G) [IsHeckeTriple H₁ H₂ g] :
+    HeckeCoset H₁ H₂ := ⟨DoubleCoset.mk H₁ H₂ g, IsHeckeTriple.degreeNeZero⟩
+
+lemma coe_mk (g : G) [IsHeckeTriple H₁ H₂ g] :
+    mk H₁ H₂ g = DoubleCoset.mk H₁ H₂ g := rfl
+
+@[simp]
+lemma mk_rep (x : HeckeCoset H₁ H₂) :
+    mk H₁ H₂ x.rep = x := by
+  simp [mk, rep_eq_out, DoubleCoset.out_eq']
+
+lemma mk_degree [IsHeckeTriple H₁ H₂ g] :
+    (mk H₁ H₂ g).degree = Nat.card (DoubleCoset.DecompQuotient H₁ H₂ g) := by
+  simp [degree, DoubleCoset.mk_degree]
+
+lemma mk_eq_iff {g g' : G} [IsHeckeTriple H₁ H₂ g] [IsHeckeTriple H₁ H₂ g'] :
+    mk H₁ H₂ g = mk H₁ H₂ g' ↔ ∃ h₁ ∈ H₁, ∃ h₂ ∈ H₂, g' = h₁ * g * h₂ := by
+  rw [Subtype.ext_iff, DoubleCoset.eq]
+
+@[simp]
+lemma diag_mk_one_rep_mem (H : Subgroup G) : (mk H H 1).rep ∈ H := by
+  obtain ⟨_, h₁, _, h₂, heq⟩ :=
+    HeckeCoset.mk_eq_iff.mp (show mk H H 1 = mk H H (mk H H 1).rep from by simp)
+  simp [heq, H.mul_mem h₁ h₂]
+
+@[simp]
+lemma diag_one_degree_eq_one (H : Subgroup G) : (mk H H 1).degree = 1 := by
+  rw [mk_degree, DoubleCoset.DecompQuotient.nat_card_eq_relIndex]
+  simp
+
+lemma induction_on (x : HeckeCoset H₁ H₂) {p : HeckeCoset H₁ H₂ → Prop}
+    (h : ∀ (g : G) [IsHeckeTriple H₁ H₂ g], p (mk H₁ H₂ g)) :
+    p x := by
+  rw [← mk_rep x]
+  exact h x.rep
+
+end HeckeCoset

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/DecompQuotient.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/DecompQuotient.lean
@@ -23,7 +23,8 @@ namespace DoubleCoset
 
 section decomp
 
-/-- tbd -/
+/-- The decomposition quotient `H₁ ⧸ (H₁ ∩ gH₂g⁻¹)`, indexing the left cosets of `Γ₂` inside
+the double coset `H₁gH₂`; see `DoubleCoset.doubleCoset_eq_iUnion_leftCosets`. -/
 abbrev DecompQuotient := H₁ ⧸ ((ConjAct.toConjAct g) • H₂).subgroupOf H₁
 
 namespace DecompQuotient
@@ -31,7 +32,8 @@ namespace DecompQuotient
 lemma nat_card_eq_relIndex :
     Nat.card (DecompQuotient H₁ H₂ g) = (ConjAct.toConjAct g • H₂).relIndex H₁ := rfl
 
-/-- The canonical map from `DecompQuotient` to left cosets. -/
+/-- The canonical map from the decomposition quotient `H₁ ⧸ (H₁ ∩ gH₂g⁻¹)` to left coset space
+`G ⧸ H₂`. -/
 def toLeftCoset :
     DecompQuotient H₁ H₂ g → G ⧸ H₂ :=
   Quotient.lift (fun x => (x * g : G)) fun _ _ h => by
@@ -47,12 +49,12 @@ lemma toLeftCoset_mk (x : H₁) :
   rfl
 
 lemma toLeftCoset_apply (x : DecompQuotient H₁ H₂ g) :
-    DecompQuotient.toLeftCoset H₁ H₂ g x = (x.out.val * g : G ⧸ H₂) := by
+    toLeftCoset H₁ H₂ g x = (x.out.val * g : G ⧸ H₂) := by
   nth_rw 1 [← Quotient.out_eq x]
   rfl
 
-lemma toLeftCoset.injective :
-    Function.Injective (DecompQuotient.toLeftCoset H₁ H₂ g) := by
+lemma toLeftCoset_injective :
+    Function.Injective (toLeftCoset H₁ H₂ g) := by
   intro i j hij
   rw [← QuotientGroup.out_eq' i, ← QuotientGroup.out_eq' j, QuotientGroup.eq]
   simpa [toLeftCoset_apply, QuotientGroup.eq, mul_assoc, Subgroup.mem_subgroupOf,
@@ -74,7 +76,8 @@ section degree
 
 variable {H₁ H₂} (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G))
 
-/-- tbd -/
+/-- The cardinality of `H₁ ⧸ (H₁ ∩ gH₂g⁻¹)`, which depends only the correponding double coset
+`H₁gH₂`. -/
 noncomputable def Quotient.degree :
     ℕ := Quotient.liftOn x (fun x => (ConjAct.toConjAct x • H₂).relIndex H₁) fun a b hab => by
   obtain ⟨h₁, hh₁, h₂, hh₂, rfl⟩ := DoubleCoset.rel_iff.mp hab

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/DecompQuotient.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/DecompQuotient.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, Jiaxi Mo
+-/
+module
+
+public import Mathlib.GroupTheory.DoubleCoset
+public import Mathlib.GroupTheory.Index
+
+/-!
+# Decompsition Quotient
+
+-/
+
+@[expose] public section
+
+variable {G : Type*} [Group G] (H₁ H₂ : Subgroup G) (g g' : G)
+
+open Pointwise
+
+namespace DoubleCoset
+
+section decomp
+
+/-- tbd -/
+abbrev DecompQuotient := H₁ ⧸ ((ConjAct.toConjAct g) • H₂).subgroupOf H₁
+
+namespace DecompQuotient
+
+lemma nat_card_eq_relIndex :
+    Nat.card (DecompQuotient H₁ H₂ g) = (ConjAct.toConjAct g • H₂).relIndex H₁ := rfl
+
+/-- The canonical map from `DecompQuotient` to left cosets. -/
+def toLeftCoset :
+    DecompQuotient H₁ H₂ g → G ⧸ H₂ :=
+  Quotient.lift (fun x => (x * g : G)) fun _ _ h => by
+    rw [Quotient.eq, QuotientGroup.leftRel_apply]
+    have := (QuotientGroup.leftRel_apply.mp h)
+    simpa [mul_assoc] using Subgroup.mem_conjAct_pointwise_smul_iff.mp this
+
+variable {H₁ H₂ H₃ g g'}
+
+@[simp]
+lemma toLeftCoset_mk (x : H₁) :
+    toLeftCoset H₁ H₂ g (x : DecompQuotient H₁ H₂ g) = (x.val * g : G ⧸ H₂) :=
+  rfl
+
+lemma toLeftCoset_apply (x : DecompQuotient H₁ H₂ g) :
+    DecompQuotient.toLeftCoset H₁ H₂ g x = (x.out.val * g : G ⧸ H₂) := by
+  nth_rw 1 [← Quotient.out_eq x]
+  rfl
+
+lemma toLeftCoset.injective :
+    Function.Injective (DecompQuotient.toLeftCoset H₁ H₂ g) := by
+  intro i j hij
+  rw [← QuotientGroup.out_eq' i, ← QuotientGroup.out_eq' j, QuotientGroup.eq]
+  simpa [toLeftCoset_apply, QuotientGroup.eq, mul_assoc, Subgroup.mem_subgroupOf,
+    Subgroup.mem_conjAct_pointwise_smul_iff] using hij
+
+lemma exists_toLeftCoset_of_mk_eq
+    {g d : G}
+    (hgd : DoubleCoset.mk H₁ H₂ g = DoubleCoset.mk H₁ H₂ d) :
+    ∃ i : DecompQuotient H₁ H₂ g, toLeftCoset H₁ H₂ g i = (d : G ⧸ H₂) := by
+  obtain ⟨h₁, hh₁, h₂, hh₂, rfl⟩ := (DoubleCoset.eq H₁ H₂ g d).mp hgd
+  refine ⟨QuotientGroup.mk ⟨h₁, hh₁⟩, ?_⟩
+  simp [hh₂]
+
+end DecompQuotient
+
+end decomp
+
+section degree
+
+variable {H₁ H₂} (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G))
+
+/-- tbd -/
+noncomputable def Quotient.degree :
+    ℕ := Quotient.liftOn x (fun x => (ConjAct.toConjAct x • H₂).relIndex H₁) fun a b hab => by
+  obtain ⟨h₁, hh₁, h₂, hh₂, rfl⟩ := DoubleCoset.rel_iff.mp hab
+  have hH₁ : ConjAct.toConjAct h₁ • H₁ = H₁ :=
+    Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hh₁)
+  have hH₂ : ConjAct.toConjAct h₂ • H₂ = H₂ :=
+    Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hh₂)
+  nth_rewrite 2 [← hH₁]
+  simp [mul_smul, hH₂, Subgroup.relIndex_pointwise_smul]
+
+lemma mk_degree (g : G) :
+    (mk H₁ H₂ g).degree = Nat.card (DecompQuotient H₁ H₂ g)  := rfl
+
+lemma degree_eq_out :
+    x.degree = Nat.card (DecompQuotient H₁ H₂ x.out)  := by
+  simp [← mk_degree, out_eq']
+
+@[simp]
+lemma diag_mk_one_degree_eq_one (H : Subgroup G) : (mk H H 1).degree = 1 := by
+  simp [mk_degree]
+
+end degree
+
+end DoubleCoset

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Multiplicity.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, Jiaxi Mo
+-/
+module
+
+public import Mathlib.RepresentationTheory.HeckeCoset.Basic
+public import Mathlib.Data.Finsupp.Defs
+
+/-!
+# Multiplicity
+
+-/
+
+@[expose] public section
+
+open DoubleCoset Pointwise
+
+variable {G : Type*} [Group G] {H₁ H₂ H₃ : Subgroup G} (g g' : G)
+
+namespace DoubleCoset.DecompQuotient
+
+lemma snd_eq_of_fst_eq {g g' d : G} {i : DecompQuotient H₁ H₂ g}
+    {j₁ j₂ : DecompQuotient H₂ H₃ g'}
+    (h₁ : ((i.out : G) * g * ((j₁.out : G) * g') : G ⧸ H₃) = (d : G ⧸ H₃))
+    (h₂ : ((i.out : G) * g * ((j₂.out : G) * g') : G ⧸ H₃) = (d : G ⧸ H₃)) :
+    j₁ = j₂ := by
+  apply DecompQuotient.toLeftCoset.injective
+  have h := h₁.trans h₂.symm
+  simp only [toLeftCoset_apply, QuotientGroup.eq] at h ⊢
+  simpa [mul_assoc] using h
+
+end DoubleCoset.DecompQuotient
+
+namespace HeckeCoset
+
+/-- tbd -/
+noncomputable def mulMap (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃)
+    (p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep) : HeckeCoset H₁ H₃ :=
+  mk H₁ H₃ (p.1.out * x.rep * p.2.out * y.rep)
+
+lemma mulMap_eq_of_mk_eq (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃)
+    (z : HeckeCoset H₁ H₃) {p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep}
+    (h : ((p.1.out * x.rep * ((p.2.out : G) * y.rep) : G) : G ⧸ H₃) = (z.rep : G ⧸ H₃)) :
+    x.mulMap y p = z := by
+  rw [← HeckeCoset.mk_rep z]
+  apply HeckeCoset.mk_eq_iff.mpr
+  exact ⟨1, H₁.one_mem, ((p.1.out * x.rep * p.2.out * y.rep)⁻¹ * z.rep), by
+    simpa [mul_assoc] using QuotientGroup.eq.mp h, by simp [mul_assoc]⟩
+
+/-- tbd -/
+noncomputable def multiplicity (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃) :
+    HeckeCoset H₁ H₃ →₀ ℕ :=
+  Finsupp.ofSupportFinite
+    (fun z => Nat.card {p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep |
+      ((p.1.out : G) * x.rep * ((p.2.out : G) * y.rep) : G ⧸ H₃) = (z.rep : G ⧸ H₃)}) <| by
+    classical
+    refine (Finset.univ.image (x.mulMap y)).finite_toSet.subset ?_
+    intro z hz
+    simp only [Function.mem_support, Nat.card_ne_zero] at hz
+    obtain ⟨⟨p, hp⟩, _⟩ := hz
+    exact Finset.mem_image.mpr ⟨p, Finset.mem_univ p, mulMap_eq_of_mk_eq x y z hp⟩
+
+lemma multiplicity_apply (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃)
+    (z : HeckeCoset H₁ H₃) :
+    x.multiplicity y z =
+      Nat.card {p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep |
+        (p.1.out * x.rep * (p.2.out * y.rep) : G ⧸ H₃) = (z.rep : G ⧸ H₃)} := rfl
+
+end HeckeCoset

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Multiplicity.lean
@@ -33,26 +33,26 @@ lemma DecompQuotient.snd_eq_of_fst_eq {g g' d : G} {i : DecompQuotient H₁ H₂
 
 end DoubleCoset
 
-namespace HeckeCoset
+namespace DoubleCoset₀
 
 /-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the mixed double coset
 `H₁ (σᵢ g₁ τⱼ g₂) H₃` of their product. -/
-noncomputable def mulMap (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃)
-    (p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep) : HeckeCoset H₁ H₃ :=
+noncomputable def mulMap (x : DoubleCoset₀ H₁ H₂) (y : DoubleCoset₀ H₂ H₃)
+    (p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep) : DoubleCoset₀ H₁ H₃ :=
   mk H₁ H₃ (p.1.out * x.rep * p.2.out * y.rep)
 
-lemma mulMap_eq_of_mk_eq (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃)
-    (z : HeckeCoset H₁ H₃) {p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep}
+lemma mulMap_eq_of_mk_eq (x : DoubleCoset₀ H₁ H₂) (y : DoubleCoset₀ H₂ H₃)
+    (z : DoubleCoset₀ H₁ H₃) {p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep}
     (h : ((p.1.out * x.rep * ((p.2.out : G) * y.rep) : G) : G ⧸ H₃) = (z.rep : G ⧸ H₃)) :
     x.mulMap y p = z := by
-  rw [← HeckeCoset.mk_rep z]
-  apply HeckeCoset.mk_eq_iff.mpr
+  rw [← DoubleCoset₀.mk_rep z]
+  apply DoubleCoset₀.mk_eq_iff.mpr
   exact ⟨1, H₁.one_mem, ((p.1.out * x.rep * p.2.out * y.rep)⁻¹ * z.rep), by
     simpa [mul_assoc] using QuotientGroup.eq.mp h, by simp [mul_assoc]⟩
 
 /-- Shimura's multiplicity descended to Hecke double cosets. -/
-noncomputable def multiplicity (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃) :
-    HeckeCoset H₁ H₃ →₀ ℕ :=
+noncomputable def multiplicity (x : DoubleCoset₀ H₁ H₂) (y : DoubleCoset₀ H₂ H₃) :
+    DoubleCoset₀ H₁ H₃ →₀ ℕ :=
   Finsupp.ofSupportFinite
     (fun z => Nat.card {p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep |
       ((p.1.out : G) * x.rep * ((p.2.out : G) * y.rep) : G ⧸ H₃) = (z.rep : G ⧸ H₃)}) <| by
@@ -63,10 +63,10 @@ noncomputable def multiplicity (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H
     obtain ⟨⟨p, hp⟩, _⟩ := hz
     exact Finset.mem_image.mpr ⟨p, Finset.mem_univ p, mulMap_eq_of_mk_eq x y z hp⟩
 
-lemma multiplicity_apply (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃)
-    (z : HeckeCoset H₁ H₃) :
+lemma multiplicity_apply (x : DoubleCoset₀ H₁ H₂) (y : DoubleCoset₀ H₂ H₃)
+    (z : DoubleCoset₀ H₁ H₃) :
     x.multiplicity y z =
       Nat.card {p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep |
         (p.1.out * x.rep * (p.2.out * y.rep) : G ⧸ H₃) = (z.rep : G ⧸ H₃)} := rfl
 
-end HeckeCoset
+end DoubleCoset₀

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Multiplicity.lean
@@ -15,27 +15,28 @@ public import Mathlib.Data.Finsupp.Defs
 
 @[expose] public section
 
-open DoubleCoset Pointwise
+open DoubleCoset
 
 variable {G : Type*} [Group G] {H₁ H₂ H₃ : Subgroup G} (g g' : G)
 
-namespace DoubleCoset.DecompQuotient
+namespace DoubleCoset
 
-lemma snd_eq_of_fst_eq {g g' d : G} {i : DecompQuotient H₁ H₂ g}
+lemma DecompQuotient.snd_eq_of_fst_eq {g g' d : G} {i : DecompQuotient H₁ H₂ g}
     {j₁ j₂ : DecompQuotient H₂ H₃ g'}
     (h₁ : ((i.out : G) * g * ((j₁.out : G) * g') : G ⧸ H₃) = (d : G ⧸ H₃))
     (h₂ : ((i.out : G) * g * ((j₂.out : G) * g') : G ⧸ H₃) = (d : G ⧸ H₃)) :
     j₁ = j₂ := by
-  apply DecompQuotient.toLeftCoset.injective
+  apply toLeftCoset_injective
   have h := h₁.trans h₂.symm
   simp only [toLeftCoset_apply, QuotientGroup.eq] at h ⊢
   simpa [mul_assoc] using h
 
-end DoubleCoset.DecompQuotient
+end DoubleCoset
 
 namespace HeckeCoset
 
-/-- tbd -/
+/-- The map sending a pair of coset representatives `(σᵢ, τⱼ)` to the mixed double coset
+`H₁ (σᵢ g₁ τⱼ g₂) H₃` of their product. -/
 noncomputable def mulMap (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃)
     (p : DecompQuotient H₁ H₂ x.rep × DecompQuotient H₂ H₃ y.rep) : HeckeCoset H₁ H₃ :=
   mk H₁ H₃ (p.1.out * x.rep * p.2.out * y.rep)
@@ -49,7 +50,7 @@ lemma mulMap_eq_of_mk_eq (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃)
   exact ⟨1, H₁.one_mem, ((p.1.out * x.rep * p.2.out * y.rep)⁻¹ * z.rep), by
     simpa [mul_assoc] using QuotientGroup.eq.mp h, by simp [mul_assoc]⟩
 
-/-- tbd -/
+/-- Shimura's multiplicity descended to Hecke double cosets. -/
 noncomputable def multiplicity (x : HeckeCoset H₁ H₂) (y : HeckeCoset H₂ H₃) :
     HeckeCoset H₁ H₃ →₀ ℕ :=
   Finsupp.ofSupportFinite

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Multiplicity.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Multiplicity.lean
@@ -5,7 +5,7 @@ Authors: Chris Birkbeck, Jiaxi Mo
 -/
 module
 
-public import Mathlib.RepresentationTheory.HeckeCoset.Basic
+public import Mathlib.NumberTheory.HeckeRing.HeckeCoset.Basic
 public import Mathlib.Data.Finsupp.Defs
 
 /-!

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 Jiaxi Mo. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jiaxi Mo
+-/
+module
+
+public import Mathlib.RepresentationTheory.HeckeCoset.Multiplicity
+
+/-!
+# Multiplicity
+
+-/
+
+@[expose] public section
+
+open DoubleCoset
+
+variable {G : Type*} [Group G] {H H₁ H₂ : Subgroup G}
+
+namespace DoubleCoset
+
+/-- tbd -/
+def inv (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)) :
+    DoubleCoset.Quotient (H₂ : Set G) (H₁ : Set G) :=
+  Quotient.liftOn x (fun x => DoubleCoset.mk H₂ H₁ x⁻¹) fun a b hab => by
+    obtain ⟨h₁, hh₁, h₂, hh₂, heq⟩ := DoubleCoset.rel_iff.mp hab
+    rw [DoubleCoset.eq]
+    exact ⟨h₂⁻¹, H₂.inv_mem hh₂, h₁⁻¹, H₁.inv_mem hh₁, by simp [heq, mul_assoc]⟩
+
+@[simp]
+lemma inv_mk (g : G) :
+    inv (mk H₁ H₂ g) = mk H₂ H₁ g⁻¹ := by
+  rfl
+
+lemma mk_inv_out (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)) :
+    mk H₂ H₁ x.out⁻¹ = inv x := by
+  simp [← inv_mk, DoubleCoset.out_eq']
+
+@[simp]
+lemma inv_inv (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)) :
+    inv (inv x) = x :=
+  Quotient.inductionOn x fun x => by simp
+
+end DoubleCoset
+
+/-- tbd -/
+class IsHeckeUnimodular (H : Subgroup G) : Prop where
+  degree_eq_inv_degree : ∀ (x : DoubleCoset.Quotient (H : Set G) (H : Set G)),
+    x.degree = (inv x).degree
+
+instance [IsHeckeUnimodular H] (g : G) [IsHeckeTriple H H g] :
+    IsHeckeTriple H H g⁻¹ := by
+  rw [isHeckeTriple_iff, ←inv_mk g, ← IsHeckeUnimodular.degree_eq_inv_degree]
+  simp [mk_degree]
+namespace HeckeCoset
+
+variable [IsHeckeUnimodular H]
+
+/-- tbd -/
+def inv (x : HeckeCoset H H) :
+    HeckeCoset H H := ⟨DoubleCoset.inv x, by simp [← IsHeckeUnimodular.degree_eq_inv_degree]⟩
+
+lemma coe_inv (x : HeckeCoset H H) :
+    x.inv = DoubleCoset.inv x.val := rfl
+
+@[simp]
+lemma inv_mk (g : G) [IsHeckeTriple H H g] :
+    (mk H H g).inv = mk H H g⁻¹ := rfl
+
+lemma mk_inv_rep (x : HeckeCoset H H) :
+    mk H H x.rep⁻¹ = x.inv  := by
+  simp [inv, ← DoubleCoset.mk_inv_out, rep_eq_out]
+
+@[simp]
+lemma inv_inv (x : HeckeCoset H H) :
+    x.inv.inv = x :=
+  induction_on x (p := fun x => x.inv.inv = x) fun g => by simp
+
+lemma inv_eq_iff {x y : HeckeCoset H H} :
+    x.inv = y ↔ x = y.inv :=
+  ⟨by intro rfl; simp, by intro rfl; simp⟩
+
+@[simp]
+lemma inv_degree_eq_degree (x : HeckeCoset H H) :
+    x.inv.degree = x.degree := by
+  rw [← mk_rep x, mk_degree, ← DoubleCoset.mk_degree, IsHeckeUnimodular.degree_eq_inv_degree]
+  simp [inv, mk_degree, DoubleCoset.mk_degree]
+
+lemma diag_one_inv_eq_self :
+    (mk H H 1).inv = (mk H H 1) := by
+  simp
+
+private lemma multiplicity_self_inv_mk_one_eq_degree (x : HeckeCoset H H) :
+    x.multiplicity x.inv (mk H H 1) = x.degree := by classical
+  simp only  [multiplicity_apply]
+  obtain ⟨h₁, hh₁, h₂, hh₂, hinv⟩ := mk_eq_iff.mp
+    (show mk H H x.rep⁻¹ = mk H H x.inv.rep by simp [mk_inv_rep])
+  let j : DecompQuotient H H x.inv.rep := QuotientGroup.mk ⟨h₁⁻¹, H.inv_mem hh₁⟩
+  have hrep : DoubleCoset.mk H H x.inv.rep = DoubleCoset.mk H H x.rep⁻¹ := by
+    rw [← coe_mk, ← coe_mk, mk_inv_rep, mk_rep]
+  obtain ⟨j, hj⟩ := DoubleCoset.DecompQuotient.exists_toLeftCoset_of_mk_eq hrep
+  simp only [DoubleCoset.DecompQuotient.toLeftCoset_apply] at hj
+  have heq (i : DecompQuotient H H x.rep) :
+      (i.out * x.rep * (j.out * x.inv.rep) : G ⧸ H)
+        = ((mk H H 1).rep : G ⧸ H) := by
+    calc
+      _ = (i.out : G ⧸ H) := by
+        simpa [MulAction.Quotient.smul_mk, smul_eq_mul, mul_assoc] using
+          congrArg (fun q : G ⧸ H => (i.out * x.rep : G) • q) hj
+      _ = _ := by
+        simpa [QuotientGroup.eq (a := i.out.val)] using H.mul_mem (H.inv_mem i.out.prop) (by simp)
+  let equiv :
+      {p : DecompQuotient H H x.rep × DecompQuotient H H x.inv.rep |
+        ((p.1.out * x.rep * (p.2.out * x.inv.rep) : G) :  G ⧸ H) = ((mk H H 1).rep : G ⧸ H)}
+      ≃ DecompQuotient H H x.rep :=
+    { toFun p := p.1.1
+      invFun i := ⟨(i, j), heq i⟩
+      left_inv p := Subtype.ext
+        (Prod.ext rfl (DoubleCoset.DecompQuotient.snd_eq_of_fst_eq (heq p.1.1) p.prop))
+      right_inv _ := rfl}
+  simpa [degree_eq_rep] using Nat.card_congr equiv
+
+private lemma multiplicity_ne_self_inv_mk_one_eq_zero {x y : HeckeCoset H H} (h : y ≠ x.inv) :
+    x.multiplicity y (mk H H 1) = 0 := by
+  simp only [multiplicity_apply]
+  by_contra hne
+  obtain ⟨p, hp⟩ := (Nat.card_ne_zero.mp hne).left
+  simp only [Set.mem_ofPred_eq, ← mul_assoc, QuotientGroup.eq, mul_inv_rev] at hp
+  have heq : y = x.inv := by
+    rw [← HeckeCoset.mk_rep y, ← mk_inv_rep]
+    apply mk_eq_iff.mpr
+    have : y.rep⁻¹ * p.2.out⁻¹ * x.rep⁻¹ ∈ H := by
+      simpa [mul_assoc] using
+        H.mul_mem hp (H.mul_mem (H.inv_mem (HeckeCoset.diag_mk_one_rep_mem H)) p.1.out.prop)
+    exact ⟨p.2.out, p.2.out.prop, (y.rep⁻¹ * p.2.out⁻¹ * x.rep⁻¹), this, by simp [mul_assoc]⟩
+  exact h heq
+
+@[simp]
+lemma multiplicity_apply_one {x y : HeckeCoset H H} [Decidable (y = x.inv)] :
+    x.multiplicity y (mk H H 1) = if y = x.inv then x.degree else 0 := by
+  by_cases h : y = x.inv
+  · simp [h, HeckeCoset.multiplicity_self_inv_mk_one_eq_degree]
+  · simp [h, HeckeCoset.multiplicity_ne_self_inv_mk_one_eq_zero]
+
+end HeckeCoset

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
@@ -49,9 +49,9 @@ class IsHeckeUnimodular (H : Subgroup G) : Prop where
   degree_eq_inv_degree : ∀ (x : DoubleCoset.Quotient (H : Set G) (H : Set G)),
     x.degree = (inv x).degree
 
-instance [IsHeckeUnimodular H] (g : G) [IsHeckeTriple H H g] :
-    IsHeckeTriple H H g⁻¹ := by
-  rw [isHeckeTriple_iff, ←inv_mk g, ← IsHeckeUnimodular.degree_eq_inv_degree]
+instance [IsHeckeUnimodular H] (g : G) [IsHeckeFinite H H g] :
+    IsHeckeFinite H H g⁻¹ := by
+  rw [isHeckeFinite_iff, ←inv_mk g, ← IsHeckeUnimodular.degree_eq_inv_degree]
   simp [mk_degree]
 
 namespace DoubleCoset₀
@@ -66,7 +66,7 @@ lemma coe_inv (x : DoubleCoset₀ H H) :
     x.inv = DoubleCoset.inv x.val := rfl
 
 @[simp]
-lemma inv_mk (g : G) [IsHeckeTriple H H g] :
+lemma inv_mk (g : G) [IsHeckeFinite H H g] :
     (mk H H g).inv = mk H H g⁻¹ := rfl
 
 lemma mk_inv_rep (x : DoubleCoset₀ H H) :

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.NumberTheory.HeckeRing.HeckeCoset.Multiplicity
 
 /-!
-# Multiplicity
+# Unimodular
 
 -/
 
@@ -53,6 +53,7 @@ instance [IsHeckeUnimodular H] (g : G) [IsHeckeTriple H H g] :
     IsHeckeTriple H H g⁻¹ := by
   rw [isHeckeTriple_iff, ←inv_mk g, ← IsHeckeUnimodular.degree_eq_inv_degree]
   simp [mk_degree]
+
 namespace DoubleCoset₀
 
 variable [IsHeckeUnimodular H]

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
@@ -20,7 +20,7 @@ variable {G : Type*} [Group G] {H H₁ H₂ : Subgroup G}
 
 namespace DoubleCoset
 
-/-- tbd -/
+/-- The map sending `H₁gH₂` to `H₂g⁻¹H₁`. -/
 def inv (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)) :
     DoubleCoset.Quotient (H₂ : Set G) (H₁ : Set G) :=
   Quotient.liftOn x (fun x => DoubleCoset.mk H₂ H₁ x⁻¹) fun a b hab => by
@@ -44,7 +44,7 @@ lemma inv_inv (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)) :
 
 end DoubleCoset
 
-/-- tbd -/
+/-- A subgroup `H` is called Hecke unimodular if `Nat.card HgH = Nat.card Hg⁻¹H` for any `g`. -/
 class IsHeckeUnimodular (H : Subgroup G) : Prop where
   degree_eq_inv_degree : ∀ (x : DoubleCoset.Quotient (H : Set G) (H : Set G)),
     x.degree = (inv x).degree
@@ -57,7 +57,7 @@ namespace HeckeCoset
 
 variable [IsHeckeUnimodular H]
 
-/-- tbd -/
+/-- The map sending `HgH` to `Hg⁻¹H`. -/
 def inv (x : HeckeCoset H H) :
     HeckeCoset H H := ⟨DoubleCoset.inv x, by simp [← IsHeckeUnimodular.degree_eq_inv_degree]⟩
 
@@ -82,7 +82,7 @@ lemma inv_eq_iff {x y : HeckeCoset H H} :
   ⟨by intro rfl; simp, by intro rfl; simp⟩
 
 @[simp]
-lemma inv_degree_eq_degree (x : HeckeCoset H H) :
+lemma inv_degree (x : HeckeCoset H H) :
     x.inv.degree = x.degree := by
   rw [← mk_rep x, mk_degree, ← DoubleCoset.mk_degree, IsHeckeUnimodular.degree_eq_inv_degree]
   simp [inv, mk_degree, DoubleCoset.mk_degree]
@@ -92,7 +92,7 @@ lemma diag_one_inv_eq_self :
   simp
 
 private lemma multiplicity_self_inv_mk_one_eq_degree (x : HeckeCoset H H) :
-    x.multiplicity x.inv (mk H H 1) = x.degree := by classical
+    x.multiplicity x.inv (mk H H 1) = x.degree := by
   simp only  [multiplicity_apply]
   obtain ⟨h₁, hh₁, h₂, hh₂, hinv⟩ := mk_eq_iff.mp
     (show mk H H x.rep⁻¹ = mk H H x.inv.rep by simp [mk_inv_rep])

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
@@ -5,7 +5,7 @@ Authors: Jiaxi Mo
 -/
 module
 
-public import Mathlib.RepresentationTheory.HeckeCoset.Multiplicity
+public import Mathlib.NumberTheory.HeckeRing.HeckeCoset.Multiplicity
 
 /-!
 # Multiplicity

--- a/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
+++ b/Mathlib/NumberTheory/HeckeRing/HeckeCoset/Unimodular.lean
@@ -53,36 +53,36 @@ instance [IsHeckeUnimodular H] (g : G) [IsHeckeTriple H H g] :
     IsHeckeTriple H H g⁻¹ := by
   rw [isHeckeTriple_iff, ←inv_mk g, ← IsHeckeUnimodular.degree_eq_inv_degree]
   simp [mk_degree]
-namespace HeckeCoset
+namespace DoubleCoset₀
 
 variable [IsHeckeUnimodular H]
 
 /-- The map sending `HgH` to `Hg⁻¹H`. -/
-def inv (x : HeckeCoset H H) :
-    HeckeCoset H H := ⟨DoubleCoset.inv x, by simp [← IsHeckeUnimodular.degree_eq_inv_degree]⟩
+def inv (x : DoubleCoset₀ H H) :
+    DoubleCoset₀ H H := ⟨DoubleCoset.inv x, by simp [← IsHeckeUnimodular.degree_eq_inv_degree]⟩
 
-lemma coe_inv (x : HeckeCoset H H) :
+lemma coe_inv (x : DoubleCoset₀ H H) :
     x.inv = DoubleCoset.inv x.val := rfl
 
 @[simp]
 lemma inv_mk (g : G) [IsHeckeTriple H H g] :
     (mk H H g).inv = mk H H g⁻¹ := rfl
 
-lemma mk_inv_rep (x : HeckeCoset H H) :
+lemma mk_inv_rep (x : DoubleCoset₀ H H) :
     mk H H x.rep⁻¹ = x.inv  := by
   simp [inv, ← DoubleCoset.mk_inv_out, rep_eq_out]
 
 @[simp]
-lemma inv_inv (x : HeckeCoset H H) :
+lemma inv_inv (x : DoubleCoset₀ H H) :
     x.inv.inv = x :=
   induction_on x (p := fun x => x.inv.inv = x) fun g => by simp
 
-lemma inv_eq_iff {x y : HeckeCoset H H} :
+lemma inv_eq_iff {x y : DoubleCoset₀ H H} :
     x.inv = y ↔ x = y.inv :=
   ⟨by intro rfl; simp, by intro rfl; simp⟩
 
 @[simp]
-lemma inv_degree (x : HeckeCoset H H) :
+lemma inv_degree (x : DoubleCoset₀ H H) :
     x.inv.degree = x.degree := by
   rw [← mk_rep x, mk_degree, ← DoubleCoset.mk_degree, IsHeckeUnimodular.degree_eq_inv_degree]
   simp [inv, mk_degree, DoubleCoset.mk_degree]
@@ -91,7 +91,7 @@ lemma diag_one_inv_eq_self :
     (mk H H 1).inv = (mk H H 1) := by
   simp
 
-private lemma multiplicity_self_inv_mk_one_eq_degree (x : HeckeCoset H H) :
+private lemma multiplicity_self_inv_mk_one_eq_degree (x : DoubleCoset₀ H H) :
     x.multiplicity x.inv (mk H H 1) = x.degree := by
   simp only  [multiplicity_apply]
   obtain ⟨h₁, hh₁, h₂, hh₂, hinv⟩ := mk_eq_iff.mp
@@ -121,26 +121,26 @@ private lemma multiplicity_self_inv_mk_one_eq_degree (x : HeckeCoset H H) :
       right_inv _ := rfl}
   simpa [degree_eq_rep] using Nat.card_congr equiv
 
-private lemma multiplicity_ne_self_inv_mk_one_eq_zero {x y : HeckeCoset H H} (h : y ≠ x.inv) :
+private lemma multiplicity_ne_self_inv_mk_one_eq_zero {x y : DoubleCoset₀ H H} (h : y ≠ x.inv) :
     x.multiplicity y (mk H H 1) = 0 := by
   simp only [multiplicity_apply]
   by_contra hne
   obtain ⟨p, hp⟩ := (Nat.card_ne_zero.mp hne).left
   simp only [Set.mem_ofPred_eq, ← mul_assoc, QuotientGroup.eq, mul_inv_rev] at hp
   have heq : y = x.inv := by
-    rw [← HeckeCoset.mk_rep y, ← mk_inv_rep]
+    rw [← DoubleCoset₀.mk_rep y, ← mk_inv_rep]
     apply mk_eq_iff.mpr
     have : y.rep⁻¹ * p.2.out⁻¹ * x.rep⁻¹ ∈ H := by
       simpa [mul_assoc] using
-        H.mul_mem hp (H.mul_mem (H.inv_mem (HeckeCoset.diag_mk_one_rep_mem H)) p.1.out.prop)
+        H.mul_mem hp (H.mul_mem (H.inv_mem (DoubleCoset₀.diag_mk_one_rep_mem H)) p.1.out.prop)
     exact ⟨p.2.out, p.2.out.prop, (y.rep⁻¹ * p.2.out⁻¹ * x.rep⁻¹), this, by simp [mul_assoc]⟩
   exact h heq
 
 @[simp]
-lemma multiplicity_apply_one {x y : HeckeCoset H H} [Decidable (y = x.inv)] :
+lemma multiplicity_apply_one {x y : DoubleCoset₀ H H} [Decidable (y = x.inv)] :
     x.multiplicity y (mk H H 1) = if y = x.inv then x.degree else 0 := by
   by_cases h : y = x.inv
-  · simp [h, HeckeCoset.multiplicity_self_inv_mk_one_eq_degree]
-  · simp [h, HeckeCoset.multiplicity_ne_self_inv_mk_one_eq_zero]
+  · simp [h, DoubleCoset₀.multiplicity_self_inv_mk_one_eq_degree]
+  · simp [h, DoubleCoset₀.multiplicity_ne_self_inv_mk_one_eq_zero]
 
-end HeckeCoset
+end DoubleCoset₀


### PR DESCRIPTION
This draft is a potential refactor of the standard Hecke double coset theory, aiming to pick up some possible common base materials for both `NumberTheory` and `RepresentationTheory`.

Review order: `DecompQuotient` => `Basic` => `Multiplicity` => `Unimodular` (Likely you don't need unimodular for modular forms, right?)

Remark. To keep the old `HeckeCoset` for `NumberTheory`, I renamed the generic `HeckeCoset` as `DoubleCoset₀` but it could also be `HeckeDoubleCoset` or something better.

Remark. `[IsHeckeFinite]` could in principle just be `[Finite DecompQuotient]`, but I am worry about registering `[Fintype DecompQuotient]` if we use `Finite`. Moreover, `IsHeckeFinite.degreeNeZero` is slightly more convenient since it packages  both `Finite`  and `Nonempty`.

Remark. `degree` is useful in `RepresentationTheory`, e.g. normalizing the trace of Hecke algebra action and the involution calculation. Moreover, working at the representative level without `degree` will need trivial conjugation lemmas frequently for different representatives.

Remark. We just choose representatives to define multiplicity on `DoubleCoset₀` but did not include proof of descent properties (and for my application it is somehow less important) For the moment the main selling point is that this allows **dot notation**, as showed in `Unimodular`, which will be helpful under other namespace like `HeckeAlgebra`.

I hope we can replace the current `IsHeckeTriple` by `[Finite DecompQuotient]` ( or rename it as `[IsHeckeFinite]/[DoubleCoset.HasFiniteDecomp]...`) hence eleminate some chasing finiteness proofs, no matter whether we eventually choose to work with `DoubleCoset` or `DoubleCoset₀`. If the full Hecke algebra API is a detour for `NumberTheory`, then the _**minimum**_ common base in this draft seems to be `DecompQuotient` plus a single instance
```
instance instIsHeckeFinite_trans [IsHeckeFinite H₁ H₂ g]
    [IsHeckeFinite H₂ H₃ g'] (h₂ : H₂) : IsHeckeFinite H₁ H₃ (g * h₂ * g') :=
```
Let me know if any other part is also interesting to you, so that I can move the rest to `RepresentationTheory`. @CBirkbeck 