### PR TITLE
fix(Tactic/FastInstance): telescope over instance families

### DIFF
--- a/Mathlib/Tactic/FastInstance.lean
+++ b/Mathlib/Tactic/FastInstance.lean
@@ -46,6 +46,10 @@ is `withReducible` with some exceptions.
 -/
 partial def makeFastInstance (inst expectedType : Expr) (root := true) (trace : Array Name := #[]) :
     MetaM Expr := withReducible do
+  -- Telescope since it might be a family of instances.
+  forallTelescopeReducing expectedType fun xs expectedType => do
+  mkLambdaFVars xs <| ← withNewMCtxDepth <| do
+  let inst ← whnfI <| mkAppN inst xs
   withTraceNode `Elab.fast_instance (fun _ => return m!"type: {expectedType}") do
   let some className ← isClass? expectedType
     | error trace m!"Can only be used for classes, but type is{indentExpr expectedType}"
@@ -138,16 +142,14 @@ public def elabFastInstance : TermElab
     let inst ← withSynthesize <| elabTerm arg expectedType?
     let expectedType ← expectedType?.getDM (inferType inst)
     try
-      -- Telescope since it might be a family of instances.
-      forallTelescopeReducing expectedType fun xs expectedType => do
-        mkLambdaFVars xs <| ← withNewMCtxDepth <| makeFastInstance inst expectedType
+      makeFastInstance inst expectedType
     catch e =>
       logException e
       return inst
   | _, _ => Elab.throwUnsupportedSyntax
 
-/-- `inferInstanceAs% A` is shorthand for `fast_instance% inferInstanceAs A`.
-This is preferred over `inferInstanceAs` when the instance can be reduced to
+/-- `inferInstanceAs% A` is shorthand for `fast_instance% _root_.inferInstanceAs A`.
+This is preferred over the `inferInstanceAs` elaborator when the instance can be reduced to
 constructor applications. In that case, the parameters of the constructors will be filled in
 using the expected type, so that the instance will unfold nicely during unification. -/
 macro "inferInstanceAs% " source:term : term =>

--- a/Mathlib/Tactic/FastInstance.lean
+++ b/Mathlib/Tactic/FastInstance.lean
@@ -148,7 +148,7 @@ public def elabFastInstance : TermElab
   | _, _ => Elab.throwUnsupportedSyntax
 
 /-- `inferInstanceAs% A` is shorthand for `fast_instance% _root_.inferInstanceAs A`.
-This is preferred over the `inferInstanceAs` elaborator when the instance can be reduced to
+This is preferred over `_root_.inferInstanceAs` when the instance can be reduced to
 constructor applications. In that case, the parameters of the constructors will be filled in
 using the expected type, so that the instance will unfold nicely during unification. -/
 macro "inferInstanceAs% " source:term : term =>

--- a/Mathlib/Tactic/FastInstance.lean
+++ b/Mathlib/Tactic/FastInstance.lean
@@ -47,8 +47,7 @@ is `withReducible` with some exceptions.
 partial def makeFastInstance (inst expectedType : Expr) (root := true) (trace : Array Name := #[]) :
     MetaM Expr := withReducible do
   -- Telescope since it might be a family of instances.
-  forallTelescopeReducing expectedType fun xs expectedType => do
-  mkLambdaFVars xs <| ← withNewMCtxDepth <| do
+  forallTelescopeReducing expectedType fun xs expectedType => do mkLambdaFVars xs <| ← do
   let inst ← whnfI <| mkAppN inst xs
   withTraceNode `Elab.fast_instance (fun _ => return m!"type: {expectedType}") do
   let some className ← isClass? expectedType
@@ -142,7 +141,7 @@ public def elabFastInstance : TermElab
     let inst ← withSynthesize <| elabTerm arg expectedType?
     let expectedType ← expectedType?.getDM (inferType inst)
     try
-      makeFastInstance inst expectedType
+      withNewMCtxDepth <| makeFastInstance inst expectedType
     catch e =>
       logException e
       return inst

--- a/Mathlib/Tactic/FastInstance.lean
+++ b/Mathlib/Tactic/FastInstance.lean
@@ -73,7 +73,7 @@ partial def makeFastInstance (inst expectedType : Expr) (root := true) (trace : 
         is not defeq to inferred instance{indentExpr new}"
   -- Otherwise, try to reduce it to a constructor.
   else
-    (← whnfI inst).withApp fun f args => do
+    inst.withApp fun f args => do
     let error' (m : MessageData) : MetaM Expr := do
       if isStructure (← getEnv) className then
         error trace m

--- a/MathlibTest/FastInstance.lean
+++ b/MathlibTest/FastInstance.lean
@@ -82,7 +82,7 @@ set_option pp.explicit true in
 /-!
 Non-defeq error
 -/
-instance : Mul Nat := ⟨(· * · )⟩
+instance : Mul Nat := ⟨(· * ·)⟩
 
 /--
 warning: An instance of `Mul Nat` already exists.
@@ -143,6 +143,137 @@ info: @Dec.mk It dec2 : Dec It
 #guard_msgs in
 set_option pp.explicit true in
 #check fast_instance% { dec := dec2 : Dec It }
+
+/-! The provided instance does not reduce to a constructor application but it is defeq to what
+`inferInstance` would synthesize, so we allow it. -/
+/--
+info: let this := dec2;
+@Dec.mk It this : Dec It
+-/
+#guard_msgs in
+set_option pp.explicit true in
+#check let := dec2; fast_instance% { dec := dec2 : Dec It }
+
+class DecEq (α : Type*) where
+  [decEq : DecidableEq α]
+
+def UnitAlias : Type :=
+  Unit
+
+/-! The root is an instance family. -/
+example : DecidableEq UnitAlias :=
+  fast_instance% fun _ _ ↦ isTrue rfl
+
+/-! The root is an instance family, and the instances do not reduce to a constructor application. -/
+/--
+error: Provided instance does not reduce to a constructor application
+  decidable_of_iff (() = ()) ⋯
+Reduces to an application of decidable_of_iff.
+
+This instance is not a structure and not canonical. Use a separate 'instance' command to define it.
+
+Use `set_option trace.Elab.fast_instance true` to analyze the error.
+
+Trace of fields visited: []
+-/
+#guard_msgs in
+example : DecidableEq UnitAlias :=
+  fast_instance% fun _ _ ↦ decidable_of_iff (() = ()) .rfl
+
+/-! The root is an instance family, and the instances do not reduce to a constructor application,
+but are equal defeq to what `inferInstance` would synthesize, so we allow it with a warning. -/
+/--
+warning: An instance of `Decidable (a = b)` already exists.
+Please use `inferInstance` instead of `fast_instance%`
+
+Note: This linter can be disabled with `set_option linter.fast_instance_existing false`
+-/
+#guard_msgs in
+example : DecidableEq UnitAlias :=
+  let (a b : UnitAlias) : Decidable (a = b) := isTrue rfl
+  fast_instance% fun _ _ ↦ inferInstance
+
+/-! A nested instance field contains an instance family. -/
+example : DecEq UnitAlias :=
+  fast_instance% { decEq := fun _ _ ↦ isTrue rfl }
+
+/-! A nested instance field contains an instance family, and the instances do not reduce to a
+constructor application. -/
+/--
+error: Provided instance does not reduce to a constructor application
+  sorry
+Reduces to an application of sorryAx.
+
+This instance is not a structure and not canonical. Use a separate 'instance' command to define it.
+
+Use `set_option trace.Elab.fast_instance true` to analyze the error.
+
+Trace of fields visited: [testing.DecEq.decEq]
+-/
+#guard_msgs in
+example : DecEq α :=
+  fast_instance% { decEq := fun a b ↦ sorry }
+
+/- A nested instance field contains an instance family, and the instances do not reduce to a
+constructor application, it is defeq to what `inferInstance` would synthesize so we allow it. -/
+#guard_msgs (drop warning) in
+example : DecEq α :=
+  let : DecidableEq α := fun a b ↦ sorry
+  fast_instance% { decEq := this : DecEq α }
+
+/-! The root is not a class. -/
+/--
+error: Can only be used for classes, but type is
+  Unit
+
+Use `set_option trace.Elab.fast_instance true` to analyze the error.
+
+Trace of fields visited: []
+-/
+#guard_msgs in
+example : Unit := fast_instance% ()
+
+class UnitClass where
+  [unit : Unit]
+
+/-! A nested instance field is not a class. -/
+/--
+error: Can only be used for classes, but type is
+  Unit
+
+Use `set_option trace.Elab.fast_instance true` to analyze the error.
+
+Trace of fields visited: [testing.UnitClass.unit]
+-/
+#guard_msgs in
+example : UnitClass := fast_instance% { unit := () }
+
+/-! The root is a family but not of classes. -/
+/--
+error: Can only be used for classes, but type is
+  Unit
+
+Use `set_option trace.Elab.fast_instance true` to analyze the error.
+
+Trace of fields visited: []
+-/
+#guard_msgs in
+example : Unit → Unit := fast_instance% fun _ ↦ ()
+
+class Func where
+  [func : Unit → Unit]
+
+/-! A nested instance field is a family but not of classes. -/
+/--
+error: Can only be used for classes, but type is
+  Unit
+
+Use `set_option trace.Elab.fast_instance true` to analyze the error.
+
+Trace of fields visited: [testing.Func.func]
+-/
+#guard_msgs in
+example : Func := fast_instance% { func := fun _ ↦ () }
 
 /-!
 Checking that proof fields whose types already match at instances transparency


### PR DESCRIPTION
Fix `fast_instance%` to support for instance families (e.g. `Π i, Group (G i)` and `DecidableEq α`) (regression since #36420), both for the top-level instance and nested instances.

---
The `forallTelescopeReducing` only telescoped the `expectedType` but not `inst`; we have to `mkAppN` and give it the telescope metavariables.
Also moved the `forallTelescopeReducing` call to inside the function to restore support for nested instance families as well.

Added a bunch of tests, and also tweaked the docstring of `inferInstanceAs%` since it was inaccurate after Lean shipped a new `inferInstanceAs` elaborator (which wraps instances in auxiliary semireducible defs).

[#mathlib4 > fast_instance% recursion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/fast_instance.25.20recursion/with/619696862)

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
