### PR TITLE
chore(Order/Interval/Set/SuccPred): generalize lemmas

### DIFF
--- a/Mathlib/Order/Interval/Set/SuccPred.lean
+++ b/Mathlib/Order/Interval/Set/SuccPred.lean
@@ -32,15 +32,17 @@ assert_not_exists MonoidWithZero
 open Order
 
 namespace Set
-variable {α : Type*} [LinearOrder α]
+variable {α : Type*}
 
 /-! ### Two-sided intervals -/
 
 section SuccOrder
-variable [SuccOrder α] {a b : α}
+
+section Preorder
+variable [Preorder α] [SuccOrder α] {a b : α}
 
 /-!
-#### Orders possibly with maximal elements
+#### Preorders possibly with maximal elements
 
 ##### Equalities of intervals
 -/
@@ -55,6 +57,52 @@ lemma Ico_succ_left_eq_Ioo (a b : α) : Ico (succ a) b = Ioo a b := by
 @[to_dual Icc_pred_right_eq_Ico_of_not_isMin]
 lemma Icc_succ_left_eq_Ioc_of_not_isMax (ha : ¬ IsMax a) (b : α) : Icc (succ a) b = Ioc a b := by
   ext x; rw [mem_Icc, mem_Ioc, succ_le_iff_of_not_isMax ha]
+
+/-!
+#### Preorders with no maximal elements
+
+##### Equalities of intervals
+-/
+
+variable [NoMaxOrder α]
+
+@[to_dual (reorder := a b) Icc_pred_right_eq_Ico]
+lemma Icc_succ_left_eq_Ioc (a b : α) : Icc (succ a) b = Ioc a b :=
+  Icc_succ_left_eq_Ioc_of_not_isMax (not_isMax _) _
+
+end Preorder
+
+section PartialOrder
+variable [PartialOrder α] [SuccOrder α] {a b : α}
+
+/-!
+#### Partial orders possibly with maximal elements
+
+##### Inserting into intervals
+-/
+
+@[to_dual insert_Icc_pred_right_eq_Icc]
+lemma insert_Icc_succ_left_eq_Icc (h : a ≤ b) : insert a (Icc (succ a) b) = Icc a b := by
+  ext x; simp [or_and_left, eq_comm, ← le_iff_eq_or_succ_le]; aesop
+
+@[to_dual insert_Ioc_pred_right_eq_Ioc]
+lemma insert_Ico_succ_left_eq_Ico (h : a < b) : insert a (Ico (succ a) b) = Ico a b := by
+  rw [Ico_succ_left_eq_Ioo, ← Ioo_insert_left h]
+
+@[to_dual insert_Ico_pred_right_eq_Ico]
+lemma insert_Ioc_succ_left_eq_Ioc (h : a < b) : insert (succ a) (Ioc (succ a) b) = Ioc a b := by
+  rw [Ioc_insert_left (succ_le_of_lt h), Icc_succ_left_eq_Ioc_of_not_isMax h.not_isMax]
+
+end PartialOrder
+
+section LinearOrder
+variable [LinearOrder α] [SuccOrder α] {a b : α}
+
+/-!
+#### Linear orders possibly with maximal elements
+
+##### Equalities of intervals
+-/
 
 @[to_dual Ioc_pred_left_eq_Icc_of_not_isMin]
 lemma Ico_succ_right_eq_Icc_of_not_isMax (hb : ¬ IsMax b) (a : α) : Ico a (succ b) = Icc a b := by
@@ -71,10 +119,6 @@ lemma Ico_succ_succ_eq_Ioc_of_not_isMax (hb : ¬ IsMax b) (a : α) :
 
 /-! ##### Inserting into intervals -/
 
-@[to_dual insert_Icc_pred_right_eq_Icc]
-lemma insert_Icc_succ_left_eq_Icc (h : a ≤ b) : insert a (Icc (succ a) b) = Icc a b := by
-  ext x; simp [or_and_left, eq_comm, ← le_iff_eq_or_succ_le]; aesop
-
 @[to_dual insert_Icc_left_eq_Icc_pred]
 lemma insert_Icc_right_eq_Icc_succ (h : a ≤ succ b) :
     insert (succ b) (Icc a b) = Icc a (succ b) := by
@@ -83,32 +127,20 @@ lemma insert_Icc_right_eq_Icc_succ (h : a ≤ succ b) :
 @[to_dual insert_Ioc_left_eq_Ioc_pred_of_not_isMin]
 lemma insert_Ico_right_eq_Ico_succ_of_not_isMax (h : a ≤ b) (hb : ¬ IsMax b) :
     insert b (Ico a b) = Ico a (succ b) := by
