### PR TITLE
[Merged by Bors] - feat(cache): read from cache.mathlib.org by default

### DIFF
--- a/Cache/Cli.lean
+++ b/Cache/Cli.lean
@@ -4,15 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Marcelo Lynch
 -/
 
-import Cache.Infra
-
 /-!
-# Cache CLI option and environment flag parsing
+# Cache CLI option parsing
 
-Helpers for the cache binary's command line and for the boolean environment
-variables it reads at startup. They live here rather than in `Cache.Main` so
-the test binary can import them directly — `Cache.Main`'s top-level `main`
-would otherwise collide with the test entrypoint.
+Pure helpers for the cache binary's option parsing. They live here rather than
+in `Cache.Main` so the test binary can import them directly — `Cache.Main`'s
+top-level `main` would otherwise collide with the test entrypoint.
 
 The cache binary partitions its arguments into named options (`--name=value`),
 boolean flags (`--name`), and positional arguments before dispatch. These
@@ -20,8 +17,6 @@ helpers implement that partitioning and the validation of known option names.
 -/
 
 namespace Cache.Cli
-
-open Cache.Requests (nonEmptyEnvValue)
 
 /-- The named options supported by the CLI. -/
 def knownNamedOpts : List String :=
@@ -50,25 +45,5 @@ option. Used to error out on unknown `--`-prefixed tokens so typos like
 def isKnownOpt (opt : String) : Bool :=
   knownNamedOpts.any (opt.startsWith s!"--{·}=") ||
   knownFlagOpts.any (opt == s!"--{·}")
-
-/--
-Value of the boolean environment variable `name`, given its raw value `value?`:
-`1` and `true` are on, `0` and `false` are off, and case does not matter. An
-absent, empty, or whitespace-only value takes `ifUnset`; any other value warns
-on stderr and takes `ifUnset` as well.
--/
-def parseEnvFlag (name : String) (value? : Option String) (ifUnset : Bool) : IO Bool := do
-  let some value := nonEmptyEnvValue value? | return ifUnset
-  match value.toLower with
-  | "1" | "true" => return true
-  | "0" | "false" => return false
-  | _ =>
-    IO.eprintln s!"Warning: ignoring {name}={value} (expected 1, true, 0 or false)."
-    return ifUnset
-
-/-- Value of the boolean environment variable `name`, read from the environment
-and parsed by `parseEnvFlag`. -/
-def getEnvFlag (name : String) (ifUnset : Bool) : IO Bool := do
-  parseEnvFlag name (← IO.getEnv name) ifUnset
 
 end Cache.Cli

--- a/Cache/Cli.lean
+++ b/Cache/Cli.lean
@@ -7,7 +7,7 @@ Authors: Marcelo Lynch
 import Cache.Infra
 
 /-!
-# Cache CLI option parsing
+# Cache CLI option and environment flag parsing
 
 Helpers for the cache binary's command line and for the boolean environment
 variables it reads at startup. They live here rather than in `Cache.Main` so
@@ -54,12 +54,8 @@ def isKnownOpt (opt : String) : Bool :=
 /--
 Value of the boolean environment variable `name`, given its raw value `value?`:
 `1` and `true` are on, `0` and `false` are off, and case does not matter. An
-absent, empty, or whitespace-only value takes `ifUnset`, so a variable that
-defaults on and one that defaults off share this parser.
-
-Any other value warns on stderr and takes `ifUnset` as well. The warning is
-what tells the reader their setting had no effect, so it belongs with the parse
-that rejects the value.
+absent, empty, or whitespace-only value takes `ifUnset`; any other value warns
+on stderr and takes `ifUnset` as well.
 -/
 def parseEnvFlag (name : String) (value? : Option String) (ifUnset : Bool) : IO Bool := do
   let some value := nonEmptyEnvValue value? | return ifUnset

--- a/Cache/Cli.lean
+++ b/Cache/Cli.lean
@@ -4,12 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Marcelo Lynch
 -/
 
+import Cache.Infra
+
 /-!
 # Cache CLI option parsing
 
-Pure helpers for the cache binary's option parsing. They live here rather than
-in `Cache.Main` so the test binary can import them directly — `Cache.Main`'s
-top-level `main` would otherwise collide with the test entrypoint.
+Helpers for the cache binary's command line and for the boolean environment
+variables it reads at startup. They live here rather than in `Cache.Main` so
+the test binary can import them directly — `Cache.Main`'s top-level `main`
+would otherwise collide with the test entrypoint.
 
 The cache binary partitions its arguments into named options (`--name=value`),
 boolean flags (`--name`), and positional arguments before dispatch. These
@@ -17,6 +20,8 @@ helpers implement that partitioning and the validation of known option names.
 -/
 
 namespace Cache.Cli
+
+open Cache.Requests (nonEmptyEnvValue)
 
 /-- The named options supported by the CLI. -/
 def knownNamedOpts : List String :=
@@ -45,5 +50,29 @@ option. Used to error out on unknown `--`-prefixed tokens so typos like
 def isKnownOpt (opt : String) : Bool :=
   knownNamedOpts.any (opt.startsWith s!"--{·}=") ||
   knownFlagOpts.any (opt == s!"--{·}")
+
+/--
+Value of the boolean environment variable `name`, given its raw value `value?`:
+`1` and `true` are on, `0` and `false` are off, and case does not matter. An
+absent, empty, or whitespace-only value takes `ifUnset`, so a variable that
+defaults on and one that defaults off share this parser.
+
+Any other value warns on stderr and takes `ifUnset` as well. The warning is
+what tells the reader their setting had no effect, so it belongs with the parse
+that rejects the value.
+-/
+def parseEnvFlag (name : String) (value? : Option String) (ifUnset : Bool) : IO Bool := do
+  let some value := nonEmptyEnvValue value? | return ifUnset
+  match value.toLower with
+  | "1" | "true" => return true
+  | "0" | "false" => return false
+  | _ =>
+    IO.eprintln s!"Warning: ignoring {name}={value} (expected 1, true, 0 or false)."
+    return ifUnset
+
+/-- Value of the boolean environment variable `name`, read from the environment
+and parsed by `parseEnvFlag`. -/
+def getEnvFlag (name : String) (ifUnset : Bool) : IO Bool := do
+  parseEnvFlag name (← IO.getEnv name) ifUnset
 
 end Cache.Cli

