### PR TITLE
feat: lattice lemmas about `Submodule.toAffineSubspace`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -224,6 +224,19 @@ instance : Coe (Submodule k V) (AffineSubspace k V) := ⟨toAffineSubspace⟩
 theorem mem_toAffineSubspace {p : Submodule k V} {x : V} :
     x ∈ (p : AffineSubspace k V) ↔ x ∈ p := Iff.rfl
 
+@[simp]
+theorem coe_toAffineSubspace (p : Submodule k V) : ((p : AffineSubspace k V) : Set V) = p :=
+  rfl
+
+@[simp]
+theorem toAffineSubspace_le_toAffineSubspace {p q : Submodule k V} :
+    p.toAffineSubspace ≤ q.toAffineSubspace ↔ p ≤ q :=
+  .rfl
+
+@[gcongr]
+theorem monotone_toAffineSubspace : Monotone ((↑) : Submodule k V → AffineSubspace k V) :=
+  fun _ _ => toAffineSubspace_le_toAffineSubspace.mpr
+
 end Submodule
 
 namespace AffineSubspace
@@ -1156,3 +1169,45 @@ lemma affineSpan_insert_zero (s : Set V) :
   exact subset_sub_left <| mem_insert ..
 
 end AffineSpace'
+
+namespace Submodule
+
+variable {k V : Type*} [Ring k] [AddCommGroup V] [Module k V]
+
+@[simp]
+theorem toAffineSubspace_top : ((⊤ : Submodule k V) : AffineSubspace k V) = ⊤ :=
+  rfl
+
+@[simp]
+theorem toAffineSubspace_bot : ((⊥ : Submodule k V) : AffineSubspace k V) = {0} :=
+  rfl
+
+theorem toAffineSubspace_inf (p q : Submodule k V) :
+    (p ⊓ q : Submodule k V) = (p ⊓ q : AffineSubspace k V) :=
+  rfl
+
+theorem toAffineSubspace_sInf (s : Set (Submodule k V)) :
+    sInf s = ⨅ p ∈ s, (p : AffineSubspace k V) :=
+  SetLike.coe_injective <| by simp
+
+theorem toAffineSubspace_iInf {ι : Type*} (p : ι → Submodule k V) :
+    ⨅ i, p i = ⨅ i, (p i : AffineSubspace k V) :=
+  SetLike.coe_injective <| by simp
+
+theorem toAffineSubspace_sSup {s : Set (Submodule k V)} (hs : s.Nonempty) :
+    sSup s = ⨆ p ∈ s, (p : AffineSubspace k V) := by
+  refine le_antisymm (le_of_forall_ge fun q hq => ?_) monotone_toAffineSubspace.le_map_sSup
+  rw [iSup₂_le_iff] at hq
+  obtain ⟨p, hp⟩ := hs
+  lift q to Submodule k V using hq p hp p.zero_mem
+  simpa using hq
+
+theorem toAffineSubspace_iSup {ι : Type*} [Nonempty ι] (p : ι → Submodule k V) :
+    ⨆ i, p i = ⨆ i, (p i : AffineSubspace k V) := by
+  rw [← sSup_range, toAffineSubspace_sSup (range_nonempty _), iSup_range]
+
+theorem toAffineSubspace_sup (p q : Submodule k V) :
+    (p ⊔ q : Submodule k V) = (p ⊔ q : AffineSubspace k V) := by
+  simp_rw [sup_eq_iSup, toAffineSubspace_iSup, Bool.apply_cond]
+
+end Submodule


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
