### PR TITLE
feat: a syntax linter for the `@[congr]` attribute

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7607,6 +7607,7 @@ public import Mathlib.Tactic.LinearCombinationPrime
 public import Mathlib.Tactic.Linter
 public import Mathlib.Tactic.Linter.AuxLemma
 public import Mathlib.Tactic.Linter.CommandRanges
+public import Mathlib.Tactic.Linter.CongrFixedArgs
 public import Mathlib.Tactic.Linter.DeprecatedModule
 public import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 public import Mathlib.Tactic.Linter.DirectoryDependency

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
@@ -343,6 +343,8 @@ lemma cfcₙ_congr {f g : R → R} {a : A} (hfg : (σₙ R a).EqOn f g) :
     · rw [cfcₙ_apply_of_not_map_zero a h0, cfcₙ_apply_of_not_map_zero]
       exact fun hf ↦ h0 (hfg (quasispectrum.zero_mem R a) ▸ hf)
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 /-- A version of `cfcₙ_congr` suitable for `@[congr]`. -/
 @[congr]
 lemma cfcₙ_congr' {f g : R → R} {a : A} (hfg : ∀ x ∈ σₙ R a, f x = g x) :

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -424,6 +424,8 @@ lemma cfc_congr {f g : R → R} {a : A} (hfg : (spectrum R a).EqOn f g) :
     · rw [cfc_apply_of_not_continuousOn a hg, cfc_apply_of_not_continuousOn]
       exact fun hf ↦ hg (hf.congr hfg.symm)
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 /-- A version of `cfc_congr` suitable for `@[congr]`. -/
 @[congr]
 lemma cfc_congr' {f g : R → R} {a : A} (hfg : ∀ x ∈ spectrum R a, f x = g x) :

--- a/Mathlib/Data/Finset/Filter.lean
+++ b/Mathlib/Data/Finset/Filter.lean
@@ -172,6 +172,8 @@ theorem filter_false_of_mem (h : ∀ x ∈ s, ¬p x) : s.filter p = ∅ := filte
 theorem filter_const (p : Prop) [Decidable p] (s : Finset α) :
     (s.filter fun _a => p) = if p then s else ∅ := by split_ifs <;> simp [*]
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr]
 theorem filter_congr {s : Finset α} (H : ∀ x ∈ s, p x ↔ q x) : filter p s = filter q s :=
   eq_of_veq <| Multiset.filter_congr H

--- a/Mathlib/Data/Finset/Fold.lean
+++ b/Mathlib/Data/Finset/Fold.lean
@@ -68,6 +68,8 @@ theorem fold_image [DecidableEq α] {g : γ → α} {s : Finset γ}
     (H : Set.InjOn g s) : (s.image g).fold op b f = s.fold op b (f ∘ g) := by
   simp only [fold, image_val_of_injOn H, Multiset.map_map]
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr]
 theorem fold_congr {g : α → β} (H : ∀ x ∈ s, f x = g x) : s.fold op b f = s.fold op b g := by
   rw [fold, fold, map_congr rfl H]

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -313,6 +313,8 @@ theorem mapDomain_single {f : α → β} {a : α} {b : M} : mapDomain f (single 
 theorem mapDomain_zero {f : α → β} : mapDomain f (0 : α →₀ M) = (0 : β →₀ M) :=
   sum_zero_index
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr] theorem mapDomain_congr {f g : α → β} (h : ∀ x ∈ v.support, f x = g x) :
     v.mapDomain f = v.mapDomain g :=
   Finset.sum_congr rfl fun _ H => by simp only [h _ H]

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -919,6 +919,8 @@ theorem filterMap_eq_flatMap_toList (f : α → Option β) (l : List α) :
   induction l with | nil => ?_ | cons a l ih => ?_ <;> simp [filterMap_cons]
   rcases f a <;> simp [ih]
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr]
 theorem filterMap_congr {f g : α → Option β} {l : List α}
     (h : ∀ x ∈ l, f x = g x) : l.filterMap f = l.filterMap g := by

--- a/Mathlib/Data/List/Find.lean
+++ b/Mathlib/Data/List/Find.lean
@@ -31,6 +31,8 @@ theorem find?_eq_find?_of_perm {p : α → Bool} {l₁ l₂ : List α}
   | trans _ _ ih1 ih2 =>
     refine (ih1 ?_).trans (ih2 ?_) <;> grind
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 /-- If two predicates agree on all the elements, so does `find?`. -/
 @[congr]
 theorem find?_congr {p₁ p₂ : α → Bool} {l : List α} (h : ∀ x ∈ l, p₁ x = p₂ x) :

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -60,6 +60,8 @@ theorem unzip_swap (l : List (α × β)) : unzip (l.map Prod.swap) = (unzip l).s
   simp only [unzip_eq_map, map_map]
   rfl
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr]
 theorem zipWith_congr (f g : α → β → γ) (la : List α) (lb : List β)
     (h : List.Forall₂ (fun a b => f a b = g a b) la lb) : zipWith f la lb = zipWith g la lb := by

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -154,6 +154,8 @@ theorem mem_bind {b s} {f : α → Multiset β} : b ∈ bind s f ↔ ∃ a ∈ s
 @[simp]
 theorem card_bind : card (s.bind f) = (s.map (card ∘ f)).sum := by simp [bind]
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr]
 theorem bind_congr {f g : α → Multiset β} {m : Multiset α} :
     (∀ a ∈ m, f a = g a) → bind m f = bind m g := by simp +contextual [bind]

--- a/Mathlib/Data/Multiset/Filter.lean
+++ b/Mathlib/Data/Multiset/Filter.lean
@@ -49,6 +49,8 @@ def filter (s : Multiset α) : Multiset α :=
 theorem filter_zero : filter p 0 = 0 :=
   rfl
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr]
 theorem filter_congr {p q : α → Prop} [DecidablePred p] [DecidablePred q] {s : Multiset α} :
     (∀ x ∈ s, p x ↔ q x) → filter p s = filter q s :=

