### PR TITLE
refactor(CategoryTheory): insert missing functor associators and unitors

### DIFF
--- a/Mathlib/AlgebraicGeometry/ColimitsOver.lean
+++ b/Mathlib/AlgebraicGeometry/ColimitsOver.lean
@@ -76,7 +76,7 @@ noncomputable
 def transitionMap {i j : 𝒰.I₀} (hij : i ⟶ j) :
     (Over.map ⊤ (d.prop_trans hij)).obj (d.cocone i).pt ⟶ (d.cocone j).pt :=
   (isColimitOfPreserves (Over.map ⊤ (d.prop_trans hij)) (d.isColimit i)).desc
-    (d.transitionCocone hij)
+    ((Cocone.precompose (Functor.associator _ _ _).hom).obj (d.transitionCocone hij))
 
 @[reassoc]
 lemma cocone_ι_transitionMap {i j : 𝒰.I₀} (hij : i ⟶ j) (a : J) :

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
@@ -101,11 +101,12 @@ noncomputable def isColimitMapCoconeOfSubobjectMkEqISup
   haveI := mono_of_isColimit_monoOver F (colimit.isColimit _) f (by simp [f])
   have := subobjectMk_of_isColimit_eq_iSup F (colimit.isColimit _) f (by simp [f])
   rw [← h] at this
-  refine IsColimit.ofIsoColimit (colimit.isColimit _)
+  refine IsColimit.ofIsoColimit ((IsColimit.precomposeHomEquiv (Functor.associator _ _ _) _).symm
+    (colimit.isColimit (F ⋙ MonoOver.forget X ⋙ Over.forget X)))
     (Cocone.ext (Subobject.isoOfMkEqMk _ _ this) (fun j ↦ ?_))
   rw [← cancel_mono (c.pt.hom)]
   dsimp
-  rw [Category.assoc, Subobject.ofMkLEMk_comp, Over.w]
+  rw [Category.id_comp, Category.assoc, Subobject.ofMkLEMk_comp, Over.w]
   apply colimit.ι_desc
 
 /-- If `C` is a Grothendieck abelian category, `X : C`, if `F : J ⥤ MonoOver X` is a

