### PR TITLE
chore: rename `Isometry` to `Isometric`

### DIFF
--- a/Mathlib/Algebra/Module/ZLattice/Basic.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Basic.lean
@@ -664,7 +664,7 @@ theorem Real.finrank_eq_int_finrank_of_discrete {E : Type*} [NormedAddCommGroup 
   let f := Submodule.comapSubtypeEquivOfLe (span_le_restrictScalars ℤ ℝ s)
   have : DiscreteTopology L := by
     let e : span ℤ s ≃L[ℤ] L :=
-      ⟨f.symm, continuous_of_discreteTopology, Isometry.continuous fun _ ↦ congrFun rfl⟩
+      ⟨f.symm, continuous_of_discreteTopology, Isometric.continuous fun _ ↦ congrFun rfl⟩
     exact e.toHomeomorph.discreteTopology
   have : IsZLattice ℝ L := ⟨eq_top_iff.mpr <|
     span_span_coe_preimage.symm.le.trans (span_mono (Set.preimage_mono subset_span))⟩

--- a/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
+++ b/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
@@ -400,7 +400,7 @@ theorem radius_compContinuousLinearMap_linearIsometryEquiv_eq [Nontrivial E]
 /-- This is a version of `radius_compContinuousLinearMap_linearIsometryEquiv_eq` with better
 opportunity for unification, at the cost of manually supplying some hypotheses. -/
 theorem radius_compContinuousLinearMap_eq [Nontrivial E]
-    (p : FormalMultilinearSeries 𝕜 F G) (u : E →L[𝕜] F) (hu_iso : Isometry u)
+    (p : FormalMultilinearSeries 𝕜 F G) (u : E →L[𝕜] F) (hu_iso : Isometric u)
     (hu_surj : Function.Surjective u) :
     (p.compContinuousLinearMap u).radius = p.radius :=
   let v : E ≃ₗᵢ[𝕜] F :=

--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -63,12 +63,14 @@ def starNormedAddGroupHom : NormedAddGroupHom E E :=
   { starAddEquiv with bound' := ⟨1, fun _ => le_trans (norm_star _).le (one_mul _).symm.le⟩ }
 
 /-- The `star` map in a normed star group is an isometry -/
-theorem star_isometry : Isometry (star : E → E) :=
-  show Isometry starAddEquiv from
-    AddMonoidHomClass.isometry_of_norm starAddEquiv (show ∀ x, ‖x⋆‖ = ‖x‖ from norm_star)
+theorem star_isometric : Isometric (star : E → E) :=
+  show Isometric starAddEquiv from
+    AddMonoidHomClass.isometric_of_norm starAddEquiv (show ∀ x, ‖x⋆‖ = ‖x‖ from norm_star)
+
+@[deprecated (since := "2026-09-09")] alias star_isometry := star_isometric
 
 instance (priority := 100) NormedStarGroup.to_continuousStar : ContinuousStar E :=
-  ⟨star_isometry.continuous⟩
+  ⟨star_isometric.continuous⟩
 
 noncomputable
 instance [NormedField 𝕜] [NormedSpace 𝕜 E] [Star 𝕜] [TrivialStar 𝕜] [StarModule 𝕜 E] :
@@ -78,22 +80,22 @@ instance [NormedField 𝕜] [NormedSpace 𝕜 E] [Star 𝕜] [TrivialStar 𝕜] 
 variable (x : E) (r : ℝ)
 
 @[simp] lemma Metric.star_ball : star (ball x r) = ball (star x) r := by
-  simpa using star_isometry.preimage_ball (star x) r
+  simpa using star_isometric.preimage_ball (star x) r
 
 @[simp] lemma Metric.star_closedBall : star (closedBall x r) = closedBall (star x) r := by
-  simpa using star_isometry.preimage_closedBall (star x) r
+  simpa using star_isometric.preimage_closedBall (star x) r
 
 @[simp] lemma Metric.star_sphere : star (sphere x r) = sphere (star x) r := by
-  simpa using star_isometry.preimage_sphere (star x) r
+  simpa using star_isometric.preimage_sphere (star x) r
 
 @[simp] lemma dist_star_star (x y : E) : dist (star x) (star y) = dist x y :=
-  star_isometry.dist_eq x y
+  star_isometric.dist_eq x y
 
 @[simp] lemma edist_star_star (x y : E) : edist (star x) (star y) = edist x y :=
-  star_isometry.edist_eq x y
+  star_isometric.edist_eq x y
 
 @[simp] lemma nndist_star_star (x y : E) : nndist (star x) (star y) = nndist x y :=
-  star_isometry.nndist_eq x y
+  star_isometric.nndist_eq x y
 
 end NormedStarGroup
 

--- a/Mathlib/Analysis/CStarAlgebra/Commutative/PosPart.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Commutative/PosPart.lean
@@ -57,8 +57,8 @@ open ContinuousMap WeakDual in
 protected lemma posPart_mono : Monotone (fun a : A ↦ a⁺) := by
   let φ : A →⋆ₙₐ[ℂ] C(characterSpace ℂ A⁺¹, ℂ) :=
     .comp (gelfandStarTransform A⁺¹) (Unitization.inrNonUnitalStarAlgHom ℂ A)
-  have hφ : Isometry φ :=
-    StarAlgEquiv.isometry (gelfandStarTransform (A⁺¹)) |>.comp <| Unitization.isometry_inr
+  have hφ : Isometric φ :=
+    StarAlgEquiv.isometric (gelfandStarTransform (A⁺¹)) |>.comp <| Unitization.isometric_inr
   intro a b hab
   simp only
   by_cases ha : IsSelfAdjoint a

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
@@ -144,9 +144,9 @@ theorem IsStarNormal.instContinuousFunctionalCalculus :
   predicate_zero := .zero
   spectrum_nonempty a _ := spectrum.nonempty a
   exists_cfc_of_predicate a ha := by
-    have : Isometry ((StarAlgebra.elemental ℂ a).subtype.comp <| continuousFunctionalCalculus a :
+    have : Isometric ((StarAlgebra.elemental ℂ a).subtype.comp <| continuousFunctionalCalculus a :
         C(spectrum ℂ a, ℂ) →⋆ₐ[ℂ] A) :=
-      isometry_subtype_coe.comp <| StarAlgEquiv.isometry (continuousFunctionalCalculus a)
+      isometric_subtype_coe.comp <| StarAlgEquiv.isometric (continuousFunctionalCalculus a)
     refine ⟨_, this.continuous, this.injective, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩
     case hom_id => exact congr_arg Subtype.val <| continuousFunctionalCalculus_map_id a
     case hom_map_spectrum =>
@@ -162,18 +162,18 @@ lemma cfcHom_eq_of_isStarNormal (a : A) [ha : IsStarNormal a] :
     cfcHom ha = (StarAlgebra.elemental ℂ a).subtype.comp (continuousFunctionalCalculus a) := by
   refine cfcHom_eq_of_continuous_of_map_id ha _ ?_ ?_
   · exact continuous_subtype_val.comp <|
-      (StarAlgEquiv.isometry (continuousFunctionalCalculus a)).continuous
+      (StarAlgEquiv.isometric (continuousFunctionalCalculus a)).continuous
   · simp [continuousFunctionalCalculus_map_id a]
 
 instance IsStarNormal.instIsometricContinuousFunctionalCalculus :
     IsometricContinuousFunctionalCalculus ℂ A IsStarNormal where
   isometric a ha := by
     rw [cfcHom_eq_of_isStarNormal]
-    exact isometry_subtype_coe.comp <| StarAlgEquiv.isometry (continuousFunctionalCalculus a)
+    exact isometric_subtype_coe.comp <| StarAlgEquiv.isometric (continuousFunctionalCalculus a)
 
 instance IsSelfAdjoint.instIsometricContinuousFunctionalCalculus :
     IsometricContinuousFunctionalCalculus ℝ A IsSelfAdjoint :=
-  SpectrumRestricts.isometric_cfc Complex.reCLM Complex.isometry_ofReal (.zero _)
+  SpectrumRestricts.isometric_cfc Complex.reCLM Complex.isometric_ofReal (.zero _)
     fun _ ↦ isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts
 
 end Unital
@@ -199,7 +199,7 @@ open ContinuousMapZero in
 instance IsStarNormal.instNonUnitalIsometricContinuousFunctionalCalculus :
     NonUnitalIsometricContinuousFunctionalCalculus ℂ A IsStarNormal where
   isometric a ha := by
-    refine AddMonoidHomClass.isometry_of_norm _ fun f ↦ ?_
+    refine AddMonoidHomClass.isometric_of_norm _ fun f ↦ ?_
     rw [← norm_inr (𝕜 := ℂ), ← inrNonUnitalStarAlgHom_apply, ← NonUnitalStarAlgHom.comp_apply,
       inr_comp_cfcₙHom_eq_cfcₙAux a, cfcₙAux]
     simp only [NonUnitalStarAlgHom.comp_assoc, NonUnitalStarAlgHom.comp_apply,
@@ -209,7 +209,7 @@ instance IsStarNormal.instNonUnitalIsometricContinuousFunctionalCalculus :
 
 instance IsSelfAdjoint.instNonUnitalIsometricContinuousFunctionalCalculus :
     NonUnitalIsometricContinuousFunctionalCalculus ℝ A IsSelfAdjoint :=
-  QuasispectrumRestricts.isometric_cfc Complex.reCLM Complex.isometry_ofReal (.zero _)
+  QuasispectrumRestricts.isometric_cfc Complex.reCLM Complex.isometric_ofReal (.zero _)
     fun _ ↦ isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts
 
 end NonUnital

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Continuity.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Continuity.lean
@@ -166,7 +166,7 @@ lemma lipschitzOnWith_cfc_fun (a : A) :
   by_cases ha : p a
   · intro f hf g hg
     simp only
-    rw [cfc_apply .., cfc_apply .., isometry_cfcHom (R := R) a ha |>.edist_eq]
+    rw [cfc_apply .., cfc_apply .., isometric_cfcHom (R := R) a ha |>.edist_eq]
     simp only [ENNReal.coe_one, one_mul]
     rw [edist_continuousRestrict_of_singleton hf hg]
   · simpa [cfc_apply_of_not_predicate a ha] using LipschitzWith.const' 0 |>.lipschitzOnWith
@@ -225,7 +225,7 @@ theorem continuous_cfcHomSuperset_left
     simp only [Metric.mem_closedBall, dist_comm g, dist_eq_norm] at hg
     refine ⟨_, g_cont, fun x ↦ ?_⟩
     rw [← map_sub, cfcHomSuperset_apply]
-    rw [isometry_cfcHom (R := 𝕜) _ (ha' x) |>.norm_map_of_map_zero (map_zero (cfcHom (ha' x)))]
+    rw [isometric_cfcHom (R := 𝕜) _ (ha' x) |>.norm_map_of_map_zero (map_zero (cfcHom (ha' x)))]
     rw [ContinuousMap.norm_le _ hε.le] at hg ⊢
     aesop
 
@@ -705,9 +705,9 @@ lemma lipschitzOnWith_cfcₙ_fun (a : A) :
   by_cases ha : p a
   · rintro f ⟨hf, hf0⟩ g ⟨hg, hg0⟩
     simp only
-    rw [cfcₙ_apply .., cfcₙ_apply .., isometry_cfcₙHom (R := R) a ha |>.edist_eq]
+    rw [cfcₙ_apply .., cfcₙ_apply .., isometric_cfcₙHom (R := R) a ha |>.edist_eq]
     simp only [ENNReal.coe_one, one_mul]
-    rw [← ContinuousMapZero.isometry_toContinuousMap.edist_eq,
+    rw [← ContinuousMapZero.isometric_toContinuousMap.edist_eq,
       edist_continuousRestrict_of_singleton hf hg]
   · simpa [cfcₙ_apply_of_not_predicate a ha] using LipschitzWith.const' 0 |>.lipschitzOnWith
 
@@ -760,7 +760,7 @@ theorem continuous_cfcₙHomSuperset_left
     simp only [Metric.mem_closedBall, dist_comm g, dist_eq_norm] at hg
     refine ⟨_, g_cont, fun x ↦ ?_⟩
     rw [← map_sub, cfcₙHomSuperset_apply]
-    rw [isometry_cfcₙHom (R := 𝕜) _ (ha' x) |>.norm_map_of_map_zero (map_zero (cfcₙHom (ha' x)))]
+    rw [isometric_cfcₙHom (R := 𝕜) _ (ha' x) |>.norm_map_of_map_zero (map_zero (cfcₙHom (ha' x)))]
     rw [ContinuousMapZero.norm_def, ContinuousMap.norm_le _ hε.le] at hg ⊢
     aesop
 

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -138,7 +138,7 @@ theorem RCLike.nonUnitalContinuousFunctionalCalculus :
         ⟨cfcₙAux hp₁ a ha f, cfcₙAux_mem_range_inr hp₁ a ha f⟩
     refine ⟨ψ, ?continuous, ?injective, ?map_id, fun f ↦ ?map_spec, fun f ↦ ?isStarNormal⟩
     case continuous =>
-      rw [isometry_inr (𝕜 := 𝕜) |>.isEmbedding.continuous_iff]
+      rw [isometric_inr (𝕜 := 𝕜) |>.isEmbedding.continuous_iff]
       have := continuous_cfcₙAux hp₁ a ha
       simp only [coe_comp, NonUnitalStarAlgHom.coe_coe, Function.comp_def,
         inrRangeEquiv_symm_apply, coe_codRestrict, ψ]
@@ -172,7 +172,7 @@ theorem RCLike.nonUnitalContinuousFunctionalCalculusIsClosedEmbedding :
     NonUnitalClosedEmbeddingContinuousFunctionalCalculus 𝕜 A p where
   toNonUnitalContinuousFunctionalCalculus := RCLike.nonUnitalContinuousFunctionalCalculus hp₁
   isClosedEmbedding a ha := by
-    apply isometry_inr (𝕜 := 𝕜) (A := A) |>.isClosedEmbedding |>.of_comp_iff.mp
+    apply isometric_inr (𝕜 := 𝕜) (A := A) |>.isClosedEmbedding |>.of_comp_iff.mp
     convert! isClosedEmbedding_cfcₙAux hp₁ a ha
     congrm (⇑$(inrNonUnitalStarAlgHom_comp_cfcₙHom_eq_cfcₙAux hp₁ a ha))
 
