### PR TITLE
[Merged by Bors] - feat(Data/Fintype/Defs): add DecidableLE (∀ a, β a)

### DIFF
--- a/Mathlib/Data/Fintype/Defs.lean
+++ b/Mathlib/Data/Fintype/Defs.lean
@@ -214,7 +214,7 @@ instance decidableExistsFintype {p : α → Prop} [DecidablePred p] [Fintype α]
     Decidable (∃ a, p a) :=
   decidable_of_iff (∃ a ∈ @univ α _, p a) (by simp)
 
-instance Pi.instDecidableLE {α} {β : α → Type*} [∀ a, LE (β a)] [∀ i, DecidableLE (β a)]
+instance Pi.instDecidableLE {α} {β : α → Type*} [∀ a, LE (β a)] [∀ a, DecidableLE (β a)]
   [Fintype α] : DecidableLE (∀ a, β a) := fun _ _ ↦ decidable_of_iff _ Pi.le_def.symm
 
 instance decidableMemRangeFintype [Fintype α] [DecidableEq β] (f : α → β) :

--- a/Mathlib/Data/Fintype/Defs.lean
+++ b/Mathlib/Data/Fintype/Defs.lean
@@ -214,8 +214,8 @@ instance decidableExistsFintype {p : α → Prop} [DecidablePred p] [Fintype α]
     Decidable (∃ a, p a) :=
   decidable_of_iff (∃ a ∈ @univ α _, p a) (by simp)
 
-instance Pi.instDecidableLE {α} {β : α → Type*} [∀ i, LE (β i)] [∀ i, DecidableLE (β i)]
-  [Fintype α] : DecidableLE (∀ i, β i) := fun _ _ ↦ decidable_of_iff _ Pi.le_def.symm
+instance Pi.instDecidableLE {α} {β : α → Type*} [∀ a, LE (β a)] [∀ i, DecidableLE (β a)]
+  [Fintype α] : DecidableLE (∀ a, β a) := fun _ _ ↦ decidable_of_iff _ Pi.le_def.symm
 
 instance decidableMemRangeFintype [Fintype α] [DecidableEq β] (f : α → β) :
     DecidablePred (· ∈ Set.range f) := fun _ => Fintype.decidableExistsFintype

--- a/Mathlib/Data/Fintype/Defs.lean
+++ b/Mathlib/Data/Fintype/Defs.lean
@@ -214,6 +214,9 @@ instance decidableExistsFintype {p : α → Prop} [DecidablePred p] [Fintype α]
     Decidable (∃ a, p a) :=
   decidable_of_iff (∃ a ∈ @univ α _, p a) (by simp)
 
+instance Pi.instDecidableLE {α} {β : α → Type*} [∀ i, LE (β i)] [∀ i, DecidableLE (β i)]
+  [Fintype α] : DecidableLE (∀ i, β i) := fun _ _ ↦ decidable_of_iff _ Pi.le_def.symm
+
 instance decidableMemRangeFintype [Fintype α] [DecidableEq β] (f : α → β) :
     DecidablePred (· ∈ Set.range f) := fun _ => Fintype.decidableExistsFintype
 

--- a/Mathlib/Data/Fintype/Defs.lean
+++ b/Mathlib/Data/Fintype/Defs.lean
@@ -214,8 +214,9 @@ instance decidableExistsFintype {p : α → Prop} [DecidablePred p] [Fintype α]
     Decidable (∃ a, p a) :=
   decidable_of_iff (∃ a ∈ @univ α _, p a) (by simp)
 
-instance Pi.instDecidableLE {α} {β : α → Type*} [∀ a, LE (β a)] [∀ a, DecidableLE (β a)]
-  [Fintype α] : DecidableLE (∀ a, β a) := fun _ _ ↦ decidable_of_iff _ Pi.le_def.symm
+instance {β : α → Type*} [∀ a, LE (β a)] [∀ a, DecidableLE (β a)] [Fintype α] :
+    DecidableLE (∀ a, β a) :=
+  fun _ _ ↦ decidable_of_iff _ Pi.le_def.symm
 
 instance decidableMemRangeFintype [Fintype α] [DecidableEq β] (f : α → β) :
     DecidablePred (· ∈ Set.range f) := fun _ => Fintype.decidableExistsFintype


### PR DESCRIPTION
This PR grew out of the project to define the Tamari lattice in https://github.com/Julian-Kuelshammer/ExtensionClosedSubcategoriesOfAn/blob/main/ExtensionClosedSubcategoriesOfAn/BracketingFunctions.lean

Prepared with the help of Claude. For this specific instance, I asked what was needed to make defining the Tamari lattice in the project above work. It then suggested an instance just for functions (Fin n -> Fin n). After the discussion it suggested the instance above but with an assumption of Preorder instead of LE, so I changed that. I then found a (hopefully) suitable file to put it in and changed the variable names to the surrouning ones.  

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