--- a/Mathlib/CategoryTheory/Comma/Final.lean
+++ b/Mathlib/CategoryTheory/Comma/Final.lean
@@ -160,7 +160,8 @@ lemma map_final {A : Type u₁} [Category.{v₁} A] {B : Type u₂} [Category.{v
   have := final_of_natIso iR
   rw [isConnected_iff_of_equivalence (StructuredArrow.commaMapEquivalence iL.hom iR.inv _)]
   have : StructuredArrow.map₂ u₂ iR.hom ≅ StructuredArrow.post j₂ G R' ⋙
-      StructuredArrow.map₂ (G := 𝟭 _) (F := 𝟭 _) (R' := R ⋙ H) u₂ iR.hom ⋙
+      StructuredArrow.map₂ (G := 𝟭 _) (F := 𝟭 _) (R := G ⋙ R') (R' := R ⋙ H) u₂
+          ((Functor.rightUnitor _).hom ≫ iR.hom ≫ (Functor.leftUnitor _).inv) ⋙
       StructuredArrow.pre _ R H :=
     eqToIso (by
       congr

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Basic.lean
@@ -438,18 +438,19 @@ end
 set_option backward.defeqAttrib.useBackward true in
 /-- `StructuredArrow.post` is a special case of `StructuredArrow.map₂` up to natural isomorphism. -/
 def postIsoMap₂ (S : C) (F : B ⥤ C) (G : C ⥤ D) :
-    post S F G ≅ map₂ (F := 𝟭 _) (𝟙 _) (𝟙 (F ⋙ G)) :=
+    post S F G ≅ map₂ (F := 𝟭 _) (𝟙 _) (F ⋙ G).leftUnitor.inv :=
   NatIso.ofComponents fun _ => isoMk <| Iso.refl _
 
 set_option backward.defeqAttrib.useBackward true in
 /-- `StructuredArrow.map` is a special case of `StructuredArrow.map₂` up to natural isomorphism. -/
-def mapIsoMap₂ {S S' : D} (f : S ⟶ S') : map (T := T) f ≅ map₂ (F := 𝟭 _) (G := 𝟭 _) f (𝟙 T) :=
+def mapIsoMap₂ {S S' : D} (f : S ⟶ S') :
+    map (T := T) f ≅ map₂ (F := 𝟭 _) (G := 𝟭 _) f (T.rightUnitor.hom ≫ T.leftUnitor.inv) :=
   NatIso.ofComponents fun _ => isoMk <| Iso.refl _
 
 set_option backward.defeqAttrib.useBackward true in
 /-- `StructuredArrow.pre` is a special case of `StructuredArrow.map₂` up to natural isomorphism. -/
 def preIsoMap₂ (S : D) (F : B ⥤ C) (G : C ⥤ D) :
-    pre S F G ≅ map₂ (G := 𝟭 _) (𝟙 _) (𝟙 (F ⋙ G)) :=
+    pre S F G ≅ map₂ (G := 𝟭 _) (𝟙 _) (F ⋙ G).rightUnitor.hom :=
   NatIso.ofComponents fun _ => isoMk <| Iso.refl _
 
 /-- A structured arrow is called universal if it is initial. -/
@@ -898,7 +899,7 @@ set_option backward.defeqAttrib.useBackward true in
 /-- `CostructuredArrow.post` is a special case of `CostructuredArrow.map₂` up to natural
 isomorphism. -/
 def postIsoMap₂ (S : C) (F : B ⥤ C) (G : C ⥤ D) :
-    post F G S ≅ map₂ (F := 𝟭 _) (𝟙 (F ⋙ G)) (𝟙 _) :=
+    post F G S ≅ map₂ (F := 𝟭 _) (F ⋙ G).leftUnitor.hom (𝟙 _) :=
   NatIso.ofComponents fun _ => isoMk <| Iso.refl _
 
 /-- A costructured arrow is called universal if it is terminal. -/
@@ -1132,13 +1133,13 @@ def StructuredArrow.preEquivalence (f : StructuredArrow e G) :
 
 set_option backward.isDefEq.respectTransparency.types false in
 set_option backward.defeqAttrib.useBackward true in
-/-- The functor `StructuredArrow d T ⥤ StructuredArrow e (T ⋙ S)` that `u : e ⟶ S.obj d`
-induces via `StructuredArrow.map₂` can be expressed up to isomorphism by
+/-- The functor `StructuredArrow d T ⥤ StructuredArrow e T'` that `u : e ⟶ S.obj d` and
+`β : T ⋙ S ⟶ 𝟭 C ⋙ T'` induce via `StructuredArrow.map₂` can be expressed up to isomorphism by
 `StructuredArrow.preEquivalence` and `StructuredArrow.proj`. -/
 def StructuredArrow.map₂IsoPreEquivalenceInverseCompProj {T : C ⥤ D} {S : D ⥤ E} {T' : C ⥤ E}
-    (d : D) (e : E) (u : e ⟶ S.obj d) (α : T ⋙ S ⟶ T') :
-    map₂ (F := 𝟭 _) u α ≅ (preEquivalence T (mk u)).inverse ⋙ proj (mk u) (pre _ T S) ⋙
-      map₂ (F := 𝟭 _) (G := 𝟭 _) (𝟙 _) α :=
+    (d : D) (e : E) (u : e ⟶ S.obj d) (β : T ⋙ S ⟶ 𝟭 C ⋙ T') :
+    map₂ (F := 𝟭 _) u β ≅ (preEquivalence T (mk u)).inverse ⋙ proj (mk u) (pre _ T S) ⋙
+      map₂ (F := 𝟭 _) (G := 𝟭 _) (𝟙 _) ((T ⋙ S).rightUnitor.hom ≫ β) :=
   NatIso.ofComponents fun _ => isoMk (Iso.refl _)
 
 set_option backward.defeqAttrib.useBackward true in
@@ -1181,7 +1182,7 @@ induces via `CostructuredArrow.map₂` can be expressed up to isomorphism by
 `CostructuredArrow.preEquivalence` and `CostructuredArrow.proj`. -/
 def CostructuredArrow.map₂IsoPreEquivalenceInverseCompProj (T : C ⥤ D) (S : D ⥤ E) (d : D) (e : E)
     (u : S.obj d ⟶ e) :
-    map₂ (F := 𝟭 _) (U := T ⋙ S) (𝟙 (T ⋙ S)) u ≅
+    map₂ (F := 𝟭 _) (U := T ⋙ S) (T ⋙ S).leftUnitor.hom u ≅
       (preEquivalence T (mk u)).inverse ⋙ proj (pre T S _) (mk u) :=
   NatIso.ofComponents fun _ => isoMk (Iso.refl _)
 

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -437,7 +437,7 @@ def congrRight (e : C ≌ D) : E ⥤ C ≌ E ⥤ D where
   functor := (whiskeringRight _ _ _).obj e.functor
   inverse := (whiskeringRight _ _ _).obj e.inverse
   unitIso := NatIso.ofComponents
-      fun F => F.rightUnitor.symm ≪≫ isoWhiskerLeft F e.unitIso ≪≫ Functor.associator _ _ _
+      fun F => F.rightUnitor.symm ≪≫ isoWhiskerLeft F e.unitIso ≪≫ (Functor.associator _ _ _).symm
   counitIso := NatIso.ofComponents
       fun F => Functor.associator _ _ _ ≪≫ isoWhiskerLeft F e.counitIso ≪≫ F.rightUnitor
 

--- a/Mathlib/CategoryTheory/Filtered/Final.lean
+++ b/Mathlib/CategoryTheory/Filtered/Final.lean
@@ -383,18 +383,15 @@ induces via `StructuredArrow.map₂` is final, if `T` and `S` are final and the 
 filtered. -/
 instance StructuredArrow.final_map₂_id [IsFiltered C] {E : Type u₃} [Category.{v₃} E]
     {T : C ⥤ D} [T.Final] {S : D ⥤ E} [S.Final] {T' : C ⥤ E}
-    {d : D} {e : E} (u : e ⟶ S.obj d) (α : T ⋙ S ⟶ T') [IsIso α] :
-    Final (map₂ (F := 𝟭 _) u α) := by
+    {d : D} {e : E} (u : e ⟶ S.obj d) (β : T ⋙ S ⟶ 𝟭 C ⋙ T') [IsIso β] :
+    Final (map₂ (F := 𝟭 _) u β) := by
   have : IsFiltered (StructuredArrow e (T ⋙ S)) :=
     (T ⋙ S).final_iff_isFiltered_structuredArrow.mp inferInstance e
-  apply final_of_natIso (map₂IsoPreEquivalenceInverseCompProj d e u α).symm
+  apply final_of_natIso (map₂IsoPreEquivalenceInverseCompProj d e u β).symm
 
 /-- `StructuredArrow.map` is final if the functor `T` is final and its domain is filtered. -/
 instance StructuredArrow.final_map [IsFiltered C] {S S' : D} (f : S ⟶ S') (T : C ⥤ D) [T.Final] :
     Final (map (T := T) f) := by
-  have := NatIso.isIso_of_isIso_app (𝟙 T)
-  have : (map₂ (F := 𝟭 C) (G := 𝟭 D) f (𝟙 T)).Final := by
-    apply StructuredArrow.final_map₂_id (S := 𝟭 D) (T := T) (T' := T) f (𝟙 T)
   apply final_of_natIso (mapIsoMap₂ f).symm
 
 /-- `StructuredArrow.post X T S` is final if `T` and `S` are final and the domain of `T` is
@@ -405,10 +402,11 @@ instance StructuredArrow.final_post [IsFiltered C] {E : Type u₃} [Category.{v�
 
 /-- The functor `CostructuredArrow T d ⥤ CostructuredArrow (T ⋙ S) e` that `u : S.obj d ⟶ e`
 induces via `CostructuredArrow.map₂` is initial, if `T` and `S` are initial and the domain of `T` is
-filtered. -/
+cofiltered. -/
 instance CostructuredArrow.initial_map₂_id [IsCofiltered C] {E : Type u₃} [Category.{v₃} E]
     (T : C ⥤ D) [T.Initial] (S : D ⥤ E) [S.Initial] (d : D) (e : E)
-    (u : S.obj d ⟶ e) : Initial (map₂ (F := 𝟭 _) (U := T ⋙ S) (𝟙 (T ⋙ S)) u) := by
+    (u : S.obj d ⟶ e) :
+    Initial (map₂ (F := 𝟭 _) (U := T ⋙ S) (T ⋙ S).leftUnitor.hom u) := by
   have := (T ⋙ S).initial_iff_isCofiltered_costructuredArrow.mp inferInstance e
   apply initial_of_natIso (map₂IsoPreEquivalenceInverseCompProj T S d e u).symm
 

--- a/Mathlib/CategoryTheory/Functor/Derived/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/Derived/Adjunction.lean
@@ -73,8 +73,8 @@ def derived' [G'.IsLeftDerivedFunctor α W₁] [F'.IsRightDerivedFunctor β W₂
       hε (G.obj X₁), reassoc_of% eq₃, ← L₂.map_comp, adj.left_triangle_components,
       Functor.map_id, Category.comp_id]
   right_triangle_components := by
-    suffices F'.leftUnitor.inv ≫ whiskerLeft F' η ≫ (Functor.associator _ _ _).inv ≫
-      whiskerRight ε F' ≫ F'.rightUnitor.hom = 𝟙 _ from
+    suffices F'.rightUnitor.inv ≫ whiskerLeft F' η ≫ (Functor.associator _ _ _).inv ≫
+      whiskerRight ε F' ≫ F'.leftUnitor.hom = 𝟙 _ from
         fun Y₂ ↦ by simpa using congr_app this Y₂
     apply F'.rightDerived_ext β W₂
     ext X₂

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -325,7 +325,8 @@ induced by a natural transformation `L' ⟶ L ⋙ G'`. -/
 def LeftExtension.postcomp₁ (f : L' ⟶ L ⋙ G) (F : C ⥤ H) :
     LeftExtension L' F ⥤ LeftExtension L F :=
   StructuredArrow.map₂ (F := (whiskeringLeft D D' H).obj G) (G := 𝟭 _) (𝟙 _)
-    ((whiskeringLeft C D' H).map f)
+    ((Functor.rightUnitor _).hom ≫ (whiskeringLeft C D' H).map f ≫
+      (whiskeringLeftObjCompIso L G).hom)
 
 /-- The functor `RightExtension L' F ⥤ RightExtension L F`
 induced by a natural transformation `L ⋙ G ⟶ L'`. -/
@@ -333,7 +334,8 @@ induced by a natural transformation `L ⋙ G ⟶ L'`. -/
 def RightExtension.postcomp₁ (f : L ⋙ G ⟶ L') (F : C ⥤ H) :
     RightExtension L' F ⥤ RightExtension L F :=
   CostructuredArrow.map₂ (F := (whiskeringLeft D D' H).obj G) (G := 𝟭 _)
-    ((whiskeringLeft C D' H).map f) (𝟙 _)
+    ((whiskeringLeftObjCompIso L G).inv ≫ (whiskeringLeft C D' H).map f ≫
+      (Functor.rightUnitor _).inv) (𝟙 _)
 
 variable [IsEquivalence G]
 
@@ -465,13 +467,15 @@ variable (L : C ⥤ D) (F : C ⥤ H) (F' : D ⥤ H) (G : C' ⥤ C)
 obtained by precomposition. -/
 @[simps!, implicit_reducible]
 def LeftExtension.precomp : LeftExtension L F ⥤ LeftExtension (G ⋙ L) (G ⋙ F) :=
-  StructuredArrow.map₂ (F := 𝟭 _) (G := (whiskeringLeft C' C H).obj G) (𝟙 _) (𝟙 _)
+  StructuredArrow.map₂ (F := 𝟭 _) (G := (whiskeringLeft C' C H).obj G) (𝟙 _)
+    ((whiskeringLeftObjCompIso G L).inv ≫ (Functor.leftUnitor _).inv)
 
 /-- The functor `RightExtension L F ⥤ RightExtension (G ⋙ L) (G ⋙ F)`
 obtained by precomposition. -/
 @[simps!, implicit_reducible]
 def RightExtension.precomp : RightExtension L F ⥤ RightExtension (G ⋙ L) (G ⋙ F) :=
-  CostructuredArrow.map₂ (F := 𝟭 _) (G := (whiskeringLeft C' C H).obj G) (𝟙 _) (𝟙 _)
+  CostructuredArrow.map₂ (F := 𝟭 _) (G := (whiskeringLeft C' C H).obj G)
+    ((Functor.leftUnitor _).hom ≫ (whiskeringLeftObjCompIso G L).hom) (𝟙 _)
 
 variable [IsEquivalence G]
 
@@ -806,7 +810,8 @@ lemma isLeftKanExtension_iff_precomp_equivalence
   let Φ : L₂.LeftExtension F₂ ⥤ L₁.LeftExtension F₁ :=
     StructuredArrow.map₂ (F := (whiskeringLeft _ _ _).obj G')
       (G := (whiskeringLeft _ _ _).obj G) e.hom
-        ((whiskeringLeft C D' H).mapIso iso).hom
+        ((whiskeringLeftObjCompIso G L₂).inv ≫ ((whiskeringLeft C D' H).mapIso iso).hom ≫
+          (whiskeringLeftObjCompIso L₁ G').hom)
   exact Equiv.nonempty_congr ((IsInitial.isInitialIffObj Φ _).trans
     (IsInitial.equivOfIso (StructuredArrow.isoMk e')))
 
@@ -822,7 +827,8 @@ lemma isRightKanExtension_iff_precomp_equivalence
   let Φ : L₂.RightExtension F₂ ⥤ L₁.RightExtension F₁ :=
     CostructuredArrow.map₂ (F := (whiskeringLeft _ _ _).obj G')
       (G := (whiskeringLeft _ _ _).obj G)
-      ((whiskeringLeft C D' H).mapIso iso).inv e.inv
+      ((whiskeringLeftObjCompIso L₁ G').inv ≫ ((whiskeringLeft C D' H).mapIso iso).inv ≫
+        (whiskeringLeftObjCompIso G L₂).hom) e.inv
   exact Equiv.nonempty_congr ((IsTerminal.isTerminalIffObj Φ _).trans
     (IsTerminal.equivOfIso (CostructuredArrow.isoMk e'.symm).symm))
 

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -289,8 +289,10 @@ the data of natural transformations between each side that are compatible with t
 action on edge maps. -/
 def mkNatTrans {F : C ⋆ D ⥤ E} {F' : C ⋆ D ⥤ E}
     (αₗ : inclLeft C D ⋙ F ⟶ inclLeft C D ⋙ F') (αᵣ : inclRight C D ⋙ F ⟶ inclRight C D ⋙ F')
-    (h : whiskerRight (edgeTransform C D) F ≫ whiskerLeft (Prod.snd C D) αᵣ =
-      whiskerLeft (Prod.fst C D) αₗ ≫ whiskerRight (edgeTransform C D) F' := by cat_disch) :
+    (h : (Functor.associator ..).inv ≫ whiskerRight (edgeTransform C D) F ≫
+        (Functor.associator ..).hom ≫ whiskerLeft (Prod.snd C D) αᵣ =
+      whiskerLeft (Prod.fst C D) αₗ ≫ (Functor.associator ..).inv ≫
+        whiskerRight (edgeTransform C D) F' ≫ (Functor.associator ..).hom := by cat_disch) :
     F ⟶ F' where
   app x := match x with
     | left x => αₗ.app x
@@ -299,14 +301,16 @@ def mkNatTrans {F : C ⋆ D ⥤ E} {F' : C ⋆ D ⥤ E}
     cases f with
     | @left x y f => simpa using! αₗ.naturality f
     | @right x y f => simpa using! αᵣ.naturality f
-    | @edge c d => exact funext_iff.mp (NatTrans.ext_iff.mp h) (c, d)
+    | @edge c d => simpa using! NatTrans.congr_app h (c, d)
 
 section
 
 variable {F : C ⋆ D ⥤ E} {F' : C ⋆ D ⥤ E}
     (αₗ : inclLeft C D ⋙ F ⟶ inclLeft C D ⋙ F') (αᵣ : inclRight C D ⋙ F ⟶ inclRight C D ⋙ F')
-    (h : whiskerRight (edgeTransform C D) F ≫ whiskerLeft (Prod.snd C D) αᵣ =
-      whiskerLeft (Prod.fst C D) αₗ ≫ whiskerRight (edgeTransform C D) F' := by cat_disch)
+    (h : (Functor.associator ..).inv ≫ whiskerRight (edgeTransform C D) F ≫
+        (Functor.associator ..).hom ≫ whiskerLeft (Prod.snd C D) αᵣ =
+      whiskerLeft (Prod.fst C D) αₗ ≫ (Functor.associator ..).inv ≫
+        whiskerRight (edgeTransform C D) F' ≫ (Functor.associator ..).hom := by cat_disch)
 
 set_option backward.privateInPublic true in
 @[simp]
@@ -352,11 +356,15 @@ lemma mkNatTransComp
     (αᵣ : inclRight C D ⋙ F ⟶ inclRight C D ⋙ F')
     (βₗ : inclLeft C D ⋙ F' ⟶ inclLeft C D ⋙ F'')
     (βᵣ : inclRight C D ⋙ F' ⟶ inclRight C D ⋙ F'')
-    (h : whiskerRight (edgeTransform C D) F ≫ whiskerLeft (Prod.snd C D) αᵣ =
-      whiskerLeft (Prod.fst C D) αₗ ≫ whiskerRight (edgeTransform C D) F' := by cat_disch)
-    (h' : whiskerRight (edgeTransform C D) F' ≫ whiskerLeft (Prod.snd C D) βᵣ =
-      whiskerLeft (Prod.fst C D) βₗ ≫ whiskerRight (edgeTransform C D) F'' := by cat_disch) :
-    mkNatTrans (αₗ ≫ βₗ) (αᵣ ≫ βᵣ) (by simp [← h', reassoc_of% h]) =
+    (h : (Functor.associator ..).inv ≫ whiskerRight (edgeTransform C D) F ≫
+        (Functor.associator ..).hom ≫ whiskerLeft (Prod.snd C D) αᵣ =
+      whiskerLeft (Prod.fst C D) αₗ ≫ (Functor.associator ..).inv ≫
+        whiskerRight (edgeTransform C D) F' ≫ (Functor.associator ..).hom := by cat_disch)
+    (h' : (Functor.associator ..).inv ≫ whiskerRight (edgeTransform C D) F' ≫
+        (Functor.associator ..).hom ≫ whiskerLeft (Prod.snd C D) βᵣ =
+      whiskerLeft (Prod.fst C D) βₗ ≫ (Functor.associator ..).inv ≫
+        whiskerRight (edgeTransform C D) F'' ≫ (Functor.associator ..).hom := by cat_disch) :
+    mkNatTrans (αₗ ≫ βₗ) (αᵣ ≫ βᵣ) (by simp [h', reassoc_of% h]) =
     mkNatTrans αₗ αᵣ h ≫ mkNatTrans βₗ βᵣ h' := by
   apply natTrans_ext <;> cat_disch
 
@@ -370,12 +378,15 @@ transformation is respected through these isomorphisms. -/
 def mkNatIso {F : C ⋆ D ⥤ E} {G : C ⋆ D ⥤ E}
     (eₗ : inclLeft C D ⋙ F ≅ inclLeft C D ⋙ G)
     (eᵣ : inclRight C D ⋙ F ≅ inclRight C D ⋙ G)
-    (h : whiskerRight (edgeTransform C D) F ≫ (isoWhiskerLeft (Prod.snd C D) eᵣ).hom =
-      (isoWhiskerLeft (Prod.fst C D) eₗ).hom ≫ whiskerRight (edgeTransform C D) G := by cat_disch) :
+    (h : (Functor.associator ..).inv ≫ whiskerRight (edgeTransform C D) F ≫
+        (Functor.associator ..).hom ≫ (isoWhiskerLeft (Prod.snd C D) eᵣ).hom =
+      (isoWhiskerLeft (Prod.fst C D) eₗ).hom ≫ (Functor.associator ..).inv ≫
+        whiskerRight (edgeTransform C D) G ≫ (Functor.associator ..).hom := by cat_disch) :
     F ≅ G where
   hom := mkNatTrans eₗ.hom eᵣ.hom (by simpa using h)
-  inv := mkNatTrans eₗ.inv eᵣ.inv (by rw [Eq.comm, ← isoWhiskerLeft_inv, ← isoWhiskerLeft_inv,
-    Iso.inv_comp_eq, ← Category.assoc, Eq.comm, Iso.comp_inv_eq, h])
+  inv := mkNatTrans eₗ.inv eᵣ.inv (by
+    rw [← isoWhiskerLeft_inv, ← isoWhiskerLeft_inv, Iso.eq_inv_comp, ← reassoc_of% h,
+      Iso.hom_inv_id, Category.comp_id])
 
 /-- A pair of functors ((C ⥤ E), (D ⥤ E')) induces a functor `C ⋆ D ⥤ E ⋆ E'`. -/
 def mapPair (Fₗ : C ⥤ E) (Fᵣ : D ⥤ E') : C ⋆ D ⥤ E ⋆ E' :=
@@ -436,12 +447,14 @@ def mapPairComp (Fₗ : C ⥤ E) (Fᵣ : D ⥤ E') (Gₗ : E ⥤ J) (Gᵣ : E' �
       Functor.associator Fₗ Gₗ (inclLeft J K) ≪≫
       (isoWhiskerLeft Fₗ (mapPairLeft Gₗ Gᵣ).symm) ≪≫
       (Functor.associator Fₗ (inclLeft E E') (mapPair Gₗ Gᵣ)).symm ≪≫
-      isoWhiskerRight (mapPairLeft Fₗ Fᵣ).symm (mapPair Gₗ Gᵣ))
+      isoWhiskerRight (mapPairLeft Fₗ Fᵣ).symm (mapPair Gₗ Gᵣ) ≪≫
+      Functor.associator (inclLeft C D) (mapPair Fₗ Fᵣ) (mapPair Gₗ Gᵣ))
     (mapPairRight (Fₗ ⋙ Gₗ) (Fᵣ ⋙ Gᵣ) ≪≫
       Functor.associator Fᵣ Gᵣ (inclRight J K) ≪≫
       (isoWhiskerLeft Fᵣ (mapPairRight Gₗ Gᵣ).symm) ≪≫
       (Functor.associator Fᵣ (inclRight E E') (mapPair Gₗ Gᵣ)).symm ≪≫
-      isoWhiskerRight (mapPairRight Fₗ Fᵣ).symm (mapPair Gₗ Gᵣ))
+      isoWhiskerRight (mapPairRight Fₗ Fᵣ).symm (mapPair Gₗ Gᵣ) ≪≫
+      Functor.associator (inclRight C D) (mapPair Fₗ Fᵣ) (mapPair Gₗ Gᵣ))
 
 section mapPairComp
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
@@ -59,6 +59,7 @@ def raiseCone [IsConnected J] {B : D} {F : J ⥤ CostructuredArrow K B}
   π.app j := CostructuredArrow.homMk (c.π.app j) <| by
     let z : (Functor.const J).obj (K.obj c.pt) ⟶ _ :=
       (CategoryTheory.Functor.constComp J c.pt K).inv ≫ Functor.whiskerRight c.π K ≫
+        (Functor.associator F (CostructuredArrow.proj K B) K).hom ≫
         natTransInCostructuredArrow F
     convert! (nat_trans_from_is_connected z j (Classical.arbitrary J)) <;> simp [z]
   π.naturality X Y f := by

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -312,7 +312,8 @@ set_option backward.defeqAttrib.useBackward true in
 instance (priority := 100) comp_preservesColimit {B : Type u₄} [Category.{v₄} B] {H : E ⥤ B}
     [PreservesColimit G H] : PreservesColimit (F ⋙ G) H where
   preserves {c} hc := by
-    refine ⟨isColimitExtendCoconeEquiv (G := G ⋙ H) F (H.mapCocone c) ?_⟩
+    refine ⟨(IsColimit.precomposeInvEquiv (Functor.associator F G H) _)
+      (isColimitExtendCoconeEquiv (G := G ⋙ H) F _ ?_)⟩
     let hc' := isColimitOfPreserves H ((isColimitExtendCoconeEquiv F c).symm hc)
     exact IsColimit.ofIsoColimit hc' (Cocone.ext (Iso.refl _) (by simp))
 
@@ -321,15 +322,20 @@ instance (priority := 100) comp_reflectsColimit {B : Type u₄} [Category.{v₄}
     [ReflectsColimit G H] : ReflectsColimit (F ⋙ G) H where
   reflects {c} hc := by
     refine ⟨isColimitExtendCoconeEquiv F _ (isColimitOfReflects H ?_)⟩
-    let hc' := (isColimitExtendCoconeEquiv (G := G ⋙ H) F _).symm hc
+    let hc' := (isColimitExtendCoconeEquiv (G := G ⋙ H) F _).symm
+      ((IsColimit.precomposeInvEquiv (Functor.associator F G H) _).symm hc)
     exact IsColimit.ofIsoColimit hc' (Cocone.ext (Iso.refl _) (by simp))
 
 instance (priority := 100) compCreatesColimit {B : Type u₄} [Category.{v₄} B] {H : E ⥤ B}
     [CreatesColimit G H] : CreatesColimit (F ⋙ G) H where
   lifts {c} hc := by
-    refine ⟨(liftColimit ((isColimitExtendCoconeEquiv F (G := G ⋙ H) _).symm hc)).whisker F, ?_⟩
-    let i := liftedColimitMapsToOriginal ((isColimitExtendCoconeEquiv F (G := G ⋙ H) _).symm hc)
-    exact (Cocone.whiskering F).mapIso i ≪≫ ((coconesEquiv F (G ⋙ H)).unitIso.app _).symm
+    let t := (isColimitExtendCoconeEquiv F (G := G ⋙ H) _).symm
+      ((IsColimit.precomposeInvEquiv (Functor.associator F G H) c).symm hc)
+    refine ⟨(liftColimit t).whisker F, ?_⟩
+    let i := liftedColimitMapsToOriginal t
+    refine ?_ ≪≫ (Cocone.precompose (Functor.associator F G H).hom).mapIso
+      ((Cocone.whiskering F).mapIso i ≪≫ ((coconesEquiv F (G ⋙ H)).unitIso.app _).symm) ≪≫ ?_
+    all_goals exact Cocone.ext (Iso.refl _) (by simp)
 
 set_option backward.isDefEq.respectTransparency.types false in
 set_option backward.defeqAttrib.useBackward true in
@@ -418,10 +424,14 @@ def createsColimitOfComp {B : Type u₄} [Category.{v₄} B] {H : E ⥤ B}
     [CreatesColimit (F ⋙ G) H] : CreatesColimit G H where
   reflects := (reflectsColimit_of_comp F).reflects
   lifts {c} hc := by
-    refine ⟨(extendCocone (F := F)).obj (liftColimit ((isColimitWhiskerEquiv F _).symm hc)), ?_⟩
-    let i := liftedColimitMapsToOriginal (K := (F ⋙ G)) ((isColimitWhiskerEquiv F _).symm hc)
-    refine ?_ ≪≫ ((extendCocone (F := F)).mapIso i) ≪≫ ((coconesEquiv F (G ⋙ H)).counitIso.app _)
-    exact Cocone.ext (Iso.refl _)
+    let t := (IsColimit.precomposeHomEquiv (Functor.associator F G H) _).symm
+      ((isColimitWhiskerEquiv F _).symm hc)
+    refine ⟨(extendCocone (F := F)).obj (liftColimit t), ?_⟩
+    let i := liftedColimitMapsToOriginal t
+    refine ?_ ≪≫ (extendCocone (F := F)).mapIso
+      ((Cocone.precompose (Functor.associator F G H).inv).mapIso i ≪≫ ?_) ≪≫
+      ((coconesEquiv F (G ⋙ H)).counitIso.app _)
+    all_goals exact Cocone.ext (Iso.refl _) (by simp)
 
 include F in
 theorem hasColimitsOfShape_of_final [HasColimitsOfShape C E] : HasColimitsOfShape D E where
@@ -674,7 +684,8 @@ set_option backward.defeqAttrib.useBackward true in
 instance (priority := 100) comp_preservesLimit {B : Type u₄} [Category.{v₄} B] {H : E ⥤ B}
     [PreservesLimit G H] : PreservesLimit (F ⋙ G) H where
   preserves {c} hc := by
-    refine ⟨isLimitExtendConeEquiv (G := G ⋙ H) F (H.mapCone c) ?_⟩
+    refine ⟨(IsLimit.postcomposeHomEquiv (Functor.associator F G H) _)
+      (isLimitExtendConeEquiv (G := G ⋙ H) F _ ?_)⟩
     let hc' := isLimitOfPreserves H ((isLimitExtendConeEquiv F c).symm hc)
     exact IsLimit.ofIsoLimit hc' (Cone.ext (Iso.refl _) (by simp))
 
@@ -683,15 +694,20 @@ instance (priority := 100) comp_reflectsLimit {B : Type u₄} [Category.{v₄} B
     [ReflectsLimit G H] : ReflectsLimit (F ⋙ G) H where
   reflects {c} hc := by
     refine ⟨isLimitExtendConeEquiv F _ (isLimitOfReflects H ?_)⟩
-    let hc' := (isLimitExtendConeEquiv (G := G ⋙ H) F _).symm hc
+    let hc' := (isLimitExtendConeEquiv (G := G ⋙ H) F _).symm
+      ((IsLimit.postcomposeHomEquiv (Functor.associator F G H) _).symm hc)
     exact IsLimit.ofIsoLimit hc' (Cone.ext (Iso.refl _) (by simp))
 
 instance (priority := 100) compCreatesLimit {B : Type u₄} [Category.{v₄} B] {H : E ⥤ B}
     [CreatesLimit G H] : CreatesLimit (F ⋙ G) H where
   lifts {c} hc := by
-    refine ⟨(liftLimit ((isLimitExtendConeEquiv F (G := G ⋙ H) _).symm hc)).whisker F, ?_⟩
-    let i := liftedLimitMapsToOriginal ((isLimitExtendConeEquiv F (G := G ⋙ H) _).symm hc)
-    exact (Cone.whiskering F).mapIso i ≪≫ ((conesEquiv F (G ⋙ H)).unitIso.app _).symm
+    let t := (isLimitExtendConeEquiv F (G := G ⋙ H) _).symm
+      ((IsLimit.postcomposeHomEquiv (Functor.associator F G H) c).symm hc)
+    refine ⟨(liftLimit t).whisker F, ?_⟩
+    let i := liftedLimitMapsToOriginal t
+    refine ?_ ≪≫ (Cone.postcompose (Functor.associator F G H).inv).mapIso
+      ((Cone.whiskering F).mapIso i ≪≫ ((conesEquiv F (G ⋙ H)).unitIso.app _).symm) ≪≫ ?_
+    all_goals exact Cone.ext (Iso.refl _) (by simp)
 
 set_option backward.isDefEq.respectTransparency.types false in
 set_option backward.defeqAttrib.useBackward true in
@@ -770,10 +786,14 @@ def createsLimitOfComp {B : Type u₄} [Category.{v₄} B] {H : E ⥤ B}
     [CreatesLimit (F ⋙ G) H] : CreatesLimit G H where
   reflects := (reflectsLimit_of_comp F).reflects
   lifts {c} hc := by
-    refine ⟨(extendCone (F := F)).obj (liftLimit ((isLimitWhiskerEquiv F _).symm hc)), ?_⟩
-    let i := liftedLimitMapsToOriginal (K := (F ⋙ G)) ((isLimitWhiskerEquiv F _).symm hc)
-    refine ?_ ≪≫ ((extendCone (F := F)).mapIso i) ≪≫ ((conesEquiv F (G ⋙ H)).counitIso.app _)
-    exact Cone.ext (Iso.refl _)
+    let t := (IsLimit.postcomposeInvEquiv (Functor.associator F G H) _).symm
+      ((isLimitWhiskerEquiv F _).symm hc)
+    refine ⟨(extendCone (F := F)).obj (liftLimit t), ?_⟩
+    let i := liftedLimitMapsToOriginal t
+    refine ?_ ≪≫ (extendCone (F := F)).mapIso
+      ((Cone.postcompose (Functor.associator F G H).hom).mapIso i ≪≫ ?_) ≪≫
+      ((conesEquiv F (G ⋙ H)).counitIso.app _)
+    all_goals exact Cone.ext (Iso.refl _) (by simp)
 
 include F in
 theorem hasLimitsOfShape_of_initial [HasLimitsOfShape C E] : HasLimitsOfShape D E where
@@ -870,8 +890,11 @@ instance final_comp [hF : Final F] [hG : Final G] : Final (F ⋙ G) := by
   rw [final_iff_comp_equivalence G s₃.functor, final_iff_equivalence_comp s₂.inverse,
     final_iff_isIso_colimit_pre] at hG
   intro H
-  rw [← colimit.pre_pre]
-  infer_instance
+  have : IsIso (colimit.pre ((s₂.inverse ⋙ G ⋙ s₃.functor) ⋙ H) (s₁.inverse ⋙ F ⋙ s₂.functor) ≫
+      colimit.pre H (s₂.inverse ⋙ G ⋙ s₃.functor)) := inferInstance
+  rw [colimit.pre_pre] at this
+  exact IsIso.of_isIso_comp_left (HasColimit.isoOfNatIso (Functor.associator
+    (s₁.inverse ⋙ F ⋙ s₂.functor) (s₂.inverse ⋙ G ⋙ s₃.functor) H)).inv _
 
 instance initial_comp [Initial F] [Initial G] : Initial (F ⋙ G) := by
   suffices Final (F ⋙ G).op from initial_of_final_op _
@@ -891,8 +914,11 @@ theorem final_of_final_comp [hF : Final F] [hFG : Final (F ⋙ G)] : Final G := 
   rw [final_iff_comp_equivalence (F ⋙ G) s₃.functor, final_iff_equivalence_comp s₁.inverse,
     final_natIso_iff _i, final_iff_isIso_colimit_pre] at hFG
   intro H
-  replace hFG := hFG H
-  rw [← colimit.pre_pre] at hFG
+  have := hFG H
+  have : IsIso (colimit.pre ((s₂.inverse ⋙ G ⋙ s₃.functor) ⋙ H) (s₁.inverse ⋙ F ⋙ s₂.functor) ≫
+      colimit.pre H (s₂.inverse ⋙ G ⋙ s₃.functor)) := by
+    rw [colimit.pre_pre]
+    infer_instance
   exact IsIso.of_isIso_comp_left (colimit.pre _ (s₁.inverse ⋙ F ⋙ s₂.functor)) _
 
 theorem initial_of_initial_comp [Initial F] [Initial (F ⋙ G)] : Initial G := by

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
@@ -269,7 +269,9 @@ def limitCompWhiskeringLeftIsoCompLimit (F : J ⥤ K ⥤ C) (G : D ⥤ K) [HasLi
     limit (F ⋙ (whiskeringLeft _ _ _).obj G) ≅ G ⋙ limit F :=
   NatIso.ofComponents (fun j =>
     limitObjIsoLimitCompEvaluation (F ⋙ (whiskeringLeft _ _ _).obj G) j ≪≫
-      HasLimit.isoOfNatIso (isoWhiskerLeft F (whiskeringLeftCompEvaluation G j)) ≪≫
+      HasLimit.isoOfNatIso
+        (Functor.associator F ((whiskeringLeft D K C).obj G) ((evaluation D C).obj j) ≪≫
+          isoWhiskerLeft F (whiskeringLeftCompEvaluation G j)) ≪≫
       (limitObjIsoLimitCompEvaluation F (G.obj j)).symm)
 
 set_option backward.defeqAttrib.useBackward true in
@@ -360,7 +362,9 @@ def colimitCompWhiskeringLeftIsoCompColimit (F : J ⥤ K ⥤ C) (G : D ⥤ K) [H
     colimit (F ⋙ (whiskeringLeft _ _ _).obj G) ≅ G ⋙ colimit F :=
   NatIso.ofComponents (fun j =>
     colimitObjIsoColimitCompEvaluation (F ⋙ (whiskeringLeft _ _ _).obj G) j ≪≫
-      HasColimit.isoOfNatIso (isoWhiskerLeft F (whiskeringLeftCompEvaluation G j)) ≪≫
+      HasColimit.isoOfNatIso
+        (Functor.associator F ((whiskeringLeft D K C).obj G) ((evaluation D C).obj j) ≪≫
+          isoWhiskerLeft F (whiskeringLeftCompEvaluation G j)) ≪≫
       (colimitObjIsoColimitCompEvaluation F (G.obj j)).symm)
 
 set_option backward.defeqAttrib.useBackward true in

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -458,11 +458,16 @@ theorem limit.lift_pre (c : Cone F) :
 variable {L : Type u₃} [Category.{v₃} L]
 variable (D : L ⥤ K)
 
+/-- Precomposing with `E` and then with `D` is precomposing with `D ⋙ E`, up to the canonical
+isomorphism between the chosen limits of `(D ⋙ E) ⋙ F` and `D ⋙ E ⋙ F`. -/
 @[to_dual (attr := simp)]
-theorem limit.pre_pre [h : HasLimit (D ⋙ E ⋙ F)] : haveI : HasLimit ((D ⋙ E) ⋙ F) := h
-    limit.pre F E ≫ limit.pre (E ⋙ F) D = limit.pre F (D ⋙ E) := by
-  have : HasLimit ((D ⋙ E) ⋙ F) := h
-  ext j; erw [assoc, limit.pre_π, limit.pre_π, limit.pre_π]; rfl
+theorem limit.pre_pre [HasLimit (D ⋙ E ⋙ F)] :
+    letI : HasLimit ((D ⋙ E) ⋙ F) := hasLimit_of_iso (Functor.associator D E F).symm
+    limit.pre F E ≫ limit.pre (E ⋙ F) D =
+      limit.pre F (D ⋙ E) ≫ (HasLimit.isoOfNatIso (Functor.associator D E F)).hom := by
+  let _ : HasLimit ((D ⋙ E) ⋙ F) := hasLimit_of_iso (Functor.associator D E F).symm
+  ext j
+  simp
 
 variable {E F}
 
@@ -499,27 +504,33 @@ theorem limit.lift_post (c : Cone F) :
   rw [assoc, limit.post_π, ← G.map_comp, limit.lift_π, limit.lift_π]
   rfl
 
+/-- Postcomposing with `G` and then with `H` is postcomposing with `G ⋙ H`, up to the canonical
+isomorphism between the chosen limits of `(F ⋙ G) ⋙ H` and `F ⋙ G ⋙ H`. -/
 @[to_dual (attr := simp)]
-theorem limit.post_post {E : Type u''} [Category.{v''} E] (H : D ⥤ E) [h : HasLimit ((F ⋙ G) ⋙ H)] :
-    -- H G (limit F) ⟶ H (limit (F ⋙ G)) ⟶ limit ((F ⋙ G) ⋙ H) equals
-    -- H G (limit F) ⟶ limit (F ⋙ (G ⋙ H))
-    haveI : HasLimit (F ⋙ G ⋙ H) := h
-    H.map (limit.post F G) ≫ limit.post (F ⋙ G) H = limit.post F (G ⋙ H) := by
-  have : HasLimit (F ⋙ G ⋙ H) := h
-  ext; erw [assoc, limit.post_π, ← H.map_comp, limit.post_π, limit.post_π]; rfl
+theorem limit.post_post {E : Type u''} [Category.{v''} E] (H : D ⥤ E)
+    [HasLimit ((F ⋙ G) ⋙ H)] :
+    letI : HasLimit (F ⋙ G ⋙ H) := hasLimit_of_iso (Functor.associator F G H)
+    H.map (limit.post F G) ≫ limit.post (F ⋙ G) H =
+      limit.post F (G ⋙ H) ≫ (HasLimit.isoOfNatIso (Functor.associator F G H)).inv := by
+  let _ : HasLimit (F ⋙ G ⋙ H) := hasLimit_of_iso (Functor.associator F G H)
+  ext
+  simp [← H.map_comp]
 
 end Post
 
+/-- Precomposition and postcomposition commute, up to the canonical isomorphism between the
+chosen limits of `(E ⋙ F) ⋙ G` and `E ⋙ F ⋙ G`. -/
 @[to_dual]
 theorem limit.pre_post {D : Type u'} [Category.{v'} D] (E : K ⥤ J) (F : J ⥤ C) (G : C ⥤ D)
     [HasLimit F] [HasLimit (E ⋙ F)] [HasLimit (F ⋙ G)]
-    [h : HasLimit ((E ⋙ F) ⋙ G)] :
-    -- G (limit F) ⟶ G (limit (E ⋙ F)) ⟶ limit ((E ⋙ F) ⋙ G) vs
-    -- G (limit F) ⟶ limit F ⋙ G ⟶ limit (E ⋙ (F ⋙ G)) or
-    haveI : HasLimit (E ⋙ F ⋙ G) := h
-    G.map (limit.pre F E) ≫ limit.post (E ⋙ F) G = limit.post F G ≫ limit.pre (F ⋙ G) E := by
-  have : HasLimit (E ⋙ F ⋙ G) := h
-  ext; erw [assoc, limit.post_π, ← G.map_comp, limit.pre_π, assoc, limit.pre_π, limit.post_π]
+    [HasLimit ((E ⋙ F) ⋙ G)] :
+    letI : HasLimit (E ⋙ F ⋙ G) := hasLimit_of_iso (Functor.associator E F G)
+    G.map (limit.pre F E) ≫ limit.post (E ⋙ F) G =
+      limit.post F G ≫ limit.pre (F ⋙ G) E ≫
+        (HasLimit.isoOfNatIso (Functor.associator E F G)).inv := by
+  let _ : HasLimit (E ⋙ F ⋙ G) := hasLimit_of_iso (Functor.associator E F G)
+  ext j
+  simp [← G.map_comp]
 
 @[to_dual]
 instance hasLimit_equivalence_comp (e : K ≌ J) [HasLimit F] : HasLimit (e.functor ⋙ F) :=

--- a/Mathlib/CategoryTheory/Limits/IndYoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/IndYoneda.lean
@@ -67,16 +67,22 @@ lemma coyonedaOpColimitIsoLimitCoyoneda_inv_comp_π (i : I) :
 noncomputable def colimitHomIsoLimitYoneda
     [HasLimitsOfShape Iᵒᵖ (Type u₂)] (A : C) :
     (colimit F ⟶ A) ≅ limit (F.op ⋙ yoneda.obj A) :=
-  (coyonedaOpColimitIsoLimitCoyoneda F).app A ≪≫ limitObjIsoLimitCompEvaluation _ _
+  (coyonedaOpColimitIsoLimitCoyoneda F).app A ≪≫
+    limitObjIsoLimitCompEvaluation (F.op ⋙ coyoneda) A ≪≫
+      HasLimit.isoOfNatIso (Functor.associator F.op coyoneda ((evaluation C (Type u₂)).obj A) ≪≫
+        Functor.isoWhiskerLeft F.op (compEvaluation coyoneda A))
 
 @[reassoc (attr := simp)]
 lemma colimitHomIsoLimitYoneda_hom_comp_π [HasLimitsOfShape Iᵒᵖ (Type u₂)] (A : C) (i : I) :
     (colimitHomIsoLimitYoneda F A).hom ≫ limit.π (F.op ⋙ yoneda.obj A) ⟨i⟩ =
       (yoneda.obj A).map (colimit.ι F i).op := by
-  simp only [colimitHomIsoLimitYoneda, Iso.trans_hom, Iso.app_hom, Category.assoc]
-  erw [limitObjIsoLimitCompEvaluation_hom_π]
-  change ((coyonedaOpColimitIsoLimitCoyoneda F).hom ≫ _).app A = _
-  rw [coyonedaOpColimitIsoLimitCoyoneda_hom_comp_π, Functor.flip_map_app]
+  simp only [Functor.comp_obj, Functor.op_obj, yoneda_obj_obj, colimitHomIsoLimitYoneda,
+    Iso.trans_hom, Iso.app_hom, Category.assoc, HasLimit.isoOfNatIso_hom_π,
+    evaluation_obj_obj, Functor.flip_obj_obj, Functor.isoWhiskerLeft_hom, NatTrans.comp_app,
+    Functor.associator_hom_app, Functor.whiskerLeft_app, compEvaluation_hom_app,
+    Category.comp_id, limitObjIsoLimitCompEvaluation_hom_π, yoneda_obj_map, Quiver.Hom.unop_op]
+  rw [← NatTrans.comp_app, coyonedaOpColimitIsoLimitCoyoneda_hom_comp_π]
+  simp only [Functor.flip_map_app, yoneda_obj_map, Quiver.Hom.unop_op]
 
 set_option backward.defeqAttrib.useBackward true in
 @[reassoc (attr := simp)]
@@ -115,17 +121,23 @@ lemma coyonedaOpColimitIsoLimitCoyoneda'_inv_comp_π (i : I) :
 /-- Variant of `colimitHomIsoLimitYoneda` for contravariant `F`. -/
 noncomputable def colimitHomIsoLimitYoneda' [HasLimitsOfShape I (Type u₂)] (A : C) :
     (colimit F ⟶ A) ≅ limit (F.rightOp ⋙ yoneda.obj A) :=
-  (coyonedaOpColimitIsoLimitCoyoneda' F).app A ≪≫ limitObjIsoLimitCompEvaluation _ _
+  (coyonedaOpColimitIsoLimitCoyoneda' F).app A ≪≫
+    limitObjIsoLimitCompEvaluation (F.rightOp ⋙ coyoneda) A ≪≫
+      HasLimit.isoOfNatIso
+        (Functor.associator F.rightOp coyoneda ((evaluation C (Type u₂)).obj A) ≪≫
+          Functor.isoWhiskerLeft F.rightOp (compEvaluation coyoneda A))
 
 @[reassoc (attr := simp)]
 lemma colimitHomIsoLimitYoneda'_hom_comp_π [HasLimitsOfShape I (Type u₂)] (A : C) (i : I) :
     (colimitHomIsoLimitYoneda' F A).hom ≫ limit.π (F.rightOp ⋙ yoneda.obj A) i =
       (yoneda.obj A).map (colimit.ι F ⟨i⟩).op := by
-  simp only [colimitHomIsoLimitYoneda', Iso.trans_hom,
-    Iso.app_hom, Category.assoc]
-  erw [limitObjIsoLimitCompEvaluation_hom_π]
-  change ((coyonedaOpColimitIsoLimitCoyoneda' F).hom ≫ _).app A = _
-  rw [coyonedaOpColimitIsoLimitCoyoneda'_hom_comp_π, Functor.flip_map_app]
+  simp only [Functor.comp_obj, yoneda_obj_obj, colimitHomIsoLimitYoneda',
+    Iso.trans_hom, Iso.app_hom, Category.assoc, HasLimit.isoOfNatIso_hom_π,
+    evaluation_obj_obj, Functor.flip_obj_obj, Functor.isoWhiskerLeft_hom, NatTrans.comp_app,
+    Functor.associator_hom_app, Functor.whiskerLeft_app, compEvaluation_hom_app,
+    Category.comp_id, limitObjIsoLimitCompEvaluation_hom_π, yoneda_obj_map, Quiver.Hom.unop_op]
+  rw [← NatTrans.comp_app, coyonedaOpColimitIsoLimitCoyoneda'_hom_comp_π]
+  simp only [Functor.flip_map_app, yoneda_obj_map, Quiver.Hom.unop_op]
 
 set_option backward.defeqAttrib.useBackward true in
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Pullbacks.lean
@@ -342,7 +342,8 @@ def PushoutCocone.isColimitYonedaEquiv (c : PushoutCocone f g) :
     (Equiv.piCongrRight (fun X ↦
       (IsLimit.whiskerEquivalenceEquiv walkingSpanOpEquiv.symm).trans
         ((IsLimit.postcomposeHomEquiv
-          (isoWhiskerRight (cospanOp f g).symm (yoneda.obj X)) _).symm.trans
+          ((Functor.associator _ _ _).symm ≪≫
+            isoWhiskerRight (cospanOp f g).symm (yoneda.obj X)) _).symm.trans
             (Equiv.trans (IsLimit.equivIsoLimit
               (by exact Cone.ext (Iso.refl _) (by rintro (_ | _ | _) <;> cat_disch)))
                 (c.op.isLimitMapConeEquiv (yoneda.obj X))))))

--- a/Mathlib/CategoryTheory/Limits/Shapes/Opposites/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Opposites/Pullbacks.lean
@@ -68,7 +68,7 @@ def spanUnop {X Y Z : Cᵒᵖ} (f : X ⟶ Z) (g : Y ⟶ Z) :
 def opCospan {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
     (cospan f g).op ≅ walkingCospanOpEquiv.functor ⋙ span f.op g.op :=
   calc
-    (cospan f g).op ≅ 𝟭 _ ⋙ (cospan f g).op := .refl _
+    (cospan f g).op ≅ 𝟭 _ ⋙ (cospan f g).op := (Functor.leftUnitor _).symm
     _ ≅ (walkingCospanOpEquiv.functor ⋙ walkingCospanOpEquiv.inverse) ⋙ (cospan f g).op :=
       isoWhiskerRight walkingCospanOpEquiv.unitIso _
     _ ≅ walkingCospanOpEquiv.functor ⋙ walkingCospanOpEquiv.inverse ⋙ (cospan f g).op :=
@@ -102,7 +102,7 @@ def cospanUnop {X Y Z : Cᵒᵖ} (f : X ⟶ Y) (g : X ⟶ Z) :
 def opSpan {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
     (span f g).op ≅ walkingSpanOpEquiv.functor ⋙ cospan f.op g.op :=
   calc
-    (span f g).op ≅ 𝟭 _ ⋙ (span f g).op := .refl _
+    (span f g).op ≅ 𝟭 _ ⋙ (span f g).op := (Functor.leftUnitor _).symm
     _ ≅ (walkingSpanOpEquiv.functor ⋙ walkingSpanOpEquiv.inverse) ⋙ (span f g).op :=
       isoWhiskerRight walkingSpanOpEquiv.unitIso _
     _ ≅ walkingSpanOpEquiv.functor ⋙ walkingSpanOpEquiv.inverse ⋙ (span f g).op :=

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -370,7 +370,8 @@ theorem IsVanKampenColimit.map_reflective [HasColimitsOfShape J C]
     dsimp [α']
     simp only [Category.comp_id, Adjunction.counit_naturality_assoc, Category.id_comp,
       Adjunction.counit_naturality, Category.assoc, Functor.map_comp]
-  let β := isoWhiskerLeft F' (asIso adj.counit) ≪≫ F'.rightUnitor
+  -- bracketed as `(F' ⋙ Gr) ⋙ Gl`, matching `hr` and `Gl.mapCocone` below
+  let β := Functor.associator F' Gr Gl ≪≫ isoWhiskerLeft F' (asIso adj.counit) ≪≫ F'.rightUnitor
   let hl := (IsColimit.precomposeHomEquiv β c').symm hc'
   let hr := isColimitOfPreserves Gl (colimit.isColimit <| F' ⋙ Gr)
   have : α.app j = β.inv.app _ ≫ Gl.map (Gr.map <| α'.app j) := by
@@ -392,7 +393,8 @@ theorem IsVanKampenColimit.map_reflective [HasColimitsOfShape J C]
       intro j
       rw [hl.fac]
       dsimp [β]
-      simp only [Category.comp_id, hα'', Category.assoc, Gl.map_comp]
+      simp only [Functor.comp_obj, Category.comp_id, Category.id_comp, hα'', Category.assoc,
+        Gl.map_comp]
       congr 1
       exact (NatTrans.congr_app h j).symm
   rw [this]

--- a/Mathlib/CategoryTheory/Limits/Weighted/PreservesLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/Weighted/PreservesLimit.lean
@@ -82,7 +82,8 @@ public lemma preservesLimit
     [PreservesColimit G.leftOp (hasWeightedLimit.{w} F).ι] :
     PreservesLimit G (weightedLimFlipObj'.{w} F) where
   preserves {c} hc := ⟨by
-    refine (IsLimit.equivOfNatIsoOfIso (Iso.refl _) _ _ ?_).1
+    refine (IsLimit.equivOfNatIsoOfIso ((Functor.associator ..).symm ≪≫
+      isoWhiskerRight (Functor.opOpCompLeftOpOpIso G) _) _ _ ?_).1
       ((preservesLimit' (coconeLeftOpOfCone c)
         (isColimitOfPreserves (hasWeightedLimit.{w} F).ι
           (isColimitCoconeLeftOpOfCone _ hc))).whiskerEquivalence

--- a/Mathlib/CategoryTheory/Localization/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Localization/Adjunction.lean
@@ -49,34 +49,28 @@ noncomputable def ε : 𝟭 D₁ ⟶ G' ⋙ F' := by
   letI : Lifting L₁ W₁ ((G ⋙ F) ⋙ L₁) (G' ⋙ F') :=
     Lifting.mk (CatCommSq.hComp G F L₁ L₂ L₁ G' F').iso.symm
   exact Localization.liftNatTrans L₁ W₁ L₁ ((G ⋙ F) ⋙ L₁) (𝟭 D₁) (G' ⋙ F')
-    (whiskerRight adj.unit L₁)
+    (L₁.leftUnitor.inv ≫ whiskerRight adj.unit L₁)
 
 set_option backward.defeqAttrib.useBackward true in
 lemma ε_app (X₁ : C₁) :
     (ε adj L₁ W₁ L₂ G' F').app (L₁.obj X₁) =
       L₁.map (adj.unit.app X₁) ≫ (CatCommSq.iso F L₂ L₁ F').hom.app (G.obj X₁) ≫
         F'.map ((CatCommSq.iso G L₁ L₂ G').hom.app X₁) := by
-  let : Lifting L₁ W₁ ((G ⋙ F) ⋙ L₁) (G' ⋙ F') :=
-    Lifting.mk (CatCommSq.hComp G F L₁ L₂ L₁ G' F').iso.symm
-  simp only [ε, liftNatTrans_app, Lifting.iso, Iso.symm,
-    Functor.id_obj, Functor.comp_obj, Functor.rightUnitor_hom_app,
-      whiskerRight_app, CatCommSq.hComp_iso_hom_app, id_comp]
+  simp [ε]
 
 /-- Auxiliary definition of the counit morphism for the adjunction `Adjunction.localization` -/
 noncomputable def η : F' ⋙ G' ⟶ 𝟭 D₂ := by
   letI : Lifting L₂ W₂ ((F ⋙ G) ⋙ L₂) (F' ⋙ G') :=
     Lifting.mk (CatCommSq.hComp F G L₂ L₁ L₂ F' G').iso.symm
-  exact liftNatTrans L₂ W₂ ((F ⋙ G) ⋙ L₂) L₂ (F' ⋙ G') (𝟭 D₂) (whiskerRight adj.counit L₂)
+  exact liftNatTrans L₂ W₂ ((F ⋙ G) ⋙ L₂) L₂ (F' ⋙ G') (𝟭 D₂)
+    (whiskerRight adj.counit L₂ ≫ L₂.leftUnitor.hom)
 
 lemma η_app (X₂ : C₂) :
     (η adj L₁ L₂ W₂ G' F').app (L₂.obj X₂) =
       G'.map ((CatCommSq.iso F L₂ L₁ F').inv.app X₂) ≫
         (CatCommSq.iso G L₁ L₂ G').inv.app (F.obj X₂) ≫
         L₂.map (adj.counit.app X₂) := by
-  let : Lifting L₂ W₂ ((F ⋙ G) ⋙ L₂) (F' ⋙ G') :=
-    Lifting.mk (CatCommSq.hComp F G L₂ L₁ L₂ F' G').iso.symm
-  simp only [η, liftNatTrans_app, Lifting.iso, Iso.symm, CatCommSq.hComp_iso_inv_app,
-    whiskerRight_app, Functor.rightUnitor_inv_app, comp_id, assoc]
+  simp [η]
 
 end Localization
 
@@ -143,7 +137,8 @@ lemma isLocalization [F.Full] [F.Faithful] :
   have : IsIso (whiskerRight adj.unit W.Q) := NatIso.isIso_of_isIso_app _
   let e : W.Localization ≌ C₂ := Equivalence.mk (Localization.lift G hG W.Q) (F ⋙ W.Q)
     (liftNatIso W.Q W W.Q (G ⋙ F ⋙ W.Q) _ _
-    (W.Q.leftUnitor.symm ≪≫ asIso (whiskerRight adj.unit W.Q)))
+    (W.Q.leftUnitor.symm ≪≫ asIso (whiskerRight adj.unit W.Q) ≪≫
+      Functor.associator G F W.Q))
     (Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ (Localization.fac G hG W.Q) ≪≫
       asIso adj.counit)
   apply Functor.IsLocalization.of_equivalence_target W.Q W G e

--- a/Mathlib/CategoryTheory/Monad/Limits.lean
+++ b/Mathlib/CategoryTheory/Monad/Limits.lean
@@ -58,7 +58,8 @@ def γ : D ⋙ T.forget ⋙ ↑T ⟶ D ⋙ T.forget where app j := (D.obj j).a
 @[simps! π_app]
 def newCone : Cone (D ⋙ forget T) where
   pt := T.obj c.pt
-  π := (Functor.constComp _ _ (T : C ⥤ C)).inv ≫ whiskerRight c.π (T : C ⥤ C) ≫ γ D
+  π := (Functor.constComp _ _ (T : C ⥤ C)).inv ≫ whiskerRight c.π (T : C ⥤ C) ≫
+    (Functor.associator _ _ _).hom ≫ γ D
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The algebra structure which will be the apex of the new limit cone for `D`. -/
@@ -406,7 +407,8 @@ def γ : D ⋙ T.forget ⟶ D ⋙ T.forget ⋙ ↑T where app j := (D.obj j).a
 @[simps! ι_app]
 def newCocone : Cocone (D ⋙ forget T) where
   pt := T.obj c.pt
-  ι := γ D ≫ whiskerRight c.ι (T : C ⥤ C) ≫ (Functor.constComp J _ (T : C ⥤ C)).hom
+  ι := γ D ≫ (Functor.associator _ _ _).inv ≫ whiskerRight c.ι (T : C ⥤ C) ≫
+    (Functor.constComp J _ (T : C ⥤ C)).hom
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The coalgebra structure which will be the point of the new colimit cone for `D`. -/

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -9,6 +9,7 @@ public import Mathlib.CategoryTheory.Limits.Constructions.FiniteProductsOfBinary
 public import Mathlib.CategoryTheory.Limits.FullSubcategory
 public import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Terminal
 public import Mathlib.CategoryTheory.Monoidal.Braided.Basic
+public import Mathlib.CategoryTheory.Monoidal.Multifunctor
 
 /-!
 # Categories with chosen finite products
@@ -664,8 +665,11 @@ def prodComparisonNatTrans (A : C) :
 
 set_option backward.defeqAttrib.useBackward true in
 theorem prodComparisonNatTrans_comp :
-    prodComparisonNatTrans (F ⋙ G) A = Functor.whiskerRight (prodComparisonNatTrans F A) G ≫
-      Functor.whiskerLeft F (prodComparisonNatTrans G (F.obj A)) := by
+    prodComparisonNatTrans (F ⋙ G) A =
+      (Functor.associator _ F G).inv ≫ Functor.whiskerRight (prodComparisonNatTrans F A) G ≫
+        (Functor.associator F _ G).hom ≫
+          Functor.whiskerLeft F (prodComparisonNatTrans G (F.obj A)) ≫
+            (Functor.associator F G _).inv := by
   ext; simp [prodComparison_comp]
 
 set_option backward.defeqAttrib.useBackward true in
@@ -688,11 +692,15 @@ def prodComparisonBifunctorNatTrans :
 variable {E : Type u₂} [Category.{v₂} E] [CartesianMonoidalCategory E] (G : D ⥤ E)
 
 set_option backward.defeqAttrib.useBackward true in
-theorem prodComparisonBifunctorNatTrans_comp : prodComparisonBifunctorNatTrans (F ⋙ G) =
-    Functor.whiskerRight
-      (prodComparisonBifunctorNatTrans F) ((Functor.whiskeringRight _ _ _).obj G) ≫
-        Functor.whiskerLeft F (Functor.whiskerRight (prodComparisonBifunctorNatTrans G)
-          ((Functor.whiskeringLeft _ _ _).obj F)) := by
+theorem prodComparisonBifunctorNatTrans_comp :
+    prodComparisonBifunctorNatTrans (F ⋙ G) =
+      (curriedTensorPostCompIso F G).hom ≫
+        Functor.whiskerRight (prodComparisonBifunctorNatTrans F)
+            ((Functor.whiskeringRight C D E).obj G) ≫
+          (curriedTensorPreCompPostIso F G).hom ≫
+            Functor.whiskerLeft F (Functor.whiskerRight (prodComparisonBifunctorNatTrans G)
+              ((Functor.whiskeringLeft C D E).obj F)) ≫
+              (curriedTensorPreCompIso F G).hom := by
   ext; simp [prodComparison_comp]
 
 instance (A : C) [∀ B, IsIso (prodComparison F A B)] : IsIso (prodComparisonNatTrans F A) := by

--- a/Mathlib/CategoryTheory/Monoidal/Multifunctor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Multifunctor.lean
@@ -95,6 +95,41 @@ def curriedTensorPreFunctor : (C ⥤ D) ⥤ C ⥤ C ⥤ D where
 abbrev curriedTensorPostFunctor : (C ⥤ D) ⥤ C ⥤ C ⥤ D :=
   Functor.postcompose₂.flip.obj (curriedTensor C)
 
+section
+
+variable {E : Type*} [Category* E] [MonoidalCategory E] (F : C ⥤ D) (G : D ⥤ E)
+
+/-- `(F ⋙ G) (A ⊗ B) ≅ G (F (A ⊗ B))`, naturally in `A` and `B`. -/
+@[simps!]
+def curriedTensorPostCompIso :
+    curriedTensorPost (F ⋙ G) ≅ curriedTensorPost F ⋙ (Functor.whiskeringRight C D E).obj G :=
+  Functor.isoWhiskerLeft (curriedTensor C) (Functor.whiskeringRightObjCompIso F G).symm ≪≫
+    (Functor.associator _ _ _).symm
+
+/-- `G` applied to the bifunctor `F - ⊗ F -` is the bifunctor `G (- ⊗ -)` evaluated at
+`(F A, F B)`: both are `G (F A ⊗ F B)`, naturally in `A` and `B`. -/
+@[simps!]
+def curriedTensorPreCompPostIso :
+    curriedTensorPre F ⋙ (Functor.whiskeringRight C D E).obj G ≅
+      F ⋙ curriedTensorPost G ⋙ (Functor.whiskeringLeft C D E).obj F :=
+  Functor.associator _ _ _ ≪≫
+    Functor.isoWhiskerLeft F (Functor.associator _ _ _ ≪≫
+      Functor.isoWhiskerLeft (curriedTensor D)
+        (Functor.whiskeringLeftObjCompWhiskeringRightObjIso F G) ≪≫
+      (Functor.associator _ _ _).symm)
+
+/-- `G (F A) ⊗ G (F B) ≅ (F ⋙ G) A ⊗ (F ⋙ G) B`, naturally in `A` and `B`. -/
+@[simps!]
+def curriedTensorPreCompIso :
+    F ⋙ curriedTensorPre G ⋙ (Functor.whiskeringLeft C D E).obj F ≅ curriedTensorPre (F ⋙ G) :=
+  Functor.isoWhiskerLeft F (Functor.associator _ _ _ ≪≫
+      Functor.isoWhiskerLeft G (Functor.associator _ _ _ ≪≫
+        Functor.isoWhiskerLeft (curriedTensor E)
+          (Functor.whiskeringLeftObjCompIso F G).symm)) ≪≫
+    (Functor.associator _ _ _).symm
+
+end
+
 end MonoidalCategory
 
 open MonoidalCategory

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -364,6 +364,11 @@ end
 def leftOpRightOpIso (F : C ⥤ Dᵒᵖ) : F.leftOp.rightOp ≅ F :=
   NatIso.ofComponents fun _ => Iso.refl _
 
+/-- Reindexing `F.leftOp.op` along `opOp C` recovers `F`. -/
+@[simps!]
+def opOpCompLeftOpOpIso (F : C ⥤ Dᵒᵖ) : opOp C ⋙ F.leftOp.op ≅ F :=
+  NatIso.ofComponents fun _ ↦ Iso.refl _
+
 /-- The isomorphism between `F.rightOp.leftOp` and `F`. -/
 @[simps!]
 def rightOpLeftOpIso (F : Cᵒᵖ ⥤ D) : F.rightOp.leftOp ≅ F :=

--- a/Mathlib/CategoryTheory/Shift/Induced.lean
+++ b/Mathlib/CategoryTheory/Shift/Induced.lean
@@ -137,7 +137,8 @@ noncomputable def induced : HasShift D A :=
         suffices (Induced.add F s i (m₁ + m₂) m₃).hom ≫
             whiskerRight (Induced.add F s i m₁ m₂).hom (s m₃) =
             eqToHom (by rw [add_assoc]) ≫ (Induced.add F s i m₁ (m₂ + m₃)).hom ≫
-              whiskerLeft (s m₁) (Induced.add F s i m₂ m₃).hom by
+              whiskerLeft (s m₁) (Induced.add F s i m₂ m₃).hom ≫
+                (Functor.associator (s m₁) (s m₂) (s m₃)).inv by
           intro X
           simpa using NatTrans.congr_app this X
         apply ((whiskeringLeft C D D).obj F).map_injective

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -167,6 +167,16 @@ def whiskeringRightObjCompIso {D' : Type u₄} [Category.{v₄} D'] (F : C ⥤ D
     (whiskeringRight E C D').obj (F ⋙ G) :=
   Iso.refl _
 
+/-- The isomorphism between left-whiskering by `F` followed by right-whiskering by `G` and
+right-whiskering by `G` followed by left-whiskering by `F`. This is the functorial form of
+`whiskerRight_left`; its component at `H` is the associator `(F ⋙ H) ⋙ G ≅ F ⋙ H ⋙ G`. -/
+@[simps!]
+def whiskeringLeftObjCompWhiskeringRightObjIso {D' : Type u₄} [Category.{v₄} D'] (F : C ⥤ D)
+    (G : D' ⥤ E) :
+    (whiskeringLeft C D D').obj F ⋙ (whiskeringRight C D' E).obj G ≅
+    (whiskeringRight D D' E).obj G ⋙ (whiskeringLeft C D E).obj F :=
+  NatIso.ofComponents fun H ↦ associator F H G
+
 instance full_whiskeringRight_obj {F : D ⥤ E} [F.Faithful] [F.Full] :
     ((whiskeringRight C D E).obj F).Full :=
   ((Functor.FullyFaithful.ofFullyFaithful F).whiskeringRight C).full


### PR DESCRIPTION
This PR inserts the functor associators and unitors that Mathlib currently omits, or applies in the wrong direction, when it identifies `(F ⋙ G) ⋙ H` with `F ⋙ G ⋙ H` or `𝟭 C ⋙ F` with `F` by unfolding `Functor.comp` and `Functor.id`. None of these changes are *necessary*, but all reduce some defeq abuse that hopefully will make life easier in future.

It is extracted from Paul Reichert's experiment making `Functor.comp` and `Functor.id` `instance_reducible` with a semireducible `map` field (https://github.com/leanprover-community/mathlib4/compare/master...leanprover-community:mathlib4-nightly-testing:datokrat/functorcomp, discussed at https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency), keeping only the bracketing and unit fixes so that future experiments of this kind have less to repair. The `Functor.comp_map` proof changes from that branch are not included, and the corresponding changes for (pre)sheaves of modules are in a separate PR.

The notable API changes are: `limit.pre_pre`, `post_post`, `pre_post` and their duals now relate the two bracketings through `HasLimit.isoOfNatIso (Functor.associator _ _ _)`; `StructuredArrow.final_map₂_id` takes `β : T ⋙ S ⟶ 𝟭 C ⋙ T'`; and `Join.mkNatTrans` and `mkNatIso` carry associators in their (autoparam) compatibility hypothesis.

🤖 Prepared with Claude Code