### PR TITLE
chore(Data/Set/Semiring): add simp attributes

### DIFF
--- a/Mathlib/Data/Set/Semiring.lean
+++ b/Mathlib/Data/Set/Semiring.lean
@@ -54,10 +54,11 @@ protected theorem down_up (s : Set α) : s.up.down = s :=
 protected theorem up_down (s : SetSemiring α) : s.down.up = s :=
   rfl
 
--- TODO: These lemmas should be tagged `simp`
+@[simp]
 theorem up_le_up {s t : Set α} : s.up ≤ t.up ↔ s ⊆ t :=
   Iff.rfl
 
+@[simp]
 theorem up_lt_up {s t : Set α} : s.up < t.up ↔ s ⊂ t :=
   Iff.rfl
 


### PR DESCRIPTION
Mark `up_le_up` and `up_lt_up` with `@[simp]`, as requested by the existing TODO.

--------

Tests:
- `lake env lean Mathlib/Data/Set/Semiring.lean`
- `lake build Mathlib.Data.Set.Semiring`
- `lake exe runLinter Mathlib.Data.Set.Semiring`