### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Subgroup/Ker): add `Subgroup.map_top`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Ker.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Ker.lean
@@ -81,6 +81,11 @@ theorem mem_range {f : G →* N} {y : N} : y ∈ f.range ↔ ∃ x, f x = y :=
 @[to_additive]
 theorem range_eq_map (f : G →* N) : f.range = (⊤ : Subgroup G).map f := by ext; simp
 
+/-- The image of `⊤` under a group homomorphism equals its range. -/
+@[to_additive]
+theorem _root_.Subgroup.map_top (f : G →* N) : (⊤ : Subgroup G).map f = f.range :=
+  (range_eq_map f).symm
+
 @[to_additive (attr := simp)]
 theorem comap_range_self (f : G →* N) : f.range.comap f = ⊤ := by
   ext
@@ -633,6 +638,6 @@ open MonoidHom in
 lemma map_range_powMonoidHom (e : M ≃* N) (n : ℕ) :
     (powMonoidHom (α := M) n).range.map e = (powMonoidHom (α := N) n).range := by
   have H : (e : M →* N).comp (powMonoidHom n) = (powMonoidHom n).comp e := by ext : 1; simp
-  rw [map_range, H, range_comp, e.range_eq_top, ← range_eq_map]
+  rw [map_range, H, range_comp, e.range_eq_top, Subgroup.map_top]
 
 end MulEquiv

--- a/Mathlib/Analysis/Normed/Group/Hom.lean
+++ b/Mathlib/Analysis/Normed/Group/Hom.lean
@@ -696,7 +696,7 @@ theorem incl_range (s : AddSubgroup V₁) : (incl s).range = s := by
 
 @[simp]
 theorem range_comp_incl_top : (f.comp (incl (⊤ : AddSubgroup V₁))).range = f.range := by
-  simp [comp_range, incl_range, ← AddMonoidHom.range_eq_map]; rfl
+  simp [comp_range, incl_range, AddSubgroup.map_top]; rfl
 
 end Range
 

--- a/Mathlib/GroupTheory/Commutator/Basic.lean
+++ b/Mathlib/GroupTheory/Commutator/Basic.lean
@@ -469,7 +469,7 @@ variable {G} in
 @[to_additive]
 lemma Subgroup.map_subtype_commutator (H : Subgroup G) :
     (_root_.commutator H).map H.subtype = ⁅H, H⁆ := by
-  rw [_root_.commutator_def, map_commutator, ← MonoidHom.range_eq_map, H.range_subtype]
+  rw [_root_.commutator_def, map_commutator, Subgroup.map_top, H.range_subtype]
 
 variable {G} in
 @[to_additive]
