### PR TITLE
[Merged by Bors] - feat(Algebra): generalize Baer's injective criterion to non-commutative rings

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Ext/Baer.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Ext/Baer.lean
@@ -45,7 +45,7 @@ universe than `ModuleCat.{v} R`.
 
 universe u v
 
-variable {R : Type u} [CommRing R]
+variable {R : Type u} [Ring R]
 
 open CategoryTheory Abelian
 
@@ -127,8 +127,8 @@ lemma hasInjectiveDimensionLE_of_quotients [Small.{v} R] (M : ModuleCat.{v} R) (
 private noncomputable def extQuotientBotZeroEquiv [Small.{v} R] (M : ModuleCat.{v} R) :
     (Ext (ModuleCat.of R (Shrink.{v} (R ⧸ (⊥ : Ideal R)))) M 0) ≃ M :=
   (Ext.homEquiv₀.trans ModuleCat.homEquiv).trans ((((Shrink.linearEquiv _ _).trans
-    (Submodule.quotEquivOfEqBot _ rfl)).congrLeft M R).trans
-      (LinearMap.ringLmapEquivSelf R R M)).toEquiv
+    (Submodule.quotEquivOfEqBot _ rfl)).congrLeft M ℕ).trans
+      (LinearMap.ringLmapEquivSelf R ℕ M)).toEquiv
 
 /-- If `Ext⁰(R ⧸ ⊥, M)` is a subsingleton, then `M` is a subsingleton. -/
 private lemma subsingleton_of_ext_quotient_bot_zero [Small.{v} R] (M : ModuleCat.{v} R)


### PR DESCRIPTION
Almost the entire body of the recently merged PR #32058 goes through identically for non-commutative rings, with one small change to a private definition. (The choice of `S = ℕ` is required in the non-commutative case per the
[docstring](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/Equiv/Basic.html#LinearMap.ringLmapEquivSelf))

---

AI disclosure: This generalization was originally found and writen by an agent working on an auto-formalization that required the non-commutative Baer criterion.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
