### PR TITLE
[Merged by Bors] - feat(NumberTheory/Height/EllipticCurve): naïve height and approximate parallelogram law

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/AddSubMap.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/AddSubMap.lean
@@ -150,6 +150,11 @@ noncomputable def sym2x (P Q : W'.Point) : Fin 3 → R :=
   letI Qx := Q.xRep
   ![Px 0 * Qx 0, Px 0 * Qx 1 + Px 1 * Qx 0, Px 1 * Qx 1]
 
+lemma sym2x_eq {P Q : W'.Point} :
+    sym2x P Q =
+      ![P.xRep 0 * Q.xRep 0, P.xRep 0 * Q.xRep 1 + P.xRep 1 * Q.xRep 0, P.xRep 1 * Q.xRep 1] :=
+  (rfl)
+
 @[simp]
 lemma sym2x_zero_zero : (0 : W'.Point).sym2x 0 = ![1, 0, 0] := by
   simp [sym2x]

--- a/Mathlib/NumberTheory/Height/EllipticCurve.lean
+++ b/Mathlib/NumberTheory/Height/EllipticCurve.lean
@@ -129,4 +129,7 @@ end Northcott
 
 end WeierstrassCurve.Affine
 
+@[deprecated (since := "2026-09-05")] alias
+  WeierstrassCurve.abs_logHeight_addSubMap_sub_two_mul_logHeight_le :=
+    WeierstrassCurve.Affine.abs_logHeight_addSubMap_sub_two_mul_logHeight_le
 end

--- a/Mathlib/NumberTheory/Height/EllipticCurve.lean
+++ b/Mathlib/NumberTheory/Height/EllipticCurve.lean
@@ -6,44 +6,70 @@ Authors: Michael Stoll
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.AddSubMap
+public import Mathlib.GroupTheory.Descent
 public import Mathlib.NumberTheory.Height.MvPolynomial
+public import Mathlib.Order.Northcott
 
 /-!
 # The naïve height and the approximate parallelogram law
 
-This file defines the *naïve height* on an elliptic curve (over a field `K` with a theory of
-heights, i.e., satisfying `[Height.AdmissibleAbsValues K]`).
+This file defines the *naïve height* on an elliptic curve (over a field `F` with a theory of
+heights, i.e., satisfying `[Height.AdmissibleAbsValues F]`).
 
-The final goal of this file is to prove the *approximate parallelogram law* for (affine) points
-on elliptic curves,
+We then prove the *approximate parallelogram law* for (affine) points on elliptic curves,
 ```
   |h(P+Q) + h(P-Q) - 2*(h(P) + h(Q))| ≤ C
 ```
 where `h` is the naïve height, `P` and `Q` are affine points on a `WeierstrassCurve` and `C`
 is some real constant depending only on the Weierstrass model.
-
-### TODO
-
-* Define the naïve height
-* Add the further ingredients needed for the approximate parallelogram law
-* Add the statement and proof of the approximate parallelogram law
 -/
 
 public section
 
-namespace WeierstrassCurve
+namespace WeierstrassCurve.Affine
 
-open Height MvPolynomial
+open Height
 
-variable {K : Type*} [Field K] [AdmissibleAbsValues K] (W : WeierstrassCurve K) [W.IsElliptic]
+variable {F : Type*} [Field F] [AdmissibleAbsValues F] {W : Affine F}
 
-/-- If `W` is a Weierstrass curve over `K`, then the map `F : ℙ² → ℙ²` given by `addSubMap W`
+section NaiveHeight
+
+/-- The naïve logarithmic height of an affine point on `W`. -/
+noncomputable def Point.naiveHeight (P : W.Point) : ℝ :=
+  logHeight P.xRep
+
+lemma Point.naiveHeight_eq_logHeight (P : W.Point) : P.naiveHeight = logHeight P.xRep :=
+  (rfl)
+
+lemma Point.naiveHeight_eq_logHeight₁ {P : W.Point} :
+    P.naiveHeight = logHeight₁ (P.xRep 0) := by
+  match P with
+  | 0 => simp [naiveHeight, xRep]
+  | some .. => simpa [naiveHeight] using (logHeight₁_eq_logHeight _).symm
+
+variable (W)
+
+lemma abs_logHeight_sym2x_sub_le :
+    ∃ C, ∀ P Q : W.Point, |logHeight (P.sym2x Q) - (P.naiveHeight + Q.naiveHeight)| ≤ C := by
+  obtain ⟨C, hC⟩ := abs_logHeight_sym2_sub_le F
+  refine ⟨C, fun P Q ↦ ?_⟩
+  rw [P.naiveHeight_eq_logHeight, Q.naiveHeight_eq_logHeight, Point.sym2x_eq]
+  have H₁ := logHeight_fun_mul_eq P.xRep_ne_zero Q.xRep_ne_zero
+  have H (v : Fin 2 → F) : ![v 0, v 1] = v := by ext i : 1; fin_cases i <;> simp
+  have h₀ (P : W.Point) : ![P.xRep 0, P.xRep 1] ≠ 0 := H P.xRep ▸ P.xRep_ne_zero
+  specialize hC (h₀ P) (h₀ Q)
+  rw [H P.xRep, H Q.xRep] at *
+  grind only [= abs.eq_1, = max_def]
+
+variable [W.IsElliptic]
+
+/-- If `W` is a Weierstrass curve over `F`, then the map `Φ : ℙ² → ℙ²` given by `addSubMap W`
 is a morphism.
 
-This implies that `|logHeight (F x) - 2 * logHeight x| ≤ C` for a constant `C`,
-where `x = ![s, t, u]` and `F` acts on the coordinate vector. -/
+This implies that `|logHeight (Φ x) - 2 * logHeight x| ≤ C` for a constant `C`,
+where `x = ![s, t, u]` and `Φ` acts on the coordinate vector. -/
 theorem abs_logHeight_addSubMap_sub_two_mul_logHeight_le :
-    ∃ C, ∀ x : Fin 3 → K,
+    ∃ C, ∀ x : Fin 3 → F,
       |logHeight (fun i ↦ (addSubMap W i).eval x) - 2 * logHeight x| ≤ C := by
   obtain ⟨C₁, hC₁⟩ := logHeight_eval_le' <| isHomogeneous_addSubMap W
   obtain ⟨C₂, h⟩ := logHeight_eval_ge' (N := 2)
@@ -51,6 +77,56 @@ theorem abs_logHeight_addSubMap_sub_two_mul_logHeight_le :
   have hC₂ := fun x ↦ h _ <| addSubMapCoeff_condition W x
   refine ⟨max C₁ (-C₂), fun x ↦ abs_sub_le_iff.mpr ⟨?_, ?_⟩⟩ <;> grind
 
-end WeierstrassCurve
+/-- The **approximate parallelogram law** for the naïve height on an elliptic curve. -/
+theorem approx_parallelogram_law [DecidableEq F] :
+    ∃ C, ∀ (P Q : W.Point),
+      |(P + Q).naiveHeight + (P - Q).naiveHeight - 2 * (P.naiveHeight + Q.naiveHeight)| ≤ C := by
+  obtain ⟨C₁, hC₁⟩ := abs_logHeight_sym2x_sub_le W
+  obtain ⟨C₂, hC₂⟩ := abs_logHeight_addSubMap_sub_two_mul_logHeight_le W
+  refine ⟨3 * C₁ + C₂, fun P Q ↦ ?_⟩
+  obtain ⟨t, ht₀, ht⟩ := Point.sym2x_add_sub_eq_addSubMap_sym2x P Q
+  replace ht := congrArg logHeight ht
+  rw [Height.logHeight_smul_eq_logHeight _ ht₀] at ht
+  have hPQ := hC₁ P Q
+  have haddsub := hC₁ (P + Q) (P - Q)
+  have hC := ht ▸ hC₂ (P.sym2x Q)
+  -- speed up `grind` below by reducing to the essentials
+  generalize (P + Q).naiveHeight + (P - Q).naiveHeight = A at haddsub ⊢
+  generalize logHeight ((P + Q).sym2x (P - Q)) = B at hC haddsub
+  generalize logHeight (P.sym2x Q) = B' at hPQ hC
+  generalize P.naiveHeight + Q.naiveHeight = A' at hPQ ⊢
+  grind only [= abs.eq_1, = max_def]
+
+end NaiveHeight
+
+section Northcott
+
+instance [Northcott (logHeight₁ (K := F))] : Northcott (Point.naiveHeight (F := F) (W := W)) := by
+  eta_expand
+  simp only [Point.naiveHeight_eq_logHeight₁]
+  rw [← Function.comp_def]
+  have : Filter.TendstoCofinite fun P : W.Point ↦ P.xRep 0 :=
+    (Filter.tendstoCofinite_iff_finite_preimage_singleton _).mpr finite_preimage_xRep0
+  exact Northcott.comp_of_finite_fibers ..
+
+variable [Northcott (logHeight₁ (K := F))]
+
+variable (W) in
+/-- The set of `F`-points on `W` with naïve height bounded by `B` is finite.
+This is an important ingredient for the *Mordell-Weil Theorem*. -/
+lemma finite_naiveHeight_le (B : ℝ) : {P : W.Point | P.naiveHeight ≤ B}.Finite :=
+  Northcott.finite_le B
+
+variable [DecidableEq F] [W.IsElliptic]
+
+/-- The group of `F`-rational torsion points on an elliptic curve is finite when `F` is a field
+that has the Northcott property (e.g., a number field). -/
+theorem finite_torsion : Finite (AddCommGroup.torsion W.Point) := by
+  obtain ⟨C, hC⟩ := approx_parallelogram_law W
+  exact AddCommGroup.finite_torsion_of_descent' hC
+
+end Northcott
+
+end WeierstrassCurve.Affine
 
 end


### PR DESCRIPTION
This is the final step toward the *approximate parallelogram law* on an elliptic curve:
`|h (P+Q) + h (P-Q) - 2 * (h P + h Q)| ≤ C`, where `h` is the naïve height (defined in this PR) and `C` is a constant depending only on the curve.

We use this to deduce that the group of `F`-rational torsion points on an elliptic curve is finite, when `F` is a field satisfying the Northcott property (e.g., a number field).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
