### PR TITLE
[Merged by Bors] - feat(Analysis/InnerProductSpace/Projection): relate projection distance to infDist

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
@@ -236,11 +236,11 @@ theorem dist_starProjection_eq_infDist
     dist y (U.starProjection y) = Metric.infDist y U := by
   simp [Metric.infDist_eq_iInf, U.starProjection_minimal, dist_eq_norm]
 
-/-- The norm of the orthogonal projection of `y` onto `Uᗮ` is `Metric.infDist y U`. -/
-theorem norm_starProjection_orthogonal_eq_infDist
-    {U : Submodule 𝕜 E} [U.HasOrthogonalProjection] (y : E) :
-    ‖Uᗮ.starProjection y‖ = Metric.infDist y U := by
-  simpa [U.starProjection_orthogonal_val, dist_eq_norm] using U.dist_starProjection_eq_infDist y
+/-- The norm of the orthogonal projection of `y` onto `U` is `Metric.infDist y Uᗮ`. -/
+theorem norm_starProjection_eq_infDist
+    (U : Submodule 𝕜 E) [U.HasOrthogonalProjection] (y : E) :
+    ‖U.starProjection y‖ = Metric.infDist y Uᗮ := by
+  simp [← Uᗮ.dist_starProjection_eq_infDist y]
 
 /-- The orthogonal projection sends elements of `K` to themselves. -/
 @[simp]

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
@@ -230,6 +230,18 @@ theorem starProjection_minimal {U : Submodule 𝕜 E} [U.HasOrthogonalProjection
   rw [starProjection_apply, U.norm_eq_iInf_iff_inner_eq_zero (Submodule.coe_mem _)]
   exact starProjection_inner_eq_zero _
 
+/-- The distance from `y` to its orthogonal projection onto `U` is `Metric.infDist y U`. -/
+theorem dist_starProjection_eq_infDist
+    (U : Submodule 𝕜 E) [U.HasOrthogonalProjection] (y : E) :
+    dist y (U.starProjection y) = Metric.infDist y U := by
+  simp [Metric.infDist_eq_iInf, U.starProjection_minimal, dist_eq_norm]
+
+/-- The norm of the orthogonal projection of `y` onto `Uᗮ` is `Metric.infDist y U`. -/
+theorem norm_starProjection_orthogonal_eq_infDist
+    {U : Submodule 𝕜 E} [U.HasOrthogonalProjection] (y : E) :
+    ‖Uᗮ.starProjection y‖ = Metric.infDist y U := by
+  simpa [U.starProjection_orthogonal_val, dist_eq_norm] using U.dist_starProjection_eq_infDist y
+
 /-- The orthogonal projection sends elements of `K` to themselves. -/
 @[simp]
 theorem orthogonalProjectionOnto_mem_subspace_eq_self (v : K) :

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
@@ -236,11 +236,25 @@ theorem dist_starProjection_eq_infDist
     dist y (U.starProjection y) = Metric.infDist y U := by
   simp [Metric.infDist_eq_iInf, U.starProjection_minimal, dist_eq_norm]
 
+/-- The nonnegative distance from `y` to its orthogonal projection onto `U` is
+`Metric.infNndist y U`. -/
+theorem nndist_starProjection_eq_infNndist
+    (U : Submodule 𝕜 E) [U.HasOrthogonalProjection] (y : E) :
+    nndist y (U.starProjection y) = Metric.infNndist y U := by
+  ext; simp [dist_starProjection_eq_infDist, ← Metric.coe_infNndist]
+
 /-- The norm of the orthogonal projection of `y` onto `U` is `Metric.infDist y Uᗮ`. -/
 theorem norm_starProjection_eq_infDist
     (U : Submodule 𝕜 E) [U.HasOrthogonalProjection] (y : E) :
     ‖U.starProjection y‖ = Metric.infDist y Uᗮ := by
   simp [← Uᗮ.dist_starProjection_eq_infDist y]
+
+/-- The nonnegative norm of the orthogonal projection of `y` onto `U` is
+`Metric.infNndist y Uᗮ`. -/
+theorem nnnorm_starProjection_eq_infNndist
+    (U : Submodule 𝕜 E) [U.HasOrthogonalProjection] (y : E) :
+    ‖U.starProjection y‖₊ = Metric.infNndist y Uᗮ := by
+  simp [← nndist_starProjection_eq_infNndist, nndist_eq_nnnorm]
 
 /-- The orthogonal projection sends elements of `K` to themselves. -/
 @[simp]


### PR DESCRIPTION
This PR adds six lemmas connecting orthogonal projection with distance to a submodule, in `ℝ`-, `ℝ≥0`-, and `ℝ≥0∞`-valued forms.

---

- `Submodule.dist_starProjection_eq_infDist` identifies the distance from a point to its orthogonal projection with its distance to the submodule.
- `Submodule.nndist_starProjection_eq_infNndist` gives the corresponding result for nonnegative distance.
- `Submodule.edist_starProjection_eq_infEDist` gives the corresponding result for extended distance.
- `Submodule.norm_starProjection_eq_infDist` identifies the norm of the orthogonal projection onto a submodule with the distance to its orthogonal complement.
- `Submodule.nnnorm_starProjection_eq_infNndist` gives the corresponding result for the nonnegative norm.
- `Submodule.enorm_starProjection_eq_infEDist` gives the corresponding result for the extended norm.

This was split out of #42483 following review feedback.

---

### LLM disclosure

I used OpenAI Codex substantially for planning, Lean implementation, and local validation. I reviewed the statements and proofs line by line and can explain them.

I validated the change with a targeted build of `Mathlib.Analysis.InnerProductSpace.Projection.Basic`, the style and environment linters, signature and axiom checks, a placeholder scan, and `git diff --check`. The corresponding GitHub build, test, and lint jobs also passed.