--- a/Cache/Env.lean
+++ b/Cache/Env.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Marcelo Lynch. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Marcelo Lynch
+-/
+
+/-!
+# Cache environment variable parsing
+
+Helpers for reading the cache tool's environment variables: an empty or
+whitespace-only value means unset, a base URL also loses its trailing slashes,
+and a boolean flag accepts `1`/`true` and `0`/`false`.
+-/
+
+namespace Cache
+
+/--
+Trimmed value of an environment variable. An empty or whitespace-only value
+means unset.
+
+CI wires the cache variables from a GitHub Actions `vars` lookup. That lookup
+yields an empty string for an undefined variable, and such a value selects the
+same behavior as an absent one.
+-/
+def nonEmptyEnvValue (value? : Option String) : Option String :=
+  (value?.map (·.trimAscii.copy)).filter (!·.isEmpty)
+
+/-- Reads `name` from the environment through `nonEmptyEnvValue`. -/
+def getEnvNonEmpty (name : String) : IO (Option String) := do
+  return nonEmptyEnvValue (← IO.getEnv name)
+
+/--
+Value of an environment variable that names a base URL. The same empty rule as
+`nonEmptyEnvValue` applies, and the base also loses its trailing slashes, so a
+later `/{path}` follows a single separator.
+-/
+def normalizeBaseURL (value? : Option String) : Option String :=
+  (value?.map fun v => (v.trimAscii.dropEndWhile '/').copy).filter (!·.isEmpty)
+
+/--
+Value of the boolean environment variable `name`, given its raw value `value?`:
+`1` and `true` are on, `0` and `false` are off, and case does not matter. An
+absent, empty, or whitespace-only value takes `ifUnset`; any other value warns
+on stderr and takes `ifUnset` as well.
+-/
+def parseEnvFlag (name : String) (value? : Option String) (ifUnset : Bool) : IO Bool := do
+  let some value := nonEmptyEnvValue value? | return ifUnset
+  match value.toLower with
+  | "1" | "true" => return true
+  | "0" | "false" => return false
+  | _ =>
+    IO.eprintln s!"Warning: ignoring {name}={value} (expected 1, true, 0 or false)."
+    return ifUnset
+
+/-- Value of the boolean environment variable `name`, read from the environment
+and parsed by `parseEnvFlag`. -/
+def getEnvFlag (name : String) (ifUnset : Bool) : IO Bool := do
+  parseEnvFlag name (← IO.getEnv name) ifUnset
+
+end Cache

--- a/Cache/Infra.lean
+++ b/Cache/Infra.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Marcelo Lynch, Arthur Paulino
 -/
 
+import Cache.Env
+
 /-!
 # Cache backend infrastructure
 
@@ -131,29 +133,6 @@ def flatPath (c : Container) (repo : String) : Bool :=
   | _ => false
 
 end Container
-
-/--
-Trimmed value of an environment variable. An empty or whitespace-only value
-means unset.
-
-CI wires the cache variables from a GitHub Actions `vars` lookup. That lookup
-yields an empty string for an undefined variable, and such a value selects the
-same behavior as an absent one.
--/
-def nonEmptyEnvValue (value? : Option String) : Option String :=
-  (value?.map (·.trimAscii.copy)).filter (!·.isEmpty)
-
-/-- Reads `name` from the environment through `nonEmptyEnvValue`. -/
-def getEnvNonEmpty (name : String) : IO (Option String) := do
-  return nonEmptyEnvValue (← IO.getEnv name)
-
-/--
-Value of an environment variable that names a base URL. The same empty rule as
-`nonEmptyEnvValue` applies, and the base also loses its trailing slashes, so a
-later `/{path}` follows a single separator.
--/
-def normalizeBaseURL (value? : Option String) : Option String :=
-  (value?.map fun v => (v.trimAscii.dropEndWhile '/').copy).filter (!·.isEmpty)
 
 /--
 The public Mathlib cache endpoint. It serves the same `/{container}/{key}`

--- a/Cache/Infra.lean
+++ b/Cache/Infra.lean
@@ -163,22 +163,14 @@ The Mathlib cache read endpoint: one hostname that serves the whole
 at its edge. A read through it costs the project less and lands nearer the
 reader than a read straight from storage.
 -/
-def cacheHostURL : String := "https://cache.mathlib.org"
+def publicCacheEndpoint : String := "https://cache.mathlib.org"
 
 /--
-Whether the tool takes its legacy path wherever a legacy and a current one
-differ. It governs one such choice: which host serves reads, `azureAccountURL`
-or `cacheHostURL`.
+Set this from `MATHLIB_CACHE_DEBUG_USE_LEGACY` at startup.
 
-`main` sets this from `MATHLIB_CACHE_DEBUG_USE_LEGACY` at startup, so the
-variable is read once and a value `Cache.Cli.parseEnvFlag` cannot read warns
-once, however many read URLs the command builds.
-
-That variable is a troubleshooting fallback, for the days when the current path
-misbehaves and a contributor needs their build to finish. It is no part of the
-tool's interface: nothing should depend on it, and it goes away with the legacy
-path it selects. A consumer that needs a durable choice of read host names one
-with `MATHLIB_CACHE_BASE_URL`.
+That variable is intended a troubleshooting fallback as the public Mathlib endpoint
+(enabled in September 2026) is battle-tested. It should be retired once support for
+the Azure storage account is disabled.
 -/
 initialize useLegacy : IO.Ref Bool ← IO.mkRef false
 
@@ -187,7 +179,7 @@ Default base URL for cache reads: the read endpoint, or the storage account
 itself, which is the legacy read host.
 -/
 def defaultGetBaseURL (useLegacy : Bool) : String :=
-  if useLegacy then azureAccountURL else cacheHostURL
+  if useLegacy then azureAccountURL else publicCacheEndpoint
 
 /--
 Base URL for cache reads: `MATHLIB_CACHE_BASE_URL` if set, otherwise
@@ -203,12 +195,6 @@ external consumers: it names one flat endpoint and bypasses the container
 lookup chain. `MATHLIB_CACHE_BASE_URL` serves internal consumers, that is,
 CI and contributors to the mathlib4 repository. It keeps the lookup chain and
 rebases each container read under the given host.
