### PR TITLE
[Merged by Bors] - perf: disable the unreachable tactic linter

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -43,8 +43,8 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
 abbrev mathlibLeanOptions := #[
     ⟨`pp.unicode.fun, true⟩, -- pretty-prints `fun a ↦ b`
     ⟨`autoImplicit, false⟩,
-    ⟨`linter.unreachableTactic, false⟩, -- superseded by the unused tactic linter
     ⟨`maxSynthPendingDepth, .ofNat 3⟩,
+    ⟨`weak.linter.unreachableTactic, false⟩, -- superseded by the unused tactic linter
   ] ++ -- options that are used in `lake build`
     mathlibOnlyLinters.map fun s ↦ { s with name := `weak ++ s.name }
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -43,6 +43,7 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
 abbrev mathlibLeanOptions := #[
     ⟨`pp.unicode.fun, true⟩, -- pretty-prints `fun a ↦ b`
     ⟨`autoImplicit, false⟩,
+    ⟨`linter.unreachableTactic, false⟩, -- superseded by the unused tactic linter
     ⟨`maxSynthPendingDepth, .ofNat 3⟩,
   ] ++ -- options that are used in `lake build`
     mathlibOnlyLinters.map fun s ↦ { s with name := `weak ++ s.name }


### PR DESCRIPTION
This PR disables the unreachable tactic linter (from Batteries), because it is almost entirely superseded by the unused tactic linter (from Mathlib). Maybe it should be upstreamed to Batteries after #42536?, so that the unreachable tactic linter can be deprecated there?

The unusedTactic linter was directly based on the unreachableTactic linter: both search the whole infotree to find all tactic states. UnreachableTactic warns when a tactic has no tactic state at all. UnusedTactic additionally warns when the tactic state is the same before an after the tactic.

With this explanation, the unusedTactic linter in stronger entirely. However, both linters come with some exceptions of which syntax not to look inside of. For example, unusedTactic doesn't look inside Batteries' seq_focus notation, because there is a legitimate use case for an unused tactic here: one might write something like `tac1 <;> [tac2; skip]`. The complete list of syntaxes that the linter doesn't look into is as follows, and I think they are all pretty reasonable:
```
    `Mathlib.Tactic.Says.says,
    ``Parser.Term.binderTactic, -- This is for autoparams, which contain unused tactics
    ``Lean.Parser.Term.dynamicQuot, -- Allow quoted tactics
    ``Lean.Parser.Tactic.quotSeq,
    ``Lean.Parser.Tactic.tacticStop_,
    ``Lean.Parser.Command.notation,
    ``Lean.Parser.Command.mixfix,
    ``Lean.Parser.Tactic.discharger,
    ``Lean.Parser.Command.registerTryTactic,
    `Batteries.Tactic.seq_focus,
    `Mathlib.Tactic.Hint.registerHintStx,
    `Mathlib.Tactic.LinearCombination.linearCombination,
    `Mathlib.Tactic.LinearCombinationPrime.linearCombination',
    `Aesop.Frontend.Parser.addRules,
    `Aesop.Frontend.Parser.aesopTactic,
    `Aesop.Frontend.Parser.aesopTactic?,
    ``Mathlib.Linter.UnusedTactic.«command#show_kind_»,
    -- the following `SyntaxNodeKind`s play a role in silencing `test`s
    ``Lean.Parser.Tactic.failIfSuccess,
    `Mathlib.Tactic.successIfFailWithMsg,
    `Mathlib.Tactic.failIfNoProgress
```

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
