### PR TITLE
feat(Combinatorics/SimpleGraph/Connectivity): change IsEdgeReachable and IsEdgeConnected to accept ENat instead of Nat

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -653,7 +653,7 @@ lemma IsTree.chromaticNumber_le_two (hG : G.IsTree) : G.chromaticNumber ≤ 2 :=
 lemma exists_isCycle_of_two_le_isEdgeReachable {u v : V} (huv : u ≠ v) {n : ℕ} (hn : 2 ≤ n)
     (h : G.IsEdgeReachable n u v) : ∃ w : G.Walk u u, w.IsCycle := by
   classical
-  obtain ⟨w, hw, h⟩ := exists_adj_isEdgeReachable_two huv (h.anti hn)
+  obtain ⟨w, hw, h⟩ := exists_adj_isEdgeReachable_two huv (h.anti (Nat.ofNat_le_cast.mpr hn))
   have := @h {s(u, w)} (by simp)
   obtain ⟨w, p, hp₁, hp₂⟩ := adj_and_reachable_delete_edges_iff_exists_cycle.mp ⟨hw, this⟩
   exact ⟨p.rotate _ (p.fst_mem_support_of_mem_edges hp₂), hp₁.rotate _⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -650,10 +650,10 @@ lemma IsAcyclic.chromaticNumber_le_two (hG : G.IsAcyclic) : G.chromaticNumber �
 lemma IsTree.chromaticNumber_le_two (hG : G.IsTree) : G.chromaticNumber ≤ 2 :=
   hG.colorable_two.chromaticNumber_le
 
-lemma exists_isCycle_of_two_le_isEdgeReachable {u v : V} (huv : u ≠ v) {n : ℕ} (hn : 2 ≤ n)
+lemma exists_isCycle_of_two_le_isEdgeReachable {u v : V} (huv : u ≠ v) {n : ℕ∞} (hn : 2 ≤ n)
     (h : G.IsEdgeReachable n u v) : ∃ w : G.Walk u u, w.IsCycle := by
   classical
