### PR TITLE
[Merged by Bors] - chore(Order/Irreducible): use `to_dual`

### DIFF
--- a/Mathlib/Order/Birkhoff.lean
+++ b/Mathlib/Order/Birkhoff.lean
@@ -59,32 +59,11 @@ variable {α : Type*}
 section PartialOrder
 variable [PartialOrder α]
 
-namespace UpperSet
-variable {s : UpperSet α}
-
-@[simp] lemma infIrred_Ici (a : α) : InfIrred (Ici a) := by
-  refine ⟨fun h ↦ Ici_ne_top h.eq_top, fun s t hst ↦ ?_⟩
-  have := mem_Ici_iff.2 (le_refl a)
-  rw [← hst] at this
-  exact this.imp (fun ha ↦ le_antisymm (le_Ici.2 ha) <| hst.ge.trans inf_le_left) fun ha ↦
-      le_antisymm (le_Ici.2 ha) <| hst.ge.trans inf_le_right
-
-variable [Finite α]
-
-@[simp] lemma infIrred_iff_of_finite : InfIrred s ↔ ∃ a, Ici a = s := by
-  refine ⟨fun hs ↦ ?_, ?_⟩
-  · obtain ⟨a, ha, has⟩ := (s : Set α).toFinite.exists_minimal (coe_nonempty.2 hs.ne_top)
-    exact ⟨a, (hs.2 <| erase_inf_Ici ha fun b hb ↦ le_imp_eq_iff_le_imp_ge.2 <| has hb).resolve_left
-      (lt_erase.2 ha).ne'⟩
-  · rintro ⟨a, rfl⟩
-    exact infIrred_Ici _
-
-end UpperSet
-
 namespace LowerSet
 variable {s : LowerSet α}
 
-@[simp] lemma supIrred_Iic (a : α) : SupIrred (Iic a) := by
+@[to_dual (attr := simp)]
+lemma supIrred_Iic (a : α) : SupIrred (Iic a) := by
   refine ⟨fun h ↦ Iic_ne_bot h.eq_bot, fun s t hst ↦ ?_⟩
   have := mem_Iic_iff.2 (le_refl a)
   rw [← hst] at this
@@ -93,7 +72,8 @@ variable {s : LowerSet α}
 
 variable [Finite α]
 
