### PR TITLE
chore(LinearAlgebra/Multilinear): generalise `MultilinearMap` to semilinear maps

### DIFF
--- a/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
@@ -811,7 +811,8 @@ and multilinearly on `p`. -/
 @[simps! apply_apply]
 def compAlongOrderedFinpartitionₗ :
     (F [×c.length]→L[𝕜] G) →ₗ[𝕜]
-      MultilinearMap 𝕜 (fun i : Fin c.length ↦ E [×c.partSize i]→L[𝕜] F) (E [×n]→L[𝕜] G) where
+      MultilinearMap (RingHom.id 𝕜) (fun i : Fin c.length ↦ E [×c.partSize i]→L[𝕜] F)
+        (E [×n]→L[𝕜] G) where
   toFun f :=
     MultilinearMap.mk' (fun p ↦ c.compAlongOrderedFinpartition f p)
       (fun p m q q' ↦ by

--- a/Mathlib/Analysis/Normed/Module/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Multilinear/Basic.lean
@@ -135,7 +135,7 @@ then `f m` has norm `0`.
 Note that we cannot drop the continuity assumption because `f (m : Unit → E) = f (m ())`,
 where the domain has zero norm and the codomain has a nonzero norm
 does not satisfy this condition. -/
-lemma norm_map_coord_zero (f : MultilinearMap 𝕜 E G) (hf : Continuous f)
+lemma norm_map_coord_zero (f : MultilinearMap (RingHom.id 𝕜) E G) (hf : Continuous f)
     {m : ∀ i, E i} {i : ι} (hi : ‖m i‖ = 0) : ‖f m‖ = 0 := by
   classical
   rw [← inseparable_zero_iff_norm] at hi ⊢
@@ -154,7 +154,7 @@ then it satisfies this inequality for all `m`.
 The first assumption is automatically satisfied on normed spaces, see `bound_of_shell` below.
 For seminormed spaces, it follows from continuity of `f`, see next lemma,
 see `bound_of_shell_of_continuous` below. -/
-theorem bound_of_shell_of_norm_map_coord_zero (f : MultilinearMap 𝕜 E G)
+theorem bound_of_shell_of_norm_map_coord_zero (f : MultilinearMap (RingHom.id 𝕜) E G)
     (hf₀ : ∀ {m i}, ‖m i‖ = 0 → ‖f m‖ = 0)
     {ε : ι → ℝ} {C : ℝ} (hε : ∀ i, 0 < ε i) {c : ι → 𝕜} (hc : ∀ i, 1 < ‖c i‖)
     (hf : ∀ m : ∀ i, E i, (∀ i, ε i / ‖c i‖ ≤ ‖m i‖) → (∀ i, ‖m i‖ < ε i) → ‖f m‖ ≤ C * ∏ i, ‖m i‖)
@@ -170,7 +170,7 @@ theorem bound_of_shell_of_norm_map_coord_zero (f : MultilinearMap 𝕜 E G)
 /-- If a continuous multilinear map in finitely many variables on normed spaces satisfies
 the inequality `‖f m‖ ≤ C * ∏ i, ‖m i‖` on a shell `ε i / ‖c i‖ < ‖m i‖ < ε i` for some positive
 numbers `ε i` and elements `c i : 𝕜`, `1 < ‖c i‖`, then it satisfies this inequality for all `m`. -/
-theorem bound_of_shell_of_continuous (f : MultilinearMap 𝕜 E G) (hfc : Continuous f)
+theorem bound_of_shell_of_continuous (f : MultilinearMap (RingHom.id 𝕜) E G) (hfc : Continuous f)
     {ε : ι → ℝ} {C : ℝ} (hε : ∀ i, 0 < ε i) {c : ι → 𝕜} (hc : ∀ i, 1 < ‖c i‖)
     (hf : ∀ m : ∀ i, E i, (∀ i, ε i / ‖c i‖ ≤ ‖m i‖) → (∀ i, ‖m i‖ < ε i) → ‖f m‖ ≤ C * ∏ i, ‖m i‖)
     (m : ∀ i, E i) : ‖f m‖ ≤ C * ∏ i, ‖m i‖ :=
@@ -179,7 +179,7 @@ theorem bound_of_shell_of_continuous (f : MultilinearMap 𝕜 E G) (hfc : Contin
 /-- If a multilinear map in finitely many variables on normed spaces is continuous, then it
 satisfies the inequality `‖f m‖ ≤ C * ∏ i, ‖m i‖`, for some `C` which can be chosen to be
 positive. -/
-theorem exists_bound_of_continuous (f : MultilinearMap 𝕜 E G) (hf : Continuous f) :
+theorem exists_bound_of_continuous (f : MultilinearMap (RingHom.id 𝕜) E G) (hf : Continuous f) :
     ∃ C : ℝ, 0 < C ∧ ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖ := by
   cases isEmpty_or_nonempty ι
   · refine ⟨‖f 0‖ + 1, add_pos_of_nonneg_of_pos (norm_nonneg _) zero_lt_one, fun m => ?_⟩
@@ -205,7 +205,8 @@ The bound reads
 `‖f m - f m'‖ ≤
   C * ‖m 1 - m' 1‖ * max ‖m 2‖ ‖m' 2‖ * max ‖m 3‖ ‖m' 3‖ * ... * max ‖m n‖ ‖m' n‖ + ...`,
 where the other terms in the sum are the same products where `1` is replaced by any `i`. -/
-theorem norm_image_sub_le_of_bound' [DecidableEq ι] (f : MultilinearMap 𝕜 E G) {C : ℝ} (hC : 0 ≤ C)
+theorem norm_image_sub_le_of_bound' [DecidableEq ι] (f : MultilinearMap (RingHom.id 𝕜) E G)
+    {C : ℝ} (hC : 0 ≤ C)
     (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) (m₁ m₂ : ∀ i, E i) :
     ‖f m₁ - f m₂‖ ≤ C * ∑ i, ∏ j, if j = i then ‖m₁ i - m₂ i‖ else max ‖m₁ j‖ ‖m₂ j‖ := by
   have A :
@@ -247,7 +248,7 @@ theorem norm_image_sub_le_of_bound' [DecidableEq ι] (f : MultilinearMap 𝕜 E 
 using the multilinearity. Here, we give a usable but not very precise version. See
 `norm_image_sub_le_of_bound'` for a more precise but less usable version. The bound is
 `‖f m - f m'‖ ≤ C * card ι * ‖m - m'‖ * (max ‖m‖ ‖m'‖) ^ (card ι - 1)`. -/
-theorem norm_image_sub_le_of_bound (f : MultilinearMap 𝕜 E G)
+theorem norm_image_sub_le_of_bound (f : MultilinearMap (RingHom.id 𝕜) E G)
     {C : ℝ} (hC : 0 ≤ C) (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) (m₁ m₂ : ∀ i, E i) :
     ‖f m₁ - f m₂‖ ≤ C * Fintype.card ι * max ‖m₁‖ ‖m₂‖ ^ (Fintype.card ι - 1) * ‖m₁ - m₂‖ := by
   classical
@@ -277,7 +278,8 @@ theorem norm_image_sub_le_of_bound (f : MultilinearMap 𝕜 E G)
 
 /-- If a multilinear map satisfies an inequality `‖f m‖ ≤ C * ∏ i, ‖m i‖`, then it is
 continuous. -/
-theorem continuous_of_bound (f : MultilinearMap 𝕜 E G) (C : ℝ) (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) :
+theorem continuous_of_bound (f : MultilinearMap (RingHom.id 𝕜) E G) (C : ℝ)
+    (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) :
     Continuous f := by
   let D := max C 1
   have D_pos : 0 ≤ D := le_trans zero_le_one (le_max_right _ _)
@@ -297,19 +299,20 @@ theorem continuous_of_bound (f : MultilinearMap 𝕜 E G) (C : ℝ) (H : ∀ m, 
 
 /-- Constructing a continuous multilinear map from a multilinear map satisfying a boundedness
 condition. -/
-def mkContinuous (f : MultilinearMap 𝕜 E G) (C : ℝ) (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) :
+def mkContinuous (f : MultilinearMap (RingHom.id 𝕜) E G) (C : ℝ) (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) :
     ContinuousMultilinearMap 𝕜 E G :=
   { f with cont := f.continuous_of_bound C H }
 
 @[simp]
-theorem coe_mkContinuous (f : MultilinearMap 𝕜 E G) (C : ℝ) (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) :
+theorem coe_mkContinuous (f : MultilinearMap (RingHom.id 𝕜) E G) (C : ℝ)
+    (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) :
     ⇑(f.mkContinuous C H) = f :=
   rfl
 
 /-- Given a multilinear map in `n` variables, if one restricts it to `k` variables putting `z` on
 the other coordinates, then the resulting restricted function satisfies an inequality
 `‖f.restr v‖ ≤ C * ‖z‖^(n-k) * Π ‖v i‖` if the original function satisfies `‖f v‖ ≤ C * Π ‖v i‖`. -/
-theorem restr_norm_le {k n : ℕ} (f : MultilinearMap 𝕜 (fun _ : Fin n => G) G')
+theorem restr_norm_le {k n : ℕ} (f : MultilinearMap (RingHom.id 𝕜) (fun _ : Fin n => G) G')
     (s : Finset (Fin n)) (hk : #s = k) (z : G) {C : ℝ} (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖)
     (v : Fin k → G) : ‖f.restr s hk z v‖ ≤ C * ‖z‖ ^ (n - k) * ∏ i, ‖v i‖ := by
   rw [mul_right_comm, mul_assoc]
@@ -675,14 +678,14 @@ variable [Fintype ι]
 /-- If a continuous multilinear map is constructed from a multilinear map via the constructor
 `mkContinuous`, then its norm is bounded by the bound given to the constructor if it is
 nonnegative. -/
-theorem MultilinearMap.mkContinuous_norm_le (f : MultilinearMap 𝕜 E G) {C : ℝ} (hC : 0 ≤ C)
-    (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) : ‖f.mkContinuous C H‖ ≤ C :=
+theorem MultilinearMap.mkContinuous_norm_le (f : MultilinearMap (RingHom.id 𝕜) E G) {C : ℝ}
+    (hC : 0 ≤ C) (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) : ‖f.mkContinuous C H‖ ≤ C :=
   ContinuousMultilinearMap.opNorm_le_bound hC fun m => H m
 
 /-- If a continuous multilinear map is constructed from a multilinear map via the constructor
 `mkContinuous`, then its norm is bounded by the bound given to the constructor if it is
 nonnegative. -/
-theorem MultilinearMap.mkContinuous_norm_le' (f : MultilinearMap 𝕜 E G) {C : ℝ}
+theorem MultilinearMap.mkContinuous_norm_le' (f : MultilinearMap (RingHom.id 𝕜) E G) {C : ℝ}
     (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) : ‖f.mkContinuous C H‖ ≤ max C 0 :=
   ContinuousMultilinearMap.opNorm_le_bound (le_max_right _ _) fun m ↦ (H m).trans <|
     mul_le_mul_of_nonneg_right (le_max_left _ _) <| by positivity
@@ -843,15 +846,17 @@ open ContinuousMultilinearMap
 
 namespace MultilinearMap
 
-/-- Given a map `f : G →ₗ[𝕜] MultilinearMap 𝕜 E G'` and an estimate
+/-- Given a map `f : G →ₗ[𝕜] MultilinearMap (RingHom.id 𝕜) E G'` and an estimate
 `H : ∀ x m, ‖f x m‖ ≤ C * ‖x‖ * ∏ i, ‖m i‖`, construct a continuous linear
 map from `G` to `ContinuousMultilinearMap 𝕜 E G'`.
 
-In order to lift, e.g., a map `f : (MultilinearMap 𝕜 E G) →ₗ[𝕜] MultilinearMap 𝕜 E' G'`
+In order to lift, e.g., a map
+`f : (MultilinearMap (RingHom.id 𝕜) E G) →ₗ[𝕜] MultilinearMap (RingHom.id 𝕜) E' G'`
 to a map `(ContinuousMultilinearMap 𝕜 E G) →L[𝕜] ContinuousMultilinearMap 𝕜 E' G'`,
 one can apply this construction to `f.comp ContinuousMultilinearMap.toMultilinearMapLinear`
-which is a linear map from `ContinuousMultilinearMap 𝕜 E G` to `MultilinearMap 𝕜 E' G'`. -/
-def mkContinuousLinear (f : G →ₗ[𝕜] MultilinearMap 𝕜 E G') (C : ℝ)
+which is a linear map from `ContinuousMultilinearMap 𝕜 E G` to
+`MultilinearMap (RingHom.id 𝕜) E' G'`. -/
+def mkContinuousLinear (f : G →ₗ[𝕜] MultilinearMap (RingHom.id 𝕜) E G') (C : ℝ)
     (H : ∀ x m, ‖f x m‖ ≤ C * ‖x‖ * ∏ i, ‖m i‖) : G →L[𝕜] ContinuousMultilinearMap 𝕜 E G' :=
   LinearMap.mkContinuous
     { toFun := fun x => (f x).mkContinuous (C * ‖x‖) <| H x
@@ -865,21 +870,23 @@ def mkContinuousLinear (f : G →ₗ[𝕜] MultilinearMap 𝕜 E G') (C : ℝ)
       simpa using ((f x).mkContinuous_norm_le' _).trans_eq <| by
         rw [max_mul_of_nonneg _ _ (norm_nonneg x), zero_mul]
 
-theorem mkContinuousLinear_norm_le' (f : G →ₗ[𝕜] MultilinearMap 𝕜 E G') (C : ℝ)
+theorem mkContinuousLinear_norm_le' (f : G →ₗ[𝕜] MultilinearMap (RingHom.id 𝕜) E G') (C : ℝ)
     (H : ∀ x m, ‖f x m‖ ≤ C * ‖x‖ * ∏ i, ‖m i‖) : ‖mkContinuousLinear f C H‖ ≤ max C 0 := by
   dsimp only [mkContinuousLinear]
   exact LinearMap.mkContinuous_norm_le _ (le_max_right _ _) _
 
-theorem mkContinuousLinear_norm_le (f : G →ₗ[𝕜] MultilinearMap 𝕜 E G') {C : ℝ} (hC : 0 ≤ C)
-    (H : ∀ x m, ‖f x m‖ ≤ C * ‖x‖ * ∏ i, ‖m i‖) : ‖mkContinuousLinear f C H‖ ≤ C :=
+theorem mkContinuousLinear_norm_le (f : G →ₗ[𝕜] MultilinearMap (RingHom.id 𝕜) E G') {C : ℝ}
+    (hC : 0 ≤ C) (H : ∀ x m, ‖f x m‖ ≤ C * ‖x‖ * ∏ i, ‖m i‖) :
+    ‖mkContinuousLinear f C H‖ ≤ C :=
   (mkContinuousLinear_norm_le' f C H).trans_eq (max_eq_left hC)
 
 variable [∀ i, SeminormedAddCommGroup (E' i)] [∀ i, NormedSpace 𝕜 (E' i)]
 
-/-- Given a map `f : MultilinearMap 𝕜 E (MultilinearMap 𝕜 E' G)` and an estimate
-`H : ∀ m m', ‖f m m'‖ ≤ C * ∏ i, ‖m i‖ * ∏ i, ‖m' i‖`, upgrade all `MultilinearMap`s in the type to
-`ContinuousMultilinearMap`s. -/
-def mkContinuousMultilinear (f : MultilinearMap 𝕜 E (MultilinearMap 𝕜 E' G)) (C : ℝ)
+/-- Given a map `f : MultilinearMap (RingHom.id 𝕜) E (MultilinearMap (RingHom.id 𝕜) E' G)`
+and an estimate `H : ∀ m m', ‖f m m'‖ ≤ C * ∏ i, ‖m i‖ * ∏ i, ‖m' i‖`, upgrade all
+`MultilinearMap`s in the type to `ContinuousMultilinearMap`s. -/
+def mkContinuousMultilinear
+    (f : MultilinearMap (RingHom.id 𝕜) E (MultilinearMap (RingHom.id 𝕜) E' G)) (C : ℝ)
     (H : ∀ m₁ m₂, ‖f m₁ m₂‖ ≤ (C * ∏ i, ‖m₁ i‖) * ∏ i, ‖m₂ i‖) :
     ContinuousMultilinearMap 𝕜 E (ContinuousMultilinearMap 𝕜 E' G) :=
   mkContinuous
@@ -897,18 +904,21 @@ def mkContinuousMultilinear (f : MultilinearMap 𝕜 E (MultilinearMap 𝕜 E' G
       positivity
 
 @[simp]
-theorem mkContinuousMultilinear_apply (f : MultilinearMap 𝕜 E (MultilinearMap 𝕜 E' G)) {C : ℝ}
+theorem mkContinuousMultilinear_apply
+    (f : MultilinearMap (RingHom.id 𝕜) E (MultilinearMap (RingHom.id 𝕜) E' G)) {C : ℝ}
     (H : ∀ m₁ m₂, ‖f m₁ m₂‖ ≤ (C * ∏ i, ‖m₁ i‖) * ∏ i, ‖m₂ i‖) (m : ∀ i, E i) :
     ⇑(mkContinuousMultilinear f C H m) = f m :=
   rfl
 
-theorem mkContinuousMultilinear_norm_le' (f : MultilinearMap 𝕜 E (MultilinearMap 𝕜 E' G)) (C : ℝ)
+theorem mkContinuousMultilinear_norm_le'
+    (f : MultilinearMap (RingHom.id 𝕜) E (MultilinearMap (RingHom.id 𝕜) E' G)) (C : ℝ)
     (H : ∀ m₁ m₂, ‖f m₁ m₂‖ ≤ (C * ∏ i, ‖m₁ i‖) * ∏ i, ‖m₂ i‖) :
     ‖mkContinuousMultilinear f C H‖ ≤ max C 0 := by
   dsimp only [mkContinuousMultilinear]
   exact mkContinuous_norm_le _ (le_max_right _ _) _
 
-theorem mkContinuousMultilinear_norm_le (f : MultilinearMap 𝕜 E (MultilinearMap 𝕜 E' G)) {C : ℝ}
+theorem mkContinuousMultilinear_norm_le
+    (f : MultilinearMap (RingHom.id 𝕜) E (MultilinearMap (RingHom.id 𝕜) E' G)) {C : ℝ}
     (hC : 0 ≤ C) (H : ∀ m₁ m₂, ‖f m₁ m₂‖ ≤ (C * ∏ i, ‖m₁ i‖) * ∏ i, ‖m₂ i‖) :
     ‖mkContinuousMultilinear f C H‖ ≤ C :=
   (mkContinuousMultilinear_norm_le' f C H).trans_eq (max_eq_left hC)
@@ -945,7 +955,7 @@ def flipMultilinear (f : G →L[𝕜] ContinuousMultilinearMap 𝕜 E G') :
       map_update_smul' := fun m i c x => by
         ext1
         simp only [FunLike.coe_smul, ContinuousMultilinearMap.map_update_smul, LinearMap.coe_mk,
-          LinearMap.mkContinuous_apply, Pi.smul_apply, AddHom.coe_mk] }
+          LinearMap.mkContinuous_apply, Pi.smul_apply, AddHom.coe_mk, RingHom.id_apply] }
     ‖f‖ fun m => by
       dsimp only [MultilinearMap.coe_mk]
       exact LinearMap.mkContinuous_norm_le _ (by positivity) _
@@ -1099,7 +1109,7 @@ open Function in
 sending a continuous multilinear map `g` to `g (f₁ ·, ..., fₙ ·)`
 is continuous-linear in `g` and multilinear in `f₁, ..., fₙ`. -/
 noncomputable def compContinuousLinearMapMultilinear :
-    MultilinearMap 𝕜 (fun i ↦ E i →L[𝕜] E₁ i)
+    MultilinearMap (RingHom.id 𝕜) (fun i ↦ E i →L[𝕜] E₁ i)
       ((ContinuousMultilinearMap 𝕜 E₁ G) →L[𝕜] ContinuousMultilinearMap 𝕜 E G) where
   toFun := compContinuousLinearMapL
   map_update_add' f i f₁ f₂ := by
@@ -1283,7 +1293,7 @@ namespace MultilinearMap
 /-- If a multilinear map in finitely many variables on normed spaces satisfies the inequality
 `‖f m‖ ≤ C * ∏ i, ‖m i‖` on a shell `ε i / ‖c i‖ < ‖m i‖ < ε i` for some positive numbers `ε i`
 and elements `c i : 𝕜`, `1 < ‖c i‖`, then it satisfies this inequality for all `m`. -/
-theorem bound_of_shell (f : MultilinearMap 𝕜 E G) {ε : ι → ℝ} {C : ℝ} {c : ι → 𝕜}
+theorem bound_of_shell (f : MultilinearMap (RingHom.id 𝕜) E G) {ε : ι → ℝ} {C : ℝ} {c : ι → 𝕜}
     (hε : ∀ i, 0 < ε i) (hc : ∀ i, 1 < ‖c i‖)
     (hf : ∀ m : ∀ i, E i, (∀ i, ε i / ‖c i‖ ≤ ‖m i‖) → (∀ i, ‖m i‖ < ε i) → ‖f m‖ ≤ C * ∏ i, ‖m i‖)
     (m : ∀ i, E i) : ‖f m‖ ≤ C * ∏ i, ‖m i‖ :=

--- a/Mathlib/Analysis/Normed/Module/Multilinear/Curry.lean
+++ b/Mathlib/Analysis/Normed/Module/Multilinear/Curry.lean
@@ -195,7 +195,8 @@ variables obtained by concatenating the variables, given by `m ↦ f (init m) (m
 def ContinuousMultilinearMap.uncurryRight
     (f : ContinuousMultilinearMap 𝕜 (fun i : Fin n => Ei <| castSucc i) (Ei (last n) →L[𝕜] G)) :
     ContinuousMultilinearMap 𝕜 Ei G :=
-  let f' : MultilinearMap 𝕜 (fun i : Fin n => Ei <| castSucc i) (Ei (last n) →ₗ[𝕜] G) :=
+  let f' : MultilinearMap (RingHom.id 𝕜) (fun i : Fin n => Ei <| castSucc i)
+      (Ei (last n) →ₗ[𝕜] G) :=
     (ContinuousLinearMap.coeLM 𝕜).compMultilinearMap f.toMultilinearMap
   f'.uncurryRight.mkContinuous ‖f‖ fun m => f.norm_map_init_le m
 
@@ -211,7 +212,8 @@ a continuous multilinear map in `n` variables into continuous linear maps, given
 `m ↦ (x ↦ f (snoc m x))`. -/
 def ContinuousMultilinearMap.curryRight (f : ContinuousMultilinearMap 𝕜 Ei G) :
     ContinuousMultilinearMap 𝕜 (fun i : Fin n => Ei <| castSucc i) (Ei (last n) →L[𝕜] G) :=
-  let f' : MultilinearMap 𝕜 (fun i : Fin n => Ei <| castSucc i) (Ei (last n) →L[𝕜] G) :=
+  let f' : MultilinearMap (RingHom.id 𝕜) (fun i : Fin n => Ei <| castSucc i)
+      (Ei (last n) →L[𝕜] G) :=
     { toFun := fun m =>
         (f.toMultilinearMap.curryRight m).mkContinuous (‖f‖ * ∏ i, ‖m i‖) fun x =>
           f.norm_map_snoc_le m x

--- a/Mathlib/Analysis/Normed/Module/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Module/PiTensorProduct/InjectiveSeminorm.lean
@@ -128,7 +128,7 @@ theorem norm_eval_le_injectiveSeminorm (f : ContinuousMultilinearMap 𝕜 E F) (
   set f'₀ := lift.symm (e.symm.toLinearMap ∘ₗ LinearMap.rangeRestrict (lift f.toMultilinearMap))
   have hf'₀ : ∀ (x : Π (i : ι), E i), ‖f'₀ x‖ ≤ ‖f‖ * ∏ i, ‖x i‖ := fun x ↦ by
     change ‖e (f'₀ x)‖ ≤ _
-    simp only [lift_symm, LinearMap.compMultilinearMapₛₗ_apply, LinearMap.coe_comp,
+    simp only [lift_symm, LinearMap.compMultilinearMap_apply, LinearMap.coe_comp,
         LinearEquiv.coe_coe, Function.comp_apply, LinearEquiv.apply_symm_apply, Submodule.coe_norm,
         LinearMap.codRestrict_apply, lift.tprod, ContinuousMultilinearMap.coe_coe, e, f'₀]
     exact f.le_opNorm x
@@ -138,7 +138,7 @@ theorem norm_eval_le_injectiveSeminorm (f : ContinuousMultilinearMap 𝕜 E F) (
     induction x using PiTensorProduct.induction_on with
     | smul_tprod =>
       simp only [lift_symm, map_smul, lift.tprod, ContinuousMultilinearMap.coe_coe,
-      MultilinearMap.coe_mkContinuous, LinearMap.compMultilinearMapₛₗ_apply, LinearMap.coe_comp,
+      MultilinearMap.coe_mkContinuous, LinearMap.compMultilinearMap_apply, LinearMap.coe_comp,
       LinearEquiv.coe_coe, Function.comp_apply, LinearEquiv.apply_symm_apply, SetLike.val_smul,
       LinearMap.codRestrict_apply, f', f'₀]
     | add _ _ hx hy => simp only [map_add, Submodule.coe_add, hx, hy]

--- a/Mathlib/Analysis/Normed/Module/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Module/PiTensorProduct/InjectiveSeminorm.lean
@@ -128,7 +128,7 @@ theorem norm_eval_le_injectiveSeminorm (f : ContinuousMultilinearMap 𝕜 E F) (
   set f'₀ := lift.symm (e.symm.toLinearMap ∘ₗ LinearMap.rangeRestrict (lift f.toMultilinearMap))
   have hf'₀ : ∀ (x : Π (i : ι), E i), ‖f'₀ x‖ ≤ ‖f‖ * ∏ i, ‖x i‖ := fun x ↦ by
     change ‖e (f'₀ x)‖ ≤ _
-    simp only [lift_symm, LinearMap.compMultilinearMap_apply, LinearMap.coe_comp,
+    simp only [lift_symm, LinearMap.compMultilinearMapₛₗ_apply, LinearMap.coe_comp,
         LinearEquiv.coe_coe, Function.comp_apply, LinearEquiv.apply_symm_apply, Submodule.coe_norm,
         LinearMap.codRestrict_apply, lift.tprod, ContinuousMultilinearMap.coe_coe, e, f'₀]
     exact f.le_opNorm x
@@ -138,7 +138,7 @@ theorem norm_eval_le_injectiveSeminorm (f : ContinuousMultilinearMap 𝕜 E F) (
     induction x using PiTensorProduct.induction_on with
     | smul_tprod =>
       simp only [lift_symm, map_smul, lift.tprod, ContinuousMultilinearMap.coe_coe,
-      MultilinearMap.coe_mkContinuous, LinearMap.compMultilinearMap_apply, LinearMap.coe_comp,
+      MultilinearMap.coe_mkContinuous, LinearMap.compMultilinearMapₛₗ_apply, LinearMap.coe_comp,
       LinearEquiv.coe_coe, Function.comp_apply, LinearEquiv.apply_symm_apply, SetLike.val_smul,
       LinearMap.codRestrict_apply, f', f'₀]
     | add _ _ hx hy => simp only [map_add, Submodule.coe_add, hx, hy]

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -65,7 +65,7 @@ variable (R M N ι)
 
 /-- An alternating map from `ι → M` to `N`, denoted `M [⋀^ι]→ₗ[R] N`,
 is a multilinear map that vanishes when two of its arguments are equal. -/
-structure AlternatingMap extends MultilinearMap R (fun _ : ι => M) N where
+structure AlternatingMap extends MultilinearMap (RingHom.id R) (fun _ : ι => M) N where
   /-- The map is alternating: if `v` has two equal coordinates, then `f v = 0`. -/
   map_eq_zero_of_eq' : ∀ (v : ι → M) (i j : ι), v i = v j → i ≠ j → toFun v = 0
 
@@ -105,7 +105,7 @@ theorem toFun_eq_coe : f.toFun = f :=
   rfl
 
 @[simp]
-theorem coe_mk (f : MultilinearMap R (fun _ : ι => M) N) (h) :
+theorem coe_mk (f : MultilinearMap (RingHom.id R) (fun _ : ι => M) N) (h) :
     ⇑(⟨f, h⟩ : M [⋀^ι]→ₗ[R] N) = f :=
   rfl
 
@@ -128,19 +128,19 @@ theorem ext {f f' : M [⋀^ι]→ₗ[R] N} (H : ∀ x, f x = f' x) : f = f' :=
 
 attribute [coe] AlternatingMap.toMultilinearMap
 
-instance instCoe : Coe (M [⋀^ι]→ₗ[R] N) (MultilinearMap R (fun _ : ι => M) N) :=
+instance instCoe : Coe (M [⋀^ι]→ₗ[R] N) (MultilinearMap (RingHom.id R) (fun _ : ι => M) N) :=
   ⟨fun x => x.toMultilinearMap⟩
 
 @[simp, norm_cast]
-theorem coe_multilinearMap : ⇑(f : MultilinearMap R (fun _ : ι => M) N) = f :=
+theorem coe_multilinearMap : ⇑(f : MultilinearMap (RingHom.id R) (fun _ : ι => M) N) = f :=
   rfl
 
 theorem coe_multilinearMap_injective :
-    Function.Injective ((↑) : M [⋀^ι]→ₗ[R] N → MultilinearMap R (fun _ : ι => M) N) :=
+    Function.Injective ((↑) : M [⋀^ι]→ₗ[R] N → MultilinearMap (RingHom.id R) (fun _ : ι => M) N) :=
   fun _ _ h => ext <| MultilinearMap.congr_fun h
 
 theorem coe_multilinearMap_mk (f : (ι → M) → N) (h₁ h₂ h₃) :
-    ((⟨⟨f, h₁, h₂⟩, h₃⟩ : M [⋀^ι]→ₗ[R] N) : MultilinearMap R (fun _ : ι => M) N) =
+    ((⟨⟨f, h₁, h₂⟩, h₃⟩ : M [⋀^ι]→ₗ[R] N) : MultilinearMap (RingHom.id R) (fun _ : ι => M) N) =
       ⟨f, @h₁, @h₂⟩ := by
   simp
 
@@ -208,7 +208,7 @@ variable {S : Type*} [Monoid S] [DistribMulAction S N] [SMulCommClass R S N]
 
 instance instSMul : SMul S (M [⋀^ι]→ₗ[R] N) :=
   ⟨fun c f =>
-    { c • (f : MultilinearMap R (fun _ : ι => M) N) with
+    { c • (f : MultilinearMap (RingHom.id R) (fun _ : ι => M) N) with
       map_eq_zero_of_eq' := fun v i j h hij => by simp [f.map_eq_zero_of_eq v h hij] }⟩
 
 @[simp]
@@ -216,7 +216,7 @@ theorem smul_apply (c : S) (m : ι → M) : (c • f) m = c • f m :=
   rfl
 
 @[norm_cast]
-theorem coe_smul (c : S) : ↑(c • f) = c • (f : MultilinearMap R (fun _ : ι => M) N) :=
+theorem coe_smul (c : S) : ↑(c • f) = c • (f : MultilinearMap (RingHom.id R) (fun _ : ι => M) N) :=
   rfl
 
 theorem coeFn_smul (c : S) (f : M [⋀^ι]→ₗ[R] N) : ⇑(c • f) = c • ⇑f :=
@@ -241,7 +241,7 @@ def prod (f : M [⋀^ι]→ₗ[R] N) (g : M [⋀^ι]→ₗ[R] P) : M [⋀^ι]→
 
 @[simp]
 theorem coe_prod (f : M [⋀^ι]→ₗ[R] N) (g : M [⋀^ι]→ₗ[R] P) :
-    (f.prod g : MultilinearMap R (fun _ : ι => M) (N × P)) = MultilinearMap.prod f g :=
+    (f.prod g : MultilinearMap (RingHom.id R) (fun _ : ι => M) (N × P)) = MultilinearMap.prod f g :=
   rfl
 
 /-- Combine a family of alternating maps with the same domain and codomains `N i` into an
@@ -255,7 +255,8 @@ def pi {ι' : Type*} {N : ι' → Type*} [∀ i, AddCommMonoid (N i)] [∀ i, Mo
 @[simp]
 theorem coe_pi {ι' : Type*} {N : ι' → Type*} [∀ i, AddCommMonoid (N i)] [∀ i, Module R (N i)]
     (f : ∀ i, M [⋀^ι]→ₗ[R] N i) :
-    (pi f : MultilinearMap R (fun _ : ι => M) (∀ i, N i)) = MultilinearMap.pi fun a => f a :=
+    (pi f : MultilinearMap (RingHom.id R) (fun _ : ι => M) (∀ i, N i)) =
+      MultilinearMap.pi fun a => f a :=
   rfl
 
 /-- Given an alternating `R`-multilinear map `f` taking values in `R`, `f.smul_right z` is the map
@@ -269,12 +270,13 @@ def smulRight {R M₁ M₂ ι : Type*} [CommSemiring R] [AddCommMonoid M₁] [Ad
 @[simp]
 theorem coe_smulRight {R M₁ M₂ ι : Type*} [CommSemiring R] [AddCommMonoid M₁] [AddCommMonoid M₂]
     [Module R M₁] [Module R M₂] (f : M₁ [⋀^ι]→ₗ[R] R) (z : M₂) :
-    (f.smulRight z : MultilinearMap R (fun _ : ι => M₁) M₂) = MultilinearMap.smulRight f z :=
+    (f.smulRight z : MultilinearMap (RingHom.id R) (fun _ : ι => M₁) M₂) =
+      MultilinearMap.smulRight f z :=
   rfl
 
 instance instAdd : Add (M [⋀^ι]→ₗ[R] N) where
   add a b :=
-    { (a + b : MultilinearMap R (fun _ : ι => M) N) with
+    { (a + b : MultilinearMap (RingHom.id R) (fun _ : ι => M) N) with
       map_eq_zero_of_eq' := fun v i j h hij => by
         simp [a.map_eq_zero_of_eq v h hij, b.map_eq_zero_of_eq v h hij] }
 
@@ -283,11 +285,11 @@ theorem add_apply : (f + f') v = f v + f' v :=
   rfl
 
 @[norm_cast]
-theorem coe_add : (↑(f + f') : MultilinearMap R (fun _ : ι => M) N) = f + f' :=
+theorem coe_add : (↑(f + f') : MultilinearMap (RingHom.id R) (fun _ : ι => M) N) = f + f' :=
   rfl
 
 instance instZero : Zero (M [⋀^ι]→ₗ[R] N) :=
-  ⟨{ (0 : MultilinearMap R (fun _ : ι => M) N) with
+  ⟨{ (0 : MultilinearMap (RingHom.id R) (fun _ : ι => M) N) with
       map_eq_zero_of_eq' := fun _ _ _ _ _ => by simp }⟩
 
 @[simp]
@@ -295,12 +297,12 @@ theorem zero_apply : (0 : M [⋀^ι]→ₗ[R] N) v = 0 :=
   rfl
 
 @[norm_cast]
-theorem coe_zero : ((0 : M [⋀^ι]→ₗ[R] N) : MultilinearMap R (fun _ : ι => M) N) = 0 :=
+theorem coe_zero : ((0 : M [⋀^ι]→ₗ[R] N) : MultilinearMap (RingHom.id R) (fun _ : ι => M) N) = 0 :=
   rfl
 
 @[simp]
 theorem mk_zero :
-    mk (0 : MultilinearMap R (fun _ : ι ↦ M) N) (0 : M [⋀^ι]→ₗ[R] N).2 = 0 :=
+    mk (0 : MultilinearMap (RingHom.id R) (fun _ : ι ↦ M) N) (0 : M [⋀^ι]→ₗ[R] N).2 = 0 :=
   rfl
 
 instance instInhabited : Inhabited (M [⋀^ι]→ₗ[R] N) :=
@@ -311,7 +313,7 @@ instance instAddCommMonoid : AddCommMonoid (M [⋀^ι]→ₗ[R] N) := fast_insta
 
 instance instNeg : Neg (M [⋀^ι]→ₗ[R] N') :=
   ⟨fun f =>
-    { -(f : MultilinearMap R (fun _ : ι => M) N') with
+    { -(f : MultilinearMap (RingHom.id R) (fun _ : ι => M) N') with
       map_eq_zero_of_eq' := fun v i j h hij => by simp [f.map_eq_zero_of_eq v h hij] }⟩
 
 @[simp]
@@ -319,12 +321,13 @@ theorem neg_apply (m : ι → M) : (-g) m = -g m :=
   rfl
 
 @[norm_cast]
-theorem coe_neg : ((-g : M [⋀^ι]→ₗ[R] N') : MultilinearMap R (fun _ : ι => M) N') = -g :=
+theorem coe_neg :
+    ((-g : M [⋀^ι]→ₗ[R] N') : MultilinearMap (RingHom.id R) (fun _ : ι => M) N') = -g :=
   rfl
 
 instance instSub : Sub (M [⋀^ι]→ₗ[R] N') :=
   ⟨fun f g =>
-    { (f - g : MultilinearMap R (fun _ : ι => M) N') with
+    { (f - g : MultilinearMap (RingHom.id R) (fun _ : ι => M) N') with
       map_eq_zero_of_eq' := fun v i j h hij => by
         simp [f.map_eq_zero_of_eq v h hij, g.map_eq_zero_of_eq v h hij] }⟩
 
@@ -333,7 +336,7 @@ theorem sub_apply (m : ι → M) : (g - g₂) m = g m - g₂ m :=
   rfl
 
 @[norm_cast]
-theorem coe_sub : (↑(g - g₂) : MultilinearMap R (fun _ : ι => M) N') = g - g₂ :=
+theorem coe_sub : (↑(g - g₂) : MultilinearMap (RingHom.id R) (fun _ : ι => M) N') = g - g₂ :=
   rfl
 
 instance instAddCommGroup : AddCommGroup (M [⋀^ι]→ₗ[R] N') := fast_instance%
@@ -367,7 +370,8 @@ instance instIsTorsionFree [IsTorsionFree S N] : IsTorsionFree S (M [⋀^ι]→�
 
 /-- Embedding of alternating maps into multilinear maps as a linear map. -/
 @[simps]
-def toMultilinearMapLM : (M [⋀^ι]→ₗ[R] N) →ₗ[S] MultilinearMap R (fun _ : ι ↦ M) N where
+def toMultilinearMapLM :
+    (M [⋀^ι]→ₗ[R] N) →ₗ[S] MultilinearMap (RingHom.id R) (fun _ : ι ↦ M) N where
   toFun := toMultilinearMap
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
@@ -419,7 +423,7 @@ variable {S : Type*} {N₂ : Type*} [AddCommMonoid N₂] [Module R N₂]
 
 /-- Composing an alternating map with a linear map on the left gives again an alternating map. -/
 def compAlternatingMap (g : N →ₗ[R] N₂) (f : M [⋀^ι]→ₗ[R] N) : M [⋀^ι]→ₗ[R] N₂ where
-  __ := g.compMultilinearMap (f : MultilinearMap R (fun _ : ι => M) N)
+  __ := g.compMultilinearMap (f : MultilinearMap (RingHom.id R) (fun _ : ι => M) N)
   map_eq_zero_of_eq' v i j h hij := by simp [f.map_eq_zero_of_eq v h hij]
 
 @[simp]
@@ -504,7 +508,7 @@ variable {M₃ : Type*} [AddCommMonoid M₃] [Module R M₃]
 /-- Composing an alternating map with the same linear map on each argument gives again an
 alternating map. -/
 def compLinearMap (f : M [⋀^ι]→ₗ[R] N) (g : M₂ →ₗ[R] M) : M₂ [⋀^ι]→ₗ[R] N :=
-  { (f : MultilinearMap R (fun _ : ι => M) N).compLinearMap fun _ => g with
+  { (f : MultilinearMap (RingHom.id R) (fun _ : ι => M) N).compLinearMap fun _ => g with
     map_eq_zero_of_eq' := fun _ _ _ h hij => f.map_eq_zero_of_eq _ (LinearMap.congr_arg h) hij }
 
 theorem coe_compLinearMap (f : M [⋀^ι]→ₗ[R] N) (g : M₂ →ₗ[R] M) :
@@ -775,7 +779,7 @@ theorem domDomCongr_perm [Fintype ι] [DecidableEq ι] (σ : Equiv.Perm ι) :
 
 @[norm_cast]
 theorem coe_domDomCongr (σ : ι ≃ ι') :
-    ↑(f.domDomCongr σ) = (f : MultilinearMap R (fun _ : ι => M) N).domDomCongr σ :=
+    ↑(f.domDomCongr σ) = (f : MultilinearMap (RingHom.id R) (fun _ : ι => M) N).domDomCongr σ :=
   MultilinearMap.ext fun _ => rfl
 
 end DomDomCongr
@@ -820,7 +824,8 @@ open Equiv
 
 variable [Fintype ι] [DecidableEq ι]
 
-private theorem alternization_map_eq_zero_of_eq_aux (m : MultilinearMap R (fun _ : ι => M) N')
+private theorem alternization_map_eq_zero_of_eq_aux
+    (m : MultilinearMap (RingHom.id R) (fun _ : ι => M) N')
     (v : ι → M) (i j : ι) (i_ne_j : i ≠ j) (hv : v i = v j) :
     (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ) v = 0 := by
   rw [sum_apply]
@@ -832,7 +837,7 @@ private theorem alternization_map_eq_zero_of_eq_aux (m : MultilinearMap R (fun _
 
 /-- Produce an `AlternatingMap` out of a `MultilinearMap`, by summing over all argument
 permutations. -/
-def alternatization : MultilinearMap R (fun _ : ι => M) N' →+ M [⋀^ι]→ₗ[R] N' where
+def alternatization : MultilinearMap (RingHom.id R) (fun _ : ι => M) N' →+ M [⋀^ι]→ₗ[R] N' where
   toFun m :=
     { ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ with
       toFun := ⇑(∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ)
@@ -841,15 +846,15 @@ def alternatization : MultilinearMap R (fun _ : ι => M) N' →+ M [⋀^ι]→�
   map_add' a b := by ext; simp [Finset.sum_add_distrib]
   map_zero' := by ext; simp
 
-theorem alternatization_def (m : MultilinearMap R (fun _ : ι => M) N') :
+theorem alternatization_def (m : MultilinearMap (RingHom.id R) (fun _ : ι => M) N') :
     ⇑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ :) :=
   rfl
 
-theorem alternatization_coe (m : MultilinearMap R (fun _ : ι => M) N') :
+theorem alternatization_coe (m : MultilinearMap (RingHom.id R) (fun _ : ι => M) N') :
     ↑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ :) :=
   coe_injective rfl
 
-theorem alternatization_apply (m : MultilinearMap R (fun _ : ι => M) N') (v : ι → M) :
+theorem alternatization_apply (m : MultilinearMap (RingHom.id R) (fun _ : ι => M) N') (v : ι → M) :
     alternatization m v = ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ v := by
   simp only [alternatization_def, smul_apply, sum_apply]
 
@@ -860,7 +865,7 @@ namespace AlternatingMap
 /-- Alternatizing a multilinear map that is already alternating results in a scale factor of `n!`,
 where `n` is the number of inputs. -/
 theorem coe_alternatization [DecidableEq ι] [Fintype ι] (a : M [⋀^ι]→ₗ[R] N') :
-    MultilinearMap.alternatization (a : MultilinearMap R (fun _ => M) N')
+    MultilinearMap.alternatization (a : MultilinearMap (RingHom.id R) (fun _ => M) N')
     = Nat.factorial (Fintype.card ι) • a := by
   apply AlternatingMap.coe_injective
   simp_rw [MultilinearMap.alternatization_def, ← coe_domDomCongr, domDomCongr_perm, coe_smul,
@@ -875,7 +880,7 @@ variable {N'₂ : Type*} [AddCommGroup N'₂] [Module R N'₂] [DecidableEq ι] 
 
 /-- Composition with a linear map before and after alternatization are equivalent. -/
 theorem compMultilinearMap_alternatization (g : N' →ₗ[R] N'₂)
-    (f : MultilinearMap R (fun _ : ι => M) N') :
+    (f : MultilinearMap (RingHom.id R) (fun _ : ι => M) N') :
     MultilinearMap.alternatization (g.compMultilinearMap f)
       = g.compAlternatingMap (MultilinearMap.alternatization f) := by
   ext

--- a/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
+++ b/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
@@ -46,11 +46,13 @@ set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 /-- summand used in `AlternatingMap.domCoprod` -/
 def domCoprod.summand (a : Mᵢ [⋀^ιa]→ₗ[R'] N₁) (b : Mᵢ [⋀^ιb]→ₗ[R'] N₂)
-    (σ : Perm.ModSumCongr ιa ιb) : MultilinearMap R' (fun _ : ιa ⊕ ιb => Mᵢ) (N₁ ⊗[R'] N₂) :=
+    (σ : Perm.ModSumCongr ιa ιb) :
+    MultilinearMap (RingHom.id R') (fun _ : ιa ⊕ ιb => Mᵢ) (N₁ ⊗[R'] N₂) :=
   Quotient.liftOn' σ
     (fun σ =>
       Equiv.Perm.sign σ •
-        (MultilinearMap.domCoprod ↑a ↑b : MultilinearMap R' (fun _ => Mᵢ) (N₁ ⊗ N₂)).domDomCongr σ)
+        (MultilinearMap.domCoprod ↑a ↑b :
+          MultilinearMap (RingHom.id R') (fun _ => Mᵢ) (N₁ ⊗ N₂)).domDomCongr σ)
     fun σ₁ σ₂ H => by
     rw [QuotientGroup.leftRel_apply] at H
     obtain ⟨⟨sl, sr⟩, h⟩ := H
@@ -69,8 +71,8 @@ theorem domCoprod.summand_mk'' (a : Mᵢ [⋀^ιa]→ₗ[R'] N₁) (b : Mᵢ [�
     (σ : Equiv.Perm (ιa ⊕ ιb)) :
     domCoprod.summand a b (Quotient.mk'' σ) =
       Equiv.Perm.sign σ •
-        (MultilinearMap.domCoprod ↑a ↑b : MultilinearMap R' (fun _ => Mᵢ) (N₁ ⊗ N₂)).domDomCongr
-          σ :=
+        (MultilinearMap.domCoprod ↑a ↑b :
+          MultilinearMap (RingHom.id R') (fun _ => Mᵢ) (N₁ ⊗ N₂)).domDomCongr σ :=
   rfl
 
 /-- Swapping elements in `σ` with equal values in `v` results in an addition that cancels -/
@@ -148,7 +150,7 @@ def domCoprod (a : Mᵢ [⋀^ιa]→ₗ[R'] N₁) (b : Mᵢ [⋀^ιb]→ₗ[R'] 
           Equiv.swap_smul_involutive i j σ }
 
 theorem domCoprod_coe (a : Mᵢ [⋀^ιa]→ₗ[R'] N₁) (b : Mᵢ [⋀^ιb]→ₗ[R'] N₂) :
-    (↑(a.domCoprod b) : MultilinearMap R' (fun _ => Mᵢ) _) =
+    (↑(a.domCoprod b) : MultilinearMap (RingHom.id R') (fun _ => Mᵢ) _) =
       ∑ σ : Perm.ModSumCongr ιa ιb, domCoprod.summand a b σ :=
   MultilinearMap.ext fun _ => rfl
 
@@ -185,7 +187,8 @@ open Equiv
 
 /-- A helper lemma for `MultilinearMap.domCoprod_alternization`. -/
 theorem MultilinearMap.domCoprod_alternization_coe [DecidableEq ιa] [DecidableEq ιb]
-    (a : MultilinearMap R' (fun _ : ιa => Mᵢ) N₁) (b : MultilinearMap R' (fun _ : ιb => Mᵢ) N₂) :
+    (a : MultilinearMap (RingHom.id R') (fun _ : ιa => Mᵢ) N₁)
+    (b : MultilinearMap (RingHom.id R') (fun _ : ιb => Mᵢ) N₂) :
     MultilinearMap.domCoprod (MultilinearMap.alternatization a)
       (MultilinearMap.alternatization b) =
       ∑ σa : Perm ιa, ∑ σb : Perm ιb,
@@ -204,7 +207,8 @@ open Perm in
 as computing the `AlternatingMap.domCoprod` of the `MultilinearMap.alternatization`s.
 -/
 theorem MultilinearMap.domCoprod_alternization [DecidableEq ιa] [DecidableEq ιb]
-    (a : MultilinearMap R' (fun _ : ιa => Mᵢ) N₁) (b : MultilinearMap R' (fun _ : ιb => Mᵢ) N₂) :
+    (a : MultilinearMap (RingHom.id R') (fun _ : ιa => Mᵢ) N₁)
+    (b : MultilinearMap (RingHom.id R') (fun _ : ιb => Mᵢ) N₂) :
     MultilinearMap.alternatization (MultilinearMap.domCoprod a b) =
       a.alternatization.domCoprod (MultilinearMap.alternatization b) := by
   apply coe_multilinearMap_injective
@@ -239,7 +243,8 @@ theorem MultilinearMap.domCoprod_alternization [DecidableEq ιa] [DecidableEq ι
 theorem MultilinearMap.domCoprod_alternization_eq [DecidableEq ιa] [DecidableEq ιb]
     (a : Mᵢ [⋀^ιa]→ₗ[R'] N₁) (b : Mᵢ [⋀^ιb]→ₗ[R'] N₂) :
     MultilinearMap.alternatization
-      (MultilinearMap.domCoprod a b : MultilinearMap R' (fun _ : ιa ⊕ ιb => Mᵢ) (N₁ ⊗ N₂)) =
+      (MultilinearMap.domCoprod a b :
+        MultilinearMap (RingHom.id R') (fun _ : ιa ⊕ ιb => Mᵢ) (N₁ ⊗ N₂)) =
       ((Fintype.card ιa).factorial * (Fintype.card ιb).factorial) • a.domCoprod b := by
   rw [MultilinearMap.domCoprod_alternization, coe_alternatization, coe_alternatization, mul_smul,
     ← AlternatingMap.domCoprod'_apply, ← AlternatingMap.domCoprod'_apply,

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -247,6 +247,146 @@ instance addCommMonoid : AddCommMonoid (MultilinearMap σ M₁ M₂) := fast_ins
 
 end AddCommMonoidSemilinear
 
+section CompLinearMap
+
+variable {R₃ : Type*} [Semiring R] [Semiring R₂] [Semiring R₃]
+  {σ₁₂ : R →+* R₂} {σ₂₃ : R₂ →+* R₃} {σ₁₃ : R →+* R₃}
+  [∀ i, AddCommMonoid (M₁ i)] [∀ i, Module R (M₁ i)]
+  [∀ i, AddCommMonoid (M₁' i)] [∀ i, Module R₂ (M₁' i)]
+  [AddCommMonoid M₂] [Module R₃ M₂]
+
+/-- If `g` is a multilinear map and `f` is a collection of semilinear maps,
+then `g (f₁ m₁, ..., fₙ mₙ)` is again a multilinear map, that we call
+`g.compLinearMap f`. -/
+def compLinearMap [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
+    (g : MultilinearMap σ₂₃ M₁' M₂) (f : ∀ i, M₁ i →ₛₗ[σ₁₂] M₁' i) :
+    MultilinearMap σ₁₃ M₁ M₂ where
+  toFun m := g fun i => f i (m i)
+  map_update_add' m i x y := by
+    have : ∀ j z, f j (update m i z j) = update (fun k => f k (m k)) i (f i z) j := fun j z =>
+      Function.apply_update (fun k => f k) _ _ _ _
+    simp [this]
+  map_update_smul' m i c x := by
+    have : ∀ j z, f j (update m i z j) = update (fun k => f k (m k)) i (f i z) j := fun j z =>
+      Function.apply_update (fun k => f k) _ _ _ _
+    simp [this, map_smulₛₗ, RingHomCompTriple.comp_apply]
+
+variable [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
+
+@[simp]
+theorem compLinearMap_apply (g : MultilinearMap σ₂₃ M₁' M₂) (f : ∀ i, M₁ i →ₛₗ[σ₁₂] M₁' i)
+    (m : ∀ i, M₁ i) : g.compLinearMap f m = g fun i => f i (m i) :=
+  rfl
+
+end CompLinearMap
+
+section SemilinearCodomain
+
+variable [Semiring R] [Semiring R₂] {σ : R →+* R₂}
+  [∀ i, AddCommMonoid (M₁ i)] [∀ i, Module R (M₁ i)]
+  [AddCommMonoid M₂] [Module R₂ M₂] [AddCommMonoid M₃] [Module R₂ M₃]
+
+/-- If `f` is a multilinear map, then `f.toLinearMap m i` is the semilinear map obtained by fixing
+all coordinates but `i` equal to those of `m`, and varying the `i`-th coordinate. -/
+@[simps]
+def toLinearMap [DecidableEq ι] (f : MultilinearMap σ M₁ M₂) (m : ∀ i, M₁ i) (i : ι) :
+    M₁ i →ₛₗ[σ] M₂ where
+  toFun x := f (update m i x)
+  map_add' x y := by simp
+  map_smul' c x := by simp
+
+/-- The Cartesian product of two multilinear maps, as a multilinear map. -/
+@[simps]
+def prod (f : MultilinearMap σ M₁ M₂) (g : MultilinearMap σ M₁ M₃) :
+    MultilinearMap σ M₁ (M₂ × M₃) where
+  toFun m := (f m, g m)
+  map_update_add' m i x y := by simp
+  map_update_smul' m i c x := by simp
+
+/-- Combine a family of multilinear maps with the same domain and codomains `M' i` into a
+multilinear map taking values in the space of functions `∀ i, M' i`. -/
+@[simps]
+def pi {ι' : Type*} {M' : ι' → Type*} [∀ i, AddCommMonoid (M' i)] [∀ i, Module R₂ (M' i)]
+    (f : ∀ i, MultilinearMap σ M₁ (M' i)) :
+    MultilinearMap σ M₁ (∀ i, M' i) where
+  toFun m i := f i m
+  map_update_add' _ _ _ _ := funext fun j => (f j).map_update_add _ _ _ _
+  map_update_smul' _ _ _ _ := funext fun j => (f j).map_update_smulₛₗ _ _ _ _
+
+/-- Restrict the codomain of a multilinear map to a submodule.
+
+This is the multilinear version of `LinearMap.codRestrict`. -/
+@[simps]
+def codRestrict (f : MultilinearMap σ M₁ M₂) (p : Submodule R₂ M₂) (h : ∀ v, f v ∈ p) :
+    MultilinearMap σ M₁ p where
+  toFun v := ⟨f v, h v⟩
+  map_update_add' _ _ _ _ := Subtype.ext <| MultilinearMap.map_update_add _ _ _ _ _
+  map_update_smul' _ _ _ _ := Subtype.ext <| MultilinearMap.map_update_smulₛₗ _ _ _ _ _
+
+end SemilinearCodomain
+
+section DomDomCongr
+
+variable {ι₁ ι₂ ι₃ : Type*}
+variable [Semiring R] [Semiring R₂] {σ : R →+* R₂}
+  [AddCommMonoid M₂] [Module R M₂] [AddCommMonoid M₃] [Module R₂ M₃]
+
+/-- Transfer the arguments to a map along an equivalence between argument indices.
+
+The naming is derived from `Finsupp.domCongr`, noting that here the permutation applies to the
+domain of the domain. -/
+@[simps apply]
+def domDomCongr (e : ι₁ ≃ ι₂) (m : MultilinearMap σ (fun _ : ι₁ => M₂) M₃) :
+    MultilinearMap σ (fun _ : ι₂ => M₂) M₃ where
+  toFun v := m fun i => v (e i)
+  map_update_add' v i a b := by
+    let := e.injective.decidableEq
+    simp_rw [Function.update_apply_equiv_apply v]
+    rw [m.map_update_add]
+  map_update_smul' v i a b := by
+    let := e.injective.decidableEq
+    simp_rw [Function.update_apply_equiv_apply v]
+    simp [m.map_update_smulₛₗ]
+
+theorem domDomCongr_trans (e₁ : ι₁ ≃ ι₂) (e₂ : ι₂ ≃ ι₃)
+    (m : MultilinearMap σ (fun _ : ι₁ => M₂) M₃) :
+    m.domDomCongr (e₁.trans e₂) = (m.domDomCongr e₁).domDomCongr e₂ :=
+  rfl
+
+theorem domDomCongr_mul (e₁ : Equiv.Perm ι₁) (e₂ : Equiv.Perm ι₁)
+    (m : MultilinearMap σ (fun _ : ι₁ => M₂) M₃) :
+    m.domDomCongr (e₂ * e₁) = (m.domDomCongr e₁).domDomCongr e₂ :=
+  rfl
+
+/-- `MultilinearMap.domDomCongr` as an equivalence.
+
+This is declared separately because it does not work with dot notation. -/
+@[simps apply symm_apply]
+def domDomCongrEquiv (e : ι₁ ≃ ι₂) :
+    MultilinearMap σ (fun _ : ι₁ => M₂) M₃ ≃+ MultilinearMap σ (fun _ : ι₂ => M₂) M₃ where
+  toFun := domDomCongr e
+  invFun := domDomCongr e.symm
+  left_inv m := by
+    ext
+    simp [domDomCongr]
+  right_inv m := by
+    ext
+    simp [domDomCongr]
+  map_add' a b := by
+    ext
+    simp [domDomCongr]
+
+/-- The results of applying `domDomCongr` to two maps are equal if
+and only if those maps are. -/
+@[simp]
+theorem domDomCongr_eq_iff (e : ι₁ ≃ ι₂)
+    (f g : MultilinearMap σ (fun _ : ι₁ => M₂) M₃) :
+    f.domDomCongr e = g.domDomCongr e ↔ f = g :=
+  (domDomCongrEquiv e : _ ≃+ MultilinearMap σ (fun _ => M₂) M₃).apply_eq_iff_eq
+
+end DomDomCongr
+
+
 section Semiring
 
 variable [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M₂]
@@ -271,32 +411,6 @@ def mk' [DecidableEq ι] (f : (∀ i, M₁ i) → M₂)
 protected theorem map_update_smul [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) (c : R) (x : M₁ i) :
     f (update m i (c • x)) = c • f (update m i x) := by
   simp
-
-/-- If `f` is a multilinear map, then `f.toLinearMap m i` is the linear map obtained by fixing all
-coordinates but `i` equal to those of `m`, and varying the `i`-th coordinate. -/
-@[simps]
-def toLinearMap [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) : M₁ i →ₗ[R] M₂ where
-  toFun x := f (update m i x)
-  map_add' x y := by simp
-  map_smul' c x := by simp
-
-/-- The Cartesian product of two multilinear maps, as a multilinear map. -/
-@[simps]
-def prod (f : MultilinearMap (RingHom.id R) M₁ M₂) (g : MultilinearMap (RingHom.id R) M₁ M₃) :
-    MultilinearMap (RingHom.id R) M₁ (M₂ × M₃) where
-  toFun m := (f m, g m)
-  map_update_add' m i x y := by simp
-  map_update_smul' m i c x := by simp
-
-/-- Combine a family of multilinear maps with the same domain and codomains `M' i` into a
-multilinear map taking values in the space of functions `∀ i, M' i`. -/
-@[simps]
-def pi {ι' : Type*} {M' : ι' → Type*} [∀ i, AddCommMonoid (M' i)] [∀ i, Module R (M' i)]
-    (f : ∀ i, MultilinearMap (RingHom.id R) M₁ (M' i)) :
-    MultilinearMap (RingHom.id R) M₁ (∀ i, M' i) where
-  toFun m i := f i m
-  map_update_add' _ _ _ _ := funext fun j => (f j).map_update_add _ _ _ _
-  map_update_smul' _ _ _ _ := funext fun j => (f j).map_update_smul _ _ _ _
 
 section
 
@@ -387,26 +501,6 @@ section
 
 variable [∀ i, AddCommMonoid (M₁' i)] [∀ i, Module R (M₁' i)]
 variable [∀ i, AddCommMonoid (M₁'' i)] [∀ i, Module R (M₁'' i)]
-
-/-- If `g` is a multilinear map and `f` is a collection of linear maps,
-then `g (f₁ m₁, ..., fₙ mₙ)` is again a multilinear map, that we call
-`g.compLinearMap f`. -/
-def compLinearMap (g : MultilinearMap (RingHom.id R) M₁' M₂) (f : ∀ i, M₁ i →ₗ[R] M₁' i) :
-    MultilinearMap (RingHom.id R) M₁ M₂ where
-  toFun m := g fun i => f i (m i)
-  map_update_add' m i x y := by
-    have : ∀ j z, f j (update m i z j) = update (fun k => f k (m k)) i (f i z) j := fun j z =>
-      Function.apply_update (fun k => f k) _ _ _ _
-    simp [this]
-  map_update_smul' m i c x := by
-    have : ∀ j z, f j (update m i z j) = update (fun k => f k (m k)) i (f i z) j := fun j z =>
-      Function.apply_update (fun k => f k) _ _ _ _
-    simp [this]
-
-@[simp]
-theorem compLinearMap_apply (g : MultilinearMap (RingHom.id R) M₁' M₂) (f : ∀ i, M₁ i →ₗ[R] M₁' i)
-    (m : ∀ i, M₁ i) : g.compLinearMap f m = g fun i => f i (m i) :=
-  rfl
 
 /-- Composing a multilinear map twice with a linear map in each argument is
 the same as composing with their composition. -/
@@ -681,16 +775,6 @@ theorem map_update_sum {α : Type*} [DecidableEq ι] (t : Finset α) (i : ι) (g
 
 end ApplySum
 
-/-- Restrict the codomain of a multilinear map to a submodule.
-
-This is the multilinear version of `LinearMap.codRestrict`. -/
-@[simps]
-def codRestrict (f : MultilinearMap (RingHom.id R) M₁ M₂) (p : Submodule R M₂) (h : ∀ v, f v ∈ p) :
-    MultilinearMap (RingHom.id R) M₁ p where
-  toFun v := ⟨f v, h v⟩
-  map_update_add' _ _ _ _ := Subtype.ext <| MultilinearMap.map_update_add _ _ _ _ _
-  map_update_smul' _ _ _ _ := Subtype.ext <| MultilinearMap.map_update_smul _ _ _ _ _
-
 section RestrictScalar
 
 variable (R)
@@ -711,66 +795,6 @@ theorem coe_restrictScalars (f : MultilinearMap (RingHom.id A) M₁ M₂) :
   rfl
 
 end RestrictScalar
-
-section
-
-variable {ι₁ ι₂ ι₃ : Type*}
-
-/-- Transfer the arguments to a map along an equivalence between argument indices.
-
-The naming is derived from `Finsupp.domCongr`, noting that here the permutation applies to the
-domain of the domain. -/
-@[simps apply]
-def domDomCongr (σ : ι₁ ≃ ι₂) (m : MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃) :
-    MultilinearMap (RingHom.id R) (fun _ : ι₂ => M₂) M₃ where
-  toFun v := m fun i => v (σ i)
-  map_update_add' v i a b := by
-    let := σ.injective.decidableEq
-    simp_rw [Function.update_apply_equiv_apply v]
-    rw [m.map_update_add]
-  map_update_smul' v i a b := by
-    let := σ.injective.decidableEq
-    simp_rw [Function.update_apply_equiv_apply v]
-    simp [m.map_update_smul]
-
-theorem domDomCongr_trans (σ₁ : ι₁ ≃ ι₂) (σ₂ : ι₂ ≃ ι₃)
-    (m : MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃) :
-    m.domDomCongr (σ₁.trans σ₂) = (m.domDomCongr σ₁).domDomCongr σ₂ :=
-  rfl
-
-theorem domDomCongr_mul (σ₁ : Equiv.Perm ι₁) (σ₂ : Equiv.Perm ι₁)
-    (m : MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃) :
-    m.domDomCongr (σ₂ * σ₁) = (m.domDomCongr σ₁).domDomCongr σ₂ :=
-  rfl
-
-/-- `MultilinearMap.domDomCongr` as an equivalence.
-
-This is declared separately because it does not work with dot notation. -/
-@[simps apply symm_apply]
-def domDomCongrEquiv (σ : ι₁ ≃ ι₂) :
-    MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃ ≃+
-      MultilinearMap (RingHom.id R) (fun _ : ι₂ => M₂) M₃ where
-  toFun := domDomCongr σ
-  invFun := domDomCongr σ.symm
-  left_inv m := by
-    ext
-    simp [domDomCongr]
-  right_inv m := by
-    ext
-    simp [domDomCongr]
-  map_add' a b := by
-    ext
-    simp [domDomCongr]
-
-/-- The results of applying `domDomCongr` to two maps are equal if
-and only if those maps are. -/
-@[simp]
-theorem domDomCongr_eq_iff (σ : ι₁ ≃ ι₂)
-    (f g : MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃) :
-    f.domDomCongr σ = g.domDomCongr σ ↔ f = g :=
-  (domDomCongrEquiv σ : _ ≃+ MultilinearMap (RingHom.id R) (fun _ => M₂) M₃).apply_eq_iff_eq
-
-end
 
 /-! If `{a // P a}` is a subtype of `ι` and if we fix an element `z` of `(i : {a // ¬ P a}) → M₁ i`,
 then a multilinear map on `M₁` defines a multilinear map on the restriction of `M₁` to
@@ -838,29 +862,42 @@ end MultilinearMap
 
 namespace LinearMap
 
+section CompMultilinearMap
+
+variable {R₃ : Type*} [Semiring R] [Semiring R₂] [Semiring R₃]
+  {σ₁₂ : R →+* R₂} {σ₂₃ : R₂ →+* R₃} {σ₁₃ : R →+* R₃}
+  [∀ i, AddCommMonoid (M₁ i)] [∀ i, Module R (M₁ i)]
+  [AddCommMonoid M₂] [Module R₂ M₂] [AddCommMonoid M₃] [Module R₃ M₃]
+
+/-- Composing a multilinear map with a semilinear map gives again a multilinear map. -/
+def compMultilinearMap [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
+    (g : M₂ →ₛₗ[σ₂₃] M₃) (f : MultilinearMap σ₁₂ M₁ M₂) :
+    MultilinearMap σ₁₃ M₁ M₃ where
+  toFun := g ∘ f
+  map_update_add' m i x y := by simp
+  map_update_smul' m i c x := by
+    simp [map_smulₛₗ, RingHomCompTriple.comp_apply]
+
+variable [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
+
+@[simp]
+theorem coe_compMultilinearMap (g : M₂ →ₛₗ[σ₂₃] M₃) (f : MultilinearMap σ₁₂ M₁ M₂) :
+    ⇑(g.compMultilinearMap f) = g ∘ f :=
+  rfl
+
+@[simp]
+theorem compMultilinearMap_apply (g : M₂ →ₛₗ[σ₂₃] M₃) (f : MultilinearMap σ₁₂ M₁ M₂)
+    (m : ∀ i, M₁ i) :
+    g.compMultilinearMap f m = g (f m) :=
+  rfl
+
+end CompMultilinearMap
+
 variable [Semiring R]
 variable [∀ i, AddCommMonoid (M₁ i)] [∀ i, AddCommMonoid (M₁' i)]
   [AddCommMonoid M₂] [AddCommMonoid M₃] [AddCommMonoid M₄] [AddCommMonoid M']
 variable [∀ i, Module R (M₁ i)] [∀ i, Module R (M₁' i)]
   [Module R M₂] [Module R M₃] [Module R M₄] [Module R M']
-
-/-- Composing a multilinear map with a linear map gives again a multilinear map. -/
-def compMultilinearMap (g : M₂ →ₗ[R] M₃) (f : MultilinearMap (RingHom.id R) M₁ M₂) :
-    MultilinearMap (RingHom.id R) M₁ M₃ where
-  toFun := g ∘ f
-  map_update_add' m i x y := by simp
-  map_update_smul' m i c x := by simp
-
-@[simp]
-theorem coe_compMultilinearMap (g : M₂ →ₗ[R] M₃) (f : MultilinearMap (RingHom.id R) M₁ M₂) :
-    ⇑(g.compMultilinearMap f) = g ∘ f :=
-  rfl
-
-@[simp]
-theorem compMultilinearMap_apply (g : M₂ →ₗ[R] M₃) (f : MultilinearMap (RingHom.id R) M₁ M₂)
-    (m : ∀ i, M₁ i) :
-    g.compMultilinearMap f m = g (f m) :=
-  rfl
 
 @[simp]
 theorem id_compMultilinearMap (f : MultilinearMap (RingHom.id R) M₁ M₂) :

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -24,11 +24,13 @@ public import Mathlib.Algebra.Order.BigOperators.Group.Finset
 We define multilinear maps as maps from `∀ (i : ι), M₁ i` to `M₂` which are linear in each
 coordinate. Here, `M₁ i` and `M₂` are modules over a ring `R`, and `ι` is an arbitrary type
 (although some statements will require it to be a fintype). This space, denoted by
-`MultilinearMap R M₁ M₂`, inherits a module structure by pointwise addition and multiplication.
+`MultilinearMap (RingHom.id R) M₁ M₂`, inherits a module structure by pointwise addition and
+multiplication.
 
 ## Main definitions
 
-* `MultilinearMap R M₁ M₂` is the space of multilinear maps from `∀ (i : ι), M₁ i` to `M₂`.
+* `MultilinearMap (RingHom.id R) M₁ M₂` is the space of multilinear maps
+  from `∀ (i : ι), M₁ i` to `M₂`.
 * `f.map_update_smul` is the multiplicativity of the multilinear map `f` along each coordinate.
 * `f.map_update_add` is the additivity of the multilinear map `f` along each coordinate.
 * `f.map_smul_univ` expresses the multiplicativity of `f` over all coordinates at the same time,
@@ -73,104 +75,102 @@ which is much easier to clean up since `_inst` is a free variable
 and so the equality can just be substituted.
 -/
 
+set_option linter.style.longFile 1700
+
 @[expose] public section
 
 open Fin Function Finset Set
 
-universe uR uS uι v v' v₁ v₁' v₁'' v₂ v₃ v₄
+universe uR uR₂ uS uι v v' v₁ v₁' v₁'' v₂ v₃ v₄
 
-variable {R : Type uR} {S : Type uS} {ι : Type uι} {n : ℕ}
+variable {R : Type uR} {R₂ : Type uR₂} {S : Type uS} {ι : Type uι} {n : ℕ}
   {M : Fin n.succ → Type v} {M₁ : ι → Type v₁} {M₁' : ι → Type v₁'} {M₁'' : ι → Type v₁''}
 variable {M₂ : Type v₂} {M₃ : Type v₃} {M₄ : Type v₄} {M' : Type v'}
 
 -- Don't generate injectivity lemmas, which the `simpNF` linter will time out on.
 set_option genInjectivity false in
-/-- Multilinear maps over the ring `R`, from `∀ i, M₁ i` to `M₂` where `M₁ i` and `M₂` are modules
-over `R`. -/
-structure MultilinearMap (R : Type uR) {ι : Type uι} (M₁ : ι → Type v₁) (M₂ : Type v₂) [Semiring R]
-  [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M₂] [∀ i, Module R (M₁ i)] [Module R M₂] where
+/-- Semilinear multilinear maps over a ring hom `σ : R →+* R₂`, from `∀ i, M₁ i` (modules over `R`)
+to `M₂` (a module over `R₂`). The map is additive in every coordinate and σ-semilinear in scalar
+multiplication: `toFun (update m i (c • x)) = σ c • toFun (update m i x)`.
+
+When `σ = RingHom.id R` (so `R₂ = R`), this is the usual notion of a multilinear map.
+
+This is the n-ary analog of `LinearMap σ M M₂`, mirroring the 2022 Dupuis `LinearMap` →
+semilinear refactor (mathlib PR #9272). -/
+structure MultilinearMap {R : Type uR} {R₂ : Type uR₂} [Semiring R] [Semiring R₂] (σ : R →+* R₂)
+    {ι : Type uι} (M₁ : ι → Type v₁) (M₂ : Type v₂)
+    [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M₂] [∀ i, Module R (M₁ i)] [Module R₂ M₂] where
   /-- The underlying multivariate function of a multilinear map. -/
   toFun : (∀ i, M₁ i) → M₂
   /-- A multilinear map is additive in every argument. -/
   map_update_add' :
     ∀ [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) (x y : M₁ i),
       toFun (update m i (x + y)) = toFun (update m i x) + toFun (update m i y)
-  /-- A multilinear map is compatible with scalar multiplication in every argument. -/
+  /-- A multilinear map is compatible with scalar multiplication in every argument
+  (σ-semilinearly: `c` from `R` is mapped to `σ c` in `R₂`). -/
   map_update_smul' :
     ∀ [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) (c : R) (x : M₁ i),
-      toFun (update m i (c • x)) = c • toFun (update m i x)
+      toFun (update m i (c • x)) = σ c • toFun (update m i x)
 
 namespace MultilinearMap
 
-section Semiring
+section FunLike
 
-variable [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M₂]
-  [AddCommMonoid M₃] [AddCommMonoid M'] [∀ i, Module R (M i)] [∀ i, Module R (M₁ i)] [Module R M₂]
-  [Module R M₃] [Module R M'] (f f' : MultilinearMap R M₁ M₂)
+variable [Semiring R] [Semiring R₂] {σ : R →+* R₂}
+  [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M₂]
+  [∀ i, Module R (M₁ i)] [Module R₂ M₂]
+  (f f' : MultilinearMap σ M₁ M₂)
 
-instance : FunLike (MultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
+instance instFunLike : FunLike (MultilinearMap σ M₁ M₂) (∀ i, M₁ i) M₂ where
   coe f := f.toFun
   coe_injective f g h := by cases f; cases g; cases h; rfl
 
 initialize_simps_projections MultilinearMap (toFun → apply)
 
-/-- Constructor for `MultilinearMap R M₁ M₂` when the
-index type `ι` is already endowed with a `DecidableEq` instance. -/
-@[simps]
-def mk' [DecidableEq ι] (f : (∀ i, M₁ i) → M₂)
-    (h₁ : ∀ (m : ∀ i, M₁ i) (i : ι) (x y : M₁ i),
-      f (update m i (x + y)) = f (update m i x) + f (update m i y) := by aesop)
-    (h₂ : ∀ (m : ∀ i, M₁ i) (i : ι) (c : R) (x : M₁ i),
-      f (update m i (c • x)) = c • f (update m i x) := by aesop) :
-    MultilinearMap R M₁ M₂ where
-  toFun := f
-  map_update_add' m i x y := by convert! h₁ m i x y
-  map_update_smul' m i c x := by convert! h₂ m i c x
+@[simp]
+theorem toFun_eq_coe : f.toFun = ⇑f := rfl
 
 @[simp]
-theorem toFun_eq_coe : f.toFun = ⇑f :=
-  rfl
+theorem coe_mk (f : (∀ i, M₁ i) → M₂) (h₁ h₂) :
+    ⇑(⟨f, h₁, h₂⟩ : MultilinearMap σ M₁ M₂) = f := rfl
 
-@[simp]
-theorem coe_mk (f : (∀ i, M₁ i) → M₂) (h₁ h₂) : ⇑(⟨f, h₁, h₂⟩ : MultilinearMap R M₁ M₂) = f :=
-  rfl
-
-theorem congr_fun {f g : MultilinearMap R M₁ M₂} (h : f = g) (x : ∀ i, M₁ i) : f x = g x :=
+theorem congr_fun {f g : MultilinearMap σ M₁ M₂} (h : f = g) (x : ∀ i, M₁ i) : f x = g x :=
   DFunLike.congr_fun h x
 
-nonrec theorem congr_arg (f : MultilinearMap R M₁ M₂) {x y : ∀ i, M₁ i} (h : x = y) : f x = f y :=
+nonrec theorem congr_arg (f : MultilinearMap σ M₁ M₂) {x y : ∀ i, M₁ i} (h : x = y) : f x = f y :=
   DFunLike.congr_arg f h
 
-theorem coe_injective : Injective ((↑) : MultilinearMap R M₁ M₂ → (∀ i, M₁ i) → M₂) :=
+theorem coe_injective : Injective ((↑) : MultilinearMap σ M₁ M₂ → (∀ i, M₁ i) → M₂) :=
   DFunLike.coe_injective
 
 @[norm_cast]
-theorem coe_inj {f g : MultilinearMap R M₁ M₂} : (f : (∀ i, M₁ i) → M₂) = g ↔ f = g :=
+theorem coe_inj {f g : MultilinearMap σ M₁ M₂} : (f : (∀ i, M₁ i) → M₂) = g ↔ f = g :=
   DFunLike.coe_fn_eq
 
 @[ext]
-theorem ext {f f' : MultilinearMap R M₁ M₂} (H : ∀ x, f x = f' x) : f = f' :=
+theorem ext {f f' : MultilinearMap σ M₁ M₂} (H : ∀ x, f x = f' x) : f = f' :=
   DFunLike.ext _ _ H
 
 @[simp]
-theorem mk_coe (f : MultilinearMap R M₁ M₂) (h₁ h₂) :
-    (⟨f, h₁, h₂⟩ : MultilinearMap R M₁ M₂) = f := rfl
+theorem mk_coe (f : MultilinearMap σ M₁ M₂) (h₁ h₂) :
+    (⟨f, h₁, h₂⟩ : MultilinearMap σ M₁ M₂) = f := rfl
 
 @[simp]
 protected theorem map_update_add [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) (x y : M₁ i) :
     f (update m i (x + y)) = f (update m i x) + f (update m i y) :=
   f.map_update_add' m i x y
 
-/-- Earlier, this name was used by what is now called `MultilinearMap.map_update_smul_left`. -/
+/-- σ-twisted version of `MultilinearMap.map_update_smul`. For semilinear maps, the scalar
+in the codomain is `σ c` rather than `c`. -/
 @[simp]
-protected theorem map_update_smul [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) (c : R) (x : M₁ i) :
-    f (update m i (c • x)) = c • f (update m i x) :=
+protected theorem map_update_smulₛₗ [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) (c : R) (x : M₁ i) :
+    f (update m i (c • x)) = σ c • f (update m i x) :=
   f.map_update_smul' m i c x
 
 theorem map_coord_zero {m : ∀ i, M₁ i} (i : ι) (h : m i = 0) : f m = 0 := by
   classical
     have : (0 : R) • (0 : M₁ i) = 0 := by simp
-    rw [← update_eq_self i m, h, ← this, f.map_update_smul, zero_smul]
+    rw [← update_eq_self i m, h, ← this, f.map_update_smulₛₗ, map_zero, zero_smul]
 
 @[simp]
 theorem map_update_zero [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) : f (update m i 0) = 0 :=
@@ -181,37 +181,48 @@ theorem map_zero [Nonempty ι] : f 0 = 0 := by
   obtain ⟨i⟩ := ‹Nonempty ι›
   exact map_coord_zero f i rfl
 
-instance : Add (MultilinearMap R M₁ M₂) :=
-  ⟨fun f f' =>
-    ⟨fun x => f x + f' x, fun m i x y => by simp [add_left_comm, add_assoc], fun m i c x => by
-      simp [smul_add]⟩⟩
+end FunLike
 
-instance : IsAddApply (MultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
+section AddCommMonoidSemilinear
+
+variable [Semiring R] [Semiring R₂] {σ : R →+* R₂}
+  [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M₂]
+  [∀ i, Module R (M₁ i)] [Module R₂ M₂]
+  (g g' : MultilinearMap σ M₁ M₂)
+
+instance : Add (MultilinearMap σ M₁ M₂) :=
+  ⟨fun f f' =>
+    ⟨fun x => f x + f' x,
+      fun m i x y => by simp [add_left_comm, add_assoc],
+      fun m i c x => by simp [smul_add]⟩⟩
+
+instance : IsAddApply (MultilinearMap σ M₁ M₂) (∀ i, M₁ i) M₂ where
   add_apply _ _ _ := rfl
 
 @[deprecated (since := "2026-06-10")] protected alias add_apply := add_apply
 
-instance : Zero (MultilinearMap R M₁ M₂) :=
+instance : Zero (MultilinearMap σ M₁ M₂) :=
   ⟨⟨fun _ => 0, fun _ _ _ _ => by simp, fun _ _ c _ => by simp⟩⟩
 
-instance : IsZeroApply (MultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
+instance : IsZeroApply (MultilinearMap σ M₁ M₂) (∀ i, M₁ i) M₂ where
   zero_apply _ := rfl
 
-instance : Inhabited (MultilinearMap R M₁ M₂) :=
+instance : Inhabited (MultilinearMap σ M₁ M₂) :=
   ⟨0⟩
 
 @[deprecated (since := "2026-06-10")] protected alias zero_apply := zero_apply
 
 section SMul
 
-variable [DistribSMul S M₂] [SMulCommClass R S M₂]
+variable [DistribSMul S M₂] [SMulCommClass R₂ S M₂]
 
-instance : SMul S (MultilinearMap R M₁ M₂) :=
+instance : SMul S (MultilinearMap σ M₁ M₂) :=
   ⟨fun c f =>
-    ⟨fun m => c • f m, fun m i x y => by simp [smul_add], fun l i x d => by
-      simp [← smul_comm x c (_ : M₂)]⟩⟩
+    ⟨fun m => c • f m, fun m i x y => by simp [smul_add],
+      fun l i x d => by
+        rw [f.map_update_smulₛₗ, (smul_comm (σ x) c (f (update l i d))).symm]⟩⟩
 
-instance : IsSMulApply S (MultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
+instance : IsSMulApply S (MultilinearMap σ M₁ M₂) (∀ i, M₁ i) M₂ where
   smul_apply _ _ _ := rfl
 
 @[deprecated (since := "2026-06-10")] protected alias smul_apply := smul_apply
@@ -221,9 +232,9 @@ instance : IsSMulApply S (MultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
 end SMul
 
 -- The `AddMonoid` instance exists to help speedup unification
-instance : AddMonoid (MultilinearMap R M₁ M₂) := fast_instance% FunLike.addMonoid
+instance : AddMonoid (MultilinearMap σ M₁ M₂) := fast_instance% FunLike.addMonoid
 
-instance addCommMonoid : AddCommMonoid (MultilinearMap R M₁ M₂) := fast_instance%
+instance addCommMonoid : AddCommMonoid (MultilinearMap σ M₁ M₂) := fast_instance%
   FunLike.addCommMonoid
 
 @[deprecated (since := "2026-06-10")] alias coeAddMonoidHom := FunLike.coeAddMonoidHom
@@ -233,6 +244,33 @@ instance addCommMonoid : AddCommMonoid (MultilinearMap R M₁ M₂) := fast_inst
 @[deprecated (since := "2026-06-10")] alias coe_sum := FunLike.coe_sum
 
 @[deprecated (since := "2026-06-10")] protected alias sum_apply := _root_.sum_apply
+
+end AddCommMonoidSemilinear
+
+section Semiring
+
+variable [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M₂]
+  [AddCommMonoid M₃] [AddCommMonoid M'] [∀ i, Module R (M i)] [∀ i, Module R (M₁ i)] [Module R M₂]
+  [Module R M₃] [Module R M'] (f f' : MultilinearMap (RingHom.id R) M₁ M₂)
+
+/-- Constructor for `MultilinearMap (RingHom.id R) M₁ M₂` when the
+index type `ι` is already endowed with a `DecidableEq` instance. -/
+@[simps]
+def mk' [DecidableEq ι] (f : (∀ i, M₁ i) → M₂)
+    (h₁ : ∀ (m : ∀ i, M₁ i) (i : ι) (x y : M₁ i),
+      f (update m i (x + y)) = f (update m i x) + f (update m i y) := by aesop)
+    (h₂ : ∀ (m : ∀ i, M₁ i) (i : ι) (c : R) (x : M₁ i),
+      f (update m i (c • x)) = c • f (update m i x) := by aesop) :
+    MultilinearMap (RingHom.id R) M₁ M₂ where
+  toFun := f
+  map_update_add' m i x y := by convert! h₁ m i x y
+  map_update_smul' m i c x := by convert! h₂ m i c x
+
+/-- Earlier, this name was used by what is now called `MultilinearMap.map_update_smul_left`. -/
+@[simp]
+protected theorem map_update_smul [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) (c : R) (x : M₁ i) :
+    f (update m i (c • x)) = c • f (update m i x) := by
+  simp
 
 /-- If `f` is a multilinear map, then `f.toLinearMap m i` is the linear map obtained by fixing all
 coordinates but `i` equal to those of `m`, and varying the `i`-th coordinate. -/
@@ -244,8 +282,8 @@ def toLinearMap [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) : M₁ i →ₗ[R]
 
 /-- The Cartesian product of two multilinear maps, as a multilinear map. -/
 @[simps]
-def prod (f : MultilinearMap R M₁ M₂) (g : MultilinearMap R M₁ M₃) :
-    MultilinearMap R M₁ (M₂ × M₃) where
+def prod (f : MultilinearMap (RingHom.id R) M₁ M₂) (g : MultilinearMap (RingHom.id R) M₁ M₃) :
+    MultilinearMap (RingHom.id R) M₁ (M₂ × M₃) where
   toFun m := (f m, g m)
   map_update_add' m i x y := by simp
   map_update_smul' m i c x := by simp
@@ -254,7 +292,8 @@ def prod (f : MultilinearMap R M₁ M₂) (g : MultilinearMap R M₁ M₃) :
 multilinear map taking values in the space of functions `∀ i, M' i`. -/
 @[simps]
 def pi {ι' : Type*} {M' : ι' → Type*} [∀ i, AddCommMonoid (M' i)] [∀ i, Module R (M' i)]
-    (f : ∀ i, MultilinearMap R M₁ (M' i)) : MultilinearMap R M₁ (∀ i, M' i) where
+    (f : ∀ i, MultilinearMap (RingHom.id R) M₁ (M' i)) :
+    MultilinearMap (RingHom.id R) M₁ (∀ i, M' i) where
   toFun m i := f i m
   map_update_add' _ _ _ _ := funext fun j => (f j).map_update_add _ _ _ _
   map_update_smul' _ _ _ _ := funext fun j => (f j).map_update_smul _ _ _ _
@@ -266,7 +305,7 @@ variable (R M₂ M₃)
 /-- Equivalence between linear maps `M₂ →ₗ[R] M₃` and one-multilinear maps. -/
 @[simps]
 def ofSubsingleton [Subsingleton ι] (i : ι) :
-    (M₂ →ₗ[R] M₃) ≃ MultilinearMap R (fun _ : ι ↦ M₂) M₃ where
+    (M₂ →ₗ[R] M₃) ≃ MultilinearMap (RingHom.id R) (fun _ : ι ↦ M₂) M₃ where
   toFun f :=
     { toFun := fun x ↦ f (x i)
       map_update_add' := by intros; simp [update_eq_const_of_subsingleton]
@@ -283,7 +322,7 @@ variable (M₁) {M₂}
 
 /-- The constant map is multilinear when `ι` is empty. -/
 @[simps -fullyApplied]
-def constOfIsEmpty [IsEmpty ι] (m : M₂) : MultilinearMap R M₁ M₂ where
+def constOfIsEmpty [IsEmpty ι] (m : M₂) : MultilinearMap (RingHom.id R) M₁ M₂ where
   toFun := Function.const _ m
   map_update_add' _ := isEmptyElim
   map_update_smul' _ := isEmptyElim
@@ -295,8 +334,9 @@ of these variables, one gets a new multilinear map on `Fin k` by varying these v
 the other ones equal to a given value `z`. It is denoted by `f.restr s hk z`, where `hk` is a
 proof that the cardinality of `s` is `k`. The implicit identification between `Fin k` and `s` that
 we use is the canonical (increasing) bijection. -/
-def restr {k n : ℕ} (f : MultilinearMap R (fun _ : Fin n => M') M₂) (s : Finset (Fin n))
-    (hk : #s = k) (z : M') : MultilinearMap R (fun _ : Fin k => M') M₂ where
+def restr {k n : ℕ} (f : MultilinearMap (RingHom.id R) (fun _ : Fin n => M') M₂)
+    (s : Finset (Fin n))
+    (hk : #s = k) (z : M') : MultilinearMap (RingHom.id R) (fun _ : Fin k => M') M₂ where
   toFun v := f fun j => if h : j ∈ s then v ((s.orderIsoOfFin hk).symm ⟨j, h⟩) else z
   map_update_add' := by
     simp [dite_comp_equiv_update (s.orderIsoOfFin hk).symm]
@@ -306,21 +346,22 @@ def restr {k n : ℕ} (f : MultilinearMap R (fun _ : Fin n => M') M₂) (s : Fin
 /-- In the specific case of multilinear maps on spaces indexed by `Fin (n+1)`, where one can build
 an element of `∀ (i : Fin (n+1)), M i` using `cons`, one can express directly the additivity of a
 multilinear map along the first variable. -/
-theorem cons_add (f : MultilinearMap R M M₂) (m : ∀ i : Fin n, M i.succ) (x y : M 0) :
+theorem cons_add (f : MultilinearMap (RingHom.id R) M M₂) (m : ∀ i : Fin n, M i.succ) (x y : M 0) :
     f (cons (x + y) m) = f (cons x m) + f (cons y m) := by
   simp_rw [← update_cons_zero x m (x + y), f.map_update_add, update_cons_zero]
 
 /-- In the specific case of multilinear maps on spaces indexed by `Fin (n+1)`, where one can build
 an element of `∀ (i : Fin (n+1)), M i` using `cons`, one can express directly the multiplicativity
 of a multilinear map along the first variable. -/
-theorem cons_smul (f : MultilinearMap R M M₂) (m : ∀ i : Fin n, M i.succ) (c : R) (x : M 0) :
+theorem cons_smul (f : MultilinearMap (RingHom.id R) M M₂) (m : ∀ i : Fin n, M i.succ) (c : R)
+    (x : M 0) :
     f (cons (c • x) m) = c • f (cons x m) := by
   simp_rw [← update_cons_zero x m (c • x), f.map_update_smul, update_cons_zero]
 
 /-- In the specific case of multilinear maps on spaces indexed by `Fin (n+1)`, where one can build
 an element of `∀ (i : Fin (n+1)), M i` using `snoc`, one can express directly the additivity of a
 multilinear map along the first variable. -/
-theorem snoc_add (f : MultilinearMap R M M₂)
+theorem snoc_add (f : MultilinearMap (RingHom.id R) M M₂)
     (m : ∀ i : Fin n, M (castSucc i)) (x y : M (last n)) :
     f (snoc m (x + y)) = f (snoc m x) + f (snoc m y) := by
   simp_rw [← update_snoc_last x m (x + y), f.map_update_add, update_snoc_last]
@@ -328,15 +369,16 @@ theorem snoc_add (f : MultilinearMap R M M₂)
 /-- In the specific case of multilinear maps on spaces indexed by `Fin (n+1)`, where one can build
 an element of `∀ (i : Fin (n+1)), M i` using `cons`, one can express directly the multiplicativity
 of a multilinear map along the first variable. -/
-theorem snoc_smul (f : MultilinearMap R M M₂) (m : ∀ i : Fin n, M (castSucc i)) (c : R)
+theorem snoc_smul (f : MultilinearMap (RingHom.id R) M M₂) (m : ∀ i : Fin n, M (castSucc i)) (c : R)
     (x : M (last n)) : f (snoc m (c • x)) = c • f (snoc m x) := by
   simp_rw [← update_snoc_last x m (c • x), f.map_update_smul, update_snoc_last]
 
-theorem map_insertNth_add (f : MultilinearMap R M M₂) (p : Fin (n + 1)) (m : ∀ i, M (p.succAbove i))
-    (x y : M p) : f (p.insertNth (x + y) m) = f (p.insertNth x m) + f (p.insertNth y m) := by
+theorem map_insertNth_add (f : MultilinearMap (RingHom.id R) M M₂) (p : Fin (n + 1))
+    (m : ∀ i, M (p.succAbove i)) (x y : M p) :
+    f (p.insertNth (x + y) m) = f (p.insertNth x m) + f (p.insertNth y m) := by
   simpa using f.map_update_add (p.insertNth 0 m) p x y
 
-theorem map_insertNth_smul (f : MultilinearMap R M M₂) (p : Fin (n + 1))
+theorem map_insertNth_smul (f : MultilinearMap (RingHom.id R) M M₂) (p : Fin (n + 1))
     (m : ∀ i, M (p.succAbove i)) (c : R) (x : M p) :
     f (p.insertNth (c • x) m) = c • f (p.insertNth x m) := by
   simpa using f.map_update_smul (p.insertNth 0 m) p c x
@@ -349,8 +391,8 @@ variable [∀ i, AddCommMonoid (M₁'' i)] [∀ i, Module R (M₁'' i)]
 /-- If `g` is a multilinear map and `f` is a collection of linear maps,
 then `g (f₁ m₁, ..., fₙ mₙ)` is again a multilinear map, that we call
 `g.compLinearMap f`. -/
-def compLinearMap (g : MultilinearMap R M₁' M₂) (f : ∀ i, M₁ i →ₗ[R] M₁' i) :
-    MultilinearMap R M₁ M₂ where
+def compLinearMap (g : MultilinearMap (RingHom.id R) M₁' M₂) (f : ∀ i, M₁ i →ₗ[R] M₁' i) :
+    MultilinearMap (RingHom.id R) M₁ M₂ where
   toFun m := g fun i => f i (m i)
   map_update_add' m i x y := by
     have : ∀ j z, f j (update m i z j) = update (fun k => f k (m k)) i (f i z) j := fun j z =>
@@ -362,44 +404,46 @@ def compLinearMap (g : MultilinearMap R M₁' M₂) (f : ∀ i, M₁ i →ₗ[R]
     simp [this]
 
 @[simp]
-theorem compLinearMap_apply (g : MultilinearMap R M₁' M₂) (f : ∀ i, M₁ i →ₗ[R] M₁' i)
+theorem compLinearMap_apply (g : MultilinearMap (RingHom.id R) M₁' M₂) (f : ∀ i, M₁ i →ₗ[R] M₁' i)
     (m : ∀ i, M₁ i) : g.compLinearMap f m = g fun i => f i (m i) :=
   rfl
 
 /-- Composing a multilinear map twice with a linear map in each argument is
 the same as composing with their composition. -/
-theorem compLinearMap_assoc (g : MultilinearMap R M₁'' M₂) (f₁ : ∀ i, M₁' i →ₗ[R] M₁'' i)
-    (f₂ : ∀ i, M₁ i →ₗ[R] M₁' i) :
+theorem compLinearMap_assoc (g : MultilinearMap (RingHom.id R) M₁'' M₂)
+    (f₁ : ∀ i, M₁' i →ₗ[R] M₁'' i) (f₂ : ∀ i, M₁ i →ₗ[R] M₁' i) :
     (g.compLinearMap f₁).compLinearMap f₂ = g.compLinearMap fun i => f₁ i ∘ₗ f₂ i :=
   rfl
 
 /-- Composing the zero multilinear map with a linear map in each argument. -/
 @[simp]
 theorem zero_compLinearMap (f : ∀ i, M₁ i →ₗ[R] M₁' i) :
-    (0 : MultilinearMap R M₁' M₂).compLinearMap f = 0 :=
+    (0 : MultilinearMap (RingHom.id R) M₁' M₂).compLinearMap f = 0 :=
   ext fun _ => rfl
 
 /-- Composing a multilinear map with the identity linear map in each argument. -/
 @[simp]
-theorem compLinearMap_id (g : MultilinearMap R M₁' M₂) :
+theorem compLinearMap_id (g : MultilinearMap (RingHom.id R) M₁' M₂) :
     (g.compLinearMap fun _ => LinearMap.id) = g :=
   ext fun _ => rfl
 
 /-- Composing with a family of surjective linear maps is injective. -/
 theorem compLinearMap_injective (f : ∀ i, M₁ i →ₗ[R] M₁' i) (hf : ∀ i, Surjective (f i)) :
-    Injective fun g : MultilinearMap R M₁' M₂ => g.compLinearMap f := fun g₁ g₂ h =>
+    Injective fun g : MultilinearMap (RingHom.id R) M₁' M₂ => g.compLinearMap f := fun g₁ g₂ h =>
   ext fun x => by
     simpa [fun i => surjInv_eq (hf i)]
       using MultilinearMap.ext_iff.mp h fun i => surjInv (hf i) (x i)
 
 theorem compLinearMap_inj (f : ∀ i, M₁ i →ₗ[R] M₁' i) (hf : ∀ i, Surjective (f i))
-    (g₁ g₂ : MultilinearMap R M₁' M₂) : g₁.compLinearMap f = g₂.compLinearMap f ↔ g₁ = g₂ :=
+    (g₁ g₂ : MultilinearMap (RingHom.id R) M₁' M₂) :
+    g₁.compLinearMap f = g₂.compLinearMap f ↔ g₁ = g₂ :=
   (compLinearMap_injective _ hf).eq_iff
 
 /-- Composing a multilinear map with a linear equiv on each argument gives the zero map
 if and only if the multilinear map is the zero map. -/
 @[simp]
-theorem comp_linearEquiv_eq_zero_iff (g : MultilinearMap R M₁' M₂) (f : ∀ i, M₁ i ≃ₗ[R] M₁' i) :
+theorem comp_linearEquiv_eq_zero_iff (g : MultilinearMap (RingHom.id R) M₁' M₂)
+    (f : ∀ i, M₁ i ≃ₗ[R] M₁' i) :
     (g.compLinearMap fun i => (f i : M₁ i →ₗ[R] M₁' i)) = 0 ↔ g = 0 := by
   set f' := fun i => (f i : M₁ i →ₗ[R] M₁' i)
   rw [← zero_compLinearMap f', compLinearMap_inj f' fun i => (f i).surjective]
@@ -415,8 +459,9 @@ variable [∀ i, ∀ b, AddCommMonoid (N i b)] [∀ i, ∀ b, Module R (N i b)]
 multilinear map `f i` with index type `β i`, then `m ↦ g (f₁ m_11 m_12 ...) (f₂ m_21 m_22 ...) ...`
 is multilinear with index type `(Σ i, β i)`. -/
 @[simps]
-def compMultilinearMap (g : MultilinearMap R M₁ M₂) (f : (i : ι) → MultilinearMap R (N i) (M₁ i)) :
-    MultilinearMap R (fun j : Σ i, β i ↦ N j.fst j.snd) M₂ where
+def compMultilinearMap (g : MultilinearMap (RingHom.id R) M₁ M₂)
+    (f : (i : ι) → MultilinearMap (RingHom.id R) (N i) (M₁ i)) :
+    MultilinearMap (RingHom.id R) (fun j : Σ i, β i ↦ N j.fst j.snd) M₂ where
   toFun m := g fun i ↦ f i (Sigma.curry m i)
   map_update_add' {hDecEqSigma} := by
     classical
@@ -640,8 +685,8 @@ end ApplySum
 
 This is the multilinear version of `LinearMap.codRestrict`. -/
 @[simps]
-def codRestrict (f : MultilinearMap R M₁ M₂) (p : Submodule R M₂) (h : ∀ v, f v ∈ p) :
-    MultilinearMap R M₁ p where
+def codRestrict (f : MultilinearMap (RingHom.id R) M₁ M₂) (p : Submodule R M₂) (h : ∀ v, f v ∈ p) :
+    MultilinearMap (RingHom.id R) M₁ p where
   toFun v := ⟨f v, h v⟩
   map_update_add' _ _ _ _ := Subtype.ext <| MultilinearMap.map_update_add _ _ _ _ _
   map_update_smul' _ _ _ _ := Subtype.ext <| MultilinearMap.map_update_smul _ _ _ _ _
@@ -654,13 +699,15 @@ variable {A : Type*} [Semiring A] [SMul R A] [∀ i : ι, Module A (M₁ i)] [Mo
 
 /-- Reinterpret an `A`-multilinear map as an `R`-multilinear map, if `A` is an algebra over `R`
 and their actions on all involved modules agree with the action of `R` on `A`. -/
-def restrictScalars (f : MultilinearMap A M₁ M₂) : MultilinearMap R M₁ M₂ where
+def restrictScalars (f : MultilinearMap (RingHom.id A) M₁ M₂) :
+    MultilinearMap (RingHom.id R) M₁ M₂ where
   toFun := f
   map_update_add' := f.map_update_add
   map_update_smul' m i := (f.toLinearMap m i).map_smul_of_tower
 
 @[simp]
-theorem coe_restrictScalars (f : MultilinearMap A M₁ M₂) : ⇑(f.restrictScalars R) = f :=
+theorem coe_restrictScalars (f : MultilinearMap (RingHom.id A) M₁ M₂) :
+    ⇑(f.restrictScalars R) = f :=
   rfl
 
 end RestrictScalar
@@ -674,8 +721,8 @@ variable {ι₁ ι₂ ι₃ : Type*}
 The naming is derived from `Finsupp.domCongr`, noting that here the permutation applies to the
 domain of the domain. -/
 @[simps apply]
-def domDomCongr (σ : ι₁ ≃ ι₂) (m : MultilinearMap R (fun _ : ι₁ => M₂) M₃) :
-    MultilinearMap R (fun _ : ι₂ => M₂) M₃ where
+def domDomCongr (σ : ι₁ ≃ ι₂) (m : MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃) :
+    MultilinearMap (RingHom.id R) (fun _ : ι₂ => M₂) M₃ where
   toFun v := m fun i => v (σ i)
   map_update_add' v i a b := by
     let := σ.injective.decidableEq
@@ -684,15 +731,15 @@ def domDomCongr (σ : ι₁ ≃ ι₂) (m : MultilinearMap R (fun _ : ι₁ => M
   map_update_smul' v i a b := by
     let := σ.injective.decidableEq
     simp_rw [Function.update_apply_equiv_apply v]
-    rw [m.map_update_smul]
+    simp [m.map_update_smul]
 
 theorem domDomCongr_trans (σ₁ : ι₁ ≃ ι₂) (σ₂ : ι₂ ≃ ι₃)
-    (m : MultilinearMap R (fun _ : ι₁ => M₂) M₃) :
+    (m : MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃) :
     m.domDomCongr (σ₁.trans σ₂) = (m.domDomCongr σ₁).domDomCongr σ₂ :=
   rfl
 
 theorem domDomCongr_mul (σ₁ : Equiv.Perm ι₁) (σ₂ : Equiv.Perm ι₁)
-    (m : MultilinearMap R (fun _ : ι₁ => M₂) M₃) :
+    (m : MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃) :
     m.domDomCongr (σ₂ * σ₁) = (m.domDomCongr σ₁).domDomCongr σ₂ :=
   rfl
 
@@ -701,7 +748,8 @@ theorem domDomCongr_mul (σ₁ : Equiv.Perm ι₁) (σ₂ : Equiv.Perm ι₁)
 This is declared separately because it does not work with dot notation. -/
 @[simps apply symm_apply]
 def domDomCongrEquiv (σ : ι₁ ≃ ι₂) :
-    MultilinearMap R (fun _ : ι₁ => M₂) M₃ ≃+ MultilinearMap R (fun _ : ι₂ => M₂) M₃ where
+    MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃ ≃+
+      MultilinearMap (RingHom.id R) (fun _ : ι₂ => M₂) M₃ where
   toFun := domDomCongr σ
   invFun := domDomCongr σ.symm
   left_inv m := by
@@ -717,9 +765,10 @@ def domDomCongrEquiv (σ : ι₁ ≃ ι₂) :
 /-- The results of applying `domDomCongr` to two maps are equal if
 and only if those maps are. -/
 @[simp]
-theorem domDomCongr_eq_iff (σ : ι₁ ≃ ι₂) (f g : MultilinearMap R (fun _ : ι₁ => M₂) M₃) :
+theorem domDomCongr_eq_iff (σ : ι₁ ≃ ι₂)
+    (f g : MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃) :
     f.domDomCongr σ = g.domDomCongr σ ↔ f = g :=
-  (domDomCongrEquiv σ : _ ≃+ MultilinearMap R (fun _ => M₂) M₃).apply_eq_iff_eq
+  (domDomCongrEquiv σ : _ ≃+ MultilinearMap (RingHom.id R) (fun _ => M₂) M₃).apply_eq_iff_eq
 
 end
 
@@ -750,9 +799,9 @@ domain of the domain.
 
 For a linear map version, see `MultilinearMap.domDomRestrictₗ`.
 -/
-def domDomRestrict (f : MultilinearMap R M₁ M₂) (P : ι → Prop) [DecidablePred P]
+def domDomRestrict (f : MultilinearMap (RingHom.id R) M₁ M₂) (P : ι → Prop) [DecidablePred P]
     (z : (i : {a : ι // ¬ P a}) → M₁ i) :
-    MultilinearMap R (fun (i : {a : ι // P a}) => M₁ i) M₂ where
+    MultilinearMap (RingHom.id R) (fun (i : {a : ι // P a}) => M₁ i) M₂ where
   toFun x := f (fun j ↦ if h : P j then x ⟨j, h⟩ else z ⟨j, h⟩)
   map_update_add' x i a b := by
     classical
@@ -761,22 +810,22 @@ def domDomRestrict (f : MultilinearMap R M₁ M₂) (P : ι → Prop) [Decidable
   map_update_smul' z i c a := by
     classical
     repeat (rw [domDomRestrict_aux])
-    simp only [MultilinearMap.map_update_smul]
+    simp only [MultilinearMap.map_update_smul, RingHom.id_apply]
 
 @[simp]
-lemma domDomRestrict_apply (f : MultilinearMap R M₁ M₂) (P : ι → Prop)
+lemma domDomRestrict_apply (f : MultilinearMap (RingHom.id R) M₁ M₂) (P : ι → Prop)
     [DecidablePred P] (x : (i : {a // P a}) → M₁ i) (z : (i : {a // ¬ P a}) → M₁ i) :
     f.domDomRestrict P z x = f (fun j => if h : P j then x ⟨j, h⟩ else z ⟨j, h⟩) := rfl
 
 -- TODO: Should add a ref here when available.
 /-- The "derivative" of a multilinear map, as a linear map from `(i : ι) → M₁ i` to `M₂`.
 For continuous multilinear maps, this will indeed be the derivative. -/
-def linearDeriv [DecidableEq ι] [Fintype ι] (f : MultilinearMap R M₁ M₂)
+def linearDeriv [DecidableEq ι] [Fintype ι] (f : MultilinearMap (RingHom.id R) M₁ M₂)
     (x : (i : ι) → M₁ i) : ((i : ι) → M₁ i) →ₗ[R] M₂ :=
   ∑ i : ι, (f.toLinearMap x i).comp (LinearMap.proj i)
 
 @[simp]
-lemma linearDeriv_apply [DecidableEq ι] [Fintype ι] (f : MultilinearMap R M₁ M₂)
+lemma linearDeriv_apply [DecidableEq ι] [Fintype ι] (f : MultilinearMap (RingHom.id R) M₁ M₂)
     (x y : (i : ι) → M₁ i) :
     f.linearDeriv x y = ∑ i, f (update x i (y i)) := by
   unfold linearDeriv
@@ -796,72 +845,76 @@ variable [∀ i, Module R (M₁ i)] [∀ i, Module R (M₁' i)]
   [Module R M₂] [Module R M₃] [Module R M₄] [Module R M']
 
 /-- Composing a multilinear map with a linear map gives again a multilinear map. -/
-def compMultilinearMap (g : M₂ →ₗ[R] M₃) (f : MultilinearMap R M₁ M₂) : MultilinearMap R M₁ M₃ where
+def compMultilinearMap (g : M₂ →ₗ[R] M₃) (f : MultilinearMap (RingHom.id R) M₁ M₂) :
+    MultilinearMap (RingHom.id R) M₁ M₃ where
   toFun := g ∘ f
   map_update_add' m i x y := by simp
   map_update_smul' m i c x := by simp
 
 @[simp]
-theorem coe_compMultilinearMap (g : M₂ →ₗ[R] M₃) (f : MultilinearMap R M₁ M₂) :
+theorem coe_compMultilinearMap (g : M₂ →ₗ[R] M₃) (f : MultilinearMap (RingHom.id R) M₁ M₂) :
     ⇑(g.compMultilinearMap f) = g ∘ f :=
   rfl
 
 @[simp]
-theorem compMultilinearMap_apply (g : M₂ →ₗ[R] M₃) (f : MultilinearMap R M₁ M₂) (m : ∀ i, M₁ i) :
+theorem compMultilinearMap_apply (g : M₂ →ₗ[R] M₃) (f : MultilinearMap (RingHom.id R) M₁ M₂)
+    (m : ∀ i, M₁ i) :
     g.compMultilinearMap f m = g (f m) :=
   rfl
 
 @[simp]
-theorem id_compMultilinearMap (f : MultilinearMap R M₁ M₂) :
+theorem id_compMultilinearMap (f : MultilinearMap (RingHom.id R) M₁ M₂) :
     (id : M₂ →ₗ[R] M₂).compMultilinearMap f = f := rfl
 
-theorem comp_compMultilinearMap (g : M₃ →ₗ[R] M₄) (g' : M₂ →ₗ[R] M₃) (f : MultilinearMap R M₁ M₂) :
+theorem comp_compMultilinearMap (g : M₃ →ₗ[R] M₄) (g' : M₂ →ₗ[R] M₃)
+    (f : MultilinearMap (RingHom.id R) M₁ M₂) :
     (g.comp g').compMultilinearMap f = g.compMultilinearMap (g'.compMultilinearMap f) := rfl
 
 /-- The two types of composition are associative. -/
 theorem compMultilinearMap_compLinearMap
-    (g : M₂ →ₗ[R] M₃) (f : MultilinearMap R M₁ M₂) (f' : ∀ i, M₁' i →ₗ[R] M₁ i) :
+    (g : M₂ →ₗ[R] M₃) (f : MultilinearMap (RingHom.id R) M₁ M₂) (f' : ∀ i, M₁' i →ₗ[R] M₁ i) :
     g.compMultilinearMap (f.compLinearMap f') = (g.compMultilinearMap f).compLinearMap f' := rfl
 
 @[simp]
 theorem compMultilinearMap_zero (g : M₂ →ₗ[R] M₃) :
-    g.compMultilinearMap (0 : MultilinearMap R M₁ M₂) = 0 :=
+    g.compMultilinearMap (0 : MultilinearMap (RingHom.id R) M₁ M₂) = 0 :=
   MultilinearMap.ext fun _ => map_zero g
 
 @[simp]
-theorem zero_compMultilinearMap (f : MultilinearMap R M₁ M₂) :
+theorem zero_compMultilinearMap (f : MultilinearMap (RingHom.id R) M₁ M₂) :
     (0 : M₂ →ₗ[R] M₃).compMultilinearMap f = 0 := rfl
 
 @[simp]
-theorem compMultilinearMap_add (g : M₂ →ₗ[R] M₃) (f₁ f₂ : MultilinearMap R M₁ M₂) :
+theorem compMultilinearMap_add (g : M₂ →ₗ[R] M₃) (f₁ f₂ : MultilinearMap (RingHom.id R) M₁ M₂) :
     g.compMultilinearMap (f₁ + f₂) = g.compMultilinearMap f₁ + g.compMultilinearMap f₂ :=
   MultilinearMap.ext fun _ => map_add g _ _
 
 @[simp]
-theorem add_compMultilinearMap (g₁ g₂ : M₂ →ₗ[R] M₃) (f : MultilinearMap R M₁ M₂) :
+theorem add_compMultilinearMap (g₁ g₂ : M₂ →ₗ[R] M₃) (f : MultilinearMap (RingHom.id R) M₁ M₂) :
     (g₁ + g₂).compMultilinearMap f = g₁.compMultilinearMap f + g₂.compMultilinearMap f := rfl
 
 @[simp]
 theorem compMultilinearMap_smul [DistribSMul S M₂] [DistribSMul S M₃]
     [SMulCommClass R S M₂] [SMulCommClass R S M₃] [CompatibleSMul M₂ M₃ S R]
-    (g : M₂ →ₗ[R] M₃) (s : S) (f : MultilinearMap R M₁ M₂) :
+    (g : M₂ →ₗ[R] M₃) (s : S) (f : MultilinearMap (RingHom.id R) M₁ M₂) :
     g.compMultilinearMap (s • f) = s • g.compMultilinearMap f :=
   MultilinearMap.ext fun _ => g.map_smul_of_tower _ _
 
 @[simp]
 theorem smul_compMultilinearMap [Monoid S] [DistribMulAction S M₃] [SMulCommClass R S M₃]
-    (g : M₂ →ₗ[R] M₃) (s : S) (f : MultilinearMap R M₁ M₂) :
+    (g : M₂ →ₗ[R] M₃) (s : S) (f : MultilinearMap (RingHom.id R) M₁ M₂) :
     (s • g).compMultilinearMap f = s • g.compMultilinearMap f := rfl
 
 /-- The multilinear version of `LinearMap.subtype_comp_codRestrict` -/
 @[simp]
-theorem subtype_compMultilinearMap_codRestrict (f : MultilinearMap R M₁ M₂) (p : Submodule R M₂)
-    (h) : p.subtype.compMultilinearMap (f.codRestrict p h) = f :=
+theorem subtype_compMultilinearMap_codRestrict (f : MultilinearMap (RingHom.id R) M₁ M₂)
+    (p : Submodule R M₂) (h) :
+    p.subtype.compMultilinearMap (f.codRestrict p h) = f :=
   rfl
 
 /-- The multilinear version of `LinearMap.comp_codRestrict` -/
 @[simp]
-theorem compMultilinearMap_codRestrict (g : M₂ →ₗ[R] M₃) (f : MultilinearMap R M₁ M₂)
+theorem compMultilinearMap_codRestrict (g : M₂ →ₗ[R] M₃) (f : MultilinearMap (RingHom.id R) M₁ M₂)
     (p : Submodule R M₃) (h) :
     (g.codRestrict p h).compMultilinearMap f =
       (g.compMultilinearMap f).codRestrict p fun v => h (f v) :=
@@ -871,7 +924,7 @@ variable {ι₁ ι₂ : Type*}
 
 @[simp]
 theorem compMultilinearMap_domDomCongr (σ : ι₁ ≃ ι₂) (g : M₂ →ₗ[R] M₃)
-    (f : MultilinearMap R (fun _ : ι₁ => M') M₂) :
+    (f : MultilinearMap (RingHom.id R) (fun _ : ι₁ => M') M₂) :
     (g.compMultilinearMap f).domDomCongr σ = g.compMultilinearMap (f.domDomCongr σ) := by
   ext
   simp [MultilinearMap.domDomCongr]
@@ -885,8 +938,9 @@ section Semiring
 variable [Semiring R] [(i : ι) → AddCommMonoid (M₁ i)] [(i : ι) → Module R (M₁ i)]
   [AddCommMonoid M₂] [Module R M₂]
 
-instance [Monoid S] [DistribMulAction S M₂] [SMulCommClass R S M₂] :
-    DistribMulAction S (MultilinearMap R M₁ M₂) := fast_instance% FunLike.distribMulAction
+instance [Semiring R₂] {σ : R →+* R₂} [Module R₂ M₂]
+    [Monoid S] [DistribMulAction S M₂] [SMulCommClass R₂ S M₂] :
+    DistribMulAction S (MultilinearMap σ M₁ M₂) := fast_instance% FunLike.distribMulAction
 
 section Module
 
@@ -894,10 +948,11 @@ variable [Semiring S] [Module S M₂] [SMulCommClass R S M₂]
 
 /-- The space of multilinear maps over an algebra over `R` is a module over `R`, for the pointwise
 addition and scalar multiplication. -/
-instance : Module S (MultilinearMap R M₁ M₂) := fast_instance%
-  FunLike.module
+instance instModule [Semiring R₂] {σ : R →+* R₂} [Module R₂ M₂] [SMulCommClass R₂ S M₂] :
+    Module S (MultilinearMap σ M₁ M₂) := fast_instance% FunLike.module
 
-instance [Module.IsTorsionFree S M₂] : Module.IsTorsionFree S (MultilinearMap R M₁ M₂) :=
+instance [Semiring R₂] {σ : R →+* R₂} [Module R₂ M₂] [SMulCommClass R₂ S M₂]
+    [Module.IsTorsionFree S M₂] : Module.IsTorsionFree S (MultilinearMap σ M₁ M₂) :=
   coe_injective.moduleIsTorsionFree _ FunLike.coe_smul
 
 variable [AddCommMonoid M₃] [Module S M₃] [Module R M₃] [SMulCommClass R S M₃]
@@ -906,7 +961,7 @@ variable (S) in
 /-- `LinearMap.compMultilinearMap` as an `S`-linear map. -/
 @[simps]
 def _root_.LinearMap.compMultilinearMapₗ [LinearMap.CompatibleSMul M₂ M₃ S R] (g : M₂ →ₗ[R] M₃) :
-    MultilinearMap R M₁ M₂ →ₗ[S] MultilinearMap R M₁ M₃ where
+    MultilinearMap (RingHom.id R) M₁ M₂ →ₗ[S] MultilinearMap (RingHom.id R) M₁ M₃ where
   toFun := g.compMultilinearMap
   map_add' := g.compMultilinearMap_add
   map_smul' := g.compMultilinearMap_smul
@@ -919,7 +974,7 @@ and the multilinear version of `LinearEquiv.congrRight`. -/
 @[simps! apply symm_apply]
 def _root_.LinearEquiv.multilinearMapCongrRight
     [LinearMap.CompatibleSMul M₂ M₃ S R] [LinearMap.CompatibleSMul M₃ M₂ S R] (g : M₂ ≃ₗ[R] M₃) :
-    MultilinearMap R M₁ M₂ ≃ₗ[S] MultilinearMap R M₁ M₃ where
+    MultilinearMap (RingHom.id R) M₁ M₂ ≃ₗ[S] MultilinearMap (RingHom.id R) M₁ M₃ where
   __ := g.toLinearMap.compMultilinearMapₗ S
   invFun := g.symm.toLinearMap.compMultilinearMapₗ S
   left_inv _ := by ext; simp
@@ -930,10 +985,10 @@ variable (R S M₁ M₂ M₃)
 section OfSubsingleton
 
 /-- Linear equivalence between linear maps `M₂ →ₗ[R] M₃`
-and one-multilinear maps `MultilinearMap R (fun _ : ι ↦ M₂) M₃`. -/
+and one-multilinear maps `MultilinearMap (RingHom.id R) (fun _ : ι ↦ M₂) M₃`. -/
 @[simps +simpRhs]
 def ofSubsingletonₗ [Subsingleton ι] (i : ι) :
-    (M₂ →ₗ[R] M₃) ≃ₗ[S] MultilinearMap R (fun _ : ι ↦ M₂) M₃ :=
+    (M₂ →ₗ[R] M₃) ≃ₗ[S] MultilinearMap (RingHom.id R) (fun _ : ι ↦ M₂) M₃ :=
   { ofSubsingleton R M₂ M₃ i with
     map_add' := fun _ _ ↦ rfl
     map_smul' := fun _ _ ↦ rfl }
@@ -943,7 +998,8 @@ end OfSubsingleton
 /-- The dependent version of `MultilinearMap.domDomCongrLinearEquiv`. -/
 @[simps apply symm_apply]
 def domDomCongrLinearEquiv' {ι' : Type*} (σ : ι ≃ ι') :
-    MultilinearMap R M₁ M₂ ≃ₗ[S] MultilinearMap R (fun i => M₁ (σ.symm i)) M₂ where
+    MultilinearMap (RingHom.id R) M₁ M₂ ≃ₗ[S]
+      MultilinearMap (RingHom.id R) (fun i => M₁ (σ.symm i)) M₂ where
   toFun f :=
     { toFun := f ∘ (σ.piCongrLeft' M₁).symm
       map_update_add' := fun m i => by
@@ -955,7 +1011,7 @@ def domDomCongrLinearEquiv' {ι' : Type*} (σ : ι ≃ ι') :
         let := σ.decidableEq
         rw [← σ.apply_symm_apply i]
         intro x
-        simp only [Function.comp, piCongrLeft'_symm_update, f.map_update_smul] }
+        simp only [Function.comp, piCongrLeft'_symm_update, f.map_update_smul, RingHom.id_apply] }
   invFun f :=
     { toFun := f ∘ σ.piCongrLeft' M₁
       map_update_add' := fun m i => by
@@ -967,7 +1023,7 @@ def domDomCongrLinearEquiv' {ι' : Type*} (σ : ι ≃ ι') :
         let := σ.symm.decidableEq
         rw [← σ.symm_apply_apply i]
         intro x
-        simp only [Function.comp, piCongrLeft'_update, f.map_update_smul] }
+        simp only [Function.comp, piCongrLeft'_update, f.map_update_smul, RingHom.id_apply] }
   map_add' f₁ f₂ := by
     ext
     simp only [Function.comp, coe_mk, add_apply]
@@ -984,7 +1040,7 @@ def domDomCongrLinearEquiv' {ι' : Type*} (σ : ι ≃ ι') :
 /-- The space of constant maps is equivalent to the space of maps that are multilinear with respect
 to an empty family. -/
 @[simps]
-def constLinearEquivOfIsEmpty [IsEmpty ι] : M₂ ≃ₗ[S] MultilinearMap R M₁ M₂ where
+def constLinearEquivOfIsEmpty [IsEmpty ι] : M₂ ≃ₗ[S] MultilinearMap (RingHom.id R) M₁ M₂ where
   toFun := MultilinearMap.constOfIsEmpty R _
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
@@ -994,9 +1050,11 @@ def constLinearEquivOfIsEmpty [IsEmpty ι] : M₂ ≃ₗ[S] MultilinearMap R M�
 /-- `MultilinearMap.domDomCongr` as a `LinearEquiv`. -/
 @[simps apply symm_apply]
 def domDomCongrLinearEquiv {ι₁ ι₂} (σ : ι₁ ≃ ι₂) :
-    MultilinearMap R (fun _ : ι₁ => M₂) M₃ ≃ₗ[S] MultilinearMap R (fun _ : ι₂ => M₂) M₃ :=
+    MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃ ≃ₗ[S]
+      MultilinearMap (RingHom.id R) (fun _ : ι₂ => M₂) M₃ :=
   { (domDomCongrEquiv σ :
-      MultilinearMap R (fun _ : ι₁ => M₂) M₃ ≃+ MultilinearMap R (fun _ : ι₂ => M₂) M₃) with
+      MultilinearMap (RingHom.id R) (fun _ : ι₁ => M₂) M₃ ≃+
+        MultilinearMap (RingHom.id R) (fun _ : ι₂ => M₂) M₃) with
     map_smul' := fun c f => by
       ext
       simp [MultilinearMap.domDomCongr] }
@@ -1008,7 +1066,8 @@ end Semiring
 section CommSemiring
 
 variable [CommSemiring R] [∀ i, AddCommMonoid (M₁ i)] [∀ i, AddCommMonoid (M i)] [AddCommMonoid M₂]
-  [∀ i, Module R (M i)] [∀ i, Module R (M₁ i)] [Module R M₂] (f f' : MultilinearMap R M₁ M₂)
+  [∀ i, Module R (M i)] [∀ i, Module R (M₁ i)] [Module R M₂]
+  (f f' : MultilinearMap (RingHom.id R) M₁ M₂)
 
 section
 variable [Π i, AddCommMonoid (M₁' i)] [Π i, Module R (M₁' i)]
@@ -1018,9 +1077,9 @@ from the elements satisfying `P` to the multilinear maps on elements not satisfy
 In other words, splitting the variables into two subsets one gets a multilinear map into
 multilinear maps.
 This is a linear map version of the function `MultilinearMap.domDomRestrict`. -/
-def domDomRestrictₗ (f : MultilinearMap R M₁ M₂) (P : ι → Prop) [DecidablePred P] :
-    MultilinearMap R (fun (i : {a : ι // ¬ P a}) => M₁ i)
-      (MultilinearMap R (fun (i : {a : ι // P a}) => M₁ i) M₂) where
+def domDomRestrictₗ (f : MultilinearMap (RingHom.id R) M₁ M₂) (P : ι → Prop) [DecidablePred P] :
+    MultilinearMap (RingHom.id R) (fun (i : {a : ι // ¬ P a}) => M₁ i)
+      (MultilinearMap (RingHom.id R) (fun (i : {a : ι // P a}) => M₁ i) M₂) where
   toFun := fun z ↦ domDomRestrict f P z
   map_update_add' := by
     intro h m i x y
@@ -1050,9 +1109,9 @@ indices `i` in `s` one uses the `i`-th coordinate of the vector `v_{e.symm i}` a
 uses the `i`-th coordinate of a reference vector `x`.
 This is multilinear in the components of `x` outside of `s`, and in the `v_j`. -/
 noncomputable def iteratedFDerivComponent {α : Type*}
-    (f : MultilinearMap R M₁ M₂) {s : Set ι} (e : α ≃ s) [DecidablePred (· ∈ s)] :
-    MultilinearMap R (fun (i : {a : ι // a ∉ s}) ↦ M₁ i)
-      (MultilinearMap R (fun (_ : α) ↦ (∀ i, M₁ i)) M₂) where
+    (f : MultilinearMap (RingHom.id R) M₁ M₂) {s : Set ι} (e : α ≃ s) [DecidablePred (· ∈ s)] :
+    MultilinearMap (RingHom.id R) (fun (i : {a : ι // a ∉ s}) ↦ M₁ i)
+      (MultilinearMap (RingHom.id R) (fun (_ : α) ↦ (∀ i, M₁ i)) M₂) where
   toFun := fun z ↦
     { toFun := fun v ↦ domDomRestrictₗ f (fun i ↦ i ∈ s) z (fun i ↦ v (e.symm i) i)
       map_update_add' := by classical simp [iteratedFDeriv_aux]
@@ -1070,14 +1129,14 @@ by the subsets `s` of `ι` of cardinality `k` and then the bijections between `F
 
 For the continuous version, see `ContinuousMultilinearMap.iteratedFDeriv`. -/
 protected noncomputable def iteratedFDeriv [Fintype ι]
-    (f : MultilinearMap R M₁ M₂) (k : ℕ) (x : (i : ι) → M₁ i) :
-    MultilinearMap R (fun (_ : Fin k) ↦ (∀ i, M₁ i)) M₂ :=
+    (f : MultilinearMap (RingHom.id R) M₁ M₂) (k : ℕ) (x : (i : ι) → M₁ i) :
+    MultilinearMap (RingHom.id R) (fun (_ : Fin k) ↦ (∀ i, M₁ i)) M₂ :=
   ∑ e : Fin k ↪ ι, iteratedFDerivComponent f e.toEquivRange (fun i ↦ x i)
 
 /-- If `f` is a collection of linear maps, then the construction `MultilinearMap.compLinearMap`
 sending a multilinear map `g` to `g (f₁ ⬝ , ..., fₙ ⬝ )` is linear in `g`. -/
 @[simps] def compLinearMapₗ (f : Π (i : ι), M₁ i →ₗ[R] M₁' i) :
-    (MultilinearMap R M₁' M₂) →ₗ[R] MultilinearMap R M₁ M₂ where
+    (MultilinearMap (RingHom.id R) M₁' M₂) →ₗ[R] MultilinearMap (RingHom.id R) M₁ M₂ where
   toFun := fun g ↦ g.compLinearMap f
   map_add' := fun _ _ ↦ rfl
   map_smul' := fun _ _ ↦ rfl
@@ -1088,7 +1147,7 @@ This is `MultilinearMap.compLinearMap` as a linear equivalence,
 and the multilinear version of `LinearEquiv.congrLeft`. -/
 @[simps! apply symm_apply]
 def _root_.LinearEquiv.multilinearMapCongrLeft (e : Π (i : ι), M₁ i ≃ₗ[R] M₁' i) :
-    (MultilinearMap R M₁' M₂) ≃ₗ[R] MultilinearMap R M₁ M₂ where
+    (MultilinearMap (RingHom.id R) M₁' M₂) ≃ₗ[R] MultilinearMap (RingHom.id R) M₁ M₂ where
   __ := compLinearMapₗ (e · |>.toLinearMap)
   invFun := compLinearMapₗ (e · |>.symm.toLinearMap)
   left_inv _ := by ext; simp
@@ -1098,8 +1157,8 @@ def _root_.LinearEquiv.multilinearMapCongrLeft (e : Π (i : ι), M₁ i ≃ₗ[R
 sending a multilinear map `g` to `g (f₁ ⬝ , ..., fₙ ⬝ )` is linear in `g` and multilinear in
 `f₁, ..., fₙ`. -/
 @[simps] def compLinearMapMultilinear :
-    @MultilinearMap R ι (fun i ↦ M₁ i →ₗ[R] M₁' i)
-      ((MultilinearMap R M₁' M₂) →ₗ[R] MultilinearMap R M₁ M₂) _ _ _
+    @MultilinearMap R R _ _ (RingHom.id R) ι (fun i ↦ M₁ i →ₗ[R] M₁' i)
+      ((MultilinearMap (RingHom.id R) M₁' M₂) →ₗ[R] MultilinearMap (RingHom.id R) M₁ M₂) _ _
         (fun _ ↦ LinearMap.module) _ where
   toFun := MultilinearMap.compLinearMapₗ
   map_update_add' := by
@@ -1128,8 +1187,9 @@ If `g` is a multilinear map `M' → M₂`, then `g` can be reinterpreted as a mu
 map from `Π i, M₁ᵢ ⟶ M₁ᵢ'` to `M ⟶ M₂` via `(fᵢ) ↦ v ↦ g(fᵢ vᵢ)`.
 -/
 @[simps!] def piLinearMap :
-    MultilinearMap R M₁' M₂ →ₗ[R]
-    MultilinearMap R (fun i ↦ M₁ i →ₗ[R] M₁' i) (MultilinearMap R M₁ M₂) where
+    MultilinearMap (RingHom.id R) M₁' M₂ →ₗ[R]
+    MultilinearMap (RingHom.id R) (fun i ↦ M₁ i →ₗ[R] M₁' i)
+      (MultilinearMap (RingHom.id R) M₁ M₂) where
   toFun g := (LinearMap.applyₗ g).compMultilinearMap compLinearMapMultilinear
   map_add' := by simp
   map_smul' := by simp
@@ -1174,7 +1234,7 @@ theorem map_update_smul_left [DecidableEq ι] [Fintype ι]
 
 This is the multilinear version of `LinearMap.ext_ring`. -/
 @[ext]
-theorem ext_ring [Finite ι] ⦃f g : MultilinearMap R (fun _ : ι => R) M₂⦄
+theorem ext_ring [Finite ι] ⦃f g : MultilinearMap (RingHom.id R) (fun _ : ι => R) M₂⦄
     (h : f (fun _ ↦ 1) = g (fun _ ↦ 1)) : f = g := by
   ext x
   obtain ⟨_⟩ := nonempty_fintype ι
@@ -1192,7 +1252,7 @@ to `m` the product of all the `m i`.
 
 See also `MultilinearMap.mkPiAlgebraFin` for a version that works with a non-commutative
 algebra `A` but requires `ι = Fin n`. -/
-protected def mkPiAlgebra : MultilinearMap R (fun _ : ι => A) A where
+protected def mkPiAlgebra : MultilinearMap (RingHom.id R) (fun _ : ι => A) A where
   toFun m := ∏ i, m i
   map_update_add' m i x y := by simp [Finset.prod_update_of_mem, add_mul]
   map_update_smul' m i c x := by simp [Finset.prod_update_of_mem]
@@ -1215,7 +1275,7 @@ to `m` the product of all the `m i`.
 
 See also `MultilinearMap.mkPiAlgebra` for a version that assumes `[CommSemiring A]` but works
 for `A^ι` with any finite type `ι`. -/
-protected def mkPiAlgebraFin : MultilinearMap R (fun _ : Fin n => A) A :=
+protected def mkPiAlgebraFin : MultilinearMap (RingHom.id R) (fun _ : Fin n => A) A :=
   MultilinearMap.mk' (fun m ↦ (List.ofFn m).prod)
     (fun m i x y ↦ by
       simp [List.ofFn_eq_map, (List.nodup_finRange n).map_update, List.prod_set, add_mul,
@@ -1237,11 +1297,12 @@ end
 
 /-- Given an `R`-multilinear map `f` taking values in `R`, `f.smulRight z` is the map
 sending `m` to `f m • z`. -/
-def smulRight (f : MultilinearMap R M₁ R) (z : M₂) : MultilinearMap R M₁ M₂ :=
+def smulRight (f : MultilinearMap (RingHom.id R) M₁ R) (z : M₂) :
+    MultilinearMap (RingHom.id R) M₁ M₂ :=
   (LinearMap.smulRight LinearMap.id z).compMultilinearMap f
 
 @[simp]
-theorem smulRight_apply (f : MultilinearMap R M₁ R) (z : M₂) (m : ∀ i, M₁ i) :
+theorem smulRight_apply (f : MultilinearMap (RingHom.id R) M₁ R) (z : M₂) (m : ∀ i, M₁ i) :
     f.smulRight z m = f m • z :=
   rfl
 
@@ -1250,7 +1311,7 @@ variable (R ι)
 /-- The canonical multilinear map on `R^ι` when `ι` is finite, associating to `m` the product of
 all the `m i` (multiplied by a fixed reference element `z` in the target module). See also
 `mkPiAlgebra` for a more general version. -/
-protected def mkPiRing [Fintype ι] (z : M₂) : MultilinearMap R (fun _ : ι => R) M₂ :=
+protected def mkPiRing [Fintype ι] (z : M₂) : MultilinearMap (RingHom.id R) (fun _ : ι => R) M₂ :=
   (MultilinearMap.mkPiAlgebra R ι R).smulRight z
 
 variable {R ι}
@@ -1260,7 +1321,8 @@ theorem mkPiRing_apply [Fintype ι] (z : M₂) (m : ι → R) :
     (MultilinearMap.mkPiRing R ι z : (ι → R) → M₂) m = (∏ i, m i) • z :=
   rfl
 
-theorem mkPiRing_apply_one_eq_self [Fintype ι] (f : MultilinearMap R (fun _ : ι => R) M₂) :
+theorem mkPiRing_apply_one_eq_self [Fintype ι]
+    (f : MultilinearMap (RingHom.id R) (fun _ : ι => R) M₂) :
     MultilinearMap.mkPiRing R ι (f fun _ => 1) = f := by
   ext
   simp
@@ -1282,37 +1344,41 @@ end CommSemiring
 
 section RangeAddCommGroup
 
-variable [Semiring R] [∀ i, AddCommMonoid (M₁ i)] [AddCommGroup M₂] [∀ i, Module R (M₁ i)]
-  [Module R M₂] (f g : MultilinearMap R M₁ M₂)
+variable [Semiring R] [Semiring R₂] {σ : R →+* R₂}
+  [∀ i, AddCommMonoid (M₁ i)] [AddCommGroup M₂] [∀ i, Module R (M₁ i)]
+  [Module R₂ M₂] (f g : MultilinearMap σ M₁ M₂)
 
-instance : Neg (MultilinearMap R M₁ M₂) :=
-  ⟨fun f => ⟨fun m => -f m, fun m i x y => by simp [add_comm], fun m i c x => by simp⟩⟩
+instance : Neg (MultilinearMap σ M₁ M₂) :=
+  ⟨fun f => ⟨fun m => -f m,
+    fun m i x y => by simp [add_comm],
+    fun m i c x => by simp⟩⟩
 
-instance : IsNegApply (MultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
+instance : IsNegApply (MultilinearMap σ M₁ M₂) (∀ i, M₁ i) M₂ where
   neg_apply _ _ := rfl
 
 @[deprecated (since := "2026-06-10")] protected alias neg_apply := neg_apply
 
-instance : Sub (MultilinearMap R M₁ M₂) :=
+instance : Sub (MultilinearMap σ M₁ M₂) :=
   ⟨fun f g =>
     ⟨fun m => f m - g m, fun m i x y => by
       simp only [MultilinearMap.map_update_add, sub_eq_add_neg, neg_add]
       abel,
-      fun m i c x => by simp only [MultilinearMap.map_update_smul, smul_sub]⟩⟩
+      fun m i c x => by
+        simp only [MultilinearMap.map_update_smulₛₗ, smul_sub]⟩⟩
 
-instance : IsSubApply (MultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
+instance : IsSubApply (MultilinearMap σ M₁ M₂) (∀ i, M₁ i) M₂ where
   sub_apply _ _ _ := rfl
 
 @[deprecated (since := "2026-06-10")] protected alias sub_apply := sub_apply
 
-instance : AddCommGroup (MultilinearMap R M₁ M₂) := fast_instance% FunLike.addCommGroup
+instance : AddCommGroup (MultilinearMap σ M₁ M₂) := fast_instance% FunLike.addCommGroup
 
 end RangeAddCommGroup
 
 section AddCommGroup
 
 variable [Semiring R] [∀ i, AddCommGroup (M₁ i)] [AddCommGroup M₂] [∀ i, Module R (M₁ i)]
-  [Module R M₂] (f : MultilinearMap R M₁ M₂)
+  [Module R M₂] (f : MultilinearMap (RingHom.id R) M₁ M₂)
 
 @[simp]
 theorem map_update_neg [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) (x : M₁ i) :
@@ -1397,7 +1463,8 @@ variable [CommSemiring R] [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M₂] [
 /-- When `ι` is finite, multilinear maps on `R^ι` with values in `M₂` are in bijection with `M₂`,
 as such a multilinear map is completely determined by its value on the constant vector made of ones.
 We register this bijection as a linear equivalence in `MultilinearMap.piRingEquiv`. -/
-protected def piRingEquiv [Fintype ι] : M₂ ≃ₗ[R] MultilinearMap R (fun _ : ι => R) M₂ where
+protected def piRingEquiv [Fintype ι] :
+    M₂ ≃ₗ[R] MultilinearMap (RingHom.id R) (fun _ : ι => R) M₂ where
   toFun z := MultilinearMap.mkPiRing R ι z
   invFun f := f fun _ => 1
   map_add' z z' := by
@@ -1419,7 +1486,7 @@ variable [Ring R] [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M'] [AddCommMon
 /-- The pushforward of an indexed collection of submodule `p i ⊆ M₁ i` by `f : M₁ → M₂`.
 
 Note that this is not a submodule - it is not closed under addition. -/
-def map [Nonempty ι] (f : MultilinearMap R M₁ M₂) (p : ∀ i, Submodule R (M₁ i)) :
+def map [Nonempty ι] (f : MultilinearMap (RingHom.id R) M₁ M₂) (p : ∀ i, Submodule R (M₁ i)) :
     SubMulAction R M₂ where
   carrier := f '' { v | ∀ i, v i ∈ p i }
   smul_mem' := fun c _ ⟨x, hx, hf⟩ => by
@@ -1433,12 +1500,13 @@ def map [Nonempty ι] (f : MultilinearMap R M₁ M₂) (p : ∀ i, Submodule R (
     · rw [f.map_update_smul, update_eq_self]
 
 /-- The map is always nonempty. This lemma is needed to apply `SubMulAction.zero_mem`. -/
-theorem map_nonempty [Nonempty ι] (f : MultilinearMap R M₁ M₂) (p : ∀ i, Submodule R (M₁ i)) :
+theorem map_nonempty [Nonempty ι] (f : MultilinearMap (RingHom.id R) M₁ M₂)
+    (p : ∀ i, Submodule R (M₁ i)) :
     (map f p : Set M₂).Nonempty :=
   ⟨f 0, 0, fun i => (p i).zero_mem, rfl⟩
 
 /-- The range of a multilinear map, closed under scalar multiplication. -/
-def range [Nonempty ι] (f : MultilinearMap R M₁ M₂) : SubMulAction R M₂ :=
+def range [Nonempty ι] (f : MultilinearMap (RingHom.id R) M₁ M₂) : SubMulAction R M₂ :=
   f.map fun _ => ⊤
 
 end Submodule

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -407,7 +407,6 @@ def mk' [DecidableEq ι] (f : (∀ i, M₁ i) → M₂)
   map_update_smul' m i c x := by convert! h₂ m i c x
 
 /-- Earlier, this name was used by what is now called `MultilinearMap.map_update_smul_left`. -/
-@[simp]
 protected theorem map_update_smul [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) (c : R) (x : M₁ i) :
     f (update m i (c • x)) = c • f (update m i x) := by
   simp

--- a/Mathlib/LinearAlgebra/Multilinear/Basis.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basis.lean
@@ -27,8 +27,8 @@ variable {ι R : Type*} [CommSemiring R]
 
 /-- Two multilinear maps indexed by a `Fintype` are equal if they are equal when all arguments
 are basis vectors. -/
-theorem Module.Basis.ext_multilinear [Finite ι] {f g : MultilinearMap R M N} {ιM : ι → Type*}
-    (e : ∀ i, Basis (ιM i) R (M i))
+theorem Module.Basis.ext_multilinear [Finite ι] {f g : MultilinearMap (RingHom.id R) M N}
+    {ιM : ι → Type*} (e : ∀ i, Basis (ιM i) R (M i))
     (h : ∀ v : (i : ι) → ιM i, (f fun i ↦ e i (v i)) = g fun i ↦ e i (v i)) : f = g := by
   cases nonempty_fintype ι
   classical
@@ -48,7 +48,7 @@ variable {κ : ι → Type*} (b : (i : ι) → Basis (κ i) R (M i))
 open scoped Classical in
 /-- A basis for multilinear maps given a finite basis on each domain and a basis on the codomain. -/
 noncomputable def multilinearMap [Finite ι] [∀ i, Finite (κ i)] :
-    Basis ((Π i, κ i) × ι') R (MultilinearMap R M N) where
+    Basis ((Π i, κ i) × ι') R (MultilinearMap (RingHom.id R) M N) where
   repr :=
     have : Fintype ι := Fintype.ofFinite _
     have (i : ι) : Fintype (κ i) := Fintype.ofFinite _

--- a/Mathlib/LinearAlgebra/Multilinear/Curry.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
@@ -58,21 +58,23 @@ variable [CommSemiring R] [∀ i, AddCommMonoid (M i)] [AddCommMonoid M'] [AddCo
 /-- Given a linear map `f` from `M 0` to multilinear maps on `n` variables,
 construct the corresponding multilinear map on `n+1` variables obtained by concatenating
 the variables, given by `m ↦ f (m 0) (tail m)` -/
-def LinearMap.uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂) :
-    MultilinearMap R M M₂ :=
+def LinearMap.uncurryLeft
+    (f : M 0 →ₗ[R] MultilinearMap (RingHom.id R) (fun i : Fin n => M i.succ) M₂) :
+    MultilinearMap (RingHom.id R) M M₂ :=
   MultilinearMap.mk' (fun m ↦ f (m 0) (tail m))
     (fun m i x y ↦ by cases i using Fin.cases <;> simp [Ne.symm])
     (fun m i c x ↦ by cases i using Fin.cases <;> simp [Ne.symm])
 
 @[simp]
-theorem LinearMap.uncurryLeft_apply (f : M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂)
+theorem LinearMap.uncurryLeft_apply
+    (f : M 0 →ₗ[R] MultilinearMap (RingHom.id R) (fun i : Fin n => M i.succ) M₂)
     (m : ∀ i, M i) : f.uncurryLeft m = f (m 0) (tail m) :=
   rfl
 
 /-- Given a multilinear map `f` in `n+1` variables, split the first variable to obtain
 a linear map into multilinear maps in `n` variables, given by `x ↦ (m ↦ f (cons x m))`. -/
-def MultilinearMap.curryLeft (f : MultilinearMap R M M₂) :
-    M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂ where
+def MultilinearMap.curryLeft (f : MultilinearMap (RingHom.id R) M M₂) :
+    M 0 →ₗ[R] MultilinearMap (RingHom.id R) (fun i : Fin n => M i.succ) M₂ where
   toFun x := MultilinearMap.mk' fun m => f (cons x m)
   map_add' x y := by
     ext m
@@ -82,17 +84,17 @@ def MultilinearMap.curryLeft (f : MultilinearMap R M M₂) :
     exact cons_smul f m c x
 
 @[simp]
-theorem MultilinearMap.curryLeft_apply (f : MultilinearMap R M M₂) (x : M 0)
+theorem MultilinearMap.curryLeft_apply (f : MultilinearMap (RingHom.id R) M M₂) (x : M 0)
     (m : ∀ i : Fin n, M i.succ) : f.curryLeft x m = f (cons x m) :=
   rfl
 
 @[simp]
-theorem LinearMap.curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i :
+theorem LinearMap.curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap (RingHom.id R) (fun i :
     Fin n => M i.succ) M₂) : f.uncurryLeft.curryLeft = f := by
   rfl
 
 @[simp]
-theorem MultilinearMap.uncurry_curryLeft (f : MultilinearMap R M M₂) :
+theorem MultilinearMap.uncurry_curryLeft (f : MultilinearMap (RingHom.id R) M M₂) :
     f.curryLeft.uncurryLeft = f := by
   ext m
   simp
@@ -108,7 +110,8 @@ The direct and inverse maps are given by `f.curryLeft` and `f.uncurryLeft`. Use 
 unless you need the full framework of linear equivs. -/
 @[simps]
 def multilinearCurryLeftEquiv :
-    MultilinearMap R M M₂ ≃ₗ[R] (M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂) where
+    MultilinearMap (RingHom.id R) M M₂ ≃ₗ[R]
+      (M 0 →ₗ[R] MultilinearMap (RingHom.id R) (fun i : Fin n => M i.succ) M₂) where
   toFun := MultilinearMap.curryLeft
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
@@ -124,43 +127,43 @@ variable {R M M₂}
 `M₂`, construct the corresponding multilinear map on `n+1` variables obtained by concatenating
 the variables, given by `m ↦ f (init m) (m (last n))` -/
 def MultilinearMap.uncurryRight
-    (f : MultilinearMap R (fun i : Fin n => M (castSucc i)) (M (last n) →ₗ[R] M₂)) :
-    MultilinearMap R M M₂ :=
+    (f : MultilinearMap (RingHom.id R) (fun i : Fin n => M (castSucc i)) (M (last n) →ₗ[R] M₂)) :
+    MultilinearMap (RingHom.id R) M M₂ :=
   MultilinearMap.mk' (fun m ↦ f (init m) (m (last n)))
     (fun m i x y ↦ by cases i using Fin.lastCases <;> simp [Ne.symm])
     (fun m i c x ↦ by cases i using Fin.lastCases <;> simp [Ne.symm])
 
 @[simp]
 theorem MultilinearMap.uncurryRight_apply
-    (f : MultilinearMap R (fun i : Fin n => M (castSucc i)) (M (last n) →ₗ[R] M₂))
+    (f : MultilinearMap (RingHom.id R) (fun i : Fin n => M (castSucc i)) (M (last n) →ₗ[R] M₂))
     (m : ∀ i, M i) : f.uncurryRight m = f (init m) (m (last n)) :=
   rfl
 
 /-- Given a multilinear map `f` in `n+1` variables, split the last variable to obtain
 a multilinear map in `n` variables taking values in linear maps from `M (last n)` to `M₂`, given by
 `m ↦ (x ↦ f (snoc m x))`. -/
-def MultilinearMap.curryRight (f : MultilinearMap R M M₂) :
-    MultilinearMap R (fun i : Fin n => M (Fin.castSucc i)) (M (last n) →ₗ[R] M₂) :=
+def MultilinearMap.curryRight (f : MultilinearMap (RingHom.id R) M M₂) :
+    MultilinearMap (RingHom.id R) (fun i : Fin n => M (Fin.castSucc i)) (M (last n) →ₗ[R] M₂) :=
   MultilinearMap.mk' fun m ↦
     { toFun := fun x => f (snoc m x)
       map_add' := fun x y => by simp_rw [f.snoc_add]
       map_smul' := fun c x => by simp only [f.snoc_smul, RingHom.id_apply] }
 
 @[simp]
-theorem MultilinearMap.curryRight_apply (f : MultilinearMap R M M₂)
+theorem MultilinearMap.curryRight_apply (f : MultilinearMap (RingHom.id R) M M₂)
     (m : ∀ i : Fin n, M (castSucc i)) (x : M (last n)) : f.curryRight m x = f (snoc m x) :=
   rfl
 
 @[simp]
 theorem MultilinearMap.curry_uncurryRight
-    (f : MultilinearMap R (fun i : Fin n => M (castSucc i)) (M (last n) →ₗ[R] M₂)) :
+    (f : MultilinearMap (RingHom.id R) (fun i : Fin n => M (castSucc i)) (M (last n) →ₗ[R] M₂)) :
     f.uncurryRight.curryRight = f := by
   ext m x
   simp only [snoc_last, MultilinearMap.curryRight_apply, MultilinearMap.uncurryRight_apply]
   rw [init_snoc]
 
 @[simp]
-theorem MultilinearMap.uncurry_curryRight (f : MultilinearMap R M M₂) :
+theorem MultilinearMap.uncurry_curryRight (f : MultilinearMap (RingHom.id R) M M₂) :
     f.curryRight.uncurryRight = f := by
   ext m
   simp
@@ -175,8 +178,8 @@ isomorphism as a linear isomorphism in `multilinearCurryRightEquiv R M M₂`.
 The direct and inverse maps are given by `f.curryRight` and `f.uncurryRight`. Use these
 unless you need the full framework of linear equivs. -/
 def multilinearCurryRightEquiv :
-    MultilinearMap R M M₂ ≃ₗ[R]
-      MultilinearMap R (fun i : Fin n => M (castSucc i)) (M (last n) →ₗ[R] M₂) where
+    MultilinearMap (RingHom.id R) M M₂ ≃ₗ[R]
+      MultilinearMap (RingHom.id R) (fun i : Fin n => M (castSucc i)) (M (last n) →ₗ[R] M₂) where
   toFun := MultilinearMap.curryRight
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
@@ -191,7 +194,8 @@ in `n` variables `M 0`, ..., `M n` with `M p` removed,
 returns a multilinear map in all `n + 1` variables. -/
 @[simps!]
 def LinearMap.uncurryMid (p : Fin (n + 1))
-    (f : M p →ₗ[R] MultilinearMap R (fun i ↦ M (p.succAbove i)) M₂) : MultilinearMap R M M₂ :=
+    (f : M p →ₗ[R] MultilinearMap (RingHom.id R) (fun i ↦ M (p.succAbove i)) M₂) :
+    MultilinearMap (RingHom.id R) M M₂ :=
   .mk' (fun m ↦ f (m p) (p.removeNth m))
     (fun m i x y ↦ by cases i using Fin.succAboveCases p <;> simp)
     (fun m i x y ↦ by cases i using Fin.succAboveCases p <;> simp)
@@ -199,27 +203,29 @@ def LinearMap.uncurryMid (p : Fin (n + 1))
 /-- Interpret a multilinear map in `n + 1` variables
 as a linear map in `p`th variable with values in the multilinear maps in the other variables. -/
 @[simps!]
-def MultilinearMap.curryMid (p : Fin (n + 1)) (f : MultilinearMap R M M₂) :
-    M p →ₗ[R] MultilinearMap R (fun i ↦ M (p.succAbove i)) M₂ where
+def MultilinearMap.curryMid (p : Fin (n + 1)) (f : MultilinearMap (RingHom.id R) M M₂) :
+    M p →ₗ[R] MultilinearMap (RingHom.id R) (fun i ↦ M (p.succAbove i)) M₂ where
   toFun x := .mk' fun m ↦ f (p.insertNth x m)
-  map_add' x y := by ext; simp [map_insertNth_add]
-  map_smul' c x := by ext; simp [map_insertNth_smul]
+  map_add' x y := by ext; simp [mk', map_insertNth_add]
+  map_smul' c x := by ext; simp [mk', map_insertNth_smul]
 
 @[simp]
 theorem LinearMap.curryMid_uncurryMid (i : Fin (n + 1))
-    (f : M i →ₗ[R] MultilinearMap R (fun j ↦ M (i.succAbove j)) M₂) :
-    (f.uncurryMid i).curryMid i = f := by ext; simp
+    (f : M i →ₗ[R] MultilinearMap (RingHom.id R) (fun j ↦ M (i.succAbove j)) M₂) :
+    (f.uncurryMid i).curryMid i = f := by ext x m; simp [mk', LinearMap.uncurryMid, curryMid]
 
 @[simp]
-theorem MultilinearMap.uncurryMid_curryMid (i : Fin (n + 1)) (f : MultilinearMap R M M₂) :
-    (f.curryMid i).uncurryMid i = f := by ext; simp
+theorem MultilinearMap.uncurryMid_curryMid (i : Fin (n + 1))
+    (f : MultilinearMap (RingHom.id R) M M₂) :
+    (f.curryMid i).uncurryMid i = f := by ext m; simp [LinearMap.uncurryMid, curryMid, mk']
 
 variable (R M M₂)
 
 /-- `MultilinearMap.curryMid` as a linear equivalence. -/
 @[simps]
 def MultilinearMap.curryMidLinearEquiv (p : Fin (n + 1)) :
-    MultilinearMap R M M₂ ≃ₗ[R] M p →ₗ[R] MultilinearMap R (fun i ↦ M (p.succAbove i)) M₂ where
+    MultilinearMap (RingHom.id R) M M₂ ≃ₗ[R]
+      M p →ₗ[R] MultilinearMap (RingHom.id R) (fun i ↦ M (p.succAbove i)) M₂ where
   toFun := MultilinearMap.curryMid p
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
@@ -236,8 +242,9 @@ variable {R M₂} {N : (ι ⊕ ι') → Type*}
 on `(fun _ : ι ⊕ ι' => M')` induces a multilinear map on
 `(fun (i : ι) ↦ N (.inl i))` taking values in the space of
 linear maps on `(fun (i : ι') ↦ N (.inr i))`. -/
-def currySum (f : MultilinearMap R N M₂) :
-    MultilinearMap R (fun i : ι ↦ N (.inl i)) (MultilinearMap R (fun i : ι' ↦ N (.inr i)) M₂) where
+def currySum (f : MultilinearMap (RingHom.id R) N M₂) :
+    MultilinearMap (RingHom.id R) (fun i : ι ↦ N (.inl i))
+      (MultilinearMap (RingHom.id R) (fun i : ι' ↦ N (.inr i)) M₂) where
   toFun u :=
     { toFun v := f (Sum.rec u v)
       map_update_add' := by let := Classical.decEq ι; simp
@@ -248,22 +255,22 @@ def currySum (f : MultilinearMap R N M₂) :
     ext fun _ ↦ by let := Classical.decEq ι'; simp
 
 @[simp low]
-theorem currySum_apply (f : MultilinearMap R N M₂)
+theorem currySum_apply (f : MultilinearMap (RingHom.id R) N M₂)
     (u : (i : ι) → N (Sum.inl i)) (v : (i : ι') → N (Sum.inr i)) :
     currySum f u v = f (Sum.rec u v) := rfl
 
 @[simp]
 theorem currySum_apply' {N : Type*} [AddCommMonoid N] [Module R N]
-    (f : MultilinearMap R (fun _ : ι ⊕ ι' ↦ N) M₂)
+    (f : MultilinearMap (RingHom.id R) (fun _ : ι ⊕ ι' ↦ N) M₂)
     (u : ι → N) (v : ι' → N) :
     currySum f u v = f (Sum.elim u v) := rfl
 
 @[simp]
-lemma currySum_add (f₁ f₂ : MultilinearMap R N M₂) :
+lemma currySum_add (f₁ f₂ : MultilinearMap (RingHom.id R) N M₂) :
     currySum (f₁ + f₂) = currySum f₁ + currySum f₂ := rfl
 
 @[simp]
-lemma currySum_smul (r : R) (f : MultilinearMap R N M₂) :
+lemma currySum_smul (r : R) (f : MultilinearMap (RingHom.id R) N M₂) :
     currySum (r • f) = r • currySum f := rfl
 
 /-- Given a family of modules `N : (ι ⊕ ι') → Type*`, a multilinear map on
@@ -271,9 +278,9 @@ lemma currySum_smul (r : R) (f : MultilinearMap R N M₂) :
 linear maps on `(fun (i : ι') ↦ N (.inr i))` induces a multilinear map
 on `(fun _ : ι ⊕ ι' => M')` induces. -/
 def uncurrySum
-    (g : MultilinearMap R (fun i : ι ↦ N (.inl i))
-      (MultilinearMap R (fun i : ι' ↦ N (.inr i)) M₂)) :
-    MultilinearMap R N M₂ where
+    (g : MultilinearMap (RingHom.id R) (fun i : ι ↦ N (.inl i))
+      (MultilinearMap (RingHom.id R) (fun i : ι' ↦ N (.inr i)) M₂)) :
+    MultilinearMap (RingHom.id R) N M₂ where
   toFun u := g (fun i ↦ u (.inl i)) (fun i' ↦ u (.inr i'))
   map_update_add' := by
     let := Classical.decEq ι
@@ -286,26 +293,26 @@ def uncurrySum
 
 @[simp]
 theorem uncurrySum_apply
-    (g : MultilinearMap R (fun i : ι ↦ N (.inl i))
-      (MultilinearMap R (fun i : ι' ↦ N (.inr i)) M₂)) (u) :
+    (g : MultilinearMap (RingHom.id R) (fun i : ι ↦ N (.inl i))
+      (MultilinearMap (RingHom.id R) (fun i : ι' ↦ N (.inr i)) M₂)) (u) :
     g.uncurrySum u =
       g (fun i ↦ u (.inl i)) (fun i' ↦ u (.inr i')) := rfl
 
 @[simp]
 lemma uncurrySum_add
-    (g₁ g₂ : MultilinearMap R (fun i : ι ↦ N (.inl i))
-      (MultilinearMap R (fun i : ι' ↦ N (.inr i)) M₂)) :
+    (g₁ g₂ : MultilinearMap (RingHom.id R) (fun i : ι ↦ N (.inl i))
+      (MultilinearMap (RingHom.id R) (fun i : ι' ↦ N (.inr i)) M₂)) :
     uncurrySum (g₁ + g₂) = uncurrySum g₁ + uncurrySum g₂ :=
   rfl
 
 lemma uncurrySum_smul
-    (r : R) (g : MultilinearMap R (fun i : ι ↦ N (.inl i))
-      (MultilinearMap R (fun i : ι' ↦ N (.inr i)) M₂)) :
+    (r : R) (g : MultilinearMap (RingHom.id R) (fun i : ι ↦ N (.inl i))
+      (MultilinearMap (RingHom.id R) (fun i : ι' ↦ N (.inr i)) M₂)) :
     uncurrySum (r • g) = r • uncurrySum g :=
   rfl
 
 @[simp]
-lemma uncurrySum_currySum (f : MultilinearMap R N M₂) :
+lemma uncurrySum_currySum (f : MultilinearMap (RingHom.id R) N M₂) :
     uncurrySum (currySum f) = f := by
   ext
   simp only [uncurrySum_apply, currySum_apply]
@@ -314,8 +321,8 @@ lemma uncurrySum_currySum (f : MultilinearMap R N M₂) :
 
 @[simp]
 lemma currySum_uncurrySum
-    (g : MultilinearMap R (fun i : ι ↦ N (.inl i))
-      (MultilinearMap R (fun i : ι' ↦ N (.inr i)) M₂)) :
+    (g : MultilinearMap (RingHom.id R) (fun i : ι ↦ N (.inl i))
+      (MultilinearMap (RingHom.id R) (fun i : ι' ↦ N (.inr i)) M₂)) :
     currySum (uncurrySum g) = g :=
   rfl
 
@@ -323,9 +330,9 @@ lemma currySum_uncurrySum
 from `(fun (i : ι) ↦ N (.inl i))` taking values in the space of
 linear maps on `(fun (i : ι') ↦ N (.inr i))`. -/
 @[simps]
-def currySumEquiv : MultilinearMap R N M₂ ≃ₗ[R]
-    MultilinearMap R (fun i : ι ↦ N (.inl i))
-      (MultilinearMap R (fun i : ι' ↦ N (.inr i)) M₂) where
+def currySumEquiv : MultilinearMap (RingHom.id R) N M₂ ≃ₗ[R]
+    MultilinearMap (RingHom.id R) (fun i : ι ↦ N (.inl i))
+      (MultilinearMap (RingHom.id R) (fun i : ι' ↦ N (.inr i)) M₂) where
   toFun := currySum
   invFun := uncurrySum
   left_inv _ := by simp
@@ -347,8 +354,9 @@ variable (R M₂ M')
 multilinear maps on `fun i : Fin k => M'` taking values in the space of multilinear maps
 on `fun i : Fin l => M'`. -/
 def curryFinFinset {k l n : ℕ} {s : Finset (Fin n)} (hk : #s = k) (hl : #sᶜ = l) :
-    MultilinearMap R (fun _ : Fin n => M') M₂ ≃ₗ[R]
-      MultilinearMap R (fun _ : Fin k => M') (MultilinearMap R (fun _ : Fin l => M') M₂) :=
+    MultilinearMap (RingHom.id R) (fun _ : Fin n => M') M₂ ≃ₗ[R]
+      MultilinearMap (RingHom.id R) (fun _ : Fin k => M')
+        (MultilinearMap (RingHom.id R) (fun _ : Fin l => M') M₂) :=
   (domDomCongrLinearEquiv R R M' M₂ (finSumEquivOfFinset hk hl).symm).trans
     currySumEquiv
 
@@ -356,7 +364,8 @@ variable {R M₂ M'}
 
 @[simp]
 theorem curryFinFinset_apply {k l n : ℕ} {s : Finset (Fin n)} (hk : #s = k) (hl : #sᶜ = l)
-    (f : MultilinearMap R (fun _ : Fin n => M') M₂) (mk : Fin k → M') (ml : Fin l → M') :
+    (f : MultilinearMap (RingHom.id R) (fun _ : Fin n => M') M₂) (mk : Fin k → M')
+    (ml : Fin l → M') :
     curryFinFinset R M₂ M' hk hl f mk ml =
       f fun i => Sum.elim mk ml ((finSumEquivOfFinset hk hl).symm i) :=
   rfl
@@ -364,7 +373,8 @@ theorem curryFinFinset_apply {k l n : ℕ} {s : Finset (Fin n)} (hk : #s = k) (h
 @[simp]
 theorem curryFinFinset_symm_apply {k l n : ℕ} {s : Finset (Fin n)} (hk : #s = k)
     (hl : #sᶜ = l)
-    (f : MultilinearMap R (fun _ : Fin k => M') (MultilinearMap R (fun _ : Fin l => M') M₂))
+    (f : MultilinearMap (RingHom.id R) (fun _ : Fin k => M')
+      (MultilinearMap (RingHom.id R) (fun _ : Fin l => M') M₂))
     (m : Fin n → M') :
     (curryFinFinset R M₂ M' hk hl).symm f m =
       f (fun i => m <| finSumEquivOfFinset hk hl (Sum.inl i)) fun i =>
@@ -373,7 +383,8 @@ theorem curryFinFinset_symm_apply {k l n : ℕ} {s : Finset (Fin n)} (hk : #s = 
 
 theorem curryFinFinset_symm_apply_piecewise_const {k l n : ℕ} {s : Finset (Fin n)} (hk : #s = k)
     (hl : #sᶜ = l)
-    (f : MultilinearMap R (fun _ : Fin k => M') (MultilinearMap R (fun _ : Fin l => M') M₂))
+    (f : MultilinearMap (RingHom.id R) (fun _ : Fin k => M')
+      (MultilinearMap (RingHom.id R) (fun _ : Fin l => M') M₂))
     (x y : M') :
     (curryFinFinset R M₂ M' hk hl).symm f (s.piecewise (fun _ => x) fun _ => y) =
       f (fun _ => x) fun _ => y := by
@@ -388,12 +399,13 @@ theorem curryFinFinset_symm_apply_piecewise_const {k l n : ℕ} {s : Finset (Fin
 @[simp]
 theorem curryFinFinset_symm_apply_const {k l n : ℕ} {s : Finset (Fin n)} (hk : #s = k)
     (hl : #sᶜ = l)
-    (f : MultilinearMap R (fun _ : Fin k => M') (MultilinearMap R (fun _ : Fin l => M') M₂))
+    (f : MultilinearMap (RingHom.id R) (fun _ : Fin k => M')
+      (MultilinearMap (RingHom.id R) (fun _ : Fin l => M') M₂))
     (x : M') : ((curryFinFinset R M₂ M' hk hl).symm f fun _ => x) = f (fun _ => x) fun _ => x :=
   rfl
 
 theorem curryFinFinset_apply_const {k l n : ℕ} {s : Finset (Fin n)} (hk : #s = k)
-    (hl : #sᶜ = l) (f : MultilinearMap R (fun _ : Fin n => M') M₂) (x y : M') :
+    (hl : #sᶜ = l) (f : MultilinearMap (RingHom.id R) (fun _ : Fin n => M') M₂) (x y : M') :
     (curryFinFinset R M₂ M' hk hl f (fun _ => x) fun _ => y) =
       f (s.piecewise (fun _ => x) fun _ => y) := by
   rw [← curryFinFinset_symm_apply_piecewise_const hk hl, LinearEquiv.symm_apply_apply]

--- a/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
@@ -53,7 +53,7 @@ generators.
 This is a multilinear version of `DFinsupp.lhom_ext'`. -/
 @[ext]
 theorem dfinsupp_ext [∀ i, DecidableEq (κ i)]
-    ⦃f g : MultilinearMap R (fun i ↦ Π₀ j : κ i, M i j) N⦄
+    ⦃f g : MultilinearMap (RingHom.id R) (fun i ↦ Π₀ j : κ i, M i j) N⦄
     (h : ∀ p : Π i, κ i,
       f.compLinearMap (fun i => DFinsupp.lsingle (p i)) =
       g.compLinearMap (fun i => DFinsupp.lsingle (p i))) : f = g := by
@@ -90,8 +90,8 @@ This is the `DFinsupp` version of `MultilinearMap.piFamily`.
 -/
 @[simps]
 def dfinsuppFamily
-    (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) :
-    MultilinearMap R (fun i => Π₀ j : κ i, M i j) (Π₀ t : Π i, κ i, N t) where
+    (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p)) :
+    MultilinearMap (RingHom.id R) (fun i => Π₀ j : κ i, M i j) (Π₀ t : Π i, κ i, N t) where
   toFun x :=
   { toFun := fun p => f p (fun i => x i (p i))
     support' := (Trunc.finChoice fun i => (x i).support').map fun s => ⟨
@@ -115,7 +115,7 @@ def dfinsuppFamily
 theorem support_dfinsuppFamily_subset
     [∀ i, DecidableEq (κ i)]
     [∀ i j, (x : M i j) → Decidable (x ≠ 0)] [∀ i, (x : N i) → Decidable (x ≠ 0)]
-    (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p))
+    (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p))
     (x : ∀ i, Π₀ j : κ i, M i j) :
     (dfinsuppFamily f x).support ⊆ Fintype.piFinset fun i => (x i).support := by
   intro p hp
@@ -129,12 +129,12 @@ theorem support_dfinsuppFamily_subset
 at that point. -/
 @[simp]
 theorem dfinsuppFamily_single [∀ i, DecidableEq (κ i)]
-    (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p))
+    (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p))
     (p : ∀ i, κ i) (m : ∀ i, M i (p i)) :
     dfinsuppFamily f (fun i => .single (p i) (m i)) = DFinsupp.single p (f p m) := by
   ext q
   obtain rfl | hpq := eq_or_ne q p
-  · simp
+  · simp [dfinsuppFamily]
   · rw [DFinsupp.single_eq_of_ne hpq]
     rw [Function.ne_iff] at hpq
     obtain ⟨i, hpqi⟩ := hpq
@@ -145,42 +145,46 @@ theorem dfinsuppFamily_single [∀ i, DecidableEq (κ i)]
 the component from that member. -/
 @[simp]
 theorem dfinsuppFamily_single_left_apply [∀ i, DecidableEq (κ i)]
-    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) (x : Π i, Π₀ j, M i j) :
+    (p : Π i, κ i) (f : MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p))
+    (x : Π i, Π₀ j, M i j) :
     dfinsuppFamily (Pi.single p f) x = DFinsupp.single p (f fun i => x _ (p i)) := by
   ext p'
   obtain rfl | hp := eq_or_ne p p'
-  · simp
-  · simp [hp]
+  · simp [dfinsuppFamily]
+  · simp [dfinsuppFamily, hp]
 
 theorem dfinsuppFamily_single_left [∀ i, DecidableEq (κ i)]
-    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) :
+    (p : Π i, κ i) (f : MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p)) :
     dfinsuppFamily (Pi.single p f) =
       (DFinsupp.lsingle p).compMultilinearMap (f.compLinearMap fun i => DFinsupp.lapply (p i)) :=
   ext <| dfinsuppFamily_single_left_apply _ _
 
 @[simp]
 theorem dfinsuppFamily_compLinearMap_lsingle [∀ i, DecidableEq (κ i)]
-    (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) (p : ∀ i, κ i) :
+    (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p))
+    (p : ∀ i, κ i) :
     (dfinsuppFamily f).compLinearMap (fun i => DFinsupp.lsingle (p i))
       = (DFinsupp.lsingle p).compMultilinearMap (f p) :=
   MultilinearMap.ext <| dfinsuppFamily_single f p
 
 @[simp]
 theorem dfinsuppFamily_zero :
-    dfinsuppFamily (0 : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) = 0 := by
-  ext; simp
+    dfinsuppFamily (0 : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p))
+      = 0 := by
+  ext; simp [dfinsuppFamily]
 
 @[simp]
-theorem dfinsuppFamily_add (f g : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) :
+theorem dfinsuppFamily_add
+    (f g : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p)) :
     dfinsuppFamily (f + g) = dfinsuppFamily f + dfinsuppFamily g := by
-  ext; simp
+  ext; simp [dfinsuppFamily]
 
 @[simp]
 theorem dfinsuppFamily_smul
     [Monoid S] [∀ p, DistribMulAction S (N p)] [∀ p, SMulCommClass R S (N p)]
-    (s : S) (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) :
+    (s : S) (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p)) :
     dfinsuppFamily (s • f) = s • dfinsuppFamily f := by
-  ext; simp
+  ext; simp [dfinsuppFamily]
 
 end Semiring
 
@@ -193,8 +197,8 @@ variable [∀ i k, Module R (M i k)] [∀ p, Module R (N p)]
 /-- `MultilinearMap.dfinsuppFamily` as a linear map. -/
 @[simps]
 def dfinsuppFamilyₗ :
-    (Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p))
-      →ₗ[R] MultilinearMap R (fun i => Π₀ j : κ i, M i j) (Π₀ t : Π i, κ i, N t) where
+    (Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p))
+      →ₗ[R] MultilinearMap (RingHom.id R) (fun i => Π₀ j : κ i, M i j) (Π₀ t : Π i, κ i, N t) where
   toFun := dfinsuppFamily
   map_add' := dfinsuppFamily_add
   map_smul' := dfinsuppFamily_smul
@@ -205,8 +209,8 @@ variable (R κ) in
 /-- The linear equivalence between families indexed by `p : Π i : ι, κ i` of multilinear maps
 on the `fun i ↦ M i (p i)` and the space of multilinear map on `fun i ↦ Π₀ j : κ i, M i j`. -/
 def fromDFinsuppEquiv :
-    ((p : Π i, κ i) → MultilinearMap R (fun i ↦ M i (p i)) N) ≃ₗ[R]
-      MultilinearMap R (fun i ↦ Π₀ j : κ i, M i j) N :=
+    ((p : Π i, κ i) → MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) N) ≃ₗ[R]
+      MultilinearMap (RingHom.id R) (fun i ↦ Π₀ j : κ i, M i j) N :=
   LinearEquiv.ofLinearMap
     ((DFinsupp.lsum ℕ fun _ ↦ .id).compMultilinearMapₗ R ∘ₗ MultilinearMap.dfinsuppFamilyₗ)
     (LinearMap.pi fun p ↦ MultilinearMap.compLinearMapₗ fun i ↦ DFinsupp.lsingle (p i))
@@ -215,14 +219,14 @@ def fromDFinsuppEquiv :
 
 @[simp]
 theorem fromDFinsuppEquiv_single
-    (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) N)
+    (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) N)
     (p : Π i, κ i) (x : Π i, M i (p i)) :
     fromDFinsuppEquiv κ R f (fun i => DFinsupp.single (p i) (x i)) = f p x := by
   simp [fromDFinsuppEquiv]
 
 theorem fromDFinsuppEquiv_apply
     [Π i (j : κ i) (x : M i j), Decidable (x ≠ 0)]
-    (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) N)
+    (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) N)
     (x : Π i, Π₀ (j : κ i), M i j) :
     fromDFinsuppEquiv κ R f x =
       ∑ p ∈ Fintype.piFinset (fun i ↦ (x i).support), f p (fun i ↦ x i (p i)) := by
@@ -232,8 +236,8 @@ theorem fromDFinsuppEquiv_apply
   simp
 
 @[simp]
-theorem fromDFinsuppEquiv_symm_apply (f : MultilinearMap R (fun i ↦ Π₀ j : κ i, M i j) N)
-    (p : Π i, κ i) :
+theorem fromDFinsuppEquiv_symm_apply
+    (f : MultilinearMap (RingHom.id R) (fun i ↦ Π₀ j : κ i, M i j) N) (p : Π i, κ i) :
     (fromDFinsuppEquiv κ R).symm f p = f.compLinearMap (fun i ↦ DFinsupp.lsingle (p i)) :=
   rfl
 
@@ -252,7 +256,8 @@ the domain and `ι'` on the codomain and the dependent, finitely supported maps 
 `(Π i, κ i) × ι'` into `R`.
 -/
 def freeDFinsuppEquiv :
-    (Π₀ (_ : (Π i, κ i) × ι'), R) ≃ₗ[R] MultilinearMap R (fun i => Π₀ _ : κ i, R) (Π₀ _ : ι', R) :=
+    (Π₀ (_ : (Π i, κ i) × ι'), R) ≃ₗ[R]
+      MultilinearMap (RingHom.id R) (fun i => Π₀ _ : κ i, R) (Π₀ _ : ι', R) :=
   (DFinsupp.domLCongr (M := fun _ => R) (Equiv.sigmaEquivProd _ _).symm) ≪≫ₗ
   (DFinsupp.sigmaCurryLEquiv (M := fun _ _ => R)) ≪≫ₗ
   DFinsupp.linearEquivFunOnFintype ≪≫ₗ

--- a/Mathlib/LinearAlgebra/Multilinear/DirectSum.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/DirectSum.lean
@@ -17,8 +17,9 @@ This file describes multilinear maps on direct sums.
 
 * `MultilinearMap.fromDirectSumEquiv` : If `ι` is a `Fintype`, `κ i` is a family of types
   indexed by `ι` and we are given an `R`-module `M i j` for every `i : ι` and `j : κ i`, this is
-  the linear equivalence between `Π p : (i : ι) → κ i, MultilinearMap R (fun i ↦ M i (p i)) M'` and
-  `MultilinearMap R (fun i ↦ ⨁ j : κ i, M i j) M'`.
+  the linear equivalence between
+  `Π p : (i : ι) → κ i, MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) M'`
+  and `MultilinearMap (RingHom.id R) (fun i ↦ ⨁ j : κ i, M i j) M'`.
 -/
 
 @[expose] public section
@@ -34,7 +35,7 @@ variable [∀ i j, AddCommMonoid (M i j)] [∀ i j, Module R (M i j)] [AddCommMo
 /-- Two multilinear maps from direct sums are equal if they agree on the generators. -/
 @[ext]
 theorem directSum_ext [Finite ι] [(i : ι) → DecidableEq (κ i)]
-    ⦃f g : MultilinearMap R (fun i ↦ ⨁ j : κ i, M i j) M'⦄
+    ⦃f g : MultilinearMap (RingHom.id R) (fun i ↦ ⨁ j : κ i, M i j) M'⦄
     (h : ∀ p : (i : ι) → κ i,
       f.compLinearMap (fun i => DirectSum.lof _ _ _ (p i)) =
       g.compLinearMap (fun i => DirectSum.lof _ _ _ (p i))) : f = g :=
@@ -45,15 +46,15 @@ variable [DecidableEq ι]
 /-- The linear equivalence between families indexed by `p : Π i : ι, κ i` of multilinear maps
 on the `fun i ↦ M i (p i)` and the space of multilinear map on `fun i ↦ ⨁ j : κ i, M i j`. -/
 noncomputable def fromDirectSumEquiv [Finite ι] :
-    ((p : (i : ι) → κ i) → MultilinearMap R (fun i ↦ M i (p i)) M') ≃ₗ[R]
-    MultilinearMap R (fun i ↦ ⨁ j : κ i, M i j) M' :=
+    ((p : (i : ι) → κ i) → MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) M') ≃ₗ[R]
+    MultilinearMap (RingHom.id R) (fun i ↦ ⨁ j : κ i, M i j) M' :=
   haveI : Fintype ι := Fintype.ofFinite ι
   haveI : (i : ι) → DecidableEq (κ i) := fun i ↦ Classical.typeDecidableEq (κ i)
   fromDFinsuppEquiv _ _
 
 @[simp]
 theorem fromDirectSumEquiv_lof [Finite ι] [(i : ι) → DecidableEq (κ i)]
-    (f : (p : (i : ι) → κ i) → MultilinearMap R (fun i ↦ M i (p i)) M')
+    (f : (p : (i : ι) → κ i) → MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) M')
     (p : (i : ι) → κ i) (x : (i : ι) → M i (p i)) :
     fromDirectSumEquiv f (fun i => lof R _ _ _ (x i)) = f p x := by
   have : Fintype ι := Fintype.ofFinite ι
@@ -63,7 +64,7 @@ theorem fromDirectSumEquiv_lof [Finite ι] [(i : ι) → DecidableEq (κ i)]
 /-- Prefer using `fromDirectSumEquiv_lof` where possible. -/
 theorem fromDirectSumEquiv_apply [Fintype ι] [(i : ι) → DecidableEq (κ i)]
     [Π i (j : κ i) (x : M i j), Decidable (x ≠ 0)]
-    (f : (p : (i : ι) → κ i) → MultilinearMap R (fun i ↦ M i (p i)) M')
+    (f : (p : (i : ι) → κ i) → MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) M')
     (x : ⨁ i, ⨁ (j : κ i), M i j) :
     fromDirectSumEquiv f x =
       ∑ p ∈ Fintype.piFinset (fun i ↦ (x i).support), f p (fun i ↦ x i (p i)) := by
@@ -72,7 +73,7 @@ theorem fromDirectSumEquiv_apply [Fintype ι] [(i : ι) → DecidableEq (κ i)]
 
 @[simp]
 theorem fromDirectSumEquiv_symm_apply [Finite ι] [(i : ι) → DecidableEq (κ i)]
-    (f : MultilinearMap R (fun i ↦ ⨁ j : κ i, M i j) M')
+    (f : MultilinearMap (RingHom.id R) (fun i ↦ ⨁ j : κ i, M i j) M')
     (p : (i : ι) → κ i) :
     fromDirectSumEquiv.symm f p = f.compLinearMap (fun i ↦ DirectSum.lof _ _ _ (p i)) := by
   have : Fintype ι := Fintype.ofFinite ι

--- a/Mathlib/LinearAlgebra/Multilinear/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/FiniteDimensional.lean
@@ -32,7 +32,8 @@ variable [Module.Finite R M₂] [Module.Free R M₂]
 
 private theorem free_and_finite_fin (n : ℕ) (N : Fin n → Type*) [∀ i, AddCommGroup (N i)]
     [∀ i, Module R (N i)] [∀ i, Module.Finite R (N i)] [∀ i, Module.Free R (N i)] :
-    Module.Free R (MultilinearMap R N M₂) ∧ Module.Finite R (MultilinearMap R N M₂) := by
+    Module.Free R (MultilinearMap (RingHom.id R) N M₂) ∧
+      Module.Finite R (MultilinearMap (RingHom.id R) N M₂) := by
   induction n with
   | zero =>
     have : IsEmpty (Fin Nat.zero) := inferInstanceAs (IsEmpty (Fin 0))
@@ -41,8 +42,8 @@ private theorem free_and_finite_fin (n : ℕ) (N : Fin n → Type*) [∀ i, AddC
         Module.Finite.equiv (constLinearEquivOfIsEmpty R R N M₂)⟩
   | succ n ih =>
     suffices
-      Module.Free R (N 0 →ₗ[R] MultilinearMap R (fun i : Fin n => N i.succ) M₂) ∧
-        Module.Finite R (N 0 →ₗ[R] MultilinearMap R (fun i : Fin n => N i.succ) M₂) by
+      Module.Free R (N 0 →ₗ[R] MultilinearMap (RingHom.id R) (fun i : Fin n => N i.succ) M₂) ∧
+        Module.Finite R (N 0 →ₗ[R] MultilinearMap (RingHom.id R) (fun i : Fin n => N i.succ) M₂) by
       cases this
       exact
         ⟨Module.Free.of_equiv (multilinearCurryLeftEquiv R N M₂).symm,
@@ -55,7 +56,8 @@ variable [∀ i, Module.Finite R (M₁ i)] [∀ i, Module.Free R (M₁ i)]
 
 -- the induction requires us to show both at once
 private theorem free_and_finite :
-    Module.Free R (MultilinearMap R M₁ M₂) ∧ Module.Finite R (MultilinearMap R M₁ M₂) := by
+    Module.Free R (MultilinearMap (RingHom.id R) M₁ M₂) ∧
+      Module.Finite R (MultilinearMap (RingHom.id R) M₁ M₂) := by
   cases nonempty_fintype ι
   have := @free_and_finite_fin R M₂ _ _ _ _ _ (Fintype.card ι)
     (fun x => M₁ ((Fintype.equivFin ι).symm x))
@@ -63,10 +65,11 @@ private theorem free_and_finite :
   have e := domDomCongrLinearEquiv' R R M₁ M₂ (Fintype.equivFin ι)
   exact ⟨Module.Free.of_equiv e.symm, Module.Finite.equiv e.symm⟩
 
-instance _root_.Module.Finite.multilinearMap : Module.Finite R (MultilinearMap R M₁ M₂) :=
+instance _root_.Module.Finite.multilinearMap :
+    Module.Finite R (MultilinearMap (RingHom.id R) M₁ M₂) :=
   free_and_finite.2
 
-instance _root_.Module.Free.multilinearMap : Module.Free R (MultilinearMap R M₁ M₂) :=
+instance _root_.Module.Free.multilinearMap : Module.Free R (MultilinearMap (RingHom.id R) M₁ M₂) :=
   free_and_finite.1
 
 end MultilinearMap

--- a/Mathlib/LinearAlgebra/Multilinear/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Finsupp.lean
@@ -36,7 +36,8 @@ the domain and `ι'` on the codomain and the finitely supported maps from
 This is the `Finsupp` version of `MultilinearMap.freeDFinsuppEquiv`.
 -/
 noncomputable def freeFinsuppEquiv :
-    (((Π i, κ i) × ι') →₀ R) ≃ₗ[R] MultilinearMap R (fun i => (κ i →₀ R)) (ι' →₀ R) :=
+    (((Π i, κ i) × ι') →₀ R) ≃ₗ[R]
+      MultilinearMap (RingHom.id R) (fun i => (κ i →₀ R)) (ι' →₀ R) :=
   (finsuppLequivDFinsupp R) ≪≫ₗ freeDFinsuppEquiv ≪≫ₗ
   ((finsuppLequivDFinsupp R).multilinearMapCongrRight R).symm ≪≫ₗ
   LinearEquiv.multilinearMapCongrLeft (fun _ => finsuppLequivDFinsupp R)

--- a/Mathlib/LinearAlgebra/Multilinear/Pi.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Pi.lean
@@ -42,7 +42,7 @@ variable [∀ i k, Module R (M i k)] [Module R N]
 This is a multilinear version of `LinearMap.pi_ext`. -/
 @[ext]
 theorem pi_ext [Finite ι] [∀ i, Finite (κ i)] [∀ i, DecidableEq (κ i)]
-    ⦃f g : MultilinearMap R (fun i ↦ Π j : κ i, M i j) N⦄
+    ⦃f g : MultilinearMap (RingHom.id R) (fun i ↦ Π j : κ i, M i j) N⦄
     (h : ∀ p : Π i, κ i,
       f.compLinearMap (fun i => LinearMap.single R _ (p i)) =
       g.compLinearMap (fun i => LinearMap.single R _ (p i))) : f = g := by
@@ -74,8 +74,8 @@ each family, `piFamily f` maps a family of functions (one for each domain `κ i`
 from each selection of indices (with domain `Π i, κ i`).
 -/
 @[simps]
-def piFamily (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) :
-    MultilinearMap R (fun i => Π j : κ i, M i j) (Π t : Π i, κ i, N t) where
+def piFamily (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p)) :
+    MultilinearMap (RingHom.id R) (fun i => Π j : κ i, M i j) (Π t : Π i, κ i, N t) where
   toFun x := fun p => f p (fun i => x i (p i))
   map_update_add' {dec} m i x y := funext fun p => by
     dsimp
@@ -89,12 +89,12 @@ def piFamily (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N
 at that point. -/
 @[simp]
 theorem piFamily_single [Fintype ι] [∀ i, DecidableEq (κ i)]
-    (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p))
+    (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p))
     (p : ∀ i, κ i) (m : ∀ i, M i (p i)) :
     piFamily f (fun i => Pi.single (p i) (m i)) = Pi.single p (f p m) := by
   ext q
   obtain rfl | hpq := eq_or_ne p q
-  · simp
+  · simp [piFamily]
   · rw [Pi.single_eq_of_ne' hpq]
     rw [Function.ne_iff] at hpq
     obtain ⟨i, hpqi⟩ := hpq
@@ -105,42 +105,45 @@ theorem piFamily_single [Fintype ι] [∀ i, DecidableEq (κ i)]
 the component from that member. -/
 @[simp]
 theorem piFamily_single_left_apply [Fintype ι] [∀ i, DecidableEq (κ i)]
-    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) (x : Π i j, M i j) :
+    (p : Π i, κ i) (f : MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p))
+    (x : Π i j, M i j) :
     piFamily (Pi.single p f) x = Pi.single p (f fun i => x i (p i)) := by
   ext p'
   obtain rfl | hp := eq_or_ne p p'
-  · simp
-  · simp [hp]
+  · simp [piFamily]
+  · simp [piFamily, hp]
 
 theorem piFamily_single_left [Fintype ι] [∀ i, DecidableEq (κ i)]
-    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) :
+    (p : Π i, κ i) (f : MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p)) :
     piFamily (Pi.single p f) =
       (LinearMap.single R _ p).compMultilinearMap (f.compLinearMap fun i => .proj (p i)) :=
   ext <| piFamily_single_left_apply _ _
 
 @[simp]
 theorem piFamily_compLinearMap_lsingle [Fintype ι] [∀ i, DecidableEq (κ i)]
-    (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) (p : ∀ i, κ i) :
+    (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p)) (p : ∀ i, κ i) :
     (piFamily f).compLinearMap (fun i => LinearMap.single _ _ (p i))
       = (LinearMap.single _ _ p).compMultilinearMap (f p) :=
   MultilinearMap.ext <| piFamily_single f p
 
 @[simp]
 theorem piFamily_zero :
-    piFamily (0 : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) = 0 := by
-  ext; simp
+    piFamily (0 : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p))
+      = 0 := by
+  ext; simp [piFamily]
 
 @[simp]
-theorem piFamily_add (f g : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) :
+theorem piFamily_add
+    (f g : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p)) :
     piFamily (f + g) = piFamily f + piFamily g := by
-  ext; simp
+  ext; simp [piFamily]
 
 @[simp]
 theorem piFamily_smul
     [Monoid S] [∀ p, DistribMulAction S (N p)] [∀ p, SMulCommClass R S (N p)]
-    (s : S) (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) :
+    (s : S) (f : Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p)) :
     piFamily (s • f) = s • piFamily f := by
-  ext; simp
+  ext; simp [piFamily]
 
 end Semiring
 
@@ -153,8 +156,8 @@ variable [∀ i k, Module R (M i k)] [∀ p, Module R (N p)]
 /-- `MultilinearMap.piFamily` as a linear map. -/
 @[simps]
 def piFamilyₗ :
-    (Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p))
-      →ₗ[R] MultilinearMap R (fun i => Π j : κ i, M i j) (Π t : Π i, κ i, N t) where
+    (Π (p : Π i, κ i), MultilinearMap (RingHom.id R) (fun i ↦ M i (p i)) (N p))
+      →ₗ[R] MultilinearMap (RingHom.id R) (fun i => Π j : κ i, M i j) (Π t : Π i, κ i, N t) where
   toFun := piFamily
   map_add' := piFamily_add
   map_smul' := piFamily_smul

--- a/Mathlib/LinearAlgebra/Multilinear/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/TensorProduct.lean
@@ -35,10 +35,9 @@ variable {N : ι₁ ⊕ ι₂ → Type*} [∀ i, AddCommMonoid (N i)] [∀ i, Mo
 a multilinear map from the modules `N (.inl i₁)` to `N₁` and
 a multilinear map from the modules `N (.inr i₁)` to `N₂`, this
 is the induced multilinear map from all the modules `N i` to `N₁ ⊗ N₂`. -/
-@[simps apply]
-def domCoprodDep (a : MultilinearMap R (fun i₁ ↦ N (.inl i₁)) N₁)
-    (b : MultilinearMap R (fun i₂ ↦ N (.inr i₂)) N₂) :
-    MultilinearMap R N (N₁ ⊗[R] N₂) where
+def domCoprodDep (a : MultilinearMap (RingHom.id R) (fun i₁ ↦ N (.inl i₁)) N₁)
+    (b : MultilinearMap (RingHom.id R) (fun i₂ ↦ N (.inr i₂)) N₂) :
+    MultilinearMap (RingHom.id R) N (N₁ ⊗[R] N₂) where
   toFun v := a (fun i₁ ↦ v (.inl i₁)) ⊗ₜ b (fun i₂ ↦ v (.inr i₂))
   map_update_add' := by
     rintro _ _ (_ | _) _ _
@@ -49,17 +48,27 @@ def domCoprodDep (a : MultilinearMap R (fun i₁ ↦ N (.inl i₁)) N₁)
     · let := Classical.decEq ι₁; simp
     · let := Classical.decEq ι₂; simp
 
+@[simp]
+theorem domCoprodDep_apply (a : MultilinearMap (RingHom.id R) (fun i₁ ↦ N (.inl i₁)) N₁)
+    (b : MultilinearMap (RingHom.id R) (fun i₂ ↦ N (.inr i₂)) N₂)
+    (v : ∀ i, N i) :
+    a.domCoprodDep b v = a (fun i₁ ↦ v (.inl i₁)) ⊗ₜ b (fun i₂ ↦ v (.inr i₂)) := rfl
+
 /-- A more bundled version of `MultilinearMap.domCoprodDep`, as a linear map
 from the tensor product of spaces of multilinear maps. -/
 def domCoprodDep' :
-    MultilinearMap R (fun i₁ ↦ N (.inl i₁)) N₁ ⊗[R] MultilinearMap R (fun i₂ ↦ N (.inr i₂)) N₂ →ₗ[R]
-        MultilinearMap R N (N₁ ⊗[R] N₂) :=
+    MultilinearMap (RingHom.id R) (fun i₁ ↦ N (.inl i₁)) N₁ ⊗[R]
+        MultilinearMap (RingHom.id R) (fun i₂ ↦ N (.inr i₂)) N₂ →ₗ[R]
+      MultilinearMap (RingHom.id R) N (N₁ ⊗[R] N₂) :=
   TensorProduct.lift (LinearMap.mk₂ R domCoprodDep
-    (by aesop) (by aesop) (by aesop) (by aesop))
+    (fun _ _ _ => by ext; simp [domCoprodDep, add_tmul])
+    (fun _ _ _ => by ext; simp [domCoprodDep])
+    (fun _ _ _ => by ext; simp [domCoprodDep, tmul_add])
+    (fun _ _ _ => by ext; simp [domCoprodDep, tmul_smul]))
 
 @[simp]
-theorem domCoprodDep'_apply (a : MultilinearMap R (fun i₁ ↦ N (.inl i₁)) N₁)
-    (b : MultilinearMap R (fun i₂ ↦ N (.inr i₂)) N₂) :
+theorem domCoprodDep'_apply (a : MultilinearMap (RingHom.id R) (fun i₁ ↦ N (.inl i₁)) N₁)
+    (b : MultilinearMap (RingHom.id R) (fun i₂ ↦ N (.inr i₂)) N₂) :
     domCoprodDep' (a ⊗ₜ b) = domCoprodDep a b := by
   rfl
 
@@ -81,27 +90,29 @@ to the simple case defined here. See
 [this zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Instances.20on.20.60sum.2Eelim.20A.20B.20i.60/near/218484619).
 -/
 @[simps! apply]
-def domCoprod (a : MultilinearMap R (fun _ : ι₁ => N) N₁)
-    (b : MultilinearMap R (fun _ : ι₂ => N) N₂) :
-    MultilinearMap R (fun _ : ι₁ ⊕ ι₂ => N) (N₁ ⊗[R] N₂) :=
+def domCoprod (a : MultilinearMap (RingHom.id R) (fun _ : ι₁ => N) N₁)
+    (b : MultilinearMap (RingHom.id R) (fun _ : ι₂ => N) N₂) :
+    MultilinearMap (RingHom.id R) (fun _ : ι₁ ⊕ ι₂ => N) (N₁ ⊗[R] N₂) :=
   domCoprodDep a b
 
 /-- A more bundled version of `MultilinearMap.domCoprod` that maps
 `((ι₁ → N) → N₁) ⊗ ((ι₂ → N) → N₂)` to `(ι₁ ⊕ ι₂ → N) → N₁ ⊗ N₂`. -/
 def domCoprod' :
-    MultilinearMap R (fun _ : ι₁ => N) N₁ ⊗[R] MultilinearMap R (fun _ : ι₂ => N) N₂ →ₗ[R]
-      MultilinearMap R (fun _ : ι₁ ⊕ ι₂ => N) (N₁ ⊗[R] N₂) :=
+    MultilinearMap (RingHom.id R) (fun _ : ι₁ => N) N₁ ⊗[R]
+        MultilinearMap (RingHom.id R) (fun _ : ι₂ => N) N₂ →ₗ[R]
+      MultilinearMap (RingHom.id R) (fun _ : ι₁ ⊕ ι₂ => N) (N₁ ⊗[R] N₂) :=
   domCoprodDep' (R := R) (N := fun (_ : ι₁ ⊕ ι₂) ↦ N)
 
 @[simp]
-theorem domCoprod'_apply (a : MultilinearMap R (fun _ : ι₁ => N) N₁)
-    (b : MultilinearMap R (fun _ : ι₂ => N) N₂) : domCoprod' (a ⊗ₜ[R] b) = domCoprod a b :=
+theorem domCoprod'_apply (a : MultilinearMap (RingHom.id R) (fun _ : ι₁ => N) N₁)
+    (b : MultilinearMap (RingHom.id R) (fun _ : ι₂ => N) N₂) :
+    domCoprod' (a ⊗ₜ[R] b) = domCoprod a b :=
   rfl
 
 /-- When passed an `Equiv.sumCongr`, `MultilinearMap.domDomCongr` distributes over
 `MultilinearMap.domCoprod`. -/
-theorem domCoprod_domDomCongr_sumCongr (a : MultilinearMap R (fun _ : ι₁ => N) N₁)
-    (b : MultilinearMap R (fun _ : ι₂ => N) N₂) (σa : ι₁ ≃ ι₃) (σb : ι₂ ≃ ι₄) :
+theorem domCoprod_domDomCongr_sumCongr (a : MultilinearMap (RingHom.id R) (fun _ : ι₁ => N) N₁)
+    (b : MultilinearMap (RingHom.id R) (fun _ : ι₂ => N) N₂) (σa : ι₁ ≃ ι₃) (σb : ι₂ ≃ ι₄) :
     (a.domCoprod b).domDomCongr (σa.sumCongr σb) =
       (a.domDomCongr σa).domCoprod (b.domDomCongr σb) :=
   rfl

--- a/Mathlib/LinearAlgebra/PiTensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct/Basic.lean
@@ -402,49 +402,6 @@ section lift
 variable {R' : Type*} [CommSemiring R'] {σ : R →+* R'}
   {E' : Type*} [AddCommMonoid E'] [Module R' E']
 
-/-- Composition of a `MultilinearMap (RingHom.id R) M₁ M₂` with a semilinear `M₂ →ₛₗ[σ] M₃`,
-producing a `MultilinearMap σ M₁ M₃`. -/
-def _root_.LinearMap.compMultilinearMapₛₗ
-    {M₂ M₃ : Type*} [AddCommMonoid M₂] [Module R M₂] [AddCommMonoid M₃] [Module R' M₃]
-    (g : M₂ →ₛₗ[σ] M₃) (f : MultilinearMap (RingHom.id R) (fun i ↦ s i) M₂) :
-    MultilinearMap σ (fun i ↦ s i) M₃ where
-  toFun m := g (f m)
-  map_update_add' m i x y := by simp
-  map_update_smul' m i c x := by simp [g.map_smulₛₗ]
-
-@[simp]
-theorem _root_.LinearMap.compMultilinearMapₛₗ_apply
-    {M₂ M₃ : Type*} [AddCommMonoid M₂] [Module R M₂] [AddCommMonoid M₃] [Module R' M₃]
-    (g : M₂ →ₛₗ[σ] M₃) (f : MultilinearMap (RingHom.id R) (fun i ↦ s i) M₂) (m : Π i, s i) :
-    g.compMultilinearMapₛₗ f m = g (f m) :=
-  rfl
-
-/-- Composes a multilinear map `g : MultilinearMap (RingHom.id R') M₁' M₂` with a family of
-σ-semilinear maps `f : Π i, sᵢ →ₛₗ[σ] M₁' i` (where σ : R →+* R'), producing a σ-semilinear
-multilinear map `MultilinearMap σ s M₂`. -/
-def _root_.MultilinearMap.compLinearMapₛₗ
-    {M₁' : ι → Type*} [∀ i, AddCommMonoid (M₁' i)] [∀ i, Module R' (M₁' i)]
-    {M₂ : Type*} [AddCommMonoid M₂] [Module R' M₂]
-    (g : MultilinearMap (RingHom.id R') M₁' M₂) (f : ∀ i, s i →ₛₗ[σ] M₁' i) :
-    MultilinearMap σ s M₂ where
-  toFun m := g fun i ↦ f i (m i)
-  map_update_add' m i x y := by
-    have h : ∀ j z, f j (update m i z j) = update (fun k ↦ f k (m k)) i (f i z) j :=
-      fun j z ↦ Function.apply_update (fun k ↦ f k) _ _ _ _
-    simp [h]
-  map_update_smul' m i c x := by
-    have h : ∀ j z, f j (update m i z j) = update (fun k ↦ f k (m k)) i (f i z) j :=
-      fun j z ↦ Function.apply_update (fun k ↦ f k) _ _ _ _
-    simp [h, (f i).map_smulₛₗ]
-
-@[simp]
-theorem _root_.MultilinearMap.compLinearMapₛₗ_apply
-    {M₁' : ι → Type*} [∀ i, AddCommMonoid (M₁' i)] [∀ i, Module R' (M₁' i)]
-    {M₂ : Type*} [AddCommMonoid M₂] [Module R' M₂]
-    (g : MultilinearMap (RingHom.id R') M₁' M₂) (f : ∀ i, s i →ₛₗ[σ] M₁' i) (m : ∀ i, s i) :
-    g.compLinearMapₛₗ f m = g fun i ↦ f i (m i) :=
-  rfl
-
 /-- Auxiliary function to constructing a semilinear map `(⨂[R] i, s i) → E'` given a
 semilinear `MultilinearMap σ s E'` with the property that its composition with the canonical
 `MultilinearMap (RingHom.id R) s (⨂[R] i, s i)` is the given multilinear map.
@@ -495,13 +452,13 @@ This is a linear equivalence over `R'` (the codomain ring of `σ`). When `σ = R
 specializes to the original linear `lift`. -/
 def lift : MultilinearMap σ s E' ≃ₗ[R'] (⨂[R] i, s i) →ₛₗ[σ] E' where
   toFun φ := { liftAux φ with map_smul' := liftAux.smulₛₗ }
-  invFun φ' := φ'.compMultilinearMapₛₗ (tprod R)
+  invFun φ' := φ'.compMultilinearMap (tprod R)
   left_inv φ := by
     ext
-    simp [liftAux_tprod, LinearMap.compMultilinearMapₛₗ]
+    simp [liftAux_tprod, LinearMap.compMultilinearMap]
   right_inv φ := by
     ext
-    simp [liftAux_tprod, LinearMap.compMultilinearMapₛₗ]
+    simp [liftAux_tprod, LinearMap.compMultilinearMap]
   map_add' φ₁ φ₂ := by
     ext
     simp [liftAux_tprod]
@@ -520,12 +477,12 @@ theorem lift.unique {φ' : (⨂[R] i, s i) →ₛₗ[σ] E'} (H : ∀ f, φ' (Pi
   ext_iff_tprod.mpr fun f ↦ by rw [H, lift.tprod]
 
 theorem lift.unique' {φ' : (⨂[R] i, s i) →ₛₗ[σ] E'}
-    (H : φ'.compMultilinearMapₛₗ (PiTensorProduct.tprod R) = φ) : φ' = lift φ :=
+    (H : φ'.compMultilinearMap (PiTensorProduct.tprod R) = φ) : φ' = lift φ :=
   lift.unique fun f ↦ MultilinearMap.congr_fun H f
 
 @[simp]
 theorem lift_symm (φ' : (⨂[R] i, s i) →ₛₗ[σ] E') :
-    lift.symm φ' = φ'.compMultilinearMapₛₗ (tprod R) :=
+    lift.symm φ' = φ'.compMultilinearMap (tprod R) :=
   rfl
 
 @[simp]
@@ -552,7 +509,7 @@ This is `TensorProduct.map` for an arbitrary family of modules. -/
 def map {R' : Type*} [CommSemiring R'] {σ : R →+* R'}
     {u : ι → Type*} [∀ i, AddCommMonoid (u i)] [∀ i, Module R' (u i)]
     (f : Π i, s i →ₛₗ[σ] u i) : (⨂[R] i, s i) →ₛₗ[σ] ⨂[R'] i, u i :=
-  lift <| (tprod R').compLinearMapₛₗ f
+  lift <| (tprod R').compLinearMap f
 
 @[simp] lemma map_tprod {R' : Type*} [CommSemiring R'] {σ : R →+* R'}
     {u : ι → Type*} [∀ i, AddCommMonoid (u i)] [∀ i, Module R' (u i)]

--- a/Mathlib/LinearAlgebra/PiTensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct/Basic.lean
@@ -25,7 +25,7 @@ binary tensor product in `Mathlib/LinearAlgebra/TensorProduct/Basic.lean`.
   This is bundled as a multilinear map from `Π i, s i` to `⨂[R] i, s i`.
 * `liftAddHom` constructs an `AddMonoidHom` from `(⨂[R] i, s i)` to some space `F` from a
   function `φ : (R × Π i, s i) → F` with the appropriate properties.
-* `lift φ` with `φ : MultilinearMap R s E` is the corresponding linear map
+* `lift φ` with `φ : MultilinearMap (RingHom.id R) s E` is the corresponding linear map
   `(⨂[R] i, s i) →ₗ[R] E`. This is bundled as a linear equivalence.
 * `PiTensorProduct.reindex e` re-indexes the components of `⨂[R] i : ι, M` along `e : ι ≃ ι₂`.
 * `PiTensorProduct.tmulEquiv` equivalence between a `TensorProduct` of `PiTensorProduct`s and
@@ -272,20 +272,21 @@ instance : IsScalarTower R R (⨂[R] i, s i) :=
   PiTensorProduct.isScalarTower'
 
 variable (R) in
-/-- The canonical `MultilinearMap R s (⨂[R] i, s i)`.
+/-- The canonical `MultilinearMap (RingHom.id R) s (⨂[R] i, s i)`.
 
 `tprod R fun i => f i` has notation `⨂ₜ[R] i, f i`. -/
-def tprod : MultilinearMap R s (⨂[R] i, s i) where
+def tprod : MultilinearMap (RingHom.id R) s (⨂[R] i, s i) where
   toFun := tprodCoeff R 1
   map_update_add' {_ f} i x y := (add_tprodCoeff (1 : R) f i x y).symm
   map_update_smul' {_ f} i r x := by
+    simp only [RingHom.id_apply]
     rw [smul_tprodCoeff', ← smul_tprodCoeff (1 : R) _ i, update_idem, update_self]
 
 @[inherit_doc tprod]
 notation3:100 "⨂ₜ["R"] "(...)", "r:(scoped f => tprod R f) => r
 
 theorem tprod_eq_tprodCoeff_one :
-    ⇑(tprod R : MultilinearMap R s (⨂[R] i, s i)) = tprodCoeff R 1 := rfl
+    ⇑(tprod R : MultilinearMap (RingHom.id R) s (⨂[R] i, s i)) = tprodCoeff R 1 := rfl
 
 @[simp]
 theorem tprodCoeff_eq_smul_tprod (z : R) (f : Π i, s i) : tprodCoeff R z f = z • tprod R f := by
@@ -360,16 +361,24 @@ protected theorem induction_on {motive : (⨂[R] i, s i) → Prop} (z : ⨂[R] i
   simp_rw [← tprodCoeff_eq_smul_tprod] at smul_tprod
   exact PiTensorProduct.induction_on' z smul_tprod add
 
+/-- Two semilinear maps out of a `PiTensorProduct` agree iff they agree on all `tprod R f`. -/
+theorem ext_iff_tprod {R' : Type*} [CommSemiring R'] {σ : R →+* R'} {E' : Type*}
+    [AddCommMonoid E'] [Module R' E'] {φ₁ φ₂ : (⨂[R] i, s i) →ₛₗ[σ] E'} :
+    φ₁ = φ₂ ↔ ∀ f : Π i, s i, φ₁ (tprod R f) = φ₂ (tprod R f) := by
+  refine ⟨fun h _ ↦ h ▸ rfl, fun H ↦ LinearMap.ext fun z ↦ ?_⟩
+  refine PiTensorProduct.induction_on' z ?_ fun {x y} hx hy ↦ by rw [φ₁.map_add, φ₂.map_add, hx, hy]
+  intro r f
+  rw [tprodCoeff_eq_smul_tprod, φ₁.map_smulₛₗ, φ₂.map_smulₛₗ, H]
+
 @[ext]
+theorem extₛₗ {R' : Type*} [CommSemiring R'] {σ : R →+* R'} {E' : Type*}
+    [AddCommMonoid E'] [Module R' E'] {φ₁ φ₂ : (⨂[R] i, s i) →ₛₗ[σ] E'}
+    (H : ∀ f : Π i, s i, φ₁ (tprod R f) = φ₂ (tprod R f)) : φ₁ = φ₂ :=
+  ext_iff_tprod.mpr H
+
 theorem ext {φ₁ φ₂ : (⨂[R] i, s i) →ₗ[R] E}
-    (H : φ₁.compMultilinearMap (tprod R) = φ₂.compMultilinearMap (tprod R)) : φ₁ = φ₂ := by
-  refine LinearMap.ext ?_
-  refine fun z ↦
-    PiTensorProduct.induction_on' z ?_ fun {x y} hx hy ↦ by rw [φ₁.map_add, φ₂.map_add, hx, hy]
-  · intro r f
-    rw [tprodCoeff_eq_smul_tprod, φ₁.map_smul, φ₂.map_smul]
-    apply congr_arg
-    exact MultilinearMap.congr_fun H f
+    (H : φ₁.compMultilinearMap (tprod R) = φ₂.compMultilinearMap (tprod R)) : φ₁ = φ₂ :=
+  ext_iff_tprod.mpr fun f ↦ MultilinearMap.congr_fun H f
 
 /-- The pure tensors (i.e. the elements of the image of `PiTensorProduct.tprod`) span
 the tensor product. -/
@@ -390,18 +399,69 @@ variable {s}
 
 section lift
 
-/-- Auxiliary function to constructing a linear map `(⨂[R] i, s i) → E` given a
-`MultilinearMap R s E` with the property that its composition with the canonical
-`MultilinearMap R s (⨂[R] i, s i)` is the given multilinear map. -/
-def liftAux (φ : MultilinearMap R s E) : (⨂[R] i, s i) →+ E :=
-  liftAddHom (fun p : R × Π i, s i ↦ p.1 • φ p.2)
-    (fun z f i hf ↦ by simp_rw [map_coord_zero φ i hf, smul_zero])
-    (fun f ↦ by simp_rw [zero_smul])
-    (fun z f i m₁ m₂ ↦ by simp_rw [← smul_add, φ.map_update_add])
-    (fun z₁ z₂ f ↦ by rw [← add_smul])
-    fun z f i r ↦ by simp [φ.map_update_smul, smul_smul, mul_comm]
+variable {R' : Type*} [CommSemiring R'] {σ : R →+* R'}
+  {E' : Type*} [AddCommMonoid E'] [Module R' E']
 
-theorem liftAux_tprod (φ : MultilinearMap R s E) (f : Π i, s i) : liftAux φ (tprod R f) = φ f := by
+/-- Composition of a `MultilinearMap (RingHom.id R) M₁ M₂` with a semilinear `M₂ →ₛₗ[σ] M₃`,
+producing a `MultilinearMap σ M₁ M₃`. -/
+def _root_.LinearMap.compMultilinearMapₛₗ
+    {M₂ M₃ : Type*} [AddCommMonoid M₂] [Module R M₂] [AddCommMonoid M₃] [Module R' M₃]
+    (g : M₂ →ₛₗ[σ] M₃) (f : MultilinearMap (RingHom.id R) (fun i ↦ s i) M₂) :
+    MultilinearMap σ (fun i ↦ s i) M₃ where
+  toFun m := g (f m)
+  map_update_add' m i x y := by simp
+  map_update_smul' m i c x := by simp [g.map_smulₛₗ]
+
+@[simp]
+theorem _root_.LinearMap.compMultilinearMapₛₗ_apply
+    {M₂ M₃ : Type*} [AddCommMonoid M₂] [Module R M₂] [AddCommMonoid M₃] [Module R' M₃]
+    (g : M₂ →ₛₗ[σ] M₃) (f : MultilinearMap (RingHom.id R) (fun i ↦ s i) M₂) (m : Π i, s i) :
+    g.compMultilinearMapₛₗ f m = g (f m) :=
+  rfl
+
+/-- Composes a multilinear map `g : MultilinearMap (RingHom.id R') M₁' M₂` with a family of
+σ-semilinear maps `f : Π i, sᵢ →ₛₗ[σ] M₁' i` (where σ : R →+* R'), producing a σ-semilinear
+multilinear map `MultilinearMap σ s M₂`. -/
+def _root_.MultilinearMap.compLinearMapₛₗ
+    {M₁' : ι → Type*} [∀ i, AddCommMonoid (M₁' i)] [∀ i, Module R' (M₁' i)]
+    {M₂ : Type*} [AddCommMonoid M₂] [Module R' M₂]
+    (g : MultilinearMap (RingHom.id R') M₁' M₂) (f : ∀ i, s i →ₛₗ[σ] M₁' i) :
+    MultilinearMap σ s M₂ where
+  toFun m := g fun i ↦ f i (m i)
+  map_update_add' m i x y := by
+    have h : ∀ j z, f j (update m i z j) = update (fun k ↦ f k (m k)) i (f i z) j :=
+      fun j z ↦ Function.apply_update (fun k ↦ f k) _ _ _ _
+    simp [h]
+  map_update_smul' m i c x := by
+    have h : ∀ j z, f j (update m i z j) = update (fun k ↦ f k (m k)) i (f i z) j :=
+      fun j z ↦ Function.apply_update (fun k ↦ f k) _ _ _ _
+    simp [h, (f i).map_smulₛₗ]
+
+@[simp]
+theorem _root_.MultilinearMap.compLinearMapₛₗ_apply
+    {M₁' : ι → Type*} [∀ i, AddCommMonoid (M₁' i)] [∀ i, Module R' (M₁' i)]
+    {M₂ : Type*} [AddCommMonoid M₂] [Module R' M₂]
+    (g : MultilinearMap (RingHom.id R') M₁' M₂) (f : ∀ i, s i →ₛₗ[σ] M₁' i) (m : ∀ i, s i) :
+    g.compLinearMapₛₗ f m = g fun i ↦ f i (m i) :=
+  rfl
+
+/-- Auxiliary function to constructing a semilinear map `(⨂[R] i, s i) → E'` given a
+semilinear `MultilinearMap σ s E'` with the property that its composition with the canonical
+`MultilinearMap (RingHom.id R) s (⨂[R] i, s i)` is the given multilinear map.
+
+When `σ = RingHom.id R` (so `R' = R`, `E' = E`), this recovers the linear case. -/
+def liftAux (φ : MultilinearMap σ s E') : (⨂[R] i, s i) →+ E' :=
+  liftAddHom (fun p : R × Π i, s i ↦ σ p.1 • φ p.2)
+    (fun z f i hf ↦ by dsimp only; rw [φ.map_coord_zero i hf, smul_zero])
+    (fun f ↦ by dsimp only; rw [_root_.map_zero, zero_smul])
+    (fun z f i m₁ m₂ ↦ by dsimp only; rw [← smul_add, φ.map_update_add])
+    (fun z₁ z₂ f ↦ by dsimp only; rw [← add_smul, ← _root_.map_add])
+    fun z f i r ↦ by
+      dsimp only
+      rw [φ.map_update_smulₛₗ, smul_smul, ← _root_.map_mul, mul_comm, update_eq_self]
+
+theorem liftAux_tprod (φ : MultilinearMap σ s E') (f : Π i, s i) :
+    liftAux φ (tprod R f) = φ f := by
   simp only [liftAux, liftAddHom, tprod_eq_tprodCoeff_one, tprodCoeff, AddCon.coe_mk']
   -- The end of this proof was very different before https://github.com/leanprover/lean4/pull/2644:
   -- rw [FreeAddMonoid.of, FreeAddMonoid.ofList, Equiv.refl_apply, AddCon.lift_coe]
@@ -411,29 +471,37 @@ theorem liftAux_tprod (φ : MultilinearMap R s E) (f : Π i, s i) : liftAux φ (
   conv_lhs => apply AddCon.lift_coe
   simp
 
-theorem liftAux_tprodCoeff (φ : MultilinearMap R s E) (z : R) (f : Π i, s i) :
-    liftAux φ (tprodCoeff R z f) = z • φ f := rfl
+theorem liftAux_tprodCoeff (φ : MultilinearMap σ s E') (z : R) (f : Π i, s i) :
+    liftAux φ (tprodCoeff R z f) = σ z • φ f := rfl
 
-theorem liftAux.smul {φ : MultilinearMap R s E} (r : R) (x : ⨂[R] i, s i) :
-    liftAux φ (r • x) = r • liftAux φ x := by
+theorem liftAux.smulₛₗ {φ : MultilinearMap σ s E'} (r : R) (x : ⨂[R] i, s i) :
+    liftAux φ (r • x) = σ r • liftAux φ x := by
   refine PiTensorProduct.induction_on' x ?_ ?_
   · intro z f
-    rw [smul_tprodCoeff' r z f, liftAux_tprodCoeff, liftAux_tprodCoeff, smul_assoc]
+    rw [smul_tprodCoeff' r z f, liftAux_tprodCoeff, liftAux_tprodCoeff, smul_eq_mul,
+      _root_.map_mul, mul_smul]
   · intro z y ihz ihy
     rw [smul_add, (liftAux φ).map_add, ihz, ihy, (liftAux φ).map_add, smul_add]
 
-/-- Constructing a linear map `(⨂[R] i, s i) → E` given a `MultilinearMap R s E` with the
-property that its composition with the canonical `MultilinearMap R s E` is
-the given multilinear map `φ`. -/
-def lift : MultilinearMap R s E ≃ₗ[R] (⨂[R] i, s i) →ₗ[R] E where
-  toFun φ := { liftAux φ with map_smul' := liftAux.smul }
-  invFun φ' := φ'.compMultilinearMap (tprod R)
+theorem liftAux.smul {φ : MultilinearMap (RingHom.id R) s E} (r : R) (x : ⨂[R] i, s i) :
+    liftAux φ (r • x) = r • liftAux φ x :=
+  liftAux.smulₛₗ r x
+
+/-- Constructing a semilinear map `(⨂[R] i, s i) → E'` given a `MultilinearMap σ s E'` with the
+property that its composition with the canonical `MultilinearMap (RingHom.id R) s (⨂[R] i, s i)` is
+the given multilinear map `φ`.
+
+This is a linear equivalence over `R'` (the codomain ring of `σ`). When `σ = RingHom.id R`,
+specializes to the original linear `lift`. -/
+def lift : MultilinearMap σ s E' ≃ₗ[R'] (⨂[R] i, s i) →ₛₗ[σ] E' where
+  toFun φ := { liftAux φ with map_smul' := liftAux.smulₛₗ }
+  invFun φ' := φ'.compMultilinearMapₛₗ (tprod R)
   left_inv φ := by
     ext
-    simp [liftAux_tprod, LinearMap.compMultilinearMap]
+    simp [liftAux_tprod, LinearMap.compMultilinearMapₛₗ]
   right_inv φ := by
     ext
-    simp [liftAux_tprod]
+    simp [liftAux_tprod, LinearMap.compMultilinearMapₛₗ]
   map_add' φ₁ φ₂ := by
     ext
     simp [liftAux_tprod]
@@ -441,26 +509,27 @@ def lift : MultilinearMap R s E ≃ₗ[R] (⨂[R] i, s i) →ₗ[R] E where
     ext
     simp [liftAux_tprod]
 
-variable {φ : MultilinearMap R s E}
+variable {φ : MultilinearMap σ s E'}
 
 @[simp]
 theorem lift.tprod (f : Π i, s i) : lift φ (tprod R f) = φ f :=
   liftAux_tprod φ f
 
-theorem lift.unique' {φ' : (⨂[R] i, s i) →ₗ[R] E}
-    (H : φ'.compMultilinearMap (PiTensorProduct.tprod R) = φ) : φ' = lift φ :=
-  ext <| H.symm ▸ (lift.symm_apply_apply φ).symm
-
-theorem lift.unique {φ' : (⨂[R] i, s i) →ₗ[R] E} (H : ∀ f, φ' (PiTensorProduct.tprod R f) = φ f) :
+theorem lift.unique {φ' : (⨂[R] i, s i) →ₛₗ[σ] E'} (H : ∀ f, φ' (PiTensorProduct.tprod R f) = φ f) :
     φ' = lift φ :=
-  lift.unique' (MultilinearMap.ext H)
+  ext_iff_tprod.mpr fun f ↦ by rw [H, lift.tprod]
+
+theorem lift.unique' {φ' : (⨂[R] i, s i) →ₛₗ[σ] E'}
+    (H : φ'.compMultilinearMapₛₗ (PiTensorProduct.tprod R) = φ) : φ' = lift φ :=
+  lift.unique fun f ↦ MultilinearMap.congr_fun H f
 
 @[simp]
-theorem lift_symm (φ' : (⨂[R] i, s i) →ₗ[R] E) : lift.symm φ' = φ'.compMultilinearMap (tprod R) :=
+theorem lift_symm (φ' : (⨂[R] i, s i) →ₛₗ[σ] E') :
+    lift.symm φ' = φ'.compMultilinearMapₛₗ (tprod R) :=
   rfl
 
 @[simp]
-theorem lift_tprod : lift (tprod R : MultilinearMap R s _) = LinearMap.id :=
+theorem lift_tprod : lift (tprod R : MultilinearMap (RingHom.id R) s _) = LinearMap.id :=
   Eq.symm <| lift.unique' rfl
 
 end lift
@@ -473,17 +542,22 @@ variable [∀ i, AddCommMonoid (t' i)] [∀ i, Module R (t' i)]
 variable (g : Π i, t i →ₗ[R] t' i) (f : Π i, s i →ₗ[R] t i)
 
 /--
-Let `sᵢ` and `tᵢ` be two families of `R`-modules.
-Let `f` be a family of `R`-linear maps between `sᵢ` and `tᵢ`, i.e. `f : Πᵢ sᵢ → tᵢ`,
-then there is an induced map `⨂ᵢ sᵢ → ⨂ᵢ tᵢ` by `⨂ aᵢ ↦ ⨂ fᵢ aᵢ`.
+Let `sᵢ` be a family of `R`-modules and `uᵢ` a family of `R'`-modules, where `σ : R →+* R'`.
+Let `f` be a family of `σ`-semilinear maps `Πᵢ sᵢ →ₛₗ[σ] uᵢ`. Then there is an induced
+σ-semilinear map `⨂ᵢ sᵢ →ₛₗ[σ] ⨂ᵢ uᵢ` by `⨂ aᵢ ↦ ⨂ fᵢ aᵢ`.
 
-This is `TensorProduct.map` for an arbitrary family of modules.
--/
-def map : (⨂[R] i, s i) →ₗ[R] ⨂[R] i, t i :=
-  lift <| (tprod R).compLinearMap f
+When `σ = RingHom.id R` (so `R' = R`), this recovers the linear `PiTensorProduct.map`.
 
-@[simp] lemma map_tprod (x : Π i, s i) :
-    map f (tprod R x) = tprod R fun i ↦ f i (x i) :=
+This is `TensorProduct.map` for an arbitrary family of modules. -/
+def map {R' : Type*} [CommSemiring R'] {σ : R →+* R'}
+    {u : ι → Type*} [∀ i, AddCommMonoid (u i)] [∀ i, Module R' (u i)]
+    (f : Π i, s i →ₛₗ[σ] u i) : (⨂[R] i, s i) →ₛₗ[σ] ⨂[R'] i, u i :=
+  lift <| (tprod R').compLinearMapₛₗ f
+
+@[simp] lemma map_tprod {R' : Type*} [CommSemiring R'] {σ : R →+* R'}
+    {u : ι → Type*} [∀ i, AddCommMonoid (u i)] [∀ i, Module R' (u i)]
+    (f : Π i, s i →ₛₗ[σ] u i) (x : Π i, s i) :
+    map f (tprod R x) = tprod R' fun i ↦ f i (x i) :=
   lift.tprod _
 
 -- No lemmas about associativity, because we don't have associativity of `PiTensorProduct` yet.
@@ -504,13 +578,13 @@ def mapIncl (p : Π i, Submodule R (s i)) : (⨂[R] i, p i) →ₗ[R] ⨂[R] i, 
 
 theorem map_comp : map (fun (i : ι) ↦ g i ∘ₗ f i) = map g ∘ₗ map f := by
   ext
-  simp only [LinearMap.compMultilinearMap_apply, map_tprod, LinearMap.coe_comp, Function.comp_apply]
+  simp only [map_tprod, LinearMap.coe_comp, Function.comp_apply]
 
-theorem lift_comp_map (h : MultilinearMap R t E) :
+theorem lift_comp_map (h : MultilinearMap (RingHom.id R) t E) :
     lift h ∘ₗ map f = lift (h.compLinearMap f) := by
   ext
-  simp only [LinearMap.compMultilinearMap_apply, LinearMap.coe_comp, Function.comp_apply,
-    map_tprod, lift.tprod, MultilinearMap.compLinearMap_apply]
+  simp only [LinearMap.coe_comp, Function.comp_apply, map_tprod, lift.tprod,
+    MultilinearMap.compLinearMap_apply]
 
 attribute [local ext high] ext
 
@@ -565,7 +639,8 @@ the family.
 -/
 @[simps]
 noncomputable def mapMultilinear :
-    MultilinearMap R (fun (i : ι) ↦ s i →ₗ[R] t i) ((⨂[R] i, s i) →ₗ[R] ⨂[R] i, t i) where
+    MultilinearMap (RingHom.id R) (fun (i : ι) ↦ s i →ₗ[R] t i)
+      ((⨂[R] i, s i) →ₗ[R] ⨂[R] i, t i) where
   toFun := map
   map_update_smul' _ _ _ _ := PiTensorProduct.map_update_smul _ _ _ _
   map_update_add' _ _ _ _ := PiTensorProduct.map_update_add _ _ _ _
@@ -586,7 +661,7 @@ def piTensorHomMap : (⨂[R] i, s i →ₗ[R] t i) →ₗ[R] (⨂[R] i, s i) →
 
 @[simp] lemma piTensorHomMap_tprod_tprod (f : Π i, s i →ₗ[R] t i) (x : Π i, s i) :
     piTensorHomMap (tprod R f) (tprod R x) = tprod R fun i ↦ f i (x i) := by
-  simp [piTensorHomMap]
+  simp [piTensorHomMap, piLinearMap, compLinearMapMultilinear]
 
 lemma piTensorHomMap_tprod_eq_map (f : Π i, s i →ₗ[R] t i) :
     piTensorHomMap (tprod R f) = map f := by
@@ -666,7 +741,7 @@ def piTensorHomMap₂ : (⨂[R] i, s i →ₗ[R] t i →ₗ[R] t' i) →ₗ[R]
 @[simp] lemma piTensorHomMap₂_tprod_tprod_tprod
     (f : ∀ i, s i →ₗ[R] t i →ₗ[R] t' i) (a : ∀ i, s i) (b : ∀ i, t i) :
     piTensorHomMap₂ (tprod R f) (tprod R a) (tprod R b) = tprod R (fun i ↦ f i (a i) (b i)) := by
-  simp [piTensorHomMapFun₂, piTensorHomMap₂]
+  simp [piTensorHomMapFun₂, piTensorHomMap₂, piLinearMap, compLinearMapMultilinear]
 
 end map
 
@@ -695,23 +770,24 @@ theorem reindex_comp_tprod (e : ι ≃ ι₂) :
     (domDomCongrLinearEquiv' R R s _ e).symm (tprod R) :=
   MultilinearMap.ext <| reindex_tprod e
 
-theorem lift_comp_reindex (e : ι ≃ ι₂) (φ : MultilinearMap R (fun i ↦ s (e.symm i)) E) :
+theorem lift_comp_reindex (e : ι ≃ ι₂)
+    (φ : MultilinearMap (RingHom.id R) (fun i ↦ s (e.symm i)) E) :
     lift φ ∘ₗ (reindex R s e) = lift ((domDomCongrLinearEquiv' R R s _ e).symm φ) := by
   ext; simp [reindex]
 
 @[simp]
-theorem lift_comp_reindex_symm (e : ι ≃ ι₂) (φ : MultilinearMap R s E) :
+theorem lift_comp_reindex_symm (e : ι ≃ ι₂) (φ : MultilinearMap (RingHom.id R) s E) :
     lift φ ∘ₗ (reindex R s e).symm = lift (domDomCongrLinearEquiv' R R s _ e φ) := by
   ext; simp [reindex]
 
 theorem lift_reindex
-    (e : ι ≃ ι₂) (φ : MultilinearMap R (fun i ↦ s (e.symm i)) E) (x : ⨂[R] i, s i) :
+    (e : ι ≃ ι₂) (φ : MultilinearMap (RingHom.id R) (fun i ↦ s (e.symm i)) E) (x : ⨂[R] i, s i) :
     lift φ (reindex R s e x) = lift ((domDomCongrLinearEquiv' R R s _ e).symm φ) x :=
   LinearMap.congr_fun (lift_comp_reindex e φ) x
 
 @[simp]
 theorem lift_reindex_symm
-    (e : ι ≃ ι₂) (φ : MultilinearMap R s E) (x : ⨂[R] i, s (e.symm i)) :
+    (e : ι ≃ ι₂) (φ : MultilinearMap (RingHom.id R) s E) (x : ⨂[R] i, s (e.symm i)) :
     lift φ (reindex R s e |>.symm x) = lift (domDomCongrLinearEquiv' R R s _ e φ) x :=
   LinearMap.congr_fun (lift_comp_reindex_symm e φ) x
 
@@ -721,10 +797,8 @@ theorem reindex_trans (e : ι ≃ ι₂) (e' : ι₂ ≃ ι₃) :
     (reindex R s e).trans (reindex R _ e') = reindex R s (e.trans e') := by
   apply LinearEquiv.toLinearMap_injective
   ext f
-  simp only [LinearEquiv.trans_apply, LinearEquiv.coe_coe, reindex_tprod,
-    LinearMap.coe_compMultilinearMap, Function.comp_apply,
-    reindex_comp_tprod]
-  congr
+  change (reindex R _ e') (reindex R s e (tprod R f)) = reindex R s (e.trans e') (tprod R f)
+  simp_rw [reindex_tprod, Equiv.symm_trans_apply]
 
 theorem reindex_reindex (e : ι ≃ ι₂) (e' : ι₂ ≃ ι₃) (x : ⨂[R] i, s i) :
     reindex R _ e' (reindex R s e x) = reindex R s (e.trans e') x :=
@@ -751,8 +825,7 @@ with `PiTensorProduct.map`. -/
 theorem map_comp_reindex_eq (f : Π i, s i →ₗ[R] t i) (e : ι ≃ ι₂) :
     map (fun i ↦ f (e.symm i)) ∘ₗ reindex R s e = reindex R t e ∘ₗ map f := by
   ext m
-  simp only [LinearMap.compMultilinearMap_apply, LinearEquiv.coe_coe,
-    LinearMap.comp_apply, reindex_tprod, map_tprod]
+  simp only [LinearEquiv.coe_coe, LinearMap.comp_apply, reindex_tprod, map_tprod]
 
 theorem map_reindex (f : Π i, s i →ₗ[R] t i) (e : ι ≃ ι₂) (x : ⨂[R] i, s i) :
     map (fun i ↦ f (e.symm i)) (reindex R s e x) = reindex R t e (map f x) :=
@@ -762,8 +835,8 @@ theorem map_comp_reindex_symm (f : Π i, s i →ₗ[R] t i) (e : ι ≃ ι₂) :
     map f ∘ₗ (reindex R s e).symm = (reindex R t e).symm ∘ₗ map (fun i => f (e.symm i)) := by
   ext m
   apply LinearEquiv.injective (reindex R t e)
-  simp only [LinearMap.compMultilinearMap_apply, LinearMap.coe_comp, LinearEquiv.coe_coe,
-    comp_apply, ← map_reindex, LinearEquiv.apply_symm_apply, map_tprod]
+  simp only [LinearMap.coe_comp, LinearEquiv.coe_coe, comp_apply, ← map_reindex,
+    LinearEquiv.apply_symm_apply, map_tprod]
 
 theorem map_reindex_symm (f : Π i, s i →ₗ[R] t i) (e : ι ≃ ι₂) (x : ⨂[R] i, s (e.symm i)) :
     map f ((reindex R s e).symm x) = (reindex R t e).symm (map (fun i ↦ f (e.symm i)) x) :=
@@ -783,11 +856,11 @@ def isEmptyEquiv [IsEmpty ι] : (⨂[R] i : ι, s i) ≃ₗ[R] R where
       simp only [map_smulₛₗ, RingHom.id_apply, lift.tprod, constOfIsEmpty_apply, const_apply,
         smul_eq_mul, mul_one]
       congr
-      aesop
+      simp
     · simp only
       intro x y hx hy
       rw [map_add, add_smul, hx, hy]
-  right_inv t := by simp
+  right_inv t := by simp [constOfIsEmpty]
   map_add' := map_add _
   map_smul' := map_smul _
 
@@ -851,10 +924,10 @@ def tmulEquivDep :
         map_add' := by simp
         map_smul' := by simp })
     (PiTensorProduct.lift (MultilinearMap.domCoprodDep (tprod R) (tprod R))) (by
-      ext
-      dsimp
-      simp only [lift.tprod, domCoprodDep_apply, lift.tmul, LinearMap.coe_mk, AddHom.coe_mk,
-        currySum_apply]
+      ext x
+      simp only [LinearMap.coe_comp, Function.comp_apply, lift.tprod, domCoprodDep_apply,
+        lift.tmul, LinearMap.coe_mk, AddHom.coe_mk, coe_currySumEquiv, currySum_apply,
+        LinearMap.id_coe, id_eq]
       congr
       ext (_ | _) <;> simp)
     (TensorProduct.ext (by aesop))
@@ -870,7 +943,7 @@ lemma tmulEquivDep_apply (a : (i₁ : ι) → N (.inl i₁))
 lemma tmulEquivDep_symm_apply (f : (i : ι ⊕ ι₂) → N i) :
     (tmulEquivDep R N).symm (⨂ₜ[R] i, f i) =
       ((⨂ₜ[R] i₁, f (.inl i₁)) ⊗ₜ (⨂ₜ[R] i₂, f (.inr i₂))) := by
-  simp [tmulEquivDep]
+  simp [tmulEquivDep, MultilinearMap.domCoprodDep_apply]
 
 end tmulEquivDep
 

--- a/Mathlib/LinearAlgebra/PiTensorProduct/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct/DFinsupp.lean
@@ -37,9 +37,19 @@ def ofDFinsuppEquiv :
     (lift <| MultilinearMap.fromDFinsuppEquiv κ R
       fun p ↦ (DFinsupp.lsingle p).compMultilinearMap (tprod R))
     (DFinsupp.lsum R fun p ↦ lift <|
-      (PiTensorProduct.map fun i ↦ DFinsupp.lsingle (p i)).compMultilinearMap (tprod R))
+      ((PiTensorProduct.map fun i ↦ DFinsupp.lsingle (p i) :
+          (⨂[R] i, M i (p i)) →ₗ[R] _)).compMultilinearMap (tprod R))
     (by ext p x; simp)
-    (by ext x; simp)
+    (by
+      classical
+      ext x
+      have hx : x = fun i ↦ ∑ j ∈ (x i).support, DFinsupp.single j ((x i) j) :=
+        funext fun i ↦ ((x i).sum_single).symm
+      conv_rhs =>
+        rw [LinearMap.id_apply, hx,
+          (tprod R).map_sum_finset (fun i j ↦ DFinsupp.single j ((x i) j))
+            (fun i ↦ (x i).support)]
+      simp [MultilinearMap.fromDFinsuppEquiv_apply])
 
 @[simp]
 theorem ofDFinsuppEquiv_tprod_single (p : Π i, κ i) (x : Π i, M i (p i)) :

--- a/Mathlib/LinearAlgebra/PiTensorProduct/Generators.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct/Generators.lean
@@ -130,7 +130,7 @@ lemma ext_of_span_eq_top
 
 lemma _root_.MultilinearMap.ext_of_span_eq_top
     (hg : ∀ i, Submodule.span R (Set.range (@g i)) = ⊤)
-    {φ φ' : MultilinearMap R M N}
+    {φ φ' : MultilinearMap (RingHom.id R) M N}
     (h : ∀ (j : (i : ι) → γ i), φ (fun i ↦ g (j i)) = φ' (fun i ↦ g (j i))) :
     φ = φ' := by
   suffices lift φ = lift φ' by

--- a/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
@@ -322,7 +322,7 @@ variable (R M)
 /-- Construct a product of `n` elements of the module within the tensor algebra.
 
 See also `PiTensorProduct.tprod`. -/
-def tprod (n : ℕ) : MultilinearMap R (fun _ : Fin n => M) (TensorAlgebra R M) :=
+def tprod (n : ℕ) : MultilinearMap (RingHom.id R) (fun _ : Fin n => M) (TensorAlgebra R M) :=
   (MultilinearMap.mkPiAlgebraFin R n (TensorAlgebra R M)).compLinearMap fun _ => ι R
 
 @[simp]

--- a/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
@@ -47,7 +47,7 @@ theorem toTensorAlgebra_gMul {i j} (a : (⨂[R]^i) M) (b : (⨂[R]^j) M) :
   refine LinearMap.congr_fun (LinearMap.congr_fun ?_ a) b
   clear! a b
   ext (a b)
-  simp only [LinearMap.compMultilinearMap_apply, LinearMap.compr₂_apply, ← gMul_def,
+  simp only [LinearMap.compr₂_apply, ← gMul_def,
     TensorProduct.mk_apply, LinearEquiv.coe_coe, tprod_mul_tprod, toTensorAlgebra_tprod,
     TensorAlgebra.tprod_apply, LinearMap.comp_apply, LinearMap.compl₂_apply]
   refine Eq.trans ?_ List.prod_append

--- a/Mathlib/LinearAlgebra/TensorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorPower/Basic.lean
@@ -184,7 +184,7 @@ theorem mul_assoc {na nb nc} (a : (⨂[R]^na) M) (b : (⨂[R]^nb) M) (c : (⨂[R
     LinearMap.congr_fun (LinearMap.congr_fun (LinearMap.congr_fun this a) b) c
   ext a b c
   -- clean up
-  simp only [e, LinearMap.compMultilinearMap_apply, lhs_eq, rhs_eq, tprod_mul_tprod, cast_tprod]
+  simp only [e, lhs_eq, rhs_eq, tprod_mul_tprod, cast_tprod]
   congr 1 with j
   rw [Fin.append_assoc]
   refine congr_arg (Fin.append a (Fin.append b c)) (Fin.ext ?_)

--- a/Mathlib/LinearAlgebra/TensorPower/Pairing.lean
+++ b/Mathlib/LinearAlgebra/TensorPower/Pairing.lean
@@ -29,7 +29,7 @@ variable (R : Type*) (M : Type*) [CommSemiring R] [AddCommMonoid M] [Module R M]
 /-- The canonical multilinear map from `n` copies of the dual of the module `M`
 to the dual of `⨂[R]^n M`. -/
 noncomputable def multilinearMapToDual :
-    MultilinearMap R (fun (_ : Fin n) ↦ Module.Dual R M)
+    MultilinearMap (RingHom.id R) (fun (_ : Fin n) ↦ Module.Dual R M)
       (Module.Dual R (⨂[R]^n M)) :=
   have : ∀ (_ : DecidableEq (Fin n)) (f : Fin n → Module.Dual R M)
       (φ : Module.Dual R M) (i j : Fin n) (v : Fin n → M),

--- a/Mathlib/LinearAlgebra/TensorPower/Symmetric.lean
+++ b/Mathlib/LinearAlgebra/TensorPower/Symmetric.lean
@@ -112,7 +112,7 @@ def mk : (⨂[R] (_ : ι), M) →ₗ[R] Sym[R] ι M where
 variable {M ι} in
 /-- The multilinear map that takes `ι`-indexed elements of `M` and
 returns their symmetric tensor power. Denoted `⨂ₛ[R] i, f i`. -/
-def tprod : MultilinearMap R (fun _ : ι ↦ M) Sym[R] ι M :=
+def tprod : MultilinearMap (RingHom.id R) (fun _ : ι ↦ M) Sym[R] ι M :=
   (mk R ι M).compMultilinearMap (PiTensorProduct.tprod R)
 
 unsuppress_compilation in

--- a/Mathlib/RingTheory/PiTensorProduct.lean
+++ b/Mathlib/RingTheory/PiTensorProduct.lean
@@ -205,7 +205,7 @@ Lifting a multilinear map to an algebra homomorphism from tensor product
 -/
 @[simps!]
 def liftAlgHom {S : Type*} [Semiring S] [Algebra R S]
-    (f : MultilinearMap R A S)
+    (f : MultilinearMap (RingHom.id R) A S)
     (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) : (⨂[R] i, A i) →ₐ[R] S :=
   AlgHom.ofLinearMap (lift f) (show lift f (tprod R 1) = 1 by simp [one]) <|
     LinearMap.map_mul_iff _ |>.mpr <| by aesop

--- a/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
@@ -50,7 +50,8 @@ conditions between the algebraic and the topological structures, but this is not
 definition. -/
 structure ContinuousMultilinearMap (R : Type u) {ι : Type v} (M₁ : ι → Type w₁) (M₂ : Type w₂)
   [Semiring R] [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M₂] [∀ i, Module R (M₁ i)] [Module R M₂]
-  [∀ i, TopologicalSpace (M₁ i)] [TopologicalSpace M₂] extends MultilinearMap R M₁ M₂ where
+  [∀ i, TopologicalSpace (M₁ i)] [TopologicalSpace M₂]
+  extends MultilinearMap (RingHom.id R) M₁ M₂ where
   cont : Continuous toFun
 
 attribute [inherit_doc ContinuousMultilinearMap] ContinuousMultilinearMap.cont
@@ -72,7 +73,7 @@ variable [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, AddCommMonoid (M₁ i
 theorem toMultilinearMap_injective :
     Function.Injective
       (ContinuousMultilinearMap.toMultilinearMap :
-        ContinuousMultilinearMap R M₁ M₂ → MultilinearMap R M₁ M₂)
+        ContinuousMultilinearMap R M₁ M₂ → MultilinearMap (RingHom.id R) M₁ M₂)
   | ⟨f, hf⟩, ⟨g, hg⟩, h => by subst h; rfl
 
 instance funLike : FunLike (ContinuousMultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
@@ -121,7 +122,7 @@ theorem map_zero [Nonempty ι] : f 0 = 0 :=
   f.toMultilinearMap.map_zero
 
 instance : Zero (ContinuousMultilinearMap R M₁ M₂) :=
-  ⟨{ (0 : MultilinearMap R M₁ M₂) with cont := continuous_const }⟩
+  ⟨{ (0 : MultilinearMap (RingHom.id R) M₁ M₂) with cont := continuous_const }⟩
 
 instance : Inhabited (ContinuousMultilinearMap R M₁ M₂) :=
   ⟨0⟩
@@ -573,7 +574,8 @@ instance : Module R' (ContinuousMultilinearMap A M₁ M₂) := fast_instance%
 /-- Linear map version of the map `toMultilinearMap` associating to a continuous multilinear map
 the corresponding multilinear map. -/
 @[simps]
-def toMultilinearMapLinear : ContinuousMultilinearMap A M₁ M₂ →ₗ[R'] MultilinearMap A M₁ M₂ where
+def toMultilinearMapLinear :
+    ContinuousMultilinearMap A M₁ M₂ →ₗ[R'] MultilinearMap (RingHom.id A) M₁ M₂ where
   toFun := toMultilinearMap
   map_add' := toMultilinearMap_add
   map_smul' := toMultilinearMap_smul


### PR DESCRIPTION
It's time we generalised `MultilinearMap` to semilinear maps, following the same line as #24208 for bilinear maps. This is necessary to define inner products on tensor powers. This is also needed to work towards a "future work" item in `Analysis/InnerProductSpace/ExteriorPower.lean`. Probably first in a series of PRs propagating this generalisation.

Since `MultilinearMap` doesn't have a dedicated notation like `LinearMap`, the downstream uses have to explicitly write `(RingHom.id 𝕜)` in place of `𝕜`. May be worth introducing new notations.

CLOSED due to duplication with #42534.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
