### PR TITLE
feat(Topology/Baire/Lemmas): a space is Baire iff countable unions of closed nowhere dense sets have empty interior

### DIFF
--- a/Mathlib/Topology/Baire/Lemmas.lean
+++ b/Mathlib/Topology/Baire/Lemmas.lean
@@ -46,6 +46,19 @@ section BaireTheorem
 
 variable [TopologicalSpace X]
 
+/-- A space has the Baire property iff the countable union of closed nowhere dense sets has empty
+interior. -/
+theorem baireSpace_iff_interior_iUnion_eq_empty :
+    BaireSpace X ↔ ∀ f : ℕ → Set X,
+      (∀ n, IsClosed (f n)) → (∀ n, IsNowhereDense (f n)) → interior (⋃ n, f n) = ∅ := by
+  refine baireSpace_iff X |>.trans ⟨fun h f hc hnd ↦ ?_, fun h f ho hd ↦ ?_⟩
+  · rw [interior_eq_empty_iff_dense_compl, compl_iUnion]
+    refine h _ (hc · |>.isOpen_compl) fun n ↦ ?_
+    exact isClosed_isNowhereDense_iff_compl.mp ⟨hc n, hnd n⟩ |>.right
+  · rw [← interior_compl_eq_empty_iff_dense, compl_iInter]
+    refine h _ (ho · |>.isClosed_compl) fun n ↦ ?_
+    exact isClosed_compl_and_isNowhereDense_compl.mpr ⟨ho n, hd n⟩ |>.right
+
 /-- The intersection of finitely many open dense sets is dense. -/
 theorem Set.Finite.dense_sInter {s : Set (Set X)} (hs : s.Finite)
     (ho : ∀ t ∈ s, IsOpen t) (hd : ∀ t ∈ s, Dense t) : Dense (⋂₀ s) := by
@@ -66,6 +79,10 @@ variable [BaireSpace X]
 theorem dense_iInter_of_isOpen_nat {f : ℕ → Set X} (ho : ∀ n, IsOpen (f n))
     (hd : ∀ n, Dense (f n)) : Dense (⋂ n, f n) :=
   BaireSpace.baire_property f ho hd
+
+theorem interior_iUnion_eq_empty_of_isClosed_nat {f : ℕ → Set X} (hc : ∀ n, IsClosed (f n))
+    (hnd : ∀ n, IsNowhereDense (f n)) : interior (⋃ n, f n) = ∅ :=
+  baireSpace_iff_interior_iUnion_eq_empty.mp ‹_› f hc hnd
 
 /-- A dense Gδ subset of a Baire space is Baire. -/
 theorem IsGδ.baireSpace_of_dense {s : Set X} (hG : IsGδ s) (hd : Dense s) : BaireSpace s := by
