### PR TITLE
[Merged by Bors] - feat(AffineSpace): define the dimension of an affine subspace

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5063,6 +5063,7 @@ public import Mathlib.LinearAlgebra.AffineSpace.Centroid
 public import Mathlib.LinearAlgebra.AffineSpace.Ceva
 public import Mathlib.LinearAlgebra.AffineSpace.Combination
 public import Mathlib.LinearAlgebra.AffineSpace.Defs
+public import Mathlib.LinearAlgebra.AffineSpace.Dimension
 public import Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional
 public import Mathlib.LinearAlgebra.AffineSpace.Homogenization
 public import Mathlib.LinearAlgebra.AffineSpace.Independent

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
@@ -151,6 +151,14 @@ theorem coe_affineSpan_eq_singleton_iff (s : Set P) (x : P) : affineSpan k s = {
 theorem mem_affineSpan_singleton : p₁ ∈ affineSpan k ({p₂} : Set P) ↔ p₁ = p₂ := by
   simp
 
+@[simp]
+theorem singleton_ne_bot (x : P) : ({x} : AffineSubspace k P) ≠ ⊥ := by
+  simp [← SetLike.coe_ne_coe]
+
+@[simp]
+theorem singleton_ne_top [Nontrivial P] (x : P) : ({x} : AffineSubspace k P) ≠ ⊤ := by
+  simp [← SetLike.coe_ne_coe]
+
 instance unique_affineSpan_singleton (p : P) : Unique (affineSpan k {p}) where
   default := ⟨p, mem_affineSpan _ (Set.mem_singleton _)⟩
   uniq := fun x ↦ Subtype.ext ((mem_affineSpan_singleton _ _).1 x.property)

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -267,6 +267,11 @@ theorem direction_eq_vectorSpan (s : AffineSubspace k P) : s.direction = vectorS
 theorem direction_singleton (x : P) : ({x} : AffineSubspace k P).direction = ⊥ := by
   simp [direction]
 
+@[simp]
+theorem direction_eq_bot_iff {s : AffineSubspace k P} :
+    s.direction = ⊥ ↔ (s : Set P).Subsingleton := by
+  simp [direction]
+
 /-- Alternative definition of the direction when the affine subspace is nonempty. This is defined so
 that the order on submodules (as used in the definition of `Submodule.span`) can be used in the
 proof of `coe_direction_eq_vsub_set`, and is not intended to be used beyond that proof. -/

--- a/Mathlib/LinearAlgebra/AffineSpace/Dimension.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Dimension.lean
@@ -24,12 +24,14 @@ is similary defined using `Module.finrank`.
 
 public section
 
+open Cardinal
+
 namespace AffineSubspace
 
 universe u v v' a a'
 
-variable {R : Type u} {V : Type v} {V' : Type v'} {A : Type a} {A' : Type a'}
-variable [AddCommGroup V] [AddTorsor V A] [AddCommGroup V'] [AddTorsor V' A']
+variable {R : Type u} {V : Type v} {V' : Type v'} {A A₁ : Type a} {A' : Type a'}
+variable [AddCommGroup V] [AddTorsor V A] [AddTorsor V A₁] [AddCommGroup V'] [AddTorsor V' A']
 
 section Ring
 
@@ -101,13 +103,12 @@ theorem finDim_eq_finrank_of_not_finite [Module.Free R s.direction] [StrongRankC
 
 @[simp]
 theorem dim_lt_aleph0 [StrongRankCondition R] (s : AffineSubspace R A)
-    [Module.Finite R s.direction] : dim s < Cardinal.aleph0 := by
+    [Module.Finite R s.direction] : dim s < ℵ₀ := by
   dsimp [dim]
   split_ifs <;> simp [Module.rank_lt_aleph0]
 
 theorem finite_iff_dim_lt_aleph0 [StrongRankCondition R] (s : AffineSubspace R A)
-    [Module.Free R s.direction] :
-    Module.Finite R s.direction ↔ dim s < Cardinal.aleph0 := by
+    [Module.Free R s.direction] : Module.Finite R s.direction ↔ dim s < ℵ₀ := by
   refine ⟨fun h ↦ dim_lt_aleph0 s, fun h ↦ ?_⟩
   rcases eq_or_ne s ⊥ with rfl | hs
   · rw [direction_bot]
@@ -145,13 +146,16 @@ theorem finDim_mono [StrongRankCondition R] [Module.Finite R t.direction] (h : s
   simp [finDim_eq_finrank hs, finDim_eq_finrank (ne_bot_of_le_ne_bot hs h),
     Submodule.finrank_mono (direction_le h)]
 
-theorem map_lift_dim_map_le (f : A →ᵃ[R] A') (s : AffineSubspace R A) :
+theorem lift_dim_map_le (f : A →ᵃ[R] A') (s : AffineSubspace R A) :
     WithBot.map Cardinal.lift.{v} (map f s).dim ≤
       WithBot.map Cardinal.lift.{v'} s.dim := by
   by_cases hs : map f s = ⊥
   · simp [hs]
   rw [dim_eq_rank hs, dim_eq_rank (by simp_all), map_direction]
   simp [lift_rank_map_le]
+
+theorem dim_map_le (f : A →ᵃ[R] A₁) (s : AffineSubspace R A) : (map f s).dim ≤ s.dim := by
+  simpa using lift_dim_map_le f s
 
 theorem finDim_map_le_finDim [StrongRankCondition R] (f : A →ᵃ[R] A') (s : AffineSubspace R A)
     [Module.Finite R s.direction] : (map f s).finDim ≤ s.finDim := by
@@ -160,7 +164,7 @@ theorem finDim_map_le_finDim [StrongRankCondition R] (f : A →ᵃ[R] A') (s : A
   rw [finDim_eq_finrank hs, finDim_eq_finrank (by simp_all), map_direction]
   simp [Submodule.finrank_map_le]
 
-theorem map_lift_dim_map_eq_of_injective {f : A →ᵃ[R] A'} (hf : Function.Injective f)
+theorem lift_dim_map_of_injective {f : A →ᵃ[R] A'} (hf : Function.Injective f)
     (s : AffineSubspace R A) :
     WithBot.map Cardinal.lift.{v} (map f s).dim =
       WithBot.map Cardinal.lift.{v'} s.dim := by
@@ -171,7 +175,11 @@ theorem map_lift_dim_map_eq_of_injective {f : A →ᵃ[R] A'} (hf : Function.Inj
   refine LinearEquiv.lift_rank_eq <| (Submodule.equivMapOfInjective _ ?_ _).symm
   exact f.linear_injective_iff.mpr hf
 
-theorem finDim_map_eq_finDim_of_injective {f : A →ᵃ[R] A'} (hf : Function.Injective f)
+theorem dim_map_of_injective {f : A →ᵃ[R] A₁} (hf : Function.Injective f)
+    (s : AffineSubspace R A) : (map f s).dim = s.dim := by
+  simpa using lift_dim_map_of_injective hf s
+
+theorem finDim_map_of_injective {f : A →ᵃ[R] A'} (hf : Function.Injective f)
     (s : AffineSubspace R A) : (map f s).finDim = s.finDim := by
   by_cases hs : map f s = ⊥
   · simp_all

--- a/Mathlib/LinearAlgebra/AffineSpace/Dimension.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Dimension.lean
@@ -130,14 +130,14 @@ theorem dim_eq_finDim_unbot (hs : s ≠ ⊥) [StrongRankCondition R] [Module.Fin
   norm_cast
   exact Cardinal.cast_toNat_of_lt_aleph0 (Module.rank_lt_aleph0 _ _) |>.symm
 
-@[mono]
+@[gcongr]
 theorem dim_mono (h : s ≤ t) : dim s ≤ dim t := by
   by_cases hs : s = ⊥
   · simp [hs]
   simp [dim_eq_rank hs, dim_eq_rank (ne_bot_of_le_ne_bot hs h),
     Submodule.rank_mono (direction_le h)]
 
-@[mono]
+@[gcongr]
 theorem finDim_mono [StrongRankCondition R] [Module.Finite R t.direction] (h : s ≤ t) :
     finDim s ≤ finDim t := by
   by_cases hs : s = ⊥
@@ -202,7 +202,7 @@ section DivisionRing
 variable [DivisionRing R] [Module R V]
 variable {s t : AffineSubspace R A}
 
-@[mono]
+@[gcongr]
 theorem finDim_strictMono [Module.Finite R t.direction] (h : s < t) : finDim s < finDim t := by
   by_cases hs : s = ⊥
   · simp_all [bot_lt_iff_ne_bot]

--- a/Mathlib/LinearAlgebra/AffineSpace/Dimension.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Dimension.lean
@@ -58,6 +58,16 @@ theorem findim_bot : findim (⊥ : AffineSubspace R A) = ⊥ := by
   simp [findim]
 
 @[simp]
+theorem dim_singleton [Nontrivial R] (x : A) : dim ({x} : AffineSubspace R A) = 0 := by
+  unfold dim
+  rw [direction_singleton]
+  simp
+
+@[simp]
+theorem findim_singleton [Nontrivial R] (x : A) : findim ({x} : AffineSubspace R A) = 0 := by
+  simp [findim]
+
+@[simp]
 theorem dim_eq_bot_iff : dim s = ⊥ ↔ s = ⊥ := by
   simp [dim]
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Dimension.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Dimension.lean
@@ -18,7 +18,7 @@ is similary defined using `Module.finrank`.
 ## Main definitions
 
 * `AffineSubspace.dim`: Dimension expressed as `WithBot Cardinal`
-* `AffineSubspace.findim`: Dimension expressed as `WithBot ℕ` with a junk value of 0 for infinite
+* `AffineSubspace.finDim`: Dimension expressed as `WithBot ℕ` with a junk value of 0 for infinite
   dimensional spaces.
 -/
 
@@ -45,8 +45,8 @@ noncomputable def dim (s : AffineSubspace R A) : WithBot Cardinal :=
 
 /-- The dimension of `s` is equal to `⊥` if `s = ⊥`, and otherwise it is equal to the finite
 dimension of `s` interpreted as a linear space. Note that this inherits `Module.finrank`s junk
-value: `AffineSubspace.findim s = 0` for infinite dimensional subspaces. -/
-noncomputable def findim (s : AffineSubspace R A) : WithBot ℕ :=
+value: `AffineSubspace.finDim s = 0` for infinite dimensional subspaces. -/
+noncomputable def finDim (s : AffineSubspace R A) : WithBot ℕ :=
   WithBot.map Cardinal.toNat (dim s)
 
 @[simp]
@@ -54,8 +54,8 @@ theorem dim_bot : dim (⊥ : AffineSubspace R A) = ⊥ := by
   simp [dim]
 
 @[simp]
-theorem findim_bot : findim (⊥ : AffineSubspace R A) = ⊥ := by
-  simp [findim]
+theorem finDim_bot : finDim (⊥ : AffineSubspace R A) = ⊥ := by
+  simp [finDim]
 
 @[simp]
 theorem dim_singleton [Nontrivial R] (x : A) : dim ({x} : AffineSubspace R A) = 0 := by
@@ -64,39 +64,39 @@ theorem dim_singleton [Nontrivial R] (x : A) : dim ({x} : AffineSubspace R A) = 
   simp
 
 @[simp]
-theorem findim_singleton [Nontrivial R] (x : A) : findim ({x} : AffineSubspace R A) = 0 := by
-  simp [findim]
+theorem finDim_singleton [Nontrivial R] (x : A) : finDim ({x} : AffineSubspace R A) = 0 := by
+  simp [finDim]
 
 @[simp]
 theorem dim_eq_bot_iff : dim s = ⊥ ↔ s = ⊥ := by
   simp [dim]
 
 @[simp]
-theorem findim_eq_bot_iff : findim s = ⊥ ↔ s = ⊥ := by
-  simp [findim]
+theorem finDim_eq_bot_iff : finDim s = ⊥ ↔ s = ⊥ := by
+  simp [finDim]
 
 theorem dim_ne_bot_iff : dim s ≠ ⊥ ↔ (s : Set A).Nonempty := by
   contrapose!
   simp
 
-theorem findim_ne_bot_iff : findim s ≠ ⊥ ↔ (s : Set A).Nonempty := by
+theorem finDim_ne_bot_iff : finDim s ≠ ⊥ ↔ (s : Set A).Nonempty := by
   contrapose!
   simp
 
 theorem dim_eq_rank (h : s ≠ ⊥) : dim s = Module.rank R s.direction := by
   simpa [dim]
 
-theorem findim_eq_finrank (h : s ≠ ⊥) : findim s = Module.finrank R s.direction := by
-  simp [findim, dim_eq_rank h]
+theorem finDim_eq_finrank (h : s ≠ ⊥) : finDim s = Module.finrank R s.direction := by
+  simp [finDim, dim_eq_rank h]
   norm_cast
 
 @[simp]
-theorem findim_eq_finrank_of_not_finite [Module.Free R s.direction] [StrongRankCondition R]
-    (h : ¬Module.Finite R s.direction) : findim s = 0 := by
+theorem finDim_eq_finrank_of_not_finite [Module.Free R s.direction] [StrongRankCondition R]
+    (h : ¬Module.Finite R s.direction) : finDim s = 0 := by
   by_cases hs : s = ⊥
   · rw [hs, direction_bot] at h
     exact False.elim <| h <| Module.Finite.bot ..
-  rw [findim_eq_finrank hs, Nat.cast_eq_zero]
+  rw [finDim_eq_finrank hs, Nat.cast_eq_zero]
   exact Module.finrank_of_not_finite h
 
 @[simp]
@@ -114,19 +114,19 @@ theorem finite_iff_dim_lt_aleph0 [StrongRankCondition R] (s : AffineSubspace R A
     infer_instance
   · exact Module.rank_lt_aleph0_iff.mp (by simpa [dim_eq_rank hs] using h)
 
-theorem finite_of_findim_ne_zero [StrongRankCondition R] (s : AffineSubspace R A)
-    [Module.Free R s.direction] (h : findim s ≠ 0) : Module.Finite R s.direction := by
+theorem finite_of_finDim_ne_zero [StrongRankCondition R] (s : AffineSubspace R A)
+    [Module.Free R s.direction] (h : finDim s ≠ 0) : Module.Finite R s.direction := by
   rcases eq_or_ne s ⊥ with rfl | hs
   · rw [direction_bot]
     infer_instance
-  exact Module.finite_of_finrank_pos <| Nat.pos_of_ne_zero (by simpa [findim_eq_finrank hs] using h)
+  exact Module.finite_of_finrank_pos <| Nat.pos_of_ne_zero (by simpa [finDim_eq_finrank hs] using h)
 
-theorem findim_eq_map_dim_toNat : findim s = (dim s).map Cardinal.toNat := by
-  simp [findim]
+theorem finDim_eq_map_dim_toNat : finDim s = (dim s).map Cardinal.toNat := by
+  simp [finDim]
 
-theorem dim_eq_findim_unbot (hs : s ≠ ⊥) [StrongRankCondition R] [Module.Finite R s.direction] :
-    dim s = (findim s).unbot (by simpa) := by
-  simp only [dim_eq_rank hs, findim, WithBot.map_coe, WithBot.unbot_coe]
+theorem dim_eq_finDim_unbot (hs : s ≠ ⊥) [StrongRankCondition R] [Module.Finite R s.direction] :
+    dim s = (finDim s).unbot (by simpa) := by
+  simp only [dim_eq_rank hs, finDim, WithBot.map_coe, WithBot.unbot_coe]
   norm_cast
   exact Cardinal.cast_toNat_of_lt_aleph0 (Module.rank_lt_aleph0 _ _) |>.symm
 
@@ -138,11 +138,11 @@ theorem dim_mono (h : s ≤ t) : dim s ≤ dim t := by
     Submodule.rank_mono (direction_le h)]
 
 @[mono]
-theorem findim_mono [StrongRankCondition R] [Module.Finite R t.direction] (h : s ≤ t) :
-    findim s ≤ findim t := by
+theorem finDim_mono [StrongRankCondition R] [Module.Finite R t.direction] (h : s ≤ t) :
+    finDim s ≤ finDim t := by
   by_cases hs : s = ⊥
   · simp [hs]
-  simp [findim_eq_finrank hs, findim_eq_finrank (ne_bot_of_le_ne_bot hs h),
+  simp [finDim_eq_finrank hs, finDim_eq_finrank (ne_bot_of_le_ne_bot hs h),
     Submodule.finrank_mono (direction_le h)]
 
 theorem map_lift_dim_map_le (f : A →ᵃ[R] A') (s : AffineSubspace R A) :
@@ -153,11 +153,11 @@ theorem map_lift_dim_map_le (f : A →ᵃ[R] A') (s : AffineSubspace R A) :
   rw [dim_eq_rank hs, dim_eq_rank (by simp_all), map_direction]
   simp [lift_rank_map_le]
 
-theorem findim_map_le_findim [StrongRankCondition R] (f : A →ᵃ[R] A') (s : AffineSubspace R A)
-    [Module.Finite R s.direction] : (map f s).findim ≤ s.findim := by
+theorem finDim_map_le_finDim [StrongRankCondition R] (f : A →ᵃ[R] A') (s : AffineSubspace R A)
+    [Module.Finite R s.direction] : (map f s).finDim ≤ s.finDim := by
   by_cases hs : (map f s) = ⊥
   · simp [hs]
-  rw [findim_eq_finrank hs, findim_eq_finrank (by simp_all), map_direction]
+  rw [finDim_eq_finrank hs, finDim_eq_finrank (by simp_all), map_direction]
   simp [Submodule.finrank_map_le]
 
 theorem map_lift_dim_map_eq_of_injective {f : A →ᵃ[R] A'} (hf : Function.Injective f)
@@ -171,11 +171,11 @@ theorem map_lift_dim_map_eq_of_injective {f : A →ᵃ[R] A'} (hf : Function.Inj
   refine LinearEquiv.lift_rank_eq <| (Submodule.equivMapOfInjective _ ?_ _).symm
   exact f.linear_injective_iff.mpr hf
 
-theorem findim_map_eq_findim_of_injective {f : A →ᵃ[R] A'} (hf : Function.Injective f)
-    (s : AffineSubspace R A) : (map f s).findim = s.findim := by
+theorem finDim_map_eq_finDim_of_injective {f : A →ᵃ[R] A'} (hf : Function.Injective f)
+    (s : AffineSubspace R A) : (map f s).finDim = s.finDim := by
   by_cases hs : map f s = ⊥
   · simp_all
-  rw [findim_eq_finrank hs, findim_eq_finrank (by simp_all), map_direction]
+  rw [finDim_eq_finrank hs, finDim_eq_finrank (by simp_all), map_direction]
   norm_cast
   refine LinearEquiv.finrank_eq <| (Submodule.equivMapOfInjective _ ?_ _).symm
   exact f.linear_injective_iff.mpr hf
@@ -188,12 +188,12 @@ theorem dim_le_zero_iff_subsingleton [IsDomain R] [Module.IsTorsionFree R s.dire
   simp [dim_eq_rank, hs, rank_zero_iff, Submodule.subsingleton_iff_eq_bot]
 
 @[simp]
-theorem findim_le_zero_iff_subsingleton [StrongRankCondition R] [IsDomain R]
+theorem finDim_le_zero_iff_subsingleton [StrongRankCondition R] [IsDomain R]
     [Module.IsTorsionFree R s.direction] [Module.Finite R s.direction] :
-    findim s ≤ 0 ↔ (s : Set A).Subsingleton := by
+    finDim s ≤ 0 ↔ (s : Set A).Subsingleton := by
   by_cases hs : s = ⊥
   · simp [hs]
-  simp [findim_eq_finrank, hs, Module.finrank_zero_iff, Submodule.subsingleton_iff_eq_bot]
+  simp [finDim_eq_finrank, hs, Module.finrank_zero_iff, Submodule.subsingleton_iff_eq_bot]
 
 end Ring
 
@@ -203,10 +203,10 @@ variable [DivisionRing R] [Module R V]
 variable {s t : AffineSubspace R A}
 
 @[mono]
-theorem findim_strictMono [Module.Finite R t.direction] (h : s < t) : findim s < findim t := by
+theorem finDim_strictMono [Module.Finite R t.direction] (h : s < t) : finDim s < finDim t := by
   by_cases hs : s = ⊥
   · simp_all [bot_lt_iff_ne_bot]
-  rw [findim_eq_finrank hs, findim_eq_finrank (ne_bot_of_gt h), Nat.cast_lt]
+  rw [finDim_eq_finrank hs, finDim_eq_finrank (ne_bot_of_gt h), Nat.cast_lt]
   refine Submodule.finrank_lt_finrank_of_lt (direction_lt_of_nonempty h ?_)
   exact (nonempty_iff_ne_bot _).mpr hs
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Dimension.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Dimension.lean
@@ -1,0 +1,205 @@
+/-
+Copyright (c) 2026 Vlad Tsyrklevich. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Allamigeon, Arne Kuhrs, Louis Theran, Vlad Tsyrklevich, Juni Vogt
+-/
+module
+
+public import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic
+public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+
+/-!
+## (Finite) Dimension of an affine subspace
+
+This file defines the dimension of an affine subspace to be `⊥` for the empty subspace,
+and otherwise equal to the `Module.rank` of the direction of the subspace. The finite dimension
+is similary defined using `Module.finrank`.
+
+## Main definitions
+
+* `AffineSubspace.dim`: Dimension expressed as `WithBot Cardinal`
+* `AffineSubspace.findim`: Dimension expressed as `WithBot ℕ` with a junk value of 0 for infinite
+  dimensional spaces.
+-/
+
+public section
+
+namespace AffineSubspace
+
+universe u v v' a a'
+
+variable {R : Type u} {V : Type v} {V' : Type v'} {A : Type a} {A' : Type a'}
+variable [AddCommGroup V] [AddTorsor V A] [AddCommGroup V'] [AddTorsor V' A']
+
+section Ring
+
+variable [Ring R] [Module R V] [Module R V']
+variable {s t : AffineSubspace R A}
+
+open Classical in
+/-- The dimension of `s` is equal to `⊥` if `s = ⊥`, and otherwise it is equal to the dimension of
+`s` interpreted as a linear space. -/
+noncomputable def dim (s : AffineSubspace R A) : WithBot Cardinal :=
+  if s = ⊥ then ⊥
+  else Module.rank R s.direction
+
+/-- The dimension of `s` is equal to `⊥` if `s = ⊥`, and otherwise it is equal to the finite
+dimension of `s` interpreted as a linear space. Note that this inherits `Module.finrank`s junk
+value: `AffineSubspace.findim s = 0` for infinite dimensional subspaces. -/
+noncomputable def findim (s : AffineSubspace R A) : WithBot ℕ :=
+  WithBot.map Cardinal.toNat (dim s)
+
+@[simp]
+theorem dim_bot : dim (⊥ : AffineSubspace R A) = ⊥ := by
+  simp [dim]
+
+@[simp]
+theorem findim_bot : findim (⊥ : AffineSubspace R A) = ⊥ := by
+  simp [findim]
+
+@[simp]
+theorem dim_eq_bot_iff : dim s = ⊥ ↔ s = ⊥ := by
+  simp [dim]
+
+@[simp]
+theorem findim_eq_bot_iff : findim s = ⊥ ↔ s = ⊥ := by
+  simp [findim]
+
+theorem dim_ne_bot_iff : dim s ≠ ⊥ ↔ (s : Set A).Nonempty := by
+  contrapose!
+  simp
+
+theorem findim_ne_bot_iff : findim s ≠ ⊥ ↔ (s : Set A).Nonempty := by
+  contrapose!
+  simp
+
+theorem dim_eq_rank (h : s ≠ ⊥) : dim s = Module.rank R s.direction := by
+  simpa [dim]
+
+theorem findim_eq_finrank (h : s ≠ ⊥) : findim s = Module.finrank R s.direction := by
+  simp [findim, dim_eq_rank h]
+  norm_cast
+
+@[simp]
+theorem findim_eq_finrank_of_not_finite [Module.Free R s.direction] [StrongRankCondition R]
+    (h : ¬Module.Finite R s.direction) : findim s = 0 := by
+  by_cases hs : s = ⊥
+  · rw [hs, direction_bot] at h
+    exact False.elim <| h <| Module.Finite.bot ..
+  rw [findim_eq_finrank hs, Nat.cast_eq_zero]
+  exact Module.finrank_of_not_finite h
+
+@[simp]
+theorem dim_lt_aleph0 [StrongRankCondition R] (s : AffineSubspace R A)
+    [Module.Finite R s.direction] : dim s < Cardinal.aleph0 := by
+  dsimp [dim]
+  split_ifs <;> simp [Module.rank_lt_aleph0]
+
+theorem finite_iff_dim_lt_aleph0 [StrongRankCondition R] (s : AffineSubspace R A)
+    [Module.Free R s.direction] :
+    Module.Finite R s.direction ↔ dim s < Cardinal.aleph0 := by
+  refine ⟨fun h ↦ dim_lt_aleph0 s, fun h ↦ ?_⟩
+  rcases eq_or_ne s ⊥ with rfl | hs
+  · rw [direction_bot]
+    infer_instance
+  · exact Module.rank_lt_aleph0_iff.mp (by simpa [dim_eq_rank hs] using h)
+
+theorem finite_of_findim_ne_zero [StrongRankCondition R] (s : AffineSubspace R A)
+    [Module.Free R s.direction] (h : findim s ≠ 0) : Module.Finite R s.direction := by
+  rcases eq_or_ne s ⊥ with rfl | hs
+  · rw [direction_bot]
+    infer_instance
+  exact Module.finite_of_finrank_pos <| Nat.pos_of_ne_zero (by simpa [findim_eq_finrank hs] using h)
+
+theorem findim_eq_map_dim_toNat : findim s = (dim s).map Cardinal.toNat := by
+  simp [findim]
+
+theorem dim_eq_findim_unbot (hs : s ≠ ⊥) [StrongRankCondition R] [Module.Finite R s.direction] :
+    dim s = (findim s).unbot (by simpa) := by
+  simp only [dim_eq_rank hs, findim, WithBot.map_coe, WithBot.unbot_coe]
+  norm_cast
+  exact Cardinal.cast_toNat_of_lt_aleph0 (Module.rank_lt_aleph0 _ _) |>.symm
+
+@[mono]
+theorem dim_mono (h : s ≤ t) : dim s ≤ dim t := by
+  by_cases hs : s = ⊥
+  · simp [hs]
+  simp [dim_eq_rank hs, dim_eq_rank (ne_bot_of_le_ne_bot hs h),
+    Submodule.rank_mono (direction_le h)]
+
+@[mono]
+theorem findim_mono [StrongRankCondition R] [Module.Finite R t.direction] (h : s ≤ t) :
+    findim s ≤ findim t := by
+  by_cases hs : s = ⊥
+  · simp [hs]
+  simp [findim_eq_finrank hs, findim_eq_finrank (ne_bot_of_le_ne_bot hs h),
+    Submodule.finrank_mono (direction_le h)]
+
+theorem map_lift_dim_map_le (f : A →ᵃ[R] A') (s : AffineSubspace R A) :
+    WithBot.map Cardinal.lift.{v} (map f s).dim ≤
+      WithBot.map Cardinal.lift.{v'} s.dim := by
+  by_cases hs : map f s = ⊥
+  · simp [hs]
+  rw [dim_eq_rank hs, dim_eq_rank (by simp_all), map_direction]
+  simp [lift_rank_map_le]
+
+theorem findim_map_le_findim [StrongRankCondition R] (f : A →ᵃ[R] A') (s : AffineSubspace R A)
+    [Module.Finite R s.direction] : (map f s).findim ≤ s.findim := by
+  by_cases hs : (map f s) = ⊥
+  · simp [hs]
+  rw [findim_eq_finrank hs, findim_eq_finrank (by simp_all), map_direction]
+  simp [Submodule.finrank_map_le]
+
+theorem map_lift_dim_map_eq_of_injective {f : A →ᵃ[R] A'} (hf : Function.Injective f)
+    (s : AffineSubspace R A) :
+    WithBot.map Cardinal.lift.{v} (map f s).dim =
+      WithBot.map Cardinal.lift.{v'} s.dim := by
+  by_cases hs : map f s = ⊥
+  · simp_all
+  rw [dim_eq_rank hs, dim_eq_rank (by simp_all), map_direction]
+  simp only [WithBot.map_coe, WithBot.coe_inj]
+  refine LinearEquiv.lift_rank_eq <| (Submodule.equivMapOfInjective _ ?_ _).symm
+  exact f.linear_injective_iff.mpr hf
+
+theorem findim_map_eq_findim_of_injective {f : A →ᵃ[R] A'} (hf : Function.Injective f)
+    (s : AffineSubspace R A) : (map f s).findim = s.findim := by
+  by_cases hs : map f s = ⊥
+  · simp_all
+  rw [findim_eq_finrank hs, findim_eq_finrank (by simp_all), map_direction]
+  norm_cast
+  refine LinearEquiv.finrank_eq <| (Submodule.equivMapOfInjective _ ?_ _).symm
+  exact f.linear_injective_iff.mpr hf
+
+@[simp]
+theorem dim_le_zero_iff_subsingleton [IsDomain R] [Module.IsTorsionFree R s.direction] :
+    dim s ≤ 0 ↔ (s : Set A).Subsingleton := by
+  by_cases hs : s = ⊥
+  · simp [hs]
+  simp [dim_eq_rank, hs, rank_zero_iff, Submodule.subsingleton_iff_eq_bot]
+
+@[simp]
+theorem findim_le_zero_iff_subsingleton [StrongRankCondition R] [IsDomain R]
+    [Module.IsTorsionFree R s.direction] [Module.Finite R s.direction] :
+    findim s ≤ 0 ↔ (s : Set A).Subsingleton := by
+  by_cases hs : s = ⊥
+  · simp [hs]
+  simp [findim_eq_finrank, hs, Module.finrank_zero_iff, Submodule.subsingleton_iff_eq_bot]
+
+end Ring
+
+section DivisionRing
+
+variable [DivisionRing R] [Module R V]
+variable {s t : AffineSubspace R A}
+
+@[mono]
+theorem findim_strictMono [Module.Finite R t.direction] (h : s < t) : findim s < findim t := by
+  by_cases hs : s = ⊥
+  · simp_all [bot_lt_iff_ne_bot]
+  rw [findim_eq_finrank hs, findim_eq_finrank (ne_bot_of_gt h), Nat.cast_lt]
+  refine Submodule.finrank_lt_finrank_of_lt (direction_lt_of_nonempty h ?_)
+  exact (nonempty_iff_ne_bot _).mpr hs
+
+end DivisionRing
+
+end AffineSubspace

--- a/Mathlib/SetTheory/Cardinal/Defs.lean
+++ b/Mathlib/SetTheory/Cardinal/Defs.lean
@@ -167,9 +167,13 @@ theorem lift_id' (a : Cardinal.{max u v}) : lift.{u} a = a :=
   inductionOn a fun _ => mk_congr Equiv.ulift
 
 /-- A cardinal lifted to the same universe equals itself. -/
-@[simp]
 theorem lift_id (a : Cardinal) : lift.{u, u} a = a :=
   lift_id'.{u, u} a
+
+/-- The map lifting a cardinal to the same universe is equal to the identity. -/
+@[simp]
+theorem lift_eq_id : lift.{u, u} = id := by
+  funext; exact lift_id _
 
 /-- A cardinal lifted to the zero universe equals itself. -/
 @[simp]


### PR DESCRIPTION
Define the dimension of affine subspace as `WithBot Cardinal`/`WithBot Nat`. It's equal to `⊥` if the subspace is empty, and otherwise it's equal to `Module.rank`/`Module.finrank`. This is a useful notion since the empty subspace and a point are clearly different dimensions that behave differently. This is motivated by the fact that this notion of dimension correlates with the rank of an element in the face lattice of a polytope.

`LinearAlgebra/FiniteDimensional.lean` develops some basic theory for finite dimensional affine subspaces using Module.finrank directly. I want to get this definition and basic API reviewed first, and then I intend to update it to use this new API.

Created as part of the Berlin "Polyhedra in Lean" workshop.

Co-authored-by: Xavier Allamigeon <xavier.allamigeon@inria.fr>
Co-authored-by: Arne Kuhrs <ArneKuhrs@users.noreply.github.com>
Co-authored-by: Louis Theran <lst6@st-andrews.ac.uk>
Co-authored-by: Juni Vogt <juni@vo.gt>

---

I also have some further API for dimension that I would like to add (classifying 0/1 dimensional subspaces, relating it to `AffineIndependent` generators of a subspace) that would go along with a forthcoming refactor of `LinearAlgebra/FiniteDimensional.lean`

Some relevant discussion on Zulip here, talking about the use of `WithBot`: [#mathlib4 > Dimensions of affine subspaces @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Dimensions.20of.20affine.20subspaces/near/619115381)

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
