### PR TITLE
[Merged by Bors] - fix(GroupTheory): remove a redundant instance

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -132,10 +132,6 @@ theorem coe_quotient_smul {H : Subgroup G} [H.Normal] [SMul G X]
   rw [← smul_one_smul (G ⧸ H) g x, ← QuotientGroup.mk_one, Quotient.smul_coe,
     smul_eq_mul, mul_one]
 
-@[to_additive]
-instance mulLeftCosetsCompSubtypeVal (H I : Subgroup G) : MulAction I (G ⧸ H) :=
-  MulAction.compHom (G ⧸ H) (Subgroup.subtype I)
-
 variable (G)
 variable [MulAction G X] (x : X)
 


### PR DESCRIPTION
Remove `mulLeftCosetsCompSubtypeVal` as Lean automatically synthesizes this. 
```
variable (H I : Subgroup G)
#synth MulAction I (G ⧸ H) --succeed

@[to_additive]
instance mulLeftCosetsCompSubtypeVal (H I : Subgroup G) : MulAction I (G ⧸ H) :=
  MulAction.compHom (G ⧸ H) (Subgroup.subtype I)
```
The original redundant instance causes downstream defeq problems as discussed here https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/How.20does.20.60MulAction.2Esubgroup_smul_def.60.20work.20exactly.3F/with/620456713.