### PR TITLE
[Merged by Bors] - chore(Basic/Logic): deduplicate `Prop.exists` and `Prop.forall`

### DIFF
--- a/Mathlib/Basic/Logic/Basic.lean
+++ b/Mathlib/Basic/Logic/Basic.lean
@@ -692,12 +692,15 @@ theorem Exists.fst {b : Prop} {p : b → Prop} : Exists p → b
 theorem Exists.snd {b : Prop} {p : b → Prop} : ∀ h : Exists p, p h.fst
   | ⟨_, h⟩ => h
 
-theorem Prop.exists_iff {p : Prop → Prop} : (∃ h, p h) ↔ p False ∨ p True :=
+theorem Prop.exists {p : Prop → Prop} : (∃ h, p h) ↔ p False ∨ p True :=
   ⟨fun ⟨h₁, h₂⟩ ↦ by_cases (fun H : h₁ ↦ .inr <| by simpa only [H] using h₂)
     (fun H ↦ .inl <| by simpa only [H] using h₂), fun h ↦ h.elim (.intro _) (.intro _)⟩
 
-theorem Prop.forall_iff {p : Prop → Prop} : (∀ h, p h) ↔ p False ∧ p True :=
+theorem Prop.forall {p : Prop → Prop} : (∀ h, p h) ↔ p False ∧ p True :=
   ⟨fun H ↦ ⟨H _, H _⟩, fun ⟨h₁, h₂⟩ h ↦ by by_cases H : h <;> simpa only [H]⟩
+
+@[deprecated (since := "2026-09-02")] alias Prop.exists_iff := Prop.exists
+@[deprecated (since := "2026-09-02")] alias Prop.forall_iff := Prop.forall
 
 theorem exists_iff_of_forall {p : Prop} {q : p → Prop} (h : ∀ h, q h) : (∃ h, q h) ↔ p :=
   ⟨Exists.fst, fun H ↦ ⟨H, h H⟩⟩

--- a/Mathlib/Basic/Logic/Lemmas.lean
+++ b/Mathlib/Basic/Logic/Lemmas.lean
@@ -6,7 +6,6 @@ Authors: Yaël Dillies
 module
 
 public import Mathlib.Basic.Logic.Basic
-public import Mathlib.Tactic.Convert
 public import Mathlib.Tactic.SplitIfs
 public import Mathlib.Tactic.Tauto
 
@@ -63,10 +62,3 @@ theorem ite_ite_distrib_left : ite p a (ite q b c) = ite q (ite p a b) (ite p a 
 
 theorem ite_ite_distrib_right : ite p (ite q a b) c = ite q (ite p a c) (ite p b c) :=
   dite_dite_distrib_right
-
-lemma Prop.forall {f : Prop → Prop} : (∀ p, f p) ↔ f True ∧ f False :=
-  ⟨fun h ↦ ⟨h _, h _⟩, by rintro ⟨h₁, h₀⟩ p; by_cases hp : p <;> simp only [hp] <;> assumption⟩
-
-lemma Prop.exists {f : Prop → Prop} : (∃ p, f p) ↔ f True ∨ f False :=
-  ⟨fun ⟨p, h⟩ ↦ by refine (em p).imp ?_ ?_ <;> intro H <;> convert! h <;> simp [H],
-    by rintro (h | h) <;> exact ⟨_, h⟩⟩

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -6,6 +6,7 @@ Authors: David Wärn, Kim Morrison, Matteo Cipollina, Runtian Zhou
 module
 
 public import Mathlib.Basic.Logic.Lemmas
+public import Mathlib.Data.Nat.Notation
 public import Mathlib.Combinatorics.Quiver.Prefunctor
 public import Batteries.Data.List.Basic
 

--- a/Mathlib/Order/Filter/EventuallyConst.lean
+++ b/Mathlib/Order/Filter/EventuallyConst.lean
@@ -61,7 +61,7 @@ alias ⟨EventuallyConst.eventuallyEq_const, _⟩ := eventuallyConst_iff_exists_
 
 theorem eventuallyConst_pred' {p : α → Prop} :
     EventuallyConst p l ↔ (p =ᶠ[l] fun _ ↦ False) ∨ (p =ᶠ[l] fun _ ↦ True) := by
-  simp only [eventuallyConst_iff_exists_eventuallyEq, Prop.exists_iff]
+  simp only [eventuallyConst_iff_exists_eventuallyEq, Prop.exists]
 
 theorem eventuallyConst_pred {p : α → Prop} :
     EventuallyConst p l ↔ (∀ᶠ x in l, p x) ∨ (∀ᶠ x in l, ¬p x) := by

--- a/Mathlib/Topology/Order/Category/FrameAdjunction.lean
+++ b/Mathlib/Topology/Order/Category/FrameAdjunction.lean
@@ -61,7 +61,7 @@ def openOfElementHom : FrameHom L (Set (PT L)) where
   toFun u := {x | x u}
   map_inf' a b := by simp [Set.ofPred_and]
   map_top' := by simp
-  map_sSup' S := by ext; simp [Prop.exists_iff]
+  map_sSup' S := by ext; simp [Prop.exists]
 
 namespace PT
 
@@ -102,7 +102,7 @@ def localePointOfSpacePoint (x : X) : PT (Opens X) where
   toFun := (x ∈ ·)
   map_inf' _ _ := rfl
   map_top' := rfl
-  map_sSup' S := by simp [Prop.exists_iff]
+  map_sSup' S := by simp [Prop.exists]
 
 /-- The counit is a frame homomorphism. -/
 def counitAppCont : FrameHom L (Opens <| PT L) where


### PR DESCRIPTION
Claude picked up on `Prop.exists` and `Prop.exists_iff`, as well as `Prop.forall` and `Prop.forall_iff`, being duplicates (up to reordering on the RHS).

In deprecating, we've decided to keep the statement, proof and location of `Prop.exists_iff` and `Prop.forall_iff`:
- Statement: I couldn't find justification for choosing one or the other, so this choice is arbitrary.
- Location: We keep the earlier location out of necessity.
- Proof: The selected proof allows us to avoid importing `Mathlib.Tactic.Convert`.

For the name, we went with `Prop.exists` and `Prop.forall`, since the naming convention isn't clear on the `_iff` suffix being needed.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
