### PR TITLE
[Merged by Bors] - chore(Algebra/Polynomial/Div): generalize `rootMultiplicity` lemmas to non-commutative rings

### DIFF
--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -515,6 +515,14 @@ section Semiring
 
 variable [Semiring S] {f : R →+* S}
 
+lemma comp_X_add_C_eq_zero_iff {p : S[X]} {t : S} : p.comp (X + C t) = 0 ↔ p = 0 := by
+  refine ⟨fun h ↦ ?_, by simp +contextual⟩
+  nontriviality S
+  simpa [h] using (p.coeff_comp_degree_mul_degree <| ne_zero_of_eq_one <| natDegree_X_add_C t).symm
+
+lemma comp_X_add_C_ne_zero_iff {p : S[X]} {t : S} : p.comp (X + C t) ≠ 0 ↔ p ≠ 0 :=
+  comp_X_add_C_eq_zero_iff.not
+
 theorem aeval_eq_sum_range [Algebra R S] {p : R[X]} (x : S) :
     aeval x p = ∑ i ∈ Finset.range (p.natDegree + 1), p.coeff i • x ^ i := by
   simp_rw [Algebra.smul_def]
@@ -663,11 +671,6 @@ theorem aeval_endomorphism {M : Type*} [AddCommGroup M] [Module R M] (f : M →�
 lemma X_sub_C_pow_dvd_iff {n : ℕ} : (X - C t) ^ n ∣ p ↔ X ^ n ∣ p.comp (X + C t) := by
   convert! (map_dvd_iff <| algEquivAevalXAddC t).symm using 2
   simp [C_eq_algebraMap]
-
-lemma comp_X_add_C_eq_zero_iff : p.comp (X + C t) = 0 ↔ p = 0 :=
-  EmbeddingLike.map_eq_zero_iff (f := algEquivAevalXAddC t)
-
-lemma comp_X_add_C_ne_zero_iff : p.comp (X + C t) ≠ 0 ↔ p ≠ 0 := comp_X_add_C_eq_zero_iff.not
 
 lemma dvd_comp_C_mul_X_add_C_iff (p q : R[X]) (a b : R) [Invertible a] :
     p ∣ q.comp (C a * X + C b) ↔ p.comp (C ⅟a * (X - C b)) ∣ q := by

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -555,6 +555,41 @@ theorem exists_eq_pow_rootMultiplicity_mul_and_not_dvd (p : R[X]) (hp : p ≠ 0)
   rw [rootMultiplicity_eq_multiplicity, ite_eq_right hp]
   apply (finiteMultiplicity_X_sub_C a hp).exists_eq_pow_mul_and_not_dvd
 
+/-- The multiplicity of `a` as root of a nonzero polynomial `p` is at least `n` iff
+`(X - a) ^ n` divides `p`. -/
+lemma le_rootMultiplicity_iff (p0 : p ≠ 0) {a : R} {n : ℕ} :
+    n ≤ rootMultiplicity a p ↔ (X - C a) ^ n ∣ p := by
+  simp_rw [rootMultiplicity, dite_eq_right p0, Nat.le_find_iff, not_not]
+  refine ⟨fun h => ?_, fun h m hm => (pow_dvd_pow _ hm).trans h⟩
+  rcases n with - | n
+  · rw [pow_zero]
+    apply one_dvd
+  · exact h n n.lt_succ_self
+
+lemma rootMultiplicity_le_iff (p0 : p ≠ 0) (a : R) (n : ℕ) :
+    rootMultiplicity a p ≤ n ↔ ¬(X - C a) ^ (n + 1) ∣ p := by
+  rw [← (le_rootMultiplicity_iff p0).not, not_le, Nat.lt_add_one_iff]
+
+/-- The multiplicity of `p + q` is at least the minimum of the multiplicities. -/
+lemma rootMultiplicity_add {p q : R[X]} (a : R) (hzero : p + q ≠ 0) :
+    min (rootMultiplicity a p) (rootMultiplicity a q) ≤ rootMultiplicity a (p + q) := by
+  rw [le_rootMultiplicity_iff hzero]
+  exact min_pow_dvd_add (pow_rootMultiplicity_dvd p a) (pow_rootMultiplicity_dvd q a)
+
+lemma pow_rootMultiplicity_not_dvd (p0 : p ≠ 0) (a : R) :
+    ¬(X - C a) ^ (rootMultiplicity a p + 1) ∣ p := by rw [← rootMultiplicity_le_iff p0]
+
+/-- See `Polynomial.rootMultiplicity_eq_natTrailingDegree` for the general case. -/
+lemma rootMultiplicity_eq_natTrailingDegree' : p.rootMultiplicity 0 = p.natTrailingDegree := by
+  by_cases h : p = 0
+  · simp only [h, rootMultiplicity_zero, natTrailingDegree_zero]
+  refine le_antisymm ?_ ?_
+  · rw [rootMultiplicity_le_iff h, map_zero, sub_zero, X_pow_dvd_iff, not_forall]
+    exact ⟨p.natTrailingDegree,
+      fun h' ↦ trailingCoeff_nonzero_iff_nonzero.2 h <| h' <| Nat.lt_add_one _⟩
+  · rw [le_rootMultiplicity_iff h, map_zero, sub_zero, X_pow_dvd_iff]
+    exact fun _ ↦ coeff_eq_zero_of_lt_natTrailingDegree
+
 end multiplicity
 
 end Ring
@@ -702,27 +737,6 @@ lemma eval_divByMonic_eq_trailingCoeff_comp {p : R[X]} {t : R} :
     trailingCoeff, Nat.le_zero.1 (natTrailingDegree_le_of_ne_zero <|
       this ▸ eval_divByMonic_pow_rootMultiplicity_ne_zero t hp), this]
 