-
-The audience follows from what each variable exposes. The chain and the
-container names are mathlib4's own layout, free to change with the containers
-themselves, so only a reader who tracks this repository should bind to them. A
-project that depends on mathlib reads through `MATHLIB_CACHE_GET_URL`, whose
-flat namespace is a stable contract.
 
 Only reads follow this base. Uploads, marker writes, and the blob-listing
 query authenticate against Azure and use `Container.azureURL` directly.

--- a/Cache/Infra.lean
+++ b/Cache/Infra.lean
@@ -64,6 +64,11 @@ inductive Container where
   | legacy
   deriving DecidableEq, Repr, BEq, Inhabited
 
+/--
+Base URL of the `lakecache` Azure Blob Storage account.
+-/
+def azureAccountURL : String := "https://lakecache.blob.core.windows.net"
+
 namespace Container
 
 /-- Canonical short name for a container, used in CLI flags and URLs. -/
@@ -100,7 +105,7 @@ def azureContainerName : Container → String
 
 /-- Public Azure Blob Storage base URL for a container. -/
 def azureURL (c : Container) : String :=
-  s!"https://lakecache.blob.core.windows.net/{c.azureContainerName}"
+  s!"{azureAccountURL}/{c.azureContainerName}"
 
 /--
 Whether file lookups in this container use the flat `/f/<hash>` layout, or
@@ -152,14 +157,44 @@ later `/{path}` follows a single separator.
 def normalizeBaseURL (value? : Option String) : Option String :=
   (value?.map fun v => (v.trimAscii.dropEndWhile '/').copy).filter (!·.isEmpty)
 
-/-- Default base URL for cache reads: the direct address of the Azure Blob
-Storage account. -/
-def defaultGetBaseURL : String := "https://lakecache.blob.core.windows.net"
+/--
+The Mathlib cache read endpoint: one hostname that serves the whole
+`/{container}/{key}` namespace the storage account holds, and caches artifacts
+at its edge. A read through it costs the project less and lands nearer the
+reader than a read straight from storage.
+-/
+def cacheHostURL : String := "https://cache.mathlib.org"
+
+/--
+Whether the tool takes its legacy path wherever a legacy and a current one
+differ. It governs one such choice: which host serves reads, `azureAccountURL`
+or `cacheHostURL`.
+
+`main` sets this from `MATHLIB_CACHE_DEBUG_USE_LEGACY` at startup, so the
+variable is read once and a value `Cache.Cli.parseEnvFlag` cannot read warns
+once, however many read URLs the command builds.
+
+That variable is a troubleshooting fallback, for the days when the current path
+misbehaves and a contributor needs their build to finish. It is no part of the
+tool's interface: nothing should depend on it, and it goes away with the legacy
+path it selects. A consumer that needs a durable choice of read host names one
+with `MATHLIB_CACHE_BASE_URL`.
+-/
+initialize useLegacy : IO.Ref Bool ← IO.mkRef false
+
+/--
+Default base URL for cache reads: the read endpoint, or the storage account
+itself, which is the legacy read host.
+-/
+def defaultGetBaseURL (useLegacy : Bool) : String :=
+  if useLegacy then azureAccountURL else cacheHostURL
 
 /--
 Base URL for cache reads: `MATHLIB_CACHE_BASE_URL` if set, otherwise
-`defaultGetBaseURL`. `normalizeBaseURL` reads the value, so it arrives trimmed,
-free of trailing slashes, and unset when empty.
+`defaultGetBaseURL useLegacy`. `normalizeBaseURL` reads the value, so it
+arrives trimmed, free of trailing slashes, and unset when empty. A base URL
+wins over `useLegacy`, being the more specific answer to the same question:
+which host serves reads.
 
 A read URL is `{base}/{azureContainerName}/{key}`, the namespace the Azure
 account serves. Any host that mirrors that namespace is therefore a valid base.
@@ -169,18 +204,24 @@ lookup chain. `MATHLIB_CACHE_BASE_URL` serves internal consumers, that is,
 CI and contributors to the mathlib4 repository. It keeps the lookup chain and
 rebases each container read under the given host.
 
+The audience follows from what each variable exposes. The chain and the
+container names are mathlib4's own layout, free to change with the containers
+themselves, so only a reader who tracks this repository should bind to them. A
+project that depends on mathlib reads through `MATHLIB_CACHE_GET_URL`, whose
+flat namespace is a stable contract.
+
 Only reads follow this base. Uploads, marker writes, and the blob-listing
 query authenticate against Azure and use `Container.azureURL` directly.
 -/
-def getBaseURLFrom (envValue? : Option String) : String :=
-  (normalizeBaseURL envValue?).getD defaultGetBaseURL
+def getBaseURLFrom (envValue? : Option String) (useLegacy : Bool) : String :=
+  (normalizeBaseURL envValue?).getD (defaultGetBaseURL useLegacy)
 
 /--
 Base URL for cache reads, resolved from the environment.
 Written on top of the pure function above, which is separate to be testable.
 -/
 def getBaseURL : IO String := do
-  return getBaseURLFrom (← IO.getEnv "MATHLIB_CACHE_BASE_URL")
+  return getBaseURLFrom (← IO.getEnv "MATHLIB_CACHE_BASE_URL") (← useLegacy.get)
 
 /-- Read URL for a container: `{getBaseURL}/{azureContainerName}`. -/
 def Container.getURL (c : Container) : IO String := do

--- a/Cache/Infra.lean
+++ b/Cache/Infra.lean
@@ -64,9 +64,7 @@ inductive Container where
   | legacy
   deriving DecidableEq, Repr, BEq, Inhabited
 
-/--
-Base URL of the `lakecache` Azure Blob Storage account.
--/
+/-- Base URL of the `lakecache` Azure Blob Storage account. -/
 def azureAccountURL : String := "https://lakecache.blob.core.windows.net"
 
 namespace Container
@@ -158,25 +156,26 @@ def normalizeBaseURL (value? : Option String) : Option String :=
   (value?.map fun v => (v.trimAscii.dropEndWhile '/').copy).filter (!·.isEmpty)
 
 /--
