### PR TITLE
feat(RepresentationTheory): add two simp lemmas

### DIFF
--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -220,6 +220,16 @@ lemma comp_toLinearMap (f : IntertwiningMap σ τ) (g : IntertwiningMap ρ σ) :
 lemma comp_apply (f : IntertwiningMap σ τ) (g : IntertwiningMap ρ σ) (v : V) :
     comp f g v = f (g v) := rfl
 
+@[simp]
+lemma comp_zero (f : IntertwiningMap σ τ) :
+    comp f (0 : IntertwiningMap ρ σ) = 0 := by
+  ext; simp
+
+@[simp]
+lemma zero_comp (g : IntertwiningMap ρ σ) :
+    comp (0 : IntertwiningMap σ τ) g = 0 := by
+  ext; simp
+
 lemma comp_add (f₁ f₂ : IntertwiningMap σ τ) (g : IntertwiningMap ρ σ) :
     (f₁ + f₂).comp g = comp f₁ g + comp f₂ g := by ext1; simp [LinearMap.add_comp]
 

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -228,10 +228,10 @@ lemma comp_zero (f : IntertwiningMap σ τ) :
 lemma zero_comp (g : IntertwiningMap ρ σ) :
     comp (0 : IntertwiningMap σ τ) g = 0 := by ext; simp
 
-lemma comp_add (f₁ f₂ : IntertwiningMap σ τ) (g : IntertwiningMap ρ σ) :
+lemma add_comp (f₁ f₂ : IntertwiningMap σ τ) (g : IntertwiningMap ρ σ) :
     (f₁ + f₂).comp g = comp f₁ g + comp f₂ g := by ext1; simp [LinearMap.add_comp]
 
-lemma add_comp (f : IntertwiningMap σ τ) (g₁ g₂ : IntertwiningMap ρ σ) :
+lemma comp_add (f : IntertwiningMap σ τ) (g₁ g₂ : IntertwiningMap ρ σ) :
     comp f (g₁ + g₂) = comp f g₁ + comp f g₂ := by ext1; simp [LinearMap.comp_add]
 
 variable (A) in

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -222,13 +222,11 @@ lemma comp_apply (f : IntertwiningMap σ τ) (g : IntertwiningMap ρ σ) (v : V)
 
 @[simp]
 lemma comp_zero (f : IntertwiningMap σ τ) :
-    comp f (0 : IntertwiningMap ρ σ) = 0 := by
-  ext; simp
+    comp f (0 : IntertwiningMap ρ σ) = 0 := by ext; simp
 
 @[simp]
 lemma zero_comp (g : IntertwiningMap ρ σ) :
-    comp (0 : IntertwiningMap σ τ) g = 0 := by
-  ext; simp
+    comp (0 : IntertwiningMap σ τ) g = 0 := by ext; simp
 
 lemma comp_add (f₁ f₂ : IntertwiningMap σ τ) (g : IntertwiningMap ρ σ) :
     (f₁ + f₂).comp g = comp f₁ g + comp f₂ g := by ext1; simp [LinearMap.add_comp]

--- a/Mathlib/RepresentationTheory/Rep/Basic.lean
+++ b/Mathlib/RepresentationTheory/Rep/Basic.lean
@@ -219,12 +219,12 @@ lemma hom_comp_toLinearMap (f : A ⟶ B) (g : B ⟶ C) :
 lemma add_comp (f₁ f₂ : A ⟶ B) (g : B ⟶ C) :
     (f₁ + f₂) ≫ g = f₁ ≫ g + f₂ ≫ g := by
   ext1
-  simp [add_hom, Representation.IntertwiningMap.add_comp]
+  simp [add_hom, Representation.IntertwiningMap.comp_add]
 
 lemma comp_add (f : A ⟶ B) (g₁ g₂ : B ⟶ C) :
     f ≫ (g₁ + g₂) = f ≫ g₁ + f ≫ g₂ := by
   ext1
-  simp [add_hom, Representation.IntertwiningMap.comp_add]
+  simp [add_hom, Representation.IntertwiningMap.add_comp]
 
 instance : Zero (A ⟶ B) where
   zero := ofHom (0 : A.ρ.IntertwiningMap B.ρ)


### PR DESCRIPTION
We add two simp lemmas saying both the composition and precomposition with zero are zero
```
@[simp]
lemma comp_zero (f : IntertwiningMap σ τ) :
    comp f (0 : IntertwiningMap ρ σ) = 0 := by ext; simp

@[simp]
lemma zero_comp (g : IntertwiningMap ρ σ) :
    comp (0 : IntertwiningMap σ τ) g = 0 := by ext; simp
```
We also fix the names `add_comp` and `comp_add`