### PR TITLE
[Merged by Bors] - fix: fix `cfc_congr` lemmas

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
@@ -343,11 +343,13 @@ lemma cfcₙ_congr {f g : R → R} {a : A} (hfg : (σₙ R a).EqOn f g) :
     · rw [cfcₙ_apply_of_not_map_zero a h0, cfcₙ_apply_of_not_map_zero]
       exact fun hf ↦ h0 (hfg (quasispectrum.zero_mem R a) ▸ hf)
 
-/-- A version of `cfcₙ_congr` suitable for `@[congr]`. -/
+/-- A version of `cfcₙ_congr` suitable for `@[congr]`. The `a = b` argument is necessary to ensure
+that `norm_cast` visits both the function and the element. -/
 @[congr]
-lemma cfcₙ_congr' {f g : R → R} {a : A} (hfg : ∀ x ∈ σₙ R a, f x = g x) :
-    cfcₙ f a = cfcₙ g a :=
-  cfcₙ_congr hfg
+lemma cfcₙ_congr' {f g : R → R} {a b : A} (hab : a = b) (hfg : ∀ x ∈ σₙ R b, f x = g x) :
+    cfcₙ f a = cfcₙ g b := by
+  subst hab
+  exact cfcₙ_congr hfg
 
 lemma eqOn_of_cfcₙ_eq_cfcₙ {f g : R → R} {a : A} (h : cfcₙ f a = cfcₙ g a) (ha : p a := by cfc_tac)
     (hf : ContinuousOn f (σₙ R a) := by cfc_cont_tac) (hf0 : f 0 = 0 := by cfc_zero_tac)

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -424,11 +424,13 @@ lemma cfc_congr {f g : R → R} {a : A} (hfg : (spectrum R a).EqOn f g) :
     · rw [cfc_apply_of_not_continuousOn a hg, cfc_apply_of_not_continuousOn]
       exact fun hf ↦ hg (hf.congr hfg.symm)
 
-/-- A version of `cfc_congr` suitable for `@[congr]`. -/
+/-- A version of `cfc_congr` suitable for `@[congr]`. The `a = b` argument is necessary to ensure
+that `norm_cast` visits both the function and the element. -/
 @[congr]
-lemma cfc_congr' {f g : R → R} {a : A} (hfg : ∀ x ∈ spectrum R a, f x = g x) :
-    cfc f a = cfc g a :=
-  cfc_congr hfg
+lemma cfc_congr' {f g : R → R} {a b : A} (hab : a = b) (hfg : ∀ x ∈ spectrum R b, f x = g x) :
+    cfc f a = cfc g b := by
+  subst hab
+  exact cfc_congr hfg
 
 lemma eqOn_of_cfc_eq_cfc {f g : R → R} {a : A} (h : cfc f a = cfc g a)
     (hf : ContinuousOn f (spectrum R a) := by cfc_cont_tac)


### PR DESCRIPTION
#43028 introduced a regression in `norm_cast` due to adding an `@[congr]` lemma for `cfc` and `cfcₙ` which did not vary all arguments. This causes the following call to `norm_cast` to fail to close the goal. What happens is that on the LHS, the current `cfc_congr'` lemma causes `norm_cast` to visit the function, but *skip* the argument `((n : A) + m)`, leaving it as `↑n + ↑m`. On the RHS, because nothing needs to happen to the function, it acts on the `((n : A) + m)`, turning it into `↑(n + m)`. Another call to `norm_cast` then closes the goal because it does the same thing to the LHS now.

```lean
module

public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic

example {A : Type*} [CStarAlgebra A] (n m : ℕ) :
    cfc (fun x : ℝ ↦ (x : ℂ).re) ((n : A) + m) = cfc (fun x : ℝ ↦ x) ((n : A) + m) := by
  norm_cast
```

The fix is to update the `cfc_congr'` lemma to vary all the arguments, as with, for example, `Finset.sum_congr`:

```lean
@[congr]
lemma cfc_congr' {f g : R → R} {a b : A} (hab : a = b) (hfg : ∀ x ∈ spectrum R b, f x = g x) :
    cfc f a = cfc g b := by
  subst hab
  exact cfc_congr hfg
```

---

This issue is documented on the docstring of the `@[congr]` attribute, but there is no warning when you write a bad `@[congr]` lemma.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
