### PR TITLE
[Merged by Bors] - chore(Data/Finset/Max): use `to_dual`

### DIFF
--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -31,218 +31,144 @@ variable [LinearOrder α]
 /-- Let `s` be a finset in a linear order. Then `s.max` is the maximum of `s` if `s` is not empty,
 and `⊥` otherwise. It belongs to `WithBot α`. If you want to get an element of `α`, see
 `s.max'`. -/
+@[to_dual
+/-- Let `s` be a finset in a linear order. Then `s.min` is the minimum of `s` if `s` is not empty,
+and `⊤` otherwise. It belongs to `WithTop α`. If you want to get an element of `α`, see
+`s.min'`. -/]
 protected def max (s : Finset α) : WithBot α :=
   sup s (↑)
 
+@[to_dual]
 theorem max_eq_sup_coe {s : Finset α} : s.max = s.sup (↑) :=
   rfl
 
+@[to_dual]
 theorem max_eq_sup_withBot (s : Finset α) : s.max = sup s (↑) :=
   rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem max_empty : (∅ : Finset α).max = ⊥ :=
   rfl
 
-@[simp, grind =]
+@[to_dual (attr := simp, grind =)]
 theorem max_insert {a : α} {s : Finset α} : (insert a s).max = max ↑a s.max :=
   fold_insert_idem
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem max_singleton {a : α} : Finset.max {a} = (a : WithBot α) := by
   rw [← insert_empty_eq]
   exact max_insert
 
+@[to_dual]
 lemma max_pair (a b : α) :
     Finset.max {a, b} = max (↑a) (↑b) := by
   simp
 
+@[to_dual]
 theorem max_of_mem {s : Finset α} {a : α} (h : a ∈ s) : ∃ b : α, s.max = b :=
   let ⟨b, h, _⟩ := WithBot.le_iff_forall.1 (le_sup (α := WithBot α) h) _ rfl; ⟨b, h⟩
 
+@[to_dual]
 theorem max_of_nonempty {s : Finset α} (h : s.Nonempty) : ∃ a : α, s.max = a :=
   let ⟨_, h⟩ := h
   max_of_mem h
 
+@[to_dual]
 theorem max_eq_bot {s : Finset α} : s.max = ⊥ ↔ s = ∅ :=
   ⟨fun h ↦ s.eq_empty_or_nonempty.elim id fun H ↦ by
       obtain ⟨a, ha⟩ := max_of_nonempty H
       rw [h] at ha; cases ha; , -- the `;` is needed since the `cases` syntax allows `cases a, b`
     fun h ↦ h.symm ▸ max_empty⟩
 
+@[to_dual]
 theorem mem_of_max {s : Finset α} : ∀ {a : α}, s.max = a → a ∈ s := by
   induction s using Finset.induction_on with
   | empty => intro _ H; cases H
-  | _ => grind [WithBot.coe_eq_coe]
+  | _ a s _ h =>
+    intro a ha
+    simp only [max_insert] at ha
+    cases max_eq_iff.mp ha <;> simp_all
 
+@[to_dual min_le]
 theorem le_max {a : α} {s : Finset α} (as : a ∈ s) : ↑a ≤ s.max :=
   le_sup as
 
+@[to_dual notMem_of_coe_lt_min]
 theorem notMem_of_max_lt_coe {a : α} {s : Finset α} (h : s.max < a) : a ∉ s :=
   mt le_max h.not_ge
 
+@[to_dual min_le_of_eq]
 theorem le_max_of_eq {s : Finset α} {a b : α} (h₁ : a ∈ s) (h₂ : s.max = b) : a ≤ b :=
   WithBot.coe_le_coe.mp <| (le_max h₁).trans h₂.le
 
+@[to_dual notMem_of_lt_min]
 theorem notMem_of_max_lt {s : Finset α} {a b : α} (h₁ : b < a) (h₂ : s.max = ↑b) : a ∉ s :=
   Finset.notMem_of_max_lt_coe <| h₂.trans_lt <| WithBot.coe_lt_coe.mpr h₁
 