-The Mathlib cache read endpoint: one hostname that serves the whole
-`/{container}/{key}` namespace the storage account holds, and caches artifacts
-at its edge. A read through it costs the project less and lands nearer the
-reader than a read straight from storage.
+The public Mathlib cache endpoint. It serves the same `/{container}/{key}`
+namespace as the storage account and caches artifacts at its edge, so reads
+cost the project less and land nearer the reader.
 -/
 def publicCacheEndpoint : String := "https://cache.mathlib.org"
 
 /--
-Set this from `MATHLIB_CACHE_DEBUG_USE_LEGACY` at startup.
+Whether reads address the Azure storage account instead of
+`publicCacheEndpoint`. `main` sets this from `MATHLIB_CACHE_DEBUG_USE_LEGACY`
+at startup.
 
-That variable is intended a troubleshooting fallback as the public Mathlib endpoint
-(enabled in September 2026) is battle-tested. It should be retired once support for
-the Azure storage account is disabled.
+The variable is a troubleshooting fallback for the transition to the public
+endpoint, enabled in September 2026, and it should be retired together with
+direct reads from the storage account.
 -/
 initialize useLegacy : IO.Ref Bool ← IO.mkRef false
 
 /--
-Default base URL for cache reads: the read endpoint, or the storage account
-itself, which is the legacy read host.
+Default base URL for cache reads: `publicCacheEndpoint`, or `azureAccountURL`
+when `useLegacy` is set.
 -/
 def defaultGetBaseURL (useLegacy : Bool) : String :=
   if useLegacy then azureAccountURL else publicCacheEndpoint
@@ -184,9 +183,7 @@ def defaultGetBaseURL (useLegacy : Bool) : String :=
 /--
 Base URL for cache reads: `MATHLIB_CACHE_BASE_URL` if set, otherwise
 `defaultGetBaseURL useLegacy`. `normalizeBaseURL` reads the value, so it
-arrives trimmed, free of trailing slashes, and unset when empty. A base URL
-wins over `useLegacy`, being the more specific answer to the same question:
-which host serves reads.
+arrives trimmed, free of trailing slashes, and unset when empty.
 
 A read URL is `{base}/{azureContainerName}/{key}`, the namespace the Azure
 account serves. Any host that mirrors that namespace is therefore a valid base.

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -97,12 +97,13 @@ Valid arguments are:
                           Troubleshooting fallback. Set to 1 or true to take the
                           tool's legacy path: reads address the Azure storage
                           account instead of https://cache.mathlib.org. This
-                          variable is unsupported and can go away in any
-                          release; do not depend on it.
-* MATHLIB_CACHE_GET_URL   Download from this single URL, bypassing the containers
-* MATHLIB_CACHE_PUT_URL   Upload to this single URL, bypassing the containers
+                          variable is for troubleshooting only.
+* MATHLIB_CACHE_GET_URL   Download from this single URL as a flat namespace.
+                          Allows third parties to use their own cache endpoint.
+* MATHLIB_CACHE_PUT_URL   Upload artifacts to this URL as a flat namespace.
+                          Allows third parties to upload to their own cache endpoint.
 * MATHLIB_CACHE_FROM      Comma-separated container list for reads, same shape as
-                          --cache-from. Used by CI to widen reads per job;
+                          --cache-from. Used by mathlib CI to widen reads per job;
                           --cache-from takes precedence when both are set.
 
 An empty value means unset for MATHLIB_CACHE_GET_URL and MATHLIB_CACHE_FROM.

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -93,6 +93,12 @@ Valid arguments are:
 # Environment variables
 
 * MATHLIB_CACHE_DIR       Local cache directory (default: ~/.cache/mathlib)
+* MATHLIB_CACHE_DEBUG_USE_LEGACY
+                          Troubleshooting fallback. Set to 1 or true to take the
+                          tool's legacy path: reads address the Azure storage
+                          account instead of https://cache.mathlib.org. This
+                          variable is unsupported and can go away in any
+                          release; do not depend on it.
 * MATHLIB_CACHE_GET_URL   Download from this single URL, bypassing the containers
 * MATHLIB_CACHE_PUT_URL   Upload to this single URL, bypassing the containers
 * MATHLIB_CACHE_FROM      Comma-separated container list for reads, same shape as
@@ -128,6 +134,9 @@ def main (args : List String) : IO Unit := do
       IO.eprintln s!"Unknown option '{opt}'"
       IO.eprintln help
       Process.exit 1
+
+  -- Resolve the legacy switch once, before anything builds a read URL.
+  useLegacy.set (← getEnvFlag "MATHLIB_CACHE_DEBUG_USE_LEGACY" (ifUnset := false))
 
   let repo? ← parseNamedOpt "repo" options
   let stagingDir? ← parseNamedOpt "staging-dir" options

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -94,10 +94,9 @@ Valid arguments are:
 
 * MATHLIB_CACHE_DIR       Local cache directory (default: ~/.cache/mathlib)
 * MATHLIB_CACHE_DEBUG_USE_LEGACY
-                          Troubleshooting fallback. Set to 1 or true to take the
-                          tool's legacy path: reads address the Azure storage
-                          account instead of https://cache.mathlib.org. This
-                          variable is for troubleshooting only.
+                          Set to 1 or true to read from the Azure storage
+                          account instead of https://cache.mathlib.org.
+                          For troubleshooting only.
 * MATHLIB_CACHE_GET_URL   Download from this single URL as a flat namespace.
                           Allows third parties to use their own cache endpoint.
 * MATHLIB_CACHE_PUT_URL   Upload artifacts to this URL as a flat namespace.

--- a/Cache/README.md
+++ b/Cache/README.md
@@ -123,12 +123,11 @@ lake exe cache get
 
 The variable is intended as a troubleshooting fallback and it might be retired at any time.
 
-
 ## Environment Variables
 
-| Variable                         | Description                                                                                                 | Default                                         |
-|----------------------------------|-------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
-| `MATHLIB_CACHE_DIR`              | Directory for cached `.ltar` files                                                                          | `$XDG_CACHE_HOME/mathlib` or `~/.cache/mathlib` |
+| Variable            | Description                        | Default                                         |
+|---------------------|------------------------------------|-------------------------------------------------|
+| `MATHLIB_CACHE_DIR` | Directory for cached `.ltar` files | `$XDG_CACHE_HOME/mathlib` or `~/.cache/mathlib` |
 
 ## How It Works
 

