### PR TITLE
feat(CategoryTheory/Action): an adjunction induces an adjunction on Action categories

### DIFF
--- a/Mathlib/CategoryTheory/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Action/Basic.lean
@@ -477,4 +477,54 @@ def Equivalence.mapAction {V W : Type*} [Category* V] [Category* W] (G : Type*) 
   counitIso := (Functor.mapActionComp G _ _).symm ≪≫ Functor.mapActionCongr G E.counitIso
   functor_unitIso_comp X := by ext; simp
 
+/-- An adjunction `F ⊣ U` induces an adjunction between the categories of
+`G`-actions within those categories. -/
+def Adjunction.mapAction {V W : Type*} [Category* V] [Category* W] {F : V ⥤ W} {U : W ⥤ V}
+    (adj : F ⊣ U) (G : Type*) [Monoid G] : F.mapAction G ⊣ U.mapAction G :=
+  Adjunction.mkOfHomEquiv
+    { homEquiv := fun X Y =>
+        { toFun := fun f =>
+            { hom := adj.homEquiv _ _ f.hom
+              comm := fun g => by
+                show X.ρ g ≫ adj.homEquiv _ _ f.hom = adj.homEquiv _ _ f.hom ≫ U.map (Y.ρ g)
+                rw [← adj.homEquiv_naturality_left, ← adj.homEquiv_naturality_right]
+                exact congrArg (adj.homEquiv X.V Y.V) (f.comm g) }
+          invFun := fun f =>
+            { hom := (adj.homEquiv _ _).symm f.hom
+              comm := fun g => by
+                show F.map (X.ρ g) ≫ (adj.homEquiv _ _).symm f.hom
+                    = (adj.homEquiv _ _).symm f.hom ≫ Y.ρ g
+                rw [← adj.homEquiv_naturality_left_symm, ← adj.homEquiv_naturality_right_symm]
+                exact congrArg (adj.homEquiv X.V Y.V).symm (f.comm g) }
+          left_inv := fun f => by ext; simp
+          right_inv := fun f => by ext; simp }
+      homEquiv_naturality_left_symm := fun f g => by
+        ext
+        exact adj.homEquiv_naturality_left_symm f.hom g.hom
+      homEquiv_naturality_right := fun f g => by
+        ext
+        exact adj.homEquiv_naturality_right f.hom g.hom }
+
+@[simp]
+lemma Adjunction.mapAction_homEquiv_hom {V W : Type*} [Category* V] [Category* W]
+    {F : V ⥤ W} {U : W ⥤ V} (adj : F ⊣ U) (G : Type*) [Monoid G]
+    {X : Action V G} {Y : Action W G} (f : (F.mapAction G).obj X ⟶ Y) :
+    ((adj.mapAction G).homEquiv X Y f).hom = adj.homEquiv X.V Y.V f.hom := by
+  simp [Adjunction.mapAction]
+
+@[simp]
+lemma Adjunction.mapAction_homEquiv_symm_hom {V W : Type*} [Category* V] [Category* W]
+    {F : V ⥤ W} {U : W ⥤ V} (adj : F ⊣ U) (G : Type*) [Monoid G]
+    {X : Action V G} {Y : Action W G} (f : X ⟶ (U.mapAction G).obj Y) :
+    (((adj.mapAction G).homEquiv X Y).symm f).hom = (adj.homEquiv X.V Y.V).symm f.hom := by
+  simp [Adjunction.mapAction]
+
+instance Functor.mapAction_isLeftAdjoint {V W : Type*} [Category* V] [Category* W]
+    (F : V ⥤ W) (G : Type*) [Monoid G] [F.IsLeftAdjoint] : (F.mapAction G).IsLeftAdjoint :=
+  ((Adjunction.ofIsLeftAdjoint F).mapAction G).isLeftAdjoint
+
+instance Functor.mapAction_isRightAdjoint {V W : Type*} [Category* V] [Category* W]
+    (U : V ⥤ W) (G : Type*) [Monoid G] [U.IsRightAdjoint] : (U.mapAction G).IsRightAdjoint :=
+  ((Adjunction.ofIsRightAdjoint U).mapAction G).isRightAdjoint
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Action/Basic.lean
@@ -480,44 +480,37 @@ def Equivalence.mapAction {V W : Type*} [Category* V] [Category* W] (G : Type*) 
 /-- An adjunction `F ⊣ U` induces an adjunction between the categories of
 `G`-actions within those categories. -/
 def Adjunction.mapAction {V W : Type*} [Category* V] [Category* W] {F : V ⥤ W} {U : W ⥤ V}
