### PR TITLE
chore(Analysis/LocallyConvex): make `Bounded.lean` independent of `NormedSpace`

### DIFF
--- a/Mathlib/Analysis/Convex/Gauge.lean
+++ b/Mathlib/Analysis/Convex/Gauge.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.Convex.Topology
 public import Mathlib.Analysis.Normed.Module.Ball.Pointwise
-public import Mathlib.Analysis.Normed.Module.Seminorm.Basic
+public import Mathlib.Analysis.Normed.Module.Seminorm.Norm
 public import Mathlib.Analysis.LocallyConvex.Bounded
 public import Mathlib.Analysis.RCLike.Basic
 

--- a/Mathlib/Analysis/LocallyConvex/Bounded.lean
+++ b/Mathlib/Analysis/LocallyConvex/Bounded.lean
@@ -254,7 +254,7 @@ then it is also von Neumann bounded with respect to a larger field.
 See also `Bornology.IsVonNBounded.restrict_scalars` below. -/
 theorem IsVonNBounded.extend_scalars [NontriviallyNormedField 𝕜]
     {E : Type*} [AddCommGroup E] [Module 𝕜 E]
-    (𝕝 : Type*) [NontriviallyNormedField 𝕝] [Module 𝕜 𝕝] [NormSMulClass 𝕜 𝕝]
+    (𝕝 : Type*) [NontriviallyNormedField 𝕝] [Module 𝕜 𝕝]
     [Module 𝕝 E] [TopologicalSpace E] [ContinuousSMul 𝕝 E] [IsScalarTower 𝕜 𝕝 E]
     {s : Set E} (h : IsVonNBounded 𝕜 s) : IsVonNBounded 𝕝 s := by
   obtain ⟨ε, hε, hε₀⟩ : ∃ ε : ℕ → 𝕜, Tendsto ε atTop (𝓝 0) ∧ ∀ᶠ n in atTop, ε n ≠ 0 := by

--- a/Mathlib/Analysis/LocallyConvex/Bounded.lean
+++ b/Mathlib/Analysis/LocallyConvex/Bounded.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.GroupTheory.GroupAction.Pointwise
 public import Mathlib.Analysis.LocallyConvex.Basic
 public import Mathlib.Analysis.LocallyConvex.BalancedCoreHull
-public import Mathlib.Analysis.Normed.Module.Seminorm.Norm
 public import Mathlib.Topology.Bornology.Basic
 public import Mathlib.Topology.Algebra.IsUniformGroup.Basic
 public import Mathlib.Topology.UniformSpace.Cauchy
@@ -40,6 +39,8 @@ This file defines natural or von Neumann bounded sets and proves elementary prop
 * [Bourbaki, *Topological Vector Spaces*][bourbaki1987]
 
 -/
+
+assert_not_exists NormedSpace
 
 @[expose] public section
 
@@ -253,7 +254,7 @@ then it is also von Neumann bounded with respect to a larger field.
 See also `Bornology.IsVonNBounded.restrict_scalars` below. -/
 theorem IsVonNBounded.extend_scalars [NontriviallyNormedField 𝕜]
     {E : Type*} [AddCommGroup E] [Module 𝕜 E]
-    (𝕝 : Type*) [NontriviallyNormedField 𝕝] [NormedAlgebra 𝕜 𝕝]
+    (𝕝 : Type*) [NontriviallyNormedField 𝕝] [Module 𝕜 𝕝] [NormSMulClass 𝕜 𝕝]
     [Module 𝕝 E] [TopologicalSpace E] [ContinuousSMul 𝕝 E] [IsScalarTower 𝕜 𝕝 E]
     {s : Set E} (h : IsVonNBounded 𝕜 s) : IsVonNBounded 𝕝 s := by
   obtain ⟨ε, hε, hε₀⟩ : ∃ ε : ℕ → 𝕜, Tendsto ε atTop (𝓝 0) ∧ ∀ᶠ n in atTop, ε n ≠ 0 := by
