### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace/Homogenization): generalize `hom_ext` to `LinearMapClass`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Homogenization.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Homogenization.lean
@@ -162,14 +162,19 @@ theorem span_range_ofPoint : Submodule.span R (Set.range (ofPoint (R := R) (P :=
   refine Submodule.add_mem _ (Submodule.sub_mem _ ?_ ?_) (Submodule.smul_mem _ _ ?_) <;>
     exact Submodule.mem_span_of_mem <| Set.mem_range_self _
 
-theorem hom_ext {f g : Homogenization R P →ₗ[R] W}
-    (h : ∀ x, f (ofPoint x) = g (ofPoint x)) : f = g := by
+section
+
+variable {F : Type*} [FunLike F (Homogenization R P) W] [LinearMapClass F R _ _]
+
+theorem hom_ext {f g : F} (h : ∀ x, f (ofPoint x) = g (ofPoint x)) : f = g := by
+  apply LinearMap.toLinearMap_injective
   rwa [← LinearMap.eqLocus_eq_top, eq_top_iff, ← span_range_ofPoint, Submodule.span_le,
     Set.range_subset_iff]
 
-theorem hom_ext_iff {f g : Homogenization R P →ₗ[R] W} :
-    f = g ↔ ∀ x, f (ofPoint x) = g (ofPoint x) :=
+theorem hom_ext_iff {f g : F} : f = g ↔ ∀ x, f (ofPoint x) = g (ofPoint x) :=
   ⟨by rintro rfl _; rfl, hom_ext⟩
+
+end
 
 /-- Auxiliary definition used for defining `Homogenization.lift`. -/
 private def liftAux (f : P →ᵃ[R] W) : Homogenization R P →ₗ[R] W :=


### PR DESCRIPTION


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
