### PR TITLE
feat(Data/Set/Card): cardinality of complement and difference

### DIFF
--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -300,6 +300,10 @@ protected lemma exists_nat_gt (hn : n ≠ ⊤) : ∃ m : ℕ, n < m := by
 @[simp] lemma sub_eq_top_iff : a - b = ⊤ ↔ a = ⊤ ∧ b ≠ ⊤ := WithTop.sub_eq_top_iff
 lemma sub_ne_top_iff : a - b ≠ ⊤ ↔ a ≠ ⊤ ∨ b = ⊤ := WithTop.sub_ne_top_iff
 
+@[simp]
+theorem addLECancellable_iff_ne {a : ℕ∞} : AddLECancellable a ↔ a ≠ ⊤ :=
+  WithTop.addLECancellable_iff_ne_top
+
 lemma addLECancellable_of_ne_top : a ≠ ⊤ → AddLECancellable a := WithTop.addLECancellable_of_ne_top
 lemma addLECancellable_of_lt_top : a < ⊤ → AddLECancellable a := WithTop.addLECancellable_of_lt_top
 lemma addLECancellable_natCast (a : ℕ) : AddLECancellable (a : ℕ∞) := WithTop.addLECancellable_coe _

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -1177,9 +1177,8 @@ theorem ncard_compl (s : Set α) (hs : s.Finite := by toFinite_tac) :
   · rw [← ncard_add_ncard_compl s hs hsc, Nat.add_sub_cancel_left]
   · simp [hsc.ncard, hsc.to_type]
 
-theorem ncard_compl_of_ncard_eq_add (s : Set α) (hs : s.Finite := by toFinite_tac) {n : ℕ}
-    (h : Nat.card α = n + s.ncard) :
-    sᶜ.ncard = n := by
+theorem ncard_compl_of_ncard_eq_add (s : Set α) {n : ℕ} (h : Nat.card α = n + s.ncard)
+    (hs : s.Finite := by toFinite_tac) : sᶜ.ncard = n := by
   rcases sᶜ.finite_or_infinite with hsc | hsc
   · rwa [← ncard_compl_add_ncard s hs hsc, Nat.add_right_cancel_iff] at h
   · have := hsc.to_type

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -216,6 +216,11 @@ theorem encard_sdiff_add_encard_inter (s t : Set α) :
     (s \ t).encard + (s ∩ t).encard = s.encard := by
   rw [← encard_union_eq disjoint_sdiff_inter, sdiff_union_inter]
 
+/-- `encard` of a difference with no subset assumption -/
+@[simp]
+theorem encard_sdiff' (h : (t ∩ s).Finite) : (t \ s).encard = t.encard - (t ∩ s).encard := by
+  simp [← t.encard_sdiff_add_encard_inter s, h.encard_lt_top.ne]
+
 @[deprecated (since := "2026-06-03")]
 alias encard_diff_add_encard_inter := encard_sdiff_add_encard_inter
 
