### PR TITLE
[Merged by Bors] - feat(Topology/MetricSpace): variant of the Lebesgue number lemmas

### DIFF
--- a/Mathlib/Topology/MetricSpace/Bounded.lean
+++ b/Mathlib/Topology/MetricSpace/Bounded.lean
@@ -665,3 +665,19 @@ theorem exists_forall_ge_of_isBounded {f : β → α} (hf : Continuous f) (x₀ 
   hf.exists_forall_le_of_isBounded (α := αᵒᵈ) x₀ h
 
 end Continuous
+
+/-- If `U : ι → Set X` is an open covering of a compact metric space `X`,
+there exists `ε > 0` such that any subset of `X` of diameter `≤ ε`
+is containted in some `U i`. -/
+lemma CompactSpace.lebesgue_number_lemma {X : Type*} [MetricSpace X] [CompactSpace X]
+    {ι : Type*} (U : ι → Set X) (hU : ∀ i, IsOpen (U i)) (hU' : ⋃ i, U i = Set.univ) :
+    ∃ ε > 0, ∀ (S : Set X) (_ : S.Nonempty) (_ : Metric.diam S ≤ ε), ∃ (i : ι), S ⊆ U i := by
+  obtain ⟨δ, hδ, hδ'⟩ := lebesgue_number_lemma_of_metric isCompact_univ hU (by simp [hU'])
+  refine ⟨δ / 2, by simpa, fun S ⟨x, hx⟩ hS₂ ↦ ?_⟩
+  obtain ⟨i, hi⟩ := hδ' x (by simp)
+  refine ⟨i, fun s hs ↦ hi ?_⟩
+  simp only [Metric.mem_ball]
+  refine lt_of_le_of_lt (Metric.dist_le_diam_of_mem' ?_ hs hx)
+    (lt_of_le_of_lt hS₂ (by simpa))
+  simpa only [← Metric.isBounded_iff_ediam_ne_top] using
+    Metric.isBounded_of_compactSpace

--- a/Mathlib/Topology/MetricSpace/Bounded.lean
+++ b/Mathlib/Topology/MetricSpace/Bounded.lean
@@ -668,7 +668,7 @@ end Continuous
 
 /-- If `U : ι → Set X` is an open covering of a compact metric space `X`,
 there exists `ε > 0` such that any subset of `X` of diameter `≤ ε`
-is containted in some `U i`. -/
+is contained in some `U i`. -/
 lemma CompactSpace.lebesgue_number_lemma {X : Type*} [MetricSpace X] [CompactSpace X]
     {ι : Type*} (U : ι → Set X) (hU : ∀ i, IsOpen (U i)) (hU' : ⋃ i, U i = Set.univ) :
     ∃ ε > 0, ∀ (S : Set X) (_ : S.Nonempty) (_ : Metric.diam S ≤ ε), ∃ (i : ι), S ⊆ U i := by


### PR DESCRIPTION
If `U : ι → Set X` is an open covering of a compact metric space `X`, there exists `ε > 0` such that any subset of `X` of diameter `≤ ε` is containted in some `U i`.

From https://github.com/joelriou/excision and https://github.com/joelriou/topcat-model-category

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
