### PR TITLE
[Merged by Bors] - feat(Data/Nat/Factorization/Basic): add mul_factorization_le

### DIFF
--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -135,6 +135,15 @@ theorem factorization_lt {n : ℕ} (p : ℕ) (hn : n ≠ 0) : n.factorization p 
   · simpa only [factorization_eq_zero_of_not_prime n pp] using! hn.bot_lt
 
 /-- An upper bound on `n.factorization p` -/
+theorem mul_factorization_le {n p : ℕ} :
+    p * n.factorization p ≤ n := by
+  obtain rfl | hp := eq_or_ne p 1
+  · simp
+  obtain rfl | hn := eq_or_ne n 0
+  · simp
+  grw [Nat.mul_le_pow hp, Nat.ordProj_le _ hn]
+
+/-- An upper bound on `n.factorization p` -/
 theorem factorization_le_of_le_pow {n p b : ℕ} (hb : n ≤ p ^ b) : n.factorization p ≤ b := by
   if hn : n = 0 then simp [hn] else
   if pp : p.Prime then

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -136,11 +136,7 @@ theorem factorization_lt {n : ℕ} (p : ℕ) (hn : n ≠ 0) : n.factorization p 
 
 /-- An upper bound on `n.factorization p` -/
 theorem mul_factorization_le {n p : ℕ} : p * n.factorization p ≤ n := by
-  obtain rfl | hp := eq_or_ne p 1
-  · simp
-  obtain rfl | hn := eq_or_ne n 0
-  · simp
-  grw [Nat.mul_le_pow hp, Nat.ordProj_le _ hn]
+  grw [factorization_le_padicValNat, mul_padicValNat_le]
 
 /-- An upper bound on `n.factorization p` -/
 theorem factorization_le_of_le_pow {n p b : ℕ} (hb : n ≤ p ^ b) : n.factorization p ≤ b := by

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -134,7 +134,7 @@ theorem factorization_lt {n : ℕ} (p : ℕ) (hn : n ≠ 0) : n.factorization p 
       Nat.lt_pow_self pp.one_lt
   · simpa only [factorization_eq_zero_of_not_prime n pp] using! hn.bot_lt
 
-/-- An upper bound on `n.factorization p` -/
+/-- A weak upper bound on `n.factorization p` -/
 theorem mul_factorization_le {n p : ℕ} : p * n.factorization p ≤ n := by
   grw [factorization_le_padicValNat, mul_padicValNat_le]
 

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -135,8 +135,7 @@ theorem factorization_lt {n : ℕ} (p : ℕ) (hn : n ≠ 0) : n.factorization p 
   · simpa only [factorization_eq_zero_of_not_prime n pp] using! hn.bot_lt
 
 /-- An upper bound on `n.factorization p` -/
-theorem mul_factorization_le {n p : ℕ} :
-    p * n.factorization p ≤ n := by
+theorem mul_factorization_le {n p : ℕ} : p * n.factorization p ≤ n := by
   obtain rfl | hp := eq_or_ne p 1
   · simp
   obtain rfl | hn := eq_or_ne n 0

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -58,6 +58,10 @@ def factorization (n : ℕ) : ℕ →₀ ℕ where
 theorem factorization_def (n : ℕ) {p : ℕ} (pp : p.Prime) : n.factorization p = padicValNat p n := by
   simpa [factorization] using absurd pp
 
+/-- The multiplicity `n.factorization p` is at most the `p`-adic valuation of `n`. -/
+theorem factorization_le_padicValNat {n p : ℕ} : n.factorization p ≤ padicValNat p n := by
+  grind [Nat.factorization]
+
 /-- We can write both `n.factorization p` and `n.factors.count p` to represent the power
 of `p` in the factorization of `n`: we declare the former to be the simp-normal form. -/
 @[simp]

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -58,7 +58,6 @@ def factorization (n : ℕ) : ℕ →₀ ℕ where
 theorem factorization_def (n : ℕ) {p : ℕ} (pp : p.Prime) : n.factorization p = padicValNat p n := by
   simpa [factorization] using absurd pp
 
-/-- The multiplicity `n.factorization p` is at most the `p`-adic valuation of `n`. -/
 theorem factorization_le_padicValNat {n p : ℕ} : n.factorization p ≤ padicValNat p n := by
   grind [Nat.factorization]
 

--- a/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
@@ -101,7 +101,7 @@ theorem le_padicValNat_iff_replicate_subperm_primeFactorsList {a b : ℕ} {n : �
       |>.emultiplicity_eq_multiplicity, ← padicValNat_def' ha.ne_one hb,
     ENat.natCast_le_natCast]
 
-/-- An upper bound on `padicValNat p n`. -/
+/-- A weak upper bound on `padicValNat p n`. -/
 theorem mul_padicValNat_le {p n : ℕ} : p * padicValNat p n ≤ n := by
   obtain rfl | hp := eq_or_ne p 1
   · simp

--- a/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
@@ -100,3 +100,11 @@ theorem le_padicValNat_iff_replicate_subperm_primeFactorsList {a b : ℕ} {n : �
     Nat.finiteMultiplicity_iff.2 ⟨ha.ne_one, Nat.pos_of_ne_zero hb⟩
       |>.emultiplicity_eq_multiplicity, ← padicValNat_def' ha.ne_one hb,
     ENat.natCast_le_natCast]
+
+/-- An upper bound on `padicValNat p n`. -/
+theorem mul_padicValNat_le {p n : ℕ} : p * padicValNat p n ≤ n := by
+  obtain rfl | hp := eq_or_ne p 1
+  · simp
+  obtain rfl | hn := eq_or_ne n 0
+  · simp
+  grw [Nat.mul_le_pow hp, Nat.le_of_dvd hn.bot_lt pow_padicValNat_dvd]


### PR DESCRIPTION
Give a mildly tighter upper bound compared to `factorization_lt`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