+@[to_dual]
 theorem max_union {s t : Finset α} : (s ∪ t).max = s.max ⊔ t.max := sup_union
 
-@[gcongr]
+@[to_dual (attr := gcongr)]
 theorem max_mono {s t : Finset α} (st : s ⊆ t) : s.max ≤ t.max :=
   sup_mono st
 
+@[to_dual le_min]
 protected theorem max_le {M : WithBot α} {s : Finset α} (st : ∀ a ∈ s, (a : WithBot α) ≤ M) :
     s.max ≤ M :=
   Finset.sup_le st
 
-@[simp]
+@[to_dual (attr := simp) le_min_iff]
 protected lemma max_le_iff {m : WithBot α} {s : Finset α} : s.max ≤ m ↔ ∀ a ∈ s, a ≤ m :=
   Finset.sup_le_iff
 
-@[simp]
+@[to_dual (attr := simp)]
 protected lemma max_eq_top [OrderTop α] {s : Finset α} : s.max = ⊤ ↔ ⊤ ∈ s :=
   Finset.sup_eq_top_iff.trans <| by simp
-
-/-- Let `s` be a finset in a linear order. Then `s.min` is the minimum of `s` if `s` is not empty,
-and `⊤` otherwise. It belongs to `WithTop α`. If you want to get an element of `α`, see
-`s.min'`. -/
-protected def min (s : Finset α) : WithTop α :=
-  inf s (↑)
-
-theorem min_eq_inf_withTop (s : Finset α) : s.min = inf s (↑) :=
-  rfl
-
-@[simp]
-theorem min_empty : (∅ : Finset α).min = ⊤ :=
-  rfl
-
-@[simp]
-theorem min_insert {a : α} {s : Finset α} : (insert a s).min = min (↑a) s.min :=
-  fold_insert_idem
-
-@[simp]
-theorem min_singleton {a : α} : Finset.min {a} = (a : WithTop α) := by
-  rw [← insert_empty_eq]
-  exact min_insert
-
-lemma min_pair (a b : α) :
-    Finset.min {a, b} = min (↑a) (↑b) := by
-  simp
-
-theorem min_of_mem {s : Finset α} {a : α} (h : a ∈ s) : ∃ b : α, s.min = b :=
-  let ⟨b, h, _⟩ := WithTop.le_iff_forall.1 (inf_le (α := WithTop α) h) _ rfl; ⟨b, h⟩
-
-theorem min_of_nonempty {s : Finset α} (h : s.Nonempty) : ∃ a : α, s.min = a :=
-  let ⟨_, h⟩ := h
-  min_of_mem h
-
-@[simp]
-theorem min_eq_top {s : Finset α} : s.min = ⊤ ↔ s = ∅ := by
-  simp [Finset.min, eq_empty_iff_forall_notMem]
-
-theorem mem_of_min {s : Finset α} : ∀ {a : α}, s.min = a → a ∈ s :=
-  @mem_of_max αᵒᵈ _ s
-
-theorem min_le {a : α} {s : Finset α} (as : a ∈ s) : s.min ≤ a :=
-  inf_le as
-
-theorem notMem_of_coe_lt_min {a : α} {s : Finset α} (h : ↑a < s.min) : a ∉ s :=
-  mt min_le h.not_ge
-
-theorem min_le_of_eq {s : Finset α} {a b : α} (h₁ : b ∈ s) (h₂ : s.min = a) : a ≤ b :=
-  WithTop.coe_le_coe.mp <| h₂.ge.trans (min_le h₁)
-
-theorem notMem_of_lt_min {s : Finset α} {a b : α} (h₁ : a < b) (h₂ : s.min = ↑b) : a ∉ s :=
-  Finset.notMem_of_coe_lt_min <| (WithTop.coe_lt_coe.mpr h₁).trans_eq h₂.symm
-
-theorem min_union {s t : Finset α} : (s ∪ t).min = s.min ⊓ t.min := inf_union
-
-@[gcongr]
-theorem min_mono {s t : Finset α} (st : s ⊆ t) : t.min ≤ s.min :=
-  inf_mono st
-
-protected theorem le_min {m : WithTop α} {s : Finset α} (st : ∀ a : α, a ∈ s → m ≤ a) : m ≤ s.min :=
-  Finset.le_inf st
-
-@[simp]
-protected theorem le_min_iff {m : WithTop α} {s : Finset α} : m ≤ s.min ↔ ∀ a ∈ s, m ≤ a :=
-  Finset.le_inf_iff
-
-@[simp]
-protected theorem min_eq_bot [OrderBot α] {s : Finset α} : s.min = ⊥ ↔ ⊥ ∈ s :=
-  Finset.max_eq_top (α := αᵒᵈ)
-
-/-- Given a nonempty finset `s` in a linear order `α`, then `s.min' H` is its minimum, as an
-element of `α`, where `H` is a proof of nonemptiness. Without this assumption, use instead `s.min`,
-taking values in `WithTop α`. -/
-def min' (s : Finset α) (H : s.Nonempty) : α :=
-  inf' s H id
 
 /-- Given a nonempty finset `s` in a linear order `α`, then `s.max' H` is its maximum, as an
 element of `α`, where `H` is a proof of nonemptiness. Without this assumption, use instead `s.max`,
 taking values in `WithBot α`. -/
