### PR TITLE
feat(Geometry/Convex): ordered convex spaces

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4720,6 +4720,7 @@ public import Mathlib.Geometry.Convex.ConvexSpace.CompactSpaceStdSimplex
 public import Mathlib.Geometry.Convex.ConvexSpace.Defs
 public import Mathlib.Geometry.Convex.ConvexSpace.Module
 public import Mathlib.Geometry.Convex.ConvexSpace.ModuleTopology
+public import Mathlib.Geometry.Convex.ConvexSpace.Order
 public import Mathlib.Geometry.Convex.ConvexSpace.PathConnectedSpaceStdSimplex
 public import Mathlib.Geometry.Convex.ConvexSpace.Prod
 public import Mathlib.Geometry.Convex.ConvexSpace.Topology

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -10,6 +10,7 @@ public import Mathlib.Algebra.Order.Monoid.Unbundled.Defs
 public import Mathlib.Algebra.Order.IsBotOne
 public import Mathlib.Data.Ordering.Basic
 public import Mathlib.Order.MinMax
+public import Mathlib.Tactic.ByContra
 public import Mathlib.Tactic.Contrapose
 public import Mathlib.Tactic.Use
 public import Mathlib.Tactic.GRewrite
@@ -239,6 +240,12 @@ instance [MulRightReflectLE α] : IsRightCancelMul α where
 alias add_right_cancel'' := add_right_cancel
 @[to_additive existing, deprecated (since := "2026-03-14")]
 alias mul_right_cancel'' := mul_right_cancel
+
+@[to_additive] lemma le_iff_ge_of_mul_eq_mul [MulLeftMono α] [MulLeftReflectLE α]
+    [MulRightMono α] [MulRightReflectLE α] {a₁ a₂ b₁ b₂ : α} (hab : a₁ * b₁ = a₂ * b₂) :
+    a₁ ≤ a₂ ↔ b₂ ≤ b₁ where
+  mp ha := by grw [← mul_le_mul_iff_left, hab, ha]
+  mpr hb := by grw [← mul_le_mul_iff_right, hab, hb]
 
 @[to_additive] lemma mul_le_mul_iff_of_ge [MulLeftStrictMono α]
     [MulRightStrictMono α] {a₁ a₂ b₁ b₂ : α} (ha : a₁ ≤ a₂) (hb : b₁ ≤ b₂) :

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -493,6 +493,10 @@ theorem mapDomain_injOn (S : Set α) {f : α → β} (hf : Set.InjOn f S) :
 theorem equivMapDomain_eq_mapDomain {M} [AddCommMonoid M] (f : α ≃ β) (l : α →₀ M) :
     equivMapDomain f l = mapDomain f l := by ext x; simp
 
+lemma mapDomain_apply_eq_sum [DecidableEq β] (f : α → β) (x : α →₀ M) (b : β) :
+    x.mapDomain f b = ∑ i ∈ x.support with f i = b, x i := by
+  simp [mapDomain, sum, single_apply, Finset.sum_ite]
+
 end MapDomain
 
 /-! ### Declarations about `comapDomain` -/
@@ -729,6 +733,18 @@ variable [AddCommMonoid M]
 @[simp]
 lemma filter_add_filter_not (f : α →₀ M) (p : α → Prop) [DecidablePred p] :
     f.filter p + f.filter (¬ p ·) = f := by ext; simp [filter_apply]; split <;> simp
+
+@[simp]
+lemma filter_mapDomain (v : α →₀ M) (f : α → β) (p : β → Prop) [DecidablePred p] :
+    (v.mapDomain f).filter p = (v.filter fun a ↦ p (f a)).mapDomain f := by
+  classical
+  ext b
+  transitivity ∑ a ∈ v.support with f a = b, if p b then v a else 0
+  · simp [filter_apply, mapDomain_apply_eq_sum]
+  simp only [filter_apply, mapDomain_apply_eq_sum, support_filter, Finset.filter_filter,
+    Finset.sum_ite, Finset.sum_const_zero, add_zero]
+  congr! 2 with a
+  grind
 
 @[deprecated (since := "2026-05-04")] alias filter_pos_add_filter_neg := filter_add_filter_not
 
