### PR TITLE
[Merged by Bors] - chore(Data/Fin/SuccPred): avoid importing the order hierarchy

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3925,6 +3925,7 @@ public import Mathlib.Data.Erased
 public import Mathlib.Data.FP.Basic
 public import Mathlib.Data.Fin.Basic
 public import Mathlib.Data.Fin.Embedding
+public import Mathlib.Data.Fin.EquivOfInjective
 public import Mathlib.Data.Fin.Fin2
 public import Mathlib.Data.Fin.FlagRange
 public import Mathlib.Data.Fin.Init

--- a/Mathlib/Algebra/Group/Fin/Basic.lean
+++ b/Mathlib/Algebra/Group/Fin/Basic.lean
@@ -70,7 +70,7 @@ instance addCommGroup (n : ℕ) [NeZero n] : AddCommGroup (Fin n) where
   neg_add_cancel := fun ⟨a, ha⟩ ↦
     Fin.ext <| (Nat.mod_add_mod _ _ _).trans <| by
       rw [Fin.val_zero, Nat.sub_add_cancel, Nat.mod_self]
-      exact le_of_lt ha
+      exact Nat.le_of_lt ha
   sub := Fin.sub
   sub_eq_add_neg := fun ⟨a, ha⟩ ⟨b, hb⟩ ↦
     Fin.ext <| by simp [Fin.sub_def, Fin.neg_def, Fin.add_def, Nat.add_comm]
@@ -126,13 +126,11 @@ lemma lt_sub_one_iff {k : Fin (n + 2)} : k < k - 1 ↔ k = 0 := by
 @[simp] lemma le_sub_one_iff {k : Fin (n + 1)} : k ≤ k - 1 ↔ k = 0 := by
   cases n
   · simp [fin_one_eq_zero k]
-  simp only [le_def]
-  rw [← lt_sub_one_iff, le_iff_lt_or_eq, val_fin_lt, val_inj, lt_sub_one_iff, or_iff_left_iff_imp,
-    eq_comm, sub_eq_iff_eq_add]
+  rw [le_def, Nat.le_iff_lt_or_eq, val_fin_lt, lt_sub_iff, val_inj, eq_comm, sub_eq_self]
   simp
 
 lemma sub_one_lt_iff {k : Fin (n + 1)} : k - 1 < k ↔ 0 < k :=
-  not_iff_not.1 <| by simp only [lt_def, not_lt, val_fin_le, le_sub_one_iff, le_zero_iff]
+  not_iff_not.1 <| by simp only [lt_def, Nat.not_lt, val_fin_le, le_sub_one_iff, le_zero_iff]
 
 @[simp] lemma neg_last (n : ℕ) : -Fin.last n = 1 := by simp [neg_eq_iff_add_eq_zero]
 

--- a/Mathlib/Data/Fin/Embedding.lean
+++ b/Mathlib/Data/Fin/Embedding.lean
@@ -89,7 +89,7 @@ lemma nonempty_embedding_iff : Nonempty (Fin n ↪ Fin m) ↔ n ≤ m := by
   | zero => exact m.zero_le
   | succ n ihn =>
     obtain ⟨e⟩ := h
-    rcases exists_eq_succ_of_ne_zero (pos_iff_nonempty.2 (Nonempty.map e inferInstance)).ne'
+    rcases exists_eq_succ_of_ne_zero (Nat.ne_of_gt (pos_iff_nonempty.2 ⟨e 0⟩))
       with ⟨m, rfl⟩
     refine Nat.succ_le_succ <| ihn ⟨?_⟩
     refine ⟨fun i ↦ (e.setValue 0 0 i.succ).pred (mt e.setValue_eq_iff.1 i.succ_ne_zero),
@@ -97,7 +97,7 @@ lemma nonempty_embedding_iff : Nonempty (Fin n ↪ Fin m) ↔ n ≤ m := by
     simpa only [pred_inj, EmbeddingLike.apply_eq_iff_eq, succ_inj] using h
 
 lemma equiv_iff_eq : Nonempty (Fin m ≃ Fin n) ↔ m = n :=
