### PR TITLE
[Merged by Bors] - feat(Tactic/Positivity): cover `Finset.sum_pos'` with the `Finset.sum` extension

### DIFF
--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -61,8 +61,9 @@ meta def evalFinsetDens : PositivityExt where eval {u 𝕜} _ pα? e :=
   | _, _, _ => throwError "not Finset.dens"
 
 attribute [local instance] monadLiftOptionMetaM in
-/-- The `positivity` extension which proves that `∑ i ∈ s, f i` is nonnegative if `f` is, and
-positive if each `f i` is and `s` is nonempty.
+/-- The `positivity` extension which proves that `∑ a ∈ s, f a` is nonnegative if `f` is, and
+positive if either each `f i` is and `s` is nonempty, or some `f a` is where `a ∈ s` is an
+assumption.
 
 TODO: The following example does not work
 ```
@@ -88,17 +89,38 @@ meta def evalFinsetSum : PositivityExt where eval {u α} zα pα? e :=
       let pr : Q(∀ i, 0 < $f i) ← mkLambdaFVars #[i] pbody
       pure <| some q(@sum_pos $ι $α $instα (@PartialOrder.toPreorder _ $pα) $pα' $f $s _
         (fun i _ ↦ $pr i) $ps)
-    -- Try to show that the sum is positive
+    -- Try to show that the sum is positive because all summands are
     if let some p_pos := p_pos then
       return .positive p_pos
+    let pbody ← rbody.toNonneg
+    let pr : Q(∀ i, 0 ≤ $f i) ← mkLambdaFVars #[i] pbody
+    -- Else try to show that the sum is positive because one summand is. We look for the witness
+    -- among the assumptions of the form `a ∈ s`, since we have no other way of getting hold of an
+    -- element of `s` at which `f` might be positive.
+    let p_pos' : Option Q(0 < $e) ← do
+      let .some pα' ← trySynthInstanceQ q(IsOrderedCancelAddMonoid $α) | pure none
+      let mut res : Option Q(0 < $e) := none
+      for ldecl in ← getLCtx do
+        if res.isSome then break
+        if ldecl.isImplementationDetail then continue
+        let_expr Membership.mem _ _ _ s' a := ldecl.type | continue
+        unless ← withNewMCtxDepth (isDefEq s' s) do continue
+        have a : Q($ι) := a
+        have hmem : Q($a ∈ $s) := ldecl.toExpr
+        have fa : Q($α) := .betaRev f #[a]
+        let .positive pa ← catchNone (core zα pα fa) | continue
+        have pa : Q(0 < $f $a) := pa
+        assertInstancesCommute
+        res := some q(@sum_pos' $ι $α $instα (@PartialOrder.toPreorder _ $pα) $pα' $f $s _
+          (fun i _ ↦ $pr i) ⟨$a, $hmem, $pa⟩)
+      pure res
+    if let some p_pos' := p_pos' then
+      return .positive p_pos'
     -- Fall back to showing that the sum is nonnegative
-    else
-      let pbody ← rbody.toNonneg
-      let pr : Q(∀ i, 0 ≤ $f i) ← mkLambdaFVars #[i] pbody
-      let pα' ← synthInstanceQ q(AddLeftMono $α)
-      assertInstancesCommute
-      return .nonnegative q(@sum_nonneg $ι $α $instα (@PartialOrder.toPreorder _ $pα) $f $s $pα'
-        fun i _ ↦ $pr i)
+    let pα' ← synthInstanceQ q(AddLeftMono $α)
+    assertInstancesCommute
+    return .nonnegative q(@sum_nonneg $ι $α $instα (@PartialOrder.toPreorder _ $pα) $f $s $pα'
+      fun i _ ↦ $pr i)
   | _ => throwError "not Finset.sum"
 
 variable {α : Type*} {s : Finset α}
@@ -116,6 +138,19 @@ example [Nonempty α] : 0 < #(univ : Finset α) := by positivity
 example [Nonempty α] : 0 < Fintype.card α := by positivity
 example [Nonempty α] : 0 < dens (univ : Finset α) := by positivity
 example [Nonempty α] : dens (univ : Finset α) ≠ 0 := by positivity
+
+example {f : α → ℕ} : 0 ≤ ∑ a ∈ s, f a := by positivity
+example {f : α → ℕ} (hs : s.Nonempty) : 0 < ∑ i ∈ s, (f i + 1) := by positivity
+example {f : α → ℕ} {a : α} (ha : a ∈ s) (hfa : 0 < f a) : 0 < ∑ a ∈ s, f a := by positivity
+example {f : α → ℕ} {a : α} (ha : a ∈ s) (hfa : f a ≠ 0) : ∑ a ∈ s, f a ≠ 0 := by positivity
+-- `f` need not be positive at the witness `a`, in which case we only get nonnegativity
+example {f : α → ℕ} {a : α} (_ha : a ∈ s) : 0 ≤ ∑ a ∈ s, f a := by positivity
+
+-- Extra `_ ∈ s` assumptions do not throw off `positivity`
+example {f : α → ℕ} {a b : α} (_ha : a ∈ s) (hb : b ∈ s) (hb : 0 < f b) : 0 < ∑ a ∈ s, f a := by
+  positivity
+example {f : α → ℕ} {a b : α} (ha : a ∈ s) (_hb : b ∈ s) (hfa : 0 < f a) : 0 < ∑ a ∈ s, f a := by
+  positivity
 
 example {G : Type*} {A : Finset G} :
     let f := fun _ : G ↦ 1; (∀ s, f s ^ 2 = 1) → 0 ≤ #A := by

--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -60,14 +60,12 @@ meta def evalFinsetDens : PositivityExt where eval {u 𝕜} _ pα? e :=
     return .positive q(@Nonempty.dens_pos $α $instα $s $ps)
   | _, _, _ => throwError "not Finset.dens"
 
-private meta def findMemFinset {u : Level} {α : Q(Type u)} (s : Q(Finset $α)) (p : Q(Prop))
-    (e : Q($p)) :
-    MetaM <| Option <| (a : Q($α)) × Q($a ∈ $s) := withNewMCtxDepth do
+private meta def isMemFinset? {u : Level} {α : Q(Type u)} (s : Q(Finset $α)) (p : Q(Prop)) :
+    MetaM <| Option <| (a : Q($α)) ×' $p =Q ($a ∈ $s) := withNewMCtxDepth do
   let m ← mkFreshExprMVarQ q($α)
   let .defEq _ ← isDefEqQ q($p) q($m ∈ $s) | return none
   let ⟨m, _⟩ ← instantiateMVarsQ' q($m)
-  let ⟨e, _⟩ ← instantiateMVarsQ' q($e)
-  return some ⟨q($m), q($e)⟩
+  return some ⟨q($m), ⟨⟩⟩
 
 attribute [local instance] monadLiftOptionMetaM in
 /-- The `positivity` extension which proves that `∑ a ∈ s, f a` is nonnegative if `f` is, and
@@ -111,9 +109,10 @@ meta def evalFinsetSum : PositivityExt where eval {u α} zα pα? e :=
       for ldecl in ← getLCtx do
         if ldecl.isImplementationDetail then continue
         unless ← Meta.isProp ldecl.type do continue
-        let .some ⟨a, ha⟩ ← findMemFinset q($s) ldecl.type ldecl.toExpr | continue
+        have ty : Q(Prop) := ldecl.type
+        have ha : Q($ty) := ldecl.toExpr
+        let .some ⟨a, _⟩ ← isMemFinset? q($s) ty | continue
         have fa : Q($α) := .betaRev f #[a]
-        let fa ← instantiateMVarsQ q($fa)
         let : $fa =Q $f $a := ⟨⟩
         let .positive pa ← catchNone (core zα pα fa) | continue
         assertInstancesCommute

--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -60,6 +60,15 @@ meta def evalFinsetDens : PositivityExt where eval {u 𝕜} _ pα? e :=
     return .positive q(@Nonempty.dens_pos $α $instα $s $ps)
   | _, _, _ => throwError "not Finset.dens"
 
+private meta def findMemFinset {u : Level} {α : Q(Type u)} (s : Q(Finset $α)) (p : Q(Prop))
+    (e : Q($p)) :
+    MetaM <| Option <| (a : Q($α)) × Q($a ∈ $s) := withNewMCtxDepth do
+  let m ← mkFreshExprMVarQ q($α)
+  let .defEq _ ← isDefEqQ q($p) q($m ∈ $s) | return none
+  let ⟨m, _⟩ ← instantiateMVarsQ' q($m)
+  let ⟨e, _⟩ ← instantiateMVarsQ' q($e)
+  return some ⟨q($m), q($e)⟩
+
 attribute [local instance] monadLiftOptionMetaM in
 /-- The `positivity` extension which proves that `∑ a ∈ s, f a` is nonnegative if `f` is, and
 positive if either each `f i` is and `s` is nonempty, or some `f a` is where `a ∈ s` is an
@@ -101,16 +110,15 @@ meta def evalFinsetSum : PositivityExt where eval {u α} zα pα? e :=
       let .some pα' ← trySynthInstanceQ q(IsOrderedCancelAddMonoid $α) | pure none
       for ldecl in ← getLCtx do
         if ldecl.isImplementationDetail then continue
-        let_expr Membership.mem _ _ _ s' a := ldecl.type | continue
-        unless ← withNewMCtxDepth (isDefEq s' s) do continue
-        have a : Q($ι) := a
-        have hmem : Q($a ∈ $s) := ldecl.toExpr
+        unless ← Meta.isProp ldecl.type do continue
+        let .some ⟨a, ha⟩ ← findMemFinset q($s) ldecl.type ldecl.toExpr | continue
         have fa : Q($α) := .betaRev f #[a]
+        let fa ← instantiateMVarsQ q($fa)
+        let : $fa =Q $f $a := ⟨⟩
         let .positive pa ← catchNone (core zα pα fa) | continue
-        have pa : Q(0 < $f $a) := pa
         assertInstancesCommute
         return some q(@sum_pos' $ι $α $instα (@PartialOrder.toPreorder _ $pα) $pα' $f $s _
-          (fun i _ ↦ $pr i) ⟨$a, $hmem, $pa⟩)
+          (fun i _ ↦ $pr i) ⟨$a, $ha, $pa⟩)
       return none)
     if let some p_pos' := p_pos' then
       return .positive p_pos'

--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -65,7 +65,7 @@ meta def evalFinsetDens : PositivityExt where eval {u 𝕜} _ pα? e :=
 private meta def isMemFinset? {u : Level} {α : Q(Type u)} (s : Q(Finset $α)) (p : Q(Prop)) :
     MetaM <| Option <| (a : Q($α)) ×' $p =Q ($a ∈ $s) := withNewMCtxDepth do
   let m ← mkFreshExprMVarQ q($α)
-  let .defEq _ ← isDefEqQ q($p) q($m ∈ $s) | return none
+  let .defEq _ ← withReducible <| isDefEqQ q($p) q($m ∈ $s) | return none
   let ⟨m, _⟩ ← instantiateMVarsQ' q($m)
   return some ⟨q($m), ⟨⟩⟩
 

--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -107,6 +107,7 @@ meta def evalFinsetSum : PositivityExt where eval {u α} zα pα? e :=
         have hmem : Q($a ∈ $s) := ldecl.toExpr
         have fa : Q($α) := .betaRev f #[a]
         let .positive pa ← catchNone (core zα pα fa) | continue
+        have pa : Q(0 < $f $a) := pa
         assertInstancesCommute
         return some q(@sum_pos' $ι $α $instα (@PartialOrder.toPreorder _ $pα) $pα' $f $s _
           (fun i _ ↦ $pr i) ⟨$a, $hmem, $pa⟩)

--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -97,11 +97,9 @@ meta def evalFinsetSum : PositivityExt where eval {u α} zα pα? e :=
     -- Else try to show that the sum is positive because one summand is. We look for the witness
     -- among the assumptions of the form `a ∈ s`, since we have no other way of getting hold of an
     -- element of `s` at which `f` might be positive.
-    let p_pos' : Option Q(0 < $e) ← do
+    let p_pos' : Option Q(0 < $e) ← (do
       let .some pα' ← trySynthInstanceQ q(IsOrderedCancelAddMonoid $α) | pure none
-      let mut res : Option Q(0 < $e) := none
       for ldecl in ← getLCtx do
-        if res.isSome then break
         if ldecl.isImplementationDetail then continue
         let_expr Membership.mem _ _ _ s' a := ldecl.type | continue
         unless ← withNewMCtxDepth (isDefEq s' s) do continue
@@ -109,11 +107,10 @@ meta def evalFinsetSum : PositivityExt where eval {u α} zα pα? e :=
         have hmem : Q($a ∈ $s) := ldecl.toExpr
         have fa : Q($α) := .betaRev f #[a]
         let .positive pa ← catchNone (core zα pα fa) | continue
-        have pa : Q(0 < $f $a) := pa
         assertInstancesCommute
-        res := some q(@sum_pos' $ι $α $instα (@PartialOrder.toPreorder _ $pα) $pα' $f $s _
+        return some q(@sum_pos' $ι $α $instα (@PartialOrder.toPreorder _ $pα) $pα' $f $s _
           (fun i _ ↦ $pr i) ⟨$a, $hmem, $pa⟩)
-      pure res
+      return none)
     if let some p_pos' := p_pos' then
       return .positive p_pos'
     -- Fall back to showing that the sum is nonnegative

--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -60,6 +60,8 @@ meta def evalFinsetDens : PositivityExt where eval {u 𝕜} _ pα? e :=
     return .positive q(@Nonempty.dens_pos $α $instα $s $ps)
   | _, _, _ => throwError "not Finset.dens"
 
+/-- Return whether `p` is a proposition of the form `?a ∈ s`. If so, return `a` and a Qq-proof that
+`p` is `a ∈ s`. -/
 private meta def isMemFinset? {u : Level} {α : Q(Type u)} (s : Q(Finset $α)) (p : Q(Prop)) :
     MetaM <| Option <| (a : Q($α)) ×' $p =Q ($a ∈ $s) := withNewMCtxDepth do
   let m ← mkFreshExprMVarQ q($α)

--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -91,11 +91,10 @@ meta def evalFinsetSum : PositivityExt where eval {u α} zα pα? e :=
     let p_pos : Option Q(0 < $e) ← do
       let .positive pbody := rbody | pure none -- Fail if the body is not provably positive
       let some ps ← proveFinsetNonempty s | pure none
-      let .some pα' ← trySynthInstanceQ q(IsOrderedCancelAddMonoid $α) | pure none
+      let .some _pα' ← trySynthInstanceQ q(IsOrderedCancelAddMonoid $α) | pure none
       assertInstancesCommute
       let pr : Q(∀ i, 0 < $f i) ← mkLambdaFVars #[i] pbody
-      pure <| some q(@sum_pos $ι $α $instα (@PartialOrder.toPreorder _ $pα) $pα' $f $s _
-        (fun i _ ↦ $pr i) $ps)
+      pure <| some q(sum_pos (fun i _ ↦ $pr i) $ps)
     -- Try to show that the sum is positive because all summands are
     if let some p_pos := p_pos then
       return .positive p_pos
@@ -105,7 +104,7 @@ meta def evalFinsetSum : PositivityExt where eval {u α} zα pα? e :=
     -- among the assumptions of the form `a ∈ s`, since we have no other way of getting hold of an
     -- element of `s` at which `f` might be positive.
     let p_pos' : Option Q(0 < $e) ← (do
-      let .some pα' ← trySynthInstanceQ q(IsOrderedCancelAddMonoid $α) | pure none
+      let .some _pα' ← trySynthInstanceQ q(IsOrderedCancelAddMonoid $α) | pure none
       for ldecl in ← getLCtx do
         if ldecl.isImplementationDetail then continue
         unless ← Meta.isProp ldecl.type do continue
@@ -116,16 +115,14 @@ meta def evalFinsetSum : PositivityExt where eval {u α} zα pα? e :=
         let : $fa =Q $f $a := ⟨⟩
         let .positive pa ← catchNone (core zα pα fa) | continue
         assertInstancesCommute
-        return some q(@sum_pos' $ι $α $instα (@PartialOrder.toPreorder _ $pα) $pα' $f $s _
-          (fun i _ ↦ $pr i) ⟨$a, $ha, $pa⟩)
+        return some q(sum_pos' (fun i _ ↦ $pr i) ⟨$a, $ha, $pa⟩)
       return none)
     if let some p_pos' := p_pos' then
       return .positive p_pos'
     -- Fall back to showing that the sum is nonnegative
-    let pα' ← synthInstanceQ q(AddLeftMono $α)
+    let _pα' ← synthInstanceQ q(AddLeftMono $α)
     assertInstancesCommute
-    return .nonnegative q(@sum_nonneg $ι $α $instα (@PartialOrder.toPreorder _ $pα) $f $s $pα'
-      fun i _ ↦ $pr i)
+    return .nonnegative q(sum_nonneg fun i _ ↦ $pr i)
   | _ => throwError "not Finset.sum"
 
 variable {α : Type*} {s : Finset α}

--- a/Mathlib/Util/Qq.lean
+++ b/Mathlib/Util/Qq.lean
@@ -87,4 +87,11 @@ def mkNatLitQ (n : Nat) : Q(Nat) := mkNatLit n
 This is a Qq version of `Lean.mkIntLit`. -/
 def mkIntLitQ (n : Int) : Q(Int) := mkIntLit n
 
+/-- Version of `instantiateMVarsQ` that returns the Qq-fact that the new expression is equal to the
+previous one. -/
+def instantiateMVarsQ' {u : Level} {α : Q(Sort u)} (e : Q($α)) :
+    MetaM <| (e' : Q($α)) ×' ($e' =Q $e) := do
+  let e' ← instantiateMVars e
+  return ⟨e', ⟨⟩⟩
+
 end Qq


### PR DESCRIPTION
To prove `0 < ∑ a ∈ s, f a`, the `positivity` extension now also searches through assumptions of the form `a ∈ s` and for each of them tries to prove `0 < f a`.

Will be used in convexity theory.

Generated by Claude Opus

Assisted-by: Claude Opus 5


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
