### PR TITLE
[Merged by Bors] - refactor(RatFunc/Ostrowski): drop unnecessary hypothesis

### DIFF
--- a/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
+++ b/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
@@ -17,6 +17,10 @@ valuation at infinity `FunctionField.inftyValuation K`.
 
 ## Main results
 - `RatFunc.valuation_isEquiv_infty_or_adic`: Ostrowski's theorem for `K(X)`.
+
+### TODO
+- Show that a nontrivial valuation `v`, trivial on `K`, is a rank one discrete valuation.
+
 -/
 
 @[expose] public noncomputable section
@@ -252,8 +256,6 @@ lemma valuation_isEquiv_adic_of_not_isEquiv_infty [DecidableEq (RatFunc K)]
   valuation_isEquiv_infty_or_adic.or.resolve_left hni
 
 end IsTrivialOn
-
--- TODO: Show that `v` is a rank one discrete valuation.
 
 end RatFunc
 

--- a/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
+++ b/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
@@ -5,14 +5,13 @@ Authors: María Inés de Frutos-Fernández, Xavier Généreux
 -/
 module
 
-public import Mathlib.RingTheory.Valuation.Discrete.Basic
 public import Mathlib.FieldTheory.RatFunc.Valuation
 
 /-!
 # Ostrowski's theorem for `K(X)`
 
 This file proves Ostrowski's theorem for the field of rational functions `K(X)`, where `K` is any
-field: if `v` is a discrete valuation on `K(X)` which is trivial on elements of `K`, then `v` is
+field: if `v` is a valuation on `K(X)` which is trivial on elements of `K`, then `v` is
 equivalent to either the `I`-adic valuation for some `I : HeightOneSpectrum K[X]`, or to the
 valuation at infinity `FunctionField.inftyValuation K`.
 
@@ -184,28 +183,7 @@ lemma exists_zpow_uniformizingPolynomial {f : RatFunc K} (hf : f ≠ 0) :
       valuation_eq_valuation_uniformizingPolynomial_pow_of_valuation_X_le_one hle
         (p := p) (by aesop)]
 
-lemma uniformizingPolynomial_isUniformizer [hv : IsRankOneDiscrete v] :
-    v.IsUniformizer πᵥ := by
-  have h0 : v πᵥ ≠ 0 := by simpa using uniformizingPolynomial_ne_zero hle
-  rw [IsUniformizer, ← hv.valueGroup_genLTOne_eq_generator, ← h0.isUnit.unit_spec, Units.val_inj]
-  apply LinearOrderedCommGroup.Subgroup.genLTOne_unique
-  · rw [← Units.val_lt_val, h0.isUnit.unit_spec, Units.val_one]
-    exact valuation_uniformizingPolynomial_lt_one hle
-  · ext γ
-    simp only [coePolynomial_eq_algebraMap, MonoidWithZeroHom.mem_valueGroup_iff_of_comm, ne_eq,
-      map_eq_zero, Subgroup.mem_zpowers_iff]
-    refine ⟨fun ⟨k, hk⟩ ↦ ?_, fun ⟨a, ha, b, hab⟩ ↦ ?_⟩
-    · use 1, one_ne_zero, πᵥ ^ k
-      simp only [← Units.val_inj, Units.val_zpow_eq_zpow_val] at hk
-      simp [← hk]
-    · obtain ⟨ka, hka⟩ := exists_zpow_uniformizingPolynomial hle ha
-      obtain ⟨kb, hkb⟩ := exists_zpow_uniformizingPolynomial hle (f := b) (by aesop)
-      rw [MonoidWithZeroHom.coe_ofClass, hka, hkb] at hab
-      use kb - ka
-      have : v ↑πᵥ ^ ka ≠ 0 := zpow_ne_zero _ h0
-      simp [zpow_sub, ← Units.val_inj, ← coePolynomial_eq_algebraMap, field, ← hab]
-
-lemma valuation_isEquiv_valuationIdeal_adic_of_valuation_X_le_one [IsRankOneDiscrete v] :
+lemma valuation_isEquiv_valuationIdeal_adic_of_valuation_X_le_one :
     v.IsEquiv ((Pᵥ).valuation (RatFunc K)) := by
   rw [isEquiv_iff_val_le_one]
   intro f