@@ -587,8 +587,8 @@ theorem Subgroup.Normal.commutator_le_of_self_sup_commutative_eq_top {N : Subgro
   apply Function.Surjective.isMulCommutative (f := φ) _ hH
   -- We have to prove that `MonoidHom.range φ = ⊤`
   have : Subgroup.map (QuotientGroup.mk' N) ⊤ = ⊤ := by
-    rw [← MonoidHom.range_eq_map, MonoidHom.range_eq_top]
+    rw [Subgroup.map_top, MonoidHom.range_eq_top]
     exact QuotientGroup.mk'_surjective N
   rw [MulHom.coe_coe, ← MonoidHom.range_eq_top, MonoidHom.range_eq_map, ← Subgroup.map_map, ← this,
-    Subgroup.map_eq_map_iff, QuotientGroup.ker_mk', sup_comm, ← hHN, ← MonoidHom.range_eq_map]
+    Subgroup.map_eq_map_iff, QuotientGroup.ker_mk', sup_comm, ← hHN, Subgroup.map_top]
   simp

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -241,7 +241,7 @@ set_option backward.isDefEq.respectTransparency false in
 theorem subgroup_closure_range_simple : Subgroup.closure (range cs.simple) = ⊤ := by
   have : cs.simple = cs.mulEquiv.symm ∘ PresentedGroup.of := rfl
   rw [this, Set.range_comp, ← MulEquiv.coe_toMonoidHom, ← MonoidHom.map_closure,
-    PresentedGroup.closure_range_of, ← MonoidHom.range_eq_map]
+    PresentedGroup.closure_range_of, Subgroup.map_top]
   exact MonoidHom.range_eq_top.2 (MulEquiv.surjective _)
 
 /-- The simple reflections of `W` generate `W` as a monoid. -/

--- a/Mathlib/GroupTheory/IsPerfect.lean
+++ b/Mathlib/GroupTheory/IsPerfect.lean
@@ -49,7 +49,7 @@ lemma isPerfect_def : IsPerfect G ↔ commutator G = ⊤ :=
 
 lemma _root_.Subgroup.isPerfect_iff : IsPerfect H ↔ ⁅H, H⁆ = H := by
   rw [Group.isPerfect_def, ← map_subtype_inj,
-    map_subtype_commutator, ← MonoidHom.range_eq_map, range_subtype]
+    map_subtype_commutator, Subgroup.map_top, range_subtype]
 
 lemma _root_.Subgroup.commutator_eq_self [hH : IsPerfect H] : ⁅H, H⁆ = H :=
   isPerfect_iff.mp hH
@@ -65,7 +65,7 @@ instance [Subsingleton G] : IsPerfect G where
 
 theorem top_iff : IsPerfect (⊤ : Subgroup G) ↔ IsPerfect G := by
   rw [isPerfect_def, isPerfect_def, ← map_subtype_inj,
-    map_subtype_commutator, ← MonoidHom.range_eq_map, subtype_range, commutator_def]
+    map_subtype_commutator, Subgroup.map_top, subtype_range, commutator_def]
 
 instance [IsPerfect G] : IsPerfect (⊤ : Subgroup G) :=
   top_iff.mpr inferInstance

--- a/Mathlib/GroupTheory/IsSubnormal.lean
+++ b/Mathlib/GroupTheory/IsSubnormal.lean
@@ -216,7 +216,7 @@ lemma trans' {H : Subgroup K} (Hsn : IsSubnormal H) (Ksn : IsSubnormal K) :
     IsSubnormal (H.map K.subtype) := by
   induction Hsn with
   | top =>
-    rwa [← MonoidHom.range_eq_map, range_subtype]
+    rwa [Subgroup.map_top, range_subtype]
   | step A B h_le hSubn hN ih =>
     refine step (A.map K.subtype) (B.map K.subtype) (map_mono h_le) ih ?_
     rw [normal_subgroupOf_iff_le_normalizer h_le] at hN

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -488,7 +488,7 @@ coincides with the lower central series of `H` viewed as its own additive group,
 to `G`. -/]
 theorem top_subtype_lowerCentralSeries (H : Subgroup G) (n : ℕ) :
     (lowerCentralSeries ⊤ n).map H.subtype = H.lowerCentralSeries n := by
-  rw [map_lowerCentralSeries, ← MonoidHom.range_eq_map, subtype_range]
+  rw [map_lowerCentralSeries, Subgroup.map_top, subtype_range]
 
 /-- A subgroup is nilpotent iff its lower central series (computed in the ambient group) eventually
 vanishes. -/

--- a/Mathlib/GroupTheory/Perm/ClosureSwap.lean
+++ b/Mathlib/GroupTheory/Perm/ClosureSwap.lean
@@ -145,7 +145,7 @@ theorem surjective_of_isSwap_of_isPretransitive' [Finite α] (S : Set G)
     (hS2 : Subgroup.closure S = ⊤) [h : MulAction.IsPretransitive G α] :
     Function.Surjective (MulAction.toPermHom G α) := by
   have h : closure ((toPermHom G α '' S) \ {1}) = (toPermHom G α).range := by
-    rw [closure_sdiff_one, ← MonoidHom.map_closure, hS2, ← MonoidHom.range_eq_map]
+    rw [closure_sdiff_one, ← MonoidHom.map_closure, hS2, Subgroup.map_top]
   have := IsPretransitive.of_compHom (α := α) (toPermHom G α).rangeRestrict
   rw [← h] at this
   rw [← MonoidHom.range_eq_top, ← h, closure_of_isSwap_of_isPretransitive]

--- a/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
@@ -214,7 +214,7 @@ lemma _root_.Subgroup.isPretransitive_of_stabilizer_lt
     apply not_lt_of_ge
     --  `G ≤ stabilizer (Equiv.Perm α) s`
     have : G = Subgroup.map G.subtype ⊤ := by
