### PR TITLE
[Merged by Bors] - chore(GroupTheory/DoubleCoset): simpler proof

### DIFF
--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -118,24 +118,16 @@ abbrev mk (H K : Subgroup G) (a : G) : Quotient (H : Set G) K :=
 instance (H K : Subgroup G) : Inhabited (Quotient (H : Set G) K) :=
   ⟨mk H K (1 : G)⟩
 
-lemma eq'' {a b : G} (H K : Subgroup G) : mk H K a = mk H K b ↔ setoid H K a b :=
+lemma eq'' {a b : G} {H K : Subgroup G} : mk H K a = mk H K b ↔ setoid H K a b :=
   Quotient.eq
 
-lemma eq (H K : Subgroup G) (a b : G) :
+lemma eq {H K : Subgroup G} {a b : G} :
     mk H K a = mk H K b ↔ ∃ h ∈ H, ∃ k ∈ K, b = h * a * k := by
   rw [eq'']
   exact rel_iff
 
-lemma out_eq' (H K : Subgroup G) (q : Quotient ↑H ↑K) : mk H K q.out = q :=
+lemma out_eq' {H K : Subgroup G} (q : Quotient ↑H ↑K) : mk H K q.out = q :=
   Quotient.out_eq' q
-
-lemma mk_out_eq_mul (H K : Subgroup G) (g : G) :
-    ∃ h k : G, h ∈ H ∧ k ∈ K ∧ (mk H K g : Quotient ↑H ↑K).out = h * g * k := by
-  have := eq H K (mk H K g : Quotient ↑H ↑K).out g
-  rw [out_eq'] at this
-  obtain ⟨h, h_h, k, hk, T⟩ := this.1 rfl
-  refine ⟨h⁻¹, k⁻¹, H.inv_mem h_h, K.inv_mem hk, eq_mul_inv_of_mul_eq (eq_inv_mul_of_mul_eq ?_)⟩
-  rw [← mul_assoc, ← T]
 
 lemma mk_eq_of_doubleCoset_eq {H K : Subgroup G} {a b : G}
     (h : doubleCoset a H K = doubleCoset b H K) : mk H K a = mk H K b := by
@@ -158,8 +150,8 @@ set_option backward.isDefEq.respectTransparency false in
 lemma mem_quotToDoubleCoset_iff {H K : Subgroup G} (i : Quotient (H : Set G) K) (a : G) :
     a ∈ quotToDoubleCoset H K i ↔ mk H K a = i := by
   refine ⟨fun hg ↦ by simp [mk_eq_of_doubleCoset_eq (doubleCoset_eq_of_mem hg)], fun hg ↦ ?_⟩
-  rw [← out_eq' _ _ i] at hg
-  exact mem_doubleCoset.mpr ((eq _ _ _ a).mp hg.symm)
+  rw [← out_eq' i] at hg
+  exact mem_doubleCoset.mpr (eq.mp hg.symm)
 
 lemma disjoint_out {H K : Subgroup G} {a b : Quotient H K} :
     a ≠ b → Disjoint (doubleCoset a.out H K) (doubleCoset b.out (H : Set G) K) := by
@@ -171,10 +163,7 @@ lemma iUnion_quotToDoubleCoset (H K : Subgroup G) : ⋃ q, quotToDoubleCoset H K
   ext x
   simp only [Set.mem_iUnion, quotToDoubleCoset, mem_doubleCoset, SetLike.mem_coe, Set.mem_univ,
     iff_true]
-  use mk H K x
-  obtain ⟨h, k, h3, h4, h5⟩ := mk_out_eq_mul H K x
-  refine ⟨h⁻¹, H.inv_mem h3, k⁻¹, K.inv_mem h4, ?_⟩
-  simp only [h5, ← mul_assoc, one_mul, inv_mul_cancel, mul_inv_cancel_right]
+  exact ⟨mk H K x, eq.mp (out_eq' (mk H K x))⟩
 
 @[deprecated (since := "2026-04-03")]
 alias union_quotToDoubleCoset := iUnion_quotToDoubleCoset

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -129,6 +129,12 @@ lemma eq {H K : Subgroup G} {a b : G} :
 lemma out_eq' {H K : Subgroup G} (q : Quotient ↑H ↑K) : mk H K q.out = q :=
   Quotient.out_eq' q
 
+@[deprecated "Use `eq.mp (out_eq' (mk H K g))` instead." (since := "2026-09-04")]
+lemma mk_out_eq_mul (H K : Subgroup G) (g : G) :
+    ∃ h k : G, h ∈ H ∧ k ∈ K ∧ (mk H K g : Quotient ↑H ↑K).out = h * g * k := by
+  obtain ⟨h ,hh, k, hk, heq⟩ := eq.mp (out_eq' (mk H K g)).symm
+  exact ⟨h, k, hh, hk, by simp [heq]⟩
+
 lemma mk_eq_of_doubleCoset_eq {H K : Subgroup G} {a b : G}
     (h : doubleCoset a H K = doubleCoset b H K) : mk H K a = mk H K b := by
   rw [eq]

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -132,7 +132,7 @@ lemma out_eq' {H K : Subgroup G} (q : Quotient ↑H ↑K) : mk H K q.out = q :=
 @[deprecated "Use `eq.mp (out_eq' (mk H K g))` instead." (since := "2026-09-04")]
 lemma mk_out_eq_mul (H K : Subgroup G) (g : G) :
     ∃ h k : G, h ∈ H ∧ k ∈ K ∧ (mk H K g : Quotient ↑H ↑K).out = h * g * k := by
-  obtain ⟨h ,hh, k, hk, heq⟩ := eq.mp (out_eq' (mk H K g)).symm
+  obtain ⟨h, hh, k, hk, heq⟩ := eq.mp (out_eq' (mk H K g)).symm
   exact ⟨h, k, hh, hk, by simp [heq]⟩
 
 lemma mk_eq_of_doubleCoset_eq {H K : Subgroup G} {a b : G}

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -129,11 +129,9 @@ lemma eq {H K : Subgroup G} {a b : G} :
 lemma out_eq' {H K : Subgroup G} (q : Quotient ↑H ↑K) : mk H K q.out = q :=
   Quotient.out_eq' q
 
-@[deprecated "Use `eq.mp (out_eq' (mk H K g))` instead." (since := "2026-09-04")]
 lemma mk_out_eq_mul (H K : Subgroup G) (g : G) :
-    ∃ h k : G, h ∈ H ∧ k ∈ K ∧ (mk H K g : Quotient ↑H ↑K).out = h * g * k := by
-  obtain ⟨h, hh, k, hk, heq⟩ := eq.mp (out_eq' (mk H K g)).symm
-  exact ⟨h, k, hh, hk, by simp [heq]⟩
+    ∃ h ∈ H, ∃ k ∈ K, (mk H K g : Quotient ↑H ↑K).out = h * g * k :=
+  eq.mp (out_eq' (mk H K g)).symm
 
 lemma mk_eq_of_doubleCoset_eq {H K : Subgroup G} {a b : G}
     (h : doubleCoset a H K = doubleCoset b H K) : mk H K a = mk H K b := by


### PR DESCRIPTION
Remove a duplicate lemma and shorten a later proof accordingly. The following lemma has a confusing order (g, g', hg, hg', heq) conflicting with the convention elsewhere (g, hg, g' hg', heq)
```
lemma mk_out_eq_mul (H K : Subgroup G) (g : G) :
    ∃ h k : G, h ∈ H ∧ k ∈ K ∧ (mk H K g : Quotient ↑H ↑K).out = h * g * k := by
```
The content itself the same as standard API combination `eq.mp (out_eq' (mk H K g))` (up to the confusing reordering).

- [x] depends on: #43382