### PR TITLE
refactor(Logic/Relation): move inclusion lemmas out of EqvGen

### DIFF
--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -796,26 +796,32 @@ lemma eqvGen_mono {r r' : α → α → Prop} (h : r ≤ r') : EqvGen r ≤ EqvG
   | _, _, .trans _ _ _ hxy hyz => .trans _ _ _ (eqvGen_mono h _ _ hxy) (eqvGen_mono h _ _ hyz)
   | _, _, .rel _ _ hab => .rel _ _ (h _ _ hab)
 
-lemma reflGen_le_eqvGen : ReflGen r ≤ EqvGen r
+end EqvGen
+
+lemma reflGen_le_eqvGen (r : α → α → Prop) : ReflGen r ≤ EqvGen r
   |  _, _, .refl => .refl _
   |  _, _, .single h => .rel _ _ h
 
-lemma symmGen_le_eqvGen : SymmGen r ≤ EqvGen r
+lemma symmGen_le_eqvGen (r : α → α → Prop) : SymmGen r ≤ EqvGen r
   | _, _, .inl h => .rel _ _ h
   | _, _, .inr h => _root_.symm <| .rel _ _ h
 
-lemma transGen_le_eqvGen : TransGen r ≤ EqvGen r := by
+lemma transGen_le_eqvGen (r : α → α → Prop) : TransGen r ≤ EqvGen r := by
   intro _ _ h
   induction h using TransGen.trans_induction_on with
   | trans _ _ h1 h2 => exact _root_.trans h1 h2
   | single h => exact .rel _ _ h
 
-lemma reflTransGen_le_eqvGen : ReflTransGen r ≤ EqvGen r := by
+lemma reflTransGen_le_eqvGen (r : α → α → Prop) : ReflTransGen r ≤ EqvGen r := by
   intro _ _ h
   induction h using ReflTransGen.trans_induction_on with
   | refl => exact .refl _
   | trans _ _ h1 h2 => exact _root_.trans h1 h2
   | single h => exact .rel _ _ h
+
+namespace EqvGen
+
+variable (r)
 
 @[simp, grind =]
 lemma eqvGen_reflGen : EqvGen (ReflGen r) = EqvGen r :=
@@ -846,6 +852,18 @@ lemma reflTransGen_symmGen : ReflTransGen (SymmGen r) = EqvGen r := by
   rw [← eqvGen_eq_reflTransGen, eqvGen_symmGen]
 
 end EqvGen
+
+@[deprecated (since := "2026-09-10")]
+alias EqvGen.reflGen_le_eqvGen := reflGen_le_eqvGen
+
+@[deprecated (since := "2026-09-10")]
+alias EqvGen.symmGen_le_eqvGen := symmGen_le_eqvGen
+
+@[deprecated (since := "2026-09-10")]
+alias EqvGen.transGen_le_eqvGen := transGen_le_eqvGen
+
+@[deprecated (since := "2026-09-10")]
+alias EqvGen.reflTransGen_le_eqvGen := reflTransGen_le_eqvGen
 
 /-- The join of a relation on a single type is a new relation for which
 pairs of terms are related if there is a third term they are both


### PR DESCRIPTION
I moved the four relation-inclusion lemmas introduced in #40792 from `Relation.EqvGen` to `Relation`, retaining the existing names as deprecated aliases.

This refactor was split out from #40368 following the review discussion there.

Changes:

* `Relation.EqvGen.reflGen_le_eqvGen` → `Relation.reflGen_le_eqvGen`
* `Relation.EqvGen.symmGen_le_eqvGen` → `Relation.symmGen_le_eqvGen`
* `Relation.EqvGen.transGen_le_eqvGen` → `Relation.transGen_le_eqvGen`
* `Relation.EqvGen.reflTransGen_le_eqvGen` → `Relation.reflTransGen_le_eqvGen`


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
