### PR TITLE
[Merged by Bors] - chore(Algebra/Star/StarAlgHom): fix bad simp lemma

### DIFF
--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -797,7 +797,8 @@ theorem refl_symm : (StarAlgEquiv.refl R A).symm = .refl R A :=
 theorem toStarRingEquiv_symm (e : A ≃⋆ₐ[R] B) : e.symm.toStarRingEquiv = e.toStarRingEquiv.symm :=
   rfl
 
-@[simp]
+@[deprecated "use StarAlgEquiv.toStarRingEquiv_symm and/or StarRingEquiv.toRingEquiv_symm instead"
+(since := "2026-09-08")]
 theorem toRingEquiv_symm (e : A ≃⋆ₐ[R] B) : e.toStarRingEquiv.symm = e.toRingEquiv.symm := rfl
 
 /-- Transitivity of `StarAlgEquiv`. -/

--- a/Mathlib/Algebra/Star/StarRingHom.lean
+++ b/Mathlib/Algebra/Star/StarRingHom.lean
@@ -359,6 +359,10 @@ nonrec def symm (e : A ≃⋆+* B) : B ≃⋆+* A :=
       simpa only [apply_inv_apply, inv_apply_apply] using!
         congr_arg (inv e) (map_star e (inv e b)).symm }
 
+@[simp]
+theorem toRingEquiv_symm (e : A ≃⋆+* B) :
+  e.symm.toRingEquiv = e.toRingEquiv.symm := rfl
+
 /-- See Note [custom simps projection] -/
 def Simps.apply (e : A ≃⋆+* B) : A → B := e
 

--- a/Mathlib/Algebra/Star/StarRingHom.lean
+++ b/Mathlib/Algebra/Star/StarRingHom.lean
@@ -361,7 +361,7 @@ nonrec def symm (e : A ≃⋆+* B) : B ≃⋆+* A :=
 
 @[simp]
 theorem toRingEquiv_symm (e : A ≃⋆+* B) :
-  e.symm.toRingEquiv = e.toRingEquiv.symm := rfl
+    e.symm.toRingEquiv = e.toRingEquiv.symm := rfl
 
 /-- See Note [custom simps projection] -/
 def Simps.apply (e : A ≃⋆+* B) : A → B := e


### PR DESCRIPTION
`StarAlgEquiv.toRingEquiv_symm` was trying to commute `symm` across two commutative squares at once:
instead, we should have individual lemmas for the commutative squares formed by `StarAlgEquiv.toStarRingEquiv` (and the associated `symm` projections) and `StarRingEquiv.toRingEquiv`.
The former already exists; we add the latter.

Spotted by `j-loreaux` in #43393.

---

- [x] depends on: #43393
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
