### PR TITLE
[Merged by Bors] - feat(RingTheory/LocalRing/ResidueField): a predicate for separable residue field extensions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6949,6 +6949,7 @@ public import Mathlib.RingTheory.LocalRing.ResidueField.Fiber
 public import Mathlib.RingTheory.LocalRing.ResidueField.Ideal
 public import Mathlib.RingTheory.LocalRing.ResidueField.Instances
 public import Mathlib.RingTheory.LocalRing.ResidueField.Polynomial
+public import Mathlib.RingTheory.LocalRing.ResidueField.Separable
 public import Mathlib.RingTheory.LocalRing.RingHom.Basic
 public import Mathlib.RingTheory.LocalRing.Subring
 public import Mathlib.RingTheory.Localization.Algebra

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Separable.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Separable.lean
@@ -12,12 +12,12 @@ public import Mathlib.RingTheory.LocalRing.ResidueField.Instances
 # Separable residue field extensions
 
 For a prime `p` of `A`, we introduce a predicate stating that the residue field extensions
-`κ(P)/κ(p)` are separable for every prime `P` of `B` lying over `p`.
+`κ(q)/κ(p)` are separable for every prime `q` of `B` lying over `p`.
 
 ## Main definitions
 
-* `Algebra.HasSeparableResidueFieldsAt A B p`: the residue field extension `κ(P)/κ(p)` is
-  separable for every prime `P` of `B` lying over `p`.
+* `Algebra.HasSeparableResidueFieldsAt A B p`: the residue field extension `κ(q)/κ(p)` is
+  separable for every prime `q` of `B` lying over `p`.
 
 ## Main results
 
@@ -30,12 +30,12 @@ For a prime `p` of `A`, we introduce a predicate stating that the residue field 
 
 ## Implementation notes
 
-The condition is on the residue fields rather than on the quotient rings `(B ⧸ P)/(A ⧸ p)` so that
+The condition is on the residue fields rather than on the quotient rings `(B ⧸ q)/(A ⧸ p)` so that
 it makes sense at any prime: the quotients are fields only at maximal primes.
 
-The algebra structure on `κ(P)` over `κ(p)` in the predicate is the one induced by the algebra
-structure on `Localization.AtPrime P` over `Localization.AtPrime p` given by
-`Localization.AtPrime.algebraOfLiesOver`. Any other structure making `Localization.AtPrime P` an
+The algebra structure on `κ(q)` over `κ(p)` in the predicate is the one induced by the algebra
+structure on `Localization.AtPrime q` over `Localization.AtPrime p` given by
+`Localization.AtPrime.algebraOfLiesOver`. Any other structure making `Localization.AtPrime q` an
 algebra over `Localization.AtPrime p` in a compatible way with the action of `A` is equal to that
 one, see `Localization.AtPrime.algebraMap_eq`.
 -/
@@ -50,37 +50,37 @@ section Prime
 
 variable (A B : Type*) [CommRing A] [CommRing B] [Algebra A B] (p : Ideal A) [p.IsPrime]
 
-/-- `Algebra.HasSeparableResidueFieldsAt A B p` states that for every prime `P` of `B` lying over
-`p`, the residue field extension `κ(P)/κ(p)` is separable. -/
+/-- `Algebra.HasSeparableResidueFieldsAt A B p` states that for every prime `q` of `B` lying over
+`p`, the residue field extension `κ(q)/κ(p)` is separable. -/
 class HasSeparableResidueFieldsAt : Prop where
-  isSeparable' (P : Ideal B) [P.IsPrime] [P.LiesOver p] :
-    letI := Localization.AtPrime.algebraOfLiesOver p P
-    Algebra.IsSeparable p.ResidueField P.ResidueField
+  isSeparable' (q : Ideal B) [q.IsPrime] [q.LiesOver p] :
+    letI := Localization.AtPrime.algebraOfLiesOver p q
+    Algebra.IsSeparable p.ResidueField q.ResidueField
 
 variable {A B p} in
 /-- `Algebra.HasSeparableResidueFieldsAt` gives the separability for any compatible choice of the
 algebra structure on the localizations. -/
