### PR TITLE
feat(Order): `SupClosed`/`DirSupClosed`/`DirectedOn`/etc for set intervals

### DIFF
--- a/Mathlib/Order/CountableSupClosed.lean
+++ b/Mathlib/Order/CountableSupClosed.lean
@@ -139,6 +139,36 @@ protected lemma CountableSupClosed.prod [Preorder α] [Preorder β]
     exact ⟨hs.isLUB_mem (Prod.fst '' A) (by grind) (by simpa) (hAc.image Prod.fst) _ hxy.1,
       ht.isLUB_mem (Prod.snd '' A) (by grind) (by simpa) (hAc.image Prod.snd) _ hxy.2⟩
 
+@[to_dual]
+theorem IsUpperSet.countableSupClosed [LE α] (h : IsUpperSet s) : CountableSupClosed s where
+  isLUB_mem := fun _ hsubset ⟨_, hmem⟩ _ _ hlub ↦ h (hlub.left hmem) (hsubset hmem)
+
+section Preorder
+
+variable [Preorder α]
+
+@[to_dual]
+theorem CountableSupClosed.Ioi (a : α) : CountableSupClosed (Ioi a) :=
+  isUpperSet_Ioi a |>.countableSupClosed
+
+@[to_dual]
+theorem CountableSupClosed.Ici (a : α) : CountableSupClosed (Ici a) :=
+  isUpperSet_Ici a |>.countableSupClosed
+
+@[to_dual]
+theorem CountableSupClosed.Iic (a : α) : CountableSupClosed (Iic a) where
+  isLUB_mem := fun _ hsubset _ _ _ hlub ↦ hlub.right hsubset
+
+@[to_dual]
+theorem CountableSupClosed.Ioc (a b : α) : CountableSupClosed (Ioc a b) :=
+  .inter (.Ioi a) (.Iic b)
+
+@[to_dual]
+theorem CountableSupClosed.Icc (a b : α) : CountableSupClosed (Icc a b) :=
+  .inter (.Ici a) (.Iic b)
+
+end Preorder
+
 end Set
 
 section Finset

--- a/Mathlib/Order/CountableSupClosed.lean
+++ b/Mathlib/Order/CountableSupClosed.lean
@@ -148,23 +148,23 @@ section Preorder
 variable [Preorder α]
 
 @[to_dual]
-theorem CountableSupClosed.Ioi (a : α) : CountableSupClosed (Ioi a) :=
+protected theorem CountableSupClosed.Ioi (a : α) : CountableSupClosed (Ioi a) :=
   isUpperSet_Ioi a |>.countableSupClosed
 
 @[to_dual]
-theorem CountableSupClosed.Ici (a : α) : CountableSupClosed (Ici a) :=
+protected theorem CountableSupClosed.Ici (a : α) : CountableSupClosed (Ici a) :=
   isUpperSet_Ici a |>.countableSupClosed
 
 @[to_dual]
-theorem CountableSupClosed.Iic (a : α) : CountableSupClosed (Iic a) where
+protected theorem CountableSupClosed.Iic (a : α) : CountableSupClosed (Iic a) where
   isLUB_mem := fun _ hsubset _ _ _ hlub ↦ hlub.right hsubset
 
 @[to_dual]
-theorem CountableSupClosed.Ioc (a b : α) : CountableSupClosed (Ioc a b) :=
+protected theorem CountableSupClosed.Ioc (a b : α) : CountableSupClosed (Ioc a b) :=
   .inter (.Ioi a) (.Iic b)
 
 @[to_dual]
-theorem CountableSupClosed.Icc (a b : α) : CountableSupClosed (Icc a b) :=
+protected theorem CountableSupClosed.Icc (a b : α) : CountableSupClosed (Icc a b) :=
   .inter (.Ici a) (.Iic b)
 
 end Preorder

--- a/Mathlib/Order/DirSupClosed.lean
+++ b/Mathlib/Order/DirSupClosed.lean
@@ -249,17 +249,55 @@ theorem DirSupInacc.mem_iff_of_antisymmRel (hs : DirSupInacc s) {a b : α}
     (h : AntisymmRel (· ≤ ·) a b) : a ∈ s ↔ b ∈ s := by
   simpa [not_iff_not] using hs.compl.mem_iff_of_antisymmRel h
 
-lemma dirSupClosed_Iic (a : α) : DirSupClosed (Iic a) :=
+lemma DirSupClosed.Iic (a : α) : DirSupClosed (Iic a) :=
   fun _d h _ _ _a ha ↦ (isLUB_le_iff ha).2 h
 
-lemma dirSupClosedOn_Iic (a : α) : DirSupClosedOn D (Iic a) :=
-  (dirSupClosed_Iic a).dirSupClosedOn
+@[deprecated (since := "2026-09-07")] alias dirSupClosed_Iic := DirSupClosed.Iic
 
