### PR TITLE
feat(RingTheory/Polynomial/RationalRoot): rational root theorem with multiplicity

### DIFF
--- a/Mathlib/RingTheory/Polynomial/Content.lean
+++ b/Mathlib/RingTheory/Polynomial/Content.lean
@@ -484,6 +484,18 @@ theorem degree_gcd_le_right (p) {q : R[X]} (hq : q ≠ 0) : (gcd p q).degree ≤
   rw [gcd_comm]
   exact degree_gcd_le_left hq p
 
+/-- Powers of a primitive polynomial are primitive. -/
+theorem IsPrimitive.pow {q : R[X]} (hq : q.IsPrimitive) (n : ℕ) :
+    (q ^ n).IsPrimitive := by
+  induction n with
+  | zero => rw [pow_zero]; exact isPrimitive_one
+  | succ k ih => rw [pow_succ]; exact ih.mul hq
+
+/-- Finite products of primitive polynomials are primitive. -/
+theorem isPrimitive_prod {ι : Type*} (t : Finset ι) (f : ι → R[X])
+    (h : ∀ i ∈ t, (f i).IsPrimitive) : (∏ i ∈ t, f i).IsPrimitive :=
+  Finset.prod_induction f IsPrimitive (fun _ _ ha hb => ha.mul hb) isPrimitive_one h
+
 end NormalizedGCDMonoid
 
 noncomputable instance [StrongNormalizedGCDMonoid R] : StrongNormalizedGCDMonoid R[X] where

--- a/Mathlib/RingTheory/Polynomial/RationalRoot.lean
+++ b/Mathlib/RingTheory/Polynomial/RationalRoot.lean
@@ -1,13 +1,16 @@
 /-
 Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Anne Baanen
+Authors: Anne Baanen, Owen Kent
 -/
 module
 
 public import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
 public import Mathlib.RingTheory.Localization.NumDen
 public import Mathlib.RingTheory.Polynomial.ScaleRoots
+public import Mathlib.RingTheory.Polynomial.GaussLemma
+public import Mathlib.Algebra.Polynomial.BigOperators
+public import Mathlib.RingTheory.Coprime.Lemmas
 
 /-!
 # Rational root theorem and integral root theorem
@@ -21,6 +24,11 @@ field of fractions are of the form `x / y` with `x y : A`, `x ∣ p.coeff 0` and
 The corollary is the integral root theorem `isInteger_of_is_root_of_monic`:
 if `p` is monic, its roots must be integers.
 Finally, we use this to show unique factorization domains are integrally closed.
+We also prove the generalization to root multiplicity: if `r` is a root of `p` with multiplicity
+`m`, then `(den A r) ^ m ∣ p.leadingCoeff` (`den_pow_rootMultiplicity_dvd_leadingCoeff`), together
+with the multi-point product form over a finite set of points
+(`prod_den_pow_rootMultiplicity_dvd_leadingCoeff`). Both descend from the `A[X]`-level divisibility
+`den_mul_X_sub_C_num_pow_rootMultiplicity_dvd`.
 
 ## References
 