-  ⟨fun ⟨e⟩ ↦ le_antisymm (nonempty_embedding_iff.1 ⟨e⟩) (nonempty_embedding_iff.1 ⟨e.symm⟩),
+  ⟨fun ⟨e⟩ ↦ Nat.le_antisymm (nonempty_embedding_iff.1 ⟨e⟩) (nonempty_embedding_iff.1 ⟨e.symm⟩),
     fun h ↦ h ▸ ⟨.refl _⟩⟩
 
 /-- `Fin.castAdd` as an `Embedding`, `castAddEmb m i` embeds `i : Fin n` in `Fin (n+m)`.

--- a/Mathlib/Data/Fin/EquivOfInjective.lean
+++ b/Mathlib/Data/Fin/EquivOfInjective.lean
@@ -1,0 +1,22 @@
+module -- shake: keep-all
+
+public import Mathlib.Data.Fin.SuccPred
+public import Mathlib.Logic.Equiv.Set
+
+deprecated_module (since := "2026-08-26")
+
+public section
+
+namespace Fin
+
+@[deprecated Equiv.apply_ofInjective_symm (since := "2026-08-26")]
+theorem coe_of_injective_castLE_symm {n k : ℕ} (h : n ≤ k) (i : Fin k) (hi) :
+    ((Equiv.ofInjective _ (castLE_injective h)).symm ⟨i, hi⟩ : ℕ) = i := by
+  rw [← val_castLE h, Equiv.apply_ofInjective_symm _ ⟨i, hi⟩]
+
+@[deprecated Equiv.apply_ofInjective_symm (since := "2026-08-26")]
+theorem coe_of_injective_castSucc_symm {n : ℕ} (i : Fin n.succ) (hi) :
+    ((Equiv.ofInjective castSucc (castSucc_injective _)).symm ⟨i, hi⟩ : ℕ) = i := by
+  rw [← val_castSucc, Equiv.apply_ofInjective_symm _ ⟨i, hi⟩]
+
+end Fin

--- a/Mathlib/Data/Fin/Rev.lean
+++ b/Mathlib/Data/Fin/Rev.lean
@@ -6,6 +6,8 @@ Authors: Eric Rodriguez, Joel Riou, Yury Kudryashov
 module
 
 public import Mathlib.Data.Fin.SuccPred
+public import Mathlib.Logic.Equiv.Basic
+
 /-!
 # Reverse on `Fin n`
 

--- a/Mathlib/Data/Fin/SuccPred.lean
+++ b/Mathlib/Data/Fin/SuccPred.lean
@@ -6,6 +6,7 @@ Authors: Eric Rodriguez
 module
 
 public import Mathlib.Data.Fin.Basic
+public import Mathlib.Data.Set.Operations
 
 /-!
 # Successors and predecessor operations of `Fin n`
@@ -101,7 +102,7 @@ lemma castSucc_injective (n : ℕ) : Injective (@Fin.castSucc n) := castAdd_inje
     Fin.castLE h ∘ Fin.castSucc = Fin.castLE (Nat.le_of_succ_le h) :=
   rfl
 
-@[simp] lemma castLE_rfl (n : ℕ) : Fin.castLE (le_refl n) = id :=
+@[simp] lemma castLE_rfl (n : ℕ) : Fin.castLE (Nat.le_refl n) = id :=
   rfl
 
 @[simp]
@@ -245,7 +246,7 @@ theorem castSucc_castAdd (i : Fin n) : castSucc (castAdd m i) = castAdd (m + 1) 
 
 theorem succ_castAdd (i : Fin n) : succ (castAdd m i) =
     if h : i.succ = last _ then natAdd n (0 : Fin (m + 1))
-      else castAdd (m + 1) ⟨i.1 + 1, lt_of_le_of_ne i.2 (Fin.val_ne_iff.mpr h)⟩ := by
+      else castAdd (m + 1) ⟨i.1 + 1, Nat.lt_of_le_of_ne i.2 (Fin.val_ne_iff.mpr h)⟩ := by
   split_ifs with h
   exacts [Fin.ext (congr_arg Fin.val h :), rfl]
 
