### PR TITLE
perf: remove `simp` from `sup_of_le_left` and friends

### DIFF
--- a/Archive/Examples/Kuratowski.lean
+++ b/Archive/Examples/Kuratowski.lean
@@ -188,7 +188,7 @@ theorem i_fourteenSet : i fourteenSet = Ioo 0 1 ∪ Ioo 1 2 := by
 
 theorem k_fourteenSet : k fourteenSet = Icc 0 2 ∪ {3} ∪ Icc 4 5 := by
   simp_rw [fourteenSet, closure_union]
-  rw [closure_Ioo, closure_Ioo, k_Icc_4_5_inter_rat, Icc_union_Icc'] <;> simp
+  rw [closure_Ioo, closure_Ioo, k_Icc_4_5_inter_rat, Icc_union_Icc_eq_Icc] <;> simp
 
 theorem kc_fourteenSet : k fourteenSetᶜ = (Ioo 0 1 ∪ Ioo 1 2)ᶜ := by
   rw [closure_compl, compl_inj_iff, i_fourteenSet]

--- a/Archive/RiemannStieltjes.lean
+++ b/Archive/RiemannStieltjes.lean
@@ -310,7 +310,7 @@ theorem stieltjesIntegrable_iff_integrable_of_gt (hab : b < a) :
 
 lemma StieltjesIntegrable.iff_min_max :
     StieltjesIntegrable a b B f g ↔ StieltjesIntegrable (min a b) (max a b) B f g := by
-  rcases le_total a b with h | h <;> simp [h, symm_iff]
+  rcases le_total a b with h | h <;> grind [symm_iff]
 
 /-- Uniqueness: the Riemann–Stieltjes integral, when it exists, is unique. -/
 theorem HasStieltjesIntegral.unique

--- a/Counterexamples/Phillips.lean
+++ b/Counterexamples/Phillips.lean
@@ -543,7 +543,7 @@ theorem integrable_comp (Hcont : #ℝ = ℵ₁) (φ : (DiscreteCopy ℝ →ᵇ �
 theorem integral_comp (Hcont : #ℝ = ℵ₁) (φ : (DiscreteCopy ℝ →ᵇ ℝ) →L[ℝ] ℝ) :
     ∫ x in Icc 0 1, φ (f Hcont x) = φ.toBoundedAdditiveMeasure.continuousPart univ := by
   rw [← integral_congr_ae (comp_ae_eq_const Hcont φ)]
-  simp
+  simp [max_eq_left]
 
 /-!
 The next few statements show that the function `f Hcont : ℝ → (DiscreteCopy ℝ →ᵇ ℝ)` takes its
@@ -580,7 +580,7 @@ theorem no_pettis_integral (Hcont : #ℝ = ℵ₁) :
   simp only [this, map_zero] at h
   specialize h (volume.restrict (Icc (0 : ℝ) 1)).extensionToBoundedFunctions
   simp_rw [toFunctions_toMeasure_continuousPart _ _ MeasurableSet.univ] at h
-  simp at h
+  norm_num at h
 
 end Phillips1940
 

--- a/Mathlib/Algebra/Module/Submodule/Range.lean
+++ b/Mathlib/Algebra/Module/Submodule/Range.lean
@@ -332,7 +332,7 @@ theorem submoduleOf_sup_of_le {N₁ N₂ N : Submodule R M} (h₁ : N₁ ≤ N) 
     (N₁ ⊔ N₂).submoduleOf N = N₁.submoduleOf N ⊔ N₂.submoduleOf N := by
   apply Submodule.map_injective_of_injective N.subtype_injective
   simp only [submoduleOf, map_comap_eq]
-  simp_all
+  simp [*, inf_of_le_right]
 
 @[simp]
 lemma comap_subtype_le_iff {p q r : Submodule R M} :

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -368,11 +368,13 @@ theorem min_le_mk_div (a b : M) : min (mk a) (mk b) ≤ mk (a / b) := by
 
 @[to_additive]
 theorem mk_left_le_mk_mul (hab : mk a ≤ mk b) : mk a ≤ mk (a * b) := by
-  simpa [hab] using min_le_mk_mul (a := a) (b := b)
+  grw [← min_le_mk_mul]
+  simp [hab]
 
 @[to_additive]
 theorem mk_right_le_mk_mul (hba : mk b ≤ mk a) : mk b ≤ mk (a * b) := by
-  simpa [hba] using min_le_mk_mul (a := a) (b := b)
+  grw [← min_le_mk_mul]
+  simp [hba]
 
 @[to_additive]
 theorem mk_left_le_mk_div (hab : mk a ≤ mk b) : mk a ≤ mk (a / b) := by

--- a/Mathlib/Algebra/Order/Group/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Abs.lean
@@ -237,7 +237,7 @@ theorem mabs_cases (a : G) : |a|ₘ = a ∧ 1 ≤ a ∨ |a|ₘ = a⁻¹ ∧ a < 
 @[to_additive (attr := simp)]
 theorem max_one_mul_max_inv_one_eq_mabs_self (a : G) : max a 1 * max a⁻¹ 1 = |a|ₘ := by
   symm
-  rcases le_total 1 a with (ha | ha) <;> simp [ha]
+  rcases le_total 1 a with (ha | ha) <;> simp [ha, sup_of_le_left, sup_of_le_right]
 
 end LinearOrderedCommGroup
 

--- a/Mathlib/Algebra/Order/Group/MinMax.lean
+++ b/Mathlib/Algebra/Order/Group/MinMax.lean
@@ -22,7 +22,7 @@ variable {α : Type*} [Group α] [LinearOrder α] [MulLeftMono α]
 -- TODO: This duplicates `oneLePart_div_leOnePart`
 @[to_additive (attr := simp)]
 theorem max_one_div_max_inv_one_eq_self (a : α) : max a 1 / max a⁻¹ 1 = a := by
-  rcases le_total a 1 with (h | h) <;> simp [h]
+  rcases le_total a 1 with (h | h) <;> simp [h, sup_of_le_left, sup_of_le_right]
 
 alias max_zero_sub_eq_self := max_zero_sub_max_neg_zero_eq_self
 
@@ -37,7 +37,7 @@ section Inv
 variable {G₀ : Type*} [Inv G₀] [LinearOrder G₀] {x y : G₀}
 
 lemma min_inv_inv_le : min x⁻¹ y⁻¹ ≤ (max x y)⁻¹ := by
-  cases le_total x y <;> simp_all
+  rcases le_total x y with (h | h) <;> simp [h, sup_of_le_left, sup_of_le_right]
 
 end Inv
 

--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -109,7 +109,7 @@ lemma leOnePart_le_one' : a⁻ᵐ ≤ 1 ↔ a⁻¹ ≤ 1 := by simp [leOnePart]
 @[to_additive (attr := simp)] lemma oneLePart_inv (a : α) : a⁻¹⁺ᵐ = a⁻ᵐ := rfl
 
 @[to_additive] lemma oneLePart_max (a b : α) : (max a b)⁺ᵐ = max a⁺ᵐ b⁺ᵐ := by
-  simp [oneLePart, sup_sup_distrib_right]
+  simp_rw [oneLePart_def, ← sup_sup_distrib_right]
 
 end DivInvMonoid
 
@@ -183,7 +183,7 @@ lemma leOnePart_eq_inv_inf_one (a : α) : a⁻ᵐ = (a ⊓ 1)⁻¹ := by
     oneLePart_div_leOnePart, leOnePart_eq_inv_inf_one, inv_inv]
 
 @[to_additive] lemma leOnePart_min (a b : α) : (min a b)⁻ᵐ = max a⁻ᵐ b⁻ᵐ := by
-  simp [leOnePart, inv_inf, sup_sup_distrib_right]
+  simp_rw [leOnePart_def, inv_inf, ← sup_sup_distrib_right]
 
 end MulRightMono
 

--- a/Mathlib/Algebra/Order/IsBotOne.lean
+++ b/Mathlib/Algebra/Order/IsBotOne.lean
@@ -121,16 +121,16 @@ end PartialOrder
 section LinearOrder
 variable [LinearOrder α] [One α] [IsBotOneClass α]
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem one_min (a : α) : min 1 a = 1 := by simp
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem min_one (a : α) : min a 1 = 1 := by simp
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem one_max (a : α) : max 1 a = a := by simp
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem max_one (a : α) : max a 1 = a := by simp
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -219,10 +219,10 @@ variable [Monoid α] [LinearOrder α] [CanonicallyOrderedMul α]
 @[to_additive]
 theorem min_mul_distrib (a b c : α) : min a (b * c) = min a (min a b * min a c) := by
   rcases le_total a b with hb | hb
-  · simp [hb, le_mul_right]
+  · rw [inf_of_le_left hb, inf_of_le_left (le_mul_right hb), inf_of_le_left le_self_mul]
   · rcases le_total a c with hc | hc
-    · simp [hc, le_mul_left]
-    · simp [hb, hc]
+    · rw [inf_of_le_left hc, inf_of_le_left (le_mul_left hc), inf_of_le_left le_mul_self]
+    · rw [inf_of_le_right hb, inf_of_le_right hc]
 
 @[to_additive]
 theorem min_mul_distrib' (a b c : α) : min (a * b) c = min (min a c * min b c) c := by

--- a/Mathlib/Algebra/Order/Monoid/LocallyFiniteOrder.lean
+++ b/Mathlib/Algebra/Order/Monoid/LocallyFiniteOrder.lean
@@ -59,7 +59,7 @@ lemma card_Ico_one_mul [ExistsMulOfLE M] (a b : M)
     (ha : 1 ≤ a) (hb : 1 ≤ b) :
     #(Ico 1 (a * b)) = #(Ico 1 a) + #(Ico 1 b) := by
   have : Ico 1 b ∪ Ico (1 * b) (a * b) = Ico 1 (a * b) := by
-    simp [Ico_union_Ico, ha, hb, Right.one_le_mul ha hb]
+    simp [Ico_union_Ico, ha, hb, Right.one_le_mul ha hb, sup_of_le_right, inf_of_le_left]
   rw [← this, Finset.card_union, Finset.card_Ico_mul_right]
   simp [add_comm]
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -184,7 +184,7 @@ lemma of_range_subset_iSup [P.RespectsRight @IsOpenImmersion] {ι : Type*} (U : 
   apply (⨆ i, U i).ι.image_injective
   dsimp
   rw [Scheme.Hom.image_iSup, Scheme.Hom.image_top_eq_opensRange, Scheme.Opens.opensRange_ι]
-  simp [Scheme.Hom.image_preimage_eq_opensRange_inf, le_iSup U]
+  simp [Scheme.Hom.image_preimage_eq_opensRange_inf, inf_of_le_right (le_iSup U _)]
 
 lemma of_forall_exists_morphismRestrict (H : ∀ x, ∃ U : Y.Opens, x ∈ U ∧ P (f ∣_ U)) : P f := by
   choose U hxU hU using H

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -702,14 +702,14 @@ exponent is nonnegative. -/
 lemma AnalyticWithinAt.zpow_nonneg {f : E → 𝕝} {z : E} {s : Set E} {n : ℤ}
     (hf : AnalyticWithinAt 𝕜 f s z) (hn : 0 ≤ n) :
     AnalyticWithinAt 𝕜 (f ^ n) s z := by
-  simpa [← zpow_natCast, hn] using hf.pow n.toNat
+  simpa [← zpow_natCast, sup_of_le_left hn] using hf.pow n.toNat
 
 /-- ZPowers of analytic functions (into a normed division algebra over `𝕜`) are analytic if the
 exponent is nonnegative. -/
 @[to_fun]
 lemma AnalyticAt.zpow_nonneg {f : E → 𝕝} {z : E} {n : ℤ} (hf : AnalyticAt 𝕜 f z) (hn : 0 ≤ n) :
     AnalyticAt 𝕜 (f ^ n) z := by
-  simpa [← zpow_natCast, hn] using hf.pow n.toNat
+  simpa [← zpow_natCast, sup_of_le_left hn] using hf.pow n.toNat
 
 /-- ZPowers of analytic functions (into a normed division algebra over `𝕜`) are analytic if the
 exponent is nonnegative. -/
@@ -717,7 +717,7 @@ exponent is nonnegative. -/
 lemma AnalyticOn.zpow_nonneg {f : E → 𝕝} {s : Set E} {n : ℤ} (hf : AnalyticOn 𝕜 f s)
     (hn : 0 ≤ n) :
     AnalyticOn 𝕜 (f ^ n) s := by
-  simpa [← zpow_natCast, hn] using hf.pow n.toNat
+  simpa [← zpow_natCast, sup_of_le_left hn] using hf.pow n.toNat
 
 /-- ZPowers of analytic functions (into a normed division algebra over `𝕜`) are analytic if the
 exponent is nonnegative. -/

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -212,7 +212,7 @@ lemma le_analyticOrderAt_sub :
 lemma analyticOrderAt_add_eq_left_of_lt (hfg : analyticOrderAt f z₀ < analyticOrderAt g z₀) :
     analyticOrderAt (f + g) z₀ = analyticOrderAt f z₀ :=
   le_antisymm (by simpa [hfg.not_ge] using le_analyticOrderAt_sub (f := f + g) (g := g) (z₀ := z₀))
-    (by simpa [hfg.le] using le_analyticOrderAt_add (f := f) (g := g) (z₀ := z₀))
+    (by grw [← le_analyticOrderAt_add, ← hfg, min_self])
 
 lemma analyticOrderAt_add_eq_right_of_lt (hgf : analyticOrderAt g z₀ < analyticOrderAt f z₀) :
     analyticOrderAt (f + g) z₀ = analyticOrderAt g z₀ := by
@@ -223,8 +223,8 @@ of the orders of the summands. -/
 lemma analyticOrderAt_add_of_ne (hfg : analyticOrderAt f z₀ ≠ analyticOrderAt g z₀) :
     analyticOrderAt (f + g) z₀ = min (analyticOrderAt f z₀) (analyticOrderAt g z₀) := by
   obtain hfg | hgf := hfg.lt_or_gt
-  · simpa [hfg.le] using analyticOrderAt_add_eq_left_of_lt hfg
-  · simpa [hgf.le] using analyticOrderAt_add_eq_right_of_lt hgf
+  · rw [analyticOrderAt_add_eq_left_of_lt hfg, inf_of_le_left hfg.le]
+  · rw [analyticOrderAt_add_eq_right_of_lt hgf, inf_of_le_right hgf.le]
 
 lemma analyticOrderAt_smul_eq_top_of_left {f : 𝕜 → 𝕜} (hf : analyticOrderAt f z₀ = ⊤) :
      analyticOrderAt (f • g) z₀ = ⊤ := by

--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -193,9 +193,8 @@ variable [Fintype ι] [∀ i, CStarRing (R i)]
 instance _root_.Prod.cstarRing : CStarRing (R₁ × R₂) where
   norm_mul_self_le x := by
     dsimp only [norm]
-    simp only [Prod.fst_mul, Prod.fst_star, Prod.snd_mul, Prod.snd_star, norm_star_mul_self, ← sq]
-    rw [le_sup_iff]
-    rcases le_total ‖x.fst‖ ‖x.snd‖ with (h | h) <;> simp [h]
+    simp only [Prod.fst_mul, Prod.fst_star, Prod.snd_mul, Prod.snd_star, norm_star_mul_self]
+    grind
 
 instance _root_.Pi.cstarRing : CStarRing (∀ i, R i) where
   norm_mul_self_le x := by

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unique.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unique.lean
@@ -76,14 +76,14 @@ lemma toNNReal_add_add_neg_add_neg_eq (f g : C(X, ℝ)) :
     (f + g).toNNReal + (-f).toNNReal + (-g).toNNReal =
       (-(f + g)).toNNReal + f.toNNReal + g.toNNReal := by
   ext x
-  simp [max_neg_zero, -neg_add_rev]
+  simp [Real.coe_toNNReal', max_neg_zero, -neg_add_rev]
   abel
 
 lemma toNNReal_mul_add_neg_mul_add_mul_neg_eq (f g : C(X, ℝ)) :
     (f * g).toNNReal + (-f).toNNReal * g.toNNReal + f.toNNReal * (-g).toNNReal =
       (-(f * g)).toNNReal + f.toNNReal * g.toNNReal + (-f).toNNReal * (-g).toNNReal := by
   ext x
-  simp [max_neg_zero, add_mul, mul_add]
+  simp [Real.coe_toNNReal', max_neg_zero, add_mul, mul_add]
   abel
 
 @[simp]
@@ -250,8 +250,8 @@ lemma toContinuousMapHom_toNNReal (f : C(X, ℝ)₀) :
 lemma toNNReal_smul (r : ℝ≥0) (f : C(X, ℝ)₀) : (r • f).toNNReal = r • f.toNNReal := by
   ext x
   by_cases! h : 0 ≤ f x
-  · simpa [max_eq_left h, NNReal.smul_def] using mul_nonneg r.coe_nonneg h
-  · simpa [max_eq_right h.le, NNReal.smul_def]
+  · simpa [Real.coe_toNNReal', max_eq_left h, NNReal.smul_def] using mul_nonneg r.coe_nonneg h
+  · simpa [Real.coe_toNNReal', max_eq_right h.le, NNReal.smul_def]
       using mul_nonpos_of_nonneg_of_nonpos r.coe_nonneg h.le
 
 @[simp]

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -336,12 +336,12 @@ theorem circleIntegral_sub_center_inv_smul_eq_of_differentiable_on_annulus_off_c
   have hdg : Differentiable ℂ g := differentiable_exp.const_add _
   replace hs : (g ⁻¹' s).Countable := (hs.preimage (add_right_injective c)).preimage_cexp
   have h_maps : MapsTo g R A := by
-    rintro z ⟨h, -⟩; simpa [g, A, dist_eq, norm_exp, hle] using h.symm
+    rintro z ⟨h, -⟩; rw [uIcc_of_le hle] at h; simpa [g, A, norm_exp] using h.symm
   replace hc : ContinuousOn (f ∘ g) R := hc.comp hdg.continuous.continuousOn h_maps
   replace hd : ∀ z ∈ Ioo (min a b) (max a b) ×ℂ Ioo (min 0 (2 * π)) (max 0 (2 * π)) \ g ⁻¹' s,
       DifferentiableAt ℂ (f ∘ g) z := by
     refine fun z hz => (hd (g z) ⟨?_, hz.2⟩).comp z (hdg _)
-    simpa [g, dist_eq, norm_exp, hle, and_comm] using hz.1.1
+    simpa [min_eq_left, max_eq_right, g, dist_eq, norm_exp, hle, and_comm] using hz.1.1
   simpa [g, circleMap, exp_periodic _, sub_eq_zero, ← exp_add] using
     integral_boundary_rect_eq_zero_of_differentiable_on_off_countable _ ⟨a, 0⟩ ⟨b, 2 * π⟩ _ hs hc hd
 

--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -445,7 +445,7 @@ theorem negPart_divisor_add_of_analyticNhdOn_right {f₁ f₂ : 𝕜 → E} (hf�
   · suffices -(meromorphicOrderAt (f₁ + f₂) x).untop₀ ⊔ 0 = -(meromorphicOrderAt f₁ x).untop₀ ⊔ 0 by
       simpa [negPart_def, hx, hf₁, hf₁.add hf₂.meromorphicOn]
     by_cases h : 0 ≤ meromorphicOrderAt f₁ x
-    · suffices 0 ≤ meromorphicOrderAt (f₁ + f₂) x by simp_all
+    · suffices 0 ≤ meromorphicOrderAt (f₁ + f₂) x by simp [max_eq_right, *]
       calc 0
       _ ≤ min (meromorphicOrderAt f₁ x) (meromorphicOrderAt f₂ x) :=
         le_inf h (hf₂ x hx).meromorphicOrderAt_nonneg

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -687,8 +687,8 @@ theorem meromorphicOrderAt_add_of_ne
     (h : meromorphicOrderAt f₁ x ≠ meromorphicOrderAt f₂ x) :
     meromorphicOrderAt (f₁ + f₂) x = min (meromorphicOrderAt f₁ x) (meromorphicOrderAt f₂ x) := by
   rcases lt_or_lt_iff_ne.mpr h with h | h
-  · simpa [h.le] using meromorphicOrderAt_add_eq_left_of_lt hf₂ h
-  · simpa [h.le] using meromorphicOrderAt_add_eq_right_of_lt hf₁ h
+  · rw [meromorphicOrderAt_add_eq_left_of_lt hf₂ h, inf_of_le_left h.le]
+  · rw [meromorphicOrderAt_add_eq_right_of_lt hf₁ h, inf_of_le_right h.le]
 
 /-!
 ## Level Sets of the Order Function

--- a/Mathlib/Analysis/Normed/Group/Real.lean
+++ b/Mathlib/Analysis/Normed/Group/Real.lean
@@ -93,7 +93,7 @@ theorem nnnorm_of_nonneg (hr : 0 ≤ r) : ‖r‖₊ = .mk r hr :=
   NNReal.eq <| norm_of_nonneg hr
 
 lemma enorm_of_nonneg (hr : 0 ≤ r) : ‖r‖ₑ = .ofReal r := by
-  simp [enorm, nnnorm_of_nonneg hr, ENNReal.ofReal, toNNReal, hr]
+  simp [enorm, nnnorm_of_nonneg hr, ENNReal.ofReal, toNNReal_of_nonneg hr]
 
 lemma enorm_ofReal_of_nonneg {a : ℝ} (ha : 0 ≤ a) : ‖ENNReal.ofReal a‖ₑ = ‖a‖ₑ := by
   simp [Real.enorm_of_nonneg, ha]

--- a/Mathlib/Analysis/Normed/Group/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Group/Ultra.lean
@@ -133,7 +133,7 @@ lemma nnnorm_pow_le (x : S) (n : ℕ) :
     ‖x ^ n‖₊ ≤ ‖x‖₊ := by
   induction n with
   | zero => simp
-  | succ n hn => simpa [pow_add, hn] using nnnorm_mul_le_max (x ^ n) x
+  | succ n hn => grw [pow_add, nnnorm_mul_le_max, hn, pow_one, max_self]
 
 @[to_additive]
 lemma norm_pow_le (x : S) (n : ℕ) :

--- a/Mathlib/Analysis/Normed/Operator/Perturbation/StrictByFinite.lean
+++ b/Mathlib/Analysis/Normed/Operator/Perturbation/StrictByFinite.lean
@@ -245,7 +245,7 @@ public theorem ContinuousLinearMap.isStrictMap_isClosed_range_iff_restrict
     quotientQuotientEquivQuotient N A inf_le_left |>.symm.finiteDimensional
   have v_ker : Disjoint v.ker B := by
     simp [disjoint_iff, v, B, toLinearMap_liftQL, ker_liftQ,
-      map_inf_eq_map_inf_comap, comap_map_mkQ, N, inf_comm]
+      map_inf_eq_map_inf_comap, comap_map_mkQ, N, sup_of_le_right, inf_comm]
   -- Because `A` contains `N`, we have `A = comap π B`. In particular, `B` is closed.
   have comap_B : comap π.toLinearMap B = A := by simp [B, N, π]
   have A_mapsTo_B : MapsTo π A B := fun _ ↦ by simp [← comap_B]

--- a/Mathlib/Analysis/SpecialFunctions/Integrability/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrability/Basic.lean
@@ -243,7 +243,7 @@ theorem intervalIntegrable_log' : IntervalIntegrable log volume a b := by
     apply intervalIntegrable_deriv_of_nonneg (g := fun x ↦ -(x * log x - x))
     · exact (continuous_mul_log.continuousOn.sub continuous_id.continuousOn).neg
     · intro s ⟨hs, _⟩
-      norm_num at *
+      norm_num [min_eq_left, max_eq_right] at *
       simpa using! (hasDerivAt_id s).sub (hasDerivAt_mul_log hs.ne.symm)
     · intro s ⟨hs₁, hs₂⟩
       grind [Pi.neg_apply, log_nonpos_iff]

--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -52,15 +52,13 @@ theorem posLog_def : log⁺ = max 0 (log ·) := rfl
 /-- Presentation of `log` in terms of its positive part. -/
 theorem posLog_sub_posLog_inv : log⁺ x - log⁺ x⁻¹ = log x := by
   rw [posLog_apply, posLog_apply, log_inv]
-  by_cases! h : 0 ≤ log x
-  · simp [h]
-  · simp [neg_nonneg.1 (Left.nonneg_neg_iff.2 h.le)]
+  grind
 
 /-- Presentation of `log⁺` in terms of `log`. -/
 theorem half_mul_log_add_log_abs : 2⁻¹ * (log x + |log x|) = log⁺ x := by
   by_cases! hr : 0 ≤ log x
-  · simp [posLog, hr, abs_of_nonneg]
-    ring
+  · simp [posLog]
+    grind
   · simp [posLog, hr.le, abs_of_nonpos]
 
 @[simp] lemma posLog_zero : log⁺ 0 = 0 := by simp [posLog]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Orthogonality.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Orthogonality.lean
@@ -62,7 +62,7 @@ theorem intervalIntegrable_sqrt_one_sub_sq_inv :
     IntervalIntegrable (fun x ↦ √(1 - x ^ 2)⁻¹) volume (-1) 1 := by
   rw [intervalIntegrable_iff]
   refine integrableOn_deriv_of_nonneg continuous_arccos.neg.continuousOn (fun x hx ↦ ?_) (by simp)
-  simpa using! (hasDerivAt_arccos (by aesop) (by aesop)).neg
+  simpa using! (hasDerivAt_arccos (by grind) (by grind)).neg
 
 theorem integrable_measureT {f : ℝ → ℝ} (hf : ContinuousOn f (Set.Icc (-1) 1)) :
     Integrable f measureT := by
@@ -86,7 +86,7 @@ theorem integral_measureT_eq_integral_cos {f : ℝ → ℝ} :
     · simp_rw [Function.comp_apply]
       exact integral_congr <| fun x hx => by simp [cos_arccos (x := x) (by aesop) (by aesop)]
     · fun_prop
-    · exact fun x hx ↦ (hasDerivAt_arccos (by aesop) (by aesop))
+    · exact fun x hx ↦ (hasDerivAt_arccos (by grind) (by grind))
     · simp
   _ = ∫ θ in 0..π, f (cos θ) := by simp
 

--- a/Mathlib/Basic/ENNReal/Real.lean
+++ b/Mathlib/Basic/ENNReal/Real.lean
@@ -262,7 +262,7 @@ lemma ofReal_eq_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
 theorem ofReal_le_iff_le_toReal {a : ℝ} {b : ℝ≥0∞} (hb : b ≠ ∞) :
     ENNReal.ofReal a ≤ b ↔ a ≤ ENNReal.toReal b := by
   lift b to ℝ≥0 using hb
-  simpa [ENNReal.ofReal, ENNReal.toReal] using Real.toNNReal_le_iff_le_coe
+  simp
 
 theorem ofReal_lt_iff_lt_toReal {a : ℝ} {b : ℝ≥0∞} (ha : 0 ≤ a) (hb : b ≠ ∞) :
     ENNReal.ofReal a < b ↔ a < ENNReal.toReal b := by

--- a/Mathlib/Basic/NNReal/Defs.lean
+++ b/Mathlib/Basic/NNReal/Defs.lean
@@ -155,6 +155,7 @@ protected theorem «exists» {p : ℝ≥0 → Prop} :
 def _root_.Real.toNNReal (r : ℝ) : ℝ≥0 :=
   .mk (max r 0) (le_max_right _ _)
 
+@[simp]
 theorem _root_.Real.coe_toNNReal (r : ℝ) (hr : 0 ≤ r) : (Real.toNNReal r : ℝ) = r :=
   max_eq_left hr
 
@@ -534,7 +535,6 @@ namespace Real
 
 section ToNNReal
 
-@[simp]
 theorem coe_toNNReal' (r : ℝ) : (Real.toNNReal r : ℝ) = max r 0 :=
   rfl
 
@@ -546,7 +546,7 @@ theorem toNNReal_one : Real.toNNReal 1 = 1 := NNReal.eq <| coe_toNNReal _ zero_l
 
 @[simp]
 theorem toNNReal_pos {r : ℝ} : 0 < Real.toNNReal r ↔ 0 < r := by
-  simp [← NNReal.coe_lt_coe]
+  simp [← NNReal.coe_lt_coe, coe_toNNReal']
 
 @[simp]
 theorem toNNReal_eq_zero {r : ℝ} : Real.toNNReal r = 0 ↔ r ≤ 0 := by
@@ -573,7 +573,8 @@ lemma toNNReal_eq_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
 
 @[simp]
 theorem toNNReal_le_toNNReal_iff {r p : ℝ} (hp : 0 ≤ p) :
-    toNNReal r ≤ toNNReal p ↔ r ≤ p := by simp [← NNReal.coe_le_coe, hp]
+    toNNReal r ≤ toNNReal p ↔ r ≤ p := by
+  grind [← coe_le_coe, coe_toNNReal']
 
 @[simp]
 lemma toNNReal_le_one {r : ℝ} : r.toNNReal ≤ 1 ↔ r ≤ 1 := by
@@ -658,7 +659,7 @@ lemma ofNat_le_toNNReal {n : ℕ} {r : ℝ} [n.AtLeastTwo] :
 @[simp]
 theorem toNNReal_add {r p : ℝ} (hr : 0 ≤ r) (hp : 0 ≤ p) :
     Real.toNNReal (r + p) = Real.toNNReal r + Real.toNNReal p :=
-  NNReal.eq <| by simp [hr, hp, add_nonneg]
+  NNReal.eq <| by simp [coe_toNNReal, hr, hp, add_nonneg]
 
 theorem toNNReal_add_toNNReal {r p : ℝ} (hr : 0 ≤ r) (hp : 0 ≤ p) :
     Real.toNNReal r + Real.toNNReal p = Real.toNNReal (r + p) :=
@@ -694,8 +695,9 @@ theorem toNNReal_zpow {x : ℝ} (hx : 0 ≤ x) (n : ℤ) : (x ^ n).toNNReal = x.
   rw [← coe_inj, NNReal.coe_zpow, Real.coe_toNNReal _ (zpow_nonneg hx _), Real.coe_toNNReal x hx]
 
 theorem toNNReal_mul {p q : ℝ} (hp : 0 ≤ p) :
-    Real.toNNReal (p * q) = Real.toNNReal p * Real.toNNReal q :=
-  NNReal.eq <| by simp [mul_max_of_nonneg, hp]
+    Real.toNNReal (p * q) = Real.toNNReal p * Real.toNNReal q := by
+  ext
+  simp [coe_toNNReal', mul_max_of_nonneg, hp]
 
 end ToNNReal
 

--- a/Mathlib/Basic/NNReal/Defs.lean
+++ b/Mathlib/Basic/NNReal/Defs.lean
@@ -571,7 +571,6 @@ lemma toNNReal_eq_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
     r.toNNReal = ofNat(n) ↔ r = OfNat.ofNat n :=
   toNNReal_eq_natCast (NeZero.ne n)
 
-@[simp]
 theorem toNNReal_le_toNNReal_iff {r p : ℝ} (hp : 0 ≤ p) :
     toNNReal r ≤ toNNReal p ↔ r ≤ p := by
   grind [← coe_le_coe, coe_toNNReal']
@@ -671,6 +670,7 @@ theorem toNNReal_le_toNNReal {r p : ℝ} (h : r ≤ p) : Real.toNNReal r ≤ Rea
 theorem toNNReal_add_le {r p : ℝ} : Real.toNNReal (r + p) ≤ Real.toNNReal r + Real.toNNReal p :=
   NNReal.coe_le_coe.1 <| max_le (add_le_add (le_max_left _ _) (le_max_left _ _)) NNReal.zero_le_coe
 
+@[simp]
 theorem toNNReal_le_iff_le_coe {r : ℝ} {p : ℝ≥0} : toNNReal r ≤ p ↔ r ≤ ↑p :=
   NNReal.gi.gc r p
 

--- a/Mathlib/Basic/NNReal/Defs.lean
+++ b/Mathlib/Basic/NNReal/Defs.lean
@@ -575,7 +575,6 @@ theorem toNNReal_le_toNNReal_iff {r p : ℝ} (hp : 0 ≤ p) :
     toNNReal r ≤ toNNReal p ↔ r ≤ p := by
   grind [← coe_le_coe, coe_toNNReal']
 
-@[simp]
 lemma toNNReal_le_one {r : ℝ} : r.toNNReal ≤ 1 ↔ r ≤ 1 := by
   simpa using toNNReal_le_toNNReal_iff zero_le_one
 
@@ -583,7 +582,6 @@ lemma toNNReal_le_one {r : ℝ} : r.toNNReal ≤ 1 ↔ r ≤ 1 := by
 lemma one_lt_toNNReal {r : ℝ} : 1 < r.toNNReal ↔ 1 < r := by
   simpa only [not_le] using toNNReal_le_one.not
 
-@[simp]
 lemma toNNReal_le_natCast {r : ℝ} {n : ℕ} : r.toNNReal ≤ n ↔ r ≤ n := by
   simpa using toNNReal_le_toNNReal_iff n.cast_nonneg
 
@@ -591,7 +589,6 @@ lemma toNNReal_le_natCast {r : ℝ} {n : ℕ} : r.toNNReal ≤ n ↔ r ≤ n := 
 lemma natCast_lt_toNNReal {r : ℝ} {n : ℕ} : n < r.toNNReal ↔ n < r := by
   simpa only [not_le] using toNNReal_le_natCast.not
 
-@[simp]
 lemma toNNReal_le_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
     r.toNNReal ≤ ofNat(n) ↔ r ≤ n :=
   toNNReal_le_natCast

--- a/Mathlib/Combinatorics/Matroid/Basic.lean
+++ b/Mathlib/Combinatorics/Matroid/Basic.lean
@@ -519,7 +519,7 @@ theorem isBase_compl_iff_maximal_disjoint_isBase (hB : B ⊆ M.E := by aesop_mat
     rw [subset_sdiff, and_iff_right hB'.subset_ground, disjoint_comm]
     exact disjoint_of_subset_left hBI hIB'
   rw [h sdiff_subset B' ⟨hB', disjoint_sdiff_left⟩]
-  · simpa [hB'.subset_ground]
+  · simpa [hB'.subset_ground, inf_of_le_right]
   simp [subset_sdiff, hB, hBB']
 
 end IsBase

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
@@ -58,7 +58,7 @@ lemma triangleRemovalBound_mul_cube_lt (hε : 0 < ε) :
 
 lemma triangleRemovalBound_le (hε₁ : ε ≤ 1) :
     triangleRemovalBound ε ≤ (1 - ε / 4) * (ε / (16 * bound (ε / 8) ⌈4 / ε⌉₊)) ^ 3 := by
-  simp [triangleRemovalBound, hε₁]
+  simp [triangleRemovalBound, inf_of_le_right hε₁]
 
 private lemma aux {n k : ℕ} (hk : 0 < k) (hn : k ≤ n) : n < 2 * k * (n / k) := by
   rw [mul_assoc, two_mul, ← add_lt_add_iff_right (n % k), add_right_comm, add_assoc,

--- a/Mathlib/Data/EReal/Inv.lean
+++ b/Mathlib/Data/EReal/Inv.lean
@@ -189,10 +189,10 @@ lemma exists_nat_ge_mul {a : EReal} (ha : a ≠ ⊤) (n : ℕ) :
 /-! ### Min and Max -/
 
 lemma min_neg_neg (x y : EReal) : min (-x) (-y) = -max x y := by
-  rcases le_total x y with (h | h) <;> simp_all
+  grind [neg_le_neg_iff]
 
 lemma max_neg_neg (x y : EReal) : max (-x) (-y) = -min x y := by
-  rcases le_total x y with (h | h) <;> simp_all
+  grind [neg_le_neg_iff]
 
 /-! ### Inverse -/
 

--- a/Mathlib/Data/NNRat/Defs.lean
+++ b/Mathlib/Data/NNRat/Defs.lean
@@ -247,15 +247,17 @@ namespace Rat
 
 variable {p q : ℚ}
 
+theorem coe_toNNRat' (q : ℚ) : (q.toNNRat : ℚ) = max q 0 :=
+  rfl
+
 @[simp]
 theorem toNNRat_zero : toNNRat 0 = 0 := rfl
 
 @[simp]
 theorem toNNRat_one : toNNRat 1 = 1 := rfl
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem toNNRat_pos : 0 < toNNRat q ↔ 0 < q := by simp [toNNRat, ← coe_lt_coe]
+theorem toNNRat_pos : 0 < toNNRat q ↔ 0 < q := by simp [coe_toNNRat', ← coe_lt_coe]
 
 @[simp]
 theorem toNNRat_eq_zero : toNNRat q = 0 ↔ q ≤ 0 := by
@@ -263,15 +265,13 @@ theorem toNNRat_eq_zero : toNNRat q = 0 ↔ q ≤ 0 := by
 
 alias ⟨_, toNNRat_of_nonpos⟩ := toNNRat_eq_zero
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem toNNRat_le_toNNRat_iff (hp : 0 ≤ p) : toNNRat q ≤ toNNRat p ↔ q ≤ p := by
-  simp [← coe_le_coe, toNNRat, hp]
+  grind [← coe_le_coe, coe_toNNRat']
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem toNNRat_lt_toNNRat_iff' : toNNRat q < toNNRat p ↔ q < p ∧ 0 < p := by
-  simp [← coe_lt_coe, toNNRat]
+  simp [← coe_lt_coe, coe_toNNRat']
 
 theorem toNNRat_lt_toNNRat_iff (h : 0 < p) : toNNRat q < toNNRat p ↔ q < p :=
   toNNRat_lt_toNNRat_iff'.trans (and_iff_left h)
@@ -279,10 +279,9 @@ theorem toNNRat_lt_toNNRat_iff (h : 0 < p) : toNNRat q < toNNRat p ↔ q < p :=
 theorem toNNRat_lt_toNNRat_iff_of_nonneg (hq : 0 ≤ q) : toNNRat q < toNNRat p ↔ q < p :=
   toNNRat_lt_toNNRat_iff'.trans ⟨And.left, fun h ↦ ⟨h, hq.trans_lt h⟩⟩
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem toNNRat_add (hq : 0 ≤ q) (hp : 0 ≤ p) : toNNRat (q + p) = toNNRat q + toNNRat p :=
-  NNRat.ext <| by simp [toNNRat, hq, hp, add_nonneg]
+theorem toNNRat_add (hq : 0 ≤ q) (hp : 0 ≤ p) : toNNRat (q + p) = toNNRat q + toNNRat p := by
+  ext; push_cast; simp [coe_toNNRat, hq, hp, add_nonneg]
 
 theorem toNNRat_add_le : toNNRat (q + p) ≤ toNNRat q + toNNRat p :=
   coe_le_coe.1 <| max_le (add_le_add (le_max_left _ _) (le_max_left _ _)) <| coe_nonneg _
@@ -303,10 +302,9 @@ theorem toNNRat_lt_iff_lt_coe {p : ℚ≥0} (hq : 0 ≤ q) : toNNRat q < p ↔ q
 theorem lt_toNNRat_iff_coe_lt {q : ℚ≥0} : q < toNNRat p ↔ ↑q < p :=
   NNRat.gi.gc.lt_iff_lt
 
-set_option backward.isDefEq.respectTransparency false in
 theorem toNNRat_mul (hp : 0 ≤ p) : toNNRat (p * q) = toNNRat p * toNNRat q := by
   rcases le_total 0 q with hq | hq
-  · ext; simp [toNNRat, hp, hq, mul_nonneg]
+  · ext; simp [Rat.coe_toNNRat, hp, hq, mul_nonneg]
   · have hpq := mul_nonpos_of_nonneg_of_nonpos hp hq
     rw [toNNRat_eq_zero.2 hq, toNNRat_eq_zero.2 hpq, mul_zero]
 

--- a/Mathlib/Data/NNRat/Defs.lean
+++ b/Mathlib/Data/NNRat/Defs.lean
@@ -110,6 +110,7 @@ lemma «exists» {p : ℚ≥0 → Prop} : (∃ q, p q) ↔ ∃ q hq, p ⟨q, hq�
 def _root_.Rat.toNNRat (q : ℚ) : ℚ≥0 :=
   ⟨max q 0, le_max_right _ _⟩
 
+@[simp]
 theorem _root_.Rat.coe_toNNRat (q : ℚ) (hq : 0 ≤ q) : (q.toNNRat : ℚ) = q :=
   max_eq_left hq
 
@@ -265,7 +266,6 @@ theorem toNNRat_eq_zero : toNNRat q = 0 ↔ q ≤ 0 := by
 
 alias ⟨_, toNNRat_of_nonpos⟩ := toNNRat_eq_zero
 
-@[simp]
 theorem toNNRat_le_toNNRat_iff (hp : 0 ≤ p) : toNNRat q ≤ toNNRat p ↔ q ≤ p := by
   grind [← coe_le_coe, coe_toNNRat']
 
@@ -286,6 +286,7 @@ theorem toNNRat_add (hq : 0 ≤ q) (hp : 0 ≤ p) : toNNRat (q + p) = toNNRat q 
 theorem toNNRat_add_le : toNNRat (q + p) ≤ toNNRat q + toNNRat p :=
   coe_le_coe.1 <| max_le (add_le_add (le_max_left _ _) (le_max_left _ _)) <| coe_nonneg _
 
+@[simp]
 theorem toNNRat_le_iff_le_coe {p : ℚ≥0} : toNNRat q ≤ p ↔ q ≤ ↑p :=
   NNRat.gi.gc q p
 

--- a/Mathlib/Data/Sym/Sym2/Order.lean
+++ b/Mathlib/Data/Sym/Sym2/Order.lean
@@ -52,7 +52,7 @@ theorem inf_eq_inf_and_sup_eq_sup [LinearOrder α] {s t : Sym2 α} :
     s.inf = t.inf ∧ s.sup = t.sup ↔ s = t := by
   induction s with | _ a b
   induction t with | _ c d
-  obtain hab | hba := le_total a b <;> obtain hcd | hdc := le_total c d <;>
-    aesop (add unsafe le_antisymm)
+  simp
+  grind
 
 end Sym2

--- a/Mathlib/FieldTheory/Cardinality.lean
+++ b/Mathlib/FieldTheory/Cardinality.lean
@@ -58,7 +58,7 @@ theorem Fintype.not_isField_of_card_not_prime_pow {α} [Fintype α] [Ring α] :
 theorem Infinite.nonempty_field {α : Type u} [Infinite α] : Nonempty (Field α) := by
   suffices #α = #(FractionRing (MvPolynomial α <| ULift.{u} ℚ)) from
     (Cardinal.eq.1 this).map (·.field)
-  simp
+  simp [sup_of_le_right]
 
 /-- There is a field structure on type if and only if its cardinality is a prime power. -/
 theorem Field.nonempty_iff {α : Type u} : Nonempty (Field α) ↔ IsPrimePow #α := by

--- a/Mathlib/Geometry/Manifold/Instances/Icc.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Icc.lean
@@ -92,7 +92,7 @@ lemma isImmersionOfComplement_subtypeVal_Icc :
     replace hu : ofLp u.val 0 ≤ y - x := by
       apply le_of_lt
       simpa [modelWithCornersEuclideanHalfSpace_symm_apply, max_eq_left u.property] using! hu
-    simp [hz, φ, φ₀, modelWithCornersEuclideanHalfSpace_symm_apply, u.property,
+    simp [hz, φ, φ₀, modelWithCornersEuclideanHalfSpace_symm_apply, max_eq_left u.property,
       IccLeftChart_symm_apply_of_le hu]
   · -- At the right boundary point, the correct codomain chart is mapping `a` to `y - a`.
     apply IsImmersionAtOfComplement.mk_of_continuousAt (by fun_prop) φ
@@ -111,7 +111,7 @@ lemma isImmersionOfComplement_subtypeVal_Icc :
     replace hu : ofLp u.val 0 ≤ y - x := by
       apply le_of_lt
       simpa [modelWithCornersEuclideanHalfSpace_symm_apply, max_eq_left u.property] using! hu
-    simp [hz, φ, φ₀, modelWithCornersEuclideanHalfSpace_symm_apply, u.property,
+    simp [hz, φ, φ₀, modelWithCornersEuclideanHalfSpace_symm_apply, max_eq_left u.property,
       IccRightChart_symm_apply_of_le hu, Equiv.pointReflection_apply]
     linarith
 

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -255,7 +255,7 @@ lemma modelWithCornersEuclideanHalfSpace_symm_apply {n : ℕ} [NeZero n]
 lemma modelWithCornersEuclideanHalfSpace_symm_apply_of_le {n : ℕ} [NeZero n]
     {x : EuclideanSpace ℝ (Fin n)} (hx : 0 ≤ x 0) :
     (𝓡∂ n).symm x = ⟨x, hx⟩ := by
-  simp [modelWithCornersEuclideanHalfSpace_symm_apply, hx]
+  simp [modelWithCornersEuclideanHalfSpace_symm_apply, sup_of_le_left hx]
 
 lemma modelWithCornersEuclideanHalfSpace_zero {n : ℕ} [NeZero n] : (𝓡∂ n) 0 = 0 := rfl
 
@@ -289,7 +289,7 @@ lemma modelWithCornersEuclideanQuadrant_symm_apply {n : ℕ} (x : EuclideanSpace
 lemma modelWithCornersEuclideanQuadrant_symm_apply_of_le {n : ℕ}
     {x : EuclideanSpace ℝ (Fin n)} (hx : ∀ i, 0 ≤ x i) :
     (modelWithCornersEuclideanQuadrant n).symm x = ⟨x, hx⟩ := by
-  simp [modelWithCornersEuclideanQuadrant_symm_apply, hx]
+  simp [modelWithCornersEuclideanQuadrant_symm_apply, sup_of_le_left (hx _)]
 
 /-- The left chart for the topological space `[x, y]`, defined on `[x,y)` and sending `x` to `0` in
 `EuclideanHalfSpace 1`.

--- a/Mathlib/GroupTheory/Commutator/Basic.lean
+++ b/Mathlib/GroupTheory/Commutator/Basic.lean
@@ -360,11 +360,11 @@ theorem commutator_sup_right (H K N : Subgroup G) [N.Normal] : ⁅H ⊔ K, N⁆ 
   have hHNM : ⁅H, N⁆ ≤ M := commutator_le_of_le hHM hNM
   have hKNM : ⁅K, N⁆ ≤ M := commutator_le_of_le hKM hNM
   suffices (⁅H.subgroupOf M, N.subgroupOf M⁆ ⊔ ⁅K.subgroupOf M, N.subgroupOf M⁆).Normal by
-    simpa [← map_subtype_inj, map_sup, map_commutator, hHM, hKM, hNM] using
+    simpa [← map_subtype_inj, map_sup, map_commutator, inf_of_le_left, hHM, hKM, hNM] using
       commutator_sup_right_of_normal (H.subgroupOf M) (K.subgroupOf M) (N.subgroupOf M)
   suffices M ≤ normalizer (⁅H, N⁆ ⊔ ⁅K, N⁆ : Subgroup G) by
     convert Subgroup.normal_subgroupOf_of_le_normalizer this
-    simp [← map_subtype_inj, map_sup, map_commutator, hHM, hKM, hNM, hHNM, hKNM]
+    simp [← map_subtype_inj, map_sup, map_commutator, inf_of_le_left, hHM, hKM, hNM, hHNM, hKNM]
   have hHKN : ⁅H, N⁆ ⊔ ⁅K, N⁆ ≤ N := sup_le (commutator_le_right H N) (commutator_le_right K N)
   refine sup_le (sup_le ?_ ?_) ?_
   · grw [le_normalizer_iff_commutator_le_right, hHKN, ← le_sup_left]

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -104,7 +104,7 @@ theorem LinearMap.lift_rank_comap_le {f : M →ₗ[R] M'} (p : Submodule R M') :
     exact rank_mono fun x hx ↦ by aesop (add simp Subtype.ext_iff)
   have hr : Module.rank R f'.range ≤ Module.rank R p := by grw [Submodule.rank_le f'.range]
   rw [← f'.lift_rank_range_add_rank_ker]
-  gcongr <;> rwa [lift_le]
+  grw [hr, hk]
 
 omit [HasRankNullity.{u} R] in
 lemma LinearMap.rank_quot_submodule_map_eq [HasRankNullity.{v} R]

--- a/Mathlib/MeasureTheory/Function/ConvergenceInDistribution.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInDistribution.lean
@@ -325,7 +325,7 @@ theorem TendstoInDistribution.prodMk_of_tendstoInMeasure_const
   · suffices TendstoInMeasure μ'' (fun n ω ↦ ((0 : E), Y n ω - c)) l 0 by
       convert! this with n ω
       simp
-    simpa [tendstoInMeasure_iff_norm] using hY
+    simpa [max_eq_right, tendstoInMeasure_iff_norm] using hY
 
 /-- **Slutsky's theorem** for a continuous function: if `X n` converges in distribution to `Z`,
 `Y n` converges in probability to a constant `c`, and `g` is a continuous function, then

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -744,7 +744,7 @@ theorem Integrable.real_toNNReal {f : α → ℝ} (hf : Integrable f μ) :
   refine lt_of_le_of_lt ?_ ((hasFiniteIntegral_iff_norm _).1 hf.hasFiniteIntegral)
   apply lintegral_mono
   intro x
-  simp [abs_le, le_abs_self]
+  simp [Real.coe_toNNReal', abs_le, le_abs_self]
 
 theorem ofReal_toReal_ae_eq {f : α → ℝ≥0∞} (hf : ∀ᵐ x ∂μ, f x < ∞) :
     (fun x => ENNReal.ofReal (f x).toReal) =ᵐ[μ] f := by

--- a/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
@@ -561,7 +561,7 @@ theorem tendsto_integral_norm_approxOn_sub
 theorem integral_eq_integral_pos_part_sub_integral_neg_part {f : α → ℝ} (hf : Integrable f μ) :
     ∫ a, f a ∂μ = ∫ a, (Real.toNNReal (f a) : ℝ) ∂μ - ∫ a, (Real.toNNReal (-f a) : ℝ) ∂μ := by
   rw [← integral_sub hf.real_toNNReal]
-  · simp
+  · simp [Real.coe_toNNReal']
   · exact hf.neg.real_toNNReal
 
 theorem integral_abs_eq_two_mul_integral_posPart_sub_integral {f : α → ℝ} (hf : Integrable f μ) :

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -463,7 +463,7 @@ theorem continuousOn_primitive_interval' (h_int : IntervalIntegrable f μ b₁ b
     (ha : a ∈ [[b₁, b₂]]) : ContinuousOn (fun b => ∫ x in a..b, f x ∂μ) [[b₁, b₂]] := fun _ _ ↦ by
   refine continuousWithinAt_primitive (measure_singleton _) ?_
   rw [min_eq_right ha.1, max_eq_right ha.2]
-  simpa [intervalIntegrable_iff, uIoc] using h_int
+  grind [intervalIntegrable_iff, uIoc]
 
 theorem continuousOn_primitive_interval (h_int : IntegrableOn f (uIcc a b) μ) :
     ContinuousOn (fun x => ∫ t in a..x, f t ∂μ) (uIcc a b) :=
@@ -648,9 +648,10 @@ theorem continuousOn_Ici_primitive_Ioi [NullSingletonClass μ] {a₀ : ℝ}
       intro b hb
       simp [← integral_Ioi_sub_Ioi hf hb.1]
     have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a₀..b, f x ∂μ) (Icc a₀ a) a :=
-      continuousWithinAt_primitive (measure_singleton a) (by simpa [ha])
+      continuousWithinAt_primitive (measure_singleton a) (by simpa [max_eq_right ha])
     exact (continuousWithinAt_const.sub h_cwa).congr h_split (h_split a (right_mem_Icc.2 ha))
-  · simpa [ha] using (hf.mono_set (Ioi_subset_Ioi ha)).continuousWithinAt_Ici_primitive_Ioi
+  · simpa [max_eq_right ha]
+      using (hf.mono_set (Ioi_subset_Ioi ha)).continuousWithinAt_Ici_primitive_Ioi
 
 theorem continuousWithinAt_Iic_primitive_Iio {a₀ : ℝ} (hf : IntegrableOn f (Iio a₀) μ) :
     ContinuousWithinAt (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic a₀) a₀ := by
@@ -675,7 +676,8 @@ theorem continuousOn_Iic_primitive_Iio [NullSingletonClass μ] {a₀ : ℝ}
   intro a (ha : a ≤ a₀)
   rw [continuousWithinAt_iff_continuous_left_right]
   constructor
-  · simpa [ha] using (hf.mono_set (Iio_subset_Iio ha)).continuousWithinAt_Iic_primitive_Iio
+  · simpa [min_eq_right ha]
+      using (hf.mono_set (Iio_subset_Iio ha)).continuousWithinAt_Iic_primitive_Iio
   · rw [Iic_inter_Ici]
     have h_int : IntervalIntegrable f μ a a₀ :=
       (intervalIntegrable_iff_integrableOn_Ico_of_le ha).2 <| hf.mono_set Ico_subset_Iio_self
@@ -684,7 +686,7 @@ theorem continuousOn_Iic_primitive_Iio [NullSingletonClass μ] {a₀ : ℝ}
       intro b hb
       simp [integral_symm b a₀, ← integral_Iio_sub_Iio' hf (hf.mono_set (Iio_subset_Iio hb.2))]
     have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a₀..b, f x ∂μ) (Icc a a₀) a :=
-      continuousWithinAt_primitive (measure_singleton a) (by simpa [ha])
+      continuousWithinAt_primitive (measure_singleton a) (by simpa [min_eq_right ha])
     exact (continuousWithinAt_const.add h_cwa).congr h_split (h_split a (left_mem_Icc.2 ha))
 
 theorem continuousOn_Ici_primitive_Ici [NullSingletonClass μ] {a₀ : ℝ}

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -727,7 +727,8 @@ theorem integral_non_aestronglyMeasurable_of_le (h : a ≤ b)
 
 theorem norm_integral_min_max (f : ℝ → E) :
     ‖∫ x in min a b..max a b, f x ∂μ‖ = ‖∫ x in a..b, f x ∂μ‖ := by
-  cases le_total a b <;> simp [*, integral_symm a b]
+  cases le_total a b <;>
+    simp [min_eq_left, min_eq_right, max_eq_left, max_eq_right, *, integral_symm b a]
 
 theorem norm_integral_eq_norm_integral_uIoc (f : ℝ → E) :
     ‖∫ x in a..b, f x ∂μ‖ = ‖∫ x in Ι a b, f x ∂μ‖ := by
@@ -1078,9 +1079,9 @@ variable {a b c d : ℝ} {f g : ℝ → E} {μ : Measure ℝ}
 /-- If two functions are equal in the relevant interval, their interval integrals are also equal. -/
 theorem integral_congr {a b : ℝ} (h : EqOn f g [[a, b]]) :
     ∫ x in a..b, f x ∂μ = ∫ x in a..b, g x ∂μ := by
-  rcases le_total a b with hab | hab <;>
-    simpa [hab, integral_of_le, integral_of_ge] using
-      setIntegral_congr_fun measurableSet_Ioc (h.mono Ioc_subset_Icc_self)
+  rcases le_total a b with hab | hab
+    <;> simp only [integral_of_le hab, integral_of_ge hab, neg_inj]
+    <;> exact setIntegral_congr_fun measurableSet_Ioc (h.mono (by grind [uIcc]))
 
 theorem integral_add_adjacent_intervals_cancel (hab : IntervalIntegrable f μ a b)
     (hbc : IntervalIntegrable f μ b c) :

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/DerivIntegrable.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/DerivIntegrable.lean
@@ -79,7 +79,7 @@ lemma MonotoneOn.exists_tendsto_deriv_liminf_lintegral_enorm_le
         rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le hab]
         convert!
           hg.monotoneOn (Icc a (b + (n : ℝ)⁻¹)) |>.intervalIntegral_slope_le hab (by simp) using 2
-        simp [g]
+        simp [g, min_eq_right]
       _ = ENNReal.ofReal (f b - f a) := by grind
 
 /-- If `f` is monotone on `a..b`, then `f'` is interval integrable on `a..b`. -/

--- a/Mathlib/MeasureTheory/Measure/LevyProkhorovMetric.lean
+++ b/Mathlib/MeasureTheory/Measure/LevyProkhorovMetric.lean
@@ -410,7 +410,7 @@ lemma BoundedContinuousFunction.integral_le_of_levyProkhorovEDist_lt (μ ν : Me
       exact ENNReal.toReal_mono (by finiteness) <| measure_mono (subset_univ _)
   apply le_trans (setIntegral_mono (s := Ioc 0 ‖f‖) ?_ ?_ key)
   · rw [integral_add]
-    · simp [(mul_comm _ ε).le]
+    · simp [max_eq_left, (mul_comm _ ε).le]
     · exact intble₂
     · exact integrable_const ε
   · exact intble₁

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -121,7 +121,7 @@ lemma mulHeight₁_eq (x : K) :
 
 @[simp]
 lemma mulHeight₁_zero : mulHeight₁ (0 : K) = 1 := by
-  simp [mulHeight₁_eq]
+  simp [mulHeight₁_eq, sup_of_le_right]
 
 @[simp]
 lemma mulHeight₁_one : mulHeight₁ (1 : K) = 1 := by
@@ -329,7 +329,7 @@ private lemma hasFiniteMulSupport_iSup_nonarchAbsVal {x : ι → K} (hx : x ≠ 
 private lemma hasFiniteMulSupport_max_nonarchAbsVal (x : K) :
     (fun v : nonarchAbsVal ↦ v.val x ⊔ 1).HasFiniteMulSupport := by
   rcases eq_or_ne x 0 with rfl | hx
-  · simp [HasFiniteMulSupport]
+  · simp [HasFiniteMulSupport, sup_of_le_right]
   fun_prop
 
 /-- The multiplicative height of a tuple does not change under scaling. -/

--- a/Mathlib/NumberTheory/Height/MvPolynomial.lean
+++ b/Mathlib/NumberTheory/Height/MvPolynomial.lean
@@ -260,7 +260,7 @@ private lemma hasFiniteMulSupport_iSup_max_iSup_one (h : Nonempty ι') (p : ι' 
       ⨆ j, max (⨆ s : (p j).support, v.val ((p j).coeff s.val)) 1).HasFiniteMulSupport := by
   refine HasFiniteMulSupport.iSup fun j ↦ ?_
   rcases isEmpty_or_nonempty (p j).support with hs₀ | hs₀
-  · simp [hasFiniteMulSupport_one]
+  · simp [sup_of_le_right, hasFiniteMulSupport_one]
   have H (s : (p j).support) : (p j).coeff s.val ≠ 0 := mem_support_iff.mp s.prop
   fun_prop (disch := simp [H])
 

--- a/Mathlib/Order/BooleanAlgebra/Basic.lean
+++ b/Mathlib/Order/BooleanAlgebra/Basic.lean
@@ -256,7 +256,7 @@ theorem sdiff_sdiff_right : x \ (y \ z) = x \ y ⊔ x ⊓ y ⊓ z := by
           rw [sup_inf_self, sup_sdiff_left, ← sup_assoc, sup_inf_left, sdiff_sup_self',
             inf_sup_right, sup_comm y, inf_sdiff_sup_right, inf_sup_left x z y]
       _ = x ⊓ (y \ z ⊔ (x ⊓ z ⊔ (x ⊓ y ⊔ x \ y))) := by ac_rfl
-      _ = x := by simp
+      _ = x := by grw [sup_inf_sdiff, inf_eq_left, ← le_sup_right, ← le_sup_right]
   · calc
       x ⊓ y \ z ⊓ (z ⊓ x ⊔ x \ y) = x ⊓ y \ z ⊓ (z ⊓ x) ⊔ x ⊓ y \ z ⊓ x \ y := by rw [inf_sup_left]
       _ = x ⊓ (y \ z ⊓ z ⊓ x) ⊔ x ⊓ y \ z ⊓ x \ y := by ac_rfl
@@ -365,7 +365,7 @@ theorem sup_eq_sdiff_sup_sdiff_sup_inf : x ⊔ y = x \ y ⊔ y \ x ⊔ x ⊓ y :
     calc
       x \ y ⊔ y \ x ⊔ x ⊓ y = (x \ y ⊔ y \ x ⊔ x) ⊓ (x \ y ⊔ y \ x ⊔ y) := by rw [sup_inf_left]
       _ = (x \ y ⊔ x ⊔ y \ x) ⊓ (x \ y ⊔ (y \ x ⊔ y)) := by ac_rfl
-      _ = x ⊔ y := by simp
+      _ = x ⊔ y := by simp [sup_sdiff_right]
 
 theorem sup_lt_of_lt_sdiff_left (h : y < z \ x) (hxz : x ≤ z) : x ⊔ y < z := by
   rw [← sup_sdiff_cancel_right hxz]

--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -32,8 +32,8 @@ section SemilatticeSupTop
 
 variable [SemilatticeSup α] [OrderTop α]
 
-@[to_dual] theorem top_sup_eq (a : α) : ⊤ ⊔ a = ⊤ := sup_of_le_left le_top
-@[to_dual] theorem sup_top_eq (a : α) : a ⊔ ⊤ = ⊤ := sup_of_le_right le_top
+@[to_dual (attr := simp)] theorem top_sup_eq (a : α) : ⊤ ⊔ a = ⊤ := sup_of_le_left le_top
+@[to_dual (attr := simp)] theorem sup_top_eq (a : α) : a ⊔ ⊤ = ⊤ := sup_of_le_right le_top
 
 end SemilatticeSupTop
 
@@ -41,8 +41,8 @@ section SemilatticeSupBot
 
 variable [SemilatticeSup α] [OrderBot α] {a b : α}
 
-@[to_dual] theorem bot_sup_eq (a : α) : ⊥ ⊔ a = a := sup_of_le_right bot_le
-@[to_dual] theorem sup_bot_eq (a : α) : a ⊔ ⊥ = a := sup_of_le_left bot_le
+@[to_dual (attr := simp)] theorem bot_sup_eq (a : α) : ⊥ ⊔ a = a := sup_of_le_right bot_le
+@[to_dual (attr := simp)] theorem sup_bot_eq (a : α) : a ⊔ ⊥ = a := sup_of_le_left bot_le
 
 @[to_dual (attr := simp, grind =)]
 theorem sup_eq_bot_iff : a ⊔ b = ⊥ ↔ a = ⊥ ∧ b = ⊥ := by rw [eq_bot_iff, sup_le_iff]; simp

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -409,7 +409,7 @@ then `min a b` is the least element of `s ∪ t`. -/
 then `max a b` is the greatest element of `s ∪ t`. -/]
 theorem IsLeast.union [LinearOrder γ] {a b : γ} {s t : Set γ} (ha : IsLeast s a)
     (hb : IsLeast t b) : IsLeast (s ∪ t) (min a b) :=
-  ⟨by rcases le_total a b with h | h <;> simp [h, ha.1, hb.1], (ha.isGLB.union hb.isGLB).1⟩
+  ⟨by rcases le_total a b with h | h <;> grind [ha.1, hb.1], (ha.isGLB.union hb.isGLB).1⟩
 
 @[to_dual]
 theorem IsLUB.inter_Ici_of_mem [LinearOrder γ] {s : Set γ} {a b : γ} (ha : IsLUB s a) (hb : b ∈ s) :

--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -88,7 +88,7 @@ variable {ι : Type*} {f : Filter ι} {u : ι → ℝ≥0}
     NNReal.exists]
   constructor
   · rintro ⟨b, hb⟩
-    exact ⟨b.toNNReal, by simp, fun x _ ↦ by simpa [*] using hb _⟩
+    exact ⟨b.toNNReal, by simp, fun x _ ↦ by simpa [Real.coe_toNNReal', *] using hb _⟩
   · rintro ⟨b, hb₀, hb⟩
     exact ⟨b, fun x hx ↦ hb _ (hx.exists.choose_spec.trans' (by simp)) hx⟩
 

--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -69,7 +69,7 @@ variable {ι : Type*} {f : Filter ι} {u : ι → ℝ≥0}
   simp only [IsBoundedUnder, IsBounded, eventually_map, ← coe_le_coe, NNReal.exists, coe_mk]
   constructor
   · rintro ⟨b, hb⟩
-    exact ⟨b.toNNReal, by simp, by filter_upwards [hb]; simp +contextual⟩
+    exact ⟨b.toNNReal, by simp, by grw [← Real.le_coe_toNNReal]; exact hb⟩
   · rintro ⟨b, -, hb⟩
     exact ⟨b, hb⟩
 
@@ -78,7 +78,7 @@ variable {ι : Type*} {f : Filter ι} {u : ι → ℝ≥0}
   simp only [IsBoundedUnder, IsBounded, eventually_map, ← coe_le_coe, NNReal.exists, coe_mk]
   constructor
   · rintro ⟨b, hb⟩
-    exact ⟨b.toNNReal, by simp, by simpa⟩
+    exact ⟨b.toNNReal, by simp, by simpa [Real.toNNReal_le_iff_le_coe]⟩
   · rintro ⟨b, -, hb⟩
     exact ⟨b, hb⟩
 

--- a/Mathlib/Order/Heyting/Basic.lean
+++ b/Mathlib/Order/Heyting/Basic.lean
@@ -330,7 +330,7 @@ theorem le_himp_himp : a ≤ (a ⇨ b) ⇨ b :=
   le_himp_iff.2 inf_himp_le
 
 @[to_dual (attr := simp)]
-lemma himp_eq_himp_iff : b ⇨ a = a ⇨ b ↔ a = b := by simp [le_antisymm_iff]
+lemma himp_eq_himp_iff : b ⇨ a = a ⇨ b ↔ a = b := by simp [le_antisymm_iff, inf_of_le_right]
 
 @[to_dual]
 lemma himp_ne_himp_iff : b ⇨ a ≠ a ⇨ b ↔ a ≠ b := himp_eq_himp_iff.not

--- a/Mathlib/Order/Interval/Set/ProjIcc.lean
+++ b/Mathlib/Order/Interval/Set/ProjIcc.lean
@@ -64,10 +64,10 @@ theorem projIci_of_le (hx : x ≤ a) : projIci a x = ⟨a, le_rfl⟩ := Subtype.
 theorem projIic_of_le (hx : b ≤ x) : projIic b x = ⟨b, le_rfl⟩ := Subtype.ext <| min_eq_left hx
 
 theorem projIcc_of_le_left (hx : x ≤ a) : projIcc a b h x = ⟨a, left_mem_Icc.2 h⟩ := by
-  simp [projIcc, hx, hx.trans h]
+  grind [projIcc]
 
 theorem projIcc_of_right_le (hx : b ≤ x) : projIcc a b h x = ⟨b, right_mem_Icc.2 h⟩ := by
-  simp [projIcc, hx, h]
+  grind [projIcc]
 
 @[simp]
 theorem projIci_self (a : α) : projIci a a = ⟨a, le_rfl⟩ := projIci_of_le le_rfl
@@ -91,7 +91,7 @@ theorem projIcc_eq_left (h : a < b) : projIcc a b h.le x = ⟨a, left_mem_Icc.mp
   simp [projIcc, Subtype.ext_iff, h.not_ge]
 
 theorem projIcc_eq_right (h : a < b) : projIcc a b h.le x = ⟨b, right_mem_Icc.2 h.le⟩ ↔ b ≤ x := by
-  simp [projIcc, Subtype.ext_iff, max_min_distrib_left, h.le, h.not_ge]
+  grind [projIcc]
 
 set_option backward.isDefEq.respectTransparency false in
 theorem projIci_of_mem (hx : x ∈ Ici a) : projIci a x = ⟨x, hx⟩ := by simpa [projIci]
@@ -100,7 +100,7 @@ set_option backward.isDefEq.respectTransparency false in
 theorem projIic_of_mem (hx : x ∈ Iic b) : projIic b x = ⟨x, hx⟩ := by simpa [projIic]
 
 theorem projIcc_of_mem (hx : x ∈ Icc a b) : projIcc a b h x = ⟨x, hx⟩ := by
-  simp [projIcc, hx.1, hx.2]
+  grind [projIcc]
 
 @[simp]
 theorem projIci_coe (x : Ici a) : projIci a x = x := by cases x; apply projIci_of_mem

--- a/Mathlib/Order/Interval/Set/UnorderedInterval.lean
+++ b/Mathlib/Order/Interval/Set/UnorderedInterval.lean
@@ -249,11 +249,11 @@ scoped[Interval] notation "Ι" => Set.uIoc
 
 open scoped Interval
 
-@[simp, grind =] lemma uIoc_of_le (h : a ≤ b) : Ι a b = Ioc a b := by simp [uIoc, h]
-@[simp, grind =] lemma uIoc_of_ge (h : b ≤ a) : Ι a b = Ioc b a := by simp [uIoc, h]
+@[simp, grind =] lemma uIoc_of_le (h : a ≤ b) : Ι a b = Ioc a b := by grind [uIoc]
+@[simp, grind =] lemma uIoc_of_ge (h : b ≤ a) : Ι a b = Ioc b a := by grind [uIoc]
 
 lemma uIoc_eq_union : Ι a b = Ioc a b ∪ Ioc b a := by
-  cases le_total a b <;> simp [uIoc, *]
+  grind [uIoc]
 
 lemma mem_uIoc : a ∈ Ι b c ↔ b < a ∧ a ≤ c ∨ c < a ∧ a ≤ b := by
   rw [uIoc_eq_union, mem_union, mem_Ioc, mem_Ioc]

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -191,7 +191,7 @@ alias ⟨le_of_sup_eq', sup_of_le_left⟩ := sup_eq_left
 
 alias ⟨le_of_sup_eq, sup_of_le_right⟩ := sup_eq_right
 
-attribute [to_dual (attr := simp)] sup_of_le_left sup_of_le_right
+attribute [to_dual] sup_of_le_left sup_of_le_right
 attribute [to_dual le_of_inf_eq'] le_of_sup_eq
 attribute [to_dual le_of_inf_eq] le_of_sup_eq'
 
@@ -230,7 +230,7 @@ theorem sup_le_sup_left (h₁ : a ≤ b) (c) : c ⊔ a ≤ c ⊔ b :=
 theorem sup_le_sup_right (h₁ : a ≤ b) (c) : a ⊔ c ≤ b ⊔ c :=
   sup_le_sup h₁ le_rfl
 
-@[to_dual]
+@[to_dual (attr := simp)]
 theorem sup_idem (a : α) : a ⊔ a = a := by simp
 
 @[to_dual]
@@ -253,10 +253,10 @@ instance : Std.Associative (α := α) (· ⊔ ·) := ⟨sup_assoc⟩
 theorem sup_left_right_swap (a b c : α) : a ⊔ b ⊔ c = c ⊔ b ⊔ a := by
   rw [sup_comm, sup_comm a, sup_assoc]
 
-@[to_dual]
+@[to_dual (attr := simp)]
 theorem sup_left_idem (a b : α) : a ⊔ (a ⊔ b) = a ⊔ b := by simp
 
-@[to_dual]
+@[to_dual (attr := simp)]
 theorem sup_right_idem (a b : α) : a ⊔ b ⊔ b = a ⊔ b := by simp
 
 @[to_dual]

--- a/Mathlib/Order/Lattice/Congruence.lean
+++ b/Mathlib/Order/Lattice/Congruence.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Data.Setoid.Basic
 public import Mathlib.Order.Lattice
 public import Mathlib.Order.Hom.Lattice
+public import Mathlib.Tactic.Order
 
 /-!
 # Lattice Congruences
@@ -43,6 +44,8 @@ structure LatticeCon extends Setoid α where
   sup : ∀ {w x y z}, r w x → r y z → r (w ⊔ y) (x ⊔ z)
 
 namespace LatticeCon
+
+attribute [local simp] sup_of_le_left sup_of_le_right inf_of_le_left inf_of_le_right
 
 @[simp]
 lemma r_inf_sup_iff (c : LatticeCon α) {x y : α} : c.r (x ⊓ y) (x ⊔ y) ↔ c.r x y where

--- a/Mathlib/Order/Lattice/Congruence.lean
+++ b/Mathlib/Order/Lattice/Congruence.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Data.Setoid.Basic
 public import Mathlib.Order.Lattice
 public import Mathlib.Order.Hom.Lattice
-public import Mathlib.Tactic.Order
 
 /-!
 # Lattice Congruences

--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -132,11 +132,11 @@ theorem AntitoneOn.map_max (hf : AntitoneOn f s) (ha : a ∈ s) (hb : b ∈ s) :
 
 @[to_dual]
 theorem Monotone.map_max (hf : Monotone f) : f (max a b) = max (f a) (f b) := by
-  rcases le_total a b with h | h <;> simp [h, hf h]
+  rcases le_total a b with h | h <;> grind [hf h]
 
 @[to_dual]
 theorem Antitone.map_max (hf : Antitone f) : f (max a b) = min (f a) (f b) := by
-  rcases le_total a b with h | h <;> simp [h, hf h]
+  rcases le_total a b with h | h <;> grind [hf h]
 
 @[to_dual]
 theorem min_choice (a b : α) : min a b = a ∨ min a b = b := by cases le_total a b <;> simp [*]

--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -115,9 +115,9 @@ lemma SupClosed.insert_upperBounds {s : Set α} {a : α} (hs : SupClosed s) (ha 
 @[to_dual]
 lemma SupClosed.insert_lowerBounds {s : Set α} {a : α} (h : SupClosed s) (ha : a ∈ lowerBounds s) :
     SupClosed (insert a s) := by
-  rw [SupClosed]
-  have ha' : ∀ b ∈ s, a ≤ b := fun _ a ↦ ha a
-  aesop
+  unfold SupClosed at h ⊢
+  rw [mem_lowerBounds] at ha
+  simp +contextual [h, ha, sup_of_le_left, sup_of_le_right]
 
 end Set
 
@@ -211,7 +211,7 @@ section LinearOrder
 variable [LinearOrder α]
 
 @[to_dual (attr := simp)] protected lemma LinearOrder.supClosed (s : Set α) : SupClosed s :=
-  fun a ha b hb ↦ by cases le_total a b <;> simp [*]
+  fun a ha b hb ↦ by grind
 
 @[simp] protected lemma LinearOrder.isSublattice (s : Set α) : IsSublattice s :=
   ⟨LinearOrder.supClosed _, LinearOrder.infClosed _⟩

--- a/Mathlib/Order/SymmDiff.lean
+++ b/Mathlib/Order/SymmDiff.lean
@@ -158,7 +158,7 @@ theorem symmDiff_sdiff : a ∆ b \ c = a \ (b ⊔ c) ⊔ b \ (a ⊔ c) := by
 @[to_dual (attr := simp) sup_himp_bihimp]
 theorem symmDiff_sdiff_inf : a ∆ b \ (a ⊓ b) = a ∆ b := by
   rw [symmDiff_sdiff]
-  simp [symmDiff]
+  simp [symmDiff, sup_of_le_left]
 
 @[to_dual (attr := simp)]
 theorem symmDiff_sdiff_eq_sup : a ∆ (b \ a) = a ⊔ b := by

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -12,7 +12,7 @@ public import Mathlib.Tactic.Contrapose
 public import Mathlib.Tactic.Lift
 public import Mathlib.Data.Option.Basic
 public import Mathlib.Order.Lattice
-public import Mathlib.Order.BoundedOrder.Basic
+public import Mathlib.Order.BoundedOrder.Lattice
 
 /-!
 # `WithBot`, `WithTop`

--- a/Mathlib/Probability/Moments/Variance.lean
+++ b/Mathlib/Probability/Moments/Variance.lean
@@ -398,7 +398,7 @@ theorem meas_ge_le_variance_div_sq [IsFiniteMeasure μ] {X : Ω → ℝ} (hX : M
     (hc : 0 < c) : μ {ω | c ≤ |X ω - μ[X]|} ≤ ENNReal.ofReal (variance X μ / c ^ 2) := by
   rw [ENNReal.ofReal_div_of_pos (sq_pos_of_ne_zero hc.ne.symm), hX.ofReal_variance_eq]
   convert! @meas_ge_le_evariance_div_sq _ _ _ _ hX.1 c.toNNReal (by simp [hc]) using 1
-  · simp
+  · simp [Real.coe_toNNReal']
   · rw [ENNReal.ofReal_pow hc.le]
     rfl
 

--- a/Mathlib/Probability/Process/HittingTime.lean
+++ b/Mathlib/Probability/Process/HittingTime.lean
@@ -89,7 +89,7 @@ lemma hittingBtwn_univ {ι : Type*} [ConditionallyCompleteLinearOrder ι] {u : �
     hittingBtwn u .univ n m = fun _ ↦ min n m := by
   ext ω
   simp only [hittingBtwn_def, Set.mem_Icc, Set.mem_univ, and_true, Set.ofPred_true, Set.inter_univ]
-  by_cases hnm : n ≤ m <;> simp [hnm] <;> grind
+  by_cases hnm : n ≤ m <;> simp [min_eq_left, hnm] <;> grind
 
 @[simp]
 lemma hittingAfter_univ {ι : Type*} [ConditionallyCompleteLattice ι] {u : ι → Ω → β} (n : ι) :

--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -864,7 +864,7 @@ lemma stoppedProcess_div [Div β] :
 
 @[simp] lemma stoppedProcess_const_bot [OrderBot ι] :
     stoppedProcess u (fun _ ↦ ⊥) = fun _ ↦ u ⊥ := by
-  ext; simp [stoppedProcess, ← WithTop.coe_bot]
+  ext; simp_rw [stoppedProcess, inf_bot_eq, ← WithTop.coe_bot, untopD_coe]
 
 @[simp] lemma stoppedProcess_const_top : stoppedProcess u (fun _ ↦ ⊤) = u := by
   ext; simp [stoppedProcess]
@@ -913,7 +913,7 @@ theorem stoppedProcess_stoppedProcess :
   · simp [hσ]
   by_cases hστ : σ ω ≤ τ ω
   · rw [min_eq_left, untopA_eq_untop coe_ne_top]
-    · simp [hστ]
+    · simp [min_eq_left hστ]
     · refine le_trans ?_ hστ
       simp [untopA_eq_untop]
   · nth_rewrite 2 [untopA_eq_untop]
@@ -925,10 +925,10 @@ theorem stoppedProcess_stoppedProcess' :
   rw [stoppedProcess_stoppedProcess]; rfl
 
 theorem stoppedProcess_stoppedProcess_of_le_right (h : σ ≤ τ) :
-    stoppedProcess (stoppedProcess u τ) σ = stoppedProcess u σ := by simp [h]
+    stoppedProcess (stoppedProcess u τ) σ = stoppedProcess u σ := by simp [inf_of_le_left h]
 
 theorem stoppedProcess_stoppedProcess_of_le_left (h : τ ≤ σ) :
-    stoppedProcess (stoppedProcess u τ) σ = stoppedProcess u τ := by simp [h]
+    stoppedProcess (stoppedProcess u τ) σ = stoppedProcess u τ := by simp [inf_of_le_right h]
 
 section Progressive
 
@@ -991,10 +991,7 @@ theorem IsStronglyProgressive.stoppedProcess [PseudoMetrizableSpace ι]
   refine h.comp h_meas fun i ω ↦ ?_
   cases τ ω with
   | top => simp
-  | coe t =>
-    rcases le_total i t with h_it | h_ti
-    · simp [(mod_cast h_it : (i : WithTop ι) ≤ t)]
-    · simpa [(mod_cast h_ti : t ≤ (i : WithTop ι))]
+  | coe t => simp [← coe_inf]
 
 @[deprecated (since := "2026-04-24")]
 alias ProgMeasurable.stoppedProcess := IsStronglyProgressive.stoppedProcess

--- a/Mathlib/RingTheory/Algebraic/Cardinality.lean
+++ b/Mathlib/RingTheory/Algebraic/Cardinality.lean
@@ -54,8 +54,8 @@ theorem lift_cardinalMk_le_max : lift.{u} #L ≤ lift.{v} #R ⊔ ℵ₀ :=
     _ ≤ Cardinal.sum.{u, v} fun _ : R[X] => ℵ₀ :=
       (sum_le_sum _ _ fun _ => (Multiset.finite_toSet _).lt_aleph0.le)
     _ = lift.{v} #(R[X]) * ℵ₀ := by rw [sum_const, lift_aleph0]
-    _ ≤ lift.{v} (#R ⊔ ℵ₀) ⊔ ℵ₀ ⊔ ℵ₀ := (mul_le_max _ _).trans <| by
-      gcongr; simp only [lift_le, Polynomial.cardinalMk_le_max]
+    _ ≤ lift.{v} (#R ⊔ ℵ₀) ⊔ ℵ₀ ⊔ ℵ₀ := by
+      grw [mul_le_max, Polynomial.cardinalMk_le_max]
     _ = _ := by simp
 
 variable (L : Type u) [CommRing L] [IsDomain L] [Algebra R L]

--- a/Mathlib/RingTheory/AlgebraicIndependent/RankAndCardinality.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/RankAndCardinality.lean
@@ -82,11 +82,7 @@ theorem IntermediateField.rank_sup_le
   have := Algebra.Transcendental.infinite F B
   simp_rw [Algebra.Transcendental.rank_eq_cardinalMk]
   rw [sup_def, mul_mk_eq_max, ← Cardinal.lift_le.{u}]
-  refine (lift_cardinalMk_adjoin_le _ _).trans ?_
-  calc
-    _ ≤ Cardinal.lift.{v} #F ⊔ Cardinal.lift.{u} (#A ⊔ #B) ⊔ ℵ₀ := by
-      gcongr
-      rw [Cardinal.lift_le]
-      exact (mk_union_le _ _).trans_eq (by simp)
-    _ = _ := by
-      simp [lift_mk_le_lift_mk_of_injective (algebraMap F A).injective]
+  grw [lift_cardinalMk_adjoin_le, mk_union_le]
+  simp only [SetLike.coe_sort_coe, add_mk_eq_max]
+  rw [sup_of_le_left (by simp), sup_of_le_right ?_]
+  grw [lift_mk_le_lift_mk_of_injective (algebraMap F A).injective, ← le_max_left]

--- a/Mathlib/RingTheory/Depth/Rees.lean
+++ b/Mathlib/RingTheory/Depth/Rees.lean
@@ -52,7 +52,7 @@ private lemma smul_top_quotSMulTop_ne_top_of_smul_top_ne_top {M : Type*} [AddCom
   absurd congrArg (Submodule.comap (Submodule.mkQ _)) eq
   simpa [Submodule.comap_smul_top_of_surjective I _ (Submodule.mkQ_surjective _),
     Submodule.smul_mono_left ((span_singleton_le_iff_mem I).mpr hr),
-    ← Submodule.ideal_span_singleton_smul] using hI
+    ← Submodule.ideal_span_singleton_smul, sup_of_le_left] using hI
 
 namespace ModuleCat
 

--- a/Mathlib/RingTheory/Ideal/MinimalPrime/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/MinimalPrime/Basic.lean
@@ -180,11 +180,12 @@ lemma Ideal.mem_minimalPrimes_sup {R : Type*} [CommRing R] {p I J : Ideal R} [p.
     p ∈ (I ⊔ J).minimalPrimes := by
   refine ⟨⟨‹_›, ?_⟩, fun q ⟨_, hq⟩ hqp ↦ ?_⟩
   · rw [sup_le_iff]
-    refine ⟨hle, by simpa [hle] using Ideal.comap_mono (f := Ideal.Quotient.mk I) h.le⟩
+    refine ⟨hle, ?_⟩
+    simpa [sup_of_le_right, hle] using Ideal.comap_mono (f := Ideal.Quotient.mk I) h.le
   · rw [sup_le_iff] at hq
     have h2 : p.map (Quotient.mk I) ≤ q.map (Quotient.mk I) :=
       h.2 ⟨isPrime_map_quotientMk_of_isPrime hq.1, map_mono hq.2⟩ (map_mono hqp)
-    simpa [comap_map_quotientMk, hq.1, sup_le_iff] using comap_mono (f := Ideal.Quotient.mk I) h2
+    simpa [sup_of_le_right, hq.1] using comap_mono (f := Ideal.Quotient.mk I) h2
 
 variable {S : Type*} [CommRing S] [Algebra R S]
 
@@ -211,6 +212,7 @@ lemma Ideal.map_sup_mem_minimalPrimes_of_map_quotientMk_mem_minimalPrimes
         q.map (Ideal.Quotient.mk (p.map (algebraMap R S))) :=
       hJ.2 ⟨Ideal.isPrime_map_quotientMk_of_isPrime h1, Ideal.map_mono hleq.2⟩
         (Ideal.map_mono hqle)
-    simpa [h1] using Ideal.comap_mono (f := Ideal.Quotient.mk (p.map (algebraMap R S))) h2
+    simpa [sup_of_le_right, h1]
+      using Ideal.comap_mono (f := Ideal.Quotient.mk (p.map (algebraMap R S))) h2
 
 end

--- a/Mathlib/RingTheory/KrullDimension/PID.lean
+++ b/Mathlib/RingTheory/KrullDimension/PID.lean
@@ -31,8 +31,8 @@ instance IsPrincipalIdealRing.krullDimLE_one (R : Type*) [CommRing R]
     exact hlt.not_ge
   have := Ideal.comap_isMaximal_of_surjective (Ideal.Quotient.mk P) Ideal.Quotient.mk_surjective
     (K := I.map (Ideal.Quotient.mk P))
-  simpa [Ideal.comap_map_of_surjective' (Ideal.Quotient.mk P) Ideal.Quotient.mk_surjective,
-    hlt.le] using this
+  rw [Ideal.comap_map_of_surjective' (Ideal.Quotient.mk P) Ideal.Quotient.mk_surjective] at this
+  simpa [sup_of_le_left hlt.le] using this
 
 theorem IsPrincipalIdealRing.ringKrullDim_eq_one (R : Type*) [CommRing R] [IsDomain R]
     [IsPrincipalIdealRing R] (h : ¬ IsField R) : ringKrullDim R = 1 := by

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
@@ -275,13 +275,12 @@ theorem cyclotomic_eval_lt_add_one_pow_totient {n : ℕ} {q : ℝ} (hn' : 3 ≤ 
   · simp only [Finset.mem_attach, forall_true_left, Subtype.forall, ←
       Units.val_le_val, ← NNReal.coe_le_coe, Units.val_mk0,
       coe_nnnorm]
-    intro x hx
-    have : ‖_‖ ≤ _ := hfor x hx
-    simp [this]
+    grw [← Real.le_coe_toNNReal]
+    exact hfor
   · simp only [Finset.mem_attach, Subtype.exists, ←
-      NNReal.coe_lt_coe, ← Units.val_lt_val, Units.val_mk0 _, coe_nnnorm]
-    obtain ⟨ζ, hζ, hhζ : ‖_‖ < _⟩ := hex
-    exact ⟨ζ, hζ, by simp [hhζ]⟩
+      NNReal.coe_lt_coe, ← Units.val_lt_val, Units.val_mk0, coe_nnnorm, true_and, exists_prop]
+    grw [← Real.le_coe_toNNReal]
+    exact hex
 
 theorem cyclotomic_eval_le_add_one_pow_totient {q : ℝ} (hq' : 1 < q) :
     ∀ n, (cyclotomic n ℝ).eval q ≤ (q + 1) ^ totient n

--- a/Mathlib/RingTheory/QuasiFinite/Weakly.lean
+++ b/Mathlib/RingTheory/QuasiFinite/Weakly.lean
@@ -155,13 +155,13 @@ lemma eq_of_le_of_under_eq {P Q : Ideal S} [P.IsPrime] [Q.IsPrime]
     (Ideal.map_mono h₁) (by
       rw [← Ideal.under_under (B := S), ← Ideal.under_under (A := R) (B := S) (C := S ⧸ _)]
       dsimp [Ideal.under] at h₂ ⊢
-      simp [Ideal.map_comap_le]
-      simp [Ideal.map_comap_le, ← h₂])
+      simp [sup_of_le_right, Ideal.map_comap_le]
+      simp [sup_of_le_right, Ideal.map_comap_le, ← h₂])
   replace this := (Ideal.comap_map_of_surjective _ Ideal.Quotient.mk_surjective _).symm.trans
     congr($(this).comap _)
   simp [Ideal.comap_map_of_surjective _ Ideal.Quotient.mk_surjective,
-    ← RingHom.ker_eq_comap_bot, Ideal.map_comap_le] at this
-  simpa [Ideal.map_comap_le, ← h₂] using this
+    ← RingHom.ker_eq_comap_bot, sup_of_le_left, Ideal.map_comap_le] at this
+  simpa [sup_of_le_left, Ideal.map_comap_le, ← h₂] using this
 
 open _root_.TensorProduct in
 /-- Use `Algebra.QuasiFiniteAt.baseChange` instead for `Algebra.QuasiFiniteAt R p`. -/
@@ -223,7 +223,7 @@ lemma of_restrictScalars [Algebra S T] [IsScalarTower R S T]
   apply Ideal.comap_injective_of_surjective _ Ideal.Quotient.mk_surjective
   rw [Ideal.comap_comap, Ideal.comap_map_of_surjective _ Ideal.Quotient.mk_surjective]
   refine .trans ?_ (Ideal.comap_map_of_surjective _ Ideal.Quotient.mk_surjective _).symm
-  simp [← RingHom.ker_eq_comap_bot, Ideal.map_comap_le]
+  simp [← RingHom.ker_eq_comap_bot, sup_of_le_left, Ideal.map_comap_le]
 
 /-- Use `Algebra.QuasiFinite.of_quasiFiniteAt_residueField` instead
 for `Algebra.QuasiFiniteAt R q`. -/

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/GCDMonoid.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/GCDMonoid.lean
@@ -41,8 +41,8 @@ noncomputable def UniqueFactorizationMonoid.toGCDMonoid (α : Type*) [CommMonoid
     rw [← mk_dvd_mk, Associates.quot_out, congr_fun₂ dvd_eq_le, le_inf_iff,
       mk_le_mk_iff_dvd, mk_le_mk_iff_dvd]
     exact ⟨hac, hab⟩
-  lcm_zero_left a := by simp
-  lcm_zero_right a := by simp
+  lcm_zero_left a := by simp [sup_of_le_left]
+  lcm_zero_right a := by simp [sup_of_le_right]
   gcd_mul_lcm a b := by
     rw [← mk_eq_mk_iff_associated, ← Associates.mk_mul_mk, ← associated_iff_eq, Associates.quot_out,
       Associates.quot_out, mul_comm, sup_mul_inf, Associates.mk_mul_mk]

--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -594,7 +594,8 @@ theorem power_nat_le_max {c : Cardinal.{u}} {n : ℕ} : c ^ (n : Cardinal.{u}) �
   · exact le_max_of_le_right (power_lt_aleph0 hc natCast_lt_aleph0).le
 
 lemma power_le_aleph0 {a b : Cardinal.{u}} (ha : a ≤ ℵ₀) (hb : b < ℵ₀) : a ^ b ≤ ℵ₀ := by
-  lift b to ℕ using hb; simpa [ha] using power_nat_le_max (c := a)
+  lift b to ℕ using hb
+  grw [power_nat_le_max, ha, max_self]
 
 theorem powerlt_aleph0 {c : Cardinal} (h : ℵ₀ ≤ c) : c ^< ℵ₀ = c := by
   apply le_antisymm

--- a/Mathlib/SetTheory/Cardinal/Order.lean
+++ b/Mathlib/SetTheory/Cardinal/Order.lean
@@ -163,7 +163,7 @@ theorem lift_injective : Injective lift.{u, v} :=
 theorem lift_inj {a b : Cardinal.{u}} : lift.{v, u} a = lift.{v, u} b ↔ a = b :=
   lift_injective.eq_iff
 
-@[simp]
+@[simp, gcongr]
 theorem lift_le {a b : Cardinal.{v}} : lift.{u} a ≤ lift.{u} b ↔ a ≤ b :=
   liftInitialSeg.le_iff_le
 

--- a/Mathlib/SetTheory/Ordinal/Veblen.lean
+++ b/Mathlib/SetTheory/Ordinal/Veblen.lean
@@ -737,8 +737,9 @@ theorem card_epsilon (o : Ordinal) : (ε_ o).card = max ℵ₀ o.card := by
 
 @[simp]
 theorem card_gamma (o : Ordinal) : (Γ_ o).card = max ℵ₀ o.card := by
-  apply le_antisymm (card_deriv_le_of_forall_le (by simpa [Or.comm] using card_veblen_le · 0))
+  refine le_antisymm (card_deriv_le_of_forall_le fun x ↦ ?_)
     (max_le ?_ ?_)
+  · grw [card_veblen_le, sup_of_le_left (card_le_card zero_le), max_comm]
   · exact aleph0_le_card.mpr <| omega0_lt_gamma o |>.le
   · exact card_le_card isNormal_gamma.strictMono.le_apply
 

--- a/Mathlib/Topology/ClusterPt.lean
+++ b/Mathlib/Topology/ClusterPt.lean
@@ -327,7 +327,7 @@ theorem clusterPt_iff_lift'_closure' {F : Filter X} :
   rw [clusterPt_iff_lift'_closure, inf_comm]
   constructor
   · intro h
-    simp [h, pure_neBot]
+    simp [inf_of_le_left h, pure_neBot]
   · intro h U hU
     simp_rw [← forall_mem_nonempty_iff_neBot, mem_inf_iff] at h
     simpa using h ({x} ∩ U) ⟨{x}, by simp, U, hU, rfl⟩

--- a/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
@@ -657,7 +657,7 @@ theorem nnnorm_coeFn_eq (f : α →ᵇ ℝ) : ⇑f.nnnorm = NNNorm.nnnorm ∘ �
 theorem self_eq_nnrealPart_sub_nnrealPart_neg (f : α →ᵇ ℝ) :
     ⇑f = (↑) ∘ f.nnrealPart - (↑) ∘ (-f).nnrealPart := by
   funext x
-  dsimp
+  dsimp [Real.coe_toNNReal']
   simp only [max_zero_sub_max_neg_zero_eq_self]
 
 /-- Express the absolute value of a bounded continuous function in terms of its
@@ -665,7 +665,7 @@ positive and negative parts. -/
 theorem abs_self_eq_nnrealPart_add_nnrealPart_neg (f : α →ᵇ ℝ) :
     abs ∘ ⇑f = (↑) ∘ f.nnrealPart + (↑) ∘ (-f).nnrealPart := by
   funext x
-  dsimp
+  dsimp [Real.coe_toNNReal']
   simp only [max_zero_add_max_neg_zero_eq_abs_self]
 
 end NonnegativePart

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -702,18 +702,15 @@ lemma nnrealPart_smul_pos (f : C_c(α, ℝ)) {a : ℝ} (ha : 0 ≤ a) :
   ext x
   simp only [nnrealPart_apply, coe_smul, Pi.smul_apply, Real.coe_toNNReal', smul_eq_mul,
     NNReal.coe_mul, ha, sup_of_le_left]
-  rcases le_total 0 (f x) with hfx | hfx
-  · simp [ha, hfx, mul_nonneg]
-  · simp [mul_nonpos_iff, ha, hfx]
+  rw [mul_max_of_nonneg _ _ ha, mul_zero]
 
 lemma nnrealPart_smul_neg (f : C_c(α, ℝ)) {a : ℝ} (ha : a ≤ 0) :
     (a • f).nnrealPart = (-a).toNNReal • (-f).nnrealPart := by
   ext x
   simp only [nnrealPart_apply, coe_smul, Pi.smul_apply, smul_eq_mul, Real.coe_toNNReal', coe_neg,
     Pi.neg_apply, NNReal.coe_mul]
-  rcases le_total 0 (f x) with hfx | hfx
-  · simp [mul_nonpos_iff, ha, hfx]
-  · simp [ha, hfx, mul_nonneg_of_nonpos_of_nonpos]
+  rw [sup_of_le_left (show 0 ≤ -a by simpa), mul_max_of_nonneg _ _ (by simpa)]
+  simp
 
 lemma nnrealPart_add_le_add_nnrealPart (f g : C_c(α, ℝ)) :
     (f + g).nnrealPart ≤ f.nnrealPart + g.nnrealPart := by
@@ -746,7 +743,7 @@ noncomputable def toReal (f : C_c(α, ℝ≥0)) : C_c(α, ℝ) :=
 
 @[simp]
 lemma nnrealPart_sub_nnrealPart_neg (f : C_c(α, ℝ)) :
-    (nnrealPart f).toReal - (nnrealPart (-f)).toReal = f := by ext x; simp
+    (nnrealPart f).toReal - (nnrealPart (-f)).toReal = f := by ext x; simp [Real.coe_toNNReal']
 
 /-- The map `toReal` defined as a `ℝ≥0`-linear map. -/
 noncomputable def toRealLinearMap : C_c(α, ℝ≥0) →ₗ[ℝ≥0] C_c(α, ℝ) where
@@ -810,7 +807,7 @@ noncomputable def toRealPositiveLinear (Λ : C_c(α, ℝ≥0) →ₗ[ℝ≥0] �
         rcases le_total 0 a with ha | ha
         · rw [RingHom.id_apply, smul_eq_mul, ← (smul_neg a f), nnrealPart_smul_pos f ha,
             nnrealPart_smul_pos (-f) ha]
-          simp [sup_of_le_left ha, mul_sub]
+          simp [Real.coe_toNNReal, ha, mul_sub]
         · simp only [RingHom.id_apply, smul_eq_mul, ← (smul_neg a f),
             nnrealPart_smul_neg f ha, nnrealPart_smul_neg (-f) ha, map_smul,
             NNReal.coe_mul, Real.coe_toNNReal', neg_neg, sup_of_le_left (neg_nonneg.mpr ha)]

--- a/Mathlib/Topology/ContinuousMap/Interval.lean
+++ b/Mathlib/Topology/ContinuousMap/Interval.lean
@@ -47,7 +47,7 @@ def IccExtendCM : C(C(Icc a b, E), C(α, E)) where
 @[simp]
 theorem IccExtendCM_of_mem {f : C(Icc a b, E)} {x : α} (hx : x ∈ Icc a b) :
     IccExtendCM f x = f ⟨x, hx⟩ := by
-  simp [IccExtendCM, projIccCM, projIcc, hx.1, hx.2]
+  simp [IccExtendCM, projIccCM, projIcc_of_mem, hx]
 
 /-- The concatenation of two continuous maps defined on adjacent intervals. If the values of the
 functions on the common bound do not agree, this is defined as an arbitrarily chosen constant
@@ -75,7 +75,7 @@ theorem concat_comp_IccInclusionRight (hb : f ⊤ = g ⊥) :
   obtain rfl | hxb := eq_or_ne x b
   · simpa [concat, IccInclusionRight, IccExtendCM, projIccCM, inclusion, hb]
   · have h : ¬ x ≤ b := lt_of_le_of_ne hx.1 (Ne.symm hxb) |>.not_ge
-    simp [concat, hb, IccInclusionRight, h, IccExtendCM, projIccCM, projIcc, inclusion, hx.2, hx.1]
+    simp [concat, hb, IccInclusionRight, h, IccExtendCM, projIccCM, projIcc_of_mem, inclusion, hx]
 
 @[simp]
 theorem concat_left (hb : f ⊤ = g ⊥) {t : Icc a c} (ht : t ≤ b) :
@@ -106,21 +106,21 @@ theorem tendsto_concat {ι : Type*} {p : Filter ι} {F : ι → C(Icc a b, E)} {
     rw [← concat_comp_IccInclusionLeft hfg']
     apply hfgU.comp
     rintro x ⟨y, ⟨⟨z, hz⟩, ⟨h1, (h2 : z ≤ b)⟩, rfl⟩, rfl⟩
-    simpa [projIccCM, projIcc, h2, hz.1] using! h1
+    simpa [projIccCM, projIcc_of_mem, h2, hz.1] using! h1
   have hgU : MapsTo g K₂ U := by
     rw [← concat_comp_IccInclusionRight hfg']
     apply hfgU.comp
     rintro x ⟨y, ⟨⟨z, hz⟩, ⟨h1, (h2 : b ≤ z)⟩, rfl⟩, rfl⟩
-    simpa [projIccCM, projIcc, h2, hz.2] using! h1
+    simpa [projIccCM, projIcc_of_mem, h2, hz.2] using! h1
   filter_upwards [hf K₁ hK₁ U hU hfU, hg K₂ hK₂ U hU hgU, hfg] with i hf hg hfg x hx
   by_cases! hxb : x ≤ b
   · rw [concat_left hfg hxb]
     refine hf ⟨x, ⟨x, ⟨hx, hxb⟩, rfl⟩, ?_⟩
-    simp [projIccCM, projIcc, hxb, x.2.1]
+    simp [projIccCM, projIcc_of_mem, hxb, x.2.1]
   · replace hxb : b ≤ x := hxb.le
     rw [concat_right hfg hxb]
     refine hg ⟨x, ⟨x, ⟨hx, hxb⟩, rfl⟩, ?_⟩
-    simp [projIccCM, projIcc, hxb, x.2.2]
+    simp [projIccCM, projIcc_of_mem, hxb, x.2.2]
 
 /-- The concatenation of compatible pairs of continuous maps on adjacent intervals, defined as a
 `ContinuousMap` on a subtype of the product. -/

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -231,7 +231,7 @@ theorem isClosed_and_discrete_iff {S : Set X} :
   · by_cases hx : x ∈ S
     exacts [H.2 hx, (H.1 hx).mono_left nhdsWithin_le_nhds]
   · refine ⟨fun hx ↦ ?_, fun _ ↦ H⟩
-    simpa [disjoint_iff, nhdsWithin, inf_assoc, hx] using H
+    simpa [disjoint_iff, nhdsWithin, inf_assoc, inf_of_le_right, hx] using H
 
 /-- The filter of sets with no accumulation points inside a set `S : Set X`, implemented
 as the supremum over all punctured neighborhoods within `S`. -/

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -546,7 +546,7 @@ theorem nsmul_posPart (n : ℕ) (f : locallyFinsuppWithin U Y) : (n • f)⁺ = 
   simp only [posPart, max_apply, coe_nsmul, Pi.smul_apply, coe_zero, Pi.zero_apply]
   by_cases h : f x < 0
   · simpa [max_eq_right_of_lt h] using nsmul_le_nsmul_right h.le n
-  · simpa [not_lt.1 h] using nsmul_nonneg (not_lt.1 h) n
+  · simpa [sup_of_le_left (not_lt.1 h)] using nsmul_nonneg (not_lt.1 h) n
 
 /--
 Taking the negative part of a function with locally finite support commutes with
@@ -559,7 +559,7 @@ theorem nsmul_negPart (n : ℕ) (f : locallyFinsuppWithin U Y) : (n • f)⁻ = 
     Pi.zero_apply]
   by_cases h : -f x < 0
   · simpa [max_eq_right_of_lt h] using nsmul_le_nsmul_right h.le n
-  · simpa [not_lt.1 h] using nsmul_nonneg (not_lt.1 h) n
+  · simpa [sup_of_le_left (not_lt.1 h)] using nsmul_nonneg (not_lt.1 h) n
 
 /--
 Every positive function with locally finite supports dominates a singleton indicator.

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -1129,10 +1129,11 @@ lemma separation {x : X} {C : Set X} (hxC : C ∈ 𝓝 x) :
   obtain ⟨n, hn⟩ := denseRange_iff.mp (denseRange_denseSeq X) x (ε / 2)
     (by simp_all [ε, ← IsClosed.notMem_iff_infDist_pos, mem_interior_iff_mem_nhds])
   refine ⟨n, ball 0 (ε / 2), isOpen_ball.mem_nhds ?_, ?_⟩
-  · simp [Subtype.dist_eq, abs_eq_self.mpr, coe_projIcc, hn]
+  · simp [Subtype.dist_eq, abs_eq_self.mpr, coe_projIcc, sup_of_le_right, hn]
   · intro y hy
     replace hy : dist y (denseSeq X n) < ε / 2 := by
-      simpa [Subtype.dist_eq, abs_eq_self.mpr, coe_projIcc, not_lt_of_ge, ε, div_le_iff₀] using hy
+      simpa [Subtype.dist_eq, abs_eq_self.mpr, coe_projIcc, sup_of_le_right, not_lt_of_ge, ε,
+        div_le_iff₀] using hy
     have : dist x y < infDist x (closure Cᶜ) :=
       ((dist_triangle_right x y (denseSeq X n)).trans_lt (add_lt_add hn hy)).trans_le (by simp [ε])
     simpa using notMem_of_notMem_closure (mt infDist_le_dist_of_mem this.not_ge)

--- a/Mathlib/Topology/MetricSpace/Pseudo/Constructions.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Constructions.lean
@@ -140,7 +140,7 @@ lemma NNReal.ball_zero_eq_Ico (c : ℝ) :
     Metric.ball (0 : ℝ≥0) c = Set.Ico 0 c.toNNReal := by
   by_cases! c_pos : 0 < c
   · convert! NNReal.ball_zero_eq_Ico' (NNReal.mk c c_pos.le)
-    simp [Real.toNNReal, c_pos.le]
+    ext; simp [c_pos.le]
   simp [c_pos]
 
 lemma NNReal.closedBall_zero_eq_Icc' (c : ℝ≥0) :
@@ -149,7 +149,7 @@ lemma NNReal.closedBall_zero_eq_Icc' (c : ℝ≥0) :
 lemma NNReal.closedBall_zero_eq_Icc {c : ℝ} (c_nn : 0 ≤ c) :
     Metric.closedBall (0 : ℝ≥0) c = Set.Icc 0 c.toNNReal := by
   convert! NNReal.closedBall_zero_eq_Icc' (NNReal.mk c c_nn)
-  simp [Real.toNNReal, c_nn]
+  ext; simp [c_nn]
 
 end NNReal
 

--- a/Mathlib/Topology/MetricSpace/Thickening.lean
+++ b/Mathlib/Topology/MetricSpace/Thickening.lean
@@ -227,7 +227,9 @@ theorem cthickening_zero (E : Set α) : cthickening 0 E = closure E :=
   cthickening_of_nonpos le_rfl E
 
 theorem cthickening_max_zero (δ : ℝ) (E : Set α) : cthickening (max 0 δ) E = cthickening δ E := by
-  cases le_total δ 0 <;> simp [cthickening_of_nonpos, *]
+  rcases le_total δ 0 with (h | h)
+  · simp [cthickening_of_nonpos, h]
+  · rw [sup_of_le_right h]
 
 /-- The closed thickening `Metric.cthickening δ E` of a fixed subset `E` is an increasing function
 of the thickening radius `δ`. -/

--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -583,7 +583,7 @@ theorem truncate_const_continuous_family {a b : X} (γ : Path a b)
 theorem truncate_self {a b : X} (γ : Path a b) (t : ℝ) :
     γ.truncate t t = (Path.refl <| γ.extend t).cast (by rw [min_self]) rfl := by
   ext x
-  by_cases hx : x ≤ t <;> simp [truncate]
+  by_cases hx : x ≤ t <;> simp [truncate, inf_of_le_right]
 
 theorem truncate_zero_zero {a b : X} (γ : Path a b) :
     γ.truncate 0 0 = (Path.refl a).cast (by rw [min_self, γ.extend_zero]) γ.extend_zero := by
@@ -595,7 +595,7 @@ theorem truncate_one_one {a b : X} (γ : Path a b) :
 
 @[simp]
 theorem truncate_zero_one {a b : X} (γ : Path a b) :
-    γ.truncate 0 1 = γ.cast (by simp) (by simp) := by
+    γ.truncate 0 1 = γ.cast (by grind) (by simp) := by
   ext x
   rw [cast_coe]
   have : ↑x ∈ (Icc 0 1 : Set ℝ) := x.2

--- a/Mathlib/Topology/Semicontinuity/Basic.lean
+++ b/Mathlib/Topology/Semicontinuity/Basic.lean
@@ -441,24 +441,15 @@ theorem LowerSemicontinuousWithinAt.add' {f g : α → γ} (hf : LowerSemicontin
     · obtain ⟨z₂, z₂lt, h₂⟩ : ∃ z₂ < g x, Ioc z₂ (g x) ⊆ v :=
         exists_Ioc_subset_of_mem_nhds (v_open.mem_nhds xv) hx₂
       filter_upwards [hf z₁ z₁lt, hg z₂ z₂lt] with z h₁z h₂z
-      have A1 : min (f z) (f x) ∈ u := by
-        by_cases! H : f z ≤ f x
-        · simpa [H] using h₁ ⟨h₁z, H⟩
-        · simpa [H.le]
-      have A2 : min (g z) (g x) ∈ v := by
-        by_cases! H : g z ≤ g x
-        · simpa [H] using h₂ ⟨h₂z, H⟩
-        · simpa [H.le]
+      have A1 : min (f z) (f x) ∈ u := by grind
+      have A2 : min (g z) (g x) ∈ v := by grind
       have : (min (f z) (f x), min (g z) (g x)) ∈ u ×ˢ v := ⟨A1, A2⟩
       calc
         y < min (f z) (f x) + min (g z) (g x) := h this
         _ ≤ f z + g z := add_le_add (min_le_left _ _) (min_le_left _ _)
     · simp only [not_exists, not_lt] at hx₂
       filter_upwards [hf z₁ z₁lt] with z h₁z
-      have A1 : min (f z) (f x) ∈ u := by
-        by_cases! H : f z ≤ f x
-        · simpa [H] using h₁ ⟨h₁z, H⟩
-        · simpa [H.le]
+      have A1 : min (f z) (f x) ∈ u := by grind
       have : (min (f z) (f x), g x) ∈ u ×ˢ v := ⟨A1, xv⟩
       calc
         y < min (f z) (f x) + g x := h this
@@ -468,10 +459,7 @@ theorem LowerSemicontinuousWithinAt.add' {f g : α → γ} (hf : LowerSemicontin
     · obtain ⟨z₂, z₂lt, h₂⟩ : ∃ z₂ < g x, Ioc z₂ (g x) ⊆ v :=
         exists_Ioc_subset_of_mem_nhds (v_open.mem_nhds xv) hx₂
       filter_upwards [hg z₂ z₂lt] with z h₂z
-      have A2 : min (g z) (g x) ∈ v := by
-        by_cases! H : g z ≤ g x
-        · simpa [H] using h₂ ⟨h₂z, H⟩
-        · simpa [H.le] using h₂ ⟨z₂lt, le_rfl⟩
+      have A2 : min (g z) (g x) ∈ v := by grind
       have : (f x, min (g z) (g x)) ∈ u ×ˢ v := ⟨xu, A2⟩
       calc
         y < f x + min (g z) (g x) := h this

--- a/MathlibTest/SetLike.lean
+++ b/MathlibTest/SetLike.lean
@@ -55,6 +55,7 @@ example [Monoid M] (x y z : M) (S₁ S₂ : Submonoid M) (h : S₁ ≤ S₂) (hx
 example [Monoid M] (x y z : M) (S₁ S₂ : Submonoid M) (h : S₁ ≤ S₂) (hx : x ∈ S₁)
     (hy : y ∈ S₁) (hz : z ∈ S₂) :
     x * y * z ∈ S₁ ⊔ S₂ := by
+  rw [sup_of_le_right h]
   aesop
 
 example [Monoid M] (x y z : M) (S : Submonoid M) (hxy : x * y ∈ S) (hz : z ∈ S) :


### PR DESCRIPTION
This PR removes `simp` from `sup_of_le_left` and friends, as these apply very generally and can cause expensive recursive `simp` calls. Instead, `simp` was added to lemmas like `sup_idem`, `sup_bot` and `max_zero`.

Many proofs have to be fixed. I did this manyally, mostly either by adding the removed lemma back to the `simp` call, or by writing the proof out more explicitly, or by using `grind`.

- I changed the `simp` set around `Real.toNNReal` and `Rat.toNNRat` to be compatible with the lack of a `sup_of_le_right` lemma (and to be consistent between the two).
- I added a `@[gcongr]` tag to `Cardinal.lift_le`.

The motivation for this PR is to reduce the performance impact of #42316. However, we could also decide that the performance impact is not so bad, and simply keep the `@[simp]` attributes.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
