### PR TITLE
feat(NumberTheory/LSeries): root numbers and non-vanishing in the left half-plane

### DIFF
--- a/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
@@ -539,6 +539,9 @@ lemma even_or_odd [NoZeroDivisors S] : ψ.Even ∨ ψ.Odd := by
   suffices ψ (-1) ^ 2 = 1 by convert! sq_eq_one_iff.mp this
   rw [← map_pow _, neg_one_sq, map_one]
 
+/-- The trivial Dirichlet character is even. -/
+@[simp] lemma even_one : (1 : DirichletCharacter S m).Even := MulChar.one_apply (by simp)
+
 lemma not_even_and_odd [NeZero (2 : S)] : ¬(ψ.Even ∧ ψ.Odd) := by
   rintro ⟨(h : _ = 1), (h' : _ = -1)⟩
   simp only [h', neg_eq_iff_add_eq_zero, one_add_one_eq_two, two_ne_zero] at h

--- a/Mathlib/NumberTheory/DirichletCharacter/Bounds.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Bounds.lean
@@ -33,6 +33,9 @@ namespace DirichletCharacter
   rw [← norm_pow, ← map_pow, ← Units.val_pow_eq_pow_val, pow_card_eq_one', Units.val_one, map_one,
     norm_one]
 
+/-- The value at `-1` of a Dirichlet character with target a normed field has norm `1`. -/
+@[simp] lemma norm_neg_one : ‖χ (-1)‖ = 1 := by simpa using χ.unit_norm_eq_one (-1)
+
 /-- The values of a Dirichlet character with target a normed field have norm bounded by `1`. -/
 lemma norm_le_one (a : ZMod n) : ‖χ a‖ ≤ 1 := by
   by_cases h : IsUnit a

--- a/Mathlib/NumberTheory/LSeries/Dirichlet.lean
+++ b/Mathlib/NumberTheory/LSeries/Dirichlet.lean
@@ -161,11 +161,14 @@ lemma modZero_eq_delta {χ : DirichletCharacter ℂ 0} : ↗χ = δ := by
   have : ¬ IsUnit (n : ZMod 0) := fun h ↦ hn' <| ZMod.eq_one_of_isUnit_natCast h
   simp_all [χ.map_nonunit this, delta]
 
+/-- A Dirichlet character mod `1` takes the value `1` everywhere. -/
+@[simp] lemma modOne_eq_one' {R : Type*} [CommMonoidWithZero R] {χ : DirichletCharacter R 1}
+    (y : ZMod 1) : χ y = 1 := by
+  rw [χ.level_one, MulChar.one_apply (isUnit_of_subsingleton _)]
+
 /-- The Dirichlet character mod `1` corresponds to the constant function `1`. -/
 lemma modOne_eq_one {R : Type*} [CommMonoidWithZero R] {χ : DirichletCharacter R 1} :
-    ((χ ·) : ℕ → R) = 1 := by
-  ext
-  rw [χ.level_one, MulChar.one_apply (isUnit_of_subsingleton _), Pi.one_apply]
+    ((χ ·) : ℕ → R) = 1 := funext fun _ ↦ modOne_eq_one' _
 
 lemma LSeries_modOne_eq : L ↗χ₁ = L 1 :=
   congr_arg L modOne_eq_one

--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -215,6 +215,14 @@ lemma Odd.gammaFactor_def {χ : DirichletCharacter ℂ N} (hχ : χ.Odd) (s : �
     gammaFactor χ s = Gammaℝ (s + 1) := by
   simp [gammaFactor, hχ.not_even]
 
+lemma gammaFactor_eq_zero_even {χ : DirichletCharacter ℂ N} (hχ : χ.Even) {s : ℂ} :
+    gammaFactor χ s = 0 ↔ ∃ n : ℕ, s = -(2 * n) := by
+  rw [hχ.gammaFactor_def, Gammaℝ_eq_zero_iff]
+
+lemma gammaFactor_eq_zero_odd {χ : DirichletCharacter ℂ N} (hχ : χ.Odd) {s : ℂ} :
+    gammaFactor χ s = 0 ↔ ∃ n : ℕ, s + 1 = -(2 * n) := by
+  rw [hχ.gammaFactor_def, Gammaℝ_eq_zero_iff]
+
 end gammaFactor
 
 /--

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -26,10 +26,9 @@ These results are prerequisites for the **Prime Number Theorem** and
 **Dirichlet's Theorem** on primes in arithmetic progressions.
 
 Using the functional equation, these results are extended to the left half-plane in
-`LFunction_eq_zero_iff_of_re_nonpos` and `riemannZeta_eq_zero_iff_of_re_nonpos`, which describe the
-zeros there in terms of the archimedean Gamma factor (the negative even integers for `ζ`).
-TODO: a parity analysis of L-functions to make the former fully explicit (negative even or odd
-integers according to the parity of `χ`).
+`LFunction_eq_zero_iff_of_re_nonpos` and `riemannZeta_eq_zero_iff_of_re_nonpos`, excluding negative
+integers and negative even integers respectively. TODO: a parity analysis of L-functions to
+refine the former to negative even or odd integers.
 
 As a byproduct of the above analysis, non-vanishing theorems for the root number or Gauss sum
 associated to a Dirichlet L-function are also provided.
@@ -478,10 +477,9 @@ theorem LFunction_eq_zero_iff_of_re_nonpos (hχ : χ.IsPrimitive) {s : ℂ}
   suffices completedLFunction χ s ≠ 0 by grind [LFunction_eq_completed_div_gammaFactor]
   obtain ⟨w, rfl⟩ : ∃ w, s = 1 - w := ⟨1 - s, by ring⟩
   rw [hχ.completedLFunction_one_sub]
-  refine mul_ne_zero (mul_ne_zero ?_ (rootNumber_ne_zero hχ)) ?_
+  apply_rules (transparency := .reducible) [mul_ne_zero, rootNumber_ne_zero]
   · grind [cpow_eq_zero_iff, Nat.cast_eq_zero, NeZero.ne N]
-  · refine completedLFunction_ne_zero_of_one_le_re χ⁻¹ ?_ (by grind [sub_re, one_re])
-    grind [inv_eq_one, sub_ne_zero]
+  · grind [completedLFunction_ne_zero_of_one_le_re, sub_re, one_re, inv_eq_one, sub_ne_zero]
 
 end nonvanishing
 
@@ -495,16 +493,10 @@ theorem riemannZeta_eq_zero_iff_of_re_nonpos {s : ℂ} (hs : s.re ≤ 0) :
     riemannZeta s = 0 ↔ ∃ n : ℕ, s = -2 * (n + 1) := by
   rcases eq_or_ne s 0 with rfl | h0
   · grind [riemannZeta_zero]
-  · have he : (1 : DirichletCharacter ℂ 1).Even := by
-      unfold DirichletCharacter.Even
-      simp [Subsingleton.elim (-1 : ZMod 1) 1, map_one]
-    rw [← LFunction_modOne_eq (χ := 1),
+  · rw [← LFunction_modOne_eq (χ := 1),
       LFunction_eq_zero_iff_of_re_nonpos isPrimitive_one_level_one (.inr h0) hs,
-      gammaFactor_eq_zero_even he]
-    constructor
-    · rintro ⟨n, rfl⟩
-      obtain ⟨m, rfl⟩ : ∃ m : ℕ, n = m + 1 := by cases n with
-        | zero => simp at h0
-        | succ m => exact ⟨m, rfl⟩
-      exact ⟨m, by push_cast; ring⟩
-    · rintro ⟨n, rfl⟩; exact ⟨n + 1, by push_cast; ring⟩
+      gammaFactor_eq_zero_even]
+    · constructor
+      · rintro ⟨n, rfl⟩; exact ⟨n - 1, by simp_all; norm_cast; grind⟩
+      · rintro ⟨n, rfl⟩; exact ⟨n + 1, by norm_cast⟩
+    · simp [DirichletCharacter.Even, Subsingleton.elim (-1 : ZMod 1) 1]

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -26,7 +26,7 @@ These results are prerequisites for the **Prime Number Theorem** and
 **Dirichlet's Theorem** on primes in arithmetic progressions.
 
 Using the functional equation, these results are extended to the left half-plane in
-`LFunction_ne_zero_of_re_nonpos` and `riemannZeta_ne_zero_of_re_nonpos`, excluding negative
+`LFunction_eq_zero_iff_of_re_nonpos` and `riemannZeta_eq_zero_iff_of_re_nonpos`, excluding negative
 integers and negative even integers respectively. TODO: a parity analysis of L-functions to
 refine the former to negative even or odd integers.
 
@@ -468,20 +468,26 @@ theorem norm_gaussSum_stdAddChar (hχ : χ.IsPrimitive) :
   suffices ‖gaussSum χ ZMod.stdAddChar‖ / .sqrt N = ‖rootNumber χ‖ by grind [norm_rootNumber]
   simp [rootNumber, -pow_ite, norm_natCast_cpow_of_pos, NeZero.pos N, Real.sqrt_eq_rpow]
 
+omit [NeZero N] in
+theorem gammaFactor_eq_zero_even (hχ : χ.Even) {s : ℂ} :
+    χ.gammaFactor s = 0 ↔ ∃ n : ℕ, s = -(2 * n) := by
+  rw [hχ.gammaFactor_def, Gammaℝ_eq_zero_iff]
+
+omit [NeZero N] in
+theorem gammaFactor_eq_zero_odd (hχ : χ.Odd) {s : ℂ} :
+    χ.gammaFactor s = 0 ↔ ∃ n : ℕ, s + 1 = -(2 * n) := by
+  rw [hχ.gammaFactor_def, Gammaℝ_eq_zero_iff]
+
 /-- **A primitive Dirichlet `L`-function does not vanish in the closed left half-plane away from
 the non-positive integers.** -/
-theorem LFunction_ne_zero_of_re_nonpos (hχ : χ.IsPrimitive) (hχ1 : χ ≠ 1) {s : ℂ}
-    (hs : s.re ≤ 0) (h : ∀ n : ℕ, s ≠ -n) : LFunction χ s ≠ 0 := by
-  rw [LFunction_eq_completed_div_gammaFactor χ s (by grind [h 0])]
-  apply div_ne_zero
-  · obtain ⟨w, rfl⟩ : ∃ w, s = 1 - w := ⟨1 - s, by ring⟩
-    rw [hχ.completedLFunction_one_sub]
-    refine mul_ne_zero (mul_ne_zero ?_ (rootNumber_ne_zero hχ)) ?_
-    · grind [cpow_eq_zero_iff, Nat.cast_eq_zero, NeZero.ne N]
-    · grind [completedLFunction_ne_zero_of_one_le_re, sub_re, one_re, inv_eq_one]
-  · rcases χ.even_or_odd with heo | heo <;> rw [heo.gammaFactor_def, Ne, Gammaℝ_eq_zero_iff]
-    · rintro ⟨n, _⟩; grind [h (2 * n)]
-    · rintro ⟨n, _⟩; grind [h (2 * n + 1)]
+theorem LFunction_eq_zero_iff_of_re_nonpos (hχ : χ.IsPrimitive) (hχ1 : χ ≠ 1) {s : ℂ} (h0 : s ≠ 0)
+    (hs : s.re ≤ 0) : LFunction χ s = 0 ↔ χ.gammaFactor s = 0 := by
+  suffices completedLFunction χ s ≠ 0 by grind [LFunction_eq_completed_div_gammaFactor]
+  obtain ⟨w, rfl⟩ : ∃ w, s = 1 - w := ⟨1 - s, by ring⟩
+  rw [hχ.completedLFunction_one_sub]
+  refine mul_ne_zero (mul_ne_zero ?_ (rootNumber_ne_zero hχ)) ?_
+  · grind [cpow_eq_zero_iff, Nat.cast_eq_zero, NeZero.ne N]
+  · grind [completedLFunction_ne_zero_of_one_le_re, sub_re, one_re, inv_eq_one]
 
 end nonvanishing
 

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -466,20 +466,23 @@ theorem norm_rootNumber (hχ : χ.IsPrimitive) : ‖rootNumber χ‖ = 1 := by
 theorem norm_gaussSum_stdAddChar (hχ : χ.IsPrimitive) :
     ‖gaussSum χ ZMod.stdAddChar‖ = .sqrt N := by
   suffices ‖gaussSum χ ZMod.stdAddChar‖ / .sqrt N = ‖rootNumber χ‖ by grind [norm_rootNumber]
-  simp [rootNumber, -pow_ite, norm_natCast_cpow_of_pos, NeZero.pos N, Real.sqrt_eq_rpow]
+  simp [rootNumber, -pow_ite, norm_natCast_cpow_of_pos, NeZero.pos, Real.sqrt_eq_rpow]
 
 /-- **The zeros of a primitive Dirichlet `L`-function in the closed left half-plane are exactly
 those of its archimedean Gamma factor**, with the sole exception of `s = 0` for the trivial
 character (where `gammaFactor` vanishes but `L` does not). -/
-theorem LFunction_eq_zero_iff_of_re_nonpos (hχ : χ.IsPrimitive) {s : ℂ}
-    (hχs : χ ≠ 1 ∨ s ≠ 0) (hs : s.re ≤ 0) : LFunction χ s = 0 ↔ χ.gammaFactor s = 0 := by
-  have hN : s ≠ 0 ∨ N ≠ 1 := hχs.symm.imp_right fun h hN ↦ h (level_one' χ hN)
-  suffices completedLFunction χ s ≠ 0 by grind [LFunction_eq_completed_div_gammaFactor]
-  obtain ⟨w, rfl⟩ : ∃ w, s = 1 - w := ⟨1 - s, by ring⟩
+theorem LFunction_eq_zero_iff_of_re_nonpos (hχ : χ.IsPrimitive) {s : ℂ} (hs : s.re ≤ 0) :
+    LFunction χ s = 0 ↔ χ.gammaFactor s = 0 ∧ (N ≠ 1 ∨ s ≠ 0):= by
+  have := NeZero.ne N
+  by_cases hχs : χ = 1 ∧ s = 0
+  · rw [hχs.1, hχs.2, ← changeLevel_one (d := 1), LFunction_changeLevel, gammaFactor_eq_zero_even]
+    <;> simp [LFunction_modOne_eq, riemannZeta_zero, this]
+  have : s ≠ 0 ∨ N ≠ 1 := by contrapose! hχs; simp_all [level_one']
+  suffices completedLFunction χ (1 - (1 - s)) ≠ 0 by grind [LFunction_eq_completed_div_gammaFactor]
   rw [hχ.completedLFunction_one_sub]
-  apply_rules (transparency := .reducible) [mul_ne_zero, rootNumber_ne_zero]
-  · grind [cpow_eq_zero_iff, Nat.cast_eq_zero, NeZero.ne N]
-  · grind [completedLFunction_ne_zero_of_one_le_re, sub_re, one_re, inv_eq_one, sub_ne_zero]
+  apply_rules (transparency := .reducible) [mul_ne_zero, rootNumber_ne_zero,
+    completedLFunction_ne_zero_of_one_le_re]
+  <;> grind [cpow_eq_zero_iff, Nat.cast_eq_zero, sub_re, one_re, inv_eq_one, sub_ne_zero]
 
 end nonvanishing
 
@@ -491,12 +494,8 @@ negative even integers. This is the special case of `LFunction_eq_zero_iff_of_re
 trivial character modulo `1`, whose Gamma factor is `Gammaℝ`. -/
 theorem riemannZeta_eq_zero_iff_of_re_nonpos {s : ℂ} (hs : s.re ≤ 0) :
     riemannZeta s = 0 ↔ ∃ n : ℕ, s = -2 * (n + 1) := by
-  rcases eq_or_ne s 0 with rfl | h0
-  · grind [riemannZeta_zero]
-  · rw [← LFunction_modOne_eq (χ := 1),
-      LFunction_eq_zero_iff_of_re_nonpos isPrimitive_one_level_one (.inr h0) hs,
-      gammaFactor_eq_zero_even]
-    · constructor
-      · rintro ⟨n, rfl⟩; exact ⟨n - 1, by simp_all; norm_cast; grind⟩
-      · rintro ⟨n, rfl⟩; exact ⟨n + 1, by norm_cast⟩
-    · simp [DirichletCharacter.Even, Subsingleton.elim (-1 : ZMod 1) 1]
+  rw [← LFunction_modOne_eq (χ := 1), LFunction_eq_zero_iff_of_re_nonpos
+    isPrimitive_one_level_one hs, gammaFactor_eq_zero_even (by simp)]
+  constructor
+  · rintro ⟨⟨n, rfl⟩, _⟩; exact ⟨n - 1, by simp_all; norm_cast; grind⟩
+  · rintro ⟨n, rfl⟩; exact ⟨⟨n + 1, by norm_cast⟩, by grind⟩

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -27,7 +27,7 @@ These results are prerequisites for the **Prime Number Theorem** and
 
 Using the functional equation, these results are extended to the left half-plane in
 `LFunction_eq_zero_iff_of_re_nonpos` and `riemannZeta_eq_zero_iff_of_re_nonpos`, excluding negative
-integers and negative even integers respectively. 
+integers and negative even integers respectively.
 
 As a byproduct of the above analysis, non-vanishing theorems for the root number or Gauss sum
 associated to a Dirichlet L-function are also provided.

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -456,8 +456,6 @@ theorem norm_rootNumber (hχ : χ.IsPrimitive) : ‖rootNumber χ‖ = 1 := by
   have : ‖gaussSum χ ZMod.stdAddChar‖ = ‖gaussSum χ⁻¹ ZMod.stdAddChar‖ := by
     rw [← norm_star, star_gaussSum_eq, AddChar.inv_mulShift,
       (by simp : (-1 : ZMod N) = ((-1 : (ZMod N)ˣ) : ZMod N)), gaussSum_mulShift_eq]
-    have : ‖χ (-1)‖ ^ 2 = 1 := by norm_num [← norm_pow, ← map_pow]
-    have : ‖χ (-1)‖ = 1 := by nlinarith [norm_nonneg (χ (-1))]
     simp_all
   have : ‖rootNumber χ‖ = ‖rootNumber χ⁻¹‖ := by simp [rootNumber, -pow_ite, this]
   have : ‖rootNumber χ‖ * ‖rootNumber χ⁻¹‖ = 1 := by simp [← norm_mul,

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -27,8 +27,7 @@ These results are prerequisites for the **Prime Number Theorem** and
 
 Using the functional equation, these results are extended to the left half-plane in
 `LFunction_eq_zero_iff_of_re_nonpos` and `riemannZeta_eq_zero_iff_of_re_nonpos`, excluding negative
-integers and negative even integers respectively. TODO: a parity analysis of L-functions to
-refine the former to negative even or odd integers.
+integers and negative even integers respectively. 
 
 As a byproduct of the above analysis, non-vanishing theorems for the root number or Gauss sum
 associated to a Dirichlet L-function are also provided.
@@ -470,7 +469,7 @@ theorem norm_gaussSum_stdAddChar (hχ : χ.IsPrimitive) :
 
 /-- **The zeros of a primitive Dirichlet `L`-function in the closed left half-plane are exactly
 those of its archimedean Gamma factor**, with the sole exception of `s = 0` for the trivial
-character (where `gammaFactor` vanishes but `L` does not). -/
+character. -/
 theorem LFunction_eq_zero_iff_of_re_nonpos (hχ : χ.IsPrimitive) {s : ℂ} (hs : s.re ≤ 0) :
     LFunction χ s = 0 ↔ χ.gammaFactor s = 0 ∧ (N ≠ 1 ∨ s ≠ 0):= by
   have := NeZero.ne N
@@ -484,9 +483,7 @@ theorem LFunction_eq_zero_iff_of_re_nonpos (hχ : χ.IsPrimitive) {s : ℂ} (hs 
     completedLFunction_ne_zero_of_one_le_re]
   <;> grind [cpow_eq_zero_iff, Nat.cast_eq_zero, sub_re, one_re, inv_eq_one, sub_ne_zero]
 
-/-- **The zeros of `ζ` in the closed left half-plane are exactly the trivial ones**, i.e. the
-negative even integers. This is the special case of `LFunction_eq_zero_iff_of_re_nonpos` for the
-trivial character modulo `1`, whose Gamma factor is `Gammaℝ`. -/
+/-- **The zeros of `ζ` in the closed left half-plane are exactly the trivial ones**. -/
 theorem _root_.riemannZeta_eq_zero_iff_of_re_nonpos {s : ℂ} (hs : s.re ≤ 0) :
     riemannZeta s = 0 ↔ ∃ n : ℕ, s = -2 * (n + 1) := by
   rw [← LFunction_modOne_eq (χ := 1), LFunction_eq_zero_iff_of_re_nonpos

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Michael Stoll, David Loeffler
+Authors: Michael Stoll, David Loeffler, Terence Tao
 -/
 module
 
@@ -24,6 +24,14 @@ happens to be non-zero).
 
 These results are prerequisites for the **Prime Number Theorem** and
 **Dirichlet's Theorem** on primes in arithmetic progressions.
+
+Using the functional equation, these results are extended to the left half-plane in
+`LFunction_ne_zero_of_re_nonpos` and `riemannZeta_ne_zero_of_re_nonpos`, excluding negative
+integers and negative even integers respectively. TODO: a parity analysis of L-functions to
+refine the former to negative even or odd integers.
+
+As a byproduct of the above analysis, non-vanishing theorems for the root number or Gauss sum
+associated to a Dirichlet L-function are also provided.
 
 ## Outline of proofs
 
@@ -416,6 +424,94 @@ lemma _root_.riemannZeta_ne_zero_of_one_le_re ⦃s : ℂ⦄ (hs : 1 ≤ s.re) :
   · exact riemannZeta_one_ne_zero
   · exact LFunction_modOne_eq (χ := 1) ▸ LFunction_ne_zero_of_one_le_re _ (.inr hs₀) hs
 
+/-- The completed `L`-function of a Dirichlet character does not vanish for `1 ≤ re s`,
+except when `χ` is trivial and `s = 1`. -/
+theorem completedLFunction_ne_zero_of_one_le_re ⦃s : ℂ⦄ (hχs : χ ≠ 1 ∨ s ≠ 1)
+    (hs : 1 ≤ s.re) : completedLFunction χ s ≠ 0 :=
+  fun _ ↦ LFunction_ne_zero_of_one_le_re χ hχs hs (by grind [zero_re,
+    LFunction_eq_completed_div_gammaFactor])
+
+variable {χ}
+
+/-- The root numbers of a primitive Dirichlet character and of its inverse multiply to `1`.
+-/
+theorem rootNumber_mul_rootNumber_inv (hχ : χ.IsPrimitive) :
+    rootNumber χ * rootNumber χ⁻¹ = 1 := by
+  have : completedLFunction χ 2 ≠ 0 :=
+    completedLFunction_ne_zero_of_one_le_re χ (by grind) (by simp)
+  have : completedLFunction χ 2
+      = (N : ℂ) ^ (-(3 / 2 : ℂ)) * rootNumber χ * completedLFunction χ⁻¹ (-1) := by
+    convert hχ.completedLFunction_one_sub (-1) <;> norm_num
+  have : completedLFunction χ⁻¹ (-1)
+      = (N : ℂ) ^ (3 / 2 : ℂ) * rootNumber χ⁻¹ * completedLFunction χ 2 := by
+    have : χ⁻¹.IsPrimitive := by grind [isPrimitive_def, conductor_inv]
+    convert this.completedLFunction_one_sub 2 <;> norm_num
+  grind [cpow_neg]
+
+theorem rootNumber_ne_zero (hχ : χ.IsPrimitive) : rootNumber χ ≠ 0 := by
+  grind [rootNumber_mul_rootNumber_inv]
+
+/-- **The root number of a primitive Dirichlet character has absolute value one.** -/
+theorem norm_rootNumber (hχ : χ.IsPrimitive) : ‖rootNumber χ‖ = 1 := by
+  have : ‖gaussSum χ ZMod.stdAddChar‖ = ‖gaussSum χ⁻¹ ZMod.stdAddChar‖ := by
+    rw [← norm_star, star_gaussSum_eq, AddChar.inv_mulShift,
+      (by simp : (-1 : ZMod N) = ((-1 : (ZMod N)ˣ) : ZMod N)), gaussSum_mulShift_eq]
+    have : ‖χ (-1)‖ ^ 2 = 1 := by norm_num [← norm_pow, ← map_pow]
+    have : ‖χ (-1)‖ = 1 := by nlinarith [norm_nonneg (χ (-1))]
+    simp_all
+  have : ‖rootNumber χ‖ = ‖rootNumber χ⁻¹‖ := by simp [rootNumber, -pow_ite, this]
+  have : ‖rootNumber χ‖ * ‖rootNumber χ⁻¹‖ = 1 := by simp [← norm_mul,
+    rootNumber_mul_rootNumber_inv hχ]
+  nlinarith [norm_nonneg (rootNumber χ)]
+
+/-- **The Gauss sum of a primitive Dirichlet character has absolute value `√N`.** -/
+theorem norm_gaussSum_stdAddChar (hχ : χ.IsPrimitive) :
+    ‖gaussSum χ ZMod.stdAddChar‖ = .sqrt N := by
+  suffices ‖gaussSum χ ZMod.stdAddChar‖ / .sqrt N = ‖rootNumber χ‖ by grind [norm_rootNumber]
+  simp [rootNumber, -pow_ite, norm_natCast_cpow_of_pos, NeZero.pos N, Real.sqrt_eq_rpow]
+
+/-- **A primitive Dirichlet `L`-function does not vanish in the closed left half-plane away from
+the non-positive integers.** -/
+theorem LFunction_ne_zero_of_re_nonpos (hχ : χ.IsPrimitive) (hχ1 : χ ≠ 1) {s : ℂ}
+    (hs : s.re ≤ 0) (h : ∀ n : ℕ, s ≠ -n) : LFunction χ s ≠ 0 := by
+  rw [LFunction_eq_completed_div_gammaFactor χ s (by grind [h 0])]
+  apply div_ne_zero
+  · obtain ⟨w, rfl⟩ : ∃ w, s = 1 - w := ⟨1 - s, by ring⟩
+    rw [hχ.completedLFunction_one_sub]
+    refine mul_ne_zero (mul_ne_zero ?_ (rootNumber_ne_zero hχ)) ?_
+    · grind [cpow_eq_zero_iff, Nat.cast_eq_zero, NeZero.ne N]
+    · grind [completedLFunction_ne_zero_of_one_le_re, sub_re, one_re, inv_eq_one]
+  · rcases χ.even_or_odd with heo | heo <;> rw [heo.gammaFactor_def, Ne, Gammaℝ_eq_zero_iff]
+    · rintro ⟨n, _⟩; grind [h (2 * n)]
+    · rintro ⟨n, _⟩; grind [h (2 * n + 1)]
+
 end nonvanishing
 
 end DirichletCharacter
+
+/-- `ζ` has no non-trivial zeros in the closed left half-plane. -/
+theorem riemannZeta_ne_zero_of_re_nonpos {s : ℂ} (hs : s.re ≤ 0)
+    (h : ∀ n : ℕ, s ≠ -2 * (n + 1)) : riemannZeta s ≠ 0 := by
+  rcases eq_or_ne s 0 with rfl | hs0
+  · norm_num [riemannZeta_zero]
+  obtain ⟨w, rfl⟩ : ∃ w : ℂ, s = 1 - w := ⟨1 - s, by ring⟩
+  have : 1 ≤ w.re := by grind [sub_re, one_re]
+  have : (Real.pi : ℂ) ≠ 0 := mod_cast Real.pi_ne_zero
+  have (n : ℕ) : w ≠ -n := by grind [neg_re, natCast_re]
+  have : cos (Real.pi * w / 2) ≠ 0 := by
+    rw [Ne, cos_eq_zero_iff]
+    rintro ⟨k, _⟩
+    have : w = 2 * (k : ℂ) + 1 := by grind
+    rcases lt_trichotomy k 0 with _ | rfl | _
+    · simp_all; grind
+    · grind
+    · obtain ⟨m, rfl⟩ : ∃ m : ℕ, k = (m : ℤ) + 1 := ⟨(k - 1).toNat, by omega⟩
+      exact h m (by simp_all)
+  rw [riemannZeta_one_sub ‹_› (by grind)]
+  apply_rules [mul_ne_zero, two_ne_zero, Gamma_ne_zero, riemannZeta_ne_zero_of_one_le_re]
+  grind [cpow_eq_zero_iff]
+
+/-- **The zeros of `ζ` in the closed left half-plane are exactly the trivial ones.** -/
+theorem riemannZeta_eq_zero_iff_of_re_nonpos {s : ℂ} (hs : s.re ≤ 0) :
+    riemannZeta s = 0 ↔ ∃ n : ℕ, s = -2 * (n + 1) := by
+  grind [riemannZeta_ne_zero_of_re_nonpos, riemannZeta_neg_two_mul_nat_add_one]

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -26,9 +26,10 @@ These results are prerequisites for the **Prime Number Theorem** and
 **Dirichlet's Theorem** on primes in arithmetic progressions.
 
 Using the functional equation, these results are extended to the left half-plane in
-`LFunction_eq_zero_iff_of_re_nonpos` and `riemannZeta_eq_zero_iff_of_re_nonpos`, excluding negative
-integers and negative even integers respectively. TODO: a parity analysis of L-functions to
-refine the former to negative even or odd integers.
+`LFunction_eq_zero_iff_of_re_nonpos` and `riemannZeta_eq_zero_iff_of_re_nonpos`, which describe the
+zeros there in terms of the archimedean Gamma factor (the negative even integers for `ζ`).
+TODO: a parity analysis of L-functions to make the former fully explicit (negative even or odd
+integers according to the parity of `χ`).
 
 As a byproduct of the above analysis, non-vanishing theorems for the root number or Gauss sum
 associated to a Dirichlet L-function are also provided.
@@ -468,54 +469,42 @@ theorem norm_gaussSum_stdAddChar (hχ : χ.IsPrimitive) :
   suffices ‖gaussSum χ ZMod.stdAddChar‖ / .sqrt N = ‖rootNumber χ‖ by grind [norm_rootNumber]
   simp [rootNumber, -pow_ite, norm_natCast_cpow_of_pos, NeZero.pos N, Real.sqrt_eq_rpow]
 
-omit [NeZero N] in
-theorem gammaFactor_eq_zero_even (hχ : χ.Even) {s : ℂ} :
-    χ.gammaFactor s = 0 ↔ ∃ n : ℕ, s = -(2 * n) := by
-  rw [hχ.gammaFactor_def, Gammaℝ_eq_zero_iff]
-
-omit [NeZero N] in
-theorem gammaFactor_eq_zero_odd (hχ : χ.Odd) {s : ℂ} :
-    χ.gammaFactor s = 0 ↔ ∃ n : ℕ, s + 1 = -(2 * n) := by
-  rw [hχ.gammaFactor_def, Gammaℝ_eq_zero_iff]
-
-/-- **A primitive Dirichlet `L`-function does not vanish in the closed left half-plane away from
-the non-positive integers.** -/
-theorem LFunction_eq_zero_iff_of_re_nonpos (hχ : χ.IsPrimitive) (hχ1 : χ ≠ 1) {s : ℂ} (h0 : s ≠ 0)
-    (hs : s.re ≤ 0) : LFunction χ s = 0 ↔ χ.gammaFactor s = 0 := by
+/-- **The zeros of a primitive Dirichlet `L`-function in the closed left half-plane are exactly
+those of its archimedean Gamma factor**, with the sole exception of `s = 0` for the trivial
+character (where `gammaFactor` vanishes but `L` does not). -/
+theorem LFunction_eq_zero_iff_of_re_nonpos (hχ : χ.IsPrimitive) {s : ℂ}
+    (hχs : χ ≠ 1 ∨ s ≠ 0) (hs : s.re ≤ 0) : LFunction χ s = 0 ↔ χ.gammaFactor s = 0 := by
+  have hN : s ≠ 0 ∨ N ≠ 1 := hχs.symm.imp_right fun h hN ↦ h (level_one' χ hN)
   suffices completedLFunction χ s ≠ 0 by grind [LFunction_eq_completed_div_gammaFactor]
   obtain ⟨w, rfl⟩ : ∃ w, s = 1 - w := ⟨1 - s, by ring⟩
   rw [hχ.completedLFunction_one_sub]
   refine mul_ne_zero (mul_ne_zero ?_ (rootNumber_ne_zero hχ)) ?_
   · grind [cpow_eq_zero_iff, Nat.cast_eq_zero, NeZero.ne N]
-  · grind [completedLFunction_ne_zero_of_one_le_re, sub_re, one_re, inv_eq_one]
+  · refine completedLFunction_ne_zero_of_one_le_re χ⁻¹ ?_ (by grind [sub_re, one_re])
+    grind [inv_eq_one, sub_ne_zero]
 
 end nonvanishing
 
 end DirichletCharacter
 
-/-- `ζ` has no non-trivial zeros in the closed left half-plane. -/
-theorem riemannZeta_ne_zero_of_re_nonpos {s : ℂ} (hs : s.re ≤ 0)
-    (h : ∀ n : ℕ, s ≠ -2 * (n + 1)) : riemannZeta s ≠ 0 := by
-  rcases eq_or_ne s 0 with rfl | hs0
-  · norm_num [riemannZeta_zero]
-  obtain ⟨w, rfl⟩ : ∃ w : ℂ, s = 1 - w := ⟨1 - s, by ring⟩
-  have : 1 ≤ w.re := by grind [sub_re, one_re]
-  have : (Real.pi : ℂ) ≠ 0 := mod_cast Real.pi_ne_zero
-  have (n : ℕ) : w ≠ -n := by grind [neg_re, natCast_re]
-  have : cos (Real.pi * w / 2) ≠ 0 := by
-    rw [Ne, cos_eq_zero_iff]
-    rintro ⟨k, _⟩
-    have : w = 2 * (k : ℂ) + 1 := by grind
-    rcases lt_trichotomy k 0 with _ | rfl | _
-    · simp_all; grind
-    · grind
-    · obtain ⟨m, rfl⟩ : ∃ m : ℕ, k = (m : ℤ) + 1 := ⟨(k - 1).toNat, by omega⟩
-      exact h m (by simp_all)
-  rw [riemannZeta_one_sub ‹_› (by grind)]
-  apply_rules [mul_ne_zero, two_ne_zero, Gamma_ne_zero, riemannZeta_ne_zero_of_one_le_re]
-  grind [cpow_eq_zero_iff]
-
-/-- **The zeros of `ζ` in the closed left half-plane are exactly the trivial ones.** -/
+open DirichletCharacter in
+/-- **The zeros of `ζ` in the closed left half-plane are exactly the trivial ones**, i.e. the
+negative even integers. This is the special case of `LFunction_eq_zero_iff_of_re_nonpos` for the
+trivial character modulo `1`, whose Gamma factor is `Gammaℝ`. -/
 theorem riemannZeta_eq_zero_iff_of_re_nonpos {s : ℂ} (hs : s.re ≤ 0) :
     riemannZeta s = 0 ↔ ∃ n : ℕ, s = -2 * (n + 1) := by
-  grind [riemannZeta_ne_zero_of_re_nonpos, riemannZeta_neg_two_mul_nat_add_one]
+  rcases eq_or_ne s 0 with rfl | h0
+  · grind [riemannZeta_zero]
+  · have he : (1 : DirichletCharacter ℂ 1).Even := by
+      unfold DirichletCharacter.Even
+      simp [Subsingleton.elim (-1 : ZMod 1) 1, map_one]
+    rw [← LFunction_modOne_eq (χ := 1),
+      LFunction_eq_zero_iff_of_re_nonpos isPrimitive_one_level_one (.inr h0) hs,
+      gammaFactor_eq_zero_even he]
+    constructor
+    · rintro ⟨n, rfl⟩
+      obtain ⟨m, rfl⟩ : ∃ m : ℕ, n = m + 1 := by cases n with
+        | zero => simp at h0
+        | succ m => exact ⟨m, rfl⟩
+      exact ⟨m, by push_cast; ring⟩
+    · rintro ⟨n, rfl⟩; exact ⟨n + 1, by push_cast; ring⟩

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -484,18 +484,17 @@ theorem LFunction_eq_zero_iff_of_re_nonpos (hχ : χ.IsPrimitive) {s : ℂ} (hs 
     completedLFunction_ne_zero_of_one_le_re]
   <;> grind [cpow_eq_zero_iff, Nat.cast_eq_zero, sub_re, one_re, inv_eq_one, sub_ne_zero]
 
-end nonvanishing
-
-end DirichletCharacter
-
-open DirichletCharacter in
 /-- **The zeros of `ζ` in the closed left half-plane are exactly the trivial ones**, i.e. the
 negative even integers. This is the special case of `LFunction_eq_zero_iff_of_re_nonpos` for the
 trivial character modulo `1`, whose Gamma factor is `Gammaℝ`. -/
-theorem riemannZeta_eq_zero_iff_of_re_nonpos {s : ℂ} (hs : s.re ≤ 0) :
+theorem _root_.riemannZeta_eq_zero_iff_of_re_nonpos {s : ℂ} (hs : s.re ≤ 0) :
     riemannZeta s = 0 ↔ ∃ n : ℕ, s = -2 * (n + 1) := by
   rw [← LFunction_modOne_eq (χ := 1), LFunction_eq_zero_iff_of_re_nonpos
     isPrimitive_one_level_one hs, gammaFactor_eq_zero_even (by simp)]
   constructor
   · rintro ⟨⟨n, rfl⟩, _⟩; exact ⟨n - 1, by simp_all; norm_cast; grind⟩
   · rintro ⟨n, rfl⟩; exact ⟨⟨n + 1, by norm_cast⟩, by grind⟩
+
+end nonvanishing
+
+end DirichletCharacter


### PR DESCRIPTION
`Mathlib/NumberTheory/LSeries/Nonvanishing.lean` currently establishes nonvanishing of Dirichlet
`L`-functions and the Riemann zeta function are non-zero to the **right** of the critical strip
(`re s ≥ 1`). This PR adds the counterparts on the **left** (`re s ≤ 0`), which follow from the
functional equation, together with some auxiliary facts about root-numbers and Gauss-sums which 
could be independently useful.

---

## Root numbers and Gauss sums

* `DirichletCharacter.completedLFunction_ne_zero_of_one_le_re`: the completed `L`-function
  `Λ(χ, s)` is non-zero for `1 ≤ re s` (except for the trivial character at `s = 1`).
* `DirichletCharacter.rootNumber_mul_rootNumber_inv`: for a primitive character,
  `rootNumber χ * rootNumber χ⁻¹ = 1`, obtained formally from the functional equation applied to
  both `χ` and `χ⁻¹`.
* `DirichletCharacter.norm_rootNumber`: `‖rootNumber χ‖ = 1` for primitive `χ`.
* `DirichletCharacter.norm_gaussSum_stdAddChar`: `‖gaussSum χ stdAddChar‖ = √N` for primitive `χ`
  — the classical evaluation `|τ(χ)| = √N`, here derived from the functional equation rather than
  the usual finite-field argument, so it holds for every modulus (Mathlib previously only had
  Gauss-sum non-vanishing over finite fields).

## Non-vanishing in the left half-plane

* `DirichletCharacter.LFunction_eq_zero_iff_of_re_nonpos`: for a primitive character and `re s ≤ 0` with `χ ≠ 1`  or `s` non-zero, the L-function vanishes precisely when the gamma factor vanishes.
* `riemannZeta_eq_zero_iff_of_re_nonpos`: for `re s ≤ 0`, `ζ s = 0` iff `s` is a
  negative even integer.

The code here was initially LLM-generated, but then heavily golfed and reviewed by the author.