### PR TITLE
[Merged by Bors] - chore(Tactic/GCongr): deprecate `Tactic/GCongr/CoreAttrs`

### DIFF
--- a/Mathlib/Tactic/GCongr.lean
+++ b/Mathlib/Tactic/GCongr.lean
@@ -23,7 +23,7 @@ variable {a b c d : Prop}
 @[gcongr] lemma imp_mono (h₁ : c → a) (h₂ : c → b → d) : (a → b) → c → d :=
   fun h₃ hc => h₂ hc (h₃ (h₁ hc))
 
-/-- Monotonicity of conjunction, with an extra hypothesis `a` in the `b → d` hypothesis. -/
+/-- A version of `And.imp` with an extra hypothesis `a` in the `b → d` hypothesis. -/
 @[gcongr] lemma and_mono (h₁ : a → c) (h₂ : a → b → d) : (a ∧ b) → c ∧ d :=
   fun ⟨ha, hb⟩ => ⟨h₁ ha, h₂ ha hb⟩
 

--- a/Mathlib/Tactic/GCongr.lean
+++ b/Mathlib/Tactic/GCongr.lean
@@ -1,11 +1,11 @@
 /-
 Copyright (c) 2023 Mario Carneiro, Heather Macbeth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro, Heather Macbeth
+Authors: Mario Carneiro, Heather Macbeth, Jovan Gerbscheid, Yury Kudryashov
 -/
 module
 
-public import Mathlib.Tactic.GCongr.CoreAttrs
+public import Mathlib.Tactic.GCongr.Core
 public import Mathlib.Tactic.Hint
 
 /-! # Setup for the `gcongr` tactic
@@ -13,7 +13,31 @@ public import Mathlib.Tactic.Hint
 The core implementation of the `gcongr` ("generalized congruence") tactic is in the file
 `Tactic.GCongr.Core`. -/
 
-public meta section
+public section
+
+namespace Mathlib.Tactic.GCongr
+
+variable {a b c d : Prop}
+
+/-- A version of `imp_imp_imp` that has an extra hypothesis `c` in the `b → d` hypothesis. -/
+@[gcongr] lemma imp_mono (h₁ : c → a) (h₂ : c → b → d) : (a → b) → c → d :=
+  fun h₃ hc => h₂ hc (h₃ (h₁ hc))
+
+/-- Monotonicity of conjunction, with an extra hypothesis `a` in the `b → d` hypothesis. -/
+@[gcongr] lemma and_mono (h₁ : a → c) (h₂ : a → b → d) : (a ∧ b) → c ∧ d :=
+  fun ⟨ha, hb⟩ => ⟨h₁ ha, h₂ ha hb⟩
+
+attribute [gcongr] mt Or.imp forall_imp Exists.imp
+  List.Sublist.append List.Sublist.reverse List.drop_sublist_drop_left List.Sublist.drop
+  List.Perm.cons List.Perm.append List.Perm.map
+  List.cons_subset_cons
+  Nat.sub_le_sub_left Nat.sub_le_sub_right Nat.sub_lt_sub_left Nat.sub_lt_sub_right
+  Nat.succ_le_succ Nat.div_le_div_right Nat.div_le_div
+
+-- `Nat.pow_le_pow_right` has side condition `0 < n`, which `gcongr` discharges automatically via
+-- `positivity`, unlike the `1 ≤ a` side condition of the more general `pow_le_pow_right₀`.
+attribute [gcongr high] Nat.pow_le_pow_right
+
 
 /-! We also use `assumption` to discharge side goals.
 In a further downstream file, `positivity` will also be registered as a discharger.
@@ -25,3 +49,5 @@ We register `gcongr` with the `hint` tactic.
 -/
 
 register_hint 1000 gcongr
+
+end Mathlib.Tactic.GCongr

--- a/Mathlib/Tactic/GCongr/CoreAttrs.lean
+++ b/Mathlib/Tactic/GCongr/CoreAttrs.lean
@@ -7,34 +7,4 @@ module
 
 public import Mathlib.Tactic.GCongr.Core
 
-/-!
-# gcongr attributes for lemmas up in the import chain
-
-In this file we add `gcongr` attribute to lemmas in `Lean.Init`.
-We may add lemmas from other files imported by `Mathlib/Tactic/GCongr/Core` later.
--/
-
-public meta section
-
-namespace Mathlib.Tactic.GCongr
-
-variable {a b c d : Prop}
-
-lemma imp_mono (h₁ : c → a) (h₂ : c → b → d) : (a → b) → c → d :=
-  fun h₃ hc => h₂ hc (h₃ (h₁ hc))
-
-lemma and_mono (h₁ : a → c) (h₂ : a → b → d) : (a ∧ b) → c ∧ d :=
-  fun ⟨ha, hb⟩ => ⟨h₁ ha, h₂ ha hb⟩
-
-attribute [gcongr] mt Or.imp and_mono imp_mono forall_imp Exists.imp
-  List.Sublist.append List.Sublist.reverse List.drop_sublist_drop_left List.Sublist.drop
-  List.Perm.cons List.Perm.append List.Perm.map
-  List.cons_subset_cons
-  Nat.sub_le_sub_left Nat.sub_le_sub_right Nat.sub_lt_sub_left Nat.sub_lt_sub_right
-  Nat.succ_le_succ Nat.div_le_div_right Nat.div_le_div
-
--- `Nat.pow_le_pow_right` has side condition `0 < n`, which `gcongr` discharges automatically via
--- `positivity`, unlike the `1 ≤ a` side condition of the more general `pow_le_pow_right₀`.
-attribute [gcongr high] Nat.pow_le_pow_right
-
-end Mathlib.Tactic.GCongr
+deprecated_module "use Mathlib.Tactic.GCongr instead" (since := "2026-09-09")


### PR DESCRIPTION
This PR moves the `@[gcongr]` attributes that are in `Mathlib.Tactic.GCongr.CoreAttrs` to `Mathlib.Tactic.GCongr` and deprecates the former file.

This follows the same pattern as e.g. `to_additive` of putting the basic attributes/setup in the root file of the tactic implementation.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
