### PR TITLE
[Merged by Bors] - chore(Basic): fix typos

### DIFF
--- a/Mathlib/Basic/ExistsUnique.lean
+++ b/Mathlib/Basic/ExistsUnique.lean
@@ -58,7 +58,7 @@ However, it does *not* merge binders.
 @[app_unexpander ExistsUnique] meta def unexpandExistsUnique : Lean.PrettyPrinter.Unexpander
   | `($(_) fun $x:ident ↦ $b)                      => `(∃! $x:ident, $b)
   | `($(_) fun ($x:ident : $t) ↦ $b)               => `(∃! $x:ident : $t, $b)
-  | _                                               => throw ()
+  | _                                              => throw ()
 
 /--
 `∃! x ∈ s, p x` means `∃! x, x ∈ s ∧ p x`, which is to say that there exists a unique `x ∈ s`

--- a/Mathlib/Basic/IsEmpty/Defs.lean
+++ b/Mathlib/Basic/IsEmpty/Defs.lean
@@ -76,15 +76,15 @@ instance [IsEmpty α] [IsEmpty β] : IsEmpty (α ⊕' β) :=
 instance instIsEmptySum {α β} [IsEmpty α] [IsEmpty β] : IsEmpty (α ⊕ β) :=
   ⟨fun x ↦ Sum.rec IsEmpty.false IsEmpty.false x⟩
 
-/-- subtypes of an empty type are empty -/
+/-- Subtypes of an empty type are empty. -/
 instance [IsEmpty α] (p : α → Prop) : IsEmpty (Subtype p) :=
   ⟨fun x ↦ IsEmpty.false x.1⟩
 
-/-- subtypes by an all-false predicate are false. -/
+/-- Subtypes by an all-false predicate are empty. -/
 theorem Subtype.isEmpty_of_false {p : α → Prop} (hp : ∀ a, ¬p a) : IsEmpty (Subtype p) :=
   ⟨fun x ↦ hp _ x.2⟩
 
-/-- subtypes by false are false. -/
+/-- Subtypes by `False` are empty. -/
 instance Subtype.isEmpty_false : IsEmpty { _a : α // False } :=
   Subtype.isEmpty_of_false fun _ ↦ id
 

--- a/Mathlib/Basic/Logic/Basic.lean
+++ b/Mathlib/Basic/Logic/Basic.lean
@@ -80,7 +80,7 @@ simproc_decl iffComm (_ ↔ _) := fun e => do
       ``Iff.comm,
       -- These theorems aren't commute-resistant (they turn an iff into a non-iff in a
       -- non-commutative way).
-      ``and_congr_left_iff, ``and_congr_right_iff,  ``iff_def, ``iff_def',
+      ``and_congr_left_iff, ``and_congr_right_iff, ``iff_def, ``iff_def',
       ``iff_iff_implies_and_implies, ``Bool.coe_iff_coe] do
     withTraceNode `Meta.Tactic.simp (fun _ => return m!"commuting iff: {e}") <| simp symmExpr
   -- If no actual progress happened (modulo commutativity), return early.
@@ -432,7 +432,7 @@ end Propositional
 
 section Equality
 
--- todo: change name
+-- TODO: change name
 theorem forall_cond_comm {α} {s : α → Prop} {p : α → α → Prop} :
     (∀ a, s a → ∀ b, s b → p a b) ↔ ∀ a b, s a → s b → p a b :=
   ⟨fun h a b ha hb ↦ h a ha b hb, fun h a ha b hb ↦ h a b ha hb⟩
@@ -440,7 +440,6 @@ theorem forall_cond_comm {α} {s : α → Prop} {p : α → α → Prop} :
 theorem forall_mem_comm {α β} [Membership α β] {s : β} {p : α → α → Prop} :
     (∀ a (_ : a ∈ s) b (_ : b ∈ s), p a b) ↔ ∀ a b, a ∈ s → b ∈ s → p a b :=
   forall_cond_comm
-
 
 lemma ne_of_eq_of_ne {α : Sort*} {a b c : α} (h₁ : a = b) (h₂ : b ≠ c) : a ≠ c := h₁.symm ▸ h₂
 lemma ne_of_ne_of_eq {α : Sort*} {a b c : α} (h₁ : a ≠ b) (h₂ : b = c) : a ≠ c := h₂ ▸ h₁
@@ -536,7 +535,7 @@ theorem forall₂_comm
 
 @[deprecated (since := "2026-03-25")] alias forall₂_swap := forall₂_comm
 
-/-- We intentionally restrict the type of `α` in this lemma so that this is a safer to use in simp
+/-- We intentionally restrict the type of `α` in this lemma so that this is safer to use in simp
 than `forall_comm`. -/
 theorem imp_forall_iff {α : Type*} {p : Prop} {q : α → Prop} : (p → ∀ x, q x) ↔ ∀ x, p → q x :=
   forall_comm
@@ -835,7 +834,6 @@ theorem exists_mem_of_exists (H : ∀ x, p x) : (∃ x, q x) → ∃ (x : _) (_ 
 theorem exists_of_exists_mem : (∃ (x : _) (_ : p x), q x) → ∃ x, q x
   | ⟨x, _, hq⟩ => ⟨x, hq⟩
 
-
 theorem not_exists_mem : (¬∃ x h, P x h) ↔ ∀ x h, ¬P x h := exists₂_imp
 
 theorem not_forall₂_of_exists₂_not : (∃ x h, ¬P x h) → ¬∀ x h, P x h
@@ -944,18 +942,18 @@ theorem apply_dite₂ {α β γ : Sort*} (f : α → β → γ) (P : Prop) [Deci
     f (dite P a b) (dite P c d) = dite P (fun h ↦ f (a h) (c h)) fun h ↦ f (b h) (d h) := by
   by_cases h : P <;> simp [h]
 
-/-- A two-argument function applied to two `ite`s is a `ite` of that two-argument function
+/-- A two-argument function applied to two `ite`s is an `ite` of that two-argument function
 applied to each of the branches. -/
 theorem apply_ite₂ {α β γ : Sort*} (f : α → β → γ) (P : Prop) [Decidable P] (a b : α) (c d : β) :
     f (ite P a b) (ite P c d) = ite P (f a c) (f b d) :=
   apply_dite₂ f P (fun _ ↦ a) (fun _ ↦ b) (fun _ ↦ c) fun _ ↦ d
 
-/-- A 'dite' producing a `Pi` type `Π a, σ a`, applied to a value `a : α` is a `dite` that applies
+/-- A `dite` producing a `Pi` type `Π a, σ a`, applied to a value `a : α` is a `dite` that applies
 either branch to `a`. -/
 theorem dite_apply (f : P → ∀ a, σ a) (g : ¬P → ∀ a, σ a) (a : α) :
     (dite P f g) a = dite P (fun h ↦ f h a) fun h ↦ g h a := by by_cases h : P <;> simp [h]
 
-/-- A 'ite' producing a `Pi` type `Π a, σ a`, applied to a value `a : α` is a `ite` that applies
+/-- An `ite` producing a `Pi` type `Π a, σ a`, applied to a value `a : α` is an `ite` that applies
 either branch to `a`. -/
 theorem ite_apply (f g : ∀ a, σ a) (a : α) : (ite P f g) a = ite P (f a) (g a) :=
   dite_apply P (fun _ ↦ f) (fun _ ↦ g) a

--- a/Mathlib/Basic/Nonempty.lean
+++ b/Mathlib/Basic/Nonempty.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl
 module
 
 public import Mathlib.Init
+
 /-!
 # Nonempty types
 
@@ -90,7 +91,7 @@ protected noncomputable abbrev Classical.arbitrary (α) [h : Nonempty α] : α :
   Classical.choice h
 
 /-- Given `f : α → β`, if `α` is nonempty then `β` is also nonempty.
-`Nonempty` cannot be a `functor`, because `Functor` is restricted to `Type`. -/
+`Nonempty` cannot be a `Functor`, because `Functor` is restricted to `Type`. -/
 theorem Nonempty.map {α β} (f : α → β) : Nonempty α → Nonempty β
   | ⟨h⟩ => ⟨f h⟩
 

--- a/Mathlib/Basic/Nontrivial/Basic.lean
+++ b/Mathlib/Basic/Nontrivial/Basic.lean
@@ -11,7 +11,6 @@ public import Mathlib.Data.Prod.Basic
 public import Mathlib.Logic.Function.Basic
 public import Mathlib.Order.Defs.LinearOrder
 
-
 /-!
 # Nontrivial types
 

--- a/Mathlib/Basic/Unique.lean
+++ b/Mathlib/Basic/Unique.lean
@@ -39,7 +39,6 @@ In other words, a type that is `Inhabited` and a `Subsingleton`.
 The typeclass `Unique α` is implemented as a type,
 rather than a `Prop`-valued predicate,
 for good definitional properties of the default term.
-
 -/
 
 @[expose] public section

--- a/Mathlib/Basic/UnivLE.lean
+++ b/Mathlib/Basic/UnivLE.lean
@@ -36,7 +36,7 @@ its simplicity and transitivity.
 
 The strong definition easily implies the weaker definition (see below),
 but we cannot prove the reverse implication.
-This is because in Lean's type theory, while `max u v` is at least at big as `u` and `v`,
+This is because in Lean's type theory, while `max u v` is at least as big as `u` and `v`,
 it could be bigger than both!
 See also `Mathlib/CategoryTheory/UnivLE.lean` for the statement that the stronger definition is
 equivalent to `EssSurj (uliftFunctor : Type v ⥤ Type max u v)`.
@@ -82,7 +82,7 @@ example : UnivLE.{u, max u v} := inferInstance
 example : UnivLE.{u, u + 1} := inferInstance
 example : UnivLE.{2, 5} := inferInstance
 
-/- When `small_Pi` from `Mathlib/Logic/Small/Basic.lean` is imported, we have : -/
+/- When `small_Pi` from `Mathlib/Logic/Small/Basic.lean` is imported, we have: -/
 -- example (α : Type u) (β : Type v) [UnivLE.{u, v}] : Small.{v} (α → β) := inferInstance
 
 example : ¬UnivLE.{u + 1, u} := by


### PR DESCRIPTION
Fix some typos and tidy white space.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