@@ -429,7 +430,7 @@ theorem Filter.Tendsto.isVonNBounded_range [NormedField 𝕜] [AddCommGroup E] [
 
 variable (𝕜) in
 protected theorem Bornology.IsVonNBounded.restrict_scalars_of_nontrivial
-    [NormedField 𝕜] [NormedRing 𝕜'] [NormedAlgebra 𝕜 𝕜'] [Nontrivial 𝕜']
+    [NormedField 𝕜] [NormedRing 𝕜'] [Module 𝕜 𝕜'] [NormSMulClass 𝕜 𝕜'] [Nontrivial 𝕜']
     [Zero E] [TopologicalSpace E]
     [SMul 𝕜 E] [MulAction 𝕜' E] [IsScalarTower 𝕜 𝕜' E] {s : Set E}
     (h : IsVonNBounded 𝕜' s) : IsVonNBounded 𝕜 s := by
@@ -441,7 +442,7 @@ protected theorem Bornology.IsVonNBounded.restrict_scalars_of_nontrivial
 
 variable (𝕜) in
 protected theorem Bornology.IsVonNBounded.restrict_scalars
-    [NormedField 𝕜] [NormedRing 𝕜'] [NormedAlgebra 𝕜 𝕜']
+    [NormedField 𝕜] [NormedRing 𝕜'] [Module 𝕜 𝕜'] [NormSMulClass 𝕜 𝕜']
     [Zero E] [TopologicalSpace E]
     [SMul 𝕜 E] [MulActionWithZero 𝕜' E] [IsScalarTower 𝕜 𝕜' E] {s : Set E}
     (h : IsVonNBounded 𝕜' s) : IsVonNBounded 𝕜 s :=
@@ -451,85 +452,6 @@ protected theorem Bornology.IsVonNBounded.restrict_scalars
     IsVonNBounded.of_subsingleton
   | .inr _ =>
     h.restrict_scalars_of_nontrivial _
-
-section VonNBornologyEqMetric
-
-namespace NormedSpace
-
-section NormedField
-
-variable (𝕜)
-variable [NormedField 𝕜] [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
-
-theorem isVonNBounded_of_isBounded {s : Set E} (h : Bornology.IsBounded s) :
-    Bornology.IsVonNBounded 𝕜 s := by
-  rcases h.subset_ball 0 with ⟨r, hr⟩
-  rw [Metric.nhds_basis_ball.isVonNBounded_iff]
-  rw [← ball_normSeminorm 𝕜 E] at hr ⊢
-  exact fun ε hε ↦ ((normSeminorm 𝕜 E).ball_zero_absorbs_ball_zero hε).mono_right hr
-
-variable (E)
-
-theorem isVonNBounded_ball (r : ℝ) : Bornology.IsVonNBounded 𝕜 (Metric.ball (0 : E) r) :=
-  isVonNBounded_of_isBounded _ Metric.isBounded_ball
-
-theorem isVonNBounded_closedBall (r : ℝ) :
-    Bornology.IsVonNBounded 𝕜 (Metric.closedBall (0 : E) r) :=
-  isVonNBounded_of_isBounded _ Metric.isBounded_closedBall
-
-end NormedField
-
-variable (𝕜)
-variable [NontriviallyNormedField 𝕜] [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
-
-theorem isVonNBounded_iff {s : Set E} : Bornology.IsVonNBounded 𝕜 s ↔ Bornology.IsBounded s := by
-  refine ⟨fun h ↦ ?_, isVonNBounded_of_isBounded _⟩
-  rcases (h (Metric.ball_mem_nhds 0 zero_lt_one)).exists_pos with ⟨ρ, hρ, hρball⟩
-  rcases NormedField.exists_lt_norm 𝕜 ρ with ⟨a, ha⟩
-  specialize hρball a ha.le
-  rw [← ball_normSeminorm 𝕜 E, Seminorm.smul_ball_zero (norm_pos_iff.1 <| hρ.trans ha),
-    ball_normSeminorm] at hρball
-  exact Metric.isBounded_ball.subset hρball
-
-theorem isVonNBounded_iff' {s : Set E} :
-    Bornology.IsVonNBounded 𝕜 s ↔ ∃ r : ℝ, ∀ x ∈ s, ‖x‖ ≤ r := by
-  rw [NormedSpace.isVonNBounded_iff, isBounded_iff_forall_norm_le]
-
-theorem image_isVonNBounded_iff {α : Type*} {f : α → E} {s : Set α} :
-    Bornology.IsVonNBounded 𝕜 (f '' s) ↔ ∃ r : ℝ, ∀ x ∈ s, ‖f x‖ ≤ r := by
-  simp_rw [isVonNBounded_iff', Set.forall_mem_image]
-
-/-- In a normed space, the von Neumann bornology (`Bornology.vonNBornology`) is equal to the
-metric bornology. -/
-theorem vonNBornology_eq : Bornology.vonNBornology 𝕜 E = PseudoMetricSpace.toBornology := by
-  rw [Bornology.ext_iff_isBounded]
-  intro s
-  rw [Bornology.isBounded_iff_isVonNBounded]
-  exact isVonNBounded_iff _
-
-theorem isBounded_iff_subset_smul_ball {s : Set E} :
-    Bornology.IsBounded s ↔ ∃ a : 𝕜, s ⊆ a • Metric.ball (0 : E) 1 := by
-  rw [← isVonNBounded_iff 𝕜]
-  constructor
-  · intro h
-    rcases (h (Metric.ball_mem_nhds 0 zero_lt_one)).exists_pos with ⟨ρ, _, hρball⟩
-    rcases NormedField.exists_lt_norm 𝕜 ρ with ⟨a, ha⟩
-    exact ⟨a, hρball a ha.le⟩
-  · rintro ⟨a, ha⟩
-    exact ((isVonNBounded_ball 𝕜 E 1).image (a • (1 : E →L[𝕜] E))).subset ha
-
-theorem isBounded_iff_subset_smul_closedBall {s : Set E} :
-    Bornology.IsBounded s ↔ ∃ a : 𝕜, s ⊆ a • Metric.closedBall (0 : E) 1 := by
-  constructor
-  · rw [isBounded_iff_subset_smul_ball 𝕜]
-    exact Exists.imp fun a ha => ha.trans <| Set.smul_set_mono <| Metric.ball_subset_closedBall
-  · rw [← isVonNBounded_iff 𝕜]
-    rintro ⟨a, ha⟩
-    exact ((isVonNBounded_closedBall 𝕜 E 1).image (a • (1 : E →L[𝕜] E))).subset ha
-
-end NormedSpace
-
-end VonNBornologyEqMetric
 
 section QuasiCompleteSpace
 

--- a/Mathlib/Analysis/LocallyConvex/WithSeminorms.lean
+++ b/Mathlib/Analysis/LocallyConvex/WithSeminorms.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.LocallyConvex.Bounded
 public import Mathlib.Analysis.Normed.Module.Seminorm.Basic
+public import Mathlib.Analysis.Normed.Module.Seminorm.Norm
 public import Mathlib.Analysis.Real.Sqrt
 public import Mathlib.Topology.Algebra.Equicontinuity
 public import Mathlib.Topology.MetricSpace.Equicontinuity

--- a/Mathlib/Analysis/Normed/Module/Seminorm/Norm.lean
+++ b/Mathlib/Analysis/Normed/Module/Seminorm/Norm.lean
@@ -1,11 +1,12 @@
 /-
 Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yaël Dillies, Anatole Dedecker
+Authors: Yaël Dillies, Anatole Dedecker, Moritz Doll
 -/
 
 module
 
+public import Mathlib.Analysis.LocallyConvex.Bounded
 public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.Analysis.Normed.Module.Seminorm.Basic
 
@@ -19,9 +20,9 @@ public section
 
 variable {𝕜 E F : Type*}
 
-variable [NormedField 𝕜]
-
 section Seminormed
+
+variable [NormedField 𝕜]
 
 variable [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
 variable {r : ℝ} {x : E} {c : 𝕜} {ε : ℝ}
@@ -88,6 +89,8 @@ end Seminormed
 
 section Normed
 
+variable [NormedField 𝕜]
+
 variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 variable {r : ℝ} {x : E} {c : 𝕜} {ε : ℝ}
 
@@ -104,3 +107,88 @@ lemma rescale_to_shell (hc : 1 < ‖c‖) (εpos : 0 < ε) (hx : x ≠ 0) :
   rescale_to_shell_semi_normed hc εpos (norm_ne_zero_iff.mpr hx)
 
 end Normed
+
+section VonNBornologyEqMetric
+
+namespace NormedSpace
+
+section NormedField
+
+variable (𝕜)
+variable [NormedField 𝕜] [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
+
+theorem isVonNBounded_of_isBounded {s : Set E} (h : Bornology.IsBounded s) :
+    Bornology.IsVonNBounded 𝕜 s := by
+  rcases h.subset_ball 0 with ⟨r, hr⟩
+  rw [Metric.nhds_basis_ball.isVonNBounded_iff]
+  rw [← ball_normSeminorm 𝕜 E] at hr ⊢
+  exact fun ε hε ↦ ((normSeminorm 𝕜 E).ball_zero_absorbs_ball_zero hε).mono_right hr
+
+variable (E)
+
+theorem isVonNBounded_ball (r : ℝ) : Bornology.IsVonNBounded 𝕜 (Metric.ball (0 : E) r) :=
+  isVonNBounded_of_isBounded _ Metric.isBounded_ball
+
+theorem isVonNBounded_closedBall (r : ℝ) :
+    Bornology.IsVonNBounded 𝕜 (Metric.closedBall (0 : E) r) :=
+  isVonNBounded_of_isBounded _ Metric.isBounded_closedBall
+
+end NormedField
+
+section NontriviallyNormedField
+
+open scoped Pointwise
+
+variable (𝕜)
+variable [NontriviallyNormedField 𝕜] [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
+
+theorem isVonNBounded_iff {s : Set E} : Bornology.IsVonNBounded 𝕜 s ↔ Bornology.IsBounded s := by
+  refine ⟨fun h ↦ ?_, isVonNBounded_of_isBounded _⟩
+  rcases (h (Metric.ball_mem_nhds 0 zero_lt_one)).exists_pos with ⟨ρ, hρ, hρball⟩
+  rcases NormedField.exists_lt_norm 𝕜 ρ with ⟨a, ha⟩
+  specialize hρball a ha.le
+  rw [← ball_normSeminorm 𝕜 E, Seminorm.smul_ball_zero (norm_pos_iff.1 <| hρ.trans ha),
+    ball_normSeminorm] at hρball
+  exact Metric.isBounded_ball.subset hρball
+
+theorem isVonNBounded_iff' {s : Set E} :
+    Bornology.IsVonNBounded 𝕜 s ↔ ∃ r : ℝ, ∀ x ∈ s, ‖x‖ ≤ r := by
+  rw [NormedSpace.isVonNBounded_iff, isBounded_iff_forall_norm_le]
+
+theorem image_isVonNBounded_iff {α : Type*} {f : α → E} {s : Set α} :
+    Bornology.IsVonNBounded 𝕜 (f '' s) ↔ ∃ r : ℝ, ∀ x ∈ s, ‖f x‖ ≤ r := by
+  simp_rw [isVonNBounded_iff', Set.forall_mem_image]
+
+/-- In a normed space, the von Neumann bornology (`Bornology.vonNBornology`) is equal to the
+metric bornology. -/
+theorem vonNBornology_eq : Bornology.vonNBornology 𝕜 E = PseudoMetricSpace.toBornology := by
+  rw [Bornology.ext_iff_isBounded]
+  intro s
+  rw [Bornology.isBounded_iff_isVonNBounded]
+  exact isVonNBounded_iff _
+
+theorem isBounded_iff_subset_smul_ball {s : Set E} :
+    Bornology.IsBounded s ↔ ∃ a : 𝕜, s ⊆ a • Metric.ball (0 : E) 1 := by
+  rw [← isVonNBounded_iff 𝕜]
+  constructor
+  · intro h
+    rcases (h (Metric.ball_mem_nhds 0 zero_lt_one)).exists_pos with ⟨ρ, _, hρball⟩
+    rcases NormedField.exists_lt_norm 𝕜 ρ with ⟨a, ha⟩
+    exact ⟨a, hρball a ha.le⟩
+  · rintro ⟨a, ha⟩
+    exact ((isVonNBounded_ball 𝕜 E 1).image (a • (1 : E →L[𝕜] E))).subset ha
+
+theorem isBounded_iff_subset_smul_closedBall {s : Set E} :
+    Bornology.IsBounded s ↔ ∃ a : 𝕜, s ⊆ a • Metric.closedBall (0 : E) 1 := by
+  constructor
+  · rw [isBounded_iff_subset_smul_ball 𝕜]
+    exact Exists.imp fun a ha => ha.trans <| Set.smul_set_mono <| Metric.ball_subset_closedBall
+  · rw [← isVonNBounded_iff 𝕜]
+    rintro ⟨a, ha⟩
+    exact ((isVonNBounded_closedBall 𝕜 E 1).image (a • (1 : E →L[𝕜] E))).subset ha
+
+end NontriviallyNormedField
+
+end NormedSpace
+
+end VonNBornologyEqMetric

--- a/Mathlib/Analysis/Normed/Operator/Compact/Basic.lean
+++ b/Mathlib/Analysis/Normed/Operator/Compact/Basic.lean
@@ -5,7 +5,7 @@ Authors: Anatole Dedecker
 -/
 module
 
-public import Mathlib.Analysis.LocallyConvex.Bounded
+public import Mathlib.Analysis.Normed.Module.Seminorm.Norm
 public import Mathlib.Tactic.CrossRefAttribute
 public import Mathlib.Topology.Algebra.Module.Spaces.ContinuousLinearMap
 

--- a/Mathlib/NumberTheory/Padics/Measure/Topology.lean
+++ b/Mathlib/NumberTheory/Padics/Measure/Topology.lean
@@ -42,7 +42,7 @@ continuous for all `f`).
 
 end Weak
 
-variable [CompactSpace X] [NontriviallyNormedField R] [NormedAddCommGroup E] [NormedSpace R E]
+variable [CompactSpace X] [NormedField R] [NormedAddCommGroup E] [Module R E]
 
 /-- The strong topology on `AbstractMeasure G R E` (the topology induced by the norm). -/
 @[reducible] def StrongTopology : TopologicalSpace (AbstractMeasure X R E) :=

--- a/Mathlib/Topology/Algebra/Module/Multilinear/Topology.lean
+++ b/Mathlib/Topology/Algebra/Module/Multilinear/Topology.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 module
 
+public import Mathlib.Analysis.Normed.Module.Seminorm.Norm
 public import Mathlib.Topology.Algebra.Module.Equiv
 public import Mathlib.Topology.Algebra.Module.Multilinear.Bounded
 public import Mathlib.Topology.Algebra.Module.Spaces.ContinuousLinearMap

--- a/Mathlib/Topology/Algebra/Module/Spaces/ContinuousLinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/Spaces/ContinuousLinearMap.lean
@@ -382,7 +382,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 section UniformSpace
 
 variable [UniformSpace F] [IsUniformAddGroup F] [Module 𝕜 F]
-  (𝕜' : Type*) [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜' 𝕜]
+  (𝕜' : Type*) [NontriviallyNormedField 𝕜'] [Module 𝕜' 𝕜] [NormSMulClass 𝕜' 𝕜]
   [Module 𝕜' E] [IsScalarTower 𝕜' 𝕜 E] [Module 𝕜' F] [IsScalarTower 𝕜' 𝕜 F]
 
 set_option backward.isDefEq.respectTransparency false in
@@ -399,7 +399,7 @@ theorem uniformContinuous_restrictScalars :
 end UniformSpace
 
 variable [TopologicalSpace F] [IsTopologicalAddGroup F] [Module 𝕜 F]
-  (𝕜' : Type*) [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜' 𝕜]
+  (𝕜' : Type*) [NontriviallyNormedField 𝕜'] [Module 𝕜' 𝕜] [NormSMulClass 𝕜' 𝕜]
   [Module 𝕜' E] [IsScalarTower 𝕜' 𝕜 E] [Module 𝕜' F] [IsScalarTower 𝕜' 𝕜 F]
 
 theorem isEmbedding_restrictScalars :


### PR DESCRIPTION
The only changes in the moved block is to add a section `NontriviallyNormedField` and open the scope `Pointwise`.

---

The overall goal is to make all of `LocallyConvex` independent of `NormedSpace`, which is morally the correct thing to do because locally convex topological vector spaces are more abstract than normed spaces, hence should not depend on them.

This changes indicate that there are various other places where we should separate out the theorems about normed spaces (or generalize to topological vector spaces).

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
