### PR TITLE
[Merged by Bors] - chore: keep `Mathlib.Algebra.Lie.CartanExists` import used only in an `example`

### DIFF
--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Basis.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Basis.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Algebra.Lie.Basis.Base
 public import Mathlib.Algebra.Lie.CartanCriterion
-public import Mathlib.Algebra.Lie.CartanExists
+public import Mathlib.Algebra.Lie.CartanExists  -- shake: keep (used in `example` only)
 public import Mathlib.Algebra.Lie.Weights.IsSimple
 public import Mathlib.LinearAlgebra.RootSystem.GeckConstruction.Semisimple
 public import Mathlib.LinearAlgebra.RootSystem.GeckConstruction.Relations


### PR DESCRIPTION
`lake shake --fix` removes `public import Mathlib.Algebra.Lie.CartanExists` from
`Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Basis.lean`, which then fails to build with
`Unknown identifier exists_isCartanSubalgebra_engel`.

The import's only use in that file is inside the `example` at the end, and `example` declarations
are not recorded in the `.olean`, so shake cannot see the dependency. Annotate the import with
`-- shake: keep`, matching #43388 and the existing convention elsewhere (e.g.
`Mathlib/Tactic/Group.lean`, `Mathlib/Tactic/TFAE.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)