### PR TITLE
[Merged by Bors] - feat: add IsNowhereDense.union

### DIFF
--- a/Mathlib/Topology/GDelta/Basic.lean
+++ b/Mathlib/Topology/GDelta/Basic.lean
@@ -209,6 +209,34 @@ lemma isNowhereDense_empty : IsNowhereDense (∅ : Set X) := by
 lemma IsNowhereDense.mono {s t : Set X} (ht : t ⊆ s) (hs : IsNowhereDense s) : IsNowhereDense t :=
   Set.eq_empty_of_subset_empty <| by grw [ht]; rw [hs]
 
+/-- The union of two nowhere dense sets is nowhere dense. -/
+protected lemma IsNowhereDense.union {s t : Set X} (hs : IsNowhereDense s)
+    (ht : IsNowhereDense t) : IsNowhereDense (s ∪ t) := by
+  -- `simp` will not unfold the `IsNowhereDense` definition, so restate `ht` as an equation
+  have ht' : interior (closure t) = ∅ := ht
+  rw [IsNowhereDense, closure_union]
+  have h1 : interior (closure s ∪ closure t) ⊆ closure s := by
+    simpa [ht'] using isClosed_closure.interior_union_left (s := closure s) (t := closure t)
+  exact Set.eq_empty_of_subset_empty (hs ▸ interior_maximal h1 isOpen_interior)
+
+/-- A union over a `Finset` of nowhere dense sets is nowhere dense. -/
+protected lemma IsNowhereDense.biUnion {u : Finset ι} {f : ι → Set X}
+    (hf : ∀ i ∈ u, IsNowhereDense (f i)) : IsNowhereDense (⋃ i ∈ u, f i) := by
+  classical
+  induction u using Finset.induction with
+  | empty => simp
+  | insert a u ha ih =>
+      rw [Finset.set_biUnion_insert]
+      exact (hf a (Finset.mem_insert_self a u)).union
+        (ih fun i hi => hf i (Finset.mem_insert_of_mem hi))
+
+/-- A finite union of nowhere dense sets is nowhere dense. -/
+protected lemma IsNowhereDense.iUnion [Finite ι] {f : ι → Set X}
+    (hf : ∀ i, IsNowhereDense (f i)) : IsNowhereDense (⋃ i, f i) := by
+  classical
+  cases nonempty_fintype ι
+  simpa using IsNowhereDense.biUnion (u := (Finset.univ : Finset ι)) fun i _ => hf i
+
 /-- A closed set is nowhere dense iff its interior is empty. -/
 lemma IsClosed.isNowhereDense_iff {s : Set X} (hs : IsClosed s) :
     IsNowhereDense s ↔ interior s = ∅ := by

--- a/Mathlib/Topology/GDelta/Basic.lean
+++ b/Mathlib/Topology/GDelta/Basic.lean
@@ -212,28 +212,24 @@ lemma IsNowhereDense.mono {s t : Set X} (ht : t ⊆ s) (hs : IsNowhereDense s) :
 /-- The union of two nowhere dense sets is nowhere dense. -/
 protected lemma IsNowhereDense.union {s t : Set X} (hs : IsNowhereDense s)
     (ht : IsNowhereDense t) : IsNowhereDense (s ∪ t) := by
-  -- `simp` will not unfold the `IsNowhereDense` definition, so restate `ht` as an equation
-  have ht' : interior (closure t) = ∅ := ht
-  rw [IsNowhereDense, closure_union]
+  simp only [IsNowhereDense, closure_union] at hs ht ⊢
   have h1 : interior (closure s ∪ closure t) ⊆ closure s := by
-    simpa [ht'] using isClosed_closure.interior_union_left (s := closure s) (t := closure t)
+    simpa [ht] using isClosed_closure.interior_union_left (s := closure s) (t := closure t)
   exact Set.eq_empty_of_subset_empty (hs ▸ interior_maximal h1 isOpen_interior)
 
 /-- A union over a `Finset` of nowhere dense sets is nowhere dense. -/
 protected lemma IsNowhereDense.biUnion {u : Finset ι} {f : ι → Set X}
     (hf : ∀ i ∈ u, IsNowhereDense (f i)) : IsNowhereDense (⋃ i ∈ u, f i) := by
-  classical
-  induction u using Finset.induction with
+  induction u using Finset.cons_induction with
   | empty => simp
-  | insert a u ha ih =>
-      rw [Finset.set_biUnion_insert]
-      exact (hf a (Finset.mem_insert_self a u)).union
-        (ih fun i hi => hf i (Finset.mem_insert_of_mem hi))
+  | cons a u ha ih =>
+      rw [← Finset.set_biUnion_coe, Finset.coe_cons, Set.biUnion_insert, Finset.set_biUnion_coe]
+      exact (hf a (Finset.mem_cons_self a u)).union
+        (ih fun i hi => hf i (Finset.mem_cons_of_mem hi))
 
 /-- A finite union of nowhere dense sets is nowhere dense. -/
 protected lemma IsNowhereDense.iUnion [Finite ι] {f : ι → Set X}
     (hf : ∀ i, IsNowhereDense (f i)) : IsNowhereDense (⋃ i, f i) := by
-  classical
   cases nonempty_fintype ι
   simpa using IsNowhereDense.biUnion (u := (Finset.univ : Finset ι)) fun i _ => hf i
 


### PR DESCRIPTION
Adding `IsNowhereDense.union`, `IsNowhereDense.biUnion` and `IsNowhereDense.iUnion`. Filling the gap with `IsMeagre`. Finiteness is sharp, since the union of infinite nowhere dense sets can be strictly bigger (example: the union of all fractions). No new imports.

---
  - The mathematical argument is Anatole Dedecker's from Zulip; the fractions observation is Aaron Liu's.
  - Zulip link: https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/IsNowhereDense.20union.20lemma/with/619131446.                                                          
  - Strong help from Claude Opus 5 to find the (hopefully) correct solution.                                                                            
  - I'll drop biUnion/iUnion if only the binary version is wanted.                        

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
