### PR TITLE
[Merged by Bors] - chore(Data/Finsupp): add simp on `Finsupp.ofSupportFinite_coe`

### DIFF
--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -276,13 +276,14 @@ noncomputable def ofSupportFinite (f : α → M) (hf : (Function.support f).Fini
   toFun := f
   mem_support_toFun _ := hf.mem_toFinset
 
+@[simp]
 theorem ofSupportFinite_coe {f : α → M} {hf : (Function.support f).Finite} :
     (ofSupportFinite f hf : α → M) = f :=
   rfl
 
 theorem ofSupportFinite_support {f : α → M} (hf : f.support.Finite) :
     (ofSupportFinite f hf).support = hf.toFinset := by
-  ext; simp [ofSupportFinite_coe]
+  ext; simp
 
 instance instCanLift : CanLift (α → M) (α →₀ M) (⇑) fun f => (Function.support f).Finite where
   prf f hf := ⟨ofSupportFinite f hf, rfl⟩


### PR DESCRIPTION
I think this should be a simp lemma.
```
theorem ofSupportFinite_coe {f : α → M} {hf : (Function.support f).Finite} :
    (ofSupportFinite f hf : α → M) = f :=
  rfl
```