### PR TITLE
[Merged by Bors] - chore: remove a superfluous backcompat option

### DIFF
--- a/Mathlib/RingTheory/Extension/Presentation/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Presentation/Basic.lean
@@ -358,7 +358,6 @@ noncomputable def compRelationAux (r : σ') : MvPolynomial (ι' ⊕ ι) R :=
 private lemma aux_X (i : ι' ⊕ ι) : (Q.aux P) (X i) = Sum.elim X (C ∘ P.val) i :=
   aeval_X (Sum.elim X (C ∘ P.val)) i
 
-set_option backward.isDefEq.respectTransparency.types false in
 /-- The pre-images constructed in `compRelationAux` are indeed pre-images under `aux`. -/
 private lemma compRelationAux_map (r : σ') :
     (Q.aux P) (Q.compRelationAux P r) = Q.relation r := by
@@ -369,7 +368,7 @@ private lemma compRelationAux_map (r : σ') :
   rw [AddMonoidAlgebra.ofCoeff_finsuppSum]
   congr
   ext u s m
-  simp only [aeval, AlgHom.coe_mk, coe_eval₂Hom, map_one, one_mul]
+  simp only [aeval, map_one, one_mul]
   change (eval₂ (algebraMap R (MvPolynomial ι' S)) (C ∘ P.val) (P.σ s) *
       (Finsupp.mapDomain Sum.inl u).prod fun i k ↦ Sum.elim X (C ∘ P.val) i ^ k).coeff m =
         (monomial u s).coeff m


### PR DESCRIPTION
Spotted by the nolints bot in #43506.
Merely removing the option triggers two 'unused simp arguments' warnings, so let's extract this change separately.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
