### PR TITLE
refactor(Geometry/Convex): make `StdSimplex` extend `Finsupp`

### DIFF
--- a/Mathlib/Geometry/Convex/ConvexSpace/Barycenter.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Barycenter.lean
@@ -20,7 +20,7 @@ variable {K M : Type*} [Field K] [CharZero K] [LinearOrder K] [IsStrictOrderedRi
 
 /-- In the standard simplex with vertices `M`, this is the barycenter of
 a nonempty finite subset `S` of `M`. -/
-@[simps -isSimp]
+@[simps -isSimp weights]
 noncomputable def subBarycenter (S : Finset M) (hS : S.Nonempty) : StdSimplex K M where
   weights := S.sum (fun m ↦ .single m S.card⁻¹)
   nonneg := Finset.sum_nonneg (by simp)

--- a/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
@@ -53,13 +53,15 @@ being the map `weights : StdSimplex R X → R^⊕X`.
 Note in particular that, in the common case where `X := M` is a `R`-module, `StdSimplex R M` is NOT
 the standard simplex in `M`. Indeed, the notion of a standard simplex depends on a choice of basis,
 and `M` isn't given one. -/
-structure StdSimplex (R : Type u) [LE R] [AddCommMonoid R] [One R] (X : Type v) where
-  /-- The weights of the `StdSimplex` as a `Finsupp`. -/
-  weights : X →₀ R
+structure StdSimplex (R : Type u) [LE R] [AddCommMonoid R] [One R] (X : Type v) extends
+  weights : X →₀ R where
   /-- All weights are non-negative. -/
   nonneg : 0 ≤ weights
   /-- The weights sum to 1. -/
   total : weights.sum (fun _ r => r) = 1
+
+/-- The weights of an element of the standard simplex` as a `Finsupp`. -/
+add_decl_doc StdSimplex.weights
 
 attribute [simp] StdSimplex.total
 grind_pattern StdSimplex.nonneg => self.weights

--- a/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
@@ -54,7 +54,7 @@ Note in particular that, in the common case where `X := M` is a `R`-module, `Std
 the standard simplex in `M`. Indeed, the notion of a standard simplex depends on a choice of basis,
 and `M` isn't given one. -/
 structure StdSimplex (R : Type u) [LE R] [AddCommMonoid R] [One R] (X : Type v) extends
-  weights : X →₀ R where
+    weights : X →₀ R where
   /-- All weights are non-negative. -/
   nonneg : 0 ≤ weights
   /-- The weights sum to 1. -/


### PR DESCRIPTION
Among other things, this lets users write `w.support` for `w : StdSimplex _ _` instead of `w.weights.support`. It prints the same, however.

From the Polytopes in Berlin workshop, where participants requested that they could write `w.support` instead of `w.weights.support`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
