### PR TITLE
chore(Topology/CantorBendixson): cleanup + more basic API

### DIFF
--- a/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
@@ -76,6 +76,9 @@ def lfpApprox (a : Ordinal.{u}) : α :=
   x ⊔ ⨆ b < a, f (lfpApprox b)
 termination_by a
 
+theorem lfpApprox_def (a : Ordinal.{u}) : lfpApprox f x a = x ⊔ ⨆ b < a, f (lfpApprox f x b) := by
+  rw [lfpApprox]
+
 theorem lfpApprox_mono_right : Monotone (lfpApprox f x) := by
   intro a b h
   rw [lfpApprox, lfpApprox]
@@ -259,6 +262,9 @@ termination_by a
 -- By unsealing these recursive definitions we can relate them
 -- by definitional equality
 unseal gfpApprox lfpApprox
+
+theorem gfpApprox_def (a : Ordinal.{u}) : gfpApprox f x a = x ⊓ ⨅ b < a, f (gfpApprox f x b) := by
+  rw [gfpApprox]
 
 theorem gfpApprox_zero : gfpApprox f x 0 = x := by
   exact lfpApprox_zero f.dual

--- a/Mathlib/Topology/CantorBendixson.lean
+++ b/Mathlib/Topology/CantorBendixson.lean
@@ -55,13 +55,11 @@ Cantor-Bendixson derivative sequence of a closed set.
 
 @[expose] public section
 
-open Set Cardinal OrdinalApprox Function
+open Set Cardinal Order OrdinalApprox Function
 
 universe u
 
 namespace CantorBendixson
-
-section
 
 variable {X : Type u} [TopologicalSpace X]
 
@@ -74,106 +72,105 @@ scoped[CantorBendixson] notation:max s "ᵈ[" a "]" => iteratedDerivedSet s a
 
 variable {s t : Set X} {a b : Ordinal}
 
-@[simp]
-theorem iteratedDerivedSet_zero :
-    sᵈ[0] = s := by
-  simp [iteratedDerivedSet, gfpApprox_zero]
+theorem iteratedDerivedSet_def (s : Set X) (a : Ordinal) :
+    sᵈ[a] = s ∩ ⋂ b < a, relDerivedSet sᵈ[b] := by
+  rw [iteratedDerivedSet, gfpApprox_def]
+  rfl
 
 @[simp]
-theorem iteratedDerivedSet_succ :
-    sᵈ[a + 1] = relDerivedSet (sᵈ[a]) := by
-  simpa [iteratedDerivedSet] using
-    gfpApprox_add_one relDerivedSet relDerivedSet_subset a
+theorem iteratedDerivedSet_zero (s : Set X) : sᵈ[0] = s :=
+  gfpApprox_zero ..
 
-theorem iteratedDerivedSet_limit (ha : Order.IsSuccLimit a) :
-    sᵈ[a] = ⋂ b : Set.Iio a, sᵈ[b] := by
+@[simp]
+theorem iteratedDerivedSet_add_one (s : Set X) (a : Ordinal) : sᵈ[a + 1] = relDerivedSet sᵈ[a] :=
+  gfpApprox_add_one _ relDerivedSet_subset a
+
+@[deprecated (since := "2026-09-07")]
+alias iteratedDerivedSet_succ := iteratedDerivedSet_add_one
+
+theorem iteratedDerivedSet_limit (s : Set X) (ha : IsSuccLimit a) : sᵈ[a] = ⋂ b < a, sᵈ[b] := by
   simpa [iteratedDerivedSet] using gfpApprox_of_isSuccLimit relDerivedSet ha
+
+theorem iteratedDerivSet_of_ne_zero (s : Set X) (ha : a ≠ 0) :
+    sᵈ[a] = ⋂ b < a, relDerivedSet sᵈ[b] := by
+  rw [iteratedDerivedSet_def, inter_eq_right]
+  apply (iInter₂_subset 0 ha.pos).trans
+  simp
 
 /-- A set is preperfect if and only if every stage of its iterated relative derived-set sequence
 is equal to the original set. -/
-theorem iteratedDerivedSet_constant_iff_preperfect :
-    Preperfect s ↔ ∀ a : Ordinal, sᵈ[a] = s := by
+theorem iteratedDerivedSet_constant_iff_preperfect : Preperfect s ↔ ∀ a, sᵈ[a] = s := by
   rw [preperfect_iff_eq_relDerivedSet, eq_comm,
-    ← (gfpApprox_eq_all_of_fixedPoint relDerivedSet (relDerivedSet_subset))]
+    ← gfpApprox_eq_all_of_fixedPoint _ relDerivedSet_subset]
   simp [iteratedDerivedSet]
 