--- a/Cache/README.md
+++ b/Cache/README.md
@@ -101,11 +101,46 @@ lake exe cache get --cache-from=master,forks
 
 Uploads target a single container via `--container=NAME`.
 
+## Read endpoint
+
+`cache get` reads through `https://cache.mathlib.org`. The endpoint serves the
+container namespace above, and it caches artifacts at its edge, so a read costs
+the project less and finishes sooner. It is the default, and a normal checkout
+configures nothing.
+
+### When a read fails
+
+A download that stalls or fails can point at the endpoint.
+`MATHLIB_CACHE_DEBUG_USE_LEGACY` sends reads to the Azure storage account that
+holds the artifacts, so a build can finish while the endpoint misbehaves:
+
+```bash
+# bash, zsh, Git Bash
+MATHLIB_CACHE_DEBUG_USE_LEGACY=1 lake exe cache get
+
+# PowerShell
+$env:MATHLIB_CACHE_DEBUG_USE_LEGACY = 1; lake exe cache get
+
+# Windows CMD
+set MATHLIB_CACHE_DEBUG_USE_LEGACY=1
+lake exe cache get
+```
+
+The one-line prefix form is POSIX shell syntax, so a Windows shell sets the
+variable in its own step. `1` and `true` turn the variable on, in any case. `0`,
+`false`, and an absent value turn it off. Any other value prints a warning and
+changes nothing.
+
+The variable is a troubleshooting fallback and nothing more. It is unsupported:
+it can go away in any release, together with the legacy path it selects, so no
+script or workflow should depend on it.
+
 ## Environment Variables
 
-| Variable            | Description                        | Default                                         |
-|---------------------|------------------------------------|-------------------------------------------------|
-| `MATHLIB_CACHE_DIR` | Directory for cached `.ltar` files | `$XDG_CACHE_HOME/mathlib` or `~/.cache/mathlib` |
+| Variable                         | Description                                                                                                 | Default                                         |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
+| `MATHLIB_CACHE_DIR`              | Directory for cached `.ltar` files                                                                          | `$XDG_CACHE_HOME/mathlib` or `~/.cache/mathlib` |
+| `MATHLIB_CACHE_DEBUG_USE_LEGACY` | `1` or `true` takes the legacy path: reads go to the storage account. Troubleshooting only, and unsupported | off                                             |
 
 ## How It Works
 

--- a/Cache/README.md
+++ b/Cache/README.md
@@ -103,7 +103,7 @@ Uploads target a single container via `--container=NAME`.
 
 ## Public cache endpoint
 
-`cache get` reads artifacts through `https://cache.mathlib.org`, the public cache endpoint for mathlib artifacts. 
+`cache get` reads artifacts through `https://cache.mathlib.org`, the public cache endpoint for mathlib artifacts.
 
 ### Troubleshooting
 

--- a/Cache/README.md
+++ b/Cache/README.md
@@ -101,18 +101,13 @@ lake exe cache get --cache-from=master,forks
 
 Uploads target a single container via `--container=NAME`.
 
-## Read endpoint
+## Public cache endpoint
 
-`cache get` reads through `https://cache.mathlib.org`. The endpoint serves the
-container namespace above, and it caches artifacts at its edge, so a read costs
-the project less and finishes sooner. It is the default, and a normal checkout
-configures nothing.
+`cache get` reads artifacts through `https://cache.mathlib.org`, the public cache endpoint for mathlib artifacts. 
 
-### When a read fails
+### Troubleshooting
 
-A download that stalls or fails can point at the endpoint.
-`MATHLIB_CACHE_DEBUG_USE_LEGACY` sends reads to the Azure storage account that
-holds the artifacts, so a build can finish while the endpoint misbehaves:
+The public cache endpoint has been available since September 2026. The cache client provides an environment variable `MATHLIB_CACHE_DEBUG_USE_LEGACY` to revert to the behavior before this endpoint was available, for troubleshooting any issues that might arise in the transition to this new endpoint:
 
 ```bash
 # bash, zsh, Git Bash
@@ -126,21 +121,14 @@ set MATHLIB_CACHE_DEBUG_USE_LEGACY=1
 lake exe cache get
 ```
 
-The one-line prefix form is POSIX shell syntax, so a Windows shell sets the
-variable in its own step. `1` and `true` turn the variable on, in any case. `0`,
-`false`, and an absent value turn it off. Any other value prints a warning and
-changes nothing.
+The variable is intended as a troubleshooting fallback and it might be retired at any time.
 
-The variable is a troubleshooting fallback and nothing more. It is unsupported:
-it can go away in any release, together with the legacy path it selects, so no
-script or workflow should depend on it.
 
 ## Environment Variables
 
 | Variable                         | Description                                                                                                 | Default                                         |
 |----------------------------------|-------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
 | `MATHLIB_CACHE_DIR`              | Directory for cached `.ltar` files                                                                          | `$XDG_CACHE_HOME/mathlib` or `~/.cache/mathlib` |
-| `MATHLIB_CACHE_DEBUG_USE_LEGACY` | `1` or `true` takes the legacy path: reads go to the storage account. Troubleshooting only, and unsupported | off                                             |
 
 ## How It Works
 

--- a/Cache/SECURITY.md
+++ b/Cache/SECURITY.md
@@ -131,8 +131,10 @@ The trust model does not attempt to defend against:
   branch builds the cache binary itself.
 - **Compromised storage tenant** — admin-level compromise defeats the access
   grants.
-- **Substituted read endpoint** — a host named by `MATHLIB_CACHE_GET_URL`
-  chooses the bytes it serves, and it carries the storage tenant's trust.
+- **Substituted read endpoint** — the cache does not verify downloaded bytes, so
+  whichever host answers a read carries the storage tenant's trust. That is the
+  default read host `https://cache.mathlib.org`, or a host named by
+  `MATHLIB_CACHE_GET_URL`.
 - **Sandbox escape via kernel vulnerability** — invalidates Layer 3.
 - **Maintainer trust on the trusted branches** — write access to a branch the
   cache binary is built from can land a bad tool, workflow, or toolchain.

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -184,42 +184,53 @@ def test_envValueNormalization : IO Unit := do
     (shown (normalizeBaseURL (some "https://cache.example.org///")))
   assertEq "a slash-only value reads as unset" "<unset>" (shown (normalizeBaseURL (some "/")))
 