@@ -216,7 +216,7 @@ lemma QuasispectrumRestricts.isSelfAdjoint (a : A) (ha : QuasispectrumRestricts 
 instance IsSelfAdjoint.instNonUnitalContinuousFunctionalCalculus :
     NonUnitalContinuousFunctionalCalculus ℝ A IsSelfAdjoint :=
   QuasispectrumRestricts.cfc (q := IsStarNormal) (p := IsSelfAdjoint) Complex.reCLM
-    Complex.isometry_ofReal.isClosedEmbedding (.zero _)
+    Complex.isometric_ofReal.isClosedEmbedding (.zero _)
     (fun _ ↦ isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts)
 
 end SelfAdjointNonUnital
@@ -234,7 +234,7 @@ lemma IsSelfAdjoint.spectrumRestricts {a : A} (ha : IsSelfAdjoint a) :
 instance IsSelfAdjoint.instContinuousFunctionalCalculus :
     ContinuousFunctionalCalculus ℝ A IsSelfAdjoint :=
   SpectrumRestricts.cfc (q := IsStarNormal) (p := IsSelfAdjoint) Complex.reCLM
-    Complex.isometry_ofReal.isClosedEmbedding (.zero _)
+    Complex.isometric_ofReal.isClosedEmbedding (.zero _)
     (fun _ ↦ isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts)
 
 @[deprecated "Use `ContinuousFunctionalCalculus.spectrum_nonempty a ha` instead."
@@ -352,7 +352,7 @@ lemma cfcHom_real_eq_restrict {a : A} (ha : IsSelfAdjoint a) :
 lemma cfc_real_eq_complex {a : A} (f : ℝ → ℝ) (ha : IsSelfAdjoint a := by cfc_tac) :
     cfc f a = cfc (fun x ↦ f x.re : ℂ → ℂ) a := by
   exact ha.spectrumRestricts.cfc_eq_restrict (f := Complex.reCLM)
-    Complex.isometry_ofReal.isClosedEmbedding ha ha.isStarNormal f
+    Complex.isometric_ofReal.isClosedEmbedding ha ha.isStarNormal f
 
 lemma cfc_complex_eq_real {f : ℂ → ℂ} (a : A) (hf_real : ∀ x ∈ spectrum ℂ a, star (f x) = f x)
     (ha : IsSelfAdjoint a := by cfc_tac) :
@@ -379,7 +379,7 @@ lemma cfcₙHom_real_eq_restrict {a : A} (ha : IsSelfAdjoint a) :
 lemma cfcₙ_real_eq_complex {a : A} (f : ℝ → ℝ) (ha : IsSelfAdjoint a := by cfc_tac) :
     cfcₙ f a = cfcₙ (fun x ↦ f x.re : ℂ → ℂ) a := by
   exact ha.quasispectrumRestricts.cfcₙ_eq_restrict (f := Complex.reCLM)
-    Complex.isometry_ofReal.isClosedEmbedding ha ha.isStarNormal f
+    Complex.isometric_ofReal.isClosedEmbedding ha ha.isStarNormal f
 
 lemma cfcₙ_complex_eq_real {f : ℂ → ℂ} (a : A) (hf_real : ∀ x ∈ σₙ ℂ a, star (f x) = f x)
     (ha : IsSelfAdjoint a := by cfc_tac) :

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Isometric.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Isometric.lean
@@ -32,7 +32,7 @@ class IsometricContinuousFunctionalCalculus (R A : Type*) (p : outParam (A → P
     [CommSemiring R] [StarRing R] [MetricSpace R] [IsTopologicalSemiring R] [ContinuousStar R]
     [Ring A] [StarRing A] [MetricSpace A] [Algebra R A] : Prop
     extends ContinuousFunctionalCalculus R A p where
-  isometric (a : A) (ha : p a) : Isometry (cfcHom ha (R := R))
+  isometric (a : A) (ha : p a) : Isometric (cfcHom ha (R := R))
 
 section MetricSpace
 
@@ -42,12 +42,14 @@ variable {R A : Type*} {p : A → Prop} [CommSemiring R] [StarRing R]
   [MetricSpace R] [IsTopologicalSemiring R] [ContinuousStar R] [Ring A] [StarRing A]
   [MetricSpace A] [Algebra R A] [IsometricContinuousFunctionalCalculus R A p]
 
-lemma isometry_cfcHom (a : A) (ha : p a := by cfc_tac) :
-    Isometry (cfcHom (show p a from ha) (R := R)) :=
+lemma isometric_cfcHom (a : A) (ha : p a := by cfc_tac) :
+    Isometric (cfcHom (show p a from ha) (R := R)) :=
   IsometricContinuousFunctionalCalculus.isometric a ha
 
+@[deprecated (since := "2026-09-09")] alias isometry_cfcHom := isometric_cfcHom
+
 instance [CompleteSpace R] : ClosedEmbeddingContinuousFunctionalCalculus R A p where
-  isClosedEmbedding a ha := (isometry_cfcHom a).isClosedEmbedding
+  isClosedEmbedding a ha := (isometric_cfcHom a).isClosedEmbedding
 
 end MetricSpace
 
@@ -61,7 +63,7 @@ variable [IsometricContinuousFunctionalCalculus 𝕜 A p]
 
 lemma norm_cfcHom (a : A) (f : C(σ 𝕜 a, 𝕜)) (ha : p a := by cfc_tac) :
     ‖cfcHom (show p a from ha) f‖ = ‖f‖ := by
-  refine isometry_cfcHom a |>.norm_map_of_map_zero (map_zero _) f
+  refine isometric_cfcHom a |>.norm_map_of_map_zero (map_zero _) f
 
 lemma nnnorm_cfcHom (a : A) (f : C(σ 𝕜 a, 𝕜)) (ha : p a := by cfc_tac) :
     ‖cfcHom (show p a from ha) f‖₊ = ‖f‖₊ :=
@@ -194,7 +196,7 @@ variable [CompleteSpace R] [ContinuousMap.UniqueHom R A]
 
 set_option backward.isDefEq.respectTransparency.types false in
 open scoped ContinuousFunctionalCalculus in
-protected theorem isometric_cfc (f : C(S, R)) (halg : Isometry (algebraMap R S)) (h0 : p 0)
+protected theorem isometric_cfc (f : C(S, R)) (halg : Isometric (algebraMap R S)) (h0 : p 0)
     (h : ∀ a, p a ↔ q a ∧ SpectrumRestricts a f) :
     IsometricContinuousFunctionalCalculus R A p where
   toContinuousFunctionalCalculus := SpectrumRestricts.cfc f halg.isClosedEmbedding h0 h
@@ -203,7 +205,7 @@ protected theorem isometric_cfc (f : C(S, R)) (halg : Isometry (algebraMap R S))
     have := SpectrumRestricts.cfc f halg.isClosedEmbedding h0 h
     rw [cfcHom_eq_restrict f ha ha' haf]
     refine .of_dist_eq fun g₁ g₂ ↦ ?_
-    simp only [starAlgHom_apply, isometry_cfcHom a ha' |>.dist_eq]
+    simp only [starAlgHom_apply, isometric_cfcHom a ha' |>.dist_eq]
     refine le_antisymm ?_ ?_
     all_goals refine ContinuousMap.dist_le dist_nonneg |>.mpr fun x ↦ ?_
     · simpa [halg.dist_eq] using ContinuousMap.dist_apply_le_dist _
@@ -229,7 +231,7 @@ class NonUnitalIsometricContinuousFunctionalCalculus (R A : Type*) (p : outParam
     [ContinuousStar R] [NonUnitalRing A] [StarRing A] [MetricSpace A] [Module R A]
     [IsScalarTower R A A] [SMulCommClass R A A] : Prop
     extends NonUnitalContinuousFunctionalCalculus R A p where
-  isometric (a : A) (ha : p a) : Isometry (cfcₙHom ha (R := R))
+  isometric (a : A) (ha : p a) : Isometric (cfcₙHom ha (R := R))
 
 section MetricSpace
 
@@ -243,12 +245,14 @@ open scoped NonUnitalContinuousFunctionalCalculus
 
 variable [NonUnitalIsometricContinuousFunctionalCalculus R A p]
 
-lemma isometry_cfcₙHom (a : A) (ha : p a := by cfc_tac) :
-    Isometry (cfcₙHom (show p a from ha) (R := R)) :=
+lemma isometric_cfcₙHom (a : A) (ha : p a := by cfc_tac) :
+    Isometric (cfcₙHom (show p a from ha) (R := R)) :=
   NonUnitalIsometricContinuousFunctionalCalculus.isometric a ha
 
+@[deprecated (since := "2026-09-10")] alias isometry_cfcₙHom := isometric_cfcₙHom
+
 instance [CompleteSpace R] : NonUnitalClosedEmbeddingContinuousFunctionalCalculus R A p where
-  isClosedEmbedding a ha := (isometry_cfcₙHom a).isClosedEmbedding
+  isClosedEmbedding a ha := (isometric_cfcₙHom a).isClosedEmbedding
 
 end MetricSpace
 
@@ -264,7 +268,7 @@ open scoped ContinuousMapZero NonUnitalContinuousFunctionalCalculus
 
 lemma norm_cfcₙHom (a : A) (f : C(σₙ 𝕜 a, 𝕜)₀) (ha : p a := by cfc_tac) :
     ‖cfcₙHom (show p a from ha) f‖ = ‖f‖ := by
-  refine isometry_cfcₙHom a |>.norm_map_of_map_zero (map_zero _) f
+  refine isometric_cfcₙHom a |>.norm_map_of_map_zero (map_zero _) f
 
 lemma nnnorm_cfcₙHom (a : A) (f : C(σₙ 𝕜 a, 𝕜)₀) (ha : p a := by cfc_tac) :
     ‖cfcₙHom (show p a from ha) f‖₊ = ‖f‖₊ :=
@@ -405,7 +409,7 @@ variable [CompleteSpace R] [ContinuousMapZero.UniqueHom R A]
 
 set_option backward.isDefEq.respectTransparency.types false in
 open scoped NonUnitalContinuousFunctionalCalculus in
-protected theorem isometric_cfc (f : C(S, R)) (halg : Isometry (algebraMap R S)) (h0 : p 0)
+protected theorem isometric_cfc (f : C(S, R)) (halg : Isometric (algebraMap R S)) (h0 : p 0)
     (h : ∀ a, p a ↔ q a ∧ QuasispectrumRestricts a f) :
     NonUnitalIsometricContinuousFunctionalCalculus R A p where
   toNonUnitalContinuousFunctionalCalculus := QuasispectrumRestricts.cfc f
@@ -415,7 +419,7 @@ protected theorem isometric_cfc (f : C(S, R)) (halg : Isometry (algebraMap R S))
     have := QuasispectrumRestricts.cfc f halg.isClosedEmbedding h0 h
     rw [cfcₙHom_eq_restrict f ha ha' haf]
     refine .of_dist_eq fun g₁ g₂ ↦ ?_
-    simp only [nonUnitalStarAlgHom_apply, isometry_cfcₙHom a ha' |>.dist_eq]
+    simp only [nonUnitalStarAlgHom_apply, isometric_cfcₙHom a ha' |>.dist_eq]
     refine le_antisymm ?_ ?_
     all_goals refine ContinuousMap.dist_le dist_nonneg |>.mpr fun x ↦ ?_
     · simpa [halg.dist_eq] using! ContinuousMap.dist_apply_le_dist _
@@ -425,6 +429,8 @@ protected theorem isometric_cfc (f : C(S, R)) (halg : Isometry (algebraMap R S))
         ContinuousMap.coe_mk, StarAlgHom.ofId_apply, halg.dist_eq, x']
       congr! 2
       all_goals ext; exact haf.left_inv _ |>.symm
+
+@[deprecated (since := "2026-09-09")] alias isometry_cfc := QuasispectrumRestricts.isometric_cfc
 
 end QuasispectrumRestricts
 
@@ -639,9 +645,9 @@ instance toNonUnital : NonUnitalIsometricContinuousFunctionalCalculus 𝕜 A p w
       simp only [← isCompact_iff_compactSpace, quasispectrum_eq_spectrum_union_zero] at h_cpct ⊢
       exact h_cpct |>.union isCompact_singleton
     rw [cfcₙHom_eq_cfcₙHom_of_cfcHom, cfcₙHom_of_cfcHom]
-    refine isometry_cfcHom a |>.comp ?_
+    refine isometric_cfcHom a |>.comp ?_
     simp only [MulHom.coe_coe, NonUnitalStarAlgHom.coe_toNonUnitalAlgHom]
-    refine AddMonoidHomClass.isometry_of_norm _ fun f ↦ ?_
+    refine AddMonoidHomClass.isometric_of_norm _ fun f ↦ ?_
     let ι : C(σ 𝕜 a, σₙ 𝕜 a) := ⟨_, continuous_inclusion <| spectrum_subset_quasispectrum 𝕜 a⟩
     change ‖(f : C(σₙ 𝕜 a, 𝕜)).comp ι‖ = ‖(f : C(σₙ 𝕜 a, 𝕜))‖
     apply le_antisymm (ContinuousMap.norm_le _ (by positivity) |>.mpr ?_)

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
@@ -527,8 +527,8 @@ lemma isBounded_of_bddAbove_of_bddBelow {s : Set A} (hbd : BddAbove s) (hbd' : B
 /-- The set of nonnegative elements in a C⋆-algebra is closed. -/
 lemma isClosed_nonneg : IsClosed {a : A | 0 ≤ a} := by
   suffices IsClosed {a : A⁺¹ | 0 ≤ a} by
-    rw [Unitization.isometry_inr (𝕜 := ℂ) |>.isClosedEmbedding.isClosed_iff_image_isClosed]
-    convert! this.inter <| (Unitization.isometry_inr (𝕜 := ℂ)).isClosedEmbedding.isClosed_range
+    rw [Unitization.isometric_inr (𝕜 := ℂ) |>.isClosedEmbedding.isClosed_iff_image_isClosed]
+    convert! this.inter <| (Unitization.isometric_inr (𝕜 := ℂ)).isClosedEmbedding.isClosed_range
     ext a
     simp only [Set.mem_image, Set.mem_ofPred_eq, Set.mem_inter_iff, Set.mem_range,
       ← exists_and_left]

--- a/Mathlib/Analysis/CStarAlgebra/GelfandDuality.lean
+++ b/Mathlib/Analysis/CStarAlgebra/GelfandDuality.lean
@@ -45,7 +45,7 @@ Then `η₁ : id → F ∘ G := gelfandStarTransform` and
 
 * `spectrum.gelfandTransform_eq` : the Gelfand transform is spectrum-preserving when the algebra is
   a commutative complex Banach algebra.
-* `gelfandTransform_isometry` : the Gelfand transform is an isometry when the algebra is a
+* `gelfandTransform_isometric` : the Gelfand transform is an isometry when the algebra is a
   commutative (unital) C⋆-algebra over `ℂ`.
 * `gelfandTransform_bijective` : the Gelfand transform is bijective when the algebra is a
   commutative (unital) C⋆-algebra over `ℂ`.
@@ -141,8 +141,8 @@ theorem gelfandTransform_map_star (a : A) :
 variable (A)
 
 /-- The Gelfand transform is an isometry when the algebra is a C⋆-algebra over `ℂ`. -/
-theorem gelfandTransform_isometry : Isometry (gelfandTransform ℂ A) := by
-  refine AddMonoidHomClass.isometry_of_norm (gelfandTransform ℂ A) fun a => ?_
+theorem gelfandTransform_isometric : Isometric (gelfandTransform ℂ A) := by
+  refine AddMonoidHomClass.isometric_of_norm (gelfandTransform ℂ A) fun a => ?_
   /- By `spectrum.gelfandTransform_eq`, the spectra of `star a * a` and its
     `gelfandTransform` coincide. Therefore, so do their spectral radii, and since they are
     self-adjoint, so also do their norms. Applying the C⋆-property of the norm and taking square
@@ -155,10 +155,12 @@ theorem gelfandTransform_isometry : Isometry (gelfandTransform ℂ A) := by
   simpa only [Function.comp_apply, NNReal.sqrt_sq] using!
     congr_arg (((↑) : ℝ≥0 → ℝ) ∘ ⇑NNReal.sqrt) this
 
+@[deprecated (since := "2026-09-09")] alias gelfandTransform_isometry := gelfandTransform_isometric
+
 set_option backward.defeqAttrib.useBackward true in
 /-- The Gelfand transform is bijective when the algebra is a C⋆-algebra over `ℂ`. -/
 theorem gelfandTransform_bijective : Function.Bijective (gelfandTransform ℂ A) := by
-  refine ⟨(gelfandTransform_isometry A).injective, ?_⟩
+  refine ⟨(gelfandTransform_isometric A).injective, ?_⟩
   /- The range of `gelfandTransform ℂ A` is actually a `StarSubalgebra`. The key lemma below may be
     hard to spot; it's `map_star` coming from `WeakDual.Complex.instStarHomClass`, which is a
     nontrivial result. -/
@@ -177,7 +179,7 @@ theorem gelfandTransform_bijective : Function.Bijective (gelfandTransform ℂ A)
     points in `C(characterSpace ℂ A, ℂ)` and is closed under `star`. -/
   have h : rng.topologicalClosure = rng := le_antisymm
     (StarSubalgebra.topologicalClosure_minimal le_rfl
-      (gelfandTransform_isometry A).isClosedEmbedding.isClosed_range)
+      (gelfandTransform_isometric A).isClosedEmbedding.isClosed_range)
     (StarSubalgebra.le_topologicalClosure _)
   refine h ▸ ContinuousMap.starSubalgebra_topologicalClosure_eq_top_of_separatesPoints
     _ (fun _ _ => ?_)
@@ -206,7 +208,7 @@ open scoped CStarAlgebra in
 open Unitization in
 lemma norm_add_eq_max (h : a * b = 0) : ‖a + b‖ = max ‖a‖ ‖b‖ := by
   let f := gelfandStarTransform A⁺¹ ∘ inrNonUnitalAlgHom ℂ A
-  have hf : Isometry f := gelfandTransform_isometry _ |>.comp isometry_inr
+  have hf : Isometric f := gelfandTransform_isometric _ |>.comp isometric_inr
   simp_rw [← hf.norm_map_of_map_zero (by simp [f]), show f (a + b) = f a + f b by simp [f]]
   exact ContinuousMap.norm_add_eq_max <| by simpa [f] using congr(f $h)
 

--- a/Mathlib/Analysis/CStarAlgebra/Hom.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Hom.lean
@@ -124,7 +124,9 @@ lemma norm_map (φ : F) (hφ : Function.Injective φ) (a : A) : ‖φ a‖ = ‖
 lemma nnnorm_map (φ : F) (hφ : Function.Injective φ) (a : A) : ‖φ a‖₊ = ‖a‖₊ :=
   Subtype.ext <| norm_map φ hφ a
 
-lemma isometry (φ : F) (hφ : Function.Injective φ) : Isometry φ :=
-  AddMonoidHomClass.isometry_of_norm φ (norm_map φ hφ)
+lemma isometric (φ : F) (hφ : Function.Injective φ) : Isometric φ :=
+  AddMonoidHomClass.isometric_of_norm φ (norm_map φ hφ)
+
+@[deprecated (since := "2026-09-09")] alias isometry := isometric
 
 end NonUnitalStarAlgHom

--- a/Mathlib/Analysis/CStarAlgebra/Spectrum.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Spectrum.lean
@@ -216,7 +216,7 @@ lemma IsSelfAdjoint.isConnected_spectrum_compl {a : A} (ha : IsSelfAdjoint a) :
   refine IsConnected.union ?nonempty ?upper ?lower
   case nonempty =>
     have := Filter.NeBot.nonempty_of_mem inferInstance <| Filter.mem_map.mp <|
-      Complex.isometry_ofReal.antilipschitzWith.tendsto_cobounded (spectrum.isBounded a |>.compl)
+      Complex.isometric_ofReal.antilipschitzWith.tendsto_cobounded (spectrum.isBounded a |>.compl)
     exact this.image Complex.ofReal |>.mono <| by simp
   case' upper => apply Complex.isConnected_of_upperHalfPlane ?_ <| Set.inter_subset_right
   case' lower => apply Complex.isConnected_of_lowerHalfPlane ?_ <| Set.inter_subset_right
@@ -308,8 +308,10 @@ lemma nnnorm_map (φ : F) (a : A) : ‖φ a‖₊ = ‖a‖₊ :=
 lemma norm_map (φ : F) (a : A) : ‖φ a‖ = ‖a‖ :=
   congr_arg NNReal.toReal (nnnorm_map φ a)
 
-lemma isometry (φ : F) : Isometry φ :=
-  AddMonoidHomClass.isometry_of_norm φ (norm_map φ)
+lemma isometric (φ : F) : Isometric φ :=
+  AddMonoidHomClass.isometric_of_norm φ (norm_map φ)
+
+@[deprecated (since := "2026-09-09")] alias isometry := isometric
 
 end StarAlgEquiv
 

--- a/Mathlib/Analysis/CStarAlgebra/Unitization.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Unitization.lean
@@ -15,7 +15,7 @@ show that every C⋆-algebra is a `RegularNormedAlgebra`.
 
 In addition, we show that in a `RegularNormedAlgebra` which is a `StarRing` for which the
 involution is isometric, that multiplication on the right is also an isometry (i.e.,
-`Isometry (ContinuousLinearMap.mul 𝕜 E).flip`).
+`Isometric (ContinuousLinearMap.mul 𝕜 E).flip`).
 -/
 
 public section
@@ -47,8 +47,10 @@ lemma opNNNorm_mul_flip_apply (a : E) : ‖(mul 𝕜 E).flip a‖₊ = ‖a‖�
 
 variable (E)
 
-lemma isometry_mul_flip : Isometry (mul 𝕜 E).flip :=
-  AddMonoidHomClass.isometry_of_norm _ (opNorm_mul_flip_apply 𝕜)
+lemma isometric_mul_flip : Isometric (mul 𝕜 E).flip :=
+  AddMonoidHomClass.isometric_of_norm _ (opNorm_mul_flip_apply 𝕜)
+
+@[deprecated (since := "2026-09-09")] alias isometry_mul_flip := isometric_mul_flip
 
 end ContinuousLinearMap
 
@@ -58,7 +60,7 @@ variable (E)
 
 /-- A C⋆-algebra over a densely normed field is a regular normed algebra. -/
 instance CStarRing.instRegularNormedAlgebra : RegularNormedAlgebra 𝕜 E where
-  isometry_mul' := AddMonoidHomClass.isometry_of_norm (mul 𝕜 E) fun a => NNReal.eq_iff.mp <|
+  isometric_mul' := AddMonoidHomClass.isometric_of_norm (mul 𝕜 E) fun a => NNReal.eq_iff.mp <|
     show ‖mul 𝕜 E a‖₊ = ‖a‖₊ by
     rw [← sSup_unitClosedBall_eq_nnnorm]
     refine csSup_eq_of_forall_le_of_forall_lt_exists_gt ?_ ?_ fun r hr => ?_

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -219,16 +219,18 @@ theorem conjLIE_apply (z : ℂ) : conjLIE z = conj z :=
 theorem conjLIE_symm : conjLIE.symm = conjLIE :=
   rfl
 
-theorem isometry_conj : Isometry (conj : ℂ → ℂ) :=
-  conjLIE.isometry
+theorem isometric_conj : Isometric (conj : ℂ → ℂ) :=
+  conjLIE.isometric
+
+@[deprecated (since := "2026-09-09")] alias isometry_conj := isometric_conj
 
 @[simp]
 theorem dist_conj_conj (z w : ℂ) : dist (conj z) (conj w) = dist z w :=
-  isometry_conj.dist_eq z w
+  isometric_conj.dist_eq z w
 
 @[simp]
 theorem nndist_conj_conj (z w : ℂ) : nndist (conj z) (conj w) = nndist z w :=
-  isometry_conj.nndist_eq z w
+  isometric_conj.nndist_eq z w
 
 theorem dist_conj_comm (z w : ℂ) : dist (conj z) w = dist z (conj w) := by
   rw [← dist_conj_conj, conj_conj]
@@ -286,19 +288,21 @@ def ofRealLI : ℝ →ₗᵢ[ℝ] ℂ :=
 @[simp]
 theorem ofRealLI_apply (x : ℝ) : ofRealLI x = x := rfl
 
-theorem isometry_ofReal : Isometry ((↑) : ℝ → ℂ) :=
-  ofRealLI.isometry
+theorem isometric_ofReal : Isometric ((↑) : ℝ → ℂ) :=
+  ofRealLI.isometric
+
+@[deprecated (since := "2026-09-09")] alias isometry_ofReal := isometric_ofReal
 
 @[continuity, fun_prop]
 theorem continuous_ofReal : Continuous ((↑) : ℝ → ℂ) :=
   ofRealLI.continuous
 
 theorem isUniformEmbedding_ofReal : IsUniformEmbedding ((↑) : ℝ → ℂ) :=
-  ofRealLI.isometry.isUniformEmbedding
+  ofRealLI.isometric.isUniformEmbedding
 
 lemma _root_.RCLike.isUniformEmbedding_ofReal {𝕜 : Type*} [RCLike 𝕜] :
     IsUniformEmbedding ((↑) : ℝ → 𝕜) :=
-  RCLike.ofRealLI.isometry.isUniformEmbedding
+  RCLike.ofRealLI.isometric.isUniformEmbedding
 
 theorem _root_.Filter.tendsto_ofReal_iff {α : Type*} {l : Filter α} {f : α → ℝ} {x : ℝ} :
     Tendsto (fun x ↦ (f x : ℂ)) l (𝓝 (x : ℂ)) ↔ Tendsto f l (𝓝 x) :=
@@ -434,12 +438,14 @@ def _root_.RCLike.complexLinearIsometryEquiv {𝕜 : Type*} [RCLike 𝕜]
     simp
   exact (RCLike.complexLinearIsometryEquiv h).norm_map a
 
-theorem isometry_intCast : Isometry ((↑) : ℤ → ℂ) :=
-  Isometry.of_dist_eq <| by simp_rw [← Complex.ofReal_intCast,
-    Complex.isometry_ofReal.dist_eq, Int.dist_cast_real, implies_true]
+theorem isometric_intCast : Isometric ((↑) : ℤ → ℂ) :=
+  Isometric.of_dist_eq <| by simp_rw [← Complex.ofReal_intCast,
+    Complex.isometric_ofReal.dist_eq, Int.dist_cast_real, implies_true]
+
+@[deprecated (since := "2026-09-09")] alias isometry_intCast := isometric_intCast
 
 theorem isClosedEmbedding_intCast : IsClosedEmbedding ((↑) : ℤ → ℂ) :=
-  isometry_intCast.isClosedEmbedding
+  isometric_intCast.isClosedEmbedding
 
 @[deprecated (since := "2026-04-15")] alias closedEmbedding_intCast := isClosedEmbedding_intCast
 

--- a/Mathlib/Analysis/Complex/Circle.lean
+++ b/Mathlib/Analysis/Complex/Circle.lean
@@ -208,7 +208,7 @@ variable {E : Type*} [SeminormedAddCommGroup E] [NormedSpace ℂ E] (u : Circle)
 @[simp] protected lemma enorm_smul : ‖u • v‖ₑ = ‖v‖ₑ := by simp [enorm_eq_nnnorm]
 
 instance : IsIsometricSMul Circle E :=
-  ⟨fun _ ↦ Isometry.of_dist_eq fun _ _ ↦ by simp [dist_eq_norm, ← smul_sub]⟩
+  ⟨fun _ ↦ Isometric.of_dist_eq fun _ _ ↦ by simp [dist_eq_norm, ← smul_sub]⟩
 
 end Norm
 

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
@@ -309,26 +309,32 @@ instance : ProperSpace ℍ := by
   rw [isEmbedding_coe.isCompact_iff (f := ((↑) : ℍ → ℂ)), image_coe_closedBall]
   apply isCompact_closedBall
 
-theorem isometry_vertical_line (a : ℝ) : Isometry fun y => mk ⟨a, exp y⟩ (exp_pos y) := by
-  refine Isometry.of_dist_eq fun y₁ y₂ => ?_
+theorem isometric_vertical_line (a : ℝ) : Isometric fun y => mk ⟨a, exp y⟩ (exp_pos y) := by
+  refine Isometric.of_dist_eq fun y₁ y₂ => ?_
   rw [dist_of_re_eq]
   exacts [congr_arg₂ _ (log_exp _) (log_exp _), rfl]
 
-theorem isometry_real_vadd (a : ℝ) : Isometry (a +ᵥ · : ℍ → ℍ) :=
-  Isometry.of_dist_eq fun y₁ y₂ => by simp only [dist_eq, coe_vadd, vadd_im, dist_add_left]
+@[deprecated (since := "2026-09-09")] alias isometry_vertical_line := isometric_vertical_line
 
-theorem isometry_pos_mul (a : { x : ℝ // 0 < x }) : Isometry (a • · : ℍ → ℍ) := by
-  refine Isometry.of_dist_eq fun y₁ y₂ => ?_
+theorem isometric_real_vadd (a : ℝ) : Isometric (a +ᵥ · : ℍ → ℍ) :=
+  Isometric.of_dist_eq fun y₁ y₂ => by simp only [dist_eq, coe_vadd, vadd_im, dist_add_left]
+
+@[deprecated (since := "2026-09-09")] alias isometry_real_vadd := isometric_real_vadd
+
+theorem isometric_pos_mul (a : { x : ℝ // 0 < x }) : Isometric (a • · : ℍ → ℍ) := by
+  refine Isometric.of_dist_eq fun y₁ y₂ => ?_
   simp only [dist_eq, coe_pos_real_smul, pos_real_im]; congr 2
   rw [dist_smul₀, mul_mul_mul_comm, Real.sqrt_mul (mul_self_nonneg _), Real.sqrt_mul_self_eq_abs,
     Real.norm_eq_abs, mul_left_comm]
   exact mul_div_mul_left _ _ (mt _root_.abs_eq_zero.1 a.2.ne')
 
+@[deprecated (since := "2026-09-09")] alias isometry_pos_mul := isometric_pos_mul
+
 /-- `SL(2, ℝ)` acts on the upper half plane as an isometry. -/
 instance : IsIsometricSMul SL(2, ℝ) ℍ :=
   ⟨fun g => by
-    have h₀ : Isometry (fun z => ModularGroup.S • z : ℍ → ℍ) :=
-      Isometry.of_dist_eq fun y₁ y₂ => by
+    have h₀ : Isometric (fun z => ModularGroup.S • z : ℍ → ℍ) :=
+      Isometric.of_dist_eq fun y₁ y₂ => by
         have h₁ : 0 ≤ im y₁ * im y₂ := by positivity
         have h₂ : ‖(y₁ * y₂ : ℂ)‖ ≠ 0 := by simp [y₁.ne_zero, y₂.ne_zero]
         simp_rw [modular_S_smul, inv_neg, dist_eq, dist_neg_neg,
@@ -338,10 +344,10 @@ instance : IsIsometricSMul SL(2, ℝ) ℍ :=
     by_cases hc : g 1 0 = 0
     · obtain ⟨u, v, h⟩ := exists_SL2_smul_eq_of_apply_zero_one_eq_zero g hc
       rw [h]
-      exact (isometry_real_vadd v).comp (isometry_pos_mul u)
+      exact (isometric_real_vadd v).comp (isometric_pos_mul u)
     · obtain ⟨u, v, w, h⟩ := exists_SL2_smul_eq_of_apply_zero_one_ne_zero g hc
       rw [h]
       exact
-        (isometry_real_vadd w).comp (h₀.comp <| (isometry_real_vadd v).comp <| isometry_pos_mul u)⟩
+        (isometric_real_vadd w).comp (h₀.comp <| (isometric_real_vadd v).comp <| isometric_pos_mul u)⟩
 
 end UpperHalfPlane

--- a/Mathlib/Analysis/Convex/Continuous.lean
+++ b/Mathlib/Analysis/Convex/Continuous.lean
@@ -228,7 +228,7 @@ lemma ConvexOn.locallyLipschitzOn_intrinsicInterior (hf : ConvexOn ℝ C f) :
   · simp
   have : Nonempty (affineSpan ℝ C) := ⟨⟨p, subset_affineSpan ℝ C hp⟩⟩
   set ψ := (AffineIsometryEquiv.constVSub ℝ (⟨p, subset_affineSpan ℝ C hp⟩ : affineSpan ℝ C)).symm
-  have hiso : Isometry (Subtype.val ∘ ⇑ψ) := isometry_subtype_coe.comp ψ.isometry
+  have hiso : Isometric (Subtype.val ∘ ⇑ψ) := isometry_subtype_coe.comp ψ.isometric
   have hL := (hf.comp_affineMap
     ((affineSpan ℝ C).subtype.comp ψ.toAffineEquiv.toAffineMap)).locallyLipschitzOn_interior
   refine (hiso.locallyLipschitzOn_image (by simpa using hL)).mono ?_

--- a/Mathlib/Analysis/Convex/LinearIsometry.lean
+++ b/Mathlib/Analysis/Convex/LinearIsometry.lean
@@ -63,7 +63,7 @@ instance LinearIsometry.strictConvexSpace_range [StrictConvexSpace 𝕜 E] (e : 
 lemma LinearIsometry.strictConvexSpace [StrictConvexSpace 𝕜 F] (f : E →ₗᵢ[𝕜] F) :
     StrictConvexSpace 𝕜 E where
   strictConvex_closedBall r hr := by
-    rw [← f.isometry.preimage_closedBall]
+    rw [← f.isometric.preimage_closedBall]
     exact (strictConvex_closedBall _ _ _).linearIsometry_preimage _
 
 /-- A vector subspace of a strict convex space is a strict convex space.

--- a/Mathlib/Analysis/Convex/StrictConvexBetween.lean
+++ b/Mathlib/Analysis/Convex/StrictConvexBetween.lean
@@ -133,12 +133,12 @@ lemma eq_midpoint_of_dist_eq_half (hx : dist x y = dist x z / 2) (hy : dist y z 
   · rwa [invOf_eq_inv, ← div_eq_inv_mul]
   · rwa [invOf_eq_inv, ← one_div, sub_half, one_div, ← div_eq_inv_mul]
 
-namespace Isometry
+namespace Isometric
 
 /-- An isometry of `NormedAddTorsor`s for real normed spaces, strictly convex in the case of the
 codomain, is an affine isometry.  Unlike Mazur-Ulam, this does not require the isometry to be
 surjective. -/
-noncomputable def affineIsometryOfStrictConvexSpace (hi : Isometry f) : PF →ᵃⁱ[ℝ] PE :=
+noncomputable def affineIsometryOfStrictConvexSpace (hi : Isometric f) : PF →ᵃⁱ[ℝ] PE :=
   { AffineMap.ofMapMidpoint f
       (fun x y => by
         apply eq_midpoint_of_dist_eq_half
@@ -149,10 +149,20 @@ noncomputable def affineIsometryOfStrictConvexSpace (hi : Isometry f) : PF →�
       hi.continuous with
     norm_map := fun x => by simp [AffineMap.ofMapMidpoint, ← dist_eq_norm_vsub E, hi.dist_eq] }
 
-@[simp] lemma coe_affineIsometryOfStrictConvexSpace (hi : Isometry f) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.affineIsometryOfStrictConvexSpace :=
+  affineIsometryOfStrictConvexSpace
+
+@[simp] lemma coe_affineIsometryOfStrictConvexSpace (hi : Isometric f) :
     ⇑hi.affineIsometryOfStrictConvexSpace = f := rfl
 
-@[simp] lemma affineIsometryOfStrictConvexSpace_apply (hi : Isometry f) (p : PF) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.coe_affineIsometryOfStrictConvexSpace :=
+  coe_affineIsometryOfStrictConvexSpace
+
+@[simp] lemma affineIsometryOfStrictConvexSpace_apply (hi : Isometric f) (p : PF) :
     hi.affineIsometryOfStrictConvexSpace p = f p := rfl
 
-end Isometry
+@[deprecated (since := "2026-09-10")]
+alias _root_.Isometry.affineIsometryOfStrictConvexSpace_apply :=
+  affineIsometryOfStrictConvexSpace_apply
+
+end Isometric

--- a/Mathlib/Analysis/Convex/StrictConvexSpace.lean
+++ b/Mathlib/Analysis/Convex/StrictConvexSpace.lean
@@ -33,7 +33,7 @@ In a strictly convex space, we prove
 - `norm_add_lt_of_not_sameRay`, `sameRay_iff_norm_add`, `dist_add_dist_eq_iff`:
   the triangle inequality `dist x y + dist y z ≤ dist x z` is a strict inequality unless `y` belongs
   to the segment `[x -[ℝ] z]`.
-- `Isometry.affineIsometryOfStrictConvexSpace`: an isometry of `NormedAddTorsor`s for real
+- `Isometric.affineIsometryOfStrictConvexSpace`: an isometry of `NormedAddTorsor`s for real
   normed spaces, strictly convex in the case of the codomain, is an affine isometry.
 
 We also provide several lemmas that can be used as alternative constructors for `StrictConvex ℝ E`:

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -857,9 +857,12 @@ theorem norm_map_iff_adjoint_comp_self (u : H →L[𝕜] K) :
     (∀ x : H, ‖u x‖ = ‖x‖) ↔ adjoint u ∘L u = 1 := by
   rw [LinearMap.norm_map_iff_inner_map_map u, u.inner_map_map_iff_adjoint_comp_self]
 
-theorem isometry_iff_adjoint_comp_self (u : H →L[𝕜] K) :
-    Isometry u ↔ adjoint u ∘L u = 1 := by
-  rw [AddMonoidHomClass.isometry_iff_norm, norm_map_iff_adjoint_comp_self]
+theorem isometric_iff_adjoint_comp_self (u : H →L[𝕜] K) :
+    Isometric u ↔ adjoint u ∘L u = 1 := by
+  rw [AddMonoidHomClass.isometric_iff_norm, norm_map_iff_adjoint_comp_self]
+
+@[deprecated (since := "2026-09-09")] alias isometry_iff_adjoint_comp_self :=
+  isometric_iff_adjoint_comp_self
 
 @[simp]
 lemma _root_.LinearIsometryEquiv.adjoint_eq_symm (e : H ≃ₗᵢ[𝕜] K) :
@@ -1069,7 +1072,7 @@ theorem LinearIsometry.adjoint_comp_self {E E' : Type*}
     [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]
     [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E'] [CompleteSpace E'] (f : E →ₗᵢ[𝕜] E') :
     f.toContinuousLinearMap.adjoint ∘L f.toContinuousLinearMap = 1 :=
-  f.toContinuousLinearMap.isometry_iff_adjoint_comp_self.mp f.isometry
+  f.toContinuousLinearMap.isometric_iff_adjoint_comp_self.mp f.isometric
 
 /-- A version of `LinearIsometry.adjoint_comp_self` in terms of `LinearMap.adjoint`. -/
 @[simp]

--- a/Mathlib/Analysis/InnerProductSpace/NormDet.lean
+++ b/Mathlib/Analysis/InnerProductSpace/NormDet.lean
@@ -405,13 +405,13 @@ theorem hausdorffMeasure_image [MeasurableSpace U] [BorelSpace U] [MeasurableSpa
         ((g.symm.toLinearIsometry.toLinearMap ∘ₗ f.rangeRestrict) '' s)) =
         ENNReal.ofReal f.normDet * μH[finrank ℝ U] s by
       simpa [Set.image_image]
-    rw [(LinearIsometry.isometry _).hausdorffMeasure_image (by simp),
+    rw [(LinearIsometry.isometric _).hausdorffMeasure_image (by simp),
       addHaar_image_linearMap μH[finrank ℝ U], ← normDet_eq_abs_det,
       normDet_comp_of_finrank_eq _ _ hrank.symm, g.symm.toLinearIsometry.normDet_eq_one]
     simp
   · suffices μH[finrank ℝ U] (f.range.subtypeₗᵢ '' (f.rangeRestrict '' s)) = 0 by
       simpa [(f.normDet_eq_zero_tfae.out 2 1).mp h, Set.image_image]
-    rw [(LinearIsometry.isometry _).hausdorffMeasure_image (by simp)]
+    rw [(LinearIsometry.isometric _).hausdorffMeasure_image (by simp)]
     have h : (finrank ℝ f.range : ℝ) < finrank ℝ U := by
       exact_mod_cast (f.normDet_eq_zero_tfae.out 2 4).mp h
     simp [Real.hausdorffMeasure_of_finrank_lt h]

--- a/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
@@ -370,7 +370,7 @@ private def equivAux (h : kernel H = kernel H') : OfKernel (kernel H) ≃ₗᵢ[
   .ofSurjective (toH' H h).fromCompletion <| by
     have h_sub : Set.range (toH' H h) ⊆ Set.range ⇑(toH' H h).fromCompletion := by
       rintro _ ⟨f, rfl⟩
-      exact ⟨f, UniformSpace.Completion.extension_coe (toH' H h).isometry.uniformContinuous f⟩
+      exact ⟨f, UniformSpace.Completion.extension_coe (toH' H h).isometric.uniformContinuous f⟩
     have h_dense : Dense (Set.range (toH' H h)) := by
       convert dense_iff_topologicalClosure_eq_top.mpr (kerFun_dense H')
       simp only [LinearIsometry.coe_mk, toH', ← LinearMap.coe_range,
@@ -378,7 +378,7 @@ private def equivAux (h : kernel H = kernel H') : OfKernel (kernel H) ≃ₗᵢ[
       congr! 1
       aesop
     rw [← Set.range_eq_univ,
-      ← (toH' H h).fromCompletion.isometry.isClosedEmbedding.isClosed_range.closure_eq,
+      ← (toH' H h).fromCompletion.isometric.isClosedEmbedding.isClosed_range.closure_eq,
       (h_dense.mono h_sub).closure_eq]
 
 end Equiv
@@ -397,7 +397,7 @@ private lemma toH'_apply_single (h : kernel H = kernel H') (x : X) (v : V) :
 private lemma equivAux_apply_coe (h : kernel H = kernel H') (x₀ : H₀ (kernel H)) :
     OfKernel.equivAux h x₀ = OfKernel.toH' H h x₀ := by
   simpa [OfKernel.equivAux]
-    using UniformSpace.Completion.extension_coe (OfKernel.toH' H h).isometry.uniformContinuous _
+    using UniformSpace.Completion.extension_coe (OfKernel.toH' H h).isometric.uniformContinuous _
 
 /-- If the two RKHS have the same kernel, then they are isometrically isomorphic. -/
 def equiv (h : kernel H = kernel H') : H ≃ₗᵢ[𝕜] H' :=

--- a/Mathlib/Analysis/InnerProductSpace/l2Space.lean
+++ b/Mathlib/Analysis/InnerProductSpace/l2Space.lean
@@ -250,7 +250,7 @@ protected theorem range_linearIsometry [∀ i, CompleteSpace (G i)] :
       rintro i x ⟨x, rfl⟩
       use lp.single 2 i x
       exact hV.linearIsometry_apply_single x
-    exact hV.linearIsometry.isometry.isUniformInducing.isComplete_range.isClosed
+    exact hV.linearIsometry.isometric.isUniformInducing.isComplete_range.isClosed
 
 end OrthogonalFamily
 

--- a/Mathlib/Analysis/Matrix/Order.lean
+++ b/Mathlib/Analysis/Matrix/Order.lean
@@ -360,11 +360,11 @@ instance instIsometricContinuousFunctionalCalculus [DecidableEq n] :
     IsometricContinuousFunctionalCalculus ℝ (Matrix n n 𝕜) IsSelfAdjoint where
   isometric A hA := by
     rw [← isHermitian_iff_isSelfAdjoint] at hA
-    rw [IsHermitian.cfcHom_eq_cfcAux hA, AddMonoidHomClass.isometry_iff_norm]
+    rw [IsHermitian.cfcHom_eq_cfcAux hA, AddMonoidHomClass.isometric_iff_norm]
     intro f
     simp only [IsHermitian.cfcAux_apply, Unitary.conjStarAlgAut_apply, ← Unitary.coe_star,
       CStarRing.norm_mul_coe_unitary, CStarRing.norm_coe_unitary_mul, l2_opNorm_diagonal]
-    rw [((algebraMap_isometry ℝ 𝕜).postcomp_pi).norm_map_of_map_zero (by ext; simp)]
+    rw [((algebraMap_isometric ℝ 𝕜).postcomp_pi).norm_map_of_map_zero (by ext; simp)]
     let : Fintype (spectrum ℝ A) := .ofFinite _
     rw [ContinuousMap.norm_eq_norm_coeFn]
     refine Function.Surjective.pi_norm_comp ?_ _

--- a/Mathlib/Analysis/Normed/Affine/Isometry.lean
+++ b/Mathlib/Analysis/Normed/Affine/Isometry.lean
@@ -140,11 +140,13 @@ theorem nndist_map (x y : P) : nndist (f x) (f y) = nndist x y := by simp [nndis
 @[simp]
 theorem edist_map (x y : P) : edist (f x) (f y) = edist x y := by simp [edist_dist]
 
-protected theorem isometry : Isometry f :=
+protected theorem isometric : Isometric f :=
   f.edist_map
 
+@[deprecated (since := "2026-09-10")] alias isometry := AffineIsometry.isometric
+
 protected theorem injective : Injective f₁ :=
-  f₁.isometry.injective
+  f₁.isometric.injective
 
 @[simp]
 theorem map_eq_iff {x y : P₁'} : f₁ x = f₁ y ↔ x = y :=
@@ -154,26 +156,26 @@ theorem map_ne {x y : P₁'} (h : x ≠ y) : f₁ x ≠ f₁ y :=
   f₁.injective.ne h
 
 protected theorem lipschitz : LipschitzWith 1 f :=
-  f.isometry.lipschitzWith
+  f.isometric.lipschitzWith
 
 protected theorem antilipschitz : AntilipschitzWith 1 f :=
-  f.isometry.antilipschitzWith
+  f.isometric.antilipschitzWith
 
 @[continuity]
 protected theorem continuous : Continuous f :=
-  f.isometry.continuous
+  f.isometric.continuous
 
 theorem ediam_image (s : Set P) : ediam (f '' s) = ediam s :=
-  f.isometry.ediam_image s
+  f.isometric.ediam_image s
 
 theorem ediam_range : ediam (range f) = ediam (univ : Set P) :=
-  f.isometry.ediam_range
+  f.isometric.ediam_range
 
 theorem diam_image (s : Set P) : Metric.diam (f '' s) = Metric.diam s :=
-  f.isometry.diam_image s
+  f.isometric.diam_image s
 
 theorem diam_range : Metric.diam (range f) = Metric.diam (univ : Set P) :=
-  f.isometry.diam_range
+  f.isometric.diam_range
 
 /-- Interpret an affine isometry as a continuous affine map. -/
 def toContinuousAffineMap : P →ᴬ[𝕜] P₂ := { f with cont := f.continuous }
@@ -193,7 +195,7 @@ theorem coe_toContinuousAffineMap : ⇑f.toContinuousAffineMap = f := rfl
 @[simp]
 theorem comp_continuous_iff {α : Type*} [TopologicalSpace α] {g : α → P} :
     Continuous (f ∘ g) ↔ Continuous g :=
-  f.isometry.comp_continuous_iff
+  f.isometric.comp_continuous_iff
 
 /-- The identity affine isometry. -/
 def id : P →ᵃⁱ[𝕜] P :=
@@ -404,12 +406,14 @@ namespace AffineIsometryEquiv
 
 variable (e : P ≃ᵃⁱ[𝕜] P₂)
 
-protected theorem isometry : Isometry e :=
-  e.toAffineIsometry.isometry
+protected theorem isometric : Isometric e :=
+  e.toAffineIsometry.isometric
+
+@[deprecated (since := "2026-09-10")] alias isometry := AffineIsometryEquiv.isometric
 
 /-- Reinterpret an `AffineIsometryEquiv` as an `IsometryEquiv`. -/
 def toIsometryEquiv : P ≃ᵢ P₂ :=
-  ⟨e.toAffineEquiv.toEquiv, e.isometry⟩
+  ⟨e.toAffineEquiv.toEquiv, e.isometric⟩
 
 @[simp]
 theorem coe_toIsometryEquiv : ⇑e.toIsometryEquiv = e :=
@@ -428,7 +432,7 @@ theorem coe_toHomeomorph : ⇑e.toHomeomorph = e :=
   rfl
 
 protected theorem continuous : Continuous e :=
-  e.isometry.continuous
+  e.isometric.continuous
 
 protected theorem continuousAt {x} : ContinuousAt e x :=
   e.continuous.continuousAt
@@ -633,28 +637,28 @@ theorem map_ne {x y : P} (h : x ≠ y) : e x ≠ e y :=
   e.injective.ne h
 
 protected theorem lipschitz : LipschitzWith 1 e :=
-  e.isometry.lipschitzWith
+  e.isometric.lipschitzWith
 
 protected theorem antilipschitz : AntilipschitzWith 1 e :=
-  e.isometry.antilipschitzWith
+  e.isometric.antilipschitzWith
 
 @[simp]
 theorem ediam_image (s : Set P) : ediam (e '' s) = ediam s :=
-  e.isometry.ediam_image s
+  e.isometric.ediam_image s
 
 @[simp]
 theorem diam_image (s : Set P) : Metric.diam (e '' s) = Metric.diam s :=
-  e.isometry.diam_image s
+  e.isometric.diam_image s
 
 variable {α : Type*} [TopologicalSpace α]
 
 @[simp]
 theorem comp_continuousOn_iff {f : α → P} {s : Set α} : ContinuousOn (e ∘ f) s ↔ ContinuousOn f s :=
-  e.isometry.comp_continuousOn_iff
+  e.isometric.comp_continuousOn_iff
 
 @[simp]
 theorem comp_continuous_iff {f : α → P} : Continuous (e ∘ f) ↔ Continuous f :=
-  e.isometry.comp_continuous_iff
+  e.isometric.comp_continuous_iff
 
 section Constructions
 
@@ -749,9 +753,9 @@ theorem constVAdd_zero : constVAdd 𝕜 P (0 : V) = refl 𝕜 P :=
 include 𝕜 in
 /-- The map `g` from `V` to `V₂` corresponding to a map `f` from `P` to `P₂`, at a base point `p`,
 is an isometry if `f` is one. -/
-theorem vadd_vsub {f : P → P₂} (hf : Isometry f) {p : P} {g : V → V₂}
-    (hg : ∀ v, g v = f (v +ᵥ p) -ᵥ f p) : Isometry g := by
-  convert! (vaddConst 𝕜 (f p)).symm.isometry.comp (hf.comp (vaddConst 𝕜 p).isometry)
+theorem vadd_vsub {f : P → P₂} (hf : Isometric f) {p : P} {g : V → V₂}
+    (hg : ∀ v, g v = f (v +ᵥ p) -ᵥ f p) : Isometric g := by
+  convert! (vaddConst 𝕜 (f p)).symm.isometric.comp (hf.comp (vaddConst 𝕜 p).isometric)
   exact funext hg
 
 variable (𝕜) in

--- a/Mathlib/Analysis/Normed/Algebra/GelfandFormula.lean
+++ b/Mathlib/Analysis/Normed/Algebra/GelfandFormula.lean
@@ -192,7 +192,7 @@ theorem algebraMap_eq_of_mem (hA : ∀ {a : A}, IsUnit a ↔ a ≠ 0) {a : A} {z
 
 /-- **Gelfand-Mazur theorem**: For a complex Banach division algebra, the natural `algebraMap ℂ A`
 is an algebra isomorphism whose inverse is given by selecting the (unique) element of
-`spectrum ℂ a`. In addition, `algebraMap_isometry` guarantees this map is an isometry.
+`spectrum ℂ a`. In addition, `algebraMap_isometric` guarantees this map is an isometry.
 
 Note: because `NormedDivisionRing` requires the field `norm_mul : ∀ a b, ‖a * b‖ = ‖a‖ * ‖b‖`, we
 don't use this type class and instead opt for a `NormedRing` in which the nonzero elements are

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -719,7 +719,7 @@ lemma QuasispectrumRestricts.spectralRadius_eq {𝕜₁ 𝕜₂ A : Type*} [Norm
     {f : 𝕜₂ → 𝕜₁} {a : A} (h : QuasispectrumRestricts a f) :
     spectralRadius 𝕜₁ a = spectralRadius 𝕜₂ a := by
   rw [spectralRadius, spectralRadius]
-  have := algebraMap_isometry 𝕜₁ 𝕜₂ |>.nnnorm_map_of_map_zero (map_zero _)
+  have := algebraMap_isometric 𝕜₁ 𝕜₂ |>.nnnorm_map_of_map_zero (map_zero _)
   apply le_antisymm
   all_goals apply iSup₂_le fun x hx ↦ ?_
   · refine congr_arg ((↑) : ℝ≥0 → ℝ≥0∞) (this x) |>.symm.trans_le <| le_iSup₂ (α := ℝ≥0∞) _ ?_
@@ -850,7 +850,7 @@ theorem upperHemicontinuous_quasispectrum [NontriviallyNormedField 𝕜] [Proper
     UpperHemicontinuous (quasispectrum 𝕜 : A → Set 𝕜) := by
   convert!
     upperHemicontinuous_spectrum 𝕜 (WithLp 1 (Unitization 𝕜 A)) |>.comp
-      unitization_isometry_inr.continuous
+      unitization_isometric_inr.continuous
   ext1 a
   rw [quasispectrum_eq_spectrum_toLp_inr]
   congr

--- a/Mathlib/Analysis/Normed/Algebra/Unitization.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Unitization.lean
@@ -16,7 +16,7 @@ Given a not-necessarily-unital normed `𝕜`-algebra `A`, it is frequently of in
 two properties:
 
 - `‖1‖ = 1` (i.e., `NormOneClass`)
-- The embedding of `A` in `Unitization 𝕜 A` is an isometry. (i.e., `Isometry Unitization.inr`)
+- The embedding of `A` in `Unitization 𝕜 A` is an isometry. (i.e., `Isometric Unitization.inr`)
 
 One way to do this is to pull back the norm from `WithLp 1 (𝕜 × A)`, that is,
 `‖(k, a)‖ = ‖k‖ + ‖a‖` using `Unitization.addEquiv` (i.e., the identity map).
@@ -46,7 +46,7 @@ is then also a C⋆-norm.
 - `Unitization.instNormedRing`, `Unitization.instNormedAlgebra`, `Unitization.instNormOneClass`,
   `Unitization.instCompleteSpace`: when `A` is a non-unital Banach `𝕜`-algebra with a regular norm,
   then `Unitization 𝕜 A` is a unital Banach `𝕜`-algebra with `‖1‖ = 1`.
-- `Unitization.norm_inr`, `Unitization.isometry_inr`: the natural inclusion `A → Unitization 𝕜 A`
+- `Unitization.norm_inr`, `Unitization.isometric_inr`: the natural inclusion `A → Unitization 𝕜 A`
   is an isometry, or in mathematical parlance, the norm on `A` extends to a norm on
   `Unitization 𝕜 A`.
 
@@ -109,7 +109,7 @@ variable (𝕜 A)
 /-- In a `RegularNormedAlgebra`, the map `Unitization.splitMul 𝕜 A` is injective.
 We will use this to pull back the norm from `𝕜 × (A →L[𝕜] A)` to `Unitization 𝕜 A`. -/
 theorem splitMul_injective : Function.Injective (splitMul 𝕜 A) :=
-  splitMul_injective_of_clm_mul_injective (isometry_mul 𝕜 A).injective
+  splitMul_injective_of_clm_mul_injective (isometric_mul 𝕜 A).injective
 
 variable {𝕜 A}
 
@@ -161,7 +161,7 @@ theorem lipschitzWith_addEquiv :
     rw [two_mul]
     calc
       ‖x.snd‖ = ‖mul 𝕜 A x.snd‖ :=
-        .symm <| (isometry_mul 𝕜 A).norm_map_of_map_zero (map_zero _) _
+        .symm <| (isometric_mul 𝕜 A).norm_map_of_map_zero (map_zero _) _
       _ ≤ ‖algebraMap 𝕜 _ x.fst + mul 𝕜 A x.snd‖ + ‖x.fst‖ := by
         simpa only [add_comm _ (mul 𝕜 A x.snd), norm_algebraMap'] using
           norm_le_add_norm_add (mul 𝕜 A x.snd) (algebraMap 𝕜 _ x.fst)
@@ -179,7 +179,7 @@ theorem antilipschitzWith_addEquiv :
       ‖algebraMap 𝕜 _ x.fst + mul 𝕜 A x.snd‖ ≤ ‖algebraMap 𝕜 _ x.fst‖ + ‖mul 𝕜 A x.snd‖ :=
         norm_add_le _ _
       _ = ‖x.fst‖ + ‖x.snd‖ := by
-        rw [norm_algebraMap', (AddMonoidHomClass.isometry_iff_norm (mul 𝕜 A)).mp (isometry_mul 𝕜 A)]
+        rw [norm_algebraMap', (AddMonoidHomClass.isometric_iff_norm (mul 𝕜 A)).mp (isometric_mul 𝕜 A)]
       _ ≤ _ := (add_le_add (le_max_left _ _) (le_max_right _ _)).trans_eq (two_mul _).symm
 
 open Bornology Filter
@@ -253,18 +253,20 @@ lemma norm_inr (a : A) : ‖(a : Unitization 𝕜 A)‖ = ‖a‖ := by
 lemma nnnorm_inr (a : A) : ‖(a : Unitization 𝕜 A)‖₊ = ‖a‖₊ :=
   NNReal.eq <| norm_inr a
 
-lemma isometry_inr : Isometry ((↑) : A → Unitization 𝕜 A) :=
-  AddMonoidHomClass.isometry_of_norm (inrNonUnitalAlgHom 𝕜 A) norm_inr
+lemma isometric_inr : Isometric ((↑) : A → Unitization 𝕜 A) :=
+  AddMonoidHomClass.isometric_of_norm (inrNonUnitalAlgHom 𝕜 A) norm_inr
+
+@[deprecated (since := "2026-09-09")] alias isometry_inr := isometric_inr
 
 @[fun_prop]
 theorem continuous_inr : Continuous (inr : A → Unitization 𝕜 A) :=
-  isometry_inr.continuous
+  isometric_inr.continuous
 
 lemma dist_inr (a b : A) : dist (a : Unitization 𝕜 A) (b : Unitization 𝕜 A) = dist a b :=
-  isometry_inr.dist_eq a b
+  isometric_inr.dist_eq a b
 
 lemma nndist_inr (a b : A) : nndist (a : Unitization 𝕜 A) (b : Unitization 𝕜 A) = nndist a b :=
-  isometry_inr.nndist_eq a b
+  isometric_inr.nndist_eq a b
 
 /-! These examples verify that the bornology and uniformity (hence also the topology) are the
 correct ones. -/

--- a/Mathlib/Analysis/Normed/Algebra/UnitizationL1.lean
+++ b/Mathlib/Analysis/Normed/Algebra/UnitizationL1.lean
@@ -78,10 +78,12 @@ lemma unitization_norm_inr (x : A) : ‖toLp 1 (x : Unitization 𝕜 A)‖ = ‖
 lemma unitization_nnnorm_inr (x : A) : ‖toLp 1 (x : Unitization 𝕜 A)‖₊ = ‖x‖₊ := by
   simp [unitization_nnnorm_def]
 
-lemma unitization_isometry_inr : Isometry fun x : A ↦ toLp 1 (x : Unitization 𝕜 A) :=
-  AddMonoidHomClass.isometry_of_norm
+lemma unitization_isometric_inr : Isometric fun x : A ↦ toLp 1 (x : Unitization 𝕜 A) :=
+  AddMonoidHomClass.isometric_of_norm
     ((WithLp.linearEquiv 1 𝕜 (Unitization 𝕜 A)).symm.comp <| Unitization.inrHom 𝕜 𝕜 A)
     unitization_norm_inr
+
+@[deprecated (since := "2026-09-09")] alias unitization_isometry_inr := unitization_isometric_inr
 
 variable [IsScalarTower 𝕜 A A] [SMulCommClass 𝕜 A A]
 

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -27,7 +27,7 @@ given in:
 
 -- Guard against import creep.
 assert_not_exists AddChar comap_norm_atTop DilationEquiv Finset.sup_mul_le_mul_sup_of_nonneg
-  IsOfFinOrder Isometry.norm_map_of_map_one NNReal.isOpen_Ico_zero Rat.norm_cast_real
+  IsOfFinOrder Isometric.norm_map_of_map_one NNReal.isOpen_Ico_zero Rat.norm_cast_real
   RestrictScalars
 
 variable {α β : Type*}

--- a/Mathlib/Analysis/Normed/Field/WithAbs.lean
+++ b/Mathlib/Analysis/Normed/Field/WithAbs.lean
@@ -107,7 +107,7 @@ variable {L : Type*} [NormedField L] [CompleteSpace L] {f : WithAbs v →+* L} {
 
 /-- If the absolute value of a normed field factors through an embedding into another normed field
 that is locally compact, then the completion of the first normed field is also locally compact. -/
-theorem locallyCompactSpace [LocallyCompactSpace L] (h : Isometry f) :
+theorem locallyCompactSpace [LocallyCompactSpace L] (h : Isometric f) :
     LocallyCompactSpace v.Completion :=
   h.completion_extension.isClosedEmbedding.locallyCompactSpace
 

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -47,7 +47,7 @@ variable {α V P W Q : Type*} [SeminormedAddCommGroup V] [PseudoMetricSpace P] [
   [SeminormedAddCommGroup W] [PseudoMetricSpace Q] [NormedAddTorsor W Q]
 
 instance (priority := 100) NormedAddTorsor.to_isIsIsometricVAdd : IsIsometricVAdd V P :=
-  ⟨fun c => Isometry.of_dist_eq fun x y => by
+  ⟨fun c => Isometric.of_dist_eq fun x y => by
     simp [NormedAddTorsor.dist_eq_norm']⟩
 
 /-- A `SeminormedAddCommGroup` is a `NormedAddTorsor` over itself. -/
@@ -120,12 +120,12 @@ theorem dist_vadd_right (v : V) (x : P) : dist x (v +ᵥ x) = ‖v‖ := by rw [
 theorem nndist_vadd_right (v : V) (x : P) : nndist x (v +ᵥ x) = ‖v‖₊ :=
   NNReal.eq <| dist_vadd_right _ _
 
-/-- Isometry between the tangent space `V` of a (semi)normed add torsor `P` and `P` given by
+/-- Isometric between the tangent space `V` of a (semi)normed add torsor `P` and `P` given by
 addition/subtraction of `x : P`. -/
 @[simps!]
 def IsometryEquiv.vaddConst (x : P) : V ≃ᵢ P where
   toEquiv := Equiv.vaddConst x
-  isometry_toFun := Isometry.of_dist_eq fun _ _ => dist_vadd_cancel_right _ _ _
+  isometry_toFun := Isometric.of_dist_eq fun _ _ => dist_vadd_cancel_right _ _ _
 
 @[simp]
 theorem dist_vsub_cancel_left (x y z : P) : dist (x -ᵥ y) (x -ᵥ z) = dist y z := by
@@ -135,12 +135,12 @@ theorem dist_vsub_cancel_left (x y z : P) : dist (x -ᵥ y) (x -ᵥ z) = dist y 
 theorem nndist_vsub_cancel_left (x y z : P) : nndist (x -ᵥ y) (x -ᵥ z) = nndist y z :=
   NNReal.eq <| dist_vsub_cancel_left _ _ _
 
-/-- Isometry between the tangent space `V` of a (semi)normed add torsor `P` and `P` given by
+/-- Isometric between the tangent space `V` of a (semi)normed add torsor `P` and `P` given by
 subtraction from `x : P`. -/
 @[simps!]
 def IsometryEquiv.constVSub (x : P) : P ≃ᵢ V where
   toEquiv := Equiv.constVSub x
-  isometry_toFun := Isometry.of_dist_eq fun _ _ => dist_vsub_cancel_left _ _ _
+  isometry_toFun := Isometric.of_dist_eq fun _ _ => dist_vsub_cancel_left _ _ _
 
 @[simp]
 theorem dist_vsub_cancel_right (x y z : P) : dist (x -ᵥ z) (y -ᵥ z) = dist x y :=

--- a/Mathlib/Analysis/Normed/Group/Hom.lean
+++ b/Mathlib/Analysis/Normed/Group/Hom.lean
@@ -727,22 +727,30 @@ theorem neg_iff {f : NormedAddGroupHom V₁ V₂} : (-f).NormNoninc ↔ f.NormNo
 
 end NormNoninc
 
-section Isometry
+section Isometric
 
-theorem norm_eq_of_isometry {f : NormedAddGroupHom V W} (hf : Isometry f) (v : V) : ‖f v‖ = ‖v‖ :=
-  (AddMonoidHomClass.isometry_iff_norm f).mp hf v
+theorem norm_eq_of_isometric {f : NormedAddGroupHom V W} (hf : Isometric f) (v : V) : ‖f v‖ = ‖v‖ :=
+  (AddMonoidHomClass.isometric_iff_norm f).mp hf v
 
-theorem isometry_id : @Isometry V V _ _ (id V) :=
-  _root_.isometry_id
+@[deprecated (since := "2026-09-09")] alias norm_eq_of_isometry := norm_eq_of_isometric
 
-theorem isometry_comp {g : NormedAddGroupHom V₂ V₃} {f : NormedAddGroupHom V₁ V₂} (hg : Isometry g)
-    (hf : Isometry f) : Isometry (g.comp f) :=
+theorem isometric_id : @Isometric V V _ _ (id V) :=
+  _root_.isometric_id
+
+@[deprecated (since := "2026-09-09")] alias isometry_id := isometric_id
+
+theorem isometric_comp {g : NormedAddGroupHom V₂ V₃} {f : NormedAddGroupHom V₁ V₂}
+    (hg : Isometric g) (hf : Isometric f) : Isometric (g.comp f) :=
   hg.comp hf
 
-theorem normNoninc_of_isometry (hf : Isometry f) : f.NormNoninc := fun v =>
-  le_of_eq <| norm_eq_of_isometry hf v
+@[deprecated (since := "2026-09-09")] alias isometry_comp := isometric_comp
 
-end Isometry
+theorem normNoninc_of_isometric (hf : Isometric f) : f.NormNoninc := fun v =>
+  le_of_eq <| norm_eq_of_isometric hf v
+
+@[deprecated (since := "2026-09-09")] alias normNoninc_of_isometry := normNoninc_of_isometric
+
+end Isometric
 
 variable {W₁ W₂ W₃ : Type*} [SeminormedAddCommGroup W₁] [SeminormedAddCommGroup W₂]
   [SeminormedAddCommGroup W₃]

--- a/Mathlib/Analysis/Normed/Group/Pointwise.lean
+++ b/Mathlib/Analysis/Normed/Group/Pointwise.lean
@@ -40,7 +40,7 @@ theorem Bornology.IsBounded.mul (hs : IsBounded s) (ht : IsBounded t) : IsBounde
 theorem Bornology.IsBounded.of_mul (hst : IsBounded (s * t)) : IsBounded s ∨ IsBounded t := by
   symm
   exact AntilipschitzWith.isBounded_of_image2_left _
-    (fun x => (isometry_mul_left x).antilipschitzWith)
+    (fun x => (isometric_mul_left x).antilipschitzWith)
     (by rwa [image2_swap])
 
 @[to_additive]
@@ -64,7 +64,7 @@ open EMetric
 
 @[to_additive (attr := simp)]
 theorem infEDist_inv_inv (x : E) (s : Set E) : infEDist x⁻¹ s⁻¹ = infEDist x s := by
-  rw [← image_inv_eq_inv, infEDist_image isometry_inv]
+  rw [← image_inv_eq_inv, infEDist_image isometric_inv]
 
 @[to_additive]
 theorem infEDist_inv (x : E) (s : Set E) : infEDist x⁻¹ s = infEDist x s⁻¹ := by
@@ -73,8 +73,8 @@ theorem infEDist_inv (x : E) (s : Set E) : infEDist x⁻¹ s = infEDist x s⁻¹
 @[to_additive]
 theorem ediam_mul_le (x y : Set E) : ediam (x * y) ≤ ediam x + ediam y :=
   (LipschitzOnWith.ediam_image2_le (· * ·) _ _
-        (fun _ _ => (isometry_mul_right _).lipschitzWith.lipschitzOnWith) fun _ _ =>
-        (isometry_mul_left _).lipschitzWith.lipschitzOnWith).trans_eq <|
+        (fun _ _ => (isometric_mul_right _).lipschitzWith.lipschitzOnWith) fun _ _ =>
+        (isometric_mul_left _).lipschitzWith.lipschitzOnWith).trans_eq <|
     by simp only [ENNReal.coe_one, one_mul]
 
 end EMetric

--- a/Mathlib/Analysis/Normed/Group/Quotient.lean
+++ b/Mathlib/Analysis/Normed/Group/Quotient.lean
@@ -241,8 +241,8 @@ def _root_.Subgroup.quotientIsometryEquivOfEq (h : S = T) : M ⧸ S ≃ᵢ M ⧸
 @[to_additive /-- An isometric version of `QuotientAddGroup.quotientBot`. -/]
 def quotientBotIsometryEquiv : M ⧸ (⊥ : Subgroup M) ≃ᵢ M where
   __ := quotientBot
-  isometry_toFun : Isometry quotientBot := by
-    rw [MonoidHomClass.isometry_iff_norm]
+  isometry_toFun : Isometric quotientBot := by
+    rw [MonoidHomClass.isometric_iff_norm]
     rintro ⟨x⟩
     change ‖x‖ = ‖QuotientGroup.mk x‖
     simp [norm_mk]
@@ -251,8 +251,8 @@ def quotientBotIsometryEquiv : M ⧸ (⊥ : Subgroup M) ≃ᵢ M where
 @[to_additive /-- An isometric version of `QuotientAddGroup.quotientQuotientEquivQuotient`. -/]
 def quotientQuotientIsometryEquivQuotient (h : S ≤ T) : (M ⧸ S) ⧸ T.map (mk' S) ≃ᵢ M ⧸ T where
   __ := quotientQuotientEquivQuotient S T h
-  isometry_toFun : Isometry (quotientQuotientEquivQuotient S T h) := by
-    rw [MonoidHomClass.isometry_iff_norm]
+  isometry_toFun : Isometric (quotientQuotientEquivQuotient S T h) := by
+    rw [MonoidHomClass.isometric_iff_norm]
     refine fun x => eq_of_forall_le_iff fun r => ?_
     simp only [le_norm_iff]
     exact ⟨
@@ -268,7 +268,7 @@ variable {M N : Type*} [SeminormedAddCommGroup M] [SeminormedAddCommGroup N]
 /-- The norm of the image under the natural morphism to the quotient. -/
 theorem quotient_norm_mk_eq (S : AddSubgroup M) (m : M) :
     ‖mk' S m‖ = sInf ((‖m + ·‖) '' S) := by
-  rw [mk'_apply, norm_mk, sInf_image', ← infDist_image isometry_neg, image_neg_eq_neg,
+  rw [mk'_apply, norm_mk, sInf_image', ← infDist_image isometric_neg, image_neg_eq_neg,
     neg_coe_set (H := S), infDist_eq_iInf]
   simp only [dist_eq_norm', sub_neg_eq_add, add_comm]
 
@@ -475,7 +475,7 @@ def Submodule.quotLIEOfEq (h : S = T) : M ⧸ S ≃ₗᵢ[R] M ⧸ T where
 def Submodule.quotientQuotientLIEQuotient (h : S ≤ T) : (M ⧸ S) ⧸ map S.mkQ T ≃ₗᵢ[R] M ⧸ T where
   __ := Submodule.quotientQuotientEquivQuotient S T h
   norm_map' :=
-    (AddMonoidHomClass.isometry_iff_norm _).mp
+    (AddMonoidHomClass.isometric_iff_norm _).mp
       (QuotientAddGroup.quotientQuotientIsometryEquivQuotient
         ((Submodule.toAddSubgroup_le S T).mpr h)).isometry
 

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
@@ -157,14 +157,17 @@ theorem isZero_of_subsingleton (V : SemiNormedGrp) [Subsingleton V] : Limits.IsZ
 instance hasZeroObject : Limits.HasZeroObject SemiNormedGrp.{u} :=
   ⟨⟨of PUnit, isZero_of_subsingleton _⟩⟩
 
-theorem iso_isometry_of_normNoninc {V W : SemiNormedGrp} (i : V ≅ W) (h1 : i.hom.hom.NormNoninc)
-    (h2 : i.inv.hom.NormNoninc) : Isometry i.hom := by
-  apply AddMonoidHomClass.isometry_of_norm
+theorem iso_isometric_of_normNoninc {V W : SemiNormedGrp} (i : V ≅ W) (h1 : i.hom.hom.NormNoninc)
+    (h2 : i.inv.hom.NormNoninc) : Isometric i.hom := by
+  apply AddMonoidHomClass.isometric_of_norm
   intro v
   apply le_antisymm (h1 v)
   calc
     ‖v‖ = ‖i.inv (i.hom v)‖ := by rw [← comp_apply, Iso.hom_inv_id, id_apply]
     _ ≤ ‖i.hom v‖ := h2 _
+
+@[deprecated (since := "2026-09-09")] alias iso_isometry_of_normNoninc :=
+  iso_isometric_of_normNoninc
 
 instance Hom.add {M N : SemiNormedGrp} : Add (M ⟶ N) where
   add f g := ofHom (f.hom + g.hom)
@@ -375,13 +378,15 @@ theorem isZero_of_subsingleton (V : SemiNormedGrp₁) [Subsingleton V] : Limits.
 instance hasZeroObject : Limits.HasZeroObject SemiNormedGrp₁.{u} :=
   ⟨⟨of PUnit, isZero_of_subsingleton _⟩⟩
 
-theorem iso_isometry {V W : SemiNormedGrp₁} (i : V ≅ W) : Isometry i.hom := by
-  change Isometry (⟨⟨i.hom, map_zero _⟩, fun _ _ => map_add _ _ _⟩ : V →+ W)
-  refine AddMonoidHomClass.isometry_of_norm _ ?_
+theorem iso_isometric {V W : SemiNormedGrp₁} (i : V ≅ W) : Isometric i.hom := by
+  change Isometric (⟨⟨i.hom, map_zero _⟩, fun _ _ => map_add _ _ _⟩ : V →+ W)
+  refine AddMonoidHomClass.isometric_of_norm _ ?_
   intro v
   apply le_antisymm (i.hom.2 v)
   calc
     ‖v‖ = ‖i.inv (i.hom v)‖ := by rw [← comp_apply, Iso.hom_inv_id, id_apply]
     _ ≤ ‖i.hom v‖ := i.inv.2 _
+
+@[deprecated (since := "2026-09-09")] alias iso_isometry := iso_isometric
 
 end SemiNormedGrp₁

--- a/Mathlib/Analysis/Normed/Group/Uniform.lean
+++ b/Mathlib/Analysis/Normed/Group/Uniform.lean
@@ -29,11 +29,16 @@ variable [SeminormedGroup E] [SeminormedGroup F] {s : Set E} {a b : E} {r : ℝ}
 
 @[to_additive]
 instance NormedGroup.to_isIsometricSMul : IsIsometricSMul E E :=
-  ⟨fun a => Isometry.of_dist_eq fun b c => by simp [dist_eq_norm_inv_mul]⟩
+  ⟨fun a => Isometric.of_dist_eq fun b c => by simp [dist_eq_norm_inv_mul]⟩
 
 @[to_additive]
-theorem Isometry.norm_map_of_map_one {f : E → F} (hi : Isometry f) (h₁ : f 1 = 1) (x : E) :
+theorem Isometric.norm_map_of_map_one {f : E → F} (hi : Isometric f) (h₁ : f 1 = 1) (x : E) :
     ‖f x‖ = ‖x‖ := by rw [← dist_one_right, ← h₁, hi.dist_eq, dist_one_right]
+
+@[deprecated (since := "2026-09-10")] alias Isometry.norm_map_of_map_one :=
+  Isometric.norm_map_of_map_one
+@[deprecated (since := "2026-09-10")] alias Isometry.norm_map_of_map_zero :=
+  Isometric.norm_map_of_map_zero
 
 @[to_additive (attr := simp) norm_map]
 theorem norm_map' [FunLike 𝓕 E F] [IsometryClass 𝓕 E F] [OneHomClass 𝓕 E F] (f : 𝓕) (x : E) :
@@ -112,15 +117,25 @@ theorem MonoidHomClass.uniformContinuous_of_bound [MonoidHomClass 𝓕 E F] (f :
   (MonoidHomClass.lipschitz_of_bound f C h).uniformContinuous
 
 @[to_additive]
-theorem MonoidHomClass.isometry_iff_norm [MonoidHomClass 𝓕 E F] (f : 𝓕) :
-    Isometry f ↔ ∀ x, ‖f x‖ = ‖x‖ := by
+theorem MonoidHomClass.isometric_iff_norm [MonoidHomClass 𝓕 E F] (f : 𝓕) :
+    Isometric f ↔ ∀ x, ‖f x‖ = ‖x‖ := by
   simp only [isometry_iff_dist_eq, dist_eq_norm_inv_mul, ← map_inv, ← map_mul]
   refine ⟨fun h x => ?_, fun h x y => h _⟩
   simpa using h x 1
 
-alias ⟨_, MonoidHomClass.isometry_of_norm⟩ := MonoidHomClass.isometry_iff_norm
+@[deprecated (since := "2026-09-10")] alias MonoidHomClass.isometry_iff_norm :=
+  MonoidHomClass.isometric_iff_norm
+@[deprecated (since := "2026-09-10")] alias AddMonoidHomClass.isometry_iff_norm :=
+  AddMonoidHomClass.isometric_iff_norm
 
-attribute [to_additive] MonoidHomClass.isometry_of_norm
+alias ⟨_, MonoidHomClass.isometric_of_norm⟩ := MonoidHomClass.isometric_iff_norm
+
+attribute [to_additive] MonoidHomClass.isometric_of_norm
+
+@[deprecated (since := "2026-09-10")] alias MonoidHomClass.isometry_of_norm :=
+  MonoidHomClass.isometric_of_norm
+@[deprecated (since := "2026-09-10")] alias AddMonoidHomClass.isometry_of_norm :=
+  AddMonoidHomClass.isometric_of_norm
 
 section NNNorm
 
@@ -169,9 +184,14 @@ theorem OneHomClass.bound_of_antilipschitz [OneHomClass 𝓕 E F] (f : 𝓕) {K 
   h.le_mul_nnnorm' (map_one f) x
 
 @[to_additive]
-theorem Isometry.nnnorm_map_of_map_one {f : E → F} (hi : Isometry f) (h₁ : f 1 = 1) (x : E) :
+theorem Isometric.nnnorm_map_of_map_one {f : E → F} (hi : Isometric f) (h₁ : f 1 = 1) (x : E) :
     ‖f x‖₊ = ‖x‖₊ :=
   Subtype.ext <| hi.norm_map_of_map_one h₁ x
+
+@[deprecated (since := "2026-09-10")] alias Isometry.nnnorm_map_of_map_one :=
+  Isometric.nnnorm_map_of_map_one
+@[deprecated (since := "2026-09-10")] alias Isometry.nnnorm_map_of_map_zero :=
+  Isometric.nnnorm_map_of_map_zero
 
 end NNNorm
 
@@ -199,7 +219,7 @@ variable [SeminormedCommGroup E] [SeminormedCommGroup F] {a₁ a₂ b₁ b₂ : 
 
 @[to_additive]
 instance NormedGroup.to_isIsometricSMul_right : IsIsometricSMul Eᵐᵒᵖ E :=
-  ⟨fun a => Isometry.of_dist_eq fun b c => by simp⟩
+  ⟨fun a => Isometric.of_dist_eq fun b c => by simp⟩
 
 @[to_additive (attr := simp)]
 theorem dist_mul_self_right (a b : E) : dist a (b * a) = ‖b‖ := by
@@ -474,11 +494,13 @@ end SeminormedCommGroup
 namespace Real
 open Topology
 
-theorem isometry_intCast : Isometry ((↑) : ℤ → ℝ) :=
-  Isometry.of_dist_eq <| by tauto
+theorem isometric_intCast : Isometric ((↑) : ℤ → ℝ) :=
+  Isometric.of_dist_eq <| by tauto
+
+@[deprecated (since := "2026-09-10")] alias isometry_intCast := isometric_intCast
 
 theorem isClosedEmbedding_intCast : IsClosedEmbedding ((↑) : ℤ → ℝ) :=
-  isometry_intCast.isClosedEmbedding
+  isometric_intCast.isClosedEmbedding
 
 lemma isClosed_range_intCast : IsClosed (Set.range ((↑) : ℤ → ℝ)) :=
   isClosedEmbedding_intCast.isClosed_range

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -672,12 +672,14 @@ lemma lipschitzWith_toLp [∀ i, PseudoEMetricSpace (β i)] :
     LipschitzWith ((Fintype.card ι : ℝ≥0) ^ (1 / p).toReal) (@toLp p (∀ i, β i)) :=
   (antilipschitzWith_ofLp p β).to_rightInverse (ofLp_toLp p)
 
-lemma isometry_ofLp_infty [∀ i, PseudoEMetricSpace (β i)] :
-    Isometry (@ofLp ∞ (∀ i, β i)) :=
+lemma isometric_ofLp_infty [∀ i, PseudoEMetricSpace (β i)] :
+    Isometric (@ofLp ∞ (∀ i, β i)) :=
   fun x y =>
   le_antisymm (by simpa only [ENNReal.coe_one, one_mul] using lipschitzWith_ofLp ∞ β x y)
     (by simpa only [ENNReal.div_top, ENNReal.toReal_zero, NNReal.rpow_zero, ENNReal.coe_one,
       one_mul] using antilipschitzWith_ofLp ∞ β x y)
+
+@[deprecated (since := "2026-09-09")] alias isometry_ofLp_infty := isometric_ofLp_infty
 
 /-- seminormed group instance on the product of finitely many normed groups, using the `L^p`
 norm. -/

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -662,13 +662,15 @@ lemma prod_lipschitzWith_toLp [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
     LipschitzWith ((2 : ℝ≥0) ^ (1 / p).toReal) (@toLp p (α × β)) :=
   (prod_antilipschitzWith_ofLp p α β).to_rightInverse (ofLp_toLp p)
 
-lemma prod_isometry_ofLp_infty [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
-    Isometry (@ofLp ∞ (α × β)) :=
+lemma prod_isometric_ofLp_infty [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
+    Isometric (@ofLp ∞ (α × β)) :=
   fun x y =>
   le_antisymm (by simpa only [ENNReal.coe_one, one_mul] using prod_lipschitzWith_ofLp ∞ α β x y)
     (by
       simpa only [ENNReal.div_top, ENNReal.toReal_zero, NNReal.rpow_zero, ENNReal.coe_one,
         one_mul] using prod_antilipschitzWith_ofLp ∞ α β x y)
+
+@[deprecated (since := "2026-09-09")] alias prod_isometry_ofLp_infty := prod_isometric_ofLp_infty
 
 /-- Seminormed group instance on the product of two normed groups, using the `L^p`
 norm. -/
@@ -1092,20 +1094,22 @@ end WithLp
 
 variable (γ : Type*) {α' β' : Type*}
 
-section Isometry
+section Isometric
 
 variable [hp : Fact (1 ≤ p)] [PseudoEMetricSpace α] [PseudoEMetricSpace β] [PseudoEMetricSpace γ]
   [PseudoEMetricSpace α'] [PseudoEMetricSpace β']
 
 variable {α β} in
 /-- The `L^p` product of two isometries is an isometry. -/
-theorem Isometry.withLpProdMap {f : α → α'} (hf : Isometry f) {g : β → β'} (hg : Isometry g) :
-    Isometry (WithLp.map p (Prod.map f g)) := by
+theorem Isometric.withLpProdMap {f : α → α'} (hf : Isometric f) {g : β → β'} (hg : Isometric g) :
+    Isometric (WithLp.map p (Prod.map f g)) := by
   intro _ _
   rcases p.trichotomy with rfl | rfl | hp
   · absurd hp.elim; simp
   · simp [WithLp.prod_edist_eq_sup, hf.edist_eq, hg.edist_eq]
   · simp [WithLp.prod_edist_eq_add hp, hf.edist_eq, hg.edist_eq]
+
+@[deprecated (since := "2026-09-10")] alias Isometry.withLpProdMap := Isometric.withLpProdMap
 
 namespace IsometryEquiv
 
@@ -1169,7 +1173,7 @@ theorem coe_withLpUniqueProd [Unique α] : ⇑(withLpUniqueProd p α β) = WithL
 
 end IsometryEquiv
 
-end Isometry
+end Isometric
 
 section Linear
 
@@ -1186,7 +1190,7 @@ variable {𝕜 α β} in
 def LinearIsometry.withLpProdMap (f : α →ₗᵢ[𝕜] α') (g : β →ₗᵢ[𝕜] β') :
     WithLp p (α × β) →ₗᵢ[𝕜] WithLp p (α' × β') where
   __ := (f.toLinearMap.prodMap g.toLinearMap).withLpMap p
-  norm_map' := (f.isometry.withLpProdMap p g.isometry).norm_map_of_map_zero
+  norm_map' := (f.isometric.withLpProdMap p g.isometric).norm_map_of_map_zero
     ((f.toLinearMap.prodMap g.toLinearMap).withLpMap p).map_zero
 
 namespace LinearIsometryEquiv

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -1118,16 +1118,18 @@ protected theorem norm_single (hp : 0 < p) (i : α) (x : E i) : ‖lp.single p i
     · intro j hji
       rw [lp.coeFn_single, Pi.single_eq_of_ne hji, _root_.norm_zero, Real.zero_rpow this.ne']
 
-theorem isometry_single [Fact (1 ≤ p)] (i : α) : Isometry (lp.single (E := E) p i) :=
-  AddMonoidHomClass.isometry_of_norm (lp.singleAddMonoidHom (E := E) p i) fun _ ↦
+theorem isometric_single [Fact (1 ≤ p)] (i : α) : Isometric (lp.single (E := E) p i) :=
+  AddMonoidHomClass.isometric_of_norm (lp.singleAddMonoidHom (E := E) p i) fun _ ↦
     lp.norm_single (zero_lt_one.trans_le Fact.out) _ _
+
+@[deprecated (since := "2026-09-09")] alias isometry_single := isometric_single
 
 variable (p E) in
 /-- `lp.single` as a continuous morphism of additive monoids. -/
 def singleContinuousAddMonoidHom [Fact (1 ≤ p)] (i : α) :
     ContinuousAddMonoidHom (E i) (lp E p) where
   __ := singleAddMonoidHom p i
-  continuous_toFun := isometry_single i |>.continuous
+  continuous_toFun := isometric_single i |>.continuous
 
 @[simp]
 theorem singleContinuousAddMonoidHom_apply [Fact (1 ≤ p)] (i : α) (x : E i) :
@@ -1138,7 +1140,7 @@ variable (𝕜 p E) in
 /-- `lp.single` as a continuous linear map. -/
 def singleContinuousLinearMap [Fact (1 ≤ p)] (i : α) : E i →L[𝕜] lp E p where
   __ := lsingle p i
-  cont := isometry_single i |>.continuous
+  cont := isometric_single i |>.continuous
 
 @[simp]
 theorem singleContinuousLinearMap_apply [Fact (1 ≤ p)] (i : α) (x : E i) :

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -337,9 +337,11 @@ theorem tendsto_algebraMap_cobounded (𝕜 𝕜' : Type*) [NormedField 𝕜] [Se
   exact ⟨s, fun x hx ↦ by simpa using hs (algebraMap 𝕜 𝕜' x) hx⟩
 
 /-- In a normed algebra, the inclusion of the base field in the extended field is an isometry. -/
-theorem algebraMap_isometry [NormOneClass 𝕜'] : Isometry (algebraMap 𝕜 𝕜') := by
-  refine Isometry.of_dist_eq fun x y => ?_
+theorem algebraMap_isometric [NormOneClass 𝕜'] : Isometric (algebraMap 𝕜 𝕜') := by
+  refine Isometric.of_dist_eq fun x y => ?_
   rw [dist_eq_norm, dist_eq_norm, ← map_sub, norm_algebraMap']
+
+@[deprecated (since := "2026-09-10")] alias algebraMap_isometry := algebraMap_isometric
 
 instance NormedAlgebra.id : NormedAlgebra 𝕜 𝕜 :=
   { NormedField.toNormedSpace, Algebra.id 𝕜 with }

--- a/Mathlib/Analysis/Normed/Operator/Extend.lean
+++ b/Mathlib/Analysis/Normed/Operator/Extend.lean
@@ -362,7 +362,7 @@ variable [PseudoMetricSpace R₂] [CompleteSpace F] [IsBoundedSMul R₂ F]
 `UniformSpace.Completion.extension`. -/
 def fromCompletion : UniformSpace.Completion E →ₛₗᵢ[σ₁₂] F where
   __ := f.toContinuousLinearMap.fromCompletion
-  norm_map' := f.isometry.completion_extension.norm_map_of_map_zero
+  norm_map' := f.isometric.completion_extension.norm_map_of_map_zero
     f.toContinuousLinearMap.fromCompletion.map_zero
 
 theorem fromCompletion_apply_coe (x : E) : f.fromCompletion x = f x :=
@@ -371,7 +371,7 @@ theorem fromCompletion_apply_coe (x : E) : f.fromCompletion x = f x :=
 @[simp low]
 theorem coe_fromCompletion : f.fromCompletion = Completion.extension f := by
   refine Completion.ext f.fromCompletion.continuous Completion.continuous_extension fun a => ?_
-  rw [fromCompletion_apply_coe, Completion.extension_coe f.isometry.uniformContinuous]
+  rw [fromCompletion_apply_coe, Completion.extension_coe f.isometric.uniformContinuous]
 
 @[simp]
 theorem toContinuousLinearMap_fromCompletion :
@@ -403,7 +403,7 @@ theorem completion_apply_coe (x : E) : f.completion x = f x :=
 @[simp low]
 theorem coe_completion : f.completion = Completion.map f := by
   refine Completion.ext f.completion.continuous Completion.continuous_map fun a => ?_
-  rw [completion_apply_coe, Completion.map_coe f.isometry.uniformContinuous]
+  rw [completion_apply_coe, Completion.map_coe f.isometric.uniformContinuous]
 
 @[simp]
 theorem toContinuousLinearMap_completion :

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -84,39 +84,41 @@ namespace SemilinearIsometryClass
 
 variable [FunLike 𝓕 E E₂]
 
-protected theorem isometry [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) : Isometry f :=
-  AddMonoidHomClass.isometry_of_norm _ (norm_map _)
+protected theorem isometric [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) : Isometric f :=
+  AddMonoidHomClass.isometric_of_norm _ (norm_map _)
+
+@[deprecated (since := "2026-09-10")] alias isometry := SemilinearIsometryClass.isometric
 
 @[continuity]
 protected theorem continuous [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) : Continuous f :=
-  (SemilinearIsometryClass.isometry f).continuous
+  (SemilinearIsometryClass.isometric f).continuous
 
 -- Should be `@[simp]` but it doesn't fire due to https://github.com/leanprover/lean4/issues/3107.
 theorem nnnorm_map [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) (x : E) : ‖f x‖₊ = ‖x‖₊ :=
   NNReal.eq <| norm_map f x
 
 protected theorem lipschitz [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) : LipschitzWith 1 f :=
-  (SemilinearIsometryClass.isometry f).lipschitzWith
+  (SemilinearIsometryClass.isometric f).lipschitzWith
 
 protected theorem antilipschitz [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) :
     AntilipschitzWith 1 f :=
-  (SemilinearIsometryClass.isometry f).antilipschitzWith
+  (SemilinearIsometryClass.isometric f).antilipschitzWith
 
 theorem ediam_image [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) (s : Set E) :
     Metric.ediam (f '' s) = Metric.ediam s :=
-  (SemilinearIsometryClass.isometry f).ediam_image s
+  (SemilinearIsometryClass.isometric f).ediam_image s
 
 theorem ediam_range [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) :
     Metric.ediam (range f) = Metric.ediam (univ : Set E) :=
-  (SemilinearIsometryClass.isometry f).ediam_range
+  (SemilinearIsometryClass.isometric f).ediam_range
 
 theorem diam_image [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) (s : Set E) :
     Metric.diam (f '' s) = Metric.diam s :=
-  (SemilinearIsometryClass.isometry f).diam_image s
+  (SemilinearIsometryClass.isometric f).diam_image s
 
 theorem diam_range [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) :
     Metric.diam (range f) = Metric.diam (univ : Set E) :=
-  (SemilinearIsometryClass.isometry f).diam_range
+  (SemilinearIsometryClass.isometric f).diam_range
 
 instance (priority := 100) toContinuousSemilinearMapClass
     [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] : ContinuousSemilinearMapClass 𝓕 σ₁₂ E E₂ where
@@ -124,7 +126,7 @@ instance (priority := 100) toContinuousSemilinearMapClass
 
 instance (priority := 100) toIsometryClass [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] :
     IsometryClass 𝓕 E E₂ where
-  isometry := SemilinearIsometryClass.isometry
+  isometry := SemilinearIsometryClass.isometric
 
 end SemilinearIsometryClass
 
@@ -196,15 +198,17 @@ protected lemma norm_map (x : E) : ‖f x‖ = ‖x‖ := by simp
 protected lemma nnnorm_map (x : E) : ‖f x‖₊ = ‖x‖₊ := by simp
 protected lemma enorm_map (x : E) : ‖f x‖ₑ = ‖x‖ₑ := by simp
 
-protected theorem isometry : Isometry f :=
-  AddMonoidHomClass.isometry_of_norm f.toLinearMap f.norm_map
+protected theorem isometric : Isometric f :=
+  AddMonoidHomClass.isometric_of_norm f.toLinearMap f.norm_map
 
-lemma isEmbedding (f : F →ₛₗᵢ[σ₁₂] E₂) : IsEmbedding f := f.isometry.isEmbedding
+@[deprecated (since := "2026-09-10")] alias isometry := LinearIsometry.isometric
+
+lemma isEmbedding (f : F →ₛₗᵢ[σ₁₂] E₂) : IsEmbedding f := f.isometric.isEmbedding
 
 @[simp]
 theorem isComplete_image_iff [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) {s : Set E} :
     IsComplete (f '' s) ↔ IsComplete s :=
-  _root_.isComplete_image_iff (SemilinearIsometryClass.isometry f).isUniformInducing
+  _root_.isComplete_image_iff (SemilinearIsometryClass.isometric f).isUniformInducing
 
 theorem isComplete_map_iff [RingHomSurjective σ₁₂] {p : Submodule R E} :
     IsComplete (p.map f.toLinearMap : Set E₂) ↔ IsComplete (p : Set E) :=
@@ -216,14 +220,14 @@ instance completeSpace_map [RingHomSurjective σ₁₂] (p : Submodule R E) [Com
 
 @[simp]
 theorem dist_map (x y : E) : dist (f x) (f y) = dist x y :=
-  f.isometry.dist_eq x y
+  f.isometric.dist_eq x y
 
 @[simp]
 theorem edist_map (x y : E) : edist (f x) (f y) = edist x y :=
-  f.isometry.edist_eq x y
+  f.isometric.edist_eq x y
 
 protected theorem injective : Injective f₁ :=
-  Isometry.injective (LinearIsometry.isometry f₁)
+  Isometric.injective (LinearIsometry.isometric f₁)
 
 @[simp]
 theorem map_eq_iff {x y : F} : f₁ x = f₁ y ↔ x = y :=
@@ -233,39 +237,39 @@ theorem map_ne {x y : F} (h : x ≠ y) : f₁ x ≠ f₁ y :=
   f₁.injective.ne h
 
 protected theorem lipschitz : LipschitzWith 1 f :=
-  f.isometry.lipschitzWith
+  f.isometric.lipschitzWith
 
 protected theorem antilipschitz : AntilipschitzWith 1 f :=
-  f.isometry.antilipschitzWith
+  f.isometric.antilipschitzWith
 
 @[continuity]
 protected theorem continuous : Continuous f :=
-  f.isometry.continuous
+  f.isometric.continuous
 
 @[simp]
 theorem preimage_ball (x : E) (r : ℝ) : f ⁻¹' Metric.ball (f x) r = Metric.ball x r :=
-  f.isometry.preimage_ball x r
+  f.isometric.preimage_ball x r
 
 @[simp]
 theorem preimage_sphere (x : E) (r : ℝ) : f ⁻¹' Metric.sphere (f x) r = Metric.sphere x r :=
-  f.isometry.preimage_sphere x r
+  f.isometric.preimage_sphere x r
 
 @[simp]
 theorem preimage_closedBall (x : E) (r : ℝ) :
     f ⁻¹' Metric.closedBall (f x) r = Metric.closedBall x r :=
-  f.isometry.preimage_closedBall x r
+  f.isometric.preimage_closedBall x r
 
 theorem ediam_image (s : Set E) : Metric.ediam (f '' s) = Metric.ediam s :=
-  f.isometry.ediam_image s
+  f.isometric.ediam_image s
 
 theorem ediam_range : Metric.ediam (range f) = Metric.ediam (univ : Set E) :=
-  f.isometry.ediam_range
+  f.isometric.ediam_range
 
 theorem diam_image (s : Set E) : Metric.diam (f '' s) = Metric.diam s :=
-  Isometry.diam_image (LinearIsometry.isometry f) s
+  Isometric.diam_image (LinearIsometry.isometric f) s
 
 theorem diam_range : Metric.diam (range f) = Metric.diam (univ : Set E) :=
-  Isometry.diam_range (LinearIsometry.isometry f)
+  Isometric.diam_range (LinearIsometry.isometric f)
 
 /-- Interpret a linear isometry as a continuous linear map. -/
 def toContinuousLinearMap : E →SL[σ₁₂] E₂ :=
@@ -290,7 +294,7 @@ theorem coe_toContinuousLinearMap : ⇑f.toContinuousLinearMap = f :=
 @[simp]
 theorem comp_continuous_iff {α : Type*} [TopologicalSpace α] {g : α → E} :
     Continuous (f ∘ g) ↔ Continuous g :=
-  f.isometry.comp_continuous_iff
+  f.isometric.comp_continuous_iff
 
 /-- The identity linear isometry. -/
 def id : E →ₗᵢ[R] E :=
@@ -385,8 +389,8 @@ end submoduleMap
 
 end LinearIsometry
 
-/-- Construct a `LinearIsometry` from a `LinearMap` satisfying `Isometry`. -/
-def LinearMap.toLinearIsometry (f : E →ₛₗ[σ₁₂] E₂) (hf : Isometry f) : E →ₛₗᵢ[σ₁₂] E₂ :=
+/-- Construct a `LinearIsometry` from a `LinearMap` satisfying `Isometric`. -/
+def LinearMap.toLinearIsometry (f : E →ₛₗ[σ₁₂] E₂) (hf : Isometric f) : E →ₛₗᵢ[σ₁₂] E₂ :=
   { f with
     norm_map' := by
       simp_rw [← dist_zero_right]
@@ -545,12 +549,14 @@ theorem toLinearIsometry_inj {f g : E ≃ₛₗᵢ[σ₁₂] E₂} :
 theorem coe_toLinearIsometry : ⇑e.toLinearIsometry = e :=
   rfl
 
-protected theorem isometry : Isometry e :=
-  e.toLinearIsometry.isometry
+protected theorem isometric : Isometric e :=
+  e.toLinearIsometry.isometric
+
+@[deprecated (since := "2026-09-10")] alias isometry := LinearIsometryEquiv.isometric
 
 /-- Reinterpret a `LinearIsometryEquiv` as an `IsometryEquiv`. -/
 def toIsometryEquiv : E ≃ᵢ E₂ :=
-  ⟨e.toLinearEquiv.toEquiv, e.isometry⟩
+  ⟨e.toLinearEquiv.toEquiv, e.isometric⟩
 
 theorem toIsometryEquiv_injective :
     Function.Injective (toIsometryEquiv : (E ≃ₛₗᵢ[σ₁₂] E₂) → E ≃ᵢ E₂) := fun x _ h =>
@@ -585,7 +591,7 @@ theorem coe_toHomeomorph : ⇑e.toHomeomorph = e :=
   rfl
 
 protected theorem continuous : Continuous e :=
-  e.isometry.continuous
+  e.isometric.continuous
 
 protected theorem continuousAt {x} : ContinuousAt e x :=
   e.continuous.continuousAt
@@ -907,21 +913,21 @@ theorem map_ne {x y : E} (h : x ≠ y) : e x ≠ e y :=
   e.injective.ne h
 
 protected theorem lipschitz : LipschitzWith 1 e :=
-  e.isometry.lipschitzWith
+  e.isometric.lipschitzWith
 
 protected theorem antilipschitz : AntilipschitzWith 1 e :=
-  e.isometry.antilipschitzWith
+  e.isometric.antilipschitzWith
 
 theorem image_eq_preimage_symm (s : Set E) : e '' s = e.symm ⁻¹' s :=
   e.toLinearEquiv.image_eq_preimage_symm s
 
 @[simp]
 theorem ediam_image (s : Set E) : Metric.ediam (e '' s) = Metric.ediam s :=
-  e.isometry.ediam_image s
+  e.isometric.ediam_image s
 
 @[simp]
 theorem diam_image (s : Set E) : Metric.diam (e '' s) = Metric.diam s :=
-  e.isometry.diam_image s
+  e.isometric.diam_image s
 
 @[simp]
 theorem preimage_ball (x : E₂) (r : ℝ) : e ⁻¹' Metric.ball x r = Metric.ball (e.symm x) r :=
@@ -952,11 +958,11 @@ variable {α : Type*} [TopologicalSpace α]
 
 @[simp]
 theorem comp_continuousOn_iff {f : α → E} {s : Set α} : ContinuousOn (e ∘ f) s ↔ ContinuousOn f s :=
-  e.isometry.comp_continuousOn_iff
+  e.isometric.comp_continuousOn_iff
 
 @[simp]
 theorem comp_continuous_iff {f : α → E} : Continuous (e ∘ f) ↔ Continuous f :=
-  e.isometry.comp_continuous_iff
+  e.isometric.comp_continuous_iff
 
 instance completeSpace_map (p : Submodule R E) [CompleteSpace p] :
     CompleteSpace (p.map (e : E →ₛₗ[σ₁₂] E₂)) :=
@@ -1104,7 +1110,9 @@ noncomputable def LinearIsometry.equivRange {R S : Type*} [Semiring R] [Ring S] 
 namespace MulOpposite
 variable {R H : Type*} [Semiring R] [SeminormedAddCommGroup H] [Module R H]
 
-theorem isometry_opLinearEquiv : Isometry (opLinearEquiv R (M := H)) := fun _ _ => rfl
+theorem isometric_opLinearEquiv : Isometric (opLinearEquiv R (M := H)) := fun _ _ => rfl
+
+@[deprecated (since := "2026-09-10")] alias isometry_opLinearEquiv := isometric_opLinearEquiv
 
 variable (R H) in
 /-- The linear isometry equivalence version of the function `op`. -/

--- a/Mathlib/Analysis/Normed/Operator/Mul.lean
+++ b/Mathlib/Analysis/Normed/Operator/Mul.lean
@@ -104,24 +104,26 @@ This is a useful class because it gives rise to a nice norm on the unitization; 
 a C⋆-norm when the norm on `A` is a C⋆-norm. -/
 class _root_.RegularNormedAlgebra : Prop where
   /-- The left regular representation of the algebra on itself is an isometry. -/
-  isometry_mul' : Isometry (mul 𝕜 R)
+  isometric_mul' : Isometric (mul 𝕜 R)
 
 /-- Every (unital) normed algebra such that `‖1‖ = 1` is a `RegularNormedAlgebra`. -/
 instance _root_.NormedAlgebra.instRegularNormedAlgebra {𝕜 R : Type*} [NontriviallyNormedField 𝕜]
     [SeminormedRing R] [NormedAlgebra 𝕜 R] [NormOneClass R] : RegularNormedAlgebra 𝕜 R where
-  isometry_mul' := AddMonoidHomClass.isometry_of_norm (mul 𝕜 R) <|
+  isometric_mul' := AddMonoidHomClass.isometric_of_norm (mul 𝕜 R) <|
     fun x => le_antisymm (opNorm_mul_apply_le _ _ _) <| by
       convert! ratio_le_opNorm ((mul 𝕜 R) x) (1 : R)
       simp [norm_one]
 
 variable [RegularNormedAlgebra 𝕜 R]
 
-lemma isometry_mul : Isometry (mul 𝕜 R) :=
-  RegularNormedAlgebra.isometry_mul'
+lemma isometric_mul : Isometric (mul 𝕜 R) :=
+  RegularNormedAlgebra.isometric_mul'
+
+@[deprecated (since := "2026-09-09")] alias isometry_mul := isometric_mul
 
 @[simp]
 lemma opNorm_mul_apply (x : R) : ‖mul 𝕜 R x‖ = ‖x‖ :=
-  (AddMonoidHomClass.isometry_iff_norm (mul 𝕜 R)).mp (isometry_mul 𝕜 R) x
+  (AddMonoidHomClass.isometric_iff_norm (mul 𝕜 R)).mp (isometric_mul 𝕜 R) x
 
 @[simp]
 lemma opNNNorm_mul_apply (x : R) : ‖mul 𝕜 R x‖₊ = ‖x‖₊ :=

--- a/Mathlib/Analysis/Normed/Ring/Basic.lean
+++ b/Mathlib/Analysis/Normed/Ring/Basic.lean
@@ -26,7 +26,7 @@ A normed ring instance can be constructed from a given real absolute value on a 
 
 -- Guard against import creep.
 assert_not_exists AddChar comap_norm_atTop DilationEquiv Finset.sup_mul_le_mul_sup_of_nonneg
-  IsOfFinOrder Isometry.norm_map_of_map_one NNReal.isOpen_Ico_zero Rat.norm_cast_real
+  IsOfFinOrder Isometric.norm_map_of_map_one NNReal.isOpen_Ico_zero Rat.norm_cast_real
   RestrictScalars
 
 variable {G α β ι : Type*}

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -64,9 +64,11 @@ instance Pi.seminormedRing {R : ι → Type*} [Fintype ι] [∀ i, SeminormedRin
     SeminormedRing (∀ i, R i) :=
   { Pi.nonUnitalSeminormedRing, Pi.ring with }
 
-lemma RingHom.isometry {𝕜₁ 𝕜₂ : Type*} [SeminormedRing 𝕜₁] [SeminormedRing 𝕜₂]
+lemma RingHom.isometric {𝕜₁ 𝕜₂ : Type*} [SeminormedRing 𝕜₁] [SeminormedRing 𝕜₂]
     (σ : 𝕜₁ →+* 𝕜₂) [RingHomIsometric σ] :
-    Isometry σ := AddMonoidHomClass.isometry_of_norm _ fun _ => RingHomIsometric.norm_map
+    Isometric σ := AddMonoidHomClass.isometric_of_norm _ fun _ => RingHomIsometric.norm_map
+
+@[deprecated (since := "2026-09-09")] alias RingHom.isometry := RingHom.isometric
 
 /-- If `σ` and `σ'` are mutually inverse, then one is `RingHomIsometric` if the other is. Not an
 instance, as it would cause loops. -/
@@ -211,7 +213,7 @@ namespace NNReal
 
 lemma lipschitzWith_sub : LipschitzWith 2 (fun (p : ℝ≥0 × ℝ≥0) ↦ p.1 - p.2) := by
   rw [← NNReal.isometry_coe.lipschitzWith_iff]
-  have : Isometry (Prod.map ((↑) : ℝ≥0 → ℝ) ((↑) : ℝ≥0 → ℝ)) :=
+  have : Isometric (Prod.map ((↑) : ℝ≥0 → ℝ) ((↑) : ℝ≥0 → ℝ)) :=
     NNReal.isometry_coe.prodMap NNReal.isometry_coe
   convert!
     (((LipschitzWith.prod_fst.comp this.lipschitzWith).sub

--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -477,10 +477,10 @@ lemma mapMahlerMeasure_one : (1 : A[X]).mapMahlerMeasure v = 1 := by
 
 variable {A : Type*} [NormedRing A] (p : A[X]) (v : A →+* ℂ)
 
-lemma mapMahlerMeasure_const (hv : Isometry v) (z : A) : (C z).mapMahlerMeasure v = ‖z‖ := by
+lemma mapMahlerMeasure_const (hv : Isometric v) (z : A) : (C z).mapMahlerMeasure v = ‖z‖ := by
   simp [mapMahlerMeasure, hv.norm_map_of_map_zero (map_zero _)]
 
-lemma leadingCoeff_le_mapMahlerMeasure (hv : Isometry v) :
+lemma leadingCoeff_le_mapMahlerMeasure (hv : Isometric v) :
     ‖p.leadingCoeff‖ ≤ p.mapMahlerMeasure v := by
   by_cases hp : p.leadingCoeff = 0
   · simp [hp, mapMahlerMeasure_nonneg]
@@ -491,23 +491,23 @@ lemma leadingCoeff_le_mapMahlerMeasure (hv : Isometry v) :
       leadingCoeff_le_mahlerMeasure, mapMahlerMeasure]
 
 variable {p} in
-lemma Monic.one_le_mapMahlerMeasure [NormOneClass A] (hv : Isometry v) (hp : p.Monic) :
+lemma Monic.one_le_mapMahlerMeasure [NormOneClass A] (hv : Isometric v) (hp : p.Monic) :
     1 ≤ p.mapMahlerMeasure v := by
   grw [← p.leadingCoeff_le_mapMahlerMeasure v hv, hp.leadingCoeff, norm_one]
 
 variable {p} in
-theorem mapMahlerMeasure_pos_of_ne_zero (hv : Isometry v) (hp : p ≠ 0) :
+theorem mapMahlerMeasure_pos_of_ne_zero (hv : Isometric v) (hp : p ≠ 0) :
     0 < p.mapMahlerMeasure v :=
   mahlerMeasure_pos_of_ne_zero <| (Polynomial.map_eq_zero_iff hv.injective).not.mpr hp
 
-theorem mapMahlerMeasure_le_sum_norm_coeff (hv : Isometry v) :
+theorem mapMahlerMeasure_le_sum_norm_coeff (hv : Isometric v) :
     p.mapMahlerMeasure v ≤ p.sum fun _ a ↦ ‖a‖ := by
   apply mahlerMeasure_le_sum_norm_coeff _ |>.trans_eq
   rw [sum_def, sum_def, support_map_of_injective _ hv.injective]
   exact Finset.sum_congr rfl fun x _ ↦ by
     simp [hv.norm_map_of_map_zero (map_zero _)]
 
-theorem norm_coeff_le_choose_mul_mapMahlerMeasure (hv : Isometry v) (n : ℕ) (p : A[X]) :
+theorem norm_coeff_le_choose_mul_mapMahlerMeasure (hv : Isometric v) (n : ℕ) (p : A[X]) :
     ‖p.coeff n‖ ≤ (p.natDegree).choose n * p.mapMahlerMeasure v := by
   have hv_norm : ‖p.coeff n‖ = ‖v (p.coeff n)‖ :=
     (hv.norm_map_of_map_zero (map_zero _) _).symm

--- a/Mathlib/Analysis/RCLike/ContinuousMap.lean
+++ b/Mathlib/Analysis/RCLike/ContinuousMap.lean
@@ -65,8 +65,10 @@ variable (X) in
   realToRCLikeOrderEmbedding X 𝕜 |>.lt_iff_lt
 
 variable (X) in
-@[simp] theorem isometry_realToRCLike [CompactSpace X] : Isometry (realToRCLike 𝕜 (X := X)) :=
+@[simp] theorem isometric_realToRCLike [CompactSpace X] : Isometric (realToRCLike 𝕜 (X := X)) :=
   .of_dist_eq fun f g ↦ by simp [dist_eq_norm, norm_eq_iSup_norm, ← map_sub]
+
+@[deprecated (since := "2026-09-09")] alias isometry_realToRCLike := isometric_realToRCLike
 
 variable (X) in
 @[simp, fun_prop] lemma continuous_realToRCLike : Continuous (realToRCLike 𝕜 (X := X)) :=

--- a/Mathlib/Geometry/Euclidean/PerpBisector.lean
+++ b/Mathlib/Geometry/Euclidean/PerpBisector.lean
@@ -192,10 +192,16 @@ end EuclideanGeometry
 variable {V' P' : Type*} [NormedAddCommGroup V'] [InnerProductSpace ℝ V'] [MetricSpace P']
 variable [NormedAddTorsor V' P']
 
-theorem Isometry.preimage_perpBisector {f : P → P'} (h : Isometry f) (p₁ p₂ : P) :
+theorem Isometric.preimage_perpBisector {f : P → P'} (h : Isometric f) (p₁ p₂ : P) :
     f ⁻¹' (perpBisector (f p₁) (f p₂)) = perpBisector p₁ p₂ := by
   ext x; simp [mem_perpBisector_iff_dist_eq, h.dist_eq]
 
-theorem Isometry.mapsTo_perpBisector {f : P → P'} (h : Isometry f) (p₁ p₂ : P) :
+@[deprecated (since := "2026-09-10")] alias Isometry.preimage_perpBisector :=
+  Isometric.preimage_perpBisector
+
+theorem Isometric.mapsTo_perpBisector {f : P → P'} (h : Isometric f) (p₁ p₂ : P) :
     MapsTo f (perpBisector p₁ p₂) (perpBisector (f p₁) (f p₂)) :=
   (h.preimage_perpBisector p₁ p₂).ge
+
+@[deprecated (since := "2026-09-10")] alias Isometry.mapsTo_perpBisector :=
+  Isometric.mapsTo_perpBisector

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -184,12 +184,15 @@ theorem cospherical_singleton (p : P) : Cospherical ({p} : Set P) := by
   simp
 
 /-- If `ps` is cospherical, then any of its isometric images is cospherical. -/
-theorem _root_.Isometry.cospherical {E F : Type*} [MetricSpace E] [MetricSpace F] {f : E → F}
-    (hf : Isometry f) {ps : Set E} (hps : Cospherical ps) : Cospherical (f '' ps) := by
+theorem _root_.Isometric.cospherical {E F : Type*} [MetricSpace E] [MetricSpace F] {f : E → F}
+    (hf : Isometric f) {ps : Set E} (hps : Cospherical ps) : Cospherical (f '' ps) := by
   rcases hps with ⟨c, r, hc⟩
   refine ⟨f c, r, ?_⟩
   rintro _ ⟨p, hp, rfl⟩
   rw [hf.dist_eq, hc p hp]
+
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.cospherical :=
+  _root_.Isometric.cospherical
 
 end MetricSpace
 
@@ -202,14 +205,14 @@ containing it is cospherical. -/
 theorem Cospherical.inclusion {S₁ S₂ : AffineSubspace ℝ P} [Nonempty S₁] {ps : Set S₁}
     (hps : Cospherical ps) (hS : S₁ ≤ S₂) :
     Cospherical (AffineSubspace.inclusion hS '' ps) := by
-  refine Isometry.cospherical ?_ hps
+  refine Isometric.cospherical ?_ hps
   exact S₁.subtypeₐᵢ.isometry
 
 /-- If a set of points in an affine subspace is cospherical, then its image under the coercion
 to the ambient space is cospherical. -/
 theorem Cospherical.subtype_val {S : AffineSubspace ℝ P} [Nonempty S] {ps : Set S}
     (hps : Cospherical ps) : Cospherical (Subtype.val '' ps) :=
-  Isometry.cospherical S.subtypeₐᵢ.isometry hps
+  Isometric.cospherical S.subtypeₐᵢ.isometry hps
 
 omit [NormedSpace ℝ V] in
 /-- For a point on a sphere, the norm of its displacement from the center equals the radius. -/

--- a/Mathlib/Geometry/Euclidean/Volume/Measure.lean
+++ b/Mathlib/Geometry/Euclidean/Volume/Measure.lean
@@ -125,21 +125,30 @@ theorem IsometryEquiv.measurePreserving_euclideanHausdorffMeasure (e : X ≃ᵢ 
     MeasurePreserving e μHE[d] μHE[d] :=
   (IsometryEquiv.measurePreserving_hausdorffMeasure e d).smul_measure _
 
-theorem Isometry.euclideanHausdorffMeasure_image {f : X → Y} {d : ℕ} (hf : Isometry f) (s : Set X) :
+theorem Isometric.euclideanHausdorffMeasure_image {f : X → Y} {d : ℕ} (hf : Isometric f) (s : Set X) :
     μHE[d] (f '' s) = μHE[d] s := by
   simp_rw [euclideanHausdorffMeasure_def, Measure.smul_apply]
-  rw [Isometry.hausdorffMeasure_image hf (by simp)]
+  rw [Isometric.hausdorffMeasure_image hf (by simp)]
 
-theorem Isometry.euclideanHausdorffMeasure_preimage {f : X → Y} {d : ℕ} (hf : Isometry f)
+@[deprecated (since := "2026-09-10")] alias Isometry.euclideanHausdorffMeasure_image :=
+  Isometric.euclideanHausdorffMeasure_image
+
+theorem Isometric.euclideanHausdorffMeasure_preimage {f : X → Y} {d : ℕ} (hf : Isometric f)
     (s : Set Y) : μHE[d] (f ⁻¹' s) = μHE[d] (s ∩ Set.range f) := by
   simp_rw [euclideanHausdorffMeasure_def, Measure.smul_apply]
-  rw [Isometry.hausdorffMeasure_preimage hf (by simp)]
+  rw [Isometric.hausdorffMeasure_preimage hf (by simp)]
 
-theorem Isometry.map_euclideanHausdorffMeasure {f : X → Y} {d : ℕ} (hf : Isometry f) :
+@[deprecated (since := "2026-09-10")] alias Isometry.euclideanHausdorffMeasure_preimage :=
+  Isometric.euclideanHausdorffMeasure_preimage
+
+theorem Isometric.map_euclideanHausdorffMeasure {f : X → Y} {d : ℕ} (hf : Isometric f) :
     μHE[d].map f = μHE[d].restrict (Set.range f) := by
   simp_rw [euclideanHausdorffMeasure_def]
   rw [Measure.map_smul _ hf.continuous.aemeasurable, map_hausdorffMeasure hf (by simp),
     Measure.restrict_smul]
+
+@[deprecated (since := "2026-09-10")] alias Isometry.map_euclideanHausdorffMeasure :=
+  Isometric.map_euclideanHausdorffMeasure
 
 /-!
 ### Applying scalers to `μHE[d]`

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/AEMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/AEMeasurable.lean
@@ -253,11 +253,14 @@ theorem lpMeasSubgroupToLpTrim_norm_map [hp : Fact (1 ≤ p)] (hm : m ≤ m0)
     eLpNorm_congr_ae (lpMeasSubgroupToLpTrim_ae_eq hm _), ← Lp.norm_def]
   congr
 
-theorem isometry_lpMeasSubgroupToLpTrim [hp : Fact (1 ≤ p)] (hm : m ≤ m0) :
-    Isometry (lpMeasSubgroupToLpTrim F p μ hm) :=
-  Isometry.of_dist_eq fun f g => by
+theorem isometric_lpMeasSubgroupToLpTrim [hp : Fact (1 ≤ p)] (hm : m ≤ m0) :
+    Isometric (lpMeasSubgroupToLpTrim F p μ hm) :=
+  Isometric.of_dist_eq fun f g => by
     rw [dist_eq_norm, ← lpMeasSubgroupToLpTrim_sub, lpMeasSubgroupToLpTrim_norm_map,
       dist_eq_norm]
+
+@[deprecated (since := "2026-09-09")] alias isometry_lpMeasSubgroupToLpTrim :=
+  isometric_lpMeasSubgroupToLpTrim
 
 variable (F p μ)
 
@@ -268,7 +271,7 @@ noncomputable def lpMeasSubgroupToLpTrimIso [Fact (1 ≤ p)] (hm : m ≤ m0) :
   invFun := lpTrimToLpMeasSubgroup F p μ hm
   left_inv := lpMeasSubgroupToLpTrim_left_inv hm
   right_inv := lpMeasSubgroupToLpTrim_right_inv hm
-  isometry_toFun := isometry_lpMeasSubgroupToLpTrim hm
+  isometry_toFun := isometric_lpMeasSubgroupToLpTrim hm
 
 variable (𝕜)
 

--- a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
@@ -582,9 +582,12 @@ theorem norm_compMeasurePreserving (g : Lp E p μb) (hf : MeasurePreserving f μ
     ‖compMeasurePreserving f hf g‖ = ‖g‖ :=
   congr_arg ENNReal.toReal <| g.1.eLpNorm_compMeasurePreserving hf
 
-theorem isometry_compMeasurePreserving [Fact (1 ≤ p)] (hf : MeasurePreserving f μ μb) :
-    Isometry (compMeasurePreserving f hf : Lp E p μb → Lp E p μ) :=
-  AddMonoidHomClass.isometry_of_norm _ (norm_compMeasurePreserving · hf)
+theorem isometric_compMeasurePreserving [Fact (1 ≤ p)] (hf : MeasurePreserving f μ μb) :
+    Isometric (compMeasurePreserving f hf : Lp E p μb → Lp E p μ) :=
+  AddMonoidHomClass.isometric_of_norm _ (norm_compMeasurePreserving · hf)
+
+@[deprecated (since := "2026-09-09")] alias isometry_compMeasurePreserving :=
+  isometric_compMeasurePreserving
 
 theorem toLp_compMeasurePreserving {g : β → E} (hg : MemLp g p μb) (hf : MeasurePreserving f μ μb) :
     compMeasurePreserving f hf (hg.toLp g) = (hg.comp_measurePreserving hf).toLp _ := rfl

--- a/Mathlib/MeasureTheory/Function/LpSpace/ContinuousCompMeasurePreserving.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/ContinuousCompMeasurePreserving.lean
@@ -53,7 +53,7 @@ theorem compMeasurePreserving_continuous (hp : p ≠ ∞) :
   have hp₀ : p ≠ 0 := (one_pos.trans_le Fact.out).ne'
   refine continuous_prod_of_dense_continuous_lipschitzWith _ 1
     (MeasureTheory.Lp.simpleFunc.dense hp) ?_ fun f ↦
-      (isometry_compMeasurePreserving f.2).lipschitzWith
+      (isometric_compMeasurePreserving f.2).lipschitzWith
   intro f hf
   lift f to Lp.simpleFunc E p ν using hf
   induction f using Lp.simpleFunc.induction hp₀ hp with

--- a/Mathlib/MeasureTheory/Measure/Hausdorff.lean
+++ b/Mathlib/MeasureTheory/Measure/Hausdorff.lean
@@ -348,7 +348,7 @@ theorem mkMetric_mono {m₁ m₂ : ℝ≥0∞ → ℝ≥0∞} (hle : m₁ ≤ᶠ
     (mkMetric m₁ : OuterMeasure X) ≤ mkMetric m₂ := by
   convert! @mkMetric_mono_smul X _ _ m₂ _ ENNReal.one_ne_top one_ne_zero _ <;> simp [*]
 
-theorem isometry_comap_mkMetric (m : ℝ≥0∞ → ℝ≥0∞) {f : X → Y} (hf : Isometry f)
+theorem isometric_comap_mkMetric (m : ℝ≥0∞ → ℝ≥0∞) {f : X → Y} (hf : Isometric f)
     (H : Monotone m ∨ Surjective f) : comap f (mkMetric m) = mkMetric m := by
   simp only [mkMetric, mkMetric', mkMetric'.pre, comap_iSup]
   refine surjective_id.iSup_congr id fun ε => surjective_id.iSup_congr id fun hε => ?_
@@ -361,6 +361,8 @@ theorem isometry_comap_mkMetric (m : ℝ≥0∞ → ℝ≥0∞) {f : X → Y} (h
     apply le_trans _ (h_mono (ediam_mono hst))
     simp only [(ediam_mono hst).trans ht, le_refl, ciInf_pos]
 
+@[deprecated (since := "2026-09-09")] alias isometry_comap_mkMetric := isometric_comap_mkMetric
+
 theorem mkMetric_smul (m : ℝ≥0∞ → ℝ≥0∞) {c : ℝ≥0∞} (hc : c ≠ ∞) (hc' : c ≠ 0) :
     (mkMetric (c • m) : OuterMeasure X) = c • mkMetric m := by
   simp only [mkMetric, mkMetric', mkMetric'.pre]
@@ -371,13 +373,15 @@ theorem mkMetric_nnreal_smul (m : ℝ≥0∞ → ℝ≥0∞) {c : ℝ≥0} (hc :
   rw [ENNReal.smul_def, ENNReal.smul_def,
     mkMetric_smul m ENNReal.coe_ne_top (ENNReal.coe_ne_zero.mpr hc)]
 
-theorem isometry_map_mkMetric (m : ℝ≥0∞ → ℝ≥0∞) {f : X → Y} (hf : Isometry f)
+theorem isometric_map_mkMetric (m : ℝ≥0∞ → ℝ≥0∞) {f : X → Y} (hf : Isometric f)
     (H : Monotone m ∨ Surjective f) : map f (mkMetric m) = restrict (range f) (mkMetric m) := by
-  rw [← isometry_comap_mkMetric _ hf H, map_comap]
+  rw [← isometric_comap_mkMetric _ hf H, map_comap]
+
+@[deprecated (since := "2026-09-09")] alias isometry_map_mkMetric := isometric_map_mkMetric
 
 theorem isometryEquiv_comap_mkMetric (m : ℝ≥0∞ → ℝ≥0∞) (f : X ≃ᵢ Y) :
     comap f (mkMetric m) = mkMetric m :=
-  isometry_comap_mkMetric _ f.isometry (Or.inr f.surjective)
+  isometric_comap_mkMetric _ f.isometry (Or.inr f.surjective)
 
 theorem isometryEquiv_map_mkMetric (m : ℝ≥0∞ → ℝ≥0∞) (f : X ≃ᵢ Y) :
     map f (mkMetric m) = mkMetric m := by
@@ -818,27 +822,36 @@ end AntilipschitzWith
 -/
 
 
-namespace Isometry
+namespace Isometric
 
 variable {f : X → Y} {d : ℝ}
 
-theorem hausdorffMeasure_image (hf : Isometry f) (hd : 0 ≤ d ∨ Surjective f) (s : Set X) :
+theorem hausdorffMeasure_image (hf : Isometric f) (hd : 0 ≤ d ∨ Surjective f) (s : Set X) :
     μH[d] (f '' s) = μH[d] s := by
   simp only [hausdorffMeasure, ← OuterMeasure.coe_mkMetric, ← OuterMeasure.comap_apply]
-  rw [OuterMeasure.isometry_comap_mkMetric _ hf (hd.imp_left _)]
+  rw [OuterMeasure.isometric_comap_mkMetric _ hf (hd.imp_left _)]
   exact ENNReal.monotone_rpow_of_nonneg
 
-theorem hausdorffMeasure_preimage (hf : Isometry f) (hd : 0 ≤ d ∨ Surjective f) (s : Set Y) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.hausdorffMeasure_image :=
+  hausdorffMeasure_image
+
+theorem hausdorffMeasure_preimage (hf : Isometric f) (hd : 0 ≤ d ∨ Surjective f) (s : Set Y) :
     μH[d] (f ⁻¹' s) = μH[d] (s ∩ range f) := by
   rw [← hf.hausdorffMeasure_image hd, image_preimage_eq_inter_range]
 
-theorem map_hausdorffMeasure (hf : Isometry f) (hd : 0 ≤ d ∨ Surjective f) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.hausdorffMeasure_preimage :=
+  hausdorffMeasure_preimage
+
+theorem map_hausdorffMeasure (hf : Isometric f) (hd : 0 ≤ d ∨ Surjective f) :
     Measure.map f μH[d] = μH[d].restrict (range f) := by
   ext1 s hs
   rw [map_apply hf.continuous.measurable hs, Measure.restrict_apply hs,
     hf.hausdorffMeasure_preimage hd]
 
-end Isometry
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.map_hausdorffMeasure :=
+  map_hausdorffMeasure
+
+end Isometric
 
 namespace IsometryEquiv
 
@@ -1046,8 +1059,8 @@ theorem hausdorffMeasure_smul_right_image [NormedAddCommGroup E] [NormedSpace �
       μH[1] ((‖v‖ • ·) '' LinearMap.toSpanSingleton ℝ E (‖v‖⁻¹ • v) '' s) = ‖v‖₊ • μH[1] s by
     simpa only [Set.image_image, smul_comm (norm _), inv_smul_smul₀ hn,
       LinearMap.toSpanSingleton_apply] using this
-  have iso_smul : Isometry (LinearMap.toSpanSingleton ℝ E (‖v‖⁻¹ • v)) := by
-    refine AddMonoidHomClass.isometry_of_norm _ fun x => (norm_smul _ _).trans ?_
+  have iso_smul : Isometric (LinearMap.toSpanSingleton ℝ E (‖v‖⁻¹ • v)) := by
+    refine AddMonoidHomClass.isometric_of_norm _ fun x => (norm_smul _ _).trans ?_
     rw [norm_smul, norm_inv, norm_norm, inv_mul_cancel₀ hn, mul_one, LinearMap.id_apply]
   rw [Set.image_smul, Measure.hausdorffMeasure_smul₀ zero_le_one hn, nnnorm_norm,
       NNReal.rpow_one, iso_smul.hausdorffMeasure_image (Or.inl <| zero_le_one' ℝ)]

--- a/Mathlib/MeasureTheory/Measure/ResolventTransform.lean
+++ b/Mathlib/MeasureTheory/Measure/ResolventTransform.lean
@@ -78,7 +78,7 @@ theorem norm_resolvent_le_inv_infDist_support {μ : Measure 𝕜} {a : A}
   have : 0 < infDist a (algebraMap 𝕜 A '' μ.support) := by
     refine (IsClosed.notMem_iff_infDist_pos ?_ ((Set.nonempty_of_mem hx).image _)).mp hz
     refine (Topology.IsClosedEmbedding.isClosed_iff_image_isClosed ?_).mp isClosed_support
-    exact (algebraMap_isometry 𝕜 A).isClosedEmbedding
+    exact (algebraMap_isometric 𝕜 A).isClosedEmbedding
   have : infDist a (algebraMap 𝕜 A '' μ.support) ≤ ‖(algebraMap 𝕜 A) x - a‖ := by
     grw [infDist_le_dist_of_mem (y := (algebraMap 𝕜 A) x), ← dist_eq_norm, dist_comm]
     simp [hx]
@@ -136,7 +136,7 @@ theorem hasDerivAt_resolventTransform [RCLike A] [NormedAlgebra 𝕜 A] {μ : Me
   have : 0 < infDist a (algebraMap 𝕜 A '' μ.support) := by
     refine (IsClosed.notMem_iff_infDist_pos ?_ (h.image _)).mp ha
     refine (Topology.IsClosedEmbedding.isClosed_iff_image_isClosed ?_).mp isClosed_support
-    exact (algebraMap_isometry 𝕜 A).isClosedEmbedding
+    exact (algebraMap_isometric 𝕜 A).isClosedEmbedding
   let s : Set A := ball a ((infDist a (algebraMap 𝕜 A '' μ.support)) / 2)
   have hs_z : s ∈ 𝓝 a := ball_mem_nhds _ (by positivity)
   have hs_μ : s ⊆ (algebraMap 𝕜 A '' μ.support)ᶜ := by
@@ -178,7 +178,7 @@ theorem analyticOn_resolventTransform [NormedAlgebra 𝕜 ℂ] {μ : Measure �
     exact (hasDerivAt_resolventTransform z hz).differentiableAt.differentiableWithinAt
   apply isOpen_compl_iff.mpr
   refine (Topology.IsClosedEmbedding.isClosed_iff_image_isClosed ?_).mp isClosed_support
-  exact (algebraMap_isometry 𝕜 ℂ).isClosedEmbedding
+  exact (algebraMap_isometric 𝕜 ℂ).isClosedEmbedding
 
 end Deriv
 

--- a/Mathlib/MeasureTheory/SpecificCodomains/Pi.lean
+++ b/Mathlib/MeasureTheory/SpecificCodomains/Pi.lean
@@ -34,7 +34,7 @@ lemma memLp_pi_iff : MemLp f p μ ↔ ∀ i, MemLp (f · i) p μ where
     have : f = ∑ i, (Pi.single i) ∘ (f · i) := by ext; simp
     rw [this]
     refine memLp_finsetSum' _ fun i _ ↦ ?_
-    exact (Isometry.single i).lipschitzWith.comp_memLp (by simp) (hf i)
+    exact (Isometric.single i).lipschitzWith.comp_memLp (by simp) (hf i)
 
 alias ⟨MemLp.eval, MemLp.of_eval⟩ := memLp_pi_iff
 
@@ -65,8 +65,8 @@ lemma memLp_prod_iff :
         (AddMonoidHom.inr E F) ∘ (fun x ↦ (f x).snd) := by
       ext; all_goals simp
     rw [this]
-    exact MemLp.add (Isometry.inl.lipschitzWith.comp_memLp (by simp) h.1)
-      (Isometry.inr.lipschitzWith.comp_memLp (by simp) h.2)
+    exact MemLp.add (Isometric.inl.lipschitzWith.comp_memLp (by simp) h.1)
+      (Isometric.inr.lipschitzWith.comp_memLp (by simp) h.2)
 
 lemma MemLp.fst (h : MemLp f p μ) : MemLp (fun x ↦ (f x).fst) p μ :=
   memLp_prod_iff.1 h |>.1

--- a/Mathlib/NumberTheory/NumberField/Completion/InfinitePlace.lean
+++ b/Mathlib/NumberTheory/NumberField/Completion/InfinitePlace.lean
@@ -43,8 +43,8 @@ number field at an infinite place is then derived in this file, as `InfinitePlac
 ## Main results
 - `NumberField.Completion.locallyCompactSpace` : the completion of a number field at
   an infinite place is locally compact.
-- `NumberField.Completion.isometry_extensionEmbedding` : the embedding `v.Completion →+* ℂ` is
-  an isometry. See also `isometry_extensionEmbeddingOfIsReal` for the corresponding result on
+- `NumberField.Completion.isometric_extensionEmbedding` : the embedding `v.Completion →+* ℂ` is
+  an isometry. See also `isometric_extensionEmbeddingOfIsReal` for the corresponding result on
   `v.Completion →+* ℝ` when `v` is real.
 - `NumberField.Completion.bijective_extensionEmbedding_of_isComplex` : the embedding
   `v.Completion →+* ℂ` is bijective when `v` is complex. See also
@@ -64,17 +64,22 @@ open AbsoluteValue.Completion UniformSpace.Completion NumberField.ComplexEmbeddi
 
 variable {K : Type*} [Field K] (v : InfinitePlace K)
 
-theorem isometry_embedding : Isometry (v.embedding.comp (WithAbs.equiv v.1).toRingHom) :=
-  AddMonoidHomClass.isometry_of_norm _ fun x ↦ by
+theorem isometric_embedding : Isometric (v.embedding.comp (WithAbs.equiv v.1).toRingHom) :=
+  AddMonoidHomClass.isometric_of_norm _ fun x ↦ by
     simpa using! v.norm_embedding_eq (WithAbs.equiv v.1 x)
 
-theorem isometry_embedding_of_isReal (hv : v.IsReal) :
-    Isometry ((v.embedding_of_isReal hv).comp (WithAbs.equiv v.1).toRingHom) :=
-  AddMonoidHomClass.isometry_of_norm _ fun x ↦ by
+@[deprecated (since := "2026-09-09")] alias isometry_embedding := isometric_embedding
+
+theorem isometric_embedding_of_isReal (hv : v.IsReal) :
+    Isometric ((v.embedding_of_isReal hv).comp (WithAbs.equiv v.1).toRingHom) :=
+  AddMonoidHomClass.isometric_of_norm _ fun x ↦ by
     simpa using! v.norm_embedding_of_isReal hv (WithAbs.equiv v.1 x)
 
+@[deprecated (since := "2026-09-09")] alias isometry_embedding_of_isReal :=
+  isometric_embedding_of_isReal
+
 instance : CompletableTopField (WithAbs v.1) :=
-  v.isometry_embedding.isUniformInducing.completableTopField
+  v.isometric_embedding.isUniformInducing.completableTopField
 
 /-- The completion of a number field at an infinite place, as a one-field structure wrapping the
 completion `v.1.Completion` of `K` at the underlying absolute value. -/
@@ -130,22 +135,24 @@ theorem ofCompletion_surjective : Function.Surjective (ofCompletion (v := v)) :=
 @[simp] lemma norm_ofCompletion (x : v.1.Completion) :
     ‖(ofCompletion x : v.Completion)‖ = ‖x‖ := rfl
 
-theorem isometry_toCompletion : Isometry (toCompletion (v := v)) :=
-  Isometry.of_dist_eq fun _ _ ↦ rfl
+theorem isometric_toCompletion : Isometric (toCompletion (v := v)) :=
+  Isometric.of_dist_eq fun _ _ ↦ rfl
+
+@[deprecated (since := "2026-09-09")] alias isometry_toCompletion := isometric_toCompletion
 
 /-- `Completion.toCompletion` as an isometry equivalence onto the underlying completion. -/
 def isometryEquivCompletion : v.Completion ≃ᵢ v.1.Completion where
   toEquiv := equivCompletion v
-  isometry_toFun := isometry_toCompletion v
+  isometry_toFun := isometric_toCompletion v
 
 theorem continuous_toCompletion : Continuous (toCompletion (v := v)) :=
-  (isometry_toCompletion v).continuous
+  (isometric_toCompletion v).continuous
 
 theorem continuous_ofCompletion : Continuous (ofCompletion (v := v)) :=
   (isometryEquivCompletion v).symm.continuous
 
 instance : CompleteSpace v.Completion :=
-  ((isometry_toCompletion v).isUniformInducing.completeSpace_congr
+  ((isometric_toCompletion v).isUniformInducing.completeSpace_congr
     (toCompletion_surjective v)).mpr inferInstance
 
 instance : Inhabited v.Completion := ⟨0⟩
@@ -219,36 +226,42 @@ lemma Rat.norm_infinitePlace_completion (v : InfinitePlace ℚ) (x : ℚ) :
 
 /-- The completion of a number field at an infinite place is locally compact. -/
 instance locallyCompactSpace : LocallyCompactSpace (v.Completion) :=
-  letI := AbsoluteValue.Completion.locallyCompactSpace v.isometry_embedding
+  letI := AbsoluteValue.Completion.locallyCompactSpace v.isometric_embedding
   (isometryEquivCompletion v).toHomeomorph.isClosedEmbedding.locallyCompactSpace
 
 /-- The embedding associated to an infinite place extended to an embedding `v.Completion →+* ℂ`. -/
 def extensionEmbedding : v.Completion →+* ℂ :=
-  extensionHom _ v.isometry_embedding.continuous |>.comp (equiv v).toRingHom
+  extensionHom _ v.isometric_embedding.continuous |>.comp (equiv v).toRingHom
 
 /-- The embedding `K →+* ℝ` associated to a real infinite place extended to `v.Completion →+* ℝ`. -/
 def extensionEmbeddingOfIsReal {v : InfinitePlace K} (hv : IsReal v) : v.Completion →+* ℝ :=
-  extensionHom _ (v.isometry_embedding_of_isReal hv).continuous |>.comp <|
+  extensionHom _ (v.isometric_embedding_of_isReal hv).continuous |>.comp <|
     (equiv v).toRingHom
 
 @[simp]
 theorem extensionEmbedding_coe (x : WithAbs v.1) :
     extensionEmbedding v x = v.embedding (WithAbs.equiv v.1 x) :=
-  extensionHom_coe _ v.isometry_embedding.continuous _
+  extensionHom_coe _ v.isometric_embedding.continuous _
 
 @[simp]
 theorem extensionEmbeddingOfIsReal_coe {v : InfinitePlace K} (hv : IsReal v) (x : WithAbs v.1) :
     extensionEmbeddingOfIsReal hv x = embedding_of_isReal hv (WithAbs.equiv v.1 x) :=
-  extensionHom_coe _ (v.isometry_embedding_of_isReal hv).continuous _
+  extensionHom_coe _ (v.isometric_embedding_of_isReal hv).continuous _
 
 /-- The embedding `v.Completion →+* ℂ` is an isometry. -/
-theorem isometry_extensionEmbedding : Isometry (extensionEmbedding v) :=
-  v.isometry_embedding.completion_extension.comp (isometry_toCompletion v)
+theorem isometric_extensionEmbedding : Isometric (extensionEmbedding v) :=
+  v.isometric_embedding.completion_extension.comp (isometric_toCompletion v)
+
+@[deprecated (since := "2026-09-09")] alias isometry_extensionEmbedding :=
+  isometric_extensionEmbedding
 
 /-- The embedding `v.Completion →+* ℝ` at a real infinite place is an isometry. -/
-theorem isometry_extensionEmbeddingOfIsReal {v : InfinitePlace K} (hv : IsReal v) :
-    Isometry (extensionEmbeddingOfIsReal hv) :=
-  (v.isometry_embedding_of_isReal hv).completion_extension.comp (isometry_toCompletion v)
+theorem isometric_extensionEmbeddingOfIsReal {v : InfinitePlace K} (hv : IsReal v) :
+    Isometric (extensionEmbeddingOfIsReal hv) :=
+  (v.isometric_embedding_of_isReal hv).completion_extension.comp (isometric_toCompletion v)
+
+@[deprecated (since := "2026-09-09")] alias isometry_extensionEmbeddingOfIsReal :=
+  isometric_extensionEmbeddingOfIsReal
 
 @[simp]
 theorem extensionEmbeddingOfIsReal_apply {v : InfinitePlace K} (hv : IsReal v) (x : v.Completion) :
@@ -256,19 +269,19 @@ theorem extensionEmbeddingOfIsReal_apply {v : InfinitePlace K} (hv : IsReal v) (
   induction x using induction_on with
   | hp =>
     exact isClosed_eq
-      (Complex.continuous_ofReal.comp (isometry_extensionEmbeddingOfIsReal hv).continuous)
-      (isometry_extensionEmbedding v).continuous
+      (Complex.continuous_ofReal.comp (isometric_extensionEmbeddingOfIsReal hv).continuous)
+      (isometric_extensionEmbedding v).continuous
   | ih a => simp
 
 /-- The embedding `v.Completion →+* ℂ` has closed image inside `ℂ`. -/
 theorem isClosed_image_extensionEmbedding : IsClosed (Set.range (extensionEmbedding v)) :=
-  (isometry_extensionEmbedding v).isClosedEmbedding.isClosed_range
+  (isometric_extensionEmbedding v).isClosedEmbedding.isClosed_range
 
 /-- The embedding `v.Completion →+* ℝ` associated to a real infinite place has closed image
 inside `ℝ`. -/
 theorem isClosed_image_extensionEmbeddingOfIsReal {v : InfinitePlace K} (hv : IsReal v) :
     IsClosed (Set.range (extensionEmbeddingOfIsReal hv)) :=
-  (isometry_extensionEmbeddingOfIsReal hv).isClosedEmbedding.isClosed_range
+  (isometric_extensionEmbeddingOfIsReal hv).isClosedEmbedding.isClosed_range
 
 theorem subfield_ne_real_of_isComplex {v : InfinitePlace K} (hv : IsComplex v) :
     (extensionEmbedding v).fieldRange ≠ Complex.ofRealHom.fieldRange := by
@@ -303,7 +316,7 @@ def ringEquivComplexOfIsComplex {v : InfinitePlace K} (hv : IsComplex v) :
 def isometryEquivComplexOfIsComplex {v : InfinitePlace K} (hv : IsComplex v) :
     v.Completion ≃ᵢ ℂ where
   toEquiv := ringEquivComplexOfIsComplex hv
-  isometry_toFun := isometry_extensionEmbedding v
+  isometry_toFun := isometric_extensionEmbedding v
 
 /-- If `v` is a real infinite place, then the embedding `v.Completion →+* ℝ` is surjective. -/
 theorem surjective_extensionEmbeddingOfIsReal {v : InfinitePlace K} (hv : IsReal v) :
@@ -327,7 +340,7 @@ def ringEquivRealOfIsReal {v : InfinitePlace K} (hv : IsReal v) : v.Completion �
 /-- If the infinite place `v` is real, then `v.Completion` is isometric to `ℝ`. -/
 def isometryEquivRealOfIsReal {v : InfinitePlace K} (hv : IsReal v) : v.Completion ≃ᵢ ℝ where
   toEquiv := ringEquivRealOfIsReal hv
-  isometry_toFun := isometry_extensionEmbeddingOfIsReal hv
+  isometry_toFun := isometric_extensionEmbeddingOfIsReal hv
 
 variable {L : Type*} [Field L] [Algebra K L] (w : InfinitePlace L) {v}
 
@@ -366,9 +379,9 @@ theorem liesOver_extensionEmbedding [ContinuousSMul v.Completion w.Completion]
     ext x
     induction x using induction_on
     · exact isClosed_eq
-        ((isometry_extensionEmbedding w).continuous.comp
+        ((isometric_extensionEmbedding w).continuous.comp
           (continuous_algebraMap v.Completion w.Completion))
-        (isometry_extensionEmbedding v).continuous
+        (isometric_extensionEmbedding v).continuous
     · simp [WithAbs.algebraMap_left_apply, WithAbs.algebraMap_right_apply,
         ← ComplexEmbedding.LiesOver.over w.embedding v.embedding]
 
@@ -379,9 +392,9 @@ theorem liesOver_conjugate_extensionEmbedding [ContinuousSMul v.Completion w.Com
     ext x
     induction x using induction_on
     · simpa using! isClosed_eq (.comp (by fun_prop)
-          ((isometry_extensionEmbedding w).continuous.comp <|
+          ((isometric_extensionEmbedding w).continuous.comp <|
             continuous_algebraMap v.Completion w.Completion))
-        (isometry_extensionEmbedding v).continuous
+        (isometric_extensionEmbedding v).continuous
     · simp [WithAbs.algebraMap_left_apply, WithAbs.algebraMap_right_apply,
         ← ComplexEmbedding.LiesOver.over (conjugate w.embedding) v.embedding]
 
@@ -400,10 +413,12 @@ open Completion
 
 variable [w.LiesOver v]
 
-theorem isometry_algebraMap : Isometry (algebraMap (WithAbs v.1) (WithAbs w.1)) :=
-  AddMonoidHomClass.isometry_of_norm _ fun x ↦ by
+theorem isometric_algebraMap : Isometric (algebraMap (WithAbs v.1) (WithAbs w.1)) :=
+  AddMonoidHomClass.isometric_of_norm _ fun x ↦ by
     simpa [WithAbs.norm_eq_apply_ofAbs] using
       WithAbs.ofAbs_algebraMap v.1 w.1 x ▸ comp_of_comap_eq (comap_eq w v) x.ofAbs
+
+@[deprecated (since := "2026-09-09")] alias isometry_algebraMap := isometric_algebraMap
 
 variable {v}
 

--- a/Mathlib/NumberTheory/NumberField/Completion/LiesOverInstances.lean
+++ b/Mathlib/NumberTheory/NumberField/Completion/LiesOverInstances.lean
@@ -30,7 +30,7 @@ variable [w.LiesOver v]
 lies over `v`. -/
 noncomputable def completionMap : v.Completion →+* w.Completion :=
   ((Completion.equiv w).symm.toRingHom.comp <|
-    UniformSpace.Completion.mapRingHom _ (LiesOver.isometry_algebraMap w v).continuous).comp <|
+    UniformSpace.Completion.mapRingHom _ (LiesOver.isometric_algebraMap w v).continuous).comp <|
     (Completion.equiv v).toRingHom
 
 theorem continuous_completionMap : Continuous (completionMap (v := v) (w := w)) :=

--- a/Mathlib/Probability/Distributions/Gaussian/CharFun.lean
+++ b/Mathlib/Probability/Distributions/Gaussian/CharFun.lean
@@ -94,7 +94,7 @@ lemma gaussian_charFunDual_congr [IsFiniteMeasure μ] {m : E}
     field_simp
     ring
   have : Continuous n := by
-    rw [← Complex.isometry_intCast.comp_continuous_iff]
+    rw [← Complex.isometric_intCast.comp_continuous_iff]
     change Continuous (fun L ↦ (n L : ℂ))
     simp_rw [h]
     fun_prop

--- a/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
@@ -455,8 +455,10 @@ theorem dist_extend_extend (f : α ↪ δ) (g₁ g₂ : α →ᵇ β) (h₁ h₂
         rw [extend_apply' x.coe_prop, extend_apply' x.coe_prop]
       _ ≤ _ := dist_coe_le_dist _
 
-theorem isometry_extend (f : α ↪ δ) (h : δ →ᵇ β) : Isometry fun g : α →ᵇ β => extend f g h :=
-  Isometry.of_dist_eq fun g₁ g₂ => by simp
+theorem isometric_extend (f : α ↪ δ) (h : δ →ᵇ β) : Isometric fun g : α →ᵇ β => extend f g h :=
+  Isometric.of_dist_eq fun g₁ g₂ => by simp
+
+@[deprecated (since := "2026-09-09")] alias isometry_extend := isometric_extend
 
 end Extend
 

--- a/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
@@ -480,9 +480,11 @@ variable {α : Type*} {𝕜 : Type*} {R : Type*} [TopologicalSpace α] [CompactS
 noncomputable instance [MetricSpace R] [Zero R] : MetricSpace C(α, R)₀ :=
   ContinuousMapZero.isUniformEmbedding_toContinuousMap.comapMetricSpace _
 
-lemma isometry_toContinuousMap [MetricSpace R] [Zero R] :
-    Isometry (toContinuousMap : C(α, R)₀ → C(α, R)) :=
+lemma isometric_toContinuousMap [MetricSpace R] [Zero R] :
+    Isometric (toContinuousMap : C(α, R)₀ → C(α, R)) :=
   fun _ _ ↦ rfl
+
+@[deprecated (since := "2026-09-09")] alias isometry_toContinuousMap := isometric_toContinuousMap
 
 noncomputable instance [NormedAddCommGroup R] : Norm C(α, R)₀ where
   norm f := ‖(f : C(α, R))‖

--- a/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
+++ b/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
@@ -422,7 +422,9 @@ theorem tendsto_iff_tendstoUniformly {ι : Type*} {F : ι → C₀(α, β)} {f :
     @BoundedContinuousFunction.tendsto_iff_tendstoUniformly _ _ _ _ _ (fun i => (F i).toBCF)
       f.toBCF l
 
-theorem isometry_toBCF : Isometry (toBCF : C₀(α, β) → α →ᵇ β) := by tauto
+theorem isometric_toBCF : Isometric (toBCF : C₀(α, β) → α →ᵇ β) := by tauto
+
+@[deprecated (since := "2026-09-09")] alias isometry_toBCF := isometric_toBCF
 
 theorem isClosed_range_toBCF : IsClosed (range (toBCF : C₀(α, β) → α →ᵇ β)) := by
   refine isClosed_iff_clusterPt.mpr fun f hf => ?_
@@ -442,7 +444,7 @@ theorem isClosed_range_toBCF : IsClosed (range (toBCF : C₀(α, β) → α →�
 /-- Continuous functions vanishing at infinity taking values in a complete space form a
 complete space. -/
 instance instCompleteSpace [CompleteSpace β] : CompleteSpace C₀(α, β) :=
-  (completeSpace_iff_isComplete_range isometry_toBCF.isUniformInducing).mpr
+  (completeSpace_iff_isComplete_range isometric_toBCF.isUniformInducing).mpr
     isClosed_range_toBCF.isComplete
 
 end Metric

--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -208,8 +208,10 @@ instance instCompleteSpace [CompleteSpace α] : CompleteSpace (Closeds α) := by
     ((tendsto_order.1 this).2 ε εpos).exists_forall_of_atTop
   exact ⟨N, fun n hn => lt_of_le_of_lt (main n) (hN n hn)⟩
 
-theorem isometry_singleton : Isometry ({·} : α → Closeds α) :=
+theorem isometric_singleton : Isometric ({·} : α → Closeds α) :=
   fun _ _ => hausdorffEDist_singleton
+
+@[deprecated (since := "2026-09-09")] alias isometry_singleton := isometric_singleton
 
 theorem lipschitz_sup : LipschitzWith 1 fun p : Closeds α × Closeds α => p.1 ⊔ p.2 :=
   .of_edist_le fun _ _ => hausdorffEDist_union_le
@@ -235,11 +237,15 @@ instance instEMetricSpace : EMetricSpace (Compacts α) where
 theorem edist_eq {s t : Compacts α} : edist s t = hausdorffEDist (s : Set α) t :=
   rfl
 
-theorem isometry_toCloseds : Isometry (Compacts.toCloseds (α := α)) :=
+theorem isometric_toCloseds : Isometric (Compacts.toCloseds (α := α)) :=
   fun _ _ => rfl
 
-theorem isometry_singleton : Isometry ({·} : α → Compacts α) :=
+@[deprecated (since := "2026-09-09")] alias isometry_toCloseds := isometric_toCloseds
+
+theorem isometric_singleton : Isometric ({·} : α → Compacts α) :=
   fun _ _ => hausdorffEDist_singleton
+
+@[deprecated (since := "2026-09-09")] alias isometry_singleton := isometric_singleton
 
 theorem lipschitz_sup :
     LipschitzWith 1 fun p : Compacts α × Compacts α => p.1 ⊔ p.2 :=
@@ -265,14 +271,20 @@ instance instEMetricSpace : EMetricSpace (NonemptyCompacts α) where
     rwa [s.isCompact.isClosed.closure_eq, t.isCompact.isClosed.closure_eq] at this
 
 /-- `NonemptyCompacts.toCloseds` is an isometry -/
-theorem isometry_toCloseds : Isometry (@NonemptyCompacts.toCloseds α _ _) :=
+theorem isometric_toCloseds : Isometric (@NonemptyCompacts.toCloseds α _ _) :=
   fun _ _ => rfl
 
-theorem isometry_toCompacts : Isometry (NonemptyCompacts.toCompacts (α := α)) :=
+@[deprecated (since := "2026-09-09")] alias isometry_toCloseds := isometric_toCloseds
+
+theorem isometric_toCompacts : Isometric (NonemptyCompacts.toCompacts (α := α)) :=
   fun _ _ => rfl
 
-theorem isometry_singleton : Isometry ({·} : α → NonemptyCompacts α) :=
+@[deprecated (since := "2026-09-09")] alias isometry_toCompacts := isometric_toCompacts
+
+theorem isometric_singleton : Isometric ({·} : α → NonemptyCompacts α) :=
   fun _ _ => hausdorffEDist_singleton
+
+@[deprecated (since := "2026-09-09")] alias isometry_singleton := isometric_singleton
 
 theorem lipschitz_sup :
     LipschitzWith 1 fun p : NonemptyCompacts α × NonemptyCompacts α => p.1 ⊔ p.2 :=

--- a/Mathlib/Topology/MetricSpace/Completion.lean
+++ b/Mathlib/Topology/MetricSpace/Completion.lean
@@ -156,12 +156,14 @@ instance instMetricSpace : MetricSpace (Completion α) :=
       uniformity_dist := Completion.uniformity_dist } _
 
 /-- The embedding of a metric space in its completion is an isometry. -/
-theorem coe_isometry : Isometry ((↑) : α → Completion α) :=
-  Isometry.of_dist_eq Completion.dist_eq
+theorem coe_isometric : Isometric ((↑) : α → Completion α) :=
+  Isometric.of_dist_eq Completion.dist_eq
+
+@[deprecated (since := "2026-09-09")] alias coe_isometry := coe_isometric
 
 @[simp]
 protected theorem edist_eq (x y : α) : edist (x : Completion α) y = edist x y :=
-  coe_isometry x y
+  coe_isometric x y
 
 instance {M} [Zero M] [Zero α] [SMul M α] [PseudoMetricSpace M] [IsBoundedSMul M α] :
     IsBoundedSMul M (Completion α) where
@@ -190,17 +192,22 @@ theorem LipschitzWith.completion_extension [MetricSpace β] [CompleteSpace β] {
 
 theorem LipschitzWith.completion_map [PseudoMetricSpace β] {f : α → β} {K : ℝ≥0}
     (h : LipschitzWith K f) : LipschitzWith K (Completion.map f) :=
-  one_mul K ▸ (coe_isometry.lipschitzWith.comp h).completion_extension
+  one_mul K ▸ (coe_isometric.lipschitzWith.comp h).completion_extension
 
-theorem Isometry.completion_extension [PseudoMetricSpace β] [CompleteSpace β] [T0Space β]
-    {f : α → β} (h : Isometry f) : Isometry (Completion.extension f) :=
-  Isometry.of_dist_eq fun x y => induction_on₂ x y
+theorem Isometric.completion_extension [PseudoMetricSpace β] [CompleteSpace β] [T0Space β]
+    {f : α → β} (h : Isometric f) : Isometric (Completion.extension f) :=
+  Isometric.of_dist_eq fun x y => induction_on₂ x y
     (isClosed_eq (by fun_prop) (by fun_prop)) fun _ _ ↦ by
       simp only [extension_coe h.uniformContinuous, Completion.dist_eq, h.dist_eq]
 
-theorem Isometry.completion_map [PseudoMetricSpace β] {f : α → β}
-    (h : Isometry f) : Isometry (Completion.map f) :=
-  (coe_isometry.comp h).completion_extension
+@[deprecated (since := "2026-09-10")] alias Isometry.completion_extension :=
+  Isometric.completion_extension
+
+theorem Isometric.completion_map [PseudoMetricSpace β] {f : α → β}
+    (h : Isometric f) : Isometric (Completion.map f) :=
+  (coe_isometric.comp h).completion_extension
+
+@[deprecated (since := "2026-09-10")] alias Isometry.completion_map := Isometric.completion_map
 
 section extension_maps
 
@@ -209,28 +216,45 @@ variable [Ring α] [IsTopologicalRing α] [IsUniformAddGroup α] [Ring β]
 
 /-- The extension of an isometry to the completion of the domain. -/
 @[deprecated Completion.extensionHom (since := "2026-08-11")]
-def Isometry.extensionHom [CompleteSpace β] [T0Space β] {f : α →+* β} (h : Isometry f) :
+def Isometric.extensionHom [CompleteSpace β] [T0Space β] {f : α →+* β} (h : Isometric f) :
     Completion α →+* β := Completion.extensionHom f h.continuous
 
+@[deprecated (since := "2026-09-10")] alias Isometry.extensionHom := Isometric.extensionHom
+
 @[deprecated Completion.extensionHom_coe (since := "2026-08-11")]
-theorem Isometry.extensionHom_coe [CompleteSpace β] [T0Space β] {f : α →+* β} (h : Isometry f)
+theorem Isometric.extensionHom_coe [CompleteSpace β] [T0Space β] {f : α →+* β} (h : Isometric f)
     (x : α) : h.extensionHom x = f x := Completion.extensionHom_coe f h.continuous _
+
+@[deprecated (since := "2026-09-10")] alias Isometry.extensionHom_coe :=
+  Isometric.extensionHom_coe
 
 /-- The lift of an isometry to completions. -/
 @[deprecated Completion.mapRingHom (since := "2026-08-11")]
-def Isometry.mapRingHom {f : α →+* β} (h : Isometry f) : Completion α →+* Completion β :=
+def Isometric.mapRingHom {f : α →+* β} (h : Isometric f) : Completion α →+* Completion β :=
   Completion.mapRingHom f h.continuous
 
+@[deprecated (since := "2026-09-10")] alias Isometry.mapRingHom := Isometric.mapRingHom
+
 @[deprecated Completion.mapRingHom_coe (since := "2026-08-11")]
-theorem Isometry.mapRingHom_coe {f : α →+* β} (h : Isometry f) (x : α) : h.mapRingHom x = f x :=
+theorem Isometric.mapRingHom_coe {f : α →+* β} (h : Isometric f) (x : α) : h.mapRingHom x = f x :=
   Completion.mapRingHom_coe h.uniformContinuous.continuous _
 
-theorem UniformSpace.Completion.isometry_mapRingHom {f : α →+* β} (h : Isometry f) :
-    Isometry (Completion.mapRingHom f h.continuous) :=
+@[deprecated (since := "2026-09-10")] alias Isometry.mapRingHom_coe := Isometric.mapRingHom_coe
+
+theorem UniformSpace.Completion.isometric_mapRingHom {f : α →+* β} (h : Isometric f) :
+    Isometric (Completion.mapRingHom f h.continuous) :=
   h.completion_map
 
-@[deprecated Completion.isometry_mapRingHom (since := "2026-08-11")]
-theorem Isometry.isometry_mapRingHom {f : α →+* β} (h : Isometry f) : Isometry h.mapRingHom :=
-  Completion.isometry_mapRingHom h
+@[deprecated (since := "2026-09-10")] alias UniformSpace.Completion.isometry_mapRingHom :=
+  UniformSpace.Completion.isometric_mapRingHom
+
+@[deprecated Completion.isometric_mapRingHom (since := "2026-08-11")]
+theorem Isometric.isometric_mapRingHom {f : α →+* β} (h : Isometric f) : Isometric h.mapRingHom :=
+  Completion.isometric_mapRingHom h
+
+@[deprecated (since := "2026-09-09")] alias Isometric.isometry_mapRingHom :=
+  Isometric.isometric_mapRingHom
+@[deprecated (since := "2026-09-10")] alias Isometry.isometry_mapRingHom :=
+  Isometric.isometric_mapRingHom
 
 end extension_maps

--- a/Mathlib/Topology/MetricSpace/Congruence.lean
+++ b/Mathlib/Topology/MetricSpace/Congruence.lean
@@ -104,18 +104,18 @@ lemma index_map (h : v₁ ≅ v₂) (f : ι' → ι) : (v₁ ∘ f) ≅ (v₂ �
 lemma of_subsingleton_index [Subsingleton ι] : v₁ ≅ v₂ :=
   fun i j => by simp [Subsingleton.elim i j]
 
-lemma comp_left {f : P₁ → P₃} (hf : Isometry f) (h : v₁ ≅ v₂) : f ∘ v₁ ≅ v₂ :=
+lemma comp_left {f : P₁ → P₃} (hf : Isometric f) (h : v₁ ≅ v₂) : f ∘ v₁ ≅ v₂ :=
   .trans (fun _ _ ↦ hf _ _) h
 
-lemma comp_right {f : P₂ → P₃} (hf : Isometry f) (h : v₁ ≅ v₂) : v₁ ≅ f ∘ v₂ :=
+lemma comp_right {f : P₂ → P₃} (hf : Isometric f) (h : v₁ ≅ v₂) : v₁ ≅ f ∘ v₂ :=
   .trans h (.symm <| fun _ _ ↦ hf _ _)
 
 @[simp]
-lemma comp_left_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ≅ v₂ ↔ v₁ ≅ v₂ :=
+lemma comp_left_iff {f : P₁ → P₃} (hf : Isometric f) : f ∘ v₁ ≅ v₂ ↔ v₁ ≅ v₂ :=
   ⟨.trans <| .comp_right hf (.refl _), .comp_left hf⟩
 
 @[simp]
-lemma comp_right_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ≅ f ∘ v₂ ↔ v₁ ≅ v₂ := by
+lemma comp_right_iff {f : P₂ → P₃} (hf : Isometric f) : v₁ ≅ f ∘ v₂ ↔ v₁ ≅ v₂ := by
   rw [congruent_comm, comp_left_iff hf, congruent_comm]
 
 /-- Two sets of vertices remain congruent under a dilation if the dilations have equal ratios. -/

--- a/Mathlib/Topology/MetricSpace/Cover.lean
+++ b/Mathlib/Topology/MetricSpace/Cover.lean
@@ -77,12 +77,15 @@ lemma IsCover.image_lipschitz_of_surjective {f : X → Y} {s : Set Y} {N : Set X
   have : IsCover (K₂ * ε) (f '' s.preimage f) (f '' N) := IsCover.image_lipschitz hs hf
   simp_all only [image_preimage_eq]
 
-lemma _root_.Isometry.isCover_image_iff {f : X → Y} (hf : Isometry f) (C : Set X) :
+lemma _root_.Isometric.isCover_image_iff {f : X → Y} (hf : Isometric f) (C : Set X) :
     IsCover ε (f '' s) (f '' C) ↔ IsCover ε s C := by
   refine ⟨fun h x hx ↦ ?_, fun h ↦ by simpa using h.image_lipschitz hf.lipschitzWith⟩
   obtain ⟨c, hc_mem, hc⟩ := h (Set.mem_image_of_mem _ hx)
   obtain ⟨c', hc', rfl⟩ := hc_mem
   exact ⟨c', hc', le_of_eq_of_le (hf.edist_eq _ _).symm hc⟩
+
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.isCover_image_iff :=
+  _root_.Isometric.isCover_image_iff
 
 lemma IsCover.singleton_of_ediam_le (hA : ediam s ≤ ε) (hx : x ∈ s) :
     IsCover ε s ({x} : Set X) :=

--- a/Mathlib/Topology/MetricSpace/CoveringNumbers.lean
+++ b/Mathlib/Topology/MetricSpace/CoveringNumbers.lean
@@ -380,9 +380,9 @@ end Comparisons
 
 /-- The covering number of the image of a set under an injective isometry is equal to
 the covering number of the set.
-See `Isometry.coveringNumber_image` for the version in an `EMetricSpace`, in which injectivity is
+See `Isometric.coveringNumber_image` for the version in an `EMetricSpace`, in which injectivity is
 a consequence of being an isometry. -/
-lemma _root_.Isometry.coveringNumber_image' {f : X → Y} (hf : Isometry f) (hf_inj : Set.InjOn f A) :
+lemma _root_.Isometric.coveringNumber_image' {f : X → Y} (hf : Isometric f) (hf_inj : Set.InjOn f A) :
     coveringNumber ε (f '' A) = coveringNumber ε A := by
   refine le_antisymm ?_ ?_
   · simp only [coveringNumber, le_iInf_iff]
@@ -410,13 +410,19 @@ lemma _root_.Isometry.coveringNumber_image' {f : X → Y} (hf : Isometry f) (hf_
     rw [InjOn.encard_image]
     exact hf_inj.mono hC'_subset
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.coveringNumber_image' :=
+  _root_.Isometric.coveringNumber_image'
+
 /-- The covering number of the image of a set under an injective isometry is equal to
 the covering number of the set.
-See `Isometry.coveringNumber_image'` for the version in a `PseudoEMetricSpace` and not
+See `Isometric.coveringNumber_image'` for the version in a `PseudoEMetricSpace` and not
 an `EMetricSpace`, for which an additional injectivity assumption is needed. -/
-lemma _root_.Isometry.coveringNumber_image {X : Type*} [EMetricSpace X]
-    {f : X → Y} (hf : Isometry f) {A : Set X} :
+lemma _root_.Isometric.coveringNumber_image {X : Type*} [EMetricSpace X]
+    {f : X → Y} (hf : Isometric f) {A : Set X} :
     coveringNumber ε (f '' A) = coveringNumber ε A :=
   hf.coveringNumber_image' hf.injective.injOn
+
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.coveringNumber_image :=
+  _root_.Isometric.coveringNumber_image
 
 end Metric

--- a/Mathlib/Topology/MetricSpace/Dilation.lean
+++ b/Mathlib/Topology/MetricSpace/Dilation.lean
@@ -42,7 +42,7 @@ needed.
 ## TODO
 
 - Introduce dilation equivs.
-- Refactor the `Isometry` API to match the `*HomClass` API below.
+- Refactor the `Isometric` API to match the `*HomClass` API below.
 
 ## References
 
@@ -241,16 +241,23 @@ variable (f : F)
 
 /-- Every isometry is a dilation of ratio `1`. -/
 @[simps]
-def _root_.Isometry.toDilation (f : α → β) (hf : Isometry f) : α →ᵈ β where
+def _root_.Isometric.toDilation (f : α → β) (hf : Isometric f) : α →ᵈ β where
   toFun := f
   edist_eq' := ⟨1, one_ne_zero, by simpa using! hf⟩
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.toDilation :=
+  _root_.Isometric.toDilation
+
 @[simp]
-lemma _root_.Isometry.toDilation_ratio {f : α → β} {hf : Isometry f} : ratio hf.toDilation = 1 := by
+lemma _root_.Isometric.toDilation_ratio {f : α → β} {hf : Isometric f} :
+    ratio hf.toDilation = 1 := by
   by_cases! h : ∀ x y : α, edist x y = 0 ∨ edist x y = ⊤
   · exact ratio_of_trivial hf.toDilation h
   · obtain ⟨x, y, h₁, h₂⟩ := h
     exact ratio_unique h₁ h₂ (by simp [hf x y]) |>.symm
+
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.toDilation_ratio :=
+  _root_.Isometric.toDilation_ratio
 
 theorem lipschitz : LipschitzWith (ratio f) (f : α → β) := fun x y => (edist_eq f x y).le
 

--- a/Mathlib/Topology/MetricSpace/DilationEquiv.lean
+++ b/Mathlib/Topology/MetricSpace/DilationEquiv.lean
@@ -219,7 +219,7 @@ lemma _root_.IsometryEquiv.toDilationEquiv_toDilation (e : X ≃ᵢ Y) :
 
 @[simp]
 lemma _root_.IsometryEquiv.toDilationEquiv_ratio (e : X ≃ᵢ Y) : ratio e.toDilationEquiv = 1 := by
-  rw [← ratio_toDilation, IsometryEquiv.toDilationEquiv_toDilation, Isometry.toDilation_ratio]
+  rw [← ratio_toDilation, IsometryEquiv.toDilationEquiv_toDilation, Isometric.toDilation_ratio]
 
 /-- Reinterpret a `DilationEquiv` as a homeomorphism. -/
 def toHomeomorph (e : X ≃ᵈ Y) : X ≃ₜ Y where

--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -21,7 +21,7 @@ Gluing two metric spaces along a common subset. Formally, we are given
   v
   Y
 ```
-where `hΦ : Isometry Φ` and `hΨ : Isometry Ψ`.
+where `hΦ : Isometric Φ` and `hΨ : Isometric Ψ`.
 We want to complete the square by a space `GlueSpace hΦ hΨ` and two isometries
 `toGlueL hΦ hΨ` and `toGlueR hΦ hΨ` that make the square commute.
 We start by defining a predistance on the disjoint union `X ⊕ Y`, for which
@@ -295,12 +295,16 @@ attribute [local instance] metricSpaceSum
 theorem Sum.dist_eq {x y : X ⊕ Y} : dist x y = Sum.dist x y := rfl
 
 /-- The left injection of a space in a disjoint union is an isometry -/
-theorem isometry_inl : Isometry (Sum.inl : X → X ⊕ Y) :=
-  Isometry.of_dist_eq fun _ _ => rfl
+theorem isometric_inl : Isometric (Sum.inl : X → X ⊕ Y) :=
+  Isometric.of_dist_eq fun _ _ => rfl
+
+@[deprecated (since := "2026-09-09")] alias isometry_inl := isometric_inl
 
 /-- The right injection of a space in a disjoint union is an isometry -/
-theorem isometry_inr : Isometry (Sum.inr : Y → X ⊕ Y) :=
-  Isometry.of_dist_eq fun _ _ => rfl
+theorem isometric_inr : Isometric (Sum.inr : Y → X ⊕ Y) :=
+  Isometric.of_dist_eq fun _ _ => rfl
+
+@[deprecated (since := "2026-09-09")] alias isometry_inr := isometric_inr
 
 end Sum
 
@@ -437,8 +441,10 @@ protected def metricSpace : MetricSpace (Σ i, E i) := by
 attribute [local instance] Sigma.metricSpace
 
 /-- The injection of a space in a disjoint union is an isometry -/
-theorem isometry_mk (i : ι) : Isometry (Sigma.mk i : E i → Σ k, E k) :=
-  Isometry.of_dist_eq fun x y => by simp
+theorem isometric_mk (i : ι) : Isometric (Sigma.mk i : E i → Σ k, E k) :=
+  Isometric.of_dist_eq fun x y => by simp
+
+@[deprecated (since := "2026-09-09")] alias isometry_mk := isometric_mk
 
 /-- A disjoint union of complete metric spaces is complete. -/
 protected theorem completeSpace [∀ i, CompleteSpace (E i)] : CompleteSpace (Σ i, E i) := by
@@ -446,7 +452,7 @@ protected theorem completeSpace [∀ i, CompleteSpace (E i)] : CompleteSpace (Σ
   set U := { p : (Σ k, E k) × Σ k, E k | dist p.1 p.2 < 1 }
   have hc : ∀ i, IsComplete (s i) := fun i => by
     simp only [s, ← range_sigmaMk]
-    exact (isometry_mk i).isUniformInducing.isComplete_range
+    exact (isometric_mk i).isUniformInducing.isComplete_range
   have hd : ∀ (i j), ∀ x ∈ s i, ∀ y ∈ s j, (x, y) ∈ U → i = j := fun i j x hx y hy hxy =>
     (Eq.symm hx).trans ((fst_eq_of_dist_lt_one _ _ hxy).trans hy)
   refine completeSpace_of_isComplete_univ ?_
@@ -466,7 +472,7 @@ set_option backward.privateInPublic.warn false in
 /-- Given two isometric embeddings `Φ : Z → X` and `Ψ : Z → Y`, we define a pseudometric space
 structure on `X ⊕ Y` by declaring that `Φ x` and `Ψ x` are at distance `0`. -/
 @[instance_reducible]
-def gluePremetric (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : PseudoMetricSpace (X ⊕ Y) where
+def gluePremetric (hΦ : Isometric Φ) (hΨ : Isometric Ψ) : PseudoMetricSpace (X ⊕ Y) where
   dist := glueDist Φ Ψ 0
   dist_self := glueDist_self Φ Ψ 0
   dist_comm := glueDist_comm Φ Ψ 0
@@ -474,30 +480,30 @@ def gluePremetric (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : PseudoMetricSpace (X
 
 /-- Given two isometric embeddings `Φ : Z → X` and `Ψ : Z → Y`, we define a
 space `GlueSpace hΦ hΨ` by identifying in `X ⊕ Y` the points `Φ x` and `Ψ x`. -/
-def GlueSpace (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : Type _ :=
+def GlueSpace (hΦ : Isometric Φ) (hΨ : Isometric Ψ) : Type _ :=
   @SeparationQuotient _ (gluePremetric hΦ hΨ).toUniformSpace.toTopologicalSpace
 
-instance (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : MetricSpace (GlueSpace hΦ hΨ) :=
+instance (hΦ : Isometric Φ) (hΨ : Isometric Ψ) : MetricSpace (GlueSpace hΦ hΨ) :=
   inferInstanceAs <| MetricSpace <|
     @SeparationQuotient _ (gluePremetric hΦ hΨ).toUniformSpace.toTopologicalSpace
 
 /-- The canonical map from `X` to the space obtained by gluing isometric subsets in `X` and `Y`. -/
-def toGlueL (hΦ : Isometry Φ) (hΨ : Isometry Ψ) (x : X) : GlueSpace hΦ hΨ :=
+def toGlueL (hΦ : Isometric Φ) (hΨ : Isometric Ψ) (x : X) : GlueSpace hΦ hΨ :=
   Quotient.mk'' (.inl x)
 
 /-- The canonical map from `Y` to the space obtained by gluing isometric subsets in `X` and `Y`. -/
-def toGlueR (hΦ : Isometry Φ) (hΨ : Isometry Ψ) (y : Y) : GlueSpace hΦ hΨ :=
+def toGlueR (hΦ : Isometric Φ) (hΨ : Isometric Ψ) (y : Y) : GlueSpace hΦ hΨ :=
   Quotient.mk'' (.inr y)
 
-instance inhabitedLeft (hΦ : Isometry Φ) (hΨ : Isometry Ψ) [Inhabited X] :
+instance inhabitedLeft (hΦ : Isometric Φ) (hΨ : Isometric Ψ) [Inhabited X] :
     Inhabited (GlueSpace hΦ hΨ) :=
   ⟨toGlueL _ _ default⟩
 
-instance inhabitedRight (hΦ : Isometry Φ) (hΨ : Isometry Ψ) [Inhabited Y] :
+instance inhabitedRight (hΦ : Isometric Φ) (hΨ : Isometric Ψ) [Inhabited Y] :
     Inhabited (GlueSpace hΦ hΨ) :=
   ⟨toGlueR _ _ default⟩
 
-theorem toGlue_commute (hΦ : Isometry Φ) (hΨ : Isometry Ψ) :
+theorem toGlue_commute (hΦ : Isometric Φ) (hΨ : Isometric Ψ) :
     toGlueL hΦ hΨ ∘ Φ = toGlueR hΦ hΨ ∘ Ψ := by
   let i : PseudoMetricSpace (X ⊕ Y) := gluePremetric hΦ hΨ
   let _ := i.toUniformSpace.toTopologicalSpace
@@ -506,11 +512,15 @@ theorem toGlue_commute (hΦ : Isometry Φ) (hΨ : Isometry Ψ) :
   refine SeparationQuotient.mk_eq_mk.2 (Metric.inseparable_iff.2 ?_)
   exact glueDist_glued_points Φ Ψ 0 _
 
-theorem toGlueL_isometry (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : Isometry (toGlueL hΦ hΨ) :=
-  Isometry.of_dist_eq fun _ _ => rfl
+theorem toGlueL_isometric (hΦ : Isometric Φ) (hΨ : Isometric Ψ) : Isometric (toGlueL hΦ hΨ) :=
+  Isometric.of_dist_eq fun _ _ => rfl
 
-theorem toGlueR_isometry (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : Isometry (toGlueR hΦ hΨ) :=
-  Isometry.of_dist_eq fun _ _ => rfl
+@[deprecated (since := "2026-09-09")] alias toGlueL_isometry := toGlueL_isometric
+
+theorem toGlueR_isometric (hΦ : Isometric Φ) (hΨ : Isometric Ψ) : Isometric (toGlueR hΦ hΨ) :=
+  Isometric.of_dist_eq fun _ _ => rfl
+
+@[deprecated (since := "2026-09-09")] alias toGlueR_isometry := toGlueR_isometric
 
 end Gluing --section
 
@@ -544,7 +554,7 @@ def inductiveLimitDist (f : ∀ n, X n → X (n + 1)) (x y : Σ n, X n) : ℝ :=
 
 /-- The predistance on the disjoint union `Σ n, X n` can be computed in any `X k` for large
 enough `k`. -/
-theorem inductiveLimitDist_eq_dist (I : ∀ n, Isometry (f n)) (x y : Σ n, X n) :
+theorem inductiveLimitDist_eq_dist (I : ∀ n, Isometric (f n)) (x y : Σ n, X n) :
     ∀ m (hx : x.1 ≤ m) (hy : y.1 ≤ m), inductiveLimitDist f x y =
       dist (leRecOn hx (f _) x.2 : X m) (leRecOn hy (f _) y.2 : X m)
   | 0, hx, hy => by
@@ -566,7 +576,7 @@ theorem inductiveLimitDist_eq_dist (I : ∀ n, Isometry (f n)) (x y : Σ n, X n)
 
 /-- Premetric space structure on `Σ n, X n`. -/
 @[instance_reducible]
-def inductivePremetric (I : ∀ n, Isometry (f n)) : PseudoMetricSpace (Σ n, X n) where
+def inductivePremetric (I : ∀ n, Isometric (f n)) : PseudoMetricSpace (Σ n, X n) where
   dist := inductiveLimitDist f
   dist_self x := by simp [inductiveLimitDist]
   dist_comm x y := by
@@ -590,30 +600,32 @@ def inductivePremetric (I : ∀ n, Isometry (f n)) : PseudoMetricSpace (Σ n, X 
         rw [inductiveLimitDist_eq_dist I x y m hx hy, inductiveLimitDist_eq_dist I y z m hy hz]
 
 /-- The type giving the inductive limit in a metric space context. -/
-def InductiveLimit (I : ∀ n, Isometry (f n)) : Type _ :=
+def InductiveLimit (I : ∀ n, Isometric (f n)) : Type _ :=
   @SeparationQuotient _ (inductivePremetric I).toUniformSpace.toTopologicalSpace
 
-instance {I : ∀ (n : ℕ), Isometry (f n)} : MetricSpace (InductiveLimit (f := f) I) :=
+instance {I : ∀ (n : ℕ), Isometric (f n)} : MetricSpace (InductiveLimit (f := f) I) :=
   inferInstanceAs <| MetricSpace <|
     @SeparationQuotient _ (inductivePremetric I).toUniformSpace.toTopologicalSpace
 
 /-- Mapping each `X n` to the inductive limit. -/
-def toInductiveLimit (I : ∀ n, Isometry (f n)) (n : ℕ) (x : X n) : Metric.InductiveLimit I :=
+def toInductiveLimit (I : ∀ n, Isometric (f n)) (n : ℕ) (x : X n) : Metric.InductiveLimit I :=
   Quotient.mk'' (Sigma.mk n x)
 
-instance (I : ∀ n, Isometry (f n)) [Inhabited (X 0)] : Inhabited (InductiveLimit I) :=
+instance (I : ∀ n, Isometric (f n)) [Inhabited (X 0)] : Inhabited (InductiveLimit I) :=
   ⟨toInductiveLimit _ 0 default⟩
 
 /-- The map `toInductiveLimit n` mapping `X n` to the inductive limit is an isometry. -/
-theorem toInductiveLimit_isometry (I : ∀ n, Isometry (f n)) (n : ℕ) :
-    Isometry (toInductiveLimit I n) :=
-  Isometry.of_dist_eq fun x y => by
+theorem toInductiveLimit_isometric (I : ∀ n, Isometric (f n)) (n : ℕ) :
+    Isometric (toInductiveLimit I n) :=
+  Isometric.of_dist_eq fun x y => by
     change inductiveLimitDist f ⟨n, x⟩ ⟨n, y⟩ = dist x y
     rw [inductiveLimitDist_eq_dist I ⟨n, x⟩ ⟨n, y⟩ n (le_refl n) (le_refl n), leRecOn_self,
       leRecOn_self]
 
+@[deprecated (since := "2026-09-09")] alias toInductiveLimit_isometry := toInductiveLimit_isometric
+
 /-- The maps `toInductiveLimit n` are compatible with the maps `f n`. -/
-theorem toInductiveLimit_commute (I : ∀ n, Isometry (f n)) (n : ℕ) :
+theorem toInductiveLimit_commute (I : ∀ n, Isometric (f n)) (n : ℕ) :
     toInductiveLimit I n.succ ∘ f n = toInductiveLimit I n := by
   let h := inductivePremetric I
   let _ := h.toUniformSpace.toTopologicalSpace
@@ -630,7 +642,7 @@ theorem toInductiveLimit_commute (I : ∀ n, Isometry (f n)) (n : ℕ) :
 theorem dense_iUnion_range_toInductiveLimit
     {X : ℕ → Type u} [(n : ℕ) → MetricSpace (X n)]
     {f : (n : ℕ) → X n → X (n + 1)}
-    (I : ∀ (n : ℕ), Isometry (f n)) :
+    (I : ∀ (n : ℕ), Isometric (f n)) :
     Dense (⋃ i, range (toInductiveLimit I i)) := by
   refine dense_univ.mono ?_
   rintro ⟨n, x⟩ _
@@ -639,7 +651,7 @@ theorem dense_iUnion_range_toInductiveLimit
 theorem separableSpaceInductiveLimit_of_separableSpace
     {X : ℕ → Type u} [(n : ℕ) → MetricSpace (X n)]
     [hs : (n : ℕ) → TopologicalSpace.SeparableSpace (X n)] {f : (n : ℕ) → X n → X (n + 1)}
-    (I : ∀ (n : ℕ), Isometry (f n)) :
+    (I : ∀ (n : ℕ), Isometric (f n)) :
     TopologicalSpace.SeparableSpace (Metric.InductiveLimit I) := by
   choose hsX hcX hdX using (fun n ↦ TopologicalSpace.exists_countable_dense (X n))
   let s := ⋃ (i : ℕ), (toInductiveLimit I i '' (hsX i))
@@ -647,7 +659,7 @@ theorem separableSpaceInductiveLimit_of_separableSpace
   refine .of_closure <| (dense_iUnion_range_toInductiveLimit I).mono <| iUnion_subset fun i ↦ ?_
   calc
     range (toInductiveLimit I i) ⊆ closure (toInductiveLimit I i '' (hsX i)) :=
-      (toInductiveLimit_isometry I i |>.continuous).range_subset_closure_image_dense (hdX i)
+      (toInductiveLimit_isometric I i |>.continuous).range_subset_closure_image_dense (hdX i)
     _ ⊆ closure s := closure_mono <| subset_iUnion (fun j ↦ toInductiveLimit I j '' hsX j) i
 
 end InductiveLimit --section

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -99,7 +99,7 @@ def GHSpace.Rep (p : GHSpace) : Type :=
 
 theorem eq_toGHSpace_iff {X : Type u} [MetricSpace X] [CompactSpace X] [Nonempty X]
     {p : NonemptyCompacts ℓ_infty_ℝ} :
-    ⟦p⟧ = toGHSpace X ↔ ∃ Ψ : X → ℓ_infty_ℝ, Isometry Ψ ∧ range Ψ = p := by
+    ⟦p⟧ = toGHSpace X ↔ ∃ Ψ : X → ℓ_infty_ℝ, Isometric Ψ ∧ range Ψ = p := by
   simp only [toGHSpace, Quotient.eq]
   refine ⟨fun h => ?_, ?_⟩
   · rcases Setoid.symm h with ⟨e⟩
@@ -184,7 +184,7 @@ theorem dist_ghDist (p q : GHSpace) : dist p q = ghDist p.Rep q.Rep := by
 of isometric copies of the spaces, in any metric space. -/
 theorem ghDist_le_hausdorffDist {X : Type u} [MetricSpace X] [CompactSpace X] [Nonempty X]
     {Y : Type v} [MetricSpace Y] [CompactSpace Y] [Nonempty Y] {γ : Type w} [MetricSpace γ]
-    {Φ : X → γ} {Ψ : Y → γ} (ha : Isometry Φ) (hb : Isometry Ψ) :
+    {Φ : X → γ} {Ψ : Y → γ} (ha : Isometric Φ) (hb : Isometric Ψ) :
     ghDist X Y ≤ hausdorffDist (range Φ) (range Ψ) := by
   /- For the proof, we want to embed `γ` in `ℓ^∞(ℝ)`, to say that the Hausdorff distance is realized
     in `ℓ^∞(ℝ)` and therefore bounded below by the Gromov-Hausdorff-distance. However, `γ` is not
@@ -193,8 +193,8 @@ theorem ghDist_le_hausdorffDist {X : Type u} [MetricSpace X] [CompactSpace X] [N
   let s : Set γ := range Φ ∪ range Ψ
   let Φ' : X → s := fun y => ⟨Φ y, mem_union_left _ (mem_range_self _)⟩
   let Ψ' : Y → s := fun y => ⟨Ψ y, mem_union_right _ (mem_range_self _)⟩
-  have IΦ' : Isometry Φ' := fun x y => ha x y
-  have IΨ' : Isometry Ψ' := fun x y => hb x y
+  have IΦ' : Isometric Φ' := fun x y => ha x y
+  have IΨ' : Isometric Ψ' := fun x y => hb x y
   have : IsCompact s := (isCompact_range ha.continuous).union (isCompact_range hb.continuous)
   have : CompactSpace s := ⟨isCompact_iff_isCompact_univ.1 ‹IsCompact s›⟩
   have ΦΦ' : Φ = Subtype.val ∘ Φ' := rfl
@@ -370,7 +370,7 @@ theorem hausdorffDist_optimal {X : Type u} [MetricSpace X] [CompactSpace X] [Non
     · refine (Set.Nonempty.prod ?_ ?_).image _ <;> exact ⟨_, rfl⟩
     · rintro b ⟨⟨p, q⟩, ⟨hp, hq⟩, rfl⟩
       exact B p q hp hq
-  · exact ghDist_le_hausdorffDist (isometry_optimalGHInjl X Y) (isometry_optimalGHInjr X Y)
+  · exact ghDist_le_hausdorffDist (isometric_optimalGHInjl X Y) (isometric_optimalGHInjr X Y)
 
 /-- The Gromov-Hausdorff distance can also be realized by a coupling in `ℓ^∞(ℝ)`, by embedding
 the optimal coupling through its Kuratowski embedding. -/
@@ -378,13 +378,13 @@ theorem ghDist_eq_hausdorffDist (X : Type u) [MetricSpace X] [CompactSpace X] [N
     (Y : Type v) [MetricSpace Y] [CompactSpace Y] [Nonempty Y] :
     ∃ Φ : X → ℓ_infty_ℝ,
       ∃ Ψ : Y → ℓ_infty_ℝ,
-        Isometry Φ ∧ Isometry Ψ ∧ ghDist X Y = hausdorffDist (range Φ) (range Ψ) := by
+        Isometric Φ ∧ Isometric Ψ ∧ ghDist X Y = hausdorffDist (range Φ) (range Ψ) := by
   let F := kuratowskiEmbedding (OptimalGHCoupling X Y)
   let Φ := F ∘ optimalGHInjl X Y
   let Ψ := F ∘ optimalGHInjr X Y
   refine ⟨Φ, Ψ, ?_, ?_, ?_⟩
-  · exact (kuratowskiEmbedding.isometry _).comp (isometry_optimalGHInjl X Y)
-  · exact (kuratowskiEmbedding.isometry _).comp (isometry_optimalGHInjr X Y)
+  · exact (kuratowskiEmbedding.isometry _).comp (isometric_optimalGHInjl X Y)
+  · exact (kuratowskiEmbedding.isometry _).comp (isometric_optimalGHInjr X Y)
   · rw [← image_univ, ← image_univ, image_comp F, image_univ, image_comp F (optimalGHInjr X Y),
       image_univ, ← hausdorffDist_optimal]
     exact (hausdorffDist_image (kuratowskiEmbedding.isometry _)).symm
@@ -449,9 +449,9 @@ instance : MetricSpace GHSpace where
     let γ1 := OptimalGHCoupling X Y
     let γ2 := OptimalGHCoupling Y Z
     let Φ : Y → γ1 := optimalGHInjr X Y
-    have hΦ : Isometry Φ := isometry_optimalGHInjr X Y
+    have hΦ : Isometric Φ := isometric_optimalGHInjr X Y
     let Ψ : Y → γ2 := optimalGHInjl Y Z
-    have hΨ : Isometry Ψ := isometry_optimalGHInjl Y Z
+    have hΨ : Isometric Ψ := isometric_optimalGHInjl Y Z
     have Comm : toGlueL hΦ hΨ ∘ optimalGHInjr X Y = toGlueR hΦ hΨ ∘ optimalGHInjl Y Z :=
       toGlue_commute hΦ hΨ
     calc
@@ -459,18 +459,18 @@ instance : MetricSpace GHSpace where
         rw [x.toGHSpace_rep, z.toGHSpace_rep]
       _ ≤ hausdorffDist (range (toGlueL hΦ hΨ ∘ optimalGHInjl X Y))
             (range (toGlueR hΦ hΨ ∘ optimalGHInjr Y Z)) :=
-        (ghDist_le_hausdorffDist ((toGlueL_isometry hΦ hΨ).comp (isometry_optimalGHInjl X Y))
-          ((toGlueR_isometry hΦ hΨ).comp (isometry_optimalGHInjr Y Z)))
+        (ghDist_le_hausdorffDist ((toGlueL_isometric hΦ hΨ).comp (isometric_optimalGHInjl X Y))
+          ((toGlueR_isometric hΦ hΨ).comp (isometric_optimalGHInjr Y Z)))
       _ ≤ hausdorffDist (range (toGlueL hΦ hΨ ∘ optimalGHInjl X Y))
               (range (toGlueL hΦ hΨ ∘ optimalGHInjr X Y)) +
             hausdorffDist (range (toGlueL hΦ hΨ ∘ optimalGHInjr X Y))
               (range (toGlueR hΦ hΨ ∘ optimalGHInjr Y Z)) := by
         refine hausdorffDist_triangle <| hausdorffEDist_ne_top_of_nonempty_of_bounded
           (range_nonempty _) (range_nonempty _) ?_ ?_
-        · exact (isCompact_range (Isometry.continuous
-            ((toGlueL_isometry hΦ hΨ).comp (isometry_optimalGHInjl X Y)))).isBounded
-        · exact (isCompact_range (Isometry.continuous
-            ((toGlueL_isometry hΦ hΨ).comp (isometry_optimalGHInjr X Y)))).isBounded
+        · exact (isCompact_range (Isometric.continuous
+            ((toGlueL_isometric hΦ hΨ).comp (isometric_optimalGHInjl X Y)))).isBounded
+        · exact (isCompact_range (Isometric.continuous
+            ((toGlueL_isometric hΦ hΨ).comp (isometric_optimalGHInjr X Y)))).isBounded
       _ = hausdorffDist (toGlueL hΦ hΨ '' range (optimalGHInjl X Y))
               (toGlueL hΦ hΨ '' range (optimalGHInjr X Y)) +
             hausdorffDist (toGlueR hΦ hΨ '' range (optimalGHInjl Y Z))
@@ -478,8 +478,8 @@ instance : MetricSpace GHSpace where
         simp only [← range_comp, Comm]
       _ = hausdorffDist (range (optimalGHInjl X Y)) (range (optimalGHInjr X Y)) +
             hausdorffDist (range (optimalGHInjl Y Z)) (range (optimalGHInjr Y Z)) := by
-        rw [hausdorffDist_image (toGlueL_isometry hΦ hΨ),
-          hausdorffDist_image (toGlueR_isometry hΦ hΨ)]
+        rw [hausdorffDist_image (toGlueL_isometric hΦ hΨ),
+          hausdorffDist_image (toGlueR_isometric hΦ hΨ)]
       _ = dist (toGHSpace X) (toGHSpace Y) + dist (toGHSpace Y) (toGHSpace Z) := by
         rw [hausdorffDist_optimal, hausdorffDist_optimal, ghDist, ghDist]
       _ = dist x y + dist y z := by rw [x.toGHSpace_rep, y.toGHSpace_rep, z.toGHSpace_rep]
@@ -504,8 +504,8 @@ variable {X : Type u} [MetricSpace X]
 
 theorem ghDist_le_nonemptyCompacts_dist (p q : NonemptyCompacts X) :
     dist p.toGHSpace q.toGHSpace ≤ dist p q := by
-  have ha : Isometry ((↑) : p → X) := isometry_subtype_coe
-  have hb : Isometry ((↑) : q → X) := isometry_subtype_coe
+  have ha : Isometric ((↑) : p → X) := isometry_subtype_coe
+  have hb : Isometric ((↑) : q → X) := isometry_subtype_coe
   have A : dist p q = hausdorffDist (p : Set X) q := rfl
   have I : ↑p = range ((↑) : p → X) := Subtype.range_coe_subtype.symm
   have J : ↑q = range ((↑) : q → X) := Subtype.range_coe_subtype.symm
@@ -553,8 +553,8 @@ theorem ghDist_le_of_approx_subsets {s : Set X} (Φ : s → Y) {ε₁ ε₂ ε�
     glueMetricApprox (fun x : s => (x : X)) (fun x => Φ x) (ε₂ / 2 + δ) (by linarith) this
   let Fl := @Sum.inl X Y
   let Fr := @Sum.inr X Y
-  have Il : Isometry Fl := Isometry.of_dist_eq fun x y => rfl
-  have Ir : Isometry Fr := Isometry.of_dist_eq fun x y => rfl
+  have Il : Isometric Fl := Isometric.of_dist_eq fun x y => rfl
+  have Ir : Isometric Fr := Isometric.of_dist_eq fun x y => rfl
   /- The proof goes as follows : the `ghDist` is bounded by the Hausdorff distance of the images
     in the coupling, which is bounded (using the triangular inequality) by the sum of the Hausdorff
     distances of `X` and `s` (in the coupling or, equivalently in the original space), of `s` and
@@ -912,7 +912,7 @@ structure AuxGluingStruct (A : Type) [MetricSpace A] : Type 1 where
   Space : Type
   metric : MetricSpace Space
   embed : A → Space
-  isom : Isometry embed
+  isom : Isometric embed
 
 attribute [local instance] AuxGluingStruct.metric
 
@@ -927,11 +927,11 @@ instance (A : Type) [MetricSpace A] : Inhabited (AuxGluingStruct A) :=
 at step `n` by adding `X (n+1)`, glued in an optimal way to the `X n` already sitting there. -/
 def auxGluing (n : ℕ) : AuxGluingStruct (X n) :=
   Nat.recOn n default fun n Y =>
-    { Space := GlueSpace Y.isom (isometry_optimalGHInjl (X n) (X (n + 1)))
+    { Space := GlueSpace Y.isom (isometric_optimalGHInjl (X n) (X (n + 1)))
       metric := by infer_instance
       embed :=
-        toGlueR Y.isom (isometry_optimalGHInjl (X n) (X (n + 1))) ∘ optimalGHInjr (X n) (X (n + 1))
-      isom := (toGlueR_isometry _ _).comp (isometry_optimalGHInjr (X n) (X (n + 1))) }
+        toGlueR Y.isom (isometric_optimalGHInjl (X n) (X (n + 1))) ∘ optimalGHInjr (X n) (X (n + 1))
+      isom := (toGlueR_isometric _ _).comp (isometric_optimalGHInjr (X n) (X (n + 1))) }
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The Gromov-Hausdorff space is complete. -/
@@ -947,14 +947,14 @@ instance : CompleteSpace GHSpace := by
   -- this equality is true by definition but Lean unfolds some defs in the wrong order
   have E :
     ∀ n : ℕ,
-      GlueSpace (Y n).isom (isometry_optimalGHInjl (X n) (X (n + 1))) = (Y (n + 1)).Space :=
+      GlueSpace (Y n).isom (isometric_optimalGHInjl (X n) (X (n + 1))) = (Y (n + 1)).Space :=
     fun n => by dsimp only [Y, auxGluing]
   let c n := cast (E n)
-  have ic : ∀ n, Isometry (c n) := fun n x y => by dsimp only [Y, auxGluing]; exact rfl
+  have ic : ∀ n, Isometric (c n) := fun n x y => by dsimp only [Y, auxGluing]; exact rfl
   -- there is a canonical embedding of `Y n` in `Y (n+1)`, by construction
   let f : ∀ n, (Y n).Space → (Y (n + 1)).Space := fun n =>
-    c n ∘ toGlueL (Y n).isom (isometry_optimalGHInjl (X n) (X n.succ))
-  have I : ∀ n, Isometry (f n) := fun n => (ic n).comp (toGlueL_isometry _ _)
+    c n ∘ toGlueL (Y n).isom (isometric_optimalGHInjl (X n) (X n.succ))
+  have I : ∀ n, Isometric (f n) := fun n => (ic n).comp (toGlueL_isometric _ _)
   -- consider the inductive limit `Z0` of the `Y n`, and then its completion `Z`
   let Z0 := Metric.InductiveLimit I
   let Z := UniformSpace.Completion Z0
@@ -962,33 +962,33 @@ instance : CompleteSpace GHSpace := by
   let coeZ := ((↑) : Z0 → Z)
   -- let `X2 n` be the image of `X n` in the space `Z`
   let X2 n := range (coeZ ∘ Φ n ∘ (Y n).embed)
-  have isom : ∀ n, Isometry (coeZ ∘ Φ n ∘ (Y n).embed) := by
+  have isom : ∀ n, Isometric (coeZ ∘ Φ n ∘ (Y n).embed) := by
     intro n
-    refine UniformSpace.Completion.coe_isometry.comp ?_
-    exact (toInductiveLimit_isometry _ _).comp (Y n).isom
+    refine UniformSpace.Completion.coe_isometric.comp ?_
+    exact (toInductiveLimit_isometric _ _).comp (Y n).isom
   -- The Hausdorff distance of `X2 n` and `X2 (n+1)` is by construction the distance between
   -- `u n` and `u (n+1)`, therefore bounded by `1/2^n`
   have X2n : ∀ n, X2 n =
     range ((coeZ ∘ Φ n.succ ∘ c n ∘ toGlueR (Y n).isom
-      (isometry_optimalGHInjl (X n) (X n.succ))) ∘ optimalGHInjl (X n) (X n.succ)) := by
+      (isometric_optimalGHInjl (X n) (X n.succ))) ∘ optimalGHInjl (X n) (X n.succ)) := by
     intro n
     change X2 n = range (coeZ ∘ Φ n.succ ∘ c n ∘
-      toGlueR (Y n).isom (isometry_optimalGHInjl (X n) (X n.succ)) ∘
+      toGlueR (Y n).isom (isometric_optimalGHInjl (X n) (X n.succ)) ∘
       optimalGHInjl (X n) (X n.succ))
     simp only [X2, Φ]
     rw [← toInductiveLimit_commute I]
     simp only [f, ← toGlue_commute, Function.comp_assoc]
   have X2nsucc : ∀ n, X2 n.succ =
       range ((coeZ ∘ Φ n.succ ∘ c n ∘ toGlueR (Y n).isom
-        (isometry_optimalGHInjl (X n) (X n.succ))) ∘ optimalGHInjr (X n) (X n.succ)) := by
+        (isometric_optimalGHInjl (X n) (X n.succ))) ∘ optimalGHInjr (X n) (X n.succ)) := by
     intro n
     rfl
   have D2 : ∀ n, hausdorffDist (X2 n) (X2 n.succ) < d n := fun n ↦ by
     rw [X2n n, X2nsucc n, range_comp, range_comp, hausdorffDist_image,
       hausdorffDist_optimal, ← dist_ghDist]
     · exact hu n n n.succ (le_refl n) (le_succ n)
-    · apply UniformSpace.Completion.coe_isometry.comp _
-      exact (toInductiveLimit_isometry _ _).comp ((ic n).comp (toGlueR_isometry _ _))
+    · apply UniformSpace.Completion.coe_isometric.comp _
+      exact (toInductiveLimit_isometric _ _).comp ((ic n).comp (toGlueR_isometric _ _))
   -- consider `X2 n` as a member `X3 n` of the type of nonempty compact subsets of `Z`, which
   -- is a metric space
   let X3 : ℕ → NonemptyCompacts Z := fun n =>

--- a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
@@ -115,7 +115,7 @@ private theorem maxVar_bound [CompactSpace X] [Nonempty X] [CompactSpace Y] [Non
       (diam_union (mem_range_self _) (mem_range_self _))
     _ = diam (univ : Set X) + (dist (α := X) default default + 1 + dist (α := Y) default default) +
         diam (univ : Set Y) := by
-      rw [isometry_inl.diam_range, isometry_inr.diam_range]
+      rw [isometric_inl.diam_range, isometric_inr.diam_range]
       rfl
     _ = 1 * diam (univ : Set X) + 1 + 1 * diam (univ : Set Y) := by simp
     _ ≤ 2 * diam (univ : Set X) + 1 + 2 * diam (univ : Set Y) := by gcongr <;> norm_num
@@ -486,23 +486,27 @@ def optimalGHInjl (x : X) : OptimalGHCoupling X Y :=
   Quotient.mk'' (inl x)
 
 /-- The injection of `X` in the optimal coupling between `X` and `Y` is an isometry. -/
-theorem isometry_optimalGHInjl : Isometry (optimalGHInjl X Y) :=
-  Isometry.of_dist_eq fun _ _ => candidates_dist_inl (optimalGHDist_mem_candidatesB X Y) _ _
+theorem isometric_optimalGHInjl : Isometric (optimalGHInjl X Y) :=
+  Isometric.of_dist_eq fun _ _ => candidates_dist_inl (optimalGHDist_mem_candidatesB X Y) _ _
+
+@[deprecated (since := "2026-09-09")] alias isometry_optimalGHInjl := isometric_optimalGHInjl
 
 /-- Injection of `Y` in the optimal coupling between `X` and `Y` -/
 def optimalGHInjr (y : Y) : OptimalGHCoupling X Y :=
   Quotient.mk'' (inr y)
 
 /-- The injection of `Y` in the optimal coupling between `X` and `Y` is an isometry. -/
-theorem isometry_optimalGHInjr : Isometry (optimalGHInjr X Y) :=
-  Isometry.of_dist_eq fun _ _ => candidates_dist_inr (optimalGHDist_mem_candidatesB X Y) _ _
+theorem isometric_optimalGHInjr : Isometric (optimalGHInjr X Y) :=
+  Isometric.of_dist_eq fun _ _ => candidates_dist_inr (optimalGHDist_mem_candidatesB X Y) _ _
+
+@[deprecated (since := "2026-09-09")] alias isometry_optimalGHInjr := isometric_optimalGHInjr
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The optimal coupling between two compact spaces `X` and `Y` is still a compact space -/
 instance compactSpace_optimalGHCoupling : CompactSpace (OptimalGHCoupling X Y) := ⟨by
   rw [← range_quotient_mk']
   exact isCompact_range (continuous_sum_dom.2
-    ⟨(isometry_optimalGHInjl X Y).continuous, (isometry_optimalGHInjr X Y).continuous⟩)⟩
+    ⟨(isometric_optimalGHInjl X Y).continuous, (isometric_optimalGHInjr X Y).continuous⟩)⟩
 
 set_option backward.privateInPublic true in
 set_option backward.privateInPublic.warn false in

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -48,7 +48,7 @@ properties of Hausdorff dimension.
   `HolderOnWith`, and locally Hölder maps, as well as for `Set.image` and `Set.range`.
 * `LipschitzWith.dimH_image_le` etc: Lipschitz continuous maps do not increase the Hausdorff
   dimension of sets.
-* for a map that is known to be both Lipschitz and antilipschitz (e.g., for an `Isometry` or
+* for a map that is known to be both Lipschitz and antilipschitz (e.g., for an `Isometric` or
   a `ContinuousLinearEquiv`) we also prove `dimH (f '' s) = dimH s`.
 
 ### Hausdorff measure in `ℝⁿ`
@@ -391,8 +391,10 @@ end AntilipschitzWith
 -/
 
 
-theorem Isometry.dimH_image (hf : Isometry f) (s : Set X) : dimH (f '' s) = dimH s :=
+theorem Isometric.dimH_image (hf : Isometric f) (s : Set X) : dimH (f '' s) = dimH s :=
   le_antisymm (hf.lipschitzWith.dimH_image_le _) (hf.antilipschitzWith.le_dimH_image _)
+
+@[deprecated (since := "2026-09-10")] alias Isometry.dimH_image := Isometric.dimH_image
 
 namespace IsometryEquiv
 
@@ -481,7 +483,7 @@ theorem Convex.dimH_eq_finrank_vectorSpan {s : Set E} (hcvx : Convex ℝ s) (hne
     (⟨hne.some, subset_affineSpan ℝ s hne.some_mem⟩ : affineSpan ℝ s)
   have hs_eq : s = (↑) '' ((↑) ⁻¹' s : Set (affineSpan ℝ s)) :=
     (image_preimage_eq_of_subset <| (subset_affineSpan ℝ s).trans Subtype.range_coe.superset).symm
-  rw [hs_eq, isometry_subtype_coe.dimH_image, ← φ.isometry.dimH_image,
+  rw [hs_eq, isometry_subtype_coe.dimH_image, ← φ.isometric.dimH_image,
       Real.dimH_of_nonempty_interior, direction_affineSpan ℝ s, ← hs_eq]
   simp_rw [← AffineIsometryEquiv.coe_toHomeomorph, ← φ.toHomeomorph.image_interior, image_nonempty]
   simpa [intrinsicInterior] using (intrinsicInterior_nonempty hcvx).mpr hne

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -197,7 +197,7 @@ theorem disjoint_closedEBall_of_lt_infEDist {r : ℝ≥0∞} (h : r < infEDist x
     _ < infEDist x s := h
 
 /-- The infimum edistance is invariant under isometries -/
-theorem infEDist_image (hΦ : Isometry Φ) : infEDist (Φ x) (Φ '' t) = infEDist x t := by
+theorem infEDist_image (hΦ : Isometric Φ) : infEDist (Φ x) (Φ '' t) = infEDist x t := by
   simp only [infEDist, iInf_image, hΦ.edist_eq]
 
 @[to_additive (attr := simp)]
@@ -327,7 +327,7 @@ theorem infEDist_le_infEDist_add_hausdorffEDist :
         rw [add_add_add_comm, ENNReal.add_halves]
 
 /-- The Hausdorff edistance is invariant under isometries. -/
-theorem hausdorffEDist_image (h : Isometry Φ) :
+theorem hausdorffEDist_image (h : Isometric Φ) :
     hausdorffEDist (Φ '' s) (Φ '' t) = hausdorffEDist s t := by
   simp only [hausdorffEDist_def, iSup_image, infEDist_image h]
 
@@ -594,7 +594,7 @@ theorem continuousAt_inv_infDist_pt (h : x ∉ closure s) :
     rwa [Ne, ← mem_closure_iff_infDist_zero hs]
 
 /-- The infimum distance is invariant under isometries. -/
-theorem infDist_image (hΦ : Isometry Φ) : infDist (Φ x) (Φ '' t) = infDist x t := by
+theorem infDist_image (hΦ : Isometric Φ) : infDist (Φ x) (Φ '' t) = infDist x t := by
   simp [infDist, infEDist_image hΦ]
 
 theorem infDist_inter_closedBall_of_mem (h : y ∈ s) :
@@ -776,7 +776,7 @@ theorem infDist_le_infDist_add_hausdorffDist (fin : hausdorffEDist s t ≠ ⊤) 
   exact mt (nonempty_of_hausdorffEDist_ne_top · fin) h
 
 /-- The Hausdorff distance is invariant under isometries. -/
-theorem hausdorffDist_image (h : Isometry Φ) :
+theorem hausdorffDist_image (h : Isometric Φ) :
     hausdorffDist (Φ '' s) (Φ '' t) = hausdorffDist s t := by
   simp [hausdorffDist, hausdorffEDist_image h]
 

--- a/Mathlib/Topology/MetricSpace/IsometricSMul.lean
+++ b/Mathlib/Topology/MetricSpace/IsometricSMul.lean
@@ -44,12 +44,12 @@ variable (M : Type u) (G : Type v) (X : Type w)
 
 /-- An additive action is isometric if each map `x ↦ c +ᵥ x` is an isometry. -/
 class IsIsometricVAdd (X : Type w) [PseudoEMetricSpace X] [VAdd M X] : Prop where
-  isometry_vadd (X) : ∀ c : M, Isometry ((c +ᵥ ·) : X → X)
+  isometry_vadd (X) : ∀ c : M, Isometric ((c +ᵥ ·) : X → X)
 
 /-- A multiplicative action is isometric if each map `x ↦ c • x` is an isometry. -/
 @[to_additive]
 class IsIsometricSMul (X : Type w) [PseudoEMetricSpace X] [SMul M X] : Prop where
-  isometry_smul (X) : ∀ c : M, Isometry ((c • ·) : X → X)
+  isometry_smul (X) : ∀ c : M, Isometric ((c • ·) : X → X)
 
 export IsIsometricSMul (isometry_smul)
 export IsIsometricVAdd (isometry_vadd)
@@ -81,24 +81,30 @@ theorem ediam_smul [SMul M X] [IsIsometricSMul M X] (c : M) (s : Set X) :
   (isometry_smul _ _).ediam_image s
 
 @[to_additive]
-theorem isometry_mul_left [Mul M] [PseudoEMetricSpace M] [IsIsometricSMul M M] (a : M) :
-    Isometry (a * ·) :=
+theorem isometric_mul_left [Mul M] [PseudoEMetricSpace M] [IsIsometricSMul M M] (a : M) :
+    Isometric (a * ·) :=
   isometry_smul M a
+
+@[deprecated (since := "2026-09-10")] alias isometry_mul_left := isometric_mul_left
+@[deprecated (since := "2026-09-10")] alias isometry_add_left := isometric_add_left
 
 @[to_additive (attr := simp)]
 theorem edist_mul_left [Mul M] [PseudoEMetricSpace M] [IsIsometricSMul M M] (a b c : M) :
     edist (a * b) (a * c) = edist b c :=
-  isometry_mul_left a b c
+  isometric_mul_left a b c
 
 @[to_additive]
-theorem isometry_mul_right [Mul M] [PseudoEMetricSpace M] [IsIsometricSMul Mᵐᵒᵖ M] (a : M) :
-    Isometry fun x => x * a :=
+theorem isometric_mul_right [Mul M] [PseudoEMetricSpace M] [IsIsometricSMul Mᵐᵒᵖ M] (a : M) :
+    Isometric fun x => x * a :=
   isometry_smul M (MulOpposite.op a)
+
+@[deprecated (since := "2026-09-10")] alias isometry_mul_right := isometric_mul_right
+@[deprecated (since := "2026-09-10")] alias isometry_add_right := isometric_add_right
 
 @[to_additive (attr := simp)]
 theorem edist_mul_right [Mul M] [PseudoEMetricSpace M] [IsIsometricSMul Mᵐᵒᵖ M] (a b c : M) :
     edist (a * c) (b * c) = edist a b :=
-  isometry_mul_right c a b
+  isometric_mul_right c a b
 
 @[to_additive (attr := simp)]
 theorem edist_div_right [DivInvMonoid M] [PseudoEMetricSpace M] [IsIsometricSMul Mᵐᵒᵖ M]
@@ -112,9 +118,12 @@ theorem edist_inv_inv [PseudoEMetricSpace G] [IsIsometricSMul G G] [IsIsometricS
     edist_comm]
 
 @[to_additive]
-theorem isometry_inv [PseudoEMetricSpace G] [IsIsometricSMul G G] [IsIsometricSMul Gᵐᵒᵖ G] :
-    Isometry (Inv.inv : G → G) :=
+theorem isometric_inv [PseudoEMetricSpace G] [IsIsometricSMul G G] [IsIsometricSMul Gᵐᵒᵖ G] :
+    Isometric (Inv.inv : G → G) :=
   edist_inv_inv
+
+@[deprecated (since := "2026-09-10")] alias isometry_inv := isometric_inv
+@[deprecated (since := "2026-09-10")] alias isometry_neg := isometric_neg
 
 @[to_additive]
 theorem edist_inv [PseudoEMetricSpace G] [IsIsometricSMul G G] [IsIsometricSMul Gᵐᵒᵖ G]
@@ -389,7 +398,7 @@ instance Prod.isIsometricSMul' {N} [Mul M] [PseudoEMetricSpace M] [IsIsometricSM
 instance Prod.isIsometricSMul'' {N} [Mul M] [PseudoEMetricSpace M] [IsIsometricSMul Mᵐᵒᵖ M]
     [Mul N] [PseudoEMetricSpace N] [IsIsometricSMul Nᵐᵒᵖ N] :
     IsIsometricSMul (M × N)ᵐᵒᵖ (M × N) :=
-  ⟨fun c => (isometry_mul_right c.unop.1).prodMap (isometry_mul_right c.unop.2)⟩
+  ⟨fun c => (isometric_mul_right c.unop.1).prodMap (isometric_mul_right c.unop.2)⟩
 
 @[to_additive]
 instance Units.isIsometricSMul [Monoid M] : IsIsometricSMul Mˣ X :=
@@ -422,7 +431,7 @@ instance Pi.isIsometricSMul' {ι} {M X : ι → Type*} [Fintype ι] [∀ i, SMul
 instance Pi.isIsometricSMul'' {ι} {M : ι → Type*} [Fintype ι] [∀ i, Mul (M i)]
     [∀ i, PseudoEMetricSpace (M i)] [∀ i, IsIsometricSMul (M i)ᵐᵒᵖ (M i)] :
     IsIsometricSMul (∀ i, M i)ᵐᵒᵖ (∀ i, M i) :=
-  ⟨fun c => .piMap (fun i (x : M i) => x * c.unop i) fun _ => isometry_mul_right _⟩
+  ⟨fun c => .piMap (fun i (x : M i) => x * c.unop i) fun _ => isometric_mul_right _⟩
 
 instance Additive.isIsIsometricVAdd : IsIsometricVAdd (Additive M) X :=
   ⟨fun c => isometry_smul X c.toMul⟩

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -37,33 +37,43 @@ open scoped Topology ENNReal
 
 /-- An isometry (also known as isometric embedding) is a map preserving the edistance
 between pseudoemetric spaces, or equivalently the distance between pseudometric space. -/
-def Isometry [PseudoEMetricSpace α] [PseudoEMetricSpace β] (f : α → β) : Prop :=
+def Isometric [PseudoEMetricSpace α] [PseudoEMetricSpace β] (f : α → β) : Prop :=
   ∀ x1 x2 : α, edist (f x1) (f x2) = edist x1 x2
+
+@[deprecated (since := "2026-09-09")] alias Isometry := Isometric
 
 /-- On pseudometric spaces, a map is an isometry if and only if it preserves nonnegative
 distances. -/
-theorem isometry_iff_nndist_eq [PseudoMetricSpace α] [PseudoMetricSpace β] {f : α → β} :
-    Isometry f ↔ ∀ x y, nndist (f x) (f y) = nndist x y := by
-  simp only [Isometry, edist_nndist, ENNReal.coe_inj]
+theorem isometric_iff_nndist_eq [PseudoMetricSpace α] [PseudoMetricSpace β] {f : α → β} :
+    Isometric f ↔ ∀ x y, nndist (f x) (f y) = nndist x y := by
+  simp only [Isometric, edist_nndist, ENNReal.coe_inj]
 
 /-- On pseudometric spaces, a map is an isometry if and only if it preserves distances. -/
-theorem isometry_iff_dist_eq [PseudoMetricSpace α] [PseudoMetricSpace β] {f : α → β} :
-    Isometry f ↔ ∀ x y, dist (f x) (f y) = dist x y := by
-  simp only [isometry_iff_nndist_eq, ← coe_nndist, NNReal.coe_inj]
+theorem isometric_iff_dist_eq [PseudoMetricSpace α] [PseudoMetricSpace β] {f : α → β} :
+    Isometric f ↔ ∀ x y, dist (f x) (f y) = dist x y := by
+  simp only [isometric_iff_nndist_eq, ← coe_nndist, NNReal.coe_inj]
+
+@[deprecated (since := "2026-09-09")] alias isometry_iff_nndist_eq := isometric_iff_nndist_eq
+@[deprecated (since := "2026-09-09")] alias isometry_iff_dist_eq := isometric_iff_dist_eq
 
 /-- An isometry preserves distances. -/
-alias ⟨Isometry.dist_eq, _⟩ := isometry_iff_dist_eq
+alias ⟨Isometric.dist_eq, _⟩ := isometric_iff_dist_eq
 
 /-- A map that preserves distances is an isometry -/
-alias ⟨_, Isometry.of_dist_eq⟩ := isometry_iff_dist_eq
+alias ⟨_, Isometric.of_dist_eq⟩ := isometric_iff_dist_eq
 
 /-- An isometry preserves non-negative distances. -/
-alias ⟨Isometry.nndist_eq, _⟩ := isometry_iff_nndist_eq
+alias ⟨Isometric.nndist_eq, _⟩ := isometric_iff_nndist_eq
 
 /-- A map that preserves non-negative distances is an isometry. -/
-alias ⟨_, Isometry.of_nndist_eq⟩ := isometry_iff_nndist_eq
+alias ⟨_, Isometric.of_nndist_eq⟩ := isometric_iff_nndist_eq
 
-namespace Isometry
+@[deprecated (since := "2026-09-09")] alias Isometry.dist_eq := Isometric.dist_eq
+@[deprecated (since := "2026-09-09")] alias Isometry.of_dist_eq := Isometric.of_dist_eq
+@[deprecated (since := "2026-09-09")] alias Isometry.nndist_eq := Isometric.nndist_eq
+@[deprecated (since := "2026-09-09")] alias Isometry.of_nndist_eq := Isometric.of_nndist_eq
+
+namespace Isometric
 
 section PseudoEMetricIsometry
 
@@ -71,39 +81,53 @@ variable [PseudoEMetricSpace α] [PseudoEMetricSpace β] [PseudoEMetricSpace γ]
 variable {f : α → β} {x : α}
 
 /-- An isometry preserves edistances. -/
-theorem edist_eq (hf : Isometry f) (x y : α) : edist (f x) (f y) = edist x y :=
+theorem edist_eq (hf : Isometric f) (x y : α) : edist (f x) (f y) = edist x y :=
   hf x y
 
-theorem lipschitzWith (h : Isometry f) : LipschitzWith 1 f :=
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.edist_eq := edist_eq
+
+theorem lipschitzWith (h : Isometric f) : LipschitzWith 1 f :=
   LipschitzWith.of_edist_le fun x y => (h x y).le
 
 @[deprecated (since := "2026-08-16")] alias lipschitz := lipschitzWith
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.lipschitzWith := lipschitzWith
 
-theorem antilipschitzWith (h : Isometry f) : AntilipschitzWith 1 f := fun x y => by
+theorem antilipschitzWith (h : Isometric f) : AntilipschitzWith 1 f := fun x y => by
   simp only [h x y, ENNReal.coe_one, one_mul, le_refl]
 
 @[deprecated (since := "2026-08-16")] alias antilipschitz := antilipschitzWith
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.antilipschitzWith :=
+  antilipschitzWith
 
 /-- Any map on a subsingleton is an isometry -/
 @[nontriviality]
-theorem _root_.isometry_subsingleton [Subsingleton α] : Isometry f := fun x y => by
+theorem _root_.isometric_subsingleton [Subsingleton α] : Isometric f := fun x y => by
   rw [Subsingleton.elim x y]; simp
 
-/-- The identity is an isometry -/
-theorem _root_.isometry_id : Isometry (id : α → α) := fun _ _ => rfl
+@[deprecated (since := "2026-09-09")] alias _root_.isometry_subsingleton :=
+  _root_.isometric_subsingleton
 
-theorem prodMap {δ} [PseudoEMetricSpace δ] {f : α → β} {g : γ → δ} (hf : Isometry f)
-    (hg : Isometry g) : Isometry (Prod.map f g) := fun x y => by
+/-- The identity is an isometry -/
+theorem _root_.isometric_id : Isometric (id : α → α) := fun _ _ => rfl
+
+@[deprecated (since := "2026-09-09")] alias _root_.isometry_id := _root_.isometric_id
+
+theorem prodMap {δ} [PseudoEMetricSpace δ] {f : α → β} {g : γ → δ} (hf : Isometric f)
+    (hg : Isometric g) : Isometric (Prod.map f g) := fun x y => by
   simp only [Prod.edist_eq, Prod.map_fst, hf.edist_eq, Prod.map_snd, hg.edist_eq]
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.prodMap := prodMap
+
 protected theorem piMap {ι} [Fintype ι] {α β : ι → Type*} [∀ i, PseudoEMetricSpace (α i)]
-    [∀ i, PseudoEMetricSpace (β i)] (f : ∀ i, α i → β i) (hf : ∀ i, Isometry (f i)) :
-    Isometry (Pi.map f) := fun x y => by
+    [∀ i, PseudoEMetricSpace (β i)] (f : ∀ i, α i → β i) (hf : ∀ i, Isometric (f i)) :
+    Isometric (Pi.map f) := fun x y => by
   simp only [edist_pi_def, (hf _).edist_eq, Pi.map_apply]
+
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.piMap := Isometric.piMap
 
 protected lemma single [Fintype ι] [DecidableEq ι] {E : ι → Type*} [∀ i, PseudoEMetricSpace (E i)]
     [∀ i, Zero (E i)] (i : ι) :
-    Isometry (Pi.single (M := E) i) := by
+    Isometric (Pi.single (M := E) i) := by
   intro x y
   rw [edist_pi_def]
   refine le_antisymm (Finset.sup_le fun j ↦ ?_) (Finset.le_sup_of_le (Finset.mem_univ i) (by simp))
@@ -111,82 +135,129 @@ protected lemma single [Fintype ι] [DecidableEq ι] {E : ι → Type*} [∀ i, 
   · simp
   · simp [h]
 
-protected lemma inl [AddZeroClass α] [AddZeroClass β] : Isometry (AddMonoidHom.inl α β) := by
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.single := Isometric.single
+
+protected lemma inl [AddZeroClass α] [AddZeroClass β] : Isometric (AddMonoidHom.inl α β) := by
   intro x y
   rw [Prod.edist_eq]
   simp
 
-protected lemma inr [AddZeroClass α] [AddZeroClass β] : Isometry (AddMonoidHom.inr α β) := by
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.inl := Isometric.inl
+
+protected lemma inr [AddZeroClass α] [AddZeroClass β] : Isometric (AddMonoidHom.inr α β) := by
   intro x y
   rw [Prod.edist_eq]
   simp
+
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.inr := Isometric.inr
 
 /-- The composition of isometries is an isometry. -/
-theorem comp {g : β → γ} {f : α → β} (hg : Isometry g) (hf : Isometry f) : Isometry (g ∘ f) :=
+theorem comp {g : β → γ} {f : α → β} (hg : Isometric g) (hf : Isometric f) : Isometric (g ∘ f) :=
   fun _ _ => (hg _ _).trans (hf _ _)
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.comp := comp
+
 omit [PseudoEMetricSpace α] in
-lemma postcomp_pi [Fintype α] {g : β → γ} (hg : Isometry g) : Isometry (fun f : α → β ↦ g ∘ f) :=
+lemma postcomp_pi [Fintype α] {g : β → γ} (hg : Isometric g) : Isometric (fun f : α → β ↦ g ∘ f) :=
   fun _ _ ↦ by simp [edist_pi_def, hg.edist_eq]
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.postcomp_pi := postcomp_pi
+
 /-- An isometry from a metric space is a uniform continuous map -/
-protected theorem uniformContinuous (hf : Isometry f) : UniformContinuous f :=
+protected theorem uniformContinuous (hf : Isometric f) : UniformContinuous f :=
   hf.lipschitzWith.uniformContinuous
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.uniformContinuous :=
+  Isometric.uniformContinuous
+
 /-- An isometry from a metric space is a uniform inducing map -/
-theorem isUniformInducing (hf : Isometry f) : IsUniformInducing f :=
+theorem isUniformInducing (hf : Isometric f) : IsUniformInducing f :=
   hf.antilipschitzWith.isUniformInducing hf.uniformContinuous
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.isUniformInducing := isUniformInducing
+
 theorem tendsto_nhds_iff {ι : Type*} {f : α → β} {g : ι → α} {a : Filter ι} {b : α}
-    (hf : Isometry f) : Filter.Tendsto g a (𝓝 b) ↔ Filter.Tendsto (f ∘ g) a (𝓝 (f b)) :=
+    (hf : Isometric f) : Filter.Tendsto g a (𝓝 b) ↔ Filter.Tendsto (f ∘ g) a (𝓝 (f b)) :=
   hf.isUniformInducing.isInducing.tendsto_nhds_iff
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.tendsto_nhds_iff := tendsto_nhds_iff
+
 /-- An isometry is continuous. -/
-protected theorem continuous (hf : Isometry f) : Continuous f :=
+protected theorem continuous (hf : Isometric f) : Continuous f :=
   hf.lipschitzWith.continuous
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.continuous := Isometric.continuous
+
 /-- The right inverse of an isometry is an isometry. -/
-theorem right_inv {f : α → β} {g : β → α} (h : Isometry f) (hg : RightInverse g f) : Isometry g :=
+theorem right_inv {f : α → β} {g : β → α} (h : Isometric f) (hg : RightInverse g f) : Isometric g :=
   fun x y => by rw [← h, hg _, hg _]
 
-theorem preimage_closedEBall (h : Isometry f) (x : α) (r : ℝ≥0∞) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.right_inv := right_inv
+
+theorem preimage_closedEBall (h : Isometric f) (x : α) (r : ℝ≥0∞) :
     f ⁻¹' Metric.closedEBall (f x) r = Metric.closedEBall x r := by
   ext y
   simp [h.edist_eq]
 
-theorem preimage_eball (h : Isometry f) (x : α) (r : ℝ≥0∞) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.preimage_closedEBall :=
+  preimage_closedEBall
+
+theorem preimage_eball (h : Isometric f) (x : α) (r : ℝ≥0∞) :
     f ⁻¹' Metric.eball (f x) r = Metric.eball x r := by
   ext y
   simp [h.edist_eq]
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.preimage_eball := preimage_eball
+
 /-- Isometries preserve the diameter in pseudoemetric spaces. -/
-theorem ediam_image (hf : Isometry f) (s : Set α) : Metric.ediam (f '' s) = Metric.ediam s :=
+theorem ediam_image (hf : Isometric f) (s : Set α) : Metric.ediam (f '' s) = Metric.ediam s :=
   eq_of_forall_ge_iff fun d => by simp only [Metric.ediam_le_iff, forall_mem_image, hf.edist_eq]
 
-theorem ediam_range (hf : Isometry f) : Metric.ediam (range f) = Metric.ediam (univ : Set α) := by
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.ediam_image := ediam_image
+
+theorem ediam_range (hf : Isometric f) : Metric.ediam (range f) = Metric.ediam (univ : Set α) := by
   rw [← image_univ]
   exact hf.ediam_image univ
 
-theorem mapsTo_eball (hf : Isometry f) (x : α) (r : ℝ≥0∞) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.ediam_range := ediam_range
+
+theorem mapsTo_eball (hf : Isometric f) (x : α) (r : ℝ≥0∞) :
     MapsTo f (Metric.eball x r) (Metric.eball (f x) r) :=
   (hf.preimage_eball x r).ge
 
-theorem mapsTo_closedEBall (hf : Isometry f) (x : α) (r : ℝ≥0∞) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.mapsTo_eball := mapsTo_eball
+
+theorem mapsTo_closedEBall (hf : Isometric f) (x : α) (r : ℝ≥0∞) :
     MapsTo f (Metric.closedEBall x r) (Metric.closedEBall (f x) r) :=
   (hf.preimage_closedEBall x r).ge
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.mapsTo_closedEBall :=
+  mapsTo_closedEBall
+
 /-- The injection from a subtype is an isometry -/
-theorem _root_.isometry_subtype_coe {s : Set α} : Isometry ((↑) : s → α) := fun _ _ => rfl
+theorem _root_.isometric_subtype_coe {s : Set α} : Isometric ((↑) : s → α) := fun _ _ => rfl
 
-theorem _root_.NNReal.isometry_coe : Isometry ((↑) : NNReal → ℝ) := fun _ _ ↦ rfl
+@[deprecated (since := "2026-09-09")] alias _root_.isometry_subtype_coe :=
+  _root_.isometric_subtype_coe
 
-theorem comp_continuousOn_iff {γ} [TopologicalSpace γ] (hf : Isometry f) {g : γ → α} {s : Set γ} :
+theorem _root_.NNReal.isometric_coe : Isometric ((↑) : NNReal → ℝ) := fun _ _ ↦ rfl
+
+@[deprecated (since := "2026-09-09")] alias _root_.NNReal.isometry_coe :=
+  _root_.NNReal.isometric_coe
+
+theorem comp_continuousOn_iff {γ} [TopologicalSpace γ] (hf : Isometric f) {g : γ → α} {s : Set γ} :
     ContinuousOn (f ∘ g) s ↔ ContinuousOn g s :=
   hf.isUniformInducing.isInducing.continuousOn_iff.symm
 
-theorem comp_continuous_iff {γ} [TopologicalSpace γ] (hf : Isometry f) {g : γ → α} :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.comp_continuousOn_iff :=
+  comp_continuousOn_iff
+
+theorem comp_continuous_iff {γ} [TopologicalSpace γ] (hf : Isometric f) {g : γ → α} :
     Continuous (f ∘ g) ↔ Continuous g :=
   hf.isUniformInducing.isInducing.continuous_iff.symm
+
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.comp_continuous_iff :=
+  comp_continuous_iff
 
 end PseudoEMetricIsometry
 
@@ -196,20 +267,30 @@ section EMetricIsometry
 variable [EMetricSpace α] [PseudoEMetricSpace β] {f : α → β}
 
 /-- An isometry from an emetric space is injective -/
-protected theorem injective (h : Isometry f) : Injective f :=
+protected theorem injective (h : Isometric f) : Injective f :=
   h.antilipschitzWith.injective
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.injective := Isometric.injective
+
 /-- An isometry from an emetric space is a uniform embedding -/
-lemma isUniformEmbedding (hf : Isometry f) : IsUniformEmbedding f :=
+lemma isUniformEmbedding (hf : Isometric f) : IsUniformEmbedding f :=
   hf.antilipschitzWith.isUniformEmbedding hf.lipschitzWith.uniformContinuous
 
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.isUniformEmbedding :=
+  isUniformEmbedding
+
 /-- An isometry from an emetric space is an embedding -/
-theorem isEmbedding (hf : Isometry f) : IsEmbedding f := hf.isUniformEmbedding.isEmbedding
+theorem isEmbedding (hf : Isometric f) : IsEmbedding f := hf.isUniformEmbedding.isEmbedding
+
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.isEmbedding := isEmbedding
 
 /-- An isometry from a complete emetric space is a closed embedding -/
-theorem isClosedEmbedding [CompleteSpace α] [EMetricSpace γ] {f : α → γ} (hf : Isometry f) :
+theorem isClosedEmbedding [CompleteSpace α] [EMetricSpace γ] {f : α → γ} (hf : Isometric f) :
     IsClosedEmbedding f :=
   hf.antilipschitzWith.isClosedEmbedding hf.lipschitzWith.uniformContinuous
+
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.isClosedEmbedding :=
+  isClosedEmbedding
 
 end EMetricIsometry
 
@@ -219,79 +300,115 @@ section PseudoMetricIsometry
 variable [PseudoMetricSpace α] [PseudoMetricSpace β] {f : α → β}
 
 /-- An isometry preserves the diameter in pseudometric spaces. -/
-theorem diam_image (hf : Isometry f) (s : Set α) : Metric.diam (f '' s) = Metric.diam s := by
+theorem diam_image (hf : Isometric f) (s : Set α) : Metric.diam (f '' s) = Metric.diam s := by
   rw [Metric.diam, Metric.diam, hf.ediam_image]
 
-theorem diam_range (hf : Isometry f) : Metric.diam (range f) = Metric.diam (univ : Set α) := by
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.diam_image := diam_image
+
+theorem diam_range (hf : Isometric f) : Metric.diam (range f) = Metric.diam (univ : Set α) := by
   rw [← image_univ]
   exact hf.diam_image univ
 
-theorem preimage_setOfPred_dist (hf : Isometry f) (x : α) (p : ℝ → Prop) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.diam_range := diam_range
+
+theorem preimage_setOfPred_dist (hf : Isometric f) (x : α) (p : ℝ → Prop) :
     f ⁻¹' { y | p (dist y (f x)) } = { y | p (dist y x) } := by
   simp [hf.dist_eq]
 
 @[deprecated (since := "2026-07-09")] alias preimage_setOf_dist := preimage_setOfPred_dist
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.preimage_setOfPred_dist :=
+  preimage_setOfPred_dist
 
-theorem preimage_closedBall (hf : Isometry f) (x : α) (r : ℝ) :
+theorem preimage_closedBall (hf : Isometric f) (x : α) (r : ℝ) :
     f ⁻¹' Metric.closedBall (f x) r = Metric.closedBall x r :=
   hf.preimage_setOfPred_dist x (· ≤ r)
 
-theorem preimage_ball (hf : Isometry f) (x : α) (r : ℝ) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.preimage_closedBall :=
+  preimage_closedBall
+
+theorem preimage_ball (hf : Isometric f) (x : α) (r : ℝ) :
     f ⁻¹' Metric.ball (f x) r = Metric.ball x r :=
   hf.preimage_setOfPred_dist x (· < r)
 
-theorem preimage_sphere (hf : Isometry f) (x : α) (r : ℝ) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.preimage_ball := preimage_ball
+
+theorem preimage_sphere (hf : Isometric f) (x : α) (r : ℝ) :
     f ⁻¹' Metric.sphere (f x) r = Metric.sphere x r :=
   hf.preimage_setOfPred_dist x (· = r)
 
-theorem mapsTo_ball (hf : Isometry f) (x : α) (r : ℝ) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.preimage_sphere := preimage_sphere
+
+theorem mapsTo_ball (hf : Isometric f) (x : α) (r : ℝ) :
     MapsTo f (Metric.ball x r) (Metric.ball (f x) r) :=
   (hf.preimage_ball x r).ge
 
-theorem mapsTo_sphere (hf : Isometry f) (x : α) (r : ℝ) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.mapsTo_ball := mapsTo_ball
+
+theorem mapsTo_sphere (hf : Isometric f) (x : α) (r : ℝ) :
     MapsTo f (Metric.sphere x r) (Metric.sphere (f x) r) :=
   (hf.preimage_sphere x r).ge
 
-theorem mapsTo_closedBall (hf : Isometry f) (x : α) (r : ℝ) :
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.mapsTo_sphere := mapsTo_sphere
+
+theorem mapsTo_closedBall (hf : Isometric f) (x : α) (r : ℝ) :
     MapsTo f (Metric.closedBall x r) (Metric.closedBall (f x) r) :=
   (hf.preimage_closedBall x r).ge
+
+@[deprecated (since := "2026-09-10")] alias _root_.Isometry.mapsTo_closedBall := mapsTo_closedBall
 
 end PseudoMetricIsometry
 
 -- section
-end Isometry
+end Isometric
 
 -- namespace
 /-- A uniform embedding from a uniform space to a metric space is an isometry with respect to the
 induced metric space structure on the source space. -/
-theorem IsUniformEmbedding.to_isometry {α β} [UniformSpace α] [MetricSpace β] {f : α → β}
-    (h : IsUniformEmbedding f) : (letI := h.comapMetricSpace f; Isometry f) :=
+theorem IsUniformEmbedding.to_isometric {α β} [UniformSpace α] [MetricSpace β] {f : α → β}
+    (h : IsUniformEmbedding f) : (letI := h.comapMetricSpace f; Isometric f) :=
   let _ := h.comapMetricSpace f
-  Isometry.of_dist_eq fun _ _ => rfl
+  Isometric.of_dist_eq fun _ _ => rfl
 
 /-- An embedding from a topological space to a pseudometric space is an isometry with respect to the
 induced pseudometric space structure on the source space. -/
-theorem Topology.IsEmbedding.to_isometry {α β} [TopologicalSpace α] [PseudoMetricSpace β]
-    {f : α → β} (h : IsEmbedding f) : (letI := h.comapPseudoMetricSpace; Isometry f) :=
+theorem Topology.IsEmbedding.to_isometric {α β} [TopologicalSpace α] [PseudoMetricSpace β]
+    {f : α → β} (h : IsEmbedding f) : (letI := h.comapPseudoMetricSpace; Isometric f) :=
   let _ := h.comapPseudoMetricSpace
-  Isometry.of_dist_eq fun _ _ => rfl
+  Isometric.of_dist_eq fun _ _ => rfl
 
-theorem PseudoEMetricSpace.isometry_induced (f : α → β) [m : PseudoEMetricSpace β] :
-    letI := m.induced f; Isometry f := fun _ _ ↦ rfl
+@[deprecated (since := "2026-09-09")] alias IsUniformEmbedding.to_isometry :=
+  IsUniformEmbedding.to_isometric
+@[deprecated (since := "2026-09-09")] alias Topology.IsEmbedding.to_isometry :=
+  Topology.IsEmbedding.to_isometric
 
-theorem PseudoMetricSpace.isometry_induced (f : α → β) [m : PseudoMetricSpace β] :
-    letI := m.induced f; Isometry f := fun _ _ ↦ rfl
+theorem PseudoEMetricSpace.isometric_induced (f : α → β) [m : PseudoEMetricSpace β] :
+    letI := m.induced f; Isometric f := fun _ _ ↦ rfl
 
-theorem EMetricSpace.isometry_induced (f : α → β) (hf : f.Injective) [m : EMetricSpace β] :
-    letI := m.induced f hf; Isometry f := fun _ _ ↦ rfl
+@[deprecated (since := "2026-09-09")] alias PseudoEMetricSpace.isometry_induced :=
+  PseudoEMetricSpace.isometric_induced
 
-theorem MetricSpace.isometry_induced (f : α → β) (hf : f.Injective) [m : MetricSpace β] :
-    letI := m.induced f hf; Isometry f := fun _ _ ↦ rfl
+theorem PseudoMetricSpace.isometric_induced (f : α → β) [m : PseudoMetricSpace β] :
+    letI := m.induced f; Isometric f := fun _ _ ↦ rfl
+
+@[deprecated (since := "2026-09-09")] alias PseudoMetricSpace.isometry_induced :=
+  PseudoMetricSpace.isometric_induced
+
+theorem EMetricSpace.isometric_induced (f : α → β) (hf : f.Injective) [m : EMetricSpace β] :
+    letI := m.induced f hf; Isometric f := fun _ _ ↦ rfl
+
+@[deprecated (since := "2026-09-09")] alias EMetricSpace.isometry_induced :=
+  EMetricSpace.isometric_induced
+
+theorem MetricSpace.isometric_induced (f : α → β) (hf : f.Injective) [m : MetricSpace β] :
+    letI := m.induced f hf; Isometric f := fun _ _ ↦ rfl
+
+@[deprecated (since := "2026-09-09")] alias MetricSpace.isometry_induced :=
+  MetricSpace.isometric_induced
 
 /-- `IsometryClass F α β` states that `F` is a type of isometries. -/
 class IsometryClass (F : Type*) (α β : outParam Type*)
     [PseudoEMetricSpace α] [PseudoEMetricSpace β] [FunLike F α β] : Prop where
-  protected isometry (f : F) : Isometry f
+  protected isometry (f : F) : Isometric f
 
 namespace IsometryClass
 
@@ -353,7 +470,7 @@ end IsometryClass
 /-- `α` and `β` are isometric if there is an isometric bijection between them. -/
 structure IsometryEquiv (α : Type u) (β : Type v) [PseudoEMetricSpace α] [PseudoEMetricSpace β]
     extends α ≃ β where
-  isometry_toFun : Isometry toFun
+  isometry_toFun : Isometric toFun
 
 @[inherit_doc]
 infixl:25 " ≃ᵢ " => IsometryEquiv
@@ -386,7 +503,7 @@ theorem coe_eq_toEquiv (h : α ≃ᵢ β) (a : α) : h a = h.toEquiv a := rfl
 
 @[simp] theorem coe_mk (e : α ≃ β) (h) : ⇑(mk e h) = e := rfl
 
-protected theorem isometry (h : α ≃ᵢ β) : Isometry h :=
+protected theorem isometry (h : α ≃ᵢ β) : Isometric h :=
   h.isometry_toFun
 
 protected theorem bijective (h : α ≃ᵢ β) : Bijective h :=
@@ -423,7 +540,7 @@ theorem ext ⦃h₁ h₂ : α ≃ᵢ β⦄ (H : ∀ x, h₁ x = h₂ x) : h₁ =
 /-- Alternative constructor for isometric bijections,
 taking as input an isometry, and a right inverse. -/
 def mk' {α : Type u} [EMetricSpace α] (f : α → β) (g : β → α) (hfg : ∀ x, f (g x) = x)
-    (hf : Isometry f) : α ≃ᵢ β where
+    (hf : Isometric f) : α ≃ᵢ β where
   toFun := f
   invFun := g
   left_inv _ := hf.injective <| hfg _
@@ -432,7 +549,7 @@ def mk' {α : Type u} [EMetricSpace α] (f : α → β) (g : β → α) (hfg : �
 
 /-- The identity isometry of a space. -/
 protected def refl (α : Type*) [PseudoEMetricSpace α] : α ≃ᵢ α :=
-  { Equiv.refl α with isometry_toFun := isometry_id }
+  { Equiv.refl α with isometry_toFun := isometric_id }
 
 /-- The composition of two isometric isomorphisms, as an isometric isomorphism. -/
 protected def trans (h₁ : α ≃ᵢ β) (h₂ : β ≃ᵢ γ) : α ≃ᵢ γ :=
@@ -710,22 +827,28 @@ end IsometryEquiv
 /-- An isometry induces an isometric isomorphism between the source space and the
 range of the isometry. -/
 @[simps! +simpRhs toEquiv apply]
-def Isometry.isometryEquivOnRange [EMetricSpace α] [PseudoEMetricSpace β] {f : α → β}
-    (h : Isometry f) : α ≃ᵢ range f where
+def Isometric.isometryEquivOnRange [EMetricSpace α] [PseudoEMetricSpace β] {f : α → β}
+    (h : Isometric f) : α ≃ᵢ range f where
   isometry_toFun := h
   toEquiv := Equiv.ofInjective f h.injective
 
+@[deprecated (since := "2026-09-10")] alias Isometry.isometryEquivOnRange :=
+  Isometric.isometryEquivOnRange
+
 open NNReal in
 /-- Post-composition by an isometry does not change the Lipschitz-property of a function. -/
-lemma Isometry.lipschitzWith_iff {α β γ : Type*} [PseudoEMetricSpace α] [PseudoEMetricSpace β]
-    [PseudoEMetricSpace γ] {f : α → β} {g : β → γ} (K : ℝ≥0) (h : Isometry g) :
+lemma Isometric.lipschitzWith_iff {α β γ : Type*} [PseudoEMetricSpace α] [PseudoEMetricSpace β]
+    [PseudoEMetricSpace γ] {f : α → β} {g : β → γ} (K : ℝ≥0) (h : Isometric g) :
     LipschitzWith K (g ∘ f) ↔ LipschitzWith K f := by
   simp [LipschitzWith, h.edist_eq]
 
+@[deprecated (since := "2026-09-10")] alias Isometry.lipschitzWith_iff :=
+  Isometric.lipschitzWith_iff
+
 /-- If `f` is locally Lipschitz on `s` after precomposition with an isometry `g`, then `f` is
 locally Lipschitz on `g '' s`. -/
-lemma Isometry.locallyLipschitzOn_image {α β γ : Type*} [EMetricSpace α] [PseudoEMetricSpace β]
-    [PseudoEMetricSpace γ] {g : α → β} {h : β → γ} {s : Set α} (hg : Isometry g)
+lemma Isometric.locallyLipschitzOn_image {α β γ : Type*} [EMetricSpace α] [PseudoEMetricSpace β]
+    [PseudoEMetricSpace γ] {g : α → β} {h : β → γ} {s : Set α} (hg : Isometric g)
     (hL : LocallyLipschitzOn s (h ∘ g)) : LocallyLipschitzOn (g '' s) h := by
   rintro _ ⟨x, hx, rfl⟩
   obtain ⟨K, t, ht, hK⟩ := hL hx
@@ -734,6 +857,9 @@ lemma Isometry.locallyLipschitzOn_image {α β γ : Type*} [EMetricSpace α] [Ps
     exact Filter.image_mem_map ht
   · rintro _ ⟨a, ha, rfl⟩ _ ⟨b, hb, rfl⟩
     simpa [hg.edist_eq] using hK ha hb
+
+@[deprecated (since := "2026-09-10")] alias Isometry.locallyLipschitzOn_image :=
+  Isometric.locallyLipschitzOn_image
 
 namespace IsometryClass
 

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -57,8 +57,8 @@ theorem embeddingOfSubset_dist_le (a b : α) :
   ring
 
 /-- When the reference set is dense, the embedding map is an isometry on its image. -/
-theorem embeddingOfSubset_isometry (H : DenseRange x) : Isometry (embeddingOfSubset x) := by
-  refine Isometry.of_dist_eq fun a b => ?_
+theorem embeddingOfSubset_isometric (H : DenseRange x) : Isometric (embeddingOfSubset x) := by
+  refine Isometric.of_dist_eq fun a b => ?_
   refine (embeddingOfSubset_dist_le x a b).antisymm (le_of_forall_pos_le_add fun e epos => ?_)
   -- First step: find n with dist a (x n) < e
   rcases Metric.mem_closure_range_iff.1 (H a) (e / 2) (half_pos epos) with ⟨n, hn⟩
@@ -81,9 +81,12 @@ theorem embeddingOfSubset_isometry (H : DenseRange x) : Isometry (embeddingOfSub
       _ = dist (embeddingOfSubset x b) (embeddingOfSubset x a) + e := by ring
   simpa [dist_comm] using this
 
+@[deprecated (since := "2026-09-09")] alias embeddingOfSubset_isometry :=
+  embeddingOfSubset_isometric
+
 /-- Every separable metric space embeds isometrically in `ℓ^∞(ℕ)`. -/
 theorem exists_isometric_embedding (α : Type u) [MetricSpace α] [SeparableSpace α] :
-    ∃ f : α → ℓ^∞(ℕ, ℝ), Isometry f := by
+    ∃ f : α → ℓ^∞(ℕ, ℝ), Isometric f := by
   rcases (univ : Set α).eq_empty_or_nonempty with h | h
   · use fun _ => 0; intro x; exact absurd h (Nonempty.ne_empty ⟨x, mem_univ x⟩)
   · -- We construct a map x : ℕ → α with dense image
@@ -93,7 +96,7 @@ theorem exists_isometric_embedding (α : Type u) [MetricSpace α] [SeparableSpac
     rcases this with ⟨S, ⟨S_countable, S_dense⟩⟩
     rcases Set.countable_iff_exists_subset_range.1 S_countable with ⟨x, x_range⟩
     -- Use embeddingOfSubset to construct the desired isometry
-    exact ⟨embeddingOfSubset x, embeddingOfSubset_isometry x (S_dense.mono x_range)⟩
+    exact ⟨embeddingOfSubset x, embeddingOfSubset_isometric x (S_dense.mono x_range)⟩
 
 end KuratowskiEmbedding
 
@@ -108,7 +111,7 @@ def kuratowskiEmbedding (α : Type u) [MetricSpace α] [SeparableSpace α] : α 
 The Kuratowski embedding is an isometry.
 Theorem 2.1 of [Assaf Naor, *Metric Embeddings and Lipschitz Extensions*][Naor-2015]. -/
 protected theorem kuratowskiEmbedding.isometry (α : Type u) [MetricSpace α] [SeparableSpace α] :
-    Isometry (kuratowskiEmbedding α) :=
+    Isometric (kuratowskiEmbedding α) :=
   Classical.choose_spec (exists_isometric_embedding α)
 
 /-- Version of the Kuratowski embedding for nonempty compacts -/

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -1021,7 +1021,9 @@ noncomputable instance : PseudoEMetricSpace (PiNatEmbed X Y f) :=
 lemma edist_def (x y : PiNatEmbed X Y f) :
     edist x y = ∑' i, min (2⁻¹ ^ encode i) (edist (f i x.ofPiNat) (f i y.ofPiNat)) := rfl
 
-lemma isometry_embed : Isometry (embed X Y f) := PseudoEMetricSpace.isometry_induced _
+lemma isometric_embed : Isometric (embed X Y f) := PseudoEMetricSpace.isometry_induced _
+
+@[deprecated (since := "2026-09-09")] alias isometry_embed := isometric_embed
 
 end PseudoEMetricSpace
 
@@ -1055,7 +1057,7 @@ noncomputable abbrev emetricSpace (separating_f : Pairwise fun x y ↦ ∃ i, f 
 
 lemma isUniformEmbedding_embed (separating_f : Pairwise fun x y ↦ ∃ i, f i x ≠ f i y) :
     IsUniformEmbedding (embed X Y f) :=
-  let := emetricSpace separating_f; isometry_embed.isUniformEmbedding
+  let := emetricSpace separating_f; isometric_embed.isUniformEmbedding
 
 end EMetricSpace
 

--- a/Mathlib/Topology/MetricSpace/ProperSpace/Real.lean
+++ b/Mathlib/Topology/MetricSpace/ProperSpace/Real.lean
@@ -47,7 +47,7 @@ instance : SecondCountableTopology ℝ≥0 :=
 
 instance instProperSpace : ProperSpace ℝ≥0 where
   isCompact_closedBall x r := by
-    have emb : IsClosedEmbedding ((↑) : ℝ≥0 → ℝ) := Isometry.isClosedEmbedding fun _ ↦ congrFun rfl
+    have emb : IsClosedEmbedding ((↑) : ℝ≥0 → ℝ) := Isometric.isClosedEmbedding fun _ ↦ congrFun rfl
     exact emb.isCompact_preimage (K := Metric.closedBall x r) (isCompact_closedBall _ _)
 
 end NNReal

--- a/Mathlib/Topology/MetricSpace/Similarity.lean
+++ b/Mathlib/Topology/MetricSpace/Similarity.lean
@@ -145,26 +145,34 @@ end Dilation
 
 While these are trivial consequences of the dilation results, they avoid ending up with a
 `toDilation` in the expression, and so are easier to apply to plain functions.
-If `Dilation` were a predicate like `Isometry` then these would not be needed.
+If `Dilation` were a predicate like `Isometric` then these would not be needed.
 -/
 
-section Isometry
+section Isometric
 
-lemma comp_isometry_left {f : P₁ → P₃} (hf : Isometry f) (h : v₁ ∼ v₂) : f ∘ v₁ ∼ v₂ :=
+lemma comp_isometric_left {f : P₁ → P₃} (hf : Isometric f) (h : v₁ ∼ v₂) : f ∘ v₁ ∼ v₂ :=
   comp_left hf.toDilation h
 
-lemma comp_isometry_right {f : P₂ → P₃} (hf : Isometry f) (h : v₁ ∼ v₂) : v₁ ∼ f ∘ v₂ :=
+@[deprecated (since := "2026-09-09")] alias comp_isometry_left := comp_isometric_left
+
+lemma comp_isometric_right {f : P₂ → P₃} (hf : Isometric f) (h : v₁ ∼ v₂) : v₁ ∼ f ∘ v₂ :=
   comp_right hf.toDilation h
 
+@[deprecated (since := "2026-09-09")] alias comp_isometry_right := comp_isometric_right
+
 @[simp]
-lemma comp_isometry_left_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ∼ v₂ ↔ v₁ ∼ v₂ :=
+lemma comp_isometric_left_iff {f : P₁ → P₃} (hf : Isometric f) : f ∘ v₁ ∼ v₂ ↔ v₁ ∼ v₂ :=
   comp_left_iff hf.toDilation
 
+@[deprecated (since := "2026-09-09")] alias comp_isometry_left_iff := comp_isometric_left_iff
+
 @[simp]
-lemma comp_isometry_right_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ :=
+lemma comp_isometric_right_iff {f : P₂ → P₃} (hf : Isometric f) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ :=
   comp_right_iff hf.toDilation
 
-end Isometry
+@[deprecated (since := "2026-09-09")] alias comp_isometry_right_iff := comp_isometric_right_iff
+
+end Isometric
 
 section Triangle
 

--- a/Mathlib/Topology/MetricSpace/UniformConvergence.lean
+++ b/Mathlib/Topology/MetricSpace/UniformConvergence.lean
@@ -165,19 +165,25 @@ noncomputable instance {β : Type*} [MetricSpace β] [BoundedSpace β] : MetricS
   .ofT0PseudoMetricSpace _
 
 open BoundedContinuousFunction in
-lemma isometry_ofFun_boundedContinuousFunction [TopologicalSpace α] :
-    Isometry (ofFun ∘ DFunLike.coe : (α →ᵇ β) → α →ᵤ β) := by
-  simp [Isometry, edist_def, edist_eq_iSup]
+lemma isometric_ofFun_boundedContinuousFunction [TopologicalSpace α] :
+    Isometric (ofFun ∘ DFunLike.coe : (α →ᵇ β) → α →ᵤ β) := by
+  simp [Isometric, edist_def, edist_eq_iSup]
 
-lemma isometry_ofFun_continuousMap [TopologicalSpace α] [CompactSpace α] :
-    Isometry (ofFun ∘ DFunLike.coe : C(α, β) → α →ᵤ β) :=
-  isometry_ofFun_boundedContinuousFunction.comp <|
+@[deprecated (since := "2026-09-09")] alias isometry_ofFun_boundedContinuousFunction :=
+  isometric_ofFun_boundedContinuousFunction
+
+lemma isometric_ofFun_continuousMap [TopologicalSpace α] [CompactSpace α] :
+    Isometric (ofFun ∘ DFunLike.coe : C(α, β) → α →ᵤ β) :=
+  isometric_ofFun_boundedContinuousFunction.comp <|
     ContinuousMap.isometryEquivBoundedOfCompact α β |>.isometry
+
+@[deprecated (since := "2026-09-09")] alias isometry_ofFun_continuousMap :=
+  isometric_ofFun_continuousMap
 
 lemma edist_continuousMapMk [TopologicalSpace α] [CompactSpace α]
     {f g : α →ᵤ β} (hf : Continuous (toFun f)) (hg : Continuous (toFun g)) :
     edist (⟨_, hf⟩ : C(α, β)) ⟨_, hg⟩ = edist f g := by
-  simp [← isometry_ofFun_continuousMap.edist_eq]
+  simp [← isometric_ofFun_continuousMap.edist_eq]
 
 end Metric
 
@@ -277,9 +283,11 @@ lemma lipschitzWith_restrict (s : Set α) (hs : s ∈ 𝔖) :
     LipschitzWith 1 (UniformFun.ofFun ∘ s.domRestrict ∘ toFun 𝔖 : (α →ᵤ[𝔖] β) → (s →ᵤ β)) :=
   UniformFun.lipschitzWith_iff.mpr fun x ↦ lipschitzWith_eval ⟨s, hs, x.2⟩
 
-lemma isometry_restrict (s : Set α) :
-    Isometry (UniformFun.ofFun ∘ s.domRestrict ∘ toFun {s} : (α →ᵤ[{s}] β) → (s →ᵤ β)) := by
-  simp [Isometry, edist_def, UniformFun.edist_def, iSup_subtype]
+lemma isometric_restrict (s : Set α) :
+    Isometric (UniformFun.ofFun ∘ s.domRestrict ∘ toFun {s} : (α →ᵤ[{s}] β) → (s →ᵤ β)) := by
+  simp [Isometric, edist_def, UniformFun.edist_def, iSup_subtype]
+
+@[deprecated (since := "2026-09-09")] alias isometry_restrict := isometric_restrict
 
 end EMetric
 

--- a/Mathlib/Topology/Metrizable/Urysohn.lean
+++ b/Mathlib/Topology/Metrizable/Urysohn.lean
@@ -49,7 +49,7 @@ theorem exists_isInducing_l_infty : ∃ f : X → ℕ →ᵇ ℝ, IsInducing f :
   have : DiscreteTopology s := ⟨rfl⟩
   rsuffices ⟨f, hf⟩ : ∃ f : X → s →ᵇ ℝ, IsInducing f
   · exact ⟨fun x => (f x).extend (Encodable.encode' s) 0,
-      (BoundedContinuousFunction.isometry_extend (Encodable.encode' s)
+      (BoundedContinuousFunction.isometric_extend (Encodable.encode' s)
         (0 : ℕ →ᵇ ℝ)).isEmbedding.isInducing.comp hf⟩
   have hd : ∀ UV : s, Disjoint (closure UV.1.1) UV.1.2ᶜ :=
     fun UV => disjoint_compl_right.mono_right (compl_subset_compl.2 UV.2.2)


### PR DESCRIPTION
This definition refers to an unbundled isometry: let's keep Isometry for a future bundled version. The name Isometric is an adjective and avoids questions of whether to have an Is prefix. Suggested by j-loreaux on Zulip.

Rename done using Claude code, (prompted and) every line manually reviewed by myself.

We leave declarations such as IsometryEquiv, IsometryClass, LinearIsometry alone.

---------

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
