### PR TITLE
[Merged by Bors] - chore: card -> length for `List.length` in names

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/List/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List/Defs.lean
@@ -92,9 +92,12 @@ theorem prod_replicate (n : ℕ) (a : M) : (replicate n a).prod = a ^ n := by
   | zero => rw [pow_zero, replicate_zero, prod_nil]
   | succ n ih => rw [replicate_succ, prod_cons, ih, pow_succ']
 
-@[to_additive sum_eq_card_nsmul]
-theorem prod_eq_pow_card (l : List M) (m : M) (h : ∀ x ∈ l, x = m) : l.prod = m ^ l.length := by
+@[to_additive sum_eq_length_nsmul]
+theorem prod_eq_pow_length (l : List M) (m : M) (h : ∀ x ∈ l, x = m) : l.prod = m ^ l.length := by
   rw [← prod_replicate, ← List.eq_replicate_iff.mpr ⟨rfl, h⟩]
+
+@[to_additive (attr := deprecated (since := "2026-08-26")) sum_eq_card_nsmul]
+alias prod_eq_pow_card := prod_eq_pow_length
 
 @[to_additive]
 theorem prod_hom_rel (l : List ι) {r : M → N → Prop} {f : ι → M} {g : ι → N} (h₁ : r 1 1)

--- a/Mathlib/Algebra/Order/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/List.lean
@@ -87,17 +87,23 @@ lemma prod_lt_prod_of_ne_nil [Preorder M] [MulLeftStrictMono M]
   (prod_lt_prod' f g fun i hi => (hlt i hi).le) <|
     (exists_mem_of_ne_nil l hl).imp fun i hi => ⟨hi, hlt i hi⟩
 
-@[to_additive sum_le_card_nsmul]
-lemma prod_le_pow_card [Preorder M] [MulRightMono M]
+@[to_additive sum_le_length_nsmul]
+lemma prod_le_pow_length [Preorder M] [MulRightMono M]
     [MulLeftMono M] (l : List M) (n : M) (h : ∀ x ∈ l, x ≤ n) :
     l.prod ≤ n ^ l.length := by
   simpa only [map_id', map_const', prod_replicate] using prod_le_prod' h
 
-@[to_additive card_nsmul_le_sum]
-lemma pow_card_le_prod [Preorder M] [MulRightMono M]
+@[to_additive (attr := deprecated (since := "2026-08-26")) sum_le_card_nsmul]
+alias prod_le_pow_card := prod_le_pow_length
+
+@[to_additive length_nsmul_le_sum]
+lemma pow_length_le_prod [Preorder M] [MulRightMono M]
     [MulLeftMono M] (l : List M) (n : M) (h : ∀ x ∈ l, n ≤ x) :
     n ^ l.length ≤ l.prod :=
-  @prod_le_pow_card Mᵒᵈ _ _ _ _ l n h
+  @prod_le_pow_length Mᵒᵈ _ _ _ _ l n h
+
+@[to_additive (attr := deprecated (since := "2026-08-26")) card_nsmul_le_sum]
+alias pow_card_le_prod := pow_length_le_prod
 
 @[to_additive exists_lt_of_sum_lt]
 lemma exists_lt_of_prod_lt' [LinearOrder M] [MulRightMono M]
@@ -117,8 +123,7 @@ lemma exists_le_of_prod_le' [LinearOrder M] [MulLeftStrictMono M]
 @[to_additive sum_nonneg]
 lemma one_le_prod_of_one_le [Preorder M] [MulLeftMono M] {l : List M}
     (hl₁ : ∀ x ∈ l, (1 : M) ≤ x) : 1 ≤ l.prod := by
-  -- We don't use `pow_card_le_prod` to avoid assumption
-  -- [CovariantClass M M (Function.swap (· * ·)) (· ≤ ·)]
+  -- We don't use `pow_length_le_prod` to avoid assumption [MulRightMono M]
   induction l with
   | nil => rfl
   | cons hd tl ih =>

--- a/Mathlib/Algebra/Order/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/List.lean
@@ -123,7 +123,7 @@ lemma exists_le_of_prod_le' [LinearOrder M] [MulLeftStrictMono M]
 @[to_additive sum_nonneg]
 lemma one_le_prod_of_one_le [Preorder M] [MulLeftMono M] {l : List M}
     (hl₁ : ∀ x ∈ l, (1 : M) ≤ x) : 1 ≤ l.prod := by
-  -- We don't use `pow_length_le_prod` to avoid assumption [MulRightMono M]
+  -- We don't use `pow_length_le_prod` to avoid having to assume `[MulRightMono M]`
   induction l with
   | nil => rfl
   | cons hd tl ih =>

--- a/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
@@ -40,7 +40,7 @@ lemma single_le_prod [IsOrderedMonoid α] : (∀ x ∈ s, (1 : α) ≤ x) → �
 lemma prod_le_pow_card [MulLeftMono α] (s : Multiset α) (n : α) (h : ∀ x ∈ s, x ≤ n) :
     s.prod ≤ n ^ card s := by
   induction s using Quotient.inductionOn
-  simpa using List.prod_le_pow_card _ _ h
+  simpa using List.prod_le_pow_length _ _ h
 
 @[to_additive all_zero_of_le_zero_le_of_sum_eq_zero]
 lemma all_one_of_le_one_le_of_prod_eq_one {α : Type*} [CommMonoid α]

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -121,7 +121,7 @@ theorem coeff_list_prod_of_natDegree_le (l : List S[X]) (n : ℕ) (hl : ∀ p �
     have h : natDegree tl.prod ≤ n * tl.length := by
       refine (natDegree_list_prod_le _).trans ?_
       rw [← tl.length_map natDegree, mul_comm]
-      refine List.sum_le_card_nsmul _ _ ?_
+      refine List.sum_le_length_nsmul _ _ ?_
       simpa using hl'
     exact coeff_mul_add_eq_of_natDegree_le (hl _ List.mem_cons_self) h
 

--- a/Mathlib/Algebra/TrivSqZeroExt/Basic.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt/Basic.lean
@@ -577,7 +577,7 @@ theorem snd_pow_of_smul_comm [Monoid R] [AddMonoid M] [DistribMulAction R M]
   | 0 => rw [Nat.pred_zero, pow_zero, List.range_zero, zero_smul, List.map_nil, List.sum_nil]
   | (Nat.succ n) =>
     simp_rw [Nat.pred_succ]
-    exact (List.sum_eq_card_nsmul _ (x.fst ^ n • x.snd) (by grind)).trans
+    exact (sum_eq_length_nsmul _ (x.fst ^ n • x.snd) (by grind)).trans
       (by rw [List.length_map, List.length_range])
 where
   aux : ∀ n : ℕ, x.snd <• x.fst ^ n = x.fst ^ n •> x.snd := by

--- a/Mathlib/Algebra/TrivSqZeroExt/Basic.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt/Basic.lean
@@ -577,7 +577,7 @@ theorem snd_pow_of_smul_comm [Monoid R] [AddMonoid M] [DistribMulAction R M]
   | 0 => rw [Nat.pred_zero, pow_zero, List.range_zero, zero_smul, List.map_nil, List.sum_nil]
   | (Nat.succ n) =>
     simp_rw [Nat.pred_succ]
-    exact (sum_eq_length_nsmul _ (x.fst ^ n • x.snd) (by grind)).trans
+    exact (List.sum_eq_length_nsmul _ (x.fst ^ n • x.snd) (by grind)).trans
       (by rw [List.length_map, List.length_range])
 where
   aux : ∀ n : ℕ, x.snd <• x.fst ^ n = x.fst ^ n •> x.snd := by

--- a/Mathlib/Data/Finset/NoncommProd.lean
+++ b/Mathlib/Data/Finset/NoncommProd.lean
@@ -189,7 +189,7 @@ theorem noncommProd_eq_pow_card (s : Multiset α) (comm) (m : α) (h : ∀ x ∈
     s.noncommProd comm = m ^ Multiset.card s := by
   induction s using Quotient.inductionOn
   simp only [quot_mk_to_coe, noncommProd_coe, coe_card, mem_coe] at *
-  exact List.prod_eq_pow_card _ m h
+  exact List.prod_eq_pow_length _ m h
 
 @[to_additive]
 theorem noncommProd_eq_prod {α : Type*} [CommMonoid α] (s : Multiset α) :


### PR DESCRIPTION
Some theorem names used `card` instead of `length` to refer to `List.length`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