-lemma dirSupInacc_Iic (a : α) : DirSupInacc (Iic a) :=
+lemma DirSupClosedOn.Iic (a : α) : DirSupClosedOn D (Iic a) :=
+  (DirSupClosed.Iic a).dirSupClosedOn
+
+@[deprecated (since := "2026-09-07")] alias dirSupClosedOn_Iic := DirSupClosedOn.Iic
+
+theorem DirSupClosed.Ici (a : α) : DirSupClosed (Ici a) :=
+  isUpperSet_Ici a |>.dirSupClosed
+
+theorem DirSupClosedOn.Ici (a : α) : DirSupClosedOn D (Ici a) :=
+  DirSupClosed.Ici a |>.dirSupClosedOn
+
+theorem DirSupClosed.Ioi (a : α) : DirSupClosed (Ioi a) :=
+  isUpperSet_Ioi a |>.dirSupClosed
+
+theorem DirSupClosedOn.Ioi (a : α) : DirSupClosedOn D (Ioi a) :=
+  DirSupClosed.Ioi a |>.dirSupClosedOn
+
+theorem DirSupClosed.Ioc (a b : α) : DirSupClosed (Ioc a b) :=
+  .inter (.Ioi a) (.Iic b)
+
+theorem DirSupClosedOn.Ioc (a b : α) : DirSupClosedOn D (Ioc a b) :=
+  DirSupClosed.Ioc a b |>.dirSupClosedOn
+
+theorem DirSupClosed.Icc (a b : α) : DirSupClosed (Icc a b) :=
+  .inter (.Ici a) (.Iic b)
+
+theorem DirSupClosedOn.Icc (a b : α) : DirSupClosedOn D (Icc a b) :=
+  DirSupClosed.Icc a b |>.dirSupClosedOn
+
+theorem DirSupInacc.Iio (a : α) : DirSupInacc (Iio a) :=
+  fun _ ⟨b, hb⟩ _ _ hlub hlt ↦ ⟨b, hb, hlub.left hb |>.trans_lt hlt⟩
+
+theorem DirSupInaccOn.Iio (a : α) : DirSupInaccOn D (Iio a) :=
+  DirSupInacc.Iio a |>.dirSupInaccOn
+
+lemma DirSupInacc.Iic (a : α) : DirSupInacc (Iic a) :=
   (isLowerSet_Iic a).dirSupInacc
 
-lemma dirSupInaccOn_Iic (a : α) : DirSupInaccOn D (Iic a) :=
+@[deprecated (since := "2026-09-07")] alias dirSupInacc_Iic := DirSupInacc.Iic
+
+lemma DirSupInaccOn.Iic (a : α) : DirSupInaccOn D (Iic a) :=
   (isLowerSet_Iic a).dirSupInaccOn
+
+@[deprecated (since := "2026-09-07")] alias dirSupInaccOn_Iic := DirSupInaccOn.Iic
 
 end Preorder
 
@@ -296,6 +334,24 @@ theorem dirSupInaccOn_iff_of_linearOrder :
 theorem dirSupInacc_iff_of_linearOrder :
     DirSupInacc s ↔ ∀ ⦃d⦄, d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty := by
   simp [DirSupInacc]
+
+theorem DirSupInacc.Ioi (a : α) : DirSupInacc (Ioi a) := by
+  simpa using DirSupClosed.Iic a |>.compl
+
+theorem DirSupInaccOn.Ioi (a : α) : DirSupInaccOn D (Ioi a) :=
+  DirSupInacc.Ioi a |>.dirSupInaccOn
+
+theorem DirSupInacc.Ioo (a b : α) : DirSupInacc (Ioo a b) :=
+  .inter (.Ioi a) (.Iio b)
+
+theorem DirSupInaccOn.Ioo (a b : α) : DirSupInaccOn D (Ioo a b) :=
+  DirSupInacc.Ioo a b |>.dirSupInaccOn
+
+theorem DirSupInacc.Ioc (a b : α) : DirSupInacc (Ioc a b) :=
+  .inter (.Ioi a) (.Iic b)
+
+theorem DirSupInaccOn.Ioc (a b : α) : DirSupInaccOn D (Ioc a b) :=
+  DirSupInacc.Ioc a b |>.dirSupInaccOn
 
 end LinearOrder
 

--- a/Mathlib/Order/DirSupClosed.lean
+++ b/Mathlib/Order/DirSupClosed.lean
@@ -249,52 +249,52 @@ theorem DirSupInacc.mem_iff_of_antisymmRel (hs : DirSupInacc s) {a b : α}
     (h : AntisymmRel (· ≤ ·) a b) : a ∈ s ↔ b ∈ s := by
   simpa [not_iff_not] using hs.compl.mem_iff_of_antisymmRel h
 