@@ -214,14 +192,14 @@ lemma valuation_isEquiv_valuationIdeal_adic_of_valuation_X_le_one [IsRankOneDisc
   · induction f using RatFunc.induction_on with
     | f p q hq0 =>
       have hp0 : p ≠ 0 := by simp_all
-      set pi := πᵥ with hpi_def
-      have hpi : v.IsUniformizer (pi : RatFunc K) := uniformizingPolynomial_isUniformizer hle
+      have h0lt : 0 < v (algebraMap K[X] (RatFunc K) πᵥ) := by
+        simp [pos_of_ne_zero, ne_zero_iff v, uniformizingPolynomial_ne_zero hle]
       simp only [map_div₀, valuation_of_algebraMap, intValuation_def, exp_neg, ite_eq_right hp0,
-        ite_eq_right hq0, div_inv_eq_mul]
-      rw [valuation_eq_valuation_uniformizingPolynomial_pow_of_valuation_X_le_one hle hp0,
+        ite_eq_right hq0, div_inv_eq_mul,
+        valuation_eq_valuation_uniformizingPolynomial_pow_of_valuation_X_le_one hle hp0,
         valuation_eq_valuation_uniformizingPolynomial_pow_of_valuation_X_le_one hle hq0]
-      simp_all [div_le_one₀, ← exp_add,
-        (pow_le_pow_iff_right_of_lt_one₀ (by simp_all) (IsRankOneDiscrete.generator_lt_one v))]
+      simp_all [div_le_one₀, ← exp_add, (pow_le_pow_iff_right_of_lt_one₀ h0lt
+        (valuation_uniformizingPolynomial_lt_one hle))]
 
 end Associates
 
@@ -242,23 +220,19 @@ lemma adicValuation_ne_inftyValuation [DecidableEq (RatFunc K)]
   by_contra h
   exact absurd Valuation.IsEquiv.refl (h ▸ adicValuation_not_isEquiv_infty_valuation p)
 
-section Discrete
-
-variable [IsRankOneDiscrete v]
-
 section IsTrivialOn
 
-variable [v.IsTrivialOn K]
+variable [v.IsTrivialOn K] [v.IsNontrivial]
 
 lemma valuation_isEquiv_adic_of_valuation_X_le_one (hle : v X ≤ 1) :
     ∃ (u : HeightOneSpectrum K[X]), v.IsEquiv (u.valuation _) :=
   ⟨_, valuation_isEquiv_valuationIdeal_adic_of_valuation_X_le_one hle⟩
 
 /-- **Ostrowski's Theorem** for `K(X)` with `K` any field:
-A discrete valuation of rank 1 that is trivial on `K` is equivalent either to the valuation
-at infinity or to the `p`-adic valuation for a unique maximal ideal `p` of `K[X]`. -/
+A valuation trivial on `K` is equivalent either to the valuation at infinity or to
+the `p`-adic valuation for a unique maximal ideal `p` of `K[X]`. -/
 theorem valuation_isEquiv_infty_or_adic [DecidableEq (RatFunc K)] :
-    Xor (v.IsEquiv (RatFunc.inftyValuation K))
+    Xor (v.IsEquiv (inftyValuation K))
       (∃! (u : HeightOneSpectrum K[X]), v.IsEquiv (u.valuation _)) := by
   rcases lt_or_ge 1 (v X) with hlt | hge
   /- Infinity case -/
@@ -273,13 +247,13 @@ theorem valuation_isEquiv_infty_or_adic [DecidableEq (RatFunc K)] :
       fun hv ↦ absurd (hw.symm.trans hv) (adicValuation_not_isEquiv_infty_valuation pw)⟩
 
 lemma valuation_isEquiv_adic_of_not_isEquiv_infty [DecidableEq (RatFunc K)]
-    (hni : ¬ v.IsEquiv (RatFunc.inftyValuation K)) :
+    (hni : ¬ v.IsEquiv (inftyValuation K)) :
     ∃! (u : HeightOneSpectrum K[X]), v.IsEquiv (u.valuation _) :=
   valuation_isEquiv_infty_or_adic.or.resolve_left hni
 
 end IsTrivialOn
 
-end Discrete
+-- TODO: Show that `v` is a rank one discrete valuation.
 
 end RatFunc
 

--- a/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
+++ b/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
@@ -19,7 +19,7 @@ valuation at infinity `FunctionField.inftyValuation K`.
 - `RatFunc.valuation_isEquiv_infty_or_adic`: Ostrowski's theorem for `K(X)`.
 
 ### TODO
-- Show that a nontrivial valuation `v`, trivial on `K`, is a rank one discrete valuation.
+- Show that a nontrivial valuation `v`, trivial on `K`, is a rank one discrete valuation. (*)
 
 -/
 
@@ -186,6 +186,28 @@ lemma exists_zpow_uniformizingPolynomial {f : RatFunc K} (hf : f ≠ 0) :
       valuation_eq_valuation_uniformizingPolynomial_pow_of_valuation_X_le_one hle hq,
       valuation_eq_valuation_uniformizingPolynomial_pow_of_valuation_X_le_one hle
         (p := p) (by aesop)]
