### PR TITLE
[Merged by Bors] - feat(NumberTheory/Harmonic): pointwise inv_riemannZeta_eq_sub_mul

### DIFF
--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -649,9 +649,6 @@ lemma log_deriv_riemannZeta_add_inv_sub_bounded :
     =O[𝓝[≠] 1] (fun _ ↦ (1 : ℂ)) :=
   (isBigO_const_one ..).sub_iff_left.mp log_deriv_riemannZeta_add_inv_sub_sub_isLittleO.isBigO
 
-/-- The reciprocal of the Riemann zeta function expressed via the entire function `riemannZeta₁`,
-valid at every `s ≠ 1`.  This is the pointwise form of `inv_riemannZeta_eq_sub_mul`, which holds
-eventually near `s = 1`. -/
 lemma inv_riemannZeta_eq_sub_mul_of_ne_one {s : ℂ} (hs : s ≠ 1) :
     (riemannZeta s)⁻¹ = (s - 1) * (riemannZeta₁ s)⁻¹ := by
   rw [riemannZeta_eq_inv_sub_mul hs, mul_inv, inv_inv]

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -649,11 +649,17 @@ lemma log_deriv_riemannZeta_add_inv_sub_bounded :
     =O[𝓝[≠] 1] (fun _ ↦ (1 : ℂ)) :=
   (isBigO_const_one ..).sub_iff_left.mp log_deriv_riemannZeta_add_inv_sub_sub_isLittleO.isBigO
 
+/-- The reciprocal of the Riemann zeta function expressed via the entire function `riemannZeta₁`,
+valid at every `s ≠ 1`.  This is the pointwise form of `inv_riemannZeta_eq_sub_mul`, which holds
+eventually near `s = 1`. -/
+lemma inv_riemannZeta_eq_sub_mul_of_ne_one {s : ℂ} (hs : s ≠ 1) :
+    (riemannZeta s)⁻¹ = (s - 1) * (riemannZeta₁ s)⁻¹ := by
+  rw [riemannZeta_eq_inv_sub_mul hs, mul_inv, inv_inv]
+
 lemma inv_riemannZeta_eq_sub_mul :
     ∀ᶠ s in 𝓝[≠] 1, (riemannZeta s)⁻¹ = (s - 1) * (riemannZeta₁ s)⁻¹ := by
-  filter_upwards [eventually_mem_nhdsWithin,
-    riemannZeta₁_ne_zero_of_near_one.filter_mono nhdsWithin_le_nhds] with s hs
-  simp [riemannZeta_eq_inv_sub_mul hs, field]
+  filter_upwards [eventually_mem_nhdsWithin] with s hs
+  exact inv_riemannZeta_eq_sub_mul_of_ne_one hs
 
 lemma inv_riemannZeta_sub_sub_isBigO :
     (fun s ↦ (riemannZeta s)⁻¹ - (s - 1)) =O[𝓝[≠] 1] (fun s ↦ (s - 1) ^ 2) := by


### PR DESCRIPTION
Add `inv_riemannZeta_eq_sub_mul_of_ne_one`, the pointwise identity `(riemannZeta s)^{-1} = (s - 1) * (riemannZeta_1 s)^{-1}`, valid at every `s ≠ 1` thanks to junk values.

The existing `inv_riemannZeta_eq_sub_mul`, which asserts this eventually on the punctured neighbourhood of 1, becomes a two-line corollary.  (The previous proof, also contributed by myself, was overly cautious about avoiding junk values in a manner that was unnecessary.)

---

This PR will be used in a forthcoming PR on the prime number theorem (this particular lemma is used to prove a Mobius function version of the lemma).

The code here was initially generated by an AI but reviewed by the author, though in this case I did not make any further edits to the code (beyond deleting a verbose docstring) as it was already quite short and streamlined already.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
