### PR TITLE
[Merged by Bors] - feat: add zero lemmas for even powers

### DIFF
--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -80,23 +80,26 @@ theorem le_prod_of_submultiplicative_of_nonneg {M : Type*} [CommMonoid M]
 
 end OrderedCommSemiring
 
-theorem sum_mul_self_eq_zero_iff [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
-    [ExistsAddOfLE R] (s : Finset ι)
-    (f : ι → R) : ∑ i ∈ s, f i * f i = 0 ↔ ∀ i ∈ s, f i = 0 := by
+section StrictOrderedRing
+
+variable [Semiring R] [LinearOrder R] [IsStrictOrderedRing R] [ExistsAddOfLE R]
+    (s : Finset ι) (f : ι → R)
+
+theorem sum_mul_self_eq_zero_iff
+    : ∑ i ∈ s, f i * f i = 0 ↔ ∀ i ∈ s, f i = 0 := by
   rw [sum_eq_zero_iff_of_nonneg fun _ _ ↦ mul_self_nonneg _]
   simp
 
-theorem sum_sq_eq_zero_iff [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
-    [ExistsAddOfLE R] (s : Finset ι) (f : ι → R) :
+theorem sum_sq_eq_zero_iff :
     ∑ i ∈ s, f i ^ 2 = 0 ↔ ∀ i ∈ s, f i = 0 := by
     grind [sq_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
 
 theorem sum_pow_eq_zero_iff_of_even
-    [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
-    [ExistsAddOfLE R] (s : Finset ι) (f : ι → R)
     {n : ℕ} (hn : n ≠ 0) (heven : Even n) :
     ∑ i ∈ s, f i ^ n = 0 ↔ ∀ i ∈ s, f i = 0 := by
   grind [Even.pow_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
+
+end StrictOrderedRing
 
 lemma abs_prod [CommRing R] [LinearOrder R] [IsStrictOrderedRing R] (s : Finset ι) (f : ι → R) :
     |∏ x ∈ s, f x| = ∏ x ∈ s, |f x| :=

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -93,8 +93,7 @@ theorem sum_sq_eq_zero_iff :
     ∑ i ∈ s, f i ^ 2 = 0 ↔ ∀ i ∈ s, f i = 0 := by
     grind [sq_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
 
-theorem sum_pow_eq_zero_iff_of_even
-    {n : ℕ} (hn : n ≠ 0) (heven : Even n) :
+theorem sum_pow_eq_zero_iff_of_even {n : ℕ} (hn : n ≠ 0) (heven : Even n) :
     ∑ i ∈ s, f i ^ n = 0 ↔ ∀ i ∈ s, f i = 0 := by
   grind [Even.pow_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
 

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -86,6 +86,18 @@ theorem sum_mul_self_eq_zero_iff [Semiring R] [LinearOrder R] [IsStrictOrderedRi
   rw [sum_eq_zero_iff_of_nonneg fun _ _ ↦ mul_self_nonneg _]
   simp
 
+theorem sum_sq_eq_zero_iff [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
+    [ExistsAddOfLE R] (s : Finset ι)
+    (f : ι → R) : ∑ i ∈ s, (f i) ^2 = 0 ↔ ∀ i ∈ s, f i = 0 := by
+    grind [sq_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
+
+theorem sum_pow_eq_zero_iff_of_even
+    [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
+    [ExistsAddOfLE R] (s : Finset ι) (f : ι → R)
+    (n : ℕ) (hn : n ≠ 0) (heven : Even n) :
+    (∑ i ∈ s, f i ^ n) = 0 ↔ ∀ i ∈ s, f i = 0 := by
+  grind [Even.pow_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
+
 lemma abs_prod [CommRing R] [LinearOrder R] [IsStrictOrderedRing R] (s : Finset ι) (f : ι → R) :
     |∏ x ∈ s, f x| = ∏ x ∈ s, |f x| :=
   map_prod absHom _ _

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -87,8 +87,8 @@ theorem sum_mul_self_eq_zero_iff [Semiring R] [LinearOrder R] [IsStrictOrderedRi
   simp
 
 theorem sum_sq_eq_zero_iff [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
-    [ExistsAddOfLE R] (s : Finset ι)
-    (f : ι → R) : ∑ i ∈ s, (f i) ^2 = 0 ↔ ∀ i ∈ s, f i = 0 := by
+    [ExistsAddOfLE R] (s : Finset ι) (f : ι → R) :
+    ∑ i ∈ s, f i ^ 2 = 0 ↔ ∀ i ∈ s, f i = 0 := by
     grind [sq_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
 
 theorem sum_pow_eq_zero_iff_of_even

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -95,7 +95,7 @@ theorem sum_pow_eq_zero_iff_of_even
     [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
     [ExistsAddOfLE R] (s : Finset ι) (f : ι → R)
     {n : ℕ} (hn : n ≠ 0) (heven : Even n) :
-    (∑ i ∈ s, f i ^ n) = 0 ↔ ∀ i ∈ s, f i = 0 := by
+    ∑ i ∈ s, f i ^ n = 0 ↔ ∀ i ∈ s, f i = 0 := by
   grind [Even.pow_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
 
 lemma abs_prod [CommRing R] [LinearOrder R] [IsStrictOrderedRing R] (s : Finset ι) (f : ι → R) :

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -89,9 +89,8 @@ theorem sum_mul_self_eq_zero_iff : ∑ i ∈ s, f i * f i = 0 ↔ ∀ i ∈ s, f
   rw [sum_eq_zero_iff_of_nonneg fun _ _ ↦ mul_self_nonneg _]
   simp
 
-theorem sum_sq_eq_zero_iff :
-    ∑ i ∈ s, f i ^ 2 = 0 ↔ ∀ i ∈ s, f i = 0 := by
-    grind [sq_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
+theorem sum_sq_eq_zero_iff : ∑ i ∈ s, f i ^ 2 = 0 ↔ ∀ i ∈ s, f i = 0 := by
+  grind [sq_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
 
 theorem sum_pow_eq_zero_iff_of_even {n : ℕ} (hn : n ≠ 0) (heven : Even n) :
     ∑ i ∈ s, f i ^ n = 0 ↔ ∀ i ∈ s, f i = 0 := by

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -94,7 +94,7 @@ theorem sum_sq_eq_zero_iff [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
 theorem sum_pow_eq_zero_iff_of_even
     [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
     [ExistsAddOfLE R] (s : Finset ι) (f : ι → R)
-    (n : ℕ) (hn : n ≠ 0) (heven : Even n) :
+    {n : ℕ} (hn : n ≠ 0) (heven : Even n) :
     (∑ i ∈ s, f i ^ n) = 0 ↔ ∀ i ∈ s, f i = 0 := by
   grind [Even.pow_nonneg, Finset.sum_eq_zero_iff_of_nonneg, pow_eq_zero_iff]
 

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -85,8 +85,7 @@ section StrictOrderedRing
 variable [Semiring R] [LinearOrder R] [IsStrictOrderedRing R] [ExistsAddOfLE R]
     (s : Finset ι) (f : ι → R)
 
-theorem sum_mul_self_eq_zero_iff
-    : ∑ i ∈ s, f i * f i = 0 ↔ ∀ i ∈ s, f i = 0 := by
+theorem sum_mul_self_eq_zero_iff : ∑ i ∈ s, f i * f i = 0 ↔ ∀ i ∈ s, f i = 0 := by
   rw [sum_eq_zero_iff_of_nonneg fun _ _ ↦ mul_self_nonneg _]
   simp
 

--- a/Mathlib/Algebra/Order/Ring/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Basic.lean
@@ -85,11 +85,11 @@ protected lemma Even.pow_nonneg (hn : Even n) (a : R) : 0 ≤ a ^ n := by
 lemma pow_four_le_pow_two_of_pow_two_le {a b : R} (h : a ^ 2 ≤ b) : a ^ 4 ≤ b ^ 2 :=
   (pow_mul a 2 2).symm ▸ pow_le_pow_left₀ (sq_nonneg a) h 2
 
-theorem pow_add_pow_eq_zero_iff_of_even {α : Type*} [Ring α] [LinearOrder α] [IsStrictOrderedRing α]
-    (n : ℕ) (hn : n ≠ 0) (hn' : Even n) (x y : α) :
+lemma pow_add_pow_eq_zero_iff_of_even [NoZeroDivisors R]
+    (n : ℕ) (hn : n ≠ 0) (hn' : Even n) (x y : R) :
     x ^ n + y ^ n = 0 ↔ x = 0 ∧ y = 0 := by
   obtain ⟨m, rfl⟩ := hn'
-  simp only [pow_add];
+  simp only [pow_add]
   grind [mul_self_add_mul_self_eq_zero, pow_eq_zero_iff]
 
 end IsOrderedRing

--- a/Mathlib/Algebra/Order/Ring/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Basic.lean
@@ -86,7 +86,7 @@ lemma pow_four_le_pow_two_of_pow_two_le {a b : R} (h : a ^ 2 ≤ b) : a ^ 4 ≤ 
   (pow_mul a 2 2).symm ▸ pow_le_pow_left₀ (sq_nonneg a) h 2
 
 lemma pow_add_pow_eq_zero_iff_of_even [NoZeroDivisors R]
-    (n : ℕ) (hn : n ≠ 0) (hn' : Even n) (x y : R) :
+    {n : ℕ} (hn : n ≠ 0) (hn' : Even n) (x y : R) :
     x ^ n + y ^ n = 0 ↔ x = 0 ∧ y = 0 := by
   obtain ⟨m, rfl⟩ := hn'
   simp only [pow_add]

--- a/Mathlib/Algebra/Order/Ring/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Basic.lean
@@ -85,6 +85,13 @@ protected lemma Even.pow_nonneg (hn : Even n) (a : R) : 0 ≤ a ^ n := by
 lemma pow_four_le_pow_two_of_pow_two_le {a b : R} (h : a ^ 2 ≤ b) : a ^ 4 ≤ b ^ 2 :=
   (pow_mul a 2 2).symm ▸ pow_le_pow_left₀ (sq_nonneg a) h 2
 
+theorem pow_add_pow_eq_zero_iff_of_even {α : Type*} [Ring α] [LinearOrder α] [IsStrictOrderedRing α]
+    (n : ℕ) (hn : n ≠ 0) (hn' : Even n) (x y : α) :
+    x ^ n + y ^ n = 0 ↔ x = 0 ∧ y = 0 := by
+  obtain ⟨m, rfl⟩ := hn'
+  simp only [pow_add];
+  grind [mul_self_add_mul_self_eq_zero, pow_eq_zero_iff]
+
 end IsOrderedRing
 
 variable [Semiring R] [LinearOrder R] [IsStrictOrderedRing R] {a b : R} {m n : ℕ}

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -632,23 +632,25 @@ instance (priority := 100) [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] :
     ZeroLEOneClass R where
   zero_le_one := by simpa only [one_mul] using mul_self_nonneg (1 : R)
 
+section SumOfSquares
+
+variable [NoZeroDivisors R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]
 /-- The sum of two terms of the form x * x is zero iff both elements are zero. -/
-lemma mul_self_add_mul_self_eq_zero [NoZeroDivisors R]
-    [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] :
+lemma mul_self_add_mul_self_eq_zero :
     a * a + b * b = 0 ↔ a = 0 ∧ b = 0 := by
   rw [add_eq_zero_iff_of_nonneg, mul_self_eq_zero (M₀ := R), mul_self_eq_zero (M₀ := R)] <;>
     apply mul_self_nonneg
 
 /-- The sum of two squares is zero iff both elements are zero -/
-lemma sq_add_sq_eq_zero [NoZeroDivisors R]
-    [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] :
+lemma sq_add_sq_eq_zero :
     a ^ 2 + b ^ 2 = 0 ↔ a = 0 ∧ b = 0 := by
     simpa [pow_two] using mul_self_add_mul_self_eq_zero
 
-lemma eq_zero_of_mul_self_add_mul_self_eq_zero [NoZeroDivisors R]
-    [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]
+lemma eq_zero_of_mul_self_add_mul_self_eq_zero
     (h : a * a + b * b = 0) : a = 0 :=
   (mul_self_add_mul_self_eq_zero.mp h).left
+
+end SumOfSquares
 
 theorem pos_of_right_mul_lt_le [ExistsAddOfLE R] [PosMulMono R]
     [AddRightMono R] [AddRightReflectLE R]

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -642,7 +642,7 @@ lemma mul_self_add_mul_self_eq_zero [NoZeroDivisors R]
 /-- The sum of two squares is zero iff both elements are zero -/
 lemma sq_add_sq_eq_zero [NoZeroDivisors R]
     [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] :
-    a^2 + b ^2 = 0 ↔ a = 0 ∧ b = 0 := by
+    a ^ 2 + b ^ 2 = 0 ↔ a = 0 ∧ b = 0 := by
     simpa [pow_two] using mul_self_add_mul_self_eq_zero
 
 lemma eq_zero_of_mul_self_add_mul_self_eq_zero [NoZeroDivisors R]

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -632,12 +632,18 @@ instance (priority := 100) [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] :
     ZeroLEOneClass R where
   zero_le_one := by simpa only [one_mul] using mul_self_nonneg (1 : R)
 
-/-- The sum of two squares is zero iff both elements are zero. -/
+/-- The sum of two terms of the form x * x is zero iff both elements are zero. -/
 lemma mul_self_add_mul_self_eq_zero [NoZeroDivisors R]
     [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] :
     a * a + b * b = 0 ↔ a = 0 ∧ b = 0 := by
   rw [add_eq_zero_iff_of_nonneg, mul_self_eq_zero (M₀ := R), mul_self_eq_zero (M₀ := R)] <;>
     apply mul_self_nonneg
+
+/- The sum of two squares is zero iff both elements are zero  -/
+lemma sq_add_sq_eq_zero [NoZeroDivisors R]
+    [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] :
+    a^2 + b ^2 = 0 ↔ a = 0 ∧ b = 0 := by
+    simpa [pow_two] using mul_self_add_mul_self_eq_zero
 
 lemma eq_zero_of_mul_self_add_mul_self_eq_zero [NoZeroDivisors R]
     [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -642,9 +642,8 @@ lemma mul_self_add_mul_self_eq_zero :
     apply mul_self_nonneg
 
 /-- The sum of two squares is zero iff both elements are zero -/
-lemma sq_add_sq_eq_zero :
-    a ^ 2 + b ^ 2 = 0 ↔ a = 0 ∧ b = 0 := by
-    simpa [pow_two] using mul_self_add_mul_self_eq_zero
+lemma sq_add_sq_eq_zero : a ^ 2 + b ^ 2 = 0 ↔ a = 0 ∧ b = 0 := by
+  simpa [pow_two] using mul_self_add_mul_self_eq_zero
 
 lemma eq_zero_of_mul_self_add_mul_self_eq_zero
     (h : a * a + b * b = 0) : a = 0 :=

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -639,7 +639,7 @@ lemma mul_self_add_mul_self_eq_zero [NoZeroDivisors R]
   rw [add_eq_zero_iff_of_nonneg, mul_self_eq_zero (M₀ := R), mul_self_eq_zero (M₀ := R)] <;>
     apply mul_self_nonneg
 
-/- The sum of two squares is zero iff both elements are zero  -/
+/-- The sum of two squares is zero iff both elements are zero -/
 lemma sq_add_sq_eq_zero [NoZeroDivisors R]
     [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] :
     a^2 + b ^2 = 0 ↔ a = 0 ∧ b = 0 := by


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This is a PR based on a [zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Why.20isn.27t.20there.20code.20for.20x.5E2.20.2B.20y.5E2.20.3D.200.20.3C-.3E.20x.20.3D.200.20.5E.20y.20.3D.200/with/617593940)

I added lemmas for proving that x^2 + y^2 = 0 <-> x = 0 and y =0. This one in particular was already in the library on the form of x * x + y * y, so I just added the version with the squares for practicality. Then I added the version for even powers and similar versions for finite sums.