-      rw [← MonoidHom.range_eq_map, Subgroup.range_subtype]
+      rw [Subgroup.map_top, Subgroup.range_subtype]
     rw [this, Subgroup.map_le_iff_le_comap]
     rw [show Subgroup.comap G.subtype (stabilizer M s) = stabilizer G s from rfl, hG]
 

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -91,7 +91,7 @@ theorem closure_range_of (rels : Set (FreeGroup α)) :
     Subgroup.closure (Set.range (PresentedGroup.of : α → PresentedGroup rels)) = ⊤ := by
   have : (PresentedGroup.of : α → PresentedGroup rels) = QuotientGroup.mk' _ ∘ FreeGroup.of := rfl
   rw [this, Set.range_comp, ← MonoidHom.map_closure (QuotientGroup.mk' _),
-    FreeGroup.closure_range_of, ← MonoidHom.range_eq_map]
+    FreeGroup.closure_range_of, Subgroup.map_top]
   exact MonoidHom.range_eq_top.2 (QuotientGroup.mk'_surjective _)
 
 @[induction_eliminator]

--- a/Mathlib/GroupTheory/Solvable.lean
+++ b/Mathlib/GroupTheory/Solvable.lean
@@ -225,7 +225,7 @@ theorem isSolvable_iff_commutator_lt [WellFoundedLT (Subgroup G)] :
     induction n with
     | zero =>
       rw [derivedSeries_succ, derivedSeries_zero, derivedSeries_zero, map_commutator,
-        ← MonoidHom.range_eq_map, ← MonoidHom.range_eq_map, range_subtype, range_subtype]
+        Subgroup.map_top, Subgroup.map_top, range_subtype, range_subtype]
     | succ n ih => rw [derivedSeries_succ, map_commutator, ih, derivedSeries_succ, map_commutator]
 
 @[deprecated (since := "2026-07-16")]

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
@@ -289,7 +289,7 @@ theorem commutator_alternatingGroup_eq_top (h5 : 5 ≤ Nat.card α) :
 theorem commutator_alternatingGroup_eq_self (h5 : 5 ≤ Nat.card α) :
     ⁅alternatingGroup α, alternatingGroup α⁆ = alternatingGroup α := by
   rw [← Subgroup.map_subtype_commutator, commutator_alternatingGroup_eq_top h5,
-    ← MonoidHom.range_eq_map, Subgroup.range_subtype]
+    Subgroup.map_top, Subgroup.range_subtype]
 
 /-- The commutator subgroup of the permutation group is the alternating group -/
 theorem alternatingGroup.commutator_perm_eq (h5 : 5 ≤ Nat.card α) :

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/MaximalSubgroups.lean
@@ -175,8 +175,7 @@ theorem subgroup_eq_top_of_isPreprimitive (h4 : 4 < Nat.card α)
     (hG : stabilizer (alternatingGroup α) s ≤ G) :
     G = ⊤ := by
   obtain ⟨g, hg, hg3⟩ := exists_mem_stabilizer_isThreeCycle s h4
-  rw [eq_top_iff, ← Subgroup.map_subtype_le_map_subtype,
-    Subgroup.map_top, Subgroup.range_subtype]
+  rw [eq_top_iff, ← Subgroup.map_subtype_le_map_subtype, Subgroup.map_top, Subgroup.range_subtype]
   -- By Jordan's theorem, it suffices to prove that G acts primitively
   apply alternatingGroup_le_of_isPreprimitive_of_isThreeCycle_mem _ hg3
   · use ⟨g, hg3.mem_alternatingGroup⟩

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/MaximalSubgroups.lean
@@ -176,7 +176,7 @@ theorem subgroup_eq_top_of_isPreprimitive (h4 : 4 < Nat.card α)
     G = ⊤ := by
   obtain ⟨g, hg, hg3⟩ := exists_mem_stabilizer_isThreeCycle s h4
   rw [eq_top_iff, ← Subgroup.map_subtype_le_map_subtype,
-    ← MonoidHom.range_eq_map, Subgroup.range_subtype]
+    Subgroup.map_top, Subgroup.range_subtype]
   -- By Jordan's theorem, it suffices to prove that G acts primitively
   apply alternatingGroup_le_of_isPreprimitive_of_isThreeCycle_mem _ hg3
   · use ⟨g, hg3.mem_alternatingGroup⟩

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic/Basic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic/Basic.lean
@@ -41,7 +41,7 @@ theorem isCyclic_iff_exists_zpowers_eq_top [Group α] : IsCyclic α ↔ ∃ g : 
 protected theorem Subgroup.isCyclic_iff_exists_zpowers_eq_top [Group α] (H : Subgroup α) :
     IsCyclic H ↔ ∃ g : α, Subgroup.zpowers g = H := by
   rw [isCyclic_iff_exists_zpowers_eq_top]