+@[to_dual
+/-- Given a nonempty finset `s` in a linear order `α`, then `s.min' H` is its minimum, as an
+element of `α`, where `H` is a proof of nonemptiness. Without this assumption, use instead `s.min`,
+taking values in `WithTop α`. -/]
 def max' (s : Finset α) (H : s.Nonempty) : α :=
   sup' s H id
 
 variable (s : Finset α) (H : s.Nonempty) {x : α}
 
-theorem min'_mem : s.min' H ∈ s :=
-  mem_of_min <| by simp only [Finset.min, min', id_eq, coe_inf', Function.comp_def]
-
-theorem min'_le (x) (H2 : x ∈ s) : s.min' ⟨x, H2⟩ ≤ x :=
-  min_le_of_eq H2 (WithTop.coe_untop _ _).symm
-
-theorem le_min' (x) (H2 : ∀ y ∈ s, x ≤ y) : x ≤ s.min' H :=
-  H2 _ <| min'_mem _ _
-
-theorem isLeast_min' : IsLeast (↑s) (s.min' H) :=
-  ⟨min'_mem _ _, min'_le _⟩
-
-@[simp]
-theorem le_min'_iff {x} : x ≤ s.min' H ↔ ∀ y ∈ s, x ≤ y :=
-  le_isGLB_iff (isLeast_min' s H).isGLB
-
-/-- `{a}.min' _` is `a`. -/
-@[simp]
-theorem min'_singleton (a : α) : ({a} : Finset α).min' (singleton_nonempty _) = a := by simp [min']
-
+@[to_dual]
 theorem max'_mem : s.max' H ∈ s :=
   mem_of_max <| by simp only [max', Finset.max, id_eq, coe_sup', Function.comp_def]
 
+@[to_dual min'_le]
 theorem le_max' (x) (H2 : x ∈ s) : x ≤ s.max' ⟨x, H2⟩ :=
   le_max_of_eq H2 (WithBot.coe_unbot _ _).symm
 
+@[to_dual le_min']
 theorem max'_le (x) (H2 : ∀ y ∈ s, y ≤ x) : s.max' H ≤ x :=
   H2 _ <| max'_mem _ _
 
+@[to_dual]
 theorem isGreatest_max' : IsGreatest (↑s) (s.max' H) :=
   ⟨max'_mem _ _, le_max' _⟩
 
-@[simp]
+@[to_dual (attr := simp) le_min'_iff]
 theorem max'_le_iff {x} : s.max' H ≤ x ↔ ∀ y ∈ s, y ≤ x :=
   isLUB_le_iff (isGreatest_max' s H).isLUB
 
-@[simp]
+@[to_dual (attr := simp) lt_min'_iff]
 theorem max'_lt_iff {x} : s.max' H < x ↔ ∀ y ∈ s, y < x :=
   ⟨fun Hlt y hy => (s.le_max' y hy).trans_lt Hlt, fun H => H _ <| s.max'_mem _⟩
 
-@[simp]
-theorem lt_min'_iff : x < s.min' H ↔ ∀ y ∈ s, x < y :=
-  @max'_lt_iff αᵒᵈ _ _ H _
-
+@[to_dual]
 theorem max'_eq_sup' : s.max' H = s.sup' H id := rfl
 
-theorem min'_eq_inf' : s.min' H = s.inf' H id := rfl
-
 /-- `{a}.max' _` is `a`. -/
-@[simp]
+@[to_dual (attr := simp) /-- `{a}.min' _` is `a`. -/]
 theorem max'_singleton (a : α) : ({a} : Finset α).max' (singleton_nonempty _) = a := by simp [max']
 
-lemma min'_eq_iff (a : α) : s.min' H = a ↔ a ∈ s ∧ ∀ (b : α), b ∈ s → a ≤ b :=
-  ⟨(· ▸ ⟨min'_mem _ _, min'_le _⟩), fun h ↦ le_antisymm (min'_le _ _ h.1) (le_min' _ _ _ h.2)⟩
-
+@[to_dual]
 lemma max'_eq_iff (a : α) : s.max' H = a ↔ a ∈ s ∧ ∀ (b : α), b ∈ s → b ≤ a :=
   ⟨(· ▸ ⟨max'_mem _ _, le_max' _⟩), fun h ↦ le_antisymm (max'_le _ _ _ h.2) (le_max' _ _ h.1)⟩
 
@@ -260,82 +186,53 @@ theorem min'_lt_max'_of_card (h₂ : 1 < card s) :
   rcases one_lt_card.1 h₂ with ⟨a, ha, b, hb, hab⟩
   exact s.min'_lt_max' ha hb hab
 
+@[to_dual]
 theorem max'_union {s₁ s₂ : Finset α} (h₁ : s₁.Nonempty) (h₂ : s₂.Nonempty) :
     (s₁ ∪ s₂).max' (h₁.mono subset_union_left) = s₁.max' h₁ ⊔ s₂.max' h₂ := sup'_union h₁ h₂ id
 
-theorem min'_union {s₁ s₂ : Finset α} (h₁ : s₁.Nonempty) (h₂ : s₂.Nonempty) :
-    (s₁ ∪ s₂).min' (h₁.mono subset_union_left) = s₁.min' h₁ ⊓ s₂.min' h₂ := inf'_union h₁ h₂ id
-
-theorem map_ofDual_min (s : Finset αᵒᵈ) : s.min.map ofDual = (s.image ofDual).max := by
-  rw [max_eq_sup_withBot, sup_image]
-  exact congr_fun WithBot.map_id _
-
+@[to_dual]
 theorem map_ofDual_max (s : Finset αᵒᵈ) : s.max.map ofDual = (s.image ofDual).min := by
   rw [min_eq_inf_withTop, inf_image]
   exact congr_fun WithTop.map_id _
 
-theorem map_toDual_min (s : Finset α) : s.min.map toDual = (s.image toDual).max := by
-  rw [max_eq_sup_withBot, sup_image]
-  exact congr_fun WithBot.map_id _
-
+@[to_dual]
 theorem map_toDual_max (s : Finset α) : s.max.map toDual = (s.image toDual).min := by
   rw [min_eq_inf_withTop, inf_image]
   exact congr_fun WithTop.map_id _
 
-theorem ofDual_min' {s : Finset αᵒᵈ} (hs : s.Nonempty) :
-    ofDual (min' s hs) = max' (s.image ofDual) (hs.image _) := by
-  simp [min'_eq_inf', max'_eq_sup']
-
+@[to_dual]
 theorem ofDual_max' {s : Finset αᵒᵈ} (hs : s.Nonempty) :
     ofDual (max' s hs) = min' (s.image ofDual) (hs.image _) := by
   simp [min'_eq_inf', max'_eq_sup']
 
-theorem toDual_min' {s : Finset α} (hs : s.Nonempty) :
-    toDual (min' s hs) = max' (s.image toDual) (hs.image _) := by
-  simp [min'_eq_inf', max'_eq_sup']
-
+@[to_dual]
 theorem toDual_max' {s : Finset α} (hs : s.Nonempty) :
     toDual (max' s hs) = min' (s.image toDual) (hs.image _) := by
   simp [min'_eq_inf', max'_eq_sup']
 
+@[to_dual]
 theorem max'_subset {s t : Finset α} (H : s.Nonempty) (hst : s ⊆ t) :
     s.max' H ≤ t.max' (H.mono hst) :=
   le_max' _ _ (hst (s.max'_mem H))
 
-theorem min'_subset {s t : Finset α} (H : s.Nonempty) (hst : s ⊆ t) :
-    t.min' (H.mono hst) ≤ s.min' H :=
-  min'_le _ _ (hst (s.min'_mem H))
-
-@[simp] theorem max'_insert (a : α) (s : Finset α) (H : s.Nonempty) :
+@[to_dual (attr := simp)] theorem max'_insert (a : α) (s : Finset α) (H : s.Nonempty) :
     (insert a s).max' (s.insert_nonempty a) = max a (s.max' H) :=
   (isGreatest_max' _ _).unique <| by
     rw [coe_insert]
     exact (isGreatest_max' _ _).insert _
 
-@[simp] theorem min'_insert (a : α) (s : Finset α) (H : s.Nonempty) :
-    (insert a s).min' (s.insert_nonempty a) = min a (s.min' H) :=
-  (isLeast_min' _ _).unique <| by
-    rw [coe_insert]
-    exact (isLeast_min' _ _).insert _
-
-lemma min'_pair (a b : α) :
-    min' {a, b} (insert_nonempty _ _) = min a b := by
-  simp
-
+@[to_dual]
 lemma max'_pair (a b : α) :
     max' {a, b} (insert_nonempty _ _) = max a b := by
   simp
 
+@[to_dual min'_lt_of_mem_erase_min']
 theorem lt_max'_of_mem_erase_max' [DecidableEq α] {a : α} (ha : a ∈ s.erase (s.max' H)) :
     a < s.max' H :=
   lt_of_le_of_ne (le_max' _ _ (mem_of_mem_erase ha)) <| ne_of_mem_of_not_mem ha <| notMem_erase _ _
 
-theorem min'_lt_of_mem_erase_min' [DecidableEq α] {a : α} (ha : a ∈ s.erase (s.min' H)) :
-    s.min' H < a :=
-  @lt_max'_of_mem_erase_max' αᵒᵈ _ s H _ a ha
-
 /-- To rewrite from right to left, use `Monotone.map_finset_max'`. -/
-@[simp]
+@[to_dual (attr := simp) /-- To rewrite from right to left, use `Monotone.map_finset_min'`. -/]
 theorem max'_image [LinearOrder β] {f : α → β} (hf : Monotone f) (s : Finset α)
     (h : (s.image f).Nonempty) : (s.image f).max' h = f (s.max' h.of_image) := by
   simp only [max', sup'_image]
@@ -343,51 +240,32 @@ theorem max'_image [LinearOrder β] {f : α → β} (hf : Monotone f) (s : Finse
 
 /-- A version of `Finset.max'_image` with LHS and RHS reversed.
 Also, this version assumes that `s` is nonempty, not its image. -/
+@[to_dual
+/-- A version of `Finset.min'_image` with LHS and RHS reversed.
+Also, this version assumes that `s` is nonempty, not its image. -/]
 lemma _root_.Monotone.map_finset_max' [LinearOrder β] {f : α → β} (hf : Monotone f) {s : Finset α}
     (h : s.Nonempty) : f (s.max' h) = (s.image f).max' (h.image f) :=
   .symm <| max'_image hf ..
 
-/-- To rewrite from right to left, use `Monotone.map_finset_min'`. -/
-@[simp]
-theorem min'_image [LinearOrder β] {f : α → β} (hf : Monotone f) (s : Finset α)
-    (h : (s.image f).Nonempty) : (s.image f).min' h = f (s.min' h.of_image) := by
-  simp only [min', inf'_image]
-  exact .symm <| apply_inf'_eq_inf'_comp _ _ fun _ _ ↦ hf.map_min
-
-/-- A version of `Finset.min'_image` with LHS and RHS reversed.
-Also, this version assumes that `s` is nonempty, not its image. -/
-lemma _root_.Monotone.map_finset_min' [LinearOrder β] {f : α → β} (hf : Monotone f) {s : Finset α}
-    (h : s.Nonempty) : f (s.min' h) = (s.image f).min' (h.image f) :=
-  .symm <| min'_image hf ..
-
+@[to_dual]
 theorem coe_max' {s : Finset α} (hs : s.Nonempty) : ↑(s.max' hs) = s.max :=
   coe_sup' hs id
 
-theorem coe_min' {s : Finset α} (hs : s.Nonempty) : ↑(s.min' hs) = s.min :=
-  coe_inf' hs id
-
+@[to_dual]
 theorem max_mem_image_coe {s : Finset α} (hs : s.Nonempty) :
     s.max ∈ (s.image (↑) : Finset (WithBot α)) :=
   mem_image.2 ⟨max' s hs, max'_mem _ _, coe_max' hs⟩
 
-theorem min_mem_image_coe {s : Finset α} (hs : s.Nonempty) :
-    s.min ∈ (s.image (↑) : Finset (WithTop α)) :=
-  mem_image.2 ⟨min' s hs, min'_mem _ _, coe_min' hs⟩
-
+@[to_dual]
 theorem max_mem_insert_bot_image_coe (s : Finset α) :
     s.max ∈ (insert ⊥ (s.image (↑)) : Finset (WithBot α)) :=
   mem_insert.2 <| s.eq_empty_or_nonempty.imp max_eq_bot.2 max_mem_image_coe
 
-theorem min_mem_insert_top_image_coe (s : Finset α) :
-    s.min ∈ (insert ⊤ (s.image (↑)) : Finset (WithTop α)) :=
-  mem_insert.2 <| s.eq_empty_or_nonempty.imp min_eq_top.2 min_mem_image_coe
-
+@[to_dual]
 theorem max'_erase_ne_self {s : Finset α} (s0 : (s.erase x).Nonempty) : (s.erase x).max' s0 ≠ x :=
   ne_of_mem_erase (max'_mem _ s0)
 
-theorem min'_erase_ne_self {s : Finset α} (s0 : (s.erase x).Nonempty) : (s.erase x).min' s0 ≠ x :=
-  ne_of_mem_erase (min'_mem _ s0)
-
+@[to_dual]
 theorem max_erase_ne_self {s : Finset α} : (s.erase x).max ≠ x := by
   by_cases! s0 : (s.erase x).Nonempty
   · refine ne_of_eq_of_ne (coe_max' s0).symm ?_
@@ -395,20 +273,12 @@ theorem max_erase_ne_self {s : Finset α} : (s.erase x).max ≠ x := by
   · rw [s0, max_empty]
     exact WithBot.bot_ne_coe
 
-theorem min_erase_ne_self {s : Finset α} : (s.erase x).min ≠ x := by
-  apply mt (congr_arg (WithTop.map toDual))
-  rw [map_toDual_min, image_erase toDual.injective, WithTop.map_coe]
-  apply max_erase_ne_self
-
+@[to_dual exists_next_left]
 theorem exists_next_right {x : α} {s : Finset α} (h : ∃ y ∈ s, x < y) :
     ∃ y ∈ s, x < y ∧ ∀ z ∈ s, x < z → y ≤ z :=
   have Hne : (s.filter (x < ·)).Nonempty := h.imp fun y hy => mem_filter.2 (by simpa)
   have aux := mem_filter.1 (min'_mem _ Hne)
   ⟨min' _ Hne, aux.1, by simp, fun z hzs hz => min'_le _ _ <| mem_filter.2 ⟨hzs, by simpa⟩⟩
-
-theorem exists_next_left {x : α} {s : Finset α} (h : ∃ y ∈ s, y < x) :
-    ∃ y ∈ s, y < x ∧ ∀ z ∈ s, z < x → z ≤ y :=
-  @exists_next_right αᵒᵈ _ x s h
 
 /-- If finsets `s` and `t` are interleaved, then `Finset.card s ≤ Finset.card t + 1`. -/
 theorem card_le_of_interleaved {s t : Finset α}
@@ -456,7 +326,13 @@ alias card_le_diff_of_interleaved := card_le_sdiff_of_interleaved
 * it is true on the empty `Finset`,
 * for every `s : Finset α` and an element `a` strictly greater than all elements of `s`, `p s`
   implies `p (insert a s)`. -/
-@[elab_as_elim]
+@[to_dual (attr := elab_as_elim)
+/-- Induction principle for `Finset`s in a linearly ordered type: a predicate is true on all
+`s : Finset α` provided that:
+
+* it is true on the empty `Finset`,
+* for every `s : Finset α` and an element `a` strictly less than all elements of `s`, `p s`
+  implies `p (insert a s)`. -/]
 theorem induction_on_max
     [DecidableEq α] {motive : Finset α → Prop} (s : Finset α) (empty : motive ∅)
     (insert : ∀ a s, (∀ x ∈ s, x < a) → motive s → motive (insert a s)) : motive s := by
@@ -466,18 +342,6 @@ theorem induction_on_max
   · have H : s.max' hne ∈ s := max'_mem s hne
     rw [← insert_erase H]
     exact insert _ _ (fun x ↦ s.lt_max'_of_mem_erase_max' hne) (ih _ H)
-
-/-- Induction principle for `Finset`s in a linearly ordered type: a predicate is true on all
-`s : Finset α` provided that:
-
-* it is true on the empty `Finset`,
-* for every `s : Finset α` and an element `a` strictly less than all elements of `s`, `p s`
-  implies `p (insert a s)`. -/
-@[elab_as_elim]
-theorem induction_on_min
-    [DecidableEq α] {motive : Finset α → Prop} (s : Finset α) (empty : motive ∅)
-    (insert : ∀ a s, (∀ x ∈ s, a < x) → motive s → motive (insert a s)) : motive s :=
-  @induction_on_max αᵒᵈ _ _ _ s empty insert
 
 end MaxMin
 
@@ -491,7 +355,13 @@ ordered type : a predicate is true on all `s : Finset α` provided that:
 * it is true on the empty `Finset`,
 * for every `s : Finset α` and an element `a` such that for elements of `s` denoted by `x` we have
   `f x ≤ f a`, `p s` implies `p (insert a s)`. -/
-@[elab_as_elim]
+@[to_dual (attr := elab_as_elim)
+/-- Induction principle for `Finset`s in any type from which a given function `f` maps to a linearly
+ordered type : a predicate is true on all `s : Finset α` provided that:
+
+* it is true on the empty `Finset`,
+* for every `s : Finset α` and an element `a` such that for elements of `s` denoted by `x` we have
+  `f a ≤ f x`, `p s` implies `p (insert a s)`. -/]
 theorem induction_on_max_value
     [DecidableEq ι] (f : ι → α) {motive : Finset ι → Prop} (s : Finset ι) (empty : motive ∅)
     (insert : ∀ a s, a ∉ s → (∀ x ∈ s, f x ≤ f a) → motive s → motive (insert a s)) : motive s := by
@@ -507,36 +377,22 @@ theorem induction_on_max_value
     rw [hfa]
     exact le_max' _ _ (mem_image_of_mem _ <| mem_of_mem_erase hx)
 
-/-- Induction principle for `Finset`s in any type from which a given function `f` maps to a linearly
-ordered type : a predicate is true on all `s : Finset α` provided that:
-
-* it is true on the empty `Finset`,
-* for every `s : Finset α` and an element `a` such that for elements of `s` denoted by `x` we have
-  `f a ≤ f x`, `p s` implies `p (insert a s)`. -/
-@[elab_as_elim]
-theorem induction_on_min_value
-    [DecidableEq ι] (f : ι → α) {motive : Finset ι → Prop} (s : Finset ι) (empty : motive ∅)
-    (insert : ∀ a s, a ∉ s → (∀ x ∈ s, f a ≤ f x) → motive s → motive (insert a s)) : motive s :=
-  @induction_on_max_value αᵒᵈ ι _ _ _ _ s empty insert
-
 end MaxMinInductionValue
 
 section ExistsMaxMin
 
 variable [LinearOrder α]
 
+@[to_dual]
 theorem exists_max_image (s : Finset β) (f : β → α) (h : s.Nonempty) :
     ∃ x ∈ s, ∀ x' ∈ s, f x' ≤ f x := by
   obtain ⟨y, hy⟩ := max_of_nonempty (h.image f)
   rcases mem_image.mp (mem_of_max hy) with ⟨x, hx, rfl⟩
   exact ⟨x, hx, fun x' hx' => le_max_of_eq (mem_image_of_mem f hx') hy⟩
 
-theorem exists_min_image (s : Finset β) (f : β → α) (h : s.Nonempty) :
-    ∃ x ∈ s, ∀ x' ∈ s, f x ≤ f x' :=
-  @exists_max_image αᵒᵈ β _ s f h
-
 end ExistsMaxMin
 
+@[to_dual]
 theorem isGLB_iff_isLeast [LinearOrder α] (i : α) (s : Finset α) (hs : s.Nonempty) :
     IsGLB (s : Set α) i ↔ IsLeast (↑s) i := by
   refine ⟨fun his => ?_, IsLeast.isGLB⟩
@@ -546,27 +402,17 @@ theorem isGLB_iff_isLeast [LinearOrder α] (i : α) (s : Finset α) (hs : s.None
   rw [IsGLB, IsGreatest, mem_lowerBounds, mem_upperBounds] at his
   exact le_antisymm (his.1 (Finset.min' s hs) (Finset.min'_mem s hs)) (his.2 _ (Finset.min'_le s))
 
-theorem isLUB_iff_isGreatest [LinearOrder α] (i : α) (s : Finset α) (hs : s.Nonempty) :
-    IsLUB (s : Set α) i ↔ IsGreatest (↑s) i :=
-  @isGLB_iff_isLeast αᵒᵈ _ i s hs
-
+@[to_dual]
 theorem isGLB_mem [LinearOrder α] {i : α} (s : Finset α) (his : IsGLB (s : Set α) i)
     (hs : s.Nonempty) : i ∈ s := by
   rw [← mem_coe]
   exact ((isGLB_iff_isLeast i s hs).mp his).1
 
-theorem isLUB_mem [LinearOrder α] {i : α} (s : Finset α) (his : IsLUB (s : Set α) i)
-    (hs : s.Nonempty) : i ∈ s :=
-  @isGLB_mem αᵒᵈ _ i s his hs
-
 end Finset
 
+@[to_dual]
 theorem Multiset.exists_max_image {α R : Type*} [LinearOrder R] (f : α → R) {s : Multiset α}
     (hs : s ≠ 0) : ∃ y ∈ s, ∀ z ∈ s, f z ≤ f y := by
   classical
   obtain ⟨y, hys, hy⟩ := Finset.exists_max_image s.toFinset f (toFinset_nonempty.mpr hs)
   exact ⟨y, mem_toFinset.mp hys, fun _ hz ↦ hy _ (mem_toFinset.mpr hz)⟩
-
-theorem Multiset.exists_min_image {α R : Type*} [LinearOrder R] (f : α → R) {s : Multiset α}
-    (hs : s ≠ 0) : ∃ y ∈ s, ∀ z ∈ s, f y ≤ f z :=
-  @exists_max_image α Rᵒᵈ _ f s hs


### PR DESCRIPTION
This PR uses `to_dual` on `Finset.max` and `Finset.max'`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
