### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Matrix/PosDef): generalize `PosSemidef.dotProduct_mulVec_zero_iff`

### DIFF
--- a/Mathlib/Analysis/Matrix/Order.lean
+++ b/Mathlib/Analysis/Matrix/Order.lean
@@ -149,22 +149,6 @@ lemma inv_sqrt : (CFC.sqrt A)⁻¹ = CFC.sqrt A⁻¹ := by
 
 end sqrtDeprecated
 
-/-- For `A` positive semidefinite, we have `x⋆ A x = 0` iff `A x = 0`. -/
-theorem dotProduct_mulVec_zero_iff {A : Matrix n n 𝕜} (hA : PosSemidef A) (x : n → 𝕜) :
-    star x ⬝ᵥ A *ᵥ x = 0 ↔ A *ᵥ x = 0 := by
-  classical
-  refine ⟨fun h ↦ ?_, fun h ↦ h ▸ dotProduct_zero _⟩
-  obtain ⟨B, rfl⟩ := CStarAlgebra.nonneg_iff_eq_star_mul_self.mp hA.nonneg
-  simp_rw [← Matrix.mulVec_mulVec, dotProduct_mulVec _ _ (B *ᵥ x), star_eq_conjTranspose,
-    vecMul_conjTranspose, star_star, dotProduct_star_self_eq_zero] at h ⊢
-  rw [h, mulVec_zero]
-
-/-- For `A` positive semidefinite, we have `x⋆ A x = 0` iff `A x = 0` (linear maps version). -/
-theorem toLinearMap₂'_zero_iff [DecidableEq n]
-    {A : Matrix n n 𝕜} (hA : PosSemidef A) (x : n → 𝕜) :
-    Matrix.toLinearMap₂' 𝕜 A (star x) x = 0 ↔ A *ᵥ x = 0 := by
-  simpa only [toLinearMap₂'_apply'] using hA.dotProduct_mulVec_zero_iff x
-
 theorem det_sqrt [DecidableEq n] {A : Matrix n n 𝕜} (hA : A.PosSemidef) :
     (CFC.sqrt A).det = RCLike.sqrt A.det := by
   rw [CFC.sqrt_eq_cfc, cfc_nnreal_eq_real _ A, hA.1.cfc_eq, RCLike.sqrt_of_nonneg hA.det_nonneg]

--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -7,7 +7,12 @@ module
 
 public import Mathlib.Combinatorics.SimpleGraph.AdjMatrix
 public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Finite
+public import Mathlib.LinearAlgebra.Eigenspace.Matrix
 public import Mathlib.LinearAlgebra.Matrix.PosDef
+
+import Mathlib.Algebra.Order.Star.Real
+import Mathlib.Algebra.Group.Pi.Units
+import Mathlib.Tactic.Positivity.Finset
 
 /-!
 # Laplacian Matrix
@@ -281,3 +286,5 @@ theorem card_connectedComponent_eq_finrank_ker_toLin'_lapMatrix :
   rw [Module.finrank_eq_card_basis G.lapMatrix_ker_basis]
 
 end SimpleGraph
+
+#min_imports

--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -286,5 +286,3 @@ theorem card_connectedComponent_eq_finrank_ker_toLin'_lapMatrix :
   rw [Module.finrank_eq_card_basis G.lapMatrix_ker_basis]
 
 end SimpleGraph
-
-#min_imports

--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -5,9 +5,9 @@ Authors: Adrian Wüthrich
 -/
 module
 
-public import Mathlib.Analysis.Matrix.Order
 public import Mathlib.Combinatorics.SimpleGraph.AdjMatrix
 public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Finite
+public import Mathlib.LinearAlgebra.Matrix.PosDef
 
 /-!
 # Laplacian Matrix

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -458,13 +458,6 @@ theorem posDef_iff_dotProduct_mulVec {M : Matrix n n R} :
   simp [PosDef, ← Finsupp.equivFunOnFinite.forall_congr_right, dotProduct, mulVec,
     Finsupp.sum_fintype, Finset.mul_sum, mul_assoc, this]
 
