### PR TITLE
feat(NumberTheory/NumberField): the discriminant of the quadratic fields ℚ(√d)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1222,6 +1222,8 @@ public import Mathlib.Algebra.QuadraticAlgebra.Basic
 public import Mathlib.Algebra.QuadraticAlgebra.Defs
 public import Mathlib.Algebra.QuadraticAlgebra.Discr
 public import Mathlib.Algebra.QuadraticAlgebra.Discriminant
+public import Mathlib.Algebra.QuadraticAlgebra.Int
+public import Mathlib.Algebra.QuadraticAlgebra.IsQuadraticExtension
 public import Mathlib.Algebra.QuadraticAlgebra.NormDeterminant
 public import Mathlib.Algebra.QuadraticDiscriminant
 public import Mathlib.Algebra.Quandle
@@ -5432,6 +5434,7 @@ public import Mathlib.LinearAlgebra.Trace
 public import Mathlib.LinearAlgebra.Transvection
 public import Mathlib.LinearAlgebra.Transvection.Basic
 public import Mathlib.LinearAlgebra.Transvection.Generation
+public import Mathlib.LinearAlgebra.Unimodular
 public import Mathlib.LinearAlgebra.UnitaryGroup
 public import Mathlib.LinearAlgebra.Vandermonde
 public import Mathlib.Logic.Embedding.Basic
@@ -6035,6 +6038,7 @@ public import Mathlib.NumberTheory.NumberField.InfinitePlace.Ramification
 public import Mathlib.NumberTheory.NumberField.InfinitePlace.TotallyRealComplex
 public import Mathlib.NumberTheory.NumberField.Norm
 public import Mathlib.NumberTheory.NumberField.ProductFormula
+public import Mathlib.NumberTheory.NumberField.QuadraticField.Basic
 public import Mathlib.NumberTheory.NumberField.Units.Basic
 public import Mathlib.NumberTheory.NumberField.Units.DirichletTheorem
 public import Mathlib.NumberTheory.NumberField.Units.Regulator
@@ -7125,6 +7129,7 @@ public import Mathlib.RingTheory.PowerSeries.WellKnown
 public import Mathlib.RingTheory.Prime
 public import Mathlib.RingTheory.PrincipalIdealDomain
 public import Mathlib.RingTheory.PrincipalIdealDomainOfPrime
+public import Mathlib.RingTheory.QuadraticAlgebra
 public import Mathlib.RingTheory.QuasiFinite.Basic
 public import Mathlib.RingTheory.QuasiFinite.Polynomial
 public import Mathlib.RingTheory.QuasiFinite.Weakly

--- a/Mathlib/Algebra/QuadraticAlgebra/Basic.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Basic.lean
@@ -14,7 +14,7 @@ public import Mathlib.Tactic.FieldSimp.Lemmas
 import Mathlib.Tactic.FieldSimp
 
 /-!
-# Quadratic algebras: involution, norm, trace, and change of generator.
+# Quadratic algebras: involution, norm, trace, change of generator, etc.
 
 Let `R` be a commutative ring. We define:
 
@@ -27,6 +27,8 @@ Let `R` be a commutative ring. We define:
 * `QuadraticAlgebra.changeGenerator` and `QuadraticAlgebra.changeGeneratorEquiv`: the `R`-algebra
   map, respectively isomorphism (when `u` is a unit), induced by the change of generator
   `ω ↦ u • ω + k`
+
+* `QuadraticAlgebra.baseChange`: the `R`-algebra homomorphism induced by a base change `R → S`
 
 We prove:
 
@@ -268,6 +270,10 @@ theorem norm_one : norm (1 : QuadraticAlgebra R a b) = 1 := by simp [norm]
 theorem norm_algebraMap (r : R) : norm (algebraMap R (QuadraticAlgebra R a b) r) = r ^ 2 := by
   simp [norm_def, pow_two]
 
+theorem norm_smul (r : R) (z : QuadraticAlgebra R a b) :
+    norm (r • z) = r ^ 2 * norm z := by
+  rw [Algebra.smul_def, map_mul, norm_algebraMap]
+
 @[simp]
 theorem norm_natCast (n : ℕ) : norm (n : QuadraticAlgebra R a b) = n ^ 2 := by
   simp [norm_def, pow_two]
@@ -427,6 +433,22 @@ theorem sq_eq_trace_smul_sub_norm :
 
 end trace
 
+section equivOfEq
+
+variable [CommSemiring R]
+
+/-- Equal parameters give isomorphic quadratic algebras. -/
+@[simps]
+def equivOfEq {a' b' : R} (ha : a = a') (hb : b = b') :
+    QuadraticAlgebra R a b ≃ₐ[R] QuadraticAlgebra R a' b' where
+  toFun z := ⟨z.re, z.im⟩
+  invFun z := ⟨z.re, z.im⟩
+  map_mul' _ _ := by ext <;> simp [ha, hb]
+  map_add' _ _ := by ext <;> simp
+  commutes' _ := by ext <;> simp
+
+end equivOfEq
+
 section changeGenerator
 
 variable [CommRing R]
@@ -483,6 +505,50 @@ def changeGeneratorEquiv (a b : R) (u : Rˣ) (k : R) {a' b' : R}
 @[deprecated (since := "2026-08-14")] alias mapEquiv := changeGeneratorEquiv
 
 end changeGenerator
+
+section baseChange
+
+variable {R S : Type*} (S)
+
+section CommSemiring
+
+variable [CommSemiring R] [CommRing S] [Algebra R S] (a b : R)
+
+/-- The `R`-algebra map between quadratic algebras induced by the base change `R → S`,
+sending `ω` to `ω`. -/
+@[simps!]
+def baseChange :
+    QuadraticAlgebra R a b →ₐ[R] QuadraticAlgebra S (algebraMap R S a) (algebraMap R S b) :=
+  lift ⟨omega, by ext <;> simp [Algebra.algebraMap_eq_smul_one]⟩
+
+theorem baseChange_omega :
+    baseChange S a b ω = ω := by
+  ext <;> simp
+
+theorem baseChange_injective [FaithfulSMul R S] :
+    Function.Injective (baseChange S a b) := by
+  intro _ _ h
+  simp only [QuadraticAlgebra.ext_iff, re_baseChange_apply, ← Algebra.algebraMap_eq_smul_one,
+    algebraMap.coe_inj, im_baseChange_apply] at h
+  exact QuadraticAlgebra.ext_iff.mpr h
+
+end CommSemiring
+
+section CommRing
+
+variable [CommRing R] [CommRing S] [Algebra R S] (a b : R)
+
+theorem norm_baseChange (x : QuadraticAlgebra R a b) :
+    norm (baseChange S a b x) = algebraMap R S (norm x) := by
+  simp [norm_def, Algebra.smul_def]
+
+theorem trace_baseChange (x : QuadraticAlgebra R a b) :
+    trace (baseChange S a b x) = algebraMap R S (trace x) := by
+  simp [trace_def, Algebra.smul_def, map_ofNat]
+
+end CommRing
+
+end baseChange
 
 section field
 

--- a/Mathlib/Algebra/QuadraticAlgebra/Discriminant.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Discriminant.lean
@@ -5,14 +5,16 @@ Authors: Xavier Roblot
 -/
 module
 
-public import Mathlib.Algebra.QuadraticAlgebra.Basic
+public import Mathlib.Algebra.QuadraticAlgebra.AlgHom
+public import Mathlib.Data.Nat.Prime.Int
 
 /-!
 # Discriminant of a quadratic algebra
 
 This file introduces the discriminant of a quadratic algebra `QuadraticAlgebra R a b` (with the
-convention `ω² = a + b·ω`), describes how it transforms under a change of generator, and derives,
-over a field, a criterion for `QuadraticAlgebra K a b` to be a field.
+convention `ω² = a + b·ω`), describes how it transforms under a change of generator, and derives
+the classification of quadratic algebras up to isomorphism together with a criterion, over a
+field, for `QuadraticAlgebra K a b` to be a field.
 
 ## Main definitions
 
@@ -24,6 +26,9 @@ over a field, a criterion for `QuadraticAlgebra K a b` to be a field.
   of generator `ω ↦ u • ω + k`.
 * `QuadraticAlgebra.exists_sq_eq_iff_isSquare_discr`: over a ring with `2` invertible,
   `X ^ 2 - b * X - a` has a root iff `discr a b` is a square.
+* `QuadraticAlgebra.nonempty_algEquiv_iff_of_invertible_two` and
+  `QuadraticAlgebra.nonempty_algEquiv_int_iff`: the discriminant classifies quadratic algebras
+  up to isomorphism, modulo squares of units when `2` is invertible and exactly over `ℤ`.
 * `QuadraticAlgebra.isField_iff_not_isSquare_discr`: over a field with `2 ≠ 0`,
   `QuadraticAlgebra K a b` is a field iff `discr a b` is not a square.
 -/
@@ -41,6 +46,26 @@ discriminant `b ^ 2 + 4 * a` of the polynomial `X ^ 2 - b * X - a`. -/
 def discr [CommSemiring R] (a b : R) : R := b ^ 2 + 4 * a
 
 theorem discr_def [CommSemiring R] (a b : R) : discr a b = b ^ 2 + 4 * a := rfl
+
+/-- `discr a b = b ^ 2 + 4 * a ≡ 0, 1 mod 4` for every `a b : ℤ`. -/
+theorem discr_emod_four (a b : ℤ) : discr a b % 4 = 0 ∨ discr a b % 4 = 1 := by
+  rw [discr_def]; have := Int.sq_emod_four b; lia
+
+/-- The discriminant commutes with a base change `R → S`. -/
+@[simp]
+theorem discr_algebraMap {S : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S] (a b : R) :
+    discr (algebraMap R S a) (algebraMap R S b) = algebraMap R S (discr a b) := by
+  simp [discr_def, map_ofNat]
+
+/-- `z.im ^ 2` times the discriminant of the algebra equals `trace z ^ 2 - 4 * norm z`. -/
+theorem im_sq_mul_discr [CommRing R] {a b : R} (z : QuadraticAlgebra R a b) :
+    z.im ^ 2 * discr a b = trace z ^ 2 - 4 * norm z := by
+  rw [trace_def, norm_def, discr_def]; ring
+
+/-- `im_sq_mul_discr` solved for `4 * norm z`. -/
+theorem four_mul_norm_eq [CommRing R] {a b : R} (z : QuadraticAlgebra R a b) :
+    4 * norm z = trace z ^ 2 - discr a b * z.im ^ 2 := by
+  rw [trace_def, norm_def, discr_def]; ring
 
 /-- Under the change of generator `ω ↦ u • ω + k` (see `QuadraticAlgebra.changeGenerator`), the
 discriminant is multiplied by `u ^ 2`. -/
@@ -61,13 +86,108 @@ theorem algebraMap_discr [CommRing R] (a b : R) :
 discriminant is a square. -/
 theorem exists_sq_eq_iff_isSquare_discr [CommRing R] [Invertible (2 : R)] {a b : R} :
     (∃ r : R, r ^ 2 = a + b * r) ↔ IsSquare (discr a b) := by
