### PR TITLE
[Merged by Bors] - feat: add `AffineSubspace.le_of_direction_le`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -387,23 +387,20 @@ theorem mem_direction_iff_eq_vsub_left {s : AffineSubspace k P} {p : P} (hp : p 
 instance : CanLift (AffineSubspace k V) (Submodule k V) (·) (0 ∈ ·) :=
   ⟨fun _ hs => ⟨_, direction_eq_self_iff_zero_mem.mpr hs⟩⟩
 
-/-- Two affine subspaces with the same direction and nonempty intersection are equal. -/
-theorem ext_of_direction_eq {s₁ s₂ : AffineSubspace k P} (hd : s₁.direction = s₂.direction)
-    (hn : ((s₁ : Set P) ∩ s₂).Nonempty) : s₁ = s₂ := by
-  ext p
+theorem le_of_direction_le {s₁ s₂ : AffineSubspace k P} (hd : s₁.direction ≤ s₂.direction)
+    (hn : ((s₁ : Set P) ∩ s₂).Nonempty) : s₁ ≤ s₂ := by
+  intro p hp
   have hq1 := Set.mem_of_mem_inter_left hn.some_mem
   have hq2 := Set.mem_of_mem_inter_right hn.some_mem
-  constructor
-  · intro hp
-    rw [← vsub_vadd p hn.some]
-    refine vadd_mem_of_mem_direction ?_ hq2
-    rw [← hd]
-    exact vsub_mem_direction hp hq1
-  · intro hp
-    rw [← vsub_vadd p hn.some]
-    refine vadd_mem_of_mem_direction ?_ hq1
-    rw [hd]
-    exact vsub_mem_direction hp hq2
+  rw [← vsub_vadd p hn.some]
+  refine vadd_mem_of_mem_direction ?_ hq2
+  grw [← hd]
+  exact vsub_mem_direction hp hq1
+
+/-- Two affine subspaces with the same direction and nonempty intersection are equal. -/
+theorem ext_of_direction_eq {s₁ s₂ : AffineSubspace k P} (hd : s₁.direction = s₂.direction)
+    (hn : ((s₁ : Set P) ∩ s₂).Nonempty) : s₁ = s₂ :=
+  le_antisymm (le_of_direction_le hd.le hn) (le_of_direction_le hd.ge (inter_comm .. ▸ hn))
 
 /-- Two affine subspaces with nonempty intersection are equal if and only if their directions are
 equal. -/


### PR DESCRIPTION
The proof is extracted from `AffineSubspace.ext_of_direction_eq`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
