### PR TITLE
[Merged by Bors] - feat(AffineSpace): generalize lemma to infinite-dimensional ambient spaces

### DIFF
--- a/Mathlib/Analysis/Normed/Affine/AddTorsorBases.lean
+++ b/Mathlib/Analysis/Normed/Affine/AddTorsorBases.lean
@@ -137,7 +137,7 @@ theorem interior_convexHull_nonempty_iff_affineSpan_eq_top [FiniteDimensional �
   suffices (interior (convexHull ℝ (range b))).Nonempty by
     rw [hb, Subtype.range_coe_subtype, ofPred_mem_eq] at this
     refine this.mono (by gcongr)
-  lift t to Finset V using b.finite_set
+  lift t to Finset V using b.setFinite
   exact ⟨_, b.centroid_mem_interior_convexHull⟩
 
 theorem Convex.interior_nonempty_iff_affineSpan_eq_top [FiniteDimensional ℝ V] {s : Set V}

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -91,18 +91,35 @@ instance finiteDimensional_direction_affineSpan_image_of_finite [Finite ι] (p :
     FiniteDimensional k (affineSpan k (p '' s)).direction :=
   finiteDimensional_direction_affineSpan_of_finite k (Set.toFinite _)
 
-/-- An affine-independent family of points in a finite-dimensional affine subspace is finite. -/
-theorem finite_of_fin_dim_affineIndependent {p : ι → P} (hi : AffineIndependent k p)
-    [FiniteDimensional k (vectorSpan k (Set.range p))] : Finite ι := by
+/-- An affine-independent family of points `p` generates a finite-dimensional subspace iff `p` is
+finite. -/
+theorem finiteDimensional_iff_finite {p : ι → P} (hi : AffineIndependent k p) :
+    FiniteDimensional k (vectorSpan k (Set.range p)) ↔ Finite ι := by
+  refine ⟨fun _ ↦ ?_, fun _ ↦ finiteDimensional_vectorSpan_range _ _⟩
   nontriviality ι; inhabit ι
   rw [affineIndependent_iff_linearIndependent_vsub k p default] at hi
   refine (Set.finite_singleton default).finite_of_compl (Set.finite_coe_iff.mp ?_)
   exact hi.codRestrict (vectorSpan k (Set.range p)) (by simp [vsub_mem_vectorSpan]) |>.finite
 
+/-- An affine-independent family of points in a finite-dimensional affine subspace is finite. -/
+@[deprecated finiteDimensional_iff_finite (since := "2026-09-01")]
+theorem finite_of_fin_dim_affineIndependent {p : ι → P} (hi : AffineIndependent k p)
+    [FiniteDimensional k (vectorSpan k (Set.range p))] : Finite ι :=
+  finiteDimensional_iff_finite k hi |>.mp inferInstance
+
+/-- An affine-independent subset `s` generates a finite-dimensional subspace iff `s` isfinite. -/
+theorem finiteDimensional_iff_finite' {s : Set ι} {f : s → P}
+    (hi : AffineIndependent k f) : FiniteDimensional k (vectorSpan k (Set.range f)) ↔ s.Finite := by
+  refine ⟨fun _ ↦ ?_, fun h ↦ ?_⟩
+  · exact @Set.toFinite _ s (finiteDimensional_iff_finite k hi |>.mp inferInstance)
+  · have := Set.Finite.to_subtype h
+    exact finiteDimensional_vectorSpan_range k f
+
 /-- An affine-independent subset of a finite-dimensional affine subspace is finite. -/
+@[deprecated finiteDimensional_iff_finite' (since := "2026-09-01")]
 theorem finite_set_of_fin_dim_affineIndependent {s : Set ι} {f : s → P} (hi : AffineIndependent k f)
     [FiniteDimensional k (vectorSpan k (Set.range f))] : s.Finite :=
-  @Set.toFinite _ s (finite_of_fin_dim_affineIndependent k hi)
+  finiteDimensional_iff_finite' k hi |>.mp inferInstance
 
 variable {k}
 
@@ -836,7 +853,7 @@ protected theorem finiteDimensional [Finite ι] (b : AffineBasis ι k P) : Finit
   (b.basisOf i).finiteDimensional_of_finite
 
 protected theorem finite [FiniteDimensional k V] (b : AffineBasis ι k P) : Finite ι :=
-  finite_of_fin_dim_affineIndependent k b.ind
+  finiteDimensional_iff_finite k b.ind |>.mp inferInstance
 
 protected theorem finite_set [FiniteDimensional k V] {s : Set ι} (b : AffineBasis s k P) :
     s.Finite :=

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -108,7 +108,7 @@ theorem finite_of_fin_dim_affineIndependent {p : ι → P} (hi : AffineIndepende
   finiteDimensional_iff_finite k hi |>.mp inferInstance
 
 /-- An affine-independent subset `s` generates a finite-dimensional subspace iff `s` isfinite. -/
-theorem finiteDimensional_iff_finite' {s : Set ι} {f : s → P}
+theorem finiteDimensional_iff_setFinite {s : Set ι} {f : s → P}
     (hi : AffineIndependent k f) : FiniteDimensional k (vectorSpan k (Set.range f)) ↔ s.Finite := by
   refine ⟨fun _ ↦ ?_, fun h ↦ ?_⟩
   · exact @s.toFinite _ (finiteDimensional_iff_finite k hi |>.mp inferInstance)
@@ -116,10 +116,10 @@ theorem finiteDimensional_iff_finite' {s : Set ι} {f : s → P}
     exact finiteDimensional_vectorSpan_range k f
 
 /-- An affine-independent subset of a finite-dimensional affine subspace is finite. -/
-@[deprecated finiteDimensional_iff_finite' (since := "2026-09-01")]
+@[deprecated finiteDimensional_iff_setFinite (since := "2026-09-01")]
 theorem finite_set_of_fin_dim_affineIndependent {s : Set ι} {f : s → P} (hi : AffineIndependent k f)
     [FiniteDimensional k (vectorSpan k (Set.range f))] : s.Finite :=
-  finiteDimensional_iff_finite' k hi |>.mp inferInstance
+  finiteDimensional_iff_setFinite k hi |>.mp inferInstance
 
 variable {k}
 
@@ -855,9 +855,12 @@ protected theorem finiteDimensional [Finite ι] (b : AffineBasis ι k P) : Finit
 protected theorem finite [FiniteDimensional k V] (b : AffineBasis ι k P) : Finite ι :=
   finiteDimensional_iff_finite k b.ind |>.mp inferInstance
 
-protected theorem finite_set [FiniteDimensional k V] {s : Set ι} (b : AffineBasis s k P) :
+protected theorem setFinite [FiniteDimensional k V] {s : Set ι} (b : AffineBasis s k P) :
     s.Finite :=
-  finiteDimensional_iff_finite' k b.ind |>.mp inferInstance
+  finiteDimensional_iff_setFinite k b.ind |>.mp inferInstance
+
+@[deprecated AffineBasis.setFinite (since := "2026-09-01")]
+protected alias finite_set := AffineBasis.setFinite
 
 theorem card_eq_finrank_add_one [Fintype ι] (b : AffineBasis ι k P) :
     Fintype.card ι = Module.finrank k V + 1 :=
@@ -867,7 +870,7 @@ theorem card_eq_finrank_add_one [Fintype ι] (b : AffineBasis ι k P) :
 theorem exists_affineBasis_of_finiteDimensional [Fintype ι] [FiniteDimensional k V]
     (h : Fintype.card ι = Module.finrank k V + 1) : Nonempty (AffineBasis ι k P) := by
   obtain ⟨s, b, hb⟩ := AffineBasis.exists_affineBasis k V P
-  lift s to Finset P using b.finite_set
+  lift s to Finset P using b.setFinite
   refine ⟨b.reindex <| Fintype.equivOfCardEq ?_⟩
   rw [h, ← b.card_eq_finrank_add_one]
 

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -91,18 +91,17 @@ instance finiteDimensional_direction_affineSpan_image_of_finite [Finite ι] (p :
     FiniteDimensional k (affineSpan k (p '' s)).direction :=
   finiteDimensional_direction_affineSpan_of_finite k (Set.toFinite _)
 
-/-- An affine-independent family of points in a finite-dimensional affine space is finite. -/
-theorem finite_of_fin_dim_affineIndependent [FiniteDimensional k V] {p : ι → P}
-    (hi : AffineIndependent k p) : Finite ι := by
+/-- An affine-independent family of points in a finite-dimensional affine subspace is finite. -/
+theorem finite_of_fin_dim_affineIndependent {p : ι → P} (hi : AffineIndependent k p)
+    [FiniteDimensional k (vectorSpan k (Set.range p))] : Finite ι := by
   nontriviality ι; inhabit ι
   rw [affineIndependent_iff_linearIndependent_vsub k p default] at hi
-  let : IsNoetherian k V := IsNoetherian.iff_fg.2 inferInstance
-  exact
-    (Set.finite_singleton default).finite_of_compl (Set.finite_coe_iff.1 hi.finite_of_isNoetherian)
+  refine (Set.finite_singleton default).finite_of_compl (Set.finite_coe_iff.mp ?_)
+  exact hi.codRestrict (vectorSpan k (Set.range p)) (by simp [vsub_mem_vectorSpan]) |>.finite
 
-/-- An affine-independent subset of a finite-dimensional affine space is finite. -/
-theorem finite_set_of_fin_dim_affineIndependent [FiniteDimensional k V] {s : Set ι} {f : s → P}
-    (hi : AffineIndependent k f) : s.Finite :=
+/-- An affine-independent subset of a finite-dimensional affine subspace is finite. -/
+theorem finite_set_of_fin_dim_affineIndependent {s : Set ι} {f : s → P} (hi : AffineIndependent k f)
+    [FiniteDimensional k (vectorSpan k (Set.range f))] : s.Finite :=
   @Set.toFinite _ s (finite_of_fin_dim_affineIndependent k hi)
 
 variable {k}

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -111,8 +111,8 @@ theorem finite_of_fin_dim_affineIndependent {p : ι → P} (hi : AffineIndepende
 theorem finiteDimensional_iff_finite' {s : Set ι} {f : s → P}
     (hi : AffineIndependent k f) : FiniteDimensional k (vectorSpan k (Set.range f)) ↔ s.Finite := by
   refine ⟨fun _ ↦ ?_, fun h ↦ ?_⟩
-  · exact @Set.toFinite _ s (finiteDimensional_iff_finite k hi |>.mp inferInstance)
-  · have := Set.Finite.to_subtype h
+  · exact @s.toFinite _ (finiteDimensional_iff_finite k hi |>.mp inferInstance)
+  · have := h.to_subtype
     exact finiteDimensional_vectorSpan_range k f
 
 /-- An affine-independent subset of a finite-dimensional affine subspace is finite. -/

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -857,7 +857,7 @@ protected theorem finite [FiniteDimensional k V] (b : AffineBasis ι k P) : Fini
 
 protected theorem finite_set [FiniteDimensional k V] {s : Set ι} (b : AffineBasis s k P) :
     s.Finite :=
-  finite_set_of_fin_dim_affineIndependent k b.ind
+  finiteDimensional_iff_finite' k b.ind |>.mp inferInstance
 
 theorem card_eq_finrank_add_one [Fintype ι] (b : AffineBasis ι k P) :
     Fintype.card ι = Module.finrank k V + 1 :=

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -205,10 +205,14 @@ theorem LinearIndependent.units_smul_iff (v : ι → M) (w : ι → Rˣ) :
   convert! h.units_smul (fun i ↦ (w i)⁻¹)
   simp [funext_iff]
 
+protected theorem LinearIndependent.codRestrict (hs : LinearIndependent R v) (N : Submodule R M)
+    (h : ∀ i, v i ∈ N) : LinearIndependent R (Set.codRestrict v N h) :=
+  LinearIndependent.of_comp N.subtype hs
+
 theorem linearIndependent_span (hs : LinearIndependent R v) :
     LinearIndependent R (M := span R (range v))
       (fun i : ι ↦ ⟨v i, subset_span (mem_range_self i)⟩) :=
-  LinearIndependent.of_comp (span R (range v)).subtype hs
+  hs.codRestrict _ _
 
 /-- Every finite subset of a linearly independent set is linearly independent. -/
 theorem linearIndependent_finset_map_embedding_subtype (s : Set M)


### PR DESCRIPTION
Currently, `finite_set_of_fin_dim_affineIndependent` / `finite_of_fin_dim_affineIndependent` both require finite dimensional ambient spaces, when they only require that the affinely independent set of points under consideration forms a finite-dimensional subspace. Perform this trivial generalization.

---

AI disclosure: Claude's solution was nicer than my original approach, so I ended up polishing it instead.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
