### PR TITLE
[Merged by Bors] - chore(RepresentationTheory/Basic): un-simp `isTrivial_def`

### DIFF
--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -76,7 +76,6 @@ class IsTrivial (ρ : Representation k G V) : Prop where
 
 instance : IsTrivial (trivial k G V) where
 
-@[simp]
 theorem isTrivial_def (ρ : Representation k G V) [IsTrivial ρ] (g : G) :
     ρ g = LinearMap.id := IsTrivial.out g
 
@@ -344,9 +343,8 @@ variable (ρ : Representation k G V) (S : Subgroup G)
 lemma apply_eq_of_coe_eq [IsTrivial (ρ.comp S.subtype)] (g h : G) (hgh : (g : G ⧸ S) = h) :
     ρ g = ρ h := by
   ext x
-  apply (ρ.apply_bijective g⁻¹).1
-  simpa [← Module.End.mul_apply, ← map_mul, -isTrivial_def] using
-    (congr($(isTrivial_def (ρ.comp S.subtype) ⟨g⁻¹ * h, QuotientGroup.eq.1 hgh⟩) x)).symm
+  refine (apply_bijective ρ g⁻¹).injective.eq_iff.1 ?_
+  simpa using (isTrivial_apply (ρ.comp S.subtype) ⟨g⁻¹ * h, QuotientGroup.eq.1 hgh⟩ x).symm
 
 variable [S.Normal]
 
@@ -357,8 +355,8 @@ def ofQuotient [IsTrivial (ρ.comp S.subtype)] :
   (QuotientGroup.con S).lift ρ <| by
     rintro x y ⟨⟨z, hz⟩, rfl⟩
     ext w
-    change ρ (_ * z.unop) _ = _
-    exact congr($(apply_eq_of_coe_eq ρ S _ _ (by simp_all)) w)
+    simp only [Subgroup.mk_smul, MulOpposite.smul_eq_mul_unop]
+    exact congr($(ρ.apply_eq_of_coe_eq S _ _ (by simpa)) w)
 
 @[simp]
 lemma ofQuotient_coe_apply [IsTrivial (ρ.comp S.subtype)] (g : G) (x : V) :

--- a/Mathlib/RepresentationTheory/Coinvariants.lean
+++ b/Mathlib/RepresentationTheory/Coinvariants.lean
@@ -372,14 +372,14 @@ lemma coinvariantsFunctor_hom_ext {M : ModuleCat k} {f g : (coinvariantsFunctor 
 representation, factors through `A_G`. -/
 noncomputable abbrev desc [B.ρ.IsTrivial] (f : A ⟶ B) :
     (coinvariantsFunctor k G).obj A ⟶ ModuleCat.of k B.V :=
-  ModuleCat.ofHom <| Representation.Coinvariants.lift _ f.hom.toLinearMap <| by simp [f.hom.2]
+  ModuleCat.ofHom <| Representation.Coinvariants.lift _ f.hom.toLinearMap <| by
+    simp [f.hom.2, isTrivial_def]
 
 variable (k G)
 
 instance : (coinvariantsFunctor k G).Additive where
 instance : (coinvariantsFunctor k G).Linear k where
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The adjunction between the functor sending a representation to its coinvariants and the functor
 equipping a module with the trivial representation. -/
 @[simps]
@@ -394,7 +394,6 @@ theorem coinvariantsAdjunction_homEquiv_apply_hom {X : Rep.{w} k G} {Y : ModuleC
     ((coinvariantsMk k G).app X ≫ f).hom := by
   rfl
 
-set_option backward.defeqAttrib.useBackward true in
 @[simp]
 theorem coinvariantsAdjunction_homEquiv_symm_apply_hom {X : Rep.{w} k G} {Y : ModuleCat k}
     (f : X ⟶ (trivialFunctor k G).obj Y) :

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/LowDegree.lean
@@ -950,7 +950,7 @@ theorem π_comp_H0IsoOfIsTrivial_hom :
 variable {A} in
 @[simp]
 theorem H0IsoOfIsTrivial_inv_apply (x : A) :
-    (H0IsoOfIsTrivial A).inv x = (H0Iso A).inv ⟨x, by simp⟩ := rfl
+    (H0IsoOfIsTrivial A).inv x = (H0Iso A).inv ⟨x, by simp [isTrivial_apply]⟩ := rfl
 
 end IsTrivial
 end H0
@@ -1015,7 +1015,7 @@ def H1IsoOfIsTrivial :
     H1 A ≅ ModuleCat.of k (Additive G →+ A) :=
   (HomologicalComplex.isoHomologyπ _ 0 1 (CochainComplex.prev_nat_succ 0) <| by
     ext; simp [inhomogeneousCochains.d, Unique.eq_default (α := Fin 0 → G),
-      CochainComplex.of.d]).symm ≪≫
+      CochainComplex.of.d, isTrivial_apply]).symm ≪≫
   isoCocycles₁ A ≪≫ cocycles₁IsoOfIsTrivial A
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
@@ -137,7 +137,7 @@ lemma chains₁ToCoinvariantsKer_surjective :
 @[simp]
 theorem d₁₀_eq_zero_of_isTrivial [A.IsTrivial] : d₁₀ A = 0 := by
   ext
-  simp [d₁₀]
+  simp [d₁₀, isTrivial_apply]
 
 /-- The 1st differential in the complex of inhomogeneous chains of `A : Rep k G`, as a
 `k`-linear map `(G² →₀ A) → (G →₀ A)`. It is defined by
@@ -893,7 +893,7 @@ def H0IsoOfIsTrivial :
     H0 A ≅ ModuleCat.of k A.V :=
   ((inhomogeneousChains A).isoHomologyπ 1 0 (by simp) <| by
     ext; simp [inhomogeneousChains.d_single (G := G), ChainComplex.of.d,
-       Unique.eq_default (α := Fin 0 → G)]).symm ≪≫ cyclesIso₀ A
+       Unique.eq_default (α := Fin 0 → G), isTrivial_apply]).symm ≪≫ cyclesIso₀ A
 
 @[simp]
 theorem H0IsoOfIsTrivial_inv_eq_π :
