### PR TITLE
[Merged by Bors] - feat: a discrete subset of a T1 space is locally closed

### DIFF
--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -177,7 +177,7 @@ lemma IsDiscrete.isLocallyClosed [T1Space X] (hs : IsDiscrete s) :
   simp_rw [isLocallyClosed_iff_isLocallyClosedAt,
     isLocallyClosedAt_iff_exists_isClosed_eventuallyEqSet]
   refine fun x hx ↦ ⟨{x}, isClosed_singleton, ?_⟩
-  simpa [eventuallyEqSet_iff_inf_principal, nhdsWithin] using hs.nhdsWithin x hx
+  simp [← nhdsWithin_eq_iff_eventuallyEqSet, hs.nhdsWithin x hx]
 
 section cofinite_cocompact
 

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Tactic.TautoSet
 public import Mathlib.Topology.Constructions
 public import Mathlib.Topology.Separation.Basic
+public import Mathlib.Topology.LocallyClosed
 
 /-!
 # Discrete subsets of topological spaces
@@ -170,6 +171,13 @@ lemma IsDiscrete.eq_of_specializes (hs : IsDiscrete s)
   let := hs.1
   simpa only [← Topology.IsInducing.subtypeVal.specializes_iff, hab, Subtype.mk.injEq,
     true_iff] using specializes_iff_eq (X := s) (x := ⟨a, ha⟩) (y := ⟨b, hb⟩)
+
+lemma IsDiscrete.isLocallyClosed [T1Space X] (hs : IsDiscrete s) :
+    IsLocallyClosed s := by
+  simp_rw [isLocallyClosed_iff_isLocallyClosedAt,
+    isLocallyClosedAt_iff_exists_isClosed_eventuallyEqSet]
+  refine fun x hx ↦ ⟨{x}, isClosed_singleton, ?_⟩
+  simpa [eventuallyEqSet_iff_inf_principal, nhdsWithin] using hs.nhdsWithin x hx
 
 section cofinite_cocompact
 

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -174,9 +174,9 @@ lemma IsDiscrete.eq_of_specializes (hs : IsDiscrete s)
 
 lemma IsDiscrete.isLocallyClosed [T1Space X] (hs : IsDiscrete s) :
     IsLocallyClosed s := by
-  simp_rw [isLocallyClosed_iff_isLocallyClosedAt,
-    isLocallyClosedAt_iff_exists_isClosed_eventuallyEqSet]
-  refine fun x hx ↦ ⟨{x}, isClosed_singleton, ?_⟩
+  rw [isLocallyClosed_iff_isLocallyClosedAt]
+  intro x hx
+  refine isClosed_singleton.isLocallyClosed.isLocallyClosedAt (mem_singleton x) |>.congr ?_
   simp [← nhdsWithin_eq_iff_eventuallyEqSet, hs.nhdsWithin x hx]
 
 section cofinite_cocompact

--- a/Mathlib/Topology/LocallyClosed.lean
+++ b/Mathlib/Topology/LocallyClosed.lean
@@ -267,6 +267,15 @@ alias isLocallyClosedAt_iff_closure_eventuallyLE :=
 lemma isLocallyClosedAt_iff_coborder_mem_nhds {x : X} : IsLocallyClosedAt s x ↔ coborder s ∈ 𝓝 x :=
   (isLocallyClosedAt_tfae s x).out 1 9
 
+lemma IsLocallyClosedAt.congr {x : X} (hs : IsLocallyClosedAt s x) (h : s =ᶠ[𝓝 x] t) :
+    IsLocallyClosedAt t x := by
+  rw [isLocallyClosedAt_iff_exists_isClosed_eventuallyEqSet] at *
+  exact hs.imp fun _ ↦ And.imp_right <| h.symm.trans
+
+lemma isLocallyClosedAt_congr {x : X} (h : s =ᶠ[𝓝 x] t) :
+    IsLocallyClosedAt s x ↔ IsLocallyClosedAt t x :=
+  ⟨fun hs ↦ hs.congr h, fun ht ↦ ht.congr h.symm⟩
+
 lemma interior_coborder : interior (coborder s) = {x | IsLocallyClosedAt s x} := by
   ext
   simp [isLocallyClosedAt_iff_coborder_mem_nhds, mem_interior_iff_mem_nhds]


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
