### PR TITLE
[Merged by Bors] - refactor(Tactic/Linter): rename and generalize `linter.style.nativeDecide` to `linter.style.native`

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -101,7 +101,7 @@ register_linter_set linter.mathlibStandardSet :=
   linter.style.longLine
   linter.style.longFile
   linter.style.multiGoal
-  linter.style.nativeDecide
+  linter.style.native
   linter.style.openClassical
   linter.style.maxHeartbeats
   linter.style.missingEnd

--- a/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
@@ -83,7 +83,8 @@ public register_option linter.style.admit : Bool := {
 }
 
 /-- The option `linter.style.native` of the deprecated syntax linter flags usages of
-`native_decide` and `decide +native`, which are disallowed in mathlib. -/
+tactics which use `nativeEqTrue` such as `native_decide` and `decide +native`, which are
+disallowed in mathlib. -/
 -- Note: this linter is purely for user information. Running `lean4checker` in CI catches *any*
 -- additional axioms that are introduced (not just `ofReduceBool`): the point of this check is to
 -- alert the user quickly, not to be airtight.
@@ -98,6 +99,12 @@ public register_option linter.style.nativeDecide : Bool := {
   defValue := false
   descr := "deprecated: use the `linter.style.native` option instead"
 }
+
+/-- Return whether the native-evaluation linter is enabled, honoring its deprecated option name. -/
+private def getNativeLinterValue (options : LinterOptions) : Bool :=
+  match options.get? linter.style.native.name with
+  | some value => value
+  | none => options.get `linter.style.nativeDecide (getLinterValue linter.style.native options)
 
 /-- The option `linter.style.maxHeartbeats` of the deprecated syntax linter flags usages of
 `set_option <name-containing-maxHeartbeats> n in cmd` that do not add a comment explaining
@@ -220,7 +227,7 @@ def deprecatedSyntaxLinter : Linter where run stx := do
       getLinterValue linter.style.induction (← getLinterOptions) ||
       getLinterValue linter.style.admit (← getLinterOptions) ||
       getLinterValue linter.style.maxHeartbeats (← getLinterOptions) ||
-      getLinterValue linter.style.native (← getLinterOptions) do
+      getNativeLinterValue (← getLinterOptions) do
     return
   if (← MonadState.get).messages.hasErrors then
     return
@@ -238,7 +245,8 @@ def deprecatedSyntaxLinter : Linter where run stx := do
       | `Mathlib.Tactic.induction' => Linter.logLintIf linter.style.induction stx' msg
       | ``Lean.Parser.Tactic.tacticAdmit => Linter.logLintIf linter.style.admit stx' msg
       | ``Lean.Parser.Tactic.nativeDecide | ``Lean.Parser.Tactic.decide =>
