### PR TITLE
[Merged by Bors] - feat(Algebra/Category/ModuleCat): add abbrevs for Presheaves of Modules over commutative rings

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -189,6 +189,7 @@ public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Free
 public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Generator
 public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Limits
 public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Monoidal
+public import Mathlib.Algebra.Category.ModuleCat.Presheaf.OfCommRing
 public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Pullback
 public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Pushforward
 public import Mathlib.Algebra.Category.ModuleCat.Presheaf.PushforwardZeroMonoidal

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Monoidal.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Monoidal.lean
@@ -5,7 +5,7 @@ Authors: Dagur Asgeirsson, Jack McKoen, Joël Riou
 -/
 module
 
-public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Colimits
+public import Mathlib.Algebra.Category.ModuleCat.Presheaf.OfCommRing
 public import Mathlib.Algebra.Category.ModuleCat.Monoidal.Closed
 
 /-!
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Category.ModuleCat.Monoidal.Closed
 
 Given a presheaf of commutative rings `R : Cᵒᵖ ⥤ CommRingCat`, we construct
 the monoidal category structure on the category of presheaves of modules
-`PresheafOfModules (R ⋙ forget₂ _ _)`. The tensor product `M₁ ⊗ M₂` is defined
+`PresheafOfModulesOfCommRing R`. The tensor product `M₁ ⊗ M₂` is defined
 as the presheaf of modules which sends `X : Cᵒᵖ` to `M₁.obj X ⊗ M₂.obj X`.
 
 ## Notes
@@ -31,14 +31,11 @@ universe v u v₁ u₁
 
 variable {C : Type*} [Category* C] {R : Cᵒᵖ ⥤ CommRingCat.{u}}
 
-instance (X : Cᵒᵖ) : CommRing ((R ⋙ forget₂ _ RingCat).obj X) :=
-  inferInstanceAs (CommRing (R.obj X))
-
-namespace PresheafOfModules
+namespace PresheafOfModulesOfCommRing
 
 namespace Monoidal
 
-variable (M₁ M₂ M₃ M₄ : PresheafOfModules.{u} (R ⋙ forget₂ _ _))
+variable (M₁ M₂ M₃ M₄ : PresheafOfModulesOfCommRing.{u} R)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Auxiliary definition for `tensorObj`. -/
@@ -60,18 +57,17 @@ set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 /-- The tensor product of two presheaves of modules. -/
 @[simps obj]
-noncomputable def tensorObj : PresheafOfModules (R ⋙ forget₂ _ _) where
-  obj X := M₁.obj X ⊗ M₂.obj X
-  map f := tensorObjMap M₁ M₂ f
-  map_id X := ModuleCat.MonoidalCategory.tensor_ext (by
-    intro m₁ m₂
-    dsimp [tensorObjMap]
-    simp
-    rfl) -- `ModuleCat.restrictScalarsId'App_inv_apply` doesn't get picked up due to type mismatch
-  map_comp f g := ModuleCat.MonoidalCategory.tensor_ext (by
-    intro m₁ m₂
-    dsimp [tensorObjMap]
-    simp +instances)
+noncomputable def tensorObj : PresheafOfModulesOfCommRing R :=
+  mk (fun X ↦ M₁.obj X ⊗ M₂.obj X)
+    (fun f ↦ tensorObjMap M₁ M₂ f)
+    (fun X ↦ ModuleCat.MonoidalCategory.tensor_ext (by
+      intro m₁ m₂
+      dsimp [tensorObjMap]
+      simp))
+    (fun f g ↦ ModuleCat.MonoidalCategory.tensor_ext (by
+      intro m₁ m₂
+      dsimp [tensorObjMap]
+      simp +instances))
 
 variable {M₁ M₂ M₃ M₄}
 
@@ -86,23 +82,23 @@ set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 /-- The tensor product of two morphisms of presheaves of modules. -/
 @[simps]
-noncomputable def tensorHom (f : M₁ ⟶ M₂) (g : M₃ ⟶ M₄) : tensorObj M₁ M₃ ⟶ tensorObj M₂ M₄ where
-  app X := f.app X ⊗ₘ g.app X
-  naturality {X Y} φ := ModuleCat.MonoidalCategory.tensor_ext (fun m₁ m₃ ↦ by
-    dsimp
-    rw [tensorObj_map_tmul]
-    -- Need `erw` because of the type mismatch in `map` and the tensor product.
-    erw [ModuleCat.MonoidalCategory.tensorHom_tmul, tensorObj_map_tmul]
-    rw [naturality_apply, naturality_apply]
-    simp)
+noncomputable def tensorHom (f : M₁ ⟶ M₂) (g : M₃ ⟶ M₄) :
+    tensorObj M₁ M₃ ⟶ tensorObj M₂ M₄ :=
+  mkHom (fun X ↦ f.app X ⊗ₘ g.app X)
+    (fun φ ↦ ModuleCat.MonoidalCategory.tensor_ext (fun m₁ m₃ ↦ by
+      dsimp
+      rw [tensorObj_map_tmul]
+      -- Need `erw` because of the type mismatch in `map` and the tensor product.
+      erw [ModuleCat.MonoidalCategory.tensorHom_tmul, tensorObj_map_tmul]
+      erw [PresheafOfModules.naturality_apply, PresheafOfModules.naturality_apply]
+      simp))
 
 end Monoidal
 
 open Monoidal
 
-open ModuleCat.MonoidalCategory in
 noncomputable instance monoidalCategoryStruct :
-    MonoidalCategoryStruct (PresheafOfModules.{u} (R ⋙ forget₂ _ _)) where
+    MonoidalCategoryStruct (PresheafOfModulesOfCommRing.{u} R) where
   tensorObj := tensorObj
   whiskerLeft _ _ _ g := tensorHom (𝟙 _) g
   whiskerRight f _ := tensorHom f (𝟙 _)
@@ -113,16 +109,18 @@ noncomputable instance monoidalCategoryStruct :
   leftUnitor M := Iso.symm (isoMk (fun _ ↦ (λ_ _).symm) (fun X Y f ↦ by
     ext m
     dsimp [CommRingCat.forgetToRingCat_obj]
-    erw [leftUnitor_inv_apply, leftUnitor_inv_apply, tensorObj_map_tmul, (R.map f).hom.map_one]
+    erw [ModuleCat.MonoidalCategory.leftUnitor_inv_apply,
+      ModuleCat.MonoidalCategory.leftUnitor_inv_apply, tensorObj_map_tmul, (R.map f).hom.map_one]
     rfl))
   rightUnitor M := Iso.symm (isoMk (fun _ ↦ (ρ_ _).symm) (fun X Y f ↦ by
     ext m
     dsimp [CommRingCat.forgetToRingCat_obj]
-    erw [rightUnitor_inv_apply, rightUnitor_inv_apply, tensorObj_map_tmul, (R.map f).hom.map_one]
+    erw [ModuleCat.MonoidalCategory.rightUnitor_inv_apply,
+      ModuleCat.MonoidalCategory.rightUnitor_inv_apply, tensorObj_map_tmul, (R.map f).hom.map_one]
     rfl))
 
 noncomputable instance monoidalCategory :
-    MonoidalCategory (PresheafOfModules.{u} (R ⋙ forget₂ _ _)) where
+    MonoidalCategory (PresheafOfModulesOfCommRing.{u} R) where
   tensorHom_def _ _ := by ext1; apply tensorHom_def
   id_tensorHom_id _ _ := by ext1; apply id_tensorHom_id
   tensorHom_comp_tensorHom _ _ _ _ := by ext1; apply tensorHom_comp_tensorHom
@@ -141,7 +139,7 @@ noncomputable instance monoidalCategory :
 open BraidedCategory
 
 noncomputable instance symmetricCategory :
-    SymmetricCategory (PresheafOfModules.{u} (R ⋙ forget₂ _ _)) where
+    SymmetricCategory (PresheafOfModulesOfCommRing.{u} R) where
   braiding M₁ M₂ :=
     isoMk (fun X ↦ braiding (C := ModuleCat (R.obj X)) (M₁.obj X) (M₂.obj X))
       (fun _ _ f ↦ ModuleCat.MonoidalCategory.tensor_ext (fun _ _ ↦ rfl))
