### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Opposite): add an ext lemma for the opposite category

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -955,9 +955,6 @@ def simplicialToCosimplicialAugmented :
       right := NatTrans.rightOp f.unop.left
       w := by
         ext x
-        dsimp
-        simp_rw [← op_comp]
-        congr 1
         exact (congr_app f.unop.w (op x)).symm }
 
 set_option backward.isDefEq.respectTransparency.types false in

--- a/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
@@ -64,8 +64,7 @@ def inverse :
         (Quiver.Hom.unop_inj (by exact StructuredArrow.w φ.left)))
           (by
             ext
-            exact Quiver.Hom.unop_inj
-              ((StructuredArrow.proj _ _).congr_map (CostructuredArrow.w φ)))).op
+            exact ((StructuredArrow.proj _ _).congr_map (CostructuredArrow.w φ)))).op
 
 end structuredArrowRightwardsOpEquivalence
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Opposites/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Opposites/Products.lean
@@ -310,15 +310,8 @@ def opProdIsoCoprod : op (A ⨯ B) ≅ (op A ⨿ op B) where
   hom := (prod.lift coprod.inl.unop coprod.inr.unop).op
   inv := coprod.desc prod.fst.op prod.snd.op
   hom_inv_id := by
-    apply Quiver.Hom.unop_inj
     ext <;>
-    · simp only
-      apply Quiver.Hom.op_inj
-      simp
-  inv_hom_id := by
-    ext <;>
-    · simp only [colimit.ι_desc_assoc]
-      apply Quiver.Hom.unop_inj
+    · apply Quiver.Hom.op_inj
       simp
 
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -633,8 +633,6 @@ isomorphism between the original functors `F ≅ G`. -/
 protected def op (α : F ≅ G) : G.op ≅ F.op where
   hom := NatTrans.op α.hom
   inv := NatTrans.op α.inv
-  hom_inv_id := by ext; dsimp; rw [← op_comp]; rw [α.inv_hom_id_app]; rfl
-  inv_hom_id := by ext; dsimp; rw [← op_comp]; rw [α.hom_inv_id_app]; rfl
 
 @[simp]
 theorem op_refl : NatIso.op (Iso.refl F) = Iso.refl F.op := rfl

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
@@ -63,8 +63,8 @@ noncomputable scoped instance commShift_adjunction_op_int {G : D ⥤ C} [G.CommS
       NatTrans.PullbackShift.natIsoComp, PullbackShift.functor, PullbackShift.natTrans,
       OppositeShift.adjunction, OppositeShift.natTrans, NatTrans.OppositeShift.natIsoId,
       NatTrans.OppositeShift.natIsoComp, OppositeShift.functor]
-    simp only [Category.comp_id, Category.id_comp]
-    erw [Category.comp_id] -- FIXME: this seems to be an issue with adjuction.op?
+    rw [unop_id]
+    simp
   rw [eq]
   exact inferInstanceAs (Adjunction.CommShift (PullbackShift.adjunction
     (AddMonoidHom.mk' (fun (n : ℤ) => -n) (by intros; lia))

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
@@ -58,12 +58,13 @@ noncomputable scoped instance commShift_adjunction_op_int {G : D ⥤ C} [G.CommS
   have eq : adj.op = PullbackShift.adjunction
     (AddMonoidHom.mk' (fun (n : ℤ) => -n) (by intros; lia))
       (OppositeShift.adjunction ℤ adj) := by
-    ext
+    ext x
     dsimp [PullbackShift.adjunction, NatTrans.PullbackShift.natIsoId,
       NatTrans.PullbackShift.natIsoComp, PullbackShift.functor, PullbackShift.natTrans,
       OppositeShift.adjunction, OppositeShift.natTrans, NatTrans.OppositeShift.natIsoId,
       NatTrans.OppositeShift.natIsoComp, OppositeShift.functor]
     simp only [Category.comp_id, Category.id_comp]
+    erw [Category.comp_id] -- FIXME: this seems to be an issue with adjuction.op?
   rw [eq]
   exact inferInstanceAs (Adjunction.CommShift (PullbackShift.adjunction
     (AddMonoidHom.mk' (fun (n : ℤ) => -n) (by intros; lia))

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/OpOp.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/OpOp.lean
@@ -102,12 +102,10 @@ instance : (opOp C).CommShift ℤ where
   commShiftIso := iso _
   commShiftIso_zero := by
     ext X
-    refine Quiver.Hom.unop_inj (Quiver.Hom.unop_inj ?_)
     simp [iso_hom_app X 0 0, shiftFunctorZero_op_inv_app,
       shiftFunctorZero_op_hom_app]
   commShiftIso_add p q := by
     ext X
-    refine Quiver.Hom.unop_inj (Quiver.Hom.unop_inj ?_)
     simp [← shiftFunctorAdd'_eq_shiftFunctorAdd, ← unop_comp_assoc, ← Functor.map_comp,
       fun X n ↦ iso_hom_app X n (-n) (add_neg_cancel n),
       shiftFunctor_op_map _ q (-q),

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -68,6 +68,12 @@ def Hom.opEquiv {V} [Quiver V] {X Y : V} : (X ⟶ Y) ≃ (Opposite.op Y ⟶ Oppo
   toFun := Opposite.op
   invFun := Opposite.unop
 
+/-- To show that two Homs from the opposite category agree, it suffices to show they agree
+in the original category. -/
+@[ext low, to_dual self]
+theorem Hom.unop_ext {V} [Quiver V] {X Y : Vᵒᵖ} {f g : X ⟶ Y} (h : f.unop = g.unop) : f = g :=
+  Hom.opEquiv.symm.injective h
+
 /-- A type synonym for a quiver with no arrows. -/
 def Empty (V : Type u) : Type u := V
 


### PR DESCRIPTION
This is a revival of #25914.

This adds an ext lemma `Quiver.Hom.unop_ext` to help automation around the opposite category. In essence, this is `Quiver.Hom.unop_inj` in a direct form (instead of an injectivity statement that automation has trouble using). The lemma is merely added here, and removing proofs that `cat_disch` now handle is a welcome follow-up.

The ext lemma has low priority so that it does not fire in situations where more specialized ext lemmas (such as the one for morphisms to/from co/limits) are available.

Co-authored-by: Eric Wieser <425260+eric-wieser@users.noreply.github.com>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
