### PR TITLE
refactor(ModuleCat): state pushforward coherence without identifying functor bracketings

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
@@ -77,6 +77,9 @@ lemma map_comp_apply {U V W : Cᵒᵖ} (i : U ⟶ V) (j : V ⟶ W) (x) :
     M.map (i ≫ j) x = M.map j (M.map i x) := by
   rw [M.map_comp]; rfl
 
+lemma map_id_apply (X : Cᵒᵖ) (x : M.obj X) : M.map (𝟙 X) x = x := by
+  rw [M.map_id]; rfl
+
 /-- The restriction map `M.map f` of a presheaf of modules `M`, bundled as a semilinear map
 along the ring map `R.map f`. -/
 noncomputable def restrictₛₗ {X Y : Cᵒᵖ} (f : X ⟶ Y) :

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pullback.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pullback.lean
@@ -108,32 +108,44 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 variable {F : C ⥤ D} {R : Dᵒᵖ ⥤ RingCat.{u}} {S : Cᵒᵖ ⥤ RingCat.{u}} (φ : S ⟶ F.op ⋙ R)
   {G : D ⥤ E} {T : Eᵒᵖ ⥤ RingCat.{u}} (ψ : R ⟶ G.op ⋙ T)
 
-instance : (pushforward.{v} (F := 𝟭 C) (𝟙 S)).IsRightAdjoint :=
+instance : (pushforward.{v} (pushforwardIdHom S)).IsRightAdjoint :=
   isRightAdjoint_of_iso (pushforwardId.{v} S).symm
 
 variable (S) in
 /-- The pullback by the identity morphism identifies to the identity functor of the
 category of presheaves of modules. -/
-noncomputable def pullbackId : pullback.{v} (F := 𝟭 C) (𝟙 S) ≅ 𝟭 _ :=
-  ((pullbackPushforwardAdjunction.{v} (F := 𝟭 C) (𝟙 S))).leftAdjointIdIso (pushforwardId S)
+noncomputable def pullbackId : pullback.{v} (pushforwardIdHom S) ≅ 𝟭 _ :=
+  (pullbackPushforwardAdjunction.{v} (pushforwardIdHom S)).leftAdjointIdIso (pushforwardId S)
 
 variable [(pushforward.{v} φ).IsRightAdjoint]
 
 section
 
