### PR TITLE
[Merged by Bors] - feat(Algebra/Order/BigOperators/Group/Finset): generalise exists_one_lt_of_prod_one_of_exists_ne_one

### DIFF
--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -675,6 +675,20 @@ theorem exists_lt_of_prod_lt [MulLeftMono M] (Hlt : ∏ i ∈ s, f i < ∏ i ∈
 
 @[deprecated (since := "2026-09-01")] alias exists_lt_of_prod_lt' := exists_lt_of_prod_lt
 
+@[to_additive exists_pos_of_sum_zero_of_exists_nonzero]
+theorem exists_one_lt_of_prod_one_of_exists_ne_one [MulLeftMono M] (f : ι → M)
+    (h₁ : ∏ i ∈ s, f i = 1) (h₂ : ∃ i ∈ s, f i ≠ 1) : ∃ i ∈ s, 1 < f i := by
+  by_contra! h
+  have : ¬ ∃ x ∈ s, f x < 1 := by simp [← prod_lt_one_iff_of_le_one h, h₁]
+  grind
+
+@[to_additive exists_neg_of_sum_zero_of_exists_nonzero]
+theorem exists_lt_one_of_prod_one_of_exists_ne_one [MulLeftMono M] (f : ι → M)
+    (h₁ : ∏ i ∈ s, f i = 1) (h₂ : ∃ i ∈ s, f i ≠ 1) : ∃ i ∈ s, f i < 1 := by
+  by_contra! h
+  have : ¬ ∃ x ∈ s, 1 < f x := by simp [← one_lt_prod_iff_of_one_le h, h₁]
+  grind
+
 variable [IsOrderedCancelMonoid M]
 
 @[to_additive]
@@ -684,16 +698,6 @@ theorem exists_le_of_prod_le (hs : s.Nonempty) (Hle : ∏ i ∈ s, f i ≤ ∏ i
   exact prod_lt_prod_of_nonempty hs Hlt
 
 @[deprecated (since := "2026-09-01")] alias exists_le_of_prod_le' := exists_le_of_prod_le
-
-@[to_additive exists_pos_of_sum_zero_of_exists_nonzero]
-theorem exists_one_lt_of_prod_one_of_exists_ne_one (f : ι → M) (h₁ : ∏ i ∈ s, f i = 1)
-    (h₂ : ∃ i ∈ s, f i ≠ 1) : ∃ i ∈ s, 1 < f i := by
-  contrapose! h₁
-  obtain ⟨i, m, i_ne⟩ : ∃ i ∈ s, f i ≠ 1 := h₂
-  apply ne_of_lt
-  calc
-    ∏ j ∈ s, f j < ∏ j ∈ s, 1 := prod_lt_prod h₁ ⟨i, m, (h₁ i m).lt_of_ne i_ne⟩
-    _ = 1 := prod_const_one
 
 @[deprecated (since := "2026-09-01")]
 alias exists_one_lt_of_prod_one_of_exists_ne_one' := exists_one_lt_of_prod_one_of_exists_ne_one

--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -684,10 +684,8 @@ theorem exists_one_lt_of_prod_one_of_exists_ne_one [MulLeftMono M] (f : ι → M
 
 @[to_additive exists_neg_of_sum_zero_of_exists_nonzero]
 theorem exists_lt_one_of_prod_one_of_exists_ne_one [MulLeftMono M] (f : ι → M)
-    (h₁ : ∏ i ∈ s, f i = 1) (h₂ : ∃ i ∈ s, f i ≠ 1) : ∃ i ∈ s, f i < 1 := by
-  by_contra! h
-  have : ¬ ∃ x ∈ s, 1 < f x := by simp [← one_lt_prod_iff_of_one_le h, h₁]
-  grind
+    (h₁ : ∏ i ∈ s, f i = 1) (h₂ : ∃ i ∈ s, f i ≠ 1) : ∃ i ∈ s, f i < 1 :=
+  exists_one_lt_of_prod_one_of_exists_ne_one (M := Mᵒᵈ) f h₁ h₂
 
 variable [IsOrderedCancelMonoid M]
 


### PR DESCRIPTION
and add its dual. I couldn't get to_dual to generate the dual, I presume because the rest of this file hasn't been to_dual'd yet. It's probably easier to do that in its own PR.

The generalisation here is that it uses weaker typeclass assumptions now - MulLeftMono rather than IsOrderedCancelMonoid, ie it no longer requires cancellativity.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