@@ -1430,10 +1446,6 @@ theorem mapDomain_support_of_subsingletonAddUnits [DecidableEq β] [AddCommMonoi
   refine ⟨?_, fun ⟨i, i_in, hi⟩ ↦ ?_⟩
   · simpa [mapDomain, sum, single_apply] using fun i h h' _ ↦ ⟨i, h, h'⟩
   simpa [mapDomain, sum, ← hi, single_apply] using ⟨i, by simp [mem_support_iff.mp i_in]⟩
-
-theorem mapDomain_apply_eq_sum [DecidableEq β] [AddCommMonoid M] (f : α → β)
-    (x : α →₀ M) {a : α} : (x.mapDomain f) (f a) = ∑ i ∈ x.support with f i = f a, x i := by
-  simp [mapDomain, sum, single_apply, Finset.sum_ite]
 
 theorem mapDomain_apply_eq_zero_iff_of_subsingletonAddUnits [AddCommMonoid M] (f : α → β)
     [Subsingleton (AddUnits M)] (x : α →₀ M) : mapDomain (M := M) f x = 0 ↔ x = 0 := by

--- a/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
@@ -198,10 +198,11 @@ lemma map_duple {s t : R} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) (x y : X
     (duple x y hs ht h).map f = duple (f x) (f y) hs ht h := by
   ext; simp [mapDomain_add]
 
-@[simp]
+@[to_fun (attr := simp) map_fun_id]
 lemma map_id (f : StdSimplex R X) : f.map id = f := by
   ext; simp
 
+@[to_fun map_fun_id']
 lemma map_id' : map (R := R) (id : X → X) = id := by aesop
 
 lemma map_comp (f : StdSimplex R X) (g₁ : X → Y) (g₂ : Y → Z) :

--- a/Mathlib/Geometry/Convex/ConvexSpace/Order.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Order.lean
@@ -1,0 +1,242 @@
+/-
+Copyright (c) 2026 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+module
+
+public import Mathlib.Geometry.Convex.ConvexSpace.Defs
+
+/-!
+# Ordered convex spaces
+
+This file orders the standard simplex over a partial order by stochastic dominance and defines
+ordered convex spaces, namely convex spaces over a partial order in which taking convex
+combinations is monotone.
+
+## Main declarations
+
+* `Convexity.StdSimplex.upperMass`: The upper mass function of a distribution `w` over a partial
+  order, namely the map sending `x` to the total weight `w` puts on `{y | x ≤ y}`.
+* `Convexity.StdSimplex.instPartialOrder`: The stochastic dominance order on `StdSimplex R X`,
+  namely the order induced by the pointwise order on upper mass functions.
+* `Convexity.IsOrderedConvexSpace`: Typeclass for a convex space over a partial order in which
+  `sConvexComb` is monotone for stochastic dominance.
+-/
+
+open Finsupp
+
+public section
+
+namespace Convexity
+variable {I R X : Type*}
+
+namespace StdSimplex
+section PartialOrder
+variable [Semiring R] [PartialOrder R] [PartialOrder X] {w w₁ w₂ : StdSimplex R X} {x y : X}
+
+variable (w) in
+/-- The upper mass function of a distribution `w` over a partial order: `w.upperMass x` is the
+total weight that `w` puts on the up-set of `x`.
+
+This is the (complementary) cumulative distribution function of `w`, and it determines `w`.
+See `StdSimplex.upperMass_injective`. -/
+noncomputable def upperMass (x : X) : R :=
+  open scoped Classical in (w.weights.filter (x ≤ ·)).sum fun _y r ↦ r
+
+lemma upperMass_eq_finsuppSum [DecidableLE X] (w : StdSimplex R X) (x : X) :
+    w.upperMass x = (w.weights.filter (x ≤ ·)).sum fun _y r ↦ r := by rw [upperMass]; congr!
+
+lemma upperMass_eq_sum [DecidableLE X] (w : StdSimplex R X) (x : X) :
+    w.upperMass x = ∑ y ∈ w.weights.support with x ≤ y, w.weights y := by
+  rw [upperMass_eq_finsuppSum, sum_filter_index, support_filter]
+
+/-- If no point of the support of `w` lies strictly between `x` and `y`, then the mass `w` puts
+above `x` is the mass it puts on `x` plus the mass it puts above `y`. -/
+lemma upperMass_eq_weights_add_upperMass (hxy : x < y) (hm : ∀ z, w.weights z ≠ 0 → x < z → y ≤ z) :
+    w.upperMass x = w.weights x + w.upperMass y := by
+  classical
+  have : w.weights.filter (x ≤ ·) = .single x (w.weights x) + w.weights.filter (y ≤ ·) := by
+    ext z; simp [filter_apply]; grind [lt_of_le_of_ne]
+  simp [upperMass, this, sum_add_index']
+
+open scoped Classical in
+/-- The mass `w` puts above `x` is the mass it puts on `x` plus the mass it puts strictly above
+`x`. -/
+lemma upperMass_eq_weights_add_sum (w : StdSimplex R X) (x : X) :
+    w.upperMass x = w.weights x + ∑ y ∈ w.weights.support with x < y, w.weights y := by
+  have : w.weights.filter (x ≤ ·) = .single x (w.weights x) + w.weights.filter (x < ·) := by
+    ext z; simp [filter_apply]; grind [lt_of_le_of_ne]
+  simp [upperMass, this, sum_add_index', sum_filter_index]
+
+/-- If no point of the support of `w` lies strictly above `x`, then the mass `w` puts above `x` is
+exactly the mass it puts on `x`. -/
+lemma upperMass_eq_weights (hx : ∀ y, w.weights y ≠ 0 → ¬ x < y) : w.upperMass x = w.weights x := by
+  classical
+  have : w.weights.filter (x ≤ ·) = .single x (w.weights x) := by
+    ext y; simp [filter_apply]; grind [lt_of_le_of_ne]
+  rw [upperMass, this, sum_single_index rfl]
+
+@[simp] lemma upperMass_top [OrderTop X] (w : StdSimplex R X) : w.upperMass ⊤ = w.weights ⊤ :=
+  upperMass_eq_weights fun _ _ ↦ not_top_lt
+
+variable [IsStrictOrderedRing R]
+
+@[simp] lemma upperMass_nonneg (w : StdSimplex R X) (x : X) : 0 ≤ w.upperMass x := by
+  classical rw [upperMass_eq_sum]; exact Finset.sum_nonneg fun _ _ ↦ w.weights_nonneg _
+
+@[simp] lemma upperMass_single [DecidableLE X] (x y : X) :
+    (single x : StdSimplex R X).upperMass y = if y ≤ x then 1 else 0 := by
+  rw [upperMass_eq_sum, weights_single]; split <;> simp [Finset.filter_singleton, *]
+
+omit [IsStrictOrderedRing R] in
+lemma upperMass_add_sum_not [DecidableLE X] (w : StdSimplex R X) (x : X) :
+    w.upperMass x + ∑ y ∈ w.weights.support with ¬ x ≤ y, w.weights y = 1 := by
+  rw [upperMass_eq_sum, Finset.sum_filter_add_sum_filter_not]
+  simpa [Finsupp.sum] using w.total
+
+@[simp] lemma upperMass_le_one (w : StdSimplex R X) (x : X) : w.upperMass x ≤ 1 := by
+  classical
+  rw [← upperMass_add_sum_not w x]
+  exact le_add_of_nonneg_right (Finset.sum_nonneg fun _ _ ↦ w.weights_nonneg _)
+
+/-- `w` puts all of its mass above `x` exactly when its support lies above `x`. -/
+lemma upperMass_eq_one_iff : w.upperMass x = 1 ↔ ∀ y, w.weights y ≠ 0 → x ≤ y := by
+  classical
+  have h := upperMass_add_sum_not w x
+  refine ⟨fun h1 y hy ↦ ?_, fun hall ↦ ?_⟩
+  · rw [h1] at h
+    have hz := add_left_cancel (h.trans (add_zero 1).symm)
+    by_contra! hxy
+    exact hy <| (Finset.sum_eq_zero_iff_of_nonneg fun _ _ ↦ w.weights_nonneg _).1 hz y <| by
+      simp [hy, hxy]
+  · rwa [Finset.sum_eq_zero fun y ↦ by simp +contextual [hall], add_zero] at h
+
+/-- A distribution over a partial order is determined by its upper mass function. -/
+lemma upperMass_injective : (upperMass : StdSimplex R X → X → R).Injective := by
+  classical
+  rintro w₁ w₂ h
+  ext x
+  set S := w₁.weights.support ∪ w₂.weights.support with hS
+  -- The mass `w` puts above `x` is the mass it puts on `x` plus the mass it puts on the elements
+  -- of `S` strictly above `x`.
+  have key (w : StdSimplex R X) (hw : w.weights.support ⊆ S) (x : X) :
+      w.upperMass x = w.weights x + ∑ y ∈ S with x < y, w.weights y := by
+    rw [upperMass_eq_weights_add_sum]
+    congr 1
+    exact Finset.sum_subset (by gcongr) <| by simp_all
+  have key' (x : X) :
+      w₁.weights x + ∑ y ∈ S with x < y, w₁.weights y
+        = w₂.weights x + ∑ y ∈ S with x < y, w₂.weights y :=
+    (key w₁ Finset.subset_union_left x).symm.trans
+      ((congrFun h x).trans (key w₂ Finset.subset_union_right x))
+  -- We prove that `w₁` and `w₂` agree at `x` by induction on the number of elements of `S` lying
+  -- strictly above `x`.
+  have main n x (hx : Finset.card {y ∈ S | x < y} ≤ n) : w₁.weights x = w₂.weights x := by
+    induction n generalizing x with
+    | zero =>
+      have h₀ : {y ∈ S | x < y} = ∅ := Finset.card_eq_zero.1 (Nat.le_zero.1 hx)
+      simpa [h₀] using key' x
+    | succ n ih =>
+      have hsum : ∑ y ∈ S with x < y, w₁.weights y = ∑ y ∈ S with x < y, w₂.weights y := by
+        congr! 1 with y hy
+        refine ih y ?_
+        simp only [Finset.mem_filter] at hy
+        -- The elements of `S` strictly above `y` are strictly above `x`, but `y` isn't
+        have hss : {z ∈ S | y < z} ⊂ {z ∈ S | x < z} := by
+          refine (Finset.ssubset_iff_of_subset fun z hz ↦ ?_).2 ⟨y, by simp [hy.1, hy.2], by simp⟩
+          simp only [Finset.mem_filter] at hz ⊢
+          exact ⟨hz.1, hy.2.trans hz.2⟩
+        exact Nat.lt_succ_iff.1 <| (Finset.card_lt_card hss).trans_le hx
+      exact add_right_cancel (hsum ▸ key' x)
+  exact main _ x le_rfl
+
+/-- The standard simplex indexed by a partial order is partially ordered by stochastic dominance.
+`w₁ ≤ w₂` iff on each lower set the weight of `w₁` is less than that of `w₂`. -/
+noncomputable instance instPartialOrder : PartialOrder (StdSimplex R X) :=
+  .lift upperMass upperMass_injective
+
+lemma le_def : w₁ ≤ w₂ ↔ ∀ x, w₁.upperMass x ≤ w₂.upperMass x := .rfl
+
+@[gcongr] alias ⟨upperMass_le_upperMass, _⟩ := le_def
+
+lemma forall_le_of_le (h : w₁ ≤ w₂) (h₁ : ∀ ⦃y⦄, w₁.weights y ≠ 0 → x ≤ y) :
+    ∀ ⦃y⦄, w₂.weights y ≠ 0 → x ≤ y := by
+  rw [← upperMass_eq_one_iff] at h₁ ⊢
+  exact le_antisymm (upperMass_le_one _ _) (h₁ ▸ le_def.1 h x)
+
+@[simp] lemma upperMass_map [DecidableLE X] (w : StdSimplex R I) (f : I → X) (x : X) :
+    (w.map f).upperMass x = (w.weights.filter fun i ↦ x ≤ f i).sum fun _i r ↦ r := by
+  simp [upperMass_eq_finsuppSum, sum_mapDomain_index]
+
+lemma monotone_map {w : StdSimplex R I} : Monotone (w.map : (I → X) → StdSimplex R X) := by
+  classical
+  rintro f g hfg x
+  rw [upperMass_map, upperMass_map, sum_filter_index, sum_filter_index, support_filter,
+    support_filter]
+  gcongr
+  · simp
+  · exact hfg _
+
+@[gcongr] lemma map_le_map {w : StdSimplex R I} {f g : I → X} (hfg : f ≤ g) : w.map f ≤ w.map g :=
+  monotone_map hfg
+
+@[simp] lemma single_le_single_iff : (single x : StdSimplex R X) ≤ single y ↔ x ≤ y := by
+  classical
+  refine ⟨fun h ↦ ?_, fun hxm ↦ le_def.2 fun z ↦ ?_⟩
+  · have hx := le_def.1 h x
+    simp only [upperMass_single, le_refl, ite_true] at hx
+    by_contra hxm
+    rw [ite_eq_right_iff.2 fun h ↦ absurd h hxm] at hx
+    exact absurd hx zero_lt_one.not_ge
+  · simp only [upperMass_single]
+    split_ifs with hzx hzm hzm
+    · exact le_rfl
+    · exact absurd (hzx.trans hxm) hzm
+    · exact zero_le_one
+    · exact le_rfl
+
+@[gcongr] alias ⟨_, single_le_single⟩ := single_le_single_iff
+
+lemma monotone_single : Monotone (single : X → StdSimplex R X) := fun _x _m ↦ single_le_single
+
+end PartialOrder
+end StdSimplex
+
+section IsOrderedConvexSpace
+variable [Semiring R] [PartialOrder R] [IsStrictOrderedRing R] [PartialOrder X] [ConvexSpace R X]
+
+variable (R X) in
+/-- A convex space over a partial order is *ordered* if taking convex combinations is monotone for
+the stochastic dominance order on the standard simplex.
+
+Equivalently, replacing the points of a convex combination by larger points, or moving weight from
+smaller points to larger ones, can only increase the combination. -/
+class IsOrderedConvexSpace : Prop where
+  /-- Taking convex combinations is monotone for stochastic dominance. -/
+  monotone_sConvexComb : Monotone (sConvexComb : StdSimplex R X → X)
+
+export IsOrderedConvexSpace (monotone_sConvexComb)
+
+variable [IsOrderedConvexSpace R X] {v : StdSimplex R I} {w₁ w₂ : StdSimplex R X} {f g : I → X}
+
+@[gcongr]
+lemma sConvexComb_le_sConvexComb (h : w₁ ≤ w₂) : w₁.sConvexComb ≤ w₂.sConvexComb :=
+  monotone_sConvexComb h
+
+lemma monotone_iConvexComb (v : StdSimplex R I) : Monotone (v.iConvexComb : (I → X) → X) :=
+  fun _f _g hfg ↦ monotone_sConvexComb <| StdSimplex.monotone_map hfg
+
+@[gcongr]
+lemma iConvexComb_le_iConvexComb (hfg : f ≤ g) : v.iConvexComb f ≤ v.iConvexComb g :=
+  monotone_iConvexComb _ hfg
+
+@[gcongr]
+lemma convexCombPair_le_convexCombPair {a b : R} (ha hb hab) {x₁ x₂ y₁ y₂ : X} (hx : x₁ ≤ x₂)
+    (hy : y₁ ≤ y₂) :
+    convexCombPair a b ha hb hab x₁ y₁ ≤ convexCombPair a b ha hb hab x₂ y₂ := by
+  simp only [convexCombPair_def]
+  exact iConvexComb_le_iConvexComb (Fin.forall_fin_two.2 ⟨by simpa using hx, by simpa using hy⟩)
+
+end IsOrderedConvexSpace
+end Convexity

--- a/Mathlib/Geometry/Convex/ConvexSpace/Order.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Order.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies
 module
 
 public import Mathlib.Geometry.Convex.ConvexSpace.Defs
+public import Mathlib.Order.UpperLower.CompleteLattice
 
 /-!
 # Ordered convex spaces
@@ -16,191 +17,293 @@ combinations is monotone.
 
 ## Main declarations
 
-* `Convexity.StdSimplex.upperMass`: The upper mass function of a distribution `w` over a partial
-  order, namely the map sending `x` to the total weight `w` puts on `{y | x ≤ y}`.
+* `Convexity.StdSimplex.mass`: The mass function of a distribution `w`, namely the map sending a
+  set `s` to the total weight that `w` puts on `s`.
 * `Convexity.StdSimplex.instPartialOrder`: The stochastic dominance order on `StdSimplex R X`,
-  namely the order induced by the pointwise order on upper mass functions.
+  namely `w₁ ≤ w₂` iff `w₁` puts less mass than `w₂` on every upper set.
 * `Convexity.IsOrderedConvexSpace`: Typeclass for a convex space over a partial order in which
   `sConvexComb` is monotone for stochastic dominance.
 -/
 
-open Finsupp
+open Finsupp Set
 
 public section
 
 namespace Convexity
 variable {I R X : Type*}
 
+section ConvexSpace
+variable [Semiring R] [PartialOrder R] [IsStrictOrderedRing R] [ConvexSpace R X]
+
+instance : ConvexSpace R Xᵒᵈ := ‹ConvexSpace R X›
+
+@[simp]
+lemma toDual_sConvexComb (w : StdSimplex R X) :
+    OrderDual.toDual w.sConvexComb = w.iConvexComb OrderDual.toDual :=
+  congr(sConvexComb $(StdSimplex.map_id w)).symm
+
+@[simp]
+lemma ofDual_sConvexComb (w : StdSimplex R Xᵒᵈ) :
+    OrderDual.ofDual w.sConvexComb = w.iConvexComb OrderDual.ofDual :=
+  congr(sConvexComb $(StdSimplex.map_id w)).symm
+
+@[fun_prop]
+lemma isAffineMap_toDual : IsAffineMap R (OrderDual.toDual : X → Xᵒᵈ) where
+  map_sConvexComb := toDual_sConvexComb
+
+@[fun_prop]
+lemma isAffineMap_ofDual : IsAffineMap R (OrderDual.ofDual : Xᵒᵈ → X) where
+  map_sConvexComb := ofDual_sConvexComb
+
+@[simp]
+lemma toDual_iConvexComb (w : StdSimplex R I) (f : I → X) :
+    OrderDual.toDual (w.iConvexComb f) = w.iConvexComb (fun i ↦ OrderDual.toDual (f i)) :=
+  isAffineMap_toDual.map_iConvexComb ..
+
+@[simp]
+lemma ofDual_iConvexComb (w : StdSimplex R I) (f : I → Xᵒᵈ) :
+    OrderDual.ofDual (w.iConvexComb f) = w.iConvexComb (fun i ↦ OrderDual.ofDual (f i)) :=
+  isAffineMap_ofDual.map_iConvexComb ..
+
+@[simp]
+lemma toDual_convexCombPair (a b : R) (ha hb hab) (x y : X) :
+    OrderDual.toDual (convexCombPair a b ha hb hab x y) =
+      convexCombPair a b ha hb hab (OrderDual.toDual x) (OrderDual.toDual y) :=
+  isAffineMap_toDual.map_convexCombPair ..
+
+@[simp]
+lemma ofDual_convexCombPair (a b : R) (ha hb hab) (x y : Xᵒᵈ) :
+    OrderDual.ofDual (convexCombPair a b ha hb hab x y) =
+      convexCombPair a b ha hb hab (OrderDual.ofDual x) (OrderDual.ofDual y) :=
+  isAffineMap_ofDual.map_convexCombPair ..
+
+end ConvexSpace
+
 namespace StdSimplex
-section PartialOrder
-variable [Semiring R] [PartialOrder R] [PartialOrder X] {w w₁ w₂ : StdSimplex R X} {x y : X}
+section Mass
+variable [Semiring R] [PartialOrder R] {w w₁ w₂ : StdSimplex R X} {s t : Set X}
 
 variable (w) in
-/-- The upper mass function of a distribution `w` over a partial order: `w.upperMass x` is the
-total weight that `w` puts on the up-set of `x`.
+/-- The mass function of a distribution `w`: `w.mass s` is the total weight that `w` puts on `s`. -/
+noncomputable def mass (s : Set X) : R :=
+  open scoped Classical in (w.weights.filter (· ∈ s)).sum fun _x r ↦ r
 
-This is the (complementary) cumulative distribution function of `w`, and it determines `w`.
-See `StdSimplex.upperMass_injective`. -/
-noncomputable def upperMass (x : X) : R :=
-  open scoped Classical in (w.weights.filter (x ≤ ·)).sum fun _y r ↦ r
+lemma mass_eq_finsuppSum (w : StdSimplex R X) (s : Set X) [DecidablePred (· ∈ s)] :
+    w.mass s = (w.weights.filter (· ∈ s)).sum fun _x r ↦ r := by rw [mass]; congr!
 
-lemma upperMass_eq_finsuppSum [DecidableLE X] (w : StdSimplex R X) (x : X) :
-    w.upperMass x = (w.weights.filter (x ≤ ·)).sum fun _y r ↦ r := by rw [upperMass]; congr!
+lemma mass_eq_sum (w : StdSimplex R X) (s : Set X) [DecidablePred (· ∈ s)] :
+    w.mass s = ∑ x ∈ w.weights.support with x ∈ s, w.weights x := by
+  rw [mass_eq_finsuppSum, sum_filter_index, support_filter]
 
-lemma upperMass_eq_sum [DecidableLE X] (w : StdSimplex R X) (x : X) :
-    w.upperMass x = ∑ y ∈ w.weights.support with x ≤ y, w.weights y := by
-  rw [upperMass_eq_finsuppSum, sum_filter_index, support_filter]
+@[simp] lemma mass_empty (w : StdSimplex R X) : w.mass ∅ = 0 := by simp [mass_eq_sum]
 
-/-- If no point of the support of `w` lies strictly between `x` and `y`, then the mass `w` puts
-above `x` is the mass it puts on `x` plus the mass it puts above `y`. -/
-lemma upperMass_eq_weights_add_upperMass (hxy : x < y) (hm : ∀ z, w.weights z ≠ 0 → x < z → y ≤ z) :
-    w.upperMass x = w.weights x + w.upperMass y := by
+@[simp] lemma mass_univ (w : StdSimplex R X) : w.mass univ = 1 := by
+  simpa [mass_eq_sum, Finsupp.sum] using w.total
+
+lemma mass_union_of_disjoint (hst : Disjoint s t) (w : StdSimplex R X) :
+    w.mass (s ∪ t) = w.mass s + w.mass t := by
   classical
-  have : w.weights.filter (x ≤ ·) = .single x (w.weights x) + w.weights.filter (y ≤ ·) := by
-    ext z; simp [filter_apply]; grind [lt_of_le_of_ne]
-  simp [upperMass, this, sum_add_index']
+  simp only [mass_eq_sum, mem_union, Finset.filter_or]
+  grind [Finset.sum_union, Finset.disjoint_left]
 
-open scoped Classical in
-/-- The mass `w` puts above `x` is the mass it puts on `x` plus the mass it puts strictly above
-`x`. -/
-lemma upperMass_eq_weights_add_sum (w : StdSimplex R X) (x : X) :
-    w.upperMass x = w.weights x + ∑ y ∈ w.weights.support with x < y, w.weights y := by
-  have : w.weights.filter (x ≤ ·) = .single x (w.weights x) + w.weights.filter (x < ·) := by
-    ext z; simp [filter_apply]; grind [lt_of_le_of_ne]
-  simp [upperMass, this, sum_add_index', sum_filter_index]
+@[simp] lemma mass_singleton (w : StdSimplex R X) (x : X) : w.mass {x} = w.weights x := by
+  classical simp [mass_eq_sum, Finset.sum_filter, eq_comm]
 
-/-- If no point of the support of `w` lies strictly above `x`, then the mass `w` puts above `x` is
-exactly the mass it puts on `x`. -/
-lemma upperMass_eq_weights (hx : ∀ y, w.weights y ≠ 0 → ¬ x < y) : w.upperMass x = w.weights x := by
-  classical
-  have : w.weights.filter (x ≤ ·) = .single x (w.weights x) := by
-    ext y; simp [filter_apply]; grind [lt_of_le_of_ne]
-  rw [upperMass, this, sum_single_index rfl]
-
-@[simp] lemma upperMass_top [OrderTop X] (w : StdSimplex R X) : w.upperMass ⊤ = w.weights ⊤ :=
-  upperMass_eq_weights fun _ _ ↦ not_top_lt
+@[simp]
+lemma mass_add_mass_compl (w : StdSimplex R X) (s : Set X) : w.mass s + w.mass sᶜ = 1 := by
+  classical simpa [mass_eq_sum, Finset.sum_filter_add_sum_filter_not, Finsupp.sum] using w.total
 
 variable [IsStrictOrderedRing R]
 
-@[simp] lemma upperMass_nonneg (w : StdSimplex R X) (x : X) : 0 ≤ w.upperMass x := by
-  classical rw [upperMass_eq_sum]; exact Finset.sum_nonneg fun _ _ ↦ w.weights_nonneg _
+@[simp] lemma mass_nonneg (w : StdSimplex R X) (s : Set X) : 0 ≤ w.mass s := by
+  classical rw [mass_eq_sum]; exact Finset.sum_nonneg fun _ _ ↦ w.weights_nonneg _
 
-@[simp] lemma upperMass_single [DecidableLE X] (x y : X) :
-    (single x : StdSimplex R X).upperMass y = if y ≤ x then 1 else 0 := by
-  rw [upperMass_eq_sum, weights_single]; split <;> simp [Finset.filter_singleton, *]
+@[simp] lemma mass_single (x : X) (s : Set X) [Decidable (x ∈ s)] :
+    (single x : StdSimplex R X).mass s = if x ∈ s then 1 else 0 := by
+  classical rw [mass_eq_sum, weights_single]; split <;> simp [Finset.filter_singleton, *]
 
-omit [IsStrictOrderedRing R] in
-lemma upperMass_add_sum_not [DecidableLE X] (w : StdSimplex R X) (x : X) :
-    w.upperMass x + ∑ y ∈ w.weights.support with ¬ x ≤ y, w.weights y = 1 := by
-  rw [upperMass_eq_sum, Finset.sum_filter_add_sum_filter_not]
-  simpa [Finsupp.sum] using w.total
+@[simp] lemma mass_map (w : StdSimplex R I) (f : I → X) (s : Set X) :
+    (w.map f).mass s = w.mass (f ⁻¹' s) := by
+  classical simp [mass_eq_finsuppSum, sum_mapDomain_index]
 
-@[simp] lemma upperMass_le_one (w : StdSimplex R X) (x : X) : w.upperMass x ≤ 1 := by
+@[gcongr] lemma mass_mono (w : StdSimplex R X) (hst : s ⊆ t) : w.mass s ≤ w.mass t := by
+  classical rw [mass_eq_sum, mass_eq_sum]; gcongr; simp
+
+@[simp] lemma mass_le_one : w.mass s ≤ 1 := by
+  rw [← mass_add_mass_compl]; exact le_add_of_nonneg_right (mass_nonneg ..)
+
+lemma mass_eq_zero_iff : w.mass s = 0 ↔ ∀ x, w.weights x ≠ 0 → x ∉ s := by
   classical
-  rw [← upperMass_add_sum_not w x]
-  exact le_add_of_nonneg_right (Finset.sum_nonneg fun _ _ ↦ w.weights_nonneg _)
+  rw [mass_eq_sum, Finset.sum_eq_zero_iff_of_nonneg fun _ _ ↦ w.weights_nonneg _]
+  simp +contextual [Finset.mem_filter, not_imp_not, eq_comm]
+
+lemma mass_eq_one_iff : w.mass s = 1 ↔ ∀ x, w.weights x ≠ 0 → x ∈ s := by
+  rw [← w.mass_add_mass_compl s, left_eq_add, mass_eq_zero_iff]; simp
+
+@[simp]
+lemma mass_compl_le_mass_compl_iff : w₁.mass sᶜ ≤ w₂.mass sᶜ ↔ w₂.mass s ≤ w₁.mass s :=
+  le_iff_ge_of_add_eq_add <| by simp [add_comm]
+
+end Mass
+
+section PartialOrder
+variable [Semiring R] [PartialOrder R] [PartialOrder X] {w w₁ w₂ : StdSimplex R X} {s t : Set X}
+  {x y : X}
+
+/-- The mass that `w` puts above `x` is the mass it puts on `x` plus the mass it puts strictly
+above `x`. -/
+lemma mass_Ici_eq_weights_add_mass_Ioi (w : StdSimplex R X) (x : X) :
+    w.mass (Ici x) = w.weights x + w.mass (Ioi x) := by
+  rw [← mass_singleton, ← mass_union_of_disjoint]
+  · congr 1
+    ext y
+    simp [le_iff_lt_or_eq, or_comm]
+  · simp
+
+/-- If, on the support of `w`, lying in `s` is the same as lying above `x`, then the mass that `w`
+puts on `s` is the mass it puts above `x`. -/
+lemma mass_eq_mass_Ici (w : StdSimplex R X) (h : ∀ ⦃y⦄, w.weights y ≠ 0 → (y ∈ s ↔ x ≤ y)) :
+    w.mass s = w.mass (Ici x) := by
+  classical rw [mass_eq_sum, mass_eq_sum]; congr! 2 with y hy; exact h (mem_support_iff.1 hy)
+
+variable [IsStrictOrderedRing R]
 
 /-- `w` puts all of its mass above `x` exactly when its support lies above `x`. -/
-lemma upperMass_eq_one_iff : w.upperMass x = 1 ↔ ∀ y, w.weights y ≠ 0 → x ≤ y := by
-  classical
-  have h := upperMass_add_sum_not w x
-  refine ⟨fun h1 y hy ↦ ?_, fun hall ↦ ?_⟩
-  · rw [h1] at h
-    have hz := add_left_cancel (h.trans (add_zero 1).symm)
-    by_contra! hxy
-    exact hy <| (Finset.sum_eq_zero_iff_of_nonneg fun _ _ ↦ w.weights_nonneg _).1 hz y <| by
-      simp [hy, hxy]
-  · rwa [Finset.sum_eq_zero fun y ↦ by simp +contextual [hall], add_zero] at h
+lemma mass_Ici_eq_one_iff : w.mass (Ici x) = 1 ↔ ∀ y, w.weights y ≠ 0 → x ≤ y := mass_eq_one_iff
 
-/-- A distribution over a partial order is determined by its upper mass function. -/
-lemma upperMass_injective : (upperMass : StdSimplex R X → X → R).Injective := by
-  classical
-  rintro w₁ w₂ h
-  ext x
-  set S := w₁.weights.support ∪ w₂.weights.support with hS
-  -- The mass `w` puts above `x` is the mass it puts on `x` plus the mass it puts on the elements
-  -- of `S` strictly above `x`.
-  have key (w : StdSimplex R X) (hw : w.weights.support ⊆ S) (x : X) :
-      w.upperMass x = w.weights x + ∑ y ∈ S with x < y, w.weights y := by
-    rw [upperMass_eq_weights_add_sum]
-    congr 1
-    exact Finset.sum_subset (by gcongr) <| by simp_all
-  have key' (x : X) :
-      w₁.weights x + ∑ y ∈ S with x < y, w₁.weights y
-        = w₂.weights x + ∑ y ∈ S with x < y, w₂.weights y :=
-    (key w₁ Finset.subset_union_left x).symm.trans
-      ((congrFun h x).trans (key w₂ Finset.subset_union_right x))
-  -- We prove that `w₁` and `w₂` agree at `x` by induction on the number of elements of `S` lying
-  -- strictly above `x`.
-  have main n x (hx : Finset.card {y ∈ S | x < y} ≤ n) : w₁.weights x = w₂.weights x := by
-    induction n generalizing x with
-    | zero =>
-      have h₀ : {y ∈ S | x < y} = ∅ := Finset.card_eq_zero.1 (Nat.le_zero.1 hx)
-      simpa [h₀] using key' x
-    | succ n ih =>
-      have hsum : ∑ y ∈ S with x < y, w₁.weights y = ∑ y ∈ S with x < y, w₂.weights y := by
-        congr! 1 with y hy
-        refine ih y ?_
-        simp only [Finset.mem_filter] at hy
-        -- The elements of `S` strictly above `y` are strictly above `x`, but `y` isn't
-        have hss : {z ∈ S | y < z} ⊂ {z ∈ S | x < z} := by
-          refine (Finset.ssubset_iff_of_subset fun z hz ↦ ?_).2 ⟨y, by simp [hy.1, hy.2], by simp⟩
-          simp only [Finset.mem_filter] at hz ⊢
-          exact ⟨hz.1, hy.2.trans hz.2⟩
-        exact Nat.lt_succ_iff.1 <| (Finset.card_lt_card hss).trans_le hx
-      exact add_right_cancel (hsum ▸ key' x)
-  exact main _ x le_rfl
+/-- `w` puts all of its mass below `x` exactly when its support lies below `x`. -/
+lemma mass_Iic_eq_one_iff : w.mass (Iic x) = 1 ↔ ∀ y, w.weights y ≠ 0 → y ≤ x := mass_eq_one_iff
 
-/-- The standard simplex indexed by a partial order is partially ordered by stochastic dominance.
-`w₁ ≤ w₂` iff on each lower set the weight of `w₁` is less than that of `w₂`. -/
-noncomputable instance instPartialOrder : PartialOrder (StdSimplex R X) :=
-  .lift upperMass upperMass_injective
+/-- The standard simplex indexed by a partial order is partially ordered by **stochastic
+dominance**: `w₁ ≤ w₂` iff on each upper set the mass of `w₁` is at most that of `w₂`.
 
-lemma le_def : w₁ ≤ w₂ ↔ ∀ x, w₁.upperMass x ≤ w₂.upperMass x := .rfl
+Equivalently, `w₁ ≤ w₂` iff `w₂` puts at most as much mass as `w₁` on each down-set
+(`StdSimplex.le_iff_forall_isLowerSet`), which makes stochastic dominance self-dual. -/
+noncomputable instance instPartialOrder : PartialOrder (StdSimplex R X) where
+  le w₁ w₂ := ∀ ⦃s : Set X⦄, IsUpperSet s → w₁.mass s ≤ w₂.mass s
+  le_refl w s _ := le_rfl
+  le_trans w₁ w₂ w₃ h₁₂ h₂₃ s hs := (h₁₂ hs).trans (h₂₃ hs)
+  le_antisymm w₁ w₂ h₁₂ h₂₁ := by
+    have key {s : Set X} (hs : IsUpperSet s) : w₁.mass s = w₂.mass s := (h₁₂ hs).antisymm (h₂₁ hs)
+    ext x
+    have h := w₁.mass_Ici_eq_weights_add_mass_Ioi x
+    rw [key (isUpperSet_Ici x), key (isUpperSet_Ioi x),
+      w₂.mass_Ici_eq_weights_add_mass_Ioi x] at h
+    exact (add_right_cancel h).symm
 
-@[gcongr] alias ⟨upperMass_le_upperMass, _⟩ := le_def
+lemma le_iff_forall_isUpperSet :
+    w₁ ≤ w₂ ↔ ∀ ⦃s : Set X⦄, IsUpperSet s → w₁.mass s ≤ w₂.mass s := .rfl
+
+lemma le_iff_forall_isLowerSet :
+    w₁ ≤ w₂ ↔ ∀ ⦃s : Set X⦄, IsLowerSet s → w₂.mass s ≤ w₁.mass s :=
+  compl_surjective.forall.trans <| by simp
+
+@[gcongr]
+lemma mass_mono_of_isUpperSet (hw : w₁ ≤ w₂) (hst : s ⊆ t) (ht : IsUpperSet t) :
+    w₁.mass s ≤ w₂.mass t := by grw [hst, le_iff_forall_isUpperSet.1 hw ht]
+
+lemma mass_mono_of_isLowerSet (hw : w₁ ≤ w₂) (hst : s ⊆ t) (ht : IsLowerSet t) :
+    w₂.mass s ≤ w₁.mass t := by grw [hst, le_iff_forall_isLowerSet.1 hw ht]
+
+@[gcongr] lemma mass_Ici_mono (hw : w₁ ≤ w₂) : w₁.mass (Ici x) ≤ w₂.mass (Ici x) := by
+  gcongr; exact isUpperSet_Ici _
+
+@[gcongr] lemma mass_Iic_mono (hw : w₁ ≤ w₂) : w₂.mass (Iic x) ≤ w₁.mass (Iic x) :=
+  mass_mono_of_isLowerSet hw .rfl <| isLowerSet_Iic _
+
+lemma mass_strictMono :
+    StrictMono fun (w : StdSimplex R X) (s : UpperSet X) ↦ w.mass (s : Set X) := by
+  intro w₁ w₂ h
+  refine lt_of_le_of_ne (fun s ↦ le_iff_forall_isUpperSet.1 h.le s.2) fun hmass ↦ h.ne ?_
+  exact le_antisymm h.le <| le_iff_forall_isUpperSet.2 fun s hs ↦ (congrFun hmass ⟨s, hs⟩).ge
+
+/-- If `w₁ ≤ w₂` and `w₁` puts all of its mass on an upper set `s`, then so does `w₂`. -/
+lemma mass_eq_one_of_le (hs : IsUpperSet s) (h : w₁ ≤ w₂) (h₁ : w₁.mass s = 1) : w₂.mass s = 1 :=
+  le_antisymm (mass_le_one ..) (h₁ ▸ le_iff_forall_isUpperSet.1 h hs)
+
+/-- If `w₁ ≤ w₂` and `w₂` puts all of its mass on a down-set `s`, then so does `w₁`. -/
+lemma mass_eq_one_of_ge (hs : IsLowerSet s) (h : w₁ ≤ w₂) (h₂ : w₂.mass s = 1) : w₁.mass s = 1 :=
+  le_antisymm (mass_le_one ..) (h₂ ▸ le_iff_forall_isLowerSet.1 h hs)
 
 lemma forall_le_of_le (h : w₁ ≤ w₂) (h₁ : ∀ ⦃y⦄, w₁.weights y ≠ 0 → x ≤ y) :
     ∀ ⦃y⦄, w₂.weights y ≠ 0 → x ≤ y := by
-  rw [← upperMass_eq_one_iff] at h₁ ⊢
-  exact le_antisymm (upperMass_le_one _ _) (h₁ ▸ le_def.1 h x)
+  rw [← mass_Ici_eq_one_iff] at h₁ ⊢
+  exact mass_eq_one_of_le (isUpperSet_Ici x) h h₁
 
-@[simp] lemma upperMass_map [DecidableLE X] (w : StdSimplex R I) (f : I → X) (x : X) :
-    (w.map f).upperMass x = (w.weights.filter fun i ↦ x ≤ f i).sum fun _i r ↦ r := by
-  simp [upperMass_eq_finsuppSum, sum_mapDomain_index]
+lemma forall_ge_of_le (h : w₁ ≤ w₂) (h₂ : ∀ ⦃y⦄, w₂.weights y ≠ 0 → y ≤ x) :
+    ∀ ⦃y⦄, w₁.weights y ≠ 0 → y ≤ x := by
+  rw [← mass_Iic_eq_one_iff] at h₂ ⊢
+  exact mass_eq_one_of_ge (isLowerSet_Iic x) h h₂
 
 lemma monotone_map {w : StdSimplex R I} : Monotone (w.map : (I → X) → StdSimplex R X) := by
-  classical
-  rintro f g hfg x
-  rw [upperMass_map, upperMass_map, sum_filter_index, sum_filter_index, support_filter,
-    support_filter]
-  gcongr
-  · simp
-  · exact hfg _
+  intro f g hfg s hs; rw [mass_map, mass_map]; gcongr; exact fun i hi ↦ hs (hfg i) hi
 
-@[gcongr] lemma map_le_map {w : StdSimplex R I} {f g : I → X} (hfg : f ≤ g) : w.map f ≤ w.map g :=
+@[gcongr, to_dual self]
+lemma map_le_map {w : StdSimplex R I} {f g : I → X} (hfg : f ≤ g) : w.map f ≤ w.map g :=
   monotone_map hfg
 
-@[simp] lemma single_le_single_iff : (single x : StdSimplex R X) ≤ single y ↔ x ≤ y := by
+@[simp, to_dual self]
+lemma single_le_single_iff : (single x : StdSimplex R X) ≤ single y ↔ x ≤ y := by
   classical
-  refine ⟨fun h ↦ ?_, fun hxm ↦ le_def.2 fun z ↦ ?_⟩
-  · have hx := le_def.1 h x
-    simp only [upperMass_single, le_refl, ite_true] at hx
-    by_contra hxm
-    rw [ite_eq_right_iff.2 fun h ↦ absurd h hxm] at hx
-    exact absurd hx zero_lt_one.not_ge
-  · simp only [upperMass_single]
-    split_ifs with hzx hzm hzm
-    · exact le_rfl
-    · exact absurd (hzx.trans hxm) hzm
-    · exact zero_le_one
-    · exact le_rfl
+  simpa [le_iff_forall_isUpperSet, apply_ite, ite_apply, zero_lt_one.not_ge, not_imp_not]
+    using ⟨fun h ↦ by simpa using h (isUpperSet_Ici x), fun hxy s hs ↦ hs hxy⟩
 
-@[gcongr] alias ⟨_, single_le_single⟩ := single_le_single_iff
+@[gcongr, to_dual self] alias ⟨_, single_mono⟩ := single_le_single_iff
 
-lemma monotone_single : Monotone (single : X → StdSimplex R X) := fun _x _m ↦ single_le_single
 
 end PartialOrder
+
+section LinearOrder
+variable [Semiring R] [PartialOrder R] [IsStrictOrderedRing R] [LinearOrder X]
+  {w₁ w₂ : StdSimplex R X}
+
+/-- Over a linear order, stochastic dominance can be tested on the principal upper sets alone, ie by
+comparing the (complementary) cumulative distribution functions. This is the usual definition of
+stochastic dominance.
+
+This fails over a general partial order: see the module docstring. -/
+lemma le_iff_forall_Ici : w₁ ≤ w₂ ↔ ∀ x, w₁.mass (Ici x) ≤ w₂.mass (Ici x) := by
+  classical
+  refine ⟨fun h _ ↦ mass_Ici_mono h, fun h ↦ le_iff_forall_isUpperSet.2 fun s hs ↦ ?_⟩
+  set F : Finset X := w₁.weights.support ∪ w₂.weights.support
+  -- As an upper set of the finite linear order `F`, `s` is either empty or of the form `Ici x`.
+  obtain hse | ⟨x, hsx⟩ := (hs.preimage (f := ((↑) : F → X)) fun _ _ h ↦ h).eq_empty_or_Ici
+  -- If `s` misses `F`, then neither distribution charges `s`.
+  · have key (w : StdSimplex R X) (hw : w.weights.support ⊆ F) : w.mass s = 0 :=
+      mass_eq_zero_iff.2 fun y hy hys ↦
+        Set.eq_empty_iff_forall_notMem.1 hse ⟨y, hw (mem_support_iff.2 hy)⟩ hys
+    rw [key w₁ Finset.subset_union_left, key w₂ Finset.subset_union_right]
+  -- Otherwise, on `F` the set `s` coincides with `Ici x`, so both masses are masses above `x`.
+  · have key (w : StdSimplex R X) (hw : w.weights.support ⊆ F) : w.mass s = w.mass (Ici ↑x) :=
+      mass_eq_mass_Ici _ fun y hy ↦ by
+        simpa [← Subtype.coe_le_coe] using Set.ext_iff.1 hsx ⟨y, hw (mem_support_iff.2 hy)⟩
+    rw [key w₁ Finset.subset_union_left, key w₂ Finset.subset_union_right]
+    exact h _
+
+end LinearOrder
+
+section OrderDual
+variable [Semiring R] [PartialOrder R] [IsStrictOrderedRing R] [PartialOrder X]
+
+@[simp] lemma ofDual_le_iff {w₁ w₂ : StdSimplex R Xᵒᵈ} :
+    w₂ ≤ w₁ ↔ w₁.map OrderDual.ofDual ≤ w₂.map OrderDual.ofDual := by
+  rw [le_iff_forall_isUpperSet, le_iff_forall_isLowerSet]
+  simp [OrderDual.ofDual.setCongr.forall_congr_left, Equiv.image_eq_preimage_symm]
+
+@[simp] lemma map_toDual_le_map_toDual_iff {w₁ w₂ : StdSimplex R X} :
+    w₁.map OrderDual.toDual ≤ w₂.map OrderDual.toDual ↔ w₂ ≤ w₁ := by
+  simp [ofDual_le_iff, map_map]
+
+variable (R X) in
+/-- The stochastic dominance order on the standard simplex is self-dual. -/
+noncomputable def toDualOrderIso : (StdSimplex R X)ᵒᵈ ≃o StdSimplex R Xᵒᵈ where
+  toFun w := w.ofDual.map .toDual
+  invFun w := .toDual <| w.map OrderDual.ofDual
+  left_inv w := by ext; simp
+  right_inv w := by ext; simp
+  map_rel_iff' := map_toDual_le_map_toDual_iff
+
+end OrderDual
 end StdSimplex
 
 section IsOrderedConvexSpace
@@ -220,23 +323,28 @@ export IsOrderedConvexSpace (monotone_sConvexComb)
 
 variable [IsOrderedConvexSpace R X] {v : StdSimplex R I} {w₁ w₂ : StdSimplex R X} {f g : I → X}
 
-@[gcongr]
+@[gcongr, to_dual self]
 lemma sConvexComb_le_sConvexComb (h : w₁ ≤ w₂) : w₁.sConvexComb ≤ w₂.sConvexComb :=
   monotone_sConvexComb h
 
 lemma monotone_iConvexComb (v : StdSimplex R I) : Monotone (v.iConvexComb : (I → X) → X) :=
   fun _f _g hfg ↦ monotone_sConvexComb <| StdSimplex.monotone_map hfg
 
-@[gcongr]
+@[gcongr, to_dual self]
 lemma iConvexComb_le_iConvexComb (hfg : f ≤ g) : v.iConvexComb f ≤ v.iConvexComb g :=
   monotone_iConvexComb _ hfg
 
-@[gcongr]
+@[gcongr, to_dual self (dont_translate := R)]
 lemma convexCombPair_le_convexCombPair {a b : R} (ha hb hab) {x₁ x₂ y₁ y₂ : X} (hx : x₁ ≤ x₂)
     (hy : y₁ ≤ y₂) :
     convexCombPair a b ha hb hab x₁ y₁ ≤ convexCombPair a b ha hb hab x₂ y₂ := by
   simp only [convexCombPair_def]
   exact iConvexComb_le_iConvexComb (Fin.forall_fin_two.2 ⟨by simpa using hx, by simpa using hy⟩)
+
+instance isOrderedConvexSpace_orderDual : IsOrderedConvexSpace R Xᵒᵈ where
+  monotone_sConvexComb _w₁ _w₂ h := by
+    rw [← OrderDual.ofDual_le_ofDual, ofDual_sConvexComb, ofDual_sConvexComb]
+    exact sConvexComb_le_sConvexComb (StdSimplex.ofDual_le_iff.1 h)
 
 end IsOrderedConvexSpace
 end Convexity

--- a/Mathlib/Geometry/Convex/ConvexSpace/Order.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Order.lean
@@ -290,9 +290,9 @@ variable [Semiring R] [PartialOrder R] [IsStrictOrderedRing R] [PartialOrder X]
   rw [le_iff_forall_isUpperSet, le_iff_forall_isLowerSet]
   simp [OrderDual.ofDual.setCongr.forall_congr_left, Equiv.image_eq_preimage_symm]
 
-@[simp] lemma map_toDual_le_map_toDual_iff {w₁ w₂ : StdSimplex R X} :
+lemma map_toDual_le_map_toDual_iff {w₁ w₂ : StdSimplex R X} :
     w₁.map OrderDual.toDual ≤ w₂.map OrderDual.toDual ↔ w₂ ≤ w₁ := by
-  simp [ofDual_le_iff, map_map]
+  simp [map_map]
 
 variable (R X) in
 /-- The stochastic dominance order on the standard simplex is self-dual. -/

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -92,6 +92,14 @@ theorem isUpperSet_preimage_ofDual_iff : IsUpperSet (ofDual ⁻¹' s) ↔ IsLowe
 theorem isUpperSet_preimage_toDual_iff {s : Set αᵒᵈ} : IsUpperSet (toDual ⁻¹' s) ↔ IsLowerSet s :=
   Iff.rfl
 
+@[to_dual (attr := simp)]
+theorem isUpperSet_image_toDual_iff : IsUpperSet (toDual '' s) ↔ IsLowerSet s := by
+  rw [toDual.image_eq_preimage_symm]; exact isUpperSet_preimage_ofDual_iff
+
+@[to_dual (attr := simp)]
+theorem isUpperSet_image_ofDual_iff {s : Set αᵒᵈ} : IsUpperSet (ofDual '' s) ↔ IsLowerSet s := by
+  rw [ofDual.image_eq_preimage_symm]; exact isUpperSet_preimage_toDual_iff
+
 @[to_dual] alias ⟨_, IsUpperSet.toDual⟩ := isLowerSet_preimage_ofDual_iff
 @[to_dual] alias ⟨_, IsUpperSet.ofDual⟩ := isLowerSet_preimage_toDual_iff
 


### PR DESCRIPTION
Define ordered convex spaces as those convex spaces for which taking convex combinations is monotone in its inputs. Since `sConvexComb : StdSimplex R X → X`, the best way to do so is to equip `StdSimplex R X` with the stochastic dominance order and requiring `sConvexComb` to be monotone under that order.

Generated by Claude Opus following my existing draft, then reviewed and partly rewritten by myself.

From the convexity refactor. Ordered convex spaces will be used to define convex/concave functions.

Assisted-by: Claude Opus 5


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
