### PR TITLE
[Merged by Bors] - feat(MeasureTheory/Integral/CircleAverage): add norm_circleAverage_le_circleAverage_norm

### DIFF
--- a/Mathlib/MeasureTheory/Integral/CircleAverage.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleAverage.lean
@@ -288,15 +288,20 @@ theorem circleAverage_mono_on_of_le_circle {f : ℂ → ℝ} {a : ℝ} (hf : Cir
   exact intervalIntegral.integral_mono_on_of_le_Ioo (le_of_lt two_pi_pos) hf
     intervalIntegrable_const (fun θ _ ↦ h₂f (circleMap c R θ) (circleMap_mem_sphere' c R θ))
 
+theorem norm_circleAverage_le_circleAverage_norm :
+    ‖circleAverage f c R‖ ≤ circleAverage (fun z ↦ ‖f z‖) c R := by
+  simp only [circleAverage_def, norm_smul, smul_eq_mul]
+  gcongr
+  · simp [abs_of_nonneg pi_nonneg]
+  · exact intervalIntegral.norm_integral_le_integral_norm (by positivity)
+
 /--
 Analogue of `intervalIntegral.abs_integral_le_integral_abs`: The absolute value of a circle average
 is less than or equal to the circle average of the absolute value of the function.
 -/
 theorem abs_circleAverage_le_circleAverage_abs {f : ℂ → ℝ} :
     |circleAverage f c R| ≤ circleAverage |f| c R := by
-  rw [circleAverage, circleAverage, smul_eq_mul, smul_eq_mul, abs_mul,
-    abs_of_pos (inv_pos.2 two_pi_pos), mul_le_mul_iff_of_pos_left (inv_pos.2 two_pi_pos)]
-  exact intervalIntegral.abs_integral_le_integral_abs (le_of_lt two_pi_pos)
+  simpa [← norm_eq_abs, Pi.abs_def] using norm_circleAverage_le_circleAverage_norm
 
 /--
 The circle average of a nonnegative function is nonnegative.


### PR DESCRIPTION

Adds norm_circleAverage_le_circleAverage_norm which is more general than the existing result for abs. Uses the new norm result to simplify the proof for abs.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)