### PR TITLE
[Merged by Bors] - chore(Data/Finset/Lattice/Fold): fix comp_inf'_eq_inf'_comp alias target

### DIFF
--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -624,7 +624,7 @@ theorem apply_sup'_eq_sup'_comp [SemilatticeSup γ] {s : Finset β} (H : s.Nonem
 alias comp_sup'_eq_sup'_comp := apply_sup'_eq_sup'_comp
 
 @[deprecated (since := "2026-05-29")]
-alias comp_inf'_eq_inf'_comp := apply_sup'_eq_sup'_comp
+alias comp_inf'_eq_inf'_comp := apply_inf'_eq_inf'_comp
 
 @[to_dual (attr := simp)]
 theorem _root_.map_finset_sup' [SemilatticeSup β] [FunLike F α β] [SupHomClass F α β]


### PR DESCRIPTION
The deprecated alias introduced in #37185 points at the wrong lemma.
Retarget it to apply_inf'_eq_inf'_comp.

---

Encountered while porting code from 4.29 to 4.33.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

AI disclosure:

Diagnosed the issue with Claude Code Fable, which also proposed the trivial fix.

