### PR TITLE
[Merged by Bors] - chore: keep `Mathlib.Algebra.Algebra.Rat` imports used only in `example`s

### DIFF
--- a/Mathlib/Algebra/QuadraticAlgebra/Basic.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Basic.lean
@@ -5,7 +5,7 @@ Authors: Antoine Chambert-Loir
 -/
 module
 
-public import Mathlib.Algebra.Algebra.Rat
+public import Mathlib.Algebra.Algebra.Rat  -- shake: keep (used in `example` only)
 public import Mathlib.Algebra.Algebra.Subalgebra.Lattice
 public import Mathlib.Algebra.QuadraticAlgebra.Defs
 public import Mathlib.Algebra.Star.Unitary

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -5,7 +5,7 @@ Authors: Anne Baanen
 -/
 module
 
-public import Mathlib.Algebra.Algebra.Rat
+public import Mathlib.Algebra.Algebra.Rat  -- shake: keep (used in `example` only)
 public import Mathlib.Algebra.Algebra.Subalgebra.Tower
 public import Mathlib.Algebra.Field.IsField
 public import Mathlib.Algebra.Field.Subfield.Basic


### PR DESCRIPTION
`lake shake --fix` removes `public import Mathlib.Algebra.Algebra.Rat` from
`FieldTheory/IntermediateField/Basic.lean` and `Algebra/QuadraticAlgebra/Basic.lean`,
which then fail to build with `Unknown constant DivisionRing.toRatAlgebra`.

In both files the import's only use is inside an `example`, and `example` declarations
are not recorded in the `.olean`, so shake cannot see the dependency. Annotate both
imports with `-- shake: keep`, matching the existing convention elsewhere (e.g.
`Topology/Category/UniformSpace.lean`, `RepresentationTheory/FDRep.lean`,
`Topology/Algebra/Nonarchimedean/AdicTopology.lean`).

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Spotted while looking at the CI failure on #43073.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
