### PR TITLE
feat(GroupTheory/DoubleCoset): add multiplicity for convolution product

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6576,6 +6576,8 @@ public import Mathlib.RepresentationTheory.Equiv
 public import Mathlib.RepresentationTheory.FDRep
 public import Mathlib.RepresentationTheory.FinGroupCharZero
 public import Mathlib.RepresentationTheory.FiniteIndex
+public import Mathlib.RepresentationTheory.Hecke.LeftFiniteDoubleCoset
+public import Mathlib.RepresentationTheory.Hecke.Multiplicity
 public import Mathlib.RepresentationTheory.Homological.ContCohomology.Basic
 public import Mathlib.RepresentationTheory.Homological.ContCohomology.Functoriality
 public import Mathlib.RepresentationTheory.Homological.ContCohomology.LowDegree

--- a/Mathlib/RepresentationTheory/Hecke/LeftFiniteDoubleCoset.lean
+++ b/Mathlib/RepresentationTheory/Hecke/LeftFiniteDoubleCoset.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 Jiaxi Mo. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jiaxi Mo
+-/
+module
+
+public import Mathlib.GroupTheory.DoubleCoset
+public import Mathlib.GroupTheory.GroupAction.Quotient
+
+/-!
+# Double cosets admitting finite left-coset decomposition
+
+This file introduces two indexing types for the left-coset decomposition: the intrinsic
+`LeftDecomposition` and the computational `LeftDecompQuotient`. They are equivalent via
+`toLeftDecompositionEquiv`. The first `LeftDecomposition` is useful for coordinate-free definitions
+and proofs, while the second `LeftDecompQuotient` carries a base point `gH₂` and remains useful for
+concrete convolution product computation.
+-/
+
+@[expose] public section
+
+variable {G : Type*} [Group G] {H₁ H₂ : Subgroup G} {g g' : G}
+
+open DoubleCoset Pointwise
+
+namespace DoubleCoset
+
+/-- Given a double coset `x`, the set of left cosets `{gH₂ | H₁gH₂ = x}`. -/
+def Quotient.leftDecomposition (x : Quotient (H₁ : Set G) (H₂ : Set G)) :
+    Set (G ⧸ H₂) :=
+  (Quotient.lift (fun g : G => mk H₁ H₂ g) (fun a b hab => by
+    rw [DoubleCoset.eq]
+    exact ⟨1, H₁.one_mem, _, QuotientGroup.leftRel_apply.mp hab, by simp⟩)) ⁻¹' {x}
+
+@[simp]
+lemma mem_leftDecomposition_mk {x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)} :
+    (g : G ⧸ H₂) ∈ x.leftDecomposition ↔ DoubleCoset.mk H₁ H₂ g = x := by
+  simp [Quotient.leftDecomposition]
+
+instance (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)) :
+    MulAction H₁ x.leftDecomposition where
+  smul h q := ⟨h • (q : G ⧸ H₂), by
+    rw [← QuotientGroup.out_eq' q.1, MulAction.subgroup_smul_def, MulAction.Quotient.smul_mk,
+      mem_leftDecomposition_mk, smul_eq_mul, mk_mem_mul]
+    simp [← mem_leftDecomposition_mk]⟩
+  one_smul q := Subtype.ext <| one_smul H₁ (q : G ⧸ H₂)
+  mul_smul h h' q := Subtype.ext <| mul_smul h h' (q : G ⧸ H₂)
+
+@[simp]
+lemma coe_smul_leftDecomposition {x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)} (h : H₁)
+    (y : x.leftDecomposition) :
+    ((h • y : x.leftDecomposition) : G ⧸ H₂) = (h : G) • (y : G ⧸ H₂) :=
+  rfl
+
+lemma stabilizer_leftCoset :
+    MulAction.stabilizer H₁ (g : G ⧸ H₂) = (ConjAct.toConjAct g • H₂).subgroupOf H₁ := by
+  ext h
+  have (x : G) : x ∈ ConjAct.toConjAct g • H₂ ↔ g⁻¹ * x * g ∈ H₂ := by
+    rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv, ConjAct.smul_def,
+      ConjAct.ofConjAct_toConjAct, inv_inv]
+  simp [Subgroup.mem_subgroupOf, this, eq_comm, QuotientGroup.eq, MulAction.subgroup_smul_def,
+    mul_assoc]
+
+variable (H₁ H₂ g) in
+/-- The quotient `H₁ ⧸ (H₁ ∩ gH₂g⁻¹)` indexing the left cosets `h₁gH₂` inside the double coset
+`H₁gH₂`. See also `DoubleCoset.stabilizer_leftCoset`. -/
+abbrev leftDecompQuotient := H₁ ⧸ MulAction.stabilizer H₁ (g : G ⧸ H₂)
+
+namespace leftDecompQuotient
+
+/-- The map sending `⟦h₁⟧` to `h₁gH₂`. -/
+def toLeftCoset :
+    leftDecompQuotient H₁ H₂ g → G ⧸ H₂ :=
+  MulAction.ofQuotientStabilizer H₁ (g : G ⧸ H₂)
+
+@[simp]
+lemma toLeftCoset_mk (h : H₁) :
+    toLeftCoset (h : leftDecompQuotient H₁ H₂ g) = ((h : G) * g : G ⧸ H₂) := by
+  simp [toLeftCoset, MulAction.subgroup_smul_def]
+
+lemma toLeftCoset_injective :
+    Function.Injective (toLeftCoset (H₁ := H₁) (H₂ := H₂) (g := g)) :=
+  MulAction.injective_ofQuotientStabilizer H₁ (g : G ⧸ H₂)
+
+lemma mem_range_toLeftCoset_iff :
+    (∃ i, toLeftCoset (H₁ := H₁) (g := g) i = (g' : G ⧸ H₂)) ↔ mk H₁ H₂ g = mk H₁ H₂ g' := by
+  constructor
+  · intro ⟨h, heq⟩
+    rw [← QuotientGroup.out_eq' h, toLeftCoset_mk, QuotientGroup.eq] at heq
+    exact DoubleCoset.eq.mpr ⟨_, h.out.prop, _, heq, by simp [mul_assoc]⟩
+  · intro h
+    obtain ⟨h₁, hh₁, h₂, hh₂, rfl⟩ := DoubleCoset.eq.mp h
+    exact ⟨QuotientGroup.mk ⟨h₁, hh₁⟩, by simp [hh₂]⟩
+
+/-- The equivalence between `H₁ ⧸ (H₁ ∩ gH₂g⁻¹)` and `{xH₂ | H₁xH₂ = H₁gH₂}`. -/
+@[simps! apply]
+noncomputable def toLeftDecompositionEquiv :
+    leftDecompQuotient H₁ H₂ g ≃ (mk H₁ H₂ g).leftDecomposition :=
+  (Equiv.ofInjective toLeftCoset toLeftCoset_injective).trans (Set.equivOfEq (by
+      ext x
+      rw [← QuotientGroup.out_eq' x, Set.mem_range, mem_range_toLeftCoset_iff,
+        mem_leftDecomposition_mk, eq_comm]))
+
+end leftDecompQuotient
+
+end DoubleCoset

--- a/Mathlib/RepresentationTheory/Hecke/Multiplicity.lean
+++ b/Mathlib/RepresentationTheory/Hecke/Multiplicity.lean
@@ -85,13 +85,13 @@ lemma multiplicity_mk_mk_mk (u v w : G) {ι κ : Type*}
     (f := fun ⟨p, hp⟩ => ⟨(σ p.1).val * u, ⟨by simp, by simp [← Set.mem_ofPred.mp hp, mul_assoc]⟩⟩)
   · intro ⟨⟨x1, x2⟩, hx⟩ ⟨⟨y1, y2⟩, hy⟩ heq
     simp only [Subtype.mk.injEq] at heq ⊢
-    -- We obtain injectivity from  `H₁/(gH₂g⁻¹ ∩ H₁) ↪ G ⧸ H₂` and `axH₃ = ayH₃ ↔ xH₃ = yH₃`
+    -- We obtain injectivity from  `H₁/(gH₂g⁻¹ ∩ H₁) ↪ G ⧸ H₂` and `axH₃ = ayH₃ ↔ xH₃ = yH₃`.
     obtain rfl : x1 = y1 := hσ.injective <| toLeftCoset_injective (by simp [heq])
     obtain rfl : x2 = y2 := hτ.injective <| toLeftCoset_injective (by
       simpa [mul_assoc] using congrArg ((σ x1 * u)⁻¹ • ·) (hx.trans hy.symm))
     rfl
   · intro ⟨d, hd, hrel⟩
-    -- We construct inverse `⟨i, j⟩` s.t. `(σ i * u)H₂ = d` `(τ j * v)H₃ = (σ i * u)⁻¹wH₃`
+    -- We construct the inverse `⟨i, j⟩` s.t. `(σ i * u)H₂ = d` `(τ j * v)H₃ = (σ i * u)⁻¹wH₃`.
     simp only [Set.mem_ofPred_eq, Subtype.mk.injEq, Subtype.exists, exists_prop, Prod.exists]
     obtain ⟨i, hi⟩ := toLeftDecompositionEquiv.surjective.comp hσ.surjective ⟨d, hd⟩
     simp only [Function.comp_apply, toLeftDecompositionEquiv_apply, toLeftCoset_mk,

--- a/Mathlib/RepresentationTheory/Hecke/Multiplicity.lean
+++ b/Mathlib/RepresentationTheory/Hecke/Multiplicity.lean
@@ -6,6 +6,7 @@ Authors: Jiaxi Mo
 module
 
 public import Mathlib.RepresentationTheory.Hecke.LeftFiniteDoubleCoset
+public import Mathlib.SetTheory.Cardinal.Finite
 
 /-!
 # Multiplicity of the convolution product
@@ -13,7 +14,6 @@ public import Mathlib.RepresentationTheory.Hecke.LeftFiniteDoubleCoset
 This file defines the multiplicity for a triple of double cosets: the coefficient with which the
 third occurs in the convolution product of the first two. We also provide a flexible computation
 lemma `multiplicity_mk_mk_mk` that allows arbitrary representatives to be chosen.
-
 -/
 
 @[expose] public section

--- a/Mathlib/RepresentationTheory/Hecke/Multiplicity.lean
+++ b/Mathlib/RepresentationTheory/Hecke/Multiplicity.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 Jiaxi Mo. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jiaxi Mo
+-/
+module
+
+public import Mathlib.RepresentationTheory.Hecke.LeftFiniteDoubleCoset
+
+/-!
+# Multiplicity of the convolution product
+
+This file defines the multiplicity for a triple of double cosets: the coefficient with which the
+third occurs in the convolution product of the first two. We also provide a flexible computation
+lemma `multiplicity_mk_mk_mk` that allows arbitrary representatives to be chosen.
+
+-/
+
+@[expose] public section
+
+variable {G : Type*} [Group G] {H₁ H₂ H₃ : Subgroup G}
+open DoubleCoset
+
+namespace DoubleCoset
+
+/-- The map sending `(gH₁, g'H₂)` to `H₁g⁻¹g'H₂`. -/
+def relPosition : G ⧸ H₁ → G ⧸ H₂ → DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G) :=
+  Quotient.lift₂ (fun g g' : G => mk H₁ H₂ (g⁻¹ * g')) fun _ _ _ _ ha hb => by
+    rw [eq]
+    exact ⟨_, H₁.inv_mem (QuotientGroup.leftRel_apply.mp ha), _,
+      QuotientGroup.leftRel_apply.mp hb, by simp [mul_assoc]⟩
+
+@[simp]
+lemma relPosition_mk_mk (g g' : G) :
+    relPosition (g : G ⧸ H₁) (g' : G ⧸ H₂) = mk H₁ H₂ (g⁻¹ * g') := rfl
+
+@[simp]
+lemma relPosition_smul (g : G) (c : G ⧸ H₁) (d : G ⧸ H₂) :
+    relPosition (g • c) d = relPosition c (g⁻¹ • d) := by
+  rw [← QuotientGroup.out_eq' c, ← QuotientGroup.out_eq' d, MulAction.Quotient.smul_mk,
+    MulAction.Quotient.smul_mk, relPosition_mk_mk, relPosition_mk_mk]
+  simp [mul_assoc]
+
+lemma relPosition_one_eq_iff {x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G)} {c : G ⧸ H₂} :
+    relPosition ((1 : G) : G ⧸ H₁) c = x ↔ c ∈ x.leftDecomposition := by
+  rw [← QuotientGroup.out_eq' c, relPosition_mk_mk, mem_leftDecomposition_mk]
+  simp
+
+/-- The number of left cosets `aH₂ ⊆ x` such that `H₂a⁻¹bH₃ = y` for any fixed left coset `bH₃ ⊆ z`,
+or `0` if there are infinitely many. See `multiplicity_mk_mk_mk` for a computation lemma. -/
+noncomputable def Quotient.multiplicity (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G))
+    (y : DoubleCoset.Quotient (H₂ : Set G) (H₃ : Set G))
+    (z : DoubleCoset.Quotient (H₁ : Set G) (H₃ : Set G)) :
+    ℕ :=
+  Quotient.liftOn z (fun g => Nat.card {d ∈ x.leftDecomposition | relPosition d g = y})
+    fun g g' h => by
+      obtain ⟨h₁ ,hh₁, h₃, hh₃, rfl⟩ := rel_iff.mp h
+      exact Nat.card_congr <| Equiv.subtypeEquiv (MulAction.toPerm h₁) fun c =>
+        QuotientGroup.induction_on c (by simp [hh₃, mk_mem_mul ⟨_, hh₁⟩])
+
+lemma multiplicity_mk (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G))
+    (y : DoubleCoset.Quotient (H₂ : Set G) (H₃ : Set G)) (g : G) :
+    x.multiplicity y (mk H₁ H₃ g) =  Nat.card {d ∈ x.leftDecomposition | relPosition d g = y} :=
+  rfl
+
+lemma multiplicity_of_mem (x : DoubleCoset.Quotient (H₁ : Set G) (H₂ : Set G))
+    (y : DoubleCoset.Quotient (H₂ : Set G) (H₃ : Set G))
+    (z : DoubleCoset.Quotient (H₁ : Set G) (H₃ : Set G))
+    {c : G ⧸ H₃} (hc : c ∈ z.leftDecomposition) :
+    x.multiplicity y z = Nat.card {d ∈ x.leftDecomposition | relPosition d c = y} := by
+  rw [← QuotientGroup.out_eq' c] at hc ⊢
+  have : mk H₁ H₃ c.out = z := mem_leftDecomposition_mk.mp hc
+  rw [← this, multiplicity_mk]
+
+open leftDecompQuotient in
+/-- The computation formula for multiplicity with given representatives of doublecosets and
+left-coset decompositions. -/
+lemma multiplicity_mk_mk_mk (u v w : G) {ι κ : Type*}
+    {σ : ι → H₁} (hσ : Function.Bijective fun i => (σ i : leftDecompQuotient H₁ H₂ u))
+    {τ : κ → H₂} (hτ : Function.Bijective fun j => (τ j : leftDecompQuotient H₂ H₃ v)) :
+    (mk H₁ H₂ u).multiplicity (mk H₂ H₃ v) (mk H₁ H₃ w) =
+      Nat.card {p : ι × κ | (σ p.1 * u * (τ p.2 * v) : G ⧸ H₃) = (w : G ⧸ H₃)} := by
+  rw [multiplicity_mk, eq_comm]
+  refine Nat.card_eq_of_bijective ⟨?_, ?_⟩
+    (f := fun ⟨p, hp⟩ => ⟨(σ p.1).val * u, ⟨by simp, by simp [← Set.mem_ofPred.mp hp, mul_assoc]⟩⟩)
+  · intro ⟨⟨x1, x2⟩, hx⟩ ⟨⟨y1, y2⟩, hy⟩ heq
+    simp only [Subtype.mk.injEq] at heq ⊢
+    -- We obtain injectivity from  `H₁/(gH₂g⁻¹ ∩ H₁) ↪ G ⧸ H₂` and `axH₃ = ayH₃ ↔ xH₃ = yH₃`
+    obtain rfl : x1 = y1 := hσ.injective <| toLeftCoset_injective (by simp [heq])
+    obtain rfl : x2 = y2 := hτ.injective <| toLeftCoset_injective (by
+      simpa [mul_assoc] using congrArg ((σ x1 * u)⁻¹ • ·) (hx.trans hy.symm))
+    rfl
+  · intro ⟨d, hd, hrel⟩
+    -- We construct inverse `⟨i, j⟩` s.t. `(σ i * u)H₂ = d` `(τ j * v)H₃ = (σ i * u)⁻¹wH₃`
+    simp only [Set.mem_ofPred_eq, Subtype.mk.injEq, Subtype.exists, exists_prop, Prod.exists]
+    obtain ⟨i, hi⟩ := toLeftDecompositionEquiv.surjective.comp hσ.surjective ⟨d, hd⟩
+    simp only [Function.comp_apply, toLeftDecompositionEquiv_apply, toLeftCoset_mk,
+      Subtype.ext_iff] at hi
+    obtain ⟨j, hj⟩ := toLeftDecompositionEquiv.surjective.comp hτ.surjective
+      ⟨((σ i * u)⁻¹ * w : G ⧸ H₃), by rw [mem_leftDecomposition_mk, ← relPosition_mk_mk, hi, hrel]⟩
+    exact ⟨i, j, by simpa [mul_assoc] using congrArg ((σ i * u) • ·) (Subtype.ext_iff.mp hj), hi⟩
+
+end DoubleCoset


### PR DESCRIPTION
This file defines the multiplicity for a triple of double cosets: the coefficient with which the third occurs in the convolution product of the first two. The definition itself is defined **intrinsically at the quotient level**, i.e. not using on any choice of representatives like `Quotient.out`. Then we also provide a flexible computation lemma `multiplicity_mk_mk_mk` that allows arbitrary representatives to be chosen.

co-authored with @claude opus 5 who gave a nice proof for `multiplicity_mk_mk_mk` in a minute

- [ ] depends on: #43327 