-  rw [Ico_succ_right_of_not_isMax hb, ← Ico_insert_right h]
-
-@[to_dual insert_Ioc_pred_right_eq_Ioc]
-lemma insert_Ico_succ_left_eq_Ico (h : a < b) : insert a (Ico (succ a) b) = Ico a b := by
-  rw [Ico_succ_left_of_not_isMax h.not_isMax, ← Ioo_insert_left h]
+  rw [Ico_succ_right_eq_Icc_of_not_isMax hb, ← Ico_insert_right h]
 
 @[to_dual insert_Ico_left_eq_Ico_pred_of_not_isMin]
 lemma insert_Ioc_right_eq_Ioc_succ_of_not_isMax (h : a ≤ b) (hb : ¬ IsMax b) :
     insert (succ b) (Ioc a b) = Ioc a (succ b) := by
   ext x; simp +contextual [or_and_left, le_succ_iff_eq_or_le, lt_succ_of_le_of_not_isMax h hb]
 
-@[to_dual insert_Ico_pred_right_eq_Ico]
-lemma insert_Ioc_succ_left_eq_Ioc (h : a < b) : insert (succ a) (Ioc (succ a) b) = Ioc a b := by
-  rw [Ioc_insert_left (succ_le_of_lt h), Icc_succ_left_of_not_isMax h.not_isMax]
-
 /-!
-#### Orders with no maximal elements
+#### Linear orders with no maximal elements
 
 ##### Equalities of intervals
 -/
 
 variable [NoMaxOrder α]
-
-@[to_dual (reorder := a b) Icc_pred_right_eq_Ico]
-lemma Icc_succ_left_eq_Ioc (a b : α) : Icc (succ a) b = Ioc a b :=
-  Icc_succ_left_eq_Ioc_of_not_isMax (not_isMax _) _
 
 @[to_dual (reorder := a b) Ioc_pred_left_eq_Icc]
 lemma Ico_succ_right_eq_Icc (a b : α) : Ico a (succ b) = Icc a b :=
@@ -137,11 +169,12 @@ alias Ioo_pred_left_eq_Ioc_of_not_isMin := Ioo_pred_left_eq_Ico_of_not_isMin
 
 @[deprecated (since := "2026-09-02")] alias Ioo_pred_left_eq_Ioc := Ioo_pred_left_eq_Ico
 
+end LinearOrder
+
 end SuccOrder
 
-
 section SuccPredOrder
-variable [SuccOrder α] [PredOrder α] [Nontrivial α]
+variable [LinearOrder α] [SuccOrder α] [PredOrder α] [Nontrivial α]
 
 @[to_dual self]
 lemma Icc_succ_pred_eq_Ioo (a b : α) : Icc (succ a) (pred b) = Ioo a b := by
@@ -155,11 +188,9 @@ end SuccPredOrder
 /-! ### One-sided intervals -/
 
 section SuccOrder
-variable [SuccOrder α] {a : α}
 
-@[to_dual]
-lemma Iio_succ_eq_Iic_of_not_isMax (hb : ¬ IsMax a) : Iio (succ a) = Iic a := by
-  ext x; rw [mem_Iio, mem_Iic, lt_succ_iff_of_not_isMax hb]
+section Preorder
+variable [Preorder α] [SuccOrder α] {a : α}
 
 @[to_dual]
 lemma Ici_succ_eq_Ioi_of_not_isMax (ha : ¬ IsMax a) : Ici (succ a) = Ioi a := by
@@ -168,10 +199,23 @@ lemma Ici_succ_eq_Ioi_of_not_isMax (ha : ¬ IsMax a) : Ici (succ a) = Ioi a := b
 variable [NoMaxOrder α]
 
 @[to_dual]
-lemma Iio_succ_eq_Iic (a : α) : Iio (succ a) = Iic a := Iio_succ_eq_Iic_of_not_isMax (not_isMax _)
+lemma Ici_succ_eq_Ioi (a : α) : Ici (succ a) = Ioi a := Ici_succ_eq_Ioi_of_not_isMax (not_isMax _)
+
+end Preorder
+
+section LinearOrder
+variable [LinearOrder α] [SuccOrder α] {a : α}
 
 @[to_dual]
-lemma Ici_succ_eq_Ioi (a : α) : Ici (succ a) = Ioi a := Ici_succ_eq_Ioi_of_not_isMax (not_isMax _)
+lemma Iio_succ_eq_Iic_of_not_isMax (hb : ¬ IsMax a) : Iio (succ a) = Iic a := by
+  ext x; rw [mem_Iio, mem_Iic, lt_succ_iff_of_not_isMax hb]
+
+variable [NoMaxOrder α]
+
+@[to_dual]
+lemma Iio_succ_eq_Iic (a : α) : Iio (succ a) = Iic a := Iio_succ_eq_Iic_of_not_isMax (not_isMax _)
+
+end LinearOrder
 
 end SuccOrder
 end Set

