### PR TITLE
[Merged by Bors] - feat(AffineSpace): `Singleton` instance for `AffineSubspace`

### DIFF
--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -169,10 +169,15 @@ theorem eq_orthogonalProjection_of_eq_subspace {s s' : AffineSubspace 𝕜 P} [N
   subst h
   rfl
 
-@[simp] lemma orthogonalProjection_affineSpan_singleton (p₁ p₂ : P) :
+@[simp] lemma orthogonalProjection_singleton (p₁ p₂ : P) :
     orthogonalProjection ({p₁} : AffineSubspace 𝕜 P) p₂ = p₁ := by
   have h := SetLike.coe_mem (orthogonalProjection ({p₁} : AffineSubspace 𝕜 P) p₂)
   rwa [mem_singleton_iff] at h
+
+@[deprecated orthogonalProjection_singleton (since := "2026-09-01")]
+lemma orthogonalProjection_affineSpan_singleton (p₁ p₂ : P) :
+    orthogonalProjection (affineSpan 𝕜 {p₁}) p₂ = p₁ := by
+  simp
 
 /-- The distance to a point's orthogonal projection is 0 iff it lies in the subspace. -/
 theorem dist_orthogonalProjection_eq_zero_iff {s : AffineSubspace 𝕜 P} [Nonempty s]

--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -623,7 +623,7 @@ theorem dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq
 lemma orthogonalProjectionSpan_eq_point (s : Simplex 𝕜 P 0) (p : P) :
     s.orthogonalProjectionSpan p = s.points 0 := by
   rw [orthogonalProjectionSpan]
-  convert! orthogonalProjection_affineSpan_singleton _ _
+  convert! orthogonalProjection_singleton _ _
   simp [Fin.fin_one_eq_zero]
 
 lemma orthogonalProjectionSpan_faceOpposite_eq_point_rev (s : Simplex 𝕜 P 1) (i : Fin 2)

--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -170,9 +170,9 @@ theorem eq_orthogonalProjection_of_eq_subspace {s s' : AffineSubspace 𝕜 P} [N
   rfl
 
 @[simp] lemma orthogonalProjection_affineSpan_singleton (p₁ p₂ : P) :
-    orthogonalProjection (affineSpan 𝕜 {p₁}) p₂ = p₁ := by
-  have h := SetLike.coe_mem (orthogonalProjection (affineSpan 𝕜 {p₁}) p₂)
-  rwa [mem_affineSpan_singleton] at h
+    orthogonalProjection ({p₁} : AffineSubspace 𝕜 P) p₂ = p₁ := by
+  have h := SetLike.coe_mem (orthogonalProjection ({p₁} : AffineSubspace 𝕜 P) p₂)
+  rwa [mem_singleton_iff] at h
 
 /-- The distance to a point's orthogonal projection is 0 iff it lies in the subspace. -/
 theorem dist_orthogonalProjection_eq_zero_iff {s : AffineSubspace 𝕜 P} [Nonempty s]

--- a/Mathlib/Geometry/Euclidean/SignedDist.lean
+++ b/Mathlib/Geometry/Euclidean/SignedDist.lean
@@ -280,8 +280,8 @@ lemma abs_signedInfDist_eq_dist_of_mem_affineSpan_insert {x : P}
     orthogonalProjection_vsub_orthogonalProjection, norm_smul, abs_mul]
 
 lemma signedInfDist_singleton :
-    (affineSpan ℝ ({q} : Set P)).signedInfDist p = signedDist (p -ᵥ q) q := by
-  simpa using signedInfDist_eq_signedDist_of_mem (mem_affineSpan ℝ (Set.mem_singleton q))
+    ({q} : AffineSubspace ℝ P).signedInfDist p = signedDist (p -ᵥ q) q := by
+  simpa using signedInfDist_eq_signedDist_of_mem (mem_singleton q)
 
 end AffineSubspace
 

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
@@ -131,28 +131,20 @@ variable {k : Type*} {V : Type*} {P : Type*} [Ring k] [AddCommGroup V] [Module k
 
 variable (k V) {p₁ p₂ : P}
 
-/-- The affine span of a single point, coerced to a set, contains just that point. -/
-@[simp]
-theorem coe_affineSpan_singleton (p : P) : (affineSpan k ({p} : Set P) : Set P) = {p} := by
-  ext x
-  rw [mem_coe, ← vsub_right_mem_direction_iff_mem (mem_affineSpan k (Set.mem_singleton p)) _,
-    direction_affineSpan]
-  simp
-
 /-- A point is in the affine span of a single point if and only if they are equal. -/
 @[simp]
-theorem mem_affineSpan_singleton : p₁ ∈ affineSpan k ({p₂} : Set P) ↔ p₁ = p₂ := by
-  simp [← mem_coe]
-
-@[simp]
 lemma affineSpan_singleton (x : P) : affineSpan k ({x} : Set P) = {x} := by
-  ext; simp
+  ext y
+  simp [← vsub_right_mem_direction_iff_mem (mem_affineSpan k _) _, direction_affineSpan]
 
 @[simp]
 theorem coe_affineSpan_eq_singleton_iff (s : Set P) (x : P) : affineSpan k s = {x} ↔ s = {x} := by
   refine ⟨fun h ↦ ?_, by simp +contextual⟩
   refine Set.Nonempty.subset_singleton_iff ?_ |>.mp (by simpa using affineSpan_le.mp h.le)
   exact affineSpan_nonempty k |>.mp (by simp [h])
+
+theorem mem_affineSpan_singleton : p₁ ∈ affineSpan k ({p₂} : Set P) ↔ p₁ = p₂ := by
+  simp
 
 instance unique_affineSpan_singleton (p : P) : Unique (affineSpan k {p}) where
   default := ⟨p, mem_affineSpan _ (Set.mem_singleton _)⟩

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
@@ -144,6 +144,16 @@ theorem coe_affineSpan_singleton (p : P) : (affineSpan k ({p} : Set P) : Set P) 
 theorem mem_affineSpan_singleton : p₁ ∈ affineSpan k ({p₂} : Set P) ↔ p₁ = p₂ := by
   simp [← mem_coe]
 
+@[simp]
+lemma affineSpan_singleton (x : P) : affineSpan k ({x} : Set P) = {x} := by
+  ext; simp
+
+@[simp]
+theorem coe_affineSpan_eq_singleton_iff (s : Set P) (x : P) : affineSpan k s = {x} ↔ s = {x} := by
+  refine ⟨fun h ↦ ?_, by simp +contextual⟩
+  refine Set.Nonempty.subset_singleton_iff ?_ |>.mp (by simpa using affineSpan_le.mp h.le)
+  exact affineSpan_nonempty k |>.mp (by simp [h])
+
 instance unique_affineSpan_singleton (p : P) : Unique (affineSpan k {p}) where
   default := ⟨p, mem_affineSpan _ (Set.mem_singleton _)⟩
   uniq := fun x ↦ Subtype.ext ((mem_affineSpan_singleton _ _).1 x.property)

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
@@ -137,6 +137,11 @@ lemma affineSpan_singleton (x : P) : affineSpan k ({x} : Set P) = {x} := by
   ext y
   simp [← vsub_right_mem_direction_iff_mem (mem_affineSpan k _) _, direction_affineSpan]
 
+/-- The affine span of a single point, coerced to a set, contains just that point. -/
+@[deprecated affineSpan_singleton (since := "2026-09-01")]
+theorem coe_affineSpan_singleton (p : P) : (affineSpan k ({p} : Set P) : Set P) = {p} := by
+  simp
+
 @[simp]
 theorem coe_affineSpan_eq_singleton_iff (s : Set P) (x : P) : affineSpan k s = {x} ↔ s = {x} := by
   refine ⟨fun h ↦ ?_, by simp +contextual⟩
@@ -171,8 +176,8 @@ theorem subsingleton_of_subsingleton_span_eq_top {s : Set P} (h₁ : s.Subsingle
     (h₂ : affineSpan k s = ⊤) : Subsingleton P := by
   obtain ⟨p, hp⟩ := AffineSubspace.nonempty_of_affineSpan_eq_top k V P h₂
   have : s = {p} := Subset.antisymm (fun q hq => h₁ hq hp) (by simp [hp])
-  rw [this, AffineSubspace.ext_iff, AffineSubspace.coe_affineSpan_singleton,
-    AffineSubspace.top_coe, eq_comm, ← subsingleton_iff_singleton (mem_univ _)] at h₂
+  rw [this, AffineSubspace.ext_iff, AffineSubspace.top_coe, eq_comm, affineSpan_singleton,
+    coe_singleton, ← subsingleton_iff_singleton (mem_univ _)] at h₂
   exact subsingleton_of_univ_subsingleton h₂
 
 theorem eq_univ_of_subsingleton_span_eq_top {s : Set P} (h₁ : s.Subsingleton)
@@ -470,10 +475,9 @@ the subspace. -/
 theorem direction_affineSpan_insert {s : AffineSubspace k P} {p₁ p₂ : P} (hp₁ : p₁ ∈ s) :
     (affineSpan k (insert p₂ (s : Set P))).direction =
     Submodule.span k {p₂ -ᵥ p₁} ⊔ s.direction := by
-  rw [sup_comm, ← Set.union_singleton, ← coe_affineSpan_singleton k V p₂]
-  change (s ⊔ affineSpan k {p₂}).direction = _
-  rw [direction_sup hp₁ (mem_affineSpan k (Set.mem_singleton _)), direction_affineSpan]
-  simp
+  rw [sup_comm, ← Set.union_singleton, ← AffineSubspace.coe_singleton (k := k) p₂]
+  change (s ⊔ {p₂}).direction = _
+  simp [direction_sup hp₁ (mem_singleton _)]
 
 /-- Given a point `p₁` in an affine subspace `s`, and a point `p₂`, a point `p` is in the span of
 `s` with `p₂` added if and only if it is a multiple of `p₂ -ᵥ p₁` added to a point in `s`. -/

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -163,6 +163,29 @@ instance : SetLike (AffineSubspace k P) P where
 
 instance : PartialOrder (AffineSubspace k P) := .ofSetLike (AffineSubspace k P) P
 
+instance : Singleton P (AffineSubspace k P) where
+  singleton x := {
+    carrier := {x}
+    smul_vsub_vadd_mem' _ _ _ _ := by simp +contextual }
+
+@[simp] theorem coe_singleton (x : P) : ({x} : AffineSubspace k P) = ({x} : Set P) := rfl
+
+@[simp, grind =, push]
+theorem mem_singleton_iff (x y : P) : x ∈ ({y} : AffineSubspace k P) ↔ x = y := by
+  simp [← SetLike.mem_coe]
+
+theorem notMem_singleton_iff (x y : P) : x ∉ ({y} : AffineSubspace k P) ↔ x ≠ y := by
+  simp [← SetLike.mem_coe]
+
+theorem mem_singleton (x : P) : x ∈ ({x} : AffineSubspace k P) := by simp [← SetLike.mem_coe]
+
+theorem eq_of_mem_singleton {x y : P} (h : x ∈ ({y} : AffineSubspace k P)) : x = y := by
+  simpa [← SetLike.mem_coe] using h
+
+@[simp]
+theorem singleton_eq_singleton_iff (x y : P) : {x} = ({y} : AffineSubspace k P) ↔ x = y := by
+  simp [← SetLike.coe_set_eq]
+
 @[simp] lemma carrier_eq_coe (s : AffineSubspace k P) : s.carrier = s := rfl
 
 lemma smul_vsub_vadd_mem (s : AffineSubspace k P) (c : k) {p₁ p₂ p₃ : P} :
@@ -239,6 +262,10 @@ def direction (s : AffineSubspace k P) : Submodule k V :=
 /-- The direction equals the `vectorSpan`. -/
 theorem direction_eq_vectorSpan (s : AffineSubspace k P) : s.direction = vectorSpan k (s : Set P) :=
   rfl
+
+@[simp]
+theorem direction_singleton_eq_bot (x : P) : ({x} : AffineSubspace k P).direction = ⊥ := by
+  simp [AffineSubspace.direction]
 
 /-- Alternative definition of the direction when the affine subspace is nonempty. This is defined so
 that the order on submodules (as used in the definition of `Submodule.span`) can be used in the

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -264,8 +264,8 @@ theorem direction_eq_vectorSpan (s : AffineSubspace k P) : s.direction = vectorS
   rfl
 
 @[simp]
-theorem direction_singleton_eq_bot (x : P) : ({x} : AffineSubspace k P).direction = ⊥ := by
-  simp [AffineSubspace.direction]
+theorem direction_singleton (x : P) : ({x} : AffineSubspace k P).direction = ⊥ := by
+  simp [direction]
 
 /-- Alternative definition of the direction when the affine subspace is nonempty. This is defined so
 that the order on submodules (as used in the definition of `Submodule.span`) can be used in the
@@ -991,6 +991,10 @@ alias ⟨_, _root_.Set.Nonempty.affineSpan⟩ := affineSpan_nonempty
 /-- The affine span of a nonempty set is nonempty. -/
 instance [Nonempty s] : Nonempty (affineSpan k s) :=
   ((nonempty_coe_sort.1 ‹_›).affineSpan _).to_subtype
+
+/-- The affine span of a singleton is nonempty. -/
+instance (x : P) : Nonempty ({x} : AffineSubspace k P) :=
+  ⟨x, SetLike.mem_coe.mp rfl⟩
 
 /-- The affine span of a set is `⊥` if and only if that set is empty. -/
 @[simp]

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -79,6 +79,12 @@ instance finiteDimensional_direction_affineSpan_singleton (p : P) :
   rw [direction_affineSpan]
   infer_instance
 
+/-- The direction of a singleton is finite-dimensional. -/
+instance finiteDimensional_directionsingleton (p : P) :
+    FiniteDimensional k ({p} : AffineSubspace k P).direction := by
+  rw [← affineSpan_singleton]
+  infer_instance
+
 /-- The direction of the affine span of a family indexed by a
 `Fintype` is finite-dimensional. -/
 instance finiteDimensional_direction_affineSpan_range [Finite ι] (p : ι → P) :

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -80,7 +80,7 @@ instance finiteDimensional_direction_affineSpan_singleton (p : P) :
   infer_instance
 
 /-- The direction of a singleton is finite-dimensional. -/
-instance finiteDimensional_directionsingleton (p : P) :
+instance finiteDimensional_direction_singleton (p : P) :
     FiniteDimensional k ({p} : AffineSubspace k P).direction := by
   rw [← affineSpan_singleton]
   infer_instance


### PR DESCRIPTION
Add a Singleton instance to allow referring to the singleton affine subspace as `{x}` instead of having to use the more cumbersome `affineSpan R {x}`. I've found this useful working in the [Polyhedral](https://github.com/ooovi/Polyhedral) repository and want to upstream it for subsequent PRs.

Created as part of the Berlin "Polyhedra in Lean" workshop.

Co-authored-by: Martin Winter @martinwintermath

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