-theorem isClosed_iteratedDerivedSet (hs : IsClosed s) :
-    ∀ a : Ordinal, IsClosed sᵈ[a] := by
-  intro a
+theorem isClosed_iteratedDerivedSet (hs : IsClosed s) (a : Ordinal) : IsClosed sᵈ[a] := by
   induction a using Ordinal.limitRecOn with
   | zero => simpa only [iteratedDerivedSet_zero]
   | add_one a ha =>
     simp_all [ha.relDerivedSet_eq, isClosed_iff_derivedSet_subset, derivedSet_mono]
   | limit a ha ih =>
-    simpa [iteratedDerivedSet_limit ha] using
+    simpa [iteratedDerivedSet_limit s ha] using
       isClosed_iInter fun i => isClosed_iInter fun hi => ih i hi
 
-theorem iteratedDerivedSet_antitone (s : Set X) :
-    Antitone (iteratedDerivedSet s) := gfpApprox_anti_right relDerivedSet
+theorem iteratedDerivedSet_antitone (s : Set X) : Antitone (iteratedDerivedSet s) :=
+  gfpApprox_anti_right relDerivedSet
 
-theorem iteratedDerivedSet_mono :
-    Monotone (fun s : Set X => iteratedDerivedSet s) :=
+theorem iteratedDerivedSet_monotone : Monotone (iteratedDerivedSet (X := X)) :=
   gfpApprox_mono_mid _
 
-/-- If the iterated derived set stops changing at a successor stage, then `sᵈ[a]` is a fixed
-point of `relDerivSet`. -/
+@[deprecated (since := "2026-09-07")]
+alias iteratedDerivedSet_mono := iteratedDerivedSet_monotone
+
+@[deprecated iteratedDerivedSet_succ (since := "2026-09-07")]
 theorem mem_fixedPoints_of_iteratedDerivedSet_succ_eq (ha : sᵈ[a + 1] = sᵈ[a]) :
     sᵈ[a] ∈ fixedPoints relDerivedSet := by
-  rw [Function.mem_fixedPoints_iff]
-  simpa [iteratedDerivedSet_succ] using ha.symm
+  rwa [Function.mem_fixedPoints_iff, ← iteratedDerivedSet_succ]
 
 theorem iteratedDerivedSet_mem_fixedPoints (s : Set X) :