-    (adj : F ⊣ U) (G : Type*) [Monoid G] : F.mapAction G ⊣ U.mapAction G :=
-  Adjunction.mkOfHomEquiv
-    { homEquiv := fun X Y =>
-        { toFun := fun f =>
-            { hom := adj.homEquiv _ _ f.hom
-              comm := fun g => by
-                show X.ρ g ≫ adj.homEquiv _ _ f.hom = adj.homEquiv _ _ f.hom ≫ U.map (Y.ρ g)
-                rw [← adj.homEquiv_naturality_left, ← adj.homEquiv_naturality_right]
-                exact congrArg (adj.homEquiv X.V Y.V) (f.comm g) }
-          invFun := fun f =>
-            { hom := (adj.homEquiv _ _).symm f.hom
-              comm := fun g => by
-                show F.map (X.ρ g) ≫ (adj.homEquiv _ _).symm f.hom
-                    = (adj.homEquiv _ _).symm f.hom ≫ Y.ρ g
-                rw [← adj.homEquiv_naturality_left_symm, ← adj.homEquiv_naturality_right_symm]
-                exact congrArg (adj.homEquiv X.V Y.V).symm (f.comm g) }
-          left_inv := fun f => by ext; simp
-          right_inv := fun f => by ext; simp }
-      homEquiv_naturality_left_symm := fun f g => by
+    (adj : F ⊣ U) (G : Type*) [Monoid G] : F.mapAction G ⊣ U.mapAction G where
+  unit :=
+    { app := fun X =>
+        { hom := adj.unit.app X.V
+          comm := fun g => adj.unit.naturality (X.ρ g) }
+      naturality := fun _ _ f => by
         ext
-        exact adj.homEquiv_naturality_left_symm f.hom g.hom
-      homEquiv_naturality_right := fun f g => by
+        exact adj.unit.naturality f.hom }
+  counit :=
+    { app := fun Y =>
+        { hom := adj.counit.app Y.V
+          comm := fun g => adj.counit.naturality (Y.ρ g) }
+      naturality := fun _ _ f => by
         ext
-        exact adj.homEquiv_naturality_right f.hom g.hom }
+        exact adj.counit.naturality f.hom }
+  left_triangle_components X := by
+    ext
+    exact adj.left_triangle_components X.V
+  right_triangle_components Y := by
+    ext
+    exact adj.right_triangle_components Y.V
 
 @[simp]
-lemma Adjunction.mapAction_homEquiv_hom {V W : Type*} [Category* V] [Category* W]
-    {F : V ⥤ W} {U : W ⥤ V} (adj : F ⊣ U) (G : Type*) [Monoid G]
-    {X : Action V G} {Y : Action W G} (f : (F.mapAction G).obj X ⟶ Y) :
-    ((adj.mapAction G).homEquiv X Y f).hom = adj.homEquiv X.V Y.V f.hom := by
-  simp [Adjunction.mapAction]
+lemma Adjunction.mapAction_unit_app_hom {V W : Type*} [Category* V] [Category* W]
+    {F : V ⥤ W} {U : W ⥤ V} (adj : F ⊣ U) (G : Type*) [Monoid G] (X : Action V G) :
+    ((adj.mapAction G).unit.app X).hom = adj.unit.app X.V := rfl
 
 @[simp]
