### PR TITLE
feat(SetTheory/Ordinal): classify exponential principal ordinals

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -510,17 +510,18 @@ theorem isPrincipal_opow_two : IsPrincipal (· ^ ·) 2 := by
   intro a b ha _
   simpa [lt_two_iff] using opow_le_opow_left b (lt_two_iff.1 ha)
 
-theorem isSuccLimit_of_isPrincipal_opow (ho₂ : 2 < o) (ho : IsPrincipal (· ^ ·) o) :
-    IsSuccLimit o := by
-  rw [isSuccLimit_iff, isSuccPrelimit_iff_succ_lt]
-  refine ⟨ho₂.ne_bot, fun a ha ↦ ?_⟩
-  rcases le_or_gt a 1 with ha₁ | ha₁
-  · exact (succ_le_of_lt (lt_two_iff.2 ha₁)).trans_lt ho₂
-  · exact (succ_le_of_lt (left_lt_opow ha₁ one_lt_two)).trans_lt (ho ha ho₂)
+theorem isPrincipal_mul_of_isPrincipal_opow (ho : IsPrincipal (· ^ ·) o) :
+    IsPrincipal (· * ·) o := by
+  rcases le_or_gt o 2 with ho₂ | ho₂
+  · exact isPrincipal_mul_of_le_two ho₂
+  · intro a b ha hb
+    have hm := ho (max_lt ha hb) ho₂
+    exact (mul_le_mul' (le_max_left a b) (le_max_right a b)).trans_lt
+      (by simpa [← one_add_one_eq_two, opow_add_one] using hm)
 
-/-- If `ω ^ o = o`, then `o` is multiplicatively principal. -/
-theorem isPrincipal_mul_of_omega0_opow_eq (ho : ω ^ o = o) : IsPrincipal (· * ·) o := by
-  simpa [ho] using isPrincipal_mul_omega0_opow_opow o
+theorem isSuccLimit_of_isPrincipal_opow (ho₂ : 2 < o) (ho : IsPrincipal (· ^ ·) o) :
+    IsSuccLimit o :=
+  isSuccLimit_of_isPrincipal_mul ho₂ (isPrincipal_mul_of_isPrincipal_opow ho)
 
 /-- Above `ω`, closure under exponentiation is equivalent to being a fixed point of `ω ^ ·`. -/
 theorem isPrincipal_opow_iff_omega0_opow_eq (hoω : ω < o) :
@@ -528,7 +529,8 @@ theorem isPrincipal_opow_iff_omega0_opow_eq (hoω : ω < o) :
   refine ⟨fun ho ↦ ?_, fun ho ↦ ?_⟩
   · exact op_eq_self_of_isPrincipal hoω (isNormal_opow one_lt_omega0) ho
       (isSuccLimit_of_isPrincipal_opow ((natCast_lt_omega0 2).trans hoω) ho)
-  · have hom := isPrincipal_mul_of_omega0_opow_eq ho
+  · have hom : IsPrincipal (· * ·) o := by
+      simpa [ho] using isPrincipal_mul_omega0_opow_opow o
     have hol := isSuccLimit_of_isPrincipal_mul ((natCast_lt_omega0 2).trans hoω) hom
     intro a b ha hb
     rw [← ho] at ha

--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -518,14 +518,17 @@ theorem isSuccLimit_of_isPrincipal_opow (ho₂ : 2 < o) (ho : IsPrincipal (· ^ 
   · exact (succ_le_of_lt (lt_two_iff.2 ha₁)).trans_lt ho₂
   · exact (succ_le_of_lt (left_lt_opow ha₁ one_lt_two)).trans_lt (ho ha ho₂)
 
+/-- If `ω ^ o = o`, then `o` is multiplicatively principal. -/
+theorem isPrincipal_mul_of_omega0_opow_eq (ho : ω ^ o = o) : IsPrincipal (· * ·) o := by
+  simpa [ho] using isPrincipal_mul_omega0_opow_opow o
+
 /-- Above `ω`, closure under exponentiation is equivalent to being a fixed point of `ω ^ ·`. -/
 theorem isPrincipal_opow_iff_omega0_opow_eq (hoω : ω < o) :
     IsPrincipal (· ^ ·) o ↔ ω ^ o = o := by
   refine ⟨fun ho ↦ ?_, fun ho ↦ ?_⟩
   · exact op_eq_self_of_isPrincipal hoω (isNormal_opow one_lt_omega0) ho
       (isSuccLimit_of_isPrincipal_opow ((natCast_lt_omega0 2).trans hoω) ho)
-  · have hom : IsPrincipal (· * ·) o := by
-      simpa [ho] using isPrincipal_mul_omega0_opow_opow o
+  · have hom := isPrincipal_mul_of_omega0_opow_eq ho
     have hol := isSuccLimit_of_isPrincipal_mul ((natCast_lt_omega0 2).trans hoω) hom
     intro a b ha hb
     rw [← ho] at ha

--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -550,11 +550,12 @@ theorem isPrincipal_opow_iff_zero_or_two_or_omega0_or_omega0_opow_eq :
     IsPrincipal (· ^ ·) o ↔ o = 0 ∨ o = 2 ∨ o = ω ∨ ω ^ o = o := by
   refine ⟨fun ho ↦ ?_, ?_⟩
   · simp only [or_iff_not_imp_left]
-    refine fun ho₀ ho₂ (hoω : o ≠ ω) ↦ ?_
-    rcases lt_or_ge 2 o with h₂ | h₂
+    refine fun ho₀ ho₂ hoω ↦ ?_
+    rcases gt_or_lt_of_ne ho₂ with h₂ | h₂
     · have hoω' := omega0_le_of_isSuccLimit (isSuccLimit_of_isPrincipal_opow h₂ ho)
-      exact (isPrincipal_opow_iff_omega0_opow_eq (lt_of_le_of_ne hoω' hoω.symm)).1 ho
-    · rcases le_two_iff.1 h₂ with (rfl | rfl | rfl) <;> simp_all
+      exact (isPrincipal_opow_iff_omega0_opow_eq (hoω'.lt_of_ne' hoω)).1 ho
+    · rw [lt_two_iff, le_one_iff] at h₂
+      simp_all
   · rintro (rfl | rfl | rfl | ho)
     · exact isPrincipal_zero
     · exact isPrincipal_opow_two

--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -508,18 +508,15 @@ theorem mul_eq_opow_log_succ (ha : a ≠ 0) (hb : IsPrincipal (· * ·) b) (hb�
 
 theorem isPrincipal_opow_two : IsPrincipal (· ^ ·) 2 := by
   intro a b ha _
-  obtain rfl | rfl := le_one_iff.1 (lt_two_iff.1 ha)
-  · exact (zero_opow_le b).trans_lt one_lt_two
-  · simp
+  simpa [lt_two_iff] using opow_le_opow_left b (lt_two_iff.1 ha)
 
 theorem isSuccLimit_of_isPrincipal_opow (ho₂ : 2 < o) (ho : IsPrincipal (· ^ ·) o) :
     IsSuccLimit o := by
   rw [isSuccLimit_iff, isSuccPrelimit_iff_succ_lt]
   refine ⟨ho₂.ne_bot, fun a ha ↦ ?_⟩
-  rcases lt_or_ge a 2 with ha₂ | ha₂
-  · exact (succ_le_of_lt ha₂).trans_lt ho₂
-  · refine (succ_le_of_lt ?_).trans_lt (ho ha ho₂)
-    exact left_lt_opow (one_lt_two.trans_le ha₂) one_lt_two
+  rcases le_or_gt a 1 with ha₁ | ha₁
+  · exact (succ_le_of_lt (lt_two_iff.2 ha₁)).trans_lt ho₂
+  · exact (succ_le_of_lt (left_lt_opow ha₁ one_lt_two)).trans_lt (ho ha ho₂)
 
 /-- Above `ω`, closure under exponentiation is equivalent to being a fixed point of `ω ^ ·`. -/
 theorem isPrincipal_opow_iff_omega0_opow_eq (hoω : ω < o) :
@@ -527,10 +524,9 @@ theorem isPrincipal_opow_iff_omega0_opow_eq (hoω : ω < o) :
   refine ⟨fun ho ↦ ?_, fun ho ↦ ?_⟩
   · exact op_eq_self_of_isPrincipal hoω (isNormal_opow one_lt_omega0) ho
       (isSuccLimit_of_isPrincipal_opow ((natCast_lt_omega0 2).trans hoω) ho)
-  · have hol : IsSuccLimit o := by
-      simpa [ho] using isSuccLimit_opow_left isSuccLimit_omega0 hoω.ne_bot
-    have hom : IsPrincipal (· * ·) o := by
+  · have hom : IsPrincipal (· * ·) o := by
       simpa [ho] using isPrincipal_mul_omega0_opow_opow o
+    have hol := isSuccLimit_of_isPrincipal_mul ((natCast_lt_omega0 2).trans hoω) hom
     intro a b ha hb
     rw [← ho] at ha
     obtain ⟨c, hc, hac⟩ := (lt_opow_of_isSuccLimit omega0_ne_zero hol).1 ha
@@ -550,7 +546,7 @@ The ordinal `1` is excluded because `0 ^ 0 = 1`. -/
 theorem isPrincipal_opow_iff_zero_or_two_or_omega0_or_omega0_opow_eq :
     IsPrincipal (· ^ ·) o ↔ o = 0 ∨ o = 2 ∨ o = ω ∨ ω ^ o = o := by
   refine ⟨fun ho ↦ ?_, ?_⟩
-  · rw [or_iff_not_imp_left, or_iff_not_imp_left, or_iff_not_imp_left]
+  · simp only [or_iff_not_imp_left]
     refine fun ho₀ ho₂ (hoω : o ≠ ω) ↦ ?_
     rcases lt_or_ge 2 o with h₂ | h₂
     · have hoω' := omega0_le_of_isSuccLimit (isSuccLimit_of_isPrincipal_opow h₂ ho)

--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -29,10 +29,6 @@ equivalent to the epsilon numbers given by `Ordinal.epsilon`.
 * `isPrincipal_mul_iff_le_two_or_omega0_opow_opow`: The multiplicative principal ordinals are
   `0`, `1`, `2`, and the ordinals `ω ^ ω ^ x`.
 
-## TODO
-
-* Prove that the exponential principal ordinals are `0`, `1`, `2`, `ω`, or `ε_ x`.
-
 ## Tags
 
 additively indecomposable, multiplicatively indecomposable
@@ -508,7 +504,39 @@ theorem mul_eq_opow_log_succ (ha : a ≠ 0) (hb : IsPrincipal (· * ·) b) (hb�
     simpa [succ_eq_add_one] using lt_opow_succ_log_self hb₁ _
   · grw [succ_eq_add_one, opow_add_one, opow_log_le_self b ha]
 
-/-! #### Exponential principal ordinals -/
+/-! ### Exponential principal ordinals -/
+
+theorem isPrincipal_opow_two : IsPrincipal (· ^ ·) 2 := by
+  intro a b ha _
+  obtain rfl | rfl := le_one_iff.1 (lt_two_iff.1 ha)
+  · exact (zero_opow_le b).trans_lt one_lt_two
+  · simp
+
+theorem isSuccLimit_of_isPrincipal_opow (ho₂ : 2 < o) (ho : IsPrincipal (· ^ ·) o) :
+    IsSuccLimit o := by
+  rw [isSuccLimit_iff, isSuccPrelimit_iff_succ_lt]
+  refine ⟨ho₂.ne_bot, fun a ha ↦ ?_⟩
+  rcases lt_or_ge a 2 with ha₂ | ha₂
+  · exact (succ_le_of_lt ha₂).trans_lt ho₂
+  · refine (succ_le_of_lt ?_).trans_lt (ho ha ho₂)
+    exact left_lt_opow (one_lt_two.trans_le ha₂) one_lt_two
+
+/-- Above `ω`, closure under exponentiation is equivalent to being a fixed point of `ω ^ ·`. -/
+theorem isPrincipal_opow_iff_omega0_opow_eq (hoω : ω < o) :
+    IsPrincipal (· ^ ·) o ↔ ω ^ o = o := by
+  refine ⟨fun ho ↦ ?_, fun ho ↦ ?_⟩
+  · exact op_eq_self_of_isPrincipal hoω (isNormal_opow one_lt_omega0) ho
+      (isSuccLimit_of_isPrincipal_opow ((natCast_lt_omega0 2).trans hoω) ho)
+  · have hol : IsSuccLimit o := by
+      simpa [ho] using isSuccLimit_opow_left isSuccLimit_omega0 hoω.ne_bot
+    have hom : IsPrincipal (· * ·) o := by
+      simpa [ho] using isPrincipal_mul_omega0_opow_opow o
+    intro a b ha hb
+    rw [← ho] at ha
+    obtain ⟨c, hc, hac⟩ := (lt_opow_of_isSuccLimit omega0_ne_zero hol).1 ha
+    refine (opow_le_opow_left b hac.le).trans_lt ?_
+    rw [← opow_mul, ← ho, opow_lt_opow_iff_right one_lt_omega0]
+    exact hom hc hb
 
 theorem isPrincipal_opow_omega0 : IsPrincipal (· ^ ·) ω := fun a b ha hb =>
   match a, b, lt_omega0.1 ha, lt_omega0.1 hb with
@@ -516,6 +544,26 @@ theorem isPrincipal_opow_omega0 : IsPrincipal (· ^ ·) ω := fun a b ha hb =>
 
 @[deprecated (since := "2026-03-17")]
 alias principal_opow_omega0 := isPrincipal_opow_omega0
+
+/-- The exponential principal ordinals are `0`, `2`, `ω`, and the fixed points of `ω ^ ·`.
+The ordinal `1` is excluded because `0 ^ 0 = 1`. -/
+theorem isPrincipal_opow_iff_zero_or_two_or_omega0_or_omega0_opow_eq :
+    IsPrincipal (· ^ ·) o ↔ o = 0 ∨ o = 2 ∨ o = ω ∨ ω ^ o = o := by
+  refine ⟨fun ho ↦ ?_, ?_⟩
+  · rw [or_iff_not_imp_left, or_iff_not_imp_left, or_iff_not_imp_left]
+    refine fun ho₀ ho₂ (hoω : o ≠ ω) ↦ ?_
+    rcases lt_or_ge 2 o with h₂ | h₂
+    · have hoω' := omega0_le_of_isSuccLimit (isSuccLimit_of_isPrincipal_opow h₂ ho)
+      exact (isPrincipal_opow_iff_omega0_opow_eq (lt_of_le_of_ne hoω' hoω.symm)).1 ho
+    · rcases le_two_iff.1 h₂ with (rfl | rfl | rfl) <;> simp_all
+  · rintro (rfl | rfl | rfl | ho)
+    · exact isPrincipal_zero
+    · exact isPrincipal_opow_two
+    · exact isPrincipal_opow_omega0
+    · rcases le_or_gt o 1 with ho₁ | ho₁
+      · rcases le_one_iff.1 ho₁ with (rfl | rfl) <;> simp [one_lt_omega0.ne'] at ho
+      · refine (isPrincipal_opow_iff_omega0_opow_eq ?_).2 ho
+        simpa [ho] using left_lt_opow one_lt_omega0 ho₁
 
 theorem opow_omega0 (a1 : 1 < a) (h : a < ω) : a ^ ω = ω :=
   ((opow_le_of_isSuccLimit (one_le_iff_ne_zero.1 <| le_of_lt a1) isSuccLimit_omega0).2 fun _ hb =>

--- a/Mathlib/SetTheory/Ordinal/Veblen.lean
+++ b/Mathlib/SetTheory/Ordinal/Veblen.lean
@@ -580,6 +580,10 @@ theorem omega0_lt_epsilon (o : Ordinal) : ω < ε_ o := by
   apply lt_of_lt_of_le _ <| (veblen_right_strictMono _).monotone zero_le
   simpa using iterate_omega0_opow_lt_epsilon_zero 2
 
+/-- Epsilon numbers are exponentially principal. -/
+theorem isPrincipal_opow_epsilon (o : Ordinal) : IsPrincipal (· ^ ·) (ε_ o) :=
+  (isPrincipal_opow_iff_omega0_opow_eq (omega0_lt_epsilon o)).2 (omega0_opow_epsilon o)
+
 theorem natCast_lt_epsilon (n : ℕ) (o : Ordinal) : n < ε_ o :=
   (natCast_lt_omega0 n).trans <| omega0_lt_epsilon o
 

--- a/Mathlib/SetTheory/Ordinal/Veblen.lean
+++ b/Mathlib/SetTheory/Ordinal/Veblen.lean
@@ -563,8 +563,8 @@ theorem omega0_opow_epsilon (o : Ordinal) : ω ^ ε_ o = ε_ o := by
 /-- The exponential principal ordinals are `0`, `2`, `ω`, and the epsilon numbers. -/
 theorem isPrincipal_opow_iff_zero_or_two_or_omega0_or_epsilon :
     IsPrincipal (· ^ ·) o ↔ o = 0 ∨ o = 2 ∨ o = ω ∨ o ∈ range epsilon := by
-  rw [isPrincipal_opow_iff_zero_or_two_or_omega0_or_omega0_opow_eq]
-  simp [epsilon, mem_range_veblen one_ne_zero]
+  rw [isPrincipal_opow_iff_zero_or_two_or_omega0_or_omega0_opow_eq, mem_range_veblen one_ne_zero]
+  simp
 
 /-- `ε₀` is the limit of `0`, `ω ^ 0`, `ω ^ ω ^ 0`, … -/
 theorem lt_epsilon_zero : o < ε₀ ↔ ∃ n : ℕ, o < (fun a ↦ ω ^ a)^[n] 0 := by

--- a/Mathlib/SetTheory/Ordinal/Veblen.lean
+++ b/Mathlib/SetTheory/Ordinal/Veblen.lean
@@ -560,6 +560,12 @@ theorem epsilon_le_veblen_of_ne_zero (ha : a ≠ 0) : ε_ b ≤ veblen a b :=
 theorem omega0_opow_epsilon (o : Ordinal) : ω ^ ε_ o = ε_ o := by
   rw [epsilon_eq_deriv, deriv_fp (isNormal_opow one_lt_omega0)]
 
+/-- The exponential principal ordinals are `0`, `2`, `ω`, and the epsilon numbers. -/
+theorem isPrincipal_opow_iff_zero_or_two_or_omega0_or_epsilon :
+    IsPrincipal (· ^ ·) o ↔ o = 0 ∨ o = 2 ∨ o = ω ∨ o ∈ range epsilon := by
+  rw [isPrincipal_opow_iff_zero_or_two_or_omega0_or_omega0_opow_eq]
+  simp [epsilon, mem_range_veblen one_ne_zero]
+
 /-- `ε₀` is the limit of `0`, `ω ^ 0`, `ω ^ ω ^ 0`, … -/
 theorem lt_epsilon_zero : o < ε₀ ↔ ∃ n : ℕ, o < (fun a ↦ ω ^ a)^[n] 0 := by
   rw [epsilon_zero_eq_nfp, lt_nfp_iff]


### PR DESCRIPTION
Complete `` TODO: Prove that the exponential principal ordinals are `0`, `1`, `2`, `ω`, or `ε_ x` `` in [Mathlib/SetTheory/Ordinal/Principal.lean](https://github.com/leanprover-community/mathlib4/compare/master...Jun2028:mathlib4:feat/exponential-principal-classification?expand=1#diff-c700a68af59d576bafeeeac5211181f9ce129bdead444df6c9747344817103bd)

By the way, the original TODO was wrong because `1` is not an exponential principal ordinal (it requires $0^0=1<1$ which is false).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