-lemma posDef_iff_posSemidef_of_injective_mulVec [StarOrderedRing R'] [NoZeroDivisors R']
-    {A : Matrix n n R'} (h : Function.Injective A.mulVec) : PosDef A ↔ A.PosSemidef := by
-  refine ⟨fun hA ↦ hA.posSemidef, fun hA ↦ ?_⟩
-  refine posDef_iff_dotProduct_mulVec.mpr ⟨hA.isHermitian, fun x hx ↦ lt_of_le_of_ne' ?_ ?_⟩
-  · exact hA.dotProduct_mulVec_nonneg x
-  simpa [hA.dotProduct_mulVec_zero_iff, hx] using h.eq_iff (a := x) (b := 0)
-
 namespace PosDef
 
 /-- A matrix `M : Matrix n n R` is positive definite if it is Hermitian

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -350,6 +350,34 @@ protected lemma zpow [StarOrderedRing R'] [DecidableEq n]
 lemma trace_nonneg [AddLeftMono R] {A : Matrix n n R} (hA : A.PosSemidef) : 0 ≤ A.trace :=
   Fintype.sum_nonneg fun _ ↦ hA.diag_nonneg
 
+/-- For `A` positive semidefinite, we have `x⋆ A x = 0` iff `A x = 0`. -/
+theorem dotProduct_mulVec_zero_iff [StarOrderedRing R'] [NoZeroDivisors R']
+    {A : Matrix n n R'} (hA : A.PosSemidef) {x : n → R'} :
+    star x ⬝ᵥ A *ᵥ x = 0 ↔ A *ᵥ x = 0 := by
+  classical
+  refine ⟨fun hx ↦ ?_, fun hx ↦ by simp [hx]⟩
+  suffices h : ∀ y, star x ⬝ᵥ A *ᵥ y = 0 by
+    refine dotProduct_star_self_eq_zero.mp ?_
+    simpa [dotProduct_mulVec, star_mulVec, hA.isHermitian.eq] using h (A *ᵥ x)
+  intro y
+  set z := star x ⬝ᵥ A *ᵥ y with hz
+  suffices h : star z * z ≤ 0 by simpa using le_antisymm h (by simp)
+  calc star z * z ≤ 2 • (star z * z) + star z * z * (star y ⬝ᵥ A *ᵥ y) := by
+        rw [two_smul, add_assoc]
+        apply le_add_of_nonneg_right (add_nonneg (by simp) _)
+        exact mul_nonneg (by simp) (hA.dotProduct_mulVec_nonneg y)
+    _ ≤ 0 := neg_nonneg.mp <| le_of_le_of_eq
+        (hA.dotProduct_mulVec_nonneg (-(1 + star y ⬝ᵥ A *ᵥ y) • x + star z • y)) <| by
+      simp [mulVec_add, mulVec_smul, hx, ← hz, ← hA.isHermitian.star_dotProduct_mulVec_comm x y,
+        hA.isHermitian.star_dotProduct_mulVec_comm y y]
+      ring
+
+/-- For `A` positive semidefinite, we have `x⋆ A x = 0` iff `A x = 0` (linear maps version). -/
+theorem toLinearMap₂'_zero_iff [StarOrderedRing R'] [NoZeroDivisors R'] [DecidableEq n]
+    {A : Matrix n n R'} (hA : PosSemidef A) {x : n → R'} :
+    Matrix.toLinearMap₂' R' A (star x) x = 0 ↔ A *ᵥ x = 0 := by
+  simpa only [toLinearMap₂'_apply'] using hA.dotProduct_mulVec_zero_iff
+
 end PosSemidef
 
 omit [Fintype n] in variable [Finite n] in
@@ -496,7 +524,6 @@ theorem _root_.LinearMap.BilinForm.posDef_toQuadraticMap_iff_matrix
   · rw [B.toQuadraticMap_apply, ← b.linearCombination_repr (x := v)]
     simpa [Finsupp.linearCombination_apply, map_finsuppSum, Finsupp.mul_sum, aux]
       using h.2 (b.repr.map_ne_zero_iff.mpr hv)
-
 
 lemma trace_pos [Nontrivial R] [IsOrderedCancelAddMonoid R] [Nonempty n] {A : Matrix n n R}
     (hA : A.PosDef) : 0 < A.trace :=

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -458,6 +458,13 @@ theorem posDef_iff_dotProduct_mulVec {M : Matrix n n R} :
   simp [PosDef, ← Finsupp.equivFunOnFinite.forall_congr_right, dotProduct, mulVec,
     Finsupp.sum_fintype, Finset.mul_sum, mul_assoc, this]
 
+lemma posDef_iff_posSemidef_of_injective_mulVec [StarOrderedRing R'] [NoZeroDivisors R']
+    {A : Matrix n n R'} (h : Function.Injective A.mulVec) : PosDef A ↔ A.PosSemidef := by
+  refine ⟨fun hA ↦ hA.posSemidef, fun hA ↦ ?_⟩
+  refine posDef_iff_dotProduct_mulVec.mpr ⟨hA.isHermitian, fun x hx ↦ lt_of_le_of_ne' ?_ ?_⟩
+  · exact hA.dotProduct_mulVec_nonneg x
+  simpa [hA.dotProduct_mulVec_zero_iff, hx] using h.eq_iff (a := x) (b := 0)
+
 namespace PosDef
 
 /-- A matrix `M : Matrix n n R` is positive definite if it is Hermitian

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -354,7 +354,6 @@ lemma trace_nonneg [AddLeftMono R] {A : Matrix n n R} (hA : A.PosSemidef) : 0 �
 theorem dotProduct_mulVec_zero_iff [StarOrderedRing R'] [NoZeroDivisors R']
     {A : Matrix n n R'} (hA : A.PosSemidef) {x : n → R'} :
     star x ⬝ᵥ A *ᵥ x = 0 ↔ A *ᵥ x = 0 := by
-  classical
   refine ⟨fun hx ↦ ?_, fun hx ↦ by simp [hx]⟩
   suffices h : ∀ y, star x ⬝ᵥ A *ᵥ y = 0 by
     refine dotProduct_star_self_eq_zero.mp ?_


### PR DESCRIPTION
Found from reviewing #43460.

Also decrease imports in `Combinatorics/SimpleGraph/LapMatrix` by ~25%.

Initial long and tedious proof of the generalization is by Claude (hence the label), golfed by me.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
