### PR TITLE
chore(Algebra/QuadraticAlgebra): define all the casts through C

### DIFF
--- a/Mathlib/Algebra/QuadraticAlgebra/Basic.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Basic.lean
@@ -484,6 +484,12 @@ def changeGeneratorEquiv (a b : R) (u : Rˣ) (k : R) {a' b' : R}
 
 end changeGenerator
 
+-- Over `ℤ`, the algebra structure of `QuadraticAlgebra.instAlgebra` and the one every ring carries
+-- through `Ring.toIntAlgebra` are the same instance.
+example {a b : ℤ} :
+    (Ring.toIntAlgebra (QuadraticAlgebra ℤ a b)) = instAlgebra := by
+  with_implicit rfl
+
 section field
 
 variable [Field K] {a b : K} [Hab : Fact (∀ r, r ^ 2 ≠ a + b * r)]

--- a/Mathlib/Algebra/QuadraticAlgebra/Basic.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Basic.lean
@@ -509,8 +509,8 @@ lemma norm_eq_zero_iff_eq_zero {z : QuadraticAlgebra K a b} :
   · intro hz
     simp [hz]
 
-@[simps] instance : NNRatCast (QuadraticAlgebra K a b) where nnratCast q := ⟨q, 0⟩
-@[simps] instance : RatCast (QuadraticAlgebra K a b) where ratCast q := ⟨q, 0⟩
+@[simps] instance : NNRatCast (QuadraticAlgebra K a b) where nnratCast q := .C q
+@[simps] instance : RatCast (QuadraticAlgebra K a b) where ratCast q := .C q
 
 @[simps -isSimp, simps!] instance : Inv (QuadraticAlgebra K a b) where inv z := (norm z)⁻¹ • star z
 @[simps -isSimp, simps!] instance : Div (QuadraticAlgebra K a b) where div w z := w * z⁻¹

--- a/Mathlib/Algebra/QuadraticAlgebra/Defs.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Defs.lean
@@ -267,7 +267,7 @@ section AddCommMonoidWithOne
 variable [AddCommMonoidWithOne R]
 
 instance : AddCommMonoidWithOne (QuadraticAlgebra R a b) where
-  natCast n := .C n
+  natCast n := ⟨n, 0⟩
   natCast_zero := by ext <;> simp
   natCast_succ n := by ext <;> simp
 
@@ -296,9 +296,9 @@ section AddCommGroupWithOne
 variable [AddCommGroupWithOne R]
 
 instance : AddCommGroupWithOne (QuadraticAlgebra R a b) where
-  intCast n := .C n
+  intCast n := ⟨n, 0⟩
   intCast_ofNat n := by norm_cast
-  intCast_negSucc n := by rw [Int.negSucc_eq, Int.cast_neg, C_neg]; norm_cast
+  intCast_negSucc n := by ext <;> simp [Int.negSucc_eq]
 
 @[simp, norm_cast]
 theorem re_intCast (n : ℤ) : (n : QuadraticAlgebra R a b).re = n := rfl

--- a/Mathlib/Algebra/QuadraticAlgebra/Defs.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Defs.lean
@@ -267,7 +267,7 @@ section AddCommMonoidWithOne
 variable [AddCommMonoidWithOne R]
 
 instance : AddCommMonoidWithOne (QuadraticAlgebra R a b) where
-  natCast n := ⟨n, 0⟩
+  natCast n := .C n
   natCast_zero := by ext <;> simp
   natCast_succ n := by ext <;> simp
 
@@ -296,7 +296,7 @@ section AddCommGroupWithOne
 variable [AddCommGroupWithOne R]
 
 instance : AddCommGroupWithOne (QuadraticAlgebra R a b) where
-  intCast n := ⟨n, 0⟩
+  intCast n := .C n
   intCast_ofNat n := by norm_cast
   intCast_negSucc n := by ext <;> simp [Int.negSucc_eq]
 
@@ -407,7 +407,7 @@ instance instCommSemiring : CommSemiring (QuadraticAlgebra R a b) where
   mul_comm _ _ := by ext <;> simp <;> ring
 
 instance [CommSemiring S] [Algebra S R] : Algebra S (QuadraticAlgebra R a b) where
-  algebraMap.toFun s := ⟨algebraMap S R s, 0⟩
+  algebraMap.toFun s := .C (algebraMap S R s)
   algebraMap.map_one' := by ext <;> simp
   algebraMap.map_mul' x y := by ext <;> simp
   algebraMap.map_zero' := by ext <;> simp


### PR DESCRIPTION
The casts into `QuadraticAlgebra R a b` were defined in two different ways, some through `C` and some through the anonymous constructor, which made the `Algebra ℤ` instances non-defeq at instance transparency. Using `C` everywhere fixes it, and an example records the defeq.

Prepared with Claude Code 🤖

---
