### PR TITLE
[Merged by Bors] - refactor(CategoryTheory): insert missing Functor.op compatibility isomorphisms

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialObject/Op.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Op.lean
@@ -66,7 +66,9 @@ is a covariant involution. -/
 def opFunctorCompOpFunctorIso : opFunctor (C := C) ⋙ opFunctor ≅ 𝟭 _ :=
   (Functor.whiskeringLeftObjCompIso _ _).symm ≪≫
     (Functor.whiskeringLeft _ _ _).mapIso
-    ((Functor.opHom _ _).mapIso (SimplexCategory.revCompRevIso).symm.op) ≪≫
+    ((Functor.opComp _ _).symm ≪≫
+      (Functor.opHom _ _).mapIso (SimplexCategory.revCompRevIso).symm.op ≪≫
+      Functor.opId _) ≪≫
     Functor.whiskeringLeftObjIdIso
 
 @[simp]

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -36,33 +36,50 @@ attribute [local simp] homEquiv_unit homEquiv_counit
 /-- If `G` is adjoint to `F` then `F.unop` is adjoint to `G.unop`. -/
 @[simps]
 def unop {F : Cᵒᵖ ⥤ Dᵒᵖ} {G : Dᵒᵖ ⥤ Cᵒᵖ} (h : G ⊣ F) : F.unop ⊣ G.unop where
-  unit := NatTrans.unop h.counit
-  counit := NatTrans.unop h.unit
+  unit :=
+    { app := fun X ↦ (h.counit.app (Opposite.op X)).unop
+      naturality := fun _ _ f ↦ Quiver.Hom.op_inj (by simp) }
+  counit :=
+    { app := fun X ↦ (h.unit.app (Opposite.op X)).unop
+      naturality := fun _ _ f ↦ Quiver.Hom.op_inj (by simp) }
   left_triangle_components _ := Quiver.Hom.op_inj (h.right_triangle_components _)
   right_triangle_components _ := Quiver.Hom.op_inj (h.left_triangle_components _)
 
-set_option backward.defeqAttrib.useBackward true in
 /-- If `G` is adjoint to `F` then `F.op` is adjoint to `G.op`. -/
 @[simps]
 def op {F : C ⥤ D} {G : D ⥤ C} (h : G ⊣ F) : F.op ⊣ G.op where
-  unit := NatTrans.op h.counit
-  counit := NatTrans.op h.unit
+  unit :=
+    { app := fun X ↦ (h.counit.app X.unop).op
+      naturality := fun _ _ f ↦ Quiver.Hom.unop_inj (by simp) }
+  counit :=
+    { app := fun X ↦ (h.unit.app X.unop).op
+      naturality := fun _ _ f ↦ Quiver.Hom.unop_inj (by simp) }
   left_triangle_components _ := Quiver.Hom.unop_inj (by simp)
   right_triangle_components _ := Quiver.Hom.unop_inj (by simp)
 
 /-- If `F` is adjoint to `G.leftOp` then `G` is adjoint to `F.leftOp`. -/
 @[simps]
 def leftOp {F : C ⥤ Dᵒᵖ} {G : D ⥤ Cᵒᵖ} (a : F ⊣ G.leftOp) : G ⊣ F.leftOp where
-  unit := NatTrans.unop a.counit
-  counit := NatTrans.op a.unit
+  unit :=
+    { app := fun X ↦ (a.counit.app (Opposite.op X)).unop
+      naturality := fun _ _ f ↦ Quiver.Hom.op_inj (by simpa using (a.counit.naturality f.op).symm) }
+  counit :=
+    { app := fun X ↦ (a.unit.app X.unop).op
+      naturality := fun _ _ f ↦
+        Quiver.Hom.unop_inj (by simpa using (a.unit.naturality f.unop).symm) }
   left_triangle_components X := congr($(a.right_triangle_components (.op X)).op)
   right_triangle_components X := congr($(a.left_triangle_components X.unop).unop)
 
 /-- If `F.rightOp` is adjoint to `G` then `G.rightOp` is adjoint to `F`. -/
 @[simps]
 def rightOp {F : Cᵒᵖ ⥤ D} {G : Dᵒᵖ ⥤ C} (a : F.rightOp ⊣ G) : G.rightOp ⊣ F where
