### PR TITLE
[Merged by Bors] - chore(Data): fix typos

### DIFF
--- a/Mathlib/Basic/Finite/Defs.lean
+++ b/Mathlib/Basic/Finite/Defs.lean
@@ -48,7 +48,7 @@ A finite set is defined to be a set whose coercion to a type has a `Finite` inst
 
 There are two components to finiteness constructions. The first is `Fintype` instances for each
 construction. This gives a way to actually compute a `Finset` that represents the set, and these
-may be accessed using `set.toFinset`. This gets the `Finset` in the correct form, since otherwise
+may be accessed using `Set.toFinset`. This gets the `Finset` in the correct form, since otherwise
 `Finset.univ : Finset s` is a `Finset` for the subtype for `s`. The second component is
 "constructors" for `Set.Finite` that give proofs that `Fintype` instances exist classically given
 other `Set.Finite` proofs. Unlike the `Fintype` instances, these *do not* use any decidability

--- a/Mathlib/Data/Analysis/Filter.lean
+++ b/Mathlib/Data/Analysis/Filter.lean
@@ -91,7 +91,7 @@ theorem mem_toFilter_sets (F : CFilter (Set α) σ) {a : Set α} : a ∈ F.toFil
 end CFilter
 
 -- TODO write doc strings
-/-- A realizer for filter `f` is a cfilter which generates `f`. -/
+/-- A realizer for filter `f` is a `CFilter` which generates `f`. -/
 structure Filter.Realizer (f : Filter α) where
   σ : Type*
   F : CFilter (Set α) σ

--- a/Mathlib/Data/Bool/Count.lean
+++ b/Mathlib/Data/Bool/Count.lean
@@ -15,7 +15,7 @@ public import Mathlib.Algebra.Ring.Nat
 # List of Booleans
 
 In this file we prove lemmas about the number of `false`s and `true`s in a list of Booleans. First
-we prove that the number of `false`s plus the number of `true` equals the length of the list. Then
+we prove that the number of `false`s plus the number of `true`s equals the length of the list. Then
 we prove that in a list with alternating `true`s and `false`s, the number of `true`s differs from
 the number of `false`s by at most one. We provide several versions of these statements.
 -/

--- a/Mathlib/Data/DFinsupp/BigOperators.lean
+++ b/Mathlib/Data/DFinsupp/BigOperators.lean
@@ -26,7 +26,7 @@ The support is internally represented (in the primed `DFinsupp.support'`) as a `
 represents a superset of the true support of the function, quotiented by the always-true relation so
 that this does not impact equality. This approach has computational benefits over storing a
 `Finset`; it allows us to add together two finitely-supported functions without
-having to evaluate the resulting function to recompute its support (which would required
+having to evaluate the resulting function to recompute its support (which would require
 decidability of `b = 0` for `b : β i`).
 
 The true support of the function can still be recovered with `DFinsupp.support`; but these

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -29,7 +29,7 @@ The support is internally represented (in the primed `DFinsupp.support'`) as a `
 represents a superset of the true support of the function, quotiented by the always-true relation so
 that this does not impact equality. This approach has computational benefits over storing a
 `Finset`; it allows us to add together two finitely-supported functions without