@@ -163,7 +161,7 @@ noncomputable instance symmetricCategory :
 
 section
 
-variable (M₁ M₂ M₃ M₄ : PresheafOfModules.{u} (R ⋙ forget₂ _ _))
+variable (M₁ M₂ M₃ M₄ : PresheafOfModulesOfCommRing.{u} R)
 
 lemma tensorObj_obj (X : Cᵒᵖ) :
     (M₁ ⊗ M₂).obj X =
@@ -179,7 +177,8 @@ lemma whiskerLeft_app (f : M₂ ⟶ M₃) (X : Cᵒᵖ) :
 
 variable {M₁ M₂} in
 @[simp]
-lemma whiskerRight_app (f : M₁ ⟶ M₂) (M₃ : PresheafOfModules.{u} (R ⋙ forget₂ _ _)) (X : Cᵒᵖ) :
+lemma whiskerRight_app (f : M₁ ⟶ M₂) (M₃ : PresheafOfModulesOfCommRing.{u} R)
+    (X : Cᵒᵖ) :
     dsimp% (f ▷ M₃).app X = whiskerRight (C := ModuleCat (R.obj X)) (f.app X) (M₃.obj X) := rfl
 
 variable {M₁ M₂ M₃ M₄} in
@@ -233,14 +232,14 @@ lemma braiding_inv_app (X : Cᵒᵖ) :
 
 end
 
-instance (F : PresheafOfModules.{u} (R ⋙ forget₂ _ _)) :
+instance (F : PresheafOfModulesOfCommRing.{u} R) :
     PreservesColimitsOfSize.{u, u} (tensorLeft F) where
-  preservesColimitsOfShape := ⟨⟨fun hc ↦ ⟨evaluationJointlyReflectsColimits _ _
+  preservesColimitsOfShape := ⟨⟨fun hc ↦ ⟨PresheafOfModules.evaluationJointlyReflectsColimits _ _
       (fun X ↦ isColimitOfPreserves (tensorLeft (show ModuleCat (R.obj X) from F.obj X))
-        (isColimitOfPreserves (evaluation _ X) hc))⟩⟩⟩
+        (isColimitOfPreserves (PresheafOfModules.evaluation _ X) hc))⟩⟩⟩
 
-instance (F : PresheafOfModules.{u} (R ⋙ forget₂ _ _)) :
+instance (F : PresheafOfModulesOfCommRing.{u} R) :
     PreservesColimitsOfSize.{u, u} (tensorRight F) :=
   preservesColimits_of_natIso (tensorLeftIsoTensorRight F)
 
-end PresheafOfModules
+end PresheafOfModulesOfCommRing

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Monoidal.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Monoidal.lean
@@ -5,7 +5,7 @@ Authors: Dagur Asgeirsson, Jack McKoen, Joël Riou
 -/
 module
 
-public import Mathlib.Algebra.Category.ModuleCat.Presheaf.OfCommRing
+public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Colimits
 public import Mathlib.Algebra.Category.ModuleCat.Monoidal.Closed
 
 /-!
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Category.ModuleCat.Monoidal.Closed
 
 Given a presheaf of commutative rings `R : Cᵒᵖ ⥤ CommRingCat`, we construct
 the monoidal category structure on the category of presheaves of modules
-`PresheafOfModulesOfCommRing R`. The tensor product `M₁ ⊗ M₂` is defined
+`PresheafOfModules (R ⋙ forget₂ _ _)`. The tensor product `M₁ ⊗ M₂` is defined
 as the presheaf of modules which sends `X : Cᵒᵖ` to `M₁.obj X ⊗ M₂.obj X`.
 
 ## Notes
@@ -31,11 +31,14 @@ universe v u v₁ u₁
 
 variable {C : Type*} [Category* C] {R : Cᵒᵖ ⥤ CommRingCat.{u}}
 
-namespace PresheafOfModulesOfCommRing
+instance (X : Cᵒᵖ) : CommRing ((R ⋙ forget₂ _ RingCat).obj X) :=
+  inferInstanceAs (CommRing (R.obj X))
+
+namespace PresheafOfModules
 
 namespace Monoidal
 
-variable (M₁ M₂ M₃ M₄ : PresheafOfModulesOfCommRing.{u} R)
+variable (M₁ M₂ M₃ M₄ : PresheafOfModules.{u} (R ⋙ forget₂ _ _))
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Auxiliary definition for `tensorObj`. -/
@@ -44,29 +47,31 @@ noncomputable def tensorObjMap {X Y : Cᵒᵖ} (f : X ⟶ Y) : M₁.obj X ⊗ M�
   ModuleCat.MonoidalCategory.tensorLift (fun m₁ m₂ ↦ M₁.map f m₁ ⊗ₜ M₂.map f m₂)
     (by
       intro m₁ m₁' m₂
-      dsimp
+      dsimp +instances
       rw [map_add, TensorProduct.add_tmul])
     (by intro a m₁ m₂; dsimp; erw [M₁.map_smul]; rfl)
     (by
       intro m₁ m₂ m₂'
-      dsimp
+      dsimp +instances
       rw [map_add, TensorProduct.tmul_add])
     (by intro a m₁ m₂; dsimp; erw [M₂.map_smul, TensorProduct.tmul_smul (r := R.map f a)]; rfl)
 
+set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 /-- The tensor product of two presheaves of modules. -/
 @[simps obj]
-noncomputable def tensorObj : PresheafOfModulesOfCommRing R :=
-  mk (fun X ↦ M₁.obj X ⊗ M₂.obj X)
-    (fun f ↦ tensorObjMap M₁ M₂ f)
-    (fun X ↦ ModuleCat.MonoidalCategory.tensor_ext (by
-      intro m₁ m₂
-      dsimp [tensorObjMap]
-      simp))
-    (fun f g ↦ ModuleCat.MonoidalCategory.tensor_ext (by
-      intro m₁ m₂
-      dsimp [tensorObjMap]
-      simp +instances))
+noncomputable def tensorObj : PresheafOfModules (R ⋙ forget₂ _ _) where
+  obj X := M₁.obj X ⊗ M₂.obj X
+  map f := tensorObjMap M₁ M₂ f
+  map_id X := ModuleCat.MonoidalCategory.tensor_ext (by
+    intro m₁ m₂
+    dsimp [tensorObjMap]
+    simp
+    rfl) -- `ModuleCat.restrictScalarsId'App_inv_apply` doesn't get picked up due to type mismatch
+  map_comp f g := ModuleCat.MonoidalCategory.tensor_ext (by
+    intro m₁ m₂
+    dsimp [tensorObjMap]
+    simp +instances)
 
 variable {M₁ M₂ M₃ M₄}
 
@@ -81,23 +86,23 @@ set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 /-- The tensor product of two morphisms of presheaves of modules. -/
 @[simps]
-noncomputable def tensorHom (f : M₁ ⟶ M₂) (g : M₃ ⟶ M₄) :
-    tensorObj M₁ M₃ ⟶ tensorObj M₂ M₄ :=
-  mkHom (fun X ↦ f.app X ⊗ₘ g.app X)
-    (fun φ ↦ ModuleCat.MonoidalCategory.tensor_ext (fun m₁ m₃ ↦ by
-      dsimp
-      rw [tensorObj_map_tmul]
-      -- Need `erw` because of the type mismatch in `map` and the tensor product.
-      erw [ModuleCat.MonoidalCategory.tensorHom_tmul, tensorObj_map_tmul]
-      erw [PresheafOfModules.naturality_apply, PresheafOfModules.naturality_apply]
-      simp))
+noncomputable def tensorHom (f : M₁ ⟶ M₂) (g : M₃ ⟶ M₄) : tensorObj M₁ M₃ ⟶ tensorObj M₂ M₄ where
+  app X := f.app X ⊗ₘ g.app X
+  naturality {X Y} φ := ModuleCat.MonoidalCategory.tensor_ext (fun m₁ m₃ ↦ by
+    dsimp
+    rw [tensorObj_map_tmul]
+    -- Need `erw` because of the type mismatch in `map` and the tensor product.
+    erw [ModuleCat.MonoidalCategory.tensorHom_tmul, tensorObj_map_tmul]
+    rw [naturality_apply, naturality_apply]
+    simp)
 
 end Monoidal
 
 open Monoidal
 