@@ -129,6 +146,12 @@ theorem dense_sInter_of_isOpen {S : Set (Set X)} (ho : ∀ s ∈ S, IsOpen s) (h
   · rcases hS.exists_eq_range h with ⟨f, rfl⟩
     exact dense_iInter_of_isOpen_nat (forall_mem_range.1 ho) (forall_mem_range.1 hd)
 
+theorem interior_sUnion_eq_empty_of_isClosed {S : Set (Set X)} (hc : ∀ s ∈ S, IsClosed s)
+    (hS : S.Countable) (hnd : ∀ s ∈ S, IsNowhereDense s) : interior (⋃₀ S) = ∅ := by
+  rw [interior_eq_empty_iff_dense_compl, compl_sUnion]
+  refine dense_sInter_of_isOpen (by simpa) (hS.image _) <| forall_mem_image.mpr fun s hs ↦ ?_
+  exact isClosed_isNowhereDense_iff_compl.mp ⟨hc s hs, hnd s hs⟩ |>.right
+
 /-- Baire theorem: a countable intersection of dense open sets is dense. Formulated here with
 an index set which is a countable set in any type. -/
 theorem dense_biInter_of_isOpen {S : Set α} {f : α → Set X} (ho : ∀ s ∈ S, IsOpen (f s))
@@ -136,12 +159,22 @@ theorem dense_biInter_of_isOpen {S : Set α} {f : α → Set X} (ho : ∀ s ∈ 
   rw [← sInter_image]
   refine dense_sInter_of_isOpen ?_ (hS.image _) ?_ <;> rwa [forall_mem_image]
 
+theorem interior_biUnion_of_isClosed {S : Set α} {f : α → Set X} (hc : ∀ s ∈ S, IsClosed (f s))
+    (hS : S.Countable) (hnd : ∀ s ∈ S, IsNowhereDense (f s)) : interior (⋃ s ∈ S, f s) = ∅ := by
+  rw [← sUnion_image]
+  refine interior_sUnion_eq_empty_of_isClosed ?_ (hS.image _) ?_ <;> rwa [forall_mem_image]
+
 /-- Baire theorem: a countable intersection of dense open sets is dense. Formulated here with
 an index set which is a countable type. -/
 @[wikidata Q1052678]
 theorem dense_iInter_of_isOpen [Countable ι] {f : ι → Set X} (ho : ∀ i, IsOpen (f i))
     (hd : ∀ i, Dense (f i)) : Dense (⋂ s, f s) :=
   dense_sInter_of_isOpen (forall_mem_range.2 ho) (countable_range _) (forall_mem_range.2 hd)
+
+theorem interior_iUnion_of_isClosed [Countable ι] {f : ι → Set X} (hc : ∀ i, IsClosed (f i))
+    (hnd : ∀ i, IsNowhereDense (f i)) : interior (⋃ s, f s) = ∅ :=
+  interior_sUnion_eq_empty_of_isClosed (forall_mem_range.mpr hc) (countable_range _)
+    (forall_mem_range.mpr hnd)
 
 /-- A set is residual (comeagre) if and only if it includes a dense `Gδ` set. -/
 theorem mem_residual {s : Set X} : s ∈ residual X ↔ ∃ t ⊆ s, IsGδ t ∧ Dense t := by

--- a/Mathlib/Topology/Closure.lean
+++ b/Mathlib/Topology/Closure.lean
@@ -390,6 +390,9 @@ alias ⟨Dense.closure_eq, _⟩ := dense_iff_closure_eq
 theorem interior_eq_empty_iff_dense_compl : interior s = ∅ ↔ Dense sᶜ := by
   rw [dense_iff_closure_eq, closure_compl, compl_univ_iff]
 
+theorem interior_compl_eq_empty_iff_dense : interior sᶜ = ∅ ↔ Dense s := by
+  rw [interior_eq_empty_iff_dense_compl, compl_compl]
+
 theorem Dense.interior_compl (h : Dense s) : interior sᶜ = ∅ :=
   interior_eq_empty_iff_dense_compl.2 <| by rwa [compl_compl]
 

--- a/Mathlib/Topology/Defs/Basic.lean
+++ b/Mathlib/Topology/Defs/Basic.lean
@@ -236,6 +236,7 @@ end Topology
 any countable intersection of open dense subsets is dense.
 Formulated here when the source space is ℕ.
 Use `dense_iInter_of_isOpen` which works for any countable index type instead. -/
+@[mk_iff]
 class BaireSpace (X : Type*) [TopologicalSpace X] : Prop where
   baire_property : ∀ f : ℕ → Set X, (∀ n, IsOpen (f n)) → (∀ n, Dense (f n)) → Dense (⋂ n, f n)
 

--- a/Mathlib/Topology/GDelta/Basic.lean
+++ b/Mathlib/Topology/GDelta/Basic.lean
@@ -254,6 +254,10 @@ lemma isClosed_isNowhereDense_iff_compl {s : Set X} :
   rw [and_congr_right IsClosed.isNowhereDense_iff,
     isOpen_compl_iff, interior_eq_empty_iff_dense_compl]
 
+theorem isClosed_compl_and_isNowhereDense_compl {s : Set X} :
+    IsClosed sᶜ ∧ IsNowhereDense sᶜ ↔ IsOpen s ∧ Dense s := by
+  rw [isClosed_isNowhereDense_iff_compl, compl_compl]
+
 /-- To check that `s` is nowhere dense, it suffices to check that no point of `s`
 is in the interior of `closure s`. -/
 lemma isNowhereDense_iff_disjoint {s : Set X} :


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
