### PR TITLE
perf(Tactic/Positivity): run extensions in `reducible` transparency

### DIFF
--- a/Counterexamples/NowhereDifferentiable.lean
+++ b/Counterexamples/NowhereDifferentiable.lean
@@ -146,7 +146,6 @@ theorem weierstrass_partial {a : ℝ} (ha : 0 < a) {b : ℕ} (hab : 1 < a * b) (
     ring
   simp_rw [this, ← Finset.sum_mul, geom_sum_eq hab.ne.symm]
   field_simp
-  refine div_le_div_of_nonneg_right ?_ (sub_nonneg.mpr hab.le)
   simp [sub_one_mul]
 
 /-- The remainder has lower bound in absolute value $|B| \ge |x_m - x| 2 (ab)^m / 3$ -/

--- a/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
@@ -417,7 +417,7 @@ If it is an explicit function, e.g. `|_|` or `‖_‖`, another extension should
 @[positivity _]
 meta def Mathlib.Meta.Positivity.evalAbv : PositivityExt where eval {_ _α} _zα pα? e :=
   match pα? with | none => pure .none | some _ => do
-  let (.app f a) ← whnfR e | throwError "not abv ·"
+  let (.app f a) ← whnf e | throwError "not abv ·"
   if !f.getAppFn.isFVar then
     throwError "abv: function is not a variable"
   let pa' ← mkAppM ``abv_nonneg #[f, a]

--- a/Mathlib/Algebra/Order/Field/Basic.lean
+++ b/Mathlib/Algebra/Order/Field/Basic.lean
@@ -734,12 +734,12 @@ lemma zpow_zero_pos {α : Type*} [Semifield α] [PartialOrder α] [IsStrictOrder
 /-- The `positivity` extension which identifies expressions of the form `a / b`,
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity _ / _] meta def evalDiv : PositivityExt where eval {u α} zα pα? e := do
-  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← withReducible (whnf e)
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnf e
     | throwError "not /"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   trace[Tactic.positivity.zeroness] "evalDiv: {a} divided by {b}"
   let _a ← synthInstanceQ q(Semifield $α)
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(HDiv.hDiv)
+  let ⟨_f_eq⟩ ← withNewMCtxDepth <| assertDefEqQ q($f) q(HDiv.hDiv)
   match (dependent := true) pα? with
   | none =>
     match ← core zα pα? a, ← core zα pα? b with
@@ -767,10 +767,10 @@ such that `positivity` successfully recognises both `a` and `b`. -/
 such that `positivity` successfully recognises `a`. -/
 @[positivity _⁻¹]
 meta def evalInv : PositivityExt where eval {u α} zα pα? e := do
-  let .app (f : Q($α → $α)) (a : Q($α)) ← withReducible (whnf e) | throwError "not ⁻¹"
+  let .app (f : Q($α → $α)) (a : Q($α)) ← whnf e | throwError "not ⁻¹"
   let _e_eq : $e =Q $f $a := ⟨⟩
   let _a ← synthInstanceQ q(Semifield $α)
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(Inv.inv)
+  let ⟨_f_eq⟩ ← withNewMCtxDepth <| assertDefEqQ q($f) q(Inv.inv)
   match (dependent := true) pα? with
   | none =>
     match ← core zα pα? a with
@@ -799,7 +799,7 @@ meta def evalInv : PositivityExt where eval {u α} zα pα? e := do
 @[positivity _ ^ (0 : ℤ), Pow.pow _ (0 : ℤ)]
 meta def evalPowZeroInt : PositivityExt where eval {u α} _zα pα? e :=
   match pα? with | none => pure .none | some _ => do
-  let .app (.app _ (a : Q($α))) _ ← withReducible (whnf e) | throwError "not ^"
+  let .app (.app _ (a : Q($α))) _ ← whnf e | throwError "not ^"
   let _a ← synthInstanceQ q(Semifield $α)
   let _a ← synthInstanceQ q(LinearOrder $α)
   let _a ← synthInstanceQ q(IsStrictOrderedRing $α)

--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -124,7 +124,7 @@ open Lean Meta Qq
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity _ ^ (_ : ℤ), Pow.pow _ (_ : ℤ)]
 meta def evalZPow : PositivityExt where eval {u α} zα pα? e := do
