### PR TITLE
[Merged by Bors] - feat: `Sum.swap` is strictly monotonic

### DIFF
--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -263,6 +263,12 @@ theorem swap_le_swap_iff [LE α] [LE β] {a b : α ⊕ β} : a.swap ≤ b.swap �
 theorem swap_lt_swap_iff [LT α] [LT β] {a b : α ⊕ β} : a.swap < b.swap ↔ a < b :=
   liftRel_swap_iff
 
+theorem swap_monotone [Preorder α] [Preorder β] : Monotone (α := α ⊕ β) Sum.swap :=
+  fun _ _ ↦ swap_le_swap_iff.2
+
+theorem swap_strictMono [Preorder α] [Preorder β] : StrictMono (α := α ⊕ β) Sum.swap :=
+  fun _ _ ↦ swap_lt_swap_iff.2
+
 end Disjoint
 
 /-! ### Linear sum of two orders -/

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -74,9 +74,8 @@ theorem onFun {α β : Sort*} {r : β → β → Prop} {f : α → β} :
     WellFounded r → WellFounded (r on f) :=
   InvImage.wf _
 
-instance (r : β → β → Prop) (f : α → β) [IsWellFounded β r] :
-    IsWellFounded α (r.onFun f) where
-  wf := IsWellFounded.wf.onFun
+instance (r : β → β → Prop) (f : α → β) [H : WellFounded r] : WellFounded (r.onFun f) :=
+  WellFounded.onFun H
 
 theorem _root_.Function.Injective.isWellOrder (r : β → β → Prop) {f : α → β} (hf : f.Injective)
     [IsWellOrder β r] : IsWellOrder α (r.onFun f) where
@@ -159,7 +158,7 @@ theorem wellFounded_iff_has_min {r : α → α → Prop} :
 @[to_dual]
 theorem wellFoundedLT_iff_exists_minimal [Preorder α] :
     WellFoundedLT α ↔ ∀ s : Set α, s.Nonempty → ∃ m, Minimal (· ∈ s) m := by
-  simp only [isWellFounded_iff, wellFounded_iff_has_min, not_lt_iff_le_imp_ge, Minimal]
+  simp only [wellFounded_iff_has_min, not_lt_iff_le_imp_ge, Minimal]
 
 @[to_dual]
 alias ⟨_root_.WellFoundedLT.exists_minimal, _⟩ := wellFoundedLT_iff_exists_minimal
@@ -173,8 +172,8 @@ theorem isWellOrder_iff_exists_not_lt_and_eq_or_gt :
     IsWellOrder α r ↔ ∀ s : Set α, s.Nonempty → ∃ m ∈ s, ∀ x ∈ s, ¬r x m ∧ (m = x ∨ r m x) := by
   refine ⟨fun h s hs ↦ ?_, fun h ↦ { wf := ?_, trichotomous a b := ?_ }⟩
   · grind [h.wf.has_min, trichotomous_of r]
-  · grind [wellFounded_iff_has_min]
   · grind [h {a, b} <| by simp]
+  · grind [wellFounded_iff_has_min]
 
 /-- The minimum of `f '' s` is `f` applied to the minimum of `s`. -/
 theorem min_image {r : β → β → Prop} [Std.Trichotomous r] (wf : WellFounded r) (f : α → β)
