### PR TITLE
feat(Order/Basic): relation properties of complement relations

### DIFF
--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -33,11 +33,6 @@ section General
 
 variable {α β : Type*} {r r₁ r₂ : α → α → Prop} {r' : β → β → Prop} {s t : Set α} {a b : α}
 
-protected instance Std.Symm.compl [Std.Symm r] : Std.Symm rᶜ where
-  symm a b hr hr' := hr <| symm b a hr'
-
-@[deprecated (since := "2026-06-10")] alias Symmetric.compl := Std.Symm.compl
-
 /-- An antichain is a set such that no two distinct elements are related. -/
 def IsAntichain (r : α → α → Prop) (s : Set α) : Prop :=
   s.Pairwise rᶜ

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -527,11 +527,64 @@ theorem Pi.compl_apply [∀ i, Compl (π i)] (x : ∀ i, π i) (i : ι) :
     xᶜ i = (x i)ᶜ :=
   rfl
 
-instance Std.Irrefl.compl (r : α → α → Prop) [Std.Irrefl r] : Std.Refl rᶜ :=
-  ⟨@irrefl α r _⟩
+section
 
-instance Std.Refl.compl (r : α → α → Prop) [Std.Refl r] : Std.Irrefl rᶜ :=
-  ⟨fun a ↦ not_not_intro (refl a)⟩
+variable (r s : α → α → Prop)
+
+protected instance Std.Symm.compl [Std.Symm r] : Std.Symm rᶜ where
+  symm a b hr hr' := hr <| symm b a hr'
+
+@[deprecated (since := "2026-06-10")] alias Symmetric.compl := Std.Symm.compl
+
+protected instance Std.Refl.compl [Std.Refl r] : Std.Irrefl rᶜ where
+  irrefl a := not_not_intro <| refl a
+
+protected instance Std.Irrefl.compl [Std.Irrefl r] : Std.Refl rᶜ where
+  refl := irrefl
+
+instance [Std.Asymm r] : Std.Total rᶜ :=
+  Std.Asymm.total_not
+
+instance [Std.Total r] : Std.Asymm rᶜ where
+  asymm a b := total_of r a b |>.elim
+
+instance [Std.Antisymm r] : Std.Trichotomous rᶜ where
+  trichotomous _ _ hab hba := antisymm_of r (by_contra hab) (by_contra hba)
+
+instance [Std.Trichotomous r] : Std.Antisymm rᶜ where
+  antisymm := Std.Trichotomous.trichotomous
+
+@[simp]
+theorem Std.Refl.compl_iff : Std.Refl rᶜ ↔ Std.Irrefl r :=
+  have : rᶜᶜ = r := by ext; exact not_not
+  ⟨fun _ ↦ this ▸ inferInstance, fun _ ↦ inferInstance⟩
+
+@[simp]
+theorem Std.Irrefl.compl_iff : Std.Irrefl rᶜ ↔ Std.Refl r :=
+  have : rᶜᶜ = r := by ext; exact not_not
+  ⟨fun _ ↦ this ▸ inferInstance, fun _ ↦ inferInstance⟩
+
+@[simp]
+theorem Std.Total.compl_iff : Std.Total rᶜ ↔ Std.Asymm r :=
+  have : rᶜᶜ = r := by ext; exact not_not
+  ⟨fun _ ↦ this ▸ inferInstance, fun _ ↦ inferInstance⟩
+
+@[simp]
+theorem Std.Asymm.compl_iff : Std.Asymm rᶜ ↔ Std.Total r :=
+  have : rᶜᶜ = r := by ext; exact not_not
+  ⟨fun _ ↦ this ▸ inferInstance, fun _ ↦ inferInstance⟩
+
+@[simp]
+theorem Std.Trichotomous.compl_iff : Std.Trichotomous rᶜ ↔ Std.Antisymm r :=
+  have : rᶜᶜ = r := by ext; exact not_not
+  ⟨fun _ ↦ this ▸ inferInstance, fun _ ↦ inferInstance⟩
+
+@[simp]
+theorem Std.Antisymm.compl_iff : Std.Antisymm rᶜ ↔ Std.Trichotomous r :=
+  have : rᶜᶜ = r := by ext; exact not_not
+  ⟨fun _ ↦ this ▸ inferInstance, fun _ ↦ inferInstance⟩
+
+end
 
 theorem compl_lt [LinearOrder α] : (· < · : α → α → _)ᶜ = (· ≥ ·) := by simp [compl]
 theorem compl_le [LinearOrder α] : (· ≤ · : α → α → _)ᶜ = (· > ·) := by simp [compl]


### PR DESCRIPTION
The complement turns `Refl` into `Irrefl`, `Total` into `Asymm`, and `Trichotomous` into `Antisymm`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