@@ -129,6 +137,114 @@ theorem exists_integer_of_is_root_of_monic {p : A[X]} (hp : Monic p) {r : K} (hr
     nth_rw 1 [← mk'_num_den' A r]
     rw [div_eq_iff d_ne_zero, map_mul, mul_assoc, mul_comm ((algebraMap A K) inv),
       ← map_mul, ← h_inv, map_one, mul_one]
+
+/-! ### Rational root theorem with multiplicity -/
+
+/-- The reduced linear factor `C (den A r) * X - C (num A r)` of `r : K` is primitive.
+A constant divisor of it divides both `den A r` (the coefficient of `X`) and `num A r`
+(up to sign, the constant coefficient), so it is a unit by `num_den_reduced`. -/
+private theorem isPrimitive_den_mul_X_sub_C_num (r : K) :
+    (C (den A r : A) * X - C (num A r)).IsPrimitive := by
+  intro c hc
+  have h1 : c ∣ (den A r : A) := by
+    have h := (C_dvd_iff_dvd_coeff c _).mp hc 1
+    simpa using h
+  have h0 : c ∣ num A r := by
+    have h := (C_dvd_iff_dvd_coeff c _).mp hc 0
+    simpa using h
+  exact num_den_reduced A r h0 h1
+
+/-- Over `K`, the reduced linear factor of `r` is the unit multiple
+`C (den A r) * (X - C r)` of the root factor at `r`. -/
+private theorem map_den_mul_X_sub_C_num (r : K) :
+    (C (den A r : A) * X - C (num A r)).map (algebraMap A K)
+      = C (algebraMap A K (den A r : A)) * (X - C r) := by
+  have hden0 : algebraMap A K (den A r : A) ≠ 0 :=
+    IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors (den A r).2
+  have hnum : algebraMap A K (num A r) = r * algebraMap A K (den A r : A) :=
+    (div_eq_iff hden0).mp (mk'_num_den' A r)
+  rw [Polynomial.map_sub, Polynomial.map_mul, map_C, map_C, Polynomial.map_X,
+    hnum, C_mul]
+  ring
+
+/-- The leading coefficient of the reduced linear factor is `den A r`. -/
+private theorem leadingCoeff_den_mul_X_sub_C_num (r : K) :
+    (C (den A r : A) * X - C (num A r)).leadingCoeff = (den A r : A) := by
+  have h : C (den A r : A) * X - C (num A r)
+      = C (den A r : A) * X + C (-(num A r)) := by
+    rw [map_neg, sub_eq_add_neg]
+  rw [h, leadingCoeff_linear (nonZeroDivisors.coe_ne_zero _)]
+
+/-- The `rootMultiplicity` power of the reduced linear factor `C (den A r) * X - C (num A r)`
+divides `p` in `A[X]`. This is the `A`-level form of the rational root theorem with
+multiplicity, of which `den_pow_rootMultiplicity_dvd_leadingCoeff` is the leading-coefficient
+corollary. -/
+theorem den_mul_X_sub_C_num_pow_rootMultiplicity_dvd (p : A[X]) (r : K) :
+    (C (den A r : A) * X - C (num A r))
+      ^ rootMultiplicity r (p.map (algebraMap A K)) ∣ p := by
+  let : NormalizedGCDMonoid A := Nonempty.some inferInstance
+  refine IsPrimitive.dvd_of_fraction_map_dvd_fraction_map (K := K)
+    (IsPrimitive.pow (isPrimitive_den_mul_X_sub_C_num r) _) ?_
+  rw [Polynomial.map_pow, map_den_mul_X_sub_C_num, mul_pow]
+  have hunit : IsUnit (C (algebraMap A K (den A r : A))
+      ^ rootMultiplicity r (p.map (algebraMap A K))) :=
+    (isUnit_C.mpr (isUnit_iff_ne_zero.mpr
+      (IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors (den A r).2))).pow _
+  rw [hunit.mul_left_dvd]
+  exact pow_rootMultiplicity_dvd _ r
+
+/-- **Rational root theorem with multiplicity.** If `r : K` is a root of
+`p : A[X]` over the fraction field `K` of the UFD `A` with multiplicity `m`, then
+`(den A r) ^ m` divides the leading coefficient of `p`. Stated unconditionally with
+`m = rootMultiplicity r (p.map (algebraMap A K))`; at `m = 1` it recovers
+`den_dvd_of_is_root`. -/
+theorem den_pow_rootMultiplicity_dvd_leadingCoeff (p : A[X]) (r : K) :
+    (den A r : A) ^ rootMultiplicity r (p.map (algebraMap A K))
+      ∣ p.leadingCoeff := by
+  have h := leadingCoeff_dvd_leadingCoeff
+    (den_mul_X_sub_C_num_pow_rootMultiplicity_dvd p r)
+  rwa [leadingCoeff_pow, leadingCoeff_den_mul_X_sub_C_num] at h
+
+/-- **Multi-point rational root theorem with multiplicities.** For any
+finite set `s` of points of the fraction field, the product over `r ∈ s` of
+`(den A r) ^ rootMultiplicity r` divides the leading coefficient of `p`. The
+denominators need NOT be pairwise coprime in `A`; the recombination happens on the
+polynomial side, where the root factors at distinct points are pairwise coprime
+over the field `K`. -/
+theorem prod_den_pow_rootMultiplicity_dvd_leadingCoeff (p : A[X]) (s : Finset K) :
+    (∏ r ∈ s, (den A r : A) ^ rootMultiplicity r (p.map (algebraMap A K)))
+      ∣ p.leadingCoeff := by
+  have hgdvd : (∏ r ∈ s, (C (den A r : A) * X - C (num A r))
+      ^ rootMultiplicity r (p.map (algebraMap A K))) ∣ p := by
+    let : NormalizedGCDMonoid A := Nonempty.some inferInstance
+    refine IsPrimitive.dvd_of_fraction_map_dvd_fraction_map (K := K)
+      (isPrimitive_prod _ _ fun r _ =>
+        IsPrimitive.pow (isPrimitive_den_mul_X_sub_C_num r) _) ?_
+    have hmap : (∏ r ∈ s, (C (den A r : A) * X - C (num A r))
+          ^ rootMultiplicity r (p.map (algebraMap A K))).map (algebraMap A K)
+        = (∏ r ∈ s, C (algebraMap A K (den A r : A))
+              ^ rootMultiplicity r (p.map (algebraMap A K)))
+            * ∏ r ∈ s, (X - C r) ^ rootMultiplicity r (p.map (algebraMap A K)) := by
+      rw [Polynomial.map_prod, ← Finset.prod_mul_distrib]
+      refine Finset.prod_congr rfl fun r _ => ?_
+      rw [Polynomial.map_pow, map_den_mul_X_sub_C_num, mul_pow]
+    have hunit : IsUnit (∏ r ∈ s, C (algebraMap A K (den A r : A))
+        ^ rootMultiplicity r (p.map (algebraMap A K))) :=
+      Finset.prod_induction _ IsUnit (fun a b ha hb => ha.mul hb) isUnit_one
+        fun r _ => (isUnit_C.mpr (isUnit_iff_ne_zero.mpr
+          (IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors (den A r).2))).pow _
+    rw [hmap, hunit.mul_left_dvd]
+    refine Finset.prod_dvd_of_coprime ?_ fun r _ => pow_rootMultiplicity_dvd _ r
+    intro a _ b _ hab
+    exact (isCoprime_X_sub_C_of_isUnit_sub (sub_ne_zero_of_ne hab).isUnit).pow
+  have hleadeq : (∏ r ∈ s, (C (den A r : A) * X - C (num A r))
+        ^ rootMultiplicity r (p.map (algebraMap A K))).leadingCoeff
+      = ∏ r ∈ s, (den A r : A) ^ rootMultiplicity r (p.map (algebraMap A K)) := by
+    rw [leadingCoeff_prod]
+    exact Finset.prod_congr rfl fun r _ => by
+      rw [leadingCoeff_pow, leadingCoeff_den_mul_X_sub_C_num]
+  rw [← hleadeq]
+  exact leadingCoeff_dvd_leadingCoeff hgdvd
 
 namespace UniqueFactorizationMonoid
 


### PR DESCRIPTION
This PR adds the rational root theorem with multiplicity to
`Mathlib/RingTheory/Polynomial/RationalRoot.lean`:

- `den_pow_rootMultiplicity_dvd_leadingCoeff`: if `r : K` is a root of `p : A[X]` (`A` a UFD, `K`
  its fraction field) with multiplicity `m = rootMultiplicity r (p.map (algebraMap A K))`, then
  `(den A r) ^ m ∣ p.leadingCoeff`;
- `prod_den_pow_rootMultiplicity_dvd_leadingCoeff`: the multi-point version, `∏ r ∈ s, (den A r) ^
  rootMultiplicity r ∣ p.leadingCoeff` over any finite set `s : Finset K` (the denominators need
  **not** be pairwise coprime in `A`; the recombination happens on the polynomial side, where the
  root factors at distinct points are pairwise coprime over `K`);
- `den_mul_X_sub_C_num_pow_rootMultiplicity_dvd`: the `A`-level form both corollaries come from,
  `(C (den A r) * X - C (num A r)) ^ m ∣ p` in `A[X]`.

These generalize the existing multiplicity-one statement `den_dvd_of_is_root`: at `m = 1` the new
theorem recovers it exactly (a guard `example` confirmed this against the branch). Two supporting
lemmas travel with them, placed in `Content.lean`, whose existing content they extend:

- `Polynomial.IsPrimitive.pow` and `Polynomial.isPrimitive_prod`: powers and finite
  products of primitive polynomials stay primitive.

**Proof route.** The reduced linear factor `C (den A r) * X - C (num A r)` is primitive (a constant
divisor of both coefficients divides the reduced numerator/denominator pair, hence is a unit) and,
over `K`, a unit multiple of `X - C r`. Its `rootMultiplicity`-power therefore divides `p.map
(algebraMap A K)` (`pow_rootMultiplicity_dvd`), and one-sided Gauss descent (the existing
`IsPrimitive.dvd_of_fraction_map_dvd_fraction_map`) brings the divisibility back down to `A`;
multiplicativity of the leading coefficient finishes. The multi-point case recombines the same
argument over a product of linear factors that are pairwise coprime over `K`
(`isCoprime_X_sub_C_of_isUnit_sub`, `Finset.prod_dvd_of_coprime`).

**A hypothesis note.** `Polynomial.IsPrimitive.pow` / `Polynomial.isPrimitive_prod` are stated
under `[NormalizedGCDMonoid R]`, matching the hypothesis level of their host section in
`Content.lean` (neither proof needs anything UFD-specific). The six `RationalRoot.lean`
declarations (three public, and three `private` helpers about the reduced linear factor:
`isPrimitive_den_mul_X_sub_C_num`, `map_den_mul_X_sub_C_num`,
`leadingCoeff_den_mul_X_sub_C_num`) need only the file's existing
`UniqueFactorizationMonoid A` context: where a
`NormalizedGCDMonoid A` instance is required to invoke the `Content.lean` lemmas, the proofs
materialize one locally via `let : NormalizedGCDMonoid A := Nonempty.some inferInstance` (the
`Nonempty` instance comes from `UniqueFactorizationMonoid A` through `IsGCDMonoid A`, in scope via
the file's existing `RingTheory.Localization.NumDen` import), the same idiom `GaussLemma.lean`
already uses. The statements are instance-independent.

All eight new declarations (two in `Content.lean`, six in `RationalRoot.lean`) build green and
`#print axioms` clean (`[propext, Classical.choice, Quot.sound]`; no `sorryAx`, no
`native_decide`) on master commit `8acb872c31` (toolchain v4.34.0-rc2), with `lake exe lint-style`
and the batteries env linter (`runLinter`) passing on both touched modules, and all direct
downstream importers rebuilt green. Three `public import`s are added to `RationalRoot.lean`
(`RingTheory.Polynomial.GaussLemma`, `Algebra.Polynomial.BigOperators`,
`RingTheory.Coprime.Lemmas`); each is used directly by the new proofs (`shake` no longer exists as
a lake executable on current master, so no automated minimization pass was run).

**Import-graph cost: zero downstream.** The three added imports grow `RationalRoot.lean`'s own
transitive closure by 30 modules (1614 -> 1644), mostly the `FieldTheory.SplittingField` /
`IntermediateField` / `Minpoly` cone that `GaussLemma.lean` pulls in. That growth does not
propagate: `RationalRoot.lean` has exactly three importers in Mathlib
(`RingTheory/Polynomial/IsIntegral.lean`, `RingTheory/DedekindDomain/Basic.lean`,
`NumberTheory/Niven.lean`), and all three already import `GaussLemma` and
`SplittingField.Construction` transitively today, so no file in Mathlib gains an import from this
PR. If a maintainer would still rather keep `RationalRoot.lean` light, the six declarations move to
a new `RingTheory/Polynomial/RationalRootMultiplicity.lean` without any proof change; I am happy to
do that on request.

---

**AI use disclosure** (per Mathlib's contribution guidelines): this generalization was developed in
a personal research project with the help of an AI coding agent (Claude Code). The agent developed
the multiplicity generalization and its proof (building on the existing single-multiplicity
`den_dvd_of_is_root`), then ported it directly onto Mathlib's own source files: placing the two
primitivity lemmas in `Content.lean`'s existing `NormalizedGCDMonoid` section (a weaker hypothesis
than the UFD one the standalone draft used; neither proof needs anything UFD-specific), adapting
the imports to the module system, and rebasing onto current master. During the rebase the agent
found that Mathlib had independently generalized
`IsPrimitive.dvd_of_fraction_map_dvd_fraction_map` to the one-sided form an earlier draft of this
PR supplied as a new lemma, so that lemma was dropped and the proofs call the existing one. Build
green, `#print axioms` clean, and linters passing were confirmed directly against Mathlib's source
tree. The underlying result is a natural generalization of an existing Mathlib theorem, and every
proof step uses only existing Mathlib API. I have reviewed and understand the proofs, take
responsibility for the content, and will respond to review in my own words.
