### PR TITLE
[Merged by Bors] - refactor(CategoryTheory/Limits): use compEvaluation in limitIsoFlipCompLim

### DIFF
--- a/Mathlib/CategoryTheory/Limits/ColimitLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/ColimitLimit.lean
@@ -109,6 +109,6 @@ noncomputable def colimitLimitToLimitColimitCone (G : J ⥤ K ⥤ C) [HasLimit G
       ι_colimitLimitToLimitColimit_π_assoc, curry_obj_obj_obj, Prod.swap_obj,
       uncurry_obj_obj, ι_colimMap, currying_unitIso_inv_app_app_app, Category.id_comp,
       limMap_π_assoc, Functor.flip_obj_obj, flipIsoCurrySwapUncurry_hom_app_app]
-    simp only [← comp_evaluation G k, limitObjIsoLimitCompEvaluation_hom_π_assoc]
+    simp [compEvaluation]
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
@@ -451,12 +451,7 @@ the individual limits on objects. -/
 @[simps!]
 def limitIsoFlipCompLim [HasLimitsOfShape J C] (F : J ⥤ K ⥤ C) : limit F ≅ F.flip ⋙ lim :=
   NatIso.ofComponents (fun k =>
-    limitObjIsoLimitCompEvaluation F k ≪≫ HasLimit.isoOfNatIso (compEvaluation F k)) (by
-      -- explicit so that this does not rely on unfolding `Functor.comp`
-      intro X Y f
-      apply limit.hom_ext
-      intro j
-      simp [compEvaluation, Iso.trans])
+    limitObjIsoLimitCompEvaluation F k ≪≫ HasLimit.isoOfNatIso (compEvaluation F k))
 
 set_option backward.defeqAttrib.useBackward true in
 /-- `limitIsoFlipCompLim` is natural with respect to diagrams. -/
@@ -501,12 +496,7 @@ the individual colimits on objects. -/
 @[simps!]
 def colimitIsoFlipCompColim [HasColimitsOfShape J C] (F : J ⥤ K ⥤ C) : colimit F ≅ F.flip ⋙ colim :=
   NatIso.ofComponents (fun k =>
-    colimitObjIsoColimitCompEvaluation F k ≪≫ HasColimit.isoOfNatIso (compEvaluation F k)) (by
-      -- explicit so that this does not rely on unfolding `Functor.comp`
-      intro X Y f
-      apply colimit_obj_ext
-      intro j
-      simp [compEvaluation, Iso.trans])
+    colimitObjIsoColimitCompEvaluation F k ≪≫ HasColimit.isoOfNatIso (compEvaluation F k))
 
 set_option backward.defeqAttrib.useBackward true in
 /-- `colimitIsoFlipCompColim` is natural with respect to diagrams. -/

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
@@ -450,7 +450,13 @@ open CategoryTheory.prod
 the individual limits on objects. -/
 @[simps!]
 def limitIsoFlipCompLim [HasLimitsOfShape J C] (F : J ⥤ K ⥤ C) : limit F ≅ F.flip ⋙ lim :=
-  NatIso.ofComponents (limitObjIsoLimitCompEvaluation F)
+  NatIso.ofComponents (fun k =>
+    limitObjIsoLimitCompEvaluation F k ≪≫ HasLimit.isoOfNatIso (compEvaluation F k)) (by
+      -- explicit so that this does not rely on unfolding `Functor.comp`
+      intro X Y f
+      apply limit.hom_ext
+      intro j
+      simp [compEvaluation, Iso.trans])
 
 set_option backward.defeqAttrib.useBackward true in
 /-- `limitIsoFlipCompLim` is natural with respect to diagrams. -/
@@ -494,7 +500,13 @@ def limitIsoSwapCompLim [HasLimitsOfShape J C] (G : J ⥤ K ⥤ C) :
 the individual colimits on objects. -/
 @[simps!]
 def colimitIsoFlipCompColim [HasColimitsOfShape J C] (F : J ⥤ K ⥤ C) : colimit F ≅ F.flip ⋙ colim :=
