### PR TITLE
feat(MeasureTheory/Integral/Bochner/Set): add setIntegral_union'

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -88,6 +88,11 @@ theorem setIntegral_union (hst : Disjoint s t) (ht : MeasurableSet t) (hfs : Int
     (hft : IntegrableOn f t μ) : ∫ x in s ∪ t, f x ∂μ = ∫ x in s, f x ∂μ + ∫ x in t, f x ∂μ :=
   setIntegral_union₀ hst.aedisjoint ht.nullMeasurableSet hfs hft
 
+theorem setIntegral_union' (hst : Disjoint s t) (ht : MeasurableSet t)
+    (hfst : IntegrableOn f (s ∪ t) μ) :
+    ∫ x in s ∪ t, f x ∂μ = ∫ x in s, f x ∂μ + ∫ x in t, f x ∂μ :=
+  setIntegral_union hst ht hfst.left_of_union hfst.right_of_union
+
 theorem setIntegral_sdiff₀ (ht : NullMeasurableSet t μ) (hfs : IntegrableOn f s μ) (hts : t ⊆ s) :
     ∫ x in s \ t, f x ∂μ = ∫ x in s, f x ∂μ - ∫ x in t, f x ∂μ := by
   rw [eq_sub_iff_add_eq, ← setIntegral_union₀, sdiff_union_of_subset hts]


### PR DESCRIPTION
From the Carleson project.

-------

**Upstreaming from Carleson: [/Carleson/ToMathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean](https://github.com/fpvandoorn/carleson/blob/0072b6e47ec58ac13be0a9f3b7c17e9f3bb1be2e/Carleson/ToMathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean)**

### In this PR

#### theorem setIntegral_union'

Renamed: from `MeasureTheory.setIntegral_union_2` to `MeasureTheory.setIntegral_union'`.
Signature: changed from `[MeasurableSpace X]` to `{mX : MeasurableSpace X}` (to match existing section variables).

```lean
-- CARLESON
MeasureTheory.setIntegral_union_2.{u_1, u_2} {X : Type u_1} {E : Type u_2} [NormedAddCommGroup E]
[NormedSpace ℝ E] {f : X → E} {s t : Set X} {μ : Measure X} (hst : Disjoint s t)
(ht : MeasurableSet t) (ht : MeasurableSet t) (hfst : IntegrableOn f (s ∪ t) μ)
[MeasurableSpace X]
: ∫ (x : X) in s ∪ t, f x ∂μ = ∫ (x : X) in s, f x ∂μ + ∫ (x : X) in t, f x ∂μ
-- MATHLIB
MeasureTheory.setIntegral_union'.{u_1, u_3} {X : Type u_1} {E : Type u_3} [NormedAddCommGroup E]
[NormedSpace ℝ E] {f : X → E} {s t : Set X} {μ : Measure X} (hst : Disjoint s t)
(ht : MeasurableSet t) (ht : MeasurableSet t) (hfst : IntegrableOn f (s ∪ t) μ)
{mX : MeasurableSpace X}
: ∫ (x : X) in s ∪ t, f x ∂μ = ∫ (x : X) in s, f x ∂μ + ∫ (x : X) in t, f x ∂μ
```