+variable {F' : C ⥤ D} {φ' : S ⟶ F'.op ⋙ R} [(pushforward.{v} φ').IsRightAdjoint]
+
+/-- Transport of the pullback functor along an isomorphism `F' ≅ F` of functors,
+see `PresheafOfModules.pushforwardCongr₂`. -/
+noncomputable def pullbackCongr₂ (e : F' ≅ F) (he : φ ≫ whiskerRight (NatTrans.op e.hom) R = φ') :
+    pullback.{v} φ ≅ pullback.{v} φ' :=
+  (conjugateIsoEquiv (pullbackPushforwardAdjunction.{v} φ')
+    (pullbackPushforwardAdjunction.{v} φ)).symm (pushforwardCongr₂ φ e he).symm
+
+end
+
+section
+
 variable [(pushforward.{v} ψ).IsRightAdjoint]
 
-instance : (pushforward.{v} (F := F ⋙ G) (φ ≫ whiskerLeft F.op ψ)).IsRightAdjoint :=
+instance : (pushforward.{v} (pushforwardCompHom φ ψ)).IsRightAdjoint :=
   isRightAdjoint_of_iso (pushforwardComp.{v} φ ψ)
 
 /-- The composition of two pullback functors on presheaves of modules identifies
 to the pullback for the composition. -/
 noncomputable def pullbackComp :
-    pullback.{v} φ ⋙ pullback.{v} ψ ≅
-      pullback.{v} (F := F ⋙ G) (φ ≫ whiskerLeft F.op ψ) :=
+    pullback.{v} φ ⋙ pullback.{v} ψ ≅ pullback.{v} (pushforwardCompHom φ ψ) :=
   Adjunction.leftAdjointCompIso
     (pullbackPushforwardAdjunction.{v} φ) (pullbackPushforwardAdjunction.{v} ψ)
-    (pullbackPushforwardAdjunction.{v} (F := F ⋙ G) (φ ≫ whiskerLeft F.op ψ))
+    (pullbackPushforwardAdjunction.{v} (pushforwardCompHom φ ψ))
     (pushforwardComp φ ψ)
 
 variable {T' : E'ᵒᵖ ⥤ RingCat.{u}} {G' : E ⥤ E'} (ψ' : T ⟶ G'.op ⋙ T')
@@ -141,22 +153,29 @@ variable {T' : E'ᵒᵖ ⥤ RingCat.{u}} {G' : E ⥤ E'} (ψ' : T ⟶ G'.op ⋙ 
 
 lemma pullback_assoc :
     isoWhiskerLeft _ (pullbackComp.{v} ψ ψ') ≪≫
-      pullbackComp.{v} (G := G ⋙ G') φ (ψ ≫ whiskerLeft G.op ψ') =
+      pullbackComp.{v} φ (pushforwardCompHom ψ ψ') =
     (associator _ _ _).symm ≪≫ isoWhiskerRight (pullbackComp.{v} φ ψ) _ ≪≫
-        pullbackComp.{v} (F := F ⋙ G) (φ ≫ whiskerLeft F.op ψ) ψ' :=
-  Adjunction.leftAdjointCompIso_assoc _ _ _ _ _ _ _ _ _ _ (pushforward_assoc φ ψ ψ')
+      pullbackComp.{v} (pushforwardCompHom φ ψ) ψ' ≪≫
+        pullbackCongr₂ _ (associator F G G').symm (pushforwardCompHom_assoc φ ψ ψ') := by
+  rw [pullbackCongr₂, pullbackComp, pullbackComp, pullbackComp, pullbackComp,
+    ← Adjunction.leftAdjointCompIso_trans]
+  exact Adjunction.leftAdjointCompIso_assoc _ _ _ _ _ _ _ _ _ _ (pushforward_assoc φ ψ ψ')
 
 end
 
 lemma pullback_id_comp :
-    pullbackComp.{v} (F := 𝟭 C) (𝟙 S) φ =
-      isoWhiskerRight (pullbackId S) (pullback φ) ≪≫ Functor.leftUnitor _ :=
-  Adjunction.leftAdjointCompIso_id_comp _ _ _ _ (pushforward_comp_id φ)
+    pullbackComp.{v} (F := 𝟭 C) (pushforwardIdHom S) φ ≪≫
+      pullbackCongr₂ _ (leftUnitor F).symm (pushforwardCompHom_pushforwardIdHom_left φ) =
+    isoWhiskerRight (pullbackId S) (pullback φ) ≪≫ Functor.leftUnitor _ := by
+  rw [pullbackCongr₂, pullbackComp, ← Adjunction.leftAdjointCompIso_trans]
+  exact Adjunction.leftAdjointCompIso_id_comp _ _ _ _ (pushforward_comp_id φ)
 
 lemma pullback_comp_id :
-    pullbackComp.{v} (G := 𝟭 _) φ (𝟙 R) =
-      isoWhiskerLeft _ (pullbackId R) ≪≫ Functor.rightUnitor _ :=
-  Adjunction.leftAdjointCompIso_comp_id _ _ _ _ (pushforward_id_comp φ)
+    pullbackComp.{v} (G := 𝟭 _) φ (pushforwardIdHom R) ≪≫
+      pullbackCongr₂ _ (rightUnitor F).symm (pushforwardCompHom_pushforwardIdHom_right φ) =
+    isoWhiskerLeft _ (pullbackId R) ≪≫ Functor.rightUnitor _ := by
+  rw [pullbackCongr₂, pullbackComp, ← Adjunction.leftAdjointCompIso_trans]
+  exact Adjunction.leftAdjointCompIso_comp_id _ _ _ _ (pushforward_id_comp φ)
 
 end
 

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pushforward.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pushforward.lean
@@ -134,41 +134,187 @@ lemma pushforward_map_app_apply' {M N : PresheafOfModules.{v} R} (α : M ⟶ N) 
 section
 
 variable (R) in
+/-- The morphism of presheaves of rings `R ⟶ (𝟭 D).op ⋙ R` which is the identity on each
+object: it is the left unitor of `R` composed with `Functor.opId`, see `pushforwardIdHom_eq`.
+It is the datum along which the pushforward by the identity functor is taken. -/
+@[simps]
+def pushforwardIdHom : R ⟶ (𝟭 D).op ⋙ R where
+  app X := 𝟙 _
+
+variable (R) in
+lemma pushforwardIdHom_eq :
+    pushforwardIdHom R = R.leftUnitor.inv ≫ whiskerRight (Functor.opId D).inv R := by
+  ext; simp
+
+variable (R) in
 /-- The pushforward functor by the identity morphism identifies to
-the identify functor of the category of presheaves of modules. -/
-noncomputable def pushforwardId :
-    pushforward.{v} (S := R) (F := 𝟭 _) (𝟙 R) ≅ 𝟭 _ :=
+the identity functor of the category of presheaves of modules. -/
+noncomputable def pushforwardId : pushforward.{v} (pushforwardIdHom R) ≅ 𝟭 _ :=
   Iso.refl _
 
 section
 
 variable {T : Eᵒᵖ ⥤ RingCat.{u}} {G : D ⥤ E} (ψ : R ⟶ G.op ⋙ T)
 
+/-- The morphism of presheaves of rings `S ⟶ (F ⋙ G).op ⋙ T` obtained by composing
+`φ : S ⟶ F.op ⋙ R` and `ψ : R ⟶ G.op ⋙ T`, the associator and `Functor.opComp`
+(see `pushforwardCompHom_eq`). It is the datum along which the pushforward by the
+composition `F ⋙ G` is taken. -/
+@[simps]
+def pushforwardCompHom : S ⟶ (F ⋙ G).op ⋙ T where
+  app X := φ.app X ≫ ψ.app (F.op.obj X)
+
+lemma pushforwardCompHom_eq :
+    pushforwardCompHom φ ψ = φ ≫ whiskerLeft F.op ψ ≫ (Functor.associator _ _ _).inv ≫
+      whiskerRight (Functor.opComp F G).inv T := by
+  ext; simp
+
 /-- The composition of two pushforward functors on categories of presheaves of modules
 identify to the pushforward for the composition. -/
 noncomputable def pushforwardComp :
-    pushforward.{v} ψ ⋙ pushforward.{v} φ ≅
-      pushforward.{v} (F := F ⋙ G) (φ ≫ whiskerLeft F.op ψ) :=
+    pushforward.{v} ψ ⋙ pushforward.{v} φ ≅ pushforward.{v} (pushforwardCompHom φ ψ) :=
   Iso.refl _
-
-variable {T' : E'ᵒᵖ ⥤ RingCat.{u}} {G' : E ⥤ E'} (ψ' : T ⟶ G'.op ⋙ T')
-
-lemma pushforward_assoc :
-    (pushforward ψ').isoWhiskerLeft (pushforwardComp φ ψ) ≪≫
-      pushforwardComp (F := F ⋙ G) (φ ≫ F.op.whiskerLeft ψ) ψ' =
-    ((pushforward ψ').associator (pushforward ψ) (pushforward φ)).symm ≪≫
-      isoWhiskerRight (pushforwardComp ψ ψ') (pushforward φ) ≪≫
-        pushforwardComp (G := G ⋙ G') φ (ψ ≫ G.op.whiskerLeft ψ') := by ext; rfl
 
 end
 
+section Transport
+
+/-- Pushforwards along equal morphisms of presheaves of rings are isomorphic. -/
+noncomputable def pushforwardCongr {φ ψ : S ⟶ F.op ⋙ R} (e : φ = ψ) :
+    pushforward.{v} φ ≅ pushforward.{v} ψ :=
+  NatIso.ofComponents
+    (fun M ↦ isoMk (fun X ↦ (ModuleCat.restrictScalarsCongr (by rw [e])).app (M.obj (F.op.obj X)))
+      (fun _ _ f ↦ by ext x; rfl))
+    (fun f ↦ by ext X x; rfl)
+
+@[simp]
+lemma pushforwardCongr_symm {φ ψ : S ⟶ F.op ⋙ R} (e : φ = ψ) :
+    (pushforwardCongr.{v} e).symm = pushforwardCongr e.symm := rfl
+
+@[simp]
+lemma pushforwardCongr_hom_app_app_apply {φ ψ : S ⟶ F.op ⋙ R} (e : φ = ψ)
+    (M : PresheafOfModules.{v} R) (X : Cᵒᵖ) (x : ((pushforward φ).obj M).obj X) :
+    ((pushforwardCongr e).hom.app M).app X x = x := by rfl
+
+@[simp]
+lemma pushforwardCongr_inv_app_app_apply {φ ψ : S ⟶ F.op ⋙ R} (e : φ = ψ)
+    (M : PresheafOfModules.{v} R) (X : Cᵒᵖ) (x : ((pushforward ψ).obj M).obj X) :
+    ((pushforwardCongr e).inv.app M).app X x = x := by rfl
+
+variable {F' : C ⥤ D}
+
+/-- A natural transformation `α : F' ⟶ F` induces a natural transformation between
+the pushforward functors, from `pushforward φ` to the pushforward along
+`φ ≫ whiskerRight (NatTrans.op α) R : S ⟶ F'.op ⋙ R`. -/
+noncomputable def pushforwardNatTrans (α : F' ⟶ F) :
+    pushforward.{v} φ ⟶ pushforward.{v} (φ ≫ whiskerRight (NatTrans.op α) R) where
+  app M :=
+    { app X := (ModuleCat.restrictScalars (φ.app X).hom).map (M.map (α.app X.unop).op) ≫
+        (ModuleCat.restrictScalarsComp'App (φ.app X).hom (R.map (α.app X.unop).op).hom
+          ((φ ≫ whiskerRight (NatTrans.op α) R).app X).hom (by simp)
+          (M.obj (F'.op.obj X))).inv
+      naturality := fun {X Y} i ↦ by
+        ext x
+        have h : F.op.map i ≫ (α.app Y.unop).op = (α.app X.unop).op ≫ F'.op.map i := by
+          simp only [Functor.op_map, ← op_comp, α.naturality]
+        exact (M.map_comp_apply (F.op.map i) (α.app Y.unop).op x).symm.trans
+          ((M.congr_map_apply h x).trans (M.map_comp_apply (α.app X.unop).op (F'.op.map i) x)) }
+  naturality _ _ f := by
+    ext X x
+    exact (naturality_apply f (α.app X.unop).op x).symm
+
+@[simp]
+lemma pushforwardNatTrans_app_app_apply (α : F' ⟶ F) (M : PresheafOfModules.{v} R) (X : Cᵒᵖ)
+    (x : ((pushforward φ).obj M).obj X) :
+    ((pushforwardNatTrans φ α).app M).app X x = M.map (α.app X.unop).op x := by rfl
+
+/-- A natural isomorphism `α : F' ≅ F` induces an isomorphism between the pushforward
+functors, from `pushforward φ` to the pushforward along
+`φ ≫ whiskerRight (NatTrans.op α.hom) R : S ⟶ F'.op ⋙ R`. -/
+@[simps hom]
+noncomputable def pushforwardNatIso (α : F' ≅ F) :
+    pushforward.{v} φ ≅ pushforward.{v} (φ ≫ whiskerRight (NatTrans.op α.hom) R) where
+  hom := pushforwardNatTrans φ α.hom
+  inv := pushforwardNatTrans _ α.inv ≫
+    (pushforwardCongr (by ext : 2; simp [← Functor.map_comp, ← op_comp])).hom
+  hom_inv_id := by
+    ext M X x
+    exact (M.map_comp_apply (α.hom.app X.unop).op (α.inv.app X.unop).op x).symm.trans
+      ((M.congr_map_apply (show (α.hom.app X.unop).op ≫ (α.inv.app X.unop).op = 𝟙 _ by
+        simp [← op_comp]) x).trans (M.map_id_apply _ x))
+  inv_hom_id := by
+    ext M X x
+    exact (M.map_comp_apply (α.inv.app X.unop).op (α.hom.app X.unop).op x).symm.trans
+      ((M.congr_map_apply (show (α.inv.app X.unop).op ≫ (α.hom.app X.unop).op = 𝟙 _ by
+        simp [← op_comp]) x).trans (M.map_id_apply _ x))
+
+/-- More flexible variant of `PresheafOfModules.pushforwardNatIso`: an isomorphism
+`pushforward φ ≅ pushforward ψ` when `ψ : S ⟶ F'.op ⋙ R` is obtained from
+`φ : S ⟶ F.op ⋙ R` by transport along an isomorphism `e : F' ≅ F`. Note that `e` goes from
+the base functor of `ψ` to that of `φ`, which is why the coherence lemmas below transport
+along `(associator ..).symm` and the inverses of the unitors. -/
+noncomputable def pushforwardCongr₂ {ψ : S ⟶ F'.op ⋙ R} (e : F' ≅ F)
+    (he : φ ≫ whiskerRight (NatTrans.op e.hom) R = ψ) :
+    pushforward.{v} φ ≅ pushforward.{v} ψ :=
+  pushforwardNatIso φ e ≪≫ pushforwardCongr he
+
+@[simp]
+lemma pushforwardCongr₂_hom_app_app_apply {ψ : S ⟶ F'.op ⋙ R} (e : F' ≅ F)
+    (he : φ ≫ whiskerRight (NatTrans.op e.hom) R = ψ) (M : PresheafOfModules.{v} R) (X : Cᵒᵖ)
+    (x : ((pushforward φ).obj M).obj X) :
+    ((pushforwardCongr₂ φ e he).hom.app M).app X x = M.map (e.hom.app X.unop).op x := by rfl
+
+end Transport
+
+section Coherence
+
+variable {T : Eᵒᵖ ⥤ RingCat.{u}} {G : D ⥤ E} (ψ : R ⟶ G.op ⋙ T)
+  {T' : E'ᵒᵖ ⥤ RingCat.{u}} {G' : E ⥤ E'} (ψ' : T ⟶ G'.op ⋙ T')
+
+lemma pushforwardCompHom_assoc :
+    pushforwardCompHom (pushforwardCompHom φ ψ) ψ' ≫
+      whiskerRight (NatTrans.op (associator F G G').inv) T' =
+    pushforwardCompHom φ (pushforwardCompHom ψ ψ') := by
+  ext; simp
+
+lemma pushforward_assoc :
+    isoWhiskerLeft (pushforward ψ') (pushforwardComp φ ψ) ≪≫
+      pushforwardComp (pushforwardCompHom φ ψ) ψ' ≪≫
+        pushforwardCongr₂ _ (associator F G G').symm (pushforwardCompHom_assoc φ ψ ψ') =
+    (associator (pushforward ψ') (pushforward ψ) (pushforward φ)).symm ≪≫
+      isoWhiskerRight (pushforwardComp ψ ψ') (pushforward φ) ≪≫
+        pushforwardComp φ (pushforwardCompHom ψ ψ') := by
+  ext M X x
+  exact (M.congr_map_apply (show ((associator F G G').inv.app X.unop).op = 𝟙 _ by simp) x).trans
+    (M.map_id_apply _ x)
+
+lemma pushforwardCompHom_pushforwardIdHom_left :
+    pushforwardCompHom (F := 𝟭 C) (pushforwardIdHom S) φ ≫
+      whiskerRight (NatTrans.op (leftUnitor F).inv) R = φ := by
+  ext; simp
+
+lemma pushforwardCompHom_pushforwardIdHom_right :
+    pushforwardCompHom (G := 𝟭 D) φ (pushforwardIdHom R) ≫
+      whiskerRight (NatTrans.op (rightUnitor F).inv) R = φ := by
+  ext; simp
+
 lemma pushforward_comp_id :
-    pushforwardComp.{v} (F := 𝟭 C) (𝟙 S) φ =
-      isoWhiskerLeft (pushforward.{v} φ) (pushforwardId S) ≪≫ rightUnitor _ := by ext; rfl
+    pushforwardComp.{v} (F := 𝟭 C) (pushforwardIdHom S) φ ≪≫
+      pushforwardCongr₂ _ (leftUnitor F).symm (pushforwardCompHom_pushforwardIdHom_left φ) =
+    isoWhiskerLeft (pushforward.{v} φ) (pushforwardId S) ≪≫ rightUnitor _ := by
+  ext M X x
+  exact (M.congr_map_apply (show ((leftUnitor F).inv.app X.unop).op = 𝟙 _ by simp) x).trans
+    (M.map_id_apply _ x)
 
 lemma pushforward_id_comp :
-    pushforwardComp.{v} (G := 𝟭 _) φ (𝟙 R) =
-      isoWhiskerRight (pushforwardId R) (pushforward.{v} φ) ≪≫ leftUnitor _ := by ext; rfl
+    pushforwardComp.{v} (G := 𝟭 D) φ (pushforwardIdHom R) ≪≫
+      pushforwardCongr₂ _ (rightUnitor F).symm (pushforwardCompHom_pushforwardIdHom_right φ) =
+    isoWhiskerRight (pushforwardId R) (pushforward.{v} φ) ≪≫ leftUnitor _ := by
+  ext M X x
+  exact (M.congr_map_apply (show ((rightUnitor F).inv.app X.unop).op = 𝟙 _ by simp) x).trans
+    (M.map_id_apply _ x)
+
+end Coherence
 
 end
 

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/PullbackContinuous.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/PullbackContinuous.lean
@@ -130,14 +130,14 @@ end
 end
 
 
-instance : (pushforward.{v} (F := 𝟭 C) (𝟙 S)).IsRightAdjoint :=
+instance : (pushforward.{v} (pushforwardIdHom S)).IsRightAdjoint :=
   Functor.isRightAdjoint_of_iso (pushforwardId S).symm
 
 variable (S) in
 /-- The pullback by the identity morphism identifies to the identity functor of the
 category of sheaves of modules. -/
-noncomputable def pullbackId : pullback.{v} (F := 𝟭 C) (𝟙 S) ≅ 𝟭 _ :=
-  ((pullbackPushforwardAdjunction.{v} (F := 𝟭 C) (𝟙 S))).leftAdjointIdIso (pushforwardId S)
+noncomputable def pullbackId : pullback.{v} (pushforwardIdHom S) ≅ 𝟭 _ :=
+  ((pullbackPushforwardAdjunction.{v} (pushforwardIdHom S))).leftAdjointIdIso (pushforwardId S)
 
 variable (S) in
 @[simp]
@@ -150,6 +150,22 @@ variable [(pushforward.{v} φ).IsRightAdjoint]
 
 section
 
+variable {F' : C ⥤ D} [Functor.IsContinuous F' J K]
+  {φ' : S ⟶ (F'.sheafPushforwardContinuous RingCat.{u} J K).obj R}
+  [(pushforward.{v} φ').IsRightAdjoint]
+
+/-- Transport of the pullback functor along an isomorphism `F' ≅ F` of functors,
+see `SheafOfModules.pushforwardCongr₂`. -/
+noncomputable def pullbackCongr₂ (e : F' ≅ F)
+    (he : φ ≫ (Functor.sheafPushforwardContinuousNatTrans e.hom _ _ _).app R = φ') :
+    pullback.{v} φ ≅ pullback.{v} φ' :=
+  (conjugateIsoEquiv (pullbackPushforwardAdjunction.{v} φ')
+    (pullbackPushforwardAdjunction.{v} φ)).symm (pushforwardCongr₂ φ e he).symm
+
+end
+
+section
+
 variable {K' : GrothendieckTopology D'} {K'' : GrothendieckTopology D''}
   {G : D ⥤ D'} {R' : Sheaf K' RingCat.{u}}
   [Functor.IsContinuous G K K']
@@ -158,19 +174,16 @@ variable {K' : GrothendieckTopology D'} {K'' : GrothendieckTopology D''}
 
 variable [(pushforward.{v} ψ).IsRightAdjoint]
 
-instance : (pushforward.{v} (F := F ⋙ G)
-    (φ ≫ (F.sheafPushforwardContinuous RingCat.{u} J K).map ψ)).IsRightAdjoint :=
+instance : (pushforward.{v} (pushforwardCompHom φ ψ)).IsRightAdjoint :=
   Functor.isRightAdjoint_of_iso (pushforwardComp.{v} φ ψ)
 
 /-- The composition of two pullback functors on sheaves of modules identifies
 to the pullback for the composition. -/
 noncomputable def pullbackComp :
-    pullback.{v} φ ⋙ pullback.{v} ψ ≅
-      pullback.{v} (F := F ⋙ G) (φ ≫ (F.sheafPushforwardContinuous RingCat.{u} J K).map ψ) :=
+    pullback.{v} φ ⋙ pullback.{v} ψ ≅ pullback.{v} (pushforwardCompHom φ ψ) :=
   Adjunction.leftAdjointCompIso
     (pullbackPushforwardAdjunction.{v} φ) (pullbackPushforwardAdjunction.{v} ψ)
-    (pullbackPushforwardAdjunction.{v} (F := F ⋙ G)
-      (φ ≫ (F.sheafPushforwardContinuous RingCat.{u} J K).map ψ))
+    (pullbackPushforwardAdjunction.{v} (pushforwardCompHom φ ψ))
     (pushforwardComp φ ψ)
 
 @[simp]
@@ -192,23 +205,28 @@ variable [(pushforward.{v} ψ').IsRightAdjoint]
 
 lemma pullback_assoc :
     isoWhiskerLeft _ (pullbackComp.{v} ψ ψ') ≪≫
-      pullbackComp.{v} (G := G ⋙ G') φ
-        (ψ ≫ (G.sheafPushforwardContinuous RingCat.{u} K K').map ψ') =
+      pullbackComp.{v} φ (pushforwardCompHom ψ ψ') =
     (associator _ _ _).symm ≪≫ isoWhiskerRight (pullbackComp.{v} φ ψ) _ ≪≫
-      pullbackComp.{v} (F := F ⋙ G)
-        (φ ≫ (F.sheafPushforwardContinuous RingCat.{u} J K).map ψ) ψ' :=
-  Adjunction.leftAdjointCompIso_assoc _ _ _ _ _ _ _ _ _ _ (pushforward_assoc φ ψ ψ')
+      pullbackComp.{v} (pushforwardCompHom φ ψ) ψ' ≪≫
+        pullbackCongr₂ _ (associator F G G').symm (pushforwardCompHom_assoc φ ψ ψ') := by
+  rw [pullbackCongr₂, pullbackComp, pullbackComp, pullbackComp, pullbackComp,
+    ← Adjunction.leftAdjointCompIso_trans]
+  exact Adjunction.leftAdjointCompIso_assoc _ _ _ _ _ _ _ _ _ _ (pushforward_assoc φ ψ ψ')
 
 end
 
 lemma pullback_id_comp :
-    pullbackComp.{v} (F := 𝟭 C) (𝟙 S) φ =
-      isoWhiskerRight (pullbackId S) (pullback φ) ≪≫ Functor.leftUnitor _ :=
-  Adjunction.leftAdjointCompIso_id_comp _ _ _ _ (pushforward_comp_id φ)
+    pullbackComp.{v} (F := 𝟭 C) (pushforwardIdHom S) φ ≪≫
+      pullbackCongr₂ _ (leftUnitor F).symm (pushforwardCompHom_pushforwardIdHom_left φ) =
+    isoWhiskerRight (pullbackId S) (pullback φ) ≪≫ Functor.leftUnitor _ := by
+  rw [pullbackCongr₂, pullbackComp, ← Adjunction.leftAdjointCompIso_trans]
+  exact Adjunction.leftAdjointCompIso_id_comp _ _ _ _ (pushforward_comp_id φ)
 
 lemma pullback_comp_id :
-    pullbackComp.{v} (G := 𝟭 _) φ (𝟙 R) =
-      isoWhiskerLeft _ (pullbackId R) ≪≫ Functor.rightUnitor _ :=
-  Adjunction.leftAdjointCompIso_comp_id _ _ _ _ (pushforward_id_comp φ)
+    pullbackComp.{v} (G := 𝟭 D) φ (pushforwardIdHom R) ≪≫
+      pullbackCongr₂ _ (rightUnitor F).symm (pushforwardCompHom_pushforwardIdHom_right φ) =
+    isoWhiskerLeft _ (pullbackId R) ≪≫ Functor.rightUnitor _ := by
+  rw [pullbackCongr₂, pullbackComp, ← Adjunction.leftAdjointCompIso_trans]
+  exact Adjunction.leftAdjointCompIso_comp_id _ _ _ _ (pushforward_id_comp φ)
 
 end SheafOfModules

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/PushforwardContinuous.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/PushforwardContinuous.lean
@@ -99,10 +99,20 @@ noncomputable def overPullback [Limits.HasPullbacks D] {X Y : D} (f : X ⟶ Y) :
 section
 
 variable (R) in
+/-- The morphism of sheaves of rings `R ⟶ ((𝟭 D).sheafPushforwardContinuous RingCat K K).obj R`
+which is the identity on each object (see `PresheafOfModules.pushforwardIdHom`). It is the
+datum along which the pushforward by the identity functor is taken. -/
+def pushforwardIdHom : R ⟶ ((𝟭 D).sheafPushforwardContinuous RingCat.{u} K K).obj R :=
+  ⟨PresheafOfModules.pushforwardIdHom R.obj⟩
+
+@[simp]
+lemma pushforwardIdHom_hom : (pushforwardIdHom R).hom = PresheafOfModules.pushforwardIdHom R.obj :=
+  rfl
+
+variable (R) in
 /-- The pushforward functor by the identity morphism identifies to
-the identify functor of the category of sheaves of modules. -/
-noncomputable def pushforwardId :
-    pushforward.{v} (S := R) (F := 𝟭 _) (𝟙 R) ≅ 𝟭 _ :=
+the identity functor of the category of sheaves of modules. -/
+noncomputable def pushforwardId : pushforward.{v} (pushforwardIdHom R) ≅ 𝟭 _ :=
   Iso.refl _
 
 /-- Pushforwards along equal morphisms of sheaves of rings are isomorphic. -/
@@ -132,12 +142,23 @@ variable {K' : GrothendieckTopology D'} {K'' : GrothendieckTopology D''}
   [Functor.IsContinuous G K K']
   (ψ : R ⟶ (G.sheafPushforwardContinuous RingCat.{u} K K').obj R')
 
+/-- The morphism of sheaves of rings `S ⟶ ((F ⋙ G).sheafPushforwardContinuous RingCat J K').obj R'`
+obtained by composing `φ` and `ψ` (see `PresheafOfModules.pushforwardCompHom`). It is the datum
+along which the pushforward by the composition `F ⋙ G` is taken. -/
+def pushforwardCompHom [Functor.IsContinuous (F ⋙ G) J K'] :
+    S ⟶ ((F ⋙ G).sheafPushforwardContinuous RingCat.{u} J K').obj R' :=
+  ⟨PresheafOfModules.pushforwardCompHom φ.hom ψ.hom⟩
+
+@[simp]
+lemma pushforwardCompHom_hom [Functor.IsContinuous (F ⋙ G) J K'] :
+    (pushforwardCompHom φ ψ).hom = PresheafOfModules.pushforwardCompHom φ.hom ψ.hom :=
+  rfl
+
 /-- The composition of two pushforward functors on categories of sheaves of modules
 identify to the pushforward for the composition. -/
 noncomputable def pushforwardComp :
     haveI : Functor.IsContinuous (F ⋙ G) J K' := Functor.isContinuous_comp _ _ _ K _
-    pushforward.{v} ψ ⋙ pushforward.{v} φ ≅
-      pushforward.{v} (F := F ⋙ G) (φ ≫ (F.sheafPushforwardContinuous RingCat.{u} J K).map ψ) :=
+    pushforward.{v} ψ ⋙ pushforward.{v} φ ≅ pushforward.{v} (pushforwardCompHom φ ψ) :=
   Iso.refl _
 
 -- Not a simp because the type of the LHS is dsimp-able
@@ -148,30 +169,7 @@ lemma pushforwardComp_hom_app_val_app (M U x) :
 lemma pushforwardComp_inv_app_val_app (M U x) :
   ((pushforwardComp φ ψ).inv.app M).val.app U x = x := rfl
 
-variable {G' : D' ⥤ D''} {R'' : Sheaf K'' RingCat.{u}}
-  [Functor.IsContinuous G' K' K'']
-  [Functor.IsContinuous (G ⋙ G') K K'']
-  [(F ⋙ G).IsContinuous J K']
-  (ψ' : R' ⟶ (G'.sheafPushforwardContinuous RingCat.{u} K' K'').obj R'')
-
-lemma pushforward_assoc :
-    (pushforward ψ').isoWhiskerLeft (pushforwardComp φ ψ) ≪≫
-      pushforwardComp (F := F ⋙ G)
-        (φ ≫ (F.sheafPushforwardContinuous RingCat.{u} J K).map ψ) ψ' =
-    ((pushforward ψ').associator (pushforward ψ) (pushforward φ)).symm ≪≫
-      isoWhiskerRight (pushforwardComp ψ ψ') (pushforward φ) ≪≫
-      pushforwardComp (G := G ⋙ G') φ (ψ ≫
-        (G.sheafPushforwardContinuous RingCat.{u} K K').map ψ') := by ext; rfl
-
 end
-
-lemma pushforward_comp_id :
-    pushforwardComp.{v} (F := 𝟭 C) (𝟙 S) φ =
-      isoWhiskerLeft (pushforward.{v} φ) (pushforwardId S) ≪≫ rightUnitor _ := by ext; rfl
-
-lemma pushforward_id_comp :
-    pushforwardComp.{v} (G := 𝟭 _) φ (𝟙 R) =
-      isoWhiskerRight (pushforwardId R) (pushforward.{v} φ) ≪≫ leftUnitor _ := by ext; rfl
 
 end
 
@@ -252,6 +250,68 @@ def pushforwardCongr₂ {ψ : T ⟶ (F.sheafPushforwardContinuous RingCat J K).o
 
 end NatTrans
 
+section Coherence
+
+variable {K' : GrothendieckTopology D'} {K'' : GrothendieckTopology D''}
+  {G : D ⥤ D'} {R' : Sheaf K' RingCat.{u}}
+  [Functor.IsContinuous G K K']
+  (ψ : R ⟶ (G.sheafPushforwardContinuous RingCat.{u} K K').obj R')
+  {G' : D' ⥤ D''} {R'' : Sheaf K'' RingCat.{u}}
+  [Functor.IsContinuous G' K' K'']
+  (ψ' : R' ⟶ (G'.sheafPushforwardContinuous RingCat.{u} K' K'').obj R'')
+
+lemma pushforwardCompHom_assoc [Functor.IsContinuous (F ⋙ G) J K']
+    [Functor.IsContinuous (G ⋙ G') K K'']
+    [Functor.IsContinuous ((F ⋙ G) ⋙ G') J K''] [Functor.IsContinuous (F ⋙ G ⋙ G') J K''] :
+    pushforwardCompHom (pushforwardCompHom φ ψ) ψ' ≫
+      (Functor.sheafPushforwardContinuousNatTrans (associator F G G').inv _ _ _).app R'' =
+    pushforwardCompHom φ (pushforwardCompHom ψ ψ') := by
+  ext1
+  exact PresheafOfModules.pushforwardCompHom_assoc φ.hom ψ.hom ψ'.hom
+
+lemma pushforward_assoc [Functor.IsContinuous (F ⋙ G) J K']
+    [Functor.IsContinuous (G ⋙ G') K K'']
+    [Functor.IsContinuous ((F ⋙ G) ⋙ G') J K''] [Functor.IsContinuous (F ⋙ G ⋙ G') J K''] :
+    isoWhiskerLeft (pushforward ψ') (pushforwardComp φ ψ) ≪≫
+      pushforwardComp (pushforwardCompHom φ ψ) ψ' ≪≫
+        pushforwardCongr₂ _ (associator F G G').symm (pushforwardCompHom_assoc φ ψ ψ') =
+    (associator (pushforward ψ') (pushforward ψ) (pushforward φ)).symm ≪≫
+      isoWhiskerRight (pushforwardComp ψ ψ') (pushforward φ) ≪≫
+        pushforwardComp φ (pushforwardCompHom ψ ψ') := by
+  ext M U x
+  exact (M.val.congr_map_apply
+    (show ((associator F G G').inv.app U.unop).op = 𝟙 _ by simp) x).trans (M.val.map_id_apply _ x)
+
+lemma pushforwardCompHom_pushforwardIdHom_left :
+    pushforwardCompHom (F := 𝟭 C) (pushforwardIdHom S) φ ≫
+      (Functor.sheafPushforwardContinuousNatTrans (leftUnitor F).inv _ _ _).app R = φ := by
+  ext1
+  exact PresheafOfModules.pushforwardCompHom_pushforwardIdHom_left φ.hom
+
+lemma pushforwardCompHom_pushforwardIdHom_right :
+    pushforwardCompHom (G := 𝟭 D) φ (pushforwardIdHom R) ≫
+      (Functor.sheafPushforwardContinuousNatTrans (rightUnitor F).inv _ _ _).app R = φ := by
+  ext1
+  exact PresheafOfModules.pushforwardCompHom_pushforwardIdHom_right φ.hom
+
+lemma pushforward_comp_id :
+    pushforwardComp.{v} (F := 𝟭 C) (pushforwardIdHom S) φ ≪≫
+      pushforwardCongr₂ _ (leftUnitor F).symm (pushforwardCompHom_pushforwardIdHom_left φ) =
+    isoWhiskerLeft (pushforward.{v} φ) (pushforwardId S) ≪≫ rightUnitor _ := by
+  ext M U x
+  exact (M.val.congr_map_apply
+    (show ((leftUnitor F).inv.app U.unop).op = 𝟙 _ by simp) x).trans (M.val.map_id_apply _ x)
+
+lemma pushforward_id_comp :
+    pushforwardComp.{v} (G := 𝟭 D) φ (pushforwardIdHom R) ≪≫
+      pushforwardCongr₂ _ (rightUnitor F).symm (pushforwardCompHom_pushforwardIdHom_right φ) =
+    isoWhiskerRight (pushforwardId R) (pushforward.{v} φ) ≪≫ leftUnitor _ := by
+  ext M U x
+  exact (M.val.congr_map_apply
+    (show ((rightUnitor F).inv.app U.unop).op = 𝟙 _ by simp) x).trans (M.val.map_id_apply _ x)
+
+end Coherence
+
 section Adjunction
 
 variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
@@ -262,9 +322,15 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
   (adj : F ⊣ G)
   (φ : S ⟶ (F.sheafPushforwardContinuous RingCat.{u} J K).obj R)
   (ψ : R ⟶ (G.sheafPushforwardContinuous RingCat.{u} K J).obj S)
-  (H₁ : Functor.whiskerRight (NatTrans.op adj.counit) R.obj = ψ.hom ≫ G.op.whiskerLeft φ.hom)
-  (H₂ : φ.hom ≫ F.op.whiskerLeft ψ.hom ≫
-    Functor.whiskerRight (NatTrans.op adj.unit) S.obj = 𝟙 S.obj)
+  -- `H₁` and `H₂` say that `φ` and `ψ` are compatible with the counit and the unit of `adj`:
+  -- pushing `ψ` forward along `F` and composing with `φ` recovers the counit, and
+  -- pushing `φ` forward along `G` and composing with `ψ` recovers the unit.
+  (H₁ : haveI := Functor.isContinuous_comp G F K J K
+    pushforwardIdHom R ≫ (Functor.sheafPushforwardContinuousNatTrans adj.counit _ _ _).app R =
+      pushforwardCompHom ψ φ)
+  (H₂ : haveI := Functor.isContinuous_comp F G J K J
+    pushforwardCompHom φ ψ ≫ (Functor.sheafPushforwardContinuousNatTrans adj.unit _ _ _).app S =
+      pushforwardIdHom S)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- If `F ⊣ G`, then the pushforwards along `F` and `G` are also adjoint. -/
@@ -272,12 +338,12 @@ noncomputable
 def pushforwardPushforwardAdj : pushforward.{v} φ ⊣ pushforward.{v} ψ where
   unit :=
     letI := CategoryTheory.Functor.isContinuous_comp G F K J K
-    (pushforwardId _).inv ≫ pushforwardNatTrans (𝟙 _) adj.counit ≫
-      (pushforwardCongr (by ext1; simpa)).hom ≫ (pushforwardComp _ _).inv
+    (pushforwardId _).inv ≫ pushforwardNatTrans _ adj.counit ≫
+      (pushforwardCongr H₁).hom ≫ (pushforwardComp _ _).inv
   counit :=
     letI := CategoryTheory.Functor.isContinuous_comp F G J K J
     (pushforwardComp _ _).hom ≫ pushforwardNatTrans _ adj.unit ≫
-      (pushforwardCongr (by ext1; simpa)).hom ≫ (pushforwardId _).hom
+      (pushforwardCongr H₂).hom ≫ (pushforwardId _).hom
   left_triangle_components X := by
     ext U x
     change (X.val.presheaf.map (adj.counit.app (F.obj U.unop)).op ≫
@@ -311,9 +377,9 @@ instance isLeftAdjoint_pushforward_of_isIso [F.IsCocontinuous J K] [IsIso φ] [F
   let ψ : R ⟶ (F.rightAdjoint.sheafPushforwardContinuous RingCat.{u} K J).obj S :=
     shAdj.unit.app R ≫ (F.rightAdjoint.sheafPushforwardContinuous _ _ _).map (inv φ)
   refine (SheafOfModules.pushforwardPushforwardAdj adj φ ψ ?_ ?_).isLeftAdjoint
-  · ext U : 2
+  · ext U : 3
     simp [ψ, shAdj]
-  · ext U : 2
+  · ext U : 3
     have := (inv φ).hom.naturality
     dsimp at this
     simp only [ObjectProperty.hom_inv, NatIso.isIso_inv_app, sheafPushforwardContinuous_obj_obj_obj,
@@ -340,9 +406,9 @@ set_option backward.isDefEq.respectTransparency false in
 def overPushforwardOverAdj (x : C) :
     pushforward.{w} (𝟙 (R.over x)) ⊣ pushforward.{w} (pushforwardOver x) := by
   refine pushforwardPushforwardAdj (Over.forgetAdjStar x) (𝟙 (R.over x)) _ ?_ ?_
-  · ext y : 2
+  · ext y : 3
     simp [pushforwardOver]
-  · ext y : 2
+  · ext y : 3
     simp [pushforwardOver, ← Functor.map_comp, ← op_comp]
 
 instance (x : C) : IsLeftAdjoint (pushforward.{w} (𝟙 (R.over x))) where
@@ -376,10 +442,14 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
   [Functor.IsContinuous eqv.inverse K J]
   (φ : S ⟶ (eqv.functor.sheafPushforwardContinuous RingCat.{u} J K).obj R)
   (ψ : R ⟶ (eqv.inverse.sheafPushforwardContinuous RingCat.{u} K J).obj S)
-  (H₁ : Functor.whiskerRight (NatTrans.op eqv.counit) R.obj =
-    ψ.hom ≫ eqv.inverse.op.whiskerLeft φ.hom)
-  (H₂ : φ.hom ≫ eqv.functor.op.whiskerLeft ψ.hom ≫
-    Functor.whiskerRight (NatTrans.op eqv.unit) S.obj = 𝟙 S.obj)
+  (H₁ : haveI := Functor.isContinuous_comp eqv.inverse eqv.functor K J K
+    pushforwardIdHom R ≫
+      (Functor.sheafPushforwardContinuousNatTrans eqv.counit _ _ _).app R =
+        pushforwardCompHom ψ φ)
+  (H₂ : haveI := Functor.isContinuous_comp eqv.functor eqv.inverse J K J
+    pushforwardCompHom φ ψ ≫
+      (Functor.sheafPushforwardContinuousNatTrans eqv.unit _ _ _).app S =
+        pushforwardIdHom S)
 
 /-- If `e : C ≌ D`, then the pushforwards along `e.functor` and `e.inverse` forms an equivalence. -/
 noncomputable
@@ -389,11 +459,11 @@ def pushforwardPushforwardEquivalence : SheafOfModules R ≌ SheafOfModules S wh
   unitIso :=
     letI := CategoryTheory.Functor.isContinuous_comp eqv.inverse eqv.functor K J K
     (pushforwardId _).symm ≪≫ pushforwardNatIso _ eqv.counitIso ≪≫
-      pushforwardCongr (by ext1; simpa) ≪≫ (pushforwardComp _ _).symm
+      pushforwardCongr H₁ ≪≫ (pushforwardComp _ _).symm
   counitIso :=
     letI := CategoryTheory.Functor.isContinuous_comp eqv.functor eqv.inverse J K J
     pushforwardComp _ _ ≪≫ pushforwardNatIso _ eqv.unitIso ≪≫
-      pushforwardCongr (by ext1; simpa) ≪≫ pushforwardId _
+      pushforwardCongr H₂ ≪≫ pushforwardId _
   functor_unitIso_comp :=
     (pushforwardPushforwardAdj eqv.toAdjunction φ ψ H₁ H₂).left_triangle_components
 

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Quasicoherent.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Quasicoherent.lean
@@ -436,7 +436,17 @@ noncomputable def QuasicoherentData.bind {R : Sheaf J RingCat.{u}}
   presentation i :=
     letI e := pushforwardPushforwardEquivalence (Over.iteratedSliceEquiv ((D i.1).X i.2))
       (S := (R.over _).over _) (R := R.over _) (𝟙 _) (𝟙 _)
-      (by ext : 2; exact R.1.map_id _) (by ext : 2; exact R.1.map_id _)
+      (by
+        ext : 3
+        simp only [ObjectProperty.FullSubcategory.comp_hom, pushforwardIdHom_hom,
+          Functor.sheafPushforwardContinuousNatTrans_app_hom, ObjectProperty.ι_obj]
+        exact R.obj.map_id _)
+      (by
+        ext : 3
+        simp only [ObjectProperty.FullSubcategory.comp_hom, ObjectProperty.ι_obj,
+          Functor.sheafPushforwardContinuousNatTrans_app_hom, pushforwardIdHom_hom,
+          PresheafOfModules.pushforwardIdHom_app]
+        exact R.obj.map_id _)
     (((D i.1).presentation i.2).map e.inverse (.refl _)).ofIsIso
       (e.fullyFaithfulFunctor.preimageIso
       (by exact e.counitIso.app ((M.over (X i.1)).over ((D i.1).X i.2)))).hom

--- a/Mathlib/AlgebraicGeometry/Modules/Sheaf.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Sheaf.lean
@@ -213,13 +213,13 @@ variable (X) in
 /-- The pullback of sheaves of modules by the identity morphism identifies
 to the identity functor. -/
 def pullbackId : pullback (𝟙 X) ≅ 𝟭 _ :=
-  SheafOfModules.pullbackId _
+  (pullbackPushforwardAdjunction (𝟙 X)).leftAdjointIdIso (pushforwardId X)
 
 variable (X) in
 lemma conjugateEquiv_pullbackId_hom :
     conjugateEquiv .id (pullbackPushforwardAdjunction (𝟙 X)) (pullbackId X).hom =
       (pushforwardId X).inv :=
-  SheafOfModules.conjugateEquiv_pullbackId_hom _
+  Adjunction.conjugateEquiv_leftAdjointIdIso_hom _ _
 
 /-- The composition of two pushforward functors for sheaves of modules on schemes
 identify to the pushforward for the composition. -/
@@ -235,7 +235,9 @@ set_option backward.isDefEq.respectTransparency.types false in
 identify to the pullback for the composition. -/
 def pullbackComp :
     pullback g ⋙ pullback f ≅ pullback (f ≫ g) :=
-  SheafOfModules.pullbackComp _ _
+  Adjunction.leftAdjointCompIso (pullbackPushforwardAdjunction g)
+    (pullbackPushforwardAdjunction f) (pullbackPushforwardAdjunction (f ≫ g))
+    (pushforwardComp f g)
 
 set_option backward.isDefEq.respectTransparency.types false in
 /-- Pushforwards along equal morphisms are isomorphic. -/
@@ -258,52 +260,120 @@ lemma conjugateEquiv_pullbackComp_inv :
     conjugateEquiv ((pullbackPushforwardAdjunction g).comp (pullbackPushforwardAdjunction f))
       (pullbackPushforwardAdjunction (f ≫ g)) (pullbackComp f g).inv =
     (pushforwardComp f g).hom :=
-  SheafOfModules.conjugateEquiv_pullbackComp_inv _ _
+  Adjunction.conjugateEquiv_leftAdjointCompIso_inv _ _ _ _
 
-set_option backward.isDefEq.respectTransparency false in
+/-- Associativity of the identification `Scheme.Modules.pushforwardComp`. -/
+lemma pushforward_assoc :
+    Functor.isoWhiskerLeft (pushforward f) (pushforwardComp g h) ≪≫ pushforwardComp f (g ≫ h) =
+      (Functor.associator (pushforward f) (pushforward g) (pushforward h)).symm ≪≫
+        Functor.isoWhiskerRight (pushforwardComp f g) (pushforward h) ≪≫
+          pushforwardComp (f ≫ g) h ≪≫ pushforwardCongr (Category.assoc f g h) := by
+  ext M U : 4
+  simp only [Functor.comp_obj, pushforward_obj_obj, Hom.comp_base, Opens.map_comp_obj,
+    Iso.trans_hom, Functor.isoWhiskerLeft_hom, NatTrans.comp_app, Functor.whiskerLeft_app,
+    Hom.comp_app, pushforwardComp_hom_app_app, Category.comp_id, Iso.symm_hom,
+    Functor.isoWhiskerRight_hom, Functor.associator_inv_app, Functor.whiskerRight_app,
+    Category.id_comp, pushforward_map_app, pushforwardCongr_hom_app_app]
+  exact (M.presheaf.map_id _).symm
+
+/-- Left unitality of the identification `Scheme.Modules.pushforwardComp`. -/
+lemma pushforward_id_comp :
+    pushforwardComp (𝟙 X) f ≪≫ pushforwardCongr (Category.id_comp f) =
+      Functor.isoWhiskerRight (pushforwardId X) (pushforward f) ≪≫ Functor.leftUnitor _ := by
+  ext M U : 4
+  simp only [Functor.comp_obj, pushforward_obj_obj, Hom.id_base, Iso.trans_hom, NatTrans.comp_app,
+    Hom.comp_app, Hom.comp_base, Opens.map_comp_obj, pushforwardComp_hom_app_app,
+    pushforwardCongr_hom_app_app, Category.id_comp, Functor.isoWhiskerRight_hom, Functor.id_obj,
+    Functor.whiskerRight_app, Functor.leftUnitor_hom_app, Category.comp_id, pushforward_map_app,
+    pushforwardId_hom_app_app]
+  exact M.presheaf.map_id _
+
+/-- Right unitality of the identification `Scheme.Modules.pushforwardComp`. -/
+lemma pushforward_comp_id :
+    pushforwardComp f (𝟙 Y) ≪≫ pushforwardCongr (Category.comp_id f) =
+      Functor.isoWhiskerLeft (pushforward f) (pushforwardId Y) ≪≫ Functor.rightUnitor _ := by
+  ext M U : 4
+  simp only [Functor.comp_obj, pushforward_obj_obj, Hom.id_base, Iso.trans_hom, NatTrans.comp_app,
+    Hom.comp_app, Hom.comp_base, Opens.map_comp_obj, pushforwardComp_hom_app_app,
+    pushforwardCongr_hom_app_app, Category.id_comp, Functor.isoWhiskerLeft_hom, Functor.id_obj,
+    Functor.whiskerLeft_app, Functor.rightUnitor_hom_app, Category.comp_id,
+    pushforwardId_hom_app_app]
+  exact M.presheaf.map_id _
+
+@[simp] lemma pushforwardCongr_refl : pushforwardCongr (rfl : f = f) = Iso.refl _ := by
+  ext M U : 4
+  simp
+
+/-- The transport of pullback functors along an equality of morphisms of schemes is the
+conjugate of the corresponding transport of pushforward functors. -/
+lemma conjugateIsoEquiv_symm_pushforwardCongr {f g : X ⟶ Y} (hf : f = g) :
+    (conjugateIsoEquiv (pullbackPushforwardAdjunction g)
+        (pullbackPushforwardAdjunction f)).symm (pushforwardCongr hf).symm =
+      pullbackCongr hf := by
+  subst hf
+  ext : 1
+  simp [pullbackCongr]
+
+/-- Associativity of the identification `Scheme.Modules.pullbackComp`. -/
+lemma pullback_assoc :
+    Functor.isoWhiskerLeft (pullback h) (pullbackComp f g) ≪≫
+        pullbackComp (f ≫ g) h ≪≫ pullbackCongr (Category.assoc f g h) =
+      (Functor.associator (pullback h) (pullback g) (pullback f)).symm ≪≫
+        Functor.isoWhiskerRight (pullbackComp g h) (pullback f) ≪≫ pullbackComp f (g ≫ h) := by
+  rw [pullbackComp, pullbackComp, pullbackComp, ← conjugateIsoEquiv_symm_pushforwardCongr,
+    ← Adjunction.leftAdjointCompIso_trans]
+  exact Adjunction.leftAdjointCompIso_assoc _ _ _ _ _ _ _ _ _ _ (pushforward_assoc f g h)
+
+/-- Left unitality of the identification `Scheme.Modules.pullbackComp`. -/
+lemma pullback_id_comp :
+    pullbackComp (𝟙 X) f ≪≫ pullbackCongr (Category.id_comp f) =
+      Functor.isoWhiskerLeft (pullback f) (pullbackId X) ≪≫ Functor.rightUnitor _ := by
+  rw [pullbackComp, ← conjugateIsoEquiv_symm_pushforwardCongr,
+    ← Adjunction.leftAdjointCompIso_trans]
+  exact Adjunction.leftAdjointCompIso_comp_id _ _ _ _ (pushforward_id_comp f)
+
+/-- Right unitality of the identification `Scheme.Modules.pullbackComp`. -/
+lemma pullback_comp_id :
+    pullbackComp f (𝟙 Y) ≪≫ pullbackCongr (Category.comp_id f) =
+      Functor.isoWhiskerRight (pullbackId Y) (pullback f) ≪≫ Functor.leftUnitor _ := by
+  rw [pullbackComp, ← conjugateIsoEquiv_symm_pushforwardCongr,
+    ← Adjunction.leftAdjointCompIso_trans]
+  exact Adjunction.leftAdjointCompIso_id_comp _ _ _ _ (pushforward_comp_id f)
+
 @[reassoc]
 lemma pseudofunctor_associativity :
     (pullbackComp f (g ≫ h)).inv ≫
       Functor.whiskerRight (pullbackComp g h).inv _ ≫ (Functor.associator _ _ _).hom ≫
         Functor.whiskerLeft _ (pullbackComp f g).hom ≫ (pullbackComp (f ≫ g) h).hom =
     eqToHom (by simp) := by
-  let e₁ := pullbackComp f (g ≫ h)
-  let e₂ := Functor.isoWhiskerRight (pullbackComp g h) (pullback f)
-  let e₃ := Functor.isoWhiskerLeft (pullback h) (pullbackComp f g)
-  let e₄ := pullbackComp (f ≫ g) h
-  change e₁.inv ≫ e₂.inv ≫ (Functor.associator _ _ _).hom ≫ e₃.hom ≫ e₄.hom = _
-  have : e₃.hom ≫ e₄.hom = (Functor.associator _ _ _).inv ≫ e₂.hom ≫ e₁.hom :=
-    congr_arg Iso.hom (SheafOfModules.pullback_assoc.{u}
-      h.toRingCatSheafHom g.toRingCatSheafHom f.toRingCatSheafHom)
-  simp [this]
+  have h₁ := congr_arg Iso.hom (pullback_assoc f g h)
+  simp only [Iso.trans_hom, Iso.symm_hom, Functor.isoWhiskerLeft_hom,
+    Functor.isoWhiskerRight_hom, pullbackCongr, eqToIso.hom] at h₁
+  rw [← cancel_mono (pullbackCongr (Category.assoc f g h)).hom]
+  simp only [Category.assoc, h₁, pullbackCongr, eqToIso.hom, eqToHom_trans, eqToHom_refl,
+    Iso.hom_inv_id_assoc]
+  rw [← Functor.whiskerRight_comp_assoc, Iso.inv_hom_id, Functor.whiskerRight_id',
+    Category.id_comp, Iso.inv_hom_id]
 
-set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma pseudofunctor_left_unitality :
     (pullbackComp f (𝟙 Y)).inv ≫
       Functor.whiskerRight (pullbackId Y).hom (pullback f) ≫ (Functor.leftUnitor _).hom =
         eqToHom (by simp) := by
-  let e₁ := pullbackComp f (𝟙 _)
-  let e₂ := Functor.isoWhiskerRight (pullbackId Y) (pullback f)
-  let e₃ := (pullback f).leftUnitor
-  change e₁.inv ≫ e₂.hom ≫ e₃.hom = _
-  have : e₁.hom = e₂.hom ≫ e₃.hom :=
-    congr_arg Iso.hom (SheafOfModules.pullback_id_comp.{u} f.toRingCatSheafHom)
-  simp [← this]
+  have h₁ := congr_arg Iso.hom (pullback_comp_id f)
+  simp only [Iso.trans_hom, Functor.isoWhiskerRight_hom] at h₁
+  rw [← h₁]
+  simp [pullbackCongr]
 
-set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma pseudofunctor_right_unitality :
     (pullbackComp (𝟙 X) f).inv ≫
       Functor.whiskerLeft (pullback f) (pullbackId X).hom ≫ (Functor.rightUnitor _).hom =
         eqToHom (by simp) := by
-  let e₁ := pullbackComp (𝟙 _) f
-  let e₂ := Functor.isoWhiskerLeft (pullback f) (pullbackId _)
-  let e₃ := (pullback f).rightUnitor
-  change e₁.inv ≫ e₂.hom ≫ e₃.hom = _
-  have : e₁.hom = e₂.hom ≫ e₃.hom :=
-    congr_arg Iso.hom (SheafOfModules.pullback_comp_id.{u} f.toRingCatSheafHom)
-  simp [← this]
+  have h₁ := congr_arg Iso.hom (pullback_id_comp f)
+  simp only [Iso.trans_hom, Functor.isoWhiskerLeft_hom] at h₁
+  rw [← h₁]
+  simp [pullbackCongr]
 
 set_option backward.defeqAttrib.useBackward true in
 attribute [local simp] pseudofunctor_associativity pseudofunctor_left_unitality
@@ -598,7 +668,7 @@ def overFunctorEquiv {X : Scheme.{u}} (U : X.Opens) :
       (Opens.grothendieckTopology ↥U) (Opens.grothendieckTopology ↥X) :=
     Functor.isContinuous_comp _ _ _ (.over (Opens.grothendieckTopology _) U) _
   refine SheafOfModules.pushforwardComp _ _ ≪≫ SheafOfModules.pushforwardCongr ?_
-  simp only [CategoryTheory.Functor.map_id, Opposite.op_unop, Opens.ι_appIso, Iso.refl_inv]
+  simp only [Opposite.op_unop, Opens.ι_appIso, Iso.refl_inv]
   rfl
 
 end AlgebraicGeometry.Scheme.Modules

--- a/Mathlib/CategoryTheory/Adjunction/CompositionIso.lean
+++ b/Mathlib/CategoryTheory/Adjunction/CompositionIso.lean
@@ -85,6 +85,17 @@ lemma conjugateEquiv_leftAdjointCompIso_inv (e₀₁₂ : G₂₁ ⋙ G₁₀ �
   dsimp only [leftAdjointCompIso]
   simp
 
+/-- Composing the isomorphism `G₂₁ ⋙ G₁₀ ≅ G₂₀` with an isomorphism `G₂₀ ≅ G₂₀'` of right
+adjoints amounts to composing `leftAdjointCompIso` with the conjugate isomorphism
+of left adjoints. -/
+lemma leftAdjointCompIso_trans {F₀₂' : C₀ ⥤ C₂} {G₂₀' : C₂ ⥤ C₀} (adj₀₂' : F₀₂' ⊣ G₂₀')
+    (e₀₁₂ : G₂₁ ⋙ G₁₀ ≅ G₂₀) (e : G₂₀ ≅ G₂₀') :
+    leftAdjointCompIso adj₀₁ adj₁₂ adj₀₂' (e₀₁₂ ≪≫ e) =
+      leftAdjointCompIso adj₀₁ adj₁₂ adj₀₂ e₀₁₂ ≪≫
+        (conjugateIsoEquiv adj₀₂' adj₀₂).symm e.symm := by
+  ext : 1
+  simp [leftAdjointCompIso]
+
 end
 
 set_option backward.defeqAttrib.useBackward true in

--- a/Mathlib/Topology/Sheaves/Module.lean
+++ b/Mathlib/Topology/Sheaves/Module.lean
@@ -29,10 +29,12 @@ set_option backward.isDefEq.respectTransparency false in
 def sheafOfModulesEquivOver :
     SheafOfModules.{w} (R.over U) ≌ SheafOfModules.{w} (U.sheafRestrict.obj R) := by
   refine SheafOfModules.pushforwardPushforwardEquivalence (eqv := U.overEquivalence.symm)
-    (U.overPullbackSheafEquivOver.app _).inv (U.sheafRestrictSheafEquivOver.app _).inv rfl ?_
-  ext : 2
-  simp [overPullbackSheafEquivOver, sheafRestrictSheafEquivOver, eqToHom_map, overEquivalence,
-    IsOpenMap.functor]
+    (U.overPullbackSheafEquivOver.app _).inv (U.sheafRestrictSheafEquivOver.app _).inv ?_ ?_
+  · ext : 3
+    simp [overPullbackSheafEquivOver, sheafRestrictSheafEquivOver, overEquivalence,
+      IsOpenMap.functor]
+  · ext : 3
+    simp [overPullbackSheafEquivOver, sheafRestrictSheafEquivOver, eqToHom_map, overEquivalence]
 
 /-- `sheafOfModulesEquivOver` takes `R.over U` to `R |_ U`. -/
 def sheafOfModulesEquivOverUnit (R : X.Sheaf RingCat.{u}) :


### PR DESCRIPTION
This PR makes the pushforward of (pre)sheaves of modules along the identity functor and along a composition of functors honestly typed. Currently `pushforwardId` takes `𝟙 S` at the type `S ⟶ (𝟭 C).op ⋙ S` and `pushforwardComp` takes `φ ≫ whiskerLeft F.op ψ` at the type `S ⟶ (F ⋙ G).op ⋙ T`, which only elaborate because `Functor.comp`, `Functor.id` and `Functor.op` unfold. The new `pushforwardIdHom` and `pushforwardCompHom` are the unitor and associator composed with `Functor.opId`/`Functor.opComp` (see `pushforwardIdHom_eq` and `pushforwardCompHom_eq`), and the associativity and unitality isomorphisms of pushforward and pullback are transported along the functor associator and unitors through the new `pushforwardCongr₂`/`pullbackCongr₂` (added at the presheaf level, together with `pushforwardCongr`, `pushforwardNatTrans` and `pushforwardNatIso`). The scheme-level pseudofunctor coherence lemmas in `AlgebraicGeometry.Modules.Sheaf` are reproved from these, and `Adjunction.leftAdjointCompIso_trans` is added for that purpose.

It is extracted from Paul Reichert's experiment making `Functor.comp` and `Functor.id` `instance_reducible` (https://github.com/leanprover-community/mathlib4/compare/master...leanprover-community:mathlib4-nightly-testing:datokrat/functorcomp, discussed at https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency), and is the (pre)sheaf-of-modules half of https://github.com/leanprover-community/mathlib4/pull/43566; it is independent of that PR.

🤖 Prepared with Claude Code