-/-- The read base follows `MATHLIB_CACHE_BASE_URL` when the variable is set
-and falls back to the Azure account when it is not. `getBaseURLFrom` is pure,
-so this test covers both branches; the environment-reading wrapper
+/-- The read base follows `MATHLIB_CACHE_BASE_URL` when the variable is set.
+Without it, reads address `cacheHostURL`, and address the Azure account when
+`MATHLIB_CACHE_DEBUG_USE_LEGACY` selects the legacy read host. `getBaseURLFrom` is
+pure, so this test covers every branch; the environment-reading wrapper
 (`getBaseURL`) adds no logic of its own. -/
 def test_getBaseURLFrom : IO Unit := do
   IO.println "getBaseURLFrom:"
-  assertEq "no override → the Azure account"
-    defaultGetBaseURL (getBaseURLFrom none)
+  assertEq "no override → the read endpoint"
+    "https://cache.mathlib.org" (getBaseURLFrom none false)
+  assertEq "legacy → the storage account"
+    "https://lakecache.blob.core.windows.net" (getBaseURLFrom none true)
+  -- The legacy base is the host the container URLs name, so the flag reproduces
+  -- the read URLs of a tool that knows no endpoint.
+  assertEq "the legacy base matches the container URLs"
+    azureAccountURL (getBaseURLFrom none true)
   assertEq "override → the given base"
-    "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org"))
+    "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org") false)
+  -- The variable names a host, so it answers the same question the legacy flag
+  -- does, and more specifically. It therefore wins.
+  assertEq "override wins over legacy"
+    "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org") true)
   -- A GitHub Actions `${{ vars.… }}` lookup yields "" while the variable is
   -- undefined, so an empty value must keep the default.
   assertEq "empty value counts as unset"
-    defaultGetBaseURL (getBaseURLFrom (some ""))
+    cacheHostURL (getBaseURLFrom (some "") false)
   assertEq "whitespace-only value counts as unset"
-    defaultGetBaseURL (getBaseURLFrom (some " \n"))
+    cacheHostURL (getBaseURLFrom (some " \n") false)
   assertEq "override is trimmed"
-    "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org\n"))
+    "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org\n") false)
   -- A base written with a trailing slash must not double the separator in
   -- `{base}/{container}/{key}`.
   assertEq "trailing slash is stripped"
-    "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org/"))
+    "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org/") false)
 
 /-- Read URLs follow `getBaseURL`: the same `/{container}` namespace as
-`azureURL`, under whichever base `MATHLIB_CACHE_BASE_URL` selects. With no
-override, reads address Azure directly and the two URL families coincide. -/
+`azureURL`, under whichever base the environment selects. The two URL families
+coincide only when that base is the storage account itself. -/
 def test_Container_getURL : IO Unit := do
   IO.println "Container.getURL:"
   let base ← getBaseURL
   assertEq "master read URL" s!"{base}/mathlib4-master" (← Container.master.getURL)
   assertEq "forks read URL" s!"{base}/mathlib4-forks" (← Container.forks.getURL)
   assertEq "legacy read URL" s!"{base}/mathlib4" (← Container.legacy.getURL)
-  -- The effective base drives this guard, so an empty variable reaches the
-  -- assertions below: it means unset, and the Azure host answers for it.
-  if base == defaultGetBaseURL then
-    assertEq "default read URL matches azureURL"
+  -- The Azure host answers only when the environment selects it, so this guard
+  -- keys on the effective base rather than on the default.
+  if base == azureAccountURL then
+    assertEq "legacy read URL matches azureURL"
       Container.master.azureURL (← Container.master.getURL)
 
 /-- Whether a container lays files out flat (`/f/<hash>`) or namespaces them by
@@ -612,7 +623,8 @@ def test_markerURL : IO Unit := do
     (markerURL .forks "Alice/Mathlib4" "abc123")
 
 /-- Marker probes read through the base URL; marker writes address Azure
-directly (`markerURL`). The two URLs agree only under the default base. -/
+directly (`markerURL`). The two URLs agree only when the read base is the
+storage account itself. -/
 def test_markerReadURL : IO Unit := do
   IO.println "markerReadURL:"
   let base ← getBaseURL
@@ -622,10 +634,10 @@ def test_markerReadURL : IO Unit := do
   assertEq "probe repo is lowercased in the path"
     s!"{base}/mathlib4-forks/m/alice/mathlib4/abc123"
     (← markerReadURL .forks "Alice/Mathlib4" "abc123")
-  -- The effective base drives this guard, so an empty variable reaches the
-  -- assertions below: it means unset, and the Azure host answers for it.
-  if base == defaultGetBaseURL then
-    assertEq "default probe URL matches the write URL"
+  -- The Azure host answers only when the environment selects it, so this guard
+  -- keys on the effective base rather than on the default.
+  if base == azureAccountURL then
+    assertEq "legacy probe URL matches the write URL"
       (markerURL .forks "alice/mathlib4" "abc123")
       (← markerReadURL .forks "alice/mathlib4" "abc123")
 
@@ -1020,6 +1032,46 @@ def test_parseFlagOpt : IO Unit := do
   -- Lookalike: `--help-me` isn't the `--help` flag.
   assertTrue "lookalike prefix doesn't match" (!parseFlagOpt "help" ["--help-me"])
 
