### PR TITLE
chore: weaken unused typeclass assumptions on section variables

### DIFF
--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -448,7 +448,7 @@ section Ring
 namespace Algebra
 
 variable [CommSemiring R] [Semiring A] [IsDomain A] [Semiring B] [Algebra R A] [Algebra R B]
-variable [AddCommGroup M] [Module R M] [Module A M] [Module B M]
+variable [AddCommMonoid M] [Module R M] [Module A M] [Module B M]
 variable [IsScalarTower R A M] [IsScalarTower R B M] [SMulCommClass A B M]
 
 theorem lsmul_injective [Module.IsTorsionFree A M] {x : A} (hx : x ≠ 0) :

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRingsExact.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRingsExact.lean
@@ -25,7 +25,7 @@ public section
 
 universe v u u'
 
-variable {R : Type u} [CommRing R] {R' : Type u'} [CommRing R']
+variable {R : Type u} [Ring R] {R' : Type u'} [CommRing R']
 
 open CategoryTheory
 

--- a/Mathlib/Algebra/CharP/Algebra.lean
+++ b/Mathlib/Algebra/CharP/Algebra.lean
@@ -174,7 +174,7 @@ lemma RingHom.charP_iff_charP {K L : Type*} [DivisionRing K] [NonAssocSemiring L
 
 section
 
-variable (K L : Type*) [Field K] [CommSemiring L] [Nontrivial L] [Algebra K L]
+variable (K L : Type*) [Field K] [Semiring L] [Nontrivial L] [Algebra K L]
 
 protected theorem Algebra.charP_iff (p : ℕ) : CharP K p ↔ CharP L p :=
   (algebraMap K L).charP_iff_charP p

--- a/Mathlib/Algebra/Group/Submonoid/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Pointwise.lean
@@ -289,7 +289,7 @@ end Submonoid
 
 namespace Set.IsPWO
 
-variable [CommMonoid α] [PartialOrder α] [IsOrderedCancelMonoid α] {s : Set α}
+variable [CommMonoid α] [Preorder α] [IsOrderedCancelMonoid α] {s : Set α}
 
 @[to_additive]
 theorem submonoid_closure (hpos : ∀ x : α, x ∈ s → 1 ≤ x) (h : s.IsPWO) :

--- a/Mathlib/Algebra/Order/Archimedean/Defs.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Defs.lean
@@ -53,7 +53,7 @@ theorem exists_lt_pow {a : R} (ha : 1 < a) (b : R) : ∃ n : ℕ, b < a ^ n :=
 end OrderedMonoid
 
 section OrderedGroup
-variable [CommGroup R] [LinearOrder R] [IsOrderedMonoid R] [MulArchimedean R]
+variable [CommGroup R] [PartialOrder R] [IsOrderedMonoid R] [MulArchimedean R]
 
 @[to_additive]
 theorem exists_pow_lt {a : R} (ha : a < 1) (b : R) : ∃ n : ℕ, a ^ n < b :=

--- a/Mathlib/Algebra/Order/CauSeq/Basic.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Basic.lean
@@ -503,7 +503,7 @@ end Ring
 
 section IsDomain
 
-variable [Ring β] [IsDomain β] (abv : β → α) [IsAbsoluteValue abv]
+variable [Ring β] [Nontrivial β] (abv : β → α) [IsAbsoluteValue abv]
 
 theorem one_not_equiv_zero : ¬const abv 1 ≈ const abv 0 := fun h =>
   have : ∀ ε > 0, ∃ i, ∀ k, i ≤ k → abv (1 - 0) < ε := h

--- a/Mathlib/Algebra/Order/Group/Indicator.lean
+++ b/Mathlib/Algebra/Order/Group/Indicator.lean
@@ -204,7 +204,7 @@ end CompleteLattice
 
 section CanonicallyOrderedMul
 
-variable [Monoid M] [PartialOrder M] [CanonicallyOrderedMul M]
+variable [MulOneClass M] [PartialOrder M] [CanonicallyOrderedMul M]
 
 @[to_additive]
 lemma mulIndicator_le_self (s : Set α) (f : α → M) : mulIndicator s f ≤ f :=

--- a/Mathlib/Algebra/Order/Sub/Unbundled/Hom.lean
+++ b/Mathlib/Algebra/Order/Sub/Unbundled/Hom.lean
@@ -60,7 +60,7 @@ theorem OrderIso.map_tsub {M N : Type*} [Preorder M] [Add M] [Sub M] [OrderedSub
 section Preorder
 
 variable [Preorder α]
-variable [AddCommMonoid α] [Sub α] [OrderedSub α]
+variable [AddMonoid α] [Sub α] [OrderedSub α]
 
 theorem AddMonoidHom.le_map_tsub [Preorder β] [AddZeroClass β] [Sub β] [OrderedSub β] (f : α →+ β)
     (hf : Monotone f) (a b : α) : f a - f b ≤ f (a - b) :=

--- a/Mathlib/Algebra/Order/WithTop/Untop0.lean
+++ b/Mathlib/Algebra/Order/WithTop/Untop0.lean
@@ -92,7 +92,7 @@ lemma untop₀_mul [DecidableEq α] [MulZeroClass α] (a b : WithTop α) :
 
 section OrderedAddCommGroup
 
-variable [AddCommGroup α] [PartialOrder α] {a b : WithTop α}
+variable [AddCommMonoid α] [PartialOrder α] {a b : WithTop α}
 
 /--
 Elements of ordered additive commutative groups are nonnegative iff their untop₀ is nonnegative.
@@ -126,7 +126,7 @@ end OrderedAddCommGroup
 
 section LinearOrderedAddCommGroup
 
-variable [AddCommGroup α] [LinearOrder α] {a b : WithTop α}
+variable [AddCommMonoid α] [LinearOrder α] {a b : WithTop α}
 
 @[simp] theorem untop₀_max (ha : a ≠ ⊤) (hb : b ≠ ⊤) :
     (max a b).untop₀ = max a.untop₀ b.untop₀ := by

--- a/Mathlib/Algebra/Regular/SMul.lean
+++ b/Mathlib/Algebra/Regular/SMul.lean
@@ -211,7 +211,7 @@ end MonoidWithZero
 
 section CommSemigroup
 
-variable [CommSemigroup R] [SMul R M] [IsScalarTower R R M]
+variable [CommMagma R] [SMul R M] [IsScalarTower R R M]
 
 /-- A product is `M`-regular if and only if the factors are. -/
 theorem mul_iff : IsSMulRegular M (a * b) ↔ IsSMulRegular M a ∧ IsSMulRegular M b := by

--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -268,7 +268,7 @@ end Semiring
 
 section CommSemigroup
 
-variable [CommSemigroup R] [StarMul R]
+variable [CommMagma R] [StarMul R]
 
 theorem mul {x y : R} (hx : IsSelfAdjoint x) (hy : IsSelfAdjoint y) : IsSelfAdjoint (x * y) := by
   simp only [isSelfAdjoint_iff, star_mul', hx.star_eq, hy.star_eq]

--- a/Mathlib/Analysis/Convex/Cone/TensorProduct.lean
+++ b/Mathlib/Analysis/Convex/Cone/TensorProduct.lean
@@ -57,7 +57,7 @@ namespace PointedCone
 section BasisCoordDual
 
 variable {R M : Type*} [CommRing R] [PartialOrder R] [IsOrderedRing R]
-variable [AddCommGroup M] [Module R M]
+variable [AddCommMonoid M] [Module R M]
 
 open Module
 

--- a/Mathlib/Analysis/Convex/Gauge.lean
+++ b/Mathlib/Analysis/Convex/Gauge.lean
@@ -634,7 +634,7 @@ end Seminormed
 
 section Normed
 
-variable [NormedAddCommGroup E] [NormedSpace ℝ E] {s : Set E} {r : ℝ} {x : E}
+variable [SeminormedAddCommGroup E] [NormedSpace ℝ E] {s : Set E} {r : ℝ} {x : E}
 open Metric
 
 theorem le_gauge_of_subset_closedBall (hs : Absorbent ℝ s) (hr : 0 ≤ r) (hsr : s ⊆ closedBall 0 r) :

--- a/Mathlib/Analysis/Normed/Group/CocompactMap.lean
+++ b/Mathlib/Analysis/Normed/Group/CocompactMap.lean
@@ -27,7 +27,7 @@ public section
 open Filter Metric
 
 variable {E F 𝓕 : Type*}
-variable [NormedAddCommGroup E] [NormedAddCommGroup F]
+variable [SeminormedAddCommGroup E] [NormedAddCommGroup F]
 variable {f : 𝓕}
 
 theorem CocompactMapClass.norm_le [ProperSpace F] [FunLike 𝓕 E F] [CocompactMapClass 𝓕 E F]

--- a/Mathlib/Analysis/Normed/Group/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Group/Seminorm.lean
@@ -602,7 +602,7 @@ end AddGroup
 
 section AddCommGroup
 
-variable [AddCommGroup E]
+variable [AddGroup E]
 
 theorem add_bddBelow_range_add {p q : NonarchAddGroupSeminorm E} {x : E} :
     BddBelow (range fun y => p y + q (x - y)) :=

--- a/Mathlib/Data/Finset/Pairwise.lean
+++ b/Mathlib/Data/Finset/Pairwise.lean
@@ -40,7 +40,7 @@ theorem PairwiseDisjoint.elim_finset {s : Set ι} {f : ι → Finset α} (hs : s
 
 section SemilatticeInf
 
-variable [SemilatticeInf α] [OrderBot α] {s : Finset ι} {f : ι → α}
+variable [PartialOrder α] [OrderBot α] {s : Finset ι} {f : ι → α}
 
 theorem PairwiseDisjoint.image_finset_of_le [DecidableEq ι] {s : Finset ι} {f : ι → α}
     (hs : (s : Set ι).PairwiseDisjoint f) {g : ι → ι} (hf : ∀ a, f (g a) ≤ f a) :

--- a/Mathlib/GroupTheory/Torsion.lean
+++ b/Mathlib/GroupTheory/Torsion.lean
@@ -87,7 +87,7 @@ noncomputable def IsMulTorsion.group [Monoid G] (tG : IsMulTorsion G) : Group G 
 
 section Group
 
-variable [Group G] {N : Subgroup G} [Group H]
+variable [Group G] {N : Subgroup G} [DivInvMonoid H]
 
 /-- Subgroups of torsion groups are torsion groups. -/
 @[to_additive /-- Additive subgroups of torsion additive groups are torsion additive groups. -/]

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -531,11 +531,11 @@ end CommSemiring
 
 section CommRing
 
-variable {R M : Type*} [CommRing R] [IsDomain R]
+variable {R M : Type*} [CommRing R] [NoZeroDivisors R]
 
 section AddCommGroup
 
-variable [AddCommGroup M] [Module R M]
+variable [AddCommMonoid M] [Module R M]
 
 theorem lsmul_injective [IsTorsionFree R M] {x : R} (hx : x ≠ 0) :
     Function.Injective (lsmul R M x) :=

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -887,7 +887,7 @@ lemma LinearIndependent.of_subsingleton' [Subsingleton ι] (i : ι)
 lemma LinearIndepOn.singleton' (hi : ∀ r : R, r • v i = 0 → r = 0) : LinearIndepOn R v {i} :=
   LinearIndependent.of_subsingleton' ⟨i, rfl⟩ hi
 
-variable [IsDomain R] [IsTorsionFree R M]
+variable [NoZeroDivisors R] [IsTorsionFree R M]
 
 lemma LinearIndependent.of_subsingleton [Subsingleton ι] (i : ι) (hi : v i ≠ 0) :
     LinearIndependent R v := .of_subsingleton' i (by simp [hi])

--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -289,7 +289,7 @@ end Preorder
 
 section PartialOrder
 
-variable [PartialOrder α] [PartialOrder β] {f : α → β} {s : Set α}
+variable [PartialOrder α] [Preorder β] {f : α → β} {s : Set α}
 
 lemma IsAntichain.of_strictMonoOn_antitoneOn (hf : StrictMonoOn f s) (hf' : AntitoneOn f s) :
     IsAntichain (· ≤ ·) s :=

--- a/Mathlib/Order/Monotone/Extension.lean
+++ b/Mathlib/Order/Monotone/Extension.lean
@@ -20,7 +20,7 @@ public section
 
 open Set
 
-variable {α β : Type*} [LinearOrder α] [ConditionallyCompleteLinearOrder β] {f : α → β} {s : Set α}
+variable {α β : Type*} [PartialOrder α] [ConditionallyCompleteLinearOrder β] {f : α → β} {s : Set α}
 
 /-- If a function is monotone and is bounded on a set `s`, then it admits a monotone extension to
 the whole space. -/

--- a/Mathlib/RingTheory/AlgebraTower.lean
+++ b/Mathlib/RingTheory/AlgebraTower.lean
@@ -169,7 +169,7 @@ end Semiring
 section Ring
 
 variable {R S}
-variable [CommRing R] [IsDomain R] [Ring S] [Nontrivial S] [Algebra R S]
+variable [CommRing R] [NoZeroDivisors R] [Ring S] [Nontrivial S] [Algebra R S]
 
 theorem Module.Basis.algebraMap_injective {ι : Type*} (b : Basis ι R S) :
     Function.Injective (algebraMap R S) :=

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Basic.lean
@@ -47,7 +47,7 @@ to add a `(h : ¬ IsField A)` assumption whenever this is explicitly needed.
 dedekind domain, dedekind ring
 -/
 
-variable (R A K : Type*) [CommRing R] [CommRing A] [Field K]
+variable (R A K : Type*) [CommSemiring R] [CommRing A] [Field K]
 
 open scoped nonZeroDivisors Polynomial
 

--- a/Mathlib/RingTheory/Ideal/Quotient/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Over.lean
@@ -12,7 +12,7 @@ public import Mathlib.RingTheory.Ideal.Over
 
 public section
 
-variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T]
+variable {R S T : Type*} [CommSemiring R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T]
 
 /-- Given a prime `P` of `R` and an ideal `I` in an `R`-algebra `S`.
 Suppose we can find a prime `P'` over `P`, not containing `I`,

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -29,7 +29,7 @@ ring homomorphism `f : R →+* S` satisfying 3 properties:
 In the following, let `R, P` be commutative rings, `S, Q` be `R`- and `P`-algebras
 and `M, T` be submonoids of `R` and `P` respectively, e.g.:
 ```
-variable (R S P Q : Type*) [CommRing R] [CommRing S] [CommRing P] [CommRing Q]
+variable (R S P Q : Type*) [CommRing R] [CommSemiring S] [CommRing P] [CommRing Q]
 variable [Algebra R S] [Algebra P Q] (M : Submonoid R) (T : Submonoid P)
 ```
 
@@ -630,7 +630,7 @@ end CommSemiring
 
 section CommRing
 
-variable {R : Type*} [CommRing R] {M : Submonoid R} (S : Type*) [CommRing S]
+variable {R : Type*} [CommRing R] {M : Submonoid R} (S : Type*) [CommSemiring S]
 
 namespace IsLocalization
 

--- a/Mathlib/RingTheory/Localization/Module.lean
+++ b/Mathlib/RingTheory/Localization/Module.lean
@@ -189,7 +189,7 @@ end LocalizationLocalization
 section FractionRing
 
 variable (R K : Type*) [CommRing R] [CommRing K] [Algebra R K] [IsFractionRing R K]
-variable {V : Type*} [AddCommGroup V] [Module R V] [Module K V] [IsScalarTower R K V]
+variable {V : Type*} [AddCommMonoid V] [Module R V] [Module K V] [IsScalarTower R K V]
 
 theorem LinearIndependent.iff_fractionRing {ι : Type*} {b : ι → V} :
     LinearIndependent R b ↔ LinearIndependent K b :=

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -125,7 +125,7 @@ instance : Nontrivial (ValueGroup A K) where
     dsimp at hd
     simp only [inv_smul_smul, smul_zero, one_ne_zero] at hd⟩
 
-variable [IsDomain A] [ValuationRing A] [IsFractionRing A K]
+variable [IsDomain A] [PreValuationRing A] [IsFractionRing A K]
 
 protected theorem le_total (a b : ValueGroup A K) : a ≤ b ∨ b ≤ a := by
   rcases a with ⟨a⟩; rcases b with ⟨b⟩

--- a/Mathlib/Topology/EMetricSpace/Pi.lean
+++ b/Mathlib/Topology/EMetricSpace/Pi.lean
@@ -22,7 +22,7 @@ variable {α : Type u} {β : Type v} {X : Type*}
 
 open scoped Uniformity Topology NNReal ENNReal Pointwise
 
-variable [TopologicalSpace α] [WeakPseudoEMetricSpace α]
+variable [EDist α]
 
 open EMetric
 

--- a/Mathlib/Topology/Instances/Sign.lean
+++ b/Mathlib/Topology/Instances/Sign.lean
@@ -27,7 +27,7 @@ variable {α : Type*} [Zero α] [TopologicalSpace α]
 
 section PartialOrder
 
-variable [PartialOrder α] [DecidableLT α] [OrderTopology α]
+variable [Preorder α] [DecidableLT α] [OrderTopology α]
 
 theorem continuousAt_sign_of_pos {a : α} (h : 0 < a) : ContinuousAt SignType.sign a := by
   refine (continuousAt_const : ContinuousAt (fun _ => (1 : SignType)) a).congr ?_


### PR DESCRIPTION
This PR has been described at

https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/unused.20hypotheses.3A.20431.20in.20a.2029k.20sample.2C.20and.2033.20one-line.20PRs/near/622113682

it is a list of mechanically found [1] one-liners relaxing theorems whose setting is stronger than their proof needs. Each change compiled alone against an unmodified file (whole library building locally at 633b366493).

More information on the project https://github.com/carlok/unused-assumptions

In the zulip thread, @SnirBroshi spotted that the refactored Topology/EMetricSpace/Pi.lean takes [EDist α] in place of two binders.

PS: A single PR because I noticed #42214 (813 files, merged, same kind of change).

Thank you for your work.

[1] LLM + Lean4 itself