-  let .app (.app _ (a : Q($α))) (b : Q(ℤ)) ← withReducible (whnf e) | throwError "not ^"
+  let .app (.app _ (a : Q($α))) (b : Q(ℤ)) ← whnf e | throwError "not ^"
   match (dependent := true) pα? with
   | none =>
     match ← core zα pα? a with
@@ -140,7 +140,7 @@ meta def evalZPow : PositivityExt where eval {u α} zα pα? e := do
       let _a ← synthInstanceQ q(LinearOrder $α)
       let _a ← synthInstanceQ q(IsStrictOrderedRing $α)
       assumeInstancesCommute
-      match ← whnfR b with
+      match ← whnf b with
       | .app (.app (.app (.const `OfNat.ofNat _) _) (.lit (Literal.natVal n))) _ =>
         guard (n % 2 = 0)
         have m : Q(ℕ) := mkRawNatLit (n / 2)
@@ -148,7 +148,7 @@ meta def evalZPow : PositivityExt where eval {u α} zα pα? e := do
         haveI' : $e =Q $a ^ $b := ⟨⟩
         pure (.nonnegative q(Even.zpow_nonneg (Even.add_self _) $a))
       | .app (.app (.app (.const `Neg.neg _) _) _) b' =>
-        let b' ← whnfR b'
+        let b' ← whnf b'
         let .true := b'.isAppOfArity ``OfNat.ofNat 3 | throwError "not a ^ -n where n is a literal"
         let some n := (b'.getRevArg! 1).rawNatLit? | throwError "not a ^ -n where n is a literal"
         guard (n % 2 = 0)

--- a/Mathlib/Algebra/Order/Module/Field.lean
+++ b/Mathlib/Algebra/Order/Module/Field.lean
@@ -107,7 +107,7 @@ meta def evalSMul : PositivityExt where eval {_u α} zα pα? (e : Q($α)) :=
   match pα? with | none => pure .none | some pα => do
   let .app (.app (.app (.app (.app (.app
         (.const ``HSMul.hSMul [u1, _, _]) (β : Q(Type u1))) _) _) _)
-          (a : Q($β))) (b : Q($α)) ← whnfR e | throwError "failed to match hSMul"
+          (a : Q($β))) (b : Q($α)) ← whnf e | throwError "failed to match hSMul"
   let zM : Q(Zero $β) ← synthInstanceQ q(Zero $β)
   let pM : Q(PartialOrder $β) ← synthInstanceQ q(PartialOrder $β)
   -- Using `q()` here would be impractical, as we would have to manually `synthInstanceQ` all the