--- a/Mathlib/Order/Interval/Set/SuccPred.lean
+++ b/Mathlib/Order/Interval/Set/SuccPred.lean
@@ -38,14 +38,14 @@ variable {α : Type*}
 
 section SuccOrder
 
-section Preorder
-variable [Preorder α] [SuccOrder α] {a b : α}
-
 /-!
-#### Preorders possibly with maximal elements
+#### Orders possibly with maximal elements
 
 ##### Equalities of intervals
 -/
+
+section Preorder
+variable [Preorder α] [SuccOrder α] {a b : α}
 
 @[to_dual (reorder := a b) Ioc_pred_right_eq_Ioo]
 lemma Ico_succ_left_eq_Ioo (a b : α) : Ico (succ a) b = Ioo a b := by
@@ -58,28 +58,30 @@ lemma Ico_succ_left_eq_Ioo (a b : α) : Ico (succ a) b = Ioo a b := by
 lemma Icc_succ_left_eq_Ioc_of_not_isMax (ha : ¬ IsMax a) (b : α) : Icc (succ a) b = Ioc a b := by
   ext x; rw [mem_Icc, mem_Ioc, succ_le_iff_of_not_isMax ha]
 
-/-!
-#### Preorders with no maximal elements
-
-##### Equalities of intervals
--/
-
-variable [NoMaxOrder α]
-
-@[to_dual (reorder := a b) Icc_pred_right_eq_Ico]
-lemma Icc_succ_left_eq_Ioc (a b : α) : Icc (succ a) b = Ioc a b :=
-  Icc_succ_left_eq_Ioc_of_not_isMax (not_isMax _) _
-
 end Preorder
+
+section LinearOrder
+variable [LinearOrder α] [SuccOrder α] {a b : α}
+
+@[to_dual Ioc_pred_left_eq_Icc_of_not_isMin]
+lemma Ico_succ_right_eq_Icc_of_not_isMax (hb : ¬ IsMax b) (a : α) : Ico a (succ b) = Icc a b := by
+  ext x; rw [mem_Ico, mem_Icc, lt_succ_iff_of_not_isMax hb]
+
+@[to_dual Ioo_pred_left_eq_Ico_of_not_isMin]
+lemma Ioo_succ_right_eq_Ioc_of_not_isMax (hb : ¬ IsMax b) (a : α) : Ioo a (succ b) = Ioc a b := by
+  ext x; rw [mem_Ioo, mem_Ioc, lt_succ_iff_of_not_isMax hb]
+
+@[to_dual]
+lemma Ico_succ_succ_eq_Ioc_of_not_isMax (hb : ¬ IsMax b) (a : α) :
+    Ico (succ a) (succ b) = Ioc a b := by
+  rw [Ico_succ_left_eq_Ioo, Ioo_succ_right_eq_Ioc_of_not_isMax hb]
+
+end LinearOrder
+
+/-! ##### Inserting into intervals -/
 
 section PartialOrder
 variable [PartialOrder α] [SuccOrder α] {a b : α}
-
-/-!
-#### Partial orders possibly with maximal elements
-
-##### Inserting into intervals
--/
 
 @[to_dual insert_Icc_pred_right_eq_Icc]
 lemma insert_Icc_succ_left_eq_Icc (h : a ≤ b) : insert a (Icc (succ a) b) = Icc a b := by
@@ -98,27 +100,6 @@ end PartialOrder
 section LinearOrder
 variable [LinearOrder α] [SuccOrder α] {a b : α}
 
-/-!
-#### Linear orders possibly with maximal elements
-
-##### Equalities of intervals
--/
-
-@[to_dual Ioc_pred_left_eq_Icc_of_not_isMin]
-lemma Ico_succ_right_eq_Icc_of_not_isMax (hb : ¬ IsMax b) (a : α) : Ico a (succ b) = Icc a b := by
-  ext x; rw [mem_Ico, mem_Icc, lt_succ_iff_of_not_isMax hb]
-
-@[to_dual Ioo_pred_left_eq_Ico_of_not_isMin]
-lemma Ioo_succ_right_eq_Ioc_of_not_isMax (hb : ¬ IsMax b) (a : α) : Ioo a (succ b) = Ioc a b := by
-  ext x; rw [mem_Ioo, mem_Ioc, lt_succ_iff_of_not_isMax hb]
-
-@[to_dual]
-lemma Ico_succ_succ_eq_Ioc_of_not_isMax (hb : ¬ IsMax b) (a : α) :
-    Ico (succ a) (succ b) = Ioc a b := by
-  rw [Ico_succ_left_eq_Ioo, Ioo_succ_right_eq_Ioc_of_not_isMax hb]
-
-/-! ##### Inserting into intervals -/
-
 @[to_dual insert_Icc_left_eq_Icc_pred]
 lemma insert_Icc_right_eq_Icc_succ (h : a ≤ succ b) :
     insert (succ b) (Icc a b) = Icc a (succ b) := by
