### PR TITLE
[Merged by Bors] - feat(Topology/Order/LowerUpperTopology): the order topology in a linear order is the infimum of the lower & upper topologies

### DIFF
--- a/Mathlib/Topology/Order/LowerUpperTopology.lean
+++ b/Mathlib/Topology/Order/LowerUpperTopology.lean
@@ -488,7 +488,7 @@ theorem preorderTopology_le_lower_of_linearOrder : Preorder.topology α ≤ Topo
 theorem preorderTopology_le_upper_of_linearOrder : Preorder.topology α ≤ Topology.upper α :=
   TopologicalSpace.generateFrom_anti fun s ⟨a, h⟩ ↦ ⟨a, by simp [← h]⟩
 
-theorem lower_inf_upper_of_linearOrder :
+theorem lower_inf_upper_eq_preorderTopology :
     Topology.lower α ⊓ Topology.upper α = Preorder.topology α := by
   unfold Topology.lower Topology.upper Preorder.topology
   simp [generateFrom_union, Set.ofPred_or, exists_or, eq_comm, or_comm]

--- a/Mathlib/Topology/Order/LowerUpperTopology.lean
+++ b/Mathlib/Topology/Order/LowerUpperTopology.lean
@@ -6,6 +6,7 @@ Authors: Christopher Hoskin
 module
 
 public import Mathlib.Order.Hom.CompleteLattice
+public import Mathlib.Topology.Order.Basic
 public import Mathlib.Topology.Order.Lattice
 
 /-!
@@ -476,6 +477,23 @@ lemma isTopologicalSpace_basis (U : Set α) : IsOpen U ↔ U = univ ∨ ∃ a, (
 end CompleteLinearOrder
 
 end IsUpper
+
+section LinearOrder
+
+variable (α : Type*) [LinearOrder α]
+
+theorem preorderTopology_le_lower_of_linearOrder : Preorder.topology α ≤ Topology.lower α :=
+  TopologicalSpace.generateFrom_anti fun s ⟨a, h⟩ ↦ ⟨a, by simp [← h]⟩
+
+theorem preorderTopology_le_upper_of_linearOrder : Preorder.topology α ≤ Topology.upper α :=
+  TopologicalSpace.generateFrom_anti fun s ⟨a, h⟩ ↦ ⟨a, by simp [← h]⟩
+
+theorem lower_inf_upper_of_linearOrder :
+    Topology.lower α ⊓ Topology.upper α = Preorder.topology α := by
+  unfold Topology.lower Topology.upper Preorder.topology
+  simp [generateFrom_union, Set.ofPred_or, exists_or, eq_comm, or_comm]
+
+end LinearOrder
 
 instance instIsLowerProd [Preorder α] [TopologicalSpace α] [IsLower α]
     [OrderBot α] [Preorder β] [TopologicalSpace β] [IsLower β] [OrderBot β] :


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