-instance HasSeparableResidueFieldsAt.isSeparable (P : Ideal B) [P.IsPrime] [P.LiesOver p]
+instance HasSeparableResidueFieldsAt.isSeparable (q : Ideal B) [q.IsPrime] [q.LiesOver p]
     [HasSeparableResidueFieldsAt A B p]
-    [alg : Algebra (Localization.AtPrime p) (Localization.AtPrime P)]
-    [IsScalarTower A (Localization.AtPrime p) (Localization.AtPrime P)] :
-    Algebra.IsSeparable p.ResidueField P.ResidueField :=
-  have : alg = Localization.AtPrime.algebraOfLiesOver p P :=
+    [alg : Algebra (Localization.AtPrime p) (Localization.AtPrime q)]
+    [IsScalarTower A (Localization.AtPrime p) (Localization.AtPrime q)] :
+    Algebra.IsSeparable p.ResidueField q.ResidueField :=
+  have : alg = Localization.AtPrime.algebraOfLiesOver p q :=
     Algebra.algebra_ext _ _ fun _ ↦ by rw [Localization.AtPrime.algebraMap_eq]; rfl
-  this ▸ HasSeparableResidueFieldsAt.isSeparable' P
+  this ▸ HasSeparableResidueFieldsAt.isSeparable' q
 
 variable [Algebra.IsIntegral A B]
 
 /-- If the residue field `κ(p)` is perfect, the residue field extensions above `p` are separable. -/
 instance [PerfectField p.ResidueField] : HasSeparableResidueFieldsAt A B p where
-  isSeparable' P _ _ :=
-    letI := Localization.AtPrime.algebraOfLiesOver p P
+  isSeparable' q _ _ :=
+    letI := Localization.AtPrime.algebraOfLiesOver p q
     IsAlgebraic.isSeparable_of_perfectField
 
 /-- If `A` has finite quotients, the residue field extensions above a nonzero prime of `A` are
 separable. -/
 instance [NeZero p] [Ring.HasFiniteQuotients A] : HasSeparableResidueFieldsAt A B p :=
-  haveI : Finite (A ⧸ p) := Ring.HasFiniteQuotients.finiteQuotient (NeZero.ne p)
+  have : Finite (A ⧸ p) := Ring.HasFiniteQuotients.finiteQuotient (NeZero.ne p)
   inferInstance
 
 end Prime
@@ -90,14 +90,14 @@ section Maximal
 variable {A B : Type*} [CommRing A] [CommRing B] [Algebra A B] (p : Ideal A) [p.IsMaximal]
 
 /-- At a maximal prime `p`, `Algebra.HasSeparableResidueFieldsAt` also gives the separability of
-the extension of quotient rings `(B ⧸ P)/(A ⧸ p)` for every maximal ideal `P` of `B` lying over
+the extension of quotient rings `(B ⧸ q)/(A ⧸ p)` for every maximal ideal `q` of `B` lying over
 `p`. Maximality is needed for the quotient rings to be fields; they are then canonically
 isomorphic to the residue fields. -/
 instance HasSeparableResidueFieldsAt.isSeparable_quotient [HasSeparableResidueFieldsAt A B p]
