### PR TITLE
chore(Order/BooleanAlgebra): Add push tags

### DIFF
--- a/Mathlib/Order/BooleanAlgebra/Set.lean
+++ b/Mathlib/Order/BooleanAlgebra/Set.lean
@@ -464,7 +464,6 @@ theorem sdiff_self_inter {s t : Set α} : s \ (s ∩ t) = s \ t :=
 
 @[deprecated (since := "2026-06-03")] alias diff_self_inter := sdiff_self_inter
 
-@[simp]
 theorem sdiff_self {s : Set α} : s \ s = ∅ :=
   _root_.sdiff_self
 

--- a/Mathlib/Order/BooleanAlgebra/Set.lean
+++ b/Mathlib/Order/BooleanAlgebra/Set.lean
@@ -63,21 +63,25 @@ theorem sdiff_union_sdiff_cancel' (hi : s ∩ u ⊆ t) (hu : t ⊆ s ∪ u) : (s
 
 @[deprecated (since := "2026-06-03")] alias diff_union_diff_cancel' := sdiff_union_sdiff_cancel'
 
+@[push]
 theorem sdiff_sdiff_eq_sdiff_union (h : u ⊆ s) : s \ (t \ u) = s \ t ∪ u :=
   sdiff_sdiff_eq_sdiff_sup h
 
 @[deprecated (since := "2026-06-03")] alias diff_diff_eq_sdiff_union := sdiff_sdiff_eq_sdiff_union
 
+@[push]
 theorem inter_sdiff_distrib_left (s t u : Set α) : s ∩ (t \ u) = (s ∩ t) \ (s ∩ u) :=
   inf_sdiff_distrib_left _ _ _
 
 @[deprecated (since := "2026-06-03")] alias inter_diff_distrib_left := inter_sdiff_distrib_left
 
+@[push]
 theorem inter_sdiff_distrib_right (s t u : Set α) : (s \ t) ∩ u = (s ∩ u) \ (t ∩ u) :=
   inf_sdiff_distrib_right _ _ _
 
 @[deprecated (since := "2026-06-03")] alias inter_diff_distrib_right := inter_sdiff_distrib_right
 
+@[push]
 theorem sdiff_inter_distrib_right (s t r : Set α) : (t ∩ r) \ s = (t \ s) ∩ (r \ s) :=
   inf_sdiff
 
@@ -114,10 +118,11 @@ theorem compl_inter_self (s : Set α) : sᶜ ∩ s = ∅ :=
 theorem compl_empty : (∅ : Set α)ᶜ = univ :=
   compl_bot
 
-@[simp]
+@[push, simp]
 theorem compl_union (s t : Set α) : (s ∪ t)ᶜ = sᶜ ∩ tᶜ :=
   compl_sup
 
+@[push]
 theorem compl_inter (s t : Set α) : (s ∩ t)ᶜ = sᶜ ∪ tᶜ :=
   compl_inf
 
@@ -143,9 +148,11 @@ lemma inl_compl_union_inr_compl {s : Set α} {t : Set β} :
 theorem nonempty_compl : sᶜ.Nonempty ↔ s ≠ univ :=
   (ne_univ_iff_exists_notMem s).symm
 
+@[push]
 theorem union_eq_compl_compl_inter_compl (s t : Set α) : s ∪ t = (sᶜ ∩ tᶜ)ᶜ :=
   ext fun _ => or_iff_not_and_not
 
+@[push]
 theorem inter_eq_compl_compl_union_compl (s t : Set α) : s ∩ t = (sᶜ ∪ tᶜ)ᶜ :=
   ext fun _ => and_iff_not_or_not
 
@@ -197,7 +204,7 @@ lemma mem_compl_singleton_iff : a ∈ ({b} : Set α)ᶜ ↔ a ≠ b := .rfl
 
 lemma compl_singleton_eq (a : α) : {a}ᶜ = {x | x ≠ a} := rfl
 
-@[simp]
+@[push, simp]
 lemma compl_ne_eq_singleton (a : α) : {x | x ≠ a}ᶜ = {a} := compl_compl _
 
 @[simp]
@@ -391,31 +398,37 @@ theorem sdiff_subset_comm {s t u : Set α} : s \ t ⊆ u ↔ s \ u ⊆ t :=
 
 @[deprecated (since := "2026-06-03")] alias diff_subset_comm := sdiff_subset_comm
 