--- a/Mathlib/Data/Multiset/Find.lean
+++ b/Mathlib/Data/Multiset/Find.lean
@@ -92,6 +92,8 @@ theorem find?_eq_none_iff {s : Multiset α} (hp) :
     dsimp [Set.Subsingleton] at hp
     grind
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 /-- If two predicates agree on all the elements, so does `find?`. -/
 @[congr]
 theorem find?_congr {p₁ p₂ : α → Prop} [DecidablePred p₁] [DecidablePred p₂] {s : Multiset α}

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -209,6 +209,8 @@ theorem forall_mem_image {f : α → β} {s : Set α} {p : β → Prop} :
 theorem exists_mem_image {f : α → β} {s : Set α} {p : β → Prop} :
     (∃ y ∈ f '' s, p y) ↔ ∃ x ∈ s, p (f x) := by simp
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr]
 theorem image_congr {f g : α → β} {s : Set α} (h : ∀ a ∈ s, f a = g a) : f '' s = g '' s := by
   aesop

--- a/Mathlib/Data/Set/NAry.lean
+++ b/Mathlib/Data/Set/NAry.lean
@@ -172,6 +172,8 @@ theorem image2_insert_left : image2 f (insert a s) t = (fun b => f a b) '' t ∪
 theorem image2_insert_right : image2 f s (insert b t) = (fun a => f a b) '' s ∪ image2 f s t := by
   rw [insert_eq, image2_union_right, image2_singleton_right]
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr]
 theorem image2_congr (h : ∀ a ∈ s, ∀ b ∈ t, f a b = f' a b) : image2 f s t = image2 f' s t := by
   grind

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -370,6 +370,8 @@ theorem map_zero (f : α → β) : Sym.map f (0 : Sym α 0) = (0 : Sym β 0) :=
 theorem map_cons {n : ℕ} (f : α → β) (a : α) (s : Sym α n) : (a ::ₛ s).map f = f a ::ₛ s.map f :=
   ext <| Multiset.map_cons _ _ _
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr]
 theorem map_congr {f g : α → β} {s : Sym α n} (h : ∀ x ∈ s, f x = g x) : map f s = map g s :=
   Subtype.ext <| Multiset.map_congr rfl h

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -405,6 +405,8 @@ theorem mem_map {f : α → β} {b : β} {z : Sym2 α} : b ∈ Sym2.map f z ↔ 
   cases z
   aesop
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr]
 theorem map_congr {f g : α → β} {s : Sym2 α} (h : ∀ x ∈ s, f x = g x) : map f s = map g s := by
   ext y

--- a/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
+++ b/Mathlib/Geometry/Convex/ConvexSpace/Defs.lean
@@ -523,6 +523,8 @@ lemma iConvexComb_id (w : StdSimplex R X) : w.iConvexComb id = w.sConvexComb := 
     (s.map f).iConvexComb g = s.iConvexComb (fun i ↦ g (f i)) := by
   simp only [iConvexComb, map_map]
 
+-- TODO: add an equality hypothesis for each argument flagged by `linter.congrFixedArgs`.
+set_option linter.congrFixedArgs false in
 @[congr] lemma iConvexComb_congr {w : StdSimplex R I} {f g : I → X}
     (hfg : ∀ i, w.weights i ≠ 0 → f i = g i) :
     w.iConvexComb f = w.iConvexComb g := by

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -6,6 +6,7 @@ public import Mathlib.Lean.Linter -- linter utilities; will be transitively impo
 public import Mathlib.Tactic.AdaptationNote -- make #adaptation_note available everywhere
 public import Mathlib.Tactic.Lemma
 public import Mathlib.Tactic.Linter.AuxLemma
+public import Mathlib.Tactic.Linter.CongrFixedArgs
 public import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 public import Mathlib.Tactic.Linter.DirectoryDependency
 public import Mathlib.Tactic.Linter.DocPrime
@@ -86,6 +87,7 @@ register_linter_set linter.mathlibStandardSet :=
   -- linter.allScriptsDocumented -- disabled, let's not impose this requirement downstream.
   -- linter.checkInitImports -- disabled, not relevant downstream.
   linter.auxLemma
+  linter.congrFixedArgs
   linter.flexible
   linter.hashCommand
   linter.oldObtain

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -206,6 +206,7 @@ public import Mathlib.Tactic.LinearCombinationPrime
 public import Mathlib.Tactic.Linter
 public import Mathlib.Tactic.Linter.AuxLemma
 public import Mathlib.Tactic.Linter.CommandRanges
+public import Mathlib.Tactic.Linter.CongrFixedArgs
 public import Mathlib.Tactic.Linter.DeprecatedModule
 public import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 public import Mathlib.Tactic.Linter.DirectoryDependency

--- a/Mathlib/Tactic/Linter/CongrFixedArgs.lean
+++ b/Mathlib/Tactic/Linter/CongrFixedArgs.lean
@@ -6,6 +6,7 @@ Authors: Jireh Loreaux
 module
 
 public meta import Lean.Elab.Command
+public meta import Lean.Meta.CongrTheorems
 public meta import Lean.Meta.Tactic.Simp.SimpCongrTheorems
 -- Import this linter explicitly to ensure that
 -- this file has a valid copyright header and module docstring.
@@ -23,7 +24,9 @@ Usually `simp` will revisit the resulting expression and simplify the argument l
 doesn't happen with `singlePass := true`, or when a `post` method returns `.done`
 (as in `norm_cast`), so the argument is left unsimplified.
 
-Arguments which are proofs or types, and arguments on which later arguments depend, are ignored.
+The linter only considers explicit non-type arguments which `simp` would rewrite with the default
+congruence procedure. In particular, proofs, instances, and arguments on which later
+non-proof arguments depend are ignored, as are types.
 -/
 
 meta section