@@ -184,9 +183,9 @@ theorem min_image {r : β → β → Prop} [Std.Trichotomous r] (wf : WellFounde
   rintro _ ⟨a, has, rfl⟩
   exact wf.onFun.not_lt_min s has
 
-theorem not_rel_apply_succ [h : IsWellFounded α r] (f : ℕ → α) : ∃ n, ¬ r (f (n + 1)) (f n) := by
+theorem not_rel_apply_succ [h : WellFounded r] (f : ℕ → α) : ∃ n, ¬ r (f (n + 1)) (f n) := by
   by_contra! hf
-  exact (wellFounded_iff_isEmpty_descending_chain.1 h.wf).elim ⟨f, hf⟩
+  exact (wellFounded_iff_isEmpty_descending_chain.1 h).elim ⟨f, hf⟩
 
 open Set
 
@@ -213,7 +212,7 @@ theorem WellFoundedLT.min_le [WellFoundedLT β] {x : β} {s : Set β} (hx : x �
 @[deprecated WellFoundedLT.min_le (since := "2026-08-16")]
 theorem WellFounded.min_le (h : WellFounded ((· < ·) : β → β → Prop)) {x : β} {s : Set β}
     (hx : x ∈ s) : h.min s ⟨x, hx⟩ ≤ x :=
-  (show WellFoundedLT β from ⟨h⟩).min_le hx
+  WellFoundedLT.min_lerem swap_le_swap_iff [LE α] [LE β]rem swap_le_swap_iff [LE α] [LE β] hx
 
 @[to_dual]
 theorem Set.range_injOn_strictMono_of_wellFoundedLT [WellFoundedLT β] :
@@ -417,5 +416,5 @@ noncomputable def WellFoundedLT.toOrderBot (α) [LinearOrder α] [Nonempty α] [
   bot_le a := h.min_le (Set.mem_univ a)
 
 @[to_dual]
-instance [LT α] [h : WellFoundedLT α] : WellFoundedLT (ULift α) where
-  wf := InvImage.wf ULift.down h.wf
+instance [LT α] [h : WellFoundedLT α] : WellFoundedLT (ULift α) :=
+  InvImage.wf ULift.down h

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -74,8 +74,9 @@ theorem onFun {α β : Sort*} {r : β → β → Prop} {f : α → β} :
     WellFounded r → WellFounded (r on f) :=
   InvImage.wf _
 
-instance (r : β → β → Prop) (f : α → β) [H : WellFounded r] : WellFounded (r.onFun f) :=
-  WellFounded.onFun H
+instance (r : β → β → Prop) (f : α → β) [IsWellFounded β r] :
+    IsWellFounded α (r.onFun f) where
+  wf := IsWellFounded.wf.onFun
 
 theorem _root_.Function.Injective.isWellOrder (r : β → β → Prop) {f : α → β} (hf : f.Injective)
     [IsWellOrder β r] : IsWellOrder α (r.onFun f) where
@@ -158,7 +159,7 @@ theorem wellFounded_iff_has_min {r : α → α → Prop} :
 @[to_dual]
 theorem wellFoundedLT_iff_exists_minimal [Preorder α] :
     WellFoundedLT α ↔ ∀ s : Set α, s.Nonempty → ∃ m, Minimal (· ∈ s) m := by
-  simp only [wellFounded_iff_has_min, not_lt_iff_le_imp_ge, Minimal]
+  simp only [isWellFounded_iff, wellFounded_iff_has_min, not_lt_iff_le_imp_ge, Minimal]
 
 @[to_dual]
 alias ⟨_root_.WellFoundedLT.exists_minimal, _⟩ := wellFoundedLT_iff_exists_minimal
@@ -172,8 +173,8 @@ theorem isWellOrder_iff_exists_not_lt_and_eq_or_gt :
     IsWellOrder α r ↔ ∀ s : Set α, s.Nonempty → ∃ m ∈ s, ∀ x ∈ s, ¬r x m ∧ (m = x ∨ r m x) := by
   refine ⟨fun h s hs ↦ ?_, fun h ↦ { wf := ?_, trichotomous a b := ?_ }⟩
   · grind [h.wf.has_min, trichotomous_of r]
-  · grind [h {a, b} <| by simp]
   · grind [wellFounded_iff_has_min]
+  · grind [h {a, b} <| by simp]
 
 /-- The minimum of `f '' s` is `f` applied to the minimum of `s`. -/
 theorem min_image {r : β → β → Prop} [Std.Trichotomous r] (wf : WellFounded r) (f : α → β)
@@ -183,9 +184,9 @@ theorem min_image {r : β → β → Prop} [Std.Trichotomous r] (wf : WellFounde
   rintro _ ⟨a, has, rfl⟩
   exact wf.onFun.not_lt_min s has
 
-theorem not_rel_apply_succ [h : WellFounded r] (f : ℕ → α) : ∃ n, ¬ r (f (n + 1)) (f n) := by
+theorem not_rel_apply_succ [h : IsWellFounded α r] (f : ℕ → α) : ∃ n, ¬ r (f (n + 1)) (f n) := by
   by_contra! hf
-  exact (wellFounded_iff_isEmpty_descending_chain.1 h).elim ⟨f, hf⟩
+  exact (wellFounded_iff_isEmpty_descending_chain.1 h.wf).elim ⟨f, hf⟩
 
 open Set
 
@@ -212,7 +213,7 @@ theorem WellFoundedLT.min_le [WellFoundedLT β] {x : β} {s : Set β} (hx : x �
 @[deprecated WellFoundedLT.min_le (since := "2026-08-16")]
 theorem WellFounded.min_le (h : WellFounded ((· < ·) : β → β → Prop)) {x : β} {s : Set β}
     (hx : x ∈ s) : h.min s ⟨x, hx⟩ ≤ x :=
-  WellFoundedLT.min_lerem swap_le_swap_iff [LE α] [LE β]rem swap_le_swap_iff [LE α] [LE β] hx
+  (show WellFoundedLT β from ⟨h⟩).min_le hx
 
 @[to_dual]
 theorem Set.range_injOn_strictMono_of_wellFoundedLT [WellFoundedLT β] :
@@ -416,5 +417,5 @@ noncomputable def WellFoundedLT.toOrderBot (α) [LinearOrder α] [Nonempty α] [
   bot_le a := h.min_le (Set.mem_univ a)
 
 @[to_dual]
-instance [LT α] [h : WellFoundedLT α] : WellFoundedLT (ULift α) :=
-  InvImage.wf ULift.down h
+instance [LT α] [h : WellFoundedLT α] : WellFoundedLT (ULift α) where
+  wf := InvImage.wf ULift.down h.wf


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
