### PR TITLE
feat(LinearAlgebra/LinearIndependent/Basic): promote `LinearIndepOn.id_imageₛ` to iff, and add `smul_set` version

### DIFF
--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -274,9 +274,19 @@ theorem LinearIndependent.linearCombination_ne_of_notMem_support [Nontrivial R]
 
 end Subtype
 
-theorem LinearIndepOn.id_imageₛ {s : Set M} {f : M →ₗ[R] M'} (hs : LinearIndepOn R id s)
-    (hf_inj : Set.InjOn f (span R s)) : LinearIndepOn R id (f '' s) :=
-  id_image <| hs.map_injOn f (by simpa using hf_inj)
+theorem linearIndepOn_id_imageₛ_iff {s : Set M} {f : M →ₗ[R] M'} (hf_inj : Set.InjOn f (span R s)) :
+    LinearIndepOn R id (f '' s) ↔ LinearIndepOn R id s := by
+  rw [← linearIndepOn_iff_image (hf_inj.mono subset_span)]
+  exact f.linearIndepOn_iff_of_injOn (by simpa using hf_inj)
+
+alias ⟨_, LinearIndepOn.id_imageₛ⟩ := linearIndepOn_id_imageₛ_iff
+
+open scoped Pointwise in
+@[simp]
+theorem linearIndepOn_id_smul_set_iff {G : Type*} [Group G] [DistribMulAction G M]
+    [SMulCommClass G R M] (a : G) (s : Set M) :
+    LinearIndepOn R id (a • s) ↔ LinearIndepOn R id s :=
+  linearIndepOn_id_imageₛ_iff (DistribMulAction.toLinearEquiv R M a).injective.injOn
 
 theorem surjective_of_linearIndependent_of_span [Nontrivial R] (hv : LinearIndependent R v)
     (f : ι' ↪ ι) (hss : range v ⊆ span R (range (v ∘ f))) : Surjective f := by


### PR DESCRIPTION
This is the "id"-version of `LinearMap.linearIndepOn_iff_of_injOn`. Now `LinearIndepOn.id_imageₛ` is an alias for the mpr direction.

The smul version looks similar to `LinearIndependent.group_smul_iff`, but theirs needs a group action on the ring, not the module.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