-lemma DirSupClosed.Iic (a : α) : DirSupClosed (Iic a) :=
+protected lemma DirSupClosed.Iic (a : α) : DirSupClosed (Iic a) :=
   fun _d h _ _ _a ha ↦ (isLUB_le_iff ha).2 h
 
 @[deprecated (since := "2026-09-07")] alias dirSupClosed_Iic := DirSupClosed.Iic
 
-lemma DirSupClosedOn.Iic (a : α) : DirSupClosedOn D (Iic a) :=
+protected lemma DirSupClosedOn.Iic (a : α) : DirSupClosedOn D (Iic a) :=
   (DirSupClosed.Iic a).dirSupClosedOn
 
 @[deprecated (since := "2026-09-07")] alias dirSupClosedOn_Iic := DirSupClosedOn.Iic
 
-theorem DirSupClosed.Ici (a : α) : DirSupClosed (Ici a) :=
+protected theorem DirSupClosed.Ici (a : α) : DirSupClosed (Ici a) :=
   isUpperSet_Ici a |>.dirSupClosed
 
-theorem DirSupClosedOn.Ici (a : α) : DirSupClosedOn D (Ici a) :=
+protected theorem DirSupClosedOn.Ici (a : α) : DirSupClosedOn D (Ici a) :=
   DirSupClosed.Ici a |>.dirSupClosedOn
 
-theorem DirSupClosed.Ioi (a : α) : DirSupClosed (Ioi a) :=
+protected theorem DirSupClosed.Ioi (a : α) : DirSupClosed (Ioi a) :=
   isUpperSet_Ioi a |>.dirSupClosed
 
-theorem DirSupClosedOn.Ioi (a : α) : DirSupClosedOn D (Ioi a) :=
+protected theorem DirSupClosedOn.Ioi (a : α) : DirSupClosedOn D (Ioi a) :=
   DirSupClosed.Ioi a |>.dirSupClosedOn
 
-theorem DirSupClosed.Ioc (a b : α) : DirSupClosed (Ioc a b) :=
+protected theorem DirSupClosed.Ioc (a b : α) : DirSupClosed (Ioc a b) :=
   .inter (.Ioi a) (.Iic b)
 
-theorem DirSupClosedOn.Ioc (a b : α) : DirSupClosedOn D (Ioc a b) :=
+protected theorem DirSupClosedOn.Ioc (a b : α) : DirSupClosedOn D (Ioc a b) :=
   DirSupClosed.Ioc a b |>.dirSupClosedOn
 
-theorem DirSupClosed.Icc (a b : α) : DirSupClosed (Icc a b) :=
+protected theorem DirSupClosed.Icc (a b : α) : DirSupClosed (Icc a b) :=
   .inter (.Ici a) (.Iic b)
 
-theorem DirSupClosedOn.Icc (a b : α) : DirSupClosedOn D (Icc a b) :=
+protected theorem DirSupClosedOn.Icc (a b : α) : DirSupClosedOn D (Icc a b) :=
   DirSupClosed.Icc a b |>.dirSupClosedOn
 
-theorem DirSupInacc.Iio (a : α) : DirSupInacc (Iio a) :=
+protected theorem DirSupInacc.Iio (a : α) : DirSupInacc (Iio a) :=
   fun _ ⟨b, hb⟩ _ _ hlub hlt ↦ ⟨b, hb, hlub.left hb |>.trans_lt hlt⟩
 
-theorem DirSupInaccOn.Iio (a : α) : DirSupInaccOn D (Iio a) :=
+protected theorem DirSupInaccOn.Iio (a : α) : DirSupInaccOn D (Iio a) :=
   DirSupInacc.Iio a |>.dirSupInaccOn
 
-lemma DirSupInacc.Iic (a : α) : DirSupInacc (Iic a) :=
+protected lemma DirSupInacc.Iic (a : α) : DirSupInacc (Iic a) :=
   (isLowerSet_Iic a).dirSupInacc
 
 @[deprecated (since := "2026-09-07")] alias dirSupInacc_Iic := DirSupInacc.Iic
 
-lemma DirSupInaccOn.Iic (a : α) : DirSupInaccOn D (Iic a) :=
+protected lemma DirSupInaccOn.Iic (a : α) : DirSupInaccOn D (Iic a) :=
   (isLowerSet_Iic a).dirSupInaccOn
 
 @[deprecated (since := "2026-09-07")] alias dirSupInaccOn_Iic := DirSupInaccOn.Iic
@@ -335,22 +335,22 @@ theorem dirSupInacc_iff_of_linearOrder :
     DirSupInacc s ↔ ∀ ⦃d⦄, d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty := by
   simp [DirSupInacc]
 
-theorem DirSupInacc.Ioi (a : α) : DirSupInacc (Ioi a) := by
+protected theorem DirSupInacc.Ioi (a : α) : DirSupInacc (Ioi a) := by
   simpa using DirSupClosed.Iic a |>.compl
 