+open ModuleCat.MonoidalCategory in
 noncomputable instance monoidalCategoryStruct :
-    MonoidalCategoryStruct (PresheafOfModulesOfCommRing.{u} R) where
+    MonoidalCategoryStruct (PresheafOfModules.{u} (R ⋙ forget₂ _ _)) where
   tensorObj := tensorObj
   whiskerLeft _ _ _ g := tensorHom (𝟙 _) g
   whiskerRight f _ := tensorHom f (𝟙 _)
@@ -108,18 +113,16 @@ noncomputable instance monoidalCategoryStruct :
   leftUnitor M := Iso.symm (isoMk (fun _ ↦ (λ_ _).symm) (fun X Y f ↦ by
     ext m
     dsimp [CommRingCat.forgetToRingCat_obj]
-    erw [ModuleCat.MonoidalCategory.leftUnitor_inv_apply,
-      ModuleCat.MonoidalCategory.leftUnitor_inv_apply, tensorObj_map_tmul, (R.map f).hom.map_one]
+    erw [leftUnitor_inv_apply, leftUnitor_inv_apply, tensorObj_map_tmul, (R.map f).hom.map_one]
     rfl))
   rightUnitor M := Iso.symm (isoMk (fun _ ↦ (ρ_ _).symm) (fun X Y f ↦ by
     ext m
     dsimp [CommRingCat.forgetToRingCat_obj]
-    erw [ModuleCat.MonoidalCategory.rightUnitor_inv_apply,
-      ModuleCat.MonoidalCategory.rightUnitor_inv_apply, tensorObj_map_tmul, (R.map f).hom.map_one]
+    erw [rightUnitor_inv_apply, rightUnitor_inv_apply, tensorObj_map_tmul, (R.map f).hom.map_one]
     rfl))
 
 noncomputable instance monoidalCategory :
-    MonoidalCategory (PresheafOfModulesOfCommRing.{u} R) where
+    MonoidalCategory (PresheafOfModules.{u} (R ⋙ forget₂ _ _)) where
   tensorHom_def _ _ := by ext1; apply tensorHom_def
   id_tensorHom_id _ _ := by ext1; apply id_tensorHom_id
   tensorHom_comp_tensorHom _ _ _ _ := by ext1; apply tensorHom_comp_tensorHom
@@ -138,7 +141,7 @@ noncomputable instance monoidalCategory :
 open BraidedCategory
 
 noncomputable instance symmetricCategory :
-    SymmetricCategory (PresheafOfModulesOfCommRing.{u} R) where
+    SymmetricCategory (PresheafOfModules.{u} (R ⋙ forget₂ _ _)) where
   braiding M₁ M₂ :=
     isoMk (fun X ↦ braiding (C := ModuleCat (R.obj X)) (M₁.obj X) (M₂.obj X))
       (fun _ _ f ↦ ModuleCat.MonoidalCategory.tensor_ext (fun _ _ ↦ rfl))
@@ -160,7 +163,7 @@ noncomputable instance symmetricCategory :
 
 section
 
-variable (M₁ M₂ M₃ M₄ : PresheafOfModulesOfCommRing.{u} R)
+variable (M₁ M₂ M₃ M₄ : PresheafOfModules.{u} (R ⋙ forget₂ _ _))
 
 lemma tensorObj_obj (X : Cᵒᵖ) :
     (M₁ ⊗ M₂).obj X =
@@ -176,8 +179,7 @@ lemma whiskerLeft_app (f : M₂ ⟶ M₃) (X : Cᵒᵖ) :
 
 variable {M₁ M₂} in
 @[simp]
-lemma whiskerRight_app (f : M₁ ⟶ M₂) (M₃ : PresheafOfModulesOfCommRing.{u} R)
-    (X : Cᵒᵖ) :
+lemma whiskerRight_app (f : M₁ ⟶ M₂) (M₃ : PresheafOfModules.{u} (R ⋙ forget₂ _ _)) (X : Cᵒᵖ) :
     dsimp% (f ▷ M₃).app X = whiskerRight (C := ModuleCat (R.obj X)) (f.app X) (M₃.obj X) := rfl
 
 variable {M₁ M₂ M₃ M₄} in
@@ -231,14 +233,14 @@ lemma braiding_inv_app (X : Cᵒᵖ) :
 
 end
 
-instance (F : PresheafOfModulesOfCommRing.{u} R) :
+instance (F : PresheafOfModules.{u} (R ⋙ forget₂ _ _)) :
     PreservesColimitsOfSize.{u, u} (tensorLeft F) where
-  preservesColimitsOfShape := ⟨⟨fun hc ↦ ⟨PresheafOfModules.evaluationJointlyReflectsColimits _ _
+  preservesColimitsOfShape := ⟨⟨fun hc ↦ ⟨evaluationJointlyReflectsColimits _ _
       (fun X ↦ isColimitOfPreserves (tensorLeft (show ModuleCat (R.obj X) from F.obj X))
-        (isColimitOfPreserves (PresheafOfModules.evaluation _ X) hc))⟩⟩⟩
+        (isColimitOfPreserves (evaluation _ X) hc))⟩⟩⟩
 
-instance (F : PresheafOfModulesOfCommRing.{u} R) :
+instance (F : PresheafOfModules.{u} (R ⋙ forget₂ _ _)) :
     PreservesColimitsOfSize.{u, u} (tensorRight F) :=
   preservesColimits_of_natIso (tensorLeftIsoTensorRight F)
 
