### PR TITLE
[Merged by Bors] - feat(Analysis/Normed/Module/Basic): add enorm_algebraMap', enorm_algebraMap

### DIFF
--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -291,6 +291,9 @@ theorem norm_algebraMap (x : 𝕜) : ‖algebraMap 𝕜 𝕜' x‖ = ‖x‖ * �
 theorem nnnorm_algebraMap (x : 𝕜) : ‖algebraMap 𝕜 𝕜' x‖₊ = ‖x‖₊ * ‖(1 : 𝕜')‖₊ :=
   Subtype.ext <| norm_algebraMap 𝕜' x
 
+theorem enorm_algebraMap (x : 𝕜) : ‖algebraMap 𝕜 𝕜' x‖ₑ = ‖x‖ₑ * ‖(1 : 𝕜')‖ₑ := by
+  simp only [enorm_eq_nnnorm, nnnorm_algebraMap, ENNReal.coe_mul]
+
 theorem dist_algebraMap (x y : 𝕜) :
     (dist (algebraMap 𝕜 𝕜' x) (algebraMap 𝕜 𝕜' y)) = dist x y * ‖(1 : 𝕜')‖ := by
   simp only [dist_eq_norm, ← map_sub, norm_algebraMap]
@@ -309,6 +312,7 @@ theorem Algebra.norm_smul_one_eq_norm [NormOneClass 𝕜'] (x : 𝕜) : ‖x •
 theorem nnnorm_algebraMap' [NormOneClass 𝕜'] (x : 𝕜) : ‖algebraMap 𝕜 𝕜' x‖₊ = ‖x‖₊ :=
   Subtype.ext <| norm_algebraMap' _ _
 
+/-- This is a simpler version of `enorm_algebraMap` when `‖1‖ = 1` in `𝕜'`. -/
 @[simp]
 theorem enorm_algebraMap' [NormOneClass 𝕜'] (x : 𝕜) : ‖(algebraMap 𝕜 𝕜') x‖ₑ = ‖x‖ₑ := by
   rw [enorm_eq_iff_norm_eq, norm_algebraMap']

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -309,6 +309,10 @@ theorem Algebra.norm_smul_one_eq_norm [NormOneClass 𝕜'] (x : 𝕜) : ‖x •
 theorem nnnorm_algebraMap' [NormOneClass 𝕜'] (x : 𝕜) : ‖algebraMap 𝕜 𝕜' x‖₊ = ‖x‖₊ :=
   Subtype.ext <| norm_algebraMap' _ _
 
+@[simp]
+theorem enorm_algebraMap' [NormOneClass 𝕜'] (x : 𝕜) : ‖(algebraMap 𝕜 𝕜') x‖ₑ = ‖x‖ₑ := by
+  rw [enorm_eq_iff_norm_eq, norm_algebraMap']
+
 /-- This is a simpler version of `dist_algebraMap` when `‖1‖ = 1` in `𝕜'`. -/
 @[simp]
 theorem dist_algebraMap' [NormOneClass 𝕜'] (x y : 𝕜) :


### PR DESCRIPTION
From the Carleson project.

-------

**Upstreaming from Carleson: [/Carleson/ToMathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean](https://github.com/fpvandoorn/carleson/blob/0072b6e47ec58ac13be0a9f3b7c17e9f3bb1be2e/Carleson/ToMathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean)**

### In this PR

#### enorm_algebraMap'

Refactored the body, signatures unchanged from Carleson.
Added `@[simp]` like neighbouring lemmas have it.

```lean
-- CARLESON
enorm_algebraMap'.{u_1, u_2} {𝕜 : Type u_1} (𝕜' : Type u_2) [NormedField 𝕜] [SeminormedRing 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormOneClass 𝕜'] (x : 𝕜)
: ‖(algebraMap 𝕜 𝕜') x‖ₑ = ‖x‖ₑ

-- MATHLIB
enorm_algebraMap'.{u_1, u_2} {𝕜 : Type u_1} (𝕜' : Type u_2) [NormedField 𝕜] [SeminormedRing 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormOneClass 𝕜'] (x : 𝕜)
 : ‖(algebraMap 𝕜 𝕜') x‖ₑ = ‖x‖ₑ
```