### PR TITLE
[Merged by Bors] - perf: fix LocalCohomology.lean

### DIFF
--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -80,7 +80,8 @@ section
 variable {R : Type u} [CommRing R] {D : Type u₁} [Category.{v₁} D]
 variable {E : Type u₂} [Category.{v₂} E] (I' : E ⥤ D) (I : D ⥤ Ideal R)
 
-@[simps!]
+/-- The diagram `ringModIdeals (I' ⋙ I)` is isomorphism (in fact, definitionally equal)
+to the the diagram `I' ⋙ ringModIdeals I`. -/
 def ringModIdealComp : ringModIdeals (I' ⋙ I) ≅ I' ⋙ ringModIdeals I :=
   NatIso.ofComponents (fun _ ↦ .refl _)
 

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -53,25 +53,36 @@ open Opposite CategoryTheory Limits
 
 noncomputable section
 
-universe u v v'
+universe u v₁ v₂ v₃ u₁ u₂ u₃
 
 namespace localCohomology
 
 -- We define local cohomology, implemented as a direct limit of `Ext(R/J, -)`.
 section
 
-variable {R : Type u} [CommRing R] {D : Type v} [SmallCategory D]
+variable {R : Type u} [CommRing R] {D : Type u₁} [Category.{v₁} D]
 
 /-- The directed system of `R`-modules of the form `R/J`, where `J` is an ideal of `R`,
 determined by the functor `I` -/
+@[implicit_reducible, simps]
 def ringModIdeals (I : D ⥤ Ideal R) : D ⥤ ModuleCat.{u} R where
   obj t := ModuleCat.of R <| R ⧸ I.obj t
-  map w := ModuleCat.ofHom <| Submodule.mapQ _ _ LinearMap.id (I.map w).down.down
+  map w := ModuleCat.ofHom <| Submodule.mapQ _ _ LinearMap.id (leOfHom (I.map w))
 
 /-- The diagram we will take the colimit of to define local cohomology, corresponding to the
 directed system determined by the functor `I` -/
-def diagram (I : D ⥤ Ideal R) (i : ℕ) : Dᵒᵖ ⥤ ModuleCat.{u} R ⥤ ModuleCat.{u} R :=
+abbrev diagram (I : D ⥤ Ideal R) (i : ℕ) : Dᵒᵖ ⥤ ModuleCat.{u} R ⥤ ModuleCat.{u} R :=
   (ringModIdeals I).op ⋙ Ext R (ModuleCat.{u} R) i
+
+end
+section
+
+variable {R : Type u} [CommRing R] {D : Type u₁} [Category.{v₁} D]
+variable {E : Type u₂} [Category.{v₂} E] (I' : E ⥤ D) (I : D ⥤ Ideal R)
+
+@[simps!]
+def ringModIdealComp : ringModIdeals (I' ⋙ I) ≅ I' ⋙ ringModIdeals I :=
+  NatIso.ofComponents (fun _ ↦ .refl _)
 
 end
 
@@ -79,10 +90,7 @@ section
 
 -- We momentarily need to work with a type inequality, as later we will take colimits
 -- along diagrams either in Type, or in the same universe as the ring, and we need to cover both.
-variable {R : Type max u v} [CommRing R] {D : Type v} [SmallCategory D]
-
-lemma hasColimitDiagram (I : D ⥤ Ideal R) (i : ℕ) :
-    HasColimit (diagram I i) := inferInstance
+variable {R : Type u} [CommRing R] {D : Type u₁} [Category.{v₁} D]
 
 /-
 In this definition we do not assume any special property of the diagram `I`, but the relevant case
@@ -94,27 +102,31 @@ in an ideal `J`, `localCohomology` and `localCohomology.ofSelfLERadical`.
 /-- `localCohomology.ofDiagram I i` is the functor sending a module `M` over a commutative
 ring `R` to the direct limit of `Ext^i(R/J, M)`, where `J` ranges over a collection of ideals
 of `R`, represented as a functor `I`. -/
-def ofDiagram (I : D ⥤ Ideal R) (i : ℕ) : ModuleCat.{max u v} R ⥤ ModuleCat.{max u v} R :=
-  have := hasColimitDiagram.{u, v} I i
+abbrev ofDiagram (I : D ⥤ Ideal R) (i : ℕ) [HasColimit (diagram I i)] :
+    ModuleCat.{u} R ⥤ ModuleCat.{u} R :=
   colimit (diagram I i)
 
 end
 
 section
 
-variable {R : Type max u v v'} [CommRing R] {D : Type v} [SmallCategory D]
-variable {E : Type v'} [SmallCategory E] (I' : E ⥤ D) (I : D ⥤ Ideal R)
+variable {R : Type u} [CommRing R] {D : Type u₁} [Category.{v₁} D]
+variable {E : Type u₂} [Category.{v₂} E] (I' : E ⥤ D) (I : D ⥤ Ideal R)
 
 /-- Local cohomology along a composition of diagrams. -/
 def diagramComp (i : ℕ) : diagram (I' ⋙ I) i ≅ I'.op ⋙ diagram I i :=
-  Iso.refl _
+  -- Iso.refl _ could work but would be very slow.
+  calc diagram (I' ⋙ I) i
+    _ ≅ (I' ⋙ ringModIdeals I).op ⋙ Ext R (ModuleCat.{u} R) i :=
+      Functor.isoWhiskerRight (NatIso.op (ringModIdealComp I' I)) _
+    _ ≅ (I'.op ⋙ (ringModIdeals I).op) ⋙ Ext R (ModuleCat.{u} R) i :=
+      Functor.isoWhiskerRight (Functor.opComp ..) _
+    _ ≅ I'.op ⋙ diagram I i := Functor.associator _ _ _
 
 /-- Local cohomology agrees along precomposition with a cofinal diagram. -/
-@[nolint unusedHavesSuffices]
-def isoOfFinal [Functor.Initial I'] (i : ℕ) :
-    ofDiagram.{max u v, v'} (I' ⋙ I) i ≅ ofDiagram.{max u v', v} I i :=
-  have := hasColimitDiagram.{max u v', v} I i
-  have := hasColimitDiagram.{max u v, v'} (I' ⋙ I) i
+abbrev isoOfFinal [Functor.Initial I'] (i : ℕ)
+    [HasColimit (diagram (I' ⋙ I) i)] [HasColimit (diagram I i)] :
+    ofDiagram.{u} (I' ⋙ I) i ≅ ofDiagram I i :=
   HasColimit.isoOfNatIso (diagramComp.{u} I' I i) ≪≫ Functor.Final.colimitIso _ _
 
 end


### PR DESCRIPTION
The bump to v4.34.0-rc2 made the (leaf) file `Algebra/Homology/LocalCohomology.lean` very slow.

It seems the culprit was the isomorphism `localCohomology.diagramComp`, whose body was an `Iso.refl _` abusing several definition equalities of functors (strict associativity, `Functor.opComp`, etc.).
It also looks like the universe setup in this file was using the bad pattern of typing rings in `max u v` to ensure that certain colimits exist, instead of letting the universe be free and assuming that the colimits exist (which is then automatic for reasonable universes). Some time in the file was probably lost to universe normalization.

This file will probably have to be refactored further in the future as it relies on the to-be-deprecated `Ext`, instead of using `CategoryTheory.Abelian.Ext`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