--- a/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
+++ b/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
@@ -365,7 +365,7 @@ theorem div_le_radius_compContinuousLinearMap (p : FormalMultilinearSeries 𝕜 
     _ = ‖p n‖ * r ^ n := by
       simp only [NNReal.coe_div, coe_nnnorm, div_pow, mul_assoc]
       rw [mul_div_cancel₀]
-      rw [← NNReal.coe_pos] at h_zero
+      rw [← NNReal.coe_pos, coe_nnnorm] at h_zero
       positivity
     _ ≤ C := hC n
 

--- a/Mathlib/Analysis/Hofer.lean
+++ b/Mathlib/Analysis/Hofer.lean
@@ -88,7 +88,7 @@ theorem hofer {X : Type*} [MetricSpace X] [CompleteSpace X] (x : X) (ε : ℝ) (
     suffices Tendsto v atTop atTop by rwa [tendsto_add_atTop_iff_nat] at this
     have hv₀ : 0 < v 0 := by
       calc
-        0 ≤ 2 * ϕ (u 0) := by specialize nonneg x; positivity
+        0 ≤ 2 * ϕ (u 0) := by specialize nonneg (u 0); positivity
         _ < ϕ (u (0 + 1)) := key₂ 0
     apply tendsto_atTop_of_geom_le hv₀ one_lt_two
     exact fun n => (key₂ (n + 1)).le

--- a/Mathlib/Analysis/Normed/Group/SeparationQuotient.lean
+++ b/Mathlib/Analysis/Normed/Group/SeparationQuotient.lean
@@ -124,7 +124,7 @@ theorem norm_normedMk_eq_one [NontrivialTopology M] :
   · simpa only [normedMk_apply, one_mul] using! fun _ ↦ le_rfl
   · intro N _ hle
     obtain ⟨x, _⟩ := exists_norm_ne_zero M
-    exact one_le_of_le_mul_right₀ (by positivity) (hle x)
+    exact one_le_of_le_mul_right₀ (b := ‖x‖) (by positivity) (hle x)
 
 /-- The projection is `0` if and only if all the elements have norm `0`. -/
 theorem normedMk_eq_zero_iff : normedMk (M := M) = 0 ↔ ∀ (x : M), ‖x‖ = 0 := by

--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -273,6 +273,7 @@ theorem mahlerMeasure_le_sum_norm_coeff (p : ℂ[X]) : p.mahlerMeasure ≤ p.sum
     p.intervalIntegrable_mahlerMeasure (by simp)
   rw [EventuallyLE, eventually_iff_exists_mem]
   use {x : ℝ | eval (circleMap 0 1 x) p ≠ 0}
+  simp only [mem_ofPred]
   constructor
   · rw [mem_ae_iff, compl_def, Measure.restrict_apply' (by simp)]
     apply (Finite.of_sdiff _ <| finite_singleton (2 * π)).measure_zero

--- a/Mathlib/Analysis/SpecialFunctions/Bernstein.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Bernstein.lean
@@ -82,7 +82,7 @@ open Lean Meta Qq Function
 @[positivity DFunLike.coe (bernstein _ _) _]
 meta def evalBernstein : PositivityExt where eval {_ _} _zα pα? e :=
   match pα? with | none => pure .none | some _ => do
-  let .app (.app _coe (.app (.app _ n) ν)) x ← whnfR e | throwError "not bernstein polynomial"
+  let .app (.app _coe (.app (.app _ n) ν)) x ← whnf e | throwError "not bernstein polynomial"
   let p ← mkAppOptM ``bernstein_nonneg #[n, ν, x]
   pure (.nonnegative p)
 

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -274,9 +274,10 @@ lemma hasDerivAt_half_log_one_add_div_one_sub_sub_sum_range
     congr with i
     simp [field, mul_comm, ← pow_mul]
   have hy₃ : y ^ 2 ≠ 1 := by simp [hy₁.ne', hy₂.ne]
-  have hy₄ : (1 - y) * (1 + y) = 1 - y ^ 2 := by ring
-  simp [this, field, geom_sum_eq hy₃, hy₄]
-  ring
+  norm_num
+  rw [this, geom_sum_eq hy₃]
+  have hy₄ : 0 < 1 + y := by grind
+  field
 
 /-- A lemma estimating the difference between $\frac{1}{2} * \log(\frac{1+x}{1-x})$ and its
 Taylor series at `0`, where the bound tends to `0`. This bound is particularly useful for explicit

--- a/Mathlib/MeasureTheory/Integral/PeakFunction.lean
+++ b/Mathlib/MeasureTheory/Integral/PeakFunction.lean
@@ -311,7 +311,7 @@ theorem tendsto_setIntegral_pow_smul_of_unique_maximum_of_isCompact_of_measure_n
           _ ≤ ∫ y in s, c y ^ n ∂μ :=
             setIntegral_mono_set (I n) (J n) (Eventually.of_forall inter_subset_right)
       simp_rw [φ, ← div_eq_inv_mul, div_pow, div_div]
-      have := ENNReal.toReal_pos (hμ v v_open x₀_v).ne'
+      have : 0 < μ.real (v ∩ s) := ENNReal.toReal_pos (hμ v v_open x₀_v).ne'
         ((measure_mono inter_subset_right).trans_lt hs.measure_lt_top).ne
       gcongr
       · exact hnc _ hx.1

--- a/Mathlib/MeasureTheory/Measure/Real.lean
+++ b/Mathlib/MeasureTheory/Measure/Real.lean
@@ -493,7 +493,7 @@ open Lean Meta Qq Function
 @[positivity MeasureTheory.Measure.real _ _]
 meta def evalMeasureReal : PositivityExt where eval {_ _} _zα pα? e :=
   match pα? with | none => pure .none | some _ => do
-  let .app (.app _ a) b ← whnfR e | throwError "not measureReal"
+  let .app (.app _ a) b ← whnf e | throwError "not measureReal"
   let p ← mkAppOptM ``MeasureTheory.measureReal_nonneg #[none, none, a, b]
   pure (.nonnegative p)
 

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -62,7 +62,7 @@ such that `positivity` successfully recognises both `a` and `b`. -/
     ← whnfR e | throwError "not ite"
   haveI' : $e =Q ite $p $a $b := ⟨⟩
   let ra ← core zα pα? a; let rb ← core zα pα? b
-  guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(ite (α := $α))
+  guard <|← withNewMCtxDepth <| isDefEq f q(ite (α := $α))
   id <|
   match ra, rb with
   | .positive pa, .positive pb => pure (.positive q(ite_pos $p $pa $pb))
@@ -94,7 +94,7 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnfR e | throwError "not min"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ q(LinearOrder $α)
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(min)
+  let ⟨_f_eq⟩ ← withNewMCtxDepth <| assertDefEqQ q($f) q(min)
   assumeInstancesCommute
   match (dependent := true) ← core zα pα? a, ← core zα pα? b with
   | .positive (pα := pα') pa, .positive pb =>
@@ -125,7 +125,7 @@ is nonnegative, strictly positive if at least one is positive, and nonzero if bo
   let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnfR e | throwError "not max"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ q(LinearOrder $α)
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(max)
+  let ⟨_f_eq⟩ ← withNewMCtxDepth <| assertDefEqQ q($f) q(max)
   let result : Strictness zα e pα? ← catchNone do
     let ra ← core zα pα? a
     match (dependent := true) ra with
@@ -162,7 +162,7 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ q(AddZeroClass $α)
   assumeInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(HAdd.hAdd)
+  let ⟨_f_eq⟩ ← withNewMCtxDepth <| assertDefEqQ q($f) q(HAdd.hAdd)
   let ra ← core zα pα a; let rb ← core zα pα b
   match ra, rb with
   | .positive pa, .positive pb =>
@@ -186,7 +186,7 @@ such that there is a local hypothesis `b < a`, `b ≤ a`, `a ≠ b` or `b ≠ a`
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ q(AddGroup $α)
   assumeInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(HSub.hSub)
+  let ⟨_f_eq⟩ ← withNewMCtxDepth <| assertDefEqQ q($f) q(HSub.hSub)
   id <|
   match pα? with
   | some pα => do
@@ -249,7 +249,7 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnfR e | throwError "not *"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ q(Mul $α)
-  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ q($f) q(HMul.hMul)
+  let ⟨_f_eq⟩ ← withNewMCtxDepth <| assertDefEqQ q($f) q(HMul.hMul)
   let ra ← core zα pα? a; let rb ← core zα pα? b
   let tryProveNonzero (pα? : Option Q(PartialOrder $α))
       (pa? : Option Q($a ≠ 0)) (pb? : Option Q($b ≠ 0)) : MetaM (Strictness zα e pα?) := do

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -199,14 +199,14 @@ such that there is a local hypothesis `b < a`, `b ≤ a`, `a ≠ b` or `b ≠ a`
           match e' with
           | ~q(@LE.le.{u} $β $le $lo $hi) =>
             let .defEq (_ : $α =Q $β) ← isDefEqQ α β | return .none
-            let .defEq _ ← isDefEqQ q($le) q(($pα).toLE) | return .none
+            let .defEq _ ← withImplicit <| isDefEqQ q($le) q(($pα).toLE) | return .none
             let .defEq (_ : $a =Q $hi) ← isDefEqQ a hi | return .none
             let .defEq (_ : $b =Q $lo) ← isDefEqQ b lo | return .none
             let _ ← synthInstanceQ q(AddRightMono $α)
             return .nonnegative q(sub_nonneg_of_le $p)
           | ~q(@LT.lt.{u} $β $lt $lo $hi) =>
             let .defEq (_ : $α =Q $β) ← isDefEqQ α β | return .none
-            let .defEq _ ← isDefEqQ q($lt) q(($pα).toLT) | return .none
+            let .defEq _ ← withImplicit <| isDefEqQ q($lt) q(($pα).toLT) | return .none
             let .defEq (_ : $a =Q $hi) ← isDefEqQ a hi | return .none
             let .defEq (_ : $b =Q $lo) ← isDefEqQ b lo | return .none
             let _i ← synthInstanceQ q(AddRightStrictMono $α)

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -59,7 +59,7 @@ end ite
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity ite _ _ _] def evalIte : PositivityExt where eval {u α} zα pα? e := do
   let .app (.app (.app (.app f (p : Q(Prop))) (_ : Q(Decidable $p))) (a : Q($α))) (b : Q($α))
-    ← whnfR e | throwError "not ite"
+    ← whnf e | throwError "not ite"
   haveI' : $e =Q ite $p $a $b := ⟨⟩
   let ra ← core zα pα? a; let rb ← core zα pα? b
   guard <|← withNewMCtxDepth <| isDefEq f q(ite (α := $α))
@@ -91,7 +91,7 @@ end LinearOrder
 /-- The `positivity` extension which identifies expressions of the form `min a b`,
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity min _ _] def evalMin : PositivityExt where eval {u α} zα pα? e := do
-  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnfR e | throwError "not min"
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnf e | throwError "not min"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ q(LinearOrder $α)
   let ⟨_f_eq⟩ ← withNewMCtxDepth <| assertDefEqQ q($f) q(min)
@@ -122,7 +122,7 @@ such that `positivity` successfully recognises both `a` and `b`. -/
 /-- Extension for the `max` operator. The `max` of two numbers is nonnegative if at least one
 is nonnegative, strictly positive if at least one is positive, and nonzero if both are nonzero. -/
 @[positivity max _ _] def evalMax : PositivityExt where eval {u α} zα pα? e := do
-  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnfR e | throwError "not max"
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnf e | throwError "not max"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ q(LinearOrder $α)
   let ⟨_f_eq⟩ ← withNewMCtxDepth <| assertDefEqQ q($f) q(max)
@@ -158,7 +158,7 @@ is nonnegative, strictly positive if at least one is positive, and nonzero if bo
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity _ + _] def evalAdd : PositivityExt where eval {u α} zα pα? e :=
   match pα? with | none => pure .none | some pα => do
-  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnfR e | throwError "not +"
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnf e | throwError "not +"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ q(AddZeroClass $α)
   assumeInstancesCommute
@@ -182,7 +182,7 @@ such that `positivity` successfully recognises both `a` and `b`. -/
 /-- The `positivity` extension which identifies expressions of the form `a - b`,
 such that there is a local hypothesis `b < a`, `b ≤ a`, `a ≠ b` or `b ≠ a`. -/
 @[positivity _ - _] def evalSub : PositivityExt where eval {u α} _zα pα? e := do
-  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnfR e | throwError "not -"
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnf e | throwError "not -"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ q(AddGroup $α)
   assumeInstancesCommute
@@ -246,7 +246,7 @@ such that there is a local hypothesis `b < a`, `b ≤ a`, `a ≠ b` or `b ≠ a`
 /-- The `positivity` extension which identifies expressions of the form `a * b`,
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity _ * _] def evalMul : PositivityExt where eval {u α} zα pα? e := do
-  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnfR e | throwError "not *"
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnf e | throwError "not *"
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ q(Mul $α)
   let ⟨_f_eq⟩ ← withNewMCtxDepth <| assertDefEqQ q($f) q(HMul.hMul)
@@ -332,7 +332,7 @@ theorem pow_zero_ne_zero [Semiring α] [Nontrivial α] (a : α) : a ^ 0 ≠ 0 :=
 This extension is run in addition to the general `a ^ b` extension (they are overlapping). -/
 @[positivity _ ^ (0 : ℕ)]
 meta def evalPowZeroNat : PositivityExt where eval {u α} _zα pα? e := do
-  let .app (.app _ (a : Q($α))) _ ← whnfR e | throwError "not ^"
+  let .app (.app _ (a : Q($α))) _ ← whnf e | throwError "not ^"
   let _a ← synthInstanceQ q(Semiring $α)
   assumeInstancesCommute
   haveI' : $e =Q $a ^ 0 := ⟨⟩
@@ -347,7 +347,7 @@ meta def evalPowZeroNat : PositivityExt where eval {u α} _zα pα? e := do
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity _ ^ (_ : ℕ)]
 meta def evalPow : PositivityExt where eval {u α} zα pα? e := do