-  rw [isSquare_iff_exists_sq]
-  have h2 := mul_invOf_self (2 : R)
-  refine ⟨fun ⟨r, hr⟩ ↦ ⟨2 * r - b, by rw [discr_def]; grind⟩, fun ⟨s, hs⟩ ↦ ⟨⅟2 * (b + s), ?_⟩⟩
-  rw [discr_def] at hs
-  grind
+  rw [isSquare_iff_exists_sq, discr_def]
+  exact ⟨fun ⟨r, hr⟩ ↦ ⟨2 * r - b, by grind⟩,
+    fun ⟨r, hr⟩ ↦ ⟨⅟2 * (b + r), by grind [mul_invOf_self (2 : R)]⟩⟩
 
 end discr
+
+section classification
+
+variable [CommRing R] {a b a' b' : R}
+  (f : QuadraticAlgebra R a b →ₐ[R] QuadraticAlgebra R a' b')
+
+/-- The transformation law for an injective algebra map. -/
+theorem discr_eq_im_sq_mul_discr (hf : Function.Injective f) :
+    discr a b = (f ω).im ^ 2 * discr a' b' := by
+  rw [im_sq_mul_discr (f ω), trace_algHom_omega f hf, norm_algHom_omega f hf, discr_def]
+  ring
+
+/-- `discr_eq_im_sq_mul_discr` for an `R`-algebra isomorphism `e`, for which `(e ω).im` is
+automatically a unit (`isUnit_im_omega_of_algEquiv`). -/
+theorem discr_eq_im_sq_mul_discr' (e : QuadraticAlgebra R a b ≃ₐ[R] QuadraticAlgebra R a' b') :
+    discr a b = (e ω).im ^ 2 * discr a' b' := by
+  rw [discr_eq_im_sq_mul_discr e.toAlgHom, AlgEquiv.toAlgHom_apply]
+  exact e.injective
+
+/-- If `2` is a unit, `QuadraticAlgebra R a b` is isomorphic to the standard form
+`QuadraticAlgebra R (discr a b) 0`. -/
+def algEquivDiscrZero [Invertible (2 : R)] (a b : R) :
+    QuadraticAlgebra R a b ≃ₐ[R] QuadraticAlgebra R (discr a b) 0 :=
+  (changeGeneratorEquiv a b (unitOfInvertible (2 : R)) (-b)
+    (by grind [discr_def, val_unitOfInvertible]) (by grind [val_unitOfInvertible])).symm
+
+@[simp]
+theorem re_algEquivDiscrZero_apply [Invertible (2 : R)] (z : QuadraticAlgebra R a b) :
+    (algEquivDiscrZero a b z).re = z.re + ⅟2 * b * z.im := by
+  simp [algEquivDiscrZero, mul_comm]
+
+@[simp]
+theorem im_algEquivDiscrZero_apply [Invertible (2 : R)] (z : QuadraticAlgebra R a b) :
+    (algEquivDiscrZero a b z).im = ⅟2 * z.im := by
+  simp [algEquivDiscrZero, mul_comm]
+
+@[simp]
+theorem re_algEquivDiscrZero_symm_apply [Invertible (2 : R)]
+    (z : QuadraticAlgebra R (discr a b) 0) :
+    ((algEquivDiscrZero a b).symm z).re = z.re - b * z.im := by
+  simp [algEquivDiscrZero, mul_comm, sub_eq_add_neg]
+
+@[simp]
+theorem im_algEquivDiscrZero_symm_apply [Invertible (2 : R)]
+    (z : QuadraticAlgebra R (discr a b) 0) :
+    ((algEquivDiscrZero a b).symm z).im = 2 * z.im := by
+  simp [algEquivDiscrZero, mul_comm]
+
+@[simp]
+theorem algEquivDiscrZero_apply_add_smul [Invertible (2 : R)] (x y : R) :
+    algEquivDiscrZero a b (x • 1 + y • ω) = (x + ⅟2 * b * y) • 1 + (⅟2 * y) • ω := by
+  ext <;> simp [mul_comm]
+
+@[simp]
+theorem algEquivDiscrZero_symm_apply_add_smul [Invertible (2 : R)] (x y : R) :
+    (algEquivDiscrZero a b).symm (x • 1 + y • ω) = (x - b * y) • 1 + (2 * y) • ω := by
+  ext <;> simp [mul_comm, sub_eq_add_neg]
+
+/-- If `2` is regular, `QuadraticAlgebra R a b` and `QuadraticAlgebra R a' b'` are isomorphic
+iff `discr a b = u ^ 2 * discr a' b'` for some unit `u` with `2 ∣ b - u * b'`. -/
+theorem nonempty_algEquiv_iff (h : IsRegular (2 : R)) :
+    Nonempty (QuadraticAlgebra R a b ≃ₐ[R] QuadraticAlgebra R a' b') ↔
+      ∃ u : Rˣ, discr a b = (u : R) ^ 2 * discr a' b' ∧ 2 ∣ (b - u * b') := by
+  refine ⟨fun ⟨e⟩ ↦ ?_, fun ⟨u, hu, ⟨k, hk⟩⟩ ↦ ⟨changeGeneratorEquiv a' b' u k ?_ (by grind)⟩⟩
+  · refine ⟨(isUnit_im_omega_of_algEquiv e).unit,
+      by rw [discr_eq_im_sq_mul_discr' e, IsUnit.unit_spec], ⟨(e ω).re, ?_⟩⟩
+    rw [IsUnit.unit_spec, sub_eq_iff_eq_add', add_comm, mul_comm _ b', ← trace_def, eq_comm]
+    exact trace_algHom_omega e.toAlgHom e.injective
+  · rw [discr_def, discr_def] at hu
+    rw [← h.left.eq_iff, mul_sub, mul_sub, ← mul_rotate, ← mul_assoc, ← mul_assoc, ← mul_assoc,
+      ← hk, ← h.left.eq_iff, mul_sub, ← mul_assoc, ← mul_assoc, ← pow_two, ← mul_pow, ← hk]
+    grind
+
+/-- If `2` is invertible, the discriminant classifies quadratic algebras up to
+isomorphism, modulo squares of units. -/
+theorem nonempty_algEquiv_iff_of_invertible_two [Invertible (2 : R)] :
+    Nonempty (QuadraticAlgebra R a b ≃ₐ[R] QuadraticAlgebra R a' b') ↔
+      ∃ u : Rˣ, discr a b = (u : R) ^ 2 * discr a' b' := by
+  rw [nonempty_algEquiv_iff (isUnit_of_invertible (2 : R)).isRegular]
+  simp [(isUnit_of_invertible (2 : R)).dvd]
+
+/-- Over `ℤ` the discriminant is a complete invariant of quadratic algebras up to
+isomorphism. -/
+theorem nonempty_algEquiv_int_iff {a b a' b' : ℤ} :
+    Nonempty (QuadraticAlgebra ℤ a b ≃ₐ[ℤ] QuadraticAlgebra ℤ a' b') ↔
+      discr a b = discr a' b' := by
+  rw [nonempty_algEquiv_iff (IsRegular.of_ne_zero two_ne_zero)]
+  refine ⟨fun ⟨u, hu, _⟩ ↦ by rwa [Int.isUnit_sq u.isUnit, one_mul] at hu, fun h ↦ ?_⟩
+  obtain _ | _ : 2 ∣ (b + b') ∨ 2 ∣ (b - b') := by
+    rw [← Prime.dvd_mul Int.prime_two, ← sq_sub_sq]
+    refine ⟨2 * a' - 2 * a, ?_⟩
+    rwa [mul_sub, ← mul_assoc, ← mul_assoc, show (2 : ℤ) * 2 = 4 by norm_num,
+      sub_eq_sub_iff_add_eq_add, ← discr_def, add_comm, ← discr_def]
+  · exact ⟨-1, by simpa, by simpa⟩
+  · exact ⟨1, by simpa, by simpa⟩
+
+end classification
 
 section field
 

--- a/Mathlib/Algebra/QuadraticAlgebra/Int.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Int.lean
@@ -1,0 +1,387 @@
+/-
+Copyright (c) 2026 Xavier Roblot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Roblot
+-/
+module
+
+public import Mathlib.Algebra.QuadraticAlgebra.Discriminant
+public import Mathlib.Data.Rat.Lemmas
+public import Mathlib.NumberTheory.FundamentalDiscriminant
+public import Mathlib.RingTheory.Localization.FractionRing
+public import Mathlib.RingTheory.Polynomial.RationalRoot
+
+/-!
+# Quadratic algebras over `ℤ`
+
+For `a b : ℤ`, the quadratic algebra `QuadraticAlgebra ℤ a b` is an order in
+`QuadraticAlgebra ℚ a b`: a free `ℤ`-module of rank `2` whose fraction ring is
+`QuadraticAlgebra ℚ a b`. This file establishes that relation, and then determines for which
+parameters the order is maximal, that is, is the integral closure of `ℤ` in
+`QuadraticAlgebra ℚ a b`. This happens exactly when `discr a b` is a fundamental discriminant.
+
+## Main definitions
+
+* `QuadraticAlgebra.Int.algEquivIntegralClosure`: when `discr a b` is a fundamental discriminant,
+  the isomorphism between `QuadraticAlgebra ℤ a b` and the integral closure of `ℤ` in
+  `QuadraticAlgebra ℚ a b`.
+
+## Main results
+
+* `QuadraticAlgebra ℚ a b` is the localization of `QuadraticAlgebra ℤ a b` at the nonzero
+  integers, and its fraction ring.
+* `QuadraticAlgebra.Int.isDomain_iff`: `QuadraticAlgebra ℤ a b` is an integral domain iff
+  `discr a b` is not a square.
+* `QuadraticAlgebra.Int.isIntegral_iff`: an element of `QuadraticAlgebra ℚ a b` is integral over
+  `ℤ` iff its trace and its norm are integers.
+* `QuadraticAlgebra.Int.isIntegralClosure_iff`: `QuadraticAlgebra ℤ a b` is the integral closure
+  of `ℤ` in `QuadraticAlgebra ℚ a b` iff `discr a b` is a fundamental discriminant.
+* `QuadraticAlgebra.Int.isIntegrallyClosed_iff`: `QuadraticAlgebra ℤ a b` is integrally closed iff
+  `discr a b` is a fundamental discriminant.
+
+## Tags
+
+quadratic algebra, quadratic order, integral closure, fundamental discriminant
+-/
+
+@[expose] public section
+
+namespace QuadraticAlgebra
+
+open Algebra
+
+namespace Int
+
+variable {a b : ℤ}
+
+noncomputable instance : Algebra (QuadraticAlgebra ℤ a b) (QuadraticAlgebra ℚ a b) :=
+  (baseChange ℚ a b).toRingHom.toAlgebra
+
+instance : IsScalarTower ℤ (QuadraticAlgebra ℤ a b) (QuadraticAlgebra ℚ a b) :=
+  .of_algHom (baseChange ℚ a b)
+
+/-- The algebra map of the order into `QuadraticAlgebra ℚ a b` is the base change map. -/
+theorem algebraMap_eq (x : QuadraticAlgebra ℤ a b) :
+    algebraMap (QuadraticAlgebra ℤ a b) (QuadraticAlgebra ℚ a b) x = baseChange ℚ a b x := rfl
+
+/-- The algebra map preserves the `re` part. -/
+@[simp]
+theorem algebraMap_re_eq (x : QuadraticAlgebra ℤ a b) :
+    (algebraMap (QuadraticAlgebra ℤ a b) (QuadraticAlgebra ℚ a b) x).re = x.re := by
+  simp [algebraMap_eq, re_baseChange_apply ℚ]
+
+/-- The algebra map preserves the `im` part. -/
+@[simp]
+theorem algebraMap_im_eq (x : QuadraticAlgebra ℤ a b) :
+    (algebraMap (QuadraticAlgebra ℤ a b) (QuadraticAlgebra ℚ a b) x).im = x.im := by
+  simp [algebraMap_eq, im_baseChange_apply ℚ]
+
+instance : FaithfulSMul (QuadraticAlgebra ℤ a b) (QuadraticAlgebra ℚ a b) :=
+  (faithfulSMul_iff_algebraMap_injective _ _).mpr <| baseChange_injective ℚ _ _
+
+/-- The discriminant commutes with the coercion `ℤ → ℚ`. -/
+theorem discr_intCast :
+    discr (a : ℚ) (b : ℚ) = discr a b := by
+  simpa using discr_algebraMap (S := ℚ) a b
+
+open scoped nonZeroDivisors
+
+/-- Every element of `QuadraticAlgebra ℚ a b` has a positive integer denominator. -/
+theorem exists_nat_smul_mem (z : QuadraticAlgebra ℚ a b) :
+    ∃ n : ℕ, 0 < n ∧ n • z ∈ Set.range (baseChange ℚ a b) := by
+  obtain ⟨n, hn, x, y, hx, hy⟩ : ∃ n : ℕ, 0 < n ∧ ∃ x y : ℤ, n * z.re = x ∧ n * z.im = y :=
+    ⟨z.re.den * z.im.den, by positivity, z.im.den * z.re.num, z.re.den * z.im.num,
+      by push_cast; grind [← Rat.mul_den_eq_num]⟩
+  refine ⟨n, hn, x • 1 + y • ω, ?_⟩
+  ext <;> simp [re_baseChange_apply ℚ, im_baseChange_apply ℚ, hx, hy]
+
+/-- `QuadraticAlgebra ℚ a b` is the localization of the order `QuadraticAlgebra ℤ a b` at the
+nonzero integers. This is not `IsFractionRing` in general: `QuadraticAlgebra ℤ a b` need not be a
+domain (see `isDomain_iff`). -/
+noncomputable instance :
+    IsLocalization (algebraMapSubmonoid (QuadraticAlgebra ℤ a b) ℤ⁰)
+      (QuadraticAlgebra ℚ a b) := by
+  refine ⟨fun ⟨y, ⟨x, hx, hy⟩⟩ ↦ ?_, fun x ↦ ?_, fun h ↦ ⟨1, by simpa using h⟩⟩
+  · dsimp only
+    rw [← hy, ← IsScalarTower.algebraMap_apply, IsScalarTower.algebraMap_apply ℤ ℚ]
+    exact IsUnit.map _ <| by simpa [isUnit_iff_ne_zero] using hx
+  · obtain ⟨n, hn, ⟨w, hw⟩⟩ := exists_nat_smul_mem x
+    exact ⟨⟨w, n, ⟨n, by simpa using hn.ne', rfl⟩⟩, by simp [algebraMap_eq, hw, mul_comm]⟩
+
+instance : IsFractionRing (QuadraticAlgebra ℤ a b) (QuadraticAlgebra ℚ a b) := by
+  refine IsLocalization.of_le (algebraMapSubmonoid (QuadraticAlgebra ℤ a b) ℤ⁰) _ ?_ ?_
+  · rintro _ ⟨x, hx, rfl⟩
+    exact norm_mem_nonZeroDivisors_iff.mp <| by simpa using hx
+  · intro x hx
+    rwa [isUnit_iff_norm_isUnit, isUnit_iff_ne_zero, algebraMap_eq, norm_baseChange ℚ a b,
+      eq_intCast, Int.cast_ne_zero, ← mem_nonZeroDivisors_iff_ne_zero, norm_mem_nonZeroDivisors_iff]
+
+/-- The order `QuadraticAlgebra ℤ a b` is a domain iff `discr a b` is not a square. -/
+theorem isDomain_iff :
+    IsDomain (QuadraticAlgebra ℤ a b) ↔ ¬ IsSquare (discr a b) := by
+  simp [IsFractionRing.isDomain_iff_isField (K := QuadraticAlgebra ℚ a b),
+    isField_iff_not_isSquare_discr, discr_intCast]
+
+/-!
+### Maximality of the order
+
+In this section, we determine for which `a b : ℤ` the order `QuadraticAlgebra ℤ a b` is the
+integral closure of `ℤ` in `QuadraticAlgebra ℚ a b`, the answer being that `discr a b` must be a
+fundamental discriminant (see `isIntegralClosure_iff`).
+
+Everything rests on the pivot `isIntegral_iff`: an element of `QuadraticAlgebra ℚ a b` is integral
+over `ℤ` iff its trace and its norm are integers.
+
+Being the integral closure is a local condition: it suffices that the order be saturated at every
+prime `p`, meaning that `p • z` lying in the order forces `z` to lie in it, for `z` integral (see
+`isIntegralClosure_iff_forall_prime`). This is proved by descent on the smallest `n` such that
+`n • z` lies in the order, removing one prime factor of `n` at a time.
+
+Saturation at `p` is then made explicit: it fails exactly when `discr a b = p ^ 2 * e` for some
+`e ≡ 0, 1 mod 4` (see `saturated_iff_of_odd` and `saturated_two_iff`). In one direction, the
+element witnessing the failure is `((s - b) / 2 + ω) / p` with `s = p * e`, whose trace and norm
+are integers while its `im` part is not (see `exists_unsaturated_of_sq_mul`). In the other, the
+identity `discr a b * x.im ^ 2 = d ^ 2 * (t ^ 2 - 4 * n)` of `exists_discr_mul_im_sq_eq` forces
+`p ^ 2 ∣ discr a b` as soon as `p` does not divide `x.im`, and the condition on `e` mod `4` is
+then automatic for `p` odd and requires `x.im` to be odd for `p = 2`.
+-/
+
+/-- The conjugate of an integral element is integral. -/
+theorem isIntegral_star {z : QuadraticAlgebra ℚ a b} (hz : IsIntegral ℤ z) :
+    IsIntegral ℤ (star z) :=
+  hz.map (starRingEnd _).toIntAlgHom
+
+/-- The trace of an integral element is an integer. -/
+theorem trace_mem_range_of_isIntegral {z : QuadraticAlgebra ℚ a b} (hz : IsIntegral ℤ z) :
+    trace z ∈ Set.range (algebraMap ℤ ℚ) :=
+  IsIntegrallyClosed.isIntegral_iff.mp <|
+    (algebraMap_trace_eq_add_star z ▸ hz.add (isIntegral_star hz)).tower_bot
+      (FaithfulSMul.algebraMap_injective _ _)
+
+/-- The norm of an integral element is an integer. -/
+theorem norm_mem_range_of_isIntegral {z : QuadraticAlgebra ℚ a b} (hz : IsIntegral ℤ z) :
+    norm z ∈ Set.range (algebraMap ℤ ℚ) :=
+  IsIntegrallyClosed.isIntegral_iff.mp <|
+    (algebraMap_norm_eq_mul_star z ▸ hz.mul (isIntegral_star hz)).tower_bot
+      (FaithfulSMul.algebraMap_injective _ _)
+
+open Polynomial in
+/-- An element of `QuadraticAlgebra ℚ a b` is integral over `ℤ` iff its trace and its norm are
+integers. -/
+theorem isIntegral_iff {z : QuadraticAlgebra ℚ a b} :
+    IsIntegral ℤ z ↔
+      trace z ∈ Set.range (algebraMap ℤ ℚ) ∧ norm z ∈ Set.range (algebraMap ℤ ℚ) := by
+  refine ⟨fun h ↦ ⟨trace_mem_range_of_isIntegral h, norm_mem_range_of_isIntegral h⟩,
+    fun ⟨⟨t, ht⟩, ⟨n, hn⟩⟩ ↦ ⟨X ^ 2 - C t * X + C n, by monicity!, ?_⟩⟩
+  simp only [algebraMap_int_eq, eq_intCast] at ht hn
+  simpa only [eval₂_add, eval₂_sub, eval₂_X_pow, eval₂_mul, eval₂_X, eval₂_C,
+    IsScalarTower.algebraMap_apply ℤ ℚ (QuadraticAlgebra ℚ a b), eq_intCast (algebraMap ℤ ℚ),
+    ht, hn, ← Algebra.smul_def] using sq_sub_trace_smul_add_norm_eq_zero z
+
+/-- The generator `ω` is integral over `ℤ`. -/
+theorem isIntegral_omega :
+    IsIntegral ℤ (ω : QuadraticAlgebra ℚ a b) :=
+  isIntegral_iff.mpr ⟨by simp, -a, by simp [norm_def]⟩
+
+/-- The trace of `t • 1 + ω` is `2 * t + b`. -/
+theorem trace_smul_one_add_omega (t : ℤ) :
+    trace (t • 1 + ω : QuadraticAlgebra ℚ a b) = 2 * t + b := by
+  simp
+
+/-- Four times the norm of `t • 1 + ω` is `(2 * t + b) ^ 2 - discr a b`. -/
+theorem four_mul_norm_smul_one_add_omega (t : ℤ) :
+    4 * norm (t • 1 + ω : QuadraticAlgebra ℚ a b) = (2 * t + b) ^ 2 - discr a b := by
+  rw [four_mul_norm_eq, trace_smul_one_add_omega]
+  simp [discr_intCast]
+
+/-- If `d ∣ s` and `4 * d ^ 2 ∣ s ^ 2 - discr a b`, then `((s - b) / 2 + ω) / d` is integral over
+`ℤ`. Its trace is `s / d` and four times its norm is `(s ^ 2 - discr a b) / d ^ 2`. -/
+theorem isIntegral_inv_smul_of_dvd {d s : ℤ} (hs : d ∣ s)
+    (hs' : 4 * d ^ 2 ∣ s ^ 2 - discr a b) :
+    IsIntegral ℤ ((d : ℚ)⁻¹ • (((s - b) / 2 : ℤ) • 1 + ω : QuadraticAlgebra ℚ a b)) := by
+  by_cases hd : (d : ℚ) = 0
+  · simpa [hd] using isIntegral_zero
+  obtain ⟨t, rfl⟩ : ∃ t : ℤ, 2 * t + b = s := by
+    refine ⟨(s - b) / 2, ?_⟩
+    suffices 2 ∣ (s + b) ∨ 2 ∣ (s - b) by lia
+    rw [← Int.prime_two.dvd_mul, ← sq_sub_sq, ← dvd_sub_left (by lia : 2 ∣ 4 * a), sub_sub]
+    exact dvd_trans (by lia) hs'
+  obtain ⟨u, hu⟩ := hs
+  obtain ⟨v, hv⟩ := hs'
+  refine isIntegral_iff.mpr ⟨⟨u, ?_⟩, ⟨v, ?_⟩⟩ <;> rw [algebraMap_int_eq, eq_intCast]
+  · rw [map_smul, add_sub_cancel_right, Int.mul_ediv_cancel_left _ two_ne_zero,
+      trace_smul_one_add_omega, smul_eq_mul, eq_inv_mul_iff_mul_eq₀ hd, eq_comm]
+    exact_mod_cast hu
+  · rw [norm_smul, add_sub_cancel_right, Int.mul_ediv_cancel_left _ two_ne_zero, inv_pow,
+      eq_inv_mul_iff_mul_eq₀ (by aesop), ← mul_right_inj' four_ne_zero,
+      four_mul_norm_smul_one_add_omega, eq_comm, ← mul_assoc]
+    exact_mod_cast hv
+
+variable (a b) in
+/-- For `1 < |d|`, the `im` part of `(t + ω) / d` is `1 / d`, hence not an integer. -/
+theorem im_inv_smul_notMem_range {d : ℤ} (t : ℤ) (hd : (d : ℚ) ≠ 0) (hd' : 1 < d.natAbs) :
+    ((d : ℚ)⁻¹ • (t • 1 + ω : QuadraticAlgebra ℚ a b)).im ∉ Set.range (algebraMap ℤ ℚ) := by
+  intro ⟨x, hx⟩
+  simp only [algebraMap_int_eq, eq_intCast, zsmul_eq_mul, mul_one, smul_add, im_add, im_smul,
+    im_intCast, smul_eq_mul, mul_zero, im_omega, zero_add, ← mul_eq_one_iff_eq_inv₀ hd] at hx
+  rw [← Int.cast_mul, Int.cast_eq_one, Int.mul_eq_one_iff_eq_one_or_neg_one] at hx
+  grind
+
+/-- If `discr a b = d ^ 2 * e` with `e ≡ 0, 1 mod 4` and `1 < |d|`, the order is not saturated at
+`d`: the element `((d * e - b) / 2 + ω) / d` is integral and lies in the order after scaling by
+`d`, but not before. -/
+theorem exists_unsaturated_of_sq_mul {d e : ℤ} (hd : 1 < d.natAbs) (he : discr a b = d ^ 2 * e)
+    (he' : e % 4 = 0 ∨ e % 4 = 1) :
+    ∃ z : QuadraticAlgebra ℚ a b, IsIntegral ℤ z ∧
+      d • z ∈ Set.range (baseChange ℚ a b) ∧ z ∉ Set.range (baseChange ℚ a b) := by
+  have hd₀ : (d : ℚ) ≠ 0 := by aesop
+  refine ⟨(d : ℚ)⁻¹ • (((d * e - b) / 2 : ℤ) • 1 + ω),
+    isIntegral_inv_smul_of_dvd (dvd_mul_right d e) ?_, ?_, ?_⟩
+  · rw [he, mul_pow, ← mul_sub, mul_comm, pow_two e, ← mul_sub_one]
+    refine mul_dvd_mul_left _ ?_
+    obtain _ | _ := he'
+    · exact Int.dvd_mul_of_dvd_left <| by lia
+    · exact Int.dvd_mul_of_dvd_right <| by lia
+  · rw [← Int.cast_smul_eq_zsmul ℚ d, smul_smul, mul_inv_cancel₀ hd₀, one_smul]
+    exact ⟨((d * e - b) / 2) • 1 + ω, by simp [baseChange_omega ℚ]⟩
+  · exact fun ⟨x, hx⟩ ↦ im_inv_smul_notMem_range a b ((d * e - b) / 2) hd₀ hd
+      ⟨_, by simpa [im_baseChange_apply ℚ] using congr_arg im hx⟩
+
+/-- For an integral element, an integer `im` part forces an integer `re` part. -/
+theorem re_mem_range_of_im_mem_range {z : QuadraticAlgebra ℚ a b} (h : IsIntegral ℤ z)
+    (him : z.im ∈ Set.range (algebraMap ℤ ℚ)) : z.re ∈ Set.range (algebraMap ℤ ℚ) := by
+  obtain ⟨m, hm⟩ := him
+  have : IsIntegral ℤ (z - m • ω) :=  h.sub (isIntegral_omega.smul _)
+  rwa [← re_smul_add_im_smul z, ← IsScalarTower.algebraMap_smul ℚ m, hm, add_sub_cancel_right,
+    ← algebraMap_eq_smul_one, ← IsScalarTower.coe_toAlgHom' ℤ, isIntegral_algHom_iff _
+    (FaithfulSMul.algebraMap_injective _ _), IsIntegrallyClosed.isIntegral_iff] at this
+
+/-- If `x` in the order maps to `d • z` with `z` integral and `d ∣ x.im`, then `z` already lies in
+the order. -/
+theorem mem_range_of_dvd_im {z : QuadraticAlgebra ℚ a b} {x : QuadraticAlgebra ℤ a b} {d : ℤ}
+    (hz : IsIntegral ℤ z) (hd : d ≠ 0) (hx : baseChange ℚ a b x = d • z) (him : d ∣ x.im) :
+    z ∈ Set.range (baseChange ℚ a b) := by
+  obtain ⟨v, hv⟩ := him
+  replace hv : v = z.im := by
+    have : x.im = d * z.im := by simpa [im_baseChange_apply ℚ] using congr_arg im hx
+    rwa [hv, Int.cast_mul, mul_right_inj' (Int.cast_ne_zero.mpr hd)] at this
+  obtain ⟨u, hu⟩ : z.re ∈ Set.range (algebraMap ℤ ℚ) := re_mem_range_of_im_mem_range hz ⟨v, hv⟩
+  refine ⟨u • 1 + v • ω, ?_⟩
+  simpa [QuadraticAlgebra.ext_iff, im_baseChange_apply ℚ, re_baseChange_apply ℚ] using ⟨hu, hv⟩
+
+/-- If `x` in the order maps to `d • z` with `z` integral, then `discr a b * x.im ^ 2` is `d ^ 2`
+times `t ^ 2 - 4 * n`, where `t` and `n` are the trace and the norm of `z`. -/
+theorem exists_discr_mul_im_sq_eq {z : QuadraticAlgebra ℚ a b} {x : QuadraticAlgebra ℤ a b}
+    {d : ℤ} (hz : IsIntegral ℤ z) (hx : baseChange ℚ a b x = d • z) :
+    ∃ t n : ℤ, discr a b * x.im ^ 2 = d ^ 2 * (t ^ 2 - 4 * n) := by
+  obtain ⟨⟨t, ht⟩, ⟨n, hn⟩⟩ := isIntegral_iff.mp hz
+  simp only [algebraMap_int_eq, eq_intCast] at ht hn
+  refine ⟨t, n, ?_⟩
+  apply FaithfulSMul.algebraMap_injective ℤ ℚ
+  have : x.im = d * z.im := by simpa [im_baseChange_apply ℚ] using congr_arg im hx
+  simp [ht, hn, four_mul_norm_eq, this, discr_intCast]
+  ring
+
+/-- For `p` an odd prime, the order is saturated at `p` iff `discr a b` is not `p ^ 2` times an
+integer `≡ 0, 1 mod 4`. For `p` odd that last condition is automatic, so this amounts to
+`p ^ 2 ∤ discr a b`. -/
+theorem saturated_iff_of_odd (p : ℕ) (hp₁ : p.Prime) (hp₂ : Odd p) :
+    (∀ z : QuadraticAlgebra ℚ a b, IsIntegral ℤ z →
+        p • z ∈ Set.range (baseChange ℚ a b) → z ∈ Set.range (baseChange ℚ a b)) ↔
+      ¬ ∃ e : ℤ, discr a b = (p : ℤ) ^ 2 * e ∧ (e % 4 = 0 ∨ e % 4 = 1) := by
+  let q := (p : ℤ)
+  have hq₁ : Prime q := Nat.prime_iff_prime_int.mp hp₁
+  have hq₂ : Odd q := Odd.natCast hp₂
+  refine ⟨fun h ⟨e, he, he'⟩ ↦ ?_,
+  fun h z hz ⟨x, hx⟩ ↦ ?_⟩
+  · obtain ⟨z, hz₁, hz₂, hz₃⟩ := exists_unsaturated_of_sq_mul (by exact hp₁.one_lt) he he'
+    exact hz₃ (h z hz₁ hz₂)
+  · refine mem_range_of_dvd_im hz hq₁.ne_zero hx <| Prime.dvd_of_dvd_pow hq₁ (n := 2) ?_
+    contrapose! h
+    obtain ⟨t, n, htn⟩ := exists_discr_mul_im_sq_eq hz hx
+    obtain ⟨e, he⟩ := ((Prime.coprime_iff_not_dvd hq₁).mpr h).pow_left.dvd_of_dvd_mul_right
+      ⟨t ^ 2 - 4 * n, htn⟩
+    refine ⟨e, he, ?_⟩
+    have := he ▸ discr_emod_four a b
+    rwa [Int.mul_emod, Int.sq_emod_four, Int.odd_iff.mp hq₂, one_mul, Int.emod_emod] at this
+
+/-- The order is saturated at `2` iff `discr a b` is not `4` times an integer `≡ 0, 1 mod 4`,
+that is, iff `discr a b` is not four times another discriminant. -/
+theorem saturated_two_iff :
+    (∀ z : QuadraticAlgebra ℚ a b, IsIntegral ℤ z →
+        2 • z ∈ Set.range (baseChange ℚ a b) → z ∈ Set.range (baseChange ℚ a b)) ↔
+      ¬ ∃ e : ℤ, discr a b = (2 : ℤ) ^ 2 * e ∧ (e % 4 = 0 ∨ e % 4 = 1) := by
+  refine ⟨fun hsat ⟨e, he, he'⟩ ↦ ?_, fun h z hz ⟨x, hx⟩ ↦ ?_⟩
+  · obtain ⟨z, hz₁, hz₂, hz₃⟩ := exists_unsaturated_of_sq_mul (d := 2) (by norm_num) he he'
+    exact hz₃ (hsat z hz₁ hz₂)
+  · refine mem_range_of_dvd_im hz two_ne_zero hx <| Int.prime_two.dvd_of_dvd_pow (n := 2) ?_
+    contrapose! h
+    obtain ⟨t, n, htn⟩ := exists_discr_mul_im_sq_eq hz hx
+    obtain ⟨e, he⟩ := ((Prime.coprime_iff_not_dvd Int.prime_two).mpr h).pow_left
+      |>.dvd_of_dvd_mul_right ⟨t ^ 2 - 4 * n, htn⟩
+    refine ⟨e, he, ?_⟩
+    have h₁ : Odd x.im := by rwa [← Int.odd_pow' two_ne_zero, ← Int.not_two_dvd_iff_odd]
+    have h₂ : x.im ^ 2 * e = t ^ 2 - 4 * n :=
+      mul_left_cancel₀ (by norm_num : (4 : ℤ) ≠ 0) (by grind)
+    have := Int.emod_two_eq t
+    rwa [← Int.sq_emod_four, ← Int.sub_mul_emod_self_left, ← h₂, Int.mul_emod, Int.sq_emod_four,
+      Int.odd_iff.mp h₁, one_mul, Int.emod_emod] at this
+
+/-- The order is the integral closure of `ℤ` in `QuadraticAlgebra ℚ a b` iff it is saturated at
+every prime. -/
+theorem isIntegralClosure_iff_forall_prime :
+    IsIntegralClosure (QuadraticAlgebra ℤ a b) ℤ (QuadraticAlgebra ℚ a b) ↔
+      ∀ p : ℕ, p.Prime → ∀ z : QuadraticAlgebra ℚ a b, IsIntegral ℤ z →
+        p • z ∈ Set.range (baseChange ℚ a b) → z ∈ Set.range (baseChange ℚ a b) := by
+  rw [isIntegralClosure_iff]
+  refine ⟨fun h p _ z hz _ ↦ (h z).mp hz, fun h z ↦ ⟨fun hz ↦ ?_, ?_⟩⟩
+  · obtain ⟨n, hn, hw⟩ := exists_nat_smul_mem z
+    induction n using Nat.strong_induction_on generalizing z with
+    | h n h_ind =>
+        obtain rfl | h' := eq_or_ne n 1
+        · rwa [one_smul] at hw
+        · obtain ⟨p, hp, hpn⟩ := Nat.exists_prime_and_dvd h'
+          refine h p hp z hz <| h_ind (n / p) (Nat.div_lt_self hn hp.one_lt) _ (hz.nsmul p) ?_ ?_
+          · exact (Nat.lt_div_iff_mul_lt' hpn 0).mpr hn
+          · rwa [smul_smul, Nat.div_mul_cancel hpn]
+  · rintro ⟨w, rfl⟩
+    exact (Algebra.IsIntegral.isIntegral w).map (baseChange ℚ a b)
+
+/-- The order `QuadraticAlgebra ℤ a b` is the integral closure of `ℤ` in `QuadraticAlgebra ℚ a b`
+iff `discr a b` is a fundamental discriminant. -/
+theorem isIntegralClosure_iff :
+    IsIntegralClosure (QuadraticAlgebra ℤ a b) ℤ (QuadraticAlgebra ℚ a b) ↔
+      Int.IsFundamentalDiscr (discr a b) := by
+  simp_rw (config := {singlePass := true}) +contextual [isIntegralClosure_iff_forall_prime,
+    Int.isFundamentalDiscr_iff_forall_prime, Nat.forall_prime_iff_two_and_odd, saturated_two_iff,
+    saturated_iff_of_odd, Nat.cast_ofNat]
+  exact (and_iff_right (discr_emod_four a b)).symm
+
+/-- The order `QuadraticAlgebra ℤ a b` is integrally closed iff `discr a b` is a fundamental
+discriminant. -/
+theorem isIntegrallyClosed_iff :
+    IsIntegrallyClosed (QuadraticAlgebra ℤ a b) ↔ Int.IsFundamentalDiscr (discr a b) := by
+  rw [← isIntegralClosure_iff, isIntegrallyClosed_iff_isIntegrallyClosedIn
+    (K := QuadraticAlgebra ℚ a b)]
+  exact ⟨fun _ ↦ IsIntegralClosure.of_isIntegrallyClosedIn,
+    fun _ ↦ IsIntegrallyClosedIn.of_isIntegralClosure ℤ⟩
+
+/-- When `discr a b` is a fundamental discriminant, `QuadraticAlgebra ℤ a b` is isomorphic, as a
+`ℤ`-algebra, to the integral closure of `ℤ` in `QuadraticAlgebra ℚ a b`. -/
+noncomputable def algEquivIntegralClosure (h : Int.IsFundamentalDiscr (discr a b)) :
+    QuadraticAlgebra ℤ a b ≃ₐ[ℤ] integralClosure ℤ (QuadraticAlgebra ℚ a b) :=
+  letI := isIntegralClosure_iff.mpr h
+  IsIntegralClosure.equiv ℤ (QuadraticAlgebra ℤ a b) (QuadraticAlgebra ℚ a b)
+    (integralClosure ℤ (QuadraticAlgebra ℚ a b))
+
+/-- If `D` is a fundamental discriminant, the quadratic algebra with parameters `D / 4` and
+`D % 4` has discriminant `D`. -/
+theorem _root_.Int.IsFundamentalDiscr.discr_ediv_four_emod_four {D : ℤ}
+    (h : Int.IsFundamentalDiscr D) : discr (D / 4) (D % 4) = D := by
+  have : (D % 4) ^ 2 = D % 4 := by grind [h.1]
+  rw [discr_def, this]
+  lia
+
+end Int
+
+end QuadraticAlgebra

--- a/Mathlib/Algebra/QuadraticAlgebra/IsQuadraticExtension.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/IsQuadraticExtension.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 Xavier Roblot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Roblot
+-/
+module
+
+public import Mathlib.Algebra.QuadraticAlgebra.Basic
+public import Mathlib.LinearAlgebra.Unimodular
+public import Mathlib.RingTheory.Trace.Basic
+
+/-!
+# Quadratic algebras and quadratic extensions
+
+This file relates the concrete construction `QuadraticAlgebra R a b` to the predicate
+`Algebra.IsQuadraticExtension`: a `QuadraticAlgebra` is a quadratic extension of `R`, and
+conversely every commutative quadratic extension is isomorphic to a `QuadraticAlgebra`.
+
+## Main results
+
+* `QuadraticAlgebra.instIsQuadraticExtension`: a `QuadraticAlgebra` is a quadratic extension;
+* `Algebra.IsQuadraticExtension.exists_algEquiv_quadraticAlgebra`: every commutative quadratic
+  extension is isomorphic to some `QuadraticAlgebra R a b`.
+-/
+
+public section
+
+namespace QuadraticAlgebra
+
+variable {R : Type*} [CommSemiring R] {a b : R}
+
+/-- A quadratic algebra is a quadratic extension. -/
+instance instIsQuadraticExtension [StrongRankCondition R] :
+    Algebra.IsQuadraticExtension R (QuadraticAlgebra R a b) where
+  finrank_eq_two' := finrank_eq_two a b
+
+end QuadraticAlgebra
+
+namespace Algebra
+
+open QuadraticAlgebra
+
+variable {R A : Type*} [CommRing R] [StrongRankCondition R] [CommRing A] [Algebra R A]
+  [IsQuadraticExtension R A]
+
+/-- Every quadratic extension `A / R` is isomorphic to `QuadraticAlgebra R a b` for some `a, b`. -/
+theorem IsQuadraticExtension.exists_algEquiv_quadraticAlgebra :
+    ∃ (a b : R), Nonempty (A ≃ₐ[R] QuadraticAlgebra R a b) := by
+  have : Nontrivial R := nontrivial_of_invariantBasisNumber R
+  have : Nontrivial A := Module.nontrivial_of_finrank_pos
+    (by rw [IsQuadraticExtension.finrank_eq_two R A]; norm_num)
+  obtain ⟨e, he⟩ := Module.Free.exists_basis_apply_zero_eq
+    (IsQuadraticExtension.finrank_eq_two R A) Module.Free.exists_linearMap_apply_one_eq_one
+  refine ⟨-Algebra.norm R (e 1), Algebra.trace R A (e 1),
+    ⟨(AlgEquiv.ofBijective (QuadraticAlgebra.lift ⟨(e 1), ?_⟩) ?_).symm⟩⟩
+  · simpa [← sq, ← Algebra.algebraMap_eq_smul_one, neg_add_eq_sub]
+      using IsQuadraticExtension.sq_eq_trace_smul_sub_norm R (e 1)
+  · refine ⟨(lift_injective_iff _).mpr ?_, (lift_surjective_iff _).mpr ?_⟩
+    · rw [show ![1, e 1] = e by ext i; fin_cases i <;> simp [he]]
+      exact e.linearIndependent
+    · rw [← Algebra.toSubmodule_eq_top, ← top_le_iff, ← e.span_eq, Submodule.span_le]
+      simp [Set.range_subset_iff, he]
+
+end Algebra

--- a/Mathlib/Algebra/Ring/Int/Parity.lean
+++ b/Mathlib/Algebra/Ring/Int/Parity.lean
@@ -32,6 +32,8 @@ lemma odd_iff : Odd n ↔ n % 2 = 1 where
 
 lemma not_odd_iff : ¬Odd n ↔ n % 2 = 0 := by grind
 
+lemma not_two_dvd_iff_odd : ¬ 2 ∣ n ↔ Odd n := by grind
+
 @[simp] lemma not_odd_zero : ¬Odd (0 : ℤ) := by grind
 
 @[simp, grind =] lemma not_odd_iff_even : ¬Odd n ↔ Even n := by grind

--- a/Mathlib/Algebra/Squarefree/Basic.lean
+++ b/Mathlib/Algebra/Squarefree/Basic.lean
@@ -96,6 +96,11 @@ theorem Squarefree.eq_zero_or_one_of_pow_of_not_isUnit [Monoid R] {x : R} {n : �
   have : x * x ∣ x ^ n := by rw [← sq]; exact pow_dvd_pow x h'
   exact h.squarefree_of_dvd this x (refl _)
 
+theorem Squarefree.isUnit_of_pow [Monoid R] {x : R} {n : ℕ} (hn : 2 ≤ n)
+    (h : Squarefree (x ^ n)) : IsUnit x := by
+  by_contra!
+  grind [h.eq_zero_or_one_of_pow_of_not_isUnit this]
+
 theorem Squarefree.pow_dvd_of_pow_dvd [Monoid R] {x y : R} {n : ℕ}
     (hx : Squarefree y) (h : x ^ n ∣ y) : x ^ n ∣ x := by
   by_cases hu : IsUnit x

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean
@@ -66,6 +66,15 @@ section PowerBasis
 
 open Algebra
 
+/-- Cayley–Hamilton: an algebra element is a root of the characteristic polynomial of its
+matrix of left multiplication in any basis. -/
+theorem Algebra.aeval_leftMulMatrix_charpoly {S : Type*} [Semiring S] [Algebra R S] {ι : Type*}
+    [Fintype ι] [DecidableEq ι] (b : Basis ι R S) (a : S) :
+    aeval a (leftMulMatrix b a).charpoly = 0 := by
+  apply leftMulMatrix_injective b
+  rw [map_zero, ← aeval_algHom_apply]
+  exact aeval_self_charpoly _
+
 /-- The characteristic polynomial of the map `fun x => a * x` is the minimal polynomial of `a`.
 
 In combination with `det_eq_sign_charpoly_coeff` or `trace_eq_neg_charpoly_coeff`
@@ -76,9 +85,7 @@ theorem charpoly_leftMulMatrix {S : Type*} [Ring S] [Algebra R S] (h : PowerBasi
     (leftMulMatrix h.basis h.gen).charpoly = minpoly R h.gen := by
   cases subsingleton_or_nontrivial R; · subsingleton
   apply minpoly.unique' R h.gen (charpoly_monic _)
-  · apply (injective_iff_map_eq_zero (G := S) (leftMulMatrix _)).mp
-      (leftMulMatrix_injective h.basis)
-    rw [← Polynomial.aeval_algHom_apply, aeval_self_charpoly]
+  · exact aeval_leftMulMatrix_charpoly h.basis h.gen
   refine fun q hq => or_iff_not_imp_left.2 fun h0 => ?_
   rw [Matrix.charpoly_degree_eq_dim, Fintype.card_fin] at hq
   contrapose! hq; exact h.dim_le_degree_of_root h0 hq

--- a/Mathlib/LinearAlgebra/Unimodular.lean
+++ b/Mathlib/LinearAlgebra/Unimodular.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 Xavier Roblot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Roblot
+-/
+module
+
+public import Mathlib.LinearAlgebra.Finsupp.LSum
+public import Mathlib.LinearAlgebra.Matrix.ToLinearEquiv
+public import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
+
+/-!
+# Unimodular elements and completion to a basis
+
+An element `v` of an `R`-module is *unimodular* if some linear functional takes the value
+`1` at `v`; for a free module this is equivalent to the coordinates of `v` in any basis
+generating the unit ideal (for `M = ℤⁿ`: the gcd of the coordinates is `1`, i.e. `v` is a
+*primitive* vector).
+
+The main results are:
+* `Module.Basis.span_repr_eq_top_iff`: the coordinate characterisation of unimodularity in
+  the free case;
+* `Module.Free.exists_basis_apply_zero_eq`: a unimodular vector of a rank-two module can be
+  completed to a basis. This fails in higher rank, see [lam2006];
+* `Module.Basis.span_repr_one_eq_top` and `Module.Free.exists_linearMap_apply_one_eq_one`:
+  in a nonzero algebra that is free as a module, `1` is unimodular.
+
+## References
+
+* [T. Y. Lam, *Serre's Problem on Projective Modules*][lam2006], Chapter I.
+-/
+
+public section
+
+namespace Module.Basis
+
+open Ideal
+
+section
+
+variable {R : Type*} [CommSemiring R] {M : Type*} [AddCommMonoid M] [Module R M]
+
+/-- Coordinate characterisation of unimodularity in the free case: given a basis `b`, the
+coordinates of `v` generate the unit ideal iff some linear functional takes the value `1`
+at `v` (that is, iff `v` is *unimodular*). -/
+theorem span_repr_eq_top_iff {ι : Type*} (b : Module.Basis ι R M) {v : M} :
+    span (Set.range (b.repr v)) = ⊤ ↔ ∃ f : M →ₗ[R] R, f v = 1 := by
+  rw [eq_top_iff_one]
+  refine ⟨fun h ↦ ?_, fun ⟨f, hf⟩ ↦ ?_⟩
+  · obtain ⟨c, hc⟩ := Finsupp.mem_span_range_iff_exists_finsupp.mp h
+    exact ⟨c.sum fun i a ↦ a • b.coord i, by simpa using hc⟩
+  · rw [← b.linearCombination_repr v, Finsupp.linearCombination_apply, map_finsuppSum] at hf
+    simp only [← hf, map_smul, smul_eq_mul]
+    exact Submodule.finsuppSum_mem R _ _ _ fun i _ ↦ mul_mem_right _ _ mem_span_range_self
+
+end
+
+section Algebra
+
+variable {R : Type*} [CommRing R] {A ι : Type*} [Ring A] [Algebra R A] [Nonempty ι]
+
+/-- In a nonzero algebra that is free as a module, the coordinates of `1` in any basis generate
+the unit ideal; that is, `1` is a *unimodular* element of the module. Note that this is
+specific to `1`: the coordinates of a general element need not generate the unit ideal. -/
+theorem span_repr_one_eq_top (e : Module.Basis ι R A) :
+    span (Set.range (e.repr 1)) = ⊤ := by
+  nontriviality R
+  have : Module.Free R A := .of_basis e
+  have : Nontrivial A := e.repr.toEquiv.nontrivial
+  by_contra h
+  obtain ⟨𝔪, h𝔪, hle⟩ := Ideal.exists_le_maximal _ h
+  refine Module.FaithfullyFlat.submodule_ne_top (M := A) h𝔪
+    (Submodule.eq_top_iff'.mpr fun a ↦ ?_)
+  have ha : a = (e.repr 1).sum fun i c ↦ c • (a * e i) := by
+    conv_lhs => rw [← mul_one a, ← e.linearCombination_repr 1,
+      Finsupp.linearCombination_apply, Finsupp.mul_sum]
+    simp_rw [mul_smul_comm]
+  rw [ha]
+  exact Submodule.sum_mem _ fun i _ ↦
+    Submodule.smul_mem_smul (hle (Ideal.subset_span ⟨i, rfl⟩)) Submodule.mem_top
+
+end Algebra
+
+end Module.Basis
+
+namespace Module.Free
+
+variable {R : Type*} [CommRing R]
+
+section
+
+variable {M : Type*} [AddCommGroup M] [Module R M] [Module.Free R M] [Nontrivial R]
+
+/-- A *unimodular* vector of a rank-two module can be completed to a basis: if some linear
+functional takes the value `1` at `v`, then `v` is the first vector of a basis.
+This fails for unimodular vectors in higher rank. -/
+theorem exists_basis_apply_zero_eq (h : Module.finrank R M = 2) {v : M}
+    (hv : ∃ f : M →ₗ[R] R, f v = 1) :
+    ∃ e : Module.Basis (Fin 2) R M, e 0 = v := by
+  obtain ⟨f, hf⟩ := hv
+  have : Module.Finite R M := Module.finite_of_finrank_eq_succ h
+  let b := (Module.Free.chooseBasis R M).reindex
+    (Fintype.equivFinOfCardEq ((Module.finrank_eq_card_chooseBasisIndex R M).symm.trans h))
+  have hfv : b.repr v 0 * f (b 0) + b.repr v 1 * f (b 1) = 1 := by
+    have hv2 : f v = b.repr v 0 * f (b 0) + b.repr v 1 * f (b 1) := by
+      conv_lhs => rw [← b.sum_repr v]
+      rw [map_sum, Fin.sum_univ_two, map_smul, map_smul, smul_eq_mul, smul_eq_mul]
+    rw [← hv2]; exact hf
+  let N : Matrix (Fin 2) (Fin 2) R := !![b.repr v 0, -(f (b 1)); b.repr v 1, f (b 0)]
+  have hdet : N.det = 1 := by
+    rw [Matrix.det_fin_two_of, neg_mul, sub_neg_eq_add, mul_comm (f (b 1)) (b.repr v 1)]
+    exact hfv
+  refine ⟨b.map (Matrix.toLinearEquiv b N (hdet ▸ isUnit_one)), ?_⟩
+  simpa [N] using (Fin.sum_univ_two fun i ↦ b.repr v i • b i).symm.trans (b.sum_repr v)
+
+end
+
+/-- In a nonzero algebra that is free as a module, there is a linear functional taking the
+value `1` at `1`; that is, `1` is a *unimodular* element of the module. -/
+theorem exists_linearMap_apply_one_eq_one {A : Type*} [Nontrivial A] [Ring A] [Algebra R A]
+    [Module.Free R A] : ∃ f : A →ₗ[R] R, f 1 = 1 :=
+  (Module.Free.chooseBasis R A).span_repr_eq_top_iff.mp
+    (Module.Free.chooseBasis R A).span_repr_one_eq_top
+
+end Module.Free

--- a/Mathlib/NumberTheory/FundamentalDiscriminant.lean
+++ b/Mathlib/NumberTheory/FundamentalDiscriminant.lean
@@ -5,6 +5,7 @@ Authors: Xavier Roblot
 -/
 module
 
+public import Mathlib.Data.Nat.Prime.Int
 public import Mathlib.Data.Nat.Squarefree
 
 /-!
@@ -95,5 +96,18 @@ theorem isFundamentalDiscr_four_mul_add_one {m : ℤ} :
 theorem isFundamentalDiscr_four_mul {m : ℤ} :
     IsFundamentalDiscr (4 * m) ↔ Squarefree m ∧ (m % 4 = 2 ∨ m % 4 = 3) := by
   simp [isFundamentalDiscr_iff_squarefree]
+
+/-- The only fundamental discriminant that is a square is `1`. -/
+theorem IsFundamentalDiscr.eq_one_of_isSquare (h : IsFundamentalDiscr D) (h' : IsSquare D) :
+    D = 1 := by
+  have h_main {r : ℤ} (hr : Squarefree (r * r)) : r * r = 1 := by
+    grind [isUnit_iff.mp <| Squarefree.isUnit_of_pow le_rfl (pow_two r ▸ hr)]
+  obtain ⟨r, rfl⟩ := h'
+  obtain h | h := isFundamentalDiscr_iff_squarefree.mp h
+  · exact h_main h.2
+  · obtain ⟨s, rfl⟩ : Even r := by
+      grind [prime_two.dvd_mul.mp <| dvd_trans (by norm_num : _) <| dvd_iff_emod_eq_zero.mpr h.1]
+    rw [show (s + s) * (s + s) / 4 = s * s by grind] at h
+    grind
 
 end Int

--- a/Mathlib/NumberTheory/NumberField/QuadraticField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/QuadraticField/Basic.lean
@@ -24,7 +24,16 @@ zero which is a quadratic extension of `ℚ` in the sense of `Algebra.IsQuadrati
 * `NumberField.QuadraticField.nonempty_algEquiv_quadraticAlgebra_discr`: every quadratic field
   is `ℚ(√(discr K))`;
 * `NumberField.QuadraticField.nonempty_algEquiv_iff_discr_eq`: the discriminant is a complete
-  invariant of quadratic fields.
+  invariant of quadratic fields;
+* `NumberField.QuadraticField.discr_quadraticAlgebra`: every fundamental discriminant other
+  than `1` is the discriminant of a quadratic field.
+
+## Implementation notes
+
+`QuadraticAlgebra ℚ (d : ℚ) 0` is a field, hence a number field, exactly when `d` is not a
+rational square. The results on `ℚ(√d)` therefore take a `[Fact (¬ IsSquare (d : ℚ))]` assumption,
+which is what tells Mathlib that their discriminant is defined. For `d` squarefree and
+different from `1`, `not_isSquare_intCast` below proves `¬ IsSquare (d : ℚ)`.
 -/
 
 public section
@@ -127,6 +136,62 @@ theorem nonempty_algEquiv_iff_discr_eq :
   obtain ⟨e₂⟩ := nonempty_algEquiv_ringOfIntegers F
   exact ⟨(IsFractionRing.ringEquivOfRingEquiv
     ((h ▸ e₁).trans e₂.symm).toRingEquiv).equivRatAlgEquiv _ _⟩
+
+/-- A squarefree integer `d` other than `1` is not a square in `ℚ`, the hypothesis that makes
+`ℚ(√d)` automatically a number field; see the implementation notes for details. -/
+theorem not_isSquare_intCast {d : ℤ} (hd : Squarefree d) (hd₁ : d ≠ 1) :
+    ¬ IsSquare (d : ℚ) := by
+  rw [Rat.isSquare_intCast_iff]
+  rintro ⟨r, rfl⟩
+  obtain h | h := Int.isUnit_iff.mp (Squarefree.isUnit_of_pow le_rfl ((pow_two r) ▸ hd)) <;>
+  simp [h] at hd₁ ⊢
+
+/-- When the parameters are already those of the maximal order, the discriminant of
+`QuadraticAlgebra ℚ a b` is the discriminant of the quadratic algebra. -/
+theorem discr_quadraticAlgebra_eq {a b : ℤ}
+    (h : Int.IsFundamentalDiscr (QuadraticAlgebra.discr a b))
+    (h1 : QuadraticAlgebra.discr a b ≠ 1) :
+    -- This is needed to get a number field
+    haveI : Fact (¬ IsSquare (QuadraticAlgebra.discr (a : ℚ) (b : ℚ))) :=
+      ⟨by rw [QuadraticAlgebra.Int.discr_intCast, Rat.isSquare_intCast_iff]
+          exact h.eq_one_of_isSquare.mt h1⟩
+    discr (QuadraticAlgebra ℚ a b) = QuadraticAlgebra.discr a b := by
+  have : Fact (¬ IsSquare (QuadraticAlgebra.discr (a : ℚ) (b : ℚ))) :=
+    ⟨by rw [QuadraticAlgebra.Int.discr_intCast, Rat.isSquare_intCast_iff]
+        exact h.eq_one_of_isSquare.mt h1⟩
+  exact discr_eq_quadraticAlgebra_discr
+    (QuadraticAlgebra.Int.algEquivIntegralClosure h).toRingEquiv.symm
+
+/-- Every fundamental discriminant other than `1` is the discriminant of a quadratic field.
+See the implementation notes in the module docstring for the `Fact` assumption. -/
+theorem discr_quadraticAlgebra {D : ℤ} [Fact (¬ IsSquare (D : ℚ))]
+    (hD : Int.IsFundamentalDiscr D) (hD1 : D ≠ 1) :
+    discr (QuadraticAlgebra ℚ (D : ℚ) 0) = D := by
+  have hd : QuadraticAlgebra.discr (D / 4) (D % 4) = D := hD.discr_ediv_four_emod_four
+  have : Fact (¬ IsSquare (QuadraticAlgebra.discr ((D / 4 : ℤ) : ℚ) ((D % 4 : ℤ) : ℚ))) :=
+    ⟨by rw [QuadraticAlgebra.Int.discr_intCast, hd]; exact Fact.out⟩
+  let e : QuadraticAlgebra ℚ (D : ℚ) 0 ≃ₐ[ℚ] QuadraticAlgebra ℚ (D / 4 : ℤ) (D % 4 : ℤ) := by
+    refine (QuadraticAlgebra.nonempty_algEquiv_iff_of_invertible_two.mpr
+      ⟨(isUnit_of_invertible 2).unit, ?_⟩).some
+    grind [IsUnit.unit_spec, QuadraticAlgebra.Int.discr_intCast, QuadraticAlgebra.discr_def]
+  rw [discr_eq_discr_of_algEquiv _ e, discr_quadraticAlgebra_eq (by rwa [hd]) (by rwa [hd]), hd]
+
+/-- The discriminant of `ℚ(√d)` is `4 * d` when `d` is squarefree and `d ≡ 2, 3 [ZMOD 4]`.
+See the implementation notes in the module docstring for the `Fact` assumption. -/
+theorem discr_sqrtd {d : ℤ} [Fact (¬ IsSquare (d : ℚ))]
+    (hd₁ : Squarefree d) (hd₂ : d % 4 = 2 ∨ d % 4 = 3) :
+    discr (QuadraticAlgebra ℚ (d : ℚ) 0) = 4 * d := by
+  have h₁ : QuadraticAlgebra.discr d 0 = 4 * d := by simp [QuadraticAlgebra.discr_def]
+  have h₂ : (QuadraticAlgebra.discr d 0).IsFundamentalDiscr :=
+    h₁ ▸ Int.isFundamentalDiscr_four_mul.mpr ⟨hd₁, hd₂⟩
+  simpa [QuadraticAlgebra.discr_def] using discr_quadraticAlgebra_eq h₂ (by grind)
+
+/-- The discriminant of `ℚ(√d)` is `d` itself when `d` is squarefree and `d ≡ 1 [ZMOD 4]`.
+See the implementation notes in the module docstring for the `Fact` assumption. -/
+theorem discr_half {d : ℤ} [Fact (¬ IsSquare (d : ℚ))]
+    (hd : Squarefree d) (hd1 : d ≠ 1) (h : d % 4 = 1) :
+    discr (QuadraticAlgebra ℚ (d : ℚ) 0) = d :=
+  discr_quadraticAlgebra (Int.isFundamentalDiscr_iff_squarefree.mpr (Or.inl ⟨h, hd⟩)) hd1
 
 end discr
 

--- a/Mathlib/NumberTheory/NumberField/QuadraticField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/QuadraticField/Basic.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 Xavier Roblot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Roblot
+-/
+module
+
+public import Mathlib.Algebra.QuadraticAlgebra.Int
+public import Mathlib.Algebra.QuadraticAlgebra.IsQuadraticExtension
+public import Mathlib.NumberTheory.NumberField.Discriminant.Defs
+public import Mathlib.NumberTheory.NumberField.InfinitePlace.TotallyRealComplex
+public import Mathlib.RingTheory.QuadraticAlgebra
+
+/-!
+# Quadratic fields
+
+A quadratic field is a number field of degree `2` over `ℚ`, that is, a field of characteristic
+zero which is a quadratic extension of `ℚ` in the sense of `Algebra.IsQuadraticExtension`.
+
+## Main results
+
+* `NumberField.QuadraticField.isFundamentalDiscr_discr`: the discriminant of a quadratic field
+  is a fundamental discriminant;
+* `NumberField.QuadraticField.nonempty_algEquiv_quadraticAlgebra_discr`: every quadratic field
+  is `ℚ(√(discr K))`;
+* `NumberField.QuadraticField.nonempty_algEquiv_iff_discr_eq`: the discriminant is a complete
+  invariant of quadratic fields.
+-/
+
+public section
+
+open NumberField Int
+
+open scoped QuadraticAlgebra
+
+instance NumberField.of_isQuadraticExtension (K : Type*) [Field K] [CharZero K]
+    [Algebra.IsQuadraticExtension ℚ K] : NumberField K where
+
+namespace NumberField.QuadraticField
+
+variable (K : Type*) [Field K] [CharZero K] [h : Algebra.IsQuadraticExtension ℚ K]
+
+instance : Algebra.IsQuadraticExtension ℤ (𝓞 K) where
+  finrank_eq_two' := by rw [RingOfIntegers.rank, h.finrank_eq_two]
+
+variable {K}
+
+/-- A ring isomorphism between the ring of integers of `K` and `QuadraticAlgebra ℤ a b` extends
+to their fraction fields. -/
+noncomputable def algEquivOfRingEquiv {a b : ℤ}
+    (f : 𝓞 K ≃+* QuadraticAlgebra ℤ a b) :
+    K ≃ₐ[ℚ] QuadraticAlgebra ℚ a b :=
+  (IsFractionRing.ringEquivOfRingEquiv f).equivRatAlgEquiv _ _
+
+section discr
+
+/-- If the ring of integers of `K` is `QuadraticAlgebra ℤ a b`, the discriminant of `K` is the
+discriminant of that quadratic algebra. -/
+theorem discr_eq_quadraticAlgebra_discr {a b : ℤ}
+    (f : 𝓞 K ≃+* QuadraticAlgebra ℤ a b) :
+    discr K = QuadraticAlgebra.discr a b := by
+  rw [← discr_eq_discr K ((QuadraticAlgebra.basis a b).map f.toIntAlgEquiv.symm),
+    Module.Basis.coe_map, RingEquiv.symm_toIntAlgEquiv, AlgEquiv.coe_toLinearEquiv,
+    ← Algebra.discr_eq_discr_of_algEquiv, ← Algebra.discr_quadraticAlgebra]
+  rfl
+
+variable (K)
+
+/-- The discriminant of a quadratic field is a fundamental discriminant. -/
+theorem isFundamentalDiscr_discr : Int.IsFundamentalDiscr (discr K) := by
+  obtain ⟨a, b, ⟨f⟩⟩ :=
+    Algebra.IsQuadraticExtension.exists_algEquiv_quadraticAlgebra (R := ℤ) (A := 𝓞 K)
+  rw [discr_eq_quadraticAlgebra_discr f.toRingEquiv]
+  exact QuadraticAlgebra.Int.isIntegrallyClosed_iff.mp <| IsIntegrallyClosed.of_equiv f.toRingEquiv
+
+/-- The ring of integers of a quadratic field `K` is the quadratic algebra of discriminant
+`discr K`, see `Int.IsFundamentalDiscr.discr_ediv_four_emod_four`. -/
+theorem nonempty_algEquiv_ringOfIntegers :
+    Nonempty (𝓞 K ≃ₐ[ℤ] QuadraticAlgebra ℤ (discr K / 4) (discr K % 4)) := by
+  obtain ⟨a, b, ⟨f⟩⟩ :=
+    Algebra.IsQuadraticExtension.exists_algEquiv_quadraticAlgebra (R := ℤ) (A := 𝓞 K)
+  refine ⟨f.trans (Nonempty.some ?_)⟩
+  rw [QuadraticAlgebra.nonempty_algEquiv_int_iff,
+    (isFundamentalDiscr_discr K).discr_ediv_four_emod_four,
+    discr_eq_quadraticAlgebra_discr f.toRingEquiv]
+
+/-- Every quadratic field is `ℚ(√(discr K))`. -/
+theorem nonempty_algEquiv_quadraticAlgebra_discr :
+    Nonempty (K ≃ₐ[ℚ] QuadraticAlgebra ℚ (discr K : ℚ) 0) := by
+  obtain ⟨a, b, ⟨f⟩⟩ :=
+    Algebra.IsQuadraticExtension.exists_algEquiv_quadraticAlgebra (R := ℤ) (A := 𝓞 K)
+  exact ⟨(algEquivOfRingEquiv f.toRingEquiv).trans <|
+    (QuadraticAlgebra.algEquivDiscrZero (a : ℚ) (b : ℚ)).trans <|
+      QuadraticAlgebra.equivOfEq (by rw [QuadraticAlgebra.Int.discr_intCast,
+        discr_eq_quadraticAlgebra_discr f.toRingEquiv]) rfl⟩
+
+/-- The discriminant of a quadratic field is not `1`. A more general version is the
+Hermite-Minkowski theorem, see `NumberField.abs_discr_gt_two`. -/
+theorem discr_ne_one : discr K ≠ 1 := by
+  by_contra! h
+  obtain ⟨a, b, ⟨f⟩⟩ :=
+    Algebra.IsQuadraticExtension.exists_algEquiv_quadraticAlgebra (R := ℤ) (A := 𝓞 K)
+  exact QuadraticAlgebra.Int.isDomain_iff.mp (f.symm.toMulEquiv.isDomain _)
+    (discr_eq_quadraticAlgebra_discr f.toRingEquiv ▸ h ▸ IsSquare.one)
+
+/-- `√(discr K)` lies in `K`. -/
+theorem exists_sq_eq_discr : ∃ x : K, x ^ 2 = discr K := by
+  let e := (nonempty_algEquiv_quadraticAlgebra_discr K).some
+  exact ⟨e.symm ω, by simp [← map_pow, QuadraticAlgebra.omega_pow_two_eq_add]⟩
+
+/-- The discriminant of a quadratic field is not a square. -/
+theorem not_isSquare_discr : ¬ IsSquare (discr K) :=
+  (Int.IsFundamentalDiscr.eq_one_of_isSquare (isFundamentalDiscr_discr K)).mt <| discr_ne_one K
+
+/-- **Stickelberger's theorem**, for quadratic fields: the discriminant is congruent to
+`0` or `1` modulo `4`. -/
+theorem discr_emod_four : discr K % 4 = 0 ∨ discr K % 4 = 1 :=
+  (isFundamentalDiscr_discr K).1
+
+variable (F : Type*) [Field F] [CharZero F] [Algebra.IsQuadraticExtension ℚ F]
+
+/-- The discriminant is a complete invariant of quadratic fields. -/
+theorem nonempty_algEquiv_iff_discr_eq :
+    Nonempty (K ≃ₐ[ℚ] F) ↔ discr K = discr F := by
+  refine ⟨fun ⟨e⟩ ↦ discr_eq_discr_of_algEquiv K e, fun h ↦ ?_⟩
+  obtain ⟨e₁⟩ := nonempty_algEquiv_ringOfIntegers K
+  obtain ⟨e₂⟩ := nonempty_algEquiv_ringOfIntegers F
+  exact ⟨(IsFractionRing.ringEquivOfRingEquiv
+    ((h ▸ e₁).trans e₂.symm).toRingEquiv).equivRatAlgEquiv _ _⟩
+
+end discr
+
+end NumberField.QuadraticField

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
@@ -344,6 +344,14 @@ instance integralClosure.isIntegralClosure (R A : Type*) [CommRing R] [CommRing 
   algebraMap_injective := Subtype.coe_injective
   isIntegral_iff {x} := ⟨fun h => ⟨⟨x, h⟩, rfl⟩, by rintro ⟨⟨_, h⟩, rfl⟩; exact h⟩
 
+/-- If `algebraMap A B` is injective, `A` is the integral closure of `R` in `B` iff an element
+of `B` is integral over `R` exactly when it lies in the image of `A`. -/
+theorem isIntegralClosure_iff {R A B : Type*} [CommRing R] [CommRing A] [CommRing B]
+    [Algebra R B] [Algebra A B] [FaithfulSMul A B] :
+    IsIntegralClosure A R B ↔ ∀ x : B, IsIntegral R x ↔ ∃ a : A, algebraMap A B a = x :=
+  ⟨fun _ _ ↦ IsIntegralClosure.isIntegral_iff,
+   fun h ↦ ⟨FaithfulSMul.algebraMap_injective A B, fun {x} ↦ h x⟩⟩
+
 namespace IsIntegralClosure
 
 variable {R A B : Type*} [CommRing R] [CommRing A] [CommRing B]

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -243,6 +243,12 @@ lemma surjective_iff_isField [IsDomain R] : Function.Surjective (algebraMap R K)
     (IsLocalization.atUnits R _ (S := K)
       (fun _ hx ↦ Ne.isUnit (mem_nonZeroDivisors_iff_ne_zero.mp hx))).surjective
 
+/-- The fraction ring `K` of `R` is a field iff `R` is an integral domain. -/
+theorem isDomain_iff_isField : IsDomain R ↔ IsField K := by
+  refine ⟨fun h ↦ (IsFractionRing.toField R).toIsField K, fun h ↦ ?_⟩
+  let := h.toField
+  exact IsDomain.of_faithfulSMul _ K
+
 end CommRing
 
 variable {B : Type*} [CommRing B] [IsDomain B] [Field K] {L : Type*} [Field L] [Algebra A K]

--- a/Mathlib/RingTheory/QuadraticAlgebra.lean
+++ b/Mathlib/RingTheory/QuadraticAlgebra.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 Xavier Roblot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Roblot
+-/
+module
+
+public import Mathlib.Algebra.QuadraticAlgebra.Discriminant
+public import Mathlib.RingTheory.Discriminant
+public import Mathlib.RingTheory.Polynomial.Resultant.Basic
+
+/-!
+# Ring-theoretic properties of quadratic algebras
+
+This file collects ring-theoretic properties of `QuadraticAlgebra R a b` as an `R`-algebra.
+
+## Main results
+
+* `QuadraticAlgebra.polynomial_discr_eq_discr`: the discriminant of the polynomial
+  `X ^ 2 - b • X - C a` equals `discr a b`.
+* `Algebra.trace_quadraticAlgebra_apply` and `Algebra.norm_quadraticAlgebra_apply`:
+  `Algebra.trace` and `Algebra.norm` on `QuadraticAlgebra R a b` agree with
+  `QuadraticAlgebra.trace` and `QuadraticAlgebra.norm`.
+* `Algebra.discr_quadraticAlgebra`: `Algebra.discr R (basis a b)` equals `discr a b`.
+-/
+
+@[expose] public section
+
+open QuadraticAlgebra
+
+variable {R : Type*} [CommRing R] (a b : R)
+
+open Polynomial in
+/-- The discriminant of the polynomial `X ^ 2 - b • X - C a` is the discriminant `discr a b` of
+the quadratic algebra `QuadraticAlgebra R a b`. -/
+theorem QuadraticAlgebra.polynomial_discr_eq_discr :
+    (X ^ 2 - b • X - C a).discr = discr a b := by
+  nontriviality R
+  have : (X ^ 2 - b • X - C a).degree = 2 := by
+    compute_degree!
+    simp [coeff_X]
+  rw [discr_of_degree_eq_two this]
+  simp [coeff_X, discr_def]
+
+variable {a b}
+
+/-- The algebra trace of `QuadraticAlgebra R a b` is the elementary trace. -/
+@[simp]
+theorem Algebra.trace_quadraticAlgebra_apply (z : QuadraticAlgebra R a b) :
+    Algebra.trace R (QuadraticAlgebra R a b) z = QuadraticAlgebra.trace z := by
+  simp [Algebra.trace_eq_matrix_trace (basis a b), Matrix.trace_fin_two,
+    QuadraticAlgebra.trace_def, Algebra.leftMulMatrix_eq_repr_mul, basis_repr_apply,
+    basis_apply_zero, basis_apply_one]
+  ring
+
+/-- The algebra norm of `QuadraticAlgebra R a b` is the elementary norm. -/
+@[simp]
+theorem Algebra.norm_quadraticAlgebra_apply (z : QuadraticAlgebra R a b) :
+    Algebra.norm R z = QuadraticAlgebra.norm z := by
+  simp [Algebra.norm_eq_matrix_det (basis a b), Matrix.det_fin_two, QuadraticAlgebra.norm_def,
+    Algebra.leftMulMatrix_eq_repr_mul, basis_repr_apply, basis_apply_zero, basis_apply_one]
+  ring
+
+/-- The `Algebra.discr` of the standard basis `{1, ω}` is the elementary discriminant. -/
+@[simp]
+theorem Algebra.discr_quadraticAlgebra :
+    Algebra.discr R (basis a b) = QuadraticAlgebra.discr a b := by
+  rw [Algebra.discr_def, Matrix.det_fin_two, QuadraticAlgebra.discr_def]
+  simp only [Algebra.traceMatrix_apply, Algebra.traceForm_apply,
+    Algebra.trace_quadraticAlgebra_apply, basis_apply_zero, basis_apply_one, one_mul, mul_one,
+    omega_mul_omega_eq_mk, QuadraticAlgebra.trace_def, re_one, im_one, re_omega, im_omega]
+  ring

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -627,3 +627,28 @@ lemma Module.Basis.traceDual_powerBasis_eq (pb : PowerBasis K L) (i) :
   ring
 
 end Basis
+
+namespace Algebra
+
+section IsQuadraticExtension
+
+variable {R A : Type*} [CommRing R] [Nontrivial R] [CommRing A] [Algebra R A]
+  [IsQuadraticExtension R A]
+
+variable (R) in
+/-- Every element of a quadratic extension satisfies its characteristic equation. -/
+theorem IsQuadraticExtension.sq_sub_trace_smul_add_norm_eq_zero (a : A) :
+    a ^ 2 - Algebra.trace R A a • a + algebraMap R A (Algebra.norm R a) = 0 := by
+  let b := Module.finBasisOfFinrankEq R A (IsQuadraticExtension.finrank_eq_two R A)
+  simpa [Matrix.charpoly_fin_two, ← Algebra.trace_eq_matrix_trace b,
+    ← Algebra.norm_eq_matrix_det b, smul_def] using Algebra.aeval_leftMulMatrix_charpoly b a
+
+variable (R) in
+/-- The square of an element of a quadratic extension in terms of its trace and norm. -/
+theorem IsQuadraticExtension.sq_eq_trace_smul_sub_norm (a : A) :
+    a ^ 2 = Algebra.trace R A a • a - algebraMap R A (Algebra.norm R a) := by
+  rw [← sub_eq_zero, ← sub_add, IsQuadraticExtension.sq_sub_trace_smul_add_norm_eq_zero]
+
+end IsQuadraticExtension
+
+end Algebra


### PR DESCRIPTION
This PR computes the discriminant of the concrete quadratic fields `ℚ(√d)`.

For `d` a squarefree integer other than `1`, the field `ℚ(√d)` is realized as `QuadraticAlgebra ℚ (d : ℚ) 0` and its discriminant is `4 * d` when `d ≡ 2, 3 mod 4`, and `d` itself when `d ≡ 1 mod 4`.

This completes the classification of quadratic fields by their discriminant: every fundamental discriminant other than `1` is the discriminant of a quadratic field.

Prepared with Claude Code 🤖

---

- [ ] depends on: #43490
- [ ] depends on: #43088
- [x] depends on: #42554
- [ ] depends on: #42297
