### PR TITLE
chore: remove `WittVector.mk'`

### DIFF
--- a/Mathlib/RingTheory/WittVector/Defs.lean
+++ b/Mathlib/RingTheory/WittVector/Defs.lean
@@ -58,6 +58,10 @@ structure WittVector (p : ℕ) (R : Type*) where
   -/
   coeff : ℕ → R
 
+/-- Construct a Witt vector `mk' x : 𝕎 R` from a sequence `x` of elements of `R`. -/
+@[deprecated WittVector.mk (since := "2026-09-03")]
+def WittVector.mk' {p : ℕ} {R : Type*} (coeff : ℕ → R) : WittVector p R := WittVector.mk p coeff
+
 section Notation
 
 open Lean.PrettyPrinter.Delaborator

--- a/Mathlib/RingTheory/WittVector/Defs.lean
+++ b/Mathlib/RingTheory/WittVector/Defs.lean
@@ -49,18 +49,14 @@ If `p` is invertible in `R`, this ring is isomorphic to `ℕ → R` (the product
 If `R` is a ring of characteristic `p`, then `WittVector p R` is a ring of characteristic `0`.
 The canonical example is `WittVector p (ZMod p)`,
 which is isomorphic to the `p`-adic integers `ℤ_[p]`. -/
-structure WittVector (p : ℕ) (R : Type*) where mk' ::
+structure WittVector (p : ℕ) (R : Type*) where
+  /-- Construct a Witt vector `mk p x : 𝕎 R` from a sequence `x` of elements of `R`. -/
+  mk (p) ::
   /-- `x.coeff n` is the `n`th coefficient of the Witt vector `x`.
 
   This concept does not have a standard name in the literature.
   -/
   coeff : ℕ → R
-
-/-- Construct a Witt vector `mk p x : 𝕎 R` from a sequence `x` of elements of `R`.
-
-This is preferred over `WittVector.mk'` because it has `p` explicit.
--/
-def WittVector.mk (p : ℕ) {R : Type*} (coeff : ℕ → R) : WittVector p R := mk' coeff
 
 variable {p : ℕ}
 

--- a/Mathlib/RingTheory/WittVector/Defs.lean
+++ b/Mathlib/RingTheory/WittVector/Defs.lean
@@ -58,6 +58,16 @@ structure WittVector (p : ℕ) (R : Type*) where
   -/
   coeff : ℕ → R
 
+section Notation
+
+open Lean.PrettyPrinter.Delaborator
+
+/-- This prevents `mk p x` being printed as `{ coeff := x }` by `delabStructureInstance`. -/
+@[app_delab WittVector.mk]
+meta def WittVector.delabMk : Delab := delabApp
+
+end Notation
+
 variable {p : ℕ}
 
 /- We cannot make this `localized` notation, because the `p` on the RHS doesn't occur on the left

--- a/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
+++ b/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
@@ -59,7 +59,7 @@ noncomputable def inverseCoeff (a : Units k) (A : 𝕎 k) : ℕ → k
 Upgrade a Witt vector `A` whose first entry `A.coeff 0` is a unit to be, itself, a unit in `𝕎 k`.
 -/
 def mkUnit {a : Units k} {A : 𝕎 k} (hA : A.coeff 0 = a) : Units (𝕎 k) :=
-  Units.mkOfMulEqOne A (@WittVector.mk' p _ (inverseCoeff a A)) (by
+  Units.mkOfMulEqOne A (WittVector.mk p (inverseCoeff a A)) (by
     ext n
     induction n with
     | zero => simp [WittVector.mul_coeff_zero, inverseCoeff, hA]

--- a/Mathlib/RingTheory/WittVector/Domain.lean
+++ b/Mathlib/RingTheory/WittVector/Domain.lean
@@ -55,7 +55,7 @@ local notation "𝕎" => WittVector p -- type as `\bbW`
 This is mainly useful as an auxiliary construction for `WittVector.verschiebung_nonzero`.
 -/
 def shift (x : 𝕎 R) (n : ℕ) : 𝕎 R :=
-  @mk' p R fun i => x.coeff (n + i)
+  mk p fun i => x.coeff (n + i)
 
 theorem shift_coeff (x : 𝕎 R) (n k : ℕ) : (x.shift n).coeff k = x.coeff (n + k) :=
   rfl

--- a/Mathlib/RingTheory/WittVector/Frobenius.lean
+++ b/Mathlib/RingTheory/WittVector/Frobenius.lean
@@ -208,8 +208,7 @@ instance frobeniusFun_isPoly : IsPoly p fun R _ Rcr => @frobeniusFun p R _ Rcr :
 @[ghost_simps]
 theorem ghostComponent_frobeniusFun (n : ℕ) (x : 𝕎 R) :
     ghostComponent n (frobeniusFun x) = ghostComponent (n + 1) x := by
-  simp only [ghostComponent_apply, frobeniusFun, coeff_mk, ← bind₁_frobeniusPoly_wittPolynomial,
-    aeval_bind₁]
+  simp only [ghostComponent_apply, frobeniusFun, ← bind₁_frobeniusPoly_wittPolynomial, aeval_bind₁]
 
 /-- If `R` has characteristic `p`, then there is a ring endomorphism
 that raises `r : R` to the power `p`.

--- a/Mathlib/RingTheory/WittVector/FrobeniusFractionField.lean
+++ b/Mathlib/RingTheory/WittVector/FrobeniusFractionField.lean
@@ -200,10 +200,10 @@ theorem frobenius_frobeniusRotation {a₁ a₂ : 𝕎 k} (ha₁ : a₁.coeff 0 �
   ext n
   rcases n with - | n
   · simp only [WittVector.mul_coeff_zero, WittVector.coeff_frobenius_charP, frobeniusRotation,
-      coeff_mk, frobeniusRotationCoeff]
+      frobeniusRotationCoeff]
     exact solution_spec' _ ha₁ _
   · simp only [nthRemainder_spec, WittVector.coeff_frobenius_charP,
-      frobeniusRotation, coeff_mk, frobeniusRotationCoeff]
+      frobeniusRotation, frobeniusRotationCoeff]
     have :=
       succNthVal_spec' p n a₁ a₂ (fun i : Fin (n + 1) => frobeniusRotationCoeff p ha₁ ha₂ i.val)
         ha₁ ha₂

--- a/Mathlib/RingTheory/WittVector/InitTail.lean
+++ b/Mathlib/RingTheory/WittVector/InitTail.lean
@@ -123,7 +123,7 @@ theorem coeff_add_of_disjoint (x y : 𝕎 R) (h : ∀ n, x.coeff n = 0 ∨ y.coe
   calc
     (x + y).coeff n = z.coeff n := by rw [← hx, ← hy, select_add_select_not P z]
     _ = x.coeff n + y.coeff n := by
-      simp only [z, mk.eq_1]
+      simp only [z]
       split_ifs with y0
       · rw [y0, add_zero]
       · rw [h n |>.resolve_right y0, zero_add]

--- a/Mathlib/RingTheory/WittVector/IsPoly.lean
+++ b/Mathlib/RingTheory/WittVector/IsPoly.lean
@@ -190,7 +190,7 @@ theorem ext [Fact p.Prime] {f g} (hf : IsPoly p f) (hg : IsPoly p g)
     apply eval₂Hom_congr (RingHom.ext_int _ _) _ rfl
     ext1
     apply eval₂Hom_congr (RingHom.ext_int _ _) _ rfl
-    simp only [coeff_mk]; rfl
+    rfl
 
 /-- The composition of polynomial functions is polynomial. -/
 instance comp {g f} [hg : IsPoly p g] [hf : IsPoly p f] :
@@ -351,7 +351,7 @@ theorem ext [Fact p.Prime] {f g} (hf : IsPoly₂ p f) (hg : IsPoly₂ p g)
     ext1
     apply eval₂Hom_congr (RingHom.ext_int _ _) _ rfl
     ext ⟨b, _⟩
-    fin_cases b <;> simp only [coeff_mk, uncurry] <;> rfl
+    fin_cases b <;> rfl
 
 -- unfortunately this is not universe polymorphic, merely because `f` isn't
 theorem map [Fact p.Prime] {f} (hf : IsPoly₂ p f) (g : R →+* S) (x y : 𝕎 R) :

--- a/Mathlib/RingTheory/WittVector/Teichmuller.lean
+++ b/Mathlib/RingTheory/WittVector/Teichmuller.lean
@@ -42,7 +42,7 @@ local notation "𝕎" => WittVector p -- type as `\bbW`
 The `0`-th coefficient of `teichmullerFun p r` is `r`, and all others are `0`.
 -/
 def teichmullerFun (r : R) : 𝕎 R :=
-  ⟨fun n => if n = 0 then r else 0⟩
+  mk p fun n => if n = 0 then r else 0
 
 /-!
 ## `teichmuller` is a monoid homomorphism

--- a/Mathlib/RingTheory/WittVector/Truncated.lean
+++ b/Mathlib/RingTheory/WittVector/Truncated.lean
@@ -96,7 +96,7 @@ variable [CommRing R]
 by setting all coefficients after `x` to be 0.
 -/
 def out (x : TruncatedWittVector p n R) : 𝕎 R :=
-  @WittVector.mk' p _ fun i => if h : i < n then x.coeff ⟨i, h⟩ else 0
+  WittVector.mk p fun i => if h : i < n then x.coeff ⟨i, h⟩ else 0
 
 @[simp]
 theorem coeff_out (x : TruncatedWittVector p n R) (i : Fin n) : x.out.coeff i = x.coeff i := by
@@ -315,7 +315,7 @@ variable (p)
 
 @[simp]
 theorem truncate_mk' (f : ℕ → R) :
-    truncate n (@mk' p _ f) = TruncatedWittVector.mk _ fun k => f k := by
+    truncate n (mk p f) = TruncatedWittVector.mk _ fun k => f k := by
   ext i
   simp only [coeff_truncate, TruncatedWittVector.coeff_mk]
 
@@ -417,7 +417,7 @@ variable (n)
 defining the `k`th entry to be the final entry of `fₖ s`.
 -/
 def liftFun (s : S) : 𝕎 R :=
-  @WittVector.mk' p _ fun k => TruncatedWittVector.coeff (Fin.last k) (f (k + 1) s)
+  WittVector.mk p fun k => TruncatedWittVector.coeff (Fin.last k) (f (k + 1) s)
 
 variable {f} in
 include f_compat in

--- a/Mathlib/RingTheory/WittVector/Verschiebung.lean
+++ b/Mathlib/RingTheory/WittVector/Verschiebung.lean
@@ -38,7 +38,7 @@ by inserting 0 as the 0th coefficient.
 `verschiebungFun` is the underlying function of the additive monoid hom `WittVector.verschiebung`.
 -/
 def verschiebungFun (x : 𝕎 R) : 𝕎 R :=
-  @mk' p _ fun n => if n = 0 then 0 else x.coeff (n - 1)
+  mk p fun n => if n = 0 then 0 else x.coeff (n - 1)
 
 theorem verschiebungFun_coeff (x : 𝕎 R) (n : ℕ) :
     (verschiebungFun x).coeff n = if n = 0 then 0 else x.coeff (n - 1) := by


### PR DESCRIPTION
Override the structure constructor transparencies so that duplicating a `WittVector.mk'` is no longer necessary.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