@@ -134,13 +115,25 @@ lemma insert_Ioc_right_eq_Ioc_succ_of_not_isMax (h : a ≤ b) (hb : ¬ IsMax b) 
     insert (succ b) (Ioc a b) = Ioc a (succ b) := by
   ext x; simp +contextual [or_and_left, le_succ_iff_eq_or_le, lt_succ_of_le_of_not_isMax h hb]
 
+end LinearOrder
+
 /-!
-#### Linear orders with no maximal elements
+#### Orders with no maximal elements
 
 ##### Equalities of intervals
 -/
 
-variable [NoMaxOrder α]
+section Preorder
+variable [Preorder α] [SuccOrder α] [NoMaxOrder α]
+
+@[to_dual (reorder := a b) Icc_pred_right_eq_Ico]
+lemma Icc_succ_left_eq_Ioc (a b : α) : Icc (succ a) b = Ioc a b :=
+  Icc_succ_left_eq_Ioc_of_not_isMax (not_isMax _) _
+
+end Preorder
+
+section LinearOrder
+variable [LinearOrder α] [SuccOrder α] [NoMaxOrder α]
 
 @[to_dual (reorder := a b) Ioc_pred_left_eq_Icc]
 lemma Ico_succ_right_eq_Icc (a b : α) : Ico a (succ b) = Icc a b :=
@@ -154,7 +147,12 @@ lemma Ioo_succ_right_eq_Ioc (a b : α) : Ioo a (succ b) = Ioc a b :=
 lemma Ico_succ_succ_eq_Ioc (a b : α) : Ico (succ a) (succ b) = Ioc a b :=
   Ico_succ_succ_eq_Ioc_of_not_isMax (not_isMax _) _
 
+end LinearOrder
+
 /-! ##### Inserting into intervals -/
+
+section LinearOrder
+variable [LinearOrder α] [SuccOrder α] {a b : α} [NoMaxOrder α]
 
 @[to_dual insert_Ioc_left_eq_Ioc_pred]
 lemma insert_Ico_right_eq_Ico_succ (h : a ≤ b) : insert b (Ico a b) = Ico a (succ b) :=
@@ -164,12 +162,12 @@ lemma insert_Ico_right_eq_Ico_succ (h : a ≤ b) : insert b (Ico a b) = Ico a (s
 lemma insert_Ioc_right_eq_Ioc_succ (h : a ≤ b) : insert (succ b) (Ioc a b) = Ioc a (succ b) :=
   insert_Ioc_right_eq_Ioc_succ_of_not_isMax h (not_isMax _)
 
+end LinearOrder
+
 @[deprecated (since := "2026-09-02")]
 alias Ioo_pred_left_eq_Ioc_of_not_isMin := Ioo_pred_left_eq_Ico_of_not_isMin
 
 @[deprecated (since := "2026-09-02")] alias Ioo_pred_left_eq_Ioc := Ioo_pred_left_eq_Ico
-
-end LinearOrder
 
 end SuccOrder
 


### PR DESCRIPTION
We generalize five lemmas from `LinearOrder` to `Preorder` and three to `PartialOrder`.

The motivation for the `Preorder` generalizations is to enable deprecation of the almost identical results in `Mathlib/Order/SuccPred/Basic.lean`. The results in that file are stated more generally, so we need to generalize in order to subsume them properly.

---

We're aiming to keep the statements in the touched file rather than those in `SuccPred/Basic.lean` based on [this discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/duplicate.20succ.20interval.20lemmas/with/621955635).

This PR has significant overlap with #23810, but does not cover `Finset/SuccPred.lean`. The touched file in this PR asks to be kept in sync with the `Finset` sibling, but there is already a lot of divergence since the `Finset` file hasn't been treated with `to_dual` yet. I therefore suggest that `Finset/SuccPred.lean` and the other sibling files be brought up to date in a subsequent PR.

The generalizations were performed by Claude Code, and thereafter reviewed and somewhat cleaned up by me.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
