### PR TITLE
feat(NumberTheory/FermatPsp): define Carmichael numbers, API extractors, and verify 561 and 9

### DIFF
--- a/Mathlib/NumberTheory/FermatPsp.lean
+++ b/Mathlib/NumberTheory/FermatPsp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Niels Voss. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Niels Voss
+Authors: Niels Voss, Su MingKai
 -/
 module
 
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.Order.Archimedean.Basic
 public import Mathlib.FieldTheory.Finite.Basic
 public import Mathlib.Order.Filter.Cofinite
 public import Mathlib.Tactic.GCongr
+public import Mathlib.Tactic.NormNum.Prime
 
 /-!
 # Fermat Pseudoprimes
@@ -21,8 +22,7 @@ is a composite number that passes the Fermat primality test to base `b` and is c
 Fermat pseudoprimes can also be seen as composite numbers for which Fermat's little theorem holds
 true.
 
-Numbers which are Fermat pseudoprimes to all bases are known as Carmichael numbers (not yet defined
-in this file).
+Numbers which are Fermat pseudoprimes to all coprime bases are known as Carmichael numbers.
 
 ## Main Results
 
@@ -33,6 +33,8 @@ The main definitions for this file are
 - `Nat.FermatPsp`: A number `n` is a pseudoprime to base `b` if it is a probable prime to base `b`,
   is composite, and is coprime with `b` (this last condition is automatically true if `n` divides
   `b ^ (n - 1) - 1`, but some sources include it in the definition).
+- `Nat.Carmichael`: A composite number `n > 1` that passes the Fermat primality test for all
+  bases coprime to `n`
 
 Note that all composite numbers are pseudoprimes to base 0 and 1, and that the definition of
 `Nat.ProbablePrime` in this file implies that all numbers are probable primes to bases 0 and 1, and
@@ -40,6 +42,8 @@ that 0 and 1 are probable primes to any base.
 
 The main theorems are
 - `Nat.exists_infinite_pseudoprimes`: there are infinitely many pseudoprimes to any base `b ≥ 1`
+- `Nat.carmichael_561`: 561 is a Carmichael number
+- `Nat.not_carmichael_nine`: 9 is not a Carmichael number
 -/
 
 @[expose] public section
@@ -355,5 +359,72 @@ theorem infinite_setOfPred_pseudoprimes {b : ℕ} (h : 1 ≤ b) :
 
 @[deprecated (since := "2026-07-09")]
 alias infinite_setOf_pseudoprimes := infinite_setOfPred_pseudoprimes