-having to evaluate the resulting function to recompute its support (which would required
+having to evaluate the resulting function to recompute its support (which would require
 decidability of `b = 0` for `b : β i`).
 
 The true support of the function can still be recovered with `DFinsupp.support`; but these

--- a/Mathlib/Data/DFinsupp/WellFounded.lean
+++ b/Mathlib/Data/DFinsupp/WellFounded.lean
@@ -23,7 +23,7 @@ The results are used to prove `Pi.Lex.wellFounded` and two variants, which say t
 `ι` is finite and equipped with a linear order and `(· < ·)` is well-founded on each `α i`,
 then the lexicographic `(· < ·)` is well-founded on `Π i, α i`, and the same is true for
 `Π₀ i, α i` (`DFinsupp.Lex.wellFounded_of_finite`), because `DFinsupp` is order-isomorphic
-to `pi` when `ι` is finite.
+to `Pi` when `ι` is finite.
 
 Finally, we deduce `DFinsupp.wellFoundedLT`, `Pi.wellFoundedLT`,
 `DFinsupp.wellFoundedLT_of_finite` and variants, which concern the product order

--- a/Mathlib/Data/Fin/Embedding.lean
+++ b/Mathlib/Data/Fin/Embedding.lean
@@ -12,7 +12,7 @@ public import Mathlib.Logic.Embedding.Basic
 # Embeddings of `Fin n`
 
 `Fin n` is the type whose elements are natural numbers smaller than `n`.
-This file defines embeddings between `Fin n` and other types,
+This file defines embeddings between `Fin n` and other types.
 
 ## Main definitions
 

--- a/Mathlib/Data/Finsupp/Fin.lean
+++ b/Mathlib/Data/Finsupp/Fin.lean
@@ -10,7 +10,7 @@ public import Mathlib.Data.Finsupp.Single
 /-!
 # `cons` and `tail` for maps `Fin n →₀ M`
 
-We interpret maps `Fin n →₀ M` as `n`-tuples of elements of `M`,
+We interpret maps `Fin n →₀ M` as `n`-tuples of elements of `M`.
 We define the following operations:
 * `Finsupp.tail` : the tail of a map `Fin (n + 1) →₀ M`, i.e., its last `n` entries;
 * `Finsupp.cons` : adding an element at the beginning of an `n`-tuple, to get an `n + 1`-tuple;

--- a/Mathlib/Data/Finsupp/MonomialOrder.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
 
 ## Monomial orders
 
-A *monomial order* is well ordering relation on a type of the form `σ →₀ ℕ` which
+A *monomial order* is a well ordering relation on a type of the form `σ →₀ ℕ` which
 is compatible with addition and for which `0` is the smallest element.
 Since several monomial orders may have to be used simultaneously, one cannot
 get them as instances.

--- a/Mathlib/Data/Finsupp/ToDFinsupp.lean
+++ b/Mathlib/Data/Finsupp/ToDFinsupp.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Finsupp.SMul
 # Conversion between `Finsupp` and homogeneous `DFinsupp`
 
 This module provides conversions between `Finsupp` and `DFinsupp`.
-It is in its own file since neither `Finsupp` or `DFinsupp` depend on each other.
+It is in its own file since neither `Finsupp` nor `DFinsupp` depend on each other.
 
 ## Main definitions
 
@@ -31,7 +31,7 @@ It is in its own file since neither `Finsupp` or `DFinsupp` depend on each other
 
 ## Theorems
 
-The defining features of these operations is that they preserve the function and support:
+The defining features of these operations are that they preserve the function and support:
 
 * `Finsupp.toDFinsupp_coe`
 * `Finsupp.toDFinsupp_support`

--- a/Mathlib/Data/Fintype/Order.lean
+++ b/Mathlib/Data/Fintype/Order.lean
@@ -25,7 +25,7 @@ On a `Fintype`, we can construct
 * an `OrderTop` from `SemilatticeSup`.
 * a `BoundedOrder` from `Lattice`.
 
-Those are marked as `def` to avoid defeqness issues.
+Those are marked as `def` to avoid issues with defeq.
 
 ## Completion instances
 

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -15,7 +15,7 @@ public import Mathlib.Tactic.OfNat
 /-!
 # Basic operations on the integers
 
-This file builds on `Data.Int.Init` by adding basic lemmas on integers.
+This file builds on `Data.Int.Init` by adding basic lemmas on integers
 depending on Mathlib definitions.
 -/
 

--- a/Mathlib/Data/List/Infix.lean
+++ b/Mathlib/Data/List/Infix.lean
@@ -19,7 +19,7 @@ This file proves properties about
 * `List.isSuffix`: `l₁` is a suffix of `l₂` if `l₂` ends with `l₁`.
 * `List.isInfix`: `l₁` is an infix of `l₂` if `l₁` is a prefix of some suffix of `l₂`.
 * `List.inits`: The list of prefixes of a list.
-* `List.tails`: The list of prefixes of a list.
+* `List.tails`: The list of suffixes of a list.
 * `insert` on lists
 
 All those (except `insert`) are defined in `Mathlib/Data/List/Defs.lean`.

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -20,8 +20,8 @@ This file provides basic results about `List.Pairwise` and `List.pwFilter` (defi
 `Pairwise (≠) l` means that all elements of `l` are distinct, and `Pairwise (<) l` means that `l`
 is strictly increasing.
 `pwFilter R l` is the list obtained by iteratively adding each element of `l` that doesn't break
-the pairwiseness of the list we have so far. It thus yields `l'` a maximal sublist of `l` such that
-`Pairwise R l'`.
+the pairwise property of the list we have so far. It thus yields `l'` as a maximal sublist of `l`
+such that `Pairwise R l'`.
 
 ## Tags
 

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -377,7 +377,7 @@ These predicates are equivalent to `Monotone l.get`, but they are also equivalen
 API has deliberately not been provided for decomposed lists to avoid unneeded API replication.
 The provided API should be used to move to and from `IsChain`,
 `Pairwise` or `Monotone` as needed.
---/
+-/
 
 /-- `l.SortedLE` means that the list is monotonic. -/
 def SortedLE (l : List α) := Monotone l.get

--- a/Mathlib/Data/Multiset/DershowitzManna.lean
+++ b/Mathlib/Data/Multiset/DershowitzManna.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.Multiset.OrderedMonoid
 In this file we define the _Dershowitz-Manna ordering_ on multisets. Specifically, for two multisets
 `M` and `N` in a partial order `(S, <)`, `M` is smaller than `N` in the Dershowitz-Manna ordering if
 `M` can be obtained from `N` by replacing one or more elements in `N` by some finite number of
-elements from `S`, each of which is smaller (in the underling ordering over `S`) than one of the
+elements from `S`, each of which is smaller (in the underlying ordering over `S`) than one of the
 replaced elements from `N`. We prove that, given a well-founded partial order on the underlying set,
 the Dershowitz-Manna ordering defined over multisets is also well-founded.
 

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -29,7 +29,7 @@ bitwise properties. In the second half of this file, we show properties of the b
 * `exists_most_significant_bit`: if `n ≠ 0`, then there is some position `i` that contains the most
   significant `1`-bit of `n`.
 * `lt_of_testBit`: if `n` and `m` are numbers and `i` is a position such that the `i`-th bit of
-  of `n` is zero, the `i`-th bit of `m` is one, and all more significant bits are equal, then
+  `n` is zero, the `i`-th bit of `m` is one, and all more significant bits are equal, then
   `n < m`.
 
 ## Future work

--- a/Mathlib/Data/Nat/Choose/Multinomial.lean
+++ b/Mathlib/Data/Nat/Choose/Multinomial.lean
@@ -138,8 +138,8 @@ theorem multinomial_single [DecidableEq α] :
 /-! ### Connection to binomial coefficients
 
 When `Nat.multinomial` is applied to a `Finset` of two elements `{a, b}`, the
-result a binomial coefficient. We use `binomial` in the names of lemmas that
-involves `Nat.multinomial {a, b}`.
+result is a binomial coefficient. We use `binomial` in the names of lemmas that
+involve `Nat.multinomial {a, b}`.
 -/
 
 theorem binomial_eq [DecidableEq α] (h : a ≠ b) :

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -16,7 +16,7 @@ public import Mathlib.Data.Nat.Digits.Defs
 /-!
 # Digits of a natural number
 
-This provides lemma about the digits of natural numbers.
+This provides lemmas about the digits of natural numbers.
 -/
 
 public section

--- a/Mathlib/Data/QPF/Multivariate/Basic.lean
+++ b/Mathlib/Data/QPF/Multivariate/Basic.lean
@@ -22,7 +22,7 @@ inductive ListShape (a b : Type)
   | cons : a -> b -> ListShape
 ```
 
-This shape can itself be decomposed as a sum of product which are themselves
+This shape can itself be decomposed as a sum of products which are themselves
 QPFs. It follows that the shape is a QPF and we can take its fixed point
 and create the list itself:
 
@@ -68,7 +68,7 @@ matched because they preserve the properties of QPF. The latter example,
   * Prj
   * Const
 
-each proves that some operations on functors preserves the QPF structure
+each proves that some operations on functors preserve the QPF structure
 -/
 
 @[expose] public section

--- a/Mathlib/Data/Rat/Cast/Lemmas.lean
+++ b/Mathlib/Data/Rat/Cast/Lemmas.lean
@@ -13,7 +13,7 @@ public import Mathlib.Tactic.Positivity.Basic
 # Some exiled lemmas about casting
 
 These lemmas have been removed from `Mathlib/Data/Rat/Cast/Defs.lean`
-to avoiding needing to import `Mathlib/Algebra/Field/Basic.lean` there.
+to avoid needing to import `Mathlib/Algebra/Field/Basic.lean` there.
 
 In fact, these lemmas don't appear to be used anywhere in Mathlib,
 so perhaps this file can simply be deleted.

--- a/Mathlib/Data/Set/Finite/Basic.lean
+++ b/Mathlib/Data/Set/Finite/Basic.lean
@@ -29,7 +29,7 @@ A finite set is defined to be a set whose coercion to a type has a `Finite` inst
 
 There are two components to finiteness constructions. The first is `Fintype` instances for each
 construction. This gives a way to actually compute a `Finset` that represents the set, and these
-may be accessed using `set.toFinset`. This gets the `Finset` in the correct form, since otherwise
+may be accessed using `Set.toFinset`. This gets the `Finset` in the correct form, since otherwise
 `Finset.univ : Finset s` is a `Finset` for the subtype for `s`. The second component is
 "constructors" for `Set.Finite` that give proofs that `Fintype` instances exist classically given
 other `Set.Finite` proofs. Unlike the `Fintype` instances, these *do not* use any decidability

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -684,8 +684,8 @@ lemma bijOn_id (s : Set α) : BijOn id s s := ⟨s.mapsTo_id, s.injOn_id, s.surj
 theorem BijOn.comp (hg : BijOn g t p) (hf : BijOn f s t) : BijOn (g ∘ f) s p :=
   BijOn.mk (hg.mapsTo.comp hf.mapsTo) (hg.injOn.comp hf.injOn hf.mapsTo) (hg.surjOn.comp hf.surjOn)
 
-/-- If `f : α → β` and `g : β → γ` and if `f` is injective on `s`, then `f ∘ g` is a bijection
-on `s` iff  `g` is a bijection on `f '' s`. -/
+/-- If `f : α → β` and `g : β → γ` and if `f` is injective on `s`, then `g ∘ f` is a bijection
+on `s` iff `g` is a bijection on `f '' s`. -/
 theorem bijOn_comp_iff (hf : InjOn f s) : BijOn (g ∘ f) s p ↔ BijOn g (f '' s) p := by
   simp only [BijOn, InjOn.comp_iff, surjOn_comp_iff, mapsTo_image_iff, hf]
 
@@ -703,7 +703,7 @@ p₁       p₂
 
 and `f` induces a bijection from `s : Set α` to `t : Set β`, then `g`
 induces a bijection from the image of `s` to the image of `t`, as long as `g` is
-is injective on the image of `s`.
+injective on the image of `s`.
 -/
 theorem bijOn_image_image {p₁ : α → γ} {p₂ : β → δ} {g : γ → δ} (comm : ∀ a, p₂ (f a) = g (p₁ a))
     (hbij : BijOn f s t) (hinj : InjOn g (p₁ '' s)) : BijOn g (p₁ '' s) (p₂ '' t) := by

--- a/Mathlib/Data/Sigma/Lex.lean
+++ b/Mathlib/Data/Sigma/Lex.lean
@@ -24,7 +24,7 @@ related by the summand's relation.
 Related files are:
 * `Combinatorics.CoLex`: Colexicographic order on finite sets.
 * `Data.List.Lex`: Lexicographic order on lists.
-* `Data.Sigma.Order`: Lexicographic order on `Σ i, α i` per say.
+* `Data.Sigma.Order`: Lexicographic order on `Σ i, α i` per se.
 * `Data.PSigma.Order`: Lexicographic order on `Σ' i, α i`.
 * `Data.Prod.Lex`: Lexicographic order on `α × β`. Can be thought of as the special case of
   `Sigma.Lex` where all summands are the same

--- a/Mathlib/Data/TypeVec.lean
+++ b/Mathlib/Data/TypeVec.lean
@@ -137,7 +137,8 @@ def splitFun {α α' : TypeVec (n + 1)} (f : drop α ⟹ drop α') (g : last α 
   | Fin2.fs i => f i
   | Fin2.fz => g
 
-/-- append an arrow and a function as well as their respective source and target types / typevecs -/
+/-- Append an arrow and a function as well as their respective source and target types /
+type vectors. -/
 def appendFun {α α' : TypeVec n} {β β' : Type*} (f : α ⟹ α') (g : β → β') :
     append1 α β ⟹ append1 α' β' :=
   splitFun f g

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.BitVec
 /-!
 # Adds Mathlib specific instances to the `UIntX` data types.
 
-The `CommRing` instances (and the `NatCast` and `IntCast` instances from which they is built) are
+The `CommRing` instances (and the `NatCast` and `IntCast` instances from which they are built) are
 scoped in the `UIntX.CommRing` namespace, rather than available globally. As a result, the `ring`
 tactic will not work on `UIntX` types without `open scoped UIntX.Ring`.
 

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -347,7 +347,7 @@ section UnusedInput
 variable {xs : Vector α n} {ys : Vector β n}
 
 /--
-If `f` returns the same output and next state for every value of it's first argument, then
+If `f` returns the same output and next state for every value of its first argument, then
 `xs : Vector` is ignored, and we can rewrite `mapAccumr₂` into `map`.
 -/
 @[simp]
@@ -359,7 +359,7 @@ theorem mapAccumr₂_unused_input_left (f : α → β → σ → σ × γ) (f' :
   | snoc xs ys x y ih => simp [h x y s, ih]
 
 /--
-If `f` returns the same output and next state for every value of it's second argument, then
+If `f` returns the same output and next state for every value of its second argument, then
 `ys : Vector` is ignored, and we can rewrite `mapAccumr₂` into `map`.
 -/
 @[simp]

--- a/Mathlib/Data/ZMod/IntUnitsPower.lean
+++ b/Mathlib/Data/ZMod/IntUnitsPower.lean
@@ -16,7 +16,7 @@ See also the related `negOnePow`.
 
 ## TODO
 
-* Generalize this to `Pow G (Zmod n)` where `orderOf g = n`.
+* Generalize this to `Pow G (ZMod n)` where `orderOf g = n`.
 
 ## Implementation notes
 


### PR DESCRIPTION
Fix some typos in `Mathlib/Data` that were spotted by Claude Opus 5.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