+/-- A boolean environment variable is on for `1` and `true`, off for `0` and
+`false`, and `ifUnset` for an absent or blank value.
+`MATHLIB_CACHE_DEBUG_USE_LEGACY` reads this way with `ifUnset := false`.
+
+`ifUnset` decides the unset case alone: a variable that defaults on still reads
+`0` as off. A value the parser cannot read falls back to `ifUnset` too, and
+warns — a value that silently passed as on would look like a setting that took
+effect. -/
+def test_parseEnvFlag : IO Unit := do
+  IO.println "parseEnvFlag:"
+  let shown (flag : Bool) : String := if flag then "on" else "off"
+  -- The variable name only reaches the warning, so any name serves the rest.
+  let parse (value? : Option String) (ifUnset : Bool) : IO String := do
+    return shown (← withSuppressedOutput (parseEnvFlag "FLAG" value? ifUnset))
+  assertEq "absent value takes ifUnset" "off" (← parse none false)
+  assertEq "empty value takes ifUnset" "off" (← parse (some "") false)
+  assertEq "whitespace-only value takes ifUnset" "off" (← parse (some " \n") false)
+  assertEq "1 is on" "on" (← parse (some "1") false)
+  assertEq "true is on" "on" (← parse (some "true") false)
+  assertEq "case does not matter" "on" (← parse (some "TRUE") false)
+  assertEq "surrounding space does not matter" "on" (← parse (some " true ") false)
+  assertEq "0 is off" "off" (← parse (some "0") false)
+  assertEq "false is off" "off" (← parse (some "false") false)
+  assertEq "an unreadable value falls back to ifUnset" "off" (← parse (some "yes") false)
+  assertEq "a number other than 0 or 1 is unreadable" "off" (← parse (some "2") false)
+  -- A default-on variable: `ifUnset` moves the unset case and nothing else.
+  assertEq "absent value takes an on default" "on" (← parse none true)
+  assertEq "empty value takes an on default" "on" (← parse (some "") true)
+  assertEq "0 is off against an on default" "off" (← parse (some "0") true)
+  assertEq "false is off against an on default" "off" (← parse (some "false") true)
+  assertEq "1 is on against an on default" "on" (← parse (some "1") true)
+  assertEq "an unreadable value takes an on default" "on" (← parse (some "yes") true)
+  -- The warning names the variable and the value it rejected, and it fires only
+  -- for a value the parser cannot read.
+  let (warning, _) ← IO.FS.withIsolatedStreams (parseEnvFlag "MY_FLAG" (some "yes") false)
+  assertTrue "the warning names the variable and the value"
+    ((warning.splitOn "MY_FLAG=yes").length == 2)
+  let (quiet, _) ← IO.FS.withIsolatedStreams (parseEnvFlag "MY_FLAG" (some "0") false)
+  assertEq "a readable value warns about nothing" "" quiet
+
 end CliOptions
 
 section ReadRedirects
@@ -1336,6 +1388,7 @@ def runAll : IO Unit := do
   test_findRecentSHAsWithCache
   test_getRemoteRepo_gitFallback
   test_headIsAncestorOfMaster_gitFallback
+  test_parseEnvFlag
   test_isKnownOpt
   test_parseNamedOpt
   test_parseFlagOpt
@@ -1353,8 +1406,11 @@ def runAll : IO Unit := do
 
 end Cache.Test
 
-open Cache.Test in
+open Cache.Test Cache.Requests Cache.Cli in
 def main : IO UInt32 := do
+  -- Resolve the legacy switch the way the tool's `main` does, so the read-base
+  -- assertions see the setting the environment names.
+  useLegacy.set (← getEnvFlag "MATHLIB_CACHE_DEBUG_USE_LEGACY" (ifUnset := false))
   runAll
   let n ← failures.get
   if n == 0 then

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -185,7 +185,7 @@ def test_envValueNormalization : IO Unit := do
   assertEq "a slash-only value reads as unset" "<unset>" (shown (normalizeBaseURL (some "/")))
 
 /-- The read base follows `MATHLIB_CACHE_BASE_URL` when the variable is set.
-Without it, reads address `cacheHostURL`, and address the Azure account when
+Without it, reads address `publicCacheEndpoint`, and address the Azure account when
 `MATHLIB_CACHE_DEBUG_USE_LEGACY` selects the legacy read host. `getBaseURLFrom` is
 pure, so this test covers every branch; the environment-reading wrapper
 (`getBaseURL`) adds no logic of its own. -/
@@ -208,9 +208,9 @@ def test_getBaseURLFrom : IO Unit := do
   -- A GitHub Actions `${{ vars.… }}` lookup yields "" while the variable is
   -- undefined, so an empty value must keep the default.
   assertEq "empty value counts as unset"
-    cacheHostURL (getBaseURLFrom (some "") false)
+    publicCacheEndpoint (getBaseURLFrom (some "") false)
   assertEq "whitespace-only value counts as unset"
-    cacheHostURL (getBaseURLFrom (some " \n") false)
+    publicCacheEndpoint (getBaseURLFrom (some " \n") false)
   assertEq "override is trimmed"
     "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org\n") false)
   -- A base written with a trailing slash must not double the separator in

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -195,14 +195,11 @@ def test_getBaseURLFrom : IO Unit := do
     "https://cache.mathlib.org" (getBaseURLFrom none false)
   assertEq "legacy → the storage account"
     "https://lakecache.blob.core.windows.net" (getBaseURLFrom none true)
-  -- The legacy base is the host the container URLs name, so the flag reproduces
-  -- the read URLs of a tool that knows no endpoint.
+  -- The legacy base is the host the container URLs (`azureURL`) are built on.
   assertEq "the legacy base matches the container URLs"
     azureAccountURL (getBaseURLFrom none true)
   assertEq "override → the given base"
     "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org") false)
-  -- The variable names a host, so it answers the same question the legacy flag
-  -- does, and more specifically. It therefore wins.
   assertEq "override wins over legacy"
     "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org") true)
   -- A GitHub Actions `${{ vars.… }}` lookup yields "" while the variable is
@@ -227,8 +224,6 @@ def test_Container_getURL : IO Unit := do
   assertEq "master read URL" s!"{base}/mathlib4-master" (← Container.master.getURL)
   assertEq "forks read URL" s!"{base}/mathlib4-forks" (← Container.forks.getURL)
   assertEq "legacy read URL" s!"{base}/mathlib4" (← Container.legacy.getURL)
-  -- The Azure host answers only when the environment selects it, so this guard
-  -- keys on the effective base rather than on the default.
   if base == azureAccountURL then
     assertEq "legacy read URL matches azureURL"
       Container.master.azureURL (← Container.master.getURL)
@@ -634,8 +629,6 @@ def test_markerReadURL : IO Unit := do
   assertEq "probe repo is lowercased in the path"
     s!"{base}/mathlib4-forks/m/alice/mathlib4/abc123"
     (← markerReadURL .forks "Alice/Mathlib4" "abc123")
