### PR TITLE
feat(Dynamics/Ergodic/MeasurePreservingOfMapEq): measure-preserving map from a fixed point of the pushforward

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4593,8 +4593,8 @@ public import Mathlib.Dynamics.Ergodic.Conservative
 public import Mathlib.Dynamics.Ergodic.Ergodic
 public import Mathlib.Dynamics.Ergodic.Extreme
 public import Mathlib.Dynamics.Ergodic.Function
+public import Mathlib.Dynamics.Ergodic.MeasurePreserving
 public import Mathlib.Dynamics.Ergodic.MeasurePreservingOfMapEq
-import Mathlib.Dynamics.Ergodic.MeasurePreserving
 public import Mathlib.Dynamics.Ergodic.RadonNikodym
 public import Mathlib.Dynamics.FixedPoints.Basic
 public import Mathlib.Dynamics.FixedPoints.Defs

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4593,7 +4593,8 @@ public import Mathlib.Dynamics.Ergodic.Conservative
 public import Mathlib.Dynamics.Ergodic.Ergodic
 public import Mathlib.Dynamics.Ergodic.Extreme
 public import Mathlib.Dynamics.Ergodic.Function
-public import Mathlib.Dynamics.Ergodic.MeasurePreserving
+public import Mathlib.Dynamics.Ergodic.MeasurePreservingOfMapEq
+import Mathlib.Dynamics.Ergodic.MeasurePreserving
 public import Mathlib.Dynamics.Ergodic.RadonNikodym
 public import Mathlib.Dynamics.FixedPoints.Basic
 public import Mathlib.Dynamics.FixedPoints.Defs

--- a/Mathlib/Dynamics/Ergodic/MeasurePreservingOfMapEq.lean
+++ b/Mathlib/Dynamics/Ergodic/MeasurePreservingOfMapEq.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 Francisco Ramírez. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Francisco Ramírez
+-/
+import Mathlib.Dynamics.Ergodic.MeasurePreserving
+
+/-!
+# Measure-preserving map from a fixed point of the pushforward
+
+A measurable map `T` with `ν.map T = ν` (i.e. `ν` is a fixed point of the
+pushforward by `T`) is `MeasurePreserving T ν ν`. This is the anonymous
+constructor of `MeasurePreserving` exposed under a discoverable name, useful
+in Krylov–Bogolyubov-type arguments where one obtains a fixed point of the
+pushforward and needs to promote it to `MeasurePreserving`.
+
+## Main results
+
+* `measurePreserving_of_map_eq`: `Measurable T` + `ν.map T = ν` ⇒
+  `MeasurePreserving T ν ν`.
+
+## Tags
+
+measure preserving, pushforward, fixed point, invariant measure
+-/
+
+open MeasureTheory
+
+/-- A measurable map `T` with `ν.map T = ν` is `MeasurePreserving T ν ν`.
+This is the constructor of `MeasurePreserving` (whose fields are
+`measurable` and `map_eq`), exposed under a name discoverable in
+Krylov–Bogolyubov contexts. -/
+theorem measurePreserving_of_map_eq {X : Type*} [MeasurableSpace X]
+    {T : X → X} (hT : Measurable T) {ν : Measure X} (hfix : ν.map T = ν) :
+    MeasurePreserving T ν ν :=
+  ⟨hT, hfix⟩

--- a/Mathlib/Dynamics/Ergodic/MeasurePreservingOfMapEq.lean
+++ b/Mathlib/Dynamics/Ergodic/MeasurePreservingOfMapEq.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 Francisco Ramírez. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Francisco Ramírez
 -/
-import Mathlib.Dynamics.Ergodic.MeasurePreserving
+
+module
+public import Mathlib.Dynamics.Ergodic.MeasurePreserving
 
 /-!
 # Measure-preserving map from a fixed point of the pushforward
@@ -23,6 +25,8 @@ pushforward and needs to promote it to `MeasurePreserving`.
 
 measure preserving, pushforward, fixed point, invariant measure
 -/
+
+@[expose] public section
 
 open MeasureTheory
 


### PR DESCRIPTION

`MeasurePreserving T ν ν` is a structure whose fields are `measurable` and
`map_eq`. In Krylov–Bogolyubov-type arguments one obtains a fixed point of the
pushforward (`ν.map T = ν`, e.g. as a weak-* limit of empirical measures) and
then needs to promote it to `MeasurePreserving`.

This PR exposes the anonymous constructor under a discoverable name:

* `measurePreserving_of_map_eq`: `Measurable T → ν.map T = ν → MeasurePreserving T ν ν`