### PR TITLE
feat(AlgebraicGeometry): serre's R_k condition for schemes

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1476,6 +1476,7 @@ public import Mathlib.AlgebraicGeometry.PullbackCarrier
 public import Mathlib.AlgebraicGeometry.Pullbacks
 public import Mathlib.AlgebraicGeometry.QuasiAffine
 public import Mathlib.AlgebraicGeometry.RationalMap
+public import Mathlib.AlgebraicGeometry.RegularInCodimension
 public import Mathlib.AlgebraicGeometry.RelativeGluing
 public import Mathlib.AlgebraicGeometry.ResidueField
 public import Mathlib.AlgebraicGeometry.Restrict

--- a/Mathlib/AlgebraicGeometry/RegularInCodimension.lean
+++ b/Mathlib/AlgebraicGeometry/RegularInCodimension.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 Raphael Douglas Giles. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Douglas Giles
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Properties
+public import Mathlib.RingTheory.RegularLocalRing.Defs
+
+/-!
+# Serre's condition `(Rₙ)`
+
+A scheme `X` satisfies Serre's condition `(Rₙ)`, spelled `IsRegularInCodimensionLE n X`, if every
+local ring of `X` of dimension at most `n` is regular. The dimension of the local ring at `x` is the
+codimension of the closure of `x`, which is `Order.coheight x` (see
+`AlgebraicGeometry.ringKrullDim_stalk_eq_coheight`), so this says exactly that `X` is regular in
+codimension `≤ n`.
+
+## Main definitions
+
+* `AlgebraicGeometry.IsRegularInCodimensionLE`: Serre's condition `(Rₙ)`.
+
+## Main results
+
+* `AlgebraicGeometry.IsRegularInCodimensionLE.isDiscreteValuationRing_stalk`: on a scheme satisfying
+  `(R₁)`, the local ring at a point of codimension one is a discrete valuation ring, provided that
+  local ring is a domain. This holds automatically on an integral scheme.
+
+## TODO
+
+Once Mathlib knows that a regular local ring is a domain (mathlib4#28683), the `IsDomain`
+assumption on `IsRegularInCodimensionLE.isDiscreteValuationRing_stalk` becomes redundant and should
+be removed, so that the result applies to every scheme satisfying `(R₁)` rather than only to
+integral ones.
+-/
+
+@[expose] public section
+
+universe u
+
+open Order
+
+namespace AlgebraicGeometry
+
+/--
+Serre's condition `(Rₙ)`: a scheme is regular in codimension `≤ n` if all of its local rings of
+dimension at most `n` are regular local rings.
+
+This condition is normally only considered for locally Noetherian schemes. Note that
+`IsRegularLocalRing` already requires the local rings in question to be Noetherian, so no such
+assumption appears here.
+-/
+@[stacks 033Q]
+class IsRegularInCodimensionLE (n : ℕ) (X : Scheme.{u}) : Prop where
+  isRegularLocalRing_stalk (x : X) (hx : coheight x ≤ n) :
+    IsRegularLocalRing (X.presheaf.stalk x)
+
+variable {n : ℕ} {X : Scheme.{u}}
+
+lemma isRegularInCodimensionLE_iff :
+    IsRegularInCodimensionLE n X ↔
+      ∀ x : X, coheight x ≤ n → IsRegularLocalRing (X.presheaf.stalk x) :=
+  ⟨fun ⟨h⟩ ↦ h, fun h ↦ ⟨h⟩⟩
+
+/--
+Serre's condition is stated in terms of the dimension of the local rings of `X`; this is the
+same as the condition on codimensions of points used to define `IsRegularInCodimensionLE`.
+-/
+lemma isRegularInCodimensionLE_iff_ringKrullDim :
+    IsRegularInCodimensionLE n X ↔
+      ∀ x : X, ringKrullDim (X.presheaf.stalk x) ≤ n →
+        IsRegularLocalRing (X.presheaf.stalk x) := by
+  rw [isRegularInCodimensionLE_iff]
+  refine forall_congr' fun x ↦ ?_
+  rw [ringKrullDim_stalk_eq_coheight]
+  norm_cast
+
+lemma IsRegularInCodimensionLE.mono {m n : ℕ} (h : m ≤ n) (X : Scheme.{u})
+    [IsRegularInCodimensionLE n X] : IsRegularInCodimensionLE m X :=
+  ⟨fun x hx ↦ isRegularLocalRing_stalk x <| hx.trans (by exact_mod_cast h)⟩
+
+/--
+TODO: Remove the `IsDomain (X.presheaf.stalk x)` hypothesis once Mathlib knows that regular local
+rings are domains.
+-/
+lemma IsRegularInCodimensionLE.isDiscreteValuationRing_stalk [IsRegularInCodimensionLE 1 X] {x : X}
+    [IsDomain (X.presheaf.stalk x)] (hx : coheight x = 1) :
+    IsDiscreteValuationRing (X.presheaf.stalk x) := by
+  have hreg := isRegularLocalRing_stalk (n := 1) x hx.le
+  rw [← IsLocalRing.finrank_CotangentSpace_eq_one_iff]
+  have hdim : ringKrullDim (X.presheaf.stalk x) = 1 := by
+    rw [ringKrullDim_stalk_eq_coheight x, hx]; rfl
+  have := (IsRegularLocalRing.iff_finrank_cotangentSpace (X.presheaf.stalk x)).mp hreg
+  rw [hdim] at this
+  exact_mod_cast this
+
+end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/RegularInCodimension.lean
+++ b/Mathlib/AlgebraicGeometry/RegularInCodimension.lean
@@ -76,6 +76,11 @@ lemma isRegularInCodimensionLE_iff_ringKrullDim :
   refine forall_congr' fun x ↦ ?_
   rw [ringKrullDim_stalk_eq_coheight]
   norm_cast
+lemma isRegularLocalRing_stalk (x : X) [Ring.KrullDimLE n (X.presheaf.stalk x)]
+    [IsRegularInCodimensionLE n X] : IsRegularLocalRing (X.presheaf.stalk x) := by
+  apply isRegularInCodimensionLE_iff_ringKrullDim.mp ‹_›
+  rw [← Ring.krullDimLE_iff]
+  infer_instance
 
 lemma IsRegularInCodimensionLE.anti {m n : ℕ} (h : m ≤ n) (X : Scheme.{u})
     [IsRegularInCodimensionLE n X] : IsRegularInCodimensionLE m X :=

--- a/Mathlib/AlgebraicGeometry/RegularInCodimension.lean
+++ b/Mathlib/AlgebraicGeometry/RegularInCodimension.lean
@@ -6,6 +6,7 @@ Authors: Raphael Douglas Giles
 module
 
 public import Mathlib.AlgebraicGeometry.Properties
+public import Mathlib.RingTheory.DiscreteValuationRing.TFAE
 public import Mathlib.RingTheory.RegularLocalRing.Defs
 
 /-!
@@ -76,7 +77,7 @@ lemma isRegularInCodimensionLE_iff_ringKrullDim :
   rw [ringKrullDim_stalk_eq_coheight]
   norm_cast
 
-lemma IsRegularInCodimensionLE.mono {m n : ℕ} (h : m ≤ n) (X : Scheme.{u})
+lemma IsRegularInCodimensionLE.anti {m n : ℕ} (h : m ≤ n) (X : Scheme.{u})
     [IsRegularInCodimensionLE n X] : IsRegularInCodimensionLE m X :=
   ⟨fun x hx ↦ isRegularLocalRing_stalk x <| hx.trans (by exact_mod_cast h)⟩
 
@@ -90,7 +91,8 @@ lemma IsRegularInCodimensionLE.isDiscreteValuationRing_stalk [IsRegularInCodimen
   have hreg := isRegularLocalRing_stalk (n := 1) x hx.le
   rw [← IsLocalRing.finrank_CotangentSpace_eq_one_iff]
   have hdim : ringKrullDim (X.presheaf.stalk x) = 1 := by
-    rw [ringKrullDim_stalk_eq_coheight x, hx]; rfl
+    rw [ringKrullDim_stalk_eq_coheight x, hx]
+    norm_num
   have := (IsRegularLocalRing.iff_finrank_cotangentSpace (X.presheaf.stalk x)).mp hreg
   rw [hdim] at this
   exact_mod_cast this

--- a/Mathlib/AlgebraicGeometry/RegularInCodimension.lean
+++ b/Mathlib/AlgebraicGeometry/RegularInCodimension.lean
@@ -42,7 +42,7 @@ universe u
 
 open Order
 
-namespace AlgebraicGeometry
+namespace AlgebraicGeometry.Scheme
 
 /--
 Serre's condition `(Rₙ)`: a scheme is regular in codimension `≤ n` if all of its local rings of
@@ -54,7 +54,7 @@ assumption appears here.
 -/
 @[stacks 033Q]
 class IsRegularInCodimensionLE (n : ℕ) (X : Scheme.{u}) : Prop where
-  isRegularLocalRing_stalk (x : X) (hx : coheight x ≤ n) :
+  isRegularLocalRing_stalk_of_coheight_le (x : X) (hx : coheight x ≤ n) :
     IsRegularLocalRing (X.presheaf.stalk x)
 
 variable {n : ℕ} {X : Scheme.{u}}
@@ -76,6 +76,13 @@ lemma isRegularInCodimensionLE_iff_ringKrullDim :
   refine forall_congr' fun x ↦ ?_
   rw [ringKrullDim_stalk_eq_coheight]
   norm_cast
+
+lemma isRegularInCodimensionLE_iff_ringKrullDimLE :
+    IsRegularInCodimensionLE n X ↔
+      ∀ x : X, Ring.KrullDimLE n (X.presheaf.stalk x) →
+        IsRegularLocalRing (X.presheaf.stalk x) := by
+  simp [isRegularInCodimensionLE_iff_ringKrullDim, Ring.krullDimLE_iff]
+
 lemma isRegularLocalRing_stalk (x : X) [Ring.KrullDimLE n (X.presheaf.stalk x)]
     [IsRegularInCodimensionLE n X] : IsRegularLocalRing (X.presheaf.stalk x) := by
   apply isRegularInCodimensionLE_iff_ringKrullDim.mp ‹_›
@@ -84,7 +91,7 @@ lemma isRegularLocalRing_stalk (x : X) [Ring.KrullDimLE n (X.presheaf.stalk x)]
 
 lemma IsRegularInCodimensionLE.anti {m n : ℕ} (h : m ≤ n) (X : Scheme.{u})
     [IsRegularInCodimensionLE n X] : IsRegularInCodimensionLE m X :=
-  ⟨fun x hx ↦ isRegularLocalRing_stalk x <| hx.trans (by exact_mod_cast h)⟩
+  ⟨fun x hx ↦ isRegularLocalRing_stalk_of_coheight_le x <| hx.trans (by exact_mod_cast h)⟩
 
 /--
 TODO: Remove the `IsDomain (X.presheaf.stalk x)` hypothesis once Mathlib knows that regular local
@@ -93,7 +100,7 @@ rings are domains.
 lemma IsRegularInCodimensionLE.isDiscreteValuationRing_stalk [IsRegularInCodimensionLE 1 X] {x : X}
     [IsDomain (X.presheaf.stalk x)] (hx : coheight x = 1) :
     IsDiscreteValuationRing (X.presheaf.stalk x) := by
-  have hreg := isRegularLocalRing_stalk (n := 1) x hx.le
+  have hreg := isRegularLocalRing_stalk_of_coheight_le (n := 1) x hx.le
   rw [← IsLocalRing.finrank_CotangentSpace_eq_one_iff]
   have hdim : ringKrullDim (X.presheaf.stalk x) = 1 := by
     rw [ringKrullDim_stalk_eq_coheight x, hx]
@@ -102,4 +109,4 @@ lemma IsRegularInCodimensionLE.isDiscreteValuationRing_stalk [IsRegularInCodimen
   rw [hdim] at this
   exact_mod_cast this
 
-end AlgebraicGeometry
+end AlgebraicGeometry.Scheme


### PR DESCRIPTION
In this PR, we define Serre's R_k condition. We also show that R_1 is equivalent to all local rings in codimension one being DVRs, though we show this under the assumption that the local rings are all domains. This assumption can be dropped once #28683 is merged.

AI disclosure: assisted by claude opus 5

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
