### PR TITLE
[Merged by Bors] - chore(Tactic/Simproc/ExistsAndEq): simplify proof building using `subst`

### DIFF
--- a/Mathlib/Tactic/Simproc/ExistsAndEq.lean
+++ b/Mathlib/Tactic/Simproc/ExistsAndEq.lean
@@ -108,7 +108,8 @@ where
     MetaM (List VarQ × LocalContext × Q(Prop) × Q($α)) := do
   match path with
   | [] =>
-    let ~q(@Eq.{u} $γ $x $y) := P | panic! "path is empty, but `P` is not an equality: {← ppExpr P}"
+    let ~q(@Eq.{u} $γ $x $y) := P
+      | panic! s!"path is empty, but `P` is not an equality: {← ppExpr P}"
     if eqDetermines a x y then
       return ([], ← getLCtx, P, y)
     if eqDetermines a y x then
@@ -316,35 +317,35 @@ def mkAfterToBefore {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
       return q(Exists.intro $a' $pf1)
     mkLambdaFVars #[h] pf
 
-#check instantiateMVars
+/-- Runs `k` on `e` with the metavariables occurring in `e` replaced by local variables, and
+substitutes the metavariables back into the resulting `Simp.Step`. In some cases (e.g. under
+`aesop`) the goal contains metavariables, and this is needed to handle them properly: the proof
+built by `substCore` can only be instantiated when the goal contains none.
 
-/-- Runs `k` on `e` with every metavariable occurring in `e` replaced by a local variable, and
-substitutes the metavariables back into the resulting `Simp.Step`.
-
-The proof of a rewrite must be a closed term, and `substCore` reintroduces the substituted
-hypotheses through delayed assignments, which `instantiateMVars` only expands once the goal
-contains no metavariables at all (the discharger of `simp` rejects proofs with metavariables for
-the same reason). Goals containing metavariables are common under `aesop`, say. Since such
-metavariables predate every local variable introduced by the simproc, treating them as opaque
-local variables while the proof is built is sound. -/
-partial def withMVarsAsFVars (e : Expr) (k : Expr → MetaM Simp.Step) : MetaM Simp.Step := do
+The abstraction is done by `abstractMVars`, so that metavariables occurring in the types of other
+metavariables (as in `?f : α → ?β`) are handled consistently. -/
+def withMVarsAsFVars (e : Expr) (k : Expr → MetaM Simp.Step) : MetaM Simp.Step := do
   let e ← instantiateMVars e
-  go (← getMVars e).toList e #[] #[]
-where
-  /-- Introduces a local variable for each of the remaining metavariables. -/
-  go (mvars : List MVarId) (e : Expr) (ms xs : Array Expr) : MetaM Simp.Step := do
-    match mvars with
-    | [] =>
-      let subst (r : Simp.Result) : Simp.Result :=
-        { r with expr := r.expr.replaceFVars xs ms, proof? := r.proof?.map (·.replaceFVars xs ms) }
-      match ← k e with
-      | .done r => return .done (subst r)
-      | .visit r => return .visit (subst r)
-      | .continue r? => return .continue (r?.map subst)
-    | m :: mvars =>
-      withLocalDeclD .anonymous (← instantiateMVars (← m.getType)) fun x => do
-        let e := e.replace fun t => if t == mkMVar m then some x else none
-        go mvars e (ms.push (mkMVar m)) (xs.push x)
+  if !e.hasMVar then
+    return ← k e
+  let r ← abstractMVars e
+  lambdaTelescope r.expr fun xs e' => do
+    let step ← k e'
+    -- reopen the abstraction with fresh metavariables and unify them with the original ones
+    let us ← r.paramNames.mapM fun _ => mkFreshLevelMVar
+    let (ms, _, body) ←
+      lambdaMetaTelescope (r.expr.instantiateLevelParamsArray r.paramNames us) (some r.numMVars)
+    unless ← isDefEq body e do
+      throwError "existsAndEq: failed to restore the metavariables of{indentExpr e}"
+    let restore (t : Expr) : MetaM Expr := do
+      let t ← mkLambdaFVars xs t
+      instantiateMVars <| (t.instantiateLevelParamsArray r.paramNames us).beta ms
+    let subst (res : Simp.Result) : MetaM Simp.Result :=
+      return { res with expr := ← restore res.expr, proof? := ← res.proof?.mapM restore }
+    match step with
+    | .done res => return .done (← subst res)
+    | .visit res => return .visit (← subst res)
+    | .continue res? => return .continue (← res?.mapM subst)
 
 /-- The implementation of `existsAndEq`, for an expression without metavariables. -/
 def existsAndEqCore (e : Expr) : MetaM Simp.Step := do

--- a/Mathlib/Tactic/Simproc/ExistsAndEq.lean
+++ b/Mathlib/Tactic/Simproc/ExistsAndEq.lean
@@ -55,26 +55,11 @@ abbrev HypQ := (P : Q(Prop)) × Q($P)
 instance : Inhabited HypQ where
   default := ⟨default, default⟩
 
--- /-- Used to indicate the current case should be unreachable, unless an invariant is violated.
--- `context` should be used to indicate which case is asserted to be unreachable.
--- For example, `"findEq: path for a conjunction should be nonempty"`. -/
--- private def panic! {α : Type} (context : String) : MetaM α := do
---   let e := s!"existsAndEq: internal error, unreachable case has occurred:\n{context}."
---   logError e
---   -- the following error will be caught by `simp` so we additionally log it above
---   throwError e
-
-#check mkLambda
-
-/-- Constructs `∃ f₁ f₂ ... fₙ, body`, where `[f₁, ..., fₙ] = fvars`. -/
-def mkNestedExists (fvars : List VarQ) (body : Q(Prop)) : MetaM Q(Prop) := do
-  match fvars with
-  | [] => pure body
-  | ⟨_, β, b⟩ :: tl =>
-    let res ← mkNestedExists tl body
-    let name := (← getLCtx).findFVar? b |>.get!.userName
-    let p : Q($β → Prop) ← Impl.mkLambdaQ name b res
-    pure q(Exists $p)
+/-- Checks whether the equation with sides `x` and `y` determines the free variable `a` as `y`:
+`x` is `a` itself, and `y` doesn't mention `a` (in `a = f a`, for example, it does). The callers
+try both orientations. -/
+def eqDetermines (a x y : Expr) : Bool :=
+  a == x && !(y.containsFVar a.fvarId!)
 
 /-- Finds a `Path` for `findEq`. It leads to a subexpression `a = a'` or `a' = a`, where
 `a'` doesn't contain the free variable `a`.
@@ -84,9 +69,9 @@ partial def findEqPath {u : Level} {α : Q(Sort u)} (a : Q($α)) (P : Q(Prop)) :
     MetaM <| Option Path := do
   match_expr P with
   | Eq _ x y =>
-    if a == x && !(y.containsFVar a.fvarId!) then
+    if eqDetermines a x y then
       return some []
-    if a == y && !(x.containsFVar a.fvarId!) then
+    if eqDetermines a y x then
       return some []
     return none
   | And L R =>
@@ -124,9 +109,9 @@ where
   match path with
   | [] =>
     let ~q(@Eq.{u} $γ $x $y) := P | panic! "path is empty, but `P` is not an equality: {← ppExpr P}"
-    if a == x && !(y.containsFVar a.fvarId!) then
+    if eqDetermines a x y then
       return ([], ← getLCtx, P, y)
-    if a == y && !(x.containsFVar a.fvarId!) then
+    if eqDetermines a y x then
       return ([], ← getLCtx, P, x)
     panic!
       "some side of equality must be `a`, and the other must not depend on `a`"
@@ -138,7 +123,7 @@ where
     let ~q($L ∧ $R) := P | panic! "path starts with andLeft, but `P` is not a conjuction"
     let (fvars, lctx, P', a') ← go a q($R) tl
     return (fvars, lctx, q($L ∧ $P'), a')
-  | .existsType :: tl =>
+  | .existsType :: _ =>
     panic! "not implemented"
   | .existsBody :: tl =>
     let ~q(@Exists $β $pb) := P | panic! "path starts with `existsBody`, but `P` is not `Exists`"
@@ -147,11 +132,22 @@ where
       let (fvars, lctx, P', a') ← go a q($body) tl
       return (⟨_, _, b⟩ :: fvars, lctx, P', a')
 
+/-- Constructs `∃ f₁ f₂ ... fₙ, body`, where `[f₁, ..., fₙ] = fvars`. -/
+def mkNestedExists (fvars : List VarQ) (body : Q(Prop)) : MetaM Q(Prop) := do
+  match fvars with
+  | [] => pure body
+  | ⟨_, β, b⟩ :: tl =>
+    let res ← mkNestedExists tl body
+    let name := (← getLCtx).findFVar? b |>.get!.userName
+    let p : Q($β → Prop) ← Impl.mkLambdaQ name b res
+    pure q(Exists $p)
+
 /-- The path to the equation in the result formula: the quantifiers entered along `path` are moved
 to the front, so their `existsBody` steps come first, followed by the `And` steps in their original
 order. -/
 def Path.forResult (path : Path) : Path :=
-  path.filter (· == .existsBody) ++ path.filter (· != .existsBody)
+  let (quantifiers, conjunctions) := path.partition (· == .existsBody)
+  quantifiers ++ conjunctions
 
 /-- Destructs `h : P` following `path`, as the chain of `refine h.elim fun … ↦ ?_` in the docstring
 of `mkBeforeToAfter` does: at an `existsBody` step the quantifier is unpacked with `Exists.elim`,
@@ -239,23 +235,26 @@ The proof follows the following structure:
 ```
 example (f : β → α) {P Q : β → Prop} :
     (∃ x b, P b ∧ (∃ c, f c = x ∧ Q c) ∧ Q b) → ∃ b c, P b ∧ (f c = f c ∧ Q c) ∧ Q b := by
-  -- path : EB, AR, AL, EB, AL
+  -- path : existsBody, andRight, andLeft, existsBody, andLeft
   intro ⟨x, h₁⟩
-  -- destruct the input following the path
+  -- destruct the input following the path:
+  -- obtain ⟨e1, a1, ⟨e2, h_eq, a3⟩, a2⟩ := h₁
   refine
-    h₁.elim fun e1 h₂ ↦        -- EB
-    h₂.elim fun a1 h₃ ↦        -- AR
-    h₃.elim fun h₄ a2 ↦        -- AL
-    h₄.elim fun e2 h₅ ↦        -- EB
-    h₅.elim fun h_eq a3 ↦ ?_   -- AL
+    h₁.elim fun e1 h₂ ↦           -- existsBody
+    h₂.elim fun a1 h₃ ↦           -- andRight
+    h₃.elim fun h₄ a2 ↦           -- andLeft
+    h₄.elim fun e2 h₅ ↦           -- existsBody
+    h₅.elim fun h_eq a3 ↦ ?_      -- andLeft
   -- subst the equation (`substCore`)
   subst h_eq
-  -- construct the output following the path of the result: EB, EB, AR, AL, AL
-  refine Exists.intro e1 ?_ -- EB
-  refine Exists.intro e2 ?_ -- EB
-  refine And.intro a1 ?_    -- AR
-  refine And.intro ?_ a2    -- AL
-  refine And.intro ?_ a3    -- AL
+  -- construct the output following the path of the result (with all existsBody moved left):
+  -- existsBody, existsBody, andRight, andLeft, andLeft
+  -- exact ⟨e1, e2, a1, ⟨rfl, a3⟩, a2⟩
+  refine Exists.intro e1 ?_       -- existsBody
+  refine Exists.intro e2 ?_       -- existsBody
+  refine And.intro a1 ?_          -- andRight
+  refine And.intro ?_ a2          -- andLeft
+  refine And.intro ?_ a3          -- andLeft
   exact rfl
 ``` -/
 def mkBeforeToAfter {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
@@ -289,20 +288,23 @@ The proof follows the following structure:
 example (f : β → α) {P Q : β → Prop} :
     (∃ b c, P b ∧ (f c = f c ∧ Q c) ∧ Q b) → ∃ x b, P b ∧ (∃ c, f c = x ∧ Q c) ∧ Q b := by
   intro h₁
-  -- destruct the input following the path of the result: EB, EB, AR, AL, AL
+  -- destruct the input following the path of the result (with all existsBody moved left):
+  -- existsBody, existsBody, andRight, andLeft, andLeft
+  -- obtain ⟨e1, e2, a1, ⟨_, a3⟩, a2⟩ := h₁
   refine
-    h₁.elim fun e1 h₂ ↦    -- EB
-    h₂.elim fun e2 h₃ ↦    -- EB
-    h₃.elim fun a1 h₄ ↦    -- AR
-    h₄.elim fun h₅ a2 ↦    -- AL
-    h₅.elim fun _ a3 ↦ ?_  -- AL
-  -- construct the output following the path: EB, AR, AL, EB, AL
-  refine Exists.intro (f e2) ?_  -- `a'`
-  refine Exists.intro e1 ?_      -- EB
-  refine And.intro a1 ?_         -- AR
-  refine And.intro ?_ a2         -- AL
-  refine Exists.intro e2 ?_      -- EB
-  refine And.intro ?_ a3         -- AL
+    h₁.elim fun e1 h₂ ↦           -- existsBody
+    h₂.elim fun e2 h₃ ↦           -- existsBody
+    h₃.elim fun a1 h₄ ↦           -- andRight
+    h₄.elim fun h₅ a2 ↦           -- andLeft
+    h₅.elim fun _ a3 ↦ ?_         -- andLeft
+  -- construct the output following the path: existsBody, andRight, andLeft, existsBody, andLeft
+  -- exact ⟨f e2, e1, a1, ⟨e2, rfl, a3⟩, a2⟩
+  refine Exists.intro (f e2) ?_   -- `a'`
+  refine Exists.intro e1 ?_       -- existsBody
+  refine And.intro a1 ?_          -- andRight
+  refine And.intro ?_ a2          -- andLeft
+  refine Exists.intro e2 ?_       -- existsBody
+  refine And.intro ?_ a3          -- andLeft
   exact rfl
 ``` -/
 def mkAfterToBefore {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
@@ -313,7 +315,6 @@ def mkAfterToBefore {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
       let pf1 : Q($p $a') ← construct (goal := q($p $a')) fvars path leaves
       return q(Exists.intro $a' $pf1)
     mkLambdaFVars #[h] pf
-
 
 /-- Triggers at goals of the form `∃ a, body` and checks if `body` allows a single value `a'`
 for `a`. If so, replaces `a` with `a'` and removes quantifier.

--- a/Mathlib/Tactic/Simproc/ExistsAndEq.lean
+++ b/Mathlib/Tactic/Simproc/ExistsAndEq.lean
@@ -66,27 +66,21 @@ def eqDetermines (a x y : Expr) : Bool :=
 This is a fast version that quickly returns `none` when the simproc
 is not applicable. -/
 partial def findEqPath {u : Level} {α : Q(Sort u)} (a : Q($α)) (P : Q(Prop)) :
-    MetaM <| Option Path := do
+    OptionT MetaM Path := do
   match_expr P with
   | Eq _ x y =>
     if eqDetermines a x y then
-      return some []
+      return []
     if eqDetermines a y x then
-      return some []
-    return none
+      return []
+    failure
   | And L R =>
-    if let some path ← findEqPath a L then
-      return some (.andLeft :: path)
-    if let some path ← findEqPath a R then
-      return some (.andRight :: path)
-    return none
+    ((.andLeft :: ·) <$> findEqPath a L) <|> ((.andRight :: ·) <$> findEqPath a R)
   | Exists tb pb =>
-    if (tb.containsFVar a.fvarId!) then
-      return none
-    let .lam _ _ body _ := pb | return none
-    let some path ← findEqPath a body | return none
-    return some (.existsBody :: path)
-  | _ => return none
+    guard !(tb.containsFVar a.fvarId!)
+    let .lam _ _ body _ := pb | failure
+    (.existsBody :: ·) <$> findEqPath a body
+  | _ => failure
 
 /-- Given `P : Prop` and `a : α`, traverses the expression `P` to find a subexpression of
 the form `a = a'` or `a' = a` for some `a'`. It branches at each `And` and walks into
@@ -139,8 +133,7 @@ def mkNestedExists (fvars : List VarQ) (body : Q(Prop)) : MetaM Q(Prop) := do
   | [] => pure body
   | ⟨_, β, b⟩ :: tl =>
     let res ← mkNestedExists tl body
-    let name := (← getLCtx).findFVar? b |>.get!.userName
-    let p : Q($β → Prop) ← Impl.mkLambdaQ name b res
+    let p : Q($β → Prop) ← mkLambdaFVars #[b] res
     pure q(Exists $p)
 
 /-- The path to the equation in the result formula: the quantifiers entered along `path` are moved
@@ -275,8 +268,7 @@ def mkBeforeToAfter {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
           let e := fvarSubst.apply leaf
           return ⟨← inferType e, e⟩
         goal'.assign (← construct (goal := P') fvars path.forResult leaves)
-      have pf : Q($P') := ← instantiateMVars goal
-      return pf
+      instantiateMVars goal
     let pf2 : Q(∀ a : $α, $p a → $P') ← mkLambdaFVars #[a, ha] pf1
     let pf3 : Q($P') := q(Exists.elim $h $pf2)
     mkLambdaFVars #[h] pf3
@@ -313,7 +305,7 @@ def mkAfterToBefore {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
     MetaM <| Q($P' → (∃ a, $p a)) := do
   withLocalDeclQ .anonymous .default P' fun (h : Q($P')) => do
     let pf : Q(∃ a, $p a) ← destruct h fvars path.forResult [] fun leaves _ => do
-      let pf1 : Q($p $a') ← construct (goal := q($p $a')) fvars path leaves
+      let pf1 : Q($p $a') ← construct fvars path leaves
       return q(Exists.intro $a' $pf1)
     mkLambdaFVars #[h] pf
 
@@ -345,7 +337,7 @@ def withAbstractMVars (e : Expr) (k : Expr → MetaM Simp.Step) : MetaM Simp.Ste
 /-- The implementation of `existsAndEq`, for an expression without metavariables. -/
 def existsAndEqCore (e : Expr) : MetaM Simp.Step := do
   let_expr f@Exists α p := e | return .continue
-  lambdaBoundedTelescope p 1 fun xs (body : Q(Prop)) => withNewMCtxDepth do
+  lambdaBoundedTelescope p 1 fun xs (body : Q(Prop)) => do
     let some u := f.constLevels![0]? | unreachable!
     have α : Q(Sort $u) := α; have p : Q($α → Prop) := p
     let some (a : Q($α)) := xs[0]? | return .continue

--- a/Mathlib/Tactic/Simproc/ExistsAndEq.lean
+++ b/Mathlib/Tactic/Simproc/ExistsAndEq.lean
@@ -316,12 +316,38 @@ def mkAfterToBefore {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
       return q(Exists.intro $a' $pf1)
     mkLambdaFVars #[h] pf
 
-/-- Triggers at goals of the form `∃ a, body` and checks if `body` allows a single value `a'`
-for `a`. If so, replaces `a` with `a'` and removes quantifier.
+#check instantiateMVars
 
-It looks through nested quantifiers and conjunctions searching for a `a = a'`
-or `a' = a` subexpression. -/
-simproc ↓ existsAndEq (Exists _) := fun e => do
+/-- Runs `k` on `e` with every metavariable occurring in `e` replaced by a local variable, and
+substitutes the metavariables back into the resulting `Simp.Step`.
+
+The proof of a rewrite must be a closed term, and `substCore` reintroduces the substituted
+hypotheses through delayed assignments, which `instantiateMVars` only expands once the goal
+contains no metavariables at all (the discharger of `simp` rejects proofs with metavariables for
+the same reason). Goals containing metavariables are common under `aesop`, say. Since such
+metavariables predate every local variable introduced by the simproc, treating them as opaque
+local variables while the proof is built is sound. -/
+partial def withMVarsAsFVars (e : Expr) (k : Expr → MetaM Simp.Step) : MetaM Simp.Step := do
+  let e ← instantiateMVars e
+  go (← getMVars e).toList e #[] #[]
+where
+  /-- Introduces a local variable for each of the remaining metavariables. -/
+  go (mvars : List MVarId) (e : Expr) (ms xs : Array Expr) : MetaM Simp.Step := do
+    match mvars with
+    | [] =>
+      let subst (r : Simp.Result) : Simp.Result :=
+        { r with expr := r.expr.replaceFVars xs ms, proof? := r.proof?.map (·.replaceFVars xs ms) }
+      match ← k e with
+      | .done r => return .done (subst r)
+      | .visit r => return .visit (subst r)
+      | .continue r? => return .continue (r?.map subst)
+    | m :: mvars =>
+      withLocalDeclD .anonymous (← instantiateMVars (← m.getType)) fun x => do
+        let e := e.replace fun t => if t == mkMVar m then some x else none
+        go mvars e (ms.push (mkMVar m)) (xs.push x)
+
+/-- The implementation of `existsAndEq`, for an expression without metavariables. -/
+def existsAndEqCore (e : Expr) : MetaM Simp.Step := do
   let_expr f@Exists α p := e | return .continue
   lambdaBoundedTelescope p 1 fun xs (body : Q(Prop)) => withNewMCtxDepth do
     let some u := f.constLevels![0]? | unreachable!
@@ -336,6 +362,13 @@ simproc ↓ existsAndEq (Exists _) := fun e => do
       let pfAfterBefore : Q($P' → (∃ a, $p a)) ← mkAfterToBefore a' fvars path
       let pf := q(propext ⟨$pfBeforeAfter, $pfAfterBefore⟩)
       return .visit <| Simp.ResultQ.mk _ <| some q($pf)
+
+/-- Triggers at goals of the form `∃ a, body` and checks if `body` allows a single value `a'`
+for `a`. If so, replaces `a` with `a'` and removes quantifier.
+
+It looks through nested quantifiers and conjunctions searching for a `a = a'`
+or `a' = a` subexpression. -/
+simproc ↓ existsAndEq (Exists _) := fun e => withMVarsAsFVars e existsAndEqCore
 
 end ExistsAndEq
 

--- a/Mathlib/Tactic/Simproc/ExistsAndEq.lean
+++ b/Mathlib/Tactic/Simproc/ExistsAndEq.lean
@@ -34,7 +34,7 @@ namespace ExistsAndEq
 
 /-- Type for storing the chosen branch at `And` nodes. -/
 inductive GoTo
-| left | right
+| andLeft | andRight | existsType | existsBody
 deriving BEq, Inhabited
 
 /-- Type for storing the path in the body expression leading to `a = a'`. We store only the chosen
@@ -55,14 +55,16 @@ abbrev HypQ := (P : Q(Prop)) × Q($P)
 instance : Inhabited HypQ where
   default := ⟨default, default⟩
 
-/-- Used to indicate the current case should be unreachable, unless an invariant is violated.
-`context` should be used to indicate which case is asserted to be unreachable.
-For example, `"findEq: path for a conjunction should be nonempty"`. -/
-private def assertUnreachable {α : Type} (context : String) : MetaM α := do
-  let e := s!"existsAndEq: internal error, unreachable case has occurred:\n{context}."
-  logError e
-  -- the following error will be caught by `simp` so we additionally log it above
-  throwError e
+-- /-- Used to indicate the current case should be unreachable, unless an invariant is violated.
+-- `context` should be used to indicate which case is asserted to be unreachable.
+-- For example, `"findEq: path for a conjunction should be nonempty"`. -/
+-- private def panic! {α : Type} (context : String) : MetaM α := do
+--   let e := s!"existsAndEq: internal error, unreachable case has occurred:\n{context}."
+--   logError e
+--   -- the following error will be caught by `simp` so we additionally log it above
+--   throwError e
+
+#check mkLambda
 
 /-- Constructs `∃ f₁ f₂ ... fₙ, body`, where `[f₁, ..., fₙ] = fvars`. -/
 def mkNestedExists (fvars : List VarQ) (body : Q(Prop)) : MetaM Q(Prop) := do
@@ -89,15 +91,16 @@ partial def findEqPath {u : Level} {α : Q(Sort u)} (a : Q($α)) (P : Q(Prop)) :
     return none
   | And L R =>
     if let some path ← findEqPath a L then
-      return some (.left :: path)
+      return some (.andLeft :: path)
     if let some path ← findEqPath a R then
-      return some (.right :: path)
+      return some (.andRight :: path)
     return none
   | Exists tb pb =>
     if (tb.containsFVar a.fvarId!) then
       return none
     let .lam _ _ body _ := pb | return none
-    findEqPath a body
+    let some path ← findEqPath a body | return none
+    return some (.existsBody :: path)
   | _ => return none
 
 /-- Given `P : Prop` and `a : α`, traverses the expression `P` to find a subexpression of
@@ -118,299 +121,199 @@ where
   /-- Recursive part of `findEq`. -/
   go {u : Level} {α : Q(Sort u)} (a : Q($α)) (P : Q(Prop)) (path : Path) :
     MetaM (List VarQ × LocalContext × Q(Prop) × Q($α)) := do
-  match P with
-  | ~q(@Eq.{u} $γ $x $y) =>
+  match path with
+  | [] =>
+    let ~q(@Eq.{u} $γ $x $y) := P | panic! "path is empty, but `P` is not an equality: {← ppExpr P}"
     if a == x && !(y.containsFVar a.fvarId!) then
       return ([], ← getLCtx, P, y)
     if a == y && !(x.containsFVar a.fvarId!) then
       return ([], ← getLCtx, P, x)
-    assertUnreachable
-      "findEq: some side of equality must be `a`, and the other must not depend on `a`"
-  | ~q($L ∧ $R) =>
-    match path with
-    | [] => assertUnreachable "findEq: P is conjunction but path is empty"
-    | .left :: tl =>
-      let (fvars, lctx, P', a') ← go a q($L) tl
-      return (fvars, lctx, q($P' ∧ $R), a')
-    | .right :: tl =>
-      let (fvars, lctx, P', a') ← go a q($R) tl
-      return (fvars, lctx, q($L ∧ $P'), a')
-  | ~q(@Exists $β $pb) =>
+    panic!
+      "some side of equality must be `a`, and the other must not depend on `a`"
+  | .andLeft :: tl =>
+    let ~q($L ∧ $R) := P | panic! "path starts with andLeft, but `P` is not a conjuction"
+    let (fvars, lctx, P', a') ← go a q($L) tl
+    return (fvars, lctx, q($P' ∧ $R), a')
+  | .andRight :: tl =>
+    let ~q($L ∧ $R) := P | panic! "path starts with andLeft, but `P` is not a conjuction"
+    let (fvars, lctx, P', a') ← go a q($R) tl
+    return (fvars, lctx, q($L ∧ $P'), a')
+  | .existsType :: tl =>
+    panic! "not implemented"
+  | .existsBody :: tl =>
+    let ~q(@Exists $β $pb) := P | panic! "path starts with `existsBody`, but `P` is not `Exists`"
     lambdaBoundedTelescope pb 1 fun bs (body : Q(Prop)) => do
       let #[(b : Q($β))] := bs | unreachable!
-      let (fvars, lctx, P', a') ← go a q($body) path
+      let (fvars, lctx, P', a') ← go a q($body) tl
       return (⟨_, _, b⟩ :: fvars, lctx, P', a')
-  | _ => assertUnreachable s!"findEq: unexpected P = {← ppExpr P}"
 
-/-- When `P = ∃ f₁ ... fₙ, body`, where `exs = [f₁, ..., fₙ]`, this function takes
-`act : body → goal` and proves `P → goal` using `Exists.elim`.
+/-- The path to the equation in the result formula: the quantifiers entered along `path` are moved
+to the front, so their `existsBody` steps come first, followed by the `And` steps in their original
+order. -/
+def Path.forResult (path : Path) : Path :=
+  path.filter (· == .existsBody) ++ path.filter (· != .existsBody)
 
-Example:
-```
-exs = []: act h
-exs = [b]:
-  P := ∃ b, body
-  Exists.elim h (fun b hb ↦ act hb)
-exs = [b, c]:
-  P := ∃ b c, body
-  Exists.elim h (fun b hb ↦
-    Exists.elim hb (fun c hc ↦ act hc)
-  )
-...
-``` -/
-def withNestedExistsElim {P body goal : Q(Prop)} (exs : List VarQ) (h : Q($P))
-    (act : Q($body) → MetaM Q($goal)) : MetaM Q($goal) := do
-  match exs with
+/-- Destructs `h : P` following `path`, as the chain of `refine h.elim fun … ↦ ?_` in the docstring
+of `mkBeforeToAfter` does: at an `existsBody` step the quantifier is unpacked with `Exists.elim`,
+using the next variable of `exs` as the bound variable; at an `andLeft`/`andRight` step the
+conjunction is split with `And.elim`, and the part outside the path becomes a *leaf*. The
+continuation `k` receives the leaves (in path order, after those in `acc`) and the hypothesis at
+the end of the path, i.e. the equation. All of them are local hypotheses. -/
+partial def destruct {P goal : Q(Prop)} (h : Q($P)) (exs : List VarQ) (path : Path)
+    (acc : List HypQ) (k : List HypQ → HypQ → MetaM Q($goal)) : MetaM Q($goal) := do
+  match path with
+  | [] => k acc ⟨P, h⟩
+  | .existsBody :: tl =>
+    match exs with
+    | [] => panic! "path starts with `existsBody`, but `exs` is empty"
+    | ⟨v, γ, e⟩ :: exsTl =>
+    let ~q(@Exists.{v} $β $pb) := P
+      | panic! "path starts with `existsBody`, but `P` is not `Exists`"
+    let _ : $γ =Q $β := ⟨⟩
+    withLocalDeclQ .anonymous .default q($pb $e) fun h' => do
+      let pf ← destruct h' exsTl tl acc k
+      let f : Q(∀ e, $pb e → $goal) ← mkLambdaFVars #[e, h'] pf
+      return q(Exists.elim $h $f)
+  | .andRight :: tl =>
+    let ~q($L ∧ $R) := P | panic! "path starts with `andRight`, but `P` is not a conjunction"
+    withLocalDeclQ .anonymous .default q($L) fun leaf => do
+    withLocalDeclQ .anonymous .default q($R) fun h' => do
+      let pf ← destruct h' exs tl (acc ++ [⟨q($L), leaf⟩]) k
+      let f : Q($L → $R → $goal) ← mkLambdaFVars #[leaf, h'] pf
+      return q(And.elim $f $h)
+  | .andLeft :: tl =>
+    let ~q($L ∧ $R) := P | panic! "path starts with `andLeft`, but `P` is not a conjunction"
+    withLocalDeclQ .anonymous .default q($L) fun h' => do
+    withLocalDeclQ .anonymous .default q($R) fun leaf => do
+      let pf ← destruct h' exs tl (acc ++ [⟨q($R), leaf⟩]) k
+      let f : Q($L → $R → $goal) ← mkLambdaFVars #[h', leaf] pf
+      return q(And.elim $f $h)
+  | .existsType :: _ => panic! "not implemented"
+
+/-- Constructs a proof of `goal` following `path`, as the chain of `refine Exists.intro … ?_` and
+`refine And.intro … ?_` in the docstring of `mkBeforeToAfter` does: at an `existsBody` step the
+next variable of `exs` is the witness; at an `andLeft`/`andRight` step the part outside the path
+is proved by the next leaf; the equation at the end of the path is closed by `rfl`. -/
+partial def construct {goal : Q(Prop)} (exs : List VarQ) (path : Path) (leaves : List HypQ) :
+    MetaM Q($goal) := do
+  match path with
   | [] =>
-    let _ : $P =Q $body := ⟨⟩
-    act q($h)
-  | ⟨u, β, b⟩ :: tl =>
-    let ~q(@Exists.{u} $γ $p) := P
-      | assertUnreachable <| "withNestedExistsElim: exs is not empty but P is not `Exists`.\n" ++
-          s!"P = {← ppExpr P}"
-    let _ : $β =Q $γ := ⟨⟩
-    withLocalDeclQ .anonymous .default q($p $b) fun hb => do
-      let pf1 ← withNestedExistsElim tl hb act
-      let pf2 : Q(∀ b, $p b → $goal) ← mkLambdaFVars #[b, hb] pf1
-      return q(Exists.elim $h $pf2)
+    let ~q($x = $y) := goal | panic! "path is empty, but the goal is not an equation"
+    let _ : $x =Q $y := ⟨⟩
+    return q(rfl)
+  | .existsBody :: tl =>
+    match exs with
+    | [] => panic! "path starts with `existsBody`, but `exs` is empty"
+    | ⟨v, γ, e⟩ :: exsTl =>
+    let ~q(@Exists.{v} $β $pb) := goal
+      | panic! "path starts with `existsBody`, but the goal is not `Exists`"
+    let _ : $γ =Q $β := ⟨⟩
+    let pf : Q($pb $e) ← construct exsTl tl leaves
+    return q(Exists.intro $e $pf)
+  | .andRight :: tl =>
+    let ~q($L ∧ $R) := goal
+      | panic! "path starts with `andRight`, but the goal is not a conjunction"
+    match leaves with
+    | [] => panic! "path starts with `andRight`, but `leaves` is empty"
+    | ⟨T, leaf⟩ :: leavesTl =>
+    let _ : $T =Q $L := ⟨⟩
+    have leaf : Q($L) := leaf
+    let pf : Q($R) ← construct exs tl leavesTl
+    return q(And.intro $leaf $pf)
+  | .andLeft :: tl =>
+    let ~q($L ∧ $R) := goal
+      | panic! "path starts with `andLeft`, but the goal is not a conjunction"
+    match leaves with
+    | [] => panic! "path starts with `andLeft`, but `leaves` is empty"
+    | ⟨T, leaf⟩ :: leavesTl =>
+    let _ : $T =Q $R := ⟨⟩
+    have leaf : Q($R) := leaf
+    let pf : Q($L) ← construct exs tl leavesTl
+    return q(And.intro $pf $leaf)
+  | .existsType :: _ => panic! "not implemented"
+
+/-- Generates a proof of `(∃ a, p a) → P'`. We assume that `fvars = [f₁, ..., fₙ]` are free
+variables and `P' = ∃ f₁ ... fₙ, newBody`, and `path` leads to `a = a'` in `∃ a, p a`.
+
+The proof follows the following structure:
+```
+example (f : β → α) {P Q : β → Prop} :
+    (∃ x b, P b ∧ (∃ c, f c = x ∧ Q c) ∧ Q b) → ∃ b c, P b ∧ (f c = f c ∧ Q c) ∧ Q b := by
+  -- path : EB, AR, AL, EB, AL
+  intro ⟨x, h₁⟩
+  -- destruct the input following the path
+  refine
+    h₁.elim fun e1 h₂ ↦        -- EB
+    h₂.elim fun a1 h₃ ↦        -- AR
+    h₃.elim fun h₄ a2 ↦        -- AL
+    h₄.elim fun e2 h₅ ↦        -- EB
+    h₅.elim fun h_eq a3 ↦ ?_   -- AL
+  -- subst the equation (`substCore`)
+  subst h_eq
+  -- construct the output following the path of the result: EB, EB, AR, AL, AL
+  refine Exists.intro e1 ?_ -- EB
+  refine Exists.intro e2 ?_ -- EB
+  refine And.intro a1 ?_    -- AR
+  refine And.intro ?_ a2    -- AL
+  refine And.intro ?_ a3    -- AL
+  exact rfl
+``` -/
+def mkBeforeToAfter {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
+    {P' : Q(Prop)} (fvars : List VarQ) (path : Path) :
+    MetaM <| Q((∃ a, $p a) → $P') := do
+  withLocalDeclQ .anonymous .default q(∃ a, $p a) fun h => do
+  withLocalDeclQ .anonymous .default q($α) fun a => do
+  withLocalDeclQ .anonymous .default q($p $a) fun ha => do
+    let pf1 : Q($P') ← destruct ha fvars path [] fun leaves ⟨hEqType, hEq⟩ => do
+      let ~q(@Eq.{u} $γ $x $y) := hEqType | panic! "the end of the path is not an equation"
+      -- the equation is a local hypothesis, so `substCore` applies to it directly;
+      -- for `a' = a` the variable to eliminate is on the right-hand side
+      let goal ← mkFreshExprSyntheticOpaqueMVar P'
+      let (fvarSubst, goal') ← substCore goal.mvarId! hEq.fvarId! (symm := x != a)
+      goal'.withContext do
+        let leaves : List HypQ ← leaves.mapM fun ⟨_, leaf⟩ => do
+          let e := fvarSubst.apply leaf
+          return ⟨← inferType e, e⟩
+        goal'.assign (← construct (goal := P') fvars path.forResult leaves)
+      have pf : Q($P') := ← instantiateMVars goal
+      return pf
+    let pf2 : Q(∀ a : $α, $p a → $P') ← mkLambdaFVars #[a, ha] pf1
+    let pf3 : Q($P') := q(Exists.elim $h $pf2)
+    mkLambdaFVars #[h] pf3
 
 /-- Generates a proof of `P' → ∃ a, p a`. We assume that `fvars = [f₁, ..., fₙ]` are free variables
 and `P' = ∃ f₁ ... fₙ, newBody`, and `path` leads to `a = a'` in `∃ a, p a`.
 
 The proof follows the following structure:
 ```
-example {α β : Type} (f : β → α) {p : α → Prop} :
-    (∃ b, p (f b) ∧ f b = f b) → (∃ a, p a ∧ ∃ b, a = f b) := by
-  -- withLocalDeclQ
-  intro h
-  -- withNestedExistsElim : we unpack all quantifiers in `P` to get `h : newBody`.
-  refine h.elim (fun b h ↦ ?_)
-  -- use `a'` in the leading existential quantifier
-  refine Exists.intro (f b) ?_
-  -- then we traverse `newBody` and goal simultaneously
-  refine And.intro ?_ ?_
-  -- at branches outside the path `h` must coincide with goal
-  · replace h := h.left
-    exact h
-  -- inside path we substitute variables from `fvars` into existential quantifiers.
-  · replace h := h.right
-    refine Exists.intro b ?_
-    -- at the end the goal must be `x' = x'`.
-    rfl
+example (f : β → α) {P Q : β → Prop} :
+    (∃ b c, P b ∧ (f c = f c ∧ Q c) ∧ Q b) → ∃ x b, P b ∧ (∃ c, f c = x ∧ Q c) ∧ Q b := by
+  intro h₁
+  -- destruct the input following the path of the result: EB, EB, AR, AL, AL
+  refine
+    h₁.elim fun e1 h₂ ↦    -- EB
+    h₂.elim fun e2 h₃ ↦    -- EB
+    h₃.elim fun a1 h₄ ↦    -- AR
+    h₄.elim fun h₅ a2 ↦    -- AL
+    h₅.elim fun _ a3 ↦ ?_  -- AL
+  -- construct the output following the path: EB, AR, AL, EB, AL
+  refine Exists.intro (f e2) ?_  -- `a'`
+  refine Exists.intro e1 ?_      -- EB
+  refine And.intro a1 ?_         -- AR
+  refine And.intro ?_ a2         -- AL
+  refine Exists.intro e2 ?_      -- EB
+  refine And.intro ?_ a3         -- AL
+  exact rfl
 ``` -/
-partial def mkAfterToBefore {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
-    {P' : Q(Prop)} (a' : Q($α)) (newBody : Q(Prop)) (fvars : List VarQ) (path : Path) :
+def mkAfterToBefore {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
+    {P' : Q(Prop)} (a' : Q($α)) (fvars : List VarQ) (path : Path) :
     MetaM <| Q($P' → (∃ a, $p a)) := do
   withLocalDeclQ .anonymous .default P' fun (h : Q($P')) => do
-    let pf : Q(∃ a, $p a) ← withNestedExistsElim fvars h fun (h : Q($newBody)) => do
-      let pf1 : Q($p $a') ← go h fvars path
+    let pf : Q(∃ a, $p a) ← destruct h fvars path.forResult [] fun leaves _ => do
+      let pf1 : Q($p $a') ← construct (goal := q($p $a')) fvars path leaves
       return q(Exists.intro $a' $pf1)
     mkLambdaFVars #[h] pf
-where
-  /-- Traverses `P` and `goal` simultaneously, proving `goal`. -/
-  go {goal P : Q(Prop)} (h : Q($P)) (exs : List VarQ) (path : Path) :
-    MetaM Q($goal) := do
-  match goal with
-  | ~q(@Exists $β $pb) =>
-    match exs with
-    | [] => assertUnreachable "mkAfterToBefore: goal is `Exists` but `exs` is empty"
-    | ⟨v, γ, c⟩ :: exsTail =>
-    let _ : u_1 =QL v := ⟨⟩
-    let _ : $γ =Q $β := ⟨⟩
-    let pf1 : Q($pb $c) ← go h exsTail path
-    return q(Exists.intro $c $pf1)
-  | ~q(And $L $R) =>
-    let ~q($L' ∧ $R') := P
-      | assertUnreachable "mkAfterToBefore: goal is `And` but `P` is not `And`"
-    match path with
-    | [] => assertUnreachable "mkAfterToBefore: goal is `And` but `exs` is empty"
-    | .left :: tl =>
-      let _ : $R =Q $R' := ⟨⟩
-      let pfRight : Q($R) := q(And.right $h)
-      let pfLeft : Q($L) ← go q(And.left $h) exs tl
-      return q(And.intro $pfLeft $pfRight)
-    | .right :: tl =>
-      let _ : $L =Q $L' := ⟨⟩
-      let pfLeft : Q($L) := q(And.left $h)
-      let pfRight : Q($R) ← go q(And.right $h) exs tl
-      return q(And.intro $pfLeft $pfRight)
-  | _ =>
-    let ~q($x = $y) := goal
-      | assertUnreachable "mkAfterToBefore: unexpected goal: {← ppExpr goal}"
-    if !path.isEmpty then
-      assertUnreachable "mkAfterToBefore: `goal` is equality but `path` is not empty"
-    let _ : $x =Q $y := ⟨⟩
-    return q(rfl)
 
-/-- Recursive implementation for `withExistsElimAlongPath`. -/
-partial def withExistsElimAlongPathImp {u : Level} {α : Q(Sort u)}
-    {P goal : Q(Prop)} (h : Q($P)) {a a' : Q($α)} (exs : List VarQ) (path : Path)
-    (hs : List HypQ)
-    (act : Q($a = $a') → List HypQ → MetaM Q($goal)) :
-    MetaM Q($goal) := do
-  match P with
-  | ~q(@Exists $β $pb) =>
-    match exs with
-    | [] => assertUnreachable "withExistsElimAlongPathImp: `P` is `Exists` but `exs` is empty"
-    | ⟨v, γ, b⟩ :: exsTail =>
-    let _ : u_1 =QL v := ⟨⟩
-    let _ : $γ =Q $β := ⟨⟩
-    withLocalDeclQ .anonymous .default q($pb $b) fun hb => do
-      let newHs := hs ++ [⟨_, hb⟩]
-      let pf1 ← withExistsElimAlongPathImp (P := q($pb $b)) hb exsTail path newHs act
-      let pf2 : Q(∀ b, $pb b → $goal) ← mkLambdaFVars #[b, hb] pf1
-      return q(Exists.elim $h $pf2)
-  | ~q(And $L' $R') =>
-      match path with
-      | [] => assertUnreachable "withExistsElimAlongPathImp: `P` is `And` but `path` is empty"
-      | .left :: tl =>
-        withExistsElimAlongPathImp q(And.left $h) exs tl hs act
-      | .right :: tl =>
-        withExistsElimAlongPathImp q(And.right $h) exs tl hs act
-  | ~q(@Eq.{u} $γ $x $y) =>
-    let _ : $γ =Q $α := ⟨⟩
-    if !path.isEmpty then
-      assertUnreachable "withExistsElimAlongPathImp: `P` is equality but `path` is not empty"
-    if a == x then
-      let _ : $a =Q $x := ⟨⟩
-      let _ : $a' =Q $y := ⟨⟩
-      act q($h) hs
-    else if a == y then
-      let _ : $a =Q $y := ⟨⟩
-      let _ : $a' =Q $x := ⟨⟩
-      act q(Eq.symm $h) hs
-    else
-      assertUnreachable "withExistsElimAlongPathImp: `P` is equality but neither of sides is `a`"
-  | _ => assertUnreachable s!"withExistsElimAlongPathImp: unexpected P = {← ppExpr P}"
-
-/-- Given `act : (a = a') → hb₁ → hb₂ → ... → hbₙ → goal` where `hb₁, ..., hbₙ` are hypotheses
-obtained when unpacking existential quantifiers with variables from `exs`, it proves `goal` using
-`Exists.elim`. We use this to prove implication in the forward direction. -/
-def withExistsElimAlongPath {u : Level} {α : Q(Sort u)}
-    {P goal : Q(Prop)} (h : Q($P)) {a a' : Q($α)} (exs : List VarQ) (path : Path)
-    (act : Q($a = $a') → List HypQ → MetaM Q($goal)) :
-    MetaM Q($goal) :=
-  withExistsElimAlongPathImp h exs path [] act
-
-/-- When `P = ∃ f₁ ... fₙ, body`, where `exs = [f₁, ..., fₙ]`, this function takes
-`act : body` and proves `P` using `Exists.intro`.
-
-Example:
-```
-exs = []: act
-exs = [b]:
-  P := ∃ b, body
-  Exists.intro b act
-exs = [b, c]:
-  P := ∃ b c, body
-  Exists.intro b (Exists.intro c act)
-...
-``` -/
-def withNestedExistsIntro {P body : Q(Prop)} (exs : List VarQ)
-    (act : MetaM Q($body)) : MetaM Q($P) := do
-  match exs with
-  | [] =>
-    let _ : $P =Q $body := ⟨⟩
-    act
-  | ⟨u, β, b⟩ :: tl =>
-    let ~q(@Exists.{u} $γ $p) := P
-      | assertUnreachable "withNestedExistsIntro: `exs` is not empty but `P` is not `Exists`"
-    let _ : $β =Q $γ := ⟨⟩
-    let pf ← withNestedExistsIntro tl act
-    return q(Exists.intro $b $pf)
-
-/-- Generates a proof of `∃ a, p a → P'`. We assume that `fvars = [f₁, ..., fₙ]` are free variables
-and `P' = ∃ f₁ ... fₙ, newBody`, and `path` leads to `a = a'` in `∃ a, p a`.
-
-The proof follows the following structure:
-```
-example {α β : Type} (f : β → α) {p : α → Prop} :
-    (∃ a, p a ∧ ∃ b, a = f b) → (∃ b, p (f b) ∧ f b = f b) := by
-  -- withLocalDeclQ
-  intro h
-  refine h.elim (fun a ha ↦ ?_)
-  -- withExistsElimAlongPath: following the path we unpack all existential quantifiers.
-  -- at the end `hs = [hb]`.
-  have h' := ha
-  replace h' := h'.right
-  refine Exists.elim h' (fun b hb ↦ ?_)
-  replace h' := hb
-  have h_eq := h'
-  clear h'
-  -- go: we traverse `P` and `goal` simultaneously
-  have h' := ha
-  refine Exists.intro b ?_
-  refine And.intro ?_ ?_
-  -- outside the path goal must coincide with `h_eq ▸ h'`
-  · replace h' := h'.left
-    exact Eq.mp (congrArg (fun t ↦ p t) h_eq) h'
-  -- inside the path:
-  · replace h' := h'.right
-    -- when `h'` starts with existential quantifier we replace it with next hypothesis from `hs`.
-    replace h' := hb
-    -- at the end the goal must be `x' = x'`.
-    rfl
-``` -/
-partial def mkBeforeToAfter {u : Level} {α : Q(Sort u)} {p : Q($α → Prop)}
-    {P' : Q(Prop)} (a' : Q($α)) (newBody : Q(Prop)) (fvars : List VarQ) (path : Path) :
-    MetaM <| Q((∃ a, $p a) → $P') := do
-  withLocalDeclQ .anonymous .default q(∃ a, $p a) fun h => do
-  withLocalDeclQ .anonymous .default q($α) fun a => do
-  withLocalDeclQ .anonymous .default q($p $a) fun ha => do
-    let pf1 ← withExistsElimAlongPath ha fvars path fun (h_eq : Q($a = $a')) hs => do
-      let pf1 : Q($P') ← withNestedExistsIntro fvars (body := newBody) do
-        let pf ← go ha fvars hs path h_eq
-        pure pf
-      pure pf1
-    let pf2 : Q(∀ a : $α, $p a → $P') ← mkLambdaFVars #[a, ha] pf1
-    let pf3 : Q($P') := q(Exists.elim $h $pf2)
-    mkLambdaFVars #[h] pf3
-where
-  /-- Traverses `P` and `goal` simultaneously, proving `goal`. -/
-  go {goal P : Q(Prop)} (h : Q($P)) (exs : List VarQ) (hs : List HypQ) (path : Path)
-    {u : Level} {α : Q(Sort u)} {a a' : Q($α)} (h_eq : Q($a = $a')) :
-    MetaM Q($goal) := do
-  match P with
-  | ~q(@Exists $β $pb) =>
-    match exs with
-    | [] => assertUnreachable "mkBeforeToAfter: `P` is `Exists` but `exs` is empty"
-    | ⟨v, γ, b⟩ :: exsTail =>
-    let _ : u_1 =QL v := ⟨⟩
-    let _ : $γ =Q $β := ⟨⟩
-    match hs with
-    | [] => assertUnreachable "mkBeforeToAfter: `P` is `Exists` but `hs` is empty"
-    | ⟨H, hb⟩ :: hsTail =>
-    let _ : $H =Q $pb $b := ⟨⟩
-    let pf : Q($goal) ← go hb exsTail hsTail path h_eq
-    return pf
-  | ~q(And $L $R) =>
-    let ~q($L' ∧ $R') := goal
-      | assertUnreachable "mkBeforeToAfter: `P` is `And` but `goal` is not `And`"
-    match path with
-    | [] => assertUnreachable "mkBeforeToAfter: `P` is `And` but `path` is empty"
-    | .left :: tl =>
-      let pa : Q($α → Prop) ← mkLambdaFVars #[a] R
-      let _ : $R =Q $pa $a := ⟨⟩
-      let _ : $R' =Q $pa $a' := ⟨⟩
-      let pfRight : Q($R) := q(And.right $h)
-      let pfRight' : Q($R') := q(Eq.mp (congrArg $pa $h_eq) $pfRight)
-      let pfLeft' : Q($L') ← go q(And.left $h) exs hs tl h_eq
-      return q(And.intro $pfLeft' $pfRight')
-    | .right :: tl =>
-      let pa : Q($α → Prop) ← mkLambdaFVars #[a] L
-      let _ : $L =Q $pa $a := ⟨⟩
-      let _ : $L' =Q $pa $a' := ⟨⟩
-      let pfLeft : Q($L) := q(And.left $h)
-      let pfLeft' : Q($L') := q(Eq.mp (congrArg $pa $h_eq) $pfLeft)
-      let pfRight' : Q($R') ← go q(And.right $h) exs hs tl h_eq
-      return q(And.intro $pfLeft' $pfRight')
-  | _ =>
-    let ~q($x = $y) := goal
-      | assertUnreachable s!"mkBeforeToAfter: unexpected goal = {← ppExpr goal}"
-    if !path.isEmpty then
-      assertUnreachable "mkBeforeToAfter: goal is equality but path is not empty"
-    let _ : $x =Q $y := ⟨⟩
-    return q(rfl)
 
 /-- Triggers at goals of the form `∃ a, body` and checks if `body` allows a single value `a'`
 for `a`. If so, replaces `a` with `a'` and removes quantifier.
@@ -425,12 +328,12 @@ simproc ↓ existsAndEq (Exists _) := fun e => do
     let some (a : Q($α)) := xs[0]? | return .continue
     let some path ← findEqPath a body | return .continue
     let (fvars, lctx, newBody, a') ← findEq a body path
+    let newBody := newBody.replaceFVar a a'
     withLCtx' lctx do
-      let newBody := newBody.replaceFVar a a'
       let P' : Q(Prop) ← mkNestedExists fvars newBody
-      let pfBeforeAfter : Q((∃ a, $p a) → $P') ← mkBeforeToAfter a' newBody fvars path
-      let pfAfterBefore : Q($P' → (∃ a, $p a)) ← mkAfterToBefore a' newBody fvars path
-      let pf := q(propext (Iff.intro $pfBeforeAfter $pfAfterBefore))
+      let pfBeforeAfter : Q((∃ a, $p a) → $P') ← mkBeforeToAfter fvars path
+      let pfAfterBefore : Q($P' → (∃ a, $p a)) ← mkAfterToBefore a' fvars path
+      let pf := q(propext ⟨$pfBeforeAfter, $pfAfterBefore⟩)
       return .visit <| Simp.ResultQ.mk _ <| some q($pf)
 
 end ExistsAndEq

--- a/Mathlib/Tactic/Simproc/ExistsAndEq.lean
+++ b/Mathlib/Tactic/Simproc/ExistsAndEq.lean
@@ -323,26 +323,21 @@ substitutes the metavariables back into the resulting `Simp.Step`. In some cases
 built by `substCore` can only be instantiated when the goal contains none.
 
 The abstraction is done by `abstractMVars`, so that metavariables occurring in the types of other
-metavariables (as in `?f : α → ?β`) are handled consistently. -/
-def withMVarsAsFVars (e : Expr) (k : Expr → MetaM Simp.Step) : MetaM Simp.Step := do
+metavariables (as in `?f : α → ?β`) are handled consistently.
+
+TODO: this is a general simproc infrastructure, should we moved somewhere else?
+-/
+def withAbstractMVars (e : Expr) (k : Expr → MetaM Simp.Step) : MetaM Simp.Step := do
   let e ← instantiateMVars e
   if !e.hasMVar then
     return ← k e
-  let r ← abstractMVars e
-  lambdaTelescope r.expr fun xs e' => do
-    let step ← k e'
-    -- reopen the abstraction with fresh metavariables and unify them with the original ones
-    let us ← r.paramNames.mapM fun _ => mkFreshLevelMVar
-    let (ms, _, body) ←
-      lambdaMetaTelescope (r.expr.instantiateLevelParamsArray r.paramNames us) (some r.numMVars)
-    unless ← isDefEq body e do
-      throwError "existsAndEq: failed to restore the metavariables of{indentExpr e}"
-    let restore (t : Expr) : MetaM Expr := do
-      let t ← mkLambdaFVars xs t
-      instantiateMVars <| (t.instantiateLevelParamsArray r.paramNames us).beta ms
-    let subst (res : Simp.Result) : MetaM Simp.Result :=
+  let r ← abstractMVars e (levels := false)
+  lambdaBoundedTelescope r.expr r.numMVars fun xs e' => do
+    let restore (t : Expr) : MetaM Expr :=
+      instantiateMVars <| t.replaceFVars xs r.mvars
+    let subst (res : Simp.Result) : MetaM Simp.Result := do
       return { res with expr := ← restore res.expr, proof? := ← res.proof?.mapM restore }
-    match step with
+    match ← k e' with
     | .done res => return .done (← subst res)
     | .visit res => return .visit (← subst res)
     | .continue res? => return .continue (← res?.mapM subst)
@@ -369,7 +364,7 @@ for `a`. If so, replaces `a` with `a'` and removes quantifier.
 
 It looks through nested quantifiers and conjunctions searching for a `a = a'`
 or `a' = a` subexpression. -/
-simproc ↓ existsAndEq (Exists _) := fun e => withMVarsAsFVars e existsAndEqCore
+simproc ↓ existsAndEq (Exists _) := fun e => withAbstractMVars e existsAndEqCore
 
 end ExistsAndEq
 

--- a/MathlibTest/Simproc/ExistsAndEq.lean
+++ b/MathlibTest/Simproc/ExistsAndEq.lean
@@ -70,9 +70,7 @@ example (P Q : α × β → Prop) (a : α × β) :
   simp
 
 -- The simproc must return a closed proof even when the goal contains metavariables, which is what
--- `aesop` presents to it: here the goal is `∃ a : Nat, a = Nat.succ ?b ∧ 0 < ?b`. A tactic-level
--- test cannot catch this, since the metavariable context persists to the end of the proof, where
--- `?b` is finally assigned; so we inspect the proof produced by `simp` directly.
+-- `aesop` presents to it: here the goal is `∃ a : Nat, a = Nat.succ ?b ∧ 0 < ?b`.
 open Lean Meta Qq in
 #eval show MetaM Unit from do
   let b : Q(Nat) ← mkFreshExprMVarQ q(Nat)
@@ -84,3 +82,13 @@ open Lean Meta Qq in
   let leftover := (← getMVars pf).filter (· != b.mvarId!)
   unless leftover.isEmpty do
     throwError "metavariables left in the proof: {leftover.map mkMVar}\n{pf}"
+
+-- Metavariables may depend on each other: here `?f : Nat → ?β`, and `?β` occurs in the goal too
+-- (as it arises when `simpa using` simplifies the type of a term whose implicit arguments are not
+-- determined yet). They have to be handled consistently.
+example : ∃ (β : Type) (f : Nat → β), ∃ b, f 0 = b := by
+  refine ⟨?_, ?_, ?_⟩
+  rotate_left 2
+  simp only [existsAndEq]
+  · exact Nat
+  · exact id

--- a/MathlibTest/Simproc/ExistsAndEq.lean
+++ b/MathlibTest/Simproc/ExistsAndEq.lean
@@ -69,6 +69,8 @@ example (P Q : α × β → Prop) (a : α × β) :
     (∃ b : (α × β), (P b ∧ b = a) ∧ Q b) ↔ P a ∧ Q a := by
   simp
 
+-- # Metavariables in goals
+
 -- The simproc must return a closed proof even when the goal contains metavariables, which is what
 -- `aesop` presents to it: here the goal is `∃ a : Nat, a = Nat.succ ?b ∧ 0 < ?b`.
 open Lean Meta Qq in

--- a/MathlibTest/Simproc/ExistsAndEq.lean
+++ b/MathlibTest/Simproc/ExistsAndEq.lean
@@ -68,3 +68,19 @@ example (P Q : α × β → Prop) (a : α × β) :
 example (P Q : α × β → Prop) (a : α × β) :
     (∃ b : (α × β), (P b ∧ b = a) ∧ Q b) ↔ P a ∧ Q a := by
   simp
+
+-- The simproc must return a closed proof even when the goal contains metavariables, which is what
+-- `aesop` presents to it: here the goal is `∃ a : Nat, a = Nat.succ ?b ∧ 0 < ?b`. A tactic-level
+-- test cannot catch this, since the metavariable context persists to the end of the proof, where
+-- `?b` is finally assigned; so we inspect the proof produced by `simp` directly.
+open Lean Meta Qq in
+#eval show MetaM Unit from do
+  let b : Q(Nat) ← mkFreshExprMVarQ q(Nat)
+  let e : Q(Prop) := q(∃ a : Nat, a = Nat.succ $b ∧ 0 < $b)
+  let simprocs ← ({} : Simprocs).add ``ExistsAndEq.existsAndEq (post := false)
+  let (r, _) ← Simp.main e (← Simp.mkContext) (methods := Simp.mkDefaultMethodsCore #[simprocs])
+  let some pf := r.proof? | throwError "the simproc did not fire"
+  let pf ← instantiateMVars pf
+  let leftover := (← getMVars pf).filter (· != b.mvarId!)
+  unless leftover.isEmpty do
+    throwError "metavariables left in the proof: {leftover.map mkMVar}\n{pf}"


### PR DESCRIPTION
Reuse the `subst` tactic for proof building in `existsAndEq` simproc.

The proofs the simproc build can be done as follows, by some shuffling and `subst`:
```lean4
example (f : β → α) {P : α → Prop} :
    (∃ a, P a ∧ ∃ b, a = f b) ↔ ∃ b, P (f b) ∧ f b = f b := by
  constructor
  · intro ⟨a, hP, b, h_eq⟩
    subst h_eq
    exact ⟨b, hP, rfl⟩
  · intro ⟨b, hP, _⟩
    exact ⟨f b, hP, b, rfl⟩
```

This simplifies the proof building procedure and generalizes to the dependent quantifiers case (#43059).

Other minor changes:
1. Replace `assertUnreachable` with `panic!` as we use it in situations in which assumed invariants are broken and should not happen.
2. Don't omit existential quantifiers in `GoTo` and `Path`. Now the `path` object contains enough information to build the whole proof.
3. Wrap the simproc in `withAbstractMVars` to deal with external metavariables. This is needed to isolate our `subst` call from them.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