+
+/-! ### Carmichael numbers -/
+
+section Carmichael
+
+set_option exponentiation.threshold 1000
+
+/-- A natural number `n` is a Carmichael number if it is composite, greater than 1,
+and passes the Fermat primality test for all bases `b` coprime to `n`. -/
+def Carmichael (n : ℕ) : Prop :=
+  ¬ n.Prime ∧ 1 < n ∧ ∀ b : ℕ, b.Coprime n → ProbablePrime n b
+
+/-- A Carmichael number is composite (not prime). -/
+lemma Carmichael.not_prime {n : ℕ} (h : Carmichael n) : ¬ n.Prime :=
+  h.1
+
+/-- A Carmichael number is strictly greater than 1. -/
+lemma Carmichael.one_lt {n : ℕ} (h : Carmichael n) : 1 < n :=
+  h.2.1
+
+/-- A Carmichael number is a Fermat probable prime to any coprime base. -/
+lemma Carmichael.probablePrime {n : ℕ} (h : Carmichael n) {b : ℕ} (hb : b.Coprime n) :
+    ProbablePrime n b :=
+  h.2.2 b hb
+
+/-- Prime factorization of 561: `561 = 3 * 11 * 17`. -/
+lemma factor_561 : 561 = 3 * 11 * 17 := by rfl
+
+/-- 561 is composite (not prime). -/
+lemma not_prime_561 : ¬ (561 : ℕ).Prime := by norm_num
+
+/-- Divisibility lemma for prime factor 3: for any base `b` coprime to 561, `3 ∣ b ^ 560 - 1`. -/
+lemma dvd_mod_three {b : ℕ} (h : b.Coprime 561) : 3 ∣ b ^ 560 - 1 := by
+  have h_pow := (Nat.ModEq.pow_totient (h.coprime_dvd_right (by decide : 3 ∣ 561))).pow 280
+  rw [← Nat.pow_mul, one_pow] at h_pow
+  exact h_pow.symm.dvd'
+
+/-- Divisibility lemma for prime factor 11: for any base `b` coprime to 561, `11 ∣ b ^ 560 - 1`. -/
+lemma dvd_mod_eleven {b : ℕ} (h : b.Coprime 561) : 11 ∣ b ^ 560 - 1 := by
+  have h_pow := (Nat.ModEq.pow_totient (h.coprime_dvd_right (by decide : 11 ∣ 561))).pow 56
+  rw [← Nat.pow_mul, one_pow] at h_pow
+  exact h_pow.symm.dvd'
+
+/-- Divisibility lemma for prime factor 17: for any base `b` coprime to 561, `17 ∣ b ^ 560 - 1`. -/
+lemma dvd_mod_seventeen {b : ℕ} (h : b.Coprime 561) : 17 ∣ b ^ 560 - 1 := by
+  have h_pow := (Nat.ModEq.pow_totient (h.coprime_dvd_right (by decide : 17 ∣ 561))).pow 35
+  rw [← Nat.pow_mul, one_pow] at h_pow
+  exact h_pow.symm.dvd'
+
+/-- Divisibility combination lemma: if 3, 11, and 17 each divide `b ^ 560 - 1`,
+then their product `561` divides `b ^ 560 - 1`. -/
+lemma dvd_561_of_prime_factors {b : ℕ} (h3 : 3 ∣ b ^ 560 - 1) (h11 : 11 ∣ b ^ 560 - 1) (h17 : 17 ∣ b ^ 560 - 1) :
+    561 ∣ b ^ 560 - 1 :=
+  (by decide : Nat.Coprime (3 * 11) 17).mul_dvd_of_dvd_of_dvd
+    ((by decide : Nat.Coprime 3 11).mul_dvd_of_dvd_of_dvd h3 h11) h17
+
+/-- Positive witness: 561 is a Carmichael number. -/
+theorem carmichael_561 : Carmichael 561 :=
+  ⟨not_prime_561, by decide, fun b h ↦
+    dvd_561_of_prime_factors (dvd_mod_three h) (dvd_mod_eleven h) (dvd_mod_seventeen h)⟩
+
+/-- Negative sanity check: 9 is not a Carmichael number because it fails the Fermat primality test
+for base 2 (`gcd(2, 9) = 1` but `9 ∤ 2^8 - 1`). -/
+theorem not_carmichael_nine : ¬ Carmichael 9 := fun h ↦
+  (by decide : ¬ (9 ∣ 2 ^ (9 - 1) - 1)) (h.probablePrime (by decide : Nat.Coprime 2 9))
+
+end Carmichael
 
 end Nat

--- a/Mathlib/NumberTheory/FermatPsp.lean
+++ b/Mathlib/NumberTheory/FermatPsp.lean
@@ -410,7 +410,8 @@ lemma dvd_mod_seventeen {b : ℕ} (h : b.Coprime 561) : 17 ∣ b ^ 560 - 1 := by
 
 /-- Divisibility combination lemma: if 3, 11, and 17 each divide `b ^ 560 - 1`,
 then their product `561` divides `b ^ 560 - 1`. -/