-  let .app (.app _ (a : Q($α))) (b : Q(ℕ)) ← whnfR e | throwError "not ^"
+  let .app (.app _ (a : Q($α))) (b : Q(ℕ)) ← whnf e | throwError "not ^"
   match (dependent := true) pα? with
   | none =>
     let _a ← synthInstanceQ q(MonoidWithZero $α)
@@ -749,7 +749,7 @@ meta def evalNegPart : PositivityExt where eval {u α} _ pα? e :=
 @[positivity DFunLike.coe _ _]
 meta def evalMap : PositivityExt where eval {_ β} _ pβ? e :=
   match pβ? with | none => pure .none | some _ => do
-  let .app (.app _ f) a ← whnfR e
+  let .app (.app _ f) a ← whnf e
     | throwError "not ↑f · where f is of NonnegHomClass"
   let pa ← mkAppOptM ``apply_nonneg #[none, none, β, none, none, none, none, f, a]
   pure (.nonnegative pa)

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -43,7 +43,7 @@ Example:
   let .app (.app (.app (.app f (p : Q(Prop))) (_ : Q(Decidable $p))) (a : Q($α))) (b : Q($α))
     ← withReducible (whnf e) | throwError "not ite"
   haveI' : $e =Q ite $p $a $b := ⟨⟩
