### PR TITLE
feat(CategoryTheory/LiftingProperties): the unique lifting property

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -240,6 +240,7 @@ public import Mathlib.Algebra.Category.Ring.EqualizerPushout
 public import Mathlib.Algebra.Category.Ring.FilteredColimits
 public import Mathlib.Algebra.Category.Ring.FinitePresentation
 public import Mathlib.Algebra.Category.Ring.Instances
+public import Mathlib.Algebra.Category.Ring.LiftingProperties
 public import Mathlib.Algebra.Category.Ring.Limits
 public import Mathlib.Algebra.Category.Ring.LinearAlgebra
 public import Mathlib.Algebra.Category.Ring.Small
@@ -2885,10 +2886,13 @@ public import Mathlib.CategoryTheory.Join.Pseudofunctor
 public import Mathlib.CategoryTheory.Join.Sum
 public import Mathlib.CategoryTheory.LiftingProperties.Adjunction
 public import Mathlib.CategoryTheory.LiftingProperties.Basic
+public import Mathlib.CategoryTheory.LiftingProperties.Diagonal
 public import Mathlib.CategoryTheory.LiftingProperties.Limits
 public import Mathlib.CategoryTheory.LiftingProperties.Over
 public import Mathlib.CategoryTheory.LiftingProperties.ParametrizedAdjunction
 public import Mathlib.CategoryTheory.LiftingProperties.PushoutProduct
+public import Mathlib.CategoryTheory.LiftingProperties.Unique
+public import Mathlib.CategoryTheory.LiftingProperties.UniqueLimits
 public import Mathlib.CategoryTheory.Limits.Bicones
 public import Mathlib.CategoryTheory.Limits.Chosen.End
 public import Mathlib.CategoryTheory.Limits.ColimitLimit
@@ -3291,6 +3295,7 @@ public import Mathlib.CategoryTheory.MorphismProperty.Local
 public import Mathlib.CategoryTheory.MorphismProperty.LocalClosure
 public import Mathlib.CategoryTheory.MorphismProperty.LocalEpi
 public import Mathlib.CategoryTheory.MorphismProperty.OfObjectProperty
+public import Mathlib.CategoryTheory.MorphismProperty.Orthogonal
 public import Mathlib.CategoryTheory.MorphismProperty.OverAdjunction
 public import Mathlib.CategoryTheory.MorphismProperty.Quotient
 public import Mathlib.CategoryTheory.MorphismProperty.Representable
@@ -3557,6 +3562,7 @@ public import Mathlib.CategoryTheory.SmallObject.Iteration.FunctorOfCocone
 public import Mathlib.CategoryTheory.SmallObject.Iteration.Nonempty
 public import Mathlib.CategoryTheory.SmallObject.TransfiniteCompositionLifting
 public import Mathlib.CategoryTheory.SmallObject.TransfiniteIteration
+public import Mathlib.CategoryTheory.SmallObject.UniqueTransfiniteCompositionLifting
 public import Mathlib.CategoryTheory.SmallObject.WellOrderInductionData
 public import Mathlib.CategoryTheory.SmallRepresentatives
 public import Mathlib.CategoryTheory.Square

--- a/Mathlib/Algebra/Category/Ring/LiftingProperties.lean
+++ b/Mathlib/Algebra/Category/Ring/LiftingProperties.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Jakob Scholbach. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jakob Scholbach
+-/
+module
+
+public import Mathlib.CategoryTheory.LiftingProperties.Unique
+public import Mathlib.Algebra.Category.Ring.Basic
+
+/-!
+# Unique lifting between ring maps in `CommRingCat`
+
+The unique lifting property between two morphisms `ofHom f`, `ofHom p` of
+`CommRingCat` says exactly that every commuting square of ring homomorphisms
+built from `f` and `p` admits a unique diagonal filler. This file records that
+translation.
+
+## Main declarations
+
+* `CommRingCat.hasUniqueLiftingProperty_ofHom_iff`
+-/
+
+public section
+
+open CategoryTheory CommRingCat
+
+universe u
+
+namespace CommRingCat
+
+/-- The unique lifting property between `ofHom f` and `ofHom p` in `CommRingCat` translated to a
+purely ring-theoretic existence-and-uniqueness statement. -/
+theorem hasUniqueLiftingProperty_ofHom_iff {A B X Y : Type u} [CommRing A] [CommRing B] [CommRing X]
+    [CommRing Y] (f : A →+* B) (p : X →+* Y) :
+    HasUniqueLiftingProperty (CommRingCat.ofHom f) (CommRingCat.ofHom p) ↔
+    ∀ (t : A →+* X) (b : B →+* Y), p.comp t = b.comp f →
+      ∃! l : B →+* X, l.comp f = t ∧ p.comp l = b := by
+  rw [hasUniqueLiftingProperty_iff]
+  constructor
+  · intro H t b hc
+    have sq : CommSq (CommRingCat.ofHom t) (CommRingCat.ofHom f) (CommRingCat.ofHom p)
+        (CommRingCat.ofHom b) := ⟨by rw [← ofHom_comp, ← ofHom_comp, hc]⟩
+    obtain ⟨l, ⟨hl1, hl2⟩, hu⟩ := H (CommRingCat.ofHom t) (CommRingCat.ofHom b) sq
+    refine ⟨l.hom, ⟨by simpa using congrArg (·.hom) hl1, by simpa using congrArg (·.hom) hl2⟩, ?_⟩
+    intro m ⟨hm1, hm2⟩
+    have hml : CommRingCat.ofHom m = l :=
+      hu (CommRingCat.ofHom m) ⟨by rw [← ofHom_comp, hm1], by rw [← ofHom_comp, hm2]⟩
+    rw [← hom_ofHom m, hml]
+  · intro H t b sq
+    obtain ⟨l, ⟨hl1, hl2⟩, hu⟩ := H t.hom b.hom (by simpa using congrArg (·.hom) sq.w)
+    refine ⟨CommRingCat.ofHom l, ⟨?_, ?_⟩, ?_⟩
+    · rw [← ofHom_comp, hl1, ofHom_hom]
+    · rw [← ofHom_comp, hl2, ofHom_hom]
+    · intro m ⟨hm1, hm2⟩
+      have hml : m.hom = l :=
+        hu m.hom ⟨by simpa using congrArg (·.hom) hm1, by simpa using congrArg (·.hom) hm2⟩
+      rw [← ofHom_hom m, hml]
+
+end CommRingCat

--- a/Mathlib/CategoryTheory/LiftingProperties/Basic.lean
+++ b/Mathlib/CategoryTheory/LiftingProperties/Basic.lean
@@ -16,6 +16,8 @@ shows basic properties of this notion.
 
 ## Main results
 - `HasLiftingProperty`: the definition of the lifting property
+- `isIso_of_hasLiftingProperty_self`: a morphism with the lifting property against itself
+  is an isomorphism
 
 ## Tags
 lifting property
