### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/TensorProduct): remove `zero` step from `TensorProduct.induction_on`

### DIFF
--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -166,7 +166,7 @@ variable (R A) in
 /-- The multiplication map on an `R`-algebra, as an `A`-linear map from `A ⊗[R] A` to `A`. -/
 @[simps!] def mul'' : A ⊗[R] A →ₗ[A] A where
   __ := mul' R A
-  map_smul' a x := x.induction_on (by simp) (by simp +contextual [mul', smul_tmul', mul_assoc])
+  map_smul' a x := x.inductionOn (by simp +contextual [mul', smul_tmul', mul_assoc])
     (by simp +contextual [mul_add])
 
 end Semiring

--- a/Mathlib/Algebra/Algebra/Epi.lean
+++ b/Mathlib/Algebra/Algebra/Epi.lean
@@ -34,8 +34,7 @@ lemma isEpi_iff_forall_one_tmul_eq :
     Algebra.IsEpi R A ↔ ∀ a : A, 1 ⊗ₜ[R] a = a ⊗ₜ[R] 1 := by
   refine ⟨fun h a ↦ IsEpi.injective_lift_mul <| by simp, fun h ↦ ⟨fun x y hxy ↦ ?_⟩⟩
   have h' (x : A ⊗[R] A) : ∃ a : A, x = a ⊗ₜ 1 := by
-    induction x using TensorProduct.induction_on with
-    | zero => exact ⟨0, by simp⟩
+    induction x using TensorProduct.inductionOn with
     | tmul u v =>
       use u * v
       calc u ⊗ₜ[R] v = u ⊗ₜ[R] 1 * 1 ⊗ₜ[R] v := by simp
@@ -85,7 +84,6 @@ lemma isEpi_iff_surjective_algebraMap_of_finite [Module.Finite R A] :
   have : Subsingleton ((A ⧸ R') ⊗[R] (A ⧸ R')) := by
     refine subsingleton_of_forall_eq 0 fun y ↦ ?_
     induction y with
-    | zero => rfl
     | add a b e₁ e₂ => rwa [e₁, zero_add]
     | tmul x y =>
       obtain ⟨x, rfl⟩ := R'.mkQ_surjective x

--- a/Mathlib/Algebra/Algebra/Subalgebra/Centralizer.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Centralizer.lean
@@ -91,8 +91,7 @@ lemma centralizer_coe_image_includeLeft_eq_center_tensorProduct
   · rintro ⟨w, rfl⟩
     rw [Subalgebra.mem_centralizer_iff]
     rintro _ ⟨x, hx, rfl⟩
-    induction w using TensorProduct.induction_on with
-    | zero => simp
+    induction w using TensorProduct.inductionOn with
     | tmul b c =>
       simp [Subalgebra.mem_centralizer_iff _ |>.1 b.2 x hx]
     | add y z hy hz => rw [map_add, mul_add, hy, hz, add_mul]

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -387,8 +387,7 @@ theorem map'_id {M : ModuleCat.{v} R} : map' f (𝟙 M) = 𝟙 _ := by
 theorem map'_comp {M₁ M₂ M₃ : ModuleCat.{v} R} (l₁₂ : M₁ ⟶ M₂) (l₂₃ : M₂ ⟶ M₃) :
     map' f (l₁₂ ≫ l₂₃) = map' f l₁₂ ≫ map' f l₂₃ := by
   ext x
-  induction x using TensorProduct.induction_on with
-  | zero => rfl
+  induction x using TensorProduct.inductionOn with
   | tmul => rfl
   | add _ _ ihx ihy => erw [LinearMap.map_add, LinearMap.map_add]; grind
 
@@ -750,8 +749,7 @@ def HomEquiv.fromExtendScalars {X : ModuleCat R} {Y : ModuleCat S}
   · simp
   · intro s z
     change lift _ (s • z) = s • lift _ z
-    induction z using TensorProduct.induction_on with
-    | zero => rw [smul_zero, map_zero, smul_zero]
+    induction z using TensorProduct.inductionOn with
     | tmul s' x => simp [mul_smul]
     | add _ _ ih1 ih2 => rw [smul_add, map_add, ih1, ih2, map_add, smul_add]
 
@@ -769,8 +767,7 @@ def homEquiv {X : ModuleCat R} {Y : ModuleCat S} :
     let m1 : Module R S := Module.compHom S f; let m2 : Module R Y := Module.compHom Y f
     apply hom_ext
     apply LinearMap.ext; intro z
-    induction z using TensorProduct.induction_on with
-    | zero => rw [map_zero, map_zero]
+    induction z using TensorProduct.inductionOn with
     | tmul x s =>
       erw [TensorProduct.lift.tmul]
       simp only [LinearMap.coe_mk]
@@ -841,8 +838,7 @@ def Counit.map {Y : ModuleCat S} : (restrictScalars f ⋙ extendScalars f).obj Y
     map_smul' := fun s z => by
       let m1 : Module R S := Module.compHom S f
       let m2 : Module R Y := Module.compHom Y f
-      induction z using TensorProduct.induction_on with
-      | zero => rw [smul_zero, map_zero, smul_zero]
+      induction z using TensorProduct.inductionOn with
       | tmul s' y => simp [mul_smul]
       | add _ _ ih1 ih2 => rw [smul_add, map_add, map_add, ih1, ih2, smul_add] }
 
@@ -865,8 +861,7 @@ def counit : restrictScalars.{max v u₂, u₁, u₂} f ⋙ extendScalars f ⟶ 
     let m2 : Module R Y := Module.compHom Y f
     let m2 : Module R Y' := Module.compHom Y' f
     ext z
-    induction z using TensorProduct.induction_on with
-    | zero => rw [map_zero, map_zero]
+    induction z using TensorProduct.inductionOn with
     | tmul s' y =>
       dsimp
       -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
