### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): `G.map .inl ⊔ H.map .inr = G ⊕g H`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -154,6 +154,8 @@ Any bipartite graph may be regarded as a subgraph of one of these. -/
 def completeBipartiteGraph (V W : Type*) : SimpleGraph (V ⊕ W) where
   Adj v w := v.isLeft ∧ w.isRight ∨ v.isRight ∧ w.isLeft
 
+attribute [grind =] completeBipartiteGraph_adj
+
 namespace SimpleGraph
 
 variable {ι : Sort*} {V : Type u} (G H : SimpleGraph V) {a b c u v w : V} {e : Sym2 V}
@@ -176,6 +178,7 @@ theorem ne_of_adj (h : G.Adj a b) : a ≠ b := by
   rintro rfl
   exact G.irrefl h
 
+@[grind .]
 protected theorem Adj.ne {G : SimpleGraph V} {a b : V} (h : G.Adj a b) : a ≠ b :=
   G.ne_of_adj h
 
@@ -333,7 +336,7 @@ abbrev emptyGraph (V : Type u) : SimpleGraph V := ⊥
 theorem top_adj (v w : V) : (⊤ : SimpleGraph V).Adj v w ↔ v ≠ w :=
   Iff.rfl
 
-@[simp]
+@[simp, grind =]
 theorem bot_adj (v w : V) : (⊥ : SimpleGraph V).Adj v w ↔ False :=
   Iff.rfl
 
@@ -905,7 +908,7 @@ theorem neighborSet_top : neighborSet ⊤ v = {v}ᶜ := by
   grind [mem_neighborSet, top_adj]
 
 theorem neighborSet_bot : neighborSet ⊥ v = ∅ := by
-  grind [mem_neighborSet, bot_adj]
+  grind [mem_neighborSet]
 
 variable {G} in
 theorem Adj.nontrivial (hadj : G.Adj u v) : Nontrivial V :=

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -100,6 +100,8 @@ structure SimpleGraph (V : Type u) where
 
 initialize_simps_projections SimpleGraph (Adj → adj)
 
+attribute [grind ext] SimpleGraph.ext
+
 /-- Constructor for simple graphs using a symmetric irreflexive Boolean function. -/
 @[simps]
 def SimpleGraph.mk' {V : Type u} :

--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -477,7 +477,7 @@ theorem edgeSet_completeBipartiteGraph :
     .range (fun x : W₁ × W₂ ↦ s(.inl x.1, .inr x.2)) := by
   refine Set.ext <| Sym2.ind fun u v ↦ ⟨fun h ↦ ?_, fun ⟨⟨a, b⟩, z⟩ ↦ ?_⟩
   · cases u <;> cases v <;> simp_all
-  · grind [completeBipartiteGraph_adj, mem_edgeSet]
+  · grind [mem_edgeSet]
 
 theorem encard_edgeSet_completeBipartiteGraph :
     (completeBipartiteGraph W₁ W₂).edgeSet.encard = ENat.card W₁ * ENat.card W₂ := by

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring/EdgeLabeling.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring/EdgeLabeling.lean
@@ -140,9 +140,7 @@ def labelGraph (C : EdgeLabeling G K) (k : K) : SimpleGraph V :=
 
 theorem labelGraph_adj {C : EdgeLabeling G K} {k : K} (x y : V) :
     (C.labelGraph k).Adj x y ↔ ∃ H : G.Adj x y, C ⟨s(x, y), H⟩ = k := by
-  rw [EdgeLabeling.labelGraph]
-  simp only [mem_edgeSet, fromEdgeSet_adj, Set.mem_ofPred_eq, Ne.eq_def]
-  grind [Adj.ne]
+  grind [EdgeLabeling.labelGraph, mem_edgeSet, fromEdgeSet_adj]
 
 instance [DecidableRel G.Adj] [DecidableEq K] (k : K) {C : EdgeLabeling G K} :
     DecidableRel (C.labelGraph k).Adj := fun _ _ =>