-    (P : Ideal B) [P.IsMaximal] [P.LiesOver p] :
-    Algebra.IsSeparable (A ⧸ p) (B ⧸ P) :=
-  letI := Localization.AtPrime.algebraOfLiesOver p P
-  Algebra.isSeparable_residueField_iff.mp (HasSeparableResidueFieldsAt.isSeparable' P)
+    (q : Ideal B) [q.IsMaximal] [q.LiesOver p] :
+    Algebra.IsSeparable (A ⧸ p) (B ⧸ q) :=
+  letI := Localization.AtPrime.algebraOfLiesOver p q
+  Algebra.isSeparable_residueField_iff.mp (HasSeparableResidueFieldsAt.isSeparable' q)
 
 end Maximal
 
@@ -126,7 +126,7 @@ residue field extensions of `C/A` above `p` gives separability of those of `C/B`
 theorem HasSeparableResidueFieldsAt.tower_top [HasSeparableResidueFieldsAt A C p] :
     HasSeparableResidueFieldsAt B C q where
   isSeparable' r _ _ :=
-    haveI : r.LiesOver p := Ideal.LiesOver.trans r q p
+    have : r.LiesOver p := Ideal.LiesOver.trans r q p
     letI := Localization.AtPrime.algebraOfLiesOver p q
     letI := Localization.AtPrime.algebraOfLiesOver p r
     letI := Localization.AtPrime.algebraOfLiesOver q r

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Separable.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Separable.lean
@@ -22,25 +22,22 @@ For a prime `p` of `A`, we introduce a predicate stating that the residue field 
 ## Main results
 
 * instances deducing `Algebra.HasSeparableResidueFieldsAt` when the residue field `κ(p)` is
-  perfect, when the quotient `A ⧸ p` is finite, and when `A` has finite quotients and `p` is
-  nonzero;
+  perfect, and when `A` has finite quotients and `p` is nonzero;
 * `Algebra.HasSeparableResidueFieldsAt.isSeparable_quotient`: at a maximal prime, the predicate
   also gives the separability of the extensions of quotient rings;
-* `Algebra.HasSeparableResidueFieldsAt.tower_top`: the predicate passes to an intermediate ring.
+* `Algebra.HasSeparableResidueFieldsAt.tower_top` and
+  `Algebra.HasSeparableResidueFieldsAt.tower_bot`: the predicate passes to an intermediate ring.
 
 ## Implementation notes
 
-The condition is stated on the residue fields rather than on the quotient rings `(B ⧸ P)/(A ⧸ p)`
-since the quotients are fields only when the primes are maximal, in which case they are canonically
-isomorphic to the residue fields. This is why
-`Algebra.HasSeparableResidueFieldsAt.isSeparable_quotient` assumes that `p` and `P` are maximal,
-whereas the definition itself works at an arbitrary prime.
+The condition is on the residue fields rather than on the quotient rings `(B ⧸ P)/(A ⧸ p)` so that
+it makes sense at any prime: the quotients are fields only at maximal primes.
 
-The field `Algebra.HasSeparableResidueFieldsAt.isSeparable'` fixes one algebra structure on the
-localizations, namely `Localization.AtPrime.algebraOfLiesOver`, so that proving the predicate
-involves a single choice. The instance `Algebra.HasSeparableResidueFieldsAt.isSeparable`, which is
-the one consumers use, then generalises it to an arbitrary compatible structure; the genericity is
-paid for once, there, rather than in the definition.
+The algebra structure on `κ(P)` over `κ(p)` in the predicate is the one induced by the algebra
+structure on `Localization.AtPrime P` over `Localization.AtPrime p` given by
+`Localization.AtPrime.algebraOfLiesOver`. Any other structure making `Localization.AtPrime P` an
+algebra over `Localization.AtPrime p` in a compatible way with the action of `A` is equal to that
+one, see `Localization.AtPrime.algebraMap_eq`.
 -/
 
 @[expose] public section
@@ -49,7 +46,7 @@ open Ideal
 
 namespace Algebra
 
-section
+section Prime
 
 variable (A B : Type*) [CommRing A] [CommRing B] [Algebra A B] (p : Ideal A) [p.IsPrime]
 
@@ -80,21 +77,13 @@ instance [PerfectField p.ResidueField] : HasSeparableResidueFieldsAt A B p where
     letI := Localization.AtPrime.algebraOfLiesOver p P
     IsAlgebraic.isSeparable_of_perfectField
 
-/-- If the quotient `A ⧸ p` is finite, the residue field extensions above `p` are separable. -/
-instance [Finite (A ⧸ p)] : HasSeparableResidueFieldsAt A B p where
-  isSeparable' P _ _ :=
-    haveI : p.IsMaximal := Ideal.Quotient.maximal_of_isField p (Finite.isField_of_domain _)
-    haveI : P.IsMaximal := IsMaximal.of_liesOver_isMaximal P p
-    letI := Localization.AtPrime.algebraOfLiesOver p P
-    instIsSeparableResidueFieldOfQuotientIdeal p P
-
 /-- If `A` has finite quotients, the residue field extensions above a nonzero prime of `A` are
 separable. -/
 instance [NeZero p] [Ring.HasFiniteQuotients A] : HasSeparableResidueFieldsAt A B p :=
   haveI : Finite (A ⧸ p) := Ring.HasFiniteQuotients.finiteQuotient (NeZero.ne p)
   inferInstance
 
-end
+end Prime
 
 section Maximal
 
@@ -114,19 +103,33 @@ end Maximal
 
 section Tower
 
-variable {A R B : Type*} [CommRing A] [CommRing R] [CommRing B]
-  [Algebra A R] [Algebra R B] [Algebra A B] [IsScalarTower A R B]
-  (p : Ideal A) (𝓟 : Ideal R) [p.IsPrime] [𝓟.IsPrime] [𝓟.LiesOver p]
+variable {A B C : Type*} [CommRing A] [CommRing B] [CommRing C]
+  [Algebra A B] [Algebra B C] [Algebra A C] [IsScalarTower A B C]
+  (p : Ideal A) [p.IsPrime]
 
-/-- For a tower of rings `B/R/A` and a prime `𝓟` of `R` lying over `p`, separability of the
-residue field extensions of `B/A` above `p` gives separability of those of `B/R` above `𝓟`. -/
-theorem HasSeparableResidueFieldsAt.tower_top [HasSeparableResidueFieldsAt A B p] :
-    HasSeparableResidueFieldsAt R B 𝓟 where
-  isSeparable' P _ _ :=
-    haveI : P.LiesOver p := Ideal.LiesOver.trans P 𝓟 p
-    letI := Localization.AtPrime.algebraOfLiesOver p 𝓟
-    letI := Localization.AtPrime.algebraOfLiesOver p P
-    letI := Localization.AtPrime.algebraOfLiesOver 𝓟 P
+/-- For a tower of rings `C/B/A`, separability of the residue field extensions of `C/A` above `p`
+gives separability of those of `B/A` above `p`. -/
+theorem HasSeparableResidueFieldsAt.tower_bot [Algebra.IsIntegral B C] [FaithfulSMul B C]
+    [HasSeparableResidueFieldsAt A C p] : HasSeparableResidueFieldsAt A B p where
+  isSeparable' q _ _ := by
+    obtain ⟨r, _, _⟩ : Nonempty (q.primesOver C) := nonempty_primesOver q
+    have : r.LiesOver p := Ideal.LiesOver.trans r q p
+    let := Localization.AtPrime.algebraOfLiesOver p q
+    let := Localization.AtPrime.algebraOfLiesOver p r
+    let := Localization.AtPrime.algebraOfLiesOver q r
+    exact isSeparable_tower_bot_of_isSeparable p.ResidueField q.ResidueField r.ResidueField
+
+variable (q : Ideal B) [q.IsPrime] [q.LiesOver p]
+
+/-- For a tower of rings `C/B/A` and a prime `q` of `B` lying over `p`, separability of the
+residue field extensions of `C/A` above `p` gives separability of those of `C/B` above `q`. -/
+theorem HasSeparableResidueFieldsAt.tower_top [HasSeparableResidueFieldsAt A C p] :
+    HasSeparableResidueFieldsAt B C q where
+  isSeparable' r _ _ :=
+    haveI : r.LiesOver p := Ideal.LiesOver.trans r q p
+    letI := Localization.AtPrime.algebraOfLiesOver p q
+    letI := Localization.AtPrime.algebraOfLiesOver p r
+    letI := Localization.AtPrime.algebraOfLiesOver q r
     isSeparable_tower_top_of_isSeparable p.ResidueField _ _
 
 end Tower

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Separable.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Separable.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 Xavier Roblot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Roblot
+-/
+module
+
+public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Basic
+public import Mathlib.RingTheory.LocalRing.ResidueField.Instances
+
+/-!
+# Separable residue field extensions
+
+For a prime `p` of `A`, we introduce a predicate stating that the residue field extensions
+`κ(P)/κ(p)` are separable for every prime `P` of `B` lying over `p`.
+
+## Main definitions
+
+* `Algebra.HasSeparableResidueFieldsAt A B p`: the residue field extension `κ(P)/κ(p)` is
+  separable for every prime `P` of `B` lying over `p`.
+
+## Main results
+
+* instances deducing `Algebra.HasSeparableResidueFieldsAt` when the residue field `κ(p)` is
+  perfect, when the quotient `A ⧸ p` is finite, and when `A` has finite quotients and `p` is
+  nonzero;
+* `Algebra.HasSeparableResidueFieldsAt.isSeparable_quotient`: at a maximal prime, the predicate
+  also gives the separability of the extensions of quotient rings;
+* `Algebra.HasSeparableResidueFieldsAt.tower_top`: the predicate passes to an intermediate ring.
+
+## Implementation notes
+
+The condition is stated on the residue fields rather than on the quotient rings `(B ⧸ P)/(A ⧸ p)`
+since the quotients are fields only when the primes are maximal, in which case they are canonically
+isomorphic to the residue fields. This is why
+`Algebra.HasSeparableResidueFieldsAt.isSeparable_quotient` assumes that `p` and `P` are maximal,
+whereas the definition itself works at an arbitrary prime.
+
+The field `Algebra.HasSeparableResidueFieldsAt.isSeparable'` fixes one algebra structure on the
+localizations, namely `Localization.AtPrime.algebraOfLiesOver`, so that proving the predicate
+involves a single choice. The instance `Algebra.HasSeparableResidueFieldsAt.isSeparable`, which is
+the one consumers use, then generalises it to an arbitrary compatible structure; the genericity is
+paid for once, there, rather than in the definition.
+-/
+
+@[expose] public section
+
+open Ideal
+
+namespace Algebra
+
+section
+
+variable (A B : Type*) [CommRing A] [CommRing B] [Algebra A B] (p : Ideal A) [p.IsPrime]
+
+/-- `Algebra.HasSeparableResidueFieldsAt A B p` states that for every prime `P` of `B` lying over
+`p`, the residue field extension `κ(P)/κ(p)` is separable. -/
+class HasSeparableResidueFieldsAt : Prop where
+  isSeparable' (P : Ideal B) [P.IsPrime] [P.LiesOver p] :
+    letI := Localization.AtPrime.algebraOfLiesOver p P
+    Algebra.IsSeparable p.ResidueField P.ResidueField
+
+variable {A B p} in
+/-- `Algebra.HasSeparableResidueFieldsAt` gives the separability for any compatible choice of the
+algebra structure on the localizations. -/
+instance HasSeparableResidueFieldsAt.isSeparable (P : Ideal B) [P.IsPrime] [P.LiesOver p]
+    [HasSeparableResidueFieldsAt A B p]
+    [alg : Algebra (Localization.AtPrime p) (Localization.AtPrime P)]
+    [IsScalarTower A (Localization.AtPrime p) (Localization.AtPrime P)] :
+    Algebra.IsSeparable p.ResidueField P.ResidueField :=
+  have : alg = Localization.AtPrime.algebraOfLiesOver p P :=
+    Algebra.algebra_ext _ _ fun _ ↦ by rw [Localization.AtPrime.algebraMap_eq]; rfl
+  this ▸ HasSeparableResidueFieldsAt.isSeparable' P
+
+variable [Algebra.IsIntegral A B]
+
+/-- If the residue field `κ(p)` is perfect, the residue field extensions above `p` are separable. -/
+instance [PerfectField p.ResidueField] : HasSeparableResidueFieldsAt A B p where
+  isSeparable' P _ _ :=
+    letI := Localization.AtPrime.algebraOfLiesOver p P
+    IsAlgebraic.isSeparable_of_perfectField
+
+/-- If the quotient `A ⧸ p` is finite, the residue field extensions above `p` are separable. -/
+instance [Finite (A ⧸ p)] : HasSeparableResidueFieldsAt A B p where
+  isSeparable' P _ _ :=
+    haveI : p.IsMaximal := Ideal.Quotient.maximal_of_isField p (Finite.isField_of_domain _)
+    haveI : P.IsMaximal := IsMaximal.of_liesOver_isMaximal P p
+    letI := Localization.AtPrime.algebraOfLiesOver p P
+    instIsSeparableResidueFieldOfQuotientIdeal p P
+
+/-- If `A` has finite quotients, the residue field extensions above a nonzero prime of `A` are
+separable. -/
+instance [NeZero p] [Ring.HasFiniteQuotients A] : HasSeparableResidueFieldsAt A B p :=
+  haveI : Finite (A ⧸ p) := Ring.HasFiniteQuotients.finiteQuotient (NeZero.ne p)
+  inferInstance
+
+end
+
+section Maximal
+
+variable {A B : Type*} [CommRing A] [CommRing B] [Algebra A B] (p : Ideal A) [p.IsMaximal]
+
+/-- At a maximal prime `p`, `Algebra.HasSeparableResidueFieldsAt` also gives the separability of
+the extension of quotient rings `(B ⧸ P)/(A ⧸ p)` for every maximal ideal `P` of `B` lying over
+`p`. Maximality is needed for the quotient rings to be fields; they are then canonically
+isomorphic to the residue fields. -/
+instance HasSeparableResidueFieldsAt.isSeparable_quotient [HasSeparableResidueFieldsAt A B p]
+    (P : Ideal B) [P.IsMaximal] [P.LiesOver p] :
+    Algebra.IsSeparable (A ⧸ p) (B ⧸ P) :=
+  letI := Localization.AtPrime.algebraOfLiesOver p P
+  Algebra.isSeparable_residueField_iff.mp (HasSeparableResidueFieldsAt.isSeparable' P)
+
+end Maximal
+
+section Tower
+
+variable {A R B : Type*} [CommRing A] [CommRing R] [CommRing B]
+  [Algebra A R] [Algebra R B] [Algebra A B] [IsScalarTower A R B]
+  (p : Ideal A) (𝓟 : Ideal R) [p.IsPrime] [𝓟.IsPrime] [𝓟.LiesOver p]
+
+/-- For a tower of rings `B/R/A` and a prime `𝓟` of `R` lying over `p`, separability of the
+residue field extensions of `B/A` above `p` gives separability of those of `B/R` above `𝓟`. -/
+theorem HasSeparableResidueFieldsAt.tower_top [HasSeparableResidueFieldsAt A B p] :
+    HasSeparableResidueFieldsAt R B 𝓟 where
+  isSeparable' P _ _ :=
+    haveI : P.LiesOver p := Ideal.LiesOver.trans P 𝓟 p
+    letI := Localization.AtPrime.algebraOfLiesOver p 𝓟
+    letI := Localization.AtPrime.algebraOfLiesOver p P
+    letI := Localization.AtPrime.algebraOfLiesOver 𝓟 P
+    isSeparable_tower_top_of_isSeparable p.ResidueField _ _
+
+end Tower
+
+end Algebra

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Separable.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Separable.lean
@@ -5,14 +5,16 @@ Authors: Xavier Roblot
 -/
 module
 
-public import Mathlib.RingTheory.Ideal.Quotient.HasFiniteQuotients.Basic
+public import Mathlib.FieldTheory.Perfect
+public import Mathlib.RingTheory.Ideal.GoingUp
 public import Mathlib.RingTheory.LocalRing.ResidueField.Instances
 
 /-!
 # Separable residue field extensions
 
 For a prime `p` of `A`, we introduce a predicate stating that the residue field extensions
-`κ(q)/κ(p)` are separable for every prime `q` of `B` lying over `p`.
+`κ(q)/κ(p)` are separable for every prime `q` of `B` lying over `p`. It holds automatically when
+`κ(p)` is finite, and so at any nonzero prime of a ring with finite quotients.
 
 ## Main definitions
 
@@ -21,8 +23,8 @@ For a prime `p` of `A`, we introduce a predicate stating that the residue field 
 
 ## Main results
 
-* instances deducing `Algebra.HasSeparableResidueFieldsAt` when the residue field `κ(p)` is
-  perfect, and when `A` has finite quotients and `p` is nonzero;
+* an instance deducing `Algebra.HasSeparableResidueFieldsAt` when the residue field `κ(p)` is
+  perfect;
 * `Algebra.HasSeparableResidueFieldsAt.isSeparable_quotient`: at a maximal prime, the predicate
   also gives the separability of the extensions of quotient rings;
 * `Algebra.HasSeparableResidueFieldsAt.tower_top` and
@@ -66,22 +68,15 @@ instance HasSeparableResidueFieldsAt.isSeparable (q : Ideal B) [q.IsPrime] [q.Li
     [IsScalarTower A (Localization.AtPrime p) (Localization.AtPrime q)] :
     Algebra.IsSeparable p.ResidueField q.ResidueField :=
   have : alg = Localization.AtPrime.algebraOfLiesOver p q :=
-    Algebra.algebra_ext _ _ fun _ ↦ by rw [Localization.AtPrime.algebraMap_eq]; rfl
+    Algebra.algebra_ext _ _ <| RingHom.ext_iff.mp (Localization.AtPrime.algebraMap_eq p q)
   this ▸ HasSeparableResidueFieldsAt.isSeparable' q
 
-variable [Algebra.IsIntegral A B]
-
 /-- If the residue field `κ(p)` is perfect, the residue field extensions above `p` are separable. -/
-instance [PerfectField p.ResidueField] : HasSeparableResidueFieldsAt A B p where
+instance [Algebra.IsIntegral A B] [PerfectField p.ResidueField] :
+    HasSeparableResidueFieldsAt A B p where
   isSeparable' q _ _ :=
-    letI := Localization.AtPrime.algebraOfLiesOver p q
+    let := Localization.AtPrime.algebraOfLiesOver p q
     IsAlgebraic.isSeparable_of_perfectField
-
-/-- If `A` has finite quotients, the residue field extensions above a nonzero prime of `A` are
-separable. -/
-instance [NeZero p] [Ring.HasFiniteQuotients A] : HasSeparableResidueFieldsAt A B p :=
-  have : Finite (A ⧸ p) := Ring.HasFiniteQuotients.finiteQuotient (NeZero.ne p)
-  inferInstance
 
 end Prime
 
@@ -127,9 +122,9 @@ theorem HasSeparableResidueFieldsAt.tower_top [HasSeparableResidueFieldsAt A C p
     HasSeparableResidueFieldsAt B C q where
   isSeparable' r _ _ :=
     have : r.LiesOver p := Ideal.LiesOver.trans r q p
-    letI := Localization.AtPrime.algebraOfLiesOver p q
-    letI := Localization.AtPrime.algebraOfLiesOver p r
-    letI := Localization.AtPrime.algebraOfLiesOver q r
+    let := Localization.AtPrime.algebraOfLiesOver p q
+    let := Localization.AtPrime.algebraOfLiesOver p r
+    let := Localization.AtPrime.algebraOfLiesOver q r
     isSeparable_tower_top_of_isSeparable p.ResidueField _ _
 
 end Tower


### PR DESCRIPTION
This adds `Algebra.HasSeparableResidueFieldsAt A B p`, stating that the residue field extension `κ(P)/κ(p)` is separable for every prime `P` of `B` lying over a prime `p` of `A`, along with instances deducing it when `κ(p)` is perfect, when `A ⧸ p` is finite, and when `A` has finite quotients and `p` is nonzero.

See the [Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Typeclass.20for.20separable.20residue.20fields/with/621304948) for the design.

Prepared with Claude Code 🤖

---
