### PR TITLE
chore(AlgebraicGeometry): refactor and clean up AffineTransitionLimit.lean

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -155,6 +155,15 @@ lemma ext_of_isAffine {X Y : Scheme} [IsAffine Y] {f g : X ⟶ Y} (e : f.appTop 
     f = g := by
   rw [← cancel_mono Y.toSpecΓ, Scheme.toSpecΓ_naturality, Scheme.toSpecΓ_naturality, e]
 
+lemma exists_appTop_eq_of_isAffine {X Y : Scheme} [IsAffine Y] (φ : Γ(Y, ⊤) ⟶ Γ(X, ⊤)) :
+    ∃ f : X ⟶ Y, f.appTop = φ := by
+  have h : Y.isoSpec.inv.appTop = (Scheme.ΓSpecIso Γ(Y, ⊤)).inv := by
+    rw [← cancel_epi (Scheme.ΓSpecIso Γ(Y, ⊤)).hom, Iso.hom_inv_id, ← Scheme.toSpecΓ_appTop,
+      ← Scheme.Hom.comp_appTop, Scheme.isoSpec_inv_toSpecΓ, Scheme.Hom.id_appTop]
+  refine ⟨X.toSpecΓ ≫ Spec.map φ ≫ Y.isoSpec.inv, ?_⟩
+  rw [Scheme.Hom.comp_appTop, Scheme.Hom.comp_appTop, h, Scheme.toSpecΓ_appTop, Category.assoc,
+    Scheme.ΓSpecIso_naturality, Iso.inv_hom_id_assoc]
+
 instance (P : MorphismProperty Scheme.{u}) {S : Scheme.{u}} (𝒰 : S.AffineCover P) (i : 𝒰.I₀) :
     IsAffine (𝒰.cover.X i) :=
   inferInstanceAs <| IsAffine (Spec _)
@@ -309,6 +318,15 @@ theorem Scheme.isBasis_affineOpens (X : Scheme) : Opens.IsBasis X.affineOpens :=
   refine ⟨⟨S, X.affineBasisCover_is_basis.isOpen hS⟩, ?_, hxS, hSU⟩
   rcases hS with ⟨i, rfl⟩
   exact isAffineOpen_opensRange _
+
+theorem Scheme.isBasis_affineOpens_le_preimage {X Y : Scheme} (f : X ⟶ Y) {S : Set Y.Opens}
+    (hS : Opens.IsBasis S) :
+    Opens.IsBasis {U : X.Opens | IsAffineOpen U ∧ ∃ V ∈ S, U ≤ f ⁻¹ᵁ V} := by
+  refine Opens.isBasis_iff_nbhd.mpr fun {O x} hx ↦ ?_
+  obtain ⟨V, hV, hxV, -⟩ := Opens.isBasis_iff_nbhd.mp hS (U := ⊤) (x := f x) trivial
+  obtain ⟨U, hU, hxU, hUV⟩ := Opens.isBasis_iff_nbhd.mp X.isBasis_affineOpens
+    (U := O ⊓ f ⁻¹ᵁ V) (x := x) ⟨hx, hxV⟩
+  exact ⟨U, ⟨hU, V, hV, hUV.trans inf_le_right⟩, hxU, hUV.trans inf_le_left⟩
 
 theorem iSup_affineOpens_eq_top (X : Scheme) : ⨆ i : X.affineOpens, (i : X.Opens) = ⊤ := by
   apply Opens.ext

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -780,31 +780,26 @@ include hc in
 lemma exists_app_map_eq_zero_of_isLimit {i : I} {U : (D.obj i).Opens}
     (hU : IsCompact (X := D.obj i) U) (s : Γ(D.obj i, U)) (hs : (c.π.app i).app U s = 0) :
     ∃ (j : I) (f : j ⟶ i), (D.map f).app U s = 0 := by
-  have h0 {V : (D.obj i).Opens} (hV : V ≤ U) {V' : c.pt.Opens} (e : V' ≤ c.π.app i ⁻¹ᵁ V) :
-      (c.π.app i).appLE V V' e (s |_ V) = 0 := by
-    rw [Scheme.Hom.appLE_restrict _ hV, Scheme.Hom.appLE, ConcreteCategory.comp_apply, hs,
-      map_zero]
+  have h0 {V : c.pt.Opens} (e : V ≤ c.π.app i ⁻¹ᵁ U) : (c.π.app i).appLE U V e s = 0 := by
+    rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply, hs, map_zero]
   have key {W : (D.obj i).Opens} (hW : IsAffineOpen W) (hWU : W ≤ U) :
-      ∃ (j : I) (f : j ⟶ i), (D.map f).app W (s |_ W) = 0 := by
+      ∃ (j : I) (f : j ⟶ i),
+        (D.map f).appLE U (D.map f ⁻¹ᵁ W) ((D.map f).preimage_mono hWU) s = 0 := by
     have (j : Over i) : IsAffine ((opensDiagram D i W).obj j) := hW.preimage (D.map _)
     have hle : D.map (𝟙 i) ⁻¹ᵁ W ≤ U := by simpa using hWU
-    obtain ⟨j, v, hv⟩ := exists_appTop_map_eq_zero_of_isAffine_of_isLimit _ _
-      (isLimitOpensCone D c hc i W) (.mk (𝟙 i))
-      ((D.map (𝟙 i) ⁻¹ᵁ W).topIso.inv (TopCat.Presheaf.restrictOpen s _ hle)) (by
-        change ((c.π.app i).resLE (D.map (𝟙 i) ⁻¹ᵁ W) (c.π.app i ⁻¹ᵁ W) (by simp)).appTop _ = 0
-        simp only [Scheme.Hom.appTop, Scheme.Hom.resLE_app_top, ConcreteCategory.comp_apply,
-          Iso.inv_hom_id_apply, h0, map_zero])
+    obtain ⟨j, v, hv⟩ : ∃ (j : Over i) (v : j ⟶ .mk (𝟙 i)),
+        ((D.map v.left).resLE (D.map (𝟙 i) ⁻¹ᵁ W) (D.map j.hom ⁻¹ᵁ W)
+            (by simp [← Over.w v])).appTop
+          ((D.map (𝟙 i) ⁻¹ᵁ W).topIso.inv (TopCat.Presheaf.restrictOpen s _ hle)) = 0 :=
+      exists_appTop_map_eq_zero_of_isAffine_of_isLimit _ _ (isLimitOpensCone D c hc i W)
+        (.mk (𝟙 i)) _ (by
+          change ((c.π.app i).resLE (D.map (𝟙 i) ⁻¹ᵁ W) (c.π.app i ⁻¹ᵁ W) (by simp)).appTop _ = 0
+          simp only [Scheme.Hom.resLE_appTop_apply, Iso.inv_hom_id_apply,
+            Scheme.Hom.appLE_restrict, h0, map_zero])
     have hv' : v.left = j.hom := by simpa using Over.w v
-    replace hv : ((D.map v.left).resLE (D.map (𝟙 i) ⁻¹ᵁ W) (D.map j.hom ⁻¹ᵁ W)
-        (by rw [hv']; simp)).appTop
-        ((D.map (𝟙 i) ⁻¹ᵁ W).topIso.inv (TopCat.Presheaf.restrictOpen s _ hle)) = 0 := hv
-    replace hv := congr((D.map j.hom ⁻¹ᵁ W).topIso.hom $hv)
-    simp only [Scheme.Hom.appTop, Scheme.Hom.resLE_app_top, ConcreteCategory.comp_apply,
-      Iso.inv_hom_id_apply, map_zero, hv'] at hv
-    refine ⟨j.left, j.hom, ?_⟩
-    simpa only [Scheme.Hom.app_eq_appLE, TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict,
-      ← ConcreteCategory.comp_apply, Category.assoc, Iso.inv_hom_id_assoc,
-      Scheme.Hom.map_appLE] using hv
+    exact ⟨j.left, j.hom, by
+      simpa only [Scheme.Hom.resLE_appTop_apply, Iso.inv_hom_id_apply, hv',
+        Scheme.Hom.appLE_restrict, map_zero] using congr((D.map j.hom ⁻¹ᵁ W).topIso.hom $hv)⟩
   obtain ⟨Us, hUs, hUsf, hsup⟩ := (D.obj i).isBasis_affineOpens.exists_finite_of_isCompact hU
   have : Finite Us := hUsf
   have hle (W : Us) : (W : (D.obj i).Opens) ≤ U := (le_sSup W.2).trans hsup.ge
@@ -814,14 +809,10 @@ lemma exists_app_map_eq_zero_of_isLimit {i : I} {U : (D.obj i).Opens}
     (fun W : Us ↦ D.map v ⁻¹ᵁ (W : (D.obj i).Opens)) _
     (fun W ↦ homOfLE ((D.map v).preimage_mono (hle W))) ?_ _ _ fun W ↦ ?_⟩
   · rw [hsup, sSup_eq_iSup', Scheme.Hom.preimage_iSup]
-  · have h₂ : D.map v ⁻¹ᵁ (W : (D.obj i).Opens) ≤
-        D.map (w W) ⁻¹ᵁ D.map (u W) ⁻¹ᵁ (W : (D.obj i).Opens) := by
-      rw [← Scheme.Hom.comp_preimage, ← D.map_comp, hw W]
-    convert! congr((D.map (w W)).appLE _ _ h₂ $(H W))
-    · dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-      simp [Scheme.Hom.app_eq_appLE, ← ConcreteCategory.comp_apply, -CommRingCat.hom_comp,
-        Scheme.Hom.appLE_comp_appLE, ← Functor.map_comp, hw W]
-    · simp
+  · have h := congr((D.map (w W)).appLE _ (D.map v ⁻¹ᵁ (W : (D.obj i).Opens))
+      (by rw [← Scheme.Hom.comp_preimage, ← D.map_comp, hw W]) $(H W))
+    simp only [Scheme.Hom.appLE_appLE, ← Functor.map_comp, hw W, map_zero] at h
+    exact h.trans (map_zero _).symm
 
 include hc in
 lemma exists_appTop_map_eq_zero_of_isLimit {i : I} [CompactSpace (D.obj i)] (s : Γ(D.obj i, ⊤))

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -64,23 +64,20 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
       let g (j) := IsCofiltered.infTo (insert i (Finset.univ.image i'))
         (Finset.univ.image fun j : 𝒰.I₀ ↦ ⟨_, _, by simp, by simp, f j⟩) (X := j)
       have (j : 𝒰.I₀) : IsEmpty ((𝒰.pullback₁ (D.map (g i (by simp)))).X j) := by
-        let F : (𝒰.pullback₁ (D.map (g i (by simp)))).X j ⟶
-            (𝒰.pullback₁ (D.map (f j))).X j :=
+        let F : (𝒰.pullback₁ (D.map (g i (by simp)))).X j ⟶ (𝒰.pullback₁ (D.map (f j))).X j :=
           pullback.map _ _ _ _ (D.map (g _ (by simp))) (𝟙 _) (𝟙 _) (by
             rw [← D.map_comp, IsCofiltered.infTo_commutes]
             · simp [g]
             · simp
             · exact Finset.mem_image_of_mem _ (Finset.mem_univ _)) (by simp)
         exact Function.isEmpty F
-      obtain ⟨x, -⟩ :=
-        Cover.covers (𝒰.pullback₁ (D.map (g i (by simp)))) (Nonempty.some inferInstance)
-      exact (this _).elim x
+      exact (this _).elim (Cover.covers (𝒰.pullback₁ (D.map (g i (by simp))))
+        (Nonempty.some inferInstance)).choose
     let F := Over.post D ⋙ Over.pullback (𝒰.f j) ⋙ Over.forget _
-    have (i' : _) : IsAffine (F.obj i') :=
-      inferInstanceAs (IsAffine (pullback (D.map i'.hom) (𝒰.f j)))
+    have (k : _) : IsAffine (F.obj k) := inferInstanceAs (IsAffine (pullback (D.map k.hom) (𝒰.f j)))
     have hFne (i' : _) : Nonempty (F.obj i') := H i'.hom
     let e : F ⟶ (F ⋙ Γ.rightOp) ⋙ Scheme.Spec := Functor.whiskerLeft F ΓSpec.adjunction.unit
-    have (i : _) : IsIso (e.app i) := IsAffine.affine
+    have (k : _) : IsIso (e.app k) := IsAffine.affine
     have : IsIso e := NatIso.isIso_of_isIso_app e
     let c' : LimitCone F := ⟨_, (IsLimit.postcomposeInvEquiv (asIso e) _).symm
       (isLimitOfPreserves Scheme.Spec (limit.isLimit (F ⋙ Γ.rightOp)))⟩
@@ -94,7 +91,7 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
     let α : F ⟶ Over.forget _ ⋙ D := Functor.whiskerRight
       (Functor.whiskerLeft (Over.post D) (Over.mapPullbackAdj (𝒰.f j)).counit) (Over.forget _)
     exact this.map (((Functor.Initial.isLimitWhiskerEquiv (Over.forget i) c).symm hc).lift
-        ((Cone.postcompose α).obj c'.1))
+      ((Cone.postcompose α).obj c'.1))
 
 include hc in
 open Scheme.IdealSheafData in
@@ -407,21 +404,16 @@ private nonrec lemma Scheme.exists_hom_hom_comp_eq_comp_of_isAffine_of_locallyOf
   · let e : D ⟶ D ⋙ Γ.rightOp ⋙ Scheme.Spec := D.whiskerLeft ΓSpec.adjunction.unit
     have inst (i) : IsIso (e.app i) := by dsimp [e]; infer_instance
     have inst : IsIso e := NatIso.isIso_of_isIso_app e
-    have inst (i) : IsAffine ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj i) := by
-      dsimp; infer_instance
-    have inst : IsAffine ((Cone.postcompose (asIso e).hom).obj c).pt := by
-      dsimp; infer_instance
+    have inst (i) : IsAffine ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj i) := by dsimp; infer_instance
+    have inst : IsAffine ((Cone.postcompose (asIso e).hom).obj c).pt := by dsimp; infer_instance
     have := this (D ⋙ Γ.rightOp ⋙ Scheme.Spec) ((Cone.postcompose (asIso e).hom).obj c)
       ((IsLimit.postcomposeHomEquiv (asIso e) c).symm hc) (inv e ≫ t)
       ((inv e).app _ ≫ a) ((inv e).app _ ≫ b)
       (by simp only [Cone.postcompose_obj_π, NatTrans.comp_app, NatIso.isIso_inv_app,
-            Category.assoc, IsIso.hom_inv_id_assoc, asIso_hom]
-          exact hab)
-      (by simp [ha]) (by simp [hb])
-      ⟨D ⋙ Γ.rightOp, rfl⟩
-    simp_rw [(inv e).naturality_assoc] at this
+        Category.assoc, IsIso.hom_inv_id_assoc, asIso_hom]; exact hab)
+      (by simp [ha]) (by simp [hb]) ⟨D ⋙ Γ.rightOp, rfl⟩
     obtain ⟨k, hik, hjk, H⟩ := this
-    exact ⟨k, hik, hjk, (cancel_epi _).mp H⟩
+    exact ⟨k, hik, hjk, (cancel_epi _).mp (by simpa only [(inv e).naturality_assoc] using H)⟩
   obtain ⟨D, rfl⟩ := hD
   obtain ⟨a, rfl⟩ := Spec.map_surjective a
   obtain ⟨b, rfl⟩ := Spec.map_surjective b
@@ -439,8 +431,7 @@ private nonrec lemma Scheme.exists_hom_hom_comp_eq_comp_of_isAffine_of_locallyOf
     a (Spec.map_injective (by simpa using! ha.symm))
     b (Spec.map_injective (by simpa using! hb.symm))
     (Spec.map_injective (by
-      simp only [coconeLeftOpOfCone_pt, Functor.const_obj_obj,
-        Functor.leftOp_obj, coconeLeftOpOfCone_ι_app, Spec.map_comp]
+      simp only [coconeLeftOpOfCone_ι_app, Spec.map_comp]
       simp only [← Scheme.Spec_map, ← liftedLimitMapsToOriginal_hom_π, Category.assoc, hab]))
   exact ⟨k.unop, hik.unop, hjk.unop, by simpa [← Spec.map_comp, Spec.map_inj] using! H⟩
 
@@ -630,8 +621,7 @@ lemma exists_hom_comp_eq_comp_of_locallyOfFiniteType
   · exact ⟨A.i', A.hii', isInitialOfIsEmpty.hom_ext _ _⟩
   let O : Finset I := {A.i'} ∪ Finset.univ.image (fun i : 𝒰Df.I₀ ↦ k <| A.𝒰D.idx i.1)
   let o := Nonempty.some (inferInstance : Nonempty 𝒰Df.I₀)
-  have ho : k (A.𝒰D.idx o.1) ∈ O := by
-    simp [O]
+  have ho : k (A.𝒰D.idx o.1) ∈ O := by simp [O]
   obtain ⟨l, hl1, hl2⟩ := IsCofiltered.inf_exists O
     (Finset.univ.image (fun i : 𝒰Df.I₀ ↦
       ⟨k <| A.𝒰D.idx i.1, A.i', by simp [O], by simp [O], hki' <| A.𝒰D.idx i.1⟩))
@@ -650,8 +640,7 @@ lemma exists_hom_comp_eq_comp_of_locallyOfFiniteType
     pullback.map _ _ _ _ (D.map <| hl1 hu)
       (𝟙 _) (𝟙 _) (by rw [Category.comp_id, ← D.map_comp, this o u]) rfl
   have hF : F ≫ pullback.fst (D.map (hki' _)) (A.𝒰D.f _) =
-      pullback.fst _ _ ≫ D.map (hl1 hu) := by
-    simp [F, pullback.lift_fst]
+      pullback.fst _ _ ≫ D.map (hl1 hu) := by simp [F, pullback.lift_fst]
   dsimp only [Precoverage.ZeroHypercover.pullback₁, PreZeroHypercover.pullback₁] at heq ⊢
   simp only [Functor.map_comp, Category.assoc] at heq ⊢
   simp_rw [← D.map_comp_assoc, reassoc_of% this o u, D.map_comp_assoc]

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -901,7 +901,6 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
   choose i U hU hxU t ht using exists_appLE_eq_restrict_of_isLimit D c hc s
   obtain ⟨σ, hσ⟩ := CompactSpace.elim_nhds_subcover (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).1)
     (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).2.mem_nhds (by exact hxU x))
-  choose σi hσiσ hσi using fun x ↦ Set.mem_iUnion₂.mp (hσ.ge (Set.mem_univ x))
   obtain ⟨j, fj, hfj⟩ : ∃ (j : I) (fj : ∀ x : σ, j ⟶ i x), ⨆ x : σ, D.map (fj x) ⁻¹ᵁ U x = ⊤ := by
     obtain ⟨j₀, hj₀⟩ := IsCofiltered.inf_objs_exists (σ.image i)
     have fj₀ (x : σ) : j₀ ⟶ i x := (hj₀ (Finset.mem_image_of_mem i x.2)).some
@@ -923,26 +922,20 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
       (fj x.1) (fj x.2)
   have hcov : ⨆ x : σ, D.map (v ≫ fj x) ⁻¹ᵁ U x = ⊤ := by
     simpa [Scheme.Hom.comp_preimage] using (D.map v).iSup_preimage_eq_top hfj
-  have hsheaf := ((Presheaf.isSheaf_iff_isSheaf_forget _ _ (forget _)).mp
-      (D.obj k).IsSheaf).isSheafFor
-    (.ofArrows (fun x : σ ↦ D.map (v ≫ fj x) ⁻¹ᵁ U x) fun x ↦ homOfLE le_top)
-    (fun y _ ↦ by
-      obtain ⟨x, hx⟩ : ∃ x : σ, y ∈ D.map (v ≫ fj x) ⁻¹ᵁ U x := by
-        simpa using hcov.ge (Set.mem_univ y)
-      exact ⟨_, homOfLE le_top, Sieve.ofArrows_mk _ _ x, hx⟩)
-  rw [← Presieve.isSheafFor_iff_generate, Presieve.isSheafFor_arrows_iff] at hsheaf
-  obtain ⟨t₀, ht₀, -⟩ := hsheaf (fun x ↦ (D.map _).app _ (t x)) fun x y V fVx fVy _ ↦ by
-    simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, -Scheme.Hom.comp_appLE]
-      using hv (x, y) V fVx.le fVy.le
+  have H (x : σ) : c.π.app (i x) ⁻¹ᵁ U x = c.π.app k ⁻¹ᵁ D.map (v ≫ fj x) ⁻¹ᵁ U x := by
+    rw [← Scheme.Hom.comp_preimage, Cone.w]
+  obtain ⟨t₀, ht₀, -⟩ := TopCat.Sheaf.existsUnique_gluing' ⟨_, (D.obj k).IsSheaf⟩ _ ⊤
+    (fun _ ↦ homOfLE le_top) hcov.ge (fun x ↦ (D.map (v ≫ fj x)).app (U x) (t x)) fun x y ↦ by
+      dsimp [TopologicalSpace.Opens.infLELeft, TopologicalSpace.Opens.infLERight]
+      simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, -Scheme.Hom.comp_appLE]
+        using hv (x, y) _ inf_le_left inf_le_right
   replace ht₀ (x : σ) : t₀ |_ (D.map (v ≫ fj x) ⁻¹ᵁ U x) = (D.map (v ≫ fj x)).app (U x) (t x) :=
     ht₀ x
-  refine ⟨k, t₀, TopCat.Presheaf.section_ext c.pt.sheaf _ _ _ fun y hy ↦ c.pt.presheaf.germ_ext
-    (c.π.app _ ⁻¹ᵁ U (σi y)) (hσi y) (homOfLE le_top) (homOfLE le_top) ?_⟩
-  have H : c.π.app (i (σi y)) ⁻¹ᵁ U (σi y) ≤
-      c.π.app k ⁻¹ᵁ D.map (v ≫ fj ⟨_, hσiσ y⟩) ⁻¹ᵁ U (σi y) := by
-    rw [← Scheme.Hom.comp_preimage, Cone.w]
-  refine (ht (σi y) _ le_rfl).symm.trans (Eq.trans ?_ (ConcreteCategory.comp_apply _ _ _))
-  have key := congr((c.π.app k).appLE _ (c.π.app (i (σi y)) ⁻¹ᵁ U (σi y)) H $(ht₀ ⟨_, hσiσ y⟩))
+  refine ⟨k, t₀, TopCat.Sheaf.eq_of_locally_eq' ⟨_, c.pt.IsSheaf⟩
+    (fun x : σ ↦ c.π.app (i x) ⁻¹ᵁ U x) ⊤ (fun _ ↦ homOfLE le_top) ?_ _ _ fun x ↦ ?_⟩
+  · simpa only [H] using ((c.π.app k).iSup_preimage_eq_top hcov).ge
+  refine (ht x _ le_rfl).symm.trans (Eq.trans ?_ (ConcreteCategory.comp_apply _ _ _))
+  have key := congr((c.π.app k).appLE _ (c.π.app (i x) ⁻¹ᵁ U x) (H x).le $(ht₀ x))
   simp only [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict, ← ConcreteCategory.comp_apply,
     Scheme.Hom.map_appLE, Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE, Cone.w] at key
   exact key.symm

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -1100,18 +1100,18 @@ private lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
 variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [LocallyOfFinitePresentation f]
   [∀ i, QuasiSeparatedSpace (D.obj i)]
   {i : I} {J : Type*} [Finite J] {U : J → (D.obj i).Opens} (hU : ∀ j, IsAffineOpen (U j))
+  (hcov : TopologicalSpace.IsOpenCover U)
   (hUV : ∀ j, ∃ (V : X.affineOpens) (W : S.affineOpens),
     c.π.app i ⁻¹ᵁ U j ≤ a ⁻¹ᵁ (V : X.Opens) ∧ (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens))
 
-include hc ha hU hUV in
-private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
-    ∃ (k : I) (u : k ⟶ i) (g : ∀ j, ↑(D.map u ⁻¹ᵁ U j) ⟶ X),
-      (∀ j, g j ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k) ∧
-      (∀ j, (c.π.app k).resLE _ _ le_rfl ≫ g j = (c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j).ι ≫ a) ∧
-      ∀ j₁ j₂, Scheme.homOfLE _ inf_le_left ≫ g j₁ = Scheme.homOfLE _ inf_le_right ≫ g j₂ := by
+include hc ha hU hcov hUV in
+/-- See `Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation` for the general case. -/
+private lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffineOpen :
+    ∃ (k : I) (g : D.obj k ⟶ X), c.π.app k ≫ g = a ∧ g ≫ f = t.app k := by
   have hnat {j k : I} (v : j ⟶ k) : D.map v ≫ t.app k = t.app j := by simp
   have hπ (j : I) : c.π.app j ≫ t.app j = a ≫ f := congr(($ha).app j)
   choose V W hUV hVW using hUV
+  -- Each `U j` factors after passing to some `l`, compatibly on overlaps.
   have key : ∃ (k : I) (u : k ⟶ i), ∀ j, ∃ g : ↑(D.map u ⁻¹ᵁ U j) ⟶ X,
       g ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k ∧
         ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
@@ -1157,11 +1157,16 @@ private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
     exact ⟨l, v, fun O e₁ e₂ ↦ by
       simpa using
         congr(Scheme.homOfLE _ ((le_inf e₁ e₂).trans_eq (by simp [Hom.preimage_inf])) ≫ $e)⟩
-  exact ⟨l, v ≫ u, fun j ↦ (D.map v).resLE _ (D.map (v ≫ u) ⁻¹ᵁ U j) (by simp) ≫ g j,
-    fun j ↦ by simp [hg, hnat], fun j ↦ by simpa using hg' j _ (by simp),
-    fun j₁ j₂ ↦ by simpa using hl j₁ j₂ _ (by simp) (by simp)⟩
+  -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
+  have h𝒲 := (hcov.preimage (D.map u)).preimage (D.map v)
+  obtain ⟨F, hF⟩ := exists_ι_comp_eq_of_isOpenCover h𝒲 (fun j ↦ (D.map v).resLE _ _ le_rfl ≫ g j)
+    fun j₁ j₂ ↦ by simpa using hl j₁ j₂ _ inf_le_left inf_le_right
+  refine ⟨l, F, hom_ext_of_isOpenCover (h𝒲.preimage (c.π.app l)) _ _ fun j ↦ ?_,
+    hom_ext_of_isOpenCover h𝒲 _ _ fun j ↦ ?_⟩
+  · rw [← Hom.resLE_comp_ι_assoc (c.π.app l) le_rfl, hF]
+    simpa using hg' j _ (by simp)
+  · simp [reassoc_of% hF, hg]
 
-open TopologicalSpace in
 include hc ha in
 /--
 Given a cofiltered diagram of qcqs schemes `Dᵢ` over `S` with affine transition maps.
@@ -1175,19 +1180,10 @@ lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation [∀ i, CompactSpace 
   have h𝒰 := (isBasis_affineOpens_le_preimage a
     (isBasis_affineOpens_le_preimage f S.isBasis_affineOpens)).isOpenCover
   obtain ⟨i, s, 𝒱, h𝒱, h𝒱𝒰⟩ := exists_isOpenCover_and_isAffine D c hc _ h𝒰 fun U ↦ U.2.1
-  -- Each `𝒱 j` factors after passing to some `l`, compatibly on overlaps.
-  obtain ⟨l, u, g, hg, hπg, hglue⟩ := exists_forall_homOfLE_comp_eq_of_isAffineOpen D t f c hc a ha
-    (fun j ↦ (h𝒱𝒰 j).1) fun j ↦ by
+  exact exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffineOpen D t f c hc a ha
+    (fun j ↦ (h𝒱𝒰 j).1) h𝒱 fun j ↦ by
       obtain ⟨-, V, ⟨hV, W, hW, hVW⟩, hUV⟩ := j.1.2
       exact ⟨⟨V, hV⟩, ⟨W, hW⟩, (h𝒱𝒰 j).2 ▸ hUV, hVW⟩
-  -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
-  have h𝒲 : IsOpenCover (D.map u ⁻¹ᵁ 𝒱 ·) := h𝒱.preimage (D.map u)
-  obtain ⟨F, hF⟩ := exists_ι_comp_eq_of_isOpenCover h𝒲 g hglue
-  refine ⟨l, F, hom_ext_of_isOpenCover (h𝒲.preimage (c.π.app l)) _ _ fun j ↦ ?_,
-    hom_ext_of_isOpenCover h𝒲 _ _ fun j ↦ ?_⟩
-  · rw [← Hom.resLE_comp_ι_assoc (c.π.app l) le_rfl, hF]
-    exact hπg j
-  · simp [reassoc_of% hF, hg]
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -827,7 +827,7 @@ lemma exists_app_map_eq_zero_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D
   have H : (D.map (𝟙 _) ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ U := by simp
   obtain ⟨j, f, hf⟩ := exists_appTop_map_eq_zero_of_isLimit _ _
     (isLimitOpensCone D c hc i U) (i := .mk (𝟙 i))
-    ((D.obj i).presheaf.map (homOfLE (show (D.map (𝟙 _) ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ U by simp)).op s) (by
+    ((D.obj i).presheaf.map (homOfLE H).op s) (by
       rw [← map_zero (c.pt.presheaf.map (homOfLE
         (show (c.π.app i ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ c.π.app i ⁻¹ᵁ U by simp)).op).hom, ← hs]
       dsimp [Scheme.Opens.toScheme_presheaf_obj]
@@ -900,16 +900,13 @@ private lemma exists_forall_map_appLE_eq_of_isLimit [∀ {i j} (f : i ⟶ j), Is
     ∃ (k : I) (v : k ⟶ j), ∀ x y (V : (D.obj k).Opens) (h₁ : V ≤ D.map (v ≫ u x) ⁻¹ᵁ U x)
       (h₂ : V ≤ D.map (v ≫ u y) ⁻¹ᵁ U y),
         (D.map (v ≫ u x)).appLE _ V h₁ (t x) = (D.map (v ≫ u y)).appLE _ V h₂ (t y) := by
-  refine Exists₂.imp (fun _ _ hv x y ↦ hv (x, y)) (IsCofiltered.exists_forall
-    (fun k (v : k ⟶ j) (x : J × J) ↦ ∀ (V : (D.obj k).Opens)
-      (h₁ : V ≤ D.map (v ≫ u x.1) ⁻¹ᵁ U x.1) (h₂ : V ≤ D.map (v ≫ u x.2) ⁻¹ᵁ U x.2),
-        (D.map (v ≫ u x.1)).appLE _ V h₁ (t x.1) = (D.map (v ≫ u x.2)).appLE _ V h₂ (t x.2)) ?_ ?_)
-  · exact fun w v x hv V h₁ h₂ ↦ by
-      have e : V ≤ D.map w ⁻¹ᵁ (D.map (v ≫ u x.1) ⁻¹ᵁ U x.1 ⊓ D.map (v ≫ u x.2) ⁻¹ᵁ U x.2) := by
+  refine IsCofiltered.exists_forall₂ _ ?_ ?_
+  · exact fun w v x y hv V h₁ h₂ ↦ by
+      have e : V ≤ D.map w ⁻¹ᵁ (D.map (v ≫ u x) ⁻¹ᵁ U x ⊓ D.map (v ≫ u y) ⁻¹ᵁ U y) := by
         simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
       simpa [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
         using congr((D.map w).appLE _ V e $(hv _ inf_le_left inf_le_right))
-  rintro ⟨x, y⟩
+  intro x y
   obtain ⟨k, v, hv⟩ := exists_app_map_eq_zero_of_isLimit D c hc
     (((hU x).preimage (D.map (u x))).isCompact.inter_of_isOpen
       ((hU y).preimage (D.map (u y))).isCompact ((U x).2.preimage (D.map (u x)).continuous)
@@ -1229,13 +1226,12 @@ private lemma exists_forall_resLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresen
     have e : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
     exact ⟨(D.map v).resLE _ _ e ≫ g, by simpa using congr((D.map v).resLE _ _ e ≫ $hg),
       fun O h ↦ by simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)⟩
-  obtain ⟨i', u, hu⟩ :
-      ∃ (i' : I) (u : i' ⟶ i), D.map u ⁻¹ᵁ U j ≤ t.app i' ⁻¹ᵁ (W j : S.Opens) := by
-    obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc (hU j).isCompact
-      (V := t.app i ⁻¹ᵁ (W j : S.Opens)) (by
-        rw [← Scheme.Hom.comp_preimage, hπ, Scheme.Hom.comp_preimage]
-        exact (hUV j).trans (a.preimage_mono (hVW j)))
-    exact ⟨i', u, hu.trans_eq (by rw [← Scheme.Hom.comp_preimage, hnat])⟩
+  obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc (hU j).isCompact
+    (V := t.app i ⁻¹ᵁ (W j : S.Opens)) (by
+      rw [← Scheme.Hom.comp_preimage, hπ, Scheme.Hom.comp_preimage]
+      exact (hUV j).trans (a.preimage_mono (hVW j)))
+  replace hu : D.map u ⁻¹ᵁ U j ≤ t.app i' ⁻¹ᵁ (W j : S.Opens) :=
+    hu.trans_eq (by rw [← Scheme.Hom.comp_preimage, hnat])
   have _ (k : Over i') : IsAffine ((opensDiagram D i' (D.map u ⁻¹ᵁ U j)).obj k) :=
     ((hU j).preimage _).preimage _
   let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U j) ⟶ (Functor.const (Over i')).obj (W j) :=
@@ -1273,15 +1269,12 @@ private lemma exists_forall_resLE_comp_eq_resLE_comp [LocallyOfFiniteType f]
     ∃ (l : I) (v : l ⟶ k), ∀ j₁ j₂ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U j₁)
       (e₂ : O ≤ D.map v ⁻¹ᵁ U j₂),
         (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ := by
-  refine Exists₂.imp (fun _ _ hl j₁ j₂ ↦ hl (j₁, j₂)) (IsCofiltered.exists_forall
-    (fun l (v : l ⟶ k) (j : J × J) ↦ ∀ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U j.1)
-      (e₂ : O ≤ D.map v ⁻¹ᵁ U j.2),
-        (D.map v).resLE _ O e₁ ≫ g j.1 = (D.map v).resLE _ O e₂ ≫ g j.2) ?_ ?_)
-  · exact fun w v j hv O e₁ e₂ ↦ by
+  refine IsCofiltered.exists_forall₂ _ ?_ ?_
+  · exact fun w v j₁ j₂ hv O e₁ e₂ ↦ by
       simpa [Scheme.Hom.resLE_comp_resLE_assoc] using congr((D.map w).resLE _ O
         (show O ≤ D.map w ⁻¹ᵁ _ by simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫
           $(hv _ inf_le_left inf_le_right))
-  rintro ⟨j₁, j₂⟩
+  intro j₁ j₂
   obtain ⟨l, v, e⟩ := Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType D t f c hc
     ((hU j₁).inter_of_isOpen (hU j₂) (U j₁).2 (U j₂).2)
     (Scheme.homOfLE _ inf_le_left ≫ g j₁) (Scheme.homOfLE _ inf_le_right ≫ g j₂)

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -701,6 +701,33 @@ lemma Scheme.exists_hom_hom_comp_eq_comp_of_locallyOfFiniteType
   use k, hik ≫ IsCofiltered.minToLeft i j, hik ≫ IsCofiltered.minToRight i j
   simpa using heq
 
+omit [∀ i, CompactSpace (D.obj i)] in
+include hc in
+lemma Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType
+    {i : I} {U : (D.obj i).Opens} (hU : IsCompact (X := D.obj i) U) (a b : ↑U ⟶ X)
+    (ha : U.ι ≫ t.app i = a ≫ f) (hb : U.ι ≫ t.app i = b ≫ f)
+    (hab : (c.π.app i).resLE U _ le_rfl ≫ a = (c.π.app i).resLE U _ le_rfl ≫ b) :
+    ∃ (k : I) (hik : k ⟶ i),
+      (D.map hik).resLE U _ le_rfl ≫ a = (D.map hik).resLE U _ le_rfl ≫ b := by
+  have (j : Over i) : CompactSpace ((opensDiagram D i U).obj j) :=
+    isCompact_iff_compactSpace.mp (QuasiCompact.isCompact_preimage _ U.2 hU)
+  let U₀ : (D.obj i).Opens := D.map (𝟙 i) ⁻¹ᵁ U
+  let a₀ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ a
+  let b₀ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ b
+  have ha₀ : U₀.ι ≫ t.app i = a₀ ≫ f := by simp [a₀, ← ha]
+  have hb₀ : U₀.ι ≫ t.app i = b₀ ≫ f := by simp [b₀, ← hb]
+  have hab₀ : (c.π.app i).resLE U₀ (c.π.app i ⁻¹ᵁ U) (by simp [U₀]) ≫ a₀ =
+      (c.π.app i).resLE U₀ (c.π.app i ⁻¹ᵁ U) (by simp [U₀]) ≫ b₀ := by
+    simp only [a₀, b₀, Scheme.Hom.resLE_map_assoc]
+    exact hab
+  obtain ⟨⟨k, _, u⟩, ⟨u', _, hu⟩, e⟩ := Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
+    _ (opensDiagramι .. ≫ (Over.forget i).whiskerLeft t) f _ (isLimitOpensCone D c hc i U)
+    (i := .mk (𝟙 i)) a₀ b₀ ha₀ hb₀ hab₀
+  obtain rfl : u = u' := by simpa using! hu.symm
+  replace e : (D.map u).resLE U₀ (D.map u ⁻¹ᵁ U) (by simp [U₀]) ≫ a₀ =
+      (D.map u).resLE U₀ (D.map u ⁻¹ᵁ U) (by simp [U₀]) ≫ b₀ := e
+  exact ⟨k, u, by simpa [a₀, b₀] using e⟩
+
 end LocallyOfFiniteType
 
 /-!
@@ -1255,28 +1282,15 @@ private lemma exists_forall_resLE_comp_eq_resLE_comp [LocallyOfFiniteType f]
         (show O ≤ D.map w ⁻¹ᵁ _ by simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫
           $(hv _ inf_le_left inf_le_right))
   rintro ⟨j₁, j₂⟩
-  have _ (x) : CompactSpace ((opensDiagram D k (U j₁ ⊓ U j₂)).obj x) :=
-    isCompact_iff_compactSpace.mp (QuasiCompact.isCompact_preimage _ (U j₁ ⊓ U j₂).isOpen
-      ((hU j₁).inter_of_isOpen (hU j₂) (U j₁).2 (U j₂).2))
-  let U₀ : (D.obj k).Opens := D.map (𝟙 k) ⁻¹ᵁ (U j₁ ⊓ U j₂)
-  let a₁ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ g j₁
-  let a₂ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ g j₂
-  have ha₁ : U₀.ι ≫ t.app k = a₁ ≫ f := by simp [a₁, hg]
-  have ha₂ : U₀.ι ≫ t.app k = a₂ ≫ f := by simp [a₂, hg]
-  have hab : (c.π.app k).resLE U₀ (c.π.app k ⁻¹ᵁ (U j₁ ⊓ U j₂)) (by simp [U₀]) ≫ a₁ =
-      (c.π.app k).resLE U₀ (c.π.app k ⁻¹ᵁ (U j₁ ⊓ U j₂)) (by simp [U₀]) ≫ a₂ := by
-    simp only [a₁, a₂, Scheme.Hom.resLE_map_assoc]
-    exact h j₁ j₂ _ _ _
-  obtain ⟨⟨l, ⟨⟨⟩⟩, v⟩, ⟨v', ⟨⟨⟨⟩⟩⟩, hv⟩, e⟩ :=
-    Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
-      _ (opensDiagramι .. ≫ (Over.forget k).whiskerLeft t) f _
-      (isLimitOpensCone D c hc k (U j₁ ⊓ U j₂)) (i := .mk (𝟙 k)) a₁ a₂ ha₁ ha₂ hab
-  obtain rfl : v = v' := by simpa using! hv.symm
-  replace e : (D.map v).resLE U₀ (D.map v ⁻¹ᵁ (U j₁ ⊓ U j₂)) (by simp [U₀]) ≫ a₁ =
-      (D.map v).resLE U₀ (D.map v ⁻¹ᵁ (U j₁ ⊓ U j₂)) (by simp [U₀]) ≫ a₂ := e
-  refine ⟨l, v, fun O e₁ e₂ ↦ ?_⟩
-  simpa [a₁, a₂] using congr(Scheme.homOfLE _
-    (show O ≤ D.map v ⁻¹ᵁ (U j₁ ⊓ U j₂) from le_inf e₁ e₂) ≫ $e)
+  obtain ⟨l, v, e⟩ := Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType D t f c hc
+    ((hU j₁).inter_of_isOpen (hU j₂) (U j₁).2 (U j₂).2)
+    (Scheme.homOfLE _ inf_le_left ≫ g j₁) (Scheme.homOfLE _ inf_le_right ≫ g j₂)
+    (by simp [hg]) (by simp [hg])
+    (by rw [Scheme.Hom.resLE_map_assoc, Scheme.Hom.resLE_map_assoc]; exact h j₁ j₂ _ _ _)
+  exact ⟨l, v, fun O e₁ e₂ ↦ by
+    simpa using congr(Scheme.homOfLE _
+      (show O ≤ D.map v ⁻¹ᵁ (U j₁ ⊓ U j₂) by simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫
+        $e)⟩
 
 open TopologicalSpace in
 include hc ha in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -230,11 +230,13 @@ def opensCone (i : I) (U : (D.obj i).Opens) : Cone (opensDiagram D i U) where
 
 attribute [local instance] CategoryTheory.isConnected_of_hasTerminal
 
+variable [IsCofiltered I]
+
 set_option backward.isDefEq.respectTransparency false in
 /-- Given a diagram `{ Dᵢ }_{i ∈ I}` of schemes and an open `U ⊆ Dᵢ`,
 the preimage of `U ⊆ Dᵢ` under the map `lim Dᵢ ⟶ Dᵢ` is the limit of `{ Dⱼᵢ⁻¹ U }_{j ≤ i}`. -/
 noncomputable
-def isLimitOpensCone [IsCofiltered I] (i : I) (U : (D.obj i).Opens) :
+def isLimitOpensCone (i : I) (U : (D.obj i).Opens) :
     IsLimit (opensCone D c i U) :=
   isLimitOfIsPullbackOfIsConnected (opensDiagramι D i U) _ _
     (by exact { hom := (c.π.app i ⁻¹ᵁ U).ι })
@@ -243,6 +245,7 @@ def isLimitOpensCone [IsCofiltered I] (i : I) (U : (D.obj i).Opens) :
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
+omit [IsCofiltered I] in
 instance [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] {i : I}
     (U : (D.obj i).Opens) {j k : Over i} (f : j ⟶ k) :
     IsAffineHom ((opensDiagram D i U).map f) := by
@@ -273,7 +276,6 @@ set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
 lemma exists_map_preimage_le_map_preimage
-    [IsCofiltered I]
     [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     {i : I} {U V : (D.obj i).Opens} (hU : IsCompact (U : Set (D.obj i)))
     (H : c.π.app i ⁻¹ᵁ U ≤ c.π.app i ⁻¹ᵁ V) :
@@ -295,7 +297,6 @@ lemma exists_map_preimage_le_map_preimage
 include hc in
 @[stacks 01Z4 "(2)"]
 lemma exists_map_preimage_eq_map_preimage
-    [IsCofiltered I]
     [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     {i : I} {U V : (D.obj i).Opens} (hU : IsCompact (U : Set (D.obj i)))
     (hV : IsCompact (V : Set (D.obj i))) (H : c.π.app i ⁻¹ᵁ U = c.π.app i ⁻¹ᵁ V) :
@@ -309,16 +310,14 @@ lemma exists_map_preimage_eq_map_preimage
     simpa only [Scheme.Hom.comp_preimage, Functor.map_comp] using Scheme.Hom.preimage_mono _ e₂
 
 include hc in
-lemma exists_appTop_π_eq_of_isAffine_of_isLimit [IsCofiltered I]
-    [∀ i, IsAffine (D.obj i)] (s : Γ(c.pt, ⊤)) :
+lemma exists_appTop_π_eq_of_isAffine_of_isLimit [∀ i, IsAffine (D.obj i)] (s : Γ(c.pt, ⊤)) :
     ∃ (i : I) (t : Γ(D.obj i, ⊤)), (c.π.app i).appTop t = s := by
   have : ∀ i, IsAffine (D.op.obj i).unop := by dsimp; infer_instance
   exact ⟨_, (Types.jointly_surjective_of_isColimit
     (isColimitOfPreserves (Scheme.Γ ⋙ forget _) hc.op) s).choose_spec⟩
 
 include hc in
-lemma exists_appLE_π_eq_of_isAffineOpen [IsCofiltered I]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+lemma exists_appLE_π_eq_of_isAffineOpen [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     {i : I} {U : (D.obj i).Opens} (hU : IsAffineOpen U) (s : Γ(c.pt, c.π.app i ⁻¹ᵁ U)) :
     ∃ (j : I) (u : j ⟶ i) (t : Γ(D.obj j, D.map u ⁻¹ᵁ U)),
       (c.π.app j).appLE _ _ (π_app_preimage_map_preimage D c u U).ge t = s := by
@@ -335,7 +334,7 @@ lemma exists_appLE_π_eq_of_isAffineOpen [IsCofiltered I]
   exact (c.π.app i ⁻¹ᵁ U).topIso.commRingCatIsoToRingEquiv.symm.injective ht
 
 include hc in
-lemma isBasis_preimage_isAffineOpen [IsCofiltered I] [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] :
+lemma isBasis_preimage_isAffineOpen [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] :
     TopologicalSpace.Opens.IsBasis
       { (c.π.app i ⁻¹ᵁ V : c.pt.Opens) | (i : I) (V : (D.obj i).Opens) (_ : IsAffineOpen V) } := by
   refine TopologicalSpace.Opens.isBasis_iff_nbhd.mpr fun {U x} hxU ↦ ?_
@@ -355,8 +354,7 @@ lemma isBasis_preimage_isAffineOpen [IsCofiltered I] [∀ {i j} (f : i ⟶ j), I
 set_option backward.defeqAttrib.useBackward true in
 include hc in
 @[stacks 01Z4 "(1)"]
-lemma exists_preimage_eq
-    [IsCofiltered I] [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+lemma exists_preimage_eq [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     (U : c.pt.Opens) (hU : IsCompact (U : Set c.pt)) :
     ∃ (i : I) (V : (D.obj i).Opens), IsCompact (V : Set (D.obj i)) ∧ c.π.app i ⁻¹ᵁ V = U := by
   classical
@@ -778,38 +776,35 @@ lemma exists_appTop_map_eq_zero_of_isAffine_of_isLimit
 
 variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 lemma exists_app_map_eq_zero_of_isLimit {i : I} {U : (D.obj i).Opens}
     (hU : IsCompact (X := D.obj i) U) (s : Γ(D.obj i, U)) (hs : (c.π.app i).app U s = 0) :
     ∃ (j : I) (f : j ⟶ i), (D.map f).app U s = 0 := by
+  have h0 {V : (D.obj i).Opens} (hV : V ≤ U) {V' : c.pt.Opens} (e : V' ≤ c.π.app i ⁻¹ᵁ V) :
+      (c.π.app i).appLE V V' e (TopCat.Presheaf.restrictOpen s V hV) = 0 := by
+    rw [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict, ← ConcreteCategory.comp_apply,
+      Scheme.Hom.map_appLE, Scheme.Hom.appLE, ConcreteCategory.comp_apply, hs, map_zero]
   have key {W : (D.obj i).Opens} (hW : IsAffineOpen W) (hWU : W ≤ U) :
       ∃ (j : I) (f : j ⟶ i), (D.map f).app W (s |_ W) = 0 := by
     have (j : Over i) : IsAffine ((opensDiagram D i W).obj j) := hW.preimage (D.map _)
-    have H : (D.map (𝟙 _) ⁻¹ᵁ W).ι ''ᵁ ⊤ ≤ W := by simp
-    obtain ⟨j, f, hf⟩ := exists_appTop_map_eq_zero_of_isAffine_of_isLimit _ _
+    have hle : D.map (𝟙 i) ⁻¹ᵁ W ≤ U := by simpa using hWU
+    obtain ⟨j, v, hv⟩ := exists_appTop_map_eq_zero_of_isAffine_of_isLimit _ _
       (isLimitOpensCone D c hc i W) (.mk (𝟙 i))
-      ((D.obj i).presheaf.map (homOfLE H).op (s |_ W)) (by
-        rw [← map_zero (c.pt.presheaf.map (homOfLE (show (c.π.app i ⁻¹ᵁ W).ι ''ᵁ ⊤ ≤
-          c.π.app i ⁻¹ᵁ U from le_trans (by simp) ((c.π.app i).preimage_mono hWU))).op).hom, ← hs]
-        dsimp [Scheme.Opens.toScheme_presheaf_obj, TopCat.Presheaf.restrictOpen,
-          TopCat.Presheaf.restrict]
-        rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply,
-          ← ConcreteCategory.comp_apply]
-        congr! 2
-        simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE])
-    dsimp at hf
-    refine ⟨j.left, f.left, ?_⟩
-    have hf' : f.left = j.hom := by simpa using Over.w f
-    convert!
-      congr((D.obj j.left).presheaf.map
-        (homOfLE (show D.map f.left ⁻¹ᵁ W ≤ (D.map j.hom ⁻¹ᵁ W).ι ''ᵁ ⊤ by simp [hf'])).op $hf)
-    · dsimp [Scheme.Opens.toScheme_presheaf_obj]
-      rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply]
-      congr! 2
-      simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE]
-    · simp
+      ((D.map (𝟙 i) ⁻¹ᵁ W).topIso.inv (TopCat.Presheaf.restrictOpen s _ hle)) (by
+        change ((c.π.app i).resLE (D.map (𝟙 i) ⁻¹ᵁ W) (c.π.app i ⁻¹ᵁ W) (by simp)).appTop _ = 0
+        simp only [Scheme.Hom.appTop, Scheme.Hom.resLE_app_top, ConcreteCategory.comp_apply,
+          Iso.inv_hom_id_apply, h0, map_zero])
+    have hv' : v.left = j.hom := by simpa using Over.w v
+    replace hv : ((D.map v.left).resLE (D.map (𝟙 i) ⁻¹ᵁ W) (D.map j.hom ⁻¹ᵁ W)
+        (by rw [hv']; simp)).appTop
+        ((D.map (𝟙 i) ⁻¹ᵁ W).topIso.inv (TopCat.Presheaf.restrictOpen s _ hle)) = 0 := hv
+    replace hv := congr((D.map j.hom ⁻¹ᵁ W).topIso.hom $hv)
+    simp only [Scheme.Hom.appTop, Scheme.Hom.resLE_app_top, ConcreteCategory.comp_apply,
+      Iso.inv_hom_id_apply, map_zero, hv'] at hv
+    refine ⟨j.left, j.hom, ?_⟩
+    simpa only [Scheme.Hom.app_eq_appLE, TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict,
+      ← ConcreteCategory.comp_apply, Category.assoc, Iso.inv_hom_id_assoc,
+      Scheme.Hom.map_appLE] using hv
   obtain ⟨Us, hUs, hUsf, hsup⟩ := (D.obj i).isBasis_affineOpens.exists_finite_of_isCompact hU
   have : Finite Us := hUsf
   have hle (W : Us) : (W : (D.obj i).Opens) ≤ U := (le_sSup W.2).trans hsup.ge
@@ -858,7 +853,7 @@ private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)
   have key : ∃ (n : I) (w : n ⟶ i), ∀ W : Us, ∃ T : Γ(D.obj n, D.map w ⁻¹ᵁ W.1),
       ∀ (V : c.pt.Opens) (e : V ≤ c.π.app n ⁻¹ᵁ D.map w ⁻¹ᵁ W.1),
         (c.π.app n).appLE _ V e T = s |_ V := by
-    refine IsCofiltered.exists_forall _ ?_ fun W ↦ ?_
+    refine IsCofiltered.exists_forall ?_ fun W ↦ ?_
     · rintro n m v w W ⟨T, hT⟩
       refine ⟨(D.map v).appLE _ _ (by simp) T, fun V e ↦ ?_⟩
       simpa only [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, Cone.w]
@@ -874,7 +869,7 @@ private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)
   obtain ⟨k, v, hv⟩ : ∃ (k : I) (v : k ⟶ n), ∀ (W₁ W₂ : Us) (V : (D.obj k).Opens)
       (h₁ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1) (h₂ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1),
         (D.map v).appLE _ V h₁ (T W₁) = (D.map v).appLE _ V h₂ (T W₂) := by
-    refine IsCofiltered.exists_forall₂ _ ?_ fun W₁ W₂ ↦ ?_
+    refine IsCofiltered.exists_forall₂ ?_ fun W₁ W₂ ↦ ?_
     · exact fun x v W₁ W₂ hv V h₁ h₂ ↦ by
         have e : V ≤ D.map x ⁻¹ᵁ
             (D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1 ⊓ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1) := by
@@ -927,8 +922,7 @@ lemma nonempty_isColimit_Γ_mapCocone :
   · exact fun i s t e ↦ ⟨_, Quiver.Hom.op _,
       (exists_app_map_eq_map_of_isLimit _ _ hc isCompact_univ s t e).choose_spec.choose_spec⟩
 
-instance :
-    PreservesLimit D Scheme.Γ.rightOp :=
+instance : PreservesLimit D Scheme.Γ.rightOp :=
   have : PreservesColimit D.op Scheme.Γ := ⟨fun hc ↦ nonempty_isColimit_Γ_mapCocone D _ hc.unop⟩
   preservesLimit_rightOp _ _
 
@@ -1147,18 +1141,18 @@ private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
       (∀ j, g j ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k) ∧
       (∀ j, (c.π.app k).resLE _ _ le_rfl ≫ g j = (c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j).ι ≫ a) ∧
       ∀ j₁ j₂, Scheme.homOfLE _ inf_le_left ≫ g j₁ = Scheme.homOfLE _ inf_le_right ≫ g j₂ := by
+  have hnat {j k : I} (v : j ⟶ k) : D.map v ≫ t.app k = t.app j := by simp
+  have hπ (j : I) : c.π.app j ≫ t.app j = a ≫ f := congr(($ha).app j)
+  choose V W hUV hVW using hUV
   have key : ∃ (k : I) (u : k ⟶ i), ∀ j, ∃ g : ↑(D.map u ⁻¹ᵁ U j) ⟶ X,
       g ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k ∧
         ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
           (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a := by
-    have hnat {j k : I} (v : j ⟶ k) : D.map v ≫ t.app k = t.app j := by simp
-    have hπ (j : I) : c.π.app j ≫ t.app j = a ≫ f := congr(($ha).app j)
-    choose V W hUV hVW using hUV
-    refine IsCofiltered.exists_forall _ ?_ fun j ↦ ?_
+    refine IsCofiltered.exists_forall ?_ fun j ↦ ?_
     · rintro k₁ k₂ v u j ⟨g, hg, hg'⟩
-      have e : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
-      exact ⟨(D.map v).resLE _ _ e ≫ g, by simpa using congr((D.map v).resLE _ _ e ≫ $hg),
-        fun O h ↦ by simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)⟩
+      refine ⟨(D.map v).resLE _ _ (by simp) ≫ g, ?_, fun O h ↦ ?_⟩
+      · simpa using congr((D.map v).resLE _ (D.map (v ≫ u) ⁻¹ᵁ U j) (by simp) ≫ $hg)
+      · simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)
     obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc (hU j).isCompact
       (V := t.app i ⁻¹ᵁ (W j : S.Opens)) (by
         rw [← Scheme.Hom.comp_preimage, hπ, Scheme.Hom.comp_preimage]
@@ -1193,24 +1187,22 @@ private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
   obtain ⟨l, v, hl⟩ : ∃ (l : I) (v : l ⟶ k), ∀ j₁ j₂ (O : (D.obj l).Opens)
       (e₁ : O ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j₁) (e₂ : O ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j₂),
         (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ := by
-    refine IsCofiltered.exists_forall₂ _ ?_ fun j₁ j₂ ↦ ?_
+    refine IsCofiltered.exists_forall₂ ?_ fun j₁ j₂ ↦ ?_
     · exact fun w v j₁ j₂ hv O e₁ e₂ ↦ by
-        simpa [Scheme.Hom.resLE_comp_resLE_assoc] using congr((D.map w).resLE _ O
-          (show O ≤ D.map w ⁻¹ᵁ _ by simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫
+        simpa [Scheme.Hom.resLE_comp_resLE_assoc] using
+          congr((D.map w).resLE _ O ((le_inf e₁ e₂).trans_eq (by simp [Scheme.Hom.preimage_inf])) ≫
             $(hv _ inf_le_left inf_le_right))
     have hcpt := ((hU j₁).preimage (D.map u)).isCompact_inf ((hU j₂).preimage (D.map u))
     obtain ⟨l, v, e⟩ := Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType D t f c hc
       hcpt (Scheme.homOfLE _ inf_le_left ≫ g j₁) (Scheme.homOfLE _ inf_le_right ≫ g j₂)
       (by simp [hg]) (by simp [hg])
-      (by rw [Scheme.Hom.resLE_map_assoc, Scheme.Hom.resLE_map_assoc]
-          exact (hg' j₁ _ _).trans (hg' j₂ _ _).symm)
+      (by simpa only [Scheme.Hom.resLE_map_assoc] using (hg' j₁ _ _).trans (hg' j₂ _ _).symm)
     exact ⟨l, v, fun O e₁ e₂ ↦ by
-      simpa using congr(Scheme.homOfLE _ (show O ≤ D.map v ⁻¹ᵁ _ by
-        simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫ $e)⟩
-  have e (j : J) : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
-  refine ⟨l, v ≫ u, fun j ↦ (D.map v).resLE _ _ (e j) ≫ g j, fun j ↦ ?_, fun j ↦ ?_,
-    fun j₁ j₂ ↦ ?_⟩
-  · simpa using congr((D.map v).resLE _ _ (e j) ≫ $(hg j))
+      simpa using
+        congr(Scheme.homOfLE _ ((le_inf e₁ e₂).trans_eq (by simp [Scheme.Hom.preimage_inf])) ≫ $e)⟩
+  refine ⟨l, v ≫ u, fun j ↦ (D.map v).resLE _ (D.map (v ≫ u) ⁻¹ᵁ U j) (by simp) ≫ g j,
+    fun j ↦ ?_, fun j ↦ ?_, fun j₁ j₂ ↦ ?_⟩
+  · simpa using congr((D.map v).resLE _ (D.map (v ≫ u) ⁻¹ᵁ U j) (by simp) ≫ $(hg j))
   · simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' j _ (by simp)
   · simpa using hl j₁ j₂ _ (by simp) (by simp)
 

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -857,24 +857,22 @@ private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)
     (U := ⊤) (by simpa using isCompact_univ)
   have : Finite Us := hUsf
   have hcov : IsOpenCover fun W : Us ↦ W.1 := .mk (by rw [← sSup_eq_iSup', ← hsup])
-  obtain ⟨n, w, T, hT⟩ : ∃ (n : I) (w : n ⟶ i) (T : ∀ W : Us, Γ(D.obj n, D.map w ⁻¹ᵁ W.1)),
-      ∀ (W : Us) (V : c.pt.Opens) (e : V ≤ c.π.app n ⁻¹ᵁ D.map w ⁻¹ᵁ W.1),
-        (c.π.app n).appLE _ V e (T W) = s |_ V := by
-    choose j u t ht using fun W : Us ↦
-      exists_appLE_π_eq_of_isAffineOpen D c hc (hUs W.2) (s |_ (c.π.app i ⁻¹ᵁ W.1))
-    replace ht (W : Us) (V : c.pt.Opens) (e : V ≤ c.π.app (j W) ⁻¹ᵁ D.map (u W) ⁻¹ᵁ W.1) :
-        (c.π.app (j W)).appLE _ V e (t W) = s |_ V := by
-      have h := π_app_preimage_map_preimage D c (u W) W.1
-      simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply] at ht ⊢
-      rw [← TopCat.Presheaf.restrict_restrict (e.trans_eq h) le_top s, ← ht W]
-      exact (TopCat.Presheaf.restrict_restrict (e.trans_eq h) h.ge _).symm
-    obtain ⟨m, ⟨φ⟩⟩ := IsCofiltered.exists_hom_forall fun W : Us ↦ Over.mk (u W)
-    have hφ (W : Us) : D.map m.hom ⁻¹ᵁ W.1 ≤ D.map (φ W).left ⁻¹ᵁ D.map (u W) ⁻¹ᵁ W.1 :=
-      le_of_eq (by rw [← Scheme.Hom.comp_preimage, ← D.map_comp,
-        show (φ W).left ≫ u W = m.hom from Over.w (φ W)])
-    refine ⟨m.left, m.hom, fun W ↦ (D.map (φ W).left).appLE _ _ (hφ W) (t W), fun W V e ↦ ?_⟩
-    simpa only [Over.mk_left, ← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, Cone.w]
-      using ht W V _
+  have key : ∃ (n : I) (w : n ⟶ i), ∀ W : Us, ∃ T : Γ(D.obj n, D.map w ⁻¹ᵁ W.1),
+      ∀ (V : c.pt.Opens) (e : V ≤ c.π.app n ⁻¹ᵁ D.map w ⁻¹ᵁ W.1),
+        (c.π.app n).appLE _ V e T = s |_ V := by
+    refine IsCofiltered.exists_forall _ ?_ fun W ↦ ?_
+    · rintro n m v w W ⟨T, hT⟩
+      refine ⟨(D.map v).appLE _ _ (by simp) T, fun V e ↦ ?_⟩
+      simpa only [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, Cone.w]
+        using hT V (by simpa using e)
+    obtain ⟨j, u, T, hT⟩ := exists_appLE_π_eq_of_isAffineOpen D c hc (hUs W.2)
+      (s |_ (c.π.app i ⁻¹ᵁ W.1))
+    refine ⟨j, u, T, fun V e ↦ ?_⟩
+    have h := π_app_preimage_map_preimage D c u W.1
+    simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply] at hT ⊢
+    rw [← TopCat.Presheaf.restrict_restrict (e.trans_eq h) le_top s, ← hT]
+    exact (TopCat.Presheaf.restrict_restrict (e.trans_eq h) h.ge _).symm
+  choose n w T hT using key
   obtain ⟨k, v, hv⟩ : ∃ (k : I) (v : k ⟶ n), ∀ (W₁ W₂ : Us) (V : (D.obj k).Opens)
       (h₁ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1) (h₂ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1),
         (D.map v).appLE _ V h₁ (T W₁) = (D.map v).appLE _ V h₂ (T W₂) := by

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -860,43 +860,15 @@ private lemma exists_appLE_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAf
   rw [← TopCat.Presheaf.restrict_restrict (e.trans_eq h) le_top s, ← ht]
   exact (TopCat.Presheaf.restrict_restrict (e.trans_eq h) h.ge _).symm
 
+open TopologicalSpace in
 include hc in
-private lemma exists_forall_map_appLE_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    [∀ i, QuasiSeparatedSpace (D.obj i)] {s : Γ(c.pt, ⊤)} {J : Type*} [Finite J] {j : I}
-    {i : J → I} {U : ∀ x, (D.obj (i x)).Opens} (hU : ∀ x, IsAffineOpen (U x))
-    {t : ∀ x, Γ(D.obj (i x), U x)} (ht : ∀ x (V : c.pt.Opens) (e : V ≤ c.π.app (i x) ⁻¹ᵁ U x),
-      (c.π.app (i x)).appLE (U x) V e (t x) = s |_ V) (u : ∀ x, j ⟶ i x) :
-    ∃ (k : I) (v : k ⟶ j), ∀ x y (V : (D.obj k).Opens) (h₁ : V ≤ D.map (v ≫ u x) ⁻¹ᵁ U x)
-      (h₂ : V ≤ D.map (v ≫ u y) ⁻¹ᵁ U y),
-        (D.map (v ≫ u x)).appLE _ V h₁ (t x) = (D.map (v ≫ u y)).appLE _ V h₂ (t y) := by
-  refine IsCofiltered.exists_forall₂ _ ?_ ?_
-  · exact fun w v x y hv V h₁ h₂ ↦ by
-      have e : V ≤ D.map w ⁻¹ᵁ (D.map (v ≫ u x) ⁻¹ᵁ U x ⊓ D.map (v ≫ u y) ⁻¹ᵁ U y) := by
-        simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
-      simpa [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
-        using congr((D.map w).appLE _ V e $(hv _ inf_le_left inf_le_right))
-  intro x y
-  have hcpt : IsCompact (X := D.obj j) ↑(D.map (u x) ⁻¹ᵁ U x ⊓ D.map (u y) ⁻¹ᵁ U y) :=
-    ((hU x).preimage (D.map (u x))).isCompact.inter_of_isOpen
-      ((hU y).preimage (D.map (u y))).isCompact (D.map (u x) ⁻¹ᵁ U x).2 (D.map (u y) ⁻¹ᵁ U y).2
-  obtain ⟨k, v, hv⟩ := exists_app_map_eq_map_of_isLimit D c hc hcpt
-    ((D.map (u x)).app _ (t x) |_ _) ((D.map (u y)).app _ (t y) |_ _) (by
-    dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-    simp only [← ConcreteCategory.comp_apply,
-      Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, Scheme.Hom.appLE_comp_appLE, Cone.w]
-    exact (ht x _ _).trans (ht y _ _).symm)
-  refine ⟨k, v, fun V h₁ h₂ ↦ ?_⟩
-  have H : V ≤ D.map v ⁻¹ᵁ (D.map (u x) ⁻¹ᵁ U x ⊓ D.map (u y) ⁻¹ᵁ U y) := by
-    simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
-  apply_fun (D.obj k).presheaf.map (homOfLE H).op at hv
-  dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict] at hv ⊢
-  simpa [← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
-    Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hv
-
-include hc in
-lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    (s : Γ(c.pt, ⊤)) [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)] :
-    ∃ (i : I) (t : Γ(D.obj i, ⊤)), s = (c.π.app i).appTop t := by
+private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit
+    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)] (s : Γ(c.pt, ⊤)) :
+    ∃ (k : I) (J : Type u) (U : J → (D.obj k).Opens) (_ : IsOpenCover U)
+      (t : ∀ x, Γ(D.obj k, U x)), (D.obj k).presheaf.IsCompatible U t ∧
+        ∀ x (V : c.pt.Opens) (e : V ≤ c.π.app k ⁻¹ᵁ U x),
+          (c.π.app k).appLE (U x) V e (t x) = s |_ V := by
   classical
   have := Scheme.compactSpace_of_isLimit _ _ hc
   choose i U hU hxU t ht using exists_appLE_eq_restrict_of_isLimit D c hc s
@@ -909,25 +881,54 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
       simpa [← Set.preimage_comp, ← TopCat.coe_comp, ← Scheme.Hom.comp_base,
         Set.iUnion_subtype] using hσ)
     exact ⟨j, fun x ↦ w ≫ fj₀ x, by simpa [Scheme.Hom.preimage_iSup] using hw⟩
-  obtain ⟨k, v, hv⟩ := exists_forall_map_appLE_eq_of_isLimit D c hc (J := σ)
-    (fun x ↦ hU x) (fun x ↦ ht x) fj
-  have hcov : ⨆ x : σ, D.map (v ≫ fj x) ⁻¹ᵁ U x = ⊤ := by
-    simpa [Scheme.Hom.comp_preimage] using (D.map v).iSup_preimage_eq_top hfj
-  have H (x : σ) := (π_app_preimage_map_preimage D c (v ≫ fj x) (U x)).symm
-  obtain ⟨t₀, ht₀, -⟩ := TopCat.Sheaf.existsUnique_gluing' ⟨_, (D.obj k).IsSheaf⟩ _ ⊤
-    (fun _ ↦ homOfLE le_top) hcov.ge (fun x ↦ (D.map (v ≫ fj x)).app (U x) (t x)) fun x y ↦ by
-      dsimp [TopologicalSpace.Opens.infLELeft, TopologicalSpace.Opens.infLERight]
-      simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, -Scheme.Hom.comp_appLE]
-        using hv x y _ inf_le_left inf_le_right
-  replace ht₀ (x : σ) : t₀ |_ (D.map (v ≫ fj x) ⁻¹ᵁ U x) = (D.map (v ≫ fj x)).app (U x) (t x) :=
-    ht₀ x
-  refine ⟨k, t₀, TopCat.Sheaf.eq_of_locally_eq' ⟨_, c.pt.IsSheaf⟩
-    (fun x : σ ↦ c.π.app (i x) ⁻¹ᵁ U x) ⊤ (fun _ ↦ homOfLE le_top) ?_ _ _ fun x ↦ ?_⟩
-  · simpa only [H] using ((c.π.app k).iSup_preimage_eq_top hcov).ge
+  obtain ⟨k, v, hv⟩ : ∃ (k : I) (v : k ⟶ j), ∀ (x y : σ) (V : (D.obj k).Opens)
+      (h₁ : V ≤ D.map (v ≫ fj x) ⁻¹ᵁ U x) (h₂ : V ≤ D.map (v ≫ fj y) ⁻¹ᵁ U y),
+        (D.map (v ≫ fj x)).appLE _ V h₁ (t x) = (D.map (v ≫ fj y)).appLE _ V h₂ (t y) := by
+    refine IsCofiltered.exists_forall₂ _ ?_ fun x y ↦ ?_
+    · exact fun w v x y hv V h₁ h₂ ↦ by
+        have e : V ≤ D.map w ⁻¹ᵁ (D.map (v ≫ fj x) ⁻¹ᵁ U x ⊓ D.map (v ≫ fj y) ⁻¹ᵁ U y) := by
+          simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
+        simpa [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
+          using congr((D.map w).appLE _ V e $(hv _ inf_le_left inf_le_right))
+    have hcpt : IsCompact (X := D.obj j) ↑(D.map (fj x) ⁻¹ᵁ U x ⊓ D.map (fj y) ⁻¹ᵁ U y) :=
+      ((hU x).preimage (D.map (fj x))).isCompact.inter_of_isOpen
+        ((hU y).preimage (D.map (fj y))).isCompact (D.map (fj x) ⁻¹ᵁ U x).2
+        (D.map (fj y) ⁻¹ᵁ U y).2
+    obtain ⟨k, v, hv⟩ := exists_app_map_eq_map_of_isLimit D c hc hcpt
+      ((D.map (fj x)).app _ (t x) |_ _) ((D.map (fj y)).app _ (t y) |_ _) (by
+      dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
+      simp only [← ConcreteCategory.comp_apply,
+        Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, Scheme.Hom.appLE_comp_appLE, Cone.w]
+      exact (ht x _ _).trans (ht y _ _).symm)
+    refine ⟨k, v, fun V h₁ h₂ ↦ ?_⟩
+    have H : V ≤ D.map v ⁻¹ᵁ (D.map (fj x) ⁻¹ᵁ U x ⊓ D.map (fj y) ⁻¹ᵁ U y) := by
+      simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
+    apply_fun (D.obj k).presheaf.map (homOfLE H).op at hv
+    dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict] at hv ⊢
+    simpa [← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
+      Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hv
+  refine ⟨k, σ, fun x ↦ D.map (v ≫ fj x) ⁻¹ᵁ U x,
+    .mk (by simpa [Scheme.Hom.comp_preimage] using (D.map v).iSup_preimage_eq_top hfj),
+    fun x ↦ (D.map (v ≫ fj x)).app (U x) (t x), fun x y ↦ ?_, fun x V e ↦ ?_⟩
+  · dsimp [TopologicalSpace.Opens.infLELeft, TopologicalSpace.Opens.infLERight]
+    simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, -Scheme.Hom.comp_appLE]
+      using hv x y _ inf_le_left inf_le_right
+  · simp only [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE,
+      Scheme.Hom.appLE_comp_appLE, Cone.w]
+    exact ht x V _
+
+include hc in
+lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    (s : Γ(c.pt, ⊤)) [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)] :
+    ∃ (i : I) (t : Γ(D.obj i, ⊤)), s = (c.π.app i).appTop t := by
+  obtain ⟨k, J, U, hU, t, hcompat, ht⟩ := exists_isOpenCover_appLE_eq_restrict_of_isLimit D c hc s
+  obtain ⟨t₀, ht₀, -⟩ := TopCat.Sheaf.existsUnique_gluing' ⟨_, (D.obj k).IsSheaf⟩ U ⊤
+    (fun _ ↦ homOfLE le_top) hU.ge t hcompat
+  refine ⟨k, t₀, TopCat.Sheaf.eq_of_locally_eq' ⟨_, c.pt.IsSheaf⟩ (fun x ↦ c.π.app k ⁻¹ᵁ U x) ⊤
+    (fun _ ↦ homOfLE le_top) ((c.π.app k).iSup_preimage_eq_top hU).ge _ _ fun x ↦ ?_⟩
   refine (ht x _ le_rfl).symm.trans (Eq.trans ?_ (ConcreteCategory.comp_apply _ _ _))
-  have key := congr((c.π.app k).appLE _ (c.π.app (i x) ⁻¹ᵁ U x) (H x).le $(ht₀ x))
-  simp only [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict, ← ConcreteCategory.comp_apply,
-    Scheme.Hom.map_appLE, Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE, Cone.w] at key
+  have key := congr((c.π.app k).appLE _ (c.π.app k ⁻¹ᵁ U x) le_rfl $(ht₀ x))
+  simp only [← ConcreteCategory.comp_apply, Scheme.Hom.map_appLE] at key
   exact key.symm
 
 include hc in
@@ -1282,7 +1283,7 @@ lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
   -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
   have h𝒲 : IsOpenCover (D.map u ⁻¹ᵁ 𝒱 ·) := .mk ((D.map u).iSup_preimage_eq_top h𝒱)
   let F := (Scheme.openCoverOfIsOpenCover _ _ h𝒲).glueMorphisms g fun j₁ j₂ ↦ by
-    show pullback.fst (D.map u ⁻¹ᵁ 𝒱 j₁).ι (D.map u ⁻¹ᵁ 𝒱 j₂).ι ≫ _ = pullback.snd _ _ ≫ _
+    change pullback.fst (D.map u ⁻¹ᵁ 𝒱 j₁).ι (D.map u ⁻¹ᵁ 𝒱 j₂).ι ≫ _ = pullback.snd _ _ ≫ _
     rw [← cancel_epi (isPullback_opens_inf _ _).isoPullback.hom]
     simpa using hglue j₁ j₂ _ inf_le_left inf_le_right
   have hF (j : s) : (D.map u ⁻¹ᵁ 𝒱 j).ι ≫ F = g j := Scheme.Cover.ι_glueMorphisms ..

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -1144,6 +1144,9 @@ end IsAffine
 
 section LocallyOfFinitePresentation
 
+variable [IsCofiltered I] (a : c.pt ⟶ X)
+  (ha : c.π ≫ t = (Functor.const _).map (a ≫ f))
+
 private lemma Scheme.exists_appTop_eq {Y Z : Scheme.{u}} [IsAffine Z] (φ : Γ(Z, ⊤) ⟶ Γ(Y, ⊤)) :
     ∃ g : Y ⟶ Z, g.appTop = φ := by
   have h : Z.isoSpec.inv.appTop = (Scheme.ΓSpecIso Γ(Z, ⊤)).inv := by
@@ -1153,12 +1156,10 @@ private lemma Scheme.exists_appTop_eq {Y Z : Scheme.{u}} [IsAffine Z] (φ : Γ(Z
   rw [Scheme.Hom.comp_appTop, Scheme.Hom.comp_appTop, h, Scheme.toSpecΓ_appTop, Category.assoc,
     Scheme.ΓSpecIso_naturality, Iso.inv_hom_id_assoc]
 
-include hc in
+include hc ha in
 /-- See `Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation` for the general case. -/
 private nonrec lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
-    [IsCofiltered I] [LocallyOfFinitePresentation f]
-    [IsAffine S] [IsAffine X] [∀ i, IsAffine (D.obj i)]
-    (a : c.pt ⟶ X) (ha : c.π ≫ t = (Functor.const _).map (a ≫ f)) :
+    [LocallyOfFinitePresentation f] [IsAffine S] [IsAffine X] [∀ i, IsAffine (D.obj i)] :
     ∃ (i : I) (g : D.obj i ⟶ X), c.π.app i ≫ g = a ∧ g ≫ f = t.app i := by
   -- Every scheme involved is affine, so the proof is merely translate to commutative algebra and
   -- use `RingHom.EssFiniteType.exists_eq_comp_ι_app_of_isColimit`.
@@ -1190,11 +1191,10 @@ private lemma isBasis_affineOpens_le_preimage {Y Z T : Scheme.{u}} (a : Y ⟶ Z)
     (U := O ⊓ a ⁻¹ᵁ V) (x := y) ⟨hy, hyV⟩
   exact ⟨U, ⟨hU, ⟨V, hV⟩, ⟨W, hW⟩, hUV.trans inf_le_right, hVW⟩, hyU, hUV.trans inf_le_left⟩
 
-include hc in
-private lemma exists_resLE_comp_eq_of_isAffineOpen
-    [IsCofiltered I] [LocallyOfFinitePresentation f]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    (a : c.pt ⟶ X) (ha : c.π ≫ t = (Functor.const _).map (a ≫ f))
+variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+
+include hc ha in
+private lemma exists_resLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresentation f]
     {i : I} {U : (D.obj i).Opens} (hU : IsAffineOpen U) (V : X.affineOpens) (W : S.affineOpens)
     (hVW : (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens)) (hUV : c.π.app i ⁻¹ᵁ U ≤ a ⁻¹ᵁ (V : X.Opens)) :
     ∃ (k : I) (u : k ⟶ i) (g : ↑(D.map u ⁻¹ᵁ U) ⟶ X),
@@ -1235,36 +1235,27 @@ private lemma exists_resLE_comp_eq_of_isAffineOpen
   · have h' : O ≤ c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U := by simpa using h
     simpa using congr(Scheme.homOfLE _ h' ≫ $hg ≫ (V : X.Opens).ι)
 
-include hc in
-private lemma exists_forall_resLE_comp_eq_of_isAffineOpen
-    [IsCofiltered I] [LocallyOfFinitePresentation f]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    (a : c.pt ⟶ X) (ha : c.π ≫ t = (Functor.const _).map (a ≫ f))
+include hc ha in
+private lemma exists_forall_resLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresentation f]
     {i : I} {J : Type*} [Finite J] {U : J → (D.obj i).Opens} (hU : ∀ j, IsAffineOpen (U j))
     (hUV : ∀ j, ∃ (V : X.affineOpens) (W : S.affineOpens),
       c.π.app i ⁻¹ᵁ U j ≤ a ⁻¹ᵁ (V : X.Opens) ∧ (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens)) :
-    ∃ (k : I) (u : k ⟶ i) (g : ∀ j, ↑(D.map u ⁻¹ᵁ U j) ⟶ X),
-      (∀ j, g j ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k) ∧
-        ∀ j (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
-          (c.π.app k).resLE _ O h ≫ g j = O.ι ≫ a := by
-  choose V W hUV hVW using hUV
-  choose k u g hg hg' using IsCofiltered.exists_forall
-    (fun k (u : k ⟶ i) (j : J) ↦ ∃ g : ↑(D.map u ⁻¹ᵁ U j) ⟶ X,
+    ∃ (k : I) (u : k ⟶ i), ∀ j, ∃ g : ↑(D.map u ⁻¹ᵁ U j) ⟶ X,
       g ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k ∧
         ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
-          (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a)
-    (by
-      rintro k₁ k₂ v u j ⟨g, hg, hg'⟩
-      have e : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
-      exact ⟨(D.map v).resLE _ _ e ≫ g, by simpa using congr((D.map v).resLE _ _ e ≫ $hg),
-        fun O h ↦ by
-          simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)⟩)
-    fun j ↦ exists_resLE_comp_eq_of_isAffineOpen D t f c hc a ha (hU j) (V j) (W j) (hVW j) (hUV j)
-  exact ⟨k, u, g, hg, hg'⟩
+          (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a := by
+  choose V W hUV hVW using hUV
+  refine IsCofiltered.exists_forall _ ?_ fun j ↦
+    exists_resLE_comp_eq_of_isAffineOpen D t f c hc a ha (hU j) (V j) (W j) (hVW j) (hUV j)
+  rintro k₁ k₂ v u j ⟨g, hg, hg'⟩
+  have e : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
+  exact ⟨(D.map v).resLE _ _ e ≫ g, by simpa using congr((D.map v).resLE _ _ e ≫ $hg),
+    fun O h ↦ by simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)⟩
+
+variable [∀ i, QuasiSeparatedSpace (D.obj i)]
 
 include hc in
-private lemma exists_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOfFiniteType f]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [∀ i, QuasiSeparatedSpace (D.obj i)]
+private lemma exists_resLE_comp_eq_resLE_comp [LocallyOfFiniteType f]
     {k : I} {U₁ U₂ : (D.obj k).Opens} (hU₁ : IsCompact (U₁ : Set (D.obj k)))
     (hU₂ : IsCompact (U₂ : Set (D.obj k))) (g₁ : ↑U₁ ⟶ X) (g₂ : ↑U₂ ⟶ X)
     (hg₁ : g₁ ≫ f = U₁.ι ≫ t.app k) (hg₂ : g₂ ≫ f = U₂.ι ≫ t.app k)
@@ -1296,8 +1287,7 @@ private lemma exists_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOfFiniteT
     (show O ≤ D.map v ⁻¹ᵁ (U₁ ⊓ U₂) from le_inf e₁ e₂) ≫ $e)
 
 include hc in
-private lemma exists_forall_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOfFiniteType f]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [∀ i, QuasiSeparatedSpace (D.obj i)]
+private lemma exists_forall_resLE_comp_eq_resLE_comp [LocallyOfFiniteType f]
     {k : I} {J : Type*} [Finite J] {U : J → (D.obj k).Opens}
     (hU : ∀ j, IsCompact (U j : Set (D.obj k))) (g : ∀ j, ↑(U j) ⟶ X)
     (hg : ∀ j, g j ≫ f = (U j).ι ≫ t.app k)
@@ -1305,8 +1295,8 @@ private lemma exists_forall_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOf
       (c.π.app k).resLE _ O e₁ ≫ g j₁ = (c.π.app k).resLE _ O e₂ ≫ g j₂) :
     ∃ (l : I) (v : l ⟶ k), ∀ j₁ j₂ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U j₁)
       (e₂ : O ≤ D.map v ⁻¹ᵁ U j₂),
-        (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ := by
-  obtain ⟨l, v, hl⟩ := IsCofiltered.exists_forall
+        (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ :=
+  Exists₂.imp (fun _ _ hl j₁ j₂ ↦ hl (j₁, j₂)) <| IsCofiltered.exists_forall
     (fun l (v : l ⟶ k) (j : J × J) ↦ ∀ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U j.1)
       (e₂ : O ≤ D.map v ⁻¹ᵁ U j.2),
         (D.map v).resLE _ O e₁ ≫ g j.1 = (D.map v).resLE _ O e₂ ≫ g j.2)
@@ -1316,27 +1306,23 @@ private lemma exists_forall_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOf
           $(hv _ inf_le_left inf_le_right)))
     fun j ↦ exists_resLE_comp_eq_resLE_comp D t f c hc (hU j.1) (hU j.2) _ _ (hg j.1) (hg j.2)
       (h j.1 j.2)
-  exact ⟨l, v, fun j₁ j₂ ↦ hl (j₁, j₂)⟩
 
 open TopologicalSpace in
-include hc in
+include hc ha in
 /--
 Given a cofiltered diagram of qcqs schemes `Dᵢ` over `S` with affine transition maps.
 If `X` is locally of finite presentation over `S`, then any `S`-morphism `lim Dᵢ ⟶ X` factors
 through some `lim Dᵢ ⟶ Dⱼ ⟶ X` for some `j`.
 -/
 lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
-    [IsCofiltered I] [LocallyOfFinitePresentation f]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)]
-    (a : c.pt ⟶ X) (ha : c.π ≫ t = (Functor.const _).map (a ≫ f)) :
+    [LocallyOfFinitePresentation f] [∀ i, CompactSpace (D.obj i)] :
     ∃ (i : I) (g : D.obj i ⟶ X), c.π.app i ≫ g = a ∧ g ≫ f = t.app i := by
   -- The open cover of `c := lim Dᵢ` by the affine opens `U ⊆ c` such that `U` maps into an affine
   -- `V ⊆ X` which in turn maps into an affine `W ⊆ S`.
   have h𝒰 := (isBasis_affineOpens_le_preimage a f).isOpenCover
   obtain ⟨i, s, 𝒱, h𝒱, h𝒱𝒰⟩ := Scheme.exists_isOpenCover_and_isAffine D c hc _ h𝒰 fun U ↦ U.2.1
   -- Each `𝒱 j` factors after passing to some `k`, and by finiteness a single `k` works for all `j`.
-  obtain ⟨k, fki, ak, hak, hak'⟩ := exists_forall_resLE_comp_eq_of_isAffineOpen D t f c hc a ha
+  choose k fki ak hak hak' using exists_forall_resLE_comp_eq_of_isAffineOpen D t f c hc a ha
     (fun j ↦ (h𝒱𝒰 j).1) fun j ↦ (h𝒱𝒰 j).2 ▸ j.1.2.2
   -- Likewise the `ak j` pairwise agree on overlaps after passing to some `l`.
   obtain ⟨l, flk, hl⟩ := exists_forall_resLE_comp_eq_resLE_comp D t f c hc
@@ -1372,7 +1358,7 @@ set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 /-- `Hom_S(-, X)` sends a cofiltered limit of qcqs `S`-schemes with affine transition maps
 to a filtered colimit if `X` is locally of finite presentation over `X`. -/
-instance Scheme.preservesColimit_yoneda (D : I ⥤ Over S) [IsCofiltered I]
+instance Scheme.preservesColimit_yoneda (D : I ⥤ Over S)
     [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f).left]
     [∀ (i : I), CompactSpace (D.obj i).left] [∀ (i : I), QuasiSeparatedSpace (D.obj i).left]
     (X : Over S) [LocallyOfFinitePresentation X.hom] :

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -853,10 +853,10 @@ private lemma exists_isOpenCover_app_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) 
       (h₁ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1.1) (h₂ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1.1),
         (D.map v).appLE _ V h₁ (T W₁) = (D.map v).appLE _ V h₂ (T W₂) := by
     refine IsCofiltered.exists_forall₂ ?_ fun W₁ W₂ ↦ ?_
-    · exact fun v u W₁ W₂ hv V h₁ h₂ ↦ by
-        simpa [Scheme.Hom.appLE_appLE, -Scheme.Hom.comp_appLE] using
-          congr((D.map v).appLE _ V ((le_inf h₁ h₂).trans_eq (by rw [D.map_comp]; rfl))
-            $(hv _ inf_le_left inf_le_right))
+    · intros _ _ v u W₁ W₂ hv V h₁ h₂
+      simpa [Scheme.Hom.appLE_appLE, -Scheme.Hom.comp_appLE] using
+        congr((D.map v).appLE _ V ((le_inf h₁ h₂).trans_eq (by rw [D.map_comp]; rfl))
+          $(hv _ inf_le_left inf_le_right))
     refine Exists₂.imp (fun k v hv V h₁ h₂ ↦ ?_) (exists_app_map_eq_map_of_isLimit D c hc
       ((W₁.1.2.preimage (D.map w)).isCompact_inf (W₂.1.2.preimage (D.map w)))
       (T W₁ |_ _) (T W₂ |_ _) (by

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -783,83 +783,60 @@ lemma exists_appTop_map_eq_zero_of_isAffine_of_isLimit
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
-lemma exists_appTop_map_eq_zero_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    {i : I} [CompactSpace (D.obj i)] (s : Γ(D.obj i, ⊤)) (hs : (c.π.app i).appTop s = 0) :
-    ∃ (j : I) (f : j ⟶ i), (D.map f).appTop s = 0 := by
-  classical
-  have (x : D.obj i) : ∃ (U : (D.obj i).Opens) (hU : IsAffineOpen U)
-      (hU : x ∈ U) (j : I) (f : j ⟶ i), (D.map f).app U (s |_ U) = 0 := by
-    obtain ⟨_, ⟨U, hU : IsAffineOpen U, rfl⟩, hxU, -⟩ :=
-      (D.obj i).isBasis_affineOpens.exists_subset_of_mem_open (Set.mem_univ x) isOpen_univ
-    have (j : Over i) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage (D.map _)
-    obtain ⟨j, f, hj⟩ := exists_appTop_map_eq_zero_of_isAffine_of_isLimit _ _
-      (isLimitOpensCone D c hc i U) (.mk (𝟙 i)) (((opensDiagramι D i U).app _).appTop s) (by
-        convert congr((c.pt.presheaf.map (homOfLE le_top).op).hom $hs)
-        · simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE, ← ConcreteCategory.comp_apply]; rfl
-        · simp)
-    refine ⟨U, hU, hxU, j.left, j.hom, ?_⟩
-    have hf : f.left = j.hom := by simpa using Over.w f
-    let t' : Γ(D.map j.hom ⁻¹ᵁ U, ⊤) ⟶ Γ(D.obj j.left, D.map j.hom ⁻¹ᵁ U) :=
-      (D.obj _).presheaf.map (eqToHom ((D.map j.hom ⁻¹ᵁ U).ι_image_top.symm)).op
-    convert! congr(t' $hj)
-    · dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-      simp only [Scheme.Hom.app_eq_appLE, homOfLE_leOfHom, ← ConcreteCategory.comp_apply, hf,
-        Scheme.Hom.map_appLE, TopologicalSpace.Opens.map_top, Scheme.Hom.resLE_appLE]
-      simp [t']
-    · simp
-  choose U hU hxU j f H using this
-  obtain ⟨t, ht⟩ := CompactSpace.elim_nhds_subcover (U ·) (fun x ↦ (U x).2.mem_nhds (hxU x))
-  obtain ⟨k, fk, hk⟩ := IsCofiltered.inf_exists (insert i <| t.image j) (by
-    exact t.attach.image fun x ↦ ⟨j x.1, i, Finset.mem_insert_of_mem
-      (Finset.mem_image_of_mem _ x.2), by simp, f x.1⟩)
-  refine ⟨k, fk (by simp), ?_⟩
-  apply (D.obj k).IsSheaf.section_ext
-  rintro x -
-  obtain ⟨l, hl, hlU⟩ := Set.mem_iUnion₂.mp (ht.ge (Set.mem_univ ((D.map (fk (by simp))).base x)))
-  refine ⟨D.map (fk (by simp)) ⁻¹ᵁ U l, le_top, hlU, ?_⟩
-  dsimp
-  simp only [homOfLE_leOfHom, map_zero]
-  have h₁ : fk (by simp) = fk (Finset.mem_insert_of_mem (Finset.mem_image_of_mem _ hl)) ≫ f l :=
-    (hk _ (by simp) (Finset.mem_image.mpr ⟨⟨l, hl⟩, by simp, by simp⟩)).symm
-  have h₂ : D.map (fk (Finset.mem_insert_self _ _)) ⁻¹ᵁ U l ≤ D.map (fk (Finset.mem_insert_of_mem
-      (Finset.mem_image_of_mem _ hl))) ⁻¹ᵁ D.map (f l) ⁻¹ᵁ U l := by
-    rw [← Scheme.Hom.comp_preimage, ← D.map_comp, h₁]
-  convert! congr((D.map (fk _)).appLE _ _ h₂ $(H l))
-  · dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-    simp [Scheme.Hom.app_eq_appLE, ← ConcreteCategory.comp_apply, -CommRingCat.hom_comp,
-      Scheme.Hom.appLE_comp_appLE, ← Functor.map_comp, h₁]
-  · simp
-
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
-include hc in
 lemma exists_app_map_eq_zero_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     {i : I} {U : (D.obj i).Opens} (hU : IsCompact (X := D.obj i) U) (s : Γ(D.obj i, U))
     (hs : (c.π.app i).app U s = 0) :
     ∃ (j : I) (f : j ⟶ i), (D.map f).app U s = 0 := by
-  have : CompactSpace ↥((opensDiagram D i U).obj (Over.mk (𝟙 i))) :=
-    isCompact_iff_compactSpace.mp (by simpa)
-  have H : (D.map (𝟙 _) ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ U := by simp
-  obtain ⟨j, f, hf⟩ := exists_appTop_map_eq_zero_of_isLimit _ _
-    (isLimitOpensCone D c hc i U) (i := .mk (𝟙 i))
-    ((D.obj i).presheaf.map (homOfLE H).op s) (by
-      rw [← map_zero (c.pt.presheaf.map (homOfLE
-        (show (c.π.app i ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ c.π.app i ⁻¹ᵁ U by simp)).op).hom, ← hs]
-      dsimp [Scheme.Opens.toScheme_presheaf_obj]
+  have key {W : (D.obj i).Opens} (hW : IsAffineOpen W) (hWU : W ≤ U) :
+      ∃ (j : I) (f : j ⟶ i), (D.map f).app W (s |_ W) = 0 := by
+    have (j : Over i) : IsAffine ((opensDiagram D i W).obj j) := hW.preimage (D.map _)
+    have H : (D.map (𝟙 _) ⁻¹ᵁ W).ι ''ᵁ ⊤ ≤ W := by simp
+    obtain ⟨j, f, hf⟩ := exists_appTop_map_eq_zero_of_isAffine_of_isLimit _ _
+      (isLimitOpensCone D c hc i W) (.mk (𝟙 i))
+      ((D.obj i).presheaf.map (homOfLE H).op (s |_ W)) (by
+        rw [← map_zero (c.pt.presheaf.map (homOfLE (show (c.π.app i ⁻¹ᵁ W).ι ''ᵁ ⊤ ≤
+          c.π.app i ⁻¹ᵁ U from le_trans (by simp) ((c.π.app i).preimage_mono hWU))).op).hom, ← hs]
+        dsimp [Scheme.Opens.toScheme_presheaf_obj, TopCat.Presheaf.restrictOpen,
+          TopCat.Presheaf.restrict]
+        rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply,
+          ← ConcreteCategory.comp_apply]
+        congr! 2
+        simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE])
+    dsimp at hf
+    refine ⟨j.left, f.left, ?_⟩
+    have hf' : f.left = j.hom := by simpa using Over.w f
+    convert!
+      congr((D.obj j.left).presheaf.map
+        (homOfLE (show D.map f.left ⁻¹ᵁ W ≤ (D.map j.hom ⁻¹ᵁ W).ι ''ᵁ ⊤ by simp [hf'])).op $hf)
+    · dsimp [Scheme.Opens.toScheme_presheaf_obj]
       rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply]
       congr! 2
-      simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE])
-  dsimp at hf
-  refine ⟨j.left, f.left, ?_⟩
-  have hf' : f.left = j.hom := by simpa using Over.w f
-  convert!
-    congr((D.obj j.left).presheaf.map
-      (homOfLE (show D.map f.left ⁻¹ᵁ U ≤ (D.map j.hom ⁻¹ᵁ U).ι ''ᵁ ⊤ by simp [hf'])).op $hf)
-  · dsimp [Scheme.Opens.toScheme_presheaf_obj]
-    rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply]
-    congr! 2
-    simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE]
-  · simp
+      simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE]
+    · simp
+  obtain ⟨Us, hUs, hUsf, hsup⟩ := (D.obj i).isBasis_affineOpens.exists_finite_of_isCompact hU
+  have : Finite Us := hUsf
+  have hle (W : Us) : (W : (D.obj i).Opens) ≤ U := (le_sSup W.2).trans hsup.ge
+  choose j u H using fun W : Us ↦ key (hUs W.2) (hle W)
+  obtain ⟨k, v, w, hw⟩ := IsCofiltered.wideCospan u
+  refine ⟨k, v, TopCat.Sheaf.eq_of_locally_eq' ⟨_, (D.obj k).IsSheaf⟩
+    (fun W : Us ↦ D.map v ⁻¹ᵁ (W : (D.obj i).Opens)) _
+    (fun W ↦ homOfLE ((D.map v).preimage_mono (hle W))) ?_ _ _ fun W ↦ ?_⟩
+  · rw [hsup, sSup_eq_iSup', Scheme.Hom.preimage_iSup]
+  · have h₂ : D.map v ⁻¹ᵁ (W : (D.obj i).Opens) ≤
+        D.map (w W) ⁻¹ᵁ D.map (u W) ⁻¹ᵁ (W : (D.obj i).Opens) := by
+      rw [← Scheme.Hom.comp_preimage, ← D.map_comp, hw W]
+    convert! congr((D.map (w W)).appLE _ _ h₂ $(H W))
+    · dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
+      simp [Scheme.Hom.app_eq_appLE, ← ConcreteCategory.comp_apply, -CommRingCat.hom_comp,
+        Scheme.Hom.appLE_comp_appLE, ← Functor.map_comp, hw W]
+    · simp
+
+set_option backward.defeqAttrib.useBackward true in
+include hc in
+lemma exists_appTop_map_eq_zero_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    {i : I} [CompactSpace (D.obj i)] (s : Γ(D.obj i, ⊤)) (hs : (c.π.app i).appTop s = 0) :
+    ∃ (j : I) (f : j ⟶ i), (D.map f).appTop s = 0 :=
+  exists_app_map_eq_zero_of_isLimit D c hc (by simpa using isCompact_univ) s hs
 
 include hc in
 lemma exists_app_map_eq_map_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -803,50 +803,46 @@ variable [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)]
 
 open TopologicalSpace in
 include hc in
-private lemma Scheme.exists_isOpenCover_app_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) :
+private lemma exists_isOpenCover_app_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) :
     ∃ (k : I) (J : Type u) (U : J → (D.obj k).Opens) (_ : IsOpenCover U)
       (t : ∀ x, Γ(D.obj k, U x)), (D.obj k).presheaf.IsCompatible U t ∧
         ∀ x, (c.π.app k).app (U x) (t x) = s |_ (c.π.app k ⁻¹ᵁ U x) := by
   obtain ⟨i⟩ := IsCofiltered.nonempty (C := I)
   obtain ⟨Us, hcov⟩ :=
     (IsOpenCover.mk (iSup_affineOpens_eq_top (D.obj i))).exists_finite_of_compactSpace
-  obtain ⟨n, w, hT⟩ : ∃ (n : I) (w : n ⟶ i), ∀ W : Us, ∃ T : Γ(D.obj n, D.map w ⁻¹ᵁ W.1.1),
-      (c.π.app n).appLE _ (c.π.app i ⁻¹ᵁ W.1.1) (by simp) T = s |_ _ :=
-    IsCofiltered.exists_forall (fun v u W ⟨T, hT⟩ ↦ ⟨(D.map v).appLE _ _ (by simp) T, by
-      simpa only [Hom.appLE_appLE, Cone.w] using hT⟩)
-      fun W ↦ exists_appLE_π_eq_of_isAffineOpen D c hc W.1.2 (s |_ _)
+  obtain ⟨n, w, hT⟩ := IsCofiltered.exists_forall
+    (fun v u W ⟨T, hT⟩ ↦ ⟨(D.map v).appLE _ _ (by simp) T, by
+      simpa only [Scheme.Hom.appLE_appLE, Cone.w] using hT⟩)
+    fun W : Us ↦ exists_appLE_π_eq_of_isAffineOpen D c hc W.1.2 (s |_ _)
   choose T hT using hT
   replace hT (W : Us) {V : c.pt.Opens} (e : V ≤ c.π.app n ⁻¹ᵁ D.map w ⁻¹ᵁ W.1.1) :
       (c.π.app n).appLE _ V e (T W) = s |_ V := by
     have h := π_app_preimage_map_preimage D c w W.1.1
-    rw [← Hom.restrict_appLE _ h.ge (e.trans_eq h), hT W, TopCat.Presheaf.restrict_restrict]
+    rw [← Scheme.Hom.restrict_appLE _ h.ge (e.trans_eq h), hT W, TopCat.Presheaf.restrict_restrict]
   obtain ⟨k, v, hv⟩ : ∃ (k : I) (v : k ⟶ n), ∀ (W₁ W₂ : Us) (V : (D.obj k).Opens)
       (h₁ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1.1) (h₂ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1.1),
         (D.map v).appLE _ V h₁ (T W₁) = (D.map v).appLE _ V h₂ (T W₂) := by
-    refine IsCofiltered.exists_forall₂ ?_ fun W₁ W₂ ↦ ?_
-    · intros _ _ v u W₁ W₂ hv V h₁ h₂
-      simpa [Hom.appLE_appLE, -Hom.comp_appLE] using
+    refine IsCofiltered.exists_forall₂ (fun v u W₁ W₂ hv V h₁ h₂ ↦ by
+      simpa [Scheme.Hom.appLE_appLE, -Scheme.Hom.comp_appLE] using
         congr((D.map v).appLE _ V ((le_inf h₁ h₂).trans_eq (by rw [D.map_comp]; rfl))
-          $(hv _ inf_le_left inf_le_right))
+          $(hv _ inf_le_left inf_le_right))) fun W₁ W₂ ↦ ?_
     refine Exists₂.imp (fun k v hv V h₁ h₂ ↦ ?_) (exists_app_map_eq_map_of_isLimit D c hc
-      ((W₁.1.2.preimage (D.map w)).isCompact_inf (W₂.1.2.preimage (D.map w)))
-      (T W₁ |_ _) (T W₂ |_ _) (by
-        simpa [Hom.app_restrict, ← Hom.appLE_apply] using
-          (hT W₁ _).trans (hT W₂ _).symm))
-    simpa [Hom.app_restrict, Hom.appLE_apply, TopCat.Presheaf.restrict_restrict]
+      ((W₁.1.2.preimage (D.map w)).isCompact_inf (W₂.1.2.preimage (D.map w))) (T W₁ |_ _)
+      (T W₂ |_ _) (by simpa [Scheme.Hom.app_restrict, ← Scheme.Hom.appLE_apply] using
+        (hT W₁ _).trans (hT W₂ _).symm))
+    simpa [Scheme.Hom.app_restrict, Scheme.Hom.appLE_apply, TopCat.Presheaf.restrict_restrict]
       using congr($hv |_ₗ V ⟪(le_inf h₁ h₂).trans_eq (D.map v).preimage_inf.symm⟫)
   refine ⟨k, Us, fun W ↦ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W.1.1,
     (hcov.preimage (D.map w)).preimage (D.map v), fun W ↦ (D.map v).app _ (T W),
     fun W₁ W₂ ↦ ?_, fun W ↦ ?_⟩
-  · simpa [Opens.infLELeft, Opens.infLERight, Hom.appLE] using
+  · simpa [Opens.infLELeft, Opens.infLERight, Scheme.Hom.appLE] using
       hv W₁ W₂ _ inf_le_left inf_le_right
-  · simpa only [Hom.app_eq_appLE, Hom.appLE_appLE, Cone.w] using hT W _
+  · simpa only [Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_appLE, Cone.w] using hT W _
 
 include hc in
 lemma exists_appTop_π_eq_of_isLimit (s : Γ(c.pt, ⊤)) :
     ∃ (i : I) (t : Γ(D.obj i, ⊤)), s = (c.π.app i).appTop t := by
-  obtain ⟨k, J, U, hU, t, hcompat, ht⟩ :=
-    Scheme.exists_isOpenCover_app_eq_restrict_of_isLimit D c hc s
+  obtain ⟨k, J, U, hU, t, hcompat, ht⟩ := exists_isOpenCover_app_eq_restrict_of_isLimit D c hc s
   obtain ⟨t₀, ht₀, -⟩ := TopCat.Sheaf.existsUnique_gluing' ⟨_, (D.obj k).IsSheaf⟩ U ⊤
     (fun _ ↦ homOfLE le_top) hU.ge t hcompat
   refine ⟨k, t₀, TopCat.Sheaf.eq_of_locally_eq' ⟨_, c.pt.IsSheaf⟩ (fun x ↦ c.π.app k ⁻¹ᵁ U x) ⊤

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -1172,13 +1172,24 @@ private lemma isBasis_affineOpens_le_preimage {Y Z T : Scheme.{u}} (a : Y ⟶ Z)
     (U := O ⊓ a ⁻¹ᵁ V) (x := y) ⟨hy, hyV⟩
   exact ⟨U, ⟨hU, ⟨V, hV⟩, ⟨W, hW⟩, hUV.trans inf_le_right, hVW⟩, hyU, hUV.trans inf_le_left⟩
 
-variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+open TopologicalSpace in
+lemma Scheme.exists_ι_comp_eq_of_isOpenCover {s : Type*} {X Y : Scheme.{u}} {U : s → X.Opens}
+    (hU : IsOpenCover U) (g : ∀ i, (U i).toScheme ⟶ Y)
+    (h : ∀ i j, X.homOfLE inf_le_left ≫ g i = X.homOfLE inf_le_right ≫ g j) :
+    ∃ f : X ⟶ Y, ∀ i, (U i).ι ≫ f = g i :=
+  ⟨(X.openCoverOfIsOpenCover U hU).glueMorphisms g fun i j ↦ by
+      change pullback.fst (U i).ι (U j).ι ≫ g i = pullback.snd _ _ ≫ g j
+      rw [← cancel_epi (isPullback_opens_inf (U i) (U j)).isoPullback.hom]
+      simpa using h i j,
+    fun i ↦ (X.openCoverOfIsOpenCover U hU).ι_glueMorphisms ..⟩
 
-include hc ha in
-private lemma exists_forall_resLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresentation f]
-    {i : I} {J : Type*} [Finite J] {U : J → (D.obj i).Opens} (hU : ∀ j, IsAffineOpen (U j))
-    (hUV : ∀ j, ∃ (V : X.affineOpens) (W : S.affineOpens),
-      c.π.app i ⁻¹ᵁ U j ≤ a ⁻¹ᵁ (V : X.Opens) ∧ (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens)) :
+variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [LocallyOfFinitePresentation f]
+  {i : I} {J : Type*} [Finite J] {U : J → (D.obj i).Opens} (hU : ∀ j, IsAffineOpen (U j))
+  (hUV : ∀ j, ∃ (V : X.affineOpens) (W : S.affineOpens),
+    c.π.app i ⁻¹ᵁ U j ≤ a ⁻¹ᵁ (V : X.Opens) ∧ (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens))
+
+include hc ha hU hUV in
+private lemma exists_forall_resLE_comp_eq_of_isAffineOpen :
     ∃ (k : I) (u : k ⟶ i), ∀ j, ∃ g : ↑(D.map u ⁻¹ᵁ U j) ⟶ X,
       g ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k ∧
         ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
@@ -1224,17 +1235,12 @@ private lemma exists_forall_resLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresen
 
 variable [∀ i, QuasiSeparatedSpace (D.obj i)]
 
-include hc ha in
-private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresentation f]
-    {i : I} {J : Type*} [Finite J] {U : J → (D.obj i).Opens} (hU : ∀ j, IsAffineOpen (U j))
-    (hUV : ∀ j, ∃ (V : X.affineOpens) (W : S.affineOpens),
-      c.π.app i ⁻¹ᵁ U j ≤ a ⁻¹ᵁ (V : X.Opens) ∧ (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens)) :
+include hc ha hU hUV in
+private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
     ∃ (k : I) (u : k ⟶ i) (g : ∀ j, ↑(D.map u ⁻¹ᵁ U j) ⟶ X),
       (∀ j, g j ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k) ∧
-      (∀ j (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
-        (c.π.app k).resLE _ O h ≫ g j = O.ι ≫ a) ∧
-      ∀ j₁ j₂ (O : (D.obj k).Opens) (e₁ : O ≤ D.map u ⁻¹ᵁ U j₁) (e₂ : O ≤ D.map u ⁻¹ᵁ U j₂),
-        Scheme.homOfLE _ e₁ ≫ g j₁ = Scheme.homOfLE _ e₂ ≫ g j₂ := by
+      (∀ j, (c.π.app k).resLE _ _ le_rfl ≫ g j = (c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j).ι ≫ a) ∧
+      ∀ j₁ j₂, Scheme.homOfLE _ inf_le_left ≫ g j₁ = Scheme.homOfLE _ inf_le_right ≫ g j₂ := by
   choose k u g hg hg' using exists_forall_resLE_comp_eq_of_isAffineOpen D t f c hc a ha hU hUV
   obtain ⟨l, v, hl⟩ : ∃ (l : I) (v : l ⟶ k), ∀ j₁ j₂ (O : (D.obj l).Opens)
       (e₁ : O ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j₁) (e₂ : O ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j₂),
@@ -1256,11 +1262,11 @@ private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen [LocallyOfFinitePres
       simpa using congr(Scheme.homOfLE _ (show O ≤ D.map v ⁻¹ᵁ _ by
         simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫ $e)⟩
   have e (j : J) : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
-  refine ⟨l, v ≫ u, fun j ↦ (D.map v).resLE _ _ (e j) ≫ g j, fun j ↦ ?_, fun j O h ↦ ?_,
-    fun j₁ j₂ O e₁ e₂ ↦ ?_⟩
+  refine ⟨l, v ≫ u, fun j ↦ (D.map v).resLE _ _ (e j) ≫ g j, fun j ↦ ?_, fun j ↦ ?_,
+    fun j₁ j₂ ↦ ?_⟩
   · simpa using congr((D.map v).resLE _ _ (e j) ≫ $(hg j))
-  · simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' j O (by simpa using h)
-  · simpa using hl j₁ j₂ O (by simpa using e₁) (by simpa using e₂)
+  · simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' j _ (by simp)
+  · simpa using hl j₁ j₂ _ (by simp) (by simp)
 
 open TopologicalSpace in
 include hc ha in
@@ -1269,8 +1275,7 @@ Given a cofiltered diagram of qcqs schemes `Dᵢ` over `S` with affine transitio
 If `X` is locally of finite presentation over `S`, then any `S`-morphism `lim Dᵢ ⟶ X` factors
 through some `lim Dᵢ ⟶ Dⱼ ⟶ X` for some `j`.
 -/
-lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
-    [LocallyOfFinitePresentation f] [∀ i, CompactSpace (D.obj i)] :
+lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation [∀ i, CompactSpace (D.obj i)] :
     ∃ (i : I) (g : D.obj i ⟶ X), c.π.app i ≫ g = a ∧ g ≫ f = t.app i := by
   -- The open cover of `c := lim Dᵢ` by the affine opens `U ⊆ c` such that `U` maps into an affine
   -- `V ⊆ X` which in turn maps into an affine `W ⊆ S`.
@@ -1281,15 +1286,11 @@ lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
     (fun j ↦ (h𝒱𝒰 j).1) fun j ↦ (h𝒱𝒰 j).2 ▸ j.1.2.2
   -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
   have h𝒲 : IsOpenCover (D.map u ⁻¹ᵁ 𝒱 ·) := .mk ((D.map u).iSup_preimage_eq_top h𝒱)
-  let F := (Scheme.openCoverOfIsOpenCover _ _ h𝒲).glueMorphisms g fun j₁ j₂ ↦ by
-    change pullback.fst (D.map u ⁻¹ᵁ 𝒱 j₁).ι (D.map u ⁻¹ᵁ 𝒱 j₂).ι ≫ _ = pullback.snd _ _ ≫ _
-    rw [← cancel_epi (isPullback_opens_inf _ _).isoPullback.hom]
-    simpa using hglue j₁ j₂ _ inf_le_left inf_le_right
-  have hF (j : s) : (D.map u ⁻¹ᵁ 𝒱 j).ι ≫ F = g j := Scheme.Cover.ι_glueMorphisms ..
+  obtain ⟨F, hF⟩ := Scheme.exists_ι_comp_eq_of_isOpenCover h𝒲 g hglue
   refine ⟨l, F, Scheme.hom_ext_of_isOpenCover (.mk ((c.π.app l).iSup_preimage_eq_top h𝒲)) _ _
       fun j ↦ ?_, Scheme.hom_ext_of_isOpenCover h𝒲 _ _ fun j ↦ ?_⟩
   · rw [← Hom.resLE_comp_ι_assoc (c.π.app l) le_rfl, hF]
-    exact hπg j _ _
+    exact hπg j
   · simp [reassoc_of% hF, hg]
 
 set_option backward.defeqAttrib.useBackward true in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -777,12 +777,13 @@ lemma exists_appTop_map_eq_zero_of_isAffine_of_isLimit
   dsimp at hj
   exact ⟨j.unop, f.unop, by simpa using hj⟩
 
+variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
-lemma exists_app_map_eq_zero_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    {i : I} {U : (D.obj i).Opens} (hU : IsCompact (X := D.obj i) U) (s : Γ(D.obj i, U))
-    (hs : (c.π.app i).app U s = 0) :
+lemma exists_app_map_eq_zero_of_isLimit {i : I} {U : (D.obj i).Opens}
+    (hU : IsCompact (X := D.obj i) U) (s : Γ(D.obj i, U)) (hs : (c.π.app i).app U s = 0) :
     ∃ (j : I) (f : j ⟶ i), (D.map f).app U s = 0 := by
   have key {W : (D.obj i).Opens} (hW : IsAffineOpen W) (hWU : W ≤ U) :
       ∃ (j : I) (f : j ⟶ i), (D.map f).app W (s |_ W) = 0 := by
@@ -830,22 +831,21 @@ lemma exists_app_map_eq_zero_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D
 
 set_option backward.defeqAttrib.useBackward true in
 include hc in
-lemma exists_appTop_map_eq_zero_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    {i : I} [CompactSpace (D.obj i)] (s : Γ(D.obj i, ⊤)) (hs : (c.π.app i).appTop s = 0) :
+lemma exists_appTop_map_eq_zero_of_isLimit {i : I} [CompactSpace (D.obj i)] (s : Γ(D.obj i, ⊤))
+    (hs : (c.π.app i).appTop s = 0) :
     ∃ (j : I) (f : j ⟶ i), (D.map f).appTop s = 0 :=
   exists_app_map_eq_zero_of_isLimit D c hc (by simpa using isCompact_univ) s hs
 
 include hc in
-lemma exists_app_map_eq_map_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    {i : I} {U : (D.obj i).Opens} (hU : IsCompact (X := D.obj i) U) (s t : Γ(D.obj i, U))
+lemma exists_app_map_eq_map_of_isLimit {i : I} {U : (D.obj i).Opens}
+    (hU : IsCompact (X := D.obj i) U) (s t : Γ(D.obj i, U))
     (hs : (c.π.app i).app U s = (c.π.app i).app U t) :
     ∃ (j : I) (f : j ⟶ i), (D.map f).app U s = (D.map f).app U t := by
   simpa [sub_eq_zero] using exists_app_map_eq_zero_of_isLimit _ _ hc hU (s - t)
     (by simpa +instances [map_sub, sub_eq_zero])
 
 include hc in
-private lemma exists_appLE_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    (s : Γ(c.pt, ⊤)) (x : c.pt) :
+private lemma exists_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) (x : c.pt) :
     ∃ (i : I) (U : (D.obj i).Opens) (_ : IsAffineOpen U) (_ : (c.π.app i).base x ∈ U)
       (t : Γ(D.obj i, U)), ∀ (V : c.pt.Opens) (e : V ≤ c.π.app i ⁻¹ᵁ U),
         (c.π.app i).appLE U V e t = s |_ V := by
@@ -859,11 +859,11 @@ private lemma exists_appLE_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAf
   rw [← TopCat.Presheaf.restrict_restrict (e.trans_eq h) le_top s, ← ht]
   exact (TopCat.Presheaf.restrict_restrict (e.trans_eq h) h.ge _).symm
 
+variable [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)]
+
 open TopologicalSpace in
 include hc in
-private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)] (s : Γ(c.pt, ⊤)) :
+private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) :
     ∃ (k : I) (J : Type u) (U : J → (D.obj k).Opens) (_ : IsOpenCover U)
       (t : ∀ x, Γ(D.obj k, U x)), (D.obj k).presheaf.IsCompatible U t ∧
         ∀ x (V : c.pt.Opens) (e : V ≤ c.π.app k ⁻¹ᵁ U x),
@@ -917,22 +917,20 @@ private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit
     exact ht x V _
 
 include hc in
-lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    (s : Γ(c.pt, ⊤)) [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)] :
+lemma exists_appTop_π_eq_of_isLimit (s : Γ(c.pt, ⊤)) :
     ∃ (i : I) (t : Γ(D.obj i, ⊤)), s = (c.π.app i).appTop t := by
   obtain ⟨k, J, U, hU, t, hcompat, ht⟩ := exists_isOpenCover_appLE_eq_restrict_of_isLimit D c hc s
   obtain ⟨t₀, ht₀, -⟩ := TopCat.Sheaf.existsUnique_gluing' ⟨_, (D.obj k).IsSheaf⟩ U ⊤
     (fun _ ↦ homOfLE le_top) hU.ge t hcompat
   refine ⟨k, t₀, TopCat.Sheaf.eq_of_locally_eq' ⟨_, c.pt.IsSheaf⟩ (fun x ↦ c.π.app k ⁻¹ᵁ U x) ⊤
-    (fun _ ↦ homOfLE le_top) ((c.π.app k).iSup_preimage_eq_top hU).ge _ _ fun x ↦ ?_⟩
+    (fun _ ↦ homOfLE le_top) (hU.preimage (c.π.app k)).ge _ _ fun x ↦ ?_⟩
   refine (ht x _ le_rfl).symm.trans (Eq.trans ?_ (ConcreteCategory.comp_apply _ _ _))
   have key := congr((c.π.app k).appLE _ (c.π.app k ⁻¹ᵁ U x) le_rfl $(ht₀ x))
   simp only [← ConcreteCategory.comp_apply, Scheme.Hom.map_appLE] at key
   exact key.symm
 
 include hc in
-lemma nonempty_isColimit_Γ_mapCocone [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)] :
+lemma nonempty_isColimit_Γ_mapCocone :
     Nonempty (IsColimit (Scheme.Γ.mapCocone c.op)) := by
   have : ReflectsFilteredColimits (forget CommRingCat) :=
     ⟨fun _ ↦ reflectsColimitsOfShape_of_reflectsIsomorphisms⟩
@@ -941,8 +939,7 @@ lemma nonempty_isColimit_Γ_mapCocone [∀ {i j} (f : i ⟶ j), IsAffineHom (D.m
   · exact fun i s t e ↦ ⟨_, Quiver.Hom.op _,
       (exists_app_map_eq_map_of_isLimit _ _ hc isCompact_univ s t e).choose_spec.choose_spec⟩
 
-instance [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)] :
+instance :
     PreservesLimit D Scheme.Γ.rightOp :=
   have : PreservesColimit D.op Scheme.Γ := ⟨fun hc ↦ nonempty_isColimit_Γ_mapCocone D _ hc.unop⟩
   preservesLimit_rightOp _ _
@@ -1128,15 +1125,6 @@ section LocallyOfFinitePresentation
 variable [IsCofiltered I] (a : c.pt ⟶ X)
   (ha : c.π ≫ t = (Functor.const _).map (a ≫ f))
 
-private lemma Scheme.exists_appTop_eq {Y Z : Scheme.{u}} [IsAffine Z] (φ : Γ(Z, ⊤) ⟶ Γ(Y, ⊤)) :
-    ∃ g : Y ⟶ Z, g.appTop = φ := by
-  have h : Z.isoSpec.inv.appTop = (Scheme.ΓSpecIso Γ(Z, ⊤)).inv := by
-    rw [← cancel_epi (Scheme.ΓSpecIso Γ(Z, ⊤)).hom, Iso.hom_inv_id, ← Scheme.toSpecΓ_appTop,
-      ← Scheme.Hom.comp_appTop, Scheme.isoSpec_inv_toSpecΓ, Scheme.Hom.id_appTop]
-  refine ⟨Y.toSpecΓ ≫ Spec.map φ ≫ Z.isoSpec.inv, ?_⟩
-  rw [Scheme.Hom.comp_appTop, Scheme.Hom.comp_appTop, h, Scheme.toSpecΓ_appTop, Category.assoc,
-    Scheme.ΓSpecIso_naturality, Iso.inv_hom_id_assoc]
-
 include hc ha in
 /-- See `Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation` for the general case. -/
 private nonrec lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
@@ -1155,33 +1143,9 @@ private nonrec lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
     Γ(S, ⊤) (D.op ⋙ Scheme.Γ) α f.appTop _ (isColimitOfPreserves Scheme.Γ hc.op)
     (HasRingHomProperty.iff_of_isAffine.mp ‹LocallyOfFinitePresentation f›) a.appTop fun i ↦ by
       simpa [α] using congr(Scheme.Hom.appTop $(congr(($ha).app i.unop))).symm
-  obtain ⟨g, rfl⟩ := Scheme.exists_appTop_eq φ
+  obtain ⟨g, rfl⟩ := exists_appTop_eq_of_isAffine φ
   exact ⟨i.unop, g, ext_of_isAffine (by simpa using hφ'.symm),
     ext_of_isAffine (by simpa [α] using hφ)⟩
-
-open TopologicalSpace in
-private lemma isBasis_affineOpens_le_preimage {Y Z T : Scheme.{u}} (a : Y ⟶ Z) (g : Z ⟶ T) :
-    Opens.IsBasis {U : Y.Opens | IsAffineOpen U ∧ ∃ (V : Z.affineOpens) (W : T.affineOpens),
-      U ≤ a ⁻¹ᵁ (V : Z.Opens) ∧ (V : Z.Opens) ≤ g ⁻¹ᵁ (W : T.Opens)} := by
-  refine Opens.isBasis_iff_nbhd.mpr fun {O y} hy ↦ ?_
-  obtain ⟨W, hW, hyW, -⟩ := Opens.isBasis_iff_nbhd.mp T.isBasis_affineOpens
-    (U := ⊤) (x := g (a y)) trivial
-  obtain ⟨V, hV, hyV, hVW⟩ := Opens.isBasis_iff_nbhd.mp Z.isBasis_affineOpens
-    (U := g ⁻¹ᵁ W) (x := a y) hyW
-  obtain ⟨U, hU, hyU, hUV⟩ := Opens.isBasis_iff_nbhd.mp Y.isBasis_affineOpens
-    (U := O ⊓ a ⁻¹ᵁ V) (x := y) ⟨hy, hyV⟩
-  exact ⟨U, ⟨hU, ⟨V, hV⟩, ⟨W, hW⟩, hUV.trans inf_le_right, hVW⟩, hyU, hUV.trans inf_le_left⟩
-
-open TopologicalSpace in
-lemma Scheme.exists_ι_comp_eq_of_isOpenCover {s : Type*} {X Y : Scheme.{u}} {U : s → X.Opens}
-    (hU : IsOpenCover U) (g : ∀ i, (U i).toScheme ⟶ Y)
-    (h : ∀ i j, X.homOfLE inf_le_left ≫ g i = X.homOfLE inf_le_right ≫ g j) :
-    ∃ f : X ⟶ Y, ∀ i, (U i).ι ≫ f = g i :=
-  ⟨(X.openCoverOfIsOpenCover U hU).glueMorphisms g fun i j ↦ by
-      change pullback.fst (U i).ι (U j).ι ≫ g i = pullback.snd _ _ ≫ g j
-      rw [← cancel_epi (isPullback_opens_inf (U i) (U j)).isoPullback.hom]
-      simpa using h i j,
-    fun i ↦ (X.openCoverOfIsOpenCover U hU).ι_glueMorphisms ..⟩
 
 variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [LocallyOfFinitePresentation f]
   {i : I} {J : Type*} [Finite J] {U : J → (D.obj i).Opens} (hU : ∀ j, IsAffineOpen (U j))
@@ -1279,16 +1243,19 @@ lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation [∀ i, Compac
     ∃ (i : I) (g : D.obj i ⟶ X), c.π.app i ≫ g = a ∧ g ≫ f = t.app i := by
   -- The open cover of `c := lim Dᵢ` by the affine opens `U ⊆ c` such that `U` maps into an affine
   -- `V ⊆ X` which in turn maps into an affine `W ⊆ S`.
-  have h𝒰 := (isBasis_affineOpens_le_preimage a f).isOpenCover
+  have h𝒰 := (Scheme.isBasis_affineOpens_le_preimage a
+    (Scheme.isBasis_affineOpens_le_preimage f S.isBasis_affineOpens)).isOpenCover
   obtain ⟨i, s, 𝒱, h𝒱, h𝒱𝒰⟩ := Scheme.exists_isOpenCover_and_isAffine D c hc _ h𝒰 fun U ↦ U.2.1
   -- Each `𝒱 j` factors after passing to some `l`, compatibly on overlaps.
   obtain ⟨l, u, g, hg, hπg, hglue⟩ := exists_forall_homOfLE_comp_eq_of_isAffineOpen D t f c hc a ha
-    (fun j ↦ (h𝒱𝒰 j).1) fun j ↦ (h𝒱𝒰 j).2 ▸ j.1.2.2
+    (fun j ↦ (h𝒱𝒰 j).1) fun j ↦ by
+      obtain ⟨-, V, ⟨hV, W, hW, hVW⟩, hUV⟩ := j.1.2
+      exact ⟨⟨V, hV⟩, ⟨W, hW⟩, (h𝒱𝒰 j).2 ▸ hUV, hVW⟩
   -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
-  have h𝒲 : IsOpenCover (D.map u ⁻¹ᵁ 𝒱 ·) := .mk ((D.map u).iSup_preimage_eq_top h𝒱)
+  have h𝒲 : IsOpenCover (D.map u ⁻¹ᵁ 𝒱 ·) := h𝒱.preimage (D.map u)
   obtain ⟨F, hF⟩ := Scheme.exists_ι_comp_eq_of_isOpenCover h𝒲 g hglue
-  refine ⟨l, F, Scheme.hom_ext_of_isOpenCover (.mk ((c.π.app l).iSup_preimage_eq_top h𝒲)) _ _
-      fun j ↦ ?_, Scheme.hom_ext_of_isOpenCover h𝒲 _ _ fun j ↦ ?_⟩
+  refine ⟨l, F, Scheme.hom_ext_of_isOpenCover (h𝒲.preimage (c.π.app l)) _ _ fun j ↦ ?_,
+    Scheme.hom_ext_of_isOpenCover h𝒲 _ _ fun j ↦ ?_⟩
   · rw [← Hom.resLE_comp_ι_assoc (c.π.app l) le_rfl, hF]
     exact hπg j
   · simp [reassoc_of% hF, hg]

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -263,9 +263,7 @@ variable [IsCofiltered I]
 set_option backward.isDefEq.respectTransparency false in
 /-- Given a diagram `{ Dᵢ }_{i ∈ I}` of schemes and an open `U ⊆ Dᵢ`,
 the preimage of `U ⊆ Dᵢ` under the map `lim Dᵢ ⟶ Dᵢ` is the limit of `{ Dⱼᵢ⁻¹ U }_{j ≤ i}`. -/
-noncomputable
-def isLimitOpensCone (i : I) (U : (D.obj i).Opens) :
-    IsLimit (opensCone D c i U) :=
+noncomputable def isLimitOpensCone (i : I) (U : (D.obj i).Opens) : IsLimit (opensCone D c i U) :=
   isLimitOfIsPullbackOfIsConnected (opensDiagramι D i U) _ _
     (by exact { hom := (c.π.app i ⁻¹ᵁ U).ι })
     (fun j ↦ IsOpenImmersion.isPullback _ _ _ _ (by simp) (by simp [← Scheme.Hom.comp_preimage]))
@@ -278,13 +276,12 @@ lemma exists_appTop_π_eq_of_isAffine_of_isLimit [∀ i, IsAffine (D.obj i)] (s 
   exact ⟨_, (Types.jointly_surjective_of_isColimit
     (isColimitOfPreserves (Scheme.Γ ⋙ forget _) hc.op) s).choose_spec⟩
 
-variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] {i : I} {U V : (D.obj i).Opens}
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
-lemma exists_map_preimage_le_map_preimage
-    {i : I} {U V : (D.obj i).Opens} (hU : IsCompact (U : Set (D.obj i)))
+lemma exists_map_preimage_le_map_preimage (hU : IsCompact (U : Set (D.obj i)))
     (H : c.π.app i ⁻¹ᵁ U ≤ c.π.app i ⁻¹ᵁ V) :
     ∃ (j : I) (fji : j ⟶ i), D.map fji ⁻¹ᵁ U ≤ D.map fji ⁻¹ᵁ V := by
   have (j : Over i) : CompactSpace ↥((opensDiagram D i U).obj j) :=
@@ -303,8 +300,7 @@ lemma exists_map_preimage_le_map_preimage
 
 include hc in
 @[stacks 01Z4 "(2)"]
-lemma exists_map_preimage_eq_map_preimage
-    {i : I} {U V : (D.obj i).Opens} (hU : IsCompact (U : Set (D.obj i)))
+lemma exists_map_preimage_eq_map_preimage (hU : IsCompact (U : Set (D.obj i)))
     (hV : IsCompact (V : Set (D.obj i))) (H : c.π.app i ⁻¹ᵁ U = c.π.app i ⁻¹ᵁ V) :
     ∃ (j : I) (fji : j ⟶ i), D.map fji ⁻¹ᵁ U = D.map fji ⁻¹ᵁ V := by
   obtain ⟨j₁, fj₁i, e₁⟩ := exists_map_preimage_le_map_preimage D c hc hU H.le
@@ -316,8 +312,7 @@ lemma exists_map_preimage_eq_map_preimage
     simpa only [Scheme.Hom.comp_preimage, Functor.map_comp] using Scheme.Hom.preimage_mono _ e₂
 
 include hc in
-lemma exists_appLE_π_eq_of_isAffineOpen {i : I} {U : (D.obj i).Opens} (hU : IsAffineOpen U)
-    (s : Γ(c.pt, c.π.app i ⁻¹ᵁ U)) :
+lemma exists_appLE_π_eq_of_isAffineOpen (hU : IsAffineOpen U) (s : Γ(c.pt, c.π.app i ⁻¹ᵁ U)) :
     ∃ (j : I) (u : j ⟶ i) (t : Γ(D.obj j, D.map u ⁻¹ᵁ U)),
       (c.π.app j).appLE _ _ (π_app_preimage_map_preimage D c u U).ge t = s := by
   have (j : Over i) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage (D.map _)
@@ -333,9 +328,8 @@ lemma exists_appLE_π_eq_of_isAffineOpen {i : I} {U : (D.obj i).Opens} (hU : IsA
   exact (c.π.app i ⁻¹ᵁ U).topIso.commRingCatIsoToRingEquiv.symm.injective ht
 
 include hc in
-lemma isBasis_preimage_isAffineOpen :
-    TopologicalSpace.Opens.IsBasis
-      { (c.π.app i ⁻¹ᵁ V : c.pt.Opens) | (i : I) (V : (D.obj i).Opens) (_ : IsAffineOpen V) } := by
+lemma isBasis_preimage_isAffineOpen : TopologicalSpace.Opens.IsBasis
+    { (c.π.app i ⁻¹ᵁ V : c.pt.Opens) | (i : I) (V : (D.obj i).Opens) (_ : IsAffineOpen V) } := by
   refine TopologicalSpace.Opens.isBasis_iff_nbhd.mpr fun {U x} hxU ↦ ?_
   obtain ⟨i⟩ := IsCofiltered.nonempty (C := I)
   obtain ⟨_, ⟨V, hV : IsAffineOpen V, rfl⟩, hxV, -⟩ :=
@@ -367,21 +361,18 @@ lemma exists_preimage_eq (U : c.pt.Opens) (hU : IsCompact (U : Set c.pt)) :
   · simp [-TopologicalSpace.Opens.iSup_mk, Scheme.Hom.preimage_iSup,
       ← Scheme.Hom.comp_preimage, c.w, hVi, sSup_eq_iSup']
 
-end Opens
-
 include hc in
-lemma isAffineHom_π_app [IsCofiltered I] [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] (i : I) :
-    IsAffineHom (c.π.app i) where
+lemma isAffineHom_π_app (i : I) : IsAffineHom (c.π.app i) where
   isAffine_preimage U hU := have (j : _) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage _
     Scheme.isAffine_of_isLimit _ (isLimitOpensCone D c hc i U)
 
 include hc in
-lemma Scheme.compactSpace_of_isLimit [IsCofiltered I]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [∀ i, CompactSpace (D.obj i)] :
-    CompactSpace c.pt := by
+lemma Scheme.compactSpace_of_isLimit [∀ i, CompactSpace (D.obj i)] : CompactSpace c.pt := by
   obtain ⟨i⟩ := IsCofiltered.nonempty (C := I)
   have := isAffineHom_π_app _ _ hc
   exact QuasiCompact.compactSpace_of_compactSpace (c.π.app i)
+
+end Opens
 
 /-!
 

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -37,6 +37,8 @@ namespace AlgebraicGeometry
 variable {I : Type u} [Category.{u} I] {S X : Scheme.{u}} (D : I ⥤ Scheme.{u})
   (t : D ⟶ (Functor.const I).obj S) (f : X ⟶ S) (c : Cone D) (hc : IsLimit c)
 
+attribute [local simp] Scheme.Hom.resLE_comp_resLE Scheme.Hom.resLE_comp_resLE_assoc
+
 set_option backward.isDefEq.respectTransparency false in
 include hc in
 /--
@@ -196,8 +198,6 @@ lemma exists_map_eq_top
 lemma π_app_preimage_map_preimage {i j : I} (fji : j ⟶ i) (U : (D.obj i).Opens) :
     c.π.app j ⁻¹ᵁ D.map fji ⁻¹ᵁ U = c.π.app i ⁻¹ᵁ U := by
   rw [← Scheme.Hom.comp_preimage, c.w]
-
-attribute [local simp] Scheme.Hom.resLE_comp_resLE
 
 set_option backward.isDefEq.respectTransparency.types false in
 /-- Given a diagram `{ Dᵢ }` of schemes and an open `U ⊆ Dᵢ`,
@@ -1130,63 +1130,50 @@ private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
       g ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k ∧
         ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
           (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a := by
-    refine IsCofiltered.exists_forall ?_ fun j ↦ ?_
-    · rintro k₁ k₂ v u j ⟨g, hg, hg'⟩
-      refine ⟨(D.map v).resLE _ _ (by simp) ≫ g, ?_, fun O h ↦ ?_⟩
-      · simpa using congr((D.map v).resLE _ (D.map (v ≫ u) ⁻¹ᵁ U j) (by simp) ≫ $hg)
-      · simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)
+    refine IsCofiltered.exists_forall (fun v u j ⟨g, hg, hg'⟩ ↦ ⟨(D.map v).resLE _ _ (by simp) ≫ g,
+      by simp [hg, hnat], fun O h ↦ by simpa using hg' O (h.trans (by simp))⟩) fun j ↦ ?_
     obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc (hU j).isCompact
-      (V := t.app i ⁻¹ᵁ (W j : S.Opens)) (by
-        rw [← Scheme.Hom.comp_preimage, hπ, Scheme.Hom.comp_preimage]
-        exact (hUV j).trans (a.preimage_mono (hVW j)))
-    replace hu : D.map u ⁻¹ᵁ U j ≤ t.app i' ⁻¹ᵁ (W j : S.Opens) :=
-      hu.trans_eq (by rw [← Scheme.Hom.comp_preimage, hnat])
+      (V := t.app i ⁻¹ᵁ (W j : S.Opens))
+      (by simpa only [← Scheme.Hom.comp_preimage, hπ] using (hUV j).trans (a.preimage_mono (hVW j)))
     have _ (k : Over i') : IsAffine ((opensDiagram D i' (D.map u ⁻¹ᵁ U j)).obj k) :=
       ((hU j).preimage _).preimage _
     let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U j) ⟶ (Functor.const (Over i')).obj (W j) :=
       { app k := (t.app k.left).resLE _ _ ((Scheme.Hom.preimage_mono _ hu).trans_eq
-          (by rw [← Scheme.Hom.comp_preimage, hnat]))
-        naturality k l v := ((D.map v.left).resLE_comp_resLE _ (t.app l.left) _).trans
-          (Eq.trans ((cancel_mono (W j : S.Opens).ι).mp (by simp [hnat]))
-            (Category.comp_id _).symm) }
-    obtain ⟨k, g, hg, hg'⟩ :
-        ∃ (k : Over i') (g : (D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U j).toScheme ⟶ (V j : X.Opens).toScheme),
-          (c.π.app k.left).resLE _ (c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j) (by simp) ≫ g =
-              a.resLE _ _ (by simpa using hUV j) ∧ g ≫ f.resLE _ _ (hVW j) = τ.app k :=
+          (by simp only [← Scheme.Hom.comp_preimage, hnat]))
+        naturality k l v := by
+          change (D.map v.left).resLE _ _ _ ≫ (t.app l.left).resLE (W j : S.Opens) _ _ = _ ≫ 𝟙 _
+          simp [hnat] }
+    obtain ⟨k, g, hg, hg'⟩ : ∃ (k : Over i') (g : _ ⟶ (V j : X.Opens).toScheme),
+        (c.π.app k.left).resLE _ (c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j) (by simp) ≫ g =
+          a.resLE _ _ (by simpa using hUV j) ∧ g ≫ f.resLE _ _ (hVW j) = τ.app k :=
       Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
         _ τ (f.resLE _ _ (hVW j)) _ (isLimitOpensCone D c hc i' _)
         (a.resLE _ _ (by simpa using hUV j)) (by
           ext k
-          exact ((c.π.app k.left).resLE_comp_resLE _ (t.app k.left) _).trans
-            (Eq.trans ((cancel_mono (W j : S.Opens).ι).mp (by simp [hπ]))
-              (a.resLE_comp_resLE _ f _).symm))
+          change (c.π.app k.left).resLE _ _ _ ≫ (t.app k.left).resLE (W j : S.Opens) _ _ =
+            a.resLE (V j : X.Opens) _ _ ≫ f.resLE (W j : S.Opens) _ _
+          simp [hπ])
     have e : D.map (k.hom ≫ u) ⁻¹ᵁ U j ≤ D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
     refine ⟨k.left, k.hom ≫ u, Scheme.homOfLE _ e ≫ g ≫ (V j : X.Opens).ι, ?_, fun O h ↦ ?_⟩
     · simpa [τ] using congr(Scheme.homOfLE _ e ≫ $hg' ≫ (W j : S.Opens).ι)
-    · have h' : O ≤ c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simpa using h
-      simpa using congr(Scheme.homOfLE _ h' ≫ $hg ≫ (V j : X.Opens).ι)
+    · simpa using congr(Scheme.homOfLE _ (h.trans (by simp)) ≫ $hg ≫ (V j : X.Opens).ι)
   choose k u g hg hg' using key
   obtain ⟨l, v, hl⟩ : ∃ (l : I) (v : l ⟶ k), ∀ j₁ j₂ (O : (D.obj l).Opens)
       (e₁ : O ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j₁) (e₂ : O ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j₂),
         (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ := by
-    refine IsCofiltered.exists_forall₂ ?_ fun j₁ j₂ ↦ ?_
-    · exact fun w v j₁ j₂ hv O e₁ e₂ ↦ by
-        simpa [Scheme.Hom.resLE_comp_resLE_assoc] using
-          congr((D.map w).resLE _ O ((le_inf e₁ e₂).trans_eq (by simp [Scheme.Hom.preimage_inf])) ≫
-            $(hv _ inf_le_left inf_le_right))
-    have hcpt := ((hU j₁).preimage (D.map u)).isCompact_inf ((hU j₂).preimage (D.map u))
+    refine IsCofiltered.exists_forall₂ (fun w v j₁ j₂ hv O e₁ e₂ ↦ by
+      simpa using congr((D.map w).resLE _ O ((le_inf e₁ e₂).trans_eq
+        (by simp [Scheme.Hom.preimage_inf])) ≫ $(hv _ inf_le_left inf_le_right))) fun j₁ j₂ ↦ ?_
     obtain ⟨l, v, e⟩ := Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType D t f c hc
-      hcpt (Scheme.homOfLE _ inf_le_left ≫ g j₁) (Scheme.homOfLE _ inf_le_right ≫ g j₂)
-      (by simp [hg]) (by simp [hg])
-      (by simpa only [Scheme.Hom.resLE_map_assoc] using (hg' j₁ _ _).trans (hg' j₂ _ _).symm)
+      (((hU j₁).preimage (D.map u)).isCompact_inf ((hU j₂).preimage (D.map u)))
+      (Scheme.homOfLE _ inf_le_left ≫ g j₁) (Scheme.homOfLE _ inf_le_right ≫ g j₂)
+      (by simp [hg]) (by simp [hg]) (by simpa using (hg' j₁ _ _).trans (hg' j₂ _ _).symm)
     exact ⟨l, v, fun O e₁ e₂ ↦ by
-      simpa using
-        congr(Scheme.homOfLE _ ((le_inf e₁ e₂).trans_eq (by simp [Scheme.Hom.preimage_inf])) ≫ $e)⟩
-  refine ⟨l, v ≫ u, fun j ↦ (D.map v).resLE _ (D.map (v ≫ u) ⁻¹ᵁ U j) (by simp) ≫ g j,
-    fun j ↦ ?_, fun j ↦ ?_, fun j₁ j₂ ↦ ?_⟩
-  · simpa using congr((D.map v).resLE _ (D.map (v ≫ u) ⁻¹ᵁ U j) (by simp) ≫ $(hg j))
-  · simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' j _ (by simp)
-  · simpa using hl j₁ j₂ _ (by simp) (by simp)
+      simpa using congr(Scheme.homOfLE _
+        ((le_inf e₁ e₂).trans_eq (by simp [Scheme.Hom.preimage_inf])) ≫ $e)⟩
+  exact ⟨l, v ≫ u, fun j ↦ (D.map v).resLE _ (D.map (v ≫ u) ⁻¹ᵁ U j) (by simp) ≫ g j,
+    fun j ↦ by simp [hg, hnat], fun j ↦ by simpa using hg' j _ (by simp),
+    fun j₁ j₂ ↦ by simpa using hl j₁ j₂ _ (by simp) (by simp)⟩
 
 open TopologicalSpace in
 include hc ha in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -850,7 +850,7 @@ private lemma exists_appLE_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAf
   obtain ⟨j, t, hj⟩ := exists_appTop_π_eq_of_isAffine_of_isLimit _ _
     (isLimitOpensCone D c hc i U) ((c.π.app i ⁻¹ᵁ U).topIso.inv (s |_ _))
   obtain ⟨t, rfl⟩ := (D.map j.hom ⁻¹ᵁ U).topIso.symm.commRingCatIsoToRingEquiv.surjective t
-  have h : c.π.app j.left ⁻¹ᵁ D.map j.hom ⁻¹ᵁ U = c.π.app i ⁻¹ᵁ U := congr($(c.w j.hom) ⁻¹ᵁ U)
+  have h := π_app_preimage_map_preimage D c j.hom U
   replace hj : (c.π.app j.left).appLE (D.map j.hom ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U) h.ge t =
       s |_ (c.π.app i ⁻¹ᵁ U) := by
     replace hj : ((c.π.app j.left).resLE (D.map j.hom ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U) h.ge).appTop
@@ -922,8 +922,7 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
     (fun x ↦ hU x) (fun x ↦ ht x) fj
   have hcov : ⨆ x : σ, D.map (v ≫ fj x) ⁻¹ᵁ U x = ⊤ := by
     simpa [Scheme.Hom.comp_preimage] using (D.map v).iSup_preimage_eq_top hfj
-  have H (x : σ) : c.π.app (i x) ⁻¹ᵁ U x = c.π.app k ⁻¹ᵁ D.map (v ≫ fj x) ⁻¹ᵁ U x := by
-    rw [← Scheme.Hom.comp_preimage, Cone.w]
+  have H (x : σ) := (π_app_preimage_map_preimage D c (v ≫ fj x) (U x)).symm
   obtain ⟨t₀, ht₀, -⟩ := TopCat.Sheaf.existsUnique_gluing' ⟨_, (D.obj k).IsSheaf⟩ _ ⊤
     (fun _ ↦ homOfLE le_top) hcov.ge (fun x ↦ (D.map (v ≫ fj x)).app (U x) (t x)) fun x y ↦ by
       dsimp [TopologicalSpace.Opens.infLELeft, TopologicalSpace.Opens.infLERight]

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -65,13 +65,12 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
         (Finset.univ.image fun j : 𝒰.I₀ ↦ ⟨_, _, by simp, by simp, f j⟩) (X := j)
       let 𝒱 := 𝒰.pullback₁ (D.map (g i (by simp)))
       have (j : 𝒰.I₀) : IsEmpty (𝒱.X j) := by
-        let F : 𝒱.X j ⟶ (𝒰.pullback₁ (D.map (f j))).X j :=
-          pullback.map _ _ _ _ (D.map (g _ (by simp))) (𝟙 _) (𝟙 _) (by
-            rw [← D.map_comp, IsCofiltered.infTo_commutes]
-            · simp [g]
-            · simp
-            · exact Finset.mem_image_of_mem _ (Finset.mem_univ _)) (by simp)
-        exact Function.isEmpty F
+        apply @Function.isEmpty _ _ (hf j) (?_ : 𝒱.X j ⟶ _)
+        refine pullback.map _ _ _ _ (D.map (g _ (by simp))) (𝟙 _) (𝟙 _) ?_ (by simp)
+        rw [← D.map_comp, IsCofiltered.infTo_commutes]
+        · simp [g]
+        · simp
+        · exact Finset.mem_image_of_mem _ (Finset.mem_univ j)
       exact (this _).elim (Cover.covers 𝒱 Classical.ofNonempty).choose
     let F := Over.post D ⋙ Over.pullback (𝒰.f j) ⋙ Over.forget _
     have _ (k) : IsAffine (F.obj k) := inferInstanceAs (IsAffine (pullback (D.map k.hom) (𝒰.f j)))

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -883,9 +883,7 @@ private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)
           simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
         simpa [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
           using congr((D.map x).appLE _ V e $(hv _ inf_le_left inf_le_right))
-    have hcpt : IsCompact (X := D.obj n) ↑(D.map w ⁻¹ᵁ W₁.1 ⊓ D.map w ⁻¹ᵁ W₂.1) :=
-      ((hUs W₁.2).preimage (D.map w)).isCompact.inter_of_isOpen
-        ((hUs W₂.2).preimage (D.map w)).isCompact (D.map w ⁻¹ᵁ W₁.1).2 (D.map w ⁻¹ᵁ W₂.1).2
+    have hcpt := ((hUs W₁.2).preimage (D.map w)).isCompact_inf ((hUs W₂.2).preimage (D.map w))
     obtain ⟨k, v, hv⟩ := exists_app_map_eq_map_of_isLimit D c hc hcpt (T W₁ |_ _) (T W₂ |_ _) (by
       dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
       simp only [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, Scheme.Hom.map_appLE]
@@ -1202,9 +1200,7 @@ private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
         simpa [Scheme.Hom.resLE_comp_resLE_assoc] using congr((D.map w).resLE _ O
           (show O ≤ D.map w ⁻¹ᵁ _ by simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫
             $(hv _ inf_le_left inf_le_right))
-    have hcpt : IsCompact (X := D.obj k) ↑(D.map u ⁻¹ᵁ U j₁ ⊓ D.map u ⁻¹ᵁ U j₂) :=
-      ((hU j₁).preimage (D.map u)).isCompact.inter_of_isOpen
-        ((hU j₂).preimage (D.map u)).isCompact (D.map u ⁻¹ᵁ U j₁).2 (D.map u ⁻¹ᵁ U j₂).2
+    have hcpt := ((hU j₁).preimage (D.map u)).isCompact_inf ((hU j₂).preimage (D.map u))
     obtain ⟨l, v, e⟩ := Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType D t f c hc
       hcpt (Scheme.homOfLE _ inf_le_left ≫ g j₁) (Scheme.homOfLE _ inf_le_right ≫ g j₂)
       (by simp [hg]) (by simp [hg])

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -878,14 +878,13 @@ private lemma exists_forall_map_appLE_eq_of_isLimit [∀ {i j} (f : i ⟶ j), Is
       simpa [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
         using congr((D.map w).appLE _ V e $(hv _ inf_le_left inf_le_right))
   intro x y
-  obtain ⟨k, v, hv⟩ := exists_app_map_eq_zero_of_isLimit D c hc
-    (((hU x).preimage (D.map (u x))).isCompact.inter_of_isOpen
-      ((hU y).preimage (D.map (u y))).isCompact ((U x).2.preimage (D.map (u x)).continuous)
-      ((U y).2.preimage (D.map (u y)).continuous))
-    ((D.map (u x)).app _ (t x) |_ (D.map (u x) ⁻¹ᵁ U x ⊓ D.map (u y) ⁻¹ᵁ U y) -
-      (D.map (u y)).app _ (t y) |_ (D.map (u x) ⁻¹ᵁ U x ⊓ D.map (u y) ⁻¹ᵁ U y)) (by
+  have hcpt : IsCompact (X := D.obj j) ↑(D.map (u x) ⁻¹ᵁ U x ⊓ D.map (u y) ⁻¹ᵁ U y) :=
+    ((hU x).preimage (D.map (u x))).isCompact.inter_of_isOpen
+      ((hU y).preimage (D.map (u y))).isCompact (D.map (u x) ⁻¹ᵁ U x).2 (D.map (u y) ⁻¹ᵁ U y).2
+  obtain ⟨k, v, hv⟩ := exists_app_map_eq_map_of_isLimit D c hc hcpt
+    ((D.map (u x)).app _ (t x) |_ _) ((D.map (u y)).app _ (t y) |_ _) (by
     dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-    simp only [map_sub, sub_eq_zero, ← ConcreteCategory.comp_apply,
+    simp only [← ConcreteCategory.comp_apply,
       Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, Scheme.Hom.appLE_comp_appLE, Cone.w]
     exact (ht x _ _).trans (ht y _ _).symm)
   refine ⟨k, v, fun V h₁ h₂ ↦ ?_⟩
@@ -893,7 +892,7 @@ private lemma exists_forall_map_appLE_eq_of_isLimit [∀ {i j} (f : i ⟶ j), Is
     simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
   apply_fun (D.obj k).presheaf.map (homOfLE H).op at hv
   dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict] at hv ⊢
-  simpa [sub_eq_zero, ← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
+  simpa [← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
     Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hv
 
 include hc in
@@ -1230,31 +1229,43 @@ private lemma exists_forall_resLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresen
 
 variable [∀ i, QuasiSeparatedSpace (D.obj i)]
 
-include hc in
-private lemma exists_forall_resLE_comp_eq_resLE_comp [LocallyOfFiniteType f]
-    {k : I} {J : Type*} [Finite J] {U : J → (D.obj k).Opens}
-    (hU : ∀ j, IsCompact (U j : Set (D.obj k))) (g : ∀ j, ↑(U j) ⟶ X)
-    (hg : ∀ j, g j ≫ f = (U j).ι ≫ t.app k)
-    (h : ∀ j₁ j₂ (O : c.pt.Opens) (e₁ : O ≤ c.π.app k ⁻¹ᵁ U j₁) (e₂ : O ≤ c.π.app k ⁻¹ᵁ U j₂),
-      (c.π.app k).resLE _ O e₁ ≫ g j₁ = (c.π.app k).resLE _ O e₂ ≫ g j₂) :
-    ∃ (l : I) (v : l ⟶ k), ∀ j₁ j₂ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U j₁)
-      (e₂ : O ≤ D.map v ⁻¹ᵁ U j₂),
+include hc ha in
+private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresentation f]
+    {i : I} {J : Type*} [Finite J] {U : J → (D.obj i).Opens} (hU : ∀ j, IsAffineOpen (U j))
+    (hUV : ∀ j, ∃ (V : X.affineOpens) (W : S.affineOpens),
+      c.π.app i ⁻¹ᵁ U j ≤ a ⁻¹ᵁ (V : X.Opens) ∧ (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens)) :
+    ∃ (k : I) (u : k ⟶ i) (g : ∀ j, ↑(D.map u ⁻¹ᵁ U j) ⟶ X),
+      (∀ j, g j ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k) ∧
+      (∀ j (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
+        (c.π.app k).resLE _ O h ≫ g j = O.ι ≫ a) ∧
+      ∀ j₁ j₂ (O : (D.obj k).Opens) (e₁ : O ≤ D.map u ⁻¹ᵁ U j₁) (e₂ : O ≤ D.map u ⁻¹ᵁ U j₂),
+        Scheme.homOfLE _ e₁ ≫ g j₁ = Scheme.homOfLE _ e₂ ≫ g j₂ := by
+  choose k u g hg hg' using exists_forall_resLE_comp_eq_of_isAffineOpen D t f c hc a ha hU hUV
+  obtain ⟨l, v, hl⟩ : ∃ (l : I) (v : l ⟶ k), ∀ j₁ j₂ (O : (D.obj l).Opens)
+      (e₁ : O ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j₁) (e₂ : O ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j₂),
         (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ := by
-  refine IsCofiltered.exists_forall₂ _ ?_ ?_
-  · exact fun w v j₁ j₂ hv O e₁ e₂ ↦ by
-      simpa [Scheme.Hom.resLE_comp_resLE_assoc] using congr((D.map w).resLE _ O
-        (show O ≤ D.map w ⁻¹ᵁ _ by simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫
-          $(hv _ inf_le_left inf_le_right))
-  intro j₁ j₂
-  obtain ⟨l, v, e⟩ := Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType D t f c hc
-    ((hU j₁).inter_of_isOpen (hU j₂) (U j₁).2 (U j₂).2)
-    (Scheme.homOfLE _ inf_le_left ≫ g j₁) (Scheme.homOfLE _ inf_le_right ≫ g j₂)
-    (by simp [hg]) (by simp [hg])
-    (by rw [Scheme.Hom.resLE_map_assoc, Scheme.Hom.resLE_map_assoc]; exact h j₁ j₂ _ _ _)
-  exact ⟨l, v, fun O e₁ e₂ ↦ by
-    simpa using congr(Scheme.homOfLE _
-      (show O ≤ D.map v ⁻¹ᵁ (U j₁ ⊓ U j₂) by simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫
-        $e)⟩
+    refine IsCofiltered.exists_forall₂ _ ?_ fun j₁ j₂ ↦ ?_
+    · exact fun w v j₁ j₂ hv O e₁ e₂ ↦ by
+        simpa [Scheme.Hom.resLE_comp_resLE_assoc] using congr((D.map w).resLE _ O
+          (show O ≤ D.map w ⁻¹ᵁ _ by simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫
+            $(hv _ inf_le_left inf_le_right))
+    have hcpt : IsCompact (X := D.obj k) ↑(D.map u ⁻¹ᵁ U j₁ ⊓ D.map u ⁻¹ᵁ U j₂) :=
+      ((hU j₁).preimage (D.map u)).isCompact.inter_of_isOpen
+        ((hU j₂).preimage (D.map u)).isCompact (D.map u ⁻¹ᵁ U j₁).2 (D.map u ⁻¹ᵁ U j₂).2
+    obtain ⟨l, v, e⟩ := Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType D t f c hc
+      hcpt (Scheme.homOfLE _ inf_le_left ≫ g j₁) (Scheme.homOfLE _ inf_le_right ≫ g j₂)
+      (by simp [hg]) (by simp [hg])
+      (by rw [Scheme.Hom.resLE_map_assoc, Scheme.Hom.resLE_map_assoc]
+          exact (hg' j₁ _ _).trans (hg' j₂ _ _).symm)
+    exact ⟨l, v, fun O e₁ e₂ ↦ by
+      simpa using congr(Scheme.homOfLE _ (show O ≤ D.map v ⁻¹ᵁ _ by
+        simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫ $e)⟩
+  have e (j : J) : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
+  refine ⟨l, v ≫ u, fun j ↦ (D.map v).resLE _ _ (e j) ≫ g j, fun j ↦ ?_, fun j O h ↦ ?_,
+    fun j₁ j₂ O e₁ e₂ ↦ ?_⟩
+  · simpa using congr((D.map v).resLE _ _ (e j) ≫ $(hg j))
+  · simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' j O (by simpa using h)
+  · simpa using hl j₁ j₂ O (by simpa using e₁) (by simpa using e₂)
 
 open TopologicalSpace in
 include hc ha in
@@ -1270,31 +1281,21 @@ lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
   -- `V ⊆ X` which in turn maps into an affine `W ⊆ S`.
   have h𝒰 := (isBasis_affineOpens_le_preimage a f).isOpenCover
   obtain ⟨i, s, 𝒱, h𝒱, h𝒱𝒰⟩ := Scheme.exists_isOpenCover_and_isAffine D c hc _ h𝒰 fun U ↦ U.2.1
-  -- Each `𝒱 j` factors after passing to some `k`, and by finiteness a single `k` works for all `j`.
-  choose k fki ak hak hak' using exists_forall_resLE_comp_eq_of_isAffineOpen D t f c hc a ha
+  -- Each `𝒱 j` factors after passing to some `l`, compatibly on overlaps.
+  obtain ⟨l, u, g, hg, hπg, hglue⟩ := exists_forall_homOfLE_comp_eq_of_isAffineOpen D t f c hc a ha
     (fun j ↦ (h𝒱𝒰 j).1) fun j ↦ (h𝒱𝒰 j).2 ▸ j.1.2.2
-  -- Likewise the `ak j` pairwise agree on overlaps after passing to some `l`.
-  obtain ⟨l, flk, hl⟩ := exists_forall_resLE_comp_eq_resLE_comp D t f c hc
-    (fun j ↦ ((h𝒱𝒰 j).1.preimage _).isCompact) ak hak
-    fun j₁ j₂ O e₁ e₂ ↦ (hak' j₁ O e₁).trans (hak' j₂ O e₂).symm
   -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
-  have h𝒲 : IsOpenCover (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 ·) :=
-    .mk ((D.map flk).iSup_preimage_eq_top ((D.map fki).iSup_preimage_eq_top h𝒱))
-  let al (j : s) : ↑(D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j) ⟶ X :=
-    (D.map flk).resLE (D.map fki ⁻¹ᵁ 𝒱 j) _ le_rfl ≫ ak j
-  have hglue (j₁ j₂ : s) : pullback.fst (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j₁).ι
-      (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j₂).ι ≫ al j₁ = pullback.snd _ _ ≫ al j₂ := by
+  have h𝒲 : IsOpenCover (D.map u ⁻¹ᵁ 𝒱 ·) := .mk ((D.map u).iSup_preimage_eq_top h𝒱)
+  let F := (Scheme.openCoverOfIsOpenCover _ _ h𝒲).glueMorphisms g fun j₁ j₂ ↦ by
+    show pullback.fst (D.map u ⁻¹ᵁ 𝒱 j₁).ι (D.map u ⁻¹ᵁ 𝒱 j₂).ι ≫ _ = pullback.snd _ _ ≫ _
     rw [← cancel_epi (isPullback_opens_inf _ _).isoPullback.hom]
-    simpa [al] using hl j₁ j₂ _ inf_le_left inf_le_right
-  let F := (Scheme.openCoverOfIsOpenCover _ _ h𝒲).glueMorphisms al hglue
-  have hF (j : s) : (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ F =
-      (D.map flk).resLE _ _ le_rfl ≫ ak j := Scheme.Cover.ι_glueMorphisms ..
+    simpa using hglue j₁ j₂ _ inf_le_left inf_le_right
+  have hF (j : s) : (D.map u ⁻¹ᵁ 𝒱 j).ι ≫ F = g j := Scheme.Cover.ι_glueMorphisms ..
   refine ⟨l, F, Scheme.hom_ext_of_isOpenCover (.mk ((c.π.app l).iSup_preimage_eq_top h𝒲)) _ _
       fun j ↦ ?_, Scheme.hom_ext_of_isOpenCover h𝒲 _ _ fun j ↦ ?_⟩
   · rw [← Hom.resLE_comp_ι_assoc (c.π.app l) le_rfl, hF]
-    simp only [Hom.resLE_comp_resLE_assoc, Cone.w]
-    exact hak' j _ _
-  · simp [reassoc_of% hF, hak]
+    exact hπg j _ _
+  · simp [reassoc_of% hF, hg]
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -836,28 +836,6 @@ lemma exists_appTop_π_eq_of_isAffine_of_isLimit
   exact ⟨_, (Types.jointly_surjective_of_isColimit
     (isColimitOfPreserves (Scheme.Γ ⋙ forget _) hc.op) s).choose_spec⟩
 
-private lemma exists_cone_of_pairs {C : Type*} [Category C] [IsCofiltered C] {α : Type*}
-    (σ : Finset α) (i : α → C) (j : α → α → C)
-    (p₁ : ∀ x y, j x y ⟶ i x) (p₂ : ∀ x y, j x y ⟶ i y) :
-    ∃ (k : C) (fi : ∀ {x}, x ∈ σ → (k ⟶ i x)) (fj : ∀ {x y}, x ∈ σ → y ∈ σ → (k ⟶ j x y)),
-      (∀ {x y} (hx : x ∈ σ) (hy : y ∈ σ), fj hx hy ≫ p₁ x y = fi hx) ∧
-        ∀ {x y} (hx : x ∈ σ) (hy : y ∈ σ), fj hx hy ≫ p₂ x y = fi hy := by
-  classical
-  let O : Finset C := σ.image i ∪ Finset.image₂ j σ σ
-  have hiO {x} (hx : x ∈ σ) : i x ∈ O := Finset.subset_union_left (Finset.mem_image_of_mem i hx)
-  have hjO {x y} (hx : x ∈ σ) (hy : y ∈ σ) : j x y ∈ O :=
-    Finset.subset_union_right (Finset.mem_image₂_of_mem hx hy)
-  obtain ⟨k, T, hT⟩ := IsCofiltered.inf_exists O
-    (σ.attach.image₂ (fun (x y : σ) ↦ ⟨j x.1 y.1, i x.1, hjO x.2 y.2, hiO x.2, p₁ x y⟩) σ.attach ∪
-    σ.attach.image₂ (fun (x y : σ) ↦ ⟨j x.1 y.1, i y.1, hjO x.2 y.2, hiO y.2, p₂ x y⟩) σ.attach)
-  refine ⟨k, fun hx ↦ T (hiO hx), fun hx hy ↦ T (hjO hx hy), fun {x y} hx hy ↦ ?_,
-    fun {x y} hx hy ↦ ?_⟩
-  · exact hT (hjO hx hy) (hiO hx) (f := p₁ x y) (Finset.subset_union_left
-      (Finset.mem_image₂.mpr ⟨⟨x, hx⟩, by simp, ⟨y, hy⟩, by simp, rfl⟩))
-  · exact hT (hjO hx hy) (hiO hy) (f := p₂ x y) (Finset.subset_union_right
-      (Finset.mem_image₂.mpr ⟨⟨x, hx⟩, by simp, ⟨y, hy⟩, by simp, rfl⟩))
-
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
 private lemma exists_app_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
@@ -876,14 +854,11 @@ private lemma exists_app_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffi
     rwa [Cone.w]
   · have H : c.π.app j.left ⁻¹ᵁ (D.map j.hom ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ (c.π.app i ⁻¹ᵁ U).ι ''ᵁ ⊤ := by
       simp [← Scheme.Hom.comp_preimage]
-    convert! congr(c.pt.presheaf.map (homOfLE H).op $hj)
-    · convert! ConcreteCategory.comp_apply _ _ _
-      congr
-      simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE]
-    · dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-      change _ = (c.pt.presheaf.map (homOfLE _).op ≫ c.pt.presheaf.map (homOfLE _).op) s
-      rw [← Functor.map_comp]
-      rfl
+    refine Eq.trans ?_ (congr(c.pt.presheaf.map (homOfLE H).op $hj).trans
+      (TopCat.Presheaf.restrict_restrict H le_top s))
+    convert! ConcreteCategory.comp_apply _ _ _
+    congr
+    simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE]
 
 omit [IsCofiltered I] in
 private lemma π_appLE_eq_restrict {i : I} {U : (D.obj i).Opens} {s : Γ(c.pt, ⊤)}
@@ -893,37 +868,33 @@ private lemma π_appLE_eq_restrict {i : I} {U : (D.obj i).Opens} {s : Γ(c.pt, �
   simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply, ht]
   exact TopCat.Presheaf.restrict_restrict e le_top s
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 include hc in
-private lemma exists_map_app_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+private lemma exists_map_appLE_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     [∀ i, QuasiSeparatedSpace (D.obj i)]
-    {s : Γ(c.pt, ⊤)} {i₁ i₂ : I} {U₁ : (D.obj i₁).Opens} {U₂ : (D.obj i₂).Opens}
-    (hU₁ : IsAffineOpen U₁) (hU₂ : IsAffineOpen U₂) (t₁ : Γ(D.obj i₁, U₁)) (t₂ : Γ(D.obj i₂, U₂))
+    {s : Γ(c.pt, ⊤)} {i₁ i₂ k : I} {U₁ : (D.obj i₁).Opens} {U₂ : (D.obj i₂).Opens}
+    (hU₁ : IsAffineOpen U₁) (hU₂ : IsAffineOpen U₂) {t₁ : Γ(D.obj i₁, U₁)} {t₂ : Γ(D.obj i₂, U₂)}
     (ht₁ : (c.π.app i₁).app U₁ t₁ = s |_ (c.π.app i₁ ⁻¹ᵁ U₁))
-    (ht₂ : (c.π.app i₂).app U₂ t₂ = s |_ (c.π.app i₂ ⁻¹ᵁ U₂)) :
-    ∃ (j : I) (f₁ : j ⟶ i₁) (f₂ : j ⟶ i₂),
-      (D.map f₁).app U₁ t₁ |_ (D.map f₁ ⁻¹ᵁ U₁ ⊓ D.map f₂ ⁻¹ᵁ U₂) =
-      (D.map f₂).app U₂ t₂ |_ (D.map f₁ ⁻¹ᵁ U₁ ⊓ D.map f₂ ⁻¹ᵁ U₂) := by
-  obtain ⟨j, f₁, f₂, -⟩ := IsCofilteredOrEmpty.cone_objs i₁ i₂
-  obtain ⟨k, fkj, hk⟩ := exists_app_map_eq_zero_of_isLimit D c hc
-    ((hU₁.preimage (D.map f₁)).isCompact.inter_of_isOpen (hU₂.preimage (D.map f₂)).isCompact
-      (U₁.2.preimage (D.map f₁).continuous) (U₂.2.preimage (D.map f₂).continuous))
-    ((D.map f₁).app U₁ t₁ |_ (D.map f₁ ⁻¹ᵁ U₁ ⊓ D.map f₂ ⁻¹ᵁ U₂) -
-      (D.map f₂).app U₂ t₂ |_ (D.map f₁ ⁻¹ᵁ U₁ ⊓ D.map f₂ ⁻¹ᵁ U₂)) (by
+    (ht₂ : (c.π.app i₂).app U₂ t₂ = s |_ (c.π.app i₂ ⁻¹ᵁ U₂)) (u₁ : k ⟶ i₁) (u₂ : k ⟶ i₂) :
+    ∃ (l : I) (v : l ⟶ k), ∀ (V : (D.obj l).Opens) (h₁ : V ≤ D.map (v ≫ u₁) ⁻¹ᵁ U₁)
+      (h₂ : V ≤ D.map (v ≫ u₂) ⁻¹ᵁ U₂),
+        (D.map (v ≫ u₁)).appLE U₁ V h₁ t₁ = (D.map (v ≫ u₂)).appLE U₂ V h₂ t₂ := by
+  obtain ⟨l, v, hv⟩ := exists_app_map_eq_zero_of_isLimit D c hc
+    ((hU₁.preimage (D.map u₁)).isCompact.inter_of_isOpen (hU₂.preimage (D.map u₂)).isCompact
+      (U₁.2.preimage (D.map u₁).continuous) (U₂.2.preimage (D.map u₂).continuous))
+    ((D.map u₁).app U₁ t₁ |_ (D.map u₁ ⁻¹ᵁ U₁ ⊓ D.map u₂ ⁻¹ᵁ U₂) -
+      (D.map u₂).app U₂ t₂ |_ (D.map u₁ ⁻¹ᵁ U₁ ⊓ D.map u₂ ⁻¹ᵁ U₂)) (by
     dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
     simp only [map_sub, sub_eq_zero, ← ConcreteCategory.comp_apply,
       Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, Scheme.Hom.appLE_comp_appLE, Cone.w]
     exact (π_appLE_eq_restrict D c ht₁ _).trans (π_appLE_eq_restrict D c ht₂ _).symm)
-  refine ⟨k, fkj ≫ f₁, fkj ≫ f₂, ?_⟩
-  have H : (D.map (fkj ≫ f₁) ⁻¹ᵁ U₁ ⊓ D.map (fkj ≫ f₂) ⁻¹ᵁ U₂) ≤
-      D.map fkj ⁻¹ᵁ ((D.map f₁ ⁻¹ᵁ U₁ ⊓ D.map f₂ ⁻¹ᵁ U₂)) := by simp; rfl
-  apply_fun (D.obj k).presheaf.map (homOfLE H).op at hk
-  dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict] at hk ⊢
+  refine ⟨l, v, fun V h₁ h₂ ↦ ?_⟩
+  have H : V ≤ D.map v ⁻¹ᵁ (D.map u₁ ⁻¹ᵁ U₁ ⊓ D.map u₂ ⁻¹ᵁ U₂) := by
+    simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
+  apply_fun (D.obj l).presheaf.map (homOfLE H).op at hv
+  dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict] at hv ⊢
   simpa [sub_eq_zero, ← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
-    Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hk
+    Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hv
 
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
 lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
@@ -932,62 +903,49 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
   classical
   have := Scheme.compactSpace_of_isLimit _ _ hc
   choose i U hU hxU t ht using exists_app_eq_restrict_of_isLimit D c hc s
-  choose j fjx fjy hj using fun x y ↦
-    exists_map_app_eq_of_isLimit D c hc (hU x) (hU y) (t x) (t y) (ht x) (ht y)
   obtain ⟨σ, hσ⟩ := CompactSpace.elim_nhds_subcover (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).1)
     (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).2.mem_nhds (by exact hxU x))
   choose σi hσiσ hσi using fun x ↦ Set.mem_iUnion₂.mp (hσ.ge (Set.mem_univ x))
-  obtain ⟨k, fk, fkj, hk₁, hk₂⟩ := exists_cone_of_pairs σ i j fjx fjy
-  obtain ⟨k', fk'k, hk'⟩ := exists_map_eq_top D c hc
-    (⨆ (x : _) (hx : x ∈ σ), D.map (fk hx) ⁻¹ᵁ U x) (by
-    apply SetLike.coe_injective
-    simpa [← Set.preimage_comp, ← TopCat.coe_comp, ← Scheme.Hom.comp_base])
+  obtain ⟨j, fj, hfj⟩ : ∃ (j : I) (fj : ∀ x : σ, j ⟶ i x), ⨆ x : σ, D.map (fj x) ⁻¹ᵁ U x = ⊤ := by
+    obtain ⟨j₀, hj₀⟩ := IsCofiltered.inf_objs_exists (σ.image i)
+    have fj₀ (x : σ) : j₀ ⟶ i x := (hj₀ (Finset.mem_image_of_mem i x.2)).some
+    obtain ⟨j, w, hw⟩ := exists_map_eq_top D c hc (⨆ x : σ, D.map (fj₀ x) ⁻¹ᵁ U x) (by
+      apply SetLike.coe_injective
+      simpa [← Set.preimage_comp, ← TopCat.coe_comp, ← Scheme.Hom.comp_base,
+        Set.iUnion_subtype] using hσ)
+    exact ⟨j, fun x ↦ w ≫ fj₀ x, by simpa [Scheme.Hom.preimage_iSup] using hw⟩
+  obtain ⟨k, v, hv⟩ := IsCofiltered.exists_forall
+    (fun l (v : l ⟶ j) (x : σ × σ) ↦ ∀ (V : (D.obj l).Opens)
+      (h₁ : V ≤ D.map (v ≫ fj x.1) ⁻¹ᵁ U x.1) (h₂ : V ≤ D.map (v ≫ fj x.2) ⁻¹ᵁ U x.2),
+        (D.map (v ≫ fj x.1)).appLE _ V h₁ (t x.1) = (D.map (v ≫ fj x.2)).appLE _ V h₂ (t x.2))
+    (fun w u x hu V h₁ h₂ ↦ by
+      have e : V ≤ D.map w ⁻¹ᵁ (D.map (u ≫ fj x.1) ⁻¹ᵁ U x.1 ⊓ D.map (u ≫ fj x.2) ⁻¹ᵁ U x.2) := by
+        simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
+      simpa [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
+        using congr((D.map w).appLE _ V e $(hu _ inf_le_left inf_le_right)))
+    fun x ↦ exists_map_appLE_eq_of_isLimit D c hc (hU x.1) (hU x.2) (ht x.1) (ht x.2)
+      (fj x.1) (fj x.2)
+  have hcov : ⨆ x : σ, D.map (v ≫ fj x) ⁻¹ᵁ U x = ⊤ := by
+    simpa [Scheme.Hom.comp_preimage] using (D.map v).iSup_preimage_eq_top hfj
   have hsheaf := ((Presheaf.isSheaf_iff_isSheaf_forget _ _ (forget _)).mp
-      (D.obj k').IsSheaf).isSheafFor
-    (.ofArrows (fun x : σ ↦ D.map (fk'k ≫ fk x.2) ⁻¹ᵁ U x.1) fun x ↦ homOfLE le_top)
-    (fun x _ ↦ by
-      obtain ⟨ix, hix, h⟩ : ∃ ix, ∃ (h : ix ∈ σ), (D.map (fk'k ≫ fk h)).base x ∈ U ix := by
-        simpa using hk'.ge (Set.mem_univ x)
-      refine ⟨D.map (fk'k ≫ fk hix) ⁻¹ᵁ U ix, homOfLE le_top,
-        Sieve.ofArrows_mk (I := σ) _ _ ⟨ix, hix⟩, h⟩)
+      (D.obj k).IsSheaf).isSheafFor
+    (.ofArrows (fun x : σ ↦ D.map (v ≫ fj x) ⁻¹ᵁ U x) fun x ↦ homOfLE le_top)
+    (fun y _ ↦ by
+      obtain ⟨x, hx⟩ : ∃ x : σ, y ∈ D.map (v ≫ fj x) ⁻¹ᵁ U x := by
+        simpa using hcov.ge (Set.mem_univ y)
+      exact ⟨_, homOfLE le_top, Sieve.ofArrows_mk _ _ x, hx⟩)
   rw [← Presieve.isSheafFor_iff_generate, Presieve.isSheafFor_arrows_iff] at hsheaf
   obtain ⟨t₀, ht₀, -⟩ := hsheaf (fun x ↦ (D.map _).app _ (t x)) fun x y V fVx fVy _ ↦ by
-    have H : V ≤ D.map (fk'k ≫ fkj x.2 y.2) ⁻¹ᵁ
-        (D.map (fjx ↑x ↑y) ⁻¹ᵁ U ↑x ⊓ D.map (fjy ↑x ↑y) ⁻¹ᵁ U ↑y) := by
-      change V ≤ (D.map (fk'k ≫ fkj x.2 y.2) ≫ D.map (fjx ↑x ↑y)) ⁻¹ᵁ U x ⊓
-        (D.map (fk'k ≫ fkj x.2 y.2) ≫ D.map (fjy x y)) ⁻¹ᵁ U y
-      rw [← Functor.map_comp, ← Functor.map_comp, Category.assoc, Category.assoc,
-        hk₁ x.2 y.2, hk₂ x.2 y.2, le_inf_iff]
-      exact ⟨fVx.le, fVy.le⟩
-    convert!
-      congr(((D.map (fk'k ≫ fkj x.2 y.2)).app _ ≫ (D.obj k').presheaf.map (homOfLE H).op)
-        $(hj x y)) using 1
-    · dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-      simp only [← ConcreteCategory.comp_apply]
-      congr 2
-      simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE,
-        -Scheme.Hom.comp_appLE, ← Functor.map_comp, hk₁]
-    · dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-      simp only [← ConcreteCategory.comp_apply]
-      congr 2
-      simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE,
-        -Scheme.Hom.comp_appLE, ← Functor.map_comp, hk₂]
-  refine ⟨k', t₀, TopCat.Presheaf.section_ext c.pt.sheaf _ _ _ fun y hy ↦ c.pt.presheaf.germ_ext
+    simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, -Scheme.Hom.comp_appLE]
+      using hv (x, y) V fVx.le fVy.le
+  refine ⟨k, t₀, TopCat.Presheaf.section_ext c.pt.sheaf _ _ _ fun y hy ↦ c.pt.presheaf.germ_ext
     (c.π.app _ ⁻¹ᵁ U (σi y)) (hσi y) (homOfLE le_top) (homOfLE le_top) ?_⟩
   have H : c.π.app (i (σi y)) ⁻¹ᵁ U (σi y) ≤
-      c.π.app k' ⁻¹ᵁ D.map (fk'k ≫ fk (hσiσ _)) ⁻¹ᵁ U (σi y) := by
+      c.π.app k ⁻¹ᵁ D.map (v ≫ fj ⟨_, hσiσ y⟩) ⁻¹ᵁ U (σi y) := by
     rw [← Scheme.Hom.comp_preimage, Cone.w]
-  convert! congr(c.pt.presheaf.map (homOfLE H).op ((c.π.app k').app _ $(ht₀ ⟨_, hσiσ y⟩))).symm
-  · refine (ht (σi y)).symm.trans ?_
-    dsimp [Scheme.Opens.toScheme_presheaf_obj]
-    rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply]
-    congr 2
-    simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
-  · dsimp [Scheme.Opens.toScheme_presheaf_obj]
-    rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply,
-      ← ConcreteCategory.comp_apply]
-    congr 2
-    simp [Scheme.Hom.app_eq_appLE]
+  refine (π_appLE_eq_restrict D c (ht (σi y)) le_rfl).symm.trans ?_
+  simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE,
+    -Scheme.Hom.comp_appLE] using congr((c.π.app k).appLE _ _ H $(ht₀ ⟨_, hσiσ y⟩)).symm
 
 include hc in
 lemma nonempty_isColimit_Γ_mapCocone [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
@@ -1195,8 +1153,6 @@ private lemma Scheme.exists_appTop_eq {Y Z : Scheme.{u}} [IsAffine Z] (φ : Γ(Z
   rw [Scheme.Hom.comp_appTop, Scheme.Hom.comp_appTop, h, Scheme.toSpecΓ_appTop, Category.assoc,
     Scheme.ΓSpecIso_naturality, Iso.inv_hom_id_assoc]
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 /-- See `Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation` for the general case. -/
 private nonrec lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
@@ -1234,7 +1190,6 @@ private lemma isBasis_affineOpens_le_preimage {Y Z T : Scheme.{u}} (a : Y ⟶ Z)
     (U := O ⊓ a ⁻¹ᵁ V) (x := y) ⟨hy, hyV⟩
   exact ⟨U, ⟨hU, ⟨V, hV⟩, ⟨W, hW⟩, hUV.trans inf_le_right, hVW⟩, hyU, hUV.trans inf_le_left⟩
 
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
 private lemma exists_resLE_comp_eq_of_isAffineOpen
@@ -1298,7 +1253,6 @@ private lemma exists_forall_resLE_comp_eq_of_isAffineOpen
     fun j ↦ exists_resLE_comp_eq_of_isAffineOpen D t f c hc a ha (hU j) (V j) (W j) (hVW j) (hUV j)
   exact ⟨k, u, g, hg, hg'⟩
 
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
 private lemma exists_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOfFiniteType f]

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -364,9 +364,7 @@ lemma exists_preimage_eq
   obtain ⟨s, hs, hsf, rfl⟩ := (isBasis_preimage_isAffineOpen D c hc).exists_finite_of_isCompact hU
   have : Finite s := hsf
   choose i V hV hVi using fun x : s ↦ hs x.2
-  obtain ⟨j, fj⟩ := IsCofiltered.inf_objs_exists (hsf.toFinset.attach.image
-    fun x ↦ i ⟨x.1, (by simpa only [Set.Finite.mem_toFinset] using x.2)⟩:)
-  replace fj : ∀ b : s, j ⟶ i b := fun b ↦ (@fj (i b) (by simpa using ⟨b.1, b.2, rfl⟩)).some
+  obtain ⟨j, ⟨fj⟩⟩ := IsCofiltered.exists_hom_forall i
   refine ⟨j, ⨆ (k : s), D.map (fj _) ⁻¹ᵁ V k, ?_, ?_⟩
   · simp only [TopologicalSpace.Opens.iSup_mk, TopologicalSpace.Opens.carrier_eq_coe,
       TopologicalSpace.Opens.map_coe, TopologicalSpace.Opens.coe_mk]
@@ -905,8 +903,7 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
   obtain ⟨σ, hσ⟩ := CompactSpace.elim_nhds_subcover (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).1)
     (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).2.mem_nhds (by exact hxU x))
   obtain ⟨j, fj, hfj⟩ : ∃ (j : I) (fj : ∀ x : σ, j ⟶ i x), ⨆ x : σ, D.map (fj x) ⁻¹ᵁ U x = ⊤ := by
-    obtain ⟨j₀, hj₀⟩ := IsCofiltered.inf_objs_exists (σ.image i)
-    have fj₀ (x : σ) : j₀ ⟶ i x := (hj₀ (Finset.mem_image_of_mem i x.2)).some
+    obtain ⟨j₀, ⟨fj₀⟩⟩ := IsCofiltered.exists_hom_forall fun x : σ ↦ i x
     obtain ⟨j, w, hw⟩ := exists_map_eq_top D c hc (⨆ x : σ, D.map (fj₀ x) ⁻¹ᵁ U x) (by
       apply SetLike.coe_injective
       simpa [← Set.preimage_comp, ← TopCat.coe_comp, ← Scheme.Hom.comp_base,
@@ -1059,9 +1056,7 @@ lemma Scheme.exists_isOpenCover_and_isAffine_of_finite [IsCofiltered I]
       IsOpenCover V ∧ ∀ j, IsAffineOpen (V j) ∧ U j = c.π.app i ⁻¹ᵁ (V j) := by
   classical
   choose j V hV hVU using fun k ↦ exists_isAffineOpen_preimage_eq D c hc (U k) (hU' k)
-  cases nonempty_fintype J
-  obtain ⟨i, fi⟩ := IsCofiltered.inf_objs_exists (Finset.univ.image j)
-  replace fi : ∀ k, i ⟶ j k := fun k ↦ (fi (by simp)).some
+  obtain ⟨i, ⟨fi⟩⟩ := IsCofiltered.exists_hom_forall j
   obtain ⟨k, fkj, e⟩ := exists_map_eq_top D c hc (⨆ (k), D.map (fi k) ⁻¹ᵁ V k) (by
     simp_rw [Hom.preimage_iSup, ← Hom.comp_preimage, c.w, hVU]
     exact hU)

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -1142,56 +1142,10 @@ private nonrec lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
     ext_of_isAffine (by simpa [α] using hφ)⟩
 
 variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [LocallyOfFinitePresentation f]
+  [∀ i, QuasiSeparatedSpace (D.obj i)]
   {i : I} {J : Type*} [Finite J] {U : J → (D.obj i).Opens} (hU : ∀ j, IsAffineOpen (U j))
   (hUV : ∀ j, ∃ (V : X.affineOpens) (W : S.affineOpens),
     c.π.app i ⁻¹ᵁ U j ≤ a ⁻¹ᵁ (V : X.Opens) ∧ (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens))
-
-include hc ha hU hUV in
-private lemma exists_forall_resLE_comp_eq_of_isAffineOpen :
-    ∃ (k : I) (u : k ⟶ i), ∀ j, ∃ g : ↑(D.map u ⁻¹ᵁ U j) ⟶ X,
-      g ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k ∧
-        ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
-          (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a := by
-  have hnat {j k : I} (v : j ⟶ k) : D.map v ≫ t.app k = t.app j := by simp
-  have hπ (j : I) : c.π.app j ≫ t.app j = a ≫ f := congr(($ha).app j)
-  choose V W hUV hVW using hUV
-  refine IsCofiltered.exists_forall _ ?_ fun j ↦ ?_
-  · rintro k₁ k₂ v u j ⟨g, hg, hg'⟩
-    have e : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
-    exact ⟨(D.map v).resLE _ _ e ≫ g, by simpa using congr((D.map v).resLE _ _ e ≫ $hg),
-      fun O h ↦ by simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)⟩
-  obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc (hU j).isCompact
-    (V := t.app i ⁻¹ᵁ (W j : S.Opens)) (by
-      rw [← Scheme.Hom.comp_preimage, hπ, Scheme.Hom.comp_preimage]
-      exact (hUV j).trans (a.preimage_mono (hVW j)))
-  replace hu : D.map u ⁻¹ᵁ U j ≤ t.app i' ⁻¹ᵁ (W j : S.Opens) :=
-    hu.trans_eq (by rw [← Scheme.Hom.comp_preimage, hnat])
-  have _ (k : Over i') : IsAffine ((opensDiagram D i' (D.map u ⁻¹ᵁ U j)).obj k) :=
-    ((hU j).preimage _).preimage _
-  let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U j) ⟶ (Functor.const (Over i')).obj (W j) :=
-    { app k := (t.app k.left).resLE _ _ ((Scheme.Hom.preimage_mono _ hu).trans_eq
-        (by rw [← Scheme.Hom.comp_preimage, hnat]))
-      naturality k l v := ((D.map v.left).resLE_comp_resLE _ (t.app l.left) _).trans
-        (Eq.trans ((cancel_mono (W j : S.Opens).ι).mp (by simp [hnat]))
-          (Category.comp_id _).symm) }
-  obtain ⟨k, g, hg, hg'⟩ :
-      ∃ (k : Over i') (g : (D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U j).toScheme ⟶ (V j : X.Opens).toScheme),
-        (c.π.app k.left).resLE _ (c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j) (by simp) ≫ g =
-            a.resLE _ _ (by simpa using hUV j) ∧ g ≫ f.resLE _ _ (hVW j) = τ.app k :=
-    Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
-      _ τ (f.resLE _ _ (hVW j)) _ (isLimitOpensCone D c hc i' _)
-      (a.resLE _ _ (by simpa using hUV j)) (by
-        ext k
-        exact ((c.π.app k.left).resLE_comp_resLE _ (t.app k.left) _).trans
-          (Eq.trans ((cancel_mono (W j : S.Opens).ι).mp (by simp [hπ]))
-            (a.resLE_comp_resLE _ f _).symm))
-  have e : D.map (k.hom ≫ u) ⁻¹ᵁ U j ≤ D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
-  refine ⟨k.left, k.hom ≫ u, Scheme.homOfLE _ e ≫ g ≫ (V j : X.Opens).ι, ?_, fun O h ↦ ?_⟩
-  · simpa [τ] using congr(Scheme.homOfLE _ e ≫ $hg' ≫ (W j : S.Opens).ι)
-  · have h' : O ≤ c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simpa using h
-    simpa using congr(Scheme.homOfLE _ h' ≫ $hg ≫ (V j : X.Opens).ι)
-
-variable [∀ i, QuasiSeparatedSpace (D.obj i)]
 
 include hc ha hU hUV in
 private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
@@ -1199,7 +1153,49 @@ private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
       (∀ j, g j ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k) ∧
       (∀ j, (c.π.app k).resLE _ _ le_rfl ≫ g j = (c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j).ι ≫ a) ∧
       ∀ j₁ j₂, Scheme.homOfLE _ inf_le_left ≫ g j₁ = Scheme.homOfLE _ inf_le_right ≫ g j₂ := by
-  choose k u g hg hg' using exists_forall_resLE_comp_eq_of_isAffineOpen D t f c hc a ha hU hUV
+  have key : ∃ (k : I) (u : k ⟶ i), ∀ j, ∃ g : ↑(D.map u ⁻¹ᵁ U j) ⟶ X,
+      g ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k ∧
+        ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
+          (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a := by
+    have hnat {j k : I} (v : j ⟶ k) : D.map v ≫ t.app k = t.app j := by simp
+    have hπ (j : I) : c.π.app j ≫ t.app j = a ≫ f := congr(($ha).app j)
+    choose V W hUV hVW using hUV
+    refine IsCofiltered.exists_forall _ ?_ fun j ↦ ?_
+    · rintro k₁ k₂ v u j ⟨g, hg, hg'⟩
+      have e : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
+      exact ⟨(D.map v).resLE _ _ e ≫ g, by simpa using congr((D.map v).resLE _ _ e ≫ $hg),
+        fun O h ↦ by simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)⟩
+    obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc (hU j).isCompact
+      (V := t.app i ⁻¹ᵁ (W j : S.Opens)) (by
+        rw [← Scheme.Hom.comp_preimage, hπ, Scheme.Hom.comp_preimage]
+        exact (hUV j).trans (a.preimage_mono (hVW j)))
+    replace hu : D.map u ⁻¹ᵁ U j ≤ t.app i' ⁻¹ᵁ (W j : S.Opens) :=
+      hu.trans_eq (by rw [← Scheme.Hom.comp_preimage, hnat])
+    have _ (k : Over i') : IsAffine ((opensDiagram D i' (D.map u ⁻¹ᵁ U j)).obj k) :=
+      ((hU j).preimage _).preimage _
+    let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U j) ⟶ (Functor.const (Over i')).obj (W j) :=
+      { app k := (t.app k.left).resLE _ _ ((Scheme.Hom.preimage_mono _ hu).trans_eq
+          (by rw [← Scheme.Hom.comp_preimage, hnat]))
+        naturality k l v := ((D.map v.left).resLE_comp_resLE _ (t.app l.left) _).trans
+          (Eq.trans ((cancel_mono (W j : S.Opens).ι).mp (by simp [hnat]))
+            (Category.comp_id _).symm) }
+    obtain ⟨k, g, hg, hg'⟩ :
+        ∃ (k : Over i') (g : (D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U j).toScheme ⟶ (V j : X.Opens).toScheme),
+          (c.π.app k.left).resLE _ (c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j) (by simp) ≫ g =
+              a.resLE _ _ (by simpa using hUV j) ∧ g ≫ f.resLE _ _ (hVW j) = τ.app k :=
+      Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
+        _ τ (f.resLE _ _ (hVW j)) _ (isLimitOpensCone D c hc i' _)
+        (a.resLE _ _ (by simpa using hUV j)) (by
+          ext k
+          exact ((c.π.app k.left).resLE_comp_resLE _ (t.app k.left) _).trans
+            (Eq.trans ((cancel_mono (W j : S.Opens).ι).mp (by simp [hπ]))
+              (a.resLE_comp_resLE _ f _).symm))
+    have e : D.map (k.hom ≫ u) ⁻¹ᵁ U j ≤ D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
+    refine ⟨k.left, k.hom ≫ u, Scheme.homOfLE _ e ≫ g ≫ (V j : X.Opens).ι, ?_, fun O h ↦ ?_⟩
+    · simpa [τ] using congr(Scheme.homOfLE _ e ≫ $hg' ≫ (W j : S.Opens).ι)
+    · have h' : O ≤ c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simpa using h
+      simpa using congr(Scheme.homOfLE _ h' ≫ $hg ≫ (V j : X.Opens).ι)
+  choose k u g hg hg' using key
   obtain ⟨l, v, hl⟩ : ∃ (l : I) (v : l ⟶ k), ∀ j₁ j₂ (O : (D.obj l).Opens)
       (e₁ : O ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j₁) (e₂ : O ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j₂),
         (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ := by

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -1071,7 +1071,6 @@ include hc ha hU hcov hUV in
 /-- See `Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation` for the general case. -/
 private lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffineOpen :
     ∃ (k : I) (g : D.obj k ⟶ X), c.π.app k ≫ g = a ∧ g ≫ f = t.app k := by
-  have hnat {j k : I} (v : j ⟶ k) : D.map v ≫ t.app k = t.app j := by simp
   have hπ (j : I) : c.π.app j ≫ t.app j = a ≫ f := congr(($ha).app j)
   choose V W hUV hVW using hUV
   -- Each `U j` factors after passing to some `l`, compatibly on overlaps.
@@ -1080,7 +1079,7 @@ private lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffineOp
         ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
           (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a := by
     refine IsCofiltered.exists_forall (fun v u j ⟨g, hg, hg'⟩ ↦ ⟨(D.map v).resLE _ _ (by simp) ≫ g,
-      by simp [hg, hnat], fun O h ↦ by simpa using hg' O (h.trans (by simp))⟩) fun j ↦ ?_
+      by simp [hg], fun O h ↦ by simpa using hg' O (h.trans (by simp))⟩) fun j ↦ ?_
     obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc (hU j).isCompact
       (V := t.app i ⁻¹ᵁ (W j : S.Opens))
       (by simpa only [← Hom.comp_preimage, hπ] using (hUV j).trans (a.preimage_mono (hVW j)))
@@ -1088,19 +1087,12 @@ private lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffineOp
       ((hU j).preimage _).preimage _
     let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U j) ⟶ (Functor.const (Over i')).obj (W j) :=
       { app k := (t.app k.left).resLE _ _ ((Hom.preimage_mono _ hu).trans_eq
-          (by simp only [← Hom.comp_preimage, hnat]))
-        naturality _ _ v := by
-          dsimp only [opensDiagram, Functor.const_obj_map]
-          simp [hnat] }
-    obtain ⟨k, g, hg, hg'⟩ : ∃ (k : Over i') (g : _ ⟶ (V j : X.Opens).toScheme),
-        (c.π.app k.left).resLE _ (c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j) (by simp) ≫ g =
-          a.resLE _ _ (by simpa using hUV j) ∧ g ≫ f.resLE _ _ (hVW j) = τ.app k :=
-      exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
-        _ τ (f.resLE _ _ (hVW j)) _ (isLimitOpensCone D c hc i' _)
-        (a.resLE _ _ (by simpa using hUV j)) (by
-          ext k
-          dsimp only [τ, opensCone, opensDiagram]
-          simp [hπ])
+          (by simp [← Hom.comp_preimage]))
+        naturality _ _ v := by simp [opensDiagram] }
+    obtain ⟨k, g, hg, hg'⟩ := exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
+      _ τ (f.resLE _ _ (hVW j)) _ (isLimitOpensCone D c hc i' _)
+      (a.resLE _ _ (by simpa using hUV j)) (by ext k; simp [τ, opensCone, opensDiagram, hπ])
+    dsimp only [opensCone, opensDiagram] at g hg hg'
     have e : D.map (k.hom ≫ u) ⁻¹ᵁ U j ≤ D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
     refine ⟨k.left, k.hom ≫ u, Scheme.homOfLE _ e ≫ g ≫ (V j : X.Opens).ι, ?_, fun O h ↦ ?_⟩
     · simpa [τ] using congr(Scheme.homOfLE _ e ≫ $hg' ≫ (W j : S.Opens).ι)
@@ -1116,9 +1108,8 @@ private lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffineOp
       (((hU j₁).preimage (D.map u)).isCompact_inf ((hU j₂).preimage (D.map u)))
       (Scheme.homOfLE _ inf_le_left ≫ g j₁) (Scheme.homOfLE _ inf_le_right ≫ g j₂)
       (by simp [hg]) (by simp [hg]) (by simpa using (hg' j₁ _ _).trans (hg' j₂ _ _).symm)
-    exact ⟨l, v, fun O e₁ e₂ ↦ by
-      simpa using
-        congr(Scheme.homOfLE _ ((le_inf e₁ e₂).trans_eq (by simp [Hom.preimage_inf])) ≫ $e)⟩
+    refine ⟨l, v, fun O e₁ e₂ ↦ ?_⟩
+    simpa using congr(Scheme.homOfLE _ ((le_inf e₁ e₂).trans_eq (by simp [Hom.preimage_inf])) ≫ $e)
   -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
   have h𝒲 := (hcov.preimage (D.map u)).preimage (D.map v)
   obtain ⟨F, hF⟩ := exists_ι_comp_eq_of_isOpenCover h𝒲 (fun j ↦ (D.map v).resLE _ _ le_rfl ≫ g j)

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -228,24 +228,8 @@ def opensCone (i : I) (U : (D.obj i).Opens) : Cone (opensDiagram D i U) where
   pt := c.π.app i ⁻¹ᵁ U
   π.app j := (c.π.app j.left).resLE _ _ (by rw [← Scheme.Hom.comp_preimage, c.w])
 
-attribute [local instance] CategoryTheory.isConnected_of_hasTerminal
-
-variable [IsCofiltered I]
-
-set_option backward.isDefEq.respectTransparency false in
-/-- Given a diagram `{ Dᵢ }_{i ∈ I}` of schemes and an open `U ⊆ Dᵢ`,
-the preimage of `U ⊆ Dᵢ` under the map `lim Dᵢ ⟶ Dᵢ` is the limit of `{ Dⱼᵢ⁻¹ U }_{j ≤ i}`. -/
-noncomputable
-def isLimitOpensCone (i : I) (U : (D.obj i).Opens) :
-    IsLimit (opensCone D c i U) :=
-  isLimitOfIsPullbackOfIsConnected (opensDiagramι D i U) _ _
-    (by exact { hom := (c.π.app i ⁻¹ᵁ U).ι })
-    (fun j ↦ IsOpenImmersion.isPullback _ _ _ _ (by simp) (by simp [← Scheme.Hom.comp_preimage]))
-    ((Functor.Initial.isLimitWhiskerEquiv (Over.forget i) c).symm hc)
-
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
-omit [IsCofiltered I] in
 instance [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] {i : I}
     (U : (D.obj i).Opens) {j k : Over i} (f : j ⟶ k) :
     IsAffineHom ((opensDiagram D i U).map f) := by
@@ -272,11 +256,34 @@ instance [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] {i : I}
     rw [← Scheme.Hom.comp_apply] at h₁
     rwa [← D.map_comp, Over.w f] at h₁
 
+attribute [local instance] CategoryTheory.isConnected_of_hasTerminal
+
+variable [IsCofiltered I]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Given a diagram `{ Dᵢ }_{i ∈ I}` of schemes and an open `U ⊆ Dᵢ`,
+the preimage of `U ⊆ Dᵢ` under the map `lim Dᵢ ⟶ Dᵢ` is the limit of `{ Dⱼᵢ⁻¹ U }_{j ≤ i}`. -/
+noncomputable
+def isLimitOpensCone (i : I) (U : (D.obj i).Opens) :
+    IsLimit (opensCone D c i U) :=
+  isLimitOfIsPullbackOfIsConnected (opensDiagramι D i U) _ _
+    (by exact { hom := (c.π.app i ⁻¹ᵁ U).ι })
+    (fun j ↦ IsOpenImmersion.isPullback _ _ _ _ (by simp) (by simp [← Scheme.Hom.comp_preimage]))
+    ((Functor.Initial.isLimitWhiskerEquiv (Over.forget i) c).symm hc)
+
+include hc in
+lemma exists_appTop_π_eq_of_isAffine_of_isLimit [∀ i, IsAffine (D.obj i)] (s : Γ(c.pt, ⊤)) :
+    ∃ (i : I) (t : Γ(D.obj i, ⊤)), (c.π.app i).appTop t = s := by
+  have : ∀ i, IsAffine (D.op.obj i).unop := by dsimp; infer_instance
+  exact ⟨_, (Types.jointly_surjective_of_isColimit
+    (isColimitOfPreserves (Scheme.Γ ⋙ forget _) hc.op) s).choose_spec⟩
+
+variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
 lemma exists_map_preimage_le_map_preimage
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     {i : I} {U V : (D.obj i).Opens} (hU : IsCompact (U : Set (D.obj i)))
     (H : c.π.app i ⁻¹ᵁ U ≤ c.π.app i ⁻¹ᵁ V) :
     ∃ (j : I) (fji : j ⟶ i), D.map fji ⁻¹ᵁ U ≤ D.map fji ⁻¹ᵁ V := by
@@ -297,7 +304,6 @@ lemma exists_map_preimage_le_map_preimage
 include hc in
 @[stacks 01Z4 "(2)"]
 lemma exists_map_preimage_eq_map_preimage
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     {i : I} {U V : (D.obj i).Opens} (hU : IsCompact (U : Set (D.obj i)))
     (hV : IsCompact (V : Set (D.obj i))) (H : c.π.app i ⁻¹ᵁ U = c.π.app i ⁻¹ᵁ V) :
     ∃ (j : I) (fji : j ⟶ i), D.map fji ⁻¹ᵁ U = D.map fji ⁻¹ᵁ V := by
@@ -310,15 +316,8 @@ lemma exists_map_preimage_eq_map_preimage
     simpa only [Scheme.Hom.comp_preimage, Functor.map_comp] using Scheme.Hom.preimage_mono _ e₂
 
 include hc in
-lemma exists_appTop_π_eq_of_isAffine_of_isLimit [∀ i, IsAffine (D.obj i)] (s : Γ(c.pt, ⊤)) :
-    ∃ (i : I) (t : Γ(D.obj i, ⊤)), (c.π.app i).appTop t = s := by
-  have : ∀ i, IsAffine (D.op.obj i).unop := by dsimp; infer_instance
-  exact ⟨_, (Types.jointly_surjective_of_isColimit
-    (isColimitOfPreserves (Scheme.Γ ⋙ forget _) hc.op) s).choose_spec⟩
-
-include hc in
-lemma exists_appLE_π_eq_of_isAffineOpen [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    {i : I} {U : (D.obj i).Opens} (hU : IsAffineOpen U) (s : Γ(c.pt, c.π.app i ⁻¹ᵁ U)) :
+lemma exists_appLE_π_eq_of_isAffineOpen {i : I} {U : (D.obj i).Opens} (hU : IsAffineOpen U)
+    (s : Γ(c.pt, c.π.app i ⁻¹ᵁ U)) :
     ∃ (j : I) (u : j ⟶ i) (t : Γ(D.obj j, D.map u ⁻¹ᵁ U)),
       (c.π.app j).appLE _ _ (π_app_preimage_map_preimage D c u U).ge t = s := by
   have (j : Over i) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage (D.map _)
@@ -334,7 +333,7 @@ lemma exists_appLE_π_eq_of_isAffineOpen [∀ {i j} (f : i ⟶ j), IsAffineHom (
   exact (c.π.app i ⁻¹ᵁ U).topIso.commRingCatIsoToRingEquiv.symm.injective ht
 
 include hc in
-lemma isBasis_preimage_isAffineOpen [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] :
+lemma isBasis_preimage_isAffineOpen :
     TopologicalSpace.Opens.IsBasis
       { (c.π.app i ⁻¹ᵁ V : c.pt.Opens) | (i : I) (V : (D.obj i).Opens) (_ : IsAffineOpen V) } := by
   refine TopologicalSpace.Opens.isBasis_iff_nbhd.mpr fun {U x} hxU ↦ ?_
@@ -354,8 +353,7 @@ lemma isBasis_preimage_isAffineOpen [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map
 set_option backward.defeqAttrib.useBackward true in
 include hc in
 @[stacks 01Z4 "(1)"]
-lemma exists_preimage_eq [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    (U : c.pt.Opens) (hU : IsCompact (U : Set c.pt)) :
+lemma exists_preimage_eq (U : c.pt.Opens) (hU : IsCompact (U : Set c.pt)) :
     ∃ (i : I) (V : (D.obj i).Opens), IsCompact (V : Set (D.obj i)) ∧ c.π.app i ⁻¹ᵁ V = U := by
   classical
   obtain ⟨s, hs, hsf, rfl⟩ := (isBasis_preimage_isAffineOpen D c hc).exists_finite_of_isCompact hU

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -53,37 +53,37 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
   cases isEmpty_or_nonempty I
   · have e := (isLimitEquivIsTerminalOfIsEmpty _ _ hc).uniqueUpToIso specULiftZIsTerminal
     exact Nonempty.map e.inv inferInstance
-  · have i := Nonempty.some ‹Nonempty I›
+  · have i : I := Classical.ofNonempty
     have : IsCofiltered I := ⟨⟩
     let 𝒰 := (D.obj i).affineCover.finiteSubcover
-    have (i' : _) : IsAffine (𝒰.X i') := inferInstanceAs (IsAffine (Spec _))
+    have _ (i') : IsAffine (𝒰.X i') := inferInstanceAs (IsAffine (Spec _))
     obtain ⟨j, H⟩ :
         ∃ j : 𝒰.I₀, ∀ {i'} (f : i' ⟶ i), Nonempty ((𝒰.pullback₁ (D.map f)).X j) := by
       by_contra! H
       choose i' f hf using H
       let g (j) := IsCofiltered.infTo (insert i (Finset.univ.image i'))
         (Finset.univ.image fun j : 𝒰.I₀ ↦ ⟨_, _, by simp, by simp, f j⟩) (X := j)
-      have (j : 𝒰.I₀) : IsEmpty ((𝒰.pullback₁ (D.map (g i (by simp)))).X j) := by
-        let F : (𝒰.pullback₁ (D.map (g i (by simp)))).X j ⟶ (𝒰.pullback₁ (D.map (f j))).X j :=
+      let 𝒱 := 𝒰.pullback₁ (D.map (g i (by simp)))
+      have (j : 𝒰.I₀) : IsEmpty (𝒱.X j) := by
+        let F : 𝒱.X j ⟶ (𝒰.pullback₁ (D.map (f j))).X j :=
           pullback.map _ _ _ _ (D.map (g _ (by simp))) (𝟙 _) (𝟙 _) (by
             rw [← D.map_comp, IsCofiltered.infTo_commutes]
             · simp [g]
             · simp
             · exact Finset.mem_image_of_mem _ (Finset.mem_univ _)) (by simp)
         exact Function.isEmpty F
-      exact (this _).elim (Cover.covers (𝒰.pullback₁ (D.map (g i (by simp))))
-        (Nonempty.some inferInstance)).choose
+      exact (this _).elim (Cover.covers 𝒱 Classical.ofNonempty).choose
     let F := Over.post D ⋙ Over.pullback (𝒰.f j) ⋙ Over.forget _
-    have (k : _) : IsAffine (F.obj k) := inferInstanceAs (IsAffine (pullback (D.map k.hom) (𝒰.f j)))
-    have hFne (i' : _) : Nonempty (F.obj i') := H i'.hom
+    have _ (k) : IsAffine (F.obj k) := inferInstanceAs (IsAffine (pullback (D.map k.hom) (𝒰.f j)))
+    have hFne (i') : Nonempty (F.obj i') := H i'.hom
     let e : F ⟶ (F ⋙ Γ.rightOp) ⋙ Scheme.Spec := Functor.whiskerLeft F ΓSpec.adjunction.unit
-    have (k : _) : IsIso (e.app k) := IsAffine.affine
+    have _ (k) : IsIso (e.app k) := IsAffine.affine
     have : IsIso e := NatIso.isIso_of_isIso_app e
     let c' : LimitCone F := ⟨_, (IsLimit.postcomposeInvEquiv (asIso e) _).symm
       (isLimitOfPreserves Scheme.Spec (limit.isLimit (F ⋙ Γ.rightOp)))⟩
     have : Nonempty c'.1.pt := by
       apply +allowSynthFailures PrimeSpectrum.instNonemptyOfNontrivial
-      have (i' : _) : Nontrivial ((F ⋙ Γ.rightOp).leftOp.obj i') := by
+      have _ (i') : Nontrivial ((F ⋙ Γ.rightOp).leftOp.obj i') := by
         apply +allowSynthFailures component_nontrivial
         exact (hFne _).elim fun x ↦ ⟨⟨x, trivial⟩⟩
       exact CommRingCat.FilteredColimits.nontrivial
@@ -311,7 +311,7 @@ lemma isBasis_preimage_isAffineOpen : TopologicalSpace.Opens.IsBasis
   obtain ⟨i⟩ := IsCofiltered.nonempty (C := I)
   obtain ⟨_, ⟨V, hV : IsAffineOpen V, rfl⟩, hxV, -⟩ :=
     (D.obj i).isBasis_affineOpens.exists_subset_of_mem_open (Set.mem_univ (c.π.app i x)) isOpen_univ
-  have (j : _) : IsAffine ((opensDiagram D i V).obj j) := hV.preimage _
+  have _ (j) : IsAffine ((opensDiagram D i V).obj j) := hV.preimage _
   obtain ⟨r, hrU, hxr⟩ := IsAffineOpen.exists_basicOpen_le
     (Scheme.isAffine_of_isLimit _ (isLimitOpensCone D c hc i V)) (V := U) ⟨x, hxU⟩ hxV
   obtain ⟨j, u, s, hs⟩ := exists_appLE_π_eq_of_isAffineOpen D c hc hV r
@@ -339,7 +339,7 @@ lemma exists_preimage_eq (U : c.pt.Opens) (hU : IsCompact (U : Set c.pt)) :
 
 include hc in
 lemma isAffineHom_π_app (i : I) : IsAffineHom (c.π.app i) where
-  isAffine_preimage U hU := have (j : _) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage _
+  isAffine_preimage U hU := have _ (j) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage _
     Scheme.isAffine_of_isLimit _ (isLimitOpensCone D c hc i U)
 
 include hc in
@@ -402,10 +402,10 @@ private nonrec lemma Scheme.exists_hom_hom_comp_eq_comp_of_isAffine_of_locallyOf
   obtain ⟨φ, rfl⟩ := Spec.map_surjective f
   wlog hD : ∃ D' : I ⥤ CommRingCatᵒᵖ, D = D' ⋙ Scheme.Spec generalizing D
   · let e : D ⟶ D ⋙ Γ.rightOp ⋙ Scheme.Spec := D.whiskerLeft ΓSpec.adjunction.unit
-    have inst (i) : IsIso (e.app i) := by dsimp [e]; infer_instance
-    have inst : IsIso e := NatIso.isIso_of_isIso_app e
-    have inst (i) : IsAffine ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj i) := by dsimp; infer_instance
-    have inst : IsAffine ((Cone.postcompose (asIso e).hom).obj c).pt := by dsimp; infer_instance
+    have _ (i) : IsIso (e.app i) := by dsimp [e]; infer_instance
+    have _ : IsIso e := NatIso.isIso_of_isIso_app e
+    have _ (i) : IsAffine ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj i) := by dsimp; infer_instance
+    have _ : IsAffine ((Cone.postcompose (asIso e).hom).obj c).pt := by dsimp; infer_instance
     have := this (D ⋙ Γ.rightOp ⋙ Scheme.Spec) ((Cone.postcompose (asIso e).hom).obj c)
       ((IsLimit.postcomposeHomEquiv (asIso e) c).symm hc) (inv e ≫ t)
       ((inv e).app _ ≫ a) ((inv e).app _ ≫ b)
@@ -549,7 +549,7 @@ lemma exists_eq (j : A.𝒰D.I₀) : ∃ (k : I) (hki' : k ⟶ A.i'),
     (A.𝒰D.pullback₁ (D.map hki')).f j ≫ D.map (hki' ≫ A.hii') ≫ A.a =
       (A.𝒰D.pullback₁ (D.map hki')).f j ≫ D.map (hki' ≫ A.hii') ≫ A.b := by
   have : IsAffine (A.𝒰D.X j) := inferInstanceAs (IsAffine ((A.𝒰D₀.X j.1).affineCover.X j.2))
-  have (i : _) : IsAffine ((Over.post D ⋙ Over.pullback (A.𝒰D.f j) ⋙ Over.forget _).obj i) :=
+  have _ (i) : IsAffine ((Over.post D ⋙ Over.pullback (A.𝒰D.f j) ⋙ Over.forget _).obj i) :=
     inferInstanceAs (IsAffine (pullback (D.map i.hom) (A.𝒰D.f j)))
   have : IsAffine ((Over.pullback (A.𝒰D.f j) ⋙ Over.forget (A.𝒰D.X j)).mapCone
       ((Over.conePost D A.i').obj A.c)).pt :=
@@ -620,7 +620,7 @@ lemma exists_hom_comp_eq_comp_of_locallyOfFiniteType
   rcases isEmpty_or_nonempty (D.obj A.i') with h | h
   · exact ⟨A.i', A.hii', isInitialOfIsEmpty.hom_ext _ _⟩
   let O : Finset I := {A.i'} ∪ Finset.univ.image (fun i : 𝒰Df.I₀ ↦ k <| A.𝒰D.idx i.1)
-  let o := Nonempty.some (inferInstance : Nonempty 𝒰Df.I₀)
+  let o : 𝒰Df.I₀ := Classical.ofNonempty
   have ho : k (A.𝒰D.idx o.1) ∈ O := by simp [O]
   obtain ⟨l, hl1, hl2⟩ := IsCofiltered.inf_exists O
     (Finset.univ.image (fun i : 𝒰Df.I₀ ↦
@@ -919,7 +919,7 @@ lemma Scheme.exists_isAffine_of_isLimit [IsAffine c.pt] :
   obtain ⟨i, hi⟩ := exists_isQuasiAffine_of_isLimit D c hc
   have : ∀ {i j : I} (f : i ⟶ j), IsAffineHom ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).map f) := by
     dsimp; infer_instance
-  have (j : _) : CompactSpace ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj j) :=
+  have _ (j) : CompactSpace ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj j) :=
     inferInstanceAs (CompactSpace (Spec Γ(D.obj j, ⊤)))
   obtain ⟨j, fij, hj⟩ := exists_map_eq_top _ _
     (isLimitOfPreserves (Γ.rightOp ⋙ Scheme.Spec) hc) (D.obj i).toSpecΓ.opensRange

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -851,8 +851,7 @@ include hc in
 private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) :
     ∃ (k : I) (J : Type u) (U : J → (D.obj k).Opens) (_ : IsOpenCover U)
       (t : ∀ x, Γ(D.obj k, U x)), (D.obj k).presheaf.IsCompatible U t ∧
-        ∀ x (V : c.pt.Opens) (e : V ≤ c.π.app k ⁻¹ᵁ U x),
-          (c.π.app k).appLE (U x) V e (t x) = s |_ V := by
+        ∀ x, (c.π.app k).app (U x) (t x) = s |_ (c.π.app k ⁻¹ᵁ U x) := by
   obtain ⟨i⟩ := IsCofiltered.nonempty (C := I)
   obtain ⟨Us, hUs, hUsf, hsup⟩ := (D.obj i).isBasis_affineOpens.exists_finite_of_isCompact
     (U := ⊤) (by simpa using isCompact_univ)
@@ -902,13 +901,13 @@ private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)
       Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hv
   refine ⟨k, Us, fun W ↦ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W.1,
     (hcov.preimage (D.map w)).preimage (D.map v), fun W ↦ (D.map v).app _ (T W),
-    fun W₁ W₂ ↦ ?_, fun W V e ↦ ?_⟩
+    fun W₁ W₂ ↦ ?_, fun W ↦ ?_⟩
   · dsimp [Opens.infLELeft, Opens.infLERight]
     simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, -Scheme.Hom.comp_appLE]
       using hv W₁ W₂ _ inf_le_left inf_le_right
   · simp only [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE,
       Scheme.Hom.appLE_comp_appLE, Cone.w]
-    exact hT W V _
+    exact hT W _ _
 
 include hc in
 lemma exists_appTop_π_eq_of_isLimit (s : Γ(c.pt, ⊤)) :
@@ -918,9 +917,10 @@ lemma exists_appTop_π_eq_of_isLimit (s : Γ(c.pt, ⊤)) :
     (fun _ ↦ homOfLE le_top) hU.ge t hcompat
   refine ⟨k, t₀, TopCat.Sheaf.eq_of_locally_eq' ⟨_, c.pt.IsSheaf⟩ (fun x ↦ c.π.app k ⁻¹ᵁ U x) ⊤
     (fun _ ↦ homOfLE le_top) (hU.preimage (c.π.app k)).ge _ _ fun x ↦ ?_⟩
-  refine (ht x _ le_rfl).symm.trans (Eq.trans ?_ (ConcreteCategory.comp_apply _ _ _))
+  refine (ht x).symm.trans (Eq.trans ?_ (ConcreteCategory.comp_apply _ _ _))
   have key := congr((c.π.app k).appLE _ (c.π.app k ⁻¹ᵁ U x) le_rfl $(ht₀ x))
   simp only [← ConcreteCategory.comp_apply, Scheme.Hom.map_appLE] at key
+  rw [Scheme.Hom.app_eq_appLE]
   exact key.symm
 
 include hc in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -391,48 +391,40 @@ private nonrec lemma Scheme.exists_hom_hom_comp_eq_comp_of_isAffine_of_locallyOf
     ∃ (k : I) (hik : k ⟶ i) (hjk : k ⟶ j),
       D.map hik ≫ a = D.map hjk ≫ b := by
   wlog hS : ∃ R, S = Spec R generalizing S
-  · exact this (t ≫ ((Functor.const I).mapIso S.isoSpec).hom)
-      (f ≫ S.isoSpec.hom) (by simp [ha]) (by simp [hb]) ⟨_, rfl⟩
-  obtain ⟨R, rfl⟩ := hS
-  wlog hX : ∃ S, X = Spec S generalizing X
-  · simpa using! this (a ≫ X.isoSpec.hom) (b ≫ X.isoSpec.hom) (by simp [hab]) (X.isoSpec.inv ≫ f)
+  · exact this (t ≫ (Functor.const I).map S.isoSpec.hom) (f ≫ S.isoSpec.hom)
       (by simp [ha]) (by simp [hb]) ⟨_, rfl⟩
-  obtain ⟨S, rfl⟩ := hX
+  obtain ⟨R, rfl⟩ := hS
+  wlog hX : ∃ A, X = Spec A generalizing X
+  · simpa using this (a ≫ X.isoSpec.hom) (b ≫ X.isoSpec.hom) (by simp [hab]) (X.isoSpec.inv ≫ f)
+      (by simp [ha]) (by simp [hb]) ⟨_, rfl⟩
+  obtain ⟨A, rfl⟩ := hX
   obtain ⟨φ, rfl⟩ := Spec.map_surjective f
   wlog hD : ∃ D' : I ⥤ CommRingCatᵒᵖ, D = D' ⋙ Scheme.Spec generalizing D
-  · let e : D ⟶ D ⋙ Γ.rightOp ⋙ Scheme.Spec := D.whiskerLeft ΓSpec.adjunction.unit
-    have _ (i) : IsIso (e.app i) := by dsimp [e]; infer_instance
-    have _ : IsIso e := NatIso.isIso_of_isIso_app e
-    have _ (i) : IsAffine ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj i) := by dsimp; infer_instance
-    have _ : IsAffine ((Cone.postcompose (asIso e).hom).obj c).pt := by dsimp; infer_instance
-    have := this (D ⋙ Γ.rightOp ⋙ Scheme.Spec) ((Cone.postcompose (asIso e).hom).obj c)
-      ((IsLimit.postcomposeHomEquiv (asIso e) c).symm hc) (inv e ≫ t)
-      ((inv e).app _ ≫ a) ((inv e).app _ ≫ b)
-      (by simp only [Cone.postcompose_obj_π, NatTrans.comp_app, NatIso.isIso_inv_app,
-        Category.assoc, IsIso.hom_inv_id_assoc, asIso_hom]; exact hab)
-      (by simp [ha]) (by simp [hb]) ⟨D ⋙ Γ.rightOp, rfl⟩
-    obtain ⟨k, hik, hjk, H⟩ := this
-    exact ⟨k, hik, hjk, (cancel_epi _).mp (by simpa only [(inv e).naturality_assoc] using H)⟩
+  · let D' := D ⋙ Γ.rightOp
+    let e : D ≅ D' ⋙ Scheme.Spec :=
+      NatIso.ofComponents (fun i ↦ (D.obj i).isoSpec) fun _ ↦ (isoSpec_hom_naturality _).symm
+    have _ (i) : IsAffine ((D' ⋙ Scheme.Spec).obj i) := isAffine_Spec _
+    have _ : IsAffine ((Cone.postcompose e.hom).obj c).pt := ‹_›
+    obtain ⟨k, hik, hjk, H⟩ := this (D' ⋙ Scheme.Spec) ((Cone.postcompose e.hom).obj c)
+      ((IsLimit.postcomposeHomEquiv e c).symm hc) (e.inv ≫ t) (e.inv.app _ ≫ a) (e.inv.app _ ≫ b)
+      (by simpa using hab) (by simp [ha]) (by simp [hb]) ⟨D', rfl⟩
+    exact ⟨k, hik, hjk, (cancel_epi _).mp (by simpa only [e.inv.naturality_assoc] using H)⟩
   obtain ⟨D, rfl⟩ := hD
   obtain ⟨a, rfl⟩ := Spec.map_surjective a
   obtain ⟨b, rfl⟩ := Spec.map_surjective b
-  let e : ((Functor.const Iᵒᵖ).obj R).rightOp ⋙ Scheme.Spec ≅ (Functor.const I).obj (Spec R) :=
-    NatIso.ofComponents (fun _ ↦ Iso.refl _) (by simp)
-  obtain ⟨t, rfl⟩ : ∃ t' : (Functor.const Iᵒᵖ).obj R ⟶ D.leftOp,
-      t = Functor.whiskerRight (NatTrans.rightOp t') Scheme.Spec ≫ e.hom :=
+  obtain ⟨t', ht⟩ : ∃ t' : (Functor.const Iᵒᵖ).obj R ⟶ D.leftOp,
+      ∀ i, t.app i = Spec.map (t'.app (Opposite.op i)) :=
     ⟨⟨fun i ↦ Spec.preimage (t.app i.unop), fun _ _ f ↦ Spec.map_injective
-      (by simpa using! (t.naturality f.unop).symm)⟩, by ext : 2; simp [e]⟩
+      (by simpa using (t.naturality f.unop).symm)⟩, fun _ ↦ by simp⟩
   have := monadicCreatesLimits Scheme.Spec
   obtain ⟨k, hik, hjk, H⟩ := (HasRingHomProperty.Spec_iff.mp ‹LocallyOfFiniteType (Spec.map φ)›)
-    |>.essFiniteType.exists_comp_map_eq_of_isColimit _ D.leftOp t _
-    (coconeLeftOpOfCone (liftLimit hc))
-    (isColimitCoconeLeftOpOfCone _ (liftedLimitIsLimit _))
-    a (Spec.map_injective (by simpa using! ha.symm))
-    b (Spec.map_injective (by simpa using! hb.symm))
-    (Spec.map_injective (by
-      simp only [coconeLeftOpOfCone_ι_app, Spec.map_comp]
-      simp only [← Scheme.Spec_map, ← liftedLimitMapsToOriginal_hom_π, Category.assoc, hab]))
-  exact ⟨k.unop, hik.unop, hjk.unop, by simpa [← Spec.map_comp, Spec.map_inj] using! H⟩
+    |>.essFiniteType.exists_comp_map_eq_of_isColimit _ D.leftOp t' _
+    (coconeLeftOpOfCone (liftLimit hc)) (isColimitCoconeLeftOpOfCone _ (liftedLimitIsLimit _))
+    a (Spec.map_injective (by simpa [ht] using ha.symm))
+    b (Spec.map_injective (by simpa [ht] using hb.symm))
+    (Spec.map_injective (by simp only [coconeLeftOpOfCone_ι_app, Spec.map_comp,
+      ← Scheme.Spec_map, ← liftedLimitMapsToOriginal_hom_π, Category.assoc, hab]))
+  exact ⟨k.unop, hik.unop, hjk.unop, by simpa [← Spec.map_comp, Spec.map_inj] using H⟩
 
 /-- (Implementation)
 An auxiliary structure used to prove `Scheme.exists_hom_hom_comp_eq_comp_of_locallyOfFiniteType`.

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -309,8 +309,32 @@ lemma exists_map_preimage_eq_map_preimage
     simpa only [Scheme.Hom.comp_preimage, Functor.map_comp] using Scheme.Hom.preimage_mono _ e₂
 
 set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
-open Scheme.Opens in
+include hc in
+lemma exists_appTop_π_eq_of_isAffine_of_isLimit [IsCofiltered I]
+    [∀ i, IsAffine (D.obj i)] (s : Γ(c.pt, ⊤)) :
+    ∃ (i : I) (t : Γ(D.obj i, ⊤)), (c.π.app i).appTop t = s := by
+  have : ∀ i, IsAffine (D.op.obj i).unop := by dsimp; infer_instance
+  exact ⟨_, (Types.jointly_surjective_of_isColimit
+    (isColimitOfPreserves (Scheme.Γ ⋙ forget _) hc.op) s).choose_spec⟩
+
+include hc in
+lemma exists_appLE_π_eq_of_isAffineOpen [IsCofiltered I]
+    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    {i : I} {U : (D.obj i).Opens} (hU : IsAffineOpen U) (s : Γ(c.pt, c.π.app i ⁻¹ᵁ U)) :
+    ∃ (j : I) (u : j ⟶ i) (t : Γ(D.obj j, D.map u ⁻¹ᵁ U)),
+      (c.π.app j).appLE _ _ (π_app_preimage_map_preimage D c u U).ge t = s := by
+  have (j : Over i) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage (D.map _)
+  obtain ⟨j, t, ht⟩ := exists_appTop_π_eq_of_isAffine_of_isLimit _ _
+    (isLimitOpensCone D c hc i U) ((c.π.app i ⁻¹ᵁ U).topIso.inv s)
+  obtain ⟨t, rfl⟩ := (D.map j.hom ⁻¹ᵁ U).topIso.symm.commRingCatIsoToRingEquiv.surjective t
+  refine ⟨j.left, j.hom, t, ?_⟩
+  replace ht : ((c.π.app j.left).resLE (D.map j.hom ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U)
+      (π_app_preimage_map_preimage D c j.hom U).ge).appTop
+      ((D.map j.hom ⁻¹ᵁ U).topIso.inv t) = (c.π.app i ⁻¹ᵁ U).topIso.inv s := ht
+  simp only [Scheme.Hom.appTop, Scheme.Hom.resLE_app_top, ConcreteCategory.comp_apply,
+    Iso.inv_hom_id_apply] at ht
+  exact (c.π.app i ⁻¹ᵁ U).topIso.commRingCatIsoToRingEquiv.symm.injective ht
+
 include hc in
 lemma isBasis_preimage_isAffineOpen [IsCofiltered I] [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] :
     TopologicalSpace.Opens.IsBasis
@@ -319,23 +343,14 @@ lemma isBasis_preimage_isAffineOpen [IsCofiltered I] [∀ {i j} (f : i ⟶ j), I
   obtain ⟨i⟩ := IsCofiltered.nonempty (C := I)
   obtain ⟨_, ⟨V, hV : IsAffineOpen V, rfl⟩, hxV, -⟩ :=
     (D.obj i).isBasis_affineOpens.exists_subset_of_mem_open (Set.mem_univ (c.π.app i x)) isOpen_univ
-  have (j : _) : IsAffine ((opensDiagram D i V).op.obj j).unop := hV.preimage _
   have (j : _) : IsAffine ((opensDiagram D i V).obj j) := hV.preimage _
   obtain ⟨r, hrU, hxr⟩ := IsAffineOpen.exists_basicOpen_le
     (Scheme.isAffine_of_isLimit _ (isLimitOpensCone D c hc i V)) (V := U) ⟨x, hxU⟩ hxV
-  obtain ⟨⟨j⟩, s, hs⟩ := (Types.jointly_surjective_of_isColimit (isColimitOfPreserves
-    (Scheme.Γ ⋙ forget _) (isLimitOpensCone D c hc i V).op) ((c.π.app i ⁻¹ᵁ V).topIso.inv r))
-  obtain ⟨s, rfl⟩ := (D.map j.hom ⁻¹ᵁ V).topIso.symm.commRingCatIsoToRingEquiv.surjective s
-  have h : c.π.app j.left ⁻¹ᵁ D.map j.hom ⁻¹ᵁ V = c.π.app i ⁻¹ᵁ V := congr($(c.w j.hom) ⁻¹ᵁ V)
-  have : r = (c.π.app j.left).appLE (D.map j.hom ⁻¹ᵁ V) (c.π.app i ⁻¹ᵁ V) h.ge s := by
-    convert!
-      show r = ((topIso _).inv ≫ ((opensCone D c i V).π.app j).appTop ≫ (topIso _).hom) s from
-        (c.π.app i ⁻¹ᵁ V).topIso.commRingCatIsoToRingEquiv.symm_apply_eq.mp hs.symm using 3
-    simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE]
-  refine ⟨_, ⟨j.left, _, (hV.preimage _).basicOpen s, rfl⟩, ?_⟩
-  simp only [Functor.const_obj_obj, Scheme.preimage_basicOpen] at this ⊢
-  rw [← c.pt.basicOpen_res_eq _ (eqToHom h.symm).op, ← CommRingCat.comp_apply,
-    Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, ← this]
+  obtain ⟨j, u, s, hs⟩ := exists_appLE_π_eq_of_isAffineOpen D c hc hV r
+  refine ⟨_, ⟨j, _, (hV.preimage _).basicOpen s, rfl⟩, ?_⟩
+  simp only [Functor.const_obj_obj, Scheme.preimage_basicOpen] at hs ⊢
+  rw [← c.pt.basicOpen_res_eq _ (eqToHom (π_app_preimage_map_preimage D c u V).symm).op,
+    ← CommRingCat.comp_apply, Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, hs]
   exact ⟨hxr, hrU⟩
 
 set_option backward.defeqAttrib.useBackward true in
@@ -854,41 +869,20 @@ lemma exists_app_map_eq_map_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.
   simpa [sub_eq_zero] using exists_app_map_eq_zero_of_isLimit _ _ hc hU (s - t)
     (by simpa +instances [map_sub, sub_eq_zero])
 
-set_option backward.defeqAttrib.useBackward true in
-include hc in
-lemma exists_appTop_π_eq_of_isAffine_of_isLimit
-    [∀ i, IsAffine (D.obj i)] (s : Γ(c.pt, ⊤)) :
-    ∃ (i : I) (t : Γ(D.obj i, ⊤)), (c.π.app i).appTop t = s := by
-  have : ∀ i, IsAffine (D.op.obj i).unop := by dsimp; infer_instance
-  exact ⟨_, (Types.jointly_surjective_of_isColimit
-    (isColimitOfPreserves (Scheme.Γ ⋙ forget _) hc.op) s).choose_spec⟩
-
 include hc in
 private lemma exists_appLE_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     (s : Γ(c.pt, ⊤)) (x : c.pt) :
     ∃ (i : I) (U : (D.obj i).Opens) (_ : IsAffineOpen U) (_ : (c.π.app i).base x ∈ U)
       (t : Γ(D.obj i, U)), ∀ (V : c.pt.Opens) (e : V ≤ c.π.app i ⁻¹ᵁ U),
         (c.π.app i).appLE U V e t = s |_ V := by
-  have i := IsCofiltered.nonempty (C := I).some
-  obtain ⟨_, ⟨U, hU : IsAffineOpen U, rfl⟩, hxU, -⟩ :=
-    (D.obj i).isBasis_affineOpens.exists_subset_of_mem_open
-      (Set.mem_univ ((c.π.app i).base x)) isOpen_univ
-  have (j : Over i) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage (D.map _)
-  obtain ⟨j, t, hj⟩ := exists_appTop_π_eq_of_isAffine_of_isLimit _ _
-    (isLimitOpensCone D c hc i U) ((c.π.app i ⁻¹ᵁ U).topIso.inv (s |_ _))
-  obtain ⟨t, rfl⟩ := (D.map j.hom ⁻¹ᵁ U).topIso.symm.commRingCatIsoToRingEquiv.surjective t
-  have h := π_app_preimage_map_preimage D c j.hom U
-  replace hj : (c.π.app j.left).appLE (D.map j.hom ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U) h.ge t =
-      s |_ (c.π.app i ⁻¹ᵁ U) := by
-    replace hj : ((c.π.app j.left).resLE (D.map j.hom ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U) h.ge).appTop
-        ((D.map j.hom ⁻¹ᵁ U).topIso.inv t) =
-        (c.π.app i ⁻¹ᵁ U).topIso.inv (s |_ (c.π.app i ⁻¹ᵁ U)) := hj
-    simp only [Scheme.Hom.appTop, Scheme.Hom.resLE_app_top, ConcreteCategory.comp_apply,
-      Iso.inv_hom_id_apply] at hj
-    exact (c.π.app i ⁻¹ᵁ U).topIso.commRingCatIsoToRingEquiv.symm.injective hj
-  refine ⟨j.left, D.map j.hom ⁻¹ᵁ U, hU.preimage _, h.ge hxU, t, fun V e ↦ ?_⟩
-  simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply] at hj ⊢
-  rw [← TopCat.Presheaf.restrict_restrict (e.trans_eq h) le_top s, ← hj]
+  obtain ⟨_, ⟨i, U, hU, rfl⟩, hxU, -⟩ :=
+    TopologicalSpace.Opens.isBasis_iff_nbhd.mp (isBasis_preimage_isAffineOpen D c hc)
+      (U := ⊤) (x := x) trivial
+  obtain ⟨j, u, t, ht⟩ := exists_appLE_π_eq_of_isAffineOpen D c hc hU (s |_ (c.π.app i ⁻¹ᵁ U))
+  have h := π_app_preimage_map_preimage D c u U
+  refine ⟨j, D.map u ⁻¹ᵁ U, hU.preimage _, h.ge hxU, t, fun V e ↦ ?_⟩
+  simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply] at ht ⊢
+  rw [← TopCat.Presheaf.restrict_restrict (e.trans_eq h) le_top s, ← ht]
   exact (TopCat.Presheaf.restrict_restrict (e.trans_eq h) h.ge _).symm
 
 include hc in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -308,7 +308,6 @@ lemma exists_map_preimage_eq_map_preimage
   · rw [e]
     simpa only [Scheme.Hom.comp_preimage, Functor.map_comp] using Scheme.Hom.preimage_mono _ e₂
 
-set_option backward.defeqAttrib.useBackward true in
 include hc in
 lemma exists_appTop_π_eq_of_isAffine_of_isLimit [IsCofiltered I]
     [∀ i, IsAffine (D.obj i)] (s : Γ(c.pt, ⊤)) :
@@ -829,7 +828,6 @@ lemma exists_app_map_eq_zero_of_isLimit {i : I} {U : (D.obj i).Opens}
         Scheme.Hom.appLE_comp_appLE, ← Functor.map_comp, hw W]
     · simp
 
-set_option backward.defeqAttrib.useBackward true in
 include hc in
 lemma exists_appTop_map_eq_zero_of_isLimit {i : I} [CompactSpace (D.obj i)] (s : Γ(D.obj i, ⊤))
     (hs : (c.π.app i).appTop s = 0) :

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -221,8 +221,8 @@ This is the underlying cone, and it is limiting as witnessed by `isLimitOpensCon
 def opensCone (i : I) (U : (D.obj i).Opens) : Cone (opensDiagram D i U) where
   pt := c.π.app i ⁻¹ᵁ U
   π.app j := (c.π.app j.left).resLE _ _ (by rw [← Scheme.Hom.comp_preimage, c.w])
-  π.naturality _ k f := by
-    change 𝟙 _ ≫ (c.π.app k.left).resLE (D.map k.hom ⁻¹ᵁ U) _ _ = _ ≫ (D.map f.left).resLE _ _ _
+  π.naturality _ _ f := by
+    dsimp only [opensDiagram, Functor.const_obj_map]
     simp
 
 instance [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] {i : I}
@@ -230,8 +230,8 @@ instance [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] {i : I}
     IsAffineHom ((opensDiagram D i U).map f) := by
   have he : D.map j.hom ⁻¹ᵁ U = D.map f.left ⁻¹ᵁ D.map k.hom ⁻¹ᵁ U := by
     rw [← Scheme.Hom.comp_preimage, ← D.map_comp, Over.w f]
-  change IsAffineHom ((D.map f.left).resLE _ _ _)
-  rw [Scheme.Hom.resLE_congr _ _ rfl he @IsAffineHom, Scheme.Hom.resLE_eq_morphismRestrict]
+  refine (Scheme.Hom.resLE_congr _ _ rfl he @IsAffineHom).mpr ?_
+  rw [Scheme.Hom.resLE_eq_morphismRestrict]
   exact MorphismProperty.IsStableUnderBaseChange.of_isPullback
     (isPullback_morphismRestrict (D.map f.left) _).flip inferInstance
 
@@ -245,9 +245,8 @@ noncomputable def isLimitOpensCone (i : I) (U : (D.obj i).Opens) : IsLimit (open
   refine isLimitOfIsPullbackOfIsConnected (opensDiagramι D i U) _ _ ?_ (fun j ↦ ?_)
     ((Functor.Initial.isLimitWhiskerEquiv (Over.forget i) c).symm hc)
   · exact { hom := (c.π.app i ⁻¹ᵁ U).ι, w j := ((c.π.app j.left).resLE_comp_ι _).symm }
-  · refine IsOpenImmersion.isPullback _ (c.π.app i ⁻¹ᵁ U).ι _ _
+  · refine IsOpenImmersion.isPullback _ (c.π.app i ⁻¹ᵁ U).ι (D.map j.hom ⁻¹ᵁ U).ι _
       ((c.π.app j.left).resLE_comp_ι _).symm ?_
-    change c.π.app j.left ⁻¹ᵁ (D.map j.hom ⁻¹ᵁ U).ι.opensRange = (c.π.app i ⁻¹ᵁ U).ι.opensRange
     simp
 
 include hc in
@@ -270,16 +269,12 @@ lemma exists_map_preimage_le_map_preimage (hU : IsCompact (U : Set (D.obj i)))
     exact .trans (by simp) (Scheme.Hom.preimage_mono _ H)
   obtain ⟨j, fji, hj⟩ := exists_map_eq_top _ _ (isLimitOpensCone D c hc i U) (i := .mk (𝟙 i))
     (((Scheme.isoOfEq _ (by simp)).hom ≫ U.ι) ⁻¹ᵁ V)
-    (by change (c.π.app i).resLE (D.map (𝟙 i) ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U) _ ⁻¹ᵁ
-          (((D.obj i).isoOfEq (by simp)).hom ≫ U.ι) ⁻¹ᵁ V = ⊤
+    (by dsimp only [opensCone, opensDiagram]
         simpa [← Scheme.Hom.comp_preimage, -Scheme.Hom.comp_base])
   refine ⟨j.left, j.hom, ?_⟩
-  revert hj
-  change (D.map fji.left).resLE (D.map (𝟙 i) ⁻¹ᵁ U) (D.map j.hom ⁻¹ᵁ U) _ ⁻¹ᵁ
-      (((D.obj i).isoOfEq (by simp)).hom ≫ U.ι) ⁻¹ᵁ V = ⊤ → _
-  intro hj
+  dsimp only [opensDiagram] at hj
   replace hj : (D.map j.hom ⁻¹ᵁ U).ι ⁻¹ᵁ D.map fji.left ⁻¹ᵁ V = ⊤ := by
-    simpa [← Scheme.Hom.comp_preimage, -Scheme.Hom.comp_base] using hj
+    simpa [← Scheme.Hom.comp_preimage, -Scheme.Hom.comp_base] using! hj
   replace hj : (D.map j.hom ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ D.map fji.left ⁻¹ᵁ V := Set.image_subset_iff.mpr hj.ge
   simpa [show fji.left = j.hom by simpa using fji.w] using hj
 
@@ -769,9 +764,9 @@ lemma exists_app_map_eq_zero_of_isLimit
           ((D.map (𝟙 i) ⁻¹ᵁ W).topIso.inv (TopCat.Presheaf.restrictOpen s _ hle)) = 0 :=
       exists_appTop_map_eq_zero_of_isAffine_of_isLimit _ _ (isLimitOpensCone D c hc i W)
         (.mk (𝟙 i)) _ (by
-          change ((c.π.app i).resLE (D.map (𝟙 i) ⁻¹ᵁ W) (c.π.app i ⁻¹ᵁ W) (by simp)).appTop _ = 0
-          simp only [Scheme.Hom.resLE_appTop_apply, Iso.inv_hom_id_apply,
-            Scheme.Hom.appLE_restrict, h0, map_zero])
+          refine (Scheme.Hom.resLE_appTop_apply (c.π.app i) _ _).trans ?_
+          simp only [Over.mk_hom, Iso.inv_hom_id_apply, Scheme.Hom.appLE_restrict, h0, map_zero]
+          rfl)
     have hv' : v.left = j.hom := by simpa using Over.w v
     exact ⟨j.left, j.hom, by
       simpa only [Scheme.Hom.resLE_appTop_apply, Iso.inv_hom_id_apply, hv',
@@ -910,8 +905,7 @@ lemma Scheme.exists_isQuasiAffine_of_isLimit [IsQuasiAffine c.pt] :
       rwa [basicOpen_res, eq_comm, inf_eq_right, Functor.map_comp,
         elementwise_of% Hom.comp_appTop, ← preimage_basicOpen_top, Functor.map_comp,
         Hom.comp_preimage]
-    · change x ∈ c.π.app l ⁻¹ᵁ (D.obj l).basicOpen _
-      rwa [preimage_basicOpen_top, ← elementwise_of% Hom.comp_appTop, Cone.w]
+    · rwa [← Hom.mem_preimage, preimage_basicOpen_top, ← elementwise_of% Hom.comp_appTop, Cone.w]
   choose i f hf hi using this
   obtain ⟨σ, hσ⟩ := CompactSpace.elim_nhds_subcover
     (fun x ↦ (((c.π.app (i x)) ⁻¹ᵁ (D.obj (i x)).basicOpen (f x)).1))
@@ -922,8 +916,7 @@ lemma Scheme.exists_isQuasiAffine_of_isLimit [IsQuasiAffine c.pt] :
   obtain ⟨k, fkj, hk⟩ := exists_map_eq_top D c hc
     (⨆ k, D.map (fj _ (Finset.mem_image_of_mem i (hσiσ k))) ⁻¹ᵁ (D.obj (i _)).basicOpen (f _)) (by
       refine top_le_iff.mp fun x _ ↦ TopologicalSpace.Opens.mem_iSup.mpr ⟨x, ?_⟩
-      change (c.π.app j ≫ D.map _).base x ∈ (D.obj (i (σi x))).basicOpen (f (σi x))
-      rw [Cone.w]
+      rw [← Hom.mem_preimage, ← Hom.comp_preimage, Cone.w]
       exact hσi _)
   refine ⟨k, .of_forall_exists_mem_basicOpen _ fun x ↦ ?_⟩
   obtain ⟨y, hy⟩ := TopologicalSpace.Opens.mem_iSup.mp (hk.ge (Set.mem_univ x))
@@ -1096,8 +1089,8 @@ private lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffineOp
     let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U j) ⟶ (Functor.const (Over i')).obj (W j) :=
       { app k := (t.app k.left).resLE _ _ ((Hom.preimage_mono _ hu).trans_eq
           (by simp only [← Hom.comp_preimage, hnat]))
-        naturality k l v := by
-          change (D.map v.left).resLE _ _ _ ≫ (t.app l.left).resLE (W j : S.Opens) _ _ = _ ≫ 𝟙 _
+        naturality _ _ v := by
+          dsimp only [opensDiagram, Functor.const_obj_map]
           simp [hnat] }
     obtain ⟨k, g, hg, hg'⟩ : ∃ (k : Over i') (g : _ ⟶ (V j : X.Opens).toScheme),
         (c.π.app k.left).resLE _ (c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j) (by simp) ≫ g =
@@ -1106,8 +1099,7 @@ private lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffineOp
         _ τ (f.resLE _ _ (hVW j)) _ (isLimitOpensCone D c hc i' _)
         (a.resLE _ _ (by simpa using hUV j)) (by
           ext k
-          change (c.π.app k.left).resLE _ _ _ ≫ (t.app k.left).resLE (W j : S.Opens) _ _ =
-            a.resLE (V j : X.Opens) _ _ ≫ f.resLE (W j : S.Opens) _ _
+          dsimp only [τ, opensCone, opensDiagram]
           simp [hπ])
     have e : D.map (k.hom ≫ u) ⁻¹ᵁ U j ≤ D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
     refine ⟨k.left, k.hom ≫ u, Scheme.homOfLE _ e ≫ g ≫ (V j : X.Opens).ι, ?_, fun O h ↦ ?_⟩

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -865,29 +865,38 @@ private lemma exists_appLE_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAf
   exact (TopCat.Presheaf.restrict_restrict (e.trans_eq h) h.ge _).symm
 
 include hc in
-private lemma exists_map_appLE_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    [∀ i, QuasiSeparatedSpace (D.obj i)]
-    {s : Γ(c.pt, ⊤)} {i₁ i₂ k : I} {U₁ : (D.obj i₁).Opens} {U₂ : (D.obj i₂).Opens}
-    (hU₁ : IsAffineOpen U₁) (hU₂ : IsAffineOpen U₂) {t₁ : Γ(D.obj i₁, U₁)} {t₂ : Γ(D.obj i₂, U₂)}
-    (ht₁ : ∀ (V : c.pt.Opens) (e : V ≤ c.π.app i₁ ⁻¹ᵁ U₁), (c.π.app i₁).appLE U₁ V e t₁ = s |_ V)
-    (ht₂ : ∀ (V : c.pt.Opens) (e : V ≤ c.π.app i₂ ⁻¹ᵁ U₂), (c.π.app i₂).appLE U₂ V e t₂ = s |_ V)
-    (u₁ : k ⟶ i₁) (u₂ : k ⟶ i₂) :
-    ∃ (l : I) (v : l ⟶ k), ∀ (V : (D.obj l).Opens) (h₁ : V ≤ D.map (v ≫ u₁) ⁻¹ᵁ U₁)
-      (h₂ : V ≤ D.map (v ≫ u₂) ⁻¹ᵁ U₂),
-        (D.map (v ≫ u₁)).appLE U₁ V h₁ t₁ = (D.map (v ≫ u₂)).appLE U₂ V h₂ t₂ := by
-  obtain ⟨l, v, hv⟩ := exists_app_map_eq_zero_of_isLimit D c hc
-    ((hU₁.preimage (D.map u₁)).isCompact.inter_of_isOpen (hU₂.preimage (D.map u₂)).isCompact
-      (U₁.2.preimage (D.map u₁).continuous) (U₂.2.preimage (D.map u₂).continuous))
-    ((D.map u₁).app U₁ t₁ |_ (D.map u₁ ⁻¹ᵁ U₁ ⊓ D.map u₂ ⁻¹ᵁ U₂) -
-      (D.map u₂).app U₂ t₂ |_ (D.map u₁ ⁻¹ᵁ U₁ ⊓ D.map u₂ ⁻¹ᵁ U₂)) (by
+private lemma exists_forall_map_appLE_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    [∀ i, QuasiSeparatedSpace (D.obj i)] {s : Γ(c.pt, ⊤)} {J : Type*} [Finite J] {j : I}
+    {i : J → I} {U : ∀ x, (D.obj (i x)).Opens} (hU : ∀ x, IsAffineOpen (U x))
+    {t : ∀ x, Γ(D.obj (i x), U x)} (ht : ∀ x (V : c.pt.Opens) (e : V ≤ c.π.app (i x) ⁻¹ᵁ U x),
+      (c.π.app (i x)).appLE (U x) V e (t x) = s |_ V) (u : ∀ x, j ⟶ i x) :
+    ∃ (k : I) (v : k ⟶ j), ∀ x y (V : (D.obj k).Opens) (h₁ : V ≤ D.map (v ≫ u x) ⁻¹ᵁ U x)
+      (h₂ : V ≤ D.map (v ≫ u y) ⁻¹ᵁ U y),
+        (D.map (v ≫ u x)).appLE _ V h₁ (t x) = (D.map (v ≫ u y)).appLE _ V h₂ (t y) := by
+  refine Exists₂.imp (fun _ _ hv x y ↦ hv (x, y)) (IsCofiltered.exists_forall
+    (fun k (v : k ⟶ j) (x : J × J) ↦ ∀ (V : (D.obj k).Opens)
+      (h₁ : V ≤ D.map (v ≫ u x.1) ⁻¹ᵁ U x.1) (h₂ : V ≤ D.map (v ≫ u x.2) ⁻¹ᵁ U x.2),
+        (D.map (v ≫ u x.1)).appLE _ V h₁ (t x.1) = (D.map (v ≫ u x.2)).appLE _ V h₂ (t x.2)) ?_ ?_)
+  · exact fun w v x hv V h₁ h₂ ↦ by
+      have e : V ≤ D.map w ⁻¹ᵁ (D.map (v ≫ u x.1) ⁻¹ᵁ U x.1 ⊓ D.map (v ≫ u x.2) ⁻¹ᵁ U x.2) := by
+        simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
+      simpa [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
+        using congr((D.map w).appLE _ V e $(hv _ inf_le_left inf_le_right))
+  rintro ⟨x, y⟩
+  obtain ⟨k, v, hv⟩ := exists_app_map_eq_zero_of_isLimit D c hc
+    (((hU x).preimage (D.map (u x))).isCompact.inter_of_isOpen
+      ((hU y).preimage (D.map (u y))).isCompact ((U x).2.preimage (D.map (u x)).continuous)
+      ((U y).2.preimage (D.map (u y)).continuous))
+    ((D.map (u x)).app _ (t x) |_ (D.map (u x) ⁻¹ᵁ U x ⊓ D.map (u y) ⁻¹ᵁ U y) -
+      (D.map (u y)).app _ (t y) |_ (D.map (u x) ⁻¹ᵁ U x ⊓ D.map (u y) ⁻¹ᵁ U y)) (by
     dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
     simp only [map_sub, sub_eq_zero, ← ConcreteCategory.comp_apply,
       Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, Scheme.Hom.appLE_comp_appLE, Cone.w]
-    exact (ht₁ _ _).trans (ht₂ _ _).symm)
-  refine ⟨l, v, fun V h₁ h₂ ↦ ?_⟩
-  have H : V ≤ D.map v ⁻¹ᵁ (D.map u₁ ⁻¹ᵁ U₁ ⊓ D.map u₂ ⁻¹ᵁ U₂) := by
+    exact (ht x _ _).trans (ht y _ _).symm)
+  refine ⟨k, v, fun V h₁ h₂ ↦ ?_⟩
+  have H : V ≤ D.map v ⁻¹ᵁ (D.map (u x) ⁻¹ᵁ U x ⊓ D.map (u y) ⁻¹ᵁ U y) := by
     simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
-  apply_fun (D.obj l).presheaf.map (homOfLE H).op at hv
+  apply_fun (D.obj k).presheaf.map (homOfLE H).op at hv
   dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict] at hv ⊢
   simpa [sub_eq_zero, ← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
     Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hv
@@ -909,17 +918,8 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
       simpa [← Set.preimage_comp, ← TopCat.coe_comp, ← Scheme.Hom.comp_base,
         Set.iUnion_subtype] using hσ)
     exact ⟨j, fun x ↦ w ≫ fj₀ x, by simpa [Scheme.Hom.preimage_iSup] using hw⟩
-  obtain ⟨k, v, hv⟩ := IsCofiltered.exists_forall
-    (fun l (v : l ⟶ j) (x : σ × σ) ↦ ∀ (V : (D.obj l).Opens)
-      (h₁ : V ≤ D.map (v ≫ fj x.1) ⁻¹ᵁ U x.1) (h₂ : V ≤ D.map (v ≫ fj x.2) ⁻¹ᵁ U x.2),
-        (D.map (v ≫ fj x.1)).appLE _ V h₁ (t x.1) = (D.map (v ≫ fj x.2)).appLE _ V h₂ (t x.2))
-    (fun w u x hu V h₁ h₂ ↦ by
-      have e : V ≤ D.map w ⁻¹ᵁ (D.map (u ≫ fj x.1) ⁻¹ᵁ U x.1 ⊓ D.map (u ≫ fj x.2) ⁻¹ᵁ U x.2) := by
-        simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
-      simpa [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
-        using congr((D.map w).appLE _ V e $(hu _ inf_le_left inf_le_right)))
-    fun x ↦ exists_map_appLE_eq_of_isLimit D c hc (hU x.1) (hU x.2) (ht x.1) (ht x.2)
-      (fj x.1) (fj x.2)
+  obtain ⟨k, v, hv⟩ := exists_forall_map_appLE_eq_of_isLimit D c hc (J := σ)
+    (fun x ↦ hU x) (fun x ↦ ht x) fj
   have hcov : ⨆ x : σ, D.map (v ≫ fj x) ⁻¹ᵁ U x = ⊤ := by
     simpa [Scheme.Hom.comp_preimage] using (D.map v).iSup_preimage_eq_top hfj
   have H (x : σ) : c.π.app (i x) ⁻¹ᵁ U x = c.π.app k ⁻¹ᵁ D.map (v ≫ fj x) ⁻¹ᵁ U x := by
@@ -928,7 +928,7 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
     (fun _ ↦ homOfLE le_top) hcov.ge (fun x ↦ (D.map (v ≫ fj x)).app (U x) (t x)) fun x y ↦ by
       dsimp [TopologicalSpace.Opens.infLELeft, TopologicalSpace.Opens.infLERight]
       simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, -Scheme.Hom.comp_appLE]
-        using hv (x, y) _ inf_le_left inf_le_right
+        using hv x y _ inf_le_left inf_le_right
   replace ht₀ (x : σ) : t₀ |_ (D.map (v ≫ fj x) ⁻¹ᵁ U x) = (D.map (v ≫ fj x)).app (U x) (t x) :=
     ht₀ x
   refine ⟨k, t₀, TopCat.Sheaf.eq_of_locally_eq' ⟨_, c.pt.IsSheaf⟩

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -908,15 +908,14 @@ end sections
 
 section IsAffine
 
+variable [IsCofiltered I] [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+  [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)]
+
 include hc in
 /-- Suppose `{ Xᵢ }` is an inverse system of qcqs schemes with affine transition maps.
 If `lim Xᵢ` is quasi-affine, then some `Xᵢ` is quasi-affine. -/
 @[stacks 01Z5]
-lemma Scheme.exists_isQuasiAffine_of_isLimit [IsCofiltered I]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    [∀ (i : I), CompactSpace (D.obj i)]
-    [∀ (i : I), QuasiSeparatedSpace (D.obj i)]
-    [IsQuasiAffine c.pt] :
+lemma Scheme.exists_isQuasiAffine_of_isLimit [IsQuasiAffine c.pt] :
     ∃ i, IsQuasiAffine (D.obj i) := by
   classical
   have (x : c.pt) : ∃ (i : I) (f : Γ(D.obj i, ⊤)),
@@ -966,11 +965,7 @@ include hc in
 /-- Suppose `{ Xᵢ }` is an inverse system of qcqs schemes with affine transition maps.
 If `lim Xᵢ` is affine, then some `Xᵢ` is affine. -/
 @[stacks 01Z6]
-lemma Scheme.exists_isAffine_of_isLimit [IsCofiltered I]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    [∀ (i : I), CompactSpace (D.obj i)]
-    [∀ (i : I), QuasiSeparatedSpace (D.obj i)]
-    [IsAffine c.pt] :
+lemma Scheme.exists_isAffine_of_isLimit [IsAffine c.pt] :
     ∃ i, IsAffine (D.obj i) := by
   have := isAffineHom_π_app _ _ hc
   obtain ⟨i, hi⟩ := exists_isQuasiAffine_of_isLimit D c hc
@@ -986,12 +981,10 @@ lemma Scheme.exists_isAffine_of_isLimit [IsCofiltered I]
     ((preimage_opensRange_toSpecΓ (D.map fij)).symm.trans hj)⟩⟩
 
 set_option backward.defeqAttrib.useBackward true in
+omit [∀ i, CompactSpace (D.obj i)] in
 include hc in
 @[stacks 01Z4 "(1)"]
-lemma exists_isAffineOpen_preimage_eq
-    [IsCofiltered I] [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    [∀ i, QuasiSeparatedSpace (D.obj i)]
-    (U : c.pt.Opens) (hU : IsAffineOpen U) :
+lemma exists_isAffineOpen_preimage_eq (U : c.pt.Opens) (hU : IsAffineOpen U) :
     ∃ (i : I) (V : (D.obj i).Opens), IsAffineOpen V ∧ c.π.app i ⁻¹ᵁ V = U := by
   obtain ⟨i, U, hU', rfl⟩ := exists_preimage_eq D c hc U hU.isCompact
   have (j : Over i) : CompactSpace ((opensDiagram D i U).obj j) :=
@@ -1006,9 +999,7 @@ namespace Scheme
 
 open TopologicalSpace in
 include hc in
-lemma exists_isOpenCover_and_isAffine_of_finite [IsCofiltered I]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [∀ (i : I), CompactSpace (D.obj i)]
-    [∀ (i : I), QuasiSeparatedSpace (D.obj i)]
+lemma exists_isOpenCover_and_isAffine_of_finite
     {J : Type*} [Finite J] (U : J → c.pt.Opens) (hU : IsOpenCover U)
     (hU' : ∀ i, IsAffineOpen (U i)) :
     ∃ (i : I) (V : J → (D.obj i).Opens),
@@ -1029,10 +1020,7 @@ open TopologicalSpace in
 include hc in
 /-- Suppose `{ Xᵢ }` is an inverse system of qcqs schemes with affine transition maps.
 Then any affine open cover of `lim Xᵢ` comes from a finite level. -/
-lemma exists_isOpenCover_and_isAffine [IsCofiltered I]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
-    [∀ (i : I), CompactSpace (D.obj i)]
-    [∀ (i : I), QuasiSeparatedSpace (D.obj i)]
+lemma exists_isOpenCover_and_isAffine
     {J : Type*} (U : J → c.pt.Opens) (hU : IsOpenCover U) (hU' : ∀ i, IsAffineOpen (U i)) :
     ∃ (i : I) (s : Finset J) (V : s → (D.obj i).Opens),
       IsOpenCover V ∧ ∀ j, IsAffineOpen (V j) ∧ U j = c.π.app i ⁻¹ᵁ (V j) := by
@@ -1049,10 +1037,8 @@ set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
 /-- Variant of `Scheme.exists_isOpenCover_and_isAffine_of_finite` in terms of `Scheme.OpenCover`. -/
-lemma OpenCover.exists_of_isCofiltered_of_finite [IsCofiltered I]
-    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [∀ (i : I), CompactSpace (D.obj i)]
-    [∀ (i : I), QuasiSeparatedSpace (D.obj i)]
-    (𝒰 : OpenCover.{w} c.pt) [∀ i, IsAffine (𝒰.X i)] [Finite 𝒰.I₀] :
+lemma OpenCover.exists_of_isCofiltered_of_finite (𝒰 : OpenCover.{w} c.pt)
+    [∀ i, IsAffine (𝒰.X i)] [Finite 𝒰.I₀] :
     ∃ (i : I) (R : 𝒰.I₀ → CommRingCat.{u}) (f : ∀ (a : 𝒰.I₀), Spec (R a) ⟶ (D.obj i))
       (_ : Presieve.ofArrows _ f ∈ zariskiPrecoverage _) (g : ∀ (j : 𝒰.I₀), 𝒰.X j ⟶ Spec (R j)),
       ∀ (j : 𝒰.I₀), IsPullback (g j) (𝒰.f j) (f j) (c.π.app i) := by

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -540,50 +540,33 @@ lemma exists_eq (j : A.𝒰D.I₀) : ∃ (k : I) (hki' : k ⟶ A.i'),
     (A.𝒰D.pullback₁ (D.map hki')).f j ≫ D.map (hki' ≫ A.hii') ≫ A.a =
       (A.𝒰D.pullback₁ (D.map hki')).f j ≫ D.map (hki' ≫ A.hii') ≫ A.b := by
   have : IsAffine (A.𝒰D.X j) := inferInstanceAs (IsAffine ((A.𝒰D₀.X j.1).affineCover.X j.2))
-  have _ (i) : IsAffine ((Over.post D ⋙ Over.pullback (A.𝒰D.f j) ⋙ Over.forget _).obj i) :=
+  have _ (i) : IsAffine ((A.D' j).obj i) :=
     inferInstanceAs (IsAffine (pullback (D.map i.hom) (A.𝒰D.f j)))
-  have : IsAffine ((Over.pullback (A.𝒰D.f j) ⋙ Over.forget (A.𝒰D.X j)).mapCone
-      ((Over.conePost D A.i').obj A.c)).pt :=
-    inferInstanceAs (IsAffine (pullback (A.c.π.app A.i') (A.𝒰D.f j)))
-  have : LocallyOfFiniteType ((A.𝒰X j.fst.fst).f j.fst.snd ≫ A.𝒰S.pullbackHom f j.fst.fst) := by
-    dsimp [Scheme.Cover.pullbackHom]; infer_instance
-  have H₁ := congr($(pullback.condition (f := A.g) (g := (Scheme.Pullback.diagonalCover f
-    A.𝒰S A.𝒰X).f ⟨j.1.1, (j.1.2, j.1.2)⟩)) ≫ pullback.fst _ _)
-  have H₂ := congr($(pullback.condition (f := A.g) (g := (Scheme.Pullback.diagonalCover f
-    A.𝒰S A.𝒰X).f ⟨j.1.1, (j.1.2, j.1.2)⟩)) ≫ pullback.snd _ _)
+  have : IsAffine (A.c' j).pt := inferInstanceAs (IsAffine (pullback (A.c.π.app A.i') (A.𝒰D.f j)))
+  let f' := (A.𝒰X j.1.1).f j.1.2 ≫ A.𝒰S.pullbackHom f j.1.1
+  let toDiag := (A.𝒰D₀.X j.1).affineCover.f j.2 ≫
+    (Scheme.Pullback.diagonalCover f A.𝒰S A.𝒰X).pullbackHom A.g ⟨j.1.1, (j.1.2, j.1.2)⟩
+  have : LocallyOfFiniteType f' := by dsimp [f', Scheme.Cover.pullbackHom]; infer_instance
+  have hpb := pullback.condition (f := A.g)
+    (g := (Scheme.Pullback.diagonalCover f A.𝒰S A.𝒰X).f ⟨j.1.1, (j.1.2, j.1.2)⟩)
+  have H₁ := congr($hpb ≫ pullback.fst _ _)
+  have H₂ := congr($hpb ≫ pullback.snd _ _)
   simp only [Scheme.Cover.pullbackHom, g, Category.assoc, limit.lift_π,
     PullbackCone.mk_π_app, Scheme.Pullback.diagonalCover_map] at H₁ H₂
   obtain ⟨k, hik, hjk, H⟩ := Scheme.exists_hom_hom_comp_eq_comp_of_isAffine_of_locallyOfFiniteType
-    (Over.post D ⋙ Over.pullback (A.𝒰D.f j) ⋙ Over.forget _)
-    ((Over.post D ⋙ Over.pullback (A.𝒰D.f j)).whiskerLeft (Comma.natTrans _ _) ≫
-      (Functor.const _).map ((A.𝒰D₀.X j.1).affineCover.f j.2 ≫
-      (Scheme.Pullback.diagonalCover f A.𝒰S A.𝒰X).pullbackHom _ _ ≫
-      pullback.fst _ _ ≫
-      (A.𝒰X j.fst.fst).f j.fst.snd ≫ Scheme.Cover.pullbackHom A.𝒰S f j.fst.fst))
-    (((A.𝒰X j.1.1).f j.1.2 ≫ A.𝒰S.pullbackHom f j.1.1))
-    ((Over.pullback (A.𝒰D.f j) ⋙ Over.forget _).mapCone ((Over.conePost _ _).obj A.c))
-    (by
-      refine isLimitOfPreserves (Over.pullback (A.𝒰D.f j) ⋙ Over.forget _) ?_
-      apply isLimitOfReflects (Over.forget (D.obj A.i'))
-      exact (Functor.Initial.isLimitWhiskerEquiv (Over.forget A.i') A.c).symm A.hc)
-    (i := Over.mk (𝟙 _))
-    (pullback.snd _ _ ≫ (A.𝒰D₀.X j.1).affineCover.f j.2 ≫
-      (Scheme.Pullback.diagonalCover f A.𝒰S A.𝒰X).pullbackHom _ _ ≫
-      pullback.fst _ _)
-    (by simp)
-    (j := Over.mk (𝟙 _))
-    (pullback.snd _ _ ≫ (A.𝒰D₀.X j.1).affineCover.f j.2 ≫
-      (Scheme.Pullback.diagonalCover f A.𝒰S A.𝒰X).pullbackHom _ _ ≫
-      pullback.snd _ _)
-    (by simp [pullback.condition])
+    (A.D' j) ((Over.post D ⋙ Over.pullback (A.𝒰D.f j)).whiskerLeft (Comma.natTrans _ _) ≫
+      (Functor.const _).map (toDiag ≫ pullback.fst _ _ ≫ f')) f' (A.c' j) (A.hc' j)
+    (i := Over.mk (𝟙 _)) (pullback.snd _ _ ≫ toDiag ≫ pullback.fst _ _) (by simp)
+    (j := Over.mk (𝟙 _)) (pullback.snd _ _ ≫ toDiag ≫ pullback.snd _ _)
+    (by simp [f', pullback.condition])
     (by
       rw [← cancel_mono ((A.𝒰X j.1.1).f j.1.2), ← cancel_mono (pullback.fst f (A.𝒰S.f j.1.1))]
       have H₃ := congr(pullback.fst (A.c.π.app A.i') (A.𝒰D.f j) ≫ $(A.hab))
       simp only [pullback.condition_assoc, 𝒰D, ← A.c.w A.hii', Category.assoc] at H₃
-      simpa [Scheme.Cover.pullbackHom, g, ← H₁, ← H₂, -Cone.w, -Cone.w_assoc] using! H₃)
+      simpa [c', toDiag, Scheme.Cover.pullbackHom, g, ← H₁, ← H₂, -Cone.w, -Cone.w_assoc] using! H₃)
   refine ⟨k.left, k.hom, ?_⟩
-  dsimp only [Precoverage.ZeroHypercover.pullback₁, PreZeroHypercover.pullback₁]
-  simpa [← cancel_mono ((A.𝒰X j.1.1).f j.1.2), ← cancel_mono (pullback.fst f (A.𝒰S.f j.1.1)),
+  simpa [Precoverage.ZeroHypercover.pullback₁, PreZeroHypercover.pullback₁, D', toDiag,
+    ← cancel_mono ((A.𝒰X j.1.1).f j.1.2), ← cancel_mono (pullback.fst f (A.𝒰S.f j.1.1)),
     Scheme.Cover.pullbackHom, g, ← H₁, ← H₂, pullback.condition_assoc] using! H
 
 end

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -192,6 +192,11 @@ lemma exists_map_eq_top
     (fun j k fkj fji x (hx : _ ∉ U) ↦ by rwa [Functor.map_comp] at hx)
   exact absurd (hU.ge (Set.mem_univ s)) (by simpa using hs i (𝟙 i))
 
+@[simp]
+lemma π_app_preimage_map_preimage {i j : I} (fji : j ⟶ i) (U : (D.obj i).Opens) :
+    c.π.app j ⁻¹ᵁ D.map fji ⁻¹ᵁ U = c.π.app i ⁻¹ᵁ U := by
+  rw [← Scheme.Hom.comp_preimage, c.w]
+
 attribute [local simp] Scheme.Hom.resLE_comp_resLE
 
 set_option backward.isDefEq.respectTransparency.types false in
@@ -831,6 +836,93 @@ lemma exists_appTop_π_eq_of_isAffine_of_isLimit
   exact ⟨_, (Types.jointly_surjective_of_isColimit
     (isColimitOfPreserves (Scheme.Γ ⋙ forget _) hc.op) s).choose_spec⟩
 
+private lemma exists_cone_of_pairs {C : Type*} [Category C] [IsCofiltered C] {α : Type*}
+    (σ : Finset α) (i : α → C) (j : α → α → C)
+    (p₁ : ∀ x y, j x y ⟶ i x) (p₂ : ∀ x y, j x y ⟶ i y) :
+    ∃ (k : C) (fi : ∀ {x}, x ∈ σ → (k ⟶ i x)) (fj : ∀ {x y}, x ∈ σ → y ∈ σ → (k ⟶ j x y)),
+      (∀ {x y} (hx : x ∈ σ) (hy : y ∈ σ), fj hx hy ≫ p₁ x y = fi hx) ∧
+        ∀ {x y} (hx : x ∈ σ) (hy : y ∈ σ), fj hx hy ≫ p₂ x y = fi hy := by
+  classical
+  let O : Finset C := σ.image i ∪ Finset.image₂ j σ σ
+  have hiO {x} (hx : x ∈ σ) : i x ∈ O := Finset.subset_union_left (Finset.mem_image_of_mem i hx)
+  have hjO {x y} (hx : x ∈ σ) (hy : y ∈ σ) : j x y ∈ O :=
+    Finset.subset_union_right (Finset.mem_image₂_of_mem hx hy)
+  obtain ⟨k, T, hT⟩ := IsCofiltered.inf_exists O
+    (σ.attach.image₂ (fun (x y : σ) ↦ ⟨j x.1 y.1, i x.1, hjO x.2 y.2, hiO x.2, p₁ x y⟩) σ.attach ∪
+    σ.attach.image₂ (fun (x y : σ) ↦ ⟨j x.1 y.1, i y.1, hjO x.2 y.2, hiO y.2, p₂ x y⟩) σ.attach)
+  refine ⟨k, fun hx ↦ T (hiO hx), fun hx hy ↦ T (hjO hx hy), fun {x y} hx hy ↦ ?_,
+    fun {x y} hx hy ↦ ?_⟩
+  · exact hT (hjO hx hy) (hiO hx) (f := p₁ x y) (Finset.subset_union_left
+      (Finset.mem_image₂.mpr ⟨⟨x, hx⟩, by simp, ⟨y, hy⟩, by simp, rfl⟩))
+  · exact hT (hjO hx hy) (hiO hy) (f := p₂ x y) (Finset.subset_union_right
+      (Finset.mem_image₂.mpr ⟨⟨x, hx⟩, by simp, ⟨y, hy⟩, by simp, rfl⟩))
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+include hc in
+private lemma exists_app_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    (s : Γ(c.pt, ⊤)) (x : c.pt) :
+    ∃ (i : I) (U : (D.obj i).Opens) (_ : IsAffineOpen U) (_ : (c.π.app i).base x ∈ U)
+      (t : Γ(D.obj i, U)), (c.π.app i).app U t = s |_ (c.π.app i ⁻¹ᵁ U) := by
+  have i := IsCofiltered.nonempty (C := I).some
+  obtain ⟨_, ⟨U, hU : IsAffineOpen U, rfl⟩, hxU, -⟩ :=
+    (D.obj i).isBasis_affineOpens.exists_subset_of_mem_open
+      (Set.mem_univ ((c.π.app i).base x)) isOpen_univ
+  have (j : Over i) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage (D.map _)
+  obtain ⟨j, t, hj⟩ := exists_appTop_π_eq_of_isAffine_of_isLimit _ _
+    (isLimitOpensCone D c hc i U) (s |_ _)
+  refine ⟨j.left, (D.map j.hom ⁻¹ᵁ U).ι ''ᵁ ⊤, by simpa using hU.preimage (D.map _), ?_, t, ?_⟩
+  · suffices (c.π.app j.1 ≫ D.map j.hom).base x ∈ U by simpa [-Cone.w] using this
+    rwa [Cone.w]
+  · have H : c.π.app j.left ⁻¹ᵁ (D.map j.hom ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ (c.π.app i ⁻¹ᵁ U).ι ''ᵁ ⊤ := by
+      simp [← Scheme.Hom.comp_preimage]
+    convert! congr(c.pt.presheaf.map (homOfLE H).op $hj)
+    · convert! ConcreteCategory.comp_apply _ _ _
+      congr
+      simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE]
+    · dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
+      change _ = (c.pt.presheaf.map (homOfLE _).op ≫ c.pt.presheaf.map (homOfLE _).op) s
+      rw [← Functor.map_comp]
+      rfl
+
+omit [IsCofiltered I] in
+private lemma π_appLE_eq_restrict {i : I} {U : (D.obj i).Opens} {s : Γ(c.pt, ⊤)}
+    {t : Γ(D.obj i, U)} (ht : (c.π.app i).app U t = s |_ (c.π.app i ⁻¹ᵁ U))
+    {V : c.pt.Opens} (e : V ≤ c.π.app i ⁻¹ᵁ U) :
+    (c.π.app i).appLE U V e t = s |_ V := by
+  simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply, ht]
+  exact TopCat.Presheaf.restrict_restrict e le_top s
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+include hc in
+private lemma exists_map_app_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    [∀ i, QuasiSeparatedSpace (D.obj i)]
+    {s : Γ(c.pt, ⊤)} {i₁ i₂ : I} {U₁ : (D.obj i₁).Opens} {U₂ : (D.obj i₂).Opens}
+    (hU₁ : IsAffineOpen U₁) (hU₂ : IsAffineOpen U₂) (t₁ : Γ(D.obj i₁, U₁)) (t₂ : Γ(D.obj i₂, U₂))
+    (ht₁ : (c.π.app i₁).app U₁ t₁ = s |_ (c.π.app i₁ ⁻¹ᵁ U₁))
+    (ht₂ : (c.π.app i₂).app U₂ t₂ = s |_ (c.π.app i₂ ⁻¹ᵁ U₂)) :
+    ∃ (j : I) (f₁ : j ⟶ i₁) (f₂ : j ⟶ i₂),
+      (D.map f₁).app U₁ t₁ |_ (D.map f₁ ⁻¹ᵁ U₁ ⊓ D.map f₂ ⁻¹ᵁ U₂) =
+      (D.map f₂).app U₂ t₂ |_ (D.map f₁ ⁻¹ᵁ U₁ ⊓ D.map f₂ ⁻¹ᵁ U₂) := by
+  obtain ⟨j, f₁, f₂, -⟩ := IsCofilteredOrEmpty.cone_objs i₁ i₂
+  obtain ⟨k, fkj, hk⟩ := exists_app_map_eq_zero_of_isLimit D c hc
+    ((hU₁.preimage (D.map f₁)).isCompact.inter_of_isOpen (hU₂.preimage (D.map f₂)).isCompact
+      (U₁.2.preimage (D.map f₁).continuous) (U₂.2.preimage (D.map f₂).continuous))
+    ((D.map f₁).app U₁ t₁ |_ (D.map f₁ ⁻¹ᵁ U₁ ⊓ D.map f₂ ⁻¹ᵁ U₂) -
+      (D.map f₂).app U₂ t₂ |_ (D.map f₁ ⁻¹ᵁ U₁ ⊓ D.map f₂ ⁻¹ᵁ U₂)) (by
+    dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
+    simp only [map_sub, sub_eq_zero, ← ConcreteCategory.comp_apply,
+      Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, Scheme.Hom.appLE_comp_appLE, Cone.w]
+    exact (π_appLE_eq_restrict D c ht₁ _).trans (π_appLE_eq_restrict D c ht₂ _).symm)
+  refine ⟨k, fkj ≫ f₁, fkj ≫ f₂, ?_⟩
+  have H : (D.map (fkj ≫ f₁) ⁻¹ᵁ U₁ ⊓ D.map (fkj ≫ f₂) ⁻¹ᵁ U₂) ≤
+      D.map fkj ⁻¹ᵁ ((D.map f₁ ⁻¹ᵁ U₁ ⊓ D.map f₂ ⁻¹ᵁ U₂)) := by simp; rfl
+  apply_fun (D.obj k).presheaf.map (homOfLE H).op at hk
+  dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict] at hk ⊢
+  simpa [sub_eq_zero, ← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
+    Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hk
+
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
@@ -839,91 +931,36 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
     ∃ (i : I) (t : Γ(D.obj i, ⊤)), s = (c.π.app i).appTop t := by
   classical
   have := Scheme.compactSpace_of_isLimit _ _ hc
-  have (x : c.pt) : ∃ (i : I) (U : (D.obj i).Opens) (hU : IsAffineOpen U)
-      (hU : (c.π.app i).base x ∈ U) (t : Γ(D.obj i, U)), (c.π.app i).app U t = s |_ _ := by
-    have i := IsCofiltered.nonempty (C := I).some
-    obtain ⟨_, ⟨U, hU : IsAffineOpen U, rfl⟩, hxU, -⟩ :=
-      (D.obj i).isBasis_affineOpens.exists_subset_of_mem_open
-        (Set.mem_univ ((c.π.app i).base x)) isOpen_univ
-    have (j : Over i) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage (D.map _)
-    obtain ⟨j, t, hj⟩ := exists_appTop_π_eq_of_isAffine_of_isLimit _ _
-      (isLimitOpensCone D c hc i U) (s |_ _)
-    refine ⟨j.left, (D.map j.hom ⁻¹ᵁ U).ι ''ᵁ ⊤, by simpa using hU.preimage (D.map _), ?_, t, ?_⟩
-    · suffices (c.π.app j.1 ≫ D.map j.hom).base x ∈ U by simpa [-Cone.w] using this
-      rwa [Cone.w]
-    · have H : c.π.app j.left ⁻¹ᵁ (D.map j.hom ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ (c.π.app i ⁻¹ᵁ U).ι ''ᵁ ⊤ := by
-        simp [← Scheme.Hom.comp_preimage]
-      convert! congr(c.pt.presheaf.map (homOfLE H).op $hj)
-      · convert! ConcreteCategory.comp_apply _ _ _
-        congr
-        simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE]
-      · dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-        change _ = (c.pt.presheaf.map (homOfLE _).op ≫ c.pt.presheaf.map (homOfLE _).op) s
-        rw [← Functor.map_comp]
-        rfl
-  choose i U hU hxU t ht using this
-  dsimp at ht
-  have (x y : c.pt) : ∃ (j : I) (fjx : j ⟶ i x) (fjy : j ⟶ i y),
-      (D.map fjx).app (U x) (t x) |_ (D.map fjx ⁻¹ᵁ U x ⊓ D.map fjy ⁻¹ᵁ U y) =
-      (D.map fjy).app (U y) (t y) |_ (D.map fjx ⁻¹ᵁ U x ⊓ D.map fjy ⁻¹ᵁ U y) := by
-    obtain ⟨j, fjx, fjy, -⟩ := IsCofilteredOrEmpty.cone_objs (i x) (i y)
-    obtain ⟨k, fkj, hk⟩ := exists_app_map_eq_zero_of_isLimit D c hc
-      (((hU x).preimage (D.map fjx)).isCompact.inter_of_isOpen
-        ((hU y).preimage (D.map fjy)).isCompact ((U x).2.preimage (D.map fjx).continuous)
-        ((U y).2.preimage (D.map fjy).continuous))
-      ((D.map fjx).app (U x) (t x) |_ (D.map fjx ⁻¹ᵁ U x ⊓ D.map fjy ⁻¹ᵁ U y) -
-        (D.map fjy).app (U y) (t y) |_ (D.map fjx ⁻¹ᵁ U x ⊓ D.map fjy ⁻¹ᵁ U y)) (by
-      dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-      simp only [map_sub, sub_eq_zero, ← ConcreteCategory.comp_apply,
-        Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, Scheme.Hom.appLE_comp_appLE,
-        Cone.w]
-      simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply, ht, TopCat.Presheaf.restrictOpen,
-        TopCat.Presheaf.restrict, ← ConcreteCategory.comp_apply, ← Functor.map_comp]
-      rfl)
-    refine ⟨k, fkj ≫ fjx, fkj ≫ fjy, ?_⟩
-    have H : (D.map (fkj ≫ fjx) ⁻¹ᵁ U x ⊓ D.map (fkj ≫ fjy) ⁻¹ᵁ U y) ≤
-        D.map fkj ⁻¹ᵁ ((D.map fjx ⁻¹ᵁ U x ⊓ D.map fjy ⁻¹ᵁ U y)) := by simp; rfl
-    apply_fun (D.obj k).presheaf.map (homOfLE H).op at hk
-    dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict] at hk ⊢
-    simpa [sub_eq_zero, ← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
-      Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hk
-  choose j fjx fjy hj using this
+  choose i U hU hxU t ht using exists_app_eq_restrict_of_isLimit D c hc s
+  choose j fjx fjy hj using fun x y ↦
+    exists_map_app_eq_of_isLimit D c hc (hU x) (hU y) (t x) (t y) (ht x) (ht y)
   obtain ⟨σ, hσ⟩ := CompactSpace.elim_nhds_subcover (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).1)
     (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).2.mem_nhds (by exact hxU x))
   choose σi hσiσ hσi using fun x ↦ Set.mem_iUnion₂.mp (hσ.ge (Set.mem_univ x))
-  let S : Finset _ := σ.image i ∪ Finset.image₂ j σ σ
-  have hiS {x} (hx : x ∈ σ) : i x ∈ S := Finset.subset_union_left (Finset.mem_image_of_mem i hx)
-  have hjS {x y} (hx : x ∈ σ) (hy : y ∈ σ) : j x y ∈ S :=
-    Finset.subset_union_right (Finset.mem_image₂_of_mem hx hy)
-  obtain ⟨k, fk, hk⟩ := IsCofiltered.inf_exists S
-    (σ.attach.image₂ (fun (x y : σ) ↦ ⟨j x.1 y.1, i x.1, hjS x.2 y.2, hiS x.2, fjx x y⟩) σ.attach ∪
-    σ.attach.image₂ (fun (x y : σ) ↦ ⟨j x.1 y.1, i y.1, hjS x.2 y.2, hiS y.2, fjy x y⟩) σ.attach)
-  have hk₁ {x y} (hx : x ∈ σ) (hy : y ∈ σ) := hk (hjS hx hy) (hiS hx) (f := fjx x y)
-    (Finset.subset_union_left (Finset.mem_image₂.mpr ⟨⟨x, hx⟩, by simp, ⟨y, hy⟩, by simp, rfl⟩))
-  have hk₂ {x y} (hx : x ∈ σ) (hy : y ∈ σ) := hk (hjS hx hy) (hiS hy) (f := fjy x y)
-    (Finset.subset_union_right (Finset.mem_image₂.mpr ⟨⟨x, hx⟩, by simp, ⟨y, hy⟩, by simp, rfl⟩))
+  obtain ⟨k, fk, fkj, hk₁, hk₂⟩ := exists_cone_of_pairs σ i j fjx fjy
   obtain ⟨k', fk'k, hk'⟩ := exists_map_eq_top D c hc
-    (⨆ (x : _) (hx : x ∈ σ), D.map (fk (hiS hx)) ⁻¹ᵁ U x) (by
+    (⨆ (x : _) (hx : x ∈ σ), D.map (fk hx) ⁻¹ᵁ U x) (by
     apply SetLike.coe_injective
     simpa [← Set.preimage_comp, ← TopCat.coe_comp, ← Scheme.Hom.comp_base])
-  have := ((Presheaf.isSheaf_iff_isSheaf_forget _ _ (forget _)).mp (D.obj k').IsSheaf).isSheafFor
-    (.ofArrows (fun x : σ ↦ D.map (fk'k ≫ fk (hiS x.2)) ⁻¹ᵁ U x.1) fun x ↦ homOfLE le_top)
+  have hsheaf := ((Presheaf.isSheaf_iff_isSheaf_forget _ _ (forget _)).mp
+      (D.obj k').IsSheaf).isSheafFor
+    (.ofArrows (fun x : σ ↦ D.map (fk'k ≫ fk x.2) ⁻¹ᵁ U x.1) fun x ↦ homOfLE le_top)
     (fun x _ ↦ by
-      obtain ⟨ix, hix, h⟩ : ∃ ix, ∃ (h : ix ∈ σ), (D.map (fk'k ≫ fk (hiS h))).base x ∈ U ix := by
+      obtain ⟨ix, hix, h⟩ : ∃ ix, ∃ (h : ix ∈ σ), (D.map (fk'k ≫ fk h)).base x ∈ U ix := by
         simpa using hk'.ge (Set.mem_univ x)
-      refine ⟨D.map (fk'k ≫ fk (hiS hix)) ⁻¹ᵁ U ix, homOfLE le_top,
+      refine ⟨D.map (fk'k ≫ fk hix) ⁻¹ᵁ U ix, homOfLE le_top,
         Sieve.ofArrows_mk (I := σ) _ _ ⟨ix, hix⟩, h⟩)
-  rw [← Presieve.isSheafFor_iff_generate, Presieve.isSheafFor_arrows_iff] at this
-  obtain ⟨t₀, ht₀, -⟩ := this (fun x ↦ (D.map _).app _ (t x)) fun x y V fVx fVy _ ↦ by
-    have H : V ≤ D.map (fk'k ≫ fk (hjS x.2 y.2)) ⁻¹ᵁ
+  rw [← Presieve.isSheafFor_iff_generate, Presieve.isSheafFor_arrows_iff] at hsheaf
+  obtain ⟨t₀, ht₀, -⟩ := hsheaf (fun x ↦ (D.map _).app _ (t x)) fun x y V fVx fVy _ ↦ by
+    have H : V ≤ D.map (fk'k ≫ fkj x.2 y.2) ⁻¹ᵁ
         (D.map (fjx ↑x ↑y) ⁻¹ᵁ U ↑x ⊓ D.map (fjy ↑x ↑y) ⁻¹ᵁ U ↑y) := by
-      change V ≤ (D.map (fk'k ≫ fk (hjS x.2 y.2)) ≫ D.map (fjx ↑x ↑y)) ⁻¹ᵁ U x ⊓
-        (D.map (fk'k ≫ fk (hjS x.2 y.2)) ≫ D.map (fjy x y)) ⁻¹ᵁ U y
+      change V ≤ (D.map (fk'k ≫ fkj x.2 y.2) ≫ D.map (fjx ↑x ↑y)) ⁻¹ᵁ U x ⊓
+        (D.map (fk'k ≫ fkj x.2 y.2) ≫ D.map (fjy x y)) ⁻¹ᵁ U y
       rw [← Functor.map_comp, ← Functor.map_comp, Category.assoc, Category.assoc,
         hk₁ x.2 y.2, hk₂ x.2 y.2, le_inf_iff]
       exact ⟨fVx.le, fVy.le⟩
     convert!
-      congr(((D.map (fk'k ≫ fk (hjS x.2 y.2))).app _ ≫ (D.obj k').presheaf.map (homOfLE H).op)
+      congr(((D.map (fk'k ≫ fkj x.2 y.2)).app _ ≫ (D.obj k').presheaf.map (homOfLE H).op)
         $(hj x y)) using 1
     · dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
       simp only [← ConcreteCategory.comp_apply]
@@ -938,7 +975,7 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
   refine ⟨k', t₀, TopCat.Presheaf.section_ext c.pt.sheaf _ _ _ fun y hy ↦ c.pt.presheaf.germ_ext
     (c.π.app _ ⁻¹ᵁ U (σi y)) (hσi y) (homOfLE le_top) (homOfLE le_top) ?_⟩
   have H : c.π.app (i (σi y)) ⁻¹ᵁ U (σi y) ≤
-      c.π.app k' ⁻¹ᵁ D.map (fk'k ≫ fk (hiS (hσiσ _))) ⁻¹ᵁ U (σi y) := by
+      c.π.app k' ⁻¹ᵁ D.map (fk'k ≫ fk (hσiσ _)) ⁻¹ᵁ U (σi y) := by
     rw [← Scheme.Hom.comp_preimage, Cone.w]
   convert! congr(c.pt.presheaf.map (homOfLE H).op ((c.π.app k').app _ $(ht₀ ⟨_, hσiσ y⟩))).symm
   · refine (ht (σi y)).symm.trans ?_
@@ -1149,6 +1186,15 @@ end IsAffine
 
 section LocallyOfFinitePresentation
 
+private lemma Scheme.exists_appTop_eq {Y Z : Scheme.{u}} [IsAffine Z] (φ : Γ(Z, ⊤) ⟶ Γ(Y, ⊤)) :
+    ∃ g : Y ⟶ Z, g.appTop = φ := by
+  have h : Z.isoSpec.inv.appTop = (Scheme.ΓSpecIso Γ(Z, ⊤)).inv := by
+    rw [← cancel_epi (Scheme.ΓSpecIso Γ(Z, ⊤)).hom, Iso.hom_inv_id, ← Scheme.toSpecΓ_appTop,
+      ← Scheme.Hom.comp_appTop, Scheme.isoSpec_inv_toSpecΓ, Scheme.Hom.id_appTop]
+  refine ⟨Y.toSpecΓ ≫ Spec.map φ ≫ Z.isoSpec.inv, ?_⟩
+  rw [Scheme.Hom.comp_appTop, Scheme.Hom.comp_appTop, h, Scheme.toSpecΓ_appTop, Category.assoc,
+    Scheme.ΓSpecIso_naturality, Iso.inv_hom_id_assoc]
+
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
@@ -1160,57 +1206,147 @@ private nonrec lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
     ∃ (i : I) (g : D.obj i ⟶ X), c.π.app i ≫ g = a ∧ g ≫ f = t.app i := by
   -- Every scheme involved is affine, so the proof is merely translate to commutative algebra and
   -- use `RingHom.EssFiniteType.exists_eq_comp_ι_app_of_isColimit`.
-  -- Unfortunately the translation takes 45 lines.
-  wlog hS : ∃ R, S = Spec R generalizing S
-  · obtain ⟨i, g, hg, hg'⟩ := this (t ≫ ((Functor.const I).mapIso S.isoSpec).hom)
-      (f ≫ S.isoSpec.hom) (by simp [reassoc_of% ha]) ⟨_, rfl⟩
-    exact ⟨i, g, hg, by simpa using! congr($hg' ≫ S.isoSpec.inv)⟩
-  obtain ⟨R, rfl⟩ := hS
-  wlog hX : ∃ S, X = Spec S generalizing X
-  · obtain ⟨i, f, hf⟩ := this (a ≫ X.isoSpec.hom) (X.isoSpec.inv ≫ f)
-      (by simp [ha, -Functor.map_comp]) ⟨_, rfl⟩
-    exact ⟨i, f ≫ X.isoSpec.inv, by simpa [← Iso.comp_inv_eq] using! hf⟩
-  obtain ⟨S, rfl⟩ := hX
-  obtain ⟨φ, rfl⟩ := Spec.map_surjective f
-  wlog hD : ∃ D' : I ⥤ CommRingCatᵒᵖ, D = D' ⋙ Scheme.Spec generalizing D
-  · let e : D ⟶ D ⋙ Scheme.Γ.rightOp ⋙ Scheme.Spec := D.whiskerLeft ΓSpec.adjunction.unit
-    have inst (i) : IsIso (e.app i) := by dsimp [e]; infer_instance
-    have inst : IsIso e := NatIso.isIso_of_isIso_app e
-    have inst (i) : IsAffine ((D ⋙ Scheme.Γ.rightOp ⋙ Scheme.Spec).obj i) := by
-      dsimp; infer_instance
-    obtain ⟨i, g, hg, hg'⟩ := this _ _ ((IsLimit.postcomposeHomEquiv (asIso e) c).symm hc)
-      (inv e ≫ t) a (by simpa using! ha) ⟨D ⋙ Scheme.Γ.rightOp, rfl⟩
-    exact ⟨i, e.app i ≫ g, by rwa [← Category.assoc], by simp [hg']⟩
-  obtain ⟨D, rfl⟩ := hD
-  let e : ((Functor.const Iᵒᵖ).obj R).rightOp ⋙ Scheme.Spec ≅ (Functor.const I).obj (Spec R) :=
-    NatIso.ofComponents (fun _ ↦ Iso.refl _) (by simp)
-  obtain ⟨t, rfl⟩ : ∃ t' : (Functor.const Iᵒᵖ).obj R ⟶ D.leftOp,
-      t = Functor.whiskerRight (NatTrans.rightOp t') Scheme.Spec ≫ e.hom :=
-    ⟨⟨fun i ↦ Spec.preimage (t.app i.unop), fun _ _ f ↦ Spec.map_injective
-      (by simpa using! (t.naturality f.unop).symm)⟩, by ext : 2; simp [e]⟩
-  wlog hc' : ∃ c' : Cocone D.leftOp, c = Scheme.Spec.mapCone (coneOfCoconeLeftOp c') generalizing c
-  · have inst : IsAffine c.pt := isAffine_of_isLimit _ hc
-    let e' : (D ⋙ Scheme.Spec).op ⋙ Γ ≅ D.leftOp := D.leftOp.isoWhiskerLeft SpecΓIdentity
-    let c' := coneOfCoconeLeftOp ((Cocone.precompose e'.inv).obj (Γ.mapCocone c.op))
-    have inst : ∀ i, IsAffine ((D ⋙ Scheme.Spec).op.obj i).unop := by dsimp; infer_instance
-    obtain ⟨i, f, hf⟩ := this (Scheme.Spec.mapCone c') (isLimitOfPreserves _
-      (isLimitConeOfCoconeLeftOp _ ((IsColimit.precomposeHomEquiv e'.symm _).symm
-        (isColimitOfPreserves _ hc.op)))) (c.pt.isoSpec.inv ≫ a) (by
-        ext i
-        have : c.π.app i ≫ Spec.map (t.app (.op i)) = a ≫ Spec.map φ := by
-          simpa using! congr((($ha).app i))
-        simp [c', e, e', ← this, Iso.eq_inv_comp, isoSpec_hom_naturality_assoc]) ⟨_, rfl⟩
-    refine ⟨i, f, ?_⟩
-    simpa [Iso.eq_inv_comp, c', isoSpec_hom_naturality_assoc, e'] using! hf
-  obtain ⟨c', rfl⟩ := hc'
-  obtain ⟨ψ, rfl⟩ := Spec.map_surjective a
-  replace hc := isColimitOfConeOfCoconeLeftOp _ (isLimitOfReflects _ hc)
-  obtain ⟨i, g, hg, hg'⟩ :=
-    RingHom.EssFiniteType.exists_eq_comp_ι_app_of_isColimit _ D.leftOp t _ _ hc
-    (HasRingHomProperty.Spec_iff.mp ‹LocallyOfFinitePresentation (Spec.map φ)›) ψ fun i ↦ by
-    apply Spec.map_injective; simpa using! congr(($ha).app i.unop).symm
-  exact ⟨i.unop, Spec.map g, by simpa using! congr(Spec.map $hg').symm,
-    by simpa using! congr(Spec.map $hg)⟩
+  have : ∀ i, IsAffine (D.op.obj i).unop := fun i ↦ by dsimp; infer_instance
+  let α : (Functor.const Iᵒᵖ).obj Γ(S, ⊤) ⟶ D.op ⋙ Scheme.Γ :=
+    { app := fun i ↦ (t.app i.unop).appTop
+      naturality := fun _ _ u ↦ by
+        have h := congr(Scheme.Hom.appTop $(t.naturality u.unop))
+        simp only [Scheme.Hom.comp_appTop, Functor.const_obj_map, Scheme.Hom.id_appTop] at h ⊢
+        exact h.symm }
+  obtain ⟨i, φ, hφ, hφ'⟩ := RingHom.EssFiniteType.exists_eq_comp_ι_app_of_isColimit
+    Γ(S, ⊤) (D.op ⋙ Scheme.Γ) α f.appTop _ (isColimitOfPreserves Scheme.Γ hc.op)
+    (HasRingHomProperty.iff_of_isAffine.mp ‹LocallyOfFinitePresentation f›) a.appTop fun i ↦ by
+      simpa [α] using congr(Scheme.Hom.appTop $(congr(($ha).app i.unop))).symm
+  obtain ⟨g, rfl⟩ := Scheme.exists_appTop_eq φ
+  exact ⟨i.unop, g, ext_of_isAffine (by simpa using hφ'.symm),
+    ext_of_isAffine (by simpa [α] using hφ)⟩
+
+open TopologicalSpace in
+private lemma isBasis_affineOpens_le_preimage {Y Z T : Scheme.{u}} (a : Y ⟶ Z) (g : Z ⟶ T) :
+    Opens.IsBasis {U : Y.Opens | IsAffineOpen U ∧ ∃ (V : Z.affineOpens) (W : T.affineOpens),
+      U ≤ a ⁻¹ᵁ (V : Z.Opens) ∧ (V : Z.Opens) ≤ g ⁻¹ᵁ (W : T.Opens)} := by
+  refine Opens.isBasis_iff_nbhd.mpr fun {O y} hy ↦ ?_
+  obtain ⟨W, hW, hyW, -⟩ := Opens.isBasis_iff_nbhd.mp T.isBasis_affineOpens
+    (U := ⊤) (x := g (a y)) trivial
+  obtain ⟨V, hV, hyV, hVW⟩ := Opens.isBasis_iff_nbhd.mp Z.isBasis_affineOpens
+    (U := g ⁻¹ᵁ W) (x := a y) hyW
+  obtain ⟨U, hU, hyU, hUV⟩ := Opens.isBasis_iff_nbhd.mp Y.isBasis_affineOpens
+    (U := O ⊓ a ⁻¹ᵁ V) (x := y) ⟨hy, hyV⟩
+  exact ⟨U, ⟨hU, ⟨V, hV⟩, ⟨W, hW⟩, hUV.trans inf_le_right, hVW⟩, hyU, hUV.trans inf_le_left⟩
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+include hc in
+private lemma exists_resLE_comp_eq_of_isAffineOpen
+    [IsCofiltered I] [LocallyOfFinitePresentation f]
+    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    (a : c.pt ⟶ X) (ha : c.π ≫ t = (Functor.const _).map (a ≫ f))
+    {i : I} {U : (D.obj i).Opens} (hU : IsAffineOpen U) (V : X.affineOpens) (W : S.affineOpens)
+    (hVW : (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens)) (hUV : c.π.app i ⁻¹ᵁ U ≤ a ⁻¹ᵁ (V : X.Opens)) :
+    ∃ (k : I) (u : k ⟶ i) (g : ↑(D.map u ⁻¹ᵁ U) ⟶ X),
+      g ≫ f = (D.map u ⁻¹ᵁ U).ι ≫ t.app k ∧
+        ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U),
+          (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a := by
+  obtain ⟨i', u, hu⟩ : ∃ (i' : I) (u : i' ⟶ i), D.map u ⁻¹ᵁ U ≤ t.app i' ⁻¹ᵁ (W : S.Opens) := by
+    obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc hU.isCompact
+      (V := t.app i ⁻¹ᵁ (W : S.Opens)) (by
+        rw [← Scheme.Hom.comp_preimage, ← NatTrans.comp_app, ha]
+        exact hUV.trans (a.preimage_mono hVW))
+    exact ⟨i', u, hu.trans_eq (by simp [← Scheme.Hom.comp_preimage, t.naturality])⟩
+  have _ (k : Over i') : IsAffine ((opensDiagram D i' (D.map u ⁻¹ᵁ U)).obj k) :=
+    (hU.preimage _).preimage _
+  let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U) ⟶ (Functor.const (Over i')).obj W :=
+    { app k := (t.app k.left).resLE _ _ (by
+        refine (Scheme.Hom.preimage_mono _ hu).trans ?_
+        simp [← Scheme.Hom.comp_preimage, t.naturality])
+      naturality _ _ _ := by simp [Scheme.Hom.resLE_comp_resLE] }
+  obtain ⟨k, g, hg, hg'⟩ := Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
+    _ τ (f.resLE _ _ hVW) _ (isLimitOpensCone D c hc i' _) (a.resLE _ _ (by simpa using hUV)) (by
+      ext k
+      simp [τ, Scheme.Hom.resLE_comp_resLE,
+        show c.π.app k.left ≫ t.app k.left = a ≫ f from congr(($ha).app k.left)])
+  have e : D.map (k.hom ≫ u) ⁻¹ᵁ U ≤ D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U := by simp
+  refine ⟨k.left, k.hom ≫ u, Scheme.homOfLE _ e ≫ g ≫ (V : X.Opens).ι, ?_, fun O h ↦ ?_⟩
+  · simpa [τ] using congr(Scheme.homOfLE _ e ≫ $hg' ≫ (W : S.Opens).ι)
+  · have h' : O ≤ c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U := by simpa using h
+    simpa using congr(Scheme.homOfLE _ h' ≫ $hg ≫ (V : X.Opens).ι)
+
+include hc in
+private lemma exists_forall_resLE_comp_eq_of_isAffineOpen
+    [IsCofiltered I] [LocallyOfFinitePresentation f]
+    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    (a : c.pt ⟶ X) (ha : c.π ≫ t = (Functor.const _).map (a ≫ f))
+    {i : I} {J : Type*} [Finite J] {U : J → (D.obj i).Opens} (hU : ∀ j, IsAffineOpen (U j))
+    (hUV : ∀ j, ∃ (V : X.affineOpens) (W : S.affineOpens),
+      c.π.app i ⁻¹ᵁ U j ≤ a ⁻¹ᵁ (V : X.Opens) ∧ (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens)) :
+    ∃ (k : I) (u : k ⟶ i) (g : ∀ j, ↑(D.map u ⁻¹ᵁ U j) ⟶ X),
+      (∀ j, g j ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k) ∧
+        ∀ j (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
+          (c.π.app k).resLE _ O h ≫ g j = O.ι ≫ a := by
+  choose V W hUV hVW using hUV
+  choose k u g hg hg' using IsCofiltered.exists_forall
+    (fun k (u : k ⟶ i) (j : J) ↦ ∃ g : ↑(D.map u ⁻¹ᵁ U j) ⟶ X,
+      g ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k ∧
+        ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
+          (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a)
+    (by
+      rintro k₁ k₂ v u j ⟨g, hg, hg'⟩
+      have e : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
+      exact ⟨(D.map v).resLE _ _ e ≫ g, by simpa using congr((D.map v).resLE _ _ e ≫ $hg),
+        fun O h ↦ by
+          simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)⟩)
+    fun j ↦ exists_resLE_comp_eq_of_isAffineOpen D t f c hc a ha (hU j) (V j) (W j) (hVW j) (hUV j)
+  exact ⟨k, u, g, hg, hg'⟩
+
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
+include hc in
+private lemma exists_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOfFiniteType f]
+    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [∀ i, QuasiSeparatedSpace (D.obj i)]
+    {k : I} {U₁ U₂ : (D.obj k).Opens} (hU₁ : IsCompact (U₁ : Set (D.obj k)))
+    (hU₂ : IsCompact (U₂ : Set (D.obj k))) (g₁ : ↑U₁ ⟶ X) (g₂ : ↑U₂ ⟶ X)
+    (hg₁ : g₁ ≫ f = U₁.ι ≫ t.app k) (hg₂ : g₂ ≫ f = U₂.ι ≫ t.app k)
+    (h : ∀ (O : c.pt.Opens) (e₁ : O ≤ c.π.app k ⁻¹ᵁ U₁) (e₂ : O ≤ c.π.app k ⁻¹ᵁ U₂),
+      (c.π.app k).resLE U₁ O e₁ ≫ g₁ = (c.π.app k).resLE U₂ O e₂ ≫ g₂) :
+    ∃ (l : I) (v : l ⟶ k), ∀ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U₁)
+      (e₂ : O ≤ D.map v ⁻¹ᵁ U₂), (D.map v).resLE U₁ O e₁ ≫ g₁ = (D.map v).resLE U₂ O e₂ ≫ g₂ := by
+  have _ (x) : CompactSpace ((opensDiagram D k (U₁ ⊓ U₂)).obj x) :=
+    isCompact_iff_compactSpace.mp (QuasiCompact.isCompact_preimage _ (U₁ ⊓ U₂).isOpen
+      (hU₁.inter_of_isOpen hU₂ U₁.2 U₂.2))
+  obtain ⟨⟨l, ⟨⟨⟩⟩, v⟩, ⟨v', ⟨⟨⟨⟩⟩⟩, hv⟩, e⟩ :=
+    Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
+      _ (opensDiagramι .. ≫ (Over.forget k).whiskerLeft t) f _
+      (isLimitOpensCone D c hc k (U₁ ⊓ U₂)) (i := .mk (𝟙 k))
+      (Scheme.homOfLE _ (by simp) ≫ g₁) (Scheme.homOfLE _ (by simp) ≫ g₂)
+      (by simp [hg₁]) (by simp [hg₂]) (by
+        simp only [opensCone_π_app, Over.mk_left, Over.mk_hom, Scheme.Hom.resLE_map_assoc]
+        exact h _ _ _)
+  obtain rfl : v = v' := by simpa using! hv.symm
+  refine ⟨l, v, fun O e₁ e₂ ↦ ?_⟩
+  simpa using congr(Scheme.homOfLE _ (show O ≤ D.map v ⁻¹ᵁ (U₁ ⊓ U₂) from le_inf e₁ e₂) ≫ $e)
+
+include hc in
+private lemma exists_forall_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOfFiniteType f]
+    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [∀ i, QuasiSeparatedSpace (D.obj i)]
+    {k : I} {J : Type*} [Finite J] {U : J → (D.obj k).Opens}
+    (hU : ∀ j, IsCompact (U j : Set (D.obj k))) (g : ∀ j, ↑(U j) ⟶ X)
+    (hg : ∀ j, g j ≫ f = (U j).ι ≫ t.app k)
+    (h : ∀ j₁ j₂ (O : c.pt.Opens) (e₁ : O ≤ c.π.app k ⁻¹ᵁ U j₁) (e₂ : O ≤ c.π.app k ⁻¹ᵁ U j₂),
+      (c.π.app k).resLE _ O e₁ ≫ g j₁ = (c.π.app k).resLE _ O e₂ ≫ g j₂) :
+    ∃ (l : I) (v : l ⟶ k), ∀ j₁ j₂ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U j₁)
+      (e₂ : O ≤ D.map v ⁻¹ᵁ U j₂),
+        (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ := by
+  obtain ⟨l, v, hl⟩ := IsCofiltered.exists_forall
+    (fun l (v : l ⟶ k) (j : J × J) ↦ ∀ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U j.1)
+      (e₂ : O ≤ D.map v ⁻¹ᵁ U j.2),
+        (D.map v).resLE _ O e₁ ≫ g j.1 = (D.map v).resLE _ O e₂ ≫ g j.2)
+    (fun w v j hv O e₁ e₂ ↦ by
+      simpa [Scheme.Hom.resLE_comp_resLE_assoc] using congr((D.map w).resLE _ O
+        (show O ≤ D.map w ⁻¹ᵁ _ by simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫
+          $(hv _ inf_le_left inf_le_right)))
+    fun j ↦ exists_resLE_comp_eq_resLE_comp D t f c hc (hU j.1) (hU j.2) _ _ (hg j.1) (hg j.2)
+      (h j.1 j.2)
+  exact ⟨l, v, fun j₁ j₂ ↦ hl (j₁, j₂)⟩
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
@@ -1227,107 +1363,37 @@ lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
     [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)]
     (a : c.pt ⟶ X) (ha : c.π ≫ t = (Functor.const _).map (a ≫ f)) :
     ∃ (i : I) (g : D.obj i ⟶ X), c.π.app i ≫ g = a ∧ g ≫ f = t.app i := by
-  -- The open cover of `c := lim Dᵢ` indexed by triplets of affine opens `(U, V, W)` with
-  -- `U ⊆ c`, `V ⊆ X`, `W ⊆ S` such that `U` maps to `V` maps to `W`.
-  have 𝒰 := (c.pt.isBasis_affineOpens).isOpenCover_mem_and_le
-    (((X.isBasis_affineOpens).isOpenCover_mem_and_le
-    ((S.isBasis_affineOpens).isOpenCover.comap f.base.hom)).comap a.base.hom)
-  -- By qcqs, this cover descends to some finite affine open cover `𝒱` of `Dᵢ`.
-  obtain ⟨i, s, 𝒱, h𝒱, h𝒱𝒰⟩ := Scheme.exists_isOpenCover_and_isAffine D c hc _ 𝒰 fun U ↦ U.2.1
-  obtain ⟨i', fi'i, hi'⟩ : ∃ (i' : I) (fi'i : i' ⟶ i),
-      ∀ j, D.map fi'i ⁻¹ᵁ 𝒱 j ≤ t.app i' ⁻¹ᵁ j.1.1.2.1.2.1 := by
-    choose k fk hk using fun j ↦ exists_map_preimage_le_map_preimage D c hc (h𝒱𝒰 j).1.isCompact
-      (V := t.app i ⁻¹ᵁ j.1.1.2.1.2.1) (by
-      rw [← Hom.comp_preimage, ← NatTrans.comp_app, ha]
-      exact (h𝒱𝒰 j).2.symm.trans_le (j.1.prop.2.trans (a.preimage_mono j.1.1.2.prop.2)))
-    obtain ⟨i', fi'i, fi', hfi'⟩ := IsCofiltered.wideCospan fk
-    refine ⟨i', fi'i, fun j ↦ ?_⟩
-    rw [← hfi', Functor.map_comp, Hom.comp_preimage]
-    refine (Hom.preimage_mono _ (hk _)).trans ?_
-    simp only [← Hom.comp_preimage, t.naturality, Functor.const_obj_obj,
-      Functor.const_obj_map, Category.comp_id, le_refl]
-  -- Using the affine version `exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine`,
-  -- one can now factor `Dⱼ ⁻¹ 𝒱ⱼ ⟶ lim Dᵢ ⟶ X` through some `Dⱼₖ ⁻¹ 𝒱ⱼ` for each `𝒱ⱼ`,
-  -- and by finite-ness we may chose a fixed `k` that works for every `j`.
-  have : ∃ k, ∃ (fk : k ⟶ i), ∀ j, ∃ (ak : ↑(D.map fk ⁻¹ᵁ 𝒱 j) ⟶ X),
-      ak ≫ f = Opens.ι _ ≫ t.app k ∧ c.π.app _ ∣_ _ ≫ ak = Opens.ι _ ≫ a := by
-    let 𝒱' := (D.map fi'i ⁻¹ᵁ 𝒱 ·)
-    have h𝒱'𝒰 (j : s) : c.π.app i' ⁻¹ᵁ 𝒱' j = j.1.1.1 := by
-      rw [← Hom.comp_preimage, c.w fi'i]; exact (h𝒱𝒰 j).2.symm
-    have _ (j k) : IsAffine ((opensDiagram D i' (𝒱' j)).obj k) := ((h𝒱𝒰 _).1.preimage _).preimage _
-    let t𝒱 (j : _) : opensDiagram D i' (𝒱' j) ⟶ (Functor.const (Over i')).obj j.1.1.2.1.2 :=
-    { app k := (t.app k.left).resLE _ _ <| by
-        refine (Hom.preimage_mono _ (hi' _)).trans ?_
-        simp only [Functor.const_obj_obj, ← Hom.comp_preimage, t.naturality,
-          Functor.const_obj_map, Category.comp_id, le_refl]
-      naturality {k₁ k₂} f₁₂ := by simp [Hom.resLE_comp_resLE] }
-    have (j : s) : IsAffine j.1.1.2.1.1 := j.1.1.2.prop.1
-    choose k ak hk hk' using fun j ↦ exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
-      _ (t𝒱 j) (f.resLE _ _ j.1.1.2.prop.2) _ (isLimitOpensCone D c hc i' (𝒱' j))
-      (a.resLE _ _ ((h𝒱'𝒰 _).trans_le j.1.prop.2)) (by
-      ext k
-      simp [t𝒱, Hom.resLE_comp_resLE, show c.π.app k.left ≫ t.app k.left = a ≫ f from
-        congr(($ha).app k.left)])
-    obtain ⟨i'', fi''i', fi'', hi''⟩ := IsCofiltered.wideCospan fun j ↦ (k j).hom
-    refine ⟨i'', fi''i' ≫ fi'i, fun j ↦
-      ⟨Scheme.homOfLE _ ?_ ≫ D.map (fi'' _) ∣_ _ ≫ ak j ≫ Opens.ι _, ?_, ?_⟩⟩
-    · simp only [← Hom.comp_preimage, ← Functor.map_comp, 𝒱', reassoc_of% hi'']; rfl
-    · have : ak j ≫ Opens.ι _ ≫ f = Opens.ι _ ≫ t.app (k j).left := by
-        simpa [t𝒱] using! congr($(hk' j) ≫ Opens.ι _)
-      simp [this]
-    · have e : c.π.app i'' ⁻¹ᵁ D.map (fi''i' ≫ fi'i) ⁻¹ᵁ 𝒱 j ≤ c.π.app i' ⁻¹ᵁ 𝒱' j := by
-        simp only [← Hom.comp_preimage, Cone.w, 𝒱']; rfl
-      simpa [← AlgebraicGeometry.Scheme.Hom.resLE_eq_morphismRestrict,
-        Scheme.Hom.resLE_comp_resLE_assoc] using! congr(Scheme.homOfLE _ e ≫ $(hk j) ≫ Opens.ι _)
-  choose k fki ak hak hak' using this
-  -- We may then find an `l` for each `j₁` and `j₂` such that the map `Dⱼ₁ₗ ⁻¹ 𝒱ⱼ₁ ⟶ X` and
-  -- `Dⱼ₂ₗ ⁻¹ 𝒱ⱼ₂ ⟶ X` agrees on the intersection in `Dₗ`.
-  -- And again by finiteness we may choose a global `l`.
-  obtain ⟨l, flk, hl⟩ : ∃ (l : I) (flk : l ⟶ k), ∀ j₁ j₂, Scheme.homOfLE _ inf_le_left ≫
-      D.map flk ∣_ _ ≫ ak j₁ = Scheme.homOfLE _ inf_le_right ≫ D.map flk ∣_ _ ≫ ak j₂ := by
-    let 𝒱' := (D.map fki ⁻¹ᵁ 𝒱 ·)
-    have (j₁ j₂ : s) : ∃ (l : I) (flk : l ⟶ k), Scheme.homOfLE _ inf_le_left ≫ D.map flk ∣_ _ ≫
-        ak j₁ = Scheme.homOfLE _ inf_le_right ≫ D.map flk ∣_ _ ≫ ak j₂ := by
-      have _ (x) : CompactSpace ↥((opensDiagram D k (𝒱' j₁ ⊓ 𝒱' j₂)).obj x) :=
-        isCompact_iff_compactSpace.mp (QuasiCompact.isCompact_preimage _ (𝒱' j₁ ⊓ 𝒱' j₂).isOpen
-          (((h𝒱𝒰 _).1.preimage _).isCompact.inter_of_isOpen ((h𝒱𝒰 _).1.preimage _).isCompact
-            (D.map fki ⁻¹ᵁ 𝒱 j₁).2 (D.map fki ⁻¹ᵁ 𝒱 j₂).2))
-      obtain ⟨⟨l, ⟨⟨⟩⟩, flk⟩, ⟨flk', ⟨⟨⟨⟩⟩⟩, h⟩, e⟩ :=
-        Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType _
-          (opensDiagramι .. ≫ (Over.forget k).whiskerLeft t) f _
-          (isLimitOpensCone D c hc k (𝒱' j₁ ⊓ 𝒱' j₂)) (i := .mk (𝟙 k))
-          (Scheme.homOfLE _ (by simp [𝒱']) ≫ ak j₁) (Scheme.homOfLE _ (by simp [𝒱']) ≫ ak j₂)
-          (by simp [hak]) (by simp [hak]) (by simp; simp [Hom.resLE, hak'])
-      obtain rfl : flk = flk' := by simpa using! h.symm
-      refine ⟨l, flk, by simpa [← Scheme.Hom.resLE_eq_morphismRestrict] using! e⟩
-    choose l flk hflk using this
-    obtain ⟨l', fl'k, fl'l, hl'⟩ := IsCofiltered.wideCospan (I := s × s) fun x ↦ flk x.1 x.2
-    refine ⟨l', fl'k, fun j₁ j₂ ↦ ?_⟩
-    have H : (D.map fl'k ≫ D.map fki) ⁻¹ᵁ (𝒱 j₁ ⊓ 𝒱 j₂) ≤
-        (D.map (fl'l (j₁, j₂)) ≫ D.map (flk j₁ j₂) ≫ D.map fki) ⁻¹ᵁ (𝒱 j₁ ⊓ 𝒱 j₂) := by
-      simp only [← Functor.map_comp, reassoc_of% hl']; rfl
-    simpa [← Scheme.Hom.resLE_eq_morphismRestrict, Scheme.Hom.resLE_comp_resLE_assoc,
-      ← Functor.map_comp, hl'] using! congr((D.map (fl'l (j₁, j₂))).resLE _ _ H ≫ $(hflk j₁ j₂))
+  -- The open cover of `c := lim Dᵢ` by the affine opens `U ⊆ c` such that `U` maps into an affine
+  -- `V ⊆ X` which in turn maps into an affine `W ⊆ S`.
+  have h𝒰 := (isBasis_affineOpens_le_preimage a f).isOpenCover
+  obtain ⟨i, s, 𝒱, h𝒱, h𝒱𝒰⟩ := Scheme.exists_isOpenCover_and_isAffine D c hc _ h𝒰 fun U ↦ U.2.1
+  -- Each `𝒱 j` factors after passing to some `k`, and by finiteness a single `k` works for all `j`.
+  obtain ⟨k, fki, ak, hak, hak'⟩ := exists_forall_resLE_comp_eq_of_isAffineOpen D t f c hc a ha
+    (fun j ↦ (h𝒱𝒰 j).1) fun j ↦ (h𝒱𝒰 j).2 ▸ j.1.2.2
+  -- Likewise the `ak j` pairwise agree on overlaps after passing to some `l`.
+  obtain ⟨l, flk, hl⟩ := exists_forall_resLE_comp_eq_resLE_comp D t f c hc
+    (fun j ↦ ((h𝒱𝒰 j).1.preimage _).isCompact) ak hak
+    fun j₁ j₂ O e₁ e₂ ↦ (hak' j₁ O e₁).trans (hak' j₂ O e₂).symm
   -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
-  let h𝒲 := (h𝒱.comap (D.map fki).base.hom).comap (D.map flk).base.hom
-  let 𝒲 := Scheme.openCoverOfIsOpenCover _ (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 ·) h𝒲
-  let F := 𝒲.glueMorphisms (fun j ↦ D.map flk ∣_ D.map fki ⁻¹ᵁ 𝒱 j ≫ ak j) (fun j₁ j₂ ↦ by
+  let 𝒲 := Scheme.openCoverOfIsOpenCover _ (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 ·)
+    ((h𝒱.comap (D.map fki).base.hom).comap (D.map flk).base.hom)
+  let F := 𝒲.glueMorphisms (fun j ↦ (D.map flk).resLE (D.map fki ⁻¹ᵁ 𝒱 j) _ le_rfl ≫ ak j)
+    (fun j₁ j₂ ↦ by
       rw [← cancel_epi (isPullback_opens_inf _ _).isoPullback.hom]
-      simpa [𝒲] using! hl j₁ j₂)
-  have hF (j : s) : (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ F = D.map flk ∣_ _ ≫ ak j :=
-    Scheme.Cover.ι_glueMorphisms ..
+      simpa [𝒲] using hl j₁ j₂ _ inf_le_left inf_le_right)
+  have hF (j : s) : (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ F =
+      (D.map flk).resLE _ _ le_rfl ≫ ak j := Scheme.Cover.ι_glueMorphisms ..
   refine ⟨l, F, ?_, ?_⟩
   · refine Cover.hom_ext (𝒲.pullback₁ (c.π.app l)) _ _ fun j ↦ ?_
     rw [← cancel_epi (isPullback_morphismRestrict _ _).flip.isoPullback.hom]
     dsimp [𝒲]
     simp only [pullback.condition_assoc, IsPullback.isoPullback_hom_snd_assoc,
-      IsPullback.isoPullback_hom_fst_assoc, hF]
-    have h : c.π.app l ⁻¹ᵁ D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j ≤ c.π.app k ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j := by
-      simp only [← Hom.comp_preimage, c.w_assoc, c.w]; rfl
-    simpa [← Scheme.Hom.resLE_eq_morphismRestrict, Scheme.Hom.resLE_comp_resLE_assoc] using!
-      congr(Scheme.homOfLE _ h ≫ $(hak' j))
+      IsPullback.isoPullback_hom_fst_assoc, hF, ← Hom.resLE_eq_morphismRestrict,
+      Hom.resLE_comp_resLE_assoc, Cone.w]
+    exact hak' j _ _
   · refine 𝒲.hom_ext _ _ fun j ↦ ?_
-    simp [F, Cover.ι_glueMorphisms_assoc, hak]; rfl
+    dsimp [𝒲]
+    simp [reassoc_of% hF, hak]
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -836,45 +836,42 @@ lemma exists_appTop_π_eq_of_isAffine_of_isLimit
   exact ⟨_, (Types.jointly_surjective_of_isColimit
     (isColimitOfPreserves (Scheme.Γ ⋙ forget _) hc.op) s).choose_spec⟩
 
-set_option backward.isDefEq.respectTransparency false in
 include hc in
-private lemma exists_app_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+private lemma exists_appLE_eq_restrict_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     (s : Γ(c.pt, ⊤)) (x : c.pt) :
     ∃ (i : I) (U : (D.obj i).Opens) (_ : IsAffineOpen U) (_ : (c.π.app i).base x ∈ U)
-      (t : Γ(D.obj i, U)), (c.π.app i).app U t = s |_ (c.π.app i ⁻¹ᵁ U) := by
+      (t : Γ(D.obj i, U)), ∀ (V : c.pt.Opens) (e : V ≤ c.π.app i ⁻¹ᵁ U),
+        (c.π.app i).appLE U V e t = s |_ V := by
   have i := IsCofiltered.nonempty (C := I).some
   obtain ⟨_, ⟨U, hU : IsAffineOpen U, rfl⟩, hxU, -⟩ :=
     (D.obj i).isBasis_affineOpens.exists_subset_of_mem_open
       (Set.mem_univ ((c.π.app i).base x)) isOpen_univ
   have (j : Over i) : IsAffine ((opensDiagram D i U).obj j) := hU.preimage (D.map _)
   obtain ⟨j, t, hj⟩ := exists_appTop_π_eq_of_isAffine_of_isLimit _ _
-    (isLimitOpensCone D c hc i U) (s |_ _)
-  refine ⟨j.left, (D.map j.hom ⁻¹ᵁ U).ι ''ᵁ ⊤, by simpa using hU.preimage (D.map _), ?_, t, ?_⟩
-  · suffices (c.π.app j.1 ≫ D.map j.hom).base x ∈ U by simpa [-Cone.w] using this
-    rwa [Cone.w]
-  · have H : c.π.app j.left ⁻¹ᵁ (D.map j.hom ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ (c.π.app i ⁻¹ᵁ U).ι ''ᵁ ⊤ := by
-      simp [← Scheme.Hom.comp_preimage]
-    refine Eq.trans ?_ (congr(c.pt.presheaf.map (homOfLE H).op $hj).trans
-      (TopCat.Presheaf.restrict_restrict H le_top s))
-    convert! ConcreteCategory.comp_apply _ _ _
-    congr
-    simp [Scheme.Hom.app_eq_appLE, Scheme.Hom.resLE_appLE]
-
-omit [IsCofiltered I] in
-private lemma π_appLE_eq_restrict {i : I} {U : (D.obj i).Opens} {s : Γ(c.pt, ⊤)}
-    {t : Γ(D.obj i, U)} (ht : (c.π.app i).app U t = s |_ (c.π.app i ⁻¹ᵁ U))
-    {V : c.pt.Opens} (e : V ≤ c.π.app i ⁻¹ᵁ U) :
-    (c.π.app i).appLE U V e t = s |_ V := by
-  simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply, ht]
-  exact TopCat.Presheaf.restrict_restrict e le_top s
+    (isLimitOpensCone D c hc i U) ((c.π.app i ⁻¹ᵁ U).topIso.inv (s |_ _))
+  obtain ⟨t, rfl⟩ := (D.map j.hom ⁻¹ᵁ U).topIso.symm.commRingCatIsoToRingEquiv.surjective t
+  have h : c.π.app j.left ⁻¹ᵁ D.map j.hom ⁻¹ᵁ U = c.π.app i ⁻¹ᵁ U := congr($(c.w j.hom) ⁻¹ᵁ U)
+  replace hj : (c.π.app j.left).appLE (D.map j.hom ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U) h.ge t =
+      s |_ (c.π.app i ⁻¹ᵁ U) := by
+    replace hj : ((c.π.app j.left).resLE (D.map j.hom ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U) h.ge).appTop
+        ((D.map j.hom ⁻¹ᵁ U).topIso.inv t) =
+        (c.π.app i ⁻¹ᵁ U).topIso.inv (s |_ (c.π.app i ⁻¹ᵁ U)) := hj
+    simp only [Scheme.Hom.appTop, Scheme.Hom.resLE_app_top, ConcreteCategory.comp_apply,
+      Iso.inv_hom_id_apply] at hj
+    exact (c.π.app i ⁻¹ᵁ U).topIso.commRingCatIsoToRingEquiv.symm.injective hj
+  refine ⟨j.left, D.map j.hom ⁻¹ᵁ U, hU.preimage _, h.ge hxU, t, fun V e ↦ ?_⟩
+  simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply] at hj ⊢
+  rw [← TopCat.Presheaf.restrict_restrict (e.trans_eq h) le_top s, ← hj]
+  exact (TopCat.Presheaf.restrict_restrict (e.trans_eq h) h.ge _).symm
 
 include hc in
 private lemma exists_map_appLE_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     [∀ i, QuasiSeparatedSpace (D.obj i)]
     {s : Γ(c.pt, ⊤)} {i₁ i₂ k : I} {U₁ : (D.obj i₁).Opens} {U₂ : (D.obj i₂).Opens}
     (hU₁ : IsAffineOpen U₁) (hU₂ : IsAffineOpen U₂) {t₁ : Γ(D.obj i₁, U₁)} {t₂ : Γ(D.obj i₂, U₂)}
-    (ht₁ : (c.π.app i₁).app U₁ t₁ = s |_ (c.π.app i₁ ⁻¹ᵁ U₁))
-    (ht₂ : (c.π.app i₂).app U₂ t₂ = s |_ (c.π.app i₂ ⁻¹ᵁ U₂)) (u₁ : k ⟶ i₁) (u₂ : k ⟶ i₂) :
+    (ht₁ : ∀ (V : c.pt.Opens) (e : V ≤ c.π.app i₁ ⁻¹ᵁ U₁), (c.π.app i₁).appLE U₁ V e t₁ = s |_ V)
+    (ht₂ : ∀ (V : c.pt.Opens) (e : V ≤ c.π.app i₂ ⁻¹ᵁ U₂), (c.π.app i₂).appLE U₂ V e t₂ = s |_ V)
+    (u₁ : k ⟶ i₁) (u₂ : k ⟶ i₂) :
     ∃ (l : I) (v : l ⟶ k), ∀ (V : (D.obj l).Opens) (h₁ : V ≤ D.map (v ≫ u₁) ⁻¹ᵁ U₁)
       (h₂ : V ≤ D.map (v ≫ u₂) ⁻¹ᵁ U₂),
         (D.map (v ≫ u₁)).appLE U₁ V h₁ t₁ = (D.map (v ≫ u₂)).appLE U₂ V h₂ t₂ := by
@@ -886,7 +883,7 @@ private lemma exists_map_appLE_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineH
     dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
     simp only [map_sub, sub_eq_zero, ← ConcreteCategory.comp_apply,
       Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, Scheme.Hom.appLE_comp_appLE, Cone.w]
-    exact (π_appLE_eq_restrict D c ht₁ _).trans (π_appLE_eq_restrict D c ht₂ _).symm)
+    exact (ht₁ _ _).trans (ht₂ _ _).symm)
   refine ⟨l, v, fun V h₁ h₂ ↦ ?_⟩
   have H : V ≤ D.map v ⁻¹ᵁ (D.map u₁ ⁻¹ᵁ U₁ ⊓ D.map u₂ ⁻¹ᵁ U₂) := by
     simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
@@ -895,14 +892,13 @@ private lemma exists_map_appLE_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineH
   simpa [sub_eq_zero, ← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
     Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hv
 
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     (s : Γ(c.pt, ⊤)) [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)] :
     ∃ (i : I) (t : Γ(D.obj i, ⊤)), s = (c.π.app i).appTop t := by
   classical
   have := Scheme.compactSpace_of_isLimit _ _ hc
-  choose i U hU hxU t ht using exists_app_eq_restrict_of_isLimit D c hc s
+  choose i U hU hxU t ht using exists_appLE_eq_restrict_of_isLimit D c hc s
   obtain ⟨σ, hσ⟩ := CompactSpace.elim_nhds_subcover (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).1)
     (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).2.mem_nhds (by exact hxU x))
   choose σi hσiσ hσi using fun x ↦ Set.mem_iUnion₂.mp (hσ.ge (Set.mem_univ x))
@@ -938,14 +934,18 @@ lemma exists_appTop_π_eq_of_isLimit [∀ {i j} (f : i ⟶ j), IsAffineHom (D.ma
   obtain ⟨t₀, ht₀, -⟩ := hsheaf (fun x ↦ (D.map _).app _ (t x)) fun x y V fVx fVy _ ↦ by
     simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, -Scheme.Hom.comp_appLE]
       using hv (x, y) V fVx.le fVy.le
+  replace ht₀ (x : σ) : t₀ |_ (D.map (v ≫ fj x) ⁻¹ᵁ U x) = (D.map (v ≫ fj x)).app (U x) (t x) :=
+    ht₀ x
   refine ⟨k, t₀, TopCat.Presheaf.section_ext c.pt.sheaf _ _ _ fun y hy ↦ c.pt.presheaf.germ_ext
     (c.π.app _ ⁻¹ᵁ U (σi y)) (hσi y) (homOfLE le_top) (homOfLE le_top) ?_⟩
   have H : c.π.app (i (σi y)) ⁻¹ᵁ U (σi y) ≤
       c.π.app k ⁻¹ᵁ D.map (v ≫ fj ⟨_, hσiσ y⟩) ⁻¹ᵁ U (σi y) := by
     rw [← Scheme.Hom.comp_preimage, Cone.w]
-  refine (π_appLE_eq_restrict D c (ht (σi y)) le_rfl).symm.trans ?_
-  simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE,
-    -Scheme.Hom.comp_appLE] using congr((c.π.app k).appLE _ _ H $(ht₀ ⟨_, hσiσ y⟩)).symm
+  refine (ht (σi y) _ le_rfl).symm.trans (Eq.trans ?_ (ConcreteCategory.comp_apply _ _ _))
+  have key := congr((c.π.app k).appLE _ (c.π.app (i (σi y)) ⁻¹ᵁ U (σi y)) H $(ht₀ ⟨_, hσiσ y⟩))
+  simp only [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict, ← ConcreteCategory.comp_apply,
+    Scheme.Hom.map_appLE, Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE, Cone.w] at key
+  exact key.symm
 
 include hc in
 lemma nonempty_isColimit_Γ_mapCocone [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
@@ -1190,7 +1190,6 @@ private lemma isBasis_affineOpens_le_preimage {Y Z T : Scheme.{u}} (a : Y ⟶ Z)
     (U := O ⊓ a ⁻¹ᵁ V) (x := y) ⟨hy, hyV⟩
   exact ⟨U, ⟨hU, ⟨V, hV⟩, ⟨W, hW⟩, hUV.trans inf_le_right, hVW⟩, hyU, hUV.trans inf_le_left⟩
 
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 private lemma exists_resLE_comp_eq_of_isAffineOpen
     [IsCofiltered I] [LocallyOfFinitePresentation f]
@@ -1202,27 +1201,37 @@ private lemma exists_resLE_comp_eq_of_isAffineOpen
       g ≫ f = (D.map u ⁻¹ᵁ U).ι ≫ t.app k ∧
         ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U),
           (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a := by
-  obtain ⟨i', u, hu⟩ : ∃ (i' : I) (u : i' ⟶ i), D.map u ⁻¹ᵁ U ≤ t.app i' ⁻¹ᵁ (W : S.Opens) := by
+  let t' : ∀ j : I, D.obj j ⟶ S := t.app
+  have hnat {j k : I} (v : j ⟶ k) : D.map v ≫ t' k = t' j := by simp [t']
+  have hπ (j : I) : c.π.app j ≫ t' j = a ≫ f := congr(($ha).app j)
+  obtain ⟨i', u, hu⟩ : ∃ (i' : I) (u : i' ⟶ i), D.map u ⁻¹ᵁ U ≤ t' i' ⁻¹ᵁ (W : S.Opens) := by
     obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc hU.isCompact
-      (V := t.app i ⁻¹ᵁ (W : S.Opens)) (by
-        rw [← Scheme.Hom.comp_preimage, ← NatTrans.comp_app, ha]
+      (V := t' i ⁻¹ᵁ (W : S.Opens)) (by
+        rw [← Scheme.Hom.comp_preimage, hπ, Scheme.Hom.comp_preimage]
         exact hUV.trans (a.preimage_mono hVW))
-    exact ⟨i', u, hu.trans_eq (by simp [← Scheme.Hom.comp_preimage, t.naturality])⟩
+    exact ⟨i', u, hu.trans_eq (by rw [← Scheme.Hom.comp_preimage, hnat])⟩
   have _ (k : Over i') : IsAffine ((opensDiagram D i' (D.map u ⁻¹ᵁ U)).obj k) :=
     (hU.preimage _).preimage _
   let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U) ⟶ (Functor.const (Over i')).obj W :=
-    { app k := (t.app k.left).resLE _ _ (by
-        refine (Scheme.Hom.preimage_mono _ hu).trans ?_
-        simp [← Scheme.Hom.comp_preimage, t.naturality])
-      naturality _ _ _ := by simp [Scheme.Hom.resLE_comp_resLE] }
-  obtain ⟨k, g, hg, hg'⟩ := Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
-    _ τ (f.resLE _ _ hVW) _ (isLimitOpensCone D c hc i' _) (a.resLE _ _ (by simpa using hUV)) (by
-      ext k
-      simp [τ, Scheme.Hom.resLE_comp_resLE,
-        show c.π.app k.left ≫ t.app k.left = a ≫ f from congr(($ha).app k.left)])
+    { app k := (t' k.left).resLE _ _ ((Scheme.Hom.preimage_mono _ hu).trans_eq
+        (by rw [← Scheme.Hom.comp_preimage, hnat]))
+      naturality k l v := ((D.map v.left).resLE_comp_resLE _ (t' l.left) _).trans
+        (Eq.trans ((cancel_mono (W : S.Opens).ι).mp (by simp [hnat]))
+          (Category.comp_id _).symm) }
+  obtain ⟨k, g, hg, hg'⟩ :
+      ∃ (k : Over i') (g : (D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U).toScheme ⟶ (V : X.Opens).toScheme),
+        (c.π.app k.left).resLE _ (c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U) (by simp) ≫ g =
+            a.resLE _ _ (by simpa using hUV) ∧ g ≫ f.resLE _ _ hVW = τ.app k :=
+    Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
+      _ τ (f.resLE _ _ hVW) _ (isLimitOpensCone D c hc i' _)
+      (a.resLE _ _ (by simpa using hUV)) (by
+        ext k
+        exact ((c.π.app k.left).resLE_comp_resLE _ (t' k.left) _).trans
+          (Eq.trans ((cancel_mono (W : S.Opens).ι).mp (by simp [hπ]))
+            (a.resLE_comp_resLE _ f _).symm))
   have e : D.map (k.hom ≫ u) ⁻¹ᵁ U ≤ D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U := by simp
   refine ⟨k.left, k.hom ≫ u, Scheme.homOfLE _ e ≫ g ≫ (V : X.Opens).ι, ?_, fun O h ↦ ?_⟩
-  · simpa [τ] using congr(Scheme.homOfLE _ e ≫ $hg' ≫ (W : S.Opens).ι)
+  · simpa [τ, t'] using congr(Scheme.homOfLE _ e ≫ $hg' ≫ (W : S.Opens).ι)
   · have h' : O ≤ c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U := by simpa using h
     simpa using congr(Scheme.homOfLE _ h' ≫ $hg ≫ (V : X.Opens).ι)
 
@@ -1253,7 +1262,6 @@ private lemma exists_forall_resLE_comp_eq_of_isAffineOpen
     fun j ↦ exists_resLE_comp_eq_of_isAffineOpen D t f c hc a ha (hU j) (V j) (W j) (hVW j) (hUV j)
   exact ⟨k, u, g, hg, hg'⟩
 
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 private lemma exists_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOfFiniteType f]
     [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [∀ i, QuasiSeparatedSpace (D.obj i)]
@@ -1267,17 +1275,25 @@ private lemma exists_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOfFiniteT
   have _ (x) : CompactSpace ((opensDiagram D k (U₁ ⊓ U₂)).obj x) :=
     isCompact_iff_compactSpace.mp (QuasiCompact.isCompact_preimage _ (U₁ ⊓ U₂).isOpen
       (hU₁.inter_of_isOpen hU₂ U₁.2 U₂.2))
+  let U₀ : (D.obj k).Opens := D.map (𝟙 k) ⁻¹ᵁ (U₁ ⊓ U₂)
+  let a₁ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ g₁
+  let a₂ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ g₂
+  have ha₁ : U₀.ι ≫ t.app k = a₁ ≫ f := by simp [a₁, hg₁]
+  have ha₂ : U₀.ι ≫ t.app k = a₂ ≫ f := by simp [a₂, hg₂]
+  have hab : (c.π.app k).resLE U₀ (c.π.app k ⁻¹ᵁ (U₁ ⊓ U₂)) (by simp [U₀]) ≫ a₁ =
+      (c.π.app k).resLE U₀ (c.π.app k ⁻¹ᵁ (U₁ ⊓ U₂)) (by simp [U₀]) ≫ a₂ := by
+    simp only [a₁, a₂, Scheme.Hom.resLE_map_assoc]
+    exact h _ _ _
   obtain ⟨⟨l, ⟨⟨⟩⟩, v⟩, ⟨v', ⟨⟨⟨⟩⟩⟩, hv⟩, e⟩ :=
     Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
       _ (opensDiagramι .. ≫ (Over.forget k).whiskerLeft t) f _
-      (isLimitOpensCone D c hc k (U₁ ⊓ U₂)) (i := .mk (𝟙 k))
-      (Scheme.homOfLE _ (by simp) ≫ g₁) (Scheme.homOfLE _ (by simp) ≫ g₂)
-      (by simp [hg₁]) (by simp [hg₂]) (by
-        simp only [opensCone_π_app, Over.mk_left, Over.mk_hom, Scheme.Hom.resLE_map_assoc]
-        exact h _ _ _)
+      (isLimitOpensCone D c hc k (U₁ ⊓ U₂)) (i := .mk (𝟙 k)) a₁ a₂ ha₁ ha₂ hab
   obtain rfl : v = v' := by simpa using! hv.symm
+  replace e : (D.map v).resLE U₀ (D.map v ⁻¹ᵁ (U₁ ⊓ U₂)) (by simp [U₀]) ≫ a₁ =
+      (D.map v).resLE U₀ (D.map v ⁻¹ᵁ (U₁ ⊓ U₂)) (by simp [U₀]) ≫ a₂ := e
   refine ⟨l, v, fun O e₁ e₂ ↦ ?_⟩
-  simpa using congr(Scheme.homOfLE _ (show O ≤ D.map v ⁻¹ᵁ (U₁ ⊓ U₂) from le_inf e₁ e₂) ≫ $e)
+  simpa [a₁, a₂] using congr(Scheme.homOfLE _
+    (show O ≤ D.map v ⁻¹ᵁ (U₁ ⊓ U₂) from le_inf e₁ e₂) ≫ $e)
 
 include hc in
 private lemma exists_forall_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOfFiniteType f]
@@ -1302,8 +1318,6 @@ private lemma exists_forall_resLE_comp_eq_resLE_comp [IsCofiltered I] [LocallyOf
       (h j.1 j.2)
   exact ⟨l, v, fun j₁ j₂ ↦ hl (j₁, j₂)⟩
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 open TopologicalSpace in
 include hc in
 /--
@@ -1329,25 +1343,30 @@ lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
     (fun j ↦ ((h𝒱𝒰 j).1.preimage _).isCompact) ak hak
     fun j₁ j₂ O e₁ e₂ ↦ (hak' j₁ O e₁).trans (hak' j₂ O e₂).symm
   -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
-  let 𝒲 := Scheme.openCoverOfIsOpenCover _ (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 ·)
-    ((h𝒱.comap (D.map fki).base.hom).comap (D.map flk).base.hom)
-  let F := 𝒲.glueMorphisms (fun j ↦ (D.map flk).resLE (D.map fki ⁻¹ᵁ 𝒱 j) _ le_rfl ≫ ak j)
-    (fun j₁ j₂ ↦ by
-      rw [← cancel_epi (isPullback_opens_inf _ _).isoPullback.hom]
-      simpa [𝒲] using hl j₁ j₂ _ inf_le_left inf_le_right)
+  have h𝒲 : IsOpenCover (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 ·) :=
+    (h𝒱.comap (D.map fki).base.hom).comap (D.map flk).base.hom
+  let 𝒲 := Scheme.openCoverOfIsOpenCover _ (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 ·) h𝒲
+  have hglue (j₁ j₂ : s) :
+      pullback.fst (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j₁).ι (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j₂).ι ≫
+          (D.map flk).resLE (D.map fki ⁻¹ᵁ 𝒱 j₁) _ le_rfl ≫ ak j₁ =
+        pullback.snd _ _ ≫ (D.map flk).resLE (D.map fki ⁻¹ᵁ 𝒱 j₂) _ le_rfl ≫ ak j₂ := by
+    rw [← cancel_epi (isPullback_opens_inf _ _).isoPullback.hom]
+    simpa using hl j₁ j₂ _ inf_le_left inf_le_right
+  let F := 𝒲.glueMorphisms (fun j ↦ (D.map flk).resLE (D.map fki ⁻¹ᵁ 𝒱 j) _ le_rfl ≫ ak j) hglue
   have hF (j : s) : (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ F =
       (D.map flk).resLE _ _ le_rfl ≫ ak j := Scheme.Cover.ι_glueMorphisms ..
-  refine ⟨l, F, ?_, ?_⟩
-  · refine Cover.hom_ext (𝒲.pullback₁ (c.π.app l)) _ _ fun j ↦ ?_
-    rw [← cancel_epi (isPullback_morphismRestrict _ _).flip.isoPullback.hom]
-    dsimp [𝒲]
-    simp only [pullback.condition_assoc, IsPullback.isoPullback_hom_snd_assoc,
-      IsPullback.isoPullback_hom_fst_assoc, hF, ← Hom.resLE_eq_morphismRestrict,
-      Hom.resLE_comp_resLE_assoc, Cone.w]
+  have h𝒰' : IsOpenCover (c.π.app l ⁻¹ᵁ D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 ·) :=
+    h𝒲.comap (c.π.app l).base.hom
+  have hπF (j : s) : (c.π.app l ⁻¹ᵁ D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ c.π.app l ≫ F =
+      (c.π.app l ⁻¹ᵁ D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ a := by
+    rw [← Hom.resLE_comp_ι_assoc (c.π.app l) le_rfl, hF]
+    simp only [Hom.resLE_comp_resLE_assoc, Cone.w]
     exact hak' j _ _
-  · refine 𝒲.hom_ext _ _ fun j ↦ ?_
-    dsimp [𝒲]
+  have hFf (j : s) : (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ F ≫ f =
+      (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ t.app l := by
     simp [reassoc_of% hF, hak]
+  exact ⟨l, F, Cover.hom_ext (Scheme.openCoverOfIsOpenCover _ _ h𝒰') _ _ hπF,
+    𝒲.hom_ext _ _ hFf⟩
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -1194,48 +1194,6 @@ private lemma isBasis_affineOpens_le_preimage {Y Z T : Scheme.{u}} (a : Y ⟶ Z)
 variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
 
 include hc ha in
-private lemma exists_resLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresentation f]
-    {i : I} {U : (D.obj i).Opens} (hU : IsAffineOpen U) (V : X.affineOpens) (W : S.affineOpens)
-    (hVW : (V : X.Opens) ≤ f ⁻¹ᵁ (W : S.Opens)) (hUV : c.π.app i ⁻¹ᵁ U ≤ a ⁻¹ᵁ (V : X.Opens)) :
-    ∃ (k : I) (u : k ⟶ i) (g : ↑(D.map u ⁻¹ᵁ U) ⟶ X),
-      g ≫ f = (D.map u ⁻¹ᵁ U).ι ≫ t.app k ∧
-        ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U),
-          (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a := by
-  let t' : ∀ j : I, D.obj j ⟶ S := t.app
-  have hnat {j k : I} (v : j ⟶ k) : D.map v ≫ t' k = t' j := by simp [t']
-  have hπ (j : I) : c.π.app j ≫ t' j = a ≫ f := congr(($ha).app j)
-  obtain ⟨i', u, hu⟩ : ∃ (i' : I) (u : i' ⟶ i), D.map u ⁻¹ᵁ U ≤ t' i' ⁻¹ᵁ (W : S.Opens) := by
-    obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc hU.isCompact
-      (V := t' i ⁻¹ᵁ (W : S.Opens)) (by
-        rw [← Scheme.Hom.comp_preimage, hπ, Scheme.Hom.comp_preimage]
-        exact hUV.trans (a.preimage_mono hVW))
-    exact ⟨i', u, hu.trans_eq (by rw [← Scheme.Hom.comp_preimage, hnat])⟩
-  have _ (k : Over i') : IsAffine ((opensDiagram D i' (D.map u ⁻¹ᵁ U)).obj k) :=
-    (hU.preimage _).preimage _
-  let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U) ⟶ (Functor.const (Over i')).obj W :=
-    { app k := (t' k.left).resLE _ _ ((Scheme.Hom.preimage_mono _ hu).trans_eq
-        (by rw [← Scheme.Hom.comp_preimage, hnat]))
-      naturality k l v := ((D.map v.left).resLE_comp_resLE _ (t' l.left) _).trans
-        (Eq.trans ((cancel_mono (W : S.Opens).ι).mp (by simp [hnat]))
-          (Category.comp_id _).symm) }
-  obtain ⟨k, g, hg, hg'⟩ :
-      ∃ (k : Over i') (g : (D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U).toScheme ⟶ (V : X.Opens).toScheme),
-        (c.π.app k.left).resLE _ (c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U) (by simp) ≫ g =
-            a.resLE _ _ (by simpa using hUV) ∧ g ≫ f.resLE _ _ hVW = τ.app k :=
-    Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
-      _ τ (f.resLE _ _ hVW) _ (isLimitOpensCone D c hc i' _)
-      (a.resLE _ _ (by simpa using hUV)) (by
-        ext k
-        exact ((c.π.app k.left).resLE_comp_resLE _ (t' k.left) _).trans
-          (Eq.trans ((cancel_mono (W : S.Opens).ι).mp (by simp [hπ]))
-            (a.resLE_comp_resLE _ f _).symm))
-  have e : D.map (k.hom ≫ u) ⁻¹ᵁ U ≤ D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U := by simp
-  refine ⟨k.left, k.hom ≫ u, Scheme.homOfLE _ e ≫ g ≫ (V : X.Opens).ι, ?_, fun O h ↦ ?_⟩
-  · simpa [τ, t'] using congr(Scheme.homOfLE _ e ≫ $hg' ≫ (W : S.Opens).ι)
-  · have h' : O ≤ c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U := by simpa using h
-    simpa using congr(Scheme.homOfLE _ h' ≫ $hg ≫ (V : X.Opens).ι)
-
-include hc ha in
 private lemma exists_forall_resLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresentation f]
     {i : I} {J : Type*} [Finite J] {U : J → (D.obj i).Opens} (hU : ∀ j, IsAffineOpen (U j))
     (hUV : ∀ j, ∃ (V : X.affineOpens) (W : S.affineOpens),
@@ -1244,47 +1202,47 @@ private lemma exists_forall_resLE_comp_eq_of_isAffineOpen [LocallyOfFinitePresen
       g ≫ f = (D.map u ⁻¹ᵁ U j).ι ≫ t.app k ∧
         ∀ (O : c.pt.Opens) (h : O ≤ c.π.app k ⁻¹ᵁ D.map u ⁻¹ᵁ U j),
           (c.π.app k).resLE _ O h ≫ g = O.ι ≫ a := by
+  have hnat {j k : I} (v : j ⟶ k) : D.map v ≫ t.app k = t.app j := by simp
+  have hπ (j : I) : c.π.app j ≫ t.app j = a ≫ f := congr(($ha).app j)
   choose V W hUV hVW using hUV
-  refine IsCofiltered.exists_forall _ ?_ fun j ↦
-    exists_resLE_comp_eq_of_isAffineOpen D t f c hc a ha (hU j) (V j) (W j) (hVW j) (hUV j)
-  rintro k₁ k₂ v u j ⟨g, hg, hg'⟩
-  have e : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
-  exact ⟨(D.map v).resLE _ _ e ≫ g, by simpa using congr((D.map v).resLE _ _ e ≫ $hg),
-    fun O h ↦ by simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)⟩
+  refine IsCofiltered.exists_forall _ ?_ fun j ↦ ?_
+  · rintro k₁ k₂ v u j ⟨g, hg, hg'⟩
+    have e : D.map (v ≫ u) ⁻¹ᵁ U j ≤ D.map v ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
+    exact ⟨(D.map v).resLE _ _ e ≫ g, by simpa using congr((D.map v).resLE _ _ e ≫ $hg),
+      fun O h ↦ by simpa [Scheme.Hom.resLE_comp_resLE_assoc] using hg' O (by simpa using h)⟩
+  obtain ⟨i', u, hu⟩ :
+      ∃ (i' : I) (u : i' ⟶ i), D.map u ⁻¹ᵁ U j ≤ t.app i' ⁻¹ᵁ (W j : S.Opens) := by
+    obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc (hU j).isCompact
+      (V := t.app i ⁻¹ᵁ (W j : S.Opens)) (by
+        rw [← Scheme.Hom.comp_preimage, hπ, Scheme.Hom.comp_preimage]
+        exact (hUV j).trans (a.preimage_mono (hVW j)))
+    exact ⟨i', u, hu.trans_eq (by rw [← Scheme.Hom.comp_preimage, hnat])⟩
+  have _ (k : Over i') : IsAffine ((opensDiagram D i' (D.map u ⁻¹ᵁ U j)).obj k) :=
+    ((hU j).preimage _).preimage _
+  let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U j) ⟶ (Functor.const (Over i')).obj (W j) :=
+    { app k := (t.app k.left).resLE _ _ ((Scheme.Hom.preimage_mono _ hu).trans_eq
+        (by rw [← Scheme.Hom.comp_preimage, hnat]))
+      naturality k l v := ((D.map v.left).resLE_comp_resLE _ (t.app l.left) _).trans
+        (Eq.trans ((cancel_mono (W j : S.Opens).ι).mp (by simp [hnat]))
+          (Category.comp_id _).symm) }
+  obtain ⟨k, g, hg, hg'⟩ :
+      ∃ (k : Over i') (g : (D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U j).toScheme ⟶ (V j : X.Opens).toScheme),
+        (c.π.app k.left).resLE _ (c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j) (by simp) ≫ g =
+            a.resLE _ _ (by simpa using hUV j) ∧ g ≫ f.resLE _ _ (hVW j) = τ.app k :=
+    Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
+      _ τ (f.resLE _ _ (hVW j)) _ (isLimitOpensCone D c hc i' _)
+      (a.resLE _ _ (by simpa using hUV j)) (by
+        ext k
+        exact ((c.π.app k.left).resLE_comp_resLE _ (t.app k.left) _).trans
+          (Eq.trans ((cancel_mono (W j : S.Opens).ι).mp (by simp [hπ]))
+            (a.resLE_comp_resLE _ f _).symm))
+  have e : D.map (k.hom ≫ u) ⁻¹ᵁ U j ≤ D.map k.hom ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simp
+  refine ⟨k.left, k.hom ≫ u, Scheme.homOfLE _ e ≫ g ≫ (V j : X.Opens).ι, ?_, fun O h ↦ ?_⟩
+  · simpa [τ] using congr(Scheme.homOfLE _ e ≫ $hg' ≫ (W j : S.Opens).ι)
+  · have h' : O ≤ c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j := by simpa using h
+    simpa using congr(Scheme.homOfLE _ h' ≫ $hg ≫ (V j : X.Opens).ι)
 
 variable [∀ i, QuasiSeparatedSpace (D.obj i)]
-
-include hc in
-private lemma exists_resLE_comp_eq_resLE_comp [LocallyOfFiniteType f]
-    {k : I} {U₁ U₂ : (D.obj k).Opens} (hU₁ : IsCompact (U₁ : Set (D.obj k)))
-    (hU₂ : IsCompact (U₂ : Set (D.obj k))) (g₁ : ↑U₁ ⟶ X) (g₂ : ↑U₂ ⟶ X)
-    (hg₁ : g₁ ≫ f = U₁.ι ≫ t.app k) (hg₂ : g₂ ≫ f = U₂.ι ≫ t.app k)
-    (h : ∀ (O : c.pt.Opens) (e₁ : O ≤ c.π.app k ⁻¹ᵁ U₁) (e₂ : O ≤ c.π.app k ⁻¹ᵁ U₂),
-      (c.π.app k).resLE U₁ O e₁ ≫ g₁ = (c.π.app k).resLE U₂ O e₂ ≫ g₂) :
-    ∃ (l : I) (v : l ⟶ k), ∀ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U₁)
-      (e₂ : O ≤ D.map v ⁻¹ᵁ U₂), (D.map v).resLE U₁ O e₁ ≫ g₁ = (D.map v).resLE U₂ O e₂ ≫ g₂ := by
-  have _ (x) : CompactSpace ((opensDiagram D k (U₁ ⊓ U₂)).obj x) :=
-    isCompact_iff_compactSpace.mp (QuasiCompact.isCompact_preimage _ (U₁ ⊓ U₂).isOpen
-      (hU₁.inter_of_isOpen hU₂ U₁.2 U₂.2))
-  let U₀ : (D.obj k).Opens := D.map (𝟙 k) ⁻¹ᵁ (U₁ ⊓ U₂)
-  let a₁ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ g₁
-  let a₂ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ g₂
-  have ha₁ : U₀.ι ≫ t.app k = a₁ ≫ f := by simp [a₁, hg₁]
-  have ha₂ : U₀.ι ≫ t.app k = a₂ ≫ f := by simp [a₂, hg₂]
-  have hab : (c.π.app k).resLE U₀ (c.π.app k ⁻¹ᵁ (U₁ ⊓ U₂)) (by simp [U₀]) ≫ a₁ =
-      (c.π.app k).resLE U₀ (c.π.app k ⁻¹ᵁ (U₁ ⊓ U₂)) (by simp [U₀]) ≫ a₂ := by
-    simp only [a₁, a₂, Scheme.Hom.resLE_map_assoc]
-    exact h _ _ _
-  obtain ⟨⟨l, ⟨⟨⟩⟩, v⟩, ⟨v', ⟨⟨⟨⟩⟩⟩, hv⟩, e⟩ :=
-    Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
-      _ (opensDiagramι .. ≫ (Over.forget k).whiskerLeft t) f _
-      (isLimitOpensCone D c hc k (U₁ ⊓ U₂)) (i := .mk (𝟙 k)) a₁ a₂ ha₁ ha₂ hab
-  obtain rfl : v = v' := by simpa using! hv.symm
-  replace e : (D.map v).resLE U₀ (D.map v ⁻¹ᵁ (U₁ ⊓ U₂)) (by simp [U₀]) ≫ a₁ =
-      (D.map v).resLE U₀ (D.map v ⁻¹ᵁ (U₁ ⊓ U₂)) (by simp [U₀]) ≫ a₂ := e
-  refine ⟨l, v, fun O e₁ e₂ ↦ ?_⟩
-  simpa [a₁, a₂] using congr(Scheme.homOfLE _
-    (show O ≤ D.map v ⁻¹ᵁ (U₁ ⊓ U₂) from le_inf e₁ e₂) ≫ $e)
 
 include hc in
 private lemma exists_forall_resLE_comp_eq_resLE_comp [LocallyOfFiniteType f]
@@ -1295,17 +1253,38 @@ private lemma exists_forall_resLE_comp_eq_resLE_comp [LocallyOfFiniteType f]
       (c.π.app k).resLE _ O e₁ ≫ g j₁ = (c.π.app k).resLE _ O e₂ ≫ g j₂) :
     ∃ (l : I) (v : l ⟶ k), ∀ j₁ j₂ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U j₁)
       (e₂ : O ≤ D.map v ⁻¹ᵁ U j₂),
-        (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ :=
-  Exists₂.imp (fun _ _ hl j₁ j₂ ↦ hl (j₁, j₂)) <| IsCofiltered.exists_forall
+        (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ := by
+  refine Exists₂.imp (fun _ _ hl j₁ j₂ ↦ hl (j₁, j₂)) (IsCofiltered.exists_forall
     (fun l (v : l ⟶ k) (j : J × J) ↦ ∀ (O : (D.obj l).Opens) (e₁ : O ≤ D.map v ⁻¹ᵁ U j.1)
       (e₂ : O ≤ D.map v ⁻¹ᵁ U j.2),
-        (D.map v).resLE _ O e₁ ≫ g j.1 = (D.map v).resLE _ O e₂ ≫ g j.2)
-    (fun w v j hv O e₁ e₂ ↦ by
+        (D.map v).resLE _ O e₁ ≫ g j.1 = (D.map v).resLE _ O e₂ ≫ g j.2) ?_ ?_)
+  · exact fun w v j hv O e₁ e₂ ↦ by
       simpa [Scheme.Hom.resLE_comp_resLE_assoc] using congr((D.map w).resLE _ O
         (show O ≤ D.map w ⁻¹ᵁ _ by simpa [Scheme.Hom.preimage_inf] using le_inf e₁ e₂) ≫
-          $(hv _ inf_le_left inf_le_right)))
-    fun j ↦ exists_resLE_comp_eq_resLE_comp D t f c hc (hU j.1) (hU j.2) _ _ (hg j.1) (hg j.2)
-      (h j.1 j.2)
+          $(hv _ inf_le_left inf_le_right))
+  rintro ⟨j₁, j₂⟩
+  have _ (x) : CompactSpace ((opensDiagram D k (U j₁ ⊓ U j₂)).obj x) :=
+    isCompact_iff_compactSpace.mp (QuasiCompact.isCompact_preimage _ (U j₁ ⊓ U j₂).isOpen
+      ((hU j₁).inter_of_isOpen (hU j₂) (U j₁).2 (U j₂).2))
+  let U₀ : (D.obj k).Opens := D.map (𝟙 k) ⁻¹ᵁ (U j₁ ⊓ U j₂)
+  let a₁ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ g j₁
+  let a₂ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ g j₂
+  have ha₁ : U₀.ι ≫ t.app k = a₁ ≫ f := by simp [a₁, hg]
+  have ha₂ : U₀.ι ≫ t.app k = a₂ ≫ f := by simp [a₂, hg]
+  have hab : (c.π.app k).resLE U₀ (c.π.app k ⁻¹ᵁ (U j₁ ⊓ U j₂)) (by simp [U₀]) ≫ a₁ =
+      (c.π.app k).resLE U₀ (c.π.app k ⁻¹ᵁ (U j₁ ⊓ U j₂)) (by simp [U₀]) ≫ a₂ := by
+    simp only [a₁, a₂, Scheme.Hom.resLE_map_assoc]
+    exact h j₁ j₂ _ _ _
+  obtain ⟨⟨l, ⟨⟨⟩⟩, v⟩, ⟨v', ⟨⟨⟨⟩⟩⟩, hv⟩, e⟩ :=
+    Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
+      _ (opensDiagramι .. ≫ (Over.forget k).whiskerLeft t) f _
+      (isLimitOpensCone D c hc k (U j₁ ⊓ U j₂)) (i := .mk (𝟙 k)) a₁ a₂ ha₁ ha₂ hab
+  obtain rfl : v = v' := by simpa using! hv.symm
+  replace e : (D.map v).resLE U₀ (D.map v ⁻¹ᵁ (U j₁ ⊓ U j₂)) (by simp [U₀]) ≫ a₁ =
+      (D.map v).resLE U₀ (D.map v ⁻¹ᵁ (U j₁ ⊓ U j₂)) (by simp [U₀]) ≫ a₂ := e
+  refine ⟨l, v, fun O e₁ e₂ ↦ ?_⟩
+  simpa [a₁, a₂] using congr(Scheme.homOfLE _
+    (show O ≤ D.map v ⁻¹ᵁ (U j₁ ⊓ U j₂) from le_inf e₁ e₂) ≫ $e)
 
 open TopologicalSpace in
 include hc ha in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -82,18 +82,18 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
         MorphismProperty.pullback_snd _ _ inferInstance
       isAffine_of_isAffineHom (pullback.snd (D.map i'.hom) (𝒰.f j))
     have (i' : _) : Nonempty (F.obj i') := H i'.hom
-    let e : F ⟶ (F ⋙ Scheme.Γ.rightOp) ⋙ Scheme.Spec := Functor.whiskerLeft F ΓSpec.adjunction.unit
+    let e : F ⟶ (F ⋙ Γ.rightOp) ⋙ Scheme.Spec := Functor.whiskerLeft F ΓSpec.adjunction.unit
     have (i : _) : IsIso (e.app i) := IsAffine.affine
     have : IsIso e := NatIso.isIso_of_isIso_app e
     let c' : LimitCone F := ⟨_, (IsLimit.postcomposeInvEquiv (asIso e) _).symm
-      (isLimitOfPreserves Scheme.Spec (limit.isLimit (F ⋙ Scheme.Γ.rightOp)))⟩
+      (isLimitOfPreserves Scheme.Spec (limit.isLimit (F ⋙ Γ.rightOp)))⟩
     have : Nonempty c'.1.pt := by
       apply +allowSynthFailures PrimeSpectrum.instNonemptyOfNontrivial
-      have (i' : _) : Nontrivial ((F ⋙ Scheme.Γ.rightOp).leftOp.obj i') := by
-        apply +allowSynthFailures Scheme.component_nontrivial
+      have (i' : _) : Nontrivial ((F ⋙ Γ.rightOp).leftOp.obj i') := by
+        apply +allowSynthFailures component_nontrivial
         simp
       exact CommRingCat.FilteredColimits.nontrivial
-        (isColimitCoconeLeftOpOfCone _ (limit.isLimit (F ⋙ Scheme.Γ.rightOp)))
+        (isColimitCoconeLeftOpOfCone _ (limit.isLimit (F ⋙ Γ.rightOp)))
     let α : F ⟶ Over.forget _ ⋙ D := Functor.whiskerRight
       (Functor.whiskerLeft (Over.post D) (Over.mapPullbackAdj (𝒰.f j)).counit) (Over.forget _)
     exact this.map (((Functor.Initial.isLimitWhiskerEquiv (Over.forget i) c).symm hc).lift
@@ -438,17 +438,17 @@ private nonrec lemma Scheme.exists_hom_hom_comp_eq_comp_of_isAffine_of_locallyOf
   obtain ⟨S, rfl⟩ := hX
   obtain ⟨φ, rfl⟩ := Spec.map_surjective f
   wlog hD : ∃ D' : I ⥤ CommRingCatᵒᵖ, D = D' ⋙ Scheme.Spec generalizing D
-  · let e : D ⟶ D ⋙ Scheme.Γ.rightOp ⋙ Scheme.Spec := D.whiskerLeft ΓSpec.adjunction.unit
+  · let e : D ⟶ D ⋙ Γ.rightOp ⋙ Scheme.Spec := D.whiskerLeft ΓSpec.adjunction.unit
     have inst (i) : IsIso (e.app i) := by dsimp [e]; infer_instance
     have inst : IsIso e := NatIso.isIso_of_isIso_app e
-    have inst (i) : IsAffine ((D ⋙ Scheme.Γ.rightOp ⋙ Scheme.Spec).obj i) := by
+    have inst (i) : IsAffine ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj i) := by
       dsimp; infer_instance
     have inst : IsAffine ((Cone.postcompose (asIso e).hom).obj c).pt := by
       dsimp; infer_instance
-    have := this (D ⋙ Scheme.Γ.rightOp ⋙ Scheme.Spec) ((Cone.postcompose (asIso e).hom).obj c)
+    have := this (D ⋙ Γ.rightOp ⋙ Scheme.Spec) ((Cone.postcompose (asIso e).hom).obj c)
       ((IsLimit.postcomposeHomEquiv (asIso e) c).symm hc) (inv e ≫ t)
       ((inv e).app _ ≫ a) ((inv e).app _ ≫ b) (by simp [hab]) (by simp [ha]) (by simp [hb])
-      ⟨D ⋙ Scheme.Γ.rightOp, rfl⟩
+      ⟨D ⋙ Γ.rightOp, rfl⟩
     simp_rw [(inv e).naturality_assoc] at this
     simpa using! this
   obtain ⟨D, rfl⟩ := hD
@@ -640,10 +640,12 @@ end ExistsHomHomCompEqCompAux
 
 variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
 
+namespace Scheme
+
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
-lemma Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
+lemma exists_hom_comp_eq_comp_of_locallyOfFiniteType
     {i : I} (a b : D.obj i ⟶ X) (ha : t.app i = a ≫ f) (hb : t.app i = b ≫ f)
     (hab : c.π.app i ≫ a = c.π.app i ≫ b) :
     ∃ (k : I) (hik : k ⟶ i), D.map hik ≫ a = D.map hik ≫ b := by
@@ -651,9 +653,9 @@ lemma Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
   have := isAffineHom_π_app _ _ hc
   let A : ExistsHomHomCompEqCompAux D t f :=
     { c := c, hc := hc, i := i, a := a, ha := ha, b := b, hb := hb, hab := hab
-      𝒰S := S.affineCover, 𝒰X i := Scheme.affineCover _ }
-  let 𝒰 := Scheme.Pullback.diagonalCover f A.𝒰S A.𝒰X
-  let W := Scheme.Pullback.diagonalCoverDiagonalRange f A.𝒰S A.𝒰X
+      𝒰S := S.affineCover, 𝒰X i := affineCover _ }
+  let 𝒰 := Pullback.diagonalCover f A.𝒰S A.𝒰X
+  let W := Pullback.diagonalCoverDiagonalRange f A.𝒰S A.𝒰X
   choose k hki' heq using A.exists_eq
   let 𝒰Df := A.𝒰D.finiteSubcover
   rcases isEmpty_or_nonempty (D.obj A.i') with h | h
@@ -697,14 +699,14 @@ same map `Homₛ(lim Dᵢ, X)`, there exists a `k` with `fᵢ : k ⟶ i` and `f�
 `D(fᵢ) ≫ a = D(fⱼ) ≫ b`.
 -/
 @[stacks 01ZC "Injective part of (1) => (3)"]
-lemma Scheme.exists_hom_hom_comp_eq_comp_of_locallyOfFiniteType
+lemma exists_hom_hom_comp_eq_comp_of_locallyOfFiniteType
     {i : I} (a : D.obj i ⟶ X) (ha : t.app i = a ≫ f)
     {j : I} (b : D.obj j ⟶ X) (hb : t.app j = b ≫ f)
     (hab : c.π.app i ≫ a = c.π.app j ≫ b) :
     ∃ (k : I) (hik : k ⟶ i) (hjk : k ⟶ j),
       D.map hik ≫ a = D.map hjk ≫ b := by
   let o := IsCofiltered.min i j
-  obtain ⟨k, hik, heq⟩ := Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType D t f c hc
+  obtain ⟨k, hik, heq⟩ := exists_hom_comp_eq_comp_of_locallyOfFiniteType D t f c hc
     (D.map (IsCofiltered.minToLeft i j) ≫ a) (D.map (IsCofiltered.minToRight i j) ≫ b)
     (by simp [← ha])
     (by simp [← hb]) (by simpa)
@@ -713,7 +715,7 @@ lemma Scheme.exists_hom_hom_comp_eq_comp_of_locallyOfFiniteType
 
 omit [∀ i, CompactSpace (D.obj i)] in
 include hc in
-lemma Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType
+lemma exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType
     {i : I} {U : (D.obj i).Opens} (hU : IsCompact (X := D.obj i) U) (a b : ↑U ⟶ X)
     (ha : U.ι ≫ t.app i = a ≫ f) (hb : U.ι ≫ t.app i = b ≫ f)
     (hab : (c.π.app i).resLE U _ le_rfl ≫ a = (c.π.app i).resLE U _ le_rfl ≫ b) :
@@ -727,15 +729,17 @@ lemma Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType
   have hab₀ : (c.π.app i).resLE (D.map (𝟙 i) ⁻¹ᵁ U) _ (by simp) ≫ Scheme.homOfLE _ h ≫ a =
       (c.π.app i).resLE (D.map (𝟙 i) ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U) (by simp) ≫
         Scheme.homOfLE _ h ≫ b := by
-    simp only [Scheme.Hom.resLE_map_assoc]
+    simp only [Hom.resLE_map_assoc]
     exact hab
-  obtain ⟨⟨k, _, u⟩, ⟨u', _, hu⟩, e⟩ := Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
+  obtain ⟨⟨k, _, u⟩, ⟨u', _, hu⟩, e⟩ := exists_hom_comp_eq_comp_of_locallyOfFiniteType
     _ (opensDiagramι .. ≫ (Over.forget i).whiskerLeft t) f _ (isLimitOpensCone D c hc i U)
     (i := .mk (𝟙 i)) _ _ (hres a ha) (hres b hb) hab₀
   obtain rfl : u = u' := by simpa using! hu.symm
   replace e : (D.map u).resLE _ (D.map u ⁻¹ᵁ U) (by simp) ≫ Scheme.homOfLE _ h ≫ a =
       (D.map u).resLE _ (D.map u ⁻¹ᵁ U) (by simp) ≫ Scheme.homOfLE _ h ≫ b := e
   exact ⟨k, u, by simpa using e⟩
+
+end Scheme
 
 end LocallyOfFiniteType
 
@@ -832,7 +836,7 @@ variable [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)]
 
 open TopologicalSpace in
 include hc in
-private lemma exists_isOpenCover_app_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) :
+private lemma Scheme.exists_isOpenCover_app_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) :
     ∃ (k : I) (J : Type u) (U : J → (D.obj k).Opens) (_ : IsOpenCover U)
       (t : ∀ x, Γ(D.obj k, U x)), (D.obj k).presheaf.IsCompatible U t ∧
         ∀ x, (c.π.app k).app (U x) (t x) = s |_ (c.π.app k ⁻¹ᵁ U x) := by
@@ -842,39 +846,40 @@ private lemma exists_isOpenCover_app_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) 
   obtain ⟨n, w, hT⟩ : ∃ (n : I) (w : n ⟶ i), ∀ W : Us, ∃ T : Γ(D.obj n, D.map w ⁻¹ᵁ W.1.1),
       (c.π.app n).appLE _ (c.π.app i ⁻¹ᵁ W.1.1) (by simp) T = s |_ _ :=
     IsCofiltered.exists_forall (fun v u W ⟨T, hT⟩ ↦ ⟨(D.map v).appLE _ _ (by simp) T, by
-      simpa only [Scheme.Hom.appLE_appLE, Cone.w] using hT⟩)
+      simpa only [Hom.appLE_appLE, Cone.w] using hT⟩)
       fun W ↦ exists_appLE_π_eq_of_isAffineOpen D c hc W.1.2 (s |_ _)
   choose T hT using hT
   replace hT (W : Us) {V : c.pt.Opens} (e : V ≤ c.π.app n ⁻¹ᵁ D.map w ⁻¹ᵁ W.1.1) :
       (c.π.app n).appLE _ V e (T W) = s |_ V := by
     have h := π_app_preimage_map_preimage D c w W.1.1
-    rw [← Scheme.Hom.restrict_appLE _ h.ge (e.trans_eq h), hT W, TopCat.Presheaf.restrict_restrict]
+    rw [← Hom.restrict_appLE _ h.ge (e.trans_eq h), hT W, TopCat.Presheaf.restrict_restrict]
   obtain ⟨k, v, hv⟩ : ∃ (k : I) (v : k ⟶ n), ∀ (W₁ W₂ : Us) (V : (D.obj k).Opens)
       (h₁ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1.1) (h₂ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1.1),
         (D.map v).appLE _ V h₁ (T W₁) = (D.map v).appLE _ V h₂ (T W₂) := by
     refine IsCofiltered.exists_forall₂ ?_ fun W₁ W₂ ↦ ?_
     · intros _ _ v u W₁ W₂ hv V h₁ h₂
-      simpa [Scheme.Hom.appLE_appLE, -Scheme.Hom.comp_appLE] using
+      simpa [Hom.appLE_appLE, -Hom.comp_appLE] using
         congr((D.map v).appLE _ V ((le_inf h₁ h₂).trans_eq (by rw [D.map_comp]; rfl))
           $(hv _ inf_le_left inf_le_right))
     refine Exists₂.imp (fun k v hv V h₁ h₂ ↦ ?_) (exists_app_map_eq_map_of_isLimit D c hc
       ((W₁.1.2.preimage (D.map w)).isCompact_inf (W₂.1.2.preimage (D.map w)))
       (T W₁ |_ _) (T W₂ |_ _) (by
-        simpa [Scheme.Hom.app_restrict, ← Scheme.Hom.appLE_apply] using
+        simpa [Hom.app_restrict, ← Hom.appLE_apply] using
           (hT W₁ _).trans (hT W₂ _).symm))
-    simpa [Scheme.Hom.app_restrict, Scheme.Hom.appLE_apply, TopCat.Presheaf.restrict_restrict]
+    simpa [Hom.app_restrict, Hom.appLE_apply, TopCat.Presheaf.restrict_restrict]
       using congr($hv |_ₗ V ⟪(le_inf h₁ h₂).trans_eq (D.map v).preimage_inf.symm⟫)
   refine ⟨k, Us, fun W ↦ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W.1.1,
     (hcov.preimage (D.map w)).preimage (D.map v), fun W ↦ (D.map v).app _ (T W),
     fun W₁ W₂ ↦ ?_, fun W ↦ ?_⟩
-  · simpa [Opens.infLELeft, Opens.infLERight, Scheme.Hom.appLE] using
+  · simpa [Opens.infLELeft, Opens.infLERight, Hom.appLE] using
       hv W₁ W₂ _ inf_le_left inf_le_right
-  · simpa only [Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_appLE, Cone.w] using hT W _
+  · simpa only [Hom.app_eq_appLE, Hom.appLE_appLE, Cone.w] using hT W _
 
 include hc in
 lemma exists_appTop_π_eq_of_isLimit (s : Γ(c.pt, ⊤)) :
     ∃ (i : I) (t : Γ(D.obj i, ⊤)), s = (c.π.app i).appTop t := by
-  obtain ⟨k, J, U, hU, t, hcompat, ht⟩ := exists_isOpenCover_app_eq_restrict_of_isLimit D c hc s
+  obtain ⟨k, J, U, hU, t, hcompat, ht⟩ :=
+    Scheme.exists_isOpenCover_app_eq_restrict_of_isLimit D c hc s
   obtain ⟨t₀, ht₀, -⟩ := TopCat.Sheaf.existsUnique_gluing' ⟨_, (D.obj k).IsSheaf⟩ U ⊤
     (fun _ ↦ homOfLE le_top) hU.ge t hcompat
   refine ⟨k, t₀, TopCat.Sheaf.eq_of_locally_eq' ⟨_, c.pt.IsSheaf⟩ (fun x ↦ c.π.app k ⁻¹ᵁ U x) ⊤
@@ -915,7 +920,7 @@ lemma Scheme.exists_isQuasiAffine_of_isLimit [IsCofiltered I]
     ∃ i, IsQuasiAffine (D.obj i) := by
   classical
   have (x : c.pt) : ∃ (i : I) (f : Γ(D.obj i, ⊤)),
-      IsAffineOpen (Scheme.basicOpen _ f) ∧ c.π.app i x ∈ (Scheme.basicOpen _ f) := by
+      IsAffineOpen ((D.obj i).basicOpen f) ∧ c.π.app i x ∈ (D.obj i).basicOpen f := by
     obtain ⟨i⟩ := IsCofiltered.nonempty (C := I)
     obtain ⟨_, ⟨U, hU, rfl⟩, hxU, -⟩ := (D.obj i).isBasis_affineOpens.exists_subset_of_mem_open
       (Set.mem_univ (c.π.app i x)) isOpen_univ
@@ -931,11 +936,11 @@ lemma Scheme.exists_isQuasiAffine_of_isLimit [IsCofiltered I]
     · convert!
       (hU.preimage (D.map (flk ≫ fki))).basicOpen
         ((D.obj _).presheaf.map (homOfLE le_top).op ((D.map (flk ≫ fkj)).appTop r)) using 1
-      rwa [Scheme.basicOpen_res, eq_comm, inf_eq_right, Functor.map_comp,
-        elementwise_of% Scheme.Hom.comp_appTop, ← Scheme.preimage_basicOpen_top, Functor.map_comp,
-        Scheme.Hom.comp_preimage]
+      rwa [basicOpen_res, eq_comm, inf_eq_right, Functor.map_comp,
+        elementwise_of% Hom.comp_appTop, ← preimage_basicOpen_top, Functor.map_comp,
+        Hom.comp_preimage]
     · change x ∈ c.π.app l ⁻¹ᵁ (D.obj l).basicOpen _
-      rwa [Scheme.preimage_basicOpen_top, ← elementwise_of% Scheme.Hom.comp_appTop, Cone.w]
+      rwa [preimage_basicOpen_top, ← elementwise_of% Hom.comp_appTop, Cone.w]
   choose i f hf hi using this
   obtain ⟨σ, hσ⟩ := CompactSpace.elim_nhds_subcover
     (fun x ↦ (((c.π.app (i x)) ⁻¹ᵁ (D.obj (i x)).basicOpen (f x)).1))
@@ -952,7 +957,7 @@ lemma Scheme.exists_isQuasiAffine_of_isLimit [IsCofiltered I]
   refine ⟨k, .of_forall_exists_mem_basicOpen _ fun x ↦ ?_⟩
   obtain ⟨y, hy⟩ := TopologicalSpace.Opens.mem_iSup.mp (hk.ge (Set.mem_univ x))
   use (D.map fkj).appTop ((D.map (fj _ (Finset.mem_image_of_mem i (hσiσ y)))).appTop (f _))
-  rw [← Scheme.preimage_basicOpen_top, ← Scheme.preimage_basicOpen_top]
+  rw [← preimage_basicOpen_top, ← preimage_basicOpen_top]
   exact ⟨((hf _).preimage _).preimage _, hy⟩
 
 set_option backward.defeqAttrib.useBackward true in
@@ -968,12 +973,12 @@ lemma Scheme.exists_isAffine_of_isLimit [IsCofiltered I]
     [IsAffine c.pt] :
     ∃ i, IsAffine (D.obj i) := by
   have := isAffineHom_π_app _ _ hc
-  obtain ⟨i, hi⟩ := Scheme.exists_isQuasiAffine_of_isLimit D c hc
+  obtain ⟨i, hi⟩ := exists_isQuasiAffine_of_isLimit D c hc
   have : ∀ {i j : I} (f : i ⟶ j), IsAffineHom ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).map f) := by
     dsimp; infer_instance
   have (j : _) : CompactSpace ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj j) := by dsimp; infer_instance
   obtain ⟨j, fij, hj⟩ := exists_map_eq_top _ _
-    (isLimitOfPreserves (Scheme.Γ.rightOp ⋙ Scheme.Spec) hc) (D.obj i).toSpecΓ.opensRange
+    (isLimitOfPreserves (Γ.rightOp ⋙ Scheme.Spec) hc) (D.obj i).toSpecΓ.opensRange
     ((preimage_opensRange_toSpecΓ (X := c.pt) (c.π.app i)).trans
       (by simp [Hom.opensRange_of_isIso]))
   have := IsQuasiAffine.of_isAffineHom (D.map fij)
@@ -997,9 +1002,11 @@ lemma exists_isAffineOpen_preimage_eq
   obtain ⟨j, hj⟩ := Scheme.exists_isAffine_of_isLimit _ _ (isLimitOpensCone D c hc i U)
   exact ⟨_, _, hj, by simp [← Scheme.Hom.comp_preimage]⟩
 
+namespace Scheme
+
 open TopologicalSpace in
 include hc in
-lemma Scheme.exists_isOpenCover_and_isAffine_of_finite [IsCofiltered I]
+lemma exists_isOpenCover_and_isAffine_of_finite [IsCofiltered I]
     [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [∀ (i : I), CompactSpace (D.obj i)]
     [∀ (i : I), QuasiSeparatedSpace (D.obj i)]
     {J : Type*} [Finite J] (U : J → c.pt.Opens) (hU : IsOpenCover U)
@@ -1022,7 +1029,7 @@ open TopologicalSpace in
 include hc in
 /-- Suppose `{ Xᵢ }` is an inverse system of qcqs schemes with affine transition maps.
 Then any affine open cover of `lim Xᵢ` comes from a finite level. -/
-lemma Scheme.exists_isOpenCover_and_isAffine [IsCofiltered I]
+lemma exists_isOpenCover_and_isAffine [IsCofiltered I]
     [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
     [∀ (i : I), CompactSpace (D.obj i)]
     [∀ (i : I), QuasiSeparatedSpace (D.obj i)]
@@ -1035,21 +1042,21 @@ lemma Scheme.exists_isOpenCover_and_isAffine [IsCofiltered I]
   have hU : IsOpenCover fun j : s ↦ U ↑j := by
     simpa only [IsOpenCover, eq_top_iff, ← SetLike.coe_subset_coe, Opens.coe_top, Opens.iSup_mk,
       Opens.carrier_eq_coe, Opens.coe_mk, Set.iUnion_subtype]
-  obtain ⟨i, V, hV, heq⟩ := Scheme.exists_isOpenCover_and_isAffine_of_finite _ _ hc _ hU (hU' ·)
+  obtain ⟨i, V, hV, heq⟩ := exists_isOpenCover_and_isAffine_of_finite _ _ hc _ hU (hU' ·)
   use i, s, V, hV
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 include hc in
 /-- Variant of `Scheme.exists_isOpenCover_and_isAffine_of_finite` in terms of `Scheme.OpenCover`. -/
-lemma Scheme.OpenCover.exists_of_isCofiltered_of_finite [IsCofiltered I]
+lemma OpenCover.exists_of_isCofiltered_of_finite [IsCofiltered I]
     [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] [∀ (i : I), CompactSpace (D.obj i)]
     [∀ (i : I), QuasiSeparatedSpace (D.obj i)]
     (𝒰 : OpenCover.{w} c.pt) [∀ i, IsAffine (𝒰.X i)] [Finite 𝒰.I₀] :
     ∃ (i : I) (R : 𝒰.I₀ → CommRingCat.{u}) (f : ∀ (a : 𝒰.I₀), Spec (R a) ⟶ (D.obj i))
       (_ : Presieve.ofArrows _ f ∈ zariskiPrecoverage _) (g : ∀ (j : 𝒰.I₀), 𝒰.X j ⟶ Spec (R j)),
       ∀ (j : 𝒰.I₀), IsPullback (g j) (𝒰.f j) (f j) (c.π.app i) := by
-  obtain ⟨i, V, hV, hV'⟩ := Scheme.exists_isOpenCover_and_isAffine_of_finite _ _ hc _
+  obtain ⟨i, V, hV, hV'⟩ := exists_isOpenCover_and_isAffine_of_finite _ _ hc _
     𝒰.isOpenCover_opensRange fun k ↦ isAffineOpen_opensRange (𝒰.f k)
   have hV'' (k) := dsimp% congr($((hV' k).right).carrier)
   refine ⟨i, fun k ↦ Γ(_, V k), fun k ↦ (hV' k).left.isoSpec.inv ≫ (V k).ι, ?_, ?_, ?_⟩
@@ -1061,43 +1068,45 @@ lemma Scheme.OpenCover.exists_of_isCofiltered_of_finite [IsCofiltered I]
       (hV' k).left.isoSpec.hom
   · intro k
     dsimp
-    refine ⟨⟨?_⟩, ⟨PullbackCone.IsLimit.mk _ ?_ ?_ ?_ ?_⟩⟩
+    refine ⟨⟨?_⟩, ⟨PullbackCone.IsLimit.mk _ (fun s ↦ ?_) ?_ ?_ ?_⟩⟩
     · simp [← IsAffineOpen.isoSpec_inv_ι]
-    · intro s
-      refine IsOpenImmersion.lift (𝒰.f k) s.snd ?_
+    · refine IsOpenImmersion.lift (𝒰.f k) s.snd ?_
       simp only [hV'', Set.range_subset_iff, Set.mem_preimage, SetLike.mem_coe]
-      intro y
-      rw [← Scheme.Hom.comp_apply, ← s.condition]
+      simp_rw [← Hom.comp_apply, ← s.condition]
       simp [← IsAffineOpen.isoSpec_inv_ι]
     · simp [← cancel_mono (hV' _).left.isoSpec.inv, ← cancel_mono (V k).ι, PullbackCone.condition]
     · simp
     · simp [← cancel_mono (𝒰.f k)]
 
+end Scheme
+
 end IsAffine
 
 section LocallyOfFinitePresentation
+
+namespace Scheme
 
 variable [IsCofiltered I] (a : c.pt ⟶ X)
   (ha : c.π ≫ t = (Functor.const _).map (a ≫ f))
 
 include hc ha in
 /-- See `Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation` for the general case. -/
-private nonrec lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
+private lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
     [LocallyOfFinitePresentation f] [IsAffine S] [IsAffine X] [∀ i, IsAffine (D.obj i)] :
     ∃ (i : I) (g : D.obj i ⟶ X), c.π.app i ≫ g = a ∧ g ≫ f = t.app i := by
   -- Every scheme involved is affine, so the proof is merely translate to commutative algebra and
   -- use `RingHom.EssFiniteType.exists_eq_comp_ι_app_of_isColimit`.
   have : ∀ i, IsAffine (D.op.obj i).unop := fun i ↦ by dsimp; infer_instance
-  let α : (Functor.const Iᵒᵖ).obj Γ(S, ⊤) ⟶ D.op ⋙ Scheme.Γ :=
+  let α : (Functor.const Iᵒᵖ).obj Γ(S, ⊤) ⟶ D.op ⋙ Γ :=
     { app := fun i ↦ (t.app i.unop).appTop
       naturality := fun _ _ u ↦ by
-        have h := congr(Scheme.Hom.appTop $(t.naturality u.unop))
-        simp only [Scheme.Hom.comp_appTop, Functor.const_obj_map, Scheme.Hom.id_appTop] at h ⊢
+        have h := congr(Hom.appTop $(t.naturality u.unop))
+        simp only [Hom.comp_appTop, Functor.const_obj_map, Hom.id_appTop] at h ⊢
         exact h.symm }
   obtain ⟨i, φ, hφ, hφ'⟩ := RingHom.EssFiniteType.exists_eq_comp_ι_app_of_isColimit
-    Γ(S, ⊤) (D.op ⋙ Scheme.Γ) α f.appTop _ (isColimitOfPreserves Scheme.Γ hc.op)
+    Γ(S, ⊤) (D.op ⋙ Γ) α f.appTop _ (isColimitOfPreserves Γ hc.op)
     (HasRingHomProperty.iff_of_isAffine.mp ‹LocallyOfFinitePresentation f›) a.appTop fun i ↦ by
-      simpa [α] using congr(Scheme.Hom.appTop $(congr(($ha).app i.unop))).symm
+      simpa [α] using congr(Hom.appTop $(congr(($ha).app i.unop))).symm
   obtain ⟨g, rfl⟩ := exists_appTop_eq_of_isAffine φ
   exact ⟨i.unop, g, ext_of_isAffine (by simpa using hφ'.symm),
     ext_of_isAffine (by simpa [α] using hφ)⟩
@@ -1125,19 +1134,19 @@ private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
       by simp [hg, hnat], fun O h ↦ by simpa using hg' O (h.trans (by simp))⟩) fun j ↦ ?_
     obtain ⟨i', u, hu⟩ := exists_map_preimage_le_map_preimage D c hc (hU j).isCompact
       (V := t.app i ⁻¹ᵁ (W j : S.Opens))
-      (by simpa only [← Scheme.Hom.comp_preimage, hπ] using (hUV j).trans (a.preimage_mono (hVW j)))
+      (by simpa only [← Hom.comp_preimage, hπ] using (hUV j).trans (a.preimage_mono (hVW j)))
     have _ (k : Over i') : IsAffine ((opensDiagram D i' (D.map u ⁻¹ᵁ U j)).obj k) :=
       ((hU j).preimage _).preimage _
     let τ : opensDiagram D i' (D.map u ⁻¹ᵁ U j) ⟶ (Functor.const (Over i')).obj (W j) :=
-      { app k := (t.app k.left).resLE _ _ ((Scheme.Hom.preimage_mono _ hu).trans_eq
-          (by simp only [← Scheme.Hom.comp_preimage, hnat]))
+      { app k := (t.app k.left).resLE _ _ ((Hom.preimage_mono _ hu).trans_eq
+          (by simp only [← Hom.comp_preimage, hnat]))
         naturality k l v := by
           change (D.map v.left).resLE _ _ _ ≫ (t.app l.left).resLE (W j : S.Opens) _ _ = _ ≫ 𝟙 _
           simp [hnat] }
     obtain ⟨k, g, hg, hg'⟩ : ∃ (k : Over i') (g : _ ⟶ (V j : X.Opens).toScheme),
         (c.π.app k.left).resLE _ (c.π.app i' ⁻¹ᵁ D.map u ⁻¹ᵁ U j) (by simp) ≫ g =
           a.resLE _ _ (by simpa using hUV j) ∧ g ≫ f.resLE _ _ (hVW j) = τ.app k :=
-      Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
+      exists_π_app_comp_eq_of_locallyOfFinitePresentation_of_isAffine
         _ τ (f.resLE _ _ (hVW j)) _ (isLimitOpensCone D c hc i' _)
         (a.resLE _ _ (by simpa using hUV j)) (by
           ext k
@@ -1154,14 +1163,14 @@ private lemma exists_forall_homOfLE_comp_eq_of_isAffineOpen :
         (D.map v).resLE _ O e₁ ≫ g j₁ = (D.map v).resLE _ O e₂ ≫ g j₂ := by
     refine IsCofiltered.exists_forall₂ (fun w v j₁ j₂ hv O e₁ e₂ ↦ by
       simpa using congr((D.map w).resLE _ O ((le_inf e₁ e₂).trans_eq
-        (by simp [Scheme.Hom.preimage_inf])) ≫ $(hv _ inf_le_left inf_le_right))) fun j₁ j₂ ↦ ?_
-    obtain ⟨l, v, e⟩ := Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType D t f c hc
+        (by simp [Hom.preimage_inf])) ≫ $(hv _ inf_le_left inf_le_right))) fun j₁ j₂ ↦ ?_
+    obtain ⟨l, v, e⟩ := exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType D t f c hc
       (((hU j₁).preimage (D.map u)).isCompact_inf ((hU j₂).preimage (D.map u)))
       (Scheme.homOfLE _ inf_le_left ≫ g j₁) (Scheme.homOfLE _ inf_le_right ≫ g j₂)
       (by simp [hg]) (by simp [hg]) (by simpa using (hg' j₁ _ _).trans (hg' j₂ _ _).symm)
     exact ⟨l, v, fun O e₁ e₂ ↦ by
-      simpa using congr(Scheme.homOfLE _
-        ((le_inf e₁ e₂).trans_eq (by simp [Scheme.Hom.preimage_inf])) ≫ $e)⟩
+      simpa using
+        congr(Scheme.homOfLE _ ((le_inf e₁ e₂).trans_eq (by simp [Hom.preimage_inf])) ≫ $e)⟩
   exact ⟨l, v ≫ u, fun j ↦ (D.map v).resLE _ (D.map (v ≫ u) ⁻¹ᵁ U j) (by simp) ≫ g j,
     fun j ↦ by simp [hg, hnat], fun j ↦ by simpa using hg' j _ (by simp),
     fun j₁ j₂ ↦ by simpa using hl j₁ j₂ _ (by simp) (by simp)⟩
@@ -1173,13 +1182,13 @@ Given a cofiltered diagram of qcqs schemes `Dᵢ` over `S` with affine transitio
 If `X` is locally of finite presentation over `S`, then any `S`-morphism `lim Dᵢ ⟶ X` factors
 through some `lim Dᵢ ⟶ Dⱼ ⟶ X` for some `j`.
 -/
-lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation [∀ i, CompactSpace (D.obj i)] :
+lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation [∀ i, CompactSpace (D.obj i)] :
     ∃ (i : I) (g : D.obj i ⟶ X), c.π.app i ≫ g = a ∧ g ≫ f = t.app i := by
   -- The open cover of `c := lim Dᵢ` by the affine opens `U ⊆ c` such that `U` maps into an affine
   -- `V ⊆ X` which in turn maps into an affine `W ⊆ S`.
-  have h𝒰 := (Scheme.isBasis_affineOpens_le_preimage a
-    (Scheme.isBasis_affineOpens_le_preimage f S.isBasis_affineOpens)).isOpenCover
-  obtain ⟨i, s, 𝒱, h𝒱, h𝒱𝒰⟩ := Scheme.exists_isOpenCover_and_isAffine D c hc _ h𝒰 fun U ↦ U.2.1
+  have h𝒰 := (isBasis_affineOpens_le_preimage a
+    (isBasis_affineOpens_le_preimage f S.isBasis_affineOpens)).isOpenCover
+  obtain ⟨i, s, 𝒱, h𝒱, h𝒱𝒰⟩ := exists_isOpenCover_and_isAffine D c hc _ h𝒰 fun U ↦ U.2.1
   -- Each `𝒱 j` factors after passing to some `l`, compatibly on overlaps.
   obtain ⟨l, u, g, hg, hπg, hglue⟩ := exists_forall_homOfLE_comp_eq_of_isAffineOpen D t f c hc a ha
     (fun j ↦ (h𝒱𝒰 j).1) fun j ↦ by
@@ -1187,9 +1196,9 @@ lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation [∀ i, Compac
       exact ⟨⟨V, hV⟩, ⟨W, hW⟩, (h𝒱𝒰 j).2 ▸ hUV, hVW⟩
   -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
   have h𝒲 : IsOpenCover (D.map u ⁻¹ᵁ 𝒱 ·) := h𝒱.preimage (D.map u)
-  obtain ⟨F, hF⟩ := Scheme.exists_ι_comp_eq_of_isOpenCover h𝒲 g hglue
-  refine ⟨l, F, Scheme.hom_ext_of_isOpenCover (h𝒲.preimage (c.π.app l)) _ _ fun j ↦ ?_,
-    Scheme.hom_ext_of_isOpenCover h𝒲 _ _ fun j ↦ ?_⟩
+  obtain ⟨F, hF⟩ := exists_ι_comp_eq_of_isOpenCover h𝒲 g hglue
+  refine ⟨l, F, hom_ext_of_isOpenCover (h𝒲.preimage (c.π.app l)) _ _ fun j ↦ ?_,
+    hom_ext_of_isOpenCover h𝒲 _ _ fun j ↦ ?_⟩
   · rw [← Hom.resLE_comp_ι_assoc (c.π.app l) le_rfl, hF]
     exact hπg j
   · simp [reassoc_of% hF, hg]
@@ -1198,7 +1207,7 @@ set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 /-- `Hom_S(-, X)` sends a cofiltered limit of qcqs `S`-schemes with affine transition maps
 to a filtered colimit if `X` is locally of finite presentation over `X`. -/
-instance Scheme.preservesColimit_yoneda (D : I ⥤ Over S)
+instance preservesColimit_yoneda (D : I ⥤ Over S)
     [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f).left]
     [∀ (i : I), CompactSpace (D.obj i).left] [∀ (i : I), QuasiSeparatedSpace (D.obj i).left]
     (X : Over S) [LocallyOfFinitePresentation X.hom] :
@@ -1212,17 +1221,19 @@ instance Scheme.preservesColimit_yoneda (D : I ⥤ Over S)
     refine ⟨⟨?_, ?_⟩⟩
     · rw [Functor.CoconeTypes.descColimitType_injective_iff_of_isFiltered']
       intro k g₁ g₂ hg
-      obtain ⟨k, hik, heq⟩ := Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
+      obtain ⟨k, hik, heq⟩ := exists_hom_comp_eq_comp_of_locallyOfFiniteType
         (D ⋙ Over.forget _) (.mk (fun _ ↦ (D.obj _).hom)) X.hom _ (isLimitOfPreserves _ hc.unop)
         g₁.left g₂.left (Over.w g₁).symm (Over.w g₂).symm congr($(hg).left)
       use .op k, hik.op
       cat_disch
     · intro g
-      obtain ⟨k, u, h, h'⟩ := Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
+      obtain ⟨k, u, h, h'⟩ := exists_π_app_comp_eq_of_locallyOfFinitePresentation
         (D ⋙ Over.forget _) (.mk (fun _ ↦ (D.obj _).hom)) X.hom _ (isLimitOfPreserves _ hc.unop)
         g.left (by ext; simp)
       use Functor.ιColimitType _ (.op k) (Over.homMk u)
       cat_disch
+
+end Scheme
 
 end LocallyOfFinitePresentation
 

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -1330,29 +1330,22 @@ lemma Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation
     fun j₁ j₂ O e₁ e₂ ↦ (hak' j₁ O e₁).trans (hak' j₂ O e₂).symm
   -- We may glue the morphisms into `Dₗ ⟶ X` and verify that it indeed satisfies the hypothesis.
   have h𝒲 : IsOpenCover (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 ·) :=
-    (h𝒱.comap (D.map fki).base.hom).comap (D.map flk).base.hom
-  let 𝒲 := Scheme.openCoverOfIsOpenCover _ (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 ·) h𝒲
-  have hglue (j₁ j₂ : s) :
-      pullback.fst (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j₁).ι (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j₂).ι ≫
-          (D.map flk).resLE (D.map fki ⁻¹ᵁ 𝒱 j₁) _ le_rfl ≫ ak j₁ =
-        pullback.snd _ _ ≫ (D.map flk).resLE (D.map fki ⁻¹ᵁ 𝒱 j₂) _ le_rfl ≫ ak j₂ := by
+    .mk ((D.map flk).iSup_preimage_eq_top ((D.map fki).iSup_preimage_eq_top h𝒱))
+  let al (j : s) : ↑(D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j) ⟶ X :=
+    (D.map flk).resLE (D.map fki ⁻¹ᵁ 𝒱 j) _ le_rfl ≫ ak j
+  have hglue (j₁ j₂ : s) : pullback.fst (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j₁).ι
+      (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j₂).ι ≫ al j₁ = pullback.snd _ _ ≫ al j₂ := by
     rw [← cancel_epi (isPullback_opens_inf _ _).isoPullback.hom]
-    simpa using hl j₁ j₂ _ inf_le_left inf_le_right
-  let F := 𝒲.glueMorphisms (fun j ↦ (D.map flk).resLE (D.map fki ⁻¹ᵁ 𝒱 j) _ le_rfl ≫ ak j) hglue
+    simpa [al] using hl j₁ j₂ _ inf_le_left inf_le_right
+  let F := (Scheme.openCoverOfIsOpenCover _ _ h𝒲).glueMorphisms al hglue
   have hF (j : s) : (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ F =
       (D.map flk).resLE _ _ le_rfl ≫ ak j := Scheme.Cover.ι_glueMorphisms ..
-  have h𝒰' : IsOpenCover (c.π.app l ⁻¹ᵁ D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 ·) :=
-    h𝒲.comap (c.π.app l).base.hom
-  have hπF (j : s) : (c.π.app l ⁻¹ᵁ D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ c.π.app l ≫ F =
-      (c.π.app l ⁻¹ᵁ D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ a := by
-    rw [← Hom.resLE_comp_ι_assoc (c.π.app l) le_rfl, hF]
+  refine ⟨l, F, Scheme.hom_ext_of_isOpenCover (.mk ((c.π.app l).iSup_preimage_eq_top h𝒲)) _ _
+      fun j ↦ ?_, Scheme.hom_ext_of_isOpenCover h𝒲 _ _ fun j ↦ ?_⟩
+  · rw [← Hom.resLE_comp_ι_assoc (c.π.app l) le_rfl, hF]
     simp only [Hom.resLE_comp_resLE_assoc, Cone.w]
     exact hak' j _ _
-  have hFf (j : s) : (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ F ≫ f =
-      (D.map flk ⁻¹ᵁ D.map fki ⁻¹ᵁ 𝒱 j).ι ≫ t.app l := by
-    simp [reassoc_of% hF, hak]
-  exact ⟨l, F, Cover.hom_ext (Scheme.openCoverOfIsOpenCover _ _ h𝒰') _ _ hπF,
-    𝒲.hom_ext _ _ hFf⟩
+  · simp [reassoc_of% hF, hak]
 
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -844,21 +844,6 @@ lemma exists_app_map_eq_map_of_isLimit {i : I} {U : (D.obj i).Opens}
   simpa [sub_eq_zero] using exists_app_map_eq_zero_of_isLimit _ _ hc hU (s - t)
     (by simpa +instances [map_sub, sub_eq_zero])
 
-include hc in
-private lemma exists_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) (x : c.pt) :
-    ∃ (i : I) (U : (D.obj i).Opens) (_ : IsAffineOpen U) (_ : (c.π.app i).base x ∈ U)
-      (t : Γ(D.obj i, U)), ∀ (V : c.pt.Opens) (e : V ≤ c.π.app i ⁻¹ᵁ U),
-        (c.π.app i).appLE U V e t = s |_ V := by
-  obtain ⟨_, ⟨i, U, hU, rfl⟩, hxU, -⟩ :=
-    TopologicalSpace.Opens.isBasis_iff_nbhd.mp (isBasis_preimage_isAffineOpen D c hc)
-      (U := ⊤) (x := x) trivial
-  obtain ⟨j, u, t, ht⟩ := exists_appLE_π_eq_of_isAffineOpen D c hc hU (s |_ (c.π.app i ⁻¹ᵁ U))
-  have h := π_app_preimage_map_preimage D c u U
-  refine ⟨j, D.map u ⁻¹ᵁ U, hU.preimage _, h.ge hxU, t, fun V e ↦ ?_⟩
-  simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply] at ht ⊢
-  rw [← TopCat.Presheaf.restrict_restrict (e.trans_eq h) le_top s, ← ht]
-  exact (TopCat.Presheaf.restrict_restrict (e.trans_eq h) h.ge _).symm
-
 variable [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)]
 
 open TopologicalSpace in
@@ -868,53 +853,62 @@ private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)
       (t : ∀ x, Γ(D.obj k, U x)), (D.obj k).presheaf.IsCompatible U t ∧
         ∀ x (V : c.pt.Opens) (e : V ≤ c.π.app k ⁻¹ᵁ U x),
           (c.π.app k).appLE (U x) V e (t x) = s |_ V := by
-  classical
-  have := Scheme.compactSpace_of_isLimit _ _ hc
-  choose i U hU hxU t ht using exists_appLE_eq_restrict_of_isLimit D c hc s
-  obtain ⟨σ, hσ⟩ := CompactSpace.elim_nhds_subcover (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).1)
-    (fun x ↦ ((c.π.app (i x)) ⁻¹ᵁ U x).2.mem_nhds (by exact hxU x))
-  obtain ⟨j, fj, hfj⟩ : ∃ (j : I) (fj : ∀ x : σ, j ⟶ i x), ⨆ x : σ, D.map (fj x) ⁻¹ᵁ U x = ⊤ := by
-    obtain ⟨j₀, ⟨fj₀⟩⟩ := IsCofiltered.exists_hom_forall fun x : σ ↦ i x
-    obtain ⟨j, w, hw⟩ := exists_map_eq_top D c hc (⨆ x : σ, D.map (fj₀ x) ⁻¹ᵁ U x) (by
-      apply SetLike.coe_injective
-      simpa [← Set.preimage_comp, ← TopCat.coe_comp, ← Scheme.Hom.comp_base,
-        Set.iUnion_subtype] using hσ)
-    exact ⟨j, fun x ↦ w ≫ fj₀ x, by simpa [Scheme.Hom.preimage_iSup] using hw⟩
-  obtain ⟨k, v, hv⟩ : ∃ (k : I) (v : k ⟶ j), ∀ (x y : σ) (V : (D.obj k).Opens)
-      (h₁ : V ≤ D.map (v ≫ fj x) ⁻¹ᵁ U x) (h₂ : V ≤ D.map (v ≫ fj y) ⁻¹ᵁ U y),
-        (D.map (v ≫ fj x)).appLE _ V h₁ (t x) = (D.map (v ≫ fj y)).appLE _ V h₂ (t y) := by
-    refine IsCofiltered.exists_forall₂ _ ?_ fun x y ↦ ?_
-    · exact fun w v x y hv V h₁ h₂ ↦ by
-        have e : V ≤ D.map w ⁻¹ᵁ (D.map (v ≫ fj x) ⁻¹ᵁ U x ⊓ D.map (v ≫ fj y) ⁻¹ᵁ U y) := by
+  obtain ⟨i⟩ := IsCofiltered.nonempty (C := I)
+  obtain ⟨Us, hUs, hUsf, hsup⟩ := (D.obj i).isBasis_affineOpens.exists_finite_of_isCompact
+    (U := ⊤) (by simpa using isCompact_univ)
+  have : Finite Us := hUsf
+  have hcov : IsOpenCover fun W : Us ↦ W.1 := .mk (by rw [← sSup_eq_iSup', ← hsup])
+  obtain ⟨n, w, T, hT⟩ : ∃ (n : I) (w : n ⟶ i) (T : ∀ W : Us, Γ(D.obj n, D.map w ⁻¹ᵁ W.1)),
+      ∀ (W : Us) (V : c.pt.Opens) (e : V ≤ c.π.app n ⁻¹ᵁ D.map w ⁻¹ᵁ W.1),
+        (c.π.app n).appLE _ V e (T W) = s |_ V := by
+    choose j u t ht using fun W : Us ↦
+      exists_appLE_π_eq_of_isAffineOpen D c hc (hUs W.2) (s |_ (c.π.app i ⁻¹ᵁ W.1))
+    replace ht (W : Us) (V : c.pt.Opens) (e : V ≤ c.π.app (j W) ⁻¹ᵁ D.map (u W) ⁻¹ᵁ W.1) :
+        (c.π.app (j W)).appLE _ V e (t W) = s |_ V := by
+      have h := π_app_preimage_map_preimage D c (u W) W.1
+      simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply] at ht ⊢
+      rw [← TopCat.Presheaf.restrict_restrict (e.trans_eq h) le_top s, ← ht W]
+      exact (TopCat.Presheaf.restrict_restrict (e.trans_eq h) h.ge _).symm
+    obtain ⟨m, ⟨φ⟩⟩ := IsCofiltered.exists_hom_forall fun W : Us ↦ Over.mk (u W)
+    have hφ (W : Us) : D.map m.hom ⁻¹ᵁ W.1 ≤ D.map (φ W).left ⁻¹ᵁ D.map (u W) ⁻¹ᵁ W.1 :=
+      le_of_eq (by rw [← Scheme.Hom.comp_preimage, ← D.map_comp,
+        show (φ W).left ≫ u W = m.hom from Over.w (φ W)])
+    refine ⟨m.left, m.hom, fun W ↦ (D.map (φ W).left).appLE _ _ (hφ W) (t W), fun W V e ↦ ?_⟩
+    simpa only [Over.mk_left, ← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, Cone.w]
+      using ht W V _
+  obtain ⟨k, v, hv⟩ : ∃ (k : I) (v : k ⟶ n), ∀ (W₁ W₂ : Us) (V : (D.obj k).Opens)
+      (h₁ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1) (h₂ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1),
+        (D.map v).appLE _ V h₁ (T W₁) = (D.map v).appLE _ V h₂ (T W₂) := by
+    refine IsCofiltered.exists_forall₂ _ ?_ fun W₁ W₂ ↦ ?_
+    · exact fun x v W₁ W₂ hv V h₁ h₂ ↦ by
+        have e : V ≤ D.map x ⁻¹ᵁ
+            (D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1 ⊓ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1) := by
           simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
         simpa [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
-          using congr((D.map w).appLE _ V e $(hv _ inf_le_left inf_le_right))
-    have hcpt : IsCompact (X := D.obj j) ↑(D.map (fj x) ⁻¹ᵁ U x ⊓ D.map (fj y) ⁻¹ᵁ U y) :=
-      ((hU x).preimage (D.map (fj x))).isCompact.inter_of_isOpen
-        ((hU y).preimage (D.map (fj y))).isCompact (D.map (fj x) ⁻¹ᵁ U x).2
-        (D.map (fj y) ⁻¹ᵁ U y).2
-    obtain ⟨k, v, hv⟩ := exists_app_map_eq_map_of_isLimit D c hc hcpt
-      ((D.map (fj x)).app _ (t x) |_ _) ((D.map (fj y)).app _ (t y) |_ _) (by
+          using congr((D.map x).appLE _ V e $(hv _ inf_le_left inf_le_right))
+    have hcpt : IsCompact (X := D.obj n) ↑(D.map w ⁻¹ᵁ W₁.1 ⊓ D.map w ⁻¹ᵁ W₂.1) :=
+      ((hUs W₁.2).preimage (D.map w)).isCompact.inter_of_isOpen
+        ((hUs W₂.2).preimage (D.map w)).isCompact (D.map w ⁻¹ᵁ W₁.1).2 (D.map w ⁻¹ᵁ W₂.1).2
+    obtain ⟨k, v, hv⟩ := exists_app_map_eq_map_of_isLimit D c hc hcpt (T W₁ |_ _) (T W₂ |_ _) (by
       dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-      simp only [← ConcreteCategory.comp_apply,
-        Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, Scheme.Hom.appLE_comp_appLE, Cone.w]
-      exact (ht x _ _).trans (ht y _ _).symm)
+      simp only [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, Scheme.Hom.map_appLE]
+      exact (hT W₁ _ _).trans (hT W₂ _ _).symm)
     refine ⟨k, v, fun V h₁ h₂ ↦ ?_⟩
-    have H : V ≤ D.map v ⁻¹ᵁ (D.map (fj x) ⁻¹ᵁ U x ⊓ D.map (fj y) ⁻¹ᵁ U y) := by
+    have H : V ≤ D.map v ⁻¹ᵁ (D.map w ⁻¹ᵁ W₁.1 ⊓ D.map w ⁻¹ᵁ W₂.1) := by
       simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
     apply_fun (D.obj k).presheaf.map (homOfLE H).op at hv
     dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict] at hv ⊢
     simpa [← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
       Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hv
-  refine ⟨k, σ, fun x ↦ D.map (v ≫ fj x) ⁻¹ᵁ U x,
-    .mk (by simpa [Scheme.Hom.comp_preimage] using (D.map v).iSup_preimage_eq_top hfj),
-    fun x ↦ (D.map (v ≫ fj x)).app (U x) (t x), fun x y ↦ ?_, fun x V e ↦ ?_⟩
-  · dsimp [TopologicalSpace.Opens.infLELeft, TopologicalSpace.Opens.infLERight]
+  refine ⟨k, Us, fun W ↦ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W.1,
+    (hcov.preimage (D.map w)).preimage (D.map v), fun W ↦ (D.map v).app _ (T W),
+    fun W₁ W₂ ↦ ?_, fun W V e ↦ ?_⟩
+  · dsimp [Opens.infLELeft, Opens.infLERight]
     simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, -Scheme.Hom.comp_appLE]
-      using hv x y _ inf_le_left inf_le_right
+      using hv W₁ W₂ _ inf_le_left inf_le_right
   · simp only [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE,
       Scheme.Hom.appLE_comp_appLE, Cone.w]
-    exact ht x V _
+    exact hT W V _
 
 include hc in
 lemma exists_appTop_π_eq_of_isLimit (s : Γ(c.pt, ⊤)) :

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -724,22 +724,21 @@ lemma Scheme.exists_resLE_comp_eq_resLE_comp_of_locallyOfFiniteType
       (D.map hik).resLE U _ le_rfl ≫ a = (D.map hik).resLE U _ le_rfl ≫ b := by
   have (j : Over i) : CompactSpace ((opensDiagram D i U).obj j) :=
     isCompact_iff_compactSpace.mp (QuasiCompact.isCompact_preimage _ U.2 hU)
-  let U₀ : (D.obj i).Opens := D.map (𝟙 i) ⁻¹ᵁ U
-  let a₀ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ a
-  let b₀ : ↑U₀ ⟶ X := Scheme.homOfLE _ (by simp [U₀]) ≫ b
-  have ha₀ : U₀.ι ≫ t.app i = a₀ ≫ f := by simp [a₀, ← ha]
-  have hb₀ : U₀.ι ≫ t.app i = b₀ ≫ f := by simp [b₀, ← hb]
-  have hab₀ : (c.π.app i).resLE U₀ (c.π.app i ⁻¹ᵁ U) (by simp [U₀]) ≫ a₀ =
-      (c.π.app i).resLE U₀ (c.π.app i ⁻¹ᵁ U) (by simp [U₀]) ≫ b₀ := by
-    simp only [a₀, b₀, Scheme.Hom.resLE_map_assoc]
+  have h : D.map (𝟙 i) ⁻¹ᵁ U ≤ U := by simp
+  have hres (g : ↑U ⟶ X) (hg : U.ι ≫ t.app i = g ≫ f) :
+      (D.map (𝟙 i) ⁻¹ᵁ U).ι ≫ t.app i = (Scheme.homOfLE _ h ≫ g) ≫ f := by simp [← hg]
+  have hab₀ : (c.π.app i).resLE (D.map (𝟙 i) ⁻¹ᵁ U) _ (by simp) ≫ Scheme.homOfLE _ h ≫ a =
+      (c.π.app i).resLE (D.map (𝟙 i) ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U) (by simp) ≫
+        Scheme.homOfLE _ h ≫ b := by
+    simp only [Scheme.Hom.resLE_map_assoc]
     exact hab
   obtain ⟨⟨k, _, u⟩, ⟨u', _, hu⟩, e⟩ := Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
     _ (opensDiagramι .. ≫ (Over.forget i).whiskerLeft t) f _ (isLimitOpensCone D c hc i U)
-    (i := .mk (𝟙 i)) a₀ b₀ ha₀ hb₀ hab₀
+    (i := .mk (𝟙 i)) _ _ (hres a ha) (hres b hb) hab₀
   obtain rfl : u = u' := by simpa using! hu.symm
-  replace e : (D.map u).resLE U₀ (D.map u ⁻¹ᵁ U) (by simp [U₀]) ≫ a₀ =
-      (D.map u).resLE U₀ (D.map u ⁻¹ᵁ U) (by simp [U₀]) ≫ b₀ := e
-  exact ⟨k, u, by simpa [a₀, b₀] using e⟩
+  replace e : (D.map u).resLE _ (D.map u ⁻¹ᵁ U) (by simp) ≫ Scheme.homOfLE _ h ≫ a =
+      (D.map u).resLE _ (D.map u ⁻¹ᵁ U) (by simp) ≫ Scheme.homOfLE _ h ≫ b := e
+  exact ⟨k, u, by simpa using e⟩
 
 end LocallyOfFiniteType
 

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -781,9 +781,9 @@ lemma exists_app_map_eq_zero_of_isLimit {i : I} {U : (D.obj i).Opens}
     (hU : IsCompact (X := D.obj i) U) (s : Γ(D.obj i, U)) (hs : (c.π.app i).app U s = 0) :
     ∃ (j : I) (f : j ⟶ i), (D.map f).app U s = 0 := by
   have h0 {V : (D.obj i).Opens} (hV : V ≤ U) {V' : c.pt.Opens} (e : V' ≤ c.π.app i ⁻¹ᵁ V) :
-      (c.π.app i).appLE V V' e (TopCat.Presheaf.restrictOpen s V hV) = 0 := by
-    rw [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict, ← ConcreteCategory.comp_apply,
-      Scheme.Hom.map_appLE, Scheme.Hom.appLE, ConcreteCategory.comp_apply, hs, map_zero]
+      (c.π.app i).appLE V V' e (s |_ V) = 0 := by
+    rw [Scheme.Hom.appLE_restrict _ hV, Scheme.Hom.appLE, ConcreteCategory.comp_apply, hs,
+      map_zero]
   have key {W : (D.obj i).Opens} (hW : IsAffineOpen W) (hWU : W ≤ U) :
       ∃ (j : I) (f : j ⟶ i), (D.map f).app W (s |_ W) = 0 := by
     have (j : Over i) : IsAffine ((opensDiagram D i W).obj j) := hW.preimage (D.map _)
@@ -841,67 +841,49 @@ variable [∀ i, CompactSpace (D.obj i)] [∀ i, QuasiSeparatedSpace (D.obj i)]
 
 open TopologicalSpace in
 include hc in
-private lemma exists_isOpenCover_appLE_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) :
+private lemma exists_isOpenCover_app_eq_restrict_of_isLimit (s : Γ(c.pt, ⊤)) :
     ∃ (k : I) (J : Type u) (U : J → (D.obj k).Opens) (_ : IsOpenCover U)
       (t : ∀ x, Γ(D.obj k, U x)), (D.obj k).presheaf.IsCompatible U t ∧
         ∀ x, (c.π.app k).app (U x) (t x) = s |_ (c.π.app k ⁻¹ᵁ U x) := by
   obtain ⟨i⟩ := IsCofiltered.nonempty (C := I)
-  obtain ⟨Us, hUs, hUsf, hsup⟩ := (D.obj i).isBasis_affineOpens.exists_finite_of_isCompact
-    (U := ⊤) (by simpa using isCompact_univ)
-  have : Finite Us := hUsf
-  have hcov : IsOpenCover fun W : Us ↦ W.1 := .mk (by rw [← sSup_eq_iSup', ← hsup])
-  have key : ∃ (n : I) (w : n ⟶ i), ∀ W : Us, ∃ T : Γ(D.obj n, D.map w ⁻¹ᵁ W.1),
-      ∀ (V : c.pt.Opens) (e : V ≤ c.π.app n ⁻¹ᵁ D.map w ⁻¹ᵁ W.1),
-        (c.π.app n).appLE _ V e T = s |_ V := by
-    refine IsCofiltered.exists_forall ?_ fun W ↦ ?_
-    · rintro n m v w W ⟨T, hT⟩
-      refine ⟨(D.map v).appLE _ _ (by simp) T, fun V e ↦ ?_⟩
-      simpa only [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, Cone.w]
-        using hT V (by simpa using e)
-    obtain ⟨j, u, T, hT⟩ := exists_appLE_π_eq_of_isAffineOpen D c hc (hUs W.2)
-      (s |_ (c.π.app i ⁻¹ᵁ W.1))
-    refine ⟨j, u, T, fun V e ↦ ?_⟩
-    have h := π_app_preimage_map_preimage D c u W.1
-    simp_rw [Scheme.Hom.appLE, ConcreteCategory.comp_apply] at hT ⊢
-    rw [← TopCat.Presheaf.restrict_restrict (e.trans_eq h) le_top s, ← hT]
-    exact (TopCat.Presheaf.restrict_restrict (e.trans_eq h) h.ge _).symm
-  choose n w T hT using key
+  obtain ⟨Us, hcov⟩ :=
+    (IsOpenCover.mk (iSup_affineOpens_eq_top (D.obj i))).exists_finite_of_compactSpace
+  obtain ⟨n, w, hT⟩ : ∃ (n : I) (w : n ⟶ i), ∀ W : Us, ∃ T : Γ(D.obj n, D.map w ⁻¹ᵁ W.1.1),
+      (c.π.app n).appLE _ (c.π.app i ⁻¹ᵁ W.1.1) (by simp) T = s |_ _ :=
+    IsCofiltered.exists_forall (fun v u W ⟨T, hT⟩ ↦ ⟨(D.map v).appLE _ _ (by simp) T, by
+      simpa only [Scheme.Hom.appLE_appLE, Cone.w] using hT⟩)
+      fun W ↦ exists_appLE_π_eq_of_isAffineOpen D c hc W.1.2 (s |_ _)
+  choose T hT using hT
+  replace hT (W : Us) {V : c.pt.Opens} (e : V ≤ c.π.app n ⁻¹ᵁ D.map w ⁻¹ᵁ W.1.1) :
+      (c.π.app n).appLE _ V e (T W) = s |_ V := by
+    have h := π_app_preimage_map_preimage D c w W.1.1
+    rw [← Scheme.Hom.restrict_appLE _ h.ge (e.trans_eq h), hT W, TopCat.Presheaf.restrict_restrict]
   obtain ⟨k, v, hv⟩ : ∃ (k : I) (v : k ⟶ n), ∀ (W₁ W₂ : Us) (V : (D.obj k).Opens)
-      (h₁ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1) (h₂ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1),
+      (h₁ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1.1) (h₂ : V ≤ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1.1),
         (D.map v).appLE _ V h₁ (T W₁) = (D.map v).appLE _ V h₂ (T W₂) := by
     refine IsCofiltered.exists_forall₂ ?_ fun W₁ W₂ ↦ ?_
-    · exact fun x v W₁ W₂ hv V h₁ h₂ ↦ by
-        have e : V ≤ D.map x ⁻¹ᵁ
-            (D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₁.1 ⊓ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W₂.1) := by
-          simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
-        simpa [← ConcreteCategory.comp_apply, Scheme.Hom.appLE_comp_appLE, -Scheme.Hom.comp_appLE]
-          using congr((D.map x).appLE _ V e $(hv _ inf_le_left inf_le_right))
-    have hcpt := ((hUs W₁.2).preimage (D.map w)).isCompact_inf ((hUs W₂.2).preimage (D.map w))
-    obtain ⟨k, v, hv⟩ := exists_app_map_eq_map_of_isLimit D c hc hcpt (T W₁ |_ _) (T W₂ |_ _) (by
-      dsimp +instances [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict]
-      simp only [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, Scheme.Hom.map_appLE]
-      exact (hT W₁ _ _).trans (hT W₂ _ _).symm)
-    refine ⟨k, v, fun V h₁ h₂ ↦ ?_⟩
-    have H : V ≤ D.map v ⁻¹ᵁ (D.map w ⁻¹ᵁ W₁.1 ⊓ D.map w ⁻¹ᵁ W₂.1) := by
-      simpa [Scheme.Hom.preimage_inf] using le_inf h₁ h₂
-    apply_fun (D.obj k).presheaf.map (homOfLE H).op at hv
-    dsimp [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict] at hv ⊢
-    simpa [← ConcreteCategory.comp_apply, -Scheme.Hom.comp_appLE,
-      Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_comp_appLE] using hv
-  refine ⟨k, Us, fun W ↦ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W.1,
+    · exact fun v u W₁ W₂ hv V h₁ h₂ ↦ by
+        simpa [Scheme.Hom.appLE_appLE, -Scheme.Hom.comp_appLE] using
+          congr((D.map v).appLE _ V ((le_inf h₁ h₂).trans_eq (by rw [D.map_comp]; rfl))
+            $(hv _ inf_le_left inf_le_right))
+    refine Exists₂.imp (fun k v hv V h₁ h₂ ↦ ?_) (exists_app_map_eq_map_of_isLimit D c hc
+      ((W₁.1.2.preimage (D.map w)).isCompact_inf (W₂.1.2.preimage (D.map w)))
+      (T W₁ |_ _) (T W₂ |_ _) (by
+        simpa [Scheme.Hom.app_restrict, ← Scheme.Hom.appLE_apply] using
+          (hT W₁ _).trans (hT W₂ _).symm))
+    simpa [Scheme.Hom.app_restrict, Scheme.Hom.appLE_apply, TopCat.Presheaf.restrict_restrict]
+      using congr($hv |_ₗ V ⟪(le_inf h₁ h₂).trans_eq (D.map v).preimage_inf.symm⟫)
+  refine ⟨k, Us, fun W ↦ D.map v ⁻¹ᵁ D.map w ⁻¹ᵁ W.1.1,
     (hcov.preimage (D.map w)).preimage (D.map v), fun W ↦ (D.map v).app _ (T W),
     fun W₁ W₂ ↦ ?_, fun W ↦ ?_⟩
-  · dsimp [Opens.infLELeft, Opens.infLERight]
-    simpa [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE, -Scheme.Hom.comp_appLE]
-      using hv W₁ W₂ _ inf_le_left inf_le_right
-  · simp only [← ConcreteCategory.comp_apply, Scheme.Hom.app_eq_appLE,
-      Scheme.Hom.appLE_comp_appLE, Cone.w]
-    exact hT W _ _
+  · simpa [Opens.infLELeft, Opens.infLERight, Scheme.Hom.appLE] using
+      hv W₁ W₂ _ inf_le_left inf_le_right
+  · simpa only [Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_appLE, Cone.w] using hT W _
 
 include hc in
 lemma exists_appTop_π_eq_of_isLimit (s : Γ(c.pt, ⊤)) :
     ∃ (i : I) (t : Γ(D.obj i, ⊤)), s = (c.π.app i).appTop t := by
-  obtain ⟨k, J, U, hU, t, hcompat, ht⟩ := exists_isOpenCover_appLE_eq_restrict_of_isLimit D c hc s
+  obtain ⟨k, J, U, hU, t, hcompat, ht⟩ := exists_isOpenCover_app_eq_restrict_of_isLimit D c hc s
   obtain ⟨t₀, ht₀, -⟩ := TopCat.Sheaf.existsUnique_gluing' ⟨_, (D.obj k).IsSheaf⟩ U ⊤
     (fun _ ↦ homOfLE le_top) hU.ge t hcompat
   refine ⟨k, t₀, TopCat.Sheaf.eq_of_locally_eq' ⟨_, c.pt.IsSheaf⟩ (fun x ↦ c.π.app k ⁻¹ᵁ U x) ⊤

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -39,7 +39,6 @@ variable {I : Type u} [Category.{u} I] {S X : Scheme.{u}} (D : I ⥤ Scheme.{u})
 
 attribute [local simp] Scheme.Hom.resLE_comp_resLE Scheme.Hom.resLE_comp_resLE_assoc
 
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 /--
 Suppose we have a cofiltered diagram of nonempty quasi-compact schemes,
@@ -78,10 +77,8 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
       exact (this _).elim x
     let F := Over.post D ⋙ Over.pullback (𝒰.f j) ⋙ Over.forget _
     have (i' : _) : IsAffine (F.obj i') :=
-      have : IsAffineHom (pullback.snd (D.map i'.hom) (𝒰.f j)) :=
-        MorphismProperty.pullback_snd _ _ inferInstance
-      isAffine_of_isAffineHom (pullback.snd (D.map i'.hom) (𝒰.f j))
-    have (i' : _) : Nonempty (F.obj i') := H i'.hom
+      inferInstanceAs (IsAffine (pullback (D.map i'.hom) (𝒰.f j)))
+    have hFne (i' : _) : Nonempty (F.obj i') := H i'.hom
     let e : F ⟶ (F ⋙ Γ.rightOp) ⋙ Scheme.Spec := Functor.whiskerLeft F ΓSpec.adjunction.unit
     have (i : _) : IsIso (e.app i) := IsAffine.affine
     have : IsIso e := NatIso.isIso_of_isIso_app e
@@ -91,7 +88,7 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
       apply +allowSynthFailures PrimeSpectrum.instNonemptyOfNontrivial
       have (i' : _) : Nontrivial ((F ⋙ Γ.rightOp).leftOp.obj i') := by
         apply +allowSynthFailures component_nontrivial
-        simp
+        exact (hFne _).elim fun x ↦ ⟨⟨x, trivial⟩⟩
       exact CommRingCat.FilteredColimits.nontrivial
         (isColimitCoconeLeftOpOfCone _ (limit.isLimit (F ⋙ Γ.rightOp)))
     let α : F ⟶ Over.forget _ ⋙ D := Functor.whiskerRight
@@ -99,7 +96,6 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
     exact this.map (((Functor.Initial.isLimitWhiskerEquiv (Over.forget i) c).symm hc).lift
         ((Cone.postcompose α).obj c'.1))
 
-set_option backward.defeqAttrib.useBackward true in
 include hc in
 open Scheme.IdealSheafData in
 /--
@@ -149,7 +145,6 @@ lemma exists_mem_of_isClosed_of_nonempty
     Scheme.nonempty_of_isLimit D' c' hc'
   simpa using this
 
-set_option backward.defeqAttrib.useBackward true in
 include hc in
 /--
 A variant of `exists_mem_of_isClosed_of_nonempty` where the closed sets are only defined
@@ -199,7 +194,6 @@ lemma π_app_preimage_map_preimage {i j : I} (fji : j ⟶ i) (U : (D.obj i).Open
     c.π.app j ⁻¹ᵁ D.map fji ⁻¹ᵁ U = c.π.app i ⁻¹ᵁ U := by
   rw [← Scheme.Hom.comp_preimage, c.w]
 
-set_option backward.isDefEq.respectTransparency.types false in
 /-- Given a diagram `{ Dᵢ }` of schemes and an open `U ⊆ Dᵢ`,
 this is the diagram of `{ Dⱼᵢ⁻¹ U }_{j ≤ i}`. -/
 @[simps] noncomputable
@@ -207,19 +201,19 @@ def opensDiagram (i : I) (U : (D.obj i).Opens) : Over i ⥤ Scheme where
   obj j := D.map j.hom ⁻¹ᵁ U
   map {j k} f := (D.map f.left).resLE _ _
     (by rw [← Scheme.Hom.comp_preimage, ← D.map_comp, Over.w f])
+  map_id j := by simp [← cancel_mono (D.map j.hom ⁻¹ᵁ U).ι]
+  map_comp f g := by simp
 
-set_option backward.defeqAttrib.useBackward true in
 /-- The map `Dⱼᵢ⁻¹ U ⟶ Dᵢ` from the restricted diagram to the original diagram. -/
 @[simps] noncomputable
 def opensDiagramι (i : I) (U : (D.obj i).Opens) : opensDiagram D i U ⟶ Over.forget _ ⋙ D where
-  app j := Scheme.Opens.ι _
+  app _ := Scheme.Opens.ι _
+  naturality _ _ f := (D.map f.left).resLE_comp_ι _
 
-set_option backward.isDefEq.respectTransparency false in
 instance (i : I) (U : (D.obj i).Opens) (j : Over i) :
-    IsOpenImmersion ((opensDiagramι D i U).app j) := by
-  delta opensDiagramι; infer_instance
+    IsOpenImmersion ((opensDiagramι D i U).app j) :=
+  inferInstanceAs (IsOpenImmersion (D.map j.hom ⁻¹ᵁ U).ι)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given a diagram `{ Dᵢ }` of schemes and an open `U ⊆ Dᵢ`,
 the preimage of `U ⊆ Dᵢ` under the map `lim Dᵢ ⟶ Dᵢ` is the limit of `{ Dⱼᵢ⁻¹ U }_{j ≤ i}`.
 This is the underlying cone, and it is limiting as witnessed by `isLimitOpensCone` below. -/
@@ -227,47 +221,34 @@ This is the underlying cone, and it is limiting as witnessed by `isLimitOpensCon
 def opensCone (i : I) (U : (D.obj i).Opens) : Cone (opensDiagram D i U) where
   pt := c.π.app i ⁻¹ᵁ U
   π.app j := (c.π.app j.left).resLE _ _ (by rw [← Scheme.Hom.comp_preimage, c.w])
+  π.naturality _ k f := by
+    change 𝟙 _ ≫ (c.π.app k.left).resLE (D.map k.hom ⁻¹ᵁ U) _ _ = _ ≫ (D.map f.left).resLE _ _ _
+    simp
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 instance [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] {i : I}
     (U : (D.obj i).Opens) {j k : Over i} (f : j ⟶ k) :
     IsAffineHom ((opensDiagram D i U).map f) := by
-  refine ⟨fun V hV ↦ ?_⟩
-  convert!
-    ((hV.image_of_isOpenImmersion (D.map k.hom ⁻¹ᵁ U).ι).preimage
-          (D.map f.left)).preimage_of_isOpenImmersion
-      (D.map j.hom ⁻¹ᵁ U).ι ?_
-  · ext x
-    change _ ∈ V ↔ _
-    refine ⟨fun h ↦ ⟨⟨(D.map f.left).base x.1, ?_⟩, ?_, rfl⟩, ?_⟩
-    · change (D.map f.left ≫ D.map k.hom).base x.1 ∈ U
-      rw [← D.map_comp, Over.w f]
-      exact x.2
-    · convert! h
-      exact Subtype.ext (by simp)
-    · rintro ⟨⟨_, hU⟩, hV, rfl⟩
-      convert! hV
-      exact Subtype.ext (by simp)
-  · simp only [opensDiagram_obj, Scheme.Opens.opensRange_ι]
-    rintro x ⟨⟨y, h₁ : (D.map k.hom).base y ∈ U⟩, h₂, e⟩
-    obtain rfl : y = (D.map f.left).base x := congr($e)
-    dsimp at h₁
-    rw [← Scheme.Hom.comp_apply] at h₁
-    rwa [← D.map_comp, Over.w f] at h₁
+  have he : D.map j.hom ⁻¹ᵁ U = D.map f.left ⁻¹ᵁ D.map k.hom ⁻¹ᵁ U := by
+    rw [← Scheme.Hom.comp_preimage, ← D.map_comp, Over.w f]
+  change IsAffineHom ((D.map f.left).resLE _ _ _)
+  rw [Scheme.Hom.resLE_congr _ _ rfl he @IsAffineHom, Scheme.Hom.resLE_eq_morphismRestrict]
+  exact MorphismProperty.IsStableUnderBaseChange.of_isPullback
+    (isPullback_morphismRestrict (D.map f.left) _).flip inferInstance
 
 attribute [local instance] CategoryTheory.isConnected_of_hasTerminal
 
 variable [IsCofiltered I]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given a diagram `{ Dᵢ }_{i ∈ I}` of schemes and an open `U ⊆ Dᵢ`,
 the preimage of `U ⊆ Dᵢ` under the map `lim Dᵢ ⟶ Dᵢ` is the limit of `{ Dⱼᵢ⁻¹ U }_{j ≤ i}`. -/
-noncomputable def isLimitOpensCone (i : I) (U : (D.obj i).Opens) : IsLimit (opensCone D c i U) :=
-  isLimitOfIsPullbackOfIsConnected (opensDiagramι D i U) _ _
-    (by exact { hom := (c.π.app i ⁻¹ᵁ U).ι })
-    (fun j ↦ IsOpenImmersion.isPullback _ _ _ _ (by simp) (by simp [← Scheme.Hom.comp_preimage]))
+noncomputable def isLimitOpensCone (i : I) (U : (D.obj i).Opens) : IsLimit (opensCone D c i U) := by
+  refine isLimitOfIsPullbackOfIsConnected (opensDiagramι D i U) _ _ ?_ (fun j ↦ ?_)
     ((Functor.Initial.isLimitWhiskerEquiv (Over.forget i) c).symm hc)
+  · exact { hom := (c.π.app i ⁻¹ᵁ U).ι, w j := ((c.π.app j.left).resLE_comp_ι _).symm }
+  · refine IsOpenImmersion.isPullback _ (c.π.app i ⁻¹ᵁ U).ι _ _
+      ((c.π.app j.left).resLE_comp_ι _).symm ?_
+    change c.π.app j.left ⁻¹ᵁ (D.map j.hom ⁻¹ᵁ U).ι.opensRange = (c.π.app i ⁻¹ᵁ U).ι.opensRange
+    simp
 
 include hc in
 lemma exists_appTop_π_eq_of_isAffine_of_isLimit [∀ i, IsAffine (D.obj i)] (s : Γ(c.pt, ⊤)) :
@@ -278,8 +259,6 @@ lemma exists_appTop_π_eq_of_isAffine_of_isLimit [∀ i, IsAffine (D.obj i)] (s 
 
 variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] {i : I} {U V : (D.obj i).Opens}
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 lemma exists_map_preimage_le_map_preimage (hU : IsCompact (U : Set (D.obj i)))
     (H : c.π.app i ⁻¹ᵁ U ≤ c.π.app i ⁻¹ᵁ V) :
@@ -291,8 +270,14 @@ lemma exists_map_preimage_le_map_preimage (hU : IsCompact (U : Set (D.obj i)))
     exact .trans (by simp) (Scheme.Hom.preimage_mono _ H)
   obtain ⟨j, fji, hj⟩ := exists_map_eq_top _ _ (isLimitOpensCone D c hc i U) (i := .mk (𝟙 i))
     (((Scheme.isoOfEq _ (by simp)).hom ≫ U.ι) ⁻¹ᵁ V)
-    (by simpa [← Scheme.Hom.comp_preimage, -Scheme.Hom.comp_base])
+    (by change (c.π.app i).resLE (D.map (𝟙 i) ⁻¹ᵁ U) (c.π.app i ⁻¹ᵁ U) _ ⁻¹ᵁ
+          (((D.obj i).isoOfEq (by simp)).hom ≫ U.ι) ⁻¹ᵁ V = ⊤
+        simpa [← Scheme.Hom.comp_preimage, -Scheme.Hom.comp_base])
   refine ⟨j.left, j.hom, ?_⟩
+  revert hj
+  change (D.map fji.left).resLE (D.map (𝟙 i) ⁻¹ᵁ U) (D.map j.hom ⁻¹ᵁ U) _ ⁻¹ᵁ
+      (((D.obj i).isoOfEq (by simp)).hom ≫ U.ι) ⁻¹ᵁ V = ⊤ → _
+  intro hj
   replace hj : (D.map j.hom ⁻¹ᵁ U).ι ⁻¹ᵁ D.map fji.left ⁻¹ᵁ V = ⊤ := by
     simpa [← Scheme.Hom.comp_preimage, -Scheme.Hom.comp_base] using hj
   replace hj : (D.map j.hom ⁻¹ᵁ U).ι ''ᵁ ⊤ ≤ D.map fji.left ⁻¹ᵁ V := Set.image_subset_iff.mpr hj.ge
@@ -344,7 +329,6 @@ lemma isBasis_preimage_isAffineOpen : TopologicalSpace.Opens.IsBasis
     ← CommRingCat.comp_apply, Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map, hs]
   exact ⟨hxr, hrU⟩
 
-set_option backward.defeqAttrib.useBackward true in
 include hc in
 @[stacks 01Z4 "(1)"]
 lemma exists_preimage_eq (U : c.pt.Opens) (hU : IsCompact (U : Set c.pt)) :
@@ -406,8 +390,6 @@ section LocallyOfFiniteType
 
 variable [∀ i, CompactSpace (D.obj i)] [LocallyOfFiniteType f] [IsCofiltered I]
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 /-- Subsumed by `Scheme.exists_hom_hom_comp_eq_comp_of_locallyOfFiniteType`. -/
 private nonrec lemma Scheme.exists_hom_hom_comp_eq_comp_of_isAffine_of_locallyOfFiniteType
@@ -436,10 +418,15 @@ private nonrec lemma Scheme.exists_hom_hom_comp_eq_comp_of_isAffine_of_locallyOf
       dsimp; infer_instance
     have := this (D ⋙ Γ.rightOp ⋙ Scheme.Spec) ((Cone.postcompose (asIso e).hom).obj c)
       ((IsLimit.postcomposeHomEquiv (asIso e) c).symm hc) (inv e ≫ t)
-      ((inv e).app _ ≫ a) ((inv e).app _ ≫ b) (by simp [hab]) (by simp [ha]) (by simp [hb])
+      ((inv e).app _ ≫ a) ((inv e).app _ ≫ b)
+      (by simp only [Cone.postcompose_obj_π, NatTrans.comp_app, NatIso.isIso_inv_app,
+            Category.assoc, IsIso.hom_inv_id_assoc, asIso_hom]
+          exact hab)
+      (by simp [ha]) (by simp [hb])
       ⟨D ⋙ Γ.rightOp, rfl⟩
     simp_rw [(inv e).naturality_assoc] at this
-    simpa using! this
+    obtain ⟨k, hik, hjk, H⟩ := this
+    exact ⟨k, hik, hjk, (cancel_epi _).mp H⟩
   obtain ⟨D, rfl⟩ := hD
   obtain ⟨a, rfl⟩ := Spec.map_surjective a
   obtain ⟨b, rfl⟩ := Spec.map_surjective b
@@ -495,7 +482,6 @@ noncomputable section
 variable {D t f c} [∀ {i j : I} (f : i ⟶ j), IsAffineHom (D.map f)]
 variable (A : ExistsHomHomCompEqCompAux D t f)
 
-set_option backward.isDefEq.respectTransparency false in
 omit [LocallyOfFiniteType f] in
 lemma exists_index : ∃ (i' : I) (hii' : i' ⟶ A.i),
     ((D.map hii' ≫ pullback.lift A.a A.b (A.ha.symm.trans A.hb)) ⁻¹'
@@ -512,7 +498,8 @@ lemma exists_index : ∃ (i' : I) (hii' : i' ⟶ A.i),
   refine hs A.i (𝟙 A.i) (Scheme.Pullback.range_diagonal_subset_diagonalCoverDiagonalRange _ _ _ ?_)
   use (A.c.π.app A.i ≫ A.a) s
   have H : A.c.π.app A.i ≫ A.a ≫ pullback.diagonal f =
-      A.c.π.app A.i ≫ pullback.lift A.a A.b (A.ha.symm.trans A.hb) := by ext <;> simp [hab]
+      A.c.π.app A.i ≫ pullback.lift A.a A.b (A.ha.symm.trans A.hb) := by
+    ext <;> simp [hab, pullback.lift_fst, pullback.lift_snd]
   simp [← Scheme.Hom.comp_apply, -Scheme.Hom.comp_base, H]
 
 /-- (Implementation)
@@ -529,22 +516,23 @@ See the section docstring. -/
 def g : D.obj A.i' ⟶ pullback f f :=
   (D.map A.hii' ≫ pullback.lift A.a A.b (A.ha.symm.trans A.hb))
 
-set_option backward.isDefEq.respectTransparency false in
 omit [LocallyOfFiniteType f] in
 lemma range_g_subset :
     Set.range A.g ⊆ Scheme.Pullback.diagonalCoverDiagonalRange f A.𝒰S A.𝒰X := by
-  simpa [ExistsHomHomCompEqCompAux.hii', g] using! A.exists_index.choose_spec.choose_spec
+  simpa [ExistsHomHomCompEqCompAux.hii', g, Set.compl_empty_iff, Set.preimage_eq_univ_iff,
+    -Scheme.Hom.comp_base] using! A.exists_index.choose_spec.choose_spec
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 /-- (Implementation)
 The covering of `D(i')` by the pullback of the diagonal components of `X ×ₛ X`.
 See the section docstring. -/
 noncomputable def 𝒰D₀ : Scheme.OpenCover.{u} (D.obj A.i') :=
   Scheme.Cover.mkOfCovers (Σ i : A.𝒰S.I₀, (A.𝒰X i).I₀) _
-    (fun i ↦ ((Scheme.Pullback.diagonalCover f A.𝒰S A.𝒰X).pullback₁ A.g).f ⟨i.1, i.2, i.2⟩)
+    (fun i ↦ pullback.fst A.g ((Scheme.Pullback.diagonalCover f A.𝒰S A.𝒰X).f ⟨i.1, i.2, i.2⟩))
     (fun x ↦ by simpa [← Set.mem_range, Scheme.Pullback.range_fst,
-        Scheme.Pullback.diagonalCoverDiagonalRange] using A.range_g_subset ⟨x, rfl⟩)
+        Scheme.Pullback.diagonalCoverDiagonalRange] using! A.range_g_subset ⟨x, rfl⟩)
+    (fun i ↦ by
+      have := (Scheme.Pullback.diagonalCover f A.𝒰S A.𝒰X).map_prop ⟨i.1, i.2, i.2⟩
+      infer_instance)
 
 /-- (Implementation) An affine open cover refining `𝒰D₀`. See the section docstring. -/
 noncomputable def 𝒰D : Scheme.OpenCover.{u} (D.obj A.i') :=
@@ -570,27 +558,24 @@ def hc' (j : A.𝒰D.I₀) : IsLimit (A.c' j) :=
 
 variable [∀ i, IsAffineHom (A.c.π.app i)]
 
-set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 lemma exists_eq (j : A.𝒰D.I₀) : ∃ (k : I) (hki' : k ⟶ A.i'),
     (A.𝒰D.pullback₁ (D.map hki')).f j ≫ D.map (hki' ≫ A.hii') ≫ A.a =
       (A.𝒰D.pullback₁ (D.map hki')).f j ≫ D.map (hki' ≫ A.hii') ≫ A.b := by
-  have : IsAffine (A.𝒰D.X j) := by dsimp [𝒰D]; infer_instance
-  have (i : _) : IsAffine ((Over.post D ⋙ Over.pullback (A.𝒰D.f j) ⋙ Over.forget _).obj i) := by
-    dsimp; infer_instance
+  have : IsAffine (A.𝒰D.X j) := inferInstanceAs (IsAffine ((A.𝒰D₀.X j.1).affineCover.X j.2))
+  have (i : _) : IsAffine ((Over.post D ⋙ Over.pullback (A.𝒰D.f j) ⋙ Over.forget _).obj i) :=
+    inferInstanceAs (IsAffine (pullback (D.map i.hom) (A.𝒰D.f j)))
   have : IsAffine ((Over.pullback (A.𝒰D.f j) ⋙ Over.forget (A.𝒰D.X j)).mapCone
-      ((Over.conePost D A.i').obj A.c)).pt := by
-    dsimp; infer_instance
+      ((Over.conePost D A.i').obj A.c)).pt :=
+    inferInstanceAs (IsAffine (pullback (A.c.π.app A.i') (A.𝒰D.f j)))
   have : LocallyOfFiniteType ((A.𝒰X j.fst.fst).f j.fst.snd ≫ A.𝒰S.pullbackHom f j.fst.fst) := by
     dsimp [Scheme.Cover.pullbackHom]; infer_instance
   have H₁ := congr($(pullback.condition (f := A.g) (g := (Scheme.Pullback.diagonalCover f
     A.𝒰S A.𝒰X).f ⟨j.1.1, (j.1.2, j.1.2)⟩)) ≫ pullback.fst _ _)
   have H₂ := congr($(pullback.condition (f := A.g) (g := (Scheme.Pullback.diagonalCover f
     A.𝒰S A.𝒰X).f ⟨j.1.1, (j.1.2, j.1.2)⟩)) ≫ pullback.snd _ _)
-  simp only [Scheme.Pullback.openCoverOfBase_I₀, Scheme.Pullback.openCoverOfBase_X,
-    Scheme.Cover.pullbackHom, Scheme.Pullback.openCoverOfLeftRight_I₀,
-    g, Category.assoc, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
-    Scheme.Pullback.diagonalCover_map] at H₁ H₂
+  simp only [Scheme.Cover.pullbackHom, g, Category.assoc, limit.lift_π,
+    PullbackCone.mk_π_app, Scheme.Pullback.diagonalCover_map] at H₁ H₂
   obtain ⟨k, hik, hjk, H⟩ := Scheme.exists_hom_hom_comp_eq_comp_of_isAffine_of_locallyOfFiniteType
     (Over.post D ⋙ Over.pullback (A.𝒰D.f j) ⋙ Over.forget _)
     ((Over.post D ⋙ Over.pullback (A.𝒰D.f j)).whiskerLeft (Comma.natTrans _ _) ≫
@@ -620,6 +605,7 @@ lemma exists_eq (j : A.𝒰D.I₀) : ∃ (k : I) (hki' : k ⟶ A.i'),
       simp only [pullback.condition_assoc, 𝒰D, ← A.c.w A.hii', Category.assoc] at H₃
       simpa [Scheme.Cover.pullbackHom, g, ← H₁, ← H₂, -Cone.w, -Cone.w_assoc] using! H₃)
   refine ⟨k.left, k.hom, ?_⟩
+  dsimp only [Precoverage.ZeroHypercover.pullback₁, PreZeroHypercover.pullback₁]
   simpa [← cancel_mono ((A.𝒰X j.1.1).f j.1.2), ← cancel_mono (pullback.fst f (A.𝒰S.f j.1.1)),
     Scheme.Cover.pullbackHom, g, ← H₁, ← H₂, pullback.condition_assoc] using! H
 
@@ -631,8 +617,6 @@ variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
 
 namespace Scheme
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 lemma exists_hom_comp_eq_comp_of_locallyOfFiniteType
     {i : I} (a b : D.obj i ⟶ X) (ha : t.app i = a ≫ f) (hb : t.app i = b ≫ f)
@@ -664,19 +648,20 @@ lemma exists_hom_comp_eq_comp_of_locallyOfFiniteType
   refine ⟨l, hl1 ho ≫ hki' _ ≫ A.hii', ?_⟩
   apply Cover.hom_ext (𝒰Df.pullback₁ (D.map <| hl1 ho ≫ hki' _))
   intro u
+  have hu : k (A.𝒰D.idx u.1) ∈ O :=
+    Finset.mem_union_right _ (Finset.mem_image_of_mem _ (Finset.mem_univ (α := 𝒰Df.I₀) u))
   let F : pullback (D.map (hl1 ho ≫ hki' (A.𝒰D.idx o.1))) (𝒰Df.f u) ⟶
       pullback (D.map (hki' <| A.𝒰D.idx u.1)) (A.𝒰D.f <| A.𝒰D.idx u.1) :=
-    pullback.map _ _ _ _ (D.map <| hl1 (by simp [O]))
-      (𝟙 _) (𝟙 _) (by rw [Category.comp_id, ← D.map_comp, this]) rfl
+    pullback.map _ _ _ _ (D.map <| hl1 hu)
+      (𝟙 _) (𝟙 _) (by rw [Category.comp_id, ← D.map_comp, this o u]) rfl
   have hF : F ≫ pullback.fst (D.map (hki' _)) (A.𝒰D.f _) =
-      pullback.fst _ _ ≫ D.map (hl1 (by simp [O])) := by simp [F]
-  simp only [Precoverage.ZeroHypercover.pullback₁_toPreZeroHypercover,
-    PreZeroHypercover.pullback₁_X, PreZeroHypercover.pullback₁_f, Functor.map_comp, Category.assoc]
-    at heq ⊢
+      pullback.fst _ _ ≫ D.map (hl1 hu) := by
+    simp [F, pullback.lift_fst]
+  dsimp only [Precoverage.ZeroHypercover.pullback₁, PreZeroHypercover.pullback₁] at heq ⊢
+  simp only [Functor.map_comp, Category.assoc] at heq ⊢
   simp_rw [← D.map_comp_assoc, reassoc_of% this o u, D.map_comp_assoc]
   rw [← reassoc_of% hF, ← reassoc_of% hF, heq]
 
-set_option backward.defeqAttrib.useBackward true in
 include hc in
 /--
 Given a cofiltered diagram `D` of quasi-compact `S`-schemes with affine transition maps,
@@ -753,8 +738,6 @@ section sections
 
 variable [IsCofiltered I]
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 lemma exists_appTop_map_eq_zero_of_isAffine_of_isLimit
     [∀ i, IsAffine (D.obj i)]
@@ -763,14 +746,14 @@ lemma exists_appTop_map_eq_zero_of_isAffine_of_isLimit
   have : ∀ i, IsAffine (D.op.obj i).unop := by dsimp; infer_instance
   obtain ⟨j, f, hj⟩ := (Types.FilteredColimit.isColimit_eq_iff'
     (isColimitOfPreserves (Scheme.Γ ⋙ forget _) hc.op) s (0 : Γ(D.obj i, ⊤))).mp
-    (by dsimp at hs ⊢; simpa)
+    (by dsimp at hs ⊢; exact hs.trans (map_zero (ConcreteCategory.hom (c.π.app i).appTop)).symm)
   dsimp at hj
-  exact ⟨j.unop, f.unop, by simpa using hj⟩
+  exact ⟨j.unop, f.unop, hj.trans (map_zero (ConcreteCategory.hom (D.map f.unop).appTop))⟩
 
-variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+variable [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)] {i : I} {U : (D.obj i).Opens}
 
 include hc in
-lemma exists_app_map_eq_zero_of_isLimit {i : I} {U : (D.obj i).Opens}
+lemma exists_app_map_eq_zero_of_isLimit
     (hU : IsCompact (X := D.obj i) U) (s : Γ(D.obj i, U)) (hs : (c.π.app i).app U s = 0) :
     ∃ (j : I) (f : j ⟶ i), (D.map f).app U s = 0 := by
   have h0 {V : c.pt.Opens} (e : V ≤ c.π.app i ⁻¹ᵁ U) : (c.π.app i).appLE U V e s = 0 := by
@@ -808,13 +791,13 @@ lemma exists_app_map_eq_zero_of_isLimit {i : I} {U : (D.obj i).Opens}
     exact h.trans (map_zero _).symm
 
 include hc in
-lemma exists_appTop_map_eq_zero_of_isLimit {i : I} [CompactSpace (D.obj i)] (s : Γ(D.obj i, ⊤))
+lemma exists_appTop_map_eq_zero_of_isLimit [CompactSpace (D.obj i)] (s : Γ(D.obj i, ⊤))
     (hs : (c.π.app i).appTop s = 0) :
     ∃ (j : I) (f : j ⟶ i), (D.map f).appTop s = 0 :=
   exists_app_map_eq_zero_of_isLimit D c hc (by simpa using isCompact_univ) s hs
 
 include hc in
-lemma exists_app_map_eq_map_of_isLimit {i : I} {U : (D.obj i).Opens}
+lemma exists_app_map_eq_map_of_isLimit
     (hU : IsCompact (X := D.obj i) U) (s t : Γ(D.obj i, U))
     (hs : (c.π.app i).app U s = (c.π.app i).app U t) :
     ∃ (j : I) (f : j ⟶ i), (D.map f).app U s = (D.map f).app U t := by
@@ -948,8 +931,6 @@ lemma Scheme.exists_isQuasiAffine_of_isLimit [IsQuasiAffine c.pt] :
   rw [← preimage_basicOpen_top, ← preimage_basicOpen_top]
   exact ⟨((hf _).preimage _).preimage _, hy⟩
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 /-- Suppose `{ Xᵢ }` is an inverse system of qcqs schemes with affine transition maps.
 If `lim Xᵢ` is affine, then some `Xᵢ` is affine. -/
@@ -960,16 +941,16 @@ lemma Scheme.exists_isAffine_of_isLimit [IsAffine c.pt] :
   obtain ⟨i, hi⟩ := exists_isQuasiAffine_of_isLimit D c hc
   have : ∀ {i j : I} (f : i ⟶ j), IsAffineHom ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).map f) := by
     dsimp; infer_instance
-  have (j : _) : CompactSpace ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj j) := by dsimp; infer_instance
+  have (j : _) : CompactSpace ((D ⋙ Γ.rightOp ⋙ Scheme.Spec).obj j) :=
+    inferInstanceAs (CompactSpace (Spec Γ(D.obj j, ⊤)))
   obtain ⟨j, fij, hj⟩ := exists_map_eq_top _ _
     (isLimitOfPreserves (Γ.rightOp ⋙ Scheme.Spec) hc) (D.obj i).toSpecΓ.opensRange
     ((preimage_opensRange_toSpecΓ (X := c.pt) (c.π.app i)).trans
-      (by simp [Hom.opensRange_of_isIso]))
+      (by simp [Hom.opensRange_of_isIso]; rfl))
   have := IsQuasiAffine.of_isAffineHom (D.map fij)
   exact ⟨j, ⟨isIso_of_isOpenImmersion_of_opensRange_eq_top _
     ((preimage_opensRange_toSpecΓ (D.map fij)).symm.trans hj)⟩⟩
 
-set_option backward.defeqAttrib.useBackward true in
 omit [∀ i, CompactSpace (D.obj i)] in
 include hc in
 @[stacks 01Z4 "(1)"]
@@ -1022,8 +1003,6 @@ lemma exists_isOpenCover_and_isAffine
   obtain ⟨i, V, hV, heq⟩ := exists_isOpenCover_and_isAffine_of_finite _ _ hc _ hU (hU' ·)
   use i, s, V, hV
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 include hc in
 /-- Variant of `Scheme.exists_isOpenCover_and_isAffine_of_finite` in terms of `Scheme.OpenCover`. -/
 lemma OpenCover.exists_of_isCofiltered_of_finite (𝒰 : OpenCover.{w} c.pt)
@@ -1033,7 +1012,8 @@ lemma OpenCover.exists_of_isCofiltered_of_finite (𝒰 : OpenCover.{w} c.pt)
       ∀ (j : 𝒰.I₀), IsPullback (g j) (𝒰.f j) (f j) (c.π.app i) := by
   obtain ⟨i, V, hV, hV'⟩ := exists_isOpenCover_and_isAffine_of_finite _ _ hc _
     𝒰.isOpenCover_opensRange fun k ↦ isAffineOpen_opensRange (𝒰.f k)
-  have hV'' (k) := dsimp% congr($((hV' k).right).carrier)
+  have hV'' (k) : Set.range ⇑(𝒰.f k) = ⇑(c.π.app i) ⁻¹' (V k : Set _) :=
+    congr($((hV' k).right).carrier)
   refine ⟨i, fun k ↦ Γ(_, V k), fun k ↦ (hV' k).left.isoSpec.inv ≫ (V k).ι, ?_, ?_, ?_⟩
   · simp only [IsAffineOpen.isoSpec_inv_ι, ofArrows_mem_precoverage_iff,
       IsAffineOpen.range_fromSpec, SetLike.mem_coe]
@@ -1046,9 +1026,10 @@ lemma OpenCover.exists_of_isCofiltered_of_finite (𝒰 : OpenCover.{w} c.pt)
     refine ⟨⟨?_⟩, ⟨PullbackCone.IsLimit.mk _ (fun s ↦ ?_) ?_ ?_ ?_⟩⟩
     · simp [← IsAffineOpen.isoSpec_inv_ι]
     · refine IsOpenImmersion.lift (𝒰.f k) s.snd ?_
-      simp only [hV'', Set.range_subset_iff, Set.mem_preimage, SetLike.mem_coe]
-      simp_rw [← Hom.comp_apply, ← s.condition]
-      simp [← IsAffineOpen.isoSpec_inv_ι]
+      rw [hV'', Set.range_subset_iff]
+      intro y
+      rw [Set.mem_preimage, ← Hom.comp_apply, ← s.condition, Hom.comp_apply]
+      exact (hV' k).left.range_fromSpec.le (Set.mem_range_self _)
     · simp [← cancel_mono (hV' _).left.isoSpec.inv, ← cancel_mono (V k).ι, PullbackCone.condition]
     · simp
     · simp [← cancel_mono (𝒰.f k)]
@@ -1174,8 +1155,6 @@ lemma exists_π_app_comp_eq_of_locallyOfFinitePresentation [∀ i, CompactSpace 
       obtain ⟨-, V, ⟨hV, W, hW, hVW⟩, hUV⟩ := j.1.2
       exact ⟨⟨V, hV⟩, ⟨W, hW⟩, (h𝒱𝒰 j).2 ▸ hUV, hVW⟩
 
-set_option backward.defeqAttrib.useBackward true in
-set_option backward.isDefEq.respectTransparency false in
 /-- `Hom_S(-, X)` sends a cofiltered limit of qcqs `S`-schemes with affine transition maps
 to a filtered colimit if `X` is locally of finite presentation over `X`. -/
 instance preservesColimit_yoneda (D : I ⥤ Over S)
@@ -1200,8 +1179,10 @@ instance preservesColimit_yoneda (D : I ⥤ Over S)
     · intro g
       obtain ⟨k, u, h, h'⟩ := exists_π_app_comp_eq_of_locallyOfFinitePresentation
         (D ⋙ Over.forget _) (.mk (fun _ ↦ (D.obj _).hom)) X.hom _ (isLimitOfPreserves _ hc.unop)
-        g.left (by ext; simp)
-      use Functor.ιColimitType _ (.op k) (Over.homMk u)
+        g.left (by ext; simpa using (Over.w g).symm)
+      have : (c.ι.app (.op k)).unop ≫ Over.homMk u h' = g :=
+        Over.OverMorphism.ext (by simpa using h)
+      use Functor.ιColimitType _ (.op k) (Over.homMk u h')
       cat_disch
 
 end Scheme

--- a/Mathlib/AlgebraicGeometry/Gluing.lean
+++ b/Mathlib/AlgebraicGeometry/Gluing.lean
@@ -494,6 +494,16 @@ lemma hom_ext_of_isOpenCover {s : Type*} {X Y : Scheme.{u}} {U : s → X.Opens}
     (hU : IsOpenCover U) (f g : X ⟶ Y) (h : ∀ i, (U i).ι ≫ f = (U i).ι ≫ g) : f = g :=
   (X.openCoverOfIsOpenCover U hU).hom_ext f g h
 
+lemma exists_ι_comp_eq_of_isOpenCover {s : Type*} {X Y : Scheme.{u}} {U : s → X.Opens}
+    (hU : IsOpenCover U) (g : ∀ i, (U i).toScheme ⟶ Y)
+    (h : ∀ i j, X.homOfLE inf_le_left ≫ g i = X.homOfLE inf_le_right ≫ g j) :
+    ∃ f : X ⟶ Y, ∀ i, (U i).ι ≫ f = g i :=
+  ⟨(X.openCoverOfIsOpenCover U hU).glueMorphisms g fun i j ↦ by
+      change pullback.fst (U i).ι (U j).ι ≫ g i = pullback.snd _ _ ≫ g j
+      rw [← cancel_epi (isPullback_opens_inf (U i) (U j)).isoPullback.hom]
+      simpa using h i j,
+    fun i ↦ (X.openCoverOfIsOpenCover U hU).ι_glueMorphisms ..⟩
+
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 -- TODO: generalize to covers in subcanonical topologies

--- a/Mathlib/AlgebraicGeometry/Gluing.lean
+++ b/Mathlib/AlgebraicGeometry/Gluing.lean
@@ -490,6 +490,10 @@ lemma hom_ext_of_forall {X Y : Scheme} (f g : X ⟶ Y)
       refine ⟨fun x ↦ ⟨x, by simpa using hxU x⟩, inferInstance⟩ }
   exact 𝒰.hom_ext _ _ hU
 
+lemma hom_ext_of_isOpenCover {s : Type*} {X Y : Scheme.{u}} {U : s → X.Opens}
+    (hU : IsOpenCover U) (f g : X ⟶ Y) (h : ∀ i, (U i).ι ≫ f = (U i).ι ≫ g) : f = g :=
+  (X.openCoverOfIsOpenCover U hU).hom_ext f g h
+
 set_option backward.defeqAttrib.useBackward true in
 set_option backward.isDefEq.respectTransparency false in
 -- TODO: generalize to covers in subcanonical topologies

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -53,6 +53,10 @@ class QuasiSeparated (f : X ⟶ Y) : Prop where
 
 attribute [instance] QuasiSeparated.quasiCompact_diagonal
 
+theorem IsAffineOpen.isCompact_inf [QuasiSeparatedSpace X] {U V : X.Opens} (hU : IsAffineOpen U)
+    (hV : IsAffineOpen V) : IsCompact (X := X) ↑(U ⊓ V) :=
+  hU.isCompact.inter_of_isOpen hV.isCompact U.2 V.2
+
 theorem quasiSeparatedSpace_iff_forall_affineOpens {X : Scheme} :
     QuasiSeparatedSpace X ↔ ∀ U V : X.affineOpens, IsCompact (U ∩ V : Set X) := by
   rw [quasiSeparatedSpace_iff]

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -830,6 +830,10 @@ set_option backward.isDefEq.respectTransparency false in
 @[simp] lemma resLE_app_top : (f.resLE U V e).app ⊤ =
     U.topIso.hom ≫ f.appLE U V e ≫ V.topIso.inv := by simp [Scheme.Hom.resLE]
 
+lemma resLE_appTop_apply (s : Γ(U, ⊤)) :
+    (f.resLE U V e).appTop s = V.topIso.inv (f.appLE U V e (U.topIso.hom s)) := by
+  rw [Scheme.Hom.appTop, resLE_app_top, ConcreteCategory.comp_apply, ConcreteCategory.comp_apply]
+
 set_option backward.isDefEq.respectTransparency false in
 lemma resLE_appLE {U : Y.Opens} {V : X.Opens} (e : V ≤ f ⁻¹ᵁ U)
     (O : U.toScheme.Opens) (W : V.toScheme.Opens) (e' : W ≤ resLE f U V e ⁻¹ᵁ O) :

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -177,6 +177,10 @@ lemma stalkIso_inv {X : Scheme.{u}} (U : X.Opens) (x : U) :
 
 end Scheme.Opens
 
+lemma _root_.TopologicalSpace.IsOpenCover.preimage {s : Type*} {X Y : Scheme.{u}} {U : s → Y.Opens}
+    (hU : IsOpenCover U) (f : X ⟶ Y) : IsOpenCover fun i ↦ f ⁻¹ᵁ U i :=
+  .mk (f.iSup_preimage_eq_top hU)
+
 /-- If `U` is a family of open sets that covers `X`, then `X.restrict U` forms an `X.open_cover`. -/
 @[simps! I₀ X f]
 def Scheme.openCoverOfIsOpenCover {s : Type*} (X : Scheme.{u}) (U : s → X.Opens)

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -265,7 +265,7 @@ lemma preimage_iSup {ι} (U : ι → Opens Y) : f ⁻¹ᵁ iSup U = ⨆ i, f ⁻
 lemma iSup_preimage_eq_top {ι} {U : ι → Opens Y} (hU : iSup U = ⊤) :
     ⨆ i, f ⁻¹ᵁ U i = ⊤ := f.preimage_iSup U ▸ hU ▸ rfl
 
-@[gcongr]
+@[gcongr, sheaf_restrict]
 lemma preimage_mono {U U' : Y.Opens} (hUU' : U ≤ U') :
     f ⁻¹ᵁ U ≤ f ⁻¹ᵁ U' :=
   fun _ ha ↦ hUU' ha
@@ -275,6 +275,23 @@ lemma id_preimage (U : X.Opens) : (𝟙 X) ⁻¹ᵁ U = U := rfl
 @[simp]
 lemma comp_preimage {X Y Z : Scheme.{u}} (f : X ⟶ Y) (g : Y ⟶ Z) (U) :
     (f ≫ g) ⁻¹ᵁ U = f ⁻¹ᵁ g ⁻¹ᵁ U := rfl
+
+lemma appLE_apply (e : V ≤ f ⁻¹ᵁ U) (s : Γ(Y, U)) :
+    f.appLE U V e s = (f.app U s) |_ V :=
+  rfl
+
+lemma restrict_appLE (e : V ≤ f ⁻¹ᵁ U) (e' : V' ≤ V) (s : Γ(Y, U)) :
+    (f.appLE U V e s) |_ V' = f.appLE U V' (e'.trans e) s := by
+  rw [appLE_apply, appLE_apply, TopCat.Presheaf.restrict_restrict]
+
+lemma appLE_restrict (e : U' ≤ U) (e' : V ≤ f ⁻¹ᵁ U') (s : Γ(Y, U)) :
+    f.appLE U' V e' (s |_ U') = f.appLE U V (e'.trans (f.preimage_mono e)) s := by
+  rw [TopCat.Presheaf.restrictOpen, TopCat.Presheaf.restrict, ← ConcreteCategory.comp_apply,
+    map_appLE]
+
+lemma app_restrict (e : U' ≤ U) (s : Γ(Y, U)) :
+    f.app U' (s |_ U') = (f.app U s) |_ (f ⁻¹ᵁ U') := by
+  rw [app_eq_appLE, appLE_restrict _ e, appLE_apply]
 
 end Hom
 
@@ -404,6 +421,11 @@ set_option backward.isDefEq.respectTransparency.types false in
 theorem comp_appLE {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z) (U V e) :
     (f ≫ g).appLE U V e = g.app U ≫ f.appLE _ V e := by
   rw [g.app_eq_appLE, appLE_comp_appLE]
+
+theorem appLE_appLE {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z) (U V W e₁ e₂) (s : Γ(Z, U)) :
+    f.appLE V W e₂ (g.appLE U V e₁ s) =
+      (f ≫ g).appLE U W (e₂.trans ((Opens.map f.base).map (homOfLE e₁)).le) s := by
+  rw [← ConcreteCategory.comp_apply, appLE_comp_appLE]
 
 theorem congr_app {X Y : Scheme} {f g : X ⟶ Y} (e : f = g) (U) :
     f.app U = g.app U ≫ X.presheaf.map (eqToHom (by subst e; rfl)).op := by

--- a/Mathlib/CategoryTheory/Filtered/Basic.lean
+++ b/Mathlib/CategoryTheory/Filtered/Basic.lean
@@ -884,6 +884,15 @@ lemma exists_forall [IsCofilteredOrEmpty C] {I : Type*} [Finite I] {i : C}
   obtain ⟨l, v, w, hw⟩ := wideCospan u
   exact ⟨l, v, fun x ↦ hw x ▸ hP (w x) (u x) x (hu x)⟩
 
+omit [IsCofiltered C] in
+lemma exists_forall₂ [IsCofilteredOrEmpty C] {I J : Type*} [Finite I] [Finite J] {i : C}
+    (P : ∀ k : C, (k ⟶ i) → I → J → Prop)
+    (hP : ∀ {k l} (v : l ⟶ k) (u : k ⟶ i) (x : I) (y : J), P k u x y → P l (v ≫ u) x y)
+    (h : ∀ x y, ∃ (k : C) (u : k ⟶ i), P k u x y) :
+    ∃ (k : C) (u : k ⟶ i), ∀ x y, P k u x y :=
+  exists_forall (fun k u x ↦ ∀ y, P k u x y) (fun v u x hx y ↦ hP v u x y (hx y))
+    fun x ↦ exists_forall (fun k u y ↦ P k u x y) (fun v u y ↦ hP v u x y) (h x)
+
 end Nonempty
 
 

--- a/Mathlib/CategoryTheory/Filtered/Basic.lean
+++ b/Mathlib/CategoryTheory/Filtered/Basic.lean
@@ -874,6 +874,13 @@ lemma wideCospan [IsCofilteredOrEmpty C]
     (Finset.univ.image fun x ↦ ⟨j x, i, by simp, by simp, f x⟩)
   exact ⟨k, _, _, fun x ↦ hk _ _ (Finset.mem_image_of_mem _ (Finset.mem_univ _))⟩
 
+lemma exists_hom_forall {I : Type*} [Finite I] (j : I → C) :
+    ∃ k : C, Nonempty (∀ x, k ⟶ j x) := by
+  classical
+  cases nonempty_fintype I
+  obtain ⟨k, hk⟩ := inf_objs_exists (Finset.univ.image j)
+  exact ⟨k, ⟨fun x ↦ (hk (Finset.mem_image_of_mem j (Finset.mem_univ x))).some⟩⟩
+
 omit [IsCofiltered C] in
 lemma exists_forall [IsCofilteredOrEmpty C] {I : Type*} [Finite I] {i : C}
     (P : ∀ k : C, (k ⟶ i) → I → Prop)

--- a/Mathlib/CategoryTheory/Filtered/Basic.lean
+++ b/Mathlib/CategoryTheory/Filtered/Basic.lean
@@ -883,7 +883,7 @@ lemma exists_hom_forall {I : Type*} [Finite I] (j : I → C) :
 
 omit [IsCofiltered C] in
 lemma exists_forall [IsCofilteredOrEmpty C] {I : Type*} [Finite I] {i : C}
-    (P : ∀ k : C, (k ⟶ i) → I → Prop)
+    {P : ∀ k : C, (k ⟶ i) → I → Prop}
     (hP : ∀ {k l} (v : l ⟶ k) (u : k ⟶ i) (x : I), P k u x → P l (v ≫ u) x)
     (h : ∀ x, ∃ (k : C) (u : k ⟶ i), P k u x) :
     ∃ (k : C) (u : k ⟶ i), ∀ x, P k u x := by
@@ -893,12 +893,12 @@ lemma exists_forall [IsCofilteredOrEmpty C] {I : Type*} [Finite I] {i : C}
 
 omit [IsCofiltered C] in
 lemma exists_forall₂ [IsCofilteredOrEmpty C] {I J : Type*} [Finite I] [Finite J] {i : C}
-    (P : ∀ k : C, (k ⟶ i) → I → J → Prop)
+    {P : ∀ k : C, (k ⟶ i) → I → J → Prop}
     (hP : ∀ {k l} (v : l ⟶ k) (u : k ⟶ i) (x : I) (y : J), P k u x y → P l (v ≫ u) x y)
     (h : ∀ x y, ∃ (k : C) (u : k ⟶ i), P k u x y) :
     ∃ (k : C) (u : k ⟶ i), ∀ x y, P k u x y :=
-  exists_forall (fun k u x ↦ ∀ y, P k u x y) (fun v u x hx y ↦ hP v u x y (hx y))
-    fun x ↦ exists_forall (fun k u y ↦ P k u x y) (fun v u y ↦ hP v u x y) (h x)
+  exists_forall (P := fun k u x ↦ ∀ y, P k u x y) (fun v u x hx y ↦ hP v u x y (hx y))
+    fun x ↦ exists_forall (P := fun k u y ↦ P k u x y) (fun v u y ↦ hP v u x y) (h x)
 
 end Nonempty
 

--- a/Mathlib/CategoryTheory/Filtered/Basic.lean
+++ b/Mathlib/CategoryTheory/Filtered/Basic.lean
@@ -874,6 +874,16 @@ lemma wideCospan [IsCofilteredOrEmpty C]
     (Finset.univ.image fun x ↦ ⟨j x, i, by simp, by simp, f x⟩)
   exact ⟨k, _, _, fun x ↦ hk _ _ (Finset.mem_image_of_mem _ (Finset.mem_univ _))⟩
 
+omit [IsCofiltered C] in
+lemma exists_forall [IsCofilteredOrEmpty C] {I : Type*} [Finite I] {i : C}
+    (P : ∀ k : C, (k ⟶ i) → I → Prop)
+    (hP : ∀ {k l} (v : l ⟶ k) (u : k ⟶ i) (x : I), P k u x → P l (v ≫ u) x)
+    (h : ∀ x, ∃ (k : C) (u : k ⟶ i), P k u x) :
+    ∃ (k : C) (u : k ⟶ i), ∀ x, P k u x := by
+  choose k u hu using h
+  obtain ⟨l, v, w, hw⟩ := wideCospan u
+  exact ⟨l, v, fun x ↦ hw x ▸ hP (w x) (u x) x (hu x)⟩
+
 end Nonempty
 
 


### PR DESCRIPTION
Refactor and cleans up very long proofs in AffineTransitionLimit.lean

Several proofs in this file were the largest in Mathlib (as measured by actual time to validate the proof term) and I noticed they were terrible. This was the result of some ~20 rounds of me with Claude together doing cleanup, not just shortening the proofs but also cleaning up the file in other ways. It involved pulling 15 helpful little lemmas out in other related files, reordering some declarations into an easier order to re-use, changing some section variables (to make declarations much more readable), a great reduction in `set_option backward.isDefEq.respectTransparency false` and `set_option backward.defeqAttrib.useBackward` debt, and of course, simplifying many proofs to use cleaner or more direct arguments.

The net result is 138 less lines than before, and instead of having a massive `Scheme.exists_π_app_comp_eq_of_locallyOfFinitePresentation` (and friends) that's 104 lines, nearly everything is at a sane length.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