-  NatIso.ofComponents (colimitObjIsoColimitCompEvaluation F)
+  NatIso.ofComponents (fun k =>
+    colimitObjIsoColimitCompEvaluation F k ≪≫ HasColimit.isoOfNatIso (compEvaluation F k)) (by
+      -- explicit so that this does not rely on unfolding `Functor.comp`
+      intro X Y f
+      apply colimit_obj_ext
+      intro j
+      simp [compEvaluation, Iso.trans])
 
 set_option backward.defeqAttrib.useBackward true in
 /-- `colimitIsoFlipCompColim` is natural with respect to diagrams. -/

--- a/Mathlib/CategoryTheory/Limits/Preserves/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Yoneda.lean
@@ -62,27 +62,25 @@ theorem yonedaYonedaColimit_app_inv {X : C} : ((yonedaYonedaColimit F).app (op X
     (colimitObjIsoColimitCompEvaluation _ _).hom ≫
       (colimit.post F (coyoneda.obj (op (yoneda.obj X)))) := by
   dsimp [yonedaYonedaColimit]
-  simp only [Iso.cancel_iso_hom_left]
+  simp only [Category.assoc, Iso.cancel_iso_hom_left]
   apply colimit.hom_ext
   intro j
-  rw [colimit.ι_post, ι_colimMap_assoc]
+  rw [HasColimit.ι_isoOfNatIso_hom_assoc, ι_colimMap_assoc]
+  change _ = colimit.ι (F ⋙ coyoneda.obj (op (yoneda.obj X))) j ≫
+    colimit.post F (coyoneda.obj (op (yoneda.obj X)))
+  rw [colimit.ι_post]
   simp only [← CategoryTheory.Functor.assoc, comp_evaluation]
   rw [ι_preservesColimitIso_inv_assoc]
   simp only [← comp_evaluation, comp_obj, evaluation_obj_obj, yoneda_obj_obj, uliftFunctor_obj,
     whiskerLeft_app, uliftFunctor_map, Functor.comp_map, evaluation_obj_map, yoneda_map_app]
   ext η Y f
   dsimp [largeCurriedYonedaLemma, yonedaOpCompYonedaObj, yonedaEquiv]
-  simp only [← comp_apply, Category.assoc, colimitObjIsoColimitCompEvaluation_ι_inv,
-    ← NatTrans.naturality, ← NatTrans.naturality_assoc, yoneda_obj_obj, yoneda_obj_map,
-    Quiver.Hom.unop_op]
-  simp
+  simp only [← comp_apply, Category.assoc]
+  simp [← NatTrans.naturality_apply]
 
 noncomputable instance {X : C} : PreservesColimit F (coyoneda.obj (op (yoneda.obj X))) := by
   suffices IsIso (colimit.post F (coyoneda.obj (op (yoneda.obj X)))) from
     preservesColimit_of_isIso_post _ _
-  suffices colimit.post F (coyoneda.obj (op (yoneda.obj X))) =
-      (colimitObjIsoColimitCompEvaluation _ _).inv ≫ ((yonedaYonedaColimit F).app (op X)).inv from
-    this ▸ inferInstance
-  rw [yonedaYonedaColimit_app_inv, Iso.inv_hom_id_assoc]
+  exact IsIso.of_isIso_fac_left (yonedaYonedaColimit_app_inv (F := F) (X := X)).symm
 
 end CategoryTheory


### PR DESCRIPTION
This PR inserts `HasLimit.isoOfNatIso (compEvaluation F k)` into the components of `limitIsoFlipCompLim` and `colimitIsoFlipCompColim`, which currently identify `F ⋙ (evaluation K C).obj k` with `F.flip.obj k` by unfolding, and adapts the two proofs (`colimitLimitToLimitColimitCone` and `yonedaYonedaColimit_app_inv`) that relied on that unfolding.

It is extracted from Paul Reichert's experiment making `Functor.comp` and `Functor.id` `instance_reducible` (https://github.com/leanprover-community/mathlib4/compare/master...leanprover-community:mathlib4-nightly-testing:datokrat/functorcomp, discussed at https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency); the associator and unitor fixes are in https://github.com/leanprover-community/mathlib4/pull/43566.

🤖 Prepared with Claude Code