-    ∃ a : Ordinal, sᵈ[a] ∈ fixedPoints relDerivedSet := by
-  refine ⟨(Order.succ #(Set X)).ord,
-    gfpApprox_ord_mem_fixedPoint relDerivedSet relDerivedSet_subset⟩
+    ∃ a : Ordinal, sᵈ[a] ∈ fixedPoints relDerivedSet :=
+  ⟨_, gfpApprox_ord_mem_fixedPoint relDerivedSet relDerivedSet_subset⟩
 
 /-- The perfect kernel of a set, defined as the intersection of all iterated derived sets. It is
 the largest perfect subset of the original set. -/
 def perfectKernel (s : Set X) : Set X :=
-  ⋂ a : Ordinal, sᵈ[a]
+  ⋂ a, sᵈ[a]
 
 theorem perfectKernel_subset_iteratedDerivedSet (s : Set X) (a : Ordinal) :
     perfectKernel s ⊆ sᵈ[a] :=
-  Set.iInter_subset _ a
+  iInter_subset _ a
 
-theorem perfectKernel_subset (s : Set X) :
-    perfectKernel s ⊆ s := by
+theorem perfectKernel_subset (s : Set X) : perfectKernel s ⊆ s := by
   simpa [iteratedDerivedSet_zero] using perfectKernel_subset_iteratedDerivedSet s 0
 
-theorem perfectKernel_mono (hst : s ⊆ t) :
-    perfectKernel s ⊆ perfectKernel t := by
-  simpa [perfectKernel] using Set.iInter_mono'' (iteratedDerivedSet_mono hst)
+theorem perfectKernel_mono (hst : s ⊆ t) : perfectKernel s ⊆ perfectKernel t := by
+  simpa [perfectKernel] using iInter_mono'' (iteratedDerivedSet_monotone hst)
 
-theorem isClosed_perfectKernel (hs : IsClosed s) :
-    IsClosed (perfectKernel s) :=
+theorem isClosed_perfectKernel (hs : IsClosed s) : IsClosed (perfectKernel s) :=
   isClosed_iInter (isClosed_iteratedDerivedSet hs)
 
 @[simp]
-theorem perfectKernel_empty :
-    perfectKernel (∅ : Set X) = ∅ := by
+theorem perfectKernel_empty : perfectKernel (∅ : Set X) = ∅ := by
   simpa using perfectKernel_subset ∅
 
 /-- Once `sᵈ[a]` is a fixed point of `relDerivSet`, the perfect kernel equals `sᵈ[a]`. -/
 theorem perfectKernel_eq_iteratedDerivedSet_of_mem_fixedPoints
-    (ha : sᵈ[a] ∈ fixedPoints relDerivedSet) :
-    perfectKernel s = sᵈ[a] := by
+    (ha : sᵈ[a] ∈ fixedPoints relDerivedSet) : perfectKernel s = sᵈ[a] := by
   refine le_antisymm (perfectKernel_subset_iteratedDerivedSet s a) ?_
-  refine Set.subset_iInter fun i => ?_
+  refine subset_iInter fun i => ?_
   rcases lt_or_ge i a with hi | hi
   · exact iteratedDerivedSet_antitone s hi.le
   · exact (gfpApprox_eq_of_mem_fixedPoints relDerivedSet hi ha).ge
 
 /-- Every perfect subset of a set is contained in its perfect kernel. -/
-theorem _root_.Perfect.subset_perfectKernel
-    {P : Set X} (hP : Perfect P) (hPs : P ⊆ s) :
+theorem _root_.Perfect.subset_perfectKernel {P : Set X} (hP : Perfect P) (hPs : P ⊆ s) :
     P ⊆ perfectKernel s := by
-  refine Set.subset_iInter fun i => ?_
+  refine subset_iInter fun i => ?_
   simpa [iteratedDerivedSet_constant_iff_preperfect.mp hP.acc i] using
-    iteratedDerivedSet_mono hPs i
+    iteratedDerivedSet_monotone hPs i
 
 /-- The perfect kernel of a closed set is perfect. -/
-theorem perfect_perfectKernel (hs : IsClosed s) :
-    Perfect (perfectKernel s) := by
+theorem perfect_perfectKernel (hs : IsClosed s) : Perfect (perfectKernel s) := by
   obtain ⟨a, ha⟩ := iteratedDerivedSet_mem_fixedPoints s
   rw [perfectKernel_eq_iteratedDerivedSet_of_mem_fixedPoints ha]
   refine perfect_iff_eq_derivedSet.mpr ?_
@@ -181,11 +178,8 @@ theorem perfect_perfectKernel (hs : IsClosed s) :
     (Function.mem_fixedPoints_iff.mp ha).symm
 
 /-- Taking the perfect kernel of a closed set is idempotent. -/
-theorem perfectKernel_idem (hs : IsClosed s) :
-    perfectKernel (perfectKernel s) = perfectKernel s :=
+theorem perfectKernel_idem (hs : IsClosed s) : perfectKernel (perfectKernel s) = perfectKernel s :=
   subset_antisymm (perfectKernel_subset _) <|
     (perfect_perfectKernel hs).subset_perfectKernel Subset.rfl
-
-end
 
 end CantorBendixson

--- a/Mathlib/Topology/DerivedSet.lean
+++ b/Mathlib/Topology/DerivedSet.lean
@@ -51,8 +51,9 @@ def relDerivedSet : Set X →o Set X where
   toFun s := derivedSet s ∩ s
   monotone' s t h := Set.inter_subset_inter (derivedSet_mono s t h) h
 
-@[simp] lemma relDerivedSet_apply (A : Set X) : relDerivedSet A = derivedSet A ∩ A := rfl
+lemma relDerivedSet_apply (A : Set X) : relDerivedSet A = derivedSet A ∩ A := rfl
 
+@[simp]
 lemma relDerivedSet_subset {A : Set X} : relDerivedSet A ⊆ A :=
   Set.inter_subset_right
 
@@ -80,7 +81,7 @@ lemma isClosed_iff_derivedSet_subset (A : Set X) : IsClosed A ↔ derivedSet A �
 
 lemma IsClosed.relDerivedSet_eq {A : Set X} (hA : IsClosed A) :
     relDerivedSet A = derivedSet A := by
-  simpa using (isClosed_iff_derivedSet_subset A).mp hA
+  simpa [relDerivedSet_apply] using (isClosed_iff_derivedSet_subset A).mp hA
 
 lemma closure_eq_self_union_derivedSet (A : Set X) : closure A = A ∪ derivedSet A := by
   ext
@@ -110,7 +111,7 @@ lemma preperfect_iff_subset_derivedSet {U : Set X} : Preperfect U ↔ U ⊆ deri
   Iff.rfl
 
 lemma preperfect_iff_eq_relDerivedSet {U : Set X} : Preperfect U ↔ U = relDerivedSet U := by
-  simp [preperfect_iff_subset_derivedSet]
+  simp [relDerivedSet_apply, preperfect_iff_subset_derivedSet]
 
 lemma perfect_iff_eq_derivedSet {U : Set X} : Perfect U ↔ U = derivedSet U := by
   rw [perfect_def, isClosed_iff_derivedSet_subset, preperfect_iff_subset_derivedSet,


### PR DESCRIPTION
We perform various small golfs, make some variables explicit, and add a few trivial lemmas.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I would've suggested all of this in #37375, but somehow that PR went under my radar.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