-        Linter.logLintIf linter.style.native stx' msg
+        if getNativeLinterValue (← getLinterOptions) then
+          Linter.logLint linter.style.native stx' msg
       | `MaxHeartbeats => Linter.logLintIf linter.style.maxHeartbeats stx' msg
       | _ => continue) stx
 

--- a/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
@@ -171,14 +171,14 @@ def getDeprecatedSyntax : Syntax → Array (SyntaxNodeKind × Syntax × MessageD
     | ``Parser.Term.configItem | ``Parser.Tactic.configItem =>
       if usesNativeConfig stx then
         rargs.push (kind, stx, m!"Using `+native` is not allowed in mathlib: \
-          it trusts the entire Lean compiler (not just the Lean kernel), \
-          and it can quite possibly be used to prove `{.ofConstName ``False}`.")
+          because it trusts the entire Lean compiler (not just the Lean kernel), \
+          it could quite possibly be used to prove `{.ofConstName ``False}`.")
       else
         rargs
     | ``Lean.Parser.Tactic.nativeDecide =>
       rargs.push (kind, stx, m!"Using `native_decide` is not allowed in mathlib: \
-        it trusts the entire Lean compiler (not just the Lean kernel), \
-        and it can quite possibly be used to prove `{.ofConstName ``False}`.")
+        because it trusts the entire Lean compiler (not just the Lean kernel), \
+        it could quite possibly be used to prove `{.ofConstName ``False}`.")
     | ``Lean.Parser.Command.in =>
       match getSetOptionMaxHeartbeatsComment stx with
       | none => rargs

--- a/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
@@ -199,8 +199,7 @@ def getDeprecatedSyntax : Syntax → Array (SyntaxNodeKind × Syntax × MessageD
     | _ => rargs
   | _ => default
 
--- Remove this suppression and the compatibility code marked below when
--- `linter.style.nativeDecide` is removed.
+-- TODO: Remove this `set_option` with `linter.style.nativeDecide`.
 set_option linter.deprecated false in
 /-- The deprecated syntax linter flags usages of deprecated syntax and suggests
 replacement syntax. For each individual case, linting can be turned on or off separately.

--- a/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
@@ -133,21 +133,18 @@ def getSetOptionMaxHeartbeatsComment : Syntax → Option (Name × Nat × Substri
   | _ => none
 
 /-- Whether the tactic syntax `stx` enables the `native` option. This may have false negatives for
-`tac (config := {<options>})` syntax. -/
-def usesNativeConfig (stx : Syntax) : Bool :=
-  let config := stx[1]![0]
-  if let .node _ _ configArgs := config then
-    let natives := configArgs.filterMap (match ·[0] with
-      | `(Parser.Tactic.posConfigItem| +native) => some true
-      | `(Parser.Tactic.negConfigItem| -native) => some false
-      | `(Parser.Tactic.valConfigItem| (native := true)) => some true
-      | `(Parser.Tactic.valConfigItem| (native := false)) => some false
-      | `(Parser.Tactic.valConfigItem| (config := {native := true})) => some true
-      | `(Parser.Tactic.valConfigItem| (config := {native := false})) => some false
-      | _ => none)
-    natives.back? == some true
-  else
-    false
+`tac (config := term)` syntax if `term` is not of the form `{..., native := true, ...}`. -/
+def usesNativeConfig : Syntax → Bool
+  | `(Parser.Term.configItem|   +native)
+  | `(Parser.Tactic.configItem| +native) => true
+  | `(Parser.Term.configItem|   (native := true))
+  | `(Parser.Tactic.configItem| (native := true)) => true
+  | `(Parser.Term.configItem|   (config := {$t:structInstField,*}))
+  | `(Parser.Tactic.configItem| (config := {$t:structInstField,*})) =>
+    t.getElems.any fun
+      | `(Parser.Term.structInstField| native := true) => true
+      | _ => false
+  | _ => false
 
 /-- `getDeprecatedSyntax t` returns all usages of deprecated syntax in the input syntax `t`. -/
 partial
