### PR TITLE
[Merged by Bors] - chore(Order): use `to_dual` in various places

### DIFF
--- a/Mathlib/Order/Bounded.lean
+++ b/Mathlib/Order/Bounded.lean
@@ -43,42 +43,25 @@ theorem Unbounded.mono (hst : s ⊆ t) (hs : Unbounded r s) : Unbounded r t := f
 /-! ### Alternate characterizations of unboundedness on orders -/
 
 
+@[to_dual unbounded_ge_of_forall_exists_gt]
 theorem unbounded_le_of_forall_exists_lt [Preorder α] (h : ∀ a, ∃ b ∈ s, a < b) :
     Unbounded (· ≤ ·) s := fun a =>
   let ⟨b, hb, hb'⟩ := h a
   ⟨b, hb, fun hba => hba.not_gt hb'⟩
 
+@[to_dual unbounded_ge_iff]
 theorem unbounded_le_iff [LinearOrder α] : Unbounded (· ≤ ·) s ↔ ∀ a, ∃ b ∈ s, a < b := by
   simp only [Unbounded, not_le]
 
+@[to_dual unbounded_gt_of_forall_exists_ge]
 theorem unbounded_lt_of_forall_exists_le [Preorder α] (h : ∀ a, ∃ b ∈ s, a ≤ b) :
     Unbounded (· < ·) s := fun a =>
   let ⟨b, hb, hb'⟩ := h a
   ⟨b, hb, fun hba => hba.not_ge hb'⟩
 
+@[to_dual unbounded_gt_iff]
 theorem unbounded_lt_iff [LinearOrder α] : Unbounded (· < ·) s ↔ ∀ a, ∃ b ∈ s, a ≤ b := by
   simp only [Unbounded, not_lt]
-
-theorem unbounded_ge_of_forall_exists_gt [Preorder α] (h : ∀ a, ∃ b ∈ s, b < a) :
-    Unbounded (· ≥ ·) s :=
-  @unbounded_le_of_forall_exists_lt αᵒᵈ _ _ h
-
-theorem unbounded_ge_iff [LinearOrder α] : Unbounded (· ≥ ·) s ↔ ∀ a, ∃ b ∈ s, b < a :=
-  ⟨fun h a =>
-    let ⟨b, hb, hba⟩ := h a
-    ⟨b, hb, lt_of_not_ge hba⟩,
-    unbounded_ge_of_forall_exists_gt⟩
-
-theorem unbounded_gt_of_forall_exists_ge [Preorder α] (h : ∀ a, ∃ b ∈ s, b ≤ a) :
-    Unbounded (· > ·) s := fun a =>
-  let ⟨b, hb, hb'⟩ := h a
-  ⟨b, hb, fun hba => not_le_of_gt hba hb'⟩
-
-theorem unbounded_gt_iff [LinearOrder α] : Unbounded (· > ·) s ↔ ∀ a, ∃ b ∈ s, b ≤ a :=
-  ⟨fun h a =>
-    let ⟨b, hb, hba⟩ := h a
-    ⟨b, hb, le_of_not_gt hba⟩,
-    unbounded_gt_of_forall_exists_ge⟩
 
 /-! ### Relation between boundedness by strict and nonstrict orders. -/
 

--- a/Mathlib/Order/BoundedOrder/Monotone.lean
+++ b/Mathlib/Order/BoundedOrder/Monotone.lean
@@ -29,40 +29,23 @@ section OrderTop
 
 variable [PartialOrder α] [OrderTop α] [Preorder β] {f : α → β} {a : α}
 
+@[to_dual]
 theorem StrictMono.apply_eq_top_iff (hf : StrictMono f) : f a = f ⊤ ↔ a = ⊤ :=
   ⟨fun h => not_lt_top_iff.1 fun ha => (hf ha).ne h, congr_arg _⟩
 