@@ -270,7 +271,7 @@ theorem pred_one' [NeZero n] (h := (zero_ne_one' (n := n)).symm) :
     Fin.pred (1 : Fin (n + 1)) h = 0 := by
   simp_rw [Fin.ext_iff, val_pred, val_one', val_zero, Nat.sub_eq_zero_iff_le, Nat.mod_le]
 
-theorem pred_last (h := Fin.ext_iff.not.2 last_pos'.ne') :
+theorem pred_last (h := Fin.ext_iff.not.2 (Nat.ne_of_gt last_pos')) :
     pred (last (n + 1)) h = last n := by simp_rw [← succ_last, pred_succ]
 
 theorem pred_lt_iff {j : Fin n} {i : Fin (n + 1)} (hi : i ≠ 0) : pred i hi < j ↔ i < succ j := by
@@ -298,7 +299,7 @@ theorem pred_castSucc_lt_iff {a b : Fin (n + 1)} (ha : castSucc a ≠ 0) :
   rw [pred_lt_iff, castSucc_lt_succ_iff]
 
 theorem pred_castSucc_lt {a : Fin (n + 1)} (ha : castSucc a ≠ 0) :
-    (castSucc a).pred ha < a := by rw [pred_castSucc_lt_iff, le_def]
+    (castSucc a).pred ha < a := by simp [pred_castSucc_lt_iff]
 
 theorem le_castSucc_pred_iff {a b : Fin (n + 1)} (ha : a ≠ 0) :
     b ≤ castSucc (a.pred ha) ↔ b < a := by
@@ -309,7 +310,7 @@ theorem castSucc_pred_lt_iff {a b : Fin (n + 1)} (ha : a ≠ 0) :
   rw [castSucc_pred_eq_pred_castSucc, pred_castSucc_lt_iff]
 
 theorem castSucc_pred_lt {a : Fin (n + 1)} (ha : a ≠ 0) :
-    castSucc (a.pred ha) < a := by rw [castSucc_pred_lt_iff, le_def]
+    castSucc (a.pred ha) < a := by simp [castSucc_pred_lt_iff]
 
 end Pred
 
@@ -319,15 +320,16 @@ section CastPred
 @[inline] def castPred (i : Fin (n + 1)) (h : i ≠ last n) : Fin n := castLT i (val_lt_last h)
 
 @[simp]
-lemma castLT_eq_castPred (i : Fin (n + 1)) (h : i < last _) (h' := Fin.ext_iff.not.2 h.ne) :
-    castLT i h = castPred i h' := rfl
+lemma castLT_eq_castPred (i : Fin (n + 1)) (h : i < last _)
+    (h' := Fin.ext_iff.not.2 (Nat.ne_of_lt h)) : castLT i h = castPred i h' := rfl
 
 @[simp]
 lemma coe_castPred (i : Fin (n + 1)) (h : i ≠ last _) : (castPred i h : ℕ) = i := rfl
 
 @[simp]
-theorem castPred_castSucc {i : Fin n} (h' := Fin.ext_iff.not.2 (castSucc_lt_last i).ne) :
-    castPred (castSucc i) h' = i := rfl
+theorem castPred_castSucc {i : Fin n}
+    (h' := Fin.ext_iff.not.2 (Nat.ne_of_lt <| castSucc_lt_last i)) : castPred (castSucc i) h' = i :=
+  rfl
 
 @[simp]
 theorem castSucc_castPred (i : Fin (n + 1)) (h : i ≠ last n) :
@@ -340,8 +342,8 @@ theorem castPred_eq_iff_eq_castSucc (i : Fin (n + 1)) (hi : i ≠ last _) (j : F
   ⟨fun h => by rw [← h, castSucc_castPred], fun h => by simp_rw [h, castPred_castSucc]⟩
 
 @[simp]
-theorem castPred_mk (i : ℕ) (h₁ : i < n) (h₂ := h₁.trans (Nat.lt_succ_self _))
-    (h₃ : ⟨i, h₂⟩ ≠ last _ := (ne_iff_vne _ _).mpr (val_last _ ▸ h₁.ne)) :
+theorem castPred_mk (i : ℕ) (h₁ : i < n) (h₂ := Nat.lt_trans h₁ (Nat.lt_succ_self _))
+    (h₃ : ⟨i, h₂⟩ ≠ last _ := (ne_iff_vne _ _).mpr (val_last _ ▸ Nat.ne_of_lt h₁)) :
     castPred ⟨i, h₂⟩ h₃ = ⟨i, h₁⟩ := rfl
 
 @[simp]
@@ -385,11 +387,11 @@ theorem le_castPred_iff {j : Fin n} {i : Fin (n + 1)} (hi : i ≠ last n) :
 @[simp]
 theorem castPred_inj {i j : Fin (n + 1)} {hi : i ≠ last n} {hj : j ≠ last n} :
     castPred i hi = castPred j hj ↔ i = j := by
-  simp_rw [Fin.ext_iff, le_antisymm_iff, ← le_def, castPred_le_castPred_iff]
+  simp_rw [Fin.ext_iff, Nat.le_antisymm_iff, ← le_def, castPred_le_castPred_iff]
 
 @[simp]
 theorem castPred_zero [NeZero n] :
-    castPred (0 : Fin (n + 1)) (Fin.ext_iff.not.2 last_pos'.ne) = 0 := rfl
+    castPred (0 : Fin (n + 1)) (Fin.ext_iff.not.2 (Nat.ne_of_lt last_pos')) = 0 := rfl
 
 @[simp]
 theorem castPred_eq_zero [NeZero n] {i : Fin (n + 1)} (h : i ≠ last n) :
@@ -402,7 +404,7 @@ theorem castPred_ne_zero [NeZero n] {i : Fin (n + 1)} (h₁ : i ≠ last n) (h�
 
 @[simp]
 theorem castPred_one [NeZero n] :
-    castPred (1 : Fin (n + 2)) (Fin.ext_iff.not.2 one_lt_last.ne) = 1 := by
+    castPred (1 : Fin (n + 2)) (Fin.ext_iff.not.2 (Nat.ne_of_lt one_lt_last)) = 1 := by
   cases n
   · exact subsingleton_one.elim _ 1
   · rfl
@@ -426,7 +428,7 @@ theorem lt_castPred_succ_iff {a b : Fin (n + 1)} (ha : succ a ≠ last (n + 1)) 
   rw [lt_castPred_iff, castSucc_lt_succ_iff]
 
 theorem lt_castPred_succ {a : Fin (n + 1)} (ha : succ a ≠ last (n + 1)) :
-    a < (succ a).castPred ha := by rw [lt_castPred_succ_iff, le_def]
+    a < (succ a).castPred ha := by simp [lt_castPred_succ_iff]
 
 theorem succ_castPred_le_iff {a b : Fin (n + 1)} (ha : a ≠ last n) :
     succ (a.castPred ha) ≤ b ↔ a < b := by
@@ -437,7 +439,7 @@ theorem lt_succ_castPred_iff {a b : Fin (n + 1)} (ha : a ≠ last n) :
   rw [succ_castPred_eq_castPred_succ ha, lt_castPred_succ_iff]
 
 theorem lt_succ_castPred {a : Fin (n + 1)} (ha : a ≠ last n) :
-    a < succ (a.castPred ha) := by rw [lt_succ_castPred_iff, le_def]
+    a < succ (a.castPred ha) := by simp [lt_succ_castPred_iff]
 
 theorem castPred_le_pred_iff {a b : Fin (n + 1)} (ha : a ≠ last n) (hb : b ≠ 0) :
     castPred a ha ≤ pred b hb ↔ a < b := by
@@ -449,21 +451,21 @@ theorem pred_lt_castPred_iff {a b : Fin (n + 1)} (ha : a ≠ 0) (hb : b ≠ last
 
 theorem pred_lt_castPred {a : Fin (n + 1)} (h₁ : a ≠ 0) (h₂ : a ≠ last n) :
     pred a h₁ < castPred a h₂ := by
-  rw [pred_lt_castPred_iff, le_def]
+  simp [pred_lt_castPred_iff]
 
 theorem val_sub_castLT_of_le {a b : Fin m} (ha : a.val < n) (h : b ≤ a) :
-    (a.castLT ha - b.castLT (lt_of_le_of_lt h ha)).val = (a - b).val := by
-  have : b.castLT (lt_of_le_of_lt h ha) ≤ a.castLT ha := by simpa [← val_fin_le] using h
+    (a.castLT ha - b.castLT (Nat.lt_of_le_of_lt h ha)).val = (a - b).val := by
+  have : b.castLT (Nat.lt_of_le_of_lt h ha) ≤ a.castLT ha := by simpa [← val_fin_le] using h
   simp [sub_val_of_le, h, this]
 
 theorem sub_castLT_eq_castLT_sub_of_le {a b : Fin m} (ha : a.val < n) (h : b ≤ a) :
-    a.castLT ha - b.castLT (lt_of_le_of_lt h ha) =
+    a.castLT ha - b.castLT (Nat.lt_of_le_of_lt h ha) =
       (a - b).castLT (val_sub_lt_of_lt_of_le ha h) := by
   rw [Fin.ext_iff]
   exact val_sub_castLT_of_le ha h
 
 theorem val_sub_castLT_of_lt {a b : Fin m} (hb : b < n) (h : a < b) :
-    (a.castLT (lt_trans h hb) - b.castLT hb).val = (a - b).val + n - m := by
+    (a.castLT (Nat.lt_trans h hb) - b.castLT hb).val = (a - b).val + n - m := by
   simp only [val_sub, val_castLT]
   repeat rw [Nat.mod_eq_of_lt (by omega)]
   have h' : a.val < b.val := h

--- a/Mathlib/Data/Fin/SuccPred.lean
+++ b/Mathlib/Data/Fin/SuccPred.lean
@@ -6,7 +6,6 @@ Authors: Eric Rodriguez
 module
 
 public import Mathlib.Data.Fin.Basic
-public import Mathlib.Logic.Equiv.Set
 
 /-!
 # Successors and predecessor operations of `Fin n`
@@ -24,7 +23,7 @@ related to `Fin.succ`, `Fin.pred`, and related operations on `Fin n`.
 
 @[expose] public section
 
-assert_not_exists Monoid Finset
+assert_not_exists Monoid Finset OrderTop
 
 open Fin Nat Function
 
@@ -108,12 +107,6 @@ lemma castSucc_injective (n : ℕ) : Injective (@Fin.castSucc n) := castAdd_inje
 @[simp]
 theorem range_castLE {n k : ℕ} (h : n ≤ k) : Set.range (castLE h) = { i : Fin k | (i : ℕ) < n } :=
   Set.ext fun x => ⟨fun ⟨y, hy⟩ => hy ▸ y.2, fun hx => ⟨⟨x, hx⟩, rfl⟩⟩
-
-@[simp]
-theorem coe_of_injective_castLE_symm {n k : ℕ} (h : n ≤ k) (i : Fin k) (hi) :
-    ((Equiv.ofInjective _ (castLE_injective h)).symm ⟨i, hi⟩ : ℕ) = i := by
-  rw [← val_castLE h]
-  exact congr_arg Fin.val (Equiv.apply_ofInjective_symm _ _)
 
 theorem leftInverse_cast (eq : n = m) : LeftInverse (Fin.cast eq.symm) (Fin.cast eq) :=
   fun _ => rfl
@@ -247,12 +240,6 @@ theorem coe_succ_lt_iff_lt {n : ℕ} {j k : Fin n} : (j : Fin (n + 1)) < k ↔ j
 @[simp]
 theorem range_castSucc {n : ℕ} : Set.range (castSucc : Fin n → Fin n.succ) =
     ({ i | (i : ℕ) < n } : Set (Fin n.succ)) := range_castLE (by lia)
-
-@[simp]
-theorem coe_of_injective_castSucc_symm {n : ℕ} (i : Fin n.succ) (hi) :
-    ((Equiv.ofInjective castSucc (castSucc_injective _)).symm ⟨i, hi⟩ : ℕ) = i := by
-  rw [← val_castSucc]
-  exact congr_arg val (Equiv.apply_ofInjective_symm _ _)
 
 theorem castSucc_castAdd (i : Fin n) : castSucc (castAdd m i) = castAdd (m + 1) i := rfl
 
@@ -685,7 +672,8 @@ lemma exists_succAbove_eq {x y : Fin (n + 1)} (h : x ≠ y) : ∃ z, y.succAbove
 
 /-- `succAbove` is injective at the pivot -/
 lemma succAbove_left_injective : Injective (@succAbove n) := fun _ _ h => by
-  simpa [range_succAbove] using congr_arg (fun f : Fin n → Fin (n + 1) => (Set.range f)ᶜ) h
+  by_contra! hne
+  simp [← exists_succAbove_eq_iff, ← h] at hne
 
 /-- `succAbove` is injective at the pivot -/
 @[simp] lemma succAbove_left_inj {x y : Fin (n + 1)} : x.succAbove = y.succAbove ↔ x = y :=

--- a/Mathlib/Data/Fin/SuccPred.lean
+++ b/Mathlib/Data/Fin/SuccPred.lean
@@ -24,7 +24,7 @@ related to `Fin.succ`, `Fin.pred`, and related operations on `Fin n`.
 
 @[expose] public section
 
-assert_not_exists Monoid Finset OrderTop
+assert_not_exists Monoid Finset Preorder
 
 open Fin Nat Function
 

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -10,6 +10,8 @@ public import Mathlib.Data.Nat.Find
 public import Mathlib.Order.Fin.Basic
 public import Batteries.Data.Fin.Lemmas
 
+import Mathlib.Data.Set.Insert
+
 /-!
 # Operation on tuples
 

--- a/Mathlib/Data/Fin/Tuple/Embedding.lean
+++ b/Mathlib/Data/Fin/Tuple/Embedding.lean
@@ -6,7 +6,9 @@ Authors: Antoine Chambert-Loir
 module
 
 public import Mathlib.Data.Fin.Tuple.Basic
-public import Mathlib.Order.Fin.Basic
+public import Mathlib.Data.Set.Basic
+
+import Mathlib.Data.Set.Disjoint
 
 /-! # Constructions of embeddings of `Fin n` into a type
 
@@ -81,7 +83,7 @@ theorem snoc_last {n : ℕ} {x : Fin n ↪ α} {a : α} {ha : a ∉ range x} :
 def append {m n : ℕ} {x : Fin m ↪ α} {y : Fin n ↪ α} (h : Disjoint (range x) (range y)) :
     Fin (m + n) ↪ α :=
   ⟨Fin.append x y,
-    Fin.append_injective_iff.mpr ⟨x.inj', y.inj', disjoint_range_iff.mp h⟩⟩
+    Fin.append_injective_iff.mpr ⟨x.inj', y.inj', by exact disjoint_range_iff.mp h⟩⟩
 
 @[simp, norm_cast]
 theorem coe_append {m n : ℕ} {x : Fin m ↪ α} {y : Fin n ↪ α} (h : Disjoint (range x) (range y)) :

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Data.Fin.Tuple.Basic
 
+import Mathlib.Data.Set.Image
+
 /-!
 # Matrix and vector notation
 

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 module
 
+public import Mathlib.Data.Bool.Basic
 public import Mathlib.Data.Num.Basic
 public import Mathlib.Data.Vector.Basic
 

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -225,7 +225,7 @@ theorem empty_toList_eq_ff (v : Vector α (n + 1)) : v.toList.isEmpty = false :=
   | ⟨_ :: _, _⟩ => rfl
 
 theorem not_empty_toList (v : Vector α (n + 1)) : ¬v.toList.isEmpty := by
-  simp only [empty_toList_eq_ff, Bool.coe_sort_false, not_false_iff]
+  simp [empty_toList_eq_ff]
 
 /-- Mapping under `id` does not change a vector. -/
 @[simp]
@@ -553,8 +553,7 @@ theorem eraseIdx_insertIdx' {v : Vector α (n + 1)} :
     rw [Subtype.mk_eq_mk]
     simp only [Fin.lt_def]
     split_ifs with hij
-    · rcases Nat.exists_eq_succ_of_ne_zero
-        (Nat.pos_iff_ne_zero.1 (lt_of_le_of_lt (Nat.zero_le _) hij)) with ⟨j, rfl⟩
+    · rcases j.exists_eq_succ_of_ne_zero (Nat.ne_zero_of_lt hij) with ⟨j, rfl⟩
       rw [← List.insertIdx_eraseIdx_of_ge]
       · simp; rfl
       · simpa

--- a/Mathlib/Order/Fin/Basic.lean
+++ b/Mathlib/Order/Fin/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Order.IsBotOne
 public import Mathlib.Data.Fin.Embedding
 public import Mathlib.Data.Fin.Rev
+public import Mathlib.Order.Heyting.Basic
 public import Mathlib.Order.Hom.Basic
 
 /-!

--- a/Mathlib/Order/Interval/Set/Fin.lean
+++ b/Mathlib/Order/Interval/Set/Fin.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Order.Fin.Basic
 public import Mathlib.Order.Interval.Set.UnorderedInterval
 
+import Mathlib.Logic.Equiv.Set
+
 /-!
 # (Pre)images of set intervals under `Fin` operations
 


### PR DESCRIPTION
`Mathlib.Data.Fin.SuccPred` imports `Mathlib.Logic.Equiv.Set` mostly for two simp lemmas that use `Equiv.ofInjective`, which brings with it nontrivial order definitions such as `BooleanAlgebra`.
These were introduced in leanprover-community/mathlib3#6815 but seemingly never used and spelled strangely, so we deprecate them.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