-end PresheafOfModulesOfCommRing
+end PresheafOfModules

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Monoidal.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Monoidal.lean
@@ -44,16 +44,15 @@ noncomputable def tensorObjMap {X Y : Cᵒᵖ} (f : X ⟶ Y) : M₁.obj X ⊗ M�
   ModuleCat.MonoidalCategory.tensorLift (fun m₁ m₂ ↦ M₁.map f m₁ ⊗ₜ M₂.map f m₂)
     (by
       intro m₁ m₁' m₂
-      dsimp +instances
+      dsimp
       rw [map_add, TensorProduct.add_tmul])
     (by intro a m₁ m₂; dsimp; erw [M₁.map_smul]; rfl)
     (by
       intro m₁ m₂ m₂'
-      dsimp +instances
+      dsimp
       rw [map_add, TensorProduct.tmul_add])
     (by intro a m₁ m₂; dsimp; erw [M₂.map_smul, TensorProduct.tmul_smul (r := R.map f a)]; rfl)
 
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 /-- The tensor product of two presheaves of modules. -/
 @[simps obj]

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
@@ -1,0 +1,321 @@
+/-
+Copyright (c) 2026 Brian Nugent. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Brian Nugent
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Presheaf.ColimitFunctor
+public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Sheafification
+public import Mathlib.Algebra.Category.ModuleCat.Sheaf.PullbackContinuous
+public import Mathlib.Algebra.Category.Ring.Colimits
+public import Mathlib.CategoryTheory.Sites.Point.Basic
+
+/-!
+# Modules over presheaves and sheaves of commutative rings
+
+This file provides short names for categories and functors obtained from a presheaf or
+sheaf of commutative rings by forgetting to rings. In particular, these names avoid
+repeatedly writing the relevant forgetful functor or `sheafCompose`.
+-/
+
+@[expose] public section
+
+universe v v₁ v₂ u₁ u₂ u
+
+open CategoryTheory Functor Limits
+
+/-! ## Categories -/
+
+/-- The category of presheaves of modules over a presheaf of commutative rings. -/
+abbrev PresheafOfModulesOfCommRing {C : Type u₁} [Category.{v₁} C]
+    (R : Cᵒᵖ ⥤ CommRingCat.{u}) :=
+  PresheafOfModules.{v} (R ⋙ forget₂ _ _)
+
+/-- The category of sheaves of modules over a sheaf of commutative rings. -/
+abbrev SheafOfModulesOfCommRing {C : Type u₁} [Category.{v₁} C]
+    {J : GrothendieckTopology C} (R : Sheaf J CommRingCat.{u})
+    [J.HasSheafCompose (forget₂ CommRingCat RingCat)] :=
+  SheafOfModules.{v} ((sheafCompose J (forget₂ _ _)).obj R)
+
+/-! ## Presheaves of modules -/
+
+namespace PresheafOfModulesOfCommRing
+
+section ChangeOfRings
+
+variable {C : Type u₁} [Category.{v₁} C]
+  {R S : Cᵒᵖ ⥤ CommRingCat.{u}} (φ : R ⟶ S)
+
+/-- Restriction of scalars along a morphism of presheaves of commutative rings. -/
+noncomputable abbrev restrictScalars :
+    PresheafOfModulesOfCommRing.{v} S ⥤ PresheafOfModulesOfCommRing.{v} R :=
+  PresheafOfModules.restrictScalars (whiskerRight φ (forget₂ _ _))
+
+end ChangeOfRings
+
+section Pushforward
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+
+/-- The pushforward functor along `F` for modules over a presheaf of commutative rings. -/
+abbrev pushforward₀ (F : C ⥤ D) (R : Dᵒᵖ ⥤ CommRingCat.{u}) :
+    PresheafOfModulesOfCommRing.{v} R ⥤
+      PresheafOfModulesOfCommRing.{v} (F.op ⋙ R) :=
+  PresheafOfModules.pushforward₀ F (R ⋙ forget₂ _ _)
+
+variable {F : C ⥤ D} {R : Dᵒᵖ ⥤ CommRingCat.{u}}
+  {S : Cᵒᵖ ⥤ CommRingCat.{u}} (φ : S ⟶ F.op ⋙ R)
+
+/-- The pushforward functor induced by a morphism of presheaves of commutative rings. -/
+noncomputable abbrev pushforward :
+    PresheafOfModulesOfCommRing.{v} R ⥤ PresheafOfModulesOfCommRing.{v} S :=
+  PresheafOfModules.pushforward (whiskerRight φ (forget₂ _ _))
+
+/-- The pullback functor induced by a morphism of presheaves of commutative rings. -/
+noncomputable abbrev pullback [(pushforward.{v} φ).IsRightAdjoint] :
+    PresheafOfModulesOfCommRing.{v} S ⥤ PresheafOfModulesOfCommRing.{v} R :=
+  PresheafOfModules.pullback (whiskerRight φ (forget₂ _ _))
+
+/-- The adjunction between pullback and pushforward for modules over presheaves of
+commutative rings. -/
+noncomputable abbrev pullbackPushforwardAdjunction
+    [(pushforward.{v} φ).IsRightAdjoint] :
+    pullback.{v} φ ⊣ pushforward.{v} φ :=
+  Adjunction.ofIsRightAdjoint (pushforward φ)
+
+end Pushforward
+
+section Colimit
+
+attribute [local instance] hasColimitsOfShape_of_finallySmall
+  IsFiltered.isSifted FinallySmall.preservesColimitsOfShape_of_isFiltered
+
+variable {C : Type u₁} [Category.{v₁} C] {R : Cᵒᵖ ⥤ CommRingCat.{u}}
+
+/-- The constant-presheaf functor associated to a cocone of commutative rings. -/
+noncomputable abbrev constFunctor (cR : Cocone R) :
+    ModuleCat.{u} cR.pt ⥤ PresheafOfModulesOfCommRing.{u} R :=
+  PresheafOfModules.constFunctor ((forget₂ _ _).mapCocone cR)
+
+variable [LocallySmall.{u} C] [IsCofiltered C] [InitiallySmall.{u} C]
+  {cR : Cocone R} (hcR : IsColimit cR)
+
+/-- The colimit-module functor associated to a colimit cocone of commutative rings. -/
+noncomputable abbrev colimitFunctor :
+    PresheafOfModulesOfCommRing.{u} R ⥤ ModuleCat.{u} cR.pt :=
+  PresheafOfModules.colimitFunctor
+    (isColimitOfPreserves (forget₂ _ _) hcR)
+
+/-- The adjunction between the colimit-module and constant-presheaf functors. -/
+noncomputable abbrev colimitAdjunction :
+    colimitFunctor hcR ⊣ constFunctor cR :=
+  PresheafOfModules.colimitAdjunction
+    (isColimitOfPreserves (forget₂ _ _) hcR)
+
+/-- The coprojection `P.obj U →+ (colimitFunctor hcR).obj P` into the colimit module. -/
+noncomputable def ιColimitFunctor
+    (P : PresheafOfModulesOfCommRing.{u} R) (U : Cᵒᵖ) :
+    P.obj U →+ (colimitFunctor hcR).obj P :=
+  (colimit.ι P.presheaf U).hom
+
+/-- The coprojections into the colimit module commute with restriction maps. -/
+@[simp]
+lemma ιColimitFunctor_map
+    (P : PresheafOfModulesOfCommRing.{u} R) {V U : Cᵒᵖ}
+    (f : V ⟶ U) (x : P.obj V) :
+    ιColimitFunctor hcR P U (P.map f x) = ιColimitFunctor hcR P V x :=
+  ConcreteCategory.congr_hom (colimit.w P.presheaf f) x
+
+/-- The colimit cocone on the underlying presheaf of additive commutative groups. -/
+noncomputable def coconeColimitFunctor
+    (P : PresheafOfModulesOfCommRing.{u} R) : Cocone P.presheaf where
+  pt := (forget₂ _ AddCommGrpCat).obj ((colimitFunctor hcR).obj P)
+  ι.app U := AddCommGrpCat.ofHom (ιColimitFunctor hcR P U)
+  ι.naturality V U f := by
+    ext x
+    exact ιColimitFunctor_map hcR P f x
+
+/-- The cocone `coconeColimitFunctor hcR P` is a colimit cocone. -/
+noncomputable def isColimitCoconeColimitFunctor
+    (P : PresheafOfModulesOfCommRing.{u} R) :
+    IsColimit (coconeColimitFunctor hcR P) :=
+  colimit.isColimit P.presheaf
+
+end Colimit
+
+section Fiber
+
+attribute [local instance] hasColimitsOfShape_of_finallySmall
+  IsFiltered.isSifted FinallySmall.preservesColimitsOfShape_of_isFiltered
+
+variable {C : Type u₁} [Category.{v₁} C] [LocallySmall.{u} C]
+  {J : GrothendieckTopology C} (Φ : GrothendieckTopology.Point.{u} J)
+
+/-- The fiber functor at a point for modules over a presheaf of commutative rings. -/
+noncomputable def fiber (R : Cᵒᵖ ⥤ CommRingCat.{u}) :
+    PresheafOfModulesOfCommRing.{u} R ⥤
+      ModuleCat.{u} (Φ.presheafFiber.obj R :) :=
+  pushforward₀ (CategoryOfElements.π Φ.fiber) R ⋙
+    colimitFunctor
+      (colimit.isColimit ((CategoryOfElements.π Φ.fiber).op ⋙ R))
+
+end Fiber
+
+end PresheafOfModulesOfCommRing
+
+/-! ## Sheaves of modules -/
+
+namespace SheafOfModulesOfCommRing
+
+section Basic
+
+variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
+  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
+
+/-- The underlying presheaf of modules of a sheaf of modules. -/
+abbrev val {R : Sheaf J CommRingCat.{u}} (F : SheafOfModulesOfCommRing.{v} R) :
+    PresheafOfModulesOfCommRing.{v} R.obj :=
+  SheafOfModules.val F
+
+/-- The functor forgetting the sheaf condition on a sheaf of modules. -/
+abbrev forget (R : Sheaf J CommRingCat.{u}) :
+    SheafOfModulesOfCommRing.{v} R ⥤ PresheafOfModulesOfCommRing.{v} R.obj :=
+  SheafOfModules.forget _
+
+/-- The forgetful functor from sheaves of modules to presheaves of modules is fully
+faithful. -/
+abbrev fullyFaithfulForget (R : Sheaf J CommRingCat.{u}) :
+    (forget.{v} R).FullyFaithful :=
+  SheafOfModules.fullyFaithfulForget _
+
+/-- The functor forgetting the sheaf condition is faithful. -/
+instance (R : Sheaf J CommRingCat.{u}) : (forget.{v} R).Faithful :=
+  (fullyFaithfulForget R).faithful
+
+/-- The functor forgetting the sheaf condition is full. -/
+instance (R : Sheaf J CommRingCat.{u}) : (forget.{v} R).Full :=
+  (fullyFaithfulForget R).full
+
+/-- The functor forgetting the sheaf condition reflects isomorphisms. -/
+instance (R : Sheaf J CommRingCat.{u}) : (forget.{v} R).ReflectsIsomorphisms :=
+  (fullyFaithfulForget R).reflectsIsomorphisms
+
+end Basic
+
+section ChangeOfRings
+
+variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
+  {R S : Sheaf J CommRingCat.{u}}
+  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
+
+/-- Restriction of scalars along a morphism of sheaves of commutative rings. -/
+noncomputable abbrev restrictScalars (φ : R ⟶ S) :
+    SheafOfModulesOfCommRing.{v} S ⥤ SheafOfModulesOfCommRing.{v} R :=
+  SheafOfModules.restrictScalars
+    ((sheafCompose J (forget₂ _ _)).map φ)
+
+end ChangeOfRings
+
+section Pushforward
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+  {J : GrothendieckTopology C} {K : GrothendieckTopology D} {F : C ⥤ D}
+  {S : Sheaf J CommRingCat.{u}} {R : Sheaf K CommRingCat.{u}}
+  [Functor.IsContinuous F J K]
+  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
+  [K.HasSheafCompose (forget₂ CommRingCat RingCat)]
+  (φ : S ⟶ (F.sheafPushforwardContinuous CommRingCat.{u} J K).obj R)
+
+/-- The pushforward functor induced by a morphism of sheaves of commutative rings. -/
+noncomputable abbrev pushforward :
+    SheafOfModulesOfCommRing.{v} R ⥤ SheafOfModulesOfCommRing.{v} S :=
+  SheafOfModules.pushforward
+    ((sheafCompose J (forget₂ _ _)).map φ)
+
+/-- The pullback functor induced by a morphism of sheaves of commutative rings. -/
+noncomputable abbrev pullback [(pushforward.{v} φ).IsRightAdjoint] :
+    SheafOfModulesOfCommRing.{v} S ⥤ SheafOfModulesOfCommRing.{v} R :=
+  SheafOfModules.pullback
+    ((sheafCompose J (forget₂ _ _)).map φ)
+
+/-- The adjunction between pullback and pushforward for modules over sheaves of
+commutative rings. -/
+noncomputable abbrev pullbackPushforwardAdjunction
+    [(pushforward.{v} φ).IsRightAdjoint] :
+    pullback.{v} φ ⊣ pushforward.{v} φ :=
+  Adjunction.ofIsRightAdjoint (pushforward φ)
+
+/-- Pushforward of sheaves of modules commutes with forgetting the sheaf condition. -/
+noncomputable def pushforwardCompForgetIso :
+    pushforward.{v} φ ⋙ forget S ≅
+      forget R ⋙ PresheafOfModulesOfCommRing.pushforward.{v}
+        ((sheafToPresheaf J CommRingCat).map φ) :=
+  Iso.refl _
+
+end Pushforward
+
+section Over
+
+variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
+  (R : Sheaf J CommRingCat.{u})
+  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
+  [∀ X, (J.over X).HasSheafCompose (forget₂ CommRingCat RingCat)]
+
+/-- Restriction of sheaves of modules to the over category of an object. -/
+noncomputable abbrev overFunctor (X : C) :
+    SheafOfModulesOfCommRing.{v} R ⥤ SheafOfModulesOfCommRing.{v} (R.over X) :=
+  SheafOfModules.overFunctor _ X
+
+/-- Pushforward of sheaves of modules along the functor `Over.map f`. -/
+noncomputable abbrev overPullback {X Y : C} (f : X ⟶ Y) :
+    SheafOfModulesOfCommRing.{v} (R.over Y) ⥤
+      SheafOfModulesOfCommRing.{v} (R.over X) :=
+  SheafOfModules.pushforward (F := Over.map f) (𝟙 _)
+
+/-- Restriction to an over category is compatible with `overPullback`. -/
+noncomputable abbrev overFunctorCompOverPullback {X Y : C} (f : X ⟶ Y) :
+    overFunctor.{v} R Y ⋙ overPullback.{v} R f ≅ overFunctor.{v} R X :=
+  SheafOfModules.pushforwardComp _ _
+
+end Over
+
+section Fiber
+
+variable {C : Type u₁} [Category.{v₁} C] [LocallySmall.{u} C]
+  {J : GrothendieckTopology C} (Φ : GrothendieckTopology.Point.{u} J)
+  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
+
+/-- The fiber functor at a point for modules over a sheaf of commutative rings. -/
+noncomputable def fiber (R : Sheaf J CommRingCat.{u}) :
+    SheafOfModulesOfCommRing.{u} R ⥤ ModuleCat.{u} (Φ.presheafFiber.obj R.obj :) :=
+  forget R ⋙ PresheafOfModulesOfCommRing.fiber Φ R.obj
+
+end Fiber
+
+end SheafOfModulesOfCommRing
+
+/-! ## Sheafification -/
+
+namespace PresheafOfModulesOfCommRing
+
+variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
+  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
+  [J.WEqualsLocallyBijective AddCommGrpCat.{v}]
+  [HasWeakSheafify J AddCommGrpCat.{v}]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The sheafification functor for modules over a sheaf of commutative rings. -/
+noncomputable abbrev sheafification (R : Sheaf J CommRingCat.{u}) :
+    PresheafOfModulesOfCommRing.{v} R.obj ⥤ SheafOfModulesOfCommRing.{v} R :=
+  PresheafOfModules.sheafification.{v} (J := J)
+    (R₀ := R.obj ⋙ forget₂ _ _)
+    (R := (sheafCompose J (forget₂ _ _)).obj R) (𝟙 _)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The adjunction between sheafification and the functor forgetting the sheaf condition. -/
+noncomputable abbrev sheafificationAdjunction (R : Sheaf J CommRingCat.{u}) :
+    sheafification.{v} R ⊣ SheafOfModulesOfCommRing.forget.{v} R :=
+  PresheafOfModules.sheafificationAdjunction (𝟙 _)
+
+end PresheafOfModulesOfCommRing

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
@@ -47,6 +47,13 @@ section ChangeOfRings
 variable {C : Type u₁} [Category.{v₁} C]
   {R S : Cᵒᵖ ⥤ CommRingCat.{u}} (φ : R ⟶ S)
 
