### PR TITLE
fix: make `Equiv.addEquiv` implicit-reducible

### DIFF
--- a/Mathlib/Algebra/Group/TransferInstance.lean
+++ b/Mathlib/Algebra/Group/TransferInstance.lean
@@ -94,7 +94,8 @@ lemma pow_def [Pow β M] (n : M) (x : α) :
 /-- An equivalence `e : α ≃ β` gives a multiplicative equivalence `α ≃* β` where
 the multiplicative structure on `α` is the one obtained by transporting a multiplicative structure
 on `β` back along `e`. -/
-@[to_additive /-- An equivalence `e : α ≃ β` gives an additive equivalence `α ≃+ β` where
+@[to_additive (attr := implicit_reducible)
+/-- An equivalence `e : α ≃ β` gives an additive equivalence `α ≃+ β` where
 the additive structure on `α` is the one obtained by transporting an additive structure
 on `β` back along `e`. -/]
 def mulEquiv (e : α ≃ β) [Mul β] :

--- a/Mathlib/LinearAlgebra/AffineSpace/Homogenization.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Homogenization.lean
@@ -86,6 +86,12 @@ instance instModule {S : Type*} [Semiring S] [Module S R] [Module S V] [IsScalar
     Module S (Homogenization R P) :=
   equivProdAux.addEquiv.module S
 
+example : instAddCommGroup.toNSMul = @NSMul.ofSMul (Homogenization R P) instModule.toSMul := by
+  with_implicit rfl
+
+example : instAddCommGroup.toZSMul = @ZSMul.ofSMul (Homogenization R P) instModule.toSMul := by
+  with_implicit rfl
+
 variable
   {S : Type*} [Semiring S] [Module S R] [Module S V] [IsScalarTower S R V]
   {T : Type*} [Semiring T] [Module T R] [Module T V] [IsScalarTower T R V]

--- a/Mathlib/LinearAlgebra/AffineSpace/Homogenization.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Homogenization.lean
@@ -86,6 +86,9 @@ instance instModule {S : Type*} [Semiring S] [Module S R] [Module S V] [IsScalar
     Module S (Homogenization R P) :=
   equivProdAux.addEquiv.module S
 
+/- Test that `NSMul`/`ZSMul` instances are defeq. See `Mathlib/Algebra/Group/Monoid.lean` for
+design notes on `NSMul`. -/
+
 example : instAddCommGroup.toNSMul = @NSMul.ofSMul (Homogenization R P) instModule.toSMul := by
   with_implicit rfl
 


### PR DESCRIPTION
Without this change, defining instances using `someEquiv.addCommGroup` and `someEquiv.addEquiv.module` results in non-defeq `NSMul` and `ZSMul` instances.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
