### PR TITLE
feat(Analysis): Laplacian and gradient under composition with a dilation

### DIFF
--- a/Mathlib/Analysis/Calculus/Gradient/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Gradient/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.InnerProductSpace.Dual
 public import Mathlib.Analysis.Calculus.FDeriv.Basic
+public import Mathlib.Analysis.Calculus.FDeriv.Equiv
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 
 /-!
@@ -303,6 +304,19 @@ lemma inner_gradient_right : ⟪x, ∇ f y⟫ = conj (fderiv 𝕜 f y x) := by
   rw [← inner_conj_symm, inner_gradient_left]
 
 end Inner
+
+section Comp
+
+/-! ### Composition with a dilation -/
+
+/-- The gradient of `f ∘ (c • ·)`. The derivative picks up a factor `c`
+(`fderiv_comp_smul`), and the Riesz isomorphism is conjugate linear, so the gradient
+picks up `conj c`. No differentiability is assumed: for `c = 0` both sides vanish. -/
+theorem gradient_comp_smul (c : 𝕜) : ∇ (f <| c • ·) x = conj c • ∇ f (c • x) := by
+  have h : fderiv 𝕜 (f <| c • ·) x = c • fderiv 𝕜 f (c • x) := fderiv_comp_smul c
+  rw [gradient, gradient, h, map_smulₛₗ]
+
+end Comp
 
 section congr
 

--- a/Mathlib/Analysis/InnerProductSpace/Laplacian.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Laplacian.lean
@@ -365,6 +365,12 @@ theorem laplacian_smul_nhds (v : 𝕜) (h : ContDiffAt ℝ 2 f x) :
   filter_upwards [h.eventually (by simp)] with a ha
   simp [laplacian_smul v ha]
 
+/-- The Laplacian of `f ∘ (c • ·)`: each of the two derivatives contributes a factor `c`. -/
+theorem laplacian_comp_smul (c : ℝ) (hf : ContDiff ℝ 2 f) :
+    Δ (f <| c • ·) x = c ^ 2 • Δ f (c • x) := by
+  simp [laplacian_eq_iteratedFDeriv_stdOrthonormalBasis, iteratedFDeriv_comp_const_smul c hf,
+    Finset.smul_sum]
+
 /-!
 ## Commutativity of Δ with Linear Operators
 


### PR DESCRIPTION
feat(Analysis): Laplacian and gradient under composition with a dilation

Two lemmas describing how the Laplacian and the gradient behave under
pre-composition with `c • ·`, the missing companions of `fderiv_comp_smul`
and `iteratedFDeriv_comp_const_smul`.

* `InnerProductSpace.laplacian_comp_smul` (in `InnerProductSpace/Laplacian.lean`,
  next to `laplacian_smul`): for `f : E → F` with `ContDiff ℝ 2 f` and `c : ℝ`,
  `Δ (f <| c • ·) x = c ^ 2 • Δ f (c • x)`.
  Each of the two derivatives contributes one factor of `c`.
  Proof: `laplacian_eq_iteratedFDeriv_stdOrthonormalBasis` and
  `iteratedFDeriv_comp_const_smul`, in the style of `laplacian_smul`.

* `gradient_comp_smul` (in `Calculus/Gradient/Basic.lean`): for `f : F → 𝕜`
  and `c : 𝕜`, `∇ (f <| c • ·) x = conj c • ∇ f (c • x)`.
  The derivative picks up `c` (`fderiv_comp_smul`) and the Riesz isomorphism is
  conjugate linear, hence `conj c`. No differentiability hypothesis: for `c = 0`
  both sides are `0`, exactly as in `fderiv_comp_smul`.

Motivation: the parabolic scaling `v ↦ λ • v (λ • x) (λ² t)` of the Navier–Stokes
equations, where every term acquires `λ³`. Establishing that in Lean required
these two facts, which were the only missing pieces; the rest was already in
Mathlib.

Names follow `fderiv_comp_smul` rather than `iteratedFDeriv_comp_const_smul`;
happy to switch if the other convention is preferred.

---

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