@@ -171,17 +168,17 @@ def getDeprecatedSyntax : Syntax → Array (SyntaxNodeKind × Syntax × MessageD
       rargs.push (kind, stx,
         "The `admit` tactic is discouraged: \
          please strongly consider using the synonymous `sorry` instead.")
-    | ``Lean.Parser.Tactic.decide =>
+    | ``Parser.Term.configItem | ``Parser.Tactic.configItem =>
       if usesNativeConfig stx then
-        rargs.push (kind, stx, "Using `decide +native` is not allowed in mathlib: \
-        because it trusts the entire Lean compiler (not just the Lean kernel), \
-        it could quite possibly be used to prove false.")
+        rargs.push (kind, stx, m!"Using `+native` is not allowed in mathlib: \
+          it trusts the entire Lean compiler (not just the Lean kernel), \
+          and it can quite possibly be used to prove `{.ofConstName ``False}`.")
       else
         rargs
     | ``Lean.Parser.Tactic.nativeDecide =>
-      rargs.push (kind, stx, "Using `native_decide` is not allowed in mathlib: \
-        because it trusts the entire Lean compiler (not just the Lean kernel), \
-        it could quite possibly be used to prove false.")
+      rargs.push (kind, stx, m!"Using `native_decide` is not allowed in mathlib: \
+        it trusts the entire Lean compiler (not just the Lean kernel), \
+        and it can quite possibly be used to prove `{.ofConstName ``False}`.")
     | ``Lean.Parser.Command.in =>
       match getSetOptionMaxHeartbeatsComment stx with
       | none => rargs
@@ -208,7 +205,7 @@ replacement syntax. For each individual case, linting can be turned on or off se
 * `cases'`, superseded by `obtain`, `rcases` and `cases` (controlled by `linter.style.cases`)
 * `induction'`, superseded by `induction` (controlled by `linter.style.induction`)
 * `admit`, superseded by `sorry` (controlled by `linter.style.admit`)
-* `native_decide` and `decide +native`, which trust the Lean compiler
+* `native_decide` and any config setting `+native`, which trust the Lean compiler
   (controlled by `linter.style.native`)
 * `set_option maxHeartbeats`, should contain an explanatory comment
   (controlled by `linter.style.maxHeartbeats`)
@@ -238,7 +235,8 @@ def deprecatedSyntaxLinter : Linter where run stx := do
       | `Mathlib.Tactic.cases' => Linter.logLintIf linter.style.cases stx' msg
       | `Mathlib.Tactic.induction' => Linter.logLintIf linter.style.induction stx' msg
       | ``Lean.Parser.Tactic.tacticAdmit => Linter.logLintIf linter.style.admit stx' msg
-      | ``Lean.Parser.Tactic.nativeDecide | ``Lean.Parser.Tactic.decide => do
+      | ``Lean.Parser.Tactic.nativeDecide
+      | ``Parser.Term.configItem | ``Parser.Tactic.configItem => do
         -- TODO: this block should be removed when `linter.style.nativeDecide` is removed and
         -- replaced with just `Linter.logLint linter.style.native stx' msg`
         let options ← getLinterOptions

--- a/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
@@ -132,8 +132,8 @@ def getSetOptionMaxHeartbeatsComment : Syntax → Option (Name × Nat × Substri
         some default
   | _ => none
 
-/-- Whether the tactic syntax `stx` enables the `native` option. This may have false negatives for
-`tac (config := term)` syntax if `term` is not of the form `{..., native := true, ...}`. -/
+/-- Whether the config item `stx` enables the `native` option. This may have false negatives for
+`(config := term)` syntax if `term` is not of the form `{..., native := true, ...}`. -/
 def usesNativeConfig : Syntax → Bool
   | `(Parser.Term.configItem|   +native)
   | `(Parser.Tactic.configItem| +native) => true

--- a/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
@@ -203,6 +203,8 @@ def getDeprecatedSyntax : Syntax → Array (SyntaxNodeKind × Syntax × MessageD
     | _ => rargs
   | _ => default
 
+-- Remove this suppression and the compatibility code marked below when
+-- `linter.style.nativeDecide` is removed.
 set_option linter.deprecated false in
 /-- The deprecated syntax linter flags usages of deprecated syntax and suggests
 replacement syntax. For each individual case, linting can be turned on or off separately.
@@ -223,6 +225,7 @@ def deprecatedSyntaxLinter : Linter where run stx := do
       getLinterValue linter.style.admit (← getLinterOptions) ||
       getLinterValue linter.style.maxHeartbeats (← getLinterOptions) ||
       getLinterValue linter.style.native (← getLinterOptions) ||
+      -- TODO: Remove this line with `linter.style.nativeDecide`.
       getLinterValue linter.style.nativeDecide (← getLinterOptions) do
     return
   if (← MonadState.get).messages.hasErrors then
@@ -241,8 +244,13 @@ def deprecatedSyntaxLinter : Linter where run stx := do
       | `Mathlib.Tactic.induction' => Linter.logLintIf linter.style.induction stx' msg
       | ``Lean.Parser.Tactic.tacticAdmit => Linter.logLintIf linter.style.admit stx' msg
       | ``Lean.Parser.Tactic.nativeDecide | ``Lean.Parser.Tactic.decide => do
-        Linter.logLintIf linter.style.native stx' msg
-        Linter.logLintIf linter.style.nativeDecide stx' msg
+        -- TODO: this block should be removed when `linter.style.nativeDecide` is removed and
+        -- replaced with just `Linter.logLint linter.style.native stx' msg`
+        let options ← getLinterOptions
+        if getLinterValue linter.style.native options then
+          Linter.logLint linter.style.native stx' msg
+        else if getLinterValue linter.style.nativeDecide options then
+          Linter.logLint linter.style.nativeDecide stx' msg
       | `MaxHeartbeats => Linter.logLintIf linter.style.maxHeartbeats stx' msg
       | _ => continue) stx
 

--- a/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
@@ -82,14 +82,21 @@ public register_option linter.style.admit : Bool := {
   descr := "enable the admit linter"
 }
 
-/-- The option `linter.style.nativeDecide` of the deprecated syntax linter flags usages of
-the `native_decide` tactic, which is disallowed in mathlib. -/
+/-- The option `linter.style.native` of the deprecated syntax linter flags usages of
+`native_decide` and `decide +native`, which are disallowed in mathlib. -/
 -- Note: this linter is purely for user information. Running `lean4checker` in CI catches *any*
 -- additional axioms that are introduced (not just `ofReduceBool`): the point of this check is to
 -- alert the user quickly, not to be airtight.
+public register_option linter.style.native : Bool := {
+  defValue := false
+  descr := "enable the native-evaluation linter"
+}
+
+/-- Deprecated in favor of `linter.style.native`. -/
+@[deprecated linter.style.native (since := "2026-08-28")]
 public register_option linter.style.nativeDecide : Bool := {
   defValue := false
-  descr := "enable the nativeDecide linter"
+  descr := "deprecated: use the `linter.style.native` option instead"
 }
 
 /-- The option `linter.style.maxHeartbeats` of the deprecated syntax linter flags usages of
@@ -202,6 +209,8 @@ replacement syntax. For each individual case, linting can be turned on or off se
 * `cases'`, superseded by `obtain`, `rcases` and `cases` (controlled by `linter.style.cases`)
 * `induction'`, superseded by `induction` (controlled by `linter.style.induction`)
 * `admit`, superseded by `sorry` (controlled by `linter.style.admit`)
+* `native_decide` and `decide +native`, which trust the Lean compiler
+  (controlled by `linter.style.native`)
 * `set_option maxHeartbeats`, should contain an explanatory comment
   (controlled by `linter.style.maxHeartbeats`)
 -/
@@ -211,7 +220,7 @@ def deprecatedSyntaxLinter : Linter where run stx := do
       getLinterValue linter.style.induction (← getLinterOptions) ||
       getLinterValue linter.style.admit (← getLinterOptions) ||
       getLinterValue linter.style.maxHeartbeats (← getLinterOptions) ||
-      getLinterValue linter.style.nativeDecide (← getLinterOptions) do
+      getLinterValue linter.style.native (← getLinterOptions) do
     return
   if (← MonadState.get).messages.hasErrors then
     return
@@ -229,7 +238,7 @@ def deprecatedSyntaxLinter : Linter where run stx := do
       | `Mathlib.Tactic.induction' => Linter.logLintIf linter.style.induction stx' msg
       | ``Lean.Parser.Tactic.tacticAdmit => Linter.logLintIf linter.style.admit stx' msg
       | ``Lean.Parser.Tactic.nativeDecide | ``Lean.Parser.Tactic.decide =>
-        Linter.logLintIf linter.style.nativeDecide stx' msg
+        Linter.logLintIf linter.style.native stx' msg
       | `MaxHeartbeats => Linter.logLintIf linter.style.maxHeartbeats stx' msg
       | _ => continue) stx
 

--- a/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
@@ -132,26 +132,22 @@ def getSetOptionMaxHeartbeatsComment : Syntax → Option (Name × Nat × Substri
         some default
   | _ => none
 
-/-- Whether a given piece of syntax represents a `decide` tactic call with the `native` option
-enabled. This may have false negatives for `decide (config := {<options>})` syntax. -/
-def isDecideNative (stx : Syntax ) : Bool :=
-  match stx with
-  | .node _ ``Lean.Parser.Tactic.decide args =>
-    -- The configuration passed to the tactic call.
-    let config := args[1]![0]
-    -- Check all configuration arguments in order to determine the final
-    -- toggling of the native decide option.
-    if let (.node _ _ config_args) := config then
-      let natives := config_args.filterMap (match ·[0] with
-        | `(Parser.Tactic.posConfigItem| +native) => some true
-        | `(Parser.Tactic.negConfigItem| -native) => some false
-        | `(Parser.Tactic.valConfigItem| (config := {native := true})) => some true
-        | `(Parser.Tactic.valConfigItem| (config := {native := false})) => some false
-        | _ => none)
-      natives.back? == some true
-    else
-      false
-  | _ => false
+/-- Whether the tactic syntax `stx` enables the `native` option. This may have false negatives for
+`tac (config := {<options>})` syntax. -/
+def usesNativeConfig (stx : Syntax) : Bool :=
+  let config := stx[1]![0]
+  if let .node _ _ configArgs := config then
+    let natives := configArgs.filterMap (match ·[0] with
+      | `(Parser.Tactic.posConfigItem| +native) => some true
+      | `(Parser.Tactic.negConfigItem| -native) => some false
+      | `(Parser.Tactic.valConfigItem| (native := true)) => some true
+      | `(Parser.Tactic.valConfigItem| (native := false)) => some false
+      | `(Parser.Tactic.valConfigItem| (config := {native := true})) => some true
+      | `(Parser.Tactic.valConfigItem| (config := {native := false})) => some false
+      | _ => none)
+    natives.back? == some true
+  else
+    false
 
 /-- `getDeprecatedSyntax t` returns all usages of deprecated syntax in the input syntax `t`. -/
 partial
@@ -176,7 +172,7 @@ def getDeprecatedSyntax : Syntax → Array (SyntaxNodeKind × Syntax × MessageD
         "The `admit` tactic is discouraged: \
          please strongly consider using the synonymous `sorry` instead.")
     | ``Lean.Parser.Tactic.decide =>
-      if isDecideNative stx then
+      if usesNativeConfig stx then
         rargs.push (kind, stx, "Using `decide +native` is not allowed in mathlib: \
         because it trusts the entire Lean compiler (not just the Lean kernel), \
         it could quite possibly be used to prove false.")

--- a/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedSyntaxLinter.lean
@@ -100,12 +100,6 @@ public register_option linter.style.nativeDecide : Bool := {
   descr := "deprecated: use the `linter.style.native` option instead"
 }
 
-/-- Return whether the native-evaluation linter is enabled, honoring its deprecated option name. -/
-private def getNativeLinterValue (options : LinterOptions) : Bool :=
-  match options.get? linter.style.native.name with
-  | some value => value
-  | none => options.get `linter.style.nativeDecide (getLinterValue linter.style.native options)
-
 /-- The option `linter.style.maxHeartbeats` of the deprecated syntax linter flags usages of
 `set_option <name-containing-maxHeartbeats> n in cmd` that do not add a comment explaining
 the reason for the modification of the `maxHeartbeats`.
@@ -209,6 +203,7 @@ def getDeprecatedSyntax : Syntax → Array (SyntaxNodeKind × Syntax × MessageD
     | _ => rargs
   | _ => default
 
+set_option linter.deprecated false in
 /-- The deprecated syntax linter flags usages of deprecated syntax and suggests
 replacement syntax. For each individual case, linting can be turned on or off separately.
 
@@ -227,7 +222,8 @@ def deprecatedSyntaxLinter : Linter where run stx := do
       getLinterValue linter.style.induction (← getLinterOptions) ||
       getLinterValue linter.style.admit (← getLinterOptions) ||
       getLinterValue linter.style.maxHeartbeats (← getLinterOptions) ||
-      getNativeLinterValue (← getLinterOptions) do
+      getLinterValue linter.style.native (← getLinterOptions) ||
+      getLinterValue linter.style.nativeDecide (← getLinterOptions) do
     return
   if (← MonadState.get).messages.hasErrors then
     return
@@ -244,9 +240,9 @@ def deprecatedSyntaxLinter : Linter where run stx := do
       | `Mathlib.Tactic.cases' => Linter.logLintIf linter.style.cases stx' msg
       | `Mathlib.Tactic.induction' => Linter.logLintIf linter.style.induction stx' msg
       | ``Lean.Parser.Tactic.tacticAdmit => Linter.logLintIf linter.style.admit stx' msg
-      | ``Lean.Parser.Tactic.nativeDecide | ``Lean.Parser.Tactic.decide =>
-        if getNativeLinterValue (← getLinterOptions) then
-          Linter.logLint linter.style.native stx' msg
+      | ``Lean.Parser.Tactic.nativeDecide | ``Lean.Parser.Tactic.decide => do
+        Linter.logLintIf linter.style.native stx' msg
+        Linter.logLintIf linter.style.nativeDecide stx' msg
       | `MaxHeartbeats => Linter.logLintIf linter.style.maxHeartbeats stx' msg
       | _ => continue) stx
 

--- a/MathlibTest/Linter/DeprecatedSyntax.lean
+++ b/MathlibTest/Linter/DeprecatedSyntax.lean
@@ -114,7 +114,7 @@ example : False := by admit
 set_option linter.style.native true
 
 /--
-warning: Using `native_decide` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
+warning: Using `native_decide` is not allowed in mathlib: because it trusts the entire Lean compiler (not just the Lean kernel), it could quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
@@ -122,7 +122,7 @@ Note: This linter can be disabled with `set_option linter.style.native false`
 example : 1 + 1 = 2 := by native_decide
 
 /--
-warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
+warning: Using `+native` is not allowed in mathlib: because it trusts the entire Lean compiler (not just the Lean kernel), it could quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
@@ -132,7 +132,7 @@ example : 1 + 1 = 2 := by decide +native
 example : 1 + 1 = 2 := by decide -native
 
 /--
-warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
+warning: Using `+native` is not allowed in mathlib: because it trusts the entire Lean compiler (not just the Lean kernel), it could quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
@@ -141,7 +141,7 @@ theorem foo : 1 + 1 = 2 := by decide -native +native
 -- We warn on `+native -native` even though this ends up using `-native`.
 -- This is an implementation convenience.
 /--
-warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
+warning: Using `+native` is not allowed in mathlib: because it trusts the entire Lean compiler (not just the Lean kernel), it could quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
@@ -149,7 +149,7 @@ Note: This linter can be disabled with `set_option linter.style.native false`
 example : 1 + 1 = 2 := by decide +native -native
 
 /--
-warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
+warning: Using `+native` is not allowed in mathlib: because it trusts the entire Lean compiler (not just the Lean kernel), it could quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
@@ -159,7 +159,7 @@ example : 1 + 1 = 2 := by decide (native := true)
 example : 1 + 1 = 2 := by decide (native := false)
 
 /--
-warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
+warning: Using `+native` is not allowed in mathlib: because it trusts the entire Lean compiler (not just the Lean kernel), it could quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
@@ -167,7 +167,7 @@ Note: This linter can be disabled with `set_option linter.style.native false`
 example : 1 + 1 = 2 := by decide (config := { native := true })
 example : 1 + 1 = 2 := by decide (config := { native := false })
 /--
-warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
+warning: Using `+native` is not allowed in mathlib: because it trusts the entire Lean compiler (not just the Lean kernel), it could quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/

--- a/MathlibTest/Linter/DeprecatedSyntax.lean
+++ b/MathlibTest/Linter/DeprecatedSyntax.lean
@@ -114,8 +114,7 @@ example : False := by admit
 set_option linter.style.native true
 
 /--
-warning: Using `native_decide` is not allowed in mathlib: because it trusts the entire Lean compiler
-(not just the Lean kernel), it could quite possibly be used to prove false.
+warning: Using `native_decide` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
@@ -123,9 +122,7 @@ Note: This linter can be disabled with `set_option linter.style.native false`
 example : 1 + 1 = 2 := by native_decide
 
 /--
-warning: Using `decide +native` is not allowed in mathlib:
-because it trusts the entire Lean compiler (not just the Lean kernel),
-it could quite possibly be used to prove false.
+warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
@@ -135,41 +132,36 @@ example : 1 + 1 = 2 := by decide +native
 example : 1 + 1 = 2 := by decide -native
 
 /--
-warning: Using `decide +native` is not allowed in mathlib:
-because it trusts the entire Lean compiler (not just the Lean kernel),
-it could quite possibly be used to prove false.
+warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
 #guard_msgs in
 theorem foo : 1 + 1 = 2 := by decide -native +native
-#guard_msgs in
-example : 1 + 1 = 2 := by decide +native -native
-
+-- We warn on `+native -native` even though this ends up using `-native`.
+-- This is an implementation convenience.
 /--
-warning: Using `decide +native` is not allowed in mathlib:
-because it trusts the entire Lean compiler (not just the Lean kernel),
-it could quite possibly be used to prove false.
+warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
 #guard_msgs in
-example : 1 + 1 = 2 := by decide +native -native +native +native
-#guard_msgs in
-example : 1 + 1 = 2 := by decide +native -native +kernel +native -kernel +native -native
+example : 1 + 1 = 2 := by decide +native -native
 
 /--
-warning: Using `decide +native` is not allowed in mathlib:
-because it trusts the entire Lean compiler (not just the Lean kernel),
-it could quite possibly be used to prove false.
+warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
 
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
 #guard_msgs in
 example : 1 + 1 = 2 := by decide (config := { native := true })
 example : 1 + 1 = 2 := by decide (config := { native := false })
--- Not handled yet: since mathlib hardly uses the old config syntax and this linter is purely
--- for user information (and not hard guarantees), we deem this acceptable.
+/--
+warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
+
+Note: This linter can be disabled with `set_option linter.style.native false`
+-/
+#guard_msgs in
 example : 1 + 1 = 2 := by decide (config := { native := true, kernel := false })
 
 set_option linter.style.native false

--- a/MathlibTest/Linter/DeprecatedSyntax.lean
+++ b/MathlibTest/Linter/DeprecatedSyntax.lean
@@ -111,13 +111,13 @@ warning: declaration uses `sorry`
 #guard_msgs in
 example : False := by admit
 
-set_option linter.style.nativeDecide true
+set_option linter.style.native true
 
 /--
 warning: Using `native_decide` is not allowed in mathlib: because it trusts the entire Lean compiler
 (not just the Lean kernel), it could quite possibly be used to prove false.
 
-Note: This linter can be disabled with `set_option linter.style.nativeDecide false`
+Note: This linter can be disabled with `set_option linter.style.native false`
 -/
 #guard_msgs in
 example : 1 + 1 = 2 := by native_decide
@@ -127,7 +127,7 @@ warning: Using `decide +native` is not allowed in mathlib:
 because it trusts the entire Lean compiler (not just the Lean kernel),
 it could quite possibly be used to prove false.
 
-Note: This linter can be disabled with `set_option linter.style.nativeDecide false`
+Note: This linter can be disabled with `set_option linter.style.native false`
 -/
 #guard_msgs in
 example : 1 + 1 = 2 := by decide +native
@@ -139,7 +139,7 @@ warning: Using `decide +native` is not allowed in mathlib:
 because it trusts the entire Lean compiler (not just the Lean kernel),
 it could quite possibly be used to prove false.
 
-Note: This linter can be disabled with `set_option linter.style.nativeDecide false`
+Note: This linter can be disabled with `set_option linter.style.native false`
 -/
 #guard_msgs in
 theorem foo : 1 + 1 = 2 := by decide -native +native
@@ -151,7 +151,7 @@ warning: Using `decide +native` is not allowed in mathlib:
 because it trusts the entire Lean compiler (not just the Lean kernel),
 it could quite possibly be used to prove false.
 
-Note: This linter can be disabled with `set_option linter.style.nativeDecide false`
+Note: This linter can be disabled with `set_option linter.style.native false`
 -/
 #guard_msgs in
 example : 1 + 1 = 2 := by decide +native -native +native +native
@@ -163,7 +163,7 @@ warning: Using `decide +native` is not allowed in mathlib:
 because it trusts the entire Lean compiler (not just the Lean kernel),
 it could quite possibly be used to prove false.
 
-Note: This linter can be disabled with `set_option linter.style.nativeDecide false`
+Note: This linter can be disabled with `set_option linter.style.native false`
 -/
 #guard_msgs in
 example : 1 + 1 = 2 := by decide (config := { native := true })
@@ -172,7 +172,7 @@ example : 1 + 1 = 2 := by decide (config := { native := false })
 -- for user information (and not hard guarantees), we deem this acceptable.
 example : 1 + 1 = 2 := by decide (config := { native := true, kernel := false })
 
-set_option linter.style.nativeDecide false
+set_option linter.style.native false
 
 set_option linter.style.maxHeartbeats true
 /--

--- a/MathlibTest/Linter/DeprecatedSyntax.lean
+++ b/MathlibTest/Linter/DeprecatedSyntax.lean
@@ -154,6 +154,16 @@ warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean co
 Note: This linter can be disabled with `set_option linter.style.native false`
 -/
 #guard_msgs in
+example : 1 + 1 = 2 := by decide (native := true)
+#guard_msgs in
+example : 1 + 1 = 2 := by decide (native := false)
+
+/--
+warning: Using `+native` is not allowed in mathlib: it trusts the entire Lean compiler (not just the Lean kernel), and it can quite possibly be used to prove `False`.
+
+Note: This linter can be disabled with `set_option linter.style.native false`
+-/
+#guard_msgs in
 example : 1 + 1 = 2 := by decide (config := { native := true })
 example : 1 + 1 = 2 := by decide (config := { native := false })
 /--


### PR DESCRIPTION
This refactors and renames the linter catching uses of `native_decide` and `native +decide` from `linter.style.nativeDecide` to `linter.style.native` for use in future tactics that also have a native compute option such as #42850. As such, this changes the behavior to lint any use of `+native`, `(native := true)`, or `(config := { ..., native := true, ...})`, not just configs that appear after `decide`.

This PR removes the logic that calculates whether `+native` is still active after multiple toggles (e.g. `decide +native -native`, which we now warn on) for the sake of a cleaner implementation, but we assume that this behavior is seldom relied on.