+
+-- TODO: remove the hypothesis [hv : IsRankOneDiscrete v] once TODO (*) is in Mathlib.
+lemma uniformizingPolynomial_isUniformizer [hv : IsRankOneDiscrete v] :
+    v.IsUniformizer πᵥ := by
+  have h0 : v πᵥ ≠ 0 := by simpa using uniformizingPolynomial_ne_zero hle
+  rw [IsUniformizer, ← hv.valueGroup_genLTOne_eq_generator, ← h0.isUnit.unit_spec, Units.val_inj]
+  apply LinearOrderedCommGroup.Subgroup.genLTOne_unique
+  · rw [← Units.val_lt_val, h0.isUnit.unit_spec, Units.val_one]
+    exact valuation_uniformizingPolynomial_lt_one hle
+  · ext γ
+    simp only [coePolynomial_eq_algebraMap, MonoidWithZeroHom.mem_valueGroup_iff_of_comm, ne_eq,
+      map_eq_zero, Subgroup.mem_zpowers_iff]
+    refine ⟨fun ⟨k, hk⟩ ↦ ?_, fun ⟨a, ha, b, hab⟩ ↦ ?_⟩
+    · use 1, one_ne_zero, πᵥ ^ k
+      simp only [← Units.val_inj, Units.val_zpow_eq_zpow_val] at hk
+      simp [← hk]
+    · obtain ⟨ka, hka⟩ := exists_zpow_uniformizingPolynomial hle ha
+      obtain ⟨kb, hkb⟩ := exists_zpow_uniformizingPolynomial hle (f := b) (by aesop)
+      rw [MonoidWithZeroHom.coe_ofClass, hka, hkb] at hab
+      use kb - ka
+      have : v ↑πᵥ ^ ka ≠ 0 := zpow_ne_zero _ h0
+      simp [zpow_sub, ← Units.val_inj, ← coePolynomial_eq_algebraMap, field, ← hab]
 
 lemma valuation_isEquiv_valuationIdeal_adic_of_valuation_X_le_one :
     v.IsEquiv ((Pᵥ).valuation (RatFunc K)) := by


### PR DESCRIPTION
Ostrowski's theorem for `k(X)` states that a nontrivial valuation `v` which is trivial on the base field `k` is either equivalent to the valuation at infinity or to the `p`-adic valuation for a unique maximal ideal `p` of `K[X]`.
See [here](https://kconrad.math.uconn.edu/blurbs/gradnumthy/ostrowskiF(T).pdf) for the source.

**What is currently in mathlib**: A *rank one discrete valuation* `v` which is ... (rest is same as above)

**What this PR proposes**: A *nontrivial* `v` which is ... (rest is same as above)

The rank one discrete hypothesis is strictly stronger than what is required here. Any user wanting to apply this lemma needs to discharge this by proving `IsRankOneDiscrete v` for their specific valuation.

**Note**: A nontrivial valuation on `k(X)` can be shown to be rank one discrete. It is essentially immediate from Ostrowski since the valuation at infinity and the `p`-adics are already rank one discrete in Mathlib. We are, however, missing some API to prove this easily: A valuation equiv. to a rank one discrete valuation is rank one discrete.

This fact should not be an assumption but a theorem.

AI disclaimer: I asked Claude Fable to draft a correct proof of `valuation_isEquiv_valuationIdeal_adic_of_valuation_X_le_one` with the current hypotheses.

Co-authored-by: María Inés de Frutos Fernández <[mariaines.dff@gmail.com](mailto:mariaines.dff@gmail.com)>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
