### PR TITLE
fix(LinearAlgebra/Projectivization/Subspace): fix non-defeq `Min` instances

### DIFF
--- a/Mathlib/LinearAlgebra/Projectivization/Subspace.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Subspace.lean
@@ -122,12 +122,6 @@ def gi : GaloisInsertion (span : Set (ℙ K V) → Subspace K V) SetLike.coe whe
 theorem span_coe (W : Subspace K V) : span ↑W = W :=
   GaloisInsertion.l_u_eq gi W
 
-/-- The infimum of two subspaces exists. -/
-instance instInf : Min (Subspace K V) :=
-  ⟨fun A B =>
-    ⟨A ⊓ B, fun _v _w hv hw _hvw h1 h2 =>
-      ⟨A.mem_add _ _ hv hw _ h1.1 h2.1, B.mem_add _ _ hv hw _ h1.2 h2.2⟩⟩⟩
-
 /-- Infimums of arbitrary collections of subspaces exist. -/
 instance instInfSet : InfSet (Subspace K V) :=
   ⟨fun A =>
@@ -136,15 +130,21 @@ instance instInfSet : InfSet (Subspace K V) :=
       exact s.mem_add v w hv hw _ (h1 s ⟨s, hs, rfl⟩) (h2 s ⟨s, hs, rfl⟩)⟩⟩
 
 /-- The subspaces of a projective space form a complete lattice. -/
-instance : CompleteLattice (Subspace K V) :=
-  { __ := completeLatticeOfInf (Subspace K V)
-      (by
-        refine fun s => ⟨fun a ha x hx => hx _ ⟨a, ha, rfl⟩, fun a ha x hx E => ?_⟩
-        rintro ⟨E, hE, rfl⟩
-        exact ha hE hx)
-    inf_le_left := fun A B _ hx => (@inf_le_left _ _ A B) hx
-    inf_le_right := fun A B _ hx => (@inf_le_right _ _ A B) hx
-    le_inf := fun _ _ _ h1 h2 _ hx => (le_inf h1 h2) hx }
+instance : CompleteLattice (Subspace K V) where
+  __ := completeLatticeOfInf (Subspace K V)
+    (by
+      refine fun s => ⟨fun a ha x hx => hx _ ⟨a, ha, rfl⟩, fun a ha x hx E => ?_⟩
+      rintro ⟨E, hE, rfl⟩
+      exact ha hE hx)
+  bot := ⟨∅, fun _ _ _ _ _ h _ => h.elim⟩
+  bot_le _ := Set.empty_subset _
+  top := ⟨Set.univ, fun _ _ _ _ _ _ _ => trivial⟩
+  le_top _ := Set.subset_univ _
+  inf A B := ⟨A ∩ B, fun _v _w hv hw _hvw h1 h2 =>
+    ⟨A.mem_add _ _ hv hw _ h1.1 h2.1, B.mem_add _ _ hv hw _ h1.2 h2.2⟩⟩
+  inf_le_left _ _ := Set.inter_subset_left
+  inf_le_right _ _ := Set.inter_subset_right
+  le_inf _ _ _ := Set.subset_inter
 
 instance subspaceInhabited : Inhabited (Subspace K V) where default := ⊤
 
@@ -264,11 +264,8 @@ theorem mem_submodule_iff (s : Projectivization.Subspace K V) {v : V} (hv : v �
   ⟨fun h => h hv, fun h _ => h⟩
 
 @[simp]
-lemma bot_coe : ((⊥ : Subspace K V) : Set (Projectivization K V)) = ∅ := by
-  ext x
-  simp only [SetLike.mem_coe, Set.mem_empty_iff_false, iff_false]
-  induction x using ind with | h v hv =>
-  rwa [← Subspace.mem_submodule_iff _ hv, Subspace.submodule.map_bot, Submodule.mem_bot]
+lemma bot_coe : ((⊥ : Subspace K V) : Set (Projectivization K V)) = ∅ :=
+  rfl
 
 end Subspace
 


### PR DESCRIPTION
The `CompleteLattice` instance of `Projectivization.Subspace` is currently defined using `completeLatticeOfInf`, which conflicts with the `Min` instance defined earlier. This PR fixes this by overriding the `inf` field. To avoid possible issues with  `⊥` and `⊤`, they are also redefined  to have good defeqs.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
