### PR TITLE
feat(PointedCone): affine span of a pointed cone hull equals the submodule span

### DIFF
--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -6,6 +6,7 @@ Authors: Johan Commelin, Aaron Anderson
 module
 
 public import Mathlib.Algebra.Order.BigOperators.Group.Finset
+public import Mathlib.Algebra.Order.Group.PosPart
 public import Mathlib.Algebra.Order.Module.Defs
 public import Mathlib.Algebra.Order.Pi
 public import Mathlib.Algebra.Order.Sub.Basic
@@ -310,6 +311,24 @@ lemma support_add_eq_union {f1 f2 : ι →₀ α} [DecidableEq ι] :
     (support_mono le_self_add) (support_mono le_add_self)
 
 end PartialOrder
+
+section PosPart
+
+variable [AddGroup α] [Lattice α] {f : ι →₀ α}
+
+@[simp, grind =]
+lemma posPart_apply (f : ι →₀ α) (i : ι) : f⁺ i = (f i)⁺ := rfl
+
+@[simp, grind =]
+lemma negPart_apply (f : ι →₀ α) (i : ι) : f⁻ i = (f i)⁻ := rfl
+
+lemma support_posPart_subset (f : ι →₀ α) : f⁺.support ⊆ f.support := by
+  grind [posPart_zero]
+
+lemma support_negPart_subset (f : ι →₀ α) : f⁻.support ⊆ f.support := by
+  grind [negPart_zero]
+
+end PosPart
 
 section LinearOrder
 

--- a/Mathlib/Geometry/Convex/Cone/Pointed.lean
+++ b/Mathlib/Geometry/Convex/Cone/Pointed.lean
@@ -8,8 +8,8 @@ module
 public import Mathlib.Algebra.Group.Submonoid.Support
 public import Mathlib.Algebra.Order.Monoid.Submonoid
 public import Mathlib.Algebra.Order.Nonneg.Module
+public import Mathlib.Data.Finsupp.Order
 public import Mathlib.Geometry.Convex.Cone.Basic
-
 
 /-!
 # Pointed cones
@@ -378,6 +378,34 @@ theorem lineal_eq_sSup (C : PointedCone R E) : C.lineal = sSup {S : Submodule R 
   simp_rw [gc_ofSubmodule_lineal.le_iff_le, Set.Iic_def, csSup_Iic]
 
 end Lineal
+
+section AffineSpan
+
+variable [Ring R] [Lattice R] [IsOrderedRing R] [AddCommGroup E] [Module R E]
+
+lemma sum_posPart_mem_hull {s : Set E} {c : E →₀ R} (hc : ↑c.support ⊆ s) :
+    c⁺.sum (fun a b ↦ b • a) ∈ hull R s :=
+  mem_hull_set.mpr ⟨c⁺, le_trans (by simpa using Finsupp.support_posPart_subset c) hc, by simp⟩
+
+lemma sum_negPart_mem_hull {s : Set E} {c : E →₀ R} (hc : ↑c.support ⊆ s) :
+    c⁻.sum (fun a b ↦ b • a) ∈ hull R s :=
+  mem_hull_set.mpr ⟨c⁻, le_trans (by simpa using Finsupp.support_negPart_subset c) hc, by simp⟩
+
+theorem affineSpan_hull_eq_toAffineSubspace_span {K : Set E} :
+    affineSpan R (hull R K) = (span R K).toAffineSubspace := by
+  apply le_antisymm
+  · grw [affineSpan_le_toAffineSubspace_span, Submodule.span_span_of_tower]
+  refine fun x hx ↦ ⟨0, by simp, ?_⟩
+  obtain ⟨c, hc₁, rfl⟩ := Submodule.mem_span_set.mp hx
+  rw [← posPart_sub_negPart c, Finsupp.sum_sub_index (by simp [sub_smul])]
+  simpa using vsub_mem_vectorSpan R (sum_posPart_mem_hull hc₁) (sum_negPart_mem_hull hc₁)
+
+theorem affineSpan_hull_eq_affineSpan_insert {K : Set E} :
+    affineSpan R (hull R K) = affineSpan R (insert 0 K) := by
+  rw [AffineSubspace.ext_iff, affineSpan_insert_zero, affineSpan_hull_eq_toAffineSubspace_span]
+  norm_cast
+
+end AffineSpan
 
 section Salient
 


### PR DESCRIPTION
These are useful API lemmas extracted from a proof that homogenization increases dimension by one.

Created as part of the "Polyhedra in Lean" workshop in Berlin.

---

AI disclosure: I used Claude to find what files to place lemmas into, the lemmas were written by hand.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