-@[simp] lemma supIrred_iff_of_finite : SupIrred s ↔ ∃ a, Iic a = s := by
+@[to_dual (attr := simp)]
+lemma supIrred_iff_of_finite : SupIrred s ↔ ∃ a, Iic a = s := by
   refine ⟨fun hs ↦ ?_, ?_⟩
   · obtain ⟨a, ha, has⟩ := (s : Set α).toFinite.exists_maximal (coe_nonempty.2 hs.ne_bot)
     exact ⟨a, (hs.2 <| erase_sup_Iic ha fun b hb ↦
@@ -105,31 +85,23 @@ end LowerSet
 
 namespace OrderEmbedding
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The **Birkhoff Embedding** of a finite partial order as sup-irreducible elements in its
 lattice of lower sets. -/
+@[to_dual
+/-- The **Birkhoff Embedding** of a finite partial order as inf-irreducible elements in its
+lattice of lower sets. -/]
 def supIrredLowerSet : α ↪o {s : LowerSet α // SupIrred s} where
   toFun a := ⟨Iic a, supIrred_Iic _⟩
-  inj' _ := by simp
+  inj' := by simp [Injective]
   map_rel_iff' := by simp
 
-set_option backward.isDefEq.respectTransparency false in
-/-- The **Birkhoff Embedding** of a finite partial order as inf-irreducible elements in its
-lattice of lower sets. -/
-def infIrredUpperSet : α ↪o {s : UpperSet α // InfIrred s} where
-  toFun a := ⟨Ici a, infIrred_Ici _⟩
-  inj' _ := by simp
-  map_rel_iff' := by simp
-
-@[simp] lemma supIrredLowerSet_apply (a : α) : supIrredLowerSet a = ⟨Iic a, supIrred_Iic _⟩ := rfl
-@[simp] lemma infIrredUpperSet_apply (a : α) : infIrredUpperSet a = ⟨Ici a, infIrred_Ici _⟩ := rfl
+@[to_dual (attr := simp)]
+lemma supIrredLowerSet_apply (a : α) : supIrredLowerSet a = ⟨Iic a, supIrred_Iic _⟩ := rfl
 
 variable [Finite α]
 
+@[to_dual]
 lemma supIrredLowerSet_surjective : Surjective (supIrredLowerSet (α := α)) := by
-  aesop (add simp Surjective)
-
-lemma infIrredUpperSet_surjective : Surjective (infIrredUpperSet (α := α)) := by
   aesop (add simp Surjective)
 
 end OrderEmbedding
@@ -139,16 +111,14 @@ variable [Finite α]
 
 /-- **Birkhoff Representation for partial orders.** Any partial order is isomorphic
 to the partial order of sup-irreducible elements in its lattice of lower sets. -/
+@[to_dual
+/-- **Birkhoff Representation for partial orders.** Any partial order is isomorphic
+to the partial order of inf-irreducible elements in its lattice of upper sets. -/]
 noncomputable def supIrredLowerSet : α ≃o {s : LowerSet α // SupIrred s} :=
   RelIso.ofSurjective _ OrderEmbedding.supIrredLowerSet_surjective
 
-/-- **Birkhoff Representation for partial orders.** Any partial order is isomorphic
-to the partial order of inf-irreducible elements in its lattice of upper sets. -/
-noncomputable def infIrredUpperSet : α ≃o {s : UpperSet α // InfIrred s} :=
-  RelIso.ofSurjective _ OrderEmbedding.infIrredUpperSet_surjective
-
-@[simp] lemma supIrredLowerSet_apply (a : α) : supIrredLowerSet a = ⟨Iic a, supIrred_Iic _⟩ := rfl
-@[simp] lemma infIrredUpperSet_apply (a : α) : infIrredUpperSet a = ⟨Ici a, infIrred_Ici _⟩ := rfl
+@[to_dual (attr := simp)]
+lemma supIrredLowerSet_apply (a : α) : supIrredLowerSet a = ⟨Iic a, supIrred_Iic _⟩ := rfl
 
 end OrderIso
 end PartialOrder
@@ -157,8 +127,8 @@ namespace OrderIso
 section SemilatticeSup
 variable [SemilatticeSup α] [OrderBot α] [Finite α]
 
-set_option backward.isDefEq.respectTransparency false in
-@[simp] lemma supIrredLowerSet_symm_apply (s : {s : LowerSet α // SupIrred s}) [Fintype s] :
+@[to_dual (attr := simp)]
+lemma supIrredLowerSet_symm_apply (s : {s : LowerSet α // SupIrred s}) [Fintype s] :
     supIrredLowerSet.symm s = (s.1 : Set α).toFinset.sup id := by
   classical
   obtain ⟨s, hs⟩ := s
@@ -168,21 +138,6 @@ set_option backward.isDefEq.respectTransparency false in
   simp [symm_apply_eq]
 
 end SemilatticeSup
-
-section SemilatticeInf
-variable [SemilatticeInf α] [OrderTop α] [Finite α]
-
-set_option backward.isDefEq.respectTransparency false in
-@[simp] lemma infIrredUpperSet_symm_apply (s : {s : UpperSet α // InfIrred s}) [Fintype s] :
-    infIrredUpperSet.symm s = (s.1 : Set α).toFinset.inf id := by
-  classical
-  obtain ⟨s, hs⟩ := s
-  obtain ⟨a, rfl⟩ := infIrred_iff_of_finite.1 hs
-  cases nonempty_fintype α
-  have : LocallyFiniteOrder α := Fintype.toLocallyFiniteOrder
-  simp [symm_apply_eq]
-
-end SemilatticeInf
 end OrderIso
 
 section DistribLattice

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -790,7 +790,8 @@ variable [SemilatticeSup α] [LocallyFiniteOrderBot α]
 lemma sup'_Iic (a : α) : (Iic a).sup' nonempty_Iic id = a :=
   le_antisymm (sup'_le _ _ fun _ ↦ mem_Iic.1) <| le_sup' (f := id) <| mem_Iic.2 <| le_refl a
 
-@[simp] lemma sup_Iic [OrderBot α] (a : α) : (Iic a).sup id = a :=
+@[to_dual (attr := simp)]
+lemma sup_Iic [OrderBot α] (a : α) : (Iic a).sup id = a :=
   le_antisymm (Finset.sup_le fun _ ↦ mem_Iic.1) <| le_sup (f := id) <| mem_Iic.2 <| le_refl a
 
 lemma image_subset_Iic_sup [OrderBot α] [DecidableEq α] (f : ι → α) (s : Finset ι) :
@@ -809,9 +810,6 @@ variable [SemilatticeInf α] [LocallyFiniteOrderTop α]
 
 lemma inf'_Ici (a : α) : (Ici a).inf' nonempty_Ici id = a :=
   ge_antisymm (le_inf' _ _ fun _ ↦ mem_Ici.1) <| inf'_le (f := id) <| mem_Ici.2 <| le_refl a
-
-@[simp] lemma inf_Ici [OrderTop α] (a : α) : (Ici a).inf id = a :=
-  le_antisymm (inf_le (f := id) <| mem_Ici.2 <| le_refl a) <| Finset.le_inf fun _ ↦ mem_Ici.1
 
 end SemilatticeInf
 

--- a/Mathlib/Order/Irreducible.lean
+++ b/Mathlib/Order/Irreducible.lean
@@ -46,55 +46,68 @@ variable [SemilatticeSup α] {a b c : α}
 
 /-- A sup-irreducible element is a non-bottom element which isn't the supremum of anything smaller.
 -/
+@[to_dual
+/-- An inf-irreducible element is a non-top element which isn't the infimum of anything bigger. -/]
 def SupIrred (a : α) : Prop :=
   ¬IsMin a ∧ ∀ ⦃b c⦄, b ⊔ c = a → b = a ∨ c = a
 
 /-- A sup-prime element is a non-bottom element which isn't less than the supremum of anything
 smaller. -/
+@[to_dual
+/-- An inf-irreducible element is a non-top element which isn't the infimum of anything bigger. -/]
 def SupPrime (a : α) : Prop :=
   ¬IsMin a ∧ ∀ ⦃b c⦄, a ≤ b ⊔ c → a ≤ b ∨ a ≤ c
 
+@[to_dual]
 theorem SupIrred.not_isMin (ha : SupIrred a) : ¬IsMin a :=
   ha.1
 
+@[to_dual]
 theorem SupPrime.not_isMin (ha : SupPrime a) : ¬IsMin a :=
   ha.1
 
+@[to_dual]
 theorem IsMin.not_supIrred (ha : IsMin a) : ¬SupIrred a := fun h => h.1 ha
 
+@[to_dual]
 theorem IsMin.not_supPrime (ha : IsMin a) : ¬SupPrime a := fun h => h.1 ha
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem not_supIrred : ¬SupIrred a ↔ IsMin a ∨ ∃ b c, b ⊔ c = a ∧ b < a ∧ c < a := by
   rw [SupIrred, not_and_or]
   push Not
   rw [exists₂_congr]
   simp +contextual [@eq_comm _ _ a]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem not_supPrime : ¬SupPrime a ↔ IsMin a ∨ ∃ b c, a ≤ b ⊔ c ∧ ¬a ≤ b ∧ ¬a ≤ c := by
   rw [SupPrime, not_and_or]; push Not; rfl
 
+@[to_dual]
 protected theorem SupPrime.supIrred : SupPrime a → SupIrred a :=
   And.imp_right fun h b c ha => by simpa [← ha] using h ha.ge
 
+@[to_dual inf_le]
 theorem SupPrime.le_sup (ha : SupPrime a) : a ≤ b ⊔ c ↔ a ≤ b ∨ a ≤ c :=
   ⟨fun h => ha.2 h, fun h => h.elim le_sup_of_le_left le_sup_of_le_right⟩
 
 variable [OrderBot α] {s : Finset ι} {f : ι → α}
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem not_supIrred_bot : ¬SupIrred (⊥ : α) :=
   isMin_bot.not_supIrred
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem not_supPrime_bot : ¬SupPrime (⊥ : α) :=
   isMin_bot.not_supPrime
 
+@[to_dual]
 theorem SupIrred.ne_bot (ha : SupIrred a) : a ≠ ⊥ := by rintro rfl; exact not_supIrred_bot ha
 
+@[to_dual]
 theorem SupPrime.ne_bot (ha : SupPrime a) : a ≠ ⊥ := by rintro rfl; exact not_supPrime_bot ha
 
+@[to_dual]
 theorem SupIrred.finset_sup_eq (ha : SupIrred a) (h : s.sup f = a) : ∃ i ∈ s, f i = a := by
   classical
   induction s using Finset.induction with
@@ -104,6 +117,7 @@ theorem SupIrred.finset_sup_eq (ha : SupIrred a) (h : s.sup f = a) : ∃ i ∈ s
     rw [sup_insert] at h
     exact (ha.2 h).imp_right ih
 
+@[to_dual finset_inf_le]
 theorem SupPrime.le_finset_sup (ha : SupPrime a) : a ≤ s.sup f ↔ ∃ i ∈ s, a ≤ f i := by
   classical
   induction s using Finset.induction with
@@ -114,6 +128,9 @@ variable [WellFoundedLT α]
 
 /-- In a well-founded lattice, any element is the supremum of finitely many sup-irreducible
 elements. This is the order-theoretic analogue of prime factorisation. -/
+@[to_dual
+/-- In a cowell-founded lattice, any element is the infimum of finitely many inf-irreducible
+elements. This is the order-theoretic analogue of prime factorisation. -/]
 theorem exists_supIrred_decomposition (a : α) :
     ∃ s : Finset α, s.sup id = a ∧ ∀ ⦃b⦄, b ∈ s → SupIrred b := by
   classical
@@ -131,143 +148,46 @@ theorem exists_supIrred_decomposition (a : α) :
 
 end SemilatticeSup
 
-section SemilatticeInf
-
-variable [SemilatticeInf α] {a b c : α}
-
-/-- An inf-irreducible element is a non-top element which isn't the infimum of anything bigger. -/
-def InfIrred (a : α) : Prop :=
-  ¬IsMax a ∧ ∀ ⦃b c⦄, b ⊓ c = a → b = a ∨ c = a
-
-/-- An inf-prime element is a non-top element which isn't bigger than the infimum of anything
-bigger. -/
-def InfPrime (a : α) : Prop :=
-  ¬IsMax a ∧ ∀ ⦃b c⦄, b ⊓ c ≤ a → b ≤ a ∨ c ≤ a
-
-@[simp]
-theorem IsMax.not_infIrred (ha : IsMax a) : ¬InfIrred a := fun h => h.1 ha
-
-@[simp]
-theorem IsMax.not_infPrime (ha : IsMax a) : ¬InfPrime a := fun h => h.1 ha
-
-@[simp]
-theorem not_infIrred : ¬InfIrred a ↔ IsMax a ∨ ∃ b c, b ⊓ c = a ∧ a < b ∧ a < c :=
-  @not_supIrred αᵒᵈ _ _
-
-@[simp]
-theorem not_infPrime : ¬InfPrime a ↔ IsMax a ∨ ∃ b c, b ⊓ c ≤ a ∧ ¬b ≤ a ∧ ¬c ≤ a :=
-  @not_supPrime αᵒᵈ _ _
-
-protected theorem InfPrime.infIrred : InfPrime a → InfIrred a :=
-  And.imp_right fun h b c ha => by simpa [← ha] using h ha.le
-
-theorem InfPrime.inf_le (ha : InfPrime a) : b ⊓ c ≤ a ↔ b ≤ a ∨ c ≤ a :=
-  ⟨fun h => ha.2 h, fun h => h.elim inf_le_of_left_le inf_le_of_right_le⟩
-
-variable [OrderTop α] {s : Finset ι} {f : ι → α}
-
-theorem not_infIrred_top : ¬InfIrred (⊤ : α) :=
-  isMax_top.not_infIrred
-
-theorem not_infPrime_top : ¬InfPrime (⊤ : α) :=
-  isMax_top.not_infPrime
-
-theorem InfIrred.ne_top (ha : InfIrred a) : a ≠ ⊤ := by rintro rfl; exact not_infIrred_top ha
-
-theorem InfPrime.ne_top (ha : InfPrime a) : a ≠ ⊤ := by rintro rfl; exact not_infPrime_top ha
-
-theorem InfIrred.finset_inf_eq : InfIrred a → s.inf f = a → ∃ i ∈ s, f i = a :=
-  @SupIrred.finset_sup_eq _ αᵒᵈ _ _ _ _ _
-
-theorem InfPrime.finset_inf_le (ha : InfPrime a) : s.inf f ≤ a ↔ ∃ i ∈ s, f i ≤ a :=
-  @SupPrime.le_finset_sup _ αᵒᵈ _ _ _ _ _ ha
-
-variable [WellFoundedGT α]
-
-/-- In a cowell-founded lattice, any element is the infimum of finitely many inf-irreducible
-elements. This is the order-theoretic analogue of prime factorisation. -/
-theorem exists_infIrred_decomposition (a : α) :
-    ∃ s : Finset α, s.inf id = a ∧ ∀ ⦃b⦄, b ∈ s → InfIrred b :=
-  exists_supIrred_decomposition (α := αᵒᵈ) _
-
-end SemilatticeInf
-
 section SemilatticeSup
 
 variable [SemilatticeSup α]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem infIrred_toDual {a : α} : InfIrred (toDual a) ↔ SupIrred a :=
   Iff.rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem infPrime_toDual {a : α} : InfPrime (toDual a) ↔ SupPrime a :=
   Iff.rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem supIrred_ofDual {a : αᵒᵈ} : SupIrred (ofDual a) ↔ InfIrred a :=
   Iff.rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem supPrime_ofDual {a : αᵒᵈ} : SupPrime (ofDual a) ↔ InfPrime a :=
   Iff.rfl
 
-alias ⟨_, SupIrred.dual⟩ := infIrred_toDual
+@[to_dual] alias ⟨_, SupIrred.dual⟩ := infIrred_toDual
 
-alias ⟨_, SupPrime.dual⟩ := infPrime_toDual
+@[to_dual] alias ⟨_, SupPrime.dual⟩ := infPrime_toDual
 
-alias ⟨_, InfIrred.ofDual⟩ := supIrred_ofDual
+@[to_dual] alias ⟨_, InfIrred.ofDual⟩ := supIrred_ofDual
 
-alias ⟨_, InfPrime.ofDual⟩ := supPrime_ofDual
+@[to_dual] alias ⟨_, InfPrime.ofDual⟩ := supPrime_ofDual
 
 end SemilatticeSup
-
-section SemilatticeInf
-
-variable [SemilatticeInf α]
-
-@[simp]
-theorem supIrred_toDual {a : α} : SupIrred (toDual a) ↔ InfIrred a :=
-  Iff.rfl
-
-@[simp]
-theorem supPrime_toDual {a : α} : SupPrime (toDual a) ↔ InfPrime a :=
-  Iff.rfl
-
-@[simp]
-theorem infIrred_ofDual {a : αᵒᵈ} : InfIrred (ofDual a) ↔ SupIrred a :=
-  Iff.rfl
-
-@[simp]
-theorem infPrime_ofDual {a : αᵒᵈ} : InfPrime (ofDual a) ↔ SupPrime a :=
-  Iff.rfl
-
-alias ⟨_, InfIrred.dual⟩ := supIrred_toDual
-
-alias ⟨_, InfPrime.dual⟩ := supPrime_toDual
-
-alias ⟨_, SupIrred.ofDual⟩ := infIrred_ofDual
-
-alias ⟨_, SupPrime.ofDual⟩ := infPrime_ofDual
-
-end SemilatticeInf
 
 section DistribLattice
 
 variable [DistribLattice α] {a : α}
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem supPrime_iff_supIrred : SupPrime a ↔ SupIrred a :=
   ⟨SupPrime.supIrred,
     And.imp_right fun h b c => by simp_rw [← inf_eq_left, inf_sup_left]; exact @h _ _⟩
 
-@[simp]
-theorem infPrime_iff_infIrred : InfPrime a ↔ InfIrred a :=
-  ⟨InfPrime.infIrred,
-    And.imp_right fun h b c => by simp_rw [← sup_eq_left, sup_inf_left]; exact @h _ _⟩
-
-protected alias ⟨_, SupIrred.supPrime⟩ := supPrime_iff_supIrred
-protected alias ⟨_, InfIrred.infPrime⟩ := infPrime_iff_infIrred
+@[to_dual] protected alias ⟨_, SupIrred.supPrime⟩ := supPrime_iff_supIrred
 
 end DistribLattice
 
@@ -275,18 +195,12 @@ section LinearOrder
 
 variable [LinearOrder α] {a : α}
 
+@[to_dual]
 theorem supPrime_iff_not_isMin : SupPrime a ↔ ¬IsMin a :=
   and_iff_left <| by simp
 
-theorem infPrime_iff_not_isMax : InfPrime a ↔ ¬IsMax a :=
-  and_iff_left <| by simp
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem supIrred_iff_not_isMin : SupIrred a ↔ ¬IsMin a :=
   and_iff_left fun _ _ => by simpa only [max_eq_iff] using Or.imp And.left And.left
-
-@[simp]
-theorem infIrred_iff_not_isMax : InfIrred a ↔ ¬IsMax a :=
-  and_iff_left fun _ _ => by simpa only [min_eq_iff] using Or.imp And.left And.left
 
 end LinearOrder

--- a/Mathlib/Order/UpperLower/Principal.lean
+++ b/Mathlib/Order/UpperLower/Principal.lean
@@ -35,14 +35,14 @@ variable [Preorder α] [Preorder β] {s : UpperSet α} {a b : α}
 
 /-- Principal upper set. `Set.Ici` as an upper set. The smallest upper set containing a given
 element. -/
-@[to_dual
+@[to_dual (attr := implicit_reducible)
 /-- Principal lower set. `Set.Iic` as a lower set. The smallest lower set containing a given
 element. -/]
 def Ici (a : α) : UpperSet α :=
   ⟨Set.Ici a, isUpperSet_Ici a⟩
 
 /-- Strict principal upper set. `Set.Ioi` as an upper set. -/
-@[to_dual
+@[to_dual (attr := implicit_reducible)
 /-- Strict principal lower set. `Set.Iio` as a lower set. -/]
 def Ioi (a : α) : UpperSet α :=
   ⟨Set.Ioi a, isUpperSet_Ioi a⟩


### PR DESCRIPTION
This PR uses `to_dual` on `SupIrred`/`InfIrred` and `SupPrime`/`InfPrime`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
