### PR TITLE
[Merged by Bors] - feat(Data): two appended lists are sorted iff

### DIFF
--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -689,6 +689,60 @@ theorem sortedLE_insertionSort : (l.insertionSort (· ≤ ·)).SortedLE :=
 theorem sortedGE_insertionSort : (l.insertionSort (· ≥ ·)).SortedGE :=
   (pairwise_insertionSort _ _).sortedGE
 
+@[grind =]
+theorem sortedLE_append {l₁ l₂ : List α} :
+    SortedLE (l₁ ++ l₂) ↔ SortedLE l₁ ∧ SortedLE l₂ ∧ ∀ᵉ (a ∈ l₁) (b ∈ l₂), a ≤ b := by
+  rw [sortedLE_iff_pairwise, sortedLE_iff_pairwise, sortedLE_iff_pairwise, pairwise_append]
+
+@[grind =]
+theorem sortedGE_append {l₁ l₂ : List α} :
+    SortedGE (l₁ ++ l₂) ↔ SortedGE l₁ ∧ SortedGE l₂ ∧ ∀ᵉ (a ∈ l₁) (b ∈ l₂), a ≥ b := by
+  rw [sortedGE_iff_pairwise, sortedGE_iff_pairwise, sortedGE_iff_pairwise, pairwise_append]
+
+@[grind =]
+theorem sortedLT_append {l₁ l₂ : List α} :
+    SortedLT (l₁ ++ l₂) ↔ SortedLT l₁ ∧ SortedLT l₂ ∧ ∀ᵉ (a ∈ l₁) (b ∈ l₂), a < b := by
+  rw [sortedLT_iff_pairwise, sortedLT_iff_pairwise, sortedLT_iff_pairwise, pairwise_append]
+
+@[grind =]
+theorem sortedGT_append {l₁ l₂ : List α} :
+    SortedGT (l₁ ++ l₂) ↔ SortedGT l₁ ∧ SortedGT l₂ ∧ ∀ᵉ (a ∈ l₁) (b ∈ l₂), a > b := by
+  rw [sortedGT_iff_pairwise, sortedGT_iff_pairwise, sortedGT_iff_pairwise, pairwise_append]
+
+section
+
+variable {a : α}
+
+@[simp]
+theorem sortedLE_cons : SortedLE (a :: l) ↔ (∀ b ∈ l, a ≤ b) ∧ SortedLE l := by
+  simp [sortedLE_iff_pairwise]
+
+@[simp]
+theorem sortedGE_cons : SortedGE (a :: l) ↔ (∀ b ∈ l, b ≤ a) ∧ SortedGE l := by
+  simp [sortedGE_iff_pairwise]
+
+@[simp]
+theorem sortedLT_cons : SortedLT (a :: l) ↔ (∀ b ∈ l, a < b) ∧ SortedLT l := by
+  simp [sortedLT_iff_pairwise]
+
+@[simp]
+theorem sortedGT_cons : SortedGT (a :: l) ↔ (∀ b ∈ l, b < a) ∧ SortedGT l := by
+  simp [sortedGT_iff_pairwise]
+
+theorem sortedLE_concat : SortedLE (l.concat a) ↔ (∀ b ∈ l, b ≤ a) ∧ SortedLE l := by
+  grind
+
+theorem sortedGE_concat : SortedLE (l.concat a) ↔ (∀ b ∈ l, b ≤ a) ∧ SortedLE l := by
+  grind
+
+theorem sortedLT_concat : SortedLT (l.concat a) ↔ (∀ b ∈ l, b < a) ∧ SortedLT l := by
+  grind
+
+theorem sortedGT_concat : SortedGT (l.concat a) ↔ (∀ b ∈ l, a < b) ∧ SortedGT l := by
+  grind
+
+end
+
 @[simp]
 theorem SortedLT.getElem_le_getElem_iff (hl : l.SortedLT) {i j} {hi : i < l.length}
     {hj : j < l.length} : l[i] ≤ l[j] ↔ i ≤ j := hl.strictMono_get.le_iff_le

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -696,7 +696,7 @@ theorem sortedLE_append {l₁ l₂ : List α} :
 
 @[grind =]
 theorem sortedGE_append {l₁ l₂ : List α} :
-    SortedGE (l₁ ++ l₂) ↔ SortedGE l₁ ∧ SortedGE l₂ ∧ ∀ᵉ (a ∈ l₁) (b ∈ l₂), a ≥ b := by
+    SortedGE (l₁ ++ l₂) ↔ SortedGE l₁ ∧ SortedGE l₂ ∧ ∀ᵉ (a ∈ l₁) (b ∈ l₂), b ≤ a := by
   rw [sortedGE_iff_pairwise, sortedGE_iff_pairwise, sortedGE_iff_pairwise, pairwise_append]
 
 @[grind =]
@@ -706,7 +706,7 @@ theorem sortedLT_append {l₁ l₂ : List α} :
 
 @[grind =]
 theorem sortedGT_append {l₁ l₂ : List α} :
-    SortedGT (l₁ ++ l₂) ↔ SortedGT l₁ ∧ SortedGT l₂ ∧ ∀ᵉ (a ∈ l₁) (b ∈ l₂), a > b := by
+    SortedGT (l₁ ++ l₂) ↔ SortedGT l₁ ∧ SortedGT l₂ ∧ ∀ᵉ (a ∈ l₁) (b ∈ l₂), b < a := by
   rw [sortedGT_iff_pairwise, sortedGT_iff_pairwise, sortedGT_iff_pairwise, pairwise_append]
 
 section
@@ -732,7 +732,7 @@ theorem sortedGT_cons : SortedGT (a :: l) ↔ (∀ b ∈ l, b < a) ∧ SortedGT 
 theorem sortedLE_concat : SortedLE (l.concat a) ↔ (∀ b ∈ l, b ≤ a) ∧ SortedLE l := by
   grind
 
-theorem sortedGE_concat : SortedLE (l.concat a) ↔ (∀ b ∈ l, b ≤ a) ∧ SortedLE l := by
+theorem sortedGE_concat : SortedGE (l.concat a) ↔ (∀ b ∈ l, a ≤ b) ∧ SortedGE l := by
   grind
 
 theorem sortedLT_concat : SortedLT (l.concat a) ↔ (∀ b ∈ l, b < a) ∧ SortedLT l := by


### PR DESCRIPTION
Like #43454.

Of course this can also be stated with min/max, which we should also have. But I do think these versions are useful as well

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