+@[push]
 theorem sdiff_inter {s t u : Set α} : s \ (t ∩ u) = s \ t ∪ s \ u :=
   sdiff_inf
 
 @[deprecated (since := "2026-06-03")] alias diff_inter := sdiff_inter
 
+@[push ←]
 theorem sdiff_inter_sdiff : s \ t ∩ (s \ u) = s \ (t ∪ u) :=
   sdiff_sup.symm
 
 @[deprecated (since := "2026-06-03")] alias diff_inter_diff := sdiff_inter_sdiff
 
+@[push]
 theorem sdiff_compl : s \ tᶜ = s ∩ t :=
   _root_.sdiff_compl
 
 @[deprecated (since := "2026-06-03")] alias diff_compl := sdiff_compl
 
+@[push]
 theorem compl_sdiff : (t \ s)ᶜ = s ∪ tᶜ :=
   Eq.trans _root_.compl_sdiff himp_eq
 
 @[deprecated (since := "2026-06-03")] alias compl_diff := compl_sdiff
 
+@[push]
 theorem sdiff_sdiff_right {s t u : Set α} : s \ (t \ u) = s \ t ∪ s ∩ u :=
   sdiff_sdiff_right'
 
 @[deprecated (since := "2026-06-03")] alias diff_diff_right := sdiff_sdiff_right
 
+@[push]
 theorem inter_sdiff_right_comm : (s ∩ t) \ u = s \ u ∩ t := by
   rw [sdiff_eq, sdiff_eq, inter_right_comm]
 
@@ -439,28 +452,31 @@ theorem sdiff_inter_self {a b : Set α} : b \ a ∩ a = ∅ :=
 
 @[deprecated (since := "2026-06-03")] alias diff_inter_self := sdiff_inter_self
 
-@[simp]
+@[push, simp]
 theorem sdiff_inter_self_eq_sdiff {s t : Set α} : s \ (t ∩ s) = s \ t :=
   sdiff_inf_self_right _ _
 
 @[deprecated (since := "2026-06-03")] alias diff_inter_self_eq_diff := sdiff_inter_self_eq_sdiff
 
-@[simp]
+@[push, simp]
 theorem sdiff_self_inter {s t : Set α} : s \ (s ∩ t) = s \ t :=
   sdiff_inf_self_left _ _
 
 @[deprecated (since := "2026-06-03")] alias diff_self_inter := sdiff_self_inter
 
+@[simp]
 theorem sdiff_self {s : Set α} : s \ s = ∅ :=
   _root_.sdiff_self
 
 @[deprecated (since := "2026-06-03")] alias diff_self := sdiff_self
 
+@[push]
 theorem sdiff_sdiff_right_self (s t : Set α) : s \ (s \ t) = s ∩ t :=
   _root_.sdiff_sdiff_right_self
 
 @[deprecated (since := "2026-06-03")] alias diff_diff_right_self := sdiff_sdiff_right_self
 
+@[push]
 theorem sdiff_sdiff_cancel_left {s t : Set α} (h : s ⊆ t) : t \ (t \ s) = s :=
   sdiff_sdiff_eq_self h
 

--- a/Mathlib/Order/BooleanAlgebra/Set.lean
+++ b/Mathlib/Order/BooleanAlgebra/Set.lean
@@ -148,11 +148,11 @@ lemma inl_compl_union_inr_compl {s : Set α} {t : Set β} :
 theorem nonempty_compl : sᶜ.Nonempty ↔ s ≠ univ :=
   (ne_univ_iff_exists_notMem s).symm
 
-@[push]
+@[push ←]
 theorem union_eq_compl_compl_inter_compl (s t : Set α) : s ∪ t = (sᶜ ∩ tᶜ)ᶜ :=
   ext fun _ => or_iff_not_and_not
 
-@[push]
+@[push ←]
 theorem inter_eq_compl_compl_union_compl (s t : Set α) : s ∩ t = (sᶜ ∪ tᶜ)ᶜ :=
   ext fun _ => and_iff_not_or_not
 


### PR DESCRIPTION
Add push tags to some lemmas in Mathlib/Order/BooleanAlgebra/Set.lean

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