+abbrev obj (F : PresheafOfModulesOfCommRing.{v} R) (X : Cᵒᵖ) : ModuleCat.{v} (R.obj X) :=
+    PresheafOfModules.obj F X
+
+abbrev map (F : PresheafOfModulesOfCommRing.{v} R) {X Y : Cᵒᵖ} (f : X ⟶ Y) :
+    F.obj X ⟶ (ModuleCat.restrictScalars (R.map f).hom).obj (F.obj Y) :=
+  PresheafOfModules.map _ _
+
 /-- Restriction of scalars along a morphism of presheaves of commutative rings. -/
 noncomputable abbrev restrictScalars :
     PresheafOfModulesOfCommRing.{v} S ⥤ PresheafOfModulesOfCommRing.{v} R :=

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
@@ -42,17 +42,63 @@ abbrev SheafOfModulesOfCommRing {C : Type u₁} [Category.{v₁} C]
 
 namespace PresheafOfModulesOfCommRing
 
+section Basic
+
+variable {C : Type u₁} [Category.{v₁} C]
+  {R : Cᵒᵖ ⥤ CommRingCat.{u}}
+
+/-- Construct a presheaf of modules over a presheaf of commutative rings. -/
+abbrev mk (obj : ∀ (X : Cᵒᵖ), ModuleCat.{v} (R.obj X)) (map : ∀ {X Y : Cᵒᵖ} (f : X ⟶ Y),
+      obj X ⟶ (ModuleCat.restrictScalars (R.map f).hom).obj (obj Y))
+    (map_id : ∀ (X : Cᵒᵖ), map (𝟙 X) = (ModuleCat.restrictScalarsId' (R.map (𝟙 X)).hom
+      (congrArg CommRingCat.Hom.hom (R.map_id X))).inv.app _)
+    (map_comp : ∀ {X Y Z : Cᵒᵖ} (f : X ⟶ Y) (g : Y ⟶ Z),
+      map (f ≫ g) = map f ≫ (ModuleCat.restrictScalars _).map (map g) ≫
+        (ModuleCat.restrictScalarsComp' (R.map f).hom (R.map g).hom (R.map (f ≫ g)).hom
+          (congrArg CommRingCat.Hom.hom <| R.map_comp f g)).inv.app _) :
+    PresheafOfModulesOfCommRing.{v} R where
+  obj := obj
+  map := map
+  map_id := map_id
+  map_comp := map_comp
+
+/-- Evaluate a presheaf of modules over a presheaf of commutative rings at an object. -/
+abbrev obj (F : PresheafOfModulesOfCommRing.{v} R) (X : Cᵒᵖ) : ModuleCat.{v} (R.obj X) :=
+  PresheafOfModules.obj F X
+
+/-- The restriction map of a presheaf of modules over a presheaf of commutative rings. -/
+abbrev map (F : PresheafOfModulesOfCommRing.{v} R) {X Y : Cᵒᵖ} (f : X ⟶ Y) :
+    F.obj X ⟶ (ModuleCat.restrictScalars (R.map f).hom).obj (F.obj Y) :=
+  PresheafOfModules.map _ _
+
+/-- Construct a morphism of presheaves of modules over a presheaf of commutative rings. -/
+abbrev mkHom {M₁ M₂ : PresheafOfModulesOfCommRing.{v} R}
+    (app : ∀ (X : Cᵒᵖ), M₁.obj X ⟶ M₂.obj X)
+    (naturality : ∀ {X Y : Cᵒᵖ} (f : X ⟶ Y),
+      M₁.map f ≫ (ModuleCat.restrictScalars (R.map f).hom).map (app Y) =
+        app X ≫ M₂.map f) : M₁ ⟶ M₂ where
+  app := app
+  naturality := naturality
+
+/-- Construct an isomorphism of presheaves of modules over a presheaf of commutative rings. -/
+abbrev isoMk {M₁ M₂ : PresheafOfModulesOfCommRing.{v} R}
+    (app : ∀ (X : Cᵒᵖ), M₁.obj X ≅ M₂.obj X)
+    (naturality : ∀ ⦃X Y : Cᵒᵖ⦄ (f : X ⟶ Y),
+      M₁.map f ≫ (ModuleCat.restrictScalars (R.map f).hom).map (app Y).hom =
+        (app X).hom ≫ M₂.map f := by cat_disch) : M₁ ≅ M₂ :=
+  PresheafOfModules.isoMk app naturality
+
+/-- The free presheaf of modules of rank one over a presheaf of commutative rings. -/
+noncomputable abbrev unit (R : Cᵒᵖ ⥤ CommRingCat.{u}) :
+    PresheafOfModulesOfCommRing.{u} R :=
+  PresheafOfModules.unit (R ⋙ forget₂ _ _)
+
+end Basic
+
 section ChangeOfRings
 
 variable {C : Type u₁} [Category.{v₁} C]
   {R S : Cᵒᵖ ⥤ CommRingCat.{u}} (φ : R ⟶ S)
