### PR TITLE
[Merged by Bors] - feat: injectivity of Function.extend for disjoint ranges

### DIFF
--- a/Mathlib/Data/Set/Restrict.lean
+++ b/Mathlib/Data/Set/Restrict.lean
@@ -142,6 +142,31 @@ lemma _root_.Function.Injective.extend_injOn {f : α → β} {g : α → γ} {j 
     (range f).InjOn (extend f g j) :=
   (hf.factorsThrough g).extend_injOn hg
 
+/-- If `f`, `g` and `j` are injective and `g` and `j` have disjoint ranges,
+then `extend f g j` is injective. -/
+lemma _root_.Function.Injective.extend_of_disjoint {f : α → β} {g : α → γ} {j : β → γ}
+    (hf : f.Injective) (hg : g.Injective) (hj : j.Injective)
+    (hd : Disjoint (range g) (range j)) :
+    Injective (extend f g j) := by
+  intro x y h
+  obtain ⟨a, rfl⟩ | hx := em (∃ a, f a = x) <;> obtain ⟨b, rfl⟩ | hy := em (∃ a, f a = y)
+  · rw [hf.extend_apply, hf.extend_apply] at h
+    rw [hg h]
+  · rw [hf.extend_apply, extend_apply' _ _ _ hy] at h
+    exact absurd ⟨y, h.symm⟩ (disjoint_left.1 hd (mem_range_self a))
+  · rw [extend_apply' _ _ _ hx, hf.extend_apply] at h
+    exact absurd ⟨x, h⟩ (disjoint_left.1 hd (mem_range_self b))
+  · rw [extend_apply' _ _ _ hx, extend_apply' _ _ _ hy] at h
+    exact hj h
+
+/-- `Function.extend f Sum.inl Sum.inr : β → α ⊕ β` is injective when `f` is:
+elements in the range of `f` are sent into `Sum.inl` along `f`'s (injective) inverse,
+and everything else is sent to itself under `Sum.inr`. -/
+lemma _root_.Function.Injective.extend_sum_inl_inr {f : α → β} (hf : f.Injective) :
+    Injective (extend f (Sum.inl : α → α ⊕ β) (Sum.inr : β → α ⊕ β)) :=
+  hf.extend_of_disjoint (fun _ _ ↦ Sum.inl.inj) (fun _ _ ↦ Sum.inr.inj)
+    isCompl_range_inl_range_inr.disjoint
+
 /-- Restrict codomain of a function `f` to a set `s`. Same as `Subtype.coind` but this version
 has codomain `↥s` instead of `Subtype s`. -/
 def codRestrict (f : ι → α) (s : Set α) (h : ∀ x, f x ∈ s) : ι → s := fun x => ⟨f x, h x⟩

--- a/Mathlib/Data/Set/Restrict.lean
+++ b/Mathlib/Data/Set/Restrict.lean
@@ -159,14 +159,6 @@ lemma _root_.Function.Injective.extend_of_disjoint {f : α → β} {g : α → �
   · rw [extend_apply' _ _ _ hx, extend_apply' _ _ _ hy] at h
     exact hj h
 
-/-- `Function.extend f Sum.inl Sum.inr : β → α ⊕ β` is injective when `f` is:
-elements in the range of `f` are sent into `Sum.inl` along `f`'s (injective) inverse,
-and everything else is sent to itself under `Sum.inr`. -/
-lemma _root_.Function.Injective.extend_sum_inl_inr {f : α → β} (hf : f.Injective) :
-    Injective (extend f (Sum.inl : α → α ⊕ β) (Sum.inr : β → α ⊕ β)) :=
-  hf.extend_of_disjoint (fun _ _ ↦ Sum.inl.inj) (fun _ _ ↦ Sum.inr.inj)
-    isCompl_range_inl_range_inr.disjoint
-
 /-- Restrict codomain of a function `f` to a set `s`. Same as `Subtype.coind` but this version
 has codomain `↥s` instead of `Subtype s`. -/
 def codRestrict (f : ι → α) (s : Set α) (h : ∀ x, f x ∈ s) : ι → s := fun x => ⟨f x, h x⟩

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -940,6 +940,23 @@ theorem Bijective.comp_right (hf : Bijective f) : Bijective fun g : β → γ �
     ⟨g ∘ surjInv hf.surjective,
      by simp only [comp_assoc g _ f, (leftInverse_surjInv hf).comp_eq_id, comp_id]⟩⟩
 
+/-- `Function.extend f Sum.inl Sum.inr : β → α ⊕ β` is injective when `f` is:
+elements in the range of `f` are sent into `Sum.inl` along `f`'s (injective) inverse,
+and everything else is sent to itself under `Sum.inr`. -/
+theorem Injective.extend_sum_inl_inr {α β : Type*} {f : α → β} (hf : Injective f) :
+    Injective (extend f (Sum.inl : α → α ⊕ β) (Sum.inr : β → α ⊕ β)) := by
+  intro x y h
+  have h_cases (z : β) : (∃ a, f a = z) ∨ (extend f Sum.inl Sum.inr z = Sum.inr z) := by
+    rw [Classical.or_iff_not_imp_left]
+    simp +contextual
+  rcases h_cases x with ⟨a, rfl⟩ | hx <;> rcases h_cases y with ⟨b, rfl⟩ | hy
+  · rw [hf.extend_apply, hf.extend_apply] at h
+    exact congr_arg f (Sum.inl.inj h)
+  · rw [hf.extend_apply, hy] at h; contradiction
+  · rw [hx, hf.extend_apply] at h; contradiction
+  · rw [hx, hy] at h
+    exact Sum.inr.inj h
+
 end Extend
 
 namespace FactorsThrough

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -945,17 +945,9 @@ elements in the range of `f` are sent into `Sum.inl` along `f`'s (injective) inv
 and everything else is sent to itself under `Sum.inr`. -/
 theorem Injective.extend_sum_inl_inr {α β : Type*} {f : α → β} (hf : Injective f) :
     Injective (extend f (Sum.inl : α → α ⊕ β) (Sum.inr : β → α ⊕ β)) := by
-  intro x y h
-  have h_cases (z : β) : (∃ a, f a = z) ∨ (extend f Sum.inl Sum.inr z = Sum.inr z) := by
-    rw [Classical.or_iff_not_imp_left]
-    simp +contextual
-  rcases h_cases x with ⟨a, rfl⟩ | hx <;> rcases h_cases y with ⟨b, rfl⟩ | hy
-  · rw [hf.extend_apply, hf.extend_apply] at h
-    exact congr_arg f (Sum.inl.inj h)
-  · rw [hf.extend_apply, hy] at h; contradiction
-  · rw [hx, hf.extend_apply] at h; contradiction
-  · rw [hx, hy] at h
-    exact Sum.inr.inj h
+  apply LeftInverse.injective (g := Sum.elim f id)
+  intro x
+  obtain ⟨a, rfl⟩ | hx := em (∃ a, f a = x) <;> simp_all
 
 end Extend
 

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -940,15 +940,6 @@ theorem Bijective.comp_right (hf : Bijective f) : Bijective fun g : β → γ �
     ⟨g ∘ surjInv hf.surjective,
      by simp only [comp_assoc g _ f, (leftInverse_surjInv hf).comp_eq_id, comp_id]⟩⟩
 
-/-- `Function.extend f Sum.inl Sum.inr : β → α ⊕ β` is injective when `f` is:
-elements in the range of `f` are sent into `Sum.inl` along `f`'s (injective) inverse,
-and everything else is sent to itself under `Sum.inr`. -/
-theorem Injective.extend_sum_inl_inr {α β : Type*} {f : α → β} (hf : Injective f) :
-    Injective (extend f (Sum.inl : α → α ⊕ β) (Sum.inr : β → α ⊕ β)) := by
-  apply LeftInverse.injective (g := Sum.elim f id)
-  intro x
-  obtain ⟨a, rfl⟩ | hx := em (∃ a, f a = x) <;> simp_all
-
 end Extend
 
 namespace FactorsThrough


### PR DESCRIPTION
This PR adds `Function.Injective.extend_of_disjoint`: if `f : α → β`, `g : α → γ` and `j : β → γ` are injective and `g` and `j` have disjoint ranges, then `Function.extend f g j` is injective. It is used in https://github.com/leanprover/cslib/pull/401 to build families of total orders for a comparison-sorting lower bound, via `Function.extend f Sum.inl Sum.inr : β → α ⊕ β`.

🤖 Prepared with Claude Code