-  unit := NatTrans.unop a.counit
-  counit := NatTrans.op a.unit
+  unit :=
+    { app := fun X ↦ (a.counit.app (Opposite.op X)).unop
+      naturality := fun _ _ f ↦ Quiver.Hom.op_inj (by simpa using (a.counit.naturality f.op).symm) }
+  counit :=
+    { app := fun X ↦ (a.unit.app X.unop).op
+      naturality := fun _ _ f ↦
+        Quiver.Hom.unop_inj (by simpa using (a.unit.naturality f.unop).symm) }
   left_triangle_components X := congr($(a.right_triangle_components (.op X)).op)
   right_triangle_components X := congr($(a.left_triangle_components X.unop).unop)
 

--- a/Mathlib/CategoryTheory/Limits/ConstructLimitMap.lean
+++ b/Mathlib/CategoryTheory/Limits/ConstructLimitMap.lean
@@ -116,9 +116,8 @@ lemma Limits.exists_eq_isColimitMap_of_preservesColimit_coyoneda
     exact preservesColimit_of_iso_diagram _ iso.symm
   obtain ⟨J, _, _, G, G', _, _, g, hg⟩ :=
     exists_eq_isLimitMap_of_preservesColimit_yoneda hc'.op hc.op f.op
-  have := NatTrans.leftOp g
   refine ⟨Jᵒᵖ, inferInstance, inferInstance, G'.leftOp, G.leftOp, inferInstance, inferInstance,
