### PR TITLE
chore: mark local tactics as `local` so they don't pollute the tactic documentation

### DIFF
--- a/Archive/Imo/Imo2001Q5.lean
+++ b/Archive/Imo/Imo2001Q5.lean
@@ -144,7 +144,7 @@ lemma AQB_eq : ∠ s.A s.Q s.B = 2 * π / 3 - s.x := by
   grind
 
 /-- A macro for applying the bounds on `x`, `x_pos` and `x_lt_pi_div_three`. -/
-macro (name := bx) "bx" : tactic => `(tactic| linarith [s.x_pos, s.x_lt_pi_div_three])
+local macro (name := bx) "bx" : tactic => `(tactic| linarith [s.x_pos, s.x_lt_pi_div_three])
 
 /-! ### Trigonometric reduction using the law of sines -/
 

--- a/Counterexamples/ZeroDivisorsInAddMonoidAlgebras.lean
+++ b/Counterexamples/ZeroDivisorsInAddMonoidAlgebras.lean
@@ -153,7 +153,7 @@ instance : One F :=
   ⟨F.one⟩
 
 /-- A tactic to prove trivial goals by enumeration. -/
-macro "boom" : tactic => `(tactic| (repeat' rintro ⟨⟩) <;> decide)
+local macro "boom" : tactic => `(tactic| (repeat' rintro ⟨⟩) <;> decide)
 
 /-- `val` maps `0 1 : F` to their counterparts in `ℕ`.
 We use it to lift the linear order on `ℕ`. -/

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -256,7 +256,7 @@ open Lean
 * `y ^ n` where `i = n • j` and `y ∈ 𝒜 j`.
 * a natural number `n`.
 -/
-macro "mem_tac" : tactic =>
+local macro "mem_tac" : tactic =>
   `(tactic| first | exact pow_mem_graded _ (SetLike.coe_mem _) | exact natCast_mem_graded _ _ |
     exact pow_mem_graded _ f_deg)
 

--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -72,7 +72,7 @@ variable (F G : ComposableArrows C n)
 
 -- We do not yet replace `omega` with `lia` here, as it is measurably slower.
 /-- A wrapper for `omega` which prefaces it with some quick and useful attempts -/
-local macro "valid" : tactic =>
+macro "valid" : tactic =>
   `(tactic| first | assumption | apply zero_le | apply le_rfl | transitivity <;> assumption | omega)
 
 /-- The `i`th object (with `i : ℕ` such that `i ≤ n`) of `F : ComposableArrows C n`. -/

--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -72,7 +72,7 @@ variable (F G : ComposableArrows C n)
 
 -- We do not yet replace `omega` with `lia` here, as it is measurably slower.
 /-- A wrapper for `omega` which prefaces it with some quick and useful attempts -/
-macro "valid" : tactic =>
+local macro "valid" : tactic =>
   `(tactic| first | assumption | apply zero_le | apply le_rfl | transitivity <;> assumption | omega)
 
 /-- The `i`th object (with `i : ℕ` such that `i ≤ n`) of `F : ComposableArrows C n`. -/

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -253,7 +253,7 @@ lemma two_pow_and (n i : ℕ) : 2 ^ i &&& n = 2 ^ i * (n.testBit i).toNat := by
 
 /-- Proving associativity of bitwise operations in general essentially boils down to a huge case
     distinction, so it is shorter to use this tactic instead of proving it in the general case. -/
-macro "bitwise_assoc_tac" : tactic => set_option hygiene false in `(tactic| (
+local macro "bitwise_assoc_tac" : tactic => set_option hygiene false in `(tactic| (
   induction n using Nat.binaryRec generalizing m k with | zero => simp | bit b n hn => ?_
   induction m using Nat.binaryRec with | zero => simp | bit b' m hm => ?_
   induction k using Nat.binaryRec <;>

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -234,10 +234,8 @@ def toFractionRingRingEquiv : K⟮X⟯ ≃+* FractionRing K[X] where
 
 end Field
 
-section TacticInterlude
-
 /-- Solve equations for `K⟮X⟯` by working in `FractionRing K[X]`. -/
-macro "frac_tac" : tactic => `(tactic|
+local macro "frac_tac" : tactic => `(tactic|
   · repeat (rintro (⟨⟩ : _⟮X⟯))
     try simp only [← ofFractionRing_zero, ← ofFractionRing_add, ← ofFractionRing_sub,
       ← ofFractionRing_neg, ← ofFractionRing_one, ← ofFractionRing_mul, ← ofFractionRing_div,
@@ -247,7 +245,7 @@ macro "frac_tac" : tactic => `(tactic|
       add_mul, zero_mul, one_mul, neg_mul, mul_neg, add_neg_cancel])
 
 /-- Solve equations for `K⟮X⟯` by applying `RatFunc.induction_on`. -/
-macro "smul_tac" : tactic => `(tactic|
+local macro "smul_tac" : tactic => `(tactic|
     repeat
       (first
         | rintro (⟨⟩ : _⟮X⟯)
@@ -259,8 +257,6 @@ macro "smul_tac" : tactic => `(tactic|
       Int.cast_negSucc, Int.cast_natCast, Nat.cast_succ,
       Localization.mk_zero, Localization.add_mk_self, Localization.neg_mk,
       ofFractionRing_zero, ← ofFractionRing_add, ← ofFractionRing_neg])
-
-end TacticInterlude
 
 section CommRing
 

--- a/Mathlib/RingTheory/WittVector/Basic.lean
+++ b/Mathlib/RingTheory/WittVector/Basic.lean
@@ -78,7 +78,7 @@ theorem surjective (f : α → β) (hf : Surjective f) : Surjective (mapFun f : 
     by ext n; simp only [mapFun, coeff_mk, comp_apply, Classical.choose_spec (hf (x.coeff n))]⟩
 
 /-- Auxiliary tactic for showing that `mapFun` respects the ring operations. -/
-macro "map_fun_tac" : tactic => `(tactic| (
+local macro "map_fun_tac" : tactic => `(tactic| (
   -- TODO: the Lean 3 version of this tactic was more functional
   ext n
   simp only [mapFun, mk, comp_apply, zero_coeff, map_zero,

--- a/Mathlib/RingTheory/WittVector/Truncated.lean
+++ b/Mathlib/RingTheory/WittVector/Truncated.lean
@@ -195,7 +195,7 @@ theorem coeff_zero (i : Fin n) : (0 : TruncatedWittVector p n R).coeff i = 0 := 
 end TruncatedWittVector
 
 /-- A macro tactic used to prove that `truncateFun` respects ring operations. -/
-macro (name := witt_truncateFun_tac) "witt_truncateFun_tac" : tactic =>
+local macro (name := witt_truncateFun_tac) "witt_truncateFun_tac" : tactic =>
   `(tactic|
     { change _ = WittVector.truncateFun n _
       apply TruncatedWittVector.out_injective


### PR DESCRIPTION
The tactic documentation is a very crowded place. This PR helps that by marking some tactics as `local`.

Other tactics could be removed from it by marking them with `@[tactic_alt]`.

Note: there is a tactic called `valid` that can't be made local because it is used in autoParams. It should probably be renamed instead.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
