### PR TITLE
feat: quaternion operations wrt coordinates

### DIFF
--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -173,6 +173,8 @@ instance : Zero ℍ[R,c₁,c₂,c₃] := ⟨⟨0, 0, 0, 0⟩⟩
 @[simp, norm_cast]
 theorem coe_zero : ((0 : R) : ℍ[R,c₁,c₂,c₃]) = 0 := rfl
 
+lemma mk_zero : (0 : ℍ[R,c₁,c₂,c₃]) = ⟨0, 0, 0, 0⟩ := rfl
+
 instance : Inhabited ℍ[R,c₁,c₂,c₃] := ⟨0⟩
 
 section One
@@ -185,6 +187,8 @@ instance : One ℍ[R,c₁,c₂,c₃] := ⟨⟨1, 0, 0, 0⟩⟩
 
 @[simp, norm_cast]
 theorem coe_one : ((1 : R) : ℍ[R,c₁,c₂,c₃]) = 1 := rfl
+
+lemma mk_one : (1 : ℍ[R,c₁,c₂,c₃]) = ⟨1, 0, 0, 0⟩ := rfl
 
 end One
 end Zero
@@ -390,6 +394,8 @@ theorem im_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).im = 0 :=
 theorem coe_natCast (n : ℕ) : ↑(n : R) = (n : ℍ[R,c₁,c₂,c₃]) :=
   rfl
 
+lemma mk_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]) = ⟨n, 0, 0, 0⟩ := rfl
+
 @[simp, norm_cast]
 theorem re_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).re = z :=
   rfl
@@ -428,6 +434,8 @@ theorem im_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).im = 0 :=
 @[norm_cast]
 theorem coe_intCast (z : ℤ) : ↑(z : R) = (z : ℍ[R,c₁,c₂,c₃]) :=
   rfl
+
+lemma mk_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]) = ⟨z, 0, 0, 0⟩ := rfl
 
 end AddCommGroupWithOne
 
@@ -838,6 +846,14 @@ theorem imK_mul : (a * b).imK = a.re * b.imK + a.imI * b.imJ - a.imJ * b.imI + a
 @[simp, norm_cast]
 theorem coe_mul : ((x * y : R) : ℍ[R]) = x * y := QuaternionAlgebra.coe_mul x y
 
+lemma mk_mul_mk (a₁ a₂ a₃ a₄ b₁ b₂ b₃ b₄ : R) :
+    (⟨a₁, a₂, a₃, a₄⟩ : ℍ[R]) * ⟨b₁, b₂, b₃, b₄⟩ =
+    ⟨a₁ * b₁ - a₂ * b₂ - a₃ * b₃ - a₄ * b₄,
+     a₁ * b₂ + a₂ * b₁ + a₃ * b₄ - a₄ * b₃,
+     a₁ * b₃ - a₂ * b₄ + a₃ * b₁ + a₄ * b₂,
+     a₁ * b₄ + a₂ * b₃ - a₃ * b₂ + a₄ * b₁⟩ := by
+  ext; exacts [re_mul .., imI_mul .., imJ_mul .., imK_mul ..]
+
 @[norm_cast, simp]
 theorem coe_pow (n : ℕ) : (↑(x ^ n) : ℍ[R]) = (x : ℍ[R]) ^ n :=
   QuaternionAlgebra.coe_pow x n
@@ -960,6 +976,8 @@ theorem star_eq_two_re_sub : star a = ↑(2 * a.re) - a := by
 @[simp, norm_cast]
 theorem star_coe : star (x : ℍ[R]) = x :=
   QuaternionAlgebra.star_coe x
+
+lemma star_mk (a₁ a₂ a₃ a₄ : R) : star (⟨a₁, a₂, a₃, a₄⟩ : ℍ[R]) = ⟨a₁, -a₂, -a₃, -a₄⟩ := by simp
 
 @[simp]
 theorem star_im : star a.im = -a.im := by ext <;> simp


### PR DESCRIPTION
Add `QuaternionAlgebra.mk_{zero,one,natCast,intCast}` and `QuaternionAlgebra.{mk_mul_mk,star_mk}` as convenience lemmas for working with quaternions whose coordinates are explicitly given. These lemmas allow [the following code](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Transparency.20problem.20with.20quaternions/near/618254305) to work:

```lean
import Mathlib.Analysis.Quaternion
import Mathlib.NumberTheory.Real.GoldenRatio

noncomputable section
open goldenRatio Quaternion

/-- The unit icosian `(1 + i + j + k) / 2`, which has order 6. -/
def icosian6 : ℍˣ where
  val := ⟨2⁻¹, 2⁻¹, 2⁻¹, 2⁻¹⟩
  inv := ⟨2⁻¹, -2⁻¹, -2⁻¹, -2⁻¹⟩
  val_inv := by rw [mk_mul_mk, QuaternionAlgebra.mk_one]; norm_num
  inv_val := by rw [mk_mul_mk, QuaternionAlgebra.mk_one]; norm_num

/-- The unit icosian `(φ + i + ψ*j) / 2`, which has order 10. -/
def icosian10 : ℍˣ where
  val := ⟨φ / 2, 2⁻¹, ψ / 2, 0⟩
  inv := ⟨φ / 2, -2⁻¹, -ψ / 2, 0⟩
  val_inv := by rw [mk_mul_mk, QuaternionAlgebra.mk_one]; grind
  inv_val := by rw [mk_mul_mk, QuaternionAlgebra.mk_one]; grind

/-- The unit icosians. -/
def Icosian : Subgroup ℍˣ := Subgroup.closure {icosian6, icosian10}
```