-  obtain ⟨w, hw, h⟩ := exists_adj_isEdgeReachable_two huv (h.anti (Nat.ofNat_le_cast.mpr hn))
+  obtain ⟨w, hw, h⟩ := exists_adj_isEdgeReachable_two huv (h.anti hn)
   have := @h {s(u, w)} (by simp)
   obtain ⟨w, p, hp₁, hp₂⟩ := adj_and_reachable_delete_edges_iff_exists_cycle.mp ⟨hw, this⟩
   exact ⟨p.rotate _ (p.fst_mem_support_of_mem_edges hp₂), hp₁.rotate _⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -150,7 +150,7 @@ lemma isEdgeReachable_two : G.IsEdgeReachable 2 u v ↔ ∀ e, (G.deleteEdges {e
 -- TODO: This should be `G.IsEdgeConnected 2 ↔ ∀ e, ¬G.IsBridge e` after
 -- https://github.com/leanprover-community/mathlib4/pull/32583
 lemma isEdgeConnected_two : G.IsEdgeConnected 2 ↔ ∀ e, (G.deleteEdges {e}).Preconnected := by
-  simp [isEdgeConnected_add_one, ←one_add_one_eq_two]
+  simp [isEdgeConnected_add_one, ← one_add_one_eq_two]
 
 lemma exists_adj_isEdgeReachable_two (hne : u ≠ v) (h : G.IsEdgeReachable 2 u v) :
     ∃ w : V, G.Adj u w ∧ G.IsEdgeReachable 2 u w := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -25,7 +25,7 @@ This file defines k-edge-connectivity for simple graphs.
 
 namespace SimpleGraph
 
-variable {V : Type*} {G H : SimpleGraph V} {k l : ℕ} {u v w x y : V}
+variable {V : Type*} {G H : SimpleGraph V} {k l : ℕ∞} {u v w x y : V}
 
 variable (G k u v) in
 /-- Two vertices are `k`-edge-reachable if they remain reachable after removing strictly fewer than
@@ -75,7 +75,7 @@ lemma isEdgeConnected_one : G.IsEdgeConnected 1 ↔ G.Preconnected := by
   simp [IsEdgeConnected, Preconnected]
 
 lemma IsEdgeReachable.reachable (hk : k ≠ 0) (huv : G.IsEdgeReachable k u v) : G.Reachable u v :=
-  isEdgeReachable_one.mp (huv.anti (Nat.one_le_iff_ne_zero.mpr hk))
+  isEdgeReachable_one.mp (huv.anti (Order.one_le_iff_ne_zero.mpr hk))
 
 @[nontriviality]
 lemma IsEdgeReachable.of_subsingleton [Subsingleton V] : G.IsEdgeReachable k u v :=
@@ -96,7 +96,7 @@ lemma IsEdgeReachable.le_degree [Fintype (G.neighborSet u)] (h : G.IsEdgeReachab
     (huv : u ≠ v) : k ≤ G.degree u := by
   classical
   by_contra! hh
-  rw [← card_incidenceSet_eq_degree, ← ENat.natCast_lt_natCast, Set.coe_fintypeCard] at hh
+  rw [← card_incidenceSet_eq_degree, Set.coe_fintypeCard] at hh
   obtain ⟨w, _⟩ := h hh |>.exists_isPath
   simpa using w.adj_snd <| mt Walk.Nil.eq huv
 
@@ -144,13 +144,13 @@ lemma isBridge_iff_not_isEdgeReachable_two (huv : G.Adj u v) :
 alias isBridge_iff_adj_and_not_isEdgeConnected_two := isBridge_iff_not_isEdgeReachable_two
 
 lemma isEdgeReachable_two : G.IsEdgeReachable 2 u v ↔ ∀ e, (G.deleteEdges {e}).Reachable u v := by
-  simp [isEdgeReachable_add_one]
+  simp [isEdgeReachable_add_one, ←one_add_one_eq_two]
 
 /-- A graph is 2-edge-connected iff it has no bridge. -/
 -- TODO: This should be `G.IsEdgeConnected 2 ↔ ∀ e, ¬G.IsBridge e` after
 -- https://github.com/leanprover-community/mathlib4/pull/32583
 lemma isEdgeConnected_two : G.IsEdgeConnected 2 ↔ ∀ e, (G.deleteEdges {e}).Preconnected := by
-  simp [isEdgeConnected_add_one]
+  simp [isEdgeConnected_add_one, ←one_add_one_eq_two]
 
 lemma exists_adj_isEdgeReachable_two (hne : u ≠ v) (h : G.IsEdgeReachable 2 u v) :
     ∃ w : V, G.Adj u w ∧ G.IsEdgeReachable 2 u w := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -144,7 +144,7 @@ lemma isBridge_iff_not_isEdgeReachable_two (huv : G.Adj u v) :
 alias isBridge_iff_adj_and_not_isEdgeConnected_two := isBridge_iff_not_isEdgeReachable_two
 
 lemma isEdgeReachable_two : G.IsEdgeReachable 2 u v ↔ ∀ e, (G.deleteEdges {e}).Reachable u v := by
-  simp [isEdgeReachable_add_one, ←one_add_one_eq_two]
+  simp [isEdgeReachable_add_one, ← one_add_one_eq_two]
 
 /-- A graph is 2-edge-connected iff it has no bridge. -/
 -- TODO: This should be `G.IsEdgeConnected 2 ↔ ∀ e, ¬G.IsBridge e` after

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -201,9 +201,7 @@ theorem isEdgeReachable_top_iff_forall_nat :
       s.ncard = Fintype.card ↑s := this.symm
       _ = Fintype.card (Fin n) := Fintype.card_congr a
       _ = n := Fintype.card_fin n
-  have : s.encard = n := by
-    rw [←this]
-    simp only [Set.coe_ncard_eq_encard]
+  have : s.encard = n := by simp [← this, s.coe_ncard_eq_encard]
   simp [this, ENat.natCast_lt_succ]
 
 theorem isEdgeConnected_top_iff_forall_nat :

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -190,45 +190,32 @@ theorem isEdgeReachable_top_iff_forall_nat :
     G.IsEdgeReachable ⊤ u v ↔ ∀ n : ℕ, G.IsEdgeReachable n u v := by
   constructor
   · intro h n s h'
-    have : s.Finite := Set.finite_of_encard_lt_coe h'
     rw [isEdgeReachable_top_iff_forall_finite] at h
-    exact @h s this
-
+    exact @h s (Set.finite_of_encard_lt_coe h')
   intro h s h'
-  have : s.Finite := by
-    exact Set.encard_lt_top_iff.mp h'
+  have : s.Finite := Set.encard_lt_top_iff.mp h'
   have this2 := this
   cases this
   expose_names
-  have := @h (n + 1) s 
-  simp only [Nat.cast_add, Nat.cast_one] at this
-  apply this
-  have : Finite s := by
-    exact Set.Finite.to_subtype this2
+  -- necessary else Fintype.card doesn't synthesize
   have : Fintype s := by
     exact this2.fintype
+  have := @h (n + 1) s 
+  apply this
   have : Fintype.card ↑s = s.ncard := by
     exact Set.fintypeCard_eq_ncard s
+  -- possibly extracted into a lemma
+  -- ↑s ≃ Fin n → s.ncard = n
   have : s.ncard = n := by
     calc
       s.ncard = Fintype.card ↑s := this.symm
       _ = Fintype.card (Fin n) := Fintype.card_congr a
       _ = n := Fintype.card_fin n
-
   have : s.encard = n := by
     rw [←this]
     simp only [Set.coe_ncard_eq_encard]
   rw [this]
   exact ENat.natCast_lt_succ
-
-#check Set.Finite.cast_ncard_eq
-#check Set.encard_coe_eq_coe_finsetCard
-#check Set.ncard
-#check Set.encard_coe_eq_coe_finsetCard
-#check Fintype.card_congr
-#check Set.ncard_eq_toFinset_card
-#check Set.ncard_eq_toFinset_card
-#check Set.finite_of_encard_lt_coe
 
 theorem isEdgeConnected_top_iff_forall_nat :
     G.IsEdgeConnected ⊤ ↔ ∀ n : ℕ, G.IsEdgeConnected n := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -183,8 +183,7 @@ theorem isEdgeReachable_top_iff_forall_finite :
 
 theorem isEdgeConnected_top_iff_forall_finite :
     G.IsEdgeConnected ⊤ ↔ ∀ ⦃s⦄, s.Finite → (G.deleteEdges s).Preconnected := by
-  simp only [Preconnected, IsEdgeConnected, isEdgeReachable_top_iff_forall_finite]
-  grind
+  simp_rw [isEdgeConnected_iff, Set.encard_lt_top_iff]
 
 theorem isEdgeReachable_top_iff_forall_nat :
     G.IsEdgeReachable ⊤ u v ↔ ∀ n : ℕ, G.IsEdgeReachable n u v := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -201,8 +201,7 @@ theorem isEdgeReachable_top_iff_forall_nat :
       s.ncard = Fintype.card ↑s := this.symm
       _ = Fintype.card (Fin n) := Fintype.card_congr a
       _ = n := Fintype.card_fin n
-  have : s.encard = n := by simp [← this, s.coe_ncard_eq_encard]
-  simp [this, ENat.natCast_lt_succ]
+  simp [this, ← s.coe_ncard_eq_encard, ENat.natCast_lt_succ]
 
 theorem isEdgeConnected_top_iff_forall_nat :
     G.IsEdgeConnected ⊤ ↔ ∀ n : ℕ, G.IsEdgeConnected n := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -207,7 +207,7 @@ theorem isEdgeReachable_top_iff_forall_nat :
 theorem isEdgeConnected_top_iff_forall_nat :
     G.IsEdgeConnected ⊤ ↔ ∀ n : ℕ, G.IsEdgeConnected n := by
   simp [IsEdgeConnected, isEdgeReachable_top_iff_forall_nat]
-  grind
+  exact ⟨fun h n u v ↦ h u v n, fun h u v n ↦ h n u v⟩
 
 /-!
 ### 2-reachability

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -204,8 +204,7 @@ theorem isEdgeReachable_top_iff_forall_nat :
   have : s.encard = n := by
     rw [←this]
     simp only [Set.coe_ncard_eq_encard]
-  rw [this]
-  exact ENat.natCast_lt_succ
+  simp [this, ENat.natCast_lt_succ]
 
 theorem isEdgeConnected_top_iff_forall_nat :
     G.IsEdgeConnected ⊤ ↔ ∀ n : ℕ, G.IsEdgeConnected n := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -172,10 +172,6 @@ lemma exists_adj_isEdgeReachable_two (hne : u ≠ v) (h : G.IsEdgeReachable 2 u 
     refine (Set.subsingleton_iff_singleton h').mp ?_
     exact Set.encard_le_one_iff_subsingleton.mp (Order.le_of_lt_succ hs)
 
-/-!
-### `⊤` and `⊥` theorems
--/
-
 theorem isEdgeReachable_top_iff_forall_finite :
     G.IsEdgeReachable ⊤ u v ↔ ∀ ⦃s⦄, s.Finite → (G.deleteEdges s).Reachable u v :=
   ⟨fun h s h' ↦ @h s (Set.Finite.encard_lt_top h'),

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -183,11 +183,7 @@ theorem isEdgeConnected_top_iff_forall_finite :
 
 theorem isEdgeReachable_top_iff_forall_nat :
     G.IsEdgeReachable ⊤ u v ↔ ∀ n : ℕ, G.IsEdgeReachable n u v := by
-  constructor
-  · intro h n s h'
-    rw [isEdgeReachable_top_iff_forall_finite] at h
-    exact @h s (Set.finite_of_encard_lt_coe h')
-  intro h s h'
+  refine ⟨fun h _ ↦ h.anti le_top, fun h s h' ↦ ?_⟩
   have : s.Finite := Set.encard_lt_top_iff.mp h'
   have this2 := this
   cases this

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -200,7 +200,7 @@ theorem isEdgeReachable_top_iff_forall_nat :
   -- necessary else Fintype.card doesn't synthesize
   have : Fintype s := by
     exact this2.fintype
-  have := @h (n + 1) s 
+  have := @h (n + 1) s
   apply this
   have : Fintype.card ↑s = s.ncard := by
     exact Set.fintypeCard_eq_ncard s

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -173,9 +173,8 @@ lemma exists_adj_isEdgeReachable_two (hne : u ≠ v) (h : G.IsEdgeReachable 2 u 
     exact Set.encard_le_one_iff_subsingleton.mp (Order.le_of_lt_succ hs)
 
 theorem isEdgeReachable_top_iff_forall_finite :
-    G.IsEdgeReachable ⊤ u v ↔ ∀ ⦃s⦄, s.Finite → (G.deleteEdges s).Reachable u v :=
-  ⟨fun h s h' ↦ @h s (Set.Finite.encard_lt_top h'),
-    fun h s lt_top ↦ @h s (Set.encard_lt_top_iff.mp lt_top)⟩
+    G.IsEdgeReachable ⊤ u v ↔ ∀ ⦃s⦄, s.Finite → (G.deleteEdges s).Reachable u v := by
+  simp_rw [IsEdgeReachable, Set.encard_lt_top_iff]
 
 theorem isEdgeConnected_top_iff_forall_finite :
     G.IsEdgeConnected ⊤ ↔ ∀ ⦃s⦄, s.Finite → (G.deleteEdges s).Preconnected := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -188,36 +188,25 @@ theorem isEdgeConnected_top_iff_forall_finite :
 
 theorem isEdgeReachable_top_iff_forall_nat :
     G.IsEdgeReachable ⊤ u v ↔ ∀ n : ℕ, G.IsEdgeReachable n u v := by
-  --rw [isEdgeReachable_top_iff_forall_finite]
-  --unfold IsEdgeReachable
   constructor
-  intro h
-  intro n
-  intro s h'
-  have : s.encard < ⊤ := by
-    exact lt_top_of_lt h'
-  have : s.Finite := by
-    #check Set.encard_lt_top_iff 
-    exact Set.encard_lt_top_iff.mp this 
-  (expose_names; exact Reachable.symm (id (IsEdgeReachable.symm h) this_1)) 
+  · intro h n s h'
+    have : s.Finite := Set.finite_of_encard_lt_coe h'
+    rw [isEdgeReachable_top_iff_forall_finite] at h
+    exact @h s this
 
-  intro h
-  intro s h'
+  intro h s h'
   have : s.Finite := by
-    #check Set.encard_lt_top_iff
     exact Set.encard_lt_top_iff.mp h'
   have this2 := this
   cases this
   expose_names
-  #check IsEdgeReachable
   have := @h (n + 1) s 
-  simp at this
+  simp only [Nat.cast_add, Nat.cast_one] at this
   apply this
   have : Finite s := by
     exact Set.Finite.to_subtype this2
   have : Fintype s := by
     exact this2.fintype
-  #check Set.Finite.cast_ncard_eq
   have : Fintype.card ↑s = s.ncard := by
     exact Set.fintypeCard_eq_ncard s
   have : s.ncard = n := by
@@ -225,29 +214,21 @@ theorem isEdgeReachable_top_iff_forall_nat :
       s.ncard = Fintype.card ↑s := this.symm
       _ = Fintype.card (Fin n) := Fintype.card_congr a
       _ = n := Fintype.card_fin n
-  
+
   have : s.encard = n := by
-    rw [←this] 
-    #check Set.Finite.cast_ncard_eq
-    simp?
-   -- #check Set.encard_coe_eq_coe_finsetCard
-   -- #check Set.ncard
-   -- simp
-   -- rw [Set.encard_eq_coe_fintype_card]
-   -- rw [Fintype.card_congr a]
-   -- exact_mod_cast Nat.lt_succ_self n
-   -- rw [Set.encard_coe_eq_coe_finsetCard]
-   -- rw [Set.encard_eq_coe_set_ncard]
-   -- rw [Fintype.card_congr a]
-   -- exact_mod_cast Nat.lt_succ_self n
-   -- #check Fintype.card_congr
-   -- simpa using Fintype.card_congr a
-   -- #check Set.ncard_eq_toFinset_card s
-   -- simp [Set.ncard_eq_toFinset_card s]
-   -- simpa [Set.ncard_eq_toFinset_card] using Nat.lt_succ_self n
-   -- sorry
+    rw [←this]
+    simp only [Set.coe_ncard_eq_encard]
   rw [this]
   exact ENat.natCast_lt_succ
+
+#check Set.Finite.cast_ncard_eq
+#check Set.encard_coe_eq_coe_finsetCard
+#check Set.ncard
+#check Set.encard_coe_eq_coe_finsetCard
+#check Fintype.card_congr
+#check Set.ncard_eq_toFinset_card
+#check Set.ncard_eq_toFinset_card
+#check Set.finite_of_encard_lt_coe
 
 theorem isEdgeConnected_top_iff_forall_nat :
     G.IsEdgeConnected ⊤ ↔ ∀ n : ℕ, G.IsEdgeConnected n := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -37,6 +37,10 @@ variable (G k) in
 /-- A graph is `k`-edge-connected if any two vertices are `k`-edge-reachable. -/
 def IsEdgeConnected : Prop := ∀ u v, G.IsEdgeReachable k u v
 
+theorem isEdgeConnected_iff :
+    G.IsEdgeConnected k ↔ ∀ ⦃s⦄, s.encard < k → (G.deleteEdges s).Preconnected :=
+  ⟨fun h _ hs u v ↦ h u v hs, fun h u v _ hs ↦ h hs u v⟩
+
 @[refl, simp]
 protected lemma IsEdgeReachable.rfl {u : V} : G.IsEdgeReachable k u u := fun _ _ ↦ .rfl
 
@@ -167,6 +171,89 @@ lemma exists_adj_isEdgeReachable_two (hne : u ≠ v) (h : G.IsEdgeReachable 2 u 
     contrapose h'
     refine (Set.subsingleton_iff_singleton h').mp ?_
     exact Set.encard_le_one_iff_subsingleton.mp (Order.le_of_lt_succ hs)
+
+/-!
+### `⊤` and `⊥` theorems
+-/
+
+theorem isEdgeReachable_top_iff_forall_finite :
+    G.IsEdgeReachable ⊤ u v ↔ ∀ ⦃s⦄, s.Finite → (G.deleteEdges s).Reachable u v :=
+  ⟨fun h s h' ↦ @h s (Set.Finite.encard_lt_top h'),
+    fun h s lt_top ↦ @h s (Set.encard_lt_top_iff.mp lt_top)⟩
+
+theorem isEdgeConnected_top_iff_forall_finite :
+    G.IsEdgeConnected ⊤ ↔ ∀ ⦃s⦄, s.Finite → (G.deleteEdges s).Preconnected := by
+  simp only [Preconnected, IsEdgeConnected, isEdgeReachable_top_iff_forall_finite]
+  grind
+
+theorem isEdgeReachable_top_iff_forall_nat :
+    G.IsEdgeReachable ⊤ u v ↔ ∀ n : ℕ, G.IsEdgeReachable n u v := by
+  --rw [isEdgeReachable_top_iff_forall_finite]
+  --unfold IsEdgeReachable
+  constructor
+  intro h
+  intro n
+  intro s h'
+  have : s.encard < ⊤ := by
+    exact lt_top_of_lt h'
+  have : s.Finite := by
+    #check Set.encard_lt_top_iff 
+    exact Set.encard_lt_top_iff.mp this 
+  (expose_names; exact Reachable.symm (id (IsEdgeReachable.symm h) this_1)) 
+
+  intro h
+  intro s h'
+  have : s.Finite := by
+    #check Set.encard_lt_top_iff
+    exact Set.encard_lt_top_iff.mp h'
+  have this2 := this
+  cases this
+  expose_names
+  #check IsEdgeReachable
+  have := @h (n + 1) s 
+  simp at this
+  apply this
+  have : Finite s := by
+    exact Set.Finite.to_subtype this2
+  have : Fintype s := by
+    exact this2.fintype
+  #check Set.Finite.cast_ncard_eq
+  have : Fintype.card ↑s = s.ncard := by
+    exact Set.fintypeCard_eq_ncard s
+  have : s.ncard = n := by
+    calc
+      s.ncard = Fintype.card ↑s := this.symm
+      _ = Fintype.card (Fin n) := Fintype.card_congr a
+      _ = n := Fintype.card_fin n
+  
+  have : s.encard = n := by
+    rw [←this] 
+    #check Set.Finite.cast_ncard_eq
+    simp?
+   -- #check Set.encard_coe_eq_coe_finsetCard
+   -- #check Set.ncard
+   -- simp
+   -- rw [Set.encard_eq_coe_fintype_card]
+   -- rw [Fintype.card_congr a]
+   -- exact_mod_cast Nat.lt_succ_self n
+   -- rw [Set.encard_coe_eq_coe_finsetCard]
+   -- rw [Set.encard_eq_coe_set_ncard]
+   -- rw [Fintype.card_congr a]
+   -- exact_mod_cast Nat.lt_succ_self n
+   -- #check Fintype.card_congr
+   -- simpa using Fintype.card_congr a
+   -- #check Set.ncard_eq_toFinset_card s
+   -- simp [Set.ncard_eq_toFinset_card s]
+   -- simpa [Set.ncard_eq_toFinset_card] using Nat.lt_succ_self n
+   -- sorry
+  rw [this]
+  exact ENat.natCast_lt_succ
+
+theorem isEdgeConnected_top_iff_forall_nat :
+    G.IsEdgeConnected ⊤ ↔ ∀ n : ℕ, G.IsEdgeConnected n := by
+  unfold IsEdgeConnected
+  simp only [isEdgeReachable_top_iff_forall_nat]
+  grind
 
 /-!
 ### 2-reachability

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -185,6 +185,7 @@ theorem isEdgeReachable_top_iff_forall_nat :
     G.IsEdgeReachable ⊤ u v ↔ ∀ n : ℕ, G.IsEdgeReachable n u v := by
   constructor
   · intro h n s h'
+    #check h.anti
     rw [isEdgeReachable_top_iff_forall_finite] at h
     exact @h s (Set.finite_of_encard_lt_coe h')
   intro h s h'
@@ -214,8 +215,7 @@ theorem isEdgeReachable_top_iff_forall_nat :
 
 theorem isEdgeConnected_top_iff_forall_nat :
     G.IsEdgeConnected ⊤ ↔ ∀ n : ℕ, G.IsEdgeConnected n := by
-  unfold IsEdgeConnected
-  simp only [isEdgeReachable_top_iff_forall_nat]
+  simp [IsEdgeConnected, isEdgeReachable_top_iff_forall_nat]
   grind
 
 /-!

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -205,7 +205,7 @@ theorem isEdgeReachable_top_iff_forall_nat :
 
 theorem isEdgeConnected_top_iff_forall_nat :
     G.IsEdgeConnected ⊤ ↔ ∀ n : ℕ, G.IsEdgeConnected n := by
-  simp [IsEdgeConnected, isEdgeReachable_top_iff_forall_nat]
+  simp_rw [IsEdgeConnected, isEdgeReachable_top_iff_forall_nat]
   exact ⟨fun h n u v ↦ h u v n, fun h u v n ↦ h n u v⟩
 
 /-!

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -185,12 +185,10 @@ theorem isEdgeReachable_top_iff_forall_nat :
   refine ⟨fun h _ ↦ h.anti le_top, fun h s h' ↦ ?_⟩
   have : s.Finite := Set.encard_lt_top_iff.mp h'
   have this2 := this
-  cases this
-  expose_names
+  have ⟨n, ⟨a⟩⟩ := this.exists_equiv_fin
   -- necessary else Fintype.card doesn't synthesize
   have : Fintype s := this2.fintype
-  have := @h (n + 1) s
-  apply this
+  apply @h (n + 1) s
   -- possibly extracted into a lemma
   -- ↑s ≃ Fin n → s.ncard = n
   simp [← s.coe_ncard_eq_encard, ← s.fintypeCard_eq_ncard, Fintype.card_congr a,

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -188,20 +188,13 @@ theorem isEdgeReachable_top_iff_forall_nat :
   cases this
   expose_names
   -- necessary else Fintype.card doesn't synthesize
-  have : Fintype s := by
-    exact this2.fintype
+  have : Fintype s := this2.fintype
   have := @h (n + 1) s
   apply this
-  have : Fintype.card ↑s = s.ncard := by
-    exact Set.fintypeCard_eq_ncard s
   -- possibly extracted into a lemma
   -- ↑s ≃ Fin n → s.ncard = n
-  have : s.ncard = n := by
-    calc
-      s.ncard = Fintype.card ↑s := this.symm
-      _ = Fintype.card (Fin n) := Fintype.card_congr a
-      _ = n := Fintype.card_fin n
-  simp [this, ← s.coe_ncard_eq_encard, ENat.natCast_lt_succ]
+  simp [← s.coe_ncard_eq_encard, ← s.fintypeCard_eq_ncard, Fintype.card_congr a,
+  ENat.natCast_lt_succ]
 
 theorem isEdgeConnected_top_iff_forall_nat :
     G.IsEdgeConnected ⊤ ↔ ∀ n : ℕ, G.IsEdgeConnected n := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -182,17 +182,8 @@ theorem isEdgeConnected_top_iff_forall_finite :
 
 theorem isEdgeReachable_top_iff_forall_nat :
     G.IsEdgeReachable ⊤ u v ↔ ∀ n : ℕ, G.IsEdgeReachable n u v := by
-  refine ⟨fun h _ ↦ h.anti le_top, fun h s h' ↦ ?_⟩
-  have : s.Finite := Set.encard_lt_top_iff.mp h'
-  have this2 := this
-  have ⟨n, ⟨a⟩⟩ := this.exists_equiv_fin
-  -- necessary else Fintype.card doesn't synthesize
-  have : Fintype s := this2.fintype
-  apply @h (n + 1) s
-  -- possibly extracted into a lemma
-  -- ↑s ≃ Fin n → s.ncard = n
-  simp [← s.coe_ncard_eq_encard, ← s.fintypeCard_eq_ncard, Fintype.card_congr a,
-  ENat.natCast_lt_succ]
+  refine ⟨fun h _ ↦ h.anti le_top, fun h s hlt ↦ h (s.ncard + 1) ?_⟩
+  simp [← Set.encard_lt_top_iff.mp hlt |>.cast_ncard_eq, -Nat.cast_add]
 
 theorem isEdgeConnected_top_iff_forall_nat :
     G.IsEdgeConnected ⊤ ↔ ∀ n : ℕ, G.IsEdgeConnected n := by

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -1430,3 +1430,18 @@ theorem Set.ncard_le_ncard_image_add_one_iff {α β : Type*} (s : Set α) [Finit
   simpa [Subtype.ext_iff, ← (Set.image_injective.mpr Subtype.val_injective).eq_iff,
      Set.image_insert_eq, Set.image_singleton] using
       (Set.surjective_mapsTo_image_restrict f s).card_le_card_add_one_iff
+
+theorem finite_of_encard_lt {α : Type} {s : Set α} {n : ℕ} : s.encard < n → s.Finite := by
+  intro h'
+  /-
+  -- shorter proof
+  have : s.encard ≤ n - 1 := by
+    exact ENat.le_sub_one_of_lt h'
+  exact Set.finite_of_encard_le_coe this 
+  -/
+  have : s.encard < ⊤ := by
+    exact lt_top_of_lt h'
+  have : s.Finite := by
+    #check Set.encard_lt_top_iff 
+    exact Set.encard_lt_top_iff.mp this 
+  exact Set.finite_coe_iff.mp this

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -164,6 +164,9 @@ theorem encard_ne_top_iff : s.encard ≠ ⊤ ↔ s.Finite := by
 theorem finite_of_encard_le_coe {k : ℕ} (h : s.encard ≤ k) : s.Finite := by
   rw [← encard_lt_top_iff]; exact h.trans_lt (WithTop.coe_lt_top _)
 
+theorem finite_of_encard_lt_coe {k : ℕ} (h : s.encard < k) : s.Finite :=
+  finite_of_encard_le_coe h.le
+
 theorem finite_of_encard_eq_coe {k : ℕ} (h : s.encard = k) : s.Finite :=
   finite_of_encard_le_coe h.le
 
@@ -1430,18 +1433,3 @@ theorem Set.ncard_le_ncard_image_add_one_iff {α β : Type*} (s : Set α) [Finit
   simpa [Subtype.ext_iff, ← (Set.image_injective.mpr Subtype.val_injective).eq_iff,
      Set.image_insert_eq, Set.image_singleton] using
       (Set.surjective_mapsTo_image_restrict f s).card_le_card_add_one_iff
-
-theorem finite_of_encard_lt {α : Type} {s : Set α} {n : ℕ} : s.encard < n → s.Finite := by
-  intro h'
-  /-
-  -- shorter proof
-  have : s.encard ≤ n - 1 := by
-    exact ENat.le_sub_one_of_lt h'
-  exact Set.finite_of_encard_le_coe this 
-  -/
-  have : s.encard < ⊤ := by
-    exact lt_top_of_lt h'
-  have : s.Finite := by
-    #check Set.encard_lt_top_iff 
-    exact Set.encard_lt_top_iff.mp this 
-  exact Set.finite_coe_iff.mp this

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -164,9 +164,6 @@ theorem encard_ne_top_iff : s.encard ≠ ⊤ ↔ s.Finite := by
 theorem finite_of_encard_le_coe {k : ℕ} (h : s.encard ≤ k) : s.Finite := by
   rw [← encard_lt_top_iff]; exact h.trans_lt (WithTop.coe_lt_top _)
 
-theorem finite_of_encard_lt_coe {k : ℕ} (h : s.encard < k) : s.Finite :=
-  finite_of_encard_le_coe h.le
-
 theorem finite_of_encard_eq_coe {k : ℕ} (h : s.encard = k) : s.Finite :=
   finite_of_encard_le_coe h.le
 


### PR DESCRIPTION



---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
