### PR TITLE
refactor(Combinatorics/Partition): eliminate T2Space requirement from generating function

### DIFF
--- a/Mathlib/Combinatorics/Enumerative/Partition/Basic.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition/Basic.lean
@@ -131,6 +131,7 @@ def ofSymShapeEquiv (μ : Partition n) (e : σ ≃ τ) :
 /-- Convert a `Partition n` to a member of `(Finset.Icc 1 n).finsuppAntidiag n`
 (see `Nat.Partition.toFinsuppAntidiag_mem_finsuppAntidiag` for the proof).
 `p.toFinsuppAntidiag i` is defined as `i` times the number of occurrence of `i` in `p`. -/
+@[simps]
 def toFinsuppAntidiag {n : ℕ} (p : Partition n) : ℕ →₀ ℕ where
   toFun m := p.parts.count m * m
   support := p.parts.toFinset

--- a/Mathlib/Combinatorics/Enumerative/Partition/GenFun.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition/GenFun.lean
@@ -108,9 +108,9 @@ private theorem aux_prod_f_eq_prod_coeff (f : ℕ → ℕ → R) {n : ℕ} (p : 
   refine prod_subset_one_on_sdiff ?_ (fun i hi ↦ ?_) (fun i hi ↦ ?_)
   · grind
   · rw [mem_sdiff, Multiset.mem_toFinset] at hi
-    simp [toFinsuppAntidiag, hi.2]
+    simp [hi.2]
   · rw [Multiset.mem_toFinset] at hi
-    simp [toFinsuppAntidiag, (p.parts_pos hi).ne.symm, Multiset.count_ne_zero.mpr hi]
+    simp [(p.parts_pos hi).ne.symm, Multiset.count_ne_zero.mpr hi]
 
 private theorem aux_dvd_of_coeff_ne_zero {f : ℕ → ℕ → R} {d : ℕ} {s : Finset ℕ}
     {g : ℕ →₀ ℕ} (hg : g ∈ s.finsuppAntidiag d) (hcoeff : ∀ i ∈ s, (coeff (g i))
@@ -148,7 +148,7 @@ private theorem aux_prod_coeff_eq_zero_of_notMem_range (f : ℕ → ℕ → R) {
     apply sum_subset_zero_on_sdiff h (by simp)
     exact fun x hx ↦ Nat.div_mul_cancel <| aux_dvd_of_coeff_ne_zero hg hprod x
   · ext x
-    simpa [toFinsuppAntidiag] using Nat.div_mul_cancel <| aux_dvd_of_coeff_ne_zero hg hprod x
+    simpa using Nat.div_mul_cancel <| aux_dvd_of_coeff_ne_zero hg hprod x
 
 variable [TopologicalSpace R]
 

--- a/Mathlib/Combinatorics/Enumerative/Partition/GenFun.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition/GenFun.lean
@@ -19,7 +19,9 @@ G_f(X) = \sum_{n = 0}^{\infty} \left(\sum_{p \in P_{n}} \prod_{i \in p} f(i, \#i
 $$
 where $P_n$ is all partitions of $n$, $\#i$ is the count of $i$ in the partition $p$.
 We give the definition `Nat.Partition.genFun` using the first equation, and prove the second
-equation in `Nat.Partition.hasProd_genFun` (with shifted indices).
+equation in `Nat.Partition.hasProd_genFun` (with shifted indices). To avoid nested infinite
+expression, the factors in the second equation is defined as `Nat.Partition.genFunFactor`, and its
+equivalence to the infinite sum is shown at `Nat.Partition.hasSum_genFunFactor`.
 
 This generating function can be specialized to
 * When $f(i, c) = 1$, this is the generating function for partition function $p(n)$
@@ -61,7 +63,8 @@ lemma coeff_genFun (f : ℕ → ℕ → R) (n : ℕ) :
     (genFun f).coeff n = ∑ p : n.Partition, p.parts.toFinsupp.prod f :=
   PowerSeries.coeff_mk _ _
 
-/-- The summands in the formula `Nat.Partition.hasProd_genFun` tends to infinity in their order. -/
+-- TODO: this was an intermediate lemma in this file but is no longer in use. Generalize this
+-- and move this to a better place.
 theorem tendsto_order_genFun_term_atTop_nhds_top (f : ℕ → ℕ → R) (i : ℕ) :
     Filter.Tendsto (fun j ↦ (f (i + 1) (j + 1) • (X : R⟦X⟧) ^ ((i + 1) * (j + 1))).order)
     Filter.atTop (nhds ⊤) := by
@@ -74,41 +77,51 @@ theorem tendsto_order_genFun_term_atTop_nhds_top (f : ℕ → ℕ → R) (i : �
   norm_cast
   grind
 
-variable [TopologicalSpace R]
+/-- Factor for part $i$ of the generating function associated with character $f(i, c)$ for partition
+functions. -/
+noncomputable def genFunFactor (f : ℕ → ℕ → R) (i : ℕ) : R⟦X⟧ :=
+  PowerSeries.mk fun n ↦ if n ≠ 0 ∧ i ∣ n then f i (n / i) else 0
 
-/-- The infinite sum in the formula `Nat.Partition.hasProd_genFun` always converges. -/
-theorem summable_genFun_term (f : ℕ → ℕ → R) (i : ℕ) :
-    Summable fun j ↦ f (i + 1) (j + 1) • (X : R⟦X⟧) ^ ((i + 1) * (j + 1)) := by
-  apply WithPiTopology.summable_of_tendsto_order_atTop_nhds_top
-  apply tendsto_order_genFun_term_atTop_nhds_top
+@[simp]
+theorem constantCoeff_genFunFactor (f : ℕ → ℕ → R) (i : ℕ) :
+    (genFunFactor f i).constantCoeff = 0 := by
+  simp [genFunFactor]
 
-/-- Alternative form of `summable_genFun_term` that unshifts the first index. -/
-theorem summable_genFun_term' (f : ℕ → ℕ → R) {i : ℕ} (hi : i ≠ 0) :
-    Summable fun j ↦ f i (j + 1) • (X : R⟦X⟧) ^ (i * (j + 1)) := by
-  obtain ⟨a, rfl⟩ := Nat.exists_eq_add_one_of_ne_zero hi
-  apply summable_genFun_term
+@[simp]
+theorem coeff_genFunFactor (f : ℕ → ℕ → R) {i j : ℕ} (hi : i ≠ 0) (hj : j ≠ 0) :
+    (genFunFactor f i).coeff (j * i) = f i j := by
+  simp [genFunFactor, hi, hj]
 
-variable [T2Space R]
+@[simp]
+theorem coeff_genFunFactor_self (f : ℕ → ℕ → R) {i : ℕ} (hi : i ≠ 0) :
+    (genFunFactor f i).coeff i = f i 1 := by
+  simpa using coeff_genFunFactor f hi (one_ne_zero)
 
-private theorem aux_dvd_of_coeff_ne_zero {f : ℕ → ℕ → R} {d : ℕ} {s : Finset ℕ} (hs0 : 0 ∉ s)
-    {g : ℕ →₀ ℕ} (hg : g ∈ s.finsuppAntidiag d)
-    (hprod : ∀ i ∈ s, (coeff (g i)) (1 + ∑' j, f i (j + 1) • X ^ (i * (j + 1))) ≠ (0 : R)) (x : ℕ) :
+theorem dvd_of_coeff_genFunFactor_ne_zero {f : ℕ → ℕ → R} {i n : ℕ}
+    (h : (genFunFactor f i).coeff n ≠ 0) : i ∣ n := by
+  simp_all [genFunFactor]
+
+private theorem aux_prod_f_eq_prod_coeff (f : ℕ → ℕ → R) {n : ℕ} (p : Partition n) {s : Finset ℕ}
+    (hs : Icc 1 n ⊆ s) :
+    p.parts.toFinsupp.prod f = ∏ i ∈ s, coeff (p.toFinsuppAntidiag i) (1 + genFunFactor f i) := by
+  simp_rw [Finsupp.prod, Multiset.toFinsupp_support, Multiset.toFinsupp_apply]
+  refine prod_subset_one_on_sdiff ?_ (fun i hi ↦ ?_) (fun i hi ↦ ?_)
+  · grind
+  · rw [mem_sdiff, Multiset.mem_toFinset] at hi
+    simp [toFinsuppAntidiag, hi.2]
+  · rw [Multiset.mem_toFinset] at hi
+    simp [toFinsuppAntidiag, (p.parts_pos hi).ne.symm, Multiset.count_ne_zero.mpr hi]
+
+private theorem aux_dvd_of_coeff_ne_zero {f : ℕ → ℕ → R} {d : ℕ} {s : Finset ℕ}
+    {g : ℕ →₀ ℕ} (hg : g ∈ s.finsuppAntidiag d) (hcoeff : ∀ i ∈ s, (coeff (g i))
+    (1 + genFunFactor f i) ≠ 0) (x : ℕ) :
     x ∣ g x := by
   by_cases hx : x ∈ s
-  · specialize hprod x hx
-    contrapose hprod
-    have hx0 : x ≠ 0 := fun h ↦ hs0 (h ▸ hx)
-    rw [map_add, (summable_genFun_term' f hx0).map_tsum _ (WithPiTopology.continuous_coeff _ _)]
-    rw [show (0 : R) = 0 + ∑' (i : ℕ), 0 by simp]
-    congrm (?_ + ∑' (i : ℕ), ?_)
-    · suffices g x ≠ 0 by simp [this]
-      contrapose hprod
-      simp [hprod]
-    · rw [map_smul, coeff_X_pow]
-      apply smul_eq_zero_of_right
-      suffices g x ≠ x * (i + 1) by simp [this]
-      contrapose hprod
-      simp [hprod]
+  · by_cases hgx : g x = 0
+    · simp [hgx]
+    specialize hcoeff x hx
+    simp only [map_add, coeff_one, hgx, ↓reduceIte, zero_add] at hcoeff
+    exact dvd_of_coeff_genFunFactor_ne_zero hcoeff
   · suffices g x = 0 by simp [this]
     contrapose! hx
     exact mem_of_subset (mem_finsuppAntidiag.mp hg).2 <| by simpa using hx
@@ -116,63 +129,57 @@ private theorem aux_dvd_of_coeff_ne_zero {f : ℕ → ℕ → R} {d : ℕ} {s : 
 private theorem aux_prod_coeff_eq_zero_of_notMem_range (f : ℕ → ℕ → R) {d : ℕ} {s : Finset ℕ}
     (hs0 : 0 ∉ s) {g : ℕ →₀ ℕ} (hg : g ∈ s.finsuppAntidiag d)
     (hg' : g ∉ Set.range (toFinsuppAntidiag (n := d))) :
-    ∏ i ∈ s, (coeff (g i)) (1 + ∑' j, f i (j + 1) • X ^ (i * (j + 1)) : R⟦X⟧) = 0 := by
-  suffices ∃ i ∈ s, (coeff (g i)) ((1 : R⟦X⟧) + ∑' j, f i (j + 1) • X ^ (i * (j + 1))) = 0 by
+    ∏ i ∈ s, (1 + genFunFactor f i).coeff (g i) = 0 := by
+  suffices ∃ i ∈ s, (1 + genFunFactor f i).coeff (g i) = 0 by
     obtain ⟨i, hi, hi'⟩ := this
-    apply prod_eq_zero hi hi'
+    exact prod_eq_zero hi hi'
   contrapose! hg' with hprod
-  rw [Set.mem_range]
   have hgne0 (i : ℕ) : g i ≠ 0 ↔ i ≠ 0 ∧ i ≤ g i := by
     refine ⟨fun h ↦ ⟨?_, ?_⟩, by grind⟩
     · contrapose hs0 with rfl
       exact mem_of_subset (mem_finsuppAntidiag.mp hg).2 (by simpa using h)
-    · exact Nat.le_of_dvd (Nat.pos_of_ne_zero h) <| aux_dvd_of_coeff_ne_zero hs0 hg hprod _
+    · exact Nat.le_of_dvd (Nat.pos_of_ne_zero h) <| aux_dvd_of_coeff_ne_zero hg hprod _
   refine ⟨Nat.Partition.mk (Finsupp.mk g.support (fun i ↦ g i / i) ?_).toMultiset ?_ ?_, ?_⟩
   · simpa using hgne0
-  · suffices ∀ i, g i ≠ 0 → i ≠ 0 by simpa [Nat.pos_iff_ne_zero]
-    exact fun i h ↦ ((hgne0 i).mp h).1
-  · obtain ⟨h1, h2⟩ := mem_finsuppAntidiag.mp hg
-    refine Eq.trans ?_ h1
+  · suffices ∀ i, g i ≠ 0 → 0 < i by simpa
+    exact fun i h ↦ Nat.pos_iff_ne_zero.mpr ((hgne0 i).mp h).1
+  · obtain ⟨rfl, h⟩ := mem_finsuppAntidiag.mp hg
     suffices ∑ x ∈ g.support, g x / x * x = ∑ x ∈ s, g x by simpa [Finsupp.sum]
-    apply sum_subset_zero_on_sdiff h2 (by simp)
-    exact fun x hx ↦ Nat.div_mul_cancel <| aux_dvd_of_coeff_ne_zero hs0 hg hprod x
+    apply sum_subset_zero_on_sdiff h (by simp)
+    exact fun x hx ↦ Nat.div_mul_cancel <| aux_dvd_of_coeff_ne_zero hg hprod x
   · ext x
-    simpa [toFinsuppAntidiag] using Nat.div_mul_cancel <| aux_dvd_of_coeff_ne_zero hs0 hg hprod x
+    simpa [toFinsuppAntidiag] using Nat.div_mul_cancel <| aux_dvd_of_coeff_ne_zero hg hprod x
 
-private theorem aux_prod_f_eq_prod_coeff (f : ℕ → ℕ → R) {n : ℕ} (p : Partition n) {s : Finset ℕ}
-    (hs : Icc 1 n ⊆ s) (hs0 : 0 ∉ s) :
-    p.parts.toFinsupp.prod f =
-    ∏ i ∈ s, coeff (p.toFinsuppAntidiag i) (1 + ∑' j, f i (j + 1) • X ^ (i * (j + 1))) := by
-  simp_rw [Finsupp.prod, Multiset.toFinsupp_support, Multiset.toFinsupp_apply]
-  apply prod_subset_one_on_sdiff
-  · grind
-  · intro x hx
-    rw [mem_sdiff, Multiset.mem_toFinset] at hx
-    have hx0 : x ≠ 0 := fun h ↦ hs0 (h ▸ hx.1)
-    have hsum := (summable_genFun_term' f hx0).map_tsum _
-      (WithPiTopology.continuous_constantCoeff R)
-    simp [toFinsuppAntidiag, hsum, hx.2, hx0]
-  · intro i hi
-    rw [Multiset.mem_toFinset] at hi
-    have hi0 : i ≠ 0 := (p.parts_pos hi).ne.symm
-    rw [map_add, (summable_genFun_term' f hi0).map_tsum _ (WithPiTopology.continuous_coeff _ _)]
-    suffices f i (Multiset.count i p.parts) =
-        ∑' j, if Multiset.count i p.parts * i = i * (j + 1) then f i (j + 1) else 0 by
-      simpa [toFinsuppAntidiag, hi, hi0, coeff_X_pow]
-    rw [tsum_eq_single (Multiset.count i p.parts - 1) ?_]
-    · rw [mul_comm]
-      simp [Nat.sub_add_cancel (Multiset.one_le_count_iff_mem.mpr hi)]
-    intro b hb
-    suffices Multiset.count i p.parts * i ≠ i * (b + 1) by simp [this]
-    rw [mul_comm i, (mul_left_inj' (Nat.ne_zero_of_lt (p.parts_pos hi))).ne]
-    grind
+variable [TopologicalSpace R]
+
+theorem hasSum_genFunFactor (f : ℕ → ℕ → R) {i : ℕ} (hi : i ≠ 0) :
+    HasSum (fun j ↦ (f i (j + 1) • (X : R⟦X⟧) ^ (i * (j + 1)))) (genFunFactor f i) := by
+  have hinj : Function.Injective (fun j ↦ i * (j + 1)) :=
+    (mul_right_injective₀ hi).comp (add_left_injective 1)
+  convert! (hinj.hasSum_iff ?_).mpr (genFunFactor f i).hasSum_of_monomials_self with j
+  · simp [genFunFactor, hi, monomial_eq_C_mul_X_pow, smul_eq_C_mul]
+  intro n h
+  suffices ¬(n ≠ 0 ∧ i ∣ n) by simp [genFunFactor, this]
+  contrapose! h
+  obtain ⟨h0, k, rfl⟩ := h
+  have : k ≠ 0 := fun h ↦ by simp [h] at h0
+  obtain ⟨j, rfl⟩ := Nat.exists_eq_add_one_of_ne_zero this
+  simp
+
+theorem summable_genFun_term (f : ℕ → ℕ → R) (i : ℕ) :
+    Summable fun j ↦ f (i + 1) (j + 1) • (X : R⟦X⟧) ^ ((i + 1) * (j + 1)) :=
+  (hasSum_genFunFactor f (by simp)).summable
+
+theorem summable_genFun_term' (f : ℕ → ℕ → R) {i : ℕ} (hi : i ≠ 0) :
+    Summable fun j ↦ f i (j + 1) • (X : R⟦X⟧) ^ (i * (j + 1)) :=
+  (hasSum_genFunFactor f hi).summable
 
 theorem hasProd_genFun (f : ℕ → ℕ → R) :
-    HasProd (fun i ↦ 1 + ∑' j, f (i + 1) (j + 1) • X ^ ((i + 1) * (j + 1))) (genFun f) := by
+    HasProd (fun i ↦ 1 + genFunFactor f (i + 1)) (genFun f) := by
   rw [HasProd, WithPiTopology.tendsto_iff_coeff_tendsto]
   refine fun d ↦ tendsto_atTop_of_eventually_const (fun s (hs : s ≥ range d) ↦ ?_)
-  have : ∏ i ∈ s, ((1 : R⟦X⟧) + ∑' j, f (i + 1) (j + 1) • X ^ ((i + 1) * (j + 1)))
-      = ∏ i ∈ s.map (addRightEmbedding 1), (1 + ∑' j, f i (j + 1) • X ^ (i * (j + 1))) := by simp
+  have : ∏ i ∈ s, (1 + genFunFactor f (i + 1)) =
+    ∏ i ∈ s.map (addRightEmbedding 1), (1 + genFunFactor f i) := by simp
   rw [this]
   have hs : Icc 1 d ⊆ s.map (addRightEmbedding 1) := by
     intro i
@@ -184,14 +191,23 @@ theorem hasProd_genFun (f : ℕ → ℕ → R) :
   · intro p _
     exact mem_of_subset (finsuppAntidiag_mono hs _) p.toFinsuppAntidiag_mem_finsuppAntidiag
   · exact fun g hg hg' ↦ aux_prod_coeff_eq_zero_of_notMem_range f (by simp) hg (by simpa using hg')
-  · exact fun p _ ↦ aux_prod_f_eq_prod_coeff f p hs (by simp)
+  · exact fun p _ ↦ aux_prod_f_eq_prod_coeff f p hs
 
-theorem multipliable_genFun (f : ℕ → ℕ → R) :
-    Multipliable fun i ↦ (1 : R⟦X⟧) + ∑' j, f (i + 1) (j + 1) • X ^ ((i + 1) * (j + 1)) :=
+theorem multipliable_one_add_genFunFactor (f : ℕ → ℕ → R) :
+    Multipliable fun i ↦ 1 + genFunFactor f (i + 1) :=
   (hasProd_genFun f).multipliable
 
+@[deprecated (since := "2026-08-30")] alias multipliable_genFun := multipliable_one_add_genFunFactor
+
+variable [T2Space R]
+
+theorem hasProd_genFun' (f : ℕ → ℕ → R) :
+    HasProd (fun i ↦ 1 + ∑' j, f (i + 1) (j + 1) • X ^ ((i + 1) * (j + 1))) (genFun f) := by
+  convert hasProd_genFun f with i
+  exact (hasSum_genFunFactor f (by simp)).tsum_eq
+
 theorem genFun_eq_tprod (f : ℕ → ℕ → R) :
-    genFun f = ∏' i, (1 + ∑' j, f (i + 1) (j + 1) • X ^ ((i + 1) * (j + 1))) :=
+    genFun f = ∏' i, (1 + genFunFactor f (i + 1)) :=
   (hasProd_genFun f).tprod_eq.symm
 
 end Nat.Partition

--- a/Mathlib/Combinatorics/Enumerative/Partition/Glaisher.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition/Glaisher.lean
@@ -50,7 +50,7 @@ theorem hasProd_powerSeriesMk_card_restricted [IsTopologicalSemiring R]
     (p : ℕ → Prop) [DecidablePred p] :
     HasProd (fun i ↦ if p (i + 1) then ∑' j : ℕ, X ^ ((i + 1) * j) else 1)
     (PowerSeries.mk fun n ↦ (#(restricted n p) : R)) := by
-  convert! hasProd_genFun (fun i c ↦ if p i then (1 : R) else 0) using 1
+  convert! hasProd_genFun' (fun i c ↦ if p i then (1 : R) else 0) using 1
   · ext1 i
     split_ifs
     · rw [tsum_eq_zero_add' ?_]
@@ -81,7 +81,7 @@ theorem hasProd_powerSeriesMk_card_countRestricted {m : ℕ} (hm : 0 < m) :
     HasProd (fun i ↦ ∑ j ∈ range m, X ^ ((i + 1) * j))
     (PowerSeries.mk fun n ↦ (#(countRestricted n m) : R)) := by
   nontriviality R using Subsingleton.eq_one (α := R⟦X⟧)
-  convert! hasProd_genFun (fun i c ↦ if c < m then (1 : R) else 0) using 1
+  convert! hasProd_genFun' (fun i c ↦ if c < m then (1 : R) else 0) using 1
   · ext1 i
     rw [sum_range_eq_add_Ico _ hm, sum_Ico_eq_sum_range]
     congrm $(by simp) + ?_


### PR DESCRIPTION
Previously, the key lemma in this file had the shape `HasProd (fun i ↦ 1 + ∑' j, f (i + 1) (j + 1) • X ^ ((i + 1) * (j + 1))) (genFun f)`, which has a nested infinite sum inside the infinite prod. As a result, all related lemma needed T2Space when it doesn't have to. The new formulation extract the inner sum into a power series definition `genFunFactor` that works in general topological space, eliminating `T2Space` for the `HasProd`/`HasSum` lemma.

The old formula is kept under the name `hasProd_genFun'`. This is still used in the downstream file `Glaisher.lean`. To reduce the code change size, the refactor in `Glaisher.lean` is deferred to a future PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