@@ -305,8 +310,12 @@ theorem tsub_encard_le_encard_sdiff (s t : Set α) : s.encard - t.encard ≤ (s 
 @[deprecated (since := "2026-06-03")]
 alias tsub_encard_le_encard_diff := tsub_encard_le_encard_sdiff
 
-theorem encard_add_encard_compl (s : Set α) : s.encard + sᶜ.encard = (univ : Set α).encard := by
-  rw [← encard_union_eq disjoint_compl_right, union_compl_self]
+theorem encard_add_encard_compl (s : Set α) : s.encard + sᶜ.encard = ENat.card α := by
+  simp [← encard_union_eq disjoint_compl_right]
+
+@[simp]
+theorem encard_compl {s : Set α} (hs : s.Finite) : sᶜ.encard = ENat.card α - s.encard := by
+  simp [← encard_add_encard_compl s, hs.encard_lt_top.ne]
 
 end Lattice
 
@@ -744,6 +753,12 @@ theorem ncard_le_ncard_insert (a : α) (s : Set α) : s.ncard ≤ (insert a s).n
 theorem ncard_pair {a b : α} (h : a ≠ b) : ({a, b} : Set α).ncard = 2 := by
   simp [h]
 
+@[simp]
+theorem ncard_pair_iff {a b : α} : Set.ncard {a, b} = 2 ↔ a ≠ b := by
+  refine ⟨fun h ↦ ?_, (by simp [·])⟩
+  by_contra!
+  simp [this] at h
+
 -- removing `@[simp]` because the LHS is not in simp normal form
 theorem ncard_sdiff_singleton_add_one {a : α} (h : a ∈ s)
     (hs : s.Finite := by toFinite_tac) : (s \ {a}).ncard + 1 = s.ncard := by
@@ -752,15 +767,6 @@ theorem ncard_sdiff_singleton_add_one {a : α} (h : a ∈ s)
 
 @[deprecated (since := "2026-06-03")]
 alias ncard_diff_singleton_add_one := ncard_sdiff_singleton_add_one
-
-@[simp] theorem ncard_sdiff_singleton_of_mem {a : α} (h : a ∈ s) :
-    (s \ {a}).ncard = s.ncard - 1 := by
-  rcases s.infinite_or_finite with hs | hs
-  · simp_all [ncard, Infinite.sdiff hs (finite_singleton a)]
-  · exact eq_tsub_of_add_eq (ncard_sdiff_singleton_add_one h hs)
-
-@[deprecated (since := "2026-06-03")]
-alias ncard_diff_singleton_of_mem := ncard_sdiff_singleton_of_mem
 
 theorem ncard_sdiff_singleton_lt_of_mem {a : α} (h : a ∈ s) (hs : s.Finite := by toFinite_tac) :
     (s \ {a}).ncard < s.ncard := by
@@ -776,16 +782,6 @@ theorem ncard_sdiff_singleton_le (s : Set α) (a : α) : (s \ {a}).ncard ≤ s.n
   exact (hs.sdiff (by simp)).ncard
 
 @[deprecated (since := "2026-06-03")] alias ncard_diff_singleton_le := ncard_sdiff_singleton_le
-
-theorem pred_ncard_le_ncard_sdiff_singleton (s : Set α) (a : α) :
-    s.ncard - 1 ≤ (s \ {a}).ncard := by
-  by_cases h : a ∈ s
-  · rw [ncard_sdiff_singleton_of_mem h]
-  rw [sdiff_singleton_eq_self h]
-  apply Nat.pred_le
-
-@[deprecated (since := "2026-06-03")]
-alias pred_ncard_le_ncard_diff_singleton := pred_ncard_le_ncard_sdiff_singleton
 
 theorem ncard_exchange {a b : α} (ha : a ∉ s) (hb : b ∈ s) : (insert a (s \ {b})).ncard = s.ncard :=
   congr_arg ENat.toNat <| encard_exchange ha hb
@@ -1117,6 +1113,31 @@ theorem exists_mem_notMem_of_ncard_lt_ncard (h : s.ncard < t.ncard)
 @[deprecated (since := "2026-06-03")]
 alias ncard_inter_add_ncard_diff_eq_ncard := ncard_inter_add_ncard_sdiff_eq_ncard
 
+/-- `ncard` of a difference with no subset assumption -/
+@[simp]
+theorem ncard_sdiff'' (h : (t ∩ s).Finite := by toFinite_tac) :
+    (t \ s).ncard = t.ncard - (t ∩ s).ncard := by
+  rcases t.finite_or_infinite with ht | ht
+  · simp [← ncard_inter_add_ncard_sdiff_eq_ncard t s ht]
+  · rw [ht.ncard, ← sdiff_self_inter, ht.sdiff h |>.ncard]
+    simp
+
+theorem ncard_sdiff_singleton_of_mem {a : α} (h : a ∈ s) : (s \ {a}).ncard = s.ncard - 1 := by
+  simp [h]
+
+@[deprecated (since := "2026-06-03")]
+alias ncard_diff_singleton_of_mem := ncard_sdiff_singleton_of_mem
+
+theorem pred_ncard_le_ncard_sdiff_singleton (s : Set α) (a : α) :
+    s.ncard - 1 ≤ (s \ {a}).ncard := by
+  by_cases h : a ∈ s
+  · rw [ncard_sdiff_singleton_of_mem h]
+  rw [sdiff_singleton_eq_self h]
+  apply Nat.pred_le
+
+@[deprecated (since := "2026-06-03")]
+alias pred_ncard_le_ncard_diff_singleton := pred_ncard_le_ncard_sdiff_singleton
+
 theorem ncard_eq_ncard_iff_ncard_sdiff_eq_ncard_sdiff (hs : s.Finite := by toFinite_tac)
     (ht : t.Finite := by toFinite_tac) : s.ncard = t.ncard ↔ (s \ t).ncard = (t \ s).ncard := by
   rw [← ncard_inter_add_ncard_sdiff_eq_ncard s t hs, ← ncard_inter_add_ncard_sdiff_eq_ncard t s ht,
@@ -1149,14 +1170,21 @@ theorem ncard_compl_add_ncard (s : Set α) (hs : s.Finite := by toFinite_tac)
     (hsc : sᶜ.Finite := by toFinite_tac) : sᶜ.ncard + s.ncard = Nat.card α := by
   rw [add_comm, ncard_add_ncard_compl s hs hsc]
 
-theorem ncard_compl (s : Set α) (hs : s.Finite := by toFinite_tac)
-    (hsc : sᶜ.Finite := by toFinite_tac) : sᶜ.ncard = Nat.card α - s.ncard := by
-  rw [← ncard_add_ncard_compl s hs hsc, Nat.add_sub_cancel_left]
+@[simp]
+theorem ncard_compl (s : Set α) (hs : s.Finite := by toFinite_tac) :
+    sᶜ.ncard = Nat.card α - s.ncard := by
+  rcases sᶜ.finite_or_infinite with hsc | hsc
+  · rw [← ncard_add_ncard_compl s hs hsc, Nat.add_sub_cancel_left]
+  · simp [hsc.ncard, hsc.to_type]
 
-theorem ncard_compl_of_ncard_eq_add [Finite α] (s : Set α) {n : ℕ}
+theorem ncard_compl_of_ncard_eq_add (s : Set α) (hs : s.Finite := by toFinite_tac) {n : ℕ}
     (h : Nat.card α = n + s.ncard) :
     sᶜ.ncard = n := by
-  rwa [← ncard_compl_add_ncard s, Nat.add_right_cancel_iff] at h
+  rcases sᶜ.finite_or_infinite with hsc | hsc
+  · rwa [← ncard_compl_add_ncard s hs hsc, Nat.add_right_cancel_iff] at h
+  · have := hsc.to_type
+    rw [Nat.card_eq_zero_of_infinite] at h
+    rw [hsc.ncard, Nat.eq_zero_of_add_eq_zero_right h.symm]
 
 theorem eq_univ_iff_ncard [Finite α] (s : Set α) :
     s = univ ↔ ncard s = Nat.card α := by
@@ -1169,6 +1197,13 @@ lemma even_ncard_compl_iff [Finite α] (heven : Even (Nat.card α)) (s : Set α)
 lemma odd_ncard_compl_iff [Finite α] (heven : Even (Nat.card α)) (s : Set α) :
     Odd sᶜ.ncard ↔ Odd s.ncard := by
   rw [← Nat.not_even_iff_odd, even_ncard_compl_iff heven, Nat.not_even_iff_odd]
+
+lemma even_ncard_compl_iff' (h : Odd (Nat.card α)) (s : Set α) : Even sᶜ.ncard ↔ Odd s.ncard := by
+  have : Finite α := Nat.finite_of_card_ne_zero <| Nat.ne_of_odd_add h
+  rwa [iff_comm, ← Nat.odd_add, ncard_add_ncard_compl]
+
+lemma odd_ncard_compl_iff' (h : Odd (Nat.card α)) (s : Set α) : Odd sᶜ.ncard ↔ Even s.ncard := by
+  rw [← Nat.not_even_iff_odd, even_ncard_compl_iff' h, Nat.not_odd_iff_even]
 
 theorem nonempty_inter_of_lt_ncard_add_ncard [Finite α]
     (h : Nat.card α < s.ncard + t.ncard) : (s ∩ t).Nonempty := by

--- a/Mathlib/Data/Set/Finite/Basic.lean
+++ b/Mathlib/Data/Set/Finite/Basic.lean
@@ -832,6 +832,9 @@ theorem infinite_univ_iff : (@univ α).Infinite ↔ Infinite α := by
 theorem infinite_univ [h : Infinite α] : (@univ α).Infinite :=
   infinite_univ_iff.2 h
 
+theorem Infinite.to_type (hs : s.Infinite) : Infinite α :=
+  infinite_univ_iff.mp <| hs.mono s.subset_univ
+
 lemma Infinite.exists_notMem_finite (hs : s.Infinite) (ht : t.Finite) : ∃ a, a ∈ s ∧ a ∉ t := by
   by_contra! h; exact hs <| ht.subset h
 

--- a/Mathlib/Data/Set/PowersetCard.lean
+++ b/Mathlib/Data/Set/PowersetCard.lean
@@ -73,8 +73,8 @@ theorem eq_iff_subset {s t : Set.powersetCard α n} : s = t ↔ (s : Finset α) 
 theorem exists_mem_notMem (hn : 1 ≤ n) (hα : n < ENat.card α) {a b : α} (hab : a ≠ b) :
     ∃ s : powersetCard α n, a ∈ s ∧ b ∉ s := by
   have ha' : n ≤ Set.encard {b}ᶜ := by
-    rwa [← (Set.encard_add_encard_compl {b}).trans (Set.encard_univ α), Set.encard_singleton,
-      add_comm, ENat.lt_add_one_iff' (ENat.natCast_ne_top n)] at hα
+    rwa [← encard_add_encard_compl, encard_singleton, add_comm,
+      ENat.lt_add_one_iff' (ENat.natCast_ne_top n)] at hα
   obtain ⟨s, has, has', hs⟩ :=
     Set.exists_superset_subset_encard_eq (s := {a}) (by simp [Ne.symm hab]) (by simpa) ha'
   have : Set.Finite s := Set.finite_of_encard_eq_coe hs

--- a/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
@@ -171,21 +171,19 @@ theorem has_swap_mem_of_lt_stabilizer [DecidableEq α]
     use g, hg
     rw [stabilizer_compl] at hg'
     exact hG.le hg'
-  have hα : Set.encard (_root_.Set.univ : Set α) = 2 := by
+  have hα : ENat.card α = 2 := by
     rw [← Set.encard_add_encard_compl s]
-    have : (1 + 1 : ENat) = 2 := by norm_num
-    convert! this <;>
+    convert one_add_one_eq_two <;>
     · apply le_antisymm
       · assumption
       rw [one_le_encard_iff_nonempty, Set.nonempty_iff_ne_empty]
       aesop
   have _ : Finite α := by
-    rw [finite_iff_nonempty_fintype]
-    refine univ_finite_iff_nonempty_fintype.mp ?_
-    exact finite_of_encard_eq_coe hα
+    rw [← ENat.card_lt_top, hα]
+    exact ENat.ofNat_ne_top 2 |>.lt_top
   have hα : Nat.card α = 2 := by
-    rw [← ENat.card_coe_set_eq, ENat.card_eq_coe_natCard, Nat.card_coe_set_eq, ncard_univ] at hα
-    exact ENat.natCast_inj.mp hα
+    rw [ENat.card_eq_coe_natCard] at hα
+    exact_mod_cast hα
   have hα2 : Fact (Nat.card (Perm α)).Prime := by
     apply Fact.mk
     rw [Nat.card_perm, hα, Nat.factorial_two]

--- a/Mathlib/LinearAlgebra/PiTensorProduct/Generators.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct/Generators.lean
@@ -126,7 +126,7 @@ lemma ext_of_span_eq_top
         rw [Function.subtypeNeLift_of_neq _ _ _ _ (by assumption)]
         rfl
       simpa only [lift.equiv_symm_apply, this] using h (Function.subtypeNeLift i₀ j g₀)
-    · exact Set.ncard_compl_of_ncard_eq_add _ (by simpa)
+    · exact Set.ncard_compl_of_ncard_eq_add {i₀} (by simpa)
 
 lemma _root_.MultilinearMap.ext_of_span_eq_top
     (hg : ∀ i, Submodule.span R (Set.range (@g i)) = ⊤)


### PR DESCRIPTION
- `ncard_compl` doesn't need `sᶜ.Finite`
- added `sᶜ.encard` lemma
- added `[e]ncard (t \ s)` lemmas that don't require `s ⊆ t`
- tag them `simp`

---
and generalized nearby similar things.

`ncard_sdiff_singleton_of_mem` and `pred_ncard_le_ncard_sdiff_singleton` were moved down to be able to use the `ncard` diff lemma.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
