### PR TITLE
feat(Algebra/Order/Group/Cylic): add OrderMonoidIso.map_genLTOne

### DIFF
--- a/Mathlib/Algebra/Order/Group/Cyclic.lean
+++ b/Mathlib/Algebra/Order/Group/Cyclic.lean
@@ -103,3 +103,42 @@ lemma genLTOne_unique {g : G} (hg : g < 1) (htop : Subgroup.zpowers g = ⊤) : g
 end IsCyclic
 
 end LinearOrderedCommGroup
+
+/-- The order preserving isomorphism from the top subgroup to the group. -/
+def Subgroup.topOrderMonoidIso (G : Type*) [Group G] [Preorder G] :
+    (⊤ : Subgroup G) ≃*o G where
+  __ := (Subgroup.topEquiv (G := G))
+  map_le_map_iff' := by simp
+
+namespace OrderMonoidIso
+
+open LinearOrderedCommGroup.Subgroup
+
+variable {A B : Type*} [LinearOrder A] [CommGroup A] [IsOrderedMonoid A] [Nontrivial A] [IsCyclic A]
+  [LinearOrder B] [CommGroup B] [IsOrderedMonoid B] [Nontrivial B] [IsCyclic B] (f : A ≃*o B)
+
+theorem map_genLTOne : f (LinearOrderedCommGroup.Subgroup.genLTOne ⊤) =
+      (LinearOrderedCommGroup.Subgroup.genLTOne ⊤) := by
+  apply genLTOne_unique
+  · rw [← map_one f, map_lt_map_iff]
+    exact genLTOne_lt_one ⊤
+  · rw [Subgroup.eq_top_iff']
+    intro y
+    obtain ⟨x, hx⟩ := EquivLike.surjective f y
+    obtain ⟨k, hk⟩ : x ∈ Subgroup.zpowers (LinearOrderedCommGroup.Subgroup.genLTOne ⊤) := by
+      simp [genLTOne_zpowers_eq_top]
+    exact ⟨k, by simp [← hx, ← hk]⟩
+
+theorem map_genLTOne' : f (LinearOrderedCommGroup.genLTOne A) =
+      (LinearOrderedCommGroup.genLTOne B) := by
+  apply LinearOrderedCommGroup.genLTOne_unique
+  · rw [← map_one f, map_lt_map_iff]
+    exact LinearOrderedCommGroup.Subgroup.genLTOne_lt_one ⊤
+  · rw [Subgroup.eq_top_iff']
+    intro y
+    obtain ⟨x, hx⟩ := EquivLike.surjective f y
+    obtain ⟨k, hk⟩ : x ∈ Subgroup.zpowers (LinearOrderedCommGroup.Subgroup.genLTOne ⊤) := by
+      simp [genLTOne_zpowers_eq_top]
+    exact ⟨k, by simp [← hx, ← hk]⟩
+
+end OrderMonoidIso


### PR DESCRIPTION
Co-authored-by: @xgenereux

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