+@[to_dual]
 theorem StrictAnti.apply_eq_top_iff (hf : StrictAnti f) : f a = f ⊤ ↔ a = ⊤ :=
   ⟨fun h => not_lt_top_iff.1 fun ha => (hf ha).ne' h, congr_arg _⟩
 
 end OrderTop
 
+@[to_dual]
 theorem StrictMono.maximal_preimage_top [LinearOrder α] [Preorder β] [OrderTop β] {f : α → β}
     (H : StrictMono f) {a} (h_top : f a = ⊤) (x : α) : x ≤ a :=
   H.maximal_of_maximal_image
     (fun p => by
       rw [h_top]
       exact le_top)
-    x
-
-section OrderBot
-
-variable [PartialOrder α] [OrderBot α] [Preorder β] {f : α → β} {a : α}
-
-theorem StrictMono.apply_eq_bot_iff (hf : StrictMono f) : f a = f ⊥ ↔ a = ⊥ :=
-  hf.dual.apply_eq_top_iff
-
-theorem StrictAnti.apply_eq_bot_iff (hf : StrictAnti f) : f a = f ⊥ ↔ a = ⊥ :=
-  hf.dual.apply_eq_top_iff
-
-end OrderBot
-
-theorem StrictMono.minimal_preimage_bot [LinearOrder α] [Preorder β] [OrderBot β] {f : α → β}
-    (H : StrictMono f) {a} (h_bot : f a = ⊥) (x : α) : a ≤ x :=
-  H.minimal_of_minimal_image
-    (fun p => by
-      rw [h_bot]
-      exact bot_le)
     x
 
 section Logic

--- a/Mathlib/Order/Bounds/Image.lean
+++ b/Mathlib/Order/Bounds/Image.lean
@@ -158,18 +158,13 @@ section StrictMono
 
 variable [LinearOrder α] [Preorder β] {f : α → β} {a : α} {s : Set α}
 
+@[to_dual]
 lemma StrictMono.mem_upperBounds_image (hf : StrictMono f) :
     f a ∈ upperBounds (f '' s) ↔ a ∈ upperBounds s := by simp [upperBounds, hf.le_iff_le]
 
-lemma StrictMono.mem_lowerBounds_image (hf : StrictMono f) :
-    f a ∈ lowerBounds (f '' s) ↔ a ∈ lowerBounds s := by simp [lowerBounds, hf.le_iff_le]
-
+@[to_dual]
 lemma StrictMono.map_isLeast (hf : StrictMono f) : IsLeast (f '' s) (f a) ↔ IsLeast s a := by
   simp [IsLeast, hf.injective.eq_iff, hf.mem_lowerBounds_image]
-
-lemma StrictMono.map_isGreatest (hf : StrictMono f) :
-    IsGreatest (f '' s) (f a) ↔ IsGreatest s a := by
-  simp [IsGreatest, hf.injective.eq_iff, hf.mem_upperBounds_image]
 
 end StrictMono
 
@@ -177,19 +172,14 @@ section StrictAnti
 
 variable [LinearOrder α] [Preorder β] {f : α → β} {a : α} {s : Set α}
 
+@[to_dual]
 lemma StrictAnti.mem_upperBounds_image (hf : StrictAnti f) :
     f a ∈ upperBounds (f '' s) ↔ a ∈ lowerBounds s := by
   simp [upperBounds, lowerBounds, hf.le_iff_ge]
 
-lemma StrictAnti.mem_lowerBounds_image (hf : StrictAnti f) :
-    f a ∈ lowerBounds (f '' s) ↔ a ∈ upperBounds s := by
-  simp [upperBounds, lowerBounds, hf.le_iff_ge]
-
+@[to_dual]
 lemma StrictAnti.map_isLeast (hf : StrictAnti f) : IsLeast (f '' s) (f a) ↔ IsGreatest s a := by
   simp [IsLeast, IsGreatest, hf.injective.eq_iff, hf.mem_lowerBounds_image]