-/-- The multiplicity of `a` as root of a nonzero polynomial `p` is at least `n` iff
-`(X - a) ^ n` divides `p`. -/
-lemma le_rootMultiplicity_iff (p0 : p ≠ 0) {a : R} {n : ℕ} :
-    n ≤ rootMultiplicity a p ↔ (X - C a) ^ n ∣ p := by
-  simp_rw [rootMultiplicity, dite_eq_right p0, Nat.le_find_iff, not_not]
-  refine ⟨fun h => ?_, fun h m hm => (pow_dvd_pow _ hm).trans h⟩
-  rcases n with - | n
-  · rw [pow_zero]
-    apply one_dvd
-  · exact h n n.lt_succ_self
-
-lemma rootMultiplicity_le_iff (p0 : p ≠ 0) (a : R) (n : ℕ) :
-    rootMultiplicity a p ≤ n ↔ ¬(X - C a) ^ (n + 1) ∣ p := by
-  rw [← (le_rootMultiplicity_iff p0).not, not_le, Nat.lt_add_one_iff]
-
-/-- The multiplicity of `p + q` is at least the minimum of the multiplicities. -/
-lemma rootMultiplicity_add {p q : R[X]} (a : R) (hzero : p + q ≠ 0) :
-    min (rootMultiplicity a p) (rootMultiplicity a q) ≤ rootMultiplicity a (p + q) := by
-  rw [le_rootMultiplicity_iff hzero]
-  exact min_pow_dvd_add (pow_rootMultiplicity_dvd p a) (pow_rootMultiplicity_dvd q a)
-
 lemma le_rootMultiplicity_mul {p q : R[X]} (x : R) (hpq : p * q ≠ 0) :
     rootMultiplicity x p + rootMultiplicity x q ≤ rootMultiplicity x (p * q) := by
   rw [le_rootMultiplicity_iff hpq, pow_add]
@@ -732,20 +746,6 @@ lemma rootMultiplicity_le_rootMultiplicity_of_dvd {p q : R[X]} (hq : q ≠ 0) (h
     p.rootMultiplicity x ≤ q.rootMultiplicity x := by
   obtain ⟨_, rfl⟩ := hpq
   exact Nat.le_of_add_right_le <| le_rootMultiplicity_mul x hq
-
-lemma pow_rootMultiplicity_not_dvd (p0 : p ≠ 0) (a : R) :
-    ¬(X - C a) ^ (rootMultiplicity a p + 1) ∣ p := by rw [← rootMultiplicity_le_iff p0]
-
-/-- See `Polynomial.rootMultiplicity_eq_natTrailingDegree` for the general case. -/
-lemma rootMultiplicity_eq_natTrailingDegree' : p.rootMultiplicity 0 = p.natTrailingDegree := by
-  by_cases h : p = 0
-  · simp only [h, rootMultiplicity_zero, natTrailingDegree_zero]
-  refine le_antisymm ?_ ?_
-  · rw [rootMultiplicity_le_iff h, map_zero, sub_zero, X_pow_dvd_iff, not_forall]
-    exact ⟨p.natTrailingDegree,
-      fun h' ↦ trailingCoeff_nonzero_iff_nonzero.2 h <| h' <| Nat.lt_add_one _⟩
-  · rw [le_rootMultiplicity_iff h, map_zero, sub_zero, X_pow_dvd_iff]
-    exact fun _ ↦ coeff_eq_zero_of_lt_natTrailingDegree
 
 /-- Division by a monic polynomial doesn't change the leading coefficient. -/
 lemma leadingCoeff_divByMonic_of_monic (hmonic : q.Monic)


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
