### PR TITLE
[Merged by Bors] - chore: add module deprecation for `LinearAlgebra/Matrix/Cartan`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5239,6 +5239,7 @@ public import Mathlib.LinearAlgebra.Matrix.Basis
 public import Mathlib.LinearAlgebra.Matrix.Bilinear
 public import Mathlib.LinearAlgebra.Matrix.BilinearForm
 public import Mathlib.LinearAlgebra.Matrix.Block
+public import Mathlib.LinearAlgebra.Matrix.Cartan
 public import Mathlib.LinearAlgebra.Matrix.Cartan.Basic
 public import Mathlib.LinearAlgebra.Matrix.CharP
 public import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic

--- a/Mathlib/Data/Matrix/Cartan.lean
+++ b/Mathlib/Data/Matrix/Cartan.lean
@@ -1,7 +1,5 @@
 module
 
-public import Mathlib.Data.Sym.Sym2
-public import Mathlib.Tactic.ContinuousFunctionalCalculus
-public import Mathlib.Tactic.NormNum.GCD
+public import Mathlib.LinearAlgebra.Matrix.Cartan.Basic
 
 deprecated_module (since := "2026-06-05")

--- a/Mathlib/LinearAlgebra/Matrix/Cartan.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Cartan.lean
@@ -1,0 +1,5 @@
+module -- shake: keep-all
+
+public import Mathlib.LinearAlgebra.Matrix.Cartan.Basic
+
+deprecated_module (since := "2026-09-08")


### PR DESCRIPTION
Follow up from https://github.com/leanprover-community/mathlib4/pull/43460

---



[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
