### PR TITLE
feat: add Algebra.Polynomial.Laurent.Roots

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1188,6 +1188,7 @@ public import Mathlib.Algebra.Polynomial.Homogenize
 public import Mathlib.Algebra.Polynomial.Identities
 public import Mathlib.Algebra.Polynomial.Inductions
 public import Mathlib.Algebra.Polynomial.Laurent
+public import Mathlib.Algebra.Polynomial.Laurent.Roots
 public import Mathlib.Algebra.Polynomial.Lifts
 public import Mathlib.Algebra.Polynomial.Mirror
 public import Mathlib.Algebra.Polynomial.Module.AEval

--- a/Mathlib/Algebra/Polynomial/Laurent/Roots.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent/Roots.lean
@@ -11,9 +11,10 @@ import Mathlib.Algebra.Polynomial.Roots
 /-!
 # Roots of Laurent polynomials
 
-A Laurent polynomial over an integral domain is determined by its values at the units of the ring,
-as soon as there are infinitely many of them: this is the analogue for `R[T;T⁻¹]` of
-`Polynomial.eq_zero_of_infinite_isRoot`, and it follows from it by clearing denominators.
+A Laurent polynomial mapping injectively into an integral domain is determined by its values at
+the units of the domain, as soon as there are infinitely many of them: this is the analogue for
+`R[T;T⁻¹]` of `Polynomial.eq_zero_of_infinite_isRoot`, and it follows from it by clearing
+denominators.
 
 ## Main results
 
@@ -27,22 +28,24 @@ as soon as there are infinitely many of them: this is the analogue for `R[T;T⁻
 
 namespace LaurentPolynomial
 
-variable {R : Type*} [CommRing R] [IsDomain R]
+variable {R S : Type*} [CommRing S] [IsDomain S]
 
 /-- A Laurent polynomial vanishing at infinitely many units is zero. -/
-theorem eq_zero_of_infinite_eval₂_eq_zero (p : R[T;T⁻¹])
-    (h : {x : Rˣ | eval₂ (RingHom.id R) x p = 0}.Infinite) : p = 0 := by
+theorem eq_zero_of_infinite_eval₂_eq_zero [CommSemiring R] {f : R →+* S}
+    (hf : Function.Injective f) (p : R[T;T⁻¹])
+    (h : {x : Sˣ | eval₂ f x p = 0}.Infinite) : p = 0 := by
   obtain ⟨n, q, hq⟩ := exists_T_pow p
   have hq0 : q = 0 := by
+    rw [← Polynomial.map_eq_zero_iff hf]
     refine Polynomial.eq_zero_of_infinite_isRoot _
       (Set.infinite_of_injOn_mapsTo Units.val_injective.injOn (fun x hx ↦ ?_) h)
-    simpa [Polynomial.IsRoot, ← Polynomial.eval₂_id, ← eval₂_toLaurent, hq] using hx
+    simpa [Polynomial.IsRoot, Polynomial.eval_map, ← eval₂_toLaurent, hq] using hx
   rw [hq0, map_zero] at hq
   exact (isUnit_T (n : ℤ)).mul_left_eq_zero.mp hq.symm
 
 /-- Two Laurent polynomials agreeing at infinitely many units are equal. -/
-theorem eq_of_infinite_eval₂_eq {p q : R[T;T⁻¹]}
-    (h : {x : Rˣ | eval₂ (RingHom.id R) x p = eval₂ (RingHom.id R) x q}.Infinite) : p = q :=
-  sub_eq_zero.mp <| eq_zero_of_infinite_eval₂_eq_zero _ <| by simpa [sub_eq_zero] using h
+theorem eq_of_infinite_eval₂_eq [CommRing R] {f : R →+* S} (hf : Function.Injective f)
+    {p q : R[T;T⁻¹]} (h : {x : Sˣ | eval₂ f x p = eval₂ f x q}.Infinite) : p = q :=
+  sub_eq_zero.mp <| eq_zero_of_infinite_eval₂_eq_zero hf _ <| by simpa [sub_eq_zero] using h
 
 end LaurentPolynomial

--- a/Mathlib/Algebra/Polynomial/Laurent/Roots.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent/Roots.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 Riccardo Brasca. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Riccardo Brasca
+-/
+module
+
+public import Mathlib.Algebra.Polynomial.Laurent
+import Mathlib.Algebra.Polynomial.Roots
+
+/-!
+# Roots of Laurent polynomials
+
+A Laurent polynomial over an integral domain is determined by its values at the units of the ring,
+as soon as there are infinitely many of them: this is the analogue for `R[T;T⁻¹]` of
+`Polynomial.eq_zero_of_infinite_isRoot`, and it follows from it by clearing denominators.
+
+## Main results
+
+* `LaurentPolynomial.eq_zero_of_infinite_eval₂_eq_zero`: a Laurent polynomial vanishing at
+  infinitely many units is zero.
+* `LaurentPolynomial.eq_of_infinite_eval₂_eq`: two Laurent polynomials agreeing at infinitely
+  many units are equal.
+-/
+
+@[expose] public section
+
+namespace LaurentPolynomial
+
+variable {R : Type*} [CommRing R] [IsDomain R]
+
+/-- A Laurent polynomial vanishing at infinitely many units is zero. -/
+theorem eq_zero_of_infinite_eval₂_eq_zero (p : R[T;T⁻¹])
+    (h : {x : Rˣ | eval₂ (RingHom.id R) x p = 0}.Infinite) : p = 0 := by
+  obtain ⟨n, q, hq⟩ := exists_T_pow p
+  have hq0 : q = 0 := by
+    refine Polynomial.eq_zero_of_infinite_isRoot _
+      (Set.infinite_of_injOn_mapsTo Units.val_injective.injOn (fun x hx ↦ ?_) h)
+    simpa [Polynomial.IsRoot, ← Polynomial.eval₂_id, ← eval₂_toLaurent, hq] using hx
+  rw [hq0, map_zero] at hq
+  exact (isUnit_T (n : ℤ)).mul_left_eq_zero.mp hq.symm
+
+/-- Two Laurent polynomials agreeing at infinitely many units are equal. -/
+theorem eq_of_infinite_eval₂_eq {p q : R[T;T⁻¹]}
+    (h : {x : Rˣ | eval₂ (RingHom.id R) x p = eval₂ (RingHom.id R) x q}.Infinite) : p = q :=
+  sub_eq_zero.mp <| eq_zero_of_infinite_eval₂_eq_zero _ <| by simpa [sub_eq_zero] using h
+
+end LaurentPolynomial


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