-theorem DirSupInaccOn.Ioi (a : α) : DirSupInaccOn D (Ioi a) :=
+protected theorem DirSupInaccOn.Ioi (a : α) : DirSupInaccOn D (Ioi a) :=
   DirSupInacc.Ioi a |>.dirSupInaccOn
 
-theorem DirSupInacc.Ioo (a b : α) : DirSupInacc (Ioo a b) :=
+protected theorem DirSupInacc.Ioo (a b : α) : DirSupInacc (Ioo a b) :=
   .inter (.Ioi a) (.Iio b)
 
-theorem DirSupInaccOn.Ioo (a b : α) : DirSupInaccOn D (Ioo a b) :=
+protected theorem DirSupInaccOn.Ioo (a b : α) : DirSupInaccOn D (Ioo a b) :=
   DirSupInacc.Ioo a b |>.dirSupInaccOn
 
-theorem DirSupInacc.Ioc (a b : α) : DirSupInacc (Ioc a b) :=
+protected theorem DirSupInacc.Ioc (a b : α) : DirSupInacc (Ioc a b) :=
   .inter (.Ioi a) (.Iic b)
 
-theorem DirSupInaccOn.Ioc (a b : α) : DirSupInaccOn D (Ioc a b) :=
+protected theorem DirSupInaccOn.Ioc (a b : α) : DirSupInaccOn D (Ioc a b) :=
   DirSupInacc.Ioc a b |>.dirSupInaccOn
 
 end LinearOrder

--- a/Mathlib/Order/Interval/Set/Image.lean
+++ b/Mathlib/Order/Interval/Set/Image.lean
@@ -431,22 +431,33 @@ end Set
 section Preorder
 variable [Preorder α]
 
-lemma directedOn_le_Iic (b : α) : DirectedOn (· ≤ ·) (Iic b) :=
+@[to_dual ge_Ici]
+lemma DirectedOn.le_Iic (b : α) : DirectedOn (· ≤ ·) (Iic b) :=
   fun _x hx _y hy ↦ ⟨b, le_rfl, hx, hy⟩
 
-lemma directedOn_le_Icc (a b : α) : DirectedOn (· ≤ ·) (Icc a b) :=
+@[to_dual (attr := deprecated (since := "2026-09-07")) directedOn_ge_Ici]
+alias directedOn_le_Iic := DirectedOn.le_Iic
+
+@[to_dual (reorder := a b) ge_Icc]
+lemma DirectedOn.le_Icc (a b : α) : DirectedOn (· ≤ ·) (Icc a b) :=
   fun _x hx _y hy ↦ ⟨b, right_mem_Icc.2 <| hx.1.trans hx.2, hx.2, hy.2⟩
 
-lemma directedOn_le_Ioc (a b : α) : DirectedOn (· ≤ ·) (Ioc a b) :=
+@[to_dual (attr := deprecated (since := "2026-09-07")) directedOn_ge_Icc]
+alias directedOn_le_Icc := DirectedOn.le_Icc
+
+@[to_dual (reorder := a b) ge_Ico]
+lemma DirectedOn.le_Ioc (a b : α) : DirectedOn (· ≤ ·) (Ioc a b) :=
   fun _x hx _y hy ↦ ⟨b, right_mem_Ioc.2 <| hx.1.trans_le hx.2, hx.2, hy.2⟩
 
-lemma directedOn_ge_Ici (a : α) : DirectedOn (· ≥ ·) (Ici a) :=
-  fun _x hx _y hy ↦ ⟨a, le_rfl, hx, hy⟩
+@[to_dual (attr := deprecated (since := "2026-09-07")) directedOn_ge_Ico]
+alias directedOn_le_Ioc := DirectedOn.le_Ioc
 
-lemma directedOn_ge_Icc (a b : α) : DirectedOn (· ≥ ·) (Icc a b) :=
-  fun _x hx _y hy ↦ ⟨a, left_mem_Icc.2 <| hx.1.trans hx.2, hx.1, hy.1⟩
+@[to_dual ge_Iio]
+theorem DirectedOn.le_Ioi [IsDirectedOrder α] (a : α) : DirectedOn (· ≤ ·) (Ioi a) :=
+  fun b hb c _ ↦ exists_ge_ge b c |>.imp fun _ ⟨hb', hc'⟩ ↦ ⟨hb.trans_le hb', hb', hc'⟩
 
-lemma directedOn_ge_Ico (a b : α) : DirectedOn (· ≥ ·) (Ico a b) :=
-  fun _x hx _y hy ↦ ⟨a, left_mem_Ico.2 <| hx.1.trans_lt hx.2, hx.1, hy.1⟩
+@[to_dual ge_Iic]
+theorem DirectedOn.le_Ici [IsDirectedOrder α] (a : α) : DirectedOn (· ≤ ·) (Ici a) :=
+  fun b hb c _ ↦ exists_ge_ge b c |>.imp fun _ ⟨hb', hc'⟩ ↦ ⟨hb.trans hb', hb', hc'⟩
 
 end Preorder