@@ -892,8 +887,7 @@ def extendRestrictScalarsAdj {R : Type u₁} {S : Type u₂} [CommRing R] [CommR
       dsimp
       rfl
     homEquiv_counit := fun {X Y g} ↦ hom_ext <| LinearMap.ext fun x => by
-        induction x using TensorProduct.induction_on with
-        | zero => rw [map_zero, map_zero]
+        induction x using TensorProduct.inductionOn with
         | tmul =>
           rw [ExtendRestrictScalarsAdj.homEquiv_symm_apply]
           dsimp

--- a/Mathlib/Algebra/Category/Ring/Under/Limits.lean
+++ b/Mathlib/Algebra/Category/Ring/Under/Limits.lean
@@ -73,7 +73,6 @@ def tensorProductFanIso [Fintype ι] [DecidableEq ι] :
     apply CommRingCat.mkUnder_ext
     intro c
     induction c
-    · simp only [map_zero, Under.comp_right]
     · simp only [AlgHom.toUnder_right, Algebra.TensorProduct.map_tmul, AlgHom.coe_id, id_eq,
         Pi.evalAlgHom_apply, Under.comp_right, comp_apply, AlgEquiv.toUnder_hom_right_apply,
         Algebra.TensorProduct.piRight_tmul]

--- a/Mathlib/Algebra/Central/TensorProduct.lean
+++ b/Mathlib/Algebra/Central/TensorProduct.lean
@@ -43,8 +43,7 @@ lemma Algebra.TensorProduct.includeLeft_map_center_le :
   simp only [Subalgebra.mem_map, Subalgebra.mem_center_iff] at hx ⊢
   obtain ⟨b, hb0, rfl⟩ := hx
   intro bc
-  induction bc using TensorProduct.induction_on with
-  | zero => simp
+  induction bc using TensorProduct.inductionOn with
   | tmul b' c => simp [hb0]
   | add _ _ _ _ => simp_all [add_mul, mul_add]
 
@@ -53,8 +52,7 @@ lemma Algebra.TensorProduct.includeRight_map_center_le :
   simp only [Subalgebra.mem_map, Subalgebra.mem_center_iff] at hx ⊢
   obtain ⟨c, hc0, rfl⟩ := hx
   intro bc
-  induction bc using TensorProduct.induction_on with
-  | zero => simp
+  induction bc using TensorProduct.inductionOn with
   | tmul b c' => simp [hc0]
   | add _ _ _ _ => simp_all [add_mul, mul_add]
 

--- a/Mathlib/Algebra/Lie/BaseChange.lean
+++ b/Mathlib/Algebra/Lie/BaseChange.lean
@@ -63,18 +63,15 @@ theorem bracket_tmul (s t : A) (x : L) (y : M) : ⁅s ⊗ₜ[R] x, t ⊗ₜ[R] y
 set_option backward.privateInPublic true in
 private theorem bracket_lie_self (x : A ⊗[R] L) : ⁅x, x⁆ = 0 := by
   simp only [bracket_def]
-  refine x.induction_on ?_ ?_ ?_
-  · simp only [map_zero]
+  refine x.inductionOn ?_ ?_
   · intro a l
     simp only [bracket'_tmul, TensorProduct.tmul_zero, lie_self]
   · intro z₁ z₂ h₁ h₂
     suffices bracket' R A L L z₁ z₂ + bracket' R A L L z₂ z₁ = 0 by
       rw [map_add, map_add, LinearMap.add_apply, LinearMap.add_apply, h₁, h₂,
         zero_add, add_zero, add_comm, this]
-    refine z₁.induction_on ?_ ?_ ?_
-    · simp only [map_zero, add_zero, LinearMap.zero_apply]
-    · intro a₁ l₁; refine z₂.induction_on ?_ ?_ ?_
-      · simp only [map_zero, add_zero, LinearMap.zero_apply]
+    refine z₁.inductionOn ?_ ?_
+    · intro a₁ l₁; refine z₂.inductionOn ?_ ?_
       · intro a₂ l₂
         simp only [← lie_skew l₂ l₁, mul_comm a₁ a₂, TensorProduct.tmul_neg, bracket'_tmul,
           add_neg_cancel]
@@ -87,14 +84,11 @@ set_option backward.privateInPublic true in
 private theorem bracket_leibniz_lie (x y : A ⊗[R] L) (z : A ⊗[R] M) :
     ⁅x, ⁅y, z⁆⁆ = ⁅⁅x, y⁆, z⁆ + ⁅y, ⁅x, z⁆⁆ := by
   simp only [bracket_def]
-  refine x.induction_on ?_ ?_ ?_
-  · simp only [map_zero, add_zero, LinearMap.zero_apply]
+  refine x.inductionOn ?_ ?_
   · intro a₁ l₁
-    refine y.induction_on ?_ ?_ ?_
-    · simp only [map_zero, add_zero, LinearMap.zero_apply]
+    refine y.inductionOn ?_ ?_
     · intro a₂ l₂
-      refine z.induction_on ?_ ?_ ?_
-      · simp only [map_zero, add_zero]
+      refine z.inductionOn ?_ ?_
       · intro a₃ l₃; simp only [bracket'_tmul]
         rw [mul_left_comm a₂ a₁ a₃, mul_assoc, leibniz_lie, TensorProduct.tmul_add]
       · grind
@@ -131,11 +125,11 @@ def map {R A B L L' : Type*} [CommRing R] [CommRing A] [Algebra R A] [CommRing B
   { TensorProduct.map f.toLinearMap g with
     map_lie' {x y} := by
       simp only [bracket_def, AddHom.toFun_eq_coe, LinearMap.coe_toAddHom]
-      refine x.induction_on (by simp) ?_ ?_
+      refine x.inductionOn ?_ ?_
       · intro _ _
-        refine y.induction_on (by simp) (fun _ _ ↦ by simp) (fun _ _ h1 h2 ↦ by simp [h1, h2])
+        refine y.inductionOn (fun _ _ ↦ by simp) (fun _ _ h1 h2 ↦ by simp [h1, h2])
       · intro _ _
-        refine y.induction_on (by simp) (fun _ _ h ↦ by simp [h]) (by simp_all) }
+        refine y.inductionOn (fun _ _ h ↦ by simp [h]) (by simp_all) }
 
 @[simp]
 lemma map_apply_tmul {R A B L L' : Type*} [CommRing R] [CommRing A] [Algebra R A] [CommRing B]
@@ -195,7 +189,7 @@ def baseChange : LieSubmodule A (A ⊗[R] L) (A ⊗[R] M) :=
       rw [Submodule.mem_carrier, SetLike.mem_coe] at hm ⊢
       rw [Submodule.baseChange_eq_span] at hm
       obtain ⟨c, rfl⟩ := (Finsupp.mem_span_iff_linearCombination _ _ _).mp hm
-      refine x.induction_on (by simp) (fun a y ↦ ?_) (fun y z hy hz ↦ ?_)
+      refine x.inductionOn (fun a y ↦ ?_) (fun y z hy hz ↦ ?_)
       · change toEnd A (A ⊗[R] L) (A ⊗[R] M) _ _ ∈ _
         simp_rw [Finsupp.linearCombination_apply, Finsupp.sum, map_sum, map_smul, toEnd_apply_apply]
         refine Submodule.sum_mem _ fun ⟨_, n, hn, h⟩ _ ↦ Submodule.smul_mem _ _ ?_

--- a/Mathlib/Algebra/Lie/Derivation/BaseChange.lean
+++ b/Mathlib/Algebra/Lie/Derivation/BaseChange.lean
@@ -42,8 +42,8 @@ def ofDerivation : Derivation R A A →ₗ⁅R⁆ LieDerivation R (A ⊗[R] L) (
       map_smul' := by simp
       leibniz' x y := by
         simp only [LinearMap.coe_mk, AddHom.coe_mk]
-        refine x.induction_on (by simp) (fun _ l ↦ ?_) (fun _ _ h1 h2 ↦ ?_)
-        · refine y.induction_on (by simp) (fun _ l' ↦ ?_) (fun _ _ h1 h2 ↦ ?_)
+        refine x.inductionOn (fun _ l ↦ ?_) (fun _ _ h1 h2 ↦ ?_)
+        · refine y.inductionOn (fun _ l' ↦ ?_) (fun _ _ h1 h2 ↦ ?_)
           · simp [← lie_skew l' l, -lie_skew, add_tmul, tmul_neg]
           · simp [h1, h2, sub_add_sub_comm]
         · simp [h1, h2, sub_add_sub_comm] }
@@ -51,7 +51,7 @@ def ofDerivation : Derivation R A A →ₗ⁅R⁆ LieDerivation R (A ⊗[R] L) (
   map_smul' _ _ := by ext; simp
   map_lie' {_ _} := by
     ext z
-    refine z.induction_on (by simp) (by simp [sub_tmul]) (fun _ _ hx hy ↦ ?_)
+    refine z.inductionOn (by simp [sub_tmul]) (fun _ _ hx hy ↦ ?_)
     simp_all
     abel
 
@@ -70,9 +70,9 @@ def ofLieDerivation : (LieDerivation R L L) →ₗ⁅R⁆ (LieDerivation R (A �
       map_smul' := by simp
       leibniz' x y := by
         simp only [LinearMap.coe_mk, AddHom.coe_mk]
-        refine x.induction_on (by simp) ?_ ?_
+        refine x.inductionOn ?_ ?_
         · intros _ _
-          refine y.induction_on (by simp) ?_ ?_
+          refine y.inductionOn ?_ ?_
           · intros _ _
             simp [LieAlgebra.ExtendScalars.bracket_tmul, tmul_sub, mul_comm]
           · intros _ _ h1 h2
@@ -85,7 +85,7 @@ def ofLieDerivation : (LieDerivation R L L) →ₗ⁅R⁆ (LieDerivation R (A �
   map_smul' _ _ := by ext _; simp
   map_lie' {_ _} := by
     ext z
-    refine z.induction_on (by simp) (fun a l ↦ ?_) (fun _ _ hx hy ↦ ?_)
+    refine z.inductionOn (fun a l ↦ ?_) (fun _ _ hx hy ↦ ?_)
     · simp [tmul_sub]
     · simp_all [sub_add_sub_comm]
 

--- a/Mathlib/Algebra/Lie/Loop.lean
+++ b/Mathlib/Algebra/Lie/Loop.lean
@@ -80,12 +80,10 @@ noncomputable instance [DecidableEq A] [AddCommMonoid A] :
     rw [decomposeTensor_apply] at hi hj ⊢
     obtain ⟨xi, rfl⟩ := hi
     obtain ⟨xj, rfl⟩ := hj
-    induction xi using TensorProduct.induction_on with
-    | zero => simp
+    induction xi using TensorProduct.inductionOn with
     | tmul x y =>
       simp only [LinearMap.rTensor_tmul, Submodule.subtype_apply]
-      induction xj using TensorProduct.induction_on with
-      | zero => simp
+      induction xj using TensorProduct.inductionOn with
       | tmul u v =>
         obtain ⟨x, hx⟩ := x
         obtain ⟨u, hu⟩ := u

--- a/Mathlib/Algebra/Lie/TensorProduct.lean
+++ b/Mathlib/Algebra/Lie/TensorProduct.lean
@@ -122,8 +122,7 @@ nonrec def map (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) : M ⊗[R] N 
   { map (f : M →ₗ[R] P) (g : N →ₗ[R] Q) with
     map_lie' := fun {x t} => by
       simp only [LinearMap.toFun_eq_coe]
-      refine t.induction_on ?_ ?_ ?_
-      · simp only [map_zero, lie_zero]
+      refine t.inductionOn ?_ ?_
       · intro m n
         simp only [LieModuleHom.coe_toLinearMap, lie_tmul_right, LieModuleHom.map_lie, map_tmul,
           map_add]

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -307,7 +307,7 @@ lemma lowerCentralSeries_one_inf_center_le_ker_traceForm [Module.Free R M] [Modu
   replace hzc : 1 ⊗ₜ[R] z ∈ LieAlgebra.center A (A ⊗[R] L) := by
     simp only [mem_maxTrivSubmodule] at hzc ⊢
     intro y
-    exact y.induction_on rfl (fun a u ↦ by simp [hzc u])
+    exact y.inductionOn (fun a u ↦ by simp [hzc u])
       (fun u v hu hv ↦ by simp [A, hu, hv])
   apply LinearMap.trace_comp_eq_zero_of_commute_of_trace_restrict_eq_zero
   · exact IsTriangularizable.maxGenEigenspace_eq_top (1 ⊗ₜ[R] x)

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -87,8 +87,7 @@ protected theorem weight_vector_multiplication (M₁ M₂ M₃ : Type*)
   -- Set up some notation.
   let F : Module.End R M₃ := toEnd R L M₃ x - (χ₁ + χ₂) • ↑1
   -- The goal is linear in `t` so use induction to reduce to the case that `t` is a pure tensor.
-  refine t.induction_on ?_ ?_ ?_
-  · use 0; simp only [map_zero]
+  refine t.inductionOn ?_ ?_
   swap
   · rintro t₁ t₂ ⟨k₁, hk₁⟩ ⟨k₂, hk₂⟩; use max k₁ k₂
     simp only [map_add, Module.End.pow_map_zero_of_le (le_max_left k₁ k₂) hk₁,

--- a/Mathlib/Algebra/Module/Bimodule.lean
+++ b/Mathlib/Algebra/Module/Bimodule.lean
@@ -84,7 +84,7 @@ def mk (p : AddSubmonoid M) (hA : ∀ (a : A) {m : M}, m ∈ p → a • m ∈ p
   { p with
     carrier := p
     smul_mem' := fun ab m =>
-      TensorProduct.induction_on ab (fun _ => by simp only [zero_smul, SetLike.mem_coe, zero_mem])
+      TensorProduct.inductionOn ab
         (fun a b hm => by simpa only [TensorProduct.Algebra.smul_def] using! hA a (hB b hm))
         fun z w hz hw hm => by simpa only [add_smul] using! p.add_mem (hz hm) (hw hm) }
 

--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -119,9 +119,9 @@ Any linear map `L : A → B⋆` induces a character in `(A ⊗ B)⋆` by `a ⊗ 
 @[simps] noncomputable def uncurry :
     (A →ₗ[R] CharacterModule B) →ₗ[R] CharacterModule (A ⊗[R] B) where
   toFun c := TensorProduct.liftAddHom c.toAddMonoidHom fun r a b ↦ congr($(c.map_smul r a) b)
-  map_add' c c' := DFunLike.ext _ _ fun x ↦ by refine x.induction_on ?_ ?_ ?_ <;> aesop
-  map_smul' r c := DFunLike.ext _ _ fun x ↦ x.induction_on
-    (by simp_rw [map_zero]) (fun a b ↦ congr($(c.map_smul r a) b).symm) (by aesop)
+  map_add' c c' := DFunLike.ext _ _ fun x ↦ by refine x.inductionOn ?_ ?_ <;> aesop
+  map_smul' r c := DFunLike.ext _ _ fun x ↦ x.inductionOn
+    (fun a b ↦ congr($(c.map_smul r a) b).symm) (by aesop)
 
 /--
 Any character `c` in `(A ⊗ B)⋆` induces a linear map `A → B⋆` by `a ↦ b ↦ c (a ⊗ b)`.
@@ -142,7 +142,7 @@ Linear maps into a character module are exactly characters of the tensor product
 -/
 @[simps!] noncomputable def homEquiv :
     (A →ₗ[R] CharacterModule B) ≃ₗ[R] CharacterModule (A ⊗[R] B) :=
-  .ofLinearMap uncurry curry (by ext _ z; refine z.induction_on ?_ ?_ ?_ <;> aesop) (by aesop)
+  .ofLinearMap uncurry curry (by ext _ z; refine z.inductionOn ?_ ?_ <;> aesop) (by aesop)
 
 theorem dual_rTensor_conj_homEquiv (f : A →ₗ[R] A') :
     homEquiv.symm.toLinearMap ∘ₗ dual (f.rTensor B) ∘ₗ homEquiv.toLinearMap = f.lcomp R _ := rfl

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -600,8 +600,7 @@ lemma X_pow_smul_rTensor_monomial [CommSemiring S] [Algebra R S] {N : Type*}
     [AddCommMonoid N] [Module R N] (k : ℕ) (sn : S ⊗[R] N) :
     X (R := S) ^ k • (LinearMap.rTensor N ((monomial 0).restrictScalars R)) sn =
       (LinearMap.rTensor N ((monomial k).restrictScalars R)) sn := by
-  induction sn using TensorProduct.induction_on with
-  | zero => simp
+  induction sn using TensorProduct.inductionOn with
   | add x y hx hy => simp [hx, hy]
   | tmul s n =>
     simp only [rTensor_tmul, coe_restrictScalars, monomial_zero_left]

--- a/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
@@ -71,7 +71,7 @@ variable (𝕜) in
 
 @[simp] lemma inner_map_map (f : E →ₗᵢ[𝕜] G) (g : F →ₗᵢ[𝕜] H) (x y : E ⊗[𝕜] F) :
     inner 𝕜 (map f.toLinearMap g.toLinearMap x) (map f.toLinearMap g.toLinearMap y) = inner 𝕜 x y :=
-  x.induction_on (by simp [inner_def]) (y.induction_on (by simp [inner_def]) (by simp)
+  x.inductionOn (y.inductionOn (by simp)
     (by simp_all [inner_def])) (by simp_all [inner_def])
 
 lemma inner_mapIncl_mapIncl (E' : Submodule 𝕜 E) (F' : Submodule 𝕜 F) (x y : E' ⊗[𝕜] F') :
@@ -133,7 +133,7 @@ set_option backward.privateInPublic.warn false in
 noncomputable instance instNormedAddCommGroup : NormedAddCommGroup (E ⊗[𝕜] F) :=
   letI : InnerProductSpace.Core 𝕜 (E ⊗[𝕜] F) :=
   { conj_inner_symm x y :=
-      x.induction_on (by simp [inner]) (y.induction_on (by simp [inner]) (by simp)
+      x.inductionOn (y.inductionOn (by simp)
         (by simp_all [inner])) (by simp_all [inner])
     add_left _ _ _ := LinearMap.map_add₂ _ _ _ _
     smul_left _ _ _ := LinearMap.map_smulₛₗ₂ _ _ _ _
@@ -336,8 +336,8 @@ noncomputable def mapInclIsometry (E' : Submodule 𝕜 E) (F' : Submodule 𝕜 F
 
 @[simp] theorem inner_comm_comm (x y : E ⊗[𝕜] F) :
     inner 𝕜 (TensorProduct.comm 𝕜 E F x) (TensorProduct.comm 𝕜 E F y) = inner 𝕜 x y :=
-  x.induction_on (by simp) (fun _ _ =>
-    y.induction_on (by simp) (by simp [mul_comm])
+  x.inductionOn (fun _ _ =>
+    y.inductionOn (by simp [mul_comm])
     fun _ _ h1 h2 => by simp only [inner_add_right, map_add, h1, h2])
   fun _ _ h1 h2 => by simp only [inner_add_left, map_add, h1, h2]
 
@@ -363,8 +363,8 @@ noncomputable def commIsometry : E ⊗[𝕜] F ≃ₗᵢ[𝕜] F ⊗[𝕜] E :=
 
 @[simp] theorem inner_lid_lid (x y : 𝕜 ⊗[𝕜] E) :
     inner 𝕜 (TensorProduct.lid 𝕜 E x) (TensorProduct.lid 𝕜 E y) = inner 𝕜 x y :=
-  x.induction_on (by simp) (fun _ _ =>
-    y.induction_on (by simp) (by simp [inner_smul_left, inner_smul_right, mul_assoc])
+  x.inductionOn (fun _ _ =>
+    y.inductionOn (by simp [inner_smul_left, inner_smul_right, mul_assoc])
     fun _ _ h1 h2 => by simp only [inner_add_right, map_add, h1, h2])
   fun _ _ h1 h2 => by simp only [inner_add_left, map_add, h1, h2]
 
@@ -422,10 +422,10 @@ lemma lidIsometry_eq_ridIsometry : lidIsometry 𝕜 𝕜 = ridIsometry 𝕜 𝕜
 
 @[simp] theorem inner_assoc_assoc (x y : E ⊗[𝕜] F ⊗[𝕜] G) :
     inner 𝕜 (TensorProduct.assoc 𝕜 E F G x) (TensorProduct.assoc 𝕜 E F G y) = inner 𝕜 x y :=
-  x.induction_on (by simp) (fun a _ =>
-    y.induction_on (by simp) (fun c _ =>
-      a.induction_on (by simp) (fun _ _ =>
-        c.induction_on (by simp) (by simp [mul_assoc])
+  x.inductionOn (fun a _ =>
+    y.inductionOn (fun c _ =>
+      a.inductionOn (fun _ _ =>
+        c.inductionOn (by simp [mul_assoc])
         fun _ _ h1 h2 => by simp only [add_tmul, inner_add_right, map_add, h1, h2])
       fun _ _ h1 h2 => by simp only [add_tmul, inner_add_left, map_add, h1, h2])
     fun _ _ h1 h2 => by simp only [inner_add_right, map_add, h1, h2])

--- a/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
@@ -672,7 +672,6 @@ lemma IsPurelyInseparable.exists_pow_pow_mem_range_tensorProduct_of_expChar
   nontriviality (R ⊗[k] K)
   obtain (hq | hq) := expChar_is_prime_or_one k q
   induction x with
-  | zero => exact ⟨0, 0, by simp⟩
   | add x y h h' =>
     have : ExpChar (R ⊗[k] K) q := expChar_of_injective_ringHom (algebraMap k _).injective q
     simp_rw [RingHom.mem_range, ← RingHom.mem_rangeS, ← Subalgebra.mem_perfectClosure_iff] at h h' ⊢

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -76,7 +76,6 @@ lemma finsuppLeft_apply_tmul_apply (p : ι →₀ M) (n : N) (i : ι) :
 theorem finsuppLeft_apply (t : (ι →₀ M) ⊗[R] N) (i : ι) :
     finsuppLeft R S M N ι t i = rTensor N (Finsupp.lapply i) t := by
   induction t with
-  | zero => simp
   | tmul f n => simp only [finsuppLeft_apply_tmul_apply, rTensor_tmul, Finsupp.lapply_apply]
   | add x y hx hy => simp [map_add, hx, hy]
 
@@ -109,7 +108,6 @@ lemma finsuppRight_apply_tmul_apply (m : M) (p : ι →₀ N) (i : ι) :
 theorem finsuppRight_apply (t : M ⊗[R] (ι →₀ N)) (i : ι) :
     finsuppRight R S M N ι t i = lTensor M (Finsupp.lapply i) t := by
   induction t with
-  | zero => simp
   | tmul m f => simp [finsuppRight_apply_tmul_apply]
   | add x y hx hy => simp [map_add, hx, hy]
 

--- a/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
@@ -120,8 +120,7 @@ lemma directSumLeft_tmul (m : ⨁ i, M₁ i) (n : M₂') (i : ι₁) :
 lemma directSumLeft_symm_of {i : ι₁} (x : (M₁ i) ⊗[R] M₂') :
     (directSumLeft R S M₁ M₂').symm ((of (fun i ↦ M₁ i ⊗[R] M₂') i) x) =
       rTensor M₂' (lof R ι₁ M₁ i) x := by
-  induction x using TensorProduct.induction_on with
-  | zero => simp
+  induction x using TensorProduct.inductionOn with
   | tmul x y => rw [← lof_eq_of S, directSumLeft_symm_lof_tmul, rTensor_tmul, lof_eq_of, lof_eq_of]
   | add x y h₁ h₂ => simp [h₁, h₂]
 

--- a/Mathlib/LinearAlgebra/Dual/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/Dual/BaseChange.lean
@@ -120,7 +120,6 @@ noncomputable def toDualBaseChange :
   simp only [AlgebraTensorModule.curry_apply, curry_apply, LinearMap.coe_restrictScalars,
     LinearEquiv.coe_coe, LinearEquiv.trans_apply]
   induction w using ibc.inductionOn with
-  | zero => simp
   | tmul v =>
     simp only [toDualBaseChangeAux_tmul, one_mul]
     conv_lhs => rw [← Basis.sum_equivFun b v, map_sum]

--- a/Mathlib/LinearAlgebra/Dual/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/Dual/BaseChange.lean
@@ -93,8 +93,7 @@ private noncomputable def toDualBaseChangeAux :
     map_add' a b := by simp [add_smul]
     map_smul' r a := by simp }).toAddHom
   map_smul' a g := by
-    induction g using TensorProduct.induction_on with
-    | zero => simp
+    induction g using TensorProduct.inductionOn with
     | add x y hx hy => aesop
     | tmul b f => simp [TensorProduct.smul_tmul', mul_smul]
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -163,7 +163,6 @@ theorem baseChange_ext ⦃Q₁ Q₂ : QuadraticMap A (A ⊗[R] M₂) N₁⦄
   ext x
   induction x with
   | tmul => simp [h]
-  | zero => simp
   | add x y hx hy =>
     have : Q₁.polarBilin = Q₂.polarBilin := by
       ext

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -385,7 +385,6 @@ lemma tensorProductAssoc_def (eA : A ≃ₗ[R] A') (eB : B ≃ₗ[R] B') (eC : C
       (TensorProduct.assoc R A' B' C') <| congr eA.symm <| congr eB.symm (eC).symm) := by
   ext x
   induction x with
-  | zero => simp
   | add => simp [*]
   | tmul x a => induction x <;> simp [*, add_tmul]
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -106,7 +106,7 @@ variable {f f'}
 
 @[simp]
 theorem liftAux.smulₛₗ (r : R) (x) : liftAux f' (r • x) = σ₁₂ r • liftAux f' x :=
-  TensorProduct.induction_on x (smul_zero _).symm
+  TensorProduct.inductionOn x
     (fun p q => by simp_rw [← tmul_smul, liftAux_tmul, (f' p).map_smulₛₗ])
     fun p q ih1 ih2 => by simp_rw [smul_add, (liftAux f').map_add, ih1, ih2, smul_add]
 
@@ -132,7 +132,7 @@ theorem lift.tmul' (x y) : (lift f').1 (x ⊗ₜ y) = f' x y :=
 
 theorem ext' {g h : M ⊗[R] N →ₛₗ[σ₁₂] P₂} (H : ∀ x y, g (x ⊗ₜ y) = h (x ⊗ₜ y)) : g = h :=
   LinearMap.ext fun z =>
-    TensorProduct.induction_on z (by simp_rw [map_zero]) H fun x y ihx ihy => by
+    TensorProduct.inductionOn z H fun x y ihx ihy => by
       rw [g.map_add, h.map_add, ihx, ihy]
 
 theorem lift.unique {g : M ⊗[R] N →ₛₗ[σ₁₂] P₂} (H : ∀ x y, g (x ⊗ₜ y) = f' x y) : g = lift f' :=
@@ -322,7 +322,6 @@ def mapOfCompatibleSMul : M ⊗[A] N →ₗ[S] M ⊗[R] N where
       map_smul' := fun _ _ ↦ rfl }
   map_smul' s x := by
     induction x with
-    | zero => simp
     | add x y _ _ => simp_all
     | tmul x y => simp [smul_tmul']
 
@@ -332,7 +331,7 @@ def mapOfCompatibleSMul : M ⊗[A] N →ₗ[S] M ⊗[R] N where
 /-- The map `mapOfCompatibleSMul` is surjective. Its kernel is characterized by the Lemma
 `TensorProduct.AlgebraTensorModule.ker_mapOfCompatibleSMul`. -/
 theorem mapOfCompatibleSMul_surjective : Function.Surjective (mapOfCompatibleSMul R A S M N) :=
-  fun x ↦ x.induction_on (⟨0, map_zero _⟩) (fun m n ↦ ⟨_, mapOfCompatibleSMul_tmul ..⟩)
+  fun x ↦ x.inductionOn (fun m n ↦ ⟨_, mapOfCompatibleSMul_tmul ..⟩)
     fun _ _ ⟨x, hx⟩ ⟨y, hy⟩ ↦ ⟨x + y, by simpa using congr($hx + $hy)⟩
 
 attribute [local instance] SMulCommClass.symm
@@ -343,9 +342,9 @@ where `S` is any other ring acting on `M` and whose action commutes with the `A`
 def equivOfCompatibleSMul [CompatibleSMul A R M N] : M ⊗[A] N ≃ₗ[S] M ⊗[R] N where
   __ := mapOfCompatibleSMul R A S M N
   invFun := mapOfCompatibleSMul A R S M N
-  left_inv x := x.induction_on (map_zero _) (fun _ _ ↦ rfl)
+  left_inv x := x.inductionOn (fun _ _ ↦ rfl)
     fun _ _ h h' ↦ by simpa using congr($h + $h')
-  right_inv x := x.induction_on (map_zero _) (fun _ _ ↦ rfl)
+  right_inv x := x.inductionOn (fun _ _ ↦ rfl)
     fun _ _ h h' ↦ by simpa using congr($h + $h')
 
 end CompatibleSMul
@@ -376,8 +375,7 @@ instance neg : Neg (M ⊗[R] N) where
   neg := Neg.aux R
 
 protected theorem neg_add_cancel (x : M ⊗[R] N) : -x + x = 0 :=
-  x.induction_on
-    (by rw [add_zero]; apply (Neg.aux R).map_zero)
+  x.inductionOn
     (fun x y => by convert! (add_tmul (R := R) (-x) x y).symm; rw [neg_add_cancel, zero_tmul])
     fun x y hx hy => by
     suffices -x + x + (-y + y) = 0 by

--- a/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
@@ -115,16 +115,6 @@ unsafe instance [Repr M] [Repr N] : Repr (M ⊗[R] N) where
       (if p > 65 then (Std.Format.bracketFill "(" · ")") else (.fill ·)) <|
         .joinSep parts f!" +{Std.Format.line}"
 
-@[deprecated "Use `TensorProduction.inductionOn` instead" (since := "2026-09-07")]
-protected theorem induction_on {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
-    (zero : motive 0)
-    (tmul : ∀ x y, motive <| x ⊗ₜ[R] y)
-    (add : ∀ x y, motive x → motive y → motive (x + y)) : motive z :=
-  AddCon.induction_on z fun x =>
-    FreeAddMonoid.recOn x zero fun ⟨m, n⟩ y ih => by
-      rw [AddCon.coe_add]
-      exact add _ _ (tmul ..) ih
-
 variable (M) in
 @[simp]
 theorem zero_tmul (n : N) : (0 : M) ⊗ₜ[R] n = 0 :=
@@ -149,6 +139,14 @@ protected theorem inductionOn {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
     FreeAddMonoid.recOn x (by convert (tmul 0 0); simp; rfl) fun ⟨m, n⟩ y ih => by
       rw [AddCon.coe_add]
       exact add _ _ (tmul ..) ih
+
+set_option linter.unusedVariables false
+@[deprecated "Use `TensorProduction.inductionOn` instead" (since := "2026-09-07")]
+protected theorem induction_on {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
+    (zero : motive 0)
+    (tmul : ∀ x y, motive <| x ⊗ₜ[R] y)
+    (add : ∀ x y, motive x → motive y → motive (x + y)) : motive z :=
+  TensorProduct.inductionOn z tmul add
 
 instance uniqueLeft [Subsingleton M] : Unique (M ⊗[R] N) where
   default := 0

--- a/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
@@ -115,7 +115,7 @@ unsafe instance [Repr M] [Repr N] : Repr (M ⊗[R] N) where
       (if p > 65 then (Std.Format.bracketFill "(" · ")") else (.fill ·)) <|
         .joinSep parts f!" +{Std.Format.line}"
 
-@[elab_as_elim, induction_eliminator]
+@[elab_as_elim]
 protected theorem induction_on {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
     (zero : motive 0)
     (tmul : ∀ x y, motive <| x ⊗ₜ[R] y)
@@ -141,14 +141,23 @@ theorem tmul_zero (m : M) : m ⊗ₜ[R] (0 : N) = 0 :=
 theorem tmul_add (m : M) (n₁ n₂ : N) : m ⊗ₜ (n₁ + n₂) = m ⊗ₜ n₁ + m ⊗ₜ[R] n₂ :=
   Eq.symm <| Quotient.sound' <| AddConGen.Rel.of _ _ <| Eqv.of_add_right _ _ _
 
+@[elab_as_elim, induction_eliminator]
+protected theorem inductionOn {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
+    (tmul : ∀ x y, motive <| x ⊗ₜ[R] y)
+    (add : ∀ x y, motive x → motive y → motive (x + y)) : motive z :=
+  AddCon.induction_on z fun x =>
+    FreeAddMonoid.recOn x (by convert (tmul 0 0); simp; rfl) fun ⟨m, n⟩ y ih => by
+      rw [AddCon.coe_add]
+      exact add _ _ (tmul ..) ih
+
 instance uniqueLeft [Subsingleton M] : Unique (M ⊗[R] N) where
   default := 0
-  uniq z := z.induction_on rfl (fun x y ↦ by rw [Subsingleton.elim x 0, zero_tmul]) <| by
+  uniq z := z.inductionOn (fun x y ↦ by rw [Subsingleton.elim x 0, zero_tmul]) <| by
     rintro _ _ rfl rfl; apply add_zero
 
 instance uniqueRight [Subsingleton N] : Unique (M ⊗[R] N) where
   default := 0
-  uniq z := z.induction_on rfl (fun x y ↦ by rw [Subsingleton.elim y 0, tmul_zero]) <| by
+  uniq z := z.inductionOn (fun x y ↦ by rw [Subsingleton.elim y 0, tmul_zero]) <| by
     rintro _ _ rfl rfl; apply add_zero
 
 section
@@ -242,19 +251,19 @@ protected theorem smul_add (r : R') (x y : M ⊗[R] N) : r • (x + y) = r • x
 
 protected theorem zero_smul (x : M ⊗[R] N) : (0 : R'') • x = 0 :=
   have : ∀ (r : R'') (m : M) (n : N), r • m ⊗ₜ[R] n = (r • m) ⊗ₜ n := fun _ _ _ => rfl
-  x.induction_on (by rw [TensorProduct.smul_zero])
+  x.inductionOn
     (fun m n => by rw [this, zero_smul, zero_tmul]) fun x y ihx ihy => by
     rw [TensorProduct.smul_add, ihx, ihy, add_zero]
 
 protected theorem one_smul (x : M ⊗[R] N) : (1 : R') • x = x :=
   have : ∀ (r : R') (m : M) (n : N), r • m ⊗ₜ[R] n = (r • m) ⊗ₜ n := fun _ _ _ => rfl
-  x.induction_on (by rw [TensorProduct.smul_zero])
+  x.inductionOn
     (fun m n => by rw [this, one_smul])
     fun x y ihx ihy => by rw [TensorProduct.smul_add, ihx, ihy]
 
 protected theorem add_smul (r s : R'') (x : M ⊗[R] N) : (r + s) • x = r • x + s • x :=
   have : ∀ (r : R'') (m : M) (n : N), r • m ⊗ₜ[R] n = (r • m) ⊗ₜ n := fun _ _ _ => rfl
-  x.induction_on (by simp_rw [TensorProduct.smul_zero, add_zero])
+  x.inductionOn
     (fun m n => by simp_rw [this, add_smul, add_tmul]) fun x y ihx ihy => by
     simp_rw [TensorProduct.smul_add]
     rw [ihx, ihy, add_add_add_comm]
@@ -283,7 +292,7 @@ instance leftDistribMulAction : DistribMulAction R' (M ⊗[R] N) :=
   have : ∀ (r : R') (m : M) (n : N), r • m ⊗ₜ[R] n = (r • m) ⊗ₜ n := fun _ _ _ => rfl
   { smul_add := fun r x y => TensorProduct.smul_add r x y
     mul_smul := fun r s x =>
-      x.induction_on (by simp_rw [TensorProduct.smul_zero])
+      x.inductionOn
         (fun m n => by simp_rw [this, mul_smul]) fun x y ihx ihy => by
         simp_rw [TensorProduct.smul_add]
         rw [ihx, ihy]
@@ -317,7 +326,7 @@ instance : Module R (M ⊗[R] N) :=
 
 instance [Module R''ᵐᵒᵖ M] [IsCentralScalar R'' M] : IsCentralScalar R'' (M ⊗[R] N) where
   op_smul_eq_smul r x :=
-    x.induction_on (by rw [smul_zero, smul_zero])
+    x.inductionOn
       (fun x y => by rw [smul_tmul', smul_tmul', op_smul_eq_smul]) fun x y hx hy => by
       rw [smul_add, smul_add, hx, hy]
 
@@ -330,7 +339,7 @@ variable [SMulCommClass R R'₂ M]
 /-- `SMulCommClass R' R'₂ M` implies `SMulCommClass R' R'₂ (M ⊗[R] N)` -/
 instance smulCommClass_left [SMulCommClass R' R'₂ M] : SMulCommClass R' R'₂ (M ⊗[R] N) where
   smul_comm r' r'₂ x :=
-    TensorProduct.induction_on x (by simp_rw [TensorProduct.smul_zero])
+    TensorProduct.inductionOn x
       (fun m n => by simp_rw [smul_tmul', smul_comm]) fun x y ihx ihy => by
       simp_rw [TensorProduct.smul_add]; rw [ihx, ihy]
 
@@ -339,7 +348,7 @@ variable [SMul R'₂ R']
 /-- `IsScalarTower R'₂ R' M` implies `IsScalarTower R'₂ R' (M ⊗[R] N)` -/
 instance isScalarTower_left [IsScalarTower R'₂ R' M] : IsScalarTower R'₂ R' (M ⊗[R] N) :=
   ⟨fun s r x =>
-    x.induction_on (by simp)
+    x.inductionOn
       (fun m n => by rw [smul_tmul', smul_tmul', smul_tmul', smul_assoc]) fun x y ihx ihy => by
       rw [smul_add, smul_add, smul_add, ihx, ihy]⟩
 
@@ -349,7 +358,7 @@ variable [CompatibleSMul R R'₂ M N] [CompatibleSMul R R' M N]
 /-- `IsScalarTower R'₂ R' N` implies `IsScalarTower R'₂ R' (M ⊗[R] N)` -/
 instance isScalarTower_right [IsScalarTower R'₂ R' N] : IsScalarTower R'₂ R' (M ⊗[R] N) :=
   ⟨fun s r x =>
-    x.induction_on (by simp)
+    x.inductionOn
       (fun m n => by rw [← tmul_smul, ← tmul_smul, ← tmul_smul, smul_assoc]) fun x y ihx ihy => by
       rw [smul_add, smul_add, smul_add, ihx, ihy]⟩
 
@@ -410,8 +419,7 @@ variable (R M N)
 /-- The simple (aka pure) elements span the tensor product. -/
 theorem span_tmul_eq_top : Submodule.span R { t : M ⊗[R] N | ∃ m n, m ⊗ₜ n = t } = ⊤ := by
   ext t; simp only [Submodule.mem_top, iff_true]
-  refine t.induction_on ?_ ?_ ?_
-  · exact Submodule.zero_mem _
+  refine t.inductionOn ?_ ?_
   · intro m n
     apply Submodule.subset_span
     use m, n
@@ -427,9 +435,6 @@ theorem exists_eq_tmul_of_forall (x : TensorProduct R M N)
     (h : ∀ (m₁ m₂ : M) (n₁ n₂ : N), ∃ m n, m₁ ⊗ₜ n₁ + m₂ ⊗ₜ n₂ = m ⊗ₜ[R] n) :
     ∃ m n, x = m ⊗ₜ n := by
   induction x with
-  | zero =>
-    use 0, 0
-    rw [TensorProduct.zero_tmul]
   | tmul m n => use m, n
   | add x y h₁ h₂ =>
     obtain ⟨m₁, n₁, rfl⟩ := h₁

--- a/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
@@ -137,8 +137,7 @@ protected theorem inductionOn {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
     (add : ∀ x y, motive x → motive y → motive (x + y)) : motive z :=
   AddCon.induction_on z fun x =>
     FreeAddMonoid.recOn x (by simpa using! tmul 0 0) fun ⟨m, n⟩ y ih => by
-      rw [AddCon.coe_add]
-      exact add _ _ (tmul ..) ih
+      simpa using! add _ _ (tmul ..) ih
 
 set_option linter.unusedVariables false
 @[deprecated "Use `TensorProduction.inductionOn` instead" (since := "2026-09-07")]

--- a/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
@@ -136,7 +136,7 @@ protected theorem inductionOn {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
     (tmul : ∀ x y, motive <| x ⊗ₜ[R] y)
     (add : ∀ x y, motive x → motive y → motive (x + y)) : motive z :=
   AddCon.induction_on z fun x =>
-    FreeAddMonoid.recOn x (by convert (tmul 0 0); simp; rfl) fun ⟨m, n⟩ y ih => by
+    FreeAddMonoid.recOn x (by simpa using! tmul 0 0) fun ⟨m, n⟩ y ih => by
       rw [AddCon.coe_add]
       exact add _ _ (tmul ..) ih
 
@@ -150,12 +150,12 @@ protected theorem induction_on {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
 
 instance uniqueLeft [Subsingleton M] : Unique (M ⊗[R] N) where
   default := 0
-  uniq z := z.inductionOn (fun x y ↦ by rw [Subsingleton.elim x 0, zero_tmul]) <| by
+  uniq z := z.inductionOn (fun x y => by rw [Subsingleton.elim x 0, zero_tmul]) <| by
     rintro _ _ rfl rfl; apply add_zero
 
 instance uniqueRight [Subsingleton N] : Unique (M ⊗[R] N) where
   default := 0
-  uniq z := z.inductionOn (fun x y ↦ by rw [Subsingleton.elim y 0, tmul_zero]) <| by
+  uniq z := z.inductionOn (fun x y => by rw [Subsingleton.elim y 0, tmul_zero]) <| by
     rintro _ _ rfl rfl; apply add_zero
 
 section

--- a/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
@@ -115,7 +115,7 @@ unsafe instance [Repr M] [Repr N] : Repr (M ⊗[R] N) where
       (if p > 65 then (Std.Format.bracketFill "(" · ")") else (.fill ·)) <|
         .joinSep parts f!" +{Std.Format.line}"
 
-@[elab_as_elim]
+@[deprecated "Use `TensorProduction.inductionOn` instead" (since := "2026-09-07")]
 protected theorem induction_on {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
     (zero : motive 0)
     (tmul : ∀ x y, motive <| x ⊗ₜ[R] y)

--- a/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
@@ -150,12 +150,12 @@ protected theorem induction_on {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
 
 instance uniqueLeft [Subsingleton M] : Unique (M ⊗[R] N) where
   default := 0
-  uniq z := z.inductionOn (fun x y => by rw [Subsingleton.elim x 0, zero_tmul]) <| by
+  uniq z := z.inductionOn (fun x y ↦ by rw [Subsingleton.elim x 0, zero_tmul]) <| by
     rintro _ _ rfl rfl; apply add_zero
 
 instance uniqueRight [Subsingleton N] : Unique (M ⊗[R] N) where
   default := 0
-  uniq z := z.inductionOn (fun x y => by rw [Subsingleton.elim y 0, tmul_zero]) <| by
+  uniq z := z.inductionOn (fun x y ↦ by rw [Subsingleton.elim y 0, tmul_zero]) <| by
     rintro _ _ rfl rfl; apply add_zero
 
 section

--- a/Mathlib/LinearAlgebra/TensorProduct/DirectLimit.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/DirectLimit.lean
@@ -47,7 +47,7 @@ given by `gᵢ ⊗ m ↦ [gᵢ] ⊗ m`.
 noncomputable def fromDirectLimit :
     DirectLimit (G · ⊗[R] M) (f ▷ M) →ₗ[R] DirectLimit G f ⊗[R] M :=
   Module.DirectLimit.lift _ _ _ _ (fun _ ↦ (of _ _ _ _ _).rTensor M)
-    fun _ _ _ x ↦ by refine x.induction_on ?_ ?_ ?_ <;> aesop
+    fun _ _ _ x ↦ by refine x.inductionOn ?_ ?_ <;> aesop
 
 variable {M} in
 @[simp] lemma fromDirectLimit_of_tmul {i : ι} (g : G i) (m : M) :
@@ -89,7 +89,7 @@ noncomputable def directLimitLeft :
 
 lemma directLimitLeft_rTensor_of {i : ι} (x : G i ⊗[R] M) :
     directLimitLeft f M (LinearMap.rTensor M (of ..) x) = of _ _ _ (f ▷ M) _ x :=
-  x.induction_on (by simp) (by simp +contextual) (by simp +contextual)
+  x.inductionOn (by simp +contextual) (by simp +contextual)
 
 /--
 `M ⊗ (limᵢ Gᵢ)` and `limᵢ (M ⊗ Gᵢ)` are isomorphic as modules

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -57,7 +57,6 @@ of `M × N`, such that `x` is equal to the sum of `m_i ⊗ₜ[R] n_i`. -/
 theorem exists_multiset (x : M ⊗[R] N) :
     ∃ S : Multiset (M × N), x = (S.map fun i ↦ i.1 ⊗ₜ[R] i.2).sum := by
   induction x with
-  | zero => exact ⟨0, by simp⟩
   | tmul x y => exact ⟨{(x, y)}, by simp⟩
   | add x y hx hy =>
     obtain ⟨Sx, hx⟩ := hx
@@ -70,7 +69,6 @@ such that `x` is equal to the sum of `m_i ⊗ₜ[R] n_i`. -/
 theorem exists_finsupp_left (x : M ⊗[R] N) :
     ∃ S : M →₀ N, x = S.sum fun m n ↦ m ⊗ₜ[R] n := by
   induction x with
-  | zero => exact ⟨0, by simp⟩
   | tmul x y => exact ⟨Finsupp.single x y, by simp⟩
   | add x y hx hy =>
     obtain ⟨Sx, hx⟩ := hx
@@ -111,8 +109,7 @@ theorem exists_finite_submodule_of_setFinite (s : Set (M ⊗[R] N)) (hs : s.Fini
   | empty => exact ⟨_, _, fg_bot, fg_bot, Set.empty_subset _⟩
   | @insert a s _ _ ih =>
   obtain ⟨M', N', hM', hN', h⟩ := ih
-  refine TensorProduct.induction_on a ?_ (fun x y ↦ ?_) fun x y hx hy ↦ ?_
-  · exact ⟨M', N', hM', hN', Set.insert_subset (zero_mem _) h⟩
+  refine TensorProduct.inductionOn a (fun x y ↦ ?_) fun x y hx hy ↦ ?_
   · refine ⟨_, _, hM'.sup (fg_span_singleton x),
       hN'.sup (fg_span_singleton y), Set.insert_subset ?_ fun z hz ↦ ?_⟩
     · exact ⟨⟨x, mem_sup_right (mem_span_singleton_self x)⟩ ⊗ₜ
@@ -185,7 +182,6 @@ theorem exists_finite_submodule_right_of_setFinite' (s : Set (M₁ ⊗[R] N₁))
 lemma exists_sum_tmul_eq (x : M ⊗[R] N) :
     ∃ (k : ℕ) (m : Fin k → M) (n : Fin k → N), x = ∑ j, m j ⊗ₜ n j := by
   induction x with
-  | zero => exact ⟨0, IsEmpty.elim inferInstance, IsEmpty.elim inferInstance, by simp⟩
   | tmul x y => exact ⟨1, fun _ ↦ x, fun _ ↦ y, by simp⟩
   | add x y hx hy =>
     obtain ⟨kx, mx, nx, rfl⟩ := hx

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -63,7 +63,7 @@ def prodLeft : (M₁ × M₂) ⊗[R] M₃ ≃ₗ[S] (M₁ ⊗[R] M₃) × (M₂ 
   AddEquiv.toLinearEquiv (TensorProduct.comm _ _ _ ≪≫ₗ
       TensorProduct.prodRight R R _ _ _ ≪≫ₗ
       (TensorProduct.comm R _ _).prodCongr (TensorProduct.comm R _ _)).toAddEquiv
-    fun c x ↦ x.induction_on (by simp) (by simp [TensorProduct.smul_tmul']) (by simp_all)
+    fun c x ↦ x.inductionOn (by simp [TensorProduct.smul_tmul']) (by simp_all)
 
 @[simp] theorem prodLeft_tmul (m₁ : M₁) (m₂ : M₂) (m₃ : M₃) :
     prodLeft R S M₁ M₂ M₃ ((m₁, m₂) ⊗ₜ m₃) = (m₁ ⊗ₜ m₃, m₂ ⊗ₜ m₃) :=

--- a/Mathlib/LinearAlgebra/TensorProduct/Quotient.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Quotient.lean
@@ -274,7 +274,6 @@ noncomputable def tensorQuotientEquiv (n : Submodule B N) :
   map_smul' m x := by
     simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, LinearEquiv.coe_coe]
     induction x with
-    | zero => simp
     | add x y hx hy => simp [hx, hy]
     | tmul x y =>
       obtain ⟨y, rfl⟩ := Submodule.Quotient.mk_surjective _ y

--- a/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
@@ -118,7 +118,6 @@ theorem LinearMap.lTensor_surjective (hg : Function.Surjective g) :
     Function.Surjective (lTensor Q g) := by
   intro z
   induction z with
-  | zero => exact ⟨0, map_zero _⟩
   | tmul q p =>
     obtain ⟨n, rfl⟩ := hg p
     exact ⟨q ⊗ₜ[R] n, rfl⟩
@@ -149,7 +148,6 @@ theorem LinearMap.rTensor_surjective (hg : Function.Surjective g) :
     Function.Surjective (rTensor Q g) := by
   intro z
   induction z with
-  | zero => exact ⟨0, map_zero _⟩
   | tmul p q =>
     obtain ⟨n, rfl⟩ := hg p
     exact ⟨n ⊗ₜ[R] q, rfl⟩
@@ -471,14 +469,8 @@ lemma Ideal.map_includeLeft_eq (I : Ideal A) :
       simp only [map_add]
     · rintro a x - ⟨x, hx, rfl⟩
       induction a with
-      | zero =>
-        use 0
-        simp only [map_zero, smul_eq_mul, zero_mul]
       | tmul a b =>
         induction x with
-        | zero =>
-          use 0
-          simp only [map_zero, smul_eq_mul, mul_zero]
         | tmul x y =>
           use (a • x) ⊗ₜ[R] (b * y)
           simp only [smul_eq_mul]
@@ -495,9 +487,6 @@ lemma Ideal.map_includeLeft_eq (I : Ideal A) :
         simp only [map_add, ha', add_smul, hb']
   · rintro x ⟨y, rfl⟩
     induction y with
-    | zero =>
-        rw [map_zero]
-        apply zero_mem
     | tmul a b =>
         simp only [LinearMap.rTensor_tmul, Submodule.coe_subtype]
         suffices (a : A) ⊗ₜ[R] b = ((1 : A) ⊗ₜ[R] b) * ((a : A) ⊗ₜ[R] (1 : B)) by
@@ -535,14 +524,8 @@ lemma Ideal.map_includeRight_eq (I : Ideal B) :
       simp only [map_add]
     · rintro a x - ⟨x, hx, rfl⟩
       induction a with
-      | zero =>
-        use 0
-        simp only [map_zero, smul_eq_mul, zero_mul]
       | tmul a b =>
         induction x with
-        | zero =>
-          use 0
-          simp only [map_zero, smul_eq_mul, mul_zero]
         | tmul x y =>
           use (a * x) ⊗ₜ[R] (b • y)
           simp only [LinearMap.lTensor_tmul, Submodule.coe_subtype, smul_eq_mul, tmul_mul_tmul]
@@ -559,9 +542,6 @@ lemma Ideal.map_includeRight_eq (I : Ideal B) :
         simp only [map_add, ha', add_smul, hb']
   · rintro x ⟨y, rfl⟩
     induction y with
-    | zero =>
-        rw [map_zero]
-        apply zero_mem
     | tmul a b =>
         simp only [LinearMap.lTensor_tmul, Submodule.coe_subtype]
         suffices a ⊗ₜ[R] (b : B) = (a ⊗ₜ[R] (1 : B)) * ((1 : A) ⊗ₜ[R] (b : B)) by

--- a/Mathlib/LinearAlgebra/TensorProduct/Submodule.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Submodule.lean
@@ -119,7 +119,6 @@ theorem mulMap_range : LinearMap.range (mulMap M N) = M * N := by
   refine le_antisymm ?_ (mul_le.2 fun m hm n hn ↦ ⟨⟨m, hm⟩ ⊗ₜ[R] ⟨n, hn⟩, rfl⟩)
   rintro _ ⟨x, rfl⟩
   induction x with
-  | zero => rw [map_zero]; exact zero_mem _
   | tmul a b => exact mul_mem_mul a.2 b.2
   | add a b ha hb => rw [map_add]; exact add_mem ha hb
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -474,11 +474,9 @@ theorem distribBaseChange_symm_tmul
 lemma cancelBaseChange_self_eq_lid :
     cancelBaseChange R A A A N = TensorProduct.lid A (A ⊗[R] N) := by
   ext x
-  induction x using TensorProduct.induction_on with
-  | zero => simp only [map_zero]
+  induction x using TensorProduct.inductionOn with
   | tmul b y =>
-    induction y using TensorProduct.induction_on with
-    | zero => simp
+    induction y using TensorProduct.inductionOn with
     | tmul a m =>
       simp only [cancelBaseChange_tmul, lid_tmul, smul_tmul', smul_eq_mul, mul_comm]
     | add x y hx hy =>

--- a/Mathlib/LinearAlgebra/Transvection/Basic.lean
+++ b/Mathlib/LinearAlgebra/Transvection/Basic.lean
@@ -510,7 +510,6 @@ theorem IsBaseChange.transvection (f : Dual R V) (v : V) :
     ibc.endHom (transvection f v) = transvection (ibc.toDual f) (ε v) := by
   ext w
   induction w using ibc.inductionOn with
-  | zero => simp
   | add x y hx hy => simp [hx, hy]
   | smul a w hw => simp [hw]
   | tmul x => simp [LinearMap.transvection.apply, endHom_comp_apply, toDual_comp_apply]

--- a/Mathlib/NumberTheory/Padics/Measure/Basic.lean
+++ b/Mathlib/NumberTheory/Padics/Measure/Basic.lean
@@ -251,7 +251,6 @@ lemma prodMk_eq_prodMk' : prodMk μ ν = prodMk' μ ν := by
   apply DFunLike.coe_injective
   apply denseRange_tensorHom.equalizer (by fun_prop) (by fun_prop) (funext fun h ↦ ?_)
   induction h with
-  | zero => simp
   | add => grind
   | tmul f g => simp [prodMul_def, prodMk_prod_apply μ, prodMk'_prod_apply μ]
 

--- a/Mathlib/RepresentationTheory/Tannaka.lean
+++ b/Mathlib/RepresentationTheory/Tannaka.lean
@@ -125,7 +125,7 @@ def mulRepHom : rightFDRep (k := k) (G := G) ⊗ rightFDRep ⟶ rightFDRep where
   comm := by
     intro
     ext u
-    refine TensorProduct.induction_on u rfl (fun _ _ ↦ rfl) (fun _ _ hx hy ↦ ?_)
+    refine TensorProduct.inductionOn u (fun _ _ ↦ rfl) (fun _ _ hx hy ↦ ?_)
     simp only [map_add, hx, hy]
 
 /-- The `rightFDRep` component of `η : Aut (forget k G)` preserves multiplication -/

--- a/Mathlib/RingTheory/Algebraic/Integral.lean
+++ b/Mathlib/RingTheory/Algebraic/Integral.lean
@@ -611,7 +611,7 @@ instance Algebra.IsAlgebraic.tensorProduct : Algebra.IsAlgebraic R' (R' ⊗[R] S
   isAlgebraic p :=
     have := IsAlgebraic.nontrivial R S
     have := (FaithfulSMul.algebraMap_injective R R').nontrivial
-    p.induction_on isAlgebraic_zero (fun _ s ↦ .tmul _ <| alg.1 s) (fun _ _ ↦ .add)
+    p.inductionOn (fun _ s ↦ .tmul _ <| alg.1 s) (fun _ _ ↦ .add)
 
 variable (S' : Type*) [CommRing S'] [Algebra R S'] [Algebra S S'] [Algebra R' S']
   [IsScalarTower R R' S'] [IsScalarTower R S S']

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -79,10 +79,6 @@ of coalgebras, bialgebras, and hopf algebras, and shouldn't be relied on downstr
 scoped macro "hopf_tensor_induction " var:elimTarget "with " var₁:ident var₂:ident : tactic =>
   `(tactic|
     (induction $var with
-      | zero =>
-        -- avoid the more general `map_zero` for performance reasons
-        simp only [tmul_zero, LinearEquiv.map_zero, LinearMap.map_zero,
-          zero_tmul, zero_mul, mul_zero]
       | add _ _ h₁ h₂ =>
         -- avoid the more general `map_add` for performance reasons
         simp only [LinearEquiv.map_add, LinearMap.map_add,

--- a/Mathlib/RingTheory/EssentialFiniteness.lean
+++ b/Mathlib/RingTheory/EssentialFiniteness.lean
@@ -171,8 +171,7 @@ instance EssFiniteType.baseChange [h : EssFiniteType R S] : EssFiniteType T (T �
   obtain ⟨σ, hσ⟩ := h
   use σ.image Algebra.TensorProduct.includeRight
   intro s
-  induction s using TensorProduct.induction_on with
-  | zero => exact ⟨1, one_mem _, isUnit_one, by simp⟩
+  induction s using TensorProduct.inductionOn with
   | tmul x y =>
     obtain ⟨t, h₁, h₂, h₃⟩ := hσ y
     have H (x : S) (hx : x ∈ Algebra.adjoin R (σ : Set S)) :

--- a/Mathlib/RingTheory/Etale/Kaehler.lean
+++ b/Mathlib/RingTheory/Etale/Kaehler.lean
@@ -167,12 +167,10 @@ def tensorCotangentInvFun
       LinearEquiv.symm_apply_apply, f']
     clear hx ha
     induction x with
-    | zero => simp only [map_zero, ZeroMemClass.coe_zero, zero_smul]
     | add x y _ _ =>
       simp only [map_add, Submodule.coe_add, add_smul, zero_add, *]
     | tmul a b =>
       induction y with
-      | zero => simp only [map_zero, smul_zero]
       | add x y hx hy => simp only [LinearMap.map_add, smul_add, hx, hy, zero_add]
       | tmul c d =>
         simp only [LinearMap.liftBaseChange_tmul, LinearMap.coe_comp, SetLike.val_smul,
@@ -210,7 +208,6 @@ def tensorCotangent [alg : Algebra P.Ring Q.Ring] (halg : algebraMap P.Ring Q.Ri
     left_inv x := by
       simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom]
       induction x with
-      | zero => simp only [map_zero]
       | add x y _ _ => simp only [map_add, *]
       | tmul a b =>
         obtain ⟨b, rfl⟩ := Cotangent.mk_surjective b
@@ -224,7 +221,6 @@ def tensorCotangent [alg : Algebra P.Ring Q.Ring] (halg : algebraMap P.Ring Q.Ri
       obtain ⟨x, rfl⟩ := H.surjective x
       simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom]
       induction x with
-      | zero => simp only [map_zero]
       | add x y _ _ => simp only [map_add, *]
       | tmul a b =>
         simp only [LinearMap.liftBaseChange_tmul, map_smul]

--- a/Mathlib/RingTheory/Etale/QuasiFinite.lean
+++ b/Mathlib/RingTheory/Etale/QuasiFinite.lean
@@ -317,7 +317,6 @@ lemma Algebra.exists_etale_isIdempotentElem_forall_liesOver_eq_aux₂
     apply Localization.awayMap_awayMap_surjective
     refine Localization.awayMap_surjective_iff.mpr fun a ↦ ?_
     induction a with
-    | zero => use 0; simp
     | tmul a b =>
       obtain ⟨b', m, e : _ = _⟩ := Localization.awayMap_surjective_iff.mp hg b
       refine ⟨e₀ ^ m * a ⊗ₜ b', m, ?_⟩

--- a/Mathlib/RingTheory/Extension/Cotangent/BaseChange.lean
+++ b/Mathlib/RingTheory/Extension/Cotangent/BaseChange.lean
@@ -96,7 +96,6 @@ lemma tensorCotangentSpace_tmul (t : T) (x : P.CotangentSpace) :
     P.tensorCotangentSpace T (t ⊗ₜ x) = t • CotangentSpace.map (P.toBaseChange T) x := by
   dsimp only [CotangentSpace] at x
   induction x with
-  | zero => rw [tmul_zero, LinearEquiv.map_zero, LinearMap.map_zero, smul_zero]
   | add x y hx hy => rw [tmul_add, LinearEquiv.map_add, LinearMap.map_add, smul_add, hx, hy]
   | tmul s y =>
   simp [tensorCotangentSpace_tmul_tmul, CotangentSpace.map_tmul_eq_tmul_map,

--- a/Mathlib/RingTheory/Extension/Cotangent/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Cotangent/Basic.lean
@@ -177,15 +177,12 @@ lemma map_comp (f : Hom P P') (g : Hom P' P'') :
     CotangentSpace.map (g.comp f) =
       (CotangentSpace.map g).restrictScalars S ∘ₗ CotangentSpace.map f := by
   ext x
-  induction x using TensorProduct.induction_on with
-  | zero =>
-    simp only [map_zero]
+  induction x using TensorProduct.inductionOn with
   | add =>
     simp only [map_add, LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply, *]
   | tmul x y =>
     obtain ⟨y, rfl⟩ := KaehlerDifferential.tensorProductTo_surjective _ _ y
     induction y with
-    | zero => simp only [map_zero, tmul_zero]
     | add => simp only [map_add, tmul_add, LinearMap.coe_comp, LinearMap.coe_restrictScalars,
       Function.comp_apply, *]
     | tmul => simp only [Derivation.tensorProductTo_tmul, tmul_smul, smul_tmul', map_tmul,
@@ -291,15 +288,12 @@ lemma CotangentSpace.map_sub_map (f g : Hom P P') :
     CotangentSpace.map f - CotangentSpace.map g =
       P'.cotangentComplex.restrictScalars S ∘ₗ (f.sub g) := by
   ext x
-  induction x using TensorProduct.induction_on with
-  | zero =>
-    simp only [map_zero]
+  induction x using TensorProduct.inductionOn with
   | add =>
     simp only [map_add, LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply, *]
   | tmul x y =>
     obtain ⟨y, rfl⟩ := KaehlerDifferential.tensorProductTo_surjective _ _ y
     induction y with
-    | zero => simp only [map_zero, tmul_zero]
     | add => simp only [map_add, tmul_add, LinearMap.coe_comp, LinearMap.coe_restrictScalars,
       Function.comp_apply, *]
     | tmul =>

--- a/Mathlib/RingTheory/Extension/Generators.lean
+++ b/Mathlib/RingTheory/Extension/Generators.lean
@@ -262,8 +262,7 @@ def baseChange (T) [CommRing T] [Algebra R T] (P : Generators R S ι) :
     Generators T (T ⊗[R] S) ι := by
   apply Generators.ofSurjective (fun x ↦ 1 ⊗ₜ[R] P.val x)
   intro x
-  induction x using TensorProduct.induction_on with
-  | zero => exact ⟨0, map_zero _⟩
+  induction x using TensorProduct.inductionOn with
   | tmul a b =>
     let X := P.σ b
     use a • MvPolynomial.map (algebraMap R T) X

--- a/Mathlib/RingTheory/Finiteness/Descent.lean
+++ b/Mathlib/RingTheory/Finiteness/Descent.lean
@@ -62,7 +62,6 @@ lemma Ideal.FG.of_FG_map_of_faithfullyFlat [Module.FaithfullyFlat R S] {I : Idea
       simp [f, Algebra.smul_def]
     · rintro - ⟨x, rfl⟩
       induction x with
-      | zero => simp
       | add _ _ _ _ => simp_all [Ideal.add_mem]
       | tmul s x =>
         have : f (s ⊗ₜ[R] x) = s • f (1 ⊗ₜ x) := by simp [f]

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -588,14 +588,14 @@ theorem map_id_injective_of_flat_left {g : M₁ →ₗ[R] N₂ →ₗ[R] N} (hg 
     (i : M₂ →ₗ[R] N₂) (hi : Function.Injective i) [Module.Flat R M₁] :
     Function.Injective (hf.map hg LinearMap.id i) := by
   have h : hf.map hg LinearMap.id i = hg.equiv ∘ i.lTensor M₁ ∘ hf.equiv.symm :=
-    funext fun x ↦ hf.inductionOn x (by simp) (by simp) (fun _ _ hx hy ↦ by simp [hx, hy])
+    funext fun x ↦ hf.inductionOn x (by simp) (fun _ _ hx hy ↦ by simp [hx, hy])
   simpa [h] using Module.Flat.lTensor_preserves_injective_linearMap i hi
 
 theorem map_id_injective_of_flat_right {g : N₁ →ₗ[R] M₂ →ₗ[R] N} (hg : IsTensorProduct g)
     (i : M₁ →ₗ[R] N₁) (hi : Function.Injective i) [Module.Flat R M₂] :
     Function.Injective (hf.map hg i LinearMap.id) := by
   have h : hf.map hg i LinearMap.id = hg.equiv ∘ i.rTensor M₂ ∘ hf.equiv.symm :=
-    funext fun x ↦ hf.inductionOn x (by simp) (by simp) (fun _ _ hx hy ↦ by simp [hx, hy])
+    funext fun x ↦ hf.inductionOn x (by simp) (fun _ _ hx hy ↦ by simp [hx, hy])
   simpa [h] using Module.Flat.rTensor_preserves_injective_linearMap i hi
 
 /-- If `M₂` and `N₁` are flat `R`-modules, `i₁ : M₁ →ₗ[R] N₁` and `i₂ : M₂ →ₗ[R] N₂` are injective
@@ -605,7 +605,7 @@ theorem map_id_injective_of_flat_right {g : N₁ →ₗ[R] M₂ →ₗ[R] N} (hg
 theorem map_injective_of_flat_right_left (h₁ : Function.Injective i₁) (h₂ : Function.Injective i₂)
     [Module.Flat R M₂] [Module.Flat R N₁] : Function.Injective (hf.map hg i₁ i₂) := by
   have h : hf.map hg i₁ i₂ = hg.equiv ∘ TensorProduct.map i₁ i₂ ∘ hf.equiv.symm :=
-    funext fun x ↦ hf.inductionOn x (by simp) (by simp) (fun _ _ hx hy ↦ by simp [hx, hy])
+    funext fun x ↦ hf.inductionOn x (by simp) (fun _ _ hx hy ↦ by simp [hx, hy])
   simpa [h] using map_injective_of_flat_flat i₁ i₂ h₁ h₂
 
 /-- If `M₁` and `N₂` are flat `R`-modules, `i₁ : M₁ →ₗ[R] N₁` and `i₂ : M₂ →ₗ[R] N₂` are injective
@@ -615,7 +615,7 @@ theorem map_injective_of_flat_right_left (h₁ : Function.Injective i₁) (h₂ 
 theorem map_injective_of_flat_left_right (h₁ : Function.Injective i₁) (h₂ : Function.Injective i₂)
     [Module.Flat R M₁] [Module.Flat R N₂] : Function.Injective (hf.map hg i₁ i₂) := by
   have h : hf.map hg i₁ i₂ = hg.equiv ∘ TensorProduct.map i₁ i₂ ∘ hf.equiv.symm :=
-    funext fun x ↦ hf.inductionOn x (by simp) (by simp) (fun _ _ hx hy ↦ by simp [hx, hy])
+    funext fun x ↦ hf.inductionOn x (by simp) (fun _ _ hx hy ↦ by simp [hx, hy])
   simpa [h] using map_injective_of_flat_flat' i₁ i₂ h₁ h₂
 
 end IsTensorProduct

--- a/Mathlib/RingTheory/Flat/Equalizer.lean
+++ b/Mathlib/RingTheory/Flat/Equalizer.lean
@@ -260,7 +260,6 @@ private lemma AlgHom.coe_tensorEqualizerAux (x : T ⊗[R] AlgHom.equalizer f g) 
     (AlgHom.tensorEqualizerAux S T f g x : T ⊗[R] A) =
       Algebra.TensorProduct.map (AlgHom.id S T) (AlgHom.equalizer f g).val x := by
   induction x with
-  | zero => rfl
   | tmul => rfl
   | add x y hx hy => simp [hx, hy]
 
@@ -327,15 +326,12 @@ def Algebra.kerTensorProductMapIdToAlgHomEquiv
     { __ := e₄'.symm, map_smul' r' x := by
         dsimp
         induction x with
-        | zero => simp only [smul_zero, LinearEquiv.map_zero]
         | add x y _ _ => simp only [smul_add, LinearEquiv.map_add, *]
         | tmul x y =>
         induction x with
-        | zero => simp only [zero_tmul, smul_zero, LinearEquiv.map_zero]
         | add x y _ _ => simp only [smul_add, add_tmul, LinearEquiv.map_add, *]
         | tmul x z =>
         induction r' with
-        | zero => simp only [zero_smul, LinearEquiv.map_zero]
         | add x y _ _ => simp only [add_smul, LinearEquiv.map_add, *]
         | tmul r s =>
         rw [smul_tmul']

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
@@ -336,7 +336,6 @@ lemma rTensor_reflects_exact [fl : FaithfullyFlat R M]
     LinearMap.range_eq_top]
   intro x
   induction x using TensorProduct.inductionOn with
-  | zero => exact ⟨0, by simp⟩
   -- let `x ⊗ m` be an element in `ker l23 ⊗ M`, then `x ⊗ m` is in the kernel of `l23 ⊗ 𝟙M`.
   -- Since `N1 ⊗ M -l12 ⊗ M-> N2 ⊗ M -l23 ⊗ M-> N3 ⊗ M` is exact, we have that `x ⊗ m` is in
   -- the range of `l12 ⊗ 𝟙M`, i.e. `x ⊗ m = (l12 ⊗ 𝟙M) y` for some `y ∈ N1 ⊗ M` as elements of

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
@@ -335,7 +335,7 @@ lemma rTensor_reflects_exact [fl : FaithfullyFlat R M]
   rw [e.toEquiv.subsingleton_congr, Submodule.Quotient.subsingleton_iff,
     LinearMap.range_eq_top]
   intro x
-  induction x using TensorProduct.induction_on with
+  induction x using TensorProduct.inductionOn with
   | zero => exact ⟨0, by simp⟩
   -- let `x ⊗ m` be an element in `ker l23 ⊗ M`, then `x ⊗ m` is in the kernel of `l23 ⊗ 𝟙M`.
   -- Since `N1 ⊗ M -l12 ⊗ M-> N2 ⊗ M -l23 ⊗ M-> N3 ⊗ M` is exact, we have that `x ⊗ m` is in

--- a/Mathlib/RingTheory/GradedAlgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/TensorProduct.lean
@@ -123,7 +123,6 @@ def liftEquiv : (𝒜 →ₐᵍ[R] (ℬ · |>.restrictScalars R)) ≃ ((𝒜 · 
       map_mem hx := by
         obtain ⟨x, rfl⟩ := toBaseChange_surjective' _ _ hx
         induction x with
-        | zero => simp
         | add => simp_all [add_mem]
         | tmul r x => simpa using smul_mem _ _ <| by exact f.map_mem x.2 }
   invFun f :=

--- a/Mathlib/RingTheory/Grassmannian.lean
+++ b/Mathlib/RingTheory/Grassmannian.lean
@@ -171,8 +171,7 @@ theorem map_comp (N : G(k, A ⊗[R] M; A)) :
   have hcomp : fAC = e.toLinearMap.comp fBC := by
     apply LinearMap.ext
     intro z
-    induction z using TensorProduct.induction_on with
-    | zero => simp [fAC, fBC, e]
+    induction z using TensorProduct.inductionOn with
     | tmul c m =>
       simp only [fAC, fBC, e, baseChangeMkQ, LinearMap.comp_apply, cancelBaseChange_symm_tmul,
          LinearMap.baseChange_tmul, Submodule.mkQ_apply, LinearEquiv.coe_trans, LinearEquiv.coe_coe,

--- a/Mathlib/RingTheory/Ideal/CotangentBaseChange.lean
+++ b/Mathlib/RingTheory/Ideal/CotangentBaseChange.lean
@@ -70,7 +70,6 @@ lemma tensorCotangentHom_surjective :
   obtain ⟨y, rfl⟩ := I.map_includeRight_eq.le hx
   obtain rfl : hx = I.map_includeRight_eq.ge ⟨y, rfl⟩ := rfl
   induction y with
-  | zero => exact ⟨0, by simp only [map_zero]; exact (map_zero _).symm⟩
   | add x y hx hy =>
     obtain ⟨a, ha⟩ := hx
     obtain ⟨b, hb⟩ := hy

--- a/Mathlib/RingTheory/Ideal/Quotient/ChineseRemainder.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/ChineseRemainder.lean
@@ -55,7 +55,7 @@ theorem ker_tensorProductMk_quotient :
   refine le_antisymm (Submodule.smul_le.mpr fun r hr m _ ↦ ⟨⟨r, ?_⟩ ⊗ₜ m, rfl⟩) ?_
   · simpa only [ker_pi, Submodule.ker_mkQ]
   rintro _ ⟨x, rfl⟩
-  refine x.induction_on (by simp) (fun r m ↦ Submodule.smul_mem_smul ?_ ⟨⟩) fun _ _ ↦ ?_
+  refine x.inductionOn (fun r m ↦ Submodule.smul_mem_smul ?_ ⟨⟩) fun _ _ ↦ ?_
   · simpa only [← (I _).ker_mkQ, ← ker_pi] using! Subtype.mem _
   · simpa using! add_mem
 

--- a/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
@@ -252,7 +252,7 @@ variable (R A B)
 instance Algebra.IsIntegral.tensorProduct [CommRing B]
     [Algebra R A] [Algebra R B] [int : Algebra.IsIntegral R B] :
     Algebra.IsIntegral A (A ⊗[R] B) where
-  isIntegral p := p.induction_on isIntegral_zero (fun _ s ↦ .tmul _ <| int.1 s) (fun _ _ ↦ .add)
+  isIntegral p := p.inductionOn (fun _ s ↦ .tmul _ <| int.1 s) (fun _ _ ↦ .add)
 
 end TensorProduct
 

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -105,7 +105,7 @@ theorem map_eq (hf : IsTensorProduct f) (hg : IsTensorProduct g) (i₁ : M₁ �
   simp [map]
 
 @[elab_as_elim]
-theorem inductionOn (h : IsTensorProduct f) {motive : M → Prop} (m : M)
+theorem induction_on (h : IsTensorProduct f) {motive : M → Prop} (m : M)
     (zero : motive 0) (tmul : ∀ x y, motive (f x y))
     (add : ∀ x y, motive x → motive y → motive (x + y)) : motive m := by
   rw [← h.equiv.right_inv m]
@@ -113,6 +113,21 @@ theorem inductionOn (h : IsTensorProduct f) {motive : M → Prop} (m : M)
   change motive (TensorProduct.lift f y)
   induction y using TensorProduct.induction_on with
   | zero => rwa [map_zero]
+  | tmul _ _ =>
+    rw [TensorProduct.lift.tmul]
+    apply tmul
+  | add _ _ _ _ =>
+    rw [map_add]
+    apply add <;> assumption
+
+@[elab_as_elim]
+theorem inductionOn (h : IsTensorProduct f) {motive : M → Prop} (m : M)
+    (tmul : ∀ x y, motive (f x y))
+    (add : ∀ x y, motive x → motive y → motive (x + y)) : motive m := by
+  rw [← h.equiv.right_inv m]
+  generalize h.equiv.invFun m = y
+  change motive (TensorProduct.lift f y)
+  induction y with
   | tmul _ _ =>
     rw [TensorProduct.lift.tmul]
     apply tmul
@@ -135,7 +150,7 @@ variable {P₁ P₂ P : Type*} [AddCommMonoid P₁] [AddCommMonoid P₂]
   (i₁ : N₁ →ₗ[R] P₁) (j₁ : M₁ →ₗ[R] N₁) (i₂ : N₂ →ₗ[R] P₂) (j₂ : M₂ →ₗ[R] N₂)
 
 theorem map_comp : hf.map hp (i₁ ∘ₗ j₁) (i₂ ∘ₗ j₂) = hg.map hp i₁ i₂ ∘ₗ hf.map hg j₁ j₂ :=
-  LinearMap.ext <| fun x ↦ hf.inductionOn x (by simp) (by simp) (fun _ _ h₁ h₂ ↦ by simp [h₁, h₂])
+  LinearMap.ext <| fun x ↦ hf.inductionOn x (by simp) (fun _ _ h₁ h₂ ↦ by simp [h₁, h₂])
 
 theorem map_map (x : M) :
     hg.map hp i₁ i₂ ((hf.map hg j₁ j₂) x) = hf.map hp (i₁ ∘ₗ j₁) (i₂ ∘ₗ j₂) x :=
@@ -144,7 +159,7 @@ theorem map_map (x : M) :
 @[simp]
 theorem map_id :
     hf.map hf (LinearMap.id : M₁ →ₗ[R] M₁) (LinearMap.id : M₂ →ₗ[R] M₂) = LinearMap.id :=
-  LinearMap.ext <| fun x ↦ hf.inductionOn x (by simp) (by simp) (fun _ _ h₁ h₂ ↦ by simp [h₁, h₂])
+  LinearMap.ext <| fun x ↦ hf.inductionOn x (by simp) (fun _ _ h₁ h₂ ↦ by simp [h₁, h₂])
 
 @[simp]
 protected theorem map_one : hf.map hf (1 : M₁ →ₗ[R] M₁) (1 : M₂ →ₗ[R] M₂) = 1 :=
@@ -343,7 +358,6 @@ noncomputable nonrec def IsBaseChange.lift (g : M →ₗ[R] Q) : N →ₗ[S] Q :
       have hF : ∀ (s : S) (m : M), h.lift F (s • f m) = s • g m := h.lift_eq F
       change h.lift F (r • x) = r • h.lift F x
       induction x using h.inductionOn with
-      | zero => rw [smul_zero, map_zero, smul_zero]
       | tmul s m =>
         change h.lift F (r • s • f m) = r • h.lift F (s • f m)
         rw [← mul_smul, hF, hF, mul_smul]
@@ -365,7 +379,7 @@ include h
 nonrec theorem IsBaseChange.inductionOn (x : N) (motive : N → Prop) (zero : motive 0)
     (tmul : ∀ m : M, motive (f m)) (smul : ∀ (s : S) (n), motive n → motive (s • n))
     (add : ∀ n₁ n₂, motive n₁ → motive n₂ → motive (n₁ + n₂)) : motive x :=
-  h.inductionOn x zero (fun _ _ => smul _ _ (tmul _)) add
+  h.induction_on x zero (fun _ _ => smul _ _ (tmul _)) add
 
 theorem IsBaseChange.algHom_ext (g₁ g₂ : N →ₗ[S] Q) (e : ∀ x, g₁ (f x) = g₂ (f x)) : g₁ = g₂ := by
   ext x

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -111,7 +111,7 @@ theorem inductionOn (h : IsTensorProduct f) {motive : M → Prop} (m : M)
   rw [← h.equiv.right_inv m]
   generalize h.equiv.invFun m = y
   change motive (TensorProduct.lift f y)
-  induction y with
+  induction y using TensorProduct.induction_on with
   | zero => rwa [map_zero]
   | tmul _ _ =>
     rw [TensorProduct.lift.tmul]
@@ -231,12 +231,10 @@ noncomputable def assoc {T : Type*} [CommSemiring T] [Algebra R T] [Module T M�
   toAddEquiv := IsTensorProduct.assocAux (f.restrictScalars₁₂ R S) hf g hg
   map_smul' t x := by
     induction x with
-    | zero => simp
     | add x y _ _ => simp_all
     | tmul x y =>
     obtain ⟨x, rfl⟩ := hf.equiv.surjective x
     induction x with
-    | zero => simp
     | add x y _ _ => simp_all [add_tmul]
     | tmul x z =>
       have : t • (f x) z = f (t • x) z := by simp
@@ -404,8 +402,7 @@ noncomputable nonrec def IsBaseChange.equiv : S ⊗[R] M ≃ₗ[S] N :=
   { h.equiv with
     map_smul' := fun r x => by
       change h.equiv (r • x) = r • h.equiv x
-      refine TensorProduct.induction_on x ?_ ?_ ?_
-      · rw [smul_zero, map_zero, smul_zero]
+      refine TensorProduct.inductionOn x ?_ ?_
       · intro x y
         simp [smul_tmul', Algebra.linearMap_apply, smul_comm r x]
       · intro x y hx hy
@@ -466,7 +463,6 @@ lemma isBaseChange_tensorProduct_map {f : M →ₗ[S] N} (hf : IsBaseChange A f)
     (AlgebraTensorModule.congr hf.equiv (LinearEquiv.refl R P))
   refine IsBaseChange.of_equiv e (fun x ↦ ?_)
   induction x with
-  | zero => simp
   | tmul => simp [e, IsBaseChange.equiv_tmul]
   | add _ _ h1 h2 => simp [tmul_add, h1, h2]
 
@@ -489,8 +485,7 @@ theorem IsBaseChange.of_lift_unique
     refine
       { f' with
         map_smul' := fun s x =>
-          TensorProduct.induction_on x ?_ (fun s' y => smul_assoc s s' _) fun x y hx hy => ?_ }
-    · dsimp; rw [map_zero, smul_zero, map_zero, smul_zero]
+          TensorProduct.inductionOn x (fun s' y => smul_assoc s s' _) fun x y hx hy => ?_ }
     · dsimp at *; rw [smul_add, map_add, map_add, smul_add, hx, hy]
   simp_rw [DFunLike.ext_iff, LinearMap.comp_apply, LinearMap.restrictScalars_apply] at hg
   let fe : S ⊗[R] M ≃ₗ[S] N :=
@@ -629,11 +624,9 @@ def Algebra.IsPushout.equiv [h : Algebra.IsPushout R S R' S'] : S ⊗[R] R' ≃�
   map_mul' x y := by
     dsimp
     induction x with
-    | zero => simp
     | add x y _ _ => simp [*, add_mul]
     | tmul a b =>
       induction y with
-      | zero => simp
       | add x y _ _ => simp [*, mul_add]
       | tmul x y => simp [IsBaseChange.equiv_tmul, Algebra.smul_def, mul_mul_mul_comm]
   commutes' := by simp [IsBaseChange.equiv_tmul, Algebra.smul_def]
@@ -656,7 +649,7 @@ variable {R S R' S'}
 theorem Algebra.IsPushout.symm (h : Algebra.IsPushout R S R' S') : Algebra.IsPushout R R' S S' where
   out := .of_equiv
     { __ := (TensorProduct.comm R ..).toAddEquiv.trans (equiv R S R' S').toAddEquiv,
-      map_smul' _ x := x.induction_on (by simp) (fun _ _ ↦ by
+      map_smul' _ x := x.inductionOn (fun _ _ ↦ by
         simp [equiv_tmul, Algebra.smul_def, mul_left_comm]) (by simp +contextual) }
     fun _ ↦ by simp [equiv_tmul]
 
@@ -815,7 +808,6 @@ def IsPushout.cancelBaseChange : B ⊗[A] M ≃ₗ[S] S ⊗[R] M :=
   AddEquiv.toLinearEquiv (IsPushout.cancelBaseChangeAux R S A B M).symm <| by
     intro s x
     induction x with
-    | zero => simp
     | add x y hx hy => simp only [smul_add, map_add, hx, hy]
     | tmul s' m => simp [Algebra.smul_def, TensorProduct.smul_tmul']
 

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -723,7 +723,7 @@ theorem Algebra.IsPushout.algHom_ext [H : Algebra.IsPushout R S R' S'] {A : Type
     [Algebra R A] {f g : S' →ₐ[R] A} (h₁ : f.comp (toAlgHom R R' S') = g.comp (toAlgHom R R' S'))
     (h₂ : f.comp (toAlgHom R S S') = g.comp (toAlgHom R S S')) : f = g := by
   ext x
-  refine H.1.inductionOn x _ ?_ ?_ ?_ ?_
+  refine H.1.inductionOn x ?_ ?_ ?_
   · exact AlgHom.congr_fun h₁
   · intro s s' e
     rw [Algebra.smul_def, map_mul, map_mul, e]

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -606,7 +606,7 @@ theorem IsBaseChange.map_id_lsmul_eq_lsmul_algebraMap
     {f : M →ₗ[R] N} (hf : IsBaseChange S f) (x : R) :
     hf.map hf LinearMap.id (LinearMap.lsmul R M x) = LinearMap.lsmul S N (algebraMap R S x) := by
   ext y
-  refine IsTensorProduct.inductionOn hf y (by simp) ?_ (fun _ _ ha hb ↦ by simp [ha, hb])
+  refine IsTensorProduct.inductionOn hf y ?_ (fun _ _ ha hb ↦ by simp [ha, hb])
   intro s m
   rw [hf.map_eq hf]
   simpa using smul_comm x s (f m)

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -105,22 +105,6 @@ theorem map_eq (hf : IsTensorProduct f) (hg : IsTensorProduct g) (i₁ : M₁ �
   simp [map]
 
 @[elab_as_elim]
-theorem induction_on (h : IsTensorProduct f) {motive : M → Prop} (m : M)
-    (zero : motive 0) (tmul : ∀ x y, motive (f x y))
-    (add : ∀ x y, motive x → motive y → motive (x + y)) : motive m := by
-  rw [← h.equiv.right_inv m]
-  generalize h.equiv.invFun m = y
-  change motive (TensorProduct.lift f y)
-  induction y using TensorProduct.induction_on with
-  | zero => rwa [map_zero]
-  | tmul _ _ =>
-    rw [TensorProduct.lift.tmul]
-    apply tmul
-  | add _ _ _ _ =>
-    rw [map_add]
-    apply add <;> assumption
-
-@[elab_as_elim]
 theorem inductionOn (h : IsTensorProduct f) {motive : M → Prop} (m : M)
     (tmul : ∀ x y, motive (f x y))
     (add : ∀ x y, motive x → motive y → motive (x + y)) : motive m := by
@@ -376,15 +360,14 @@ section
 include h
 
 @[elab_as_elim]
-nonrec theorem IsBaseChange.inductionOn (x : N) (motive : N → Prop) (zero : motive 0)
+nonrec theorem IsBaseChange.inductionOn (x : N) {motive : N → Prop}
     (tmul : ∀ m : M, motive (f m)) (smul : ∀ (s : S) (n), motive n → motive (s • n))
     (add : ∀ n₁ n₂, motive n₁ → motive n₂ → motive (n₁ + n₂)) : motive x :=
-  h.induction_on x zero (fun _ _ => smul _ _ (tmul _)) add
+  h.inductionOn x (fun _ _ => smul _ _ (tmul _)) add
 
 theorem IsBaseChange.algHom_ext (g₁ g₂ : N →ₗ[S] Q) (e : ∀ x, g₁ (f x) = g₂ (f x)) : g₁ = g₂ := by
   ext x
-  refine h.inductionOn x _ ?_ ?_ ?_ ?_
-  · rw [map_zero, map_zero]
+  refine h.inductionOn x ?_ ?_ ?_
   · assumption
   · intro s n e'
     rw [g₁.map_smul, g₂.map_smul, e']
@@ -741,7 +724,6 @@ theorem Algebra.IsPushout.algHom_ext [H : Algebra.IsPushout R S R' S'] {A : Type
     (h₂ : f.comp (toAlgHom R S S') = g.comp (toAlgHom R S S')) : f = g := by
   ext x
   refine H.1.inductionOn x _ ?_ ?_ ?_ ?_
-  · simp only [map_zero]
   · exact AlgHom.congr_fun h₁
   · intro s s' e
     rw [Algebra.smul_def, map_mul, map_mul, e]

--- a/Mathlib/RingTheory/Kaehler/Basic.lean
+++ b/Mathlib/RingTheory/Kaehler/Basic.lean
@@ -83,14 +83,12 @@ theorem Derivation.tensorProductTo_mul (D : Derivation R S M) (x y : S ⊗[R] S)
     D.tensorProductTo (x * y) =
       TensorProduct.lmul' (S := S) R x • D.tensorProductTo y +
         TensorProduct.lmul' (S := S) R y • D.tensorProductTo x := by
-  refine TensorProduct.induction_on x ?_ ?_ ?_
-  · rw [zero_mul, map_zero, map_zero, zero_smul, smul_zero, add_zero]
+  refine TensorProduct.inductionOn x ?_ ?_
   swap
   · intro x₁ y₁ h₁ h₂
     rw [add_mul, map_add, map_add, map_add, add_smul, smul_add, h₁, h₂, add_add_add_comm]
   intro x₁ x₂
-  refine TensorProduct.induction_on y ?_ ?_ ?_
-  · rw [mul_zero, map_zero, map_zero, zero_smul, smul_zero, add_zero]
+  refine TensorProduct.inductionOn y ?_ ?_
   swap
   · intro x₁ y₁ h₁ h₂
     rw [mul_add, map_add, map_add, map_add, add_smul, smul_add, h₁, h₂, add_add_add_comm]
@@ -117,8 +115,7 @@ theorem KaehlerDifferential.submodule_span_range_eq_ideal :
       rw [hx, TensorProduct.zero_tmul, sub_zero]
     rw [← this]
     clear this hx
-    refine TensorProduct.induction_on x ?_ ?_ ?_
-    · rw [map_zero, TensorProduct.zero_tmul, sub_zero]; exact zero_mem _
+    refine TensorProduct.inductionOn x ?_ ?_
     · intro x y
       have : x ⊗ₜ[R] y - (x * y) ⊗ₜ[R] (1 : S) = x • ((1 : S) ⊗ₜ y - y ⊗ₜ (1 : S)) := by
         simp_rw [smul_sub, TensorProduct.smul_tmul', smul_eq_mul, mul_one]
@@ -731,7 +728,6 @@ lemma KaehlerDifferential.range_mapBaseChange :
   apply le_antisymm
   · rintro _ ⟨x, rfl⟩
     induction x with
-    | zero => simp
     | tmul r s =>
       obtain ⟨x, rfl⟩ := linearCombination_surjective _ _ s
       simp only [mapBaseChange_tmul, LinearMap.mem_ker, map_smul]

--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -485,7 +485,6 @@ private lemma auxMemKer (z : T ⊗[S] P.toExtension.H1Cotangent) :
       ((LinearMap.lTensor T Extension.h1Cotangentι) z) ∈
         (Q.comp P).toExtension.cotangentComplex.ker := by
   induction z with
-  | zero => simp
   | tmul x y => simp [← Extension.CotangentSpace.map_cotangentComplex]
   | add x y hx hy => simpa using Submodule.add_mem _ hx hy
 
@@ -510,7 +509,6 @@ theorem exact_liftBaseChange_map_of_flat [Module.Flat S T] :
       P.toExtension.exact_hCotangentι_cotangentComplex).linearMap_ker_eq] at x_in
   rcases x_in with ⟨x, rfl⟩
   use x; induction x with
-  | zero => ext; simp
   | tmul x y => ext; simp
   | add x y hx hy => ext; simp [hx (auxMemKer Q P x), hy (auxMemKer Q P y)]
 

--- a/Mathlib/RingTheory/Kaehler/TensorProduct.lean
+++ b/Mathlib/RingTheory/Kaehler/TensorProduct.lean
@@ -115,7 +115,6 @@ lemma map_liftBaseChange_smul [h : Algebra.IsPushout R S A B] (b : B) (x) :
     ((map R S A B).restrictScalars R).liftBaseChange S (b • x) =
     b • ((map R S A B).restrictScalars R).liftBaseChange S x := by
   induction b using h.1.inductionOn with
-  | zero => simp only [zero_smul, map_zero]
   | smul s b e => rw [smul_assoc, map_smul, e, smul_assoc]
   | add b₁ b₂ e₁ e₂ => simp only [map_add, e₁, e₂, add_smul]
   | tmul a =>
@@ -136,7 +135,6 @@ def derivationTensorProduct [h : Algebra.IsPushout R S A B] :
     rw [Derivation.map_one_eq_zero, TensorProduct.tmul_zero]
   leibniz' a b := by
     induction a using h.out.inductionOn with
-    | zero => rw [map_zero, zero_smul, smul_zero, zero_add, zero_mul, map_zero]
     | smul x y e =>
       rw [smul_mul_assoc, map_smul, e, map_smul, smul_add,
         smul_comm x b, smul_assoc]
@@ -144,7 +142,6 @@ def derivationTensorProduct [h : Algebra.IsPushout R S A B] :
     | tmul z =>
       dsimp
       induction b using h.out.inductionOn with
-      | zero => rw [map_zero, zero_smul, smul_zero, zero_add, mul_zero, map_zero]
       | tmul =>
         simp only [AlgHom.toLinearMap_apply, IsScalarTower.coe_toAlgHom',
           algebraMap_smul, ← map_mul]
@@ -197,7 +194,6 @@ def tensorKaehlerEquivBase [h : Algebra.IsPushout R S A B] :
       simp only [Derivation.tensorProductTo_tmul, LinearMap.map_smul,
         Derivation.liftKaehlerDifferential_comp_D, map_liftBaseChange_smul]
       induction y using h.1.inductionOn
-      · simp only [map_zero, smul_zero]
       · simp only [AlgHom.toLinearMap_apply, IsScalarTower.coe_toAlgHom',
           derivationTensorProduct_algebraMap, LinearMap.liftBaseChange_tmul,
           LinearMap.coe_restrictScalars, map_D, one_smul]

--- a/Mathlib/RingTheory/Kaehler/TensorProduct.lean
+++ b/Mathlib/RingTheory/Kaehler/TensorProduct.lean
@@ -72,14 +72,12 @@ instance : IsScalarTower R A (S ⊗[R] Ω[A⁄R]) := by
   apply IsScalarTower.of_algebraMap_smul
   intro r x
   induction x
-  · simp only [smul_zero]
   · rw [mulActionBaseChange_smul_tmul, algebraMap_smul, tmul_smul]
   · simp only [smul_add, *]
 
 instance : SMulCommClass S A (S ⊗[R] Ω[A⁄R]) where
   smul_comm s a x := by
     induction x
-    · simp only [smul_zero]
     · rw [mulActionBaseChange_smul_tmul, smul_tmul', smul_tmul', mulActionBaseChange_smul_tmul]
     · simp only [smul_add, *]
 
@@ -122,7 +120,6 @@ lemma map_liftBaseChange_smul [h : Algebra.IsPushout R S A B] (b : B) (x) :
   | add b₁ b₂ e₁ e₂ => simp only [map_add, e₁, e₂, add_smul]
   | tmul a =>
     induction x
-    · simp only [smul_zero, map_zero]
     · simp [smul_comm]
     · simp only [map_add, smul_add, *]
 
@@ -174,7 +171,6 @@ lemma tensorKaehlerEquiv_left_inv [Algebra.IsPushout R S A B] :
   intro x y
   obtain ⟨y, rfl⟩ := tensorProductTo_surjective _ _ y
   induction y
-  · simp only [map_zero, TensorProduct.tmul_zero]
   · simp only [LinearMap.restrictScalars_comp, Derivation.tensorProductTo_tmul, LinearMap.coe_comp,
       LinearMap.coe_restrictScalars, Function.comp_apply, LinearMap.liftBaseChange_tmul, map_smul,
       map_D, LinearMap.map_smul_of_tower, Derivation.liftKaehlerDifferential_comp_D,
@@ -195,7 +191,6 @@ def tensorKaehlerEquivBase [h : Algebra.IsPushout R S A B] :
     obtain ⟨x, rfl⟩ := tensorProductTo_surjective _ _ x
     dsimp
     induction x with
-    | zero => simp
     | add x y e₁ e₂ => simp only [map_add, e₁, e₂]
     | tmul x y =>
       -- We use the specialized version of `map_smul` here for performance.
@@ -258,16 +253,13 @@ def tensorKaehlerEquiv [h : Algebra.IsPushout R S A B] :
   obtain ⟨m, rfl⟩ := (Algebra.IsPushout.equiv R A S B).surjective m
   dsimp
   induction m with
-  | zero => simp
   | add x y _ _ => simp only [add_smul, map_add, *]
   | tmul a b =>
   induction x with
-  | zero => simp
   | add x y _ _ => simp only [smul_add, map_add, *]
   | tmul x y =>
   obtain ⟨x, rfl⟩ := (Algebra.IsPushout.equiv R A S B).surjective x
   induction x with
-  | zero => simp
   | add x y _ _ => simp only [smul_add, map_add, *, add_tmul]
   | tmul x z =>
   suffices b • z • a • x • KaehlerDifferential.map R S A B y =
@@ -283,7 +275,6 @@ lemma tensorKaehlerEquiv_tmul_D [Algebra.IsPushout R S A B] (b a) :
   have : Algebra.IsPushout R A S B := .symm inferInstance
   obtain ⟨b, rfl⟩ := (Algebra.IsPushout.equiv R A S B).surjective b
   induction b with
-  | zero => simp
   | add x y _ _ => simp only [map_add, *, add_tmul, add_smul]
   | tmul a' s =>
   trans s • a' • D S B (algebraMap A B a)

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -185,7 +185,6 @@ theorem right_inv (M : Matrix n n A) : (toFunAlgHom n R A) (invFun n R A M) = M 
 
 theorem left_inv (M : A ⊗[R] Matrix n n R) : invFun n R A (toFunAlgHom n R A M) = M := by
   induction M with
-  | zero => simp
   | tmul a m => simp
   | add x y hx hy =>
     rw [map_add]
@@ -262,7 +261,7 @@ variable (m n A B) in
 def kroneckerTMulStarAlgEquiv :
     Matrix m m A ⊗[R] Matrix n n B ≃⋆ₐ[S] Matrix (m × n) (m × n) (A ⊗[R] B) :=
   .ofAlgEquiv (kroneckerTMulAlgEquiv m n R S A B)
-  fun x ↦ x.induction_on (by simp)
+  fun x ↦ x.inductionOn
     (by simp [star_eq_conjTranspose, conjTranspose_kroneckerTMul])
     (by simp_all)
 
@@ -301,7 +300,7 @@ variable (m n) in
 def kroneckerStarAlgEquiv [StarRing R] :
     (Matrix m m R ⊗[R] Matrix n n R) ≃⋆ₐ[R] Matrix (m × n) (m × n) R :=
   .ofAlgEquiv (kroneckerAlgEquiv m n R)
-  fun x ↦ x.induction_on (by simp)
+  fun x ↦ x.inductionOn
     (by simp [star_eq_conjTranspose, conjTranspose_kronecker])
     (by simp_all)
 

--- a/Mathlib/RingTheory/PicardGroup.lean
+++ b/Mathlib/RingTheory/PicardGroup.lean
@@ -801,7 +801,7 @@ noncomputable def tensorSubmoduleAlgebraEquiv : A ⊗[R] submoduleAlgebra e ≃�
   .ofBijective (.mul'' R A ∘ₗ AlgebraTensorModule.lTensor A A (Submodule.subtype _)) <| by
     convert! (AlgebraTensorModule.congr (.refl ..) (submoduleAlgebraEquiv e) ≪≫ₗ e).bijective
     ext x
-    refine x.induction_on (by simp) ?_ (by simp +contextual)
+    refine x.inductionOn ?_ (by simp +contextual)
     intro a x
     obtain ⟨m, rfl⟩ := (submoduleAlgebraEquiv e).symm.surjective x
     suffices a * toAlgebra e m = e (a ⊗ₜ[R] m) by simpa using! this

--- a/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
+++ b/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
@@ -364,7 +364,6 @@ lemma finite_universalFactorizationMap :
     simpa [← Polynomial.eval₂_map, F] using! hp'
   intro x
   induction x with
-  | zero => exact RingHom.isIntegralElem_zero _
   | add x y _ _ => exact RingHom.IsIntegralElem.add _ ‹_› ‹_›
   | tmul x y =>
     suffices (universalFactorizationMap R n m k hn).IsIntegralElem (x ⊗ₜ 1 * 1 ⊗ₜ y) by simpa

--- a/Mathlib/RingTheory/PolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/PolynomialAlgebra.lean
@@ -126,8 +126,7 @@ theorem invFun_monomial (n : ℕ) (a : A) :
   eval₂_monomial _ _
 
 theorem left_inv (x : A ⊗ R[X]) : invFun R A ((toFunAlgHom R A) x) = x := by
-  refine TensorProduct.induction_on x ?_ ?_ ?_
-  · simp [invFun]
+  refine TensorProduct.inductionOn x ?_ ?_
   · intro a p
     dsimp only [invFun]
     rw [toFunAlgHom_apply_tmul, eval₂_sum]

--- a/Mathlib/RingTheory/RingHom/Surjective.lean
+++ b/Mathlib/RingTheory/RingHom/Surjective.lean
@@ -49,7 +49,6 @@ theorem surjective_isStableUnderBaseChange : IsStableUnderBaseChange surjective 
   refine IsStableUnderBaseChange.mk surjective_respectsIso ?_
   introv h x
   induction x with
-  | zero => exact ⟨0, map_zero _⟩
   | tmul x y =>
     obtain ⟨y, rfl⟩ := h y; use y • x; dsimp
     rw [TensorProduct.smul_tmul, Algebra.algebraMap_eq_smul_one]

--- a/Mathlib/RingTheory/Smooth/Fiber.lean
+++ b/Mathlib/RingTheory/Smooth/Fiber.lean
@@ -130,7 +130,6 @@ private lemma FormallySmooth.of_formallySmooth_residueField_tensor_aux
   ext x
   dsimp
   induction x with
-  | zero => simp only [LinearEquiv.map_zero, LinearMap.map_zero]
   | add x y _ _ => simp only [LinearEquiv.map_add, LinearMap.map_add, *]
   | tmul x y =>
   dsimp [eₗ, eᵣ, e₁, KaehlerDifferential.cotangentComplexBaseChange,

--- a/Mathlib/RingTheory/Smooth/IntegralClosure.lean
+++ b/Mathlib/RingTheory/Smooth/IntegralClosure.lean
@@ -41,7 +41,6 @@ def TensorProduct.toIntegralClosure
     S ⊗[R] integralClosure R B →ₐ[S] integralClosure S (S ⊗[R] B) :=
     (Algebra.TensorProduct.map (.id _ _) (integralClosure R B).val).codRestrict _ fun x ↦ by
   induction x with
-  | zero => simp
   | add x y _ _ => rw [map_add]; exact add_mem ‹_› ‹_›
   | tmul x y =>
     convert!

--- a/Mathlib/RingTheory/SurjectiveOnStalks.lean
+++ b/Mathlib/RingTheory/SurjectiveOnStalks.lean
@@ -137,9 +137,6 @@ lemma SurjectiveOnStalks.exists_mul_eq_tmul
     ∃ (t : T) (r : R) (a : S), (r • t ∉ J) ∧
       (1 : S) ⊗ₜ[R] (r • t) * x = a ⊗ₜ[R] t := by
   induction x with
-  | zero =>
-    exact ⟨1, 1, 0, by rw [one_smul]; exact J.primeCompl.one_mem,
-      by rw [mul_zero, TensorProduct.zero_tmul]⟩
   | tmul x₁ x₂ =>
     obtain ⟨y, s, c, hs, hc, e⟩ := (surjective_localRingHom_iff _).mp (hf₂ J hJ) x₂
     simp_rw [Algebra.smul_def]

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -76,8 +76,7 @@ lemma range_liftBaseChange (l : M →ₗ[R] N) :
     LinearMap.range (l.liftBaseChange A) = Submodule.span A (LinearMap.range l) := by
   apply le_antisymm
   · rintro _ ⟨x, rfl⟩
-    induction x using TensorProduct.induction_on
-    · simp
+    induction x using TensorProduct.inductionOn
     · rw [LinearMap.liftBaseChange_tmul]
       exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨_, rfl⟩)
     · rw [map_add]
@@ -179,9 +178,7 @@ instance (priority := 100) isScalarTower_right [Monoid S] [DistribMulAction S A]
   smul_assoc r x y := by
     change r • x * y = r • (x * y)
     induction y with
-    | zero => simp [smul_zero]
     | tmul a b => induction x with
-      | zero => simp [smul_zero]
       | tmul a' b' =>
         dsimp
         rw [TensorProduct.smul_tmul', TensorProduct.smul_tmul', tmul_mul_tmul, smul_mul_assoc]
@@ -194,9 +191,7 @@ instance (priority := 100) sMulCommClass_right [Monoid S] [DistribMulAction S A]
   smul_comm r x y := by
     change r • (x * y) = x * r • y
     induction y with
-    | zero => simp [smul_zero]
     | tmul a b => induction x with
-      | zero => simp [smul_zero]
       | tmul a' b' =>
         dsimp
         rw [TensorProduct.smul_tmul', TensorProduct.smul_tmul', tmul_mul_tmul, mul_smul_comm]
@@ -212,10 +207,10 @@ variable [NonAssocSemiring A] [Module R A] [SMulCommClass R A A] [IsScalarTower 
 variable [NonAssocSemiring B] [Module R B] [SMulCommClass R B B] [IsScalarTower R B B]
 
 protected theorem one_mul (x : A ⊗[R] B) : mul (1 ⊗ₜ 1) x = x := by
-  refine TensorProduct.induction_on x ?_ ?_ ?_ <;> simp +contextual
+  refine TensorProduct.inductionOn x ?_ ?_ <;> simp +contextual
 
 protected theorem mul_one (x : A ⊗[R] B) : mul x (1 ⊗ₜ 1) = x := by
-  refine TensorProduct.induction_on x ?_ ?_ ?_ <;> simp +contextual
+  refine TensorProduct.inductionOn x ?_ ?_ <;> simp +contextual
 
 instance instNonAssocSemiring : NonAssocSemiring (A ⊗[R] B) where
   one_mul := Algebra.TensorProduct.one_mul
@@ -369,7 +364,6 @@ lemma ringHom_ext {C : Type*} [Semiring C] {f g : A ⊗[R] B →+* C}
     (h₂ : f.comp includeRight.toRingHom = g.comp includeRight.toRingHom) : f = g := by
   ext x
   induction x with
-  | zero => simp
   | add x y _ _ => simp_all
   | tmul x y => simpa [← map_mul] using congr($h₁ x * $h₂ y)
 
@@ -435,11 +429,9 @@ variable [CommSemiring B] [Algebra R B]
 instance instCommSemiring : CommSemiring (A ⊗[R] B) where
   toSemiring := inferInstance
   mul_comm x y := by
-    refine TensorProduct.induction_on x ?_ ?_ ?_
-    · simp
+    refine TensorProduct.inductionOn x ?_ ?_
     · intro a₁ b₁
-      refine TensorProduct.induction_on y ?_ ?_ ?_
-      · simp
+      refine TensorProduct.inductionOn y ?_ ?_
       · intro a₂ b₂
         simp [mul_comm]
       · intro a₂ b₂ ha hb
@@ -508,7 +500,7 @@ instance right_isScalarTower : IsScalarTower R B (A ⊗[R] B) :=
 lemma right_algebraMap_apply (b : B) : algebraMap B (A ⊗[R] B) b = 1 ⊗ₜ b := rfl
 
 instance : SMulCommClass A B (A ⊗[R] B) where
-  smul_comm a b x := x.induction_on (by simp)
+  smul_comm a b x := x.inductionOn
     (fun _ _ ↦ by simp [Algebra.smul_def, right_algebraMap_apply, smul_tmul'])
     fun _ _ h₁ h₂ ↦ by simpa using congr($h₁ + $h₂)
 
@@ -534,7 +526,6 @@ lemma closure_range_union_range_eq_top [CommRing R] [Ring A] [Ring B]
   rw [← top_le_iff]
   rintro x -
   induction x with
-  | zero => exact zero_mem _
   | tmul x y =>
     convert_to (Algebra.TensorProduct.includeLeftRingHom (R := R) x) *
       (Algebra.TensorProduct.includeRight y) ∈ _
@@ -627,14 +618,7 @@ protected def module : Module (A ⊗[R] B) M where
     simp only [(· • ·), Algebra.TensorProduct.one_def]
     simp only [moduleAux_apply, one_smul]
   mul_smul x y m := by
-    refine TensorProduct.induction_on x ?_ ?_ ?_ <;> refine TensorProduct.induction_on y ?_ ?_ ?_
-    · simp only [(· • ·), mul_zero, map_zero, LinearMap.zero_apply]
-    · intro a b
-      simp only [(· • ·), zero_mul, map_zero, LinearMap.zero_apply]
-    · intro z w _ _
-      simp only [(· • ·), zero_mul, map_zero, LinearMap.zero_apply]
-    · intro a b
-      simp only [(· • ·), mul_zero, map_zero, LinearMap.zero_apply]
+    refine TensorProduct.inductionOn x ?_ ?_ <;> refine TensorProduct.inductionOn y ?_ ?_
     · intro a₁ b₁ a₂ b₂
       -- Porting note: was one `simp only`, not two
       simp only [(· • ·), Algebra.TensorProduct.tmul_mul_tmul]
@@ -644,8 +628,6 @@ protected def module : Module (A ⊗[R] B) M where
       simp only [(· • ·)] at hz hw ⊢
       simp only [moduleAux_apply, mul_add, map_add,
         LinearMap.add_apply, moduleAux_apply, hz, hw]
-    · intro z w _ _
-      simp only [(· • ·), mul_zero, map_zero, LinearMap.zero_apply]
     · intro a b z w hz hw
       simp only [(· • ·)] at hz hw ⊢
       simp only [map_add, add_mul, LinearMap.add_apply, hz, hw]
@@ -747,8 +729,8 @@ variable [StarRing R] [StarRing A] [StarRing B] [StarModule R A] [StarModule R B
 
 noncomputable instance : StarMul (A ⊗[R] B) where
   star_mul x y :=
-    x.induction_on (by simp) (fun _ _ ↦
-      y.induction_on (by simp)
+    x.inductionOn (fun _ _ ↦
+      y.inductionOn
         fun _ _ ↦ by simp
       fun _ _ h₁ h₂ ↦ by simp [add_mul, mul_add, h₁, h₂])
     fun _ _ h₁ h₂ ↦ by simp [add_mul, mul_add, h₁, h₂]

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -662,7 +662,7 @@ lemma Submodule.map_range_rTensor_subtype_lid {R Q} [CommSemiring R] [AddCommMon
   refine le_antisymm ?_ fun q h ↦ Submodule.smul_induction_on h
     (fun r hr q _ ↦ ⟨⟨r, hr⟩ ⊗ₜ q, by simp⟩) (by simp +contextual [add_mem])
   rintro _ ⟨t, rfl⟩
-  exact t.induction_on (by simp) (by simp +contextual [Submodule.smul_mem_smul])
+  exact t.inductionOn (by simp +contextual [Submodule.smul_mem_smul])
     (by simp +contextual [add_mem])
 
 section

--- a/Mathlib/RingTheory/TensorProduct/Finite.lean
+++ b/Mathlib/RingTheory/TensorProduct/Finite.lean
@@ -34,7 +34,6 @@ submodule of `N`, under the tensor product of the inclusion `J → N` and the id
 theorem exists_fg_le_eq_rTensor_subtype (x : N ⊗ M) :
     ∃ (J : Submodule R N) (_ : J.FG) (y : J ⊗ M), x = rTensor M J.subtype y := by
   induction x with
-  | zero => exact ⟨⊥, fg_bot, 0, rfl⟩
   | tmul i m => exact ⟨R ∙ i, fg_span_singleton i, ⟨i, mem_span_singleton_self _⟩ ⊗ₜ[R] m, rfl⟩
   | add x₁ x₂ ihx₁ ihx₂ =>
     obtain ⟨J₁, fg₁, y₁, rfl⟩ := ihx₁
@@ -84,7 +83,6 @@ instance Module.Finite.base_change [CommSemiring R] [Semiring A] [Algebra R A] [
     refine ⟨⟨s.image (TensorProduct.mk R A M 1), eq_top_iff.mpr ?_⟩⟩
     rintro x -
     induction x with
-    | zero => exact zero_mem _
     | tmul x y =>
       rw [Finset.coe_image, ← Submodule.span_span_of_tower R, Submodule.span_image, hs,
         Submodule.map_top, LinearMap.coe_range, ← mul_one x, ← smul_eq_mul,

--- a/Mathlib/RingTheory/TensorProduct/Free.lean
+++ b/Mathlib/RingTheory/TensorProduct/Free.lean
@@ -58,7 +58,7 @@ theorem basisAux_tmul (a : A) (m : M) :
   simp [basisAux, ← Algebra.commutes, Algebra.smul_def]
 
 theorem basisAux_map_smul (a : A) (x : A ⊗[R] M) : basisAux A b (a • x) = a • basisAux A b x :=
-  TensorProduct.induction_on x (by simp)
+  TensorProduct.inductionOn x
     (fun x y => by simp only [TensorProduct.smul_tmul', basisAux_tmul, smul_assoc])
     fun x y hx hy => by simp [hx, hy]
 

--- a/Mathlib/RingTheory/TensorProduct/IsBaseChangeHom.lean
+++ b/Mathlib/RingTheory/TensorProduct/IsBaseChangeHom.lean
@@ -174,7 +174,6 @@ theorem endHom_one {α : M →ₗ[R] P} (j : IsBaseChange S α) :
     j.endHom 1 = 1 := by
   ext p
   induction p using j.inductionOn with
-  | zero => simp
   | add x y hx hy => simp [hx, hy]
   | smul _ _ h => simp [h]
   | tmul m => simp [endHom_comp_apply]

--- a/Mathlib/RingTheory/TensorProduct/IsBaseChangeHom.lean
+++ b/Mathlib/RingTheory/TensorProduct/IsBaseChangeHom.lean
@@ -54,8 +54,7 @@ def linearMapRightBaseChangeHom (ε : N →ₗ[R] P) :
     map_smul' r s := by simp }).toAddHom
   map_smul' s x := by
     simp only [AddHom.toFun_eq_coe, coe_toAddHom, RingHom.id_apply]
-    induction x using TensorProduct.induction_on with
-    | zero => simp
+    induction x using TensorProduct.inductionOn with
     | add x y hx hy => simp [smul_add, hx, hy]
     | tmul t f => simp [TensorProduct.smul_tmul', mul_smul]
 

--- a/Mathlib/RingTheory/TensorProduct/Maps.lean
+++ b/Mathlib/RingTheory/TensorProduct/Maps.lean
@@ -325,7 +325,7 @@ canonical T-algebra homomorphism from `A ⊗[S] B` to `A ⊗[R] B`,
 where `T` is any other ring acting on `A` and whose action commutes with the `R` and `S`-actions. -/
 def mapOfCompatibleSMul : A ⊗[S] B →ₐ[T] A ⊗[R] B :=
   .ofLinearMap (_root_.TensorProduct.mapOfCompatibleSMul R S T A B) rfl fun x ↦
-    x.induction_on (by simp) (fun _ _ y ↦ y.induction_on (by simp) (by simp)
+    x.inductionOn (fun _ _ y ↦ y.inductionOn (by simp)
       fun _ _ h h' ↦ by simp only [mul_add, map_add, h, h'])
       fun _ _ h h' _ ↦ by simp only [add_mul, map_add, h, h']
 
@@ -752,7 +752,7 @@ variable (R)
 def lmul'' : S ⊗[R] S →ₐ[S] S :=
   algHomOfLinearMapTensorProduct
     { __ := LinearMap.mul' R S
-      map_smul' := fun s x ↦ x.induction_on (by simp)
+      map_smul' := fun s x ↦ x.inductionOn
         (fun _ _ ↦ by simp [TensorProduct.smul_tmul', mul_assoc])
         fun x y hx hy ↦ by simp_all [mul_add] }
     (fun a₁ a₂ b₁ b₂ => by simp [mul_mul_mul_comm]) <| by simp
@@ -788,8 +788,8 @@ variable (R S) in
 /-- If multiplication by elements of S can switch between the two factors of `S ⊗[R] S`,
 then `lmul''` is an isomorphism. -/
 def lmulEquiv [CompatibleSMul R S S S] : S ⊗[R] S ≃ₐ[S] S :=
-  .ofAlgHom (lmul'' R) includeLeft lmul'_comp_includeLeft <| AlgHom.ext fun x ↦ x.induction_on
-    (by simp) (fun x y ↦ show (x * y) ⊗ₜ[R] 1 = x ⊗ₜ[R] y by
+  .ofAlgHom (lmul'' R) includeLeft lmul'_comp_includeLeft <| AlgHom.ext fun x ↦ x.inductionOn
+    (fun x y ↦ show (x * y) ⊗ₜ[R] 1 = x ⊗ₜ[R] y by
       rw [mul_comm, ← smul_eq_mul, smul_tmul, smul_eq_mul, mul_one])
     fun _ _ hx hy ↦ by simp_all [add_tmul]
 

--- a/Mathlib/RingTheory/TensorProduct/Pi.lean
+++ b/Mathlib/RingTheory/TensorProduct/Pi.lean
@@ -36,9 +36,7 @@ variable {R S A B} in
 lemma piRightHom_mul (x y : A ⊗[R] ∀ i, B i) :
     piRightHom R S A B (x * y) = piRightHom R S A B x * piRightHom R S A B y := by
   induction x
-  · simp
   · induction y
-    · simp
     · ext j
       simp
     · simp_all [mul_add]

--- a/Mathlib/RingTheory/Unramified/Finite.lean
+++ b/Mathlib/RingTheory/Unramified/Finite.lean
@@ -244,15 +244,13 @@ def sec :
       LinearMap.flip_apply, TensorProduct.AlgebraTensorModule.mapBilinear_apply, RingHom.id_apply]
     trans (TensorProduct.AlgebraTensorModule.map (LinearMap.id (R := S) (M := S))
       ((LinearMap.flip (AlgHom.toLinearMap (lsmul R R M))) m)) ((1 ⊗ₜ r) * elem R S)
-    · induction elem R S using TensorProduct.induction_on
-      · simp
+    · induction elem R S using TensorProduct.inductionOn
       · simp [smul_comm r]
       · simp only [map_add, mul_add, *]
     · have := one_tmul_sub_tmul_one_mul_elem (R := R) r
       rw [sub_mul, sub_eq_zero] at this
       rw [this]
-      induction elem R S using TensorProduct.induction_on
-      · simp
+      induction elem R S using TensorProduct.inductionOn
       · simp [TensorProduct.smul_tmul']
       · simp only [map_add, smul_add, mul_add, *]
 
@@ -265,8 +263,7 @@ lemma comp_sec :
     Function.comp_apply, LinearMap.flip_apply, TensorProduct.AlgebraTensorModule.mapBilinear_apply,
     TensorProduct.AlgebraTensorModule.lift_apply, LinearMap.id_coe, id_eq]
   trans (TensorProduct.lmul' R (elem R S)) • x
-  · induction elem R S using TensorProduct.induction_on with
-    | zero => simp
+  · induction elem R S using TensorProduct.inductionOn with
     | tmul r s => simp [mul_smul, smul_comm r s]
     | add y z hy hz => simp [hy, hz, add_smul]
   · rw [lmul_elem, one_smul]


### PR DESCRIPTION
1) Deprecate + rename in Mathlib.LinearAlgebra.TensorProduct.Defs.lean
```
@[deprecated "Use `TensorProduction.inductionOn` instead" (since := "2026-09-07")]
protected theorem induction_on {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
```

```
@[elab_as_elim, induction_eliminator]
protected theorem inductionOn {motive : M ⊗[R] N → Prop} (z : M ⊗[R] N)
    (tmul : ∀ x y, motive <| x ⊗ₜ[R] y)
    (add : ∀ x y, motive x → motive y → motive (x + y)) : motive z :=
```
2) Remove `zero` from `IsTensorProduct.inductionOn` `IsBaseChange.inductionOn` in Mathlib.RingTheory.IsTensorProduct.lean

[#mathlib4 > Redundant "zero" step in TensorProduct.induction_on @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Redundant.20.22zero.22.20step.20in.20TensorProduct.2Einduction_on/near/614858536)