### PR TITLE
chore: change `Equiv.topologicalSpace` to use the coinduced topology

### DIFF
--- a/Mathlib/Analysis/Normed/Module/TransferInstance.lean
+++ b/Mathlib/Analysis/Normed/Module/TransferInstance.lean
@@ -45,9 +45,21 @@ end Equiv
 /-- Transfer `NormedSpace` across an `AddEquiv` -/
 protected abbrev AddEquiv.normedSpace (𝕜 : Type*) [NormedField 𝕜]
     [AddCommGroup α] [SeminormedAddCommGroup β] [NormedSpace 𝕜 β] (e : α ≃+ β) :
-    letI : SeminormedAddCommGroup α := .induced _ _ e
+    letI : SeminormedAddCommGroup α :=
+      letI := e.pseudometricSpace
+      fast_instance%
+      { SeminormedAddCommGroup.induced α β e with
+        toPseudoMetricSpace := e.pseudometricSpace }
     NormedSpace 𝕜 α :=
+  letI : SeminormedAddCommGroup α :=
+    letI := e.pseudometricSpace
+    fast_instance%
+    { SeminormedAddCommGroup.induced α β e with
+      toPseudoMetricSpace := e.pseudometricSpace }
   letI := e.module 𝕜
-  .induced _ _ _ (e.linearEquiv _)
+  { norm_smul_le a b := by
+      change norm (e (a • b)) ≤ norm a * norm (e b)
+      rw [← norm_smul, ← e.linearEquiv_apply (R := 𝕜),
+        ← e.linearEquiv_apply (R := 𝕜), map_smul] }
 
 @[deprecated (since := "2026-07-30")] alias Equiv.normedSpace := AddEquiv.normedSpace

--- a/Mathlib/Topology/Algebra/Module/TransferInstance.lean
+++ b/Mathlib/Topology/Algebra/Module/TransferInstance.lean
@@ -46,10 +46,7 @@ def continuousLinearEquiv (e : α ≃+ β) :
   letI := e.topologicalSpace
   letI := e.module R
   { toLinearEquiv := e.linearEquiv _
-    continuous_toFun := continuous_induced_dom
-    continuous_invFun := by
-      simp +instances only [Equiv.topologicalSpace, e.toFun_as_coe, ← e.coinduced_symm]
-      exact continuous_coinduced_rng }
+    __ := e.homeomorph }
 
 @[simp]
 lemma toLinearEquiv_continuousLinearEquiv (e : α ≃+ β) :

--- a/Mathlib/Topology/Homeomorph/TransferInstance.lean
+++ b/Mathlib/Topology/Homeomorph/TransferInstance.lean
@@ -25,7 +25,7 @@ namespace Equiv
 /-- Transfer a `TopologicalSpace` across an `Equiv` -/
 protected abbrev topologicalSpace [TopologicalSpace β] (e : α ≃ β) :
     TopologicalSpace α :=
-  .induced e.toFun ‹_›
+  .coinduced e.invFun ‹_›
 
 /-- An equivalence `e : α ≃ β` gives a homeomorphism `α ≃ₜ β` where the topological space structure
 on `α` is the one obtained by transporting the topological space structure on `β` back along `e`. -/
@@ -34,11 +34,11 @@ def homeomorph [TopologicalSpace β] (e : α ≃ β) :
     α ≃ₜ β :=
   letI := e.topologicalSpace
   { e with
-    continuous_toFun := continuous_induced_dom
-    continuous_invFun := by
-      simp only [Equiv.invFun_as_coe]
-      convert! continuous_coinduced_rng
-      rw [e.coinduced_symm]
+    continuous_invFun := continuous_coinduced_rng
+    continuous_toFun := by
+      simp only [Equiv.toFun_as_coe]
+      convert! continuous_induced_dom
+      rw [← e.coinduced_symm]
       rfl }
 
 end Equiv

--- a/Mathlib/Topology/MetricSpace/TransferInstance.lean
+++ b/Mathlib/Topology/MetricSpace/TransferInstance.lean
@@ -6,6 +6,7 @@ Authors: Michael Rothgang
 module
 
 public import Mathlib.Topology.MetricSpace.Basic
+public import Mathlib.Topology.Homeomorph.TransferInstance
 
 /-!
 # Transfer metric space structures across `Equiv`s
@@ -28,10 +29,14 @@ protected abbrev dist (e : α ≃ β) [Dist β] : Dist α := ⟨fun x y ↦ dist
 
 /-- Transfer a `PseudoMetricSpace` across an `Equiv` -/
 protected abbrev pseudometricSpace [PseudoMetricSpace β] (e : α ≃ β) : PseudoMetricSpace α :=
-  .induced e.toFun ‹_›
+  letI := e.topologicalSpace
+  (PseudoMetricSpace.induced e.toFun ‹_›).replaceTopology
+    (by exact congrFun e.coinduced_symm inferInstance)
 
 /-- Transfer a `MetricSpace` across an `Equiv` -/
 protected abbrev metricSpace [MetricSpace β] (e : α ≃ β) : MetricSpace α :=
-  .induced e.toFun e.injective ‹_›
+  letI := e.topologicalSpace
+  (MetricSpace.induced e.toFun e.injective ‹_›).replaceTopology
+    (by exact congrFun e.coinduced_symm inferInstance)
 
 end Equiv


### PR DESCRIPTION
Change `Equiv.topologicalSpace` to be an `abbrev` for `.coinduced e.invFun ‹_›` instead of `.induced e.toFun ‹_›`. They are propeq, but `.coinduced` has better defeqs. For example, `(f.trans g).topologicalSpace` is defeq to `letI := g.topologicalSpace; f.topologicalSpace` and `letI := e.topolgicalSpace; IsOpen s` is defeq to `IsOpen (e.symm ⁻¹' s)`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
