### PR TITLE
ci: publish the master cache to R2 and verify direct bucket reads

### DIFF
--- a/.github/workflows/r2_cache_publish.yml
+++ b/.github/workflows/r2_cache_publish.yml
@@ -1,0 +1,378 @@
+name: publish cache to R2
+
+# Publishes the master cache to the R2 bucket after every master CI run, and
+# verifies that the bucket alone serves the commit's full cache — with no
+# Azure fallback in the read path.
+#
+# Jobs (per master push, after `continuous integration` completes):
+#   upload   Assemble the commit's full `.ltar` set locally: warm from the
+#            triggering run's `cache-snapshot` and `cache-staging` artifacts
+#            (free bandwidth, no storage egress), then top up anything still
+#            missing through the normal read chain (MATHLIB_CACHE_BASE_URL;
+#            its backend falls back to Azure, so files the bucket does not
+#            hold yet arrive from there). Copy the set to the bucket; only
+#            objects the bucket is missing are transferred.
+#   verify   Fresh runner, empty cache dir, MATHLIB_CACHE_GET_URL pointed at
+#            the bucket's anonymous host. Passes only when every file of the
+#            commit's closure downloads: 100% hits served by the bucket.
+#   marker   Write the completeness marker m/leanprover-community/mathlib4/{sha}
+#            (content: the sha). Files first, marker last; the `verify` job
+#            between them is the completeness proof the marker asserts.
+#   report   Zulip message when any job fails.
+#
+# Required repository configuration:
+#   Environment `cache-upload-master` — the deployment branch policy admits
+#   only refs release managers control (master, staging, v4.* tags), so a
+#   dispatch from any other ref cannot reach these secrets:
+#     MATHLIB_CACHE_R2_WRITE_KEY  S3 credential for the bucket, as
+#                                 `<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>`
+#                                 (an R2 API token scoped to the cache
+#                                 bucket, Object Read & Write).
+#     MATHLIB_CACHE_R2_GET_URL    Anonymous read endpoint for verification,
+#                                 e.g. `https://<bucket-public-host>/mathlib4`.
+#                                 A secret, not a variable: public run logs
+#                                 must not advertise a URL that bypasses the
+#                                 resolver (its metrics and cached-404
+#                                 protection only see traffic that goes
+#                                 through it). The S3 endpoint below stays a
+#                                 variable because it is useless without the
+#                                 write key.
+#   Repository variables:
+#     MATHLIB_CACHE_R2_S3_ENDPOINT  Authenticated S3 endpoint for uploads,
+#                                   e.g. `https://<account>.r2.cloudflarestorage.com`.
+#     MATHLIB_CACHE_BASE_URL        (existing) read base for the top-up fetch.
+#   Repository secrets:
+#     ZULIP_API_KEY               (existing) used by `report`.
+
+on:
+  workflow_run:
+    workflows: ["continuous integration"]
+    types: [completed]
+    branches: [master]
+  # Manual fallback: re-run a commit whose publish failed, or seed from the
+  # most recent master build. The gate job validates the source run, so a
+  # dispatch cannot feed the bucket from anything but a master push build.
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: >-
+          id of a successful master-push `continuous integration` run to
+          publish; empty takes the most recent one
+        required: false
+        type: string
+        default: ''
+
+# No concurrency group: parallel runs are safe (uploads are content-addressed
+# and idempotent, each run verifies and marks only its own commit), and a
+# queued-run cancellation would silently skip a commit's marker.
+
+permissions:
+  contents: read
+  actions: read # read the triggering run's metadata and artifacts
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  upload:
+    name: Upload master cache to R2
+    if: >-
+      github.repository == 'leanprover-community/mathlib4' &&
+      (github.event_name == 'workflow_dispatch' ||
+        (github.event.workflow_run.conclusion == 'success' &&
+         github.event.workflow_run.event == 'push' &&
+         github.event.workflow_run.head_branch == 'master'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: cache-upload-master
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+      run_id: ${{ steps.resolve.outputs.run_id }}
+    env:
+      MATHLIB_CACHE_DIR: ${{ github.workspace }}/r2-publish-cache
+      RCLONE_CONFIG_R2_TYPE: s3
+      RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+      RCLONE_CONFIG_R2_ENDPOINT: ${{ vars.MATHLIB_CACHE_R2_S3_ENDPOINT }}
+      RCLONE_CONFIG_R2_NO_CHECK_BUCKET: "true"
+      # Bucket and key prefix of the master namespace. The prefix is part of
+      # the published URL contract; change it only with the resolver config.
+      R2_DEST: mathlib4-cache/mathlib4
+    steps:
+      - name: Resolve and validate the source run
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGERING_RUN_ID: ${{ github.event.workflow_run.id }}
+          INPUT_RUN_ID: ${{ inputs.run_id }}
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
+            RUN_ID="${TRIGGERING_RUN_ID}"
+          else
+            RUN_ID="${INPUT_RUN_ID}"
+            if [ -z "${RUN_ID}" ]; then
+              RUN_ID="$(gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/build.yml/runs?branch=master&event=push&status=success&per_page=1" \
+                --jq '.workflow_runs[0].id // empty')"
+            fi
+          fi
+          if [ -z "${RUN_ID}" ]; then
+            echo "::error::no source run found"
+            exit 1
+          fi
+          # Both trigger paths pass this one validation: only a successful
+          # master-push run of build.yml may feed the master namespace
+          # (contributors with branch push access can dispatch workflows, so
+          # the run id input is untrusted).
+          IFS=$'\t' read -r wf_path head_branch event conclusion sha < <(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" \
+            --jq '[.path, .head_branch, .event, .conclusion, .head_sha] | @tsv')
+          if [ "${wf_path}" != ".github/workflows/build.yml" ] \
+              || [ "${head_branch}" != "master" ] \
+              || [ "${event}" != "push" ] \
+              || [ "${conclusion}" != "success" ]; then
+            echo "::error::run ${RUN_ID} is not a successful master-push build.yml run \
+          (path=${wf_path} branch=${head_branch} event=${event} conclusion=${conclusion})"
+            exit 1
+          fi
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "::notice::publishing the cache of ${sha} from run ${RUN_ID}"
+
+      - name: Checkout mathlib at the built commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.resolve.outputs.sha }}
+          path: mathlib
+
+      - name: Install elan
+        run: |
+          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
+          chmod +x elan-init.sh
+          ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      # The two warm-start artifacts are bandwidth savers, not correctness
+      # requirements: the top-up fetch below covers whatever they miss. Both
+      # can legitimately be absent (`cache-snapshot` uploads best-effort;
+      # `cache-staging` is skipped when a build stages nothing).
+      - name: Check which artifacts the source run carries
+        id: artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ steps.resolve.outputs.run_id }}
+        run: |
+          for name in cache-snapshot cache-staging; do
+            found="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts?name=${name}&per_page=100" \
+              --jq "[.artifacts[] | select(.name == \"${name}\" and .expired == false)] | length")"
+            key="${name//-/_}"
+            if [ "${found}" -gt 0 ]; then
+              echo "${key}=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "${key}=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::run ${RUN_ID} carries no ${name} artifact; the top-up fetch covers it"
+            fi
+          done
+
+      - name: Warm from the run's cache snapshot (full set)
+        if: ${{ steps.artifacts.outputs.cache_snapshot == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cache-snapshot
+          path: ${{ github.workspace }}/r2-publish-cache
+          run-id: ${{ steps.resolve.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Warm from the run's staged delta
+        if: ${{ steps.artifacts.outputs.cache_staging == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cache-staging
+          path: ${{ github.workspace }}/r2-publish-cache
+          run-id: ${{ steps.resolve.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Complete the commit's cache set locally
+        working-directory: mathlib
+        env:
+          MATHLIB_CACHE_BASE_URL: ${{ vars.MATHLIB_CACHE_BASE_URL }}
+        run: |
+          # The four roots are the libraries the master build stages. `get-`
+          # downloads without decompressing: this job needs the `.ltar`
+          # bytes, not a build directory. Files already warmed from the
+          # artifacts are skipped.
+          log="${RUNNER_TEMP}/topup.log"
+          lake exe cache get- Mathlib.lean Archive.lean Counterexamples.lean Wanted.lean 2>&1 | tee "${log}"
+          # An incomplete local set must not reach the bucket's completeness
+          # pipeline: the marker downstream asserts the full closure.
+          if grep -q "some files were not found in the cache" "${log}"; then
+            echo "::error::the read chain did not serve this commit's full closure"
+            exit 1
+          fi
+          echo "local .ltar count: $(find "${MATHLIB_CACHE_DIR}" -name '*.ltar' | wc -l)"
+
+      - name: Install rclone
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
+
+      - name: Configure the R2 write credential
+        env:
+          R2_WRITE_KEY: ${{ secrets.MATHLIB_CACHE_R2_WRITE_KEY }}
+        run: |
+          if [ -z "${R2_WRITE_KEY}" ] || [ -z "${RCLONE_CONFIG_R2_ENDPOINT}" ]; then
+            echo "::error::MATHLIB_CACHE_R2_WRITE_KEY (environment secret) and \
+          MATHLIB_CACHE_R2_S3_ENDPOINT (repository variable) must be set"
+            exit 1
+          fi
+          key="$(printf %s "${R2_WRITE_KEY}" | tr -d '[:space:]')"
+          access_key_id="${key%%:*}"
+          secret_access_key="${key#*:}"
+          echo "::add-mask::${access_key_id}"
+          echo "::add-mask::${secret_access_key}"
+          {
+            echo "RCLONE_CONFIG_R2_ACCESS_KEY_ID=${access_key_id}"
+            echo "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=${secret_access_key}"
+          } >> "$GITHUB_ENV"
+
+      - name: Upload the set to the bucket
+        run: |
+          # --no-traverse probes the bucket per file; a listing of the
+          # destination prefix (millions of objects) would be slower than a
+          # few thousand probes. --size-only suffices to skip a present
+          # file: `.ltar` names are content hashes.
+          rclone copy "${MATHLIB_CACHE_DIR}" "r2:${R2_DEST}/f/" \
+            --include '*.ltar' --size-only --no-traverse \
+            --transfers 32 --checkers 32 \
+            --stats-one-line --stats 30s
+
+  verify:
+    name: Verify direct bucket reads
+    needs: upload
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: cache-upload-master
+    env:
+      MATHLIB_CACHE_DIR: ${{ github.workspace }}/verify-cache
+    steps:
+      - name: Checkout mathlib at the built commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.upload.outputs.sha }}
+          path: mathlib
+
+      - name: Install elan
+        run: |
+          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
+          chmod +x elan-init.sh
+          ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      - name: Download the full closure from the bucket
+        working-directory: mathlib
+        env:
+          MATHLIB_CACHE_GET_URL: ${{ secrets.MATHLIB_CACHE_R2_GET_URL }}
+          SHA: ${{ needs.upload.outputs.sha }}
+        run: |
+          if [ -z "${MATHLIB_CACHE_GET_URL}" ]; then
+            echo "::error::MATHLIB_CACHE_R2_GET_URL (environment secret) must be set"
+            exit 1
+          fi
+          mkdir -p "${MATHLIB_CACHE_DIR}"
+          # The cache dir starts empty, so the whole closure must download;
+          # GET_URL bypasses the container chain, so no fallback can mask a
+          # missing object. A 404 is a miss, not a failure, and exits 0 —
+          # the grep below is the actual completeness check.
+          log="${RUNNER_TEMP}/verify.log"
+          lake exe cache get- Mathlib.lean Archive.lean Counterexamples.lean Wanted.lean 2>&1 | tee "${log}"
+          if grep -q "some files were not found in the cache" "${log}"; then
+            echo "::error::the bucket does not serve this commit's full closure"
+            exit 1
+          fi
+          attempted="$(grep -oE 'Attempting to download [0-9]+' "${log}" | grep -oE '[0-9]+' | head -1 || true)"
+          # A small attempt count means the run did not measure the closure
+          # (wrong roots, or a warm cache dir): fail rather than report a
+          # vacuous 100%. The closure is ~8000 files today.
+          if [ "${attempted:-0}" -lt 1000 ]; then
+            echo "::error::only ${attempted:-0} file(s) attempted; the verification set is implausibly small"
+            exit 1
+          fi
+          echo "::notice::the bucket served all ${attempted} file(s): 100% hits, no fallback"
+          echo "The bucket served all ${attempted} file(s) of \`${SHA}\`: 100% hits, no fallback." >> "$GITHUB_STEP_SUMMARY"
+
+  marker:
+    name: Write the completeness marker
+    needs: [upload, verify]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: cache-upload-master
+    env:
+      RCLONE_CONFIG_R2_TYPE: s3
+      RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+      RCLONE_CONFIG_R2_ENDPOINT: ${{ vars.MATHLIB_CACHE_R2_S3_ENDPOINT }}
+      RCLONE_CONFIG_R2_NO_CHECK_BUCKET: "true"
+      R2_DEST: mathlib4-cache/mathlib4
+    steps:
+      - name: Install rclone
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
+
+      - name: Configure the R2 write credential
+        env:
+          R2_WRITE_KEY: ${{ secrets.MATHLIB_CACHE_R2_WRITE_KEY }}
+        run: |
+          key="$(printf %s "${R2_WRITE_KEY}" | tr -d '[:space:]')"
+          access_key_id="${key%%:*}"
+          secret_access_key="${key#*:}"
+          echo "::add-mask::${access_key_id}"
+          echo "::add-mask::${secret_access_key}"
+          {
+            echo "RCLONE_CONFIG_R2_ACCESS_KEY_ID=${access_key_id}"
+            echo "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=${secret_access_key}"
+          } >> "$GITHUB_ENV"
+
+      - name: Write the marker
+        env:
+          SHA: ${{ needs.upload.outputs.sha }}
+        run: |
+          # Marker shape: m/{repo}/{sha}, content the sha plus a newline —
+          # what the cache tool probes and writes. Written last: `verify`
+          # passing is the completeness statement the marker records.
+          printf '%s\n' "${SHA}" > marker
+          rclone copyto marker "r2:${R2_DEST}/m/leanprover-community/mathlib4/${SHA}"
+          echo "::notice::marker written for ${SHA}"
+
+  report:
+    name: Report a failure to Zulip
+    needs: [upload, verify, marker]
+    if: ${{ always() && github.repository == 'leanprover-community/mathlib4' && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Compose the message
+        id: compose
+        env:
+          UPLOAD: ${{ needs.upload.result }}
+          VERIFY: ${{ needs.verify.result }}
+          MARKER: ${{ needs.marker.result }}
+          SHA: ${{ needs.upload.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "msg<<MSG_EOF"
+            echo "**R2 cache publish failed** ([run](${RUN_URL}), rev \`${SHA:0:12}\`)"
+            echo ""
+            echo "- upload: \`${UPLOAD}\`"
+            echo "- verify: \`${VERIFY}\`"
+            echo "- marker: \`${MARKER}\`"
+            echo "MSG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send to Zulip
+        uses: zulip/github-actions-zulip/send-message@f675f2b4eb2a95fae974215476dcb7ad8dfeff6b # v2.0.2
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+          organization-url: 'https://leanprover.zulipchat.com'
+          to: 'infrastructure'
+          type: 'stream'
+          topic: 'R2 cache publish'
+          content: ${{ steps.compose.outputs.msg }}

--- a/.github/workflows/r2_cache_publish.yml
+++ b/.github/workflows/r2_cache_publish.yml
@@ -23,22 +23,27 @@ name: publish cache to R2
 #             between them is the completeness proof the marker asserts.
 #   report    Zulip message when any job fails.
 #
-# Credential isolation: a job's referenced secrets live in the runner process
-# for the job's whole lifetime, so the job — not the step — is the exposure
-# boundary. The jobs that execute repo-derived code (`assemble` and `verify`
-# run the Lean toolchain, the lakefile, and the cache tool) reference no
-# write-capable secret; the jobs that reference the write key (`push`,
-# `marker`) execute only pinned actions, apt-installed rclone, and inline
-# bash.
+# Credential isolation: a job's credentials live in the runner process for
+# the job's whole lifetime, so the job — not the step — is the exposure
+# boundary. `push` and `marker` mint their own short-lived R2 credentials
+# from the cache broker, and execute only pinned actions, apt-installed
+# rclone, and inline bash. `assemble` and `verify` run the Lean toolchain,
+# the lakefile, and the cache tool; they declare neither the minting
+# environment nor `id-token: write`, so they cannot mint. This repository
+# holds no durable storage credential: each minted credential expires on
+# its own, and the one long-lived credential lives in the broker Worker.
 #
 # Required repository configuration:
-#   Environment `cache-upload-master` — the deployment branch policy admits
-#   only refs release managers control (master, staging, v4.* tags), so a
-#   dispatch from any other ref cannot reach these secrets:
-#     MATHLIB_CACHE_R2_WRITE_KEY  S3 credential for the bucket, as
-#                                 `<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>`
-#                                 (an R2 API token scoped to the cache
-#                                 bucket, Object Read & Write).
+#   Environment `cache-upload-r2-master` — the write identity, declared by
+#   `push` and `marker` only. Its branch policy admits master and v4.* tags.
+#   This environment belongs to this workflow alone: `cache-upload-master`
+#   also carries build_template.yml's Azure upload_cache job, and one
+#   environment shared by two publishers cannot tell them apart. The OIDC
+#   `sub` names the environment and not the job, so every job that declares
+#   it can reach its credentials — keep it off `assemble` and `verify`,
+#   which run repository code.
+#   Environment `cache-upload-master` — read side only, declared by
+#   `verify`. It holds no write-capable secret:
 #     MATHLIB_CACHE_R2_GET_URL    Anonymous read endpoint for verification,
 #                                 e.g. `https://<bucket-public-host>/mathlib4`.
 #                                 A secret, not a variable: public run logs
@@ -46,9 +51,12 @@ name: publish cache to R2
 #                                 resolver (its metrics and cached-404
 #                                 protection only see traffic that goes
 #                                 through it). The S3 endpoint below stays a
-#                                 variable because it is useless without the
-#                                 write key.
+#                                 variable because it is useless without a
+#                                 credential the broker mints.
 #   Repository variables:
+#     MATHLIB_CACHE_BROKER_URL      The cache broker endpoint that mints the
+#                                   upload credentials, e.g.
+#                                   `https://<broker-host>/r2-credentials`.
 #     MATHLIB_CACHE_R2_S3_ENDPOINT  Authenticated S3 endpoint for uploads,
 #                                   e.g. `https://<account>.r2.cloudflarestorage.com`.
 #     MATHLIB_CACHE_BASE_URL        (existing) read base for the top-up fetch.
@@ -229,7 +237,14 @@ jobs:
     needs: assemble
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    environment: cache-upload-master
+    environment: cache-upload-r2-master
+    # Job-level permissions replace the workflow's, so restate what this job
+    # needs. `id-token: write` stays off `assemble` and `verify`: the OIDC
+    # `sub` names the environment and not the job.
+    permissions:
+      contents: read
+      actions: read # download-artifact reads this run's artifacts
+      id-token: write # request the OIDC token the broker verifies
     env:
       RCLONE_CONFIG_R2_TYPE: s3
       RCLONE_CONFIG_R2_PROVIDER: Cloudflare
@@ -250,24 +265,31 @@ jobs:
       - name: Install rclone
         run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
 
-      - name: Configure the R2 write credential
+      # The job's whole credential: short-lived, scoped to the bucket's
+      # `mathlib4/` prefix, and expiring on its own. The broker answers only
+      # a token whose claims match its grant, so the environment above is
+      # what authorises this mint.
+      - name: Mint short-lived R2 credentials from the broker
         env:
-          R2_WRITE_KEY: ${{ secrets.MATHLIB_CACHE_R2_WRITE_KEY }}
+          BROKER_URL: ${{ vars.MATHLIB_CACHE_BROKER_URL }}
         run: |
-          if [ -z "${R2_WRITE_KEY}" ] || [ -z "${RCLONE_CONFIG_R2_ENDPOINT}" ]; then
-            echo "::error::MATHLIB_CACHE_R2_WRITE_KEY (environment secret) and \
-          MATHLIB_CACHE_R2_S3_ENDPOINT (repository variable) must be set"
+          if [ -z "${BROKER_URL}" ] || [ -z "${RCLONE_CONFIG_R2_ENDPOINT}" ]; then
+            echo "::error::MATHLIB_CACHE_BROKER_URL and \
+          MATHLIB_CACHE_R2_S3_ENDPOINT (repository variables) must be set"
             exit 1
           fi
-          key="$(printf %s "${R2_WRITE_KEY}" | tr -d '[:space:]')"
-          access_key_id="${key%%:*}"
-          secret_access_key="${key#*:}"
-          echo "::add-mask::${access_key_id}"
-          echo "::add-mask::${secret_access_key}"
+          jwt="$(curl -sSf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=mathlib-cache-broker" | jq -er .value)"
+          creds="$(curl -sSf -X POST -H "Authorization: Bearer ${jwt}" "${BROKER_URL}")"
+          for field in accessKeyId secretAccessKey sessionToken; do
+            echo "::add-mask::$(jq -er ".${field}" <<<"${creds}")"
+          done
           {
-            echo "RCLONE_CONFIG_R2_ACCESS_KEY_ID=${access_key_id}"
-            echo "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=${secret_access_key}"
+            echo "RCLONE_CONFIG_R2_ACCESS_KEY_ID=$(jq -er .accessKeyId <<<"${creds}")"
+            echo "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=$(jq -er .secretAccessKey <<<"${creds}")"
+            echo "RCLONE_CONFIG_R2_SESSION_TOKEN=$(jq -er .sessionToken <<<"${creds}")"
           } >> "$GITHUB_ENV"
+          echo "::notice::minted grant $(jq -r .grant <<<"${creds}") (ttl $(jq -r .ttlSeconds <<<"${creds}")s)"
 
       - name: Upload the set to the bucket
         run: |
@@ -339,7 +361,10 @@ jobs:
     needs: [assemble, push, verify]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: cache-upload-master
+    environment: cache-upload-r2-master
+    permissions:
+      contents: read
+      id-token: write # request the OIDC token the broker verifies
     env:
       RCLONE_CONFIG_R2_TYPE: s3
       RCLONE_CONFIG_R2_PROVIDER: Cloudflare
@@ -350,24 +375,31 @@ jobs:
       - name: Install rclone
         run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
 
-      - name: Configure the R2 write credential
+      # The job's whole credential: short-lived, scoped to the bucket's
+      # `mathlib4/` prefix, and expiring on its own. The broker answers only
+      # a token whose claims match its grant, so the environment above is
+      # what authorises this mint.
+      - name: Mint short-lived R2 credentials from the broker
         env:
-          R2_WRITE_KEY: ${{ secrets.MATHLIB_CACHE_R2_WRITE_KEY }}
+          BROKER_URL: ${{ vars.MATHLIB_CACHE_BROKER_URL }}
         run: |
-          if [ -z "${R2_WRITE_KEY}" ] || [ -z "${RCLONE_CONFIG_R2_ENDPOINT}" ]; then
-            echo "::error::MATHLIB_CACHE_R2_WRITE_KEY (environment secret) and \
-          MATHLIB_CACHE_R2_S3_ENDPOINT (repository variable) must be set"
+          if [ -z "${BROKER_URL}" ] || [ -z "${RCLONE_CONFIG_R2_ENDPOINT}" ]; then
+            echo "::error::MATHLIB_CACHE_BROKER_URL and \
+          MATHLIB_CACHE_R2_S3_ENDPOINT (repository variables) must be set"
             exit 1
           fi
-          key="$(printf %s "${R2_WRITE_KEY}" | tr -d '[:space:]')"
-          access_key_id="${key%%:*}"
-          secret_access_key="${key#*:}"
-          echo "::add-mask::${access_key_id}"
-          echo "::add-mask::${secret_access_key}"
+          jwt="$(curl -sSf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=mathlib-cache-broker" | jq -er .value)"
+          creds="$(curl -sSf -X POST -H "Authorization: Bearer ${jwt}" "${BROKER_URL}")"
+          for field in accessKeyId secretAccessKey sessionToken; do
+            echo "::add-mask::$(jq -er ".${field}" <<<"${creds}")"
+          done
           {
-            echo "RCLONE_CONFIG_R2_ACCESS_KEY_ID=${access_key_id}"
-            echo "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=${secret_access_key}"
+            echo "RCLONE_CONFIG_R2_ACCESS_KEY_ID=$(jq -er .accessKeyId <<<"${creds}")"
+            echo "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=$(jq -er .secretAccessKey <<<"${creds}")"
+            echo "RCLONE_CONFIG_R2_SESSION_TOKEN=$(jq -er .sessionToken <<<"${creds}")"
           } >> "$GITHUB_ENV"
+          echo "::notice::minted grant $(jq -r .grant <<<"${creds}") (ttl $(jq -r .ttlSeconds <<<"${creds}")s)"
 
       - name: Write the marker
         env:

--- a/.github/workflows/r2_cache_publish.yml
+++ b/.github/workflows/r2_cache_publish.yml
@@ -104,6 +104,9 @@ jobs:
          github.event.workflow_run.head_branch == 'master'))
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # No environment and no `id-token`, both deliberate: this job runs
+    # repository code, so it must stay unable to mint. Adding either would
+    # hand it a write credential.
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
       run_id: ${{ steps.resolve.outputs.run_id }}
@@ -307,6 +310,12 @@ jobs:
     needs: [assemble, push]
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # `cache-upload-master` for the GET_URL secret, and deliberately not
+    # `cache-upload-r2-master`: this job runs the Lean toolchain, the
+    # lakefile, and the cache tool. The OIDC `sub` names the environment
+    # and not the job, so declaring the minting environment here — even
+    # only to reach a secret — would let repository code mint a write
+    # credential. Put any secret this job needs in this environment.
     environment: cache-upload-master
     env:
       MATHLIB_CACHE_DIR: ${{ github.workspace }}/verify-cache
@@ -362,6 +371,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: cache-upload-r2-master
+    # Job-level permissions replace the workflow's, so restate what this
+    # job needs. Keep this pair on `push` and `marker` only.
     permissions:
       contents: read
       id-token: write # request the OIDC token the broker verifies

--- a/.github/workflows/r2_cache_publish.yml
+++ b/.github/workflows/r2_cache_publish.yml
@@ -26,12 +26,14 @@ name: publish cache to R2
 # Credential isolation: a job's credentials live in the runner process for
 # the job's whole lifetime, so the job — not the step — is the exposure
 # boundary. `push` and `marker` mint their own short-lived R2 credentials
-# from the cache broker, and execute only pinned actions, apt-installed
-# rclone, and inline bash. `assemble` and `verify` run the Lean toolchain,
-# the lakefile, and the cache tool; they declare neither the minting
-# environment nor `id-token: write`, so they cannot mint. This repository
-# holds no durable storage credential: each minted credential expires on
-# its own, and the one long-lived credential lives in the broker Worker.
+# from the cache broker through mathlib-ci's SHA-pinned
+# `broker-create-cache-credentials` action, and execute only pinned
+# actions, apt-installed rclone, and inline bash. `assemble` and `verify`
+# run the Lean toolchain, the lakefile, and the cache tool; they declare
+# neither the minting environment nor `id-token: write`, so they cannot
+# mint. This repository holds no durable storage credential: each minted
+# credential expires on its own, and the one long-lived credential lives
+# in the broker Worker.
 #
 # Required repository configuration:
 #   Environment `cache-upload-r2-master` — the write identity, declared by
@@ -54,9 +56,10 @@ name: publish cache to R2
 #                                 variable because it is useless without a
 #                                 credential the broker mints.
 #   Repository variables:
-#     MATHLIB_CACHE_BROKER_URL      The cache broker endpoint that mints the
-#                                   upload credentials, e.g.
-#                                   `https://<broker-host>/r2-credentials`.
+#     MATHLIB_CACHE_BROKER_URL      Base URL of the cache broker that mints
+#                                   the upload credentials, e.g.
+#                                   `https://<broker-host>` — the mint action
+#                                   appends `/r2-credentials`.
 #     MATHLIB_CACHE_R2_S3_ENDPOINT  Authenticated S3 endpoint for uploads,
 #                                   e.g. `https://<account>.r2.cloudflarestorage.com`.
 #     MATHLIB_CACHE_BASE_URL        (existing) read base for the top-up fetch.
@@ -271,28 +274,27 @@ jobs:
       # The job's whole credential: short-lived, scoped to the bucket's
       # `mathlib4/` prefix, and expiring on its own. The broker answers only
       # a token whose claims match its grant, so the environment above is
-      # what authorises this mint.
+      # what authorises this mint. `on-failure: fail` because this workflow
+      # has no other upload path. An empty repository variable fails the
+      # action's URL validation, so unset configuration cannot pass silently.
       - name: Mint short-lived R2 credentials from the broker
-        env:
-          BROKER_URL: ${{ vars.MATHLIB_CACHE_BROKER_URL }}
+        uses: leanprover-community/mathlib-ci/.github/actions/broker-create-cache-credentials@9473fccd25902125ea64f7d7253810daeea563d4 # cache/broker-create-cache-credentials
+        with:
+          broker-url: ${{ vars.MATHLIB_CACHE_BROKER_URL }}
+          put-base-url: ${{ vars.MATHLIB_CACHE_R2_S3_ENDPOINT }}/mathlib4-cache
+          on-failure: fail
+
+      # The action exports the credential as MATHLIB_CACHE_S3_* for the
+      # cache tool; this job uploads with rclone, so route the same values
+      # there. They are already masked. MATHLIB_CACHE_PUT_BASE_URL is inert
+      # here: rclone addresses the bucket through R2_DEST.
+      - name: Route the minted credential to rclone
         run: |
-          if [ -z "${BROKER_URL}" ] || [ -z "${RCLONE_CONFIG_R2_ENDPOINT}" ]; then
-            echo "::error::MATHLIB_CACHE_BROKER_URL and \
-          MATHLIB_CACHE_R2_S3_ENDPOINT (repository variables) must be set"
-            exit 1
-          fi
-          jwt="$(curl -sSf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=mathlib-cache-broker" | jq -er .value)"
-          creds="$(curl -sSf -X POST -H "Authorization: Bearer ${jwt}" "${BROKER_URL}")"
-          for field in accessKeyId secretAccessKey sessionToken; do
-            echo "::add-mask::$(jq -er ".${field}" <<<"${creds}")"
-          done
           {
-            echo "RCLONE_CONFIG_R2_ACCESS_KEY_ID=$(jq -er .accessKeyId <<<"${creds}")"
-            echo "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=$(jq -er .secretAccessKey <<<"${creds}")"
-            echo "RCLONE_CONFIG_R2_SESSION_TOKEN=$(jq -er .sessionToken <<<"${creds}")"
+            echo "RCLONE_CONFIG_R2_ACCESS_KEY_ID=${MATHLIB_CACHE_S3_ACCESS_KEY_ID}"
+            echo "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=${MATHLIB_CACHE_S3_SECRET_ACCESS_KEY}"
+            echo "RCLONE_CONFIG_R2_SESSION_TOKEN=${MATHLIB_CACHE_S3_SESSION_TOKEN}"
           } >> "$GITHUB_ENV"
-          echo "::notice::minted grant $(jq -r .grant <<<"${creds}") (ttl $(jq -r .ttlSeconds <<<"${creds}")s)"
 
       - name: Upload the set to the bucket
         run: |
@@ -389,28 +391,25 @@ jobs:
       # The job's whole credential: short-lived, scoped to the bucket's
       # `mathlib4/` prefix, and expiring on its own. The broker answers only
       # a token whose claims match its grant, so the environment above is
-      # what authorises this mint.
+      # what authorises this mint. `on-failure: fail` because this workflow
+      # has no other upload path.
       - name: Mint short-lived R2 credentials from the broker
-        env:
-          BROKER_URL: ${{ vars.MATHLIB_CACHE_BROKER_URL }}
+        uses: leanprover-community/mathlib-ci/.github/actions/broker-create-cache-credentials@9473fccd25902125ea64f7d7253810daeea563d4 # cache/broker-create-cache-credentials
+        with:
+          broker-url: ${{ vars.MATHLIB_CACHE_BROKER_URL }}
+          put-base-url: ${{ vars.MATHLIB_CACHE_R2_S3_ENDPOINT }}/mathlib4-cache
+          on-failure: fail
+
+      # The action exports the credential as MATHLIB_CACHE_S3_* for the
+      # cache tool; this job uploads with rclone, so route the same values
+      # there. They are already masked.
+      - name: Route the minted credential to rclone
         run: |
-          if [ -z "${BROKER_URL}" ] || [ -z "${RCLONE_CONFIG_R2_ENDPOINT}" ]; then
-            echo "::error::MATHLIB_CACHE_BROKER_URL and \
-          MATHLIB_CACHE_R2_S3_ENDPOINT (repository variables) must be set"
-            exit 1
-          fi
-          jwt="$(curl -sSf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=mathlib-cache-broker" | jq -er .value)"
-          creds="$(curl -sSf -X POST -H "Authorization: Bearer ${jwt}" "${BROKER_URL}")"
-          for field in accessKeyId secretAccessKey sessionToken; do
-            echo "::add-mask::$(jq -er ".${field}" <<<"${creds}")"
-          done
           {
-            echo "RCLONE_CONFIG_R2_ACCESS_KEY_ID=$(jq -er .accessKeyId <<<"${creds}")"
-            echo "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=$(jq -er .secretAccessKey <<<"${creds}")"
-            echo "RCLONE_CONFIG_R2_SESSION_TOKEN=$(jq -er .sessionToken <<<"${creds}")"
+            echo "RCLONE_CONFIG_R2_ACCESS_KEY_ID=${MATHLIB_CACHE_S3_ACCESS_KEY_ID}"
+            echo "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=${MATHLIB_CACHE_S3_SECRET_ACCESS_KEY}"
+            echo "RCLONE_CONFIG_R2_SESSION_TOKEN=${MATHLIB_CACHE_S3_SESSION_TOKEN}"
           } >> "$GITHUB_ENV"
-          echo "::notice::minted grant $(jq -r .grant <<<"${creds}") (ttl $(jq -r .ttlSeconds <<<"${creds}")s)"
 
       - name: Write the marker
         env:

--- a/.github/workflows/r2_cache_publish.yml
+++ b/.github/workflows/r2_cache_publish.yml
@@ -5,20 +5,31 @@ name: publish cache to R2
 # Azure fallback in the read path.
 #
 # Jobs (per master push, after `continuous integration` completes):
-#   upload   Assemble the commit's full `.ltar` set locally: warm from the
-#            triggering run's `cache-snapshot` and `cache-staging` artifacts
-#            (free bandwidth, no storage egress), then top up anything still
-#            missing through the normal read chain (MATHLIB_CACHE_BASE_URL;
-#            its backend falls back to Azure, so files the bucket does not
-#            hold yet arrive from there). Copy the set to the bucket; only
-#            objects the bucket is missing are transferred.
-#   verify   Fresh runner, empty cache dir, MATHLIB_CACHE_GET_URL pointed at
-#            the bucket's anonymous host. Passes only when every file of the
-#            commit's closure downloads: 100% hits served by the bucket.
-#   marker   Write the completeness marker m/leanprover-community/mathlib4/{sha}
-#            (content: the sha). Files first, marker last; the `verify` job
-#            between them is the completeness proof the marker asserts.
-#   report   Zulip message when any job fails.
+#   assemble  Assemble the commit's full `.ltar` set locally: warm from the
+#             triggering run's `cache-snapshot` and `cache-staging` artifacts
+#             (free bandwidth, no storage egress), then top up anything still
+#             missing through the normal read chain (MATHLIB_CACHE_BASE_URL;
+#             its backend falls back to Azure, so files the bucket does not
+#             hold yet arrive from there). Publish the set as a run artifact
+#             with the minimum retention: a handoff to `push`, not a
+#             deliverable.
+#   push      Copy the assembled set to the bucket; only objects the bucket
+#             is missing are transferred.
+#   verify    Fresh runner, empty cache dir, MATHLIB_CACHE_GET_URL pointed at
+#             the bucket's anonymous host. Passes only when every file of the
+#             commit's closure downloads: 100% hits served by the bucket.
+#   marker    Write the completeness marker m/leanprover-community/mathlib4/{sha}
+#             (content: the sha). Files first, marker last; the `verify` job
+#             between them is the completeness proof the marker asserts.
+#   report    Zulip message when any job fails.
+#
+# Credential isolation: a job's referenced secrets live in the runner process
+# for the job's whole lifetime, so the job — not the step — is the exposure
+# boundary. The jobs that execute repo-derived code (`assemble` and `verify`
+# run the Lean toolchain, the lakefile, and the cache tool) reference no
+# write-capable secret; the jobs that reference the write key (`push`,
+# `marker`) execute only pinned actions, apt-installed rclone, and inline
+# bash.
 #
 # Required repository configuration:
 #   Environment `cache-upload-master` — the deployment branch policy admits
@@ -50,7 +61,7 @@ on:
     types: [completed]
     branches: [master]
   # Manual fallback: re-run a commit whose publish failed, or seed from the
-  # most recent master build. The gate job validates the source run, so a
+  # most recent master build. `assemble` validates the source run, so a
   # dispatch cannot feed the bucket from anything but a master push build.
   workflow_dispatch:
     inputs:
@@ -75,8 +86,8 @@ defaults:
     shell: bash -euo pipefail {0}
 
 jobs:
-  upload:
-    name: Upload master cache to R2
+  assemble:
+    name: Assemble the commit's cache set
     if: >-
       github.repository == 'leanprover-community/mathlib4' &&
       (github.event_name == 'workflow_dispatch' ||
@@ -85,19 +96,11 @@ jobs:
          github.event.workflow_run.head_branch == 'master'))
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    environment: cache-upload-master
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
       run_id: ${{ steps.resolve.outputs.run_id }}
     env:
       MATHLIB_CACHE_DIR: ${{ github.workspace }}/r2-publish-cache
-      RCLONE_CONFIG_R2_TYPE: s3
-      RCLONE_CONFIG_R2_PROVIDER: Cloudflare
-      RCLONE_CONFIG_R2_ENDPOINT: ${{ vars.MATHLIB_CACHE_R2_S3_ENDPOINT }}
-      RCLONE_CONFIG_R2_NO_CHECK_BUCKET: "true"
-      # Bucket and key prefix of the master namespace. The prefix is part of
-      # the published URL contract; change it only with the resolver config.
-      R2_DEST: mathlib4-cache/mathlib4
     steps:
       - name: Resolve and validate the source run
         id: resolve
@@ -212,6 +215,38 @@ jobs:
           fi
           echo "local .ltar count: $(find "${MATHLIB_CACHE_DIR}" -name '*.ltar' | wc -l)"
 
+      - name: Publish the set as a run artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: r2-publish-set
+          path: ${{ github.workspace }}/r2-publish-cache/*.ltar
+          compression-level: 0 # `.ltar` files are already zstd-compressed
+          retention-days: 1 # a job-to-job handoff, not a deliverable
+          if-no-files-found: error
+
+  push:
+    name: Push the set to the bucket
+    needs: assemble
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: cache-upload-master
+    env:
+      RCLONE_CONFIG_R2_TYPE: s3
+      RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+      RCLONE_CONFIG_R2_ENDPOINT: ${{ vars.MATHLIB_CACHE_R2_S3_ENDPOINT }}
+      RCLONE_CONFIG_R2_NO_CHECK_BUCKET: "true"
+      # Bucket and key prefix of the master namespace. The prefix is part of
+      # the published URL contract; change it only with the resolver config.
+      R2_DEST: mathlib4-cache/mathlib4
+    steps:
+      # No `run-id`, so the artifact can only come from this run's own
+      # `assemble` job.
+      - name: Download the assembled set
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: r2-publish-set
+          path: ${{ github.workspace }}/r2-publish-set
+
       - name: Install rclone
         run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
 
@@ -240,14 +275,14 @@ jobs:
           # destination prefix (millions of objects) would be slower than a
           # few thousand probes. --size-only suffices to skip a present
           # file: `.ltar` names are content hashes.
-          rclone copy "${MATHLIB_CACHE_DIR}" "r2:${R2_DEST}/f/" \
+          rclone copy "${GITHUB_WORKSPACE}/r2-publish-set" "r2:${R2_DEST}/f/" \
             --include '*.ltar' --size-only --no-traverse \
             --transfers 32 --checkers 32 \
             --stats-one-line --stats 30s
 
   verify:
     name: Verify direct bucket reads
-    needs: upload
+    needs: [assemble, push]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: cache-upload-master
@@ -257,7 +292,7 @@ jobs:
       - name: Checkout mathlib at the built commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.upload.outputs.sha }}
+          ref: ${{ needs.assemble.outputs.sha }}
           path: mathlib
 
       - name: Install elan
@@ -271,7 +306,7 @@ jobs:
         working-directory: mathlib
         env:
           MATHLIB_CACHE_GET_URL: ${{ secrets.MATHLIB_CACHE_R2_GET_URL }}
-          SHA: ${{ needs.upload.outputs.sha }}
+          SHA: ${{ needs.assemble.outputs.sha }}
         run: |
           if [ -z "${MATHLIB_CACHE_GET_URL}" ]; then
             echo "::error::MATHLIB_CACHE_R2_GET_URL (environment secret) must be set"
@@ -301,7 +336,7 @@ jobs:
 
   marker:
     name: Write the completeness marker
-    needs: [upload, verify]
+    needs: [assemble, push, verify]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: cache-upload-master
@@ -319,6 +354,11 @@ jobs:
         env:
           R2_WRITE_KEY: ${{ secrets.MATHLIB_CACHE_R2_WRITE_KEY }}
         run: |
+          if [ -z "${R2_WRITE_KEY}" ] || [ -z "${RCLONE_CONFIG_R2_ENDPOINT}" ]; then
+            echo "::error::MATHLIB_CACHE_R2_WRITE_KEY (environment secret) and \
+          MATHLIB_CACHE_R2_S3_ENDPOINT (repository variable) must be set"
+            exit 1
+          fi
           key="$(printf %s "${R2_WRITE_KEY}" | tr -d '[:space:]')"
           access_key_id="${key%%:*}"
           secret_access_key="${key#*:}"
@@ -331,7 +371,7 @@ jobs:
 
       - name: Write the marker
         env:
-          SHA: ${{ needs.upload.outputs.sha }}
+          SHA: ${{ needs.assemble.outputs.sha }}
         run: |
           # Marker shape: m/{repo}/{sha}, content the sha plus a newline —
           # what the cache tool probes and writes. Written last: `verify`
@@ -342,7 +382,7 @@ jobs:
 
   report:
     name: Report a failure to Zulip
-    needs: [upload, verify, marker]
+    needs: [assemble, push, verify, marker]
     if: ${{ always() && github.repository == 'leanprover-community/mathlib4' && contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -350,17 +390,22 @@ jobs:
       - name: Compose the message
         id: compose
         env:
-          UPLOAD: ${{ needs.upload.result }}
+          ASSEMBLE: ${{ needs.assemble.result }}
+          PUSH: ${{ needs.push.result }}
           VERIFY: ${{ needs.verify.result }}
           MARKER: ${{ needs.marker.result }}
-          SHA: ${{ needs.upload.outputs.sha }}
+          SHA: ${{ needs.assemble.outputs.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # The sha is empty when `assemble` fails before resolving the
+          # source run.
+          sha="${SHA:-unresolved}"
           {
             echo "msg<<MSG_EOF"
-            echo "**R2 cache publish failed** ([run](${RUN_URL}), rev \`${SHA:0:12}\`)"
+            echo "**R2 cache publish failed** ([run](${RUN_URL}), rev \`${sha:0:12}\`)"
             echo ""
-            echo "- upload: \`${UPLOAD}\`"
+            echo "- assemble: \`${ASSEMBLE}\`"
+            echo "- push: \`${PUSH}\`"
             echo "- verify: \`${VERIFY}\`"
             echo "- marker: \`${MARKER}\`"
             echo "MSG_EOF"


### PR DESCRIPTION
This PR adds one workflow: `r2_cache_publish.yml`. The workflow runs after each successful `continuous integration` run on `master`. It publishes the commit's cache files to the R2 bucket. Then it verifies that the bucket alone serves the commit's full cache.

The workflow has five jobs:

1. `assemble` assembles the commit's full `.ltar` set on the runner. It warms the set from the run's `cache-snapshot` and `cache-staging` artifacts. These downloads are free and cause no storage egress. Both artifacts are optional; a top-up fetch through `MATHLIB_CACHE_BASE_URL` completes the set. The read chain falls back to Azure, so the top-up also heals files that the bucket does not hold yet. The job publishes the set as a run artifact with one-day retention. This job holds no bucket credential.
2. `push` downloads the run artifact and copies the set to the bucket. Only missing objects transfer. The job mints a short-lived R2 credential from the cache broker, directly before the upload. It runs only pinned actions, apt-installed rclone, and inline bash.
3. `verify` starts with an empty cache directory on a fresh runner. It sets `MATHLIB_CACHE_GET_URL` to the bucket's anonymous host and runs `lake exe cache get-` for the four staged roots. This bypasses the container chain, so no fallback can mask a missing object. The job fails unless every file of the closure downloads: 100% cache hits from the bucket.
4. `marker` writes `m/leanprover-community/mathlib4/{sha}` with the sha as content. The marker means "this commit's full set is in the bucket, and a fresh reader verified it". The files go first and the marker goes last; `verify` sits between them. A side effect: `cache query` starts to resolve master commits once the resolver serves these markers.
5. `report` sends a Zulip message when a job fails.

Credentials:

- `push` and `marker` exchange the job's GitHub OIDC token for a short-lived R2 credential. They use mathlib-ci's SHA-pinned `broker-create-cache-credentials` action (leanprover-community/mathlib-ci#67) with the `fail` posture: this workflow has no other upload path. The broker's `mathlib4-master-publish` grant scopes the credential to the bucket's `mathlib4/` prefix, with a 15-minute lifetime.
- The two jobs declare the dedicated `cache-upload-r2-master` environment. The grant keys on the environment claim in the OIDC `sub`, and the environment's deployment branch policy admits only refs that release managers control. The shared `cache-upload-master` environment cannot serve here: it also carries the Azure `upload_cache` job, and one environment shared by two publishers cannot tell them apart.
- The repository holds no durable storage credential. Each minted credential expires on its own. The one long-lived credential lives in the broker Worker.

Trust and gating:

- Both trigger paths validate the source run with one check: the run must be a successful `master` push run of `build.yml`. A dispatched `run_id` is untrusted input, because contributors with branch access can dispatch workflows; the check rejects any other run.
- `workflow_run` executes this file from `master`, so a branch push cannot substitute its own version.
- A job's credentials live in the runner process for the whole job, so the job is the exposure boundary. The jobs that run repo-derived code (`assemble`, `verify`) declare neither the minting environment nor `id-token: write`, so they cannot mint. The jobs that mint (`push`, `marker`) run no repo-derived code.

Required configuration before merge (operator action):

- Environment `cache-upload-r2-master`, with a deployment branch policy that admits `master` and `v4.*` tags. It holds no secret; it is the OIDC identity the broker grant trusts.
- Environment secret `MATHLIB_CACHE_R2_GET_URL` in `cache-upload-master`: the anonymous read endpoint for `verify`. This is a secret so that public run logs do not advertise a URL that bypasses the resolver; the resolver carries the metrics and the cached-404 protection.
- Repository variable `MATHLIB_CACHE_BROKER_URL`: the broker base URL. The mint action appends `/r2-credentials`.
- Repository variable `MATHLIB_CACHE_R2_S3_ENDPOINT`: the authenticated S3 endpoint. It stays a variable because it is useless without a minted credential.
- The broker deployed with the `mathlib4-master-publish` grant (on cache-infrastructure main since #5).

Sequencing and watch items:

- mathlib-ci#67 must merge first. The action pin points at that PR's head today; re-pin to the merged commit before this PR leaves draft.
- The grant's 15-minute credential lifetime is provisional against the push job's 45-minute timeout. The mint runs directly before the upload, and a normal push transfers only the day's new objects. Measure a real push and raise the TTL if it runs close.

Cost, at about 20 to 30 master pushes per day: the per-file bucket probes and the verification reads meter as R2 class B operations, on the order of 500 thousand per day, which is about $5 per month. Uploads transfer only new objects. Ingress and egress are free.

Open questions for review:

- The failure report posts to the `infrastructure` stream, topic `R2 cache publish`. Tell me the correct stream if this one is wrong.
- The first runs top up the `Archive`, `Counterexamples` and `Wanted` closures through the Azure fallback, because earlier backfills covered the `Mathlib` root only. This is a one-time cost; later runs find the files in the bucket.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
