### PR TITLE
feat(Algebra/MonoidAlgebra/PointwiseSMul): add smulAntidiagonal and API

### DIFF
--- a/Mathlib/Algebra/MonoidAlgebra/PointwiseSMul.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/PointwiseSMul.lean
@@ -97,7 +97,7 @@ theorem mem_smulAntidiagonal_iff [SMul G P] [IsLeftCancelSMul G P] [Semiring R] 
     gh ∈ smulAntidiagonal f x p ↔ f.coeff gh.1 ≠ 0 ∧ x gh.2 ≠ 0 ∧ gh.1 • gh.2 = p := by
   simp [smulAntidiagonal]
 
-@[to_additive (dont_translate := R) smul_eq_addMonoidAlgebra_mul]
+@[to_additive (dont_translate := R) smul_coeff_eq_coeff_mul]
 theorem smul_coeff_eq_coeff_mul [Semiring R] [CancelMonoid G] (a b : MonoidAlgebra R G) :
     a • (b.coeff : G → R) = (a * b).coeff := by
   ext g

--- a/Mathlib/Algebra/MonoidAlgebra/PointwiseSMul.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/PointwiseSMul.lean
@@ -73,4 +73,53 @@ theorem smul_apply_mulAction [Group G] [MulAction G P] [Semiring R] [AddCommMono
   rw [smul_eq, Finset.sum_of_injOn Prod.fst h₁ h₂ h₃]
   aesop
 
+@[to_additive]
+theorem finite_smulAntidiagonal [SMul G P] [IsLeftCancelSMul G P] [Semiring R] [Zero V]
+    (f : MonoidAlgebra R G) (x : P → V) (p : P) :
+    (Set.smulAntidiagonal (SetLike.coe f.coeff.support) x.support p).Finite := by
+  refine Set.Finite.of_injOn (t := SetLike.coe f.coeff.support) (fun _ ⟨h, _⟩ ↦ h) ?_
+    f.coeff.support.finite_toSet
+  intro _ ⟨_, _, hp⟩ gp ⟨_, _, hgp⟩ h
+  rw [h, ← hgp] at hp
+  exact Prod.ext h (IsLeftCancelSMul.left_cancel gp.1 _ _ hp)
+
+/-- The finset of pairs, whose parts lie in the support of specified functions, that scalar-multiply
+to a given element. -/
+@[to_additive /-- The finset of pairs, whose parts lie in the support of specified functions, that
+vector-add to a given element. -/]
+def smulAntidiagonal [SMul G P] [IsLeftCancelSMul G P] [Semiring R] [Zero V]
+    (f : MonoidAlgebra R G) (x : P → V) (p : P) : Finset (G × P) :=
+  (f.finite_smulAntidiagonal x p).toFinset
+
+@[to_additive]
+theorem mem_smulAntidiagonal_iff [SMul G P] [IsLeftCancelSMul G P] [Semiring R] [Zero V]
+    (f : MonoidAlgebra R G) (x : P → V) (p : P) (gh : G × P) :
+    gh ∈ smulAntidiagonal f x p ↔ f.coeff gh.1 ≠ 0 ∧ x gh.2 ≠ 0 ∧ gh.1 • gh.2 = p := by
+  simp [smulAntidiagonal]
+
+@[to_additive (dont_translate := R) smul_eq_addMonoidAlgebra_mul]
+theorem smul_coeff_eq_coeff_mul [Semiring R] [CancelMonoid G] (a b : MonoidAlgebra R G) :
+    a • (b.coeff : G → R) = (a * b).coeff := by
+  ext g
+  classical
+  rw [MonoidAlgebra.smul_eq, MonoidAlgebra.coeff_mul]
+  simp_rw [Finsupp.sum]
+  rw [Finset.sum_sigma', Finset.sum_of_injOn]
+  · exact fun (x, y) ↦ ⟨x, y⟩
+  · simp
+  · intro gh h
+    rw [Finset.mem_coe, Finset.mem_smulAntidiagonal] at h
+    have : b.coeff gh.2 ≠ 0 := h.2.1
+    simp [h.1, this]
+  · intro gh _ h
+    simp only [ite_eq_right_iff]
+    contrapose! h
+    simp only [Finsupp.fun_support_eq, Set.mem_image, SetLike.mem_coe, Finset.mem_smulAntidiagonal,
+      Finsupp.mem_support_iff, smul_eq_mul, Prod.exists]
+    use gh.fst, gh.snd
+    exact ⟨⟨(by simp [left_ne_zero_of_mul h.2]), right_ne_zero_of_mul h.2, h.1⟩, rfl⟩
+  · intro _ h
+    rw [Finset.mem_smulAntidiagonal, smul_eq_mul] at h
+    simp [h.2.2]
+
 end MonoidAlgebra


### PR DESCRIPTION
Given actions of `R` on `V` and `G` on `P`, the `smulAntidiagonal` of `f : MonoidAlgebra R G` and `x : P → V` at `p : P` is the finset in `G × P` whose elements scalar-multiply to `p` and whose components lie in the support of `f` and `x`. This PR defines the `smulAntidiagonal` and shows that convolutional scalar multiplication coincides with monoid algebra multiplication when `V = R` and `P = G`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