@@ -984,7 +984,7 @@ def mkH1OfIsTrivial : Additive (Abelianization G) →ₗ[ℤ] A →ₗ[ℤ] H1 A
     map_mul' g h := Multiplicative.toAdd.injective <| LinearMap.ext fun a => by
       simpa [← map_add] using ((H1π_eq_iff _ _).2 ⟨single (g, h) a, by
         simp [cycles₁IsoOfIsTrivial, sub_add_eq_add_sub, add_comm (single h a),
-          d₂₁_single (A := A)]⟩).symm }
+          d₂₁_single (A := A), isTrivial_apply]⟩).symm }
 
 variable {A} in
 @[simp]
@@ -1000,7 +1000,8 @@ def H1ToTensorOfIsTrivial : H1 A →ₗ[ℤ] (Additive <| Abelianization G) ⊗[
     (TensorProduct.mk ℤ _ _ (Additive.ofMul (Abelianization.of g)))).comp
       (cycles₁ A).toAddSubgroup.subtype) fun ⟨y, hy⟩ ⟨z, hz⟩ => AddMonoidHom.mem_ker.2 <| by
       simp [← hz, d₂₁, sum_sum_index, sum_add_index', tmul_add, sum_sub_index, tmul_sub,
-        shortComplexH1]).comp <| AddMonoidHomClass.toAddMonoidHom (H1Iso A).hom.hom).toIntLinearMap
+        shortComplexH1, isTrivial_apply]).comp <|
+          AddMonoidHomClass.toAddMonoidHom (H1Iso A).hom.hom).toIntLinearMap
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in


### PR DESCRIPTION
`isTrivial_def` is a poor simp lemma since its LHS matches every application of every representation.
Indeed, when doing double (or more) quotienting, `isTrivial_def` will make `simp` much slower, 
```
import Mathlib.RepresentationTheory.Invariants

open Representation
variable {k G : Type*} [CommRing k] [Group G] (A : Rep k G)
  (H : Subgroup G) [H.Normal] (K : Subgroup (G ⧸ H)) [K.Normal]

-- a `rfl` fact that `simp` proves via `ofQuotient_coe_apply`, `subrepresentation_apply`, …
set_option trace.profiler.useHeartbeats true in
set_option trace.profiler true in
example (g : G) (x : (A.quotientToInvariants H).quotientToInvariants K) :
    (((A.quotientToInvariants H).quotientToInvariants K).ρ ((g : G ⧸ H) : (G ⧸ H) ⧸ K) x).1.1
      = A.ρ g x.1.1 := by
  simp                     -- 2012796
  -- simp [-isTrivial_def] -- 1461641 
```

We also remove two superfluous backward compatibility options.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