-  -- The Azure host answers only when the environment selects it, so this guard
-  -- keys on the effective base rather than on the default.
   if base == azureAccountURL then
     assertEq "legacy probe URL matches the write URL"
       (markerURL .forks "alice/mathlib4" "abc123")
@@ -1037,9 +1030,8 @@ def test_parseFlagOpt : IO Unit := do
 `MATHLIB_CACHE_DEBUG_USE_LEGACY` reads this way with `ifUnset := false`.
 
 `ifUnset` decides the unset case alone: a variable that defaults on still reads
-`0` as off. A value the parser cannot read falls back to `ifUnset` too, and
-warns — a value that silently passed as on would look like a setting that took
-effect. -/
+`0` as off, and a value the parser cannot read warns and falls back to
+`ifUnset`. -/
 def test_parseEnvFlag : IO Unit := do
   IO.println "parseEnvFlag:"
   let shown (flag : Bool) : String := if flag then "on" else "off"

--- a/Cache/Test.lean
+++ b/Cache/Test.lean
@@ -216,17 +216,26 @@ def test_getBaseURLFrom : IO Unit := do
     "https://cache.example.org" (getBaseURLFrom (some "https://cache.example.org/") false)
 
 /-- Read URLs follow `getBaseURL`: the same `/{container}` namespace as
-`azureURL`, under whichever base the environment selects. The two URL families
-coincide only when that base is the storage account itself. -/
+`azureURL`, under whichever base the environment selects. Without a base-URL
+override, both positions of the legacy switch are pinned: the endpoint by
+default, `azureURL` under legacy. -/
 def test_Container_getURL : IO Unit := do
   IO.println "Container.getURL:"
   let base ← getBaseURL
   assertEq "master read URL" s!"{base}/mathlib4-master" (← Container.master.getURL)
   assertEq "forks read URL" s!"{base}/mathlib4-forks" (← Container.forks.getURL)
   assertEq "legacy read URL" s!"{base}/mathlib4" (← Container.legacy.getURL)
-  if base == azureAccountURL then
+  -- A base-URL override answers for both switch positions, so the pinned
+  -- assertions run only without one.
+  if (normalizeBaseURL (← IO.getEnv "MATHLIB_CACHE_BASE_URL")).isNone then
+    let ambient ← useLegacy.get
+    useLegacy.set false
+    assertEq "default read URL is on the endpoint"
+      s!"{publicCacheEndpoint}/mathlib4-master" (← Container.master.getURL)
+    useLegacy.set true
     assertEq "legacy read URL matches azureURL"
       Container.master.azureURL (← Container.master.getURL)
+    useLegacy.set ambient
 
 /-- Whether a container lays files out flat (`/f/<hash>`) or namespaces them by
 repo (`/f/<repo>/<hash>`). The layout is fixed per container so that all of a
@@ -618,8 +627,9 @@ def test_markerURL : IO Unit := do
     (markerURL .forks "Alice/Mathlib4" "abc123")
 
 /-- Marker probes read through the base URL; marker writes address Azure
-directly (`markerURL`). The two URLs agree only when the read base is the
-storage account itself. -/
+directly (`markerURL`). Without a base-URL override, both positions of the
+legacy switch are pinned: probes address the endpoint by default, and under
+legacy they match the write URL. -/
 def test_markerReadURL : IO Unit := do
   IO.println "markerReadURL:"
   let base ← getBaseURL
@@ -629,10 +639,17 @@ def test_markerReadURL : IO Unit := do
   assertEq "probe repo is lowercased in the path"
     s!"{base}/mathlib4-forks/m/alice/mathlib4/abc123"
     (← markerReadURL .forks "Alice/Mathlib4" "abc123")
-  if base == azureAccountURL then
+  if (normalizeBaseURL (← IO.getEnv "MATHLIB_CACHE_BASE_URL")).isNone then
+    let ambient ← useLegacy.get
+    useLegacy.set false
+    assertEq "default probe URL is on the endpoint"
+      s!"{publicCacheEndpoint}/mathlib4-forks/m/alice/mathlib4/abc123"
+      (← markerReadURL .forks "alice/mathlib4" "abc123")
+    useLegacy.set true
     assertEq "legacy probe URL matches the write URL"
       (markerURL .forks "alice/mathlib4" "abc123")
       (← markerReadURL .forks "alice/mathlib4" "abc123")
+    useLegacy.set ambient
 
 end Marker
 
@@ -1398,7 +1415,7 @@ def runAll : IO Unit := do
 
 end Cache.Test
 
-open Cache.Test Cache.Requests Cache.Cli in
+open Cache Cache.Test Cache.Requests in
 def main : IO UInt32 := do
   -- Resolve the legacy switch the way the tool's `main` does, so the read-base
   -- assertions see the setting the environment names.


### PR DESCRIPTION
Cache reads use `https://cache.mathlib.org` by default. The endpoint serves the same `/{container}/{key}` namespace as the Azure storage account, and it caches artifacts at its edge. 

Upcoming changes include separating the storage for forks from the master cache.

CI already reads through the endpoint: PR #42657 added the `MATHLIB_CACHE_BASE_URL` seam, and PR #42777 wired it from a repository variable. This PR makes the endpoint the default for every other client.

`MATHLIB_CACHE_DEBUG_USE_LEGACY=1` sends reads back to the storage account. The variable is a troubleshooting fallback, hence 'unsupported', albeit documented. `1` and `true` turn it on, `0`, `false`, and an absent or empty value turn it off, and any other value prints one warning and keeps the default. 

`MATHLIB_CACHE_BASE_URL` stays as a durable way to choose a read host for CI, and it takes precedence.

The write path does not change in this PR. 

After this PR, an empty `MATHLIB_CACHE_BASE_URL` selects the endpoint, not Azure. To send CI back to Azure, set the variable to `https://lakecache.blob.core.windows.net`.

Validation: `lake exe cache-test` passes with no variable set, with the legacy flag, and with a base URL set. A live `lake exe cache get Mathlib/Init.lean` fetched 64 of 64 files from the endpoint by default, and the same 64 from the storage account under the flag. A set base URL won over the flag, and an unrecognized flag value printed exactly one warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