-
-abbrev obj (F : PresheafOfModulesOfCommRing.{v} R) (X : Cᵒᵖ) : ModuleCat.{v} (R.obj X) :=
-    PresheafOfModules.obj F X
-
-abbrev map (F : PresheafOfModulesOfCommRing.{v} R) {X Y : Cᵒᵖ} (f : X ⟶ Y) :
-    F.obj X ⟶ (ModuleCat.restrictScalars (R.map f).hom).obj (F.obj Y) :=
-  PresheafOfModules.map _ _
 
 /-- Restriction of scalars along a morphism of presheaves of commutative rings. -/
 noncomputable abbrev restrictScalars :

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Pullback
 
 /-!
-# Modules over presheaves commutative rings
+# Modules over presheaves of commutative rings
 
 This file provides short names for categories and functors obtained from a presheaf of commutative
 rings by forgetting to rings. In particular, these names reduce the need for
@@ -36,11 +36,11 @@ variable {C : Type u₁} [Category.{v₁} C] {R : Cᵒᵖ ⥤ CommRingCat.{u}}
 abbrev mk (obj : ∀ (X : Cᵒᵖ), ModuleCat.{v} (R.obj X)) (map : ∀ {X Y : Cᵒᵖ} (f : X ⟶ Y),
       obj X ⟶ (ModuleCat.restrictScalars (R.map f).hom).obj (obj Y))
     (map_id : ∀ (X : Cᵒᵖ), map (𝟙 X) = (ModuleCat.restrictScalarsId' (R.map (𝟙 X)).hom
-      (congrArg CommRingCat.Hom.hom (R.map_id X))).inv.app _)
+      (congrArg CommRingCat.Hom.hom (R.map_id X))).inv.app _ := by cat_disch)
     (map_comp : ∀ {X Y Z : Cᵒᵖ} (f : X ⟶ Y) (g : Y ⟶ Z),
       map (f ≫ g) = map f ≫ (ModuleCat.restrictScalars _).map (map g) ≫
         (ModuleCat.restrictScalarsComp' (R.map f).hom (R.map g).hom (R.map (f ≫ g)).hom
-          (congrArg CommRingCat.Hom.hom <| R.map_comp f g)).inv.app _) :
+          (congrArg CommRingCat.Hom.hom <| R.map_comp f g)).inv.app _ := by cat_disch) :
     PresheafOfModulesOfCommRing.{v} R where
   obj := obj
   map := map
@@ -57,11 +57,11 @@ abbrev map (F : PresheafOfModulesOfCommRing.{v} R) {X Y : Cᵒᵖ} (f : X ⟶ Y)
   PresheafOfModules.map _ _
 
 /-- Construct a morphism of presheaves of modules over a presheaf of commutative rings. -/
-abbrev mkHom {M₁ M₂ : PresheafOfModulesOfCommRing.{v} R}
+abbrev homMk {M₁ M₂ : PresheafOfModulesOfCommRing.{v} R}
     (app : ∀ (X : Cᵒᵖ), M₁.obj X ⟶ M₂.obj X)
     (naturality : ∀ {X Y : Cᵒᵖ} (f : X ⟶ Y),
       M₁.map f ≫ (ModuleCat.restrictScalars (R.map f).hom).map (app Y) =
-        app X ≫ M₂.map f) : M₁ ⟶ M₂ where
+        app X ≫ M₂.map f := by cat_disch) : M₁ ⟶ M₂ where
   app := app
   naturality := naturality
 

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
@@ -5,17 +5,13 @@ Authors: Brian Nugent
 -/
 module
 
-public import Mathlib.Algebra.Category.ModuleCat.Presheaf.ColimitFunctor
-public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Sheafification
-public import Mathlib.Algebra.Category.ModuleCat.Sheaf.PullbackContinuous
-public import Mathlib.Algebra.Category.Ring.Colimits
-public import Mathlib.CategoryTheory.Sites.Point.Basic
+public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Pullback
 
 /-!
-# Modules over presheaves and sheaves of commutative rings
+# Modules over presheaves commutative rings
 
-This file provides short names for categories and functors obtained from a presheaf or
-sheaf of commutative rings by forgetting to rings. In particular, these names avoid
+This file provides short names for categories and functors obtained from a presheaf of commutative
+rings by forgetting to rings. In particular, these names reduce the need for
 repeatedly writing the relevant forgetful functor or `sheafCompose`.
 -/
 
@@ -25,27 +21,16 @@ universe v v₁ v₂ u₁ u₂ u
 
 open CategoryTheory Functor Limits
 
-/-! ## Categories -/
-
 /-- The category of presheaves of modules over a presheaf of commutative rings. -/
 abbrev PresheafOfModulesOfCommRing {C : Type u₁} [Category.{v₁} C]
     (R : Cᵒᵖ ⥤ CommRingCat.{u}) :=
   PresheafOfModules.{v} (R ⋙ forget₂ _ _)
 
