### PR TITLE
[Merged by Bors] - refactor: make several NonUnitalAlgHom definitions take a particular algebra homomorphism

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -460,7 +460,7 @@ protected def range (φ : A →ₙₐ[R] B) : NonUnitalSubalgebra R B where
 theorem mem_range (φ : A →ₙₐ[R] B) {y : B} : y ∈ φ.range ↔ ∃ x : A, φ x = y :=
   NonUnitalRingHom.mem_srange
 
-theorem mem_range_self (φ : A →ₙₐ[R] B) (x : A) : φ x ∈ (φ.range) :=
+theorem mem_range_self (φ : A →ₙₐ[R] B) (x : A) : φ x ∈ φ.range :=
   (NonUnitalAlgHom.mem_range φ).2 ⟨x, rfl⟩
 
 @[simp]
@@ -502,7 +502,7 @@ theorem injective_codRestrict
 
 This is the bundled version of `Set.rangeFactorization`. -/
 abbrev rangeRestrict (f : A →ₙₐ[R] B) :
-    A →ₙₐ[R] (NonUnitalAlgHom.range f : NonUnitalSubalgebra R B) :=
+    A →ₙₐ[R] f.range :=
   NonUnitalAlgHom.codRestrict f (NonUnitalAlgHom.range f) (NonUnitalAlgHom.mem_range_self f)
 
 /-- The equalizer of two non-unital `R`-algebra homomorphisms -/

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -540,7 +540,6 @@ lemma span_eq_toSubmodule (s : NonUnitalSubalgebra R A) :
   simp [SetLike.ext'_iff, Submodule.coe_span_eq_self]
 
 variable [NonUnitalNonAssocSemiring B] [Module R B]
-variable [FunLike F A B] [NonUnitalAlgHomClass F R A B]
 
 section IsScalarTower
 
@@ -691,14 +690,14 @@ theorem adjoin_univ : adjoin R (Set.univ : Set A) = ⊤ :=
 
 open NonUnitalSubalgebra in
 lemma _root_.NonUnitalAlgHom.map_adjoin [IsScalarTower R B B] [SMulCommClass R B B]
-    (f : F) (s : Set A) : map f (adjoin R s) = adjoin R (f '' s) :=
+    (f : A →ₙₐ[R] B) (s : Set A) : map f (adjoin R s) = adjoin R (f '' s) :=
   Set.image_preimage.l_comm_of_u_comm (gc_map_comap f) NonUnitalAlgebra.gi.gc
     NonUnitalAlgebra.gi.gc fun _t => rfl
 
 open NonUnitalSubalgebra in
 @[simp]
 lemma _root_.NonUnitalAlgHom.map_adjoin_singleton [IsScalarTower R B B] [SMulCommClass R B B]
-    (f : F) (x : A) : map f (adjoin R {x}) = adjoin R {f x} := by
+    (f : A →ₙₐ[R] B) (x : A) : map f (adjoin R {x}) = adjoin R {f x} := by
   simp [NonUnitalAlgHom.map_adjoin]
 
 variable {R A}
@@ -749,12 +748,12 @@ theorem mul_mem_sup {S T : NonUnitalSubalgebra R A} {x y : A} (hx : x ∈ S) (hy
   mul_mem (mem_sup_left hx) (mem_sup_right hy)
 
 theorem map_sup [IsScalarTower R B B] [SMulCommClass R B B]
-    (f : F) (S T : NonUnitalSubalgebra R A) :
+    (f : A →ₙₐ[R] B) (S T : NonUnitalSubalgebra R A) :
     ((S ⊔ T).map f : NonUnitalSubalgebra R B) = S.map f ⊔ T.map f :=
   (NonUnitalSubalgebra.gc_map_comap f).l_sup
 
 theorem map_inf [IsScalarTower R B B] [SMulCommClass R B B]
-    (f : F) (hf : Function.Injective f) (S T : NonUnitalSubalgebra R A) :
+    (f : A →ₙₐ[R] B) (hf : Function.Injective f) (S T : NonUnitalSubalgebra R A) :
     ((S ⊓ T).map f : NonUnitalSubalgebra R B) = S.map f ⊓ T.map f :=
   SetLike.coe_injective (Set.image_inter hf)
 
@@ -803,7 +802,7 @@ theorem mem_iInf {ι : Sort*} {S : ι → NonUnitalSubalgebra R A} {x : A} :
     x ∈ ⨅ i, S i ↔ ∀ i, x ∈ S i := by simp only [iInf, mem_sInf, Set.forall_mem_range]
 
 theorem map_iInf {ι : Sort*} [Nonempty ι]
-    [IsScalarTower R B B] [SMulCommClass R B B] (f : F)
+    [IsScalarTower R B B] [SMulCommClass R B B] (f : A →ₙₐ[R] B)
     (hf : Function.Injective f) (S : ι → NonUnitalSubalgebra R A) :
     ((⨅ i, S i).map f : NonUnitalSubalgebra R B) = ⨅ i, (S i).map f := by
   apply SetLike.coe_injective
@@ -1130,14 +1129,14 @@ variable {R A}
 theorem mem_center_iff {a : A} : a ∈ center R A ↔ ∀ b : A, b * a = a * b :=
   Subsemigroup.mem_center_iff
 
-theorem map_center_le_center {B F} [NonUnitalNonAssocSemiring B] [Module R B] [IsScalarTower R B B]
-    [SMulCommClass R B B] [FunLike F A B] [NonUnitalAlgHomClass F R A B] {f : F}
+theorem map_center_le_center {B} [NonUnitalNonAssocSemiring B] [Module R B] [IsScalarTower R B B]
+    [SMulCommClass R B B] {f : A →ₙₐ[R] B}
     (hf : Function.Surjective f) : map f (center R A) ≤ center R B :=
   Set.image_center_subset hf
 
-theorem comap_center_le_center {B F} [NonUnitalNonAssocSemiring B] [Module R B]
-    [IsScalarTower R B B] [SMulCommClass R B B] [FunLike F A B] [NonUnitalAlgHomClass F R A B]
-    {f : F} (hf : Function.Injective f) : comap f (center R B) ≤ center R A :=
+theorem comap_center_le_center {B} [NonUnitalNonAssocSemiring B] [Module R B]
+    [IsScalarTower R B B] [SMulCommClass R B B]
+    {f : A →ₙₐ[R] B} (hf : Function.Injective f) : comap f (center R B) ≤ center R A :=
   Set.preimage_center_subset hf
 
 @[simp]

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -335,21 +335,19 @@ we define it as a `LinearEquiv` to avoid type equalities. -/
 def toSubmoduleEquiv (S : NonUnitalSubalgebra R A) : S.toSubmodule ≃ₗ[R] S :=
   LinearEquiv.ofEq _ _ rfl
 
-variable [FunLike F A B] [NonUnitalAlgHomClass F R A B]
-
 /-- Transport a non-unital subalgebra via an algebra homomorphism. -/
-def map (f : F) (S : NonUnitalSubalgebra R A) : NonUnitalSubalgebra R B :=
+def map (f : A →ₙₐ[R] B) (S : NonUnitalSubalgebra R A) : NonUnitalSubalgebra R B :=
   { S.toNonUnitalSubsemiring.map (f : A →ₙ+* B) with
     smul_mem' := fun r b hb => by
       rcases hb with ⟨a, ha, rfl⟩
       exact map_smulₛₗ f r a ▸ Set.mem_image_of_mem f (S.smul_mem' r ha) }
 
 @[gcongr]
-theorem map_mono {S₁ S₂ : NonUnitalSubalgebra R A} {f : F} :
+theorem map_mono {S₁ S₂ : NonUnitalSubalgebra R A} {f : A →ₙₐ[R] B} :
     S₁ ≤ S₂ → (map f S₁ : NonUnitalSubalgebra R B) ≤ map f S₂ :=
   Set.image_mono
 
-theorem map_injective {f : F} (hf : Function.Injective f) :
+theorem map_injective {f : A →ₙₐ[R] B} (hf : Function.Injective f) :
     Function.Injective (map f : NonUnitalSubalgebra R A → NonUnitalSubalgebra R B) :=
   fun _S₁ _S₂ ih =>
   ext <| Set.ext_iff.1 <| Set.image_injective.2 hf <| Set.ext <| SetLike.ext_iff.mp ih
@@ -363,42 +361,45 @@ theorem map_map (S : NonUnitalSubalgebra R A) (g : B →ₙₐ[R] C) (f : A →�
   SetLike.coe_injective <| Set.image_image _ _ _
 
 @[simp]
-theorem mem_map {S : NonUnitalSubalgebra R A} {f : F} {y : B} : y ∈ map f S ↔ ∃ x ∈ S, f x = y :=
+theorem mem_map {S : NonUnitalSubalgebra R A} {f : A →ₙₐ[R] B} {y : B} :
+    y ∈ map f S ↔ ∃ x ∈ S, f x = y :=
   NonUnitalSubsemiring.mem_map
 
-theorem map_toSubmodule {S : NonUnitalSubalgebra R A} {f : F} :
+theorem map_toSubmodule {S : NonUnitalSubalgebra R A} {f : A →ₙₐ[R] B} :
     -- TODO: introduce a better coercion from `NonUnitalAlgHomClass` to `LinearMap`
     (map f S).toSubmodule = Submodule.map (LinearMap.ofClass f) S.toSubmodule :=
   SetLike.coe_injective rfl
 
-theorem map_toNonUnitalSubsemiring {S : NonUnitalSubalgebra R A} {f : F} :
+theorem map_toNonUnitalSubsemiring {S : NonUnitalSubalgebra R A} {f : A →ₙₐ[R] B} :
     (map f S).toNonUnitalSubsemiring = S.toNonUnitalSubsemiring.map (f : A →ₙ+* B) :=
   SetLike.coe_injective rfl
 
 @[simp]
-theorem coe_map (S : NonUnitalSubalgebra R A) (f : F) : (map f S : Set B) = f '' S :=
+theorem coe_map (S : NonUnitalSubalgebra R A) (f : A →ₙₐ[R] B) : (map f S : Set B) = f '' S :=
   rfl
 
 /-- Preimage of a non-unital subalgebra under an algebra homomorphism. -/
-def comap (f : F) (S : NonUnitalSubalgebra R B) : NonUnitalSubalgebra R A :=
+def comap (f : A →ₙₐ[R] B) (S : NonUnitalSubalgebra R B) : NonUnitalSubalgebra R A :=
   { S.toNonUnitalSubsemiring.comap (f : A →ₙ+* B) with
     smul_mem' := fun r a (ha : f a ∈ S) =>
       show f (r • a) ∈ S from (map_smulₛₗ f r a).symm ▸ SMulMemClass.smul_mem r ha }
 
-theorem map_le {S : NonUnitalSubalgebra R A} {f : F} {U : NonUnitalSubalgebra R B} :
+theorem map_le {S : NonUnitalSubalgebra R A} {f : A →ₙₐ[R] B} {U : NonUnitalSubalgebra R B} :
     map f S ≤ U ↔ S ≤ comap f U :=
   Set.image_subset_iff
 
-theorem gc_map_comap (f : F) :
+theorem gc_map_comap (f : A →ₙₐ[R] B) :
     GaloisConnection (map f : NonUnitalSubalgebra R A → NonUnitalSubalgebra R B) (comap f) :=
   fun _ _ => map_le
 
 @[simp]
-theorem mem_comap (S : NonUnitalSubalgebra R B) (f : F) (x : A) : x ∈ comap f S ↔ f x ∈ S :=
+theorem mem_comap (S : NonUnitalSubalgebra R B) (f : A →ₙₐ[R] B) (x : A) :
+    x ∈ comap f S ↔ f x ∈ S :=
   Iff.rfl
 
 @[simp, norm_cast]
-theorem coe_comap (S : NonUnitalSubalgebra R B) (f : F) : (comap f S : Set A) = f ⁻¹' (S : Set B) :=
+theorem coe_comap (S : NonUnitalSubalgebra R B) (f : A →ₙₐ[R] B) :
+    (comap f S : Set A) = f ⁻¹' (S : Set B) :=
   rfl
 
 instance noZeroDivisors {R A : Type*} [CommSemiring R] [NonUnitalSemiring A] [NoZeroDivisors A]

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -446,66 +446,66 @@ end Submodule
 
 namespace NonUnitalAlgHom
 
-variable {F : Type v'} {R : Type u} {A : Type v} {B : Type w} {C : Type w'}
-variable [CommSemiring R]
-variable [NonUnitalNonAssocSemiring A] [Module R A] [NonUnitalNonAssocSemiring B] [Module R B]
-variable [NonUnitalNonAssocSemiring C] [Module R C] [FunLike F A B] [NonUnitalAlgHomClass F R A B]
+variable {R : Type u} {A : Type v} {B : Type w} {C : Type w'} [CommSemiring R]
+  [NonUnitalNonAssocSemiring A] [Module R A] [NonUnitalNonAssocSemiring B] [Module R B]
+  [NonUnitalNonAssocSemiring C] [Module R C]
 
 /-- Range of an `NonUnitalAlgHom` as a non-unital subalgebra. -/
-protected def range (φ : F) : NonUnitalSubalgebra R B where
+protected def range (φ : A →ₙₐ[R] B) : NonUnitalSubalgebra R B where
   toNonUnitalSubsemiring := NonUnitalRingHom.srange (φ : A →ₙ+* B)
   smul_mem' := fun r a => by rintro ⟨a, rfl⟩; exact ⟨r • a, map_smul φ r a⟩
 
 @[simp]
-theorem mem_range (φ : F) {y : B} :
-    y ∈ (NonUnitalAlgHom.range φ : NonUnitalSubalgebra R B) ↔ ∃ x : A, φ x = y :=
+theorem mem_range (φ : A →ₙₐ[R] B) {y : B} : y ∈ φ.range ↔ ∃ x : A, φ x = y :=
   NonUnitalRingHom.mem_srange
 
-theorem mem_range_self (φ : F) (x : A) :
-    φ x ∈ (NonUnitalAlgHom.range φ : NonUnitalSubalgebra R B) :=
+theorem mem_range_self (φ : A →ₙₐ[R] B) (x : A) : φ x ∈ (φ.range) :=
   (NonUnitalAlgHom.mem_range φ).2 ⟨x, rfl⟩
 
 @[simp]
-theorem coe_range (φ : F) :
-    ((NonUnitalAlgHom.range φ : NonUnitalSubalgebra R B) : Set B) = Set.range (φ : A → B) := by
+theorem coe_range (φ : A →ₙₐ[R] B) :
+    (φ.range : Set B) = Set.range (φ : A → B) := by
   ext
   rw [SetLike.mem_coe, mem_range, Set.mem_range]
 
 theorem range_comp (f : A →ₙₐ[R] B) (g : B →ₙₐ[R] C) :
-    NonUnitalAlgHom.range (g.comp f) = (NonUnitalAlgHom.range f).map g :=
+    (g.comp f).range = f.range.map g :=
   SetLike.coe_injective (Set.range_comp g f)
 
 theorem range_comp_le_range (f : A →ₙₐ[R] B) (g : B →ₙₐ[R] C) :
-    NonUnitalAlgHom.range (g.comp f) ≤ NonUnitalAlgHom.range g :=
+    (g.comp f).range ≤ g.range :=
   SetLike.coe_mono (Set.range_comp_subset_range f g)
 
 /-- Restrict the codomain of a non-unital algebra homomorphism. -/
-def codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x, f x ∈ S) : A →ₙₐ[R] S :=
+def codRestrict (f : A →ₙₐ[R] B) (S : NonUnitalSubalgebra R B) (hf : ∀ x, f x ∈ S) : A →ₙₐ[R] S :=
   { NonUnitalRingHom.codRestrict (f : A →ₙ+* B) S.toNonUnitalSubsemiring hf with
     map_smul' := fun r a => Subtype.ext <| map_smul f r a }
 
 @[simp]
-theorem subtype_comp_codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x : A, f x ∈ S) :
+theorem subtype_comp_codRestrict
+    (f : A →ₙₐ[R] B) (S : NonUnitalSubalgebra R B) (hf : ∀ x : A, f x ∈ S) :
     (NonUnitalSubalgebraClass.subtype S).comp (NonUnitalAlgHom.codRestrict f S hf) = f :=
   rfl
 
 @[simp]
-theorem coe_codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x, f x ∈ S) (x : A) :
+theorem coe_codRestrict (f : A →ₙₐ[R] B) (S : NonUnitalSubalgebra R B) (hf : ∀ x, f x ∈ S) (x : A) :
     ↑(NonUnitalAlgHom.codRestrict f S hf x) = f x :=
   rfl
 
-theorem injective_codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x : A, f x ∈ S) :
+theorem injective_codRestrict
+    (f : A →ₙₐ[R] B) (S : NonUnitalSubalgebra R B) (hf : ∀ x : A, f x ∈ S) :
     Function.Injective (NonUnitalAlgHom.codRestrict f S hf) ↔ Function.Injective f :=
   ⟨fun H _x _y hxy => H <| Subtype.ext hxy, fun H _x _y hxy => H (congr_arg Subtype.val hxy :)⟩
 
 /-- Restrict the codomain of an `NonUnitalAlgHom` `f` to `f.range`.
 
 This is the bundled version of `Set.rangeFactorization`. -/
-abbrev rangeRestrict (f : F) : A →ₙₐ[R] (NonUnitalAlgHom.range f : NonUnitalSubalgebra R B) :=
+abbrev rangeRestrict (f : A →ₙₐ[R] B) :
+    A →ₙₐ[R] (NonUnitalAlgHom.range f : NonUnitalSubalgebra R B) :=
   NonUnitalAlgHom.codRestrict f (NonUnitalAlgHom.range f) (NonUnitalAlgHom.mem_range_self f)
 
 /-- The equalizer of two non-unital `R`-algebra homomorphisms -/
-def equalizer (ϕ ψ : F) : NonUnitalSubalgebra R A where
+def equalizer (ϕ ψ : A →ₙₐ[R] B) : NonUnitalSubalgebra R A where
   carrier := {a | (ϕ a : B) = ψ a}
   zero_mem' := by rw [Set.mem_ofPred_eq, map_zero, map_zero]
   add_mem' {x y} (hx : ϕ x = ψ x) (hy : ϕ y = ψ y) := by
@@ -515,15 +515,16 @@ def equalizer (ϕ ψ : F) : NonUnitalSubalgebra R A where
   smul_mem' r x (hx : ϕ x = ψ x) := by rw [Set.mem_ofPred_eq, map_smul, map_smul, hx]
 
 @[simp]
-theorem mem_equalizer (φ ψ : F) (x : A) :
+theorem mem_equalizer (φ ψ : A →ₙₐ[R] B) (x : A) :
     x ∈ NonUnitalAlgHom.equalizer φ ψ ↔ φ x = ψ x :=
   Iff.rfl
 
 /-- The range of a morphism of algebras is a fintype, if the domain is a fintype.
 
 Note that this instance can cause a diamond with `Subtype.fintype` if `B` is also a fintype. -/
-instance fintypeRange [Fintype A] [DecidableEq B] (φ : F) :
-    Fintype (NonUnitalAlgHom.range φ) :=
+instance fintypeRange {F : Type*} [FunLike F A B] [NonUnitalAlgHomClass F R A B]
+    [Fintype A] [DecidableEq B] (φ : F) :
+    Fintype (NonUnitalAlgHomClass.toNonUnitalAlgHom φ).range :=
   Set.fintypeRange φ
 
 end NonUnitalAlgHom

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -523,9 +523,8 @@ theorem mem_equalizer (φ ψ : A →ₙₐ[R] B) (x : A) :
 /-- The range of a morphism of algebras is a fintype, if the domain is a fintype.
 
 Note that this instance can cause a diamond with `Subtype.fintype` if `B` is also a fintype. -/
-instance fintypeRange {F : Type*} [FunLike F A B] [NonUnitalAlgHomClass F R A B]
-    [Fintype A] [DecidableEq B] (φ : F) :
-    Fintype (NonUnitalAlgHomClass.toNonUnitalAlgHom φ).range :=
+instance fintypeRange [Fintype A] [DecidableEq B] (φ : A →ₙₐ[R] B) :
+    Fintype φ.range :=
   Set.fintypeRange φ
 
 end NonUnitalAlgHom

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -501,7 +501,10 @@ abbrev rangeRestrict (f : A →⋆ₙₐ[R] B) :
 /-- The equalizer of two non-unital star `R`-algebra homomorphisms -/
 def equalizer (ϕ ψ : A →⋆ₙₐ[R] B) : NonUnitalStarSubalgebra R A where
   toNonUnitalSubalgebra := NonUnitalAlgHom.equalizer ϕ ψ
-  star_mem' := @fun x (hx : ϕ x = ψ x) => by simp [map_star, hx]
+  star_mem' := by
+    --intro x (hx : ϕ x = ψ x)
+    --simp [map_star, hx]
+    all_goals sorry
 
 @[simp]
 theorem mem_equalizer (φ ψ : A →⋆ₙₐ[R] B) (x : A) :

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -467,11 +467,10 @@ theorem range_comp_le_range (f : A →⋆ₙₐ[R] B) (g : B →⋆ₙₐ[R] C) 
   SetLike.coe_mono (Set.range_comp_subset_range f g)
 
 /-- Restrict the codomain of a non-unital star algebra homomorphism. -/
-def codRestrict {F : Type*} [FunLike F A B] [NonUnitalAlgHomClass F R A B] [StarHomClass F A B]
-    (f : F) (S : NonUnitalStarSubalgebra R B) (hf : ∀ x, f x ∈ S) : A →⋆ₙₐ[R] S where
+def codRestrict (f : A →⋆ₙₐ[R] B) (S : NonUnitalStarSubalgebra R B) (hf : ∀ x, f x ∈ S) :
+    A →⋆ₙₐ[R] S where
   toNonUnitalAlgHom := NonUnitalAlgHom.codRestrict f S.toNonUnitalSubalgebra hf
-  map_star' := fun a => Subtype.ext <| by
-    apply map_star f a
+  map_star' := fun a => Subtype.ext <| by exact map_star f a
 
 @[simp]
 theorem subtype_comp_codRestrict
@@ -500,11 +499,17 @@ abbrev rangeRestrict (f : A →⋆ₙₐ[R] B) :
 
 /-- The equalizer of two non-unital star `R`-algebra homomorphisms -/
 def equalizer (ϕ ψ : A →⋆ₙₐ[R] B) : NonUnitalStarSubalgebra R A where
-  toNonUnitalSubalgebra := NonUnitalAlgHom.equalizer ϕ ψ
+  toNonUnitalSubalgebra := NonUnitalAlgHom.equalizer ϕ ψ.toNonUnitalAlgHom
   star_mem' := by
-    --intro x (hx : ϕ x = ψ x)
-    --simp [map_star, hx]
-    all_goals sorry
+    intro x hx
+    simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup,
+      NonUnitalSubsemiring.mem_toAddSubmonoid, NonUnitalSubalgebra.mem_toNonUnitalSubsemiring,
+      NonUnitalAlgHom.mem_equalizer, coe_toNonUnitalAlgHom] at hx
+    simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup,
+      NonUnitalSubsemiring.mem_toAddSubmonoid, NonUnitalSubalgebra.mem_toNonUnitalSubsemiring,
+      NonUnitalAlgHom.mem_equalizer, coe_toNonUnitalAlgHom, map_star, ← hx]
+    change ϕ (star x) = star (ϕ x)
+    exact map_star ..
 
 @[simp]
 theorem mem_equalizer (φ ψ : A →⋆ₙₐ[R] B) (x : A) :

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -467,10 +467,11 @@ theorem range_comp_le_range (f : A →⋆ₙₐ[R] B) (g : B →⋆ₙₐ[R] C) 
   SetLike.coe_mono (Set.range_comp_subset_range f g)
 
 /-- Restrict the codomain of a non-unital star algebra homomorphism. -/
-def codRestrict
-    (f : A →⋆ₙₐ[R] B) (S : NonUnitalStarSubalgebra R B) (hf : ∀ x, f x ∈ S) : A →⋆ₙₐ[R] S where
+def codRestrict {F : Type*} [FunLike F A B] [NonUnitalAlgHomClass F R A B] [StarHomClass F A B]
+    (f : F) (S : NonUnitalStarSubalgebra R B) (hf : ∀ x, f x ∈ S) : A →⋆ₙₐ[R] S where
   toNonUnitalAlgHom := NonUnitalAlgHom.codRestrict f S.toNonUnitalSubalgebra hf
-  map_star' := fun a => Subtype.ext <| map_star f a
+  map_star' := fun a => Subtype.ext <| by
+    apply map_star f a
 
 @[simp]
 theorem subtype_comp_codRestrict

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -469,7 +469,7 @@ theorem range_comp_le_range (f : A →⋆ₙₐ[R] B) (g : B →⋆ₙₐ[R] C) 
 /-- Restrict the codomain of a non-unital star algebra homomorphism. -/
 def codRestrict (f : A →⋆ₙₐ[R] B) (S : NonUnitalStarSubalgebra R B) (hf : ∀ x, f x ∈ S) :
     A →⋆ₙₐ[R] S where
-  toNonUnitalAlgHom := NonUnitalAlgHom.codRestrict f S.toNonUnitalSubalgebra hf
+  toNonUnitalAlgHom := NonUnitalAlgHom.codRestrict f.toNonUnitalAlgHom S.toNonUnitalSubalgebra hf
   map_star' := fun a => Subtype.ext <| by exact map_star f a
 
 @[simp]

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -449,25 +449,21 @@ protected def range (φ : A →⋆ₙₐ[R] B) : NonUnitalStarSubalgebra R B whe
 
 @[simp]
 theorem mem_range (φ : A →⋆ₙₐ[R] B) {y : B} :
-    y ∈ (NonUnitalStarAlgHom.range φ : NonUnitalStarSubalgebra R B) ↔ ∃ x : A, φ x = y :=
+    y ∈ φ.range ↔ ∃ x : A, φ x = y :=
   NonUnitalRingHom.mem_srange
 
-theorem mem_range_self (φ : A →⋆ₙₐ[R] B) (x : A) :
-    φ x ∈ (NonUnitalStarAlgHom.range φ : NonUnitalStarSubalgebra R B) :=
-  (NonUnitalAlgHom.mem_range φ).2 ⟨x, rfl⟩
+theorem mem_range_self (φ : A →⋆ₙₐ[R] B) (x : A) : φ x ∈ φ.range := (φ.mem_range).2 ⟨x, rfl⟩
 
 @[simp, norm_cast]
-theorem coe_range (φ : A →⋆ₙₐ[R] B) :
-    ((NonUnitalStarAlgHom.range φ : NonUnitalStarSubalgebra R B) : Set B) =
-    Set.range (φ : A → B) := by
+theorem coe_range (φ : A →⋆ₙₐ[R] B) : (φ.range : Set B) = Set.range (φ : A → B) := by
   rfl
 
 theorem range_comp (f : A →⋆ₙₐ[R] B) (g : B →⋆ₙₐ[R] C) :
-    NonUnitalStarAlgHom.range (g.comp f) = (NonUnitalStarAlgHom.range f).map g :=
+    (g.comp f).range = f.range.map g :=
   SetLike.coe_injective (Set.range_comp g f)
 
 theorem range_comp_le_range (f : A →⋆ₙₐ[R] B) (g : B →⋆ₙₐ[R] C) :
-    NonUnitalStarAlgHom.range (g.comp f) ≤ NonUnitalStarAlgHom.range g :=
+    (g.comp f).range ≤ g.range :=
   SetLike.coe_mono (Set.range_comp_subset_range f g)
 
 /-- Restrict the codomain of a non-unital star algebra homomorphism. -/

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -470,7 +470,7 @@ theorem range_comp_le_range (f : A →⋆ₙₐ[R] B) (g : B →⋆ₙₐ[R] C) 
 def codRestrict (f : A →⋆ₙₐ[R] B) (S : NonUnitalStarSubalgebra R B) (hf : ∀ x, f x ∈ S) :
     A →⋆ₙₐ[R] S where
   toNonUnitalAlgHom := NonUnitalAlgHom.codRestrict f.toNonUnitalAlgHom S.toNonUnitalSubalgebra hf
-  map_star' := fun a => Subtype.ext <| by exact map_star f a
+  map_star' := fun a => Subtype.ext <| map_star f a
 
 @[simp]
 theorem subtype_comp_codRestrict

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -499,17 +499,8 @@ abbrev rangeRestrict (f : A →⋆ₙₐ[R] B) :
 
 /-- The equalizer of two non-unital star `R`-algebra homomorphisms -/
 def equalizer (ϕ ψ : A →⋆ₙₐ[R] B) : NonUnitalStarSubalgebra R A where
-  toNonUnitalSubalgebra := NonUnitalAlgHom.equalizer ϕ ψ.toNonUnitalAlgHom
-  star_mem' := by
-    intro x hx
-    simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup,
-      NonUnitalSubsemiring.mem_toAddSubmonoid, NonUnitalSubalgebra.mem_toNonUnitalSubsemiring,
-      NonUnitalAlgHom.mem_equalizer, coe_toNonUnitalAlgHom] at hx
-    simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup,
-      NonUnitalSubsemiring.mem_toAddSubmonoid, NonUnitalSubalgebra.mem_toNonUnitalSubsemiring,
-      NonUnitalAlgHom.mem_equalizer, coe_toNonUnitalAlgHom, map_star, ← hx]
-    change ϕ (star x) = star (ϕ x)
-    exact map_star ..
+  toNonUnitalSubalgebra := NonUnitalAlgHom.equalizer ϕ.toNonUnitalAlgHom ψ.toNonUnitalAlgHom
+  star_mem' := @fun x (hx : ϕ x = ψ x) => by simp [map_star, hx]
 
 @[simp]
 theorem mem_equalizer (φ ψ : A →⋆ₙₐ[R] B) (x : A) :


### PR DESCRIPTION
as opposed to a `NonUnitalAlgHomClass`.
Specifically, this PR changes `NonUnitalSubalgebra.{map, comap}` as well as `NonUnitalAlgHom.{range,rangeRestrict,codRestrict,equalizer}`.

Since this removes all uses of a bundled morphism class, we also remove the assocated variable lines
and align them with standard mathlib style.

Adapt (almost) all theorems about them to take in a concrete morphism also.

This follows the general patterns established in #31365:
> we should restrict definitions to explicit morphisms, instead of morphism classes in order to avoid proliferating definitions.

> Given a definition Bar that takes FooHom as an argument, a theorem whose statement involves Bar should only ever be written for FooHoms and never FooHomClasses. Indeed in the latter case, the statement would require the coercion from the morphism class to the morphism, thereby making it less general.

---

Continuation of #43377.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
