### PR TITLE
[Merged by Bors] - chore(Algebra/Category): tidy markdown headers

### DIFF
--- a/Mathlib/Algebra/Category/Grp/FiniteGrp.lean
+++ b/Mathlib/Algebra/Category/Grp/FiniteGrp.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.Category.Grp.Basic
 public import Mathlib.Basic.Finite.Defs
 
 /-!
+# The category of finite groups
 
 ## Main definitions and results
 

--- a/Mathlib/Algebra/Category/Grp/ZModuleEquivalence.lean
+++ b/Mathlib/Algebra/Category/Grp/ZModuleEquivalence.lean
@@ -8,11 +8,14 @@ module
 public import Mathlib.Algebra.Category.ModuleCat.Basic
 
 /-!
+# ℤ-modules are equivalent to additive commutative groups
+
 The forgetful functor from ℤ-modules to additive commutative groups is
 an equivalence of categories.
 
-TODO:
-either use this equivalence to transport the monoidal structure from `Module ℤ` to `Ab`,
+## TODO
+
+Either use this equivalence to transport the monoidal structure from `Module ℤ` to `Ab`,
 or, having constructed that monoidal structure directly, show this functor is monoidal.
 -/
 

--- a/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
@@ -12,6 +12,8 @@ public import Mathlib.CategoryTheory.Monoidal.Types.Basic
 public import Mathlib.LinearAlgebra.DirectSum.Finsupp
 
 /-!
+# Adjunctions involving the category of `R`-modules
+
 The functor of forming finitely supported functions on a type with values in a `[Ring R]`
 is the left adjoint of
 the forgetful functor from `R`-modules to types.

--- a/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
@@ -12,8 +12,6 @@ public import Mathlib.CategoryTheory.Monoidal.Types.Basic
 public import Mathlib.LinearAlgebra.DirectSum.Finsupp
 
 /-!
-# Adjunctions involving the category of `R`-modules
-
 The functor of forming finitely supported functions on a type with values in a `[Ring R]`
 is the left adjoint of
 the forgetful functor from `R`-modules to types.


### PR DESCRIPTION
This PR ensures files in `Mathlib/Algebra/Category` have one and only one H1 header, in accordance with the style guide. It also fixes other minor formatting issues related to headers in the touched files.

The new headers that this PR introduces were authored by Claude Opus 5.

Split off from #42594 at the request of a reviewer.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
