### PR TITLE
[Merged by Bors] - feat(NumberTheory/NumberField/House): house is multiplicative on powers

### DIFF
--- a/Mathlib/NumberTheory/NumberField/House.lean
+++ b/Mathlib/NumberTheory/NumberField/House.lean
@@ -61,6 +61,17 @@ theorem house_add_le (α β : K) : house (α + β) ≤ house α + house β := by
 theorem house_pow_le (α : K) (i : ℕ) : house (α ^ i) ≤ house α ^ i := by
   simpa only [house, map_pow] using norm_pow_le ((canonicalEmbedding K) α) i
 
+theorem house_pow (α : K) (i : ℕ) : house (α ^ i) = house α ^ i := by
+  have hmono : Monotone (fun x : NNReal => x ^ i) := fun a b h => pow_le_pow_left' h i
+  rw [house_eq_sup', house_eq_sup']
+  have h : (fun φ : K →+* ℂ ↦ ‖φ (α ^ i)‖₊)
+      = (fun x : NNReal ↦ x ^ i) ∘ (fun φ : K →+* ℂ ↦ ‖φ α‖₊) := by
+    funext φ
+    simp [map_pow, nnnorm_pow]
+  rw [h, ← Finset.apply_sup'_eq_sup'_comp _ _ fun x y ↦ hmono.map_max]
+  push_cast
+  rfl
+
 theorem house_nat_mul (α : K) (c : ℕ) : house (c * α) = c * house α := by
   rw [house_eq_sup', house_eq_sup', Finset.sup'_eq_sup, Finset.sup'_eq_sup]
   norm_cast

--- a/Mathlib/NumberTheory/NumberField/House.lean
+++ b/Mathlib/NumberTheory/NumberField/House.lean
@@ -59,15 +59,10 @@ theorem house_add_le (α β : K) : house (α + β) ≤ house α + house β := by
   simp only [house, map_add]; apply norm_add_le
 
 theorem house_pow (α : K) (i : ℕ) : house (α ^ i) = house α ^ i := by
-  have hmono : Monotone (fun x : NNReal => x ^ i) := fun a b h => pow_le_pow_left' h i
-  rw [house_eq_sup', house_eq_sup']
-  have h : (fun φ : K →+* ℂ ↦ ‖φ (α ^ i)‖₊)
-      = (fun x : NNReal ↦ x ^ i) ∘ (fun φ : K →+* ℂ ↦ ‖φ α‖₊) := by
-    funext φ
-    simp [map_pow, nnnorm_pow]
-  rw [h, ← Finset.apply_sup'_eq_sup'_comp _ _ fun x y ↦ hmono.map_max]
-  push_cast
-  rfl
+  simp_rw [house_eq_sup', map_pow, nnnorm_pow]
+  rw [← Function.comp_def (· ^ i),
+    ← Finset.apply_sup'_eq_sup'_comp _ _ fun _ _ ↦ (pow_left_mono (M := NNReal) i).map_max,
+    NNReal.coe_pow]
 
 @[deprecated house_pow (since := "2026-08-28")]
 theorem house_pow_le (α : K) (i : ℕ) : house (α ^ i) ≤ house α ^ i := (house_pow α i).le

--- a/Mathlib/NumberTheory/NumberField/House.lean
+++ b/Mathlib/NumberTheory/NumberField/House.lean
@@ -58,9 +58,6 @@ lemma house_prod_le (s : Finset K) : house (∏ x ∈ s, x) ≤ ∏ x ∈ s, hou
 theorem house_add_le (α β : K) : house (α + β) ≤ house α + house β := by
   simp only [house, map_add]; apply norm_add_le
 
-theorem house_pow_le (α : K) (i : ℕ) : house (α ^ i) ≤ house α ^ i := by
-  simpa only [house, map_pow] using norm_pow_le ((canonicalEmbedding K) α) i
-
 theorem house_pow (α : K) (i : ℕ) : house (α ^ i) = house α ^ i := by
   have hmono : Monotone (fun x : NNReal => x ^ i) := fun a b h => pow_le_pow_left' h i
   rw [house_eq_sup', house_eq_sup']
@@ -71,6 +68,9 @@ theorem house_pow (α : K) (i : ℕ) : house (α ^ i) = house α ^ i := by
   rw [h, ← Finset.apply_sup'_eq_sup'_comp _ _ fun x y ↦ hmono.map_max]
   push_cast
   rfl
+
+@[deprecated house_pow (since := "2026-08-28")]
+theorem house_pow_le (α : K) (i : ℕ) : house (α ^ i) ≤ house α ^ i := (house_pow α i).le
 
 theorem house_nat_mul (α : K) (c : ℕ) : house (c * α) = c * house α := by
   rw [house_eq_sup', house_eq_sup', Finset.sup'_eq_sup, Finset.sup'_eq_sup]


### PR DESCRIPTION
`house_pow_le` gives only `house (α ^ i) ≤ house α ^ i`. The equality holds: `house` is the maximum of `‖φ α‖` over the embeddings `φ : K →+* ℂ`, and `x ↦ x ^ i` is monotone on `ℝ≥0`, so the power commutes with the maximum.

I needed the equality rather than the bound in a descent argument, where a house bound on `α ^ k` has to transfer back to `α`.

The proof follows the existing `house_nat_mul` in the same file: rewrite both sides with `house_eq_sup'`, then push the monotone map through the `Finset.sup'`.

---

AI usage, per the contribution guidelines: I used Claude Code (Claude Opus 5) to find and write this proof, and it also drafted this description. I have reviewed the proof, understand the argument, and can justify the design choices without it.
