### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): define Weil divisors

### DIFF
--- a/Mathlib/AlgebraicGeometry/AlgebraicCycle/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/AlgebraicCycle/Basic.lean
@@ -99,24 +99,6 @@ lemma IsWeilDivisor.add [AddMonoid R] {D E : AlgebraicCycle X R} (hD : IsWeilDiv
     (hE : IsWeilDivisor E) : IsWeilDivisor (D + E) :=
   (Function.support_add _ _).trans (Set.union_subset hD hE)
 
-open Function.locallyFinsuppWithin in
-@[simp]
-lemma isWeilDivisor_neg [AddGroup R] {D : AlgebraicCycle X R} :
-    IsWeilDivisor (-D) ↔ IsWeilDivisor D := by
-  simp only [IsWeilDivisor, support_neg]
-
-lemma IsWeilDivisor.neg [AddGroup R] {D : AlgebraicCycle X R} (hD : IsWeilDivisor D) :
-    IsWeilDivisor (-D) := by simp [hD]
-
-lemma IsWeilDivisor.sub [AddGroup R] {D E : AlgebraicCycle X R} (hD : IsWeilDivisor D)
-    (hE : IsWeilDivisor E) : IsWeilDivisor (D - E) := by
-  rw [sub_eq_add_neg]
-  exact hD.add hE.neg
-
-open Function.locallyFinsuppWithin in
-lemma isWeilDivisor_single [DecidableEq X] [Zero R] {x : X} (hx : Order.coheight x = 1) (r : R) :
-    IsWeilDivisor (single x r) := fun _ _ ↦ by simp_all
-
 variable (X R) in
 /--
 The Weil divisors on `X`, as a subgroup of the algebraic cycles
@@ -127,6 +109,20 @@ def weilDivisors [AddGroup R] : AddSubgroup (AlgebraicCycle X R) :=
 @[simp]
 lemma mem_weilDivisors [AddGroup R] {D : AlgebraicCycle X R} :
     D ∈ weilDivisors X R ↔ IsWeilDivisor D := Iff.rfl
+
+@[simp]
+lemma isWeilDivisor_neg [AddGroup R] {D : AlgebraicCycle X R} :
+    IsWeilDivisor (-D) ↔ IsWeilDivisor D := (weilDivisors X R).neg_mem_iff
+
+lemma IsWeilDivisor.neg [AddGroup R] {D : AlgebraicCycle X R} (hD : IsWeilDivisor D) :
+    IsWeilDivisor (-D) := (weilDivisors X R).neg_mem hD
+
+lemma IsWeilDivisor.sub [AddGroup R] {D E : AlgebraicCycle X R} (hD : IsWeilDivisor D)
+    (hE : IsWeilDivisor E) : IsWeilDivisor (D - E) := (weilDivisors X R).sub_mem hD hE
+
+open Function.locallyFinsuppWithin in
+lemma isWeilDivisor_single [DecidableEq X] [Zero R] {x : X} (hx : Order.coheight x = 1) (r : R) :
+    IsWeilDivisor (single x r) := fun _ _ ↦ by simp_all
 
 end WeilDivisor
 

--- a/Mathlib/AlgebraicGeometry/AlgebraicCycle/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/AlgebraicCycle/Basic.lean
@@ -76,4 +76,47 @@ lemma map_id {N : Type*} [DecidableEq N] (wx : X → N) (c : AlgebraicCycle X R)
   apply Function.locallyFinsupp.map_id
   simp [mapCoeff]
 
+section WeilDivisor
+
+variable {R : Type*}
+
+/--
+A Weil divisor is an algebraic cycle supported purely in codimension one
+-/
+def IsWeilDivisor [Zero R] (D : AlgebraicCycle X R) : Prop :=
+  D.support ⊆ {x | Order.coheight x = 1}
+
+lemma isWeilDivisor_iff [Zero R] {D : AlgebraicCycle X R} :
+    IsWeilDivisor D ↔ D.support ⊆ {x | Order.coheight x = 1} := Iff.rfl
+
+lemma IsWeilDivisor.coheight_eq_one [Zero R] {D : AlgebraicCycle X R} (hD : IsWeilDivisor D)
+    {x : X} (hx : D x ≠ 0) : Order.coheight x = 1 := hD hx
+
+lemma isWeilDivisor_zero [Zero R] : IsWeilDivisor (0 : AlgebraicCycle X R) :=
+  fun _ hx => absurd rfl hx
+
+lemma IsWeilDivisor.add [AddMonoid R] {D E : AlgebraicCycle X R} (hD : IsWeilDivisor D)
+    (hE : IsWeilDivisor E) : IsWeilDivisor (D + E) :=
+  (Function.support_add _ _).trans (Set.union_subset hD hE)
+
+open Function.locallyFinsuppWithin in
+@[simp]
+lemma isWeilDivisor_neg [AddGroup R] {D : AlgebraicCycle X R} :
+    IsWeilDivisor (-D) ↔ IsWeilDivisor D := by
+  simp only [IsWeilDivisor, support_neg]
+
+lemma IsWeilDivisor.neg [AddGroup R] {D : AlgebraicCycle X R} (hD : IsWeilDivisor D) :
+    IsWeilDivisor (-D) := by simp [hD]
+
+lemma IsWeilDivisor.sub [AddGroup R] {D E : AlgebraicCycle X R} (hD : IsWeilDivisor D)
+    (hE : IsWeilDivisor E) : IsWeilDivisor (D - E) := by
+  rw [sub_eq_add_neg]
+  exact hD.add hE.neg
+
+open Function.locallyFinsuppWithin in
+lemma isWeilDivisor_single [DecidableEq X] [Zero R] {x : X} (hx : Order.coheight x = 1) (r : R) :
+    IsWeilDivisor (single x r) := fun _ _ ↦ by simp_all
+
+end WeilDivisor
+
 end AlgebraicGeometry.AlgebraicCycle

--- a/Mathlib/AlgebraicGeometry/AlgebraicCycle/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/AlgebraicCycle/Basic.lean
@@ -117,6 +117,17 @@ open Function.locallyFinsuppWithin in
 lemma isWeilDivisor_single [DecidableEq X] [Zero R] {x : X} (hx : Order.coheight x = 1) (r : R) :
     IsWeilDivisor (single x r) := fun _ _ ↦ by simp_all
 
+variable (X R) in
+/--
+The Weil divisors on `X`, as a subgroup of the algebraic cycles
+-/
+def weilDivisors [AddGroup R] : AddSubgroup (AlgebraicCycle X R) :=
+  Function.locallyFinsuppWithin.supported R Set.univ {x : X | Order.coheight x = 1}
+
+@[simp]
+lemma mem_weilDivisors [AddGroup R] {D : AlgebraicCycle X R} :
+    D ∈ weilDivisors X R ↔ IsWeilDivisor D := Iff.rfl
+
 end WeilDivisor
 
 end AlgebraicGeometry.AlgebraicCycle

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -398,6 +398,24 @@ instance [AddCommGroup Y] : AddCommGroup (locallyFinsuppWithin U Y) :=
   Injective.addCommGroup (M₁ := locallyFinsuppWithin U Y) (M₂ := X → Y)
     _ coe_injective coe_zero coe_add coe_neg coe_sub coe_nsmul coe_zsmul
 
+variable (Y) in
+/--
+`supported Y U s` is the additive subgroup of those functions with locally finite support
+within `U` whose support is contained in `s`.
+
+This is the analogue of `Finsupp.supported`, which cannot be used here: it is a `Submodule` of
+`α →₀ M` and so requires a semiring acting on a commutative `M`, whereas `Y` is an arbitrary
+additive group.
+-/
+def supported [AddGroup Y] (U s : Set X) : AddSubgroup (locallyFinsuppWithin U Y) where
+  carrier := {D | D.support ⊆ s}
+  zero_mem' := by simp
+  add_mem' ha hb := (support_add _ _).trans (Set.union_subset ha hb)
+  neg_mem' ha := by simpa [support_neg] using ha
+
+@[simp] lemma mem_supported [AddGroup Y] {s : Set X} {D : locallyFinsuppWithin U Y} :
+    D ∈ supported Y U s ↔ D.support ⊆ s := Iff.rfl
+
 instance [LE Y] [Zero Y] : LE (locallyFinsuppWithin U Y) where
   le := fun D₁ D₂ ↦ (D₁ : X → Y) ≤ D₂
 


### PR DESCRIPTION
In this PR, we define the predicate IsWeilDivisor on an algebraic cycle, together with some basic API.

It should be noted that our definition of Weil divisor is just an algebraic cycle which is supported only in codimension one, and assumes nothing of the codomain (namely we do not assume the coefficients are integers). This allows one to use this predicate for Q-divisors or R-divisors for example, but it is something worth noting for a predicate called "IsWeilDivisor".

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
