### PR TITLE
[Merged by Bors] - chore: weaken unused hypotheses (Data and Order: thread on zulip)

### DIFF
--- a/Mathlib/Data/Finset/Pairwise.lean
+++ b/Mathlib/Data/Finset/Pairwise.lean
@@ -38,9 +38,9 @@ theorem PairwiseDisjoint.elim_finset {s : Set ι} {f : ι → Finset α} (hs : s
     {i j : ι} (hi : i ∈ s) (hj : j ∈ s) (a : α) (hai : a ∈ f i) (haj : a ∈ f j) : i = j :=
   hs.elim hi hj (Finset.not_disjoint_iff.2 ⟨a, hai, haj⟩)
 
-section SemilatticeInf
+section PartialOrder
 
-variable [SemilatticeInf α] [OrderBot α] {s : Finset ι} {f : ι → α}
+variable [PartialOrder α] [OrderBot α] {s : Finset ι} {f : ι → α}
 
 theorem PairwiseDisjoint.image_finset_of_le [DecidableEq ι] {s : Finset ι} {f : ι → α}
     (hs : (s : Set ι).PairwiseDisjoint f) {g : ι → ι} (hf : ∀ a, f (g a) ≤ f a) :
@@ -52,7 +52,7 @@ theorem PairwiseDisjoint.attach (hs : (s : Set ι).PairwiseDisjoint f) :
     (s.attach : Set { x // x ∈ s }).PairwiseDisjoint (f ∘ Subtype.val) := fun i _ j _ hij =>
   hs i.2 j.2 <| mt Subtype.ext hij
 
-end SemilatticeInf
+end PartialOrder
 
 variable [Lattice α] [OrderBot α]
 

--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -289,7 +289,7 @@ end Preorder
 
 section PartialOrder
 
-variable [PartialOrder α] [PartialOrder β] {f : α → β} {s : Set α}
+variable [PartialOrder α] [Preorder β] {f : α → β} {s : Set α}
 
 lemma IsAntichain.of_strictMonoOn_antitoneOn (hf : StrictMonoOn f s) (hf' : AntitoneOn f s) :
     IsAntichain (· ≤ ·) s :=

--- a/Mathlib/Order/Monotone/Extension.lean
+++ b/Mathlib/Order/Monotone/Extension.lean
@@ -20,7 +20,7 @@ public section
 
 open Set
 
-variable {α β : Type*} [LinearOrder α] [ConditionallyCompleteLinearOrder β] {f : α → β} {s : Set α}
+variable {α β : Type*} [PartialOrder α] [ConditionallyCompleteLinearOrder β] {f : α → β} {s : Set α}
 
 /-- If a function is monotone and is bounded on a set `s`, then it admits a monotone extension to
 the whole space. -/


### PR DESCRIPTION
trying to follow the request of @b-mehta on this [zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/unused.20hypotheses.3A.20431.20in.20a.2029k.20sample.2C.20and.2033.20one-line.20PRs/near/623003643)

I send here a PR regarding 3 files:

* Mathlib/Data/Finset/Pairwise.lean
* Mathlib/Order/Antichain.lean
* Mathlib/Order/Monotone/Extension.lean