-
-lemma StrictAnti.map_isGreatest (hf : StrictAnti f) : IsGreatest (f '' s) (f a) ↔ IsLeast s a := by
-  simp [IsLeast, IsGreatest, hf.injective.eq_iff, hf.mem_upperBounds_image]
 
 end StrictAnti
 

--- a/Mathlib/Order/Bounds/OrderIso.lean
+++ b/Mathlib/Order/Bounds/OrderIso.lean
@@ -20,42 +20,28 @@ namespace OrderIso
 
 variable {α β : Type*} [Preorder α] [Preorder β] (f : α ≃o β)
 
+@[to_dual]
 theorem upperBounds_image {s : Set α} : upperBounds (f '' s) = f '' upperBounds s :=
   Subset.antisymm
     (fun x hx =>
       ⟨f.symm x, fun _ hy => f.le_symm_apply.2 (hx <| mem_image_of_mem _ hy), f.apply_symm_apply x⟩)
     f.monotone.image_upperBounds_subset_upperBounds_image
 
-theorem lowerBounds_image {s : Set α} : lowerBounds (f '' s) = f '' lowerBounds s :=
-  @upperBounds_image αᵒᵈ βᵒᵈ _ _ f.dual _
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem isLUB_image {s : Set α} {x : β} : IsLUB (f '' s) x ↔ IsLUB s (f.symm x) :=
   ⟨fun h => IsLUB.of_image (by simp) ((f.apply_symm_apply x).symm ▸ h), fun h =>
     (IsLUB.of_image (by simp)) <| (f.symm_image_image s).symm ▸ h⟩
 
+@[to_dual]
 theorem isLUB_image' {s : Set α} {x : α} : IsLUB (f '' s) (f x) ↔ IsLUB s x := by
   rw [isLUB_image, f.symm_apply_apply]
 
-@[simp]
-theorem isGLB_image {s : Set α} {x : β} : IsGLB (f '' s) x ↔ IsGLB s (f.symm x) :=
-  f.dual.isLUB_image
-
-theorem isGLB_image' {s : Set α} {x : α} : IsGLB (f '' s) (f x) ↔ IsGLB s x :=
-  f.dual.isLUB_image'
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem isLUB_preimage {s : Set β} {x : α} : IsLUB (f ⁻¹' s) x ↔ IsLUB s (f x) := by
   rw [← f.symm_symm, ← image_eq_preimage_symm, isLUB_image]
 
+@[to_dual]
 theorem isLUB_preimage' {s : Set β} {x : β} : IsLUB (f ⁻¹' s) (f.symm x) ↔ IsLUB s x := by
   rw [isLUB_preimage, f.apply_symm_apply]
-
-@[simp]
-theorem isGLB_preimage {s : Set β} {x : α} : IsGLB (f ⁻¹' s) x ↔ IsGLB s (f x) :=
-  f.dual.isLUB_preimage
-
-theorem isGLB_preimage' {s : Set β} {x : β} : IsGLB (f ⁻¹' s) (f.symm x) ↔ IsGLB s x :=
-  f.dual.isLUB_preimage'
 
 end OrderIso

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -128,13 +128,10 @@ class CompletelyDistribLattice (α : Type u) extends CompleteLattice α, Biheyti
   protected iInf_iSup_eq {ι : Type u} {κ : ι → Type u} (f : ∀ a, κ a → α) :
     (⨅ a, ⨆ b, f a b) = ⨆ g : ∀ a, κ a, ⨅ a, f a (g a)
 
+@[to_dual iSup_iInf_le]
 theorem le_iInf_iSup [CompleteLattice α] {f : ∀ a, κ a → α} :
     (⨆ g : ∀ a, κ a, ⨅ a, f a (g a)) ≤ ⨅ a, ⨆ b, f a b :=
   iSup_le fun _ => le_iInf fun a => le_trans (iInf_le _ a) (le_iSup _ _)