-  guard <| ← withDefault <| withNewMCtxDepth <| isDefEq f q(ite (α := $α))
+  guard <| ← withNewMCtxDepth <| isDefEq f q(ite (α := $α))
   let ra ← core zα pα a; let rb ← core zα pα b
   ...
 ```
@@ -435,7 +435,8 @@ def orElse {pα?} {e : Q($α)} (t₁ : Strictness zα e pα?) (t₂ : MetaM (Str
     | _ => pure (.nonzero p₁)
 
 /-- Run each registered `positivity` extension on an expression, returning a `NormNum.Result`. -/
-def core (pα? : Option Q(PartialOrder $α)) (e : Q($α)) : MetaM (Strictness zα e pα?) := do
+def core (pα? : Option Q(PartialOrder $α)) (e : Q($α)) : MetaM (Strictness zα e pα?) :=
+  withReducible do
   let mut result := .none
   trace[Tactic.positivity] "trying to prove positivity of {e}"
   for ext in ← (positivityExt.getState (← getEnv)).2.getMatch e do


### PR DESCRIPTION
This PR makes it so that `positivity` extensions are executed at `reducible` transparency, which should help with proof maintainability, and gives a slight speedup.

- This does not affect the check of whether the goal is a positivity goal. So, `0 i < x` is still considered a positivity goal, even though `0 i` is not defeq to `0` at reducible transparency.
- The positivity extension for subtraction is checking that it has the right instance using `isDefEq`, so this has to be done at the `implicit` transparency. Apparently, this change causes `positivity` to succeed somewhere where it did not before.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