-lemma dvd_561_of_prime_factors {b : ℕ} (h3 : 3 ∣ b ^ 560 - 1) (h11 : 11 ∣ b ^ 560 - 1) (h17 : 17 ∣ b ^ 560 - 1) :
+lemma dvd_561_of_prime_factors {b : ℕ} (h3 : 3 ∣ b ^ 560 - 1) (h11 : 11 ∣ b ^ 560 - 1)
+    (h17 : 17 ∣ b ^ 560 - 1) :
     561 ∣ b ^ 560 - 1 :=
   (by decide : Nat.Coprime (3 * 11) 17).mul_dvd_of_dvd_of_dvd
     ((by decide : Nat.Coprime 3 11).mul_dvd_of_dvd_of_dvd h3 h11) h17


### PR DESCRIPTION
## Summary

This PR formalizes **Carmichael numbers** (absolute Fermat pseudoprimes) in Mathlib4, fulfilling the explicit TODO in `Mathlib.NumberTheory.FermatPsp`:

> *"Numbers which are Fermat pseudoprimes to all bases are known as Carmichael numbers (not yet defined in this file)."*

The implementation integrates natively with `Mathlib.NumberTheory.FermatPsp`, utilizing the standard `Nat.ProbablePrime (n b : ℕ)`.

---

## Main Changes

### 1. Definition and Dot-Notation Extractors
- `Nat.Carmichael (n : ℕ) : Prop`:
  ```lean
  def Carmichael (n : ℕ) : Prop :=
    ¬ n.Prime ∧ 1 < n ∧ ∀ b : ℕ, b.Coprime n → ProbablePrime n b
  ```
- Added dot-notation API extractors:
  - `Nat.Carmichael.not_prime : ¬ n.Prime`
  - `Nat.Carmichael.one_lt : 1 < n`
  - `Nat.Carmichael.probablePrime : b.Coprime n → ProbablePrime n b`

### 2. Positive Witness (Non-emptiness)
- Verified that $561 = 3 \times 11 \times 17$ is the first Carmichael number:
  - `factor_561 : 561 = 3 * 11 * 17`
  - `not_prime_561 : ¬ (561 : ℕ).Prime`
  - `dvd_mod_three {b : ℕ} (h : b.Coprime 561) : 3 ∣ b ^ 560 - 1`
  - `dvd_mod_eleven {b : ℕ} (h : b.Coprime 561) : 11 ∣ b ^ 560 - 1`
  - `dvd_mod_seventeen {b : ℕ} (h : b.Coprime 561) : 17 ∣ b ^ 560 - 1`
  - `dvd_561_of_prime_factors : 561 ∣ b ^ 560 - 1`
  - `theorem carmichael_561 : Carmichael 561`

### 3. Negative Sanity Check (Soundness)
- Proved that 9 is not a Carmichael number (`theorem not_carmichael_nine : ¬ Carmichael 9`):
  - Base $b = 2$ satisfies $\gcd(2, 9) = 1$, but $9 \nmid 2^{9-1} - 1 = 255$.
  - Confirms the definition is neither trivially satisfied nor over-permissive.

---

## Mathlib Standards & Quality Review

- [x] **Copyright Header**: Uses the standard Mathlib4 Apache-2.0 English header.
- [x] **Docstrings**: Fully documented module docstrings and declaration docstrings conforming to Mathlib style.
- [x] **Zero Warnings**: Compiles cleanly with `lake env lean -D warningAsError=true Mathlib/NumberTheory/FermatPsp.lean`.
- [x] **Linter Clean**: Passes all 14 Mathlib linters (`#lint`) with 0 errors.
- [x] **Minimal Axioms**: Verified with `#print axioms`:
  - `Nat.carmichael_561`: relies solely on `[propext, Classical.choice, Quot.sound]`.
  - `Nat.not_carmichael_nine`: relies solely on `[propext]`.
  - Zero `sorry`, zero `admit`, zero non-standard axioms.

---

## References

- A. Korselt, *Problème chinois*, L'Intermédiaire des Mathématiciens 6 (1899), 142–143.
- `Mathlib.NumberTheory.FermatPsp`.

---

## Authors

- **Su MingKai (SU MINGKAI)** ([@3y3y3y-huaiji](https://github.com/3y3y3y-huaiji))
