### PR TITLE
[Merged by Bors] - chore(LeviCivita): update reference to Lean transparency issue in TODO

### DIFF
--- a/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita.lean
@@ -176,8 +176,8 @@ variable [IsContMDiffRiemannianBundle I 1 E (fun (x : M) ↦ TangentSpace I x)]
 -- with `open scoped RealInnerProductSpace`.
 local notation "⟪" X ", " Y "⟫" => fun x ↦ inner ℝ (X x) (Y x)
 
-/- TODO: The next two lemmas are workarounds for some version of https://github.com/leanprover/lean4/issues/9077
-(Instance synthesis sees through type synonyms).
+/- TODO: The next two lemmas are workarounds for https://github.com/leanprover/lean4/issues/14949
+(Unification sees through type synonyms when checking instances' types).
 They should be removed when that issue will be fully solved. -/
 
 variable {I} in


### PR DESCRIPTION
`LeviCivita` contains a workaround, annotated with a TODO comment that referred to Lean issue leanprover/lean4#9077. This change points the reference to leanprover/lean4#14949 instead, which was created to differentiate the two related but different phenomena.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
