### PR TITLE
[Merged by Bors] - feat(AffineIndependent): add `AffineIndepOn`

### DIFF
--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -497,4 +497,11 @@ lemma cons_swap (a : α) (x : Fin n → α) (i j : Fin n) :
 
 end swap
 
+@[simp]
+lemma injective_pair_iff_ne {x y : α} : Function.Injective ![x, y] ↔ x ≠ y := by
+  simp [Function.Injective, Fin.forall_fin_two, eq_comm]
+
+@[deprecated Matrix.injective_pair_iff_ne (since := "2026-09-04")]
+alias _root_.injective_pair_iff_ne := injective_pair_iff_ne
+
 end Matrix

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -190,6 +190,22 @@ theorem AffineIndependent.vectorSpan_eq_top_of_card_eq_finrank_add_one [FiniteDi
     vectorSpan k (Set.range p) = ⊤ :=
   Submodule.eq_top_of_finrank_eq <| hi.finrank_vectorSpan hc
 
+/-- The `vectorSpan` of the image of an affinely independent finite nonempty set has dimension one
+less than its cardinality. -/
+theorem AffineIndepOn.finrank_vectorSpan_image {p : ι → P} {s : Set ι} (hs₁ : s.Finite)
+    (hs₂ : s.Nonempty) (hi : AffineIndepOn k p s) :
+    finrank k (vectorSpan k (p '' s)) = s.ncard - 1 := by
+  have := hs₁.fintype
+  rw [Set.image_eq_range]
+  apply hi.affineIndependent.finrank_vectorSpan
+  simp [Nat.sub_add_cancel <| (Set.ncard_pos hs₁).mpr hs₂]
+
+/-- The `vectorSpan` of an affinely independent finite nonempty set has dimension one less than its
+cardinality. -/
+theorem AffineIndepOn.finrank_vectorSpan {s : Set P} (hs₁ : s.Finite) (hs₂ : s.Nonempty)
+    (hi : AffineIndepOn k id s) : finrank k (vectorSpan k s) = s.ncard - 1 := by
+  rw [← hi.finrank_vectorSpan_image hs₁ hs₂, Set.image_id]
+
 namespace Affine.Simplex
 
 /-- A convenience instance for use when restricting to the affine subspace spanned by the vertices

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -25,6 +25,9 @@ This file defines affinely independent families of points.
   points in the family, or any equal affine combinations having the
   same weights.
 
+* `AffineIndepOn k p s` states that the points of a family `p : ι → P`
+  indexed by the elements of `s : Set ι` are affinely independent.
+
 ## References
 
 * https://en.wikipedia.org/wiki/Affine_space
@@ -50,6 +53,10 @@ def AffineIndependent (p : ι → P) : Prop :=
   ∀ (s : Finset ι) (w : ι → k),
     ∑ i ∈ s, w i = 0 → s.weightedVSub p w = (0 : V) → ∀ i ∈ s, w i = 0
 
+/-- `AffineIndepOn k p s` states that the points in the family `p` that are indexed
+by the elements of `s` are affinely independent over `k`. -/
+def AffineIndepOn (p : ι → P) (s : Set ι) : Prop := AffineIndependent k (fun x : s ↦ p x)
+
 /-- The definition of `AffineIndependent`. -/
 theorem affineIndependent_def (p : ι → P) :
     AffineIndependent k p ↔
@@ -57,9 +64,46 @@ theorem affineIndependent_def (p : ι → P) :
         ∑ i ∈ s, w i = 0 → s.weightedVSub p w = (0 : V) → ∀ i ∈ s, w i = 0 :=
   Iff.rfl
 
+variable {k} in
+theorem AffineIndepOn.affineIndependent {p : ι → P} {s : Set ι} (h : AffineIndepOn k p s) :
+    AffineIndependent k (fun x : s ↦ p x) := h
+
+theorem affineIndependent_set_coe_iff {p : ι → P} {s : Set ι} :
+    AffineIndependent k (fun x : s ↦ p x) ↔ AffineIndepOn k p s :=
+  Iff.rfl
+
 /-- A family with at most one point is affinely independent. -/
 theorem affineIndependent_of_subsingleton [Subsingleton ι] (p : ι → P) : AffineIndependent k p :=
   fun _ _ h _ i hi => Fintype.eq_of_subsingleton_of_sum_eq h i hi
+
+/-- A set with at most one point is affinely independent. -/
+theorem AffineIndepOn.of_subsingleton' (p : ι → P) {s : Set ι} (hs : s.Subsingleton) :
+    AffineIndepOn k p s :=
+  have := (Set.subsingleton_coe s).mpr hs
+  affineIndependent_of_subsingleton _ _
+
+@[nontriviality]
+theorem AffineIndependent.of_subsingleton [Subsingleton k] (p : ι → P) : AffineIndependent k p :=
+  fun _ _ _ _ _ _ ↦ Subsingleton.elim _ _
+
+@[nontriviality]
+theorem AffineIndepOn.of_subsingleton [Subsingleton k] (p : ι → P) (s : Set ι) :
+    AffineIndepOn k p s :=
+  AffineIndependent.of_subsingleton _ _
+
+@[simp]
+lemma AffineIndepOn.singleton (p : ι → P) (i : ι) : AffineIndepOn k p {i} :=
+  .of_subsingleton' k p Set.subsingleton_singleton
+
+theorem affineIndependent_empty_type [IsEmpty ι] (p : ι → P) : AffineIndependent k p :=
+  affineIndependent_of_subsingleton _ _
+
+@[simp]
+theorem affineIndepOn_empty (p : ι → P) : AffineIndepOn k p ∅ :=
+  .of_subsingleton' k p Set.subsingleton_empty
+
+theorem affineIndependent_subtype_iff {s : Set P} :
+    AffineIndependent k (Subtype.val : s → P) ↔ AffineIndepOn k id s := Iff.rfl
 
 /-- A family indexed by a `Fintype` is affinely independent if and
 only if no nontrivial weighted subtractions over `Finset.univ` (where
@@ -246,6 +290,12 @@ theorem LinearIndependent.affineIndependent
   simp only [vsub_eq_sub, sub_zero] at hwv
   exact linearIndependent_iff'.mp hv s w hwv i hi
 
+variable {k} in
+/-- A linearly independent family of vectors, restricted to `s`, is also affinely independent. -/
+theorem LinearIndepOn.affineIndepOn {v : ι → V} {s : Set ι} (hv : LinearIndepOn k v s) :
+    AffineIndepOn k v s :=
+  hv.linearIndependent.affineIndependent
+
 variable {k}
 
 /-- If we single out one member of an affine-independent family of points and affinely transport
@@ -285,6 +335,10 @@ protected theorem AffineIndependent.injective [Nontrivial k] {p : ι → P}
   by_contra hij'
   refine ha.ne_zero ⟨i, hij'⟩ (vsub_eq_zero_iff_eq.mpr ?_)
   simp_all only [ne_eq]
+
+theorem AffineIndepOn.injOn [Nontrivial k] {p : ι → P} {s : Set ι} (hs : AffineIndepOn k p s) :
+    Set.InjOn p s :=
+  Set.injOn_iff_injective.mpr hs.injective
 
 /-- If a family is affinely independent, so is any subfamily given by
 composition of an embedding into index type with the original
@@ -337,6 +391,63 @@ theorem affineIndependent_equiv {ι' : Type*} (e : ι ≃ ι') {p : ι' → P} :
   rw [this]
   exact h.comp_embedding e.symm.toEmbedding
 
+theorem affineIndependent_equiv' {ι' : Type*} (e : ι ≃ ι') {f : ι' → P} {g : ι → P}
+    (h : f ∘ e = g) : AffineIndependent k g ↔ AffineIndependent k f :=
+  h ▸ affineIndependent_equiv e
+
+theorem affineIndepOn_equiv {ι' : Type*} (e : ι ≃ ι') {f : ι' → P} {s : Set ι} :
+    AffineIndepOn k (f ∘ e) s ↔ AffineIndepOn k f (e '' s) :=
+  affineIndependent_equiv' (e.image s) <| by simp [funext_iff]
+
+@[simp]
+theorem affineIndepOn_univ_iff {p : ι → P} : AffineIndepOn k p Set.univ ↔ AffineIndependent k p :=
+  affineIndependent_equiv' (Equiv.Set.univ ι) rfl
+
+alias ⟨_, AffineIndependent.affineIndepOn_univ⟩ := affineIndepOn_univ_iff
+
+theorem AffineIndependent.affineIndepOn {p : ι → P} (h : AffineIndependent k p) (s : Set ι) :
+    AffineIndepOn k p s :=
+  h.subtype s
+
+theorem AffineIndependent.affineIndepOn_id {p : ι → P} (h : AffineIndependent k p) :
+    AffineIndepOn k id (Set.range p) :=
+  h.range
+
+theorem affineIndepOn_iff_image {s : Set ι} {f : ι → P} (hf : Set.InjOn f s) :
+    AffineIndepOn k f s ↔ AffineIndepOn k id (f '' s) :=
+  affineIndependent_equiv' (Equiv.Set.imageOfInjOn _ _ hf) rfl
+
+theorem AffineIndepOn.id_image {p : ι → P} {s : Set ι} (hs : AffineIndepOn k p s) :
+    AffineIndepOn k id (p '' s) := by
+  nontriviality k
+  exact (affineIndepOn_iff_image hs.injOn).mp hs
+
+theorem affineIndepOn_iff_affineIndepOn_image_injOn [Nontrivial k] {p : ι → P} {s : Set ι} :
+    AffineIndepOn k p s ↔ AffineIndepOn k id (p '' s) ∧ Set.InjOn p s :=
+  ⟨fun h ↦ ⟨h.id_image, h.injOn⟩, fun h ↦ (affineIndepOn_iff_image h.2).mpr h.1⟩
+
+theorem AffineIndepOn.comp_of_image {ι' : Type*} {s : Set ι'} {f : ι' → ι} {p : ι → P}
+    (h : AffineIndepOn k p (f '' s)) (hf : Set.InjOn f s) : AffineIndepOn k (p ∘ f) s :=
+  h.comp_embedding (Equiv.Set.imageOfInjOn f s hf).toEmbedding
+
+theorem AffineIndepOn.image_of_comp {ι' : Type*} {s : Set ι} (f : ι → ι') (g : ι' → P)
+    (hs : AffineIndepOn k (g ∘ f) s) : AffineIndepOn k g (f '' s) := by
+  nontriviality k
+  exact (affineIndependent_equiv'
+    (Equiv.Set.imageOfInjOn f s (Set.injOn_iff_injective.mpr hs.injective.of_comp)) rfl).mp hs
+
+theorem affineIndepOn_range_iff {ι' : Type*} {f : ι → ι'} (hf : Injective f) (g : ι' → P) :
+    AffineIndepOn k g (Set.range f) ↔ AffineIndependent k (g ∘ f) :=
+  affineIndependent_equiv' (Equiv.ofInjective f hf) rfl |>.symm
+
+alias ⟨AffineIndependent.of_affineIndepOn_range, _⟩ := affineIndepOn_range_iff
+
+theorem affineIndepOn_id_range_iff {f : ι → P} (hf : Injective f) :
+    AffineIndepOn k id (Set.range f) ↔ AffineIndependent k f :=
+  affineIndepOn_range_iff hf id
+
+alias ⟨AffineIndependent.of_affineIndepOn_id_range, _⟩ := affineIndepOn_id_range_iff
+
 /-- Swapping the first two points preserves affine independence. -/
 theorem AffineIndependent.comm_left {p₁ p₂ p₃ : P} (h : AffineIndependent k ![p₁, p₂, p₃]) :
     AffineIndependent k ![p₂, p₁, p₃] := by
@@ -366,6 +477,22 @@ protected theorem AffineIndependent.mono {s t : Set P}
     (ha : AffineIndependent k (fun x => x : t → P)) (hs : s ⊆ t) :
     AffineIndependent k (fun x => x : s → P) :=
   ha.comp_embedding (s.embeddingOfSubset t hs)
+
+/-- If a set of points is affinely independent, so is any subset. -/
+protected theorem AffineIndepOn.mono {p : ι → P} {s t : Set ι} (hs : AffineIndepOn k p s)
+    (h : t ⊆ s) : AffineIndepOn k p t :=
+  hs.comp_embedding ⟨_, Set.inclusion_injective h⟩
+
+theorem affineIndepOn_congr {p q : ι → P} {s : Set ι} (h : Set.EqOn p q s) :
+    AffineIndepOn k p s ↔ AffineIndepOn k q s := by
+  rw [AffineIndepOn, AffineIndepOn]
+  convert! Iff.rfl using 2
+  ext x
+  exact h.symm x.2
+
+theorem AffineIndepOn.congr {p q : ι → P} {s : Set ι} (hp : AffineIndepOn k p s)
+    (h : Set.EqOn p q s) : AffineIndepOn k q s :=
+  (affineIndepOn_congr h).mp hp
 
 /-- If the range of an injective indexed family of points is affinely
 independent, so is that family. -/
@@ -408,6 +535,13 @@ lemma AffineIndependent.indicator_extend_eq_of_affineCombination_comp_embedding_
     Set.indicator (Set.range e) (extend e w₂ 0) = w₁ := by
   simpa using ha.indicator_extend_eq_of_affineCombination_comp_embedding_eq hw₁ hw₂ e h
 
+theorem affineIndepOn_iff_linearIndepOn_vsub {p : ι → P} {s : Set ι} {i : ι} (hi : i ∈ s) :
+    AffineIndepOn k p s ↔ LinearIndepOn k (fun j ↦ p j -ᵥ p i) (s \ {i}) := by
+  rw [← affineIndependent_set_coe_iff, affineIndependent_iff_linearIndependent_vsub _ _ ⟨i, hi⟩,
+    ← linearIndependent_set_coe_iff]
+  exact linearIndependent_equiv'
+    ((Equiv.subtypeEquivRight (by simp)).trans (Equiv.Set.sep s (· ≠ i)).symm) rfl
+
 section Composition
 
 variable {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k V₂] [AffineSpace V₂ P₂]
@@ -424,6 +558,12 @@ theorem AffineIndependent.of_comp {p : ι → P} (f : P →ᵃ[k] P₂) (hai : A
     f.linearMap_vsub] at hai
   exact LinearIndependent.of_comp f.linear hai
 
+/-- If the image of a set of points in affine space under an affine transformation is affine-
+independent, then the original set of points is also affine-independent. -/
+theorem AffineIndepOn.of_comp {s : Set ι} {p : ι → P} (f : P →ᵃ[k] P₂)
+    (hai : AffineIndepOn k (f ∘ p) s) : AffineIndepOn k p s :=
+  AffineIndependent.of_comp f hai
+
 /-- The image of a family of points in affine space, under an injective affine transformation, is
 affine-independent. -/
 theorem AffineIndependent.map' {p : ι → P} (hai : AffineIndependent k p) (f : P →ᵃ[k] P₂)
@@ -437,15 +577,31 @@ theorem AffineIndependent.map' {p : ι → P} (hai : AffineIndependent k p) (f :
   have hf' : LinearMap.ker f.linear = ⊥ := by rwa [LinearMap.ker_eq_bot, f.linear_injective_iff]
   exact LinearIndependent.map' hai f.linear hf'
 
+/-- The image of a set of points in affine space, under an injective affine transformation, is
+affine-independent. -/
+theorem AffineIndepOn.map' {s : Set ι} {p : ι → P} (hai : AffineIndepOn k p s) (f : P →ᵃ[k] P₂)
+    (hf : Function.Injective f) : AffineIndepOn k (f ∘ p) s :=
+  AffineIndependent.map' hai f hf
+
 /-- Injective affine maps preserve affine independence. -/
 theorem AffineMap.affineIndependent_iff {p : ι → P} (f : P →ᵃ[k] P₂) (hf : Function.Injective f) :
     AffineIndependent k (f ∘ p) ↔ AffineIndependent k p :=
   ⟨AffineIndependent.of_comp f, fun hai => AffineIndependent.map' hai f hf⟩
 
+/-- Injective affine maps preserve affine independence. -/
+theorem AffineMap.affineIndepOn_iff {s : Set ι} {p : ι → P} (f : P →ᵃ[k] P₂)
+    (hf : Function.Injective f) : AffineIndepOn k (f ∘ p) s ↔ AffineIndepOn k p s :=
+  ⟨AffineIndepOn.of_comp f, fun hai ↦ AffineIndepOn.map' hai f hf⟩
+
 /-- Affine equivalences preserve affine independence of families of points. -/
 theorem AffineEquiv.affineIndependent_iff {p : ι → P} (e : P ≃ᵃ[k] P₂) :
     AffineIndependent k (e ∘ p) ↔ AffineIndependent k p :=
   e.toAffineMap.affineIndependent_iff e.toEquiv.injective
+
+/-- Affine equivalences preserve affine independence of sets of points. -/
+theorem AffineEquiv.affineIndepOn_iff {s : Set ι} {p : ι → P} (e : P ≃ᵃ[k] P₂) :
+    AffineIndepOn k (e ∘ p) s ↔ AffineIndepOn k p s :=
+  e.toAffineMap.affineIndepOn_iff e.toEquiv.injective
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Affine equivalences preserve affine independence of subsets. -/
@@ -453,6 +609,12 @@ theorem AffineEquiv.affineIndependent_set_of_eq_iff {s : Set P} (e : P ≃ᵃ[k]
     AffineIndependent k ((↑) : e '' s → P₂) ↔ AffineIndependent k ((↑) : s → P) := by
   have : e ∘ ((↑) : s → P) = ((↑) : e '' s → P₂) ∘ (e : P ≃ P₂).image s := rfl
   simp [← e.affineIndependent_iff, this, affineIndependent_equiv]
+
+theorem affineIndependent_restrict_iff {s : Set ι} {p : ι → P} :
+    AffineIndependent k (s.domRestrict p) ↔ AffineIndepOn k p s :=
+  Iff.rfl
+
+alias ⟨AffineIndepOn.affineIndependent_restrict, _⟩ := affineIndependent_restrict_iff
 
 end Composition
 
@@ -535,6 +697,13 @@ theorem AffineIndependent.notMem_affineSpan_sdiff [Nontrivial k] {p : ι → P}
 
 @[deprecated (since := "2026-06-03")]
 alias AffineIndependent.notMem_affineSpan_diff := AffineIndependent.notMem_affineSpan_sdiff
+
+/-- If a set is affinely independent, a point in the set is not
+in the affine span of the other points, if the underlying ring is nontrivial. -/
+theorem AffineIndepOn.notMem_affineSpan_sdiff [Nontrivial k] {p : ι → P} {s : Set ι} {i : ι}
+    (hs : AffineIndepOn k p s) (hi : i ∈ s) : p i ∉ affineSpan k (p '' (s \ {i})) := by
+  have := hs.affineIndependent.notMem_affineSpan_sdiff ⟨i, hi⟩ Set.univ
+  simpa [← Function.comp_def, Set.image_comp, Set.image_sdiff] using this
 
 lemma AffineIndependent.injective_affineSpan_image [Nontrivial k] {p : ι → P}
     (ha : AffineIndependent k p) : Injective fun (s : Set ι) ↦ affineSpan k (p '' s) := by
@@ -786,20 +955,51 @@ theorem exists_affineIndependent (s : Set P) :
 
 variable {V}
 
+variable {k} in
+theorem AffineIndepOn.id_insert {s : Set P} {q : P} (hs : AffineIndepOn k id s)
+    (hq : q ∉ affineSpan k s) : AffineIndepOn k id (insert q s) := by
+  rcases s.eq_empty_or_nonempty with rfl | ⟨p₁, hp₁⟩
+  · simp
+  rw [affineIndepOn_iff_linearIndepOn_vsub (Set.mem_insert_of_mem q hp₁),
+    ← Set.insert_sdiff_singleton_comm (by grind [mem_affineSpan])]
+  apply LinearIndepOn.insert ((affineIndepOn_iff_linearIndepOn_vsub hp₁).mp hs)
+  simp only [id_eq, ← vectorSpan_eq_span_vsub_set_right_ne k hp₁, ← direction_affineSpan]
+  rwa [AffineSubspace.vsub_right_mem_direction_iff_mem (mem_affineSpan k hp₁)]
+
+variable {k} in
+protected theorem AffineIndepOn.insert {s : Set ι} {x : ι} {p : ι → P} (hs : AffineIndepOn k p s)
+    (hx : p x ∉ affineSpan k (p '' s)) : AffineIndepOn k p (insert x s) := by
+  have : p x ∉ p '' s := fun h ↦ hx (mem_affineSpan k h)
+  have := (Set.injOn_insert fun h ↦ this (Set.mem_image_of_mem p h)).mpr ⟨hs.injOn, this⟩
+  rw [affineIndepOn_iff_image this, Set.image_insert_eq]
+  exact hs.id_image.id_insert hx
+
+theorem affineIndepOn_insert {s : Set ι} {x : ι} {p : ι → P} (hxs : x ∉ s) :
+    AffineIndepOn k p (insert x s) ↔ AffineIndepOn k p s ∧ p x ∉ affineSpan k (p '' s) :=
+  ⟨fun h ↦ ⟨h.mono (by simp),
+      Set.insert_sdiff_self_of_notMem hxs ▸ h.notMem_affineSpan_sdiff (by simp)⟩,
+    fun ⟨hs, hx⟩ ↦ hs.insert hx⟩
+
+variable {k} in
+/-- A shortcut to a convenient form for the negation in `AffineIndepOn.mem_affineSpan_iff`. -/
+theorem AffineIndepOn.notMem_affineSpan_iff {s : Set ι} {x : ι} {p : ι → P}
+    (h : AffineIndepOn k p s) :
+    p x ∉ affineSpan k (p '' s) ↔ AffineIndepOn k p (insert x s) ∧ x ∉ s := by
+  grind [mem_affineSpan, affineIndepOn_insert]
+
+theorem affineIndepOn_pair_iff {p : ι → P} {i j : ι} (hij : i ≠ j) :
+    AffineIndepOn k p {i, j} ↔ p i ≠ p j := by
+  rw [affineIndepOn_iff_linearIndepOn_vsub (Set.mem_insert i _), ne_comm,
+    Set.insert_sdiff_self_of_notMem (by simpa), linearIndepOn_singleton_iff, vsub_ne_zero]
+
+/-- Two different points are affinely independent. -/
+theorem affineIndepOn_of_ne {p₁ p₂ : P} (h : p₁ ≠ p₂) : AffineIndepOn k id {p₁, p₂} :=
+  (affineIndepOn_pair_iff k h).mpr h
+
 /-- Two different points are affinely independent. -/
 theorem affineIndependent_of_ne {p₁ p₂ : P} (h : p₁ ≠ p₂) : AffineIndependent k ![p₁, p₂] := by
-  rw [affineIndependent_iff_linearIndependent_vsub k ![p₁, p₂] 0]
-  let i₁ : { x // x ≠ (0 : Fin 2) } := ⟨1, by simp⟩
-  have he' : ∀ i, i = i₁ := by
-    rintro ⟨i, hi⟩
-    ext
-    fin_cases i
-    · simp at hi
-    · simp [i₁]
-  have : Unique { x // x ≠ (0 : Fin 2) } := ⟨⟨i₁⟩, he'⟩
-  refine .of_subsingleton default ?_
-  rw [he' default]
-  simpa using! h.symm
+  rw [← affineIndepOn_id_range_iff (Matrix.injective_pair_iff_ne.mpr h)]
+  simpa using affineIndepOn_of_ne k h.symm
 
 variable {k}
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -68,7 +68,7 @@ variable {k} in
 theorem AffineIndepOn.affineIndependent {p : ι → P} {s : Set ι} (h : AffineIndepOn k p s) :
     AffineIndependent k (fun x : s ↦ p x) := h
 
-theorem affineIndependent_set_coe_iff {p : ι → P} {s : Set ι} :
+theorem affineIndependent_subtypeVal_iff {p : ι → P} {s : Set ι} :
     AffineIndependent k (fun x : s ↦ p x) ↔ AffineIndepOn k p s :=
   Iff.rfl
 
@@ -540,7 +540,7 @@ lemma AffineIndependent.indicator_extend_eq_of_affineCombination_comp_embedding_
 
 theorem affineIndepOn_iff_linearIndepOn_vsub {p : ι → P} {s : Set ι} {i : ι} (hi : i ∈ s) :
     AffineIndepOn k p s ↔ LinearIndepOn k (fun j ↦ p j -ᵥ p i) (s \ {i}) := by
-  rw [← affineIndependent_set_coe_iff, affineIndependent_iff_linearIndependent_vsub _ _ ⟨i, hi⟩,
+  rw [← affineIndependent_subtypeVal_iff, affineIndependent_iff_linearIndependent_vsub _ _ ⟨i, hi⟩,
     ← linearIndependent_set_coe_iff]
   exact linearIndependent_equiv'
     ((Equiv.subtypeEquivRight (by simp)).trans (Equiv.Set.sep s (· ≠ i)).symm) rfl

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -77,7 +77,7 @@ theorem affineIndependent_of_subsingleton [Subsingleton ι] (p : ι → P) : Aff
   fun _ _ h _ i hi => Fintype.eq_of_subsingleton_of_sum_eq h i hi
 
 /-- A set with at most one point is affinely independent. -/
-theorem AffineIndepOn.of_subsingleton' (p : ι → P) {s : Set ι} (hs : s.Subsingleton) :
+theorem AffineIndepOn.of_setSubsingleton (p : ι → P) {s : Set ι} (hs : s.Subsingleton) :
     AffineIndepOn k p s :=
   have := (Set.subsingleton_coe s).mpr hs
   affineIndependent_of_subsingleton _ _
@@ -93,14 +93,14 @@ theorem AffineIndepOn.of_subsingleton [Subsingleton k] (p : ι → P) (s : Set �
 
 @[simp]
 lemma AffineIndepOn.singleton (p : ι → P) (i : ι) : AffineIndepOn k p {i} :=
-  .of_subsingleton' k p Set.subsingleton_singleton
+  .of_setSubsingleton k p Set.subsingleton_singleton
 
 theorem affineIndependent_empty_type [IsEmpty ι] (p : ι → P) : AffineIndependent k p :=
   affineIndependent_of_subsingleton _ _
 
 @[simp]
 theorem affineIndepOn_empty (p : ι → P) : AffineIndepOn k p ∅ :=
-  .of_subsingleton' k p Set.subsingleton_empty
+  .of_setSubsingleton k p Set.subsingleton_empty
 
 theorem affineIndependent_subtype_iff {s : Set P} :
     AffineIndependent k (Subtype.val : s → P) ↔ AffineIndepOn k id s := Iff.rfl
@@ -413,19 +413,6 @@ theorem AffineIndependent.affineIndepOn_id {p : ι → P} (h : AffineIndependent
     AffineIndepOn k id (Set.range p) :=
   h.range
 
-theorem affineIndepOn_iff_image {s : Set ι} {f : ι → P} (hf : Set.InjOn f s) :
-    AffineIndepOn k f s ↔ AffineIndepOn k id (f '' s) :=
-  affineIndependent_equiv' (Equiv.Set.imageOfInjOn _ _ hf) rfl
-
-theorem AffineIndepOn.id_image {p : ι → P} {s : Set ι} (hs : AffineIndepOn k p s) :
-    AffineIndepOn k id (p '' s) := by
-  nontriviality k
-  exact (affineIndepOn_iff_image hs.injOn).mp hs
-
-theorem affineIndepOn_iff_affineIndepOn_image_injOn [Nontrivial k] {p : ι → P} {s : Set ι} :
-    AffineIndepOn k p s ↔ AffineIndepOn k id (p '' s) ∧ Set.InjOn p s :=
-  ⟨fun h ↦ ⟨h.id_image, h.injOn⟩, fun h ↦ (affineIndepOn_iff_image h.2).mpr h.1⟩
-
 theorem AffineIndepOn.comp_of_image {ι' : Type*} {s : Set ι'} {f : ι' → ι} {p : ι → P}
     (h : AffineIndepOn k p (f '' s)) (hf : Set.InjOn f s) : AffineIndepOn k (p ∘ f) s :=
   h.comp_embedding (Equiv.Set.imageOfInjOn f s hf).toEmbedding
@@ -436,9 +423,25 @@ theorem AffineIndepOn.image_of_comp {ι' : Type*} {s : Set ι} (f : ι → ι') 
   exact (affineIndependent_equiv'
     (Equiv.Set.imageOfInjOn f s (Set.injOn_iff_injective.mpr hs.injective.of_comp)) rfl).mp hs
 
+theorem affineIndepOn_image_iff {ι' : Type*} {s : Set ι} {f : ι → ι'} (g : ι' → P)
+    (hf : Set.InjOn f s) : AffineIndepOn k g (f '' s) ↔ AffineIndepOn k (g ∘ f) s :=
+  ⟨fun h ↦ h.comp_of_image hf, fun h ↦ h.image_of_comp f g⟩
+
+theorem affineIndepOn_iff_image {s : Set ι} {f : ι → P} (hf : Set.InjOn f s) :
+    AffineIndepOn k f s ↔ AffineIndepOn k id (f '' s) :=
+  (affineIndepOn_image_iff id hf).symm
+
+theorem AffineIndepOn.id_image {p : ι → P} {s : Set ι} (hs : AffineIndepOn k p s) :
+    AffineIndepOn k id (p '' s) :=
+  hs.image_of_comp p id
+
+theorem affineIndepOn_iff_affineIndepOn_image_injOn [Nontrivial k] {p : ι → P} {s : Set ι} :
+    AffineIndepOn k p s ↔ AffineIndepOn k id (p '' s) ∧ Set.InjOn p s :=
+  ⟨fun h ↦ ⟨h.id_image, h.injOn⟩, fun h ↦ (affineIndepOn_iff_image h.2).mpr h.1⟩
+
 theorem affineIndepOn_range_iff {ι' : Type*} {f : ι → ι'} (hf : Injective f) (g : ι' → P) :
-    AffineIndepOn k g (Set.range f) ↔ AffineIndependent k (g ∘ f) :=
-  affineIndependent_equiv' (Equiv.ofInjective f hf) rfl |>.symm
+    AffineIndepOn k g (Set.range f) ↔ AffineIndependent k (g ∘ f) := by
+  simpa using affineIndepOn_image_iff g <| hf.injOn (s := .univ)
 
 alias ⟨AffineIndependent.of_affineIndepOn_range, _⟩ := affineIndepOn_range_iff
 
@@ -490,7 +493,7 @@ theorem affineIndepOn_congr {p q : ι → P} {s : Set ι} (h : Set.EqOn p q s) :
   ext x
   exact h.symm x.2
 
-theorem AffineIndepOn.congr {p q : ι → P} {s : Set ι} (hp : AffineIndepOn k p s)
+protected theorem AffineIndepOn.congr {p q : ι → P} {s : Set ι} (hp : AffineIndepOn k p s)
     (h : Set.EqOn p q s) : AffineIndepOn k q s :=
   (affineIndepOn_congr h).mp hp
 

--- a/Mathlib/LinearAlgebra/Matrix/Notation.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Notation.lean
@@ -542,10 +542,3 @@ theorem vec3_dotProduct (v w : Fin 3 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 
 end Vec2AndVec3
 
 end Matrix
-
-@[simp]
-lemma injective_pair_iff_ne {α : Type*} {x y : α} :
-    Function.Injective ![x, y] ↔ x ≠ y := by
-  refine ⟨fun h ↦ ?_, fun h a b h' ↦ ?_⟩
-  · simpa using h.ne Fin.zero_ne_one
-  · fin_cases a <;> fin_cases b <;> aesop

--- a/Mathlib/LinearAlgebra/Projectivization/Basic.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Basic.lean
@@ -243,9 +243,8 @@ theorem linearIndepOn_pair (D D' : ℙ K V) :
   by_cases h : D = D'
   · simpa [h] using D'.rep_nonzero
   rw [← ne_eq, ← linearIndependent_pair_iff_ne, LinearIndependent.pair_symm_iff,
-    ← linearIndepOn_id_range_iff] at h
-  · simpa using h
-  · simpa [injective_pair_iff_ne, injective_pair_iff_ne, ne_eq] using h.injective
+    ← linearIndepOn_id_range_iff h.injective] at h
+  simpa using h
 
 end linearIndependent
 


### PR DESCRIPTION
`LinearIndepOn` is a set-valued analog of `LinearIndependent`. `AffineIndepOn` is similarly a set-valued analog of `AffineIndependent` that makes it easier to reason about operations like insertion/deletion occurring over sets. The first half of the change is mostly copied from `LinearIndepOn`.

Created as part of the "Polyhedra in Lean" workshop in Berlin.

---

AI disclosure: Claude helped find some lemmas I had forgotten to copy over, and then I used it to generate a few proofs (relating AffineIndepOn/LinearIndepOn and for `insert`) that I then golfed/edited.

There should also be an `AffineIndepOn`-version of `exists_affineIndependent`, but I have another change I also have scheduled for this lemma so I want to do this in a follow-up since this PR is large-enough as-is.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