-
-lemma iSup_iInf_le [CompleteLattice α] {f : ∀ a, κ a → α} :
-    ⨆ a, ⨅ b, f a b ≤ ⨅ g : ∀ a, κ a, ⨆ a, f a (g a) :=
-  le_iInf_iSup (α := αᵒᵈ)
 
 namespace Order.Frame.MinimalAxioms
 variable (s : Set α) (a b : α)

--- a/Mathlib/Order/Filter/AtTopBot/Map.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Map.lean
@@ -28,36 +28,21 @@ open Filter
 
 variable [Preorder α] [Preorder β]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem comap_atTop (e : α ≃o β) : comap e atTop = atTop := by
   simp [atTop, ← e.surjective.iInf_comp]
 
-@[simp]
-theorem comap_atBot (e : α ≃o β) : comap e atBot = atBot :=
-  e.dual.comap_atTop
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem map_atTop (e : α ≃o β) : map (e : α → β) atTop = atTop := by
   rw [← e.comap_atTop, map_comap_of_surjective e.surjective]
 
-@[simp]
-theorem map_atBot (e : α ≃o β) : map (e : α → β) atBot = atBot :=
-  e.dual.map_atTop
-
+@[to_dual]
 theorem tendsto_atTop (e : α ≃o β) : Tendsto e atTop atTop :=
   e.map_atTop.le
 
-theorem tendsto_atBot (e : α ≃o β) : Tendsto e atBot atBot :=
-  e.map_atBot.le
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem tendsto_atTop_iff {l : Filter γ} {f : γ → α} (e : α ≃o β) :
     Tendsto (fun x => e (f x)) l atTop ↔ Tendsto f l atTop := by
   rw [← e.comap_atTop, tendsto_comap_iff, Function.comp_def]
-
-@[simp]
-theorem tendsto_atBot_iff {l : Filter γ} {f : γ → α} (e : α ≃o β) :
-    Tendsto (fun x => e (f x)) l atBot ↔ Tendsto f l atBot :=
-  e.dual.tendsto_atTop_iff
 
 end OrderIso

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -147,23 +147,16 @@ end ConditionallyCompleteLinearOrderBot
 section CompleteLinearOrder
 variable [CompleteLinearOrder α] {s : Set α} {f : ι → α} {x : α}
 
+@[to_dual]
 lemma sSup_mem_of_not_isSuccPrelimit (hlim : ¬ IsSuccPrelimit (sSup s)) : sSup s ∈ s := by
   obtain ⟨y, hy⟩ := not_forall_not.mp hlim
   obtain ⟨i, his, hi⟩ := lt_sSup_iff.mp hy.lt
   exact eq_of_le_of_not_lt (le_sSup his) (hy.2 hi) ▸ his
 
-lemma sInf_mem_of_not_isPredPrelimit (hlim : ¬ IsPredPrelimit (sInf s)) : sInf s ∈ s := by
-  obtain ⟨y, hy⟩ := not_forall_not.mp hlim
-  obtain ⟨i, his, hi⟩ := sInf_lt_iff.mp hy.lt
-  exact eq_of_le_of_not_lt (sInf_le his) (hy.2 · hi) ▸ his
-
+@[to_dual]
 lemma exists_eq_iSup_of_not_isSuccPrelimit (hf : ¬ IsSuccPrelimit (⨆ i, f i)) :
     ∃ i, f i = ⨆ i, f i :=
   sSup_mem_of_not_isSuccPrelimit hf
-
-lemma exists_eq_iInf_of_not_isPredPrelimit (hf : ¬ IsPredPrelimit (⨅ i, f i)) :
-    ∃ i, f i = ⨅ i, f i :=
-  sInf_mem_of_not_isPredPrelimit hf
 
 /-- Similar to `sSup_lt_iff` but with a weaker RHS, as it does not require a uniform bound. -/
 @[to_dual lt_sInf_iff_of_not_isPredPrelimit


### PR DESCRIPTION
This PR uses `to_dual` for various order theorems.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