-lemma Adjunction.mapAction_homEquiv_symm_hom {V W : Type*} [Category* V] [Category* W]
-    {F : V ⥤ W} {U : W ⥤ V} (adj : F ⊣ U) (G : Type*) [Monoid G]
-    {X : Action V G} {Y : Action W G} (f : X ⟶ (U.mapAction G).obj Y) :
-    (((adj.mapAction G).homEquiv X Y).symm f).hom = (adj.homEquiv X.V Y.V).symm f.hom := by
-  simp [Adjunction.mapAction]
+lemma Adjunction.mapAction_counit_app_hom {V W : Type*} [Category* V] [Category* W]
+    {F : V ⥤ W} {U : W ⥤ V} (adj : F ⊣ U) (G : Type*) [Monoid G] (Y : Action W G) :
+    ((adj.mapAction G).counit.app Y).hom = adj.counit.app Y.V := rfl
 
 instance Functor.mapAction_isLeftAdjoint {V W : Type*} [Category* V] [Category* W]
     (F : V ⥤ W) (G : Type*) [Monoid G] [F.IsLeftAdjoint] : (F.mapAction G).IsLeftAdjoint :=


### PR DESCRIPTION
> ### Use of AI — disclosure
>
> This PR was produced by an AI agent (Claude Code, Anthropic) running on my machine, not written
> by me by hand. The agent wrote the Lean code, checked it against a local Mathlib `v4.30.0`
> build, diagnosed the first CI failure (`rw` no longer seeing through
> `((F.mapAction G).obj X).V ≡ F.obj X.V` at `implicit` transparency under `v4.34.0-rc2`) and
> replaced the `mkOfHomEquiv` construction with the current unit/counit one.
>
> I had not read Mathlib's guidelines on AI use before this PR was opened, and it was opened
> without any prior discussion in the community — both of which your guidelines ask for. I am
> leaving it in draft while I review the contribution properly, and I will either rewrite this
> description in my own words once I can stand behind every design decision here, or close the
> PR. Apologies for the process error.

---

Adds `Adjunction.mapAction`: an adjunction `F ⊣ U` between `V` and `W` induces an adjunction

```
F.mapAction G ⊣ U.mapAction G
```

between `Action V G` and `Action W G`, together with the `hom` simp lemmas for its unit and
counit components and the corresponding `IsLeftAdjoint` / `IsRightAdjoint` instances for
`Functor.mapAction`.

The adjunction is built directly from `adj.unit` and `adj.counit`: every field is either
naturality of an existing natural transformation or a triangle identity, transported with
`Action.hom_ext`.

This completes the small family already in the same file — `Functor.mapAction`,
`Functor.mapActionComp`, `Functor.mapActionCongr`, `Equivalence.mapAction` — and is placed
immediately after `Equivalence.mapAction`. It needs no new imports: `Adjunction` is already
available via `Mathlib.CategoryTheory.Adjunction.Limits`.

### Motivation

The free–forgetful adjunction for `G`-representations does not currently exist in Mathlib.
`Rep.linearization` is there as a functor, but nothing says it is a left adjoint. With this lemma
it follows immediately from `ModuleCat.adj`:

```lean
example (k G : Type u) [CommRing k] [Monoid G] :
    (linearization k G : Action (Type u) G ⥤ Rep.{u} k G) ⊣
      RepToAction k G ⋙ (forget (ModuleCat.{u} k)).mapAction G :=
  ((ModuleCat.adj.{u} k).mapAction G).comp (repIsoAction k G).symm.toAdjunction
```

(`linearization k G = (ModuleCat.free k).mapAction G ⋙ ActionToRep k G` holds by `rfl`.) I have
kept that corollary out of this PR because it would add a
`Mathlib.Algebra.Category.ModuleCat.Adjunctions` import to `Mathlib/RepresentationTheory/Rep/Basic.lean`;
happy to add it here or in a follow-up, wherever reviewers prefer.

### Verification

Checked against Mathlib `v4.30.0`, where the patched `Mathlib/CategoryTheory/Action/Basic.lean`
compiles with no errors and no warnings. I cannot run CI's toolchain (`v4.34.0-rc2`) locally, so
this is a draft until CI confirms.

---

Opened as a draft pending CI.
