### PR TITLE
feat(Order/WithBot): add `WithBot.map_lt_map_iff`

### DIFF
--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -134,7 +134,7 @@ variable [Preorder α] [Preorder β]
 protected def withBotMap (f : α ↪o β) : WithBot α ↪o WithBot β where
   toFun := WithBot.map f
   inj' := WithBot.map_injective f.injective
-  map_rel_iff' := WithBot.map_le_iff f f.map_rel_iff
+  map_rel_iff' := WithBot.map_le_map_iff f f.map_rel_iff
 
 -- `simps` could generate this theorem, but `to_dual` is not happy with that version.
 @[to_dual (attr := simp)]

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -479,6 +479,13 @@ lemma unbotA_le_iff [Nonempty α] (hx : x ≠ ⊥) : x.unbotA ≤ a ↔ x ≤ a 
 @[to_dual]
 lemma unbotA_mono [Nonempty α] (hy : x ≠ ⊥) (h : x ≤ y) : x.unbotA ≤ y.unbotA := unbotD_mono hy h
 
+@[to_dual]
+lemma map_le_map_iff [LE β] (f : α → β) (hf : ∀ {a b}, f a ≤ f b ↔ a ≤ b) :
+    x.map f ≤ y.map f ↔ x ≤ y := by cases x <;> cases y <;> simp [hf]
+
+@[to_dual (attr := deprecated (since := "2026-09-03"))]
+alias map_le_iff := map_le_map_iff
+
 end LE
 
 section LT
@@ -527,6 +534,10 @@ lemma lt_unbotA_iff [Nonempty α] (hx : x ≠ ⊥) : a < x.unbotA ↔ a < x := l
 @[to_dual lt_untopA_iff]
 lemma unbotA_lt_iff [Nonempty α] (hx : x ≠ ⊥) : x.unbotA < a ↔ x < a := by
   lift x to α using hx; simp
+
+@[to_dual]
+lemma map_lt_map_iff [LT β] (f : α → β) (hf : ∀ {a b}, f a < f b ↔ a < b) :
+    x.map f < y.map f ↔ x < y := by cases x <;> cases y <;> simp [hf]
 
 end LT
 
@@ -582,10 +593,6 @@ theorem strictMono_map_iff {f : α → β} :
 
 @[to_dual]
 alias ⟨_, _root_.StrictMono.withBot_map⟩ := strictMono_map_iff
-
-@[to_dual]
-lemma map_le_iff (f : α → β) (mono_iff : ∀ {a b}, f a ≤ f b ↔ a ≤ b) :
-    x.map f ≤ y.map f ↔ x ≤ y := by cases x <;> cases y <;> simp [mono_iff]
 
 @[to_dual coe_untopD_le]
 theorem le_coe_unbotD (x : WithBot α) (b : α) : x ≤ x.unbotD b := by cases x <;> simp


### PR DESCRIPTION
Add `WithBot.map_lt_map_iff`, the `<` analogue of `WithBot.map_le_iff`, for use in a follow-up.

Its natural home is the `LT` section. For symmetry, we also generalize `WithBot.map_le_iff`.

Also rename `map_le_iff` to `map_le_map_iff`, since the operation appears on both sides of the relation. The bare `X_le_iff` form is used throughout Mathlib for the one-sided shape `f a ≤ b ↔ ...`.

---

Developed with help from of Claude Opus 5.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
