### PR TITLE
feat(Geometry/Convex): `positivity` extension for `StdSimplex.weights`

### DIFF
--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -5,6 +5,8 @@ Authors: Johannes Hölzl, Kim Morrison
 -/
 module
 
+public meta import Mathlib.Util.Qq
+
 public import Mathlib.Algebra.FiniteSupport.Defs
 public import Mathlib.Data.Multiset.Find
 
@@ -498,3 +500,31 @@ theorem support_zipWith [D : DecidableEq α] {f : M → N → O} {hf : f 0 0 = 0
 end ZipWith
 
 end Finsupp
+
+namespace Qq
+open Lean Meta
+
+/-- Match a type `α : Type u` against `X →₀ R`, returning `X` and `R` along with proofs that
+`u = max uX uR` and `α = (X →₀ R)`.
+
+Qq cannot match `α` against `~q($X →₀ $R)` directly, since that needs solving the universe
+constraint `u =?= max ?uX ?uR`, so we introduce the level metavariables by hand. -/
+meta def matchFinsupp {u : Level} (α : Q(Type u)) : MetaM <| Option <|
+    (uX uR : Level) × (X : Q(Type uX)) × (R : Q(Type uR)) × (instZero : Q(Zero $R)) ×'
+      (_ : u =QL max uX uR) ×' ($α =Q @Finsupp $X $R $instZero) :=
+  withNewMCtxDepth do
+    let uX ← mkFreshLevelMVar
+    let uR ← mkFreshLevelMVar
+    let X ← mkFreshExprMVarQ q(Type uX)
+    let R ← mkFreshExprMVarQ q(Type uR)
+    let instZero ← mkFreshExprMVarQ q(Zero $R)
+    let .defEq _ ← isLevelDefEqQ ql(u) ql(max uX uR) | pure none
+    let .defEq _ ← isDefEqQ q($α) q(@Finsupp $X $R $instZero) | pure none
+    let ⟨uX, _⟩ ← instantiateLevelMVarsQ uX
+    let ⟨uR, _⟩ ← instantiateLevelMVarsQ uR
+    let ⟨X, _⟩ ← instantiateMVarsQ' X
+    let ⟨R, _⟩ ← instantiateMVarsQ' R
+    let ⟨instZero, _⟩ ← instantiateMVarsQ' instZero
+    return some ⟨uX, uR, X, R, instZero, ⟨⟩, ⟨⟩⟩
+
+end Qq

--- a/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
@@ -8,6 +8,7 @@ public import Mathlib.Algebra.BigOperators.Fin
 public import Mathlib.Algebra.Order.Interval.Set.Instances
 public import Mathlib.Data.Finsupp.Order
 public import Mathlib.LinearAlgebra.Finsupp.LSum
+public import Mathlib.Tactic.Positivity.Core
 
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Positivity.Basic
@@ -61,7 +62,7 @@ structure StdSimplex (R : Type u) [LE R] [AddCommMonoid R] [One R] (X : Type v) 
   /-- The weights sum to 1. -/
   total : weights.sum (fun _ r => r) = 1
 
-attribute [simp] StdSimplex.total
+attribute [simp] StdSimplex.total StdSimplex.nonneg
 grind_pattern StdSimplex.nonneg => self.weights
 grind_pattern StdSimplex.total => self.weights
 
@@ -75,6 +76,9 @@ variable {R : Type u} [PartialOrder R] [Semiring R] {w : StdSimplex R X} {x : X}
 
 @[simp] lemma weights_ne_zero [Nontrivial R] : ∀ w : StdSimplex R X, w.weights ≠ 0 := by
   rintro ⟨_, -, total⟩ rfl; simp at total
+
+@[simp] lemma weights_pos [Nontrivial R] (w : StdSimplex R X) : 0 < w.weights :=
+  w.nonneg.lt_of_ne w.weights_ne_zero.symm
 
 lemma support_weights_nonempty [Nontrivial R] (w : StdSimplex R X) :
     w.weights.support.Nonempty := by simp
@@ -757,3 +761,31 @@ lemma isAffineMap_convexCombPair (m : X) :
 end CommSemiring
 
 end Convexity
+
+namespace Mathlib.Meta.Positivity
+open Lean Meta Qq Convexity
+
+/-- Extension for the `positivity` tactic: the weights of a `StdSimplex` are always nonnegative,
+and even positive, ie nonzero, when `R` is nontrivial. -/
+@[positivity Convexity.StdSimplex.weights _]
+meta def evalStdSimplexWeights : PositivityExt where eval {_ _} _zα pα? e :=
+  match pα? with | none => pure .none | some _ => do
+  let w ← match ← whnfR e with
+    | .app _ w | .proj ``StdSimplex 0 w => pure w
+    | _ => throwError "not `StdSimplex.weights`"
+  -- `StdSimplex.weights_pos` needs `Nontrivial R`, so fall back to nonnegativity without it.
+  match ← observing? (mkAppM ``StdSimplex.weights_pos #[w]) with
+  | some p => pure (.positive p)
+  | none => pure (.nonnegative (← mkAppM ``StdSimplex.nonneg #[w]))
+
+/-- Extension for the `positivity` tactic: the weights of a `StdSimplex` are always nonnegative.
+
+This handles `w.weights i`; see `evalStdSimplexWeights` for the unapplied `w.weights`. -/
+@[positivity DFunLike.coe (Convexity.StdSimplex.weights _) _]
+meta def evalStdSimplexWeightsApply : PositivityExt where eval {_ _} _zα pα? e :=
+  match pα? with | none => pure .none | some _ => do
+  let .app (.app _coe (.app _ w)) i ← whnfR e | throwError "not `StdSimplex.weights`"
+  let p ← mkAppOptM ``StdSimplex.weights_nonneg #[none, none, none, none, w, i]
+  pure (.nonnegative p)
+
+end Mathlib.Meta.Positivity

--- a/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.Order.Interval.Set.Instances
 public import Mathlib.Data.Finsupp.Order
 public import Mathlib.LinearAlgebra.Finsupp.LSum
 public import Mathlib.Tactic.Positivity.Core
+public import Mathlib.Util.Qq
 
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Positivity.Basic
@@ -765,27 +766,57 @@ end Convexity
 namespace Mathlib.Meta.Positivity
 open Lean Meta Qq Convexity
 
-/-- Extension for the `positivity` tactic: the weights of a `StdSimplex` are always nonnegative,
-and even positive, ie nonzero, when `R` is nontrivial. -/
-@[positivity Convexity.StdSimplex.weights _]
-meta def evalStdSimplexWeights : PositivityExt where eval {_ _} _zα pα? e :=
+/-- Extension for the `positivity` tactic: the weights of a `StdSimplex` are always nonnegative
+(in the sense ),
+and even positive (in the sense of `0 < w.weights`, not `∀ i, 0 < w.weights i`) when `R` is
+nontrivial. -/
+@[positivity StdSimplex.weights _]
+meta def evalStdSimplexWeights : PositivityExt where eval {_u α} _zα pα? e :=
   match pα? with | none => pure .none | some _ => do
-  let w ← match ← whnfR e with
-    | .app _ w | .proj ``StdSimplex 0 w => pure w
-    | _ => throwError "not `StdSimplex.weights`"
+  let some ⟨_uX, _uR, _X, R, _instZero, _hu, _hα⟩ ← matchFinsupp α | throwError "not a `Finsupp`"
+  let _semiringR ← synthInstanceQ q(Semiring $R)
+  let _partialOrderR ← synthInstanceQ q(PartialOrder $R)
+  assertInstancesCommute
+  let ~q(StdSimplex.weights $w) := q($e) | throwError "Not a match"
+  assumeInstancesCommute
   -- `StdSimplex.weights_pos` needs `Nontrivial R`, so fall back to nonnegativity without it.
-  match ← observing? (mkAppM ``StdSimplex.weights_pos #[w]) with
-  | some p => pure (.positive p)
-  | none => pure (.nonnegative (← mkAppM ``StdSimplex.nonneg #[w]))
+  match ← trySynthInstanceQ q(Nontrivial $R) with
+  | .some _instNontrivial => pure <| .positive q(StdSimplex.weights_pos $w)
+  | _ => pure <| .nonnegative q(StdSimplex.nonneg $w)
 
 /-- Extension for the `positivity` tactic: the weights of a `StdSimplex` are always nonnegative.
 
 This handles `w.weights i`; see `evalStdSimplexWeights` for the unapplied `w.weights`. -/
-@[positivity DFunLike.coe (Convexity.StdSimplex.weights _) _]
-meta def evalStdSimplexWeightsApply : PositivityExt where eval {_ _} _zα pα? e :=
+@[positivity StdSimplex.weights _ _]
+meta def evalStdSimplexWeightsApply : PositivityExt where eval {_u α} _zα pα? e :=
   match pα? with | none => pure .none | some _ => do
-  let .app (.app _coe (.app _ w)) i ← whnfR e | throwError "not `StdSimplex.weights`"
-  let p ← mkAppOptM ``StdSimplex.weights_nonneg #[none, none, none, none, w, i]
-  pure (.nonnegative p)
+  let _instPartialOrder ← synthInstanceQ q(PartialOrder $α)
+  let _instSemiring ← synthInstanceQ q(Semiring $α)
+  let uX ← mkFreshLevelMVar
+  let X ← mkFreshExprMVarQ q(Type uX)
+  let w' ← mkFreshExprMVarQ q(StdSimplex $α $X)
+  let i' ← mkFreshExprMVarQ q($X)
+  assumeInstancesCommute
+  let .defEq _ ← isDefEqQ e q(($w').weights $i') | throwError "not `StdSimplex.weights`"
+  let ⟨w, _⟩ ← instantiateMVarsQ' w'
+  let ⟨i, _⟩ ← instantiateMVarsQ' i'
+  pure (.nonnegative q(StdSimplex.weights_nonneg (w := $w) $i))
 
 end Mathlib.Meta.Positivity
+
+/- ## `Convexity.StdSimplex.weights` -/
+
+example {R M : Type*} [PartialOrder R] [Semiring R] (w : Convexity.StdSimplex R M) :
+    0 ≤ w.weights := by positivity
+
+example {R M : Type*} [PartialOrder R] [Semiring R] [Nontrivial R]
+    (w : Convexity.StdSimplex R M) : 0 < w.weights := by positivity
+
+example {R M : Type*} [PartialOrder R] [Semiring R] [Nontrivial R]
+    (w : Convexity.StdSimplex R M) : w.weights ≠ 0 := by positivity
+
+example {R M : Type*} [PartialOrder R] [Semiring R] (w : Convexity.StdSimplex R M) (i : M) :
+    0 ≤ w.weights i := by positivity
+
+example {R M : Type*} [PartialOrder R] [Semiring R] [IsOrderedRing R]
+    (w : Convexity.StdSimplex R M) (i j : M) : 0 ≤ w.weights i * w.weights j := by positivity

--- a/Mathlib/Util/Qq.lean
+++ b/Mathlib/Util/Qq.lean
@@ -42,6 +42,20 @@ def inferTypeQ' (e : Expr) : MetaM ((u : Level) × (α : Q(Type $u)) × Q($α)) 
 
 theorem QuotedDefEq.rfl {u : Level} {α : Q(Sort u)} {a : Q($α)} : @QuotedDefEq u α a a := ⟨⟩
 
+/-- Instantiate the level metavariables in `u`, remembering that the result is defeq to `u`.
+
+This is a `Qq` version of `Lean.instantiateLevelMVars`. -/
+-- The `u'` binder is used in the return type, but the linter cannot see through `=QL`
+def instantiateLevelMVarsQ (u : Level) : MetaM ((_u' : Level) ×' (u =QL _u')) :=
+  return ⟨← instantiateLevelMVars u, ⟨⟩⟩
+
+/-- Instantiate the metavariables in `e`, remembering that the result is defeq to `e`.
+
+This is a variant of `Qq.instantiateMVarsQ` which returns the defeq proof. -/
+def instantiateMVarsQ' {u : Level} {α : Q(Sort u)} (e : Q($α)) :
+    MetaM ((e' : Q($α)) ×' $e =Q $e') :=
+  return ⟨← instantiateMVarsQ e, ⟨⟩⟩
+
 /-- Return a local declaration whose type is definitionally equal to `sort`.
 
 This is a Qq version of `Lean.Meta.findLocalDeclWithType?` -/

--- a/MathlibTest/Tactic/Positivity.lean
+++ b/MathlibTest/Tactic/Positivity.lean
@@ -5,6 +5,7 @@ import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan
 import Mathlib.Basic.ENNReal.Basic
+import Mathlib.Geometry.Convex.ConvexSpace.Defs
 import Mathlib.MeasureTheory.Integral.Bochner.Basic
 import Mathlib.NumberTheory.ArithmeticFunction.Misc
 import Mathlib.NumberTheory.Chebyshev
@@ -667,3 +668,20 @@ example {α : Type*} [Semiring α] [Nontrivial α] (a : α) : a ^ 0 ≠ 0 := by 
 
 example {α : Type*} [AddGroup α] {a b : α} (ha : a ≠ b) : 0 ≠ b - a := by positivity
 example {α : Type*} [AddGroup α] {a b : α} (ha : a ≠ b) : 0 ≠ a - b := by positivity
+
+/- ## `Convexity.StdSimplex.weights` -/
+
+example {R M : Type*} [PartialOrder R] [Semiring R] (w : Convexity.StdSimplex R M) :
+    0 ≤ w.weights := by positivity
+
+example {R M : Type*} [PartialOrder R] [Semiring R] [Nontrivial R]
+    (w : Convexity.StdSimplex R M) : 0 < w.weights := by positivity
+
+example {R M : Type*} [PartialOrder R] [Semiring R] [Nontrivial R]
+    (w : Convexity.StdSimplex R M) : w.weights ≠ 0 := by positivity
+
+example {R M : Type*} [PartialOrder R] [Semiring R] (w : Convexity.StdSimplex R M) (i : M) :
+    0 ≤ w.weights i := by positivity
+
+example {R M : Type*} [PartialOrder R] [Semiring R] [IsOrderedRing R]
+    (w : Convexity.StdSimplex R M) (i j : M) : 0 ≤ w.weights i * w.weights j := by positivity


### PR DESCRIPTION
Also add some Qq helper to Qq-match a type with `Finsupp`.

From the Polyhedra in Berlin workshop where people would have found it useful for `positivity` to close some goals.

Generated by Claude Opus in a few prompts worth of review.

Assisted-by: Claude Opus 5


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
