### PR TITLE
feat(MeasureTheory/Integral/Bochner/Basic): add enorm_integral_norm_eq_lintegral_enorm

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
@@ -515,6 +515,12 @@ theorem ofReal_integral_norm_eq_lintegral_enorm {P : Type*} [NormedAddCommGroup 
   rw [integral_norm_eq_lintegral_enorm hf.aestronglyMeasurable, ENNReal.ofReal_toReal]
   exact lt_top_iff_ne_top.mp (hasFiniteIntegral_iff_enorm.mpr hf.2)
 
+theorem enorm_integral_norm_eq_lintegral_enorm {P : Type*} [NormedAddCommGroup P] {f : α → P}
+  (hf : Integrable f μ) : ‖∫ x, ‖f x‖ ∂μ‖ₑ = ∫⁻ x, ‖f x‖ₑ ∂μ := by
+  rw [integral_norm_eq_lintegral_enorm hf.aestronglyMeasurable, Real.enorm_eq_ofReal toReal_nonneg,
+    ofReal_toReal]
+  exact lt_top_iff_ne_top.mp (hasFiniteIntegral_iff_enorm.mpr hf.2)
+
 theorem SimpleFunc.integral_eq_integral [CompleteSpace E] (f : α →ₛ E) (hfi : Integrable f μ) :
     f.integral μ = ∫ x, f x ∂μ := by
   rw [MeasureTheory.integral_eq f hfi, ← L1.SimpleFunc.toLp_one_eq_toL1,


### PR DESCRIPTION
From the Carleson project.

-------

**Upstreaming from Carleson: [/Carleson/ToMathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean](https://github.com/fpvandoorn/carleson/blob/0072b6e47ec58ac13be0a9f3b7c17e9f3bb1be2e/Carleson/ToMathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean)**

### In this PR

#### enorm_integral_norm_eq_lintegral_enorm

- renamed (`integral` -> `lintegral`) to match neighbouring lemmas
- generalized the statement (`{𝕜 : Type u_2} [RCLike 𝕜]` -> `{P : Type u_7} [NormedAddCommGroup P]`) to match neighbouring lemmas 
- refactored the proof body

```lean
-- CARLESON
enorm_integral_norm_eq_integral_enorm.{u_1, u_2} {α : Type u_1} {μ : Measure α}  (hf : Integrable f μ)
[MeasurableSpace α]
{𝕜 : Type u_2} [RCLike 𝕜] {f : α → 𝕜}
: ‖∫ (x : α), ‖f x‖ ∂μ‖ₑ = ∫⁻ (x : α), ‖f x‖ₑ ∂μ

-- MATHLIB
MeasureTheory.enorm_integral_norm_eq_lintegral_enorm.{u_1, u_7} {α : Type u_1} {μ : Measure α} (hf : Integrable f μ)
{m : MeasurableSpace α} 
{P : Type u_7} [NormedAddCommGroup P] {f : α → P} 
: ‖∫ (x : α), ‖f x‖ ∂μ‖ₑ = ∫⁻ (x : α), ‖f x‖ₑ ∂μ
```