@@ -208,6 +206,6 @@ theorem toTopEdgeLabeling_labelGraph_compl (G : SimpleGraph V) [DecidableRel G.A
 theorem TopEdgeLabeling.labelGraph_toTopEdgeLabeling [DecidableEq V]
     (C : TopEdgeLabeling V (Fin 2)) : (C.labelGraph 1).toTopEdgeLabeling = C := by
   refine EdgeLabeling.ext_get ?_
-  grind [toTopEdgeLabeling_get, TopEdgeLabeling.labelGraph_adj, Adj.ne]
+  grind [toTopEdgeLabeling_get, TopEdgeLabeling.labelGraph_adj]
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -62,16 +62,15 @@ instance instDecidableMapAdj [DecidableEq W] {f : V → W} {a b}
     [Decidable (Relation.Map G.Adj f f a b)] : Decidable ((G.map f).Adj a b) :=
   inferInstanceAs <| Decidable (_ ∧ _)
 
-@[simp]
-theorem map_adj (f : V ↪ W) (G : SimpleGraph V) (u v : W) :
-    (G.map f).Adj u v ↔ ∃ u' v' : V, G.Adj u' v' ∧ f u' = u ∧ f v' = v := by
-  dsimp [SimpleGraph.map, Relation.Map]
-  grind [SimpleGraph.Adj.ne]
-
 @[grind =]
 theorem map_adj' (f : V → W) (G : SimpleGraph V) (u v : W) :
     (G.map f).Adj u v ↔ u ≠ v ∧ ∃ u' v' : V, G.Adj u' v' ∧ f u' = u ∧ f v' = v :=
   Iff.rfl
+
+@[simp]
+theorem map_adj (f : V ↪ W) (G : SimpleGraph V) (u v : W) :
+    (G.map f).Adj u v ↔ ∃ u' v' : V, G.Adj u' v' ∧ f u' = u ∧ f v' = v := by
+  grind
 
 theorem edgeSet_map (f : V ↪ W) (G : SimpleGraph V) :
     (G.map f).edgeSet = f.sym2Map '' G.edgeSet := by
@@ -109,13 +108,11 @@ theorem map_monotone (f : V → W) : Monotone (SimpleGraph.map f) := by
 
 @[simp] lemma map_id : G.map id = G := by
   ext
-  dsimp [SimpleGraph.map, Relation.Map]
-  grind [SimpleGraph.Adj.ne]
+  grind
 
 @[simp] lemma map_map (f : V → W) (g : W → X) : (G.map f).map g = G.map (g ∘ f) := by
   ext
-  dsimp [SimpleGraph.map, Relation.Map]
-  grind [SimpleGraph.Adj.ne]
+  grind
 
 theorem support_map (f : V ↪ W) (G : SimpleGraph V) :
     (G.map f).support = f '' G.support := by

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -68,6 +68,7 @@ theorem map_adj (f : V ↪ W) (G : SimpleGraph V) (u v : W) :
   dsimp [SimpleGraph.map, Relation.Map]
   grind [SimpleGraph.Adj.ne]
 
+@[grind =]
 theorem map_adj' (f : V → W) (G : SimpleGraph V) (u v : W) :
     (G.map f).Adj u v ↔ u ≠ v ∧ ∃ u' v' : V, G.Adj u' v' ∧ f u' = u ∧ f v' = v :=
   Iff.rfl

--- a/Mathlib/Combinatorics/SimpleGraph/Star.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Star.lean
@@ -84,4 +84,10 @@ lemma degree_starGraph_center [Fintype V] [DecidableEq V] {r : V} :
     (starGraph r).degree r = Fintype.card V - 1 := by
   simp
 
+theorem starGraph_inl_unitMk : starGraph (.inl ()) = completeBipartiteGraph Unit V := by
+  ext (_ | _) (_ | _) <;> simp
+
+theorem starGraph_inr_unitMk : starGraph (.inr ()) = completeBipartiteGraph V Unit := by
+  ext (_ | _) (_ | _) <;> simp
+
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Star.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Star.lean
@@ -85,11 +85,9 @@ lemma degree_starGraph_center [Fintype V] [DecidableEq V] {r : V} :
   simp
 
 theorem starGraph_inl_unitMk : starGraph (.inl ()) = completeBipartiteGraph Unit V := by
-  ext
   grind
 
 theorem starGraph_inr_unitMk : starGraph (.inr ()) = completeBipartiteGraph V Unit := by
-  ext
   grind
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Star.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Star.lean
@@ -39,7 +39,7 @@ def starGraph (r : V) : SimpleGraph V :=
 instance [DecidableEq V] (r : V) : DecidableRel (starGraph r).Adj :=
   inferInstanceAs (DecidableRel fun x y ↦ x ≠ y ∧ (x = r ∨ y = r))
 
-@[simp]
+@[simp, grind =]
 lemma starGraph_adj {r x y : V} : (starGraph r).Adj x y ↔ x ≠ y ∧ (x = r ∨ y = r) := by
   simp [starGraph, fromRel]
 
@@ -77,7 +77,7 @@ lemma isTree_starGraph (r : V) : (starGraph r).IsTree :=
 /-- Every non-center vertex of a starGraph has degree one. -/
 lemma degree_starGraph_of_ne_center [Fintype V] [DecidableEq V] {r v : V} (h : v ≠ r) :
     (starGraph r).degree v = 1 :=
-  degree_eq_one_iff_existsUnique_adj.mpr ⟨r, by simp [h], by grind [starGraph_adj]⟩
+  degree_eq_one_iff_existsUnique_adj.mpr ⟨r, by simp [h], by grind⟩
 
 /-- The center vertex of a starGraph has degree (card V) - 1. -/
 lemma degree_starGraph_center [Fintype V] [DecidableEq V] {r : V} :
@@ -85,9 +85,11 @@ lemma degree_starGraph_center [Fintype V] [DecidableEq V] {r : V} :
   simp
 
 theorem starGraph_inl_unitMk : starGraph (.inl ()) = completeBipartiteGraph Unit V := by
-  ext (_ | _) (_ | _) <;> simp
+  ext
+  grind
 
 theorem starGraph_inr_unitMk : starGraph (.inr ()) = completeBipartiteGraph V Unit := by
-  ext (_ | _) (_ | _) <;> simp
+  ext
+  grind
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Sum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Sum.lean
@@ -54,15 +54,12 @@ theorem sum_adj_inr : (G ⊕g H).Adj (.inr w) (.inr w') ↔ H.Adj w w' := by
   simp
 
 theorem map_inl_sup_map_inr : G.map .inl ⊔ H.map .inr = G ⊕g H := by
-  ext
   grind
 
 theorem map_inl : G.map .inl = G ⊕g (⊥ : SimpleGraph W) := by
-  ext
   grind
 
 theorem map_inr : G.map .inr = (⊥ : SimpleGraph W) ⊕g G := by
-  ext
   grind
 
 /-- The disjoint sum is commutative up to isomorphism. `Iso.sumComm` as a graph isomorphism. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Sum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Sum.lean
@@ -51,6 +51,21 @@ theorem sum_adj_inl : (G ⊕g H).Adj (.inl v) (.inl v') ↔ G.Adj v v' := by
 theorem sum_adj_inr : (G ⊕g H).Adj (.inr w) (.inr w') ↔ H.Adj w w' := by
   simp
 
+theorem map_inl_sup_map_inr : G.map .inl ⊔ H.map .inr = G ⊕g H := by
+  ext (_ | _) (_ | _)
+  case inl.inr | inr.inl => simp [map_adj']
+  case inl.inl | inr.inr => simpa [map_adj'] using Adj.ne
+
+theorem map_inl : G.map .inl = G ⊕g (⊥ : SimpleGraph W) := by
+  ext (_ | _) (_ | _)
+  case inl.inl => simpa [map_adj'] using Adj.ne
+  all_goals simp [map_adj']
+
+theorem map_inr : G.map .inr = (⊥ : SimpleGraph W) ⊕g G := by
+  ext (_ | _) (_ | _)
+  case inr.inr => simpa [map_adj'] using Adj.ne
+  all_goals simp [map_adj']
+
 /-- The disjoint sum is commutative up to isomorphism. `Iso.sumComm` as a graph isomorphism. -/
 @[simps!]
 def Iso.sumComm : G ⊕g H ≃g H ⊕g G := ⟨Equiv.sumComm V W, by

--- a/Mathlib/Combinatorics/SimpleGraph/Sum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Sum.lean
@@ -45,6 +45,8 @@ protected def sum (G : SimpleGraph V) (H : SimpleGraph W) : SimpleGraph (V ⊕ W
 
 @[inherit_doc] infixl:60 " ⊕g " => SimpleGraph.sum
 
+attribute [grind =] sum_adj
+
 theorem sum_adj_inl : (G ⊕g H).Adj (.inl v) (.inl v') ↔ G.Adj v v' := by
   simp
 
@@ -52,19 +54,16 @@ theorem sum_adj_inr : (G ⊕g H).Adj (.inr w) (.inr w') ↔ H.Adj w w' := by
   simp
 
 theorem map_inl_sup_map_inr : G.map .inl ⊔ H.map .inr = G ⊕g H := by
-  ext (_ | _) (_ | _)
-  case inl.inr | inr.inl => simp [map_adj']
-  case inl.inl | inr.inr => simpa [map_adj'] using Adj.ne
+  ext
+  grind
 
 theorem map_inl : G.map .inl = G ⊕g (⊥ : SimpleGraph W) := by
-  ext (_ | _) (_ | _)
-  case inl.inl => simpa [map_adj'] using Adj.ne
-  all_goals simp [map_adj']
+  ext
+  grind
 
 theorem map_inr : G.map .inr = (⊥ : SimpleGraph W) ⊕g G := by
-  ext (_ | _) (_ | _)
-  case inr.inr => simpa [map_adj'] using Adj.ne
-  all_goals simp [map_adj']
+  ext
+  grind
 
 /-- The disjoint sum is commutative up to isomorphism. `Iso.sumComm` as a graph isomorphism. -/
 @[simps!]

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Basic.lean
@@ -112,7 +112,7 @@ lemma exists_length_eq_one_iff {u v : V} : (∃ (p : G.Walk u v), p.length = 1) 
   ⟨fun ⟨_, hp⟩ ↦ adj_of_length_eq_one hp, (⟨·.toWalk, by simp⟩)⟩
 
 theorem eq_of_length_le_one {p q : G.Walk u v} (hp : p.length ≤ 1) (hq : q.length ≤ 1) : p = q := by
-  grind [cases Walk, length_cons, Adj.ne]
+  grind [cases Walk, length_cons]
 
 /-- The `support` of a walk is the list of vertices it visits in order. -/
 def support {u v : V} : G.Walk u v → List V

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Chord.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Chord.lean
@@ -55,7 +55,7 @@ theorem IsChordless.mem_edges {p : G.Walk u v} (h : p.IsChordless) {u' v' : V}
   isChordless_iff_forall_mem_edges.mp h hu' hv' hadj
 
 theorem _root_.SimpleGraph.Adj.isChordless_toWalk (h : G.Adj u v) : h.toWalk.IsChordless := by
-  grind [isChordless_iff_forall_mem_edges, h.support_toWalk, h.edges_toWalk, Adj.ne]
+  grind [isChordless_iff_forall_mem_edges, h.support_toWalk, h.edges_toWalk]
 
 end Walk
 end SimpleGraph


### PR DESCRIPTION
and similar trivial graph identities:
- `G.map .inl = G ⊕g ⊥`
- `G.map .inr = ⊥ ⊕g G`
- `starGraph (.inl ()) = completeBipartiteGraph Unit V`
- `starGraph (.inr ()) = completeBipartiteGraph V Unit`

---
I tried to construct some graph using some combination of these primitives and noticed that these are interchangable but not defeq. Not sure which spelling is preferable.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