@@ -43,16 +46,16 @@ public register_option linter.congrFixedArgs : Bool := {
 namespace CongrFixedArgs
 
 /-- Given a `@[congr]` theorem `thm` whose conclusion is `f a₁ ... aₙ = f b₁ ... bₙ` (or `↔`),
-returns the positions `i` of the explicit arguments of `f` for which `aᵢ` and `bᵢ` are the same.
-Arguments which are proofs or types, and those on which later arguments of `f` depend, are
-skipped. -/
+returns the positions `i` of the explicit non-type arguments of `f` for which `aᵢ` and `bᵢ` are the
+same, but which `simp` would rewrite with the default congruence procedure. -/
 def fixedArgs (thm : SimpCongrTheorem) : MetaM (Array Nat) := do
   let (_, _, type) ← forallMetaTelescopeReducing (← getConstInfo thm.theoremName).type
   let some (lhs, rhs) := type.eqOrIff? | return #[]
   let fnInfo ← getFunInfoNArgs lhs.getAppFn lhs.getAppNumArgs
-  let args := lhs.getAppArgs.zip <| rhs.getAppArgs.zip fnInfo.paramInfo
-  let fixed : Array Bool ← args.mapM fun (a, b, p) ↦ do
-    return p.binderInfo.isExplicit && !p.hasFwdDeps && a == b && !(← isProof a) && !(← isType a)
+  let kinds ← getCongrSimpKinds lhs.getAppFn fnInfo
+  let args := lhs.getAppArgs.zip <| rhs.getAppArgs.zip <| fnInfo.paramInfo.zip kinds
+  let fixed : Array Bool ← args.mapM fun (a, b, p, k) ↦ do
+    return p.binderInfo.isExplicit && (k matches .eq) && a == b && !(← isType a)
   return fixed.zipIdx.filterMap (fun x ↦ if x.fst == true then some x.snd else none)
 
 /-- Logs a warning at `ref` if the `@[congr]` theorem `thm` has fixed explicit arguments. -/

--- a/Mathlib/Tactic/Linter/CongrFixedArgs.lean
+++ b/Mathlib/Tactic/Linter/CongrFixedArgs.lean
@@ -15,15 +15,13 @@ public meta import Mathlib.Tactic.Linter.Header  -- shake: keep
 # The `congrFixedArgs` linter
 
 The `congrFixedArgs` linter emits a warning when a theorem is given the `@[congr]` attribute, but
-some explicit argument of the function in its conclusion is the same on both sides.
+some explicit argument of the function in its conclusion is the same on both sides. This is in
+direct violation of the recommendation in the documentation of `@[congr]`.
 
-When `simp` uses such a congruence theorem, it never visits that argument. Usually `simp` will
-revisit the resulting expression and simplify the argument later, but this doesn't happen with
-`singlePass := true`, or when a `post` method returns `.done` (as in `norm_cast`), so the argument
-is left unsimplified. For example, if `Set.image_congr : (∀ a ∈ s, f a = g a) → f '' s = g '' s`
-were a `@[congr]` theorem, then `norm_cast` could simplify `f` but not `s` in `f '' s`.
-
-The fix is to add an equality hypothesis for each such argument, as in `Finset.sum_congr`.
+When `simp` uses a bad congruence theorem like this, it never visits that argument.
+Usually `simp` will revisit the resulting expression and simplify the argument later, but this
+doesn't happen with `singlePass := true`, or when a `post` method returns `.done`
+(as in `norm_cast`), so the argument is left unsimplified.
 
 Arguments which are proofs or types, and arguments on which later arguments depend, are ignored.
 -/
@@ -34,12 +32,9 @@ open Lean Meta Elab Command Linter
 
 namespace Mathlib.Linter
 
-/--
-The `congrFixedArgs` linter emits a warning when a theorem is given the `@[congr]` attribute, but
-some explicit argument of the function in its conclusion is the same on both sides. `simp` never
-visits such an argument when using the congruence theorem, which can leave it unsimplified (e.g.
-by `norm_cast`). Add an equality hypothesis for each such argument instead.
--/
+/-- The `congrFixedArgs` linter emits a warning when a theorem is given the `@[congr]` attribute,
+but some explicit argument of the function in its conclusion is the same on both sides, in violation
+of the recommendation in the documentation of `@[congr]`. -/
 public register_option linter.congrFixedArgs : Bool := {
   defValue := true
   descr := "enable the congrFixedArgs linter"
@@ -47,15 +42,15 @@ public register_option linter.congrFixedArgs : Bool := {
 
 namespace CongrFixedArgs
 
-/-- Given a `@[congr]` theorem `declName` whose conclusion is `f a₁ ... aₙ = f b₁ ... bₙ` (or `↔`),
-returns `f` together with the positions `i` of the explicit arguments of `f` for which `aᵢ` and
-`bᵢ` are the same. Arguments which are proofs or types, and those on which later arguments of `f`
-depend, are skipped. -/
-def fixedArgs (declName : Name) : MetaM (Option (Expr × Array Nat)) := do
+/-- Given a theorem `declName` whose conclusion is `f a₁ ... aₙ = f b₁ ... bₙ` (or `↔`) for a
+constant `f`, returns the name of `f` together with the positions `i` of the explicit arguments of
+`f` for which `aᵢ` and `bᵢ` are the same. Arguments which are proofs or types, and those on which
+later arguments of `f` depend, are skipped. -/
+def fixedArgs (declName : Name) : MetaM (Option (Name × Array Nat)) := do
   let (_, _, type) ← forallMetaTelescopeReducing (← inferType (← mkConstWithLevelParams declName))
   let some (lhs, rhs) := type.eqOrIff? | return none
-  let fn := lhs.getAppFn
-  let fnInfo ← getFunInfoNArgs fn lhs.getAppNumArgs
+  let some fnName := lhs.getAppFn.constName? | return none
+  let fnInfo ← getFunInfoNArgs lhs.getAppFn lhs.getAppNumArgs
   let lhsArgs := lhs.getAppArgs
   let rhsArgs := rhs.getAppArgs
   let mut fixed := #[]
@@ -64,24 +59,21 @@ def fixedArgs (declName : Name) : MetaM (Option (Expr × Array Nat)) := do
     if pinfo.binderInfo.isExplicit && !pinfo.hasFwdDeps && some lhsArgs[i] == rhsArgs[i]? then
       unless (← isProof lhsArgs[i]) || (← isType lhsArgs[i]) do
         fixed := fixed.push i
-  return some (fn, fixed)
+  return some (fnName, fixed)
 
-/-- Whether `declName` is registered as a `@[congr]` theorem. -/
-def isCongrTheorem (env : Environment) (declName : Name) : Bool :=
-  (congrExtension.getState env).lemmas.toList.any (·.2.any (·.theoremName == declName))
-
-/-- Logs a warning at `ref` if the `@[congr]` theorem `declName` has fixed explicit arguments. -/
+/-- Logs a warning at `ref` if `declName` is a `@[congr]` theorem with fixed explicit arguments. -/
 def lintCongrTheorem (ref : Syntax) (declName : Name) : CommandElabM Unit := do
-  let some (fn, fixed) ← liftTermElabM <| fixedArgs declName | return
+  let some (fnName, fixed) ← liftTermElabM <| fixedArgs declName | return
+  -- `@[congr]` theorems are indexed by the head function of their conclusion.
+  unless (congrExtension.getState (← getEnv)).get fnName |>.any (·.theoremName == declName) do
+    return
   if fixed.isEmpty then return
-  let binderNames := (← liftTermElabM <| inferType fn).getForallBinderNames.toArray
+  let binderNames := (← getConstInfo fnName).type.getForallBinderNames.toArray
   let args := fixed.toList.map fun i ↦ m!"`{binderNames[i]?.getD `_}` (argument #{i + 1})"
   logLint linter.congrFixedArgs ref m!"\
     The `@[congr]` theorem `{.ofConstName declName}` does not allow the following explicit \
-    arguments of `{.ofConstName fn.constName!}` to change: {MessageData.joinSep args ", "}.\n\
-    When `simp` uses this theorem, it does not simplify these arguments, and tactics which don't \
-    revisit the result (such as `norm_cast`) leave them unsimplified. Add an equality hypothesis \
-    for each of them (as in `Finset.sum_congr`)."
+    arguments of `{.ofConstName fnName}` to change: {MessageData.joinSep args ", "}. \
+    This violates the recommendation in the documentation of `@[congr]`."
 
 @[inherit_doc Mathlib.Linter.linter.congrFixedArgs]
 def congrFixedArgsLinter : Linter where run := withSetOptionIn fun stx ↦ do
@@ -91,7 +83,7 @@ def congrFixedArgsLinter : Linter where run := withSetOptionIn fun stx ↦ do
     return
   -- Only commands which mention the `congr` attribute can add `@[congr]` theorems.
   let some congrAttr := stx.find? fun s ↦
-    s.isOfKind ``Lean.Parser.Attr.simple && s[0].getId == `congr | return
+    s.isOfKind ``Lean.Parser.Attr.simple && s[0].getId == ``congr | return
   let env ← getEnv
   let mut linted : NameSet := {}
   -- `attribute [congr] foo bar`: lint the named theorems.
@@ -100,7 +92,7 @@ def congrFixedArgsLinter : Linter where run := withSetOptionIn fun stx ↦ do
     for id in s[4].getArgs do
       let some declName ← (do return some (← liftCoreM <| realizeGlobalConstNoOverload id))
         <|> pure none | continue
-      if isCongrTheorem env declName && !linted.contains declName then
+      unless linted.contains declName do
         linted := linted.insert declName
         lintCongrTheorem id declName
   -- `@[congr] theorem foo ...`: lint the `@[congr]` theorems declared in this command.

--- a/Mathlib/Tactic/Linter/CongrFixedArgs.lean
+++ b/Mathlib/Tactic/Linter/CongrFixedArgs.lean
@@ -42,40 +42,32 @@ public register_option linter.congrFixedArgs : Bool := {
 
 namespace CongrFixedArgs
 
-/-- Given a theorem `declName` whose conclusion is `f a₁ ... aₙ = f b₁ ... bₙ` (or `↔`) for a
-constant `f`, returns the name of `f` together with the positions `i` of the explicit arguments of
-`f` for which `aᵢ` and `bᵢ` are the same. Arguments which are proofs or types, and those on which
-later arguments of `f` depend, are skipped. -/
-def fixedArgs (declName : Name) : MetaM (Option (Name × Array Nat)) := do
-  let (_, _, type) ← forallMetaTelescopeReducing (← inferType (← mkConstWithLevelParams declName))
-  let some (lhs, rhs) := type.eqOrIff? | return none
-  let some fnName := lhs.getAppFn.constName? | return none
+/-- Given a `@[congr]` theorem `thm` whose conclusion is `f a₁ ... aₙ = f b₁ ... bₙ` (or `↔`),
+returns the positions `i` of the explicit arguments of `f` for which `aᵢ` and `bᵢ` are the same.
+Arguments which are proofs or types, and those on which later arguments of `f` depend, are
+skipped. -/
+def fixedArgs (thm : SimpCongrTheorem) : MetaM (Array Nat) := do
+  let (_, _, type) ← forallMetaTelescopeReducing (← getConstInfo thm.theoremName).type
+  let some (lhs, rhs) := type.eqOrIff? | return #[]
   let fnInfo ← getFunInfoNArgs lhs.getAppFn lhs.getAppNumArgs
-  let lhsArgs := lhs.getAppArgs
-  let rhsArgs := rhs.getAppArgs
-  let mut fixed := #[]
-  for h : i in [:lhsArgs.size] do
-    let some pinfo := fnInfo.paramInfo[i]? | continue
-    if pinfo.binderInfo.isExplicit && !pinfo.hasFwdDeps && some lhsArgs[i] == rhsArgs[i]? then
-      unless (← isProof lhsArgs[i]) || (← isType lhsArgs[i]) do
-        fixed := fixed.push i
-  return some (fnName, fixed)
+  let args := lhs.getAppArgs.zip <| rhs.getAppArgs.zip fnInfo.paramInfo
+  let fixed : Array Bool ← args.mapM fun (a, b, p) ↦ do
+    return p.binderInfo.isExplicit && !p.hasFwdDeps && a == b && !(← isProof a) && !(← isType a)
+  return fixed.zipIdx.filterMap (fun x ↦ if x.fst == true then some x.snd else none)
 
-/-- Logs a warning at `ref` if `declName` is a `@[congr]` theorem with fixed explicit arguments. -/
-def lintCongrTheorem (ref : Syntax) (declName : Name) : CommandElabM Unit := do
-  let some (fnName, fixed) ← liftTermElabM <| fixedArgs declName | return
-  -- `@[congr]` theorems are indexed by the head function of their conclusion.
-  unless (congrExtension.getState (← getEnv)).get fnName |>.any (·.theoremName == declName) do
-    return
+/-- Logs a warning at `ref` if the `@[congr]` theorem `thm` has fixed explicit arguments. -/
+def lintCongrTheorem (ref : Syntax) (thm : SimpCongrTheorem) : CommandElabM Unit := do
+  let fixed ← liftTermElabM <| fixedArgs thm
   if fixed.isEmpty then return
   -- Display each argument as `x : T`, as in the signature of the head function.
-  let args ← liftTermElabM <| forallTelescopeReducing (← getConstInfo fnName).type fun xs _ ↦
-    fixed.toList.filterMapM fun i ↦ do
+  let args ← liftTermElabM <| forallTelescopeReducing (← getConstInfo thm.funName).type fun xs _ ↦
+    fixed.filterMapM fun i ↦ do
       let some x := xs[i]? | return none
       addMessageContext m!"`{x} : {← inferType x}`"
   logLint linter.congrFixedArgs ref m!"\
-    The `@[congr]` theorem `{.ofConstName declName}` does not allow the following explicit \
-    arguments of `{.ofConstName fnName}` to change:{indentD (MessageData.joinSep args "\n")}\n\
+    The `@[congr]` theorem `{.ofConstName thm.theoremName}` does not allow the following explicit \
+    arguments of `{.ofConstName thm.funName}` to change:\
+      {indentD (MessageData.joinSep args.toList "\n")}\n\
     This violates the recommendation in the documentation of `@[congr]`."
 
 @[inherit_doc Mathlib.Linter.linter.congrFixedArgs]
@@ -88,6 +80,7 @@ def congrFixedArgsLinter : Linter where run := withSetOptionIn fun stx ↦ do
   let some congrAttr := stx.find? fun s ↦
     s.isOfKind ``Lean.Parser.Attr.simple && s[0].getId == ``congr | return
   let env ← getEnv
+  let congrThms := (congrExtension.getState env).lemmas.toList.flatMap (·.2)
   let mut linted : NameSet := {}
   -- `attribute [congr] foo bar`: lint the named theorems.
   for s in stx.topDown do
@@ -95,20 +88,20 @@ def congrFixedArgsLinter : Linter where run := withSetOptionIn fun stx ↦ do
     for id in s[4].getArgs do
       let some declName ← (do return some (← liftCoreM <| realizeGlobalConstNoOverload id))
         <|> pure none | continue
+      let some thm := congrThms.find? (·.theoremName == declName) | continue
       unless linted.contains declName do
         linted := linted.insert declName
-        lintCongrTheorem id declName
+        lintCongrTheorem id thm
   -- `@[congr] theorem foo ...`: lint the `@[congr]` theorems declared in this command.
   let some cmdRange := stx.getRange? | return
-  for (_, thms) in (congrExtension.getState env).lemmas.toList do
-    for thm in thms do
-      let declName := thm.theoremName
-      if linted.contains declName || (env.getModuleIdxFor? declName).isSome then continue
-      let some ranges ← findDeclarationRanges? declName | continue
-      let pos := (← getFileMap).ofPosition ranges.range.pos
-      if cmdRange.start ≤ pos && pos < cmdRange.stop then
-        linted := linted.insert declName
-        lintCongrTheorem congrAttr declName
+  for thm in congrThms do
+    let declName := thm.theoremName
+    if linted.contains declName || (env.getModuleIdxFor? declName).isSome then continue
+    let some ranges ← findDeclarationRanges? declName | continue
+    let pos := (← getFileMap).ofPosition ranges.range.pos
+    if cmdRange.start ≤ pos && pos < cmdRange.stop then
+      linted := linted.insert declName
+      lintCongrTheorem congrAttr thm
 
 initialize addLinter congrFixedArgsLinter
 

--- a/Mathlib/Tactic/Linter/CongrFixedArgs.lean
+++ b/Mathlib/Tactic/Linter/CongrFixedArgs.lean
@@ -73,6 +73,19 @@ def lintCongrTheorem (ref : Syntax) (thm : SimpCongrTheorem) : CommandElabM Unit
       {indentD (MessageData.joinSep args.toList "\n")}\n\
     This violates the recommendation in the documentation of `@[congr]`."
 
+/-- Whether `stx` is the `congr` attribute. -/
+def isCongrAttr (stx : Syntax) : Bool :=
+  stx.isOfKind ``Lean.Parser.Attr.simple && stx[0].getId == ``congr
+
+/-- The identifiers `foo bar` in the `attribute [congr] foo bar` commands occurring in `stx`. -/
+def congrAttributeTargets (stx : Syntax) : Array Syntax := Id.run do
+  let mut ids := #[]
+  for s in stx.topDown do
+    -- `attribute [attrs,*] ids*`
+    if s.isOfKind ``Lean.Parser.Command.attribute && (s[2].find? isCongrAttr).isSome then
+      ids := ids ++ s[4].getArgs
+  return ids
+
 @[inherit_doc Mathlib.Linter.linter.congrFixedArgs]
 def congrFixedArgsLinter : Linter where run := withSetOptionIn fun stx ↦ do
   unless getLinterValue linter.congrFixedArgs (← getLinterOptions) do
@@ -80,21 +93,18 @@ def congrFixedArgsLinter : Linter where run := withSetOptionIn fun stx ↦ do
   if (← get).messages.hasErrors then
     return
   -- Only commands which mention the `congr` attribute can add `@[congr]` theorems.
-  let some congrAttr := stx.find? fun s ↦
-    s.isOfKind ``Lean.Parser.Attr.simple && s[0].getId == ``congr | return
+  let some congrAttr := stx.find? isCongrAttr | return
   let env ← getEnv
   let congrThms := (congrExtension.getState env).lemmas.toList.flatMap (·.2)
   let mut linted : NameSet := {}
   -- `attribute [congr] foo bar`: lint the named theorems.
-  for s in stx.topDown do
-    unless s.isOfKind ``Lean.Parser.Command.attribute do continue
-    for id in s[4].getArgs do
-      let some declName ← (do return some (← liftCoreM <| realizeGlobalConstNoOverload id))
-        <|> pure none | continue
-      let some thm := congrThms.find? (·.theoremName == declName) | continue
-      unless linted.contains declName do
-        linted := linted.insert declName
-        lintCongrTheorem id thm
+  for id in congrAttributeTargets stx do
+    let declName ← try liftCoreM <| realizeGlobalConstNoOverload id catch _ => continue
+    -- This fails for `attribute [local congr] foo in ...`, whose attribute is already gone.
+    let some thm := congrThms.find? (·.theoremName == declName) | continue
+    unless linted.contains declName do
+      linted := linted.insert declName
+      lintCongrTheorem id thm
   -- `@[congr] theorem foo ...`: lint the `@[congr]` theorems declared in this command.
   let some cmdRange := stx.getRange? | return
   for thm in congrThms do

--- a/Mathlib/Tactic/Linter/CongrFixedArgs.lean
+++ b/Mathlib/Tactic/Linter/CongrFixedArgs.lean
@@ -68,11 +68,14 @@ def lintCongrTheorem (ref : Syntax) (declName : Name) : CommandElabM Unit := do
   unless (congrExtension.getState (← getEnv)).get fnName |>.any (·.theoremName == declName) do
     return
   if fixed.isEmpty then return
-  let binderNames := (← getConstInfo fnName).type.getForallBinderNames.toArray
-  let args := fixed.toList.map fun i ↦ m!"`{binderNames[i]?.getD `_}` (argument #{i + 1})"
+  -- Display each argument as `x : T`, as in the signature of the head function.
+  let args ← liftTermElabM <| forallTelescopeReducing (← getConstInfo fnName).type fun xs _ ↦
+    fixed.toList.filterMapM fun i ↦ do
+      let some x := xs[i]? | return none
+      addMessageContext m!"`{x} : {← inferType x}`"
   logLint linter.congrFixedArgs ref m!"\
     The `@[congr]` theorem `{.ofConstName declName}` does not allow the following explicit \
-    arguments of `{.ofConstName fnName}` to change: {MessageData.joinSep args ", "}. \
+    arguments of `{.ofConstName fnName}` to change:{indentD (MessageData.joinSep args "\n")}\n\
     This violates the recommendation in the documentation of `@[congr]`."
 
 @[inherit_doc Mathlib.Linter.linter.congrFixedArgs]

--- a/Mathlib/Tactic/Linter/CongrFixedArgs.lean
+++ b/Mathlib/Tactic/Linter/CongrFixedArgs.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+module
+
+public meta import Lean.Elab.Command
+public meta import Lean.Meta.Tactic.Simp.SimpCongrTheorems
+-- Import this linter explicitly to ensure that
+-- this file has a valid copyright header and module docstring.
+public meta import Mathlib.Tactic.Linter.Header  -- shake: keep
+
+/-!
+# The `congrFixedArgs` linter
+
+The `congrFixedArgs` linter emits a warning when a theorem is given the `@[congr]` attribute, but
+some explicit argument of the function in its conclusion is the same on both sides.
+
+When `simp` uses such a congruence theorem, it never visits that argument. Usually `simp` will
+revisit the resulting expression and simplify the argument later, but this doesn't happen with
+`singlePass := true`, or when a `post` method returns `.done` (as in `norm_cast`), so the argument
+is left unsimplified. For example, if `Set.image_congr : (∀ a ∈ s, f a = g a) → f '' s = g '' s`
+were a `@[congr]` theorem, then `norm_cast` could simplify `f` but not `s` in `f '' s`.
+
+The fix is to add an equality hypothesis for each such argument, as in `Finset.sum_congr`.
+
+Arguments which are proofs or types, and arguments on which later arguments depend, are ignored.
+-/
+
+meta section
+
+open Lean Meta Elab Command Linter
+
+namespace Mathlib.Linter
+
+/--
+The `congrFixedArgs` linter emits a warning when a theorem is given the `@[congr]` attribute, but
+some explicit argument of the function in its conclusion is the same on both sides. `simp` never
+visits such an argument when using the congruence theorem, which can leave it unsimplified (e.g.
+by `norm_cast`). Add an equality hypothesis for each such argument instead.
+-/
+public register_option linter.congrFixedArgs : Bool := {
+  defValue := true
+  descr := "enable the congrFixedArgs linter"
+}
+
+namespace CongrFixedArgs
+
+/-- Given a `@[congr]` theorem `declName` whose conclusion is `f a₁ ... aₙ = f b₁ ... bₙ` (or `↔`),
+returns `f` together with the positions `i` of the explicit arguments of `f` for which `aᵢ` and
+`bᵢ` are the same. Arguments which are proofs or types, and those on which later arguments of `f`
+depend, are skipped. -/
+def fixedArgs (declName : Name) : MetaM (Option (Expr × Array Nat)) := do
+  let (_, _, type) ← forallMetaTelescopeReducing (← inferType (← mkConstWithLevelParams declName))
+  let some (lhs, rhs) := type.eqOrIff? | return none
+  let fn := lhs.getAppFn
+  let fnInfo ← getFunInfoNArgs fn lhs.getAppNumArgs
+  let lhsArgs := lhs.getAppArgs
+  let rhsArgs := rhs.getAppArgs
+  let mut fixed := #[]
+  for h : i in [:lhsArgs.size] do
+    let some pinfo := fnInfo.paramInfo[i]? | continue
+    if pinfo.binderInfo.isExplicit && !pinfo.hasFwdDeps && some lhsArgs[i] == rhsArgs[i]? then
+      unless (← isProof lhsArgs[i]) || (← isType lhsArgs[i]) do
+        fixed := fixed.push i
+  return some (fn, fixed)
+
+/-- Whether `declName` is registered as a `@[congr]` theorem. -/
+def isCongrTheorem (env : Environment) (declName : Name) : Bool :=
+  (congrExtension.getState env).lemmas.toList.any (·.2.any (·.theoremName == declName))
+
+/-- Logs a warning at `ref` if the `@[congr]` theorem `declName` has fixed explicit arguments. -/
+def lintCongrTheorem (ref : Syntax) (declName : Name) : CommandElabM Unit := do
+  let some (fn, fixed) ← liftTermElabM <| fixedArgs declName | return
+  if fixed.isEmpty then return
+  let binderNames := (← liftTermElabM <| inferType fn).getForallBinderNames.toArray
+  let args := fixed.toList.map fun i ↦ m!"`{binderNames[i]?.getD `_}` (argument #{i + 1})"
+  logLint linter.congrFixedArgs ref m!"\
+    The `@[congr]` theorem `{.ofConstName declName}` does not allow the following explicit \
+    arguments of `{.ofConstName fn.constName!}` to change: {MessageData.joinSep args ", "}.\n\
+    When `simp` uses this theorem, it does not simplify these arguments, and tactics which don't \
+    revisit the result (such as `norm_cast`) leave them unsimplified. Add an equality hypothesis \
+    for each of them (as in `Finset.sum_congr`)."
+
+@[inherit_doc Mathlib.Linter.linter.congrFixedArgs]
+def congrFixedArgsLinter : Linter where run := withSetOptionIn fun stx ↦ do
+  unless getLinterValue linter.congrFixedArgs (← getLinterOptions) do
+    return
+  if (← get).messages.hasErrors then
+    return
+  -- Only commands which mention the `congr` attribute can add `@[congr]` theorems.
+  let some congrAttr := stx.find? fun s ↦
+    s.isOfKind ``Lean.Parser.Attr.simple && s[0].getId == `congr | return
+  let env ← getEnv
+  let mut linted : NameSet := {}
+  -- `attribute [congr] foo bar`: lint the named theorems.
+  for s in stx.topDown do
+    unless s.isOfKind ``Lean.Parser.Command.attribute do continue
+    for id in s[4].getArgs do
+      let some declName ← (do return some (← liftCoreM <| realizeGlobalConstNoOverload id))
+        <|> pure none | continue
+      if isCongrTheorem env declName && !linted.contains declName then
+        linted := linted.insert declName
+        lintCongrTheorem id declName
+  -- `@[congr] theorem foo ...`: lint the `@[congr]` theorems declared in this command.
+  let some cmdRange := stx.getRange? | return
+  for (_, thms) in (congrExtension.getState env).lemmas.toList do
+    for thm in thms do
+      let declName := thm.theoremName
+      if linted.contains declName || (env.getModuleIdxFor? declName).isSome then continue
+      let some ranges ← findDeclarationRanges? declName | continue
+      let pos := (← getFileMap).ofPosition ranges.range.pos
+      if cmdRange.start ≤ pos && pos < cmdRange.stop then
+        linted := linted.insert declName
+        lintCongrTheorem congrAttr declName
+
+initialize addLinter congrFixedArgsLinter
+
+end CongrFixedArgs
+
+end Mathlib.Linter

--- a/MathlibTest/Linter/CongrFixedArgs.lean
+++ b/MathlibTest/Linter/CongrFixedArgs.lean
@@ -7,8 +7,7 @@ def myMap (f : Nat → Nat) (l : List Nat) : List Nat := l.map f
 
 -- `l` is the same on both sides.
 /--
-warning: The `@[congr]` theorem `myMap_congr` does not allow the following explicit arguments of `myMap` to change: `l` (argument #2).
-When `simp` uses this theorem, it does not simplify these arguments, and tactics which don't revisit the result (such as `norm_cast`) leave them unsimplified. Add an equality hypothesis for each of them (as in `Finset.sum_congr`).
+warning: The `@[congr]` theorem `myMap_congr` does not allow the following explicit arguments of `myMap` to change: `l` (argument #2). This violates the recommendation in the documentation of `@[congr]`.
 
 Note: This linter can be disabled with `set_option linter.congrFixedArgs false`
 -/
@@ -32,26 +31,12 @@ theorem myMap_congr'' {f g : Nat → Nat} {l : List Nat} (h : ∀ x ∈ l, f x =
 
 -- The attribute can also be added with the `attribute` command.
 /--
-warning: The `@[congr]` theorem `myMap_congr''` does not allow the following explicit arguments of `myMap` to change: `l` (argument #2).
-When `simp` uses this theorem, it does not simplify these arguments, and tactics which don't revisit the result (such as `norm_cast`) leave them unsimplified. Add an equality hypothesis for each of them (as in `Finset.sum_congr`).
+warning: The `@[congr]` theorem `myMap_congr''` does not allow the following explicit arguments of `myMap` to change: `l` (argument #2). This violates the recommendation in the documentation of `@[congr]`.
 
 Note: This linter can be disabled with `set_option linter.congrFixedArgs false`
 -/
 #guard_msgs in
 attribute [congr] myMap_congr''
-
--- The linter can be disabled.
-#guard_msgs in
-set_option linter.congrFixedArgs false in
-@[congr]
-theorem myMap_congr''' {f g : Nat → Nat} {l : List Nat} (h : ∀ x ∈ l, f x = g x) :
-    myMap f l = myMap g l :=
-  List.map_congr_left h
-
--- Other attributes don't trigger the linter.
-#guard_msgs in
-@[simp]
-theorem myMap_nil (f : Nat → Nat) : myMap f [] = [] := rfl
 
 def myGet (l : List Nat) (i : Nat) (_h : i < l.length) : Nat := l[i]
 

--- a/MathlibTest/Linter/CongrFixedArgs.lean
+++ b/MathlibTest/Linter/CongrFixedArgs.lean
@@ -5,9 +5,10 @@ set_option linter.congrFixedArgs true
 
 def myMap (f : Nat → Nat) (l : List Nat) : List Nat := l.map f
 
--- `l` is the same on both sides.
 /--
-warning: The `@[congr]` theorem `myMap_congr` does not allow the following explicit arguments of `myMap` to change: `l` (argument #2). This violates the recommendation in the documentation of `@[congr]`.
+warning: The `@[congr]` theorem `myMap_congr` does not allow the following explicit arguments of `myMap` to change:
+  `l : List Nat`
+This violates the recommendation in the documentation of `@[congr]`.
 
 Note: This linter can be disabled with `set_option linter.congrFixedArgs false`
 -/
@@ -17,7 +18,7 @@ theorem myMap_congr {f g : Nat → Nat} {l : List Nat} (h : ∀ x ∈ l, f x = g
     myMap f l = myMap g l :=
   List.map_congr_left h
 
--- Every explicit argument may change: no warning.
+-- Every explicit argument changes: no warning.
 #guard_msgs in
 @[congr]
 theorem myMap_congr' {f g : Nat → Nat} {l l' : List Nat} (hl : l = l')
@@ -29,14 +30,32 @@ theorem myMap_congr'' {f g : Nat → Nat} {l : List Nat} (h : ∀ x ∈ l, f x =
     myMap f l = myMap g l :=
   List.map_congr_left h
 
--- The attribute can also be added with the `attribute` command.
 /--
-warning: The `@[congr]` theorem `myMap_congr''` does not allow the following explicit arguments of `myMap` to change: `l` (argument #2). This violates the recommendation in the documentation of `@[congr]`.
+warning: The `@[congr]` theorem `myMap_congr''` does not allow the following explicit arguments of `myMap` to change:
+  `l : List Nat`
+This violates the recommendation in the documentation of `@[congr]`.
 
 Note: This linter can be disabled with `set_option linter.congrFixedArgs false`
 -/
 #guard_msgs in
 attribute [congr] myMap_congr''
+
+def myZipWith (f : Nat → Nat → Nat) (l₁ l₂ : List Nat) : List Nat := List.zipWith f l₁ l₂
+
+/--
+warning: The `@[congr]` theorem `myZipWith_congr` does not allow the following explicit arguments of `myZipWith` to change:
+  `l₁ : List Nat`
+  `l₂ : List Nat`
+This violates the recommendation in the documentation of `@[congr]`.
+
+Note: This linter can be disabled with `set_option linter.congrFixedArgs false`
+-/
+#guard_msgs in
+@[congr]
+theorem myZipWith_congr {f g : Nat → Nat → Nat} {l₁ l₂ : List Nat} (h : ∀ a b, f a b = g a b) :
+    myZipWith f l₁ l₂ = myZipWith g l₁ l₂ := by
+  have : f = g := funext fun a ↦ funext (h a)
+  rw [this]
 
 def myGet (l : List Nat) (i : Nat) (_h : i < l.length) : Nat := l[i]
 

--- a/MathlibTest/Linter/CongrFixedArgs.lean
+++ b/MathlibTest/Linter/CongrFixedArgs.lean
@@ -1,0 +1,64 @@
+import Mathlib.Tactic.Linter.CongrFixedArgs
+import Mathlib.Init
+
+set_option linter.congrFixedArgs true
+
+def myMap (f : Nat → Nat) (l : List Nat) : List Nat := l.map f
+
+-- `l` is the same on both sides.
+/--
+warning: The `@[congr]` theorem `myMap_congr` does not allow the following explicit arguments of `myMap` to change: `l` (argument #2).
+When `simp` uses this theorem, it does not simplify these arguments, and tactics which don't revisit the result (such as `norm_cast`) leave them unsimplified. Add an equality hypothesis for each of them (as in `Finset.sum_congr`).
+
+Note: This linter can be disabled with `set_option linter.congrFixedArgs false`
+-/
+#guard_msgs in
+@[congr]
+theorem myMap_congr {f g : Nat → Nat} {l : List Nat} (h : ∀ x ∈ l, f x = g x) :
+    myMap f l = myMap g l :=
+  List.map_congr_left h
+
+-- Every explicit argument may change: no warning.
+#guard_msgs in
+@[congr]
+theorem myMap_congr' {f g : Nat → Nat} {l l' : List Nat} (hl : l = l')
+    (h : ∀ x ∈ l', f x = g x) : myMap f l = myMap g l' := by
+  subst hl
+  exact List.map_congr_left h
+
+theorem myMap_congr'' {f g : Nat → Nat} {l : List Nat} (h : ∀ x ∈ l, f x = g x) :
+    myMap f l = myMap g l :=
+  List.map_congr_left h
+
+-- The attribute can also be added with the `attribute` command.
+/--
+warning: The `@[congr]` theorem `myMap_congr''` does not allow the following explicit arguments of `myMap` to change: `l` (argument #2).
+When `simp` uses this theorem, it does not simplify these arguments, and tactics which don't revisit the result (such as `norm_cast`) leave them unsimplified. Add an equality hypothesis for each of them (as in `Finset.sum_congr`).
+
+Note: This linter can be disabled with `set_option linter.congrFixedArgs false`
+-/
+#guard_msgs in
+attribute [congr] myMap_congr''
+
+-- The linter can be disabled.
+#guard_msgs in
+set_option linter.congrFixedArgs false in
+@[congr]
+theorem myMap_congr''' {f g : Nat → Nat} {l : List Nat} (h : ∀ x ∈ l, f x = g x) :
+    myMap f l = myMap g l :=
+  List.map_congr_left h
+
+-- Other attributes don't trigger the linter.
+#guard_msgs in
+@[simp]
+theorem myMap_nil (f : Nat → Nat) : myMap f [] = [] := rfl
+
+def myGet (l : List Nat) (i : Nat) (_h : i < l.length) : Nat := l[i]
+
+-- Proof arguments are ignored, even when they are the same on both sides.
+#guard_msgs in
+@[congr]
+theorem myGet_congr {l l' : List Nat} {i i' : Nat} (hl : l = l') (hi : i = i')
+    (h : i < l.length) : myGet l i h = myGet l' i' (hl ▸ hi ▸ h) := by
+  subst hl hi
+  rfl


### PR DESCRIPTION
The documentation for the `@[congr]` attribute states:
```
A `simp` congruence lemma should prove the equality of two applications of the same function from
the equality of the individual arguments. They are used by `simp` to visit subexpressions of an
application where the default congruence algorithm fails. This is particularly important for
functions where some parameters depend on previous parameters.

Congruence lemmas should have an equality for every parameter, possibly bounded by foralls, with
the right hand side being an application of a parameter on the right-hand side. When applying
congruence theorems, `simp` will first infer parameters from the right-hand side, then try to
simplify each left-hand side of the parameter equalities and finally infer the right-hand side
parameters from the result.
```
However, no check is performed to verify that all the arguments to the function vary. This PR adds a syntax linter to check this and turns it on by default across Mathlib. We explicitly silence the linter where it currently triggers.

This linter addresses a real problem, as I was bitten by the lack of this check in #43028 and fixed in #43689.

---

AI disclosure: this was generated by Claude (Opus 5) with my prompting. I rewrote some bits here and there to something I found more suitable, especially in the documentation portions. I understand all the meta code written herein, but I'm not sure if it follows best practices everywhere or not.

After some initial review, I had some better ideas of what could be changed, and made edits myself, without Claude.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