-/-- The category of sheaves of modules over a sheaf of commutative rings. -/
-abbrev SheafOfModulesOfCommRing {C : Type u₁} [Category.{v₁} C]
-    {J : GrothendieckTopology C} (R : Sheaf J CommRingCat.{u})
-    [J.HasSheafCompose (forget₂ CommRingCat RingCat)] :=
-  SheafOfModules.{v} ((sheafCompose J (forget₂ _ _)).obj R)
-
-/-! ## Presheaves of modules -/
-
 namespace PresheafOfModulesOfCommRing
 
 section Basic
 
-variable {C : Type u₁} [Category.{v₁} C]
-  {R : Cᵒᵖ ⥤ CommRingCat.{u}}
+variable {C : Type u₁} [Category.{v₁} C] {R : Cᵒᵖ ⥤ CommRingCat.{u}}
 
 /-- Construct a presheaf of modules over a presheaf of commutative rings. -/
 abbrev mk (obj : ∀ (X : Cᵒᵖ), ModuleCat.{v} (R.obj X)) (map : ∀ {X Y : Cᵒᵖ} (f : X ⟶ Y),
@@ -93,21 +78,14 @@ noncomputable abbrev unit (R : Cᵒᵖ ⥤ CommRingCat.{u}) :
     PresheafOfModulesOfCommRing.{u} R :=
   PresheafOfModules.unit (R ⋙ forget₂ _ _)
 
-end Basic
-
-section ChangeOfRings
-
-variable {C : Type u₁} [Category.{v₁} C]
-  {R S : Cᵒᵖ ⥤ CommRingCat.{u}} (φ : R ⟶ S)
-
 /-- Restriction of scalars along a morphism of presheaves of commutative rings. -/
-noncomputable abbrev restrictScalars :
+noncomputable abbrev restrictScalars {S : Cᵒᵖ ⥤ CommRingCat.{u}} (φ : R ⟶ S) :
     PresheafOfModulesOfCommRing.{v} S ⥤ PresheafOfModulesOfCommRing.{v} R :=
   PresheafOfModules.restrictScalars (whiskerRight φ (forget₂ _ _))
 
-end ChangeOfRings
+end Basic
 
-section Pushforward
+section PushforwardPullback
 
 variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
@@ -135,240 +113,8 @@ commutative rings. -/
 noncomputable abbrev pullbackPushforwardAdjunction
     [(pushforward.{v} φ).IsRightAdjoint] :
     pullback.{v} φ ⊣ pushforward.{v} φ :=
-  Adjunction.ofIsRightAdjoint (pushforward φ)
+  PresheafOfModules.pullbackPushforwardAdjunction _
 
-end Pushforward
-
-section Colimit
-
-attribute [local instance] hasColimitsOfShape_of_finallySmall
-  IsFiltered.isSifted FinallySmall.preservesColimitsOfShape_of_isFiltered
-
-variable {C : Type u₁} [Category.{v₁} C] {R : Cᵒᵖ ⥤ CommRingCat.{u}}
-
-/-- The constant-presheaf functor associated to a cocone of commutative rings. -/
-noncomputable abbrev constFunctor (cR : Cocone R) :
-    ModuleCat.{u} cR.pt ⥤ PresheafOfModulesOfCommRing.{u} R :=
-  PresheafOfModules.constFunctor ((forget₂ _ _).mapCocone cR)
-
-variable [LocallySmall.{u} C] [IsCofiltered C] [InitiallySmall.{u} C]
-  {cR : Cocone R} (hcR : IsColimit cR)
-
-/-- The colimit-module functor associated to a colimit cocone of commutative rings. -/
-noncomputable abbrev colimitFunctor :
-    PresheafOfModulesOfCommRing.{u} R ⥤ ModuleCat.{u} cR.pt :=
-  PresheafOfModules.colimitFunctor
-    (isColimitOfPreserves (forget₂ _ _) hcR)
-
-/-- The adjunction between the colimit-module and constant-presheaf functors. -/
-noncomputable abbrev colimitAdjunction :
-    colimitFunctor hcR ⊣ constFunctor cR :=
-  PresheafOfModules.colimitAdjunction
-    (isColimitOfPreserves (forget₂ _ _) hcR)
-
-/-- The coprojection `P.obj U →+ (colimitFunctor hcR).obj P` into the colimit module. -/
-noncomputable def ιColimitFunctor
-    (P : PresheafOfModulesOfCommRing.{u} R) (U : Cᵒᵖ) :
-    P.obj U →+ (colimitFunctor hcR).obj P :=
-  (colimit.ι P.presheaf U).hom
-
-/-- The coprojections into the colimit module commute with restriction maps. -/
-@[simp]
-lemma ιColimitFunctor_map
-    (P : PresheafOfModulesOfCommRing.{u} R) {V U : Cᵒᵖ}
-    (f : V ⟶ U) (x : P.obj V) :
-    ιColimitFunctor hcR P U (P.map f x) = ιColimitFunctor hcR P V x :=
-  ConcreteCategory.congr_hom (colimit.w P.presheaf f) x
-
-/-- The colimit cocone on the underlying presheaf of additive commutative groups. -/
-noncomputable def coconeColimitFunctor
-    (P : PresheafOfModulesOfCommRing.{u} R) : Cocone P.presheaf where
-  pt := (forget₂ _ AddCommGrpCat).obj ((colimitFunctor hcR).obj P)
-  ι.app U := AddCommGrpCat.ofHom (ιColimitFunctor hcR P U)
-  ι.naturality V U f := by
-    ext x
-    exact ιColimitFunctor_map hcR P f x
-
-/-- The cocone `coconeColimitFunctor hcR P` is a colimit cocone. -/
-noncomputable def isColimitCoconeColimitFunctor
-    (P : PresheafOfModulesOfCommRing.{u} R) :
-    IsColimit (coconeColimitFunctor hcR P) :=
-  colimit.isColimit P.presheaf
-
-end Colimit
-
-section Fiber
-
-attribute [local instance] hasColimitsOfShape_of_finallySmall
-  IsFiltered.isSifted FinallySmall.preservesColimitsOfShape_of_isFiltered
-
-variable {C : Type u₁} [Category.{v₁} C] [LocallySmall.{u} C]
-  {J : GrothendieckTopology C} (Φ : GrothendieckTopology.Point.{u} J)
-
-/-- The fiber functor at a point for modules over a presheaf of commutative rings. -/
-noncomputable def fiber (R : Cᵒᵖ ⥤ CommRingCat.{u}) :
-    PresheafOfModulesOfCommRing.{u} R ⥤
-      ModuleCat.{u} (Φ.presheafFiber.obj R :) :=
-  pushforward₀ (CategoryOfElements.π Φ.fiber) R ⋙
-    colimitFunctor
-      (colimit.isColimit ((CategoryOfElements.π Φ.fiber).op ⋙ R))
-
-end Fiber
-
-end PresheafOfModulesOfCommRing
-
-/-! ## Sheaves of modules -/
-
-namespace SheafOfModulesOfCommRing
-
-section Basic
-
-variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
-  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
-
-/-- The underlying presheaf of modules of a sheaf of modules. -/
-abbrev val {R : Sheaf J CommRingCat.{u}} (F : SheafOfModulesOfCommRing.{v} R) :
-    PresheafOfModulesOfCommRing.{v} R.obj :=
-  SheafOfModules.val F
-
-/-- The functor forgetting the sheaf condition on a sheaf of modules. -/
-abbrev forget (R : Sheaf J CommRingCat.{u}) :
-    SheafOfModulesOfCommRing.{v} R ⥤ PresheafOfModulesOfCommRing.{v} R.obj :=
-  SheafOfModules.forget _
-
-/-- The forgetful functor from sheaves of modules to presheaves of modules is fully
-faithful. -/
-abbrev fullyFaithfulForget (R : Sheaf J CommRingCat.{u}) :
-    (forget.{v} R).FullyFaithful :=
-  SheafOfModules.fullyFaithfulForget _
-
-/-- The functor forgetting the sheaf condition is faithful. -/
-instance (R : Sheaf J CommRingCat.{u}) : (forget.{v} R).Faithful :=
-  (fullyFaithfulForget R).faithful
-
-/-- The functor forgetting the sheaf condition is full. -/
-instance (R : Sheaf J CommRingCat.{u}) : (forget.{v} R).Full :=
-  (fullyFaithfulForget R).full
-
-/-- The functor forgetting the sheaf condition reflects isomorphisms. -/
-instance (R : Sheaf J CommRingCat.{u}) : (forget.{v} R).ReflectsIsomorphisms :=
-  (fullyFaithfulForget R).reflectsIsomorphisms
-
-end Basic
-
-section ChangeOfRings
-
-variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
-  {R S : Sheaf J CommRingCat.{u}}
-  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
-
-/-- Restriction of scalars along a morphism of sheaves of commutative rings. -/
-noncomputable abbrev restrictScalars (φ : R ⟶ S) :
-    SheafOfModulesOfCommRing.{v} S ⥤ SheafOfModulesOfCommRing.{v} R :=
-  SheafOfModules.restrictScalars
-    ((sheafCompose J (forget₂ _ _)).map φ)
-
-end ChangeOfRings
-
-section Pushforward
-
-variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
-  {J : GrothendieckTopology C} {K : GrothendieckTopology D} {F : C ⥤ D}
-  {S : Sheaf J CommRingCat.{u}} {R : Sheaf K CommRingCat.{u}}
-  [Functor.IsContinuous F J K]
-  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
-  [K.HasSheafCompose (forget₂ CommRingCat RingCat)]
-  (φ : S ⟶ (F.sheafPushforwardContinuous CommRingCat.{u} J K).obj R)
-
-/-- The pushforward functor induced by a morphism of sheaves of commutative rings. -/
-noncomputable abbrev pushforward :
-    SheafOfModulesOfCommRing.{v} R ⥤ SheafOfModulesOfCommRing.{v} S :=
-  SheafOfModules.pushforward
-    ((sheafCompose J (forget₂ _ _)).map φ)
-
-/-- The pullback functor induced by a morphism of sheaves of commutative rings. -/
-noncomputable abbrev pullback [(pushforward.{v} φ).IsRightAdjoint] :
-    SheafOfModulesOfCommRing.{v} S ⥤ SheafOfModulesOfCommRing.{v} R :=
-  SheafOfModules.pullback
-    ((sheafCompose J (forget₂ _ _)).map φ)
-
-/-- The adjunction between pullback and pushforward for modules over sheaves of
-commutative rings. -/
-noncomputable abbrev pullbackPushforwardAdjunction
-    [(pushforward.{v} φ).IsRightAdjoint] :
-    pullback.{v} φ ⊣ pushforward.{v} φ :=
-  Adjunction.ofIsRightAdjoint (pushforward φ)
-
-/-- Pushforward of sheaves of modules commutes with forgetting the sheaf condition. -/
-noncomputable def pushforwardCompForgetIso :
-    pushforward.{v} φ ⋙ forget S ≅
-      forget R ⋙ PresheafOfModulesOfCommRing.pushforward.{v}
-        ((sheafToPresheaf J CommRingCat).map φ) :=
-  Iso.refl _
-
-end Pushforward
-
-section Over
-
-variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
-  (R : Sheaf J CommRingCat.{u})
-  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
-  [∀ X, (J.over X).HasSheafCompose (forget₂ CommRingCat RingCat)]
-
-/-- Restriction of sheaves of modules to the over category of an object. -/
-noncomputable abbrev overFunctor (X : C) :
-    SheafOfModulesOfCommRing.{v} R ⥤ SheafOfModulesOfCommRing.{v} (R.over X) :=
-  SheafOfModules.overFunctor _ X
-
-/-- Pushforward of sheaves of modules along the functor `Over.map f`. -/
-noncomputable abbrev overPullback {X Y : C} (f : X ⟶ Y) :
-    SheafOfModulesOfCommRing.{v} (R.over Y) ⥤
-      SheafOfModulesOfCommRing.{v} (R.over X) :=
-  SheafOfModules.pushforward (F := Over.map f) (𝟙 _)
-
-/-- Restriction to an over category is compatible with `overPullback`. -/
-noncomputable abbrev overFunctorCompOverPullback {X Y : C} (f : X ⟶ Y) :
-    overFunctor.{v} R Y ⋙ overPullback.{v} R f ≅ overFunctor.{v} R X :=
-  SheafOfModules.pushforwardComp _ _
-
-end Over
-
-section Fiber
-
-variable {C : Type u₁} [Category.{v₁} C] [LocallySmall.{u} C]
-  {J : GrothendieckTopology C} (Φ : GrothendieckTopology.Point.{u} J)
-  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
-
-/-- The fiber functor at a point for modules over a sheaf of commutative rings. -/
-noncomputable def fiber (R : Sheaf J CommRingCat.{u}) :
-    SheafOfModulesOfCommRing.{u} R ⥤ ModuleCat.{u} (Φ.presheafFiber.obj R.obj :) :=
-  forget R ⋙ PresheafOfModulesOfCommRing.fiber Φ R.obj
-
-end Fiber
-
-end SheafOfModulesOfCommRing
-
-/-! ## Sheafification -/
-
-namespace PresheafOfModulesOfCommRing
-
-variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
-  [J.HasSheafCompose (forget₂ CommRingCat RingCat)]
-  [J.WEqualsLocallyBijective AddCommGrpCat.{v}]
-  [HasWeakSheafify J AddCommGrpCat.{v}]
-
-set_option backward.isDefEq.respectTransparency false in
-/-- The sheafification functor for modules over a sheaf of commutative rings. -/
-noncomputable abbrev sheafification (R : Sheaf J CommRingCat.{u}) :
-    PresheafOfModulesOfCommRing.{v} R.obj ⥤ SheafOfModulesOfCommRing.{v} R :=
-  PresheafOfModules.sheafification.{v} (J := J)
-    (R₀ := R.obj ⋙ forget₂ _ _)
-    (R := (sheafCompose J (forget₂ _ _)).obj R) (𝟙 _)
-
-set_option backward.isDefEq.respectTransparency false in
-/-- The adjunction between sheafification and the functor forgetting the sheaf condition. -/
-noncomputable abbrev sheafificationAdjunction (R : Sheaf J CommRingCat.{u}) :
-    sheafification.{v} R ⊣ SheafOfModulesOfCommRing.forget.{v} R :=
-  PresheafOfModules.sheafificationAdjunction (𝟙 _)
+end PushforwardPullback
 
 end PresheafOfModulesOfCommRing

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/OfCommRing.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Pullback
 
 This file provides short names for categories and functors obtained from a presheaf of commutative
 rings by forgetting to rings. In particular, these names reduce the need for
-repeatedly writing the relevant forgetful functor or `sheafCompose`.
+repeatedly writing the relevant forgetful functor.
 -/
 
 @[expose] public section


### PR DESCRIPTION
Currently in mathlib, to define a presheaf of modules over a commutative ring, one 
writes 
```
variable  {C : Type*} [Category* C] (R : Cᵒᵖ ⥤ CommRingCat.{u}) (F : PresheafOfModules.{v} (R ⋙ forget₂ _ _))
```

The problem with this formulation is that many operations do not preserve the shape of `(R ⋙ forget₂ _ _)`. For 
example, [PresheafOfModules.pushforward₀](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pushforward.html#PresheafOfModules.pushforward%E2%82%80) has type `PresheafOfModules (R ⋙ forget₂ _ _) ⥤ PresheafOfModules (F.op ⋙ R ⋙ forget₂ _ _)` when applied directly. This is why [PresheafOfModules.pushforward₀OfCommRingCat](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pushforward.html#PresheafOfModules.pushforward%E2%82%80OfCommRingCat) was introduced. There are now around a dozen of these comm ring specific abbrevs in open PRs. In this PR, I introduce `PresheafOfModulesOfCommRing` with the goal of having a namespace to put all of these as well as making it easier to avoid making mistakes. 

For an example of this being used, see #43193.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