-    NatTrans.leftOp g, ?_⟩
+    (Functor.leftOpCompOp G' D).inv ≫ NatTrans.leftOp g ≫ (Functor.leftOpCompOp G D').hom, ?_⟩
   refine Quiver.Hom.op_inj ?_
   rw [hg]
   refine ((Functor.Initial.isLimitWhiskerEquiv G' c.op).symm hc.op).hom_ext fun k ↦ ?_

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -151,8 +151,8 @@ def opOp : C ⥤ Cᵒᵖᵒᵖ where
 def opOpEquivalence : Cᵒᵖᵒᵖ ≌ C where
   functor := unopUnop C
   inverse := opOp C
-  unitIso := Iso.refl (𝟭 Cᵒᵖᵒᵖ)
-  counitIso := Iso.refl (opOp C ⋙ unopUnop C)
+  unitIso := NatIso.ofComponents fun _ ↦ Iso.refl _
+  counitIso := NatIso.ofComponents fun _ ↦ Iso.refl _
 
 instance : (opOp C).IsEquivalence :=
   (opOpEquivalence C).isEquivalence_inverse
@@ -344,6 +344,13 @@ def rightOpComp {E : Type*} [Category* E] (F : Cᵒᵖ ⥤ D) (G : D ⥤ E) :
 @[simps!]
 def leftOpComp {E : Type*} [Category* E] (F : C ⥤ D) (G : D ⥤ Eᵒᵖ) :
     (F ⋙ G).leftOp ≅ F.op ⋙ G.leftOp :=
+  Iso.refl _
+
+/-- Compatibility of `Functor.leftOp` with respect to composition with the opposite of a
+functor. -/
+@[simps!]
+def leftOpCompOp {E : Type*} [Category* E] (F : C ⥤ Dᵒᵖ) (G : D ⥤ E) :
+    (F ⋙ G.op).leftOp ≅ F.leftOp ⋙ G :=
   Iso.refl _
 
 section

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Basic.lean
@@ -136,12 +136,16 @@ are stated as separate lemmas. -/
 def opShiftFunctorEquivalence (n : ℤ) : Cᵒᵖ ≌ Cᵒᵖ where
   functor := shiftFunctor Cᵒᵖ n
   inverse := (shiftFunctor C n).op
-  unitIso := NatIso.op (shiftFunctorCompIsoId C (-n) n n.add_left_neg) ≪≫
+  unitIso := (Functor.opId C).symm ≪≫
+    NatIso.op (shiftFunctorCompIsoId C (-n) n n.add_left_neg) ≪≫
+    Functor.opComp (shiftFunctor C (-n)) (shiftFunctor C n) ≪≫
     Functor.isoWhiskerRight (shiftFunctorOpIso C n (-n) n.add_right_neg).symm (shiftFunctor C n).op
   counitIso := Functor.isoWhiskerLeft _ (shiftFunctorOpIso C n (-n) n.add_right_neg) ≪≫
-    NatIso.op (shiftFunctorCompIsoId C n (-n) n.add_right_neg).symm
+    (Functor.opComp (shiftFunctor C n) (shiftFunctor C (-n))).symm ≪≫
+    NatIso.op (shiftFunctorCompIsoId C n (-n) n.add_right_neg).symm ≪≫ Functor.opId C
   functor_unitIso_comp X := Quiver.Hom.unop_inj (by
     dsimp [shiftFunctorOpIso]
+    simp only [Category.id_comp, Category.comp_id]
     erw [comp_id, Functor.map_id, comp_id]
     change (shiftFunctorCompIsoId C n (-n) (add_neg_cancel n)).inv.app (X.unop⟦-n⟧) ≫
       ((shiftFunctorCompIsoId C (-n) n (neg_add_cancel n)).hom.app X.unop)⟦-n⟧' = 𝟙 _
@@ -156,7 +160,7 @@ lemma opShiftFunctorEquivalence_unitIso_hom_app (X : Cᵒᵖ) (n m : ℤ) (hnm :
       ((shiftFunctorCompIsoId C m n (by lia)).hom.app X.unop).op ≫
         (((shiftFunctorOpIso C n m hnm).inv.app (X)).unop⟦n⟧').op := by
   obtain rfl : m = -n := by lia
-  rfl
+  simp [opShiftFunctorEquivalence]
 
 #adaptation_note
 /-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
@@ -167,7 +171,7 @@ lemma opShiftFunctorEquivalence_unitIso_inv_app (X : Cᵒᵖ) (n m : ℤ) (hnm :
       (((shiftFunctorOpIso C n m hnm).hom.app (X)).unop⟦n⟧').op ≫
       ((shiftFunctorCompIsoId C m n (by lia)).inv.app X.unop).op := by
   obtain rfl : m = -n := by lia
-  rfl
+  simp [opShiftFunctorEquivalence]
 
 #adaptation_note
 /-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
@@ -179,7 +183,7 @@ lemma opShiftFunctorEquivalence_counitIso_hom_app (X : Cᵒᵖ) (n m : ℤ) (hnm
         ((shiftFunctorCompIsoId C n m hnm).inv.app X.unop).op
         := by
   obtain rfl : m = -n := by lia
-  rfl
+  simp [opShiftFunctorEquivalence]
 
 #adaptation_note
 /-- `respectTransparency.types true` changes the auto-generated lemmas' signature -/
@@ -190,7 +194,7 @@ lemma opShiftFunctorEquivalence_counitIso_inv_app (X : Cᵒᵖ) (n m : ℤ) (hnm
       ((shiftFunctorCompIsoId C n m hnm).hom.app X.unop).op ≫
         (shiftFunctorOpIso C n m hnm).inv.app (Opposite.op (X.unop⟦n⟧)) := by
   obtain rfl : m = -n := by lia
-  rfl
+  simp [opShiftFunctorEquivalence]
 
 /-! The naturality of the unit and counit isomorphisms are restated in the following
 lemmas so as to mitigate the need for `erw`. -/
@@ -236,6 +240,7 @@ lemma opShiftFunctorEquivalence_zero_unitIso_hom_app (X : Cᵒᵖ) :
       (((shiftFunctorZero Cᵒᵖ ℤ).inv.app X).unop⟦(0 : ℤ)⟧').op := by
   apply Quiver.Hom.unop_inj
   dsimp [opShiftFunctorEquivalence]
+  simp only [Category.comp_id]
   rw [shiftFunctorZero_op_inv_app, unop_comp, Quiver.Hom.unop_op, Functor.map_comp,
     shiftFunctorCompIsoId_zero_zero_hom_app, assoc]
 
@@ -246,6 +251,7 @@ lemma opShiftFunctorEquivalence_zero_unitIso_inv_app (X : Cᵒᵖ) :
         ((shiftFunctorZero C ℤ).inv.app X.unop).op := by
   apply Quiver.Hom.unop_inj
   dsimp [opShiftFunctorEquivalence]
+  simp only [Category.id_comp]
   rw [shiftFunctorZero_op_hom_app, unop_comp, Quiver.Hom.unop_op, Functor.map_comp,
     shiftFunctorCompIsoId_zero_zero_inv_app, assoc]
 
@@ -258,17 +264,20 @@ lemma opShiftFunctorEquivalence_add_unitIso_hom_app_eq
       (((opShiftFunctorEquivalence C m).unitIso.hom.app (X⟦n⟧)).unop⟦n⟧').op ≫
       ((shiftFunctorAdd' C m n p h).hom.app _).op ≫
       (((shiftFunctorAdd' Cᵒᵖ n m p (by lia)).inv.app X).unop⟦p⟧').op := by
-  dsimp [opShiftFunctorEquivalence]
+  rw [opShiftFunctorEquivalence_unitIso_hom_app X p (-p) (by lia),
+    opShiftFunctorEquivalence_unitIso_hom_app X n (-n) (by lia),
+    opShiftFunctorEquivalence_unitIso_hom_app (X⟦n⟧) m (-m) (by lia)]
   simp only [shiftFunctorAdd'_op_inv_app _ n m p (by lia) _ _ _ (add_neg_cancel n)
     (add_neg_cancel m) (add_neg_cancel p), shiftFunctor_op_map _ m (-m),
     Category.assoc, Iso.inv_hom_id_app_assoc]
   erw [Functor.map_id, Functor.map_id, Functor.map_id, Functor.map_id,
-    id_comp, id_comp, id_comp, comp_id, comp_id]
+    id_comp, id_comp]
   dsimp
   rw [comp_id, shiftFunctorCompIsoId_add'_hom_app _ _ _ _ _ _
     (neg_add_cancel m) (neg_add_cancel n) (neg_add_cancel p) h]
   dsimp
-  rw [Category.assoc, Category.assoc]
+  simp only [Category.assoc]
+  erw [comp_id, id_comp, id_comp]
   rfl
 
 set_option backward.defeqAttrib.useBackward true in

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
@@ -117,6 +117,7 @@ lemma map_opShiftFunctorEquivalence_unitIso_hom_app_unop (X : Cᵒᵖ) (n : ℤ)
         (((F.op).commShiftIso n).inv.app X).unop⟦n⟧' ≫
         ((opShiftFunctorEquivalence D n).unitIso.hom.app (op _)).unop := by
   dsimp [opShiftFunctorEquivalence]
+  simp only [comp_id]
   simp only [map_comp, unop_comp, Quiver.Hom.unop_op, assoc,
     map_shiftFunctorCompIsoId_hom_app, commShiftIso_hom_naturality_assoc,
     op_commShiftIso_inv_app _ _ _ _ (add_neg_cancel n)]
@@ -148,6 +149,7 @@ lemma map_opShiftFunctorEquivalence_counitIso_hom_app_unop (X : Cᵒᵖ) (n : �
           ((F.op.commShiftIso n).hom.app (op (X.unop⟦n⟧))).unop := by
   apply Quiver.Hom.op_inj
   dsimp [opShiftFunctorEquivalence]
+  simp only [id_comp, comp_id]
   rw [assoc, F.op_commShiftIso_hom_app_assoc _ _ _ (add_neg_cancel n), map_comp,
     map_shiftFunctorCompIsoId_inv_app_assoc, op_comp, op_comp_assoc, op_comp_assoc,
     NatTrans.naturality_assoc, op_map, Iso.inv_hom_id_app_assoc, Quiver.Hom.unop_op]


### PR DESCRIPTION
This PR inserts `Functor.opId`, `Functor.opComp` and the new `Functor.leftOpCompOp` where Mathlib currently identifies `(F ⋙ G).op` with `F.op ⋙ G.op`, `(𝟭 C).op` with `𝟭 Cᵒᵖ`, or `(F ⋙ G.op).leftOp` with `F.leftOp ⋙ G` by unfolding `Functor.op`, and states the units and counits of `Adjunction.op`, `unop`, `leftOp` and `rightOp` componentwise rather than as `NatTrans.op`/`NatTrans.unop` at a type that only matches after unfolding. The unit and counit of `opOpEquivalence` are likewise built from components. The affected declarations are `opShiftFunctorEquivalence`, `SimplicialObject.opFunctorCompOpFunctorIso` and `Limits.exists_eq_isColimitMap_of_preservesColimit_coyoneda`.

It is extracted from Paul Reichert's experiment making `Functor.comp` and `Functor.id` `instance_reducible` (https://github.com/leanprover-community/mathlib4/compare/master...leanprover-community:mathlib4-nightly-testing:datokrat/functorcomp, discussed at https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency), keeping only the `Functor.op` fixes; the associator and unitor fixes are in https://github.com/leanprover-community/mathlib4/pull/43566.

🤖 Prepared with Claude Code