--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -10,6 +10,7 @@ public import Mathlib.Data.Finset.Powerset
 public import Mathlib.Data.Set.Finite.Basic
 public import Mathlib.Order.Closure
 public import Mathlib.Order.ConditionallyCompleteLattice.Finset
+public import Mathlib.Order.UpperLower.Basic
 
 /-!
 # Sets closed under join/meet
@@ -118,6 +119,26 @@ lemma SupClosed.insert_lowerBounds {s : Set α} {a : α} (h : SupClosed s) (ha :
   rw [SupClosed]
   have ha' : ∀ b ∈ s, a ≤ b := fun _ a ↦ ha a
   aesop
+
+@[to_dual]
+theorem SupClosed.Ioi (a : α) : SupClosed (Ioi a) :=
+  isUpperSet_Ioi a |>.supClosed
+
+@[to_dual]
+theorem SupClosed.Ici (a : α) : SupClosed (Ici a) :=
+  isUpperSet_Ici a |>.supClosed
+
+@[to_dual]
+theorem SupClosed.Iic (a : α) : SupClosed (Iic a) :=
+  DirectedOn.supClosed_of_isLowerSet (isLowerSet_Iic a) (.le_Iic a)
+
+@[to_dual]
+theorem SupClosed.Ioc (a b : α) : SupClosed (Ioc a b) :=
+  .inter (.Ioi a) (.Iic b)
+
+@[to_dual]
+theorem SupClosed.Icc (a b : α) : SupClosed (Icc a b) :=
+  .inter (.Ici a) (.Iic b)
 
 end Set
 

--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -121,23 +121,23 @@ lemma SupClosed.insert_lowerBounds {s : Set α} {a : α} (h : SupClosed s) (ha :
   aesop
 
 @[to_dual]
-theorem SupClosed.Ioi (a : α) : SupClosed (Ioi a) :=
+protected theorem SupClosed.Ioi (a : α) : SupClosed (Ioi a) :=
   isUpperSet_Ioi a |>.supClosed
 
 @[to_dual]
-theorem SupClosed.Ici (a : α) : SupClosed (Ici a) :=
+protected theorem SupClosed.Ici (a : α) : SupClosed (Ici a) :=
   isUpperSet_Ici a |>.supClosed
 
 @[to_dual]
-theorem SupClosed.Iic (a : α) : SupClosed (Iic a) :=
+protected theorem SupClosed.Iic (a : α) : SupClosed (Iic a) :=
   DirectedOn.supClosed_of_isLowerSet (isLowerSet_Iic a) (.le_Iic a)
 
 @[to_dual]
-theorem SupClosed.Ioc (a b : α) : SupClosed (Ioc a b) :=
+protected theorem SupClosed.Ioc (a b : α) : SupClosed (Ioc a b) :=
   .inter (.Ioi a) (.Iic b)
 
 @[to_dual]
-theorem SupClosed.Icc (a b : α) : SupClosed (Icc a b) :=
+protected theorem SupClosed.Icc (a b : α) : SupClosed (Icc a b) :=
   .inter (.Ici a) (.Iic b)
 
 end Set

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -138,6 +138,45 @@ theorem isOpen_of_isLowerSet (hDL : IsLowerSet D) (h : IsLowerSet s) : IsOpen s 
 theorem isClosed_of_isUpperSet (hDL : IsLowerSet D) (h : IsUpperSet s) : IsClosed s :=
   (isClosed_iff_dirSupClosedOn hDL).2 h.dirSupClosedOn
 
+theorem IsOpen.Iio_of_isLowerSet (h : IsLowerSet D) (a : α) : IsOpen (Iio a) :=
+  isOpen_iff_dirSupInaccOn h |>.mpr <| .Iio a
+
+theorem IsOpen.Iic_of_isLowerSet (h : IsLowerSet D) (a : α) : IsOpen (Iic a) :=
+  isOpen_iff_dirSupInaccOn h |>.mpr <| .Iic a
+
+theorem IsOpen.Ioi_of_isLowerSet {α : Type*} [LinearOrder α] [TopologicalSpace α] {D : Set (Set α)}
+    [IsScottHausdorff α D] (h : IsLowerSet D) (a : α) : IsOpen (Ioi a) :=
+  isOpen_iff_dirSupInaccOn h |>.mpr <| .Ioi a
+
+theorem IsOpen.Ioo_of_isLowerSet {α : Type*} [LinearOrder α] [TopologicalSpace α] {D : Set (Set α)}
+    [IsScottHausdorff α D] (h : IsLowerSet D) (a b : α) : IsOpen (Ioo a b) :=
+  isOpen_iff_dirSupInaccOn h |>.mpr <| .Ioo a b
+
+theorem IsOpen.Ioc_of_isLowerSet {α : Type*} [LinearOrder α] [TopologicalSpace α] {D : Set (Set α)}
+    [IsScottHausdorff α D] (h : IsLowerSet D) (a b : α) : IsOpen (Ioc a b) :=
+  isOpen_iff_dirSupInaccOn h |>.mpr <| .Ioc a b
+
+theorem IsClosed.Iic_of_isLowerSet (h : IsLowerSet D) (a : α) : IsClosed (Iic a) :=
+  isClosed_iff_dirSupClosedOn h |>.mpr <| .Iic a
+
+theorem IsClosed.Ici_of_isLowerSet (h : IsLowerSet D) (a : α) : IsClosed (Ici a) :=
+  isClosed_iff_dirSupClosedOn h |>.mpr <| .Ici a
+
+theorem IsClosed.Ioi_of_isLowerSet (h : IsLowerSet D) (a : α) : IsClosed (Ioi a) :=
+  isClosed_iff_dirSupClosedOn h |>.mpr <| .Ioi a
+
+theorem IsClosed.Ioc_of_isLowerSet (h : IsLowerSet D) (a b : α) : IsClosed (Ioc a b) :=
+  isClosed_iff_dirSupClosedOn h |>.mpr <| .Ioc a b
+
+theorem IsClosed.Icc_of_isLowerSet (h : IsLowerSet D) (a b : α) : IsClosed (Icc a b) :=
+  isClosed_iff_dirSupClosedOn h |>.mpr <| .Icc a b
+
+theorem ClosedIicTopology.of_isLowerSet (h : IsLowerSet D) : ClosedIicTopology α where
+  isClosed_Iic := IsClosed.Iic_of_isLowerSet h
+
+theorem ClosedIciTopology.of_isLowerSet (h : IsLowerSet D) : ClosedIciTopology α where
+  isClosed_Ici := IsClosed.Ici_of_isLowerSet h
+
 end General
 
 section univ
@@ -149,6 +188,45 @@ theorem isOpen_iff_dirSupInacc : IsOpen s ↔ DirSupInacc s := by
 
 theorem isClosed_iff_dirSupClosed : IsClosed s ↔ DirSupClosed s := by
   rw [isClosed_iff_dirSupClosedOn isLowerSet_univ, dirSupClosedOn_univ]
+
+theorem IsOpen.Iio (a : α) : IsOpen (Iio a) :=
+  isOpen_iff_dirSupInacc.mpr <| .Iio a
+
+theorem IsOpen.Iic (a : α) : IsOpen (Iic a) :=
+  isOpen_iff_dirSupInacc.mpr <| .Iic a
+
+theorem IsOpen.Ioi {α : Type*} [LinearOrder α] [TopologicalSpace α] [IsScottHausdorff α univ]
+    (a : α) : IsOpen (Ioi a) :=
+  isOpen_iff_dirSupInacc.mpr <| .Ioi a
+
+theorem IsOpen.Ioo {α : Type*} [LinearOrder α] [TopologicalSpace α] [IsScottHausdorff α univ]
+    (a b : α) : IsOpen (Ioo a b) :=
+  isOpen_iff_dirSupInacc.mpr <| .Ioo a b
+
+theorem IsOpen.Ioc {α : Type*} [LinearOrder α] [TopologicalSpace α] [IsScottHausdorff α univ]
+    (a b : α) : IsOpen (Ioc a b) :=
+  isOpen_iff_dirSupInacc.mpr <| .Ioc a b
+
+theorem IsClosed.Iic (a : α) : IsClosed (Iic a) :=
+  isClosed_iff_dirSupClosed.mpr <| .Iic a
+
+theorem IsClosed.Ici (a : α) : IsClosed (Ici a) :=
+  isClosed_iff_dirSupClosed.mpr <| .Ici a
+
+theorem IsClosed.Ioi (a : α) : IsClosed (Ioi a) :=
+  isClosed_iff_dirSupClosed.mpr <| .Ioi a
+
+theorem IsClosed.Ioc (a b : α) : IsClosed (Ioc a b) :=
+  isClosed_iff_dirSupClosed.mpr <| .Ioc a b
+
+theorem IsClosed.Icc (a b : α) : IsClosed (Icc a b) :=
+  isClosed_iff_dirSupClosed.mpr <| .Icc a b
+
+instance : ClosedIicTopology α where
+  isClosed_Iic := IsClosed.Iic
+
+instance : ClosedIciTopology α where
+  isClosed_Ici := IsClosed.Ici
 
 end univ
 end IsScottHausdorff
@@ -222,7 +300,7 @@ lemma lowerClosure_subset_closure [IsScott α univ] : ↑(lowerClosure s) ⊆ cl
 
 instance [IsScott α univ] : ClosedIicTopology α where
   isClosed_Iic _ :=
-    isClosed_iff_isLowerSet_and_dirSupClosed.2 ⟨isLowerSet_Iic _, dirSupClosed_Iic _⟩
+    isClosed_iff_isLowerSet_and_dirSupClosed.2 ⟨isLowerSet_Iic _, .Iic _⟩
 
 /--
 The closure of a singleton `{a}` in the Scott topology is the right-closed left-infinite interval

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -189,37 +189,37 @@ theorem isOpen_iff_dirSupInacc : IsOpen s ↔ DirSupInacc s := by
 theorem isClosed_iff_dirSupClosed : IsClosed s ↔ DirSupClosed s := by
   rw [isClosed_iff_dirSupClosedOn isLowerSet_univ, dirSupClosedOn_univ]
 
-theorem IsOpen.Iio (a : α) : IsOpen (Iio a) :=
+protected theorem IsOpen.Iio (a : α) : IsOpen (Iio a) :=
   isOpen_iff_dirSupInacc.mpr <| .Iio a
 
-theorem IsOpen.Iic (a : α) : IsOpen (Iic a) :=
+protected theorem IsOpen.Iic (a : α) : IsOpen (Iic a) :=
   isOpen_iff_dirSupInacc.mpr <| .Iic a
 
-theorem IsOpen.Ioi {α : Type*} [LinearOrder α] [TopologicalSpace α] [IsScottHausdorff α univ]
-    (a : α) : IsOpen (Ioi a) :=
+protected theorem IsOpen.Ioi {α : Type*} [LinearOrder α] [TopologicalSpace α]
+    [IsScottHausdorff α univ] (a : α) : IsOpen (Ioi a) :=
   isOpen_iff_dirSupInacc.mpr <| .Ioi a
 
-theorem IsOpen.Ioo {α : Type*} [LinearOrder α] [TopologicalSpace α] [IsScottHausdorff α univ]
-    (a b : α) : IsOpen (Ioo a b) :=
+protected theorem IsOpen.Ioo {α : Type*} [LinearOrder α] [TopologicalSpace α]
+    [IsScottHausdorff α univ] (a b : α) : IsOpen (Ioo a b) :=
   isOpen_iff_dirSupInacc.mpr <| .Ioo a b
 
-theorem IsOpen.Ioc {α : Type*} [LinearOrder α] [TopologicalSpace α] [IsScottHausdorff α univ]
-    (a b : α) : IsOpen (Ioc a b) :=
+protected theorem IsOpen.Ioc {α : Type*} [LinearOrder α] [TopologicalSpace α]
+    [IsScottHausdorff α univ] (a b : α) : IsOpen (Ioc a b) :=
   isOpen_iff_dirSupInacc.mpr <| .Ioc a b
 
-theorem IsClosed.Iic (a : α) : IsClosed (Iic a) :=
+protected theorem IsClosed.Iic (a : α) : IsClosed (Iic a) :=
   isClosed_iff_dirSupClosed.mpr <| .Iic a
 
-theorem IsClosed.Ici (a : α) : IsClosed (Ici a) :=
+protected theorem IsClosed.Ici (a : α) : IsClosed (Ici a) :=
   isClosed_iff_dirSupClosed.mpr <| .Ici a
 
-theorem IsClosed.Ioi (a : α) : IsClosed (Ioi a) :=
+protected theorem IsClosed.Ioi (a : α) : IsClosed (Ioi a) :=
   isClosed_iff_dirSupClosed.mpr <| .Ioi a
 
-theorem IsClosed.Ioc (a b : α) : IsClosed (Ioc a b) :=
+protected theorem IsClosed.Ioc (a b : α) : IsClosed (Ioc a b) :=
   isClosed_iff_dirSupClosed.mpr <| .Ioc a b
 
-theorem IsClosed.Icc (a b : α) : IsClosed (Icc a b) :=
+protected theorem IsClosed.Icc (a b : α) : IsClosed (Icc a b) :=
   isClosed_iff_dirSupClosed.mpr <| .Icc a b
 
 instance : ClosedIicTopology α where

--- a/Mathlib/Topology/Order/UpperLowerSetTopology.lean
+++ b/Mathlib/Topology/Order/UpperLowerSetTopology.lean
@@ -23,7 +23,7 @@ topology does not coincide with the lower topology.
 ## Main statements
 
 - `Topology.IsUpperSet.toAlexandrovDiscrete`: The upper set topology is Alexandrov-discrete.
-- `Topology.IsUpperSet.isClosed_iff_isLower` - a set is closed if and only if it is a Lower set
+- `Topology.IsUpperSet.isClosed_iff_isLowerSet` - a set is closed if and only if it is a Lower set
 - `Topology.IsUpperSet.closure_eq_lowerClosure` - topological closure coincides with lower closure
 - `Topology.IsUpperSet.monotone_iff_continuous` - the continuous functions are the monotone
   functions
@@ -243,15 +243,17 @@ instance toAlexandrovDiscrete : AlexandrovDiscrete α where
   isOpen_sInter S := by simpa only [isOpen_iff_isUpperSet] using isUpperSet_sInter (α := α)
 
 -- c.f. isClosed_iff_lower_and_subset_implies_LUB_mem
-lemma isClosed_iff_isLower : IsClosed s ↔ IsLowerSet s := by
-  rw [← isOpen_compl_iff, isOpen_iff_isUpperSet,
-    isLowerSet_compl.symm, compl_compl]
+lemma isClosed_iff_isLowerSet : IsClosed s ↔ IsLowerSet s := by
+  rw [← isOpen_compl_iff, isOpen_iff_isUpperSet, isLowerSet_compl.symm, compl_compl]
+
+@[deprecated (since := "2026-09-07")]
+alias isClosed_iff_isLower := isClosed_iff_isLowerSet
 
 lemma closure_eq_lowerClosure {s : Set α} : closure s = lowerClosure s := by
   rw [subset_antisymm_iff]
-  refine ⟨?_, lowerClosure_min subset_closure (isClosed_iff_isLower.1 isClosed_closure)⟩
+  refine ⟨?_, lowerClosure_min subset_closure (isClosed_iff_isLowerSet.1 isClosed_closure)⟩
   · apply closure_minimal subset_lowerClosure _
-    rw [isClosed_iff_isLower]
+    rw [isClosed_iff_isLowerSet]
     exact LowerSet.lower (lowerClosure s)
 
 /--
@@ -276,6 +278,18 @@ lemma nhds_eq_principal_Ici (a : α) : 𝓝 a = 𝓟 (Ici a) := by
 
 lemma nhdsSet_eq_principal_upperClosure (s : Set α) : 𝓝ˢ s = 𝓟 ↑(upperClosure s) := by
   rw [← principal_nhdsKer, nhdsKer_eq_upperClosure]
+
+protected theorem IsOpen.Ioi (a : α) : IsOpen (Ioi a) :=
+  isOpen_iff_isUpperSet.mpr <| isUpperSet_Ioi a
+
+protected theorem IsOpen.Ici (a : α) : IsOpen (Ici a) :=
+  isOpen_iff_isUpperSet.mpr <| isUpperSet_Ici a
+
+protected theorem IsClosed.Iio (a : α) : IsClosed (Iio a) :=
+  isClosed_iff_isLowerSet.mpr <| isLowerSet_Iio a
+
+protected theorem IsClosed.Iic (a : α) : IsClosed (Iic a) :=
+  isClosed_iff_isLowerSet.mpr <| isLowerSet_Iic a
 
 end Preorder
 
@@ -344,8 +358,11 @@ lemma isOpen_iff_isLowerSet : IsOpen s ↔ IsLowerSet s := by rw [topology_eq α
 
 instance toAlexandrovDiscrete : AlexandrovDiscrete α := IsUpperSet.toAlexandrovDiscrete (α := αᵒᵈ)
 
-lemma isClosed_iff_isUpper : IsClosed s ↔ IsUpperSet s := by
+lemma isClosed_iff_isUpperSet : IsClosed s ↔ IsUpperSet s := by
   rw [← isOpen_compl_iff, isOpen_iff_isLowerSet, isUpperSet_compl.symm, compl_compl]
+
+@[deprecated (since := "2026-09-07")]
+alias isClosed_iff_isUpper := isClosed_iff_isUpperSet
 
 lemma closure_eq_upperClosure {s : Set α} : closure s = upperClosure s :=
   IsUpperSet.closure_eq_lowerClosure (α := αᵒᵈ)
@@ -372,6 +389,18 @@ lemma nhds_eq_principal_Iic (a : α) : 𝓝 a = 𝓟 (Iic a) := by
 
 lemma nhdsSet_eq_principal_lowerClosure (s : Set α) : 𝓝ˢ s = 𝓟 ↑(lowerClosure s) := by
   rw [← principal_nhdsKer, nhdsKer_eq_lowerClosure]
+
+protected theorem IsOpen.Iio (a : α) : IsOpen (Iio a) :=
+  isOpen_iff_isLowerSet.mpr <| isLowerSet_Iio a
+
+protected theorem IsOpen.Iic (a : α) : IsOpen (Iic a) :=
+  isOpen_iff_isLowerSet.mpr <| isLowerSet_Iic a
+
+protected theorem IsClosed.Ioi (a : α) : IsClosed (Ioi a) :=
+  isClosed_iff_isUpperSet.mpr <| isUpperSet_Ioi a
+
+protected theorem IsClosed.Ici (a : α) : IsClosed (Ici a) :=
+  isClosed_iff_isUpperSet.mpr <| isUpperSet_Ici a
 
 end Preorder
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
