### PR TITLE
[Merged by Bors] - feat(Topology/Sets): the union of an open set of `Compacts` is open

### DIFF
--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -533,6 +533,14 @@ instance : ContinuousSup (Compacts α) := by
   simp_rw [isEmbedding_coe.continuous_iff, Function.comp_def, coe_sup]
   fun_prop
 
+theorem isOpen_biUnion_coe_of_isOpen {S : Set (Compacts α)} (hS : IsOpen S) :
+    IsOpen (⋃ K ∈ S, (K : Set α)) := by
+  simp_rw [isOpen_iff_eventually, forall_mem_biUnion]
+  intro K hK x hx
+  have : Continuous ({·} ⊔ K) := by fun_prop
+  filter_upwards [(this.tendsto' x K (by ext1; simpa)).eventually (hS.eventually_mem hK)] with y hy
+  exact mem_iUnion₂_of_mem hy <| by simp
+
 @[fun_prop]
 theorem continuous_prod : Continuous fun p : Compacts α × Compacts β => p.1 ×ˢ p.2 := by
   rw [continuous_induced_rng, continuous_generateFrom_iff]
@@ -884,6 +892,11 @@ theorem dense_setOfPred_finite : Dense {K : NonemptyCompacts α | (K : Set α).F
 
 @[deprecated (since := "2026-07-09")]
 alias dense_setOf_finite := dense_setOfPred_finite
+
+theorem isOpen_biUnion_coe_of_isOpen {S : Set (NonemptyCompacts α)} (hS : IsOpen S) :
+    IsOpen (⋃ K ∈ S, (K : Set α)) := by
+  rw [isOpenEmbedding_toCompacts.isOpen_iff_image_isOpen] at hS
+  simpa using Compacts.isOpen_biUnion_coe_of_isOpen hS
 
 /-- Given a basis `B` on a topological space `α`, the topology of `NonemptyCompacts α` has a basis
 consisting of sets of the form `{K | K ⊆ U₁ ∪ … ∪ Uₙ, K ∩ U₁ ≠ ∅, …, K ∩ Uₙ ≠ ∅}`, where


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