-  simp_rw [← map_subtype_inj, ← MonoidHom.range_eq_map,
+  simp_rw [← map_subtype_inj, Subgroup.map_top,
     H.range_subtype, MonoidHom.map_zpowers, Subtype.exists, coe_subtype, exists_prop]
   exact exists_congr fun g ↦ and_iff_right_of_imp fun h ↦ h ▸ mem_zpowers g
 

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -256,7 +256,7 @@ theorem normalizer_le_centralizer_or_le_commutator :
     isCyclic_of_surjective _ (Subgroup.subgroupOfEquivOfLe P.le_normalizer).symm.surjective
   refine (le_center_or_le_commutator Q).imp (fun h ↦ ?_) (fun h ↦ ?_)
   · rw [← SetLike.coe_subset_coe, ← Subgroup.centralizer_eq_top_iff_subset, eq_top_iff,
-      ← Subgroup.map_subtype_le_map_subtype, ← MonoidHom.range_eq_map,
+      ← Subgroup.map_subtype_le_map_subtype, Subgroup.map_top,
       (Subgroup.normalizer (P : Set G)).range_subtype] at h
     replace h := h.trans (Subgroup.map_centralizer_le_centralizer_image _ _)
     rwa [← Subgroup.coe_map, P.coe_subtype, ← P.coe_coe,

--- a/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -296,9 +296,9 @@ lemma finiteIndex_conjGL (g : GL (Fin 2) ℚ) : (conjGL ⊤ (g.map <| Rat.castHo
   constructor
   let t := (toConjAct <| g.map <| Rat.castHom ℝ)⁻¹
   suffices (t • 𝒮ℒ ⊓ 𝒮ℒ).relIndex 𝒮ℒ ≠ 0 by
-    rwa [conjGL, index_comap, ← inf_relIndex_right, ← MonoidHom.range_eq_map]
+    rwa [conjGL, index_comap, ← inf_relIndex_right, Subgroup.map_top]
   obtain ⟨N, hN, hN'⟩ := exists_Gamma_le_conj' g 1
-  rw [Gamma_one_top, ← MonoidHom.range_eq_map] at hN'
+  rw [Gamma_one_top, Subgroup.map_top] at hN'
   suffices Γ(N) ≤ (t • 𝒮ℒ ⊓ 𝒮ℒ).comap (mapGL ℝ) by
     have _ : NeZero N := ⟨hN⟩
     simpa only [index_comap] using! (finiteIndex_of_le this).index_ne_zero

--- a/Mathlib/RingTheory/Valuation/Discrete/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Discrete/Basic.lean
@@ -124,7 +124,7 @@ lemma embedding_generator' :
 
 lemma generator'_zpowers_eq_top : (zpowers (generator' v)) = ⊤ := by
   rw [← map_subtype_inj, MonoidHom.map_zpowers,
-    subtype_apply, ← MonoidHom.range_eq_map, Subgroup.subtype_range]
+    subtype_apply, Subgroup.map_top, Subgroup.subtype_range]
   apply generator_zpowers_eq_valueGroup
 
 lemma generator'_lt_one : generator' v < 1 :=


### PR DESCRIPTION
This adds `Subgroup.map_top : (⊤ : Subgroup G).map f = f.range`, the reverse direction of `MonoidHom.range_eq_map`, and uses it at the 21 places where mathlib was rewriting with `← MonoidHom.range_eq_map`.

The lemma was originally part of #40597; it is extracted here so that the refactor can be reviewed separately.

Prepared with Claude Code 🤖

---
