### PR TITLE
[Merged by Bors] - feat(Analysis/CStarAlgebra/CFC/Order): `e * e ≤ e` when `e` is an element of the nonnegative closed unit ball

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
@@ -599,6 +599,35 @@ lemma inr_map_Ici_zero : inr '' (Ici (0 : A)) ⊆ Ici (0 : A⁺¹) := by
 
 end Icc
 
+lemma nnrpow_le_self_of_nonneg_of_norm_le_one {e : A} (he0 : 0 ≤ e) (he1 : ‖e‖ ≤ 1)
+    {n : ℝ≥0} (hn : 1 ≤ n) : e ^ n ≤ e := by
+  have : n ≠ 0 := by aesop
+  conv_rhs => rw [← cfcₙ_id' ℝ e]
+  rw [CFC.nnrpow_eq_cfcₙ_real e, ← sub_nonneg, ← cfcₙ_sub ..]
+  refine cfcₙ_nonneg fun x hx ↦ sub_nonneg.mpr ?_
+  have := quasispectrum.norm_le_norm_of_mem hx
+  grw [he1, Real.norm_eq_abs] at this
+  exact Real.rpow_le_self_of_le_one (quasispectrum_nonneg_of_nonneg _ he0 _ hx) (by grind) hn
+
+/-- If `e` is an element of the nonnegative closed unit ball, then `e * e ≤ e`, with equality
+if `e` is an extreme point
+(see `isStarProjection_iff_mem_extremePoints_setOfPred_nonneg_inter_unitClosedBall`). -/
+lemma mul_self_le_of_nonneg_of_norm_le_one {e : A} (he0 : 0 ≤ e) (he1 : ‖e‖ ≤ 1) :
+    e * e ≤ e := CFC.nnrpow_two e ▸ nnrpow_le_self_of_nonneg_of_norm_le_one he0 he1 one_le_two
+
+lemma self_le_nnrpow_of_nonneg_of_norm_le_one {e : A} (he0 : 0 ≤ e) (he1 : ‖e‖ ≤ 1)
+    {n : ℝ≥0} (hn0 : n ≠ 0) (hn : n ≤ 1) : e ≤ e ^ n := by
+  conv_lhs => rw [← cfcₙ_id' ℝ e]
+  rw [CFC.nnrpow_eq_cfcₙ_real e, ← sub_nonneg, ← cfcₙ_sub ..]
+  refine cfcₙ_nonneg fun x hx ↦ sub_nonneg.mpr ?_
+  have := quasispectrum.norm_le_norm_of_mem hx
+  grw [he1, Real.norm_eq_abs] at this
+  exact Real.self_le_rpow_of_le_one (quasispectrum_nonneg_of_nonneg _ he0 _ hx) (by grind) hn
+
+lemma self_le_sqrt_of_nonneg_of_norm_le_one {e : A} (he0 : 0 ≤ e) (he1 : ‖e‖ ≤ 1) :
+    e ≤ CFC.sqrt e :=
+  CFC.sqrt_eq_nnrpow e ▸ self_le_nnrpow_of_nonneg_of_norm_le_one he0 he1 (by simp) (by simp)
+
 end CStarAlgebra
 
 open CStarAlgebra Unitization CFC in

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
@@ -599,15 +599,19 @@ lemma inr_map_Ici_zero : inr '' (Ici (0 : A)) ⊆ Ici (0 : A⁺¹) := by
 
 end Icc
 
+lemma nnrpow_le_nnrpow_of_nonneg_of_norm_le_one {e : A} (he0 : 0 ≤ e) (he1 : ‖e‖ ≤ 1) {m n : ℝ≥0}
+    (hm : m ≠ 0) (hmn : m ≤ n) : e ^ n ≤ e ^ m := by
+  have hn : n ≠ 0 := by aesop
+  rw [CFC.nnrpow_eq_cfcₙ_real e, CFC.nnrpow_eq_cfcₙ_real e]
+  refine cfcₙ_mono fun x hx ↦ ?_
+  have hx1 : x ≤ 1 := by grw [Real.le_norm_self x, quasispectrum.norm_le_norm_of_mem hx, he1]
+  exact Real.rpow_le_rpow_of_exponent_ge' (quasispectrum_nonneg_of_nonneg _ he0 _ hx) hx1
+    m.coe_nonneg (mod_cast hmn)
+
 lemma nnrpow_le_self_of_nonneg_of_norm_le_one {e : A} (he0 : 0 ≤ e) (he1 : ‖e‖ ≤ 1)
     {n : ℝ≥0} (hn : 1 ≤ n) : e ^ n ≤ e := by
-  have : n ≠ 0 := by aesop
-  conv_rhs => rw [← cfcₙ_id' ℝ e]
-  rw [CFC.nnrpow_eq_cfcₙ_real e, ← sub_nonneg, ← cfcₙ_sub ..]
-  refine cfcₙ_nonneg fun x hx ↦ sub_nonneg.mpr ?_
-  have := quasispectrum.norm_le_norm_of_mem hx
-  grw [he1, Real.norm_eq_abs] at this
-  exact Real.rpow_le_self_of_le_one (quasispectrum_nonneg_of_nonneg _ he0 _ hx) (by grind) hn
+  conv_rhs => rw [← CFC.nnrpow_one e]
+  exact nnrpow_le_nnrpow_of_nonneg_of_norm_le_one he0 he1 (by simp) hn
 
 /-- If `e` is an element of the nonnegative closed unit ball, then `e * e ≤ e`, with equality
 if `e` is an extreme point
@@ -617,12 +621,8 @@ lemma mul_self_le_of_nonneg_of_norm_le_one {e : A} (he0 : 0 ≤ e) (he1 : ‖e�
 
 lemma self_le_nnrpow_of_nonneg_of_norm_le_one {e : A} (he0 : 0 ≤ e) (he1 : ‖e‖ ≤ 1)
     {n : ℝ≥0} (hn0 : n ≠ 0) (hn : n ≤ 1) : e ≤ e ^ n := by
-  conv_lhs => rw [← cfcₙ_id' ℝ e]
-  rw [CFC.nnrpow_eq_cfcₙ_real e, ← sub_nonneg, ← cfcₙ_sub ..]
-  refine cfcₙ_nonneg fun x hx ↦ sub_nonneg.mpr ?_
-  have := quasispectrum.norm_le_norm_of_mem hx
-  grw [he1, Real.norm_eq_abs] at this
-  exact Real.self_le_rpow_of_le_one (quasispectrum_nonneg_of_nonneg _ he0 _ hx) (by grind) hn
+  conv_lhs => rw [← CFC.nnrpow_one e]
+  exact nnrpow_le_nnrpow_of_nonneg_of_norm_le_one he0 he1 hn0 hn
 
 lemma self_le_sqrt_of_nonneg_of_norm_le_one {e : A} (he0 : 0 ≤ e) (he1 : ‖e‖ ≤ 1) :
     e ≤ CFC.sqrt e :=

--- a/Mathlib/Analysis/CStarAlgebra/Extreme.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Extreme.lean
@@ -71,16 +71,14 @@ theorem isStarProjection_iff_mem_extremePoints_setOfPred_nonneg_inter_unitClosed
     closed unit ball. So `2 • e - e * e` is in the nonnegative closed unit ball.
     Then using the extremity of `e`, we get `e * e = e` since `e * e` is obviously in the
     nonnegative closed unit ball, and `e = 2⁻¹ • e * e + 2⁻¹ • (2 • e - e * e)`. -/
-    have := calc
-      0 ≤ (e : A⁺¹) * (2 - e) := by
-        have : (e : A⁺¹) ≤ 1 := norm_le_one_iff_of_nonneg _ (by simpa) |>.mp (by simpa [norm_inr])
-        apply Commute.mul_nonneg (by simpa) (by grw [sub_nonneg, this, one_le_two])
-        simp [commute_iff_eq, mul_sub, sub_mul, mul_two, two_mul]
-      _ = (((2 : ℝ) • e - e * e : A) : A⁺¹) := by simp [mul_sub, two_smul, mul_two]
-    refine ⟨h3 _ (Commute.mul_nonneg h1 h1 rfl) ?_ ((2 : ℝ) • e - e * e) this.of_inr ?_
+    have : 0 ≤ (2 : ℝ) • e - e * e := by
+      have : e * e ≤ e := le_of_inr <| by
+        simpa using mul_self_le_of_nonneg_of_norm_le_one h1.inr (by simpa [norm_inr])
+      simpa [two_smul] using le_add_of_nonneg_of_le h1 this
+    refine ⟨h3 _ (Commute.mul_nonneg h1 h1 rfl) ?_ ((2 : ℝ) • e - e * e) this ?_
       ⟨2⁻¹, 2⁻¹, by simp [smul_sub, ← one_div, smul_smul]⟩, h1.isSelfAdjoint⟩
     · grw [norm_mul_le, h2, h2, one_mul]
-    · rw [← norm_inr (𝕜 := ℂ), norm_le_one_iff_of_nonneg _ this, ← sub_nonneg]
+    · rw [← norm_inr (𝕜 := ℂ), norm_le_one_iff_of_nonneg _ this.inr, ← sub_nonneg]
       calc 0 ≤ star (1 - e : A⁺¹) * (1 - e) := star_mul_self_nonneg _
         _ = _ := by simp [LE.le.star_eq, h1, mul_sub, sub_mul, two_smul, sub_sub, add_sub]
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
