### PR TITLE
[Merged by Bors] - perf(Tactic/Linter/InternalConstructor): try `foldInfo` instead of `foldInfoM`

### DIFF
--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -60,19 +60,24 @@ def internalConstructor : Linter where
     unless Linter.getLinterValue linter.internalConstructors (← Linter.getLinterOptions) do
       return
     for t in ← getInfoTrees do
-      t.foldInfoM (init := ()) fun ctx info _ => do
+      -- Collect the warnings separately from logging them, since (compiled) `foldInfo` is faster
+      -- than (interpreted, specialized) `foldInfoM`.
+      let warnings := t.foldInfo (init := #[]) fun ctx info w =>
         match info with
-        | .ofTermInfo i =>
-          let .const n _ := i.expr.cleanupAnnotations | pure ()
+        | .ofTermInfo i => Id.run do
+          let .const n _ := i.expr.cleanupAnnotations | pure w
           if
             -- Putting the conjuncts in this order provides a performance benefit.
             n.isInternal && !isPrivateName n && ctx.env.isImportedConst n && ctx.env.isConstructor n
           then
-            -- Use `withRef` to fall back to outer ref if `info.stx` has no position info
-            withRef info.stx do
-              logLintError linter.internalConstructors (← getRef)
-                m!"`{.ofConstName n}` is an internal constructor and should not be used directly."
-        | _ => pure ()
+            pure <| w.push (n, i.stx)
+          else
+            pure w
+        | _ => w
+      for (name, stx) in warnings do
+        logLintError linter.internalConstructors stx
+          m!"`{.ofConstName name}` is an internal constructor and should not be used directly."
+
 where
   /-- We inline some of `logLint` so that we can log an error instead of a warning. -/
   logLintError (linterOption) (stx) (msg) := do

--- a/Mathlib/Tactic/Linter/InternalConstructor.lean
+++ b/Mathlib/Tactic/Linter/InternalConstructor.lean
@@ -62,18 +62,15 @@ def internalConstructor : Linter where
     for t in ← getInfoTrees do
       -- Collect the warnings separately from logging them, since (compiled) `foldInfo` is faster
       -- than (interpreted, specialized) `foldInfoM`.
-      let warnings := t.foldInfo (init := #[]) fun ctx info w =>
-        match info with
-        | .ofTermInfo i => Id.run do
-          let .const n _ := i.expr.cleanupAnnotations | pure w
-          if
-            -- Putting the conjuncts in this order provides a performance benefit.
-            n.isInternal && !isPrivateName n && ctx.env.isImportedConst n && ctx.env.isConstructor n
-          then
-            pure <| w.push (n, i.stx)
-          else
-            pure w
-        | _ => w
+      let warnings := t.foldInfo (init := #[]) fun ctx info w => Id.run do
+        if let .ofTermInfo i := info then
+          if let .const n _ := i.expr.cleanupAnnotations then
+            if
+              -- Putting the conjuncts in this order provides a performance benefit.
+              n.isInternal && !isPrivateName n && ctx.env.isImportedConst n && ctx.env.isConstructor n
+            then
+              return w.push (n, i.stx)
+        return w
       for (name, stx) in warnings do
         logLintError linter.internalConstructors stx
           m!"`{.ofConstName name}` is an internal constructor and should not be used directly."


### PR DESCRIPTION
According Jovan's comments in #42883, this is supposed to be faster.

Right now I don't know how to replicate the `getRef` for fallback position info if the syntax itself doesn't contain position info. But first let's see if this is actually faster.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
