### PR TITLE
chore: use Nat.pred in Finset.pred_card_le_card_erase

### DIFF
--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -162,7 +162,7 @@ theorem card_erase_lt_of_mem : a ∈ s → #(s.erase a) < #s :=
 theorem card_erase_le : #(s.erase a) ≤ #s :=
   Multiset.card_erase_le
 
-theorem pred_card_le_card_erase : #s - 1 ≤ #(s.erase a) := by grind
+theorem pred_card_le_card_erase : (#s).pred ≤ #(s.erase a) := by grind
 
 /-- If `a ∈ s` is known, see also `Finset.card_erase_of_mem` and `Finset.erase_eq_of_notMem`. -/
 theorem card_erase_eq_ite : #(s.erase a) = if a ∈ s then #s - 1 else #s :=


### PR DESCRIPTION
## Summary

Addresses part of #21584 (naming consistency tracker):

> `Finset.pred_card_le_card_erase`: Why does this use `- 1` instead of `pred` when `pred` rather than `sub_one` is in the name?

Change the statement to use `(#s).pred` so the lemma matches its `pred_…` name. Left related `#s - 1` lemmas (`card_erase_of_mem`, `card_erase_eq_ite`, …) untouched — they are not named `pred_*`.

```lean
theorem pred_card_le_card_erase : (#s).pred ≤ #(s.erase a) := by grind
```

## Notes for #21584 maintainers (already done upstream — checkbox only)

- `tsum_geometric_nnreal` already deprecated → `NNReal.tsum_geometric` (since 2026-03-18)
- `Nat.digits_len` already deprecated → `length_digits` (since 2026-03-18)

## Checklist

- [x] minimal one-line statement change in `Mathlib/Data/Finset/Card.lean`
- [x] no drive-by renames