### PR TITLE
refactor: rename the `diag` name token to `diagonal`

### DIFF
--- a/Archive/Imo/Imo1998Q2.lean
+++ b/Archive/Imo/Imo1998Q2.lean
@@ -102,8 +102,12 @@ def A : Finset (AgreedTriple C J) :=
   Finset.univ.filter @fun (a : AgreedTriple C J) =>
     (a.judgePair.Agree r a.contestant ∧ a.judgePair.Distinct)
 
-theorem A_maps_to_offDiag_judgePair (a : AgreedTriple C J) :
-    a ∈ A r → a.judgePair ∈ Finset.offDiag (@Finset.univ J _) := by simp [A, Finset.mem_offDiag]
+theorem A_maps_to_offDiagonal_judgePair (a : AgreedTriple C J) :
+    a ∈ A r → a.judgePair ∈ Finset.offDiagonal (@Finset.univ J _) := by
+  simp [A, Finset.mem_offDiagonal]
+
+@[deprecated (since := "2026-09-06")]
+alias A_maps_to_offDiag_judgePair := A_maps_to_offDiagonal_judgePair
 
 open scoped Classical in
 theorem A_fibre_over_contestant (c : C) :
@@ -146,8 +150,8 @@ theorem A_card_upper_bound {k : ℕ}
     (A r).card ≤ k * (Fintype.card J * Fintype.card J - Fintype.card J) := by
   change _ ≤ k * (Finset.card _ * Finset.card _ - Finset.card _)
   classical
-  rw [← Finset.offDiag_card]
-  apply Finset.card_le_mul_card_image_of_maps_to (A_maps_to_offDiag_judgePair r)
+  rw [← Finset.offDiagonal_card]
+  apply Finset.card_le_mul_card_image_of_maps_to (A_maps_to_offDiagonal_judgePair r)
   intro p hp
   have hp' : p.Distinct := by grind
   rw [← A_fibre_over_judgePair_card r hp']; apply hk; exact hp'
@@ -188,14 +192,14 @@ theorem distinct_judge_pairs_card_lower_bound {z : ℕ} (hJ : Fintype.card J = 2
   let s := Finset.univ.filter fun p : JudgePair J => p.Agree r c
   let t := Finset.univ.filter fun p : JudgePair J => p.Distinct
   have hs : 2 * z * z + 2 * z + 1 ≤ s.card := judge_pairs_card_lower_bound r hJ c
-  have hst : s \ t = Finset.univ.diag := by
+  have hst : s \ t = Finset.univ.diagonal := by
     ext p; constructor <;> intro hp
     · unfold s t at hp
       aesop
     · unfold s t
       suffices p.judge₁ = p.judge₂ by simp [this]
       aesop
-  have hst' : (s \ t).card = 2 * z + 1 := by rw [hst, Finset.diag_card, ← hJ, Finset.card_univ]
+  have hst' : (s \ t).card = 2 * z + 1 := by rw [hst, Finset.diagonal_card, ← hJ, Finset.card_univ]
   rw [Finset.filter_and, ← Finset.sdiff_sdiff_self_left s t, Finset.card_sdiff_of_subset]
   · rw [hst']; rw [add_assoc] at hs; apply le_tsub_of_add_le_right hs
   · apply Finset.sdiff_subset

--- a/Archive/Wiedijk100Theorems/BallotProblem.lean
+++ b/Archive/Wiedijk100Theorems/BallotProblem.lean
@@ -309,7 +309,7 @@ theorem ballot_neg (p q : ℕ) (qp : q < p) :
 
 theorem ballot_problem' :
     ∀ q p, q < p → (uniformOn (countedSequence p q) staysPositive).toReal = (p - q) / (p + q) := by
-  apply Nat.diag_induction
+  apply Nat.diagonal_induction
   · intro p
     rw [ballot_same]
     simp

--- a/Counterexamples/SorgenfreyLine.lean
+++ b/Counterexamples/SorgenfreyLine.lean
@@ -256,7 +256,7 @@ theorem nhds_prod_antitone_basis_inv_pnat (x y : ℝₗ) :
 set_option backward.isDefEq.respectTransparency false in
 /-- The sets of rational and irrational points of the antidiagonal `{(x, y) | x + y = 0}` cannot be
 separated by open neighborhoods. This implies that `ℝₗ × ℝₗ` is not a normal space. -/
-theorem not_separatedNhds_rat_irrational_antidiag :
+theorem not_separatedNhds_rat_irrational_antidiagonal :
     ¬SeparatedNhds {x : ℝₗ × ℝₗ | x.1 + x.2 = 0 ∧ ∃ r : ℚ, ↑r = x.1}
     {x : ℝₗ × ℝₗ | x.1 + x.2 = 0 ∧ Irrational (toReal x.1)} := by
   have h₀ : ∀ {n : ℕ+}, 0 < (n : ℝ)⁻¹ := inv_pos.2 (Nat.cast_pos.2 (PNat.pos _))

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -291,9 +291,12 @@ lemma prod_fiberwise' (s : Finset ι) (g : ι → κ) (f : κ → M) :
 end bij
 
 @[to_additive (attr := simp)]
-lemma prod_diag (s : Finset ι) (f : ι × ι → M) :
-    ∏ i ∈ s.diag, f i = ∏ i ∈ s, f (i, i) := by
-  simp [diag]
+lemma prod_diagonal (s : Finset ι) (f : ι × ι → M) :
+    ∏ i ∈ s.diagonal, f i = ∏ i ∈ s, f (i, i) := by
+  simp [diagonal]
+
+@[deprecated (since := "2026-09-06")] alias prod_diag := prod_diagonal
+@[deprecated (since := "2026-09-06")] alias sum_diag := sum_diagonal
 
 @[to_additive]
 theorem prod_image' [DecidableEq ι] {s : Finset κ} {g : κ → ι} (h : κ → M)

--- a/Mathlib/Algebra/BigOperators/Intervals.lean
+++ b/Mathlib/Algebra/BigOperators/Intervals.lean
@@ -184,7 +184,7 @@ theorem sum_range_id (n : ℕ) : ∑ i ∈ range n, i = n * (n - 1) / 2 := by
 end GaussSum
 
 @[to_additive]
-lemma prod_range_diag_flip (n : ℕ) (f : ℕ → ℕ → M) :
+lemma prod_range_diagonal_flip (n : ℕ) (f : ℕ → ℕ → M) :
     (∏ m ∈ range n, ∏ k ∈ range (m + 1), f k (m - k)) =
       ∏ m ∈ range n, ∏ k ∈ range (n - m), f m k := by
   rw [prod_sigma', prod_sigma']
@@ -193,6 +193,9 @@ lemma prod_range_diag_flip (n : ℕ) (f : ℕ → ℕ → M) :
       Nat.lt_succ_iff, le_add_iff_nonneg_right, Nat.zero_le, and_true, and_imp, implies_true,
       Sigma.forall, add_tsub_cancel_of_le, add_tsub_cancel_left]
   exact fun a b han hba ↦ lt_of_le_of_lt hba han
+
+@[to_additive (attr := deprecated (since := "2026-09-06"))]
+alias prod_range_diag_flip := prod_range_diagonal_flip
 
 end Generic
 

--- a/Mathlib/Algebra/BigOperators/Sym.lean
+++ b/Mathlib/Algebra/BigOperators/Sym.lean
@@ -19,13 +19,16 @@ namespace Finset
 
 open Multiset
 
-theorem sum_sym2_filter_not_isDiag {ι M} [LinearOrder ι] [AddCommMonoid M]
+theorem sum_sym2_filter_not_isDiagonal {ι M} [LinearOrder ι] [AddCommMonoid M]
     (s : Finset ι) (p : Sym2 ι → M) :
-    ∑ i ∈ s.sym2 with ¬ i.IsDiag, p i = ∑ i ∈ s.offDiag with i.1 < i.2, p s(i.1, i.2) := by
-  rw [Finset.offDiag_filter_lt_eq_filter_le]
+    ∑ i ∈ s.sym2 with ¬ i.IsDiagonal, p i = ∑ i ∈ s.offDiagonal with i.1 < i.2, p s(i.1, i.2) := by
+  rw [Finset.offDiagonal_filter_lt_eq_filter_le]
   conv_rhs => rw [← Finset.sum_subtype_eq_sum_filter]
   refine (Finset.sum_equiv Sym2.sortEquiv.symm ?_ ?_).symm
   all_goals aesop
+
+@[deprecated (since := "2026-09-06")]
+alias sum_sym2_filter_not_isDiag := sum_sym2_filter_not_isDiagonal
 
 theorem sum_count_of_mem_sym {α} [DecidableEq α] {m : ℕ} {k : Sym α m} {s : Finset α}
     (hk : k ∈ s.sym m) : (∑ i ∈ s, count i k) = m := by

--- a/Mathlib/Algebra/DirectSum/LinearMap.lean
+++ b/Mathlib/Algebra/DirectSum/LinearMap.lean
@@ -47,7 +47,7 @@ lemma toMatrix_directSum_collectedBasis_eq_blockDiagonal' {R M₁ M₂ : Type*} 
   · simp [h₂.collectedBasis_repr_of_mem _ (hf _ (Subtype.mem _)), restrict_apply]
   · simp [hij, h₂.collectedBasis_repr_of_mem_ne _ hij.symm (hf _ (Subtype.mem _))]
 
-lemma diag_toMatrix_directSum_collectedBasis_eq_zero_of_mapsTo_ne
+lemma diagonal_toMatrix_directSum_collectedBasis_eq_zero_of_mapsTo_ne
     {κ : ι → Type*} [∀ i, Fintype (κ i)] [∀ i, DecidableEq (κ i)]
     {s : Finset ι} (h : IsInternal fun i : s ↦ N i)
     (b : (i : s) → Basis (κ i) R (N i)) (σ : ι → ι) (hσ : ∀ i, σ i ≠ i)
@@ -61,6 +61,10 @@ lemma diag_toMatrix_directSum_collectedBasis_eq_zero_of_mapsTo_ne
     exact h.collectedBasis_repr_of_mem_ne b hσ <| hf _ <| Subtype.mem (b i k)
   · suffices f (b i k) = 0 by simp [this]
     simpa [hN _ hi] using hf i <| Subtype.mem (b i k)
+
+@[deprecated (since := "2026-09-06")]
+alias diag_toMatrix_directSum_collectedBasis_eq_zero_of_mapsTo_ne :=
+  diagonal_toMatrix_directSum_collectedBasis_eq_zero_of_mapsTo_ne
 
 variable [∀ i, Module.Finite R (N i)] [∀ i, Module.Free R (N i)]
 
@@ -95,7 +99,7 @@ lemma trace_eq_zero_of_mapsTo_ne (h : IsInternal N) [IsNoetherian R M]
   replace h : IsInternal fun i : s ↦ N i := by
     convert! DirectSum.isInternal_ne_bot_iff.mpr h <;> simp [s]
   simp_rw [trace_eq_matrix_trace R (h.collectedBasis b), Matrix.trace,
-    diag_toMatrix_directSum_collectedBasis_eq_zero_of_mapsTo_ne h b σ hσ hf (by simp [s]),
+    diagonal_toMatrix_directSum_collectedBasis_eq_zero_of_mapsTo_ne h b σ hσ hf (by simp [s]),
     Pi.zero_apply, Finset.sum_const_zero]
 
 /-- If `f` and `g` are commuting endomorphisms of a finite, free `R`-module `M`, such that `f`

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -521,8 +521,8 @@ lemma coeff_mul [DecidableEq M] (x y : R[M]) (m : M) :
 alias mul_apply := coeff_mul
 
 open Finset in
-@[to_additive (dont_translate := R) coeff_mul_antidiag]
-lemma coeff_mul_antidiag (x y : R[M]) (m : M) (s : Finset (M × M))
+@[to_additive (dont_translate := R) coeff_mul_antidiagonal]
+lemma coeff_mul_antidiagonal (x y : R[M]) (m : M) (s : Finset (M × M))
     (hs : ∀ {p}, p ∈ s ↔ p.1 * p.2 = m) : (x * y).coeff m = ∑ p ∈ s, x.coeff p.1 * y.coeff p.2 := by
   classical
   let F (p : M × M) : R := if p.1 * p.2 = m then x.coeff p.1 * y.coeff p.2 else 0
@@ -539,9 +539,12 @@ lemma coeff_mul_antidiag (x y : R[M]) (m : M) (s : Finset (M × M))
         · rw [h1, zero_mul]
         · rw [hp hps h1, mul_zero]
 
-@[to_additive (attr := deprecated coeff_mul_antidiag (since := "2026-06-18")) (dont_translate := R)
-  mul_apply_antidiagonal]
-alias mul_apply_antidiagonal := coeff_mul_antidiag
+@[to_additive (attr := deprecated (since := "2026-09-06")) (dont_translate := R) coeff_mul_antidiag]
+alias coeff_mul_antidiag := coeff_mul_antidiagonal
+
+@[to_additive (attr := deprecated coeff_mul_antidiagonal (since := "2026-06-18"))
+  (dont_translate := R) mul_apply_antidiagonal]
+alias mul_apply_antidiagonal := coeff_mul_antidiagonal
 
 @[to_additive (attr := simp) (dont_translate := R) single_mul_single]
 lemma single_mul_single (m₁ m₂ : M) (r₁ r₂ : R) :

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -651,7 +651,7 @@ theorem coeff_C_mul (m) (a : R) (p : MvPolynomial σ R) : (C a * p).coeff m = a 
 
 theorem coeff_mul [DecidableEq σ] (p q : MvPolynomial σ R) (n : σ →₀ ℕ) :
     (p * q).coeff n = ∑ x ∈ Finset.antidiagonal n, p.coeff x.1 * q.coeff x.2 :=
-  AddMonoidAlgebra.coeff_mul_antidiag p q _ _ Finset.mem_antidiagonal
+  AddMonoidAlgebra.coeff_mul_antidiagonal p q _ _ Finset.mem_antidiagonal
 
 @[simp]
 theorem coeff_mul_monomial (m) (s : σ →₀ ℕ) (r : R) (p : MvPolynomial σ R) :

--- a/Mathlib/Algebra/MvPolynomial/Coeff.lean
+++ b/Mathlib/Algebra/MvPolynomial/Coeff.lean
@@ -32,7 +32,7 @@ private lemma coeff_linearCombination_X_pow_of_eq (a : σ →₀ R) {n : ℕ}
     ((a.linearCombination R X : MvPolynomial σ R) ^ n).coeff s =
       s.multinomial * s.prod (fun r m ↦ a r ^ m) := by
   classical
-  simp only [sum, linearCombination_apply, Finset.sum_pow_eq_sum_piAntidiag, coeff_sum,
+  simp only [sum, linearCombination_apply, Finset.sum_pow_eq_sum_piAntidiagonal, coeff_sum,
     ← C_eq_coe_nat, coeff_C_mul, smul_eq_C_mul, mul_pow, Finset.prod_mul_distrib, ← map_pow,
     ← map_prod, coeff_prod_X_pow, mul_ite, mul_one, mul_zero]
   rw [Finset.sum_eq_single (s : σ → ℕ)]
@@ -43,7 +43,7 @@ private lemma coeff_linearCombination_X_pow_of_eq (a : σ →₀ R) {n : ℕ}
       simp only [Finsupp.mem_support_iff, ne_eq, not_forall, Decidable.not_not] at hs'
       obtain ⟨i, hsi, hai⟩ := hs'
       rw [← mul_prod_erase _ i _ (by simpa), hai, zero_pow hsi, zero_mul, mul_zero]
-  · simp only [Finset.mem_piAntidiag, ne_eq, Finsupp.mem_support_iff, ite_eq_right_iff, and_imp]
+  · simp only [Finset.mem_piAntidiagonal, ne_eq, Finsupp.mem_support_iff, ite_eq_right_iff, and_imp]
     intro _ _ _ _ hed
     simp [Finsupp.ext_iff] at hed
     grind
@@ -51,7 +51,7 @@ private lemma coeff_linearCombination_X_pow_of_eq (a : σ →₀ R) {n : ℕ}
     intro hs' hs''
     rw [eq_indicator_self_iff] at hs''
     exfalso
-    rw [Finset.mem_piAntidiag, not_and_or] at hs'
+    rw [Finset.mem_piAntidiagonal, not_and_or] at hs'
     rcases hs' with hs' | hs'
     · apply hs'
       rw [← hs, sum_of_support_subset _ hs'' _ (by simp)]
@@ -61,14 +61,14 @@ private lemma coeff_linearCombination_X_pow_of_ne (a : σ →₀ R) {n : ℕ}
     (hs : s.sum (fun _ m ↦ m) ≠ n) :
     (((a.linearCombination R X : MvPolynomial σ R)) ^ n).coeff s = 0 := by
   classical
-  simp only [sum, linearCombination_apply, Finset.sum_pow_eq_sum_piAntidiag, coeff_sum, ← map_pow,
-    ← C_eq_coe_nat, coeff_C_mul, smul_eq_C_mul, mul_pow, Finset.prod_mul_distrib, ← map_prod,
-    coeff_prod_X_pow, mul_ite, mul_one, mul_zero]
+  simp only [sum, linearCombination_apply, Finset.sum_pow_eq_sum_piAntidiagonal, coeff_sum,
+    ← map_pow, ← C_eq_coe_nat, coeff_C_mul, smul_eq_C_mul, mul_pow, Finset.prod_mul_distrib,
+    ← map_prod, coeff_prod_X_pow, mul_ite, mul_one, mul_zero]
   apply Finset.sum_eq_zero (fun x hx ↦ ?_)
   rw [ite_eq_right]
   rintro ⟨rfl⟩
   apply hs
-  simp only [Finset.mem_piAntidiag] at hx
+  simp only [Finset.mem_piAntidiagonal] at hx
   rw [sum_of_support_subset _ (support_indicator_subset a.support _) _ (by simp), ← hx.1]
   congr
   ext i

--- a/Mathlib/Algebra/Order/Antidiag/Finsupp.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Finsupp.lean
@@ -16,15 +16,15 @@ This file defines the finset of finitely functions summing to a specific value o
 finsets should be thought of as the "antidiagonals" in the space of finitely supported functions.
 
 Precisely, for a commutative monoid `μ` with antidiagonals (see `Finset.HasAntidiagonal`),
-`Finset.finsuppAntidiag s n` is the finset of all finitely supported functions `f : ι →₀ μ` with
+`Finset.finsuppAntidiagonal s n` is the finset of all finitely supported functions `f : ι →₀ μ` with
 support contained in `s` and such that the sum of its values equals `n : μ`.
 
-We define it using `Finset.piAntidiag s n`, the corresponding antidiagonal in `ι → μ`.
+We define it using `Finset.piAntidiagonal s n`, the corresponding antidiagonal in `ι → μ`.
 
 ## Main declarations
 
-* `Finset.finsuppAntidiag s n`: Finset of all finitely supported functions `f : ι →₀ μ` with support
-  contained in `s` and such that the sum of its values equals `n : μ`.
+* `Finset.finsuppAntidiagonal s n`: Finset of all finitely supported functions `f : ι →₀ μ`
+  with support contained in `s` and such that the sum of its values equals `n : μ`.
 
 -/
 
@@ -42,35 +42,52 @@ variable [DecidableEq ι] [AddCommMonoid μ] [HasAntidiagonal μ] [DecidableEq �
   {n : μ} {f : ι →₀ μ}
 
 /-- The finset of functions `ι →₀ μ` with support contained in `s` and sum equal to `n`. -/
-def finsuppAntidiag (s : Finset ι) (n : μ) : Finset (ι →₀ μ) :=
-  (piAntidiag s n).attach.map ⟨fun f ↦ ⟨s.filter (f.1 · ≠ 0), f.1, by
-    simpa using (mem_piAntidiag.1 f.2).2⟩, fun _ _ hfg ↦ Subtype.ext (congr_arg (⇑) hfg)⟩
+def finsuppAntidiagonal (s : Finset ι) (n : μ) : Finset (ι →₀ μ) :=
+  (piAntidiagonal s n).attach.map ⟨fun f ↦ ⟨s.filter (f.1 · ≠ 0), f.1, by
+    simpa using (mem_piAntidiagonal.1 f.2).2⟩, fun _ _ hfg ↦ Subtype.ext (congr_arg (⇑) hfg)⟩
 
-@[simp] lemma mem_finsuppAntidiag : f ∈ finsuppAntidiag s n ↔ s.sum f = n ∧ f.support ⊆ s := by
-  simp [finsuppAntidiag, ← DFunLike.coe_fn_eq, subset_iff]
+@[deprecated (since := "2026-09-06")] alias finsuppAntidiag := finsuppAntidiagonal
 
-lemma mem_finsuppAntidiag' :
-    f ∈ finsuppAntidiag s n ↔ f.sum (fun _ x ↦ x) = n ∧ f.support ⊆ s := by
-  simp only [mem_finsuppAntidiag, and_congr_left_iff]
+@[simp] lemma mem_finsuppAntidiagonal :
+    f ∈ finsuppAntidiagonal s n ↔ s.sum f = n ∧ f.support ⊆ s := by
+  simp [finsuppAntidiagonal, ← DFunLike.coe_fn_eq, subset_iff]
+
+@[deprecated (since := "2026-09-06")] alias mem_finsuppAntidiag := mem_finsuppAntidiagonal
+
+lemma mem_finsuppAntidiagonal' :
+    f ∈ finsuppAntidiagonal s n ↔ f.sum (fun _ x ↦ x) = n ∧ f.support ⊆ s := by
+  simp only [mem_finsuppAntidiagonal, and_congr_left_iff]
   rintro hf
   rw [sum_of_support_subset (N := μ) f hf (fun _ x ↦ x) fun _ _ ↦ rfl]
 
-@[simp] lemma finsuppAntidiag_empty_zero : finsuppAntidiag (∅ : Finset ι) (0 : μ) = {0} := by
+@[deprecated (since := "2026-09-06")] alias mem_finsuppAntidiag' := mem_finsuppAntidiagonal'
+
+@[simp] lemma finsuppAntidiagonal_empty_zero :
+    finsuppAntidiagonal (∅ : Finset ι) (0 : μ) = {0} := by
   ext f; simp
 
-@[simp] lemma finsuppAntidiag_empty_of_ne_zero (hn : n ≠ 0) :
-    finsuppAntidiag (∅ : Finset ι) n = ∅ :=
+@[deprecated (since := "2026-09-06")]
+alias finsuppAntidiag_empty_zero := finsuppAntidiagonal_empty_zero
+
+@[simp] lemma finsuppAntidiagonal_empty_of_ne_zero (hn : n ≠ 0) :
+    finsuppAntidiagonal (∅ : Finset ι) n = ∅ :=
   eq_empty_of_forall_notMem (by simp [hn.symm])
 
-lemma finsuppAntidiag_empty (n : μ) :
-    finsuppAntidiag (∅ : Finset ι) n = if n = 0 then {0} else ∅ := by split_ifs with hn <;> simp [*]
+@[deprecated (since := "2026-09-06")]
+alias finsuppAntidiag_empty_of_ne_zero := finsuppAntidiagonal_empty_of_ne_zero
 
-theorem mem_finsuppAntidiag_insert {a : ι} {s : Finset ι}
+lemma finsuppAntidiagonal_empty (n : μ) :
+    finsuppAntidiagonal (∅ : Finset ι) n = if n = 0 then {0} else ∅ := by
+  split_ifs with hn <;> simp [*]
+
+@[deprecated (since := "2026-09-06")] alias finsuppAntidiag_empty := finsuppAntidiagonal_empty
+
+theorem mem_finsuppAntidiagonal_insert {a : ι} {s : Finset ι}
     (h : a ∉ s) (n : μ) {f : ι →₀ μ} :
-    f ∈ finsuppAntidiag (insert a s) n ↔
+    f ∈ finsuppAntidiagonal (insert a s) n ↔
       ∃ m ∈ antidiagonal n, ∃ (g : ι →₀ μ),
-        f = Finsupp.update g a m.1 ∧ g ∈ finsuppAntidiag s m.2 := by
-  simp only [mem_finsuppAntidiag, mem_antidiagonal, Prod.exists, sum_insert h]
+        f = Finsupp.update g a m.1 ∧ g ∈ finsuppAntidiagonal s m.2 := by
+  simp only [mem_finsuppAntidiagonal, mem_antidiagonal, Prod.exists, sum_insert h]
   constructor
   · rintro ⟨rfl, hsupp⟩
     refine ⟨_, _, rfl, Finsupp.erase a f, ?_, ?_, ?_⟩
@@ -88,15 +105,18 @@ theorem mem_finsuppAntidiag_insert {a : ι} {s : Finset ι}
       intro x hx
       rw [update_of_ne (ne_of_mem_of_not_mem hx h) n1 ⇑g]
 
+@[deprecated (since := "2026-09-06")]
+alias mem_finsuppAntidiag_insert := mem_finsuppAntidiagonal_insert
+
 set_option backward.isDefEq.respectTransparency false in
-theorem finsuppAntidiag_insert {a : ι} {s : Finset ι}
+theorem finsuppAntidiagonal_insert {a : ι} {s : Finset ι}
     (h : a ∉ s) (n : μ) :
-    finsuppAntidiag (insert a s) n = (antidiagonal n).biUnion
+    finsuppAntidiagonal (insert a s) n = (antidiagonal n).biUnion
       (fun p : μ × μ =>
-        (finsuppAntidiag s p.snd).attach.map
+        (finsuppAntidiagonal s p.snd).attach.map
         ⟨fun f => Finsupp.update f.val a p.fst,
         (fun ⟨f, hf⟩ ⟨g, hg⟩ hfg => Subtype.ext <| by
-          simp only [mem_finsuppAntidiag] at hf hg
+          simp only [mem_finsuppAntidiagonal] at hf hg
           simp only [DFunLike.ext_iff] at hfg ⊢
           intro x
           obtain rfl | hx := eq_or_ne x a
@@ -105,26 +125,31 @@ theorem finsuppAntidiag_insert {a : ι} {s : Finset ι}
             rw [notMem_support_iff.mp hf, notMem_support_iff.mp hg]
           · simpa only [coe_update, Function.update, dite_eq_right hx] using hfg x)⟩) := by
   ext f
-  rw [mem_finsuppAntidiag_insert h, mem_biUnion]
+  rw [mem_finsuppAntidiagonal_insert h, mem_biUnion]
   simp_rw [mem_map, mem_attach, true_and, Subtype.exists, Embedding.coeFn_mk, exists_prop, and_comm,
     eq_comm]
 
+@[deprecated (since := "2026-09-06")] alias finsuppAntidiag_insert := finsuppAntidiagonal_insert
+
 @[gcongr]
-theorem finsuppAntidiag_mono {s t : Finset ι} (h : s ⊆ t) (n : μ) :
-    finsuppAntidiag s n ⊆ finsuppAntidiag t n := by
+theorem finsuppAntidiagonal_mono {s t : Finset ι} (h : s ⊆ t) (n : μ) :
+    finsuppAntidiagonal s n ⊆ finsuppAntidiagonal t n := by
   intro a
-  simp_rw [mem_finsuppAntidiag']
+  simp_rw [mem_finsuppAntidiagonal']
   rintro ⟨hsum, hmem⟩
   exact ⟨hsum, hmem.trans h⟩
+
+@[deprecated (since := "2026-09-06")] alias finsuppAntidiag_mono := finsuppAntidiagonal_mono
 
 variable [AddCommMonoid μ'] [HasAntidiagonal μ'] [DecidableEq μ']
 
 set_option backward.isDefEq.respectTransparency false in
 -- This should work under the assumption that e is an embedding and an AddHom
-lemma mapRange_finsuppAntidiag_subset {e : μ ≃+ μ'} {s : Finset ι} {n : μ} :
-    (finsuppAntidiag s n).map (mapRange.addEquiv e).toEmbedding ⊆ finsuppAntidiag s (e n) := by
+lemma mapRange_finsuppAntidiagonal_subset {e : μ ≃+ μ'} {s : Finset ι} {n : μ} :
+    (finsuppAntidiagonal s n).map (mapRange.addEquiv e).toEmbedding ⊆
+      finsuppAntidiagonal s (e n) := by
   intro f
-  simp only [mem_map, mem_finsuppAntidiag']
+  simp only [mem_map, mem_finsuppAntidiagonal']
   rintro ⟨g, ⟨hsum, hsupp⟩, rfl⟩
   simp only [AddEquiv.toEquiv_eq_coe, mapRange.addEquiv_toEquiv, Equiv.coe_toEmbedding,
     mapRange.equiv_apply, EquivLike.coe_coe]
@@ -132,21 +157,28 @@ lemma mapRange_finsuppAntidiag_subset {e : μ ≃+ μ'} {s : Finset ι} {n : μ}
   · rw [sum_mapRange_index (fun _ ↦ rfl), ← hsum, _root_.map_finsuppSum]
   · exact subset_trans (support_mapRange) hsupp
 
-lemma mapRange_finsuppAntidiag_eq {e : μ ≃+ μ'} {s : Finset ι} {n : μ} :
-    (finsuppAntidiag s n).map (mapRange.addEquiv e).toEmbedding = finsuppAntidiag s (e n) := by
+@[deprecated (since := "2026-09-06")]
+alias mapRange_finsuppAntidiag_subset := mapRange_finsuppAntidiagonal_subset
+
+lemma mapRange_finsuppAntidiagonal_eq {e : μ ≃+ μ'} {s : Finset ι} {n : μ} :
+    (finsuppAntidiagonal s n).map (mapRange.addEquiv e).toEmbedding =
+      finsuppAntidiagonal s (e n) := by
   ext f
   constructor
-  · apply mapRange_finsuppAntidiag_subset
+  · apply mapRange_finsuppAntidiagonal_subset
   · set h := (mapRange.addEquiv e).toEquiv with hh
     intro hf
     have : n = e.symm (e n) := (AddEquiv.eq_symm_apply e).mpr rfl
     rw [mem_map_equiv, this]
-    apply mapRange_finsuppAntidiag_subset
+    apply mapRange_finsuppAntidiagonal_subset
     rw [← mem_map_equiv]
     convert! hf
     rw [map_map, hh]
     convert! map_refl
     apply Function.Embedding.equiv_symm_toEmbedding_trans_toEmbedding
+
+@[deprecated (since := "2026-09-06")]
+alias mapRange_finsuppAntidiag_eq := mapRange_finsuppAntidiagonal_eq
 
 end AddCommMonoid
 
@@ -154,8 +186,10 @@ section CanonicallyOrderedAddCommMonoid
 variable [DecidableEq ι] [DecidableEq μ] [AddCommMonoid μ] [PartialOrder μ]
   [CanonicallyOrderedAdd μ] [HasAntidiagonal μ]
 
-@[simp] lemma finsuppAntidiag_zero (s : Finset ι) : finsuppAntidiag s (0 : μ) = {0} := by
-  ext f; simp [finsuppAntidiag, ← DFunLike.coe_fn_eq (g := f), eq_comm]
+@[simp] lemma finsuppAntidiagonal_zero (s : Finset ι) : finsuppAntidiagonal s (0 : μ) = {0} := by
+  ext f; simp [finsuppAntidiagonal, ← DFunLike.coe_fn_eq (g := f), eq_comm]
+
+@[deprecated (since := "2026-09-06")] alias finsuppAntidiag_zero := finsuppAntidiagonal_zero
 
 end CanonicallyOrderedAddCommMonoid
 end Finset

--- a/Mathlib/Algebra/Order/Antidiag/FinsuppEquiv.lean
+++ b/Mathlib/Algebra/Order/Antidiag/FinsuppEquiv.lean
@@ -12,19 +12,20 @@ import Mathlib.Data.Sym.Card
 
 /-!
 
-# Equivalence between `Finset.finsuppAntidiag` and `Sym`
+# Equivalence between `Finset.finsuppAntidiagonal` and `Sym`
 
 This file collects further results about equivalence and cardinality related to
-`Finset.finsuppAntidiag`. This file is separated from `Mathlib.Algebra.Order.Antidiag.Finsupp` to
-reduce imports.
+`Finset.finsuppAntidiagonal`. This file is separated from
+`Mathlib.Algebra.Order.Antidiag.Finsupp` to reduce imports.
 
 ## Main declarations
-* `Finset.finsuppAntidiagEquivSubtype`: `Finset.finsuppAntidiag s n` is equivalent to subtype of
-  `s →₀ μ` whose sum is `n`.
-* `Finset.finsuppAntidiagEquiv`: `Finset.finsuppAntidiag s n` is equivalent to `Sym s n` for
+* `Finset.finsuppAntidiagonalEquivSubtype`: `Finset.finsuppAntidiagonal s n` is equivalent to
+  subtype of `s →₀ μ` whose sum is `n`.
+* `Finset.finsuppAntidiagonalEquiv`: `Finset.finsuppAntidiagonal s n` is equivalent to `Sym s n` for
   natural number `n`.
-* `Finset.card_finsuppAntidiag_nat_eq_choose` and `Finset.card_finsuppAntidiag_nat_eq_multichoose`:
-  cardinality formula for `Finset.finsuppAntidiag s n` for natural number `n`.
+* `Finset.card_finsuppAntidiagonal_nat_eq_choose` and
+  `Finset.card_finsuppAntidiagonal_nat_eq_multichoose`:
+  cardinality formula for `Finset.finsuppAntidiagonal s n` for natural number `n`.
 -/
 
 @[expose] public section
@@ -38,44 +39,61 @@ variable [DecidableEq ι] [AddCommMonoid μ] [HasAntidiagonal μ] [DecidableEq �
   {n : μ}
 
 variable (s n) in
-/-- The equivalence between `Finset.finsuppAntidiag s n` and the subtype of `s →₀ μ` whose sum is
-`n`. -/
+/-- The equivalence between `Finset.finsuppAntidiagonal s n` and the subtype of `s →₀ μ`
+whose sum is `n`. -/
 @[simps]
-noncomputable def finsuppAntidiagEquivSubtype :
-    s.finsuppAntidiag n ≃ { P : s →₀ μ // (P.sum fun (_ : s) ↦ id) = n } where
+noncomputable def finsuppAntidiagonalEquivSubtype :
+    s.finsuppAntidiagonal n ≃ { P : s →₀ μ // (P.sum fun (_ : s) ↦ id) = n } where
   toFun f := ⟨subtypeDomain (· ∈ s) f.val, by
     have hf := f.2
-    rw [mem_finsuppAntidiag'] at hf
+    rw [mem_finsuppAntidiagonal'] at hf
     simpa [sum, filter_mem_eq_inter, inter_eq_left.mpr hf.2] using hf.1⟩
-  invFun f := ⟨extendDomain f.val, mem_finsuppAntidiag'.mpr
+  invFun f := ⟨extendDomain f.val, mem_finsuppAntidiagonal'.mpr
     ⟨by simpa [sum] using f.2, by simp [map_eq_image, image_subset_iff]⟩⟩
   left_inv f := by
-    obtain ⟨hsum, hs⟩ := mem_finsuppAntidiag.mp f.prop
+    obtain ⟨hsum, hs⟩ := mem_finsuppAntidiagonal.mp f.prop
     ext1
     exact extendDomain_subtypeDomain _ hs
   right_inv f := by simp
 
+@[deprecated (since := "2026-09-06")]
+alias finsuppAntidiagEquivSubtype := finsuppAntidiagonalEquivSubtype
+
 variable (s) in
-/-- The equivalence between `Finset.finsuppAntidiag s n` and `Sym s n`. -/
-noncomputable def finsuppAntidiagEquiv (n : ℕ) : s.finsuppAntidiag n ≃ Sym s n :=
-  (finsuppAntidiagEquivSubtype s n).trans (Sym.equivNatSum s n).symm
+/-- The equivalence between `Finset.finsuppAntidiagonal s n` and `Sym s n`. -/
+noncomputable def finsuppAntidiagonalEquiv (n : ℕ) : s.finsuppAntidiagonal n ≃ Sym s n :=
+  (finsuppAntidiagonalEquivSubtype s n).trans (Sym.equivNatSum s n).symm
+
+@[deprecated (since := "2026-09-06")] alias finsuppAntidiagEquiv := finsuppAntidiagonalEquiv
 
 @[simp]
-theorem finsuppAntidiagEquiv_symm_apply_apply (n : ℕ) (f : Sym s n) (a : s) :
-    ((finsuppAntidiagEquiv s n).symm f).val a.val = f.toMultiset.count a := by
-  simp [finsuppAntidiagEquiv]
+theorem finsuppAntidiagonalEquiv_symm_apply_apply (n : ℕ) (f : Sym s n) (a : s) :
+    ((finsuppAntidiagonalEquiv s n).symm f).val a.val = f.toMultiset.count a := by
+  simp [finsuppAntidiagonalEquiv]
+
+@[deprecated (since := "2026-09-06")]
+alias finsuppAntidiagEquiv_symm_apply_apply := finsuppAntidiagonalEquiv_symm_apply_apply
 
 @[simp]
-theorem count_coe_finsuppAntidiagEquiv_apply (n : ℕ) (f : s.finsuppAntidiag n) (a : s) :
-    (finsuppAntidiagEquiv s n f).toMultiset.count a = f.val a := by
-  simp [finsuppAntidiagEquiv]
+theorem count_coe_finsuppAntidiagonalEquiv_apply (n : ℕ) (f : s.finsuppAntidiagonal n) (a : s) :
+    (finsuppAntidiagonalEquiv s n f).toMultiset.count a = f.val a := by
+  simp [finsuppAntidiagonalEquiv]
 
-theorem card_finsuppAntidiag_nat_eq_choose (n : ℕ) :
-    #(s.finsuppAntidiag n) = (#s + n - 1).choose n := by
-  simp [card_eq_of_equiv_fintype (finsuppAntidiagEquiv s n), Sym.card_sym_eq_choose]
+@[deprecated (since := "2026-09-06")]
+alias count_coe_finsuppAntidiagEquiv_apply := count_coe_finsuppAntidiagonalEquiv_apply
 
-theorem card_finsuppAntidiag_nat_eq_multichoose (n : ℕ) :
-    #(s.finsuppAntidiag n) = (#s).multichoose n := by
-  simp [card_eq_of_equiv_fintype (finsuppAntidiagEquiv s n), Sym.card_sym_eq_multichoose]
+theorem card_finsuppAntidiagonal_nat_eq_choose (n : ℕ) :
+    #(s.finsuppAntidiagonal n) = (#s + n - 1).choose n := by
+  simp [card_eq_of_equiv_fintype (finsuppAntidiagonalEquiv s n), Sym.card_sym_eq_choose]
+
+@[deprecated (since := "2026-09-06")]
+alias card_finsuppAntidiag_nat_eq_choose := card_finsuppAntidiagonal_nat_eq_choose
+
+theorem card_finsuppAntidiagonal_nat_eq_multichoose (n : ℕ) :
+    #(s.finsuppAntidiagonal n) = (#s).multichoose n := by
+  simp [card_eq_of_equiv_fintype (finsuppAntidiagonalEquiv s n), Sym.card_sym_eq_multichoose]
+
+@[deprecated (since := "2026-09-06")]
+alias card_finsuppAntidiag_nat_eq_multichoose := card_finsuppAntidiagonal_nat_eq_multichoose
 
 end Finset

--- a/Mathlib/Algebra/Order/Antidiag/Nat.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Nat.lean
@@ -14,11 +14,11 @@ public import Mathlib.Tactic.FinCases
 # Sets of tuples with a fixed product
 
 This file defines the finite set of `d`-tuples of natural numbers with a fixed product `n` as
-`Nat.finMulAntidiag`.
+`Nat.finMulAntidiagonal`.
 
 ## Main Results
 * There are `d^(ω n)` ways to write `n` as a product of `d` natural numbers, when `n` is squarefree
-  (`card_finMulAntidiag_of_squarefree`)
+  (`card_finMulAntidiagonal_of_squarefree`)
 * There are `3^(ω n)` pairs of natural numbers whose `lcm` is `n`, when `n` is squarefree
   (`card_pair_lcm_eq`)
 -/
@@ -54,18 +54,20 @@ namespace Nat
 
 /-- The `Finset` of all `d`-tuples of natural numbers whose product is `n`. Defined to be `∅` when
 `n = 0`. -/
-def finMulAntidiag (d : ℕ) (n : ℕ) : Finset (Fin d → ℕ) :=
+def finMulAntidiagonal (d : ℕ) (n : ℕ) : Finset (Fin d → ℕ) :=
   if hn : 0 < n then
     (Finset.finAntidiagonal d (Additive.ofMul (α := ℕ+) ⟨n, hn⟩)).map <|
       .arrowCongrRight <| Additive.toMul.toEmbedding.trans <| ⟨PNat.val, PNat.coe_injective⟩
   else
     ∅
 
+@[deprecated (since := "2026-09-06")] alias finMulAntidiag := finMulAntidiagonal
+
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem mem_finMulAntidiag {d n : ℕ} {f : Fin d → ℕ} :
-    f ∈ finMulAntidiag d n ↔ ∏ i, f i = n ∧ n ≠ 0 := by
-  unfold finMulAntidiag
+theorem mem_finMulAntidiagonal {d n : ℕ} {f : Fin d → ℕ} :
+    f ∈ finMulAntidiagonal d n ↔ ∏ i, f i = n ∧ n ≠ 0 := by
+  unfold finMulAntidiagonal
   split_ifs with h
   · simp_rw [mem_map, mem_finAntidiagonal, Function.Embedding.arrowCongrRight_apply,
       Function.comp_def, Function.Embedding.trans_apply, Equiv.coe_toEmbedding,
@@ -83,57 +85,78 @@ theorem mem_finMulAntidiag {d n : ℕ} {f : Fin d → ℕ} :
   · simp only [not_lt, nonpos_iff_eq_zero] at h
     simp only [h, notMem_empty, ne_eq, not_true_eq_false, and_false]
 
-@[simp]
-theorem finMulAntidiag_zero_right (d : ℕ) :
-    finMulAntidiag d 0 = ∅ := rfl
+@[deprecated (since := "2026-09-06")] alias mem_finMulAntidiag := mem_finMulAntidiagonal
 
-theorem finMulAntidiag_one {d : ℕ} :
-    finMulAntidiag d 1 = {fun _ => 1} := by
+@[simp]
+theorem finMulAntidiagonal_zero_right (d : ℕ) :
+    finMulAntidiagonal d 0 = ∅ := rfl
+
+@[deprecated (since := "2026-09-06")]
+alias finMulAntidiag_zero_right := finMulAntidiagonal_zero_right
+
+theorem finMulAntidiagonal_one {d : ℕ} :
+    finMulAntidiagonal d 1 = {fun _ => 1} := by
   ext
-  simp only [mem_finMulAntidiag, prod_eq_one_iff, mem_univ, forall_const, ne_eq, one_ne_zero,
+  simp only [mem_finMulAntidiagonal, prod_eq_one_iff, mem_univ, forall_const, ne_eq, one_ne_zero,
     not_false_eq_true, and_true, mem_singleton]
   grind
 
-theorem finMulAntidiag_zero_left {n : ℕ} (hn : n ≠ 1) :
-    finMulAntidiag 0 n = ∅ := by
+@[deprecated (since := "2026-09-06")] alias finMulAntidiag_one := finMulAntidiagonal_one
+
+theorem finMulAntidiagonal_zero_left {n : ℕ} (hn : n ≠ 1) :
+    finMulAntidiagonal 0 n = ∅ := by
   ext
   simp [hn.symm]
 
-theorem dvd_of_mem_finMulAntidiag {n d : ℕ} {f : Fin d → ℕ} (hf : f ∈ finMulAntidiag d n)
+@[deprecated (since := "2026-09-06")] alias finMulAntidiag_zero_left := finMulAntidiagonal_zero_left
+
+theorem dvd_of_mem_finMulAntidiagonal {n d : ℕ} {f : Fin d → ℕ} (hf : f ∈ finMulAntidiagonal d n)
     (i : Fin d) : f i ∣ n := by
-  rw [mem_finMulAntidiag] at hf
+  rw [mem_finMulAntidiagonal] at hf
   rw [← hf.1]
   exact dvd_prod_of_mem f (mem_univ i)
 
-theorem ne_zero_of_mem_finMulAntidiag {d n : ℕ} {f : Fin d → ℕ}
-    (hf : f ∈ finMulAntidiag d n) (i : Fin d) : f i ≠ 0 :=
-  ne_zero_of_dvd_ne_zero (mem_finMulAntidiag.mp hf).2 (dvd_of_mem_finMulAntidiag hf i)
+@[deprecated (since := "2026-09-06")]
+alias dvd_of_mem_finMulAntidiag := dvd_of_mem_finMulAntidiagonal
 
-theorem prod_eq_of_mem_finMulAntidiag {d n : ℕ} {f : Fin d → ℕ}
-    (hf : f ∈ finMulAntidiag d n) : ∏ i, f i = n :=
-  (mem_finMulAntidiag.mp hf).1
+theorem ne_zero_of_mem_finMulAntidiagonal {d n : ℕ} {f : Fin d → ℕ}
+    (hf : f ∈ finMulAntidiagonal d n) (i : Fin d) : f i ≠ 0 :=
+  ne_zero_of_dvd_ne_zero (mem_finMulAntidiagonal.mp hf).2 (dvd_of_mem_finMulAntidiagonal hf i)
 
-theorem finMulAntidiag_eq_piFinset_divisors_filter {d m n : ℕ} (hmn : m ∣ n) (hn : n ≠ 0) :
-    finMulAntidiag d m =
+@[deprecated (since := "2026-09-06")]
+alias ne_zero_of_mem_finMulAntidiag := ne_zero_of_mem_finMulAntidiagonal
+
+theorem prod_eq_of_mem_finMulAntidiagonal {d n : ℕ} {f : Fin d → ℕ}
+    (hf : f ∈ finMulAntidiagonal d n) : ∏ i, f i = n :=
+  (mem_finMulAntidiagonal.mp hf).1
+
+@[deprecated (since := "2026-09-06")]
+alias prod_eq_of_mem_finMulAntidiag := prod_eq_of_mem_finMulAntidiagonal
+
+theorem finMulAntidiagonal_eq_piFinset_divisors_filter {d m n : ℕ} (hmn : m ∣ n) (hn : n ≠ 0) :
+    finMulAntidiagonal d m =
       {f ∈ Fintype.piFinset fun _ : Fin d => n.divisors | ∏ i, f i = m} := by
   ext f
   simp only [ne_eq,
     Fintype.mem_piFinset, mem_divisors, mem_filter]
   constructor
   · intro hf
-    refine ⟨?_, prod_eq_of_mem_finMulAntidiag hf⟩
-    exact fun i => ⟨(dvd_of_mem_finMulAntidiag hf i).trans hmn, hn⟩
-  · rw [mem_finMulAntidiag]
+    refine ⟨?_, prod_eq_of_mem_finMulAntidiagonal hf⟩
+    exact fun i => ⟨(dvd_of_mem_finMulAntidiagonal hf i).trans hmn, hn⟩
+  · rw [mem_finMulAntidiagonal]
     exact fun ⟨_, hprod⟩ => ⟨hprod, ne_zero_of_dvd_ne_zero hn hmn⟩
 
-lemma image_apply_finMulAntidiag {d n : ℕ} {i : Fin d} (hd : d ≠ 1) :
-    (finMulAntidiag d n).image (fun f => f i) = divisors n := by
+@[deprecated (since := "2026-09-06")]
+alias finMulAntidiag_eq_piFinset_divisors_filter := finMulAntidiagonal_eq_piFinset_divisors_filter
+
+lemma image_apply_finMulAntidiagonal {d n : ℕ} {i : Fin d} (hd : d ≠ 1) :
+    (finMulAntidiagonal d n).image (fun f => f i) = divisors n := by
   ext k
   simp only [mem_image, ne_eq, mem_divisors]
   constructor
   · rintro ⟨f, hf, rfl⟩
-    exact ⟨dvd_of_mem_finMulAntidiag hf _, (mem_finMulAntidiag.mp hf).2⟩
-  · simp_rw [mem_finMulAntidiag]
+    exact ⟨dvd_of_mem_finMulAntidiagonal hf _, (mem_finMulAntidiagonal.mp hf).2⟩
+  · simp_rw [mem_finMulAntidiagonal]
     rintro ⟨⟨r, rfl⟩, hn⟩
     have hs : Nontrivial (Fin d) := by
       rw [Fin.nontrivial_iff_two_le]
@@ -148,15 +171,21 @@ lemma image_apply_finMulAntidiag {d n : ℕ} {i : Fin d} (hd : d ≠ 1) :
     · simp_all
     exact mem_erase.mpr ⟨hi_ne, mem_univ _⟩
 
-lemma image_piFinTwoEquiv_finMulAntidiag {n : ℕ} :
-    (finMulAntidiag 2 n).image (piFinTwoEquiv <| fun _ => ℕ) = divisorsAntidiagonal n := by
+@[deprecated (since := "2026-09-06")]
+alias image_apply_finMulAntidiag := image_apply_finMulAntidiagonal
+
+lemma image_piFinTwoEquiv_finMulAntidiagonal {n : ℕ} :
+    (finMulAntidiagonal 2 n).image (piFinTwoEquiv <| fun _ => ℕ) = divisorsAntidiagonal n := by
   ext x
   simp [(piFinTwoEquiv <| fun _ => ℕ).symm.surjective.exists]
 
-lemma finMulAntidiag_existsUnique_prime_dvd {d n p : ℕ} (hn : Squarefree n)
-    (hp : p ∈ n.primeFactorsList) (f : Fin d → ℕ) (hf : f ∈ finMulAntidiag d n) :
+@[deprecated (since := "2026-09-06")]
+alias image_piFinTwoEquiv_finMulAntidiag := image_piFinTwoEquiv_finMulAntidiagonal
+
+lemma finMulAntidiagonal_existsUnique_prime_dvd {d n p : ℕ} (hn : Squarefree n)
+    (hp : p ∈ n.primeFactorsList) (f : Fin d → ℕ) (hf : f ∈ finMulAntidiagonal d n) :
     ∃! i, p ∣ f i := by
-  rw [mem_finMulAntidiag] at hf
+  rw [mem_finMulAntidiagonal] at hf
   rw [mem_primeFactorsList hf.2, ← hf.1, hp.1.prime.dvd_finsetProd_iff] at hp
   obtain ⟨i, his, hi⟩ := hp.2
   refine ⟨i, hi, ?_⟩
@@ -169,14 +198,17 @@ lemma finMulAntidiag_existsUnique_prime_dvd {d n p : ℕ} (hn : Squarefree n)
     ← Finset.mul_prod_erase _ _ (mem_erase.mpr ⟨hij, mem_univ _⟩), ← mul_assoc]
   apply Nat.dvd_mul_right
 
+@[deprecated (since := "2026-09-06")]
+alias finMulAntidiag_existsUnique_prime_dvd := finMulAntidiagonal_existsUnique_prime_dvd
+
 private def primeFactorsPiBij (d n : ℕ) :
     ∀ f ∈ (n.primeFactors.pi fun _ => (univ : Finset <| Fin d)), Fin d → ℕ :=
   fun f _ i => ∏ p ∈ {p ∈ n.primeFactors.attach | f p.1 p.2 = i}, p
 
 private theorem primeFactorsPiBij_img (d n : ℕ) (hn : Squarefree n)
     (f : (p : ℕ) → p ∈ n.primeFactors → Fin d) (hf : f ∈ pi n.primeFactors fun _ => univ) :
-    Nat.primeFactorsPiBij d n f hf ∈ finMulAntidiag d n := by
-  rw [mem_finMulAntidiag]
+    Nat.primeFactorsPiBij d n f hf ∈ finMulAntidiagonal d n := by
+  rw [mem_finMulAntidiagonal]
   refine ⟨?_, hn.ne_zero⟩
   unfold Nat.primeFactorsPiBij
   rw [prod_fiberwise_of_maps_to, prod_attach (f := fun x => x)]
@@ -207,16 +239,16 @@ private theorem primeFactorsPiBij_inj (d n : ℕ)
     exact hfg rfl
 
 private theorem primeFactorsPiBij_surj (d n : ℕ) (hn : Squarefree n)
-    (t : Fin d → ℕ) (ht : t ∈ finMulAntidiag d n) : ∃ (g : _)
+    (t : Fin d → ℕ) (ht : t ∈ finMulAntidiagonal d n) : ∃ (g : _)
     (hg : g ∈ pi n.primeFactors fun _ => univ), Nat.primeFactorsPiBij d n g hg = t := by
   have existsUnique := fun (p : ℕ) (hp : p ∈ n.primeFactors) =>
-    (finMulAntidiag_existsUnique_prime_dvd hn
+    (finMulAntidiagonal_existsUnique_prime_dvd hn
       (mem_primeFactors_iff_mem_primeFactorsList.mp hp) t ht)
   choose f hf hf_unique using existsUnique
   refine ⟨f, ?_, ?_⟩
   · simp only [mem_pi, mem_univ, forall_true_iff]
   funext i
-  have : t i ∣ n := dvd_of_mem_finMulAntidiag ht _
+  have : t i ∣ n := dvd_of_mem_finMulAntidiagonal ht _
   trans (∏ p ∈ n.primeFactors.attach, if p.1 ∣ t i then p else 1)
   · rw [Nat.primeFactorsPiBij, ← prod_filter]
     congr
@@ -225,21 +257,27 @@ private theorem primeFactorsPiBij_surj (d n : ℕ) (hn : Squarefree n)
   rw [primeFactors_filter_dvd_of_dvd hn.ne_zero this]
   exact prod_primeFactors_of_squarefree <| hn.squarefree_of_dvd this
 
-private theorem card_finMulAntidiag_pi (d n : ℕ) (hn : Squarefree n) :
+private theorem card_finMulAntidiagonal_pi (d n : ℕ) (hn : Squarefree n) :
     #(n.primeFactors.pi fun _ => (univ : Finset <| Fin d)) =
-      #(finMulAntidiag d n) := by
+      #(finMulAntidiagonal d n) := by
   apply Finset.card_bij (Nat.primeFactorsPiBij d n) (primeFactorsPiBij_img d n hn)
     (primeFactorsPiBij_inj d n) (primeFactorsPiBij_surj d n hn)
 
 open scoped ArithmeticFunction.omega in -- access notation `ω`
-theorem card_finMulAntidiag_of_squarefree {d n : ℕ} (hn : Squarefree n) :
-    #(finMulAntidiag d n) = d ^ ω n := by
-  rw [← card_finMulAntidiag_pi d n hn, Finset.card_pi, Finset.prod_const,
+theorem card_finMulAntidiagonal_of_squarefree {d n : ℕ} (hn : Squarefree n) :
+    #(finMulAntidiagonal d n) = d ^ ω n := by
+  rw [← card_finMulAntidiagonal_pi d n hn, Finset.card_pi, Finset.prod_const,
     ArithmeticFunction.cardDistinctFactors_apply, ← List.card_toFinset, toFinset_factors,
     Finset.card_fin]
 
-theorem finMulAntidiag_three {n : ℕ} (a) (ha : a ∈ finMulAntidiag 3 n) : a 0 * a 1 * a 2 = n := by
-  rw [← (mem_finMulAntidiag.mp ha).1, Fin.prod_univ_three a]
+@[deprecated (since := "2026-09-06")]
+alias card_finMulAntidiag_of_squarefree := card_finMulAntidiagonal_of_squarefree
+
+theorem finMulAntidiagonal_three {n : ℕ} (a) (ha : a ∈ finMulAntidiagonal 3 n) :
+    a 0 * a 1 * a 2 = n := by
+  rw [← (mem_finMulAntidiagonal.mp ha).1, Fin.prod_univ_three a]
+
+@[deprecated (since := "2026-09-06")] alias finMulAntidiag_three := finMulAntidiagonal_three
 
 namespace card_pair_lcm_eq
 
@@ -248,47 +286,47 @@ The following private declarations are ingredients for the proof of `card_pair_l
 -/
 
 @[reducible]
-private def f {n : ℕ} : ∀ a ∈ finMulAntidiag 3 n, ℕ × ℕ := fun a _ => (a 0 * a 1, a 0 * a 2)
+private def f {n : ℕ} : ∀ a ∈ finMulAntidiagonal 3 n, ℕ × ℕ := fun a _ => (a 0 * a 1, a 0 * a 2)
 
 private theorem f_img {n : ℕ} (hn : Squarefree n) (a : Fin 3 → ℕ)
-    (ha : a ∈ finMulAntidiag 3 n) :
+    (ha : a ∈ finMulAntidiagonal 3 n) :
     f a ha ∈ Finset.filter (fun ⟨x, y⟩ => x.lcm y = n) (n.divisors ×ˢ n.divisors) := by
   rw [mem_filter, Finset.mem_product, mem_divisors, mem_divisors]
-  refine ⟨⟨⟨?_, hn.ne_zero⟩, ⟨?_, hn.ne_zero⟩⟩, ?_⟩ <;> rw [f, ← finMulAntidiag_three a ha]
+  refine ⟨⟨⟨?_, hn.ne_zero⟩, ⟨?_, hn.ne_zero⟩⟩, ?_⟩ <;> rw [f, ← finMulAntidiagonal_three a ha]
   · apply dvd_mul_right
   · use a 1; ring
   dsimp only
   rw [lcm_mul_left, Nat.Coprime.lcm_eq_mul]
   · ring
   refine coprime_of_squarefree_mul (hn.squarefree_of_dvd ?_)
-  use a 0; rw [← finMulAntidiag_three a ha]; ring
+  use a 0; rw [← finMulAntidiagonal_three a ha]; ring
 
-private theorem f_inj {n : ℕ} (a : Fin 3 → ℕ) (ha : a ∈ finMulAntidiag 3 n)
-    (b : Fin 3 → ℕ) (hb : b ∈ finMulAntidiag 3 n) (hfab : f a ha = f b hb) :
+private theorem f_inj {n : ℕ} (a : Fin 3 → ℕ) (ha : a ∈ finMulAntidiagonal 3 n)
+    (b : Fin 3 → ℕ) (hb : b ∈ finMulAntidiagonal 3 n) (hfab : f a ha = f b hb) :
     a = b := by
   obtain ⟨hfab1, hfab2⟩ := Prod.mk.inj hfab
   have hprods : a 0 * a 1 * a 2 = a 0 * a 1 * b 2 := by
-    rw [finMulAntidiag_three a ha, hfab1, finMulAntidiag_three b hb]
+    rw [finMulAntidiagonal_three a ha, hfab1, finMulAntidiagonal_three b hb]
   have hab2 : a 2 = b 2 := by
-    rw [← mul_right_inj' <| mul_ne_zero (ne_zero_of_mem_finMulAntidiag ha 0)
-      (ne_zero_of_mem_finMulAntidiag ha 1)]
+    rw [← mul_right_inj' <| mul_ne_zero (ne_zero_of_mem_finMulAntidiagonal ha 0)
+      (ne_zero_of_mem_finMulAntidiagonal ha 1)]
     exact hprods
   have hab0 : a 0 = b 0 := by
     rw [hab2] at hfab2
-    exact (mul_left_inj' <| ne_zero_of_mem_finMulAntidiag hb 2).mp hfab2;
+    exact (mul_left_inj' <| ne_zero_of_mem_finMulAntidiagonal hb 2).mp hfab2;
   have hab1 : a 1 = b 1 := by
     rw [hab0] at hfab1
-    exact (mul_right_inj' <| ne_zero_of_mem_finMulAntidiag hb 0).mp hfab1;
+    exact (mul_right_inj' <| ne_zero_of_mem_finMulAntidiagonal hb 0).mp hfab1;
   funext i; fin_cases i <;> assumption
 
 private theorem f_surj {n : ℕ} (hn : n ≠ 0) (b : ℕ × ℕ)
     (hb : b ∈ Finset.filter (fun ⟨x, y⟩ => x.lcm y = n) (n.divisors ×ˢ n.divisors)) :
-    ∃ (a : Fin 3 → ℕ) (ha : a ∈ finMulAntidiag 3 n), f a ha = b := by
+    ∃ (a : Fin 3 → ℕ) (ha : a ∈ finMulAntidiagonal 3 n), f a ha = b := by
   dsimp only at hb
   let g := b.fst.gcd b.snd
   let a := ![g, b.fst / g, b.snd / g]
-  have ha : a ∈ finMulAntidiag 3 n := by
-    rw [mem_finMulAntidiag]
+  have ha : a ∈ finMulAntidiagonal 3 n := by
+    rw [mem_finMulAntidiagonal]
     rw [mem_filter, Finset.mem_product] at hb
     refine ⟨?_, hn⟩
     · rw [Fin.prod_univ_three a]
@@ -307,7 +345,7 @@ open card_pair_lcm_eq in
 open scoped ArithmeticFunction.omega in -- access notation `ω`
 theorem card_pair_lcm_eq {n : ℕ} (hn : Squarefree n) :
     #{p ∈ (n.divisors ×ˢ n.divisors) | p.1.lcm p.2 = n} = 3 ^ ω n := by
-  rw [← card_finMulAntidiag_of_squarefree hn, eq_comm]
+  rw [← card_finMulAntidiagonal_of_squarefree hn, eq_comm]
   apply Finset.card_bij f (f_img hn) f_inj (f_surj hn.ne_zero)
 
 end Nat

--- a/Mathlib/Algebra/Order/Antidiag/Pi.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Pi.lean
@@ -18,20 +18,20 @@ This file provides the finset of functions summing to a specific value on a fins
 should be thought of as the "antidiagonals" in the space of functions.
 
 Precisely, for a commutative monoid `μ` with antidiagonals (see `Finset.HasAntidiagonal`),
-`Finset.piAntidiag s n` is the finset of all functions `f : ι → μ` with support contained in `s` and
-such that the sum of its values equals `n : μ`.
+`Finset.piAntidiagonal s n` is the finset of all functions `f : ι → μ` with support contained in `s`
+and such that the sum of its values equals `n : μ`.
 
 We define it recursively on `s` using `Finset.HasAntidiagonal.antidiagonal : μ → Finset (μ × μ)`.
 Technically, we non-canonically identify `s` with `Fin n` where `n = s.card`, recurse on `n` using
 that `(Fin (n + 1) → μ) ≃ (Fin n → μ) × μ`, and show the end result doesn't depend on our
-identification. See `Finset.finAntidiag` for the details.
+identification. See `Finset.finAntidiagonal` for the details.
 
 ## Main declarations
 
-* `Finset.piAntidiag s n`: Finset of all functions `f : ι → μ` with support contained in `s` and
+* `Finset.piAntidiagonal s n`: Finset of all functions `f : ι → μ` with support contained in `s` and
   such that the sum of its values equals `n : μ`.
-* `Finset.finAntidiagonal d n`: Computationally efficient special case of `Finset.piAntidiag` when
-  `ι := Fin d`.
+* `Finset.finAntidiagonal d n`: Computationally efficient special case of `Finset.piAntidiagonal`
+  when `ι := Fin d`.
 
 ## TODO
 
@@ -39,7 +39,7 @@ identification. See `Finset.finAntidiag` for the details.
 
 ## See also
 
-`Finset.finsuppAntidiag` for the `Finset (ι →₀ μ)`-valued version of `Finset.piAntidiag`.
+`Finset.finsuppAntidiagonal` for the `Finset (ι →₀ μ)`-valued version of `Finset.piAntidiagonal`.
 -/
 
 @[expose] public section
@@ -103,7 +103,7 @@ choice.
 -/
 
 /-- The finset of functions `ι → μ` with support contained in `s` and sum `n`. -/
-def piAntidiag (s : Finset ι) (n : μ) : Finset (ι → μ) := by
+def piAntidiagonal (s : Finset ι) (n : μ) : Finset (ι → μ) := by
   refine (Fintype.truncEquivFinOfCardEq <| Fintype.card_coe s).lift
     (fun e ↦ (finAntidiagonal s.card n).map ⟨fun f i ↦ if hi : i ∈ s then f (e ⟨i, hi⟩) else 0, ?_⟩)
     fun e₁ e₂ ↦ ?_
@@ -117,10 +117,12 @@ def piAntidiag (s : Finset ι) (n : μ) : Finset (ι → μ) := by
     have := Fintype.sum_equiv (e₂.symm.trans e₁) _ g fun _ ↦ rfl
     simp_all
 
+@[deprecated (since := "2026-09-06")] alias piAntidiag := piAntidiagonal
+
 variable {s : Finset ι} {n : μ} {f : ι → μ}
 
-@[simp] lemma mem_piAntidiag : f ∈ piAntidiag s n ↔ s.sum f = n ∧ ∀ i, f i ≠ 0 → i ∈ s := by
-  rw [piAntidiag]
+@[simp] lemma mem_piAntidiagonal : f ∈ piAntidiagonal s n ↔ s.sum f = n ∧ ∀ i, f i ≠ 0 → i ∈ s := by
+  rw [piAntidiagonal]
   induction Fintype.truncEquivFinOfCardEq (Fintype.card_coe s) using Trunc.ind with | _ e
   simp only [Trunc.lift_mk, mem_map, mem_finAntidiagonal, Embedding.coeFn_mk]
   constructor
@@ -132,24 +134,37 @@ variable {s : Finset ι} {n : μ} {f : ι → μ}
     rw [← sum_attach s]
     exact Fintype.sum_equiv e.symm _ _ (by simp)
 
-@[simp] lemma piAntidiag_empty_zero : piAntidiag (∅ : Finset ι) (0 : μ) = {0} := by
+@[deprecated (since := "2026-09-06")] alias mem_piAntidiag := mem_piAntidiagonal
+
+@[simp] lemma piAntidiagonal_empty_zero : piAntidiagonal (∅ : Finset ι) (0 : μ) = {0} := by
   ext; simp [funext_iff]
 
-@[simp] lemma piAntidiag_empty_of_ne_zero (hn : n ≠ 0) : piAntidiag (∅ : Finset ι) n = ∅ :=
+@[deprecated (since := "2026-09-06")] alias piAntidiag_empty_zero := piAntidiagonal_empty_zero
+
+@[simp] lemma piAntidiagonal_empty_of_ne_zero (hn : n ≠ 0) : piAntidiagonal (∅ : Finset ι) n = ∅ :=
   eq_empty_of_forall_notMem (by simp [hn.symm])
 
-lemma piAntidiag_empty (n : μ) : piAntidiag (∅ : Finset ι) n = if n = 0 then {0} else ∅ := by
+@[deprecated (since := "2026-09-06")]
+alias piAntidiag_empty_of_ne_zero := piAntidiagonal_empty_of_ne_zero
+
+lemma piAntidiagonal_empty (n : μ) :
+    piAntidiagonal (∅ : Finset ι) n = if n = 0 then {0} else ∅ := by
   split_ifs with hn <;> simp [*]
 
-lemma finset_congr_piAntidiag_eq_antidiag (n : μ) :
-    (Equiv.boolArrowEquivProd _).finsetCongr (piAntidiag univ n) = antidiagonal n := by
+@[deprecated (since := "2026-09-06")] alias piAntidiag_empty := piAntidiagonal_empty
+
+lemma finset_congr_piAntidiagonal_eq_antidiagonal (n : μ) :
+    (Equiv.boolArrowEquivProd _).finsetCongr (piAntidiagonal univ n) = antidiagonal n := by
   ext ⟨x₁, x₂⟩
   simp_rw [Equiv.finsetCongr_apply, mem_map, Equiv.toEmbedding, Function.Embedding.coeFn_mk,
     ← Equiv.eq_symm_apply]
   simp [add_comm]
 
+@[deprecated (since := "2026-09-06")]
+alias finset_congr_piAntidiag_eq_antidiag := finset_congr_piAntidiagonal_eq_antidiagonal
+
 @[deprecated (since := "2026-08-11")]
-alias finsetCongr_piAntidiag_eq_antidiag := finset_congr_piAntidiag_eq_antidiag
+alias finsetCongr_piAntidiag_eq_antidiag := finset_congr_piAntidiagonal_eq_antidiagonal
 
 end AddCommMonoid
 
@@ -157,22 +172,26 @@ section AddCancelCommMonoid
 variable [DecidableEq ι] [AddCancelCommMonoid μ] [HasAntidiagonal μ] [DecidableEq μ] {i : ι}
   {s : Finset ι}
 
-lemma pairwiseDisjoint_piAntidiag_map_addRightEmbedding (hi : i ∉ s) (n : μ) :
+lemma pairwiseDisjoint_piAntidiagonal_map_addRightEmbedding (hi : i ∉ s) (n : μ) :
     (antidiagonal n : Set (μ × μ)).PairwiseDisjoint fun p ↦
-      map (addRightEmbedding fun j ↦ if j = i then p.1 else 0) (s.piAntidiag p.2) := by
+      map (addRightEmbedding fun j ↦ if j = i then p.1 else 0) (s.piAntidiagonal p.2) := by
   rintro ⟨a, b⟩ hab ⟨c, d⟩ hcd
   simp only [ne_eq, HasAntidiagonal.antidiagonal_congr' hab hcd, disjoint_left, mem_map,
-    mem_piAntidiag, addRightEmbedding_apply, not_exists, not_and, and_imp, forall_exists_index]
+    mem_piAntidiagonal, addRightEmbedding_apply, not_exists, not_and, and_imp, forall_exists_index]
   rintro hfg _ f rfl - rfl g rfl - hgf
   exact hfg <| by simpa [sum_add_distrib, hi] using congr_arg (∑ j ∈ s, · j) hgf.symm
 
-lemma piAntidiag_cons (hi : i ∉ s) (n : μ) :
-    piAntidiag (cons i s hi) n = (antidiagonal n).disjiUnion (fun p : μ × μ ↦
-      (piAntidiag s p.snd).map (addRightEmbedding fun t ↦ if t = i then p.fst else 0))
-        (pairwiseDisjoint_piAntidiag_map_addRightEmbedding hi _) := by
+@[deprecated (since := "2026-09-06")]
+alias pairwiseDisjoint_piAntidiag_map_addRightEmbedding :=
+  pairwiseDisjoint_piAntidiagonal_map_addRightEmbedding
+
+lemma piAntidiagonal_cons (hi : i ∉ s) (n : μ) :
+    piAntidiagonal (cons i s hi) n = (antidiagonal n).disjiUnion (fun p : μ × μ ↦
+      (piAntidiagonal s p.snd).map (addRightEmbedding fun t ↦ if t = i then p.fst else 0))
+        (pairwiseDisjoint_piAntidiagonal_map_addRightEmbedding hi _) := by
   ext f
-  simp only [mem_piAntidiag, sum_cons, ne_eq, mem_cons, mem_disjiUnion, mem_antidiagonal, mem_map,
-    Prod.exists]
+  simp only [mem_piAntidiagonal, sum_cons, ne_eq, mem_cons, mem_disjiUnion, mem_antidiagonal,
+    mem_map, Prod.exists]
   constructor
   · rintro ⟨hn, hf⟩
     refine ⟨_, _, hn, update f i 0, ⟨sum_update_of_notMem hi _ _, fun j ↦ ?_⟩, by aesop⟩
@@ -181,10 +200,14 @@ lemma piAntidiag_cons (hi : i ∉ s) (n : μ) :
     have := hg i
     aesop (add simp [sum_add_distrib])
 
-lemma piAntidiag_insert [DecidableEq (ι → μ)] (hi : i ∉ s) (n : μ) :
-    piAntidiag (insert i s) n = (antidiagonal n).biUnion fun p : μ × μ ↦ (piAntidiag s p.snd).image
-      (fun f j ↦ f j + if j = i then p.fst else 0) := by
-  simpa [map_eq_image, addRightEmbedding] using! piAntidiag_cons hi n
+@[deprecated (since := "2026-09-06")] alias piAntidiag_cons := piAntidiagonal_cons
+
+lemma piAntidiagonal_insert [DecidableEq (ι → μ)] (hi : i ∉ s) (n : μ) :
+    piAntidiagonal (insert i s) n = (antidiagonal n).biUnion fun p : μ × μ ↦
+      (piAntidiagonal s p.snd).image (fun f j ↦ f j + if j = i then p.fst else 0) := by
+  simpa [map_eq_image, addRightEmbedding] using! piAntidiagonal_cons hi n
+
+@[deprecated (since := "2026-09-06")] alias piAntidiag_insert := piAntidiagonal_insert
 
 end AddCancelCommMonoid
 
@@ -192,8 +215,10 @@ section CanonicallyOrderedAddCommMonoid
 variable [DecidableEq ι] [AddCommMonoid μ] [PartialOrder μ]
   [CanonicallyOrderedAdd μ] [HasAntidiagonal μ] [DecidableEq μ]
 
-@[simp] lemma piAntidiag_zero (s : Finset ι) : piAntidiag s (0 : μ) = {0} := by
+@[simp] lemma piAntidiagonal_zero (s : Finset ι) : piAntidiagonal s (0 : μ) = {0} := by
   ext; simp [funext_iff, not_imp_comm, ← forall_and]
+
+@[deprecated (since := "2026-09-06")] alias piAntidiag_zero := piAntidiagonal_zero
 
 end CanonicallyOrderedAddCommMonoid
 
@@ -202,15 +227,18 @@ variable [DecidableEq ι]
 
 open Pointwise
 
-lemma piAntidiag_univ_fin_eq_antidiagonalTuple (n k : ℕ) :
-    piAntidiag univ n = Nat.antidiagonalTuple k n := by
+lemma piAntidiagonal_univ_fin_eq_antidiagonalTuple (n k : ℕ) :
+    piAntidiagonal univ n = Nat.antidiagonalTuple k n := by
   ext; simp [Nat.mem_antidiagonalTuple]
 
-lemma nsmul_piAntidiag [DecidableEq (ι → ℕ)] (s : Finset ι) (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
-    n • piAntidiag s m = {f ∈ piAntidiag s (n * m) | ∀ i ∈ s, n ∣ f i} := by
+@[deprecated (since := "2026-09-06")]
+alias piAntidiag_univ_fin_eq_antidiagonalTuple := piAntidiagonal_univ_fin_eq_antidiagonalTuple
+
+lemma nsmul_piAntidiagonal [DecidableEq (ι → ℕ)] (s : Finset ι) (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    n • piAntidiagonal s m = {f ∈ piAntidiagonal s (n * m) | ∀ i ∈ s, n ∣ f i} := by
   ext f
   refine mem_smul_finset.trans ?_
-  simp only [mem_filter, mem_piAntidiag, and_assoc]
+  simp only [mem_filter, mem_piAntidiagonal, and_assoc]
   constructor
   · rintro ⟨f, rfl, hf, rfl⟩
     simpa [← mul_sum, hn] using hf
@@ -224,28 +252,37 @@ lemma nsmul_piAntidiag [DecidableEq (ι → ℕ)] (s : Finset ι) (m : ℕ) {n :
   simp [funext_iff, Nat.mul_div_cancel', ← Nat.sum_div, *]
   grind
 
-lemma map_nsmul_piAntidiag (s : Finset ι) (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
-    (piAntidiag s m).map ⟨(n • ·), nsmul_right_injective hn⟩ =
-        {f ∈ piAntidiag s (n * m) | ∀ i ∈ s, n ∣ f i} := by
-  classical rw [map_eq_image]; exact nsmul_piAntidiag _ _ hn
+@[deprecated (since := "2026-09-06")] alias nsmul_piAntidiag := nsmul_piAntidiagonal
 
-lemma nsmul_piAntidiag_univ [Fintype ι] (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
-    n • piAntidiag univ m = {f ∈ piAntidiag (univ : Finset ι) (n * m) | ∀ i, n ∣ f i} := by
-  simpa using nsmul_piAntidiag (univ : Finset ι) m hn
+lemma map_nsmul_piAntidiagonal (s : Finset ι) (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    (piAntidiagonal s m).map ⟨(n • ·), nsmul_right_injective hn⟩ =
+        {f ∈ piAntidiagonal s (n * m) | ∀ i ∈ s, n ∣ f i} := by
+  classical rw [map_eq_image]; exact nsmul_piAntidiagonal _ _ hn
 
-lemma map_nsmul_piAntidiag_univ [Fintype ι] (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
-    (piAntidiag (univ : Finset ι) m).map ⟨(n • ·), nsmul_right_injective hn⟩ =
-      {f ∈ piAntidiag (univ : Finset ι) (n * m) | ∀ i, n ∣ f i} := by
-  simpa using map_nsmul_piAntidiag (univ : Finset ι) m hn
+@[deprecated (since := "2026-09-06")] alias map_nsmul_piAntidiag := map_nsmul_piAntidiagonal
+
+lemma nsmul_piAntidiagonal_univ [Fintype ι] (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    n • piAntidiagonal univ m = {f ∈ piAntidiagonal (univ : Finset ι) (n * m) | ∀ i, n ∣ f i} := by
+  simpa using nsmul_piAntidiagonal (univ : Finset ι) m hn
+
+@[deprecated (since := "2026-09-06")] alias nsmul_piAntidiag_univ := nsmul_piAntidiagonal_univ
+
+lemma map_nsmul_piAntidiagonal_univ [Fintype ι] (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    (piAntidiagonal (univ : Finset ι) m).map ⟨(n • ·), nsmul_right_injective hn⟩ =
+      {f ∈ piAntidiagonal (univ : Finset ι) (n * m) | ∀ i, n ∣ f i} := by
+  simpa using map_nsmul_piAntidiagonal (univ : Finset ι) m hn
+
+@[deprecated (since := "2026-09-06")]
+alias map_nsmul_piAntidiag_univ := map_nsmul_piAntidiagonal_univ
 
 end Nat
 
-lemma map_sym_eq_piAntidiag [DecidableEq ι] (s : Finset ι) (n : ℕ) :
+lemma map_sym_eq_piAntidiagonal [DecidableEq ι] (s : Finset ι) (n : ℕ) :
     (s.sym n).map ⟨fun m a ↦ m.1.count a, Multiset.count_injective.comp Sym.coe_injective⟩ =
-      piAntidiag s n := by
+      piAntidiagonal s n := by
   ext f
   simp only [Sym.val_eq_coe, mem_map, mem_sym_iff, Embedding.coeFn_mk, funext_iff, Sym.exists,
-    Sym.mem_mk, Sym.coe_mk, exists_and_left, exists_prop, mem_piAntidiag, ne_eq]
+    Sym.mem_mk, Sym.coe_mk, exists_and_left, exists_prop, mem_piAntidiagonal, ne_eq]
   constructor
   · rintro ⟨m, hm, rfl, hf⟩
     simpa [← hf, Multiset.sum_count_eq_card hm]
@@ -253,5 +290,7 @@ lemma map_sym_eq_piAntidiag [DecidableEq ι] (s : Finset ι) (n : ℕ) :
     refine ⟨∑ a ∈ s, f a • {a}, ?_, ?_⟩
     · simp +contextual
     · simpa [Multiset.count_sum', Multiset.count_singleton, not_imp_comm, eq_comm (a := 0)] using hf
+
+@[deprecated (since := "2026-09-06")] alias map_sym_eq_piAntidiag := map_sym_eq_piAntidiagonal
 
 end Finset

--- a/Mathlib/Algebra/Order/BigOperators/Group/LocallyFinite.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/LocallyFinite.lean
@@ -141,12 +141,15 @@ section LocallyFiniteOrderTopBot
 variable [Fintype α] [LocallyFiniteOrderTop α] [LocallyFiniteOrderBot α]
 
 @[to_additive]
-lemma prod_prod_Ioi_mul_eq_prod_prod_off_diag (f : α → α → M) :
+lemma prod_prod_Ioi_mul_eq_prod_prod_off_diagonal (f : α → α → M) :
     ∏ i, ∏ j ∈ Ioi i, f j i * f i j = ∏ i, ∏ j ∈ {i}ᶜ, f j i := by
   simp_rw [← Ioi_disjUnion_Iio, prod_disjUnion, prod_mul_distrib]
   congr 1
   rw [prod_sigma', prod_sigma']
   refine prod_nbij' (fun i ↦ ⟨i.2, i.1⟩) (fun i ↦ ⟨i.2, i.1⟩) ?_ ?_ ?_ ?_ ?_ <;> simp
+
+@[to_additive (attr := deprecated (since := "2026-09-06"))]
+alias prod_prod_Ioi_mul_eq_prod_prod_off_diag := prod_prod_Ioi_mul_eq_prod_prod_off_diagonal
 
 end LocallyFiniteOrderTopBot
 

--- a/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
+++ b/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
@@ -74,7 +74,7 @@ theorem _root_.cauchy_product (ha : IsCauSeq abs fun m ↦ ∑ n ∈ range m, ab
   have h₁ :
     (∑ m ∈ range K, ∑ k ∈ range (m + 1), f k * g (m - k)) =
       ∑ m ∈ range K, ∑ n ∈ range (K - m), f m * g n := by
-    simpa using sum_range_diag_flip K fun m n ↦ f m * g n
+    simpa using sum_range_diagonal_flip K fun m n ↦ f m * g n
   have h₂ :
     (fun i ↦ ∑ k ∈ range (K - i), f i * g k) = fun i ↦ f i * ∑ k ∈ range (K - i), g k := by
     simp [Finset.mul_sum]

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -112,7 +112,7 @@ theorem coeff_mul (p q : R[X]) (n : ℕ) :
     coeff (p * q) n = ∑ x ∈ antidiagonal n, coeff p x.1 * coeff q x.2 := by
   rcases p with ⟨p⟩; rcases q with ⟨q⟩
   simp_rw [← ofFinsupp_mul, coeff]
-  exact AddMonoidAlgebra.coeff_mul_antidiag p q n _ Finset.mem_antidiagonal
+  exact AddMonoidAlgebra.coeff_mul_antidiagonal p q n _ Finset.mem_antidiagonal
 
 @[simp]
 theorem mul_coeff_zero (p q : R[X]) : coeff (p * q) 0 = coeff p 0 * coeff q 0 := by simp [coeff_mul]

--- a/Mathlib/AlgebraicTopology/ModelCategory/Cylinder.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/Cylinder.lean
@@ -232,7 +232,7 @@ variable [ModelCategory C] {A : C} (P : Cylinder A)
 section
 
 variable (h : MorphismProperty.MapFactorizationData (cofibrations C) (trivialFibrations C)
-    (codiag A))
+    (coprod.codiagonal A))
 
 set_option backward.isDefEq.respectTransparency false in
 /-- A cylinder object for `A` can be obtained from a factorization of the obvious

--- a/Mathlib/AlgebraicTopology/ModelCategory/PathObject.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/PathObject.lean
@@ -234,7 +234,7 @@ variable [ModelCategory C] {A : C} (P : PathObject A)
 section
 
 variable (h : MorphismProperty.MapFactorizationData
-  (trivialCofibrations C) (fibrations C) (diag A))
+  (trivialCofibrations C) (fibrations C) (prod.diagonal A))
 
 /-- A path object for `A` can be obtained from a factorization of the obvious
 map `A ⟶ A ⨯ A` as a trivial cofibration followed by a fibration. -/

--- a/Mathlib/AlgebraicTopology/Quasicategory/StrictSegal.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/StrictSegal.lean
@@ -84,7 +84,7 @@ theorem quasicategory {X : SSet.{u}} (sx : StrictSegal X) : Quasicategory X := b
         ext a : 1
         fin_cases a <;> fin_cases m <;> rfl
       rw [← spine_arrow, spine_δ_arrow_eq sx _ heq, hi]
-      simp only [spineToDiagonal, diagonal, spineToSimplex_spine_apply]
+      simp only [spineToDiagonal, SimplicialObject.diagonal, spineToSimplex_spine_apply]
       rw [← types_comp_apply (σ₀.app _) (X.map _), ← σ₀.naturality, types_comp_apply]
       dsimp
       apply congr_arg

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -131,8 +131,10 @@ lemma mkOfLe_refl {n} (j : Fin (n + 1)) :
     mkOfLe j j (by lia) = ⦋1⦌.const ⦋n⦌ j := Hom.ext_one_left _ _
 
 /-- The morphism `⦋1⦌ ⟶ ⦋n⦌` that picks out the "diagonal composite" edge -/
-def diag (n : ℕ) : ⦋1⦌ ⟶ ⦋n⦌ :=
+def diagonal (n : ℕ) : ⦋1⦌ ⟶ ⦋n⦌ :=
   mkOfLe 0 (Fin.last n) (Fin.zero_le _)
+
+@[deprecated (since := "2026-09-06")] alias diag := diagonal
 
 /-- The morphism `⦋1⦌ ⟶ ⦋n⦌` that picks out the edge spanning the interval from `j` to `j + l`. -/
 def intervalEdge {n} (j l : ℕ) (hjl : j + l ≤ n) : ⦋1⦌ ⟶ ⦋n⦌ :=
@@ -199,11 +201,13 @@ lemma mkOfSucc_subinterval_eq {n} (j l : ℕ) (hjl : j + l ≤ n) (i : Fin l) :
 
 set_option backward.isDefEq.respectTransparency.types false in
 @[simp]
-lemma diag_subinterval_eq {n} (j l : ℕ) (hjl : j + l ≤ n) :
-    diag l ≫ subinterval j l hjl = intervalEdge j l hjl := by
-  unfold subinterval intervalEdge diag mkOfLe
+lemma diagonal_subinterval_eq {n} (j l : ℕ) (hjl : j + l ≤ n) :
+    diagonal l ≫ subinterval j l hjl = intervalEdge j l hjl := by
+  unfold subinterval intervalEdge diagonal mkOfLe
   ext (i : Fin 2)
   match i with | 0 | 1 => simp <;> lia
+
+@[deprecated (since := "2026-09-06")] alias diag_subinterval_eq := diagonal_subinterval_eq
 
 instance (Δ : SimplexCategory) : Subsingleton (Δ ⟶ ⦋0⦌) where
   allEq f g := by ext : 3; apply Subsingleton.elim (α := Fin 1)

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -100,7 +100,7 @@ def σ {n} (i : Fin (n + 1)) : X _⦋n⦌ ⟶ X _⦋n + 1⦌ :=
 lemma σ_def {n} (i : Fin (n + 1)) : X.σ i = X.map (SimplexCategory.σ i).op := rfl
 
 /-- The diagonal of a simplex is the long edge of the simplex. -/
-def diagonal {n : ℕ} : X _⦋n⦌ ⟶ X _⦋1⦌ := X.map ((SimplexCategory.diag n).op)
+def diagonal {n : ℕ} : X _⦋n⦌ ⟶ X _⦋1⦌ := X.map ((SimplexCategory.diagonal n).op)
 
 /-- Isomorphisms from identities in ℕ. -/
 def eqToIso {n m : ℕ} (h : n = m) : X _⦋n⦌ ≅ X _⦋m⦌ :=

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
@@ -139,7 +139,7 @@ set_option backward.privateInPublic true in
 /-- In the presence of the strict Segal condition, a path of length `m` can be
 "composed" by taking the diagonal edge of the resulting `m`-simplex. -/
 def spineToDiagonal : Path X m → X _⦋1⦌ₙ₊₁ :=
-  X.map (tr (diag m)).op ∘ sx.spineToSimplex m h
+  X.map (tr (diagonal m)).op ∘ sx.spineToSimplex m h
 
 end autoParam
 
@@ -176,7 +176,7 @@ theorem spineToSimplex_edge (f : Path X m) (j l : ℕ) (hjl : j + l ≤ m) :
       sx.spineToDiagonal l (by lia) (f.interval j l hjl) := by
   dsimp only [spineToDiagonal, Function.comp_apply]
   rw [← spineToSimplex_interval, ← Functor.map_comp_apply, ← op_comp,
-    ← tr_comp, diag_subinterval_eq]
+    ← tr_comp, diagonal_subinterval_eq]
 
 end spineToSimplex
 
@@ -362,7 +362,7 @@ theorem spineToSimplex_edge :
       sx.spineToDiagonal (f.interval j l hjl) := by
   dsimp only [spineToDiagonal, SimplicialObject.diagonal]
   rw [← spineToSimplex_interval, ← Functor.map_comp_apply, ← op_comp,
-    diag_subinterval_eq]
+    diagonal_subinterval_eq]
 
 end interval
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -802,7 +802,7 @@ namespace FormalMultilinearSeries
 variable (p : FormalMultilinearSeries 𝕜 E F)
 
 open Fintype ContinuousLinearMap in
-theorem derivSeries_apply_diag (n : ℕ) (x : E) :
+theorem derivSeries_apply_diagonal (n : ℕ) (x : E) :
     derivSeries p n (fun _ ↦ x) x = (n + 1) • p (n + 1) fun _ ↦ x := by
   simp only [derivSeries, compFormalMultilinearSeries_apply, changeOriginSeries,
     compContinuousMultilinearMap_coe, ContinuousLinearEquiv.coe_coe, LinearIsometryEquiv.coe_coe,
@@ -813,10 +813,12 @@ theorem derivSeries_apply_diag (n : ℕ) (x : E) :
   · rw [← card, card_subtype, ← Finset.powerset_univ, ← Finset.powersetCard_eq_filter,
       Finset.card_powersetCard, ← card, card_fin, eq_comm, add_comm, Nat.choose_succ_self_right]
 
+@[deprecated (since := "2026-09-06")] alias derivSeries_apply_diag := derivSeries_apply_diagonal
+
 @[simp]
 lemma derivSeries_coeff_one (p : FormalMultilinearSeries 𝕜 𝕜 F) (n : ℕ) :
     p.derivSeries.coeff n 1 = (n + 1) • p.coeff (n + 1) :=
-  p.derivSeries_apply_diag _ _
+  p.derivSeries_apply_diagonal _ _
 
 end FormalMultilinearSeries
 
@@ -828,9 +830,12 @@ variable {p : FormalMultilinearSeries 𝕜 E F} {f : E → F} {x : E} {r : ℝ�
   (h : HasFPowerSeriesOnBall f p x r) (y : E)
 
 include h in
-theorem iteratedFDeriv_zero_apply_diag : iteratedFDeriv 𝕜 0 f x = p 0 := by
+theorem iteratedFDeriv_zero_apply_diagonal : iteratedFDeriv 𝕜 0 f x = p 0 := by
   ext
   simpa using (coeff_zero h _).symm
+
+@[deprecated (since := "2026-09-06")]
+alias iteratedFDeriv_zero_apply_diag := iteratedFDeriv_zero_apply_diagonal
 
 open ContinuousLinearMap
 
@@ -839,8 +844,8 @@ private theorem factorial_smul' {n : ℕ} : ∀ {F : Type max u v} [NormedAddCom
     {f : E → F}, HasFPowerSeriesOnBall f p x r →
     n ! • p n (fun _ ↦ y) = iteratedFDeriv 𝕜 n f x (fun _ ↦ y) := by
   induction n with | zero => _ | succ n ih => _ <;> intro F _ _ _ p f h
-  · rw [factorial_zero, one_smul, h.iteratedFDeriv_zero_apply_diag]
-  · rw [factorial_succ, mul_comm, mul_smul, ← derivSeries_apply_diag,
+  · rw [factorial_zero, one_smul, h.iteratedFDeriv_zero_apply_diagonal]
+  · rw [factorial_succ, mul_comm, mul_smul, ← derivSeries_apply_diagonal,
       ← _root_.smul_apply, ih h.fderiv, iteratedFDeriv_succ_apply_right]
     rfl
 
@@ -854,8 +859,8 @@ derivative as a sum over the permutations of `Fin n`, see
 theorem factorial_smul (n : ℕ) :
     n ! • p n (fun _ ↦ y) = iteratedFDeriv 𝕜 n f x (fun _ ↦ y) := by
   cases n
-  · rw [factorial_zero, one_smul, h.iteratedFDeriv_zero_apply_diag]
-  · rw [factorial_succ, mul_comm, mul_smul, ← derivSeries_apply_diag,
+  · rw [factorial_zero, one_smul, h.iteratedFDeriv_zero_apply_diagonal]
+  · rw [factorial_succ, mul_comm, mul_smul, ← derivSeries_apply_diagonal,
       ← _root_.smul_apply, factorial_smul' _ h.fderiv, iteratedFDeriv_succ_apply_right]
     rfl
 

--- a/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
+++ b/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
@@ -131,7 +131,7 @@ theorem uniformCauchySeqOnFilter_of_fderiv (hf' : UniformCauchySeqOnFilter f' l 
     -- neighborhood to small enough ball
     rw [Metric.tendstoUniformlyOnFilter_iff] at hf' ⊢
     intro ε hε
-    have := (tendsto_swap4_prod.eventually (hf.prod_mk hf)).diag_of_prod_right
+    have := (tendsto_swap4_prod.eventually (hf.prod_mk hf)).diagonal_of_prod_right
     obtain ⟨a, b, c, d, e⟩ := eventually_prod_iff.1 ((hf' ε hε).and this)
     obtain ⟨R, hR, hR'⟩ := Metric.nhds_basis_ball.eventually_iff.mp d
     let r := min 1 R
@@ -279,7 +279,7 @@ theorem difference_quotients_converge_uniformly
   intro ε hε
   obtain ⟨q, hqpos, hqε⟩ := exists_pos_rat_lt hε
   specialize hfg' (q : ℝ) (by simp [hqpos])
-  have := (tendsto_swap4_prod.eventually (hf.prod_mk hf)).diag_of_prod_right
+  have := (tendsto_swap4_prod.eventually (hf.prod_mk hf)).diagonal_of_prod_right
   obtain ⟨a, b, c, d, e⟩ := eventually_prod_iff.1 (hfg'.and this)
   obtain ⟨r, hr, hr'⟩ := Metric.nhds_basis_ball.eventually_iff.mp d
   rw [eventually_prod_iff]

--- a/Mathlib/Basic/Finite/Prod.lean
+++ b/Mathlib/Basic/Finite/Prod.lean
@@ -92,8 +92,10 @@ instance fintypeProd (s : Set α) (t : Set β) [Fintype s] [Fintype t] :
     Fintype (s ×ˢ t : Set (α × β)) :=
   Fintype.ofFinset (s.toFinset ×ˢ t.toFinset) <| by simp
 
-instance fintypeOffDiag (s : Set α) [Fintype s] : Fintype s.offDiag :=
-  Fintype.ofFinset s.toFinset.offDiag <| by simp
+instance fintypeOffDiagonal (s : Set α) [Fintype s] : Fintype s.offDiagonal :=
+  Fintype.ofFinset s.toFinset.offDiagonal <| by simp
+
+@[deprecated (since := "2026-09-06")] alias fintypeOffDiag := fintypeOffDiagonal
 
 /-- `image2 f s t` is `Fintype` if `s` and `t` are. -/
 instance fintypeImage2 [DecidableEq γ] (f : α → β → γ) (s : Set α) (t : Set β) [hs : Fintype s]
@@ -178,8 +180,10 @@ protected theorem infinite_prod :
 theorem finite_prod : (s ×ˢ t).Finite ↔ (s.Finite ∨ t = ∅) ∧ (t.Finite ∨ s = ∅) := by
   contrapose! +distrib; exact Set.infinite_prod
 
-protected theorem Finite.offDiag {s : Set α} (hs : s.Finite) : s.offDiag.Finite :=
-  (hs.prod hs).subset s.offDiag_subset_prod
+protected theorem Finite.offDiagonal {s : Set α} (hs : s.Finite) : s.offDiagonal.Finite :=
+  (hs.prod hs).subset s.offDiagonal_subset_prod
+
+@[deprecated (since := "2026-09-06")] alias Finite.offDiag := Finite.offDiagonal
 
 protected theorem Finite.image2 (f : α → β → γ) (hs : s.Finite) (ht : t.Finite) :
     (image2 f s t).Finite := by
@@ -197,9 +201,11 @@ theorem Finite.toFinset_prod {s : Set α} {t : Set β} (hs : s.Finite) (ht : t.F
     hs.toFinset ×ˢ ht.toFinset = (hs.prod ht).toFinset :=
   Finset.ext <| by simp
 
-theorem Finite.toFinset_offDiag {s : Set α} (hs : s.Finite) :
-    hs.offDiag.toFinset = hs.toFinset.offDiag :=
+theorem Finite.toFinset_offDiagonal {s : Set α} (hs : s.Finite) :
+    hs.offDiagonal.toFinset = hs.toFinset.offDiagonal :=
   Finset.ext <| by simp
+
+@[deprecated (since := "2026-09-06")] alias Finite.toFinset_offDiag := Finite.toFinset_offDiagonal
 
 theorem finite_image_fst_and_snd_iff {s : Set (α × β)} :
     (Prod.fst '' s).Finite ∧ (Prod.snd '' s).Finite ↔ s.Finite :=

--- a/Mathlib/CategoryTheory/Abelian/NonPreadditive.lean
+++ b/Mathlib/CategoryTheory/Abelian/NonPreadditive.lean
@@ -212,18 +212,18 @@ section
 
 /-- The composite `A ⟶ A ⨯ A ⟶ cokernel (Δ A)`, where the first map is `(𝟙 A, 0)` and the second map
 is the canonical projection into the cokernel. -/
-abbrev r (A : C) : A ⟶ cokernel (diag A) :=
-  prod.lift (𝟙 A) 0 ≫ cokernel.π (diag A)
+abbrev r (A : C) : A ⟶ cokernel (prod.diagonal A) :=
+  prod.lift (𝟙 A) 0 ≫ cokernel.π (prod.diagonal A)
 
-instance mono_Δ {A : C} : Mono (diag A) :=
+instance mono_Δ {A : C} : Mono (prod.diagonal A) :=
   mono_of_mono_fac <| prod.lift_fst _ _
 
 instance mono_r {A : C} : Mono (r A) := by
-  let hl : IsLimit (KernelFork.ofι (diag A) (cokernel.condition (diag A))) :=
+  let hl : IsLimit (KernelFork.ofι (prod.diagonal A) (cokernel.condition (prod.diagonal A))) :=
     monoIsKernelOfCokernel _ (colimit.isColimit _)
   apply NormalEpiCategory.mono_of_cancel_zero
   intro Z x hx
-  have hxx : (x ≫ prod.lift (𝟙 A) (0 : A ⟶ A)) ≫ cokernel.π (diag A) = 0 := by
+  have hxx : (x ≫ prod.lift (𝟙 A) (0 : A ⟶ A)) ≫ cokernel.π (prod.diagonal A) = 0 := by
     rw [Category.assoc, hx]
   obtain ⟨y, hy⟩ := KernelFork.IsLimit.lift' hl _ hxx
   rw [KernelFork.ι_ofι] at hy
@@ -250,7 +250,8 @@ instance epi_r {A : C} : Epi (r A) := by
     epiIsCokernelOfKernel _ hp1
   apply NormalMonoCategory.epi_of_zero_cancel
   intro Z z hz
-  have h : prod.lift (𝟙 A) (0 : A ⟶ A) ≫ cokernel.π (diag A) ≫ z = 0 := by rw [← Category.assoc, hz]
+  have h : prod.lift (𝟙 A) (0 : A ⟶ A) ≫ cokernel.π (prod.diagonal A) ≫ z = 0 := by
+    rw [← Category.assoc, hz]
   obtain ⟨t, ht⟩ := CokernelCofork.IsColimit.desc' hp2 _ h
   rw [CokernelCofork.π_ofπ] at ht
   have htt : t = 0 := by
@@ -258,22 +259,24 @@ instance epi_r {A : C} : Epi (r A) := by
     change 𝟙 A ≫ t = 0
     rw [← Limits.prod.lift_snd (𝟙 A) (𝟙 A), Category.assoc, ht, ← Category.assoc,
       cokernel.condition, zero_comp]
-  apply (cancel_epi (cokernel.π (diag A))).1
+  apply (cancel_epi (cokernel.π (prod.diagonal A))).1
   rw [← ht, htt, comp_zero, comp_zero]
 
 instance isIso_r {A : C} : IsIso (r A) :=
   isIso_of_mono_of_epi _
 
-/-- The composite `A ⨯ A ⟶ cokernel (diag A) ⟶ A` given by the natural projection into the cokernel
-followed by the inverse of `r`. In the category of modules, using the normal kernels and
+/-- The composite `A ⨯ A ⟶ cokernel (prod.diagonal A) ⟶ A` given by the natural projection into the
+cokernel followed by the inverse of `r`. In the category of modules, using the normal kernels and
 cokernels, this map is equal to the map `(a, b) ↦ a - b`, hence the name `σ` for "subtraction". -/
 abbrev σ {A : C} : A ⨯ A ⟶ A :=
-  cokernel.π (diag A) ≫ inv (r A)
+  cokernel.π (prod.diagonal A) ≫ inv (r A)
 
 end
 
 @[reassoc]
-theorem diag_σ {X : C} : diag X ≫ σ = 0 := by rw [cokernel.condition_assoc, zero_comp]
+theorem diagonal_σ {X : C} : prod.diagonal X ≫ σ = 0 := by rw [cokernel.condition_assoc, zero_comp]
+
+@[deprecated (since := "2026-09-06")] alias diag_σ := diagonal_σ
 
 @[reassoc (attr := simp)]
 theorem lift_σ {X : C} : prod.lift (𝟙 X) 0 ≫ σ = 𝟙 X := by rw [← Category.assoc, IsIso.hom_inv_id]
@@ -283,14 +286,14 @@ theorem lift_map {X Y : C} (f : X ⟶ Y) :
     prod.lift (𝟙 X) 0 ≫ Limits.prod.map f f = f ≫ prod.lift (𝟙 Y) 0 := by simp
 
 /-- σ is a cokernel of Δ X. -/
-def isColimitσ {X : C} : IsColimit (CokernelCofork.ofπ (σ : X ⨯ X ⟶ X) diag_σ) :=
+def isColimitσ {X : C} : IsColimit (CokernelCofork.ofπ (σ : X ⨯ X ⟶ X) diagonal_σ) :=
   cokernel.cokernelIso _ σ (asIso (r X)).symm (by rw [Iso.symm_hom, asIso_inv])
 
 /-- This is the key identity satisfied by `σ`. -/
 theorem σ_comp {X Y : C} (f : X ⟶ Y) : σ ≫ f = Limits.prod.map f f ≫ σ := by
   obtain ⟨g, hg⟩ :=
     CokernelCofork.IsColimit.desc' isColimitσ (Limits.prod.map f f ≫ σ) (by
-      rw [prod.diag_map_assoc, diag_σ, comp_zero])
+      rw [prod.diagonal_map_assoc, diagonal_σ, comp_zero])
   suffices hfg : f = g by rw [← hg, Cofork.π_ofπ, hfg]
   calc
     f = f ≫ prod.lift (𝟙 Y) 0 ≫ σ := by rw [lift_σ, Category.comp_id]
@@ -338,7 +341,7 @@ theorem sub_zero {X Y : C} (a : X ⟶ Y) : a - 0 = a := by
   rw [← prod.comp_lift, Category.assoc, lift_σ, Category.comp_id]
 
 theorem sub_self {X Y : C} (a : X ⟶ Y) : a - a = 0 := by
-  rw [sub_def, ← Category.comp_id a, ← prod.comp_lift, Category.assoc, diag_σ, comp_zero]
+  rw [sub_def, ← Category.comp_id a, ← prod.comp_lift, Category.assoc, diagonal_σ, comp_zero]
 
 theorem lift_sub_lift {X Y : C} (a b c d : X ⟶ Y) :
     prod.lift a b - prod.lift c d = prod.lift (a - c) (b - d) := by

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -1241,38 +1241,45 @@ set_option backward.defeqAttrib.useBackward true in
 /-- The canonical functor from the structured arrow category on the diagonal functor
 `T ⥤ T × T` to the structured arrow category on `Under.forget`. -/
 @[simps!]
-def ofDiagEquivalence.functor (X : T × T) :
-    StructuredArrow X (Functor.diag _) ⥤ StructuredArrow X.2 (Under.forget X.1) :=
+def ofDiagonalEquivalence.functor (X : T × T) :
+    StructuredArrow X (Functor.diagonal _) ⥤ StructuredArrow X.2 (Under.forget X.1) :=
   Functor.toStructuredArrow
     (Functor.toUnder (StructuredArrow.proj X _) _
       (fun f ↦ f.hom.1) (fun g ↦ by simp [← w g])) _ _
     (fun f ↦ f.hom.2) (fun g ↦ by simp [← w g])
 
 set_option backward.defeqAttrib.useBackward true in
-/-- The inverse functor of `ofDiagEquivalence.functor`. -/
+/-- The inverse functor of `ofDiagonalEquivalence.functor`. -/
 @[simps!]
-def ofDiagEquivalence.inverse (X : T × T) :
-    StructuredArrow X.2 (Under.forget X.1) ⥤ StructuredArrow X (Functor.diag _) :=
+def ofDiagonalEquivalence.inverse (X : T × T) :
+    StructuredArrow X.2 (Under.forget X.1) ⥤ StructuredArrow X (Functor.diagonal _) :=
   Functor.toStructuredArrow (StructuredArrow.proj _ _ ⋙ Under.forget _) _ _
     (fun f => (f.right.hom, f.hom)) (fun m => by have := m.w; cat_disch)
 
 set_option backward.isDefEq.respectTransparency.types false in
 set_option backward.defeqAttrib.useBackward true in
 /-- Characterization of the structured arrow category on the diagonal functor `T ⥤ T × T`. -/
-def ofDiagEquivalence (X : T × T) :
-    StructuredArrow X (Functor.diag _) ≌ StructuredArrow X.2 (Under.forget X.1) where
-  functor := ofDiagEquivalence.functor X
-  inverse := ofDiagEquivalence.inverse X
+def ofDiagonalEquivalence (X : T × T) :
+    StructuredArrow X (Functor.diagonal _) ≌ StructuredArrow X.2 (Under.forget X.1) where
+  functor := ofDiagonalEquivalence.functor X
+  inverse := ofDiagonalEquivalence.inverse X
   unitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by simp)
   counitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by cat_disch)
 
-/-- A version of `StructuredArrow.ofDiagEquivalence` with the roles of the first and second
+/-- A version of `StructuredArrow.ofDiagonalEquivalence` with the roles of the first and second
 projection swapped. -/
-def ofDiagEquivalence' (X : T × T) :
-    StructuredArrow X (Functor.diag _) ≌ StructuredArrow X.1 (Under.forget X.2) :=
-  (ofDiagEquivalence X).trans <|
+def ofDiagonalEquivalence' (X : T × T) :
+    StructuredArrow X (Functor.diagonal _) ≌ StructuredArrow X.1 (Under.forget X.2) :=
+  (ofDiagonalEquivalence X).trans <|
     (ofStructuredArrowProjEquivalence (𝟭 T) X.1 X.2).trans <|
     StructuredArrow.mapNatIso (Under.forget X.2).rightUnitor
+
+@[deprecated (since := "2026-09-06")]
+alias ofDiagEquivalence.functor := ofDiagonalEquivalence.functor
+@[deprecated (since := "2026-09-06")]
+alias ofDiagEquivalence.inverse := ofDiagonalEquivalence.inverse
+@[deprecated (since := "2026-09-06")] alias ofDiagEquivalence := ofDiagonalEquivalence
+@[deprecated (since := "2026-09-06")] alias ofDiagEquivalence' := ofDiagonalEquivalence'
 
 section CommaFst
 
@@ -1350,8 +1357,8 @@ set_option backward.defeqAttrib.useBackward true in
 /-- The canonical functor from the costructured arrow category on the diagonal functor
 `T ⥤ T × T` to the costructured arrow category on `Under.forget`. -/
 @[simps!]
-def ofDiagEquivalence.functor (X : T × T) :
-    CostructuredArrow (Functor.diag _) X ⥤ CostructuredArrow (Over.forget X.1) X.2 :=
+def ofDiagonalEquivalence.functor (X : T × T) :
+    CostructuredArrow (Functor.diagonal _) X ⥤ CostructuredArrow (Over.forget X.1) X.2 :=
   Functor.toCostructuredArrow
     (Functor.toOver (CostructuredArrow.proj _ X) _
       (fun g => by exact g.hom.1) (fun m => by have := congrArg (·.1) m.w; cat_disch))
@@ -1359,31 +1366,38 @@ def ofDiagEquivalence.functor (X : T × T) :
     (fun f => f.hom.2) (fun m => by have := congrArg (·.2) m.w; cat_disch)
 
 set_option backward.defeqAttrib.useBackward true in
-/-- The inverse functor of `ofDiagEquivalence.functor`. -/
+/-- The inverse functor of `ofDiagonalEquivalence.functor`. -/
 @[simps!]
-def ofDiagEquivalence.inverse (X : T × T) :
-    CostructuredArrow (Over.forget X.1) X.2 ⥤ CostructuredArrow (Functor.diag _) X :=
+def ofDiagonalEquivalence.inverse (X : T × T) :
+    CostructuredArrow (Over.forget X.1) X.2 ⥤ CostructuredArrow (Functor.diagonal _) X :=
   Functor.toCostructuredArrow (CostructuredArrow.proj _ _ ⋙ Over.forget _) _ X
     (fun f => (f.left.hom, f.hom)) (fun m => by have := m.w; cat_disch)
 
 set_option backward.isDefEq.respectTransparency.types false in
 set_option backward.defeqAttrib.useBackward true in
 /-- Characterization of the costructured arrow category on the diagonal functor `T ⥤ T × T`. -/
-def ofDiagEquivalence (X : T × T) :
-    CostructuredArrow (Functor.diag _) X ≌ CostructuredArrow (Over.forget X.1) X.2 where
-  functor := ofDiagEquivalence.functor X
-  inverse := ofDiagEquivalence.inverse X
+def ofDiagonalEquivalence (X : T × T) :
+    CostructuredArrow (Functor.diagonal _) X ≌ CostructuredArrow (Over.forget X.1) X.2 where
+  functor := ofDiagonalEquivalence.functor X
+  inverse := ofDiagonalEquivalence.inverse X
   unitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by simp)
   counitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by cat_disch)
 
-/-- A version of `CostructuredArrow.ofDiagEquivalence` with the roles of the first and second
+/-- A version of `CostructuredArrow.ofDiagonalEquivalence` with the roles of the first and second
 projection swapped. -/
 -- noncomputability is only for performance
-noncomputable def ofDiagEquivalence' (X : T × T) :
-    CostructuredArrow (Functor.diag _) X ≌ CostructuredArrow (Over.forget X.2) X.1 :=
-  (ofDiagEquivalence X).trans <|
+noncomputable def ofDiagonalEquivalence' (X : T × T) :
+    CostructuredArrow (Functor.diagonal _) X ≌ CostructuredArrow (Over.forget X.2) X.1 :=
+  (ofDiagonalEquivalence X).trans <|
     (ofCostructuredArrowProjEquivalence (𝟭 T) X.1 X.2).trans <|
     CostructuredArrow.mapNatIso (Over.forget X.2).rightUnitor
+
+@[deprecated (since := "2026-09-06")]
+alias ofDiagEquivalence.functor := ofDiagonalEquivalence.functor
+@[deprecated (since := "2026-09-06")]
+alias ofDiagEquivalence.inverse := ofDiagonalEquivalence.inverse
+@[deprecated (since := "2026-09-06")] alias ofDiagEquivalence := ofDiagonalEquivalence
+@[deprecated (since := "2026-09-06")] alias ofDiagEquivalence' := ofDiagonalEquivalence'
 
 section CommaFst
 

--- a/Mathlib/CategoryTheory/Filtered/Final.lean
+++ b/Mathlib/CategoryTheory/Filtered/Final.lean
@@ -26,7 +26,7 @@ final can be restated. We show:
 * If `D` is a filtered category and `F : C ⥤ D` is fully faithful and satisfies the additional
   condition that for every `d : D` there is an object `c : D` and a morphism `d ⟶ F.obj c`, then
   `C` is filtered and `F` is final.
-* Finality and initiality of diagonal functors `diag : C ⥤ C × C` and of projection functors
+* Finality and initiality of diagonal functors `diagonal : C ⥤ C × C` and of projection functors
   of (co)structured arrow categories.
 * Finality of `StructuredArrow.post`, given the finality of its arguments.
 
@@ -314,19 +314,22 @@ theorem Functor.initial_iff_isCofiltered_costructuredArrow [IsCofilteredOrEmpty 
 
 /-- If `C` is filtered, then the structured arrow category on the diagonal functor `C ⥤ C × C`
 is filtered as well. -/
-instance [IsFilteredOrEmpty C] (X : C × C) : IsFiltered (StructuredArrow X (diag C)) := by
+instance [IsFilteredOrEmpty C] (X : C × C) : IsFiltered (StructuredArrow X (diagonal C)) := by
   have : ∀ Y, IsFiltered (StructuredArrow Y (Under.forget X.1)) := by
     rw [← final_iff_isFiltered_structuredArrow (Under.forget X.1)]
     infer_instance
-  apply IsFiltered.of_equivalence (StructuredArrow.ofDiagEquivalence X).symm
+  apply IsFiltered.of_equivalence (StructuredArrow.ofDiagonalEquivalence X).symm
 
 /-- The diagonal functor on any filtered category is final. -/
-instance Functor.final_diag_of_isFiltered [IsFilteredOrEmpty C] : Final (Functor.diag C) :=
+instance Functor.final_diagonal_of_isFiltered [IsFilteredOrEmpty C] : Final (Functor.diagonal C) :=
   final_of_isFiltered_structuredArrow _
+
+@[deprecated (since := "2026-09-06")]
+alias Functor.final_diag_of_isFiltered := Functor.final_diagonal_of_isFiltered
 
 -- Adding this instance causes performance problems elsewhere, even with low priority
 theorem IsFilteredOrEmpty.isSiftedOrEmpty [IsFilteredOrEmpty C] : IsSiftedOrEmpty C :=
-  Functor.final_diag_of_isFiltered
+  Functor.final_diagonal_of_isFiltered
 
 -- Adding this instance causes performance problems elsewhere, even with low priority
 attribute [local instance] IsFiltered.nonempty in
@@ -334,15 +337,19 @@ theorem IsFiltered.isSifted [IsFiltered C] : IsSifted C where
 
 /-- If `C` is cofiltered, then the costructured arrow category on the diagonal functor `C ⥤ C × C`
 is cofiltered as well. -/
-instance [IsCofilteredOrEmpty C] (X : C × C) : IsCofiltered (CostructuredArrow (diag C) X) := by
+instance [IsCofilteredOrEmpty C] (X : C × C) : IsCofiltered (CostructuredArrow (diagonal C) X) := by
   have : ∀ Y, IsCofiltered (CostructuredArrow (Over.forget X.1) Y) := by
     rw [← initial_iff_isCofiltered_costructuredArrow (Over.forget X.1)]
     infer_instance
-  apply IsCofiltered.of_equivalence (CostructuredArrow.ofDiagEquivalence X).symm
+  apply IsCofiltered.of_equivalence (CostructuredArrow.ofDiagonalEquivalence X).symm
 
 /-- The diagonal functor on any cofiltered category is initial. -/
-instance Functor.initial_diag_of_isFiltered [IsCofilteredOrEmpty C] : Initial (Functor.diag C) :=
+instance Functor.initial_diagonal_of_isFiltered [IsCofilteredOrEmpty C] :
+    Initial (Functor.diagonal C) :=
   initial_of_isCofiltered_costructuredArrow _
+
+@[deprecated (since := "2026-09-06")]
+alias Functor.initial_diag_of_isFiltered := Functor.initial_diagonal_of_isFiltered
 
 /-- If `C` is filtered, then every functor `F : C ⥤ Discrete PUnit` is final. -/
 theorem Functor.final_of_isFiltered_of_pUnit [IsFiltered C] (F : C ⥤ Discrete PUnit) :

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts/BinaryProducts.lean
@@ -111,8 +111,10 @@ noncomputable abbrev prod.lift {W X Y : C} [HasBinaryProduct X Y]
   limit.lift _ (BinaryFan.mk f g)
 
 /-- diagonal arrow of the binary product in the category `fam I` -/
-noncomputable abbrev diag (X : C) [HasBinaryProduct X X] : X ⟶ X ⨯ X :=
+noncomputable abbrev prod.diagonal (X : C) [HasBinaryProduct X X] : X ⟶ X ⨯ X :=
   prod.lift (𝟙 _) (𝟙 _)
+
+@[deprecated (since := "2026-09-06")] alias diag := prod.diagonal
 
 /-- If the coproduct of `X` and `Y` exists, then every pair of morphisms `f : X ⟶ W` and
 `g : Y ⟶ W` induces a morphism `coprod.desc f g : X ⨿ Y ⟶ W`. -/
@@ -121,8 +123,10 @@ noncomputable abbrev coprod.desc {W X Y : C} [HasBinaryCoproduct X Y]
   colimit.desc _ (BinaryCofan.mk f g)
 
 /-- codiagonal arrow of the binary coproduct -/
-noncomputable abbrev codiag (X : C) [HasBinaryCoproduct X X] : X ⨿ X ⟶ X :=
+noncomputable abbrev coprod.codiagonal (X : C) [HasBinaryCoproduct X X] : X ⨿ X ⟶ X :=
   coprod.desc (𝟙 _) (𝟙 _)
+
+@[deprecated (since := "2026-09-06")] alias codiag := coprod.codiagonal
 
 @[reassoc]
 theorem prod.lift_fst {W X Y : C} [HasBinaryProduct X Y] (f : W ⟶ X) (g : W ⟶ Y) :
@@ -192,8 +196,10 @@ noncomputable section ProdLemmas
 theorem prod.comp_lift {V W X Y : C} [HasBinaryProduct X Y] (f : V ⟶ W) (g : W ⟶ X) (h : W ⟶ Y) :
     f ≫ prod.lift g h = prod.lift (f ≫ g) (f ≫ h) := by ext <;> simp
 
-theorem prod.comp_diag {X Y : C} [HasBinaryProduct Y Y] (f : X ⟶ Y) :
-    f ≫ diag Y = prod.lift f f := by simp
+theorem prod.comp_diagonal {X Y : C} [HasBinaryProduct Y Y] (f : X ⟶ Y) :
+    f ≫ prod.diagonal Y = prod.lift f f := by simp
+
+@[deprecated (since := "2026-09-06")] alias prod.comp_diag := prod.comp_diagonal
 
 @[reassoc (attr := simp)]
 theorem prod.map_fst {W X Y Z : C} [HasBinaryProduct W X] [HasBinaryProduct Y Z] (f : W ⟶ Y)
@@ -270,19 +276,27 @@ instance prod.map_mono {C : Type*} [Category* C] {W X Y Z : C} (f : W ⟶ Y) (g 
       simpa using congr_arg (fun f => f ≫ prod.snd) h⟩
 
 @[reassoc]
-theorem prod.diag_map {X Y : C} (f : X ⟶ Y) [HasBinaryProduct X X] [HasBinaryProduct Y Y] :
-    diag X ≫ prod.map f f = f ≫ diag Y := by simp
+theorem prod.diagonal_map {X Y : C} (f : X ⟶ Y) [HasBinaryProduct X X] [HasBinaryProduct Y Y] :
+    prod.diagonal X ≫ prod.map f f = f ≫ prod.diagonal Y := by simp
+
+@[deprecated (since := "2026-09-06")] alias prod.diag_map := prod.diagonal_map
 
 @[reassoc]
-theorem prod.diag_map_fst_snd {X Y : C} [HasBinaryProduct X Y] [HasBinaryProduct (X ⨯ Y) (X ⨯ Y)] :
-    diag (X ⨯ Y) ≫ prod.map prod.fst prod.snd = 𝟙 (X ⨯ Y) := by simp
+theorem prod.diagonal_map_fst_snd {X Y : C} [HasBinaryProduct X Y]
+    [HasBinaryProduct (X ⨯ Y) (X ⨯ Y)] :
+    prod.diagonal (X ⨯ Y) ≫ prod.map prod.fst prod.snd = 𝟙 (X ⨯ Y) := by simp
+
+@[deprecated (since := "2026-09-06")] alias prod.diag_map_fst_snd := prod.diagonal_map_fst_snd
 
 @[reassoc]
-theorem prod.diag_map_fst_snd_comp [HasLimitsOfShape (Discrete WalkingPair) C] {X X' Y Y' : C}
+theorem prod.diagonal_map_fst_snd_comp [HasLimitsOfShape (Discrete WalkingPair) C] {X X' Y Y' : C}
     (g : X ⟶ Y) (g' : X' ⟶ Y') :
-    diag (X ⨯ X') ≫ prod.map (prod.fst ≫ g) (prod.snd ≫ g') = prod.map g g' := by simp
+    prod.diagonal (X ⨯ X') ≫ prod.map (prod.fst ≫ g) (prod.snd ≫ g') = prod.map g g' := by simp
 
-instance {X : C} [HasBinaryProduct X X] : IsSplitMono (diag X) :=
+@[deprecated (since := "2026-09-06")]
+alias prod.diag_map_fst_snd_comp := prod.diagonal_map_fst_snd_comp
+
+instance {X : C} [HasBinaryProduct X X] : IsSplitMono (prod.diagonal X) :=
   IsSplitMono.mk' { retraction := prod.fst }
 
 end ProdLemmas
@@ -295,8 +309,10 @@ theorem coprod.desc_comp {V W X Y : C} [HasBinaryCoproduct X Y] (f : V ⟶ W) (g
     (h : Y ⟶ V) : coprod.desc g h ≫ f = coprod.desc (g ≫ f) (h ≫ f) := by
   ext <;> simp
 
-theorem coprod.diag_comp {X Y : C} [HasBinaryCoproduct X X] (f : X ⟶ Y) :
-    codiag X ≫ f = coprod.desc f f := by simp
+theorem coprod.diagonal_comp {X Y : C} [HasBinaryCoproduct X X] (f : X ⟶ Y) :
+    coprod.codiagonal X ≫ f = coprod.desc f f := by simp
+
+@[deprecated (since := "2026-09-06")] alias coprod.diag_comp := coprod.diagonal_comp
 
 @[reassoc (attr := simp)]
 theorem coprod.inl_map {W X Y Z : C} [HasBinaryCoproduct W X] [HasBinaryCoproduct Y Z] (f : W ⟶ Y)
@@ -378,18 +394,28 @@ instance coprod.map_epi {C : Type*} [Category* C] {W X Y Z : C} (f : W ⟶ Y) (g
       simpa using congr_arg (fun f => coprod.inr ≫ f) h⟩
 
 @[reassoc]
-theorem coprod.map_codiag {X Y : C} (f : X ⟶ Y) [HasBinaryCoproduct X X] [HasBinaryCoproduct Y Y] :
-    coprod.map f f ≫ codiag Y = codiag X ≫ f := by simp
+theorem coprod.map_codiagonal {X Y : C} (f : X ⟶ Y) [HasBinaryCoproduct X X]
+    [HasBinaryCoproduct Y Y] :
+    coprod.map f f ≫ coprod.codiagonal Y = coprod.codiagonal X ≫ f := by simp
+
+@[deprecated (since := "2026-09-06")] alias coprod.map_codiag := coprod.map_codiagonal
 
 @[reassoc]
-theorem coprod.map_inl_inr_codiag {X Y : C} [HasBinaryCoproduct X Y]
+theorem coprod.map_inl_inr_codiagonal {X Y : C} [HasBinaryCoproduct X Y]
     [HasBinaryCoproduct (X ⨿ Y) (X ⨿ Y)] :
-    coprod.map coprod.inl coprod.inr ≫ codiag (X ⨿ Y) = 𝟙 (X ⨿ Y) := by simp
+    coprod.map coprod.inl coprod.inr ≫ coprod.codiagonal (X ⨿ Y) = 𝟙 (X ⨿ Y) := by simp
+
+@[deprecated (since := "2026-09-06")]
+alias coprod.map_inl_inr_codiag := coprod.map_inl_inr_codiagonal
 
 @[reassoc]
-theorem coprod.map_comp_inl_inr_codiag [HasColimitsOfShape (Discrete WalkingPair) C] {X X' Y Y' : C}
-    (g : X ⟶ Y) (g' : X' ⟶ Y') :
-    coprod.map (g ≫ coprod.inl) (g' ≫ coprod.inr) ≫ codiag (Y ⨿ Y') = coprod.map g g' := by simp
+theorem coprod.map_comp_inl_inr_codiagonal [HasColimitsOfShape (Discrete WalkingPair) C]
+    {X X' Y Y' : C} (g : X ⟶ Y) (g' : X' ⟶ Y') :
+    coprod.map (g ≫ coprod.inl) (g' ≫ coprod.inr) ≫ coprod.codiagonal (Y ⨿ Y') =
+      coprod.map g g' := by simp
+
+@[deprecated (since := "2026-09-06")]
+alias coprod.map_comp_inl_inr_codiag := coprod.map_comp_inl_inr_codiagonal
 
 end CoprodLemmas
 

--- a/Mathlib/CategoryTheory/Limits/Sifted.lean
+++ b/Mathlib/CategoryTheory/Limits/Sifted.lean
@@ -48,7 +48,7 @@ section
 variable (C : Type u) [Category.{v} C]
 
 /-- A category `C` `IsSiftedOrEmpty` if the diagonal functor `C ⥤ C × C` is final. -/
-abbrev IsSiftedOrEmpty : Prop := Final (diag C)
+abbrev IsSiftedOrEmpty : Prop := Final (diagonal C)
 
 /-- A category `C` `IsSifted` if
 1. the diagonal functor `C ⥤ C × C` is final.
@@ -69,9 +69,9 @@ variable {C}
 set_option backward.defeqAttrib.useBackward true in
 /-- Being sifted is preserved by equivalences of categories -/
 lemma isSifted_of_equiv [IsSifted C] {D : Type u₁} [Category.{v₁} D] (e : D ≌ C) : IsSifted D :=
-  letI : Final (diag D) := by
+  letI : Final (diagonal D) := by
     let : D × D ≌ C × C := Equivalence.prod e e
-    have sq : (e.inverse ⋙ diag D ⋙ this.functor ≅ diag C) :=
+    have sq : (e.inverse ⋙ diagonal D ⋙ this.functor ≅ diagonal C) :=
         NatIso.ofComponents (fun c ↦ by dsimp [this]
                                         exact Iso.prod (e.counitIso.app c) (e.counitIso.app c))
     apply_rules [final_iff_comp_equivalence _ this.functor |>.mpr,
@@ -88,8 +88,8 @@ lemma isSifted_iff_asSmallIsSifted : IsSifted C ↔ IsSifted (AsSmall.{w} C) whe
 instance [IsSifted C] : IsConnected C :=
   isConnected_of_zigzag
     (by intro c₁ c₂
-        have X : StructuredArrow (c₁, c₂) (diag C) :=
-          letI S : Final (diag C) := by infer_instance
+        have X : StructuredArrow (c₁, c₂) (diagonal C) :=
+          letI S : Final (diagonal C) := by infer_instance
           Nonempty.some (S.out (c₁, c₂)).is_nonempty
         use [X.right, c₂]
         constructor
@@ -104,13 +104,13 @@ set_option backward.defeqAttrib.useBackward true in
 instance [HasBinaryCoproducts C] : IsSiftedOrEmpty C := by
     constructor
     rintro ⟨c₁, c₂⟩
-    have : _root_.Nonempty <| StructuredArrow (c₁, c₂) (diag C) :=
+    have : _root_.Nonempty <| StructuredArrow (c₁, c₂) (diagonal C) :=
       ⟨.mk ((coprod.inl : c₁ ⟶ c₁ ⨿ c₂), (coprod.inr : c₂ ⟶ c₁ ⨿ c₂))⟩
     apply isConnected_of_zigzag
     rintro ⟨_, c, f⟩ ⟨_, c', g⟩
-    dsimp only [const_obj_obj, diag_obj] at f g
+    dsimp only [const_obj_obj, diagonal_obj] at f g
     use [.mk ((coprod.inl : c₁ ⟶ c₁ ⨿ c₂), (coprod.inr : c₂ ⟶ c₁ ⨿ c₂)), .mk (g.fst, g.snd)]
-    simp only [colimit.cocone_x, diag_obj, Prod.mk.eta, List.isChain_cons_cons,
+    simp only [colimit.cocone_x, diagonal_obj, Prod.mk.eta, List.isChain_cons_cons,
       List.isChain_singleton, and_true, ne_eq, reduceCtorEq, not_false_eq_true,
       List.getLast_cons, List.cons_ne_self, List.getLast_singleton]
     exact ⟨⟨Zag.of_inv <| StructuredArrow.homMk <| coprod.desc f.fst f.snd,
@@ -127,7 +127,7 @@ variable {D : Type u₁} [Category.{v₁} D]
 instance [IsSiftedOrEmpty C] [IsSiftedOrEmpty D] :
     IsSiftedOrEmpty (C × D) :=
   let e : (C × C) × (D × D) ≌ (C × D) × (C × D) := prod.prodμ ..
-  final_of_natIso (Iso.refl ((Functor.diag C).prod (Functor.diag D) ⋙ e.functor))
+  final_of_natIso (Iso.refl ((Functor.diagonal C).prod (Functor.diagonal D) ⋙ e.functor))
 
 /-- The product of two sifted categories is sifted. -/
 instance prod_isSifted [IsSifted C] [IsSifted D] : IsSifted (C × D) where
@@ -144,7 +144,7 @@ variable {C : Type u} [Category.{v} C] [IsSiftedOrEmpty C] {D : Type u₁} [Cate
   {D' : Type u₂} [Category.{v₂} D'] (F : C ⥤ D) (G : C ⥤ D')
 
 instance [F.Final] [G.Final] : (F.prod' G).Final :=
-  show (diag C ⋙ F.prod G).Final from final_comp _ _
+  show (diagonal C ⋙ F.prod G).Final from final_comp _ _
 
 end
 
@@ -165,11 +165,11 @@ variable (X Y : C ⥤ Type u)
 set_option backward.isDefEq.respectTransparency false in
 set_option backward.defeqAttrib.useBackward true in
 /-- Through the isomorphisms `PreservesColimit₂.isoColimitUncurryWhiskeringLeft₂` and
-`externalProductCompDiagIso`, the comparison map `colimit.pre (X ⊠ Y) (diag C)` identifies with the
-product comparison map for the colimit functor. -/
+`externalProductCompDiagonalIso`, the comparison map `colimit.pre (X ⊠ Y) (diagonal C)` identifies
+with the product comparison map for the colimit functor. -/
 lemma factorization_prodComparison_colim :
-    (HasColimit.isoOfNatIso ((externalProductCompDiagIso _ _).app (X, Y)).symm).hom ≫
-      colimit.pre (X ⊠ Y) (diag C) ≫
+    (HasColimit.isoOfNatIso ((externalProductCompDiagonalIso _ _).app (X, Y)).symm).hom ≫
+      colimit.pre (X ⊠ Y) (diagonal C) ≫
         (PreservesColimit₂.isoColimitUncurryWhiskeringLeft₂ X Y <|
           curriedTensor <| Type u).hom =
     CartesianMonoidalCategory.prodComparison colim X Y := by
@@ -233,7 +233,7 @@ theorem isSiftedOrEmpty_of_colim_preservesBinaryProducts
     IsSiftedOrEmpty C := by
   apply final_of_colimit_comp_coyoneda_iso_pUnit
   rintro ⟨c₁, c₂⟩
-  calc colimit <| diag C ⋙ coyoneda.obj (op (c₁, c₂))
+  calc colimit <| diagonal C ⋙ coyoneda.obj (op (c₁, c₂))
     _ ≅ colimit <| _ ⋙ (coyoneda.obj _) ⊠ (coyoneda.obj _) :=
       HasColimit.isoOfNatIso <| isoWhiskerLeft _ <| .refl _
     _ ≅ colimit (_ ⊗ _) := HasColimit.isoOfNatIso <| .refl _

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct/Basic.lean
@@ -60,15 +60,19 @@ set_option backward.isDefEq.respectTransparency.types false in
 set_option backward.defeqAttrib.useBackward true in
 /-- When both diagrams have the same source category, composing the external product with
 the diagonal gives the pointwise functor tensor product.
-Note that `(externalProductCompDiagIso _ _).app (F₁, F₂) : Functor.diag J₁ ⋙ F₁ ⊠ F₂ ≅ F₁ ⊗ F₂`
+Note that
+`(externalProductCompDiagonalIso _ _).app (F₁, F₂) : Functor.diagonal J₁ ⋙ F₁ ⊠ F₂ ≅ F₁ ⊗ F₂`
 type checks. -/
 @[simps!]
-def externalProductCompDiagIso :
-    externalProductBifunctor J₁ J₁ C ⋙ (whiskeringLeft _ _ _ |>.obj <| Functor.diag J₁) ≅
+def externalProductCompDiagonalIso :
+    externalProductBifunctor J₁ J₁ C ⋙ (whiskeringLeft _ _ _ |>.obj <| Functor.diagonal J₁) ≅
     tensor (J₁ ⥤ C) :=
   NatIso.ofComponents
     (fun _ ↦ NatIso.ofComponents (fun _ ↦ Iso.refl _) (by simp [tensorHom_def]))
     (fun _ ↦ by ext; simp [tensorHom_def])
+
+@[deprecated (since := "2026-09-06")]
+alias externalProductCompDiagIso := externalProductCompDiagonalIso
 
 set_option backward.defeqAttrib.useBackward true in
 /-- When `C` is braided, there is an isomorphism `Prod.swap _ _ ⋙ F₁ ⊠ F₂ ≅ F₂ ⊠ F₁`, natural

--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -813,15 +813,26 @@ instance [F.Monoidal] [G.Monoidal] : (prod F G).Monoidal where
 end Prod
 
 set_option backward.defeqAttrib.useBackward true in
-instance : (diag C).Monoidal :=
+instance : (diagonal C).Monoidal :=
   CoreMonoidal.toMonoidal
     { εIso := Iso.refl _
       μIso := fun _ _ ↦ Iso.refl _ }
 
-@[simp] lemma diag_ε : ε (diag C) = 𝟙 _ := rfl
-@[simp] lemma diag_η : η (diag C) = 𝟙 _ := rfl
-@[simp] lemma diag_μ (X Y : C) : μ (diag C) X Y = 𝟙 _ := rfl
-@[simp] lemma diag_δ (X Y : C) : δ (diag C) X Y = 𝟙 _ := rfl
+@[simp] lemma diagonal_ε : ε (diagonal C) = 𝟙 _ := rfl
+
+@[deprecated (since := "2026-09-06")] alias diag_ε := diagonal_ε
+
+@[simp] lemma diagonal_η : η (diagonal C) = 𝟙 _ := rfl
+
+@[deprecated (since := "2026-09-06")] alias diag_η := diagonal_η
+
+@[simp] lemma diagonal_μ (X Y : C) : μ (diagonal C) X Y = 𝟙 _ := rfl
+
+@[deprecated (since := "2026-09-06")] alias diag_μ := diagonal_μ
+
+@[simp] lemma diagonal_δ (X Y : C) : δ (diagonal C) X Y = 𝟙 _ := rfl
+
+@[deprecated (since := "2026-09-06")] alias diag_δ := diagonal_δ
 
 section Prod'
 
@@ -833,7 +844,7 @@ variable [F.LaxMonoidal] [G.LaxMonoidal]
 
 /-- The functor `C ⥤ D × E` obtained from two lax monoidal functors is lax monoidal. -/
 instance LaxMonoidal.prod' : (prod' F G).LaxMonoidal :=
-  inferInstanceAs (diag C ⋙ prod F G).LaxMonoidal
+  inferInstanceAs (diagonal C ⋙ prod F G).LaxMonoidal
 
 @[simp] lemma prod'_ε_fst : (ε (prod' F G)).1 = ε F := by
   change _ ≫ F.map (𝟙 _) = _
@@ -863,7 +874,7 @@ variable [F.OplaxMonoidal] [G.OplaxMonoidal]
 
 /-- The functor `C ⥤ D × E` obtained from two oplax monoidal functors is oplax monoidal. -/
 instance OplaxMonoidal.prod' : (prod' F G).OplaxMonoidal :=
-  inferInstanceAs (diag C ⋙ prod F G).OplaxMonoidal
+  inferInstanceAs (diagonal C ⋙ prod F G).OplaxMonoidal
 
 @[simp] lemma prod'_η_fst : (η (prod' F G)).1 = η F := by
   change F.map (𝟙 _) ≫ _ = _

--- a/Mathlib/CategoryTheory/Monoidal/Limits/Colimits.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Limits/Colimits.lean
@@ -77,7 +77,7 @@ noncomputable def IsColimit.tensor [PreservesColimit₂ F₁ F₂ (curriedTensor
     (hc₁ : IsColimit c₁) (hc₂ : IsColimit c₂) :
     IsColimit (c₁.tensor c₂) := by
   refine (IsColimit.equivOfNatIsoOfIso ?_ _ _ ?_).1
-    ((Functor.Final.isColimitWhiskerEquiv (Functor.diag J) _).2 (hc₁.tensor₂ hc₂))
+    ((Functor.Final.isColimitWhiskerEquiv (Functor.diagonal J) _).2 (hc₁.tensor₂ hc₂))
   · exact NatIso.ofComponents (fun _ ↦ Iso.refl _) (fun _ ↦ by simp)
   · exact Cocone.ext (Iso.refl _)
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Representable.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Representable.lean
@@ -585,9 +585,10 @@ For an object `X` in a category `D`, if the diagonal morphism `X ⟶ X × X` is 
 representable, then every morphism of the form `F.obj a ⟶ X` is relatively representable with
 respect to `F`.
 -/
-lemma of_diag {X : D} (h : F.relativelyRepresentable (Limits.diag X))
+lemma of_diagonal {X : D} (h : F.relativelyRepresentable (Limits.prod.diagonal X))
     ⦃a : C⦄ (g : F.obj a ⟶ X) : F.relativelyRepresentable g := by
-  rw [(by cat_disch : Limits.diag X = pullback.lift (𝟙 X) (𝟙 X) ≫ (prodIsoPullback X X).inv)] at h
+  rw [(by cat_disch :
+    Limits.prod.diagonal X = pullback.lift (𝟙 X) (𝟙 X) ≫ (prodIsoPullback X X).inv)] at h
   intro a' g'
   obtain ⟨_, ⟨left⟩⟩ := pullback_map_diagonal_isPullback g g' (terminal.from X)
   let prodMap : F.obj (a ⨯ a') ⟶ X ⨯ X :=
@@ -601,6 +602,8 @@ lemma of_diag {X : D} (h : F.relativelyRepresentable (Limits.diag X))
   exact ⟨_, ⟨_, ⟨_, IsPullback.of_iso_pullback (fst := pbRepr.hom ≫ pullback.fst g g')
     (snd := F.map (Functor.preimage F (pbRepr.hom ≫ pullback.snd g g')))
     ⟨by simp [pullback.condition]⟩ pbRepr (by cat_disch) (by cat_disch)⟩⟩⟩
+
+@[deprecated (since := "2026-09-06")] alias of_diag := of_diagonal
 
 /-- Assume that
 1. `C` has binary products and pullbacks,
@@ -636,10 +639,11 @@ set_option backward.isDefEq.respectTransparency false in
 For an object `X` in a category `D`, if every morphism of the form `F.obj a ⟶ X` is relatively
 representable with respect to `F`, so is the diagonal morphism `X ⟶ X × X`.
 -/
-lemma diag_of_map_from_obj [HasPullbacks C] [PreservesLimitsOfShape WalkingCospan F]
+lemma diagonal_of_map_from_obj [HasPullbacks C] [PreservesLimitsOfShape WalkingCospan F]
     {X : D} (h : ∀ ⦃a : C⦄ (g : F.obj a ⟶ X), F.relativelyRepresentable g) :
-    F.relativelyRepresentable (Limits.diag X) := by
-  rw [(by cat_disch : Limits.diag X = pullback.lift (𝟙 X) (𝟙 X) ≫ (prodIsoPullback X X).inv)]
+    F.relativelyRepresentable (Limits.prod.diagonal X) := by
+  rw [(by cat_disch :
+    Limits.prod.diagonal X = pullback.lift (𝟙 X) (𝟙 X) ≫ (prodIsoPullback X X).inv)]
   suffices F.relativelyRepresentable (pullback.lift (𝟙 _) (𝟙 _)) from
     (respectsIso F).toRespectsRight.postcomp _ (inferInstance : IsIso _) _ this
   intro a g
@@ -659,6 +663,8 @@ lemma diag_of_map_from_obj [HasPullbacks C] [PreservesLimitsOfShape WalkingCospa
   exact hg ▸ ⟨_, ⟨_, ⟨_, IsPullback.of_isLimit <| pasteVertIsPullback rfl bot
     (map_preimage F topMap ▸ top).flip.isLimit'.some⟩⟩⟩
 
+@[deprecated (since := "2026-09-06")] alias diag_of_map_from_obj := diagonal_of_map_from_obj
+
 /-- Assume that
 1. `C` has binary products and pullbacks,
 2. `D` has pullbacks, binary products and a terminal object, and
@@ -667,10 +673,12 @@ lemma diag_of_map_from_obj [HasPullbacks C] [PreservesLimitsOfShape WalkingCospa
 For an object `X` in a category `D`, the diagonal morphism `X ⟶ X × X` is relatively representable
 with respect to `F` if and only if so is every morphism of the form `F.obj a ⟶ X`.
 -/
-lemma diag_iff {X : D} [HasPullbacks C] [PreservesLimitsOfShape WalkingCospan F] :
-    F.relativelyRepresentable (Limits.diag X) ↔
+lemma diagonal_iff {X : D} [HasPullbacks C] [PreservesLimitsOfShape WalkingCospan F] :
+    F.relativelyRepresentable (Limits.prod.diagonal X) ↔
       ∀ ⦃a : C⦄ (g : F.obj a ⟶ X), F.relativelyRepresentable g :=
-  ⟨fun h _ g => of_diag h g, fun h => diag_of_map_from_obj h⟩
+  ⟨fun h _ g => of_diagonal h g, fun h => diagonal_of_map_from_obj h⟩
+
+@[deprecated (since := "2026-09-06")] alias diag_iff := diagonal_iff
 
 end Diagonal
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -290,10 +290,12 @@ variable (C)
 
 /-- The diagonal functor. -/
 @[implicit_reducible, simps! obj map]
-def diag : C ⥤ C × C :=
+def diagonal : C ⥤ C × C :=
   (𝟭 C).prod' (𝟭 C)
 
 end
+
+@[deprecated (since := "2026-09-06")] alias diag := diagonal
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Subterminal.lean
+++ b/Mathlib/CategoryTheory/Subterminal.lean
@@ -83,27 +83,36 @@ theorem isSubterminal_of_terminal [HasTerminal C] : IsSubterminal (⊤_ C) := fu
   subsingleton
 
 /-- If `A` is subterminal, its diagonal morphism is an isomorphism.
-The converse of `isSubterminal_of_isIso_diag`.
+The converse of `isSubterminal_of_isIso_diagonal`.
 -/
-theorem IsSubterminal.isIso_diag (hA : IsSubterminal A) [HasBinaryProduct A A] : IsIso (diag A) :=
+theorem IsSubterminal.isIso_diagonal (hA : IsSubterminal A) [HasBinaryProduct A A] :
+    IsIso (prod.diagonal A) :=
   ⟨⟨Limits.prod.fst,
       ⟨by simp, by
         rw [IsSubterminal.def] at hA
         cat_disch⟩⟩⟩
 
+@[deprecated (since := "2026-09-06")] alias IsSubterminal.isIso_diag := IsSubterminal.isIso_diagonal
+
 /-- If the diagonal morphism of `A` is an isomorphism, then it is subterminal.
-The converse of `isSubterminal.isIso_diag`.
+The converse of `isSubterminal.isIso_diagonal`.
 -/
-theorem isSubterminal_of_isIso_diag [HasBinaryProduct A A] [IsIso (diag A)] : IsSubterminal A :=
+theorem isSubterminal_of_isIso_diagonal [HasBinaryProduct A A] [IsIso (prod.diagonal A)] :
+    IsSubterminal A :=
   fun Z f g => by
-  have : (Limits.prod.fst : A ⨯ A ⟶ _) = Limits.prod.snd := by simp [← cancel_epi (diag A)]
+  have : (Limits.prod.fst : A ⨯ A ⟶ _) = Limits.prod.snd := by simp [← cancel_epi (prod.diagonal A)]
   rw [← prod.lift_fst f g, this, prod.lift_snd]
+
+@[deprecated (since := "2026-09-06")]
+alias isSubterminal_of_isIso_diag := isSubterminal_of_isIso_diagonal
 
 /-- If `A` is subterminal, it is isomorphic to `A ⨯ A`. -/
 @[simps!]
-def IsSubterminal.isoDiag (hA : IsSubterminal A) [HasBinaryProduct A A] : A ⨯ A ≅ A := by
-  letI := IsSubterminal.isIso_diag hA
-  apply (asIso (diag A)).symm
+def IsSubterminal.isoDiagonal (hA : IsSubterminal A) [HasBinaryProduct A A] : A ⨯ A ≅ A := by
+  letI := IsSubterminal.isIso_diagonal hA
+  apply (asIso (prod.diagonal A)).symm
+
+@[deprecated (since := "2026-09-06")] alias IsSubterminal.isoDiag := IsSubterminal.isoDiagonal
 
 variable (C)
 

--- a/Mathlib/Combinatorics/Enumerative/Partition/Basic.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition/Basic.lean
@@ -128,18 +128,21 @@ def ofSymShapeEquiv (μ : Partition n) (e : σ ≃ τ) :
   left_inv := by intro x; simp
   right_inv := by intro x; simp
 
-/-- Convert a `Partition n` to a member of `(Finset.Icc 1 n).finsuppAntidiag n`
-(see `Nat.Partition.toFinsuppAntidiag_mem_finsuppAntidiag` for the proof).
-`p.toFinsuppAntidiag i` is defined as `i` times the number of occurrence of `i` in `p`. -/
-def toFinsuppAntidiag {n : ℕ} (p : Partition n) : ℕ →₀ ℕ where
+/-- Convert a `Partition n` to a member of `(Finset.Icc 1 n).finsuppAntidiagonal n`
+(see `Nat.Partition.toFinsuppAntidiagonal_mem_finsuppAntidiagonal` for the proof).
+`p.toFinsuppAntidiagonal i` is defined as `i` times the number of occurrence of `i` in `p`. -/
+def toFinsuppAntidiagonal {n : ℕ} (p : Partition n) : ℕ →₀ ℕ where
   toFun m := p.parts.count m * m
   support := p.parts.toFinset
   mem_support_toFun m := by
     suffices m ∈ p.parts → m ≠ 0 by simpa
     grind
 
-theorem toFinsuppAntidiag_injective (n : ℕ) : Function.Injective (toFinsuppAntidiag (n := n)) := by
-  unfold toFinsuppAntidiag
+@[deprecated (since := "2026-09-06")] alias toFinsuppAntidiag := toFinsuppAntidiagonal
+
+theorem toFinsuppAntidiagonal_injective (n : ℕ) :
+    Function.Injective (toFinsuppAntidiagonal (n := n)) := by
+  unfold toFinsuppAntidiagonal
   intro p q h
   rw [Finsupp.mk.injEq] at h
   obtain ⟨hfinset, hcount⟩ := h
@@ -149,16 +152,23 @@ theorem toFinsuppAntidiag_injective (n : ℕ) : Function.Injective (toFinsuppAnt
   · grind [Multiset.count_eq_zero]
   · exact Nat.eq_of_mul_eq_mul_right h0 <| funext_iff.mp hcount m
 
-theorem toFinsuppAntidiag_mem_finsuppAntidiag {n : ℕ} (p : Partition n) :
-    p.toFinsuppAntidiag ∈ (Finset.Icc 1 n).finsuppAntidiag n := by
+@[deprecated (since := "2026-09-06")]
+alias toFinsuppAntidiag_injective := toFinsuppAntidiagonal_injective
+
+theorem toFinsuppAntidiagonal_mem_finsuppAntidiagonal {n : ℕ} (p : Partition n) :
+    p.toFinsuppAntidiagonal ∈ (Finset.Icc 1 n).finsuppAntidiagonal n := by
   have hp : p.parts.toFinset ⊆ Finset.Icc 1 n := by
     grind
-  suffices ∑ m ∈ Finset.Icc 1 n, Multiset.count m p.parts * m = n by simpa [toFinsuppAntidiag, hp]
+  suffices ∑ m ∈ Finset.Icc 1 n, Multiset.count m p.parts * m = n by
+    simpa [toFinsuppAntidiagonal, hp]
   convert! ← p.parts_sum
   rw [Finset.sum_multiset_count]
   apply Finset.sum_subset hp
   suffices ∀ (x : ℕ), 1 ≤ x → x ≤ n → x ∉ p.parts → x ∉ p.parts ∨ x = 0 by simpa
   grind
+
+@[deprecated (since := "2026-09-06")]
+alias toFinsuppAntidiag_mem_finsuppAntidiag := toFinsuppAntidiagonal_mem_finsuppAntidiagonal
 
 /-- The partition of exactly one part. -/
 def indiscrete (n : ℕ) : Partition n := ofSums n {n} rfl

--- a/Mathlib/Combinatorics/Enumerative/Partition/GenFun.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition/GenFun.lean
@@ -91,7 +91,7 @@ theorem summable_genFun_term' (f : ℕ → ℕ → R) {i : ℕ} (hi : i ≠ 0) :
 variable [T2Space R]
 
 private theorem aux_dvd_of_coeff_ne_zero {f : ℕ → ℕ → R} {d : ℕ} {s : Finset ℕ} (hs0 : 0 ∉ s)
-    {g : ℕ →₀ ℕ} (hg : g ∈ s.finsuppAntidiag d)
+    {g : ℕ →₀ ℕ} (hg : g ∈ s.finsuppAntidiagonal d)
     (hprod : ∀ i ∈ s, (coeff (g i)) (1 + ∑' j, f i (j + 1) • X ^ (i * (j + 1))) ≠ (0 : R)) (x : ℕ) :
     x ∣ g x := by
   by_cases hx : x ∈ s
@@ -111,11 +111,11 @@ private theorem aux_dvd_of_coeff_ne_zero {f : ℕ → ℕ → R} {d : ℕ} {s : 
       simp [hprod]
   · suffices g x = 0 by simp [this]
     contrapose! hx
-    exact mem_of_subset (mem_finsuppAntidiag.mp hg).2 <| by simpa using hx
+    exact mem_of_subset (mem_finsuppAntidiagonal.mp hg).2 <| by simpa using hx
 
 private theorem aux_prod_coeff_eq_zero_of_notMem_range (f : ℕ → ℕ → R) {d : ℕ} {s : Finset ℕ}
-    (hs0 : 0 ∉ s) {g : ℕ →₀ ℕ} (hg : g ∈ s.finsuppAntidiag d)
-    (hg' : g ∉ Set.range (toFinsuppAntidiag (n := d))) :
+    (hs0 : 0 ∉ s) {g : ℕ →₀ ℕ} (hg : g ∈ s.finsuppAntidiagonal d)
+    (hg' : g ∉ Set.range (toFinsuppAntidiagonal (n := d))) :
     ∏ i ∈ s, (coeff (g i)) (1 + ∑' j, f i (j + 1) • X ^ (i * (j + 1)) : R⟦X⟧) = 0 := by
   suffices ∃ i ∈ s, (coeff (g i)) ((1 : R⟦X⟧) + ∑' j, f i (j + 1) • X ^ (i * (j + 1))) = 0 by
     obtain ⟨i, hi, hi'⟩ := this
@@ -125,24 +125,25 @@ private theorem aux_prod_coeff_eq_zero_of_notMem_range (f : ℕ → ℕ → R) {
   have hgne0 (i : ℕ) : g i ≠ 0 ↔ i ≠ 0 ∧ i ≤ g i := by
     refine ⟨fun h ↦ ⟨?_, ?_⟩, by grind⟩
     · contrapose hs0 with rfl
-      exact mem_of_subset (mem_finsuppAntidiag.mp hg).2 (by simpa using h)
+      exact mem_of_subset (mem_finsuppAntidiagonal.mp hg).2 (by simpa using h)
     · exact Nat.le_of_dvd (Nat.pos_of_ne_zero h) <| aux_dvd_of_coeff_ne_zero hs0 hg hprod _
   refine ⟨Nat.Partition.mk (Finsupp.mk g.support (fun i ↦ g i / i) ?_).toMultiset ?_ ?_, ?_⟩
   · simpa using hgne0
   · suffices ∀ i, g i ≠ 0 → i ≠ 0 by simpa [Nat.pos_iff_ne_zero]
     exact fun i h ↦ ((hgne0 i).mp h).1
-  · obtain ⟨h1, h2⟩ := mem_finsuppAntidiag.mp hg
+  · obtain ⟨h1, h2⟩ := mem_finsuppAntidiagonal.mp hg
     refine Eq.trans ?_ h1
     suffices ∑ x ∈ g.support, g x / x * x = ∑ x ∈ s, g x by simpa [Finsupp.sum]
     apply sum_subset_zero_on_sdiff h2 (by simp)
     exact fun x hx ↦ Nat.div_mul_cancel <| aux_dvd_of_coeff_ne_zero hs0 hg hprod x
   · ext x
-    simpa [toFinsuppAntidiag] using Nat.div_mul_cancel <| aux_dvd_of_coeff_ne_zero hs0 hg hprod x
+    simpa [toFinsuppAntidiagonal] using
+      Nat.div_mul_cancel <| aux_dvd_of_coeff_ne_zero hs0 hg hprod x
 
 private theorem aux_prod_f_eq_prod_coeff (f : ℕ → ℕ → R) {n : ℕ} (p : Partition n) {s : Finset ℕ}
     (hs : Icc 1 n ⊆ s) (hs0 : 0 ∉ s) :
     p.parts.toFinsupp.prod f =
-    ∏ i ∈ s, coeff (p.toFinsuppAntidiag i) (1 + ∑' j, f i (j + 1) • X ^ (i * (j + 1))) := by
+    ∏ i ∈ s, coeff (p.toFinsuppAntidiagonal i) (1 + ∑' j, f i (j + 1) • X ^ (i * (j + 1))) := by
   simp_rw [Finsupp.prod, Multiset.toFinsupp_support, Multiset.toFinsupp_apply]
   apply prod_subset_one_on_sdiff
   · grind
@@ -151,14 +152,14 @@ private theorem aux_prod_f_eq_prod_coeff (f : ℕ → ℕ → R) {n : ℕ} (p : 
     have hx0 : x ≠ 0 := fun h ↦ hs0 (h ▸ hx.1)
     have hsum := (summable_genFun_term' f hx0).map_tsum _
       (WithPiTopology.continuous_constantCoeff R)
-    simp [toFinsuppAntidiag, hsum, hx.2, hx0]
+    simp [toFinsuppAntidiagonal, hsum, hx.2, hx0]
   · intro i hi
     rw [Multiset.mem_toFinset] at hi
     have hi0 : i ≠ 0 := (p.parts_pos hi).ne.symm
     rw [map_add, (summable_genFun_term' f hi0).map_tsum _ (WithPiTopology.continuous_coeff _ _)]
     suffices f i (Multiset.count i p.parts) =
         ∑' j, if Multiset.count i p.parts * i = i * (j + 1) then f i (j + 1) else 0 by
-      simpa [toFinsuppAntidiag, hi, hi0, coeff_X_pow]
+      simpa [toFinsuppAntidiagonal, hi, hi0, coeff_X_pow]
     rw [tsum_eq_single (Multiset.count i p.parts - 1) ?_]
     · rw [mul_comm]
       simp [Nat.sub_add_cancel (Multiset.one_le_count_iff_mem.mpr hi)]
@@ -180,9 +181,11 @@ theorem hasProd_genFun (f : ℕ → ℕ → R) :
     intro h1 h2
     refine ⟨i - 1, mem_of_subset hs ?_, ?_⟩ <;> grind
   rw [coeff_genFun, coeff_prod]
-  refine (sum_of_injOn toFinsuppAntidiag (toFinsuppAntidiag_injective d).injOn ?_ ?_ ?_).symm
+  refine (sum_of_injOn toFinsuppAntidiagonal
+    (toFinsuppAntidiagonal_injective d).injOn ?_ ?_ ?_).symm
   · intro p _
-    exact mem_of_subset (finsuppAntidiag_mono hs _) p.toFinsuppAntidiag_mem_finsuppAntidiag
+    exact mem_of_subset (finsuppAntidiagonal_mono hs _)
+      p.toFinsuppAntidiagonal_mem_finsuppAntidiagonal
   · exact fun g hg hg' ↦ aux_prod_coeff_eq_zero_of_notMem_range f (by simp) hg (by simpa using hg')
   · exact fun p _ ↦ aux_prod_f_eq_prod_coeff f p hs (by simp)
 

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -379,7 +379,7 @@ theorem isAcyclic_sup_fromEdgeSet_iff {u v : V} :
     (G ⊔ edge u v).IsAcyclic ↔
       G.IsAcyclic ∧ (G.Reachable u v → u = v ∨ G.Adj u v) := by
   by_cases huv : u = v
-  · grind [sup_eq_left, edge_le, Sym2.mem_diagSet, Sym2.mk_isDiag_iff]
+  · grind [sup_eq_left, edge_le, Sym2.mem_diagonalSet, Sym2.mk_isDiagonal_iff]
   by_cases hadj : G.Adj u v
   · grind [sup_eq_left, edge_le, mem_edgeSet]
   refine ⟨?_, fun ⟨hacyc, hreach⟩ ↦ hacyc.sup_edge_of_not_reachable <| by grind⟩
@@ -413,7 +413,7 @@ theorem maximal_isAcyclic_iff_reachable_eq {F : SimpleGraph V} (hle : F ≤ G) (
   have ⟨H, hFH, hHG, hH⟩ := exists_gt_of_not_maximal ⟨hle, hF⟩ this
   have ⟨e, heH, heF⟩ := Set.exists_of_ssubset <| edgeSet_strict_mono hFH
   have h_bridge : (F ⊔ fromEdgeSet {e}).IsBridge e := by
-    refine isAcyclic_iff_forall_isBridge.mp ?_ <| by simp [H.not_isDiag_of_mem_edgeSet heH]
+    refine isAcyclic_iff_forall_isBridge.mp ?_ <| by simp [H.not_isDiagonal_of_mem_edgeSet heH]
     exact hH.anti <| sup_le_iff.mpr ⟨hFH.le, H.fromEdgeSet_le.mpr <| by grind⟩
   have : (F ⊔ fromEdgeSet {e}).deleteEdges {e} = F := by simpa using heF
   cases e

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -486,13 +486,22 @@ abbrev edgeSet (G : SimpleGraph V) : Set (Sym2 V) := edgeSetEmbedding V G
 theorem mem_edgeSet : s(v, w) ∈ G.edgeSet ↔ G.Adj v w :=
   Iff.rfl
 
-theorem not_isDiag_of_mem_edgeSet : e ∈ edgeSet G → ¬e.IsDiag :=
+theorem not_isDiagonal_of_mem_edgeSet : e ∈ edgeSet G → ¬e.IsDiagonal :=
   Sym2.ind (fun _ _ => Adj.ne) e
 
-@[simp] lemma not_mem_edgeSet_of_isDiag : e.IsDiag → e ∉ edgeSet G :=
-  imp_not_comm.1 G.not_isDiag_of_mem_edgeSet
+@[deprecated (since := "2026-09-06")]
+alias not_isDiag_of_mem_edgeSet := not_isDiagonal_of_mem_edgeSet
 
-alias _root_.Sym2.IsDiag.not_mem_edgeSet := not_mem_edgeSet_of_isDiag
+@[simp] lemma not_mem_edgeSet_of_isDiagonal : e.IsDiagonal → e ∉ edgeSet G :=
+  imp_not_comm.1 G.not_isDiagonal_of_mem_edgeSet
+
+@[deprecated (since := "2026-09-06")]
+alias not_mem_edgeSet_of_isDiag := not_mem_edgeSet_of_isDiagonal
+
+alias _root_.Sym2.IsDiagonal.not_mem_edgeSet := not_mem_edgeSet_of_isDiagonal
+
+@[deprecated (since := "2026-09-06")]
+alias _root_.Sym2.IsDiag.not_mem_edgeSet := not_mem_edgeSet_of_isDiagonal
 
 theorem edgeSet_inj : G₁.edgeSet = G₂.edgeSet ↔ G₁ = G₂ := (edgeSetEmbedding V).eq_iff_eq
 
@@ -516,12 +525,15 @@ theorem edgeSet_bot : (⊥ : SimpleGraph V).edgeSet = ∅ :=
   Sym2.fromRel_bot
 
 @[simp]
-theorem edgeSet_top : (⊤ : SimpleGraph V).edgeSet = Sym2.diagSetᶜ :=
-  Sym2.diagSet_compl_eq_fromRel_ne.symm
+theorem edgeSet_top : (⊤ : SimpleGraph V).edgeSet = Sym2.diagonalSetᶜ :=
+  Sym2.diagonalSet_compl_eq_fromRel_ne.symm
 
 @[simp]
-theorem edgeSet_subset_compl_diagSet : G.edgeSet ⊆ Sym2.diagSetᶜ := by
+theorem edgeSet_subset_compl_diagonalSet : G.edgeSet ⊆ Sym2.diagonalSetᶜ := by
   simpa [Set.subset_compl_iff_disjoint_left, edgeSet, edgeSetEmbedding] using G.loopless
+
+@[deprecated (since := "2026-09-06")]
+alias edgeSet_subset_compl_diagSet := edgeSet_subset_compl_diagonalSet
 
 @[simp]
 theorem edgeSet_sup : (G₁ ⊔ G₂).edgeSet = G₁.edgeSet ∪ G₂.edgeSet := by
@@ -577,9 +589,12 @@ theorem disjoint_of_disjoint_support (h : Disjoint G.support H.support) : Disjoi
 /-- This lemma, combined with `edgeSet_sdiff` and `edgeSet_fromEdgeSet`,
 allows proving `(G \ fromEdgeSet s).edgeSet = G.edgeSet \ s` by `simp`. -/
 @[simp]
-theorem edgeSet_sdiff_sdiff_isDiag (G : SimpleGraph V) (s : Set (Sym2 V)) :
-    G.edgeSet \ (s \ Sym2.diagSet) = G.edgeSet \ s := by
-  grind [Sym2.mem_diagSet, not_isDiag_of_mem_edgeSet]
+theorem edgeSet_sdiff_sdiff_isDiagonal (G : SimpleGraph V) (s : Set (Sym2 V)) :
+    G.edgeSet \ (s \ Sym2.diagonalSet) = G.edgeSet \ s := by
+  grind [Sym2.mem_diagonalSet, not_isDiagonal_of_mem_edgeSet]
+
+@[deprecated (since := "2026-09-06")]
+alias edgeSet_sdiff_sdiff_isDiag := edgeSet_sdiff_sdiff_isDiagonal
 
 /-- Two vertices are adjacent iff there is an edge between them. The
 condition `v ≠ w` ensures they are different endpoints of the edge,
@@ -658,7 +673,7 @@ theorem fromEdgeSet_adj : (fromEdgeSet s).Adj v w ↔ s(v, w) ∈ s ∧ v ≠ w 
 -- Note: we need to make sure `fromEdgeSet_adj` and this lemma are confluent.
 -- In particular, both yield `s(u, v) ∈ (fromEdgeSet s).edgeSet` ==> `s(v, w) ∈ s ∧ v ≠ w`.
 @[simp]
-theorem edgeSet_fromEdgeSet : (fromEdgeSet s).edgeSet = s \ Sym2.diagSet := by
+theorem edgeSet_fromEdgeSet : (fromEdgeSet s).edgeSet = s \ Sym2.diagonalSet := by
   ext e
   exact Sym2.ind (by simp) e
 
@@ -668,12 +683,12 @@ theorem fromEdgeSet_edgeSet : fromEdgeSet G.edgeSet = G := by
   exact ⟨fun h => h.1, fun h => ⟨h, G.ne_of_adj h⟩⟩
 
 @[simp] lemma le_fromEdgeSet_iff : G ≤ fromEdgeSet s ↔ G.edgeSet ⊆ s := by
-  simp [← edgeSet_subset_edgeSet, Set.subset_def]; grind [not_isDiag_of_mem_edgeSet]
+  simp [← edgeSet_subset_edgeSet, Set.subset_def]; grind [not_isDiagonal_of_mem_edgeSet]
 
 @[simp] lemma fromEdgeSet_le {s : Set (Sym2 V)} :
-    fromEdgeSet s ≤ G ↔ s \ Sym2.diagSet ⊆ G.edgeSet := by simp [← edgeSet_subset_edgeSet]
+    fromEdgeSet s ≤ G ↔ s \ Sym2.diagonalSet ⊆ G.edgeSet := by simp [← edgeSet_subset_edgeSet]
 
-lemma edgeSet_eq_iff : G.edgeSet = s ↔ G = fromEdgeSet s ∧ Disjoint s Sym2.diagSet where
+lemma edgeSet_eq_iff : G.edgeSet = s ↔ G = fromEdgeSet s ∧ Disjoint s Sym2.diagonalSet where
   mp := by rintro rfl; simp +contextual [Set.disjoint_right]
   mpr := by rintro ⟨rfl, hs⟩; simp [hs]
 
@@ -682,7 +697,9 @@ theorem fromEdgeSet_empty : fromEdgeSet (∅ : Set (Sym2 V)) = ⊥ := by
   ext v w
   simp only [fromEdgeSet_adj, Set.mem_empty_iff_false, false_and, bot_adj]
 
-@[simp] lemma fromEdgeSet_not_isDiag : @fromEdgeSet V Sym2.diagSetᶜ = ⊤ := by ext; simp
+@[simp] lemma fromEdgeSet_not_isDiagonal : @fromEdgeSet V Sym2.diagonalSetᶜ = ⊤ := by ext; simp
+
+@[deprecated (since := "2026-09-06")] alias fromEdgeSet_not_isDiag := fromEdgeSet_not_isDiagonal
 
 @[simp]
 theorem fromEdgeSet_univ : fromEdgeSet (Set.univ : Set (Sym2 V)) = ⊤ := by
@@ -734,9 +751,9 @@ theorem fromEdgeSet_mono {s t : Set (Sym2 V)} (h : s ⊆ t) : fromEdgeSet s ≤ 
   simp only [le_fromEdgeSet_iff, edgeSet_fromEdgeSet]; grw [h]; exact sdiff_le
 
 @[simp] lemma disjoint_fromEdgeSet : Disjoint G (fromEdgeSet s) ↔ Disjoint G.edgeSet s := by
-  conv_rhs => rw [← Set.sdiff_union_inter s Sym2.diagSet]
+  conv_rhs => rw [← Set.sdiff_union_inter s Sym2.diagonalSet]
   rw [← disjoint_edgeSet, edgeSet_fromEdgeSet]
-  grind [edgeSet_subset_compl_diagSet]
+  grind [edgeSet_subset_compl_diagonalSet]
 
 @[simp] lemma fromEdgeSet_disjoint : Disjoint (fromEdgeSet s) G ↔ Disjoint s G.edgeSet := by
   rw [disjoint_comm, disjoint_fromEdgeSet, disjoint_comm]

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -653,7 +653,7 @@ lemma free_killCopies (hH : H ≠ ⊥) : H.Free (G.killCopies H) := by
   have he' : e' ∈ G'.coe.edgeSet := (Iso.map_mem_edgeSet_iff _).2 he₀
   rw [Subgraph.edgeSet_coe] at he'
   have := Subgraph.edgeSet_subset _ he'
-  simp only [edgeSet_sdiff, edgeSet_fromEdgeSet, edgeSet_sdiff_sdiff_isDiag, Set.mem_sdiff,
+  simp only [edgeSet_sdiff, edgeSet_fromEdgeSet, edgeSet_sdiff_sdiff_isDiagonal, Set.mem_sdiff,
     Set.mem_iUnion, not_exists] at this
   refine this.2 (G'.map <| .ofLE sdiff_le) ⟨((Copy.ofLE _ _ _).isoSubgraphMap _).comp hHG'.some⟩ ?_
   rw [Sym2.map_map, Set.mem_singleton_iff, ← he₁]

--- a/Mathlib/Combinatorics/SimpleGraph/DeleteEdges.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DeleteEdges.lean
@@ -61,7 +61,7 @@ instance [DecidableRel G.Adj] [DecidablePred (· ∈ s)] [DecidableEq V] :
 theorem deleteEdges_deleteEdges (s s' : Set (Sym2 V)) :
     (G.deleteEdges s).deleteEdges s' = G.deleteEdges (s ∪ s') := by simp [deleteEdges, sdiff_sdiff]
 
--- This is not marked `simp` since `deleteEdges_of_subset_diagSet` already proves it
+-- This is not marked `simp` since `deleteEdges_of_subset_diagonalSet` already proves it
 lemma deleteEdges_empty : G.deleteEdges ∅ = G := by simp [deleteEdges]
 @[simp] lemma deleteEdges_univ : G.deleteEdges Set.univ = ⊥ := by simp [deleteEdges]
 
@@ -86,8 +86,11 @@ theorem deleteEdges_eq_inter_edgeSet (s : Set (Sym2 V)) :
   ext
   simp +contextual [imp_false]
 
-@[simp] lemma deleteEdges_of_subset_diagSet (G : SimpleGraph V) (hs : s ⊆ Sym2.diagSet) :
+@[simp] lemma deleteEdges_of_subset_diagonalSet (G : SimpleGraph V) (hs : s ⊆ Sym2.diagonalSet) :
     G.deleteEdges s = G := by ext u v; simpa using (·.ne <| hs ·)
+
+@[deprecated (since := "2026-09-06")]
+alias deleteEdges_of_subset_diagSet := deleteEdges_of_subset_diagonalSet
 
 theorem deleteEdges_sdiff_eq_of_le {H : SimpleGraph V} (h : H ≤ G) :
     G.deleteEdges (G.edgeSet \ H.edgeSet) = H := by
@@ -130,7 +133,7 @@ lemma deleteIncidenceSet_le (G : SimpleGraph V) (x : V) : G.deleteIncidenceSet x
 lemma edgeSet_fromEdgeSet_incidenceSet (G : SimpleGraph V) (x : V) :
     (fromEdgeSet (G.incidenceSet x)).edgeSet = G.incidenceSet x := by
   rw [edgeSet_fromEdgeSet, sdiff_eq_left, ← Set.subset_compl_iff_disjoint_right]
-  exact (incidenceSet_subset G x).trans G.edgeSet_subset_compl_diagSet
+  exact (incidenceSet_subset G x).trans G.edgeSet_subset_compl_diagonalSet
 
 /-- The edge set of `G.deleteIncidenceSet x` is the edge set of `G` set difference the incidence
 set of the vertex `x`. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -69,13 +69,16 @@ variable {G}
 theorem mem_edgeFinset : e ∈ G.edgeFinset ↔ e ∈ G.edgeSet :=
   Set.mem_toFinset
 
-theorem not_isDiag_of_mem_edgeFinset : e ∈ G.edgeFinset → ¬e.IsDiag :=
-  not_isDiag_of_mem_edgeSet _ ∘ mem_edgeFinset.1
+theorem not_isDiagonal_of_mem_edgeFinset : e ∈ G.edgeFinset → ¬e.IsDiagonal :=
+  not_isDiagonal_of_mem_edgeSet _ ∘ mem_edgeFinset.1
+
+@[deprecated (since := "2026-09-06")]
+alias not_isDiag_of_mem_edgeFinset := not_isDiagonal_of_mem_edgeFinset
 
 /-- Mapping an edge to a finite set produces a finset of size `2`. -/
 theorem card_toFinset_mem_edgeFinset [DecidableEq V] (e : G.edgeFinset) :
     (e : Sym2 V).toFinset.card = 2 :=
-  Sym2.card_toFinset_of_not_isDiag e.val (G.not_isDiag_of_mem_edgeFinset e.prop)
+  Sym2.card_toFinset_of_not_isDiagonal e.val (G.not_isDiagonal_of_mem_edgeFinset e.prop)
 
 @[simp]
 theorem edgeFinset_inj : G₁.edgeFinset = G₂.edgeFinset ↔ G₁ = G₂ := by simp [edgeFinset]
@@ -134,12 +137,12 @@ variable [Fintype V]
 
 @[simp]
 theorem edgeFinset_top [DecidableEq V] :
-    (⊤ : SimpleGraph V).edgeFinset = Sym2.diagSetᶜ.toFinset := by simp [← coe_inj]
+    (⊤ : SimpleGraph V).edgeFinset = Sym2.diagonalSetᶜ.toFinset := by simp [← coe_inj]
 
 /-- The complete graph on `n` vertices has `n.choose 2` edges. -/
 theorem card_edgeFinset_top_eq_card_choose_two [DecidableEq V] :
     #(⊤ : SimpleGraph V).edgeFinset = (Fintype.card V).choose 2 := by
-  simp_rw [edgeFinset, Set.toFinset_card, edgeSet_top, ← Sym2.card_diagSet_compl]
+  simp_rw [edgeFinset, Set.toFinset_card, edgeSet_top, ← Sym2.card_diagonalSet_compl]
 
 /-- Any graph on `n` vertices has at most `n.choose 2` edges. -/
 theorem card_edgeFinset_le_card_choose_two : #G.edgeFinset ≤ (Fintype.card V).choose 2 := by

--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -146,7 +146,7 @@ lemma adj_edge {v w : V} : (edge s t).Adj v w ↔ s(s, t) = s(v, w) ∧ v ≠ w 
 lemma edge_comm : edge s t = edge t s := by
   rw [edge, edge, Sym2.eq_swap]
 
-@[simp] lemma edge_le : edge s t ≤ G ↔ {s(s, t)} \ Sym2.diagSet ⊆ G.edgeSet := by simp [edge]
+@[simp] lemma edge_le : edge s t ≤ G ↔ {s(s, t)} \ Sym2.diagonalSet ⊆ G.edgeSet := by simp [edge]
 
 variable [DecidableEq V] in
 instance : DecidableRel (edge s t).Adj := fun _ _ ↦ by
@@ -168,7 +168,7 @@ lemma edge_le_iff {v w : V} : edge v w ≤ G ↔ v = w ∨ G.Adj v w := by
     grind [adj_symm]
 
 @[simp]
-lemma edgeSet_edge (v w : V) : (edge v w).edgeSet = {s(v, w)} \ Sym2.diagSet := by simp [edge]
+lemma edgeSet_edge (v w : V) : (edge v w).edgeSet = {s(v, w)} \ Sym2.diagonalSet := by simp [edge]
 
 lemma edgeSet_edge_subset {v w : V} : (edge v w).edgeSet ⊆ {s(v, w)} := by simp [edge]
 
@@ -195,7 +195,7 @@ lemma sdiff_edge {u v : V} (h : ¬G.Adj u v) : G \ edge u v = G := by
 theorem biSup_fromEdgeSet_singleton_eq : ⨆ e ∈ G.edgeSet, fromEdgeSet {e} = G := by
   simp_rw [← edgeSet_inj, ← iSup_subtype'', edgeSet_iSup, edgeSet_fromEdgeSet, ← Set.iUnion_sdiff,
     Set.iUnion_coe_set, Set.biUnion_of_singleton]
-  exact Set.disjoint_left.mpr G.edgeSet_subset_compl_diagSet |>.sdiff_eq_left
+  exact Set.disjoint_left.mpr G.edgeSet_subset_compl_diagonalSet |>.sdiff_eq_left
 
 theorem sSup_edge_eq : sSup { edge u v | (u : V) (v : V) (_ : G.Adj u v) } = G := by
   refine .trans ?_ G.biSup_fromEdgeSet_singleton_eq

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
@@ -38,7 +38,7 @@ namespace Finpartition
 /-- The energy of a partition, also known as index. Auxiliary quantity for Szemerédi's regularity
 lemma. -/
 def energy : ℚ :=
-  ((∑ uv ∈ P.parts.offDiag, G.edgeDensity uv.1 uv.2 ^ 2) : ℚ) / (#P.parts : ℚ) ^ 2
+  ((∑ uv ∈ P.parts.offDiagonal, G.edgeDensity uv.1 uv.2 ^ 2) : ℚ) / (#P.parts : ℚ) ^ 2
 
 theorem energy_nonneg : 0 ≤ P.energy G := by
   exact div_nonneg (Finset.sum_nonneg fun _ _ => sq_nonneg _) <| sq_nonneg _
@@ -46,12 +46,12 @@ theorem energy_nonneg : 0 ≤ P.energy G := by
 theorem energy_le_one : P.energy G ≤ 1 :=
   div_le_of_le_mul₀ (sq_nonneg _) zero_le_one <|
     calc
-      ∑ uv ∈ P.parts.offDiag, G.edgeDensity uv.1 uv.2 ^ 2 ≤ #P.parts.offDiag • (1 : ℚ) :=
+      ∑ uv ∈ P.parts.offDiagonal, G.edgeDensity uv.1 uv.2 ^ 2 ≤ #P.parts.offDiagonal • (1 : ℚ) :=
         sum_le_card_nsmul _ _ 1 fun _ _ =>
           (sq_le_one_iff₀ <| G.edgeDensity_nonneg _ _).2 <| G.edgeDensity_le_one _ _
-      _ = #P.parts.offDiag := Nat.smul_one_eq_cast _
+      _ = #P.parts.offDiagonal := Nat.smul_one_eq_cast _
       _ ≤ _ := by
-        rw [offDiag_card, one_mul]
+        rw [offDiagonal_card, one_mul]
         norm_cast
         rw [sq]
         exact tsub_le_self
@@ -59,7 +59,7 @@ theorem energy_le_one : P.energy G ≤ 1 :=
 @[simp, norm_cast]
 theorem coe_energy {𝕜 : Type*} [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] :
     (P.energy G : 𝕜) =
-      (∑ uv ∈ P.parts.offDiag, (G.edgeDensity uv.1 uv.2 : 𝕜) ^ 2) / (#P.parts : 𝕜) ^ 2 := by
+      (∑ uv ∈ P.parts.offDiagonal, (G.edgeDensity uv.1 uv.2 : 𝕜) ^ 2) / (#P.parts : 𝕜) ^ 2 := by
   rw [energy]; norm_cast
 
 end Finpartition

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
@@ -87,18 +87,19 @@ theorem increment_isEquipartition : (increment hP G ε).IsEquipartition := by
 
 set_option backward.privateInPublic true in
 /-- The contribution to `Finpartition.energy` of a pair of distinct parts of a `Finpartition`. -/
-private noncomputable def distinctPairs (x : {x // x ∈ P.parts.offDiag}) :
+private noncomputable def distinctPairs (x : {x // x ∈ P.parts.offDiagonal}) :
     Finset (Finset α × Finset α) :=
-  (chunk hP G ε (mem_offDiag.1 x.2).1).parts ×ˢ (chunk hP G ε (mem_offDiag.1 x.2).2.1).parts
+  (chunk hP G ε (mem_offDiagonal.1 x.2).1).parts ×ˢ (chunk hP G ε (mem_offDiagonal.1 x.2).2.1).parts
 
 variable {hP G ε}
 
 private theorem distinctPairs_increment :
-    P.parts.offDiag.attach.biUnion (distinctPairs hP G ε) ⊆ (increment hP G ε).parts.offDiag := by
+    P.parts.offDiagonal.attach.biUnion (distinctPairs hP G ε) ⊆
+      (increment hP G ε).parts.offDiagonal := by
   rintro ⟨Ui, Vj⟩
-  simp only [distinctPairs, increment, mem_offDiag, bind_parts, mem_biUnion, Prod.exists,
+  simp only [distinctPairs, increment, mem_offDiagonal, bind_parts, mem_biUnion, Prod.exists,
     mem_product, mem_attach, true_and, Subtype.exists, and_imp,
-    mem_offDiag, forall_exists_index, Ne]
+    mem_offDiagonal, forall_exists_index, Ne]
   refine fun U V hUV hUi hVj => ⟨⟨_, hUV.1, hUi⟩, ⟨_, hUV.2.1, hVj⟩, ?_⟩
   rintro rfl
   obtain ⟨i, hi⟩ := nonempty_of_mem_parts _ hUi
@@ -106,12 +107,12 @@ private theorem distinctPairs_increment :
     Finpartition.le _ hVj hi)
 
 private lemma pairwiseDisjoint_distinctPairs :
-    (P.parts.offDiag.attach : Set {x // x ∈ P.parts.offDiag}).PairwiseDisjoint
+    (P.parts.offDiagonal.attach : Set {x // x ∈ P.parts.offDiagonal}).PairwiseDisjoint
       (distinctPairs hP G ε) := by
   simp +unfoldPartialApp only [distinctPairs, Set.PairwiseDisjoint,
     Function.onFun, Finset.disjoint_left, mem_product]
   rintro ⟨⟨s₁, s₂⟩, hs⟩ _ ⟨⟨t₁, t₂⟩, ht⟩ _ hst ⟨u, v⟩ huv₁ huv₂
-  rw [mem_offDiag] at hs ht
+  rw [mem_offDiagonal] at hs ht
   obtain ⟨a, ha⟩ := Finpartition.nonempty_of_mem_parts _ huv₁.1
   obtain ⟨b, hb⟩ := Finpartition.nonempty_of_mem_parts _ huv₁.2
   exact hst <| Subtype.ext <| Prod.ext
@@ -124,7 +125,7 @@ variable [Nonempty α]
 
 set_option backward.privateInPublic true in
 set_option backward.privateInPublic.warn false in
-lemma le_sum_distinctPairs_edgeDensity_sq (x : {i // i ∈ P.parts.offDiag}) (hε₁ : ε ≤ 1)
+lemma le_sum_distinctPairs_edgeDensity_sq (x : {i // i ∈ P.parts.offDiagonal}) (hε₁ : ε ≤ 1)
     (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5) :
     (G.edgeDensity x.1.1 x.1.2 : ℝ) ^ 2 +
       ((if G.IsUniform ε x.1.1 x.1.2 then 0 else ε ^ 4 / 3) - ε ^ 5 / 25) ≤
@@ -133,7 +134,7 @@ lemma le_sum_distinctPairs_edgeDensity_sq (x : {i // i ∈ P.parts.offDiag}) (h�
   split_ifs with h
   · rw [add_zero]
     exact edgeDensity_chunk_uniform hPα hPε _ _
-  · exact edgeDensity_chunk_not_uniform hPα hPε hε₁ (mem_offDiag.1 x.2).2.2 h
+  · exact edgeDensity_chunk_not_uniform hPα hPε hε₁ (mem_offDiagonal.1 x.2).2.2 h
 
 /-- The increment partition has energy greater than the original one by a known fixed amount. -/
 theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ #P.parts)
@@ -141,12 +142,12 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ #P.parts)
     (hPG : ¬P.IsUniform G ε) (hε₀ : 0 ≤ ε) (hε₁ : ε ≤ 1) :
     ↑(P.energy G) + ε ^ 5 / 4 ≤ (increment hP G ε).energy G := by
   calc
-    _ = (∑ x ∈ P.parts.offDiag, (G.edgeDensity x.1 x.2 : ℝ) ^ 2 +
+    _ = (∑ x ∈ P.parts.offDiagonal, (G.edgeDensity x.1 x.2 : ℝ) ^ 2 +
           #P.parts ^ 2 * (ε ^ 5 / 4) : ℝ) / #P.parts ^ 2 := by
         rw [coe_energy, add_div, mul_div_cancel_left₀]; positivity
-    _ ≤ (∑ x ∈ P.parts.offDiag.attach, (∑ i ∈ distinctPairs hP G ε x,
+    _ ≤ (∑ x ∈ P.parts.offDiagonal.attach, (∑ i ∈ distinctPairs hP G ε x,
           G.edgeDensity i.1 i.2 ^ 2 : ℝ) / 16 ^ #P.parts) / #P.parts ^ 2 := ?_
-    _ = (∑ x ∈ P.parts.offDiag.attach, ∑ i ∈ distinctPairs hP G ε x,
+    _ = (∑ x ∈ P.parts.offDiagonal.attach, ∑ i ∈ distinctPairs hP G ε x,
           G.edgeDensity i.1 i.2 ^ 2 : ℝ) / #(increment hP G ε).parts ^ 2 := by
         rw [card_increment hPα hPG, coe_stepBound, mul_pow, pow_right_comm,
           div_mul_eq_div_div_swap, ← sum_div]; norm_num
@@ -156,11 +157,11 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ #P.parts)
         rw [← sum_biUnion pairwiseDisjoint_distinctPairs]
         exact sum_le_sum_of_subset_of_nonneg distinctPairs_increment fun i _ _ ↦ sq_nonneg _
   gcongr
-  rw [Finpartition.IsUniform, not_le, mul_tsub, mul_one, ← offDiag_card] at hPG
+  rw [Finpartition.IsUniform, not_le, mul_tsub, mul_one, ← offDiagonal_card] at hPG
   calc
-    _ ≤ ∑ x ∈ P.parts.offDiag, (edgeDensity G x.1 x.2 : ℝ) ^ 2 +
-        (#(nonUniforms P G ε) * (ε ^ 4 / 3) - #P.parts.offDiag * (ε ^ 5 / 25)) := ?_
-    _ = ∑ x ∈ P.parts.offDiag, ((G.edgeDensity x.1 x.2 : ℝ) ^ 2 +
+    _ ≤ ∑ x ∈ P.parts.offDiagonal, (edgeDensity G x.1 x.2 : ℝ) ^ 2 +
+        (#(nonUniforms P G ε) * (ε ^ 4 / 3) - #P.parts.offDiagonal * (ε ^ 5 / 25)) := ?_
+    _ = ∑ x ∈ P.parts.offDiagonal, ((G.edgeDensity x.1 x.2 : ℝ) ^ 2 +
         ((if G.IsUniform ε x.1 x.2 then (0 : ℝ) else ε ^ 4 / 3) - ε ^ 5 / 25) : ℝ) := by
         rw [sum_add_distrib, sum_sub_distrib, sum_const, nsmul_eq_mul, sum_ite, sum_const_zero,
           zero_add, sum_const, nsmul_eq_mul, ← Finpartition.nonUniforms, ← add_sub_assoc,
@@ -170,15 +171,15 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ #P.parts)
   gcongr
   calc
     _ = (6 / 7 * #P.parts ^ 2) * ε ^ 5 * (7 / 24) := by ring
-    _ ≤ #P.parts.offDiag * ε ^ 5 * (22 / 75) := by
+    _ ≤ #P.parts.offDiagonal * ε ^ 5 * (22 / 75) := by
         gcongr ?_ * _ * ?_
-        · rw [← mul_div_right_comm, div_le_iff₀ (by simp), offDiag_card]
+        · rw [← mul_div_right_comm, div_le_iff₀ (by simp), offDiagonal_card]
           norm_cast
           rw [tsub_mul]
           refine le_tsub_of_add_le_left ?_
           nlinarith
         · norm_num
-    _ = (#P.parts.offDiag * ε * (ε ^ 4 / 3) - #P.parts.offDiag * (ε ^ 5 / 25)) := by ring
-    _ ≤ (#(nonUniforms P G ε) * (ε ^ 4 / 3) - #P.parts.offDiag * (ε ^ 5 / 25)) := by gcongr
+    _ = (#P.parts.offDiagonal * ε * (ε ^ 4 / 3) - #P.parts.offDiagonal * (ε ^ 5 / 25)) := by ring
+    _ ≤ (#(nonUniforms P G ε) * (ε ^ 4 / 3) - #P.parts.offDiagonal * (ε ^ 5 / 25)) := by gcongr
 
 end SzemerediRegularity

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -199,13 +199,13 @@ namespace Finpartition
 /-- The pairs of parts of a partition `P` which are not `ε`-dense in a graph `G`. Note that we
 dismiss the diagonal. We do not care whether `s` is `ε`-dense with itself. -/
 def sparsePairs (ε : 𝕜) : Finset (Finset α × Finset α) :=
-  P.parts.offDiag.filter fun (u, v) ↦ G.edgeDensity u v < ε
+  P.parts.offDiagonal.filter fun (u, v) ↦ G.edgeDensity u v < ε
 
 omit [IsStrictOrderedRing 𝕜] in
 @[simp]
 lemma mk_mem_sparsePairs (u v : Finset α) (ε : 𝕜) :
     (u, v) ∈ P.sparsePairs G ε ↔ u ∈ P.parts ∧ v ∈ P.parts ∧ u ≠ v ∧ G.edgeDensity u v < ε := by
-  rw [sparsePairs, mem_filter, mem_offDiag, and_assoc, and_assoc]
+  rw [sparsePairs, mem_filter, mem_offDiagonal, and_assoc, and_assoc]
 
 omit [IsStrictOrderedRing 𝕜] in
 lemma sparsePairs_mono {ε ε' : 𝕜} (h : ε ≤ ε') : P.sparsePairs G ε ⊆ P.sparsePairs G ε' :=
@@ -214,12 +214,12 @@ lemma sparsePairs_mono {ε ε' : 𝕜} (h : ε ≤ ε') : P.sparsePairs G ε ⊆
 /-- The pairs of parts of a partition `P` which are not `ε`-uniform in a graph `G`. Note that we
 dismiss the diagonal. We do not care whether `s` is `ε`-uniform with itself. -/
 def nonUniforms (ε : 𝕜) : Finset (Finset α × Finset α) :=
-  P.parts.offDiag.filter fun (u, v) ↦ ¬G.IsUniform ε u v
+  P.parts.offDiagonal.filter fun (u, v) ↦ ¬G.IsUniform ε u v
 
 omit [IsStrictOrderedRing 𝕜] in
 @[simp] lemma mk_mem_nonUniforms :
     (u, v) ∈ P.nonUniforms G ε ↔ u ∈ P.parts ∧ v ∈ P.parts ∧ u ≠ v ∧ ¬G.IsUniform ε u v := by
-  rw [nonUniforms, mem_filter, mem_offDiag, and_assoc, and_assoc]
+  rw [nonUniforms, mem_filter, mem_offDiagonal, and_assoc, and_assoc]
 
 theorem nonUniforms_mono {ε ε' : 𝕜} (h : ε ≤ ε') : P.nonUniforms G ε' ⊆ P.nonUniforms G ε :=
   monotone_filter_right _ fun _ _ => mt <| SimpleGraph.IsUniform.mono h
@@ -246,7 +246,7 @@ lemma isUniform_one : P.IsUniform G (1 : 𝕜) := by
   rw [IsUniform, mul_one, Nat.cast_le]
   refine (card_filter_le _
     (fun uv => ¬SimpleGraph.IsUniform G 1 (Prod.fst uv) (Prod.snd uv))).trans ?_
-  rw [offDiag_card, Nat.mul_sub_left_distrib, mul_one]
+  rw [offDiagonal_card, Nat.mul_sub_left_distrib, mul_one]
 
 variable {P G}
 
@@ -285,8 +285,8 @@ lemma IsEquipartition.card_interedges_sparsePairs_le' (hP : P.IsEquipartition)
   calc
     _ ≤ ∑ UV ∈ P.sparsePairs G ε, (#(G.interedges UV.1 UV.2) : 𝕜) := mod_cast card_biUnion_le
     _ ≤ ∑ UV ∈ P.sparsePairs G ε, ε * (#UV.1 * #UV.2) := ?_
-    _ ≤ ∑ UV ∈ P.parts.offDiag, ε * (#UV.1 * #UV.2) := by gcongr; apply filter_subset
-    _ = ε * ∑ UV ∈ P.parts.offDiag, (#UV.1 * #UV.2 : 𝕜) := (mul_sum _ _ _).symm
+    _ ≤ ∑ UV ∈ P.parts.offDiagonal, ε * (#UV.1 * #UV.2) := by gcongr; apply filter_subset
+    _ = ε * ∑ UV ∈ P.parts.offDiagonal, (#UV.1 * #UV.2 : 𝕜) := (mul_sum _ _ _).symm
     _ ≤ _ := ?_
   · gcongr with ⟨U, V⟩ hUV
     simp only [mk_mem_sparsePairs, ne_eq, ← card_interedges_div_card, Rat.cast_div,
@@ -297,15 +297,16 @@ lemma IsEquipartition.card_interedges_sparsePairs_le' (hP : P.IsEquipartition)
   norm_cast
   gcongr
   calc
-    (_ : ℕ) ≤ _ := sum_le_card_nsmul P.parts.offDiag (fun i ↦ #i.1 * #i.2)
+    (_ : ℕ) ≤ _ := sum_le_card_nsmul P.parts.offDiagonal (fun i ↦ #i.1 * #i.2)
             ((#A / #P.parts + 1) ^ 2 : ℕ) ?_
     _ ≤ (#P.parts * (#A / #P.parts) + #P.parts) ^ 2 := ?_
     _ ≤ _ := by gcongr; apply Nat.mul_div_le
-  · simp only [Prod.forall, and_imp, mem_offDiag, sq]
+  · simp only [Prod.forall, and_imp, mem_offDiagonal, sq]
     rintro U V hU hV -
     exact_mod_cast Nat.mul_le_mul (hP.card_part_le_average_add_one hU)
       (hP.card_part_le_average_add_one hV)
-  · rw [smul_eq_mul, offDiag_card, Nat.mul_sub_right_distrib, ← sq, ← mul_pow, mul_add_one (α := ℕ)]
+  · rw [smul_eq_mul, offDiagonal_card, Nat.mul_sub_right_distrib, ← sq, ← mul_pow,
+      mul_add_one (α := ℕ)]
     exact Nat.sub_le _ _
 
 lemma IsEquipartition.card_interedges_sparsePairs_le (hP : P.IsEquipartition) (hε : 0 ≤ ε) :
@@ -323,8 +324,8 @@ private lemma aux {i j : ℕ} (hj : 0 < j) : j * (j - 1) * (i / j + 1) ^ 2 < (i 
   gcongr
   apply Nat.mul_div_le
 
-lemma IsEquipartition.card_biUnion_offDiag_le' (hP : P.IsEquipartition) :
-    (#(P.parts.biUnion offDiag) : 𝕜) ≤ #A * (#A + #P.parts) / #P.parts := by
+lemma IsEquipartition.card_biUnion_offDiagonal_le' (hP : P.IsEquipartition) :
+    (#(P.parts.biUnion offDiagonal) : 𝕜) ≤ #A * (#A + #P.parts) / #P.parts := by
   obtain h | h := P.parts.eq_empty_or_nonempty
   · simp [h]
   calc
@@ -336,16 +337,19 @@ lemma IsEquipartition.card_biUnion_offDiag_le' (hP : P.IsEquipartition) :
     _ = _ := by rw [← div_add_same (mod_cast h.card_pos.ne'), mul_div_assoc]
   · simpa using Nat.cast_div_le
   suffices (#U - 1) * #U ≤ #A / #P.parts * (#A / #P.parts + 1) by
-    rwa [Nat.mul_sub_right_distrib, one_mul, ← offDiag_card] at this
+    rwa [Nat.mul_sub_right_distrib, one_mul, ← offDiagonal_card] at this
   have := hP.card_part_le_average_add_one hU
   refine Nat.mul_le_mul ((Nat.sub_le_sub_right this 1).trans ?_) this
   simp only [Nat.add_succ_sub_one, add_zero, le_rfl]
 
-lemma IsEquipartition.card_biUnion_offDiag_le (hε : 0 < ε) (hP : P.IsEquipartition)
-    (hP' : 4 / ε ≤ #P.parts) : #(P.parts.biUnion offDiag) ≤ ε / 2 * #A ^ 2 := by
+@[deprecated (since := "2026-09-06")]
+alias IsEquipartition.card_biUnion_offDiag_le' := IsEquipartition.card_biUnion_offDiagonal_le'
+
+lemma IsEquipartition.card_biUnion_offDiagonal_le (hε : 0 < ε) (hP : P.IsEquipartition)
+    (hP' : 4 / ε ≤ #P.parts) : #(P.parts.biUnion offDiagonal) ≤ ε / 2 * #A ^ 2 := by
   obtain rfl | hA : A = ⊥ ∨ _ := A.eq_empty_or_nonempty
   · simp [Subsingleton.elim P ⊥]
-  apply hP.card_biUnion_offDiag_le'.trans
+  apply hP.card_biUnion_offDiagonal_le'.trans
   rw [div_le_iff₀ (Nat.cast_pos.2 (P.parts_nonempty hA.ne_empty).card_pos)]
   have : (#A : 𝕜) + #P.parts ≤ 2 * #A := by
     rw [two_mul]; gcongr; exact P.card_parts_le_card
@@ -356,6 +360,9 @@ lemma IsEquipartition.card_biUnion_offDiag_le (hε : 0 < ε) (hP : P.IsEquiparti
       <;> ring
   rwa [← div_le_iff₀', one_div_div]
   positivity
+
+@[deprecated (since := "2026-09-06")]
+alias IsEquipartition.card_biUnion_offDiag_le := IsEquipartition.card_biUnion_offDiagonal_le
 
 lemma IsEquipartition.sum_nonUniforms_lt' (hA : A.Nonempty) (hε : 0 < ε) (hP : P.IsEquipartition)
     (hG : P.IsUniform G ε) :
@@ -424,11 +431,11 @@ lemma regularityReduced_anti {δ₁ δ₂ : 𝕜} (hδ : δ₁ ≤ δ₂) :
 omit [IsStrictOrderedRing 𝕜] in
 lemma unreduced_edges_subset :
     (A ×ˢ A).filter (fun (x, y) ↦ G.Adj x y ∧ ¬ (G.regularityReduced P (ε / 8) (ε / 4)).Adj x y) ⊆
-      (P.nonUniforms G (ε / 8)).biUnion (fun (U, V) ↦ U ×ˢ V) ∪ P.parts.biUnion offDiag ∪
+      (P.nonUniforms G (ε / 8)).biUnion (fun (U, V) ↦ U ×ˢ V) ∪ P.parts.biUnion offDiagonal ∪
         (P.sparsePairs G (ε / 4)).biUnion fun (U, V) ↦ G.interedges U V := by
   rintro ⟨x, y⟩
   simp only [mem_filter, regularityReduced_adj, not_and, not_exists,
-    not_le, mem_biUnion, mem_union, mem_product, Prod.exists, mem_offDiag, and_imp,
+    not_le, mem_biUnion, mem_union, mem_product, Prod.exists, mem_offDiagonal, and_imp,
     or_assoc, and_assoc, P.mk_mem_nonUniforms, Finpartition.mk_mem_sparsePairs, mem_interedges_iff]
   intro hx hy h h'
   replace h' := h' h

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
@@ -89,7 +89,8 @@ lemma LocallyLinear.map (f : α ↪ β) (hG : G.LocallyLinear) : (G.map f).Local
 
 lemma edgeDisjointTriangles_iff_mem_sym2_subsingleton :
     G.EdgeDisjointTriangles ↔
-      ∀ ⦃e : Sym2 α⦄, ¬ e.IsDiag → {s ∈ G.cliqueSet 3 | e ∈ (s : Finset α).sym2}.Subsingleton := by
+      ∀ ⦃e : Sym2 α⦄, ¬ e.IsDiagonal →
+        {s ∈ G.cliqueSet 3 | e ∈ (s : Finset α).sym2}.Subsingleton := by
   classical
   have (a b) (hab : a ≠ b) : {s ∈ (G.cliqueSet 3 : Set (Finset α)) | s(a, b) ∈ (s : Finset α).sym2}
     = {s | G.Adj a b ∧ ∃ c, G.Adj a c ∧ G.Adj b c ∧ s = {a, b, c}} := by
@@ -119,8 +120,8 @@ lemma edgeDisjointTriangles_iff_mem_sym2_subsingleton :
   constructor
   · rw [Sym2.forall]
     rintro hG a b hab
-    simp only [Sym2.mk_isDiag_iff] at hab
-    rw [this _ _ (Sym2.mk_isDiag_iff.not.2 hab)]
+    simp only [Sym2.mk_isDiagonal_iff] at hab
+    rw [this _ _ (Sym2.mk_isDiagonal_iff.not.2 hab)]
     rintro _ ⟨hab, c, hac, hbc, rfl⟩ _ ⟨-, d, had, hbd, rfl⟩
     refine hG.eq ?_ ?_ (Set.Nontrivial.not_subsingleton ⟨a, ?_, b, ?_, hab.ne⟩) <;>
       simp [is3Clique_triple_iff, *]
@@ -128,7 +129,7 @@ lemma edgeDisjointTriangles_iff_mem_sym2_subsingleton :
       forall_exists_index, and_imp, ← Set.not_nontrivial_iff (s := _ ∩ _), not_imp_not,
       Set.Nontrivial, Set.mem_inter_iff, mem_coe]
     rintro hG _ a b c hab hac hbc rfl _ d e f hde hdf hef rfl g hg₁ hg₂ h hh₁ hh₂ hgh
-    refine hG (Sym2.mk_isDiag_iff.not.2 hgh) ⟨⟨a, b, c, ?_⟩, by simpa using And.intro hg₁ hh₁⟩
+    refine hG (Sym2.mk_isDiagonal_iff.not.2 hgh) ⟨⟨a, b, c, ?_⟩, by simpa using And.intro hg₁ hh₁⟩
       ⟨⟨d, e, f, ?_⟩, by simpa using And.intro hg₂ hh₂⟩ <;> simp [*]
 
 alias ⟨EdgeDisjointTriangles.mem_sym2_subsingleton, _⟩ :=
@@ -156,7 +157,7 @@ lemma EdgeDisjointTriangles.card_edgeFinset_le (hG : G.EdgeDisjointTriangles) :
     simp [insert_subset, *]
   · simpa only [card_le_one, mem_bipartiteBelow, and_imp, Set.Subsingleton, Set.mem_ofPred_eq,
       mem_cliqueFinset_iff, mem_cliqueSet_iff]
-      using hG.mem_sym2_subsingleton (G.not_isDiag_of_mem_edgeSet <| mem_edgeFinset.1 he)
+      using hG.mem_sym2_subsingleton (G.not_isDiagonal_of_mem_edgeSet <| mem_edgeFinset.1 he)
 
 lemma LocallyLinear.card_edgeFinset (hG : G.LocallyLinear) :
     #G.edgeFinset = 3 * #(G.cliqueFinset 3) := by

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
@@ -110,7 +110,7 @@ lemma regularityReduced_edges_card_aux [Nonempty α] (hε : 0 < ε) (hP : P.IsEq
     2 * (#G.edgeFinset - #(G.regularityReduced P (ε / 8) (ε / 4)).edgeFinset : ℝ)
       < 2 * ε * (card α ^ 2 : ℕ) := by
   let A := (P.nonUniforms G (ε / 8)).biUnion fun (U, V) ↦ U ×ˢ V
-  let B := P.parts.biUnion offDiag
+  let B := P.parts.biUnion offDiagonal
   let C := (P.sparsePairs G (ε / 4)).biUnion fun (U, V) ↦ G.interedges U V
   calc
     _ = (#((univ ×ˢ univ).filter fun (x, y) ↦
@@ -127,7 +127,7 @@ lemma regularityReduced_edges_card_aux [Nonempty α] (hε : 0 < ε) (hP : P.IsEq
       gcongr; exact hP.sum_nonUniforms_lt univ_nonempty (by positivity) hPε
     _ ≤ _ + ε / 2 * card α ^ 2 + 4 * (ε / 4) * card α ^ 2 := by
       gcongr
-      · exact hP.card_biUnion_offDiag_le hε hP'
+      · exact hP.card_biUnion_offDiagonal_le hε hP'
       · exact hP.card_interedges_sparsePairs_le (G := G) (ε := ε / 4) (by positivity)
     _ = 2 * ε * (card α ^ 2 : ℕ) := by norm_cast; ring
 

--- a/Mathlib/Data/Fin/Tuple/NatAntidiagonal.lean
+++ b/Mathlib/Data/Fin/Tuple/NatAntidiagonal.lean
@@ -37,7 +37,7 @@ While we could implement this by filtering `(Fintype.PiFinset fun _ ↦ range (n
 this implementation would be much slower.
 
 In the future, we could consider generalizing `Finset.Nat.antidiagonalTuple` further to
-support finitely-supported functions, as in `Finset.finsuppAntidiag` from
+support finitely-supported functions, as in `Finset.finsuppAntidiagonal` from
 `Mathlib/Algebra/Order/Antidiag/Finsupp.lean`.
 -/
 

--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -145,12 +145,19 @@ variable {ι : Type*} [DecidableEq (ι → α)] {s : Finset α} {f : ι → α}
 
 /-- The diagonal of a finset `s : Finset α` as a finset of functions `ι → α`, namely the set of
 constant functions valued in `s`. -/
-def piDiag (s : Finset α) (ι : Type*) [DecidableEq (ι → α)] : Finset (ι → α) := s.image (const ι)
+def piDiagonal (s : Finset α) (ι : Type*) [DecidableEq (ι → α)] : Finset (ι → α) :=
+  s.image (const ι)
 
-@[simp] lemma mem_piDiag : f ∈ s.piDiag ι ↔ ∃ a ∈ s, const ι a = f := mem_image
+@[deprecated (since := "2026-09-06")] alias piDiag := piDiagonal
 
-@[simp] lemma card_piDiag (s : Finset α) (ι : Type*) [DecidableEq (ι → α)] [Nonempty ι] :
-    (s.piDiag ι).card = s.card := by rw [piDiag, card_image_of_injective _ const_injective]
+@[simp] lemma mem_piDiagonal : f ∈ s.piDiagonal ι ↔ ∃ a ∈ s, const ι a = f := mem_image
+
+@[deprecated (since := "2026-09-06")] alias mem_piDiag := mem_piDiagonal
+
+@[simp] lemma card_piDiagonal (s : Finset α) (ι : Type*) [DecidableEq (ι → α)] [Nonempty ι] :
+    (s.piDiagonal ι).card = s.card := by rw [piDiagonal, card_image_of_injective _ const_injective]
+
+@[deprecated (since := "2026-09-06")] alias card_piDiag := card_piDiagonal
 
 /-! ### Restriction -/
 

--- a/Mathlib/Data/Finset/Prod.lean
+++ b/Mathlib/Data/Finset/Prod.lean
@@ -19,10 +19,10 @@ This file defines finset constructions on the product type `α × β`. Beware no
 ## Main declarations
 
 * `Finset.product`: Turns `s : Finset α`, `t : Finset β` into their product in `Finset (α × β)`.
-* `Finset.diag`: For `s : Finset α`, `s.diag` is the `Finset (α × α)` of pairs `(a, a)` with
+* `Finset.diagonal`: For `s : Finset α`, `s.diagonal` is the `Finset (α × α)` of pairs `(a, a)` with
   `a ∈ s`.
-* `Finset.offDiag`: For `s : Finset α`, `s.offDiag` is the `Finset (α × α)` of pairs `(a, b)` with
-  `a, b ∈ s` and `a ≠ b`.
+* `Finset.offDiagonal`: For `s : Finset α`, `s.offDiagonal` is the `Finset (α × α)` of pairs
+  `(a, b)` with `a, b ∈ s` and `a ≠ b`.
 -/
 
 @[expose] public section
@@ -240,128 +240,187 @@ theorem product_disjUnion (ht : Disjoint t t') :
 
 end Prod
 
-section Diag
+section Diagonal
 
 variable (s t : Finset α)
 
-/-- Given a finite set `s`, the diagonal, `s.diag` is the set of pairs of the form `(a, a)` for
+/-- Given a finite set `s`, the diagonal, `s.diagonal` is the set of pairs of the form `(a, a)` for
 `a ∈ s`. -/
-def diag : Finset (α × α) := s.map ⟨Function.diag, Function.diag_injective⟩
+def diagonal : Finset (α × α) := s.map ⟨Prod.diagonal, Prod.diagonal_injective⟩
 
--- TODO: define `Multiset.offDiag`, provide basic API, use it here
-/-- Given a finite set `s`, the off-diagonal, `s.offDiag` is the set of pairs `(a, b)` with `a ≠ b`
-for `a, b ∈ s`. -/
-def offDiag : Finset (α × α) :=
-  .mk (Quotient.map List.offDiag (fun _ _ ↦ List.Perm.offDiag) s.1) <| by
+@[deprecated (since := "2026-09-06")] alias diag := diagonal
+
+-- TODO: define `Multiset.offDiagonal`, provide basic API, use it here
+/-- Given a finite set `s`, the off-diagonal, `s.offDiagonal` is the set of pairs `(a, b)` with
+`a ≠ b` for `a, b ∈ s`. -/
+def offDiagonal : Finset (α × α) :=
+  .mk (Quotient.map List.offDiagonal (fun _ _ ↦ List.Perm.offDiagonal) s.1) <| by
     rcases s with ⟨⟨s⟩, hs⟩
-    exact hs.offDiag
+    exact hs.offDiagonal
+
+@[deprecated (since := "2026-09-06")] alias offDiag := offDiagonal
 
 variable {s} {x : α × α}
 
 @[simp, grind =]
-theorem mem_diag : x ∈ s.diag ↔ x.1 ∈ s ∧ x.1 = x.2 := by
-  aesop (add simp diag)
+theorem mem_diagonal : x ∈ s.diagonal ↔ x.1 ∈ s ∧ x.1 = x.2 := by
+  aesop (add simp diagonal)
+
+@[deprecated (since := "2026-09-06")] alias mem_diag := mem_diagonal
 
 @[simp, grind =]
-theorem mem_offDiag : x ∈ s.offDiag ↔ x.1 ∈ s ∧ x.2 ∈ s ∧ x.1 ≠ x.2 := by
+theorem mem_offDiagonal : x ∈ s.offDiagonal ↔ x.1 ∈ s ∧ x.2 ∈ s ∧ x.1 ≠ x.2 := by
   rcases s with ⟨⟨s⟩, hs⟩
-  exact hs.mem_offDiag
+  exact hs.mem_offDiagonal
+
+@[deprecated (since := "2026-09-06")] alias mem_offDiag := mem_offDiagonal
 
 @[simp, grind =]
-theorem diag_nonempty : s.diag.Nonempty ↔ s.Nonempty := by
-  simp [diag]
+theorem diagonal_nonempty : s.diagonal.Nonempty ↔ s.Nonempty := by
+  simp [diagonal]
+
+@[deprecated (since := "2026-09-06")] alias diag_nonempty := diagonal_nonempty
 
 @[simp, grind =]
-theorem diag_eq_empty : s.diag = ∅ ↔ s = ∅ := by
-  simp [diag]
+theorem diagonal_eq_empty : s.diagonal = ∅ ↔ s = ∅ := by
+  simp [diagonal]
 
-theorem diag_eq_filter [DecidableEq α] :
-    s.diag = (s ×ˢ s).filter fun a : α × α => a.fst = a.snd := by
+@[deprecated (since := "2026-09-06")] alias diag_eq_empty := diagonal_eq_empty
+
+theorem diagonal_eq_filter [DecidableEq α] :
+    s.diagonal = (s ×ˢ s).filter fun a : α × α => a.fst = a.snd := by
   ext; simp +contextual
+
+@[deprecated (since := "2026-09-06")] alias diag_eq_filter := diagonal_eq_filter
 
 variable (s)
 
 @[simp]
-theorem image_diag [DecidableEq β] (f : α × α → β) (s : Finset α) :
-    s.diag.image f = s.image fun x ↦ f (x, x) := by
+theorem image_diagonal [DecidableEq β] (f : α × α → β) (s : Finset α) :
+    s.diagonal.image f = s.image fun x ↦ f (x, x) := by
   grind
+
+@[deprecated (since := "2026-09-06")] alias image_diag := image_diagonal
 
 @[simp, norm_cast]
-theorem coe_offDiag : (s.offDiag : Set (α × α)) = (s : Set α).offDiag :=
-  Set.ext fun _ => mem_offDiag
+theorem coe_offDiagonal : (s.offDiagonal : Set (α × α)) = (s : Set α).offDiagonal :=
+  Set.ext fun _ => mem_offDiagonal
+
+@[deprecated (since := "2026-09-06")] alias coe_offDiag := coe_offDiagonal
 
 @[simp]
-theorem diag_card : (diag s).card = s.card := by
-  simp [diag]
+theorem diagonal_card : (diagonal s).card = s.card := by
+  simp [diagonal]
+
+@[deprecated (since := "2026-09-06")] alias diag_card := diagonal_card
 
 @[simp]
-theorem offDiag_card : (offDiag s).card = s.card * s.card - s.card := by
+theorem offDiagonal_card : (offDiagonal s).card = s.card * s.card - s.card := by
   rw [← sq]
   rcases s with ⟨⟨s⟩, hs⟩
-  apply List.length_offDiag
+  apply List.length_offDiagonal
+
+@[deprecated (since := "2026-09-06")] alias offDiag_card := offDiagonal_card
 
 @[gcongr, mono]
-theorem diag_mono : Monotone (diag : Finset α → Finset (α × α)) := fun _ _ ↦ by simp [diag]
+theorem diagonal_mono : Monotone (diagonal : Finset α → Finset (α × α)) :=
+  fun _ _ ↦ by simp [diagonal]
+
+@[deprecated (since := "2026-09-06")] alias diag_mono := diagonal_mono
 
 @[gcongr, mono]
-theorem offDiag_mono : Monotone (offDiag : Finset α → Finset (α × α)) := fun _ _ h _ hx =>
-  mem_offDiag.2 <| And.imp (@h _) (And.imp_left <| @h _) <| mem_offDiag.1 hx
+theorem offDiagonal_mono : Monotone (offDiagonal : Finset α → Finset (α × α)) := fun _ _ h _ hx =>
+  mem_offDiagonal.2 <| And.imp (@h _) (And.imp_left <| @h _) <| mem_offDiagonal.1 hx
+
+@[deprecated (since := "2026-09-06")] alias offDiag_mono := offDiagonal_mono
 
 @[simp]
-theorem diag_empty : (∅ : Finset α).diag = ∅ :=
+theorem diagonal_empty : (∅ : Finset α).diagonal = ∅ :=
   rfl
 
+@[deprecated (since := "2026-09-06")] alias diag_empty := diagonal_empty
+
 @[simp]
-theorem offDiag_empty : (∅ : Finset α).offDiag = ∅ :=
+theorem offDiagonal_empty : (∅ : Finset α).offDiagonal = ∅ :=
   rfl
 
-@[simp]
-theorem diag_union_offDiag [DecidableEq α] : s.diag ∪ s.offDiag = s ×ˢ s := by
-  grind
+@[deprecated (since := "2026-09-06")] alias offDiag_empty := offDiagonal_empty
 
 @[simp]
-theorem disjoint_diag_offDiag : Disjoint s.diag s.offDiag := by simp [disjoint_left]
-
-theorem product_sdiff_diag [DecidableEq α] : s ×ˢ s \ s.diag = s.offDiag := by grind
-
-theorem product_sdiff_offDiag [DecidableEq α] : s ×ˢ s \ s.offDiag = s.diag := by grind
-
-theorem diag_inter [DecidableEq α] : (s ∩ t).diag = s.diag ∩ t.diag := by
+theorem diagonal_union_offDiagonal [DecidableEq α] : s.diagonal ∪ s.offDiagonal = s ×ˢ s := by
   grind
 
-theorem offDiag_inter [DecidableEq α] : (s ∩ t).offDiag = s.offDiag ∩ t.offDiag :=
+@[deprecated (since := "2026-09-06")] alias diag_union_offDiag := diagonal_union_offDiagonal
+
+@[simp]
+theorem disjoint_diagonal_offDiagonal : Disjoint s.diagonal s.offDiagonal := by simp [disjoint_left]
+
+@[deprecated (since := "2026-09-06")] alias disjoint_diag_offDiag := disjoint_diagonal_offDiagonal
+
+theorem product_sdiff_diagonal [DecidableEq α] : s ×ˢ s \ s.diagonal = s.offDiagonal := by grind
+
+@[deprecated (since := "2026-09-06")] alias product_sdiff_diag := product_sdiff_diagonal
+
+theorem product_sdiff_offDiagonal [DecidableEq α] : s ×ˢ s \ s.offDiagonal = s.diagonal := by grind
+
+@[deprecated (since := "2026-09-06")] alias product_sdiff_offDiag := product_sdiff_offDiagonal
+
+theorem diagonal_inter [DecidableEq α] : (s ∩ t).diagonal = s.diagonal ∩ t.diagonal := by
+  grind
+
+@[deprecated (since := "2026-09-06")] alias diag_inter := diagonal_inter
+
+theorem offDiagonal_inter [DecidableEq α] : (s ∩ t).offDiagonal = s.offDiagonal ∩ t.offDiagonal :=
   coe_injective <| by
     push_cast
-    exact Set.offDiag_inter _ _
+    exact Set.offDiagonal_inter _ _
 
-theorem diag_union [DecidableEq α] : (s ∪ t).diag = s.diag ∪ t.diag := by
+@[deprecated (since := "2026-09-06")] alias offDiag_inter := offDiagonal_inter
+
+theorem diagonal_union [DecidableEq α] : (s ∪ t).diagonal = s.diagonal ∪ t.diagonal := by
   grind
+
+@[deprecated (since := "2026-09-06")] alias diag_union := diagonal_union
 
 variable {s t}
 
-theorem offDiag_union [DecidableEq α] (h : Disjoint s t) :
-    (s ∪ t).offDiag = s.offDiag ∪ t.offDiag ∪ s ×ˢ t ∪ t ×ˢ s :=
+theorem offDiagonal_union [DecidableEq α] (h : Disjoint s t) :
+    (s ∪ t).offDiagonal = s.offDiagonal ∪ t.offDiagonal ∪ s ×ˢ t ∪ t ×ˢ s :=
   coe_injective <| by
     push_cast
-    exact Set.offDiag_union (disjoint_coe.2 h)
+    exact Set.offDiagonal_union (disjoint_coe.2 h)
+
+@[deprecated (since := "2026-09-06")] alias offDiag_union := offDiagonal_union
 
 @[simp]
-theorem offDiag_singleton (a : α) : ({a} : Finset α).offDiag = ∅ := by simp [← Finset.card_eq_zero]
+theorem offDiagonal_singleton (a : α) : ({a} : Finset α).offDiagonal = ∅ := by
+  simp [← Finset.card_eq_zero]
 
-theorem diag_singleton (a : α) : ({a} : Finset α).diag = {(a, a)} := by grind
+@[deprecated (since := "2026-09-06")] alias offDiag_singleton := offDiagonal_singleton
 
-theorem diag_insert [DecidableEq α] (a : α) :
-    (insert a s).diag = insert (a, a) s.diag := by grind
+theorem diagonal_singleton (a : α) : ({a} : Finset α).diagonal = {(a, a)} := by grind
 
-theorem offDiag_insert [DecidableEq α] {a : α} (has : a ∉ s) :
-    (insert a s).offDiag = s.offDiag ∪ {a} ×ˢ s ∪ s ×ˢ {a} := by
+@[deprecated (since := "2026-09-06")] alias diag_singleton := diagonal_singleton
+
+theorem diagonal_insert [DecidableEq α] (a : α) :
+    (insert a s).diagonal = insert (a, a) s.diagonal := by grind
+
+@[deprecated (since := "2026-09-06")] alias diag_insert := diagonal_insert
+
+theorem offDiagonal_insert [DecidableEq α] {a : α} (has : a ∉ s) :
+    (insert a s).offDiagonal = s.offDiagonal ∪ {a} ×ˢ s ∪ s ×ˢ {a} := by
   grind
 
-theorem offDiag_filter_lt_eq_filter_le {ι} [PartialOrder ι] [DecidableLE ι] [DecidableLT ι]
+@[deprecated (since := "2026-09-06")] alias offDiag_insert := offDiagonal_insert
+
+theorem offDiagonal_filter_lt_eq_filter_le {ι} [PartialOrder ι] [DecidableLE ι] [DecidableLT ι]
     (s : Finset ι) :
-    s.offDiag.filter (fun i => i.1 < i.2) = s.offDiag.filter (fun i => i.1 ≤ i.2) := by
+    s.offDiagonal.filter (fun i => i.1 < i.2) = s.offDiagonal.filter (fun i => i.1 ≤ i.2) := by
   ext
   simpa using fun _ _ a ↦ (Ne.le_iff_lt a).symm
+
+@[deprecated (since := "2026-09-06")]
+alias offDiag_filter_lt_eq_filter_le := offDiagonal_filter_lt_eq_filter_le
 
 /-- The number of strictly ordered pairs `(a, b)` with `a, b ∈ s` is `(#s).choose 2`. -/
 lemma card_product_filter_lt [LinearOrder α] :
@@ -369,10 +428,10 @@ lemma card_product_filter_lt [LinearOrder α] :
   set u : Finset (α × α) := {x ∈ s ×ˢ s | x.1 < x.2}
   set v : Finset (α × α) := {x ∈ s ×ˢ s | x.2 < x.1}
   have disj : Disjoint u v := by grind [disjoint_left]
-  have union : u.disjUnion v disj = s.offDiag := by grind
+  have union : u.disjUnion v disj = s.offDiagonal := by grind
   have swap : #u = #v := Finset.card_equiv (Equiv.prodComm α α) (by grind)
-  grind [Nat.mul_sub_one, offDiag_card, Nat.choose_two_right]
+  grind [Nat.mul_sub_one, offDiagonal_card, Nat.choose_two_right]
 
-end Diag
+end Diagonal
 
 end Finset

--- a/Mathlib/Data/Finset/Sym.lean
+++ b/Mathlib/Data/Finset/Sym.lean
@@ -121,7 +121,7 @@ theorem sym2_nonempty : s.sym2.Nonempty ↔ s.Nonempty := by
 protected alias ⟨_, Nonempty.sym2⟩ := sym2_nonempty
 
 @[simp]
-theorem sym2_singleton (a : α) : ({a} : Finset α).sym2 = {Sym2.diag a} := rfl
+theorem sym2_singleton (a : α) : ({a} : Finset α).sym2 = {Sym2.diagonal a} := rfl
 
 /-- Finset **stars and bars** for the case `n = 2`. -/
 theorem card_sym2 (s : Finset α) : s.sym2.card = Nat.choose (s.card + 1) 2 := by
@@ -134,24 +134,38 @@ variable {s t : Finset α} {a b : α}
 theorem sym2_eq_image [DecidableEq α] : s.sym2 = (s ×ˢ s).image Sym2.mk.uncurry := by
   ext ⟨a, b⟩; simp; grind
 
-theorem isDiag_mk_of_mem_diag {a b : α} (h : (a, b) ∈ s.diag) : s(a, b).IsDiag := by
+theorem isDiagonal_mk_of_mem_diagonal {a b : α} (h : (a, b) ∈ s.diagonal) : s(a, b).IsDiagonal := by
   simp at *; grind
 
-theorem not_isDiag_mk_of_mem_offDiag {a b : α} (h : (a, b) ∈ s.offDiag) : ¬ s(a, b).IsDiag := by
+@[deprecated (since := "2026-09-06")] alias isDiag_mk_of_mem_diag := isDiagonal_mk_of_mem_diagonal
+
+theorem not_isDiagonal_mk_of_mem_offDiagonal {a b : α} (h : (a, b) ∈ s.offDiagonal) :
+    ¬ s(a, b).IsDiagonal := by
   simp at *; grind
+
+@[deprecated (since := "2026-09-06")]
+alias not_isDiag_mk_of_mem_offDiag := not_isDiagonal_mk_of_mem_offDiagonal
 
 section Sym2
 
 @[simp]
-theorem diag_mem_sym2_mem_iff : (∀ b, b ∈ Sym2.diag a → b ∈ s) ↔ a ∈ s := by
+theorem diagonal_mem_sym2_mem_iff : (∀ b, b ∈ Sym2.diagonal a → b ∈ s) ↔ a ∈ s := by
   rw [← mem_sym2_iff]
   exact mk_mem_sym2_iff.trans <| and_self_iff
 
-theorem diag_mem_sym2_iff : Sym2.diag a ∈ s.sym2 ↔ a ∈ s := by simp [diag_mem_sym2_mem_iff]
+@[deprecated (since := "2026-09-06")] alias diag_mem_sym2_mem_iff := diagonal_mem_sym2_mem_iff
 
-theorem image_diag_union_image_offDiag [DecidableEq α] :
-    s.diag.image Sym2.mk.uncurry ∪ s.offDiag.image Sym2.mk.uncurry = s.sym2 := by
-  rw [← image_union, diag_union_offDiag, sym2_eq_image]
+theorem diagonal_mem_sym2_iff : Sym2.diagonal a ∈ s.sym2 ↔ a ∈ s := by
+  simp [diagonal_mem_sym2_mem_iff]
+
+@[deprecated (since := "2026-09-06")] alias diag_mem_sym2_iff := diagonal_mem_sym2_iff
+
+theorem image_diagonal_union_image_offDiagonal [DecidableEq α] :
+    s.diagonal.image Sym2.mk.uncurry ∪ s.offDiagonal.image Sym2.mk.uncurry = s.sym2 := by
+  rw [← image_union, diagonal_union_offDiagonal, sym2_eq_image]
+
+@[deprecated (since := "2026-09-06")]
+alias image_diag_union_image_offDiag := image_diagonal_union_image_offDiagonal
 
 end Sym2
 

--- a/Mathlib/Data/Fintype/Pi.lean
+++ b/Mathlib/Data/Fintype/Pi.lean
@@ -172,10 +172,13 @@ namespace Finset
 variable {ι : Type*} [DecidableEq (ι → α)] {s : Finset α} {f : ι → α}
 
 lemma piFinset_filter_const [DecidableEq ι] [Fintype ι] :
-    {f ∈ Fintype.piFinset fun _ : ι ↦ s | ∃ a ∈ s, const ι a = f} = s.piDiag ι := by aesop
+    {f ∈ Fintype.piFinset fun _ : ι ↦ s | ∃ a ∈ s, const ι a = f} = s.piDiagonal ι := by aesop
 
-lemma piDiag_subset_piFinset [DecidableEq ι] [Fintype ι] :
-    s.piDiag ι ⊆ Fintype.piFinset fun _ ↦ s := by simp [← piFinset_filter_const]
+lemma piDiagonal_subset_piFinset [DecidableEq ι] [Fintype ι] :
+    s.piDiagonal ι ⊆ Fintype.piFinset fun _ ↦ s := by simp [← piFinset_filter_const]
+
+@[deprecated (since := "2026-09-06")]
+alias piDiag_subset_piFinset := piDiagonal_subset_piFinset
 
 end Finset
 

--- a/Mathlib/Data/Fintype/Prod.lean
+++ b/Mathlib/Data/Fintype/Prod.lean
@@ -33,9 +33,11 @@ theorem toFinset_prod (s : Set α) (t : Set β) [Fintype s] [Fintype t] [Fintype
   ext
   simp
 
-theorem toFinset_offDiag {s : Set α} [Fintype s] [Fintype s.offDiag] :
-    s.offDiag.toFinset = s.toFinset.offDiag :=
+theorem toFinset_offDiagonal {s : Set α} [Fintype s] [Fintype s.offDiagonal] :
+    s.offDiagonal.toFinset = s.toFinset.offDiagonal :=
   Finset.ext <| by simp
+
+@[deprecated (since := "2026-09-06")] alias toFinset_offDiag := toFinset_offDiagonal
 
 end Set
 

--- a/Mathlib/Data/List/OffDiag.lean
+++ b/Mathlib/Data/List/OffDiag.lean
@@ -12,9 +12,9 @@ import Mathlib.Data.List.Perm.Basic
 public import Mathlib.Data.Nat.Notation
 
 /-!
-# Definition and basic properties of `List.offDiag`
+# Definition and basic properties of `List.offDiagonal`
 
-In this file we define `List.offDiag l` to be the product `l.product l`
+In this file we define `List.offDiagonal l` to be the product `l.product l`
 with the diagonal removed.
 The actual definition is more complicated to avoid assuming that equality on `α` is decidable.
 -/
@@ -27,43 +27,57 @@ namespace List
 
 variable {α : Type*} {l : List α}
 
-/-- `List.offDiag l` is the product `l.product l` with the diagonal removed. -/
-def offDiag (l : List α) : List (α × α) :=
+/-- `List.offDiagonal l` is the product `l.product l` with the diagonal removed. -/
+def offDiagonal (l : List α) : List (α × α) :=
   l.zipIdx.flatMap fun (x, n) ↦ map (Prod.mk x) <| l.eraseIdx n
 
-@[simp]
-theorem offDiag_nil : offDiag ([] : List α) = [] := rfl
+@[deprecated (since := "2026-09-06")] alias offDiag := offDiagonal
 
-theorem offDiag_cons_perm (a : α) (l : List α) :
-    offDiag (a :: l) ~ map (a, ·) l ++ map (·, a) l ++ l.offDiag := by
-  simp only [offDiag, zipIdx_cons']
+@[simp]
+theorem offDiagonal_nil : offDiagonal ([] : List α) = [] := rfl
+
+@[deprecated (since := "2026-09-06")] alias offDiag_nil := offDiagonal_nil
+
+theorem offDiagonal_cons_perm (a : α) (l : List α) :
+    offDiagonal (a :: l) ~ map (a, ·) l ++ map (·, a) l ++ l.offDiagonal := by
+  simp only [offDiagonal, zipIdx_cons']
   have : map (fun x ↦ (x.fst, a)) l.zipIdx = map (·, a) l := by
     conv_rhs => rw [← zipIdx_map_fst 0 l, map_map, Function.comp_def]
   simp [append_assoc, perm_append_left_iff, flatMap_map,
     ← (map_append_flatMap_perm _ _ _).congr_left, this]
 
-@[simp]
-theorem offDiag_singleton (a : α) : offDiag [a] = [] := rfl
+@[deprecated (since := "2026-09-06")] alias offDiag_cons_perm := offDiagonal_cons_perm
 
-theorem length_offDiag' (l : List α) : length l.offDiag = length l * (length l - 1) := by
+@[simp]
+theorem offDiagonal_singleton (a : α) : offDiagonal [a] = [] := rfl
+
+@[deprecated (since := "2026-09-06")] alias offDiag_singleton := offDiagonal_singleton
+
+theorem length_offDiagonal' (l : List α) : length l.offDiagonal = length l * (length l - 1) := by
   have : ∀ x ∈ l.zipIdx, length (eraseIdx l x.2) = length l - 1 := fun x hx ↦
     length_eraseIdx_of_lt <| snd_lt_of_mem_zipIdx hx
-  simp [offDiag, map_congr_left this]
+  simp [offDiagonal, map_congr_left this]
+
+@[deprecated (since := "2026-09-06")] alias length_offDiag' := length_offDiagonal'
 
 @[simp]
-theorem length_offDiag (l : List α) : length l.offDiag = length l ^ 2 - length l := by
-  simp [length_offDiag', Nat.mul_sub, Nat.pow_two]
+theorem length_offDiagonal (l : List α) : length l.offDiagonal = length l ^ 2 - length l := by
+  simp [length_offDiagonal', Nat.mul_sub, Nat.pow_two]
 
-theorem mem_offDiag_iff_getElem {x : α × α} :
-    x ∈ l.offDiag ↔ ∃ (i : ℕ) (_ : i < l.length) (j : ℕ) (_ : j < l.length),
+@[deprecated (since := "2026-09-06")] alias length_offDiag := length_offDiagonal
+
+theorem mem_offDiagonal_iff_getElem {x : α × α} :
+    x ∈ l.offDiagonal ↔ ∃ (i : ℕ) (_ : i < l.length) (j : ℕ) (_ : j < l.length),
       i ≠ j ∧ l[i] = x.1 ∧ l[j] = x.2 := by
   rcases x with ⟨x, y⟩
-  simp only [offDiag, exists_mem_zipIdx, mem_eraseIdx_iff_getElem, mem_flatMap, mem_map,
+  simp only [offDiagonal, exists_mem_zipIdx, mem_eraseIdx_iff_getElem, mem_flatMap, mem_map,
     Nat.zero_add, Prod.ext_iff, ← exists_and_right, exists_and_left, @exists_comm α, and_assoc,
     exists_eq_left', ne_comm]
 
-theorem count_offDiag_eq_mul_sub_ite [DecidableEq α] (l : List α) (a b : α) :
-    count (a, b) l.offDiag = count a l * count b l - if a = b then count a l else 0 := by
+@[deprecated (since := "2026-09-06")] alias mem_offDiag_iff_getElem := mem_offDiagonal_iff_getElem
+
+theorem count_offDiagonal_eq_mul_sub_ite [DecidableEq α] (l : List α) (a b : α) :
+    count (a, b) l.offDiagonal = count a l * count b l - if a = b then count a l else 0 := by
   induction l with
   | nil => simp
   | cons c l ihl =>
@@ -75,24 +89,33 @@ theorem count_offDiag_eq_mul_sub_ite [DecidableEq α] (l : List α) (a b : α) :
       split_ifs with h
       · rw [h, count_map_of_injective l (·, y) (by simp [Function.Injective])]
       · simp [count_eq_zero, h]
-    simp only [(offDiag_cons_perm _ _).count_eq, count_append, ihl, H₁, H₂, count_cons, beq_iff_eq]
+    simp only [(offDiagonal_cons_perm _ _).count_eq, count_append, ihl, H₁, H₂, count_cons,
+      beq_iff_eq]
     have := Nat.le_mul_self (count c l)
     split_ifs <;> simp_all <;> grind
 
-@[gcongr]
-protected theorem Perm.offDiag {l₁ l₂ : List α} (h : l₁ ~ l₂) : l₁.offDiag ~ l₂.offDiag := by
-  classical simp_all [perm_iff_count, count_offDiag_eq_mul_sub_ite]
+@[deprecated (since := "2026-09-06")]
+alias count_offDiag_eq_mul_sub_ite := count_offDiagonal_eq_mul_sub_ite
 
-protected theorem Nodup.offDiag (h : l.Nodup) : l.offDiag.Nodup := by
+@[gcongr]
+protected theorem Perm.offDiagonal {l₁ l₂ : List α} (h : l₁ ~ l₂) :
+    l₁.offDiagonal ~ l₂.offDiagonal := by
+  classical simp_all [perm_iff_count, count_offDiagonal_eq_mul_sub_ite]
+
+@[deprecated (since := "2026-09-06")] alias Perm.offDiag := Perm.offDiagonal
+
+protected theorem Nodup.offDiagonal (h : l.Nodup) : l.offDiagonal.Nodup := by
   let := Classical.decEq α
   rw [nodup_iff_count_le_one]
   rintro ⟨x, y⟩
-  rw [count_offDiag_eq_mul_sub_ite l x y]
+  rw [count_offDiagonal_eq_mul_sub_ite l x y]
   grind
 
-protected theorem Nodup.of_offDiag (h : l.offDiag.Nodup) : l.Nodup := by
+@[deprecated (since := "2026-09-06")] alias Nodup.offDiag := Nodup.offDiagonal
+
+protected theorem Nodup.of_offDiagonal (h : l.offDiagonal.Nodup) : l.Nodup := by
   let := Classical.decEq α
-  simp only [nodup_iff_count_le_one, Prod.forall, count_offDiag_eq_mul_sub_ite] at *
+  simp only [nodup_iff_count_le_one, Prod.forall, count_offDiagonal_eq_mul_sub_ite] at *
   intro a
   specialize h a a
   contrapose h
@@ -104,24 +127,32 @@ protected theorem Nodup.of_offDiag (h : l.offDiag.Nodup) : l.Nodup := by
       rw [← Nat.two_mul]
       exact Nat.mul_le_mul_right _ h
 
-/-- `List.offDiag l` has no duplicates iff the original list has no duplicates. -/
-@[simp]
-theorem nodup_offDiag : l.offDiag.Nodup ↔ l.Nodup := ⟨.of_offDiag, .offDiag⟩
+@[deprecated (since := "2026-09-06")] alias Nodup.of_offDiag := Nodup.of_offDiagonal
 
-/-- If `l : List α` is a list with no duplicates, then `x : α × α` belongs to `List.offDiag l`
+/-- `List.offDiagonal l` has no duplicates iff the original list has no duplicates. -/
+@[simp]
+theorem nodup_offDiagonal : l.offDiagonal.Nodup ↔ l.Nodup := ⟨.of_offDiagonal, .offDiagonal⟩
+
+@[deprecated (since := "2026-09-06")] alias nodup_offDiag := nodup_offDiagonal
+
+/-- If `l : List α` is a list with no duplicates, then `x : α × α` belongs to `List.offDiagonal l`
 iff both components of `x` belong to `l` and they are not equal. -/
-theorem Nodup.mem_offDiag (h : l.Nodup) {x : α × α} :
-    x ∈ l.offDiag ↔ x.1 ∈ l ∧ x.2 ∈ l ∧ x.1 ≠ x.2 := by
+theorem Nodup.mem_offDiagonal (h : l.Nodup) {x : α × α} :
+    x ∈ l.offDiagonal ↔ x.1 ∈ l ∧ x.2 ∈ l ∧ x.1 ≠ x.2 := by
   rcases x with ⟨x, y⟩
-  simp_rw [mem_offDiag_iff_getElem, mem_iff_getElem, Ne]
+  simp_rw [mem_offDiagonal_iff_getElem, mem_iff_getElem, Ne]
   constructor
   · rintro ⟨i, hi, j, hj, hne, rfl, rfl⟩
     exact ⟨⟨i, hi, rfl⟩, ⟨j, hj, rfl⟩, mt h.getElem_inj_iff.1 hne⟩
   · rintro ⟨⟨i, hi, rfl⟩, ⟨j, hj, rfl⟩, hne⟩
     exact ⟨i, hi, j, hj, mt h.getElem_inj_iff.2 hne, rfl, rfl⟩
 
-theorem map_prodMap_offDiag {β : Type*} (f : α → β) (l : List α) :
-    map (Prod.map f f) l.offDiag = (map f l).offDiag := by
-  simp [offDiag, map_flatMap, zipIdx_map, flatMap_map, eraseIdx_map, Function.comp_def]
+@[deprecated (since := "2026-09-06")] alias Nodup.mem_offDiag := Nodup.mem_offDiagonal
+
+theorem map_prodMap_offDiagonal {β : Type*} (f : α → β) (l : List α) :
+    map (Prod.map f f) l.offDiagonal = (map f l).offDiagonal := by
+  simp [offDiagonal, map_flatMap, zipIdx_map, flatMap_map, eraseIdx_map, Function.comp_def]
+
+@[deprecated (since := "2026-09-06")] alias map_prodMap_offDiag := map_prodMap_offDiagonal
 
 end List

--- a/Mathlib/Data/Nat/Choose/Multinomial.lean
+++ b/Mathlib/Data/Nat/Choose/Multinomial.lean
@@ -267,24 +267,24 @@ open scoped Function -- required for scoped `on` notation
 set_option backward.isDefEq.respectTransparency false in
 -- TODO: Can we prove one of the following two from the other one?
 /-- The **multinomial theorem**. -/
-lemma sum_pow_eq_sum_piAntidiag_of_commute (s : Finset α) (f : α → R)
+lemma sum_pow_eq_sum_piAntidiagonal_of_commute (s : Finset α) (f : α → R)
     (hc : (s : Set α).Pairwise (Commute on f)) (n : ℕ) :
-    (∑ i ∈ s, f i) ^ n = ∑ k ∈ piAntidiag s n, multinomial s k *
+    (∑ i ∈ s, f i) ^ n = ∑ k ∈ piAntidiagonal s n, multinomial s k *
       s.noncommProd (fun i ↦ f i ^ k i) (hc.mono' fun _ _ h ↦ h.pow_pow ..) := by
   induction s using Finset.cons_induction generalizing n with
   | empty => cases n <;> simp
   | cons a s has ih => ?_
-  rw [Finset.sum_cons, piAntidiag_cons, sum_disjiUnion]
+  rw [Finset.sum_cons, piAntidiagonal_cons, sum_disjiUnion]
   simp only [sum_map, Pi.add_apply, multinomial_cons,
     Pi.add_apply, ite_true, Nat.cast_mul, noncommProd_cons,
     ite_true, sum_add_distrib, sum_ite_eq', has, ite_false, add_zero,
     addRightEmbedding_apply]
   suffices ∀ p : ℕ × ℕ, p ∈ antidiagonal n →
-    ∑ g ∈ piAntidiag s p.2, ((g a + p.1 + s.sum g).choose (g a + p.1) : R) *
+    ∑ g ∈ piAntidiagonal s p.2, ((g a + p.1 + s.sum g).choose (g a + p.1) : R) *
       multinomial s (g + fun i ↦ ite (i = a) p.1 0) *
         (f a ^ (g a + p.1) * s.noncommProd (fun i ↦ f i ^ (g i + ite (i = a) p.1 0))
           ((hc.mono (by simp)).mono' fun i j h ↦ h.pow_pow ..)) =
-      ∑ g ∈ piAntidiag s p.2, n.choose p.1 * multinomial s g * (f a ^ p.1 *
+      ∑ g ∈ piAntidiagonal s p.2, n.choose p.1 * multinomial s g * (f a ^ p.1 *
         s.noncommProd (fun i ↦ f i ^ g i) ((hc.mono (by simp)).mono' fun i j h ↦ h.pow_pow ..)) by
     rw [sum_congr rfl this]
     simp only [Nat.antidiagonal_eq_map, sum_map, Function.Embedding.coeFn_mk]
@@ -294,7 +294,7 @@ lemma sum_pow_eq_sum_piAntidiag_of_commute (s : Finset α) (f : α → R)
     refine sum_congr rfl fun i _ ↦ sum_congr rfl fun g _ ↦ ?_
     rw [← Nat.cast_comm, (Nat.commute_cast (f a ^ i) _).left_comm, mul_assoc]
   refine fun p hp ↦ sum_congr rfl fun f hf ↦ ?_
-  rw [mem_piAntidiag] at hf
+  rw [mem_piAntidiagonal] at hf
   rw [not_imp_comm.1 (hf.2 _) has, zero_add, hf.1]
   congr 2
   · rw [mem_antidiagonal.1 hp]
@@ -305,6 +305,9 @@ lemma sum_pow_eq_sum_piAntidiag_of_commute (s : Finset α) (f : α → R)
   refine noncommProd_congr rfl (fun t ht ↦ ?_) _
   rw [ite_eq_right, add_zero]
   exact ne_of_mem_of_not_mem ht has
+
+@[deprecated (since := "2026-09-06")]
+alias sum_pow_eq_sum_piAntidiag_of_commute := sum_pow_eq_sum_piAntidiagonal_of_commute
 
 /-- The **multinomial theorem**. -/
 theorem sum_pow_of_commute (x : α → R) (s : Finset α)
@@ -347,10 +350,13 @@ end Semiring
 section CommSemiring
 variable [CommSemiring R] {f : α → R} {s : Finset α}
 
-lemma sum_pow_eq_sum_piAntidiag (s : Finset α) (f : α → R) (n : ℕ) :
-    (∑ i ∈ s, f i) ^ n = ∑ k ∈ piAntidiag s n, multinomial s k * ∏ i ∈ s, f i ^ k i := by
+lemma sum_pow_eq_sum_piAntidiagonal (s : Finset α) (f : α → R) (n : ℕ) :
+    (∑ i ∈ s, f i) ^ n = ∑ k ∈ piAntidiagonal s n, multinomial s k * ∏ i ∈ s, f i ^ k i := by
   simp_rw [← noncommProd_eq_prod]
-  rw [← sum_pow_eq_sum_piAntidiag_of_commute _ _ fun _ _ _ _ _ ↦ Commute.all ..]
+  rw [← sum_pow_eq_sum_piAntidiagonal_of_commute _ _ fun _ _ _ _ _ ↦ Commute.all ..]
+
+@[deprecated (since := "2026-09-06")]
+alias sum_pow_eq_sum_piAntidiag := sum_pow_eq_sum_piAntidiagonal
 
 theorem sum_pow (x : α → R) (n : ℕ) :
     s.sum x ^ n = ∑ k ∈ s.sym n, k.val.countPerms * (k.val.map x).prod := by

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -351,7 +351,7 @@ def decreasingInduction' {P : ℕ → Sort*} (h : ∀ k < n, m ≤ k → P (k + 
 `P (a + 1) (a + 1)` is true for all `a`, `P 0 (b + 1)` is true for all `b` and for all
 `a < b`, `P (a + 1) b` is true and `P a (b + 1)` is true implies `P (a + 1) (b + 1)` is true. -/
 @[elab_as_elim]
-theorem diag_induction (P : ℕ → ℕ → Prop) (ha : ∀ a, P (a + 1) (a + 1)) (hb : ∀ b, P 0 (b + 1))
+theorem diagonal_induction (P : ℕ → ℕ → Prop) (ha : ∀ a, P (a + 1) (a + 1)) (hb : ∀ b, P 0 (b + 1))
     (hd : ∀ a b, a < b → P (a + 1) b → P a (b + 1) → P (a + 1) (b + 1)) : ∀ a b, a < b → P a b
   | 0, _ + 1, _ => hb _
   | a + 1, b + 1, h => by
@@ -359,9 +359,11 @@ theorem diag_induction (P : ℕ → ℕ → Prop) (ha : ∀ a, P (a + 1) (a + 1)
     · have : a + 1 = b ∨ a + 1 < b := by lia
       rcases this with (rfl | h)
       · exact ha _
-      apply diag_induction P ha hb hd (a + 1) b h
-    apply diag_induction P ha hb hd a (b + 1)
+      apply diagonal_induction P ha hb hd (a + 1) b h
+    apply diagonal_induction P ha hb hd a (b + 1)
     apply Nat.lt_of_le_of_lt (Nat.le_succ _) h
+
+@[deprecated (since := "2026-09-06")] alias diag_induction := diagonal_induction
 
 /-! ### `mod`, `dvd` -/
 

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Cofix.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Cofix.lean
@@ -351,11 +351,11 @@ section LiftRMap
 
 theorem liftR_map {α β : TypeVec n} {F' : TypeVec n → Type u} [MvFunctor F'] [LawfulMvFunctor F']
     (R : β ⊗ β ⟹ «repeat» n Prop) (x : F' α) (f g : α ⟹ β) (h : α ⟹ Subtype_ R)
-    (hh : subtypeVal _ ⊚ h = (f ⊗' g) ⊚ prod.diag) : LiftR' R (f <$$> x) (g <$$> x) := by
+    (hh : subtypeVal _ ⊚ h = (f ⊗' g) ⊚ prod.diagonal) : LiftR' R (f <$$> x) (g <$$> x) := by
   rw [LiftR_def]
   exists h <$$> x
-  rw [MvFunctor.map_map, comp_assoc, hh, ← comp_assoc, fst_prod_mk, comp_assoc, fst_diag]
-  rw [MvFunctor.map_map, comp_assoc, hh, ← comp_assoc, snd_prod_mk, comp_assoc, snd_diag]
+  rw [MvFunctor.map_map, comp_assoc, hh, ← comp_assoc, fst_prod_mk, comp_assoc, fst_diagonal]
+  rw [MvFunctor.map_map, comp_assoc, hh, ← comp_assoc, snd_prod_mk, comp_assoc, snd_diagonal]
   dsimp [LiftR']; constructor <;> rfl
 
 open Function
@@ -366,14 +366,14 @@ theorem liftR_map_last [lawful : LawfulMvFunctor F]
     (x : F (α ::: ι)) (f g : ι → ι') (hh : ∀ x : ι, R (f x) (g x)) :
     LiftR' (RelLast' _ R) ((id ::: f) <$$> x) ((id ::: g) <$$> x) :=
   let h : ι → { x : ι' × ι' // uncurry R x } := fun x => ⟨(f x, g x), hh x⟩
-  let b : (α ::: ι) ⟹ _ := @diagSub n α ::: h
+  let b : (α ::: ι) ⟹ _ := @diagonalSub n α ::: h
   let c :
     (Subtype_ α.repeatEq ::: { x // uncurry R x }) ⟹
       ((fun i : Fin2 n => { x // ofRepeat (α.RelLast' R i.fs x) }) ::: Subtype (uncurry R)) :=
     ofSubtype _ ::: id
   have hh :
     subtypeVal _ ⊚ toSubtype _ ⊚ fromAppend1DropLast ⊚ c ⊚ b =
-      ((id ::: f) ⊗' (id ::: g)) ⊚ prod.diag := by
+      ((id ::: f) ⊗' (id ::: g)) ⊚ prod.diagonal := by
     dsimp [b]
     apply eq_of_drop_last_eq
     · dsimp

--- a/Mathlib/Data/Set/Operations.lean
+++ b/Mathlib/Data/Set/Operations.lean
@@ -32,7 +32,7 @@ More advanced theorems about these definitions are located in other files in `Ma
   it is more general than `f '' univ` because it allows functions from `Sort*`;
 - `s ×ˢ t`: product of `s : Set α` and `t : Set β` as a set in `α × β`;
 - `Set.diagonal`: the diagonal in `α × α`;
-- `Set.offDiag s`: the part of `s ×ˢ s` that is off the diagonal;
+- `Set.offDiagonal s`: the part of `s ×ˢ s` that is off the diagonal;
 - `Set.pi`: indexed product of a family of sets `∀ i, Set (α i)`,
   as a set in `∀ i, α i`;
 - `Set.EqOn f g s`: the predicate saying that two functions are equal on a set;
@@ -262,11 +262,16 @@ theorem mem_diagonal (x : α) : (x, x) ∈ diagonal α := rfl
 @[simp, grind =, push] theorem mem_diagonal_iff {x : α × α} : x ∈ diagonal α ↔ x.1 = x.2 := .rfl
 
 /-- The off-diagonal of a set `s` is the set of pairs `(a, b)` with `a, b ∈ s` and `a ≠ b`. -/
-def offDiag (s : Set α) : Set (α × α) := {x | x.1 ∈ s ∧ x.2 ∈ s ∧ x.1 ≠ x.2}
+def offDiagonal (s : Set α) : Set (α × α) := {x | x.1 ∈ s ∧ x.2 ∈ s ∧ x.1 ≠ x.2}
+
+@[deprecated (since := "2026-09-06")] alias offDiag := offDiagonal
 
 @[simp, grind =, push]
-theorem mem_offDiag {x : α × α} {s : Set α} : x ∈ s.offDiag ↔ x.1 ∈ s ∧ x.2 ∈ s ∧ x.1 ≠ x.2 :=
+theorem mem_offDiagonal {x : α × α} {s : Set α} :
+    x ∈ s.offDiagonal ↔ x.1 ∈ s ∧ x.2 ∈ s ∧ x.1 ≠ x.2 :=
   Iff.rfl
+
+@[deprecated (since := "2026-09-06")] alias mem_offDiag := mem_offDiagonal
 
 end Diagonal
 

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -22,7 +22,7 @@ This file contains basic results on the following notions, which are defined in 
 * `Set.prod`: Binary product of sets. For `s : Set α`, `t : Set β`, we have
   `s.prod t : Set (α × β)`. Denoted by `s ×ˢ t`.
 * `Set.diagonal`: Diagonal of a type. `Set.diagonal α = {(x, x) | x : α}`.
-* `Set.offDiag`: Off-diagonal. `s ×ˢ s` without the diagonal.
+* `Set.offDiagonal`: Off-diagonal. `s ×ˢ s` without the diagonal.
 * `Set.pi`: Arbitrary product of sets.
 -/
 
@@ -430,7 +430,7 @@ theorem preimage_coe_coe_diagonal (s : Set α) :
   simp [Set.diagonal]
 
 @[simp]
-theorem range_diag : range Function.diag = diagonal α := by
+theorem range_diag : range Prod.diagonal = diagonal α := by
   ext ⟨x, y⟩
   simp [diagonal, eq_comm]
 
@@ -441,13 +441,13 @@ theorem prod_subset_compl_diagonal_iff_disjoint : s ×ˢ t ⊆ (diagonal α)ᶜ 
   prod_subset_iff.trans disjoint_iff_forall_ne.symm
 
 @[simp]
-theorem diag_preimage_prod (s t : Set α) : Function.diag ⁻¹' s ×ˢ t = s ∩ t :=
+theorem diag_preimage_prod (s t : Set α) : Prod.diagonal ⁻¹' s ×ˢ t = s ∩ t :=
   rfl
 
-theorem diag_preimage_prod_self (s : Set α) : Function.diag ⁻¹' s ×ˢ s = s :=
+theorem diag_preimage_prod_self (s : Set α) : Prod.diagonal ⁻¹' s ×ˢ s = s :=
   inter_self s
 
-theorem diag_image (s : Set α) : Function.diag '' s = diagonal α ∩ s ×ˢ s := by
+theorem diag_image (s : Set α) : Prod.diagonal '' s = diagonal α ∩ s ×ˢ s := by
   rw [← range_diag, ← image_preimage_eq_range_inter, diag_preimage_prod_self]
 
 theorem diagonal_eq_univ_iff : diagonal α = univ ↔ Subsingleton α := by
@@ -549,70 +549,100 @@ end Pullback
 
 namespace Set
 
-section OffDiag
+section OffDiagonal
 
 variable {α : Type*} {s t : Set α} {a : α}
 
-theorem offDiag_mono : Monotone (offDiag : Set α → Set (α × α)) := fun _ _ h _ =>
+theorem offDiagonal_mono : Monotone (offDiagonal : Set α → Set (α × α)) := fun _ _ h _ =>
   And.imp (@h _) <| And.imp_left <| @h _
 
-@[simp]
-theorem offDiag_nonempty : s.offDiag.Nonempty ↔ s.Nontrivial := by
-  simp [offDiag, Set.Nonempty, Set.Nontrivial]
+@[deprecated (since := "2026-09-06")] alias offDiag_mono := offDiagonal_mono
 
 @[simp]
-theorem offDiag_eq_empty : s.offDiag = ∅ ↔ s.Subsingleton := by
-  rw [← not_nonempty_iff_eq_empty, ← not_nontrivial_iff, offDiag_nonempty.not]
+theorem offDiagonal_nonempty : s.offDiagonal.Nonempty ↔ s.Nontrivial := by
+  simp [offDiagonal, Set.Nonempty, Set.Nontrivial]
 
-alias ⟨_, Nontrivial.offDiag_nonempty⟩ := offDiag_nonempty
+@[deprecated (since := "2026-09-06")] alias offDiag_nonempty := offDiagonal_nonempty
 
-alias ⟨_, Subsingleton.offDiag_eq_empty⟩ := offDiag_eq_empty
+@[simp]
+theorem offDiagonal_eq_empty : s.offDiagonal = ∅ ↔ s.Subsingleton := by
+  rw [← not_nonempty_iff_eq_empty, ← not_nontrivial_iff, offDiagonal_nonempty.not]
+
+alias ⟨_, Nontrivial.offDiagonal_nonempty⟩ := offDiagonal_nonempty
+
+alias ⟨_, Subsingleton.offDiagonal_eq_empty⟩ := offDiagonal_eq_empty
+
+@[deprecated (since := "2026-09-06")] alias offDiag_eq_empty := offDiagonal_eq_empty
+@[deprecated (since := "2026-09-06")]
+alias Nontrivial.offDiag_nonempty := Nontrivial.offDiagonal_nonempty
+@[deprecated (since := "2026-09-06")]
+alias Subsingleton.offDiag_eq_empty := Subsingleton.offDiagonal_eq_empty
 
 variable (s t)
 
-theorem offDiag_subset_prod : s.offDiag ⊆ s ×ˢ s := fun _ hx => ⟨hx.1, hx.2.1⟩
+theorem offDiagonal_subset_prod : s.offDiagonal ⊆ s ×ˢ s := fun _ hx => ⟨hx.1, hx.2.1⟩
 
-theorem offDiag_eq_sep_prod : s.offDiag = { x ∈ s ×ˢ s | x.1 ≠ x.2 } :=
+@[deprecated (since := "2026-09-06")] alias offDiag_subset_prod := offDiagonal_subset_prod
+
+theorem offDiagonal_eq_sep_prod : s.offDiagonal = { x ∈ s ×ˢ s | x.1 ≠ x.2 } :=
   ext fun _ => and_assoc.symm
 
-@[simp]
-theorem offDiag_empty : (∅ : Set α).offDiag = ∅ := by simp
+@[deprecated (since := "2026-09-06")] alias offDiag_eq_sep_prod := offDiagonal_eq_sep_prod
 
 @[simp]
-theorem offDiag_singleton (a : α) : ({a} : Set α).offDiag = ∅ := by simp
+theorem offDiagonal_empty : (∅ : Set α).offDiagonal = ∅ := by simp
+
+@[deprecated (since := "2026-09-06")] alias offDiag_empty := offDiagonal_empty
 
 @[simp]
-theorem offDiag_univ : (univ : Set α).offDiag = (diagonal α)ᶜ :=
+theorem offDiagonal_singleton (a : α) : ({a} : Set α).offDiagonal = ∅ := by simp
+
+@[deprecated (since := "2026-09-06")] alias offDiag_singleton := offDiagonal_singleton
+
+@[simp]
+theorem offDiagonal_univ : (univ : Set α).offDiagonal = (diagonal α)ᶜ :=
   ext <| by simp
 
+@[deprecated (since := "2026-09-06")] alias offDiag_univ := offDiagonal_univ
+
 @[simp]
-theorem prod_sdiff_diagonal : s ×ˢ s \ diagonal α = s.offDiag :=
+theorem prod_sdiff_diagonal : s ×ˢ s \ diagonal α = s.offDiagonal :=
   ext fun _ => and_assoc
 
 @[simp]
-theorem disjoint_diagonal_offDiag : Disjoint (diagonal α) s.offDiag :=
+theorem disjoint_diagonal_offDiagonal : Disjoint (diagonal α) s.offDiagonal :=
   disjoint_left.mpr fun _ hd ho => ho.2.2 hd
 
-theorem offDiag_inter : (s ∩ t).offDiag = s.offDiag ∩ t.offDiag :=
+@[deprecated (since := "2026-09-06")]
+alias disjoint_diagonal_offDiag := disjoint_diagonal_offDiagonal
+
+theorem offDiagonal_inter : (s ∩ t).offDiagonal = s.offDiagonal ∩ t.offDiagonal :=
   ext fun x => by
-    simp only [mem_offDiag, mem_inter_iff]
+    simp only [mem_offDiagonal, mem_inter_iff]
     tauto
+
+@[deprecated (since := "2026-09-06")] alias offDiag_inter := offDiagonal_inter
 
 variable {s t}
 
-theorem offDiag_union (h : Disjoint s t) :
-    (s ∪ t).offDiag = s.offDiag ∪ t.offDiag ∪ s ×ˢ t ∪ t ×ˢ s := by
+theorem offDiagonal_union (h : Disjoint s t) :
+    (s ∪ t).offDiagonal = s.offDiagonal ∪ t.offDiagonal ∪ s ×ˢ t ∪ t ×ˢ s := by
   ext x
-  simp only [mem_offDiag, mem_union, ne_eq, mem_prod]
+  simp only [mem_offDiagonal, mem_union, ne_eq, mem_prod]
   constructor
   · rintro ⟨h0 | h0, h1 | h1, h2⟩ <;> simp [h0, h1, h2]
   · rintro (((⟨h0, h1, h2⟩ | ⟨h0, h1, h2⟩) | ⟨h0, h1⟩) | ⟨h0, h1⟩) <;>
       simp [*, h.ne_of_mem, Ne.symm]
 
-theorem offDiag_insert (ha : a ∉ s) : (insert a s).offDiag = s.offDiag ∪ {a} ×ˢ s ∪ s ×ˢ {a} := by
+@[deprecated (since := "2026-09-06")] alias offDiag_union := offDiagonal_union
+
+theorem offDiagonal_insert (ha : a ∉ s) :
+    (insert a s).offDiagonal = s.offDiagonal ∪ {a} ×ˢ s ∪ s ×ˢ {a} := by
   grind
 
-end OffDiag
+@[deprecated (since := "2026-09-06")] alias offDiag_insert := offDiagonal_insert
+
+end OffDiagonal
 
 /-! ### Cartesian set-indexed product of sets -/
 

--- a/Mathlib/Data/Sym/Card.lean
+++ b/Mathlib/Data/Sym/Card.lean
@@ -122,41 +122,55 @@ namespace Sym2
 
 variable [DecidableEq α]
 
-/-- The `diag` of `s : Finset α` is sent on a finset of `Sym2 α` of card `#s`. -/
-theorem card_image_diag (s : Finset α) : #(s.diag.image Sym2.mk.uncurry) = #s := by
+/-- The `diagonal` of `s : Finset α` is sent on a finset of `Sym2 α` of card `#s`. -/
+theorem card_image_diagonal (s : Finset α) : #(s.diagonal.image Sym2.mk.uncurry) = #s := by
   simp [card_image_of_injOn]
 
-lemma two_mul_card_image_offDiag (s : Finset α) :
-    2 * #(s.offDiag.image Sym2.mk.uncurry) = #s.offDiag := by
+@[deprecated (since := "2026-09-06")] alias card_image_diag := card_image_diagonal
+
+lemma two_mul_card_image_offDiagonal (s : Finset α) :
+    2 * #(s.offDiagonal.image Sym2.mk.uncurry) = #s.offDiagonal := by
   rw [card_eq_sum_card_image (Sym2.mk.uncurry : α × α → _), sum_const_nat (Sym2.ind _), mul_comm]
   -- FIXME: Would be cool for the final `aesop` call not to require this `a ≠ b ∨ b ≠ a` trick.
   have (a b : α) (ha : a ∈ s) (hb : b ∈ s) (hab : a ≠ b ∨ b ≠ a) :
-      {z ∈ s.offDiag | Sym2.mk.uncurry z = s(a, b)} = .cons (a, b) {(b, a)}
+      {z ∈ s.offDiagonal | Sym2.mk.uncurry z = s(a, b)} = .cons (a, b) {(b, a)}
         (by simpa [eq_comm] using hab) := by aesop
   aesop
 
-/-- The `offDiag` of `s : Finset α` is sent on a finset of `Sym2 α` of card `#s.offDiag / 2`.
+@[deprecated (since := "2026-09-06")]
+alias two_mul_card_image_offDiag := two_mul_card_image_offDiagonal
+
+/-- The `offDiagonal` of `s : Finset α` is sent on a finset of `Sym2 α` of
+card `#s.offDiagonal / 2`.
 This is because every element `s(x, y)` of `Sym2 α` not on the diagonal comes from exactly two
 pairs: `(x, y)` and `(y, x)`. -/
-theorem card_image_offDiag (s : Finset α) :
-    #(s.offDiag.image Sym2.mk.uncurry) = (#s).choose 2 := by
-  rw [Nat.choose_two_right, Nat.mul_sub_left_distrib, mul_one, ← offDiag_card,
-    Nat.div_eq_of_eq_mul_right Nat.zero_lt_two (two_mul_card_image_offDiag s).symm]
+theorem card_image_offDiagonal (s : Finset α) :
+    #(s.offDiagonal.image Sym2.mk.uncurry) = (#s).choose 2 := by
+  rw [Nat.choose_two_right, Nat.mul_sub_left_distrib, mul_one, ← offDiagonal_card,
+    Nat.div_eq_of_eq_mul_right Nat.zero_lt_two (two_mul_card_image_offDiagonal s).symm]
 
-theorem card_subtype_diag [Fintype α] : card { a : Sym2 α // a.IsDiag } = card α :=
-  card_congr diagElemEquiv
+@[deprecated (since := "2026-09-06")] alias card_image_offDiag := card_image_offDiagonal
 
-theorem card_subtype_not_diag [Fintype α] :
-    card { a : Sym2 α // ¬a.IsDiag } = (card α).choose 2 := by
-  convert! card_image_offDiag (univ : Finset α)
-  rw [← filter_image_mk_not_isDiag, Fintype.card_of_subtype]
+theorem card_subtype_diagonal [Fintype α] : card { a : Sym2 α // a.IsDiagonal } = card α :=
+  card_congr diagonalElemEquiv
+
+@[deprecated (since := "2026-09-06")] alias card_subtype_diag := card_subtype_diagonal
+
+theorem card_subtype_not_diagonal [Fintype α] :
+    card { a : Sym2 α // ¬a.IsDiagonal } = (card α).choose 2 := by
+  convert! card_image_offDiagonal (univ : Finset α)
+  rw [← filter_image_mk_not_isDiagonal, Fintype.card_of_subtype]
   rintro x
   rw [mem_filter, univ_product_univ, mem_image]
   obtain ⟨a, ha⟩ := Quot.exists_rep x
   exact and_iff_right ⟨a, mem_univ _, ha⟩
 
-lemma card_diagSet_compl [Fintype α] : card (diagSetᶜ : Set (Sym2 α)) = (card α).choose 2 :=
-  card_subtype_not_diag
+@[deprecated (since := "2026-09-06")] alias card_subtype_not_diag := card_subtype_not_diagonal
+
+lemma card_diagonalSet_compl [Fintype α] : card (diagonalSetᶜ : Set (Sym2 α)) = (card α).choose 2 :=
+  card_subtype_not_diagonal
+
+@[deprecated (since := "2026-09-06")] alias card_diagSet_compl := card_diagonalSet_compl
 
 /-- Type **stars and bars** for the case `n = 2`. -/
 protected theorem card {α} [Fintype α] : card (Sym2 α) = Nat.choose (card α + 1) 2 :=

--- a/Mathlib/Data/Sym/NatCard.lean
+++ b/Mathlib/Data/Sym/NatCard.lean
@@ -47,31 +47,39 @@ end Sym
 namespace Sym2
 
 instance [Infinite α] : Infinite (Sym2 α) :=
-  .of_injective Sym2.diag <| Sym2.diag_injective
+  .of_injective Sym2.diagonal <| Sym2.diagonal_injective
 
-instance [Infinite α] : Infinite {a : Sym2 α // a.IsDiag} :=
-  .of_injective (fun a : α => ⟨.diag a, rfl⟩) fun _ _ h => Sym2.diag_injective congr($h)
+instance [Infinite α] : Infinite {a : Sym2 α // a.IsDiagonal} :=
+  .of_injective (fun a : α => ⟨.diagonal a, rfl⟩) fun _ _ h => Sym2.diagonal_injective congr($h)
 
-instance [Infinite α] : Infinite {a : Sym2 α // ¬a.IsDiag} :=
+instance [Infinite α] : Infinite {a : Sym2 α // ¬a.IsDiagonal} :=
   let e := Infinite.natEmbedding α
   .of_injective (fun n => ⟨s(e 0, e (n + 1)), by simp⟩) fun _ _ => by simp
 
-theorem natCard_subtype_diag : Nat.card { a : Sym2 α // a.IsDiag } = Nat.card α :=
-  Nat.card_congr diagElemEquiv
+theorem natCard_subtype_diagonal : Nat.card { a : Sym2 α // a.IsDiagonal } = Nat.card α :=
+  Nat.card_congr diagonalElemEquiv
 
-theorem natCard_subtype_not_diag :
-    Nat.card { a : Sym2 α // ¬a.IsDiag } = (Nat.card α).choose 2 := by
+@[deprecated (since := "2026-09-06")] alias natCard_subtype_diag := natCard_subtype_diagonal
+
+theorem natCard_subtype_not_diagonal :
+    Nat.card { a : Sym2 α // ¬a.IsDiagonal } = (Nat.card α).choose 2 := by
   cases finite_or_infinite α
   · obtain ⟨_⟩ := nonempty_fintype α; let := Classical.decEq α
     simp_rw [Nat.card_eq_fintype_card]
-    exact card_subtype_not_diag
+    exact card_subtype_not_diagonal
   · simp
 
-lemma ncard_diagSet : (diagSet : Set (Sym2 α)).ncard = Nat.card α :=
-  natCard_subtype_diag _
+@[deprecated (since := "2026-09-06")] alias natCard_subtype_not_diag := natCard_subtype_not_diagonal
 
-lemma ncard_diagSet_compl : (diagSetᶜ : Set (Sym2 α)).ncard = (Nat.card α).choose 2 :=
-  natCard_subtype_not_diag _
+lemma ncard_diagonalSet : (diagonalSet : Set (Sym2 α)).ncard = Nat.card α :=
+  natCard_subtype_diagonal _
+
+@[deprecated (since := "2026-09-06")] alias ncard_diagSet := ncard_diagonalSet
+
+lemma ncard_diagonalSet_compl : (diagonalSetᶜ : Set (Sym2 α)).ncard = (Nat.card α).choose 2 :=
+  natCard_subtype_not_diagonal _
+
+@[deprecated (since := "2026-09-06")] alias ncard_diagSet_compl := ncard_diagonalSet_compl
 
 /-- Type **stars and bars** for the case `n = 2`. -/
 protected theorem natCard : Nat.card (Sym2 α) = Nat.choose (Nat.card α + 1) 2 := by

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -498,76 +498,121 @@ variable {z : Sym2 α} {f : α → β}
 /-- A type `α` is naturally included in the diagonal of `α × α`, and this function gives the image
 of this diagonal in `Sym2 α`.
 -/
-def diag (x : α) : Sym2 α := s(x, x)
+def diagonal (x : α) : Sym2 α := s(x, x)
 
-theorem diag_injective : Function.Injective (Sym2.diag : α → Sym2 α) := fun x y h => by
+@[deprecated (since := "2026-09-06")] alias diag := diagonal
+
+theorem diagonal_injective : Function.Injective (Sym2.diagonal : α → Sym2 α) := fun x y h => by
   cases Sym2.exact h <;> rfl
+
+@[deprecated (since := "2026-09-06")] alias diag_injective := diagonal_injective
 
 /-- A predicate for testing whether an element of `Sym2 α` is on the diagonal.
 -/
-def IsDiag : Sym2 α → Prop :=
+def IsDiagonal : Sym2 α → Prop :=
   lift ⟨Eq, fun _ _ => propext eq_comm⟩
 
+@[deprecated (since := "2026-09-06")] alias IsDiag := IsDiagonal
+
 @[simp]
-theorem mk_isDiag_iff {x y : α} : IsDiag s(x, y) ↔ x = y :=
+theorem mk_isDiagonal_iff {x y : α} : IsDiagonal s(x, y) ↔ x = y :=
   Iff.rfl
 
-protected lemma IsDiag.map : z.IsDiag → (z.map f).IsDiag := Sym2.ind (fun _ _ ↦ congr_arg f) z
+@[deprecated (since := "2026-09-06")] alias mk_isDiag_iff := mk_isDiagonal_iff
 
-lemma isDiag_map (hf : Injective f) : (z.map f).IsDiag ↔ z.IsDiag :=
+protected lemma IsDiagonal.map : z.IsDiagonal → (z.map f).IsDiagonal :=
+  Sym2.ind (fun _ _ ↦ congr_arg f) z
+
+@[deprecated (since := "2026-09-06")] alias IsDiag.map := IsDiagonal.map
+
+lemma isDiagonal_map (hf : Injective f) : (z.map f).IsDiagonal ↔ z.IsDiagonal :=
   Sym2.ind (fun _ _ ↦ hf.eq_iff) z
 
+@[deprecated (since := "2026-09-06")] alias isDiag_map := isDiagonal_map
+
 @[simp]
-theorem diag_isDiag (a : α) : IsDiag (diag a) :=
+theorem diagonal_isDiagonal (a : α) : IsDiagonal (diagonal a) :=
   Eq.refl a
 
+@[deprecated (since := "2026-09-06")] alias diag_isDiag := diagonal_isDiagonal
+
 @[simp, nontriviality]
-lemma isDiag_of_subsingleton [Subsingleton α] (z : Sym2 α) : z.IsDiag := z.ind Subsingleton.elim
+lemma isDiagonal_of_subsingleton [Subsingleton α] (z : Sym2 α) : z.IsDiagonal :=
+  z.ind Subsingleton.elim
+
+@[deprecated (since := "2026-09-06")] alias isDiag_of_subsingleton := isDiagonal_of_subsingleton
 
 variable (z) in
 /-- Computably extract the element when known to be diagonal. -/
-def diagElem : z.IsDiag → α :=
+def diagonalElem : z.IsDiagonal → α :=
   z.rec (fun a b _ => a) fun a b a' b' h => funext fun hx : a' = b' => by
     cases hx
     cases h <;> rfl
 
-@[simp]
-theorem diagElem_mk {a b : α} (h : IsDiag s(a, b)) : s(a, b).diagElem h = a := rfl
+@[deprecated (since := "2026-09-06")] alias diagElem := diagonalElem
 
 @[simp]
-theorem diag_diagElem (h : z.IsDiag) : diag (z.diagElem h) = z := by
+theorem diagonalElem_mk {a b : α} (h : IsDiagonal s(a, b)) : s(a, b).diagonalElem h = a := rfl
+
+@[deprecated (since := "2026-09-06")] alias diagElem_mk := diagonalElem_mk
+
+@[simp]
+theorem diagonal_diagonalElem (h : z.IsDiagonal) : diagonal (z.diagonalElem h) = z := by
   cases z; cases h; rfl
 
-/-- `Sym2.diagElem` and `Sym2.diag` as an equivalence. -/
+@[deprecated (since := "2026-09-06")] alias diag_diagElem := diagonal_diagonalElem
+
+/-- `Sym2.diagonalElem` and `Sym2.diagonal` as an equivalence. -/
 @[simps]
-def diagElemEquiv : { a : Sym2 α // a.IsDiag } ≃ α where
-  toFun x := x.1.diagElem x.2
-  invFun a := ⟨diag a, rfl⟩
+def diagonalElemEquiv : { a : Sym2 α // a.IsDiagonal } ≃ α where
+  toFun x := x.1.diagonalElem x.2
+  invFun a := ⟨diagonal a, rfl⟩
   left_inv x := by ext; simp
-  right_inv a := by simp [diag]
+  right_inv a := by simp [diagonal]
+
+@[deprecated (since := "2026-09-06")] alias diagElemEquiv := diagonalElemEquiv
 
 /-- The set of all `Sym2 α` elements on the diagonal. -/
-def diagSet : Set (Sym2 α) := {z | z.IsDiag}
+def diagonalSet : Set (Sym2 α) := {z | z.IsDiagonal}
 
-@[simp] lemma mem_diagSet : z ∈ diagSet ↔ z.IsDiag := .rfl
+@[deprecated (since := "2026-09-06")] alias diagSet := diagonalSet
 
-@[simp] lemma range_diag : .range (diag : α → Sym2 α) = diagSet := by
-  ext ⟨a, b⟩; simp [diag, eq_comm]
+@[simp] lemma mem_diagonalSet : z ∈ diagonalSet ↔ z.IsDiagonal := .rfl
 
-theorem diagSet_eq_setOfPred_isDiag : diagSet = {z : Sym2 α | z.IsDiag} := rfl
+@[deprecated (since := "2026-09-06")] alias mem_diagSet := mem_diagonalSet
+
+@[simp] lemma range_diagonal : .range (diagonal : α → Sym2 α) = diagonalSet := by
+  ext ⟨a, b⟩; simp [diagonal, eq_comm]
+
+@[deprecated (since := "2026-09-06")] alias range_diag := range_diagonal
+
+theorem diagonalSet_eq_setOfPred_isDiagonal : diagonalSet = {z : Sym2 α | z.IsDiagonal} := rfl
+
+@[deprecated (since := "2026-09-06")]
+alias diagSet_eq_setOfPred_isDiag := diagonalSet_eq_setOfPred_isDiagonal
 
 @[deprecated (since := "2026-07-09")]
-alias diagSet_eq_setOf_isDiag := diagSet_eq_setOfPred_isDiag
+alias diagSet_eq_setOf_isDiag := diagonalSet_eq_setOfPred_isDiagonal
 
-theorem diagSet_eq_univ_of_subsingleton [Subsingleton α] : @diagSet α = Set.univ := by ext; simp
+theorem diagonalSet_eq_univ_of_subsingleton [Subsingleton α] : @diagonalSet α = Set.univ := by
+  ext; simp
 
-instance IsDiag.decidablePred (α : Type u) [DecidableEq α] : DecidablePred (@IsDiag α) :=
-  fun z => z.recOnSubsingleton fun _ _ => decidable_of_iff' _ mk_isDiag_iff
+@[deprecated (since := "2026-09-06")]
+alias diagSet_eq_univ_of_subsingleton := diagonalSet_eq_univ_of_subsingleton
 
-instance decidablePred_mem_diagSet (α : Type u) [DecidableEq α] : DecidablePred (· ∈ @diagSet α) :=
-  IsDiag.decidablePred _
+instance IsDiagonal.decidablePred (α : Type u) [DecidableEq α] : DecidablePred (@IsDiagonal α) :=
+  fun z => z.recOnSubsingleton fun _ _ => decidable_of_iff' _ mk_isDiagonal_iff
 
-theorem other_ne {a : α} {z : Sym2 α} (hd : ¬IsDiag z) (h : a ∈ z) : Mem.other h ≠ a := by
+@[deprecated (since := "2026-09-06")] alias IsDiag.decidablePred := IsDiagonal.decidablePred
+
+instance decidablePred_mem_diagonalSet (α : Type u) [DecidableEq α] :
+    DecidablePred (· ∈ @diagonalSet α) :=
+  IsDiagonal.decidablePred _
+
+@[deprecated (since := "2026-09-06")]
+alias decidablePred_mem_diagSet := decidablePred_mem_diagonalSet
+
+theorem other_ne {a : α} {z : Sym2 α} (hd : ¬IsDiagonal z) (h : a ∈ z) : Mem.other h ≠ a := by
   contrapose hd
   have h' := Sym2.other_spec h
   rw [hd] at h'
@@ -621,26 +666,41 @@ theorem fromRel_top_iff {sym : Std.Symm r} : fromRel sym = .univ ↔ r = ⊤ := 
   ext x y
   simpa [h] using fromRel_prop (sym := sym)
 
-theorem fromRel_ne : fromRel (α := α) (r := Ne) inferInstance = {z | ¬IsDiag z} := by
+theorem fromRel_ne : fromRel (α := α) (r := Ne) inferInstance = {z | ¬IsDiagonal z} := by
   ext z; exact z.ind (by simp)
 
-lemma diagSet_eq_fromRel_eq : diagSet = fromRel (α := α) eq_equivalence.stdSymm := by
+lemma diagonalSet_eq_fromRel_eq : diagonalSet = fromRel (α := α) eq_equivalence.stdSymm := by
   ext ⟨a, b⟩; simp
 
-lemma diagSet_compl_eq_fromRel_ne : diagSetᶜ = fromRel (α := α) (r := Ne) inferInstance := by
+@[deprecated (since := "2026-09-06")] alias diagSet_eq_fromRel_eq := diagonalSet_eq_fromRel_eq
+
+lemma diagonalSet_compl_eq_fromRel_ne :
+    diagonalSetᶜ = fromRel (α := α) (r := Ne) inferInstance := by
   ext ⟨a, b⟩; simp
 
-@[simp] lemma diagSet_subset_fromRel (hr : Std.Symm r) : diagSet ⊆ fromRel hr ↔ Std.Refl r := by
+@[deprecated (since := "2026-09-06")]
+alias diagSet_compl_eq_fromRel_ne := diagonalSet_compl_eq_fromRel_ne
+
+@[simp] lemma diagonalSet_subset_fromRel (hr : Std.Symm r) :
+    diagonalSet ⊆ fromRel hr ↔ Std.Refl r := by
   simp [Set.subset_def, Sym2.forall, refl_def]
 
-@[simp] lemma disjoint_diagSet_fromRel (hr : Std.Symm r) :
-    Disjoint diagSet (fromRel hr) ↔ Std.Irrefl r := by
+@[deprecated (since := "2026-09-06")] alias diagSet_subset_fromRel := diagonalSet_subset_fromRel
+
+@[simp] lemma disjoint_diagonalSet_fromRel (hr : Std.Symm r) :
+    Disjoint diagonalSet (fromRel hr) ↔ Std.Irrefl r := by
   simp [Set.disjoint_left, Sym2.forall, irrefl_def]
 
-@[simp] lemma fromRel_subset_compl_diagSet (hr : Std.Symm r) :
-    fromRel hr ⊆ diagSetᶜ ↔ Std.Irrefl r := by simp [Set.subset_compl_iff_disjoint_left]
+@[deprecated (since := "2026-09-06")] alias disjoint_diagSet_fromRel := disjoint_diagonalSet_fromRel
 
-theorem fromRel_irrefl {sym : Std.Symm r} : Std.Irrefl r ↔ ∀ {z}, z ∈ fromRel sym → ¬IsDiag z where
+@[simp] lemma fromRel_subset_compl_diagonalSet (hr : Std.Symm r) :
+    fromRel hr ⊆ diagonalSetᶜ ↔ Std.Irrefl r := by simp [Set.subset_compl_iff_disjoint_left]
+
+@[deprecated (since := "2026-09-06")]
+alias fromRel_subset_compl_diagSet := fromRel_subset_compl_diagonalSet
+
+theorem fromRel_irrefl {sym : Std.Symm r} :
+    Std.Irrefl r ↔ ∀ {z}, z ∈ fromRel sym → ¬IsDiagonal z where
   mp := by intro ⟨h⟩; apply Sym2.ind; aesop
   mpr h := ⟨fun _ hr ↦ h (fromRel_prop.mpr hr) rfl⟩
 
@@ -803,23 +863,30 @@ lemma toFinset_mk_eq {x y : α} : s(x, y).toFinset = {x, y} := by
   ext; simp [← Sym2.mem_toFinset, ← Sym2.mem_iff]
 
 /-- Mapping an unordered pair on the diagonal to a finite set produces a finset of size `1`. -/
-theorem card_toFinset_of_isDiag (z : Sym2 α) (h : z.IsDiag) : #(z : Sym2 α).toFinset = 1 := by
+theorem card_toFinset_of_isDiagonal (z : Sym2 α) (h : z.IsDiagonal) :
+    #(z : Sym2 α).toFinset = 1 := by
   induction z
-  rw [Sym2.mk_isDiag_iff] at h
+  rw [Sym2.mk_isDiagonal_iff] at h
   simp [Sym2.toFinset_mk_eq, h]
 
+@[deprecated (since := "2026-09-06")] alias card_toFinset_of_isDiag := card_toFinset_of_isDiagonal
+
 /-- Mapping an unordered pair off the diagonal to a finite set produces a finset of size `2`. -/
-theorem card_toFinset_of_not_isDiag (z : Sym2 α) (h : ¬z.IsDiag) : #(z : Sym2 α).toFinset = 2 := by
+theorem card_toFinset_of_not_isDiagonal (z : Sym2 α) (h : ¬z.IsDiagonal) :
+    #(z : Sym2 α).toFinset = 2 := by
   induction z
-  rw [Sym2.mk_isDiag_iff] at h
+  rw [Sym2.mk_isDiagonal_iff] at h
   simp [Sym2.toFinset_mk_eq, h]
+
+@[deprecated (since := "2026-09-06")]
+alias card_toFinset_of_not_isDiag := card_toFinset_of_not_isDiagonal
 
 /-- Mapping an unordered pair to a finite set produces a finset of size `1` if the pair is on the
 diagonal, else of size `2` if the pair is off the diagonal. -/
-theorem card_toFinset (z : Sym2 α) : #(z : Sym2 α).toFinset = if z.IsDiag then 1 else 2 := by
-  by_cases h : z.IsDiag
-  · simp [card_toFinset_of_isDiag z h, h]
-  · simp [card_toFinset_of_not_isDiag z h, h]
+theorem card_toFinset (z : Sym2 α) : #(z : Sym2 α).toFinset = if z.IsDiagonal then 1 else 2 := by
+  by_cases h : z.IsDiagonal
+  · simp [card_toFinset_of_isDiagonal z h, h]
+  · simp [card_toFinset_of_not_isDiagonal z h, h]
 
 end ToFinset
 
@@ -959,11 +1026,18 @@ theorem other_invol {a : α} {z : Sym2 α} (ha : a ∈ z) (hb : Mem.other ha ∈
     convert! other_invol' ha hb using 2
     apply other_eq_other'
 
-theorem filter_image_mk_isDiag [DecidableEq α] (s : Finset α) :
-    {x ∈ (s ×ˢ s).image Sym2.mk.uncurry | x.IsDiag} = s.diag.image Sym2.mk.uncurry := by aesop
+theorem filter_image_mk_isDiagonal [DecidableEq α] (s : Finset α) :
+    {x ∈ (s ×ˢ s).image Sym2.mk.uncurry | x.IsDiagonal} =
+      s.diagonal.image Sym2.mk.uncurry := by aesop
 
-theorem filter_image_mk_not_isDiag [DecidableEq α] (s : Finset α) :
-    {x ∈ (s ×ˢ s).image Sym2.mk.uncurry | ¬x.IsDiag} = s.offDiag.image Sym2.mk.uncurry := by aesop
+@[deprecated (since := "2026-09-06")] alias filter_image_mk_isDiag := filter_image_mk_isDiagonal
+
+theorem filter_image_mk_not_isDiagonal [DecidableEq α] (s : Finset α) :
+    {x ∈ (s ×ˢ s).image Sym2.mk.uncurry | ¬x.IsDiagonal} =
+      s.offDiagonal.image Sym2.mk.uncurry := by aesop
+
+@[deprecated (since := "2026-09-06")]
+alias filter_image_mk_not_isDiag := filter_image_mk_not_isDiagonal
 
 end Decidable
 
@@ -977,7 +1051,7 @@ instance [IsEmpty α] : IsEmpty (Sym2 α) :=
   (equivSym α).isEmpty
 
 instance [Nontrivial α] : Nontrivial (Sym2 α) :=
-  diag_injective.nontrivial
+  diagonal_injective.nontrivial
 
 -- TODO: use a sort order if available, https://github.com/leanprover-community/mathlib/issues/18166
 unsafe instance [Repr α] : Repr (Sym2 α) where

--- a/Mathlib/Data/TypeVec.lean
+++ b/Mathlib/Data/TypeVec.lean
@@ -442,9 +442,11 @@ def prod.snd : ∀ {n} {α β : TypeVec.{u} n}, α ⊗ β ⟹ β
   | succ _, _, _, Fin2.fz => Prod.snd
 
 /-- introduce a product where both components are the same -/
-def prod.diag : ∀ {n} {α : TypeVec.{u} n}, α ⟹ α ⊗ α
-  | succ _, α, Fin2.fs _, x => @prod.diag _ (drop α) _ x
+def prod.diagonal : ∀ {n} {α : TypeVec.{u} n}, α ⟹ α ⊗ α
+  | succ _, α, Fin2.fs _, x => @prod.diagonal _ (drop α) _ x
   | succ _, _, Fin2.fz, x => (x, x)
+
+@[deprecated (since := "2026-09-06")] alias prod.diag := prod.diagonal
 
 /-- constructor for `prod` -/
 def prod.mk : ∀ {n} {α β : TypeVec.{u} n} (i : Fin2 n), α i → β i → (α ⊗ β) i
@@ -492,15 +494,19 @@ theorem snd_prod_mk {α α' β β' : TypeVec n} (f : α ⟹ β) (g : α' ⟹ β'
   | fz => rfl
   | fs _ i_ih => apply i_ih
 
-theorem fst_diag {α : TypeVec n} : TypeVec.prod.fst ⊚ (prod.diag : α ⟹ _) = id := by
+theorem fst_diagonal {α : TypeVec n} : TypeVec.prod.fst ⊚ (prod.diagonal : α ⟹ _) = id := by
   funext i; induction i with
   | fz => rfl
   | fs _ i_ih => apply i_ih
 
-theorem snd_diag {α : TypeVec n} : TypeVec.prod.snd ⊚ (prod.diag : α ⟹ _) = id := by
+@[deprecated (since := "2026-09-06")] alias fst_diag := fst_diagonal
+
+theorem snd_diagonal {α : TypeVec n} : TypeVec.prod.snd ⊚ (prod.diagonal : α ⟹ _) = id := by
   funext i; induction i with
   | fz => rfl
   | fs _ i_ih => apply i_ih
+
+@[deprecated (since := "2026-09-06")] alias snd_diag := snd_diagonal
 
 theorem repeatEq_iff_eq {α : TypeVec n} {i x y} :
     ofRepeat (repeatEq α i (prod.mk _ x y)) ↔ x = y := by
@@ -548,11 +554,13 @@ def ofSubtype' {n} {α : TypeVec.{u} n} (p : α ⊗ α ⟹ «repeat» n Prop) :
   | Fin2.fs i, x => ofSubtype' _ i x
   | Fin2.fz, x => ⟨x.val, cast (by congr) x.property⟩
 
-/-- similar to `diag` but the target vector is a `Subtype_`
+/-- similar to `diagonal` but the target vector is a `Subtype_`
 guaranteeing the equality of the components -/
-def diagSub {n} {α : TypeVec.{u} n} : α ⟹ Subtype_ (repeatEq α)
-  | Fin2.fs _, x => @diagSub _ (drop α) _ x
+def diagonalSub {n} {α : TypeVec.{u} n} : α ⟹ Subtype_ (repeatEq α)
+  | Fin2.fs _, x => @diagonalSub _ (drop α) _ x
   | Fin2.fz, x => ⟨(x, x), rfl⟩
+
+@[deprecated (since := "2026-09-06")] alias diagSub := diagonalSub
 
 theorem subtypeVal_nil {α : TypeVec.{u} 0} (ps : α ⟹ «repeat» 0 Prop) :
     TypeVec.subtypeVal ps = nilFun :=
@@ -560,11 +568,14 @@ theorem subtypeVal_nil {α : TypeVec.{u} 0} (ps : α ⟹ «repeat» 0 Prop) :
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem diag_sub_val {n} {α : TypeVec.{u} n} : subtypeVal (repeatEq α) ⊚ diagSub = prod.diag := by
+theorem diagonal_sub_val {n} {α : TypeVec.{u} n} :
+    subtypeVal (repeatEq α) ⊚ diagonalSub = prod.diagonal := by
   ext i x
   induction i with
-  | fz => simp only [comp, subtypeVal, diagSub, prod.diag]
+  | fz => simp only [comp, subtypeVal, diagonalSub, prod.diagonal]
   | fs _ i_ih => apply @i_ih (drop α)
+
+@[deprecated (since := "2026-09-06")] alias diag_sub_val := diagonal_sub_val
 
 theorem prod_id : ∀ {n} {α β : TypeVec.{u} n}, (id ⊗' id) = (id : α ⊗ β ⟹ _) := by
   intros
@@ -585,7 +596,9 @@ theorem append_prod_appendFun {n} {α α' β β' : TypeVec.{u} n} {φ φ' ψ ψ'
 end Liftp'
 
 @[simp]
-theorem dropFun_diag {α} : dropFun (@prod.diag (n + 1) α) = prod.diag := rfl
+theorem dropFun_diagonal {α} : dropFun (@prod.diagonal (n + 1) α) = prod.diagonal := rfl
+
+@[deprecated (since := "2026-09-06")] alias dropFun_diag := dropFun_diagonal
 
 @[simp]
 theorem dropFun_subtypeVal {α} (p : α ⟹ «repeat» (n + 1) Prop) :

--- a/Mathlib/LinearAlgebra/ExteriorPower/Basis.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/Basis.lean
@@ -54,7 +54,7 @@ lemma ιMultiDual_apply_ιMulti (s : powersetCard I n) (v : Fin n → M) :
 /-- Let `b` be a basis of `M` indexed by a linearly ordered type `I` and `s` be a finset of `I`
 of cardinality `n`. If we apply the linear form on `⋀[R]^n M` defined by `b` and `s`
 to the exterior product of the `b i` for `i ∈ s`, then we get `1`. -/
-lemma ιMultiDual_apply_diag (s : powersetCard I n) :
+lemma ιMultiDual_apply_diagonal (s : powersetCard I n) :
     ιMultiDual R n b s (ιMulti_family R n b s) = 1 := by
   rw [ιMulti_family, ιMultiDual_apply_ιMulti]
   suffices Matrix.of (fun i j => b.coord (powersetCard.ofFinEmbEquiv.symm s j)
@@ -63,11 +63,14 @@ lemma ιMultiDual_apply_diag (s : powersetCard I n) :
   ext
   simp [Matrix.one_apply, Finsupp.single_apply]
 
+@[deprecated (since := "2026-09-06")]
+alias ιMultiDual_apply_diag := ιMultiDual_apply_diagonal
+
 /-- Let `b` be a basis of `M` indexed by a linearly ordered type `I` and `s` be a finset of `I`
 of cardinality `n`. Let `t` be a finset of `I` of cardinality `n` such that `s ≠ t`. If we apply
 the linear form on `⋀[R]^n M` defined by `b` and `s` to the exterior product of the
 `b i` for `i ∈ t`, then we get `0`. -/
-lemma ιMultiDual_apply_nondiag (s t : powersetCard I n) (hst : s ≠ t) :
+lemma ιMultiDual_apply_nondiagonal (s t : powersetCard I n) (hst : s ≠ t) :
     ιMultiDual R n b s (ιMulti_family R n b t) = 0 := by
   rw [ιMulti_family, ιMultiDual_apply_ιMulti]
   obtain ⟨i, his, hit⟩ := (exists_mem_notMem_iff_ne s t).mp hst
@@ -81,14 +84,17 @@ lemma ιMultiDual_apply_nondiag (s t : powersetCard I n) (hst : s ≠ t) :
   rw [h, powersetCard.ofFinEmbEquiv_symm_apply, ← powersetCard.mem_coe_iff]
   exact Finset.orderEmbOfFin_mem t.val t.prop j
 
+@[deprecated (since := "2026-09-06")]
+alias ιMultiDual_apply_nondiag := ιMultiDual_apply_nondiagonal
+
 /-- If `b` is a basis of `M` (indexed by a linearly ordered type), then the family
 `exteriorPower.ιMulti R n b` of the `n`-fold exterior products of its elements is linearly
 independent in the `n`th exterior power of `M`. -/
 lemma ιMulti_family_linearIndependent_ofBasis :
     LinearIndependent R (ιMulti_family R n b) :=
   LinearIndependent.of_pairwise_dual_eq_zero_one _ (fun s ↦ ιMultiDual R n b s)
-    (fun _ _ h => ιMultiDual_apply_nondiag R n b _ _ h)
-    (fun _ => ιMultiDual_apply_diag _ _ _ _)
+    (fun _ _ h => ιMultiDual_apply_nondiagonal R n b _ _ h)
+    (fun _ => ιMultiDual_apply_diagonal _ _ _ _)
 
 variable {R} in
 /-- If `b` is a basis of `M` (indexed by a linearly ordered type), the basis of the `n`th
@@ -117,8 +123,8 @@ lemma basis_coord (s : powersetCard I n) :
   rintro x ⟨t, rfl⟩
   rw [Basis.coord_apply]
   by_cases! hst : s = t
-  · rw [hst, ιMultiDual_apply_diag, ← basis_apply, Basis.repr_self, Finsupp.single_eq_same]
-  · rw [ιMultiDual_apply_nondiag R n b s t hst, ← basis_apply, Basis.repr_self,
+  · rw [hst, ιMultiDual_apply_diagonal, ← basis_apply, Basis.repr_self, Finsupp.single_eq_same]
+  · rw [ιMultiDual_apply_nondiagonal R n b s t hst, ← basis_apply, Basis.repr_self,
       Finsupp.single_eq_of_ne hst]
 
 lemma basis_repr_apply (x : ⋀[R]^n M)
@@ -129,12 +135,12 @@ lemma basis_repr_apply (x : ⋀[R]^n M)
 @[simp]
 lemma basis_repr_self (s : powersetCard I n) :
     Basis.repr (b.exteriorPower n) (ιMulti_family R n b s) s = 1 := by
-  simpa [basis_repr_apply] using ιMultiDual_apply_diag R n b s
+  simpa [basis_repr_apply] using ιMultiDual_apply_diagonal R n b s
 
 @[simp]
 lemma basis_repr_ne {s t : powersetCard I n} (hst : s ≠ t) :
     Basis.repr (b.exteriorPower n) (ιMulti_family R n b s) t = 0 := by
-  simpa [basis_repr_apply] using ιMultiDual_apply_nondiag R n b t s hst.symm
+  simpa [basis_repr_apply] using ιMultiDual_apply_nondiagonal R n b t s hst.symm
 
 lemma basis_repr (s : powersetCard I n) :
     Basis.repr (b.exteriorPower n) (ιMulti_family R n b s) = Finsupp.single s 1 := by

--- a/Mathlib/LinearAlgebra/Matrix/Cartan.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Cartan.lean
@@ -462,7 +462,7 @@ end CartanMatrix
 structure Matrix.IsFiniteCartan {ι : Type*} [Fintype ι] [DecidableEq ι]
     (M : Matrix ι ι ℤ) : Prop where
   diag : ∀ i, M i i = 2
-  offDiag_nonpos : ∀ i j, i ≠ j → M i j ≤ 0
+  offDiagonal_nonpos : ∀ i j, i ≠ j → M i j ≤ 0
   zero_comm : ∀ i j, M i j = 0 ↔ M j i = 0
   exists_posDef : ∃ d : ι → ℤ, (∀ i, 0 < d i) ∧ (diagonal d * M).PosDef
 

--- a/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
@@ -79,7 +79,7 @@ section Field
 variable {m : Type*} [Fintype m] {K : Type u} [Field K]
 
 theorem rank_diagonal [DecidableEq m] [DecidableEq K] (w : m → K) :
-    LinearMap.rank (toLin' (diagonal w)) = Fintype.card { i // w i ≠ 0 } := by
+    LinearMap.rank (toLin' (Matrix.diagonal w)) = Fintype.card { i // w i ≠ 0 } := by
   have hIJ : IsCompl { i : m | w i ≠ 0 } { i : m | w i = 0 } := isCompl_compl.symm
   have B₁ := iSup_range_single_eq_iInf_ker_proj K (fun _ : m => K) hIJ (Set.toFinite _)
   rw [LinearMap.rank, range_diagonal, B₁, ← @rank_fun' K]

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -591,47 +591,68 @@ namespace SpecialLinearGroup
 
 /-- An element in SLₙ(F) induced by a diagonal matrix `1` on any other entries and `a`, `a⁻¹` on
   positition `i` and `j` respectively where `i ≠ j`. -/
-noncomputable def diag2n {ι : Type*} [Fintype ι] [DecidableEq ι] {i j : ι} (hij : i ≠ j) (a : F)
+noncomputable def diagonal2n {ι : Type*} [Fintype ι] [DecidableEq ι] {i j : ι} (hij : i ≠ j) (a : F)
     (ha : a ≠ 0) : SpecialLinearGroup ι F :=
   ⟨diagonal (fun k ↦ if k = i then a else if k = j then a⁻¹ else 1), by
     simp [Finset.prod_ite, hij.symm, Finset.card_eq_one (s := {x : ι | x = i}).2 ⟨i, by grind⟩,
       mul_inv_cancel₀ ha]⟩
 
-lemma diag2n_coe {ι : Type*} [Fintype ι] [DecidableEq ι] {i j : ι} (hij : i ≠ j) (a : F)
-    (ha : a ≠ 0) : (diag2n hij a ha).1 = diagonal (fun k ↦
+@[deprecated (since := "2026-09-06")] alias diag2n := diagonal2n
+
+lemma diagonal2n_coe {ι : Type*} [Fintype ι] [DecidableEq ι] {i j : ι} (hij : i ≠ j) (a : F)
+    (ha : a ≠ 0) : (diagonal2n hij a ha).1 = diagonal (fun k ↦
       if k = i then a else if k = j then a⁻¹ else 1) := rfl
+
+@[deprecated (since := "2026-09-06")] alias diag2n_coe := diagonal2n_coe
 
 /-- An element in SL₂(F) induced by a diagonal matrix with `a`, `a⁻¹` on
   positition `0` and `1` respectively. -/
-noncomputable abbrev diag2 (a : F) (ha : a ≠ 0) : SL(2, F) :=
-  diag2n zero_ne_one a ha
+noncomputable abbrev diagonal2 (a : F) (ha : a ≠ 0) : SL(2, F) :=
+  diagonal2n zero_ne_one a ha
 
-lemma diag2_def {a : F} (ha : a ≠ 0) : diag2 a ha = diag2n zero_ne_one a ha := rfl
+@[deprecated (since := "2026-09-06")] alias diag2 := diagonal2
 
-lemma diag2_coe (a : F) (ha : a ≠ 0) :
-    (diag2 a ha).1 = diagonal (fun i ↦ match i with | 0 => a|1 => a⁻¹) := by simp [diag2n_coe]
+lemma diagonal2_def {a : F} (ha : a ≠ 0) : diagonal2 a ha = diagonal2n zero_ne_one a ha := rfl
 
-lemma diag2_coe' {a : F} (ha : a ≠ 0) :
-    (diag2 a ha).1 = !![a, 0; 0, a⁻¹] := by
+@[deprecated (since := "2026-09-06")] alias diag2_def := diagonal2_def
+
+lemma diagonal2_coe (a : F) (ha : a ≠ 0) :
+    (diagonal2 a ha).1 = diagonal (fun i ↦ match i with | 0 => a|1 => a⁻¹) := by
+  simp [diagonal2n_coe]
+
+@[deprecated (since := "2026-09-06")] alias diag2_coe := diagonal2_coe
+
+lemma diagonal2_coe' {a : F} (ha : a ≠ 0) :
+    (diagonal2 a ha).1 = !![a, 0; 0, a⁻¹] := by
   ext i j
-  fin_cases i <;> fin_cases j <;> simp [diag2n_coe]
+  fin_cases i <;> fin_cases j <;> simp [diagonal2n_coe]
 
-lemma diag2_smul_single_i₁ {a : F} (ha : a ≠ 0) :
-    diag2 a ha • (Pi.single 0 1 : Fin 2 → F) = a • Pi.single 0 (1 : F) := by
-  ext k; fin_cases k <;> simp [Matrix.SpecialLinearGroup.smul_def, diag2_coe]
+@[deprecated (since := "2026-09-06")] alias diag2_coe' := diagonal2_coe'
 
-lemma diag2_smul_single_i₂ {a : F} (ha : a ≠ 0) :
-    diag2 a ha • (Pi.single 1 1 : Fin 2 → F) = a⁻¹ • Pi.single 1 (1 : F) := by
-  ext k; fin_cases k <;> simp [Matrix.SpecialLinearGroup.smul_def, diag2_coe]
+lemma diagonal2_smul_single_i₁ {a : F} (ha : a ≠ 0) :
+    diagonal2 a ha • (Pi.single 0 1 : Fin 2 → F) = a • Pi.single 0 (1 : F) := by
+  ext k; fin_cases k <;> simp [Matrix.SpecialLinearGroup.smul_def, diagonal2_coe]
 
-lemma diag2_mul_inv (a : F) (ha : a ≠ 0) :
-    diag2 a ha * diag2 a⁻¹ (inv_ne_zero ha) = 1 := Subtype.ext <| by
-  simp [diag2_coe, funext_iff, mul_inv_cancel₀ ha, inv_mul_cancel₀ ha]
+@[deprecated (since := "2026-09-06")] alias diag2_smul_single_i₁ := diagonal2_smul_single_i₁
 
-lemma diag2_inv (a : F) (ha : a ≠ 0) :
-    (diag2 a ha)⁻¹ = diag2 a⁻¹ (inv_ne_zero ha) := by
+lemma diagonal2_smul_single_i₂ {a : F} (ha : a ≠ 0) :
+    diagonal2 a ha • (Pi.single 1 1 : Fin 2 → F) = a⁻¹ • Pi.single 1 (1 : F) := by
+  ext k; fin_cases k <;> simp [Matrix.SpecialLinearGroup.smul_def, diagonal2_coe]
+
+@[deprecated (since := "2026-09-06")] alias diag2_smul_single_i₂ := diagonal2_smul_single_i₂
+
+lemma diagonal2_mul_inv (a : F) (ha : a ≠ 0) :
+    diagonal2 a ha * diagonal2 a⁻¹ (inv_ne_zero ha) = 1 := Subtype.ext <| by
+  simp [diagonal2_coe, funext_iff, mul_inv_cancel₀ ha, inv_mul_cancel₀ ha]
+
+@[deprecated (since := "2026-09-06")] alias diag2_mul_inv := diagonal2_mul_inv
+
+lemma diagonal2_inv (a : F) (ha : a ≠ 0) :
+    (diagonal2 a ha)⁻¹ = diagonal2 a⁻¹ (inv_ne_zero ha) := by
   apply inv_eq_of_mul_eq_one_right
-  exact diag2_mul_inv a ha
+  exact diagonal2_mul_inv a ha
+
+@[deprecated (since := "2026-09-06")] alias diag2_inv := diagonal2_inv
 
 section induction
 
@@ -649,7 +670,7 @@ lemma coeMonoidHom_apply (g : SpecialLinearGroup ι R) : coeMonoidHom g = (g : M
 lemma coeMonoidHom_injective : Function.Injective (coeMonoidHom : SpecialLinearGroup ι R → _) :=
   Subtype.val_injective
 
-private lemma diag_decompose (i₀ : ι) (D : ι → F) (hD : det (diagonal D) = 1) :
+private lemma diagonal_decompose (i₀ : ι) (D : ι → F) (hD : det (diagonal D) = 1) :
     Finset.prod {i | i ≠ i₀} (fun i k ↦ if k = i then D i else
       if k = i₀ then (D i)⁻¹ else 1 : ι → ι → F) = D := by
   rw [det_diagonal, show Finset.univ = insert i₀ ({i | i ≠ i₀} : Finset ι) by grind,
@@ -667,29 +688,34 @@ lemma diagonal_neZero (D : ι → F) (hD : det (diagonal D) = 1) (j : ι) :
   exact zero_ne_one hD
 
 set_option backward.isDefEq.respectTransparency.types false in
-lemma diag_commute (i₀ : ι) (D : ι → F) (hD : det (diagonal D) = 1) :
+lemma diagonal_commute (i₀ : ι) (D : ι → F) (hD : det (diagonal D) = 1) :
     (({i | i ≠ i₀} : Finset ι) : Set ι).Pairwise (Function.onFun Commute fun i ↦
-      if hi : i ≠ i₀ then diag2n hi (D i) (diagonal_neZero D hD i) else 1) := by
+      if hi : i ≠ i₀ then diagonal2n hi (D i) (diagonal_neZero D hD i) else 1) := by
   intro i1 hi1 i2 hi2 hi12
   ext i j
-  simp [apply_dite, diag2n_coe]
+  simp [apply_dite, diagonal2n_coe]
   split_ifs <;> simp [diagonal_apply]; grind
 
+@[deprecated (since := "2026-09-06")] alias diag_commute := diagonal_commute
+
 set_option backward.isDefEq.respectTransparency.types false in
-lemma diag_eq_diag2n_prod (i₀ : ι) (D : ι → F) (hD : det (diagonal D) = 1) :
+lemma diagonal_eq_diagonal2n_prod (i₀ : ι) (D : ι → F) (hD : det (diagonal D) = 1) :
     (⟨diagonal D, hD⟩ : SpecialLinearGroup ι F) =
       Finset.noncommProd {i : ι | i ≠ i₀} (fun i ↦ if hi : i ≠ i₀ then
-      diag2n hi (D i) (diagonal_neZero D hD i) else 1) (diag_commute i₀ D hD) := by
+      diagonal2n hi (D i) (diagonal_neZero D hD i) else 1) (diagonal_commute i₀ D hD) := by
   set g : ι → ι → F := fun i k ↦ if k = i then D i else if k = i₀ then (D i)⁻¹ else 1 with hg_def
   apply coeMonoidHom_injective
   rw [Finset.map_noncommProd]
   simp_rw [coeMonoidHom_apply, apply_dite, coe_one]
   rw [Finset.noncommProd_congr (s₂ := {i | i ≠ i₀}) rfl (fun i hi ↦
-      (dite_eq_left (Finset.mem_filter.1 hi).2 : _ = (diag2n (Finset.mem_filter.1 hi).2 _ _).1))]
+      (dite_eq_left (Finset.mem_filter.1 hi).2 :
+        _ = (diagonal2n (Finset.mem_filter.1 hi).2 _ _).1))]
   convert_to! _ = Finset.noncommProd {i | i ≠ i₀} (fun x ↦ diagonal (g x)) _
   simp_rw [← diagonalRingHom_apply]
   rw [← Finset.map_noncommProd _ _ (fun _ _ _ _ _ ↦ Commute.all _ _), Finset.noncommProd_eq_prod]
-  rw [diag_decompose i₀ D hD]
+  rw [diagonal_decompose i₀ D hD]
+
+@[deprecated (since := "2026-09-06")] alias diag_eq_diag2n_prod := diagonal_eq_diagonal2n_prod
 
 set_option backward.isDefEq.respectTransparency.types false in
 /-- The `SpecialLinearGroup` analogue of
@@ -707,15 +733,15 @@ theorem exists_list_transvec_mul_diagonal_mul_list_transvec (M : SpecialLinearGr
 
 theorem diagonal_transvection_induction' [Nontrivial ι] (P : SpecialLinearGroup ι F → Prop)
     (M : SpecialLinearGroup ι F)
-    (hdiag : ∀ (i j : ι) (hij : i ≠ j) {c : F} (hc : c ≠ 0), P (diag2n hij c hc))
+    (hdiagonal2n : ∀ (i j : ι) (hij : i ≠ j) {c : F} (hc : c ≠ 0), P (diagonal2n hij c hc))
     (htransvec : ∀ (i j : ι) (hij : i ≠ j) (a : F), P (transvection hij a))
     (hmul : ∀ A B, P A → P B → P (A * B)) : P M := by
   obtain ⟨i₀, j₀, hij₀⟩ := exists_pair_ne ι
   have hP1 : P 1 := transvection_coeff_zero (F := F) hij₀ ▸ htransvec i₀ j₀ hij₀ 0
   have hdiagonal (D : ι → F) (hD : det (diagonal D) = 1) : P ⟨diagonal D, hD⟩ := by
-    rw [diag_eq_diag2n_prod i₀ D hD]
+    rw [diagonal_eq_diagonal2n_prod i₀ D hD]
     refine Finset.noncommProd_induction _ _ _ P hmul hP1 fun i hi => ?_
-    simp [(Finset.mem_filter.1 hi).2, hdiag]
+    simp [(Finset.mem_filter.1 hi).2, hdiagonal2n]
   have hlist (L : List (TransvectionStruct ι F)) :
       P (L.map TransvectionStruct.toSpecialLinearGroup).prod := by
     induction L with
@@ -733,34 +759,37 @@ end SpecialLinearGroup
 open Matrix.SpecialLinearGroup
 open scoped commutatorElement
 
-lemma commutator_diag2_transvection (a : F) (ha : a ≠ 0) (b c : F)
-    (hc : c = b * (a ^ 2 - 1)) : ⁅diag2 a ha, SpecialLinearGroup.transvection zero_ne_one b⁆ =
+lemma commutator_diagonal2_transvection (a : F) (ha : a ≠ 0) (b c : F)
+    (hc : c = b * (a ^ 2 - 1)) : ⁅diagonal2 a ha, SpecialLinearGroup.transvection zero_ne_one b⁆ =
     (SpecialLinearGroup.transvection zero_ne_one c : SL(2, F)) := by
-  rw [commutatorElement_def, diag2_inv a ha, SpecialLinearGroup.transvection_inv zero_ne_one b]
+  rw [commutatorElement_def, diagonal2_inv a ha, SpecialLinearGroup.transvection_inv zero_ne_one b]
   refine Subtype.ext <| Matrix.ext fun i j ↦ ?_
   fin_cases i <;> fin_cases j
-  <;> simp [hc, SpecialLinearGroup.transvection_coe, diag2_coe, mul_add, add_mul,
+  <;> simp [hc, SpecialLinearGroup.transvection_coe, diagonal2_coe, mul_add, add_mul,
     mul_inv_cancel₀ ha, inv_mul_cancel₀ ha, mul_comm a b, mul_assoc b a a, ← pow_two,
     mul_sub_one, ← sub_eq_add_neg]
+
+@[deprecated (since := "2026-09-06")]
+alias commutator_diag2_transvection := commutator_diagonal2_transvection
 
 /-- For any `c : F`, given `a ≠ 0` and `a² ≠ 1`, the transvection `transvection i₁ i₂ hij c` is
 a commutator in `SL ι F`, hence lies in `commutator (SL ι F)`. -/
 lemma transvection_mem_commutator₀ {a : F} (ha : a ≠ 0) (hasq : a ^ 2 ≠ 1) (c : F) :
     SpecialLinearGroup.transvection zero_ne_one c ∈ commutator SL(2, F) := by
-  rw [← commutator_diag2_transvection a ha (c / (a ^ 2 - 1)) c
+  rw [← commutator_diagonal2_transvection a ha (c / (a ^ 2 - 1)) c
     (div_mul_cancel₀ c (sub_ne_zero_of_ne hasq)).symm]
   exact Subgroup.commutator_mem_commutator (Subgroup.mem_top _) (Subgroup.mem_top _)
 
 lemma transvection_mem_commutator₁ {a : F} (ha : a ≠ 0) (hasq : a ^ 2 ≠ 1) (c : F) :
     SpecialLinearGroup.transvection one_ne_zero c ∈ commutator SL(2, F) := by
   have (b c' : F) (hc : c' = b * (a ^ 2 - 1)) :
-      ⁅diag2 a⁻¹ (inv_ne_zero ha), SpecialLinearGroup.transvection one_ne_zero b⁆ =
+      ⁅diagonal2 a⁻¹ (inv_ne_zero ha), SpecialLinearGroup.transvection one_ne_zero b⁆ =
       (SpecialLinearGroup.transvection one_ne_zero c' : SL(2, F)) := by
-    rw [commutatorElement_def, diag2_inv a⁻¹ (inv_ne_zero ha),
+    rw [commutatorElement_def, diagonal2_inv a⁻¹ (inv_ne_zero ha),
       SpecialLinearGroup.transvection_inv one_ne_zero b]
     refine Subtype.ext <| Matrix.ext fun i j ↦ ?_
     fin_cases i <;> fin_cases j <;>
-    simp [hc, SpecialLinearGroup.transvection_coe, diag2_coe, inv_inv, mul_add, add_mul,
+    simp [hc, SpecialLinearGroup.transvection_coe, diagonal2_coe, inv_inv, mul_add, add_mul,
       mul_inv_cancel₀ ha, inv_mul_cancel₀ ha, mul_comm a b, mul_assoc b a a, ← pow_two,
       mul_sub_one, ← sub_eq_add_neg]
   rw [← this (c / (a ^ 2 - 1)) c (div_mul_cancel₀ c (sub_ne_zero_of_ne hasq)).symm]
@@ -774,8 +803,8 @@ lemma transvection_mem_commutator {a : F} (ha : a ≠ 0) (hasq : a ^ 2 ≠ 1) {i
   · obtain rfl : j = 0 := by fin_cases j <;> tauto
     exact transvection_mem_commutator₁ ha hasq c
 
-lemma diag2_decompose (a : F) (ha : a ≠ 0) :
-    diag2 a ha = SpecialLinearGroup.transvection zero_ne_one a *
+lemma diagonal2_decompose (a : F) (ha : a ≠ 0) :
+    diagonal2 a ha = SpecialLinearGroup.transvection zero_ne_one a *
       SpecialLinearGroup.transvection one_ne_zero (- a⁻¹) *
       SpecialLinearGroup.transvection zero_ne_one a *
       SpecialLinearGroup.transvection zero_ne_one (-1) *
@@ -783,7 +812,9 @@ lemma diag2_decompose (a : F) (ha : a ≠ 0) :
       SpecialLinearGroup.transvection zero_ne_one (-1) := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-  simp [diag2_coe', transvection_coe, mul_add, add_mul, mul_inv_cancel₀ ha, inv_mul_cancel₀ ha]
+  simp [diagonal2_coe', transvection_coe, mul_add, add_mul, mul_inv_cancel₀ ha, inv_mul_cancel₀ ha]
+
+@[deprecated (since := "2026-09-06")] alias diag2_decompose := diagonal2_decompose
 
 theorem SL2.transvection_induction (P : SL(2, F) → Prop)
     (htransvec : ∀ (i j : Fin 2) (h : i ≠ j) c, P (SpecialLinearGroup.transvection h c))
@@ -791,13 +822,13 @@ theorem SL2.transvection_induction (P : SL(2, F) → Prop)
   refine diagonal_transvection_induction' P _ (fun i j hij c hc ↦ ?_) htransvec hmul
   fin_cases i
   · obtain rfl : j = 1 := by fin_cases j <;> tauto
-    change P (diag2 c hc)
-    rw [diag2_decompose c hc]
+    change P (diagonal2 c hc)
+    rw [diagonal2_decompose c hc]
     refine hmul _ _ (hmul _ _ (hmul _ _ (hmul _ _ (hmul _ _ ?_ ?_) ?_) ?_) ?_) ?_
     all_goals exact htransvec _ _ _ _
   · obtain rfl : j = 0 := by fin_cases j <;> tauto
-    rw [show diag2n hij c hc = diag2 c⁻¹ (inv_ne_zero hc) by
-      ext; simp [diag2n_coe, diagonal_apply]; grind, diag2_decompose c⁻¹ (inv_ne_zero hc)]
+    rw [show diagonal2n hij c hc = diagonal2 c⁻¹ (inv_ne_zero hc) by
+      ext; simp [diagonal2n_coe, diagonal_apply]; grind, diagonal2_decompose c⁻¹ (inv_ne_zero hc)]
     refine hmul _ _ (hmul _ _ (hmul _ _ (hmul _ _ (hmul _ _ ?_ ?_) ?_) ?_) ?_) ?_
     all_goals exact htransvec _ _ _ _
 

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -30,7 +30,7 @@ It contains theorems relating these to each other, as well as to `LinearMap.ker`
   - `LinearMap.single`
 - pi types in the domain:
   - `LinearMap.proj`
-  - `LinearMap.diag`
+  - `LinearMap.diagonal`
 
 -/
 
@@ -329,9 +329,11 @@ end
 
 section
 
-/-- `diag i j` is the identity map if `i = j`. Otherwise it is the constant 0 map. -/
-def diag (i j : ι) : φ i →ₗ[R] φ j :=
+/-- `diagonal i j` is the identity map if `i = j`. Otherwise it is the constant 0 map. -/
+def diagonal (i j : ι) : φ i →ₗ[R] φ j :=
   @Function.update ι (fun j => φ i →ₗ[R] φ j) _ 0 i id j
+
+@[deprecated (since := "2026-09-06")] alias diag := diagonal
 
 theorem update_apply (f : (i : ι) → M₂ →ₗ[R] φ i) (c : M₂) (i j : ι) (b : M₂ →ₗ[R] φ i) :
     (update f i b j) c = update (fun i => f i c) i (b c) j := by
@@ -341,16 +343,18 @@ theorem update_apply (f : (i : ι) → M₂ →ₗ[R] φ i) (c : M₂) (i j : ι
 
 variable (R φ)
 
-theorem single_eq_pi_diag (i : ι) : single R φ i = pi (diag i) := by
+theorem single_eq_pi_diagonal (i : ι) : single R φ i = pi (diagonal i) := by
   ext x j
   convert! (update_apply 0 x i j _).symm
   rfl
 
+@[deprecated (since := "2026-09-06")] alias single_eq_pi_diag := single_eq_pi_diagonal
+
 theorem ker_single (i : ι) : ker (single R φ i) = ⊥ :=
   ker_eq_bot_of_injective <| Pi.single_injective _
 
-theorem proj_comp_single (i j : ι) : (proj i).comp (single R φ j) = diag j i := by
-  rw [single_eq_pi_diag, proj_pi]
+theorem proj_comp_single (i j : ι) : (proj i).comp (single R φ j) = diagonal j i := by
+  rw [single_eq_pi_diagonal, proj_pi]
 
 end
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -359,13 +359,13 @@ theorem choose_exists_companion : Q.exists_companion.choose = polarBilin Q :=
 
 protected theorem map_sum {ι} [DecidableEq ι] (Q : QuadraticMap R M N) (s : Finset ι) (f : ι → M) :
     Q (∑ i ∈ s, f i) = ∑ i ∈ s, Q (f i)
-      + ∑ ij ∈ s.sym2 with ¬ ij.IsDiag, polarSym2 Q (ij.map f) := by
+      + ∑ ij ∈ s.sym2 with ¬ ij.IsDiagonal, polarSym2 Q (ij.map f) := by
   induction s using Finset.cons_induction with
   | empty => simp
   | cons a s ha ih =>
     simp_rw [Finset.sum_cons, QuadraticMap.map_add, ih, add_assoc, Finset.sym2_cons,
       Finset.sum_filter, Finset.sum_disjUnion, Finset.sum_map, Finset.sum_cons,
-      Sym2.mkEmbedding_apply, Sym2.mk_isDiag_iff, not_true, ite_false, zero_add,
+      Sym2.mkEmbedding_apply, Sym2.mk_isDiagonal_iff, not_true, ite_false, zero_add,
       Sym2.map_mk, polarSym2_sym2Mk, ← polarBilin_apply_apply, _root_.map_sum,
       polarBilin_apply_apply]
     congr 2

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basis.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basis.lean
@@ -55,12 +55,13 @@ variable [DecidableEq ι]
 /-- The quadratic version of `_root_.map_finsupp_sum`. -/
 theorem map_finsuppSum (Q : QuadraticMap R M N) (f : ι →₀ R) (g : ι → R → M) :
     Q (f.sum g) = f.sum (fun i r ↦ Q (g i r)) +
-      ∑ p ∈ f.support.sym2 with ¬ p.IsDiag, polarSym2 Q (p.map fun i ↦ g i (f i)) := Q.map_sum _ _
+      ∑ p ∈ f.support.sym2 with ¬ p.IsDiagonal, polarSym2 Q (p.map fun i ↦ g i (f i)) :=
+        Q.map_sum _ _
 
 /-- The quadratic version of `Finsupp.apply_linearCombination`. -/
 theorem apply_linearCombination (Q : QuadraticMap R M N) {g : ι → M} (l : ι →₀ R) :
     Q (linearCombination R g l) = linearCombination R (Q ∘ g) (l * l) +
-      ∑ p ∈ l.support.sym2 with ¬ p.IsDiag, (p.map l).mul • polarSym2 Q (p.map g) := by
+      ∑ p ∈ l.support.sym2 with ¬ p.IsDiagonal, (p.map l).mul • polarSym2 Q (p.map g) := by
   simp_rw [linearCombination_apply, map_finsuppSum, Q.map_smul, mul_smul]
   rw [(l * l).sum_of_support_subset support_mul_subset_left _ <| by simp]
   simp [Finsupp.sum, ← polarSym2_map_smul, mul_smul]
@@ -68,7 +69,7 @@ theorem apply_linearCombination (Q : QuadraticMap R M N) {g : ι → M} (l : ι 
 /-- The quadratic version of `LinearMap.sum_repr_mul_repr_mul`. -/
 theorem sum_repr_sq_add_sum_repr_mul_polar (Q : QuadraticMap R M N) (bm : Basis ι R M) (x : M) :
     linearCombination R (Q ∘ bm) (bm.repr x * bm.repr x) +
-      ∑ p ∈ (bm.repr x).support.sym2 with ¬ p.IsDiag,
+      ∑ p ∈ (bm.repr x).support.sym2 with ¬ p.IsDiagonal,
         Sym2.mul (p.map (bm.repr x)) • polarSym2 Q (p.map bm) = Q x := by
   rw [← apply_linearCombination, Basis.linearCombination_repr]
 
@@ -97,15 +98,15 @@ theorem toQuadraticMap_toBilin (Q : QuadraticMap R M N) (bm : Basis ι R M) :
   rw [← bm.linearCombination_repr x, LinearMap.BilinMap.toQuadraticMap_apply,
       Finsupp.linearCombination_apply, Finsupp.sum]
   simp_rw [LinearMap.map_sum₂, map_sum, LinearMap.map_smul₂, map_smul, toBilin_apply,
-    smul_ite, smul_zero, ← Finset.sum_product', ← Finset.diag_union_offDiag,
-    Finset.sum_union (Finset.disjoint_diag_offDiag _), Finset.sum_diag, ite_true]
+    smul_ite, smul_zero, ← Finset.sum_product', ← Finset.diagonal_union_offDiagonal,
+    Finset.sum_union (Finset.disjoint_diagonal_offDiagonal _), Finset.sum_diagonal, ite_true]
   rw [Finset.sum_ite_of_false, QuadraticMap.map_sum, ← Finset.sum_filter]
   · simp_rw [← polar_smul_right _ (bm.repr x <| Prod.snd _),
       ← polar_smul_left _ (bm.repr x <| Prod.fst _)]
-    simp_rw [QuadraticMap.map_smul, mul_smul, Finset.sum_sym2_filter_not_isDiag]
+    simp_rw [QuadraticMap.map_smul, mul_smul, Finset.sum_sym2_filter_not_isDiagonal]
     rfl
   · intro x hx
-    rw [Finset.mem_offDiag] at hx
+    rw [Finset.mem_offDiagonal] at hx
     simpa using hx.2.2
 
 /-- From a free module, every quadratic map can be built from a bilinear form.

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -191,7 +191,7 @@ lemma cartanMatrix_mul_diagonal_eq [Fintype ι] [DecidableEq ι] [P.IsRootSystem
   simpa [← algebraMap_pairingIn P ℤ i j] using
     congr_fun₂ (cartanMatrixIn_mul_diagonal_eq ℤ P.toInvariantForm b) i j
 
-lemma exists_cartanMatrix_mul_diagaonal_posDef [DecidableEq ι] [P.IsRootSystem] :
+lemma exists_cartanMatrix_mul_diagonal_posDef [DecidableEq ι] [P.IsRootSystem] :
     ∃ d : b.support → ℤ, (∀ i, 0 < d i) ∧ (b.cartanMatrix * diagonal d).PosDef := by
   have _i : Fintype ι := Fintype.ofFinite ι
   set d : b.support → ℤ := fun i ↦ P.RootFormIn ℤ (P.rootSpanMem ℤ i) (P.rootSpanMem ℤ i) with hd
@@ -205,9 +205,9 @@ lemma exists_cartanMatrix_mul_diagaonal_posDef [DecidableEq ι] [P.IsRootSystem]
     rw [← LinearMap.BilinForm.posDef_toQuadraticMap_iff_matrix _ _ aux]
     simpa using P.posRootForm_rootFormIn_posDef ℤ
 
-lemma exists_cartanMatrix_diagaonal_mul_posDef [DecidableEq ι] [P.IsRootSystem] :
+lemma exists_cartanMatrix_diagonal_mul_posDef [DecidableEq ι] [P.IsRootSystem] :
     ∃ d : b.support → ℤ, (∀ i, 0 < d i) ∧ (diagonal d * b.cartanMatrix).PosDef := by
-  obtain ⟨d, hd, hd'⟩ := b.flip.exists_cartanMatrix_mul_diagaonal_posDef
+  obtain ⟨d, hd, hd'⟩ := b.flip.exists_cartanMatrix_mul_diagonal_posDef
   refine ⟨d, hd, ?_⟩
   rw [← PosDef.transpose_iff] at hd'
   aesop
@@ -219,7 +219,7 @@ lemma det_four_sub_cartanMatrix_ne_zero [DecidableEq ι] [P.IsRootSystem] :
     have aux : (4 - b.cartanMatrix).toLin' = - (b.cartanMatrix.toLin' - (4 : ℤ) • 1) := by ext; simp
     rwa [ne_eq, ← det_toLin', det_eq_zero_iff_ker_ne_bot, aux, ker_neg, ← eigenspace_def,
       ← hasEigenvalue_iff]
-  obtain ⟨d, hd, hdS⟩ := b.exists_cartanMatrix_diagaonal_mul_posDef
+  obtain ⟨d, hd, hdS⟩ := b.exists_cartanMatrix_diagonal_mul_posDef
   have aux (i j : b.support) : b.cartanMatrix i j ≤ if i = j then 2 else 0 := by
     rcases eq_or_ne i j with rfl | hij
     · simp
@@ -412,9 +412,9 @@ lemma cartanMatrix_isIndecomposable [P.IsReduced] [P.IsIrreducible] :
 lemma cartanMatrix_isFiniteCartan [DecidableEq ι] [P.IsRootSystem] :
     b.cartanMatrix.IsFiniteCartan where
   diag i := b.cartanMatrix_apply_same i
-  offDiag_nonpos i j hij := b.cartanMatrix_le_zero_of_ne i j hij
+  offDiagonal_nonpos i j hij := b.cartanMatrix_le_zero_of_ne i j hij
   zero_comm _ _ := b.cartanMatrix_apply_eq_zero_iff_symm
-  exists_posDef := b.exists_cartanMatrix_diagaonal_mul_posDef
+  exists_posDef := b.exists_cartanMatrix_diagonal_mul_posDef
 
 end IsCrystallographic
 

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -27,6 +27,16 @@ universe u v w x
 
 namespace Function
 
+@[deprecated (since := "2026-09-06")] protected alias diag := Prod.diagonal
+@[deprecated (since := "2026-09-06")] alias diag_def := Prod.diagonal_def
+@[deprecated (since := "2026-09-06")] alias diag_apply := Prod.diagonal_apply
+@[deprecated (since := "2026-09-06")] alias diag_injective := Prod.diagonal_injective
+@[deprecated (since := "2026-09-06")] alias fst_comp_diag := Prod.fst_comp_diagonal
+@[deprecated (since := "2026-09-06")] alias snd_comp_diag := Prod.snd_comp_diagonal
+@[deprecated (since := "2026-09-06")] alias diag_comp := Prod.diagonal_comp
+@[deprecated (since := "2026-09-06")] alias map_comp_diag := Prod.map_comp_diagonal
+@[deprecated (since := "2026-09-06")] alias swap_comp_diag := Prod.swap_comp_diagonal
+
 section
 
 variable {α β γ : Sort*} {f : α → β}

--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -112,30 +112,38 @@ end Prod
 
 /- ### The diagonal map -/
 
-/-- The diagonal map into `Prod`. -/
-@[inline] protected def diag {α} : α → α × α := fun a : α ↦ (a, a)
+end Function
 
-section Diag
+namespace Prod
 
 variable {α β γ : Type*} (f : α → β) (g : α → γ) (a b : α)
 
-theorem diag_def : Function.diag = fun a : α ↦ (a, a) := rfl
+/-- The diagonal map into `Prod`. -/
+@[inline] def diagonal {α} : α → α × α := fun a : α ↦ (a, a)
 
-@[simp, grind =] theorem diag_apply : Function.diag a = (a, a) := rfl
+theorem diagonal_def : diagonal = fun a : α ↦ (a, a) := rfl
 
-theorem diag_injective : Injective (α := α) Function.diag := fun _ _ ↦ congrArg Prod.fst
+@[simp, grind =] theorem diagonal_apply : diagonal a = (a, a) := rfl
 
-@[simp] theorem prod_id_id : Function.prod (@id α) id = Function.diag := rfl
-@[simp] theorem fst_comp_diag : Prod.fst ∘ Function.diag = @id α := rfl
-@[simp] theorem snd_comp_diag : Prod.snd ∘ Function.diag = @id α := rfl
+theorem diagonal_injective : Function.Injective (α := α) diagonal :=
+  fun _ _ ↦ congrArg Prod.fst
 
-@[simp] theorem diag_comp : Function.diag ∘ f = Function.prod f f := rfl
+@[simp] theorem fst_comp_diagonal : Prod.fst ∘ diagonal = @id α := rfl
+@[simp] theorem snd_comp_diagonal : Prod.snd ∘ diagonal = @id α := rfl
 
-@[simp] theorem map_comp_diag : Prod.map f g ∘ Function.diag = Function.prod f g := rfl
+@[simp] theorem diagonal_comp : diagonal ∘ f = Function.prod f f := rfl
 
-@[simp] theorem swap_comp_diag : Prod.swap ∘ Function.diag = Function.diag (α := α) := rfl
+@[simp] theorem map_comp_diagonal : Prod.map f g ∘ diagonal = Function.prod f g := rfl
 
-end Diag
+@[simp] theorem swap_comp_diagonal : Prod.swap ∘ diagonal = diagonal (α := α) := rfl
+
+end Prod
+
+namespace Function
+
+variable {α : Sort u₁} {β : Sort u₂} {φ : Sort u₃} {δ : Sort u₄}
+
+@[simp] theorem prod_id_id {α : Type*} : Function.prod (@id α) id = Prod.diagonal := rfl
 
 /- ### `onFun` function -/
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -422,11 +422,15 @@ theorem measurable_prodMk_right {y : β} : Measurable fun x : α => (x, y) :=
   measurable_id.prodMk measurable_const
 
 @[fun_prop]
-theorem measurable_diag : @Measurable α (α × α) m (m.prod m) Function.diag :=
+theorem measurable_diagonal : @Measurable α (α × α) m (m.prod m) Prod.diagonal :=
   measurable_id.prodMk measurable_id
 
-theorem measurable_diag' {m'} (h : m' ≤ m) : @Measurable α (α × α) m (m.prod m') Function.diag :=
+theorem measurable_diagonal' {m'} (h : m' ≤ m) :
+    @Measurable α (α × α) m (m.prod m') Prod.diagonal :=
   measurable_id.prodMk (measurable_id'' h)
+
+@[deprecated (since := "2026-09-06")] alias measurable_diag := measurable_diagonal
+@[deprecated (since := "2026-09-06")] alias measurable_diag' := measurable_diagonal'
 
 theorem Measurable.of_uncurry_left {f : α → β → γ} (hf : Measurable (uncurry f)) {x : α} :
     Measurable (f x) :=

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -33,7 +33,7 @@ Let `n : ℕ`. All of the following definitions are in the `Nat` namespace:
 
 Since `0` has infinitely many divisors, none of the definitions in this file make sense for it.
 Therefore we adopt the convention that `Nat.divisors 0`, `Nat.properDivisors 0`,
-`Nat.divisorsAntidiagonal 0` and `Int.divisorsAntidiag 0` are all `∅`.
+`Nat.divisorsAntidiagonal 0` and `Int.divisorsAntidiagonal 0` are all `∅`.
 
 ## Tags
 divisors, perfect numbers
@@ -330,8 +330,11 @@ theorem swap_mem_divisorsAntidiagonal {x : ℕ × ℕ} :
     x.swap ∈ divisorsAntidiagonal n ↔ x ∈ divisorsAntidiagonal n := by
   rw [mem_divisorsAntidiagonal, mem_divisorsAntidiagonal, mul_comm, Prod.swap]
 
-lemma prodMk_mem_divisorsAntidiag {x y : ℕ} (hn : n ≠ 0) :
+lemma prodMk_mem_divisorsAntidiagonal {x y : ℕ} (hn : n ≠ 0) :
     (x, y) ∈ n.divisorsAntidiagonal ↔ x * y = n := by simp [hn]
+
+@[deprecated (since := "2026-09-06")]
+alias prodMk_mem_divisorsAntidiag := prodMk_mem_divisorsAntidiagonal
 
 theorem fst_mem_divisors_of_mem_antidiagonal {x : ℕ × ℕ} (h : x ∈ divisorsAntidiagonal n) :
     x.fst ∈ divisors n := by
@@ -603,11 +606,11 @@ def divisors (z : ℤ) : Finset ℤ :=
 
 /-- Pairs of divisors of an integer as a finset.
 
-`z.divisorsAntidiag` is the finset of pairs `(a, b) : ℤ × ℤ` such that `a * b = z`.
-By convention, we set `Int.divisorsAntidiag 0 = ∅`.
+`z.divisorsAntidiagonal` is the finset of pairs `(a, b) : ℤ × ℤ` such that `a * b = z`.
+By convention, we set `Int.divisorsAntidiagonal 0 = ∅`.
 
 O(|z|). Computed from `Nat.divisorsAntidiagonal`. -/
-def divisorsAntidiag : (z : ℤ) → Finset (ℤ × ℤ)
+def divisorsAntidiagonal : (z : ℤ) → Finset (ℤ × ℤ)
   | (n : ℕ) =>
     let s : Finset (ℕ × ℕ) := n.divisorsAntidiagonal
     (s.map <| .prodMap natCast natCast).disjUnion (s.map <| .prodMap negNatCast negNatCast) <| by
@@ -661,86 +664,89 @@ lemma mem_divisors_self (hz : z ≠ 0) : z ∈ divisors z :=
   simp
 
 @[simp]
-lemma mem_divisorsAntidiag : xy ∈ divisorsAntidiag z ↔ xy.fst * xy.snd = z ∧ z ≠ 0 := by
+lemma mem_divisorsAntidiagonal : xy ∈ divisorsAntidiagonal z ↔ xy.fst * xy.snd = z ∧ z ≠ 0 := by
   rcases z, xy with ⟨_ | _, ⟨_ | _, _ | _⟩⟩
   -- splitting this case saves about 1770 heartbeats i.e. 12.5% faster
   case ofNat.negSucc.negSucc =>
-    simp [divisorsAntidiag]
+    simp [divisorsAntidiagonal]
     grind [Nat.cast_inj]
   all_goals
-    simp [divisorsAntidiag]
+    simp [divisorsAntidiagonal]
     grind
 
-theorem image_fst_divisorsAntidiag : z.divisorsAntidiag.image Prod.fst = z.divisors := by
+theorem image_fst_divisorsAntidiagonal : z.divisorsAntidiagonal.image Prod.fst = z.divisors := by
   ext
   simp [Eq.comm, dvd_def]
 
-theorem image_snd_divisorsAntidiag : z.divisorsAntidiag.image Prod.snd = z.divisors := by
+theorem image_snd_divisorsAntidiagonal : z.divisorsAntidiagonal.image Prod.snd = z.divisors := by
   ext
   simp [Eq.comm, mul_comm, dvd_def]
 
-@[simp] lemma divisorsAntidiag_zero : divisorsAntidiag 0 = ∅ := rfl
+@[simp] lemma divisorsAntidiagonal_zero : divisorsAntidiagonal 0 = ∅ := rfl
 
 -- TODO Write a simproc instead of `divisorsAntidiagonal_one`, ..., `divisorsAntidiagonal_four` ...
 
 @[simp]
 theorem divisorsAntidiagonal_one :
-    Int.divisorsAntidiag 1 = {(1, 1), (-1, -1)} :=
+    Int.divisorsAntidiagonal 1 = {(1, 1), (-1, -1)} :=
   rfl
 
 @[simp]
 theorem divisorsAntidiagonal_two :
-    Int.divisorsAntidiag 2 = {(1, 2), (2, 1), (-1, -2), (-2, -1)} :=
+    Int.divisorsAntidiagonal 2 = {(1, 2), (2, 1), (-1, -2), (-2, -1)} :=
   rfl
 
 @[simp]
 theorem divisorsAntidiagonal_three :
-    Int.divisorsAntidiag 3 = {(1, 3), (3, 1), (-1, -3), (-3, -1)} :=
+    Int.divisorsAntidiagonal 3 = {(1, 3), (3, 1), (-1, -3), (-3, -1)} :=
   rfl
 
 @[simp]
 theorem divisorsAntidiagonal_four :
-    Int.divisorsAntidiag 4 = {(1, 4), (2, 2), (4, 1), (-1, -4), (-2, -2), (-4, -1)} :=
+    Int.divisorsAntidiagonal 4 = {(1, 4), (2, 2), (4, 1), (-1, -4), (-2, -2), (-4, -1)} :=
   rfl
 
-lemma prodMk_mem_divisorsAntidiag (hz : z ≠ 0) : (x, y) ∈ z.divisorsAntidiag ↔ x * y = z := by
+lemma prodMk_mem_divisorsAntidiagonal (hz : z ≠ 0) :
+    (x, y) ∈ z.divisorsAntidiagonal ↔ x * y = z := by
   simp [hz]
 
 @[simp high]
-lemma swap_mem_divisorsAntidiag : xy.swap ∈ z.divisorsAntidiag ↔ xy ∈ z.divisorsAntidiag := by
+lemma swap_mem_divisorsAntidiagonal :
+    xy.swap ∈ z.divisorsAntidiagonal ↔ xy ∈ z.divisorsAntidiagonal := by
   simp [mul_comm]
 
-lemma neg_mem_divisorsAntidiag : -xy ∈ z.divisorsAntidiag ↔ xy ∈ z.divisorsAntidiag := by simp
+lemma neg_mem_divisorsAntidiagonal :
+    -xy ∈ z.divisorsAntidiagonal ↔ xy ∈ z.divisorsAntidiagonal := by simp
 
 @[simp]
-lemma map_prodComm_divisorsAntidiag :
-    z.divisorsAntidiag.map (Equiv.prodComm _ _).toEmbedding = z.divisorsAntidiag := by
-  ext; simp [mem_divisorsAntidiag]
+lemma map_prodComm_divisorsAntidiagonal :
+    z.divisorsAntidiagonal.map (Equiv.prodComm _ _).toEmbedding = z.divisorsAntidiagonal := by
+  ext; simp [mem_divisorsAntidiagonal]
 
 @[simp]
-lemma map_neg_divisorsAntidiag :
-    z.divisorsAntidiag.map (Equiv.neg _).toEmbedding = z.divisorsAntidiag := by
-  ext; simp [mem_divisorsAntidiag, mul_comm]
+lemma map_neg_divisorsAntidiagonal :
+    z.divisorsAntidiagonal.map (Equiv.neg _).toEmbedding = z.divisorsAntidiagonal := by
+  ext; simp [mem_divisorsAntidiagonal, mul_comm]
 
-lemma divisorsAntidiag_neg :
-    (-z).divisorsAntidiag =
-      z.divisorsAntidiag.map (.prodMap (.refl _) (Equiv.neg _).toEmbedding) := by
-  ext; simp [mem_divisorsAntidiag, Prod.ext_iff, neg_eq_iff_eq_neg]
+lemma divisorsAntidiagonal_neg :
+    (-z).divisorsAntidiagonal =
+      z.divisorsAntidiagonal.map (.prodMap (.refl _) (Equiv.neg _).toEmbedding) := by
+  ext; simp [mem_divisorsAntidiagonal, Prod.ext_iff, neg_eq_iff_eq_neg]
 
-lemma divisorsAntidiag_natCast (n : ℕ) :
-    divisorsAntidiag n =
+lemma divisorsAntidiagonal_natCast (n : ℕ) :
+    divisorsAntidiagonal n =
       (n.divisorsAntidiagonal.map <| .prodMap natCast natCast).disjUnion
         (n.divisorsAntidiagonal.map <| .prodMap negNatCast negNatCast) (by
           simp +contextual [disjoint_left, eq_comm]) := rfl
 
-lemma divisorsAntidiag_neg_natCast (n : ℕ) :
-    divisorsAntidiag (-n) =
+lemma divisorsAntidiagonal_neg_natCast (n : ℕ) :
+    divisorsAntidiagonal (-n) =
       (n.divisorsAntidiagonal.map <| .prodMap natCast negNatCast).disjUnion
         (n.divisorsAntidiagonal.map <| .prodMap negNatCast natCast) (by
           simp +contextual [disjoint_left, eq_comm]) := by cases n <;> rfl
 
-lemma divisorsAntidiag_ofNat (n : ℕ) :
-    divisorsAntidiag ofNat(n) =
+lemma divisorsAntidiagonal_ofNat (n : ℕ) :
+    divisorsAntidiagonal ofNat(n) =
       (n.divisorsAntidiagonal.map <| .prodMap natCast natCast).disjUnion
         (n.divisorsAntidiagonal.map <| .prodMap negNatCast negNatCast) (by
           simp +contextual [disjoint_left, eq_comm]) := rfl
@@ -751,8 +757,8 @@ lemma mul_mem_one_two_three_iff {a b : ℤ} :
       (1, 1), (-1, -1),
       (1, 2), (2, 1), (-1, -2), (-2, -1),
       (1, 3), (3, 1), (-1, -3), (-3, -1)} : Set (ℤ × ℤ)) := by
-  simp only [← Int.prodMk_mem_divisorsAntidiag, Set.mem_insert_iff, Set.mem_singleton_iff, ne_eq,
-    one_ne_zero, not_false_eq_true, OfNat.ofNat_ne_zero]
+  simp only [← Int.prodMk_mem_divisorsAntidiagonal, Set.mem_insert_iff, Set.mem_singleton_iff,
+    ne_eq, one_ne_zero, not_false_eq_true, OfNat.ofNat_ne_zero]
   aesop
 
 /-- This lemma justifies its existence from its utility in crystallographic root system theory. -/
@@ -763,8 +769,31 @@ lemma mul_mem_zero_one_two_three_four_iff {a b : ℤ} (h₀ : a = 0 ↔ b = 0) :
       (1, 2), (2, 1), (-1, -2), (-2, -1),
       (1, 3), (3, 1), (-1, -3), (-3, -1),
       (4, 1), (1, 4), (-4, -1), (-1, -4), (2, 2), (-2, -2)} : Set (ℤ × ℤ)) := by
-  simp only [← Int.prodMk_mem_divisorsAntidiag, Set.mem_insert_iff, Set.mem_singleton_iff, ne_eq,
-    one_ne_zero, not_false_eq_true, OfNat.ofNat_ne_zero]
+  simp only [← Int.prodMk_mem_divisorsAntidiagonal, Set.mem_insert_iff, Set.mem_singleton_iff,
+    ne_eq, one_ne_zero, not_false_eq_true, OfNat.ofNat_ne_zero]
   aesop
+
+@[deprecated (since := "2026-09-06")] alias divisorsAntidiag := divisorsAntidiagonal
+@[deprecated (since := "2026-09-06")] alias mem_divisorsAntidiag := mem_divisorsAntidiagonal
+@[deprecated (since := "2026-09-06")]
+alias image_fst_divisorsAntidiag := image_fst_divisorsAntidiagonal
+@[deprecated (since := "2026-09-06")]
+alias image_snd_divisorsAntidiag := image_snd_divisorsAntidiagonal
+@[deprecated (since := "2026-09-06")] alias divisorsAntidiag_zero := divisorsAntidiagonal_zero
+@[deprecated (since := "2026-09-06")]
+alias prodMk_mem_divisorsAntidiag := prodMk_mem_divisorsAntidiagonal
+@[deprecated (since := "2026-09-06")]
+alias swap_mem_divisorsAntidiag := swap_mem_divisorsAntidiagonal
+@[deprecated (since := "2026-09-06")] alias neg_mem_divisorsAntidiag := neg_mem_divisorsAntidiagonal
+@[deprecated (since := "2026-09-06")]
+alias map_prodComm_divisorsAntidiag := map_prodComm_divisorsAntidiagonal
+@[deprecated (since := "2026-09-06")]
+alias map_neg_divisorsAntidiag := map_neg_divisorsAntidiagonal
+@[deprecated (since := "2026-09-06")] alias divisorsAntidiag_neg := divisorsAntidiagonal_neg
+@[deprecated (since := "2026-09-06")]
+alias divisorsAntidiag_natCast := divisorsAntidiagonal_natCast
+@[deprecated (since := "2026-09-06")]
+alias divisorsAntidiag_neg_natCast := divisorsAntidiagonal_neg_natCast
+@[deprecated (since := "2026-09-06")] alias divisorsAntidiag_ofNat := divisorsAntidiagonal_ofNat
 
 end Int

--- a/Mathlib/NumberTheory/HeckeRing/Defs.lean
+++ b/Mathlib/NumberTheory/HeckeRing/Defs.lean
@@ -133,12 +133,16 @@ theorem trans [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] :
     le_commensurator_right H₂⟩
 
 /-- The left diagonal datum `(H₁, Δ, H₁)`. Not an instance, since `H₂` cannot be inferred. -/
-theorem diag_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
+theorem diagonal_left [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₁ H₁ :=
   ⟨left_le H₂, left_le H₂, .refl H₁, le_commensurator_left H₂⟩
 
+@[deprecated (since := "2026-09-06")] alias diag_left := diagonal_left
+
 /-- The right diagonal datum `(H₂, Δ, H₂)`. Not an instance, since `H₁` cannot be inferred. -/
-theorem diag_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
+theorem diagonal_right [IsHeckeTriple Δ H₁ H₂] : IsHeckeTriple Δ H₂ H₂ :=
   ⟨right_le H₁, right_le H₁, .refl H₂, le_commensurator_right H₁⟩
+
+@[deprecated (since := "2026-09-06")] alias diag_right := diagonal_right
 
 end IsHeckeTriple
 

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -758,7 +758,7 @@ lemma mulHeight_mul_le (x y : ι → K) : mulHeight (x * y) ≤ mulHeight x * mu
   rcases eq_or_ne y 0 with rfl | hy
   · simpa using one_le_mulHeight x
   rw [← mulHeight_fun_mul_eq hx hy,
-    show x * y = (fun a ↦ x a.1 * y a.2) ∘ Function.diag by ext1; simp]
+    show x * y = (fun a ↦ x a.1 * y a.2) ∘ Prod.diagonal by ext1; simp]
   exact mulHeight_comp_le ..
 
 open Real in

--- a/Mathlib/Order/Filter/Prod.lean
+++ b/Mathlib/Order/Filter/Prod.lean
@@ -187,24 +187,31 @@ theorem Eventually.image_of_prod {y : α → β} {r : α → β → Prop}
 
 /-- A fact that is eventually true about all pairs `l ×ˢ l` is eventually true about
 all diagonal pairs `(i, i)` -/
-theorem Eventually.diag_of_prod {p : α × α → Prop} (h : ∀ᶠ i in f ×ˢ f, p i) :
+theorem Eventually.diagonal_of_prod {p : α × α → Prop} (h : ∀ᶠ i in f ×ˢ f, p i) :
     ∀ᶠ i in f, p (i, i) :=
   h.image_of_prod (r := p.curry) tendsto_id
 
-theorem Eventually.diag_of_prod_left {f : Filter α} {g : Filter γ} {p : (α × α) × γ → Prop} :
+theorem Eventually.diagonal_of_prod_left {f : Filter α} {g : Filter γ} {p : (α × α) × γ → Prop} :
     (∀ᶠ x in (f ×ˢ f) ×ˢ g, p x) → ∀ᶠ x : α × γ in f ×ˢ g, p ((x.1, x.1), x.2) := by
   intro h
   obtain ⟨t, ht, s, hs, hst⟩ := eventually_prod_iff.1 h
-  exact (ht.diag_of_prod.prod_mk hs).mono fun x hx => by simp only [hst hx.1 hx.2]
+  exact (ht.diagonal_of_prod.prod_mk hs).mono fun x hx => by simp only [hst hx.1 hx.2]
 
-theorem Eventually.diag_of_prod_right {f : Filter α} {g : Filter γ} {p : α × γ × γ → Prop} :
+theorem Eventually.diagonal_of_prod_right {f : Filter α} {g : Filter γ} {p : α × γ × γ → Prop} :
     (∀ᶠ x in f ×ˢ (g ×ˢ g), p x) → ∀ᶠ x : α × γ in f ×ˢ g, p (x.1, x.2, x.2) := by
   intro h
   obtain ⟨t, ht, s, hs, hst⟩ := eventually_prod_iff.1 h
-  exact (ht.prod_mk hs.diag_of_prod).mono fun x hx => by simp only [hst hx.1 hx.2]
+  exact (ht.prod_mk hs.diagonal_of_prod).mono fun x hx => by simp only [hst hx.1 hx.2]
 
-theorem tendsto_diag : Tendsto Function.diag f (f ×ˢ f) :=
-  tendsto_iff_eventually.mpr fun _ hpr => hpr.diag_of_prod
+theorem tendsto_diagonal : Tendsto Prod.diagonal f (f ×ˢ f) :=
+  tendsto_iff_eventually.mpr fun _ hpr => hpr.diagonal_of_prod
+
+@[deprecated (since := "2026-09-06")] alias Eventually.diag_of_prod := Eventually.diagonal_of_prod
+@[deprecated (since := "2026-09-06")]
+alias Eventually.diag_of_prod_left := Eventually.diagonal_of_prod_left
+@[deprecated (since := "2026-09-06")]
+alias Eventually.diag_of_prod_right := Eventually.diagonal_of_prod_right
+@[deprecated (since := "2026-09-06")] alias tendsto_diag := tendsto_diagonal
 
 theorem prod_iInf_left [Nonempty ι] {f : ι → Filter α} {g : Filter β} :
     (⨅ i, f i) ×ˢ g = ⨅ i, f i ×ˢ g := by

--- a/Mathlib/Order/FixedPoints.lean
+++ b/Mathlib/Order/FixedPoints.lean
@@ -142,17 +142,17 @@ theorem map_gfp_comp : f (g.comp f).gfp = (f.comp g).gfp :=
   f.dual.map_lfp_comp g.dual
 
 -- Diagonal rule
-theorem lfp_lfp (h : α →o α →o α) : (lfp.comp h).lfp = h.onDiag.lfp := by
+theorem lfp_lfp (h : α →o α →o α) : (lfp.comp h).lfp = h.onDiagonal.lfp := by
   let a := (lfp.comp h).lfp
   refine (lfp_le _ ?_).antisymm (lfp_le _ (Eq.le ?_))
-  · exact lfp_le _ h.onDiag.map_lfp.le
+  · exact lfp_le _ h.onDiagonal.map_lfp.le
   have ha : (lfp ∘ h) a = a := (lfp.comp h).map_lfp
   calc
     h a a = h a (h a).lfp := congr_arg (h a) ha.symm
     _ = (h a).lfp := (h a).map_lfp
     _ = a := ha
 
-theorem gfp_gfp (h : α →o α →o α) : (gfp.comp h).gfp = h.onDiag.gfp :=
+theorem gfp_gfp (h : α →o α →o α) : (gfp.comp h).gfp = h.onDiagonal.gfp :=
   @lfp_lfp αᵒᵈ _ <| (OrderHom.dualIso αᵒᵈ αᵒᵈ).symm.toOrderEmbedding.toOrderHom.comp h.dual
 
 end Eqn

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -41,8 +41,8 @@ because the more bundled version usually does not work with dot notation.
 * `OrderHom.prod`: combine `α →o β` and `α →o γ` into `α →o β × γ`;
 * `OrderHom.prodₘ`: a more bundled version of `OrderHom.prod`;
 * `OrderHom.prodIso`: order isomorphism between `α →o β × γ` and `(α →o β) × (α →o γ)`;
-* `OrderHom.diag`: diagonal embedding of `α` into `α × α` as a bundled monotone map;
-* `OrderHom.onDiag`: restrict a monotone map `α →o α →o β` to the diagonal;
+* `OrderHom.diagonal`: diagonal embedding of `α` into `α × α` as a bundled monotone map;
+* `OrderHom.onDiagonal`: restrict a monotone map `α →o α →o β` to the diagonal;
 * `OrderHom.fst`: projection `Prod.fst : α × β → α` as a bundled monotone map;
 * `OrderHom.snd`: projection `Prod.snd : α × β → β` as a bundled monotone map;
 * `OrderHom.prodMap`: `Prod.map f g` as a bundled monotone map;
@@ -401,13 +401,17 @@ def prodₘ : (α →o β) →o (α →o γ) →o α →o β × γ :=
 
 /-- Diagonal embedding of `α` into `α × α` as an `OrderHom`. -/
 @[simps!]
-def diag : α →o α × α :=
+def diagonal : α →o α × α :=
   id.prod id
+
+@[deprecated (since := "2026-09-06")] alias diag := diagonal
 
 /-- Restriction of `f : α →o α →o β` to the diagonal. -/
 @[simps! +simpRhs]
-def onDiag (f : α →o α →o β) : α →o β :=
-  (curry.symm f).comp diag
+def onDiagonal (f : α →o α →o β) : α →o β :=
+  (curry.symm f).comp diagonal
+
+@[deprecated (since := "2026-09-06")] alias onDiag := onDiagonal
 
 /-- `Prod.fst` as an `OrderHom`. -/
 @[simps]

--- a/Mathlib/Probability/Combinatorics/BinomialRandomGraph/Defs.lean
+++ b/Mathlib/Probability/Combinatorics/BinomialRandomGraph/Defs.lean
@@ -44,7 +44,7 @@ variable (V p) in
 /-- The binomial distribution with parameter `p` on simple graphs with vertices `V`. -/
 @[expose]
 noncomputable def binomialRandom : Measure (SimpleGraph V) :=
-  setBer(Sym2.diagSetᶜ, p).comap edgeSet
+  setBer(Sym2.diagonalSetᶜ, p).comap edgeSet
 
 @[inherit_doc] scoped notation "G(" V ", " p ")" => binomialRandom V p
 
@@ -52,7 +52,7 @@ section Countable
 variable [Countable V]
 
 variable (V p) in
-lemma binomialRandom_eq_map : G(V, p) = map fromEdgeSet setBer(Sym2.diagSetᶜ, p) := by
+lemma binomialRandom_eq_map : G(V, p) = map fromEdgeSet setBer(Sym2.diagonalSetᶜ, p) := by
   refine (map_eq_comap measurable_fromEdgeSet measurableEmbedding_edgeSet ?_
     fromEdgeSet_edgeSet).symm
   filter_upwards [setBernoulli_ae_subset] with S hS
@@ -60,12 +60,12 @@ lemma binomialRandom_eq_map : G(V, p) = map fromEdgeSet setBer(Sym2.diagSetᶜ, 
 
 variable (p) in
 lemma binomialRandom_apply' (S : Set (SimpleGraph V)) :
-    G(V, p) S = setBer(Sym2.diagSetᶜ, p) (edgeSet '' S) := by
+    G(V, p) S = setBer(Sym2.diagonalSetᶜ, p) (edgeSet '' S) := by
   rw [binomialRandom, measurableEmbedding_edgeSet.comap_apply]
 
 variable (p) in
 lemma binomialRandom_apply (S : Set (SimpleGraph V)) :
-    G(V, p) S = infinitePi (fun e : Sym2 V ↦ Ber(¬ e.IsDiag, False, p))
+    G(V, p) S = infinitePi (fun e : Sym2 V ↦ Ber(¬ e.IsDiagonal, False, p))
       ((fun G e ↦ e ∈ G.edgeSet) '' S) := by
   simp [binomialRandom_apply', setBernoulli_apply, ← Set.image_comp]
 
@@ -90,10 +90,10 @@ variable (p) in
   classical
   cases nonempty_fintype V
   simp only [binomialRandom, measurableEmbedding_edgeSet.comap_apply, Set.image_singleton,
-    edgeSet_subset_compl_diagSet, setBernoulli_singleton, Set.toFinite]
+    edgeSet_subset_compl_diagonalSet, setBernoulli_singleton, Set.toFinite]
   rw [Set.ncard_sdiff (by simp)]
   congr!
-  rw [Nat.card_eq_fintype_card, ← Sym2.card_diagSet_compl, Fintype.card_eq_nat_card,
+  rw [Nat.card_eq_fintype_card, ← Sym2.card_diagonalSet_compl, Fintype.card_eq_nat_card,
     ← Nat.card_coe_set_eq]
 
 end SimpleGraph

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -130,7 +130,7 @@ section Copy
 /-- The deterministic kernel that maps `x : α` to the Dirac measure at `(x, x) : α × α`. -/
 noncomputable
 def copy (α : Type*) [MeasurableSpace α] : Kernel α (α × α) :=
-  Kernel.deterministic Function.diag (measurable_id.prod measurable_id)
+  Kernel.deterministic Prod.diagonal (measurable_id.prod measurable_id)
 
 instance : IsMarkovKernel (copy α) := by rw [copy]; infer_instance
 

--- a/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureCompProd.lean
@@ -99,14 +99,14 @@ lemma _root_.ProbabilityTheory.Kernel.compProd_apply_eq_compProd_sectR {γ : Typ
   ext s hs
   simp_rw [Kernel.compProd_apply hs, compProd_apply hs, Kernel.sectR_apply]
 
-lemma compProd_id [SFinite μ] : μ ⊗ₘ Kernel.id = μ.map Function.diag := by
+lemma compProd_id [SFinite μ] : μ ⊗ₘ Kernel.id = μ.map Prod.diagonal := by
   ext s hs
   rw [compProd_apply hs, map_apply (measurable_id.prod measurable_id) hs]
   have h_meas a : MeasurableSet (Prod.mk a ⁻¹' s) := measurable_prodMk_left hs
   simp_rw [Kernel.id_apply, dirac_apply' _ (h_meas _)]
   calc ∫⁻ a, (Prod.mk a ⁻¹' s).indicator 1 a ∂μ
-  _ = ∫⁻ a, (Function.diag ⁻¹' s).indicator 1 a ∂μ := rfl
-  _ = μ (Function.diag ⁻¹' s) := by
+  _ = ∫⁻ a, (Prod.diagonal ⁻¹' s).indicator 1 a ∂μ := rfl
+  _ = μ (Prod.diagonal ⁻¹' s) := by
     rw [lintegral_indicator_one]
     exact (measurable_id.prod measurable_id) hs
 

--- a/Mathlib/Probability/Kernel/Condexp.lean
+++ b/Mathlib/Probability/Kernel/Condexp.lean
@@ -48,12 +48,12 @@ variable {Ω F : Type*} {m mΩ : MeasurableSpace Ω} {μ : Measure Ω} {f : Ω �
 theorem _root_.MeasureTheory.AEStronglyMeasurable.comp_snd_map_prod_id (hm : m ≤ mΩ)
     [TopologicalSpace F] (hf : AEStronglyMeasurable f μ) :
     AEStronglyMeasurable[m.prod mΩ] (fun x : Ω × Ω => f x.2)
-      (@Measure.map Ω (Ω × Ω) mΩ (m.prod mΩ) Function.diag μ) :=
+      (@Measure.map Ω (Ω × Ω) mΩ (m.prod mΩ) Prod.diagonal μ) :=
   hf.comp_snd_map_prodMk (@Measurable.aemeasurable Ω Ω mΩ m id μ (measurable_id'' hm))
 
 theorem _root_.MeasureTheory.Integrable.comp_snd_map_prod_id (hm : m ≤ mΩ) [NormedAddCommGroup F]
     (hf : Integrable f μ) : Integrable (fun x : Ω × Ω => f x.2)
-      (@Measure.map Ω (Ω × Ω) mΩ (m.prod mΩ) Function.diag μ) :=
+      (@Measure.map Ω (Ω × Ω) mΩ (m.prod mΩ) Prod.diagonal μ) :=
   hf.comp_snd_map_prodMk (@Measurable.aemeasurable Ω Ω mΩ m id μ (measurable_id'' hm))
 
 end AuxLemmas
@@ -92,7 +92,7 @@ instance : IsMarkovKernel (condExpKernel μ m) := by
 
 lemma compProd_trim_condExpKernel (hm : m ≤ mΩ) :
     (μ.trim hm) ⊗ₘ condExpKernel μ m
-      = @Measure.map Ω (Ω × Ω) mΩ (m.prod mΩ) Function.diag μ := by
+      = @Measure.map Ω (Ω × Ω) mΩ (m.prod mΩ) Prod.diagonal μ := by
   rcases isEmpty_or_nonempty Ω with h | h
   · simp [Measure.eq_zero_of_isEmpty μ]
   rw [condExpKernel_eq, trim_eq_map hm]

--- a/Mathlib/Probability/Kernel/Deterministic.lean
+++ b/Mathlib/Probability/Kernel/Deterministic.lean
@@ -68,7 +68,7 @@ lemma parallelComp_self_comp_copy {κ : Kernel α β} [IsDeterministic κ] :
 instance {f : α → β} (hf : Measurable f) : IsDeterministic (deterministic f hf) where
   parallelComp_self_comp_copy' := by
     simp_rw [parallelComp_comp_copy, deterministic_prod_deterministic, copy,
-      deterministic_comp_deterministic, Function.comp_def, Function.diag_def]
+      deterministic_comp_deterministic, Function.comp_def, Prod.diagonal_def]
 
 instance : IsDeterministic (mβ := mα) (Kernel.id (α := α)) := by unfold Kernel.id; infer_instance
 

--- a/Mathlib/Probability/Moments/SubGaussian.lean
+++ b/Mathlib/Probability/Moments/SubGaussian.lean
@@ -882,8 +882,8 @@ lemma HasSubgaussianMGF.add_of_hasCondSubgaussianMGF [IsFiniteMeasure μ]
     (hX : HasSubgaussianMGF X cX (μ.trim hm)) (hY : HasCondSubgaussianMGF m hm Y cY μ) :
     HasSubgaussianMGF (X + Y) (cX + cY) μ := by
   suffices HasSubgaussianMGF (fun p ↦ X p.1 + Y p.2) (cX + cY)
-      (@Measure.map Ω (Ω × Ω) mΩ (m.prod mΩ) Function.diag μ) by
-    have h_eq : X + Y = (fun p ↦ X p.1 + Y p.2) ∘ Function.diag := rfl
+      (@Measure.map Ω (Ω × Ω) mΩ (m.prod mΩ) Prod.diagonal μ) by
+    have h_eq : X + Y = (fun p ↦ X p.1 + Y p.2) ∘ Prod.diagonal := rfl
     rw [h_eq]
     refine HasSubgaussianMGF.of_map ?_ this
     exact @Measurable.aemeasurable _ _ _ (m.prod mΩ) _ _

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -334,7 +334,7 @@ theorem comul_comp_lapply (i : ι) :
     comul ∘ₗ (lapply i : _ →ₗ[R] A i) = TensorProduct.map (lapply i) (lapply i) ∘ₗ comul := by
   ext j
   have := eq_or_ne i j
-  aesop (add simp [TensorProduct.map_map, proj_comp_single, diag])
+  aesop (add simp [TensorProduct.map_map, proj_comp_single, diagonal])
 
 @[simp] theorem counit_comp_lsingle (i : ι) : counit ∘ₗ (lsingle i : A i →ₗ[R] _) = counit := by
   ext; simp
@@ -401,7 +401,7 @@ theorem comul_comp_lsingle (i : ι) :
 theorem comul_comp_lapply (i : ι) :
     comul ∘ₗ (lapply i : _ →ₗ[R] A) = TensorProduct.map (lapply i) (lapply i) ∘ₗ comul := by
   ext j; have := eq_or_ne i j
-  aesop (add simp [TensorProduct.map_map, proj_comp_single, diag])
+  aesop (add simp [TensorProduct.map_map, proj_comp_single, diagonal])
 
 @[simp] theorem counit_comp_lsingle (i : ι) : counit ∘ₗ (lsingle i : A →ₗ[R] _) = counit := by
   ext; simp
@@ -462,7 +462,7 @@ theorem comul_comp_single (i : n) :
 theorem comul_comp_proj (i : n) :
     comul ∘ₗ (proj i : (Π i, A i) →ₗ[R] A i) = map (proj i) (proj i) ∘ₗ comul := by
   ext j; have := eq_or_ne i j
-  aesop (add simp [map_map, proj_comp_single, diag])
+  aesop (add simp [map_map, proj_comp_single, diagonal])
 
 @[simp] theorem counit_comp_single (i : n) : counit ∘ₗ .single R A i = counit := by ext; simp
 

--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -214,7 +214,7 @@ theorem discr_powerBasis_eq_norm [Algebra.IsSeparable K L] :
   apply (algebraMap K E).injective
   rw [map_mul, map_pow, map_neg, map_one, discr_powerBasis_eq_prod'' _ _ _ e]
   congr
-  rw [norm_eq_prod_embeddings, prod_prod_Ioi_mul_eq_prod_prod_off_diag]
+  rw [norm_eq_prod_embeddings, prod_prod_Ioi_mul_eq_prod_prod_off_diagonal]
   conv_rhs =>
     congr
     rfl

--- a/Mathlib/RingTheory/MatrixPolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixPolynomialAlgebra.lean
@@ -176,7 +176,7 @@ variable {S : Type*} [CommSemiring S] (f : S →+* Matrix n n R)
 
 lemma evalRingHom_mapMatrix_comp_polyToMatrix :
     (evalRingHom 0).mapMatrix.comp f.polyToMatrix = f.comp (evalRingHom 0) := by
-  ext <;> simp [RingHom.polyToMatrix, -AlgEquiv.symm_toRingEquiv, diagonal, apply_ite]
+  ext <;> simp [RingHom.polyToMatrix, -AlgEquiv.symm_toRingEquiv, Matrix.diagonal, apply_ite]
 
 lemma evalRingHom_mapMatrix_comp_compRingEquiv {m} [Fintype m] [DecidableEq m] :
     (evalRingHom 0).mapMatrix.comp (compRingEquiv m n R[X]) =

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -675,16 +675,16 @@ set_option backward.isDefEq.respectTransparency false in
 theorem coeff_prod [DecidableEq ι] [DecidableEq σ]
     (f : ι → MvPowerSeries σ R) (d : σ →₀ ℕ) (s : Finset ι) :
     coeff d (∏ j ∈ s, f j) =
-      ∑ l ∈ finsuppAntidiag s d,
+      ∑ l ∈ finsuppAntidiagonal s d,
         ∏ i ∈ s, coeff (l i) (f i) := by
   induction s using Finset.induction_on generalizing d with
   | empty =>
-    simp only [prod_empty, sum_const, nsmul_eq_mul, mul_one, coeff_one, finsuppAntidiag_empty]
+    simp only [prod_empty, sum_const, nsmul_eq_mul, mul_one, coeff_one, finsuppAntidiagonal_empty]
     split_ifs
     · simp only [card_singleton, Nat.cast_one]
     · simp only [card_empty, Nat.cast_zero]
   | insert a s ha ih =>
-    rw [finsuppAntidiag_insert ha, prod_insert ha, coeff_mul, sum_biUnion]
+    rw [finsuppAntidiagonal_insert ha, prod_insert ha, coeff_mul, sum_biUnion]
     · apply Finset.sum_congr rfl
       simp only [mem_antidiagonal, sum_map, Function.Embedding.coeFn_mk, coe_update, Prod.forall]
       rintro u v rfl
@@ -714,10 +714,10 @@ theorem prod_monomial (f : ι → σ →₀ ℕ) (g : ι → R) (s : Finset ι) 
   | cons a s ha h => simp [h, monomial_mul_monomial]
 
 /-- The `d`th coefficient of a power of a multivariate power series
-is the sum, indexed by `finsuppAntidiag (Finset.range n) d`, of products of coefficients -/
+is the sum, indexed by `finsuppAntidiagonal (Finset.range n) d`, of products of coefficients -/
 theorem coeff_pow [DecidableEq σ] (f : MvPowerSeries σ R) {n : ℕ} (d : σ →₀ ℕ) :
     coeff d (f ^ n) =
-      ∑ l ∈ finsuppAntidiag (Finset.range n) d,
+      ∑ l ∈ finsuppAntidiagonal (Finset.range n) d,
         ∏ i ∈ Finset.range n, coeff (l i) f := by
   suffices f ^ n = (Finset.range n).prod fun _ ↦ f by
     rw [this, coeff_prod]
@@ -738,7 +738,7 @@ theorem coeff_eq_zero_of_constantCoeff_nilpotent {f : MvPowerSeries σ R} {m : �
   rw [coeff_pow]
   apply sum_eq_zero
   intro k hk
-  rw [mem_finsuppAntidiag] at hk
+  rw [mem_finsuppAntidiagonal] at hk
   set s := {i ∈ range n | k i = 0} with hs_def
   have hs : s ⊆ range n := filter_subset _ _
   have hs' (i : ℕ) (hi : i ∈ s) : coeff (k i) f = constantCoeff f := by

--- a/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
@@ -536,7 +536,7 @@ theorem truncTotal_subst_eq_truncTotal_subst_truncTotal_of_le (ha : HasSubst a)
     · intro n
       simp_rw [Finsupp.prod, coeff_prod]
       congr! 3 with l hl i hi
-      obtain ⟨hl₁, -⟩ := mem_finsuppAntidiag.mp hl
+      obtain ⟨hl₁, -⟩ := mem_finsuppAntidiagonal.mp hl
       have : (l i).degree ≤ d.degree :=
         hl₁ ▸ Finsupp.degree_mono (single_le_sum_of_canonicallyOrdered hi)
       exact_mod_cast (coeff_truncTotal_pow _ (by nlinarith [hx i])).symm

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -637,10 +637,10 @@ variable {R : Type*} [CommSemiring R] {ι : Type*}
 
 /-- Coefficients of a product of power series -/
 theorem coeff_prod [DecidableEq ι] (f : ι → PowerSeries R) (d : ℕ) (s : Finset ι) :
-    coeff d (∏ j ∈ s, f j) = ∑ l ∈ finsuppAntidiag s d, ∏ i ∈ s, coeff (l i) (f i) := by
+    coeff d (∏ j ∈ s, f j) = ∑ l ∈ finsuppAntidiagonal s d, ∏ i ∈ s, coeff (l i) (f i) := by
   simp only [coeff]
   rw [MvPowerSeries.coeff_prod, ← Finsupp.uniqueAddEquiv_symm_apply _ d,
-    ← mapRange_finsuppAntidiag_eq, sum_map]
+    ← mapRange_finsuppAntidiagonal_eq, sum_map]
   rfl
 
 theorem prod_monomial (f : ι → ℕ) (g : ι → R) (s : Finset ι) :
@@ -653,7 +653,7 @@ theorem monomial_pow (m : ℕ) (a : R) (n : ℕ) : (monomial m a) ^ n = monomial
 
 /-- The `n`-th coefficient of the `k`-th power of a power series. -/
 lemma coeff_pow (k n : ℕ) (φ : R⟦X⟧) :
-    coeff n (φ ^ k) = ∑ l ∈ finsuppAntidiag (range k) n, ∏ i ∈ range k, coeff (l i) φ := by
+    coeff n (φ ^ k) = ∑ l ∈ finsuppAntidiagonal (range k) n, ∏ i ∈ range k, coeff (l i) φ := by
   have h₁ (i : ℕ) : Function.const ℕ φ i = φ := rfl
   have h₂ (i : ℕ) : ∏ j ∈ range i, Function.const ℕ φ j = φ ^ i := by
     apply prod_range_induction (fun _ => φ) (fun i => φ ^ i) rfl i (fun _ => congrFun rfl)

--- a/Mathlib/RingTheory/WittVector/InitTail.lean
+++ b/Mathlib/RingTheory/WittVector/InitTail.lean
@@ -86,7 +86,7 @@ theorem select_add_select_not : ∀ x : 𝕎 R, select P x + select (fun i => ¬
   -- Porting note: TC search was insufficient to find this instance, even though all required
   -- instances exist. See zulip: [https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/WittVector.20saga/near/370073526]
   have : IsPoly p fun {R} [CommRing R] x ↦ select P x + select (fun i ↦ ¬P i) x :=
-    IsPoly₂.diag (hf := IsPoly₂.comp)
+    IsPoly₂.diagonal (hf := IsPoly₂.comp)
   ghost_calc x
   intro n
   simp only [map_add]

--- a/Mathlib/RingTheory/WittVector/IsPoly.lean
+++ b/Mathlib/RingTheory/WittVector/IsPoly.lean
@@ -248,7 +248,7 @@ instance IsPoly.comp₂ {g f} [hg : IsPoly p g] [hf : IsPoly₂ p f] :
   simp only [peval, aeval_bind₁, hg, hf]
 
 /-- The diagonal `fun x ↦ f x x` of a polynomial function `f` is polynomial. -/
-instance IsPoly₂.diag {f} [hf : IsPoly₂ p f] : IsPoly p fun _ _Rcr x => f x x := by
+instance IsPoly₂.diagonal {f} [hf : IsPoly₂ p f] : IsPoly p fun _ _Rcr x => f x x := by
   obtain ⟨φ, hf⟩ := hf
   refine ⟨⟨fun n => bind₁ (uncurry ![X, X]) (φ n), ?_⟩⟩
   intros; funext n
@@ -256,6 +256,8 @@ instance IsPoly₂.diag {f} [hf : IsPoly₂ p f] : IsPoly p fun _ _Rcr x => f x 
   apply eval₂Hom_congr rfl _ rfl
   ext ⟨i, k⟩
   fin_cases i <;> simp
+
+@[deprecated (since := "2026-09-06")] alias IsPoly₂.diag := IsPoly₂.diagonal
 
 /-- The additive negation is a polynomial function on Witt vectors. -/
 instance negIsPoly [Fact p.Prime] : IsPoly p fun R _ => @Neg.neg (𝕎 R) _ :=

--- a/Mathlib/SetTheory/Cardinal/Cofinality/Club.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality/Club.lean
@@ -148,7 +148,7 @@ protected theorem inter (hα : cof α ≠ ℵ₀) (hs : IsClub s) (ht : IsClub t
   simpa [hs, ht] using IsClub.sInter_of_countable (s := {s, t}) hα
 
 /-- Club sets are closed under diagonal intersections. -/
-protected theorem diag [IsRegularCardinalOrder α] {f : α → Set α} (hα : cof α ≠ ℵ₀)
+protected theorem diagonal [IsRegularCardinalOrder α] {f : α → Set α} (hα : cof α ≠ ℵ₀)
     (hf : ∀ a, IsClub (f a)) : IsClub {a | ∀ b < a, a ∈ f b} where
   dirSupClosed t ht ht₀ _ a ha b hb := by
     obtain ⟨c, hc, hbc, -⟩ := ha.exists_between hb
@@ -190,6 +190,8 @@ protected theorem diag [IsRegularCardinalOrder α] {f : α → Set α} (hα : co
         exact (hg _).1 _ (hb.trans_le <| hgm.monotone hm)
     · use g^[n + 1] a
       simp [- Function.iterate_succ]
+
+@[deprecated (since := "2026-09-06")] alias diag := diagonal
 
 theorem _root_.Order.IsNormal.isClub_range {f : α → α} (hf : IsNormal f) : IsClub (.range f) :=
   ⟨hf.dirSupClosed_range, fun x ↦ ⟨_, ⟨x, rfl⟩, hf.strictMono.le_apply⟩⟩
@@ -342,7 +344,7 @@ theorem exists_isStationary_preimage_singleton [IsRegularCardinalOrder α] {f : 
   by_contra!
   choose g hg using this
   simp_rw [Set.eq_empty_iff_forall_notMem] at hg
-  obtain ⟨a, hs, ha⟩ := hs <| .diag hα fun a ↦ (hg a).1
+  obtain ⟨a, hs, ha⟩ := hs <| .diagonal hα fun a ↦ (hg a).1
   apply (hg (f a)).2 a
   grind
 

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -217,7 +217,10 @@ def inr : B →ₜ* (A × B) :=
 
 /-- The continuous homomorphism given by the diagonal embedding. -/
 @[to_additive (attr := simps!) /-- The continuous homomorphism given by the diagonal embedding. -/]
-def diag : A →ₜ* (A × A) := prod (id A) (id A)
+def diagonal : A →ₜ* (A × A) := prod (id A) (id A)
+
+@[to_additive (attr := deprecated (since := "2026-09-06"))]
+alias diag := diagonal
 
 /-- The continuous homomorphism given by swapping components. -/
 @[to_additive (attr := simps!) /-- The continuous homomorphism given by swapping components. -/]

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
@@ -155,13 +155,13 @@ variable {ι : Type*} {l : Filter ι} {l' : Filter β} {f f' : ι → β → α}
 theorem TendstoUniformlyOnFilter.mul (hf : TendstoUniformlyOnFilter f g l l')
     (hf' : TendstoUniformlyOnFilter f' g' l l') : TendstoUniformlyOnFilter (f * f') (g * g') l l' :=
   fun u hu =>
-  ((uniformContinuous_mul.comp_tendstoUniformlyOnFilter (hf.prodMk hf')) u hu).diag_of_prod_left
+  ((uniformContinuous_mul.comp_tendstoUniformlyOnFilter (hf.prodMk hf')) u hu).diagonal_of_prod_left
 
 @[to_additive (attr := to_fun)]
 theorem TendstoUniformlyOnFilter.div (hf : TendstoUniformlyOnFilter f g l l')
     (hf' : TendstoUniformlyOnFilter f' g' l l') : TendstoUniformlyOnFilter (f / f') (g / g') l l' :=
   fun u hu =>
-  ((uniformContinuous_div.comp_tendstoUniformlyOnFilter (hf.prodMk hf')) u hu).diag_of_prod_left
+  ((uniformContinuous_div.comp_tendstoUniformlyOnFilter (hf.prodMk hf')) u hu).diagonal_of_prod_left
 
 @[to_additive (attr := to_fun)]
 theorem TendstoUniformlyOnFilter.inv (hf : TendstoUniformlyOnFilter f g l l') :
@@ -171,12 +171,12 @@ theorem TendstoUniformlyOnFilter.inv (hf : TendstoUniformlyOnFilter f g l l') :
 @[to_additive (attr := to_fun)]
 theorem TendstoUniformlyOn.mul (hf : TendstoUniformlyOn f g l s)
     (hf' : TendstoUniformlyOn f' g' l s) : TendstoUniformlyOn (f * f') (g * g') l s := fun u hu =>
-  ((uniformContinuous_mul.comp_tendstoUniformlyOn (hf.prodMk hf')) u hu).diag_of_prod
+  ((uniformContinuous_mul.comp_tendstoUniformlyOn (hf.prodMk hf')) u hu).diagonal_of_prod
 
 @[to_additive (attr := to_fun)]
 theorem TendstoUniformlyOn.div (hf : TendstoUniformlyOn f g l s)
     (hf' : TendstoUniformlyOn f' g' l s) : TendstoUniformlyOn (f / f') (g / g') l s := fun u hu =>
-  ((uniformContinuous_div.comp_tendstoUniformlyOn (hf.prodMk hf')) u hu).diag_of_prod
+  ((uniformContinuous_div.comp_tendstoUniformlyOn (hf.prodMk hf')) u hu).diagonal_of_prod
 
 @[to_additive (attr := to_fun)]
 theorem TendstoUniformlyOn.inv (hf : TendstoUniformlyOn f g l s) :
@@ -186,12 +186,12 @@ theorem TendstoUniformlyOn.inv (hf : TendstoUniformlyOn f g l s) :
 @[to_additive (attr := to_fun)]
 theorem TendstoUniformly.mul (hf : TendstoUniformly f g l) (hf' : TendstoUniformly f' g' l) :
     TendstoUniformly (f * f') (g * g') l := fun u hu =>
-  ((uniformContinuous_mul.comp_tendstoUniformly (hf.prodMk hf')) u hu).diag_of_prod
+  ((uniformContinuous_mul.comp_tendstoUniformly (hf.prodMk hf')) u hu).diagonal_of_prod
 
 @[to_additive (attr := to_fun)]
 theorem TendstoUniformly.div (hf : TendstoUniformly f g l) (hf' : TendstoUniformly f' g' l) :
     TendstoUniformly (f / f') (g / g') l := fun u hu =>
-  ((uniformContinuous_div.comp_tendstoUniformly (hf.prodMk hf')) u hu).diag_of_prod
+  ((uniformContinuous_div.comp_tendstoUniformly (hf.prodMk hf')) u hu).diagonal_of_prod
 
 @[to_additive (attr := to_fun)]
 theorem TendstoUniformly.inv (hf : TendstoUniformly f g l) :

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
@@ -378,7 +378,7 @@ instance IsUniformGroup.isRightUniformGroup : IsRightUniformGroup α where
   uniformity_eq := by
     refine eq_of_forall_le_iff fun 𝓕 ↦ ?_
     rw [nhds_eq_comap_uniformity, comap_comap, ← tendsto_iff_comap,
-      ← (tendsto_diag_uniformity Prod.fst 𝓕).uniformity_mul_iff_left, ← tendsto_id']
+      ← (tendsto_diagonal_uniformity Prod.fst 𝓕).uniformity_mul_iff_left, ← tendsto_id']
     congrm Tendsto ?_ _ _
     ext <;> simp
 
@@ -387,7 +387,7 @@ instance IsUniformGroup.isLeftUniformGroup : IsLeftUniformGroup α where
   uniformity_eq := by
     refine eq_of_forall_le_iff fun 𝓕 ↦ ?_
     rw [nhds_eq_comap_uniformity, comap_comap, ← tendsto_iff_comap,
-      ← (tendsto_diag_uniformity Prod.fst 𝓕).uniformity_mul_iff_right, ← tendsto_id']
+      ← (tendsto_diagonal_uniformity Prod.fst 𝓕).uniformity_mul_iff_right, ← tendsto_id']
     congrm Tendsto ?_ _ _
     ext <;> simp
 

--- a/Mathlib/Topology/Algebra/ProperAction/Basic.lean
+++ b/Mathlib/Topology/Algebra/ProperAction/Basic.lean
@@ -139,8 +139,8 @@ theorem t2Space_of_properSMul_of_t1Group [h_proper : ProperSMul G X] [T1Space G]
   rw [t2_iff_isClosed_diagonal]
   let g := fun gx : G × X ↦ (gx.1 • gx.2, gx.2)
   have proper_g : IsProperMap g := (properSMul_iff G X).1 h_proper
-  have : g ∘ f = Function.diag := by ext x <;> simp [f, g]
-  have range_gf : range (g ∘ f) = diagonal X := by simp [this]
+  have : g ∘ f = Prod.diagonal := by ext x <;> simp [f, g]
+  have range_gf : range (g ∘ f) = Set.diagonal X := by simp [this]
   rw [← range_gf]
   exact (proper_g.comp proper_f).isClosed_range
 

--- a/Mathlib/Topology/Category/TopPair.lean
+++ b/Mathlib/Topology/Category/TopPair.lean
@@ -96,9 +96,11 @@ def incl : TopCat.{u} ⥤ TopPair.{u} where
 
 /-- The functor from topological spaces to topological pairs that sends a space X to the identity
 morphism on X. -/
-abbrev diag : TopCat.{u} ⥤ TopPair.{u} where
+abbrev diagonal : TopCat.{u} ⥤ TopPair.{u} where
   obj X := TopPair.of (𝟙 X) Topology.IsEmbedding.id
   map f := TopPair.ofHom f f
+
+@[deprecated (since := "2026-09-06")] alias diag := diagonal
 
 set_option backward.isDefEq.respectTransparency.types false in
 set_option backward.defeqAttrib.useBackward true in
@@ -110,10 +112,12 @@ def inclAdjProj₁ : incl ⊣ proj₁ where
 
 /-- The projection functor to the first component is left adjoint to the diagonal functor. -/
 @[simps]
-def proj₁AdjDiag : proj₁ ⊣ diag where
+def proj₁AdjDiagonal : proj₁ ⊣ diagonal where
   unit.app X := TopPair.ofHom (𝟙 X.fst) X.map
   unit.naturality X Y f := MorphismProperty.Arrow.Hom.ext f.w (by cat_disch)
   counit.app X := 𝟙 X
+
+@[deprecated (since := "2026-09-06")] alias proj₁AdjDiag := proj₁AdjDiagonal
 
 set_option backward.defeqAttrib.useBackward true in
 /-- The unique morphism (X, ∅) ⟶ (X, A) that is the identity on X. -/

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -428,7 +428,7 @@ theorem IsCompact.mem_prod_nhdsSet_of_forall {K : Set Y} {X} {l : Filter X} {s :
 -- That would seem a bit more natural.
 theorem IsCompact.nhdsSet_inf_eq_biSup {K : Set X} (hK : IsCompact K) (l : Filter X) :
     (𝓝ˢ K) ⊓ l = ⨆ x ∈ K, 𝓝 x ⊓ l := by
-  have : ∀ f : Filter X, f ⊓ l = comap Function.diag (f ×ˢ l) := fun f ↦ by
+  have : ∀ f : Filter X, f ⊓ l = comap Prod.diagonal (f ×ˢ l) := fun f ↦ by
     simpa only [comap_prod] using! congrArg₂ (· ⊓ ·) comap_id.symm comap_id.symm
   simp_rw [this, ← comap_iSup, hK.nhdsSet_prod_eq_biSup]
 

--- a/Mathlib/Topology/Constructions/SumProd.lean
+++ b/Mathlib/Topology/Constructions/SumProd.lean
@@ -148,8 +148,10 @@ theorem Continuous.prodMk_right (x : X) : Continuous fun y : Y => (x, y) := by f
 theorem Continuous.prodMk_left (y : Y) : Continuous fun x : X => (x, y) := by fun_prop
 
 @[continuity, fun_prop]
-theorem continuous_diag : Continuous (Function.diag : X → X × X) :=
+theorem continuous_diagonal : Continuous (Prod.diagonal : X → X × X) :=
   continuous_id.prodMk continuous_id
+
+@[deprecated (since := "2026-09-06")] alias continuous_diag := continuous_diagonal
 
 /-- If `f x y` is continuous in `x` for all `y ∈ s`,
 then the set of `x` such that `f x` maps `s` to `t` is closed. -/

--- a/Mathlib/Topology/FiberBundle/Constructions.lean
+++ b/Mathlib/Topology/FiberBundle/Constructions.lean
@@ -111,10 +111,13 @@ instance FiberBundle.Prod.topologicalSpace : TopologicalSpace (TotalSpace (F₁ 
 
 /-- The diagonal map from the total space of the fiberwise product of two fiber bundles
 `E₁`, `E₂` into `TotalSpace F₁ E₁ × TotalSpace F₂ E₂` is an inducing map. -/
-theorem FiberBundle.Prod.isInducing_diag :
+theorem FiberBundle.Prod.isInducing_diagonal :
     IsInducing (fun p ↦ (⟨p.1, p.2.1⟩, ⟨p.1, p.2.2⟩) :
       TotalSpace (F₁ × F₂) (E₁ ×ᵇ E₂) → TotalSpace F₁ E₁ × TotalSpace F₂ E₂) :=
   ⟨rfl⟩
+
+@[deprecated (since := "2026-09-06")]
+alias FiberBundle.Prod.isInducing_diag := FiberBundle.Prod.isInducing_diagonal
 
 end Defs
 
@@ -143,7 +146,7 @@ theorem Prod.continuous_to_fun : ContinuousOn (Prod.toFun' e₁ e₂)
     fun p ↦ ((⟨p.1, p.2.1⟩ : TotalSpace F₁ E₁), (⟨p.1, p.2.2⟩ : TotalSpace F₂ E₂))
   let f₂ : TotalSpace F₁ E₁ × TotalSpace F₂ E₂ → (B × F₁) × B × F₂ := fun p ↦ ⟨e₁ p.1, e₂ p.2⟩
   let f₃ : (B × F₁) × B × F₂ → B × F₁ × F₂ := fun p ↦ ⟨p.1.1, p.1.2, p.2.2⟩
-  have hf₁ : Continuous f₁ := (Prod.isInducing_diag F₁ E₁ F₂ E₂).continuous
+  have hf₁ : Continuous f₁ := (Prod.isInducing_diagonal F₁ E₁ F₂ E₂).continuous
   have hf₂ : ContinuousOn f₂ (e₁.source ×ˢ e₂.source) :=
     e₁.toOpenPartialHomeomorph.continuousOn.prodMap e₂.toOpenPartialHomeomorph.continuousOn
   have hf₃ : Continuous f₃ := by fun_prop
@@ -182,7 +185,7 @@ theorem Prod.right_inv {x : B × F₁ × F₂}
 
 theorem Prod.continuous_inv_fun :
     ContinuousOn (Prod.invFun' e₁ e₂) ((e₁.baseSet ∩ e₂.baseSet) ×ˢ univ) := by
-  rw [(Prod.isInducing_diag F₁ E₁ F₂ E₂).continuousOn_iff]
+  rw [(Prod.isInducing_diagonal F₁ E₁ F₂ E₂).continuousOn_iff]
   have H₁ : Continuous fun p : B × F₁ × F₂ ↦ ((p.1, p.2.1), (p.1, p.2.2)) := by fun_prop
   refine (e₁.continuousOn_symm.prodMap e₂.continuousOn_symm).comp H₁.continuousOn ?_
   exact fun x h ↦ ⟨⟨h.1.1, mem_univ _⟩, ⟨h.1.2, mem_univ _⟩⟩
@@ -205,7 +208,7 @@ noncomputable def prod : Trivialization (F₁ × F₂) (π (F₁ × F₂) (E₁ 
   open_source := by
     convert!
       (e₁.open_source.prod e₂.open_source).preimage
-        (FiberBundle.Prod.isInducing_diag F₁ E₁ F₂ E₂).continuous
+        (FiberBundle.Prod.isInducing_diagonal F₁ E₁ F₂ E₂).continuous
     ext x
     simp only [Trivialization.source_eq, mfld_simps]
   open_target := (e₁.open_baseSet.inter e₂.open_baseSet).prod isOpen_univ
@@ -230,7 +233,7 @@ variable [∀ x, Zero (E₁ x)] [∀ x, Zero (E₂ x)] [∀ x : B, TopologicalSp
 /-- The product of two fiber bundles is a fiber bundle. -/
 @[simps] noncomputable instance FiberBundle.prod : FiberBundle (F₁ × F₂) (E₁ ×ᵇ E₂) where
   totalSpaceMk_isInducing' b := by
-    rw [← (Prod.isInducing_diag F₁ E₁ F₂ E₂).of_comp_iff]
+    rw [← (Prod.isInducing_diagonal F₁ E₁ F₂ E₂).of_comp_iff]
     exact (totalSpaceMk_isInducing F₁ E₁ b).prodMap (totalSpaceMk_isInducing F₂ E₂ b)
   trivializationAtlas' := { e |
     ∃ (e₁ : Trivialization F₁ (π F₁ E₁)) (e₂ : Trivialization F₂ (π F₂ E₂))

--- a/Mathlib/Topology/MetricSpace/Infsep.lean
+++ b/Mathlib/Topology/MetricSpace/Infsep.lean
@@ -137,30 +137,33 @@ theorem einfsep_pair_le_right (hxy : x ≠ y) : ({x, y} : Set α).einfsep ≤ ed
 theorem einfsep_pair_eq_inf (hxy : x ≠ y) : ({x, y} : Set α).einfsep = edist x y ⊓ edist y x :=
   le_antisymm (le_inf (einfsep_pair_le_left hxy) (einfsep_pair_le_right hxy)) le_einfsep_pair
 
-theorem einfsep_eq_iInf : s.einfsep = ⨅ d : s.offDiag, (uncurry edist) (d : α × α) := by
+theorem einfsep_eq_iInf : s.einfsep = ⨅ d : s.offDiagonal, (uncurry edist) (d : α × α) := by
   refine eq_of_forall_le_iff fun _ => ?_
-  simp_rw [le_einfsep_iff, le_iInf_iff, imp_forall_iff, SetCoe.forall, mem_offDiag,
+  simp_rw [le_einfsep_iff, le_iInf_iff, imp_forall_iff, SetCoe.forall, mem_offDiagonal,
     Prod.forall, uncurry_apply_pair, and_imp]
 
-theorem einfsep_of_fintype [Fintype s] : s.einfsep = s.offDiag.toFinset.inf (uncurry edist) := by
+theorem einfsep_of_fintype [Fintype s] :
+    s.einfsep = s.offDiagonal.toFinset.inf (uncurry edist) := by
   refine eq_of_forall_le_iff fun _ => ?_
-  simp_rw [le_einfsep_iff, imp_forall_iff, Finset.le_inf_iff, mem_toFinset, mem_offDiag,
+  simp_rw [le_einfsep_iff, imp_forall_iff, Finset.le_inf_iff, mem_toFinset, mem_offDiagonal,
     Prod.forall, uncurry_apply_pair, and_imp]
 
-theorem Finite.einfsep (hs : s.Finite) : s.einfsep = hs.offDiag.toFinset.inf (uncurry edist) := by
+theorem Finite.einfsep (hs : s.Finite) :
+    s.einfsep = hs.offDiagonal.toFinset.inf (uncurry edist) := by
   refine eq_of_forall_le_iff fun _ => ?_
-  simp_rw [le_einfsep_iff, imp_forall_iff, Finset.le_inf_iff, Finite.mem_toFinset, mem_offDiag,
+  simp_rw [le_einfsep_iff, imp_forall_iff, Finset.le_inf_iff, Finite.mem_toFinset, mem_offDiagonal,
     Prod.forall, uncurry_apply_pair, and_imp]
 
 theorem Finset.coe_einfsep {s : Finset α} :
-    (s : Set α).einfsep = s.offDiag.inf (uncurry edist) := by
-  simp_rw [einfsep_of_fintype, ← Finset.coe_offDiag, Finset.toFinset_coe]
+    (s : Set α).einfsep = s.offDiagonal.inf (uncurry edist) := by
+  simp_rw [einfsep_of_fintype, ← Finset.coe_offDiagonal, Finset.toFinset_coe]
 
 theorem Nontrivial.einfsep_exists_of_finite [Finite s] (hs : s.Nontrivial) :
     ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ s.einfsep = edist x y := by
   cases nonempty_fintype s
   simp_rw [einfsep_of_fintype]
-  rcases Finset.exists_mem_eq_inf s.offDiag.toFinset (by simpa) (uncurry edist) with ⟨w, hxy, hed⟩
+  rcases Finset.exists_mem_eq_inf s.offDiagonal.toFinset (by simpa) (uncurry edist) with
+    ⟨w, hxy, hed⟩
   simp_rw [mem_toFinset] at hxy
   exact ⟨w.fst, hxy.1, w.snd, hxy.2.1, hxy.2.2, hed⟩
 
@@ -369,71 +372,78 @@ theorem Nontrivial.infsep_anti (hs : s.Nontrivial) (hst : s ⊆ t) : t.infsep �
   ENNReal.toReal_mono hs.einfsep_ne_top (einfsep_anti hst)
 
 theorem infsep_eq_iInf [Decidable s.Nontrivial] :
-    s.infsep = if s.Nontrivial then ⨅ d : s.offDiag, (uncurry dist) (d : α × α) else 0 := by
+    s.infsep = if s.Nontrivial then ⨅ d : s.offDiagonal, (uncurry dist) (d : α × α) else 0 := by
   split_ifs with hs
-  · have hb : BddBelow (uncurry dist '' s.offDiag) := by
+  · have hb : BddBelow (uncurry dist '' s.offDiagonal) := by
       refine ⟨0, fun d h => ?_⟩
       simp_rw [mem_image, Prod.exists, uncurry_apply_pair] at h
       rcases h with ⟨_, _, _, rfl⟩
       exact dist_nonneg
     refine eq_of_forall_le_iff fun _ => ?_
-    simp_rw [hs.le_infsep_iff, le_ciInf_set_iff (offDiag_nonempty.mpr hs) hb, imp_forall_iff,
-      mem_offDiag, Prod.forall, uncurry_apply_pair, and_imp]
+    simp_rw [hs.le_infsep_iff, le_ciInf_set_iff (offDiagonal_nonempty.mpr hs) hb, imp_forall_iff,
+      mem_offDiagonal, Prod.forall, uncurry_apply_pair, and_imp]
   · exact (not_nontrivial_iff.mp hs).infsep_zero
 
 theorem Nontrivial.infsep_eq_iInf (hs : s.Nontrivial) :
-    s.infsep = ⨅ d : s.offDiag, (uncurry dist) (d : α × α) := by
+    s.infsep = ⨅ d : s.offDiagonal, (uncurry dist) (d : α × α) := by
   classical rw [Set.infsep_eq_iInf, ite_eq_left hs]
 
 theorem infsep_of_fintype [Decidable s.Nontrivial] [Fintype s] : s.infsep =
-    if hs : s.Nontrivial then s.offDiag.toFinset.inf' (by simpa) (uncurry dist) else 0 := by
+    if hs : s.Nontrivial then s.offDiagonal.toFinset.inf' (by simpa) (uncurry dist) else 0 := by
   split_ifs with hs
   · refine eq_of_forall_le_iff fun _ => ?_
-    simp_rw [hs.le_infsep_iff, imp_forall_iff, Finset.le_inf'_iff, mem_toFinset, mem_offDiag,
+    simp_rw [hs.le_infsep_iff, imp_forall_iff, Finset.le_inf'_iff, mem_toFinset, mem_offDiagonal,
       Prod.forall, uncurry_apply_pair, and_imp]
   · rw [not_nontrivial_iff] at hs
     exact hs.infsep_zero
 
 theorem Nontrivial.infsep_of_fintype [Fintype s] (hs : s.Nontrivial) :
-    s.infsep = s.offDiag.toFinset.inf' (by simpa) (uncurry dist) := by
+    s.infsep = s.offDiagonal.toFinset.inf' (by simpa) (uncurry dist) := by
   classical rw [Set.infsep_of_fintype, dite_eq_left hs]
 
 theorem Finite.infsep [Decidable s.Nontrivial] (hsf : s.Finite) :
     s.infsep =
-      if hs : s.Nontrivial then hsf.offDiag.toFinset.inf' (by simpa) (uncurry dist) else 0 := by
+      if hs : s.Nontrivial then hsf.offDiagonal.toFinset.inf' (by simpa) (uncurry dist) else 0 := by
   split_ifs with hs
   · refine eq_of_forall_le_iff fun _ => ?_
     simp_rw [hs.le_infsep_iff, imp_forall_iff, Finset.le_inf'_iff, Finite.mem_toFinset,
-      mem_offDiag, Prod.forall, uncurry_apply_pair, and_imp]
+      mem_offDiagonal, Prod.forall, uncurry_apply_pair, and_imp]
   · rw [not_nontrivial_iff] at hs
     exact hs.infsep_zero
 
 theorem Finite.infsep_of_nontrivial (hsf : s.Finite) (hs : s.Nontrivial) :
-    s.infsep = hsf.offDiag.toFinset.inf' (by simpa) (uncurry dist) := by
+    s.infsep = hsf.offDiagonal.toFinset.inf' (by simpa) (uncurry dist) := by
   classical simp_rw [hsf.infsep, dite_eq_left hs]
 
 theorem _root_.Finset.coe_infsep (s : Finset α) : (s : Set α).infsep =
-    if hs : s.offDiag.Nonempty then s.offDiag.inf' hs (uncurry dist) else 0 := by
-  have H : (s : Set α).Nontrivial ↔ s.offDiag.Nonempty := by
-    rw [← Set.offDiag_nonempty, ← Finset.coe_offDiag, Finset.coe_nonempty]
+    if hs : s.offDiagonal.Nonempty then s.offDiagonal.inf' hs (uncurry dist) else 0 := by
+  have H : (s : Set α).Nontrivial ↔ s.offDiagonal.Nonempty := by
+    rw [← Set.offDiagonal_nonempty, ← Finset.coe_offDiagonal, Finset.coe_nonempty]
   split_ifs with hs
-  · classical simp_rw [(H.mpr hs).infsep_of_fintype, ← Finset.coe_offDiag, Finset.toFinset_coe]
+  · classical simp_rw [(H.mpr hs).infsep_of_fintype, ← Finset.coe_offDiagonal, Finset.toFinset_coe]
   · exact (not_nontrivial_iff.mp (H.mp.mt hs)).infsep_zero
 
-theorem _root_.Finset.coe_infsep_of_offDiag_nonempty {s : Finset α}
-    (hs : s.offDiag.Nonempty) : (s : Set α).infsep = s.offDiag.inf' hs (uncurry dist) := by
+theorem _root_.Finset.coe_infsep_of_offDiagonal_nonempty {s : Finset α}
+    (hs : s.offDiagonal.Nonempty) : (s : Set α).infsep = s.offDiagonal.inf' hs (uncurry dist) := by
   rw [Finset.coe_infsep, dite_eq_left hs]
 
-theorem _root_.Finset.coe_infsep_of_offDiag_empty
-    {s : Finset α} (hs : s.offDiag = ∅) : (s : Set α).infsep = 0 := by
+@[deprecated (since := "2026-09-06")]
+alias _root_.Finset.coe_infsep_of_offDiag_nonempty :=
+  _root_.Finset.coe_infsep_of_offDiagonal_nonempty
+
+theorem _root_.Finset.coe_infsep_of_offDiagonal_empty
+    {s : Finset α} (hs : s.offDiagonal = ∅) : (s : Set α).infsep = 0 := by
   rw [← Finset.not_nonempty_iff_eq_empty] at hs
   rw [Finset.coe_infsep, dite_eq_right hs]
+
+@[deprecated (since := "2026-09-06")]
+alias _root_.Finset.coe_infsep_of_offDiag_empty := _root_.Finset.coe_infsep_of_offDiagonal_empty
 
 theorem Nontrivial.infsep_exists_of_finite [Finite s] (hs : s.Nontrivial) :
     ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ s.infsep = dist x y := by
   cases nonempty_fintype s
   simp_rw [hs.infsep_of_fintype]
-  rcases Finset.exists_mem_eq_inf' (s := s.offDiag.toFinset) (by simpa) (uncurry dist) with
+  rcases Finset.exists_mem_eq_inf' (s := s.offDiagonal.toFinset) (by simpa) (uncurry dist) with
     ⟨w, hxy, hed⟩
   simp_rw [mem_toFinset] at hxy
   exact ⟨w.fst, hxy.1, w.snd, hxy.2.1, hxy.2.2, hed⟩

--- a/Mathlib/Topology/UniformSpace/Defs.lean
+++ b/Mathlib/Topology/UniformSpace/Defs.lean
@@ -329,12 +329,14 @@ theorem Filter.Tendsto.uniformity_symm {l : Filter β} {f : β → α × α} (h 
   tendsto_swap_uniformity.comp h
 
 /-- Relation `fun f g ↦ Tendsto (fun x ↦ (f x, g x)) l (𝓤 α)` is reflexive. -/
-theorem tendsto_diag_uniformity (f : β → α) (l : Filter β) :
+theorem tendsto_diagonal_uniformity (f : β → α) (l : Filter β) :
     Tendsto (fun x => (f x, f x)) l (𝓤 α) := fun _s hs =>
   mem_map.2 <| univ_mem' fun _ => refl_mem_uniformity hs
 
+@[deprecated (since := "2026-09-06")] alias tendsto_diag_uniformity := tendsto_diagonal_uniformity
+
 theorem tendsto_const_uniformity {a : α} {f : Filter β} : Tendsto (fun _ => (a, a)) f (𝓤 α) :=
-  tendsto_diag_uniformity (fun _ => a) f
+  tendsto_diagonal_uniformity (fun _ => a) f
 
 theorem symm_of_uniformity {s : SetRel α α} (hs : s ∈ 𝓤 α) :
     ∃ t ∈ 𝓤 α, SetRel.IsSymm t ∧ t ⊆ s :=

--- a/Mathlib/Topology/UniformSpace/UniformConvergence.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergence.lean
@@ -287,19 +287,19 @@ theorem TendstoUniformlyOnFilter.prodMk {ι' β' : Type*} [UniformSpace β'] {F'
     (h' : TendstoUniformlyOnFilter F' f' q p') :
     TendstoUniformlyOnFilter (fun (i : ι × ι') a => (F i.1 a, F' i.2 a)) (fun a => (f a, f' a))
       (p ×ˢ q) p' :=
-  fun u hu => ((h.prodMap h') u hu).diag_of_prod_right
+  fun u hu => ((h.prodMap h') u hu).diagonal_of_prod_right
 
 protected theorem TendstoUniformlyOn.prodMk {ι' β' : Type*} [UniformSpace β'] {F' : ι' → α → β'}
     {f' : α → β'} {p' : Filter ι'} (h : TendstoUniformlyOn F f p s)
     (h' : TendstoUniformlyOn F' f' p' s) :
     TendstoUniformlyOn (fun (i : ι × ι') a => (F i.1 a, F' i.2 a)) (fun a => (f a, f' a)) (p ×ˢ p')
       s :=
-  (congr_arg _ s.inter_self).mp ((h.prodMap h').comp Function.diag)
+  (congr_arg _ s.inter_self).mp ((h.prodMap h').comp Prod.diagonal)
 
 theorem TendstoUniformly.prodMk {ι' β' : Type*} [UniformSpace β'] {F' : ι' → α → β'} {f' : α → β'}
     {p' : Filter ι'} (h : TendstoUniformly F f p) (h' : TendstoUniformly F' f' p') :
     TendstoUniformly (fun (i : ι × ι') a => (F i.1 a, F' i.2 a)) (fun a => (f a, f' a)) (p ×ˢ p') :=
-  (h.prodMap h').comp Function.diag
+  (h.prodMap h').comp Prod.diagonal
 
 /-- Uniform convergence on a filter `p'` to a constant function is equivalent to convergence in
 `p ×ˢ p'`. -/
@@ -360,7 +360,7 @@ theorem UniformContinuousOn.tendstoUniformlyOn [UniformSpace α] [UniformSpace �
     (Tendsto.inf ?_ <| tendsto_principal_principal.2 fun x hx => ⟨⟨hU, hx.2⟩, hx⟩)
   simp only [uniformity_prod_eq_comap_prod, tendsto_comap_iff,
     nhds_eq_comap_uniformity, comap_comap]
-  exact tendsto_comap.prodMk (tendsto_diag_uniformity _ _)
+  exact tendsto_comap.prodMk (tendsto_diagonal_uniformity _ _)
 
 theorem UniformContinuousOn.tendstoUniformly [UniformSpace α] [UniformSpace γ] {U : Set α}
     (hU : U ∈ 𝓝 x) {F : α → β → γ} (hF : UniformContinuousOn ↿F (U ×ˢ (univ : Set β))) :
@@ -454,7 +454,7 @@ theorem TendstoUniformlyOnFilter.uniformCauchySeqOnFilter (hF : TendstoUniformly
   intro u hu
   rcases comp_symm_of_uniformity hu with ⟨t, ht, htsymm, htmem⟩
   have := tendsto_swap4_prod.eventually ((hF t ht).prod_mk (hF t ht))
-  apply this.diag_of_prod_right.mono
+  apply this.diagonal_of_prod_right.mono
   simp only [and_imp, Prod.forall]
   intro n1 n2 x hl hr
   exact htmem <| SetRel.prodMk_mem_comp (htsymm hl) hr
@@ -552,12 +552,12 @@ theorem UniformCauchySeqOn.prodMap {ι' α' β' : Type*} [UniformSpace β'] {F' 
 theorem UniformCauchySeqOn.prod {ι' β' : Type*} [UniformSpace β'] {F' : ι' → α → β'}
     {p' : Filter ι'} (h : UniformCauchySeqOn F p s) (h' : UniformCauchySeqOn F' p' s) :
     UniformCauchySeqOn (fun (i : ι × ι') a => (F i.fst a, F' i.snd a)) (p ×ˢ p') s :=
-  (congr_arg _ s.inter_self).mp ((h.prodMap h').comp Function.diag)
+  (congr_arg _ s.inter_self).mp ((h.prodMap h').comp Prod.diagonal)
 
 theorem UniformCauchySeqOn.prod' {β' : Type*} [UniformSpace β'] {F' : ι → α → β'}
     (h : UniformCauchySeqOn F p s) (h' : UniformCauchySeqOn F' p s) :
     UniformCauchySeqOn (fun (i : ι) a => (F i a, F' i a)) p s := fun u hu =>
-  have hh : Tendsto (fun x : ι => (x, x)) p (p ×ˢ p) := tendsto_diag
+  have hh : Tendsto (fun x : ι => (x, x)) p (p ×ˢ p) := tendsto_diagonal
   (hh.prodMap hh).eventually ((h.prod h') u hu)
 
 /-- If a sequence of functions is uniformly Cauchy on a set, then the values at each point form

--- a/MathlibTest/Tactic/Push/Basic.lean
+++ b/MathlibTest/Tactic/Push/Basic.lean
@@ -136,7 +136,7 @@ example (p : Nat × Nat) (A B : Set Nat) : p ∈ A ×ˢ B := by
   guard_target =ₛ p ∈ A ×ˢ B
   exact test_sorry
 
-example (p : Nat × Nat) (A : Set Nat) : p ∈ Set.diagonal Nat ∪ Set.offDiag A := by
+example (p : Nat × Nat) (A : Set Nat) : p ∈ Set.diagonal Nat ∪ Set.offDiagonal A := by
   push _ ∈ _
   guard_target =ₛ p.1 = p.2 ∨ p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 ≠ p.2
   exact test_sorry

--- a/MathlibTest/antidiagonal.lean
+++ b/MathlibTest/antidiagonal.lean
@@ -33,4 +33,4 @@ info: {fun₀ | "C" => 3,
  fun₀ | "A" => 3}
 -/
 #guard_msgs in
-#eval finsuppAntidiag {"A", "B", "C"} 3
+#eval finsuppAntidiagonal {"A", "B", "C"} 3

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -627,7 +627,7 @@ Q617417:
 
 Q619985:
   title: Multinomial theorem
-  decl: Finset.sum_pow_eq_sum_piAntidiag_of_commute
+  decl: Finset.sum_pow_eq_sum_piAntidiagonal_of_commute
   # TODO: is Finset.sum_pow_of_commute better?
 
 Q620602:

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -262,6 +262,7 @@
  ["defsWithUnderscore", "Submodule.submodule_torsionBy_orderIso"],
  ["defsWithUnderscore", "Sylow.unique_of_normal"],
  ["defsWithUnderscore", "Sym2.decidablePred_mem_diagSet"],
+ ["defsWithUnderscore", "Sym2.decidablePred_mem_diagonalSet"],
  ["defsWithUnderscore", "Topology.Continuous_of"],
  ["defsWithUnderscore", "Topology.IsClosed_of"],
  ["defsWithUnderscore", "Topology.IsOpen_of"],


### PR DESCRIPTION
Per recent discussion on Zulip, we want to move away from using `diag` as a name token. This renames every declaration where `diag` abbreviates *diagonal* to spell it out in full, with a `@[deprecated]` alias for each.

I've tried to split it into reviewable commits by area (`Prod`/`offDiag`, `Sym2`/`Finset.diag`, `antidiag`, `CategoryTheory`, misc, leftovers) plus a small `diagaonal` typo fix. I will try and break it up into discrete sub-PRs if necessary.

Out of scope, handled in follow-ups:
- `Set.diagonal` / `Prod.diagonalSet`- to be handled in #38380
- the `Matrix.diag` / `blockDiag` / `IsDiag` constructor/extractor swap - there's one or two of these where something is being constructed/extracted or where 
- the `diag`-means-*diagram* cases (`(Co)limitPresentation.diag`, `Galois.EssSurj.quotientDiag`, `CommDiag`), which will be renamed to `diagram`

🤖 Generated with [Claude Code](https://claude.com/claude-code)