@@ -118,6 +120,13 @@ theorem iff_of_arrow_iso_left {A B A' B' X Y : C} {i : A ⟶ B} {i' : A' ⟶ B'}
   exacts [of_arrow_iso_left e p, of_arrow_iso_left e.symm p]
 
 end HasLiftingProperty
+
+/-- A morphism with the (ordinary, not necessarily unique) lifting property against itself is an
+isomorphism. -/
+@[to_dual self]
+lemma isIso_of_hasLiftingProperty_self (f : X ⟶ Y) [HasLiftingProperty f f] : IsIso f :=
+  have sq : CommSq (𝟙 X) f f (𝟙 Y) := ⟨by rw [id_comp, comp_id]⟩
+  ⟨sq.lift, sq.fac_left, sq.fac_right⟩
 
 @[to_dual]
 lemma RetractArrow.rightLiftingProperty

--- a/Mathlib/CategoryTheory/LiftingProperties/Diagonal.lean
+++ b/Mathlib/CategoryTheory/LiftingProperties/Diagonal.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Jakob Scholbach. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jakob Scholbach
+-/
+module
+
+public import Mathlib.CategoryTheory.LiftingProperties.Unique
+public import Mathlib.CategoryTheory.Limits.Shapes.Diagonal
+
+/-!
+# Unique lifting via the codiagonal and the diagonal
+
+For `i : A ⟶ B` and `p : X ⟶ Y`, uniqueness of lifts of squares from `i` to `p` is equivalent
+to the ordinary (non-unique) lifting property of `i` against the diagonal
+`X ⟶ X ×_Y X` (`pullback.diagonal p`), and also to that of the codiagonal
+`B ⊔_A B ⟶ B` (`pushout.codiagonal i`) against `p`: a pair of lifts of a square from `i` to `p`
+corresponds to a lift of a square built from the (co)diagonal. Consequently the unique lifting
+property is the conjunction of two ordinary lifting properties.
+
+## Main declarations
+
+* `hasAtMostOneLiftingProperty_iff_codiagonal`, `hasAtMostOneLiftingProperty_iff_diagonal`;
+* `hasUniqueLiftingProperty_iff_lifting_and_codiagonal`,
+  `hasUniqueLiftingProperty_iff_lifting_and_diagonal`.
+-/
+
+public section
+
+namespace CategoryTheory
+
+open Category Limits
+
+variable {C : Type*} [Category* C] {A B X Y : C} (i : A ⟶ B) (p : X ⟶ Y)
+
+section Codiagonal
+
+variable [HasPushout i i]
+
+/-- Lifts against `i` are unique if and only if lifts against the codiagonal of
+`i` exist. -/
+theorem hasAtMostOneLiftingProperty_iff_codiagonal :
+    HasAtMostOneLiftingProperty i p ↔ HasLiftingProperty (pushout.codiagonal i) p := by
+  constructor
+  · intro h
+    refine ⟨fun {f g} sq => ?_⟩
+    -- the two legs of `f` are lifts of the same square under `i`, hence agree
+    have hl : pushout.inl i i ≫ f = pushout.inr i i ≫ f :=
+      CommSq.lift_eq_of_hasAtMostOneLiftingProperty i p
+        (sq := ⟨by rw [assoc, assoc, sq.w, pushout.inl_codiagonal_assoc]⟩)
+        rfl (by rw [assoc, sq.w, pushout.inl_codiagonal_assoc])
+        (pushout.condition_assoc f).symm (by rw [assoc, sq.w, pushout.inr_codiagonal_assoc])
+    exact CommSq.HasLift.mk'
+      { l := pushout.inl i i ≫ f
+        fac_left := pushout.hom_ext (by rw [pushout.inl_codiagonal_assoc])
+          (by rw [pushout.inr_codiagonal_assoc, hl])
+        fac_right := by rw [assoc, sq.w, pushout.inl_codiagonal_assoc] }
+  · intro h
+    refine ⟨fun {f g} sq => ⟨fun l₁ l₂ => ?_⟩⟩
+    -- glue the two lifts to a square under the codiagonal; both are legs of its lift
+    have sq' : CommSq (pushout.desc l₁.l l₂.l (l₁.fac_left.trans l₂.fac_left.symm))
+        (pushout.codiagonal i) p g :=
+      ⟨pushout.hom_ext
+        (by rw [pushout.inl_desc_assoc, l₁.fac_right, pushout.inl_codiagonal_assoc])
+        (by rw [pushout.inr_desc_assoc, l₂.fac_right, pushout.inr_codiagonal_assoc])⟩
+    apply CommSq.LiftStruct.ext
+    calc l₁.l = pushout.inl i i ≫ pushout.codiagonal i ≫ sq'.lift := by
+            rw [sq'.fac_left, pushout.inl_desc]
+      _ = pushout.inr i i ≫ pushout.codiagonal i ≫ sq'.lift := by
+            rw [pushout.inl_codiagonal_assoc, pushout.inr_codiagonal_assoc]
+      _ = l₂.l := by rw [sq'.fac_left, pushout.inr_desc]
+
+/-- Lifts against `i` exist uniquely if and only if ordinary lifts exist against
+both `i` and its codiagonal. -/
+theorem hasUniqueLiftingProperty_iff_lifting_and_codiagonal :
+    HasUniqueLiftingProperty i p ↔
+      HasLiftingProperty i p ∧ HasLiftingProperty (pushout.codiagonal i) p :=
+  ⟨fun h => ⟨h.toHasLiftingProperty,
+    (hasAtMostOneLiftingProperty_iff_codiagonal i p).mp h.toHasAtMostOneLiftingProperty⟩,
+   fun ⟨hi, hc⟩ => { hi, (hasAtMostOneLiftingProperty_iff_codiagonal i p).mpr hc with }⟩
+
+end Codiagonal
+
+section Diagonal
+
+variable [HasPullback p p]
+
+/-- Lifts against `p` are unique if and only if lifts against the diagonal of
+`p` exist. -/
+theorem hasAtMostOneLiftingProperty_iff_diagonal :
+    HasAtMostOneLiftingProperty i p ↔ HasLiftingProperty i (pullback.diagonal p) := by
+  constructor
+  · intro h
+    refine ⟨fun {f g} sq => ?_⟩
+    -- the two legs of `g` are lifts of the same square under `i`, hence agree
+    have h₁ : i ≫ g ≫ pullback.fst p p = f := by
+      rw [← assoc, ← sq.w, assoc, pullback.diagonal_fst, comp_id]
+    have h₂ : i ≫ g ≫ pullback.snd p p = f := by
+      rw [← assoc, ← sq.w, assoc, pullback.diagonal_snd, comp_id]
+    have sq₀ : CommSq f i p (g ≫ pullback.fst p p ≫ p) :=
+      ⟨by rw [← assoc, ← sq.w, assoc, pullback.diagonal_fst_assoc]⟩
+    have hl : g ≫ pullback.fst p p = g ≫ pullback.snd p p :=
+      CommSq.lift_eq_of_hasAtMostOneLiftingProperty i p (sq := sq₀)
+        h₁ (assoc _ _ _) h₂ (by rw [assoc, ← pullback.condition])
+    exact CommSq.HasLift.mk'
+      { l := g ≫ pullback.fst p p
+        fac_left := h₁
+        fac_right := pullback.hom_ext
+          (by rw [assoc, assoc, pullback.diagonal_fst, comp_id])
+          (by rw [assoc, assoc, pullback.diagonal_snd, comp_id, hl]) }
+  · intro h
+    refine ⟨fun {f g} sq => ⟨fun l₁ l₂ => ?_⟩⟩
+    -- glue the two lifts to a square over the diagonal; both are legs of its lift
+    have sq' : CommSq f i (pullback.diagonal p)
+        (pullback.lift l₁.l l₂.l (l₁.fac_right.trans l₂.fac_right.symm)) :=
+      ⟨pullback.hom_ext
+        (by rw [assoc, assoc, pullback.diagonal_fst, pullback.lift_fst, comp_id, l₁.fac_left])
+        (by rw [assoc, assoc, pullback.diagonal_snd, pullback.lift_snd, comp_id, l₂.fac_left])⟩
+    apply CommSq.LiftStruct.ext
+    calc l₁.l = (sq'.lift ≫ pullback.diagonal p) ≫ pullback.fst p p := by
+            rw [sq'.fac_right, pullback.lift_fst]
+      _ = (sq'.lift ≫ pullback.diagonal p) ≫ pullback.snd p p := by
+            rw [assoc, assoc, pullback.diagonal_fst, pullback.diagonal_snd]
+      _ = l₂.l := by rw [sq'.fac_right, pullback.lift_snd]
+
+/-- Lifts against `p` exist uniquely if and only if ordinary lifts exist against
+both `p` and its diagonal. -/
+theorem hasUniqueLiftingProperty_iff_lifting_and_diagonal :
+    HasUniqueLiftingProperty i p ↔
+      HasLiftingProperty i p ∧ HasLiftingProperty i (pullback.diagonal p) :=
+  ⟨fun h => ⟨h.toHasLiftingProperty,
+    (hasAtMostOneLiftingProperty_iff_diagonal i p).mp h.toHasAtMostOneLiftingProperty⟩,
+   fun ⟨hp, hd⟩ => { hp, (hasAtMostOneLiftingProperty_iff_diagonal i p).mpr hd with }⟩
+
+end Diagonal
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/LiftingProperties/Unique.lean
+++ b/Mathlib/CategoryTheory/LiftingProperties/Unique.lean
@@ -1,0 +1,313 @@
+/-
+Copyright (c) 2026 Jakob Scholbach. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jakob Scholbach
+-/
+module
+
+public import Mathlib.CategoryTheory.LiftingProperties.Basic
+
+/-!
+# Unique and at-most-one lifting properties
+
+For `i : A ⟶ B` and `p : X ⟶ Y`, a commutative square from `i` to `p` may have at least one
+lift (`HasLiftingProperty`), at most one (`HasAtMostOneLiftingProperty`, expressed
+as `Subsingleton sq.LiftStruct`), or exactly one (`HasUniqueLiftingProperty`, extending both).
+This file develops the at-most-one and unique variants: their basic API and their stability
+under composition, cancellation, isomorphism of arrows, retracts and duality.
+
+## Main declarations
+
+* `HasAtMostOneLiftingProperty i p`, `HasUniqueLiftingProperty i p`: the two classes.
+* `CommSq.lift_eq_of_hasAtMostOneLiftingProperty`: two fillers of the same square agree.
+* `hasUniqueLiftingProperty_iff`: the unique lifting property as an explicit `∃!` statement.
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+open Category
+
+variable {C : Type*} [Category* C] {A B X Y : C} (i : A ⟶ B) (p : X ⟶ Y)
+
+-- `to_dual` cannot validate the auto-generated translations of the class' field and
+-- constructor, because the reordering of `A B X Y` and `i p` has to be applied to them by
+-- hand; the linter asks for exactly that, and the two `attribute [to_dual …]` commands below
+-- supply the manual translations it wants. The suppression covers only those two.
+set_option linter.translate.warnInvalid false in
+/-- `i` has the at most one lift against `p` if every
+commutative square from `i` to `p` has at most one filler, i.e. its type of lifts is a
+subsingleton. -/
+@[to_dual self (reorder := A Y, B X, i p)]
+class HasAtMostOneLiftingProperty : Prop where
+  /-- Every commutative square from `i` to `p` has at most one filler. -/
+  subsingleton_liftStruct :
+    ∀ {f : A ⟶ X} {g : B ⟶ Y} (sq : CommSq f i p g), Subsingleton sq.LiftStruct
+
+attribute [to_dual self] HasAtMostOneLiftingProperty.subsingleton_liftStruct
+attribute [to_dual self (reorder := A Y, B X, i p, subsingleton_liftStruct (f g))]
+  HasAtMostOneLiftingProperty.mk
+
+/-- `i` has the unique lifting property against `p` if every commutative
+square from `i` to `p` has exactly one filler. -/
+@[to_dual self (reorder := A Y, B X, i p)]
+class HasUniqueLiftingProperty : Prop extends HasLiftingProperty i p,
+    HasAtMostOneLiftingProperty i p
+
+/-- Unfolding of `HasAtMostOneLiftingProperty` as an instance about a given square. -/
+@[to_dual self]
+instance subsingleton_liftStruct_of_hasAtMostOneLiftingProperty
+    {f : A ⟶ X} {g : B ⟶ Y} (sq : CommSq f i p g)
+    [h : HasAtMostOneLiftingProperty i p] :
+    Subsingleton sq.LiftStruct :=
+  h.subsingleton_liftStruct sq
+
+/-- If `i` has the unique lifting property against `p`, a commutative square from `i` to `p`
+has exactly one lift. This is choice-based data, not an instance: the `Unique` structure carries
+the chosen lift, so making it an instance would let unrelated `Unique` goals be closed by an
+arbitrary filler. -/
+@[to_dual self, instance_reducible]
+noncomputable def CommSq.uniqueLiftStruct {f : A ⟶ X} {g : B ⟶ Y}
+    (sq : CommSq f i p g) [HasUniqueLiftingProperty i p] : Unique sq.LiftStruct :=
+  uniqueOfSubsingleton (inferInstance : sq.HasLift).exists_lift.some
+
+/-- Two morphisms `B ⟶ X` filling the same commutative square from `i` to `p` are equal,
+provided `i` has at most one lift against `p`. -/
+@[to_dual self (reorder := A Y, B X, i p, f g, h₁ h₁', h₂ h₂')]
+theorem CommSq.lift_eq_of_hasAtMostOneLiftingProperty
+    {f : A ⟶ X} {g : B ⟶ Y} {sq : CommSq f i p g}
+    [HasAtMostOneLiftingProperty i p] {l₁ l₂ : B ⟶ X}
+    (h₁ : i ≫ l₁ = f) (h₁' : l₁ ≫ p = g)
+    (h₂ : i ≫ l₂ = f) (h₂' : l₂ ≫ p = g) : l₁ = l₂ := by
+  have : (⟨l₁, h₁, h₁'⟩ : sq.LiftStruct) = ⟨l₂, h₂, h₂'⟩ := Subsingleton.elim _ _
+  exact congrArg CommSq.LiftStruct.l this
+
+namespace HasAtMostOneLiftingProperty
+
+/-- An epimorphism has at most one lift against any `p`: two fillers agree after precomposition
+with `i`, hence agree. -/
+@[to_dual]
+instance of_epi [Epi i] : HasAtMostOneLiftingProperty i p where
+  subsingleton_liftStruct _ := inferInstance -- inferring from CommSq.subsingleton_liftStruct_of_epi
+
+variable {i p}
+
+/-- Having at most one lift is self-dual: it passes to the opposite category, with the roles
+of `i` and `p` exchanged. -/
+@[to_dual self]
+theorem op (h : HasAtMostOneLiftingProperty i p) :
+    HasAtMostOneLiftingProperty p.op i.op where
+  subsingleton_liftStruct sq := by
+    have := h.subsingleton_liftStruct sq.unop
+    exact (CommSq.LiftStruct.unopEquiv sq).subsingleton
+
+/-- The converse of `HasAtMostOneLiftingProperty.op`, for arrows of an opposite category. -/
+@[to_dual self]
+theorem unop {A B X Y : Cᵒᵖ} {i : A ⟶ B} {p : X ⟶ Y}
+    (h : HasAtMostOneLiftingProperty i p) :
+    HasAtMostOneLiftingProperty p.unop i.unop where
+  subsingleton_liftStruct sq := by
+    have := h.subsingleton_liftStruct sq.op
+    exact (CommSq.LiftStruct.opEquiv sq).subsingleton
+
+/-- Having at most one lift is invariant under passing to the opposite category. -/
+@[to_dual self]
+theorem iff_op : HasAtMostOneLiftingProperty i p ↔
+    HasAtMostOneLiftingProperty p.op i.op :=
+  ⟨op, unop⟩
+
+/-- The version of `HasAtMostOneLiftingProperty.iff_op` for arrows of an opposite category. -/
+@[to_dual self]
+theorem iff_unop {A B X Y : Cᵒᵖ} (i : A ⟶ B) (p : X ⟶ Y) :
+    HasAtMostOneLiftingProperty i p ↔
+    HasAtMostOneLiftingProperty p.unop i.unop :=
+  ⟨unop, op⟩
+
+/-- If two composable maps `i` and `i'` have at most one lift against `p`, then the same is true
+for their composite. -/
+@[to_dual of_comp_right]
+instance of_comp_left {A B B' X Y : C} (i : A ⟶ B) (i' : B ⟶ B') (p : X ⟶ Y)
+    [HasAtMostOneLiftingProperty i p] [HasAtMostOneLiftingProperty i' p] :
+    HasAtMostOneLiftingProperty (i ≫ i') p where
+  subsingleton_liftStruct {f g} sq := ⟨fun l₁ l₂ => by
+    have hl : ∀ l : sq.LiftStruct, i ≫ i' ≫ l.l = f := fun l => by rw [← assoc, l.fac_left]
+    have hr : ∀ l : sq.LiftStruct, (i' ≫ l.l) ≫ p = i' ≫ g := fun l => by simp [l.fac_right]
+    have step : i' ≫ l₁.l = i' ≫ l₂.l :=
+      CommSq.lift_eq_of_hasAtMostOneLiftingProperty i p (sq := ⟨by simp [sq.w]⟩)
+        (hl l₁) (hr l₁) (hl l₂) (hr l₂)
+    exact CommSq.LiftStruct.ext (CommSq.lift_eq_of_hasAtMostOneLiftingProperty i' p
+      (sq := ⟨hr l₁⟩) rfl l₁.fac_right step.symm l₂.fac_right)⟩
+
+/-- If `i` has at most one lift against `p ≫ q`, then it has at most one lift against `p`.
+No hypothesis on the cancelled factor `q` is needed: a lift of a square against `p` is
+also a lift of the composed square against `p ≫ q`. -/
+@[to_dual of_comp_left_cancel]
+theorem of_comp_right_cancel {A B X Y Z : C} (i : A ⟶ B) (p : X ⟶ Y) (q : Y ⟶ Z)
+    [HasAtMostOneLiftingProperty i (p ≫ q)] : HasAtMostOneLiftingProperty i p where
+  subsingleton_liftStruct {f g} sq := ⟨fun l₁ l₂ =>
+    CommSq.LiftStruct.ext (CommSq.lift_eq_of_hasAtMostOneLiftingProperty i (p ≫ q)
+      (sq := ⟨by rw [← assoc, sq.w, assoc]⟩)
+      l₁.fac_left (by rw [← assoc, l₁.fac_right])
+      l₂.fac_left (by rw [← assoc, l₂.fac_right]))⟩
+
+/-- Having at most one lift against a given map `p` is stable under isomorphism of arrows. -/
+@[to_dual (reorder := i i' e p) of_arrow_iso_right]
+theorem of_arrow_iso_left {A B A' B' X Y : C} {i : A ⟶ B} {i' : A' ⟶ B'}
+    (e : Arrow.mk i ≅ Arrow.mk i') (p : X ⟶ Y)
+    [HasAtMostOneLiftingProperty i p] : HasAtMostOneLiftingProperty i' p := by
+  rw [Arrow.iso_w' e]
+  infer_instance
+
+/-- The `Iff` version of `HasAtMostOneLiftingProperty.of_arrow_iso_left`. -/
+@[to_dual (reorder := i i' e p) iff_of_arrow_iso_right]
+theorem iff_of_arrow_iso_left {A B A' B' X Y : C} {i : A ⟶ B} {i' : A' ⟶ B'}
+    (e : Arrow.mk i ≅ Arrow.mk i') (p : X ⟶ Y) :
+    HasAtMostOneLiftingProperty i p ↔ HasAtMostOneLiftingProperty i' p := by
+  constructor <;> intro
+  exacts [of_arrow_iso_left e p, of_arrow_iso_left e.symm p]
+
+end HasAtMostOneLiftingProperty
+
+/-- Maps having at most one lift against a given map `i` are stable under retracts: if `p'` is a
+retract of `p` and `i` has at most one lift against `p`, then it has at most one lift
+against `p'`. -/
+@[to_dual leftAtMostOneLiftingProperty]
+lemma RetractArrow.rightAtMostOneLiftingProperty
+    {A B X Y X' Y' : C} {p : X ⟶ Y} {p' : X' ⟶ Y'}
+    (h : RetractArrow p' p) (i : A ⟶ B) [HasAtMostOneLiftingProperty i p] :
+    HasAtMostOneLiftingProperty i p' where
+  subsingleton_liftStruct := fun {f g} sq ↦ by
+    have sq' : CommSq (f ≫ h.i.left) i p (g ≫ h.i.right) :=
+      ⟨by rw [← sq.w_assoc, assoc, RetractArrow.i_w]⟩
+    refine Function.Injective.subsingleton
+      (f := fun l : sq.LiftStruct ↦ (⟨l.l ≫ h.i.left, by rw [← assoc, l.fac_left],
+        by rw [assoc, RetractArrow.i_w, ← assoc, l.fac_right]⟩ : sq'.LiftStruct)) ?_
+    intro l₁ l₂ hl
+    apply CommSq.LiftStruct.ext
+    have := congrArg (fun m ↦ CommSq.LiftStruct.l m ≫ h.r.left) hl
+    simpa using this
+
+namespace HasUniqueLiftingProperty
+
+/-- Existence and uniqueness of lifts together give the unique lifting property. -/
+@[to_dual self]
+theorem mk' [HasLiftingProperty i p] [HasAtMostOneLiftingProperty i p] :
+    HasUniqueLiftingProperty i p :=
+  { toHasLiftingProperty := inferInstance
+    toHasAtMostOneLiftingProperty := inferInstance }
+
+/-- An epimorphism with the lifting property against `p` has the unique lifting property
+against `p`. -/
+@[to_dual]
+theorem of_epi [Epi i] [HasLiftingProperty i p] : HasUniqueLiftingProperty i p :=
+  mk' i p
+
+/-- An isomorphism has the unique lifting property against any `p`. -/
+@[to_dual of_right_iso]
+instance (priority := 100) of_left_iso [IsIso i] : HasUniqueLiftingProperty i p :=
+  mk' i p
+
+variable {i p}
+
+/-- The unique lifting property is self-dual: it passes to the opposite category, with the roles
+of `i` and `p` exchanged. -/
+@[to_dual self]
+theorem op (h : HasUniqueLiftingProperty i p) : HasUniqueLiftingProperty p.op i.op :=
+  { h.toHasLiftingProperty.op, h.toHasAtMostOneLiftingProperty.op with }
+
+/-- The converse of `HasUniqueLiftingProperty.op`, for arrows of an opposite category. -/
+@[to_dual self]
+theorem unop {A B X Y : Cᵒᵖ} {i : A ⟶ B} {p : X ⟶ Y}
+    (h : HasUniqueLiftingProperty i p) : HasUniqueLiftingProperty p.unop i.unop :=
+  { h.toHasLiftingProperty.unop, h.toHasAtMostOneLiftingProperty.unop with }
+
+/-- The unique lifting property is invariant under passing to the opposite category. -/
+@[to_dual self]
+theorem iff_op : HasUniqueLiftingProperty i p ↔ HasUniqueLiftingProperty p.op i.op :=
+  ⟨op, unop⟩
+
+/-- The version of `HasUniqueLiftingProperty.iff_op` for arrows of an opposite category. -/
+@[to_dual self]
+theorem iff_unop {A B X Y : Cᵒᵖ} (i : A ⟶ B) (p : X ⟶ Y) :
+    HasUniqueLiftingProperty i p ↔ HasUniqueLiftingProperty p.unop i.unop :=
+  ⟨unop, op⟩
+
+/-- The unique lifting property against `p` is stable under composition on the left. -/
+@[to_dual of_comp_right]
+instance of_comp_left {A B B' X Y : C} (i : A ⟶ B) (i' : B ⟶ B') (p : X ⟶ Y)
+    [HasUniqueLiftingProperty i p] [HasUniqueLiftingProperty i' p] :
+    HasUniqueLiftingProperty (i ≫ i') p :=
+  mk' _ _
+
+/-- A cancellation property: if `i` has the unique lifting property against
+`p ≫ q` and at most one lift against `q`, then it has the unique lifting property against `p`. -/
+@[to_dual of_comp_left_cancel]
+theorem of_comp_right_cancel {A B X Y Z : C} (i : A ⟶ B) (p : X ⟶ Y) (q : Y ⟶ Z)
+    [HasUniqueLiftingProperty i (p ≫ q)] [HasAtMostOneLiftingProperty i q] :
+    HasUniqueLiftingProperty i p := by
+  have hamo : HasAtMostOneLiftingProperty i p :=
+    HasAtMostOneLiftingProperty.of_comp_right_cancel i p q
+  have hlift : HasLiftingProperty i p := ⟨fun {u v} sq => by
+    have sq' : CommSq u i (p ≫ q) (v ≫ q) := ⟨by rw [← assoc, sq.w, assoc]⟩
+    have key : sq'.lift ≫ p = v :=
+      CommSq.lift_eq_of_hasAtMostOneLiftingProperty i q
+        (sq := ⟨by rw [sq.w, assoc]⟩)
+        (by rw [← assoc, sq'.fac_left]) (by rw [assoc, sq'.fac_right])
+        sq.w.symm rfl
+    exact CommSq.HasLift.mk' { l := sq'.lift, fac_left := sq'.fac_left, fac_right := key }⟩
+  exact { hlift, hamo with }
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The unique lifting property against a given map `p` is stable under isomorphism of arrows. -/
+@[to_dual (reorder := i i' e p) of_arrow_iso_right]
+theorem of_arrow_iso_left {A B A' B' X Y : C} {i : A ⟶ B} {i' : A' ⟶ B'}
+    (e : Arrow.mk i ≅ Arrow.mk i') (p : X ⟶ Y) [HasUniqueLiftingProperty i p] :
+    HasUniqueLiftingProperty i' p :=
+    { HasLiftingProperty.of_arrow_iso_left e p,
+        HasAtMostOneLiftingProperty.of_arrow_iso_left e p with }
+
+/-- The `Iff` version of `HasUniqueLiftingProperty.of_arrow_iso_left`. -/
+@[to_dual (reorder := i i' e p) iff_of_arrow_iso_right]
+theorem iff_of_arrow_iso_left {A B A' B' X Y : C} {i : A ⟶ B} {i' : A' ⟶ B'}
+    (e : Arrow.mk i ≅ Arrow.mk i') (p : X ⟶ Y) :
+    HasUniqueLiftingProperty i p ↔ HasUniqueLiftingProperty i' p := by
+  constructor <;> intro
+  exacts [of_arrow_iso_left e p, of_arrow_iso_left e.symm p]
+
+end HasUniqueLiftingProperty
+
+/-- Maps against which `i` has the unique lifting property are stable under retracts. -/
+@[to_dual leftUniqueLiftingProperty]
+lemma RetractArrow.rightUniqueLiftingProperty
+    {A B X Y X' Y' : C} {p : X ⟶ Y} {p' : X' ⟶ Y'}
+    (h : RetractArrow p' p) (i : A ⟶ B) [HasUniqueLiftingProperty i p] :
+    HasUniqueLiftingProperty i p' :=
+    have := h.rightLiftingProperty i
+    have := h.rightAtMostOneLiftingProperty i
+    HasUniqueLiftingProperty.mk' i p'
+
+/-- The unique lifting property of `i` against `p` is equivalent to: every commutative square
+from `i` to `p` has a unique filler. -/
+theorem hasUniqueLiftingProperty_iff (i : A ⟶ B) (p : X ⟶ Y) :
+    HasUniqueLiftingProperty i p ↔
+    ∀ (t : A ⟶ X) (b : B ⟶ Y), CommSq t i p b → ∃! l : B ⟶ X, i ≫ l = t ∧ l ≫ p = b := by
+  constructor
+  · intro h t b sq
+    exact ⟨sq.lift, ⟨sq.fac_left, sq.fac_right⟩, fun l hl =>
+      CommSq.lift_eq_of_hasAtMostOneLiftingProperty i p (sq := sq) hl.1 hl.2
+        sq.fac_left sq.fac_right⟩
+  · intro H
+    have hlp : HasLiftingProperty i p :=
+      ⟨fun {t b} sq => CommSq.HasLift.mk'
+        { l := (H t b sq).choose
+          fac_left := (H t b sq).choose_spec.1.1
+          fac_right := (H t b sq).choose_spec.1.2 }⟩
+    have hamo : HasAtMostOneLiftingProperty i p :=
+      ⟨fun {t b} sq => ⟨fun l₁ l₂ => by
+        apply CommSq.LiftStruct.ext
+        have huniq := (H t b sq).choose_spec.2
+        rw [huniq l₁.l ⟨l₁.fac_left, l₁.fac_right⟩, huniq l₂.l ⟨l₂.fac_left, l₂.fac_right⟩]⟩⟩
+    exact HasUniqueLiftingProperty.mk' i p
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/LiftingProperties/UniqueLimits.lean
+++ b/Mathlib/CategoryTheory/LiftingProperties/UniqueLimits.lean
@@ -1,0 +1,277 @@
+/-
+Copyright (c) 2026 Jakob Scholbach. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jakob Scholbach
+-/
+module
+
+public import Mathlib.CategoryTheory.LiftingProperties.Unique
+public import Mathlib.CategoryTheory.LiftingProperties.Limits
+
+/-!
+# Unique lifting properties and (co)limits
+
+This file mirrors `Mathlib.CategoryTheory.LiftingProperties.Limits` for the
+at-most-one and unique lifting properties: the (co)base-change lemmas along a
+pushout/pullback square, and the closure of unique lifting under (co)products.
+
+For pushouts, pullbacks, products and coproducts, existence of lifts is not
+re-proved: it is taken from the ordinary lifting property in mathlib, the new
+content is the uniqueness half expressed via `HasAtMostOneLiftingProperty`, and
+the `HasUniqueLiftingProperty` versions follow by `HasUniqueLiftingProperty.mk'`.
+
+For a general `J`-shaped (co)limit this is no longer possible, because the
+ordinary-lifting statement is false. There `HasUniqueLiftingProperty.of_isLimit`
+builds the lift itself: it lifts each component square and uses uniqueness to
+show that the component lifts are compatible with the transition maps of the
+diagram, so that they form a cone and induce a map to the limit.
+
+These are the individual-morphism prerequisites for the closure instances on the
+`leftOrthogonal`/`rightOrthogonal` morphism properties.
+
+## Main declarations
+
+* `CategoryTheory.IsPushout.hasAtMostOneLiftingProperty`
+* `CategoryTheory.IsPullback.hasAtMostOneLiftingProperty`
+* `CategoryTheory.IsPushout.hasUniqueLiftingProperty`
+* `CategoryTheory.IsPullback.hasUniqueLiftingProperty`
+* the `pushout.inl` / `pushout.inr` / `pullback.fst` / `pullback.snd` instances
+* the `Pi.map` / `Sigma.map` (co)product instances
+* `CategoryTheory.HasAtMostOneLiftingProperty.of_isLimit` / `.of_isColimit`
+* `CategoryTheory.HasUniqueLiftingProperty.of_isLimit` / `.of_isColimit` — the
+  general `J`-shaped (co)limit lifting lemmas, whose ordinary-lifting analogue is
+  false and where uniqueness is what repairs it
+
+-/
+
+public section
+
+namespace CategoryTheory
+
+open Category Limits
+
+variable {C : Type*} [Category* C] {X Y Z W : C}
+  {f : X ⟶ Y} {s : X ⟶ Z} {g : Z ⟶ W} {t : Y ⟶ W}
+
+/-- Base change of the at-most-one lifting property along a pushout square: if
+squares with `f` on the left and `g'` on the right have at most one lift, then so
+do squares with the pushout `g` on the left and `g'` on the right. -/
+lemma IsPushout.hasAtMostOneLiftingProperty (h : IsPushout s f g t)
+    {Z' W' : C} (g' : Z' ⟶ W') [HasAtMostOneLiftingProperty f g'] :
+    HasAtMostOneLiftingProperty g g' where
+  subsingleton_liftStruct {u v} sq := ⟨fun l₁ l₂ => by
+    apply CommSq.LiftStruct.ext
+    apply h.hom_ext
+    · rw [l₁.fac_left, l₂.fac_left]
+    · exact CommSq.lift_eq_of_hasAtMostOneLiftingProperty f g'
+        (sq := ⟨by rw [assoc, sq.w, ← assoc, h.w, assoc]⟩)
+        (by rw [← assoc, ← h.w, assoc, l₁.fac_left]) (by rw [assoc, l₁.fac_right])
+        (by rw [← assoc, ← h.w, assoc, l₂.fac_left]) (by rw [assoc, l₂.fac_right])⟩
+
+/-- Base change of the at-most-one lifting property along a pullback square: if
+squares with `f'` on the left and `g` on the right have at most one lift, then so
+do squares with `f'` on the left and the pullback `f` on the right. -/
+lemma IsPullback.hasAtMostOneLiftingProperty (h : IsPullback s f g t)
+    {X' Y' : C} (f' : X' ⟶ Y') [HasAtMostOneLiftingProperty f' g] :
+    HasAtMostOneLiftingProperty f' f where
+  subsingleton_liftStruct {u v} sq := ⟨fun l₁ l₂ => by
+    apply CommSq.LiftStruct.ext
+    apply h.hom_ext
+    · exact CommSq.lift_eq_of_hasAtMostOneLiftingProperty f' g
+        (sq := ⟨by rw [assoc, h.w, ← assoc, sq.w, assoc]⟩)
+        (by rw [← assoc, l₁.fac_left]) (by rw [assoc, h.w, ← assoc, l₁.fac_right])
+        (by rw [← assoc, l₂.fac_left]) (by rw [assoc, h.w, ← assoc, l₂.fac_right])
+    · rw [l₁.fac_right, l₂.fac_right]⟩
+
+/-- Base change of the unique lifting property along a pushout square. -/
+lemma IsPushout.hasUniqueLiftingProperty (h : IsPushout s f g t)
+    {Z' W' : C} (g' : Z' ⟶ W') [HasUniqueLiftingProperty f g'] :
+    HasUniqueLiftingProperty g g' :=
+  have : HasLiftingProperty g g' := h.hasLiftingProperty g'
+  have : HasAtMostOneLiftingProperty g g' := h.hasAtMostOneLiftingProperty g'
+  HasUniqueLiftingProperty.mk' g g'
+
+/-- Base change of the unique lifting property along a pullback square. -/
+lemma IsPullback.hasUniqueLiftingProperty (h : IsPullback s f g t)
+    {X' Y' : C} (f' : X' ⟶ Y') [HasUniqueLiftingProperty f' g] :
+    HasUniqueLiftingProperty f' f :=
+  have : HasLiftingProperty f' f := h.hasLiftingProperty f'
+  have : HasAtMostOneLiftingProperty f' f := h.hasAtMostOneLiftingProperty f'
+  HasUniqueLiftingProperty.mk' f' f
+
+instance [HasPushout s f] {T₁ T₂ : C} (p : T₁ ⟶ T₂) [HasAtMostOneLiftingProperty f p] :
+    HasAtMostOneLiftingProperty (pushout.inl s f) p :=
+  (IsPushout.of_hasPushout s f).hasAtMostOneLiftingProperty p
+
+instance [HasPushout s f] {T₁ T₂ : C} (p : T₁ ⟶ T₂) [HasAtMostOneLiftingProperty s p] :
+    HasAtMostOneLiftingProperty (pushout.inr s f) p :=
+  (IsPushout.of_hasPushout s f).flip.hasAtMostOneLiftingProperty p
+
+instance [HasPullback g t] {T₁ T₂ : C} (p : T₁ ⟶ T₂) [HasAtMostOneLiftingProperty p g] :
+    HasAtMostOneLiftingProperty p (pullback.snd g t) :=
+  (IsPullback.of_hasPullback g t).hasAtMostOneLiftingProperty p
+
+instance [HasPullback g t] {T₁ T₂ : C} (p : T₁ ⟶ T₂) [HasAtMostOneLiftingProperty p t] :
+    HasAtMostOneLiftingProperty p (pullback.fst g t) :=
+  (IsPullback.of_hasPullback g t).flip.hasAtMostOneLiftingProperty p
+
+instance [HasPushout s f] {T₁ T₂ : C} (p : T₁ ⟶ T₂) [HasUniqueLiftingProperty f p] :
+    HasUniqueLiftingProperty (pushout.inl s f) p :=
+  (IsPushout.of_hasPushout s f).hasUniqueLiftingProperty p
+
+instance [HasPushout s f] {T₁ T₂ : C} (p : T₁ ⟶ T₂) [HasUniqueLiftingProperty s p] :
+    HasUniqueLiftingProperty (pushout.inr s f) p :=
+  (IsPushout.of_hasPushout s f).flip.hasUniqueLiftingProperty p
+
+instance [HasPullback g t] {T₁ T₂ : C} (p : T₁ ⟶ T₂) [HasUniqueLiftingProperty p g] :
+    HasUniqueLiftingProperty p (pullback.snd g t) :=
+  (IsPullback.of_hasPullback g t).hasUniqueLiftingProperty p
+
+instance [HasPullback g t] {T₁ T₂ : C} (p : T₁ ⟶ T₂) [HasUniqueLiftingProperty p t] :
+    HasUniqueLiftingProperty p (pullback.fst g t) :=
+  (IsPullback.of_hasPullback g t).flip.hasUniqueLiftingProperty p
+
+set_option backward.isDefEq.respectTransparency false in
+instance {J : Type*} {A B : J → C} [HasProduct A] [HasProduct B]
+    (f : (j : J) → A j ⟶ B j) {X Y : C} (p : X ⟶ Y)
+    [∀ j, HasAtMostOneLiftingProperty p (f j)] :
+    HasAtMostOneLiftingProperty p (Limits.Pi.map f) where
+  subsingleton_liftStruct {t b} sq := ⟨fun l₁ l₂ => by
+    apply CommSq.LiftStruct.ext
+    apply Pi.hom_ext
+    intro j
+    exact CommSq.lift_eq_of_hasAtMostOneLiftingProperty p (f j)
+      (sq := ⟨by rw [assoc, ← Pi.map_π, ← assoc, sq.w, assoc]⟩)
+      (by rw [← assoc, l₁.fac_left]) (by rw [assoc, ← Pi.map_π, ← assoc, l₁.fac_right])
+      (by rw [← assoc, l₂.fac_left]) (by rw [assoc, ← Pi.map_π, ← assoc, l₂.fac_right])⟩
+
+set_option backward.isDefEq.respectTransparency false in
+instance {J : Type*} {A B : J → C} [HasCoproduct A] [HasCoproduct B]
+    (f : (j : J) → A j ⟶ B j) {X Y : C} (p : X ⟶ Y)
+    [∀ j, HasAtMostOneLiftingProperty (f j) p] :
+    HasAtMostOneLiftingProperty (Limits.Sigma.map f) p where
+  subsingleton_liftStruct {t b} sq := ⟨fun l₁ l₂ => by
+    apply CommSq.LiftStruct.ext
+    apply Sigma.hom_ext
+    intro j
+    exact CommSq.lift_eq_of_hasAtMostOneLiftingProperty (f j) p
+      (sq := ⟨by rw [assoc, sq.w, ← assoc, Sigma.ι_map, assoc]⟩)
+      (by rw [← assoc, ← Sigma.ι_map, assoc, l₁.fac_left]) (by rw [assoc, l₁.fac_right])
+      (by rw [← assoc, ← Sigma.ι_map, assoc, l₂.fac_left]) (by rw [assoc, l₂.fac_right])⟩
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Right-hand closure of the unique lifting property under products: if `p` on the left has
+the unique lifting property against every `f j` on the right, then it has it against
+`Pi.map f` on the right. -/
+instance {J : Type*} {A B : J → C} [HasProduct A] [HasProduct B]
+    (f : (j : J) → A j ⟶ B j) {X Y : C} (p : X ⟶ Y)
+    [∀ j, HasUniqueLiftingProperty p (f j)] :
+    HasUniqueLiftingProperty p (Limits.Pi.map f) :=
+  HasUniqueLiftingProperty.mk' p (Limits.Pi.map f)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Left-hand closure of the unique lifting property under coproducts: if every `f j` on the
+left has the unique lifting property against `p` on the right, then so does `Sigma.map f`
+on the left.
+
+This is not deduced from the product instance in `Cᵒᵖ` because `(Sigma.map f).op` is only
+isomorphic to `Pi.map (fun j ↦ (f j).op)`, not equal to it, so transporting through `Cᵒᵖ`
+would cost an arrow isomorphism and be no shorter than the direct proof. -/
+instance {J : Type*} {A B : J → C} [HasCoproduct A] [HasCoproduct B]
+    (f : (j : J) → A j ⟶ B j) {X Y : C} (p : X ⟶ Y)
+    [∀ j, HasUniqueLiftingProperty (f j) p] :
+    HasUniqueLiftingProperty (Limits.Sigma.map f) p :=
+  HasUniqueLiftingProperty.mk' (Limits.Sigma.map f) p
+
+section IsLimitColimit
+
+variable {J : Type*} [Category J] {X₁ X₂ : J ⥤ C}
+
+/-- If `i` has at most one lift against every component of a natural transformation
+`f` between `J`-shaped diagrams, then it has at most one lift against any morphism
+`φ` of limit cones lying over `f`. Only the source cone need be a limit. -/
+lemma HasAtMostOneLiftingProperty.of_isLimit (f : X₁ ⟶ X₂)
+    {c₁ : Cone X₁} {c₂ : Cone X₂} (h₁ : IsLimit c₁) {φ : c₁.pt ⟶ c₂.pt}
+    (hφ : ∀ j, φ ≫ c₂.π.app j = c₁.π.app j ≫ f.app j)
+    {A B : C} (i : A ⟶ B) [∀ j, HasAtMostOneLiftingProperty i (f.app j)] :
+    HasAtMostOneLiftingProperty i φ where
+  subsingleton_liftStruct {u v} sq := ⟨fun l l' => by
+    apply CommSq.LiftStruct.ext
+    apply h₁.hom_ext
+    intro j
+    exact CommSq.lift_eq_of_hasAtMostOneLiftingProperty i (f.app j)
+      (sq := ⟨by rw [assoc, ← hφ j, ← assoc, sq.w, assoc]⟩)
+      (by rw [← assoc, l.fac_left]) (by rw [assoc, ← hφ j, ← assoc, l.fac_right])
+      (by rw [← assoc, l'.fac_left]) (by rw [assoc, ← hφ j, ← assoc, l'.fac_right])⟩
+
+/-- If `i` has the unique lifting property against every component of a natural
+transformation `f` between `J`-shaped diagrams, then it has the unique lifting
+property against any morphism `φ` of limit cones lying over `f`.
+
+This has no ordinary-lifting analogue: componentwise lifts need not be compatible
+with the transition maps of the diagram, and it is *uniqueness* (through
+`HasAtMostOneLiftingProperty.of_isLimit`) that forces the compatibility making them
+assemble into a map to the limit. -/
+lemma HasUniqueLiftingProperty.of_isLimit (f : X₁ ⟶ X₂)
+    {c₁ : Cone X₁} {c₂ : Cone X₂} (h₁ : IsLimit c₁) (h₂ : IsLimit c₂)
+    {φ : c₁.pt ⟶ c₂.pt} (hφ : ∀ j, φ ≫ c₂.π.app j = c₁.π.app j ≫ f.app j)
+    {A B : C} (i : A ⟶ B) [∀ j, HasUniqueLiftingProperty i (f.app j)] :
+    HasUniqueLiftingProperty i φ where
+  subsingleton_liftStruct :=
+    (HasAtMostOneLiftingProperty.of_isLimit f h₁ hφ i).subsingleton_liftStruct
+  sq_hasLift {u v} sq := by
+    -- the componentwise squares and their (unique) lifts
+    have sqj : ∀ j, CommSq (u ≫ c₁.π.app j) i (f.app j) (v ≫ c₂.π.app j) :=
+      fun j => ⟨by rw [assoc, ← hφ j, ← assoc, sq.w, assoc]⟩
+    -- uniqueness makes the lifts into a cone over `X₁` with apex `B`
+    let cone : Cone X₁ :=
+      { pt := B
+        π :=
+          { app := fun j => (sqj j).lift
+            naturality := fun j j' α => by
+              simp only [Functor.const_obj_obj, Functor.const_obj_map, id_comp]
+              symm
+              exact CommSq.lift_eq_of_hasAtMostOneLiftingProperty i (f.app j') (sq := sqj j')
+                (by rw [← assoc, (sqj j).fac_left, assoc, c₁.w α])
+                (by rw [assoc, f.naturality α, ← assoc, (sqj j).fac_right, assoc, c₂.w α])
+                (sqj j').fac_left (sqj j').fac_right } }
+    exact CommSq.HasLift.mk'
+      { l := h₁.lift cone
+        fac_left := h₁.hom_ext fun j => by rw [assoc, h₁.fac]; exact (sqj j).fac_left
+        fac_right := h₂.hom_ext fun j => by
+          rw [assoc, hφ j, ← assoc, h₁.fac]; exact (sqj j).fac_right }
+
+/-- Colimit dual of `HasAtMostOneLiftingProperty.of_isLimit`: if every component of
+`f` has at most one lift against `p`, then so does any morphism `φ` of colimit
+cocones lying over `f`. Only the target cocone need be a colimit.
+
+Proved by passing to `Cᵒᵖ`, where `c₂.op` is a limit cone and `φ.op` lies over `NatTrans.op f`. -/
+lemma HasAtMostOneLiftingProperty.of_isColimit (f : X₁ ⟶ X₂)
+    {c₁ : Cocone X₁} {c₂ : Cocone X₂} (h₂ : IsColimit c₂) {φ : c₁.pt ⟶ c₂.pt}
+    (hφ : ∀ j, c₁.ι.app j ≫ φ = f.app j ≫ c₂.ι.app j)
+    {A B : C} (p : A ⟶ B) [∀ j, HasAtMostOneLiftingProperty (f.app j) p] :
+    HasAtMostOneLiftingProperty φ p :=
+  haveI : ∀ j, HasAtMostOneLiftingProperty p.op ((NatTrans.op f).app j) :=
+    fun j => (inferInstance : HasAtMostOneLiftingProperty (f.app j.unop) p).op
+  (HasAtMostOneLiftingProperty.of_isLimit (NatTrans.op f) (c₂ := c₁.op) h₂.op (φ := φ.op)
+    (fun j => Quiver.Hom.unop_inj (hφ j.unop)) p.op).unop
+
+/-- Colimit dual of `HasUniqueLiftingProperty.of_isLimit`: the unique lifting
+property against every component of `f` gives the unique lifting property against
+any morphism `φ` of colimit cocones lying over `f`.
+
+Proved by passing to `Cᵒᵖ`, where `c₁.op`, `c₂.op` are limit cones and `φ.op` lies over
+`NatTrans.op f`. -/
+lemma HasUniqueLiftingProperty.of_isColimit (f : X₁ ⟶ X₂)
+    {c₁ : Cocone X₁} {c₂ : Cocone X₂} (h₁ : IsColimit c₁) (h₂ : IsColimit c₂)
+    {φ : c₁.pt ⟶ c₂.pt} (hφ : ∀ j, c₁.ι.app j ≫ φ = f.app j ≫ c₂.ι.app j)
+    {A B : C} (p : A ⟶ B) [∀ j, HasUniqueLiftingProperty (f.app j) p] :
+    HasUniqueLiftingProperty φ p :=
+  haveI : ∀ j, HasUniqueLiftingProperty p.op ((NatTrans.op f).app j) :=
+    fun j => (inferInstance : HasUniqueLiftingProperty (f.app j.unop) p).op
+  (HasUniqueLiftingProperty.of_isLimit (NatTrans.op f) (c₂ := c₁.op) h₂.op h₁.op (φ := φ.op)
+    (fun j => Quiver.Hom.unop_inj (hφ j.unop)) p.op).unop
+
+end IsLimitColimit
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/MorphismProperty/Orthogonal.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Orthogonal.lean
@@ -1,0 +1,583 @@
+/-
+Copyright (c) 2026 Jakob Scholbach. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jakob Scholbach
+-/
+module
+
+public import Mathlib.CategoryTheory.LiftingProperties.UniqueLimits
+public import Mathlib.CategoryTheory.MorphismProperty.LiftingProperty
+
+/-!
+# Left and right orthogonals of a morphism property
+
+Given a morphism property `T`, we define the classes of morphisms that are left
+(resp. right) orthogonal to `T`, i.e. that have the *unique* left (resp. right)
+lifting property with respect to every morphism in `T`.
+
+This file mirrors `Mathlib.CategoryTheory.MorphismProperty.LiftingProperty`
+(`llp`/`rlp`) with `HasLiftingProperty` replaced by `HasUniqueLiftingProperty`.
+
+## Main declarations
+
+* `CategoryTheory.MorphismProperty.leftOrthogonal`,
+  `CategoryTheory.MorphismProperty.rightOrthogonal`: the two orthogonal classes.
+* `CategoryTheory.MorphismProperty.IsOrthogonalPair`: the property that two
+  classes are the orthogonals of each other.
+* `CategoryTheory.MorphismProperty.gc_leftOrthogonal_rightOrthogonal`: the two
+  operations form an antitone Galois connection, whence the triple identities
+  `CategoryTheory.MorphismProperty.rightOrthogonal_leftOrthogonal_rightOrthogonal`
+  and
+  `CategoryTheory.MorphismProperty.leftOrthogonal_rightOrthogonal_leftOrthogonal`.
+* `CategoryTheory.MorphismProperty.leftOrthogonal_le_llp`,
+  `CategoryTheory.MorphismProperty.rightOrthogonal_le_rlp`: comparison with the
+  ordinary lifting-property classes.
+* `CategoryTheory.MorphismProperty.IsOrthogonalPair.inf_eq_isomorphisms`: the
+  two classes of an orthogonal pair meet in the isomorphisms.
+
+Both classes contain the isomorphisms and are closed under composition,
+retracts, and the appropriate variance of base change and (co)limits; each such
+closure property comes in a bare form for `leftOrthogonal`/`rightOrthogonal` and
+in an instance form for the two classes of an `IsOrthogonalPair`. Cancellation
+is discussed below. Finally, `op_leftOrthogonal` and its three companions
+identify the orthogonals in `Cᵒᵖ`.
+
+## Cancellation terminology and orientation
+
+Cancellation properties of the orthogonal classes are expressed through mathlib's
+relative predicates `MorphismProperty.HasOfPostcompProperty` and
+`MorphismProperty.HasOfPrecompProperty`.
+
+With mathlib's composition convention (`f ≫ g` means `g` after `f`), the
+orientation dictionary is:
+
+| cancellation | rule | mathlib predicate |
+|---|---|---|
+| right cancellation | `f ≫ g ∈ P`, `g ∈ P` ⟹ `f ∈ P` | `P.HasOfPostcompProperty P` |
+| left cancellation | `f ≫ g ∈ P`, `f ∈ P` ⟹ `g ∈ P` | `P.HasOfPrecompProperty P` |
+
+The two orthogonal classes satisfy **one each, not both**:
+
+* `T.rightOrthogonal` — the *right* class — has the *of-postcomp* property
+  (right cancellation);
+* `T.leftOrthogonal` — the *left* class — has the *of-precomp* property
+  (left cancellation).
+
+Neither class has the other property in general, and neither has
+`HasTwoOutOfThreeProperty`: `HasTwoOutOfThreeProperty` is a tempting but wrong
+target here. Relative forms `B.HasOfPostcompProperty W'` for `W' ≤ B` are
+obtained from `HasOfPostcompProperty.of_le`, not from bespoke instances.
+
+Proposition 3 of [anel2009] uses the opposite cancellation vocabulary: it calls
+the right class's of-postcomp rule above *left cancellation*, and calls the dual
+rule *right cancellation*. The names in this file follow mathlib's composition
+API and the orientation table above.
+
+## References
+
+* [M. Anel, *Grothendieck topologies from unique factorisation systems*][anel2009]
+
+-/
+
+@[expose] public section
+
+universe w v u
+
+namespace CategoryTheory
+
+variable {C : Type u} [Category.{v} C] (T : MorphismProperty C)
+
+namespace MorphismProperty
+
+/-- Given `T : MorphismProperty C`, this is the class of morphisms that are left
+orthogonal to `T`, i.e. that have the *unique* left lifting property with respect
+to `T`. -/
+def leftOrthogonal : MorphismProperty C := fun _ _ f ↦
+  ∀ ⦃X Y : C⦄ (g : X ⟶ Y) (_ : T g), HasUniqueLiftingProperty f g
+
+/-- Given `T : MorphismProperty C`, this is the class of morphisms that are right
+orthogonal to `T`, i.e. that have the *unique* right lifting property with respect
+to `T`. -/
+def rightOrthogonal : MorphismProperty C := fun _ _ f ↦
+  ∀ ⦃X Y : C⦄ (g : X ⟶ Y) (_ : T g), HasUniqueLiftingProperty g f
+
+lemma leftOrthogonal_of_isIso {A B : C} (i : A ⟶ B) [IsIso i] :
+    T.leftOrthogonal i :=
+  fun _ _ _ _ ↦ inferInstance
+
+lemma rightOrthogonal_of_isIso {X Y : C} (f : X ⟶ Y) [IsIso f] :
+    T.rightOrthogonal f :=
+  fun _ _ _ _ ↦ inferInstance
+
+/-- `T ≤ T'.leftOrthogonal` if and only if `T' ≤ T.rightOrthogonal`; both express
+that every morphism in `T'` has the unique lifting property against every morphism
+in `T`. -/
+lemma le_leftOrthogonal_iff_le_rightOrthogonal (T' : MorphismProperty C) :
+    T ≤ T'.leftOrthogonal ↔ T' ≤ T.rightOrthogonal :=
+  ⟨fun h _ _ _ hp _ _ _ hi ↦ h _ hi _ hp,
+    fun h _ _ _ hi _ _ _ hp ↦ h _ hp _ hi⟩
+
+/-- `leftOrthogonal` and `rightOrthogonal` form a Galois connection between
+`MorphismProperty C` and its order dual. -/
+lemma gc_leftOrthogonal_rightOrthogonal :
+    GaloisConnection (OrderDual.toDual (α := MorphismProperty C) ∘ leftOrthogonal)
+      (rightOrthogonal ∘ OrderDual.ofDual) :=
+  fun _ _ ↦ le_leftOrthogonal_iff_le_rightOrthogonal _ _
+
+/-- Every morphism property is contained in the left orthogonal of its right
+orthogonal. -/
+lemma le_leftOrthogonal_rightOrthogonal : T ≤ T.rightOrthogonal.leftOrthogonal := by
+  rw [le_leftOrthogonal_iff_le_rightOrthogonal]
+
+/-- The triple orthogonal `T.rightOrthogonal.leftOrthogonal.rightOrthogonal`
+collapses to `T.rightOrthogonal`. -/
+@[simp]
+lemma rightOrthogonal_leftOrthogonal_rightOrthogonal :
+    T.rightOrthogonal.leftOrthogonal.rightOrthogonal = T.rightOrthogonal :=
+  gc_leftOrthogonal_rightOrthogonal.u_l_u_eq_u T
+
+/-- The triple orthogonal `T.leftOrthogonal.rightOrthogonal.leftOrthogonal`
+collapses to `T.leftOrthogonal`. -/
+@[simp]
+lemma leftOrthogonal_rightOrthogonal_leftOrthogonal :
+    T.leftOrthogonal.rightOrthogonal.leftOrthogonal = T.leftOrthogonal :=
+  gc_leftOrthogonal_rightOrthogonal.l_u_l_eq_l T
+
+lemma antitone_rightOrthogonal :
+    Antitone (rightOrthogonal : MorphismProperty C → _) :=
+  fun _ _ h ↦ gc_leftOrthogonal_rightOrthogonal.monotone_u h
+
+lemma antitone_leftOrthogonal :
+    Antitone (leftOrthogonal : MorphismProperty C → _) :=
+  fun _ _ h ↦ gc_leftOrthogonal_rightOrthogonal.monotone_l h
+
+/-- **Right orthogonals only see the left-saturation of a class.** If a class `Q`
+sits between `P` and its left-saturation `P.rightOrthogonal.leftOrthogonal`, then
+`P` and `Q` have the same right orthogonal.
+
+This is the abstract generality behind "spreading out": any class obtained from `P`
+by cobase changes, isomorphisms, retracts, (transfinite) composition, or coproducts
+— all of which preserve membership in the *left* orthogonal — is automatically
+`≤ P.rightOrthogonal.leftOrthogonal`, so enlarging `P` to it does not change the
+right orthogonal. Concretely, if every `Q`-morphism is (up to isomorphism of arrows)
+a cobase change of a `P`-morphism and `P ≤ Q`, the hypothesis holds and
+`P.rightOrthogonal = Q.rightOrthogonal`.
+
+The proof is pure order theory: `antitone_rightOrthogonal` gives one inclusion from
+`P ≤ Q`, and the other follows from applying it to `hQ` together with the triple
+collapse `rightOrthogonal_leftOrthogonal_rightOrthogonal`. -/
+lemma rightOrthogonal_eq_of_le_of_le_leftOrthogonal_rightOrthogonal
+    {P Q : MorphismProperty C} (hPQ : P ≤ Q)
+    (hQ : Q ≤ P.rightOrthogonal.leftOrthogonal) :
+    P.rightOrthogonal = Q.rightOrthogonal :=
+  le_antisymm
+    (by simpa using antitone_rightOrthogonal hQ)
+    (antitone_rightOrthogonal hPQ)
+
+/-- Dual of `rightOrthogonal_eq_of_le_of_le_leftOrthogonal_rightOrthogonal`: if `Q`
+sits between `P` and its right-saturation `P.leftOrthogonal.rightOrthogonal`, then
+`P` and `Q` have the same left orthogonal. -/
+lemma leftOrthogonal_eq_of_le_of_le_rightOrthogonal_leftOrthogonal
+    {P Q : MorphismProperty C} (hPQ : P ≤ Q)
+    (hQ : Q ≤ P.leftOrthogonal.rightOrthogonal) :
+    P.leftOrthogonal = Q.leftOrthogonal :=
+  le_antisymm
+    (by simpa using antitone_leftOrthogonal hQ)
+    (antitone_leftOrthogonal hPQ)
+
+/-- The left orthogonal in the opposite category is the opposite of the right
+orthogonal: unique left lifting against `T.op` is unique right lifting against
+`T`, read in `Cᵒᵖ`. -/
+@[simp]
+lemma op_leftOrthogonal : T.op.leftOrthogonal = T.rightOrthogonal.op := by
+  ext X Y f
+  exact ⟨fun hf _ _ g hg ↦ (hf g.op hg).unop, fun hf _ _ g hg ↦ (hf g.unop hg).op⟩
+
+/-- The right orthogonal in the opposite category is the opposite of the left
+orthogonal. -/
+@[simp]
+lemma op_rightOrthogonal : T.op.rightOrthogonal = T.leftOrthogonal.op := by
+  ext X Y f
+  exact ⟨fun hf _ _ g hg ↦ (hf g.op hg).unop, fun hf _ _ g hg ↦ (hf g.unop hg).op⟩
+
+/-- Dual of `op_leftOrthogonal` for a property on an opposite category. -/
+@[simp]
+lemma unop_leftOrthogonal (T : MorphismProperty Cᵒᵖ) :
+    T.unop.leftOrthogonal = T.rightOrthogonal.unop := by
+  ext X Y f
+  exact ⟨fun hf _ _ g hg ↦ (hf g.unop hg).op, fun hf _ _ g hg ↦ (hf g.op hg).unop⟩
+
+/-- Dual of `op_rightOrthogonal` for a property on an opposite category. -/
+@[simp]
+lemma unop_rightOrthogonal (T : MorphismProperty Cᵒᵖ) :
+    T.unop.rightOrthogonal = T.leftOrthogonal.unop := by
+  ext X Y f
+  exact ⟨fun hf _ _ g hg ↦ (hf g.unop hg).op, fun hf _ _ g hg ↦ (hf g.op hg).unop⟩
+
+/-- Two morphism properties form an orthogonal pair if each is exactly the
+corresponding unique orthogonal of the other. This is the notion of a unique
+lifting system of [anel2009], Definition 1; it does not include a factorization
+axiom. -/
+class IsOrthogonalPair (A B : MorphismProperty C) : Prop where
+  left_eq : B.leftOrthogonal = A
+  right_eq : A.rightOrthogonal = B
+
+-- `left_eq` and `right_eq` are not `simp` lemmas: in `B.leftOrthogonal = A` the class argument
+-- `A` does not occur in the left-hand side, and dually for `right_eq`, so neither is usable by
+-- `simp`. Use them through an explicit `rw [← IsOrthogonalPair.left_eq (A := A) (B := B)]`.
+
+/-- The orthogonal pair generated by a morphism property `T`
+([anel2009], Lemma 2). -/
+instance rightOrthogonal_isOrthogonalPair :
+    IsOrthogonalPair T.rightOrthogonal.leftOrthogonal T.rightOrthogonal where
+  left_eq := rfl
+  right_eq := rightOrthogonal_leftOrthogonal_rightOrthogonal T
+
+/-- The dual orthogonal pair generated by a morphism property `T`. -/
+instance leftOrthogonal_isOrthogonalPair :
+    IsOrthogonalPair T.leftOrthogonal T.leftOrthogonal.rightOrthogonal where
+  left_eq := leftOrthogonal_rightOrthogonal_leftOrthogonal T
+  right_eq := rfl
+
+/-- Membership in the right orthogonal of a family `MorphismProperty.ofHoms f` reduces to the
+unique right lifting property against each generator `f i`. This has nothing to do with the
+particular family; it is the defining unfolding of `rightOrthogonal` for a property generated by
+an explicit family of morphisms. -/
+lemma rightOrthogonal_ofHoms_iff {ι : Type*} {A B : ι → C} (f : ∀ i, A i ⟶ B i)
+    {X Y : C} (p : X ⟶ Y) :
+    (MorphismProperty.ofHoms f).rightOrthogonal p ↔
+      ∀ i, HasUniqueLiftingProperty (f i) p :=
+  ⟨fun h i => h _ ⟨i⟩, fun h _ _ g hg => by obtain ⟨i⟩ := hg; exact h i⟩
+
+/-- Dual of `rightOrthogonal_ofHoms_iff`: membership in the left orthogonal of a family
+`MorphismProperty.ofHoms f` reduces to the unique left lifting property against each generator. -/
+lemma leftOrthogonal_ofHoms_iff {ι : Type*} {A B : ι → C} (f : ∀ i, A i ⟶ B i)
+    {X Y : C} (p : X ⟶ Y) :
+    (MorphismProperty.ofHoms f).leftOrthogonal p ↔
+      ∀ i, HasUniqueLiftingProperty p (f i) :=
+  ⟨fun h i => h _ ⟨i⟩, fun h _ _ g hg => by obtain ⟨i⟩ := hg; exact h i⟩
+
+/-- The left orthogonal is contained in the (ordinary) left lifting property: a
+morphism with the *unique* left lifting property in particular has the left lifting
+property. -/
+lemma leftOrthogonal_le_llp : T.leftOrthogonal ≤ T.llp :=
+  fun _ _ _ hf _ _ g hg ↦ (hf g hg).toHasLiftingProperty
+
+/-- The right orthogonal is contained in the (ordinary) right lifting property: a
+morphism with the *unique* right lifting property in particular has the right
+lifting property. -/
+lemma rightOrthogonal_le_rlp : T.rightOrthogonal ≤ T.rlp :=
+  fun _ _ _ hf _ _ g hg ↦ (hf g hg).toHasLiftingProperty
+
+/-- The left orthogonal of `T` is multiplicative: it contains the identities and
+is stable under composition. Identities are isomorphisms (`leftOrthogonal_of_isIso`)
+and composition is `HasUniqueLiftingProperty.of_comp_left`. -/
+instance leftOrthogonal_isMultiplicative : T.leftOrthogonal.IsMultiplicative where
+  id_mem X _ _ p hp := by infer_instance
+  comp_mem i j hi hj _ _ p hp := by
+    have := hi _ hp
+    have := hj _ hp
+    infer_instance
+
+/-- The right orthogonal of `T` is multiplicative: it contains the identities and
+is stable under composition (`HasUniqueLiftingProperty.of_comp_right`). -/
+instance rightOrthogonal_isMultiplicative : T.rightOrthogonal.IsMultiplicative where
+  id_mem X _ _ p hp := by infer_instance
+  comp_mem i j hi hj _ _ p hp := by
+    have := hi _ hp
+    have := hj _ hp
+    infer_instance
+
+/-- The left orthogonal of `T` respects isomorphisms: it is stable under composition
+and contains the isomorphisms, which is all `respectsIso_of_isStableUnderComposition`
+needs. -/
+instance leftOrthogonal_respectsIso : T.leftOrthogonal.RespectsIso :=
+  respectsIso_of_isStableUnderComposition fun _ _ f hf ↦
+    haveI : IsIso f := hf
+    T.leftOrthogonal_of_isIso f
+
+/-- The right orthogonal of `T` respects isomorphisms: it is stable under composition
+and contains the isomorphisms, which is all `respectsIso_of_isStableUnderComposition`
+needs. -/
+instance rightOrthogonal_respectsIso : T.rightOrthogonal.RespectsIso :=
+  respectsIso_of_isStableUnderComposition fun _ _ f hf ↦
+    haveI : IsIso f := hf
+    T.rightOrthogonal_of_isIso f
+
+set_option synthInstance.checkSynthOrder false in
+/-- The left class of an orthogonal pair is multiplicative
+([anel2009], Proposition 3(1)). -/
+instance IsOrthogonalPair.left_isMultiplicative (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] : A.IsMultiplicative := by
+  rw [← IsOrthogonalPair.left_eq (A := A) (B := B)]
+  infer_instance
+
+set_option synthInstance.checkSynthOrder false in
+/-- The right class of an orthogonal pair is multiplicative
+([anel2009], Proposition 3(1)). -/
+instance IsOrthogonalPair.right_isMultiplicative (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] : B.IsMultiplicative := by
+  rw [← IsOrthogonalPair.right_eq (A := A) (B := B)]
+  infer_instance
+
+/-- The left orthogonal of `T` is stable under retracts, via
+`RetractArrow.leftUniqueLiftingProperty`. -/
+instance leftOrthogonal_isStableUnderRetracts : T.leftOrthogonal.IsStableUnderRetracts where
+  of_retract h hg _ _ f hf :=
+    letI := hg _ hf
+    h.leftUniqueLiftingProperty f
+
+/-- The right orthogonal of `T` is stable under retracts, via
+`RetractArrow.rightUniqueLiftingProperty`. -/
+instance rightOrthogonal_isStableUnderRetracts : T.rightOrthogonal.IsStableUnderRetracts where
+  of_retract h hf _ _ g hg :=
+    letI := hf _ hg
+    h.rightUniqueLiftingProperty g
+
+/-- The left orthogonal of `T` is stable under cobase change, via
+`IsPushout.hasUniqueLiftingProperty`. -/
+instance leftOrthogonal_isStableUnderCobaseChange :
+    T.leftOrthogonal.IsStableUnderCobaseChange where
+  of_isPushout h hf _ _ g' hg' :=
+    letI := hf _ hg'
+    h.hasUniqueLiftingProperty g'
+
+/-- The right orthogonal of `T` is stable under base change, via
+`IsPullback.hasUniqueLiftingProperty`. -/
+instance rightOrthogonal_isStableUnderBaseChange :
+    T.rightOrthogonal.IsStableUnderBaseChange where
+  of_isPullback h hf _ _ f' hf' :=
+    letI := hf _ hf'
+    h.hasUniqueLiftingProperty f'
+
+/-- The right orthogonal of `T` has the of-postcomp property against itself: if
+`f ≫ g` and `g` are both right orthogonal to `T`, then so is `f` (right
+cancellation). See the module docstring for the orientation dictionary. -/
+instance rightOrthogonal_hasOfPostcompProperty :
+    T.rightOrthogonal.HasOfPostcompProperty T.rightOrthogonal where
+  of_postcomp f g hg hfg _ _ i hi := by
+    have := hfg i hi
+    have := (hg i hi).toHasAtMostOneLiftingProperty
+    exact .of_comp_right_cancel i f g
+
+/-- The left orthogonal of `T` has the of-precomp property against itself: if
+`f ≫ g` and `f` are both left orthogonal to `T`, then so is `g` (left
+cancellation). See the module docstring for the orientation dictionary. -/
+instance leftOrthogonal_hasOfPrecompProperty :
+    T.leftOrthogonal.HasOfPrecompProperty T.leftOrthogonal where
+  of_precomp f g hf hfg _ _ i hi := by
+    have := hfg i hi
+    have := (hf i hi).toHasAtMostOneLiftingProperty
+    exact .of_comp_left_cancel i g f
+
+set_option synthInstance.checkSynthOrder false in
+/-- The left class of an orthogonal pair is stable under retracts
+([anel2009], Proposition 3(3)). -/
+instance IsOrthogonalPair.left_isStableUnderRetracts (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] : A.IsStableUnderRetracts := by
+  rw [← IsOrthogonalPair.left_eq (A := A) (B := B)]
+  infer_instance
+
+set_option synthInstance.checkSynthOrder false in
+/-- The right class of an orthogonal pair is stable under retracts
+([anel2009], Proposition 3(3)). -/
+instance IsOrthogonalPair.right_isStableUnderRetracts (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] : B.IsStableUnderRetracts := by
+  rw [← IsOrthogonalPair.right_eq (A := A) (B := B)]
+  infer_instance
+
+set_option synthInstance.checkSynthOrder false in
+/-- The left class of an orthogonal pair is stable under cobase change
+([anel2009], Proposition 3(3)). -/
+instance IsOrthogonalPair.left_isStableUnderCobaseChange (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] : A.IsStableUnderCobaseChange := by
+  rw [← IsOrthogonalPair.left_eq (A := A) (B := B)]
+  infer_instance
+
+set_option synthInstance.checkSynthOrder false in
+/-- The right class of an orthogonal pair is stable under base change
+([anel2009], Proposition 3(3)). -/
+instance IsOrthogonalPair.right_isStableUnderBaseChange (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] : B.IsStableUnderBaseChange := by
+  rw [← IsOrthogonalPair.right_eq (A := A) (B := B)]
+  infer_instance
+
+set_option synthInstance.checkSynthOrder false in
+/-- The right class of an orthogonal pair has of-postcomp cancellation (called
+left cancellation in [anel2009], Proposition 3(3), and right cancellation in the
+orientation table in this module). -/
+instance IsOrthogonalPair.right_hasOfPostcompProperty (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] : B.HasOfPostcompProperty B := by
+  rw [← IsOrthogonalPair.right_eq (A := A) (B := B)]
+  infer_instance
+
+set_option synthInstance.checkSynthOrder false in
+/-- The left class of an orthogonal pair has of-precomp cancellation (the dual
+of the rule called left cancellation in [anel2009], Proposition 3(3), and left
+cancellation in the orientation table in this module). -/
+instance IsOrthogonalPair.left_hasOfPrecompProperty (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] : A.HasOfPrecompProperty A := by
+  rw [← IsOrthogonalPair.left_eq (A := A) (B := B)]
+  infer_instance
+
+/-- Thin wrapper over `MorphismProperty.of_postcomp` for the right orthogonal, so
+downstream files need not name the `HasOfPostcompProperty` typeclass: if `g` and
+`f ≫ g` are right orthogonal to `T`, then so is `f`. -/
+lemma rightOrthogonal_of_postcomp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+    (hg : T.rightOrthogonal g) (hfg : T.rightOrthogonal (f ≫ g)) :
+    T.rightOrthogonal f :=
+  T.rightOrthogonal.of_postcomp f g hg hfg
+
+/-- Right cancellation of a **monomorphism**, with no hypothesis on `T`: if `f ≫ g` is right
+orthogonal to `T` and `g` is a monomorphism, then `f` is right orthogonal to `T`.
+
+This strengthens `rightOrthogonal_of_postcomp`, which asks the cancelled factor `g` to lie in
+the right class; here it only has to be monic. Both halves of unique lifting survive the
+cancellation: a lift of a square against `f` is obtained from the lift against `f ≫ g` because
+`g` is monic, and uniqueness is inherited because `g` being monic gives
+`HasAtMostOneLiftingProperty i g` for free. -/
+lemma rightOrthogonal_of_postcomp_mono {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Mono g]
+    (hfg : T.rightOrthogonal (f ≫ g)) : T.rightOrthogonal f := fun _ _ i hi ↦ by
+  have := hfg i hi
+  exact .of_comp_right_cancel i f g
+
+/-- Left cancellation of an **epimorphism**, the dual of `rightOrthogonal_of_postcomp_mono`: if
+`f ≫ g` is left orthogonal to `T` and `f` is an epimorphism, then `g` is left orthogonal
+to `T`. -/
+lemma leftOrthogonal_of_precomp_epi {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Epi f]
+    (hfg : T.leftOrthogonal (f ≫ g)) : T.leftOrthogonal g := fun _ _ p hp ↦ by
+  have := hfg p hp
+  exact .of_comp_left_cancel p g f
+
+/-- Thin wrapper over `MorphismProperty.of_precomp` for the left orthogonal: if
+`f` and `f ≫ g` are left orthogonal to `T`, then so is `g`. -/
+lemma leftOrthogonal_of_precomp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+    (hf : T.leftOrthogonal f) (hfg : T.leftOrthogonal (f ≫ g)) :
+    T.leftOrthogonal g :=
+  T.leftOrthogonal.of_precomp f g hf hfg
+
+/-- A section of a morphism in the right orthogonal of `T` is itself right orthogonal
+to `T`: if `f ≫ g = 𝟙` and `g` is right orthogonal to `T`, then so is `f` (one
+of the section/retraction consequences of [anel2009], Proposition 3(3)). The composite
+`f ≫ g` is an isomorphism, hence right orthogonal by `rightOrthogonal_of_isIso`,
+and of-postcomp cancellation (`rightOrthogonal_of_postcomp`) then yields `f`.
+Retractions of right-class maps follow from stability under retracts. -/
+lemma rightOrthogonal_of_section {X Y : C} {f : X ⟶ Y} {g : Y ⟶ X}
+    (hg : T.rightOrthogonal g) (h : f ≫ g = 𝟙 X) : T.rightOrthogonal f := by
+  have hfg : T.rightOrthogonal (f ≫ g) := by
+    rw [h]; exact T.rightOrthogonal_of_isIso _
+  exact T.rightOrthogonal_of_postcomp f g hg hfg
+
+/-- A retraction of a morphism in the left orthogonal of `T` is itself left orthogonal
+to `T`: if `f ≫ g = 𝟙` and `f` is left orthogonal to `T`, then so is `g` (one
+of the dual section/retraction consequences of [anel2009], Proposition 3(3)).
+Sections
+of left-class maps follow from stability under retracts. -/
+lemma leftOrthogonal_of_retraction {X Y : C} {f : X ⟶ Y} {g : Y ⟶ X}
+    (hf : T.leftOrthogonal f) (h : f ≫ g = 𝟙 X) : T.leftOrthogonal g := by
+  have hfg : T.leftOrthogonal (f ≫ g) := by
+    rw [h]; exact T.leftOrthogonal_of_isIso _
+  exact T.leftOrthogonal_of_precomp f g hf hfg
+
+/-- A morphism that is both left orthogonal to `T` and in `T` is an isomorphism:
+it then has the unique lifting property against itself, hence the ordinary lifting
+property against itself, so it is an isomorphism ([anel2009], Proposition 3(2),
+one inclusion). Stated generically in `T`; no `IsOrthogonalPair` is needed. -/
+lemma leftOrthogonal_inf_le_isomorphisms : T.leftOrthogonal ⊓ T ≤ isomorphisms C := by
+  intro X Y f hf
+  obtain ⟨hfl, hfT⟩ := hf
+  have hlp : HasLiftingProperty f f := (hfl f hfT).toHasLiftingProperty
+  exact isIso_of_hasLiftingProperty_self f
+
+/-- A morphism that is both in `T` and right orthogonal to `T` is an isomorphism
+([anel2009], Proposition 3(2), the dual inclusion). Stated generically in `T`. -/
+lemma inf_rightOrthogonal_le_isomorphisms : T ⊓ T.rightOrthogonal ≤ isomorphisms C := by
+  intro X Y f hf
+  obtain ⟨hfT, hfr⟩ := hf
+  have hlp : HasLiftingProperty f f := (hfr f hfT).toHasLiftingProperty
+  exact isIso_of_hasLiftingProperty_self f
+
+/-- The intersection of the two classes of an orthogonal pair is exactly the
+isomorphisms ([anel2009], Proposition 3(2)). -/
+lemma IsOrthogonalPair.inf_eq_isomorphisms (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] : A ⊓ B = isomorphisms C := by
+  apply le_antisymm
+  · rw [← IsOrthogonalPair.left_eq (A := A) (B := B)]
+    exact B.leftOrthogonal_inf_le_isomorphisms
+  · intro X Y f hf
+    rw [isomorphisms.iff] at hf
+    have : IsIso f := hf
+    constructor
+    · rw [← IsOrthogonalPair.left_eq (A := A) (B := B)]
+      exact B.leftOrthogonal_of_isIso f
+    · rw [← IsOrthogonalPair.right_eq (A := A) (B := B)]
+      exact A.rightOrthogonal_of_isIso f
+
+/-- The right orthogonal of `T` is stable under limits of any shape `J`: a morphism
+of limit cones lying over a natural transformation whose every component is right
+orthogonal to `T` is itself right orthogonal to `T` ([anel2009],
+Proposition 3(4)).
+
+This has no ordinary-lifting analogue for non-discrete `J`; see
+`HasUniqueLiftingProperty.of_isLimit`. The discrete-`J` case recovers stability
+under products.
+
+**Which limit this is.** The limit here is taken in `Arrow C`, so for a diagram
+of quotient maps `A j ⟶ A j ⧸ I j` in `CommRingCat` the conclusion is about the
+arrow `lim A j ⟶ lim (A j ⧸ I j)`. That arrow is in general *not* the quotient
+map of the limit pair, which is `lim A j ⟶ (lim A j) ⧸ (lim I j)`: the two
+targets differ already for a tower of surjections, since a limit of quotients
+need not be the quotient by the limit ideal. The statement about the limit
+*pair* is a different theorem with a different proof — it comes from
+reflectivity of the right class inside the arrows of a quotient-like class (the
+Phase G.2 of `cellular_presentation_plan.md`, with Stacks 0EM6 as its
+corollary).
+
+Both statements are wanted, and this one is the right tool precisely when the
+morphism at hand is not known to be a quotient — for instance when surjectivity
+of the right factor of a factorization is itself the hard theorem. Do not
+replace it by the pair statement. -/
+instance rightOrthogonal_isStableUnderLimitsOfShape (J : Type*) [Category J] :
+    T.rightOrthogonal.IsStableUnderLimitsOfShape J where
+  condition _ _ _ _ h₁ h₂ f hf _ hφ _ _ i hi := by
+    have : ∀ j, HasUniqueLiftingProperty i (f.app j) := fun j ↦ hf j i hi
+    exact HasUniqueLiftingProperty.of_isLimit f h₁ h₂ hφ i
+
+/-- The left orthogonal of `T` is stable under colimits of any shape `J`: a morphism
+of colimit cocones lying over a natural transformation whose every component is left
+orthogonal to `T` is itself left orthogonal to `T` ([anel2009],
+Proposition 3(4), dual).
+
+The discrete-`J` case recovers stability under coproducts. -/
+instance leftOrthogonal_isStableUnderColimitsOfShape (J : Type*) [Category J] :
+    T.leftOrthogonal.IsStableUnderColimitsOfShape J where
+  condition _ _ _ _ h₁ h₂ f hf _ hφ _ _ p hp := by
+    have : ∀ j, HasUniqueLiftingProperty (f.app j) p := fun j ↦ hf j p hp
+    exact HasUniqueLiftingProperty.of_isColimit f h₁ h₂ hφ p
+
+/-- The left orthogonal of `T` is stable under coproducts. The
+`IsStableUnderCoproductsOfShape J` field is filled from
+`leftOrthogonal_isStableUnderColimitsOfShape` (a coproduct is a colimit over a
+discrete shape). -/
+instance leftOrthogonal_isStableUnderCoproducts :
+    IsStableUnderCoproducts.{w} T.leftOrthogonal where
+
+set_option synthInstance.checkSynthOrder false in
+/-- The right class of an orthogonal pair is stable under limits of any shape `J`
+([anel2009], Proposition 3(4)). -/
+instance IsOrthogonalPair.right_isStableUnderLimitsOfShape (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] (J : Type*) [Category J] : B.IsStableUnderLimitsOfShape J := by
+  rw [← IsOrthogonalPair.right_eq (A := A) (B := B)]
+  infer_instance
+
+set_option synthInstance.checkSynthOrder false in
+/-- The left class of an orthogonal pair is stable under colimits of any shape `J`
+([anel2009], Proposition 3(4), dual). -/
+instance IsOrthogonalPair.left_isStableUnderColimitsOfShape (A B : MorphismProperty C)
+    [IsOrthogonalPair A B] (J : Type*) [Category J] : A.IsStableUnderColimitsOfShape J := by
+  rw [← IsOrthogonalPair.left_eq (A := A) (B := B)]
+  infer_instance
+
+end MorphismProperty
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/SmallObject/UniqueTransfiniteCompositionLifting.lean
+++ b/Mathlib/CategoryTheory/SmallObject/UniqueTransfiniteCompositionLifting.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 Jakob Scholbach. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jakob Scholbach
+-/
+module
+
+public import Mathlib.CategoryTheory.MorphismProperty.Orthogonal
+public import Mathlib.CategoryTheory.SmallObject.TransfiniteCompositionLifting
+
+/-!
+# Unique lifting is stable under transfinite composition (pointwise)
+
+This file provides the uniqueness half of the statement that the class of maps
+with the unique left lifting property against a fixed map `p` is stable under
+transfinite composition. (The existence half is
+`HasLiftingProperty.transfiniteComposition.hasLiftingProperty_ι_app_bot`.)
+
+## Main declarations
+
+* `HasUniqueLiftingProperty.transfiniteComposition.hasUniqueLiftingProperty_ι_app_bot`
+  — if every successor map lifts uniquely against `p`, so does the transfinite
+  composite.
+* `MorphismProperty.isStableUnderTransfiniteCompositionOfShape_leftOrthogonal` and
+  `MorphismProperty.isStableUnderTransfiniteComposition_leftOrthogonal` — instances
+  saying that `T.leftOrthogonal` is closed under transfinite composition, of a fixed
+  shape `J` and of arbitrary shape respectively.
+
+## The proof
+
+Two lifts `m₁ m₂ : c.pt ⟶ X` of a square along the transfinite composition
+`c.ι.app ⊥` are compared stage by stage, by transfinite induction on `j : J`
+(`HasAtMostOneLiftingProperty.transfiniteComposition.comp_ext`):
+
+* at the bottom stage, `c.ι.app ⊥ ≫ m₁ = c.ι.app ⊥ ≫ m₂` is the hypothesis;
+* to pass from `j` to `Order.succ j`, the two composites with `c.ι.app (Order.succ j)`
+  are two lifts of one and the same square along
+  `F.obj j ⟶ F.obj (Order.succ j)`, so they agree by the assumption on that map;
+* at a limit stage, `F.obj j` is the colimit of the earlier stages, so the claim
+  follows from the inductive hypothesis by `hom_ext`.
+
+Since `c` is a colimit, extensionality of `c.pt` then gives `m₁ = m₂`.
+-/
+
+public section
+
+universe w
+
+namespace CategoryTheory
+
+open Category Limits
+
+variable {C : Type*} [Category* C]
+
+namespace HasAtMostOneLiftingProperty
+
+namespace transfiniteComposition
+
+/- Throughout this section `J` is a well-ordered type, `F : J ⥤ C` is a
+well-order-continuous functor and `c` is a cocone over `F`, so that once `c` is a colimit
+(`hc`) the map `c.ι.app ⊥ : F.obj ⊥ ⟶ c.pt` is the transfinite composition of `F`. The map
+to lift against is `p : X ⟶ Y`, and `hF` says that each successor map
+`F.obj j ⟶ F.obj (Order.succ j)` has at most one lift against `p`. -/
+variable {J : Type w} [LinearOrder J] [OrderBot J] [SuccOrder J] [WellFoundedLT J]
+  {F : J ⥤ C} [F.IsWellOrderContinuous] {c : Cocone F} (hc : IsColimit c)
+  {X Y : C} {p : X ⟶ Y}
+  (hF : ∀ (j : J) (_ : ¬IsMax j),
+    HasAtMostOneLiftingProperty (F.map (homOfLE (Order.le_succ j))) p)
+
+include hF
+
+/-- Two lifts `m₁ m₂ : c.pt ⟶ X` of the same square agree after precomposition
+with `c.ι.app j`, for every `j : J`, provided they agree at the bottom stage and
+have the same composite with `p`. -/
+lemma comp_ext (m₁ m₂ : c.pt ⟶ X)
+    (hbot : c.ι.app ⊥ ≫ m₁ = c.ι.app ⊥ ≫ m₂)
+    (hp : m₁ ≫ p = m₂ ≫ p) (j : J) :
+    c.ι.app j ≫ m₁ = c.ι.app j ≫ m₂ := by
+  induction j using SuccOrder.limitRecOn with
+  | isMin j hj =>
+    obtain rfl := isMin_iff_eq_bot.mp hj
+    exact hbot
+  | succ j hj IH =>
+    have := hF j hj
+    have w : (c.ι.app j ≫ m₁) ≫ p =
+        F.map (homOfLE (Order.le_succ j)) ≫ (c.ι.app (Order.succ j) ≫ m₁ ≫ p) := by
+      rw [Category.assoc, Cocone.w_assoc]
+    let sq : CommSq (c.ι.app j ≫ m₁) (F.map (homOfLE (Order.le_succ j))) p
+        (c.ι.app (Order.succ j) ≫ m₁ ≫ p) := ⟨w⟩
+    exact congrArg CommSq.LiftStruct.l (Subsingleton.elim
+      (⟨c.ι.app (Order.succ j) ≫ m₁, by rw [Cocone.w_assoc], by rw [Category.assoc]⟩ :
+        sq.LiftStruct)
+      ⟨c.ι.app (Order.succ j) ≫ m₂, by rw [Cocone.w_assoc, IH], by rw [Category.assoc, hp]⟩)
+  | isSuccLimit j hj IH =>
+    apply (F.isColimitOfIsWellOrderContinuous j hj).hom_ext
+    rintro ⟨b, hb⟩
+    have hbj : b < j := hb
+    change F.map (homOfLE hbj.le) ≫ c.ι.app j ≫ m₁
+        = F.map (homOfLE hbj.le) ≫ c.ι.app j ≫ m₂
+    rw [Cocone.w_assoc, Cocone.w_assoc]
+    exact IH b hbj
+
+include hc
+
+/-- The transfinite composition `c.ι.app ⊥` has at most one lift against `p`
+whenever each successor map does. -/
+lemma hasAtMostOneLiftingProperty_ι_app_bot :
+    HasAtMostOneLiftingProperty (c.ι.app ⊥) p where
+  subsingleton_liftStruct sq := ⟨fun l₁ l₂ => by
+    apply CommSq.LiftStruct.ext
+    apply hc.hom_ext
+    intro j
+    exact comp_ext hF l₁.l l₂.l
+      (by rw [l₁.fac_left, l₂.fac_left]) (by rw [l₁.fac_right, l₂.fac_right]) j⟩
+
+end transfiniteComposition
+
+end HasAtMostOneLiftingProperty
+
+namespace HasUniqueLiftingProperty
+
+namespace transfiniteComposition
+
+variable {J : Type w} [LinearOrder J] [OrderBot J] [SuccOrder J] [WellFoundedLT J]
+  {F : J ⥤ C} [F.IsWellOrderContinuous] {c : Cocone F} (hc : IsColimit c)
+  {X Y : C} {p : X ⟶ Y}
+
+include hc
+
+/-- The transfinite composition `c.ι.app ⊥` has a unique lift against `p`
+whenever each successor map does. -/
+lemma hasUniqueLiftingProperty_ι_app_bot
+    (hF : ∀ (j : J) (_ : ¬IsMax j),
+      HasUniqueLiftingProperty (F.map (homOfLE (Order.le_succ j))) p) :
+    HasUniqueLiftingProperty (c.ι.app ⊥) p :=
+  have := HasLiftingProperty.transfiniteComposition.hasLiftingProperty_ι_app_bot hc
+    (fun j hj => (hF j hj).toHasLiftingProperty)
+  have := HasAtMostOneLiftingProperty.transfiniteComposition.hasAtMostOneLiftingProperty_ι_app_bot
+    hc (fun j hj => (hF j hj).toHasAtMostOneLiftingProperty)
+  HasUniqueLiftingProperty.mk' (c.ι.app ⊥) p
+
+end transfiniteComposition
+
+end HasUniqueLiftingProperty
+
+namespace MorphismProperty
+
+variable (T : MorphismProperty C)
+  (J : Type w) [LinearOrder J] [SuccOrder J] [OrderBot J] [WellFoundedLT J]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The left orthogonal of `T` is stable under transfinite compositions of shape `J`.
+(Compare to `MorphismProperty.isStableUnderTransfiniteCompositionOfShape_llp`.) -/
+instance isStableUnderTransfiniteCompositionOfShape_leftOrthogonal :
+    T.leftOrthogonal.IsStableUnderTransfiniteCompositionOfShape J := by
+  rw [isStableUnderTransfiniteCompositionOfShape_iff]
+  rintro X Y f ⟨h⟩
+  have : T.leftOrthogonal (h.incl.app ⊥) := fun _ _ p hp ↦
+    HasUniqueLiftingProperty.transfiniteComposition.hasUniqueLiftingProperty_ι_app_bot
+      (hc := h.isColimit) (fun j hj ↦ h.map_mem j hj _ hp)
+  exact (MorphismProperty.arrow_mk_iso_iff _
+    (Arrow.isoMk h.isoBot.symm (Iso.refl _))).2 this
+
+/-- The left orthogonal of `T` is stable under (arbitrary-shape) transfinite
+compositions. -/
+instance isStableUnderTransfiniteComposition_leftOrthogonal :
+    MorphismProperty.IsStableUnderTransfiniteComposition.{w} T.leftOrthogonal where
+
+end MorphismProperty
+
+end CategoryTheory

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -197,7 +197,8 @@
 
 @Misc{            anel2009,
   author        = {Anel, Mathieu},
-  title         = {Grothendieck topologies from unique factorisation systems},
+  title         = {Grothendieck topologies from unique factorisation
+                  systems},
   year          = {2009},
   eprint        = {0902.1130},
   archiveprefix = {arXiv},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -195,6 +195,15 @@
   url           = {https://doi.org/10.1016/0012-365X(74)90133-2}
 }
 
+@Misc{            anel2009,
+  author        = {Anel, Mathieu},
+  title         = {Grothendieck topologies from unique factorisation systems},
+  year          = {2009},
+  eprint        = {0902.1130},
+  archiveprefix = {arXiv},
+  primaryclass  = {math.AG}
+}
+
 @Article{         assouad1983,
   author        = {Assouad, P.},
   title         = {Densit{\'e} et dimension},


### PR DESCRIPTION
Introduces `HasAtMostOneLiftingProperty` and `HasUniqueLiftingProperty`, the at-most-one and exactly-one analogues of `HasLiftingProperty`, and develops the API around them:

* `LiftingProperties/Unique.lean` — the two classes of the orthogonal factorization system, their opposite, composition, cancellation, arrow-isomorphism and retract API.
* `LiftingProperties/Diagonal.lean` — unique lifting characterized by ordinary lifting against `pushout.codiagonal i` and against `pullback.diagonal p`.
* `LiftingProperties/UniqueLimits.lean` — stability under pushouts, pullbacks, products, coproducts and general (co)limits.
* `MorphismProperty/Orthogonal.lean` — the left and right orthogonals of a morphism property, mirroring `MorphismProperty/LiftingProperty.lean`'s `llp`/`rlp`, with their Galois connection, following [anel2009].
* `SmallObject/UniqueTransfiniteCompositionLifting.lean` — the left orthogonal of a morphism property is stable under transfinite composition.
* `Algebra/Category/Ring/LiftingProperties.lean` — the translation between unique lifting in `CommRingCat` and ring homomorphisms. (This is included in view of applications in commutative algebra and algebraic geometry.)

`LiftingProperties/Basic.lean` gains `isIso_of_hasLiftingProperty_self`, which belongs with the ordinary lifting property rather than with the new classes.

This code was sketched out by myself mostly based on the paper by Anel "Grothendieck topologies from unique factorisation
systems" and then implemented using Claude Code. I have thoroughly reviewed the code, and hope it is acceptable to submit in this form as a PR. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
